### PR TITLE
fix(atif): emit ATIF-v1.7 and make orphaned tool results conformant

### DIFF
--- a/agent/atif.go
+++ b/agent/atif.go
@@ -9,7 +9,7 @@ import (
 	"primeradiant.com/serf/agent/internal/atif"
 )
 
-// exportATIF reads a transcript JSONL file, converts it to an ATIF v1.6
+// exportATIF reads a transcript JSONL file, converts it to an ATIF v1.7
 // trajectory, and writes the result to outPath.
 func exportATIF(transcriptPath, outPath string) error {
 	header, entries, _, err := readTranscript(transcriptPath)

--- a/agent/atif_test.go
+++ b/agent/atif_test.go
@@ -61,8 +61,8 @@ func TestExportATIF_WritesFile(t *testing.T) {
 	if traj.SessionID != "test-sess" {
 		t.Errorf("SessionID = %q, want %q", traj.SessionID, "test-sess")
 	}
-	if traj.SchemaVersion != "ATIF-v1.6" {
-		t.Errorf("SchemaVersion = %q, want %q", traj.SchemaVersion, "ATIF-v1.6")
+	if traj.SchemaVersion != "ATIF-v1.7" {
+		t.Errorf("SchemaVersion = %q, want %q", traj.SchemaVersion, "ATIF-v1.7")
 	}
 	if len(traj.Steps) != 1 {
 		t.Errorf("len(Steps) = %d, want 1", len(traj.Steps))

--- a/agent/internal/atif/atif.go
+++ b/agent/internal/atif/atif.go
@@ -1,5 +1,5 @@
 // Package atif converts a serf session transcript into an Agent Trajectory
-// Interchange Format (ATIF v1.6) document.
+// Interchange Format (ATIF v1.7) document.
 package atif
 
 import (
@@ -11,9 +11,9 @@ import (
 	"primeradiant.com/serf/llm"
 )
 
-// ATIF v1.6 types — Agent Trajectory Interchange Format.
+// ATIF v1.7 types — Agent Trajectory Interchange Format.
 
-// Trajectory is the root object of an ATIF v1.6 document.
+// Trajectory is the root object of an ATIF v1.7 document.
 type Trajectory struct {
 	SchemaVersion string         `json:"schema_version"`
 	SessionID     string         `json:"session_id"`
@@ -59,7 +59,7 @@ type Observation struct {
 
 // ObservationResult is a single tool result within an observation.
 type ObservationResult struct {
-	SourceCallID string `json:"source_call_id"`
+	SourceCallID string `json:"source_call_id,omitempty"`
 	Content      string `json:"content"`
 }
 
@@ -80,7 +80,7 @@ type FinalMetrics struct {
 	Extra                 map[string]any `json:"extra,omitempty"`
 }
 
-// Convert converts a serf transcript (header + entries) into an ATIF v1.6 trajectory.
+// Convert converts a serf transcript (header + entries) into an ATIF v1.7 trajectory.
 func Convert(header transcript.Header, entries []transcript.Entry) Trajectory {
 	version := header.BuildVersion
 	if version == "" {
@@ -88,7 +88,7 @@ func Convert(header transcript.Header, entries []transcript.Entry) Trajectory {
 	}
 
 	traj := Trajectory{
-		SchemaVersion: "ATIF-v1.6",
+		SchemaVersion: "ATIF-v1.7",
 		SessionID:     header.SessionID,
 		Agent: Agent{
 			Name:      "serf",
@@ -178,9 +178,26 @@ func Convert(header transcript.Header, entries []transcript.Entry) Trajectory {
 			stepID++
 
 		case schema.TurnToolResults:
-			// Orphaned TOOL_RESULTS (not preceded by ASSISTANT). Preserve as system step.
+			// Orphaned TOOL_RESULTS (not preceded by ASSISTANT). ATIF forbids an
+			// observation on a non-agent step and requires every observation
+			// source_call_id to reference a tool_call in the same step. These
+			// results have no originating tool_call in this trajectory, so emit
+			// them on an agent step with the source_call_id nulled and preserve
+			// the original ids in extra for traceability.
 			obs, errMap, durMap := convertToolResults(turn)
 			extra := map[string]any{"serf_kind": "orphaned_tool_results"}
+			if obs != nil {
+				var origIDs []string
+				for i := range obs.Results {
+					if obs.Results[i].SourceCallID != "" {
+						origIDs = append(origIDs, obs.Results[i].SourceCallID)
+						obs.Results[i].SourceCallID = ""
+					}
+				}
+				if len(origIDs) > 0 {
+					extra["orphaned_source_call_ids"] = origIDs
+				}
+			}
 			if len(errMap) > 0 {
 				extra["tool_errors"] = errMap
 			}
@@ -189,7 +206,7 @@ func Convert(header transcript.Header, entries []transcript.Entry) Trajectory {
 			}
 			step := Step{
 				StepID:      stepID,
-				Source:      "system",
+				Source:      "agent",
 				Timestamp:   formatTimestamp(turn),
 				Observation: obs,
 				Extra:       extra,

--- a/agent/internal/atif/atif_test.go
+++ b/agent/internal/atif/atif_test.go
@@ -50,8 +50,8 @@ func TestConvertToATIF_SimpleConversation(t *testing.T) {
 	traj := Convert(header, entries)
 
 	// --- Root trajectory fields ---
-	if traj.SchemaVersion != "ATIF-v1.6" {
-		t.Errorf("SchemaVersion = %q, want %q", traj.SchemaVersion, "ATIF-v1.6")
+	if traj.SchemaVersion != "ATIF-v1.7" {
+		t.Errorf("SchemaVersion = %q, want %q", traj.SchemaVersion, "ATIF-v1.7")
 	}
 	if traj.SessionID != "sess-001" {
 		t.Errorf("SessionID = %q, want %q", traj.SessionID, "sess-001")
@@ -663,8 +663,8 @@ func TestConvertToATIF_EmptyTranscript(t *testing.T) {
 
 	traj := Convert(header, nil)
 
-	if traj.SchemaVersion != "ATIF-v1.6" {
-		t.Errorf("SchemaVersion = %q, want %q", traj.SchemaVersion, "ATIF-v1.6")
+	if traj.SchemaVersion != "ATIF-v1.7" {
+		t.Errorf("SchemaVersion = %q, want %q", traj.SchemaVersion, "ATIF-v1.7")
 	}
 	if traj.SessionID != "sess-empty" {
 		t.Errorf("SessionID = %q, want %q", traj.SessionID, "sess-empty")
@@ -801,8 +801,13 @@ func TestConvertToATIF_OrphanedToolResults(t *testing.T) {
 	}
 
 	step := traj.Steps[0]
-	if step.Source != "system" {
-		t.Errorf("Source = %q, want %q", step.Source, "system")
+	// ATIF forbids an observation on a non-agent step and requires every
+	// observation source_call_id to reference a tool_call in the same step.
+	// An orphaned tool result has no originating tool_call, so it is emitted as
+	// an agent step with the source_call_id nulled; the original ids are kept
+	// in extra for traceability.
+	if step.Source != "agent" {
+		t.Errorf("Source = %q, want %q", step.Source, "agent")
 	}
 	if step.Extra["serf_kind"] != "orphaned_tool_results" {
 		t.Errorf("Extra[serf_kind] = %v, want %q", step.Extra["serf_kind"], "orphaned_tool_results")
@@ -813,8 +818,15 @@ func TestConvertToATIF_OrphanedToolResults(t *testing.T) {
 	if len(step.Observation.Results) != 1 {
 		t.Fatalf("len(Observation.Results) = %d, want 1", len(step.Observation.Results))
 	}
-	if step.Observation.Results[0].SourceCallID != "orphan-call-1" {
-		t.Errorf("Results[0].SourceCallID = %q, want %q", step.Observation.Results[0].SourceCallID, "orphan-call-1")
+	if step.Observation.Results[0].SourceCallID != "" {
+		t.Errorf("Results[0].SourceCallID = %q, want empty (nulled)", step.Observation.Results[0].SourceCallID)
+	}
+	origIDs, ok := step.Extra["orphaned_source_call_ids"].([]string)
+	if !ok {
+		t.Fatalf("Extra[orphaned_source_call_ids] type = %T, want []string", step.Extra["orphaned_source_call_ids"])
+	}
+	if len(origIDs) != 1 || origIDs[0] != "orphan-call-1" {
+		t.Errorf("Extra[orphaned_source_call_ids] = %v, want [orphan-call-1]", origIDs)
 	}
 	if step.Observation.Results[0].Content != "orphaned result" {
 		t.Errorf("Results[0].Content = %q, want %q", step.Observation.Results[0].Content, "orphaned result")

--- a/agent/session_config.go
+++ b/agent/session_config.go
@@ -135,7 +135,7 @@ type SessionConfig struct {
 	// Snapshots are written to <StateDir>/sessions/ and tasks to <StateDir>/tasks/.
 	StateDir string `json:"-"`
 
-	// ExportATIFPath, when non-empty, causes Session.Close to export an ATIF v1.6
+	// ExportATIFPath, when non-empty, causes Session.Close to export an ATIF v1.7
 	// trajectory JSON file to this path. Only root sessions (spawn.depth==0) export.
 	ExportATIFPath string `json:"-"`
 

--- a/cmd/serf/main.go
+++ b/cmd/serf/main.go
@@ -173,7 +173,7 @@ func newRunFlagSet(stderr io.Writer) (*flag.FlagSet, *runCLIFlags) {
 	flags.shareTaskStore = fs.Bool("share-task-store", false, "share task list between parent and child sessions")
 	flags.resultToolName = fs.String("result-tool-name", "", "override the result tool `name` (default: communicate)")
 	flags.reasoningEffort = fs.String("reasoning-effort", "", "reasoning effort `level`: minimal|low|medium|high|xhigh|max|none")
-	flags.exportATIF = fs.String("export-atif", "", "export ATIF v1.6 trajectory to this `path` on session close")
+	flags.exportATIF = fs.String("export-atif", "", "export ATIF v1.7 trajectory to this `path` on session close")
 	flags.contextStrategy = fs.String("context-strategy", "", "context management `strategy`: compact|session-log|ooda (default: compact)")
 	flags.outputSchema = fs.String("output-schema", "", "inline JSON Schema `document` applied to the communicate tool's output field (replaces the default schema)")
 	flags.verbose = fs.Bool("verbose", false, "emit NDJSON events to stderr")


### PR DESCRIPTION
## What

Bumps serf's native ATIF export from `ATIF-v1.6` to `ATIF-v1.7` and fixes the orphaned-tool-results path so every exported trajectory is valid under the v1.7 schema.

## Why

We're adding serf as a coding-agent harness in superpowers-evals (quorum), whose capture pipeline consumes ATIF and validates strictly against **ATIF-v1.7**. Serf was already emitting the v1.7 shape but labelling it v1.6, and one edge case produced an invalid trajectory.

## Details

**Version bump.** Verified against Harbor 0.14.0's schema (`src/harbor/models/trajectories/`, the upstream ATIF authority) that v1.7 is a strict superset of v1.6 — it only *adds* optional fields (`ObservationResult.extra`, `trajectory_id`, `reasoning_effort`, multimodal content). Serf's output is a conformant subset, so relabelling it v1.7 is truthful, not a fudge. Updated the version constant, doc comments, and the `--export-atif` flag help.

**Orphaned tool results.** A `TOOL_RESULTS` turn with no preceding assistant turn was emitted as a `system` step carrying an `observation` whose `source_call_id` referenced a tool_call that doesn't exist in that step. ATIF (and quorum) forbid an observation on a non-agent step and require every `source_call_id` to reference a same-step `tool_call`, so those trajectories were rejected. Now emitted as an `agent` step with the `source_call_id` nulled (Harbor's blessed representation for results with no originating call), preserving the original ids in `extra.orphaned_source_call_ids` for traceability.

Tool names are intentionally left native (`use_skill`, etc.) — ATIF's `function_name` is the real invoked name, and Harbor's own converters preserve native names. Canonicalization is the consumer's job.

## Testing

- `go test ./agent/internal/atif/ ./agent/ ./cmd/serf/` — green (version + orphaned-results assertions updated/added).
- `make lint-docs lint-naming lint-internal` — green.
- `go build ./...` — green.
- **End-to-end:** built serf and ran `serf --model anthropic/claude-sonnet-4-6 --plugin-dir <superpowers> --export-atif …` on "Let's make a react todo list". The exported trajectory (12 steps, `schema_version: ATIF-v1.7`) passes quorum's `validateTrajectory` (`ok: true`), and the superpowers `brainstorming` skill auto-triggered before any code — confirming the full capture path works.

🤖 Authored with Claude Code (Opus 4.8).

https://claude.ai/code/session_01HtiJKYUr4J4K1ECfyrfUH4