### PR TITLE
chore(lint): clean staticcheck (QF1012/SA1019) under Go 1.25 + golangci-lint v2

### DIFF
--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -195,7 +195,7 @@ func (e *LocalExecutionEnvironment) ReadFile(path string, offsetLine *int, limit
 	}
 	var out strings.Builder
 	for i := start; i <= end; i++ {
-		out.WriteString(fmt.Sprintf("%4d\t%s\n", i, lines[i-1]))
+		fmt.Fprintf(&out, "%4d\t%s\n", i, lines[i-1])
 	}
 	return out.String(), nil
 }

--- a/agent/internal/contextmgr/context_manager.go
+++ b/agent/internal/contextmgr/context_manager.go
@@ -791,7 +791,7 @@ func formatCheckpoint(data checkpointData, meta *CompactionMeta, maxChars int) s
 
 	// Transcript pointer — tells the model how to access full history via transcript tools.
 	if meta != nil && meta.SessionID != "" {
-		fixed.WriteString(fmt.Sprintf("Earlier history was compacted. This session's id is %s. Use read_session_transcript to recover earlier detail, or find_session_transcripts to search it.\n", meta.SessionID))
+		fmt.Fprintf(&fixed, "Earlier history was compacted. This session's id is %s. Use read_session_transcript to recover earlier detail, or find_session_transcripts to search it.\n", meta.SessionID)
 	}
 
 	// Files modified.
@@ -801,12 +801,12 @@ func formatCheckpoint(data checkpointData, meta *CompactionMeta, maxChars int) s
 			files = append(files, f)
 		}
 		sort.Strings(files)
-		fixed.WriteString(fmt.Sprintf("Files modified: %s\n", strings.Join(files, ", ")))
+		fmt.Fprintf(&fixed, "Files modified: %s\n", strings.Join(files, ", "))
 	}
 
 	// Tool call counts.
 	if total := sumCounts(data.toolCounts); total > 0 {
-		fixed.WriteString(fmt.Sprintf("Actions taken: %d tool calls (", total))
+		fmt.Fprintf(&fixed, "Actions taken: %d tool calls (", total)
 		toolNames := make([]string, 0, len(data.toolCounts))
 		for name := range data.toolCounts {
 			toolNames = append(toolNames, name)
@@ -816,7 +816,7 @@ func formatCheckpoint(data checkpointData, meta *CompactionMeta, maxChars int) s
 			if i > 0 {
 				fixed.WriteString(", ")
 			}
-			fixed.WriteString(fmt.Sprintf("%d %s", data.toolCounts[name], name))
+			fmt.Fprintf(&fixed, "%d %s", data.toolCounts[name], name)
 		}
 		fixed.WriteString(")\n")
 	}
@@ -849,7 +849,7 @@ func formatCheckpoint(data checkpointData, meta *CompactionMeta, maxChars int) s
 			skillNames = append(skillNames, s)
 		}
 		sort.Strings(skillNames)
-		fixed.WriteString(fmt.Sprintf("Activated skills: %s\n", strings.Join(skillNames, ", ")))
+		fmt.Fprintf(&fixed, "Activated skills: %s\n", strings.Join(skillNames, ", "))
 	}
 
 	fixedStr := fixed.String()
@@ -1141,11 +1141,11 @@ func renderTurnForElicit(t schema.Turn) string {
 			}
 		case llm.ContentToolCall:
 			if p.ToolCall != nil {
-				b.WriteString(fmt.Sprintf("Tool call %s(%s)\n", p.ToolCall.Name, strings.TrimSpace(string(p.ToolCall.Arguments))))
+				fmt.Fprintf(&b, "Tool call %s(%s)\n", p.ToolCall.Name, strings.TrimSpace(string(p.ToolCall.Arguments)))
 			}
 		case llm.ContentToolResult:
 			if p.ToolResult != nil {
-				b.WriteString(fmt.Sprintf("Tool result %s: %s\n", p.ToolResult.Name, fmt.Sprint(p.ToolResult.Content)))
+				fmt.Fprintf(&b, "Tool result %s: %s\n", p.ToolResult.Name, fmt.Sprint(p.ToolResult.Content))
 			}
 		}
 	}
@@ -1223,9 +1223,9 @@ func (cm *Manager) summarizeWithLLMSteered(ctx context.Context, history []schema
 					}
 					switch {
 					case endTurn:
-						b.WriteString(fmt.Sprintf("Agent Message: %s\n", msg))
+						fmt.Fprintf(&b, "Agent Message: %s\n", msg)
 					default:
-						b.WriteString(fmt.Sprintf("Agent Status: %s\n", msg))
+						fmt.Fprintf(&b, "Agent Status: %s\n", msg)
 					}
 				}
 			}
@@ -1236,7 +1236,7 @@ func (cm *Manager) summarizeWithLLMSteered(ctx context.Context, history []schema
 					if len(content) > 200 {
 						content = content[:200] + "..."
 					}
-					b.WriteString(fmt.Sprintf("Tool(%s): %s\n", p.ToolResult.Name, content))
+					fmt.Fprintf(&b, "Tool(%s): %s\n", p.ToolResult.Name, content)
 				}
 			}
 		case schema.TurnSteering:

--- a/agent/internal/contextmgr/fork_summarize.go
+++ b/agent/internal/contextmgr/fork_summarize.go
@@ -59,7 +59,7 @@ func buildSummarizePrompt(turns []schema.Turn) string {
 			b.WriteString("Assistant: " + truncate(t.Message.Text(), 500) + "\n")
 			for _, p := range t.Message.Content {
 				if p.Kind == llm.ContentToolCall && p.ToolCall != nil {
-					b.WriteString(fmt.Sprintf("  [tool_call: %s(%s)]\n", p.ToolCall.Name, truncate(string(p.ToolCall.Arguments), 200)))
+					fmt.Fprintf(&b, "  [tool_call: %s(%s)]\n", p.ToolCall.Name, truncate(string(p.ToolCall.Arguments), 200))
 				}
 			}
 		case schema.TurnTool, schema.TurnToolResults:
@@ -70,7 +70,7 @@ func buildSummarizePrompt(turns []schema.Turn) string {
 					if p.ToolResult.IsError {
 						errTag = " ERROR"
 					}
-					b.WriteString(fmt.Sprintf("Tool(%s)%s: %s\n", p.ToolResult.Name, errTag, truncate(content, 300)))
+					fmt.Fprintf(&b, "Tool(%s)%s: %s\n", p.ToolResult.Name, errTag, truncate(content, 300))
 				}
 			}
 		case schema.TurnSteering:

--- a/agent/internal/contextmgr/strategy_checkpoint_pred.go
+++ b/agent/internal/contextmgr/strategy_checkpoint_pred.go
@@ -191,7 +191,7 @@ func (s *CheckpointPredStrategy) predictiveCheckpoint(ctx context.Context, histo
 			for _, p := range t.Message.Content {
 				if p.Kind == llm.ContentToolResult && p.ToolResult != nil {
 					content := fmt.Sprint(p.ToolResult.Content)
-					b.WriteString(fmt.Sprintf("Tool(%s): %s\n", p.ToolResult.Name, truncate(content, 200)))
+					fmt.Fprintf(&b, "Tool(%s): %s\n", p.ToolResult.Name, truncate(content, 200))
 				}
 			}
 		}

--- a/agent/internal/contextmgr/strategy_memory_crystals.go
+++ b/agent/internal/contextmgr/strategy_memory_crystals.go
@@ -66,7 +66,7 @@ func (s *MemoryCrystalsStrategy) injectCrystals(history *[]schema.Turn) {
 	var b strings.Builder
 	b.WriteString("[MEMORY CRYSTALS]\nKey facts preserved from this session:\n\n")
 	for _, c := range s.crystals {
-		b.WriteString(fmt.Sprintf("Turn %d [%s]: %s\n", c.Turn, c.Action, c.Facts))
+		fmt.Fprintf(&b, "Turn %d [%s]: %s\n", c.Turn, c.Action, c.Facts)
 	}
 	b.WriteString("[END CRYSTALS]")
 
@@ -131,7 +131,7 @@ func (s *MemoryCrystalsStrategy) crystallize(ctx context.Context, client *llm.Cl
 					if p.ToolResult.IsError {
 						errTag = " ERROR"
 					}
-					b.WriteString(fmt.Sprintf("Tool(%s)%s: %s\n", p.ToolResult.Name, errTag, truncate(content, 200)))
+					fmt.Fprintf(&b, "Tool(%s)%s: %s\n", p.ToolResult.Name, errTag, truncate(content, 200))
 				}
 			}
 		}

--- a/agent/internal/contextmgr/strategy_recursive_distill.go
+++ b/agent/internal/contextmgr/strategy_recursive_distill.go
@@ -144,7 +144,7 @@ func (s *RecursiveDistillStrategy) microSummarize(ctx context.Context, client *l
 			for _, p := range t.Message.Content {
 				if p.Kind == llm.ContentToolResult && p.ToolResult != nil {
 					content := fmt.Sprint(p.ToolResult.Content)
-					b.WriteString(fmt.Sprintf("Tool(%s): %s\n", p.ToolResult.Name, truncate(content, 100)))
+					fmt.Fprintf(&b, "Tool(%s): %s\n", p.ToolResult.Name, truncate(content, 100))
 				}
 			}
 		}
@@ -178,7 +178,7 @@ Status update:`, b.String())
 func (s *RecursiveDistillStrategy) macroSummarize(ctx context.Context, client *llm.Client, micros []string) (string, error) {
 	var b strings.Builder
 	for i, m := range micros {
-		b.WriteString(fmt.Sprintf("%d. %s\n", i+1, m))
+		fmt.Fprintf(&b, "%d. %s\n", i+1, m)
 	}
 
 	prompt := fmt.Sprintf(`Consolidate these action summaries into a structured progress report (3-5 sentences). Preserve:

--- a/agent/internal/contextmgr/strategy_session_log.go
+++ b/agent/internal/contextmgr/strategy_session_log.go
@@ -184,9 +184,9 @@ func (s *SessionLogStrategy) sessionLogCheckpoint(history []schema.Turn, preserv
 
 	var b strings.Builder
 	b.WriteString("[CONTEXT CHECKPOINT - SESSION LOG]\n")
-	b.WriteString(fmt.Sprintf("Original prompt: %s\n", originalPrompt))
+	fmt.Fprintf(&b, "Original prompt: %s\n", originalPrompt)
 	if s.session != nil {
-		b.WriteString(fmt.Sprintf("This session's id is %s. Use read_session_transcript to recover earlier detail, or find_session_transcripts to search it.\n", s.session.ID()))
+		fmt.Fprintf(&b, "This session's id is %s. Use read_session_transcript to recover earlier detail, or find_session_transcripts to search it.\n", s.session.ID())
 	}
 	b.WriteString("\n")
 

--- a/agent/internal/sessionlog/sessionlog.go
+++ b/agent/internal/sessionlog/sessionlog.go
@@ -164,11 +164,11 @@ func (l *SessionLog) String() string {
 			sb.WriteString("\n")
 		}
 		// Format: "Turn 47 [edit_file] success: Modified auth middleware..."
-		sb.WriteString(fmt.Sprintf("Turn %d [%s] %s: %s",
+		fmt.Fprintf(&sb, "Turn %d [%s] %s: %s",
 			entry.Turn,
 			entry.Action,
 			entry.Outcome,
-			entry.Summary))
+			entry.Summary)
 		wrote = true
 	}
 

--- a/agent/session_tools_shell.go
+++ b/agent/session_tools_shell.go
@@ -500,8 +500,8 @@ func runBufferedShell(ctx context.Context, env execenv.ExecutionEnvironment, dep
 	if errors.Is(err, context.Canceled) && !res.TimedOut {
 		b.WriteString("[ERROR: Command was canceled before completion. Partial output is shown above.]\n")
 	} else if res.TimedOut {
-		b.WriteString(fmt.Sprintf("[ERROR: Command timed out after %dms. Partial output is shown above.\nYou can retry with a longer timeout by setting the %s parameter.]\n", timeout, timeoutParam))
+		fmt.Fprintf(&b, "[ERROR: Command timed out after %dms. Partial output is shown above.\nYou can retry with a longer timeout by setting the %s parameter.]\n", timeout, timeoutParam)
 	}
-	b.WriteString(fmt.Sprintf("exit_code=%d duration_ms=%d timed_out=%t\n", res.ExitCode, res.DurationMS, res.TimedOut))
+	fmt.Fprintf(&b, "exit_code=%d duration_ms=%d timed_out=%t\n", res.ExitCode, res.DurationMS, res.TimedOut)
 	return b.String(), err
 }

--- a/agent/session_tools_task.go
+++ b/agent/session_tools_task.go
@@ -233,7 +233,7 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 				}
 
 				total, done := store.Progress()
-				msg.WriteString(fmt.Sprintf("Progress: %d/%d tasks complete.", done, total))
+				fmt.Fprintf(&msg, "Progress: %d/%d tasks complete.", done, total)
 				return tool.StateResult{Output: msg.String(), State: store.View()}, nil
 			default:
 				return nil, fmt.Errorf("unknown task_list action %q: use view, append, or update", action)

--- a/agent/task_reminders.go
+++ b/agent/task_reminders.go
@@ -12,15 +12,15 @@ import (
 func formatCurrentTaskSteering(task taskpkg.Task) string {
 	var b strings.Builder
 	b.WriteString("<SYSTEM-REMINDER>\n")
-	b.WriteString(fmt.Sprintf("<CURRENT-TASK id=\"%d\">\n", task.ID))
-	b.WriteString(fmt.Sprintf("<TITLE>%s</TITLE>\n", task.Description))
+	fmt.Fprintf(&b, "<CURRENT-TASK id=\"%d\">\n", task.ID)
+	fmt.Fprintf(&b, "<TITLE>%s</TITLE>\n", task.Description)
 	if task.Prompt != "" {
 		b.WriteString("<INSTRUCTIONS>\n")
 		b.WriteString(strings.TrimSpace(task.Prompt))
 		b.WriteString("\n</INSTRUCTIONS>\n")
 	}
 	b.WriteString("</CURRENT-TASK>\n")
-	b.WriteString(fmt.Sprintf("Call your next tool: use task_list to mark task %d as done when this step is complete.\n", task.ID))
+	fmt.Fprintf(&b, "Call your next tool: use task_list to mark task %d as done when this step is complete.\n", task.ID)
 	b.WriteString("</SYSTEM-REMINDER>")
 	return b.String()
 }
@@ -38,16 +38,16 @@ func taskReminderFull(store *taskpkg.TaskStore) string {
 	b.WriteString("<SYSTEM-REMINDER>\n")
 	b.WriteString("Task list:\n")
 	for _, t := range tasks {
-		b.WriteString(fmt.Sprintf("  [%s] #%d: %s", t.Status, t.ID, t.Description))
+		fmt.Fprintf(&b, "  [%s] #%d: %s", t.Status, t.ID, t.Description)
 		if t.ReasoningEffort != "" {
-			b.WriteString(fmt.Sprintf(" [%s]", t.ReasoningEffort))
+			fmt.Fprintf(&b, " [%s]", t.ReasoningEffort)
 		}
 		if len(t.DependsOn) > 0 {
-			b.WriteString(fmt.Sprintf(" (depends_on: %v)", t.DependsOn))
+			fmt.Fprintf(&b, " (depends_on: %v)", t.DependsOn)
 		}
 		b.WriteString("\n")
 		for _, n := range t.Notes {
-			b.WriteString(fmt.Sprintf("    note: %s\n", n))
+			fmt.Fprintf(&b, "    note: %s\n", n)
 		}
 	}
 	b.WriteString("</SYSTEM-REMINDER>")

--- a/agent/transcript_render.go
+++ b/agent/transcript_render.go
@@ -1040,7 +1040,7 @@ func jobResultBody(raw string) (string, bool) {
 		if pretty, ok := prettyJSONValue(r.StructuredResult); ok {
 			b.WriteString(pretty)
 		} else {
-			b.WriteString(fmt.Sprint(r.StructuredResult))
+			fmt.Fprint(&b, r.StructuredResult)
 		}
 		b.WriteString("\n")
 	}

--- a/cmd/serf-docscheck/main.go
+++ b/cmd/serf-docscheck/main.go
@@ -88,53 +88,66 @@ func main() {
 // checkPackage parses the non-test Go files in dir and returns a violation for
 // each exported package-level declaration that lacks a doc comment.
 func checkPackage(dir string) ([]violation, error) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, dir, func(fi os.FileInfo) bool {
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, parser.ParseComments)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
 
+	fset := token.NewFileSet()
 	var out []violation
-	for _, pkg := range pkgs {
-		if strings.HasSuffix(pkg.Name, "_test") {
+	for _, entry := range entries {
+		if entry.IsDir() {
 			continue
 		}
-		for path, file := range pkg.Files {
-			base := filepath.Base(path)
-			for _, decl := range file.Decls {
-				switch d := decl.(type) {
-				case *ast.FuncDecl:
-					// Package-level functions only (methods are out of scope).
-					if d.Recv == nil && d.Name.IsExported() && d.Doc == nil {
-						out = append(out, violation{dir, base, "func", d.Name.Name})
-					}
-				case *ast.GenDecl:
-					// A doc on the GenDecl block (e.g. a single `// X ...` above a
-					// lone `type X ...`, or a comment above a parenthesized group)
-					// documents its specs.
-					if d.Doc != nil {
-						continue
-					}
-					for _, spec := range d.Specs {
-						switch s := spec.(type) {
-						case *ast.TypeSpec:
-							if s.Name.IsExported() && s.Doc == nil {
-								out = append(out, violation{dir, base, "type", s.Name.Name})
-							}
-						case *ast.ValueSpec:
-							if s.Doc != nil {
-								continue
-							}
-							kind := "var"
-							if d.Tok.String() == "const" {
-								kind = "const"
-							}
-							for _, n := range s.Names {
-								if n.IsExported() {
-									out = append(out, violation{dir, base, kind, n.Name})
-								}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		path := filepath.Join(dir, name)
+		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			return nil, err
+		}
+		// Skip external test packages (e.g. `package foo_test`); the filename
+		// filter already drops *_test.go, this guards a non-test file that
+		// nonetheless declares a _test package name.
+		if strings.HasSuffix(file.Name.Name, "_test") {
+			continue
+		}
+
+		base := filepath.Base(path)
+		for _, decl := range file.Decls {
+			switch d := decl.(type) {
+			case *ast.FuncDecl:
+				// Package-level functions only (methods are out of scope).
+				if d.Recv == nil && d.Name.IsExported() && d.Doc == nil {
+					out = append(out, violation{dir, base, "func", d.Name.Name})
+				}
+			case *ast.GenDecl:
+				// A doc on the GenDecl block (e.g. a single `// X ...` above a
+				// lone `type X ...`, or a comment above a parenthesized group)
+				// documents its specs.
+				if d.Doc != nil {
+					continue
+				}
+				for _, spec := range d.Specs {
+					switch s := spec.(type) {
+					case *ast.TypeSpec:
+						if s.Name.IsExported() && s.Doc == nil {
+							out = append(out, violation{dir, base, "type", s.Name.Name})
+						}
+					case *ast.ValueSpec:
+						if s.Doc != nil {
+							continue
+						}
+						kind := "var"
+						if d.Tok.String() == "const" {
+							kind = "const"
+						}
+						for _, n := range s.Names {
+							if n.IsExported() {
+								out = append(out, violation{dir, base, kind, n.Name})
 							}
 						}
 					}

--- a/cmd/serf-tui/internal/toolsummary/tool_summary.go
+++ b/cmd/serf-tui/internal/toolsummary/tool_summary.go
@@ -237,8 +237,8 @@ func unifiedDiff(filename, old, new_ string) string {
 	newLines := strings.Split(new_, "\n")
 
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("--- %s\n+++ %s\n@@ -%d,%d +%d,%d @@\n",
-		filename, filename, 1, len(oldLines), 1, len(newLines)))
+	fmt.Fprintf(&b, "--- %s\n+++ %s\n@@ -%d,%d +%d,%d @@\n",
+		filename, filename, 1, len(oldLines), 1, len(newLines))
 	for _, l := range oldLines {
 		b.WriteString("-" + l + "\n")
 	}
@@ -292,7 +292,7 @@ func renderTaskAppend(tasks []any) string {
 			continue
 		}
 		desc, _ := m["description"].(string)
-		b.WriteString(fmt.Sprintf("  %d. %s\n", i+1, desc))
+		fmt.Fprintf(&b, "  %d. %s\n", i+1, desc)
 		if prompt, _ := m["prompt"].(string); prompt != "" {
 			// Show first line of prompt indented.
 			first := prompt
@@ -302,7 +302,7 @@ func renderTaskAppend(tasks []any) string {
 			if len(first) > 72 {
 				first = first[:72] + "…"
 			}
-			b.WriteString(fmt.Sprintf("     %s\n", first))
+			fmt.Fprintf(&b, "     %s\n", first)
 		}
 	}
 	return strings.TrimRight(b.String(), "\n")
@@ -331,7 +331,7 @@ func renderTaskUpdate(updates []any) string {
 		if icon == "" {
 			icon = "·"
 		}
-		b.WriteString(fmt.Sprintf("  %s task %d → %s\n", icon, id, status))
+		fmt.Fprintf(&b, "  %s task %d → %s\n", icon, id, status)
 	}
 	return strings.TrimRight(b.String(), "\n")
 }

--- a/cmd/serf-tui/model.go
+++ b/cmd/serf-tui/model.go
@@ -240,7 +240,7 @@ func renderTasks(tasks []task.Task, _ int) string {
 	}
 
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("Tasks (%d):\n", len(tasks)))
+	fmt.Fprintf(&b, "Tasks (%d):\n", len(tasks))
 
 	statusIcon := map[task.TaskStatus]string{
 		task.TaskOpen:       "○",
@@ -254,12 +254,12 @@ func renderTasks(tasks []task.Task, _ int) string {
 		if icon == "" {
 			icon = "?"
 		}
-		b.WriteString(fmt.Sprintf("  %s [%d] %s — %s", icon, t.ID, t.Type, t.Description))
+		fmt.Fprintf(&b, "  %s [%d] %s — %s", icon, t.ID, t.Type, t.Description)
 		if len(t.DependsOn) > 0 {
-			b.WriteString(fmt.Sprintf(" (depends on: %v)", t.DependsOn))
+			fmt.Fprintf(&b, " (depends on: %v)", t.DependsOn)
 		}
 		if t.ReasoningEffort != "" {
-			b.WriteString(fmt.Sprintf(" [%s]", t.ReasoningEffort))
+			fmt.Fprintf(&b, " [%s]", t.ReasoningEffort)
 		}
 		b.WriteString("\n")
 	}


### PR DESCRIPTION
Mechanical staticcheck cleanup to make `make lint` clean under Go 1.25.6 + golangci-lint v2.12.2. 40× QF1012 (`WriteString(fmt.Sprintf(...))` → `fmt.Fprintf(...)`) across cmd/serf-tui, agent/*; 1× SA1019 (`parser.ParseDir` → `ParseFile`-loop in cmd/serf-docscheck). `make build-all` exit 0; all four lint gates exit 0; serf-docscheck behavior verified identical (negative test). No functional changes.