### PR TITLE
fix(agent): identity-scope job-targeted event watches; inform+breaker on watcher notifications

### DIFF
--- a/agent/cov_s1_watch_event_target_test.go
+++ b/agent/cov_s1_watch_event_target_test.go
@@ -26,18 +26,26 @@ func TestS1Cov_watchEventWatchedIdentity(t *testing.T) {
 
 func TestS1Cov_watchEventMatchesTarget(t *testing.T) {
 	// Session targets always match.
-	if !watchEventMatchesTarget("caller", events.JobStartedData{JobID: "job_x"}) {
+	if !watchEventMatchesTarget("caller", "", events.SessionEvent{Data: events.JobStartedData{JobID: "job_x"}}) {
 		t.Fatal("session target must match any event")
 	}
 	// Concrete targets match only the same job id.
-	if !watchEventMatchesTarget("job_x", events.JobStartedData{JobID: "job_x"}) {
+	if !watchEventMatchesTarget("job_x", "", events.SessionEvent{Data: events.JobStartedData{JobID: "job_x"}}) {
 		t.Fatal("start event for the target job must match")
 	}
-	if watchEventMatchesTarget("job_x", events.JobFinishedData{JobID: "job_y"}) {
+	if watchEventMatchesTarget("job_x", "", events.SessionEvent{Data: events.JobFinishedData{JobID: "job_y"}}) {
 		t.Fatal("finish event for a different job must not match")
 	}
-	// Non job-lifecycle events default to matching a concrete target.
-	if !watchEventMatchesTarget("job_x", events.CommunicateData{}) {
-		t.Fatal("non-lifecycle event defaults to match")
+	// Non job-lifecycle events are scoped by originating session: only the
+	// watched job's child session matches; watcher-origin and identity-less
+	// events do not (they would echo the watcher back at itself).
+	if !watchEventMatchesTarget("job_x", "sess_child", events.SessionEvent{SessionID: "sess_child", Data: events.CommunicateData{}}) {
+		t.Fatal("watched job's session event must match")
+	}
+	if watchEventMatchesTarget("job_x", "sess_child", events.SessionEvent{SessionID: "sess_watcher", Data: events.CommunicateData{}}) {
+		t.Fatal("watcher-origin non-lifecycle event must not match")
+	}
+	if watchEventMatchesTarget("job_x", "", events.SessionEvent{Data: events.CommunicateData{}}) {
+		t.Fatal("identity-less non-lifecycle event must not match")
 	}
 }

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -198,6 +198,7 @@ func DefJobWatch(eventKinds []string) llm.ToolDefinition {
 		"For cross-session session sources such as `parent`, omitting trigger fields watches all bounded public events for that source. " +
 		"Pick the trigger mode that matches the signal: session event frames use `events` (available: " + kinds + "), `event_filter`, and optional `every`; concrete job output uses `output_match`; periodic progress uses `progress_interval_ms`. " +
 		"`event_filter` narrows assistant.tool events by tool_name and ok/error status. " +
+		"Do not use job_watch to learn when a job completes — a finished job delivers its completion notification (with result excerpt) automatically; to trigger on a job's output, use `output_match`. " +
 		"Observers report findings with `communicate(end_turn=true)`. " +
 		"`operation=\"clear\"` removes a watch by `watch_id`."
 	return llm.ToolDefinition{

--- a/agent/job_notify.go
+++ b/agent/job_notify.go
@@ -172,12 +172,14 @@ func formatJobNotificationBlock(n jobNotification, excerpt notificationExcerpt) 
 	}
 
 	if n.Status == jobNotificationEventWatch && n.JobID == "" {
+		body := fmt.Sprintf("Watch event triggered: %s.", n.Reason)
+		if n.Notice != "" {
+			body += "\n" + n.Notice
+		}
 		return fmt.Sprintf(
-			"<job-notification %s>\n"+
-				"Watch event triggered: %s.\n"+
-				"</job-notification>",
+			"<job-notification %s>\n%s\n</job-notification>",
 			strings.Join(attrs, " "),
-			n.Reason,
+			body,
 		)
 	}
 
@@ -194,6 +196,9 @@ func formatJobNotificationBlock(n jobNotification, excerpt notificationExcerpt) 
 	body := fmt.Sprintf("Job %s %s. %s", n.JobID, event, instruction)
 	if excerpt.text != "" {
 		body += "\nexcerpt:\n" + excerpt.text
+	}
+	if n.Notice != "" {
+		body += "\n" + n.Notice
 	}
 	return fmt.Sprintf(
 		"<job-notification %s>\n%s\n</job-notification>",

--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -720,6 +720,20 @@ func validateWatchEventArgs(a watchArgs) error {
 			return fmt.Errorf("invalid_request: unknown event kind %q", name)
 		}
 	}
+	// Session-event kinds other than job.notification observe the watching
+	// session's own activity (their payloads carry no job identity, and a child
+	// session's events never reach this evaluator), so a concrete-job-targeted
+	// watch on them can only echo the watcher's own calls back at it labeled as
+	// job activity. Refuse the trigger rather than ack one that cannot fire as
+	// asked.
+	if len(a.Events) > 0 && !isWatchSessionTarget(a.Target) {
+		for _, name := range a.Events {
+			if name == "job.notification" {
+				continue
+			}
+			return fmt.Errorf(`invalid_request: events %q watch the watching session's own activity and cannot be scoped to a concrete job; a finished job delivers its completion notification (with result excerpt) automatically — to trigger on the job's output use output_match, or watch events ["job.notification"]`, name)
+		}
+	}
 	if a.Every > 0 {
 		if len(a.Events) != 1 {
 			return errors.New("invalid_request: every requires exactly one watched event kind")
@@ -2427,7 +2441,13 @@ func watchEventMatchesTarget(target string, data events.EventData) bool {
 	case events.JobFinishedData:
 		return d.JobID == target
 	default:
-		return true
+		// Only job lifecycle payloads carry a job identity. Everything else on
+		// the stream is the watching session's OWN activity — a child session's
+		// events never reach this evaluator — so matching it against a concrete
+		// job target would echo the watcher back at itself labeled as job
+		// activity. Fail closed: an event that cannot prove it belongs to the
+		// target does not fire a job-targeted watch.
+		return false
 	}
 }
 

--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -97,6 +97,13 @@ func watchBudgetClearedMessage(target string) string {
 	)
 }
 
+func watchRunawayClearedMessage(target string) string {
+	return fmt.Sprintf(
+		"watch cleared: frames on %s were repeatedly triggered by your own responses to this watch (runaway self-influence); do not re-arm it — rely on the automatic completion notification, or use output_match",
+		target,
+	)
+}
+
 type watchKey struct {
 	VisibleSessionID   string
 	Target             string
@@ -718,20 +725,6 @@ func validateWatchEventArgs(a watchArgs) error {
 		}
 		if _, ok := modelEventKinds[name]; !ok {
 			return fmt.Errorf("invalid_request: unknown event kind %q", name)
-		}
-	}
-	// Session-event kinds other than job.notification observe the watching
-	// session's own activity (their payloads carry no job identity, and a child
-	// session's events never reach this evaluator), so a concrete-job-targeted
-	// watch on them can only echo the watcher's own calls back at it labeled as
-	// job activity. Refuse the trigger rather than ack one that cannot fire as
-	// asked.
-	if len(a.Events) > 0 && !isWatchSessionTarget(a.Target) {
-		for _, name := range a.Events {
-			if name == "job.notification" {
-				continue
-			}
-			return fmt.Errorf(`invalid_request: events %q watch the watching session's own activity and cannot be scoped to a concrete job; a finished job delivers its completion notification (with result excerpt) automatically — to trigger on the job's output use output_match, or watch events ["job.notification"]`, name)
 		}
 	}
 	if a.Every > 0 {
@@ -1542,6 +1535,13 @@ func watchKeyForConfigLocked(jm *jobManager, cfg *watchConfig) (watchKey, bool) 
 // cfg is detached, a later in-flight settle that increments past the budget
 // finds no live key and returns without re-notifying.
 func (jm *jobManager) autoClearWatchOverBudget(cfg *watchConfig) {
+	jm.autoClearWatch(cfg, "budget_exhausted", watchBudgetClearedMessage(cfg.target))
+}
+
+// autoClearWatch tears a watch down as a circuit-breaker action, with the
+// given durable end reason and model-facing message (budget exhaustion or a
+// runaway self-influence chain on the notification path).
+func (jm *jobManager) autoClearWatch(cfg *watchConfig, endReason, message string) {
 	jm.mu.Lock()
 	key, ok := watchKeyForConfigLocked(jm, cfg)
 	if !ok {
@@ -1552,7 +1552,7 @@ func (jm *jobManager) autoClearWatchOverBudget(cfg *watchConfig) {
 		key:       key,
 		cfg:       cfg,
 		terminal:  watchSendTerminalSnapshotsLocked(cfg, jobstore.EventWatchSendDropped, "watch cleared", jm.now()),
-		endReason: "budget_exhausted",
+		endReason: endReason,
 	}}
 	markWatchConfigSnapshotsRejectingLocked(targets)
 	jm.mu.Unlock()
@@ -1566,7 +1566,7 @@ func (jm *jobManager) autoClearWatchOverBudget(cfg *watchConfig) {
 	jm.removeWatchSendTerminalSnapshots(dropped)
 
 	jm.enqueueWatchNotifications([]jobNotification{
-		jm.watchNotificationFromWatch(cfg, "", watchBudgetClearedMessage(cfg.target), nil),
+		jm.watchNotificationFromWatch(cfg, "", message, nil),
 	})
 	jm.kick()
 }
@@ -2149,10 +2149,11 @@ func (jm *jobManager) onSessionEvent(ev events.SessionEvent) {
 	var notifications []jobNotification
 	var deliveries []watchSendDelivery
 	var overBudget []*watchConfig
+	var runaway []*watchConfig
 
 	jm.mu.Lock()
 	for _, cfg := range jm.watches {
-		dec := evaluateWatchEvent(cfg.eventSnapshot(isActiveWatchTargetLocked(jm, cfg.target)), ev)
+		dec := evaluateWatchEvent(cfg.eventSnapshot(isActiveWatchTargetLocked(jm, cfg.target), jm.targetChildSessionIDLocked(cfg.target)), ev)
 		cfg.eventCount = dec.eventCount
 		if !dec.matched {
 			continue
@@ -2160,7 +2161,20 @@ func (jm *jobManager) onSessionEvent(ev events.SessionEvent) {
 		if dec.send {
 			deliveries = append(deliveries, jm.watchSendSnapshot(cfg, dec.watchedIdentity, fmt.Sprintf("event: %s", kind), ev).withSelfInfluence(jm.classifySelfInfluenceLocked(cfg, ev.Provenance)))
 		} else {
-			notifications = append(notifications, jm.watchNotificationFromWatch(cfg, dec.notifyJobID, fmt.Sprintf("event: %s", kind), ev.Provenance))
+			// Watcher notifications run the same inform+breaker policy as watch
+			// sends: a self-influenced echo is delivered with the disengage
+			// notice, and the runaway fuse drops it once the delivered-prior
+			// chain is deep enough (the watch auto-clears like an over-budget
+			// one). Without this, the no-send path — the only shape job_watch's
+			// public arguments can express — delivers unclassified echoes.
+			influence := jm.classifySelfInfluenceLocked(cfg, ev.Provenance)
+			if influence.fuseDepth >= runawaySelfInfluenceDepth {
+				runaway = append(runaway, cfg)
+				continue
+			}
+			n := jm.watchNotificationFromWatch(cfg, dec.notifyJobID, fmt.Sprintf("event: %s", kind), ev.Provenance)
+			n.Notice = selfInfluenceNotice(influence.self, influence.gradientDepth, influence.truncated)
+			notifications = append(notifications, n)
 			if jm.recordWatchDeliveryLocked(cfg) {
 				overBudget = append(overBudget, cfg)
 			}
@@ -2173,6 +2187,9 @@ func (jm *jobManager) onSessionEvent(ev events.SessionEvent) {
 	jm.enqueueWatchNotifications(notifications)
 	jm.recordWatchSendsAndKick(deliveries)
 	jm.autoClearOverBudgetWatches(overBudget)
+	for _, cfg := range runaway {
+		jm.autoClearWatch(cfg, "runaway_self_influence", watchRunawayClearedMessage(cfg.target))
+	}
 }
 
 // watchEventSnapshot is a read-only copy of the per-watch fields that decide
@@ -2192,20 +2209,26 @@ type watchEventSnapshot struct {
 	eventCount     int
 	hasSend        bool
 	sendTo         string
+	// targetSessionID is the watched job's child session id (delegates only;
+	// empty for shells and session targets). Non-lifecycle events match a
+	// concrete-job target only when their envelope originates from this
+	// session — see watchEventMatchesTarget.
+	targetSessionID string
 }
 
-func (cfg *watchConfig) eventSnapshot(targetActive bool) watchEventSnapshot {
+func (cfg *watchConfig) eventSnapshot(targetActive bool, targetSessionID string) watchEventSnapshot {
 	snap := watchEventSnapshot{
-		target:         cfg.target,
-		targetActive:   targetActive,
-		wildcardEvents: cfg.wildcardEvents,
-		eventKinds:     cfg.eventKinds,
-		eventFilter:    cfg.eventFilter,
-		watchID:        cfg.watchID,
-		generation:     cfg.generation,
-		triggerKind:    cfg.triggerKind,
-		triggerEvery:   cfg.triggerEvery,
-		eventCount:     cfg.eventCount,
+		target:          cfg.target,
+		targetActive:    targetActive,
+		targetSessionID: targetSessionID,
+		wildcardEvents:  cfg.wildcardEvents,
+		eventKinds:      cfg.eventKinds,
+		eventFilter:     cfg.eventFilter,
+		watchID:         cfg.watchID,
+		generation:      cfg.generation,
+		triggerKind:     cfg.triggerKind,
+		triggerEvery:    cfg.triggerEvery,
+		eventCount:      cfg.eventCount,
 	}
 	if cfg.send != nil {
 		snap.hasSend = true
@@ -2249,7 +2272,7 @@ func evaluateWatchEvent(snap watchEventSnapshot, ev events.SessionEvent) watchEv
 	} else if !snap.eventKinds[kind] {
 		return miss
 	}
-	if !watchEventMatchesTarget(snap.target, data) {
+	if !watchEventMatchesTarget(snap.target, snap.targetSessionID, ev) {
 		return miss
 	}
 	if !watchEventFilterMatches(snap.eventFilter, ev) {
@@ -2431,23 +2454,25 @@ func watchEventWatchedIdentity(target string, data events.EventData) string {
 	}
 }
 
-func watchEventMatchesTarget(target string, data events.EventData) bool {
+// watchEventMatchesTarget decides whether an event belongs to a watch's target.
+// Session targets observe their own stream, so every event matches. A concrete
+// job target observes THAT job (spec: "a concrete job's output/progress/events"):
+// lifecycle payloads name their job, and every other kind is scoped by the
+// envelope's originating session against the watched job's child session.
+// Watcher-origin events (ev.SessionID == the watcher's session, which stamps its
+// own emissions) therefore never fire a job-targeted watch — matching them would
+// echo the watcher back at itself labeled as job activity.
+func watchEventMatchesTarget(target, targetSessionID string, ev events.SessionEvent) bool {
 	if isWatchSessionTarget(target) {
 		return true
 	}
-	switch d := data.(type) {
+	switch d := ev.Data.(type) {
 	case events.JobStartedData:
 		return d.JobID == target
 	case events.JobFinishedData:
 		return d.JobID == target
 	default:
-		// Only job lifecycle payloads carry a job identity. Everything else on
-		// the stream is the watching session's OWN activity — a child session's
-		// events never reach this evaluator — so matching it against a concrete
-		// job target would echo the watcher back at itself labeled as job
-		// activity. Fail closed: an event that cannot prove it belongs to the
-		// target does not fire a job-targeted watch.
-		return false
+		return ev.SessionID != "" && ev.SessionID == targetSessionID
 	}
 }
 
@@ -2456,6 +2481,21 @@ func isActiveWatchTargetLocked(jm *jobManager, target string) bool {
 		return true
 	}
 	return isWatchableConcreteJobLocked(jm.running[target])
+}
+
+// targetChildSessionIDLocked resolves a concrete watch target to the watched
+// job's child session id — the identity non-lifecycle events must carry to
+// match it (watchEventMatchesTarget). Empty for session targets, shells, and
+// jobs without a child session. Caller holds jm.mu.
+func (jm *jobManager) targetChildSessionIDLocked(target string) string {
+	if isWatchSessionTarget(target) {
+		return ""
+	}
+	run := jm.running[target]
+	if run == nil || run.rec == nil || run.rec.DelegateRestore == nil {
+		return ""
+	}
+	return run.rec.DelegateRestore.ChildSessionID
 }
 
 // feedJobOutput level-triggers output_match watches on a freshly produced

--- a/agent/job_watch_events_test.go
+++ b/agent/job_watch_events_test.go
@@ -214,15 +214,18 @@ func TestConcreteJobEventWatchSendsFrame(t *testing.T) {
 	seedCommonWatchSendTargets(t, jm)
 
 	rec, _ := jm.createShell(createShellOpts{Command: "x"})
+	// job.notification is the one event kind a concrete-job target can scope
+	// (lifecycle payloads name their job); tool events are scoped by the
+	// watched job's child session and never fire from watcher-origin events.
 	_, err := jm.configureWatch(watchArgs{
 		Target: rec.JobID,
-		Events: []string{"assistant.tool"},
+		Events: []string{"job.notification"},
 		Send:   &watchSendArgs{To: "dlg_obs", Message: "observe"},
 	})
 	if err != nil {
 		t.Fatalf("configure: %v", err)
 	}
-	onSessionEventKD(jm, events.EventToolCallEnd, nil)
+	onSessionEventKD(jm, events.EventJobFinished, events.JobFinishedData{JobID: rec.JobID})
 
 	// Observation records the send as pending (frame snapshot included); delivery
 	// is the loop-owned drain's job.
@@ -242,7 +245,7 @@ func TestConcreteJobEventWatchSendsFrame(t *testing.T) {
 	}
 	if !strings.Contains(state.Frame, "observe") ||
 		!strings.Contains(state.Frame, rec.JobID) ||
-		!strings.Contains(state.Frame, "event: TOOL_CALL_END") {
+		!strings.Contains(state.Frame, "event: JOB_FINISHED") {
 		t.Fatalf("pending frame = %q, want configured message, job id, and trigger", state.Frame)
 	}
 }

--- a/agent/job_watch_scope_test.go
+++ b/agent/job_watch_scope_test.go
@@ -5,56 +5,69 @@ import (
 	"testing"
 
 	"primeradiant.com/serf/agent/events"
+	"primeradiant.com/serf/agent/provenance"
 )
 
 // These tests pin the scoping rule for concrete-job-targeted session-event
-// watches (PRI-2525). ToolCallEndData and CommunicateData carry no job/session
-// identity, and the only session whose events reach a jobManager's evaluator is
-// the watcher's own — so a job-targeted watch on those kinds can never observe
-// the watched job and instead echoes the watcher's own tool calls back at it
-// labeled as job activity. The echo is a self-sustaining coordination loop:
-// each frame provokes a communicate, whose TOOL_CALL_END fires the next frame.
+// watches and the inform+breaker policy on watcher-notification deliveries
+// (PRI-2525). Non-lifecycle event payloads carry no job identity, and the only
+// session whose events reach a jobManager's evaluator today is the watcher's
+// own — so before identity scoping, a job-targeted event watch could only echo
+// the watcher's own tool calls back at it labeled as job activity, and the
+// no-send notification path delivered those echoes without self-influence
+// classification.
 
-// A job-targeted watch must not match tool events, filtered or not: the event
-// cannot prove it belongs to the target job.
-func TestJobTargetWatchDoesNotMatchOwnToolEvents(t *testing.T) {
+// A job-targeted watch must not match the watcher's own tool events: the
+// envelope's originating session is the watcher, not the watched job.
+func TestJobTargetWatchDoesNotMatchWatcherOwnToolEvents(t *testing.T) {
 	snap := watchEventSnapshot{
-		target:       "job_watched",
-		targetActive: true,
-		eventKinds:   map[events.EventKind]bool{events.EventToolCallEnd: true},
-		eventFilter:  &watchEventFilter{ToolName: "communicate", Status: "ok"},
-		watchID:      "watch_scope_1",
-		generation:   "g1",
+		target:          "job_watched",
+		targetActive:    true,
+		targetSessionID: "sess_child",
+		eventKinds:      map[events.EventKind]bool{events.EventToolCallEnd: true},
+		eventFilter:     &watchEventFilter{ToolName: "communicate", Status: "ok"},
+		watchID:         "watch_scope_1",
+		generation:      "g1",
 	}
 	ev := events.SessionEvent{
-		Kind: events.EventToolCallEnd,
-		Data: events.ToolCallEndData{ToolName: "communicate"},
+		Kind:      events.EventToolCallEnd,
+		SessionID: "sess_watcher",
+		Data:      events.ToolCallEndData{ToolName: "communicate"},
 	}
 	if dec := evaluateWatchEvent(snap, ev); dec.matched {
-		t.Fatalf("job-targeted watch matched the session's own communicate TOOL_CALL_END: %+v", dec)
+		t.Fatalf("job-targeted watch matched a watcher-origin communicate TOOL_CALL_END: %+v", dec)
+	}
+	// An event that cannot prove its origin does not fire either.
+	ev.SessionID = ""
+	if dec := evaluateWatchEvent(snap, ev); dec.matched {
+		t.Fatalf("job-targeted watch matched an identity-less tool event: %+v", dec)
 	}
 }
 
-// The wildcard-events form of the same hole: without an event_filter the gate
-// must still refuse identity-less kinds on a concrete job target.
-func TestJobTargetWildcardWatchDoesNotMatchOwnToolEvents(t *testing.T) {
+// The spec's promised semantics: an event originating from the watched job's
+// child session matches its job-targeted watch.
+func TestJobTargetWatchMatchesWatchedJobSessionEvents(t *testing.T) {
 	snap := watchEventSnapshot{
-		target:         "job_watched",
-		targetActive:   true,
-		wildcardEvents: true,
-		watchID:        "watch_scope_2",
-		generation:     "g1",
+		target:          "job_watched",
+		targetActive:    true,
+		targetSessionID: "sess_child",
+		eventKinds:      map[events.EventKind]bool{events.EventToolCallEnd: true},
+		eventFilter:     &watchEventFilter{ToolName: "communicate", Status: "ok"},
+		watchID:         "watch_scope_2",
+		generation:      "g1",
 	}
 	ev := events.SessionEvent{
-		Kind: events.EventToolCallEnd,
-		Data: events.ToolCallEndData{ToolName: "shell"},
+		Kind:      events.EventToolCallEnd,
+		SessionID: "sess_child",
+		Data:      events.ToolCallEndData{ToolName: "communicate"},
 	}
-	if dec := evaluateWatchEvent(snap, ev); dec.matched {
-		t.Fatalf("job-targeted wildcard watch matched an unscopeable tool event: %+v", dec)
+	if dec := evaluateWatchEvent(snap, ev); !dec.matched {
+		t.Fatalf("job-targeted watch must match the watched job's own session events: %+v", dec)
 	}
 }
 
-// Job lifecycle events carry a JobID and stay matchable on a job target.
+// Job lifecycle events carry a JobID and stay matchable on a job target
+// regardless of envelope identity.
 func TestJobTargetWatchStillMatchesJobLifecycle(t *testing.T) {
 	snap := watchEventSnapshot{
 		target:       "job_watched",
@@ -64,8 +77,9 @@ func TestJobTargetWatchStillMatchesJobLifecycle(t *testing.T) {
 		generation:   "g1",
 	}
 	ev := events.SessionEvent{
-		Kind: events.EventJobFinished,
-		Data: events.JobFinishedData{JobID: "job_watched"},
+		Kind:      events.EventJobFinished,
+		SessionID: "sess_watcher",
+		Data:      events.JobFinishedData{JobID: "job_watched"},
 	}
 	if dec := evaluateWatchEvent(snap, ev); !dec.matched {
 		t.Fatalf("job-targeted watch must still match its own job's lifecycle event: %+v", dec)
@@ -84,79 +98,132 @@ func TestSessionTargetWatchStillMatchesToolEvents(t *testing.T) {
 		generation:   "g1",
 	}
 	ev := events.SessionEvent{
-		Kind: events.EventToolCallEnd,
-		Data: events.ToolCallEndData{ToolName: "read_file"},
+		Kind:      events.EventToolCallEnd,
+		SessionID: "sess_watcher",
+		Data:      events.ToolCallEndData{ToolName: "read_file"},
 	}
 	if dec := evaluateWatchEvent(snap, ev); !dec.matched {
 		t.Fatalf("session-target watch must keep matching its own tool events: %+v", dec)
 	}
 }
 
-// Create-time: serf must refuse the trigger it cannot honor instead of acking
-// it. A concrete-job target may only watch job.notification; assistant.tool /
-// communicate / "*" (and event_filter, which implies assistant.tool) observe
-// the watcher's own session and are rejected with guidance.
-func TestJobTargetEventWatchRejectedAtCreate(t *testing.T) {
-	cases := []struct {
-		name string
-		args watchArgs
-	}{
-		{"assistant.tool with filter", watchArgs{
-			Target:      "job_watched",
-			Events:      []string{"assistant.tool"},
-			EventFilter: &watchEventFilter{ToolName: "communicate", Status: "ok"},
-		}},
-		{"assistant.tool bare", watchArgs{
-			Target: "job_watched",
-			Events: []string{"assistant.tool"},
-		}},
-		{"communicate kind", watchArgs{
-			Target: "job_watched",
-			Events: []string{"communicate"},
-		}},
-		{"wildcard", watchArgs{
-			Target: "job_watched",
-			Events: []string{"*"},
-		}},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := validateWatchEventArgs(tc.args)
-			if err == nil {
-				t.Fatal("expected invalid_request for an unscopeable event watch on a concrete job target")
-			}
-			if !strings.Contains(err.Error(), "invalid_request") {
-				t.Fatalf("want invalid_request, got: %v", err)
-			}
-		})
+// Install stays permissive (loop-guard posture): event watches on concrete job
+// targets are accepted; identity scoping happens at match time, not create time.
+func TestJobTargetEventWatchStillInstallsAtCreate(t *testing.T) {
+	err := validateWatchEventArgs(watchArgs{
+		Target:      "job_watched",
+		Events:      []string{"assistant.tool"},
+		EventFilter: &watchEventFilter{ToolName: "communicate", Status: "ok"},
+	})
+	if err != nil {
+		t.Fatalf("expected install-permissive accept, got: %v", err)
 	}
 }
 
-// The scoped and session-target forms stay accepted.
-func TestScopedEventWatchesStillAcceptedAtCreate(t *testing.T) {
-	cases := []struct {
-		name string
-		args watchArgs
-	}{
-		{"job.notification on job target", watchArgs{
-			Target: "job_watched",
-			Events: []string{"job.notification"},
-		}},
-		{"assistant.tool on session target", watchArgs{
-			Target:      runtimeMessageAliasCaller,
-			Events:      []string{"assistant.tool"},
-			EventFilter: &watchEventFilter{ToolName: "read_file", Status: "ok"},
-		}},
-		{"communicate on session target", watchArgs{
-			Target: runtimeMessageAliasCaller,
-			Events: []string{"communicate"},
-		}},
+// A self-influenced watcher-notification frame carries the disengage notice —
+// the same inform+breaker policy the send path applies. Without classification
+// on the no-send path, the only shape job_watch's public arguments can express
+// delivered unclassified echoes.
+func TestNotificationPathCarriesSelfInfluenceNotice(t *testing.T) {
+	jm := newTestJM(t)
+	var got []jobNotification
+	jm.enqueue = func(n jobNotification) { got = append(got, n) }
+
+	installWatchBelowValidation(t, jm, watchArgs{
+		Target: runtimeMessageAliasCaller,
+		Events: []string{"assistant.tool"},
+	})
+	watchID, generation := singleWatchIdentity(t, jm)
+
+	jm.onSessionEvent(events.SessionEvent{
+		Kind:       events.EventToolCallEnd,
+		SessionID:  jm.sessionID,
+		Data:       events.ToolCallEndData{ToolName: "read_file"},
+		Provenance: provenance.WithWatch(nil, watchID, generation, "wd_prior", jm.sessionID, ""),
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("want one watcher notification, got %d", len(got))
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := validateWatchEventArgs(tc.args); err != nil {
-				t.Fatalf("expected accept, got: %v", err)
-			}
-		})
+	if got[0].Notice == "" {
+		t.Fatal("self-influenced notification frame must carry the disengage notice")
 	}
+	if !strings.Contains(formatJobNotificationBlock(got[0], notificationExcerpt{}), got[0].Notice) {
+		t.Fatal("rendered notification block must include the notice")
+	}
+	// A frame with no self-influence carries no notice.
+	got = nil
+	jm.onSessionEvent(events.SessionEvent{
+		Kind:      events.EventToolCallEnd,
+		SessionID: jm.sessionID,
+		Data:      events.ToolCallEndData{ToolName: "read_file"},
+	})
+	if len(got) != 1 {
+		t.Fatalf("want one watcher notification, got %d", len(got))
+	}
+	if got[0].Notice != "" {
+		t.Fatalf("un-influenced frame must carry no notice, got %q", got[0].Notice)
+	}
+}
+
+// Once the delivered-prior chain of a watch is runaway-deep, the notification
+// path drops the delivery and auto-clears the watch — mirroring the send
+// path's fuse in recordWatchSend.
+func TestNotificationPathRunawayFuseClearsWatch(t *testing.T) {
+	jm := newTestJM(t)
+	var got []jobNotification
+	jm.enqueue = func(n jobNotification) { got = append(got, n) }
+
+	installWatchBelowValidation(t, jm, watchArgs{
+		Target: runtimeMessageAliasCaller,
+		Events: []string{"assistant.tool"},
+	})
+	watchID, generation := singleWatchIdentity(t, jm)
+
+	var chain *provenance.Causal
+	jm.mu.Lock()
+	for i := 0; i < runawaySelfInfluenceDepth; i++ {
+		deliveryID := "wd_runaway_" + strings.Repeat("x", i+1)
+		chain = provenance.WithWatch(chain, watchID, generation, deliveryID, jm.sessionID, "")
+		jm.deliveredWatchSendIDs[deliveryID] = struct{}{}
+	}
+	jm.mu.Unlock()
+
+	jm.onSessionEvent(events.SessionEvent{
+		Kind:       events.EventToolCallEnd,
+		SessionID:  jm.sessionID,
+		Data:       events.ToolCallEndData{ToolName: "read_file"},
+		Provenance: chain,
+	})
+
+	var clearNotice bool
+	for _, n := range got {
+		if strings.HasPrefix(n.Reason, "event: ") {
+			t.Fatalf("runaway-deep echo must not deliver a watch frame: %+v", n)
+		}
+		if strings.Contains(n.Reason, "runaway self-influence") {
+			clearNotice = true
+		}
+	}
+	if !clearNotice {
+		t.Fatal("runaway clear must tell the model why the watch ended")
+	}
+	if jm.watchCount() != 0 {
+		t.Fatalf("runaway watch must auto-clear; watchCount = %d", jm.watchCount())
+	}
+}
+
+// singleWatchIdentity returns the (watchID, generation) of the jobManager's
+// only installed watch.
+func singleWatchIdentity(t *testing.T, jm *jobManager) (string, string) {
+	t.Helper()
+	jm.mu.Lock()
+	defer jm.mu.Unlock()
+	if len(jm.watches) != 1 {
+		t.Fatalf("want exactly one watch installed, got %d", len(jm.watches))
+	}
+	for _, cfg := range jm.watches {
+		return cfg.watchID, cfg.generation
+	}
+	return "", ""
 }

--- a/agent/job_watch_scope_test.go
+++ b/agent/job_watch_scope_test.go
@@ -1,0 +1,162 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"primeradiant.com/serf/agent/events"
+)
+
+// These tests pin the scoping rule for concrete-job-targeted session-event
+// watches (PRI-2525). ToolCallEndData and CommunicateData carry no job/session
+// identity, and the only session whose events reach a jobManager's evaluator is
+// the watcher's own — so a job-targeted watch on those kinds can never observe
+// the watched job and instead echoes the watcher's own tool calls back at it
+// labeled as job activity. The echo is a self-sustaining coordination loop:
+// each frame provokes a communicate, whose TOOL_CALL_END fires the next frame.
+
+// A job-targeted watch must not match tool events, filtered or not: the event
+// cannot prove it belongs to the target job.
+func TestJobTargetWatchDoesNotMatchOwnToolEvents(t *testing.T) {
+	snap := watchEventSnapshot{
+		target:       "job_watched",
+		targetActive: true,
+		eventKinds:   map[events.EventKind]bool{events.EventToolCallEnd: true},
+		eventFilter:  &watchEventFilter{ToolName: "communicate", Status: "ok"},
+		watchID:      "watch_scope_1",
+		generation:   "g1",
+	}
+	ev := events.SessionEvent{
+		Kind: events.EventToolCallEnd,
+		Data: events.ToolCallEndData{ToolName: "communicate"},
+	}
+	if dec := evaluateWatchEvent(snap, ev); dec.matched {
+		t.Fatalf("job-targeted watch matched the session's own communicate TOOL_CALL_END: %+v", dec)
+	}
+}
+
+// The wildcard-events form of the same hole: without an event_filter the gate
+// must still refuse identity-less kinds on a concrete job target.
+func TestJobTargetWildcardWatchDoesNotMatchOwnToolEvents(t *testing.T) {
+	snap := watchEventSnapshot{
+		target:         "job_watched",
+		targetActive:   true,
+		wildcardEvents: true,
+		watchID:        "watch_scope_2",
+		generation:     "g1",
+	}
+	ev := events.SessionEvent{
+		Kind: events.EventToolCallEnd,
+		Data: events.ToolCallEndData{ToolName: "shell"},
+	}
+	if dec := evaluateWatchEvent(snap, ev); dec.matched {
+		t.Fatalf("job-targeted wildcard watch matched an unscopeable tool event: %+v", dec)
+	}
+}
+
+// Job lifecycle events carry a JobID and stay matchable on a job target.
+func TestJobTargetWatchStillMatchesJobLifecycle(t *testing.T) {
+	snap := watchEventSnapshot{
+		target:       "job_watched",
+		targetActive: true,
+		eventKinds:   map[events.EventKind]bool{events.EventJobFinished: true},
+		watchID:      "watch_scope_3",
+		generation:   "g1",
+	}
+	ev := events.SessionEvent{
+		Kind: events.EventJobFinished,
+		Data: events.JobFinishedData{JobID: "job_watched"},
+	}
+	if dec := evaluateWatchEvent(snap, ev); !dec.matched {
+		t.Fatalf("job-targeted watch must still match its own job's lifecycle event: %+v", dec)
+	}
+}
+
+// Session-target watches (self/parent observers) keep tool-event semantics:
+// firing on the session's own events is their intended meaning.
+func TestSessionTargetWatchStillMatchesToolEvents(t *testing.T) {
+	snap := watchEventSnapshot{
+		target:       runtimeMessageAliasCaller,
+		targetActive: true,
+		eventKinds:   map[events.EventKind]bool{events.EventToolCallEnd: true},
+		eventFilter:  &watchEventFilter{ToolName: "read_file", Status: "ok"},
+		watchID:      "watch_scope_4",
+		generation:   "g1",
+	}
+	ev := events.SessionEvent{
+		Kind: events.EventToolCallEnd,
+		Data: events.ToolCallEndData{ToolName: "read_file"},
+	}
+	if dec := evaluateWatchEvent(snap, ev); !dec.matched {
+		t.Fatalf("session-target watch must keep matching its own tool events: %+v", dec)
+	}
+}
+
+// Create-time: serf must refuse the trigger it cannot honor instead of acking
+// it. A concrete-job target may only watch job.notification; assistant.tool /
+// communicate / "*" (and event_filter, which implies assistant.tool) observe
+// the watcher's own session and are rejected with guidance.
+func TestJobTargetEventWatchRejectedAtCreate(t *testing.T) {
+	cases := []struct {
+		name string
+		args watchArgs
+	}{
+		{"assistant.tool with filter", watchArgs{
+			Target:      "job_watched",
+			Events:      []string{"assistant.tool"},
+			EventFilter: &watchEventFilter{ToolName: "communicate", Status: "ok"},
+		}},
+		{"assistant.tool bare", watchArgs{
+			Target: "job_watched",
+			Events: []string{"assistant.tool"},
+		}},
+		{"communicate kind", watchArgs{
+			Target: "job_watched",
+			Events: []string{"communicate"},
+		}},
+		{"wildcard", watchArgs{
+			Target: "job_watched",
+			Events: []string{"*"},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateWatchEventArgs(tc.args)
+			if err == nil {
+				t.Fatal("expected invalid_request for an unscopeable event watch on a concrete job target")
+			}
+			if !strings.Contains(err.Error(), "invalid_request") {
+				t.Fatalf("want invalid_request, got: %v", err)
+			}
+		})
+	}
+}
+
+// The scoped and session-target forms stay accepted.
+func TestScopedEventWatchesStillAcceptedAtCreate(t *testing.T) {
+	cases := []struct {
+		name string
+		args watchArgs
+	}{
+		{"job.notification on job target", watchArgs{
+			Target: "job_watched",
+			Events: []string{"job.notification"},
+		}},
+		{"assistant.tool on session target", watchArgs{
+			Target:      runtimeMessageAliasCaller,
+			Events:      []string{"assistant.tool"},
+			EventFilter: &watchEventFilter{ToolName: "read_file", Status: "ok"},
+		}},
+		{"communicate on session target", watchArgs{
+			Target: runtimeMessageAliasCaller,
+			Events: []string{"communicate"},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateWatchEventArgs(tc.args); err != nil {
+				t.Fatalf("expected accept, got: %v", err)
+			}
+		})
+	}
+}

--- a/agent/jobs.go
+++ b/agent/jobs.go
@@ -328,6 +328,10 @@ type jobNotification struct {
 	// against the owning jobManager's CURRENT pending state at accept time
 	// (spec §4.3). The frame text is deliberately NOT carried here.
 	WatchSend *watchSendToken
+	// Notice is the inform+breaker's model-facing self-influence line for a
+	// watcher-notification frame (the send path carries its notice on the
+	// rendered frame instead). Advisory and in-memory only.
+	Notice string
 	// receiverSessionID/receiverNotify route no-send watch notifications for
 	// concrete descendant watches back to the ancestor session that installed
 	// them. They are in-memory only; active watches are not restored without a

--- a/agent/watch_seqfuzz_test.go
+++ b/agent/watch_seqfuzz_test.go
@@ -375,7 +375,7 @@ func (h *ws_harness) applyEmit(op ws_op) ws_opOutcome {
 	predicted := 0
 	h.jm.mu.Lock()
 	for _, cfg := range h.jm.watches {
-		dec := evaluateWatchEvent(cfg.eventSnapshot(isActiveWatchTargetLocked(h.jm, cfg.target)), ev)
+		dec := evaluateWatchEvent(cfg.eventSnapshot(isActiveWatchTargetLocked(h.jm, cfg.target), h.jm.targetChildSessionIDLocked(cfg.target)), ev)
 		if dec.matched && !dec.send {
 			predicted++
 		}


### PR DESCRIPTION
Superseded by #15 (branch was renamed during cleanup, which auto-closed this PR).