### PR TITLE
fix(agent): identity-scope job-targeted event watches; inform+breaker on watcher notifications

### DIFF
--- a/agent/cov_s1_watch_event_target_test.go
+++ b/agent/cov_s1_watch_event_target_test.go
@@ -26,18 +26,26 @@ func TestS1Cov_watchEventWatchedIdentity(t *testing.T) {
 
 func TestS1Cov_watchEventMatchesTarget(t *testing.T) {
 	// Session targets always match.
-	if !watchEventMatchesTarget("caller", events.JobStartedData{JobID: "job_x"}) {
+	if !watchEventMatchesTarget("caller", "", events.SessionEvent{Data: events.JobStartedData{JobID: "job_x"}}) {
 		t.Fatal("session target must match any event")
 	}
 	// Concrete targets match only the same job id.
-	if !watchEventMatchesTarget("job_x", events.JobStartedData{JobID: "job_x"}) {
+	if !watchEventMatchesTarget("job_x", "", events.SessionEvent{Data: events.JobStartedData{JobID: "job_x"}}) {
 		t.Fatal("start event for the target job must match")
 	}
-	if watchEventMatchesTarget("job_x", events.JobFinishedData{JobID: "job_y"}) {
+	if watchEventMatchesTarget("job_x", "", events.SessionEvent{Data: events.JobFinishedData{JobID: "job_y"}}) {
 		t.Fatal("finish event for a different job must not match")
 	}
-	// Non job-lifecycle events default to matching a concrete target.
-	if !watchEventMatchesTarget("job_x", events.CommunicateData{}) {
-		t.Fatal("non-lifecycle event defaults to match")
+	// Non job-lifecycle events are scoped by originating session: only the
+	// watched job's child session matches; watcher-origin and identity-less
+	// events do not (they would echo the watcher back at itself).
+	if !watchEventMatchesTarget("job_x", "sess_child", events.SessionEvent{SessionID: "sess_child", Data: events.CommunicateData{}}) {
+		t.Fatal("watched job's session event must match")
+	}
+	if watchEventMatchesTarget("job_x", "sess_child", events.SessionEvent{SessionID: "sess_watcher", Data: events.CommunicateData{}}) {
+		t.Fatal("watcher-origin non-lifecycle event must not match")
+	}
+	if watchEventMatchesTarget("job_x", "", events.SessionEvent{Data: events.CommunicateData{}}) {
+		t.Fatal("identity-less non-lifecycle event must not match")
 	}
 }

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -198,6 +198,7 @@ func DefJobWatch(eventKinds []string) llm.ToolDefinition {
 		"For cross-session session sources such as `parent`, omitting trigger fields watches all bounded public events for that source. " +
 		"Pick the trigger mode that matches the signal: session event frames use `events` (available: " + kinds + "), `event_filter`, and optional `every`; concrete job output uses `output_match`; periodic progress uses `progress_interval_ms`. " +
 		"`event_filter` narrows assistant.tool events by tool_name and ok/error status. " +
+		"Do not use job_watch to learn when a job completes — a finished job delivers its completion notification (with result excerpt) automatically; to trigger on a job's output, use `output_match`. " +
 		"Observers report findings with `communicate(end_turn=true)`. " +
 		"`operation=\"clear\"` removes a watch by `watch_id`."
 	return llm.ToolDefinition{

--- a/agent/job_notify.go
+++ b/agent/job_notify.go
@@ -172,12 +172,14 @@ func formatJobNotificationBlock(n jobNotification, excerpt notificationExcerpt) 
 	}
 
 	if n.Status == jobNotificationEventWatch && n.JobID == "" {
+		body := fmt.Sprintf("Watch event triggered: %s.", n.Reason)
+		if n.Notice != "" {
+			body += "\n" + n.Notice
+		}
 		return fmt.Sprintf(
-			"<job-notification %s>\n"+
-				"Watch event triggered: %s.\n"+
-				"</job-notification>",
+			"<job-notification %s>\n%s\n</job-notification>",
 			strings.Join(attrs, " "),
-			n.Reason,
+			body,
 		)
 	}
 
@@ -194,6 +196,9 @@ func formatJobNotificationBlock(n jobNotification, excerpt notificationExcerpt) 
 	body := fmt.Sprintf("Job %s %s. %s", n.JobID, event, instruction)
 	if excerpt.text != "" {
 		body += "\nexcerpt:\n" + excerpt.text
+	}
+	if n.Notice != "" {
+		body += "\n" + n.Notice
 	}
 	return fmt.Sprintf(
 		"<job-notification %s>\n%s\n</job-notification>",

--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -97,6 +97,13 @@ func watchBudgetClearedMessage(target string) string {
 	)
 }
 
+func watchRunawayClearedMessage(target string) string {
+	return fmt.Sprintf(
+		"watch cleared: frames on %s were repeatedly triggered by your own responses to this watch (runaway self-influence); do not re-arm it — rely on the automatic completion notification, or use output_match",
+		target,
+	)
+}
+
 type watchKey struct {
 	VisibleSessionID   string
 	Target             string
@@ -1528,6 +1535,13 @@ func watchKeyForConfigLocked(jm *jobManager, cfg *watchConfig) (watchKey, bool) 
 // cfg is detached, a later in-flight settle that increments past the budget
 // finds no live key and returns without re-notifying.
 func (jm *jobManager) autoClearWatchOverBudget(cfg *watchConfig) {
+	jm.autoClearWatch(cfg, "budget_exhausted", watchBudgetClearedMessage(cfg.target))
+}
+
+// autoClearWatch tears a watch down as a circuit-breaker action, with the
+// given durable end reason and model-facing message (budget exhaustion or a
+// runaway self-influence chain on the notification path).
+func (jm *jobManager) autoClearWatch(cfg *watchConfig, endReason, message string) {
 	jm.mu.Lock()
 	key, ok := watchKeyForConfigLocked(jm, cfg)
 	if !ok {
@@ -1538,7 +1552,7 @@ func (jm *jobManager) autoClearWatchOverBudget(cfg *watchConfig) {
 		key:       key,
 		cfg:       cfg,
 		terminal:  watchSendTerminalSnapshotsLocked(cfg, jobstore.EventWatchSendDropped, "watch cleared", jm.now()),
-		endReason: "budget_exhausted",
+		endReason: endReason,
 	}}
 	markWatchConfigSnapshotsRejectingLocked(targets)
 	jm.mu.Unlock()
@@ -1552,7 +1566,7 @@ func (jm *jobManager) autoClearWatchOverBudget(cfg *watchConfig) {
 	jm.removeWatchSendTerminalSnapshots(dropped)
 
 	jm.enqueueWatchNotifications([]jobNotification{
-		jm.watchNotificationFromWatch(cfg, "", watchBudgetClearedMessage(cfg.target), nil),
+		jm.watchNotificationFromWatch(cfg, "", message, nil),
 	})
 	jm.kick()
 }
@@ -2135,10 +2149,11 @@ func (jm *jobManager) onSessionEvent(ev events.SessionEvent) {
 	var notifications []jobNotification
 	var deliveries []watchSendDelivery
 	var overBudget []*watchConfig
+	var runaway []*watchConfig
 
 	jm.mu.Lock()
 	for _, cfg := range jm.watches {
-		dec := evaluateWatchEvent(cfg.eventSnapshot(isActiveWatchTargetLocked(jm, cfg.target)), ev)
+		dec := evaluateWatchEvent(cfg.eventSnapshot(isActiveWatchTargetLocked(jm, cfg.target), jm.targetChildSessionIDLocked(cfg.target)), ev)
 		cfg.eventCount = dec.eventCount
 		if !dec.matched {
 			continue
@@ -2146,7 +2161,20 @@ func (jm *jobManager) onSessionEvent(ev events.SessionEvent) {
 		if dec.send {
 			deliveries = append(deliveries, jm.watchSendSnapshot(cfg, dec.watchedIdentity, fmt.Sprintf("event: %s", kind), ev).withSelfInfluence(jm.classifySelfInfluenceLocked(cfg, ev.Provenance)))
 		} else {
-			notifications = append(notifications, jm.watchNotificationFromWatch(cfg, dec.notifyJobID, fmt.Sprintf("event: %s", kind), ev.Provenance))
+			// Watcher notifications run the same inform+breaker policy as watch
+			// sends: a self-influenced echo is delivered with the disengage
+			// notice, and the runaway fuse drops it once the delivered-prior
+			// chain is deep enough (the watch auto-clears like an over-budget
+			// one). Without this, the no-send path — the only shape job_watch's
+			// public arguments can express — delivers unclassified echoes.
+			influence := jm.classifySelfInfluenceLocked(cfg, ev.Provenance)
+			if influence.fuseDepth >= runawaySelfInfluenceDepth {
+				runaway = append(runaway, cfg)
+				continue
+			}
+			n := jm.watchNotificationFromWatch(cfg, dec.notifyJobID, fmt.Sprintf("event: %s", kind), ev.Provenance)
+			n.Notice = selfInfluenceNotice(influence.self, influence.gradientDepth, influence.truncated)
+			notifications = append(notifications, n)
 			if jm.recordWatchDeliveryLocked(cfg) {
 				overBudget = append(overBudget, cfg)
 			}
@@ -2159,6 +2187,9 @@ func (jm *jobManager) onSessionEvent(ev events.SessionEvent) {
 	jm.enqueueWatchNotifications(notifications)
 	jm.recordWatchSendsAndKick(deliveries)
 	jm.autoClearOverBudgetWatches(overBudget)
+	for _, cfg := range runaway {
+		jm.autoClearWatch(cfg, "runaway_self_influence", watchRunawayClearedMessage(cfg.target))
+	}
 }
 
 // watchEventSnapshot is a read-only copy of the per-watch fields that decide
@@ -2178,20 +2209,26 @@ type watchEventSnapshot struct {
 	eventCount     int
 	hasSend        bool
 	sendTo         string
+	// targetSessionID is the watched job's child session id (delegates only;
+	// empty for shells and session targets). Non-lifecycle events match a
+	// concrete-job target only when their envelope originates from this
+	// session — see watchEventMatchesTarget.
+	targetSessionID string
 }
 
-func (cfg *watchConfig) eventSnapshot(targetActive bool) watchEventSnapshot {
+func (cfg *watchConfig) eventSnapshot(targetActive bool, targetSessionID string) watchEventSnapshot {
 	snap := watchEventSnapshot{
-		target:         cfg.target,
-		targetActive:   targetActive,
-		wildcardEvents: cfg.wildcardEvents,
-		eventKinds:     cfg.eventKinds,
-		eventFilter:    cfg.eventFilter,
-		watchID:        cfg.watchID,
-		generation:     cfg.generation,
-		triggerKind:    cfg.triggerKind,
-		triggerEvery:   cfg.triggerEvery,
-		eventCount:     cfg.eventCount,
+		target:          cfg.target,
+		targetActive:    targetActive,
+		targetSessionID: targetSessionID,
+		wildcardEvents:  cfg.wildcardEvents,
+		eventKinds:      cfg.eventKinds,
+		eventFilter:     cfg.eventFilter,
+		watchID:         cfg.watchID,
+		generation:      cfg.generation,
+		triggerKind:     cfg.triggerKind,
+		triggerEvery:    cfg.triggerEvery,
+		eventCount:      cfg.eventCount,
 	}
 	if cfg.send != nil {
 		snap.hasSend = true
@@ -2235,7 +2272,7 @@ func evaluateWatchEvent(snap watchEventSnapshot, ev events.SessionEvent) watchEv
 	} else if !snap.eventKinds[kind] {
 		return miss
 	}
-	if !watchEventMatchesTarget(snap.target, data) {
+	if !watchEventMatchesTarget(snap.target, snap.targetSessionID, ev) {
 		return miss
 	}
 	if !watchEventFilterMatches(snap.eventFilter, ev) {
@@ -2417,17 +2454,25 @@ func watchEventWatchedIdentity(target string, data events.EventData) string {
 	}
 }
 
-func watchEventMatchesTarget(target string, data events.EventData) bool {
+// watchEventMatchesTarget decides whether an event belongs to a watch's target.
+// Session targets observe their own stream, so every event matches. A concrete
+// job target observes THAT job (spec: "a concrete job's output/progress/events"):
+// lifecycle payloads name their job, and every other kind is scoped by the
+// envelope's originating session against the watched job's child session.
+// Watcher-origin events (ev.SessionID == the watcher's session, which stamps its
+// own emissions) therefore never fire a job-targeted watch — matching them would
+// echo the watcher back at itself labeled as job activity.
+func watchEventMatchesTarget(target, targetSessionID string, ev events.SessionEvent) bool {
 	if isWatchSessionTarget(target) {
 		return true
 	}
-	switch d := data.(type) {
+	switch d := ev.Data.(type) {
 	case events.JobStartedData:
 		return d.JobID == target
 	case events.JobFinishedData:
 		return d.JobID == target
 	default:
-		return true
+		return ev.SessionID != "" && ev.SessionID == targetSessionID
 	}
 }
 
@@ -2436,6 +2481,21 @@ func isActiveWatchTargetLocked(jm *jobManager, target string) bool {
 		return true
 	}
 	return isWatchableConcreteJobLocked(jm.running[target])
+}
+
+// targetChildSessionIDLocked resolves a concrete watch target to the watched
+// job's child session id — the identity non-lifecycle events must carry to
+// match it (watchEventMatchesTarget). Empty for session targets, shells, and
+// jobs without a child session. Caller holds jm.mu.
+func (jm *jobManager) targetChildSessionIDLocked(target string) string {
+	if isWatchSessionTarget(target) {
+		return ""
+	}
+	run := jm.running[target]
+	if run == nil || run.rec == nil || run.rec.DelegateRestore == nil {
+		return ""
+	}
+	return run.rec.DelegateRestore.ChildSessionID
 }
 
 // feedJobOutput level-triggers output_match watches on a freshly produced

--- a/agent/job_watch_events_test.go
+++ b/agent/job_watch_events_test.go
@@ -214,15 +214,18 @@ func TestConcreteJobEventWatchSendsFrame(t *testing.T) {
 	seedCommonWatchSendTargets(t, jm)
 
 	rec, _ := jm.createShell(createShellOpts{Command: "x"})
+	// job.notification is the one event kind a concrete-job target can scope
+	// (lifecycle payloads name their job); tool events are scoped by the
+	// watched job's child session and never fire from watcher-origin events.
 	_, err := jm.configureWatch(watchArgs{
 		Target: rec.JobID,
-		Events: []string{"assistant.tool"},
+		Events: []string{"job.notification"},
 		Send:   &watchSendArgs{To: "dlg_obs", Message: "observe"},
 	})
 	if err != nil {
 		t.Fatalf("configure: %v", err)
 	}
-	onSessionEventKD(jm, events.EventToolCallEnd, nil)
+	onSessionEventKD(jm, events.EventJobFinished, events.JobFinishedData{JobID: rec.JobID})
 
 	// Observation records the send as pending (frame snapshot included); delivery
 	// is the loop-owned drain's job.
@@ -242,7 +245,7 @@ func TestConcreteJobEventWatchSendsFrame(t *testing.T) {
 	}
 	if !strings.Contains(state.Frame, "observe") ||
 		!strings.Contains(state.Frame, rec.JobID) ||
-		!strings.Contains(state.Frame, "event: TOOL_CALL_END") {
+		!strings.Contains(state.Frame, "event: JOB_FINISHED") {
 		t.Fatalf("pending frame = %q, want configured message, job id, and trigger", state.Frame)
 	}
 }

--- a/agent/job_watch_scope_test.go
+++ b/agent/job_watch_scope_test.go
@@ -1,0 +1,229 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"primeradiant.com/serf/agent/events"
+	"primeradiant.com/serf/agent/provenance"
+)
+
+// These tests pin the scoping rule for concrete-job-targeted session-event
+// watches and the inform+breaker policy on watcher-notification deliveries.
+// Non-lifecycle event payloads carry no job identity, and the only
+// session whose events reach a jobManager's evaluator today is the watcher's
+// own — so before identity scoping, a job-targeted event watch could only echo
+// the watcher's own tool calls back at it labeled as job activity, and the
+// no-send notification path delivered those echoes without self-influence
+// classification.
+
+// A job-targeted watch must not match the watcher's own tool events: the
+// envelope's originating session is the watcher, not the watched job.
+func TestJobTargetWatchDoesNotMatchWatcherOwnToolEvents(t *testing.T) {
+	snap := watchEventSnapshot{
+		target:          "job_watched",
+		targetActive:    true,
+		targetSessionID: "sess_child",
+		eventKinds:      map[events.EventKind]bool{events.EventToolCallEnd: true},
+		eventFilter:     &watchEventFilter{ToolName: "communicate", Status: "ok"},
+		watchID:         "watch_scope_1",
+		generation:      "g1",
+	}
+	ev := events.SessionEvent{
+		Kind:      events.EventToolCallEnd,
+		SessionID: "sess_watcher",
+		Data:      events.ToolCallEndData{ToolName: "communicate"},
+	}
+	if dec := evaluateWatchEvent(snap, ev); dec.matched {
+		t.Fatalf("job-targeted watch matched a watcher-origin communicate TOOL_CALL_END: %+v", dec)
+	}
+	// An event that cannot prove its origin does not fire either.
+	ev.SessionID = ""
+	if dec := evaluateWatchEvent(snap, ev); dec.matched {
+		t.Fatalf("job-targeted watch matched an identity-less tool event: %+v", dec)
+	}
+}
+
+// The spec's promised semantics: an event originating from the watched job's
+// child session matches its job-targeted watch.
+func TestJobTargetWatchMatchesWatchedJobSessionEvents(t *testing.T) {
+	snap := watchEventSnapshot{
+		target:          "job_watched",
+		targetActive:    true,
+		targetSessionID: "sess_child",
+		eventKinds:      map[events.EventKind]bool{events.EventToolCallEnd: true},
+		eventFilter:     &watchEventFilter{ToolName: "communicate", Status: "ok"},
+		watchID:         "watch_scope_2",
+		generation:      "g1",
+	}
+	ev := events.SessionEvent{
+		Kind:      events.EventToolCallEnd,
+		SessionID: "sess_child",
+		Data:      events.ToolCallEndData{ToolName: "communicate"},
+	}
+	if dec := evaluateWatchEvent(snap, ev); !dec.matched {
+		t.Fatalf("job-targeted watch must match the watched job's own session events: %+v", dec)
+	}
+}
+
+// Job lifecycle events carry a JobID and stay matchable on a job target
+// regardless of envelope identity.
+func TestJobTargetWatchStillMatchesJobLifecycle(t *testing.T) {
+	snap := watchEventSnapshot{
+		target:       "job_watched",
+		targetActive: true,
+		eventKinds:   map[events.EventKind]bool{events.EventJobFinished: true},
+		watchID:      "watch_scope_3",
+		generation:   "g1",
+	}
+	ev := events.SessionEvent{
+		Kind:      events.EventJobFinished,
+		SessionID: "sess_watcher",
+		Data:      events.JobFinishedData{JobID: "job_watched"},
+	}
+	if dec := evaluateWatchEvent(snap, ev); !dec.matched {
+		t.Fatalf("job-targeted watch must still match its own job's lifecycle event: %+v", dec)
+	}
+}
+
+// Session-target watches (self/parent observers) keep tool-event semantics:
+// firing on the session's own events is their intended meaning.
+func TestSessionTargetWatchStillMatchesToolEvents(t *testing.T) {
+	snap := watchEventSnapshot{
+		target:       runtimeMessageAliasCaller,
+		targetActive: true,
+		eventKinds:   map[events.EventKind]bool{events.EventToolCallEnd: true},
+		eventFilter:  &watchEventFilter{ToolName: "read_file", Status: "ok"},
+		watchID:      "watch_scope_4",
+		generation:   "g1",
+	}
+	ev := events.SessionEvent{
+		Kind:      events.EventToolCallEnd,
+		SessionID: "sess_watcher",
+		Data:      events.ToolCallEndData{ToolName: "read_file"},
+	}
+	if dec := evaluateWatchEvent(snap, ev); !dec.matched {
+		t.Fatalf("session-target watch must keep matching its own tool events: %+v", dec)
+	}
+}
+
+// Install stays permissive (loop-guard posture): event watches on concrete job
+// targets are accepted; identity scoping happens at match time, not create time.
+func TestJobTargetEventWatchStillInstallsAtCreate(t *testing.T) {
+	err := validateWatchEventArgs(watchArgs{
+		Target:      "job_watched",
+		Events:      []string{"assistant.tool"},
+		EventFilter: &watchEventFilter{ToolName: "communicate", Status: "ok"},
+	})
+	if err != nil {
+		t.Fatalf("expected install-permissive accept, got: %v", err)
+	}
+}
+
+// A self-influenced watcher-notification frame carries the disengage notice —
+// the same inform+breaker policy the send path applies. Without classification
+// on the no-send path, the only shape job_watch's public arguments can express
+// delivered unclassified echoes.
+func TestNotificationPathCarriesSelfInfluenceNotice(t *testing.T) {
+	jm := newTestJM(t)
+	var got []jobNotification
+	jm.enqueue = func(n jobNotification) { got = append(got, n) }
+
+	installWatchBelowValidation(t, jm, watchArgs{
+		Target: runtimeMessageAliasCaller,
+		Events: []string{"assistant.tool"},
+	})
+	watchID, generation := singleWatchIdentity(t, jm)
+
+	jm.onSessionEvent(events.SessionEvent{
+		Kind:       events.EventToolCallEnd,
+		SessionID:  jm.sessionID,
+		Data:       events.ToolCallEndData{ToolName: "read_file"},
+		Provenance: provenance.WithWatch(nil, watchID, generation, "wd_prior", jm.sessionID, ""),
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("want one watcher notification, got %d", len(got))
+	}
+	if got[0].Notice == "" {
+		t.Fatal("self-influenced notification frame must carry the disengage notice")
+	}
+	if !strings.Contains(formatJobNotificationBlock(got[0], notificationExcerpt{}), got[0].Notice) {
+		t.Fatal("rendered notification block must include the notice")
+	}
+	// A frame with no self-influence carries no notice.
+	got = nil
+	jm.onSessionEvent(events.SessionEvent{
+		Kind:      events.EventToolCallEnd,
+		SessionID: jm.sessionID,
+		Data:      events.ToolCallEndData{ToolName: "read_file"},
+	})
+	if len(got) != 1 {
+		t.Fatalf("want one watcher notification, got %d", len(got))
+	}
+	if got[0].Notice != "" {
+		t.Fatalf("un-influenced frame must carry no notice, got %q", got[0].Notice)
+	}
+}
+
+// Once the delivered-prior chain of a watch is runaway-deep, the notification
+// path drops the delivery and auto-clears the watch — mirroring the send
+// path's fuse in recordWatchSend.
+func TestNotificationPathRunawayFuseClearsWatch(t *testing.T) {
+	jm := newTestJM(t)
+	var got []jobNotification
+	jm.enqueue = func(n jobNotification) { got = append(got, n) }
+
+	installWatchBelowValidation(t, jm, watchArgs{
+		Target: runtimeMessageAliasCaller,
+		Events: []string{"assistant.tool"},
+	})
+	watchID, generation := singleWatchIdentity(t, jm)
+
+	var chain *provenance.Causal
+	jm.mu.Lock()
+	for i := 0; i < runawaySelfInfluenceDepth; i++ {
+		deliveryID := "wd_runaway_" + strings.Repeat("x", i+1)
+		chain = provenance.WithWatch(chain, watchID, generation, deliveryID, jm.sessionID, "")
+		jm.deliveredWatchSendIDs[deliveryID] = struct{}{}
+	}
+	jm.mu.Unlock()
+
+	jm.onSessionEvent(events.SessionEvent{
+		Kind:       events.EventToolCallEnd,
+		SessionID:  jm.sessionID,
+		Data:       events.ToolCallEndData{ToolName: "read_file"},
+		Provenance: chain,
+	})
+
+	var clearNotice bool
+	for _, n := range got {
+		if strings.HasPrefix(n.Reason, "event: ") {
+			t.Fatalf("runaway-deep echo must not deliver a watch frame: %+v", n)
+		}
+		if strings.Contains(n.Reason, "runaway self-influence") {
+			clearNotice = true
+		}
+	}
+	if !clearNotice {
+		t.Fatal("runaway clear must tell the model why the watch ended")
+	}
+	if jm.watchCount() != 0 {
+		t.Fatalf("runaway watch must auto-clear; watchCount = %d", jm.watchCount())
+	}
+}
+
+// singleWatchIdentity returns the (watchID, generation) of the jobManager's
+// only installed watch.
+func singleWatchIdentity(t *testing.T, jm *jobManager) (string, string) {
+	t.Helper()
+	jm.mu.Lock()
+	defer jm.mu.Unlock()
+	if len(jm.watches) != 1 {
+		t.Fatalf("want exactly one watch installed, got %d", len(jm.watches))
+	}
+	for _, cfg := range jm.watches {
+		return cfg.watchID, cfg.generation
+	}
+	return "", ""
+}

--- a/agent/jobs.go
+++ b/agent/jobs.go
@@ -328,6 +328,10 @@ type jobNotification struct {
 	// against the owning jobManager's CURRENT pending state at accept time
 	// (spec §4.3). The frame text is deliberately NOT carried here.
 	WatchSend *watchSendToken
+	// Notice is the inform+breaker's model-facing self-influence line for a
+	// watcher-notification frame (the send path carries its notice on the
+	// rendered frame instead). Advisory and in-memory only.
+	Notice string
 	// receiverSessionID/receiverNotify route no-send watch notifications for
 	// concrete descendant watches back to the ancestor session that installed
 	// them. They are in-memory only; active watches are not restored without a

--- a/agent/watch_seqfuzz_test.go
+++ b/agent/watch_seqfuzz_test.go
@@ -375,7 +375,7 @@ func (h *ws_harness) applyEmit(op ws_op) ws_opOutcome {
 	predicted := 0
 	h.jm.mu.Lock()
 	for _, cfg := range h.jm.watches {
-		dec := evaluateWatchEvent(cfg.eventSnapshot(isActiveWatchTargetLocked(h.jm, cfg.target)), ev)
+		dec := evaluateWatchEvent(cfg.eventSnapshot(isActiveWatchTargetLocked(h.jm, cfg.target), h.jm.targetChildSessionIDLocked(cfg.target)), ev)
 		if dec.matched && !dec.send {
 			predicted++
 		}


### PR DESCRIPTION
## Problem

A concrete-job-targeted `job_watch` on session-event kinds (`events:["communicate"]`, `events:["assistant.tool"]`+`event_filter`) can never observe the watched job — those payloads carry no job identity, `watchEventMatchesTarget` defaulted open for them, and the only events reaching a jobManager's evaluator are its own session's. The watch instead fires on the **watcher's own** tool calls, delivered back as `<job-notification event="watch">` frames labeled with the watched job's id.

On an orchestrator driving delegate subagents this is a self-sustaining coordination loop: contentless frame → investigate (`read_session_transcript`) + report (`communicate`) → the communicate fires the next frame. Forensics from three runs of the same 14-task plan (identical binary, model, provider):

| run | style | frames (all echoes of own communicate) | cost vs healthy |
|---|---|---|---|
| production run A | `events:["communicate"]` ×33 + 29 clear/recreate cycles | 149/149 | ~6× |
| production run B | `events:["communicate"]` ×34 | 134/134 | ~3.4× |
| local repro | `events:["assistant.tool"]`+filter | 248/248 | ~3.6× |

Whether a run spirals is a coin flip on the model's per-run choice of coordination style; `output_match` watches and plain completion notifications stay healthy.

The inform+breaker policy couldn't catch it: self-influence classification and the runaway fuse run only on the watch-**send** path, but `send` is not a public `job_watch` argument — the model's watches ride the no-send notification path, which delivered unclassified echoes (the disengage nudge fired once in 248 frames). Run A's 29 clear/recreate cycles also reset the per-watch fuse each time.

## Fix (three parts, each enforcing an existing promise)

1. **Identity-scope the target gate** (`watchEventMatchesTarget`): non-lifecycle events match a concrete-job target only when the envelope's `SessionID` equals the watched job's child session (`DelegateRestore.ChildSessionID`). Implements job-control.md's "a concrete job's output/progress/events"; watcher-origin and identity-less events no longer fire job-targeted watches. Install stays permissive — no create-time rejection, loop-guard posture unchanged.
2. **Inform+breaker on the notification path**: self-influenced frames now carry the disengage notice (`jobNotification.Notice`), and a runaway-deep chain clears the watch with an honest reason (`watchRunawayClearedMessage`). Deliberate divergence from the send path's drop-per-delivery: a clear guarantees the loop terminates — flagging for review.
3. **`DefJobWatch` guidance**: the spec's "Do not use job_watch to learn when a job completes" (job-control.md:42) now reaches the model in the tool description.

## Validation

- `go build ./...`, `go vet ./agent/`, `go test ./agent/... ./server/... ./cmd/...`: 65 packages ok. (`agent/execenv` sandbox tests fail identically on pristine `main` on darwin — pre-existing, unrelated.)
- Only two existing tests updated, both pinning the default-open behavior this fixes; zero loop-guard/design-policy tests changed. New coverage in `agent/job_watch_scope_test.go` (echo gate both directions, scoped-match semantics, lifecycle + session-target regression guards, install-permissive, notice, runaway clear).
- Live A/B (same plan/model/provider, prompt forced into the echoing styles): old binary 17/17 echo frames → this branch **0 frames**, ~2.1× cheaper, identical commits produced. The `events:["communicate"]` variant: 5 watches created+acked, 0 frames, tasks complete via completion notifications.
- Full 14-task run, unmodified config: cost landed in the healthy cluster, 14/14 tasks, output tree byte-identical to a healthy baseline run — healthy path unchanged.

## Known caveats for review

- Runaway-fuse depth for notification-only chains counts delivered-send IDs, so pure-notification chains may undercount depth (the `self` notice still fires; the identity gate already kills the job-target echo class).
- The create ack still reads "[watching job_X · events: …]" for a trigger that cannot fire until child-session events are forwarded to the parent evaluator — ack honesty and/or actual event forwarding left as follow-up design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)