### PR TITLE
tool: guide purpose fields toward gerund-form activity phrases

### DIFF
--- a/.superpowers/sdd/iter4-fix-report.md
+++ b/.superpowers/sdd/iter4-fix-report.md
@@ -1,0 +1,148 @@
+# Iteration-4 fix report — renderer pipeline (branch webui-joy)
+
+Scope: F1–F5 in `cmd/serf-hub/assets/{renderer.js,renderer-tools.js,style.css}` +
+`cmd/serf-hub/jstest/`. Red-first: every behavioral fix has a failing test
+captured before the change.
+
+## F1 (Important) — stale overlapping readThread completion wedges hydration
+
+**Red evidence** — new `cmd/serf-hub/jstest/test-renderer-hydration-stale-overlap.js`,
+two overlapping readThread deferrals (H1 superseded by a reconnect's H2; H2
+resolved fully, then stale H1 resolved / H3 rejected after H4):
+
+```
+FAIL: stale H1 completion did not wedge hydrationInProgress ...
+FAIL: stale H1 completion did not clear appwireHydrated
+FAIL: stale H1 did not reset/re-render the transcript (got 150 messages)
+FAIL: transcript is still exactly H2's events
+FAIL: stale H3 rejection did NOT clear the new stream (clearAppwireStream would kill live delivery)
+FAIL: stale H3 rejection raised no connection banner over a healthy stream
+```
+
+Root cause confirmed by the red run: the stale H1 passed the
+session/conversation entry check (`renderer.js` old line 845), reset H2's
+transcript, replayed 150 events (one chunk), then aborted on the *later*
+`this.liveStream !== appwireStream` check (old line 899) — leaving
+`hydrationInProgress` stuck true.
+
+**Change** (`renderer.js`, `connectAppwire`):
+- Top of the readThread `.then` (before ANY state/DOM mutation):
+  `if (this.liveStream !== appwireStream) return;` — mirrors the existing
+  mid-chunk/post-paging check, using the same stream token captured at
+  connect time (`const appwireStream = this.liveStream;`).
+- Top of the `.catch`: same guard, so a stale rejection can no longer
+  `clearAppwireStream()` the healthy new stream or raise a false
+  "Connection lost" banner + reconnect loop.
+
+**Green evidence**: `PASS: stale overlapping readThread completion/rejection
+is guarded before any state mutation` (transcript stays H2's 3 events;
+`hydrationInProgress === false`; `appwireHydrated === true`; stale rejection
+leaves stream/hydration/banner untouched).
+
+## F2 (Important) — hydration's final scrollToBottom yanks a mid-replay reader
+
+**Red evidence** — new `cmd/serf-hub/jstest/test-renderer-hydration-scroll-intent.js`
+(jsdom, `scrollHeight` stubbed to 5000, scroll event dispatched by hand
+mid-replay):
+
+```
+FAIL: reader scrolled mid-replay — final settle did NOT yank to bottom (scrollTop=5000, want 1200)
+```
+
+**Change** (`renderer.js`):
+- Init: `this.readerScrolledDuringHydration = false; this.programmaticScroll = false;`
+- Scroll listener (`bindScrollAffordance`): sets
+  `readerScrolledDuringHydration = true` when a scroll event fires while
+  `this.hydrationInProgress && !this.programmaticScroll`; the affordance tick
+  is untouched.
+- `scrollToBottom()` wraps the `scrollTop` write in a
+  `programmaticScroll` try/finally marker so programmatic scrolls can never be
+  read as reader intent.
+- Hydration start: flag cleared alongside `hydrationInProgress = true`;
+  also cleared in `resetTranscriptReplay()`.
+- Hydration-end settle:
+  `if (!this.readerScrolledDuringHydration) this.scrollToBottom(); this.readerScrolledDuringHydration = false;`
+  Programmatic paging scrolls can't fire mid-hydration anyway
+  (`maybeLoadOlderTurns` is guarded), so only genuine reader scrolls set intent.
+
+**Green evidence**: `PASS: hydration-end settle honors reader scroll intent
+(no yank; sticks when untouched)` — case (a) no scroll → settle parks at
+bottom (scrollTop 5000); case (b) mid-replay scroll to 1200 → stays 1200;
+case (c) later hydration with no scroll → sticks at bottom again (flag reset).
+
+## F3 (Important) — >8KB tail-fold silently drops bytes behind a bare "…\n"
+
+**Red evidence** — `test-tool-streaming-output.js` updated first:
+
+```
+FAIL: bodyEnd prefixes an HONEST not-retained note (not a bare ellipsis masquerading as ordinary output)
+FAIL: the bare … prefix is gone — elision is stated, not implied
+FAIL: expandable content begins with the honest not-retained note
+FAIL: read bodyEnd prefixes the honest not-retained note
+```
+
+**Change** (`renderer-tools.js`, `tailFoldOutput`): the `"…\n"` prefix is
+replaced with the drop-note idiom's honest statement, rendered as a text line
+(the string lands in a `<pre>`):
+`earlier output not retained — showing the last 8,000 chars\n` + the same
+surrogate-safe `tailSlice(text, max)`. Fold behavior otherwise unchanged.
+`test-renderer-surrogate-tail.js` was updated to the new prefix (it asserted
+the old `"…\n"`), slicing past the note line via its length.
+
+**Green evidence**: both files pass; the multi-line >8KB case still ends with
+`line-0899`, oldest lines still elided, fold chrome still builds past 5 lines.
+
+## F4 (Minor) — streaming caret never animates
+
+**Red evidence** — stylesheet-text assertion in `test-renderer-streaming-tail.js`:
+
+```
+FAIL: caret breathes via the think-breathe keyframe on --pulse-cycle (got: color: var(--accent);)
+```
+
+**Change** (`style.css`): `.assistant-message .streaming-tail .streaming-caret`
+gains `animation: think-breathe var(--pulse-cycle) infinite;` — the same
+sanctioned keyframe/token as `.think.streaming .think-glyph`. Coverage under
+`prefers-reduced-motion` comes from the existing universal collapse
+(§1.5: `animation-duration: 1ms !important; animation-iteration-count: 1`),
+which the test asserts is present.
+
+**Green evidence**: caret-rule + reduced-motion assertions pass.
+
+## F5 (Minor) — missing parse-failure fallback test
+
+The fallback already existed (`renderAssistantMessage`: `try { innerHTML =
+marked.parse(text) } catch { el.textContent = text }`); coverage was missing.
+Added to `test-renderer-streaming-tail.js`: `marked.parse` throws at
+finalization → `ASSISTANT_TEXT_END` does not throw, the message stays as plain
+text (`textContent === "plain fallback text"`, zero element children). Passed
+immediately (pure coverage test, no source change needed).
+
+## Gate outputs
+
+- `cd cmd/serf-hub/jstest && ./run-all.sh` → **178/178 OK**, `jstest: all tests passed`, rc=0
+  (includes the two new test files; captured in /tmp/iter4-jstest.log during the run).
+- `make build-hub` → success (build-runtime-pair.sh).
+- `GOCACHE=/tmp/serf-go-build-cache go test ./cmd/serf-hub` → `ok primeradiant.com/serf/cmd/serf-hub 21.099s`.
+
+## Files changed
+
+- `cmd/serf-hub/assets/renderer.js` (F1 guards, F2 intent tracking/settle/marker)
+- `cmd/serf-hub/assets/renderer-tools.js` (F3 honest tail-fold note)
+- `cmd/serf-hub/assets/style.css` (F4 caret breathe)
+- `cmd/serf-hub/jstest/test-renderer-hydration-stale-overlap.js` (new, F1)
+- `cmd/serf-hub/jstest/test-renderer-hydration-scroll-intent.js` (new, F2)
+- `cmd/serf-hub/jstest/test-tool-streaming-output.js` (F3 assertions)
+- `cmd/serf-hub/jstest/test-renderer-surrogate-tail.js` (F3 prefix update)
+- `cmd/serf-hub/jstest/test-renderer-streaming-tail.js` (F4 + F5 assertions)
+
+## Concerns
+
+- The `programmaticScroll` marker is synchronous; browser scroll events fire
+  async, so it guards intent only because the hydration-end `scrollToBottom`
+  runs after `hydrationInProgress` is cleared and all mid-hydration programmatic
+  scrolls are suppressed (`suppressScrollSettle`) or guarded
+  (`maybeLoadOlderTurns`). If a future change introduces an unguarded
+  programmatic scroll inside the replay window, it must use the marker.
+- `tailFoldOutput`'s note formats the budget with `toLocaleString("en-US")`
+  (deterministic under Node ≥13 full-ICU and browsers).

--- a/.superpowers/sdd/iter4-fix-report.md
+++ b/.superpowers/sdd/iter4-fix-report.md
@@ -146,3 +146,78 @@ immediately (pure coverage test, no source change needed).
   programmatic scroll inside the replay window, it must use the marker.
 - `tailFoldOutput`'s note formats the budget with `toLocaleString("en-US")`
   (deterministic under Node ≥13 full-ICU and browsers).
+
+---
+
+## N1 fix: depth-counted programmatic scrolls (2026-07-19)
+
+**Finding.** `prependOlderTurns`' scrollTop writes (the sync compensation and
+the rAF two-phase drift correction) fire their scroll events ASYNC. During
+multi-page `loadOlderTurnsUntilPrimaryDialogue` (which runs mid-hydration),
+those events landed after the synchronous `programmaticScroll` marker had
+cleared and falsely set `readerScrolledDuringHydration`, wrongly suppressing
+the hydration-end `scrollToBottom`.
+
+**Fix.** Replaced the boolean marker with a depth counter
+`programmaticScrollDepth` (init 0):
+
+- The scroll listener sets `readerScrolledDuringHydration` only when
+  `hydrationInProgress && programmaticScrollDepth === 0`.
+- `prependOlderTurns` increments the depth (+ a `prependSettleHolds` count)
+  before its scroll writes; the surviving keyed `prepend-settle` frame
+  callback releases all outstanding holds via a one-task-deferred decrement
+  (so the rAF correction's own async scroll event also lands while depth > 0;
+  per HTML rendering steps the scroll event for a write made inside a rAF
+  callback dispatches in the same frame AFTER rAF callbacks, so a synchronous
+  decrement inside the callback would have been too early). A later prepend
+  re-scheduling the keyed frame cancels the previous settle — its hold is
+  subsumed by the surviving settle, so the counter cannot get stuck; the
+  catch path releases the prepend's own hold if anything throws before the
+  settle is scheduled.
+- `scrollToBottom` wraps the same way: increment, decrement on the next task
+  (`setTimeout(0)`), since its scroll event is also async.
+- Real reader scrolls (depth 0) set the flag exactly as before.
+
+**Red evidence** (test extended, renderer unmodified):
+
+```
+FAIL: converse: the reader scroll was dispatched at programmatic depth 0 (got undefined)
+FAIL: N1: prepend scroll writes did not read as reader intent — final settle scrolls to bottom (scrollTop=0, want 5000)
+FAIL: N1: programmatic scroll depth returned to 0 after the settles (got undefined)
+exit=1
+```
+
+**Green evidence** (after the fix):
+
+```
+PASS: hydration-end settle honors reader scroll intent (no yank; sticks when untouched)
+exit=0
+```
+
+**Gate outputs:**
+
+- `cmd/serf-hub/jstest/run-all.sh` → `jstest: all tests passed` (exit 0)
+- `make build-hub` → exit 0
+- `GOCACHE=/tmp/serf-go-build-cache go test ./cmd/serf-hub` →
+  `ok  primeradiant.com/serf/cmd/serf-hub  20.892s`
+
+**Files:**
+
+- `cmd/serf-hub/assets/renderer.js` (depth counter in init, scroll listener,
+  `scrollToBottom`, `prependOlderTurns`; marker comments updated)
+- `cmd/serf-hub/jstest/test-renderer-hydration-scroll-intent.js` (scenario (d):
+  multi-page hydration with two mid-hydration prepends whose async scroll
+  events fire while `hydrationInProgress` — flag stays false, settle parks at
+  the bottom, depth returns to 0; scenario (b) strengthened: a real reader
+  scroll at depth 0 still sets the flag and suppresses the settle)
+
+**Concerns:**
+
+- The settle release is deferred one task past the rAF correction to cover the
+  correction's async scroll event; in the worst case a reader's own scroll
+  landing inside that one-task window is also treated as programmatic. That
+  window is a macrotask (~0ms) once per prepend settle — vanishingly small,
+  and the consequence is only a missed intent flag during hydration.
+- jsdom fires no scroll events of its own (no layout), so the test simulates
+  the browser's async dispatch with a `setTimeout(0)` after each prepend —
+  mirroring real event-loop ordering, verified by the RED run.

--- a/.superpowers/sdd/iter5-fix-report.md
+++ b/.superpowers/sdd/iter5-fix-report.md
@@ -1,0 +1,97 @@
+# Iteration-5 fix report
+
+Branch `webui-joy`, worktree `webui-joy`. Scope: `cmd/serf-hub/assets/renderer.js` + `cmd/serf-hub/jstest/`. Red-first: every test below was run against the pre-fix renderer (via `git stash push -- cmd/serf-hub/assets/renderer.js`) and failed; all pass after the fix.
+
+## F1 (Important): stale hydration's `finally` clobbers the successor's scroll-settle suppression
+
+**Trace (confirmed in code).** `connectAppwire`'s `readThread().then(async …)` runs a chunked replay (`HYDRATION_CHUNK = 150`, `await setTimeout(0)` between slices). H1 suspends at its first yield; a reconnect starts H2, which sets `hydrationInProgress`/`suppressScrollSettle` and suspends mid-replay itself. H1 resumes, fails the `this.liveStream !== appwireStream` staleness check (~line 915 pre-fix) and `return`s — but its unconditional outer `finally` still ran `this.suppressScrollSettle = false` while H2 owned the stream, stripping H2's O(N²)-avoidance suppression mid-replay and re-enabling replay-time scroll/pill side effects.
+
+**Audit of sibling flags in the same block.** `hydrationInProgress = false` (line ~943) and `replayingBufferedNotifications = false` (inner finally, ~941) sit after the last staleness check with no intervening `await`, so a stale H1 cannot reach them today — but they are the same shared-flag pattern and were hardened with the same ownership guard. The `.catch` path already guards (`if (this.liveStream !== appwireStream) return;`). Converse hygiene: since a stale finally no longer clears `suppressScrollSettle`, `init()` now resets it (it already reset `hydrationInProgress`) so the flag can never leak into a session whose hydration never ran (a non-appwire view would otherwise suppress stick-to-bottom and the new-content pill forever).
+
+**Red evidence** (`jstest/test-renderer-hydration-stale-overlap.js`, new section (c); H1 = 300 events, H2 = 600 events, H2 started at H1's first yield; `suppressScrollSettle` instrumented with an accessor to catch any true→false transition landing while H2 owns the replay):
+
+```
+FAIL: (c) H1's stale finally did NOT clear suppressScrollSettle under H2's mid-replay ownership
+```
+
+**Change** (`assets/renderer.js`, hydration completion block): all three flag clears are now ownership-guarded —
+
+```js
+} finally {
+  if (this.liveStream === appwireStream) this.replayingBufferedNotifications = false;
+}
+if (this.liveStream === appwireStream) this.hydrationInProgress = false;
+} finally {
+  // Stale-overlap guard: a superseded hydration that returned at one of the
+  // staleness aborts above still runs THIS finally … Only the stream owner
+  // clears the flag; the successor clears it in its own finally.
+  if (this.liveStream === appwireStream) this.suppressScrollSettle = false;
+}
+```
+
+plus `this.suppressScrollSettle = false;` in `init()` next to the existing `hydrationInProgress` reset.
+
+**Green evidence:** full file passes — `PASS: stale overlapping readThread completion/rejection is guarded before any state mutation` (sections (a) stale-.then, (b) stale-.catch, (c) mid-replay clobber; section (c) also asserts H2 completes with both flags cleared and the transcript holding exactly H2's 600 events).
+
+## F2 (Minor): `init()` zeros the prepend-settle counters but doesn't cancel the keyed frame callbacks
+
+**Trace.** `init()` zeroed `programmaticScrollDepth`/`prependSettleHolds` but left session A's keyed `"prepend-settle"`/`"prepend-settle-release"` frame callbacks scheduled. A stale release firing into session B drains B's hold accumulator (`programmaticScrollDepth = Math.max(0, depth - holds)`), so B's correction-window scroll event lands with depth 0 and reads as reader intent (`readerScrolledDuringHydration`).
+
+**Red evidence** (`jstest/test-renderer-prepend-settle-release.js`, new section (e); keyed-cancellation mirrored into the test's `scheduleFrame` stub; session B is a fresh conversation element because `init()` is idempotent per element):
+
+```
+FAIL: (e) init also cancelled session A's keyed prepend-settle frames
+FAIL: (e) the stale session-A release callback is inert after init
+FAIL: (e) firing the stale callback left B's holds untouched (holds=0)
+FAIL: (e) firing the stale callback left B's depth untouched (depth=0)
+```
+
+**Change** (`assets/renderer.js`, `init()`): alongside the zeroing —
+
+```js
+this.cancelFrame("prepend-settle");
+this.cancelFrame("prepend-settle-release");
+```
+
+**Green evidence:** `PASS: prepend-settle depth release is frame-chained (ordering, hold window, accumulator drain)` — sections (a)–(d) unchanged and passing; (e) asserts init zeroes the counters, cancels both keyed frames, the stale callback is inert, B's holds/depth stay at 1, and B's own settle/release drains normally.
+
+## F3 (Minor): transient "↓ 0 new" pill visible for ~300ms
+
+**Trace.** `renderNewContentPill`'s plain-count branch paints the *debounced* `newContentPaintedCount`, which is 0 on the hidden→visible first paint while `newContentCount` is already positive; the trailing 300ms debounce in `scheduleNewContentCountPaint` then commits the real count. Net effect: the pill badges "↓ 0 new" for the entire first debounce window — exactly what the browser probe caught. (`noteNewContent(0)` is not reachable: its only call site guards `added > 0`.)
+
+**Red evidence** (`jstest/test-renderer-new-content-pill.js`, new "never renders a zero count" section):
+
+```
+FAIL: first paint never reads '↓ 0 new' (got ↓ 0 new)
+FAIL: first paint shows a positive count (got ↓ 0 new)
+```
+
+**Change** (`assets/renderer.js`):
+
+1. `renderNewContentPill`: capture `wasHidden` before un-hiding; on the hidden→visible transition seed `newContentPaintedCount = newContentCount`. Repaints while already visible keep the debounced value, so the existing anti-jitter guarantee ("count does not repaint to the final total mid-burst") is preserved.
+2. `scheduleNewContentCountPaint`: the trailing commit bails to `clearNewContentPill()` when `newContentCount <= 0`, so no path can ever paint 0.
+
+**Green evidence:** `PASS: new-content pill counts, clears, and goes attention-aware` — all pre-existing sections (including the mid-burst anti-jitter assertions) plus the new zero-count section pass: first paint shows a positive count immediately, trailing commit never shows 0.
+
+## Gate
+
+```
+$ cd cmd/serf-hub/jstest && ./run-all.sh
+OK      test-abbreviate-model.js
+…
+OK      test-transcript-windowing.js
+OK      test-turn-meta-badge.js
+jstest: all tests passed          # 179 OK, 0 FAIL/TIMEOUT/MISSING
+
+$ make build-hub
+LDFLAGS="…" scripts/build-runtime-pair.sh   # exit 0
+
+$ GOCACHE=/tmp/serf-go-build-cache go test ./cmd/serf-hub
+ok  	primeradiant.com/serf/cmd/serf-hub	21.027s
+```
+
+Note: two in-harness background invocations of `run-all.sh` were reaped mid-suite
+(the suite runs ~7 minutes; the job wrapper did not survive). The final gate run
+was executed detached (`nohup ./run-all.sh`) and completed end-to-end with
+"jstest: all tests passed"; the mid-run prefix (169 tests) and a manual run of
+the remaining 10 test files had also already passed independently.

--- a/agent/internal/tool/registry.go
+++ b/agent/internal/tool/registry.go
@@ -21,7 +21,7 @@ import (
 	"primeradiant.com/serf/llm"
 )
 
-const toolPurposeDescription = "Briefly explain why you are calling this tool and what you expect to learn or accomplish."
+const toolPurposeDescription = "A short verb-first gerund phrase naming what this call is doing, e.g. \"Reading the config file\" or \"Searching for the handler\". Keep it to a few words so it renders nicely as an inline activity label."
 
 func WithPurposeParameter(td llm.ToolDefinition) llm.ToolDefinition {
 	params := CloneSchemaMap(td.Parameters)

--- a/agent/internal/tool/registry_test.go
+++ b/agent/internal/tool/registry_test.go
@@ -16,6 +16,34 @@ import (
 	"primeradiant.com/serf/llm"
 )
 
+func TestWithPurposeParameter_DescriptionGuidesGerundForm(t *testing.T) {
+	td := WithPurposeParameter(llm.ToolDefinition{Name: "demo"})
+	props, _ := td.Parameters["properties"].(map[string]any)
+	if props == nil {
+		t.Fatalf("purpose injection produced no properties: %#v", td.Parameters)
+	}
+	purpose, _ := props["purpose"].(map[string]any)
+	if purpose == nil {
+		t.Fatalf("purpose property missing: %#v", props)
+	}
+	desc, _ := purpose["description"].(string)
+	if desc == "" {
+		t.Fatalf("purpose property has no description: %#v", purpose)
+	}
+	// The purpose string renders as an inline activity label in the UI, so the
+	// description must steer the model toward a verb-first gerund phrase with
+	// a concrete example rather than imperative or verbose prose.
+	if !strings.Contains(desc, "gerund") {
+		t.Errorf("description lacks gerund-form guidance: %q", desc)
+	}
+	if !strings.Contains(desc, "Reading the config file") {
+		t.Errorf("description lacks a concrete gerund example: %q", desc)
+	}
+	if utf8.RuneCountInString(desc) > 240 {
+		t.Errorf("description should stay concise, got %d runes: %q", utf8.RuneCountInString(desc), desc)
+	}
+}
+
 func TestToolRegistry_ToolStateResult_CarriesStateAsSideChannel(t *testing.T) {
 	r := NewRegistry()
 	if err := r.Register(RegisteredTool{

--- a/cmd/serf-hub/assets/renderer-format.js
+++ b/cmd/serf-hub/assets/renderer-format.js
@@ -621,6 +621,20 @@
     return s.length > n ? s.slice(0, n) + "…" : s;
   }
 
+  // tailSlice returns the last max code units of text, adjusted so the slice
+  // never BEGINS on a low surrogate (0xDC00–0xDFFF): starting mid-pair renders
+  // U+FFFD as the first visible char of the tail. The orphaned unit is dropped
+  // (the tail is one code unit shorter), keeping the pair's high half with the
+  // elided head. Shared by every 8KB live/final tail slice in renderer-tools.
+  function tailSlice(text, max) {
+    text = String(text || "");
+    if (text.length <= max) return text;
+    let start = text.length - max;
+    const code = text.charCodeAt(start);
+    if (code >= 0xDC00 && code <= 0xDFFF) start++;
+    return text.slice(start);
+  }
+
   // turnMetaParts distills a completed turn's Usage/Cost/durationMs into the
   // individual display parts the per-turn badge renders as separate DOM nodes
   // (the cost gets its own child span for later Show-cost CSS gating).
@@ -722,6 +736,7 @@
     taskTimeOf,
     formatToolDuration,
     clip,
+    tailSlice,
     reasoningGist,
     reasoningTier,
     turnMetaParts,

--- a/cmd/serf-hub/assets/renderer-tools.js
+++ b/cmd/serf-hub/assets/renderer-tools.js
@@ -83,6 +83,15 @@
     return lines;
   }
 
+  // tailFoldOutput is the bodyEnd counterpart of the streaming live tail:
+  // past the clip budget, keep the LAST max chars (the lines the user was
+  // watching while it streamed) prefixed with an elision line, rather than
+  // snapping the pane back to the oldest bytes with a head-clip.
+  function tailFoldOutput(text, max) {
+    text = String(text || "");
+    return text.length > max ? "…\n" + text.slice(-max) : text;
+  }
+
   function outputPreviewBody(className, outputClassName, el) {
     const wrap = document.createElement("div");
     wrap.className = "tool-body output-preview-body tool-body--preview " + className;
@@ -229,7 +238,7 @@
     b.outputPre.style.display = "";
     // Live tail while streaming: past the clip budget a head-clip freezes the
     // pane (the tail stops moving — looks stalled). bodyEnd keeps the
-    // head-based clip + fold semantics for the final render.
+    // same tail orientation for the final render (tailFoldOutput).
     const text = String(out || "");
     b.outputPre.textContent = text.length > 8000 ? text.slice(-8000) : text;
     b.outputPre.scrollTop = b.outputPre.scrollHeight;
@@ -240,7 +249,9 @@
       state.body.streaming = false;
       if (state.body.wrap) state.body.wrap.classList.remove("streaming");
     }
-    setReadOutput(state, clip(data.error || out || "", 8000));
+    // Errors keep the head-clip (the message's leading context matters); a
+    // long successful read tail-folds so the final lines stay visible.
+    setReadOutput(state, data.error ? clip(data.error, 8000) : tailFoldOutput(out, 8000));
   }
 
   function grepTarget(a) {
@@ -547,7 +558,7 @@
       b.pre.style.display = "";
       // Live tail while streaming: past the clip budget a head-clip freezes
       // the pane (the tail stops moving — looks stalled). bodyEnd keeps the
-      // head-based clip + fold semantics for the final render.
+      // same tail orientation for the final render (tailFoldOutput).
       const text = String(out || "");
       b.pre.textContent = text.length > 8000 ? text.slice(-8000) : text;
       b.pre.scrollTop = b.pre.scrollHeight;
@@ -557,7 +568,10 @@
       state.body.streaming = false;
       if (state.body.wrap) state.body.wrap.classList.remove("streaming");
       const text = data.error || out || "";
-      setExpandableOutput(state.body, clip(text, 8000), { moreClass: "shell-output-more", outputClassName: "shell-output terminal-output" });
+      // Errors keep the head-clip; a long successful run tail-folds to the
+      // LAST 8000 chars — the live tail the user was watching while it
+      // streamed — prefixed with an elision line.
+      setExpandableOutput(state.body, data.error ? clip(text, 8000) : tailFoldOutput(text, 8000), { moreClass: "shell-output-more", outputClassName: "shell-output terminal-output" });
       const st = parseToolState(data.tool_state);
       const failed = data.error || (st && st.exit_code && st.exit_code !== 0);
       if (state.body.footerEl) {

--- a/cmd/serf-hub/assets/renderer-tools.js
+++ b/cmd/serf-hub/assets/renderer-tools.js
@@ -87,9 +87,17 @@
   // past the clip budget, keep the LAST max chars (the lines the user was
   // watching while it streamed) prefixed with an elision line, rather than
   // snapping the pane back to the oldest bytes with a head-clip.
+  // The prefix is an HONEST not-retained note (the drop-note idiom from
+  // dropNote/opts.dropped, rendered as a text line since this string lands in
+  // a <pre>): the earlier bytes are GONE, and a bare "…" would masquerade as
+  // ordinary output — the design system distinguishes client-collapsed
+  // (recoverable) from source-dropped (stated plainly).
   function tailFoldOutput(text, max) {
     text = String(text || "");
-    return text.length > max ? "…\n" + tailSlice(text, max) : text;
+    if (text.length <= max) return text;
+    const note = "earlier output not retained — showing the last " +
+      Number(max).toLocaleString("en-US") + " chars";
+    return note + "\n" + tailSlice(text, max);
   }
 
   function outputPreviewBody(className, outputClassName, el) {

--- a/cmd/serf-hub/assets/renderer-tools.js
+++ b/cmd/serf-hub/assets/renderer-tools.js
@@ -223,10 +223,19 @@
   }
 
   function readToolBodyDelta(state, out) {
-    setReadOutput(state, clip(out || "", 8000));
+    const b = state.body;
+    if (!b || !b.outputPre) return;
+    if (!b.streaming) { b.streaming = true; if (b.wrap) b.wrap.classList.add("streaming"); }
+    b.outputPre.style.display = "";
+    b.outputPre.textContent = clip(out || "", 8000);
+    b.outputPre.scrollTop = b.outputPre.scrollHeight;
   }
 
   function readToolBodyEnd(state, data, out) {
+    if (state.body) {
+      state.body.streaming = false;
+      if (state.body.wrap) state.body.wrap.classList.remove("streaming");
+    }
     setReadOutput(state, clip(data.error || out || "", 8000));
   }
 
@@ -526,12 +535,19 @@
     },
     body: (args, el) => shellTerminalBody(args, el),
     bodyDelta: (state, out) => {
-      if (state.body && state.body.pre) {
-        setExpandableOutput(state.body, clip(out, 8000), { moreClass: "shell-output-more", outputClassName: "shell-output terminal-output" });
-      }
+      const b = state.body;
+      if (!b || !b.pre) return;
+      // Stream in place: one <pre>, tail-anchored, height-clamped by CSS. The
+      // fold/binary/error chrome is built once at bodyEnd — never per delta.
+      if (!b.streaming) { b.streaming = true; if (b.wrap) b.wrap.classList.add("streaming"); }
+      b.pre.style.display = "";
+      b.pre.textContent = clip(out, 8000);
+      b.pre.scrollTop = b.pre.scrollHeight;
     },
     bodyEnd: (state, data, out) => {
       if (!state.body) return;
+      state.body.streaming = false;
+      if (state.body.wrap) state.body.wrap.classList.remove("streaming");
       const text = data.error || out || "";
       setExpandableOutput(state.body, clip(text, 8000), { moreClass: "shell-output-more", outputClassName: "shell-output terminal-output" });
       const st = parseToolState(data.tool_state);

--- a/cmd/serf-hub/assets/renderer-tools.js
+++ b/cmd/serf-hub/assets/renderer-tools.js
@@ -227,7 +227,11 @@
     if (!b || !b.outputPre) return;
     if (!b.streaming) { b.streaming = true; if (b.wrap) b.wrap.classList.add("streaming"); }
     b.outputPre.style.display = "";
-    b.outputPre.textContent = clip(out || "", 8000);
+    // Live tail while streaming: past the clip budget a head-clip freezes the
+    // pane (the tail stops moving — looks stalled). bodyEnd keeps the
+    // head-based clip + fold semantics for the final render.
+    const text = String(out || "");
+    b.outputPre.textContent = text.length > 8000 ? text.slice(-8000) : text;
     b.outputPre.scrollTop = b.outputPre.scrollHeight;
   }
 
@@ -541,7 +545,11 @@
       // fold/binary/error chrome is built once at bodyEnd — never per delta.
       if (!b.streaming) { b.streaming = true; if (b.wrap) b.wrap.classList.add("streaming"); }
       b.pre.style.display = "";
-      b.pre.textContent = clip(out, 8000);
+      // Live tail while streaming: past the clip budget a head-clip freezes
+      // the pane (the tail stops moving — looks stalled). bodyEnd keeps the
+      // head-based clip + fold semantics for the final render.
+      const text = String(out || "");
+      b.pre.textContent = text.length > 8000 ? text.slice(-8000) : text;
       b.pre.scrollTop = b.pre.scrollHeight;
     },
     bodyEnd: (state, data, out) => {

--- a/cmd/serf-hub/assets/renderer-tools.js
+++ b/cmd/serf-hub/assets/renderer-tools.js
@@ -9,7 +9,7 @@
   // (so this.upsertJobRef etc. resolve at call time). Loads after
   // renderer-format.js, before renderer.js.
 
-  const { parseToolState, parseToolJSON, formatBytes, compactParts, clip } =
+  const { parseToolState, parseToolJSON, formatBytes, compactParts, clip, tailSlice } =
     window.SerfRendererInternal;
 
   // toolRendererFor returns the renderer descriptor for a given tool name.
@@ -89,7 +89,7 @@
   // snapping the pane back to the oldest bytes with a head-clip.
   function tailFoldOutput(text, max) {
     text = String(text || "");
-    return text.length > max ? "…\n" + text.slice(-max) : text;
+    return text.length > max ? "…\n" + tailSlice(text, max) : text;
   }
 
   function outputPreviewBody(className, outputClassName, el) {
@@ -240,7 +240,7 @@
     // pane (the tail stops moving — looks stalled). bodyEnd keeps the
     // same tail orientation for the final render (tailFoldOutput).
     const text = String(out || "");
-    b.outputPre.textContent = text.length > 8000 ? text.slice(-8000) : text;
+    b.outputPre.textContent = tailSlice(text, 8000);
     b.outputPre.scrollTop = b.outputPre.scrollHeight;
   }
 
@@ -560,7 +560,7 @@
       // the pane (the tail stops moving — looks stalled). bodyEnd keeps the
       // same tail orientation for the final render (tailFoldOutput).
       const text = String(out || "");
-      b.pre.textContent = text.length > 8000 ? text.slice(-8000) : text;
+      b.pre.textContent = tailSlice(text, 8000);
       b.pre.scrollTop = b.pre.scrollHeight;
     },
     bodyEnd: (state, data, out) => {

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -2462,12 +2462,18 @@
       if (!this.reasoningEl) this.beginReasoning();
       this.reasoningBuf += delta || "";
       const body = this.reasoningEl.querySelector(".think-body");
-      const pv = this.reasoningEl.querySelector(".pv");
-      if (body) body.textContent = this.reasoningBuf;
-      // Teleprompter tail: the trailing fragment of the live reasoning. The
-      // slot is one line tall and the tail reveals right-to-left (CSS), so its
-      // height never changes as tokens arrive.
-      if (pv) pv.textContent = clip(this.reasoningBuf.replace(/\s+/g, " ").trim(), 200);
+      if (body) body.appendChild(document.createTextNode(delta || ""));
+      // The teleprompter tail refreshes once per settle, from a bounded slice.
+      this.reasoningPreviewDirty = true;
+    },
+
+    // updateReasoningPreview refreshes the one-line teleprompter tail. Bounded
+    // to the last 400 chars so a long thought never pays O(buffer) per frame.
+    updateReasoningPreview() {
+      const el = this.reasoningEl;
+      if (!el) return;
+      const pv = el.querySelector(".pv");
+      if (pv) pv.textContent = clip(String(this.reasoningBuf || "").slice(-400).replace(/\s+/g, " ").trim(), 200);
     },
 
     // finalizeReasoning collapses the in-progress thought to a one-line summary

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -830,37 +830,47 @@
           }
           hydratedNotificationKeys = hydrationKeysFromThread(thread);
           const hydrationEvents = Array.from(window.SerfAppwire.eventsFromThread(thread));
-          for (const [kind, data] of hydrationEvents) {
-            this.handleData(kind, data);
-          }
-          await this.loadOlderTurnsUntilPrimaryDialogue(
-            this.eventsContainPrimaryDialogue(hydrationEvents),
-            sessionId,
-            conversation,
-            appwireStream,
-          );
-          if (this.liveStream !== appwireStream || this.conversation !== conversation) return;
-          // Surface any sandbox escalation blocked on this session (M7 surface-on-
-          // entry / reconnect), de-duped against live ones.
-          this.surfaceSnapshotEscalations(thread);
-          this.appwireHydrated = true;
-          // The stream is live again: a reconnect succeeded, so retire any
-          // chrome reconnect banner and re-enable the composer.
-          this.clearConnectionBanner();
-          this.replayingBufferedNotifications = true;
+          // Per-event stick measurement during the replay loop is the O(N²)
+          // session-open path: suppress it for the whole replay (hydration
+          // events AND buffered notifications) and settle once at the end.
+          this.suppressScrollSettle = true;
           try {
-            while (pendingNotifications.length > 0) {
-              const [method, params] = pendingNotifications.shift();
-              if (notificationCoveredByHydration(method, params)) continue;
-              const replayParams = notificationForHydrationReplay(method, params);
-              if (notificationMatches(replayParams)) deliverNotification(method, replayParams);
+            for (const [kind, data] of hydrationEvents) {
+              this.handleData(kind, data);
+            }
+            await this.loadOlderTurnsUntilPrimaryDialogue(
+              this.eventsContainPrimaryDialogue(hydrationEvents),
+              sessionId,
+              conversation,
+              appwireStream,
+            );
+            if (this.liveStream !== appwireStream || this.conversation !== conversation) return;
+            // Surface any sandbox escalation blocked on this session (M7 surface-on-
+            // entry / reconnect), de-duped against live ones.
+            this.surfaceSnapshotEscalations(thread);
+            this.appwireHydrated = true;
+            // The stream is live again: a reconnect succeeded, so retire any
+            // chrome reconnect banner and re-enable the composer.
+            this.clearConnectionBanner();
+            this.replayingBufferedNotifications = true;
+            try {
+              while (pendingNotifications.length > 0) {
+                const [method, params] = pendingNotifications.shift();
+                if (notificationCoveredByHydration(method, params)) continue;
+                const replayParams = notificationForHydrationReplay(method, params);
+                if (notificationMatches(replayParams)) deliverNotification(method, replayParams);
+              }
+            } finally {
+              this.replayingBufferedNotifications = false;
             }
           } finally {
-            this.replayingBufferedNotifications = false;
+            this.suppressScrollSettle = false;
           }
+          this.scrollToBottom();
         })
         .catch((err) => {
           if (this.sessionId !== sessionId || this.conversation !== conversation) return;
+          this.suppressScrollSettle = false;
           this.clearAppwireStream();
           if (this.isAppwireApplicationError(err)) {
             this.showConnectionBanner("unavailable", err && err.message ? err.message : String(err));
@@ -1084,6 +1094,7 @@
     resetTranscriptReplay() {
       if (!this.conversation) return;
       this.cancelFrameFlush();
+      this.suppressScrollSettle = false;
       this.frameQueue = [];
       this.frameGeneration = (this.frameGeneration || 0) + 1;
       this.discardPendingAsk();

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -194,6 +194,14 @@
 
       this.activeMessages = new Map();   // messageId -> {el, textBuf, markdownTimer}
       this.activeTools = new Map();      // callId -> {el, outputBuf}
+      // Per-conversation render caches: the previous session's DOM is gone
+      // (element swapped, innerHTML wiped below), so any cache holding element
+      // references from it must reset — otherwise stale error anchors produce
+      // a phantom error pill and dirty/pending sets render into detached nodes.
+      this.errorAnchorCache = null;
+      if (this.dirtyAssistantMessages) this.dirtyAssistantMessages.clear();
+      this.pendingDiffDeltas = new Map(); // callId -> {renderer, state, out} (settleFrame coalescing)
+      this.lastFinalizedAssistantEl = null;
       this.activeJobs = new Map();       // appwire jobId -> subagent row el
       this.subagentRowsByDelegate = new Map();   // delegateId -> subagent row els
       this.subagentRowsByOriginCall = new Map(); // origin tool call id -> subagent row el
@@ -1146,6 +1154,9 @@
       this.subagentModule = null;
       this.currentTurnHasAgentWork = false;
       this.errorAnchorCache = null;
+      if (this.dirtyAssistantMessages) this.dirtyAssistantMessages.clear();
+      if (this.pendingDiffDeltas) this.pendingDiffDeltas.clear();
+      this.lastFinalizedAssistantEl = null;
     },
 
     markCurrentTurnAgentWork() {
@@ -1322,6 +1333,12 @@
             this.suppressedToolCalls.clear();
             this.pendingTaskCalls.clear();
             this.pendingAskCalls.clear();
+            // Same swap hazard as init(): the conversation DOM was just wiped,
+            // so caches holding element references from it must reset too.
+            this.errorAnchorCache = null;
+            if (this.dirtyAssistantMessages) this.dirtyAssistantMessages.clear();
+            if (this.pendingDiffDeltas) this.pendingDiffDeltas.clear();
+            this.lastFinalizedAssistantEl = null;
             taskDescriptions.clear();
             taskDetails.clear();
             this.lastCurrentTaskId = null;
@@ -1566,6 +1583,14 @@
         for (const m of this.dirtyAssistantMessages) this.renderAssistantMessage(m, m.textBuf);
         this.dirtyAssistantMessages.clear();
       }
+      // Diff renderers defer their per-delta DOM rebuild to here (one render
+      // per frame per call, last output wins) — see appendToolDelta.
+      if (this.pendingDiffDeltas && this.pendingDiffDeltas.size) {
+        for (const pending of this.pendingDiffDeltas.values()) {
+          pending.renderer.bodyDelta(pending.state, pending.out);
+        }
+        this.pendingDiffDeltas.clear();
+      }
       if (this.reasoningPreviewDirty) {
         this.reasoningPreviewDirty = false;
         this.updateReasoningPreview();
@@ -1574,7 +1599,10 @@
       // Reader is up in history: if this frame rendered new entries, surface
       // the floating "↓ N new" affordance instead of yanking the viewport.
       const added = this.conversation.children.length - entriesBefore;
-      if (added > 0) this.noteNewContent(added);
+      // Hydration replay suppresses the per-event settle; the pill must not
+      // flash for replayed history either — the final scrollToBottom after the
+      // replay clears it anyway.
+      if (added > 0 && !this.suppressScrollSettle) this.noteNewContent(added);
       if (stick && !this.suppressScrollSettle) this.scrollToBottom();
     },
 
@@ -2443,7 +2471,11 @@
         // (activeTurnId cleared) a late END REPLACES the finalized block in
         // place — it must never append a duplicate.
         const last = this.lastFinalizedAssistantEl;
-        if (!this.activeTurnId && last && last.isConnected && String(finalText).trim()) {
+        // The block being replaced must be the transcript tail: after an
+        // intervening turn rendered tool rows (or finalized empty), the
+        // pointer can name an older turn's block — replacing that would
+        // clobber history mid-transcript instead of landing the late text.
+        if (!this.activeTurnId && last && last.isConnected && last === this.conversation.lastElementChild && String(finalText).trim()) {
           const meta = last.querySelector(".turn-meta");
           try { last.innerHTML = window.marked.parse(finalText); }
           catch (e) { last.textContent = finalText; }
@@ -2457,6 +2489,10 @@
       this.currentMessageId = null;
       if (this.dirtyAssistantMessages) this.dirtyAssistantMessages.delete(m);
       if (!String(finalText || "").trim()) {
+        // Empty finalize: this turn's segment produced nothing, so no fresh
+        // block exists for a late END to replace — drop the pointer at the
+        // older turn's block before one can target it.
+        this.lastFinalizedAssistantEl = null;
         if (m.el.parentNode) m.el.parentNode.removeChild(m.el);
         return;
       }
@@ -2837,13 +2873,31 @@
       const m = this.toolStateFor(data);
       if (!m) return;
       m.outputBuf += data.delta || "";
-      if (m.renderer.bodyDelta) m.renderer.bodyDelta(m, m.outputBuf);
+      if (!m.renderer.bodyDelta) return;
+      // Diff renderers (edit/write/apply_patch — their body pre carries
+      // .diff-body) rebuild the whole diff DOM per call, so per-delta renders
+      // inside one batched flush are pure churn: defer to settleFrame, keyed
+      // by call — last output wins. Cheap single-textContent renderers
+      // (shell/read) still stream per delta.
+      if (m.body && m.body.pre && m.body.pre.classList && m.body.pre.classList.contains("diff-body")) {
+        if (!this.pendingDiffDeltas) this.pendingDiffDeltas = new Map();
+        this.pendingDiffDeltas.set(data.call_id || data.item_id, { renderer: m.renderer, state: m, out: m.outputBuf });
+        return;
+      }
+      m.renderer.bodyDelta(m, m.outputBuf);
     },
 
     finalizeToolCall(data) {
       const m = this.toolStateFor(data);
       if (!m) return;
       const out = data.output || m.outputBuf || "";
+      // bodyEnd renders the authoritative final output below; a still-pending
+      // coalesced delta for this call would re-render the stale delta buffer
+      // over it at settleFrame, so drop it first.
+      if (this.pendingDiffDeltas) {
+        this.pendingDiffDeltas.delete(data.call_id);
+        this.pendingDiffDeltas.delete(data.item_id);
+      }
 
       const ok = !data.error && toolLooksGood(data);
       if (m.statusEl) {

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -1218,6 +1218,7 @@
           break;
         case "TURN_COMPLETED":
           this.finalizeReasoning();
+          this.finalizeAssistantMessage();
           if (!data.turnId || data.turnId === this.activeTurnId) {
             // THREAD_STATUS_CHANGED("active") starts an asynchronous capability
             // refresh. Once this turn has completed, that old active snapshot
@@ -1487,6 +1488,7 @@
           this.appendSteeringMessage(data.text || imagePlaceholderForCount((data.images || []).length));
           break;
         case "SESSION_END":
+          this.finalizeAssistantMessage();
           // input_complete = clean end-of-turn termination; not user-meaningful.
           // Past replays always end this way and the dim/idle dot already
           // conveys "this conversation is over." Only render for dramatic
@@ -2294,6 +2296,7 @@
       this.removeColdStartSkeleton();
       this.endCheapCluster();
       this.closeSubagentModule();
+      this.lastFinalizedAssistantEl = null;
       const id = "msg-" + Math.random().toString(36).slice(2, 9);
       this.currentMessageId = id;
       const el = document.createElement("div");
@@ -2388,6 +2391,19 @@
       const m = this.activeMessages.get(id);
       const finalText = (data && data.text) || (m && m.textBuf) || "";
       if (!m) {
+        // Idempotence: appwire can emit TURN_COMPLETED (which finalizes) and
+        // then a synthesized ASSISTANT_TEXT_END for the same message in one
+        // notification (codex turn/completed-with-items). Between turns
+        // (activeTurnId cleared) a late END REPLACES the finalized block in
+        // place — it must never append a duplicate.
+        const last = this.lastFinalizedAssistantEl;
+        if (!this.activeTurnId && last && last.isConnected && String(finalText).trim()) {
+          const meta = last.querySelector(".turn-meta");
+          try { last.innerHTML = window.marked.parse(finalText); }
+          catch (e) { last.textContent = finalText; }
+          if (meta) last.appendChild(meta); // re-parse destroyed children; the badge rides back
+          return;
+        }
         this.appendAssistantBlock(finalText);
         return;
       }

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -200,7 +200,13 @@
       // a phantom error pill and dirty/pending sets render into detached nodes.
       this.errorAnchorCache = null;
       if (this.dirtyAssistantMessages) this.dirtyAssistantMessages.clear();
-      this.pendingDiffDeltas = new Map(); // callId -> {renderer, state, out} (settleFrame coalescing)
+      this.pendingBodyDeltas = new Map(); // callId -> {renderer, state, out} (settleFrame coalescing)
+      // Reasoning state points into the (now swapped) conversation DOM too:
+      // a stale reasoningEl would strand every post-swap delta on a detached
+      // node — beginReasoning early-returns on the truthy handle.
+      this.reasoningEl = null;
+      this.reasoningBuf = "";
+      this.reasoningPreviewDirty = false;
       this.lastFinalizedAssistantEl = null;
       this.activeJobs = new Map();       // appwire jobId -> subagent row el
       this.subagentRowsByDelegate = new Map();   // delegateId -> subagent row els
@@ -1155,7 +1161,13 @@
       this.currentTurnHasAgentWork = false;
       this.errorAnchorCache = null;
       if (this.dirtyAssistantMessages) this.dirtyAssistantMessages.clear();
-      if (this.pendingDiffDeltas) this.pendingDiffDeltas.clear();
+      if (this.pendingBodyDeltas) this.pendingBodyDeltas.clear();
+      // The in-flight thought lived in the conversation DOM just cleared.
+      // Without this reset, beginReasoning early-returns on the detached node
+      // and every post-reconnect reasoning delta vanishes into it.
+      this.reasoningEl = null;
+      this.reasoningBuf = "";
+      this.reasoningPreviewDirty = false;
       this.lastFinalizedAssistantEl = null;
     },
 
@@ -1323,6 +1335,8 @@
             history.replaceState(null, "", "/s/" + encodeURIComponent(data.session_id));
             this.conversation.innerHTML = "";
             this.reasoningEl = null;
+            this.reasoningBuf = "";
+            this.reasoningPreviewDirty = false;
             this.activeMessages.clear();
             this.activeTools.clear();
             this.activeJobs.clear();
@@ -1337,7 +1351,7 @@
             // so caches holding element references from it must reset too.
             this.errorAnchorCache = null;
             if (this.dirtyAssistantMessages) this.dirtyAssistantMessages.clear();
-            if (this.pendingDiffDeltas) this.pendingDiffDeltas.clear();
+            if (this.pendingBodyDeltas) this.pendingBodyDeltas.clear();
             this.lastFinalizedAssistantEl = null;
             taskDescriptions.clear();
             taskDetails.clear();
@@ -1583,13 +1597,13 @@
         for (const m of this.dirtyAssistantMessages) this.renderAssistantMessage(m, m.textBuf);
         this.dirtyAssistantMessages.clear();
       }
-      // Diff renderers defer their per-delta DOM rebuild to here (one render
+      // Tool renderers defer their per-delta body writes to here (one render
       // per frame per call, last output wins) — see appendToolDelta.
-      if (this.pendingDiffDeltas && this.pendingDiffDeltas.size) {
-        for (const pending of this.pendingDiffDeltas.values()) {
+      if (this.pendingBodyDeltas && this.pendingBodyDeltas.size) {
+        for (const pending of this.pendingBodyDeltas.values()) {
           pending.renderer.bodyDelta(pending.state, pending.out);
         }
-        this.pendingDiffDeltas.clear();
+        this.pendingBodyDeltas.clear();
       }
       if (this.reasoningPreviewDirty) {
         this.reasoningPreviewDirty = false;
@@ -2425,22 +2439,40 @@
       m.textBuf += delta;
       if (!m.tailEl && m.textBuf.length > 4096) {
         // Frozen head, raw tail: stop re-parsing a long message per frame. The
-        // DOM parsed so far stays; further deltas stream as plain text and the
-        // whole buffer parses once at finalization. Switches on LENGTH only
-        // (never fence state) and never flips back.
-        this.renderAssistantMessage(m, m.textBuf);
+        // head's parsed DOM FREEZES at the crossing (re-parsing the whole
+        // buffer here would visibly reflow the head and destroy any selection
+        // over it) — it keeps its last settle-render. The crossing delta and
+        // everything after streams as plain text into the tail; the whole
+        // buffer parses once at finalization. Switches on LENGTH only (never
+        // fence state) and never flips back.
         const tail = document.createElement("span");
         tail.className = "streaming-tail";
+        tail.appendChild(document.createTextNode(delta));
+        tail.appendChild(this.streamingCaret());
         m.el.appendChild(tail);
         m.tailEl = tail;
         if (this.dirtyAssistantMessages) this.dirtyAssistantMessages.delete(m);
         return;
       }
       if (m.tailEl) {
-        m.tailEl.appendChild(document.createTextNode(delta));
+        // Insert ahead of the caret so it stays glued to the newest text.
+        m.tailEl.insertBefore(document.createTextNode(delta), m.tailEl.lastChild);
       } else {
         this.markAssistantDirty(m);
       }
+    },
+
+    // streamingCaret builds the live-tail caret as a real aria-hidden span —
+    // the old ::after pseudo-element's content lands in the accessibility
+    // tree, so screen readers announced "▍" on every streamed chunk. The span
+    // disappears with the tail at finalization (innerHTML re-parse), so no
+    // teardown is needed.
+    streamingCaret() {
+      const caret = document.createElement("span");
+      caret.className = "streaming-caret";
+      caret.setAttribute("aria-hidden", "true");
+      caret.textContent = "▍";
+      return caret;
     },
 
     renderAssistantMessage(m, text) {
@@ -2471,16 +2503,28 @@
         // (activeTurnId cleared) a late END REPLACES the finalized block in
         // place — it must never append a duplicate.
         const last = this.lastFinalizedAssistantEl;
-        // The block being replaced must be the transcript tail: after an
-        // intervening turn rendered tool rows (or finalized empty), the
-        // pointer can name an older turn's block — replacing that would
-        // clobber history mid-transcript instead of landing the late text.
-        if (!this.activeTurnId && last && last.isConnected && last === this.conversation.lastElementChild && String(finalText).trim()) {
-          const meta = last.querySelector(".turn-meta");
-          try { last.innerHTML = window.marked.parse(finalText); }
-          catch (e) { last.textContent = finalText; }
-          if (meta) last.appendChild(meta); // re-parse destroyed children; the badge rides back
-          return;
+        // The block being replaced must be the transcript's LAST assistant
+        // block — not the last ELEMENT. SESSION_END finalizes the message and
+        // then appends an end banner (and system lines may follow), so a
+        // lastElementChild check wrongly rejects the replace and appends a
+        // duplicate answer. But the pointer still must not clobber history:
+        // if anything other than banners/system lines followed the block
+        // (an intervening turn's tool rows, another turn's block), the late
+        // text lands as its own block instead.
+        if (!this.activeTurnId && last && last.isConnected && String(finalText).trim()) {
+          const blocks = this.conversation ? this.conversation.querySelectorAll(".assistant-message") : [];
+          let onlyQuietFollowers = true;
+          for (let s = last.nextElementSibling; s; s = s.nextElementSibling) {
+            const cl = s.classList;
+            if (!cl || !(cl.contains("banner") || cl.contains("system-line"))) { onlyQuietFollowers = false; break; }
+          }
+          if (onlyQuietFollowers && blocks.length && blocks[blocks.length - 1] === last) {
+            const meta = last.querySelector(".turn-meta");
+            try { last.innerHTML = window.marked.parse(finalText); }
+            catch (e) { last.textContent = finalText; }
+            if (meta) last.appendChild(meta); // re-parse destroyed children; the badge rides back
+            return;
+          }
         }
         this.appendAssistantBlock(finalText);
         return;
@@ -2591,7 +2635,10 @@
       const el = this.reasoningEl;
       if (!el) return;
       const pv = el.querySelector(".pv");
-      if (pv) pv.textContent = clip(String(this.reasoningBuf || "").slice(-400).replace(/\s+/g, " ").trim(), 200);
+      // Newest 200 chars AFTER whitespace normalization: clipping the PREFIX
+      // of the 400-char slice froze the teleprompter on stale text (chars
+      // -400..-201) and never showed the live edge of the thought.
+      if (pv) pv.textContent = String(this.reasoningBuf || "").slice(-400).replace(/\s+/g, " ").trim().slice(-200);
     },
 
     // finalizeReasoning collapses the in-progress thought to a one-line summary
@@ -2874,17 +2921,15 @@
       if (!m) return;
       m.outputBuf += data.delta || "";
       if (!m.renderer.bodyDelta) return;
-      // Diff renderers (edit/write/apply_patch — their body pre carries
-      // .diff-body) rebuild the whole diff DOM per call, so per-delta renders
-      // inside one batched flush are pure churn: defer to settleFrame, keyed
-      // by call — last output wins. Cheap single-textContent renderers
-      // (shell/read) still stream per delta.
-      if (m.body && m.body.pre && m.body.pre.classList && m.body.pre.classList.contains("diff-body")) {
-        if (!this.pendingDiffDeltas) this.pendingDiffDeltas = new Map();
-        this.pendingDiffDeltas.set(data.call_id || data.item_id, { renderer: m.renderer, state: m, out: m.outputBuf });
-        return;
-      }
-      m.renderer.bodyDelta(m, m.outputBuf);
+      // Every tool renderer's bodyDelta rewrites the whole body (diffs rebuild
+      // the DOM; shell/read replace the full textContent and read scrollHeight
+      // to re-pin). Inside one batched flush, N deltas → N full rewrites is
+      // pure churn: defer to settleFrame through a per-call last-wins map.
+      // Sync paths (handleData per event) drain at the same call's settle, so
+      // per-event semantics are unchanged. bodyEnd at TOOL_CALL_END stays
+      // immediate.
+      if (!this.pendingBodyDeltas) this.pendingBodyDeltas = new Map();
+      this.pendingBodyDeltas.set(data.call_id || data.item_id, { renderer: m.renderer, state: m, out: m.outputBuf });
     },
 
     finalizeToolCall(data) {
@@ -2894,9 +2939,9 @@
       // bodyEnd renders the authoritative final output below; a still-pending
       // coalesced delta for this call would re-render the stale delta buffer
       // over it at settleFrame, so drop it first.
-      if (this.pendingDiffDeltas) {
-        this.pendingDiffDeltas.delete(data.call_id);
-        this.pendingDiffDeltas.delete(data.item_id);
+      if (this.pendingBodyDeltas) {
+        this.pendingBodyDeltas.delete(data.call_id);
+        this.pendingBodyDeltas.delete(data.item_id);
       }
 
       const ok = !data.error && toolLooksGood(data);

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -2438,27 +2438,27 @@
       if (!m) return;
       m.textBuf += delta;
       if (!m.tailEl && m.textBuf.length > 4096) {
-        // Frozen head, raw tail: stop re-parsing a long message per frame. The
-        // head's parsed DOM FREEZES at the crossing (re-parsing the whole
-        // buffer here would visibly reflow the head and destroy any selection
-        // over it) — it keeps its last settle-render. The crossing delta and
-        // everything after streams as plain text into the tail; the whole
-        // buffer parses once at finalization. Switches on LENGTH only (never
-        // fence state) and never flips back.
-        // If the last pre-crossing delta and the crossing delta landed in the
-        // SAME batched flush, the head text is still sitting in the dirty set
-        // un-rendered — the settle that would render it never runs for this
-        // message (tail mode removes it from the set). Render the pre-crossing
-        // buffer ONCE here, exactly the parse the settle would have done, so
-        // the head isn't missing until finalization. If the message is not
-        // dirty the last settle already rendered the head — nothing to do.
-        if (this.dirtyAssistantMessages && this.dirtyAssistantMessages.has(m)) {
-          this.renderAssistantMessage(m, m.textBuf.slice(0, m.textBuf.length - delta.length));
-          this.dirtyAssistantMessages.delete(m);
-        }
+        // Frozen head, raw tail: stop re-parsing a long message per frame. At
+        // the crossing the head is rendered ONCE as the first headLen chars
+        // (one bounded parse — never the whole buffer) and then FREEZES;
+        // everything past the boundary streams as plain text into the tail,
+        // and the whole buffer parses once at finalization. Switches on
+        // LENGTH only (never fence state) and never flips back.
+        // Always rendering the head here (not just when the dirty set holds
+        // an un-rendered pre-crossing buffer) means a single >4KB FIRST delta
+        // shows its first ~4KB parsed immediately instead of staying raw
+        // until finalization.
+        // Surrogate-safe boundary: a high surrogate exactly at 4096 would
+        // freeze half a pair into the head and leave the low half leading the
+        // tail as a separate text node (� until finalization). Back the
+        // boundary off one code unit so the pair stays whole in the tail.
+        let headLen = 4096;
+        const boundaryCode = m.textBuf.charCodeAt(headLen - 1);
+        if (boundaryCode >= 0xd800 && boundaryCode <= 0xdbff) headLen -= 1;
+        this.renderAssistantMessage(m, m.textBuf.slice(0, headLen));
         const tail = document.createElement("span");
         tail.className = "streaming-tail";
-        tail.appendChild(document.createTextNode(delta));
+        tail.appendChild(document.createTextNode(m.textBuf.slice(headLen)));
         tail.appendChild(this.streamingCaret());
         m.el.appendChild(tail);
         m.tailEl = tail;
@@ -2527,7 +2527,11 @@
           let onlyQuietFollowers = true;
           for (let s = last.nextElementSibling; s; s = s.nextElementSibling) {
             const cl = s.classList;
-            if (!cl || !(cl.contains("banner") || cl.contains("system-line"))) { onlyQuietFollowers = false; break; }
+            // Quiet followers: banners, system lines, and the .system-run
+            // wrapper appendSystemMessage/coalesced system runs produce
+            // (plugin runs carry .system-run too). Anything else means real
+            // content intervened and the pointer must not clobber history.
+            if (!cl || !(cl.contains("banner") || cl.contains("system-line") || cl.contains("system-run"))) { onlyQuietFollowers = false; break; }
           }
           if (onlyQuietFollowers && blocks.length && blocks[blocks.length - 1] === last) {
             const meta = last.querySelector(".turn-meta");
@@ -4961,6 +4965,16 @@
     prependOlderTurns(turns) {
       if (!this.conversation || !window.SerfAppwire || typeof window.SerfAppwire.eventsFromTurns !== "function") return;
       const sc = this.conversation;
+      // Live interaction state the staging render must not touch. Historical
+      // events run through the normal mutating path: a historical
+      // TURN_COMPLETED (no turnId) would finalize against and CLEAR the live
+      // activeTurnId (and flip the thread state / bump statusUpdateSeq); a
+      // historical USER_INPUT would settle the LIVE pending ask_user and tear
+      // down its anchor/agent-question frame; a historical REASONING_START
+      // early-returns on the live reasoningEl and its deltas then hijack the
+      // live think body/buffer. Save every field those paths touch, reset the
+      // element/buffer ones so history gets its own staging state, and restore
+      // them all in the finally.
       const saved = {
         activeMessages: this.activeMessages,
         activeTools: this.activeTools,
@@ -4981,6 +4995,19 @@
         newContentCount: this.newContentCount,
         conversation: this.conversation,
         lastFrameAt: this.lastFrameAt,
+        activeTurnId: this.activeTurnId,
+        state: this.state,
+        statusUpdateSeq: this.statusUpdateSeq,
+        reasoningEl: this.reasoningEl,
+        reasoningBuf: this.reasoningBuf,
+        reasoningPreviewDirty: this.reasoningPreviewDirty,
+        reasoningStartedAt: this.reasoningStartedAt,
+        pendingAsk: this.pendingAsk,
+        pendingAskCalls: this.pendingAskCalls,
+        agentQuestionEl: this.agentQuestionEl,
+        lastFinalizedAssistantEl: this.lastFinalizedAssistantEl,
+        currentTurnHasAgentWork: this.currentTurnHasAgentWork,
+        newContentNeedsYou: this.newContentNeedsYou,
       };
       const staging = document.createElement("div");
       this.conversation = staging;
@@ -4997,6 +5024,16 @@
       this.entryIndex = 0;
       this.cheapToolCluster = null;
       this.subagentModule = null;
+      this.activeTurnId = "";
+      this.reasoningEl = null;
+      this.reasoningBuf = "";
+      this.reasoningPreviewDirty = false;
+      this.reasoningStartedAt = 0;
+      this.pendingAsk = null;
+      this.pendingAskCalls = new Map();
+      this.agentQuestionEl = null;
+      this.lastFinalizedAssistantEl = null;
+      this.currentTurnHasAgentWork = false;
       try {
         for (const [kind, data] of window.SerfAppwire.eventsFromTurns(turns)) {
           this.handleData(kind, data);

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -187,9 +187,22 @@
       this.appwireThreadId = null;
       this.appwireHydrated = false;
       this.hydrationInProgress = false;
+      // Session-scoped like hydrationInProgress: a superseded hydration's
+      // finally deliberately does NOT clear this (the successor owns it), so
+      // the session swap must — the flag must never leak into a session whose
+      // hydration never ran (e.g. a non-appwire view would keep suppressing
+      // stick-to-bottom and the new-content pill forever).
+      this.suppressScrollSettle = false;
       this.readerScrolledDuringHydration = false;
       this.programmaticScrollDepth = 0;
       this.prependSettleHolds = 0;
+      // Cancel the previous session's keyed prepend-settle frames too: zeroing
+      // the counters alone leaves a pending "prepend-settle-release" callback
+      // that would fire into THIS session and drain its holds — misreading its
+      // correction-window scroll as reader intent (and stranding its
+      // stick-to-bottom suppression).
+      this.cancelFrame("prepend-settle");
+      this.cancelFrame("prepend-settle-release");
       this.scrollBottomHolds = 0;
       this.activeTurnId = conversationEl.dataset.activeTurnId || "";
       this.state = conversationEl.dataset.state || "ended";
@@ -938,11 +951,26 @@
                 if (notificationMatches(replayParams)) deliverNotification(method, replayParams);
               }
             } finally {
-              this.replayingBufferedNotifications = false;
+              // Ownership-guarded like the outer finally below: the buffered-
+              // replay block is synchronous today (no staleness can develop
+              // between the guard above and here), but if it ever yields, a
+              // superseded replay must not clear the successor's flag.
+              if (this.liveStream === appwireStream) this.replayingBufferedNotifications = false;
             }
-            this.hydrationInProgress = false;
+            // Same audit as the finally below: only the stream owner clears
+            // the shared replay-gate flag (see the comment at its assignment).
+            if (this.liveStream === appwireStream) this.hydrationInProgress = false;
           } finally {
-            this.suppressScrollSettle = false;
+            // Stale-overlap guard: a superseded hydration that returned at one
+            // of the staleness aborts above still runs THIS finally — while
+            // the successor hydration owns the stream and is mid-replay. An
+            // unconditional clear would strip the successor's settle
+            // suppression mid-replay, re-enabling the per-event settle work
+            // (the O(N²) path this flag exists to avoid) and replay-time
+            // scroll/pill side effects for the successor's remaining events.
+            // Only the stream owner clears the flag; the successor clears it
+            // in its own finally.
+            if (this.liveStream === appwireStream) this.suppressScrollSettle = false;
           }
           // Reader scroll intent: a scroll event during the replay means the
           // reader chose their position — the settle must not yank them back
@@ -5297,6 +5325,7 @@
         this.clearNewContentPill();
         return;
       }
+      const wasHidden = pill.hidden;
       pill.hidden = false;
       const urgent = this.pickUrgentAnchor();
       pill.classList.remove("needs-you", "error");
@@ -5314,6 +5343,12 @@
         // burst of appends settles to one number instead of repainting the
         // badge on every frame. Show the last settled value now and schedule a
         // trailing commit of the latest count.
+        // First-paint exception: on the hidden→visible transition the painted
+        // count is still 0 while the live count is already positive — showing
+        // the stale painted value would badge "↓ 0 new" for the whole debounce
+        // window. Seed from the live count on that transition only; repaints
+        // while already visible keep the debounced (anti-jitter) value.
+        if (wasHidden) this.newContentPaintedCount = this.newContentCount;
         pill.textContent = "↓ " + this.newContentPaintedCount + " new";
         this.scheduleNewContentCountPaint();
       }
@@ -5326,6 +5361,12 @@
       if (this.newContentCountTimer) clearTimeout(this.newContentCountTimer);
       this.newContentCountTimer = setTimeout(() => {
         this.newContentCountTimer = null;
+        // Never commit a zero count: a reset that missed the timer cancel must
+        // hide the pill, not badge "↓ 0 new".
+        if (this.newContentCount <= 0) {
+          this.clearNewContentPill();
+          return;
+        }
         this.newContentPaintedCount = this.newContentCount;
         const pill = this.newContentPillEl();
         // Repaint only while still showing the plain count (urgency takes over

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -1217,9 +1217,11 @@
           if (window.htmx) htmx.trigger(document.body, "serf-hub:status-refresh");
           break;
         case "TURN_COMPLETED":
-          this.finalizeReasoning();
-          this.finalizeAssistantMessage();
           if (!data.turnId || data.turnId === this.activeTurnId) {
+            // A stale/late completion for a different turn must NOT finalize
+            // the currently-streaming message — later deltas would be dropped.
+            this.finalizeReasoning();
+            this.finalizeAssistantMessage();
             // THREAD_STATUS_CHANGED("active") starts an asynchronous capability
             // refresh. Once this turn has completed, that old active snapshot
             // must not be allowed to arrive late and put the composer back into

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -258,6 +258,12 @@
       // guards against overlapping scroll-triggered fetches.
       this.olderTurnsCursor = "";
       this.loadingOlderTurns = false;
+      // Staging replay: true while prependOlderTurns runs historical events
+      // through the normal mutating path against a detached staging div.
+      // Document-level UI side effects (composer ask mode, the ask/needs-you
+      // docks, focus moves) must no-op while it is set — field save/restore
+      // cannot undo real-document mutations.
+      this.stagingReplay = false;
       this.lastFrameAt = Date.now();     // wall-clock of the last frame, for honest liveness
       this.livenessLevel = "none";       // none | quiet | concern (mockup #13)
       // New-content pill: counts transcript entries that rendered while the
@@ -2444,10 +2450,10 @@
         // everything past the boundary streams as plain text into the tail,
         // and the whole buffer parses once at finalization. Switches on
         // LENGTH only (never fence state) and never flips back.
-        // Always rendering the head here (not just when the dirty set holds
-        // an un-rendered pre-crossing buffer) means a single >4KB FIRST delta
-        // shows its first ~4KB parsed immediately instead of staying raw
-        // until finalization.
+        // Rendering the head whenever new content would enter it (not just
+        // when the dirty set holds an un-rendered pre-crossing buffer) means
+        // a single >4KB FIRST delta shows its first ~4KB parsed immediately
+        // instead of staying raw until finalization.
         // Surrogate-safe boundary: a high surrogate exactly at 4096 would
         // freeze half a pair into the head and leave the low half leading the
         // tail as a separate text node (� until finalization). Back the
@@ -2455,7 +2461,17 @@
         let headLen = 4096;
         const boundaryCode = m.textBuf.charCodeAt(headLen - 1);
         if (boundaryCode >= 0xd800 && boundaryCode <= 0xdbff) headLen -= 1;
-        this.renderAssistantMessage(m, m.textBuf.slice(0, headLen));
+        // Render the head ONLY when this crossing puts new content into it:
+        // either earlier deltas are still un-rendered (m is in the dirty set),
+        // or the settled head does not already show exactly headLen chars —
+        // preLen < headLen when part of the crossing delta belongs in the
+        // head (the first-delta/short-head case), preLen > headLen when a
+        // surrogate backoff moves a settled char into the tail. When the head
+        // already shows exactly headLen chars, re-rendering would replace the
+        // head DOM (killing any reader selection) for zero visual change.
+        const preLen = m.textBuf.length - delta.length;
+        const headStale = this.dirtyAssistantMessages && this.dirtyAssistantMessages.has(m);
+        if (headStale || preLen !== headLen) this.renderAssistantMessage(m, m.textBuf.slice(0, headLen));
         const tail = document.createElement("span");
         tail.className = "streaming-tail";
         tail.appendChild(document.createTextNode(m.textBuf.slice(headLen)));
@@ -5008,6 +5024,9 @@
         lastFinalizedAssistantEl: this.lastFinalizedAssistantEl,
         currentTurnHasAgentWork: this.currentTurnHasAgentWork,
         newContentNeedsYou: this.newContentNeedsYou,
+        newContentPaintedCount: this.newContentPaintedCount,
+        newContentJumpTarget: this.newContentJumpTarget,
+        newContentCountTimer: this.newContentCountTimer,
       };
       const staging = document.createElement("div");
       this.conversation = staging;
@@ -5034,12 +5053,26 @@
       this.agentQuestionEl = null;
       this.lastFinalizedAssistantEl = null;
       this.currentTurnHasAgentWork = false;
+      // Historical events replay through the normal mutating path; guards on
+      // the document-level UI mutations (composer ask mode, ask/needs-you
+      // docks, focus) no-op while this is set so a historical ask_user cannot
+      // hijack the LIVE composer.
+      this.stagingReplay = true;
       try {
         for (const [kind, data] of window.SerfAppwire.eventsFromTurns(turns)) {
           this.handleData(kind, data);
         }
       } finally {
         for (const key of Object.keys(saved)) this[key] = saved[key];
+        this.stagingReplay = false;
+        // The replay's own settle (stick → scrollToBottom →
+        // clearNewContentPill) kills the live pill debounce timer's underlying
+        // timeout; the restored handle alone would never fire. Re-arm it so
+        // the pending count commit still lands.
+        if (saved.newContentCountTimer != null) {
+          this.newContentCountTimer = null;
+          this.scheduleNewContentCountPaint();
+        }
       }
       const beforeHeight = sc.scrollHeight;
       const beforeTop = sc.scrollTop;
@@ -5189,6 +5222,9 @@
     },
 
     renderNeedsYouDock() {
+      // Document-level: owns the real dock above the composer form — suppress
+      // during staging replay.
+      if (this.stagingReplay) return;
       const dock = this.needsYouDockEl();
       if (!dock) return;
       if (!this.needsYouDockActive()) {
@@ -5233,6 +5269,7 @@
     },
 
     focusComposer() {
+      if (this.stagingReplay) return;
       const ta = document.querySelector("form[data-input-form] .message-input");
       if (ta) ta.focus();
     },
@@ -5288,6 +5325,8 @@
     },
 
     setComposerAskMode(active) {
+      // Staging replay (prependOlderTurns) must never touch the real composer.
+      if (this.stagingReplay) return;
       const form = document.querySelector("form[data-input-form]");
       if (!form) return;
       const wasActive = form.dataset.responseMode === "ask";
@@ -5313,6 +5352,9 @@
     },
 
     renderPendingAskDock() {
+      // Document-level: builds the dock in the real composer form, flips ask
+      // mode, and moves focus — suppress during staging replay.
+      if (this.stagingReplay) return;
       const pa = this.pendingAsk;
       const form = document.querySelector("form[data-input-form]");
       const dock = this.askDockEl();
@@ -5360,6 +5402,9 @@
     },
 
     clearPendingAskDock() {
+      // Document-level: removes the dock/footer from the real composer form
+      // and restores the composer surface — suppress during staging replay.
+      if (this.stagingReplay) return;
       const form = document.querySelector("form[data-input-form]");
       if (!form) return;
       const dock = form.querySelector("[data-ask-response-dock]");

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -2250,11 +2250,16 @@
       return this.normalizedAssistantText(el.textContent);
     },
 
+    markAssistantDirty(m) {
+      if (!this.dirtyAssistantMessages) this.dirtyAssistantMessages = new Set();
+      this.dirtyAssistantMessages.add(m);
+    },
+
     appendAssistantDelta(delta) {
       const m = this.activeMessages.get(this.currentMessageId);
       if (!m) return;
       m.textBuf += delta;
-      this.renderAssistantMessage(m, m.textBuf);
+      this.markAssistantDirty(m);
     },
 
     renderAssistantMessage(m, text) {
@@ -2284,6 +2289,7 @@
       }
       this.activeMessages.delete(id);
       this.currentMessageId = null;
+      if (this.dirtyAssistantMessages) this.dirtyAssistantMessages.delete(m);
       if (!String(finalText || "").trim()) {
         if (m.el.parentNode) m.el.parentNode.removeChild(m.el);
         return;

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -190,6 +190,7 @@
       this.readerScrolledDuringHydration = false;
       this.programmaticScrollDepth = 0;
       this.prependSettleHolds = 0;
+      this.scrollBottomHolds = 0;
       this.activeTurnId = conversationEl.dataset.activeTurnId || "";
       this.state = conversationEl.dataset.state || "ended";
       this.liveSendCap = null;
@@ -4885,19 +4886,26 @@
     },
 
     scrollToBottom() {
-      // Depth-counted programmatic scroll: the browser fires the scroll event
-      // ASYNC (a later task at the earliest), so a synchronous marker would
-      // already be cleared by the time the listener runs. Hold the depth until
-      // the next task so the listener never reads this write as reader intent
-      // during hydration (it also guards any future programmatic scroll that
-      // CAN land inside a replay window).
+      // Depth-counted programmatic scroll: a scrollTop write fires its scroll
+      // event ASYNC, in the NEXT frame's scroll steps — which run BEFORE that
+      // frame's rAF callbacks — not in a later task. A synchronous marker
+      // would already be cleared by the time the listener runs, and a
+      // one-task release would land before the frame in which the event
+      // fires, so the depth is held until the next frame instead (it also
+      // guards any future programmatic scroll that CAN land inside a replay
+      // window). Holds accumulate: a rapid burst of scrollToBottom calls
+      // reschedules the keyed release, cancelling the previous pending one,
+      // so the surviving release drains them all (no stuck counter).
       this.programmaticScrollDepth++;
+      this.scrollBottomHolds++;
       try {
         this.conversation.scrollTop = this.conversation.scrollHeight;
       } finally {
-        setTimeout(() => {
-          this.programmaticScrollDepth = Math.max(0, this.programmaticScrollDepth - 1);
-        }, 0);
+        this.scheduleFrame(() => {
+          const holds = this.scrollBottomHolds;
+          this.scrollBottomHolds = 0;
+          this.programmaticScrollDepth = Math.max(0, this.programmaticScrollDepth - holds);
+        }, "scroll-bottom-release");
       }
       // Once parked at the bottom there is no unseen content, so the
       // new-content pill (and its counter) must reset.
@@ -5210,15 +5218,21 @@
       // events ASYNC, after this function returns — a synchronous marker is
       // already cleared by then, and mid-hydration paging
       // (loadOlderTurnsUntilPrimaryDialogue) read those events as reader
-      // intent, wrongly suppressing the hydration-end settle. Hold a depth
-      // count from here until the final settle callback has completed its
-      // correction; the release is deferred one task so the correction's own
-      // async scroll event also lands while depth > 0. A subsequent prepend
-      // re-schedules the keyed "prepend-settle" frame, cancelling the
-      // previous one — its hold is subsumed by the surviving settle, so the
-      // holds pile up and the LAST settle releases them all (no stuck
-      // counter). The catch path releases this prepend's own hold if anything
-      // throws before the settle is scheduled.
+      // intent, wrongly suppressing the hydration-end settle. The
+      // correction's write fires its event in the NEXT frame's scroll steps,
+      // which run BEFORE that frame's rAF callbacks — so a one-task release
+      // lands before the event and is too early. Hold a depth count from
+      // here until one FRAME after the settle callback has completed its
+      // correction, so the correction's own scroll event also lands while
+      // depth > 0. A subsequent prepend re-schedules the keyed
+      // "prepend-settle" frame, cancelling the previous one — its hold is
+      // subsumed by the surviving settle, so the holds pile up and the LAST
+      // settle's release drains them all (no stuck counter). The release
+      // drains the accumulator at run time, so a cancelled
+      // "prepend-settle-release" (a later settle reschedules the key) never
+      // strands depth — the surviving release picks up every hold. The catch
+      // path releases this prepend's own hold if anything throws before the
+      // settle is scheduled.
       this.programmaticScrollDepth++;
       this.prependSettleHolds++;
       try {
@@ -5239,11 +5253,17 @@
               if (drift) sc.scrollTop += drift;
             }
           } finally {
-            const holds = this.prependSettleHolds;
-            this.prependSettleHolds = 0;
-            setTimeout(() => {
+            // Release one FRAME later, not one task: the correction's
+            // scrollTop write fires its scroll event in the next frame's
+            // scroll steps (before that frame's rAF callbacks), so the depth
+            // must still be held when that event lands. Draining the
+            // accumulator here keeps a cancelled release from stranding
+            // depth — the surviving release picks up every hold.
+            this.scheduleFrame(() => {
+              const holds = this.prependSettleHolds;
+              this.prependSettleHolds = 0;
               this.programmaticScrollDepth = Math.max(0, this.programmaticScrollDepth - holds);
-            }, 0);
+            }, "prepend-settle-release");
           }
         }, "prepend-settle");
         this.errorAnchorCache = null;

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -200,7 +200,7 @@
       // a phantom error pill and dirty/pending sets render into detached nodes.
       this.errorAnchorCache = null;
       if (this.dirtyAssistantMessages) this.dirtyAssistantMessages.clear();
-      this.pendingBodyDeltas = new Map(); // callId -> {renderer, state, out} (settleFrame coalescing)
+      this.pendingBodyDeltas = new Map(); // tool state object -> {renderer, state, out} (settleFrame coalescing)
       // Reasoning state points into the (now swapped) conversation DOM too:
       // a stale reasoningEl would strand every post-swap delta on a detached
       // node — beginReasoning early-returns on the truthy handle.
@@ -2445,6 +2445,17 @@
         // everything after streams as plain text into the tail; the whole
         // buffer parses once at finalization. Switches on LENGTH only (never
         // fence state) and never flips back.
+        // If the last pre-crossing delta and the crossing delta landed in the
+        // SAME batched flush, the head text is still sitting in the dirty set
+        // un-rendered — the settle that would render it never runs for this
+        // message (tail mode removes it from the set). Render the pre-crossing
+        // buffer ONCE here, exactly the parse the settle would have done, so
+        // the head isn't missing until finalization. If the message is not
+        // dirty the last settle already rendered the head — nothing to do.
+        if (this.dirtyAssistantMessages && this.dirtyAssistantMessages.has(m)) {
+          this.renderAssistantMessage(m, m.textBuf.slice(0, m.textBuf.length - delta.length));
+          this.dirtyAssistantMessages.delete(m);
+        }
         const tail = document.createElement("span");
         tail.className = "streaming-tail";
         tail.appendChild(document.createTextNode(delta));
@@ -2928,8 +2939,11 @@
       // Sync paths (handleData per event) drain at the same call's settle, so
       // per-event semantics are unchanged. bodyEnd at TOOL_CALL_END stays
       // immediate.
+      // Keyed by the tool STATE OBJECT, not an id string: delta and END events
+      // resolve the same state through activeTools aliases even when they carry
+      // different id shapes (call_id vs item_id), so keying can't diverge.
       if (!this.pendingBodyDeltas) this.pendingBodyDeltas = new Map();
-      this.pendingBodyDeltas.set(data.call_id || data.item_id, { renderer: m.renderer, state: m, out: m.outputBuf });
+      this.pendingBodyDeltas.set(m, { renderer: m.renderer, state: m, out: m.outputBuf });
     },
 
     finalizeToolCall(data) {
@@ -2939,10 +2953,7 @@
       // bodyEnd renders the authoritative final output below; a still-pending
       // coalesced delta for this call would re-render the stale delta buffer
       // over it at settleFrame, so drop it first.
-      if (this.pendingBodyDeltas) {
-        this.pendingBodyDeltas.delete(data.call_id);
-        this.pendingBodyDeltas.delete(data.item_id);
-      }
+      if (this.pendingBodyDeltas) this.pendingBodyDeltas.delete(m);
 
       const ok = !data.error && toolLooksGood(data);
       if (m.statusEl) {

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -2328,6 +2328,12 @@
     lastElementIsAssistantText(text) {
       const last = this.conversation && this.conversation.lastElementChild;
       if (!last || !last.classList || !last.classList.contains("assistant-message")) return false;
+      // While the last message is still streaming, its DOM may hold a raw
+      // markdown tail — compare source against source instead.
+      const m = this.activeMessages.get(this.currentMessageId);
+      if (m && m.el === last) {
+        return this.normalizedAssistantText(m.textBuf) === this.normalizedAssistantText(text);
+      }
       return this.normalizedAssistantText(last.textContent) === this.renderedAssistantText(text);
     },
 

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -872,6 +872,34 @@
       this.liveStream = null;
     },
 
+    // scheduleFrame runs cb on the next animation frame when rAF exists and the
+    // tab is visible; otherwise on a 16ms timer. Plain jsdom has no rAF at all,
+    // and hidden tabs never fire it — never call rAF unguarded.
+    scheduleFrame(cb) {
+      this.cancelFrame();
+      const hidden = typeof document !== "undefined" && document.hidden;
+      if (!hidden && typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+        this.scheduledFrameRaf = window.requestAnimationFrame(() => {
+          this.scheduledFrameRaf = null;
+          cb();
+        });
+        return;
+      }
+      this.scheduledFrameTimer = setTimeout(() => {
+        this.scheduledFrameTimer = null;
+        cb();
+      }, 16);
+    },
+
+    cancelFrame() {
+      if (this.scheduledFrameRaf != null && typeof window !== "undefined" && typeof window.cancelAnimationFrame === "function") {
+        try { window.cancelAnimationFrame(this.scheduledFrameRaf); } catch (e) {}
+      }
+      if (this.scheduledFrameTimer != null) clearTimeout(this.scheduledFrameTimer);
+      this.scheduledFrameRaf = null;
+      this.scheduledFrameTimer = null;
+    },
+
     // The visual viewport shrinks when a mobile software keyboard opens. Keep
     // workspace-owned CSS in sync so the composer dock can stay above it. This
     // listener belongs to the currently rendered workspace/session, not the
@@ -883,23 +911,17 @@
       const workspace = document.getElementById("workspace");
       if (!viewport || !workspace || !Number.isFinite(viewport.height)) return;
       const sessionId = this.sessionId;
-      let frame = null;
       const apply = () => {
-        frame = null;
         if (this.sessionId !== sessionId || document.getElementById("workspace") !== workspace) return;
         if (Number.isFinite(viewport.height) && viewport.height > 0) {
           workspace.style.setProperty("--workspace-visible-height", viewport.height + "px");
         }
       };
-      const schedule = () => {
-        if (frame != null) return;
-        frame = window.requestAnimationFrame(apply);
-      };
+      const schedule = () => this.scheduleFrame(apply);
       this.workspaceViewportCleanup = () => {
         viewport.removeEventListener("resize", schedule);
         viewport.removeEventListener("scroll", schedule);
-        if (frame != null) window.cancelAnimationFrame(frame);
-        frame = null;
+        this.cancelFrame();
       };
       viewport.addEventListener("resize", schedule);
       viewport.addEventListener("scroll", schedule);

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -899,29 +899,54 @@
     // scheduleFrame runs cb on the next animation frame when rAF exists and the
     // tab is visible; otherwise on a 16ms timer. Plain jsdom has no rAF at all,
     // and hidden tabs never fire it — never call rAF unguarded.
-    scheduleFrame(cb) {
-      this.cancelFrame();
+    // Slots are keyed: each key owns its pending callback, and scheduling on a
+    // key cancels only that key's pending callback. A single shared slot would
+    // let one caller (e.g. the prepend settle) cancel another's frame (e.g. the
+    // scroll tick), leaving scrollAffordanceTick stuck true forever.
+    scheduleFrame(cb, key) {
+      const slot = key == null ? "default" : key;
+      if (!this.scheduledFrameRafs) this.scheduledFrameRafs = new Map();
+      if (!this.scheduledFrameTimers) this.scheduledFrameTimers = new Map();
+      this.cancelFrame(slot);
       const hidden = typeof document !== "undefined" && document.hidden;
       if (!hidden && typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
-        this.scheduledFrameRaf = window.requestAnimationFrame(() => {
-          this.scheduledFrameRaf = null;
+        this.scheduledFrameRafs.set(slot, window.requestAnimationFrame(() => {
+          this.scheduledFrameRafs.delete(slot);
           cb();
-        });
+        }));
         return;
       }
-      this.scheduledFrameTimer = setTimeout(() => {
-        this.scheduledFrameTimer = null;
+      this.scheduledFrameTimers.set(slot, setTimeout(() => {
+        this.scheduledFrameTimers.delete(slot);
         cb();
-      }, 16);
+      }, 16));
     },
 
-    cancelFrame() {
-      if (this.scheduledFrameRaf != null && typeof window !== "undefined" && typeof window.cancelAnimationFrame === "function") {
-        try { window.cancelAnimationFrame(this.scheduledFrameRaf); } catch (e) {}
+    // cancelFrame(key) cancels that key's pending callback; with no key it
+    // cancels every slot — a bare cancelFrame() still retires a bare
+    // scheduleFrame(), which lives on the "default" key.
+    cancelFrame(key) {
+      if (key != null) {
+        this.cancelFrameSlot(key);
+        return;
       }
-      if (this.scheduledFrameTimer != null) clearTimeout(this.scheduledFrameTimer);
-      this.scheduledFrameRaf = null;
-      this.scheduledFrameTimer = null;
+      if (this.scheduledFrameRafs) for (const slot of [...this.scheduledFrameRafs.keys()]) this.cancelFrameSlot(slot);
+      if (this.scheduledFrameTimers) for (const slot of [...this.scheduledFrameTimers.keys()]) this.cancelFrameSlot(slot);
+    },
+
+    cancelFrameSlot(key) {
+      if (this.scheduledFrameRafs) {
+        const raf = this.scheduledFrameRafs.get(key);
+        if (raf != null && typeof window !== "undefined" && typeof window.cancelAnimationFrame === "function") {
+          try { window.cancelAnimationFrame(raf); } catch (e) {}
+        }
+        this.scheduledFrameRafs.delete(key);
+      }
+      if (this.scheduledFrameTimers) {
+        const timer = this.scheduledFrameTimers.get(key);
+        if (timer != null) clearTimeout(timer);
+        this.scheduledFrameTimers.delete(key);
+      }
     },
 
     // Frame batching — LIVE socket events only. Replay paths (initial hydration,
@@ -1001,11 +1026,11 @@
           workspace.style.setProperty("--workspace-visible-height", viewport.height + "px");
         }
       };
-      const schedule = () => this.scheduleFrame(apply);
+      const schedule = () => this.scheduleFrame(apply, "viewport");
       this.workspaceViewportCleanup = () => {
         viewport.removeEventListener("resize", schedule);
         viewport.removeEventListener("scroll", schedule);
-        this.cancelFrame();
+        this.cancelFrame("viewport");
       };
       viewport.addEventListener("resize", schedule);
       viewport.addEventListener("scroll", schedule);
@@ -4709,7 +4734,7 @@
           this.scheduleFrame(() => {
             this.scrollAffordanceTick = false;
             this.onScrollAffordance();
-          });
+          }, "scroll");
         });
       }
       this.clearNewContentPill();
@@ -4883,7 +4908,7 @@
         if (!sc.isConnected) return;
         const drift = sc.scrollHeight - settledHeight;
         if (drift) sc.scrollTop += drift;
-      });
+      }, "prepend-settle");
       this.errorAnchorCache = null;
     },
 

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -188,7 +188,8 @@
       this.appwireHydrated = false;
       this.hydrationInProgress = false;
       this.readerScrolledDuringHydration = false;
-      this.programmaticScroll = false;
+      this.programmaticScrollDepth = 0;
+      this.prependSettleHolds = 0;
       this.activeTurnId = conversationEl.dataset.activeTurnId || "";
       this.state = conversationEl.dataset.state || "ended";
       this.liveSendCap = null;
@@ -944,7 +945,8 @@
           }
           // Reader scroll intent: a scroll event during the replay means the
           // reader chose their position — the settle must not yank them back
-          // to the bottom. Programmatic scrolls (marked) never set the flag.
+          // to the bottom. Programmatic scrolls (depth-counted) never set the
+          // flag.
           if (!this.readerScrolledDuringHydration) this.scrollToBottom();
           this.readerScrolledDuringHydration = false;
         })
@@ -4883,14 +4885,19 @@
     },
 
     scrollToBottom() {
-      // Marked programmatic: the scroll listener must not read this as reader
-      // intent during hydration (the marker also guards any future
-      // programmatic scroll that CAN land inside a replay window).
-      this.programmaticScroll = true;
+      // Depth-counted programmatic scroll: the browser fires the scroll event
+      // ASYNC (a later task at the earliest), so a synchronous marker would
+      // already be cleared by the time the listener runs. Hold the depth until
+      // the next task so the listener never reads this write as reader intent
+      // during hydration (it also guards any future programmatic scroll that
+      // CAN land inside a replay window).
+      this.programmaticScrollDepth++;
       try {
         this.conversation.scrollTop = this.conversation.scrollHeight;
       } finally {
-        this.programmaticScroll = false;
+        setTimeout(() => {
+          this.programmaticScrollDepth = Math.max(0, this.programmaticScrollDepth - 1);
+        }, 0);
       }
       // Once parked at the bottom there is no unseen content, so the
       // new-content pill (and its counter) must reset.
@@ -4967,8 +4974,9 @@
           // Reader intent during hydration: a genuine scroll mid-replay means
           // the reader took control of the position — the hydration-end settle
           // must not yank them to the bottom. Programmatic scrolls (prepend
-          // compensation, the settle itself) are marked and never set this.
-          if (this.hydrationInProgress && !this.programmaticScroll) {
+          // compensation, the settle itself) hold a depth count that covers
+          // their ASYNC scroll events, and never set this.
+          if (this.hydrationInProgress && this.programmaticScrollDepth === 0) {
             this.readerScrolledDuringHydration = true;
           }
           if (this.scrollAffordanceTick) return;
@@ -5197,22 +5205,53 @@
           this.scheduleNewContentCountPaint();
         }
       }
-      const beforeHeight = sc.scrollHeight;
-      const beforeTop = sc.scrollTop;
-      const frag = document.createDocumentFragment();
-      while (staging.firstChild) frag.appendChild(staging.firstChild);
-      sc.insertBefore(frag, sc.firstChild);
-      sc.scrollTop = beforeTop + (sc.scrollHeight - beforeHeight);
-      // Second settle: freshly prepended entries may sit at estimated sizes
-      // (content-visibility). After the browser lays out the near-viewport
-      // ones, correct the residual drift so the reader's anchor holds.
-      const settledHeight = sc.scrollHeight;
-      this.scheduleFrame(() => {
-        if (!sc.isConnected) return;
-        const drift = sc.scrollHeight - settledHeight;
-        if (drift) sc.scrollTop += drift;
-      }, "prepend-settle");
-      this.errorAnchorCache = null;
+      // Depth-counted programmatic scroll: BOTH scrollTop writes below (the
+      // sync compensation and the rAF drift correction) fire their scroll
+      // events ASYNC, after this function returns — a synchronous marker is
+      // already cleared by then, and mid-hydration paging
+      // (loadOlderTurnsUntilPrimaryDialogue) read those events as reader
+      // intent, wrongly suppressing the hydration-end settle. Hold a depth
+      // count from here until the final settle callback has completed its
+      // correction; the release is deferred one task so the correction's own
+      // async scroll event also lands while depth > 0. A subsequent prepend
+      // re-schedules the keyed "prepend-settle" frame, cancelling the
+      // previous one — its hold is subsumed by the surviving settle, so the
+      // holds pile up and the LAST settle releases them all (no stuck
+      // counter). The catch path releases this prepend's own hold if anything
+      // throws before the settle is scheduled.
+      this.programmaticScrollDepth++;
+      this.prependSettleHolds++;
+      try {
+        const beforeHeight = sc.scrollHeight;
+        const beforeTop = sc.scrollTop;
+        const frag = document.createDocumentFragment();
+        while (staging.firstChild) frag.appendChild(staging.firstChild);
+        sc.insertBefore(frag, sc.firstChild);
+        sc.scrollTop = beforeTop + (sc.scrollHeight - beforeHeight);
+        // Second settle: freshly prepended entries may sit at estimated sizes
+        // (content-visibility). After the browser lays out the near-viewport
+        // ones, correct the residual drift so the reader's anchor holds.
+        const settledHeight = sc.scrollHeight;
+        this.scheduleFrame(() => {
+          try {
+            if (sc.isConnected) {
+              const drift = sc.scrollHeight - settledHeight;
+              if (drift) sc.scrollTop += drift;
+            }
+          } finally {
+            const holds = this.prependSettleHolds;
+            this.prependSettleHolds = 0;
+            setTimeout(() => {
+              this.programmaticScrollDepth = Math.max(0, this.programmaticScrollDepth - holds);
+            }, 0);
+          }
+        }, "prepend-settle");
+        this.errorAnchorCache = null;
+      } catch (err) {
+        this.prependSettleHolds--;
+        this.programmaticScrollDepth--;
+        throw err;
+      }
     },
 
     // noteNewContent records that `added` new transcript entries rendered while

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -1120,6 +1120,7 @@
       this.cheapToolCluster = null;
       this.subagentModule = null;
       this.currentTurnHasAgentWork = false;
+      this.errorAnchorCache = null;
     },
 
     markCurrentTurnAgentWork() {
@@ -1450,6 +1451,7 @@
           this.appendToolDelta(data);
           break;
         case "TOOL_CALL_END":
+          this.errorAnchorCache = null;
           this.markCurrentTurnAgentWork();
           if (this.suppressedToolCalls.has(data.call_id)) {
             this.suppressedToolCalls.delete(data.call_id);
@@ -4664,7 +4666,7 @@
     pickUrgentAnchor() {
       const sc = this.conversation;
       if (!sc) return null;
-      const errors = Array.from(sc.querySelectorAll('.tool-call[data-attention="error"]'));
+      const errors = this.errorAnchors();
       const errBelow = errors.find(el => this.isAnchorBelow(el));
       if (errBelow) return { kind: "error", dir: "down", el: errBelow };
       const errAbove = errors.find(el => this.isAnchorAbove(el));
@@ -4702,22 +4704,44 @@
       if (!el.__serfScrollPillBound) {
         el.__serfScrollPillBound = true;
         el.addEventListener("scroll", () => {
-          if (this.isNearTop()) this.maybeLoadOlderTurns();
-          if (this.isNearBottom()) this.clearNewContentPill();
-          // Re-evaluate the urgent anchor as the reader scrolls, so the arrow
-          // flips (↓→↑) when they pass an error and the label tracks what's
-          // still off-screen — without churning the debounced count.
-          else if (this.newContentCount > 0) this.renderNewContentPill();
-          // The dock tracks whether the question scrolled out of view, so it
-          // appears the moment the ask leaves the viewport and clears when the
-          // reader returns to it.
-          this.renderNeedsYouDock();
+          if (this.scrollAffordanceTick) return;
+          this.scrollAffordanceTick = true;
+          this.scheduleFrame(() => {
+            this.scrollAffordanceTick = false;
+            this.onScrollAffordance();
+          });
         });
       }
       this.clearNewContentPill();
       // Materialize the dock up front so its presence is independent of the
       // first scroll event.
       this.needsYouDockEl();
+    },
+
+    onScrollAffordance() {
+      if (this.isNearTop()) this.maybeLoadOlderTurns();
+      if (this.isNearBottom()) this.clearNewContentPill();
+      // Re-evaluate the urgent anchor as the reader scrolls, so the arrow
+      // flips (↓→↑) when they pass an error and the label tracks what's
+      // still off-screen — without churning the debounced count.
+      else if (this.newContentCount > 0) this.renderNewContentPill();
+      // The dock tracks whether the question scrolled out of view, so it
+      // appears the moment the ask leaves the viewport and clears when the
+      // reader returns to it.
+      this.renderNeedsYouDock();
+    },
+
+    // errorAnchors caches the per-row error anchors between invalidations —
+    // the scroll path re-queries on every frame otherwise. Invalidated on
+    // TOOL_CALL_END (a row's attention state settles), transcript prepend,
+    // and replay reset.
+    errorAnchors() {
+      if (!this.errorAnchorCache) {
+        this.errorAnchorCache = this.conversation
+          ? Array.from(this.conversation.querySelectorAll('.tool-call[data-attention="error"]'))
+          : [];
+      }
+      return this.errorAnchorCache;
     },
 
     newContentPillEl() {
@@ -4860,6 +4884,7 @@
         const drift = sc.scrollHeight - settledHeight;
         if (drift) sc.scrollTop += drift;
       });
+      this.errorAnchorCache = null;
     },
 
     // noteNewContent records that `added` new transcript entries rendered while

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -2298,6 +2298,7 @@
       this.currentMessageId = id;
       const el = document.createElement("div");
       el.className = "assistant-message";
+      el.classList.add("streaming");
       el.dataset.turnId = this.activeTurnId || "";
       this.conversation.appendChild(el);
       this.activeMessages.set(id, { el, textBuf: "" });
@@ -2345,7 +2346,24 @@
       const m = this.activeMessages.get(this.currentMessageId);
       if (!m) return;
       m.textBuf += delta;
-      this.markAssistantDirty(m);
+      if (!m.tailEl && m.textBuf.length > 4096) {
+        // Frozen head, raw tail: stop re-parsing a long message per frame. The
+        // DOM parsed so far stays; further deltas stream as plain text and the
+        // whole buffer parses once at finalization. Switches on LENGTH only
+        // (never fence state) and never flips back.
+        this.renderAssistantMessage(m, m.textBuf);
+        const tail = document.createElement("span");
+        tail.className = "streaming-tail";
+        m.el.appendChild(tail);
+        m.tailEl = tail;
+        if (this.dirtyAssistantMessages) this.dirtyAssistantMessages.delete(m);
+        return;
+      }
+      if (m.tailEl) {
+        m.tailEl.appendChild(document.createTextNode(delta));
+      } else {
+        this.markAssistantDirty(m);
+      }
     },
 
     renderAssistantMessage(m, text) {
@@ -2380,7 +2398,9 @@
         if (m.el.parentNode) m.el.parentNode.removeChild(m.el);
         return;
       }
+      m.el.classList.remove("streaming");
       this.renderAssistantMessage(m, finalText);
+      this.lastFinalizedAssistantEl = m.el;
     },
 
     // markAgentQuestion frames an agent message as the blocking "needs-you"

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -211,6 +211,9 @@
       this.lastCurrentTaskId = null;     // dedupe state for "now on X" system-line
       this.eventBuffer = [];             // queued until initialization enables transcript replay
       this.descriptionsReady = false;
+      // Frame batching state for LIVE socket notifications (see flush()).
+      this.frameQueue = [];
+      this.frameGeneration = 0;
       // Description cache is per-session: clear before entering this conversation
       // so a stale id→title mapping from a prior session can't bleed in.
       taskDescriptions.clear();
@@ -278,6 +281,7 @@
       }
 
       this.bindWorkspaceViewport();
+      this.bindVisibilityFlush();
       this.bindInputForm();
       this.bindScrollAffordance();
       this.bindPaneParentLinks();
@@ -671,18 +675,23 @@
       };
       const pendingNotifications = [];
       const deliverNotification = (method, params) => {
-        for (const [kind, data] of window.SerfAppwire.eventsFromNotification(method, params)) {
-          this.handleData(kind, data);
+        if (!this.appwireHydrated || this.replayingBufferedNotifications) {
+          for (const [kind, data] of window.SerfAppwire.eventsFromNotification(method, params)) {
+            this.handleData(kind, data);
+          }
+          // Single reconciliation site: after the authoritative reducer
+          // update has applied, give the pending registry a chance to
+          // find a matching placeholder and remove it. The hydration
+          // replay loop below also runs through deliverNotification, so
+          // replayed notifications get exactly one reconcile pass.
+          if (this.pending) {
+            reconcilePendingFromNotification(this.pending, method, params);
+          }
+          return;
         }
-        // Single reconciliation site: after the authoritative reducer
-        // update has applied, give the pending registry a chance to
-        // find a matching placeholder and remove it. The hydration
-        // replay loop below also runs through deliverNotification, so
-        // replayed notifications get exactly one reconcile pass.
-        if (this.pending) {
-          reconcilePendingFromNotification(this.pending, method, params);
-        }
+        this.enqueueLiveNotification(method, params);
       };
+      this.reconcilePending = reconcilePendingFromNotification;
       const notificationMatches = (params) => {
         const ref = params && (params.ref || (params.item && params.item.ref));
         const threadId = params && (params.threadId || (params.item && params.item.threadId));
@@ -838,11 +847,16 @@
           // The stream is live again: a reconnect succeeded, so retire any
           // chrome reconnect banner and re-enable the composer.
           this.clearConnectionBanner();
-          while (pendingNotifications.length > 0) {
-            const [method, params] = pendingNotifications.shift();
-            if (notificationCoveredByHydration(method, params)) continue;
-            const replayParams = notificationForHydrationReplay(method, params);
-            if (notificationMatches(replayParams)) deliverNotification(method, replayParams);
+          this.replayingBufferedNotifications = true;
+          try {
+            while (pendingNotifications.length > 0) {
+              const [method, params] = pendingNotifications.shift();
+              if (notificationCoveredByHydration(method, params)) continue;
+              const replayParams = notificationForHydrationReplay(method, params);
+              if (notificationMatches(replayParams)) deliverNotification(method, replayParams);
+            }
+          } finally {
+            this.replayingBufferedNotifications = false;
           }
         })
         .catch((err) => {
@@ -900,6 +914,66 @@
       this.scheduledFrameTimer = null;
     },
 
+    // Frame batching — LIVE socket events only. Replay paths (initial hydration,
+    // buffered-notification replay, prependOlderTurns) call handleData directly
+    // and never enter this queue.
+    enqueueLiveNotification(method, params) {
+      if (!Array.isArray(this.frameQueue)) { this.frameQueue = []; this.frameGeneration = 0; }
+      this.frameQueue.push({ method, params });
+      this.scheduleFrameFlush();
+    },
+
+    scheduleFrameFlush() {
+      if (this.frameFlushScheduled) return;
+      this.frameFlushScheduled = true;
+      const run = () => {
+        this.frameFlushScheduled = false;
+        this.frameFlushRaf = null;
+        this.frameFlushTimer = null;
+        this.flush();
+      };
+      const hidden = typeof document !== "undefined" && document.hidden;
+      if (!hidden && typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+        this.frameFlushRaf = window.requestAnimationFrame(run);
+      } else {
+        // Hidden tab (rAF never fires there) or no rAF at all (plain jsdom).
+        // The interval is best-effort — flush always drains the whole queue.
+        this.frameFlushTimer = setTimeout(run, hidden ? 250 : 16);
+      }
+    },
+
+    cancelFrameFlush() {
+      if (this.frameFlushRaf != null && typeof window !== "undefined" && typeof window.cancelAnimationFrame === "function") {
+        try { window.cancelAnimationFrame(this.frameFlushRaf); } catch (e) {}
+      }
+      if (this.frameFlushTimer != null) clearTimeout(this.frameFlushTimer);
+      this.frameFlushRaf = null;
+      this.frameFlushTimer = null;
+      this.frameFlushScheduled = false;
+    },
+
+    flush() {
+      this.cancelFrameFlush();
+      const q = this.frameQueue;
+      if (!q || !q.length) return;
+      this.frameQueue = [];
+      const gen = this.frameGeneration;
+      const stick = this.suppressScrollSettle ? false : this.isNearBottom();
+      const entriesBefore = this.conversation ? this.conversation.children.length : 0;
+      for (const item of q) {
+        if (gen !== this.frameGeneration) return; // transcript reset mid-flush
+        for (const [kind, data] of window.SerfAppwire.eventsFromNotification(item.method, item.params)) {
+          this.applyEvent(kind, data);
+        }
+        // Per-notification reconcile, in order, after that notification's
+        // events applied — the invariant from deliverNotification.
+        if (this.pending && this.reconcilePending) {
+          this.reconcilePending(this.pending, item.method, item.params);
+        }
+      }
+      this.settleFrame(stick, entriesBefore);
+    },
+
     // The visual viewport shrinks when a mobile software keyboard opens. Keep
     // workspace-owned CSS in sync so the composer dock can stay above it. This
     // listener belongs to the currently rendered workspace/session, not the
@@ -932,6 +1006,15 @@
       if (!this.workspaceViewportCleanup) return;
       this.workspaceViewportCleanup();
       this.workspaceViewportCleanup = null;
+    },
+
+    // Flush queued live events on ANY visibility transition: a scheduled rAF
+    // never fires once the tab hides, and on return we want the freshest state
+    // painted immediately.
+    bindVisibilityFlush() {
+      if (this.visibilityFlushBound || typeof document === "undefined") return;
+      this.visibilityFlushBound = true;
+      document.addEventListener("visibilitychange", () => this.flush());
     },
 
     scheduleAppwireReconnect() {
@@ -1000,6 +1083,9 @@
 
     resetTranscriptReplay() {
       if (!this.conversation) return;
+      this.cancelFrameFlush();
+      this.frameQueue = [];
+      this.frameGeneration = (this.frameGeneration || 0) + 1;
       this.discardPendingAsk();
       this.conversation.innerHTML = "";
       this.activeMessages.clear();

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -186,6 +186,7 @@
       this.appwireRef = null;
       this.appwireThreadId = null;
       this.appwireHydrated = false;
+      this.hydrationInProgress = false;
       this.activeTurnId = conversationEl.dataset.activeTurnId || "";
       this.state = conversationEl.dataset.state || "ended";
       this.liveSendCap = null;
@@ -843,7 +844,20 @@
         .then(async (resp) => {
           if (this.sessionId !== sessionId || this.conversation !== conversation) return;
           const thread = resp.thread || {};
-          if (this.appwireHydrated) this.resetTranscriptReplay();
+          // A reconnect can land DURING a chunked hydration: appwireHydrated is
+          // already false (cleared below at the abandoned replay's start), but
+          // its half-rendered prefix is still in the DOM. Replaying into it
+          // would duplicate that prefix — reset whenever a hydration is in
+          // flight, not only after a completed one.
+          if (this.appwireHydrated || this.hydrationInProgress) this.resetTranscriptReplay();
+          // Marks the whole replay window (initial AND reconnect hydration):
+          // gates the settings-toggle re-render and scroll-triggered older-
+          // turns paging, which must not interleave with the chunked replay.
+          // Cleared on completion and in the catch path — NOT by
+          // resetTranscriptReplay (the superseding hydration owns the flag) and
+          // NOT by the staleness aborts below (the superseding hydration may
+          // already have set it; clearing here would unguard its replay).
+          this.hydrationInProgress = true;
           // The replay below is chunked and yields to the event loop between
           // slices, so the window in which live notifications could interleave
           // into the half-rendered transcript is no longer microscopic. Gate
@@ -910,6 +924,7 @@
             } finally {
               this.replayingBufferedNotifications = false;
             }
+            this.hydrationInProgress = false;
           } finally {
             this.suppressScrollSettle = false;
           }
@@ -917,6 +932,7 @@
         })
         .catch((err) => {
           if (this.sessionId !== sessionId || this.conversation !== conversation) return;
+          this.hydrationInProgress = false;
           this.suppressScrollSettle = false;
           this.clearAppwireStream();
           if (this.isAppwireApplicationError(err)) {
@@ -1220,6 +1236,12 @@
 
     refreshTranscriptStatusVisibility() {
       if (!this.conversation || !this.sessionId) return false;
+      // A chunked hydration is mid-replay: this path resets + re-renders
+      // synchronously + flips appwireHydrated with no chunking, and the
+      // suspended replay would then resume and append its remaining slices a
+      // second time. Defer — the hydration renders the correct state anyway,
+      // and the toggle takes effect on the next natural render.
+      if (this.hydrationInProgress) return false;
       if (!window.SerfAppwire || typeof window.SerfAppwire.readThread !== "function" || typeof window.SerfAppwire.eventsFromThread !== "function") {
         return false;
       }
@@ -5007,6 +5029,11 @@
     // reader scrolls near the top and more history remains. Guarded so
     // overlapping scroll events don't double-fetch.
     maybeLoadOlderTurns() {
+      // Hydration seeds olderTurnsCursor up front but pages it via
+      // loadOlderTurnsUntilPrimaryDialogue only after the chunked replay
+      // drains; a scroll fetch in between races it on the SAME cursor and both
+      // prepend the same page. Hydration owns the cursor while in progress.
+      if (this.hydrationInProgress) return;
       if (this.loadingOlderTurns || !this.olderTurnsCursor) return;
       if (!this.sessionId || !window.SerfAppwire || typeof window.SerfAppwire.listTurns !== "function") return;
       this.loadingOlderTurns = true;

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -119,6 +119,11 @@
   const INITIAL_TURN_WINDOW = 40;
   const OLDER_TURN_PAGE = 30;
 
+  // Hydration replay chunk size: after this many events the readThread replay
+  // yields a macrotask so opening/reconnecting a long session doesn't freeze
+  // the page (an unchunked 2000-event replay is one multi-second task).
+  const HYDRATION_CHUNK = 150;
+
   const SerfRenderer = {
     // isInPane returns true when the renderer is running inside a framed pane
     // (a side-pane iframe). Uses the standard same-origin cross-frame check;
@@ -839,6 +844,16 @@
           if (this.sessionId !== sessionId || this.conversation !== conversation) return;
           const thread = resp.thread || {};
           if (this.appwireHydrated) this.resetTranscriptReplay();
+          // The replay below is chunked and yields to the event loop between
+          // slices, so the window in which live notifications could interleave
+          // into the half-rendered transcript is no longer microscopic. Gate
+          // live delivery for the whole replay: the onNotification handler's
+          // !appwireHydrated branch buffers matching notifications into
+          // pendingNotifications, and the buffered-replay loop at the end of
+          // this block delivers them in order after hydration completes. On
+          // failure the reconnect schedule re-runs hydration from scratch, so
+          // the flag is never stuck false.
+          this.appwireHydrated = false;
           // Seed the lazy-load cursor: non-empty means older turns exist beyond
           // the hydrated window and can be paged in on scroll-up.
           this.olderTurnsCursor = resp.olderCursor || "";
@@ -855,8 +870,20 @@
           // events AND buffered notifications) and settle once at the end.
           this.suppressScrollSettle = true;
           try {
-            for (const [kind, data] of hydrationEvents) {
+            // Chunked replay: a long session's thousands of events must not
+            // run as one blocking task. Slice the loop and yield a macrotask
+            // between slices so input and timers stay responsive. The
+            // staleness guards re-run after EVERY yield: a session swap (or
+            // stream teardown) mid-chunk must abort the abandoned replay
+            // cleanly instead of rendering into the new conversation.
+            for (let i = 0; i < hydrationEvents.length; i++) {
+              const [kind, data] = hydrationEvents[i];
               this.handleData(kind, data);
+              if ((i + 1) % HYDRATION_CHUNK === 0 && i + 1 < hydrationEvents.length) {
+                await new Promise((resolve) => setTimeout(resolve, 0));
+                if (this.sessionId !== sessionId || this.conversation !== conversation) return;
+                if (this.liveStream !== appwireStream) return;
+              }
             }
             await this.loadOlderTurnsUntilPrimaryDialogue(
               this.eventsContainPrimaryDialogue(hydrationEvents),

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -1245,6 +1245,20 @@
     // applyEvent is the event switch proper, split from the sync wrapper so the
     // frame-batched live path (flush) can apply N events and settle once.
     applyEvent(kind, data) {
+      // Staging-replay reachability (prependOlderTurns sets this.stagingReplay):
+      // the replay only ever feeds the kinds eventsFromTurns emits —
+      // USER_INPUT, STEERING_INJECTED, SYSTEM_MESSAGE, SYSTEM_LINE,
+      // ASSISTANT_TEXT_START/DELTA/END, TOOL_CALL_START/OUTPUT_DELTA/END,
+      // REASONING_START/DELTA, ERROR. The document-level side effects in the
+      // OTHER cases (THREAD_STATUS_CHANGED's dispatchEvent/htmx.trigger,
+      // TURN_STARTED/TURN_COMPLETED's htmx.trigger, THREAD_TITLE_CHANGED's
+      // header rewrite, SESSION_START's composer/queue chrome, QUEUE_CHANGED's
+      // queue preview, TASKS_CHANGED's badge + tasks fetch) therefore cannot
+      // fire under stagingReplay and need no guard. The document-level helpers
+      // reachable from the replayable kinds no-op on this.stagingReplay
+      // instead: updateBreadcrumbRollup, refreshTaskBadgeSoon,
+      // renderNeedsYouDock, setComposerAskMode, renderPendingAskDock,
+      // clearPendingAskDock, focusComposer.
       // Every frame from the daemon (incl. reasoning) resets the liveness clock.
       this.lastFrameAt = Date.now();
       switch (kind) {
@@ -3867,6 +3881,11 @@
     // rollup is composed honestly from the worst state we can actually observe
     // here — this session's direct children.
     updateBreadcrumbRollup() {
+      // Document-level: paints the LIVE breadcrumb's rollup chip
+      // ([data-subagent-rollup]) from this.conversation's rows. During staging
+      // replay this.conversation is the detached history div, so its rows
+      // describe the prepended page, not the live session — suppress.
+      if (this.stagingReplay) return;
       const chip = document.querySelector("[data-subagent-rollup]");
       if (!chip) return;
       let failed = 0, unknown = 0;
@@ -4781,6 +4800,11 @@
     },
 
     refreshTaskBadgeSoon() {
+      // Staging replay: historical task cards must not kick the live badge.
+      // The generation bump + /tasks fetch would be wasted anyway —
+      // requestTasks' conversation-identity guard drops the apply once the
+      // live conversation is restored — so no-op here instead.
+      if (this.stagingReplay) return;
       if (!this.sessionId) return;
       this.requestTasks();
     },
@@ -5058,8 +5082,10 @@
       // docks, focus) no-op while this is set so a historical ask_user cannot
       // hijack the LIVE composer.
       this.stagingReplay = true;
+      let replayedEvents = 0;
       try {
         for (const [kind, data] of window.SerfAppwire.eventsFromTurns(turns)) {
+          replayedEvents++;
           this.handleData(kind, data);
         }
       } finally {
@@ -5068,8 +5094,12 @@
         // The replay's own settle (stick → scrollToBottom →
         // clearNewContentPill) kills the live pill debounce timer's underlying
         // timeout; the restored handle alone would never fire. Re-arm it so
-        // the pending count commit still lands.
-        if (saved.newContentCountTimer != null) {
+        // the pending count commit still lands — but only when the replay
+        // actually applied events: a zero-event page never entered the settle,
+        // so the restored timer is still pending and re-arming would orphan it
+        // into a (idempotent but wrong) double-fire.
+        if (replayedEvents > 0 && saved.newContentCountTimer != null) {
+          if (this.newContentCountTimer) clearTimeout(this.newContentCountTimer);
           this.newContentCountTimer = null;
           this.scheduleNewContentCountPaint();
         }

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -187,6 +187,8 @@
       this.appwireThreadId = null;
       this.appwireHydrated = false;
       this.hydrationInProgress = false;
+      this.readerScrolledDuringHydration = false;
+      this.programmaticScroll = false;
       this.activeTurnId = conversationEl.dataset.activeTurnId || "";
       this.state = conversationEl.dataset.state || "ended";
       this.liveSendCap = null;
@@ -842,6 +844,15 @@
       }
       window.SerfAppwire.readThread(sessionId, true, true, true, INITIAL_TURN_WINDOW)
         .then(async (resp) => {
+          // Stale-overlap guard, FIRST: a superseded readThread (its stream was
+          // replaced by a reconnect while the request was in flight) must
+          // return before ANY state/DOM mutation. Without this an H1 resolving
+          // after H2 completed would pass the session/conversation check below,
+          // reset H2's valid transcript, replay into it, and abort on the
+          // LATER liveStream check mid-chunk — leaving hydrationInProgress
+          // stuck true forever (which then no-ops status-visibility refresh
+          // and older-turns paging indefinitely).
+          if (this.liveStream !== appwireStream) return;
           if (this.sessionId !== sessionId || this.conversation !== conversation) return;
           const thread = resp.thread || {};
           // A reconnect can land DURING a chunked hydration: appwireHydrated is
@@ -858,6 +869,9 @@
           // NOT by the staleness aborts below (the superseding hydration may
           // already have set it; clearing here would unguard its replay).
           this.hydrationInProgress = true;
+          // Fresh replay window: any reader scroll from an earlier hydration
+          // must not suppress THIS settle.
+          this.readerScrolledDuringHydration = false;
           // The replay below is chunked and yields to the event loop between
           // slices, so the window in which live notifications could interleave
           // into the half-rendered transcript is no longer microscopic. Gate
@@ -928,9 +942,18 @@
           } finally {
             this.suppressScrollSettle = false;
           }
-          this.scrollToBottom();
+          // Reader scroll intent: a scroll event during the replay means the
+          // reader chose their position — the settle must not yank them back
+          // to the bottom. Programmatic scrolls (marked) never set the flag.
+          if (!this.readerScrolledDuringHydration) this.scrollToBottom();
+          this.readerScrolledDuringHydration = false;
         })
         .catch((err) => {
+          // Same stale-overlap guard as the .then entry: a superseded
+          // readThread's rejection must not clear the NEW stream's state
+          // (clearAppwireStream would kill live delivery and the banner would
+          // lie about a healthy connection).
+          if (this.liveStream !== appwireStream) return;
           if (this.sessionId !== sessionId || this.conversation !== conversation) return;
           this.hydrationInProgress = false;
           this.suppressScrollSettle = false;
@@ -1183,6 +1206,7 @@
       if (!this.conversation) return;
       this.cancelFrameFlush();
       this.suppressScrollSettle = false;
+      this.readerScrolledDuringHydration = false;
       this.frameQueue = [];
       this.frameGeneration = (this.frameGeneration || 0) + 1;
       this.discardPendingAsk();
@@ -4859,7 +4883,15 @@
     },
 
     scrollToBottom() {
-      this.conversation.scrollTop = this.conversation.scrollHeight;
+      // Marked programmatic: the scroll listener must not read this as reader
+      // intent during hydration (the marker also guards any future
+      // programmatic scroll that CAN land inside a replay window).
+      this.programmaticScroll = true;
+      try {
+        this.conversation.scrollTop = this.conversation.scrollHeight;
+      } finally {
+        this.programmaticScroll = false;
+      }
       // Once parked at the bottom there is no unseen content, so the
       // new-content pill (and its counter) must reset.
       this.clearNewContentPill();
@@ -4932,6 +4964,13 @@
       if (!el.__serfScrollPillBound) {
         el.__serfScrollPillBound = true;
         el.addEventListener("scroll", () => {
+          // Reader intent during hydration: a genuine scroll mid-replay means
+          // the reader took control of the position — the hydration-end settle
+          // must not yank them to the bottom. Programmatic scrolls (prepend
+          // compensation, the settle itself) are marked and never set this.
+          if (this.hydrationInProgress && !this.programmaticScroll) {
+            this.readerScrolledDuringHydration = true;
+          }
           if (this.scrollAffordanceTick) return;
           this.scrollAffordanceTick = true;
           this.scheduleFrame(() => {

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -4840,6 +4840,15 @@
       while (staging.firstChild) frag.appendChild(staging.firstChild);
       sc.insertBefore(frag, sc.firstChild);
       sc.scrollTop = beforeTop + (sc.scrollHeight - beforeHeight);
+      // Second settle: freshly prepended entries may sit at estimated sizes
+      // (content-visibility). After the browser lays out the near-viewport
+      // ones, correct the residual drift so the reader's anchor holds.
+      const settledHeight = sc.scrollHeight;
+      this.scheduleFrame(() => {
+        if (!sc.isConnected) return;
+        const drift = sc.scrollHeight - settledHeight;
+        if (drift) sc.scrollTop += drift;
+      });
     },
 
     // noteNewContent records that `added` new transcript entries rendered while

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -1067,27 +1067,34 @@
     },
 
     handleData(kind, data) {
-      this.handle(kind, { data: JSON.stringify(data || {}) });
+      this.handle(kind, { data: data || {} });
     },
 
     handle(kind, ev) {
-      // Every frame from the daemon (incl. reasoning) resets the liveness clock.
-      this.lastFrameAt = Date.now();
       // Buffer only during synchronous initialization. Task descriptions are
       // auxiliary metadata and must never gate transcript replay.
       if (!this.descriptionsReady && this.eventBuffer) {
         this.eventBuffer.push([kind, ev]);
         return;
       }
+      let data = {};
+      try { data = typeof ev.data === "string" ? JSON.parse(ev.data) : (ev.data || {}); } catch (e) {}
       // Measure before the DOM mutation: only stick to the bottom if the reader
       // is already there, so streaming frames don't yank them off history.
-      const stick = this.isNearBottom();
+      const stick = this.suppressScrollSettle ? false : this.isNearBottom();
       // Count rendered transcript entries before the switch so we can tell
       // whether this frame actually appended visible content (suppressed/no-op
       // events leave the count unchanged) — the trigger for the new-content pill.
       const entriesBefore = this.conversation ? this.conversation.children.length : 0;
-      let data = {};
-      try { data = JSON.parse(ev.data); } catch (e) {}
+      this.applyEvent(kind, data);
+      this.settleFrame(stick, entriesBefore);
+    },
+
+    // applyEvent is the event switch proper, split from the sync wrapper so the
+    // frame-batched live path (flush) can apply N events and settle once.
+    applyEvent(kind, data) {
+      // Every frame from the daemon (incl. reasoning) resets the liveness clock.
+      this.lastFrameAt = Date.now();
       switch (kind) {
         case "THREAD_STATUS_CHANGED":
           {
@@ -1421,14 +1428,26 @@
           // to avoid duplicates.
           break;
       }
-      if (stick) {
-        this.scrollToBottom();
-      } else {
-        // Reader is up in history: if this frame rendered new entries, surface
-        // the floating "↓ N new" affordance instead of yanking the viewport.
-        const added = this.conversation ? this.conversation.children.length - entriesBefore : 0;
-        if (added > 0) this.noteNewContent(added);
+    },
+
+    // settleFrame runs the post-mutation work that used to live at the bottom of
+    // handle(): render coalesced assistant/reasoning updates (Tasks 4, 8), count
+    // new entries for the pill, and stick to the bottom when the reader was there.
+    settleFrame(stick, entriesBefore) {
+      if (this.dirtyAssistantMessages && this.dirtyAssistantMessages.size) {
+        for (const m of this.dirtyAssistantMessages) this.renderAssistantMessage(m, m.textBuf);
+        this.dirtyAssistantMessages.clear();
       }
+      if (this.reasoningPreviewDirty) {
+        this.reasoningPreviewDirty = false;
+        this.updateReasoningPreview();
+      }
+      if (!this.conversation) return;
+      // Reader is up in history: if this frame rendered new entries, surface
+      // the floating "↓ N new" affordance instead of yanking the viewport.
+      const added = this.conversation.children.length - entriesBefore;
+      if (added > 0) this.noteNewContent(added);
+      if (stick && !this.suppressScrollSettle) this.scrollToBottom();
     },
 
     // appendContextCompaction renders the context-compaction lifecycle event

--- a/cmd/serf-hub/assets/style.css
+++ b/cmd/serf-hub/assets/style.css
@@ -1613,6 +1613,15 @@ body.app[data-sidebar-rail] .archive-btn { display: none; }
   line-height: var(--leading-normal);
 }
 
+/* Browser-native windowing: off-screen transcript entries skip layout/paint.
+   `auto` reuses each entry's last-rendered size, so scroll geometry is exact
+   for anything rendered once; only never-rendered deep history uses the
+   estimate (prepend corrects it on the next frame). */
+.conversation > * {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 240px;
+}
+
 /* Safety net: no machine-text block may force the whole transcript column to
    scroll sideways. Any <pre> in the conversation is capped to its container and
    given its own contained horizontal scroll, so a long unbroken line scrolls

--- a/cmd/serf-hub/assets/style.css
+++ b/cmd/serf-hub/assets/style.css
@@ -2409,6 +2409,10 @@ button.composer-model-value .caret { color: var(--text-dim); }
    tree and screen readers announced "▍" on every chunk. */
 .assistant-message .streaming-tail .streaming-caret {
   color: var(--accent);
+  /* The one soft streaming-cursor breathe the design system allows: same
+     think-breathe keyframe on --pulse-cycle as the thinking spark; the
+     universal prefers-reduced-motion collapse (§1.5) makes it instant. */
+  animation: think-breathe var(--pulse-cycle) infinite;
 }
 
 /* Thinking — the quietest transcript entry (design-system §2.5, §4). A reset

--- a/cmd/serf-hub/assets/style.css
+++ b/cmd/serf-hub/assets/style.css
@@ -2404,8 +2404,10 @@ button.composer-model-value .caret { color: var(--text-dim); }
   white-space: pre-wrap;
   color: var(--text);
 }
-.assistant-message.streaming .streaming-tail::after {
-  content: "▍";
+/* The streaming caret is a real aria-hidden span (renderer.streamingCaret),
+   not a ::after pseudo-element — pseudo content lands in the accessibility
+   tree and screen readers announced "▍" on every chunk. */
+.assistant-message .streaming-tail .streaming-caret {
   color: var(--accent);
 }
 

--- a/cmd/serf-hub/assets/style.css
+++ b/cmd/serf-hub/assets/style.css
@@ -2387,6 +2387,19 @@ button.composer-model-value .caret { color: var(--text-dim); }
 .assistant-message:hover .turn-meta,
 .assistant-message:focus-within .turn-meta { opacity: 1; }
 
+/* Frozen-head/raw-tail streaming (long messages): the tail is plain pre-wrap
+   text with the one sanctioned streaming caret; finalization replaces it with
+   parsed markdown. */
+.assistant-message .streaming-tail {
+  display: block;
+  white-space: pre-wrap;
+  color: var(--text);
+}
+.assistant-message.streaming .streaming-tail::after {
+  content: "▍";
+  color: var(--accent);
+}
+
 /* Thinking — the quietest transcript entry (design-system §2.5, §4). A reset
    <button> that, while streaming, occupies a fixed-height reserved slot showing
    a one-line teleprompter tail of the live reasoning (mockup #5 alt A) so the

--- a/cmd/serf-hub/assets/style.css
+++ b/cmd/serf-hub/assets/style.css
@@ -2763,6 +2763,13 @@ details.tool-body[open] > summary::before,
   color: var(--text-dim);
 }
 .terminal-footer-bad { color: var(--error); }
+/* Streaming tool output: one clamped, tail-anchored pane until bodyEnd builds
+   the fold chrome. */
+.tool-body.streaming .terminal-output,
+.tool-body.streaming .read-tool-preview {
+  max-height: 16em;
+  overflow-y: auto;
+}
 .cheap-tool-args { margin: var(--space-2) 0 0; padding: var(--space-3) var(--space-3); background: var(--bg); border-radius: var(--radius-md); font-family: var(--font-mono); font-size: var(--text-sm); line-height: var(--leading-tight); color: var(--text-muted); white-space: pre-wrap; overflow-wrap: anywhere; }
 .cheap-tool-output { margin: var(--space-2) 0 0; padding: var(--space-3) var(--space-3); background: var(--bg); border-radius: var(--radius-md); font-family: var(--font-mono); font-size: var(--text-sm); line-height: var(--leading-tight); color: var(--text); white-space: pre-wrap; overflow-wrap: anywhere; }
 .read-tool-body .cheap-tool-output { margin-top: 0; }

--- a/cmd/serf-hub/jstest/test-appwire-live-session-updates.js
+++ b/cmd/serf-hub/jstest/test-appwire-live-session-updates.js
@@ -113,6 +113,7 @@ async function run() {
     turnId: "turn_1",
     item: { type: "userMessage", id: "item_user_1", turnId: "turn_1", text: "ping", status: "completed" },
   });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
   pass(userMessages().filter((text) => text === "ping").length === 1, "AppWire user-message notification should not duplicate the sent prompt");
 
   notificationHandler("item/started", {
@@ -127,6 +128,7 @@ async function run() {
     itemId: "item_1",
     delta: "hello from live turn",
   });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
   await new Promise((resolve) => setTimeout(resolve, 10));
 
   const assistant = conv.querySelector(".assistant-message");
@@ -137,6 +139,7 @@ async function run() {
     ref: "local:thread-live",
     status: { type: "active" },
   });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
   await new Promise((resolve) => setTimeout(resolve, 10));
   pass(conv.dataset.state === "active", "active status did not update conversation state");
   pass(window.document.querySelector(".send-btn").getAttribute("data-capability-send") === "false",
@@ -150,6 +153,7 @@ async function run() {
     ref: "local:thread-live",
     turn: { id: "turn_1", status: "inProgress" },
   });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
   await new Promise((resolve) => setTimeout(resolve, 10));
   pass(!window.document.querySelector('[data-action-trigger="interrupt"]').disabled, "interrupt should enable when a turn starts");
 
@@ -158,6 +162,7 @@ async function run() {
     ref: "local:thread-live",
     status: { type: "active" },
   });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
   await new Promise((resolve) => setTimeout(resolve, 10));
   pass(conv.dataset.state === "active", "active status did not update conversation state");
   pass(!window.document.querySelector('[data-action-trigger="interrupt"]').disabled, "active status should keep interrupt enabled while a turn is active");
@@ -167,6 +172,7 @@ async function run() {
     ref: "local:thread-live",
     turn: { id: "turn_1", status: "completed" },
   });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
   pass(window.document.querySelector('[data-action-trigger="interrupt"]').disabled, "interrupt should disable when the active turn completes");
 
   notificationHandler("thread/status/changed", {
@@ -174,6 +180,7 @@ async function run() {
     ref: "local:thread-live",
     status: { type: "idle" },
   });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
   pass(conv.dataset.state === "idle", "idle status did not update conversation state");
   pass(window.document.querySelector('[data-action-trigger="interrupt"]').disabled, "interrupt should disable while idle");
   pass(!window.document.querySelector('[data-action-trigger="shutdown"]').disabled, "shutdown should stay enabled while idle");

--- a/cmd/serf-hub/jstest/test-appwire-queue-reconcile.js
+++ b/cmd/serf-hub/jstest/test-appwire-queue-reconcile.js
@@ -85,6 +85,33 @@ require("./load-renderer").evalRenderer(window);
   assert.equal(conv.querySelectorAll(".optimistic-pending").length, 0,
     "image-only authoritative user items should reconcile pending turn/start chips");
 
+  // Multi-notification flush: two queued turns with DIFFERENT texts confirm
+  // in one batched frame. Reconcile must run per notification, in queue
+  // order — after that notification's events applied, before the next one.
+  const reconcileOrder = [];
+  const realTryReconcile = pending.tryReconcile;
+  pending.tryReconcile = (method, params) => {
+    reconcileOrder.push(method + ":" + ((params && params.text) || ""));
+    return realTryReconcile(method, params);
+  };
+  pending.register({ method: "turn/start", text: "first queued turn" });
+  pending.register({ method: "turn/start", text: "second queued turn" });
+  assert.equal(conv.querySelectorAll(".optimistic-pending").length, 2, "expected two pending turn chips");
+  notify("item/completed", {
+    threadId: "01TEST",
+    item: { type: "userMessage", text: "first queued turn", images: [] },
+  });
+  notify("item/completed", {
+    threadId: "01TEST",
+    item: { type: "userMessage", text: "second queued turn", images: [] },
+  });
+  assert.deepEqual(reconcileOrder, [], "no reconcile before the frame flushes");
+  window.SerfRenderer.flush();
+  assert.deepEqual(reconcileOrder, ["turn/start:first queued turn", "turn/start:second queued turn"],
+    "reconcile must run per notification in queue order, got " + JSON.stringify(reconcileOrder));
+  assert.equal(conv.querySelectorAll(".optimistic-pending").length, 0,
+    "both placeholders reconcile inside the single flush");
+
   console.log("PASS test-appwire-queue-reconcile.js");
   process.exit(0);
 })().catch((err) => {

--- a/cmd/serf-hub/jstest/test-appwire-queue-reconcile.js
+++ b/cmd/serf-hub/jstest/test-appwire-queue-reconcile.js
@@ -70,6 +70,7 @@ require("./load-renderer").evalRenderer(window);
     threadId: "01TEST",
     queue: { depth: 1, preview: ["queued as string"] },
   });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
 
   assert.equal(pendingQueueList.querySelectorAll(".optimistic-pending").length, 0,
     "string queue previews should reconcile pending queue chips");
@@ -80,6 +81,7 @@ require("./load-renderer").evalRenderer(window);
     threadId: "01TEST",
     item: { type: "userMessage", text: "", images: [{ type: "image", name: "shot.png" }] },
   });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
   assert.equal(conv.querySelectorAll(".optimistic-pending").length, 0,
     "image-only authoritative user items should reconcile pending turn/start chips");
 

--- a/cmd/serf-hub/jstest/test-input-area.js
+++ b/cmd/serf-hub/jstest/test-input-area.js
@@ -360,6 +360,7 @@ async function checkReconnectsLiveAfterSendOnEndedSession() {
     ref: "local:01TEST",
     item: { type: "agentMessage", id: "msg_resume" },
   });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
   await new Promise(r => setTimeout(r, 10));
 
   pass(conv.textContent.includes("resume me"), "expected resumed user message to render without refresh");

--- a/cmd/serf-hub/jstest/test-renderer-communicate-dedup.js
+++ b/cmd/serf-hub/jstest/test-renderer-communicate-dedup.js
@@ -1,7 +1,15 @@
 // A communicate tool call landing while its agentMessage is still streaming
 // (raw tail mode) must be deduped against the SOURCE buffer, not rendered text.
+//
+// Case 2 is the regression the renderer fix exists for: a delta arriving
+// AFTER the 4096-char crossing lives in the raw `.streaming-tail` as
+// unparsed markdown ("**bold tail**"), so the old rendered-DOM comparison
+// (last.textContent vs rendered candidate) can never match — the tail keeps
+// the asterisks while the rendered candidate drops them.
 const { JSDOM } = require("jsdom");
-const dom = new JSDOM(`<!DOCTYPE html><html><body>
+
+function makeRenderer() {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>
   <div class="workspace-actions">
     <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
     <button data-details-trigger><span class="panel-toggle-label">details</span></button>
@@ -10,24 +18,54 @@ const dom = new JSDOM(`<!DOCTYPE html><html><body>
   <div id="conversation" data-session-id="01TEST" data-state="active"></div>
   <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
 </body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
-const { window } = dom;
-window.marked = { parse: (t) => "<p>" + t + "</p>" };
-window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
-require("./load-renderer").evalRenderer(window);
-const conv = window.document.getElementById("conversation");
-window.SerfRenderer.init(conv);
-const R = window.SerfRenderer;
+  const { window } = dom;
+  // Mimic real markdown closely enough for this test: **bold** becomes
+  // <strong>bold</strong>, so rendered textContent drops the asterisks while
+  // a raw streaming tail keeps them.
+  window.marked = { parse: (t) => "<p>" + String(t).replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>") + "</p>" };
+  window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+  require("./load-renderer").evalRenderer(window);
+  const conv = window.document.getElementById("conversation");
+  window.SerfRenderer.init(conv);
+  return { R: window.SerfRenderer, conv };
+}
+
 const failures = [];
 const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
 
 (async () => {
-  await new Promise((r) => setTimeout(r, 30));
-  R.handleData("TURN_STARTED", { turnId: "t1" });
-  R.handleData("ASSISTANT_TEXT_START", {});
-  const text = "x".repeat(4100) + " **bold tail**";
-  R.handleData("ASSISTANT_TEXT_DELTA", { delta: text }); // switches to raw-tail mode
-  pass(R.lastElementIsAssistantText(text) === true,
-    "dedup matches the streaming message by source, raw tail included");
+  // Case 1: a single delta that crosses the 4KB threshold. The crossing delta
+  // itself is rendered into the frozen head, so the tail is empty.
+  {
+    const { R } = makeRenderer();
+    await new Promise((r) => setTimeout(r, 30));
+    R.handleData("TURN_STARTED", { turnId: "t1" });
+    R.handleData("ASSISTANT_TEXT_START", {});
+    const text = "x".repeat(4100) + " **bold tail**";
+    R.handleData("ASSISTANT_TEXT_DELTA", { delta: text }); // switches to raw-tail mode
+    pass(R.lastElementIsAssistantText(text) === true,
+      "case 1: dedup matches the streaming message by source, raw tail included");
+  }
+
+  // Case 2: a post-crossing delta lands in the raw .streaming-tail as
+  // unparsed markdown. The old rendered-DOM comparison returns false here
+  // (tail keeps "**", rendered candidate drops them); source-buffer dedup
+  // must still match.
+  {
+    const { R, conv } = makeRenderer();
+    await new Promise((r) => setTimeout(r, 30));
+    R.handleData("TURN_STARTED", { turnId: "t1" });
+    R.handleData("ASSISTANT_TEXT_START", {});
+    R.handleData("ASSISTANT_TEXT_DELTA", { delta: "x".repeat(4100) }); // crosses -> frozen head + tail span
+    R.handleData("ASSISTANT_TEXT_DELTA", { delta: " **bold tail**" }); // streams raw into the tail
+    const tail = conv.querySelector(".streaming-tail");
+    pass(!!tail, "case 2: a raw .streaming-tail exists after the post-crossing delta");
+    pass(tail && tail.textContent.includes("**bold tail**"),
+      "case 2: the tail holds unparsed markdown (asterisks intact)");
+    pass(R.lastElementIsAssistantText("x".repeat(4100) + " **bold tail**") === true,
+      "case 2: dedup matches by source buffer even with a raw markdown tail");
+  }
+
   if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
   console.log("PASS: communicate dedup compares against the source buffer while streaming");
   process.exit(0);

--- a/cmd/serf-hub/jstest/test-renderer-communicate-dedup.js
+++ b/cmd/serf-hub/jstest/test-renderer-communicate-dedup.js
@@ -35,7 +35,7 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
 
 (async () => {
   // Case 1: a single delta that crosses the 4KB threshold. The crossing delta
-  // itself is rendered into the frozen head, so the tail is empty.
+  // streams raw into the fresh tail; the (unrendered) head freezes as-is.
   {
     const { R } = makeRenderer();
     await new Promise((r) => setTimeout(r, 30));

--- a/cmd/serf-hub/jstest/test-renderer-communicate-dedup.js
+++ b/cmd/serf-hub/jstest/test-renderer-communicate-dedup.js
@@ -1,0 +1,34 @@
+// A communicate tool call landing while its agentMessage is still streaming
+// (raw tail mode) must be deduped against the SOURCE buffer, not rendered text.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+window.marked = { parse: (t) => "<p>" + t + "</p>" };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+window.SerfRenderer.init(conv);
+const R = window.SerfRenderer;
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  R.handleData("TURN_STARTED", { turnId: "t1" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  const text = "x".repeat(4100) + " **bold tail**";
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: text }); // switches to raw-tail mode
+  pass(R.lastElementIsAssistantText(text) === true,
+    "dedup matches the streaming message by source, raw tail included");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: communicate dedup compares against the source buffer while streaming");
+  process.exit(0);
+})();

--- a/cmd/serf-hub/jstest/test-renderer-delta-coalescing.js
+++ b/cmd/serf-hub/jstest/test-renderer-delta-coalescing.js
@@ -1,0 +1,44 @@
+// Assistant deltas must coalesce to at most one marked.parse per settle, not
+// one parse per delta event.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+let parses = 0;
+window.marked = { parse: (t) => { parses++; return t; } };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+window.SerfRenderer.init(conv);
+const R = window.SerfRenderer;
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  R.handleData("TURN_STARTED", { turnId: "t1" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  parses = 0;
+  // Direct internal call: five deltas, one settle (mirrors what the batched
+  // flush does per frame; handleData settles per call by design).
+  R.appendAssistantDelta("a");
+  R.appendAssistantDelta("b");
+  R.appendAssistantDelta("c");
+  R.appendAssistantDelta("d");
+  R.appendAssistantDelta("e");
+  pass(parses === 0, "no parse before settle (got " + parses + ")");
+  R.settleFrame(false, conv.children.length);
+  pass(parses === 1, "exactly one parse per settle for N deltas (got " + parses + ")");
+  const el = conv.querySelector(".assistant-message");
+  pass(el && el.textContent === "abcde", "coalesced content renders");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: assistant deltas coalesce to one parse per settle");
+  process.exit(0);
+})();

--- a/cmd/serf-hub/jstest/test-renderer-diff-delta-coalescing.js
+++ b/cmd/serf-hub/jstest/test-renderer-diff-delta-coalescing.js
@@ -1,9 +1,8 @@
-// Diff renderers (edit/write/apply_patch) rebuild the whole diff DOM per
-// bodyDelta call, so output deltas for one diff tool inside a single batched
-// flush must coalesce to ONE render per frame (last output wins), drained at
-// settleFrame. Cheap single-textContent renderers (shell) still stream per
-// delta, and a pending coalesced delta must never clobber bodyEnd's final
-// render at TOOL_CALL_END.
+// Every tool renderer's bodyDelta rewrites the whole body (diffs rebuild the
+// DOM; shell replaces textContent and reads scrollHeight), so output deltas
+// for one tool inside a single batched flush must coalesce to ONE render per
+// frame (last output wins), drained at settleFrame. A pending coalesced delta
+// must never clobber bodyEnd's final render at TOOL_CALL_END.
 const { JSDOM } = require("jsdom");
 const dom = new JSDOM(`<!DOCTYPE html><html><body>
   <div class="workspace-actions">
@@ -60,7 +59,8 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   pass(pre.textContent.includes("+final") && !pre.textContent.includes("stale-pending"),
     "bodyEnd's final output stands after the settle");
 
-  // Cheap single-textContent renderers are untouched: shell still streams per delta.
+  // Cheap single-textContent renderers coalesce the same way: two shell
+  // deltas in one frame render once at settle, with the accumulated output.
   R.handleData("TOOL_CALL_START", { call_id: "s1", tool_name: "shell", arguments_json: JSON.stringify({ command: "make" }) });
   const shellRenderer = window.SerfRendererInternal.toolRendererFor("shell");
   let shellRenders = 0;
@@ -68,9 +68,13 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   shellRenderer.bodyDelta = (state, out) => { shellRenders++; return realShellDelta(state, out); };
   R.applyEvent("TOOL_CALL_OUTPUT_DELTA", { call_id: "s1", delta: "a" });
   R.applyEvent("TOOL_CALL_OUTPUT_DELTA", { call_id: "s1", delta: "b" });
-  pass(shellRenders === 2, "shell bodyDelta stays per-delta, not coalesced (got " + shellRenders + ")");
+  pass(shellRenders === 0, "shell bodyDelta defers mid-frame like every other renderer (got " + shellRenders + ")");
+  R.settleFrame(false, conv.children.length);
+  pass(shellRenders === 1, "shell coalesces to one write per frame, last output wins (got " + shellRenders + ")");
+  const shellPre = conv.querySelector(".tool-call.shell pre");
+  pass(shellPre && shellPre.textContent === "ab", "the shell drain writes the accumulated text (got " + JSON.stringify(shellPre && shellPre.textContent) + ")");
 
   if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
-  console.log("PASS: diff output deltas coalesce to one render per frame; cheap renderers unaffected");
+  console.log("PASS: tool output deltas coalesce to one render per frame per call, last output wins");
   process.exit(0);
 })();

--- a/cmd/serf-hub/jstest/test-renderer-diff-delta-coalescing.js
+++ b/cmd/serf-hub/jstest/test-renderer-diff-delta-coalescing.js
@@ -74,6 +74,18 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   const shellPre = conv.querySelector(".tool-call.shell pre");
   pass(shellPre && shellPre.textContent === "ab", "the shell drain writes the accumulated text (got " + JSON.stringify(shellPre && shellPre.textContent) + ")");
 
+  // Key-mismatch: the delta event carries BOTH call_id and item_id (the old
+  // map keyed on call_id), but TOOL_CALL_END arrives carrying only item_id —
+  // the alias resolves the same tool state, yet a string-keyed delete misses.
+  // The stale deferred entry must not re-render the delta buffer over
+  // bodyEnd's authoritative output at the settle.
+  R.handleData("TOOL_CALL_START", { call_id: "w2", item_id: "it2", tool_name: "write_file", arguments_json: JSON.stringify({ file_path: "/b.js", content: "x" }) });
+  R.applyEvent("TOOL_CALL_OUTPUT_DELTA", { call_id: "w2", item_id: "it2", delta: "+stale-mismatch\n" });
+  R.handleData("TOOL_CALL_END", { item_id: "it2", tool_name: "write_file", output: "+final-mismatch\n" });
+  const pre2 = conv.querySelectorAll(".write-body pre.diff-body")[1];
+  pass(pre2 && pre2.textContent.includes("+final-mismatch") && !pre2.textContent.includes("stale-mismatch"),
+    "id-mismatched pending delta dropped at finalize — bodyEnd output stands (got " + JSON.stringify(pre2 && pre2.textContent) + ")");
+
   if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
   console.log("PASS: tool output deltas coalesce to one render per frame per call, last output wins");
   process.exit(0);

--- a/cmd/serf-hub/jstest/test-renderer-diff-delta-coalescing.js
+++ b/cmd/serf-hub/jstest/test-renderer-diff-delta-coalescing.js
@@ -1,0 +1,76 @@
+// Diff renderers (edit/write/apply_patch) rebuild the whole diff DOM per
+// bodyDelta call, so output deltas for one diff tool inside a single batched
+// flush must coalesce to ONE render per frame (last output wins), drained at
+// settleFrame. Cheap single-textContent renderers (shell) still stream per
+// delta, and a pending coalesced delta must never clobber bodyEnd's final
+// render at TOOL_CALL_END.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+window.marked = { parse: (t) => t };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+window.SerfRenderer.init(conv);
+const R = window.SerfRenderer;
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  R.handleData("TURN_STARTED", { turnId: "t1" });
+  R.handleData("TOOL_CALL_START", { call_id: "w1", tool_name: "write_file", arguments_json: JSON.stringify({ file_path: "/a.js", content: "x" }) });
+
+  // Spy on the write renderer's bodyDelta (the renderDiff-based path).
+  const writeRenderer = window.SerfRendererInternal.toolRendererFor("write_file");
+  let renders = 0;
+  const realBodyDelta = writeRenderer.bodyDelta;
+  writeRenderer.bodyDelta = (state, out) => { renders++; return realBodyDelta(state, out); };
+
+  // Two deltas inside one frame: applyEvent directly, settleFrame once
+  // (mirrors what the batched live flush does per frame).
+  R.applyEvent("TOOL_CALL_OUTPUT_DELTA", { call_id: "w1", delta: "+line1\n" });
+  R.applyEvent("TOOL_CALL_OUTPUT_DELTA", { call_id: "w1", delta: "+line2\n" });
+  pass(renders === 0, "no diff render before the frame settles (got " + renders + ")");
+  R.settleFrame(false, conv.children.length);
+  pass(renders === 1, "two deltas in one flush coalesce to one diff render (got " + renders + ")");
+  const pre = conv.querySelector(".write-body pre.diff-body");
+  pass(pre && pre.textContent.includes("+line1") && pre.textContent.includes("+line2"),
+    "the drain renders the full accumulated output");
+
+  // The next frame renders again — coalescing is per frame, not a latch.
+  R.applyEvent("TOOL_CALL_OUTPUT_DELTA", { call_id: "w1", delta: "+line3\n" });
+  R.settleFrame(false, conv.children.length);
+  pass(renders === 2, "next frame renders the next delta batch (got " + renders + ")");
+  pass(pre.textContent.includes("+line3"), "second drain applied");
+
+  // A still-pending coalesced delta must not clobber bodyEnd's authoritative
+  // final render when TOOL_CALL_END lands in the same frame.
+  R.applyEvent("TOOL_CALL_OUTPUT_DELTA", { call_id: "w1", delta: "+stale-pending\n" });
+  R.handleData("TOOL_CALL_END", { call_id: "w1", tool_name: "write_file", output: "+final\n" });
+  pass(renders === 2, "pending delta dropped at finalize — no stale re-render at settle (got " + renders + ")");
+  pass(pre.textContent.includes("+final") && !pre.textContent.includes("stale-pending"),
+    "bodyEnd's final output stands after the settle");
+
+  // Cheap single-textContent renderers are untouched: shell still streams per delta.
+  R.handleData("TOOL_CALL_START", { call_id: "s1", tool_name: "shell", arguments_json: JSON.stringify({ command: "make" }) });
+  const shellRenderer = window.SerfRendererInternal.toolRendererFor("shell");
+  let shellRenders = 0;
+  const realShellDelta = shellRenderer.bodyDelta;
+  shellRenderer.bodyDelta = (state, out) => { shellRenders++; return realShellDelta(state, out); };
+  R.applyEvent("TOOL_CALL_OUTPUT_DELTA", { call_id: "s1", delta: "a" });
+  R.applyEvent("TOOL_CALL_OUTPUT_DELTA", { call_id: "s1", delta: "b" });
+  pass(shellRenders === 2, "shell bodyDelta stays per-delta, not coalesced (got " + shellRenders + ")");
+
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: diff output deltas coalesce to one render per frame; cheap renderers unaffected");
+  process.exit(0);
+})();

--- a/cmd/serf-hub/jstest/test-renderer-file-mirror.js
+++ b/cmd/serf-hub/jstest/test-renderer-file-mirror.js
@@ -1,0 +1,20 @@
+// The no-bundler renderer bundle must load in the same dependency order in the
+// browser (templates/app.html) and in tests (load-renderer.js RENDERER_FILES).
+// A module added to one list but not the other breaks either the app or every
+// renderer test — this mirror makes the drift a loud failure.
+const fs = require("fs");
+const path = require("path");
+const assert = require("assert");
+const { RENDERER_FILES } = require("./load-renderer");
+
+const appHtml = fs.readFileSync(path.resolve(__dirname, "../templates/app.html"), "utf8");
+const srcs = [...appHtml.matchAll(/<script[^>]+src="([^"]+)"/g)].map((m) => m[1]);
+const scriptNames = srcs.map((s) => s.split("/").pop().replace("{{assetv}}", ""));
+const mirrored = scriptNames.filter((n) => RENDERER_FILES.includes(n));
+assert.deepStrictEqual(
+  mirrored,
+  RENDERER_FILES,
+  "templates/app.html must load exactly the RENDERER_FILES, in the same order: " +
+    JSON.stringify({ mirrored, RENDERER_FILES })
+);
+console.log("PASS: app.html script order mirrors RENDERER_FILES");

--- a/cmd/serf-hub/jstest/test-renderer-frame-batching.js
+++ b/cmd/serf-hub/jstest/test-renderer-frame-batching.js
@@ -1,0 +1,57 @@
+// Live notifications batch: N deliveries before a flush apply together with a
+// single settle; flush() drains synchronously for tests; a transcript reset
+// invalidates queued events.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+window.marked = { parse: (t) => t };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+const R = window.SerfRenderer;
+R.init(conv);
+// appwire.js is not part of the renderer bundle; stub the one surface the
+// live delivery path touches (the test overrides eventsFromNotification).
+window.SerfAppwire = { eventsFromNotification: () => [] };
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  R.appwireHydrated = true; // live mode: deliveries batch
+  pass(typeof R.flush === "function", "flush() exists");
+  pass(Array.isArray(R.frameQueue), "frameQueue exists");
+
+  // Simulate the live delivery path with a stubbed projector.
+  const realEvents = window.SerfAppwire.eventsFromNotification;
+  window.SerfAppwire.eventsFromNotification = (method, params) => {
+    if (method === "test/delta") return [["ASSISTANT_TEXT_DELTA", { delta: params.delta }]];
+    return realEvents ? realEvents(method, params) : [];
+  };
+  R.handleData("TURN_STARTED", { turnId: "t1" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  // Queue three deltas via the internal enqueue used by deliverNotification.
+  R.enqueueLiveNotification("test/delta", { delta: "a" });
+  R.enqueueLiveNotification("test/delta", { delta: "b" });
+  R.enqueueLiveNotification("test/delta", { delta: "c" });
+  pass(conv.querySelector(".assistant-message").textContent === "", "nothing renders before flush");
+  R.flush();
+  pass(conv.querySelector(".assistant-message").textContent === "abc", "flush applies all queued events");
+
+  // Generation guard: queued events from before a reset never land.
+  R.enqueueLiveNotification("test/delta", { delta: "STALE" });
+  R.resetTranscriptReplay();
+  R.flush();
+  pass(!conv.textContent.includes("STALE"), "reset invalidates the queue");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: live notifications batch per frame; reset invalidates the queue");
+  process.exit(0);
+})();

--- a/cmd/serf-hub/jstest/test-renderer-hydration-chunked.js
+++ b/cmd/serf-hub/jstest/test-renderer-hydration-chunked.js
@@ -90,7 +90,13 @@ const waitFor = async (cond, timeoutMs) => {
 
 (async () => {
   // ── (a) responsiveness + (b) ordering ────────────────────────────────────
-  const TOTAL = 2000;
+  // 300 events crosses the 150-event chunk boundary exactly once: enough to
+  // prove the replay yields mid-stream (the timer below fires after the first
+  // slice with the rest still pending) without paying for thousands of DOM
+  // appends. The responsiveness assertions stay deterministic: the timer is
+  // scheduled before the replay's first yield, so it always observes exactly
+  // one rendered slice (150 < TOTAL).
+  const TOTAL = 300;
   readThreadImpl = (sessionId) => Promise.resolve(threadWith(sessionId, userEvents("event-", TOTAL)));
   R.init(conversation);
 
@@ -162,7 +168,7 @@ const waitFor = async (cond, timeoutMs) => {
     "session-C transcript is exactly its own hydration");
 
   // ── (d) reconnect: buffered live events replay after re-hydration ────────
-  const RE_EVENTS = 400;
+  const RE_EVENTS = 300;
   readThreadImpl = (sessionId) => Promise.resolve(threadWith(sessionId, userEvents("re-event-", RE_EVENTS)));
   pass(R.appwireHydrated === true, "precondition: stream hydrated before reconnect");
   R.connectAppwire(); // reconnect: re-reads the thread and re-hydrates

--- a/cmd/serf-hub/jstest/test-renderer-hydration-chunked.js
+++ b/cmd/serf-hub/jstest/test-renderer-hydration-chunked.js
@@ -1,0 +1,212 @@
+// Hydration replay must not run as one giant blocking task: the readThread
+// .then loop is chunked, yielding a macrotask every slice so a setTimeout(0)
+// scheduled before driving hydration fires mid-replay. Live notifications
+// arriving during the (now wider) hydration window must buffer and replay
+// AFTER the hydrated content, and a session swap mid-chunk must abort cleanly.
+const assert = require("assert");
+const { JSDOM } = require("jsdom");
+
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST">
+    <span class="status-dot" data-state="active"></span>
+  </header>
+  <div class="conversation" id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <div id="input-status" class="input-status">
+    <span class="status-item liveness-inline" data-liveness hidden></span>
+  </div>
+</body></html>`, {
+  runScripts: "outside-only",
+  pretendToBeVisual: true,
+  url: "http://127.0.0.1:9180/s/01TEST",
+});
+
+const { window } = dom;
+window.marked = { parse: (text) => text };
+window.fetch = () => Promise.resolve({
+  ok: true,
+  json: () => Promise.resolve([]),
+  text: () => Promise.resolve(""),
+});
+
+let notify = () => {};
+let readThreadImpl = () => new Promise(() => {});
+
+window.SerfAppwire = {
+  tasks: () => new Promise(() => {}),
+  refForSession: (sessionId) => "local:" + sessionId,
+  activeTurnIDFromThread: () => "turn_active",
+  onNotification: (handler) => {
+    notify = handler;
+    return () => {};
+  },
+  onConnectionLost: () => () => {},
+  readThread: (sessionId) => readThreadImpl(sessionId),
+  eventsFromThread: (thread) => thread.testEvents || [],
+  eventsFromNotification: (method, params) => {
+    if (method === "item/completed" && params && params.item && params.item.type === "userMessage") {
+      return [["USER_INPUT", { text: params.item.text }]];
+    }
+    return [];
+  },
+};
+
+require("./load-renderer").evalRenderer(window);
+const R = window.SerfRenderer;
+const conversation = window.document.getElementById("conversation");
+
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+const userEvents = (prefix, count) => {
+  const events = [];
+  for (let i = 0; i < count; i++) events.push(["USER_INPUT", { text: prefix + i }]);
+  return events;
+};
+const threadWith = (sessionId, events) => ({
+  thread: {
+    id: sessionId,
+    sessionId,
+    status: "inProgress",
+    serf: { ref: "local:" + sessionId, activeTurnId: "turn_active" },
+    turns: [],
+    testEvents: events,
+  },
+});
+const userMessageTexts = (el) =>
+  Array.from(el.querySelectorAll(".user-message"))
+    .map((m) => { const t = m.querySelector(".user-message-text"); return (t || m).textContent; });
+// Wait for condition with a macrotask pump so chunked replay can proceed.
+const waitFor = async (cond, timeoutMs) => {
+  const deadline = Date.now() + (timeoutMs || 5000);
+  while (!cond()) {
+    if (Date.now() > deadline) return false;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  return true;
+};
+
+(async () => {
+  // ── (a) responsiveness + (b) ordering ────────────────────────────────────
+  const TOTAL = 2000;
+  readThreadImpl = (sessionId) => Promise.resolve(threadWith(sessionId, userEvents("event-", TOTAL)));
+  R.init(conversation);
+
+  let childrenAtTimer = -1;
+  let hydratedFlagAtTimer = null;
+  // Scheduled BEFORE the hydration replay can finish: with a chunked replay
+  // this fires between slices; with one giant blocking task it fires only
+  // after every event has rendered.
+  setTimeout(() => {
+    childrenAtTimer = conversation.querySelectorAll(".user-message").length;
+    hydratedFlagAtTimer = R.appwireHydrated;
+    // (b) a live notification landing mid-replay must buffer and appear
+    // AFTER the hydrated content, never interleaved into it.
+    notify("item/completed", {
+      ref: "local:01TEST",
+      threadId: "01TEST",
+      turnId: "turn_live",
+      item: { id: "user_live", type: "userMessage", text: "live-during-hydration" },
+    });
+  }, 0);
+
+  const finished = await waitFor(() => R.appwireHydrated === true, 60000);
+  pass(finished, "initial hydration completed");
+  pass(childrenAtTimer > 0, "timer fired after the replay started (some events rendered)");
+  pass(childrenAtTimer >= 0 && childrenAtTimer < TOTAL,
+    "setTimeout(0) fired BEFORE all " + TOTAL + " events replayed (rendered at timer fire: " + childrenAtTimer + ") — replay is one blocking task");
+  pass(hydratedFlagAtTimer === false,
+    "live notifications are gated (appwireHydrated false) while the replay is in progress");
+
+  const texts = userMessageTexts(conversation);
+  pass(texts.length === TOTAL + 1, "transcript holds every hydrated event plus the live one (got " + texts.length + ")");
+  let inOrder = texts.length >= TOTAL;
+  for (let i = 0; i < TOTAL && inOrder; i++) inOrder = texts[i] === "event-" + i;
+  pass(inOrder, "final transcript order matches the hydration event order");
+  pass(texts[texts.length - 1] === "live-during-hydration",
+    "live event during hydration appears only AFTER the hydrated content");
+
+  // ── (c) abort: swapping the session mid-chunk stops the replay ───────────
+  readThreadImpl = (sessionId) => Promise.resolve(threadWith(sessionId,
+    sessionId === "session-C" ? userEvents("c-event-", 1) : userEvents("event-", TOTAL)));
+  const conversationB = window.document.createElement("div");
+  conversationB.dataset.sessionId = "session-B";
+  conversationB.dataset.state = "active";
+  conversation.replaceWith(conversationB);
+  R.init(conversationB);
+
+  const conversationC = window.document.createElement("div");
+  conversationC.dataset.sessionId = "session-C";
+  conversationC.dataset.state = "active";
+  let swapThrew = null;
+  // Fires after session-B's first slice: swap the session out from under the
+  // suspended replay. The post-yield staleness guard must abort it cleanly.
+  setTimeout(() => {
+    try {
+      conversationB.replaceWith(conversationC);
+      R.init(conversationC);
+    } catch (err) {
+      swapThrew = err;
+    }
+  }, 0);
+
+  const finishedC = await waitFor(() => R.appwireHydrated === true && R.sessionId === "session-C", 30000);
+  pass(finishedC, "session-C hydration completed after the mid-chunk swap");
+  pass(swapThrew === null, "session swap mid-chunk threw: " + (swapThrew && swapThrew.stack));
+  const bRendered = conversationB.querySelectorAll(".user-message").length;
+  pass(bRendered > 0 && bRendered < TOTAL,
+    "abandoned session-B replay stopped mid-chunk without completing (rendered: " + bRendered + ")");
+  assert.deepStrictEqual(userMessageTexts(conversationC), ["c-event-0"],
+    "session-C transcript is exactly its own hydration");
+
+  // ── (d) reconnect: buffered live events replay after re-hydration ────────
+  const RE_EVENTS = 400;
+  readThreadImpl = (sessionId) => Promise.resolve(threadWith(sessionId, userEvents("re-event-", RE_EVENTS)));
+  pass(R.appwireHydrated === true, "precondition: stream hydrated before reconnect");
+  R.connectAppwire(); // reconnect: re-reads the thread and re-hydrates
+
+  let gatedDuringRehydration = null;
+  let renderedDuringRehydration = -1;
+  setTimeout(() => {
+    gatedDuringRehydration = R.appwireHydrated;
+    renderedDuringRehydration = conversationC.querySelectorAll(".user-message").length;
+    notify("item/completed", {
+      ref: "local:session-C",
+      threadId: "session-C",
+      turnId: "turn_live_2",
+      item: { id: "user_live_2", type: "userMessage", text: "live-after-reconnect" },
+    });
+  }, 0);
+
+  const reFinished = await waitFor(() =>
+    R.appwireHydrated === true &&
+    conversationC.querySelectorAll(".user-message").length >= RE_EVENTS + 1, 30000);
+  pass(reFinished, "re-hydration after reconnect completed");
+  pass(gatedDuringRehydration === false,
+    "re-hydration gated live delivery (appwireHydrated false during the chunked replay)");
+  pass(renderedDuringRehydration >= 0 && renderedDuringRehydration < RE_EVENTS,
+    "re-hydration replay was still in progress when the live event arrived (rendered: " + renderedDuringRehydration + ")");
+
+  const reTexts = userMessageTexts(conversationC);
+  pass(reTexts.length === RE_EVENTS + 1,
+    "single coherent transcript after reconnect, no duplicates (got " + reTexts.length + ")");
+  let reInOrder = reTexts.length >= RE_EVENTS;
+  for (let i = 0; i < RE_EVENTS && reInOrder; i++) reInOrder = reTexts[i] === "re-event-" + i;
+  pass(reInOrder, "re-hydrated transcript order matches the event order");
+  pass(reTexts[reTexts.length - 1] === "live-after-reconnect",
+    "buffered live event replayed after the re-hydrated content");
+  pass(reTexts.filter((t) => t === "live-after-reconnect").length === 1,
+    "buffered live event delivered exactly once");
+
+  if (failures.length) {
+    for (const f of failures) console.log(f);
+    process.exit(1);
+  }
+  console.log("PASS: hydration replay is chunked (responsive), ordered, abort-safe, and reconnect-coherent");
+  process.exit(0);
+})().catch((err) => {
+  console.error(err.stack || err);
+  process.exit(1);
+});

--- a/cmd/serf-hub/jstest/test-renderer-hydration-in-progress-guard.js
+++ b/cmd/serf-hub/jstest/test-renderer-hydration-in-progress-guard.js
@@ -1,0 +1,233 @@
+// hydrationInProgress guard: while a chunked hydration replay is in flight,
+// (F1) a reconnect landing mid-chunk must RESET the transcript before
+// re-hydrating (not replay into the half-rendered prefix), (F3) the settings
+// status-visibility toggle must not reset + re-render + declare hydration
+// complete under the suspended replay, and (F4) a near-top scroll must not
+// fetch the same older-turns cursor that loadOlderTurnsUntilPrimaryDialogue
+// is about to page in.
+const assert = require("assert");
+const { JSDOM } = require("jsdom");
+
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST">
+    <span class="status-dot" data-state="active"></span>
+  </header>
+  <div class="conversation" id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <div id="input-status" class="input-status">
+    <span class="status-item liveness-inline" data-liveness hidden></span>
+  </div>
+</body></html>`, {
+  runScripts: "outside-only",
+  pretendToBeVisual: true,
+  url: "http://127.0.0.1:9180/s/01TEST",
+});
+
+const { window } = dom;
+window.marked = { parse: (text) => text };
+window.fetch = () => Promise.resolve({
+  ok: true,
+  json: () => Promise.resolve([]),
+  text: () => Promise.resolve(""),
+});
+
+let notify = () => {};
+let readThreadImpl = () => new Promise(() => {});
+let listTurnsImpl = () => Promise.resolve({ turns: [], nextCursor: "" });
+
+window.SerfAppwire = {
+  tasks: () => new Promise(() => {}),
+  refForSession: (sessionId) => "local:" + sessionId,
+  activeTurnIDFromThread: () => "turn_active",
+  onNotification: (handler) => {
+    notify = handler;
+    return () => {};
+  },
+  onConnectionLost: () => () => {},
+  readThread: (sessionId) => readThreadImpl(sessionId),
+  listTurns: (sessionId, cursor, limit) => listTurnsImpl(sessionId, cursor, limit),
+  eventsFromThread: (thread) => thread.testEvents || [],
+  eventsFromTurns: (turns) => turns.map((t) => ["USER_INPUT", { text: t.text }]),
+  eventsFromNotification: (method, params) => {
+    if (method === "item/completed" && params && params.item && params.item.type === "userMessage") {
+      return [["USER_INPUT", { text: params.item.text }]];
+    }
+    return [];
+  },
+};
+
+require("./load-renderer").evalRenderer(window);
+const R = window.SerfRenderer;
+
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+const TOTAL = 300; // crosses the 150-event chunk boundary exactly once
+const userEvents = (prefix, count) => {
+  const events = [];
+  for (let i = 0; i < count; i++) events.push(["USER_INPUT", { text: prefix + i }]);
+  return events;
+};
+const noopEvents = (count) => {
+  const events = [];
+  for (let i = 0; i < count; i++) events.push(["NOOP_KIND", { i }]);
+  return events;
+};
+const threadWith = (sessionId, events, olderCursor) => ({
+  thread: {
+    id: sessionId,
+    sessionId,
+    status: "inProgress",
+    serf: { ref: "local:" + sessionId, activeTurnId: "turn_active" },
+    turns: [],
+    testEvents: events,
+  },
+  olderCursor: olderCursor || "",
+});
+const userMessageTexts = (el) =>
+  Array.from(el.querySelectorAll(".user-message"))
+    .map((m) => { const t = m.querySelector(".user-message-text"); return (t || m).textContent; });
+const waitFor = async (cond, timeoutMs) => {
+  const deadline = Date.now() + (timeoutMs || 5000);
+  while (!cond()) {
+    if (Date.now() > deadline) return false;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  return true;
+};
+const pump = async (ticks) => {
+  for (let i = 0; i < (ticks || 10); i++) await new Promise((r) => setTimeout(r, 5));
+};
+const freshConversation = (sessionId) => {
+  const el = window.document.createElement("div");
+  el.className = "conversation";
+  el.dataset.sessionId = sessionId;
+  el.dataset.state = "active";
+  return el;
+};
+const deferred = () => {
+  let resolve, reject;
+  const p = new Promise((res, rej) => { resolve = res; reject = rej; });
+  p.resolve = resolve;
+  p.reject = reject;
+  return p;
+};
+
+(async () => {
+  // ── F1: reconnect landing mid-chunk must not duplicate the transcript ────
+  // Hydration H1 renders its first slice and suspends. A reconnect (new
+  // readThread for the SAME conversation) lands before H1 resumes: it must
+  // reset the half-rendered transcript, not append a full replay on top of it.
+  const conversationA = window.document.getElementById("conversation");
+  readThreadImpl = (sessionId) => Promise.resolve(threadWith(sessionId, userEvents("f1-event-", TOTAL)));
+  R.init(conversationA);
+
+  let reconnectFiredMidReplay = false;
+  setTimeout(() => {
+    // Fires after H1's first slice: the replay is suspended at its yield.
+    reconnectFiredMidReplay = !R.appwireHydrated;
+    R.connectAppwire(); // reconnect: same session, same conversation element
+  }, 0);
+
+  const f1Done = await waitFor(() =>
+    R.appwireHydrated === true &&
+    conversationA.querySelectorAll(".user-message").length >= TOTAL, 30000);
+  await pump(20); // let any abandoned replay's tail settle before counting
+  pass(f1Done, "F1: re-hydration after the mid-chunk reconnect completed");
+  pass(reconnectFiredMidReplay, "F1: reconnect landed while the first hydration was still in progress");
+  const f1Texts = userMessageTexts(conversationA);
+  pass(f1Texts.length === TOTAL,
+    "F1: no duplicated prefix after mid-chunk reconnect (got " + f1Texts.length + " messages, want " + TOTAL + ")");
+  let f1InOrder = f1Texts.length === TOTAL;
+  for (let i = 0; i < TOTAL && f1InOrder; i++) f1InOrder = f1Texts[i] === "f1-event-" + i;
+  pass(f1InOrder, "F1: each transcript item appears exactly once, in hydration order");
+
+  // ── F3: settings status-visibility toggle mid-chunk must not corrupt ─────
+  // The toggle path resets + re-renders synchronously + sets appwireHydrated
+  // with no chunking and no guard; the suspended chunked replay then resumes
+  // and appends its remaining slices a second time.
+  const conversationB = freshConversation("01F3");
+  conversationA.replaceWith(conversationB);
+  readThreadImpl = (sessionId) => Promise.resolve(threadWith(sessionId, userEvents("f3-event-", TOTAL)));
+  R.init(conversationB);
+
+  let toggleFiredMidReplay = false;
+  let toggleReturn = null;
+  setTimeout(() => {
+    toggleFiredMidReplay = !R.appwireHydrated;
+    toggleReturn = R.refreshTranscriptStatusVisibility();
+  }, 0);
+
+  const f3Done = await waitFor(() => R.appwireHydrated === true, 30000);
+  await pump(20); // the resumed replay's tail appends after the flag flips
+  pass(f3Done, "F3: hydration completed around the mid-chunk settings toggle");
+  pass(toggleFiredMidReplay, "F3: settings toggle fired while the chunked replay was in progress");
+  pass(toggleReturn === false, "F3: the toggle defers to the in-progress hydration (returns false)");
+  const f3Texts = userMessageTexts(conversationB);
+  pass(f3Texts.length === TOTAL,
+    "F3: no duplicated tail after the mid-chunk settings toggle (got " + f3Texts.length + " messages, want " + TOTAL + ")");
+  let f3InOrder = f3Texts.length === TOTAL;
+  for (let i = 0; i < TOTAL && f3InOrder; i++) f3InOrder = f3Texts[i] === "f3-event-" + i;
+  pass(f3InOrder, "F3: each transcript item appears exactly once, in hydration order");
+
+  // ── F4: near-top scroll mid-chunk must not double-prepend an older page ──
+  // The replay seeds olderTurnsCursor up front; loadOlderTurnsUntilPrimary-
+  // Dialogue owns it once the replay drains. A scroll fetch in between races
+  // it on the SAME cursor: both prepend the same page.
+  const conversationC = freshConversation("01F4");
+  conversationB.replaceWith(conversationC);
+  const page1 = { turns: [{ text: "f4-older-page-1" }], nextCursor: "" };
+  const listTurnCalls = [];
+  const listTurnDeferreds = [];
+  listTurnsImpl = (sessionId, cursor) => {
+    const d = deferred();
+    listTurnCalls.push(cursor);
+    listTurnDeferreds.push(d);
+    return d;
+  };
+  // No primary dialogue in the hydrated window + an older cursor: hydration
+  // pages older turns in after the replay drains.
+  readThreadImpl = (sessionId) => Promise.resolve(threadWith(sessionId, noopEvents(TOTAL), "cursor-1"));
+  const prependCalls = [];
+  const origPrepend = R.prependOlderTurns.bind(R);
+  R.prependOlderTurns = (turns) => { prependCalls.push(turns); return origPrepend(turns); };
+  R.init(conversationC);
+
+  let scrollFiredMidReplay = false;
+  setTimeout(() => {
+    scrollFiredMidReplay = !R.appwireHydrated;
+    R.maybeLoadOlderTurns(); // reader near the top while the replay is suspended
+  }, 0);
+
+  const f4Fetched = await waitFor(() => listTurnCalls.length >= 1, 30000);
+  pass(f4Fetched, "F4: older-turns paging started during hydration");
+  await pump(20); // give any racing second fetch time to be issued
+  for (const d of listTurnDeferreds) d.resolve(page1);
+  const f4Done = await waitFor(() => R.appwireHydrated === true, 30000);
+  await pump(20);
+  pass(f4Done, "F4: hydration completed around the near-top scroll");
+  pass(scrollFiredMidReplay, "F4: near-top scroll fired while the chunked replay was in progress");
+  pass(listTurnCalls.length === 1,
+    "F4: exactly one older-turns fetch (the scroll fetch defers to hydration's paging) — got " +
+    listTurnCalls.length + " fetches for cursors " + JSON.stringify(listTurnCalls));
+  const page1PrependCount = prependCalls.filter((turns) =>
+    turns && turns.length === 1 && turns[0].text === "f4-older-page-1").length;
+  pass(page1PrependCount === 1,
+    "F4: the older page is prepended exactly once (got " + page1PrependCount + " prepends)");
+  const page1Rendered = userMessageTexts(conversationC).filter((t) => t === "f4-older-page-1").length;
+  pass(page1Rendered === 1,
+    "F4: the older page renders into the transcript exactly once (got " + page1Rendered + ")");
+  R.prependOlderTurns = origPrepend;
+
+  if (failures.length) {
+    for (const f of failures) console.log(f);
+    process.exit(1);
+  }
+  console.log("PASS: hydration-in-progress guard (reconnect reset, settings toggle, older-turns paging)");
+  process.exit(0);
+})().catch((err) => {
+  console.error(err.stack || err);
+  process.exit(1);
+});

--- a/cmd/serf-hub/jstest/test-renderer-hydration-scroll-intent.js
+++ b/cmd/serf-hub/jstest/test-renderer-hydration-scroll-intent.js
@@ -4,6 +4,10 @@
 // skipped for them. With no reader scroll the settle still parks at the
 // bottom. jsdom does no layout, so scrollHeight is stubbed to a fixed value
 // and scroll events are dispatched by hand.
+// N1: prependOlderTurns' scrollTop writes (the sync compensation and the rAF
+// drift correction) fire their scroll events ASYNC — while multi-page
+// loadOlderTurnsUntilPrimaryDialogue runs mid-hydration those events must not
+// read as reader intent, or the hydration-end settle is wrongly suppressed.
 const { JSDOM } = require("jsdom");
 
 const dom = new JSDOM(`<!DOCTYPE html><html><body>
@@ -34,6 +38,7 @@ window.fetch = () => Promise.resolve({
 });
 
 let readThreadImpl = () => new Promise(() => {});
+let listTurnsImpl = () => Promise.resolve({ turns: [], nextCursor: "" });
 window.SerfAppwire = {
   tasks: () => new Promise(() => {}),
   refForSession: (sessionId) => "local:" + sessionId,
@@ -41,7 +46,9 @@ window.SerfAppwire = {
   onNotification: () => () => {},
   onConnectionLost: () => () => {},
   readThread: (sessionId) => readThreadImpl(sessionId),
+  listTurns: (sessionId, cursor, limit) => listTurnsImpl(sessionId, cursor, limit),
   eventsFromThread: (thread) => thread.testEvents || [],
+  eventsFromTurns: (turns) => turns.map((t) => [t.kind || "USER_INPUT", { text: t.text }]),
   eventsFromNotification: () => [],
 };
 
@@ -58,7 +65,12 @@ const userEvents = (prefix, count) => {
   for (let i = 0; i < count; i++) events.push(["USER_INPUT", { text: prefix + i }]);
   return events;
 };
-const threadWith = (sessionId, events) => ({
+const noopEvents = (count) => {
+  const events = [];
+  for (let i = 0; i < count; i++) events.push(["NOOP_KIND", { i }]);
+  return events;
+};
+const threadWith = (sessionId, events, olderCursor) => ({
   thread: {
     id: sessionId,
     sessionId,
@@ -67,6 +79,7 @@ const threadWith = (sessionId, events) => ({
     turns: [],
     testEvents: events,
   },
+  olderCursor: olderCursor || "",
 });
 const waitFor = async (cond, timeoutMs) => {
   const deadline = Date.now() + (timeoutMs || 5000);
@@ -75,6 +88,9 @@ const waitFor = async (cond, timeoutMs) => {
     await new Promise((r) => setTimeout(r, 5));
   }
   return true;
+};
+const pump = async (ticks) => {
+  for (let i = 0; i < (ticks || 10); i++) await new Promise((r) => setTimeout(r, 5));
 };
 const freshConversation = (sessionId) => {
   const el = window.document.createElement("div");
@@ -103,12 +119,20 @@ const freshConversation = (sessionId) => {
   convA.replaceWith(convB);
   R.init(convB); // reconnect-style re-hydration on a fresh element
   // Mid-replay (after the first chunk, before completion) the reader scrolls up.
+  let depthAtReaderScroll = null;
+  let flagAfterReaderScroll = null;
   setTimeout(() => {
     convB.scrollTop = 1200;
+    depthAtReaderScroll = R.programmaticScrollDepth;
     convB.dispatchEvent(new window.Event("scroll"));
+    flagAfterReaderScroll = R.readerScrolledDuringHydration;
   }, 0);
   pass(await waitFor(() => R.appwireHydrated === true, 30000), "hydration (reader scrolled) completed");
   pass(R.hydrationInProgress === false, "hydrationInProgress cleared (scrolled case)");
+  pass(depthAtReaderScroll === 0,
+    "converse: the reader scroll was dispatched at programmatic depth 0 (got " + depthAtReaderScroll + ")");
+  pass(flagAfterReaderScroll === true,
+    "converse: a real reader scroll event at depth 0 still sets readerScrolledDuringHydration");
   pass(convB.scrollTop === 1200,
     "reader scrolled mid-replay — final settle did NOT yank to bottom (scrollTop=" + convB.scrollTop + ", want 1200)");
 
@@ -119,6 +143,53 @@ const freshConversation = (sessionId) => {
     "re-hydration completed");
   pass(convB.scrollTop === STUB_HEIGHT,
     "reader-intent flag was cleared at hydration start — settle scrolls to bottom again (scrollTop=" + convB.scrollTop + ")");
+
+  // ── (d) N1: prepend scroll writes mid-hydration must not read as intent ──
+  // Multi-page hydration: no primary dialogue in the hydrated window + an
+  // older cursor, so loadOlderTurnsUntilPrimaryDialogue pages older turns in
+  // AFTER the chunked replay drains — still mid-hydration. prependOlderTurns'
+  // scrollTop writes (the sync compensation and the rAF drift correction)
+  // fire their scroll events ASYNC; with the old synchronous marker those
+  // events landed after the marker cleared and falsely set the reader-intent
+  // flag, suppressing the hydration-end settle.
+  const convD = freshConversation("01TEST");
+  convB.replaceWith(convD);
+  const n1Pages = {
+    "cursor-1": { turns: [{ kind: "NOOP_KIND", text: "n1-page-1" }], nextCursor: "cursor-2" },
+    "cursor-2": { turns: [{ kind: "NOOP_KIND", text: "n1-page-2" }], nextCursor: "" },
+  };
+  // Resolve each page fetch on a timer so hydration awaits across macrotasks —
+  // the window in which the browser would fire the prepends' async scroll
+  // events.
+  listTurnsImpl = (sessionId, cursor) => new Promise((resolve) =>
+    setTimeout(() => resolve(n1Pages[cursor] || { turns: [], nextCursor: "" }), 0));
+  readThreadImpl = (sessionId) => Promise.resolve(threadWith(sessionId, noopEvents(TOTAL), "cursor-1"));
+  const prependCalls = [];
+  const dispatchedWhileHydrating = [];
+  const origPrependD = R.prependOlderTurns.bind(R);
+  R.prependOlderTurns = (turns) => {
+    const result = origPrependD(turns);
+    prependCalls.push(turns);
+    // The browser fires the scroll event for a programmatic scrollTop write
+    // ASYNC — simulate it on the next task, while hydration is still paging.
+    setTimeout(() => {
+      dispatchedWhileHydrating.push(R.hydrationInProgress);
+      convD.dispatchEvent(new window.Event("scroll"));
+    }, 0);
+    return result;
+  };
+  R.init(convD);
+  pass(await waitFor(() => R.appwireHydrated === true, 30000), "N1: multi-page hydration completed");
+  R.prependOlderTurns = origPrependD;
+  await pump(40); // let the prepend settles and their depth releases drain
+  pass(prependCalls.length === 2,
+    "N1: both older pages were prepended mid-hydration (got " + prependCalls.length + ")");
+  pass(dispatchedWhileHydrating.length >= 1 && dispatchedWhileHydrating[0] === true,
+    "N1: the prepend's async scroll event fired while hydration was still in progress");
+  pass(convD.scrollTop === STUB_HEIGHT,
+    "N1: prepend scroll writes did not read as reader intent — final settle scrolls to bottom (scrollTop=" + convD.scrollTop + ", want " + STUB_HEIGHT + ")");
+  pass(R.programmaticScrollDepth === 0,
+    "N1: programmatic scroll depth returned to 0 after the settles (got " + R.programmaticScrollDepth + ")");
 
   if (failures.length) {
     for (const f of failures) console.log(f);

--- a/cmd/serf-hub/jstest/test-renderer-hydration-scroll-intent.js
+++ b/cmd/serf-hub/jstest/test-renderer-hydration-scroll-intent.js
@@ -1,0 +1,132 @@
+// Reader scroll intent during hydration: the hydration-end settle must not
+// yank a reader who scrolled mid-replay back to the bottom. A scroll event
+// while hydrationInProgress marks reader intent; the final scrollToBottom is
+// skipped for them. With no reader scroll the settle still parks at the
+// bottom. jsdom does no layout, so scrollHeight is stubbed to a fixed value
+// and scroll events are dispatched by hand.
+const { JSDOM } = require("jsdom");
+
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST">
+    <span class="status-dot" data-state="active"></span>
+  </header>
+  <div id="conversation-host">
+    <div class="conversation" id="conversation" data-session-id="01TEST" data-state="active"></div>
+  </div>
+  <div id="input-status" class="input-status">
+    <span class="status-item liveness-inline" data-liveness hidden></span>
+  </div>
+</body></html>`, {
+  runScripts: "outside-only",
+  pretendToBeVisual: true,
+  url: "http://127.0.0.1:9180/s/01TEST",
+});
+
+const { window } = dom;
+window.marked = { parse: (text) => text };
+window.fetch = () => Promise.resolve({
+  ok: true,
+  json: () => Promise.resolve([]),
+  text: () => Promise.resolve(""),
+});
+
+let readThreadImpl = () => new Promise(() => {});
+window.SerfAppwire = {
+  tasks: () => new Promise(() => {}),
+  refForSession: (sessionId) => "local:" + sessionId,
+  activeTurnIDFromThread: () => "turn_active",
+  onNotification: () => () => {},
+  onConnectionLost: () => () => {},
+  readThread: (sessionId) => readThreadImpl(sessionId),
+  eventsFromThread: (thread) => thread.testEvents || [],
+  eventsFromNotification: () => [],
+};
+
+require("./load-renderer").evalRenderer(window);
+const R = window.SerfRenderer;
+const host = window.document.getElementById("conversation-host");
+
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+const STUB_HEIGHT = 5000;
+const userEvents = (prefix, count) => {
+  const events = [];
+  for (let i = 0; i < count; i++) events.push(["USER_INPUT", { text: prefix + i }]);
+  return events;
+};
+const threadWith = (sessionId, events) => ({
+  thread: {
+    id: sessionId,
+    sessionId,
+    status: "inProgress",
+    serf: { ref: "local:" + sessionId, activeTurnId: "turn_active" },
+    turns: [],
+    testEvents: events,
+  },
+});
+const waitFor = async (cond, timeoutMs) => {
+  const deadline = Date.now() + (timeoutMs || 5000);
+  while (!cond()) {
+    if (Date.now() > deadline) return false;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  return true;
+};
+const freshConversation = (sessionId) => {
+  const el = window.document.createElement("div");
+  el.className = "conversation";
+  el.dataset.sessionId = sessionId;
+  el.dataset.state = "active";
+  Object.defineProperty(el, "scrollHeight", { value: STUB_HEIGHT, configurable: true });
+  return el;
+};
+
+(async () => {
+  // ── (a) no reader scroll: the hydration-end settle parks at the bottom ───
+  const TOTAL = 300; // crosses one chunk boundary so the replay yields
+  readThreadImpl = (sessionId) => Promise.resolve(threadWith(sessionId, userEvents("event-", TOTAL)));
+  const convA = freshConversation("01TEST");
+  window.document.getElementById("conversation").replaceWith(convA);
+  R.init(convA);
+  pass(await waitFor(() => R.appwireHydrated === true, 30000), "hydration (no scroll) completed");
+  pass(R.hydrationInProgress === false, "hydrationInProgress cleared (no-scroll case)");
+  pass(convA.scrollTop === STUB_HEIGHT,
+    "with no reader scroll the final settle scrolls to bottom (scrollTop=" + convA.scrollTop + ", want " + STUB_HEIGHT + ")");
+
+  // ── (b) reader scrolls mid-replay: completion must NOT yank them ─────────
+  readThreadImpl = (sessionId) => Promise.resolve(threadWith(sessionId, userEvents("re-event-", TOTAL)));
+  const convB = freshConversation("01TEST");
+  convA.replaceWith(convB);
+  R.init(convB); // reconnect-style re-hydration on a fresh element
+  // Mid-replay (after the first chunk, before completion) the reader scrolls up.
+  setTimeout(() => {
+    convB.scrollTop = 1200;
+    convB.dispatchEvent(new window.Event("scroll"));
+  }, 0);
+  pass(await waitFor(() => R.appwireHydrated === true, 30000), "hydration (reader scrolled) completed");
+  pass(R.hydrationInProgress === false, "hydrationInProgress cleared (scrolled case)");
+  pass(convB.scrollTop === 1200,
+    "reader scrolled mid-replay — final settle did NOT yank to bottom (scrollTop=" + convB.scrollTop + ", want 1200)");
+
+  // ── (c) intent resets: a later hydration with no scroll sticks again ─────
+  readThreadImpl = (sessionId) => Promise.resolve(threadWith(sessionId, userEvents("re2-event-", 5)));
+  R.connectAppwire(); // re-hydrate; the stale reader-intent flag must not leak
+  pass(await waitFor(() => R.appwireHydrated === true && convB.querySelectorAll(".user-message").length === 5, 30000),
+    "re-hydration completed");
+  pass(convB.scrollTop === STUB_HEIGHT,
+    "reader-intent flag was cleared at hydration start — settle scrolls to bottom again (scrollTop=" + convB.scrollTop + ")");
+
+  if (failures.length) {
+    for (const f of failures) console.log(f);
+    process.exit(1);
+  }
+  console.log("PASS: hydration-end settle honors reader scroll intent (no yank; sticks when untouched)");
+  process.exit(0);
+})().catch((err) => {
+  console.error(err.stack || err);
+  process.exit(1);
+});

--- a/cmd/serf-hub/jstest/test-renderer-hydration-settle.js
+++ b/cmd/serf-hub/jstest/test-renderer-hydration-settle.js
@@ -45,6 +45,18 @@ const drainMicrotasks = async () => {
   R.suppressScrollSettle = false;
   R.handleData("ASSISTANT_TEXT_DELTA", { delta: "!" });
   pass(measures === 1, "measurement resumes after suppression");
+  // The new-content pill must not tick during a suppressed (hydration) settle
+  // either — the final scrollToBottom after replay clears it anyway.
+  let noted = 0;
+  const realNote = R.noteNewContent.bind(R);
+  R.noteNewContent = (n) => { noted++; return realNote(n); };
+  R.suppressScrollSettle = true;
+  R.handleData("USER_INPUT", { text: "replayed history" });
+  R.suppressScrollSettle = false;
+  pass(noted === 0, "noteNewContent skipped while suppressScrollSettle (got " + noted + ")");
+  R.handleData("USER_INPUT", { text: "live input" });
+  pass(noted === 1, "noteNewContent resumes after suppression (got " + noted + ")");
+  R.noteNewContent = realNote;
 
   // ── Hydration drive (appwire stubs mirror test-renderer-hydration-order.js) ──
   // A multi-event readThread replay plus one buffered live notification must

--- a/cmd/serf-hub/jstest/test-renderer-hydration-settle.js
+++ b/cmd/serf-hub/jstest/test-renderer-hydration-settle.js
@@ -1,0 +1,173 @@
+// During hydration replay, per-event stick/scroll work is suppressed; one
+// scroll settle runs when hydration completes.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+window.marked = { parse: (t) => t };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+const R = window.SerfRenderer;
+R.init(conv);
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+const deferred = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((r, j) => { resolve = r; reject = j; });
+  return { promise, resolve, reject };
+};
+const drainMicrotasks = async () => {
+  for (let i = 0; i < 12; i++) await Promise.resolve();
+};
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  pass(R.suppressScrollSettle === false || R.suppressScrollSettle === undefined,
+    "not suppressing outside hydration");
+  let measures = 0;
+  const realIsNearBottom = R.isNearBottom.bind(R);
+  R.isNearBottom = () => { measures++; return realIsNearBottom(); };
+  R.suppressScrollSettle = true;
+  R.handleData("TURN_STARTED", { turnId: "t1" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "hi" });
+  pass(measures === 0, "no stick measurement while suppressed (got " + measures + ")");
+  R.suppressScrollSettle = false;
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "!" });
+  pass(measures === 1, "measurement resumes after suppression");
+
+  // ── Hydration drive (appwire stubs mirror test-renderer-hydration-order.js) ──
+  // A multi-event readThread replay plus one buffered live notification must
+  // run with suppressScrollSettle set, measure nothing per event, and scroll
+  // exactly once when hydration completes.
+  let notify = () => {};
+  const readThreadCall = deferred();
+  window.SerfAppwire = {
+    tasks: () => new Promise(() => {}),
+    refForSession: (sessionId) => "local:" + sessionId,
+    activeTurnIDFromThread: () => "turn_active",
+    onNotification: (handler) => {
+      notify = handler;
+      return () => {};
+    },
+    onConnectionLost: () => () => {},
+    readThread: () => readThreadCall.promise,
+    eventsFromThread: (thread) => thread.testEvents,
+    eventsFromNotification: (method, params) => {
+      if (method !== "item/completed") return [];
+      return [["USER_INPUT", { text: params.item.text }]];
+    },
+  };
+  const hydConv = window.document.createElement("div");
+  hydConv.dataset.sessionId = "hyd-session";
+  hydConv.dataset.state = "active";
+  conv.replaceWith(hydConv);
+  R.init(hydConv);
+
+  const realHandleData = R.handleData.bind(R);
+  const flagsSeen = [];
+  R.handleData = (kind, data) => {
+    flagsSeen.push([kind, R.suppressScrollSettle]);
+    return realHandleData(kind, data);
+  };
+  let scrolls = 0;
+  const realScrollToBottom = R.scrollToBottom.bind(R);
+  R.scrollToBottom = () => { scrolls++; return realScrollToBottom(); };
+  measures = 0;
+
+  // A live notification arriving before hydration completes is buffered and
+  // replayed inside the same suppressed window as the thread events.
+  notify("item/completed", {
+    ref: "local:hyd-session",
+    threadId: "hyd-session",
+    turnId: "turn_live",
+    item: { id: "user_live", type: "userMessage", text: "buffered live" },
+  });
+  readThreadCall.resolve({
+    thread: {
+      id: "hyd-session",
+      sessionId: "hyd-session",
+      serf: { ref: "local:hyd-session" },
+      turns: [{
+        id: "turn_1",
+        status: "completed",
+        items: [{ id: "u1", type: "userMessage", text: "snap" }],
+      }],
+      testEvents: [
+        ["USER_INPUT", { text: "snap" }],
+        ["ASSISTANT_TEXT_START", {}],
+        ["ASSISTANT_TEXT_DELTA", { delta: "a" }],
+        ["ASSISTANT_TEXT_DELTA", { delta: "b" }],
+        ["ASSISTANT_TEXT_END", {}],
+      ],
+    },
+  });
+  await drainMicrotasks();
+
+  pass(flagsSeen.length === 6,
+    "hydration replayed 5 thread events + 1 buffered notification (got " + flagsSeen.length + ")");
+  pass(flagsSeen.every(([, flag]) => flag === true),
+    "every replayed event ran under suppressScrollSettle: " + JSON.stringify(flagsSeen));
+  pass(measures === 0,
+    "no stick measurement during hydration replay (got " + measures + ")");
+  pass(scrolls === 1,
+    "exactly one scroll settle after hydration (got " + scrolls + ")");
+  pass(R.suppressScrollSettle === false,
+    "suppression cleared after hydration");
+  pass(hydConv.textContent.includes("snap") && hydConv.textContent.includes("buffered live"),
+    "hydrated and buffered transcript content rendered");
+
+  // ── Failed hydration must clear the flag (no wedged scrolling) ──
+  const failRead = deferred();
+  window.SerfAppwire.readThread = () => failRead.promise;
+  window.SerfAppwire.eventsFromThread = () => [
+    ["USER_INPUT", { text: "fail snapshot" }],
+    ["BOOM", {}],
+  ];
+  R.handleData = (kind, data) => {
+    if (kind === "BOOM") throw new Error("mid-replay failure");
+    return realHandleData(kind, data);
+  };
+  const failConv = window.document.createElement("div");
+  failConv.dataset.sessionId = "fail-session";
+  failConv.dataset.state = "active";
+  hydConv.replaceWith(failConv);
+  R.init(failConv);
+  failRead.resolve({
+    thread: {
+      id: "fail-session",
+      sessionId: "fail-session",
+      serf: { ref: "local:fail-session" },
+      turns: [],
+    },
+  });
+  await drainMicrotasks();
+  pass(R.suppressScrollSettle === false,
+    "failed hydration cleared suppression (no wedged scrolling)");
+  // Neutralize the scheduled reconnect so it can't replay the failing fixture.
+  window.SerfAppwire.readThread = () => new Promise(() => {});
+
+  // ── resetTranscriptReplay must clear the flag too ──
+  R.handleData = realHandleData;
+  R.suppressScrollSettle = true;
+  R.resetTranscriptReplay();
+  pass(R.suppressScrollSettle === false,
+    "resetTranscriptReplay cleared suppression");
+
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: hydration replay suppresses per-event scroll settle and settles once");
+  process.exit(0);
+})().catch((err) => {
+  console.error(err.stack || err);
+  process.exit(1);
+});

--- a/cmd/serf-hub/jstest/test-renderer-hydration-stale-overlap.js
+++ b/cmd/serf-hub/jstest/test-renderer-hydration-stale-overlap.js
@@ -136,6 +136,64 @@ const pump = async (ms) => new Promise((r) => setTimeout(r, ms || 30));
   pass(userMessageTexts(conversation).every((t, i) => t === "h4-event-" + i),
     "transcript is still exactly H4's events after the stale rejection");
 
+  // ── (c) a stale H1 aborting mid-replay must not clobber H2's settle suppression ──
+  // H1 begins its chunked replay; H2 starts at H1's first yield (superseding
+  // the stream) and suspends mid-replay itself; H1 then resumes, detects its
+  // stale token, and returns. H1's finally must clear suppressScrollSettle ONLY
+  // while H1 still owns the stream — clearing it under H2's mid-replay would
+  // re-enable the per-event settle work (the O(N²) path) and replay-time
+  // scroll side effects for H2's remaining chunks.
+  // Instrument suppressScrollSettle so a true→false transition landing while
+  // H2 owns the replay (hydrationInProgress true, outside a transcript reset)
+  // is caught regardless of how the chunk timers interleave.
+  let sssValue = R.suppressScrollSettle;
+  let staleClobber = false;
+  const origReset = R.resetTranscriptReplay.bind(R);
+  let inReset = false;
+  R.resetTranscriptReplay = (...args) => {
+    inReset = true;
+    try { return origReset(...args); } finally { inReset = false; }
+  };
+  Object.defineProperty(R, "suppressScrollSettle", {
+    configurable: true,
+    get() { return sssValue; },
+    set(v) {
+      if (v === false && sssValue === true && R.hydrationInProgress === true && !inReset) {
+        staleClobber = true;
+      }
+      sssValue = v;
+    },
+  });
+
+  R.connectAppwire(); // H1 (init is idempotent per element — reconnect path starts it)
+  pass(deferrals.length === 5, "(c) connect issued a fresh readThread");
+  const hc1 = deferrals[4];
+  hc1.resolve(threadWith("01TEST", userEvents("hc1-event-", 300))); // 2 chunks → yields once
+  await Promise.resolve(); // H1's .then ran its first slice and suspended at the yield
+  pass(R.hydrationInProgress === true && R.suppressScrollSettle === true,
+    "(c) H1 mid-replay holds hydrationInProgress and suppressScrollSettle");
+
+  R.connectAppwire(); // H2 supersedes H1's stream at H1's first yield
+  pass(deferrals.length === 6, "(c) reconnect issued H2's readThread");
+  const hc2 = deferrals[5];
+  const streamH2 = R.liveStream;
+  hc2.resolve(threadWith("01TEST", userEvents("hc2-event-", 600))); // 4 chunks → H2 yields too
+  await Promise.resolve(); // H2 ran its first slice and suspended mid-replay
+  pass(R.hydrationInProgress === true && R.suppressScrollSettle === true,
+    "(c) H2 mid-replay holds both flags");
+
+  // Let every pending chunk timer fire: H1 resumes first, detects the stale
+  // token, and returns — its finally runs while H2 is still mid-replay.
+  pass(await waitFor(() => R.appwireHydrated === true && userMessageTexts(conversation).length === 600, 30000),
+    "(c) H2 completed its replay after H1's stale abort");
+  pass(!staleClobber,
+    "(c) H1's stale finally did NOT clear suppressScrollSettle under H2's mid-replay ownership");
+  pass(R.liveStream === streamH2, "(c) H2 still owns the stream after H1's abort");
+  pass(R.hydrationInProgress === false, "(c) H2 cleared hydrationInProgress on completion");
+  pass(R.suppressScrollSettle === false, "(c) H2 cleared suppressScrollSettle on completion");
+  pass(userMessageTexts(conversation).every((t, i) => t === "hc2-event-" + i),
+    "(c) transcript is exactly H2's events");
+
   if (failures.length) {
     for (const f of failures) console.log(f);
     process.exit(1);

--- a/cmd/serf-hub/jstest/test-renderer-hydration-stale-overlap.js
+++ b/cmd/serf-hub/jstest/test-renderer-hydration-stale-overlap.js
@@ -1,0 +1,148 @@
+// Stale-overlap guard: two overlapping readThread completions must not wedge
+// hydration. A superseded hydration H1 (abandoned by a reconnect that started
+// H2) resolving AFTER H2 completed must return before ANY state/DOM mutation —
+// otherwise it resets H2's valid transcript, replays into it, and the
+// mid-chunk staleness abort leaves hydrationInProgress stuck true forever
+// (which then no-ops refreshTranscriptStatusVisibility / maybeLoadOlderTurns).
+// The stale .catch path must likewise not clear the NEW stream's state.
+const { JSDOM } = require("jsdom");
+
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST">
+    <span class="status-dot" data-state="active"></span>
+  </header>
+  <div class="conversation" id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <div id="input-status" class="input-status">
+    <span class="status-item liveness-inline" data-liveness hidden></span>
+  </div>
+</body></html>`, {
+  runScripts: "outside-only",
+  pretendToBeVisual: true,
+  url: "http://127.0.0.1:9180/s/01TEST",
+});
+
+const { window } = dom;
+window.marked = { parse: (text) => text };
+window.fetch = () => Promise.resolve({
+  ok: true,
+  json: () => Promise.resolve([]),
+  text: () => Promise.resolve(""),
+});
+
+// Deferred readThread queue: each connectAppwire call captures one deferral.
+const deferrals = [];
+window.SerfAppwire = {
+  tasks: () => new Promise(() => {}),
+  refForSession: (sessionId) => "local:" + sessionId,
+  activeTurnIDFromThread: () => "turn_active",
+  onNotification: () => () => {},
+  onConnectionLost: () => () => {},
+  readThread: () => new Promise((resolve, reject) => deferrals.push({ resolve, reject })),
+  eventsFromThread: (thread) => thread.testEvents || [],
+  eventsFromNotification: () => [],
+};
+
+require("./load-renderer").evalRenderer(window);
+const R = window.SerfRenderer;
+const conversation = window.document.getElementById("conversation");
+
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+const userEvents = (prefix, count) => {
+  const events = [];
+  for (let i = 0; i < count; i++) events.push(["USER_INPUT", { text: prefix + i }]);
+  return events;
+};
+const threadWith = (sessionId, events) => ({
+  thread: {
+    id: sessionId,
+    sessionId,
+    status: "inProgress",
+    serf: { ref: "local:" + sessionId, activeTurnId: "turn_active" },
+    turns: [],
+    testEvents: events,
+  },
+});
+const userMessageTexts = (el) =>
+  Array.from(el.querySelectorAll(".user-message"))
+    .map((m) => { const t = m.querySelector(".user-message-text"); return (t || m).textContent; });
+const waitFor = async (cond, timeoutMs) => {
+  const deadline = Date.now() + (timeoutMs || 5000);
+  while (!cond()) {
+    if (Date.now() > deadline) return false;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  return true;
+};
+const pump = async (ms) => new Promise((r) => setTimeout(r, ms || 30));
+
+(async () => {
+  // ── (a) stale .then after the newer hydration completed ─────────────────
+  // H1 starts (300 events — enough to cross a chunk boundary so the abandoned
+  // replay would suspend mid-chunk), then a reconnect starts H2 (3 events).
+  R.init(conversation);
+  pass(deferrals.length === 1, "first connect issued one readThread");
+  R.connectAppwire(); // reconnect: H1's stream is superseded
+  pass(deferrals.length === 2, "reconnect issued a second readThread");
+  const h1 = deferrals[0];
+  const h2 = deferrals[1];
+  const streamAfterH2Start = R.liveStream;
+
+  // H2 (newer) resolves and completes fully.
+  h2.resolve(threadWith("01TEST", userEvents("h2-event-", 3)));
+  pass(await waitFor(() => R.appwireHydrated === true, 30000), "H2 hydration completed");
+  pass(R.hydrationInProgress === false, "hydrationInProgress cleared after H2");
+  pass(userMessageTexts(conversation).length === 3, "transcript holds exactly H2's events");
+
+  // Now the STALE H1 resolves. Without the entry guard it would reset H2's
+  // transcript, replay 150 events, then abort mid-chunk on the LATER liveStream
+  // check — leaving hydrationInProgress stuck true forever.
+  h1.resolve(threadWith("01TEST", userEvents("h1-event-", 300)));
+  await pump(60); // let any (buggy) chunked replay run several slices
+  pass(R.hydrationInProgress === false,
+    "stale H1 completion did not wedge hydrationInProgress (would no-op status refresh + older-turns paging forever)");
+  pass(R.appwireHydrated === true, "stale H1 completion did not clear appwireHydrated");
+  pass(R.liveStream === streamAfterH2Start, "stale H1 completion did not touch the live stream");
+  const textsAfterStale = userMessageTexts(conversation);
+  pass(textsAfterStale.length === 3,
+    "stale H1 did not reset/re-render the transcript (got " + textsAfterStale.length + " messages)");
+  pass(textsAfterStale.every((t, i) => t === "h2-event-" + i),
+    "transcript is still exactly H2's events");
+
+  // ── (b) stale .catch must not clear the new stream's state ───────────────
+  R.connectAppwire(); // H3
+  R.connectAppwire(); // H4 supersedes H3
+  pass(deferrals.length === 4, "two more readThreads issued");
+  const h3 = deferrals[2];
+  const h4 = deferrals[3];
+  h4.resolve(threadWith("01TEST", userEvents("h4-event-", 2)));
+  pass(await waitFor(() => R.appwireHydrated === true && userMessageTexts(conversation).length === 2, 30000),
+    "H4 hydration completed");
+  const streamAfterH4 = R.liveStream;
+  pass(!!streamAfterH4, "live stream present after H4");
+
+  h3.reject(new Error("stale transport failure"));
+  await pump(60);
+  pass(R.liveStream === streamAfterH4,
+    "stale H3 rejection did NOT clear the new stream (clearAppwireStream would kill live delivery)");
+  pass(R.appwireHydrated === true, "stale H3 rejection left appwireHydrated true");
+  pass(R.hydrationInProgress === false, "stale H3 rejection left hydrationInProgress false");
+  pass(!window.document.getElementById("connection-banner"),
+    "stale H3 rejection raised no connection banner over a healthy stream");
+  pass(userMessageTexts(conversation).every((t, i) => t === "h4-event-" + i),
+    "transcript is still exactly H4's events after the stale rejection");
+
+  if (failures.length) {
+    for (const f of failures) console.log(f);
+    process.exit(1);
+  }
+  console.log("PASS: stale overlapping readThread completion/rejection is guarded before any state mutation");
+  process.exit(0);
+})().catch((err) => {
+  console.error(err.stack || err);
+  process.exit(1);
+});

--- a/cmd/serf-hub/jstest/test-renderer-idempotent-finalize.js
+++ b/cmd/serf-hub/jstest/test-renderer-idempotent-finalize.js
@@ -39,6 +39,19 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   pass(msgs[0].textContent.includes("completed"), "late END content applied");
   pass(msgs[0].querySelector(".turn-meta"), "turn-meta survives the in-place replace");
   pass(msgs[0].dataset.turnId === "t1", "turn id preserved through replace");
+  // Mismatched completion: TURN_COMPLETED for a DIFFERENT turn must not
+  // finalize the currently-streaming message — later deltas would be dropped.
+  R.handleData("TURN_STARTED", { turnId: "t2" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "streaming" });
+  R.handleData("TURN_COMPLETED", { turnId: "OTHER", turn: { id: "OTHER", durationMs: 500 } });
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: " continues" });
+  msgs = conv.querySelectorAll(".assistant-message");
+  pass(msgs.length === 2, "mismatched completion must not finalize — later delta still lands in the same active message (got " + msgs.length + ")");
+  const live = msgs[msgs.length - 1];
+  pass(live.dataset.turnId === "t2", "live message still belongs to the active turn");
+  pass(live.textContent.includes("streaming continues"), "delta after mismatched completion renders into the active message");
+  pass(!live.querySelector(".turn-meta"), "mismatched completion appends no .turn-meta to the live message");
   if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
   console.log("PASS: finalization is idempotent across TURN_COMPLETED and a late END");
   process.exit(0);

--- a/cmd/serf-hub/jstest/test-renderer-idempotent-finalize.js
+++ b/cmd/serf-hub/jstest/test-renderer-idempotent-finalize.js
@@ -52,6 +52,31 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   pass(live.dataset.turnId === "t2", "live message still belongs to the active turn");
   pass(live.textContent.includes("streaming continues"), "delta after mismatched completion renders into the active message");
   pass(!live.querySelector(".turn-meta"), "mismatched completion appends no .turn-meta to the live message");
+  // ── Late END after an empty finalize must not target an older turn's block ──
+  // Finish t2 so its block is the finalized tail.
+  R.handleData("TURN_COMPLETED", { turnId: "t2", turn: { id: "t2", durationMs: 700 } });
+  const t2Block = conv.querySelector('.assistant-message[data-turn-id="t2"]');
+  pass(t2Block && t2Block.textContent.includes("streaming continues"), "t2 finalized as the tail block");
+  // Turn t3: tool work renders at the tail, then the turn finalizes empty
+  // (no assistant text) — lastFinalizedAssistantEl still points at t2's block.
+  R.handleData("TURN_STARTED", { turnId: "t3" });
+  // (card-mode tool: its row lands directly at the conversation tail)
+  R.handleData("TOOL_CALL_START", { call_id: "c1", tool_name: "shell", arguments_json: JSON.stringify({ command: "make test" }) });
+  R.handleData("TURN_COMPLETED", { turnId: "t3", turn: { id: "t3", durationMs: 100 } });
+  const tail = conv.lastElementChild;
+  pass(tail && tail.classList.contains("tool-call"), "tool row is the transcript tail after the empty finalize");
+  // A late END with no active message must NOT replace t2's block: the block
+  // being replaced is no longer the transcript tail.
+  R.handleData("ASSISTANT_TEXT_END", { text: "late orphan text" });
+  pass(t2Block.textContent.includes("streaming continues"), "late END did not clobber the older turn's block");
+  msgs = conv.querySelectorAll(".assistant-message");
+  pass(msgs[msgs.length - 1].textContent.includes("late orphan text"), "late END lands as its own block at the tail");
+  pass(msgs[msgs.length - 1] !== t2Block, "the late block is a new element, not the t2 block");
+  // Empty finalize of a started-then-empty message also drops the replace pointer.
+  R.handleData("TURN_STARTED", { turnId: "t4" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  R.handleData("TURN_COMPLETED", { turnId: "t4", turn: { id: "t4", durationMs: 50 } });
+  pass(R.lastFinalizedAssistantEl === null, "empty finalize clears the replace pointer");
   if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
   console.log("PASS: finalization is idempotent across TURN_COMPLETED and a late END");
   process.exit(0);

--- a/cmd/serf-hub/jstest/test-renderer-idempotent-finalize.js
+++ b/cmd/serf-hub/jstest/test-renderer-idempotent-finalize.js
@@ -99,6 +99,28 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   pass(t5Block.textContent.includes("final"), "late END content applied over the finalized block");
   pass(conv.querySelector(".banner.note") === banner, "end banner still present after the replace");
   pass(conv.lastElementChild === banner, "banner still follows the replaced block");
+  // ── Late END after a .system-run follower must still REPLACE (F2) ──────
+  // appendSystemMessage wraps quiet lifecycle events in a top-level
+  // .system-run element; the quiet-followers walk only allowed .banner and
+  // .system-line, so a system event between TURN_COMPLETED and the late END
+  // broke the replace guard and appended a duplicate answer.
+  R.handleData("TURN_STARTED", { turnId: "t6" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "system-run case answer" });
+  R.handleData("TURN_COMPLETED", { turnId: "t6", turn: { id: "t6", durationMs: 300 } });
+  R.handleData("SYSTEM_MESSAGE", { title: "Skill", text: "skill activated: demo" });
+  const sysRun = conv.querySelector(".system-run");
+  pass(!!sysRun, "system event produced a top-level .system-run wrapper");
+  pass(conv.lastElementChild === sysRun, "system-run follows the finalized assistant block");
+  const t6Block = conv.querySelector('.assistant-message[data-turn-id="t6"]');
+  const countBefore6 = conv.querySelectorAll(".assistant-message").length;
+  R.handleData("ASSISTANT_TEXT_END", { text: "system-run case answer, final" });
+  msgs = conv.querySelectorAll(".assistant-message");
+  pass(msgs.length === countBefore6, "late END after a system-run replaces in place — no duplicate (got " + msgs.length + ")");
+  pass(msgs[msgs.length - 1] === t6Block, "the SAME t6 block was replaced, not a new one appended");
+  pass(t6Block.textContent.includes("final"), "late END content applied over the system-run-followed block");
+  pass(conv.querySelector(".system-run") === sysRun, "system-run still present after the replace");
+  pass(conv.lastElementChild === sysRun, "system-run still follows the replaced block");
   if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
   console.log("PASS: finalization is idempotent across TURN_COMPLETED and a late END");
   process.exit(0);

--- a/cmd/serf-hub/jstest/test-renderer-idempotent-finalize.js
+++ b/cmd/serf-hub/jstest/test-renderer-idempotent-finalize.js
@@ -77,6 +77,28 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   R.handleData("ASSISTANT_TEXT_START", {});
   R.handleData("TURN_COMPLETED", { turnId: "t4", turn: { id: "t4", durationMs: 50 } });
   pass(R.lastFinalizedAssistantEl === null, "empty finalize clears the replace pointer");
+  // ── Late END after SESSION_END's banner must still REPLACE (F3) ────────
+  // SESSION_END finalizes the stream and then appends an end banner, so the
+  // finalized block is no longer conversation.lastElementChild. A replace
+  // guard keyed on lastElementChild rejects the late END and appends a
+  // duplicate answer.
+  R.handleData("TURN_STARTED", { turnId: "t5" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "banner case answer" });
+  R.handleData("TURN_COMPLETED", { turnId: "t5", turn: { id: "t5", durationMs: 900 } });
+  R.handleData("SESSION_END", { reason: "interrupted" });
+  const banner = conv.querySelector(".banner.note");
+  pass(!!banner && /interrupted/.test(banner.textContent), "SESSION_END appended the end banner");
+  pass(conv.lastElementChild === banner, "banner follows the finalized assistant block");
+  const t5Block = conv.querySelector('.assistant-message[data-turn-id="t5"]');
+  const countBefore = conv.querySelectorAll(".assistant-message").length;
+  R.handleData("ASSISTANT_TEXT_END", { text: "banner case answer, final" });
+  msgs = conv.querySelectorAll(".assistant-message");
+  pass(msgs.length === countBefore, "late END after the banner replaces in place — no duplicate (got " + msgs.length + ")");
+  pass(msgs[msgs.length - 1] === t5Block, "the SAME t5 block was replaced, not a new one appended");
+  pass(t5Block.textContent.includes("final"), "late END content applied over the finalized block");
+  pass(conv.querySelector(".banner.note") === banner, "end banner still present after the replace");
+  pass(conv.lastElementChild === banner, "banner still follows the replaced block");
   if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
   console.log("PASS: finalization is idempotent across TURN_COMPLETED and a late END");
   process.exit(0);

--- a/cmd/serf-hub/jstest/test-renderer-idempotent-finalize.js
+++ b/cmd/serf-hub/jstest/test-renderer-idempotent-finalize.js
@@ -1,0 +1,45 @@
+// TURN_COMPLETED finalizes from textBuf (interrupt: no ASSISTANT_TEXT_END ever
+// arrives). A subsequent ASSISTANT_TEXT_END for that message (codex
+// turn/completed-with-items path) REPLACES the block in place — no duplicate.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+window.marked = { parse: (t) => "<p>" + t + "</p>" };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+window.SerfRenderer.init(conv);
+const R = window.SerfRenderer;
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  R.handleData("TURN_STARTED", { turnId: "t1" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "partial answer" });
+  // Interrupt shape: TURN_COMPLETED with NO ASSISTANT_TEXT_END.
+  R.handleData("TURN_COMPLETED", { turnId: "t1", turn: { id: "t1", durationMs: 1200 } });
+  let msgs = conv.querySelectorAll(".assistant-message");
+  pass(msgs.length === 1, "TURN_COMPLETED finalizes the partial message (got " + msgs.length + ")");
+  pass(msgs[0].textContent.includes("partial answer"), "partial content rendered at finalize");
+  pass(msgs[0].querySelector(".turn-meta"), "turn-meta badge appended after finalize");
+  // Codex shape: the synthesized END arrives AFTER TURN_COMPLETED.
+  R.handleData("ASSISTANT_TEXT_END", { text: "partial answer, completed" });
+  msgs = conv.querySelectorAll(".assistant-message");
+  pass(msgs.length === 1, "late END replaces in place — no duplicate (got " + msgs.length + ")");
+  pass(msgs[0].textContent.includes("completed"), "late END content applied");
+  pass(msgs[0].querySelector(".turn-meta"), "turn-meta survives the in-place replace");
+  pass(msgs[0].dataset.turnId === "t1", "turn id preserved through replace");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: finalization is idempotent across TURN_COMPLETED and a late END");
+  process.exit(0);
+})();

--- a/cmd/serf-hub/jstest/test-renderer-lazy-turns.js
+++ b/cmd/serf-hub/jstest/test-renderer-lazy-turns.js
@@ -85,6 +85,69 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   R.maybeLoadOlderTurns();
   pass(listCalls === 1, "no fetch once the head is reached");
 
+  // ── F1(a): a prepend must not corrupt the LIVE turn's streaming state ──
+  // A historical (already-completed) turn's events run through the normal
+  // mutating path during the staging render; a historical TURN_COMPLETED with
+  // no turnId matches the live finalization guard and clears the live
+  // activeTurnId — the live turn's own completion then fails the guard and the
+  // message streams forever.
+  R.handleData("TURN_STARTED", { turnId: "live-t1" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "live answer streaming" });
+  const liveMsg = conv.querySelector('.assistant-message[data-turn-id="live-t1"]');
+  pass(!!liveMsg, "live streaming message exists");
+  window.SerfAppwire.eventsFromTurns = () => [
+    ["USER_INPUT", { text: "HIST-USER", turn: 2 }],
+    ["ASSISTANT_TEXT_START", {}],
+    ["ASSISTANT_TEXT_END", { text: "historical answer" }],
+    ["TURN_COMPLETED", { turn: { id: "hist-t0", durationMs: 100 } }],
+  ];
+  R.prependOlderTurns([{ id: "hist-t0" }]);
+  pass(R.activeTurnId === "live-t1", "live activeTurnId intact after prepend (got " + JSON.stringify(R.activeTurnId) + ")");
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: " continues" });
+  R.handleData("TURN_COMPLETED", { turnId: "live-t1", turn: { id: "live-t1", durationMs: 200 } });
+  pass(liveMsg.textContent.includes("live answer streaming continues"), "live message kept streaming across the prepend");
+  pass(!liveMsg.classList.contains("streaming"), "live TURN_COMPLETED still finalizes the live message");
+
+  // ── F1(b): a pending live ask_user survives a historical USER_INPUT ──
+  // USER_INPUT resolves the whole pending ask set (spec §5.2) — a HISTORICAL
+  // user message must not settle the LIVE pending ask or tear down its anchor.
+  R.handleData("TURN_STARTED", { turnId: "live-t2" });
+  R.handleData("TOOL_CALL_START", { call_id: "ask1", tool_name: "ask_user", arguments_json: JSON.stringify({ questions: [{ header: "Pick", question: "Pick one", options: [{ label: "A" }] }] }) });
+  R.handleData("TOOL_CALL_END", { call_id: "ask1", tool_name: "ask_user", output: "ok" });
+  const liveAnchor = conv.querySelector("[data-ask-anchor]");
+  pass(!!R.pendingAsk && !!liveAnchor, "live ask_user pending with a transcript anchor");
+  pass(R.agentQuestionEl === liveAnchor, "anchor recorded as the agent question");
+  window.SerfAppwire.eventsFromTurns = () => [["USER_INPUT", { text: "HIST-USER-2", turn: 3 }]];
+  R.prependOlderTurns([{ id: "hist-t1" }]);
+  pass(!!R.pendingAsk, "ask still pending after a historical USER_INPUT prepend");
+  pass(R.pendingAsk && R.pendingAsk.el === liveAnchor, "pending ask keeps its anchor element");
+  pass(liveAnchor.isConnected && conv.contains(liveAnchor), "ask anchor still in the live transcript");
+  pass(!conv.querySelector(".ask-settled-line"), "no settled line rendered for the live ask");
+  pass(R.agentQuestionEl === liveAnchor, "agent question element intact after prepend");
+
+  // ── F1(c): live reasoning survives a historical reasoning prepend ──
+  // A historical REASONING_START early-returns on the live reasoningEl, then
+  // the historical REASONING_DELTA hijacks the live think body and buffer.
+  R.handleData("TURN_STARTED", { turnId: "live-t3" });
+  R.handleData("REASONING_START", {});
+  R.handleData("REASONING_DELTA", { delta: "live thought" });
+  const liveThink = R.reasoningEl;
+  pass(!!liveThink, "live reasoning block streaming");
+  const liveThinkBody = liveThink.querySelector(".think-body");
+  window.SerfAppwire.eventsFromTurns = () => [
+    ["REASONING_START", {}],
+    ["REASONING_DELTA", { delta: "HIST-THOUGHT" }],
+    ["ASSISTANT_TEXT_START", {}],
+    ["ASSISTANT_TEXT_END", { text: "hist answer 2" }],
+  ];
+  R.prependOlderTurns([{ id: "hist-t2" }]);
+  pass(R.reasoningEl === liveThink, "live reasoningEl intact after prepend");
+  pass(R.reasoningBuf === "live thought", "live reasoningBuf intact (got " + JSON.stringify(R.reasoningBuf) + ")");
+  pass(!liveThinkBody.textContent.includes("HIST-THOUGHT"), "historical reasoning did not hijack the live think body");
+  R.handleData("REASONING_DELTA", { delta: " continues" });
+  pass(liveThinkBody.textContent === "live thought continues", "later live reasoning deltas still render into the live think body");
+
   if (failures.length) { failures.forEach((f) => console.log(f)); process.exit(1); }
   console.log("PASS: renderer lazily prepends older turns without disturbing live state");
   process.exit(0);

--- a/cmd/serf-hub/jstest/test-renderer-lazy-turns.js
+++ b/cmd/serf-hub/jstest/test-renderer-lazy-turns.js
@@ -8,6 +8,12 @@ const { JSDOM } = require("jsdom");
 const dom = new JSDOM(`<!DOCTYPE html><html><body>
   <header class="workspace-header" data-session-id="01TEST"><span class="status-dot" data-state="active"></span></header>
   <div class="conversation" id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form class="workspace-input" data-input-form data-session-id="01TEST">
+    <div data-composer-surface>
+      <textarea class="message-input"></textarea>
+      <button type="submit" class="btn btn-primary send-btn">send</button>
+    </div>
+  </form>
 </body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
 
 const { window } = dom;
@@ -147,6 +153,63 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   pass(!liveThinkBody.textContent.includes("HIST-THOUGHT"), "historical reasoning did not hijack the live think body");
   R.handleData("REASONING_DELTA", { delta: " continues" });
   pass(liveThinkBody.textContent === "live thought continues", "later live reasoning deltas still render into the live think body");
+
+  // ── F1(d): a historical ask_user in a prepended page must not hijack the
+  // LIVE composer. The ask path (handleAskUserAck → appendPendingAskQuestions
+  // → renderPendingAskDock / setComposerAskMode, markAgentQuestion →
+  // renderNeedsYouDock) mutates the REAL composer form — ask mode on, input
+  // hidden+inert, focus stolen into the dock. Field save/restore cannot undo
+  // those document-level side effects; the staging replay must suppress them.
+  const form = window.document.querySelector("form[data-input-form]");
+  const input = form.querySelector(".message-input");
+  // Settle the live ask from F1(b) so the composer is back to normal.
+  R.handleData("USER_INPUT", { text: "the live answer", turn: 10 });
+  pass(!R.pendingAsk, "live ask settled, composer back to normal");
+  pass(form.dataset.responseMode !== "ask", "composer in normal mode before the historical ask prepend");
+  pass(!input.hidden, "input visible before the historical ask prepend");
+  window.SerfAppwire.eventsFromTurns = () => [
+    ["TOOL_CALL_START", { call_id: "hask1", tool_name: "ask_user", arguments_json: JSON.stringify({ questions: [{ header: "Hist", question: "Historical?", options: [{ label: "X" }, { label: "Y" }] }] }) }],
+    ["TOOL_CALL_END", { call_id: "hask1", tool_name: "ask_user", output: "ok" }],
+  ];
+  input.focus();
+  pass(window.document.activeElement === input, "composer input focused before the historical ask prepend");
+  R.prependOlderTurns([{ id: "hist-t3" }]);
+  pass(form.dataset.responseMode !== "ask", "historical ask_user does NOT switch the live composer into ask mode");
+  pass(!input.hidden, "historical ask_user does NOT hide the live composer input");
+  pass(!form.querySelector("[data-ask-response-dock]"), "historical ask_user does NOT build a response dock in the live composer");
+  pass(window.document.activeElement === input, "historical ask_user does NOT steal focus from the live composer");
+  const nyDock = form.parentNode.querySelector("[data-needs-you-dock]");
+  pass(!nyDock || nyDock.hidden, "historical ask_user does NOT light the live needs-you dock");
+  pass(R.stagingReplay === false, "stagingReplay cleared after the prepend finally");
+  // The historical question still renders into the prepended history itself —
+  // only the composer side effects are suppressed.
+  pass(!!conv.querySelector("[data-ask-anchor]"), "historical ask anchor still renders into the prepended history");
+  // After the restore, the LIVE ask flow must still work end to end.
+  R.handleData("TURN_STARTED", { turnId: "live-t4" });
+  R.handleData("TOOL_CALL_START", { call_id: "ask2", tool_name: "ask_user", arguments_json: JSON.stringify({ questions: [{ header: "Live", question: "Live?", options: [{ label: "L" }] }] }) });
+  R.handleData("TOOL_CALL_END", { call_id: "ask2", tool_name: "ask_user", output: "ok" });
+  pass(form.dataset.responseMode === "ask", "live ask flow still activates composer ask mode after a staging replay");
+  pass(!!form.querySelector("[data-ask-response-dock]"), "live ask dock still renders after a staging replay");
+
+  // ── F2: a scroll-triggered prepend must not hide the live new-content pill.
+  // The staging render runs the normal per-event settle: the detached staging
+  // div measures "near bottom", so settleFrame → scrollToBottom →
+  // clearNewContentPill zeroes the pill fields. The saved set must cover the
+  // WHOLE pill field set — painted count, jump target, and the debounce timer
+  // — not just the raw count.
+  R.newContentCount = 3;
+  R.newContentPaintedCount = 3;
+  const jumpTarget = conv.querySelector(".assistant-message");
+  R.newContentJumpTarget = jumpTarget;
+  R.newContentCountTimer = setTimeout(() => {}, 60000);
+  window.SerfAppwire.eventsFromTurns = () => [["USER_INPUT", { text: "HIST-USER-3", turn: 4 }]];
+  R.prependOlderTurns([{ id: "hist-t9" }]);
+  pass(R.newContentCount === 3, "pill count preserved across prepend (got " + R.newContentCount + ")");
+  pass(R.newContentPaintedCount === 3, "pill painted count preserved across prepend (got " + R.newContentPaintedCount + ")");
+  pass(R.newContentJumpTarget === jumpTarget, "pill jump target preserved across prepend");
+  pass(R.newContentCountTimer !== null, "pill debounce timer survives prepend");
+  clearTimeout(R.newContentCountTimer);
+  R.newContentCountTimer = null;
 
   if (failures.length) { failures.forEach((f) => console.log(f)); process.exit(1); }
   console.log("PASS: renderer lazily prepends older turns without disturbing live state");

--- a/cmd/serf-hub/jstest/test-renderer-lazy-turns.js
+++ b/cmd/serf-hub/jstest/test-renderer-lazy-turns.js
@@ -44,6 +44,7 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   // turn to a USER_INPUT event.
   let listCalls = 0;
   let lastCursorSeen = null;
+  let taskFetches = 0;
   window.SerfAppwire = {
     listTurns: (sessionId, cursor, limit) => {
       listCalls++;
@@ -51,6 +52,7 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
       return Promise.resolve({ turns: [{ text: "OLD-USER-MESSAGE", n: 1 }], nextCursor: "" });
     },
     eventsFromTurns: (turns) => turns.map((t) => ["USER_INPUT", { text: t.text, turn: t.n }]),
+    tasks: () => { taskFetches++; return Promise.resolve([]); },
   };
   R.sessionId = "01TEST";
 
@@ -191,6 +193,57 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   pass(form.dataset.responseMode === "ask", "live ask flow still activates composer ask mode after a staging replay");
   pass(!!form.querySelector("[data-ask-response-dock]"), "live ask dock still renders after a staging replay");
 
+  // ── F1(e): a completed delegate spawn in a prepended page must not rewrite
+  // the LIVE breadcrumb rollup chip. The replay path TOOL_CALL_END →
+  // finalizeToolCall → upsertJobRef → refreshSubagentModule →
+  // updateBreadcrumbRollup reads rows from this.conversation (the STAGING div
+  // during replay) but paints the document-level [data-subagent-rollup] chip —
+  // a staging page with no failed rows would hide the live failure chip.
+  const crumb = window.document.createElement("nav");
+  crumb.setAttribute("aria-label", "breadcrumb");
+  crumb.innerHTML = '<span data-subagent-rollup class="bad">✕ 1 child failed</span>';
+  window.document.body.appendChild(crumb);
+  const liveChip = crumb.querySelector("[data-subagent-rollup]");
+  liveChip.hidden = false;
+  window.SerfAppwire.eventsFromTurns = () => [
+    ["TOOL_CALL_START", { call_id: "hdel1", tool_name: "delegate", arguments_json: JSON.stringify({ task: "historical subagent" }) }],
+    ["TOOL_CALL_END", { call_id: "hdel1", tool_name: "delegate", output: JSON.stringify({ job_id: "job-hist-1", type: "delegate", status: "completed" }) }],
+  ];
+  R.prependOlderTurns([{ id: "hist-t4" }]);
+  pass(liveChip.hidden === false, "live breadcrumb rollup chip still visible after prepend with a completed delegate spawn");
+  pass(liveChip.textContent === "✕ 1 child failed", "live breadcrumb rollup chip text untouched (got " + JSON.stringify(liveChip.textContent) + ")");
+  pass(liveChip.classList.contains("bad"), "live breadcrumb rollup chip keeps its failure styling");
+  // The historical spawn still renders into the prepended history itself —
+  // only the document-level chip side effect is suppressed.
+  pass(!!conv.querySelector(".sub-r"), "historical delegate spawn still renders a subagent row into the prepended history");
+
+  // ── F1(f): a historical task_list card must not kick the live task badge.
+  // appendTaskListSystemLine ends with refreshTaskBadgeSoon → requestTasks:
+  // the generation bump + /tasks fetch is pure waste during staging replay
+  // (requestTasks' conversation-identity guard drops the apply after the
+  // restore anyway), so the guard must no-op before the fetch.
+  const taskFetchesBefore = taskFetches;
+  window.SerfAppwire.eventsFromTurns = () => [
+    ["TOOL_CALL_START", { call_id: "htask1", tool_name: "task_list", arguments_json: JSON.stringify({ action: "update", updates: [{ id: 7, status: "done" }] }) }],
+    ["TOOL_CALL_END", { call_id: "htask1", tool_name: "task_list", output: "ok" }],
+  ];
+  R.prependOlderTurns([{ id: "hist-t5" }]);
+  pass(taskFetches === taskFetchesBefore, "historical task_list card does not fetch /tasks during staging replay (got " + (taskFetches - taskFetchesBefore) + " fetches)");
+
+  // ── Static guard scan: every document-level helper reachable from the
+  // replayable applyEvent kinds must no-op on this.stagingReplay. (A full
+  // reachability scan of renderer.js would be too fragile; this pins the
+  // known reachable set by name.)
+  const rendererSrc = require("./load-renderer").rendererSources().join("\n");
+  for (const fn of ["updateBreadcrumbRollup", "refreshTaskBadgeSoon", "renderNeedsYouDock", "setComposerAskMode", "renderPendingAskDock", "clearPendingAskDock", "focusComposer"]) {
+    const def = rendererSrc.match(new RegExp(fn + "\\([^)]*\\) \\{"));
+    pass(!!def, "static guard scan: " + fn + " definition found");
+    if (def) {
+      const head = rendererSrc.slice(def.index, def.index + 700);
+      pass(/this\.stagingReplay/.test(head), "static guard scan: " + fn + " no-ops on stagingReplay before touching document-level chrome");
+    }
+  }
+
   // ── F2: a scroll-triggered prepend must not hide the live new-content pill.
   // The staging render runs the normal per-event settle: the detached staging
   // div measures "near bottom", so settleFrame → scrollToBottom →
@@ -202,13 +255,29 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   const jumpTarget = conv.querySelector(".assistant-message");
   R.newContentJumpTarget = jumpTarget;
   R.newContentCountTimer = setTimeout(() => {}, 60000);
+  const killedTimer = R.newContentCountTimer;
   window.SerfAppwire.eventsFromTurns = () => [["USER_INPUT", { text: "HIST-USER-3", turn: 4 }]];
   R.prependOlderTurns([{ id: "hist-t9" }]);
   pass(R.newContentCount === 3, "pill count preserved across prepend (got " + R.newContentCount + ")");
   pass(R.newContentPaintedCount === 3, "pill painted count preserved across prepend (got " + R.newContentPaintedCount + ")");
   pass(R.newContentJumpTarget === jumpTarget, "pill jump target preserved across prepend");
   pass(R.newContentCountTimer !== null, "pill debounce timer survives prepend");
+  pass(R.newContentCountTimer !== killedTimer, "event-producing prepend re-arms the pill debounce timer (the settle killed the original)");
   clearTimeout(R.newContentCountTimer);
+  R.newContentCountTimer = null;
+
+  // ── F2(b): a ZERO-event prepend must leave a pending pill timer completely
+  // untouched. Nothing entered the settle, so nothing killed the original
+  // timeout — the old unconditional re-arm orphaned it into a double-fire.
+  R.newContentCount = 2;
+  R.newContentPaintedCount = 2;
+  const pendingTimer = setTimeout(() => {}, 60000);
+  R.newContentCountTimer = pendingTimer;
+  window.SerfAppwire.eventsFromTurns = () => [];
+  R.prependOlderTurns([{ id: "hist-empty" }]);
+  pass(R.newContentCountTimer === pendingTimer, "zero-event prepend leaves the pending pill timer untouched (no orphaned double-fire)");
+  pass(R.newContentCount === 2, "zero-event prepend preserves the pill count");
+  clearTimeout(pendingTimer);
   R.newContentCountTimer = null;
 
   if (failures.length) { failures.forEach((f) => console.log(f)); process.exit(1); }

--- a/cmd/serf-hub/jstest/test-renderer-needsyou-affordances.js
+++ b/cmd/serf-hub/jstest/test-renderer-needsyou-affordances.js
@@ -58,6 +58,7 @@ R.init(conv);
   Object.defineProperty(errBelow, "offsetTop", { configurable: true, get: () => 900 });
   Object.defineProperty(errBelow, "offsetHeight", { configurable: true, get: () => 40 });
   conv.appendChild(errBelow);
+  R.errorAnchorCache = null; // manual DOM injection bypasses the TOOL_CALL_END invalidation
   R.newContentCount = 1;
   R.renderNewContentPill();
   assert.ok(pill.innerHTML.includes("<svg"), "error scroll pill must render an icon, not ✕ (got " + pill.innerHTML + ")");

--- a/cmd/serf-hub/jstest/test-renderer-new-content-pill.js
+++ b/cmd/serf-hub/jstest/test-renderer-new-content-pill.js
@@ -204,6 +204,26 @@ const settle = () => new Promise((r) => setTimeout(r, 350));
   const settled = pillEl() && pillEl().textContent;
   pass(/↓ 4 new/.test(settled || ""), "debounced count settles to the final burst total (got " + settled + ")");
 
+  // ── The pill never renders a zero count ──────────────────────────────────
+  // First paint after the pill was hidden: the debounced painted count is
+  // still 0 while the live count is already positive — painting the stale
+  // painted value badges "↓ 0 new" for the whole ~300ms debounce window (a
+  // browser probe caught exactly this). The first paint must seed from the
+  // live count, and the trailing commit must never paint 0 either.
+  R.scrollToBottom(); // clears the pill: count = painted = 0, hidden
+  R.updateThreadState("active");
+  conv.scrollTop = 100;
+  R.handleData("ASSISTANT_TEXT_START", {});
+  R.handleData("ASSISTANT_TEXT_END", { text: "zero-count check" });
+  pass(pillVisible(), "pill is visible for the zero-count check");
+  const firstPaint = pillEl() && pillEl().textContent;
+  pass(!/0 new/.test(firstPaint || ""), "first paint never reads '↓ 0 new' (got " + firstPaint + ")");
+  pass(/↓ [1-9]\d* new/.test(firstPaint || ""), "first paint shows a positive count (got " + firstPaint + ")");
+  await settle(); // let the trailing debounce commit
+  const committed = pillEl() && pillEl().textContent;
+  pass(!/0 new/.test(committed || ""), "trailing commit never reads '↓ 0 new' (got " + committed + ")");
+  pass(/↓ [1-9]\d* new/.test(committed || ""), "trailing commit shows a positive count (got " + committed + ")");
+
   if (failures.length > 0) {
     for (const f of failures) console.log(f);
     process.exit(1);

--- a/cmd/serf-hub/jstest/test-renderer-new-content-pill.js
+++ b/cmd/serf-hub/jstest/test-renderer-new-content-pill.js
@@ -85,6 +85,7 @@ const settle = () => new Promise((r) => setTimeout(r, 350));
   pass(pillVisible(), "pill reappears on new content after scrolling up again");
   conv.scrollTop = 600; // reader returns to the bottom on their own
   conv.dispatchEvent(new window.Event("scroll"));
+  await new Promise((r) => setTimeout(r, 40)); // scroll handler is rAF-throttled (Task 15)
   pass(!pillVisible(), "scrolling back to the bottom clears the pill");
 
   // Attention-aware: new content under an awaiting state reads "needs you".
@@ -127,6 +128,7 @@ const settle = () => new Promise((r) => setTimeout(r, 350));
   Object.defineProperty(errBelow, "offsetTop", { configurable: true, get: () => 900 });
   Object.defineProperty(errBelow, "offsetHeight", { configurable: true, get: () => 40 });
   conv.appendChild(errBelow);
+  R.errorAnchorCache = null; // manual DOM injection bypasses the TOOL_CALL_END invalidation
   conv.scrollTop = 100; // viewport bottom = 100 + 400 = 500; error at 900 is below
   R.handleData("ASSISTANT_TEXT_START", {});
   R.handleData("ASSISTANT_TEXT_END", { text: "patching" });
@@ -160,6 +162,7 @@ const settle = () => new Promise((r) => setTimeout(r, 350));
   Object.defineProperty(errPri, "offsetTop", { configurable: true, get: () => 900 });
   Object.defineProperty(errPri, "offsetHeight", { configurable: true, get: () => 40 });
   conv.appendChild(errPri); // … AND an error is below
+  R.errorAnchorCache = null; // manual DOM injection bypasses the TOOL_CALL_END invalidation
   conv.scrollTop = 100;
   R.handleData("ASSISTANT_TEXT_START", {});
   R.handleData("ASSISTANT_TEXT_END", { text: "a reply" });
@@ -183,6 +186,7 @@ const settle = () => new Promise((r) => setTimeout(r, 350));
   // ── Debounced count settles to one value after a burst ──────────────────
   // Remove the lingering error anchors so this exercises the PLAIN count path.
   conv.querySelectorAll('.tool-call[data-attention="error"]').forEach(n => n.remove());
+  R.errorAnchorCache = null; // manual DOM removal bypasses the TOOL_CALL_END invalidation
   R.scrollToBottom();
   R.updateThreadState("active");
   conv.scrollTop = 100;

--- a/cmd/serf-hub/jstest/test-renderer-prepend-settle-release.js
+++ b/cmd/serf-hub/jstest/test-renderer-prepend-settle-release.js
@@ -1,0 +1,180 @@
+// N1-drift-gap: the prepend settle's drift correction writes scrollTop inside
+// a rAF callback; per the HTML spec's update-the-rendering steps the browser
+// fires that write's scroll event in the NEXT frame's scroll steps — which run
+// BEFORE that frame's rAF callbacks — not in a later task. The
+// programmatic-scroll depth hold must therefore be released one FRAME after
+// the correction (a one-task release lands before the event and lets it read
+// as reader intent, suppressing the hydration-end settle).
+// jsdom has no real rAF/scroll-event pipeline, so scheduleFrame is stubbed to
+// capture the keyed callbacks (preserving per-key cancellation) and the test
+// runs them by hand to assert:
+//   (a) the release is scheduled on the "prepend-settle-release" key only
+//       AFTER the settle callback runs (ordering),
+//   (b) a scroll event dispatched between the settle and the release does NOT
+//       set readerScrolledDuringHydration (depth still held), while one
+//       dispatched after the release DOES,
+//   (c) a cancelled settle's holds are drained by the surviving release
+//       (accumulator semantics — no stranded depth),
+//   (d) a cancelled "prepend-settle-release" cannot strand depth either.
+const { JSDOM } = require("jsdom");
+
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST">
+    <span class="status-dot" data-state="active"></span>
+  </header>
+  <div id="conversation-host">
+    <div class="conversation" id="conversation" data-session-id="01TEST" data-state="active"></div>
+  </div>
+  <div id="input-status" class="input-status">
+    <span class="status-item liveness-inline" data-liveness hidden></span>
+  </div>
+</body></html>`, {
+  runScripts: "outside-only",
+  pretendToBeVisual: true,
+  url: "http://127.0.0.1:9180/s/01TEST",
+});
+
+const { window } = dom;
+window.marked = { parse: (text) => text };
+window.fetch = () => Promise.resolve({
+  ok: true,
+  json: () => Promise.resolve([]),
+  text: () => Promise.resolve(""),
+});
+window.SerfAppwire = {
+  tasks: () => new Promise(() => {}),
+  refForSession: (sessionId) => "local:" + sessionId,
+  activeTurnIDFromThread: () => "turn_active",
+  onNotification: () => () => {},
+  onConnectionLost: () => () => {},
+  readThread: () => new Promise(() => {}),
+  listTurns: () => Promise.resolve({ turns: [], nextCursor: "" }),
+  eventsFromThread: (thread) => thread.testEvents || [],
+  eventsFromTurns: (turns) => turns.map((t) => [t.kind || "USER_INPUT", { text: t.text }]),
+  eventsFromNotification: () => [],
+};
+
+require("./load-renderer").evalRenderer(window);
+const R = window.SerfRenderer;
+
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+const STUB_HEIGHT = 5000;
+const conv = window.document.getElementById("conversation");
+Object.defineProperty(conv, "scrollHeight", { value: STUB_HEIGHT, configurable: true });
+
+// Stub scheduleFrame: capture the keyed callbacks instead of running them on
+// jsdom's timer-rAF, preserving the real per-key cancellation semantics
+// (scheduling on a key cancels that key's pending callback).
+const pendingFrames = new Map();
+const frameEntries = [];
+R.scheduleFrame = (cb, key) => {
+  const slot = key == null ? "default" : key;
+  const prev = pendingFrames.get(slot);
+  if (prev) prev.cancelled = true;
+  const entry = { slot, cb, cancelled: false };
+  pendingFrames.set(slot, entry);
+  frameEntries.push(entry);
+};
+const runFrame = (slot) => {
+  const entry = pendingFrames.get(slot);
+  pendingFrames.delete(slot);
+  if (!entry || entry.cancelled) return false;
+  entry.cb();
+  return true;
+};
+// The prepend's internal replay may stick-to-bottom (its own scrollToBottom),
+// which holds depth under a "scroll-bottom-release" frame of its own; flush it
+// so assertions on programmaticScrollDepth isolate the prepend holds.
+const flushScrollBottomRelease = () => {
+  while (pendingFrames.has("scroll-bottom-release")) runFrame("scroll-bottom-release");
+};
+const dispatchScroll = () => conv.dispatchEvent(new window.Event("scroll"));
+
+R.init(conv);
+R.hydrationInProgress = true; // simulate the mid-hydration paging window
+
+// ── (a) ordering: the release is chained one FRAME after the settle ────────
+R.prependOlderTurns([{ kind: "NOOP_KIND", text: "older-a" }]);
+pass(pendingFrames.has("prepend-settle"),
+  "(a) the settle frame is scheduled on the 'prepend-settle' key");
+pass(!pendingFrames.has("prepend-settle-release"),
+  "(a) the release is NOT scheduled before the settle callback runs");
+pass(R.prependSettleHolds === 1 && R.programmaticScrollDepth >= 1,
+  "(a) the prepend holds a depth count from the sync compensation onward (holds=" +
+  R.prependSettleHolds + ", depth=" + R.programmaticScrollDepth + ")");
+
+pass(runFrame("prepend-settle"), "(a) the settle callback ran");
+pass(pendingFrames.has("prepend-settle-release"),
+  "(a) the release is scheduled on the 'prepend-settle-release' key AFTER the settle callback");
+const settleIdx = frameEntries.map((e) => e.slot).lastIndexOf("prepend-settle");
+const releaseIdx = frameEntries.map((e) => e.slot).lastIndexOf("prepend-settle-release");
+pass(settleIdx !== -1 && releaseIdx > settleIdx,
+  "(a) scheduling order: 'prepend-settle' (" + settleIdx + ") precedes 'prepend-settle-release' (" + releaseIdx + ")");
+
+// ── (b) depth held across the correction's scroll-event window ─────────────
+pass(R.programmaticScrollDepth >= 1,
+  "(b) depth is still held after the settle — the release frame is pending (depth=" +
+  R.programmaticScrollDepth + ")");
+dispatchScroll();
+pass(R.readerScrolledDuringHydration === false,
+  "(b) a scroll event dispatched between the settle and the release does NOT read as reader intent");
+
+pass(runFrame("prepend-settle-release"), "(b) the release frame ran");
+pass(R.prependSettleHolds === 0,
+  "(b) the release drained the holds accumulator (prependSettleHolds=" + R.prependSettleHolds + ")");
+flushScrollBottomRelease();
+pass(R.programmaticScrollDepth === 0,
+  "(b) depth returned to 0 after the release (depth=" + R.programmaticScrollDepth + ")");
+dispatchScroll();
+pass(R.readerScrolledDuringHydration === true,
+  "(b) a scroll event dispatched after the release DOES read as reader intent");
+R.readerScrolledDuringHydration = false;
+
+// ── (c) a cancelled settle's hold is drained by the surviving release ──────
+const entriesBeforeC = frameEntries.length;
+R.prependOlderTurns([{ kind: "NOOP_KIND", text: "older-c1" }]);
+R.prependOlderTurns([{ kind: "NOOP_KIND", text: "older-c2" }]); // reschedules 'prepend-settle', cancelling the first
+const settleEntriesC = frameEntries.slice(entriesBeforeC).filter((e) => e.slot === "prepend-settle");
+pass(settleEntriesC.length === 2 && settleEntriesC[0].cancelled && !settleEntriesC[1].cancelled,
+  "(c) the second prepend cancelled the first settle (entries=" + settleEntriesC.length + ")");
+pass(R.prependSettleHolds === 2,
+  "(c) both holds accumulate (prependSettleHolds=" + R.prependSettleHolds + ")");
+pass(runFrame("prepend-settle"), "(c) the surviving settle ran");
+pass(runFrame("prepend-settle-release"), "(c) the surviving release ran");
+pass(R.prependSettleHolds === 0,
+  "(c) the surviving release drained BOTH holds (prependSettleHolds=" + R.prependSettleHolds + ")");
+flushScrollBottomRelease();
+pass(R.programmaticScrollDepth === 0,
+  "(c) no stranded depth after a cancelled settle (depth=" + R.programmaticScrollDepth + ")");
+
+// ── (d) a cancelled 'prepend-settle-release' cannot strand depth ───────────
+R.prependOlderTurns([{ kind: "NOOP_KIND", text: "older-d1" }]);
+pass(runFrame("prepend-settle"), "(d) first settle ran — release now pending");
+const pendingReleaseD = pendingFrames.get("prepend-settle-release");
+R.prependOlderTurns([{ kind: "NOOP_KIND", text: "older-d2" }]); // settle B will reschedule the release key
+pass(runFrame("prepend-settle"), "(d) second settle ran — it rescheduled the release");
+pass(pendingReleaseD && pendingReleaseD.cancelled,
+  "(d) the first release was cancelled by the second settle's release");
+pass(R.prependSettleHolds === 2,
+  "(d) the cancelled release's holds stay in the accumulator (prependSettleHolds=" + R.prependSettleHolds + ")");
+pass(runFrame("prepend-settle-release"), "(d) the surviving release ran");
+pass(R.prependSettleHolds === 0,
+  "(d) the surviving release drained every hold (prependSettleHolds=" + R.prependSettleHolds + ")");
+flushScrollBottomRelease();
+pass(R.programmaticScrollDepth === 0,
+  "(d) no stranded depth after a cancelled release (depth=" + R.programmaticScrollDepth + ")");
+dispatchScroll();
+pass(R.readerScrolledDuringHydration === true,
+  "(d) after the surviving release a scroll event reads as reader intent again");
+
+if (failures.length) {
+  for (const f of failures) console.log(f);
+  process.exit(1);
+}
+console.log("PASS: prepend-settle depth release is frame-chained (ordering, hold window, accumulator drain)");
+process.exit(0);

--- a/cmd/serf-hub/jstest/test-renderer-prepend-settle-release.js
+++ b/cmd/serf-hub/jstest/test-renderer-prepend-settle-release.js
@@ -172,6 +172,64 @@ dispatchScroll();
 pass(R.readerScrolledDuringHydration === true,
   "(d) after the surviving release a scroll event reads as reader intent again");
 
+// ── (e) init() must retire session A's keyed settle/release frames ─────────
+// init() zeroes programmaticScrollDepth/prependSettleHolds, but zeroing alone
+// leaves session A's pending "prepend-settle-release" callback alive: it would
+// fire into session B and drain B's holds, misreading B's correction-window
+// scroll as reader intent. Model keyed cancellation in the stub so init's
+// cancelFrame calls land on the same bookkeeping as the stubbed scheduleFrame.
+R.cancelFrame = (key) => {
+  if (key == null) {
+    for (const entry of pendingFrames.values()) entry.cancelled = true;
+    pendingFrames.clear();
+    return;
+  }
+  const entry = pendingFrames.get(key);
+  if (entry) { entry.cancelled = true; pendingFrames.delete(key); }
+};
+R.hydrationInProgress = true;
+R.prependOlderTurns([{ kind: "NOOP_KIND", text: "e-a" }]);
+pass(runFrame("prepend-settle"), "(e) session A settle ran — its release frame is pending");
+pass(pendingFrames.has("prepend-settle-release"),
+  "(e) session A's release frame is queued behind init");
+flushScrollBottomRelease();
+
+// Session B arrives: htmx swaps in a NEW conversation element (init is
+// idempotent per element, so reusing the old node would no-op).
+const convB = window.document.createElement("div");
+convB.className = "conversation";
+convB.id = "conversation";
+convB.dataset.sessionId = "01TEST";
+convB.dataset.state = "active";
+Object.defineProperty(convB, "scrollHeight", { value: STUB_HEIGHT, configurable: true });
+conv.parentNode.replaceChild(convB, conv);
+R.init(convB);
+pass(R.programmaticScrollDepth === 0 && R.prependSettleHolds === 0,
+  "(e) init zeroed the depth and holds counters");
+pass(!pendingFrames.has("prepend-settle") && !pendingFrames.has("prepend-settle-release"),
+  "(e) init also cancelled session A's keyed prepend-settle frames");
+
+// Session B acquires its own hold, then the browser fires the stale callback.
+R.hydrationInProgress = true;
+R.prependOlderTurns([{ kind: "NOOP_KIND", text: "e-b" }]);
+flushScrollBottomRelease();
+pass(R.prependSettleHolds === 1 && R.programmaticScrollDepth === 1,
+  "(e) session B acquired its own hold (holds=" + R.prependSettleHolds +
+  ", depth=" + R.programmaticScrollDepth + ")");
+const staleFired = runFrame("prepend-settle-release");
+pass(!staleFired, "(e) the stale session-A release callback is inert after init");
+pass(R.prependSettleHolds === 1,
+  "(e) firing the stale callback left B's holds untouched (holds=" + R.prependSettleHolds + ")");
+flushScrollBottomRelease();
+pass(R.programmaticScrollDepth === 1,
+  "(e) firing the stale callback left B's depth untouched (depth=" + R.programmaticScrollDepth + ")");
+// B's own settle/release still drains normally.
+pass(runFrame("prepend-settle"), "(e) B's settle ran");
+pass(runFrame("prepend-settle-release"), "(e) B's release ran");
+pass(R.prependSettleHolds === 0, "(e) B's release drained B's hold");
+flushScrollBottomRelease();
+pass(R.programmaticScrollDepth === 0, "(e) no stranded depth after B's release");
+
 if (failures.length) {
   for (const f of failures) console.log(f);
   process.exit(1);

--- a/cmd/serf-hub/jstest/test-renderer-reasoning-append.js
+++ b/cmd/serf-hub/jstest/test-renderer-reasoning-append.js
@@ -31,6 +31,16 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   pass(typeof R.updateReasoningPreview === "function", "updateReasoningPreview exists");
   const pv = conv.querySelector(".think .pv");
   pass(pv && pv.textContent.includes("first second"), "preview tail reflects the buffer");
+  // ── The preview shows the NEWEST text, not a stale prefix (F5) ─────────
+  // clip(prefix, 200) of the last-400 slice froze the teleprompter on chars
+  // -400..-201 forever. With a >400-char buffer the preview must END with
+  // the live edge of the thought.
+  R.handleData("REASONING_DELTA", { delta: "A".repeat(200), itemId: "r1" });
+  R.handleData("REASONING_DELTA", { delta: "B".repeat(200), itemId: "r1" });
+  const pvText = pv.textContent;
+  pass(pvText.length <= 200, "preview stays bounded to 200 chars (got " + pvText.length + ")");
+  pass(/B+$/.test(pvText) && !pvText.includes("A"), "preview ends with the newest content (B), not the stale prefix (A)");
+  pass(pvText === "B".repeat(200), "preview is exactly the newest 200 normalized chars");
   if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
   console.log("PASS: reasoning appends text nodes; preview tail is bounded");
   process.exit(0);

--- a/cmd/serf-hub/jstest/test-renderer-reasoning-append.js
+++ b/cmd/serf-hub/jstest/test-renderer-reasoning-append.js
@@ -1,0 +1,37 @@
+// Reasoning deltas append (no full-buffer rewrite) and the preview tail
+// updates at settle from a bounded slice.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+window.marked = { parse: (t) => t };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+window.SerfRenderer.init(conv);
+const R = window.SerfRenderer;
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  R.handleData("REASONING_START", { itemId: "r1" });
+  R.handleData("REASONING_DELTA", { delta: "first ", itemId: "r1" });
+  R.handleData("REASONING_DELTA", { delta: "second", itemId: "r1" });
+  const body = conv.querySelector(".think .think-body");
+  pass(body && body.textContent === "first second", "deltas append to the body");
+  pass(body && body.childNodes.length === 2, "append-only: one text node per delta (got " + (body && body.childNodes.length) + ")");
+  pass(typeof R.updateReasoningPreview === "function", "updateReasoningPreview exists");
+  const pv = conv.querySelector(".think .pv");
+  pass(pv && pv.textContent.includes("first second"), "preview tail reflects the buffer");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: reasoning appends text nodes; preview tail is bounded");
+  process.exit(0);
+})();

--- a/cmd/serf-hub/jstest/test-renderer-schedule-frame.js
+++ b/cmd/serf-hub/jstest/test-renderer-schedule-frame.js
@@ -1,0 +1,34 @@
+// scheduleFrame must work where window.requestAnimationFrame is undefined
+// (plain jsdom, and as a proxy for exotic embedded webviews).
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only" });
+const { window } = dom;
+window.marked = { parse: (t) => t };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const R = window.SerfRenderer;
+R.init(window.document.getElementById("conversation"));
+
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  pass(typeof R.scheduleFrame === "function", "scheduleFrame exists");
+  pass(typeof window.requestAnimationFrame === "undefined", "test env really has no rAF");
+  let ran = 0;
+  R.scheduleFrame(() => { ran++; });
+  await new Promise((r) => setTimeout(r, 50));
+  pass(ran === 1, "scheduleFrame falls back to a timer when rAF is missing");
+  // cancelFrame suppresses a pending callback.
+  R.scheduleFrame(() => { ran++; });
+  R.cancelFrame();
+  await new Promise((r) => setTimeout(r, 50));
+  pass(ran === 1, "cancelFrame drops the pending callback");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: scheduleFrame works without requestAnimationFrame");
+  process.exit(0);
+})();

--- a/cmd/serf-hub/jstest/test-renderer-schedule-frame.js
+++ b/cmd/serf-hub/jstest/test-renderer-schedule-frame.js
@@ -28,7 +28,26 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   R.cancelFrame();
   await new Promise((r) => setTimeout(r, 50));
   pass(ran === 1, "cancelFrame drops the pending callback");
+  // Keyed slots: two different keys both fire — neither cancels the other.
+  let a = 0, b = 0;
+  R.scheduleFrame(() => { a++; }, "scroll");
+  R.scheduleFrame(() => { b++; }, "prepend-settle");
+  await new Promise((r) => setTimeout(r, 50));
+  pass(a === 1 && b === 1, "different keys keep independent pending slots (a=" + a + ", b=" + b + ")");
+  // Same-key re-schedule cancels the earlier callback only.
+  let first = 0, second = 0;
+  R.scheduleFrame(() => { first++; }, "viewport");
+  R.scheduleFrame(() => { second++; }, "viewport");
+  await new Promise((r) => setTimeout(r, 50));
+  pass(first === 0 && second === 1, "same-key re-schedule cancels the earlier callback (first=" + first + ", second=" + second + ")");
+  // Bare cancelFrame() cancels every keyed slot.
+  let x = 0, y = 0;
+  R.scheduleFrame(() => { x++; }, "scroll");
+  R.scheduleFrame(() => { y++; }, "prepend-settle");
+  R.cancelFrame();
+  await new Promise((r) => setTimeout(r, 50));
+  pass(x === 0 && y === 0, "bare cancelFrame() cancels all keyed slots (x=" + x + ", y=" + y + ")");
   if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
-  console.log("PASS: scheduleFrame works without requestAnimationFrame");
+  console.log("PASS: scheduleFrame works without requestAnimationFrame; keyed slots stay independent");
   process.exit(0);
 })();

--- a/cmd/serf-hub/jstest/test-renderer-scroll-throttle.js
+++ b/cmd/serf-hub/jstest/test-renderer-scroll-throttle.js
@@ -32,6 +32,14 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   pass(runs <= 1, "scroll handler coalesced to at most one run per frame (got " + runs + ")");
   await new Promise((r) => setTimeout(r, 50));
   pass(runs === 1, "the coalesced run executes on the next frame");
+  // Regression: a same-tick scheduleFrame on another key (prepend-settle) must
+  // not cancel the scroll tick's pending frame — before keyed slots it did,
+  // leaving scrollAffordanceTick stuck true and killing scroll affordance.
+  runs = 0;
+  conv.dispatchEvent(new window.Event("scroll"));
+  R.scheduleFrame(() => {}, "prepend-settle");
+  await new Promise((r) => setTimeout(r, 50));
+  pass(runs === 1, "scroll tick frame survives a prepend-settle scheduleFrame (got " + runs + ")");
   // Anchor cache: querySelectorAll runs once until invalidated.
   let queries = 0;
   const realQSA = conv.querySelectorAll.bind(conv);

--- a/cmd/serf-hub/jstest/test-renderer-scroll-throttle.js
+++ b/cmd/serf-hub/jstest/test-renderer-scroll-throttle.js
@@ -1,0 +1,48 @@
+// Scroll handling is rAF-throttled (N events → one handler run) and error
+// anchors are cached between invalidations.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="idle"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+window.marked = { parse: (t) => t };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+const R = window.SerfRenderer;
+R.init(conv);
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  pass(typeof R.onScrollAffordance === "function", "onScrollAffordance exists");
+  pass(typeof R.errorAnchors === "function", "errorAnchors exists");
+  // Throttle: 5 scroll events in one tick → 1 handler run.
+  let runs = 0;
+  const real = R.onScrollAffordance.bind(R);
+  R.onScrollAffordance = () => { runs++; real(); };
+  for (let i = 0; i < 5; i++) conv.dispatchEvent(new window.Event("scroll"));
+  pass(runs <= 1, "scroll handler coalesced to at most one run per frame (got " + runs + ")");
+  await new Promise((r) => setTimeout(r, 50));
+  pass(runs === 1, "the coalesced run executes on the next frame");
+  // Anchor cache: querySelectorAll runs once until invalidated.
+  let queries = 0;
+  const realQSA = conv.querySelectorAll.bind(conv);
+  conv.querySelectorAll = (sel) => { if (sel.includes('data-attention="error"')) queries++; return realQSA(sel); };
+  R.errorAnchors();
+  R.errorAnchors();
+  pass(queries === 1, "error anchors cached between calls (got " + queries + ")");
+  R.handleData("TOOL_CALL_END", { callId: "nope" });
+  R.errorAnchors();
+  pass(queries === 2, "TOOL_CALL_END invalidates the cache");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: scroll handler throttled; error anchors cached with invalidation");
+  process.exit(0);
+})();

--- a/cmd/serf-hub/jstest/test-renderer-scroll-throttle.js
+++ b/cmd/serf-hub/jstest/test-renderer-scroll-throttle.js
@@ -50,6 +50,30 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   R.handleData("TOOL_CALL_END", { callId: "nope" });
   R.errorAnchors();
   pass(queries === 2, "TOOL_CALL_END invalidates the cache");
+  // Session swap: init() against a fresh conversation element must invalidate
+  // the anchor cache — session A's anchors are detached after the swap and
+  // must not produce a phantom error pill on session B.
+  const anchor = window.document.createElement("div");
+  anchor.className = "tool-call";
+  anchor.dataset.attention = "error";
+  conv.appendChild(anchor);
+  R.errorAnchorCache = null; // a real error row invalidates via TOOL_CALL_END
+  pass(R.errorAnchors().length === 1, "anchor cache populated from session A");
+  // F6: the dirty-assistant set is the same per-conversation hazard.
+  R.dirtyAssistantMessages = new Set([{ el: anchor, textBuf: "stale" }]);
+  const convB = window.document.createElement("div");
+  convB.id = "conversation";
+  convB.dataset.sessionId = "01TESTB";
+  convB.dataset.state = "idle";
+  conv.replaceWith(convB);
+  R.init(convB);
+  pass(R.dirtyAssistantMessages.size === 0, "init clears dirtyAssistantMessages on session swap");
+  let queriesB = 0;
+  const realQSB = convB.querySelectorAll.bind(convB);
+  convB.querySelectorAll = (sel) => { if (sel.includes('data-attention="error"')) queriesB++; return realQSB(sel); };
+  const anchorsB = R.errorAnchors();
+  pass(queriesB === 1, "errorAnchors() re-queries after session swap, no stale cache (got " + queriesB + ")");
+  pass(anchorsB.length === 0, "no detached anchors from session A leak into session B");
   if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
   console.log("PASS: scroll handler throttled; error anchors cached with invalidation");
   process.exit(0);

--- a/cmd/serf-hub/jstest/test-renderer-streaming-tail.js
+++ b/cmd/serf-hub/jstest/test-renderer-streaming-tail.js
@@ -148,6 +148,30 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   R.handleData("ASSISTANT_TEXT_END", { text: delta4 });
   pass(el4.innerHTML === "<p>" + delta4 + "</p>", "finalization parses the surrogate-boundary buffer intact");
 
+  // --- Selection-safe crossing: the head already shows EXACTLY headLen chars
+  // (settled clean — not dirty) when the crossing delta arrives, so no new
+  // content would enter the head. The crossing must NOT re-render it: a
+  // re-parse replaces the head DOM and destroys any reader selection for zero
+  // visual change.
+  R.handleData("TURN_STARTED", { turnId: "t5" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "q".repeat(4096) });
+  const el5 = conv.querySelectorAll(".assistant-message")[4];
+  pass(!!el5, "fifth message element exists");
+  const headP5 = el5 && el5.querySelector("p");
+  pass(headP5 && headP5.textContent === "q".repeat(4096), "head settled at exactly 4096 chars pre-crossing");
+  const headHTML5 = el5.innerHTML;
+  const parsesBefore5 = parses;
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "r".repeat(10) });
+  pass(parses === parsesBefore5, "no head re-parse at the crossing when the head gains no content (selection survives)");
+  pass(el5.querySelector("p") === headP5, "head DOM node untouched at the no-content crossing");
+  pass(el5.innerHTML.indexOf(headHTML5) === 0, "head innerHTML identical across the no-content crossing");
+  const tail5 = el5.querySelector(".streaming-tail");
+  pass(!!tail5, "tail still opens at the no-content crossing");
+  pass(tail5 && rawTailTextOf(tail5) === "r".repeat(10), "the whole crossing delta streams into the tail");
+  R.handleData("ASSISTANT_TEXT_END", { text: "q".repeat(4096) + "r".repeat(10) });
+  pass(el5.innerHTML === "<p>" + "q".repeat(4096) + "r".repeat(10) + "</p>", "finalization parses the no-content-crossing buffer");
+
   if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
   console.log("PASS: frozen head at the crossing, raw tail with aria-hidden caret, single final parse");
   process.exit(0);

--- a/cmd/serf-hub/jstest/test-renderer-streaming-tail.js
+++ b/cmd/serf-hub/jstest/test-renderer-streaming-tail.js
@@ -1,5 +1,9 @@
-// Past 4KB the message stops re-parsing: the parsed head freezes, deltas stream
-// as plain text in .streaming-tail, and finalization parses everything once.
+// Past 4KB the message stops re-parsing: the parsed head FREEZES at the
+// crossing (no re-parse, no reflow, no selection loss), the crossing delta
+// and everything after streams as plain text in .streaming-tail, and
+// finalization parses everything once. The live-tail caret is a real
+// aria-hidden span, not a ::after pseudo-element (which screen readers
+// announce).
 const { JSDOM } = require("jsdom");
 const dom = new JSDOM(`<!DOCTYPE html><html><body>
   <div class="workspace-actions">
@@ -25,22 +29,52 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   await new Promise((r) => setTimeout(r, 30));
   R.handleData("TURN_STARTED", { turnId: "t1" });
   R.handleData("ASSISTANT_TEXT_START", {});
-  const big = "x".repeat(4100);
-  R.handleData("ASSISTANT_TEXT_DELTA", { delta: big });
-  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "**tail**" });
+  // Sub-4KB head first, rendered via handleData so settleFrame parses it.
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "hello head" });
   const el = conv.querySelector(".assistant-message");
   pass(!!el, "message element exists");
-  pass(el.dataset.turnId === "t1", "data-turn-id preserved in tail mode");
+  pass(el.dataset.turnId === "t1", "data-turn-id preserved pre-crossing");
+  const headNodes = Array.from(el.childNodes);
+  const headHTML = el.innerHTML;
+  pass(headHTML === "<p>hello head</p>", "head rendered via settle (got " + JSON.stringify(headHTML) + ")");
+  const parsesAfterHead = parses;
+
+  // The crossing delta: head must freeze, delta streams raw into the tail.
+  const big = "x".repeat(4100);
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: big });
+  pass(parses === parsesAfterHead, "NO parse at the crossing (head freezes)");
+  const afterNodes = Array.from(el.childNodes);
+  pass(afterNodes.length === headNodes.length + 1, "crossing appends exactly one node (the tail)");
+  let headUntouched = true;
+  for (let i = 0; i < headNodes.length; i++) if (afterNodes[i] !== headNodes[i]) headUntouched = false;
+  pass(headUntouched, "head DOM untouched at the crossing (same node references)");
+  pass(el.innerHTML.startsWith(headHTML), "head innerHTML unchanged at the crossing");
   const tail = el.querySelector(".streaming-tail");
   pass(!!tail, "streaming-tail node exists past 4KB");
-  pass(tail && tail.textContent === "**tail**", "tail holds raw un-parsed markdown");
-  pass(el.classList.contains("streaming"), "message carries .streaming for the caret");
+  const rawTailText = () => Array.from(tail.childNodes)
+    .filter((n) => !(n.nodeType === 1 && n.classList.contains("streaming-caret")))
+    .map((n) => n.textContent).join("");
+  pass(tail && rawTailText() === big, "tail holds the CROSSING delta raw, un-parsed");
+  pass(el.classList.contains("streaming"), "message carries .streaming while in tail mode");
+
+  // The caret is a real aria-hidden span, last in the tail — not announced.
+  const caret = tail && tail.querySelector(".streaming-caret");
+  pass(!!caret, "caret is a real span inside the tail");
+  pass(caret && caret.getAttribute("aria-hidden") === "true", "caret is aria-hidden (out of the a11y tree)");
+  pass(caret && caret.textContent === "▍", "caret renders the ▍ glyph");
+  pass(tail && tail.lastElementChild === caret, "caret stays last in the tail");
+
+  // Post-crossing deltas stream raw, insert AHEAD of the caret, no parse.
   const before = parses;
-  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "more" });
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "**tail**" });
   pass(parses === before, "no parse per delta in tail mode");
-  R.handleData("ASSISTANT_TEXT_END", { text: big + "**tail**more" });
+  pass(rawTailText() === big + "**tail**", "post-crossing delta streams raw into the tail");
+  pass(tail.lastElementChild === caret, "caret still glued after the newest text");
+
+  R.handleData("ASSISTANT_TEXT_END", { text: "hello head" + big + "**tail**" });
   pass(!el.querySelector(".streaming-tail"), "finalization replaces the tail with parsed output");
+  pass(!el.querySelector(".streaming-caret"), "caret disappears with the tail at finalization");
   if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
-  console.log("PASS: long messages stream frozen-head/raw-tail and finalize once");
+  console.log("PASS: frozen head at the crossing, raw tail with aria-hidden caret, single final parse");
   process.exit(0);
 })();

--- a/cmd/serf-hub/jstest/test-renderer-streaming-tail.js
+++ b/cmd/serf-hub/jstest/test-renderer-streaming-tail.js
@@ -1,0 +1,46 @@
+// Past 4KB the message stops re-parsing: the parsed head freezes, deltas stream
+// as plain text in .streaming-tail, and finalization parses everything once.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+let parses = 0;
+window.marked = { parse: (t) => { parses++; return "<p>" + t + "</p>"; } };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+window.SerfRenderer.init(conv);
+const R = window.SerfRenderer;
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  R.handleData("TURN_STARTED", { turnId: "t1" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  const big = "x".repeat(4100);
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: big });
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "**tail**" });
+  const el = conv.querySelector(".assistant-message");
+  pass(!!el, "message element exists");
+  pass(el.dataset.turnId === "t1", "data-turn-id preserved in tail mode");
+  const tail = el.querySelector(".streaming-tail");
+  pass(!!tail, "streaming-tail node exists past 4KB");
+  pass(tail && tail.textContent === "**tail**", "tail holds raw un-parsed markdown");
+  pass(el.classList.contains("streaming"), "message carries .streaming for the caret");
+  const before = parses;
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "more" });
+  pass(parses === before, "no parse per delta in tail mode");
+  R.handleData("ASSISTANT_TEXT_END", { text: big + "**tail**more" });
+  pass(!el.querySelector(".streaming-tail"), "finalization replaces the tail with parsed output");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: long messages stream frozen-head/raw-tail and finalize once");
+  process.exit(0);
+})();

--- a/cmd/serf-hub/jstest/test-renderer-streaming-tail.js
+++ b/cmd/serf-hub/jstest/test-renderer-streaming-tail.js
@@ -1,9 +1,10 @@
-// Past 4KB the message stops re-parsing: the parsed head FREEZES at the
-// crossing (no re-parse, no reflow, no selection loss), the crossing delta
-// and everything after streams as plain text in .streaming-tail, and
-// finalization parses everything once. The live-tail caret is a real
-// aria-hidden span, not a ::after pseudo-element (which screen readers
-// announce).
+// Past 4KB the message stops re-parsing: at the crossing the head renders
+// ONCE as the first ≤4096 chars (one bounded parse — so a >4KB first delta
+// still shows its head formatted), then FREEZES; everything past the
+// boundary streams as plain text in .streaming-tail, and finalization parses
+// everything once. The boundary backs off one code unit when it would split
+// a surrogate pair. The live-tail caret is a real aria-hidden span, not a
+// ::after pseudo-element (which screen readers announce).
 const { JSDOM } = require("jsdom");
 const dom = new JSDOM(`<!DOCTYPE html><html><body>
   <div class="workspace-actions">
@@ -34,27 +35,26 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   const el = conv.querySelector(".assistant-message");
   pass(!!el, "message element exists");
   pass(el.dataset.turnId === "t1", "data-turn-id preserved pre-crossing");
-  const headNodes = Array.from(el.childNodes);
   const headHTML = el.innerHTML;
   pass(headHTML === "<p>hello head</p>", "head rendered via settle (got " + JSON.stringify(headHTML) + ")");
   const parsesAfterHead = parses;
 
-  // The crossing delta: head must freeze, delta streams raw into the tail.
+  // The crossing delta: the head is rendered ONCE as the first ≤4096 chars
+  // (parsed, bounded cost), then frozen; the remainder streams raw into the
+  // tail — including the crossing delta's share past the boundary.
   const big = "x".repeat(4100);
   R.handleData("ASSISTANT_TEXT_DELTA", { delta: big });
-  pass(parses === parsesAfterHead, "NO parse at the crossing (head freezes)");
-  const afterNodes = Array.from(el.childNodes);
-  pass(afterNodes.length === headNodes.length + 1, "crossing appends exactly one node (the tail)");
-  let headUntouched = true;
-  for (let i = 0; i < headNodes.length; i++) if (afterNodes[i] !== headNodes[i]) headUntouched = false;
-  pass(headUntouched, "head DOM untouched at the crossing (same node references)");
-  pass(el.innerHTML.startsWith(headHTML), "head innerHTML unchanged at the crossing");
+  pass(parses === parsesAfterHead + 1, "exactly ONE bounded parse at the crossing (head rendered once, then frozen)");
+  const buf1 = "hello head" + big;
+  const headP = el.querySelector("p");
+  pass(headP && headP.textContent === buf1.slice(0, 4096), "head shows the first 4096 chars PARSED at the crossing");
   const tail = el.querySelector(".streaming-tail");
   pass(!!tail, "streaming-tail node exists past 4KB");
   const rawTailText = () => Array.from(tail.childNodes)
     .filter((n) => !(n.nodeType === 1 && n.classList.contains("streaming-caret")))
     .map((n) => n.textContent).join("");
-  pass(tail && rawTailText() === big, "tail holds the CROSSING delta raw, un-parsed");
+  pass(tail && rawTailText() === buf1.slice(4096), "tail holds everything past the 4096 boundary raw, un-parsed");
+  pass(headP && headP.textContent + rawTailText() === buf1, "head + tail reassemble the exact buffer (nothing lost, nothing duplicated)");
   pass(el.classList.contains("streaming"), "message carries .streaming while in tail mode");
 
   // The caret is a real aria-hidden span, last in the tail — not announced.
@@ -68,7 +68,7 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   const before = parses;
   R.handleData("ASSISTANT_TEXT_DELTA", { delta: "**tail**" });
   pass(parses === before, "no parse per delta in tail mode");
-  pass(rawTailText() === big + "**tail**", "post-crossing delta streams raw into the tail");
+  pass(rawTailText() === buf1.slice(4096) + "**tail**", "post-crossing delta streams raw into the tail");
   pass(tail.lastElementChild === caret, "caret still glued after the newest text");
 
   R.handleData("ASSISTANT_TEXT_END", { text: "hello head" + big + "**tail**" });
@@ -97,29 +97,56 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   R.flush();
   const el2 = conv.querySelectorAll(".assistant-message")[1];
   pass(!!el2, "second message element exists");
-  pass(el2 && el2.innerHTML.startsWith("<p>" + head2 + "</p>"),
-    "pending head rendered at the switch inside one flush (got " + JSON.stringify(el2 && el2.innerHTML.slice(0, 120)) + ")");
+  const buf2 = head2 + cross2;
+  const head2El = el2 && el2.querySelector("p");
+  pass(head2El && head2El.textContent === buf2.slice(0, 4096),
+    "head rendered once at the switch inside one flush (first 4096 chars, parsed)");
   const tail2 = el2 && el2.querySelector(".streaming-tail");
   pass(!!tail2, "tail exists after same-flush crossing");
-  pass(tail2 && rawTailTextOf(tail2) === cross2, "tail holds the crossing delta raw after same-flush crossing");
-  pass(el2 && el2.textContent.includes(head2) && el2.textContent.includes(cross2.slice(0, 100)),
+  pass(tail2 && rawTailTextOf(tail2) === buf2.slice(4096), "tail holds the post-boundary remainder raw after same-flush crossing");
+  pass(el2 && el2.textContent.includes(head2) && el2.textContent.includes(cross2.slice(-100)),
     "no content missing after same-flush crossing");
   R.handleData("ASSISTANT_TEXT_END", { text: head2 + cross2 });
   pass(!el2.querySelector(".streaming-tail"), "finalization replaces the same-flush tail");
 
-  // --- First-delta crossing: a single >4KB FIRST delta → empty head, the
-  // entire delta raw in the tail, finalization parses it.
+  // --- First-delta crossing: a single >4KB FIRST delta renders its first
+  // ~4KB PARSED at the switch (the old behavior left the whole message raw
+  // until finalization); the remainder streams raw in the tail.
   R.handleData("TURN_STARTED", { turnId: "t3" });
   R.handleData("ASSISTANT_TEXT_START", {});
-  const first3 = "z".repeat(4100);
+  const parsesBefore3 = parses;
+  const first3 = "**bold** intro " + "z".repeat(5000 - 15);
   R.handleData("ASSISTANT_TEXT_DELTA", { delta: first3 });
   const el3 = conv.querySelectorAll(".assistant-message")[2];
   const tail3 = el3 && el3.querySelector(".streaming-tail");
   pass(!!tail3, "tail exists for first-delta crossing");
-  pass(el3 && !el3.querySelector("p"), "head stays empty for first-delta crossing (nothing pre-crossing to render)");
-  pass(tail3 && rawTailTextOf(tail3) === first3, "entire first delta raw in the tail");
+  pass(parses === parsesBefore3 + 1, "marked stub called once at the first-delta switch (head is parsed, not raw)");
+  const head3 = el3 && el3.querySelector("p");
+  pass(head3 && head3.textContent === first3.slice(0, 4096), "head shows the first ~4KB of the first delta PARSED");
+  pass(head3 && head3.textContent.includes("**bold** intro"), "formatted head carries the delta's leading content");
+  pass(tail3 && rawTailTextOf(tail3) === first3.slice(4096), "tail holds the remainder of the first delta raw");
   R.handleData("ASSISTANT_TEXT_END", { text: first3 });
   pass(el3.innerHTML === "<p>" + first3 + "</p>", "finalization parses the first-delta buffer");
+
+  // --- Surrogate pair astride the 4096 boundary: the boundary backs off one
+  // code unit so the pair stays whole in the tail — no U+FFFD in either part.
+  R.handleData("TURN_STARTED", { turnId: "t4" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  const pre4 = "a".repeat(4095);
+  const emoji = "\u{1F600}"; // surrogate pair: high half lands on index 4095
+  const delta4 = pre4 + emoji + "b".repeat(50);
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: delta4 });
+  const el4 = conv.querySelectorAll(".assistant-message")[3];
+  const head4 = el4 && el4.querySelector("p");
+  pass(head4 && head4.textContent === pre4, "head ends BEFORE the split surrogate pair");
+  pass(head4 && !head4.textContent.includes("�"), "no U+FFFD in the frozen head");
+  const tail4 = el4 && el4.querySelector(".streaming-tail");
+  pass(!!tail4, "tail exists for the surrogate-boundary crossing");
+  pass(tail4 && rawTailTextOf(tail4).startsWith(emoji), "tail starts with the WHOLE surrogate pair");
+  pass(tail4 && !rawTailTextOf(tail4).includes("�"), "no U+FFFD in the tail");
+  pass(head4 && tail4 && head4.textContent + rawTailTextOf(tail4) === delta4, "head + tail reassemble the exact buffer across the surrogate boundary");
+  R.handleData("ASSISTANT_TEXT_END", { text: delta4 });
+  pass(el4.innerHTML === "<p>" + delta4 + "</p>", "finalization parses the surrogate-boundary buffer intact");
 
   if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
   console.log("PASS: frozen head at the crossing, raw tail with aria-hidden caret, single final parse");

--- a/cmd/serf-hub/jstest/test-renderer-streaming-tail.js
+++ b/cmd/serf-hub/jstest/test-renderer-streaming-tail.js
@@ -172,6 +172,39 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   R.handleData("ASSISTANT_TEXT_END", { text: "q".repeat(4096) + "r".repeat(10) });
   pass(el5.innerHTML === "<p>" + "q".repeat(4096) + "r".repeat(10) + "</p>", "finalization parses the no-content-crossing buffer");
 
+  // --- Parse-failure fallback: marked.parse throwing at finalization must
+  // leave the message as plain text (textContent set) with no throw escaping.
+  const realParse = window.marked.parse;
+  window.marked.parse = () => { throw new Error("boom: parser exploded"); };
+  let endThrew = null;
+  R.handleData("TURN_STARTED", { turnId: "t6" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "plain fallback text" });
+  try {
+    R.handleData("ASSISTANT_TEXT_END", { text: "plain fallback text" });
+  } catch (err) {
+    endThrew = err;
+  }
+  window.marked.parse = realParse;
+  const el6 = conv.querySelectorAll(".assistant-message")[5];
+  pass(endThrew === null, "no throw escapes finalization when marked.parse fails: " + (endThrew && endThrew.message));
+  pass(!!el6, "sixth message element exists after the parse failure");
+  pass(el6 && el6.textContent === "plain fallback text", "message stays as plain text when marked.parse throws");
+  pass(el6 && el6.children.length === 0, "plain-text fallback set textContent (no parsed children)");
+
+  // --- Streaming caret breathe (stylesheet): the caret rule references the
+  // one sanctioned soft breathe (--pulse-cycle, think-breathe idiom) and the
+  // reduced-motion collapse covers it.
+  const fs = require("fs");
+  const path = require("path");
+  const css = fs.readFileSync(path.join(__dirname, "..", "assets", "style.css"), "utf8");
+  const caretRule = css.match(/\.assistant-message \.streaming-tail \.streaming-caret \{([^}]*)\}/);
+  pass(!!caretRule, "stylesheet has a .streaming-caret rule");
+  pass(caretRule && /animation:\s*think-breathe var\(--pulse-cycle\) infinite/.test(caretRule[1]),
+    "caret breathes via the think-breathe keyframe on --pulse-cycle (got: " + (caretRule && caretRule[1].trim()) + ")");
+  const reducedMotion = css.match(/@media \(prefers-reduced-motion: reduce\) \{\s*\*, \*::before, \*::after \{\s*animation-duration: 1ms !important;/);
+  pass(!!reducedMotion, "the universal reduced-motion collapse covers the caret breathe");
+
   if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
   console.log("PASS: frozen head at the crossing, raw tail with aria-hidden caret, single final parse");
   process.exit(0);

--- a/cmd/serf-hub/jstest/test-renderer-streaming-tail.js
+++ b/cmd/serf-hub/jstest/test-renderer-streaming-tail.js
@@ -74,6 +74,53 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   R.handleData("ASSISTANT_TEXT_END", { text: "hello head" + big + "**tail**" });
   pass(!el.querySelector(".streaming-tail"), "finalization replaces the tail with parsed output");
   pass(!el.querySelector(".streaming-caret"), "caret disappears with the tail at finalization");
+
+  const rawTailTextOf = (t) => Array.from(t.childNodes)
+    .filter((n) => !(n.nodeType === 1 && n.classList.contains("streaming-caret")))
+    .map((n) => n.textContent).join("");
+
+  // --- Same-flush crossing (batched live path): the last pre-crossing delta
+  // and the crossing delta landing in ONE flush must not lose the head — the
+  // switch renders the pending head once before freezing it.
+  R.handleData("TURN_STARTED", { turnId: "t2" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  // Mirror the frame-batching stub: drive the batched path directly.
+  window.SerfAppwire = {
+    eventsFromNotification: (method, params) =>
+      method === "test/delta" ? [["ASSISTANT_TEXT_DELTA", { delta: params.delta }]] : [],
+  };
+  R.appwireHydrated = true;
+  const head2 = "batched pre-crossing head";
+  const cross2 = "y".repeat(4100);
+  R.enqueueLiveNotification("test/delta", { delta: head2 });
+  R.enqueueLiveNotification("test/delta", { delta: cross2 });
+  R.flush();
+  const el2 = conv.querySelectorAll(".assistant-message")[1];
+  pass(!!el2, "second message element exists");
+  pass(el2 && el2.innerHTML.startsWith("<p>" + head2 + "</p>"),
+    "pending head rendered at the switch inside one flush (got " + JSON.stringify(el2 && el2.innerHTML.slice(0, 120)) + ")");
+  const tail2 = el2 && el2.querySelector(".streaming-tail");
+  pass(!!tail2, "tail exists after same-flush crossing");
+  pass(tail2 && rawTailTextOf(tail2) === cross2, "tail holds the crossing delta raw after same-flush crossing");
+  pass(el2 && el2.textContent.includes(head2) && el2.textContent.includes(cross2.slice(0, 100)),
+    "no content missing after same-flush crossing");
+  R.handleData("ASSISTANT_TEXT_END", { text: head2 + cross2 });
+  pass(!el2.querySelector(".streaming-tail"), "finalization replaces the same-flush tail");
+
+  // --- First-delta crossing: a single >4KB FIRST delta → empty head, the
+  // entire delta raw in the tail, finalization parses it.
+  R.handleData("TURN_STARTED", { turnId: "t3" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  const first3 = "z".repeat(4100);
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: first3 });
+  const el3 = conv.querySelectorAll(".assistant-message")[2];
+  const tail3 = el3 && el3.querySelector(".streaming-tail");
+  pass(!!tail3, "tail exists for first-delta crossing");
+  pass(el3 && !el3.querySelector("p"), "head stays empty for first-delta crossing (nothing pre-crossing to render)");
+  pass(tail3 && rawTailTextOf(tail3) === first3, "entire first delta raw in the tail");
+  R.handleData("ASSISTANT_TEXT_END", { text: first3 });
+  pass(el3.innerHTML === "<p>" + first3 + "</p>", "finalization parses the first-delta buffer");
+
   if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
   console.log("PASS: frozen head at the crossing, raw tail with aria-hidden caret, single final parse");
   process.exit(0);

--- a/cmd/serf-hub/jstest/test-renderer-surrogate-tail.js
+++ b/cmd/serf-hub/jstest/test-renderer-surrogate-tail.js
@@ -1,0 +1,70 @@
+// The 8KB live/final tail slices (shell + read_file, streaming AND bodyEnd)
+// must never begin on a low surrogate: a slice that starts mid-pair renders
+// U+FFFD as the first visible char. Fixture: "A" + "😀" + "x".repeat(7999)
+// is 8002 code units, so slice(-8000) starts exactly on 😀's low surrogate.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+require("./load-renderer").evalRenderer(window);
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+const out = "A" + "😀" + "x".repeat(7999);
+pass(out.length === 8002, "fixture is 8002 code units (slice(-8000) lands on the low surrogate)");
+pass(out.charCodeAt(2) >= 0xDC00 && out.charCodeAt(2) <= 0xDFFF, "fixture code unit 2 is a low surrogate");
+
+const startsClean = (text, label) => {
+  const code = text.charCodeAt(0);
+  pass(!(code >= 0xDC00 && code <= 0xDFFF), label + " begins with a lone low surrogate (renders U+FFFD)");
+  pass(code !== 0xFFFD, label + " begins with U+FFFD");
+  pass(code === "x".charCodeAt(0), label + " should begin on the next whole code unit ('x'), got U+" + code.toString(16));
+};
+
+// ── shell ──────────────────────────────────────────────────────────────────
+const shell = window.SerfRendererInternal.toolRendererFor("shell", {});
+const shellHost = window.document.createElement("div");
+const shellState = { body: shell.body({ command: "yes" }, shellHost), el: shellHost };
+
+shell.bodyDelta(shellState, out); // streaming live tail
+startsClean(shellState.body.pre.textContent, "shell streaming tail");
+pass(shellState.body.pre.textContent.endsWith("x".repeat(100)), "shell streaming tail keeps the tail bytes");
+
+shell.bodyEnd(shellState, { tool_state: JSON.stringify({ exit_code: 0 }) }, out); // post-bodyEnd fold
+const shellPre = shellState.body.pre.textContent;
+const shellMore = shellState.body.wrap.querySelector(".tool-output-more pre");
+const shellFull = shellPre + (shellMore ? "\n" + shellMore.textContent : "");
+pass(shellFull.startsWith("…\n"), "shell bodyEnd keeps the elision prefix");
+startsClean(shellFull.slice(2), "shell bodyEnd tail");
+pass(!shellFull.includes("😀"), "shell bodyEnd elides the split head bytes");
+
+// ── read_file ──────────────────────────────────────────────────────────────
+const read = window.SerfRendererInternal.toolRendererFor("read_file", {});
+const readHost = window.document.createElement("div");
+const readState = { body: read.body({ file_path: "/f" }, readHost), el: readHost };
+
+read.bodyDelta(readState, out); // streaming live tail
+startsClean(readState.body.outputPre.textContent, "read_file streaming tail");
+
+read.bodyEnd(readState, { output: out }, out); // post-bodyEnd fold
+const readPre = readState.body.wrap.querySelector(".read-tool-preview").textContent;
+const readMore = readState.body.wrap.querySelector(".read-tool-more pre");
+const readFull = readPre + (readMore ? "\n" + readMore.textContent : "");
+pass(readFull.startsWith("…\n"), "read_file bodyEnd keeps the elision prefix");
+startsClean(readFull.slice(2), "read_file bodyEnd tail");
+
+// ── shared helper contract ─────────────────────────────────────────────────
+const { tailSlice } = window.SerfRendererInternal;
+pass(typeof tailSlice === "function", "shared surrogate-safe tailSlice helper is exported");
+if (typeof tailSlice === "function") {
+  pass(tailSlice("short", 8000) === "short", "tailSlice returns short text untouched");
+  pass(tailSlice(out, 8000) === "x".repeat(7999), "tailSlice drops the orphaned low surrogate");
+  pass(tailSlice("ab😀cd", 3) === "cd",
+    "tailSlice never starts on a low surrogate (got " + JSON.stringify(tailSlice("ab😀cd", 3)) + ")");
+}
+
+if (failures.length) {
+  for (const f of failures) console.log(f);
+  process.exit(1);
+}
+console.log("PASS: 8KB tail slices are surrogate-safe for shell and read_file, streaming and post-bodyEnd");
+process.exit(0);

--- a/cmd/serf-hub/jstest/test-renderer-surrogate-tail.js
+++ b/cmd/serf-hub/jstest/test-renderer-surrogate-tail.js
@@ -13,6 +13,10 @@ const out = "A" + "😀" + "x".repeat(7999);
 pass(out.length === 8002, "fixture is 8002 code units (slice(-8000) lands on the low surrogate)");
 pass(out.charCodeAt(2) >= 0xDC00 && out.charCodeAt(2) <= 0xDFFF, "fixture code unit 2 is a low surrogate");
 
+// The tail-fold prefix is the honest not-retained note (a bare "…" would
+// masquerade as ordinary output while silently discarding earlier bytes).
+const NOTE = "earlier output not retained — showing the last 8,000 chars\n";
+
 const startsClean = (text, label) => {
   const code = text.charCodeAt(0);
   pass(!(code >= 0xDC00 && code <= 0xDFFF), label + " begins with a lone low surrogate (renders U+FFFD)");
@@ -33,8 +37,8 @@ shell.bodyEnd(shellState, { tool_state: JSON.stringify({ exit_code: 0 }) }, out)
 const shellPre = shellState.body.pre.textContent;
 const shellMore = shellState.body.wrap.querySelector(".tool-output-more pre");
 const shellFull = shellPre + (shellMore ? "\n" + shellMore.textContent : "");
-pass(shellFull.startsWith("…\n"), "shell bodyEnd keeps the elision prefix");
-startsClean(shellFull.slice(2), "shell bodyEnd tail");
+pass(shellFull.startsWith(NOTE), "shell bodyEnd keeps the honest not-retained prefix");
+startsClean(shellFull.slice(NOTE.length), "shell bodyEnd tail");
 pass(!shellFull.includes("😀"), "shell bodyEnd elides the split head bytes");
 
 // ── read_file ──────────────────────────────────────────────────────────────
@@ -49,8 +53,8 @@ read.bodyEnd(readState, { output: out }, out); // post-bodyEnd fold
 const readPre = readState.body.wrap.querySelector(".read-tool-preview").textContent;
 const readMore = readState.body.wrap.querySelector(".read-tool-more pre");
 const readFull = readPre + (readMore ? "\n" + readMore.textContent : "");
-pass(readFull.startsWith("…\n"), "read_file bodyEnd keeps the elision prefix");
-startsClean(readFull.slice(2), "read_file bodyEnd tail");
+pass(readFull.startsWith(NOTE), "read_file bodyEnd keeps the honest not-retained prefix");
+startsClean(readFull.slice(NOTE.length), "read_file bodyEnd tail");
 
 // ── shared helper contract ─────────────────────────────────────────────────
 const { tailSlice } = window.SerfRendererInternal;

--- a/cmd/serf-hub/jstest/test-renderer-thinking.js
+++ b/cmd/serf-hub/jstest/test-renderer-thinking.js
@@ -65,6 +65,25 @@ const R = window.SerfRenderer;
   R.handleData("TURN_COMPLETED", {});
   pass(conv.querySelectorAll(".think").length === 1, "empty thinking block is removed on turn complete");
 
+  // ── Reconnect replay must not strand reasoning state (F1) ──────────────
+  // resetTranscriptReplay wipes the conversation DOM. If reasoningEl keeps
+  // pointing at the detached node, beginReasoning early-returns and every
+  // post-reconnect delta appends to a node that isn't on the page.
+  R.handleData("REASONING_START", { itemId: "r3" });
+  R.handleData("REASONING_DELTA", { delta: "stale pre-reconnect thought", itemId: "r3" });
+  pass(R.reasoningEl && R.reasoningEl.isConnected, "pre-reset reasoning element is live in the DOM");
+  R.resetTranscriptReplay();
+  pass(R.reasoningEl === null, "reset drops the detached reasoning element handle");
+  pass(R.reasoningBuf === "", "reset clears the reasoning buffer");
+  pass(conv.querySelectorAll(".think").length === 0, "reset wipes the transcript DOM");
+  R.handleData("REASONING_START", { itemId: "r4" });
+  R.handleData("REASONING_DELTA", { delta: "fresh post-reconnect thought", itemId: "r4" });
+  const freshThink = conv.querySelector(".think");
+  pass(!!freshThink && freshThink.isConnected, "fresh reasoning renders into the live conversation after reset");
+  const freshBody = conv.querySelector(".think .think-body");
+  pass(freshBody && freshBody.textContent === "fresh post-reconnect thought",
+    "post-reconnect deltas render the NEW content only (got " + JSON.stringify(freshBody && freshBody.textContent) + ")");
+
   if (failures.length > 0) {
     for (const f of failures) console.log(f);
     process.exit(1);

--- a/cmd/serf-hub/jstest/test-renderer-visibility-flush.js
+++ b/cmd/serf-hub/jstest/test-renderer-visibility-flush.js
@@ -33,6 +33,21 @@ const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
   // Tab hides before the scheduled flush fires → event must still apply.
   window.document.dispatchEvent(new window.Event("visibilitychange"));
   pass(conv.querySelector(".assistant-message").textContent === "x", "hide drains the queue");
+
+  // Hidden tab with NO visibilitychange: rAF never fires while hidden, so the
+  // hidden-path timer (250ms) must drain the queue on its own.
+  Object.defineProperty(window.document, "hidden", { value: true, configurable: true });
+  R.enqueueLiveNotification("test/delta", { delta: "y" });
+  pass(conv.querySelector(".assistant-message").textContent === "x", "delta queued while hidden (not yet applied)");
+  await new Promise((r) => setTimeout(r, 400)); // hidden-path timer is 250ms
+  pass(conv.querySelector(".assistant-message").textContent === "xy",
+    "hidden-path timer flush drains the queue without a visibilitychange");
+
+  // Back to visible: a visibilitychange drains immediately again (both directions).
+  Object.defineProperty(window.document, "hidden", { value: false, configurable: true });
+  R.enqueueLiveNotification("test/delta", { delta: "z" });
+  window.document.dispatchEvent(new window.Event("visibilitychange"));
+  pass(conv.querySelector(".assistant-message").textContent === "xyz", "show drains the queue");
   if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
   console.log("PASS: visibilitychange drains the frame queue");
   process.exit(0);

--- a/cmd/serf-hub/jstest/test-renderer-visibility-flush.js
+++ b/cmd/serf-hub/jstest/test-renderer-visibility-flush.js
@@ -1,0 +1,39 @@
+// A visibilitychange in either direction drains a pending frame queue — a
+// scheduled rAF never fires once the tab hides.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+window.marked = { parse: (t) => t };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+const R = window.SerfRenderer;
+R.init(conv);
+// appwire.js is not part of the renderer bundle; stub the one surface the
+// live delivery path touches (the test overrides eventsFromNotification).
+window.SerfAppwire = { eventsFromNotification: () => [] };
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  R.appwireHydrated = true;
+  window.SerfAppwire.eventsFromNotification = (m, p) => m === "test/delta" ? [["ASSISTANT_TEXT_DELTA", { delta: p.delta }]] : [];
+  R.handleData("TURN_STARTED", { turnId: "t1" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  R.enqueueLiveNotification("test/delta", { delta: "x" });
+  // Tab hides before the scheduled flush fires → event must still apply.
+  window.document.dispatchEvent(new window.Event("visibilitychange"));
+  pass(conv.querySelector(".assistant-message").textContent === "x", "hide drains the queue");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: visibilitychange drains the frame queue");
+  process.exit(0);
+})();

--- a/cmd/serf-hub/jstest/test-sandbox-escalation-snapshot.js
+++ b/cmd/serf-hub/jstest/test-sandbox-escalation-snapshot.js
@@ -61,11 +61,13 @@ const { JSDOM } = require("jsdom");
   // (2) A LIVE notification for the SAME id must NOT double-render (de-dupe).
   assert.ok(notify, "renderer subscribed");
   notify("serf/sandbox/escalation/requested", { escalationId: "esc_snap", mode: "read-only", tool: "read_file", kind: "file_tool", deniedPath: "/snapshot/path" });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
   cards = window.document.querySelectorAll(".sandbox-escalation");
   assert.strictEqual(cards.length, 1, "a live notification for an already-snapshotted id must not double-render, got " + cards.length);
 
   // (3) A live notification for a NEW id DOES render a second card.
   notify("serf/sandbox/escalation/requested", { escalationId: "esc_live", mode: "read-only", tool: "write_file", kind: "file_tool", deniedPath: "/live/path" });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
   cards = window.document.querySelectorAll(".sandbox-escalation");
   assert.strictEqual(cards.length, 2, "a new live escalation must render its own card, got " + cards.length);
 

--- a/cmd/serf-hub/jstest/test-sandbox-escalation.js
+++ b/cmd/serf-hub/jstest/test-sandbox-escalation.js
@@ -86,6 +86,7 @@ const { JSDOM } = require("jsdom");
   notify("serf/sandbox/escalation/requested", {
     escalationId: "esc_1", mode: "read-only", tool: "read_file", kind: "file_tool", deniedPath: "/etc/hosts",
   });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
   const card = window.document.querySelector(".sandbox-escalation");
   assert.ok(card, "escalation card must render");
   assert.ok(/requested by serf/i.test(card.textContent),
@@ -113,6 +114,7 @@ const { JSDOM } = require("jsdom");
   notify("serf/sandbox/escalation/requested", {
     escalationId: "esc_2", mode: "read-only", tool: "write_file", kind: "file_tool", deniedPath: "/etc/passwd",
   });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
   const cards = window.document.querySelectorAll(".sandbox-escalation");
   const card2 = cards[cards.length - 1];
   card2.querySelector(".sandbox-escalation-deny").click();
@@ -125,6 +127,7 @@ const { JSDOM } = require("jsdom");
   notify("serf/sandbox/escalation/requested", {
     escalationId: "esc_conflict", mode: "read-only", tool: "read_file", kind: "file_tool", deniedPath: "/etc/shadow",
   });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
   let allCards = window.document.querySelectorAll(".sandbox-escalation");
   const cardC = allCards[allCards.length - 1];
   cardC.querySelector(".sandbox-escalation-allow").click();
@@ -138,6 +141,7 @@ const { JSDOM } = require("jsdom");
   notify("serf/sandbox/escalation/requested", {
     escalationId: "esc_transport", mode: "read-only", tool: "read_file", kind: "file_tool", deniedPath: "/etc/gshadow",
   });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
   allCards = window.document.querySelectorAll(".sandbox-escalation");
   const cardT = allCards[allCards.length - 1];
   cardT.querySelector(".sandbox-escalation-allow").click();
@@ -153,6 +157,7 @@ const { JSDOM } = require("jsdom");
   notify("serf/sandbox/escalation/requested", {
     escalationId: "esc_unavailable", mode: "read-only", tool: "read_file", kind: "file_tool", deniedPath: "/etc/group",
   });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
   allCards = window.document.querySelectorAll(".sandbox-escalation");
   const cardU = allCards[allCards.length - 1];
   cardU.querySelector(".sandbox-escalation-allow").click();

--- a/cmd/serf-hub/jstest/test-task-updated-subscription.js
+++ b/cmd/serf-hub/jstest/test-task-updated-subscription.js
@@ -92,14 +92,16 @@ const { JSDOM } = require("jsdom");
   assert.ok(!intervals.includes(5000),
     "task badge must be event-driven — no 5s poll interval after attach, got intervals " + JSON.stringify(intervals));
 
-  // Assert synchronously, in the same tick as notify(): handleData's
-  // TASKS_CHANGED case updates the badge immediately (synchronously) and
-  // only THEN kicks off the tasks() refetch as a microtask. Our tasks()
-  // stub resolves to [], which (correctly) blanks the badge back to "no
-  // tasks yet" once that microtask runs — awaiting here would race exactly
-  // that harmless-but-overwriting refetch, so the assertion must happen
-  // before it, not after.
+  // Assert synchronously, in the same tick as notify(): TASKS_CHANGED updates
+  // the badge immediately when the frame queue flushes (flush() is a
+  // synchronous drain — live deliveries batch per frame) and only THEN kicks
+  // off the tasks() refetch as a microtask. Our tasks() stub resolves to [],
+  // which (correctly) blanks the badge back to "no tasks yet" once that
+  // microtask runs — awaiting here would race exactly that
+  // harmless-but-overwriting refetch, so the assertion must happen before it,
+  // not after.
   notify("serf/task/updated", { threadId: "01S", total: 3, done: 1 });
+  window.SerfRenderer.flush(); // live deliveries batch per frame; apply them now
 
   const badge = window.document.querySelector(".panel-toggle-badge");
   assert.ok(badge, "task-status badge element must exist");

--- a/cmd/serf-hub/jstest/test-tool-streaming-output.js
+++ b/cmd/serf-hub/jstest/test-tool-streaming-output.js
@@ -1,0 +1,30 @@
+// Streaming shell output updates one <pre> in place (no fold rebuild per
+// delta); the fold chrome appears once at bodyEnd.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+require("./load-renderer").evalRenderer(window);
+const { toolRendererFor } = window.SerfRendererInternal || {};
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+const shell = (window.SerfRendererInternal.toolRendererFor || window.toolRendererFor)("shell", {});
+const host = window.document.createElement("div");
+const state = { body: shell.body({ command: "make test" }, host), el: host };
+
+shell.bodyDelta(state, "line1\nline2");
+const pre = state.body.pre;
+pass(pre && pre.textContent === "line1\nline2", "delta writes the pre directly");
+pass(!state.body.wrap.querySelector(".tool-output-more"), "no fold chrome while streaming");
+pass(state.body.wrap.classList.contains("streaming"), "wrap carries .streaming for the CSS clamp");
+const moreLines = Array.from({ length: 20 }, (_, i) => "l" + i).join("\n");
+shell.bodyDelta(state, moreLines);
+pass(!state.body.wrap.querySelector(".tool-output-more"), "still no fold after >5 lines stream in");
+shell.bodyEnd(state, { tool_state: JSON.stringify({ exit_code: 0 }) }, moreLines);
+pass(!state.body.wrap.classList.contains("streaming"), "bodyEnd drops .streaming");
+pass(!!state.body.wrap.querySelector(".tool-output-more"), "fold chrome built once at bodyEnd");
+pass(state.body.pre.textContent.split("\n").length === 5, "head shows the first 5 lines");
+
+if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+console.log("PASS: shell output streams append-only; fold builds at bodyEnd");
+process.exit(0);

--- a/cmd/serf-hub/jstest/test-tool-streaming-output.js
+++ b/cmd/serf-hub/jstest/test-tool-streaming-output.js
@@ -32,10 +32,26 @@ shell.bodyDelta(state, marker);
 pass(pre.textContent.length === 8000, "streaming caps the pane at 8000 chars");
 pass(pre.textContent.endsWith("TAIL-MARKER"), "streaming shows the LAST 8000 chars (live tail)");
 pass(!pre.textContent.startsWith("HEAD-MARKER"), "the head scrolls off while streaming");
-// bodyEnd keeps the existing head-based clip + fold semantics.
+// bodyEnd folds the TAIL with an elision prefix: the lines the user was
+// watching while streaming stay visible (the old head-clip snapped the pane
+// back to the oldest bytes).
 shell.bodyEnd(state, { tool_state: JSON.stringify({ exit_code: 0 }) }, marker);
-pass(state.body.pre.textContent.startsWith("HEAD-MARKER"), "bodyEnd keeps the head-based clip");
-pass(state.body.pre.textContent.includes("…"), "bodyEnd marks the truncation");
+pass(state.body.pre.textContent.startsWith("…\n"), "bodyEnd prefixes the elision marker");
+pass(state.body.pre.textContent.endsWith("TAIL-MARKER"), "bodyEnd keeps the LAST 8000 chars (the live tail the user was watching)");
+pass(!state.body.pre.textContent.includes("HEAD-MARKER"), "the oldest bytes are elided at bodyEnd");
+
+// Multi-line >8KB output: the expandable content begins with the elision
+// marker and ends with the FINAL line of the output.
+const bigLines = Array.from({ length: 900 }, (_, i) => "line-" + String(i).padStart(4, "0")).join("\n");
+pass(bigLines.length > 8000, "multi-line fixture exceeds the 8000-char budget");
+shell.bodyDelta(state, bigLines);
+shell.bodyEnd(state, { tool_state: JSON.stringify({ exit_code: 0 }) }, bigLines);
+const morePre = state.body.wrap.querySelector(".tool-output-more pre");
+const fullContent = state.body.pre.textContent + (morePre ? "\n" + morePre.textContent : "");
+pass(fullContent.startsWith("…\n"), "expandable content begins with the elision marker");
+pass(fullContent.endsWith("line-0899"), "expandable content ends with the FINAL line of the output");
+pass(!fullContent.includes("line-0000"), "the oldest lines are elided at bodyEnd");
+pass(!!morePre, "tail-folded output still folds past 5 lines");
 
 // The read renderer shares the live-tail streaming behavior.
 const read = (window.SerfRendererInternal.toolRendererFor || window.toolRendererFor)("read_file", {});
@@ -46,8 +62,9 @@ const readPre = readState.body.outputPre;
 pass(readPre.textContent.length === 8000 && readPre.textContent.endsWith("TAIL-MARKER"),
   "read streams the live tail past 8000 chars too");
 read.bodyEnd(readState, { output: marker }, marker);
-pass(readState.body.wrap.querySelector(".read-tool-preview").textContent.startsWith("HEAD-MARKER"),
-  "read bodyEnd keeps the head-based clip");
+const readEndPre = readState.body.wrap.querySelector(".read-tool-preview");
+pass(readEndPre.textContent.startsWith("…\n"), "read bodyEnd prefixes the elision marker");
+pass(readEndPre.textContent.endsWith("TAIL-MARKER"), "read bodyEnd keeps the LAST 8000 chars");
 
 // ── Frame-batched live deltas write the pre ONCE per frame (F4) ──────────
 // Three shell deltas inside one batched flush() must coalesce through the

--- a/cmd/serf-hub/jstest/test-tool-streaming-output.js
+++ b/cmd/serf-hub/jstest/test-tool-streaming-output.js
@@ -36,19 +36,22 @@ pass(!pre.textContent.startsWith("HEAD-MARKER"), "the head scrolls off while str
 // watching while streaming stay visible (the old head-clip snapped the pane
 // back to the oldest bytes).
 shell.bodyEnd(state, { tool_state: JSON.stringify({ exit_code: 0 }) }, marker);
-pass(state.body.pre.textContent.startsWith("…\n"), "bodyEnd prefixes the elision marker");
+pass(state.body.pre.textContent.startsWith("earlier output not retained — showing the last 8,000 chars\n"),
+  "bodyEnd prefixes an HONEST not-retained note (not a bare ellipsis masquerading as ordinary output)");
+pass(!state.body.pre.textContent.startsWith("…\n"), "the bare … prefix is gone — elision is stated, not implied");
 pass(state.body.pre.textContent.endsWith("TAIL-MARKER"), "bodyEnd keeps the LAST 8000 chars (the live tail the user was watching)");
 pass(!state.body.pre.textContent.includes("HEAD-MARKER"), "the oldest bytes are elided at bodyEnd");
 
-// Multi-line >8KB output: the expandable content begins with the elision
-// marker and ends with the FINAL line of the output.
+// Multi-line >8KB output: the expandable content begins with the honest
+// not-retained note and ends with the FINAL line of the output.
 const bigLines = Array.from({ length: 900 }, (_, i) => "line-" + String(i).padStart(4, "0")).join("\n");
 pass(bigLines.length > 8000, "multi-line fixture exceeds the 8000-char budget");
 shell.bodyDelta(state, bigLines);
 shell.bodyEnd(state, { tool_state: JSON.stringify({ exit_code: 0 }) }, bigLines);
 const morePre = state.body.wrap.querySelector(".tool-output-more pre");
 const fullContent = state.body.pre.textContent + (morePre ? "\n" + morePre.textContent : "");
-pass(fullContent.startsWith("…\n"), "expandable content begins with the elision marker");
+pass(fullContent.startsWith("earlier output not retained — showing the last 8,000 chars\n"),
+  "expandable content begins with the honest not-retained note");
 pass(fullContent.endsWith("line-0899"), "expandable content ends with the FINAL line of the output");
 pass(!fullContent.includes("line-0000"), "the oldest lines are elided at bodyEnd");
 pass(!!morePre, "tail-folded output still folds past 5 lines");
@@ -63,7 +66,8 @@ pass(readPre.textContent.length === 8000 && readPre.textContent.endsWith("TAIL-M
   "read streams the live tail past 8000 chars too");
 read.bodyEnd(readState, { output: marker }, marker);
 const readEndPre = readState.body.wrap.querySelector(".read-tool-preview");
-pass(readEndPre.textContent.startsWith("…\n"), "read bodyEnd prefixes the elision marker");
+pass(readEndPre.textContent.startsWith("earlier output not retained — showing the last 8,000 chars\n"),
+  "read bodyEnd prefixes the honest not-retained note");
 pass(readEndPre.textContent.endsWith("TAIL-MARKER"), "read bodyEnd keeps the LAST 8000 chars");
 
 // ── Frame-batched live deltas write the pre ONCE per frame (F4) ──────────

--- a/cmd/serf-hub/jstest/test-tool-streaming-output.js
+++ b/cmd/serf-hub/jstest/test-tool-streaming-output.js
@@ -25,6 +25,30 @@ pass(!state.body.wrap.classList.contains("streaming"), "bodyEnd drops .streaming
 pass(!!state.body.wrap.querySelector(".tool-output-more"), "fold chrome built once at bodyEnd");
 pass(state.body.pre.textContent.split("\n").length === 5, "head shows the first 5 lines");
 
+// Past the 8000-char budget, STREAMING keeps the live tail (a head-clip
+// freezes the pane — the tail stops moving and the command looks stalled).
+const marker = "HEAD-MARKER" + "y".repeat(9000) + "TAIL-MARKER";
+shell.bodyDelta(state, marker);
+pass(pre.textContent.length === 8000, "streaming caps the pane at 8000 chars");
+pass(pre.textContent.endsWith("TAIL-MARKER"), "streaming shows the LAST 8000 chars (live tail)");
+pass(!pre.textContent.startsWith("HEAD-MARKER"), "the head scrolls off while streaming");
+// bodyEnd keeps the existing head-based clip + fold semantics.
+shell.bodyEnd(state, { tool_state: JSON.stringify({ exit_code: 0 }) }, marker);
+pass(state.body.pre.textContent.startsWith("HEAD-MARKER"), "bodyEnd keeps the head-based clip");
+pass(state.body.pre.textContent.includes("…"), "bodyEnd marks the truncation");
+
+// The read renderer shares the live-tail streaming behavior.
+const read = (window.SerfRendererInternal.toolRendererFor || window.toolRendererFor)("read_file", {});
+const readHost = window.document.createElement("div");
+const readState = { body: read.body({ file_path: "/f" }, readHost), el: readHost };
+read.bodyDelta(readState, marker);
+const readPre = readState.body.outputPre;
+pass(readPre.textContent.length === 8000 && readPre.textContent.endsWith("TAIL-MARKER"),
+  "read streams the live tail past 8000 chars too");
+read.bodyEnd(readState, { output: marker }, marker);
+pass(readState.body.wrap.querySelector(".read-tool-preview").textContent.startsWith("HEAD-MARKER"),
+  "read bodyEnd keeps the head-based clip");
+
 if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
 console.log("PASS: shell output streams append-only; fold builds at bodyEnd");
 process.exit(0);

--- a/cmd/serf-hub/jstest/test-tool-streaming-output.js
+++ b/cmd/serf-hub/jstest/test-tool-streaming-output.js
@@ -49,6 +49,54 @@ read.bodyEnd(readState, { output: marker }, marker);
 pass(readState.body.wrap.querySelector(".read-tool-preview").textContent.startsWith("HEAD-MARKER"),
   "read bodyEnd keeps the head-based clip");
 
-if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
-console.log("PASS: shell output streams append-only; fold builds at bodyEnd");
-process.exit(0);
+// ── Frame-batched live deltas write the pre ONCE per frame (F4) ──────────
+// Three shell deltas inside one batched flush() must coalesce through the
+// per-call last-wins map and drain at settleFrame: a single full-body write
+// with the final text, not one textContent replace (+ scrollHeight read) per
+// delta. Probe: MutationObserver childList records on the pre (jsdom emits
+// exactly one record per textContent assignment — verified).
+(async () => {
+  const dom2 = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+  const win2 = dom2.window;
+  win2.marked = { parse: (t) => t };
+  win2.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+  require("./load-renderer").evalRenderer(win2);
+  const conv2 = win2.document.getElementById("conversation");
+  const R2 = win2.SerfRenderer;
+  R2.init(conv2);
+  win2.SerfAppwire = {
+    eventsFromNotification: (m, p) => m === "test/tool-delta"
+      ? [["TOOL_CALL_OUTPUT_DELTA", { call_id: p.call_id, delta: p.delta }]] : [],
+  };
+  await new Promise((r) => setTimeout(r, 30));
+  R2.handleData("TURN_STARTED", { turnId: "t9" });
+  R2.handleData("TOOL_CALL_START", { call_id: "c9", tool_name: "shell", arguments_json: JSON.stringify({ command: "make test" }) });
+  const pre2 = conv2.querySelector(".tool-call.shell pre");
+  pass(!!pre2, "shell body pre exists at TOOL_CALL_START");
+  let writes = 0;
+  const mo = new win2.MutationObserver((recs) => { for (const r of recs) if (r.type === "childList") writes++; });
+  mo.observe(pre2, { childList: true });
+  R2.enqueueLiveNotification("test/tool-delta", { call_id: "c9", delta: "one\n" });
+  R2.enqueueLiveNotification("test/tool-delta", { call_id: "c9", delta: "two\n" });
+  R2.enqueueLiveNotification("test/tool-delta", { call_id: "c9", delta: "three\n" });
+  R2.flush(); // one frame: apply all three, settle once
+  pass(pre2.textContent === "one\ntwo\nthree\n", "the drain writes the FINAL accumulated text (got " + JSON.stringify(pre2.textContent) + ")");
+  await new Promise((r) => setTimeout(r, 0)); // deliver mutation records
+  pass(writes === 1, "three deltas in one flush → the pre is written ONCE (got " + writes + " writes)");
+  mo.disconnect();
+  // The sync path is unchanged: handle→settleFrame drains within the same call.
+  R2.handleData("TOOL_CALL_OUTPUT_DELTA", { call_id: "c9", delta: "four\n" });
+  pass(pre2.textContent === "one\ntwo\nthree\nfour\n", "sync handleData drains the deferred delta in the same call");
+
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: shell output streams append-only; fold builds at bodyEnd; live deltas write once per frame");
+  process.exit(0);
+})();

--- a/cmd/serf-hub/jstest/test-transcript-windowing.js
+++ b/cmd/serf-hub/jstest/test-transcript-windowing.js
@@ -1,0 +1,44 @@
+// Windowing: stylesheet carries content-visibility on conversation children;
+// prepend schedules a next-frame scroll correction.
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+const css = fs.readFileSync(path.resolve(__dirname, "../assets/style.css"), "utf8");
+pass(/\.conversation\s*>\s*\*\s*\{[^}]*content-visibility:\s*auto/.test(css),
+  "conversation children get content-visibility: auto");
+pass(/contain-intrinsic-size:\s*auto\s+\d+px/.test(css),
+  "entries carry a remembered-size estimate");
+
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="idle"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+window.marked = { parse: (t) => t };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+const R = window.SerfRenderer;
+R.init(conv);
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  let scheduled = 0;
+  const realSchedule = R.scheduleFrame.bind(R);
+  R.scheduleFrame = (cb) => { scheduled++; realSchedule(cb); };
+  window.SerfAppwire = window.SerfAppwire || {};
+  window.SerfAppwire.eventsFromTurns = () => [];
+  R.prependOlderTurns([{ id: "old1" }]);
+  pass(scheduled === 1, "prepend schedules a next-frame settle correction");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: windowing CSS present; prepend settles in two phases");
+  process.exit(0);
+})();

--- a/docs/superpowers/plans/2026-07-18-webui-rendering-pipeline.md
+++ b/docs/superpowers/plans/2026-07-18-webui-rendering-pipeline.md
@@ -1,0 +1,1663 @@
+# Web Hub Rendering Pipeline (Plan A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate streaming jank in the Serf web hub transcript: frame-batched live events, coalesced markdown parsing, frozen-head/raw-tail long messages, idempotent finalization, append-only tool output, browser-native windowing, throttled scroll handling.
+
+**Architecture:** No bundler, vanilla JS modules sharing `window.SerfRendererInternal`, loaded in dependency order (see `cmd/serf-hub/jstest/load-renderer.js` and `cmd/serf-hub/templates/app.html`). Live socket events batch per frame at the single `deliverNotification` site; synchronous replay paths (hydration, prepend) bypass the queue. Spec: `docs/superpowers/specs/2026-07-18-webui-foundation-experience-design.md` (§1 + Increments 1–4). Increments 5–9 (layout/CSS/launchpad) are Plan B, written after this lands.
+
+**Tech Stack:** vanilla JS, jsdom-based `jstest` harness (`cmd/serf-hub/jstest/run-all.sh`), Go templates, embedded assets (`make build-hub`).
+
+## Global Constraints
+
+- Every commit leaves `make build-hub` + `cmd/serf-hub/jstest/run-all.sh` + `go test ./cmd/serf-hub` green.
+- TDD: failing test first, minimal implementation, commit.
+- `handleData(kind, data)` keeps its signature and stays SYNCHRONOUS for direct callers (hydration, prepend, tests). Only live socket delivery batches.
+- The reconcile invariant (`renderer.js:677-684`): `reconcilePendingFromNotification` runs once per notification, after that notification's events apply — preserved exactly under batching.
+- The streaming message element keeps `.assistant-message` + `data-turn-id` at all times.
+- New renderer module files (if any) must be added to BOTH `templates/app.html` `<script>` list and `jstest/load-renderer.js` `RENDERER_FILES`, in dependency order. This plan adds NO new module files — everything lands in existing ones.
+- jstest pattern (mirror `test-renderer-thinking.js`): JSDOM with `pretendToBeVisual: true` unless stated otherwise, `window.marked = { parse: (t) => t }`, `require("./load-renderer").evalRenderer(window)`, `window.SerfRenderer.init(conv)`, async IIFE, `process.exit(0)` at the end (renderer pollers keep the loop alive).
+- Work branch: `webui-joy` (already created). Do not touch files outside `cmd/serf-hub/` in this plan.
+
+---
+
+### Task 1: Renderer-file mirror test
+
+Guards the app.html ≡ RENDERER_FILES invariant that today is enforced by convention only.
+
+**Files:**
+- Create: `cmd/serf-hub/jstest/test-renderer-file-mirror.js`
+
+**Interfaces:**
+- Consumes: `require("./load-renderer").RENDERER_FILES` (array of filenames in dependency order).
+- Produces: nothing (test only).
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// The no-bundler renderer bundle must load in the same dependency order in the
+// browser (templates/app.html) and in tests (load-renderer.js RENDERER_FILES).
+// A module added to one list but not the other breaks either the app or every
+// renderer test — this mirror makes the drift a loud failure.
+const fs = require("fs");
+const path = require("path");
+const assert = require("assert");
+const { RENDERER_FILES } = require("./load-renderer");
+
+const appHtml = fs.readFileSync(path.resolve(__dirname, "../templates/app.html"), "utf8");
+const srcs = [...appHtml.matchAll(/<script[^>]+src="([^"]+)"/g)].map((m) => m[1]);
+const scriptNames = srcs.map((s) => s.split("/").pop());
+const mirrored = scriptNames.filter((n) => RENDERER_FILES.includes(n));
+assert.deepStrictEqual(
+  mirrored,
+  RENDERER_FILES,
+  "templates/app.html must load exactly the RENDERER_FILES, in the same order: " +
+    JSON.stringify({ mirrored, RENDERER_FILES })
+);
+console.log("PASS: app.html script order mirrors RENDERER_FILES");
+```
+
+- [ ] **Step 2: Run it — expect PASS immediately** (the invariant holds today; this is a characterization test)
+
+Run: `cd cmd/serf-hub/jstest && node test-renderer-file-mirror.js`
+Expected: PASS. (If it fails, the lists have already drifted — fix whichever list is wrong before continuing.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/serf-hub/jstest/test-renderer-file-mirror.js
+git commit -m "jstest: mirror app.html script order against RENDERER_FILES"
+```
+
+---
+
+### Task 2: `scheduleFrame`/`cancelFrame` helpers (rAF feature-guard)
+
+Plain jsdom (6 jstest files) has NO `requestAnimationFrame` — any new unguarded rAF call crashes those suites. One guarded helper now; all later tasks use it.
+
+**Files:**
+- Modify: `cmd/serf-hub/assets/renderer.js` (add methods near `bindWorkspaceViewport`, ~line 880; adopt in `bindWorkspaceViewport` at ~896)
+- Test: `cmd/serf-hub/jstest/test-renderer-schedule-frame.js`
+
+**Interfaces:**
+- Produces (used by Tasks 5, 6, 13, 15):
+  - `SerfRenderer.scheduleFrame(cb)` — schedules `cb` on rAF when available and document visible; else `setTimeout(cb, 16)`. Returns nothing.
+  - `SerfRenderer.cancelFrame()` — cancels the pending scheduled callback, if any.
+
+- [ ] **Step 1: Write the failing test** (deliberately NO `pretendToBeVisual` → no rAF)
+
+```js
+// scheduleFrame must work where window.requestAnimationFrame is undefined
+// (plain jsdom, and as a proxy for exotic embedded webviews).
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only" });
+const { window } = dom;
+window.marked = { parse: (t) => t };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const R = window.SerfRenderer;
+R.init(window.document.getElementById("conversation"));
+
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  pass(typeof R.scheduleFrame === "function", "scheduleFrame exists");
+  pass(typeof window.requestAnimationFrame === "undefined", "test env really has no rAF");
+  let ran = 0;
+  R.scheduleFrame(() => { ran++; });
+  await new Promise((r) => setTimeout(r, 50));
+  pass(ran === 1, "scheduleFrame falls back to a timer when rAF is missing");
+  // cancelFrame suppresses a pending callback.
+  R.scheduleFrame(() => { ran++; });
+  R.cancelFrame();
+  await new Promise((r) => setTimeout(r, 50));
+  pass(ran === 1, "cancelFrame drops the pending callback");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: scheduleFrame works without requestAnimationFrame");
+  process.exit(0);
+})();
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd cmd/serf-hub/jstest && node test-renderer-schedule-frame.js`
+Expected: FAIL — "scheduleFrame exists"
+
+- [ ] **Step 3: Implement**
+
+In `renderer.js`, add to the `SerfRenderer` object (near `bindWorkspaceViewport`):
+
+```js
+    // scheduleFrame runs cb on the next animation frame when rAF exists and the
+    // tab is visible; otherwise on a 16ms timer. Plain jsdom has no rAF at all,
+    // and hidden tabs never fire it — never call rAF unguarded.
+    scheduleFrame(cb) {
+      this.cancelFrame();
+      const hidden = typeof document !== "undefined" && document.hidden;
+      if (!hidden && typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+        this.scheduledFrameRaf = window.requestAnimationFrame(() => {
+          this.scheduledFrameRaf = null;
+          cb();
+        });
+        return;
+      }
+      this.scheduledFrameTimer = setTimeout(() => {
+        this.scheduledFrameTimer = null;
+        cb();
+      }, 16);
+    },
+
+    cancelFrame() {
+      if (this.scheduledFrameRaf != null && typeof window !== "undefined" && typeof window.cancelAnimationFrame === "function") {
+        try { window.cancelAnimationFrame(this.scheduledFrameRaf); } catch (e) {}
+      }
+      if (this.scheduledFrameTimer != null) clearTimeout(this.scheduledFrameTimer);
+      this.scheduledFrameRaf = null;
+      this.scheduledFrameTimer = null;
+    },
+```
+
+Then in `bindWorkspaceViewport` (~line 886-897), replace the hand-rolled rAF:
+
+```js
+      let frame = null;
+      const apply = () => {
+        frame = null;
+        ...
+      };
+      const schedule = () => {
+        if (frame != null) return;
+        frame = window.requestAnimationFrame(apply);
+      };
+```
+
+with:
+
+```js
+      const apply = () => {
+        if (this.sessionId !== sessionId || document.getElementById("workspace") !== workspace) return;
+        if (Number.isFinite(viewport.height) && viewport.height > 0) {
+          workspace.style.setProperty("--workspace-visible-height", viewport.height + "px");
+        }
+      };
+      const schedule = () => this.scheduleFrame(apply);
+```
+
+and update its cleanup to call `this.cancelFrame()` instead of `cancelAnimationFrame`.
+
+NOTE: `scheduleFrame` supports ONE pending callback (later calls cancel earlier ones). That is correct for every caller in this plan (viewport resize, scroll affordance, prepend settle each keep their own `tick` flag). Do not use it for the frame queue (Task 5 has its own scheduling because it must never cancel a queued flush).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd cmd/serf-hub/jstest && node test-renderer-schedule-frame.js && ./run-all.sh`
+Expected: new test PASS; whole suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/serf-hub/assets/renderer.js cmd/serf-hub/jstest/test-renderer-schedule-frame.js
+git commit -m "renderer: guarded scheduleFrame/cancelFrame helpers (rAF-free environments)"
+```
+
+---
+
+### Task 3: Split `applyEvent` out of `handle`; pass objects instead of JSON round-trip
+
+Behavior-preserving refactor that Task 5 builds on. Also removes the per-event `JSON.stringify`→`parse` round trip (jank finding #6).
+
+**Files:**
+- Modify: `cmd/serf-hub/assets/renderer.js:1047-1068` (`handleData`, `handle`) and the post-switch settle block (~1400-1420)
+
+**Interfaces:**
+- Produces (used by Tasks 4, 5):
+  - `SerfRenderer.applyEvent(kind, data)` — the event switch; `data` is a parsed object. Stamps `lastFrameAt`.
+  - `SerfRenderer.handle(kind, ev)` — thin sync wrapper: buffers while `!descriptionsReady`, parses `ev.data` (string OR object), measures stick, calls `applyEvent`, settles.
+  - `SerfRenderer.handleData(kind, data)` — unchanged signature; now passes the object through (no stringify).
+
+- [ ] **Step 1: Characterization check — no new test; the entire existing suite is the test**
+
+Run: `cd cmd/serf-hub/jstest && ./run-all.sh`
+Expected: all green BEFORE the change (baseline).
+
+- [ ] **Step 2: Implement**
+
+Replace `handleData`/`handle` (renderer.js:1047-1068):
+
+```js
+    handleData(kind, data) {
+      this.handle(kind, { data: data || {} });
+    },
+
+    handle(kind, ev) {
+      // Buffer only during synchronous initialization. Task descriptions are
+      // auxiliary metadata and must never gate transcript replay.
+      if (!this.descriptionsReady && this.eventBuffer) {
+        this.eventBuffer.push([kind, ev]);
+        return;
+      }
+      let data = {};
+      try { data = typeof ev.data === "string" ? JSON.parse(ev.data) : (ev.data || {}); } catch (e) {}
+      // Measure before the DOM mutation: only stick to the bottom if the reader
+      // is already there, so streaming frames don't yank them off history.
+      const stick = this.suppressScrollSettle ? false : this.isNearBottom();
+      const entriesBefore = this.conversation ? this.conversation.children.length : 0;
+      this.applyEvent(kind, data);
+      this.settleFrame(stick, entriesBefore);
+    },
+
+    // applyEvent is the event switch proper, split from the sync wrapper so the
+    // frame-batched live path (flush) can apply N events and settle once.
+    applyEvent(kind, data) {
+      // Every frame from the daemon (incl. reasoning) resets the liveness clock.
+      this.lastFrameAt = Date.now();
+      switch (kind) {
+        // …move the ENTIRE existing switch body here unchanged…
+      }
+    },
+
+    // settleFrame runs the post-mutation work that used to live at the bottom of
+    // handle(): render coalesced assistant/reasoning updates (Tasks 4, 8), count
+    // new entries for the pill, and stick to the bottom when the reader was there.
+    settleFrame(stick, entriesBefore) {
+      if (this.dirtyAssistantMessages && this.dirtyAssistantMessages.size) {
+        for (const m of this.dirtyAssistantMessages) this.renderAssistantMessage(m, m.textBuf);
+        this.dirtyAssistantMessages.clear();
+      }
+      if (this.reasoningPreviewDirty) {
+        this.reasoningPreviewDirty = false;
+        this.updateReasoningPreview();
+      }
+      if (!this.conversation) return;
+      const added = this.conversation.children.length - entriesBefore;
+      if (added > 0) this.noteNewContent(added);
+      if (stick && !this.suppressScrollSettle) this.scrollToBottom();
+    },
+```
+
+Move the post-switch tail of the old `handle` (the `added`/`noteNewContent`/`scrollToBottom` block at ~1400-1420) into `settleFrame` as shown. Keep every comment that documents behavior.
+
+Check the `eventBuffer` drain site (search `eventBuffer` for where buffered events replay): it must keep working with `ev` objects whose `.data` may now be an object — `handle` accepts both, so no change needed there.
+
+- [ ] **Step 3: Run the suite**
+
+Run: `cd cmd/serf-hub/jstest && ./run-all.sh && cd ../../.. && go test ./cmd/serf-hub`
+Expected: all green (pure refactor).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/serf-hub/assets/renderer.js
+git commit -m "renderer: split applyEvent from handle; drop per-event JSON round trip"
+```
+
+---
+
+### Task 4: Coalesce assistant markdown re-parse to once per frame
+
+Kills the O(L²)-per-token re-parse for messages ≤4KB (jank finding #1, short-message half). Live path pays off fully once Task 5 lands; sync callers (tests, hydration) still settle per `handle()` call, so behavior is unchanged there.
+
+**Files:**
+- Modify: `cmd/serf-hub/assets/renderer.js` (`appendAssistantDelta` :2212-2217, `finalizeAssistantMessage` :2236-2251)
+- Test: `cmd/serf-hub/jstest/test-renderer-delta-coalescing.js`
+
+**Interfaces:**
+- Consumes: `settleFrame` dirty-set block (Task 3), `renderAssistantMessage(m, text)`.
+- Produces: `SerfRenderer.markAssistantDirty(m)` — registers `m` for one render at the next settle.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// Assistant deltas must coalesce to at most one marked.parse per settle, not
+// one parse per delta event.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+let parses = 0;
+window.marked = { parse: (t) => { parses++; return t; } };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+window.SerfRenderer.init(conv);
+const R = window.SerfRenderer;
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  R.handleData("TURN_STARTED", { turnId: "t1" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  parses = 0;
+  // Direct internal call: five deltas, one settle (mirrors what the batched
+  // flush does per frame; handleData settles per call by design).
+  R.appendAssistantDelta("a");
+  R.appendAssistantDelta("b");
+  R.appendAssistantDelta("c");
+  R.appendAssistantDelta("d");
+  R.appendAssistantDelta("e");
+  pass(parses === 0, "no parse before settle (got " + parses + ")");
+  R.settleFrame(false, conv.children.length);
+  pass(parses === 1, "exactly one parse per settle for N deltas (got " + parses + ")");
+  const el = conv.querySelector(".assistant-message");
+  pass(el && el.textContent === "abcde", "coalesced content renders");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: assistant deltas coalesce to one parse per settle");
+  process.exit(0);
+})();
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd cmd/serf-hub/jstest && node test-renderer-delta-coalescing.js`
+Expected: FAIL — today each delta parses immediately (parses === 5 before settle).
+
+- [ ] **Step 3: Implement**
+
+```js
+    markAssistantDirty(m) {
+      if (!this.dirtyAssistantMessages) this.dirtyAssistantMessages = new Set();
+      this.dirtyAssistantMessages.add(m);
+    },
+
+    appendAssistantDelta(delta) {
+      const m = this.activeMessages.get(this.currentMessageId);
+      if (!m) return;
+      m.textBuf += delta;
+      this.markAssistantDirty(m);
+    },
+```
+
+In `finalizeAssistantMessage`, remove `m` from the dirty set before the final render so a later settle can't re-render a stale buffer:
+
+```js
+      this.activeMessages.delete(id);
+      this.currentMessageId = null;
+      if (this.dirtyAssistantMessages) this.dirtyAssistantMessages.delete(m);
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd cmd/serf-hub/jstest && node test-renderer-delta-coalescing.js && ./run-all.sh`
+Expected: new test PASS; suite green (existing tests call `handleData`, which settles synchronously, so they see rendered content).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/serf-hub/assets/renderer.js cmd/serf-hub/jstest/test-renderer-delta-coalescing.js
+git commit -m "renderer: coalesce assistant markdown parse to once per settle"
+```
+
+---
+
+### Task 5: Frame-batched live event delivery with `flush()`
+
+The core jank fix. Live socket notifications queue and apply once per frame; hydration/prepend replay stays synchronous. Queue is drained + generation-guarded on transcript reset; per-notification reconcile replay is preserved.
+
+**Files:**
+- Modify: `cmd/serf-hub/assets/renderer.js` — `deliverNotification` (~673-685), the buffered-replay loop (~841-846), `resetTranscriptReplay` (~981-1000)
+- Test: `cmd/serf-hub/jstest/test-renderer-frame-batching.js`
+
+**Interfaces:**
+- Consumes: `applyEvent`, `settleFrame`, `scheduleFrame`'s rAF guard pattern.
+- Produces:
+  - `SerfRenderer.flush()` — synchronously drains the frame queue (test hook + visibilitychange handler).
+  - `SerfRenderer.scheduleFrameFlush()` — schedules one flush (rAF when visible, 250ms timer when `document.hidden`, 16ms timer when no rAF).
+  - `SerfRenderer.cancelFrameFlush()` — cancels a scheduled flush.
+  - `this.frameQueue` (array of `{method, params}`), `this.frameGeneration` (number).
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// Live notifications batch: N deliveries before a flush apply together with a
+// single settle; flush() drains synchronously for tests; a transcript reset
+// invalidates queued events.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+window.marked = { parse: (t) => t };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+const R = window.SerfRenderer;
+R.init(conv);
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  R.appwireHydrated = true; // live mode: deliveries batch
+  pass(typeof R.flush === "function", "flush() exists");
+  pass(Array.isArray(R.frameQueue), "frameQueue exists");
+
+  // Simulate the live delivery path with a stubbed projector.
+  const realEvents = window.SerfAppwire.eventsFromNotification;
+  window.SerfAppwire.eventsFromNotification = (method, params) => {
+    if (method === "test/delta") return [["ASSISTANT_TEXT_DELTA", { delta: params.delta }]];
+    return realEvents ? realEvents(method, params) : [];
+  };
+  R.handleData("TURN_STARTED", { turnId: "t1" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  // Queue three deltas via the internal enqueue used by deliverNotification.
+  R.enqueueLiveNotification("test/delta", { delta: "a" });
+  R.enqueueLiveNotification("test/delta", { delta: "b" });
+  R.enqueueLiveNotification("test/delta", { delta: "c" });
+  pass(conv.querySelector(".assistant-message").textContent === "", "nothing renders before flush");
+  R.flush();
+  pass(conv.querySelector(".assistant-message").textContent === "abc", "flush applies all queued events");
+
+  // Generation guard: queued events from before a reset never land.
+  R.enqueueLiveNotification("test/delta", { delta: "STALE" });
+  R.resetTranscriptReplay();
+  R.flush();
+  pass(!conv.textContent.includes("STALE"), "reset invalidates the queue");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: live notifications batch per frame; reset invalidates the queue");
+  process.exit(0);
+})();
+```
+
+NOTE for the implementer: `enqueueLiveNotification(method, params)` is the extracted queue-push used by `deliverNotification` — name it exactly this; the test drives it directly.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd cmd/serf-hub/jstest && node test-renderer-frame-batching.js`
+Expected: FAIL — "flush() exists"
+
+- [ ] **Step 3: Implement**
+
+Add to `SerfRenderer`:
+
+```js
+    // Frame batching — LIVE socket events only. Replay paths (initial hydration,
+    // buffered-notification replay, prependOlderTurns) call handleData directly
+    // and never enter this queue.
+    enqueueLiveNotification(method, params) {
+      if (!Array.isArray(this.frameQueue)) { this.frameQueue = []; this.frameGeneration = 0; }
+      this.frameQueue.push({ method, params });
+      this.scheduleFrameFlush();
+    },
+
+    scheduleFrameFlush() {
+      if (this.frameFlushScheduled) return;
+      this.frameFlushScheduled = true;
+      const run = () => {
+        this.frameFlushScheduled = false;
+        this.frameFlushRaf = null;
+        this.frameFlushTimer = null;
+        this.flush();
+      };
+      const hidden = typeof document !== "undefined" && document.hidden;
+      if (!hidden && typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+        this.frameFlushRaf = window.requestAnimationFrame(run);
+      } else {
+        // Hidden tab (rAF never fires there) or no rAF at all (plain jsdom).
+        // The interval is best-effort — flush always drains the whole queue.
+        this.frameFlushTimer = setTimeout(run, hidden ? 250 : 16);
+      }
+    },
+
+    cancelFrameFlush() {
+      if (this.frameFlushRaf != null && typeof window !== "undefined" && typeof window.cancelAnimationFrame === "function") {
+        try { window.cancelAnimationFrame(this.frameFlushRaf); } catch (e) {}
+      }
+      if (this.frameFlushTimer != null) clearTimeout(this.frameFlushTimer);
+      this.frameFlushRaf = null;
+      this.frameFlushTimer = null;
+      this.frameFlushScheduled = false;
+    },
+
+    flush() {
+      this.cancelFrameFlush();
+      const q = this.frameQueue;
+      if (!q || !q.length) return;
+      this.frameQueue = [];
+      const gen = this.frameGeneration;
+      const stick = this.suppressScrollSettle ? false : this.isNearBottom();
+      const entriesBefore = this.conversation ? this.conversation.children.length : 0;
+      for (const item of q) {
+        if (gen !== this.frameGeneration) return; // transcript reset mid-flush
+        for (const [kind, data] of window.SerfAppwire.eventsFromNotification(item.method, item.params)) {
+          this.applyEvent(kind, data);
+        }
+        // Per-notification reconcile, in order, after that notification's
+        // events applied — the invariant from deliverNotification.
+        if (this.pending && this.reconcilePending) {
+          this.reconcilePending(this.pending, item.method, item.params);
+        }
+      }
+      this.settleFrame(stick, entriesBefore);
+    },
+```
+
+Change `deliverNotification` (~673):
+
+```js
+      const deliverNotification = (method, params) => {
+        if (!this.appwireHydrated || this.replayingBufferedNotifications) {
+          for (const [kind, data] of window.SerfAppwire.eventsFromNotification(method, params)) {
+            this.handleData(kind, data);
+          }
+          if (this.pending) reconcilePendingFromNotification(this.pending, method, params);
+          return;
+        }
+        this.enqueueLiveNotification(method, params);
+      };
+      this.reconcilePending = reconcilePendingFromNotification;
+```
+
+In the buffered-replay loop (~841), bracket it so it stays synchronous:
+
+```js
+          this.replayingBufferedNotifications = true;
+          try {
+            while (pendingNotifications.length > 0) { …unchanged… }
+          } finally {
+            this.replayingBufferedNotifications = false;
+          }
+```
+
+In `resetTranscriptReplay`, add at the top:
+
+```js
+      this.cancelFrameFlush();
+      this.frameQueue = [];
+      this.frameGeneration = (this.frameGeneration || 0) + 1;
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd cmd/serf-hub/jstest && node test-renderer-frame-batching.js && ./run-all.sh`
+Expected: new test PASS. Suite: appwire-notification tests that assert synchronously after delivering a notification WILL FAIL now — that is expected; Task 7 migrates them. If ANY other test fails, the batching leaked into a sync path — fix before continuing. (Do not commit until Task 7 completes; run Tasks 5-7 as one commit sequence.)
+
+- [ ] **Step 5: (No commit yet — continue to Task 6/7, then commit all three)**
+
+---
+
+### Task 6: Flush on visibility change (hidden-tab correctness)
+
+A queued rAF never fires once the tab hides — flush pending events on hide AND on return so no batch strands.
+
+**Files:**
+- Modify: `cmd/serf-hub/assets/renderer.js` — renderer init region (near other global listener bindings; follow the cleanup pattern of `bindWorkspaceViewport`)
+- Test: `cmd/serf-hub/jstest/test-renderer-visibility-flush.js`
+
+**Interfaces:**
+- Consumes: `flush()`, `frameQueue`.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// A visibilitychange in either direction drains a pending frame queue — a
+// scheduled rAF never fires once the tab hides.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+window.marked = { parse: (t) => t };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+const R = window.SerfRenderer;
+R.init(conv);
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  R.appwireHydrated = true;
+  window.SerfAppwire.eventsFromNotification = (m, p) => m === "test/delta" ? [["ASSISTANT_TEXT_DELTA", { delta: p.delta }]] : [];
+  R.handleData("TURN_STARTED", { turnId: "t1" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  R.enqueueLiveNotification("test/delta", { delta: "x" });
+  // Tab hides before the scheduled flush fires → event must still apply.
+  window.document.dispatchEvent(new window.Event("visibilitychange"));
+  pass(conv.querySelector(".assistant-message").textContent === "x", "hide drains the queue");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: visibilitychange drains the frame queue");
+  process.exit(0);
+})();
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: FAIL — nothing renders (queue sits until the rAF/timer fires).
+
+- [ ] **Step 3: Implement**
+
+Where the renderer binds page-level listeners during `init` (near `bindWorkspaceViewport()` / `bindScrollAffordance()` calls), add:
+
+```js
+      this.bindVisibilityFlush();
+```
+
+and the method:
+
+```js
+    // Flush queued live events on ANY visibility transition: a scheduled rAF
+    // never fires once the tab hides, and on return we want the freshest state
+    // painted immediately.
+    bindVisibilityFlush() {
+      if (this.visibilityFlushBound || typeof document === "undefined") return;
+      this.visibilityFlushBound = true;
+      document.addEventListener("visibilitychange", () => this.flush());
+    },
+```
+
+(Page-level, bound once — no per-session cleanup needed, matching `notifications.js`'s pattern. `flush()` is a no-op on an empty queue.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd cmd/serf-hub/jstest && node test-renderer-visibility-flush.js && ./run-all.sh`
+Expected: new test PASS.
+
+- [ ] **Step 5: (No commit yet — Task 7 next)**
+
+---
+
+### Task 7: Migrate appwire-notification jstests to `flush()`
+
+Tests that deliver live notifications and assert synchronously now need one `R.flush()` (or `await` of the scheduled flush) before asserting.
+
+**Files:**
+- Modify: whichever `cmd/serf-hub/jstest/test-appwire-*.js` (and any other) files fail after Task 5
+
+**Interfaces:**
+- Consumes: `SerfRenderer.flush()`.
+
+- [ ] **Step 1: Identify failures**
+
+Run: `cd cmd/serf-hub/jstest && ./run-all.sh 2>&1 | grep -E '^(FAIL|TIMEOUT)'`
+Expected: a list of test files that drive the notification path.
+
+- [ ] **Step 2: Fix each failing test**
+
+In each failing file, find where a notification is delivered (look for the test's stub of `onNotification` invocation, `deliverNotification`, `readThread` resolution, or `eventsFromNotification` being driven) and insert `R.flush()` immediately before the assertions that now observe stale DOM. Example shape:
+
+```js
+  // …test delivers a live notification…
+  R.flush(); // live deliveries batch per frame; apply them now
+  pass(conv.querySelector(".assistant-message").textContent === "…", "…");
+```
+
+Preserve every existing assertion — this is a mechanical migration, not a rewrite. If a test delivers notifications DURING hydration replay (before `appwireHydrated`), those deliveries stay synchronous — no `flush()` needed there; only live-mode deliveries need it.
+
+- [ ] **Step 3: Run the full gate**
+
+Run: `cd cmd/serf-hub/jstest && ./run-all.sh && cd ../../.. && make build-hub && go test ./cmd/serf-hub`
+Expected: everything green.
+
+- [ ] **Step 4: Commit (Tasks 5+6+7 together)**
+
+```bash
+git add cmd/serf-hub/assets/renderer.js cmd/serf-hub/jstest/
+git commit -m "renderer: frame-batch live socket events with flush-on-hide
+
+Live notifications queue and apply once per frame (single stick measure +
+settle); hydration/prepend replay stays synchronous; the queue drains on
+visibilitychange in both directions and is generation-guarded on transcript
+reset; per-notification pending reconcile replays in order after each
+notification's events. jstest appwire suites migrated to the flush() hook."
+```
+
+---
+
+### Task 8: Reasoning — append-only body, O(1) preview tail
+
+Kills the O(L²) full-buffer `textContent` replace and the O(L) regex per delta.
+
+**Files:**
+- Modify: `cmd/serf-hub/assets/renderer.js` (`appendReasoningDelta` :2328-2338)
+- Test: `cmd/serf-hub/jstest/test-renderer-reasoning-append.js`
+
+**Interfaces:**
+- Consumes: `settleFrame`'s `reasoningPreviewDirty` hook (Task 3).
+- Produces: `SerfRenderer.updateReasoningPreview()` — refreshes the `.pv` teleprompter tail from the last 400 chars of `reasoningBuf`.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// Reasoning deltas append (no full-buffer rewrite) and the preview tail
+// updates at settle from a bounded slice.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+window.marked = { parse: (t) => t };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+window.SerfRenderer.init(conv);
+const R = window.SerfRenderer;
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  R.handleData("REASONING_START", { itemId: "r1" });
+  R.handleData("REASONING_DELTA", { delta: "first ", itemId: "r1" });
+  R.handleData("REASONING_DELTA", { delta: "second", itemId: "r1" });
+  const body = conv.querySelector(".think .think-body");
+  pass(body && body.textContent === "first second", "deltas append to the body");
+  pass(body && body.childNodes.length === 2, "append-only: one text node per delta (got " + (body && body.childNodes.length) + ")");
+  pass(typeof R.updateReasoningPreview === "function", "updateReasoningPreview exists");
+  const pv = conv.querySelector(".think .pv");
+  pass(pv && pv.textContent.includes("first second"), "preview tail reflects the buffer");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: reasoning appends text nodes; preview tail is bounded");
+  process.exit(0);
+})();
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: FAIL — today the body is a single full-buffer text node and `updateReasoningPreview` doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+```js
+    appendReasoningDelta(delta) {
+      if (!this.reasoningEl) this.beginReasoning();
+      this.reasoningBuf += delta || "";
+      const body = this.reasoningEl.querySelector(".think-body");
+      if (body) body.appendChild(document.createTextNode(delta || ""));
+      // The teleprompter tail refreshes once per settle, from a bounded slice.
+      this.reasoningPreviewDirty = true;
+    },
+
+    // updateReasoningPreview refreshes the one-line teleprompter tail. Bounded
+    // to the last 400 chars so a long thought never pays O(buffer) per frame.
+    updateReasoningPreview() {
+      const el = this.reasoningEl;
+      if (!el) return;
+      const pv = el.querySelector(".pv");
+      if (pv) pv.textContent = clip(String(this.reasoningBuf || "").slice(-400).replace(/\s+/g, " ").trim(), 200);
+    },
+```
+
+(`clip` is imported from `window.SerfRendererInternal` at the top of renderer.js — same helper the old code used.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd cmd/serf-hub/jstest && node test-renderer-reasoning-append.js && ./run-all.sh`
+Expected: PASS + suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/serf-hub/assets/renderer.js cmd/serf-hub/jstest/test-renderer-reasoning-append.js
+git commit -m "renderer: append-only reasoning body, bounded preview tail"
+```
+
+---
+
+### Task 9: Streaming text — frozen head, raw tail past 4KB
+
+Long messages stop re-parsing entirely: the parsed DOM freezes, further deltas stream as plain text in a `.streaming-tail` node, and one full parse happens at finalization. Element keeps `.assistant-message` + `data-turn-id`.
+
+**Files:**
+- Modify: `cmd/serf-hub/assets/renderer.js` (`beginAssistantMessage` ~2165-2177, `appendAssistantDelta` from Task 4)
+- Modify: `cmd/serf-hub/assets/style.css` (add `.streaming-tail` + caret rules near the `.assistant-message` block)
+- Test: `cmd/serf-hub/jstest/test-renderer-streaming-tail.js`
+
+**Interfaces:**
+- Consumes: `markAssistantDirty` (Task 4).
+- Produces: `m.tailEl` on the active-message record (Task 10's finalize relies on clearing it via full re-parse).
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// Past 4KB the message stops re-parsing: the parsed head freezes, deltas stream
+// as plain text in .streaming-tail, and finalization parses everything once.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+let parses = 0;
+window.marked = { parse: (t) => { parses++; return "<p>" + t + "</p>"; } };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+window.SerfRenderer.init(conv);
+const R = window.SerfRenderer;
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  R.handleData("TURN_STARTED", { turnId: "t1" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  const big = "x".repeat(4100);
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: big });
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "**tail**" });
+  const el = conv.querySelector(".assistant-message");
+  pass(!!el, "message element exists");
+  pass(el.dataset.turnId === "t1", "data-turn-id preserved in tail mode");
+  const tail = el.querySelector(".streaming-tail");
+  pass(!!tail, "streaming-tail node exists past 4KB");
+  pass(tail && tail.textContent === "**tail**", "tail holds raw un-parsed markdown");
+  pass(el.classList.contains("streaming"), "message carries .streaming for the caret");
+  const before = parses;
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "more" });
+  pass(parses === before, "no parse per delta in tail mode");
+  R.handleData("ASSISTANT_TEXT_END", { text: big + "**tail**more" });
+  pass(!el.querySelector(".streaming-tail"), "finalization replaces the tail with parsed output");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: long messages stream frozen-head/raw-tail and finalize once");
+  process.exit(0);
+})();
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: FAIL — no `.streaming-tail`, no `.streaming` class.
+
+- [ ] **Step 3: Implement**
+
+In `beginAssistantMessage`, add `el.classList.add("streaming")` after `el.className = "assistant-message"`.
+
+Replace Task 4's `appendAssistantDelta`:
+
+```js
+    appendAssistantDelta(delta) {
+      const m = this.activeMessages.get(this.currentMessageId);
+      if (!m) return;
+      m.textBuf += delta;
+      if (!m.tailEl && m.textBuf.length > 4096) {
+        // Frozen head, raw tail: stop re-parsing a long message per frame. The
+        // DOM parsed so far stays; further deltas stream as plain text and the
+        // whole buffer parses once at finalization. Switches on LENGTH only
+        // (never fence state) and never flips back.
+        const tail = document.createElement("span");
+        tail.className = "streaming-tail";
+        m.el.appendChild(tail);
+        m.tailEl = tail;
+        if (this.dirtyAssistantMessages) this.dirtyAssistantMessages.delete(m);
+      }
+      if (m.tailEl) {
+        m.tailEl.appendChild(document.createTextNode(delta));
+      } else {
+        this.markAssistantDirty(m);
+      }
+    },
+```
+
+In `finalizeAssistantMessage`, the existing full `renderAssistantMessage(m, finalText)` already replaces the tail; add `m.el.classList.remove("streaming")` before it, and set `this.lastFinalizedAssistantEl = m.el` after (Task 10 uses this).
+
+In `style.css`, near the `.assistant-message` rules:
+
+```css
+/* Frozen-head/raw-tail streaming (long messages): the tail is plain pre-wrap
+   text with the one sanctioned streaming caret; finalization replaces it with
+   parsed markdown. */
+.assistant-message .streaming-tail {
+  display: block;
+  white-space: pre-wrap;
+  color: var(--text);
+}
+.assistant-message.streaming .streaming-tail::after {
+  content: "▍";
+  color: var(--accent);
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd cmd/serf-hub/jstest && node test-renderer-streaming-tail.js && ./run-all.sh`
+Expected: PASS + green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/serf-hub/assets/renderer.js cmd/serf-hub/assets/style.css cmd/serf-hub/jstest/test-renderer-streaming-tail.js
+git commit -m "renderer: frozen-head/raw-tail streaming for long assistant messages"
+```
+
+---
+
+### Task 10: Idempotent finalization (interrupt + codex END-after-TURN_COMPLETED)
+
+Finalization runs on `ASSISTANT_TEXT_END`, `TURN_COMPLETED`, or `SESSION_END` — whichever first — and is idempotent: a late `ASSISTANT_TEXT_END` replaces the finalized block in place, never appends a duplicate. Interrupt never emits `ASSISTANT_TEXT_END` (serf source), so without this an interrupted long message stays raw forever; the codex path emits END right after TURN_COMPLETED, which without idempotence double-renders.
+
+**Files:**
+- Modify: `cmd/serf-hub/assets/renderer.js` — `finalizeAssistantMessage` (:2236-2251), `TURN_COMPLETED` case (:1104-1106, finalize BEFORE the turn-meta block), `SESSION_END` case (~1374), `beginAssistantMessage` (clear the guard)
+- Test: `cmd/serf-hub/jstest/test-renderer-idempotent-finalize.js`
+
+**Interfaces:**
+- Consumes: `this.lastFinalizedAssistantEl` (set in Task 9's finalize edit).
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// TURN_COMPLETED finalizes from textBuf (interrupt: no ASSISTANT_TEXT_END ever
+// arrives). A subsequent ASSISTANT_TEXT_END for that message (codex
+// turn/completed-with-items path) REPLACES the block in place — no duplicate.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+window.marked = { parse: (t) => "<p>" + t + "</p>" };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+window.SerfRenderer.init(conv);
+const R = window.SerfRenderer;
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  R.handleData("TURN_STARTED", { turnId: "t1" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "partial answer" });
+  // Interrupt shape: TURN_COMPLETED with NO ASSISTANT_TEXT_END.
+  R.handleData("TURN_COMPLETED", { turnId: "t1", turn: { id: "t1", duration_ms: 1200 } });
+  let msgs = conv.querySelectorAll(".assistant-message");
+  pass(msgs.length === 1, "TURN_COMPLETED finalizes the partial message (got " + msgs.length + ")");
+  pass(msgs[0].textContent.includes("partial answer"), "partial content rendered at finalize");
+  pass(msgs[0].querySelector(".turn-meta"), "turn-meta badge appended after finalize");
+  // Codex shape: the synthesized END arrives AFTER TURN_COMPLETED.
+  R.handleData("ASSISTANT_TEXT_END", { text: "partial answer, completed" });
+  msgs = conv.querySelectorAll(".assistant-message");
+  pass(msgs.length === 1, "late END replaces in place — no duplicate (got " + msgs.length + ")");
+  pass(msgs[0].textContent.includes("completed"), "late END content applied");
+  pass(msgs[0].querySelector(".turn-meta"), "turn-meta survives the in-place replace");
+  pass(msgs[0].dataset.turnId === "t1", "turn id preserved through replace");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: finalization is idempotent across TURN_COMPLETED and a late END");
+  process.exit(0);
+})();
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: FAIL — today TURN_COMPLETED doesn't finalize, and the late END appends a second block.
+
+- [ ] **Step 3: Implement**
+
+In the `TURN_COMPLETED` case, immediately after `this.finalizeReasoning();`:
+
+```js
+          this.finalizeAssistantMessage();
+```
+
+(Finalize runs BEFORE the turn-meta block below it, so the badge appends onto the finalized message.)
+
+In the `SESSION_END` case, add at the top:
+
+```js
+          this.finalizeAssistantMessage();
+```
+
+Replace `finalizeAssistantMessage` with the idempotent version:
+
+```js
+    finalizeAssistantMessage(data) {
+      const id = this.currentMessageId;
+      const m = this.activeMessages.get(id);
+      const finalText = (data && data.text) || (m && m.textBuf) || "";
+      if (!m) {
+        // Idempotence: appwire can emit TURN_COMPLETED (which finalizes) and
+        // then a synthesized ASSISTANT_TEXT_END for the same message in one
+        // notification (codex turn/completed-with-items). Between turns
+        // (activeTurnId cleared) a late END REPLACES the finalized block in
+        // place — it must never append a duplicate.
+        const last = this.lastFinalizedAssistantEl;
+        if (!this.activeTurnId && last && last.isConnected && String(finalText).trim()) {
+          const meta = last.querySelector(".turn-meta");
+          try { last.innerHTML = window.marked.parse(finalText); }
+          catch (e) { last.textContent = finalText; }
+          if (meta) last.appendChild(meta); // re-parse destroyed children; the badge rides back
+          return;
+        }
+        this.appendAssistantBlock(finalText);
+        return;
+      }
+      this.activeMessages.delete(id);
+      this.currentMessageId = null;
+      if (this.dirtyAssistantMessages) this.dirtyAssistantMessages.delete(m);
+      if (!String(finalText || "").trim()) {
+        if (m.el.parentNode) m.el.parentNode.removeChild(m.el);
+        return;
+      }
+      m.el.classList.remove("streaming");
+      this.renderAssistantMessage(m, finalText);
+      this.lastFinalizedAssistantEl = m.el;
+    },
+```
+
+In `beginAssistantMessage`, add `this.lastFinalizedAssistantEl = null;` (a new message supersedes the guard).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd cmd/serf-hub/jstest && node test-renderer-idempotent-finalize.js && ./run-all.sh`
+Expected: PASS + green. If `test-renderer-thinking.js` or hydration tests break, check the finalize ordering they assumed (TURN_COMPLETED used to leave messages unfinalized).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/serf-hub/assets/renderer.js cmd/serf-hub/jstest/test-renderer-idempotent-finalize.js
+git commit -m "renderer: idempotent assistant finalization (interrupt + codex late-END)"
+```
+
+---
+
+### Task 11: Communicate dedup against the streaming source buffer
+
+With a raw tail, the last message's DOM `textContent` contains literal markdown, so `lastElementIsAssistantText` misfires and a mid-stream `communicate` message appends a duplicate.
+
+**Files:**
+- Modify: `cmd/serf-hub/assets/renderer.js` (`lastElementIsAssistantText` :2195-2199)
+- Test: `cmd/serf-hub/jstest/test-renderer-communicate-dedup.js`
+
+**Interfaces:**
+- Consumes: `activeMessages`, `currentMessageId`, `normalizedAssistantText`.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// A communicate tool call landing while its agentMessage is still streaming
+// (raw tail mode) must be deduped against the SOURCE buffer, not rendered text.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+window.marked = { parse: (t) => "<p>" + t + "</p>" };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+window.SerfRenderer.init(conv);
+const R = window.SerfRenderer;
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  R.handleData("TURN_STARTED", { turnId: "t1" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  const text = "x".repeat(4100) + " **bold tail**";
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: text }); // switches to raw-tail mode
+  pass(R.lastElementIsAssistantText(text) === true,
+    "dedup matches the streaming message by source, raw tail included");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: communicate dedup compares against the source buffer while streaming");
+  process.exit(0);
+})();
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: FAIL — DOM textContent (rendered head + raw tail) ≠ rendered incoming text.
+
+- [ ] **Step 3: Implement**
+
+```js
+    lastElementIsAssistantText(text) {
+      const last = this.conversation && this.conversation.lastElementChild;
+      if (!last || !last.classList || !last.classList.contains("assistant-message")) return false;
+      // While the last message is still streaming, its DOM may hold a raw
+      // markdown tail — compare source against source instead.
+      const m = this.activeMessages.get(this.currentMessageId);
+      if (m && m.el === last) {
+        return this.normalizedAssistantText(m.textBuf) === this.normalizedAssistantText(text);
+      }
+      return this.normalizedAssistantText(last.textContent) === this.renderedAssistantText(text);
+    },
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd cmd/serf-hub/jstest && node test-renderer-communicate-dedup.js && ./run-all.sh`
+Expected: PASS + green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/serf-hub/assets/renderer.js cmd/serf-hub/jstest/test-renderer-communicate-dedup.js
+git commit -m "renderer: dedup communicate against the streaming source buffer"
+```
+
+---
+
+### Task 12: Shell/read tool output — append-only streaming, chrome at bodyEnd
+
+Kills the per-delta fold rebuild (jank finding #4). During streaming the output is one `<pre>` updated in place, height-clamped and tail-anchored in CSS; the 5-line fold, binary detection, and error replacement happen once at `bodyEnd`.
+
+**Files:**
+- Modify: `cmd/serf-hub/assets/renderer-tools.js` (shell `bodyDelta` :528-532, `bodyEnd` :533-549; `readToolBodyDelta` :225-227, `readToolBodyEnd` :229-231)
+- Modify: `cmd/serf-hub/assets/style.css` (streaming clamp rules)
+- Test: `cmd/serf-hub/jstest/test-tool-streaming-output.js`
+
+**Interfaces:**
+- Consumes: `setExpandableOutput` (unchanged), `clip`.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// Streaming shell output updates one <pre> in place (no fold rebuild per
+// delta); the fold chrome appears once at bodyEnd.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+require("./load-renderer").evalRenderer(window);
+const { toolRendererFor } = window.SerfRendererInternal || {};
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+const shell = (window.SerfRendererInternal.toolRendererFor || window.toolRendererFor)("shell", {});
+const host = window.document.createElement("div");
+const state = { body: shell.body({ command: "make test" }, host), el: host };
+
+shell.bodyDelta(state, "line1\nline2");
+const pre = state.body.pre;
+pass(pre && pre.textContent === "line1\nline2", "delta writes the pre directly");
+pass(!state.body.wrap.querySelector(".tool-output-more"), "no fold chrome while streaming");
+pass(state.body.wrap.classList.contains("streaming"), "wrap carries .streaming for the CSS clamp");
+const moreLines = Array.from({ length: 20 }, (_, i) => "l" + i).join("\n");
+shell.bodyDelta(state, moreLines);
+pass(!state.body.wrap.querySelector(".tool-output-more"), "still no fold after >5 lines stream in");
+shell.bodyEnd(state, { tool_state: JSON.stringify({ exit_code: 0 }) }, moreLines);
+pass(!state.body.wrap.classList.contains("streaming"), "bodyEnd drops .streaming");
+pass(!!state.body.wrap.querySelector(".tool-output-more"), "fold chrome built once at bodyEnd");
+pass(state.body.pre.textContent.split("\n").length === 5, "head shows the first 5 lines");
+
+if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+console.log("PASS: shell output streams append-only; fold builds at bodyEnd");
+process.exit(0);
+```
+
+NOTE for the implementer: check how existing tool-renderer tests (e.g. `test-diff-line-kind.js`) obtain the renderer and the exact shape of `state.body` for shell (`shellTerminalBody`) — mirror that harness. The assertions above assume `state.body = { wrap, pre, footerEl }`; adjust the setup (not the behavior assertions) to the real shape.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: FAIL — today `bodyDelta` builds the fold on every delta.
+
+- [ ] **Step 3: Implement**
+
+In `renderer-tools.js`, shell renderer:
+
+```js
+    bodyDelta: (state, out) => {
+      const b = state.body;
+      if (!b || !b.pre) return;
+      // Stream in place: one <pre>, tail-anchored, height-clamped by CSS. The
+      // fold/binary/error chrome is built once at bodyEnd — never per delta.
+      if (!b.streaming) { b.streaming = true; if (b.wrap) b.wrap.classList.add("streaming"); }
+      b.pre.style.display = "";
+      b.pre.textContent = clip(out, 8000);
+      b.pre.scrollTop = b.pre.scrollHeight;
+    },
+    bodyEnd: (state, data, out) => {
+      if (!state.body) return;
+      state.body.streaming = false;
+      if (state.body.wrap) state.body.wrap.classList.remove("streaming");
+      const text = data.error || out || "";
+      setExpandableOutput(state.body, clip(text, 8000), { moreClass: "shell-output-more", outputClassName: "shell-output terminal-output" });
+      // …rest unchanged (footer, failure expansion)…
+    },
+```
+
+Read renderer, same pattern:
+
+```js
+  function readToolBodyDelta(state, out) {
+    const b = state.body;
+    if (!b || !b.outputPre) return;
+    if (!b.streaming) { b.streaming = true; if (b.wrap) b.wrap.classList.add("streaming"); }
+    b.outputPre.style.display = "";
+    b.outputPre.textContent = clip(out || "", 8000);
+    b.outputPre.scrollTop = b.outputPre.scrollHeight;
+  }
+
+  function readToolBodyEnd(state, data, out) {
+    if (state.body) {
+      state.body.streaming = false;
+      if (state.body.wrap) state.body.wrap.classList.remove("streaming");
+    }
+    setReadOutput(state, clip(data.error || out || "", 8000));
+  }
+```
+
+In `style.css`:
+
+```css
+/* Streaming tool output: one clamped, tail-anchored pane until bodyEnd builds
+   the fold chrome. */
+.tool-body.streaming .terminal-output,
+.tool-body.streaming .read-tool-preview {
+  max-height: 16em;
+  overflow-y: auto;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd cmd/serf-hub/jstest && node test-tool-streaming-output.js && ./run-all.sh`
+Expected: PASS + green. If `test-appwire-tool-output-stream.js` asserts the old per-delta fold, update it to the new contract (stream = plain pre; fold at end).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/serf-hub/assets/renderer-tools.js cmd/serf-hub/assets/style.css cmd/serf-hub/jstest/
+git commit -m "renderer-tools: append-only streaming tool output, fold chrome at bodyEnd"
+```
+
+---
+
+### Task 13: Transcript windowing + two-phase prepend settle
+
+`content-visibility: auto` on every direct child of `#conversation`; prepend does a next-frame correction so estimate-based scroll restoration can't drift visibly.
+
+**Files:**
+- Modify: `cmd/serf-hub/assets/style.css` (`.conversation` block ~1592)
+- Modify: `cmd/serf-hub/assets/renderer.js` (`prependOlderTurns` :4654-4659)
+- Test: `cmd/serf-hub/jstest/test-transcript-windowing.js`
+
+**Interfaces:**
+- Consumes: `scheduleFrame` (Task 2).
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// Windowing: stylesheet carries content-visibility on conversation children;
+// prepend schedules a next-frame scroll correction.
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+const css = fs.readFileSync(path.resolve(__dirname, "../assets/style.css"), "utf8");
+pass(/\.conversation\s*>\s*\*\s*\{[^}]*content-visibility:\s*auto/.test(css),
+  "conversation children get content-visibility: auto");
+pass(/contain-intrinsic-size:\s*auto\s+\d+px/.test(css),
+  "entries carry a remembered-size estimate");
+
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="idle"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+window.marked = { parse: (t) => t };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+const R = window.SerfRenderer;
+R.init(conv);
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  let scheduled = 0;
+  const realSchedule = R.scheduleFrame.bind(R);
+  R.scheduleFrame = (cb) => { scheduled++; realSchedule(cb); };
+  window.SerfAppwire = window.SerfAppwire || {};
+  window.SerfAppwire.eventsFromTurns = () => [];
+  R.prependOlderTurns([{ id: "old1" }]);
+  pass(scheduled === 1, "prepend schedules a next-frame settle correction");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: windowing CSS present; prepend settles in two phases");
+  process.exit(0);
+})();
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: FAIL — no CSS rule, no scheduled correction.
+
+- [ ] **Step 3: Implement**
+
+In `style.css` (near `.conversation`):
+
+```css
+/* Browser-native windowing: off-screen transcript entries skip layout/paint.
+   `auto` reuses each entry's last-rendered size, so scroll geometry is exact
+   for anything rendered once; only never-rendered deep history uses the
+   estimate (prepend corrects it on the next frame). */
+.conversation > * {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 240px;
+}
+```
+
+In `prependOlderTurns`, replace the tail (:4654-4659):
+
+```js
+      const beforeHeight = sc.scrollHeight;
+      const beforeTop = sc.scrollTop;
+      const frag = document.createDocumentFragment();
+      while (staging.firstChild) frag.appendChild(staging.firstChild);
+      sc.insertBefore(frag, sc.firstChild);
+      sc.scrollTop = beforeTop + (sc.scrollHeight - beforeHeight);
+      // Second settle: freshly prepended entries may sit at estimated sizes
+      // (content-visibility). After the browser lays out the near-viewport
+      // ones, correct the residual drift so the reader's anchor holds.
+      const settledHeight = sc.scrollHeight;
+      this.scheduleFrame(() => {
+        if (!sc.isConnected) return;
+        const drift = sc.scrollHeight - settledHeight;
+        if (drift) sc.scrollTop += drift;
+      });
+```
+
+- [ ] **Step 4: Run tests + build**
+
+Run: `cd cmd/serf-hub/jstest && node test-transcript-windowing.js && ./run-all.sh && cd ../../.. && make build-hub`
+Expected: PASS + green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/serf-hub/assets/style.css cmd/serf-hub/assets/renderer.js cmd/serf-hub/jstest/test-transcript-windowing.js
+git commit -m "renderer: content-visibility windowing + two-phase prepend settle"
+```
+
+---
+
+### Task 14: Hydration settle-once
+
+Per-event stick measurement during the hydration replay loop is the O(N²) session-open path (jank finding #2). Suppress it; settle once at the end.
+
+**Files:**
+- Modify: `cmd/serf-hub/assets/renderer.js` — the `readThread` `.then` hydration block (~808-847)
+- Test: `cmd/serf-hub/jstest/test-renderer-hydration-settle.js`
+
+**Interfaces:**
+- Consumes: `this.suppressScrollSettle` (honored by `handle`/`settleFrame` since Task 3).
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// During hydration replay, per-event stick/scroll work is suppressed; one
+// scroll settle runs when hydration completes.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+window.marked = { parse: (t) => t };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+const R = window.SerfRenderer;
+R.init(conv);
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  pass(R.suppressScrollSettle === false || R.suppressScrollSettle === undefined,
+    "not suppressing outside hydration");
+  let measures = 0;
+  const realIsNearBottom = R.isNearBottom.bind(R);
+  R.isNearBottom = () => { measures++; return realIsNearBottom(); };
+  R.suppressScrollSettle = true;
+  R.handleData("TURN_STARTED", { turnId: "t1" });
+  R.handleData("ASSISTANT_TEXT_START", {});
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "hi" });
+  pass(measures === 0, "no stick measurement while suppressed (got " + measures + ")");
+  R.suppressScrollSettle = false;
+  R.handleData("ASSISTANT_TEXT_DELTA", { delta: "!" });
+  pass(measures === 1, "measurement resumes after suppression");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: scroll settle is suppressible during replay");
+  process.exit(0);
+})();
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: FAIL — `suppressScrollSettle` honored since Task 3 in `handle`… verify: Task 3's `handle` checks it, so the flag mechanics may already pass. The REAL failing assertion for this task is the hydration wiring — extend the test: stub `window.SerfAppwire.readThread`/`onNotification`/`refForSession` so `R.connectAppwire` (or the init path that hydrates — check the method name containing `deliverNotification`, ~line 600-860) can be driven, then assert `isNearBottom` was called at most once around a multi-event hydration. Mirror the existing hydration test's appwire stubs (`test-renderer-hydration-order.js` — READ IT FIRST and reuse its stubbing).
+
+- [ ] **Step 3: Implement**
+
+In the `readThread(...).then` block: set the flag before the replay loop, clear it after the buffered-notification replay, and settle once:
+
+```js
+          hydratedNotificationKeys = hydrationKeysFromThread(thread);
+          const hydrationEvents = Array.from(window.SerfAppwire.eventsFromThread(thread));
+          this.suppressScrollSettle = true;
+          try {
+            for (const [kind, data] of hydrationEvents) {
+              this.handleData(kind, data);
+            }
+            await this.loadOlderTurnsUntilPrimaryDialogue(
+              this.eventsContainPrimaryDialogue(hydrationEvents),
+              sessionId, conversation, appwireStream,
+            );
+            if (this.liveStream !== appwireStream || this.conversation !== conversation) return;
+            this.surfaceSnapshotEscalations(thread);
+            this.appwireHydrated = true;
+            this.clearConnectionBanner();
+            this.replayingBufferedNotifications = true;
+            try {
+              while (pendingNotifications.length > 0) { …unchanged… }
+            } finally {
+              this.replayingBufferedNotifications = false;
+            }
+          } finally {
+            this.suppressScrollSettle = false;
+          }
+          this.scrollToBottom();
+```
+
+Also reset `this.suppressScrollSettle = false` in `resetTranscriptReplay` and in the `.catch` path so a failed hydration can't wedge scrolling.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd cmd/serf-hub/jstest && node test-renderer-hydration-settle.js && ./run-all.sh`
+Expected: PASS + green (especially `test-renderer-hydration-order.js`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/serf-hub/assets/renderer.js cmd/serf-hub/jstest/test-renderer-hydration-settle.js
+git commit -m "renderer: suppress per-event scroll settle during hydration replay"
+```
+
+---
+
+### Task 15: Throttled scroll handler + cached error anchors
+
+The scroll listener currently does O(transcript) `querySelectorAll` + layout reads per scroll event (jank finding #5).
+
+**Files:**
+- Modify: `cmd/serf-hub/assets/renderer.js` — `bindScrollAffordance` (:4508-4522), `pickUrgentAnchor` (:4470-4477), `TOOL_CALL_END` case in `applyEvent`, `prependOlderTurns`, `resetTranscriptReplay`
+- Test: `cmd/serf-hub/jstest/test-renderer-scroll-throttle.js`
+
+**Interfaces:**
+- Consumes: `scheduleFrame` (Task 2).
+- Produces:
+  - `SerfRenderer.onScrollAffordance()` — the extracted scroll handler body.
+  - `SerfRenderer.errorAnchors()` — cached `Array` of `.tool-call[data-attention="error"]`; cache invalidated on `TOOL_CALL_END`, prepend, reset.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// Scroll handling is rAF-throttled (N events → one handler run) and error
+// anchors are cached between invalidations.
+const { JSDOM } = require("jsdom");
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="idle"></div>
+  <form data-input-form data-session-id="01TEST"><textarea class="message-input"></textarea></form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+const { window } = dom;
+window.marked = { parse: (t) => t };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+require("./load-renderer").evalRenderer(window);
+const conv = window.document.getElementById("conversation");
+const R = window.SerfRenderer;
+R.init(conv);
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+(async () => {
+  await new Promise((r) => setTimeout(r, 30));
+  pass(typeof R.onScrollAffordance === "function", "onScrollAffordance exists");
+  pass(typeof R.errorAnchors === "function", "errorAnchors exists");
+  // Throttle: 5 scroll events in one tick → 1 handler run.
+  let runs = 0;
+  const real = R.onScrollAffordance.bind(R);
+  R.onScrollAffordance = () => { runs++; real(); };
+  for (let i = 0; i < 5; i++) conv.dispatchEvent(new window.Event("scroll"));
+  pass(runs <= 1, "scroll handler coalesced to at most one run per frame (got " + runs + ")");
+  await new Promise((r) => setTimeout(r, 50));
+  pass(runs === 1, "the coalesced run executes on the next frame");
+  // Anchor cache: querySelectorAll runs once until invalidated.
+  let queries = 0;
+  const realQSA = conv.querySelectorAll.bind(conv);
+  conv.querySelectorAll = (sel) => { if (sel.includes('data-attention="error"')) queries++; return realQSA(sel); };
+  R.errorAnchors();
+  R.errorAnchors();
+  pass(queries === 1, "error anchors cached between calls (got " + queries + ")");
+  R.handleData("TOOL_CALL_END", { callId: "nope" });
+  R.errorAnchors();
+  pass(queries === 2, "TOOL_CALL_END invalidates the cache");
+  if (failures.length) { for (const f of failures) console.log(f); process.exit(1); }
+  console.log("PASS: scroll handler throttled; error anchors cached with invalidation");
+  process.exit(0);
+})();
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: FAIL — methods don't exist; handler runs per event.
+
+- [ ] **Step 3: Implement**
+
+Replace the scroll listener in `bindScrollAffordance`:
+
+```js
+      if (!el.__serfScrollPillBound) {
+        el.__serfScrollPillBound = true;
+        el.addEventListener("scroll", () => {
+          if (this.scrollAffordanceTick) return;
+          this.scrollAffordanceTick = true;
+          this.scheduleFrame(() => {
+            this.scrollAffordanceTick = false;
+            this.onScrollAffordance();
+          });
+        });
+      }
+```
+
+Extract the body:
+
+```js
+    onScrollAffordance() {
+      if (this.isNearTop()) this.maybeLoadOlderTurns();
+      if (this.isNearBottom()) this.clearNewContentPill();
+      else if (this.newContentCount > 0) this.renderNewContentPill();
+      this.renderNeedsYouDock();
+    },
+```
+
+Anchor cache + use in `pickUrgentAnchor`:
+
+```js
+    errorAnchors() {
+      if (!this.errorAnchorCache) {
+        this.errorAnchorCache = this.conversation
+          ? Array.from(this.conversation.querySelectorAll('.tool-call[data-attention="error"]'))
+          : [];
+      }
+      return this.errorAnchorCache;
+    },
+```
+
+In `pickUrgentAnchor`, replace `const errors = Array.from(sc.querySelectorAll(...))` with `const errors = this.errorAnchors();`.
+
+Invalidate: add `this.errorAnchorCache = null;` in the `TOOL_CALL_END` case of `applyEvent`, at the end of `prependOlderTurns`, and in `resetTranscriptReplay`.
+
+NOTE: `scheduleFrame` supports one pending callback — the scroll tick flag makes that safe here, and Task 13's prepend settle uses its own call. If both race, the later cancels the earlier; the tick flag means the scroll handler re-arms on the next event, and prepend's settle is one-shot — acceptable; do NOT "fix" by removing the tick flag.
+
+- [ ] **Step 4: Run the full gate**
+
+Run: `cd cmd/serf-hub/jstest && node test-renderer-scroll-throttle.js && ./run-all.sh && cd ../../.. && make build-hub && go test ./cmd/serf-hub`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/serf-hub/assets/renderer.js cmd/serf-hub/jstest/test-renderer-scroll-throttle.js
+git commit -m "renderer: rAF-throttled scroll handler + cached error anchors"
+```
+
+---
+
+## Final verification (after Task 15)
+
+- [ ] Full gate: `make build-hub && cmd/serf-hub/jstest/run-all.sh && go test ./cmd/serf-hub`
+- [ ] Manual smoke with live assets: `SERF_HUB_ASSETS_DIR=$PWD/cmd/serf-hub ./serf-hub` (dev loop per design-system §10), open a streaming session at 1440px and 390px: streaming is smooth, long messages flip to raw tail and finalize formatted, interrupted turns finalize, scroll-up during streaming doesn't jump, session open doesn't stall.
+- [ ] Playwright before/after screenshots (390/768/1100/1440/2560 × dark) archived to `/tmp/webui-study/after/` for the visual review with the product owner.

--- a/docs/superpowers/specs/2026-07-18-webui-foundation-experience-design.md
+++ b/docs/superpowers/specs/2026-07-18-webui-foundation-experience-design.md
@@ -1,7 +1,13 @@
 # Serf Web Hub — Foundation + Experience Pass
 
-Status: approved (2026-07-18). Work branch: `webui-joy`.
+Status: approved (2026-07-18), revised after adversarial review (v2, same day).
+Work branch: `webui-joy`.
 Scope: `cmd/serf-hub` frontend (`assets/`, `templates/`, and `web.go` home rendering).
+
+v2 changes: two adversarial reviewers each found 13 verified issues in v1
+(reports in session transcripts `local:033rmJG0Qq602H7gRXkinK` and
+`local:033rmJGtbkJZDf40au0ZnP`). This revision resolves all of them; each fix is
+marked **[v2]**.
 
 ## Background
 
@@ -35,8 +41,8 @@ produced the findings below; all line numbers refer to `cmd/serf-hub/assets/` on
 
 1. **No wide-viewport strategy.** One 832px column + fixed 260px sidebar at every
    width ≥768px (`style.css:500, 511-516`). At 2560px the transcript occupies ~32%
-   of the viewport. Also contradicts `design-system.md` §4 (~720px cap) and §6
-   (dock spans the window).
+   of the viewport. Shipped 832px also exceeds `design-system.md` §4's ~720px cap,
+   and the capped dock contradicts §6 (dock spans the window).
 2. **Home is an 82% void.** A ~150px cluster `margin: auto`-centered in 100vh
    (`web.go:374-385`; `style.css:5479-5541`). `/new` and settings use different,
    also-unbalanced strategies; five inconsistent content widths
@@ -49,10 +55,14 @@ produced the findings below; all line numbers refer to `cmd/serf-hub/assets/` on
    (`:4561-4582`); desktop model pill is an ~18px hit target, violating
    `design-system.md` §6's ≥30px floor (`:2074-2082`).
 5. **The stylesheet fights itself.** Dead `.composer-send`/`#send-btn` selectors
-   (`:274-275` — Send's press feedback never fires); duplicate conflicting
-   `.btn:active` blocks (`:270-275` vs `:5554-5562`); undefined `--hair` (`:4683`);
-   27 legacy-alias uses; three parallel token namespaces; inverted state colors
-   (shipped green=working/blue=awaiting vs doc blue=live/amber=needs-you);
+   (`:274-275`) **[v2 correction: the Send button's press feedback DOES fire via
+   `.btn:active` in the same rule — only the two legacy selectors are dead]**;
+   duplicate conflicting `.btn:active` blocks (`:270-275` vs `:5554-5562`) that
+   silently cancel the scale-pop; undefined `--hair` (harmless today — has a
+   `var(--rule)` fallback at `:4683`); 27 legacy-alias uses; ~600 uses of the
+   shipped token names vs zero of the canonical ones; inverted state colors
+   (shipped green=working/blue=awaiting vs doc blue=live/amber=needs-you — but see
+   §3: this was a **documented deliberate decision**, `style.css:13-17`);
    `--text-dim` (3.4:1, sub-AA) used for words in ~37 places; 13 retired ALL-CAPS
    mono label treatments; 6-radius spread vs the documented two.
 
@@ -60,91 +70,177 @@ produced the findings below; all line numbers refer to `cmd/serf-hub/assets/` on
 
 Architecture is unchanged: no bundler, no framework, embedded assets, the
 `window.SerfRendererInternal` module pattern. `docs/web-ui/design-system.md` is the
-north star; where shipped code contradicts it, the code changes.
+north star; where shipped code contradicts it, the code changes — and where this
+spec extends the doc, the doc gets an addendum in the same commit (see §2).
 
 ### 1. Rendering pipeline
 
-- **Frame batching.** Socket events queue and flush once per
-  `requestAnimationFrame`. `isNearBottom()` is measured once per frame before
-  mutations; scroll settles once after.
-- **Streaming text.** Assistant deltas coalesce per frame. Short messages
-  (<4KB, no open code fence) re-parse markdown at most once per frame; long or
-  complex messages stream into a plain `.streaming-text` node with the existing
-  soft cursor, and markdown parses once at `ASSISTANT_TEXT_END`. Reasoning deltas
-  append text nodes instead of full-buffer replacement.
-- **Tool output.** Streaming output is append-only `textContent` on a single
-  `<pre>`; expand/collapse chrome is built once at `bodyEnd`. Diff rows coalesce
-  per frame.
-- **Windowing.** `content-visibility: auto` with `contain-intrinsic-size` on turn
-  containers. No hand-rolled virtualization; DOM stays intact for find-in-page.
+- **Frame batching — live events only [v2].** Only *live socket* events queue and
+  flush once per animation frame. The two synchronous replay paths are exempt and
+  stay synchronous: initial hydration replay (`renderer.js:823-826`) and
+  `prependOlderTurns`' staging-div render + measure (`:4608-4658`), which measures
+  the staged fragment immediately and would break under a queued flush.
+  `isNearBottom()` is measured once per flushed frame (not per event); scroll
+  settles once after.
+- **Hidden-tab fallback [v2].** `requestAnimationFrame` never fires in hidden
+  tabs, and a backgrounded hub tab is the common case. When `document.hidden`,
+  flush on a 250ms `setTimeout` instead (state still applies, liveness clock and
+  `serf-hub:thread-status` still dispatch, no monster refocus flush); also flush
+  once on `visibilitychange → visible`.
+- **Queue lifecycle [v2].** The queue is drained and invalidated on
+  `resetTranscriptReplay` (reconnect) with a generation guard, so stale events
+  never flush into a rehydrated transcript. Ordering with the existing
+  `descriptionsReady` event buffer (`:1053-1056`) and the pending-reconcile
+  invariant (`reconcilePendingFromNotification` must run *after* the reducer
+  applies, `:673-686`) is preserved: reconcile runs at the end of the flush, not
+  per event.
+- **Existing jstest suite [v2].** ~50 test files drive `handleData` and assert
+  synchronously. The batching increment ships a synchronous `SerfRenderer.flush()`
+  test hook and migrates affected tests to call it; the suite must stay green at
+  every commit. This migration is budgeted as part of the increment, not an
+  afterthought.
+- **Streaming text [v2].** Assistant deltas coalesce per frame. Short messages
+  (<4KB accumulated, no open code fence) re-parse markdown at most once per frame;
+  long or fenced messages switch — once, no flip-back — to a plain
+  `.streaming-text` node (new component; there is no existing soft cursor — v1
+  misspoke) with a CSS streaming caret whose lifecycle (added on first delta,
+  removed on finalize/reset/interrupt) is specified in the component. Markdown
+  parses once at finalization. **Finalization happens on `ASSISTANT_TEXT_END`,
+  `TURN_COMPLETED`, or `SESSION_END`** — interrupt never emits
+  `ASSISTANT_TEXT_END` (`agent/session_lifecycle.go:617-652`), so the renderer
+  finalizes on turn end regardless of cause; an interrupted long message renders
+  its partial markdown instead of staying raw. `TURN_COMPLETED` currently never
+  calls `finalizeAssistantMessage` (`renderer.js:1104-1106`); it will.
+- **Reasoning deltas** append text nodes instead of full-buffer replacement.
+- **Tool output [v2].** During streaming, output is append-only `textContent` on a
+  single `<pre>` that is max-height-clamped with overflow in CSS — the user
+  watches the live tail without unbounded viewport growth (preserving the intent
+  of the current 5-line fold). The 5-line fold + "expand · N more" chrome, binary
+  detection, and error replacement (`data.error` at `:533-536`) are all applied
+  once at `bodyEnd`, over the full clipped buffer. Diff rows coalesce per frame
+  instead of rebuild-per-delta.
+- **Windowing [v2].** `content-visibility: auto` with
+  `contain-intrinsic-size: auto <estimate>` applied **per existing transcript
+  entry** (`.assistant-message`, `.tool-call`, `.think`, banners — the flat
+  children of `#conversation`). No DOM regrouping: v1's "turn containers" do not
+  exist, and creating them would break clusters, sibling selectors, and the
+  new-content pill's child counting. The `auto` keyword makes the browser reuse
+  each element's last-rendered size, so only never-rendered prepended history
+  uses estimates; minor scroll drift on first reveal of ancient turns is
+  accepted and noted, since `prependOlderTurns` restores position by
+  scrollHeight delta which remains approximately correct with remembered sizes.
 - **Hydration.** Per-event scroll work suppressed during replay; one scroll
   settle at the end.
 - **Scroll handler.** rAF-throttled; error anchors cached, invalidated on
   tool-end.
-- Remove the per-event `JSON.stringify`→`parse` round trip.
+- Remove the per-event `JSON.stringify`→`parse` round trip (keep the
+  `handleData(kind, obj)` signature tests use; pass objects through).
 
 ### 2. Layout system
 
-- **One width scale.** `--measure: 720px` (reading column, per design-system §4);
-  machine rows (tool output, diffs) may bleed right to `--measure-machine`
-  (~1000px); left edges never move. Home, `/new`, settings, and transcript snap to
-  this scale.
-- **Breakpoint ladder.** Phone ≤767px (unchanged); **tablet 768–1199px** (sidebar
-  auto-collapses to the 56px rail, side panes become overlays, pickers fluid);
-  desktop 1200–1799px (current); **wide ≥1800px** (measure ~880px, machine rows
-  ~1200px, composer dock spans the window per §6).
+- **One width scale.** `--measure: 720px` for the prose reading column (per
+  design-system §4 — shipped 832px is non-compliant); machine rows (tool output,
+  diffs, code blocks) may bleed right to `--measure-machine` (~1000px); left
+  edges never move. Home, `/new`, settings, and transcript snap to this scale.
+- **Breakpoint ladder.** Phone ≤767px (unchanged); **tablet 768–1199px**;
+  desktop 1200–1799px (current); **wide ≥1800px**.
+- **Wide ≥1800px [v2].** The prose measure stays 720px at every width (no
+  contradiction with §4). What widens is the *machine* bleed (~1200px) — the
+  content type (long commands, diffs, tool dumps) that actually benefits.
+  design-system.md §4 gets a one-paragraph addendum recording this rule in the
+  same commit. The composer dock spans the window per §6.
+- **Tablet 768–1199px [v2].** Side panes are hidden (as at ≤767px today — no new
+  overlay/focus-trap machinery). The sidebar auto-rails via a **tri-state**:
+  `data-sidebar-mode="auto|rail|pane"` (auto is the default and media-query
+  driven; ⌘B cycles force-rail/force-pane and persists; the settings radio and
+  `panes.js:356` read the same attribute, replacing the binary
+  `data-sidebar-rail`). Pickers go fluid width.
 - **Composer.** Dock spans the window with the input card centered at measure;
   desktop model pill ≥30px hit target; phone control row rebalanced (no oversized
   send disc + dead gap); short-desktop rule (height <640px compacts header +
   status rail); textarea gets a px ceiling.
-- **Home launchpad.** Replace the empty state with a "Jump back in" column:
-  recent sessions (title, project, relative time, status) plus new/search
-  actions, server-rendered from roster data, on the shared width scale.
+- **Home launchpad [v2].** Replace the empty state with a "Jump back in" column:
+  up to ~8 recent sessions (title, project, relative age) plus the new/search
+  actions, server-rendered from `/api/tree` data, on the shared width scale.
+  **All interpolated strings are HTML-escaped** (titles are agent-controlled; the
+  current handler is raw `fmt.Fprint`) with a Go test asserting escaping. Live
+  status dots are hydrated client-side from the already-open appwire connection
+  after load — the static markup carries no status that could go stale.
 - **Sidebar.** One left-inset rhythm.
 
 ### 3. CSS consolidation
 
-- **One token vocabulary:** canonical `design-system.md` names (`--ink`,
-  `--surface`, `--line`, `--hair`, `--attention`, `--done`); delete the 27
-  legacy-alias uses and the third namespace.
-- **State colors per the doc:** blue = live/active, amber = needs-you, red =
-  error, neutral = done.
-- **Delete dead CSS:** `.composer-send`/`#send-btn` selectors, duplicate
-  `.btn:active` blocks (keep the scale-pop), define `--hair`.
+- **One token vocabulary [v2 — correctly scoped].** The canonical design-system
+  names (`--ink`, `--ink-2/3/4`, `--surface`, `--line`, `--hair`, `--attention`,
+  `--done`) have **zero** definitions today; the shipped namespace has ~600 uses
+  (`--text` 158, `--text-muted` 256, `--rule` 104, `--text-dim` 43, …) across 4
+  theme blocks (dark/light × default/override). Migration: (a) define canonical
+  tokens as aliases of the shipped values in all 4 theme blocks; (b) mechanical
+  rename per use site; (c) delete the 27 legacy-alias uses and the shipped names;
+  (d) jstest asserts no legacy names remain. One vocabulary at the end.
+- **State colors [v2].** Adopt the documented language (blue = live/active,
+  amber = needs-you, red = error, neutral = done), explicitly reversing the
+  recorded "accepted churn" decision (`style.css:13-17`) with the owner's
+  approval from the design review. Consumer checklist, all updated in the same
+  increment: 65 uses across 4 theme blocks; `data-state` setters (sidebar.js,
+  search.js, renderer.js, workspace.html, credentials/plugins inline scripts);
+  **`notifications.js:39-43` hardcoded favicon hex** (read the computed token at
+  runtime instead of mirroring hex); the warning tier (`--state-warning` /
+  diagnostics) keeps amber as a *diagnostic* hue distinct from needs-you via a
+  separate `--diagnostic-warning` token, and `--diagnostic-hub` is re-hued so it
+  no longer collides with `--diagnostic-ui`.
+- **Delete dead CSS:** `.composer-send`/`#send-btn` selectors; the duplicate
+  conflicting `.btn:active` blocks (keep the scale-pop, one rule); define
+  `--hair`.
 - **Contrast pass:** `--text-dim` stops coloring words (~37 sites → `--ink-3`
-  minimum); the short-think tier keeps its recede via size + italic.
+  minimum, once `--ink-3` exists); the short-think tier keeps its recede via
+  size + italic.
 - **Retire remaining ALL-CAPS mono labels** (13 sites); consolidate the radius
   scale to the documented two values.
 
 ## Error handling
 
-- Frame batching must not drop events: queue overflow is impossible (unbounded
-  array), and a flush always drains the full queue. A socket reconnect mid-frame
-  re-runs hydration through the same detached path.
-- `content-visibility` gets a `contain-intrinsic-size` estimate so scrollbar
-  geometry stays stable; elements near the viewport render normally.
-- Streaming-text fallback: if `marked.parse` throws at `ASSISTANT_TEXT_END`,
-  the message stays as plain text (current behavior on parse failure is
-  preserved).
-- The tablet rail collapse is CSS/container-query driven; manual ⌘B toggle
-  continues to override it.
+- Frame batching: the flush drains the full queue every time; hidden-tab timer +
+  `visibilitychange` flush means events never defer indefinitely; reconnect
+  drains and generation-guards the queue; replay paths bypass it entirely. **[v2
+  — replaces v1's incorrect "reconnect re-runs hydration through the same
+  detached path": initial hydration renders live, only prepend stages detached.]**
+- Streaming-text fallback: if `marked.parse` throws at finalization, the message
+  stays as plain text (current behavior preserved). Interrupt/turn-end without
+  `ASSISTANT_TEXT_END` still finalizes (see §1).
+- `content-visibility` uses `auto`-remembered sizes so scroll geometry is exact
+  for anything rendered at least once; residual drift is limited to first reveal
+  of never-rendered ancient turns.
+- The tablet rail is a tri-state; manual ⌘B always has a defined meaning;
+  settings UI and `panes.js` read the same source of truth.
 
-## Testing
+## Testing [v2 — calibrated to what the harness can actually do]
 
-- Extend `cmd/serf-hub/jstest/`: frame batching coalesces parses (N deltas → ≤1
-  parse per frame), streaming-text path for long messages, append-only tool
-  output, rAF-throttled scroll handler, hydration settle-once,
-  `content-visibility` attributes present, breakpoint rules, no legacy token
-  aliases, hit-target floors. Mirror `test-renderer.js` patterns.
-- Go web tests for the launchpad markup (`web.go`).
-- Visual verification matrix (playwright): 390/768/1100/1440/2560px × dark/light
-  × home/session, before vs after, reviewed by eye.
+- `cmd/serf-hub/jstest/` (node + jsdom, no layout engine): behavioral tests for
+  frame coalescing (N deltas in one frame → ≤1 parse), hidden-tab timer flush,
+  queue drain on reset, `flush()` test hook, streaming-text switch + finalize on
+  `TURN_COMPLETED` without `ASSISTANT_TEXT_END`, append-only tool output +
+  bodyEnd chrome, hydration settle-once, per-entry `content-visibility` inline
+  style, tri-state sidebar attribute logic, launchpad escaping (Go-side).
+- **Stylesheet-text assertions** (new small helper loading `style.css` as text)
+  for: no legacy token names, hit-target min-heights present, breakpoint rules
+  present, dead selectors gone. These verify rules exist, not that they behave —
+  behavior at real sizes is the playwright matrix below.
+- The existing jstest suite is migrated to the `flush()` hook as part of the
+  batching increment and stays green throughout.
+- Go web tests for the launchpad markup **including an XSS-escaping case**
+  (agent-controlled title containing HTML).
+- **Visual verification matrix (playwright, dev-time tooling — new to this repo,
+  not a CI gate):** 390/768/1100/1440/2560px × dark/light × home/session, before
+  vs after, reviewed by eye.
 - Gate per increment: `make build-hub` + `jstest/run-all.sh` +
   `go test ./cmd/serf-hub`. Small TDD commits on `webui-joy`.
 
 ## Out of scope
 
-- Subagent-sidebar and multi-pane feature work owned by other efforts.
-- The design-system doc itself (no principle changes).
+- Subagent-sidebar and multi-pane feature work owned by other efforts (side
+  panes are only *hidden* at tablet widths, not redesigned).
+- design-system.md *principles* (addenda recording new rules, like the wide-band
+  machine bleed, are in scope and land with their increments).
 - Backend/appwire protocol changes — all fixes are client-side except the
   server-rendered home launchpad.

--- a/docs/superpowers/specs/2026-07-18-webui-foundation-experience-design.md
+++ b/docs/superpowers/specs/2026-07-18-webui-foundation-experience-design.md
@@ -1,246 +1,284 @@
 # Serf Web Hub — Foundation + Experience Pass
 
-Status: approved (2026-07-18), revised after adversarial review (v2, same day).
+Status: approved (2026-07-18), revised after two adversarial-review rounds (v3).
 Work branch: `webui-joy`.
 Scope: `cmd/serf-hub` frontend (`assets/`, `templates/`, and `web.go` home rendering).
 
-v2 changes: two adversarial reviewers each found 13 verified issues in v1
-(reports in session transcripts `local:033rmJG0Qq602H7gRXkinK` and
-`local:033rmJGtbkJZDf40au0ZnP`). This revision resolves all of them; each fix is
-marked **[v2]**.
+v2 resolved 26 round-1 findings (reviewers 1–2, 13 each, tie). v3 resolves 26
+round-2 findings (reviewer 3: 14 — round winner; reviewer 4: 12). Round-2 reports
+in session transcripts `local:033rn6RYwumQSzT0WOLYT8` and
+`local:033rn6SS7dzJfyGLde5AIz`. Substantive v3 changes are marked **[v3]**;
+round-1 resolutions retained from v2 are unmarked.
 
 ## Background
 
 The owner reports the hub feels "clunky, unbalanced, and not very responsive" — both
 interaction latency/jank and layout adaptiveness. Two read-only audits (2026-07-18)
-produced the findings below; all line numbers refer to `cmd/serf-hub/assets/` on
-`main` at `be125a62`.
+produced the findings below; line numbers refer to `cmd/serf-hub/assets/` on `main`
+at `be125a62`.
 
 ### Jank findings (performance audit)
 
-1. **Per-token full markdown re-parse.** `appendAssistantDelta` re-runs `marked.parse`
-   on the entire accumulated message and replaces `innerHTML` on every delta
-   (`renderer.js:2212-2222`). O(L²) per message; destroys selection/hover; full
-   re-layout per token.
-2. **Per-event layout thrash.** `handle()` reads `isNearBottom()` then calls
-   `scrollToBottom()` around every event (`renderer.js:1062, 1402-1403`). During
-   hydration replay (`renderer.js:823-826`) this runs per replayed event → O(N²)
-   session open.
-3. **Unbounded transcript DOM.** No windowing or pruning anywhere; every layout
-   walks every node.
-4. **Tool-output DOM rebuild per delta.** `setExpandableOutput`
-   (`renderer-tools.js:135-172`, called from `:528-531` and `:225-227`) rebuilds the
-   whole output subtree on every output delta.
-5. **Unthrottled scroll handler** doing O(transcript) `querySelectorAll` and layout
-   reads per scroll event (`renderer.js:4510-4521`, `4470-4477`).
-6. Medium: diff DOM rebuild per delta (`renderer-tools.js:26-43, 580, 614`);
-   reasoning full-buffer `textContent` replace per token (`renderer.js:2328-2338`);
-   per-event `JSON.stringify`→`parse` round trip (`renderer.js:1047-1049, 1068`).
+1. **Per-token full markdown re-parse** (`renderer.js:2212-2222`): O(L²) per
+   message, destroys selection, full re-layout per token.
+2. **Per-event layout thrash** (`renderer.js:1062, 1402-1403`); hydration replay
+   (`:823-826`) makes session open O(N²).
+3. **Unbounded transcript DOM** — no windowing anywhere.
+4. **Tool-output DOM rebuild per delta** (`renderer-tools.js:135-172`, called at
+   `:528-531, 225-227`).
+5. **Unthrottled scroll handler** with O(transcript) queries + layout reads
+   (`renderer.js:4510-4521, 4470-4477`).
+6. Medium: diff rebuild per delta (`renderer-tools.js:26-43, 580, 614`); reasoning
+   full-buffer replace (`renderer.js:2328-2338`) **and an O(n²) preview-tail regex
+   per delta (`:2337`) [v3]**; per-event `JSON.stringify`→`parse` round trip
+   (`:1047-1049, 1068`).
 
 ### Imbalance findings (layout audit)
 
-1. **No wide-viewport strategy.** One 832px column + fixed 260px sidebar at every
-   width ≥768px (`style.css:500, 511-516`). At 2560px the transcript occupies ~32%
-   of the viewport. Shipped 832px also exceeds `design-system.md` §4's ~720px cap,
-   and the capped dock contradicts §6 (dock spans the window).
-2. **Home is an 82% void.** A ~150px cluster `margin: auto`-centered in 100vh
-   (`web.go:374-385`; `style.css:5479-5541`). `/new` and settings use different,
-   also-unbalanced strategies; five inconsistent content widths
-   (832/880/920/720/640px).
-3. **No tablet band (768–1200px).** Full sidebar + fixed 420px side panes persist
-   to 768px (`style.css:477, 518, 539`); at 1024px with a side pane open the
-   transcript gets ~344px.
-4. **Composer.** 50vh textarea ceiling with no short-desktop rule
-   (`style.css:2047`); phone rest row is two 44px discs flanking a dead gap
-   (`:4561-4582`); desktop model pill is an ~18px hit target, violating
-   `design-system.md` §6's ≥30px floor (`:2074-2082`).
-5. **The stylesheet fights itself.** Dead `.composer-send`/`#send-btn` selectors
-   (`:274-275`) **[v2 correction: the Send button's press feedback DOES fire via
-   `.btn:active` in the same rule — only the two legacy selectors are dead]**;
-   duplicate conflicting `.btn:active` blocks (`:270-275` vs `:5554-5562`) that
-   silently cancel the scale-pop; undefined `--hair` (harmless today — has a
-   `var(--rule)` fallback at `:4683`); 27 legacy-alias uses; ~600 uses of the
-   shipped token names vs zero of the canonical ones; inverted state colors
-   (shipped green=working/blue=awaiting vs doc blue=live/amber=needs-you — but see
-   §3: this was a **documented deliberate decision**, `style.css:13-17`);
-   `--text-dim` (3.4:1, sub-AA) used for words in ~37 places; 13 retired ALL-CAPS
-   mono label treatments; 6-radius spread vs the documented two.
+1. **No wide-viewport strategy** (`style.css:500, 511-516`): 32% width usage at
+   2560px; shipped 832px exceeds design-system §4's ~720px; capped dock
+   contradicts §6.
+2. **Home is an 82% void** (`web.go:374-385`; `style.css:5479-5541`); five
+   inconsistent content widths.
+3. **No tablet band (768–1200px)** (`style.css:477, 518, 539`): transcript ~344px
+   at 1024px with a side pane.
+4. **Composer** (`:2047, 4561-4582, 2074-2082`): 50vh ceiling, phone dead gap,
+   ~18px model-pill hit target (doc floor: ≥30px).
+5. **The stylesheet fights itself**: dead `.composer-send`/`#send-btn` selectors
+   (`:274-275` — dead, though Send's press feedback DOES fire via `.btn:active`);
+   duplicate conflicting `.btn:active` blocks that cancel the scale-pop
+   (`:270-275` vs `:5554-5562`); `--hair` referenced only via fallback (`:4683`);
+   27 legacy-alias uses; ~600 shipped-token uses vs zero canonical definitions;
+   shipped state colors (green=working/blue=awaiting) contradict design-system §3
+   but were a documented "accepted churn" decision (`:13-17`); `--text-dim`
+   (2.9:1 measured — sub-AA) used for words in ~37 places; 13 retired ALL-CAPS
+   mono labels; 6-radius spread vs two.
 
 ## Design decisions
 
-Architecture is unchanged: no bundler, no framework, embedded assets, the
+Architecture unchanged: no bundler, no framework, embedded assets, the
 `window.SerfRendererInternal` module pattern. `docs/web-ui/design-system.md` is the
-north star; where shipped code contradicts it, the code changes — and where this
-spec extends the doc, the doc gets an addendum in the same commit (see §2).
+north star; where shipped code contradicts it the code changes, and where this spec
+extends it the doc gets an addendum in the same commit.
 
 ### 1. Rendering pipeline
 
-- **Frame batching — live events only [v2].** Only *live socket* events queue and
-  flush once per animation frame. The two synchronous replay paths are exempt and
-  stay synchronous: initial hydration replay (`renderer.js:823-826`) and
-  `prependOlderTurns`' staging-div render + measure (`:4608-4658`), which measures
-  the staged fragment immediately and would break under a queued flush.
-  `isNearBottom()` is measured once per flushed frame (not per event); scroll
-  settles once after.
-- **Hidden-tab fallback [v2].** `requestAnimationFrame` never fires in hidden
-  tabs, and a backgrounded hub tab is the common case. When `document.hidden`,
-  flush on a 250ms `setTimeout` instead (state still applies, liveness clock and
-  `serf-hub:thread-status` still dispatch, no monster refocus flush); also flush
-  once on `visibilitychange → visible`.
-- **Queue lifecycle [v2].** The queue is drained and invalidated on
-  `resetTranscriptReplay` (reconnect) with a generation guard, so stale events
-  never flush into a rehydrated transcript. Ordering with the existing
-  `descriptionsReady` event buffer (`:1053-1056`) and the pending-reconcile
-  invariant (`reconcilePendingFromNotification` must run *after* the reducer
-  applies, `:673-686`) is preserved: reconcile runs at the end of the flush, not
-  per event.
-- **Existing jstest suite [v2].** ~50 test files drive `handleData` and assert
-  synchronously. The batching increment ships a synchronous `SerfRenderer.flush()`
-  test hook and migrates affected tests to call it; the suite must stay green at
-  every commit. This migration is budgeted as part of the increment, not an
-  afterthought.
-- **Streaming text [v2].** Assistant deltas coalesce per frame. Short messages
-  (<4KB accumulated, no open code fence) re-parse markdown at most once per frame;
-  long or fenced messages switch — once, no flip-back — to a plain
-  `.streaming-text` node (new component; there is no existing soft cursor — v1
-  misspoke) with a CSS streaming caret whose lifecycle (added on first delta,
-  removed on finalize/reset/interrupt) is specified in the component. Markdown
-  parses once at finalization. **Finalization happens on `ASSISTANT_TEXT_END`,
-  `TURN_COMPLETED`, or `SESSION_END`** — interrupt never emits
-  `ASSISTANT_TEXT_END` (`agent/session_lifecycle.go:617-652`), so the renderer
-  finalizes on turn end regardless of cause; an interrupted long message renders
-  its partial markdown instead of staying raw. `TURN_COMPLETED` currently never
-  calls `finalizeAssistantMessage` (`renderer.js:1104-1106`); it will.
-- **Reasoning deltas** append text nodes instead of full-buffer replacement.
-- **Tool output [v2].** During streaming, output is append-only `textContent` on a
-  single `<pre>` that is max-height-clamped with overflow in CSS — the user
-  watches the live tail without unbounded viewport growth (preserving the intent
-  of the current 5-line fold). The 5-line fold + "expand · N more" chrome, binary
-  detection, and error replacement (`data.error` at `:533-536`) are all applied
-  once at `bodyEnd`, over the full clipped buffer. Diff rows coalesce per frame
-  instead of rebuild-per-delta.
-- **Windowing [v2].** `content-visibility: auto` with
-  `contain-intrinsic-size: auto <estimate>` applied **per existing transcript
-  entry** (`.assistant-message`, `.tool-call`, `.think`, banners — the flat
-  children of `#conversation`). No DOM regrouping: v1's "turn containers" do not
-  exist, and creating them would break clusters, sibling selectors, and the
-  new-content pill's child counting. The `auto` keyword makes the browser reuse
-  each element's last-rendered size, so only never-rendered prepended history
-  uses estimates; minor scroll drift on first reveal of ancient turns is
-  accepted and noted, since `prependOlderTurns` restores position by
-  scrollHeight delta which remains approximately correct with remembered sizes.
+- **Frame batching — live events only.** Only live socket events queue and flush
+  once per animation frame. The synchronous replay paths (initial hydration,
+  `prependOlderTurns`' staging render+measure) are exempt. `isNearBottom()` is
+  measured once per flushed frame; scroll settles once after.
+- **Hidden-tab fallback [v3].** rAF never fires in hidden tabs. The flush
+  scheduler is: if `document.hidden`, a best-effort `setTimeout` (browsers clamp
+  background timers to ≥1s; correctness does not depend on the interval — the
+  queue always drains fully); else rAF. Additionally, any pending queue is
+  flushed immediately on `visibilitychange` in BOTH directions — hiding a tab
+  with an in-flight rAF must not strand events until refocus. The rAF call is
+  feature-guarded (`typeof requestAnimationFrame === "function"` → else 16ms
+  timeout) because plain jsdom (6 jstest files) has no rAF.
+- **Queue lifecycle [v3].** The queue stores ordered `(kind, data)` events plus
+  the ordered `(method, params)` of each originating notification. On flush:
+  apply all events, then replay `reconcilePendingFromNotification` once **per
+  queued notification, in order** — the existing per-notification invariant
+  (`renderer.js:677-684`) is preserved exactly, and optimistic placeholders can't
+  leak or cross-match. The queue is drained and generation-guarded on
+  `resetTranscriptReplay`.
+- **jstest migration.** The batching increment ships a synchronous
+  `SerfRenderer.flush()` test hook and migrates affected tests in the same
+  commits; the suite stays green at every commit.
+- **Streaming text [v3 — frozen head, raw tail].** Assistant deltas coalesce per
+  frame. While accumulated length ≤4KB: markdown re-parse at most once per frame.
+  Past 4KB the message switches — once, on length only (never on fence state),
+  no flip-back: the current parsed DOM is **frozen in place** and subsequent
+  deltas append as plain text in a `.streaming-tail` node below it, with a CSS
+  streaming caret. The user keeps the formatted head; the raw tail is bounded to
+  long messages. Finalization re-parses the whole buffer. The message element
+  keeps `.assistant-message` + `data-turn-id` at all times (the turn-meta badge
+  query at `:1122` and windowing depend on it). The communicate dedup
+  (`:2195-2210`) compares against the accumulated **source buffer** while a
+  streaming message is active, not DOM `textContent` (a raw tail breaks the
+  rendered-text comparison → duplicate communicate messages).
+- **Idempotent finalization [v3 — the critical round-2 catch].** Appwire can
+  emit `TURN_COMPLETED` *and then* a synthesized `ASSISTANT_TEXT_END` in the same
+  notification (codex turn/completed-with-items path, `appwire.js:992-998,
+  734-740`). Therefore: finalization runs on `ASSISTANT_TEXT_END`,
+  `TURN_COMPLETED`, or `SESSION_END`, **whichever arrives first**, and is
+  idempotent per turn: a later `ASSISTANT_TEXT_END` for an already-finalized
+  message **replaces the finalized block's content in place** (never
+  `appendAssistantBlock` a duplicate). Turn-meta is (re)appended **after** any
+  (re)parse, since re-parsing destroys children. A jstest covers the
+  codex-shape `TURN_COMPLETED → ASSISTANT_TEXT_END` sequence, not just the
+  serf-source shape.
+- **Reasoning deltas** append text nodes; the 200-char preview tail is
+  recomputed at most once per frame, not per delta.
+- **Tool output.** During streaming: append-only `textContent` on a single `<pre>`
+  that is max-height-clamped in CSS (live tail visible, no viewport flood). The
+  5-line fold chrome, binary detection, and `data.error` replacement apply once
+  at `bodyEnd`. Diff rows coalesce per frame.
+- **Windowing [v3].** `content-visibility: auto` with
+  `contain-intrinsic-size: auto <estimate>` on **every direct child of
+  `#conversation`** — `.assistant-message`, `.user-message`, `.tool-call`,
+  `.tool-call-cluster` (the flat child after cheap-tool regrouping — the most
+  numerous entry in heavy sessions), `.think`, banners, job cards, subagent
+  modules, system lines. No DOM regrouping. `auto` gives exact remembered sizes
+  for anything rendered once. For never-rendered prepended history (estimates
+  only), `prependOlderTurns` does a **two-phase scroll settle**: restore
+  `scrollTop` from the estimate-based scrollHeight immediately, then re-measure
+  and correct on the next frame once the browser has rendered the
+  near-viewport entries. Residual drift is bounded to deep-history paging and
+  verified in the playwright matrix.
 - **Hydration.** Per-event scroll work suppressed during replay; one scroll
   settle at the end.
 - **Scroll handler.** rAF-throttled; error anchors cached, invalidated on
-  tool-end.
+  tool-end **and on prepend/hydration** (errored rows enter via history paging
+  too).
 - Remove the per-event `JSON.stringify`→`parse` round trip (keep the
-  `handleData(kind, obj)` signature tests use; pass objects through).
+  `handleData(kind, obj)` signature tests use).
 
 ### 2. Layout system
 
-- **One width scale.** `--measure: 720px` for the prose reading column (per
-  design-system §4 — shipped 832px is non-compliant); machine rows (tool output,
-  diffs, code blocks) may bleed right to `--measure-machine` (~1000px); left
-  edges never move. Home, `/new`, settings, and transcript snap to this scale.
-- **Breakpoint ladder.** Phone ≤767px (unchanged); **tablet 768–1199px**;
-  desktop 1200–1799px (current); **wide ≥1800px**.
-- **Wide ≥1800px [v2].** The prose measure stays 720px at every width (no
-  contradiction with §4). What widens is the *machine* bleed (~1200px) — the
-  content type (long commands, diffs, tool dumps) that actually benefits.
-  design-system.md §4 gets a one-paragraph addendum recording this rule in the
-  same commit. The composer dock spans the window per §6.
-- **Tablet 768–1199px [v2].** Side panes are hidden (as at ≤767px today — no new
-  overlay/focus-trap machinery). The sidebar auto-rails via a **tri-state**:
-  `data-sidebar-mode="auto|rail|pane"` (auto is the default and media-query
-  driven; ⌘B cycles force-rail/force-pane and persists; the settings radio and
-  `panes.js:356` read the same attribute, replacing the binary
-  `data-sidebar-rail`). Pickers go fluid width.
-- **Composer.** Dock spans the window with the input card centered at measure;
-  desktop model pill ≥30px hit target; phone control row rebalanced (no oversized
-  send disc + dead gap); short-desktop rule (height <640px compacts header +
-  status rail); textarea gets a px ceiling.
-- **Home launchpad [v2].** Replace the empty state with a "Jump back in" column:
-  up to ~8 recent sessions (title, project, relative age) plus the new/search
-  actions, server-rendered from `/api/tree` data, on the shared width scale.
-  **All interpolated strings are HTML-escaped** (titles are agent-controlled; the
-  current handler is raw `fmt.Fprint`) with a Go test asserting escaping. Live
-  status dots are hydrated client-side from the already-open appwire connection
-  after load — the static markup carries no status that could go stale.
+- **One width scale.** `--measure: 720px` prose column (per design-system §4);
+  machine rows bleed right to `--measure-machine` (~1000px, clamped by the
+  container); left edges never move. All pages snap to the scale.
+- **Breakpoint ladder.** Phone ≤767px (unchanged); tablet 768–1199px; desktop
+  1200–1799px; wide ≥1800px.
+- **Wide ≥1800px.** Prose measure stays 720px at every width; the machine bleed
+  widens to ~1200px. design-system.md §4 gets an addendum recording this. The
+  composer dock spans the window per §6.
+- **Tablet 768–1199px [v3].** Side panes hidden (as ≤767px today). Sidebar
+  auto-rails via tri-state `data-sidebar-mode="auto|rail|pane"`:
+  - localStorage migration: `"true"`→`rail`, `"false"`→`pane`, absent→`auto`
+    (auto is new; before this band existed the sidebar simply stayed full, so
+    this is a deliberate, documented improvement, not a silent regression).
+  - Effective state is computed in one JS helper (attribute + `matchMedia`);
+    `panes.js`'s resizer-disable and the settings radio consume that helper —
+    no split-brain in auto mode.
+  - ⌘B cycles `rail → pane → auto`; every press produces a visible or
+    state-visible change.
+  - **Pickers:** `dir-picker.js:7-20` and the mirrored copy in `spawn.js`
+    position fixed 480–520px panels via JS at a hardcoded 767px branch — both
+    move to the shared helper and clamp inside the viewport at tablet widths
+    (or use the bottom-sheet path).
+- **Composer.** Dock spans the window, input card centered at measure; desktop
+  model pill ≥30px hit target; phone control row rebalanced; short-desktop rule
+  (height <640px compacts chrome — the playwright matrix gains a short-height
+  case); textarea px ceiling.
+- **Home launchpad [v3].** Server-rendered "Jump back in" column: up to 8
+  sessions across projects, sorted by `UpdatedAt` desc, from Current+Recent
+  tiers of the `/api/tree` data (title, project, relative age). **No live status
+  dots** — the home page has no appwire connection (it connects lazily per
+  renderer RPC only), so v2's client hydration would deliver nothing; age-only
+  markup can't go stale. **All interpolated strings HTML-escaped** with a Go XSS
+  test. Empty cases: zero sessions (first run) → the quiet wordmark welcome
+  (that state is honest); sessions all archived → welcome + a "search all
+  sessions" affordance.
 - **Sidebar.** One left-inset rhythm.
 
 ### 3. CSS consolidation
 
-- **One token vocabulary [v2 — correctly scoped].** The canonical design-system
-  names (`--ink`, `--ink-2/3/4`, `--surface`, `--line`, `--hair`, `--attention`,
-  `--done`) have **zero** definitions today; the shipped namespace has ~600 uses
-  (`--text` 158, `--text-muted` 256, `--rule` 104, `--text-dim` 43, …) across 4
-  theme blocks (dark/light × default/override). Migration: (a) define canonical
-  tokens as aliases of the shipped values in all 4 theme blocks; (b) mechanical
-  rename per use site; (c) delete the 27 legacy-alias uses and the shipped names;
-  (d) jstest asserts no legacy names remain. One vocabulary at the end.
-- **State colors [v2].** Adopt the documented language (blue = live/active,
-  amber = needs-you, red = error, neutral = done), explicitly reversing the
-  recorded "accepted churn" decision (`style.css:13-17`) with the owner's
-  approval from the design review. Consumer checklist, all updated in the same
-  increment: 65 uses across 4 theme blocks; `data-state` setters (sidebar.js,
-  search.js, renderer.js, workspace.html, credentials/plugins inline scripts);
-  **`notifications.js:39-43` hardcoded favicon hex** (read the computed token at
-  runtime instead of mirroring hex); the warning tier (`--state-warning` /
-  diagnostics) keeps amber as a *diagnostic* hue distinct from needs-you via a
-  separate `--diagnostic-warning` token, and `--diagnostic-hub` is re-hued so it
-  no longer collides with `--diagnostic-ui`.
-- **Delete dead CSS:** `.composer-send`/`#send-btn` selectors; the duplicate
-  conflicting `.btn:active` blocks (keep the scale-pop, one rule); define
-  `--hair`.
-- **Contrast pass:** `--text-dim` stops coloring words (~37 sites → `--ink-3`
-  minimum, once `--ink-3` exists); the short-think tier keeps its recede via
-  size + italic.
-- **Retire remaining ALL-CAPS mono labels** (13 sites); consolidate the radius
-  scale to the documented two values.
+- **One color-token vocabulary [v3 — correctly scoped and mapped].** Today:
+  ~600 uses of shipped color names (`--text` 158, `--text-muted` 256, `--rule`
+  104, `--text-dim` 43, …) across 4 theme blocks; zero canonical definitions.
+  Plan: (a) define canonical tokens in all 4 theme blocks; (b) rename use sites
+  per an explicit **mapping table** (in the implementation plan — e.g.
+  `--text`→`--ink`, `--text-muted`→`ink-2`, `--text-dim`→`--ink-4`,
+  `--rule`→`--line`), word-boundary-safe because the canonical `--text-*` **type
+  scale** (`--text-2xs…--text-2xl`, kept per design-system §3 and redefined by
+  `body[data-font-size]`) shares the prefix — the "no legacy names" assertion
+  carries that documented carve-out; (c) delete the 27 legacy aliases and old
+  names. Values: aliases adopt **shipped** values (no visual change) **except**
+  `--ink-3`, which takes the doc's `#7e8593` — shipped `--text-muted #7a7a86`
+  measures 4.24:1 on raised surfaces (sub-AA); the doc value passes on both
+  [v3 — R4's computed-contrast catch]. The doc §3 hex table gets an addendum
+  aligning it to shipped values where they differ.
+- **State colors [v3 — full surface].** Adopt the documented language
+  (blue=live, amber=needs-you, red=error, neutral=done), reversing the recorded
+  "accepted churn" decision with owner approval, and fixing the
+  `style.css:13-17` comment's misattribution (it cites design-system §3, which
+  documents the opposite). Verified true surface — 24 `--state-*` definitions
+  (6 tokens × 4 blocks), **125** `var(--state-*)` uses, ~49 `data-state` CSS
+  selectors, ~25 JS/template setters (sidebar.js, search.js, renderer.js,
+  workspace.html, credentials/plugins inline scripts), `thread.html:8` hardcoded
+  favicon, and these existing tests that hard-assert the old world and are
+  rewritten in the same commit: `test-color-system-css.js`,
+  `test-notifications-palette.js`, `test-style-palette.js`,
+  `test-context-pressure-css.js`, `test-subagents.js`. The warning tier (31
+  `--state-warning` uses) becomes `--diagnostic-warning`; `--diagnostic-hub` is
+  re-hued to not collide with `--diagnostic-ui`. **Favicon [v3]:** the hardcoded
+  hexes are deliberate — the favicon renders against dark browser chrome
+  regardless of page theme (`notifications.js:35-38`). Keep theme-independent
+  pinned constants (comment updated to reference the dark-theme tokens) but
+  update all three sites (`:32-33` PLAIN_FAVICON, `:39-43` STATE_COLORS, `:129`)
+  to the new language: base favicon goes neutral (post-recolor blue = working,
+  so a blue base favicon would read as "working" at rest).
+- **Delete dead CSS:** `.composer-send`/`#send-btn`; the duplicate `.btn:active`
+  blocks (keep the scale-pop, one rule); define `--hair`.
+- **Contrast pass:** `--text-dim` stops coloring words (~37 sites → `--ink-3`);
+  short-think tier keeps its recede via size + italic.
+- **Retire ALL-CAPS mono labels** (13 sites); radius scale → the documented two.
+- **Contract tests [v3]:** every existing stylesheet-asserting jstest
+  (`test-font-size-presets.js`, `test-mobile-css.js`,
+  `test-pane-and-sidebar-css.js`, etc.) is migrated in the **same commit** as
+  the change it covers — the per-commit gate never breaks.
 
 ## Error handling
 
-- Frame batching: the flush drains the full queue every time; hidden-tab timer +
-  `visibilitychange` flush means events never defer indefinitely; reconnect
-  drains and generation-guards the queue; replay paths bypass it entirely. **[v2
-  — replaces v1's incorrect "reconnect re-runs hydration through the same
-  detached path": initial hydration renders live, only prepend stages detached.]**
-- Streaming-text fallback: if `marked.parse` throws at finalization, the message
-  stays as plain text (current behavior preserved). Interrupt/turn-end without
-  `ASSISTANT_TEXT_END` still finalizes (see §1).
-- `content-visibility` uses `auto`-remembered sizes so scroll geometry is exact
-  for anything rendered at least once; residual drift is limited to first reveal
-  of never-rendered ancient turns.
-- The tablet rail is a tri-state; manual ⌘B always has a defined meaning;
-  settings UI and `panes.js` read the same source of truth.
+- Batching: full-drain flush every time; flush on hide AND on visible; rAF
+  feature-guarded; reconnect drains and generation-guards; replay paths bypass;
+  reconcile replays per notification in order.
+- Streaming text: finalization is idempotent per turn; a late
+  `ASSISTANT_TEXT_END` replaces in place; `marked.parse` failure leaves plain
+  text (current behavior); turn-meta re-appended after any reparse.
+- Windowing: two-phase prepend settle; estimates only ever affect
+  never-rendered deep history.
+- Sidebar: tri-state with migration; one effective-state helper for all JS
+  consumers.
 
-## Testing [v2 — calibrated to what the harness can actually do]
+## Testing
 
-- `cmd/serf-hub/jstest/` (node + jsdom, no layout engine): behavioral tests for
-  frame coalescing (N deltas in one frame → ≤1 parse), hidden-tab timer flush,
-  queue drain on reset, `flush()` test hook, streaming-text switch + finalize on
-  `TURN_COMPLETED` without `ASSISTANT_TEXT_END`, append-only tool output +
-  bodyEnd chrome, hydration settle-once, per-entry `content-visibility` inline
-  style, tri-state sidebar attribute logic, launchpad escaping (Go-side).
-- **Stylesheet-text assertions** (new small helper loading `style.css` as text)
-  for: no legacy token names, hit-target min-heights present, breakpoint rules
-  present, dead selectors gone. These verify rules exist, not that they behave —
-  behavior at real sizes is the playwright matrix below.
-- The existing jstest suite is migrated to the `flush()` hook as part of the
-  batching increment and stays green throughout.
-- Go web tests for the launchpad markup **including an XSS-escaping case**
-  (agent-controlled title containing HTML).
-- **Visual verification matrix (playwright, dev-time tooling — new to this repo,
-  not a CI gate):** 390/768/1100/1440/2560px × dark/light × home/session, before
-  vs after, reviewed by eye.
+- **jstest (node + jsdom):** frame coalescing; rAF-absence fallback; hidden-tab
+  timer flush; flush-on-hide; queue drain on reset; per-notification reconcile
+  replay; `flush()` hook; streaming-text switch at 4KB with frozen head +
+  `.assistant-message`/`data-turn-id` preserved; **idempotent finalization on
+  the codex-shape `TURN_COMPLETED → ASSISTANT_TEXT_END` sequence**; communicate
+  dedup against the source buffer; append-only tool output + bodyEnd chrome;
+  hydration settle-once; per-child `content-visibility`; tri-state helper logic
+  (attribute + stubbed matchMedia); renderer-file mirror test
+  (`jstest/load-renderer.js` RENDERER_FILES ≡ `templates/app.html` script
+  order).
+- **Stylesheet-text assertions:** no legacy color-token names (with the
+  `--text-*` type-scale carve-out), hit-target min-heights, breakpoint rules,
+  dead selectors gone.
+- **Go tests:** launchpad markup incl. XSS-escaping case; empty/archived
+  variants.
+- **Playwright matrix (dev-time, not CI):** 390/768/1100/1440/2560px **plus a
+  short-height (1100×600) case** × dark/light × home/session, before/after,
+  reviewed by eye; deep-history prepend scroll-stability spot check.
 - Gate per increment: `make build-hub` + `jstest/run-all.sh` +
-  `go test ./cmd/serf-hub`. Small TDD commits on `webui-joy`.
+  `go test ./cmd/serf-hub`.
+
+## Increments [v3 — dependency order]
+
+1. **Test groundwork:** `flush()` hook (initially no-op passthrough), rAF
+   feature-guard, renderer-file mirror test. No behavior change.
+2. **Frame batching** + jstest migration to `flush()`.
+3. **Streaming text** (frozen head/raw tail, idempotent finalize, dedup fix) +
+   reasoning append + tool-output append-only + diff coalescing.
+4. **Windowing + hydration settle + scroll-handler throttle/cache.**
+5. **Layout scale + breakpoint ladder** (width tokens, tablet band, wide band,
+   sidebar tri-state incl. picker JS) + composer fixes.
+6. **Home launchpad** (Go + CSS).
+7. **Token migration** (alias → rename → delete) + contract-test migration.
+8. **State colors** (full surface incl. favicon + tests).
+9. **Contrast + retired treatments** (uppercase labels, radius, `--text-dim`
+   words).
+
+Each lands green per the gate; 7 must precede 8 (state colors reference
+canonical tokens); 2 precedes 3; 5 precedes 6.
 
 ## Out of scope
 
 - Subagent-sidebar and multi-pane feature work owned by other efforts (side
-  panes are only *hidden* at tablet widths, not redesigned).
-- design-system.md *principles* (addenda recording new rules, like the wide-band
-  machine bleed, are in scope and land with their increments).
+  panes are only hidden at tablet widths).
+- design-system.md *principles* (addenda recording new rules are in scope).
 - Backend/appwire protocol changes — all fixes are client-side except the
-  server-rendered home launchpad.
+  server-rendered launchpad.

--- a/docs/superpowers/specs/2026-07-18-webui-foundation-experience-design.md
+++ b/docs/superpowers/specs/2026-07-18-webui-foundation-experience-design.md
@@ -1,0 +1,150 @@
+# Serf Web Hub — Foundation + Experience Pass
+
+Status: approved (2026-07-18). Work branch: `webui-joy`.
+Scope: `cmd/serf-hub` frontend (`assets/`, `templates/`, and `web.go` home rendering).
+
+## Background
+
+The owner reports the hub feels "clunky, unbalanced, and not very responsive" — both
+interaction latency/jank and layout adaptiveness. Two read-only audits (2026-07-18)
+produced the findings below; all line numbers refer to `cmd/serf-hub/assets/` on
+`main` at `be125a62`.
+
+### Jank findings (performance audit)
+
+1. **Per-token full markdown re-parse.** `appendAssistantDelta` re-runs `marked.parse`
+   on the entire accumulated message and replaces `innerHTML` on every delta
+   (`renderer.js:2212-2222`). O(L²) per message; destroys selection/hover; full
+   re-layout per token.
+2. **Per-event layout thrash.** `handle()` reads `isNearBottom()` then calls
+   `scrollToBottom()` around every event (`renderer.js:1062, 1402-1403`). During
+   hydration replay (`renderer.js:823-826`) this runs per replayed event → O(N²)
+   session open.
+3. **Unbounded transcript DOM.** No windowing or pruning anywhere; every layout
+   walks every node.
+4. **Tool-output DOM rebuild per delta.** `setExpandableOutput`
+   (`renderer-tools.js:135-172`, called from `:528-531` and `:225-227`) rebuilds the
+   whole output subtree on every output delta.
+5. **Unthrottled scroll handler** doing O(transcript) `querySelectorAll` and layout
+   reads per scroll event (`renderer.js:4510-4521`, `4470-4477`).
+6. Medium: diff DOM rebuild per delta (`renderer-tools.js:26-43, 580, 614`);
+   reasoning full-buffer `textContent` replace per token (`renderer.js:2328-2338`);
+   per-event `JSON.stringify`→`parse` round trip (`renderer.js:1047-1049, 1068`).
+
+### Imbalance findings (layout audit)
+
+1. **No wide-viewport strategy.** One 832px column + fixed 260px sidebar at every
+   width ≥768px (`style.css:500, 511-516`). At 2560px the transcript occupies ~32%
+   of the viewport. Also contradicts `design-system.md` §4 (~720px cap) and §6
+   (dock spans the window).
+2. **Home is an 82% void.** A ~150px cluster `margin: auto`-centered in 100vh
+   (`web.go:374-385`; `style.css:5479-5541`). `/new` and settings use different,
+   also-unbalanced strategies; five inconsistent content widths
+   (832/880/920/720/640px).
+3. **No tablet band (768–1200px).** Full sidebar + fixed 420px side panes persist
+   to 768px (`style.css:477, 518, 539`); at 1024px with a side pane open the
+   transcript gets ~344px.
+4. **Composer.** 50vh textarea ceiling with no short-desktop rule
+   (`style.css:2047`); phone rest row is two 44px discs flanking a dead gap
+   (`:4561-4582`); desktop model pill is an ~18px hit target, violating
+   `design-system.md` §6's ≥30px floor (`:2074-2082`).
+5. **The stylesheet fights itself.** Dead `.composer-send`/`#send-btn` selectors
+   (`:274-275` — Send's press feedback never fires); duplicate conflicting
+   `.btn:active` blocks (`:270-275` vs `:5554-5562`); undefined `--hair` (`:4683`);
+   27 legacy-alias uses; three parallel token namespaces; inverted state colors
+   (shipped green=working/blue=awaiting vs doc blue=live/amber=needs-you);
+   `--text-dim` (3.4:1, sub-AA) used for words in ~37 places; 13 retired ALL-CAPS
+   mono label treatments; 6-radius spread vs the documented two.
+
+## Design decisions
+
+Architecture is unchanged: no bundler, no framework, embedded assets, the
+`window.SerfRendererInternal` module pattern. `docs/web-ui/design-system.md` is the
+north star; where shipped code contradicts it, the code changes.
+
+### 1. Rendering pipeline
+
+- **Frame batching.** Socket events queue and flush once per
+  `requestAnimationFrame`. `isNearBottom()` is measured once per frame before
+  mutations; scroll settles once after.
+- **Streaming text.** Assistant deltas coalesce per frame. Short messages
+  (<4KB, no open code fence) re-parse markdown at most once per frame; long or
+  complex messages stream into a plain `.streaming-text` node with the existing
+  soft cursor, and markdown parses once at `ASSISTANT_TEXT_END`. Reasoning deltas
+  append text nodes instead of full-buffer replacement.
+- **Tool output.** Streaming output is append-only `textContent` on a single
+  `<pre>`; expand/collapse chrome is built once at `bodyEnd`. Diff rows coalesce
+  per frame.
+- **Windowing.** `content-visibility: auto` with `contain-intrinsic-size` on turn
+  containers. No hand-rolled virtualization; DOM stays intact for find-in-page.
+- **Hydration.** Per-event scroll work suppressed during replay; one scroll
+  settle at the end.
+- **Scroll handler.** rAF-throttled; error anchors cached, invalidated on
+  tool-end.
+- Remove the per-event `JSON.stringify`→`parse` round trip.
+
+### 2. Layout system
+
+- **One width scale.** `--measure: 720px` (reading column, per design-system §4);
+  machine rows (tool output, diffs) may bleed right to `--measure-machine`
+  (~1000px); left edges never move. Home, `/new`, settings, and transcript snap to
+  this scale.
+- **Breakpoint ladder.** Phone ≤767px (unchanged); **tablet 768–1199px** (sidebar
+  auto-collapses to the 56px rail, side panes become overlays, pickers fluid);
+  desktop 1200–1799px (current); **wide ≥1800px** (measure ~880px, machine rows
+  ~1200px, composer dock spans the window per §6).
+- **Composer.** Dock spans the window with the input card centered at measure;
+  desktop model pill ≥30px hit target; phone control row rebalanced (no oversized
+  send disc + dead gap); short-desktop rule (height <640px compacts header +
+  status rail); textarea gets a px ceiling.
+- **Home launchpad.** Replace the empty state with a "Jump back in" column:
+  recent sessions (title, project, relative time, status) plus new/search
+  actions, server-rendered from roster data, on the shared width scale.
+- **Sidebar.** One left-inset rhythm.
+
+### 3. CSS consolidation
+
+- **One token vocabulary:** canonical `design-system.md` names (`--ink`,
+  `--surface`, `--line`, `--hair`, `--attention`, `--done`); delete the 27
+  legacy-alias uses and the third namespace.
+- **State colors per the doc:** blue = live/active, amber = needs-you, red =
+  error, neutral = done.
+- **Delete dead CSS:** `.composer-send`/`#send-btn` selectors, duplicate
+  `.btn:active` blocks (keep the scale-pop), define `--hair`.
+- **Contrast pass:** `--text-dim` stops coloring words (~37 sites → `--ink-3`
+  minimum); the short-think tier keeps its recede via size + italic.
+- **Retire remaining ALL-CAPS mono labels** (13 sites); consolidate the radius
+  scale to the documented two values.
+
+## Error handling
+
+- Frame batching must not drop events: queue overflow is impossible (unbounded
+  array), and a flush always drains the full queue. A socket reconnect mid-frame
+  re-runs hydration through the same detached path.
+- `content-visibility` gets a `contain-intrinsic-size` estimate so scrollbar
+  geometry stays stable; elements near the viewport render normally.
+- Streaming-text fallback: if `marked.parse` throws at `ASSISTANT_TEXT_END`,
+  the message stays as plain text (current behavior on parse failure is
+  preserved).
+- The tablet rail collapse is CSS/container-query driven; manual ⌘B toggle
+  continues to override it.
+
+## Testing
+
+- Extend `cmd/serf-hub/jstest/`: frame batching coalesces parses (N deltas → ≤1
+  parse per frame), streaming-text path for long messages, append-only tool
+  output, rAF-throttled scroll handler, hydration settle-once,
+  `content-visibility` attributes present, breakpoint rules, no legacy token
+  aliases, hit-target floors. Mirror `test-renderer.js` patterns.
+- Go web tests for the launchpad markup (`web.go`).
+- Visual verification matrix (playwright): 390/768/1100/1440/2560px × dark/light
+  × home/session, before vs after, reviewed by eye.
+- Gate per increment: `make build-hub` + `jstest/run-all.sh` +
+  `go test ./cmd/serf-hub`. Small TDD commits on `webui-joy`.
+
+## Out of scope
+
+- Subagent-sidebar and multi-pane feature work owned by other efforts.
+- The design-system doc itself (no principle changes).
+- Backend/appwire protocol changes — all fixes are client-side except the
+  server-rendered home launchpad.


### PR DESCRIPTION
Fixes #25

## Summary
The shared `purpose` parameter injected into every work-tool schema (`toolPurposeDescription` in `agent/internal/tool/registry.go`) described the field as "Briefly explain why you are calling this tool and what you expect to learn or accomplish." That produced imperative or verbose prose, which reads awkwardly where purpose strings render as inline activity labels (subagent rows, tool-call cards in the web UI).

The description now gives part-of-speech guidance:

> A short verb-first gerund phrase naming what this call is doing, e.g. "Reading the config file" or "Searching for the handler". Keep it to a few words so it renders nicely as an inline activity label.

I grepped the repo for other purpose-schema definitions and prompt guidance: this constant is the only definition site (`WithPurposeParameter` injects it everywhere; `read_file`'s own `purpose` parameter in `agent/internal/tool/definitions.go` is a different field — an OCR extraction ask — and was left unchanged). No prompt templates in `agent/prompts/` mention purpose.

## Test evidence
- New test `TestWithPurposeParameter_DescriptionGuidesGerundForm` in `agent/internal/tool/registry_test.go` asserts the injected description contains gerund-form guidance, a concrete example, and stays concise (\u2264240 runes). Verified it failed before the change and passes after.
- `go test ./agent/...` — all packages ok.
- `go test ./agent` — ok (30.981s).