### PR TITLE
Render subagent inline activity as the tool call's purpose

### DIFF
--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -3442,9 +3442,16 @@
       for (const item of items) {
         const line = document.createElement("div");
         line.className = "sub-preview-line";
-        const label = item.toolName ? item.toolName : (item.type === "agentMessage" ? "assistant" : item.type || "item");
-        const text = item.description || item.text || item.output || item.status || "";
-        line.textContent = label + (text ? ": " + clip(text, 100) : "");
+        if (item.toolName) {
+          // Tool lines render just the call's purpose (#26); with no purpose,
+          // the bare tool name — never an output dump behind a "tool:" prefix.
+          const purpose = typeof item.description === "string" ? item.description.trim() : "";
+          line.textContent = purpose ? clip(purpose, 100) : item.toolName;
+        } else {
+          const label = item.type === "agentMessage" ? "assistant" : item.type || "item";
+          const text = item.description || item.text || item.output || item.status || "";
+          line.textContent = label + (text ? ": " + clip(text, 100) : "");
+        }
         box.appendChild(line);
       }
       if (data && data.truncated) {
@@ -3563,8 +3570,11 @@
       if (!item) return null;
       const tool = item.toolName || item.tool_name;
       if (tool) {
-        const detail = item.description || item.command || item.target || item.query || "";
-        return clip(detail ? tool + ": " + detail : tool, 80);
+        // Render just the tool call's purpose (#26) — no "toolname:" prefix,
+        // no raw command/target dump. With no purpose the honest fallback is
+        // the bare tool name.
+        const purpose = typeof item.description === "string" ? item.description.trim() : "";
+        return clip(purpose || tool, 80);
       }
       const type = String(item.type || "");
       if (type === "agentMessage" || type === "assistantText" || type === "reasoning") return "responding";

--- a/cmd/serf-hub/jstest/test-subagents.js
+++ b/cmd/serf-hub/jstest/test-subagents.js
@@ -314,8 +314,11 @@ await scenario("live activity: child frames push to the row's activity line, ste
     return { ok: false, detail: "a child frame must NOT render into the parent transcript" };
   }
   if (row.dataset.steps !== "1") return { ok: false, detail: "first activity should set steps=1, got " + row.dataset.steps };
-  const live = row.querySelector(".res .live");
-  if (!live || !/shell: go test/.test(live.textContent)) return { ok: false, detail: "activity line should show the latest step: " + (live && live.textContent) };
+  const liveText = () => { const el = row.querySelector(".res .live"); return el ? el.textContent : ""; };
+  // Issue #26: inline child activity renders the tool call's purpose only —
+  // no "toolname:" prefix, no raw command/target dump.
+  if (liveText() !== "go test ./...") return { ok: false, detail: "activity line should be just the purpose: " + liveText() };
+  if (liveText().includes("shell:")) return { ok: false, detail: "activity line must not carry a toolname prefix: " + liveText() };
   // A frame for an UNwatched ref is not ours — must not be swallowed.
   if (R.handleChildFrame("item/started", { ref: "local:other", item: { toolName: "grep" } })) {
     return { ok: false, detail: "a frame for an unwatched ref must not be swallowed" };
@@ -323,8 +326,14 @@ await scenario("live activity: child frames push to the row's activity line, ste
   // New activity advances the step count; an identical repeat does NOT (honest).
   R.handleChildFrame("item/started", { ref: "local:child-L", item: { toolName: "read_file", description: "auth/session.go" } });
   if (row.dataset.steps !== "2") return { ok: false, detail: "new activity should advance steps to 2, got " + row.dataset.steps };
+  if (liveText() !== "auth/session.go") return { ok: false, detail: "activity line should be the new purpose: " + liveText() };
   R.handleChildFrame("item/started", { ref: "local:child-L", item: { toolName: "read_file", description: "auth/session.go" } });
   if (row.dataset.steps !== "2") return { ok: false, detail: "identical activity must not advance steps, got " + row.dataset.steps };
+  // No purpose available: the honest fallback is the bare tool name — never a
+  // fabricated detail and never a raw arguments dump.
+  R.handleChildFrame("item/completed", { ref: "local:child-L", item: { toolName: "shell", status: "completed" } });
+  if (row.dataset.steps !== "3") return { ok: false, detail: "a purpose-less tool frame is still a new step, got " + row.dataset.steps };
+  if (liveText() !== "shell") return { ok: false, detail: "purpose-less tool frame should fall back to the bare tool name: " + liveText() };
   // Honest aging: rewind the last change and re-age → silent + a 'quiet Ns' clock.
   row.dataset.lastChangeAt = String(Date.now() - 50000);
   R.ageSubagentRow(row);
@@ -625,7 +634,7 @@ await scenario("expanded subagent row lazy-loads bounded preview", [
     return Promise.resolve({ ok: true, json: () => Promise.resolve({ ref: "local:child-preview", truncated: true, items: [
       { type: "agentMessage", text: "found three callers" },
       { type: "commandExecution", toolName: "grep_files", description: "search billing", status: "completed" },
-      { type: "agentMessage", text: "recommended fix" },
+      { type: "commandExecution", toolName: "shell", status: "completed" },
       { type: "agentMessage", text: "extra item should not render when limit is 3" },
     ] }) });
   };
@@ -637,7 +646,12 @@ await scenario("expanded subagent row lazy-loads bounded preview", [
   if (!requested.includes("local%3Achild-preview")) return { ok: false, detail: "preview endpoint not requested: " + requested };
   if (!preview) return { ok: false, detail: "missing preview container" };
   if (!preview.textContent.includes("found three callers") || !preview.textContent.includes("search billing")) return { ok: false, detail: "missing preview snippets: " + preview.textContent };
-  if (!preview.textContent.includes("recommended fix")) return { ok: false, detail: "preview should render third item (lower bound of limit is 3): " + preview.textContent };
+  const lines = Array.from(preview.querySelectorAll(".sub-preview-line"));
+  // Issue #26: a tool line is just the purpose — no "toolname:" prefix.
+  if (!lines[1] || lines[1].textContent !== "search billing") return { ok: false, detail: "tool preview line should be the bare purpose: " + (lines[1] && lines[1].textContent) };
+  if (lines[1].textContent.includes("grep_files:")) return { ok: false, detail: "tool preview line must not carry a toolname prefix: " + lines[1].textContent };
+  // No purpose on the third item: the honest fallback is the bare tool name.
+  if (!lines[2] || lines[2].textContent !== "shell") return { ok: false, detail: "purpose-less tool preview line should be the bare tool name: " + (lines[2] && lines[2].textContent) };
   if (preview.textContent.includes("extra item should not render")) return { ok: false, detail: "preview rendered more than bounded limit" };
   return { ok: true };
 });

--- a/internal/appprojector/appwire_projection.go
+++ b/internal/appprojector/appwire_projection.go
@@ -404,6 +404,10 @@ func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification
 		if p.skillCandidate.valid && p.skillCandidate.callID == data.CallID && p.skillCandidate.activationName != "" {
 			raw = skillActivationRaw(p.skillCandidate.activationName)
 		}
+		argsJSON := p.toolArgsByKey[data.CallID]
+		if argsJSON == "" {
+			argsJSON = data.ArgumentsJSON
+		}
 		item := appwire.ThreadItem{
 			Type:         "commandExecution",
 			ID:           p.toolItemID(data.CallID),
@@ -415,8 +419,11 @@ func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification
 			OutputImages: projectOutputImages(data.OutputImages),
 			Status:       "completed",
 			Raw:          raw,
+			// Carry the call's purpose onto the completed item too (#26):
+			// the started item already has it, and live consumers (the web
+			// subagent activity line) render the purpose from Description.
+			Description: apptranscript.ToolIntentFromArguments(json.RawMessage(argsJSON)),
 		}
-		argsJSON := p.toolArgsByKey[data.CallID]
 		if data.ToolName == "use_skill" && data.Error == "" {
 			skill := useSkillNameFromArgs(argsJSON)
 			activationName := ""

--- a/internal/appprojector/appwire_projection_test.go
+++ b/internal/appprojector/appwire_projection_test.go
@@ -1850,6 +1850,65 @@ func notificationTurnID(t *testing.T, items []AppNotification, method string) st
 	return notificationTurn(t, items, method).ID
 }
 
+// Issue #26: live tool frames feed the web UI's inline subagent activity line,
+// which renders the tool call's purpose. The started item carries the purpose
+// in Description; the completed item must carry it too (derived from the
+// call's arguments, mirroring apptranscript.ToolIntentFromArguments) so the
+// activity line stays on the purpose when the tool finishes.
+func TestAppEventProjectorToolCallEndCarriesPurposeDescription(t *testing.T) {
+	projector := NewAppEventProjector("th_1", "local:th_1")
+	projector.Project(events.SessionEvent{Kind: events.EventUserInput, SessionID: "th_1", Data: events.UserInputData{Text: "hello"}})
+
+	projector.Project(events.SessionEvent{Kind: events.EventToolCallStart, SessionID: "th_1", Data: events.ToolCallStartData{
+		ToolName:      "shell",
+		CallID:        "call_1",
+		ArgumentsJSON: `{"command":"go test ./...","purpose":"run the full test suite"}`,
+		Description:   "run the full test suite",
+	}})
+	out := projector.Project(events.SessionEvent{Kind: events.EventToolCallEnd, SessionID: "th_1", Data: events.ToolCallEndData{
+		ToolName: "shell",
+		CallID:   "call_1",
+		Output:   "ok",
+	}})
+	item := notificationThreadItem(t, out, appwire.NotifyItemCompleted)
+	if item.Description != "run the full test suite" {
+		t.Fatalf("completed tool item should carry the purpose-derived Description, got %q", item.Description)
+	}
+
+	// The intent field is honored too, matching ToolIntentFromArguments.
+	projector.Project(events.SessionEvent{Kind: events.EventToolCallStart, SessionID: "th_1", Data: events.ToolCallStartData{
+		ToolName:      "grep",
+		CallID:        "call_2",
+		ArgumentsJSON: `{"query":"retry","intent":"trace the retry callers"}`,
+	}})
+	out = projector.Project(events.SessionEvent{Kind: events.EventToolCallEnd, SessionID: "th_1", Data: events.ToolCallEndData{
+		ToolName: "grep",
+		CallID:   "call_2",
+		Output:   "3 matches",
+	}})
+	item = notificationThreadItem(t, out, appwire.NotifyItemCompleted)
+	if item.Description != "trace the retry callers" {
+		t.Fatalf("completed tool item should derive Description from the intent field, got %q", item.Description)
+	}
+
+	// No purpose in the arguments: Description stays empty rather than
+	// falling back to a raw command dump.
+	projector.Project(events.SessionEvent{Kind: events.EventToolCallStart, SessionID: "th_1", Data: events.ToolCallStartData{
+		ToolName:      "shell",
+		CallID:        "call_3",
+		ArgumentsJSON: `{"command":"ls -la"}`,
+	}})
+	out = projector.Project(events.SessionEvent{Kind: events.EventToolCallEnd, SessionID: "th_1", Data: events.ToolCallEndData{
+		ToolName: "shell",
+		CallID:   "call_3",
+		Output:   "...",
+	}})
+	item = notificationThreadItem(t, out, appwire.NotifyItemCompleted)
+	if item.Description != "" {
+		t.Fatalf("purpose-less tool call should have empty Description, got %q", item.Description)
+	}
+}
+
 func notificationTurn(t *testing.T, items []AppNotification, method string) appwire.Turn {
 	t.Helper()
 	for _, item := range items {


### PR DESCRIPTION
Fixes #26

## What changed

**Web UI (`cmd/serf-hub/assets/renderer.js`)** — both places that render inline subagent activity now show just the tool call's purpose, with no `toolname:` prefix and no fallback to raw command/target/query dumps:
- `childActivityFromFrame` (the live row activity line): renders `item.description` (the purpose) clipped; when no purpose exists the honest fallback is the bare tool name.
- `renderSubagentPreview` (the click-open preview): tool lines render the purpose alone; purpose-less tool lines render the bare tool name. Non-tool lines (assistant messages, etc.) are unchanged.

**Go projector (`internal/appprojector/appwire_projection.go`)** — live tool-call frames carried the purpose only on the *started* item (via `ToolCallStartData.Description`); the *completed* item had an empty `Description`, so a live child's activity line would degrade to the bare tool name the moment a tool finished. The projector now populates `Description` on the completed ThreadItem from the call's arguments via `apptranscript.ToolIntentFromArguments` (intent/purpose/description) — the same semantics replay items already get — falling back to `ToolCallEndData.ArgumentsJSON` if the start-frame args weren't tracked.

## Design decisions
- **Fallback when no purpose exists:** the bare tool name (e.g. `shell`). Truthful, and never an arguments/output dump masquerading as a summary.
- **Purpose extraction stays in Go:** JS never parses `argumentsJson`; it renders the server-supplied `description` field, matching how replay items already work.

## Test evidence
- `cd cmd/serf-hub/jstest && NODE_PATH=/tmp/serf-jstest-jsdom/node_modules sh run-all.sh` → **jstest: all tests passed** (extended the live-activity and lazy-preview scenarios in `test-subagents.js` to assert purpose-only lines and the bare-tool-name fallback; written test-first, confirmed failing before the fix).
- `go test ./internal/appprojector/... ./appwire/... ./internal/apptranscript/...` → ok (added `TestAppEventProjectorToolCallEndCarriesPurposeDescription`: purpose/intent carried onto completed items, empty when absent).
- `go test ./cmd/serf-hub/` → ok.