### PR TITLE
web: open sidebar ⋯ menus as full-width modal sheet on mobile (#27)

### DIFF
--- a/cmd/serf-hub/assets/sidebar.js
+++ b/cmd/serf-hub/assets/sidebar.js
@@ -207,15 +207,24 @@
   }
 
   // --- Row menu (⋯ popover) ----------------------------------------------------
-  var openMenuEl = null, menuAnchor = null;
+  // Desktop opens an anchored mini-popover. On phone viewports
+  // (matchMedia "(max-width: 767px)", checked at open time) the menu instead
+  // opens as a modal: a full-width bottom sheet (.sb-menu-modal) inside a
+  // fixed tap-to-dismiss scrim (.sb-menu-scrim), with SerfFocusTrap keeping
+  // Tab traversal and screen-reader scope inside the sheet (#27). Every close
+  // path funnels through closeMenu, which tears down menu, scrim, and trap.
+  var openMenuEl = null, menuAnchor = null, openMenuScrim = null, openMenuTrap = null;
   function closeMenu() {
+    if (openMenuTrap) { window.SerfFocusTrap.deactivate(openMenuTrap); openMenuTrap = null; }
+    if (openMenuScrim) { openMenuScrim.remove(); openMenuScrim = null; }
     if (openMenuEl) { openMenuEl.remove(); openMenuEl = null; menuAnchor = null; document.removeEventListener("click", onDocClick, true); }
   }
   function onDocClick(e) { if (openMenuEl && !openMenuEl.contains(e.target) && e.target !== menuAnchor) closeMenu(); }
   function openMenu(anchor, items) {
     closeMenu();
+    var mobile = window.matchMedia && window.matchMedia("(max-width: 767px)").matches;
     var menu = document.createElement("div");
-    menu.className = "sb-menu";
+    menu.className = mobile ? "sb-menu sb-menu-modal" : "sb-menu";
     menu.setAttribute("role", "menu");
     items.forEach(function (it) {
       if (it.hidden) return;
@@ -224,15 +233,32 @@
       b.addEventListener("click", function (e) { e.preventDefault(); e.stopPropagation(); closeMenu(); it.run(); });
       menu.appendChild(b);
     });
-    document.body.appendChild(menu);
-    var r = anchor.getBoundingClientRect();
-    menu.style.position = "absolute";
-    menu.style.top = (r.bottom + window.scrollY + 2) + "px";
-    menu.style.left = (r.left + window.scrollX) + "px";
+    if (mobile) {
+      // The sheet sits inside the scrim; a tap on the scrim lands outside the
+      // menu, so the existing onDocClick outside-click path dismisses it.
+      var scrim = document.createElement("div");
+      scrim.className = "sb-menu-scrim";
+      scrim.appendChild(menu);
+      document.body.appendChild(scrim);
+      openMenuScrim = scrim;
+    } else {
+      document.body.appendChild(menu);
+      var r = anchor.getBoundingClientRect();
+      menu.style.position = "absolute";
+      menu.style.top = (r.bottom + window.scrollY + 2) + "px";
+      menu.style.left = (r.left + window.scrollX) + "px";
+    }
     openMenuEl = menu; menuAnchor = anchor;
     setTimeout(function () { document.addEventListener("click", onDocClick, true); }, 0);
     document.addEventListener("keydown", onMenuKeydown);
-    var first = menu.querySelector(".sb-menu-item"); if (first) first.focus();
+    if (mobile && window.SerfFocusTrap) {
+      // Trap on the scrim (the sheet's body-level parent): siblings go inert,
+      // Tab cycles inside, focus lands on the first item, and deactivate
+      // restores focus to the anchor.
+      openMenuTrap = window.SerfFocusTrap.activate(openMenuScrim, anchor);
+    } else {
+      var first = menu.querySelector(".sb-menu-item"); if (first) first.focus();
+    }
   }
   function onMenuKeydown(e) {
     if (!openMenuEl) { document.removeEventListener("keydown", onMenuKeydown); return; }

--- a/cmd/serf-hub/assets/style.css
+++ b/cmd/serf-hub/assets/style.css
@@ -5734,6 +5734,43 @@ body.doc-page {
 .sb-menu { z-index: 60; background: var(--bg-raised); border: 1px solid var(--rule); border-radius: var(--radius-md); padding: var(--space-1); box-shadow: 0 4px 16px rgba(0,0,0,.35); min-width: 160px; }
 .sb-menu-item { display: block; width: 100%; text-align: left; padding: var(--space-2) var(--space-3); background: transparent; border: none; color: var(--text); font-size: var(--text-sm); min-height: 24px; }
 .sb-menu-item:hover, .sb-menu-item:focus { background: var(--surface-secondary); }
+/* Mobile ⋯ menu modal (#27): below 768px sidebar.js opens the row/project ⋯
+   menu as a full-width bottom sheet on a tap-to-dismiss scrim instead of the
+   anchored mini-popover above. JS gates creation on matchMedia
+   "(max-width: 767px)", so the scrim/sheet only ever exist on phone
+   viewports; the media query below is belt-and-braces so the sheet layout
+   can never leak into a desktop viewport. Scrim fades in like the other
+   overlay scrims (chip-picker, panel). */
+.sb-menu-scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: var(--z-modal);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  animation: chip-picker-scrim-in var(--motion-fast) both;
+}
+@media (max-width: 767px) {
+  .sb-menu-modal {
+    width: 100%;
+    min-width: 0;
+    border: none;
+    border-top: 1px solid var(--rule);
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+    padding: var(--space-2) var(--space-1);
+    max-height: 60vh;
+    overflow-y: auto;
+  }
+  /* Touch targets follow the phone --tap-min floor (44px, design §1.8). */
+  .sb-menu-modal .sb-menu-item {
+    min-height: var(--tap-min);
+    display: flex;
+    align-items: center;
+    padding: var(--space-3) var(--space-5);
+    font-size: var(--text-base);
+  }
+}
 .sb-rename-input { width: 100%; font-size: var(--text-base); background: var(--bg); color: var(--text); border: 1px solid var(--accent); border-radius: var(--radius-md); }
 
 /* Sidebar readability floor (design diagnostic WS3, Task 24): row meta on

--- a/cmd/serf-hub/jstest/test-sidebar-menu-mobile.js
+++ b/cmd/serf-hub/jstest/test-sidebar-menu-mobile.js
@@ -1,0 +1,127 @@
+// #27 — Mobile ⋯ menu modal. Under matchMedia "(max-width: 767px)" the
+// sidebar row/project ⋯ menu must open as a full-width modal sheet on a
+// tap-to-dismiss backdrop scrim, not as the anchored desktop mini-popover.
+// Desktop behavior must stay exactly as-is.
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+
+const sidebarSrc = fs.readFileSync(path.resolve(__dirname, "../assets/sidebar.js"), "utf8");
+const iconsSrc = fs.readFileSync(path.resolve(__dirname, "../assets/icons.js"), "utf8");
+const focusTrapSrc = fs.readFileSync(path.resolve(__dirname, "../assets/focus-trap.js"), "utf8");
+
+const failures = [];
+const pass = (c, m) => { if (!c) failures.push("FAIL: " + m); };
+const flush = () => new Promise((r) => setTimeout(r, 20));
+
+function tree() {
+  return { needs_you: [], favorites: [], archived_projects: [], test_runs: [],
+    projects: [{ key: "p1", name: "p", working_dir: "/w/p", default_expanded: true,
+      sessions: [{ row_id: "project:p1:local:01A", ref: "local:01A", session_id: "01A", title: "s", state: "idle", kind: "session", tier: "current", rename: true }] }],
+    attentionSummary: { needsYou: 0, error: 0, working: 0 } };
+}
+const emptyTree = { needs_you: [], favorites: [], archived_projects: [], test_runs: [], projects: [], attentionSummary: { needsYou: 0, error: 0, working: 0 } };
+
+function boot(isPhone) {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body><aside id="sidebar"></aside></body></html>`, { runScripts: "outside-only", pretendToBeVisual: true, url: "http://localhost/" });
+  const w = dom.window;
+  w.matchMedia = (q) => ({
+    matches: isPhone && /max-width:\s*767px/.test(q),
+    media: q, onchange: null,
+    addListener() {}, removeListener() {}, addEventListener() {}, removeEventListener() {}, dispatchEvent() { return false; },
+  });
+  w.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve(tree()) });
+  w.htmx = { process() {} };
+  w.SerfAppwire = { onNotification() {}, onConnectionRestored() {} };
+  w.eval(iconsSrc);
+  w.eval(focusTrapSrc);
+  w.eval(sidebarSrc);
+  return w;
+}
+
+function openRowMenu(w) {
+  const row = w.document.querySelector('[data-row-id="project:p1:local:01A"]');
+  const btn = row && row.querySelector(".sb-menu-btn");
+  if (!btn) throw new Error("row must carry a ⋯ menu button");
+  btn.dispatchEvent(new w.MouseEvent("click", { bubbles: true }));
+  return btn;
+}
+
+(async () => {
+  // ── Mobile: full-width modal sheet on a scrim ──────────────────────────
+  {
+    const w = boot(true);
+    await flush();
+    const btn = openRowMenu(w);
+    const menu = w.document.querySelector(".sb-menu");
+    const scrim = w.document.querySelector(".sb-menu-scrim");
+    pass(menu, "mobile: clicking ⋯ opens a menu");
+    pass(scrim, "mobile: menu opens with a backdrop scrim");
+    pass(menu && menu.classList.contains("sb-menu-modal"), "mobile: menu carries the modal sheet class");
+    pass(scrim && menu && menu.parentNode === scrim, "mobile: sheet lives inside the scrim overlay");
+    pass(menu && !menu.style.top && !menu.style.left, "mobile: sheet is not anchored under the button (no inline top/left)");
+    pass(menu && menu.getAttribute("role") === "menu", "mobile: menu keeps role=menu");
+    const items = menu ? menu.querySelectorAll(".sb-menu-item") : [];
+    pass(items.length > 0 && items[0].getAttribute("role") === "menuitem", "mobile: items keep role=menuitem");
+    pass(items.length > 0 && w.document.activeElement === items[0], "mobile: first menu item is focused on open");
+    pass(w.document.getElementById("sidebar").hasAttribute("inert"), "mobile: background is inert while the modal is open");
+    await flush(); // let openMenu install its document click listener
+
+    // Arrow-key navigation still works.
+    w.document.dispatchEvent(new w.KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    pass(items.length > 1 && w.document.activeElement === items[1], "mobile: ArrowDown moves focus to the next item");
+    w.document.dispatchEvent(new w.KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
+    pass(w.document.activeElement === items[0], "mobile: ArrowUp moves focus back to the first item");
+
+    // Escape closes, tears down the scrim, and refocuses the anchor.
+    w.document.dispatchEvent(new w.KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    pass(!w.document.querySelector(".sb-menu"), "mobile: Escape closes the menu");
+    pass(!w.document.querySelector(".sb-menu-scrim"), "mobile: Escape removes the scrim");
+    pass(w.document.activeElement === btn, "mobile: Escape refocuses the ⋯ anchor");
+    pass(!w.document.getElementById("sidebar").hasAttribute("inert"), "mobile: inert is lifted after close");
+
+    // Backdrop tap dismisses (click lands on the scrim, outside the sheet).
+    openRowMenu(w);
+    await flush();
+    const scrim2 = w.document.querySelector(".sb-menu-scrim");
+    pass(scrim2, "mobile: menu reopens with a scrim");
+    if (scrim2) scrim2.dispatchEvent(new w.MouseEvent("click", { bubbles: true }));
+    pass(!w.document.querySelector(".sb-menu"), "mobile: tapping the scrim dismisses the menu");
+    pass(!w.document.querySelector(".sb-menu-scrim"), "mobile: tapping the scrim removes it");
+
+    // Anchor-row removal (keyed reconcile) tears down the scrim too.
+    openRowMenu(w);
+    await flush();
+    pass(!!w.document.querySelector(".sb-menu-scrim"), "mobile: menu open before rerender");
+    w.SerfSidebar.renderTree(emptyTree);
+    pass(!w.document.querySelector(".sb-menu"), "mobile: removing the anchor row closes the menu");
+    pass(!w.document.querySelector(".sb-menu-scrim"), "mobile: removing the anchor row removes the scrim");
+  }
+
+  // ── Desktop: anchored mini-popover, no scrim (unchanged) ───────────────
+  {
+    const w = boot(false);
+    await flush();
+    const btn = openRowMenu(w);
+    const menu = w.document.querySelector(".sb-menu");
+    pass(menu, "desktop: clicking ⋯ opens a menu");
+    pass(!w.document.querySelector(".sb-menu-scrim"), "desktop: no scrim is created");
+    pass(menu && !menu.classList.contains("sb-menu-modal"), "desktop: menu keeps popover styling (no modal class)");
+    pass(menu && menu.parentNode === w.document.body, "desktop: menu is appended to <body>");
+    pass(menu && menu.style.position === "absolute" && menu.style.top !== "", "desktop: menu is anchored under the button");
+    const items = menu ? menu.querySelectorAll(".sb-menu-item") : [];
+    pass(items.length > 0 && w.document.activeElement === items[0], "desktop: first menu item is focused on open");
+    pass(!w.document.getElementById("sidebar").hasAttribute("inert"), "desktop: background is not inert (popover, not modal)");
+    await flush();
+    w.document.dispatchEvent(new w.KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    pass(!w.document.querySelector(".sb-menu"), "desktop: Escape closes the menu");
+    pass(w.document.activeElement === btn, "desktop: Escape refocuses the anchor");
+  }
+
+  if (failures.length) {
+    failures.forEach((f) => console.log(f));
+    process.exit(1);
+  }
+  console.log("ok mobile ⋯ menu opens as full-width modal sheet; desktop popover unchanged");
+  process.exit(0);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/cmd/serf-hub/jstest/test-sidebar-menu-modal-css.js
+++ b/cmd/serf-hub/jstest/test-sidebar-menu-modal-css.js
@@ -1,0 +1,73 @@
+// #27 — CSS contract for the mobile ⋯ menu modal: a fixed full-viewport
+// scrim on the modal layer, and inside @media (max-width: 767px) a
+// full-width bottom sheet whose items meet the phone touch-target floor
+// (var(--tap-min) = 44px there). The desktop popover rules must be
+// untouched. Pure regex assertions over style.css.
+const fs = require("fs");
+const path = require("path");
+
+const css = fs.readFileSync(path.resolve(__dirname, "../assets/style.css"), "utf8");
+
+const failures = [];
+const pass = (c, m) => { if (!c) failures.push("FAIL: " + m); };
+
+function ruleBody(selector, hay) {
+  const i = (hay || css).indexOf(selector);
+  if (i < 0) return "";
+  const h = hay || css;
+  return h.slice(i, h.indexOf("}", i));
+}
+
+// Collect the contents of every @media (max-width: 767px) { ... } block
+// (balanced braces, same approach as test-mobile-css.js).
+function mobileBlocks() {
+  const QUERY = "@media (max-width: 767px)";
+  let out = "";
+  let from = 0;
+  for (;;) {
+    const i = css.indexOf(QUERY, from);
+    if (i < 0) break;
+    const open = css.indexOf("{", i);
+    let depth = 1, j = open + 1;
+    while (j < css.length && depth > 0) {
+      if (css[j] === "{") depth++;
+      else if (css[j] === "}") depth--;
+      j++;
+    }
+    out += css.slice(open + 1, j - 1) + "\n";
+    from = j;
+  }
+  return out;
+}
+const mobile = mobileBlocks();
+
+// ── Scrim (backdrop) ─────────────────────────────────────────────────────
+const scrim = ruleBody(".sb-menu-scrim");
+pass(scrim !== "", ".sb-menu-scrim rule must exist");
+pass(/position:\s*fixed/.test(scrim), "scrim must be position:fixed");
+pass(/inset:\s*0/.test(scrim), "scrim must cover the full viewport (inset:0)");
+pass(/z-index:\s*var\(--z-modal\)/.test(scrim), "scrim must sit on the modal layer (var(--z-modal))");
+pass(!/background:\s*#[0-9a-fA-F]/.test(scrim), "scrim must not introduce a raw hex color");
+
+// ── Mobile sheet ─────────────────────────────────────────────────────────
+const sheet = ruleBody(".sb-menu-modal {", mobile) || ruleBody(".sb-menu-modal{", mobile);
+pass(sheet !== "", "mobile media query must style .sb-menu-modal");
+pass(/width:\s*100%/.test(sheet), "mobile sheet must be full-width (width:100%)");
+pass(/max-height/.test(sheet), "mobile sheet must cap its height (scroll, not cover the screen)");
+const sheetItems = ruleBody(".sb-menu-modal .sb-menu-item", mobile);
+pass(sheetItems !== "", "mobile media query must style .sb-menu-modal .sb-menu-item");
+pass(/min-height:\s*var\(--tap-min\)/.test(sheetItems) || /min-height:\s*44px/.test(sheetItems),
+  "mobile menu items must meet the 44px touch floor (var(--tap-min) or 44px)");
+
+// ── Desktop popover untouched ────────────────────────────────────────────
+const desktopMenu = ruleBody(".sb-menu {");
+pass(/min-width:\s*160px/.test(desktopMenu), "desktop .sb-menu popover keeps min-width:160px");
+const desktopItem = ruleBody(".sb-menu-item {");
+pass(/min-height:\s*24px/.test(desktopItem), "desktop .sb-menu-item keeps its 24px density");
+
+if (failures.length) {
+  failures.forEach((f) => console.log(f));
+  process.exit(1);
+}
+console.log("ok mobile ⋯ menu modal CSS (scrim + full-width sheet + 44px items; desktop untouched)");
+process.exit(0);


### PR DESCRIPTION
Fixes #27

## What

On phone viewports the sidebar row/project ⋯ menus now open as a **full-width modal bottom sheet** on a tap-to-dismiss backdrop scrim, instead of the desktop-style anchored mini-popover. Desktop behavior is unchanged.

## How

- `openMenu` checks `window.matchMedia("(max-width: 767px)")` at open time (the same breakpoint idiom already used in `sidebar.js`, `dir-picker.js`, and `spawn.js`).
- Mobile mode appends a fixed `.sb-menu-scrim` (z-index `var(--z-modal)`, fades in like the existing chip-picker/panel scrims) containing the `.sb-menu.sb-menu-modal` sheet. A scrim tap lands outside the menu, so the **existing** `onDocClick` outside-click path dismisses it — no new dismissal machinery.
- `SerfFocusTrap` (loaded before `sidebar.js` in `app.html`) activates on the scrim: background goes `inert`, Tab cycles inside the sheet, the first item is focused on open, and focus restores to the ⋯ anchor on close. Guarded by `window.SerfFocusTrap` so the menu still works if the helper is absent.
- `closeMenu` now tears down menu + scrim + trap, so every existing close path — item pick, outside click, Escape (which still refocuses the anchor), and the anchor-row-removal path in `reconcile` — is covered.
- Sheet items use the phone `--tap-min` floor (44px, design §1.8) with comfortable padding; all styling uses canonical `var(--...)` tokens (scrim dim matches the existing `rgba(0,0,0,0.45)` scrim idiom).
- Desktop path is exactly as before: no scrim, no modal class, anchored absolute positioning under the button.

## Tests (TDD)

- `cmd/serf-hub/jstest/test-sidebar-menu-mobile.js` — JSDOM with a mocked `matchMedia`. Mobile: scrim + `.sb-menu-modal` sheet appears, sheet is not anchor-positioned, `role=menu`/`menuitem` kept, first item focused, background inert, ArrowUp/ArrowDown navigation, Escape closes + removes scrim + refocuses anchor + lifts inert, backdrop tap dismisses, anchor-row removal via `renderTree` tears down the scrim. Desktop: no scrim, no modal class, body-appended anchored popover, Escape behavior unchanged.
- `cmd/serf-hub/jstest/test-sidebar-menu-modal-css.js` — CSS contract: fixed full-viewport scrim on `var(--z-modal)`, `@media (max-width: 767px)` full-width sheet with `max-height` cap, `min-height: var(--tap-min)` items, desktop `.sb-menu`/item rules untouched.
- Full suite: `cd cmd/serf-hub/jstest && NODE_PATH=/tmp/serf-jstest-jsdom/node_modules sh run-all.sh` → **all 161 tests pass**.