### PR TITLE
webui: render user-sent steering as user messages, not system dividers

### DIFF
--- a/agent/events/payloads.go
+++ b/agent/events/payloads.go
@@ -159,10 +159,21 @@ type SandboxEscalationRequestedData struct {
 	PartiallyRan bool   `json:"partially_ran,omitempty"`
 }
 
+// SteeringSourceUser marks steering that originated from the human user —
+// the UI steer action, or queued user input drained as steering — as opposed
+// to daemon/system-generated nudges (task reminders, loop detection, hook
+// context, job notifications, …). UIs render user-sourced steering as a user
+// message rather than a system steering divider (issue #24).
+const SteeringSourceUser = "user"
+
 // SteeringInjectedData is the payload for an EventSteeringInjected event.
 type SteeringInjectedData struct {
 	Text   string           `json:"text"`
 	Images []UserInputImage `json:"images,omitempty"`
+	// Source carries the steering provenance: SteeringSourceUser for
+	// human-sent steering, empty for daemon/system steering. Optional and
+	// additive; absent means system.
+	Source string `json:"source,omitempty"`
 }
 
 // QueueChangedData carries an authoritative snapshot of the per-session

--- a/agent/schema/turn.go
+++ b/agent/schema/turn.go
@@ -42,6 +42,12 @@ type Turn struct {
 	// Usage carries the token-usage stats reported by the provider; set only on
 	// assistant turns.
 	Usage llm.Usage `json:"usage,omitempty"`
+	// SteeringSource records the provenance of a TurnSteering entry:
+	// "user" for human-sent steering (the UI steer action or queued user
+	// input drained as steering), empty for daemon/system nudges. Persisted
+	// so replay/hydration can render user steering as user speech
+	// (issue #24). Empty on non-steering turns.
+	SteeringSource string `json:"steering_source,omitempty"`
 	// ResponseID is the provider's response identifier (from llm.Response.ID),
 	// recorded on assistant turns and surfaced in ATIF trajectory export.
 	ResponseID                      string `json:"response_id,omitempty"`

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -1243,10 +1243,7 @@ func (s *Session) acceptUserInput(ctx context.Context, input string, images []Im
 	}
 
 	// Drain any pending steering messages before the first LLM call (spec 2.5).
-	for _, msg := range s.drainSteeringForTurn() {
-		s.appendTurn(schema.TurnSteering, steeringMessageToLLM(msg))
-		s.emit(events.EventSteeringInjected, steeringInjectedDataFromMessage(msg))
-	}
+	s.injectDrainedSteering()
 	return nil
 }
 
@@ -1283,10 +1280,7 @@ func (s *Session) acceptContinuationInput(ctx context.Context, input string) {
 	s.appendTurn(schema.TurnSteering, llm.User(input))
 
 	// Drain any pending steering messages before the first LLM call (spec 2.5).
-	for _, msg := range s.drainSteeringForTurn() {
-		s.appendTurn(schema.TurnSteering, steeringMessageToLLM(msg))
-		s.emit(events.EventSteeringInjected, steeringInjectedDataFromMessage(msg))
-	}
+	s.injectDrainedSteering()
 }
 
 // acceptNotificationInput records a job-completion notification turn at the
@@ -1365,10 +1359,7 @@ func (s *Session) acceptNotificationInput(ctx context.Context) (proceed bool) {
 	}
 
 	// Drain any pending steering messages before the first LLM call (spec 2.5).
-	for _, msg := range s.drainSteeringForTurn() {
-		s.appendTurn(schema.TurnSteering, steeringMessageToLLM(msg))
-		s.emit(events.EventSteeringInjected, steeringInjectedDataFromMessage(msg))
-	}
+	s.injectDrainedSteering()
 	return true
 }
 

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -9,6 +9,7 @@ import (
 	"primeradiant.com/serf/agent/events"
 	"primeradiant.com/serf/agent/internal/diagnostic"
 	"primeradiant.com/serf/agent/provenance"
+	"primeradiant.com/serf/agent/schema"
 	"primeradiant.com/serf/llm"
 )
 
@@ -48,12 +49,19 @@ type steeringMessage struct {
 	Text       string
 	Images     []ImageAttachment
 	Provenance *provenance.Causal
+	// Source marks who sent the steering: events.SteeringSourceUser for
+	// human-sent steering (the UI steer action, or queued user input
+	// drained as steering), empty for daemon/system nudges. Surfaced on the
+	// SteeringInjectedData event and persisted on the transcript turn so
+	// UIs render user steering as a user message (issue #24).
+	Source string
 }
 
 func steeringInjectedDataFromMessage(msg steeringMessage) events.SteeringInjectedData {
 	return events.SteeringInjectedData{
 		Text:   msg.Text,
 		Images: userInputImagesFromAttachments(msg.Images),
+		Source: msg.Source,
 	}
 }
 
@@ -81,6 +89,20 @@ func (s *Session) SteerWithImages(msg string, images []ImageAttachment) {
 	_ = s.trySteerWithImages(msg, images)
 }
 
+// SteerFromUser queues a text-only steering message sent by the human user
+// mid-turn (the UI steer action). Unlike daemon/system nudges queued via
+// Steer, it is marked Source "user" so UIs render it as a user message
+// rather than a system steering divider (issue #24).
+func (s *Session) SteerFromUser(msg string) {
+	s.SteerFromUserWithImages(msg, nil)
+}
+
+// SteerFromUserWithImages is SteerFromUser with optional image attachments,
+// mirroring SteerWithImages for the human-sent path.
+func (s *Session) SteerFromUserWithImages(msg string, images []ImageAttachment) {
+	_ = s.trySteerEnqueue(msg, images, nil, events.SteeringSourceUser)
+}
+
 func (s *Session) trySteerWithImages(msg string, images []ImageAttachment) bool {
 	return s.trySteerWithImagesAndProvenance(msg, images, nil)
 }
@@ -98,6 +120,13 @@ func (s *Session) trySteerWithProvenanceAndNotify(msg string, p *provenance.Caus
 }
 
 func (s *Session) trySteerWithImagesAndProvenance(msg string, images []ImageAttachment, p *provenance.Causal) bool {
+	return s.trySteerEnqueue(msg, images, p, "")
+}
+
+// trySteerEnqueue is the steering-queue append primitive. source carries the
+// steering provenance marker stored on the entry (events.SteeringSourceUser
+// for human-sent steering, "" for daemon/system steering).
+func (s *Session) trySteerEnqueue(msg string, images []ImageAttachment, p *provenance.Causal, source string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closingOrClosedLocked() {
@@ -106,7 +135,7 @@ func (s *Session) trySteerWithImagesAndProvenance(msg string, images []ImageAtta
 	if strings.TrimSpace(msg) == "" && len(images) == 0 {
 		return false
 	}
-	entry := steeringMessage{Text: msg, Provenance: provenance.Clone(p)}
+	entry := steeringMessage{Text: msg, Provenance: provenance.Clone(p), Source: source}
 	if len(images) > 0 {
 		entry.Images = append([]ImageAttachment(nil), images...)
 	}
@@ -259,11 +288,10 @@ func (s *Session) DrainAsSteerWithInput(ctx context.Context, text string, images
 		combinedProvenance = provenance.Union(combinedProvenance, entry.Provenance)
 	}
 	combined := strings.Join(texts, "\n\n")
-	if len(drainedImages) == 0 {
-		s.trySteerWithProvenance(combined, combinedProvenance)
-	} else {
-		s.trySteerWithImagesAndProvenance(combined, drainedImages, combinedProvenance)
-	}
+	// The drained queue is user-typed input force-steered into the in-flight
+	// turn by a user action (turn/drainAsSteer), so the combined steering
+	// message keeps user provenance for rendering (issue #24).
+	s.trySteerEnqueue(combined, drainedImages, combinedProvenance, events.SteeringSourceUser)
 	return nil
 }
 
@@ -402,6 +430,26 @@ func (s *Session) drainSteering() []steeringMessage {
 	out := append([]steeringMessage{}, s.steeringQueue...)
 	s.steeringQueue = nil
 	return out
+}
+
+// injectDrainedSteering drains any pending steering messages at a turn
+// boundary (or mid-turn injection point), records each as a steering turn in
+// history and the transcript — preserving the message's provenance source so
+// reload/hydration renders user-sent steering as user speech (issue #24) —
+// and emits the steering-injected event. It is the single path every drain
+// site uses so live and replayed steering stay consistent.
+func (s *Session) injectDrainedSteering() {
+	for _, msg := range s.drainSteeringForTurn() {
+		t := schema.NewTurn(schema.TurnSteering, steeringMessageToLLM(msg))
+		t.SteeringSource = msg.Source
+		s.mu.Lock()
+		s.history = append(s.history, t)
+		s.mu.Unlock()
+		if err := s.transcript.Append(t); err != nil {
+			s.emit(events.EventWarning, events.WarningData{Message: fmt.Sprintf("transcript write failed: %v", err)})
+		}
+		s.emit(events.EventSteeringInjected, steeringInjectedDataFromMessage(msg))
+	}
 }
 
 func (s *Session) hasPendingSteering() bool {

--- a/agent/session_steering_source_test.go
+++ b/agent/session_steering_source_test.go
@@ -1,0 +1,161 @@
+package agent
+
+// Tests for steering provenance (issue #24): steering that originates from the
+// human user (the steer button, or queued user input drained as steering) is
+// marked Source="user" on the SteeringInjectedData event and persisted on the
+// transcript turn, so UIs can render it as user speech rather than as a
+// system-looking steering divider. Daemon/system nudges keep an empty Source.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"primeradiant.com/serf/agent/events"
+	"primeradiant.com/serf/agent/execenv"
+	"primeradiant.com/serf/agent/schema"
+	"primeradiant.com/serf/llm"
+)
+
+func TestSteerFromUser_EmitsUserSourceAndPersists(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	c := llm.NewClient()
+	c.Register(&fakeAdapter{name: "openai"})
+
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+
+	// One user-sent steering message (the steer button path) and one
+	// daemon/system nudge, drained together at a turn boundary.
+	sess.SteerFromUser("please focus on the tests")
+	sess.Steer("<SYSTEM-REMINDER>system nudge</SYSTEM-REMINDER>")
+	sess.injectDrainedSteering()
+
+	sess.mu.Lock()
+	turns := append([]schema.Turn{}, sess.history...)
+	sess.mu.Unlock()
+	if len(turns) != 2 {
+		t.Fatalf("history turns = %d, want 2", len(turns))
+	}
+	for i, want := range []string{events.SteeringSourceUser, ""} {
+		if turns[i].Kind != schema.TurnSteering {
+			t.Fatalf("turn %d kind = %s, want STEERING", i, turns[i].Kind)
+		}
+		if turns[i].SteeringSource != want {
+			t.Fatalf("turn %d SteeringSource = %q, want %q", i, turns[i].SteeringSource, want)
+		}
+	}
+
+	// The source marker must survive transcript serialization (JSONL round
+	// trip) so reload/hydration can render user steering as user speech.
+	raw, err := json.Marshal(turns[0])
+	if err != nil {
+		t.Fatalf("marshal turn: %v", err)
+	}
+	var back schema.Turn
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal turn: %v", err)
+	}
+	if back.SteeringSource != events.SteeringSourceUser {
+		t.Fatalf("round-tripped SteeringSource = %q, want %q", back.SteeringSource, events.SteeringSourceUser)
+	}
+
+	sess.Close()
+
+	var sources []string
+	var texts []string
+	for ev := range sess.Events() {
+		if d, ok := ev.Data.(events.SteeringInjectedData); ok {
+			sources = append(sources, d.Source)
+			texts = append(texts, d.Text)
+		}
+	}
+	if len(sources) != 2 {
+		t.Fatalf("steering events = %d, want 2 (%v)", len(sources), texts)
+	}
+	if sources[0] != events.SteeringSourceUser || !strings.Contains(texts[0], "focus on the tests") {
+		t.Fatalf("user steering event = {source:%q text:%q}, want source %q", sources[0], texts[0], events.SteeringSourceUser)
+	}
+	if sources[1] != "" || !strings.Contains(texts[1], "system nudge") {
+		t.Fatalf("system steering event = {source:%q text:%q}, want empty source", sources[1], texts[1])
+	}
+}
+
+func TestSteerFromUserWithImages_EmitsUserSource(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	c := llm.NewClient()
+	c.Register(&fakeAdapter{name: "openai"})
+
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+
+	sess.SteerFromUserWithImages("look at this", []ImageAttachment{{
+		MediaType: "image/png",
+		Data:      sessionPngSig,
+		Name:      "shot.png",
+	}})
+	sess.injectDrainedSteering()
+	sess.Close()
+
+	found := false
+	for ev := range sess.Events() {
+		if d, ok := ev.Data.(events.SteeringInjectedData); ok {
+			found = true
+			if d.Source != events.SteeringSourceUser {
+				t.Fatalf("Source = %q, want %q", d.Source, events.SteeringSourceUser)
+			}
+			if len(d.Images) != 1 {
+				t.Fatalf("Images = %d, want 1", len(d.Images))
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected a STEERING_INJECTED event")
+	}
+}
+
+// TestDrainAsSteer_MarksUserSource covers the queued-user-input path: text the
+// user typed into the queue, force-drained into the in-flight turn as
+// steering, is still user speech.
+func TestDrainAsSteer_MarksUserSource(t *testing.T) {
+	t.Parallel()
+	s := &Session{state: SessionProcessing}
+	if err := s.DrainAsSteerWithInput(context.Background(), "human queued text", nil); err != nil {
+		t.Fatalf("DrainAsSteerWithInput: %v", err)
+	}
+	got := s.drainSteeringForTurn()
+	if len(got) != 1 {
+		t.Fatalf("drained = %d, want 1", len(got))
+	}
+	if got[0].Source != events.SteeringSourceUser {
+		t.Fatalf("drained steering Source = %q, want %q", got[0].Source, events.SteeringSourceUser)
+	}
+}
+
+// TestSystemSteeringPaths_KeepEmptySource pins the other queue entry points
+// (internal Steer callers: task nudges, hook context, job notifications, …)
+// to the empty system source so they keep the steering-divider rendering.
+func TestSystemSteeringPaths_KeepEmptySource(t *testing.T) {
+	t.Parallel()
+	s := &Session{}
+	s.Steer("system nudge")
+	s.SteerWithProvenance("watch nudge", nil)
+	got := s.drainSteeringForTurn()
+	if len(got) != 2 {
+		t.Fatalf("drained = %d, want 2", len(got))
+	}
+	for i, msg := range got {
+		if msg.Source != "" {
+			t.Fatalf("entry %d Source = %q, want empty", i, msg.Source)
+		}
+	}
+}

--- a/agent/session_tool_round.go
+++ b/agent/session_tool_round.go
@@ -354,14 +354,10 @@ func (s *Session) injectPostToolSteering(ctx context.Context, calls []llm.ToolCa
 
 	// Inject any queued steering messages before the next model call.
 	if abortErr := s.withResponseSideEffects(ctx, func() {
-		drainedSteering := s.drainSteeringForTurn()
-		if len(drainedSteering) > 0 {
+		if s.hasPendingSteering() {
 			yieldToObserverCallback = false
 		}
-		for _, msg := range drainedSteering {
-			s.appendTurn(schema.TurnSteering, steeringMessageToLLM(msg))
-			s.emit(events.EventSteeringInjected, steeringInjectedDataFromMessage(msg))
-		}
+		s.injectDrainedSteering()
 	}); abortErr != nil {
 		return false, abortErr
 	}

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -517,6 +517,10 @@ type ThreadItem struct {
 	CompletedAt          *int64          `json:"completedAt,omitempty"`
 	Raw                  json.RawMessage `json:"raw,omitempty"`
 	EventKind            string          `json:"eventKind,omitempty"`
+	// Source carries item provenance for steering items: "user" for
+	// human-sent steering (rendered as a user message), empty for
+	// daemon/system steering (issue #24).
+	Source string `json:"source,omitempty"`
 }
 
 type OutputImage struct {

--- a/cmd/serf-hub/assets/appwire.js
+++ b/cmd/serf-hub/assets/appwire.js
@@ -652,7 +652,11 @@
       return [["USER_INPUT", event]];
     }
     if (type === "steering") {
-      return [["STEERING_INJECTED", { text: item.text || "", images: item.images || [] }]];
+      const steering = { text: item.text || "", images: item.images || [] };
+      // User-sent steering keeps its provenance through hydration so reload
+      // renders it as a user message like the live path does (issue #24).
+      if (item.source) steering.source = item.source;
+      return [["STEERING_INJECTED", steering]];
     }
     if (type === "systemMessage") {
       if (!item.text && !item.description) return [];
@@ -1014,7 +1018,13 @@
       if (params.cause) payload.cause = params.cause;
       return [["WARNING", payload]];
     }
-    if (method === "serf/steering/injected") return [["STEERING_INJECTED", { text: params.text || "", images: params.images || [] }]];
+    if (method === "serf/steering/injected") {
+      const steering = { text: params.text || "", images: params.images || [] };
+      // source:"user" marks human-sent steering; the renderer branches on it
+      // to draw a user message instead of a system steering divider (issue #24).
+      if (params.source) steering.source = params.source;
+      return [["STEERING_INJECTED", steering]];
+    }
     if (method === "serf/job/started") return [["JOB_STARTED", params.job || params]];
     if (method === "serf/job/finished") return [["JOB_FINISHED", params.job || params]];
     return [];

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -1680,6 +1680,15 @@
           this.appendSystemLine(data.text || data.message || "");
           break;
         case "STEERING_INJECTED":
+          // User-sent steering (the steer button, or queued user input
+          // drained as steering) is the human speaking mid-turn: render it as
+          // a user message, images included, not as a system steering
+          // divider (issue #24). Daemon/system steering (no source) keeps the
+          // classified treatment below.
+          if (data && data.source === "user") {
+            this.appendUserMessage(data.text || "", null, data.images || []);
+            break;
+          }
           this.appendSteeringMessage(data.text || imagePlaceholderForCount((data.images || []).length));
           break;
         case "SESSION_END":

--- a/cmd/serf-hub/jstest/test-renderer-steering-source.js
+++ b/cmd/serf-hub/jstest/test-renderer-steering-source.js
@@ -1,0 +1,137 @@
+// Issue #24: user-sent steering messages (the steer button, or queued user
+// input drained as steering) must render as user messages — not as the
+// system-looking collapsible "↻ steering injected" divider.
+//
+// The daemon marks user-originated steering with source:"user" on the
+// serf/steering/injected notification and on hydrated steering thread items;
+// appwire.js must thread that marker through both mapping paths and
+// renderer.js must branch on it.
+//
+// Covers:
+//   A. live notification mapping carries source through
+//   B. renderer renders source:"user" steering via appendUserMessage (bubble
+//      + images), not the steering divider
+//   C. renderer keeps the divider treatment for system steering (no source)
+//   D. hydration (eventsFromThread) carries item.source through
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+
+const appwireSrc = fs.readFileSync(path.resolve(__dirname, "../assets/appwire.js"), "utf8");
+
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation"
+       data-session-id="01TEST"
+       data-state="idle"></div>
+  <form data-input-form data-session-id="01TEST">
+    <textarea class="message-input"></textarea>
+  </form>
+</body></html>`, {
+  runScripts: "outside-only",
+  pretendToBeVisual: true,
+  url: "http://127.0.0.1:9180/s/01TEST",
+});
+
+const { window } = dom;
+window.marked = { parse: (t) => t };
+window.fetch = () => Promise.resolve({
+  ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve(""),
+});
+window.eval(appwireSrc);
+window.SerfAppwire.tasks = () => Promise.resolve([]);
+require("./load-renderer").evalRenderer(window);
+
+const conv = window.document.getElementById("conversation");
+window.SerfRenderer.init(conv);
+
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+async function run() {
+  await new Promise((r) => setTimeout(r, 30));
+
+  // ── A. live notification mapping carries source through ──────────────
+  const liveUser = window.SerfAppwire.eventsFromNotification("serf/steering/injected", {
+    text: "please focus on the tests",
+    source: "user",
+    images: [{ url: "data:image/png;base64,aW1n", name: "shot.png" }],
+  });
+  pass(liveUser.length === 1 && liveUser[0][0] === "STEERING_INJECTED", "live mapping should emit one STEERING_INJECTED, got " + JSON.stringify(liveUser));
+  pass(liveUser[0] && liveUser[0][1].source === "user", "live mapping must carry source=user, got " + JSON.stringify(liveUser[0] && liveUser[0][1]));
+
+  const liveSystem = window.SerfAppwire.eventsFromNotification("serf/steering/injected", {
+    text: "loop detection: you appear to be stuck",
+  });
+  pass(liveSystem[0] && !liveSystem[0][1].source, "system steering should carry no source, got " + JSON.stringify(liveSystem[0] && liveSystem[0][1]));
+
+  // ── B/C. renderer branches on source ─────────────────────────────────
+  window.SerfRenderer.handleData("SESSION_START", { model: "test", profile: "test", session_id: "01TEST" });
+  window.SerfRenderer.handleData("USER_INPUT", { text: "fix the flaky test", images: [] });
+  for (const [kind, data] of liveUser) window.SerfRenderer.handleData(kind, data);
+  for (const [kind, data] of liveSystem) window.SerfRenderer.handleData(kind, data);
+  await new Promise((r) => setTimeout(r, 10));
+
+  const users = conv.querySelectorAll(".user-message");
+  pass(users.length === 2, "expected 2 user messages (input + user steering), got " + users.length);
+  const steerBubble = users[1];
+  pass(steerBubble && steerBubble.textContent.includes("please focus on the tests"), "user steering bubble should carry the steering text");
+  const tag = steerBubble && steerBubble.querySelector(".user-message-tag");
+  pass(tag && tag.textContent === "You", "user steering bubble should carry the 'You' tag");
+  const thumb = steerBubble && steerBubble.querySelector(".user-image-thumb");
+  pass(thumb && thumb.getAttribute("src") === "data:image/png;base64,aW1n", "user steering image should render as a thumbnail");
+
+  const dividers = conv.querySelectorAll("details.steering");
+  pass(dividers.length === 1, "expected exactly 1 steering divider (the system one), got " + dividers.length);
+  pass(dividers[0] && dividers[0].textContent.includes("stuck"), "the surviving divider should be the system steering, got " + (dividers[0] && dividers[0].textContent));
+  pass(users[1] && !users[1].textContent.includes("stuck"), "system steering must not render inside a user bubble");
+
+  // ── D. hydration mapping carries item.source through ─────────────────
+  const thread = {
+    id: "01TEST",
+    turns: [{
+      id: "turn_1",
+      status: "completed",
+      items: [
+        { type: "userMessage", id: "item_user_0", text: "fix the flaky test", status: "completed" },
+        { type: "steering", id: "item_steering_1", text: "please focus on the tests", source: "user", status: "completed" },
+        { type: "steering", id: "item_steering_2", text: "<SYSTEM-REMINDER>nudge</SYSTEM-REMINDER>", status: "completed" },
+      ],
+    }],
+  };
+  const hydEvents = window.SerfAppwire.eventsFromThread(thread);
+  const hydSteering = hydEvents.filter(([kind]) => kind === "STEERING_INJECTED");
+  pass(hydSteering.length === 2, "hydration should emit 2 STEERING_INJECTED events, got " + hydSteering.length);
+  pass(hydSteering[0] && hydSteering[0][1].source === "user", "hydrated user steering must carry source=user, got " + JSON.stringify(hydSteering[0] && hydSteering[0][1]));
+  pass(hydSteering[1] && !hydSteering[1][1].source, "hydrated system steering must carry no source, got " + JSON.stringify(hydSteering[1] && hydSteering[1][1]));
+
+  // Hydrated user steering renders the same way as live (the renderer
+  // consumes the same event shape on replay).
+  for (const [kind, data] of hydSteering) window.SerfRenderer.handleData(kind, data);
+  await new Promise((r) => setTimeout(r, 10));
+  const usersAfter = conv.querySelectorAll(".user-message");
+  pass(usersAfter.length === 3, "expected 3 user messages after hydrated user steering, got " + usersAfter.length);
+  // The hydrated SYSTEM-REMINDER nudge is system steering: it keeps the
+  // divider treatment, joining the live "stuck" divider.
+  const dividersAfter = conv.querySelectorAll("details.steering");
+  pass(dividersAfter.length === 2, "expected 2 steering dividers after hydration (stuck + system nudge), got " + dividersAfter.length);
+
+  if (failures.length > 0) {
+    console.log("Rendered conversation HTML:");
+    console.log(conv.innerHTML);
+    console.log("");
+    for (const f of failures) console.log(f);
+    process.exit(1);
+  }
+  console.log("PASS: user-sent steering renders as a user message (live + hydration); system steering keeps the divider");
+  process.exit(0);
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/cmd/serf/serve.go
+++ b/cmd/serf/serve.go
@@ -506,9 +506,12 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 		return getSession().ResolveSandboxEscalation(id, approve)
 	})
 	srv.SetCompactFunc(func(ctx context.Context) error { return getSession().Compact(ctx) })
-	srv.SetSteerFunc(func(text string) { getSession().Steer(text) })
+	// The steer RPC carries human-sent steering, so it takes the user-sourced
+	// entry points: UIs render it as a user message, not a system steering
+	// divider (issue #24).
+	srv.SetSteerFunc(func(text string) { getSession().SteerFromUser(text) })
 	srv.SetSteerWithImagesFunc(func(text string, images []server.ImageAttachment) {
-		getSession().SteerWithImages(text, images)
+		getSession().SteerFromUserWithImages(text, images)
 	})
 	srv.SetQueueFunc(func(text string) error { return getSession().Enqueue(ctx, text) })
 	srv.SetQueueWithImagesFunc(func(text string, images []server.ImageAttachment) error {

--- a/internal/appprojector/appwire_projection.go
+++ b/internal/appprojector/appwire_projection.go
@@ -538,12 +538,19 @@ func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification
 		if strings.TrimSpace(text) == "" {
 			text = apptranscript.ImagePlaceholder(len(images))
 		}
-		return []AppNotification{p.notification(appwire.NotifySerfSteeringInjected, map[string]any{
+		params := map[string]any{
 			"threadId": p.threadID,
 			"ref":      p.ref,
 			"text":     text,
 			"images":   images,
-		})}
+		}
+		// User-sent steering carries its provenance so the web UI renders it
+		// as a user message rather than a system steering divider (issue #24).
+		// Empty (system) source is omitted from the wire payload.
+		if data.Source != "" {
+			params["source"] = data.Source
+		}
+		return []AppNotification{p.notification(appwire.NotifySerfSteeringInjected, params)}
 	case events.EventCompactionTurn:
 		p.clearSkillCandidate()
 		data := eventData[events.CompactionTurnData](event.Data)

--- a/internal/appprojector/appwire_projection_test.go
+++ b/internal/appprojector/appwire_projection_test.go
@@ -1078,6 +1078,44 @@ func TestAppEventProjectorProjectsSteeringInjected(t *testing.T) {
 	}
 }
 
+// TestAppEventProjectorProjectsSteeringInjectedUserSource (issue #24): the
+// provenance source on SteeringInjectedData must reach the wire so the web UI
+// can render user-sent steering as a user message instead of a system
+// steering divider.
+func TestAppEventProjectorProjectsSteeringInjectedUserSource(t *testing.T) {
+	projector := NewAppEventProjector("th_1", "local:th_1")
+	out := projector.Project(events.SessionEvent{
+		Kind:      events.EventSteeringInjected,
+		SessionID: "th_1",
+		Data:      events.SteeringInjectedData{Text: "focus on the tests", Source: events.SteeringSourceUser},
+	})
+	if len(out) != 1 || out[0].Method != appwire.NotifySerfSteeringInjected {
+		t.Fatalf("out=%+v", out)
+	}
+	params, ok := out[0].Params.(map[string]any)
+	if !ok {
+		t.Fatalf("params=%T", out[0].Params)
+	}
+	if params["source"] != events.SteeringSourceUser {
+		t.Fatalf("params[source]=%v, want %q", params["source"], events.SteeringSourceUser)
+	}
+
+	// System steering carries no source key (empty source omitted from the
+	// wire payload).
+	out = projector.Project(events.SessionEvent{
+		Kind:      events.EventSteeringInjected,
+		SessionID: "th_1",
+		Data:      events.SteeringInjectedData{Text: "<SYSTEM-REMINDER>nudge</SYSTEM-REMINDER>"},
+	})
+	params, ok = out[0].Params.(map[string]any)
+	if !ok {
+		t.Fatalf("params=%T", out[0].Params)
+	}
+	if src, present := params["source"]; present && src != "" {
+		t.Fatalf("system steering params[source]=%v, want absent or empty", src)
+	}
+}
+
 func TestAppEventProjectorProjectsCompactionTurn(t *testing.T) {
 	projector := NewAppEventProjector("th_1", "local:th_1")
 

--- a/internal/apptranscript/apptranscript.go
+++ b/internal/apptranscript/apptranscript.go
@@ -222,6 +222,10 @@ func ProjectTurn(turnID string, turnIndex int, turn schema.Turn, toolNames map[s
 			Text:   text,
 			Images: images,
 			Status: appwire.TurnStatusCompleted,
+			// SteeringSource persists who sent the steering (issue #24):
+			// "user" reaches the web UI so reload renders human-sent
+			// steering as a user message, matching the live path.
+			Source: turn.SteeringSource,
 		}}
 	case schema.TurnAssistant:
 		var items []appwire.ThreadItem

--- a/internal/apptranscript/apptranscript_test.go
+++ b/internal/apptranscript/apptranscript_test.go
@@ -72,6 +72,37 @@ func TestTurnsFromFileStampsStartedAtFromEntryTimestamp(t *testing.T) {
 	}
 }
 
+// TestProjectTurnSteeringCarriesUserSource (issue #24): a steering turn
+// recorded with SteeringSource="user" (human-sent steering) projects a
+// steering item whose Source reaches the web UI, so reload/hydration renders
+// it as a user message like the live path does. System steering keeps an
+// empty source.
+func TestProjectTurnSteeringCarriesUserSource(t *testing.T) {
+	userTurn := schema.Turn{
+		Kind:           schema.TurnSteering,
+		Message:        llm.User("focus on the tests"),
+		Timestamp:      time.Unix(1_700_000_000, 0).UTC(),
+		SteeringSource: "user",
+	}
+	items := ProjectTurn("turn_1", 1, userTurn, map[string]string{}, nil, nil)
+	if len(items) != 1 || items[0].Type != "steering" {
+		t.Fatalf("items=%+v, want one steering item", items)
+	}
+	if items[0].Source != "user" {
+		t.Fatalf("item.Source=%q, want %q", items[0].Source, "user")
+	}
+
+	sysTurn := schema.Turn{
+		Kind:      schema.TurnSteering,
+		Message:   llm.User("<SYSTEM-REMINDER>nudge</SYSTEM-REMINDER>"),
+		Timestamp: time.Unix(1_700_000_000, 0).UTC(),
+	}
+	items = ProjectTurn("turn_2", 2, sysTurn, map[string]string{}, nil, nil)
+	if len(items) != 1 || items[0].Source != "" {
+		t.Fatalf("system steering item.Source=%q, want empty", items[0].Source)
+	}
+}
+
 func TestProjectTurnMapsToolCallsAndResults(t *testing.T) {
 	toolNames := map[string]string{}
 	start := ProjectTurn("turn_1", 1, schema.Turn{


### PR DESCRIPTION
Fixes #24

## Problem
In the web UI, a steering message the **user** typed and sent via the steer button rendered like a daemon/system nudge: freeform user text fell into `classifySteering`'s "unknown" kind and drew the system-looking collapsible "↻ steering injected" divider.

## Fix
Provenance is marked end to end (no text heuristics — user text is freeform):

- **`agent/events`**: `SteeringInjectedData` gains an optional `Source` field; `SteeringSourceUser` (`"user"`) identifies human-sent steering. Additive/optional, so TUI and other consumers are unaffected.
- **`agent` session**: `steeringMessage` carries `Source` through the steering queue. New user-origin entry points `SteerFromUser` / `SteerFromUserWithImages` are wired to the `turn/steer` RPC in `cmd/serf/serve.go`; `DrainAsSteerWithInput` marks its combined message user-sourced (the drained queue is user-typed input, force-steered by a user action). All internal `Steer` callers (task reminders, loop detection, hook context, job notifications, compaction/init nudges) keep the empty system source. The four steering-drain sites now share `injectDrainedSteering`, which also persists the source on the transcript turn (`schema.Turn.SteeringSource`) so reload matches live.
- **`internal/appprojector`**: `source` added to the `serf/steering/injected` notification (omitted when empty).
- **`internal/apptranscript` + `appwire`**: steering thread items carry `Source` (`ThreadItem.Source`, `omitempty`) for hydration.
- **`cmd/serf-hub/assets`**: `appwire.js` threads `source` through both the live notification mapping and the hydration item mapping; `renderer.js` branches `STEERING_INJECTED` with `source==="user"` to `appendUserMessage` (user bubble, images included). System steering keeps the existing classified treatment.

## Test evidence (TDD — all new tests failed before the fix)
- `agent/session_steering_source_test.go`: user steer (text and with-images) emits `Source="user"` and persists `steering_source` on the transcript turn (JSON round-trip); drain-as-steer marks user; system `Steer` paths keep empty source.
- `internal/appprojector`: source passthrough onto the wire payload; omitted for system steering.
- `internal/apptranscript`: `ProjectTurn` carries `SteeringSource` onto the steering item.
- `cmd/serf-hub/jstest/test-renderer-steering-source.js`: live + hydration mappings carry `source`; user steering renders as a `.user-message` bubble with the "You" tag and image thumbnail; system steering keeps exactly the divider treatment.

Suites run:
- `go test ./agent/... ./internal/appprojector/... ./appwire/... ./internal/apptranscript/... ./server/... ./cmd/serf/... ./cmd/serf-hub/... ./cmd/serf-tui/...` — all pass.
- `cd cmd/serf-hub/jstest && NODE_PATH=/tmp/serf-jstest-jsdom/node_modules sh run-all.sh` — all tests passed.