### PR TITLE
webui: per-message promote of queued follow-up to steering

### DIFF
--- a/agent/agent_misc_program_fuzz_test.go
+++ b/agent/agent_misc_program_fuzz_test.go
@@ -148,19 +148,19 @@ func miscContinuationAndCounterProgram(t *testing.T) {
 		t.Fatal("missing live model changed profile")
 	}
 
-	counter := newTreeCounter(0)
-	for i := int64(0); i < counter.cap; i++ {
-		if !counter.reserve() {
+	counter := newTreeCounter(2)
+	for i := int64(0); i < 2; i++ {
+		if !counter.reserve(slotKindJob) {
 			t.Fatalf("reservation %d rejected", i)
 		}
 	}
-	if counter.reserve() {
+	if counter.reserve(slotKindJob) {
 		t.Fatal("counter exceeded capacity")
 	}
 	for counter.n.Load() > 0 {
-		counter.release()
+		counter.releaseKind(slotKindJob)
 	}
-	if slot, ok := (&Session{}).reserveTreeSlot(); !ok || slot != nil {
+	if slot, ok := (&Session{}).reserveTreeSlot(slotKindJob); !ok || slot != nil {
 		t.Fatalf("unbounded reservation = %#v, %v", slot, ok)
 	}
 	releasePreparedTreeSlot(nil)

--- a/agent/events/payloads.go
+++ b/agent/events/payloads.go
@@ -178,10 +178,14 @@ type SteeringInjectedData struct {
 
 // QueueChangedData carries an authoritative snapshot of the per-session
 // input queue after a mutation (kata r80p). Preview entries are FIFO with
-// the head at index 0 and have been collapsed to a single line.
+// the head at index 0 and have been collapsed to a single line. IDs is
+// FIFO-aligned with Preview and carries each entry's stable queue-entry id
+// (minted at enqueue time) so a client can promote a specific entry by
+// identity rather than by bare index (review F1, issue #22).
 type QueueChangedData struct {
 	Depth   int      `json:"depth"`
 	Preview []string `json:"preview,omitempty"`
+	IDs     []string `json:"ids,omitempty"`
 }
 
 // TaskUpdatedData is the payload for an EventTaskUpdated event: the current

--- a/agent/job_delegate_exact_running_attach_fuzz_test.go
+++ b/agent/job_delegate_exact_running_attach_fuzz_test.go
@@ -188,7 +188,7 @@ func jdraAttachWrapper(t *testing.T, prepared bool) {
 	var run *runningJob
 	var err error
 	if prepared {
-		slot, ok := p.reserveTreeSlot()
+		slot, ok := p.reserveTreeSlot(slotKindJob)
 		if !ok {
 			t.Fatal("reserve prepared slot")
 		}

--- a/agent/jobs_seed100_fuzz_test.go
+++ b/agent/jobs_seed100_fuzz_test.go
@@ -201,7 +201,7 @@ func seed100Nested(t *testing.T) {
 	if owner, rec := root.ownerJobManagerFor(forwarded.JobID); owner != child.jobManager || rec == nil {
 		t.Fatalf("nested owner = %p, %+v", owner, rec)
 	}
-	if jobs, err := root.walkDescendantJobs(listFilter{Limit: 1}); err != nil || len(jobs) != 1 {
+	if jobs, _, err := root.walkDescendantJobs(listFilter{Limit: 1}); err != nil || len(jobs) != 1 {
 		t.Fatalf("descendant walk = %v, %v", jobs, err)
 	}
 	_, _, _, _, _ = root.resolveDescendantJobOwner(forwarded.JobID)

--- a/agent/jobs_seed100_range_a_test.go
+++ b/agent/jobs_seed100_range_a_test.go
@@ -79,7 +79,7 @@ func seed100JobsRangeA(t *testing.T) {
 			durableStarted: true,
 		}
 	}
-	jobs, err := listed.listWithError(listFilter{Limit: 1})
+	jobs, _, err := listed.listWithError(listFilter{Limit: 1})
 	if err != nil {
 		t.Fatalf("listWithError: %v", err)
 	}

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -2,9 +2,12 @@ package agent
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 
 	"primeradiant.com/serf/agent/events"
 	"primeradiant.com/serf/agent/internal/diagnostic"
@@ -186,10 +189,26 @@ func (s *Session) FollowUp(msg string) {
 // are forwarded together when the entry is drained as a fresh user turn.
 // Provenance carries the causal watch origin (nil for human-typed input) so a
 // DrainAsSteer collapse can fold it into the steering message it injects.
+// ID is a stable per-entry identifier minted at enqueue time; it rides the
+// queue snapshot so a promote-by-index request can verify the entry it meant
+// is still the entry at that index (review F1, issue #22).
 type queuedInput struct {
+	ID         string
 	Text       string
 	Images     []ImageAttachment
 	Provenance *provenance.Causal
+}
+
+// queueEntrySeq guarantees queue-entry id uniqueness by construction,
+// mirroring escalationSeq: a process-monotonic counter plus a random suffix.
+var queueEntrySeq atomic.Uint64
+
+// newQueueEntryID mints a unique opaque handle for one queued input entry.
+func newQueueEntryID() string {
+	seq := queueEntrySeq.Add(1)
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	return fmt.Sprintf("q_%d_%s", seq, hex.EncodeToString(b[:]))
 }
 
 // Enqueue appends a text-only user message to the per-session input queue
@@ -221,7 +240,7 @@ func (s *Session) EnqueueWithImages(ctx context.Context, text string, images []I
 		s.mu.Unlock()
 		return errors.New("queue: session is closed")
 	}
-	entry := queuedInput{Text: text}
+	entry := queuedInput{ID: newQueueEntryID(), Text: text}
 	if len(images) > 0 {
 		entry.Images = append([]ImageAttachment(nil), images...)
 	}
@@ -262,7 +281,7 @@ func (s *Session) DrainAsSteerWithInput(ctx context.Context, text string, images
 		return errors.New("drain: no active turn to steer")
 	}
 	if strings.TrimSpace(text) != "" || len(images) > 0 {
-		entry := queuedInput{Text: text}
+		entry := queuedInput{ID: newQueueEntryID(), Text: text}
 		if len(images) > 0 {
 			entry.Images = append([]ImageAttachment(nil), images...)
 		}
@@ -301,10 +320,14 @@ func (s *Session) DrainAsSteerWithInput(ctx context.Context, text string, images
 // DrainAsSteer). Other queued messages stay queued in FIFO order. The
 // steering entry keeps the queued message's images and causal provenance,
 // and is marked Source "user" so UIs render it as user speech rather than a
-// system steering divider (issue #24). Returns an error — leaving the queue
-// untouched — when the session is closed, no turn is in flight, or index is
-// out of range, so a failed promote never silently loses the follow-up.
-func (s *Session) PromoteQueuedAsSteer(ctx context.Context, index int) error {
+// system steering divider (issue #24). When expectedID is non-empty it must
+// match the id of the entry currently at index — the queue head can be
+// consumed mid-turn, so a bare index captured from an earlier snapshot may
+// otherwise resolve to the wrong message (review F1). Returns an error —
+// leaving the queue untouched — when the session is closed, no turn is in
+// flight, index is out of range, or the id mismatches, so a failed promote
+// never silently loses or swaps the follow-up.
+func (s *Session) PromoteQueuedAsSteer(ctx context.Context, index int, expectedID string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -324,6 +347,10 @@ func (s *Session) PromoteQueuedAsSteer(ctx context.Context, index int) error {
 		return fmt.Errorf("promote: queue index %d out of range (depth %d)", index, len(s.inputQueue))
 	}
 	entry := s.inputQueue[index]
+	if expectedID != "" && entry.ID != expectedID {
+		s.mu.Unlock()
+		return fmt.Errorf("promote: queue entry at index %d no longer matches the snapshot (queue changed)", index)
+	}
 	s.inputQueue = append(s.inputQueue[:index], s.inputQueue[index+1:]...)
 	data := s.queueChangedDataLocked()
 	s.mu.Unlock()
@@ -420,14 +447,34 @@ func (s *Session) pushQueueHead(entry queuedInput) {
 	s.emit(events.EventQueueChanged, data)
 }
 
+// QueueIDs returns the stable per-entry ids of the queued messages in FIFO
+// order, aligned with QueuePreview. Callers promoting a queued message by
+// index should read the id from the same snapshot and pass it back as the
+// expected identity so a shifted queue is rejected instead of promoting the
+// wrong entry (review F1, issue #22).
+func (s *Session) QueueIDs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.inputQueue) == 0 {
+		return nil
+	}
+	out := make([]string, len(s.inputQueue))
+	for i, entry := range s.inputQueue {
+		out[i] = entry.ID
+	}
+	return out
+}
+
 // queueChangedDataLocked builds a QueueChangedData snapshot from the
 // current inputQueue. The caller must hold s.mu.
 func (s *Session) queueChangedDataLocked() events.QueueChangedData {
 	data := events.QueueChangedData{Depth: len(s.inputQueue)}
 	if len(s.inputQueue) > 0 {
 		data.Preview = make([]string, len(s.inputQueue))
+		data.IDs = make([]string, len(s.inputQueue))
 		for i, entry := range s.inputQueue {
 			data.Preview[i] = queuedEntryPreviewLine(entry)
+			data.IDs[i] = entry.ID
 		}
 	}
 	return data

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -295,6 +295,46 @@ func (s *Session) DrainAsSteerWithInput(ctx context.Context, text string, images
 	return nil
 }
 
+// PromoteQueuedAsSteer removes the single queued message at index and
+// injects it as a user-sourced STEERING message into the in-flight turn
+// (issue #22 per-message promote; the single-message counterpart of
+// DrainAsSteer). Other queued messages stay queued in FIFO order. The
+// steering entry keeps the queued message's images and causal provenance,
+// and is marked Source "user" so UIs render it as user speech rather than a
+// system steering divider (issue #24). Returns an error — leaving the queue
+// untouched — when the session is closed, no turn is in flight, or index is
+// out of range, so a failed promote never silently loses the follow-up.
+func (s *Session) PromoteQueuedAsSteer(ctx context.Context, index int) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.queueEventsMu.Lock()
+	defer s.queueEventsMu.Unlock()
+	s.mu.Lock()
+	if s.closingOrClosedLocked() {
+		s.mu.Unlock()
+		return errors.New("promote: session is closed")
+	}
+	if s.state != SessionProcessing {
+		s.mu.Unlock()
+		return errors.New("promote: no active turn to steer")
+	}
+	if index < 0 || index >= len(s.inputQueue) {
+		s.mu.Unlock()
+		return fmt.Errorf("promote: queue index %d out of range (depth %d)", index, len(s.inputQueue))
+	}
+	entry := s.inputQueue[index]
+	s.inputQueue = append(s.inputQueue[:index], s.inputQueue[index+1:]...)
+	data := s.queueChangedDataLocked()
+	s.mu.Unlock()
+	s.emit(events.EventQueueChanged, data)
+	// The promoted entry is user-typed input steered into the in-flight turn
+	// by a user action, so it keeps user provenance for rendering — same as
+	// the DrainAsSteer collapse (issue #24).
+	s.trySteerEnqueue(entry.Text, entry.Images, entry.Provenance, events.SteeringSourceUser)
+	return nil
+}
+
 // QueueDepth returns the number of messages currently in the input queue.
 func (s *Session) QueueDepth() int {
 	s.mu.Lock()

--- a/agent/session_queue_promote_test.go
+++ b/agent/session_queue_promote_test.go
@@ -1,0 +1,173 @@
+package agent
+
+// Tests for Session.PromoteQueuedAsSteer (issue #22): a single queued
+// follow-up can be promoted to a steering injection on the in-flight turn.
+// The promoted entry leaves the FIFO queue (other entries keep their order)
+// and lands on the steering queue marked Source="user" so UIs render it as
+// user speech, exactly like a DrainAsSteer collapse (issue #24).
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"primeradiant.com/serf/agent/events"
+	"primeradiant.com/serf/agent/execenv"
+	"primeradiant.com/serf/llm"
+)
+
+func newPromoteTestSession(t *testing.T) *Session {
+	t.Helper()
+	dir := t.TempDir()
+	c := llm.NewClient()
+	c.Register(&fakeAdapter{name: "openai"})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	t.Cleanup(func() { sess.Close() })
+	return sess
+}
+
+func markProcessing(sess *Session) {
+	sess.mu.Lock()
+	sess.state = SessionProcessing
+	sess.mu.Unlock()
+}
+
+func TestSession_PromoteQueuedAsSteer_RemovesOnlyThatEntry(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	for _, msg := range []string{"alpha", "bravo", "charlie"} {
+		if err := sess.Enqueue(context.Background(), msg); err != nil {
+			t.Fatalf("Enqueue %s: %v", msg, err)
+		}
+	}
+	markProcessing(sess)
+
+	if err := sess.PromoteQueuedAsSteer(context.Background(), 1); err != nil {
+		t.Fatalf("PromoteQueuedAsSteer: %v", err)
+	}
+
+	// The other queued messages stay queued, in order.
+	preview := sess.QueuePreview()
+	if len(preview) != 2 || preview[0] != "alpha" || preview[1] != "charlie" {
+		t.Fatalf("QueuePreview after promote: got %#v, want [alpha charlie]", preview)
+	}
+
+	// The promoted message — and only it — lands on the steering queue.
+	sess.mu.Lock()
+	var steering []string
+	for _, m := range sess.steeringQueue {
+		steering = append(steering, m.Text)
+	}
+	sess.mu.Unlock()
+	if len(steering) != 1 || steering[0] != "bravo" {
+		t.Fatalf("steeringQueue after promote: got %#v, want [bravo]", steering)
+	}
+}
+
+func TestSession_PromoteQueuedAsSteer_MarksUserSource(t *testing.T) {
+	t.Parallel()
+	s := &Session{state: SessionProcessing}
+	if err := s.Enqueue(context.Background(), "human queued text"); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if err := s.PromoteQueuedAsSteer(context.Background(), 0); err != nil {
+		t.Fatalf("PromoteQueuedAsSteer: %v", err)
+	}
+	got := s.drainSteeringForTurn()
+	if len(got) != 1 {
+		t.Fatalf("drained = %d, want 1", len(got))
+	}
+	if got[0].Source != events.SteeringSourceUser {
+		t.Fatalf("drained steering Source = %q, want %q", got[0].Source, events.SteeringSourceUser)
+	}
+	if got[0].Text != "human queued text" {
+		t.Fatalf("drained steering Text = %q, want %q", got[0].Text, "human queued text")
+	}
+}
+
+func TestSession_PromoteQueuedAsSteer_RejectsIdleWithoutMutatingQueue(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	if err := sess.Enqueue(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	// No turn in flight: the promote must fail honestly and leave the queued
+	// message in place so it is still processed as a normal follow-up.
+	err := sess.PromoteQueuedAsSteer(context.Background(), 0)
+	if err == nil || !strings.Contains(err.Error(), "no active turn") {
+		t.Fatalf("PromoteQueuedAsSteer idle err=%v, want no active turn", err)
+	}
+	if preview := sess.QueuePreview(); len(preview) != 1 || preview[0] != "alpha" {
+		t.Fatalf("QueuePreview after rejected promote: got %#v, want [alpha]", preview)
+	}
+	sess.mu.Lock()
+	steeringDepth := len(sess.steeringQueue)
+	sess.mu.Unlock()
+	if steeringDepth != 0 {
+		t.Fatalf("steeringQueue after rejected promote: got %d, want 0", steeringDepth)
+	}
+}
+
+func TestSession_PromoteQueuedAsSteer_IndexOutOfRange(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	if err := sess.Enqueue(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	markProcessing(sess)
+	for _, idx := range []int{-1, 1, 42} {
+		err := sess.PromoteQueuedAsSteer(context.Background(), idx)
+		if err == nil || !strings.Contains(err.Error(), "out of range") {
+			t.Fatalf("PromoteQueuedAsSteer(%d) err=%v, want out of range", idx, err)
+		}
+	}
+	if preview := sess.QueuePreview(); len(preview) != 1 || preview[0] != "alpha" {
+		t.Fatalf("QueuePreview after out-of-range promotes: got %#v, want [alpha]", preview)
+	}
+}
+
+func TestSession_PromoteQueuedAsSteer_EmitsQueueChanged(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	if err := sess.Enqueue(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Enqueue alpha: %v", err)
+	}
+	if err := sess.Enqueue(context.Background(), "bravo"); err != nil {
+		t.Fatalf("Enqueue bravo: %v", err)
+	}
+	markProcessing(sess)
+	if err := sess.PromoteQueuedAsSteer(context.Background(), 0); err != nil {
+		t.Fatalf("PromoteQueuedAsSteer: %v", err)
+	}
+	sess.Close()
+
+	var last *events.QueueChangedData
+	for ev := range sess.Events() {
+		if d, ok := ev.Data.(events.QueueChangedData); ok {
+			d := d
+			last = &d
+		}
+	}
+	if last == nil {
+		t.Fatal("expected at least one QueueChanged event")
+	}
+	if last.Depth != 1 || len(last.Preview) != 1 || last.Preview[0] != "bravo" {
+		t.Fatalf("final QueueChanged = %+v, want depth 1 preview [bravo]", *last)
+	}
+}
+
+func TestSession_PromoteQueuedAsSteer_ClosedSession(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	if err := sess.Enqueue(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	sess.Close()
+	err := sess.PromoteQueuedAsSteer(context.Background(), 0)
+	if err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("PromoteQueuedAsSteer closed err=%v, want closed", err)
+	}
+}

--- a/agent/session_queue_promote_test.go
+++ b/agent/session_queue_promote_test.go
@@ -45,7 +45,7 @@ func TestSession_PromoteQueuedAsSteer_RemovesOnlyThatEntry(t *testing.T) {
 	}
 	markProcessing(sess)
 
-	if err := sess.PromoteQueuedAsSteer(context.Background(), 1); err != nil {
+	if err := sess.PromoteQueuedAsSteer(context.Background(), 1, ""); err != nil {
 		t.Fatalf("PromoteQueuedAsSteer: %v", err)
 	}
 
@@ -73,7 +73,7 @@ func TestSession_PromoteQueuedAsSteer_MarksUserSource(t *testing.T) {
 	if err := s.Enqueue(context.Background(), "human queued text"); err != nil {
 		t.Fatalf("Enqueue: %v", err)
 	}
-	if err := s.PromoteQueuedAsSteer(context.Background(), 0); err != nil {
+	if err := s.PromoteQueuedAsSteer(context.Background(), 0, ""); err != nil {
 		t.Fatalf("PromoteQueuedAsSteer: %v", err)
 	}
 	got := s.drainSteeringForTurn()
@@ -96,7 +96,7 @@ func TestSession_PromoteQueuedAsSteer_RejectsIdleWithoutMutatingQueue(t *testing
 	}
 	// No turn in flight: the promote must fail honestly and leave the queued
 	// message in place so it is still processed as a normal follow-up.
-	err := sess.PromoteQueuedAsSteer(context.Background(), 0)
+	err := sess.PromoteQueuedAsSteer(context.Background(), 0, "")
 	if err == nil || !strings.Contains(err.Error(), "no active turn") {
 		t.Fatalf("PromoteQueuedAsSteer idle err=%v, want no active turn", err)
 	}
@@ -119,7 +119,7 @@ func TestSession_PromoteQueuedAsSteer_IndexOutOfRange(t *testing.T) {
 	}
 	markProcessing(sess)
 	for _, idx := range []int{-1, 1, 42} {
-		err := sess.PromoteQueuedAsSteer(context.Background(), idx)
+		err := sess.PromoteQueuedAsSteer(context.Background(), idx, "")
 		if err == nil || !strings.Contains(err.Error(), "out of range") {
 			t.Fatalf("PromoteQueuedAsSteer(%d) err=%v, want out of range", idx, err)
 		}
@@ -139,7 +139,7 @@ func TestSession_PromoteQueuedAsSteer_EmitsQueueChanged(t *testing.T) {
 		t.Fatalf("Enqueue bravo: %v", err)
 	}
 	markProcessing(sess)
-	if err := sess.PromoteQueuedAsSteer(context.Background(), 0); err != nil {
+	if err := sess.PromoteQueuedAsSteer(context.Background(), 0, ""); err != nil {
 		t.Fatalf("PromoteQueuedAsSteer: %v", err)
 	}
 	sess.Close()
@@ -159,6 +159,84 @@ func TestSession_PromoteQueuedAsSteer_EmitsQueueChanged(t *testing.T) {
 	}
 }
 
+// TestSession_PromoteQueuedAsSteer_ExpectedIDMismatch covers review F1: the
+// queue head can be consumed while a turn is in flight, so an index that was
+// valid when the UI snapshotted the preview may now point at a DIFFERENT
+// queued message. The promote must refuse — leaving the queue untouched —
+// when the caller's expected entry id no longer matches the entry at index.
+func TestSession_PromoteQueuedAsSteer_ExpectedIDMismatch(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	if err := sess.Enqueue(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Enqueue alpha: %v", err)
+	}
+	if err := sess.Enqueue(context.Background(), "bravo"); err != nil {
+		t.Fatalf("Enqueue bravo: %v", err)
+	}
+	ids := sess.QueueIDs()
+	if len(ids) != 2 || ids[0] == "" || ids[1] == "" || ids[0] == ids[1] {
+		t.Fatalf("QueueIDs = %#v, want two distinct non-empty ids", ids)
+	}
+	markProcessing(sess)
+
+	// Simulate the shift: the head (alpha) is consumed into a fresh user
+	// turn, so index 0 now holds bravo. A promote carrying alpha's id must
+	// fail honestly instead of steering bravo into the running turn.
+	_ = sess.popQueueHead()
+	err := sess.PromoteQueuedAsSteer(context.Background(), 0, ids[0])
+	if err == nil || !strings.Contains(err.Error(), "no longer matches") {
+		t.Fatalf("PromoteQueuedAsSteer shifted err=%v, want mismatch", err)
+	}
+	if preview := sess.QueuePreview(); len(preview) != 1 || preview[0] != "bravo" {
+		t.Fatalf("QueuePreview after mismatch: got %#v, want [bravo]", preview)
+	}
+	sess.mu.Lock()
+	steeringDepth := len(sess.steeringQueue)
+	sess.mu.Unlock()
+	if steeringDepth != 0 {
+		t.Fatalf("steeringQueue after mismatch: got %d, want 0", steeringDepth)
+	}
+
+	// The correct id still promotes.
+	if err := sess.PromoteQueuedAsSteer(context.Background(), 0, ids[1]); err != nil {
+		t.Fatalf("PromoteQueuedAsSteer with correct id: %v", err)
+	}
+	if depth := sess.QueueDepth(); depth != 0 {
+		t.Fatalf("QueueDepth after promote: got %d, want 0", depth)
+	}
+}
+
+func TestSession_PromoteQueuedAsSteer_QueueChangedCarriesIDs(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	if err := sess.Enqueue(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	markProcessing(sess)
+	ids := sess.QueueIDs()
+	if err := sess.PromoteQueuedAsSteer(context.Background(), 0, ids[0]); err != nil {
+		t.Fatalf("PromoteQueuedAsSteer: %v", err)
+	}
+	sess.Close()
+	var last *events.QueueChangedData
+	for ev := range sess.Events() {
+		if d, ok := ev.Data.(events.QueueChangedData); ok {
+			d := d
+			last = &d
+		}
+	}
+	if last == nil {
+		t.Fatal("expected at least one QueueChanged event")
+	}
+	if len(last.IDs) != len(last.Preview) {
+		t.Fatalf("QueueChanged IDs=%#v misaligned with Preview=%#v", last.IDs, last.Preview)
+	}
+	// The enqueue-time event carried the minted id.
+	if len(last.IDs) != 0 {
+		t.Fatalf("final QueueChanged IDs=%#v, want empty after promote", last.IDs)
+	}
+}
+
 func TestSession_PromoteQueuedAsSteer_ClosedSession(t *testing.T) {
 	t.Parallel()
 	sess := newPromoteTestSession(t)
@@ -166,7 +244,7 @@ func TestSession_PromoteQueuedAsSteer_ClosedSession(t *testing.T) {
 		t.Fatalf("Enqueue: %v", err)
 	}
 	sess.Close()
-	err := sess.PromoteQueuedAsSteer(context.Background(), 0)
+	err := sess.PromoteQueuedAsSteer(context.Background(), 0, "")
 	if err == nil || !strings.Contains(err.Error(), "closed") {
 		t.Fatalf("PromoteQueuedAsSteer closed err=%v, want closed", err)
 	}

--- a/agent/subagents_fuzz_test.go
+++ b/agent/subagents_fuzz_test.go
@@ -516,7 +516,7 @@ func FuzzSafz_DriveNotificationTurn(f *testing.F) {
 		// prove the decline, then return every slot.
 		var held []*treeReservation
 		for {
-			r, ok := parent.reserveTreeSlot()
+			r, ok := parent.reserveTreeSlot(slotKindJob)
 			if !ok {
 				break
 			}

--- a/appwire/client.go
+++ b/appwire/client.go
@@ -364,6 +364,15 @@ func (c *Client) TurnDrainAsSteer(ctx context.Context, params TurnDrainAsSteerPa
 	return err
 }
 
+// TurnPromoteQueuedAsSteer calls turn/promoteQueuedAsSteer (issue #22) to
+// remove the queued message at params.Index and inject it as a user-sourced
+// STEERING message into the in-flight turn, leaving the rest of the queue
+// in place. The daemon returns Conflict when no turn is active or the index
+// no longer resolves against the live queue.
+func (c *Client) TurnPromoteQueuedAsSteer(ctx context.Context, params TurnPromoteQueuedAsSteerParams) error {
+	return c.request(ctx, MethodTurnPromoteQueuedAsSteer, params, nil)
+}
+
 func pendingTargetRef(ref, threadID string) string {
 	if strings.TrimSpace(ref) != "" {
 		return ref

--- a/appwire/cov_rhub_appwire_test.go
+++ b/appwire/cov_rhub_appwire_test.go
@@ -251,6 +251,9 @@ func TestClientRequestWrappersRoundTrip(t *testing.T) {
 		{"TurnSteer", MethodTurnSteer, EmptyResponse{}, func(ctx context.Context, c *Client) error { return c.TurnSteer(ctx, TurnSteerParams{}) }},
 		{"TurnQueue", MethodTurnQueue, EmptyResponse{}, func(ctx context.Context, c *Client) error { return c.TurnQueue(ctx, TurnQueueParams{}) }},
 		{"TurnDrain", MethodTurnDrainAsSteer, EmptyResponse{}, func(ctx context.Context, c *Client) error { return c.TurnDrainAsSteer(ctx, TurnDrainAsSteerParams{}) }},
+		{"TurnPromoteQueuedAsSteer", MethodTurnPromoteQueuedAsSteer, EmptyResponse{}, func(ctx context.Context, c *Client) error {
+			return c.TurnPromoteQueuedAsSteer(ctx, TurnPromoteQueuedAsSteerParams{Index: 0})
+		}},
 		{"CommandList", MethodSerfCommandList, map[string]any{}, func(ctx context.Context, c *Client) error { _, err := c.CommandList(ctx); return err }},
 		{"MarketplaceList", MethodSerfMarketplaceList, map[string]any{}, func(ctx context.Context, c *Client) error { _, err := c.MarketplaceList(ctx); return err }},
 		{"MarketplaceAdd", MethodSerfMarketplaceAdd, map[string]any{}, func(ctx context.Context, c *Client) error {

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -103,6 +103,7 @@ var Methods = []MethodSpec{
 	{MethodTurnInterrupt, TurnInterruptParams{}, EmptyResponse{}, ScopeBoth, "Cancels the active turn matching expectedTurnId."},
 	{MethodTurnQueue, TurnQueueParams{}, EmptyResponse{}, ScopeBoth, "Queues a user message for after the active turn completes."},
 	{MethodTurnDrainAsSteer, TurnDrainAsSteerParams{}, EmptyResponse{}, ScopeBoth, "Drains the input queue and injects it as a single steering message."},
+	{MethodTurnPromoteQueuedAsSteer, TurnPromoteQueuedAsSteerParams{}, EmptyResponse{}, ScopeBoth, "Removes one queued message by index and injects it as user-sourced steering into the in-flight turn."},
 	{MethodGoalSet, GoalSetParams{}, GoalSetResponse{}, ScopeBoth, "Sets or clears the session's /goal objective."},
 	{MethodSerfTasksList, TaskListParams{}, TaskListResponse{}, ScopeBoth, "Lists the session's tasks."},
 	{MethodSerfThreadTranscriptsList, ThreadTranscriptListParams{}, ThreadTranscriptListResponse{}, ScopeHub, "Lists transcript targets (subagents/related threads) for a ref."},

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -289,10 +289,15 @@ type SerfUsage struct {
 // QueueState is the wire representation of a session's per-input queue
 // (kata r80p). Depth is len(Preview) at projection time; Preview entries
 // are FIFO with the head at index 0 and have been truncated to a single
-// line so the UI can render them without further processing.
+// line so the UI can render them without further processing. IDs is
+// FIFO-aligned with Preview: each entry's stable queue-entry id, minted by
+// the daemon at enqueue time. turn/promoteQueuedAsSteer echoes an id back
+// as expectedEntryId so a queue that shifted under the client's snapshot is
+// rejected instead of promoting the wrong message (review F1, issue #22).
 type QueueState struct {
 	Depth   int      `json:"depth,omitempty"`
 	Preview []string `json:"preview,omitempty"`
+	IDs     []string `json:"ids,omitempty"`
 }
 
 // ThreadQueueChangedParams is the params shape for thread/queueChanged
@@ -740,11 +745,17 @@ type TurnDrainAsSteerParams struct {
 // one entry of the session's FIFO input queue (matching the position shown
 // in the queue preview); the daemon removes just that entry and injects it
 // as a user-sourced steering message into the in-flight turn, leaving the
-// other queued messages in place. The daemon returns Conflict when no turn
-// is in flight or the queue has shifted so the index no longer resolves.
+// other queued messages in place. ExpectedEntryID, when non-empty, must
+// match the id the daemon minted for that entry (surfaced via
+// QueueState.IDs): the queue head can be consumed mid-turn, so a bare index
+// from an older snapshot may point at a different message — a mismatch is a
+// Conflict, not a wrong-message promote (review F1). The daemon returns
+// Conflict when no turn is in flight, the index is out of range, or the
+// expected id no longer matches.
 type TurnPromoteQueuedAsSteerParams struct {
-	Ref   string `json:"ref"`
-	Index int    `json:"index"`
+	Ref             string `json:"ref"`
+	Index           int    `json:"index"`
+	ExpectedEntryID string `json:"expectedEntryId,omitempty"`
 }
 
 type ThreadCompactStartParams struct {

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -25,6 +25,7 @@ const (
 	MethodTurnInterrupt             = "turn/interrupt"
 	MethodTurnQueue                 = "turn/queue"
 	MethodTurnDrainAsSteer          = "turn/drainAsSteer"
+	MethodTurnPromoteQueuedAsSteer  = "turn/promoteQueuedAsSteer"
 	MethodGoalSet                   = "goal/set"
 	MethodSerfTasksList             = "serf/tasks/list"
 	MethodSerfThreadNameSet         = "serf/thread/name/set"
@@ -732,6 +733,18 @@ type GoalSetResponse struct {
 type TurnDrainAsSteerParams struct {
 	Ref   string      `json:"ref"`
 	Input []InputItem `json:"input,omitempty"`
+}
+
+// TurnPromoteQueuedAsSteerParams is the wire shape for
+// turn/promoteQueuedAsSteer (issue #22 per-message promote). Index selects
+// one entry of the session's FIFO input queue (matching the position shown
+// in the queue preview); the daemon removes just that entry and injects it
+// as a user-sourced steering message into the in-flight turn, leaving the
+// other queued messages in place. The daemon returns Conflict when no turn
+// is in flight or the queue has shifted so the index no longer resolves.
+type TurnPromoteQueuedAsSteerParams struct {
+	Ref   string `json:"ref"`
+	Index int    `json:"index"`
 }
 
 type ThreadCompactStartParams struct {

--- a/cmd/serf-hub/app_rpc.go
+++ b/cmd/serf-hub/app_rpc.go
@@ -368,6 +368,22 @@ func registerThreadHandlers(
 		}
 		return appwire.EmptyResponse{}, source.DrainAsSteer(ctx, params)
 	})
+	appserver.HandleTyped(server.Router(), appwire.MethodTurnPromoteQueuedAsSteer, func(ctx context.Context, params appwire.TurnPromoteQueuedAsSteerParams) (appwire.EmptyResponse, error) {
+		if params.Index < 0 {
+			return appwire.EmptyResponse{}, appwire.InvalidParams("index must be >= 0")
+		}
+		source, err := sourceForThreadWithManagedLaunch(ctx, cfg, sources, params.Ref, "")
+		if err != nil {
+			return appwire.EmptyResponse{}, err
+		}
+		// promoteQueuedAsSteer rides on the Steer capability, same as
+		// drainAsSteer — the daemon checks the live queue and turn state
+		// itself and returns Conflict when the promote can't happen.
+		if err := ensureThreadActionAvailable(ctx, source, params.Ref, "", "steer"); err != nil {
+			return appwire.EmptyResponse{}, err
+		}
+		return appwire.EmptyResponse{}, source.PromoteQueuedAsSteer(ctx, params)
+	})
 	appserver.HandleTyped(server.Router(), appwire.MethodThreadClear, func(ctx context.Context, params appwire.ThreadClearParams) (appwire.ThreadClearResponse, error) {
 		source, err := sourceForThreadWithManagedLaunch(ctx, cfg, sources, params.Ref, "")
 		if err != nil {

--- a/cmd/serf-hub/app_rpc_test.go
+++ b/cmd/serf-hub/app_rpc_test.go
@@ -3606,6 +3606,10 @@ func (s *relayLifecycleSource) DrainAsSteer(context.Context, appwire.TurnDrainAs
 	return appwire.Unavailable("relay lifecycle source does not drain as steer")
 }
 
+func (s *relayLifecycleSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
+	return appwire.Unavailable("relay lifecycle source does not promote queued messages")
+}
+
 func (s *relayLifecycleSource) CompactThread(context.Context, appwire.ThreadCompactStartParams) error {
 	return appwire.Unavailable("relay lifecycle source does not compact threads")
 }
@@ -7072,6 +7076,7 @@ func TestHubRPCRegistersExpectedHandlerSet(t *testing.T) {
 		appwire.MethodTurnInterrupt,
 		appwire.MethodTurnQueue,
 		appwire.MethodTurnDrainAsSteer,
+		appwire.MethodTurnPromoteQueuedAsSteer,
 		appwire.MethodThreadClear,
 		appwire.MethodThreadCompactStart,
 		appwire.MethodThreadShutdown,

--- a/cmd/serf-hub/assets/appwire.js
+++ b/cmd/serf-hub/assets/appwire.js
@@ -539,13 +539,17 @@
 
   // promoteQueuedAsSteer promotes ONE queued follow-up (by FIFO index, as
   // shown in the queue preview) to a user-sourced steering injection on the
-  // in-flight turn (issue #22), leaving the rest of the queue in place. No
-  // optimistic placeholder: the daemon's thread/queueChanged re-renders the
-  // preview and serf/steering/injected (source:"user") echoes the message.
-  function promoteQueuedAsSteer(sessionId, index) {
+  // in-flight turn (issue #22), leaving the rest of the queue in place. The
+  // queue-entry id from the client's snapshot rides along: the daemon
+  // rejects with Conflict when the queue shifted under us (review F1), so a
+  // stale row can never steer the wrong message. No optimistic placeholder:
+  // the daemon's thread/queueChanged re-renders the preview and
+  // serf/steering/injected (source:"user") echoes the message.
+  function promoteQueuedAsSteer(sessionId, index, entryId) {
     return request(METHOD.turnPromoteQueuedAsSteer, {
       ref: refForSession(sessionId),
       index,
+      expectedEntryId: entryId || "",
     });
   }
 
@@ -801,6 +805,7 @@
     events.push(["QUEUE_CHANGED", {
       depth: typeof queue.depth === "number" ? queue.depth : (Array.isArray(queue.preview) ? queue.preview.length : 0),
       preview: Array.isArray(queue.preview) ? queue.preview.slice() : [],
+      ids: Array.isArray(queue.ids) ? queue.ids.slice() : [],
     }]);
     events.push.apply(events, eventsFromTurns(thread.turns));
     return events;
@@ -917,6 +922,7 @@
       return [["QUEUE_CHANGED", {
         depth: typeof q.depth === "number" ? q.depth : (Array.isArray(q.preview) ? q.preview.length : 0),
         preview: Array.isArray(q.preview) ? q.preview.slice() : [],
+        ids: Array.isArray(q.ids) ? q.ids.slice() : [],
       }]];
     }
     if (method === "serf/task/updated") {

--- a/cmd/serf-hub/assets/appwire.js
+++ b/cmd/serf-hub/assets/appwire.js
@@ -18,6 +18,7 @@
     turnInterrupt: "turn/interrupt",
     turnQueue: "turn/queue",
     turnDrainAsSteer: "turn/drainAsSteer",
+    turnPromoteQueuedAsSteer: "turn/promoteQueuedAsSteer",
     tasksList: "serf/tasks/list",
     sandboxEscalationResolve: "serf/sandbox/escalation/resolve",
     dirsComplete: "serf/dirs/complete",
@@ -534,6 +535,18 @@
       ref: refForSession(sessionId),
       input: inputItemsForTextAndAttachments(text || "", attachments),
     }, { text: text || "", items: attachments || [] });
+  }
+
+  // promoteQueuedAsSteer promotes ONE queued follow-up (by FIFO index, as
+  // shown in the queue preview) to a user-sourced steering injection on the
+  // in-flight turn (issue #22), leaving the rest of the queue in place. No
+  // optimistic placeholder: the daemon's thread/queueChanged re-renders the
+  // preview and serf/steering/injected (source:"user") echoes the message.
+  function promoteQueuedAsSteer(sessionId, index) {
+    return request(METHOD.turnPromoteQueuedAsSteer, {
+      ref: refForSession(sessionId),
+      index,
+    });
   }
 
   function action(sessionId, name, turnId) {
@@ -1053,6 +1066,7 @@
     steer,
     queueTurn,
     drainAsSteer,
+    promoteQueuedAsSteer,
     action,
     setModel,
     setReasoningEffort,

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -1490,7 +1490,7 @@
             this.renderComposerChips();
             // Reset to empty; the next QUEUE_CHANGED event (cold-load or
             // notification) will fill in authoritative state from the wire.
-            this.queueState = { depth: 0, preview: [] };
+            this.queueState = { depth: 0, preview: [], ids: [] };
             this.renderQueuePreview();
           }
           if (data.capabilities) {
@@ -1506,11 +1506,15 @@
           break;
         case "QUEUE_CHANGED":
           // Authoritative queue state from the daemon (kata r80p). The
-          // depth + preview are stored verbatim; renderQueuePreview reads
-          // straight from this.queueState.
+          // depth + preview + ids are stored verbatim; renderQueuePreview
+          // reads straight from this.queueState. ids is FIFO-aligned with
+          // preview: each entry's daemon-minted queue id, sent back as the
+          // expected identity on promote so a shifted queue is rejected
+          // instead of steering the wrong message (review F1).
           this.queueState = {
             depth: typeof data.depth === "number" ? data.depth : (Array.isArray(data.preview) ? data.preview.length : 0),
             preview: Array.isArray(data.preview) ? data.preview.slice() : [],
+            ids: Array.isArray(data.ids) ? data.ids.slice() : [],
           };
           this.renderQueuePreview();
           break;
@@ -6532,7 +6536,11 @@
         li.appendChild(textEl);
         // Per-message promote (issue #22): pull just this queued follow-up
         // out of the FIFO and inject it as user-sourced steering into the
-        // in-flight turn, leaving the other queued messages in place.
+        // in-flight turn, leaving the other queued messages in place. The
+        // daemon-minted entry id rides along so a queue that shifted under
+        // this preview is rejected instead of steering the wrong message
+        // (review F1).
+        const entryId = (state.ids && state.ids[idx]) || "";
         const promoteBtn = document.createElement("button");
         promoteBtn.type = "button";
         promoteBtn.className = "qp-promote";
@@ -6540,28 +6548,31 @@
         promoteBtn.title = "promote to steering — inject this message into the running turn now";
         promoteBtn.setAttribute("aria-label", "promote queued message " + (idx + 1) + " to steering");
         promoteBtn.textContent = "⇧";
-        promoteBtn.addEventListener("click", () => { this.promoteQueuedMessage(idx); });
+        promoteBtn.addEventListener("click", () => { this.promoteQueuedMessage(idx, entryId); });
         li.appendChild(promoteBtn);
         list.appendChild(li);
       });
     },
 
     // promoteQueuedMessage promotes one queued follow-up to a steering
-    // injection on the in-flight turn (issue #22). There is no local mirror:
-    // on success the daemon emits thread/queueChanged without the promoted
-    // entry and a serf/steering/injected with source:"user", so the preview
-    // and transcript both re-render from authoritative wire data. A failure
+    // injection on the in-flight turn (issue #22). entryId is the
+    // daemon-minted queue-entry id from the preview snapshot; the daemon
+    // rejects with Conflict when it no longer matches the entry at idx
+    // (review F1). There is no local mirror: on success the daemon emits
+    // thread/queueChanged without the promoted entry and a
+    // serf/steering/injected with source:"user", so the preview and
+    // transcript both re-render from authoritative wire data. A failure
     // (turn already ended, queue shifted under the preview) surfaces as an
     // error banner and leaves the queued message in place.
-    async promoteQueuedMessage(idx) {
+    async promoteQueuedMessage(idx, entryId) {
       try {
         if (window.SerfAppwire && typeof window.SerfAppwire.promoteQueuedAsSteer === "function") {
-          await window.SerfAppwire.promoteQueuedAsSteer(this.sessionId, idx);
+          await window.SerfAppwire.promoteQueuedAsSteer(this.sessionId, idx, entryId || "");
         } else {
           const resp = await fetch("/s/" + encodeURIComponent(this.sessionId) + "/promote-queued", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ index: idx }),
+            body: JSON.stringify({ index: idx, entryId: entryId || "" }),
           });
           if (!resp.ok) {
             const detail = (await resp.text()).trim() || ("HTTP " + resp.status);

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -6530,8 +6530,48 @@
         textEl.textContent = oneLine.length > 140 ? (oneLine.slice(0, 139) + "…") : oneLine;
         li.appendChild(idxEl);
         li.appendChild(textEl);
+        // Per-message promote (issue #22): pull just this queued follow-up
+        // out of the FIFO and inject it as user-sourced steering into the
+        // in-flight turn, leaving the other queued messages in place.
+        const promoteBtn = document.createElement("button");
+        promoteBtn.type = "button";
+        promoteBtn.className = "qp-promote";
+        promoteBtn.setAttribute("data-promote-index", String(idx));
+        promoteBtn.title = "promote to steering — inject this message into the running turn now";
+        promoteBtn.setAttribute("aria-label", "promote queued message " + (idx + 1) + " to steering");
+        promoteBtn.textContent = "⇧";
+        promoteBtn.addEventListener("click", () => { this.promoteQueuedMessage(idx); });
+        li.appendChild(promoteBtn);
         list.appendChild(li);
       });
+    },
+
+    // promoteQueuedMessage promotes one queued follow-up to a steering
+    // injection on the in-flight turn (issue #22). There is no local mirror:
+    // on success the daemon emits thread/queueChanged without the promoted
+    // entry and a serf/steering/injected with source:"user", so the preview
+    // and transcript both re-render from authoritative wire data. A failure
+    // (turn already ended, queue shifted under the preview) surfaces as an
+    // error banner and leaves the queued message in place.
+    async promoteQueuedMessage(idx) {
+      try {
+        if (window.SerfAppwire && typeof window.SerfAppwire.promoteQueuedAsSteer === "function") {
+          await window.SerfAppwire.promoteQueuedAsSteer(this.sessionId, idx);
+        } else {
+          const resp = await fetch("/s/" + encodeURIComponent(this.sessionId) + "/promote-queued", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ index: idx }),
+          });
+          if (!resp.ok) {
+            const detail = (await resp.text()).trim() || ("HTTP " + resp.status);
+            this.appendBanner("error", "promote failed: " + detail, { source: "hub", title: "Hub promote error" });
+            return;
+          }
+        }
+      } catch (err) {
+        this.appendBanner("error", "promote failed: " + err.message, { source: "hub", title: "Hub promote error" });
+      }
     },
 
     bindKeyboard() {

--- a/cmd/serf-hub/assets/style.css
+++ b/cmd/serf-hub/assets/style.css
@@ -2056,6 +2056,30 @@ body.app[data-sidebar-rail] .archive-btn { display: none; }
   white-space: nowrap;
   flex: 1;
 }
+/* issue #22: per-row promote-to-steering affordance. Subtle until
+   hover/focus, then inks up with the accent so it reads as an action. */
+.queue-preview-item .qp-promote {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  color: var(--ink-3);
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+}
+.queue-preview-item .qp-promote:hover,
+.queue-preview-item .qp-promote:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent);
+  outline: none;
+}
 
 .input-card { background: color-mix(in srgb, var(--surface) 88%, var(--bg)); border: 0; border-radius: var(--radius-md); padding: var(--space-2) var(--space-3); min-height: 0; transition: outline-color var(--motion-fast), background var(--motion-fast); }
 /* kata 65mm: drop-active is set by the shared composer-attachments helper

--- a/cmd/serf-hub/cov_exact_web_session_fuzz_test.go
+++ b/cmd/serf-hub/cov_exact_web_session_fuzz_test.go
@@ -55,6 +55,9 @@ func (s *exactWebSessionSource) QueueTurn(context.Context, appwire.TurnQueuePara
 func (s *exactWebSessionSource) DrainAsSteer(context.Context, appwire.TurnDrainAsSteerParams) error {
 	return s.err
 }
+func (s *exactWebSessionSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
+	return s.err
+}
 func (s *exactWebSessionSource) InterruptTurn(context.Context, appwire.TurnInterruptParams) error {
 	return s.err
 }

--- a/cmd/serf-hub/cov_session_live_pass4_fuzz_test.go
+++ b/cmd/serf-hub/cov_session_live_pass4_fuzz_test.go
@@ -31,6 +31,9 @@ func (s *pass4ActionSource) QueueTurn(context.Context, appwire.TurnQueueParams) 
 func (s *pass4ActionSource) DrainAsSteer(context.Context, appwire.TurnDrainAsSteerParams) error {
 	return s.err
 }
+func (s *pass4ActionSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
+	return s.err
+}
 func (s *pass4ActionSource) ShutdownThread(context.Context, appwire.ThreadShutdownParams) error {
 	return s.err
 }

--- a/cmd/serf-hub/cov_session_tree_pass6_fuzz_test.go
+++ b/cmd/serf-hub/cov_session_tree_pass6_fuzz_test.go
@@ -30,6 +30,9 @@ func (s *pass6SessionSource) QueueTurn(context.Context, appwire.TurnQueueParams)
 func (s *pass6SessionSource) DrainAsSteer(context.Context, appwire.TurnDrainAsSteerParams) error {
 	return s.err
 }
+func (s *pass6SessionSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
+	return s.err
+}
 func (s *pass6SessionSource) ShutdownThread(context.Context, appwire.ThreadShutdownParams) error {
 	return s.err
 }

--- a/cmd/serf-hub/internal/appsource/codex_source.go
+++ b/cmd/serf-hub/internal/appsource/codex_source.go
@@ -355,6 +355,10 @@ func (s *CodexSource) DrainAsSteer(context.Context, appwire.TurnDrainAsSteerPara
 	return appwire.Unavailable("codex source does not support turn/drainAsSteer")
 }
 
+func (s *CodexSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
+	return appwire.Unavailable("codex source does not support turn/promoteQueuedAsSteer")
+}
+
 func (s *CodexSource) ResolveSandboxEscalation(context.Context, appwire.SandboxEscalationResolveParams) error {
 	return appwire.Unavailable("codex source does not support serf/sandbox/escalation/resolve")
 }

--- a/cmd/serf-hub/internal/appsource/local_daemon.go
+++ b/cmd/serf-hub/internal/appsource/local_daemon.go
@@ -208,6 +208,16 @@ func (s *LocalDaemonSource) DrainAsSteer(ctx context.Context, params appwire.Tur
 	})
 }
 
+func (s *LocalDaemonSource) PromoteQueuedAsSteer(ctx context.Context, params appwire.TurnPromoteQueuedAsSteerParams) error {
+	entry, err := s.entryForRef(params.Ref, "")
+	if err != nil {
+		return err
+	}
+	return s.withClient(ctx, entry, func(client *appwire.Client) error {
+		return client.TurnPromoteQueuedAsSteer(ctx, params)
+	})
+}
+
 func (s *LocalDaemonSource) CompactThread(ctx context.Context, params appwire.ThreadCompactStartParams) error {
 	entry, err := s.entryForRef(params.Ref, "")
 	if err != nil {

--- a/cmd/serf-hub/internal/appsource/registry_test.go
+++ b/cmd/serf-hub/internal/appsource/registry_test.go
@@ -42,6 +42,9 @@ func (f fakeSource) QueueTurn(context.Context, appwire.TurnQueueParams) error { 
 func (f fakeSource) DrainAsSteer(context.Context, appwire.TurnDrainAsSteerParams) error {
 	return nil
 }
+func (f fakeSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
+	return nil
+}
 func (f fakeSource) CompactThread(context.Context, appwire.ThreadCompactStartParams) error {
 	return nil
 }

--- a/cmd/serf-hub/internal/appsource/source.go
+++ b/cmd/serf-hub/internal/appsource/source.go
@@ -20,6 +20,7 @@ type Source interface {
 	InterruptTurn(context.Context, appwire.TurnInterruptParams) error
 	QueueTurn(context.Context, appwire.TurnQueueParams) error
 	DrainAsSteer(context.Context, appwire.TurnDrainAsSteerParams) error
+	PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error
 	CompactThread(context.Context, appwire.ThreadCompactStartParams) error
 	ShutdownThread(context.Context, appwire.ThreadShutdownParams) error
 	SetThreadModel(context.Context, appwire.ThreadModelSetParams) error

--- a/cmd/serf-hub/jstest/test-queue-promote.js
+++ b/cmd/serf-hub/jstest/test-queue-promote.js
@@ -79,14 +79,14 @@ window.SerfRenderer.init(conv);
 const list = window.document.querySelector("[data-queue-list]");
 const wait = (ms) => new Promise(r => setTimeout(r, ms));
 
-function primeQueue(preview) {
+function primeQueue(preview, ids) {
   window.SerfRenderer.handle("QUEUE_CHANGED", {
-    data: JSON.stringify({ depth: preview.length, preview }),
+    data: JSON.stringify({ depth: preview.length, preview, ids: ids || [] }),
   });
 }
 
 async function testRowsHavePromoteButtons() {
-  primeQueue(["investigate the failing test", "and then verify the regression"]);
+  primeQueue(["investigate the failing test", "and then verify the regression"], ["q_1_aaa", "q_2_bbb"]);
   pass(list.children.length === 2, "expected 2 rows, got " + list.children.length);
   for (let i = 0; i < 2; i++) {
     const btn = list.children[i].querySelector("[data-promote-index]");
@@ -96,7 +96,7 @@ async function testRowsHavePromoteButtons() {
   }
 }
 
-async function testPromotePostsIndex() {
+async function testPromotePostsIndexAndEntryId() {
   fetchLog.length = 0;
   fetchResponseOk = true;
   const btn = list.children[1].querySelector("[data-promote-index]");
@@ -108,10 +108,12 @@ async function testPromotePostsIndex() {
     "expected one /promote-queued call, got " + JSON.stringify(calls));
   const body = JSON.parse((fetchLog[0] && fetchLog[0].opts && fetchLog[0].opts.body) || "{}");
   pass(body.index === 1, "expected body.index=1, got " + JSON.stringify(body));
+  pass(body.entryId === "q_2_bbb",
+    "expected body.entryId=q_2_bbb (review F1 identity), got " + JSON.stringify(body));
 
   // No local mirror: the row stays until the daemon's authoritative
   // thread/queueChanged lands with the promoted entry removed.
-  primeQueue(["investigate the failing test"]);
+  primeQueue(["investigate the failing test"], ["q_1_aaa"]);
   pass(list.children.length === 1, "expected 1 row after daemon queueChanged, got " + list.children.length);
   pass(list.children[0].textContent.includes("investigate the failing test"),
     "expected remaining row to be the first message, got " + list.children[0].textContent);
@@ -119,8 +121,23 @@ async function testPromotePostsIndex() {
     "re-rendered row should re-key its promote index to 0");
 }
 
+async function testPromoteUsesFreshIdAfterReRender() {
+  // The row re-rendered with id q_1_aaa at index 0 — a promote must send
+  // THAT id, not a stale one from an earlier snapshot.
+  fetchLog.length = 0;
+  fetchResponseOk = true;
+  const btn = list.children[0].querySelector("[data-promote-index]");
+  btn.click();
+  await wait(20);
+  const body = JSON.parse((fetchLog[0] && fetchLog[0].opts && fetchLog[0].opts.body) || "{}");
+  pass(body.index === 0 && body.entryId === "q_1_aaa",
+    "expected promote of re-rendered row to carry its current id, got " + JSON.stringify(body));
+}
+
 async function testPromoteFailureSurfacesBanner() {
-  primeQueue(["still queued"]);
+  // The 409 here is the review-F1 shape: the daemon rejected the promote
+  // because the queue shifted under the preview's snapshot.
+  primeQueue(["still queued"], ["q_3_ccc"]);
   fetchLog.length = 0;
   fetchResponseOk = false;
   const bannersBefore = window.document.querySelectorAll(".banner").length;
@@ -143,7 +160,8 @@ async function testPromoteFailureSurfacesBanner() {
 
 (async () => {
   await testRowsHavePromoteButtons();
-  await testPromotePostsIndex();
+  await testPromotePostsIndexAndEntryId();
+  await testPromoteUsesFreshIdAfterReRender();
   await testPromoteFailureSurfacesBanner();
 
   if (failures.length === 0) {

--- a/cmd/serf-hub/jstest/test-queue-promote.js
+++ b/cmd/serf-hub/jstest/test-queue-promote.js
@@ -1,0 +1,156 @@
+// test-queue-promote: verifies each queue-preview row offers a per-message
+// promote-to-steering action (issue #22). Clicking it POSTs the row index to
+// /s/<id>/promote-queued (REST fallback; the appwire path is covered by
+// Go relay tests), the daemon's thread/queueChanged re-renders the preview
+// without the promoted row, and a failed promote surfaces an error banner
+// without touching local queue state.
+
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation"
+       data-session-id="01TEST"
+       data-active-turn-id="turn_live"
+       data-state="active"></div>
+  <form class="workspace-input" data-input-form data-session-id="01TEST">
+    <div class="composer-attachments" data-composer-attachments data-attachments></div>
+    <div class="queue-preview" data-queue-preview hidden>
+      <div class="queue-preview-header">
+        <span class="queue-preview-label">queued <span data-queue-depth>0</span></span>
+      </div>
+      <ul class="queue-preview-list" data-queue-list></ul>
+    </div>
+    <div class="input-card" data-drop-zone>
+      <textarea class="message-input" rows="1"></textarea>
+    </div>
+    <div class="input-controls">
+      <div class="controls-right">
+        <button type="button" class="btn btn-ghost" data-steer-trigger>steer</button>
+        <button type="submit" class="send-btn btn btn-primary"
+                data-capability-send="false"
+                data-capability-queue="true">send</button>
+      </div>
+    </div>
+    <div class="input-status" id="input-status"></div>
+    <input type="file" data-file-picker hidden>
+  </form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+
+const { window } = dom;
+window.marked = { parse: (t) => t };
+
+let fetchResponseOk = true;
+const fetchLog = [];
+window.fetch = (url, opts) => {
+  if (typeof url === "string" && url.includes("/tasks")) {
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve([]),
+      text: () => Promise.resolve(""),
+    });
+  }
+  fetchLog.push({ url, opts });
+  return Promise.resolve({
+    ok: fetchResponseOk,
+    status: fetchResponseOk ? 204 : 409,
+    json: () => Promise.resolve({}),
+    text: () => Promise.resolve(fetchResponseOk ? "" : "no active turn to steer"),
+  });
+};
+
+Object.defineProperty(window.HTMLTextAreaElement.prototype, "scrollHeight", {
+  configurable: true,
+  get() { return 36; },
+});
+Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
+
+require("./load-renderer").evalRenderer(window);
+
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+const conv = window.document.getElementById("conversation");
+window.SerfRenderer.init(conv);
+
+const list = window.document.querySelector("[data-queue-list]");
+const wait = (ms) => new Promise(r => setTimeout(r, ms));
+
+function primeQueue(preview) {
+  window.SerfRenderer.handle("QUEUE_CHANGED", {
+    data: JSON.stringify({ depth: preview.length, preview }),
+  });
+}
+
+async function testRowsHavePromoteButtons() {
+  primeQueue(["investigate the failing test", "and then verify the regression"]);
+  pass(list.children.length === 2, "expected 2 rows, got " + list.children.length);
+  for (let i = 0; i < 2; i++) {
+    const btn = list.children[i].querySelector("[data-promote-index]");
+    pass(btn !== null, "row " + i + " should have a promote button");
+    pass(btn && btn.getAttribute("data-promote-index") === String(i),
+      "row " + i + " promote button should carry index " + i + ", got " + (btn && btn.getAttribute("data-promote-index")));
+  }
+}
+
+async function testPromotePostsIndex() {
+  fetchLog.length = 0;
+  fetchResponseOk = true;
+  const btn = list.children[1].querySelector("[data-promote-index]");
+  btn.click();
+  await wait(20);
+
+  const calls = fetchLog.map(c => c.url);
+  pass(calls.length === 1 && calls[0].includes("/s/01TEST/promote-queued"),
+    "expected one /promote-queued call, got " + JSON.stringify(calls));
+  const body = JSON.parse((fetchLog[0] && fetchLog[0].opts && fetchLog[0].opts.body) || "{}");
+  pass(body.index === 1, "expected body.index=1, got " + JSON.stringify(body));
+
+  // No local mirror: the row stays until the daemon's authoritative
+  // thread/queueChanged lands with the promoted entry removed.
+  primeQueue(["investigate the failing test"]);
+  pass(list.children.length === 1, "expected 1 row after daemon queueChanged, got " + list.children.length);
+  pass(list.children[0].textContent.includes("investigate the failing test"),
+    "expected remaining row to be the first message, got " + list.children[0].textContent);
+  pass(list.children[0].querySelector("[data-promote-index]").getAttribute("data-promote-index") === "0",
+    "re-rendered row should re-key its promote index to 0");
+}
+
+async function testPromoteFailureSurfacesBanner() {
+  primeQueue(["still queued"]);
+  fetchLog.length = 0;
+  fetchResponseOk = false;
+  const bannersBefore = window.document.querySelectorAll(".banner").length;
+  const btn = list.children[0].querySelector("[data-promote-index]");
+  btn.click();
+  await wait(20);
+
+  pass(fetchLog.length === 1, "expected one promote attempt, got " + fetchLog.length);
+  pass(window.SerfRenderer.queueState.depth === 1,
+    "queue state must be unchanged on promote failure, got depth " + window.SerfRenderer.queueState.depth);
+  pass(list.children.length === 1, "row must stay queued on promote failure");
+  const bannersAfter = window.document.querySelectorAll(".banner");
+  pass(bannersAfter.length > bannersBefore,
+    "expected a new error banner after promote failure; before=" + bannersBefore + " after=" + bannersAfter.length);
+  const newBanners = Array.from(bannersAfter).slice(bannersBefore);
+  pass(newBanners.some(b => /promote failed/i.test(b.textContent)),
+    "expected new banner mentioning 'promote failed'; new banners: " + newBanners.map(b => b.textContent).join(", "));
+  fetchResponseOk = true;
+}
+
+(async () => {
+  await testRowsHavePromoteButtons();
+  await testPromotePostsIndex();
+  await testPromoteFailureSurfacesBanner();
+
+  if (failures.length === 0) {
+    console.log("PASS: queue-preview per-message promote to steering");
+    process.exit(0);
+  } else {
+    for (const f of failures) console.log(f);
+    process.exit(1);
+  }
+})();

--- a/cmd/serf-hub/web_mutating_fuzz_test.go
+++ b/cmd/serf-hub/web_mutating_fuzz_test.go
@@ -43,6 +43,7 @@ var mutatingRoutes = []mutRoute{
 	{http.MethodPost, "/s/{id}/steer", true},
 	{http.MethodPost, "/s/{id}/queue", true},
 	{http.MethodPost, "/s/{id}/drain-as-steer", true},
+	{http.MethodPost, "/s/{id}/promote-queued", true},
 }
 
 // buildMutatingTarget substitutes the fuzzed id into a route template, escaping
@@ -123,6 +124,7 @@ func FuzzWebMutatingHandler(f *testing.F) {
 		{"/s/{id}/steer", sandboxSessionID, `{"text":"go"}`},
 		{"/s/{id}/queue", sandboxSessionID, `{"text":"later"}`},
 		{"/s/{id}/drain-as-steer", sandboxSessionID, `{}`},
+		{"/s/{id}/promote-queued", sandboxSessionID, `{"index":0}`},
 	}
 	for _, seed := range seeds {
 		f.Add(idx(seed.template), seed.id, []byte(seed.body))

--- a/cmd/serf-hub/web_promote_test.go
+++ b/cmd/serf-hub/web_promote_test.go
@@ -24,14 +24,16 @@ import (
 // promote params it was asked to relay.
 type promoteRecordingSource struct {
 	*scriptedAppSource
-	gotIndex int
-	calls    int
-	err      error
+	gotIndex      int
+	gotExpectedID string
+	calls         int
+	err           error
 }
 
 func (s *promoteRecordingSource) PromoteQueuedAsSteer(_ context.Context, params appwire.TurnPromoteQueuedAsSteerParams) error {
 	s.calls++
 	s.gotIndex = params.Index
+	s.gotExpectedID = params.ExpectedEntryID
 	return s.err
 }
 
@@ -71,12 +73,15 @@ func postPromote(web *WebServer, route, body string) *httptest.ResponseRecorder 
 
 func TestWebPromoteQueuedRelaysIndex(t *testing.T) {
 	web, source := newPromoteHarness()
-	rec := postPromote(web, "/s/remote%3Athread-1/promote-queued", `{"index":1}`)
+	rec := postPromote(web, "/s/remote%3Athread-1/promote-queued", `{"index":1,"entryId":"q_7_abc"}`)
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
 	if source.calls != 1 || source.gotIndex != 1 {
 		t.Fatalf("promote relay calls=%d index=%d, want 1/1", source.calls, source.gotIndex)
+	}
+	if source.gotExpectedID != "q_7_abc" {
+		t.Fatalf("promote relay expectedEntryId=%q, want q_7_abc", source.gotExpectedID)
 	}
 }
 
@@ -149,11 +154,14 @@ func TestHubRPCPromoteQueuedAsSteerRelays(t *testing.T) {
 		return derr
 	}
 
-	if err := dispatch(appwire.TurnPromoteQueuedAsSteerParams{Ref: "remote:thread-1", Index: 2}); err != nil {
+	if err := dispatch(appwire.TurnPromoteQueuedAsSteerParams{Ref: "remote:thread-1", Index: 2, ExpectedEntryID: "q_9_def"}); err != nil {
 		t.Fatalf("dispatch promote: %v", err)
 	}
 	if source.calls != 1 || source.gotIndex != 2 {
 		t.Fatalf("promote relay calls=%d index=%d, want 1/2", source.calls, source.gotIndex)
+	}
+	if source.gotExpectedID != "q_9_def" {
+		t.Fatalf("promote relay expectedEntryId=%q, want q_9_def", source.gotExpectedID)
 	}
 
 	err := dispatch(appwire.TurnPromoteQueuedAsSteerParams{Ref: "remote:thread-1", Index: -1})

--- a/cmd/serf-hub/web_promote_test.go
+++ b/cmd/serf-hub/web_promote_test.go
@@ -1,0 +1,170 @@
+package main
+
+// Tests for POST /s/<id>/promote-queued (issue #22): the hub REST fallback
+// for the queue-preview row's promote action. The hub relays the index to
+// the daemon's turn/promoteQueuedAsSteer; failures surface honestly (400 on
+// a malformed body, 404 when the session isn't live, the daemon's Conflict
+// when the turn already ended or the index no longer resolves).
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"primeradiant.com/serf/appwire"
+	"primeradiant.com/serf/cmd/serf-hub/internal/appsource"
+	"primeradiant.com/serf/cmd/serf-hub/internal/hubcore"
+)
+
+// promoteRecordingSource is a scripted remote source that records the
+// promote params it was asked to relay.
+type promoteRecordingSource struct {
+	*scriptedAppSource
+	gotIndex int
+	calls    int
+	err      error
+}
+
+func (s *promoteRecordingSource) PromoteQueuedAsSteer(_ context.Context, params appwire.TurnPromoteQueuedAsSteerParams) error {
+	s.calls++
+	s.gotIndex = params.Index
+	return s.err
+}
+
+func newPromoteWeb(source *promoteRecordingSource) *WebServer {
+	web := NewWebServer(hubcore.WebConfig{})
+	registry := appsource.NewRegistry()
+	registry.Add(source)
+	web.sources = registry
+	return web
+}
+
+func newPromoteThread() appwire.Thread {
+	return appwire.Thread{
+		ID: "thread-1", SessionID: "thread-1", Source: "remote", Name: "promote test",
+		CWD: "/work/project", ModelProvider: "provider/model",
+		Status: appwire.ThreadStatus{Type: "active"},
+		Turns:  []appwire.Turn{{ID: "turn-1", Status: appwire.TurnStatusCompleted}},
+		Serf: appwire.SerfThread{Ref: "remote:thread-1", ActiveTurnID: "turn-2",
+			Capabilities: appwire.ThreadCapabilities{Steer: true, Queue: true}},
+	}
+}
+
+func newPromoteHarness() (*WebServer, *promoteRecordingSource) {
+	source := &promoteRecordingSource{
+		scriptedAppSource: &scriptedAppSource{id: "remote", thread: newPromoteThread()},
+		gotIndex:          -1,
+	}
+	return newPromoteWeb(source), source
+}
+
+func postPromote(web *WebServer, route, body string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, route, strings.NewReader(body))
+	web.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+func TestWebPromoteQueuedRelaysIndex(t *testing.T) {
+	web, source := newPromoteHarness()
+	rec := postPromote(web, "/s/remote%3Athread-1/promote-queued", `{"index":1}`)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if source.calls != 1 || source.gotIndex != 1 {
+		t.Fatalf("promote relay calls=%d index=%d, want 1/1", source.calls, source.gotIndex)
+	}
+}
+
+func TestWebPromoteQueuedRejectsNegativeIndex(t *testing.T) {
+	web, source := newPromoteHarness()
+	rec := postPromote(web, "/s/remote%3Athread-1/promote-queued", `{"index":-1}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+	if source.calls != 0 {
+		t.Fatalf("source called %d times, want 0", source.calls)
+	}
+}
+
+func TestWebPromoteQueuedRejectsInvalidJSON(t *testing.T) {
+	web, source := newPromoteHarness()
+	rec := postPromote(web, "/s/remote%3Athread-1/promote-queued", `{"index":`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+	if source.calls != 0 {
+		t.Fatalf("source called %d times, want 0", source.calls)
+	}
+}
+
+func TestWebPromoteQueuedNotLive(t *testing.T) {
+	// A local route id with no roster entry is not live; the hub must 404
+	// before reaching any source.
+	web, source := newPromoteHarness()
+	rec := postPromote(web, "/s/01MISSING/promote-queued", `{"index":0}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+	if source.calls != 0 {
+		t.Fatalf("source called %d times, want 0", source.calls)
+	}
+}
+
+func TestWebPromoteQueuedSurfacesDaemonConflict(t *testing.T) {
+	web, source := newPromoteHarness()
+	source.err = appwire.Conflict("no active turn to steer")
+	rec := postPromote(web, "/s/remote%3Athread-1/promote-queued", `{"index":0}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status=%d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	if source.calls != 1 {
+		t.Fatalf("source called %d times, want 1", source.calls)
+	}
+}
+
+// TestHubRPCPromoteQueuedAsSteerRelays drives the appwire RPC path: the hub
+// app server must route turn/promoteQueuedAsSteer to the source owning the
+// ref, forwarding the index, and reject a negative index client-side.
+func TestHubRPCPromoteQueuedAsSteerRelays(t *testing.T) {
+	_, source := newPromoteHarness()
+	registry := appsource.NewRegistry()
+	registry.Add(source)
+	server := newHubAppServer(hubcore.WebConfig{Past: hubcore.NewPastIndex("")}, registry)
+
+	dispatch := func(params appwire.TurnPromoteQueuedAsSteerParams) error {
+		raw, err := json.Marshal(params)
+		if err != nil {
+			t.Fatalf("MarshalParams: %v", err)
+		}
+		_, derr := server.Router().Dispatch(context.Background(), appwire.Request{
+			ID:     appwire.NewIntID(1),
+			Method: appwire.MethodTurnPromoteQueuedAsSteer,
+			Params: raw,
+		})
+		return derr
+	}
+
+	if err := dispatch(appwire.TurnPromoteQueuedAsSteerParams{Ref: "remote:thread-1", Index: 2}); err != nil {
+		t.Fatalf("dispatch promote: %v", err)
+	}
+	if source.calls != 1 || source.gotIndex != 2 {
+		t.Fatalf("promote relay calls=%d index=%d, want 1/2", source.calls, source.gotIndex)
+	}
+
+	err := dispatch(appwire.TurnPromoteQueuedAsSteerParams{Ref: "remote:thread-1", Index: -1})
+	if err == nil {
+		t.Fatal("expected error for negative index")
+	}
+	var wireErr appwire.WireError
+	if !errors.As(err, &wireErr) || wireErr.Code != appwire.CodeInvalidParams {
+		t.Fatalf("err=%v, want InvalidParams wire error", err)
+	}
+	if source.calls != 1 {
+		t.Fatalf("source called %d times after negative index, want 1", source.calls)
+	}
+}

--- a/cmd/serf-hub/web_session.go
+++ b/cmd/serf-hub/web_session.go
@@ -336,8 +336,9 @@ func (s *WebServer) handlePromoteQueued(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	if err := source.PromoteQueuedAsSteer(r.Context(), appwire.TurnPromoteQueuedAsSteerParams{
-		Ref:   ref,
-		Index: body.Index,
+		Ref:             ref,
+		Index:           body.Index,
+		ExpectedEntryID: body.EntryID,
 	}); err != nil {
 		writeSessionActionError(w, r, err)
 		return

--- a/cmd/serf-hub/web_session.go
+++ b/cmd/serf-hub/web_session.go
@@ -304,6 +304,47 @@ func (s *WebServer) handleDrainAsSteer(w http.ResponseWriter, r *http.Request, i
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// handlePromoteQueued forwards a turn/promoteQueuedAsSteer request (issue
+// #22 per-message promote). The daemon removes the queued follow-up at
+// body.Index and injects it as user-sourced steering into the in-flight
+// turn; other queued messages stay queued. Rides on the Steer capability,
+// like drain-as-steer; the daemon returns Conflict when idle or when the
+// index no longer resolves against the live queue.
+func (s *WebServer) handlePromoteQueued(w http.ResponseWriter, r *http.Request, id string) {
+	r.Body = http.MaxBytesReader(w, r.Body, hubcore.SendMaxRequestBytes)
+	var body promoteQueuedRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if body.Index < 0 {
+		http.Error(w, "index must be >= 0", http.StatusBadRequest)
+		return
+	}
+	if !s.isLive(id) {
+		http.NotFound(w, r)
+		return
+	}
+	if err := s.ensureSessionActionAvailable(id, "steer"); err != nil {
+		writeSessionActionError(w, r, err)
+		return
+	}
+	ref := appRefFromRouteID(id)
+	source, err := sourceForThread(s.sources, ref, "")
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if err := source.PromoteQueuedAsSteer(r.Context(), appwire.TurnPromoteQueuedAsSteerParams{
+		Ref:   ref,
+		Index: body.Index,
+	}); err != nil {
+		writeSessionActionError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // handleSessionAction forwards imperative actions to a daemon. Interrupt,
 // clear, and shutdown remain live-only; compact can resume a known past
 // session because it is a session-level maintenance action rather than an

--- a/cmd/serf-hub/web_test.go
+++ b/cmd/serf-hub/web_test.go
@@ -1851,6 +1851,10 @@ func (s *scriptedAppSource) DrainAsSteer(context.Context, appwire.TurnDrainAsSte
 	return appwire.Unavailable("scripted source does not drain as steer")
 }
 
+func (s *scriptedAppSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
+	return appwire.Unavailable("scripted source does not promote queued messages")
+}
+
 func (s *scriptedAppSource) CompactThread(context.Context, appwire.ThreadCompactStartParams) error {
 	return appwire.Unavailable("scripted source does not compact threads")
 }

--- a/cmd/serf-hub/web_types.go
+++ b/cmd/serf-hub/web_types.go
@@ -263,10 +263,14 @@ type drainAsSteerRequest struct {
 // promoteQueuedRequest is the JSON body for POST /s/<id>/promote-queued
 // (issue #22). Index selects one entry of the daemon's FIFO input queue —
 // matching the row position in the web queue preview — to promote into the
-// in-flight turn as user-sourced steering. The daemon rejects the call
-// (Conflict) when no turn is in flight or the index no longer resolves.
+// in-flight turn as user-sourced steering. EntryID carries the queue-entry
+// id from the client's queue snapshot; the daemon rejects the call
+// (Conflict) when no turn is in flight, the index no longer resolves, or
+// the queue shifted so the id no longer matches the entry at index
+// (review F1).
 type promoteQueuedRequest struct {
-	Index int `json:"index"`
+	Index   int    `json:"index"`
+	EntryID string `json:"entryId,omitempty"`
 }
 
 type forkRequest struct {

--- a/cmd/serf-hub/web_types.go
+++ b/cmd/serf-hub/web_types.go
@@ -260,6 +260,15 @@ type drainAsSteerRequest struct {
 	Items []appwire.InputItem `json:"items,omitempty"`
 }
 
+// promoteQueuedRequest is the JSON body for POST /s/<id>/promote-queued
+// (issue #22). Index selects one entry of the daemon's FIFO input queue —
+// matching the row position in the web queue preview — to promote into the
+// in-flight turn as user-sourced steering. The daemon rejects the call
+// (Conflict) when no turn is in flight or the index no longer resolves.
+type promoteQueuedRequest struct {
+	Index int `json:"index"`
+}
+
 type forkRequest struct {
 	Turn          int    `json:"turn"`
 	EditedMessage string `json:"edited_message"`

--- a/cmd/serf-hub/web_workspace.go
+++ b/cmd/serf-hub/web_workspace.go
@@ -89,6 +89,12 @@ func (s *WebServer) handleSession(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.handleDrainAsSteer(w, r, id)
+	case "promote-queued":
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST required", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handlePromoteQueued(w, r, id)
 	default:
 		// /s/<id>/images/<sha> — sha-addressed image fetch for replay.
 		if strings.HasPrefix(sub, "images/") {

--- a/cmd/serf/serve.go
+++ b/cmd/serf/serve.go
@@ -68,6 +68,7 @@ type serveServer interface {
 	SetGoalStatusFunc(func() (string, int, bool))
 	SetDrainAsSteerFunc(func() error)
 	SetDrainAsSteerWithInputFunc(func(string, []server.ImageAttachment) error)
+	SetPromoteQueuedAsSteerFunc(func(int) error)
 	SetQueueDepthFunc(func() int)
 	SetQueuePreviewFunc(func() []string)
 	SetContextPressureFunc(func() float64)
@@ -536,6 +537,9 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 	srv.SetDrainAsSteerFunc(func() error { return getSession().DrainAsSteer(ctx) })
 	srv.SetDrainAsSteerWithInputFunc(func(text string, images []server.ImageAttachment) error {
 		return getSession().DrainAsSteerWithInput(ctx, text, images)
+	})
+	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
+		return getSession().PromoteQueuedAsSteer(ctx, index)
 	})
 	srv.SetQueueDepthFunc(func() int { return getSession().QueueDepth() })
 	srv.SetQueuePreviewFunc(func() []string { return getSession().QueuePreview() })

--- a/cmd/serf/serve.go
+++ b/cmd/serf/serve.go
@@ -68,7 +68,8 @@ type serveServer interface {
 	SetGoalStatusFunc(func() (string, int, bool))
 	SetDrainAsSteerFunc(func() error)
 	SetDrainAsSteerWithInputFunc(func(string, []server.ImageAttachment) error)
-	SetPromoteQueuedAsSteerFunc(func(int) error)
+	SetPromoteQueuedAsSteerFunc(func(int, string) error)
+	SetQueueIDsFunc(func() []string)
 	SetQueueDepthFunc(func() int)
 	SetQueuePreviewFunc(func() []string)
 	SetContextPressureFunc(func() float64)
@@ -538,11 +539,12 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 	srv.SetDrainAsSteerWithInputFunc(func(text string, images []server.ImageAttachment) error {
 		return getSession().DrainAsSteerWithInput(ctx, text, images)
 	})
-	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
-		return getSession().PromoteQueuedAsSteer(ctx, index)
+	srv.SetPromoteQueuedAsSteerFunc(func(index int, expectedID string) error {
+		return getSession().PromoteQueuedAsSteer(ctx, index, expectedID)
 	})
 	srv.SetQueueDepthFunc(func() int { return getSession().QueueDepth() })
 	srv.SetQueuePreviewFunc(func() []string { return getSession().QueuePreview() })
+	srv.SetQueueIDsFunc(func() []string { return getSession().QueueIDs() })
 	srv.SetContextPressureFunc(func() float64 { return getSession().ContextPressure() })
 	srv.SetContextMetricsFunc(func() server.ContextMetrics {
 		metrics := getSession().ContextMetrics()

--- a/cmd/serf/serve_residual_fuzz_test.go
+++ b/cmd/serf/serve_residual_fuzz_test.go
@@ -40,8 +40,9 @@ type residualServeServer struct {
 	goalStatus         func() (string, int, bool)
 	drain              func() error
 	drainInput         func(string, []server.ImageAttachment) error
-	promote            func(int) error
+	promote            func(int, string) error
 	queueDepth         func() int
+	queueIDs           func() []string
 	queuePreview       func() []string
 	pressure           func() float64
 	contextMetrics     func() server.ContextMetrics
@@ -83,9 +84,12 @@ func (s *residualServeServer) SetDrainAsSteerFunc(f func() error)             { 
 func (s *residualServeServer) SetDrainAsSteerWithInputFunc(f func(string, []server.ImageAttachment) error) {
 	s.drainInput = f
 }
-func (s *residualServeServer) SetPromoteQueuedAsSteerFunc(f func(int) error) { s.promote = f }
+func (s *residualServeServer) SetPromoteQueuedAsSteerFunc(f func(int, string) error) {
+	s.promote = f
+}
 func (s *residualServeServer) SetQueueDepthFunc(f func() int)          { s.queueDepth = f }
 func (s *residualServeServer) SetQueuePreviewFunc(f func() []string)   { s.queuePreview = f }
+func (s *residualServeServer) SetQueueIDsFunc(f func() []string)       { s.queueIDs = f }
 func (s *residualServeServer) SetContextPressureFunc(f func() float64) { s.pressure = f }
 func (s *residualServeServer) SetContextMetricsFunc(f func() server.ContextMetrics) {
 	s.contextMetrics = f
@@ -121,9 +125,10 @@ func exerciseResidualCallbacks(s *residualServeServer) {
 	_, _, _ = s.goalStatus()
 	_ = s.drain()
 	_ = s.drainInput("x", nil)
-	_ = s.promote(0)
+	_ = s.promote(0, "q_1_x")
 	_ = s.queueDepth()
 	_ = s.queuePreview()
+	_ = s.queueIDs()
 	_ = s.pressure()
 	_ = s.contextMetrics()
 	_, _, _ = s.workMetrics()

--- a/cmd/serf/serve_residual_fuzz_test.go
+++ b/cmd/serf/serve_residual_fuzz_test.go
@@ -40,6 +40,7 @@ type residualServeServer struct {
 	goalStatus         func() (string, int, bool)
 	drain              func() error
 	drainInput         func(string, []server.ImageAttachment) error
+	promote            func(int) error
 	queueDepth         func() int
 	queuePreview       func() []string
 	pressure           func() float64
@@ -82,6 +83,7 @@ func (s *residualServeServer) SetDrainAsSteerFunc(f func() error)             { 
 func (s *residualServeServer) SetDrainAsSteerWithInputFunc(f func(string, []server.ImageAttachment) error) {
 	s.drainInput = f
 }
+func (s *residualServeServer) SetPromoteQueuedAsSteerFunc(f func(int) error) { s.promote = f }
 func (s *residualServeServer) SetQueueDepthFunc(f func() int)          { s.queueDepth = f }
 func (s *residualServeServer) SetQueuePreviewFunc(f func() []string)   { s.queuePreview = f }
 func (s *residualServeServer) SetContextPressureFunc(f func() float64) { s.pressure = f }
@@ -119,6 +121,7 @@ func exerciseResidualCallbacks(s *residualServeServer) {
 	_, _, _ = s.goalStatus()
 	_ = s.drain()
 	_ = s.drainInput("x", nil)
+	_ = s.promote(0)
 	_ = s.queueDepth()
 	_ = s.queuePreview()
 	_ = s.pressure()

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -105,6 +105,7 @@ no router (reserved).
 | `turn/interrupt` | both | `TurnInterruptParams` | `EmptyResponse` | Cancels the active turn matching expectedTurnId. |
 | `turn/queue` | both | `TurnQueueParams` | `EmptyResponse` | Queues a user message for after the active turn completes. |
 | `turn/drainAsSteer` | both | `TurnDrainAsSteerParams` | `EmptyResponse` | Drains the input queue and injects it as a single steering message. |
+| `turn/promoteQueuedAsSteer` | both | `TurnPromoteQueuedAsSteerParams` | `EmptyResponse` | Removes one queued message by index and injects it as user-sourced steering into the in-flight turn. |
 | `goal/set` | both | `GoalSetParams` | `GoalSetResponse` | Sets or clears the session's /goal objective. |
 | `serf/tasks/list` | both | `TaskListParams` | `TaskListResponse` | Lists the session's tasks. |
 | `serf/thread/transcripts/list` | hub | `ThreadTranscriptListParams` | `ThreadTranscriptListResponse` | Lists transcript targets (subagents/related threads) for a ref. |
@@ -475,6 +476,8 @@ _(no fields)_
 | `sandboxNet` | `*bool` | yes |  |
 | `maxRounds` | `*int` | yes |  |
 | `maxSubagentDepth` | `*int` | yes |  |
+| `maxConcurrentDelegateTurns` | `*int` | yes |  |
+| `maxRetainedTerminal` | `*int` | yes |  |
 | `noProjectPrompts` | `*bool` | yes |  |
 | `nonInteractive` | `*bool` | yes |  |
 | `appReplaySize` | `*int` | yes |  |
@@ -1016,6 +1019,14 @@ _(no fields)_
 | `ref` | `string` | yes |  |
 | `threadId` | `string` | yes |  |
 | `expectedTurnId` | `string` | yes |  |
+
+
+### `TurnPromoteQueuedAsSteerParams`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `ref` | `string` |  |  |
+| `index` | `int` |  |  |
 
 
 ### `TurnQueueParams`

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -1027,6 +1027,7 @@ _(no fields)_
 |-------|---------|-----------|----------|
 | `ref` | `string` |  |  |
 | `index` | `int` |  |  |
+| `expectedEntryId` | `string` | yes |  |
 
 
 ### `TurnQueueParams`

--- a/internal/appprojector/appwire_projection.go
+++ b/internal/appprojector/appwire_projection.go
@@ -635,7 +635,11 @@ func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification
 		return []AppNotification{p.notification(appwire.NotifyThreadQueueChanged, appwire.ThreadQueueChangedParams{
 			ThreadID: p.threadID,
 			Ref:      p.ref,
-			Queue:    appwire.QueueState{Depth: data.Depth, Preview: append([]string(nil), data.Preview...)},
+			Queue: appwire.QueueState{
+				Depth:   data.Depth,
+				Preview: append([]string(nil), data.Preview...),
+				IDs:     append([]string(nil), data.IDs...),
+			},
 		})}
 	case events.EventTaskUpdated:
 		p.clearSkillCandidate()

--- a/server/appwire_promote_test.go
+++ b/server/appwire_promote_test.go
@@ -32,7 +32,7 @@ func newPromoteTestServer(t *testing.T, processing bool) (*Server, *int) {
 	}
 	srv.SetStatus(StatusInfo{SessionID: "th_1", State: state})
 	called := 0
-	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
+	srv.SetPromoteQueuedAsSteerFunc(func(index int, expectedID string) error {
 		called++
 		return nil
 	})
@@ -52,18 +52,23 @@ func TestServerAppWireTurnPromoteQueuedAsSteerDispatchesIndex(t *testing.T) {
 	srv.SetProcessing(true)
 	srv.SetStatus(StatusInfo{SessionID: "th_1", State: "active"})
 	gotIndex := -1
-	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
+	var gotExpectedID string
+	srv.SetPromoteQueuedAsSteerFunc(func(index int, expectedID string) error {
 		gotIndex = index
+		gotExpectedID = expectedID
 		return nil
 	})
 
 	conn := srv.AppServer().NewConnection("test")
-	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:th_1", Index: 1})
+	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:th_1", Index: 1, ExpectedEntryID: "q_1_abc"})
 	if resp.Kind() != appwire.MessageResponse {
 		t.Fatalf("resp=%v error=%+v", resp.Kind(), resp.Error)
 	}
 	if gotIndex != 1 {
 		t.Fatalf("promote callback index=%d, want 1", gotIndex)
+	}
+	if gotExpectedID != "q_1_abc" {
+		t.Fatalf("promote callback expectedID=%q, want q_1_abc", gotExpectedID)
 	}
 }
 
@@ -112,18 +117,25 @@ func TestServerAppWireTurnPromoteQueuedAsSteerUnavailableWithoutFunc(t *testing.
 	}
 }
 
+// TestServerAppWireTurnPromoteQueuedAsSteerPropagatesSessionError pins
+// review F2: session-side rejections (queue shifted → index out of range or
+// expected id mismatch) surface as Conflict so the client can re-sync its
+// preview instead of believing the wrong message was promoted.
 func TestServerAppWireTurnPromoteQueuedAsSteerPropagatesSessionError(t *testing.T) {
 	srv := NewServer(ServerConfig{})
 	srv.SetAppIdentity("local", "th_1")
 	srv.SetProcessing(true)
 	srv.SetStatus(StatusInfo{SessionID: "th_1", State: "active"})
-	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
+	srv.SetPromoteQueuedAsSteerFunc(func(index int, expectedID string) error {
 		return errors.New("promote: queue index 3 out of range (depth 1)")
 	})
 	conn := srv.AppServer().NewConnection("test")
 	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:th_1", Index: 3})
 	if resp.Kind() != appwire.MessageError {
 		t.Fatalf("expected error, got %v", resp.Kind())
+	}
+	if resp.Error.Error.Code != appwire.CodeConflict {
+		t.Fatalf("error=%+v, want Conflict", resp.Error.Error)
 	}
 }
 
@@ -163,12 +175,46 @@ func TestServerAppWireTurnPromoteQueuedAsSteerThroughSession(t *testing.T) {
 	srv.SetAppIdentity("local", sess.ID())
 	srv.SetProcessing(true)
 	srv.SetStatus(StatusInfo{SessionID: sess.ID(), State: "active"})
-	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
-		return sess.PromoteQueuedAsSteer(context.Background(), index)
+	srv.SetPromoteQueuedAsSteerFunc(func(index int, expectedID string) error {
+		return sess.PromoteQueuedAsSteer(context.Background(), index, expectedID)
 	})
+	srv.SetQueuePreviewFunc(sess.QueuePreview)
+	srv.SetQueueIDsFunc(sess.QueueIDs)
 
 	conn := srv.AppServer().NewConnection("test")
-	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:" + sess.ID(), Index: 0})
+	conn.HandleMessage(context.Background(), appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodInitialize, appwire.InitializeParams{}))
+
+	// The thread snapshot must carry the entry ids the UI needs to send back.
+	readResp := conn.HandleMessage(context.Background(), appwire.RequestMessage(appwire.NewIntID(9), appwire.MethodThreadRead, appwire.ThreadReadParams{Ref: "local:" + sess.ID()}))
+	if readResp.Kind() != appwire.MessageResponse {
+		t.Fatalf("thread/read: %v", readResp.Kind())
+	}
+	read, ok := readResp.Response.Result.(appwire.ThreadReadResponse)
+	if !ok {
+		t.Fatalf("thread/read result type=%T", readResp.Response.Result)
+	}
+	ids := read.Thread.Serf.Queue.IDs
+	if len(ids) != 2 || ids[0] == "" || ids[1] == "" {
+		t.Fatalf("thread queue IDs = %#v, want two non-empty ids", ids)
+	}
+
+	// Review F1: a promote naming the WRONG entry id (a stale snapshot) is a
+	// Conflict and leaves the queue fully intact — nothing is steered.
+	mismatch := promoteRPC(conn, 3, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:" + sess.ID(), Index: 0, ExpectedEntryID: ids[1]})
+	if mismatch.Kind() != appwire.MessageError {
+		t.Fatalf("mismatch promote: expected error, got %v", mismatch.Kind())
+	}
+	if mismatch.Error.Error.Code != appwire.CodeConflict {
+		t.Fatalf("mismatch error=%+v, want Conflict", mismatch.Error.Error)
+	}
+	if preview := sess.QueuePreview(); len(preview) != 2 {
+		t.Fatalf("QueuePreview after mismatch: got %#v, want both entries intact", preview)
+	}
+	if steering := sess.SteeringQueueSnapshot(); len(steering) != 0 {
+		t.Fatalf("steering queue after mismatch: got %+v, want empty", steering)
+	}
+
+	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:" + sess.ID(), Index: 0, ExpectedEntryID: ids[0]})
 	if resp.Kind() != appwire.MessageResponse {
 		t.Fatalf("resp=%v error=%+v", resp.Kind(), resp.Error)
 	}

--- a/server/appwire_promote_test.go
+++ b/server/appwire_promote_test.go
@@ -1,0 +1,188 @@
+package server
+
+// Tests for the turn/promoteQueuedAsSteer appwire method (issue #22): the
+// per-message counterpart of turn/drainAsSteer. The daemon removes the queued
+// follow-up at the requested index and injects it as user-sourced steering
+// into the in-flight turn; other queued messages stay queued. Failures are
+// honest: idle/closed → Conflict, negative index → InvalidParams, no callback
+// → Unavailable, and a session-side rejection (e.g. the queue shifted under
+// the client so the index is now out of range) propagates.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"primeradiant.com/serf/agent"
+	"primeradiant.com/serf/agent/execenv"
+	"primeradiant.com/serf/agent/provider"
+	"primeradiant.com/serf/appwire"
+	"primeradiant.com/serf/llm"
+)
+
+func newPromoteTestServer(t *testing.T, processing bool) (*Server, *int) {
+	t.Helper()
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+	srv.SetProcessing(processing)
+	state := "idle"
+	if processing {
+		state = "active"
+	}
+	srv.SetStatus(StatusInfo{SessionID: "th_1", State: state})
+	called := 0
+	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
+		called++
+		return nil
+	})
+	return srv, &called
+}
+
+func promoteRPC(conn interface {
+	HandleMessage(context.Context, appwire.Message) appwire.Message
+}, id int64, params appwire.TurnPromoteQueuedAsSteerParams) appwire.Message {
+	conn.HandleMessage(context.Background(), appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodInitialize, appwire.InitializeParams{}))
+	return conn.HandleMessage(context.Background(), appwire.RequestMessage(appwire.NewIntID(id), appwire.MethodTurnPromoteQueuedAsSteer, params))
+}
+
+func TestServerAppWireTurnPromoteQueuedAsSteerDispatchesIndex(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+	srv.SetProcessing(true)
+	srv.SetStatus(StatusInfo{SessionID: "th_1", State: "active"})
+	gotIndex := -1
+	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
+		gotIndex = index
+		return nil
+	})
+
+	conn := srv.AppServer().NewConnection("test")
+	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:th_1", Index: 1})
+	if resp.Kind() != appwire.MessageResponse {
+		t.Fatalf("resp=%v error=%+v", resp.Kind(), resp.Error)
+	}
+	if gotIndex != 1 {
+		t.Fatalf("promote callback index=%d, want 1", gotIndex)
+	}
+}
+
+func TestServerAppWireTurnPromoteQueuedAsSteerRejectsNegativeIndex(t *testing.T) {
+	srv, called := newPromoteTestServer(t, true)
+	conn := srv.AppServer().NewConnection("test")
+	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:th_1", Index: -1})
+	if resp.Kind() != appwire.MessageError {
+		t.Fatalf("expected error, got %v", resp.Kind())
+	}
+	if resp.Error.Error.Code != appwire.CodeInvalidParams {
+		t.Fatalf("error=%+v", resp.Error.Error)
+	}
+	if *called != 0 {
+		t.Fatalf("promote called=%d, want 0", *called)
+	}
+}
+
+func TestServerAppWireTurnPromoteQueuedAsSteerRejectsWhenIdle(t *testing.T) {
+	srv, called := newPromoteTestServer(t, false)
+	conn := srv.AppServer().NewConnection("test")
+	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:th_1", Index: 0})
+	if resp.Kind() != appwire.MessageError {
+		t.Fatalf("expected error, got %v", resp.Kind())
+	}
+	if resp.Error.Error.Code != appwire.CodeConflict {
+		t.Fatalf("error=%+v", resp.Error.Error)
+	}
+	if *called != 0 {
+		t.Fatalf("promote called=%d, want 0", *called)
+	}
+}
+
+func TestServerAppWireTurnPromoteQueuedAsSteerUnavailableWithoutFunc(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+	srv.SetProcessing(true)
+	srv.SetStatus(StatusInfo{SessionID: "th_1", State: "active"})
+	conn := srv.AppServer().NewConnection("test")
+	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:th_1", Index: 0})
+	if resp.Kind() != appwire.MessageError {
+		t.Fatalf("expected error, got %v", resp.Kind())
+	}
+	if resp.Error.Error.Code != appwire.CodeUnavailable {
+		t.Fatalf("error=%+v", resp.Error.Error)
+	}
+}
+
+func TestServerAppWireTurnPromoteQueuedAsSteerPropagatesSessionError(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+	srv.SetProcessing(true)
+	srv.SetStatus(StatusInfo{SessionID: "th_1", State: "active"})
+	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
+		return errors.New("promote: queue index 3 out of range (depth 1)")
+	})
+	conn := srv.AppServer().NewConnection("test")
+	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:th_1", Index: 3})
+	if resp.Kind() != appwire.MessageError {
+		t.Fatalf("expected error, got %v", resp.Kind())
+	}
+}
+
+// TestServerAppWireTurnPromoteQueuedAsSteerThroughSession exercises the full
+// stack the way cmd/serf serve wires it: the RPC drives the real agent
+// session's PromoteQueuedAsSteer, so the promoted entry leaves the queue and
+// lands on the steering queue as user-sourced steering while the other
+// queued message stays queued.
+func TestServerAppWireTurnPromoteQueuedAsSteerThroughSession(t *testing.T) {
+	dir := t.TempDir()
+	c := llm.NewClient()
+	adapter := &blockingServerAdapter{name: "openai", started: make(chan struct{}), done: make(chan error, 1)}
+	c.Register(adapter)
+	sess, err := agent.NewSession(c, provider.NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), agent.SessionConfig{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_, _ = sess.ProcessInput(ctx, "keep turn active", nil)
+	}()
+	select {
+	case <-adapter.started:
+	case <-time.After(time.Second):
+		t.Fatal("session did not enter active turn")
+	}
+
+	for _, msg := range []string{"alpha", "bravo"} {
+		if err := sess.Enqueue(context.Background(), msg); err != nil {
+			t.Fatalf("Enqueue %s: %v", msg, err)
+		}
+	}
+
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", sess.ID())
+	srv.SetProcessing(true)
+	srv.SetStatus(StatusInfo{SessionID: sess.ID(), State: "active"})
+	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
+		return sess.PromoteQueuedAsSteer(context.Background(), index)
+	})
+
+	conn := srv.AppServer().NewConnection("test")
+	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:" + sess.ID(), Index: 0})
+	if resp.Kind() != appwire.MessageResponse {
+		t.Fatalf("resp=%v error=%+v", resp.Kind(), resp.Error)
+	}
+	if preview := sess.QueuePreview(); len(preview) != 1 || preview[0] != "bravo" {
+		t.Fatalf("QueuePreview after promote: got %#v, want [bravo]", preview)
+	}
+	steering := sess.SteeringQueueSnapshot()
+	if len(steering) != 1 || steering[0].Text != "alpha" {
+		t.Fatalf("steering queue after promote: got %+v, want [alpha]", steering)
+	}
+	cancel()
+	select {
+	case <-adapter.done:
+	case <-time.After(time.Second):
+		t.Fatal("active turn did not stop after cancellation")
+	}
+}

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -96,6 +96,7 @@ func (s *Server) registerAppWireHandlers() {
 	appserver.HandleTyped(router, appwire.MethodTurnInterrupt, s.handleAppTurnInterrupt)
 	appserver.HandleTyped(router, appwire.MethodTurnQueue, s.handleAppTurnQueue)
 	appserver.HandleTyped(router, appwire.MethodTurnDrainAsSteer, s.handleAppTurnDrainAsSteer)
+	appserver.HandleTyped(router, appwire.MethodTurnPromoteQueuedAsSteer, s.handleAppTurnPromoteQueuedAsSteer)
 	appserver.HandleTyped(router, appwire.MethodGoalSet, s.handleAppGoalSet)
 	appserver.HandleTyped(router, appwire.MethodThreadCompactStart, s.handleAppThreadCompactStart)
 	appserver.HandleTyped(router, appwire.MethodThreadShutdown, s.handleAppThreadShutdown)
@@ -513,6 +514,37 @@ func (s *Server) handleAppTurnDrainAsSteer(_ context.Context, params appwire.Tur
 		err = fn()
 	}
 	if err != nil {
+		return appwire.EmptyResponse{}, err
+	}
+	return appwire.EmptyResponse{}, nil
+}
+
+// handleAppTurnPromoteQueuedAsSteer handles turn/promoteQueuedAsSteer
+// (issue #22): removes the queued follow-up at params.Index and injects it
+// as user-sourced steering into the in-flight turn. A negative index is an
+// InvalidParams rejection; an idle or closed session is a Conflict (the
+// queued message stays a normal follow-up — nothing is silently dropped);
+// a session-side out-of-range (the queue shifted between the client's
+// preview snapshot and the promote) propagates the session's error.
+func (s *Server) handleAppTurnPromoteQueuedAsSteer(_ context.Context, params appwire.TurnPromoteQueuedAsSteerParams) (appwire.EmptyResponse, error) {
+	if params.Index < 0 {
+		return appwire.EmptyResponse{}, appwire.InvalidParams("index must be >= 0")
+	}
+	s.mu.RLock()
+	fn := s.promoteSteerFunc
+	processing := s.processing
+	closed := appStatus(s.status.State, processing) == appwire.ThreadStatusClosed
+	s.mu.RUnlock()
+	if closed {
+		return appwire.EmptyResponse{}, appwire.Conflict("session is closed")
+	}
+	if !processing {
+		return appwire.EmptyResponse{}, appwire.Conflict("no active turn to steer")
+	}
+	if fn == nil {
+		return appwire.EmptyResponse{}, appwire.Unavailable("promote-queued-as-steer not available")
+	}
+	if err := fn(params.Index); err != nil {
 		return appwire.EmptyResponse{}, err
 	}
 	return appwire.EmptyResponse{}, nil

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -523,9 +523,11 @@ func (s *Server) handleAppTurnDrainAsSteer(_ context.Context, params appwire.Tur
 // (issue #22): removes the queued follow-up at params.Index and injects it
 // as user-sourced steering into the in-flight turn. A negative index is an
 // InvalidParams rejection; an idle or closed session is a Conflict (the
-// queued message stays a normal follow-up — nothing is silently dropped);
-// a session-side out-of-range (the queue shifted between the client's
-// preview snapshot and the promote) propagates the session's error.
+// queued message stays a normal follow-up — nothing is silently dropped).
+// Session-side rejections are all queue-state conflicts — the index fell
+// out of range or the expected entry id no longer matches because the queue
+// shifted under the client's snapshot (review F1) — so they map to Conflict
+// and the client can re-sync its preview (review F2).
 func (s *Server) handleAppTurnPromoteQueuedAsSteer(_ context.Context, params appwire.TurnPromoteQueuedAsSteerParams) (appwire.EmptyResponse, error) {
 	if params.Index < 0 {
 		return appwire.EmptyResponse{}, appwire.InvalidParams("index must be >= 0")
@@ -544,8 +546,8 @@ func (s *Server) handleAppTurnPromoteQueuedAsSteer(_ context.Context, params app
 	if fn == nil {
 		return appwire.EmptyResponse{}, appwire.Unavailable("promote-queued-as-steer not available")
 	}
-	if err := fn(params.Index); err != nil {
-		return appwire.EmptyResponse{}, err
+	if err := fn(params.Index, params.ExpectedEntryID); err != nil {
+		return appwire.EmptyResponse{}, appwire.Conflict(err.Error())
 	}
 	return appwire.EmptyResponse{}, nil
 }
@@ -715,6 +717,7 @@ func (s *Server) appThread() appwire.Thread {
 	dfn := s.detailedStatusFn
 	qpfn := s.queuePreviewFn
 	qdfn := s.queueDepthFn
+	qifn := s.queueIDsFn
 	gsfn := s.goalStatusFn
 	wmfn := s.workMetricsFn
 	metafn := s.sessionMetaFn
@@ -753,6 +756,11 @@ func (s *Server) appThread() appwire.Thread {
 		if preview := qpfn(); len(preview) > 0 {
 			queue.Preview = append([]string(nil), preview...)
 			queue.Depth = len(preview)
+		}
+	}
+	if qifn != nil && queue.Depth > 0 {
+		if ids := qifn(); len(ids) == queue.Depth {
+			queue.IDs = append([]string(nil), ids...)
 		}
 	}
 	// Fall back to depthFn when preview isn't wired (some tests stub only

--- a/server/server.go
+++ b/server/server.go
@@ -170,8 +170,9 @@ type Server struct {
 	goalStatusFn                 func() (status string, iterations int, ok bool)
 	drainSteerFunc               func() error
 	drainSteerInputFunc          func(string, []ImageAttachment) error
-	promoteSteerFunc             func(int) error
+	promoteSteerFunc             func(int, string) error
 	queueDepthFn                 func() int
+	queueIDsFn                   func() []string
 	queuePreviewFn               func() []string
 	compactFunc                  func(context.Context) error
 	clearFunc                    func(context.Context) error
@@ -411,8 +412,10 @@ func (s *Server) SetDrainAsSteerWithInputFunc(fn func(string, []ImageAttachment)
 // turn/promoteQueuedAsSteer (issue #22). The callback should remove the
 // queued message at the given FIFO index and inject it as a user-sourced
 // STEERING message into the in-flight turn, leaving the rest of the queue
-// untouched.
-func (s *Server) SetPromoteQueuedAsSteerFunc(fn func(int) error) {
+// untouched. A non-empty expectedID must match the queue-entry id minted at
+// enqueue time so a queue that shifted under the client's snapshot is
+// rejected rather than promoting the wrong message (review F1).
+func (s *Server) SetPromoteQueuedAsSteerFunc(fn func(int, string) error) {
 	s.mu.Lock()
 	s.promoteSteerFunc = fn
 	s.mu.Unlock()
@@ -433,6 +436,16 @@ func (s *Server) SetQueueDepthFunc(fn func() int) {
 func (s *Server) SetQueuePreviewFunc(fn func() []string) {
 	s.mu.Lock()
 	s.queuePreviewFn = fn
+	s.mu.Unlock()
+}
+
+// SetQueueIDsFunc sets a callback returning the stable per-entry ids of the
+// queued user messages in FIFO order (aligned with QueuePreview). Used by
+// appwire ReadThread to populate QueueState.IDs so a promote request can
+// carry the expected entry identity (review F1, issue #22).
+func (s *Server) SetQueueIDsFunc(fn func() []string) {
+	s.mu.Lock()
+	s.queueIDsFn = fn
 	s.mu.Unlock()
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -170,6 +170,7 @@ type Server struct {
 	goalStatusFn                 func() (status string, iterations int, ok bool)
 	drainSteerFunc               func() error
 	drainSteerInputFunc          func(string, []ImageAttachment) error
+	promoteSteerFunc             func(int) error
 	queueDepthFn                 func() int
 	queuePreviewFn               func() []string
 	compactFunc                  func(context.Context) error
@@ -403,6 +404,17 @@ func (s *Server) SetDrainAsSteerFunc(fn func() error) {
 func (s *Server) SetDrainAsSteerWithInputFunc(fn func(string, []ImageAttachment) error) {
 	s.mu.Lock()
 	s.drainSteerInputFunc = fn
+	s.mu.Unlock()
+}
+
+// SetPromoteQueuedAsSteerFunc sets the function called by appwire
+// turn/promoteQueuedAsSteer (issue #22). The callback should remove the
+// queued message at the given FIFO index and inject it as a user-sourced
+// STEERING message into the in-flight turn, leaving the rest of the queue
+// untouched.
+func (s *Server) SetPromoteQueuedAsSteerFunc(fn func(int) error) {
+	s.mu.Lock()
+	s.promoteSteerFunc = fn
 	s.mu.Unlock()
 }
 


### PR DESCRIPTION
## Summary

Implements #22: while an agent turn is running, each queued follow-up row in the web UI queue preview now offers a **promote** action (⇧ button on the row). Clicking it removes just that message from the follow-up FIFO and injects it as **user-sourced steering** into the in-flight turn; the other queued messages stay queued in order. The promoted message renders as a user message (source="user"), reusing the issue-#24 steering-source path — not as a system steering divider.

Stack, end to end:

- **agent**: `Session.PromoteQueuedAsSteer(ctx, index)` — removes `inputQueue[index]`, enqueues it on the steering queue with `Source=user` (preserving images + causal provenance), emits `QueueChanged`. Idle / closed / out-of-range fail honestly and leave the queue untouched (no silent loss).
- **appwire**: new `turn/promoteQueuedAsSteer` RPC (`ScopeBoth`) with `TurnPromoteQueuedAsSteerParams{Ref, Index}`, client wrapper, protocol-catalog entry, regenerated `docs/appwire-protocol.md`.
- **daemon (server + cmd/serf)**: `handleAppTurnPromoteQueuedAsSteer` (negative index → InvalidParams; idle/closed → Conflict; queue-shifted-out-of-range propagates the session error) wired via `SetPromoteQueuedAsSteerFunc` to the agent session in `serve.go`.
- **hub**: `appsource.Source.PromoteQueuedAsSteer` (LocalDaemonSource relays over appwire; CodexSource returns Unavailable), app_rpc relay riding the steer capability, and `POST /s/<id>/promote-queued` for the no-appwire REST fallback.
- **web**: queue-preview rows render a subtle promote button styled with canonical tokens (`--line`/`--ink-3`/`--accent`). No local mirror — the daemon's `thread/queueChanged` re-renders the preview and `serf/steering/injected` (source "user") echoes the message; failures (e.g. turn already ended) surface as an error banner and the message stays queued.

Also includes a small separate commit repairing pre-existing `serffuzz`-tagged test drift on main (tree-slot kind attribution APIs) that made `go vet -tags serffuzz ./agent` fail before this branch.

## Test evidence

- `go test ./agent ./appwire ./server ./cmd/serf ./cmd/serf-hub ./cmd/serf-hub/internal/appsource` — all ok, including new suites:
  - `agent/session_queue_promote_test.go` (6 tests: remove-only-that-entry, user source, idle rejection leaves queue intact, out-of-range, QueueChanged emission, closed session)
  - `server/appwire_promote_test.go` (6 tests incl. through-session RPC→agent-session)
  - `cmd/serf-hub/web_promote_test.go` (5 REST tests + hub RPC relay test)
- `GOCACHE=/tmp/serf-go-build-cache go test ./agent ./appwire ./cmd/serf ./cmd/serf-hub ./internal/appprojector ./internal/apptranscript` — all ok
- `make build-hub && make build-all` — ok
- `go vet` on changed packages — ok; `go vet -tags serffuzz ./agent` — ok (after the drift repair commit)
- `make lint-golangci` — PASS (7 modules)
- `cd cmd/serf-hub && bash jstest/run-all.sh` — all tests passed, including new `test-queue-promote.js` (buttons render per row, click posts the row index, preview re-renders on daemon queueChanged, failure surfaces an error banner with queue state unchanged)

Fixes #22