### PR TITLE
hub: server-truth tool hover timestamps, fixed no-reflow meta (#37)

### DIFF
--- a/appwire/types.go
+++ b/appwire/types.go
@@ -512,25 +512,30 @@ const (
 )
 
 type ThreadItem struct {
-	Type                 string          `json:"type"`
-	ID                   string          `json:"id"`
-	TurnID               string          `json:"turnId,omitempty"`
-	TranscriptEntryIndex int             `json:"transcriptEntryIndex,omitempty"`
-	Text                 string          `json:"text,omitempty"`
-	Delta                string          `json:"delta,omitempty"`
-	Images               []InputItem     `json:"images,omitempty"`
-	ToolName             string          `json:"toolName,omitempty"`
-	CallID               string          `json:"callId,omitempty"`
-	ArgumentsJSON        string          `json:"argumentsJson,omitempty"`
-	Description          string          `json:"description,omitempty"`
-	Output               string          `json:"output,omitempty"`
-	Error                string          `json:"error,omitempty"`
-	OutputImages         []OutputImage   `json:"outputImages,omitempty"`
-	Status               string          `json:"status,omitempty"`
-	StartedAt            *int64          `json:"startedAt,omitempty"`
-	CompletedAt          *int64          `json:"completedAt,omitempty"`
-	Raw                  json.RawMessage `json:"raw,omitempty"`
-	EventKind            string          `json:"eventKind,omitempty"`
+	Type                 string        `json:"type"`
+	ID                   string        `json:"id"`
+	TurnID               string        `json:"turnId,omitempty"`
+	TranscriptEntryIndex int           `json:"transcriptEntryIndex,omitempty"`
+	Text                 string        `json:"text,omitempty"`
+	Delta                string        `json:"delta,omitempty"`
+	Images               []InputItem   `json:"images,omitempty"`
+	ToolName             string        `json:"toolName,omitempty"`
+	CallID               string        `json:"callId,omitempty"`
+	ArgumentsJSON        string        `json:"argumentsJson,omitempty"`
+	Description          string        `json:"description,omitempty"`
+	Output               string        `json:"output,omitempty"`
+	Error                string        `json:"error,omitempty"`
+	OutputImages         []OutputImage `json:"outputImages,omitempty"`
+	Status               string        `json:"status,omitempty"`
+	StartedAt            *int64        `json:"startedAt,omitempty"`
+	CompletedAt          *int64        `json:"completedAt,omitempty"`
+	// DurationMS is the item's real server-measured runtime in milliseconds
+	// (tool-call items only). Stamped live from the event stream's own
+	// timestamps; nil when no honest span was recorded (issue #37: the web
+	// hover meta shows real times or nothing).
+	DurationMS *int64          `json:"durationMs,omitempty"`
+	Raw        json.RawMessage `json:"raw,omitempty"`
+	EventKind  string          `json:"eventKind,omitempty"`
 	// Source carries item provenance for steering items: "user" for
 	// human-sent steering (rendered as a user message), empty for
 	// daemon/system steering (issue #24).

--- a/cmd/serf-hub/app_threadread.go
+++ b/cmd/serf-hub/app_threadread.go
@@ -543,7 +543,8 @@ func replayTurnToAgentTurn(turn hubcore.ReplayTurn) (schema.Turn, map[string]str
 		}
 	}
 	return schema.Turn{
-		Kind: schema.TurnKind(turn.Kind),
+		Kind:      schema.TurnKind(turn.Kind),
+		Timestamp: turn.Timestamp,
 		Message: llm.Message{
 			Role:    llm.Role(turn.Message.Role),
 			Content: content,

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -3047,7 +3047,10 @@
       parent.appendChild(el);
       this.attachFileOpenBeside(el, tool, args);
 
-      const startedAt = toolEventTime(data) || new Date();
+      // Issue #37: the hover meta shows REAL server times or nothing. No
+      // client wall-clock fallback — a timestamp minted at render time would
+      // claim the action happened when the browser drew the row.
+      const startedAt = toolEventTime(data);
       const state = { el, statusEl: status, resultEl: result, metaEl: meta, outputBuf: "", tool, args, renderer, body: null, caretEl: null, ids: [], startedAt, durationMs: toolDuration(data) };
       this.renderToolMeta(state, null);
       if (renderer.body) {
@@ -3131,7 +3134,7 @@
         const text = m.renderer.result ? m.renderer.result(data, out, m) : "";
         m.resultEl.textContent = (text === "ok" || text === "done") ? "" : text;
       }
-      const endedAt = toolEventTime(data) || new Date();
+      const endedAt = toolEventTime(data);
       const duration = toolDuration(data);
       if (duration != null) m.durationMs = duration;
       this.renderToolMeta(m, endedAt);
@@ -3292,7 +3295,11 @@
       const parts = [];
       if (state.startedAt) parts.push(formatToolClock(state.startedAt));
       const duration = state.durationMs != null ? state.durationMs : (endedAt && state.startedAt ? endedAt - state.startedAt : null);
-      if (duration != null) parts.push(formatToolDuration(duration));
+      // A duration derived from second-precision replay stamps that lands on
+      // 0 is too coarse to display honestly (the real span is anywhere in
+      // 0–2s) — omit it rather than show a fake "1ms". An explicit server
+      // durationMs is millisecond truth and always shown.
+      if (duration != null && (state.durationMs != null || duration > 0)) parts.push(formatToolDuration(duration));
       state.metaEl.textContent = parts.join(" · ");
     },
 

--- a/cmd/serf-hub/assets/style.css
+++ b/cmd/serf-hub/assets/style.css
@@ -2596,7 +2596,7 @@ button.composer-model-value .caret { color: var(--ink-3); }
 .think.think-tier-short .pv { color: var(--ink-2); }
 
 /* Annotation tier — tool calls, diffs, subagent references */
-.tool-call { margin: 0 0 var(--space-3) 0; font-family: var(--font-sans); font-size: var(--text-base); line-height: var(--leading-normal); color: var(--ink-2); display: flex; column-gap: var(--space-3); row-gap: var(--space-2); flex-wrap: wrap; align-items: baseline; }
+.tool-call { position: relative; margin: 0 0 var(--space-3) 0; font-family: var(--font-sans); font-size: var(--text-base); line-height: var(--leading-normal); color: var(--ink-2); display: flex; column-gap: var(--space-3); row-gap: var(--space-2); flex-wrap: wrap; align-items: baseline; }
 .tool-call-cluster { margin-bottom: var(--space-5); }
 .tool-call-cluster .tool-call:last-child { margin-bottom: 0; }
 /* Collapsed cluster summary (mockup #6 alt A): while the cluster is live the
@@ -2667,10 +2667,16 @@ button.composer-model-value .caret { color: var(--ink-3); }
 }
 /* Timestamp · runtime: quiet on demand, not ambient noise. Hidden at rest and
    revealed on row hover / :focus-within (keyboard). opacity keeps the text in
-   the accessibility tree; touch devices reveal it via tap (sticky :hover). */
+   the accessibility tree; touch devices reveal it via tap (sticky :hover).
+   The meta is FIXED top-right of the row (position: absolute — issue #37):
+   out of the flex flow, it reserves no width and its reveal (or the runtime
+   landing at tool end) can never reflow the row's text, on any breakpoint. */
 .tool-call .tool-meta {
-  order: 2;
-  margin-left: auto;
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding-left: var(--space-3);
+  background: inherit;
   color: var(--ink-2);
   font-family: var(--font-sans);
   font-variant-numeric: tabular-nums;
@@ -4904,13 +4910,9 @@ details[open] > .diagnostic-detail-summary::after { transform: rotate(90deg); }
      narrow viewports (flex child default min-width: auto blocks shrink). */
   .tool-call .target { min-width: 0; }
 
-  /* Compact phone layout removes per-row timing meta from the flow so it does
-     not reserve ~112px and squeeze command/path text into a narrow,
-     mid-word-wrapping column; a tap on the row (sticky :hover / focus) brings
-     it back for inspection. */
-  .tool-call .tool-meta { display: none; }
-  .tool-call:hover .tool-meta,
-  .tool-call:focus-within .tool-meta { display: inline; }
+  /* Compact phone layout needs no per-row timing-meta carve-out: the meta is
+     position:absolute on every breakpoint (issue #37), so it is already out
+     of the flow and a tap reveal (sticky :hover / focus) reflows nothing. */
 
   /* Phone reading scale (2026-07-11 round 2): the transcript follows the same
      one-size rule as desktop — flowing text --text-base, mono machine text

--- a/cmd/serf-hub/internal/hubcore/types.go
+++ b/cmd/serf-hub/internal/hubcore/types.go
@@ -1,6 +1,9 @@
 package hubcore
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // ModelDescriptor is a provider/model pair used by the spawn chip and /api/models.
 type ModelDescriptor struct {
@@ -21,6 +24,9 @@ type ReplayEntry struct {
 type ReplayTurn struct {
 	Kind    string        `json:"kind"`
 	Message ReplayMessage `json:"message"`
+	// Timestamp is the turn's recorded time, carried through reload so
+	// replayed tool items can be stamped with real server times (issue #37).
+	Timestamp time.Time `json:"timestamp,omitempty"`
 }
 
 type ReplayMessage struct {

--- a/cmd/serf-hub/jstest/test-mobile-css.js
+++ b/cmd/serf-hub/jstest/test-mobile-css.js
@@ -222,11 +222,15 @@ const perKindOverride = blocks.find(
 );
 pass(!perKindOverride, "no compact phone rule may re-tier the reading column with per-kind font-size overrides");
 
-// Compact phone layout hides timing meta narrowly to avoid reserving ~112px and
-// squeezing command/path text into a narrow, mid-word-wrapping column. This is a
-// mobile overflow guard, not a desktop hover-only metadata contract.
+// The timing meta is fixed top-right (position: absolute) on every breakpoint
+// (issue #37), so it never reserves width and the command/path text always gets
+// the full row — the old compact-phone display:none carve-out (which reflowed
+// text on tap) is gone. This is the no-reflow metadata contract, not a mobile
+// overflow guard.
+const metaFixed = /\.tool-call \.tool-meta\s*\{[^}]*position:\s*absolute/.test(css);
+pass(metaFixed, ".tool-call .tool-meta is position:absolute so the command gets full width on every breakpoint");
 const metaHidden = blocks.find((b) => /\.tool-call \.tool-meta/.test(b.split("{")[0]) && /display:\s*none/.test(b));
-pass(!!metaHidden, "compact mobile may hide .tool-call .tool-meta so the command gets full width");
+pass(!metaHidden, "no breakpoint hides .tool-call .tool-meta with display:none (display toggling reflows text)");
 
 // iOS standalone runs edge-to-edge (black-translucent status bar), so every
 // full-height fixed overlay must pad its screen-edge sides with the safe-area

--- a/cmd/serf-hub/jstest/test-tool-meta-timing.js
+++ b/cmd/serf-hub/jstest/test-tool-meta-timing.js
@@ -1,0 +1,115 @@
+// Issue #37: the tool-row hover meta (.tool-meta — timestamp · runtime) must
+// show REAL server times or nothing at all. The renderer used to fall back to
+// the client wall clock (new Date()) when an event carried no timing, so every
+// stamp was "when the browser drew the row," not when the action happened on
+// the server — and on hydration of a past session every row showed page-load
+// time. Server truth rides the events as startedAt/completedAt (unix seconds)
+// and durationMs; the renderer must never invent a time.
+//
+// The meta is also laid out fixed (position: absolute, anchored top-right of
+// the row) so revealing it — on hover, focus, or when the duration lands at
+// tool end — never reflows the row's text.
+const { JSDOM } = require("jsdom");
+const fs = require("fs");
+
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <div class="workspace-actions">
+    <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+    <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+  </div>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation" data-session-id="01TEST" data-state="active"></div>
+  <form data-input-form data-session-id="01TEST">
+    <textarea class="message-input"></textarea>
+  </form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+
+const { window } = dom;
+window.marked = { parse: (t) => t };
+window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve([]), text: () => Promise.resolve("") });
+
+require("./load-renderer").evalRenderer(window);
+
+const conv = window.document.getElementById("conversation");
+window.SerfRenderer.init(conv);
+
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+const R = window.SerfRenderer;
+
+// Fixed server stamps (unix seconds). 2020-01-02T03:04:05Z is far from any
+// plausible test-run wall clock, so a client-clock fallback cannot satisfy the
+// equality assertions by coincidence.
+const START_UNIX = Date.UTC(2020, 0, 2, 3, 4, 5) / 1000;
+const END_UNIX = START_UNIX + 7;
+const clockOf = (unix) => new Date(unix * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+
+const startCall = (callId, extra) => R.handleData("TOOL_CALL_START", Object.assign({
+  call_id: callId,
+  tool_name: "shell",
+  arguments_json: JSON.stringify({ command: "echo hi" }),
+}, extra));
+const endCall = (callId, extra) => R.handleData("TOOL_CALL_END", Object.assign({
+  call_id: callId,
+  tool_name: "shell",
+  output: "hi",
+}, extra));
+// Rows don't carry the call id in the DOM; track by creation order instead.
+const metaTextAt = (i) => {
+  const rows = conv.querySelectorAll(".tool-call .tool-meta");
+  return rows[i] ? rows[i].textContent : null;
+};
+
+(async () => {
+  // Let the cold-load /tasks fetch resolve so events render instead of buffering.
+  await new Promise((r) => setTimeout(r, 30));
+
+  // ── 1. Server-stamped start: the meta shows the SERVER time, not client now.
+  startCall("c1", { startedAt: START_UNIX });
+  pass(metaTextAt(0) === clockOf(START_UNIX),
+    "meta shows the server-provided start time (want " + clockOf(START_UNIX) + ", got " + JSON.stringify(metaTextAt(0)) + ")");
+
+  // Server-stamped end: clock · runtime, both from the wire.
+  endCall("c1", { completedAt: END_UNIX, durationMs: 2500 });
+  pass(metaTextAt(0) === clockOf(START_UNIX) + " · 2.5s",
+    "meta shows server start time · server duration (got " + JSON.stringify(metaTextAt(0)) + ")");
+
+  // ── 2. No server timing anywhere: no meta at all (never client wall clock).
+  startCall("c2", {});
+  pass(metaTextAt(1) === "",
+    "no start timestamp from the server → empty meta, not client now (got " + JSON.stringify(metaTextAt(1)) + ")");
+  endCall("c2", {});
+  pass(metaTextAt(1) === "",
+    "no end timestamp/duration from the server → meta stays empty (got " + JSON.stringify(metaTextAt(1)) + ")");
+
+  // ── 3. Derived runtime from real stamps only; a same-second (0s) derived
+  // span is too coarse to display honestly, so it is omitted.
+  startCall("c3", { startedAt: START_UNIX });
+  endCall("c3", { completedAt: START_UNIX + 3 });
+  pass(metaTextAt(2) === clockOf(START_UNIX) + " · 3s",
+    "runtime derived from real started/completed stamps (got " + JSON.stringify(metaTextAt(2)) + ")");
+  startCall("c4", { startedAt: START_UNIX });
+  endCall("c4", { completedAt: START_UNIX });
+  pass(metaTextAt(3) === clockOf(START_UNIX),
+    "same-second derived span is omitted, not displayed as a fake 1ms (got " + JSON.stringify(metaTextAt(3)) + ")");
+
+  // ── 4. Layout: the meta is fixed-position (out of flow), so revealing it
+  // can never reflow the row's text — on any breakpoint.
+  const css = fs.readFileSync(__dirname + "/../assets/style.css", "utf8");
+  const metaRule = css.match(/\.tool-call \.tool-meta \{([^}]*)\}/);
+  pass(!!metaRule && /position:\s*absolute/.test(metaRule[1]),
+    ".tool-call .tool-meta is position:absolute (out of flow, no reflow)");
+  pass(/\.tool-call \{[^}]*position:\s*relative/.test(css),
+    ".tool-call establishes the positioning context (position:relative)");
+  pass(!/\.tool-call \.tool-meta \{\s*display:\s*none;\s*\}/.test(css),
+    "no breakpoint hides the meta with display:none (display↔inline reflows text)");
+  pass(!/\.tool-call:hover \.tool-meta,\s*\n?\.tool-call:focus-within \.tool-meta \{\s*display:/.test(css),
+    "hover/focus reveals via opacity, never display (display toggling reflows text)");
+
+  if (failures.length) {
+    console.error(failures.join("\n"));
+    process.exit(1);
+  }
+  console.log("ok tool meta timing");
+  process.exit(0); // the renderer's pollers keep the event loop alive otherwise
+})();

--- a/cmd/serf-hub/jstest/test-tool-renderers.js
+++ b/cmd/serf-hub/jstest/test-tool-renderers.js
@@ -687,8 +687,8 @@ await scenario("tool disclosure is inline, visible, and not a separate right-sid
   if (/\.tool-expand-btn\s*\{[^}]*order:\s*3/.test(styleSrc)) {
     return { ok: false, detail: "old right-column tool-expand-btn order:3 rule should be removed" };
   }
-  if (!/\.tool-call \.tool-meta\s*\{[^}]*margin-left:\s*auto/.test(styleSrc)) {
-    return { ok: false, detail: "tool metadata should remain right-side timing context" };
+  if (!/\.tool-call \.tool-meta\s*\{[^}]*position:\s*absolute/.test(styleSrc) || !/\.tool-call \.tool-meta\s*\{[^}]*right:\s*0/.test(styleSrc)) {
+    return { ok: false, detail: "tool metadata should remain right-side timing context (fixed top-right, issue #37)" };
   }
   if (!/\.notification-card-raw > summary::after/.test(styleSrc) || !/\.notification-card-raw > summary[\s\S]{0,400}justify-content:\s*space-between/.test(styleSrc)) {
     return { ok: false, detail: "non-tool card disclosures must keep their right chevrons" };

--- a/docs/web-ui/design-system.md
+++ b/docs/web-ui/design-system.md
@@ -184,15 +184,22 @@ content with the occasional red ✕ standing out; you never scan past a wall of 
 the tool-row caret is right-aligned (so the status/glyph leads a clean, aligned left edge), and
 card disclosures (`raw notification`, `full excerpt`, `show raw error`) read `label … ›` with the
 chevron at the right edge. A left-hung chevron offsets every row and ragged-edges the column; on the
-right it's a quiet "there's more." (On phones the timing meta is out of the flow entirely so
-commands and file paths get the full row width; a tap on the row brings it back.)
+right it's a quiet "there's more." (The timing meta is out of the flow on every
+breakpoint — fixed top-right — so commands and file paths always get the full row width; a
+hover, focus, or tap on the row brings the meta back.)
 
-**Timing metadata is on-demand.** Per-row timestamps/runtimes (`.tool-call .tool-meta`:
+**Timing metadata is on-demand — and honest.** Per-row timestamps/runtimes (`.tool-call .tool-meta`:
 `03:19:32 PM · 1ms`) and the per-turn badge (`.assistant-message .turn-meta`: duration ·
 tokens · cost) rest at `opacity: 0` and reveal on row hover, keyboard `:focus-within`, or tap
 (sticky `:hover`) on touch. `opacity` — never `display`/`visibility` — so they stay in the
-accessibility tree. A column of permanent clock stamps was ambient noise competing with the
-content; the data is one hover away, not gone. (This supersedes the 2026-07-01
+accessibility tree and revealing them reflows nothing. The meta is `position: absolute`,
+fixed to the row's top-right and out of the flex flow on every breakpoint, so neither the
+reveal nor the runtime landing at tool end can shift the row's text. The times themselves
+are **server truth or nothing** (issue #37): the hub stamps each tool item with the session
+event's own `startedAt`/`completedAt`/`durationMs` (live) or the transcript entry's recorded
+timestamp (replay), and the renderer shows no clock when none arrived — never a
+browser-wall-clock stand-in. A column of permanent clock stamps was ambient noise competing
+with the content; the data is one hover away, not gone. (This supersedes the 2026-07-01
 "always-visible" revert: the accessibility concern is answered by the a11y-tree +
 focus-within pairing, not by permanence.)
 
@@ -210,7 +217,8 @@ gutter (`--gutter`) is to its left (§3).
   Mono `--text-sm` whether primary (no purpose, target `--ink`) or demoted under a purpose
   (one truncated line, `--ink-3`, same x=0 column, no sub-indent) — dim color, not a
   smaller size, carries the demotion.
-- `.tool-meta` top-right: sans `--text-xs` `tabular-nums`, `--ink-2`, hover/focus-reveal.
+- `.tool-meta` fixed top-right (`position: absolute`, out of flow): sans `--text-xs`
+  `tabular-nums`, `--ink-2`, hover/focus-reveal; server-stamped times only (issue #37).
 - `.tool-body` / `.diff-body` / `.shell-output`…: full-width below; rails hang in the gutter,
   boxed machine output is mono `--text-sm` with its own contained `overflow-x`.
 

--- a/internal/appprojector/appwire_projection.go
+++ b/internal/appprojector/appwire_projection.go
@@ -36,15 +36,20 @@ type AppEventProjector struct {
 	threadID string
 	ref      string
 
-	nextTurn        int
-	nextItem        int
-	reservedTurnID  string
-	activeTurnID    string
-	assistantItem   string
-	assistantText   string
-	reasoningItem   string
-	toolItemsByKey  map[string]string
-	toolArgsByKey   map[string]string
+	nextTurn       int
+	nextItem       int
+	reservedTurnID string
+	activeTurnID   string
+	assistantItem  string
+	assistantText  string
+	reasoningItem  string
+	toolItemsByKey map[string]string
+	toolArgsByKey  map[string]string
+	// toolStartByKey records each open tool call's server-side start time (the
+	// EventToolCallStart event's own timestamp) so EventToolCallEnd can stamp
+	// the completed item with the call's real StartedAt/DurationMS (issue
+	// #37: the web hover meta shows server truth or nothing).
+	toolStartByKey  map[string]time.Time
 	suppressedTools map[string]struct{}
 	skillCandidate  skillActivationCandidate
 
@@ -78,6 +83,7 @@ func NewAppEventProjector(threadID, ref string) *AppEventProjector {
 		ref:             ref,
 		toolItemsByKey:  map[string]string{},
 		toolArgsByKey:   map[string]string{},
+		toolStartByKey:  map[string]time.Time{},
 		suppressedTools: map[string]struct{}{},
 	}
 }
@@ -132,6 +138,7 @@ func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification
 			p.reasoningItem = ""
 			p.toolItemsByKey = map[string]string{}
 			p.toolArgsByKey = map[string]string{}
+			p.toolStartByKey = map[string]time.Time{}
 			p.suppressedTools = map[string]struct{}{}
 			turn := appwire.Turn{ID: turnID, Status: appwire.TurnStatusCompleted}
 			p.applyPendingTiming(turnID, &turn)
@@ -183,6 +190,7 @@ func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification
 			p.reasoningItem = ""
 			p.toolItemsByKey = map[string]string{}
 			p.toolArgsByKey = map[string]string{}
+			p.toolStartByKey = map[string]time.Time{}
 			p.suppressedTools = map[string]struct{}{}
 			turn := appwire.Turn{ID: turnID, Status: appwire.TurnStatusCompleted}
 			p.applyPendingTiming(turnID, &turn)
@@ -356,6 +364,24 @@ func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification
 		itemID := p.nextItemID("tool")
 		p.toolItemsByKey[data.CallID] = itemID
 		p.toolArgsByKey[data.CallID] = data.ArgumentsJSON
+		startedItem := appwire.ThreadItem{
+			Type:          "commandExecution",
+			ID:            itemID,
+			TurnID:        p.activeTurnID,
+			ToolName:      data.ToolName,
+			CallID:        data.CallID,
+			ArgumentsJSON: data.ArgumentsJSON,
+			Description:   data.Description,
+			Status:        appwire.TurnStatusInProgress,
+		}
+		// The event's own timestamp is the server truth for when the call
+		// started; a zero timestamp leaves StartedAt unset rather than
+		// reporting the Unix epoch (issue #37).
+		if !event.Timestamp.IsZero() {
+			unix := event.Timestamp.Unix()
+			startedItem.StartedAt = &unix
+			p.toolStartByKey[data.CallID] = event.Timestamp
+		}
 		if data.ToolName == "use_skill" {
 			skill := useSkillNameFromArgs(data.ArgumentsJSON)
 			p.skillCandidate = skillActivationCandidate{
@@ -370,16 +396,7 @@ func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification
 			"threadId": p.threadID,
 			"ref":      p.ref,
 			"turnId":   p.activeTurnID,
-			"item": appwire.ThreadItem{
-				Type:          "commandExecution",
-				ID:            itemID,
-				TurnID:        p.activeTurnID,
-				ToolName:      data.ToolName,
-				CallID:        data.CallID,
-				ArgumentsJSON: data.ArgumentsJSON,
-				Description:   data.Description,
-				Status:        appwire.TurnStatusInProgress,
-			},
+			"item":     startedItem,
 		})}
 	case events.EventToolCallOutputDelta:
 		data := eventData[events.ToolCallOutputDeltaData](event.Data)
@@ -424,6 +441,22 @@ func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification
 			// subagent activity line) render the purpose from Description.
 			Description: apptranscript.ToolIntentFromArguments(json.RawMessage(argsJSON)),
 		}
+		// Server-truth timing for the hover meta (issue #37): CompletedAt from
+		// this event's own timestamp; StartedAt/DurationMS from the recorded
+		// call start. Anything not honestly recorded stays unset.
+		if !event.Timestamp.IsZero() {
+			unix := event.Timestamp.Unix()
+			item.CompletedAt = &unix
+			if start, ok := p.toolStartByKey[data.CallID]; ok && !start.IsZero() {
+				startUnix := start.Unix()
+				item.StartedAt = &startUnix
+				duration := event.Timestamp.Sub(start).Milliseconds()
+				if duration >= 0 {
+					item.DurationMS = &duration
+				}
+			}
+		}
+		delete(p.toolStartByKey, data.CallID)
 		if data.ToolName == "use_skill" && data.Error == "" {
 			skill := useSkillNameFromArgs(argsJSON)
 			activationName := ""
@@ -789,6 +822,7 @@ func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification
 			p.reasoningItem = ""
 			p.toolItemsByKey = map[string]string{}
 			p.toolArgsByKey = map[string]string{}
+			p.toolStartByKey = map[string]time.Time{}
 			p.suppressedTools = map[string]struct{}{}
 			turn := appwire.Turn{ID: turnID, Status: turnStatus}
 			p.applyPendingTiming(turnID, &turn)

--- a/internal/appprojector/appwire_projection_test.go
+++ b/internal/appprojector/appwire_projection_test.go
@@ -2027,3 +2027,65 @@ func notificationThreadStatus(t *testing.T, items []AppNotification, method stri
 	t.Fatalf("missing notification %q in %+v", method, items)
 	return appwire.ThreadStatus{}
 }
+
+// TestAppEventProjectorStampsToolItemTiming (issue #37): the web transcript's
+// per-tool hover meta (timestamp · runtime) must be built from REAL server
+// times, not the browser's wall clock. The session event stream already
+// records when each tool call started and ended (SessionEvent.Timestamp), so
+// the projector stamps the started item with StartedAt and the completed item
+// with StartedAt/CompletedAt/DurationMS. Zero timestamps stay unset rather
+// than reporting the Unix epoch.
+func TestAppEventProjectorStampsToolItemTiming(t *testing.T) {
+	projector := NewAppEventProjector("th_1", "local:th_1")
+	start := time.Unix(1_700_000_000, 0).UTC()
+	end := start.Add(2500 * time.Millisecond)
+
+	out := projector.Project(events.SessionEvent{Kind: events.EventToolCallStart, SessionID: "th_1", Timestamp: start, Data: events.ToolCallStartData{
+		ToolName: "shell",
+		CallID:   "call_timed",
+	}})
+	item := notificationThreadItem(t, out, appwire.NotifyItemStarted)
+	if item.StartedAt == nil || *item.StartedAt != start.Unix() {
+		t.Fatalf("started item StartedAt=%v, want %d", item.StartedAt, start.Unix())
+	}
+
+	out = projector.Project(events.SessionEvent{Kind: events.EventToolCallEnd, SessionID: "th_1", Timestamp: end, Data: events.ToolCallEndData{
+		ToolName: "shell",
+		CallID:   "call_timed",
+		Output:   "ok",
+	}})
+	item = notificationThreadItem(t, out, appwire.NotifyItemCompleted)
+	if item.StartedAt == nil || *item.StartedAt != start.Unix() {
+		t.Fatalf("completed item StartedAt=%v, want %d", item.StartedAt, start.Unix())
+	}
+	if item.CompletedAt == nil || *item.CompletedAt != end.Unix() {
+		t.Fatalf("completed item CompletedAt=%v, want %d", item.CompletedAt, end.Unix())
+	}
+	if item.DurationMS == nil || *item.DurationMS != 2500 {
+		t.Fatalf("completed item DurationMS=%v, want 2500", item.DurationMS)
+	}
+}
+
+// TestAppEventProjectorLeavesToolItemTimingUnsetWithoutClock: an event with a
+// zero timestamp (no recorded server time) must NOT mint epoch-0 stamps — the
+// client shows nothing rather than a fake time (issue #37).
+func TestAppEventProjectorLeavesToolItemTimingUnsetWithoutClock(t *testing.T) {
+	projector := NewAppEventProjector("th_1", "local:th_1")
+	out := projector.Project(events.SessionEvent{Kind: events.EventToolCallStart, SessionID: "th_1", Data: events.ToolCallStartData{
+		ToolName: "shell",
+		CallID:   "call_clockless",
+	}})
+	item := notificationThreadItem(t, out, appwire.NotifyItemStarted)
+	if item.StartedAt != nil {
+		t.Fatalf("started item StartedAt=%v, want nil for zero event timestamp", *item.StartedAt)
+	}
+	out = projector.Project(events.SessionEvent{Kind: events.EventToolCallEnd, SessionID: "th_1", Data: events.ToolCallEndData{
+		ToolName: "shell",
+		CallID:   "call_clockless",
+		Output:   "ok",
+	}})
+	item = notificationThreadItem(t, out, appwire.NotifyItemCompleted)
+	if item.StartedAt != nil || item.CompletedAt != nil || item.DurationMS != nil {
+		t.Fatalf("completed item timing=(%v,%v,%v), want all nil for zero event timestamps", item.StartedAt, item.CompletedAt, item.DurationMS)
+	}
+}

--- a/internal/apptranscript/apptranscript.go
+++ b/internal/apptranscript/apptranscript.go
@@ -303,7 +303,7 @@ func ProjectTurn(turnID string, turnIndex int, turn schema.Turn, toolNames map[s
 					}
 					continue
 				}
-				items = append(items, appwire.ThreadItem{
+				item := appwire.ThreadItem{
 					Type:          "commandExecution",
 					ID:            fmt.Sprintf("item_tool_%d_%d", turnIndex, i),
 					TurnID:        turnID,
@@ -312,7 +312,14 @@ func ProjectTurn(turnID string, turnIndex int, turn schema.Turn, toolNames map[s
 					ArgumentsJSON: string(part.ToolCall.Arguments),
 					Description:   ToolIntentFromArguments(part.ToolCall.Arguments),
 					Status:        appwire.TurnStatusInProgress,
-				})
+				}
+				// The entry's recorded timestamp is the server truth for when the
+				// call was issued (issue #37); a zero timestamp mints no stamp.
+				if !turn.Timestamp.IsZero() {
+					unix := turn.Timestamp.Unix()
+					item.StartedAt = &unix
+				}
+				items = append(items, item)
 			}
 		}
 		return items
@@ -338,6 +345,14 @@ func ProjectTurn(turnID string, turnIndex int, turn schema.Turn, toolNames map[s
 				CallID:   part.ToolResult.ToolCallID,
 				Status:   appwire.TurnStatusCompleted,
 				Raw:      part.ToolResult.ToolState,
+			}
+			// The entry's recorded timestamp is the server truth for when the
+			// result landed (issue #37); a zero timestamp mints no stamp. The
+			// matching StartedAt rides the earlier assistant entry's item; the
+			// client merges the two by call id.
+			if !turn.Timestamp.IsZero() {
+				unix := turn.Timestamp.Unix()
+				item.CompletedAt = &unix
 			}
 			if part.ToolResult.IsError {
 				item.Error = StringifyToolContent(part.ToolResult.Content)

--- a/internal/apptranscript/apptranscript_test.go
+++ b/internal/apptranscript/apptranscript_test.go
@@ -747,3 +747,68 @@ func TestProjectTurnModelSwitchMarkerEmptyTextOmitted(t *testing.T) {
 		t.Fatalf("items=%+v, want nil for blank marker text", out)
 	}
 }
+
+// TestProjectTurnStampsToolItemTimestamps (issue #37): a replayed tool row's
+// hover meta (timestamp · runtime) must come from REAL recorded times. The
+// transcript stamps every entry with when it was recorded, so an assistant
+// entry's tool-call item carries StartedAt (when the call was issued) and a
+// tool-results entry's item carries CompletedAt (when the result landed).
+// Zero timestamps stay unset — no epoch-0 fakes.
+func TestProjectTurnStampsToolItemTimestamps(t *testing.T) {
+	start := time.Unix(1_700_000_000, 0).UTC()
+	end := start.Add(3 * time.Second)
+	toolNames := map[string]string{}
+
+	items := ProjectTurn("turn_1", 1, schema.Turn{
+		Kind:      schema.TurnAssistant,
+		Timestamp: start,
+		Message: llm.Message{Content: []llm.ContentPart{{
+			Kind: llm.ContentToolCall,
+			ToolCall: &llm.ToolCallData{
+				ID:        "call_read",
+				Name:      "read_file",
+				Arguments: []byte(`{"path":"README.md"}`),
+			},
+		}}},
+	}, toolNames, nil, nil)
+	if len(items) != 1 || items[0].Type != "commandExecution" {
+		t.Fatalf("tool start items=%+v", items)
+	}
+	if items[0].StartedAt == nil || *items[0].StartedAt != start.Unix() {
+		t.Fatalf("tool call item StartedAt=%v, want %d (entry timestamp)", items[0].StartedAt, start.Unix())
+	}
+
+	items = ProjectTurn("turn_2", 2, schema.Turn{
+		Kind:      schema.TurnToolResults,
+		Timestamp: end,
+		Message: llm.Message{Content: []llm.ContentPart{{
+			Kind: llm.ContentToolResult,
+			ToolResult: &llm.ToolResultData{
+				ToolCallID: "call_read",
+				Content:    "ok",
+			},
+		}}},
+	}, toolNames, nil, nil)
+	if len(items) != 1 || items[0].Type != "commandExecution" {
+		t.Fatalf("tool result items=%+v", items)
+	}
+	if items[0].CompletedAt == nil || *items[0].CompletedAt != end.Unix() {
+		t.Fatalf("tool result item CompletedAt=%v, want %d (entry timestamp)", items[0].CompletedAt, end.Unix())
+	}
+
+	// A zero entry timestamp mints no stamps.
+	items = ProjectTurn("turn_3", 3, schema.Turn{
+		Kind: schema.TurnAssistant,
+		Message: llm.Message{Content: []llm.ContentPart{{
+			Kind: llm.ContentToolCall,
+			ToolCall: &llm.ToolCallData{
+				ID:        "call_notime",
+				Name:      "read_file",
+				Arguments: []byte(`{"path":"x"}`),
+			},
+		}}},
+	}, toolNames, nil, nil)
+	if len(items) != 1 || items[0].StartedAt != nil {
+		t.Fatalf("zero-timestamp tool call item StartedAt=%v, want nil", items[0].StartedAt)
+	}
+}


### PR DESCRIPTION
## Summary

The transcript's per-tool hover meta (`timestamp · runtime`) was minted from the **browser's wall clock**, not the server — and revealing it could reflow row text. This wires real server-recorded times through (live + replay) instead of faking them, shows nothing when no real time exists, and makes the meta fixed-position so it can never cause reflow.

Closes #37

## Root cause

1. **Fake times.** `renderer.js` fell back to `new Date()` in `beginToolCall`/`finalizeToolCall` because the Go server never stamped `ThreadItem.startedAt/completedAt` for tool calls — even though the JSON fields and the JS forwarding (`toolTimingPayload` in `appwire.js`) already existed. Live rows showed "when the browser drew the row"; hydrating a past session stamped every historical row with page-load time.
2. **Reflow.** `.tool-meta` was a flex item (`order: 2; margin-left: auto`) that reserved width, grew when the runtime landed at tool end, and on compact phones toggled `display: none` → `display: inline` on tap — a guaranteed text reflow.

## Design choices

- **Wire server truth, don't delete the feature.** Server truth is genuinely available: `SessionEvent.Timestamp` on the live stream and `schema.Turn.Timestamp` on every transcript entry (assistant entry = call issued; tool-results entry = result landed).
- **Live path:** `internal/appprojector` stamps tool items from the event's own timestamp — `StartedAt` at start; `CompletedAt` + millisecond `DurationMS` (new `ThreadItem.DurationMS` field) at end, tracked via a `toolStartByKey` map. Zero timestamps mint no stamps (mirrors the existing `startedTurn` contract).
- **Replay path:** `internal/apptranscript.ProjectTurn` stamps `StartedAt` on assistant tool-call items and `CompletedAt` on tool-result items from the entry timestamp. `hubcore.ReplayTurn` now carries the timestamp through reload (the existing `FuzzHubReplayCarryThrough` oracle caught that it was dropped).
- **Never fake:** both client-clock fallbacks removed — no server time, no meta. A 0s runtime derived from second-precision replay stamps is omitted rather than shown as a fake "1ms"; explicit server `durationMs` is always shown.
- **No reflow:** `.tool-meta` is now `position: absolute`, fixed top-right of the row and out of the flex flow on every breakpoint; the phone `display:none↔inline` carve-out is gone. Reveal stays opacity-only (a11y tree preserved per the design system).
- `docs/web-ui/design-system.md` updated to document "server truth or nothing" and the fixed top-right layout.

## Test evidence

- New `jstest/test-tool-meta-timing.js` — RED first (`got "10:05:13 PM"` client wall clock when no server timing existed), now green; also pins the absolute-position/no-`display:none` layout contract.
- New Go tests: `TestAppEventProjectorStampsToolItemTiming`, `TestAppEventProjectorLeavesToolItemTimingUnsetWithoutClock` (RED: build failure, `DurationMS` undefined), `TestProjectTurnStampsToolItemTimestamps` (RED: `StartedAt=<nil>, want 1700000000`).
- Full jstest harness: `jstest: all tests passed`. `go test` ok for `appwire`, `internal/appprojector`, `internal/apptranscript`, `cmd/serf-hub` (+`internal/...`), `server`; build/vet/gofmt clean.
- Two pre-existing jstest assertions encoded the old layout mechanism (`margin-left: auto`, phone `display:none`); updated to the new contract, intent preserved.
