### PR TITLE
hub: parse each job-notification block per notification turn (fixes #36)

### DIFF
--- a/cmd/serf-hub/assets/renderer-format.js
+++ b/cmd/serf-hub/assets/renderer-format.js
@@ -331,6 +331,22 @@
     return "Job " + status;
   }
 
+  // splitJobNotificationBlocks extracts each individual
+  // <job-notification ...>...</job-notification> block from steering text. A
+  // notification turn can carry several blocks joined by newlines (the daemon
+  // drains every pending notification into one reminder), so the per-block
+  // match must be non-greedy: a greedy match spans from the first opening tag
+  // to the last closing tag and aggregates distinct notifications into one.
+  // Any text between/around blocks is returned separately as leftover.
+  function splitJobNotificationBlocks(text) {
+    const blocks = [];
+    const leftover = String(text || "").replace(/<job-notification\s+[^>]*>[\s\S]*?<\/job-notification>/g, (block) => {
+      blocks.push(block);
+      return "";
+    }).trim();
+    return { blocks, leftover };
+  }
+
   function parseJobNotification(stripped) {
     const m = String(stripped || "").match(/^<job-notification\s+([^>]*)>([\s\S]*)<\/job-notification>$/);
     if (!m) return null;
@@ -457,9 +473,18 @@
     if (/pre-compaction transcript/.test(stripped)) {
       return { kind: "transcript", label: "transcript pointer", detail: "", cleanText: stripped };
     }
-    const jobNotification = parseJobNotification(stripped);
-    if (jobNotification) {
-      return { kind: "notification", label: jobNotification.title, detail: "", cleanText: stripped, notification: jobNotification };
+    const jobBlocks = splitJobNotificationBlocks(stripped);
+    if (jobBlocks.blocks.length) {
+      const notifications = jobBlocks.blocks.map(parseJobNotification);
+      return {
+        kind: "notification",
+        label: notifications[0].title,
+        detail: "",
+        cleanText: stripped,
+        notification: notifications[0],
+        notifications,
+        leftover: jobBlocks.leftover,
+      };
     }
     const observerNotification = parseObserverCallback(stripped);
     if (observerNotification) {

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -4597,30 +4597,43 @@
       }
 
       if (summary.kind === "notification") {
-        this.appendNotificationCard(summary);
+        // A notification turn can carry several <job-notification> blocks;
+        // each one renders as its own card.
+        const notifications = summary.notifications || [summary.notification];
+        for (const n of notifications) {
+          this.appendNotificationCard({ notification: n, cleanText: (n && n.rawText) || summary.cleanText });
+        }
+        // Any text between/around the blocks is kept as a plain divider.
+        if (summary.leftover) {
+          this.appendSteeringDivider("steering injected", "", summary.leftover);
+        }
         return;
       }
 
       // Default: keep the existing collapsible divider for genuine system
       // notes (loop detection, read-only nudge, all-done, transcript
       // pointer, unknown).
+      this.appendSteeringDivider(summary.label, summary.detail, summary.cleanText || text);
+    },
+
+    appendSteeringDivider(label, detail, text) {
       const el = document.createElement("details");
       el.className = "steering";
       const sum = document.createElement("summary");
       const verb = document.createElement("span");
       verb.className = "steering-verb";
-      verb.textContent = "↻ " + summary.label;
+      verb.textContent = "↻ " + label;
       sum.appendChild(verb);
-      if (summary.detail) {
-        const detail = document.createElement("span");
-        detail.className = "steering-detail";
-        detail.textContent = " · " + summary.detail;
-        sum.appendChild(detail);
+      if (detail) {
+        const detailEl = document.createElement("span");
+        detailEl.className = "steering-detail";
+        detailEl.textContent = " · " + detail;
+        sum.appendChild(detailEl);
       }
       el.appendChild(sum);
       const body = document.createElement("pre");
       body.className = "steering-body";
-      body.textContent = summary.cleanText || text;
+      body.textContent = text;
       el.appendChild(body);
       this.conversation.appendChild(el);
     },

--- a/cmd/serf-hub/jstest/test-renderer-notifications.js
+++ b/cmd/serf-hub/jstest/test-renderer-notifications.js
@@ -400,6 +400,85 @@ ${JSON.stringify({ message: "x".repeat(8200), data: { status: "DONE", concerns: 
     return { ok: true };
   });
 
+  // Issue #36: a notification turn can carry several <job-notification> blocks
+  // joined by newlines (the daemon drains every pending notification into one
+  // reminder). Each block must parse and render individually — a greedy
+  // per-message match aggregates them into one notification.
+  const multiNotification = `<job-notification job_id="job_033sO5k8TeGZmH2lGJT6BK" event="watch" job_type="watch" status="watch" reason="output_match: jstest: all tests passed" output_bytes="0">
+Job job_033sO5k8TeGZmH2lGJT6BK watch. Output is available through read_transcript(transcript_ref="job:job_033sO5k8TeGZmH2lGJT6BK") if needed.
+</job-notification>
+<job-notification job_id="job_033sNxu2eUcKPnizpWBQER" event="completed" job_type="shell" status="completed" reason="exit_zero" output_bytes="85" exit_code="0">
+Job job_033sNxu2eUcKPnizpWBQER completed. Complete output below.
+excerpt:
+PASS: composer drafts are sticky per session (localStorage)
+jstest: all tests passed
+
+</job-notification>
+<job-notification job_id="job_033sO5k8TeGZmH2lGJT6BK" event="completed" job_type="shell" status="completed" reason="exit_zero" output_bytes="473" exit_code="0">
+Job job_033sO5k8TeGZmH2lGJT6BK completed. Complete output below.
+excerpt:
+PASS: composer drafts are sticky per session (localStorage)
+jstest: all tests passed
+990534ea hub: drafts guard against cross-session text leaks (#21)
+
+</job-notification>`;
+
+  parserScenario("multi-block notification turn parses each block individually", multiNotification, (summary) => {
+    if (!summary || summary.kind !== "notification") return { ok: false, detail: "not notification" };
+    const list = summary.notifications;
+    if (!Array.isArray(list) || list.length !== 3) return { ok: false, detail: "notifications length = " + (list && list.length) };
+    const expect = [
+      { job_id: "job_033sO5k8TeGZmH2lGJT6BK", event: "watch", status: "watch", tone: "warning" },
+      { job_id: "job_033sNxu2eUcKPnizpWBQER", event: "completed", status: "completed", tone: "success" },
+      { job_id: "job_033sO5k8TeGZmH2lGJT6BK", event: "completed", status: "completed", tone: "success" },
+    ];
+    for (let i = 0; i < expect.length; i++) {
+      const n = list[i];
+      for (const [key, value] of Object.entries(expect[i])) {
+        const actual = key === "tone" ? n.tone : (n.attrs && n.attrs[key]);
+        if (actual !== value) return { ok: false, detail: "block " + i + " " + key + " = " + actual };
+      }
+    }
+    // Each block keeps only its own raw text: the first block must not span
+    // into the third block's excerpt.
+    if (list[0].rawText.includes("990534ea")) return { ok: false, detail: "first block aggregated later blocks" };
+    if (!list[2].excerpt.includes("990534ea hub: drafts guard against cross-session text leaks (#21)")) {
+      return { ok: false, detail: "third block lost its own excerpt" };
+    }
+    return { ok: true };
+  });
+
+  await scenario("multi-block notification turn renders one card per block", multiNotification, (conv) => {
+    const cards = conv.querySelectorAll(".notification-card");
+    if (cards.length !== 3) return { ok: false, detail: "card count = " + cards.length };
+    const watchCards = conv.querySelectorAll('.notification-card-warning[data-job-id="job_033sO5k8TeGZmH2lGJT6BK"]');
+    if (watchCards.length !== 1) return { ok: false, detail: "watch card count = " + watchCards.length };
+    // A watch frame carrying a concrete job_id renders "Job watch" (only a
+    // job-less watch event titles "Watch triggered").
+    if (!expectText(watchCards[0], "Job watch")) return { ok: false, detail: "watch card missing title" };
+    if (!expectText(watchCards[0], "output_match: jstest: all tests passed")) return { ok: false, detail: "watch card missing trigger reason" };
+    const doneCards = conv.querySelectorAll('.notification-card-success[data-job-id="job_033sO5k8TeGZmH2lGJT6BK"]');
+    if (doneCards.length !== 1) return { ok: false, detail: "completed card count = " + doneCards.length };
+    if (!expectText(doneCards[0], "990534ea")) return { ok: false, detail: "completed card missing its excerpt" };
+    const other = conv.querySelector('.notification-card-success[data-job-id="job_033sNxu2eUcKPnizpWBQER"]');
+    if (!other) return { ok: false, detail: "missing card for job_033sNxu2eUcKPnizpWBQER" };
+    // Each card's raw disclosure shows only its own block.
+    const raw = cards[0].querySelector(".notification-card-raw pre");
+    if (!raw || raw.textContent.includes("990534ea")) return { ok: false, detail: "first card raw aggregated later blocks" };
+    return { ok: true };
+  });
+
+  await scenario("blocks parse individually with arbitrary text between and around them",
+    "lead-in note\n" + watchNotification + "\narbitrary middle text\n" + errorNotification + "\ntrailing note", (conv) => {
+      const cards = conv.querySelectorAll(".notification-card");
+      if (cards.length !== 2) return { ok: false, detail: "card count = " + cards.length };
+      if (!expectText(cards[0], "Watch triggered")) return { ok: false, detail: "first card is not the watch notification" };
+      if (!expectText(cards[1], "Job completed")) return { ok: false, detail: "second card is not the completion notification" };
+      // The interstitial text is preserved, not swallowed into a notification.
+      if (!conv.textContent.includes("arbitrary middle text")) return { ok: false, detail: "interstitial text was lost" };
+      return { ok: true };
+    });
+
   if (!allPass) process.exit(1);
   console.log("PASS: notification renderer assertions");
   process.exit(0); // renderer pollers keep the event loop alive otherwise


### PR DESCRIPTION
## Summary

A job-notification turn drains every pending notification into one steering reminder whose `<job-notification>` blocks are joined by newlines (`formatJobNotificationReminder`). The hub renderer parsed that message with the anchored greedy regex `/^<job-notification\s+([^>]*)>([\s\S]*)<\/job-notification>$/`, which matched from the **first** opening tag to the **last** closing tag — aggregating distinct notifications into a single card with the first block's metadata and a body spanning all of them (#36).

## Root cause

`parseJobNotification` in `cmd/serf-hub/assets/renderer-format.js` assumed exactly one block per steering message. Multi-block reminders are legitimate producer behavior, so the consumer's greedy match was the defect.

## Design

- New `splitJobNotificationBlocks(text)`: extracts each block with a global **non-greedy** per-block match (consistent with the file's existing `([\s\S]*?)` patterns) and returns any text between/around blocks as `leftover`. Safe because the daemon HTML-escapes `<`/`&`/`>` inside excerpts, so a literal `</job-notification>` never appears inside a block body.
- `classifySteering` parses **each block individually** through the unchanged single-block `parseJobNotification` and returns `notifications[]` + `leftover` (keeping `notification`/`cleanText` for backward compatibility; single-block behavior is byte-identical).
- `appendSteeringMessage` renders **one card per block** (each with its own `data-job-id` rail tie) and preserves leftover text as the existing generic steering divider, so arbitrary text around blocks is neither swallowed nor fatal.

## Test evidence (TDD)

- RED: three new scenarios in `cmd/serf-hub/jstest/test-renderer-notifications.js` using the issue's exact 3-block example (watch + two completions across two job ids) failed pre-fix — aggregated into one notification; the arbitrary-text case rendered 0 cards.
- GREEN: `node test-renderer-notifications.js` — 28/28 scenarios PASS (rc=0).
- Full suite: `sh cmd/serf-hub/jstest/run-all.sh` — **jstest: all tests passed** (also re-run green on the rebased branch).

Closes #36