### PR TITLE
webui: edit or cancel an unconsumed queued message (fixes #23)

### DIFF
--- a/agent/agent_misc_program_fuzz_test.go
+++ b/agent/agent_misc_program_fuzz_test.go
@@ -148,19 +148,19 @@ func miscContinuationAndCounterProgram(t *testing.T) {
 		t.Fatal("missing live model changed profile")
 	}
 
-	counter := newTreeCounter(0)
-	for i := int64(0); i < counter.cap; i++ {
-		if !counter.reserve() {
+	counter := newTreeCounter(2)
+	for i := int64(0); i < 2; i++ {
+		if !counter.reserve(slotKindJob) {
 			t.Fatalf("reservation %d rejected", i)
 		}
 	}
-	if counter.reserve() {
+	if counter.reserve(slotKindJob) {
 		t.Fatal("counter exceeded capacity")
 	}
 	for counter.n.Load() > 0 {
-		counter.release()
+		counter.releaseKind(slotKindJob)
 	}
-	if slot, ok := (&Session{}).reserveTreeSlot(); !ok || slot != nil {
+	if slot, ok := (&Session{}).reserveTreeSlot(slotKindJob); !ok || slot != nil {
 		t.Fatalf("unbounded reservation = %#v, %v", slot, ok)
 	}
 	releasePreparedTreeSlot(nil)

--- a/agent/agent_misc_program_fuzz_test.go
+++ b/agent/agent_misc_program_fuzz_test.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -25,6 +26,7 @@ import (
 	"primeradiant.com/serf/agent/schema"
 	"primeradiant.com/serf/agent/skill"
 	taskpkg "primeradiant.com/serf/agent/task"
+	"primeradiant.com/serf/identifier"
 	"primeradiant.com/serf/llm"
 )
 
@@ -149,18 +151,18 @@ func miscContinuationAndCounterProgram(t *testing.T) {
 	}
 
 	counter := newTreeCounter(0)
-	for i := int64(0); i < counter.cap; i++ {
-		if !counter.reserve() {
+	for i := int64(0); i < counter.limit; i++ {
+		if !counter.reserve(slotKindJob) {
 			t.Fatalf("reservation %d rejected", i)
 		}
 	}
-	if counter.reserve() {
+	if counter.reserve(slotKindJob) {
 		t.Fatal("counter exceeded capacity")
 	}
 	for counter.n.Load() > 0 {
-		counter.release()
+		counter.releaseKind(slotKindJob)
 	}
-	if slot, ok := (&Session{}).reserveTreeSlot(); !ok || slot != nil {
+	if slot, ok := (&Session{}).reserveTreeSlot(slotKindJob); !ok || slot != nil {
 		t.Fatalf("unbounded reservation = %#v, %v", slot, ok)
 	}
 	releasePreparedTreeSlot(nil)
@@ -227,13 +229,27 @@ func miscStatusAndPersistenceProgram(t *testing.T, token string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// The grants path validates session ids (identifier.ValidateSessionID), so
+	// the fixture must mint real ones — human-readable stand-ins are skipped.
+	workerID, err := identifier.NewSessionID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	observerA, err := identifier.NewSessionID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	observerB, err := identifier.NewSessionID()
+	if err != nil {
+		t.Fatal(err)
+	}
 	events := []jobstore.Event{
 		{Kind: jobstore.EventJobStarted, JobID: "good", Type: jobstore.JobDelegate},
-		{Kind: jobstore.EventJobSessionAssigned, JobID: "good", TranscriptRef: encodeRef("", "worker")},
-		{Kind: jobstore.EventWatchReadGrant, JobID: "good", ObserverSessionID: "observer-b"},
-		{Kind: jobstore.EventWatchReadGrant, JobID: "good", ObserverSessionID: "observer-a"},
+		{Kind: jobstore.EventJobSessionAssigned, JobID: "good", TranscriptRef: encodeRef("", workerID)},
+		{Kind: jobstore.EventWatchReadGrant, JobID: "good", ObserverSessionID: observerB},
+		{Kind: jobstore.EventWatchReadGrant, JobID: "good", ObserverSessionID: observerA},
 		{Kind: jobstore.EventJobStarted, JobID: "shell", Type: jobstore.JobShell},
-		{Kind: jobstore.EventWatchReadGrant, JobID: "shell", ObserverSessionID: "ignored"},
+		{Kind: jobstore.EventWatchReadGrant, JobID: "shell", ObserverSessionID: observerA},
 	}
 	if err := store.AppendBatch(events); err != nil {
 		t.Fatal(err)
@@ -246,7 +262,9 @@ func miscStatusAndPersistenceProgram(t *testing.T, token string) {
 		t.Fatalf("historical records = %#v, %v", records, err)
 	}
 	grants, err := LoadSessionObserverGrants(dir, "valid")
-	if err != nil || strings.Join(grants["worker"], ",") != "observer-a,observer-b" {
+	wantObservers := []string{observerA, observerB}
+	sort.Strings(wantObservers)
+	if err != nil || strings.Join(grants[workerID], ",") != strings.Join(wantObservers, ",") {
 		t.Fatalf("observer grants = %#v, %v", grants, err)
 	}
 

--- a/agent/events/payloads.go
+++ b/agent/events/payloads.go
@@ -181,11 +181,16 @@ type SteeringInjectedData struct {
 // the head at index 0 and have been collapsed to a single line. IDs is
 // FIFO-aligned with Preview and carries each entry's stable queue-entry id
 // (minted at enqueue time) so a client can promote a specific entry by
-// identity rather than by bare index (review F1, issue #22).
+// identity rather than by bare index (review F1, issue #22). Texts is
+// FIFO-aligned with Preview and carries each entry's FULL untruncated text
+// so the edit affordance (issue #23) can restore the complete message into
+// the composer — the preview line alone would silently truncate multi-line
+// messages.
 type QueueChangedData struct {
 	Depth   int      `json:"depth"`
 	Preview []string `json:"preview,omitempty"`
 	IDs     []string `json:"ids,omitempty"`
+	Texts   []string `json:"texts,omitempty"`
 }
 
 // TaskUpdatedData is the payload for an EventTaskUpdated event: the current

--- a/agent/events/payloads.go
+++ b/agent/events/payloads.go
@@ -178,10 +178,14 @@ type SteeringInjectedData struct {
 
 // QueueChangedData carries an authoritative snapshot of the per-session
 // input queue after a mutation (kata r80p). Preview entries are FIFO with
-// the head at index 0 and have been collapsed to a single line.
+// the head at index 0 and have been collapsed to a single line. IDs is
+// FIFO-aligned with Preview and carries each entry's stable queue-entry id
+// (minted at enqueue time) so a client can promote a specific entry by
+// identity rather than by bare index (review F1, issue #22).
 type QueueChangedData struct {
 	Depth   int      `json:"depth"`
 	Preview []string `json:"preview,omitempty"`
+	IDs     []string `json:"ids,omitempty"`
 }
 
 // TaskUpdatedData is the payload for an EventTaskUpdated event: the current

--- a/agent/job_delegate_exact_running_attach_fuzz_test.go
+++ b/agent/job_delegate_exact_running_attach_fuzz_test.go
@@ -188,7 +188,7 @@ func jdraAttachWrapper(t *testing.T, prepared bool) {
 	var run *runningJob
 	var err error
 	if prepared {
-		slot, ok := p.reserveTreeSlot()
+		slot, ok := p.reserveTreeSlot(slotKindJob)
 		if !ok {
 			t.Fatal("reserve prepared slot")
 		}

--- a/agent/jobs_seed100_fuzz_test.go
+++ b/agent/jobs_seed100_fuzz_test.go
@@ -201,7 +201,7 @@ func seed100Nested(t *testing.T) {
 	if owner, rec := root.ownerJobManagerFor(forwarded.JobID); owner != child.jobManager || rec == nil {
 		t.Fatalf("nested owner = %p, %+v", owner, rec)
 	}
-	if jobs, err := root.walkDescendantJobs(listFilter{Limit: 1}); err != nil || len(jobs) != 1 {
+	if jobs, _, err := root.walkDescendantJobs(listFilter{Limit: 1}); err != nil || len(jobs) != 1 {
 		t.Fatalf("descendant walk = %v, %v", jobs, err)
 	}
 	_, _, _, _, _ = root.resolveDescendantJobOwner(forwarded.JobID)

--- a/agent/jobs_seed100_range_a_test.go
+++ b/agent/jobs_seed100_range_a_test.go
@@ -79,7 +79,7 @@ func seed100JobsRangeA(t *testing.T) {
 			durableStarted: true,
 		}
 	}
-	jobs, err := listed.listWithError(listFilter{Limit: 1})
+	jobs, _, err := listed.listWithError(listFilter{Limit: 1})
 	if err != nil {
 		t.Fatalf("listWithError: %v", err)
 	}

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -362,6 +362,48 @@ func (s *Session) PromoteQueuedAsSteer(ctx context.Context, index int, expectedI
 	return nil
 }
 
+// CancelQueued removes the single queued message at index so it is never
+// consumed (issue #23 per-message cancel; also the removal half of the web
+// UI's edit-as-cancel-and-recompose action). Other queued messages stay
+// queued in FIFO order. Unlike PromoteQueuedAsSteer, cancel does NOT
+// require an in-flight turn: a queued entry is cancellable whenever it is
+// still queued, including entries buffered on an idle session. When
+// expectedID is non-empty it must match the id of the entry currently at
+// index — the queue head can be consumed mid-turn, so a bare index captured
+// from an earlier snapshot may otherwise resolve to the wrong message
+// (review F1). On success it returns the removed entry's full untruncated
+// text and image count so the caller can restore the text into a composer
+// (edit) and warn about dropped attachments. It returns an error — leaving
+// the queue untouched — when the session is closed, index is out of range,
+// or the id mismatches, so a failed cancel never silently removes the wrong
+// follow-up.
+func (s *Session) CancelQueued(ctx context.Context, index int, expectedID string) (string, int, error) {
+	if err := ctx.Err(); err != nil {
+		return "", 0, err
+	}
+	s.queueEventsMu.Lock()
+	defer s.queueEventsMu.Unlock()
+	s.mu.Lock()
+	if s.closingOrClosedLocked() {
+		s.mu.Unlock()
+		return "", 0, errors.New("cancel: session is closed")
+	}
+	if index < 0 || index >= len(s.inputQueue) {
+		s.mu.Unlock()
+		return "", 0, fmt.Errorf("cancel: queue index %d out of range (depth %d)", index, len(s.inputQueue))
+	}
+	entry := s.inputQueue[index]
+	if expectedID != "" && entry.ID != expectedID {
+		s.mu.Unlock()
+		return "", 0, fmt.Errorf("cancel: queue entry at index %d no longer matches the snapshot (queue changed)", index)
+	}
+	s.inputQueue = append(s.inputQueue[:index], s.inputQueue[index+1:]...)
+	data := s.queueChangedDataLocked()
+	s.mu.Unlock()
+	s.emit(events.EventQueueChanged, data)
+	return entry.Text, len(entry.Images), nil
+}
+
 // QueueDepth returns the number of messages currently in the input queue.
 func (s *Session) QueueDepth() int {
 	s.mu.Lock()
@@ -465,6 +507,24 @@ func (s *Session) QueueIDs() []string {
 	return out
 }
 
+// QueueTexts returns the full untruncated text of the queued messages in
+// FIFO order, aligned with QueuePreview and QueueIDs. It backs the edit
+// affordance (issue #23): the client restores the full text into the
+// composer before asking the daemon to remove the entry, so the text is
+// never lost when the removal loses a race against consumption.
+func (s *Session) QueueTexts() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.inputQueue) == 0 {
+		return nil
+	}
+	out := make([]string, len(s.inputQueue))
+	for i, entry := range s.inputQueue {
+		out[i] = entry.Text
+	}
+	return out
+}
+
 // queueChangedDataLocked builds a QueueChangedData snapshot from the
 // current inputQueue. The caller must hold s.mu.
 func (s *Session) queueChangedDataLocked() events.QueueChangedData {
@@ -472,9 +532,11 @@ func (s *Session) queueChangedDataLocked() events.QueueChangedData {
 	if len(s.inputQueue) > 0 {
 		data.Preview = make([]string, len(s.inputQueue))
 		data.IDs = make([]string, len(s.inputQueue))
+		data.Texts = make([]string, len(s.inputQueue))
 		for i, entry := range s.inputQueue {
 			data.Preview[i] = queuedEntryPreviewLine(entry)
 			data.IDs[i] = entry.ID
+			data.Texts[i] = entry.Text
 		}
 	}
 	return data

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -2,9 +2,12 @@ package agent
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 
 	"primeradiant.com/serf/agent/events"
 	"primeradiant.com/serf/agent/internal/diagnostic"
@@ -186,10 +189,26 @@ func (s *Session) FollowUp(msg string) {
 // are forwarded together when the entry is drained as a fresh user turn.
 // Provenance carries the causal watch origin (nil for human-typed input) so a
 // DrainAsSteer collapse can fold it into the steering message it injects.
+// ID is a stable per-entry identifier minted at enqueue time; it rides the
+// queue snapshot so a promote-by-index request can verify the entry it meant
+// is still the entry at that index (review F1, issue #22).
 type queuedInput struct {
+	ID         string
 	Text       string
 	Images     []ImageAttachment
 	Provenance *provenance.Causal
+}
+
+// queueEntrySeq guarantees queue-entry id uniqueness by construction,
+// mirroring escalationSeq: a process-monotonic counter plus a random suffix.
+var queueEntrySeq atomic.Uint64
+
+// newQueueEntryID mints a unique opaque handle for one queued input entry.
+func newQueueEntryID() string {
+	seq := queueEntrySeq.Add(1)
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	return fmt.Sprintf("q_%d_%s", seq, hex.EncodeToString(b[:]))
 }
 
 // Enqueue appends a text-only user message to the per-session input queue
@@ -221,7 +240,7 @@ func (s *Session) EnqueueWithImages(ctx context.Context, text string, images []I
 		s.mu.Unlock()
 		return errors.New("queue: session is closed")
 	}
-	entry := queuedInput{Text: text}
+	entry := queuedInput{ID: newQueueEntryID(), Text: text}
 	if len(images) > 0 {
 		entry.Images = append([]ImageAttachment(nil), images...)
 	}
@@ -262,7 +281,7 @@ func (s *Session) DrainAsSteerWithInput(ctx context.Context, text string, images
 		return errors.New("drain: no active turn to steer")
 	}
 	if strings.TrimSpace(text) != "" || len(images) > 0 {
-		entry := queuedInput{Text: text}
+		entry := queuedInput{ID: newQueueEntryID(), Text: text}
 		if len(images) > 0 {
 			entry.Images = append([]ImageAttachment(nil), images...)
 		}
@@ -301,10 +320,14 @@ func (s *Session) DrainAsSteerWithInput(ctx context.Context, text string, images
 // DrainAsSteer). Other queued messages stay queued in FIFO order. The
 // steering entry keeps the queued message's images and causal provenance,
 // and is marked Source "user" so UIs render it as user speech rather than a
-// system steering divider (issue #24). Returns an error — leaving the queue
-// untouched — when the session is closed, no turn is in flight, or index is
-// out of range, so a failed promote never silently loses the follow-up.
-func (s *Session) PromoteQueuedAsSteer(ctx context.Context, index int) error {
+// system steering divider (issue #24). When expectedID is non-empty it must
+// match the id of the entry currently at index — the queue head can be
+// consumed mid-turn, so a bare index captured from an earlier snapshot may
+// otherwise resolve to the wrong message (review F1). Returns an error —
+// leaving the queue untouched — when the session is closed, no turn is in
+// flight, index is out of range, or the id mismatches, so a failed promote
+// never silently loses or swaps the follow-up.
+func (s *Session) PromoteQueuedAsSteer(ctx context.Context, index int, expectedID string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -324,6 +347,10 @@ func (s *Session) PromoteQueuedAsSteer(ctx context.Context, index int) error {
 		return fmt.Errorf("promote: queue index %d out of range (depth %d)", index, len(s.inputQueue))
 	}
 	entry := s.inputQueue[index]
+	if expectedID != "" && entry.ID != expectedID {
+		s.mu.Unlock()
+		return fmt.Errorf("promote: queue entry at index %d no longer matches the snapshot (queue changed)", index)
+	}
 	s.inputQueue = append(s.inputQueue[:index], s.inputQueue[index+1:]...)
 	data := s.queueChangedDataLocked()
 	s.mu.Unlock()
@@ -420,14 +447,34 @@ func (s *Session) pushQueueHead(entry queuedInput) {
 	s.emit(events.EventQueueChanged, data)
 }
 
+// QueueIDs returns the stable per-entry ids of the queued messages in FIFO
+// order, aligned with QueuePreview. Callers promoting a queued message by
+// index should read the id from the same snapshot and pass it back as the
+// expected identity so a shifted queue is rejected instead of promoting the
+// wrong entry (review F1, issue #22).
+func (s *Session) QueueIDs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.inputQueue) == 0 {
+		return nil
+	}
+	out := make([]string, len(s.inputQueue))
+	for i, entry := range s.inputQueue {
+		out[i] = entry.ID
+	}
+	return out
+}
+
 // queueChangedDataLocked builds a QueueChangedData snapshot from the
 // current inputQueue. The caller must hold s.mu.
 func (s *Session) queueChangedDataLocked() events.QueueChangedData {
 	data := events.QueueChangedData{Depth: len(s.inputQueue)}
 	if len(s.inputQueue) > 0 {
 		data.Preview = make([]string, len(s.inputQueue))
+		data.IDs = make([]string, len(s.inputQueue))
 		for i, entry := range s.inputQueue {
 			data.Preview[i] = queuedEntryPreviewLine(entry)
+			data.IDs[i] = entry.ID
 		}
 	}
 	return data

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -295,6 +295,46 @@ func (s *Session) DrainAsSteerWithInput(ctx context.Context, text string, images
 	return nil
 }
 
+// PromoteQueuedAsSteer removes the single queued message at index and
+// injects it as a user-sourced STEERING message into the in-flight turn
+// (issue #22 per-message promote; the single-message counterpart of
+// DrainAsSteer). Other queued messages stay queued in FIFO order. The
+// steering entry keeps the queued message's images and causal provenance,
+// and is marked Source "user" so UIs render it as user speech rather than a
+// system steering divider (issue #24). Returns an error — leaving the queue
+// untouched — when the session is closed, no turn is in flight, or index is
+// out of range, so a failed promote never silently loses the follow-up.
+func (s *Session) PromoteQueuedAsSteer(ctx context.Context, index int) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.queueEventsMu.Lock()
+	defer s.queueEventsMu.Unlock()
+	s.mu.Lock()
+	if s.closingOrClosedLocked() {
+		s.mu.Unlock()
+		return errors.New("promote: session is closed")
+	}
+	if s.state != SessionProcessing {
+		s.mu.Unlock()
+		return errors.New("promote: no active turn to steer")
+	}
+	if index < 0 || index >= len(s.inputQueue) {
+		s.mu.Unlock()
+		return fmt.Errorf("promote: queue index %d out of range (depth %d)", index, len(s.inputQueue))
+	}
+	entry := s.inputQueue[index]
+	s.inputQueue = append(s.inputQueue[:index], s.inputQueue[index+1:]...)
+	data := s.queueChangedDataLocked()
+	s.mu.Unlock()
+	s.emit(events.EventQueueChanged, data)
+	// The promoted entry is user-typed input steered into the in-flight turn
+	// by a user action, so it keeps user provenance for rendering — same as
+	// the DrainAsSteer collapse (issue #24).
+	s.trySteerEnqueue(entry.Text, entry.Images, entry.Provenance, events.SteeringSourceUser)
+	return nil
+}
+
 // QueueDepth returns the number of messages currently in the input queue.
 func (s *Session) QueueDepth() int {
 	s.mu.Lock()

--- a/agent/session_queue_cancel_test.go
+++ b/agent/session_queue_cancel_test.go
@@ -1,0 +1,227 @@
+package agent
+
+// Tests for Session.CancelQueued (issue #23): an unconsumed queued
+// follow-up can be removed from the FIFO input queue so it is never
+// consumed. The primitive returns the removed entry's full text and image
+// count so the caller (the web UI's edit action) can restore the text into
+// the composer and warn about dropped attachments. Like promote (issue
+// #22, review F1), a non-empty expectedID must match the entry at index so
+// a queue that shifted under the client's snapshot is rejected instead of
+// removing the wrong message. Unlike promote, cancel does NOT require an
+// active turn: a queued entry is cancellable whenever it is still queued,
+// including entries buffered on an idle session.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"primeradiant.com/serf/agent/events"
+)
+
+func TestSession_CancelQueued_RemovesOnlyThatEntry(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	for _, msg := range []string{"alpha", "bravo", "charlie"} {
+		if err := sess.Enqueue(context.Background(), msg); err != nil {
+			t.Fatalf("Enqueue %s: %v", msg, err)
+		}
+	}
+	markProcessing(sess)
+
+	text, images, err := sess.CancelQueued(context.Background(), 1, "")
+	if err != nil {
+		t.Fatalf("CancelQueued: %v", err)
+	}
+	if text != "bravo" || images != 0 {
+		t.Fatalf("CancelQueued returned (%q, %d), want (bravo, 0)", text, images)
+	}
+
+	// The other queued messages stay queued, in order.
+	preview := sess.QueuePreview()
+	if len(preview) != 2 || preview[0] != "alpha" || preview[1] != "charlie" {
+		t.Fatalf("QueuePreview after cancel: got %#v, want [alpha charlie]", preview)
+	}
+	texts := sess.QueueTexts()
+	if len(texts) != 2 || texts[0] != "alpha" || texts[1] != "charlie" {
+		t.Fatalf("QueueTexts after cancel: got %#v, want [alpha charlie]", texts)
+	}
+}
+
+func TestSession_CancelQueued_WorksWhileIdle(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	if err := sess.Enqueue(context.Background(), "buffered on idle session"); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	// No turn in flight: cancel is still valid — unlike promote, nothing
+	// about removal needs an in-flight turn to inject into.
+	text, _, err := sess.CancelQueued(context.Background(), 0, "")
+	if err != nil {
+		t.Fatalf("CancelQueued idle: %v", err)
+	}
+	if text != "buffered on idle session" {
+		t.Fatalf("CancelQueued returned %q, want the queued text", text)
+	}
+	if depth := sess.QueueDepth(); depth != 0 {
+		t.Fatalf("QueueDepth after cancel: got %d, want 0", depth)
+	}
+}
+
+func TestSession_CancelQueued_ReturnsFullMultilineText(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	full := "first line\nsecond line\nthird line"
+	if err := sess.Enqueue(context.Background(), full); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	text, _, err := sess.CancelQueued(context.Background(), 0, "")
+	if err != nil {
+		t.Fatalf("CancelQueued: %v", err)
+	}
+	if text != full {
+		t.Fatalf("CancelQueued text = %q, want the full untruncated message %q", text, full)
+	}
+}
+
+func TestSession_CancelQueued_ReportsImageCount(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	images := []ImageAttachment{
+		{MediaType: "image/png", Data: []byte{1, 2, 3}, Name: "a.png"},
+		{MediaType: "image/png", Data: []byte{4, 5, 6}, Name: "b.png"},
+	}
+	if err := sess.EnqueueWithImages(context.Background(), "look at these", images); err != nil {
+		t.Fatalf("EnqueueWithImages: %v", err)
+	}
+	text, n, err := sess.CancelQueued(context.Background(), 0, "")
+	if err != nil {
+		t.Fatalf("CancelQueued: %v", err)
+	}
+	if text != "look at these" || n != 2 {
+		t.Fatalf("CancelQueued returned (%q, %d), want (look at these, 2)", text, n)
+	}
+}
+
+func TestSession_CancelQueued_EmitsQueueChangedWithTexts(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	for _, msg := range []string{"alpha", "bravo"} {
+		if err := sess.Enqueue(context.Background(), msg); err != nil {
+			t.Fatalf("Enqueue %s: %v", msg, err)
+		}
+	}
+	if _, _, err := sess.CancelQueued(context.Background(), 0, ""); err != nil {
+		t.Fatalf("CancelQueued: %v", err)
+	}
+	sess.Close()
+
+	var last *events.QueueChangedData
+	for ev := range sess.Events() {
+		if d, ok := ev.Data.(events.QueueChangedData); ok {
+			d := d
+			last = &d
+		}
+	}
+	if last == nil {
+		t.Fatal("expected at least one QueueChanged event")
+	}
+	if last.Depth != 1 {
+		t.Fatalf("QueueChanged depth = %d, want 1", last.Depth)
+	}
+	if len(last.Texts) != 1 || last.Texts[0] != "bravo" {
+		t.Fatalf("QueueChanged Texts = %#v, want [bravo] (full text, FIFO-aligned with Preview)", last.Texts)
+	}
+	if len(last.IDs) != 1 || last.IDs[0] == "" {
+		t.Fatalf("QueueChanged IDs = %#v, want one non-empty id", last.IDs)
+	}
+}
+
+func TestSession_CancelQueued_IndexOutOfRange(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	if err := sess.Enqueue(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, _, err := sess.CancelQueued(context.Background(), 5, ""); err == nil {
+		t.Fatal("CancelQueued out-of-range: expected error, got nil")
+	}
+	if _, _, err := sess.CancelQueued(context.Background(), -1, ""); err == nil {
+		t.Fatal("CancelQueued negative index: expected error, got nil")
+	}
+	if preview := sess.QueuePreview(); len(preview) != 1 || preview[0] != "alpha" {
+		t.Fatalf("QueuePreview after rejected cancel: got %#v, want [alpha]", preview)
+	}
+}
+
+func TestSession_CancelQueued_ExpectedIDMismatchLeavesQueueIntact(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	for _, msg := range []string{"alpha", "bravo"} {
+		if err := sess.Enqueue(context.Background(), msg); err != nil {
+			t.Fatalf("Enqueue %s: %v", msg, err)
+		}
+	}
+	ids := sess.QueueIDs()
+	if len(ids) != 2 {
+		t.Fatalf("QueueIDs = %#v, want 2 ids", ids)
+	}
+	// Review F1 shape: the id belongs to the OTHER entry (a stale snapshot
+	// after the queue shifted). The cancel must fail and remove nothing.
+	_, _, err := sess.CancelQueued(context.Background(), 0, ids[1])
+	if err == nil || !strings.Contains(err.Error(), "no longer matches") {
+		t.Fatalf("CancelQueued mismatch err=%v, want 'no longer matches'", err)
+	}
+	if preview := sess.QueuePreview(); len(preview) != 2 {
+		t.Fatalf("QueuePreview after mismatch: got %#v, want both entries intact", preview)
+	}
+}
+
+func TestSession_CancelQueued_MatchingExpectedIDSucceeds(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	for _, msg := range []string{"alpha", "bravo"} {
+		if err := sess.Enqueue(context.Background(), msg); err != nil {
+			t.Fatalf("Enqueue %s: %v", msg, err)
+		}
+	}
+	ids := sess.QueueIDs()
+	text, _, err := sess.CancelQueued(context.Background(), 1, ids[1])
+	if err != nil {
+		t.Fatalf("CancelQueued: %v", err)
+	}
+	if text != "bravo" {
+		t.Fatalf("CancelQueued text = %q, want bravo", text)
+	}
+	if preview := sess.QueuePreview(); len(preview) != 1 || preview[0] != "alpha" {
+		t.Fatalf("QueuePreview after cancel: got %#v, want [alpha]", preview)
+	}
+}
+
+func TestSession_CancelQueued_ClosedSession(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	if err := sess.Enqueue(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	sess.Close()
+	if _, _, err := sess.CancelQueued(context.Background(), 0, ""); err == nil {
+		t.Fatal("CancelQueued on closed session: expected error, got nil")
+	}
+}
+
+func TestSession_CancelQueued_CanceledContext(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	if err := sess.Enqueue(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, _, err := sess.CancelQueued(ctx, 0, ""); err == nil {
+		t.Fatal("CancelQueued with canceled ctx: expected error, got nil")
+	}
+	if depth := sess.QueueDepth(); depth != 1 {
+		t.Fatalf("QueueDepth after ctx-canceled cancel: got %d, want 1", depth)
+	}
+}

--- a/agent/session_queue_promote_test.go
+++ b/agent/session_queue_promote_test.go
@@ -1,0 +1,173 @@
+package agent
+
+// Tests for Session.PromoteQueuedAsSteer (issue #22): a single queued
+// follow-up can be promoted to a steering injection on the in-flight turn.
+// The promoted entry leaves the FIFO queue (other entries keep their order)
+// and lands on the steering queue marked Source="user" so UIs render it as
+// user speech, exactly like a DrainAsSteer collapse (issue #24).
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"primeradiant.com/serf/agent/events"
+	"primeradiant.com/serf/agent/execenv"
+	"primeradiant.com/serf/llm"
+)
+
+func newPromoteTestSession(t *testing.T) *Session {
+	t.Helper()
+	dir := t.TempDir()
+	c := llm.NewClient()
+	c.Register(&fakeAdapter{name: "openai"})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	t.Cleanup(func() { sess.Close() })
+	return sess
+}
+
+func markProcessing(sess *Session) {
+	sess.mu.Lock()
+	sess.state = SessionProcessing
+	sess.mu.Unlock()
+}
+
+func TestSession_PromoteQueuedAsSteer_RemovesOnlyThatEntry(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	for _, msg := range []string{"alpha", "bravo", "charlie"} {
+		if err := sess.Enqueue(context.Background(), msg); err != nil {
+			t.Fatalf("Enqueue %s: %v", msg, err)
+		}
+	}
+	markProcessing(sess)
+
+	if err := sess.PromoteQueuedAsSteer(context.Background(), 1); err != nil {
+		t.Fatalf("PromoteQueuedAsSteer: %v", err)
+	}
+
+	// The other queued messages stay queued, in order.
+	preview := sess.QueuePreview()
+	if len(preview) != 2 || preview[0] != "alpha" || preview[1] != "charlie" {
+		t.Fatalf("QueuePreview after promote: got %#v, want [alpha charlie]", preview)
+	}
+
+	// The promoted message — and only it — lands on the steering queue.
+	sess.mu.Lock()
+	var steering []string
+	for _, m := range sess.steeringQueue {
+		steering = append(steering, m.Text)
+	}
+	sess.mu.Unlock()
+	if len(steering) != 1 || steering[0] != "bravo" {
+		t.Fatalf("steeringQueue after promote: got %#v, want [bravo]", steering)
+	}
+}
+
+func TestSession_PromoteQueuedAsSteer_MarksUserSource(t *testing.T) {
+	t.Parallel()
+	s := &Session{state: SessionProcessing}
+	if err := s.Enqueue(context.Background(), "human queued text"); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if err := s.PromoteQueuedAsSteer(context.Background(), 0); err != nil {
+		t.Fatalf("PromoteQueuedAsSteer: %v", err)
+	}
+	got := s.drainSteeringForTurn()
+	if len(got) != 1 {
+		t.Fatalf("drained = %d, want 1", len(got))
+	}
+	if got[0].Source != events.SteeringSourceUser {
+		t.Fatalf("drained steering Source = %q, want %q", got[0].Source, events.SteeringSourceUser)
+	}
+	if got[0].Text != "human queued text" {
+		t.Fatalf("drained steering Text = %q, want %q", got[0].Text, "human queued text")
+	}
+}
+
+func TestSession_PromoteQueuedAsSteer_RejectsIdleWithoutMutatingQueue(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	if err := sess.Enqueue(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	// No turn in flight: the promote must fail honestly and leave the queued
+	// message in place so it is still processed as a normal follow-up.
+	err := sess.PromoteQueuedAsSteer(context.Background(), 0)
+	if err == nil || !strings.Contains(err.Error(), "no active turn") {
+		t.Fatalf("PromoteQueuedAsSteer idle err=%v, want no active turn", err)
+	}
+	if preview := sess.QueuePreview(); len(preview) != 1 || preview[0] != "alpha" {
+		t.Fatalf("QueuePreview after rejected promote: got %#v, want [alpha]", preview)
+	}
+	sess.mu.Lock()
+	steeringDepth := len(sess.steeringQueue)
+	sess.mu.Unlock()
+	if steeringDepth != 0 {
+		t.Fatalf("steeringQueue after rejected promote: got %d, want 0", steeringDepth)
+	}
+}
+
+func TestSession_PromoteQueuedAsSteer_IndexOutOfRange(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	if err := sess.Enqueue(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	markProcessing(sess)
+	for _, idx := range []int{-1, 1, 42} {
+		err := sess.PromoteQueuedAsSteer(context.Background(), idx)
+		if err == nil || !strings.Contains(err.Error(), "out of range") {
+			t.Fatalf("PromoteQueuedAsSteer(%d) err=%v, want out of range", idx, err)
+		}
+	}
+	if preview := sess.QueuePreview(); len(preview) != 1 || preview[0] != "alpha" {
+		t.Fatalf("QueuePreview after out-of-range promotes: got %#v, want [alpha]", preview)
+	}
+}
+
+func TestSession_PromoteQueuedAsSteer_EmitsQueueChanged(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	if err := sess.Enqueue(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Enqueue alpha: %v", err)
+	}
+	if err := sess.Enqueue(context.Background(), "bravo"); err != nil {
+		t.Fatalf("Enqueue bravo: %v", err)
+	}
+	markProcessing(sess)
+	if err := sess.PromoteQueuedAsSteer(context.Background(), 0); err != nil {
+		t.Fatalf("PromoteQueuedAsSteer: %v", err)
+	}
+	sess.Close()
+
+	var last *events.QueueChangedData
+	for ev := range sess.Events() {
+		if d, ok := ev.Data.(events.QueueChangedData); ok {
+			d := d
+			last = &d
+		}
+	}
+	if last == nil {
+		t.Fatal("expected at least one QueueChanged event")
+	}
+	if last.Depth != 1 || len(last.Preview) != 1 || last.Preview[0] != "bravo" {
+		t.Fatalf("final QueueChanged = %+v, want depth 1 preview [bravo]", *last)
+	}
+}
+
+func TestSession_PromoteQueuedAsSteer_ClosedSession(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	if err := sess.Enqueue(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	sess.Close()
+	err := sess.PromoteQueuedAsSteer(context.Background(), 0)
+	if err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("PromoteQueuedAsSteer closed err=%v, want closed", err)
+	}
+}

--- a/agent/session_queue_promote_test.go
+++ b/agent/session_queue_promote_test.go
@@ -45,7 +45,7 @@ func TestSession_PromoteQueuedAsSteer_RemovesOnlyThatEntry(t *testing.T) {
 	}
 	markProcessing(sess)
 
-	if err := sess.PromoteQueuedAsSteer(context.Background(), 1); err != nil {
+	if err := sess.PromoteQueuedAsSteer(context.Background(), 1, ""); err != nil {
 		t.Fatalf("PromoteQueuedAsSteer: %v", err)
 	}
 
@@ -73,7 +73,7 @@ func TestSession_PromoteQueuedAsSteer_MarksUserSource(t *testing.T) {
 	if err := s.Enqueue(context.Background(), "human queued text"); err != nil {
 		t.Fatalf("Enqueue: %v", err)
 	}
-	if err := s.PromoteQueuedAsSteer(context.Background(), 0); err != nil {
+	if err := s.PromoteQueuedAsSteer(context.Background(), 0, ""); err != nil {
 		t.Fatalf("PromoteQueuedAsSteer: %v", err)
 	}
 	got := s.drainSteeringForTurn()
@@ -96,7 +96,7 @@ func TestSession_PromoteQueuedAsSteer_RejectsIdleWithoutMutatingQueue(t *testing
 	}
 	// No turn in flight: the promote must fail honestly and leave the queued
 	// message in place so it is still processed as a normal follow-up.
-	err := sess.PromoteQueuedAsSteer(context.Background(), 0)
+	err := sess.PromoteQueuedAsSteer(context.Background(), 0, "")
 	if err == nil || !strings.Contains(err.Error(), "no active turn") {
 		t.Fatalf("PromoteQueuedAsSteer idle err=%v, want no active turn", err)
 	}
@@ -119,7 +119,7 @@ func TestSession_PromoteQueuedAsSteer_IndexOutOfRange(t *testing.T) {
 	}
 	markProcessing(sess)
 	for _, idx := range []int{-1, 1, 42} {
-		err := sess.PromoteQueuedAsSteer(context.Background(), idx)
+		err := sess.PromoteQueuedAsSteer(context.Background(), idx, "")
 		if err == nil || !strings.Contains(err.Error(), "out of range") {
 			t.Fatalf("PromoteQueuedAsSteer(%d) err=%v, want out of range", idx, err)
 		}
@@ -139,7 +139,7 @@ func TestSession_PromoteQueuedAsSteer_EmitsQueueChanged(t *testing.T) {
 		t.Fatalf("Enqueue bravo: %v", err)
 	}
 	markProcessing(sess)
-	if err := sess.PromoteQueuedAsSteer(context.Background(), 0); err != nil {
+	if err := sess.PromoteQueuedAsSteer(context.Background(), 0, ""); err != nil {
 		t.Fatalf("PromoteQueuedAsSteer: %v", err)
 	}
 	sess.Close()
@@ -159,6 +159,84 @@ func TestSession_PromoteQueuedAsSteer_EmitsQueueChanged(t *testing.T) {
 	}
 }
 
+// TestSession_PromoteQueuedAsSteer_ExpectedIDMismatch covers review F1: the
+// queue head can be consumed while a turn is in flight, so an index that was
+// valid when the UI snapshotted the preview may now point at a DIFFERENT
+// queued message. The promote must refuse — leaving the queue untouched —
+// when the caller's expected entry id no longer matches the entry at index.
+func TestSession_PromoteQueuedAsSteer_ExpectedIDMismatch(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	if err := sess.Enqueue(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Enqueue alpha: %v", err)
+	}
+	if err := sess.Enqueue(context.Background(), "bravo"); err != nil {
+		t.Fatalf("Enqueue bravo: %v", err)
+	}
+	ids := sess.QueueIDs()
+	if len(ids) != 2 || ids[0] == "" || ids[1] == "" || ids[0] == ids[1] {
+		t.Fatalf("QueueIDs = %#v, want two distinct non-empty ids", ids)
+	}
+	markProcessing(sess)
+
+	// Simulate the shift: the head (alpha) is consumed into a fresh user
+	// turn, so index 0 now holds bravo. A promote carrying alpha's id must
+	// fail honestly instead of steering bravo into the running turn.
+	_ = sess.popQueueHead()
+	err := sess.PromoteQueuedAsSteer(context.Background(), 0, ids[0])
+	if err == nil || !strings.Contains(err.Error(), "no longer matches") {
+		t.Fatalf("PromoteQueuedAsSteer shifted err=%v, want mismatch", err)
+	}
+	if preview := sess.QueuePreview(); len(preview) != 1 || preview[0] != "bravo" {
+		t.Fatalf("QueuePreview after mismatch: got %#v, want [bravo]", preview)
+	}
+	sess.mu.Lock()
+	steeringDepth := len(sess.steeringQueue)
+	sess.mu.Unlock()
+	if steeringDepth != 0 {
+		t.Fatalf("steeringQueue after mismatch: got %d, want 0", steeringDepth)
+	}
+
+	// The correct id still promotes.
+	if err := sess.PromoteQueuedAsSteer(context.Background(), 0, ids[1]); err != nil {
+		t.Fatalf("PromoteQueuedAsSteer with correct id: %v", err)
+	}
+	if depth := sess.QueueDepth(); depth != 0 {
+		t.Fatalf("QueueDepth after promote: got %d, want 0", depth)
+	}
+}
+
+func TestSession_PromoteQueuedAsSteer_QueueChangedCarriesIDs(t *testing.T) {
+	t.Parallel()
+	sess := newPromoteTestSession(t)
+	if err := sess.Enqueue(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	markProcessing(sess)
+	ids := sess.QueueIDs()
+	if err := sess.PromoteQueuedAsSteer(context.Background(), 0, ids[0]); err != nil {
+		t.Fatalf("PromoteQueuedAsSteer: %v", err)
+	}
+	sess.Close()
+	var last *events.QueueChangedData
+	for ev := range sess.Events() {
+		if d, ok := ev.Data.(events.QueueChangedData); ok {
+			d := d
+			last = &d
+		}
+	}
+	if last == nil {
+		t.Fatal("expected at least one QueueChanged event")
+	}
+	if len(last.IDs) != len(last.Preview) {
+		t.Fatalf("QueueChanged IDs=%#v misaligned with Preview=%#v", last.IDs, last.Preview)
+	}
+	// The enqueue-time event carried the minted id.
+	if len(last.IDs) != 0 {
+		t.Fatalf("final QueueChanged IDs=%#v, want empty after promote", last.IDs)
+	}
+}
+
 func TestSession_PromoteQueuedAsSteer_ClosedSession(t *testing.T) {
 	t.Parallel()
 	sess := newPromoteTestSession(t)
@@ -166,7 +244,7 @@ func TestSession_PromoteQueuedAsSteer_ClosedSession(t *testing.T) {
 		t.Fatalf("Enqueue: %v", err)
 	}
 	sess.Close()
-	err := sess.PromoteQueuedAsSteer(context.Background(), 0)
+	err := sess.PromoteQueuedAsSteer(context.Background(), 0, "")
 	if err == nil || !strings.Contains(err.Error(), "closed") {
 		t.Fatalf("PromoteQueuedAsSteer closed err=%v, want closed", err)
 	}

--- a/agent/subagents_fuzz_test.go
+++ b/agent/subagents_fuzz_test.go
@@ -516,7 +516,7 @@ func FuzzSafz_DriveNotificationTurn(f *testing.F) {
 		// prove the decline, then return every slot.
 		var held []*treeReservation
 		for {
-			r, ok := parent.reserveTreeSlot()
+			r, ok := parent.reserveTreeSlot(slotKindJob)
 			if !ok {
 				break
 			}

--- a/appwire/client.go
+++ b/appwire/client.go
@@ -373,6 +373,20 @@ func (c *Client) TurnPromoteQueuedAsSteer(ctx context.Context, params TurnPromot
 	return c.request(ctx, MethodTurnPromoteQueuedAsSteer, params, nil)
 }
 
+// TurnCancelQueued calls turn/cancelQueued (issue #23) to remove the queued
+// message at params.Index so it is never consumed. The response echoes the
+// removed entry's full text and image count. The daemon returns Conflict
+// when the index no longer resolves against the live queue or the expected
+// entry id mismatches (the queue shifted under the client's snapshot,
+// review F1) — unlike promote, no active turn is required.
+func (c *Client) TurnCancelQueued(ctx context.Context, params TurnCancelQueuedParams) (TurnCancelQueuedResponse, error) {
+	var resp TurnCancelQueuedResponse
+	if err := c.request(ctx, MethodTurnCancelQueued, params, &resp); err != nil {
+		return TurnCancelQueuedResponse{}, err
+	}
+	return resp, nil
+}
+
 func pendingTargetRef(ref, threadID string) string {
 	if strings.TrimSpace(ref) != "" {
 		return ref

--- a/appwire/client.go
+++ b/appwire/client.go
@@ -364,6 +364,15 @@ func (c *Client) TurnDrainAsSteer(ctx context.Context, params TurnDrainAsSteerPa
 	return err
 }
 
+// TurnPromoteQueuedAsSteer calls turn/promoteQueuedAsSteer (issue #22) to
+// remove the queued message at params.Index and inject it as a user-sourced
+// STEERING message into the in-flight turn, leaving the rest of the queue
+// in place. The daemon returns Conflict when no turn is active or the index
+// no longer resolves against the live queue.
+func (c *Client) TurnPromoteQueuedAsSteer(ctx context.Context, params TurnPromoteQueuedAsSteerParams) error {
+	return c.request(ctx, MethodTurnPromoteQueuedAsSteer, params, nil)
+}
+
 func pendingTargetRef(ref, threadID string) string {
 	if strings.TrimSpace(ref) != "" {
 		return ref

--- a/appwire/cov_rhub_appwire_test.go
+++ b/appwire/cov_rhub_appwire_test.go
@@ -251,6 +251,9 @@ func TestClientRequestWrappersRoundTrip(t *testing.T) {
 		{"TurnSteer", MethodTurnSteer, EmptyResponse{}, func(ctx context.Context, c *Client) error { return c.TurnSteer(ctx, TurnSteerParams{}) }},
 		{"TurnQueue", MethodTurnQueue, EmptyResponse{}, func(ctx context.Context, c *Client) error { return c.TurnQueue(ctx, TurnQueueParams{}) }},
 		{"TurnDrain", MethodTurnDrainAsSteer, EmptyResponse{}, func(ctx context.Context, c *Client) error { return c.TurnDrainAsSteer(ctx, TurnDrainAsSteerParams{}) }},
+		{"TurnPromoteQueuedAsSteer", MethodTurnPromoteQueuedAsSteer, EmptyResponse{}, func(ctx context.Context, c *Client) error {
+			return c.TurnPromoteQueuedAsSteer(ctx, TurnPromoteQueuedAsSteerParams{Index: 0})
+		}},
 		{"CommandList", MethodSerfCommandList, map[string]any{}, func(ctx context.Context, c *Client) error { _, err := c.CommandList(ctx); return err }},
 		{"MarketplaceList", MethodSerfMarketplaceList, map[string]any{}, func(ctx context.Context, c *Client) error { _, err := c.MarketplaceList(ctx); return err }},
 		{"MarketplaceAdd", MethodSerfMarketplaceAdd, map[string]any{}, func(ctx context.Context, c *Client) error {

--- a/appwire/cov_rhub_appwire_test.go
+++ b/appwire/cov_rhub_appwire_test.go
@@ -254,6 +254,10 @@ func TestClientRequestWrappersRoundTrip(t *testing.T) {
 		{"TurnPromoteQueuedAsSteer", MethodTurnPromoteQueuedAsSteer, EmptyResponse{}, func(ctx context.Context, c *Client) error {
 			return c.TurnPromoteQueuedAsSteer(ctx, TurnPromoteQueuedAsSteerParams{Index: 0})
 		}},
+		{"TurnCancelQueued", MethodTurnCancelQueued, TurnCancelQueuedResponse{}, func(ctx context.Context, c *Client) error {
+			_, err := c.TurnCancelQueued(ctx, TurnCancelQueuedParams{Index: 0})
+			return err
+		}},
 		{"CommandList", MethodSerfCommandList, map[string]any{}, func(ctx context.Context, c *Client) error { _, err := c.CommandList(ctx); return err }},
 		{"MarketplaceList", MethodSerfMarketplaceList, map[string]any{}, func(ctx context.Context, c *Client) error { _, err := c.MarketplaceList(ctx); return err }},
 		{"MarketplaceAdd", MethodSerfMarketplaceAdd, map[string]any{}, func(ctx context.Context, c *Client) error {

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -103,6 +103,7 @@ var Methods = []MethodSpec{
 	{MethodTurnInterrupt, TurnInterruptParams{}, EmptyResponse{}, ScopeBoth, "Cancels the active turn matching expectedTurnId."},
 	{MethodTurnQueue, TurnQueueParams{}, EmptyResponse{}, ScopeBoth, "Queues a user message for after the active turn completes."},
 	{MethodTurnDrainAsSteer, TurnDrainAsSteerParams{}, EmptyResponse{}, ScopeBoth, "Drains the input queue and injects it as a single steering message."},
+	{MethodTurnPromoteQueuedAsSteer, TurnPromoteQueuedAsSteerParams{}, EmptyResponse{}, ScopeBoth, "Removes one queued message by index and injects it as user-sourced steering into the in-flight turn."},
 	{MethodGoalSet, GoalSetParams{}, GoalSetResponse{}, ScopeBoth, "Sets or clears the session's /goal objective."},
 	{MethodSerfTasksList, TaskListParams{}, TaskListResponse{}, ScopeBoth, "Lists the session's tasks."},
 	{MethodSerfThreadTranscriptsList, ThreadTranscriptListParams{}, ThreadTranscriptListResponse{}, ScopeHub, "Lists transcript targets (subagents/related threads) for a ref."},

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -104,6 +104,7 @@ var Methods = []MethodSpec{
 	{MethodTurnQueue, TurnQueueParams{}, EmptyResponse{}, ScopeBoth, "Queues a user message for after the active turn completes."},
 	{MethodTurnDrainAsSteer, TurnDrainAsSteerParams{}, EmptyResponse{}, ScopeBoth, "Drains the input queue and injects it as a single steering message."},
 	{MethodTurnPromoteQueuedAsSteer, TurnPromoteQueuedAsSteerParams{}, EmptyResponse{}, ScopeBoth, "Removes one queued message by index and injects it as user-sourced steering into the in-flight turn."},
+	{MethodTurnCancelQueued, TurnCancelQueuedParams{}, TurnCancelQueuedResponse{}, ScopeBoth, "Removes one queued message by index so it is never consumed (cancel; also the removal half of edit-and-recompose)."},
 	{MethodGoalSet, GoalSetParams{}, GoalSetResponse{}, ScopeBoth, "Sets or clears the session's /goal objective."},
 	{MethodSerfTasksList, TaskListParams{}, TaskListResponse{}, ScopeBoth, "Lists the session's tasks."},
 	{MethodSerfThreadTranscriptsList, ThreadTranscriptListParams{}, ThreadTranscriptListResponse{}, ScopeHub, "Lists transcript targets (subagents/related threads) for a ref."},

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -289,10 +289,15 @@ type SerfUsage struct {
 // QueueState is the wire representation of a session's per-input queue
 // (kata r80p). Depth is len(Preview) at projection time; Preview entries
 // are FIFO with the head at index 0 and have been truncated to a single
-// line so the UI can render them without further processing.
+// line so the UI can render them without further processing. IDs is
+// FIFO-aligned with Preview: each entry's stable queue-entry id, minted by
+// the daemon at enqueue time. turn/promoteQueuedAsSteer echoes an id back
+// as expectedEntryId so a queue that shifted under the client's snapshot is
+// rejected instead of promoting the wrong message (review F1, issue #22).
 type QueueState struct {
 	Depth   int      `json:"depth,omitempty"`
 	Preview []string `json:"preview,omitempty"`
+	IDs     []string `json:"ids,omitempty"`
 }
 
 // ThreadQueueChangedParams is the params shape for thread/queueChanged
@@ -740,11 +745,17 @@ type TurnDrainAsSteerParams struct {
 // one entry of the session's FIFO input queue (matching the position shown
 // in the queue preview); the daemon removes just that entry and injects it
 // as a user-sourced steering message into the in-flight turn, leaving the
-// other queued messages in place. The daemon returns Conflict when no turn
-// is in flight or the queue has shifted so the index no longer resolves.
+// other queued messages in place. ExpectedEntryID, when non-empty, must
+// match the id the daemon minted for that entry (surfaced via
+// QueueState.IDs): the queue head can be consumed mid-turn, so a bare index
+// from an older snapshot may point at a different message — a mismatch is a
+// Conflict, not a wrong-message promote (review F1). The daemon returns
+// Conflict when no turn is in flight, the index is out of range, or the
+// expected id no longer matches.
 type TurnPromoteQueuedAsSteerParams struct {
-	Ref   string `json:"ref"`
-	Index int    `json:"index"`
+	Ref             string `json:"ref"`
+	Index           int    `json:"index"`
+	ExpectedEntryID string `json:"expectedEntryId,omitempty"`
 }
 
 type ThreadCompactStartParams struct {

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -25,6 +25,7 @@ const (
 	MethodTurnInterrupt             = "turn/interrupt"
 	MethodTurnQueue                 = "turn/queue"
 	MethodTurnDrainAsSteer          = "turn/drainAsSteer"
+	MethodTurnPromoteQueuedAsSteer  = "turn/promoteQueuedAsSteer"
 	MethodGoalSet                   = "goal/set"
 	MethodSerfTasksList             = "serf/tasks/list"
 	MethodSerfThreadNameSet         = "serf/thread/name/set"
@@ -732,6 +733,18 @@ type GoalSetResponse struct {
 type TurnDrainAsSteerParams struct {
 	Ref   string      `json:"ref"`
 	Input []InputItem `json:"input,omitempty"`
+}
+
+// TurnPromoteQueuedAsSteerParams is the wire shape for
+// turn/promoteQueuedAsSteer (issue #22 per-message promote). Index selects
+// one entry of the session's FIFO input queue (matching the position shown
+// in the queue preview); the daemon removes just that entry and injects it
+// as a user-sourced steering message into the in-flight turn, leaving the
+// other queued messages in place. The daemon returns Conflict when no turn
+// is in flight or the queue has shifted so the index no longer resolves.
+type TurnPromoteQueuedAsSteerParams struct {
+	Ref   string `json:"ref"`
+	Index int    `json:"index"`
 }
 
 type ThreadCompactStartParams struct {

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -26,6 +26,7 @@ const (
 	MethodTurnQueue                 = "turn/queue"
 	MethodTurnDrainAsSteer          = "turn/drainAsSteer"
 	MethodTurnPromoteQueuedAsSteer  = "turn/promoteQueuedAsSteer"
+	MethodTurnCancelQueued          = "turn/cancelQueued"
 	MethodGoalSet                   = "goal/set"
 	MethodSerfTasksList             = "serf/tasks/list"
 	MethodSerfThreadNameSet         = "serf/thread/name/set"
@@ -294,10 +295,17 @@ type SerfUsage struct {
 // the daemon at enqueue time. turn/promoteQueuedAsSteer echoes an id back
 // as expectedEntryId so a queue that shifted under the client's snapshot is
 // rejected instead of promoting the wrong message (review F1, issue #22).
+// Texts is FIFO-aligned with Preview and carries each entry's FULL
+// untruncated text, so the edit affordance (issue #23) can restore the
+// complete message into the composer before turn/cancelQueued removes the
+// entry — the preview line alone would silently truncate multi-line
+// messages. Absent on old daemons; clients must treat a missing Texts as
+// "edit unavailable" rather than falling back to the truncated preview.
 type QueueState struct {
 	Depth   int      `json:"depth,omitempty"`
 	Preview []string `json:"preview,omitempty"`
 	IDs     []string `json:"ids,omitempty"`
+	Texts   []string `json:"texts,omitempty"`
 }
 
 // ThreadQueueChangedParams is the params shape for thread/queueChanged
@@ -756,6 +764,36 @@ type TurnPromoteQueuedAsSteerParams struct {
 	Ref             string `json:"ref"`
 	Index           int    `json:"index"`
 	ExpectedEntryID string `json:"expectedEntryId,omitempty"`
+}
+
+// TurnCancelQueuedParams is the wire shape for turn/cancelQueued (issue
+// #23): removes the queued follow-up at Index so it is never consumed. It
+// is also the removal half of the web UI's edit action (edit = restore the
+// full text from QueueState.Texts into the composer, then cancel the queued
+// copy). ExpectedEntryID plays the same review-F1 role as on
+// turn/promoteQueuedAsSteer: when non-empty it must match the id the daemon
+// minted for the entry at Index, so a queue that shifted under the client's
+// snapshot is a Conflict rather than removing the wrong message. Unlike
+// promote, cancel does NOT require an in-flight turn — a queued entry is
+// cancellable whenever it is still queued. The daemon returns Conflict when
+// the index is out of range (e.g. the entry was already consumed) or the
+// expected id no longer matches.
+type TurnCancelQueuedParams struct {
+	Ref             string `json:"ref"`
+	Index           int    `json:"index"`
+	ExpectedEntryID string `json:"expectedEntryId,omitempty"`
+}
+
+// TurnCancelQueuedResponse echoes what turn/cancelQueued removed.
+// RemovedText is the entry's full untruncated text (the client normally
+// already holds it via QueueState.Texts; the echo lets it verify the
+// removal matched its snapshot). RemovedImages counts image attachments
+// that were on the entry and are NOT restored by an edit — the client warns
+// the user to re-attach before resending rather than silently dropping
+// them.
+type TurnCancelQueuedResponse struct {
+	RemovedText   string `json:"removedText"`
+	RemovedImages int    `json:"removedImages,omitempty"`
 }
 
 type ThreadCompactStartParams struct {

--- a/cmd/serf-hub/app_rpc.go
+++ b/cmd/serf-hub/app_rpc.go
@@ -392,13 +392,13 @@ func registerThreadHandlers(
 		if err != nil {
 			return appwire.TurnCancelQueuedResponse{}, err
 		}
-		// cancelQueued rides on the Send capability, not Steer: unlike
-		// promote it needs no in-flight turn — a queued entry is cancellable
-		// whenever it is still queued, including entries buffered on an idle
-		// session (where Queue/Steer are false but Send is true). The daemon
-		// checks the live queue itself and returns Conflict when the index
-		// no longer resolves or the expected id mismatches (review F1).
-		if err := ensureThreadActionAvailable(ctx, source, params.Ref, "", "send"); err != nil {
+		// cancelQueued rides on the Queue capability — the same gate as
+		// turn/queue. It must NOT gate on Send: Send is false while a turn
+		// is in flight, which is exactly when the queue preview (and its
+		// cancel/edit buttons) exists (review C1). The daemon checks the
+		// live queue itself and returns Conflict when the index no longer
+		// resolves or the expected id mismatches (review F1).
+		if err := ensureThreadActionAvailable(ctx, source, params.Ref, "", "queue"); err != nil {
 			return appwire.TurnCancelQueuedResponse{}, err
 		}
 		return source.CancelQueued(ctx, params)

--- a/cmd/serf-hub/app_rpc.go
+++ b/cmd/serf-hub/app_rpc.go
@@ -384,6 +384,25 @@ func registerThreadHandlers(
 		}
 		return appwire.EmptyResponse{}, source.PromoteQueuedAsSteer(ctx, params)
 	})
+	appserver.HandleTyped(server.Router(), appwire.MethodTurnCancelQueued, func(ctx context.Context, params appwire.TurnCancelQueuedParams) (appwire.TurnCancelQueuedResponse, error) {
+		if params.Index < 0 {
+			return appwire.TurnCancelQueuedResponse{}, appwire.InvalidParams("index must be >= 0")
+		}
+		source, err := sourceForThreadWithManagedLaunch(ctx, cfg, sources, params.Ref, "")
+		if err != nil {
+			return appwire.TurnCancelQueuedResponse{}, err
+		}
+		// cancelQueued rides on the Send capability, not Steer: unlike
+		// promote it needs no in-flight turn — a queued entry is cancellable
+		// whenever it is still queued, including entries buffered on an idle
+		// session (where Queue/Steer are false but Send is true). The daemon
+		// checks the live queue itself and returns Conflict when the index
+		// no longer resolves or the expected id mismatches (review F1).
+		if err := ensureThreadActionAvailable(ctx, source, params.Ref, "", "send"); err != nil {
+			return appwire.TurnCancelQueuedResponse{}, err
+		}
+		return source.CancelQueued(ctx, params)
+	})
 	appserver.HandleTyped(server.Router(), appwire.MethodThreadClear, func(ctx context.Context, params appwire.ThreadClearParams) (appwire.ThreadClearResponse, error) {
 		source, err := sourceForThreadWithManagedLaunch(ctx, cfg, sources, params.Ref, "")
 		if err != nil {

--- a/cmd/serf-hub/app_rpc.go
+++ b/cmd/serf-hub/app_rpc.go
@@ -368,6 +368,22 @@ func registerThreadHandlers(
 		}
 		return appwire.EmptyResponse{}, source.DrainAsSteer(ctx, params)
 	})
+	appserver.HandleTyped(server.Router(), appwire.MethodTurnPromoteQueuedAsSteer, func(ctx context.Context, params appwire.TurnPromoteQueuedAsSteerParams) (appwire.EmptyResponse, error) {
+		if params.Index < 0 {
+			return appwire.EmptyResponse{}, appwire.InvalidParams("index must be >= 0")
+		}
+		source, err := sourceForThreadWithManagedLaunch(ctx, cfg, sources, params.Ref, "")
+		if err != nil {
+			return appwire.EmptyResponse{}, err
+		}
+		// promoteQueuedAsSteer rides on the Steer capability, same as
+		// drainAsSteer — the daemon checks the live queue and turn state
+		// itself and returns Conflict when the promote can't happen.
+		if err := ensureThreadActionAvailable(ctx, source, params.Ref, "", "steer"); err != nil {
+			return appwire.EmptyResponse{}, err
+		}
+		return appwire.EmptyResponse{}, source.PromoteQueuedAsSteer(ctx, params)
+	})
 	appserver.HandleTyped(server.Router(), appwire.MethodThreadClear, func(ctx context.Context, params appwire.ThreadClearParams) (appwire.ThreadClearResponse, error) {
 		source, err := sourceForThreadWithManagedLaunch(ctx, cfg, sources, params.Ref, "")
 		if err != nil {

--- a/cmd/serf-hub/app_rpc_test.go
+++ b/cmd/serf-hub/app_rpc_test.go
@@ -3606,6 +3606,10 @@ func (s *relayLifecycleSource) DrainAsSteer(context.Context, appwire.TurnDrainAs
 	return appwire.Unavailable("relay lifecycle source does not drain as steer")
 }
 
+func (s *relayLifecycleSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
+	return appwire.Unavailable("relay lifecycle source does not promote queued messages")
+}
+
 func (s *relayLifecycleSource) CompactThread(context.Context, appwire.ThreadCompactStartParams) error {
 	return appwire.Unavailable("relay lifecycle source does not compact threads")
 }
@@ -7072,6 +7076,7 @@ func TestHubRPCRegistersExpectedHandlerSet(t *testing.T) {
 		appwire.MethodTurnInterrupt,
 		appwire.MethodTurnQueue,
 		appwire.MethodTurnDrainAsSteer,
+		appwire.MethodTurnPromoteQueuedAsSteer,
 		appwire.MethodThreadClear,
 		appwire.MethodThreadCompactStart,
 		appwire.MethodThreadShutdown,

--- a/cmd/serf-hub/app_rpc_test.go
+++ b/cmd/serf-hub/app_rpc_test.go
@@ -3610,6 +3610,10 @@ func (s *relayLifecycleSource) PromoteQueuedAsSteer(context.Context, appwire.Tur
 	return appwire.Unavailable("relay lifecycle source does not promote queued messages")
 }
 
+func (s *relayLifecycleSource) CancelQueued(context.Context, appwire.TurnCancelQueuedParams) (appwire.TurnCancelQueuedResponse, error) {
+	return appwire.TurnCancelQueuedResponse{}, appwire.Unavailable("relay lifecycle source does not cancel queued messages")
+}
+
 func (s *relayLifecycleSource) CompactThread(context.Context, appwire.ThreadCompactStartParams) error {
 	return appwire.Unavailable("relay lifecycle source does not compact threads")
 }

--- a/cmd/serf-hub/assets/appwire.js
+++ b/cmd/serf-hub/assets/appwire.js
@@ -539,13 +539,17 @@
 
   // promoteQueuedAsSteer promotes ONE queued follow-up (by FIFO index, as
   // shown in the queue preview) to a user-sourced steering injection on the
-  // in-flight turn (issue #22), leaving the rest of the queue in place. No
-  // optimistic placeholder: the daemon's thread/queueChanged re-renders the
-  // preview and serf/steering/injected (source:"user") echoes the message.
-  function promoteQueuedAsSteer(sessionId, index) {
+  // in-flight turn (issue #22), leaving the rest of the queue in place. The
+  // queue-entry id from the client's snapshot rides along: the daemon
+  // rejects with Conflict when the queue shifted under us (review F1), so a
+  // stale row can never steer the wrong message. No optimistic placeholder:
+  // the daemon's thread/queueChanged re-renders the preview and
+  // serf/steering/injected (source:"user") echoes the message.
+  function promoteQueuedAsSteer(sessionId, index, entryId) {
     return request(METHOD.turnPromoteQueuedAsSteer, {
       ref: refForSession(sessionId),
       index,
+      expectedEntryId: entryId || "",
     });
   }
 
@@ -801,6 +805,7 @@
     events.push(["QUEUE_CHANGED", {
       depth: typeof queue.depth === "number" ? queue.depth : (Array.isArray(queue.preview) ? queue.preview.length : 0),
       preview: Array.isArray(queue.preview) ? queue.preview.slice() : [],
+      ids: Array.isArray(queue.ids) ? queue.ids.slice() : [],
     }]);
     events.push.apply(events, eventsFromTurns(thread.turns));
     return events;
@@ -917,6 +922,7 @@
       return [["QUEUE_CHANGED", {
         depth: typeof q.depth === "number" ? q.depth : (Array.isArray(q.preview) ? q.preview.length : 0),
         preview: Array.isArray(q.preview) ? q.preview.slice() : [],
+        ids: Array.isArray(q.ids) ? q.ids.slice() : [],
       }]];
     }
     if (method === "serf/task/updated") {

--- a/cmd/serf-hub/assets/appwire.js
+++ b/cmd/serf-hub/assets/appwire.js
@@ -19,6 +19,7 @@
     turnQueue: "turn/queue",
     turnDrainAsSteer: "turn/drainAsSteer",
     turnPromoteQueuedAsSteer: "turn/promoteQueuedAsSteer",
+    turnCancelQueued: "turn/cancelQueued",
     tasksList: "serf/tasks/list",
     sandboxEscalationResolve: "serf/sandbox/escalation/resolve",
     dirsComplete: "serf/dirs/complete",
@@ -553,6 +554,25 @@
     });
   }
 
+  // cancelQueued removes ONE queued follow-up (by FIFO index, as shown in
+  // the queue preview) so it is never consumed (issue #23). It is also the
+  // removal half of the row's edit action: the renderer restores the full
+  // text (from queueState.texts) into the composer FIRST, then cancels the
+  // queued copy here. The queue-entry id from the client's snapshot rides
+  // along: the daemon rejects with Conflict when the queue shifted under us
+  // (review F1), so a stale row can never remove the wrong message. No
+  // local mirror: the daemon's thread/queueChanged re-renders the preview.
+  // Resolves with { removedText, removedImages } — removedImages > 0 means
+  // attachments were on the entry and are NOT restored by an edit, which
+  // the renderer surfaces as a warning rather than silently dropping them.
+  function cancelQueued(sessionId, index, entryId) {
+    return request(METHOD.turnCancelQueued, {
+      ref: refForSession(sessionId),
+      index,
+      expectedEntryId: entryId || "",
+    });
+  }
+
   function action(sessionId, name, turnId) {
     const ref = refForSession(sessionId);
     if (name === "interrupt") return request(METHOD.turnInterrupt, { ref, expectedTurnId: turnId || "" });
@@ -806,6 +826,7 @@
       depth: typeof queue.depth === "number" ? queue.depth : (Array.isArray(queue.preview) ? queue.preview.length : 0),
       preview: Array.isArray(queue.preview) ? queue.preview.slice() : [],
       ids: Array.isArray(queue.ids) ? queue.ids.slice() : [],
+      texts: Array.isArray(queue.texts) ? queue.texts.slice() : [],
     }]);
     events.push.apply(events, eventsFromTurns(thread.turns));
     return events;
@@ -923,6 +944,7 @@
         depth: typeof q.depth === "number" ? q.depth : (Array.isArray(q.preview) ? q.preview.length : 0),
         preview: Array.isArray(q.preview) ? q.preview.slice() : [],
         ids: Array.isArray(q.ids) ? q.ids.slice() : [],
+        texts: Array.isArray(q.texts) ? q.texts.slice() : [],
       }]];
     }
     if (method === "serf/task/updated") {
@@ -1073,6 +1095,7 @@
     queueTurn,
     drainAsSteer,
     promoteQueuedAsSteer,
+    cancelQueued,
     action,
     setModel,
     setReasoningEffort,

--- a/cmd/serf-hub/assets/appwire.js
+++ b/cmd/serf-hub/assets/appwire.js
@@ -18,6 +18,7 @@
     turnInterrupt: "turn/interrupt",
     turnQueue: "turn/queue",
     turnDrainAsSteer: "turn/drainAsSteer",
+    turnPromoteQueuedAsSteer: "turn/promoteQueuedAsSteer",
     tasksList: "serf/tasks/list",
     sandboxEscalationResolve: "serf/sandbox/escalation/resolve",
     dirsComplete: "serf/dirs/complete",
@@ -534,6 +535,18 @@
       ref: refForSession(sessionId),
       input: inputItemsForTextAndAttachments(text || "", attachments),
     }, { text: text || "", items: attachments || [] });
+  }
+
+  // promoteQueuedAsSteer promotes ONE queued follow-up (by FIFO index, as
+  // shown in the queue preview) to a user-sourced steering injection on the
+  // in-flight turn (issue #22), leaving the rest of the queue in place. No
+  // optimistic placeholder: the daemon's thread/queueChanged re-renders the
+  // preview and serf/steering/injected (source:"user") echoes the message.
+  function promoteQueuedAsSteer(sessionId, index) {
+    return request(METHOD.turnPromoteQueuedAsSteer, {
+      ref: refForSession(sessionId),
+      index,
+    });
   }
 
   function action(sessionId, name, turnId) {
@@ -1053,6 +1066,7 @@
     steer,
     queueTurn,
     drainAsSteer,
+    promoteQueuedAsSteer,
     action,
     setModel,
     setReasoningEffort,

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -1490,7 +1490,7 @@
             this.renderComposerChips();
             // Reset to empty; the next QUEUE_CHANGED event (cold-load or
             // notification) will fill in authoritative state from the wire.
-            this.queueState = { depth: 0, preview: [], ids: [] };
+            this.queueState = { depth: 0, preview: [], ids: [], texts: [] };
             this.renderQueuePreview();
           }
           if (data.capabilities) {
@@ -1515,6 +1515,11 @@
             depth: typeof data.depth === "number" ? data.depth : (Array.isArray(data.preview) ? data.preview.length : 0),
             preview: Array.isArray(data.preview) ? data.preview.slice() : [],
             ids: Array.isArray(data.ids) ? data.ids.slice() : [],
+            // texts is FIFO-aligned with preview and carries each entry's
+            // FULL untruncated text for the edit affordance (issue #23) —
+            // the preview line alone would silently truncate multi-line
+            // messages. Absent on old daemons; edit degrades honestly.
+            texts: Array.isArray(data.texts) ? data.texts.slice() : [],
           };
           this.renderQueuePreview();
           break;
@@ -6550,6 +6555,36 @@
         promoteBtn.textContent = "⇧";
         promoteBtn.addEventListener("click", () => { this.promoteQueuedMessage(idx, entryId); });
         li.appendChild(promoteBtn);
+        // Per-message edit + cancel (issue #23). Edit is
+        // cancel-and-recompose: the full text (queueState.texts, not the
+        // truncated preview line) returns to the composer and the queued
+        // copy is removed. Image-only entries carry no text to recompose,
+        // so their edit button is disabled with an honest hint — cancel
+        // still works for them.
+        const fullText = state.texts && typeof state.texts[idx] === "string" ? state.texts[idx] : null;
+        const editBtn = document.createElement("button");
+        editBtn.type = "button";
+        editBtn.className = "qp-edit";
+        editBtn.setAttribute("data-edit-index", String(idx));
+        if (fullText !== null && fullText.trim() === "") {
+          editBtn.disabled = true;
+          editBtn.title = "nothing to edit — this queued message is image-only (cancel instead)";
+        } else {
+          editBtn.title = "edit — move this message back into the composer and remove it from the queue";
+        }
+        editBtn.setAttribute("aria-label", "edit queued message " + (idx + 1) + " in the composer");
+        editBtn.textContent = "✎";
+        editBtn.addEventListener("click", () => { this.editQueuedMessage(idx, entryId); });
+        li.appendChild(editBtn);
+        const cancelBtn = document.createElement("button");
+        cancelBtn.type = "button";
+        cancelBtn.className = "qp-cancel";
+        cancelBtn.setAttribute("data-cancel-index", String(idx));
+        cancelBtn.title = "cancel — remove this message from the queue so it is never sent";
+        cancelBtn.setAttribute("aria-label", "cancel queued message " + (idx + 1));
+        cancelBtn.textContent = "✕";
+        cancelBtn.addEventListener("click", () => { this.cancelQueuedMessage(idx, entryId); });
+        li.appendChild(cancelBtn);
         list.appendChild(li);
       });
     },
@@ -6582,6 +6617,87 @@
         }
       } catch (err) {
         this.appendBanner("error", "promote failed: " + err.message, { source: "hub", title: "Hub promote error" });
+      }
+    },
+
+    // removeQueuedEntry is the shared daemon call behind the queue-preview
+    // row's cancel and edit actions (issue #23): turn/cancelQueued with the
+    // review-F1 expected identity. Resolves with { removedText,
+    // removedImages } on success; on failure it appends an error banner
+    // (prefixed with failLabel) and resolves null. There is no local
+    // mirror: a successful removal re-renders from the daemon's
+    // thread/queueChanged.
+    async removeQueuedEntry(idx, entryId, failLabel) {
+      try {
+        if (window.SerfAppwire && typeof window.SerfAppwire.cancelQueued === "function") {
+          return await window.SerfAppwire.cancelQueued(this.sessionId, idx, entryId || "");
+        }
+        const resp = await fetch("/s/" + encodeURIComponent(this.sessionId) + "/cancel-queued", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ index: idx, entryId: entryId || "" }),
+        });
+        if (!resp.ok) {
+          const detail = (await resp.text()).trim() || ("HTTP " + resp.status);
+          this.appendBanner("error", failLabel + ": " + detail, { source: "hub", title: "Hub cancel error" });
+          return null;
+        }
+        return await resp.json();
+      } catch (err) {
+        this.appendBanner("error", failLabel + ": " + err.message, { source: "hub", title: "Hub cancel error" });
+        return null;
+      }
+    },
+
+    // cancelQueuedMessage removes one queued follow-up so it is never
+    // consumed (issue #23). On success the daemon's thread/queueChanged
+    // re-renders the preview without the row; on failure (already consumed,
+    // queue shifted under the preview) the row stays and the error banner
+    // says so — nothing is silently removed.
+    async cancelQueuedMessage(idx, entryId) {
+      await this.removeQueuedEntry(idx, entryId, "cancel failed");
+    },
+
+    // restoreTextToComposer puts text back into the composer without
+    // clobbering what the user has already typed there: existing composer
+    // text stays, the restored text is appended after a blank line. The
+    // synthetic input event keeps the sticky draft (SerfDrafts, issue #21)
+    // in sync through the same path as real typing — same pattern as
+    // dropComposedTextIntoComposer.
+    restoreTextToComposer(text) {
+      const ta = document.querySelector("form[data-input-form] .message-input");
+      if (!ta) return;
+      const existing = ta.value;
+      ta.value = existing.trim() === "" ? text : existing.replace(/\s+$/, "") + "\n\n" + text;
+      ta.dispatchEvent(new Event("input", { bubbles: true }));
+      ta.focus();
+      try { ta.setSelectionRange(ta.value.length, ta.value.length); } catch (e) { /* jsdom */ }
+    },
+
+    // editQueuedMessage is cancel-and-recompose (issue #23): the queued
+    // message's FULL text (queueState.texts — never the truncated preview
+    // line) returns to the composer FIRST, then the queued copy is removed.
+    // Text-first ordering is the honest race behavior: if the removal loses
+    // the race (the entry was consumed between the snapshot and the click,
+    // or the queue shifted so the expected id no longer matches), the text
+    // is already safe in the composer and the banner says the queued copy
+    // could not be removed — the user decides whether to delete the
+    // composer text or send it again, and nothing is silently duplicated or
+    // lost. An old daemon that sends no texts makes edit unavailable rather
+    // than restoring a truncated message.
+    async editQueuedMessage(idx, entryId) {
+      const texts = (this.queueState && this.queueState.texts) || [];
+      const text = texts[idx];
+      if (typeof text !== "string") {
+        this.appendBanner("error", "edit is not available for this session (the daemon does not expose the full queued text) — cancel and retype instead", { source: "hub", title: "Hub edit error" });
+        return;
+      }
+      if (text.trim() === "") return; // image-only entry; the row's edit button is disabled
+      this.restoreTextToComposer(text);
+      const removed = await this.removeQueuedEntry(idx, entryId,
+        "edit: your text is in the composer, but the queued copy could not be removed (it was already consumed or the queue changed) — delete the composer text if you don't want to resend it");
+      if (removed && typeof removed.removedImages === "number" && removed.removedImages > 0) {
+        this.appendBanner("warning", "edit: " + removed.removedImages + " image attachment(s) on the queued message were not restored — re-attach them before resending", { source: "hub", title: "Hub edit" });
       }
     },
 

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -6649,13 +6649,38 @@
       }
     },
 
+    // setQueuedRowActionsDisabled disables/enables one queue-preview row's
+    // edit + cancel buttons while a cancel/edit request for that entry is
+    // in flight (review M1): a double-click must not append the text to the
+    // composer twice or fire a second cancel that Conflicts confusingly.
+    // Re-enabling respects the image-only rule — an entry with no text
+    // keeps its edit button disabled.
+    setQueuedRowActionsDisabled(idx, disabled) {
+      const list = document.querySelector("[data-queue-list]");
+      if (!list) return;
+      const editBtn = list.querySelector('[data-edit-index="' + idx + '"]');
+      const cancelBtn = list.querySelector('[data-cancel-index="' + idx + '"]');
+      if (cancelBtn) cancelBtn.disabled = disabled;
+      if (editBtn) {
+        const texts = (this.queueState && this.queueState.texts) || [];
+        const imageOnly = typeof texts[idx] === "string" && texts[idx].trim() === "";
+        editBtn.disabled = disabled || imageOnly;
+      }
+    },
+
     // cancelQueuedMessage removes one queued follow-up so it is never
     // consumed (issue #23). On success the daemon's thread/queueChanged
     // re-renders the preview without the row; on failure (already consumed,
     // queue shifted under the preview) the row stays and the error banner
-    // says so — nothing is silently removed.
+    // says so — nothing is silently removed. The row's buttons are disabled
+    // for the duration so a second click can't double-fire (review M1).
     async cancelQueuedMessage(idx, entryId) {
-      await this.removeQueuedEntry(idx, entryId, "cancel failed");
+      this.setQueuedRowActionsDisabled(idx, true);
+      try {
+        await this.removeQueuedEntry(idx, entryId, "cancel failed");
+      } finally {
+        this.setQueuedRowActionsDisabled(idx, false);
+      }
     },
 
     // restoreTextToComposer puts text back into the composer without
@@ -6693,11 +6718,19 @@
         return;
       }
       if (text.trim() === "") return; // image-only entry; the row's edit button is disabled
-      this.restoreTextToComposer(text);
-      const removed = await this.removeQueuedEntry(idx, entryId,
-        "edit: your text is in the composer, but the queued copy could not be removed (it was already consumed or the queue changed) — delete the composer text if you don't want to resend it");
-      if (removed && typeof removed.removedImages === "number" && removed.removedImages > 0) {
-        this.appendBanner("warning", "edit: " + removed.removedImages + " image attachment(s) on the queued message were not restored — re-attach them before resending", { source: "hub", title: "Hub edit" });
+      // Disable the row's buttons before mutating the composer so a
+      // double-click can't append the text twice or fire a second cancel
+      // that Conflicts confusingly (review M1).
+      this.setQueuedRowActionsDisabled(idx, true);
+      try {
+        this.restoreTextToComposer(text);
+        const removed = await this.removeQueuedEntry(idx, entryId,
+          "edit: your text is in the composer, but the queued copy could not be removed (it was already consumed or the queue changed) — delete the composer text if you don't want to resend it");
+        if (removed && typeof removed.removedImages === "number" && removed.removedImages > 0) {
+          this.appendBanner("warning", "edit: " + removed.removedImages + " image attachment(s) on the queued message were not restored — re-attach them before resending", { source: "hub", title: "Hub edit" });
+        }
+      } finally {
+        this.setQueuedRowActionsDisabled(idx, false);
       }
     },
 

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -1490,7 +1490,7 @@
             this.renderComposerChips();
             // Reset to empty; the next QUEUE_CHANGED event (cold-load or
             // notification) will fill in authoritative state from the wire.
-            this.queueState = { depth: 0, preview: [] };
+            this.queueState = { depth: 0, preview: [], ids: [] };
             this.renderQueuePreview();
           }
           if (data.capabilities) {
@@ -1506,11 +1506,15 @@
           break;
         case "QUEUE_CHANGED":
           // Authoritative queue state from the daemon (kata r80p). The
-          // depth + preview are stored verbatim; renderQueuePreview reads
-          // straight from this.queueState.
+          // depth + preview + ids are stored verbatim; renderQueuePreview
+          // reads straight from this.queueState. ids is FIFO-aligned with
+          // preview: each entry's daemon-minted queue id, sent back as the
+          // expected identity on promote so a shifted queue is rejected
+          // instead of steering the wrong message (review F1).
           this.queueState = {
             depth: typeof data.depth === "number" ? data.depth : (Array.isArray(data.preview) ? data.preview.length : 0),
             preview: Array.isArray(data.preview) ? data.preview.slice() : [],
+            ids: Array.isArray(data.ids) ? data.ids.slice() : [],
           };
           this.renderQueuePreview();
           break;
@@ -6532,7 +6536,11 @@
         li.appendChild(textEl);
         // Per-message promote (issue #22): pull just this queued follow-up
         // out of the FIFO and inject it as user-sourced steering into the
-        // in-flight turn, leaving the other queued messages in place.
+        // in-flight turn, leaving the other queued messages in place. The
+        // daemon-minted entry id rides along so a queue that shifted under
+        // this preview is rejected instead of steering the wrong message
+        // (review F1).
+        const entryId = (state.ids && state.ids[idx]) || "";
         const promoteBtn = document.createElement("button");
         promoteBtn.type = "button";
         promoteBtn.className = "qp-promote";
@@ -6540,28 +6548,31 @@
         promoteBtn.title = "promote to steering — inject this message into the running turn now";
         promoteBtn.setAttribute("aria-label", "promote queued message " + (idx + 1) + " to steering");
         promoteBtn.textContent = "⇧";
-        promoteBtn.addEventListener("click", () => { this.promoteQueuedMessage(idx); });
+        promoteBtn.addEventListener("click", () => { this.promoteQueuedMessage(idx, entryId); });
         li.appendChild(promoteBtn);
         list.appendChild(li);
       });
     },
 
     // promoteQueuedMessage promotes one queued follow-up to a steering
-    // injection on the in-flight turn (issue #22). There is no local mirror:
-    // on success the daemon emits thread/queueChanged without the promoted
-    // entry and a serf/steering/injected with source:"user", so the preview
-    // and transcript both re-render from authoritative wire data. A failure
+    // injection on the in-flight turn (issue #22). entryId is the
+    // daemon-minted queue-entry id from the preview snapshot; the daemon
+    // rejects with Conflict when it no longer matches the entry at idx
+    // (review F1). There is no local mirror: on success the daemon emits
+    // thread/queueChanged without the promoted entry and a
+    // serf/steering/injected with source:"user", so the preview and
+    // transcript both re-render from authoritative wire data. A failure
     // (turn already ended, queue shifted under the preview) surfaces as an
     // error banner and leaves the queued message in place.
-    async promoteQueuedMessage(idx) {
+    async promoteQueuedMessage(idx, entryId) {
       try {
         if (window.SerfAppwire && typeof window.SerfAppwire.promoteQueuedAsSteer === "function") {
-          await window.SerfAppwire.promoteQueuedAsSteer(this.sessionId, idx);
+          await window.SerfAppwire.promoteQueuedAsSteer(this.sessionId, idx, entryId || "");
         } else {
           const resp = await fetch("/s/" + encodeURIComponent(this.sessionId) + "/promote-queued", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ index: idx }),
+            body: JSON.stringify({ index: idx, entryId: entryId || "" }),
           });
           if (!resp.ok) {
             const detail = (await resp.text()).trim() || ("HTTP " + resp.status);

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -6530,8 +6530,48 @@
         textEl.textContent = oneLine.length > 140 ? (oneLine.slice(0, 139) + "…") : oneLine;
         li.appendChild(idxEl);
         li.appendChild(textEl);
+        // Per-message promote (issue #22): pull just this queued follow-up
+        // out of the FIFO and inject it as user-sourced steering into the
+        // in-flight turn, leaving the other queued messages in place.
+        const promoteBtn = document.createElement("button");
+        promoteBtn.type = "button";
+        promoteBtn.className = "qp-promote";
+        promoteBtn.setAttribute("data-promote-index", String(idx));
+        promoteBtn.title = "promote to steering — inject this message into the running turn now";
+        promoteBtn.setAttribute("aria-label", "promote queued message " + (idx + 1) + " to steering");
+        promoteBtn.textContent = "⇧";
+        promoteBtn.addEventListener("click", () => { this.promoteQueuedMessage(idx); });
+        li.appendChild(promoteBtn);
         list.appendChild(li);
       });
+    },
+
+    // promoteQueuedMessage promotes one queued follow-up to a steering
+    // injection on the in-flight turn (issue #22). There is no local mirror:
+    // on success the daemon emits thread/queueChanged without the promoted
+    // entry and a serf/steering/injected with source:"user", so the preview
+    // and transcript both re-render from authoritative wire data. A failure
+    // (turn already ended, queue shifted under the preview) surfaces as an
+    // error banner and leaves the queued message in place.
+    async promoteQueuedMessage(idx) {
+      try {
+        if (window.SerfAppwire && typeof window.SerfAppwire.promoteQueuedAsSteer === "function") {
+          await window.SerfAppwire.promoteQueuedAsSteer(this.sessionId, idx);
+        } else {
+          const resp = await fetch("/s/" + encodeURIComponent(this.sessionId) + "/promote-queued", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ index: idx }),
+          });
+          if (!resp.ok) {
+            const detail = (await resp.text()).trim() || ("HTTP " + resp.status);
+            this.appendBanner("error", "promote failed: " + detail, { source: "hub", title: "Hub promote error" });
+            return;
+          }
+        }
+      } catch (err) {
+        this.appendBanner("error", "promote failed: " + err.message, { source: "hub", title: "Hub promote error" });
+      }
     },
 
     bindKeyboard() {

--- a/cmd/serf-hub/assets/style.css
+++ b/cmd/serf-hub/assets/style.css
@@ -2080,6 +2080,41 @@ body.app[data-sidebar-rail] .archive-btn { display: none; }
   border-color: var(--accent);
   outline: none;
 }
+/* issue #23: per-row edit / cancel affordances, same visual language as
+   qp-promote — subtle until hover/focus, then ink up with the accent. */
+.queue-preview-item .qp-edit,
+.queue-preview-item .qp-cancel {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  color: var(--ink-3);
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+}
+.queue-preview-item .qp-edit:hover,
+.queue-preview-item .qp-edit:focus-visible,
+.queue-preview-item .qp-cancel:hover,
+.queue-preview-item .qp-cancel:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent);
+  outline: none;
+}
+.queue-preview-item .qp-edit:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.queue-preview-item .qp-edit:disabled:hover {
+  color: var(--ink-3);
+  border-color: var(--line);
+}
 
 .input-card { background: color-mix(in srgb, var(--surface) 88%, var(--bg)); border: 0; border-radius: var(--radius-md); padding: var(--space-2) var(--space-3); min-height: 0; transition: outline-color var(--motion-fast), background var(--motion-fast); }
 /* kata 65mm: drop-active is set by the shared composer-attachments helper

--- a/cmd/serf-hub/assets/style.css
+++ b/cmd/serf-hub/assets/style.css
@@ -2107,11 +2107,13 @@ body.app[data-sidebar-rail] .archive-btn { display: none; }
   border-color: var(--accent);
   outline: none;
 }
-.queue-preview-item .qp-edit:disabled {
+.queue-preview-item .qp-edit:disabled,
+.queue-preview-item .qp-cancel:disabled {
   opacity: 0.4;
   cursor: default;
 }
-.queue-preview-item .qp-edit:disabled:hover {
+.queue-preview-item .qp-edit:disabled:hover,
+.queue-preview-item .qp-cancel:disabled:hover {
   color: var(--ink-3);
   border-color: var(--line);
 }

--- a/cmd/serf-hub/assets/style.css
+++ b/cmd/serf-hub/assets/style.css
@@ -2056,6 +2056,30 @@ body.app[data-sidebar-rail] .archive-btn { display: none; }
   white-space: nowrap;
   flex: 1;
 }
+/* issue #22: per-row promote-to-steering affordance. Subtle until
+   hover/focus, then inks up with the accent so it reads as an action. */
+.queue-preview-item .qp-promote {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  color: var(--ink-3);
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+}
+.queue-preview-item .qp-promote:hover,
+.queue-preview-item .qp-promote:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent);
+  outline: none;
+}
 
 .input-card { background: color-mix(in srgb, var(--surface) 88%, var(--bg)); border: 0; border-radius: var(--radius-md); padding: var(--space-2) var(--space-3); min-height: 0; transition: outline-color var(--motion-fast), background var(--motion-fast); }
 /* kata 65mm: drop-active is set by the shared composer-attachments helper

--- a/cmd/serf-hub/cov_exact_web_session_fuzz_test.go
+++ b/cmd/serf-hub/cov_exact_web_session_fuzz_test.go
@@ -55,6 +55,9 @@ func (s *exactWebSessionSource) QueueTurn(context.Context, appwire.TurnQueuePara
 func (s *exactWebSessionSource) DrainAsSteer(context.Context, appwire.TurnDrainAsSteerParams) error {
 	return s.err
 }
+func (s *exactWebSessionSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
+	return s.err
+}
 func (s *exactWebSessionSource) InterruptTurn(context.Context, appwire.TurnInterruptParams) error {
 	return s.err
 }

--- a/cmd/serf-hub/cov_exact_web_session_fuzz_test.go
+++ b/cmd/serf-hub/cov_exact_web_session_fuzz_test.go
@@ -58,6 +58,10 @@ func (s *exactWebSessionSource) DrainAsSteer(context.Context, appwire.TurnDrainA
 func (s *exactWebSessionSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
 	return s.err
 }
+
+func (s *exactWebSessionSource) CancelQueued(context.Context, appwire.TurnCancelQueuedParams) (appwire.TurnCancelQueuedResponse, error) {
+	return appwire.TurnCancelQueuedResponse{}, nil
+}
 func (s *exactWebSessionSource) InterruptTurn(context.Context, appwire.TurnInterruptParams) error {
 	return s.err
 }

--- a/cmd/serf-hub/cov_session_live_pass4_fuzz_test.go
+++ b/cmd/serf-hub/cov_session_live_pass4_fuzz_test.go
@@ -34,6 +34,10 @@ func (s *pass4ActionSource) DrainAsSteer(context.Context, appwire.TurnDrainAsSte
 func (s *pass4ActionSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
 	return s.err
 }
+
+func (s *pass4ActionSource) CancelQueued(context.Context, appwire.TurnCancelQueuedParams) (appwire.TurnCancelQueuedResponse, error) {
+	return appwire.TurnCancelQueuedResponse{}, nil
+}
 func (s *pass4ActionSource) ShutdownThread(context.Context, appwire.ThreadShutdownParams) error {
 	return s.err
 }

--- a/cmd/serf-hub/cov_session_live_pass4_fuzz_test.go
+++ b/cmd/serf-hub/cov_session_live_pass4_fuzz_test.go
@@ -31,6 +31,9 @@ func (s *pass4ActionSource) QueueTurn(context.Context, appwire.TurnQueueParams) 
 func (s *pass4ActionSource) DrainAsSteer(context.Context, appwire.TurnDrainAsSteerParams) error {
 	return s.err
 }
+func (s *pass4ActionSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
+	return s.err
+}
 func (s *pass4ActionSource) ShutdownThread(context.Context, appwire.ThreadShutdownParams) error {
 	return s.err
 }

--- a/cmd/serf-hub/cov_session_tree_pass6_fuzz_test.go
+++ b/cmd/serf-hub/cov_session_tree_pass6_fuzz_test.go
@@ -33,6 +33,10 @@ func (s *pass6SessionSource) DrainAsSteer(context.Context, appwire.TurnDrainAsSt
 func (s *pass6SessionSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
 	return s.err
 }
+
+func (s *pass6SessionSource) CancelQueued(context.Context, appwire.TurnCancelQueuedParams) (appwire.TurnCancelQueuedResponse, error) {
+	return appwire.TurnCancelQueuedResponse{}, nil
+}
 func (s *pass6SessionSource) ShutdownThread(context.Context, appwire.ThreadShutdownParams) error {
 	return s.err
 }

--- a/cmd/serf-hub/cov_session_tree_pass6_fuzz_test.go
+++ b/cmd/serf-hub/cov_session_tree_pass6_fuzz_test.go
@@ -30,6 +30,9 @@ func (s *pass6SessionSource) QueueTurn(context.Context, appwire.TurnQueueParams)
 func (s *pass6SessionSource) DrainAsSteer(context.Context, appwire.TurnDrainAsSteerParams) error {
 	return s.err
 }
+func (s *pass6SessionSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
+	return s.err
+}
 func (s *pass6SessionSource) ShutdownThread(context.Context, appwire.ThreadShutdownParams) error {
 	return s.err
 }

--- a/cmd/serf-hub/internal/appsource/codex_source.go
+++ b/cmd/serf-hub/internal/appsource/codex_source.go
@@ -359,6 +359,10 @@ func (s *CodexSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQ
 	return appwire.Unavailable("codex source does not support turn/promoteQueuedAsSteer")
 }
 
+func (s *CodexSource) CancelQueued(context.Context, appwire.TurnCancelQueuedParams) (appwire.TurnCancelQueuedResponse, error) {
+	return appwire.TurnCancelQueuedResponse{}, appwire.Unavailable("codex source does not support turn/cancelQueued")
+}
+
 func (s *CodexSource) ResolveSandboxEscalation(context.Context, appwire.SandboxEscalationResolveParams) error {
 	return appwire.Unavailable("codex source does not support serf/sandbox/escalation/resolve")
 }

--- a/cmd/serf-hub/internal/appsource/codex_source.go
+++ b/cmd/serf-hub/internal/appsource/codex_source.go
@@ -355,6 +355,10 @@ func (s *CodexSource) DrainAsSteer(context.Context, appwire.TurnDrainAsSteerPara
 	return appwire.Unavailable("codex source does not support turn/drainAsSteer")
 }
 
+func (s *CodexSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
+	return appwire.Unavailable("codex source does not support turn/promoteQueuedAsSteer")
+}
+
 func (s *CodexSource) ResolveSandboxEscalation(context.Context, appwire.SandboxEscalationResolveParams) error {
 	return appwire.Unavailable("codex source does not support serf/sandbox/escalation/resolve")
 }

--- a/cmd/serf-hub/internal/appsource/local_daemon.go
+++ b/cmd/serf-hub/internal/appsource/local_daemon.go
@@ -208,6 +208,16 @@ func (s *LocalDaemonSource) DrainAsSteer(ctx context.Context, params appwire.Tur
 	})
 }
 
+func (s *LocalDaemonSource) PromoteQueuedAsSteer(ctx context.Context, params appwire.TurnPromoteQueuedAsSteerParams) error {
+	entry, err := s.entryForRef(params.Ref, "")
+	if err != nil {
+		return err
+	}
+	return s.withClient(ctx, entry, func(client *appwire.Client) error {
+		return client.TurnPromoteQueuedAsSteer(ctx, params)
+	})
+}
+
 func (s *LocalDaemonSource) CompactThread(ctx context.Context, params appwire.ThreadCompactStartParams) error {
 	entry, err := s.entryForRef(params.Ref, "")
 	if err != nil {

--- a/cmd/serf-hub/internal/appsource/local_daemon.go
+++ b/cmd/serf-hub/internal/appsource/local_daemon.go
@@ -218,6 +218,23 @@ func (s *LocalDaemonSource) PromoteQueuedAsSteer(ctx context.Context, params app
 	})
 }
 
+func (s *LocalDaemonSource) CancelQueued(ctx context.Context, params appwire.TurnCancelQueuedParams) (appwire.TurnCancelQueuedResponse, error) {
+	entry, err := s.entryForRef(params.Ref, "")
+	if err != nil {
+		return appwire.TurnCancelQueuedResponse{}, err
+	}
+	var resp appwire.TurnCancelQueuedResponse
+	err = s.withClient(ctx, entry, func(client *appwire.Client) error {
+		var cerr error
+		resp, cerr = client.TurnCancelQueued(ctx, params)
+		return cerr
+	})
+	if err != nil {
+		return appwire.TurnCancelQueuedResponse{}, err
+	}
+	return resp, nil
+}
+
 func (s *LocalDaemonSource) CompactThread(ctx context.Context, params appwire.ThreadCompactStartParams) error {
 	entry, err := s.entryForRef(params.Ref, "")
 	if err != nil {

--- a/cmd/serf-hub/internal/appsource/registry_test.go
+++ b/cmd/serf-hub/internal/appsource/registry_test.go
@@ -42,6 +42,9 @@ func (f fakeSource) QueueTurn(context.Context, appwire.TurnQueueParams) error { 
 func (f fakeSource) DrainAsSteer(context.Context, appwire.TurnDrainAsSteerParams) error {
 	return nil
 }
+func (f fakeSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
+	return nil
+}
 func (f fakeSource) CompactThread(context.Context, appwire.ThreadCompactStartParams) error {
 	return nil
 }

--- a/cmd/serf-hub/internal/appsource/registry_test.go
+++ b/cmd/serf-hub/internal/appsource/registry_test.go
@@ -45,6 +45,9 @@ func (f fakeSource) DrainAsSteer(context.Context, appwire.TurnDrainAsSteerParams
 func (f fakeSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
 	return nil
 }
+func (f fakeSource) CancelQueued(context.Context, appwire.TurnCancelQueuedParams) (appwire.TurnCancelQueuedResponse, error) {
+	return appwire.TurnCancelQueuedResponse{}, nil
+}
 func (f fakeSource) CompactThread(context.Context, appwire.ThreadCompactStartParams) error {
 	return nil
 }

--- a/cmd/serf-hub/internal/appsource/source.go
+++ b/cmd/serf-hub/internal/appsource/source.go
@@ -20,6 +20,7 @@ type Source interface {
 	InterruptTurn(context.Context, appwire.TurnInterruptParams) error
 	QueueTurn(context.Context, appwire.TurnQueueParams) error
 	DrainAsSteer(context.Context, appwire.TurnDrainAsSteerParams) error
+	PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error
 	CompactThread(context.Context, appwire.ThreadCompactStartParams) error
 	ShutdownThread(context.Context, appwire.ThreadShutdownParams) error
 	SetThreadModel(context.Context, appwire.ThreadModelSetParams) error

--- a/cmd/serf-hub/internal/appsource/source.go
+++ b/cmd/serf-hub/internal/appsource/source.go
@@ -21,6 +21,7 @@ type Source interface {
 	QueueTurn(context.Context, appwire.TurnQueueParams) error
 	DrainAsSteer(context.Context, appwire.TurnDrainAsSteerParams) error
 	PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error
+	CancelQueued(context.Context, appwire.TurnCancelQueuedParams) (appwire.TurnCancelQueuedResponse, error)
 	CompactThread(context.Context, appwire.ThreadCompactStartParams) error
 	ShutdownThread(context.Context, appwire.ThreadShutdownParams) error
 	SetThreadModel(context.Context, appwire.ThreadModelSetParams) error

--- a/cmd/serf-hub/jstest/test-queue-edit-cancel.js
+++ b/cmd/serf-hub/jstest/test-queue-edit-cancel.js
@@ -50,6 +50,7 @@ const { window } = dom;
 window.marked = { parse: (t) => t };
 
 let fetchBehavior = { ok: true, status: 200, body: { removedText: "", removedImages: 0 } };
+let deferredFetchSettle = null;
 const fetchLog = [];
 window.fetch = (url, opts) => {
   if (typeof url === "string" && url.includes("/tasks")) {
@@ -62,12 +63,16 @@ window.fetch = (url, opts) => {
   }
   fetchLog.push({ url, opts });
   const b = fetchBehavior;
-  return Promise.resolve({
+  const respond = () => ({
     ok: b.ok,
     status: b.status,
     json: () => Promise.resolve(b.body || {}),
     text: () => Promise.resolve(b.ok ? JSON.stringify(b.body || {}) : (b.text || "conflict")),
   });
+  // defer: hold the response until the test settles it explicitly, so a
+  // request can be observed while still in flight (review M1).
+  if (b.defer) return new Promise(resolve => { deferredFetchSettle = () => resolve(respond()); });
+  return Promise.resolve(respond());
 };
 
 Object.defineProperty(window.HTMLTextAreaElement.prototype, "scrollHeight", {
@@ -282,6 +287,61 @@ async function testEditWithoutTextsDegradesHonestly() {
   pass(fetchLog.length === 1, "cancel should still work without texts, got " + fetchLog.length + " calls");
 }
 
+async function testInFlightGuardPreventsDoubleFire() {
+  // Review M1: while a cancel/edit request for an entry is in flight, the
+  // row's edit + cancel buttons are disabled — a double-click must not
+  // append the text to the composer twice or fire a second cancel that
+  // Conflicts confusingly.
+  primeQueue(["guard me"], ["q_a_jjj"], ["guard me"]);
+  fetchLog.length = 0;
+  fetchBehavior = { defer: true };
+  const row = list.children[0];
+  const editBtn = row.querySelector("[data-edit-index]");
+  const cancelBtn = row.querySelector("[data-cancel-index]");
+
+  editBtn.click();
+  await wait(10);
+  pass(fetchLog.length === 1, "expected one in-flight cancel, got " + fetchLog.length);
+  pass(editBtn.disabled === true, "edit button should be disabled while the request is in flight");
+  pass(cancelBtn.disabled === true, "cancel button should be disabled while the request is in flight");
+
+  // Double-clicks on the disabled buttons are no-ops.
+  editBtn.click();
+  cancelBtn.click();
+  await wait(10);
+  pass(fetchLog.length === 1, "double-click must not fire a second request, got " + fetchLog.length);
+  pass(composer.value === "guard me",
+    "composer should hold the text exactly once, got " + JSON.stringify(composer.value));
+
+  // Settle: the buttons re-enable for the (still-queued, in this test) row.
+  deferredFetchSettle();
+  await wait(20);
+  pass(cancelBtn.disabled === false, "cancel button should re-enable after the request settles");
+  pass(editBtn.disabled === false, "edit button should re-enable after the request settles");
+
+  composer.value = "";
+  composer.dispatchEvent(new window.Event("input", { bubbles: true }));
+}
+
+async function testInFlightGuardKeepsImageOnlyEditDisabled() {
+  // Re-enabling after a settle must not re-enable the edit button of an
+  // image-only entry (nothing to recompose).
+  primeQueue(["[image]"], ["q_b_kkk"], [""]);
+  fetchLog.length = 0;
+  fetchBehavior = { defer: true };
+  const row = list.children[0];
+  const editBtn = row.querySelector("[data-edit-index]");
+  const cancelBtn = row.querySelector("[data-cancel-index]");
+  cancelBtn.click();
+  await wait(10);
+  pass(fetchLog.length === 1, "expected one in-flight cancel, got " + fetchLog.length);
+  pass(cancelBtn.disabled === true, "cancel button should be disabled in flight");
+  deferredFetchSettle();
+  await wait(20);
+  pass(cancelBtn.disabled === false, "cancel button should re-enable after settle");
+  pass(editBtn.disabled === true, "image-only edit button must stay disabled after settle");
+}
+
 (async () => {
   await testRowsHaveEditAndCancelButtons();
   await testCancelPostsIndexAndEntryId();
@@ -291,6 +351,8 @@ async function testEditWithoutTextsDegradesHonestly() {
   await testEditWarnsAboutDroppedImages();
   await testEditImageOnlyEntryDisabled();
   await testEditWithoutTextsDegradesHonestly();
+  await testInFlightGuardPreventsDoubleFire();
+  await testInFlightGuardKeepsImageOnlyEditDisabled();
 
   if (failures.length === 0) {
     console.log("PASS: queue-preview per-message edit and cancel");

--- a/cmd/serf-hub/jstest/test-queue-edit-cancel.js
+++ b/cmd/serf-hub/jstest/test-queue-edit-cancel.js
@@ -1,0 +1,302 @@
+// test-queue-edit-cancel: verifies each queue-preview row offers per-message
+// edit and cancel actions (issue #23), alongside the promote action (issue
+// #22). Cancel POSTs the row index + expected entry id to
+// /s/<id>/cancel-queued (REST fallback; the appwire path is covered by Go
+// relay tests). Edit is cancel-and-recompose: the FULL untruncated text
+// (queueState.texts, never the truncated preview line) returns to the
+// composer — preserving any text already there — the sticky draft persists
+// through the same input-event path as real typing, and only then is the
+// queued copy canceled. The stale-edit race is honest: when the removal
+// fails (already consumed / queue shifted, review F1) the text stays in the
+// composer and the banner says so instead of silently duplicating.
+
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+
+const DRAFTS_SRC = fs.readFileSync(path.resolve(__dirname, "../assets/drafts.js"), "utf8");
+
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation"
+       data-session-id="01TEST"
+       data-active-turn-id="turn_live"
+       data-state="active"></div>
+  <form class="workspace-input" data-input-form data-session-id="01TEST">
+    <div class="composer-attachments" data-composer-attachments data-attachments></div>
+    <div class="queue-preview" data-queue-preview hidden>
+      <div class="queue-preview-header">
+        <span class="queue-preview-label">queued <span data-queue-depth>0</span></span>
+      </div>
+      <ul class="queue-preview-list" data-queue-list></ul>
+    </div>
+    <div class="input-card" data-drop-zone>
+      <textarea class="message-input" rows="1"></textarea>
+    </div>
+    <div class="input-controls">
+      <div class="controls-right">
+        <button type="button" class="btn btn-ghost" data-steer-trigger>steer</button>
+        <button type="submit" class="send-btn btn btn-primary"
+                data-capability-send="false"
+                data-capability-queue="true">send</button>
+      </div>
+    </div>
+    <div class="input-status" id="input-status"></div>
+    <input type="file" data-file-picker hidden>
+  </form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true, url: "http://localhost/" });
+
+const { window } = dom;
+window.marked = { parse: (t) => t };
+
+let fetchBehavior = { ok: true, status: 200, body: { removedText: "", removedImages: 0 } };
+const fetchLog = [];
+window.fetch = (url, opts) => {
+  if (typeof url === "string" && url.includes("/tasks")) {
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve([]),
+      text: () => Promise.resolve(""),
+    });
+  }
+  fetchLog.push({ url, opts });
+  const b = fetchBehavior;
+  return Promise.resolve({
+    ok: b.ok,
+    status: b.status,
+    json: () => Promise.resolve(b.body || {}),
+    text: () => Promise.resolve(b.ok ? JSON.stringify(b.body || {}) : (b.text || "conflict")),
+  });
+};
+
+Object.defineProperty(window.HTMLTextAreaElement.prototype, "scrollHeight", {
+  configurable: true,
+  get() { return 36; },
+});
+Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
+
+window.eval(DRAFTS_SRC);
+require("./load-renderer").evalRenderer(window);
+
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+const conv = window.document.getElementById("conversation");
+window.SerfRenderer.init(conv);
+
+const list = window.document.querySelector("[data-queue-list]");
+const composer = window.document.querySelector(".message-input");
+const wait = (ms) => new Promise(r => setTimeout(r, ms));
+
+function primeQueue(preview, ids, texts) {
+  const data = { depth: preview.length, preview, ids: ids || [] };
+  if (texts) data.texts = texts;
+  window.SerfRenderer.handle("QUEUE_CHANGED", { data: JSON.stringify(data) });
+}
+
+function bannerTexts() {
+  return Array.from(window.document.querySelectorAll(".banner")).map(b => b.textContent);
+}
+
+async function testRowsHaveEditAndCancelButtons() {
+  primeQueue(["investigate the failing test", "and then verify the regression"],
+    ["q_1_aaa", "q_2_bbb"],
+    ["investigate the failing test", "and then verify the regression"]);
+  pass(list.children.length === 2, "expected 2 rows, got " + list.children.length);
+  for (let i = 0; i < 2; i++) {
+    const editBtn = list.children[i].querySelector("[data-edit-index]");
+    const cancelBtn = list.children[i].querySelector("[data-cancel-index]");
+    pass(editBtn !== null, "row " + i + " should have an edit button");
+    pass(cancelBtn !== null, "row " + i + " should have a cancel button");
+    pass(editBtn && editBtn.getAttribute("data-edit-index") === String(i),
+      "row " + i + " edit button should carry index " + i);
+    pass(cancelBtn && cancelBtn.getAttribute("data-cancel-index") === String(i),
+      "row " + i + " cancel button should carry index " + i);
+    // The promote action (issue #22) must still be there too.
+    pass(list.children[i].querySelector("[data-promote-index]") !== null,
+      "row " + i + " should still have a promote button");
+  }
+}
+
+async function testCancelPostsIndexAndEntryId() {
+  fetchLog.length = 0;
+  fetchBehavior = { ok: true, status: 200, body: { removedText: "and then verify the regression", removedImages: 0 } };
+  const btn = list.children[1].querySelector("[data-cancel-index]");
+  btn.click();
+  await wait(20);
+
+  const calls = fetchLog.map(c => c.url);
+  pass(calls.length === 1 && calls[0].includes("/s/01TEST/cancel-queued"),
+    "expected one /cancel-queued call, got " + JSON.stringify(calls));
+  const body = JSON.parse((fetchLog[0] && fetchLog[0].opts && fetchLog[0].opts.body) || "{}");
+  pass(body.index === 1, "expected body.index=1, got " + JSON.stringify(body));
+  pass(body.entryId === "q_2_bbb",
+    "expected body.entryId=q_2_bbb (review F1 identity), got " + JSON.stringify(body));
+
+  // No local mirror: the row stays until the daemon's authoritative
+  // thread/queueChanged lands with the canceled entry removed.
+  primeQueue(["investigate the failing test"], ["q_1_aaa"], ["investigate the failing test"]);
+  pass(list.children.length === 1, "expected 1 row after daemon queueChanged, got " + list.children.length);
+  pass(list.children[0].querySelector("[data-cancel-index]").getAttribute("data-cancel-index") === "0",
+    "re-rendered row should re-key its cancel index to 0");
+}
+
+async function testCancelFailureSurfacesBanner() {
+  primeQueue(["still queued"], ["q_3_ccc"], ["still queued"]);
+  fetchLog.length = 0;
+  fetchBehavior = { ok: false, status: 409, text: "cancel: queue entry at index 0 no longer matches the snapshot (queue changed)" };
+  const before = bannerTexts().length;
+  list.children[0].querySelector("[data-cancel-index]").click();
+  await wait(20);
+
+  pass(fetchLog.length === 1, "expected one cancel attempt, got " + fetchLog.length);
+  pass(window.SerfRenderer.queueState.depth === 1,
+    "queue state must be unchanged on cancel failure, got depth " + window.SerfRenderer.queueState.depth);
+  pass(list.children.length === 1, "row must stay queued on cancel failure");
+  const news = bannerTexts().slice(before);
+  pass(news.some(t => /cancel failed/i.test(t)),
+    "expected new banner mentioning 'cancel failed'; new banners: " + news.join(", "));
+}
+
+async function testEditRestoresFullTextPreservingComposer() {
+  primeQueue(["line one", "second message"], ["q_4_ddd", "q_5_eee"],
+    ["line one\nline two\nline three", "second message"]);
+  composer.value = "draft in progress";
+  composer.dispatchEvent(new window.Event("input", { bubbles: true }));
+
+  fetchLog.length = 0;
+  fetchBehavior = { ok: true, status: 200, body: { removedText: "line one\nline two\nline three", removedImages: 0 } };
+  list.children[0].querySelector("[data-edit-index]").click();
+  await wait(20);
+
+  // The FULL multi-line text — not the truncated preview line — is appended
+  // after the existing composer text, which is preserved.
+  pass(composer.value === "draft in progress\n\nline one\nline two\nline three",
+    "composer should preserve existing text and append the full queued text, got " + JSON.stringify(composer.value));
+  // The sticky draft persisted through the same input-event path as typing.
+  const draft = window.localStorage.getItem("serf-hub.draft.01TEST");
+  pass(draft === "draft in progress\n\nline one\nline two\nline three",
+    "sticky draft should hold the recomposed text, got " + JSON.stringify(draft));
+  // The queued copy is canceled with its review-F1 identity.
+  const calls = fetchLog.map(c => c.url);
+  pass(calls.length === 1 && calls[0].includes("/s/01TEST/cancel-queued"),
+    "edit should cancel the queued copy, got " + JSON.stringify(calls));
+  const body = JSON.parse((fetchLog[0] && fetchLog[0].opts && fetchLog[0].opts.body) || "{}");
+  pass(body.index === 0 && body.entryId === "q_4_ddd",
+    "edit cancel should carry index 0 + q_4_ddd, got " + JSON.stringify(body));
+  pass(window.document.activeElement === composer, "composer should be focused after edit");
+
+  // Daemon confirms the removal; composer text is untouched by the re-render.
+  primeQueue(["second message"], ["q_5_eee"], ["second message"]);
+  pass(list.children.length === 1, "expected 1 row after daemon queueChanged, got " + list.children.length);
+  pass(composer.value === "draft in progress\n\nline one\nline two\nline three",
+    "composer text must survive the queue re-render, got " + JSON.stringify(composer.value));
+
+  // Clean the composer for the next test.
+  composer.value = "";
+  composer.dispatchEvent(new window.Event("input", { bubbles: true }));
+}
+
+async function testEditFailureKeepsTextAndIsHonest() {
+  // The stale-edit race: the entry was consumed between the snapshot and the
+  // click, so the cancel comes back 409. The text must STILL be in the
+  // composer (it was restored before the removal attempt) and the banner
+  // must say the queued copy could not be removed — no silent duplication.
+  primeQueue(["about to be consumed"], ["q_6_fff"], ["about to be consumed"]);
+  fetchLog.length = 0;
+  fetchBehavior = { ok: false, status: 409, text: "cancel: queue index 0 out of range (depth 0)" };
+  const before = bannerTexts().length;
+  list.children[0].querySelector("[data-edit-index]").click();
+  await wait(20);
+
+  pass(fetchLog.length === 1, "expected one cancel attempt, got " + fetchLog.length);
+  pass(composer.value === "about to be consumed",
+    "edited text must land in the composer even when removal fails, got " + JSON.stringify(composer.value));
+  pass(window.localStorage.getItem("serf-hub.draft.01TEST") === "about to be consumed",
+    "sticky draft should hold the restored text even when removal fails");
+  const news = bannerTexts().slice(before);
+  pass(news.some(t => /composer/i.test(t) && /could not be removed/i.test(t)),
+    "expected honest banner: text in composer + queued copy not removed; new banners: " + news.join(", "));
+  pass(window.SerfRenderer.queueState.depth === 1,
+    "queue state must be unchanged on failed edit-removal, got depth " + window.SerfRenderer.queueState.depth);
+
+  composer.value = "";
+  composer.dispatchEvent(new window.Event("input", { bubbles: true }));
+}
+
+async function testEditWarnsAboutDroppedImages() {
+  primeQueue(["look at these screenshots"], ["q_7_ggg"], ["look at these screenshots"]);
+  fetchLog.length = 0;
+  fetchBehavior = { ok: true, status: 200, body: { removedText: "look at these screenshots", removedImages: 2 } };
+  const before = bannerTexts().length;
+  list.children[0].querySelector("[data-edit-index]").click();
+  await wait(20);
+
+  pass(composer.value === "look at these screenshots",
+    "composer should hold the restored text, got " + JSON.stringify(composer.value));
+  const news = bannerTexts().slice(before);
+  pass(news.some(t => /re-attach/i.test(t)),
+    "expected a warning about dropped image attachments; new banners: " + news.join(", "));
+
+  composer.value = "";
+  composer.dispatchEvent(new window.Event("input", { bubbles: true }));
+}
+
+async function testEditImageOnlyEntryDisabled() {
+  // An image-only queued entry has no text to recompose; its edit button is
+  // disabled with an honest hint while cancel keeps working.
+  primeQueue(["[image]"], ["q_8_hhh"], [""]);
+  const editBtn = list.children[0].querySelector("[data-edit-index]");
+  pass(editBtn.disabled === true, "edit should be disabled for an image-only queued message");
+  fetchLog.length = 0;
+  fetchBehavior = { ok: true, status: 200, body: { removedText: "", removedImages: 1 } };
+  editBtn.click();
+  await wait(20);
+  pass(fetchLog.length === 0, "disabled edit must not call the daemon, got " + fetchLog.length + " calls");
+  pass(composer.value === "", "disabled edit must not touch the composer");
+
+  list.children[0].querySelector("[data-cancel-index]").click();
+  await wait(20);
+  pass(fetchLog.length === 1 && fetchLog[0].url.includes("/cancel-queued"),
+    "cancel should still work for an image-only entry, got " + fetchLog.length + " calls");
+}
+
+async function testEditWithoutTextsDegradesHonestly() {
+  // An old daemon sends no texts. Edit must say it is unavailable rather
+  // than restoring the truncated preview line as if it were the message.
+  primeQueue(["only the first line is shown"], ["q_9_iii"]); // no texts
+  fetchLog.length = 0;
+  const before = bannerTexts().length;
+  list.children[0].querySelector("[data-edit-index]").click();
+  await wait(20);
+  pass(fetchLog.length === 0, "edit without full texts must not call the daemon");
+  pass(composer.value === "", "edit without full texts must not touch the composer");
+  const news = bannerTexts().slice(before);
+  pass(news.some(t => /not available/i.test(t)),
+    "expected an honest 'edit not available' banner; new banners: " + news.join(", "));
+  // Cancel is unaffected by the missing texts.
+  fetchBehavior = { ok: true, status: 200, body: { removedText: "only the first line is shown", removedImages: 0 } };
+  list.children[0].querySelector("[data-cancel-index]").click();
+  await wait(20);
+  pass(fetchLog.length === 1, "cancel should still work without texts, got " + fetchLog.length + " calls");
+}
+
+(async () => {
+  await testRowsHaveEditAndCancelButtons();
+  await testCancelPostsIndexAndEntryId();
+  await testCancelFailureSurfacesBanner();
+  await testEditRestoresFullTextPreservingComposer();
+  await testEditFailureKeepsTextAndIsHonest();
+  await testEditWarnsAboutDroppedImages();
+  await testEditImageOnlyEntryDisabled();
+  await testEditWithoutTextsDegradesHonestly();
+
+  if (failures.length === 0) {
+    console.log("PASS: queue-preview per-message edit and cancel");
+    process.exit(0);
+  } else {
+    for (const f of failures) console.log(f);
+    process.exit(1);
+  }
+})();

--- a/cmd/serf-hub/jstest/test-queue-promote.js
+++ b/cmd/serf-hub/jstest/test-queue-promote.js
@@ -79,14 +79,14 @@ window.SerfRenderer.init(conv);
 const list = window.document.querySelector("[data-queue-list]");
 const wait = (ms) => new Promise(r => setTimeout(r, ms));
 
-function primeQueue(preview) {
+function primeQueue(preview, ids) {
   window.SerfRenderer.handle("QUEUE_CHANGED", {
-    data: JSON.stringify({ depth: preview.length, preview }),
+    data: JSON.stringify({ depth: preview.length, preview, ids: ids || [] }),
   });
 }
 
 async function testRowsHavePromoteButtons() {
-  primeQueue(["investigate the failing test", "and then verify the regression"]);
+  primeQueue(["investigate the failing test", "and then verify the regression"], ["q_1_aaa", "q_2_bbb"]);
   pass(list.children.length === 2, "expected 2 rows, got " + list.children.length);
   for (let i = 0; i < 2; i++) {
     const btn = list.children[i].querySelector("[data-promote-index]");
@@ -96,7 +96,7 @@ async function testRowsHavePromoteButtons() {
   }
 }
 
-async function testPromotePostsIndex() {
+async function testPromotePostsIndexAndEntryId() {
   fetchLog.length = 0;
   fetchResponseOk = true;
   const btn = list.children[1].querySelector("[data-promote-index]");
@@ -108,10 +108,12 @@ async function testPromotePostsIndex() {
     "expected one /promote-queued call, got " + JSON.stringify(calls));
   const body = JSON.parse((fetchLog[0] && fetchLog[0].opts && fetchLog[0].opts.body) || "{}");
   pass(body.index === 1, "expected body.index=1, got " + JSON.stringify(body));
+  pass(body.entryId === "q_2_bbb",
+    "expected body.entryId=q_2_bbb (review F1 identity), got " + JSON.stringify(body));
 
   // No local mirror: the row stays until the daemon's authoritative
   // thread/queueChanged lands with the promoted entry removed.
-  primeQueue(["investigate the failing test"]);
+  primeQueue(["investigate the failing test"], ["q_1_aaa"]);
   pass(list.children.length === 1, "expected 1 row after daemon queueChanged, got " + list.children.length);
   pass(list.children[0].textContent.includes("investigate the failing test"),
     "expected remaining row to be the first message, got " + list.children[0].textContent);
@@ -119,8 +121,23 @@ async function testPromotePostsIndex() {
     "re-rendered row should re-key its promote index to 0");
 }
 
+async function testPromoteUsesFreshIdAfterReRender() {
+  // The row re-rendered with id q_1_aaa at index 0 — a promote must send
+  // THAT id, not a stale one from an earlier snapshot.
+  fetchLog.length = 0;
+  fetchResponseOk = true;
+  const btn = list.children[0].querySelector("[data-promote-index]");
+  btn.click();
+  await wait(20);
+  const body = JSON.parse((fetchLog[0] && fetchLog[0].opts && fetchLog[0].opts.body) || "{}");
+  pass(body.index === 0 && body.entryId === "q_1_aaa",
+    "expected promote of re-rendered row to carry its current id, got " + JSON.stringify(body));
+}
+
 async function testPromoteFailureSurfacesBanner() {
-  primeQueue(["still queued"]);
+  // The 409 here is the review-F1 shape: the daemon rejected the promote
+  // because the queue shifted under the preview's snapshot.
+  primeQueue(["still queued"], ["q_3_ccc"]);
   fetchLog.length = 0;
   fetchResponseOk = false;
   const bannersBefore = window.document.querySelectorAll(".banner").length;
@@ -143,7 +160,8 @@ async function testPromoteFailureSurfacesBanner() {
 
 (async () => {
   await testRowsHavePromoteButtons();
-  await testPromotePostsIndex();
+  await testPromotePostsIndexAndEntryId();
+  await testPromoteUsesFreshIdAfterReRender();
   await testPromoteFailureSurfacesBanner();
 
   if (failures.length === 0) {

--- a/cmd/serf-hub/jstest/test-queue-promote.js
+++ b/cmd/serf-hub/jstest/test-queue-promote.js
@@ -1,0 +1,156 @@
+// test-queue-promote: verifies each queue-preview row offers a per-message
+// promote-to-steering action (issue #22). Clicking it POSTs the row index to
+// /s/<id>/promote-queued (REST fallback; the appwire path is covered by
+// Go relay tests), the daemon's thread/queueChanged re-renders the preview
+// without the promoted row, and a failed promote surfaces an error banner
+// without touching local queue state.
+
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+
+const dom = new JSDOM(`<!DOCTYPE html><html><body>
+  <header class="workspace-header" data-session-id="01TEST"></header>
+  <div id="conversation"
+       data-session-id="01TEST"
+       data-active-turn-id="turn_live"
+       data-state="active"></div>
+  <form class="workspace-input" data-input-form data-session-id="01TEST">
+    <div class="composer-attachments" data-composer-attachments data-attachments></div>
+    <div class="queue-preview" data-queue-preview hidden>
+      <div class="queue-preview-header">
+        <span class="queue-preview-label">queued <span data-queue-depth>0</span></span>
+      </div>
+      <ul class="queue-preview-list" data-queue-list></ul>
+    </div>
+    <div class="input-card" data-drop-zone>
+      <textarea class="message-input" rows="1"></textarea>
+    </div>
+    <div class="input-controls">
+      <div class="controls-right">
+        <button type="button" class="btn btn-ghost" data-steer-trigger>steer</button>
+        <button type="submit" class="send-btn btn btn-primary"
+                data-capability-send="false"
+                data-capability-queue="true">send</button>
+      </div>
+    </div>
+    <div class="input-status" id="input-status"></div>
+    <input type="file" data-file-picker hidden>
+  </form>
+</body></html>`, { runScripts: "outside-only", pretendToBeVisual: true });
+
+const { window } = dom;
+window.marked = { parse: (t) => t };
+
+let fetchResponseOk = true;
+const fetchLog = [];
+window.fetch = (url, opts) => {
+  if (typeof url === "string" && url.includes("/tasks")) {
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve([]),
+      text: () => Promise.resolve(""),
+    });
+  }
+  fetchLog.push({ url, opts });
+  return Promise.resolve({
+    ok: fetchResponseOk,
+    status: fetchResponseOk ? 204 : 409,
+    json: () => Promise.resolve({}),
+    text: () => Promise.resolve(fetchResponseOk ? "" : "no active turn to steer"),
+  });
+};
+
+Object.defineProperty(window.HTMLTextAreaElement.prototype, "scrollHeight", {
+  configurable: true,
+  get() { return 36; },
+});
+Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
+
+require("./load-renderer").evalRenderer(window);
+
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+const conv = window.document.getElementById("conversation");
+window.SerfRenderer.init(conv);
+
+const list = window.document.querySelector("[data-queue-list]");
+const wait = (ms) => new Promise(r => setTimeout(r, ms));
+
+function primeQueue(preview) {
+  window.SerfRenderer.handle("QUEUE_CHANGED", {
+    data: JSON.stringify({ depth: preview.length, preview }),
+  });
+}
+
+async function testRowsHavePromoteButtons() {
+  primeQueue(["investigate the failing test", "and then verify the regression"]);
+  pass(list.children.length === 2, "expected 2 rows, got " + list.children.length);
+  for (let i = 0; i < 2; i++) {
+    const btn = list.children[i].querySelector("[data-promote-index]");
+    pass(btn !== null, "row " + i + " should have a promote button");
+    pass(btn && btn.getAttribute("data-promote-index") === String(i),
+      "row " + i + " promote button should carry index " + i + ", got " + (btn && btn.getAttribute("data-promote-index")));
+  }
+}
+
+async function testPromotePostsIndex() {
+  fetchLog.length = 0;
+  fetchResponseOk = true;
+  const btn = list.children[1].querySelector("[data-promote-index]");
+  btn.click();
+  await wait(20);
+
+  const calls = fetchLog.map(c => c.url);
+  pass(calls.length === 1 && calls[0].includes("/s/01TEST/promote-queued"),
+    "expected one /promote-queued call, got " + JSON.stringify(calls));
+  const body = JSON.parse((fetchLog[0] && fetchLog[0].opts && fetchLog[0].opts.body) || "{}");
+  pass(body.index === 1, "expected body.index=1, got " + JSON.stringify(body));
+
+  // No local mirror: the row stays until the daemon's authoritative
+  // thread/queueChanged lands with the promoted entry removed.
+  primeQueue(["investigate the failing test"]);
+  pass(list.children.length === 1, "expected 1 row after daemon queueChanged, got " + list.children.length);
+  pass(list.children[0].textContent.includes("investigate the failing test"),
+    "expected remaining row to be the first message, got " + list.children[0].textContent);
+  pass(list.children[0].querySelector("[data-promote-index]").getAttribute("data-promote-index") === "0",
+    "re-rendered row should re-key its promote index to 0");
+}
+
+async function testPromoteFailureSurfacesBanner() {
+  primeQueue(["still queued"]);
+  fetchLog.length = 0;
+  fetchResponseOk = false;
+  const bannersBefore = window.document.querySelectorAll(".banner").length;
+  const btn = list.children[0].querySelector("[data-promote-index]");
+  btn.click();
+  await wait(20);
+
+  pass(fetchLog.length === 1, "expected one promote attempt, got " + fetchLog.length);
+  pass(window.SerfRenderer.queueState.depth === 1,
+    "queue state must be unchanged on promote failure, got depth " + window.SerfRenderer.queueState.depth);
+  pass(list.children.length === 1, "row must stay queued on promote failure");
+  const bannersAfter = window.document.querySelectorAll(".banner");
+  pass(bannersAfter.length > bannersBefore,
+    "expected a new error banner after promote failure; before=" + bannersBefore + " after=" + bannersAfter.length);
+  const newBanners = Array.from(bannersAfter).slice(bannersBefore);
+  pass(newBanners.some(b => /promote failed/i.test(b.textContent)),
+    "expected new banner mentioning 'promote failed'; new banners: " + newBanners.map(b => b.textContent).join(", "));
+  fetchResponseOk = true;
+}
+
+(async () => {
+  await testRowsHavePromoteButtons();
+  await testPromotePostsIndex();
+  await testPromoteFailureSurfacesBanner();
+
+  if (failures.length === 0) {
+    console.log("PASS: queue-preview per-message promote to steering");
+    process.exit(0);
+  } else {
+    for (const f of failures) console.log(f);
+    process.exit(1);
+  }
+})();

--- a/cmd/serf-hub/web_cancel_test.go
+++ b/cmd/serf-hub/web_cancel_test.go
@@ -44,6 +44,12 @@ func (s *cancelRecordingSource) CancelQueued(_ context.Context, params appwire.T
 	return appwire.TurnCancelQueuedResponse{RemovedText: s.removedText, RemovedImages: s.removedImages}, nil
 }
 
+// newCancelThread uses the REALISTIC mid-turn capability set (review C1):
+// Send is false while a turn is in flight — exactly when the queue preview
+// and its cancel/edit buttons exist. An earlier draft of this test stubbed
+// the impossible combination {Send:true, Steer:true, Queue:true}, which
+// masked that gating cancel on the Send capability 503'd every real
+// mid-turn cancel/edit.
 func newCancelThread() appwire.Thread {
 	return appwire.Thread{
 		ID: "thread-1", SessionID: "thread-1", Source: "remote", Name: "cancel test",
@@ -51,7 +57,7 @@ func newCancelThread() appwire.Thread {
 		Status: appwire.ThreadStatus{Type: "active"},
 		Turns:  []appwire.Turn{{ID: "turn-1", Status: appwire.TurnStatusCompleted}},
 		Serf: appwire.SerfThread{Ref: "remote:thread-1", ActiveTurnID: "turn-2",
-			Capabilities: appwire.ThreadCapabilities{Send: true, Steer: true, Queue: true}},
+			Capabilities: appwire.ThreadCapabilities{Send: false, Steer: true, Queue: true}},
 	}
 }
 
@@ -72,6 +78,22 @@ func postCancel(web *WebServer, route, body string) *httptest.ResponseRecorder {
 	req := httptest.NewRequest(http.MethodPost, route, strings.NewReader(body))
 	web.Handler().ServeHTTP(rec, req)
 	return rec
+}
+
+// TestWebCancelQueuedWorksWithRealisticMidTurnCaps is the review-C1
+// regression test: with a turn in flight the daemon projects Send=false,
+// Steer=true, Queue=true. The REST path must reach the source (gated on
+// Queue), not 503 with "send is not available for this session".
+func TestWebCancelQueuedWorksWithRealisticMidTurnCaps(t *testing.T) {
+	web, source := newCancelHarness()
+	source.removedText = "mid-turn text"
+	rec := postCancel(web, "/s/remote%3Athread-1/cancel-queued", `{"index":0,"entryId":"q_1_aaa"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s, want 200 with realistic mid-turn caps {Send:false,Steer:true,Queue:true}", rec.Code, rec.Body.String())
+	}
+	if source.calls != 1 {
+		t.Fatalf("source called %d times, want 1", source.calls)
+	}
 }
 
 func TestWebCancelQueuedRelaysIndexAndEchoesRemoval(t *testing.T) {
@@ -147,7 +169,9 @@ func TestWebCancelQueuedSurfacesDaemonConflict(t *testing.T) {
 // TestHubRPCCancelQueuedRelays drives the appwire RPC path: the hub app
 // server must route turn/cancelQueued to the source owning the ref,
 // forwarding the index and echoing the removal, and reject a negative index
-// client-side.
+// client-side. The scripted thread carries the realistic mid-turn caps
+// {Send:false, Steer:true, Queue:true} (review C1), so this also pins that
+// the relay gates on Queue — a Send-gated relay would 503 here.
 func TestHubRPCCancelQueuedRelays(t *testing.T) {
 	_, source := newCancelHarness()
 	source.removedText = "echo me"

--- a/cmd/serf-hub/web_cancel_test.go
+++ b/cmd/serf-hub/web_cancel_test.go
@@ -1,0 +1,199 @@
+package main
+
+// Tests for POST /s/<id>/cancel-queued (issue #23): the hub REST fallback
+// for the queue-preview row's cancel action (and the removal half of the
+// row's edit action). The hub relays the index to the daemon's
+// turn/cancelQueued and passes the removed-text echo back to the client;
+// failures surface honestly (400 on a malformed body, 404 when the session
+// isn't live, the daemon's Conflict when the index no longer resolves or
+// the queue shifted under the client's snapshot, review F1).
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"primeradiant.com/serf/appwire"
+	"primeradiant.com/serf/cmd/serf-hub/internal/appsource"
+	"primeradiant.com/serf/cmd/serf-hub/internal/hubcore"
+)
+
+// cancelRecordingSource is a scripted remote source that records the cancel
+// params it was asked to relay.
+type cancelRecordingSource struct {
+	*scriptedAppSource
+	gotIndex      int
+	gotExpectedID string
+	calls         int
+	err           error
+	removedText   string
+	removedImages int
+}
+
+func (s *cancelRecordingSource) CancelQueued(_ context.Context, params appwire.TurnCancelQueuedParams) (appwire.TurnCancelQueuedResponse, error) {
+	s.calls++
+	s.gotIndex = params.Index
+	s.gotExpectedID = params.ExpectedEntryID
+	if s.err != nil {
+		return appwire.TurnCancelQueuedResponse{}, s.err
+	}
+	return appwire.TurnCancelQueuedResponse{RemovedText: s.removedText, RemovedImages: s.removedImages}, nil
+}
+
+func newCancelThread() appwire.Thread {
+	return appwire.Thread{
+		ID: "thread-1", SessionID: "thread-1", Source: "remote", Name: "cancel test",
+		CWD: "/work/project", ModelProvider: "provider/model",
+		Status: appwire.ThreadStatus{Type: "active"},
+		Turns:  []appwire.Turn{{ID: "turn-1", Status: appwire.TurnStatusCompleted}},
+		Serf: appwire.SerfThread{Ref: "remote:thread-1", ActiveTurnID: "turn-2",
+			Capabilities: appwire.ThreadCapabilities{Send: true, Steer: true, Queue: true}},
+	}
+}
+
+func newCancelHarness() (*WebServer, *cancelRecordingSource) {
+	source := &cancelRecordingSource{
+		scriptedAppSource: &scriptedAppSource{id: "remote", thread: newCancelThread()},
+		gotIndex:          -1,
+	}
+	web := NewWebServer(hubcore.WebConfig{})
+	registry := appsource.NewRegistry()
+	registry.Add(source)
+	web.sources = registry
+	return web, source
+}
+
+func postCancel(web *WebServer, route, body string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, route, strings.NewReader(body))
+	web.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+func TestWebCancelQueuedRelaysIndexAndEchoesRemoval(t *testing.T) {
+	web, source := newCancelHarness()
+	source.removedText = "the full\nmulti-line text"
+	source.removedImages = 2
+	rec := postCancel(web, "/s/remote%3Athread-1/cancel-queued", `{"index":1,"entryId":"q_7_abc"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if source.calls != 1 || source.gotIndex != 1 {
+		t.Fatalf("cancel relay calls=%d index=%d, want 1/1", source.calls, source.gotIndex)
+	}
+	if source.gotExpectedID != "q_7_abc" {
+		t.Fatalf("cancel relay expectedEntryId=%q, want q_7_abc", source.gotExpectedID)
+	}
+	var body cancelQueuedResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response not JSON: %v (%q)", err, rec.Body.String())
+	}
+	if body.RemovedText != "the full\nmulti-line text" || body.RemovedImages != 2 {
+		t.Fatalf("response=%+v, want removed text + image count echoed", body)
+	}
+}
+
+func TestWebCancelQueuedRejectsNegativeIndex(t *testing.T) {
+	web, source := newCancelHarness()
+	rec := postCancel(web, "/s/remote%3Athread-1/cancel-queued", `{"index":-1}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+	if source.calls != 0 {
+		t.Fatalf("source called %d times, want 0", source.calls)
+	}
+}
+
+func TestWebCancelQueuedRejectsInvalidJSON(t *testing.T) {
+	web, source := newCancelHarness()
+	rec := postCancel(web, "/s/remote%3Athread-1/cancel-queued", `{"index":`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+	if source.calls != 0 {
+		t.Fatalf("source called %d times, want 0", source.calls)
+	}
+}
+
+func TestWebCancelQueuedNotLive(t *testing.T) {
+	// A local route id with no roster entry is not live; the hub must 404
+	// before reaching any source.
+	web, source := newCancelHarness()
+	rec := postCancel(web, "/s/01MISSING/cancel-queued", `{"index":0}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+	if source.calls != 0 {
+		t.Fatalf("source called %d times, want 0", source.calls)
+	}
+}
+
+func TestWebCancelQueuedSurfacesDaemonConflict(t *testing.T) {
+	web, source := newCancelHarness()
+	source.err = appwire.Conflict("cancel: queue entry at index 0 no longer matches the snapshot (queue changed)")
+	rec := postCancel(web, "/s/remote%3Athread-1/cancel-queued", `{"index":0}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status=%d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	if source.calls != 1 {
+		t.Fatalf("source called %d times, want 1", source.calls)
+	}
+}
+
+// TestHubRPCCancelQueuedRelays drives the appwire RPC path: the hub app
+// server must route turn/cancelQueued to the source owning the ref,
+// forwarding the index and echoing the removal, and reject a negative index
+// client-side.
+func TestHubRPCCancelQueuedRelays(t *testing.T) {
+	_, source := newCancelHarness()
+	source.removedText = "echo me"
+	registry := appsource.NewRegistry()
+	registry.Add(source)
+	server := newHubAppServer(hubcore.WebConfig{Past: hubcore.NewPastIndex("")}, registry)
+
+	dispatch := func(params appwire.TurnCancelQueuedParams) (any, error) {
+		raw, err := json.Marshal(params)
+		if err != nil {
+			t.Fatalf("MarshalParams: %v", err)
+		}
+		return server.Router().Dispatch(context.Background(), appwire.Request{
+			ID:     appwire.NewIntID(1),
+			Method: appwire.MethodTurnCancelQueued,
+			Params: raw,
+		})
+	}
+
+	result, err := dispatch(appwire.TurnCancelQueuedParams{Ref: "remote:thread-1", Index: 2, ExpectedEntryID: "q_9_def"})
+	if err != nil {
+		t.Fatalf("dispatch cancel: %v", err)
+	}
+	if source.calls != 1 || source.gotIndex != 2 {
+		t.Fatalf("cancel relay calls=%d index=%d, want 1/2", source.calls, source.gotIndex)
+	}
+	if source.gotExpectedID != "q_9_def" {
+		t.Fatalf("cancel relay expectedEntryId=%q, want q_9_def", source.gotExpectedID)
+	}
+	resp, ok := result.(appwire.TurnCancelQueuedResponse)
+	if !ok {
+		t.Fatalf("result type=%T, want TurnCancelQueuedResponse", result)
+	}
+	if resp.RemovedText != "echo me" {
+		t.Fatalf("removedText=%q, want echo me", resp.RemovedText)
+	}
+
+	_, err = dispatch(appwire.TurnCancelQueuedParams{Ref: "remote:thread-1", Index: -1})
+	if err == nil {
+		t.Fatal("expected error for negative index")
+	}
+	var wireErr appwire.WireError
+	if !errors.As(err, &wireErr) || wireErr.Code != appwire.CodeInvalidParams {
+		t.Fatalf("err=%v, want InvalidParams wire error", err)
+	}
+	if source.calls != 1 {
+		t.Fatalf("source called %d times after negative index, want 1", source.calls)
+	}
+}

--- a/cmd/serf-hub/web_mutating_fuzz_test.go
+++ b/cmd/serf-hub/web_mutating_fuzz_test.go
@@ -43,6 +43,7 @@ var mutatingRoutes = []mutRoute{
 	{http.MethodPost, "/s/{id}/steer", true},
 	{http.MethodPost, "/s/{id}/queue", true},
 	{http.MethodPost, "/s/{id}/drain-as-steer", true},
+	{http.MethodPost, "/s/{id}/promote-queued", true},
 }
 
 // buildMutatingTarget substitutes the fuzzed id into a route template, escaping
@@ -123,6 +124,7 @@ func FuzzWebMutatingHandler(f *testing.F) {
 		{"/s/{id}/steer", sandboxSessionID, `{"text":"go"}`},
 		{"/s/{id}/queue", sandboxSessionID, `{"text":"later"}`},
 		{"/s/{id}/drain-as-steer", sandboxSessionID, `{}`},
+		{"/s/{id}/promote-queued", sandboxSessionID, `{"index":0}`},
 	}
 	for _, seed := range seeds {
 		f.Add(idx(seed.template), seed.id, []byte(seed.body))

--- a/cmd/serf-hub/web_promote_test.go
+++ b/cmd/serf-hub/web_promote_test.go
@@ -24,14 +24,16 @@ import (
 // promote params it was asked to relay.
 type promoteRecordingSource struct {
 	*scriptedAppSource
-	gotIndex int
-	calls    int
-	err      error
+	gotIndex      int
+	gotExpectedID string
+	calls         int
+	err           error
 }
 
 func (s *promoteRecordingSource) PromoteQueuedAsSteer(_ context.Context, params appwire.TurnPromoteQueuedAsSteerParams) error {
 	s.calls++
 	s.gotIndex = params.Index
+	s.gotExpectedID = params.ExpectedEntryID
 	return s.err
 }
 
@@ -71,12 +73,15 @@ func postPromote(web *WebServer, route, body string) *httptest.ResponseRecorder 
 
 func TestWebPromoteQueuedRelaysIndex(t *testing.T) {
 	web, source := newPromoteHarness()
-	rec := postPromote(web, "/s/remote%3Athread-1/promote-queued", `{"index":1}`)
+	rec := postPromote(web, "/s/remote%3Athread-1/promote-queued", `{"index":1,"entryId":"q_7_abc"}`)
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
 	if source.calls != 1 || source.gotIndex != 1 {
 		t.Fatalf("promote relay calls=%d index=%d, want 1/1", source.calls, source.gotIndex)
+	}
+	if source.gotExpectedID != "q_7_abc" {
+		t.Fatalf("promote relay expectedEntryId=%q, want q_7_abc", source.gotExpectedID)
 	}
 }
 
@@ -149,11 +154,14 @@ func TestHubRPCPromoteQueuedAsSteerRelays(t *testing.T) {
 		return derr
 	}
 
-	if err := dispatch(appwire.TurnPromoteQueuedAsSteerParams{Ref: "remote:thread-1", Index: 2}); err != nil {
+	if err := dispatch(appwire.TurnPromoteQueuedAsSteerParams{Ref: "remote:thread-1", Index: 2, ExpectedEntryID: "q_9_def"}); err != nil {
 		t.Fatalf("dispatch promote: %v", err)
 	}
 	if source.calls != 1 || source.gotIndex != 2 {
 		t.Fatalf("promote relay calls=%d index=%d, want 1/2", source.calls, source.gotIndex)
+	}
+	if source.gotExpectedID != "q_9_def" {
+		t.Fatalf("promote relay expectedEntryId=%q, want q_9_def", source.gotExpectedID)
 	}
 
 	err := dispatch(appwire.TurnPromoteQueuedAsSteerParams{Ref: "remote:thread-1", Index: -1})

--- a/cmd/serf-hub/web_promote_test.go
+++ b/cmd/serf-hub/web_promote_test.go
@@ -1,0 +1,170 @@
+package main
+
+// Tests for POST /s/<id>/promote-queued (issue #22): the hub REST fallback
+// for the queue-preview row's promote action. The hub relays the index to
+// the daemon's turn/promoteQueuedAsSteer; failures surface honestly (400 on
+// a malformed body, 404 when the session isn't live, the daemon's Conflict
+// when the turn already ended or the index no longer resolves).
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"primeradiant.com/serf/appwire"
+	"primeradiant.com/serf/cmd/serf-hub/internal/appsource"
+	"primeradiant.com/serf/cmd/serf-hub/internal/hubcore"
+)
+
+// promoteRecordingSource is a scripted remote source that records the
+// promote params it was asked to relay.
+type promoteRecordingSource struct {
+	*scriptedAppSource
+	gotIndex int
+	calls    int
+	err      error
+}
+
+func (s *promoteRecordingSource) PromoteQueuedAsSteer(_ context.Context, params appwire.TurnPromoteQueuedAsSteerParams) error {
+	s.calls++
+	s.gotIndex = params.Index
+	return s.err
+}
+
+func newPromoteWeb(source *promoteRecordingSource) *WebServer {
+	web := NewWebServer(hubcore.WebConfig{})
+	registry := appsource.NewRegistry()
+	registry.Add(source)
+	web.sources = registry
+	return web
+}
+
+func newPromoteThread() appwire.Thread {
+	return appwire.Thread{
+		ID: "thread-1", SessionID: "thread-1", Source: "remote", Name: "promote test",
+		CWD: "/work/project", ModelProvider: "provider/model",
+		Status: appwire.ThreadStatus{Type: "active"},
+		Turns:  []appwire.Turn{{ID: "turn-1", Status: appwire.TurnStatusCompleted}},
+		Serf: appwire.SerfThread{Ref: "remote:thread-1", ActiveTurnID: "turn-2",
+			Capabilities: appwire.ThreadCapabilities{Steer: true, Queue: true}},
+	}
+}
+
+func newPromoteHarness() (*WebServer, *promoteRecordingSource) {
+	source := &promoteRecordingSource{
+		scriptedAppSource: &scriptedAppSource{id: "remote", thread: newPromoteThread()},
+		gotIndex:          -1,
+	}
+	return newPromoteWeb(source), source
+}
+
+func postPromote(web *WebServer, route, body string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, route, strings.NewReader(body))
+	web.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+func TestWebPromoteQueuedRelaysIndex(t *testing.T) {
+	web, source := newPromoteHarness()
+	rec := postPromote(web, "/s/remote%3Athread-1/promote-queued", `{"index":1}`)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if source.calls != 1 || source.gotIndex != 1 {
+		t.Fatalf("promote relay calls=%d index=%d, want 1/1", source.calls, source.gotIndex)
+	}
+}
+
+func TestWebPromoteQueuedRejectsNegativeIndex(t *testing.T) {
+	web, source := newPromoteHarness()
+	rec := postPromote(web, "/s/remote%3Athread-1/promote-queued", `{"index":-1}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+	if source.calls != 0 {
+		t.Fatalf("source called %d times, want 0", source.calls)
+	}
+}
+
+func TestWebPromoteQueuedRejectsInvalidJSON(t *testing.T) {
+	web, source := newPromoteHarness()
+	rec := postPromote(web, "/s/remote%3Athread-1/promote-queued", `{"index":`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+	if source.calls != 0 {
+		t.Fatalf("source called %d times, want 0", source.calls)
+	}
+}
+
+func TestWebPromoteQueuedNotLive(t *testing.T) {
+	// A local route id with no roster entry is not live; the hub must 404
+	// before reaching any source.
+	web, source := newPromoteHarness()
+	rec := postPromote(web, "/s/01MISSING/promote-queued", `{"index":0}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s, want 404", rec.Code, rec.Body.String())
+	}
+	if source.calls != 0 {
+		t.Fatalf("source called %d times, want 0", source.calls)
+	}
+}
+
+func TestWebPromoteQueuedSurfacesDaemonConflict(t *testing.T) {
+	web, source := newPromoteHarness()
+	source.err = appwire.Conflict("no active turn to steer")
+	rec := postPromote(web, "/s/remote%3Athread-1/promote-queued", `{"index":0}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status=%d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	if source.calls != 1 {
+		t.Fatalf("source called %d times, want 1", source.calls)
+	}
+}
+
+// TestHubRPCPromoteQueuedAsSteerRelays drives the appwire RPC path: the hub
+// app server must route turn/promoteQueuedAsSteer to the source owning the
+// ref, forwarding the index, and reject a negative index client-side.
+func TestHubRPCPromoteQueuedAsSteerRelays(t *testing.T) {
+	_, source := newPromoteHarness()
+	registry := appsource.NewRegistry()
+	registry.Add(source)
+	server := newHubAppServer(hubcore.WebConfig{Past: hubcore.NewPastIndex("")}, registry)
+
+	dispatch := func(params appwire.TurnPromoteQueuedAsSteerParams) error {
+		raw, err := json.Marshal(params)
+		if err != nil {
+			t.Fatalf("MarshalParams: %v", err)
+		}
+		_, derr := server.Router().Dispatch(context.Background(), appwire.Request{
+			ID:     appwire.NewIntID(1),
+			Method: appwire.MethodTurnPromoteQueuedAsSteer,
+			Params: raw,
+		})
+		return derr
+	}
+
+	if err := dispatch(appwire.TurnPromoteQueuedAsSteerParams{Ref: "remote:thread-1", Index: 2}); err != nil {
+		t.Fatalf("dispatch promote: %v", err)
+	}
+	if source.calls != 1 || source.gotIndex != 2 {
+		t.Fatalf("promote relay calls=%d index=%d, want 1/2", source.calls, source.gotIndex)
+	}
+
+	err := dispatch(appwire.TurnPromoteQueuedAsSteerParams{Ref: "remote:thread-1", Index: -1})
+	if err == nil {
+		t.Fatal("expected error for negative index")
+	}
+	var wireErr appwire.WireError
+	if !errors.As(err, &wireErr) || wireErr.Code != appwire.CodeInvalidParams {
+		t.Fatalf("err=%v, want InvalidParams wire error", err)
+	}
+	if source.calls != 1 {
+		t.Fatalf("source called %d times after negative index, want 1", source.calls)
+	}
+}

--- a/cmd/serf-hub/web_session.go
+++ b/cmd/serf-hub/web_session.go
@@ -336,8 +336,9 @@ func (s *WebServer) handlePromoteQueued(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	if err := source.PromoteQueuedAsSteer(r.Context(), appwire.TurnPromoteQueuedAsSteerParams{
-		Ref:   ref,
-		Index: body.Index,
+		Ref:             ref,
+		Index:           body.Index,
+		ExpectedEntryID: body.EntryID,
 	}); err != nil {
 		writeSessionActionError(w, r, err)
 		return

--- a/cmd/serf-hub/web_session.go
+++ b/cmd/serf-hub/web_session.go
@@ -351,10 +351,10 @@ func (s *WebServer) handlePromoteQueued(w http.ResponseWriter, r *http.Request, 
 // action). The daemon removes the queued follow-up at body.Index so it is
 // never consumed and echoes the removed entry's full text + image count,
 // which the hub passes through so the client can verify the removal matched
-// its snapshot and warn about dropped attachments. Rides on the Send
-// capability — unlike promote, cancel needs no in-flight turn: a queued
-// entry is cancellable whenever it is still queued, including entries
-// buffered on an idle session (where Queue/Steer are false). The daemon
+// its snapshot and warn about dropped attachments. Rides on the Queue
+// capability — the same gate as turn/queue. It must NOT gate on Send:
+// Send is false while a turn is in flight, which is exactly when the queue
+// preview (and its cancel/edit buttons) exists (review C1). The daemon
 // returns Conflict when the index no longer resolves or the queue shifted
 // under the client's snapshot (review F1).
 func (s *WebServer) handleCancelQueued(w http.ResponseWriter, r *http.Request, id string) {
@@ -372,7 +372,7 @@ func (s *WebServer) handleCancelQueued(w http.ResponseWriter, r *http.Request, i
 		http.NotFound(w, r)
 		return
 	}
-	if err := s.ensureSessionActionAvailable(id, "send"); err != nil {
+	if err := s.ensureSessionActionAvailable(id, "queue"); err != nil {
 		writeSessionActionError(w, r, err)
 		return
 	}

--- a/cmd/serf-hub/web_session.go
+++ b/cmd/serf-hub/web_session.go
@@ -304,6 +304,47 @@ func (s *WebServer) handleDrainAsSteer(w http.ResponseWriter, r *http.Request, i
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// handlePromoteQueued forwards a turn/promoteQueuedAsSteer request (issue
+// #22 per-message promote). The daemon removes the queued follow-up at
+// body.Index and injects it as user-sourced steering into the in-flight
+// turn; other queued messages stay queued. Rides on the Steer capability,
+// like drain-as-steer; the daemon returns Conflict when idle or when the
+// index no longer resolves against the live queue.
+func (s *WebServer) handlePromoteQueued(w http.ResponseWriter, r *http.Request, id string) {
+	r.Body = http.MaxBytesReader(w, r.Body, hubcore.SendMaxRequestBytes)
+	var body promoteQueuedRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if body.Index < 0 {
+		http.Error(w, "index must be >= 0", http.StatusBadRequest)
+		return
+	}
+	if !s.isLive(id) {
+		http.NotFound(w, r)
+		return
+	}
+	if err := s.ensureSessionActionAvailable(id, "steer"); err != nil {
+		writeSessionActionError(w, r, err)
+		return
+	}
+	ref := appRefFromRouteID(id)
+	source, err := sourceForThread(s.sources, ref, "")
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if err := source.PromoteQueuedAsSteer(r.Context(), appwire.TurnPromoteQueuedAsSteerParams{
+		Ref:   ref,
+		Index: body.Index,
+	}); err != nil {
+		writeSessionActionError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // handleSessionAction forwards imperative actions to a daemon. Interrupt,
 // clear, and shutdown remain live-only; compact can resume a known past
 // session because it is a session-level maintenance action rather than an

--- a/cmd/serf-hub/web_session.go
+++ b/cmd/serf-hub/web_session.go
@@ -346,6 +346,58 @@ func (s *WebServer) handlePromoteQueued(w http.ResponseWriter, r *http.Request, 
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// handleCancelQueued forwards a turn/cancelQueued request (issue #23
+// per-message cancel; also the removal half of the queue-preview row's edit
+// action). The daemon removes the queued follow-up at body.Index so it is
+// never consumed and echoes the removed entry's full text + image count,
+// which the hub passes through so the client can verify the removal matched
+// its snapshot and warn about dropped attachments. Rides on the Send
+// capability — unlike promote, cancel needs no in-flight turn: a queued
+// entry is cancellable whenever it is still queued, including entries
+// buffered on an idle session (where Queue/Steer are false). The daemon
+// returns Conflict when the index no longer resolves or the queue shifted
+// under the client's snapshot (review F1).
+func (s *WebServer) handleCancelQueued(w http.ResponseWriter, r *http.Request, id string) {
+	r.Body = http.MaxBytesReader(w, r.Body, hubcore.SendMaxRequestBytes)
+	var body cancelQueuedRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if body.Index < 0 {
+		http.Error(w, "index must be >= 0", http.StatusBadRequest)
+		return
+	}
+	if !s.isLive(id) {
+		http.NotFound(w, r)
+		return
+	}
+	if err := s.ensureSessionActionAvailable(id, "send"); err != nil {
+		writeSessionActionError(w, r, err)
+		return
+	}
+	ref := appRefFromRouteID(id)
+	source, err := sourceForThread(s.sources, ref, "")
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	removed, err := source.CancelQueued(r.Context(), appwire.TurnCancelQueuedParams{
+		Ref:             ref,
+		Index:           body.Index,
+		ExpectedEntryID: body.EntryID,
+	})
+	if err != nil {
+		writeSessionActionError(w, r, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(cancelQueuedResponse{
+		RemovedText:   removed.RemovedText,
+		RemovedImages: removed.RemovedImages,
+	})
+}
+
 // handleSessionAction forwards imperative actions to a daemon. Interrupt,
 // clear, and shutdown remain live-only; compact can resume a known past
 // session because it is a session-level maintenance action rather than an

--- a/cmd/serf-hub/web_test.go
+++ b/cmd/serf-hub/web_test.go
@@ -1855,6 +1855,10 @@ func (s *scriptedAppSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPr
 	return appwire.Unavailable("scripted source does not promote queued messages")
 }
 
+func (s *scriptedAppSource) CancelQueued(context.Context, appwire.TurnCancelQueuedParams) (appwire.TurnCancelQueuedResponse, error) {
+	return appwire.TurnCancelQueuedResponse{}, appwire.Unavailable("scripted source does not cancel queued messages")
+}
+
 func (s *scriptedAppSource) CompactThread(context.Context, appwire.ThreadCompactStartParams) error {
 	return appwire.Unavailable("scripted source does not compact threads")
 }

--- a/cmd/serf-hub/web_test.go
+++ b/cmd/serf-hub/web_test.go
@@ -1851,6 +1851,10 @@ func (s *scriptedAppSource) DrainAsSteer(context.Context, appwire.TurnDrainAsSte
 	return appwire.Unavailable("scripted source does not drain as steer")
 }
 
+func (s *scriptedAppSource) PromoteQueuedAsSteer(context.Context, appwire.TurnPromoteQueuedAsSteerParams) error {
+	return appwire.Unavailable("scripted source does not promote queued messages")
+}
+
 func (s *scriptedAppSource) CompactThread(context.Context, appwire.ThreadCompactStartParams) error {
 	return appwire.Unavailable("scripted source does not compact threads")
 }

--- a/cmd/serf-hub/web_types.go
+++ b/cmd/serf-hub/web_types.go
@@ -263,10 +263,14 @@ type drainAsSteerRequest struct {
 // promoteQueuedRequest is the JSON body for POST /s/<id>/promote-queued
 // (issue #22). Index selects one entry of the daemon's FIFO input queue —
 // matching the row position in the web queue preview — to promote into the
-// in-flight turn as user-sourced steering. The daemon rejects the call
-// (Conflict) when no turn is in flight or the index no longer resolves.
+// in-flight turn as user-sourced steering. EntryID carries the queue-entry
+// id from the client's queue snapshot; the daemon rejects the call
+// (Conflict) when no turn is in flight, the index no longer resolves, or
+// the queue shifted so the id no longer matches the entry at index
+// (review F1).
 type promoteQueuedRequest struct {
-	Index int `json:"index"`
+	Index   int    `json:"index"`
+	EntryID string `json:"entryId,omitempty"`
 }
 
 type forkRequest struct {

--- a/cmd/serf-hub/web_types.go
+++ b/cmd/serf-hub/web_types.go
@@ -273,6 +273,31 @@ type promoteQueuedRequest struct {
 	EntryID string `json:"entryId,omitempty"`
 }
 
+// cancelQueuedRequest is the JSON body for POST /s/<id>/cancel-queued
+// (issue #23). Index selects one entry of the daemon's FIFO input queue —
+// matching the row position in the web queue preview — to remove so it is
+// never consumed. It is also the removal half of the row's edit action
+// (edit = restore the full text into the composer, then cancel the queued
+// copy). EntryID carries the queue-entry id from the client's queue
+// snapshot; the daemon rejects the call (Conflict) when the index no longer
+// resolves or the queue shifted so the id no longer matches the entry at
+// index (review F1).
+type cancelQueuedRequest struct {
+	Index   int    `json:"index"`
+	EntryID string `json:"entryId,omitempty"`
+}
+
+// cancelQueuedResponse is the JSON body returned by POST
+// /s/<id>/cancel-queued on success: an echo of what was removed.
+// RemovedText lets the client verify the removal matched its snapshot;
+// RemovedImages counts attachments that were on the entry and are NOT
+// restored by an edit, so the UI can warn instead of silently dropping
+// them.
+type cancelQueuedResponse struct {
+	RemovedText   string `json:"removedText"`
+	RemovedImages int    `json:"removedImages,omitempty"`
+}
+
 type forkRequest struct {
 	Turn          int    `json:"turn"`
 	EditedMessage string `json:"edited_message"`

--- a/cmd/serf-hub/web_types.go
+++ b/cmd/serf-hub/web_types.go
@@ -260,6 +260,15 @@ type drainAsSteerRequest struct {
 	Items []appwire.InputItem `json:"items,omitempty"`
 }
 
+// promoteQueuedRequest is the JSON body for POST /s/<id>/promote-queued
+// (issue #22). Index selects one entry of the daemon's FIFO input queue —
+// matching the row position in the web queue preview — to promote into the
+// in-flight turn as user-sourced steering. The daemon rejects the call
+// (Conflict) when no turn is in flight or the index no longer resolves.
+type promoteQueuedRequest struct {
+	Index int `json:"index"`
+}
+
 type forkRequest struct {
 	Turn          int    `json:"turn"`
 	EditedMessage string `json:"edited_message"`

--- a/cmd/serf-hub/web_workspace.go
+++ b/cmd/serf-hub/web_workspace.go
@@ -89,6 +89,12 @@ func (s *WebServer) handleSession(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.handleDrainAsSteer(w, r, id)
+	case "promote-queued":
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST required", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handlePromoteQueued(w, r, id)
 	default:
 		// /s/<id>/images/<sha> — sha-addressed image fetch for replay.
 		if strings.HasPrefix(sub, "images/") {

--- a/cmd/serf-hub/web_workspace.go
+++ b/cmd/serf-hub/web_workspace.go
@@ -95,6 +95,12 @@ func (s *WebServer) handleSession(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.handlePromoteQueued(w, r, id)
+	case "cancel-queued":
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST required", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handleCancelQueued(w, r, id)
 	default:
 		// /s/<id>/images/<sha> — sha-addressed image fetch for replay.
 		if strings.HasPrefix(sub, "images/") {

--- a/cmd/serf/serve.go
+++ b/cmd/serf/serve.go
@@ -68,6 +68,7 @@ type serveServer interface {
 	SetGoalStatusFunc(func() (string, int, bool))
 	SetDrainAsSteerFunc(func() error)
 	SetDrainAsSteerWithInputFunc(func(string, []server.ImageAttachment) error)
+	SetPromoteQueuedAsSteerFunc(func(int) error)
 	SetQueueDepthFunc(func() int)
 	SetQueuePreviewFunc(func() []string)
 	SetContextPressureFunc(func() float64)
@@ -536,6 +537,9 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 	srv.SetDrainAsSteerFunc(func() error { return getSession().DrainAsSteer(ctx) })
 	srv.SetDrainAsSteerWithInputFunc(func(text string, images []server.ImageAttachment) error {
 		return getSession().DrainAsSteerWithInput(ctx, text, images)
+	})
+	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
+		return getSession().PromoteQueuedAsSteer(ctx, index)
 	})
 	srv.SetQueueDepthFunc(func() int { return getSession().QueueDepth() })
 	srv.SetQueuePreviewFunc(func() []string { return getSession().QueuePreview() })

--- a/cmd/serf/serve.go
+++ b/cmd/serf/serve.go
@@ -69,9 +69,11 @@ type serveServer interface {
 	SetDrainAsSteerFunc(func() error)
 	SetDrainAsSteerWithInputFunc(func(string, []server.ImageAttachment) error)
 	SetPromoteQueuedAsSteerFunc(func(int, string) error)
+	SetCancelQueuedFunc(func(int, string) (string, int, error))
 	SetQueueIDsFunc(func() []string)
 	SetQueueDepthFunc(func() int)
 	SetQueuePreviewFunc(func() []string)
+	SetQueueTextsFunc(func() []string)
 	SetContextPressureFunc(func() float64)
 	SetContextMetricsFunc(func() server.ContextMetrics)
 	SetWorkMetricsFunc(func() (int64, *appwire.SerfUsage, int64))
@@ -542,9 +544,13 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 	srv.SetPromoteQueuedAsSteerFunc(func(index int, expectedID string) error {
 		return getSession().PromoteQueuedAsSteer(ctx, index, expectedID)
 	})
+	srv.SetCancelQueuedFunc(func(index int, expectedID string) (string, int, error) {
+		return getSession().CancelQueued(ctx, index, expectedID)
+	})
 	srv.SetQueueDepthFunc(func() int { return getSession().QueueDepth() })
 	srv.SetQueuePreviewFunc(func() []string { return getSession().QueuePreview() })
 	srv.SetQueueIDsFunc(func() []string { return getSession().QueueIDs() })
+	srv.SetQueueTextsFunc(func() []string { return getSession().QueueTexts() })
 	srv.SetContextPressureFunc(func() float64 { return getSession().ContextPressure() })
 	srv.SetContextMetricsFunc(func() server.ContextMetrics {
 		metrics := getSession().ContextMetrics()

--- a/cmd/serf/serve.go
+++ b/cmd/serf/serve.go
@@ -68,7 +68,8 @@ type serveServer interface {
 	SetGoalStatusFunc(func() (string, int, bool))
 	SetDrainAsSteerFunc(func() error)
 	SetDrainAsSteerWithInputFunc(func(string, []server.ImageAttachment) error)
-	SetPromoteQueuedAsSteerFunc(func(int) error)
+	SetPromoteQueuedAsSteerFunc(func(int, string) error)
+	SetQueueIDsFunc(func() []string)
 	SetQueueDepthFunc(func() int)
 	SetQueuePreviewFunc(func() []string)
 	SetContextPressureFunc(func() float64)
@@ -538,11 +539,12 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 	srv.SetDrainAsSteerWithInputFunc(func(text string, images []server.ImageAttachment) error {
 		return getSession().DrainAsSteerWithInput(ctx, text, images)
 	})
-	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
-		return getSession().PromoteQueuedAsSteer(ctx, index)
+	srv.SetPromoteQueuedAsSteerFunc(func(index int, expectedID string) error {
+		return getSession().PromoteQueuedAsSteer(ctx, index, expectedID)
 	})
 	srv.SetQueueDepthFunc(func() int { return getSession().QueueDepth() })
 	srv.SetQueuePreviewFunc(func() []string { return getSession().QueuePreview() })
+	srv.SetQueueIDsFunc(func() []string { return getSession().QueueIDs() })
 	srv.SetContextPressureFunc(func() float64 { return getSession().ContextPressure() })
 	srv.SetContextMetricsFunc(func() server.ContextMetrics {
 		metrics := getSession().ContextMetrics()

--- a/cmd/serf/serve_residual_fuzz_test.go
+++ b/cmd/serf/serve_residual_fuzz_test.go
@@ -40,8 +40,9 @@ type residualServeServer struct {
 	goalStatus         func() (string, int, bool)
 	drain              func() error
 	drainInput         func(string, []server.ImageAttachment) error
-	promote            func(int) error
+	promote            func(int, string) error
 	queueDepth         func() int
+	queueIDs           func() []string
 	queuePreview       func() []string
 	pressure           func() float64
 	contextMetrics     func() server.ContextMetrics
@@ -83,9 +84,12 @@ func (s *residualServeServer) SetDrainAsSteerFunc(f func() error)             { 
 func (s *residualServeServer) SetDrainAsSteerWithInputFunc(f func(string, []server.ImageAttachment) error) {
 	s.drainInput = f
 }
-func (s *residualServeServer) SetPromoteQueuedAsSteerFunc(f func(int) error) { s.promote = f }
+func (s *residualServeServer) SetPromoteQueuedAsSteerFunc(f func(int, string) error) {
+	s.promote = f
+}
 func (s *residualServeServer) SetQueueDepthFunc(f func() int)          { s.queueDepth = f }
 func (s *residualServeServer) SetQueuePreviewFunc(f func() []string)   { s.queuePreview = f }
+func (s *residualServeServer) SetQueueIDsFunc(f func() []string)       { s.queueIDs = f }
 func (s *residualServeServer) SetContextPressureFunc(f func() float64) { s.pressure = f }
 func (s *residualServeServer) SetContextMetricsFunc(f func() server.ContextMetrics) {
 	s.contextMetrics = f
@@ -121,9 +125,10 @@ func exerciseResidualCallbacks(s *residualServeServer) {
 	_, _, _ = s.goalStatus()
 	_ = s.drain()
 	_ = s.drainInput("x", nil)
-	_ = s.promote(0)
+	_ = s.promote(0, "q_1_x")
 	_ = s.queueDepth()
 	_ = s.queuePreview()
+	_ = s.queueIDs()
 	_ = s.pressure()
 	_ = s.contextMetrics()
 	_, _, _ = s.workMetrics()

--- a/cmd/serf/serve_residual_fuzz_test.go
+++ b/cmd/serf/serve_residual_fuzz_test.go
@@ -40,6 +40,7 @@ type residualServeServer struct {
 	goalStatus         func() (string, int, bool)
 	drain              func() error
 	drainInput         func(string, []server.ImageAttachment) error
+	promote            func(int) error
 	queueDepth         func() int
 	queuePreview       func() []string
 	pressure           func() float64
@@ -82,6 +83,7 @@ func (s *residualServeServer) SetDrainAsSteerFunc(f func() error)             { 
 func (s *residualServeServer) SetDrainAsSteerWithInputFunc(f func(string, []server.ImageAttachment) error) {
 	s.drainInput = f
 }
+func (s *residualServeServer) SetPromoteQueuedAsSteerFunc(f func(int) error) { s.promote = f }
 func (s *residualServeServer) SetQueueDepthFunc(f func() int)          { s.queueDepth = f }
 func (s *residualServeServer) SetQueuePreviewFunc(f func() []string)   { s.queuePreview = f }
 func (s *residualServeServer) SetContextPressureFunc(f func() float64) { s.pressure = f }
@@ -119,6 +121,7 @@ func exerciseResidualCallbacks(s *residualServeServer) {
 	_, _, _ = s.goalStatus()
 	_ = s.drain()
 	_ = s.drainInput("x", nil)
+	_ = s.promote(0)
 	_ = s.queueDepth()
 	_ = s.queuePreview()
 	_ = s.pressure()

--- a/cmd/serf/serve_residual_fuzz_test.go
+++ b/cmd/serf/serve_residual_fuzz_test.go
@@ -41,9 +41,11 @@ type residualServeServer struct {
 	drain              func() error
 	drainInput         func(string, []server.ImageAttachment) error
 	promote            func(int, string) error
+	cancel             func(int, string) (string, int, error)
 	queueDepth         func() int
 	queueIDs           func() []string
 	queuePreview       func() []string
+	queueTexts         func() []string
 	pressure           func() float64
 	contextMetrics     func() server.ContextMetrics
 	workMetrics        func() (int64, *appwire.SerfUsage, int64)
@@ -87,9 +89,13 @@ func (s *residualServeServer) SetDrainAsSteerWithInputFunc(f func(string, []serv
 func (s *residualServeServer) SetPromoteQueuedAsSteerFunc(f func(int, string) error) {
 	s.promote = f
 }
+func (s *residualServeServer) SetCancelQueuedFunc(f func(int, string) (string, int, error)) {
+	s.cancel = f
+}
 func (s *residualServeServer) SetQueueDepthFunc(f func() int)          { s.queueDepth = f }
 func (s *residualServeServer) SetQueuePreviewFunc(f func() []string)   { s.queuePreview = f }
 func (s *residualServeServer) SetQueueIDsFunc(f func() []string)       { s.queueIDs = f }
+func (s *residualServeServer) SetQueueTextsFunc(f func() []string)     { s.queueTexts = f }
 func (s *residualServeServer) SetContextPressureFunc(f func() float64) { s.pressure = f }
 func (s *residualServeServer) SetContextMetricsFunc(f func() server.ContextMetrics) {
 	s.contextMetrics = f

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -106,6 +106,7 @@ no router (reserved).
 | `turn/queue` | both | `TurnQueueParams` | `EmptyResponse` | Queues a user message for after the active turn completes. |
 | `turn/drainAsSteer` | both | `TurnDrainAsSteerParams` | `EmptyResponse` | Drains the input queue and injects it as a single steering message. |
 | `turn/promoteQueuedAsSteer` | both | `TurnPromoteQueuedAsSteerParams` | `EmptyResponse` | Removes one queued message by index and injects it as user-sourced steering into the in-flight turn. |
+| `turn/cancelQueued` | both | `TurnCancelQueuedParams` | `TurnCancelQueuedResponse` | Removes one queued message by index so it is never consumed (cancel; also the removal half of edit-and-recompose). |
 | `goal/set` | both | `GoalSetParams` | `GoalSetResponse` | Sets or clears the session's /goal objective. |
 | `serf/tasks/list` | both | `TaskListParams` | `TaskListResponse` | Lists the session's tasks. |
 | `serf/thread/transcripts/list` | hub | `ThreadTranscriptListParams` | `ThreadTranscriptListResponse` | Lists transcript targets (subagents/related threads) for a ref. |
@@ -994,6 +995,23 @@ _(no fields)_
 | `itemId` | `string` |  |  |
 | `callId` | `string` |  |  |
 | `delta` | `string` |  |  |
+
+
+### `TurnCancelQueuedParams`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `ref` | `string` |  |  |
+| `index` | `int` |  |  |
+| `expectedEntryId` | `string` | yes |  |
+
+
+### `TurnCancelQueuedResponse`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `removedText` | `string` |  |  |
+| `removedImages` | `int` | yes |  |
 
 
 ### `TurnCompletedParams`

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -105,6 +105,7 @@ no router (reserved).
 | `turn/interrupt` | both | `TurnInterruptParams` | `EmptyResponse` | Cancels the active turn matching expectedTurnId. |
 | `turn/queue` | both | `TurnQueueParams` | `EmptyResponse` | Queues a user message for after the active turn completes. |
 | `turn/drainAsSteer` | both | `TurnDrainAsSteerParams` | `EmptyResponse` | Drains the input queue and injects it as a single steering message. |
+| `turn/promoteQueuedAsSteer` | both | `TurnPromoteQueuedAsSteerParams` | `EmptyResponse` | Removes one queued message by index and injects it as user-sourced steering into the in-flight turn. |
 | `goal/set` | both | `GoalSetParams` | `GoalSetResponse` | Sets or clears the session's /goal objective. |
 | `serf/tasks/list` | both | `TaskListParams` | `TaskListResponse` | Lists the session's tasks. |
 | `serf/thread/transcripts/list` | hub | `ThreadTranscriptListParams` | `ThreadTranscriptListResponse` | Lists transcript targets (subagents/related threads) for a ref. |
@@ -475,6 +476,8 @@ _(no fields)_
 | `sandboxNet` | `*bool` | yes |  |
 | `maxRounds` | `*int` | yes |  |
 | `maxSubagentDepth` | `*int` | yes |  |
+| `maxConcurrentDelegateTurns` | `*int` | yes |  |
+| `maxRetainedTerminal` | `*int` | yes |  |
 | `noProjectPrompts` | `*bool` | yes |  |
 | `nonInteractive` | `*bool` | yes |  |
 | `appReplaySize` | `*int` | yes |  |
@@ -1016,6 +1019,14 @@ _(no fields)_
 | `ref` | `string` | yes |  |
 | `threadId` | `string` | yes |  |
 | `expectedTurnId` | `string` | yes |  |
+
+
+### `TurnPromoteQueuedAsSteerParams`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `ref` | `string` |  |  |
+| `index` | `int` |  |  |
 
 
 ### `TurnQueueParams`

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -1027,6 +1027,7 @@ _(no fields)_
 |-------|---------|-----------|----------|
 | `ref` | `string` |  |  |
 | `index` | `int` |  |  |
+| `expectedEntryId` | `string` | yes |  |
 
 
 ### `TurnQueueParams`

--- a/internal/appprojector/appwire_projection.go
+++ b/internal/appprojector/appwire_projection.go
@@ -639,6 +639,7 @@ func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification
 				Depth:   data.Depth,
 				Preview: append([]string(nil), data.Preview...),
 				IDs:     append([]string(nil), data.IDs...),
+				Texts:   append([]string(nil), data.Texts...),
 			},
 		})}
 	case events.EventTaskUpdated:

--- a/internal/appprojector/appwire_projection.go
+++ b/internal/appprojector/appwire_projection.go
@@ -635,7 +635,11 @@ func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification
 		return []AppNotification{p.notification(appwire.NotifyThreadQueueChanged, appwire.ThreadQueueChangedParams{
 			ThreadID: p.threadID,
 			Ref:      p.ref,
-			Queue:    appwire.QueueState{Depth: data.Depth, Preview: append([]string(nil), data.Preview...)},
+			Queue: appwire.QueueState{
+				Depth:   data.Depth,
+				Preview: append([]string(nil), data.Preview...),
+				IDs:     append([]string(nil), data.IDs...),
+			},
 		})}
 	case events.EventTaskUpdated:
 		p.clearSkillCandidate()

--- a/server/appwire_cancel_test.go
+++ b/server/appwire_cancel_test.go
@@ -1,0 +1,256 @@
+package server
+
+// Tests for the turn/cancelQueued appwire method (issue #23): the daemon
+// removes the queued follow-up at the requested index so it is never
+// consumed, echoing the removed entry's full text and image count. Unlike
+// turn/promoteQueuedAsSteer, cancel does NOT require an active turn — a
+// queued entry is cancellable whenever it is still queued. Failures are
+// honest: closed → Conflict, negative index → InvalidParams, no callback →
+// Unavailable, and a session-side rejection (the index fell out of range or
+// the expected entry id no longer matches, review F1) propagates as
+// Conflict.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"primeradiant.com/serf/agent"
+	"primeradiant.com/serf/agent/execenv"
+	"primeradiant.com/serf/agent/provider"
+	"primeradiant.com/serf/appwire"
+	"primeradiant.com/serf/llm"
+)
+
+func cancelRPC(conn interface {
+	HandleMessage(context.Context, appwire.Message) appwire.Message
+}, id int64, params appwire.TurnCancelQueuedParams) appwire.Message {
+	conn.HandleMessage(context.Background(), appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodInitialize, appwire.InitializeParams{}))
+	return conn.HandleMessage(context.Background(), appwire.RequestMessage(appwire.NewIntID(id), appwire.MethodTurnCancelQueued, params))
+}
+
+func TestServerAppWireTurnCancelQueuedDispatchesIndex(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+	srv.SetProcessing(true)
+	srv.SetStatus(StatusInfo{SessionID: "th_1", State: "active"})
+	gotIndex := -1
+	var gotExpectedID string
+	srv.SetCancelQueuedFunc(func(index int, expectedID string) (string, int, error) {
+		gotIndex = index
+		gotExpectedID = expectedID
+		return "the removed text", 2, nil
+	})
+
+	conn := srv.AppServer().NewConnection("test")
+	resp := cancelRPC(conn, 2, appwire.TurnCancelQueuedParams{Ref: "local:th_1", Index: 1, ExpectedEntryID: "q_1_abc"})
+	if resp.Kind() != appwire.MessageResponse {
+		t.Fatalf("resp=%v error=%+v", resp.Kind(), resp.Error)
+	}
+	if gotIndex != 1 || gotExpectedID != "q_1_abc" {
+		t.Fatalf("cancel func got index=%d expectedID=%q, want 1/q_1_abc", gotIndex, gotExpectedID)
+	}
+	got, ok := resp.Response.Result.(appwire.TurnCancelQueuedResponse)
+	if !ok {
+		t.Fatalf("result type=%T, want TurnCancelQueuedResponse", resp.Response.Result)
+	}
+	if got.RemovedText != "the removed text" || got.RemovedImages != 2 {
+		t.Fatalf("response=%+v, want removedText/removedImages echoed", got)
+	}
+}
+
+// TestServerAppWireTurnCancelQueuedAllowedWhileIdle pins the difference from
+// promote: canceling a queued follow-up does not require an in-flight turn.
+func TestServerAppWireTurnCancelQueuedAllowedWhileIdle(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+	srv.SetProcessing(false)
+	srv.SetStatus(StatusInfo{SessionID: "th_1", State: "idle"})
+	called := 0
+	srv.SetCancelQueuedFunc(func(index int, expectedID string) (string, int, error) {
+		called++
+		return "text", 0, nil
+	})
+
+	conn := srv.AppServer().NewConnection("test")
+	resp := cancelRPC(conn, 2, appwire.TurnCancelQueuedParams{Ref: "local:th_1", Index: 0})
+	if resp.Kind() != appwire.MessageResponse {
+		t.Fatalf("idle cancel: resp=%v error=%+v, want success", resp.Kind(), resp.Error)
+	}
+	if called != 1 {
+		t.Fatalf("cancel func called %d times, want 1", called)
+	}
+}
+
+func TestServerAppWireTurnCancelQueuedRejectsNegativeIndex(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+	srv.SetProcessing(true)
+	srv.SetStatus(StatusInfo{SessionID: "th_1", State: "active"})
+	srv.SetCancelQueuedFunc(func(int, string) (string, int, error) { return "", 0, nil })
+
+	conn := srv.AppServer().NewConnection("test")
+	resp := cancelRPC(conn, 2, appwire.TurnCancelQueuedParams{Ref: "local:th_1", Index: -1})
+	if resp.Kind() != appwire.MessageError {
+		t.Fatalf("expected error, got %v", resp.Kind())
+	}
+	if resp.Error.Error.Code != appwire.CodeInvalidParams {
+		t.Fatalf("error=%+v, want InvalidParams", resp.Error.Error)
+	}
+}
+
+func TestServerAppWireTurnCancelQueuedRejectsWhenClosed(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+	srv.SetProcessing(false)
+	srv.SetStatus(StatusInfo{SessionID: "th_1", State: "closed"})
+	srv.SetCancelQueuedFunc(func(int, string) (string, int, error) { return "", 0, nil })
+
+	conn := srv.AppServer().NewConnection("test")
+	resp := cancelRPC(conn, 2, appwire.TurnCancelQueuedParams{Ref: "local:th_1", Index: 0})
+	if resp.Kind() != appwire.MessageError {
+		t.Fatalf("expected error, got %v", resp.Kind())
+	}
+	if resp.Error.Error.Code != appwire.CodeConflict {
+		t.Fatalf("error=%+v, want Conflict", resp.Error.Error)
+	}
+}
+
+func TestServerAppWireTurnCancelQueuedUnavailableWithoutFunc(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+	srv.SetProcessing(true)
+	srv.SetStatus(StatusInfo{SessionID: "th_1", State: "active"})
+
+	conn := srv.AppServer().NewConnection("test")
+	resp := cancelRPC(conn, 2, appwire.TurnCancelQueuedParams{Ref: "local:th_1", Index: 0})
+	if resp.Kind() != appwire.MessageError {
+		t.Fatalf("expected error, got %v", resp.Kind())
+	}
+	if resp.Error.Error.Code != appwire.CodeUnavailable {
+		t.Fatalf("error=%+v, want Unavailable", resp.Error.Error)
+	}
+}
+
+// TestServerAppWireTurnCancelQueuedPropagatesSessionError pins the review-F2
+// mapping: session-side rejections (stale index, shifted id) are Conflicts
+// so the client can re-sync its preview.
+func TestServerAppWireTurnCancelQueuedPropagatesSessionError(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+	srv.SetProcessing(true)
+	srv.SetStatus(StatusInfo{SessionID: "th_1", State: "active"})
+	srv.SetCancelQueuedFunc(func(index int, expectedID string) (string, int, error) {
+		return "", 0, errors.New("cancel: queue index 3 out of range (depth 1)")
+	})
+
+	conn := srv.AppServer().NewConnection("test")
+	resp := cancelRPC(conn, 2, appwire.TurnCancelQueuedParams{Ref: "local:th_1", Index: 3})
+	if resp.Kind() != appwire.MessageError {
+		t.Fatalf("expected error, got %v", resp.Kind())
+	}
+	if resp.Error.Error.Code != appwire.CodeConflict {
+		t.Fatalf("error=%+v, want Conflict", resp.Error.Error)
+	}
+}
+
+// TestServerAppWireTurnCancelQueuedThroughSession exercises the full stack
+// the way cmd/serf serve wires it: the RPC drives the real agent session's
+// CancelQueued, so the canceled entry leaves the queue (and is never
+// consumed) while the other queued message stays queued. The thread
+// snapshot carries the full Texts the edit affordance restores into the
+// composer.
+func TestServerAppWireTurnCancelQueuedThroughSession(t *testing.T) {
+	dir := t.TempDir()
+	c := llm.NewClient()
+	adapter := &blockingServerAdapter{name: "openai", started: make(chan struct{}), done: make(chan error, 1)}
+	c.Register(adapter)
+	sess, err := agent.NewSession(c, provider.NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), agent.SessionConfig{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_, _ = sess.ProcessInput(ctx, "keep turn active", nil)
+	}()
+	select {
+	case <-adapter.started:
+	case <-time.After(time.Second):
+		t.Fatal("session did not enter active turn")
+	}
+
+	for _, msg := range []string{"alpha\nwith a second line", "bravo"} {
+		if err := sess.Enqueue(context.Background(), msg); err != nil {
+			t.Fatalf("Enqueue %q: %v", msg, err)
+		}
+	}
+
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", sess.ID())
+	srv.SetProcessing(true)
+	srv.SetStatus(StatusInfo{SessionID: sess.ID(), State: "active"})
+	srv.SetCancelQueuedFunc(func(index int, expectedID string) (string, int, error) {
+		return sess.CancelQueued(context.Background(), index, expectedID)
+	})
+	srv.SetQueuePreviewFunc(sess.QueuePreview)
+	srv.SetQueueIDsFunc(sess.QueueIDs)
+	srv.SetQueueTextsFunc(sess.QueueTexts)
+
+	conn := srv.AppServer().NewConnection("test")
+	conn.HandleMessage(context.Background(), appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodInitialize, appwire.InitializeParams{}))
+
+	// The thread snapshot must carry the full untruncated texts and the
+	// entry ids the UI sends back as expected identity.
+	readResp := conn.HandleMessage(context.Background(), appwire.RequestMessage(appwire.NewIntID(9), appwire.MethodThreadRead, appwire.ThreadReadParams{Ref: "local:" + sess.ID()}))
+	if readResp.Kind() != appwire.MessageResponse {
+		t.Fatalf("thread/read: %v", readResp.Kind())
+	}
+	read, ok := readResp.Response.Result.(appwire.ThreadReadResponse)
+	if !ok {
+		t.Fatalf("thread/read result type=%T", readResp.Response.Result)
+	}
+	queue := read.Thread.Serf.Queue
+	if len(queue.IDs) != 2 || queue.IDs[0] == "" || queue.IDs[1] == "" {
+		t.Fatalf("thread queue IDs = %#v, want two non-empty ids", queue.IDs)
+	}
+	if len(queue.Texts) != 2 || queue.Texts[0] != "alpha\nwith a second line" || queue.Texts[1] != "bravo" {
+		t.Fatalf("thread queue Texts = %#v, want full untruncated texts", queue.Texts)
+	}
+
+	// Review F1: a cancel naming the WRONG entry id (a stale snapshot) is a
+	// Conflict and leaves the queue fully intact — nothing is removed.
+	mismatch := cancelRPC(conn, 3, appwire.TurnCancelQueuedParams{Ref: "local:" + sess.ID(), Index: 0, ExpectedEntryID: queue.IDs[1]})
+	if mismatch.Kind() != appwire.MessageError {
+		t.Fatalf("mismatch cancel: expected error, got %v", mismatch.Kind())
+	}
+	if mismatch.Error.Error.Code != appwire.CodeConflict {
+		t.Fatalf("mismatch error=%+v, want Conflict", mismatch.Error.Error)
+	}
+	if preview := sess.QueuePreview(); len(preview) != 2 {
+		t.Fatalf("QueuePreview after mismatch: got %#v, want both entries intact", preview)
+	}
+
+	resp := cancelRPC(conn, 2, appwire.TurnCancelQueuedParams{Ref: "local:" + sess.ID(), Index: 0, ExpectedEntryID: queue.IDs[0]})
+	if resp.Kind() != appwire.MessageResponse {
+		t.Fatalf("resp=%v error=%+v", resp.Kind(), resp.Error)
+	}
+	removed, ok := resp.Response.Result.(appwire.TurnCancelQueuedResponse)
+	if !ok {
+		t.Fatalf("result type=%T", resp.Response.Result)
+	}
+	if removed.RemovedText != "alpha\nwith a second line" {
+		t.Fatalf("removedText = %q, want the full multi-line message", removed.RemovedText)
+	}
+	if preview := sess.QueuePreview(); len(preview) != 1 || preview[0] != "bravo" {
+		t.Fatalf("QueuePreview after cancel: got %#v, want [bravo]", preview)
+	}
+	cancel()
+	select {
+	case <-adapter.done:
+	case <-time.After(time.Second):
+		t.Fatal("session turn did not finish after cancel")
+	}
+}

--- a/server/appwire_promote_test.go
+++ b/server/appwire_promote_test.go
@@ -32,7 +32,7 @@ func newPromoteTestServer(t *testing.T, processing bool) (*Server, *int) {
 	}
 	srv.SetStatus(StatusInfo{SessionID: "th_1", State: state})
 	called := 0
-	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
+	srv.SetPromoteQueuedAsSteerFunc(func(index int, expectedID string) error {
 		called++
 		return nil
 	})
@@ -52,18 +52,23 @@ func TestServerAppWireTurnPromoteQueuedAsSteerDispatchesIndex(t *testing.T) {
 	srv.SetProcessing(true)
 	srv.SetStatus(StatusInfo{SessionID: "th_1", State: "active"})
 	gotIndex := -1
-	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
+	var gotExpectedID string
+	srv.SetPromoteQueuedAsSteerFunc(func(index int, expectedID string) error {
 		gotIndex = index
+		gotExpectedID = expectedID
 		return nil
 	})
 
 	conn := srv.AppServer().NewConnection("test")
-	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:th_1", Index: 1})
+	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:th_1", Index: 1, ExpectedEntryID: "q_1_abc"})
 	if resp.Kind() != appwire.MessageResponse {
 		t.Fatalf("resp=%v error=%+v", resp.Kind(), resp.Error)
 	}
 	if gotIndex != 1 {
 		t.Fatalf("promote callback index=%d, want 1", gotIndex)
+	}
+	if gotExpectedID != "q_1_abc" {
+		t.Fatalf("promote callback expectedID=%q, want q_1_abc", gotExpectedID)
 	}
 }
 
@@ -112,18 +117,25 @@ func TestServerAppWireTurnPromoteQueuedAsSteerUnavailableWithoutFunc(t *testing.
 	}
 }
 
+// TestServerAppWireTurnPromoteQueuedAsSteerPropagatesSessionError pins
+// review F2: session-side rejections (queue shifted → index out of range or
+// expected id mismatch) surface as Conflict so the client can re-sync its
+// preview instead of believing the wrong message was promoted.
 func TestServerAppWireTurnPromoteQueuedAsSteerPropagatesSessionError(t *testing.T) {
 	srv := NewServer(ServerConfig{})
 	srv.SetAppIdentity("local", "th_1")
 	srv.SetProcessing(true)
 	srv.SetStatus(StatusInfo{SessionID: "th_1", State: "active"})
-	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
+	srv.SetPromoteQueuedAsSteerFunc(func(index int, expectedID string) error {
 		return errors.New("promote: queue index 3 out of range (depth 1)")
 	})
 	conn := srv.AppServer().NewConnection("test")
 	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:th_1", Index: 3})
 	if resp.Kind() != appwire.MessageError {
 		t.Fatalf("expected error, got %v", resp.Kind())
+	}
+	if resp.Error.Error.Code != appwire.CodeConflict {
+		t.Fatalf("error=%+v, want Conflict", resp.Error.Error)
 	}
 }
 
@@ -163,12 +175,46 @@ func TestServerAppWireTurnPromoteQueuedAsSteerThroughSession(t *testing.T) {
 	srv.SetAppIdentity("local", sess.ID())
 	srv.SetProcessing(true)
 	srv.SetStatus(StatusInfo{SessionID: sess.ID(), State: "active"})
-	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
-		return sess.PromoteQueuedAsSteer(context.Background(), index)
+	srv.SetPromoteQueuedAsSteerFunc(func(index int, expectedID string) error {
+		return sess.PromoteQueuedAsSteer(context.Background(), index, expectedID)
 	})
+	srv.SetQueuePreviewFunc(sess.QueuePreview)
+	srv.SetQueueIDsFunc(sess.QueueIDs)
 
 	conn := srv.AppServer().NewConnection("test")
-	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:" + sess.ID(), Index: 0})
+	conn.HandleMessage(context.Background(), appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodInitialize, appwire.InitializeParams{}))
+
+	// The thread snapshot must carry the entry ids the UI needs to send back.
+	readResp := conn.HandleMessage(context.Background(), appwire.RequestMessage(appwire.NewIntID(9), appwire.MethodThreadRead, appwire.ThreadReadParams{Ref: "local:" + sess.ID()}))
+	if readResp.Kind() != appwire.MessageResponse {
+		t.Fatalf("thread/read: %v", readResp.Kind())
+	}
+	read, ok := readResp.Response.Result.(appwire.ThreadReadResponse)
+	if !ok {
+		t.Fatalf("thread/read result type=%T", readResp.Response.Result)
+	}
+	ids := read.Thread.Serf.Queue.IDs
+	if len(ids) != 2 || ids[0] == "" || ids[1] == "" {
+		t.Fatalf("thread queue IDs = %#v, want two non-empty ids", ids)
+	}
+
+	// Review F1: a promote naming the WRONG entry id (a stale snapshot) is a
+	// Conflict and leaves the queue fully intact — nothing is steered.
+	mismatch := promoteRPC(conn, 3, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:" + sess.ID(), Index: 0, ExpectedEntryID: ids[1]})
+	if mismatch.Kind() != appwire.MessageError {
+		t.Fatalf("mismatch promote: expected error, got %v", mismatch.Kind())
+	}
+	if mismatch.Error.Error.Code != appwire.CodeConflict {
+		t.Fatalf("mismatch error=%+v, want Conflict", mismatch.Error.Error)
+	}
+	if preview := sess.QueuePreview(); len(preview) != 2 {
+		t.Fatalf("QueuePreview after mismatch: got %#v, want both entries intact", preview)
+	}
+	if steering := sess.SteeringQueueSnapshot(); len(steering) != 0 {
+		t.Fatalf("steering queue after mismatch: got %+v, want empty", steering)
+	}
+
+	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:" + sess.ID(), Index: 0, ExpectedEntryID: ids[0]})
 	if resp.Kind() != appwire.MessageResponse {
 		t.Fatalf("resp=%v error=%+v", resp.Kind(), resp.Error)
 	}

--- a/server/appwire_promote_test.go
+++ b/server/appwire_promote_test.go
@@ -1,0 +1,188 @@
+package server
+
+// Tests for the turn/promoteQueuedAsSteer appwire method (issue #22): the
+// per-message counterpart of turn/drainAsSteer. The daemon removes the queued
+// follow-up at the requested index and injects it as user-sourced steering
+// into the in-flight turn; other queued messages stay queued. Failures are
+// honest: idle/closed → Conflict, negative index → InvalidParams, no callback
+// → Unavailable, and a session-side rejection (e.g. the queue shifted under
+// the client so the index is now out of range) propagates.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"primeradiant.com/serf/agent"
+	"primeradiant.com/serf/agent/execenv"
+	"primeradiant.com/serf/agent/provider"
+	"primeradiant.com/serf/appwire"
+	"primeradiant.com/serf/llm"
+)
+
+func newPromoteTestServer(t *testing.T, processing bool) (*Server, *int) {
+	t.Helper()
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+	srv.SetProcessing(processing)
+	state := "idle"
+	if processing {
+		state = "active"
+	}
+	srv.SetStatus(StatusInfo{SessionID: "th_1", State: state})
+	called := 0
+	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
+		called++
+		return nil
+	})
+	return srv, &called
+}
+
+func promoteRPC(conn interface {
+	HandleMessage(context.Context, appwire.Message) appwire.Message
+}, id int64, params appwire.TurnPromoteQueuedAsSteerParams) appwire.Message {
+	conn.HandleMessage(context.Background(), appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodInitialize, appwire.InitializeParams{}))
+	return conn.HandleMessage(context.Background(), appwire.RequestMessage(appwire.NewIntID(id), appwire.MethodTurnPromoteQueuedAsSteer, params))
+}
+
+func TestServerAppWireTurnPromoteQueuedAsSteerDispatchesIndex(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+	srv.SetProcessing(true)
+	srv.SetStatus(StatusInfo{SessionID: "th_1", State: "active"})
+	gotIndex := -1
+	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
+		gotIndex = index
+		return nil
+	})
+
+	conn := srv.AppServer().NewConnection("test")
+	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:th_1", Index: 1})
+	if resp.Kind() != appwire.MessageResponse {
+		t.Fatalf("resp=%v error=%+v", resp.Kind(), resp.Error)
+	}
+	if gotIndex != 1 {
+		t.Fatalf("promote callback index=%d, want 1", gotIndex)
+	}
+}
+
+func TestServerAppWireTurnPromoteQueuedAsSteerRejectsNegativeIndex(t *testing.T) {
+	srv, called := newPromoteTestServer(t, true)
+	conn := srv.AppServer().NewConnection("test")
+	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:th_1", Index: -1})
+	if resp.Kind() != appwire.MessageError {
+		t.Fatalf("expected error, got %v", resp.Kind())
+	}
+	if resp.Error.Error.Code != appwire.CodeInvalidParams {
+		t.Fatalf("error=%+v", resp.Error.Error)
+	}
+	if *called != 0 {
+		t.Fatalf("promote called=%d, want 0", *called)
+	}
+}
+
+func TestServerAppWireTurnPromoteQueuedAsSteerRejectsWhenIdle(t *testing.T) {
+	srv, called := newPromoteTestServer(t, false)
+	conn := srv.AppServer().NewConnection("test")
+	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:th_1", Index: 0})
+	if resp.Kind() != appwire.MessageError {
+		t.Fatalf("expected error, got %v", resp.Kind())
+	}
+	if resp.Error.Error.Code != appwire.CodeConflict {
+		t.Fatalf("error=%+v", resp.Error.Error)
+	}
+	if *called != 0 {
+		t.Fatalf("promote called=%d, want 0", *called)
+	}
+}
+
+func TestServerAppWireTurnPromoteQueuedAsSteerUnavailableWithoutFunc(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+	srv.SetProcessing(true)
+	srv.SetStatus(StatusInfo{SessionID: "th_1", State: "active"})
+	conn := srv.AppServer().NewConnection("test")
+	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:th_1", Index: 0})
+	if resp.Kind() != appwire.MessageError {
+		t.Fatalf("expected error, got %v", resp.Kind())
+	}
+	if resp.Error.Error.Code != appwire.CodeUnavailable {
+		t.Fatalf("error=%+v", resp.Error.Error)
+	}
+}
+
+func TestServerAppWireTurnPromoteQueuedAsSteerPropagatesSessionError(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+	srv.SetProcessing(true)
+	srv.SetStatus(StatusInfo{SessionID: "th_1", State: "active"})
+	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
+		return errors.New("promote: queue index 3 out of range (depth 1)")
+	})
+	conn := srv.AppServer().NewConnection("test")
+	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:th_1", Index: 3})
+	if resp.Kind() != appwire.MessageError {
+		t.Fatalf("expected error, got %v", resp.Kind())
+	}
+}
+
+// TestServerAppWireTurnPromoteQueuedAsSteerThroughSession exercises the full
+// stack the way cmd/serf serve wires it: the RPC drives the real agent
+// session's PromoteQueuedAsSteer, so the promoted entry leaves the queue and
+// lands on the steering queue as user-sourced steering while the other
+// queued message stays queued.
+func TestServerAppWireTurnPromoteQueuedAsSteerThroughSession(t *testing.T) {
+	dir := t.TempDir()
+	c := llm.NewClient()
+	adapter := &blockingServerAdapter{name: "openai", started: make(chan struct{}), done: make(chan error, 1)}
+	c.Register(adapter)
+	sess, err := agent.NewSession(c, provider.NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), agent.SessionConfig{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_, _ = sess.ProcessInput(ctx, "keep turn active", nil)
+	}()
+	select {
+	case <-adapter.started:
+	case <-time.After(time.Second):
+		t.Fatal("session did not enter active turn")
+	}
+
+	for _, msg := range []string{"alpha", "bravo"} {
+		if err := sess.Enqueue(context.Background(), msg); err != nil {
+			t.Fatalf("Enqueue %s: %v", msg, err)
+		}
+	}
+
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", sess.ID())
+	srv.SetProcessing(true)
+	srv.SetStatus(StatusInfo{SessionID: sess.ID(), State: "active"})
+	srv.SetPromoteQueuedAsSteerFunc(func(index int) error {
+		return sess.PromoteQueuedAsSteer(context.Background(), index)
+	})
+
+	conn := srv.AppServer().NewConnection("test")
+	resp := promoteRPC(conn, 2, appwire.TurnPromoteQueuedAsSteerParams{Ref: "local:" + sess.ID(), Index: 0})
+	if resp.Kind() != appwire.MessageResponse {
+		t.Fatalf("resp=%v error=%+v", resp.Kind(), resp.Error)
+	}
+	if preview := sess.QueuePreview(); len(preview) != 1 || preview[0] != "bravo" {
+		t.Fatalf("QueuePreview after promote: got %#v, want [bravo]", preview)
+	}
+	steering := sess.SteeringQueueSnapshot()
+	if len(steering) != 1 || steering[0].Text != "alpha" {
+		t.Fatalf("steering queue after promote: got %+v, want [alpha]", steering)
+	}
+	cancel()
+	select {
+	case <-adapter.done:
+	case <-time.After(time.Second):
+		t.Fatal("active turn did not stop after cancellation")
+	}
+}

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -96,6 +96,7 @@ func (s *Server) registerAppWireHandlers() {
 	appserver.HandleTyped(router, appwire.MethodTurnInterrupt, s.handleAppTurnInterrupt)
 	appserver.HandleTyped(router, appwire.MethodTurnQueue, s.handleAppTurnQueue)
 	appserver.HandleTyped(router, appwire.MethodTurnDrainAsSteer, s.handleAppTurnDrainAsSteer)
+	appserver.HandleTyped(router, appwire.MethodTurnPromoteQueuedAsSteer, s.handleAppTurnPromoteQueuedAsSteer)
 	appserver.HandleTyped(router, appwire.MethodGoalSet, s.handleAppGoalSet)
 	appserver.HandleTyped(router, appwire.MethodThreadCompactStart, s.handleAppThreadCompactStart)
 	appserver.HandleTyped(router, appwire.MethodThreadShutdown, s.handleAppThreadShutdown)
@@ -513,6 +514,37 @@ func (s *Server) handleAppTurnDrainAsSteer(_ context.Context, params appwire.Tur
 		err = fn()
 	}
 	if err != nil {
+		return appwire.EmptyResponse{}, err
+	}
+	return appwire.EmptyResponse{}, nil
+}
+
+// handleAppTurnPromoteQueuedAsSteer handles turn/promoteQueuedAsSteer
+// (issue #22): removes the queued follow-up at params.Index and injects it
+// as user-sourced steering into the in-flight turn. A negative index is an
+// InvalidParams rejection; an idle or closed session is a Conflict (the
+// queued message stays a normal follow-up — nothing is silently dropped);
+// a session-side out-of-range (the queue shifted between the client's
+// preview snapshot and the promote) propagates the session's error.
+func (s *Server) handleAppTurnPromoteQueuedAsSteer(_ context.Context, params appwire.TurnPromoteQueuedAsSteerParams) (appwire.EmptyResponse, error) {
+	if params.Index < 0 {
+		return appwire.EmptyResponse{}, appwire.InvalidParams("index must be >= 0")
+	}
+	s.mu.RLock()
+	fn := s.promoteSteerFunc
+	processing := s.processing
+	closed := appStatus(s.status.State, processing) == appwire.ThreadStatusClosed
+	s.mu.RUnlock()
+	if closed {
+		return appwire.EmptyResponse{}, appwire.Conflict("session is closed")
+	}
+	if !processing {
+		return appwire.EmptyResponse{}, appwire.Conflict("no active turn to steer")
+	}
+	if fn == nil {
+		return appwire.EmptyResponse{}, appwire.Unavailable("promote-queued-as-steer not available")
+	}
+	if err := fn(params.Index); err != nil {
 		return appwire.EmptyResponse{}, err
 	}
 	return appwire.EmptyResponse{}, nil

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -523,9 +523,11 @@ func (s *Server) handleAppTurnDrainAsSteer(_ context.Context, params appwire.Tur
 // (issue #22): removes the queued follow-up at params.Index and injects it
 // as user-sourced steering into the in-flight turn. A negative index is an
 // InvalidParams rejection; an idle or closed session is a Conflict (the
-// queued message stays a normal follow-up — nothing is silently dropped);
-// a session-side out-of-range (the queue shifted between the client's
-// preview snapshot and the promote) propagates the session's error.
+// queued message stays a normal follow-up — nothing is silently dropped).
+// Session-side rejections are all queue-state conflicts — the index fell
+// out of range or the expected entry id no longer matches because the queue
+// shifted under the client's snapshot (review F1) — so they map to Conflict
+// and the client can re-sync its preview (review F2).
 func (s *Server) handleAppTurnPromoteQueuedAsSteer(_ context.Context, params appwire.TurnPromoteQueuedAsSteerParams) (appwire.EmptyResponse, error) {
 	if params.Index < 0 {
 		return appwire.EmptyResponse{}, appwire.InvalidParams("index must be >= 0")
@@ -544,8 +546,8 @@ func (s *Server) handleAppTurnPromoteQueuedAsSteer(_ context.Context, params app
 	if fn == nil {
 		return appwire.EmptyResponse{}, appwire.Unavailable("promote-queued-as-steer not available")
 	}
-	if err := fn(params.Index); err != nil {
-		return appwire.EmptyResponse{}, err
+	if err := fn(params.Index, params.ExpectedEntryID); err != nil {
+		return appwire.EmptyResponse{}, appwire.Conflict(err.Error())
 	}
 	return appwire.EmptyResponse{}, nil
 }
@@ -715,6 +717,7 @@ func (s *Server) appThread() appwire.Thread {
 	dfn := s.detailedStatusFn
 	qpfn := s.queuePreviewFn
 	qdfn := s.queueDepthFn
+	qifn := s.queueIDsFn
 	gsfn := s.goalStatusFn
 	wmfn := s.workMetricsFn
 	metafn := s.sessionMetaFn
@@ -753,6 +756,11 @@ func (s *Server) appThread() appwire.Thread {
 		if preview := qpfn(); len(preview) > 0 {
 			queue.Preview = append([]string(nil), preview...)
 			queue.Depth = len(preview)
+		}
+	}
+	if qifn != nil && queue.Depth > 0 {
+		if ids := qifn(); len(ids) == queue.Depth {
+			queue.IDs = append([]string(nil), ids...)
 		}
 	}
 	// Fall back to depthFn when preview isn't wired (some tests stub only

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -97,6 +97,7 @@ func (s *Server) registerAppWireHandlers() {
 	appserver.HandleTyped(router, appwire.MethodTurnQueue, s.handleAppTurnQueue)
 	appserver.HandleTyped(router, appwire.MethodTurnDrainAsSteer, s.handleAppTurnDrainAsSteer)
 	appserver.HandleTyped(router, appwire.MethodTurnPromoteQueuedAsSteer, s.handleAppTurnPromoteQueuedAsSteer)
+	appserver.HandleTyped(router, appwire.MethodTurnCancelQueued, s.handleAppTurnCancelQueued)
 	appserver.HandleTyped(router, appwire.MethodGoalSet, s.handleAppGoalSet)
 	appserver.HandleTyped(router, appwire.MethodThreadCompactStart, s.handleAppThreadCompactStart)
 	appserver.HandleTyped(router, appwire.MethodThreadShutdown, s.handleAppThreadShutdown)
@@ -552,6 +553,38 @@ func (s *Server) handleAppTurnPromoteQueuedAsSteer(_ context.Context, params app
 	return appwire.EmptyResponse{}, nil
 }
 
+// handleAppTurnCancelQueued handles turn/cancelQueued (issue #23): removes
+// the queued follow-up at params.Index so it is never consumed, echoing the
+// removed entry's full text and image count. Unlike promote, cancel does
+// NOT require an in-flight turn — a queued entry is cancellable whenever it
+// is still queued, including entries buffered on an idle session. A
+// negative index is an InvalidParams rejection; a closed session is a
+// Conflict. Session-side rejections are all queue-state conflicts — the
+// index fell out of range (the entry was already consumed) or the expected
+// entry id no longer matches because the queue shifted under the client's
+// snapshot (review F1) — so they map to Conflict and the client can re-sync
+// its preview (review F2).
+func (s *Server) handleAppTurnCancelQueued(_ context.Context, params appwire.TurnCancelQueuedParams) (appwire.TurnCancelQueuedResponse, error) {
+	if params.Index < 0 {
+		return appwire.TurnCancelQueuedResponse{}, appwire.InvalidParams("index must be >= 0")
+	}
+	s.mu.RLock()
+	fn := s.cancelQueuedFunc
+	closed := appStatus(s.status.State, s.processing) == appwire.ThreadStatusClosed
+	s.mu.RUnlock()
+	if closed {
+		return appwire.TurnCancelQueuedResponse{}, appwire.Conflict("session is closed")
+	}
+	if fn == nil {
+		return appwire.TurnCancelQueuedResponse{}, appwire.Unavailable("cancel-queued not available")
+	}
+	text, images, err := fn(params.Index, params.ExpectedEntryID)
+	if err != nil {
+		return appwire.TurnCancelQueuedResponse{}, appwire.Conflict(err.Error())
+	}
+	return appwire.TurnCancelQueuedResponse{RemovedText: text, RemovedImages: images}, nil
+}
+
 // handleAppGoalSet handles goal/set. An empty objective clears the goal; both
 // set and clear route through the single goalFunc callback (the callback maps an
 // empty objective to ClearGoal). Started reports whether the goal loop began
@@ -718,6 +751,7 @@ func (s *Server) appThread() appwire.Thread {
 	qpfn := s.queuePreviewFn
 	qdfn := s.queueDepthFn
 	qifn := s.queueIDsFn
+	qtfn := s.queueTextsFn
 	gsfn := s.goalStatusFn
 	wmfn := s.workMetricsFn
 	metafn := s.sessionMetaFn
@@ -761,6 +795,11 @@ func (s *Server) appThread() appwire.Thread {
 	if qifn != nil && queue.Depth > 0 {
 		if ids := qifn(); len(ids) == queue.Depth {
 			queue.IDs = append([]string(nil), ids...)
+		}
+	}
+	if qtfn != nil && queue.Depth > 0 {
+		if texts := qtfn(); len(texts) == queue.Depth {
+			queue.Texts = append([]string(nil), texts...)
 		}
 	}
 	// Fall back to depthFn when preview isn't wired (some tests stub only

--- a/server/server.go
+++ b/server/server.go
@@ -171,9 +171,11 @@ type Server struct {
 	drainSteerFunc               func() error
 	drainSteerInputFunc          func(string, []ImageAttachment) error
 	promoteSteerFunc             func(int, string) error
+	cancelQueuedFunc             func(int, string) (string, int, error)
 	queueDepthFn                 func() int
 	queueIDsFn                   func() []string
 	queuePreviewFn               func() []string
+	queueTextsFn                 func() []string
 	compactFunc                  func(context.Context) error
 	clearFunc                    func(context.Context) error
 	pressureFn                   func() float64
@@ -421,6 +423,19 @@ func (s *Server) SetPromoteQueuedAsSteerFunc(fn func(int, string) error) {
 	s.mu.Unlock()
 }
 
+// SetCancelQueuedFunc sets the function called by appwire
+// turn/cancelQueued (issue #23). The callback should remove the queued
+// message at the given FIFO index so it is never consumed, returning the
+// removed entry's full text and image count. A non-empty expectedID must
+// match the queue-entry id minted at enqueue time so a queue that shifted
+// under the client's snapshot is rejected rather than removing the wrong
+// message (review F1). Unlike promote, no active turn is required.
+func (s *Server) SetCancelQueuedFunc(fn func(int, string) (string, int, error)) {
+	s.mu.Lock()
+	s.cancelQueuedFunc = fn
+	s.mu.Unlock()
+}
+
 // SetQueueDepthFunc sets a callback returning the current queue depth so
 // capability projection can advertise Queue accurately.
 func (s *Server) SetQueueDepthFunc(fn func() int) {
@@ -446,6 +461,17 @@ func (s *Server) SetQueuePreviewFunc(fn func() []string) {
 func (s *Server) SetQueueIDsFunc(fn func() []string) {
 	s.mu.Lock()
 	s.queueIDsFn = fn
+	s.mu.Unlock()
+}
+
+// SetQueueTextsFunc sets a callback returning the full untruncated texts of
+// the queued user messages in FIFO order (aligned with QueuePreview). Used
+// by appwire ReadThread to populate QueueState.Texts so the edit affordance
+// (issue #23) can restore the complete message into the composer before
+// canceling the queued copy.
+func (s *Server) SetQueueTextsFunc(fn func() []string) {
+	s.mu.Lock()
+	s.queueTextsFn = fn
 	s.mu.Unlock()
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -170,8 +170,9 @@ type Server struct {
 	goalStatusFn                 func() (status string, iterations int, ok bool)
 	drainSteerFunc               func() error
 	drainSteerInputFunc          func(string, []ImageAttachment) error
-	promoteSteerFunc             func(int) error
+	promoteSteerFunc             func(int, string) error
 	queueDepthFn                 func() int
+	queueIDsFn                   func() []string
 	queuePreviewFn               func() []string
 	compactFunc                  func(context.Context) error
 	clearFunc                    func(context.Context) error
@@ -411,8 +412,10 @@ func (s *Server) SetDrainAsSteerWithInputFunc(fn func(string, []ImageAttachment)
 // turn/promoteQueuedAsSteer (issue #22). The callback should remove the
 // queued message at the given FIFO index and inject it as a user-sourced
 // STEERING message into the in-flight turn, leaving the rest of the queue
-// untouched.
-func (s *Server) SetPromoteQueuedAsSteerFunc(fn func(int) error) {
+// untouched. A non-empty expectedID must match the queue-entry id minted at
+// enqueue time so a queue that shifted under the client's snapshot is
+// rejected rather than promoting the wrong message (review F1).
+func (s *Server) SetPromoteQueuedAsSteerFunc(fn func(int, string) error) {
 	s.mu.Lock()
 	s.promoteSteerFunc = fn
 	s.mu.Unlock()
@@ -433,6 +436,16 @@ func (s *Server) SetQueueDepthFunc(fn func() int) {
 func (s *Server) SetQueuePreviewFunc(fn func() []string) {
 	s.mu.Lock()
 	s.queuePreviewFn = fn
+	s.mu.Unlock()
+}
+
+// SetQueueIDsFunc sets a callback returning the stable per-entry ids of the
+// queued user messages in FIFO order (aligned with QueuePreview). Used by
+// appwire ReadThread to populate QueueState.IDs so a promote request can
+// carry the expected entry identity (review F1, issue #22).
+func (s *Server) SetQueueIDsFunc(fn func() []string) {
+	s.mu.Lock()
+	s.queueIDsFn = fn
 	s.mu.Unlock()
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -170,6 +170,7 @@ type Server struct {
 	goalStatusFn                 func() (status string, iterations int, ok bool)
 	drainSteerFunc               func() error
 	drainSteerInputFunc          func(string, []ImageAttachment) error
+	promoteSteerFunc             func(int) error
 	queueDepthFn                 func() int
 	queuePreviewFn               func() []string
 	compactFunc                  func(context.Context) error
@@ -403,6 +404,17 @@ func (s *Server) SetDrainAsSteerFunc(fn func() error) {
 func (s *Server) SetDrainAsSteerWithInputFunc(fn func(string, []ImageAttachment) error) {
 	s.mu.Lock()
 	s.drainSteerInputFunc = fn
+	s.mu.Unlock()
+}
+
+// SetPromoteQueuedAsSteerFunc sets the function called by appwire
+// turn/promoteQueuedAsSteer (issue #22). The callback should remove the
+// queued message at the given FIFO index and inject it as a user-sourced
+// STEERING message into the in-flight turn, leaving the rest of the queue
+// untouched.
+func (s *Server) SetPromoteQueuedAsSteerFunc(fn func(int) error) {
+	s.mu.Lock()
+	s.promoteSteerFunc = fn
 	s.mu.Unlock()
 }
 


### PR DESCRIPTION
## Summary

Fixes #23 — in the web UI, every unconsumed queued message (queue-preview row) now has **edit** and **cancel** actions next to the issue-#22 promote action, following the promote architecture end to end.

**Daemon primitive** — `Session.CancelQueued(ctx, index, expectedID)` removes one queued follow-up so it is never consumed, with the same review-F1 expected-identity race protection as `PromoteQueuedAsSteer` (32513db3). Unlike promote it requires **no in-flight turn** — a queued entry is cancellable whenever it is still queued, including entries buffered on an idle session. It returns the removed entry's full text + image count. `QueueChangedData`/`QueueState` now carry `Texts` (full untruncated text, FIFO-aligned with `Preview`/`IDs`) so edit can restore the complete message — the preview line alone would silently truncate multi-line messages.

**Full stack** — new appwire `turn/cancelQueued` (ScopeBoth, `TurnCancelQueuedResponse{removedText, removedImages}`) → server handler (negative index → InvalidParams, closed → Conflict, session rejections → Conflict per review F2) → `serf serve` wiring → hub `Source.CancelQueued` (local daemon forwards; codex → Unavailable) → hub appwire relay (gated on the **Send** capability, not Steer — cancel needs no active turn) → REST fallback `POST /s/<id>/cancel-queued` → web UI.

**Design decisions**
- *Edit UX shape*: cancel-and-recompose. The full text returns to the composer **first** — appended after a blank line when the composer already has text (existing text is never clobbered), persisted through the SerfDrafts input-event path — then the queued copy is canceled. The row disappears via the daemon's authoritative `thread/queueChanged` (no local mirror).
- *Stale-edit race*: text-first ordering means the removal losing the race (message consumed between snapshot and click, or queue shifted so the expected id mismatches) can never lose the user's text. The banner then says the queued copy could **not** be removed and the text is in the composer — honest, no silent duplication.
- *Image entries*: image-only queued messages disable edit (nothing to recompose; cancel still works); a successful edit whose entry had attachments warns "re-attach before resending" via the response's `removedImages` instead of silently dropping them.
- *Old daemons* (no `Texts`): edit degrades to an honest "edit unavailable — cancel and retype" banner rather than restoring a truncated preview line.
- *Steering queue*: investigated — pending steering entries are not user-visible anywhere (`SteeringQueueSnapshot` is test-only), so edit/cancel scope is the input queue (queued follow-ups) exactly as rendered in the queue preview.

## Test evidence

- `make build-hub` / `make build-all` — PASS
- `go test ./agent ./appwire ./server ./cmd/serf ./cmd/serf-hub ./internal/appprojector ./internal/apptranscript` — all ok
- `go vet` on changed packages + `go vet -tags serffuzz ./agent` — clean
- `make lint-golangci` — PASS (7 modules)
- `cd cmd/serf-hub && bash jstest/run-all.sh` — all tests passed
- New tests: agent `session_queue_cancel_test.go` (10: removal/FIFO/idle/multiline/images/queueChanged-with-Texts/out-of-range/id-mismatch/closed/canceled-ctx), server `appwire_cancel_test.go` (7, incl. through-session + review-F1 mismatch), hub `web_cancel_test.go` (6, REST + RPC relay), jsdom `test-queue-edit-cancel.js` (8 scenarios: buttons, cancel posts identity, cancel failure banner, edit preserves composer + persists draft, failed edit keeps text + honest banner, dropped-images warning, image-only disabled, old-daemon degradation)

`docs/appwire-protocol.md` regenerated (`make generate`).