### PR TITLE
webui,tui: prepopulate session path dropdown with 15 recent projects (#35)

### DIFF
--- a/appwire/client.go
+++ b/appwire/client.go
@@ -406,6 +406,12 @@ func (c *Client) DirsComplete(ctx context.Context, params DirsCompleteParams) (D
 	return out, err
 }
 
+func (c *Client) ProjectsRecent(ctx context.Context, params ProjectsRecentParams) (ProjectsRecentResponse, error) {
+	var out ProjectsRecentResponse
+	err := c.request(ctx, MethodSerfProjectsRecent, params, &out)
+	return out, err
+}
+
 func (c *Client) HarnessList(ctx context.Context, params HarnessListParams) (HarnessListResponse, error) {
 	var out HarnessListResponse
 	err := c.request(ctx, MethodSerfHarnessesList, params, &out)

--- a/appwire/cov_rhub_appwire_test.go
+++ b/appwire/cov_rhub_appwire_test.go
@@ -186,6 +186,16 @@ func TestClientRequestWrappersRoundTrip(t *testing.T) {
 			}
 			return nil
 		}},
+		{"ProjectsRecent", MethodSerfProjectsRecent, ProjectsRecentResponse{Data: []string{"/a", "/b"}}, func(ctx context.Context, c *Client) error {
+			out, err := c.ProjectsRecent(ctx, ProjectsRecentParams{Limit: 15})
+			if err != nil {
+				return err
+			}
+			if len(out.Data) != 2 {
+				return errors.New("ProjectsRecent decode mismatch")
+			}
+			return nil
+		}},
 		{"HarnessList", MethodSerfHarnessesList, HarnessListResponse{Data: []HarnessDescriptor{{ID: "serf"}}}, func(ctx context.Context, c *Client) error {
 			out, err := c.HarnessList(ctx, HarnessListParams{})
 			if err != nil {

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -110,6 +110,7 @@ var Methods = []MethodSpec{
 	{MethodSerfThreadTranscriptsList, ThreadTranscriptListParams{}, ThreadTranscriptListResponse{}, ScopeHub, "Lists transcript targets (subagents/related threads) for a ref."},
 	{MethodSerfSubagentPreview, SerfSubagentPreviewParams{}, SerfSubagentPreviewResponse{}, ScopeHub, "Reads a bounded lazy preview of a subagent transcript's latest direct items."},
 	{MethodSerfDirsComplete, DirsCompleteParams{}, DirsCompleteResponse{}, ScopeHub, "Directory-path autocompletion for a prefix."},
+	{MethodSerfProjectsRecent, ProjectsRecentParams{}, ProjectsRecentResponse{}, ScopeHub, "Lists the most recently used project working directories (session creation path-dropdown options; default cap 15)."},
 	{MethodSerfPathValidate, PathValidateParams{}, PathValidateResponse{}, ScopeHub, "Validates a launch path."},
 	{MethodSerfHarnessesList, HarnessListParams{}, HarnessListResponse{}, ScopeHub, "Lists available harness descriptors."},
 	{MethodSerfUpgrade, UpgradeParams{}, UpgradeResponse{}, ScopeHub, "Performs or reports a serf binary upgrade."},

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -33,6 +33,7 @@ const (
 	MethodSerfThreadTranscriptsList = "serf/thread/transcripts/list"
 	MethodSerfSubagentPreview       = "serf/subagentPreview"
 	MethodSerfDirsComplete          = "serf/dirs/complete"
+	MethodSerfProjectsRecent        = "serf/projects/recent"
 	MethodSerfPathValidate          = "serf/path/validate"
 	MethodSerfHarnessesList         = "serf/harnesses/list"
 	MethodSerfUpgrade               = "serf/upgrade"
@@ -876,6 +877,19 @@ type DirsCompleteParams struct {
 }
 
 type DirsCompleteResponse struct {
+	Data []string `json:"data"`
+}
+
+// ProjectsRecentParams selects how many recent project directories the hub
+// returns. Limit <= 0 means the hub default (the session creation flows'
+// 15-option dropdown cap).
+type ProjectsRecentParams struct {
+	Limit int `json:"limit,omitempty"`
+}
+
+// ProjectsRecentResponse lists distinct project working directories ordered
+// by actual recency of use (most recently active session first).
+type ProjectsRecentResponse struct {
 	Data []string `json:"data"`
 }
 

--- a/cmd/serf-hub/app_rpc.go
+++ b/cmd/serf-hub/app_rpc.go
@@ -663,6 +663,10 @@ func notifyPluginUpdated(server *appserver.Server) {
 	server.BroadcastAll(appwire.NotifySerfPluginUpdated, map[string]string{})
 }
 
+// recentProjectDirsLimit is the session creation flows' path-dropdown option
+// count (issue #35): the 15 most recently used projects.
+const recentProjectDirsLimit = 15
+
 // registerMiscHandlers registers the remaining hub RPC handlers: model list,
 // task list, transcript list, directory completion, path validation, and the
 // harness descriptor list.
@@ -683,6 +687,17 @@ func registerMiscHandlers(server *appserver.Server, cfg hubcore.WebConfig, sourc
 	})
 	appserver.HandleTyped(server.Router(), appwire.MethodSerfDirsComplete, func(_ context.Context, params appwire.DirsCompleteParams) (appwire.DirsCompleteResponse, error) {
 		return fspaths.CompleteDirs(params)
+	})
+	appserver.HandleTyped(server.Router(), appwire.MethodSerfProjectsRecent, func(_ context.Context, params appwire.ProjectsRecentParams) (appwire.ProjectsRecentResponse, error) {
+		limit := params.Limit
+		if limit <= 0 {
+			limit = recentProjectDirsLimit
+		}
+		var dirs []string
+		if cfg.Past != nil {
+			dirs = cfg.Past.RecentProjectDirs(limit)
+		}
+		return appwire.ProjectsRecentResponse{Data: dirs}, nil
 	})
 	appserver.HandleTyped(server.Router(), appwire.MethodSerfPathValidate, func(_ context.Context, params appwire.PathValidateParams) (appwire.PathValidateResponse, error) {
 		return fspaths.ValidateLaunchPath(params), nil

--- a/cmd/serf-hub/app_rpc_test.go
+++ b/cmd/serf-hub/app_rpc_test.go
@@ -6717,6 +6717,55 @@ func TestHubRPCDirsCompleteReturnsMatchingDirectories(t *testing.T) {
 	}
 }
 
+// TestHubRPCProjectsRecentReturnsMostRecentDirs covers the session creation
+// flows' recent-project source (issue #35): serf/projects/recent serves the
+// past index's distinct working dirs, most-recently-used first, defaulting to
+// the 15-option cap when the request carries no limit.
+func TestHubRPCProjectsRecentReturnsMostRecentDirs(t *testing.T) {
+	past := hubcore.NewPastIndex("")
+	now := time.Now().UTC()
+	metas := []schema.SessionMeta{
+		{ID: "02wMz5Txv1C3Hut0M8GCeB", UpdatedAt: now.Add(-1 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: "/alpha"}},
+		{ID: "02wMz5Txv2enqVTitaig6F", UpdatedAt: now.Add(-2 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: "/beta"}},
+		{ID: "02wMz5Txv5aIxgf9yVdd0N", UpdatedAt: now.Add(-3 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: "/alpha"}}, // older dup — dropped
+	}
+	for n := 0; n < 20; n++ {
+		metas = append(metas, schema.SessionMeta{
+			ID:        fmt.Sprintf("02wMz5Txv1C3Hut0M8GC%02d", n),
+			UpdatedAt: now.Add(-time.Duration(n+4) * time.Minute),
+			EnvInfo:   schema.EnvironmentInfo{WorkingDir: fmt.Sprintf("/proj-%02d", n)},
+		})
+	}
+	past.SeedForTest(metas)
+
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{Past: past})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	resp, err := client.ProjectsRecent(context.Background(), appwire.ProjectsRecentParams{})
+	if err != nil {
+		t.Fatalf("ProjectsRecent: %v", err)
+	}
+	if len(resp.Data) != 15 {
+		t.Fatalf("recent dirs=%d, want the default 15-option cap", len(resp.Data))
+	}
+	if resp.Data[0] != "/alpha" || resp.Data[1] != "/beta" {
+		t.Fatalf("recent dirs[0:2]=%v, want [/alpha /beta] (most recently used first)", resp.Data[:2])
+	}
+
+	limited, err := client.ProjectsRecent(context.Background(), appwire.ProjectsRecentParams{Limit: 2})
+	if err != nil {
+		t.Fatalf("ProjectsRecent limit=2: %v", err)
+	}
+	if len(limited.Data) != 2 || limited.Data[0] != "/alpha" || limited.Data[1] != "/beta" {
+		t.Fatalf("recent dirs limit=2 = %v, want [/alpha /beta]", limited.Data)
+	}
+}
+
 func TestHubRPCThreadForkRoutesNonLocalCapableSource(t *testing.T) {
 	source := &forkingRelaySource{
 		relayBroadcastSource: relayBroadcastSource{
@@ -7215,6 +7264,7 @@ func TestHubRPCRegistersExpectedHandlerSet(t *testing.T) {
 		appwire.MethodSerfTasksList,
 		appwire.MethodSerfThreadTranscriptsList,
 		appwire.MethodSerfDirsComplete,
+		appwire.MethodSerfProjectsRecent,
 		appwire.MethodSerfPathValidate,
 		appwire.MethodSerfHarnessesList,
 		appwire.MethodSerfCommandList,

--- a/cmd/serf-hub/assets/appwire.js
+++ b/cmd/serf-hub/assets/appwire.js
@@ -23,6 +23,7 @@
     tasksList: "serf/tasks/list",
     sandboxEscalationResolve: "serf/sandbox/escalation/resolve",
     dirsComplete: "serf/dirs/complete",
+    projectsRecent: "serf/projects/recent",
     pathValidate: "serf/path/validate",
     serfUpgrade: "serf/upgrade",
     modelList: "model/list",
@@ -367,6 +368,14 @@
     return request(METHOD.dirsComplete, { prefix: prefix || "" }).then((resp) => ({
       results: (resp.data || []).map((path) => ({ path, is_git: false })),
     }));
+  }
+
+  // recentProjects returns the hub's most recently used project working
+  // directories (server-capped at 15) for the session creation path dropdown.
+  function recentProjects() {
+    return request(METHOD.projectsRecent, {}).then((resp) => (
+      resp && Array.isArray(resp.data) ? resp.data : []
+    ));
   }
 
   function validatePath(path, kind) {
@@ -1083,6 +1092,7 @@
     listModels,
     listModelsWithDiagnostics,
     completeDirs,
+    recentProjects,
     validatePath,
     upgrade,
     startThread,

--- a/cmd/serf-hub/assets/dir-picker.js
+++ b/cmd/serf-hub/assets/dir-picker.js
@@ -44,6 +44,16 @@
     return global.SerfAppwire.completeDirs(prefix);
   }
 
+  // recentProjects fetches the hub's most recently used project directories
+  // (server-capped at 15) to prepopulate the picker on an empty query. Older
+  // hub clients without the RPC degrade to no recent section.
+  function recentProjects() {
+    if (global.SerfAppwire && typeof global.SerfAppwire.recentProjects === "function") {
+      return global.SerfAppwire.recentProjects().catch(() => []);
+    }
+    return Promise.resolve([]);
+  }
+
   function removeExisting() {
     const existing = document.querySelector(".chip-picker");
     if (existing) {
@@ -157,6 +167,10 @@
 
     let timer = null;
     let requestID = 0;
+    // The dropdown is prepopulated with the most recent projects (issue #35)
+    // on its initial listing only; browsing or typing swaps to plain
+    // completion results.
+    let pendingRecent = true;
 
     function close() {
       if (timer) {
@@ -184,12 +198,14 @@
     }
 
     function browseTo(path) {
+      pendingRecent = false;
       currentDir = trimTrailingSlash(path);
       setInputValue(withTrailingSlash(currentDir));
       fetchDirs(withTrailingSlash(currentDir));
     }
 
     function searchFromInput(value) {
+      pendingRecent = false;
       const query = String(value || "");
       currentDir = query.endsWith("/") ? trimTrailingSlash(query) : parentDir(query);
       fetchDirs(query);
@@ -206,6 +222,33 @@
       row.innerHTML = '<span class="chip-picker-dir-name">..</span>';
       row.addEventListener("click", () => browseTo(parent || "/"));
       results.appendChild(row);
+    }
+
+    // Recent-project options accept on click (they pick the project, not
+    // browse into it) and show the full path — basenames collide across
+    // projects, so the basename alone would be ambiguous.
+    function appendRecentRows(recents) {
+      const header = document.createElement("div");
+      header.className = "chip-picker-dir-recent-header";
+      header.textContent = "Recent projects";
+      results.appendChild(header);
+      recents.forEach((path) => {
+        const el = document.createElement("button");
+        el.type = "button";
+        el.className = "chip-picker-dir-row chip-picker-dir-recent";
+        el.dataset.recentPath = path;
+        el.title = path;
+        const name = document.createElement("span");
+        name.className = "chip-picker-dir-name";
+        name.textContent = baseName(path);
+        el.appendChild(name);
+        const full = document.createElement("span");
+        full.className = "chip-picker-dir-recent-path";
+        full.textContent = path;
+        el.appendChild(full);
+        el.addEventListener("click", () => accept(path));
+        results.appendChild(el);
+      });
     }
 
     function appendDirRow(r) {
@@ -230,17 +273,25 @@
 
     function fetchDirs(prefix) {
       const currentRequestID = ++requestID;
+      const showRecent = pendingRecent;
+      pendingRecent = false;
+      const recentsPromise = showRecent ? recentProjects() : Promise.resolve([]);
       const dirsPromise = completeDirs(prefix);
-      dirsPromise.then((data) => {
+      Promise.all([dirsPromise, recentsPromise]).then(([data, recents]) => {
         if (currentRequestID !== requestID || !picker.parentNode) return;
         results.innerHTML = "";
         appendParentRow();
+        if (showRecent && recents.length > 0) {
+          appendRecentRows(recents);
+        }
         const list = normalizedResults(data);
         if (list.length === 0) {
-          const empty = document.createElement("div");
-          empty.className = "empty-state empty-state-picker";
-          empty.innerHTML = '<p class="empty-state-body">No directories here</p>';
-          results.appendChild(empty);
+          if (!showRecent || recents.length === 0) {
+            const empty = document.createElement("div");
+            empty.className = "empty-state empty-state-picker";
+            empty.innerHTML = '<p class="empty-state-body">No directories here</p>';
+            results.appendChild(empty);
+          }
           return;
         }
         list.forEach(appendDirRow);

--- a/cmd/serf-hub/assets/style.css
+++ b/cmd/serf-hub/assets/style.css
@@ -3641,6 +3641,8 @@ details[open] > .diagnostic-detail-summary::after { transform: rotate(90deg); }
 .chip-picker-dir-parent:hover { background: var(--line); }
 .chip-picker-dir-name { color: var(--ink); font-family: var(--font-mono); font-size: var(--text-sm); min-width: 0; overflow-wrap: anywhere; }
 .chip-picker-dir-tag { color: var(--diagnostic-warning); font-family: var(--font-mono); font-size: var(--text-2xs); padding: var(--space-1) var(--space-3); border: 1px solid var(--diagnostic-warning); border-radius: var(--radius-md); flex-shrink: 0; }
+.chip-picker-dir-recent-header { color: var(--ink-3); font-family: var(--font-mono); font-size: var(--text-2xs); padding: var(--space-2) var(--space-4) 0; }
+.chip-picker-dir-recent-path { color: var(--ink-3); font-family: var(--font-mono); font-size: var(--text-2xs); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; direction: rtl; text-align: right; }
 
 
 /* ── Search palette ──────────────────────────────────────────────────────── */

--- a/cmd/serf-hub/internal/hubcore/past.go
+++ b/cmd/serf-hub/internal/hubcore/past.go
@@ -548,6 +548,34 @@ func (i *PastIndex) RecentModels(limit int) []appwire.ModelDescriptor {
 	return out
 }
 
+// RecentProjectDirs returns up to limit distinct project working directories
+// for the session creation flows' path dropdown (issue #35), ordered by
+// actual recency of use: the index's most-recently-updated-first session
+// order (session_order.go's sessionMetaLess — a session's UpdatedAt is its
+// last activity moment), not directory mtime. Entries with a blank WorkingDir
+// are skipped. Deduped on the dir's first (most recent) occurrence.
+func (i *PastIndex) RecentProjectDirs(limit int) []string {
+	if limit <= 0 {
+		return nil
+	}
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	seen := make(map[string]bool, limit)
+	var out []string
+	for _, e := range i.all {
+		dir := strings.TrimSpace(e.Meta.EnvInfo.WorkingDir)
+		if dir == "" || seen[dir] {
+			continue
+		}
+		seen[dir] = true
+		out = append(out, dir)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out
+}
+
 // ObserversOf returns the session ids of observer subagents granted read on the
 // given worker session, reconstructed from durable jobs.jsonl watch-read-grants
 // at the last Rebuild. The result is at most one rebuild interval stale. It is

--- a/cmd/serf-hub/internal/hubcore/recent_projects_test.go
+++ b/cmd/serf-hub/internal/hubcore/recent_projects_test.go
@@ -1,0 +1,65 @@
+package hubcore
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"primeradiant.com/serf/agent/schema"
+)
+
+// TestPastIndex_RecentProjectDirs_DedupesGlobalRecencyLastN covers the session
+// creation flows' recent-project source (issue #35): distinct working dirs in
+// the index's most-recently-updated-first order, deduped on first (most
+// recent) occurrence, blank dirs skipped, capped at the limit.
+func TestPastIndex_RecentProjectDirs_DedupesGlobalRecencyLastN(t *testing.T) {
+	idx := NewPastIndex("")
+	now := time.Now().UTC()
+	idx.SeedForTest([]schema.SessionMeta{
+		{ID: "02wMz5Txv1C3Hut0M8GCeB", UpdatedAt: now.Add(-1 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: "/alpha"}},
+		{ID: "02wMz5Txv2enqVTitaig6F", UpdatedAt: now.Add(-2 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: "/beta"}},
+		{ID: "02wMz5Txv47YP64RR3B9YJ", UpdatedAt: now.Add(-3 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: "  "}}, // blank — skipped
+		{ID: "02wMz5Txv5aIxgf9yVdd0N", UpdatedAt: now.Add(-4 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: "/alpha"}}, // dup of /alpha, older — dropped
+		{ID: "02wMz5Txv733WHFsVy66SR", UpdatedAt: now.Add(-5 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: "/gamma"}},
+	})
+	got := idx.RecentProjectDirs(15)
+	want := []string{"/alpha", "/beta", "/gamma"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RecentProjectDirs(15) = %v, want %v", got, want)
+	}
+}
+
+func TestPastIndex_RecentProjectDirs_CapsAtLimit(t *testing.T) {
+	idx := NewPastIndex("")
+	now := time.Now().UTC()
+	metas := make([]schema.SessionMeta, 0, 20)
+	for n := 0; n < 20; n++ {
+		metas = append(metas, schema.SessionMeta{
+			ID:        fmt.Sprintf("02wMz5Txv1C3Hut0M8GC%02d", n),
+			UpdatedAt: now.Add(-time.Duration(n) * time.Minute),
+			EnvInfo:   schema.EnvironmentInfo{WorkingDir: fmt.Sprintf("/proj-%02d", n)},
+		})
+	}
+	idx.SeedForTest(metas)
+	got := idx.RecentProjectDirs(15)
+	if len(got) != 15 {
+		t.Fatalf("RecentProjectDirs(15) returned %d dirs, want 15", len(got))
+	}
+	if got[0] != "/proj-00" || got[14] != "/proj-14" {
+		t.Fatalf("RecentProjectDirs(15) = %v…%v, want /proj-00…/proj-14 (most recent first)", got[0], got[14])
+	}
+}
+
+func TestPastIndex_RecentProjectDirs_EmptyIndexOrNonPositiveLimitReturnsNil(t *testing.T) {
+	idx := NewPastIndex("")
+	if got := idx.RecentProjectDirs(15); got != nil {
+		t.Fatalf("RecentProjectDirs on empty index = %v, want nil", got)
+	}
+	idx.SeedForTest([]schema.SessionMeta{
+		{ID: "02wMz5Txv1C3Hut0M8GCeB", UpdatedAt: time.Now().UTC(), EnvInfo: schema.EnvironmentInfo{WorkingDir: "/alpha"}},
+	})
+	if got := idx.RecentProjectDirs(0); got != nil {
+		t.Fatalf("RecentProjectDirs(0) = %v, want nil", got)
+	}
+}

--- a/cmd/serf-hub/jstest/test-dir-picker-recent.js
+++ b/cmd/serf-hub/jstest/test-dir-picker-recent.js
@@ -1,0 +1,115 @@
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+
+const dirPickerSrc = fs.readFileSync(path.resolve(__dirname, "../assets/dir-picker.js"), "utf8");
+
+function assert(cond, msg) {
+  if (!cond) {
+    console.error("FAIL: " + msg);
+    process.exit(1);
+  }
+}
+
+function makeDom(appwire) {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>
+    <div id="anchor-wrap"><button id="anchor" type="button">dir</button></div>
+  </body></html>`, {
+    runScripts: "outside-only",
+    pretendToBeVisual: true,
+    url: "http://127.0.0.1:9180/new",
+  });
+  dom.window.SerfAppwire = appwire;
+  dom.window.eval(dirPickerSrc);
+  return dom;
+}
+
+(async function main() {
+  // The 15 most recent projects prepopulate the picker on an empty open
+  // (issue #35), most-recent first, above the browse listing.
+  const recent = Array.from({ length: 15 }, (_, i) => "/home/jesse/proj-" + String(i).padStart(2, "0"));
+  let recentCalls = 0;
+  const accepted = [];
+  const dom = makeDom({
+    completeDirs() {
+      return Promise.resolve({ results: [{ path: "/home/jesse/other", is_git: false }] });
+    },
+    recentProjects() {
+      recentCalls++;
+      return Promise.resolve(recent);
+    },
+  });
+  const anchor = dom.window.document.getElementById("anchor");
+  dom.window.SerfDirPicker.open({ anchor, currentValue: "", onAccept(v) { accepted.push(v); } });
+  await new Promise((r) => setTimeout(r, 0));
+
+  const picker = dom.window.document.querySelector(".chip-picker-dir");
+  assert(picker, "picker should render");
+  assert(recentCalls === 1, "recentProjects should be fetched once on an empty open, got " + recentCalls);
+  const results = picker.querySelector(".chip-picker-results");
+  const header = results.querySelector(".chip-picker-dir-recent-header");
+  assert(header, "recent projects section header should render");
+  assert(results.firstElementChild === header, "recent projects section should sit above the browse listing");
+  const rows = picker.querySelectorAll(".chip-picker-dir-recent");
+  assert(rows.length === 15, "picker should render the 15 most recent projects as options, got " + rows.length);
+  assert(rows[0].dataset.recentPath === recent[0], "first recent option should be the most recently used project");
+  assert(rows[14].dataset.recentPath === recent[14], "recent options should keep the server's recency order");
+  assert(picker.querySelector('[data-dir-path="/home/jesse/other"]'),
+    "browse rows should still render below the recent projects");
+
+  rows[0].click();
+  await new Promise((r) => setTimeout(r, 0));
+  assert(accepted[0] === recent[0], "clicking a recent project option should accept that path");
+  assert(!dom.window.document.querySelector(".chip-picker-dir"), "picker should close after accepting a recent project");
+
+  // Typing a query swaps the recent options for search results.
+  dom.window.SerfDirPicker.open({ anchor, currentValue: "", onAccept(v) { accepted.push(v); } });
+  await new Promise((r) => setTimeout(r, 0));
+  const picker2 = dom.window.document.querySelector(".chip-picker-dir");
+  const input2 = picker2.querySelector(".chip-picker-search");
+  input2.value = "/home/jesse/ot";
+  input2.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+  await new Promise((r) => setTimeout(r, 170));
+  await new Promise((r) => setTimeout(r, 0));
+  assert(picker2.querySelectorAll(".chip-picker-dir-recent").length === 0,
+    "typing a query should replace the recent options with search results");
+  assert(picker2.querySelector('[data-dir-path="/home/jesse/other"]'),
+    "search results should still render after typing");
+  input2.dispatchEvent(new dom.window.KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+
+  // The initial listing shows recents even when the picker opens on an
+  // existing value (the spawn flow passes the last-used dir); browsing into
+  // a directory swaps back to plain results.
+  recentCalls = 0;
+  dom.window.SerfDirPicker.open({ anchor, currentValue: "/home/jesse", onAccept(v) { accepted.push(v); } });
+  await new Promise((r) => setTimeout(r, 0));
+  const pickerInit = dom.window.document.querySelector(".chip-picker-dir");
+  assert(recentCalls === 1, "initial listing on an existing value should fetch recents, got " + recentCalls);
+  assert(pickerInit.querySelectorAll(".chip-picker-dir-recent").length === 15,
+    "initial listing on an existing value should show the recent options");
+  pickerInit.querySelector('[data-dir-path="/home/jesse/other"]').click();
+  await new Promise((r) => setTimeout(r, 0));
+  assert(dom.window.document.querySelectorAll(".chip-picker-dir-recent").length === 0,
+    "browsing into a directory should replace the recent options");
+  const pickerEsc = dom.window.document.querySelector(".chip-picker-dir");
+  pickerEsc.querySelector(".chip-picker-search").dispatchEvent(
+    new dom.window.KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+
+  // An older hub client without recentProjects must not break the picker.
+  const dom2 = makeDom({
+    completeDirs() {
+      return Promise.resolve({ results: [{ path: "/home/jesse/other", is_git: false }] });
+    },
+  });
+  const anchor2 = dom2.window.document.getElementById("anchor");
+  dom2.window.SerfDirPicker.open({ anchor: anchor2, currentValue: "", onAccept() {} });
+  await new Promise((r) => setTimeout(r, 0));
+  const picker3 = dom2.window.document.querySelector(".chip-picker-dir");
+  assert(picker3, "picker should render without recentProjects support");
+  assert(picker3.querySelectorAll(".chip-picker-dir-recent").length === 0,
+    "no recent section without recentProjects support");
+  assert(picker3.querySelector('[data-dir-path="/home/jesse/other"]'),
+    "browse rows should still render without recentProjects support");
+
+  console.log("PASS test-dir-picker-recent");
+})();

--- a/cmd/serf-hub/web_appwire_fuzz_test.go
+++ b/cmd/serf-hub/web_appwire_fuzz_test.go
@@ -236,6 +236,7 @@ func FuzzAppWireDispatch(f *testing.F) {
 		{appwire.MethodSerfLaunchGetLayer, `{"cwd":"x","layer":"global"}`},
 		{appwire.MethodSerfLaunchTrustRepo, `{"cwd":"x","hash":"deadbeef"}`},
 		{appwire.MethodSerfDirsComplete, `{"prefix":"/tmp"}`},
+		{appwire.MethodSerfProjectsRecent, `{}`},
 		{appwire.MethodSerfPathValidate, `{"path":"/tmp","kind":"dir"}`},
 		{appwire.MethodSerfHarnessesList, `{}`},
 		{appwire.MethodSerfUpgrade, `{"requested":"latest"}`},

--- a/cmd/serf-tui/hub_commands.go
+++ b/cmd/serf-tui/hub_commands.go
@@ -113,8 +113,12 @@ type hubSpawnOptionsMsg struct {
 	emptyTaskUnsupportedReasons map[string]string
 	emptyTaskUnsupportedNext    map[string]string
 	models                      []tuipick.ModelPickerItem
-	err                         error
-	modelErr                    error
+	// recentDirs carries the hub's most recently used project dirs (the Dir
+	// field's prepopulated dropdown options, issue #35). Best-effort: a hub
+	// too old for serf/projects/recent leaves it nil.
+	recentDirs []string
+	err        error
+	modelErr   error
 }
 
 type hubAuthStatusMsg struct {
@@ -283,12 +287,18 @@ func fetchHubSpawnOptions(client *appwire.Client, workingDir string) tea.Cmd {
 				emptyTaskUnsupportedNext[option.ID] = next
 			}
 		}
+		// Recent project dirs are best-effort: a failure (e.g. an older hub
+		// without serf/projects/recent) must not break spawning.
+		var recentDirs []string
+		if recentResp, err := client.ProjectsRecent(context.Background(), appwire.ProjectsRecentParams{}); err == nil {
+			recentDirs = recentResp.Data
+		}
 		modelResp, err := client.ModelList(context.Background(), appwire.ModelListParams{CWD: workingDir})
 		if err != nil {
-			return hubSpawnOptionsMsg{harnesses: harnesses, harnessKinds: harnessKinds, emptyTaskUnsupportedReasons: emptyTaskUnsupportedReasons, emptyTaskUnsupportedNext: emptyTaskUnsupportedNext, modelErr: err}
+			return hubSpawnOptionsMsg{harnesses: harnesses, harnessKinds: harnessKinds, emptyTaskUnsupportedReasons: emptyTaskUnsupportedReasons, emptyTaskUnsupportedNext: emptyTaskUnsupportedNext, recentDirs: recentDirs, modelErr: err}
 		}
 		models := modelPickerItemsFromResponse(modelResp, false)
-		return hubSpawnOptionsMsg{harnesses: harnesses, harnessKinds: harnessKinds, emptyTaskUnsupportedReasons: emptyTaskUnsupportedReasons, emptyTaskUnsupportedNext: emptyTaskUnsupportedNext, models: models}
+		return hubSpawnOptionsMsg{harnesses: harnesses, harnessKinds: harnessKinds, emptyTaskUnsupportedReasons: emptyTaskUnsupportedReasons, emptyTaskUnsupportedNext: emptyTaskUnsupportedNext, models: models, recentDirs: recentDirs}
 	}
 }
 

--- a/cmd/serf-tui/hub_model.go
+++ b/cmd/serf-tui/hub_model.go
@@ -113,6 +113,13 @@ type hubModel struct {
 	spawnDirInput           textinput.Model
 	spawnSubmitting         bool
 	spawnFocus              hubSpawnField
+	// spawnRecentDirs holds the hub's most recently used project dirs (the
+	// Dir field's prepopulated dropdown options, issue #35), fetched with the
+	// spawn options. spawnRecentIdx tracks the tab-cycle position: the index
+	// of the recent dir currently shown in the field, or -1 when the field
+	// holds anything else.
+	spawnRecentDirs []string
+	spawnRecentIdx  int
 
 	detail  hubSessionDetail
 	session model
@@ -200,7 +207,7 @@ func newHubModel(client *appwire.Client, hubURL string, stateDirs ...string) hub
 		stateDir = strings.TrimSpace(stateDirs[0])
 	}
 	session := newModel(nil)
-	model := hubModel{client: client, hubURL: hubURL, stateDir: stateDir, session: session, browseSelected: -1, dashboardFilter: newHubFilterInput(), dashboardRecentOpen: map[string]bool{}, dashboardProjectClosed: map[string]bool{}, spawnDirInput: newSpawnDirInput()}
+	model := hubModel{client: client, hubURL: hubURL, stateDir: stateDir, session: session, browseSelected: -1, dashboardFilter: newHubFilterInput(), dashboardRecentOpen: map[string]bool{}, dashboardProjectClosed: map[string]bool{}, spawnDirInput: newSpawnDirInput(), spawnRecentIdx: -1}
 	// Construct the pending coordinator with a buffering placeholder
 	// send. main.go calls model.pending.setSend(program.Send) after
 	// tea.NewProgram so coordinator-emitted msgs reach Update. Until

--- a/cmd/serf-tui/hub_spawn.go
+++ b/cmd/serf-tui/hub_spawn.go
@@ -63,6 +63,14 @@ func (m hubModel) updateSpawnKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "tab":
 		if m.spawnFocus == hubSpawnFieldDir {
 			current := m.spawnDirInput.Value()
+			// The Dir field's dropdown is prepopulated with the most recent
+			// projects (issue #35): on an empty field (or while a recent
+			// option is showing) tab cycles them instead of completing.
+			if next, ok := m.nextSpawnRecentDir(current); ok {
+				m.spawnDirInput.SetValue(next)
+				m.spawnDir = strings.TrimSpace(next)
+				return m, nil
+			}
 			// Spawn working-dir accepts directories only; without this
 			// filter Tab could land a file path in the field which the
 			// later submit validation would reject.
@@ -241,6 +249,40 @@ func (m hubModel) spawnFieldPrefix(field hubSpawnField) string {
 	return " "
 }
 
+// nextSpawnRecentDir cycles the Dir field through the hub's most recently
+// used project dirs: from an empty field it fills the most recent one, and
+// from a recent option it advances (wrapping) to the next. It returns false
+// when the field holds a custom path, leaving tab to plain path completion.
+func (m *hubModel) nextSpawnRecentDir(current string) (string, bool) {
+	if len(m.spawnRecentDirs) == 0 {
+		return "", false
+	}
+	cur := strings.TrimSpace(current)
+	if cur == "" {
+		m.spawnRecentIdx = 0
+		return m.spawnRecentDirs[0], true
+	}
+	if m.spawnRecentIdx >= 0 && m.spawnRecentIdx < len(m.spawnRecentDirs) && cur == m.spawnRecentDirs[m.spawnRecentIdx] {
+		m.spawnRecentIdx = (m.spawnRecentIdx + 1) % len(m.spawnRecentDirs)
+		return m.spawnRecentDirs[m.spawnRecentIdx], true
+	}
+	return "", false
+}
+
+// spawnRecentDirsVisible reports whether the Dir field's recent-project
+// dropdown options render: while the field is empty or shows one of the
+// recent options, hidden once the user types a custom path.
+func (m hubModel) spawnRecentDirsVisible() bool {
+	if len(m.spawnRecentDirs) == 0 {
+		return false
+	}
+	cur := strings.TrimSpace(m.spawnDirInput.Value())
+	if cur == "" {
+		return true
+	}
+	return stringInSlice(cur, m.spawnRecentDirs)
+}
+
 func (m hubModel) spawnFieldHint() string {
 	switch m.spawnFocus {
 	case hubSpawnFieldHarness:
@@ -251,7 +293,7 @@ func (m hubModel) spawnFieldHint() string {
 		}
 		return "enter: choose model"
 	case hubSpawnFieldDir:
-		return "type path  tab: complete  enter: next  ctrl+u clear"
+		return "type path  tab: recent/complete  enter: next  ctrl+u clear"
 	default:
 		return "enter: spawn  ctrl+j: newline"
 	}
@@ -291,6 +333,8 @@ func (m *hubModel) resetSpawnForm() {
 	m.spawnModelPicker = nil
 	m.spawnSubmitting = false
 	m.spawnFocus = hubSpawnFieldPrompt
+	m.spawnRecentDirs = nil
+	m.spawnRecentIdx = -1
 	m.spawnDirInput.Blur()
 	m.session.resetInput()
 	if envModel := envvars.SERFModel.Trimmed(); strings.Contains(envModel, "/") {
@@ -486,6 +530,15 @@ func (m hubModel) spawnView() string {
 		fmt.Fprintf(&b, "  Project:  %s\n", m.spawnProject)
 	}
 	fmt.Fprintf(&b, "%s Dir:      %s\n", m.spawnFieldPrefix(hubSpawnFieldDir), m.spawnDirView())
+	if m.spawnFocus == hubSpawnFieldDir && m.spawnRecentDirsVisible() {
+		for i, dir := range m.spawnRecentDirs {
+			prefix := "    "
+			if i == m.spawnRecentIdx {
+				prefix = "  > "
+			}
+			fmt.Fprintf(&b, "%s%s\n", prefix, dir)
+		}
+	}
 	fmt.Fprintf(&b, "%s Prompt (optional):\n", m.spawnFieldPrefix(hubSpawnFieldPrompt))
 	for _, line := range strings.Split(strings.TrimSuffix(renderComposerDraft(m.session.input.Value(), m.width-2, 0), "\n"), "\n") {
 		b.WriteString("  ")

--- a/cmd/serf-tui/hub_spawn_recent_test.go
+++ b/cmd/serf-tui/hub_spawn_recent_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"primeradiant.com/serf/appwire"
+	"primeradiant.com/serf/internal/appserver"
+)
+
+// TestFetchHubSpawnOptionsIncludesRecentDirs covers the terminal session
+// creation flow's recent-project source (issue #35): spawn options carry the
+// hub's most recently used project dirs for the Dir field's dropdown.
+func TestFetchHubSpawnOptionsIncludesRecentDirs(t *testing.T) {
+	recent := []string{"/proj/alpha", "/proj/beta"}
+	client, cleanup := newTestHubClient(t, func(app *appserver.Server) {
+		appserver.HandleTyped(app.Router(), appwire.MethodSerfHarnessesList, func(context.Context, appwire.HarnessListParams) (appwire.HarnessListResponse, error) {
+			return appwire.HarnessListResponse{Data: []appwire.HarnessDescriptor{{ID: "serf", Label: "serf"}}}, nil
+		})
+		appserver.HandleTyped(app.Router(), appwire.MethodModelList, func(context.Context, appwire.ModelListParams) (appwire.ModelListResponse, error) {
+			return appwire.ModelListResponse{Data: []appwire.ModelDescriptor{{Provider: "openai", Model: "gpt-5"}}}, nil
+		})
+		appserver.HandleTyped(app.Router(), appwire.MethodSerfProjectsRecent, func(context.Context, appwire.ProjectsRecentParams) (appwire.ProjectsRecentResponse, error) {
+			return appwire.ProjectsRecentResponse{Data: recent}, nil
+		})
+	})
+	defer cleanup()
+
+	msg := fetchHubSpawnOptions(client, "")()
+	opts, ok := msg.(hubSpawnOptionsMsg)
+	if !ok || opts.err != nil {
+		t.Fatalf("msg=%T err=%v", msg, opts.err)
+	}
+	if len(opts.recentDirs) != 2 || opts.recentDirs[0] != "/proj/alpha" || opts.recentDirs[1] != "/proj/beta" {
+		t.Fatalf("recentDirs=%v, want %v", opts.recentDirs, recent)
+	}
+
+	m := newHubModel(client, "http://hub.test")
+	m.openSpawnForm()
+	updated, _ := m.Update(msg)
+	got := updated.(hubModel)
+	if len(got.spawnRecentDirs) != 2 || got.spawnRecentDirs[0] != "/proj/alpha" {
+		t.Fatalf("spawnRecentDirs=%v, want %v", got.spawnRecentDirs, recent)
+	}
+}
+
+// TestHubModelSpawnDirTabCyclesRecentProjects: on an empty Dir field, tab
+// prepopulates the most recent project; repeated tabs cycle the list.
+func TestHubModelSpawnDirTabCyclesRecentProjects(t *testing.T) {
+	m := newHubModel(nil, "")
+	m.openSpawnForm()
+	m.spawnRecentDirs = []string{"/proj/alpha", "/proj/beta", "/proj/gamma"}
+	m.setSpawnFocus(hubSpawnFieldDir)
+
+	tab := func() hubModel {
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = updated.(hubModel)
+		return m
+	}
+
+	if got := tab(); got.spawnDir != "/proj/alpha" {
+		t.Fatalf("first tab dir=%q, want /proj/alpha (most recent project)", got.spawnDir)
+	}
+	if got := tab(); got.spawnDir != "/proj/beta" {
+		t.Fatalf("second tab dir=%q, want /proj/beta", got.spawnDir)
+	}
+	if got := tab(); got.spawnDir != "/proj/gamma" {
+		t.Fatalf("third tab dir=%q, want /proj/gamma", got.spawnDir)
+	}
+	if got := tab(); got.spawnDir != "/proj/alpha" {
+		t.Fatalf("fourth tab dir=%q, want wrap-around to /proj/alpha", got.spawnDir)
+	}
+	if m.spawnFocus != hubSpawnFieldDir {
+		t.Fatalf("cycling recent projects should keep focus on the dir field, got %v", m.spawnFocus)
+	}
+}
+
+// TestHubModelSpawnViewListsRecentProjects: the Dir field's dropdown lists
+// the recent projects as options while the field shows one of them (or
+// nothing), and hides them once the user types a custom path.
+func TestHubModelSpawnViewListsRecentProjects(t *testing.T) {
+	m := newHubModel(nil, "")
+	m.openSpawnForm()
+	m.spawnRecentDirs = []string{"/proj/alpha", "/proj/beta"}
+	m.setSpawnFocus(hubSpawnFieldDir)
+
+	view := m.spawnView()
+	if !strings.Contains(view, "/proj/alpha") || !strings.Contains(view, "/proj/beta") {
+		t.Fatalf("spawn view should list recent project options:\n%s", view)
+	}
+
+	m.setSpawnDir("/custom/path")
+	view = m.spawnView()
+	if strings.Contains(view, "/proj/alpha") {
+		t.Fatalf("spawn view should hide recent options for a custom path:\n%s", view)
+	}
+}

--- a/cmd/serf-tui/hub_update.go
+++ b/cmd/serf-tui/hub_update.go
@@ -521,6 +521,7 @@ func (m hubModel) updateImpl(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.spawnHarness = m.spawnHarnesses[0]
 		}
 		m.spawnModels = msg.models
+		m.spawnRecentDirs = msg.recentDirs
 		if m.mode == hubModeSpawn {
 			m.syncSpawnModelWithHarness()
 			if msg.modelErr != nil && m.spawnHarnessUsesSerfModels() {

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -112,6 +112,7 @@ no router (reserved).
 | `serf/thread/transcripts/list` | hub | `ThreadTranscriptListParams` | `ThreadTranscriptListResponse` | Lists transcript targets (subagents/related threads) for a ref. |
 | `serf/subagentPreview` | hub | `SerfSubagentPreviewParams` | `SerfSubagentPreviewResponse` | Reads a bounded lazy preview of a subagent transcript's latest direct items. |
 | `serf/dirs/complete` | hub | `DirsCompleteParams` | `DirsCompleteResponse` | Directory-path autocompletion for a prefix. |
+| `serf/projects/recent` | hub | `ProjectsRecentParams` | `ProjectsRecentResponse` | Lists the most recently used project working directories (session creation path-dropdown options; default cap 15). |
 | `serf/path/validate` | hub | `PathValidateParams` | `PathValidateResponse` | Validates a launch path. |
 | `serf/harnesses/list` | hub | `HarnessListParams` | `HarnessListResponse` | Lists available harness descriptors. |
 | `serf/upgrade` | hub | `UpgradeParams` | `UpgradeResponse` | Performs or reports a serf binary upgrade. |
@@ -648,6 +649,20 @@ _(no fields)_
 | `plugin` | `string` |  |  |
 | `marketplace` | `string` |  |  |
 | `autoUpgrade` | `bool` |  |  |
+
+
+### `ProjectsRecentParams`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `limit` | `int` | yes |  |
+
+
+### `ProjectsRecentResponse`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `data` | `[]string` |  |  |
 
 
 ### `ReasoningSummaryDeltaParams`


### PR DESCRIPTION
## Summary

The web and terminal session creation flows now prepopulate the working-directory dropdown with the 15 most recent projects as options.

- **Web (serf-hub `/new` spawn form + all `SerfDirPicker` consumers):** the directory picker's initial listing renders a "Recent projects" section (up to 15 options) above the browse listing; clicking an option accepts the path. Browsing or typing swaps back to plain completion results.
- **Terminal (serf-tui hub spawn form):** the Dir field lists the recent projects while it is empty (or shows a recent option); `tab` fills/cycles them, wrapping at the end. Custom paths keep filesystem tab-completion.

## Design

- **Shared source:** one new hub-scoped AppWire RPC, `serf/projects/recent`, backed by `hubcore.PastIndex.RecentProjectDirs` — both clients render what the hub returns; no per-client ordering logic.
- **Recency:** actual recency of *use*. The past index is already sorted most-recently-updated-first (`sessionMetaLess`; a session meta's `UpdatedAt` is its last activity moment). The RPC walks that order, dedupes `WorkingDir` on first (most recent) occurrence, skips blanks.
- **Cap 15:** server-side default (`recentProjectDirsLimit` in `cmd/serf-hub/app_rpc.go`) when the request carries no limit; both clients pass none.
- **Graceful degradation:** web feature-detects `SerfAppwire.recentProjects`; TUI treats the RPC as best-effort — older hubs just show no options.
- Docs: `docs/appwire-protocol.md` regenerated.

## Test evidence

- New tests: `hubcore/recent_projects_test.go` (dedupe/order/cap/blank/empty), `app_rpc_test.go` RPC test through a real websocket client (23 seeded metas → exactly 15, recency order), appwire client roundtrip row, jstest `test-dir-picker-recent.js` (initial listing, accept-on-click, query swap, old-hub tolerance), TUI `hub_spawn_recent_test.go` (fetch, tab cycling, view visibility).
- Full suites green: `go test` on `appwire`, `cmd/serf-hub`, `cmd/serf-hub/internal/hubcore`, `cmd/serf-tui`; jstest `run-all.sh` 193/193; `go vet` clean; `make lint-generated` passes.

Closes #35
