### PR TITLE
webui: desktop collapsed sidebar hides fully — no 56px rail (#33)

### DIFF
--- a/cmd/serf-hub/assets/sidebar.js
+++ b/cmd/serf-hub/assets/sidebar.js
@@ -1103,8 +1103,9 @@
     if (open) {
       document.body.setAttribute("data-sidebar-open", "");
       document.addEventListener("click", onOutsideClick, true);
-      // Only trap focus on phone — desktop sidebar isn't a drawer. Match
-      // the design-language breakpoint.
+      // Only trap focus on phone — on tablet/desktop the collapsed-state
+      // drawer follows the short-landscape precedent (no trap; ⌘B and the
+      // chip remain reachable). Match the design-language breakpoint.
       var isPhone = window.matchMedia && window.matchMedia("(max-width: 767px)").matches;
       if (isPhone && window.SerfFocusTrap) {
         var sidebar = document.getElementById("sidebar");
@@ -1166,16 +1167,19 @@
 
   // Sidebar tri-state — auto | rail | pane, persisted to localStorage under
   // the legacy key. body[data-sidebar-mode] records the SETTING;
-  // body[data-sidebar-rail] reflects the EFFECTIVE state, so all rail CSS and
-  // panes.js's resizer-disable keep reading one attribute. Migration: the old
-  // binary pref maps "true"→rail, "false"→pane, absent→auto (auto is new:
+  // body[data-sidebar-rail] reflects the EFFECTIVE state, so the collapsed CSS
+  // and panes.js's resizer-disable keep reading one attribute. Migration: the
+  // old binary pref maps "true"→rail, "false"→pane, absent→auto (auto is new:
   // rail below 1200px, pane at/above — before the tablet band existed the
   // sidebar simply stayed full, so this is a deliberate improvement).
+  // "rail" is the legacy name for the collapsed state: since issue #33 the
+  // collapse is TOTAL — the sidebar leaves the layout (no 56px icon strip)
+  // and reopens as an overlay drawer via the app-shell nav chip.
   var SIDEBAR_MODE_KEY = "serf-hub.sidebar.rail";
   var SIDEBAR_DESKTOP_QUERY = "(min-width: 1200px)";
   // Phone band: the off-canvas drawer (body[data-sidebar-open]) governs the
-  // sidebar, never the tri-state. The rail's 56px strip is a desktop/tablet
-  // affordance; on a phone it shrinks the drawer to an unusable sliver.
+  // sidebar, never the tri-state. Collapse is a desktop/tablet affordance; on
+  // a phone the rail attribute would hide the drawer entirely.
   var SIDEBAR_PHONE_QUERY = "(max-width: 767px)";
 
   function readSidebarMode() {

--- a/cmd/serf-hub/assets/style.css
+++ b/cmd/serf-hub/assets/style.css
@@ -904,24 +904,35 @@ body.app[data-pane-dragging="true"] .pane-frame { pointer-events: none; }
   border-color: var(--line);
 }
 
-/* Rail mode: collapse to 56px, hide text columns, hide most header actions. */
-body.app[data-sidebar-rail] #sidebar { width: 56px; min-width: 56px; max-width: 56px; }
+/* Collapsed mode (issue #33): the sidebar leaves the layout entirely — the
+   56px icon rail is retired. The app-shell nav chip (display:none on desktop
+   otherwise) floats top-left so the sidebar can be reopened as an overlay
+   drawer, mirroring the phone / short-landscape pattern; ⌘B and the in-header
+   mode toggle cycle back to pane. */
+body.app[data-sidebar-rail] #sidebar { display: none; }
 body.app[data-sidebar-rail] .sidebar-resizer { display: none; }
-body.app[data-sidebar-rail] .sidebar-header .sidebar-action { display: none; }
-body.app[data-sidebar-rail] .sidebar-header { padding: 0 var(--space-3) var(--space-3); justify-content: center; gap: 0; }
-body.app[data-sidebar-rail] .sidebar-rail-toggle::before { content: "☰"; }
-body.app[data-sidebar-rail] .sidebar-rail-toggle { font-size: 0; }
-body.app[data-sidebar-rail] .sidebar-rail-toggle::before { font-size: var(--text-base); }
-body.app[data-sidebar-rail] .sidebar-section-header,
-body.app[data-sidebar-rail] .project-header .project-name,
-body.app[data-sidebar-rail] .project-header .count,
-body.app[data-sidebar-rail] .project-header .project-folder,
-body.app[data-sidebar-rail] .project-gear-btn,
-body.app[data-sidebar-rail] .project-new-btn { display: none; }
-body.app[data-sidebar-rail] .sb-row { grid-template-columns: 1fr; padding: var(--space-2); justify-content: center; }
-body.app[data-sidebar-rail] .sb-row .text-col,
-body.app[data-sidebar-rail] .sb-row .title,
-body.app[data-sidebar-rail] .sb-row .row-end { display: none; }
+body.app[data-sidebar-rail] .app-nav-toggle {
+  display: inline-flex;
+  position: fixed;
+  top: var(--space-3);
+  left: var(--space-3);
+  width: var(--tap-min);
+  height: var(--tap-min);
+  z-index: var(--z-fixed-action);
+}
+body.has-connection-banner.app[data-sidebar-rail] .app-nav-toggle { top: calc(32px + var(--space-3)); }
+body.app[data-sidebar-rail] .workspace-header { padding-left: calc(var(--tap-min) + var(--space-6)); }
+body.app[data-sidebar-rail][data-sidebar-open] #sidebar {
+  display: block;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: var(--sidebar-w, 260px);
+  max-width: 88vw;
+  z-index: var(--z-drawer);
+  background: var(--surface);
+}
 
 /* Container query — the same collapse triggered structurally if a parent
    ever shrinks the sidebar below 80px independent of the rail attribute. */
@@ -1127,15 +1138,6 @@ body.app[data-sidebar-rail] .sb-row .row-end { display: none; }
   transform: rotate(90deg);
 }
 
-/* Rail mode: hide tier headers, age, and subagent rows along with the
-   rest of the text-bearing chrome. */
-body.app[data-sidebar-rail] .tier-header,
-body.app[data-sidebar-rail] .project-age,
-body.app[data-sidebar-rail] .subagent-toggle,
-body.app[data-sidebar-rail] .cluster-header,
-body.app[data-sidebar-rail] .sb-section { display: none; }
-body.app[data-sidebar-rail] .subagent-row .subagent-title { display: none; }
-body.app[data-sidebar-rail] .subagent-row-wrap > .open-beside-btn { display: none; }
 @container sidebar (max-width: 80px) {
   .tier-header span,
   .project-age,
@@ -1299,13 +1301,9 @@ body.app[data-sidebar-rail] .subagent-row-wrap > .open-beside-btn { display: non
   color: var(--ink-2);
 }
 
-/* Rail mode + container-collapse hide the needs-you label, rollup badges,
-   cluster text, and date sub-headers along with the rest of the text-bearing
-   sidebar chrome. */
-body.app[data-sidebar-rail] .needs-you-header span,
-body.app[data-sidebar-rail] .rollup-badge,
-body.app[data-sidebar-rail] .cluster-header .text-col,
-body.app[data-sidebar-rail] .test-date-header { display: none; }
+/* Container-collapse hides the needs-you label, rollup badges, cluster text,
+   and date sub-headers along with the rest of the text-bearing sidebar
+   chrome. */
 @container sidebar (max-width: 80px) {
   .needs-you-header span,
   .rollup-badge,
@@ -1494,10 +1492,6 @@ details.session-tier.archived .sb-row .title { color: var(--ink-2); }
   color: var(--ink);
 }
 
-/* Rail mode + container-collapse: hide tier labels and archive buttons
-   along with the rest of the text-bearing sidebar chrome. */
-body.app[data-sidebar-rail] .session-tier-label,
-body.app[data-sidebar-rail] .archive-btn { display: none; }
 /* Archive control icon (a box, not the ⋯ menu glyph): block so it centers in
    the icon button without baseline gap; inherits the button's color. */
 .archive-btn .archive-icon { display: block; }
@@ -5840,10 +5834,8 @@ body.doc-page {
    is opacity:0 from intercepting clicks meant for the other. */
 .sb-row .age-slot .sb-menu-btn { pointer-events: none; }
 .sb-row:hover .age-slot .sb-menu-btn, .sb-row:focus-within .age-slot .sb-menu-btn { pointer-events: auto; }
-/* Rail mode (56px icon rail): session rows already hide their whole
-   .row-end (age + ⋯ menu) above — nothing session-row-specific needed
-   here. Project headers have no row-end equivalent, so they still need
-   their own hide, but they have none in rail mode today (unchanged). */
+/* Collapsed mode hides the entire sidebar (issue #33), so no row-end or
+   project-header menu chrome needs rail-scoped hides here. */
 .sb-menu { z-index: 60; background: var(--surface); border: 1px solid var(--line); border-radius: var(--radius-md); padding: var(--space-1); box-shadow: 0 4px 16px rgba(0,0,0,.35); min-width: 160px; }
 .sb-menu-item { display: block; width: 100%; text-align: left; padding: var(--space-2) var(--space-3); background: transparent; border: none; color: var(--ink); font-size: var(--text-sm); min-height: 24px; }
 .sb-menu-item:hover, .sb-menu-item:focus { background: var(--surface-2); }

--- a/cmd/serf-hub/jstest/test-sidebar-collapsed-css.js
+++ b/cmd/serf-hub/jstest/test-sidebar-collapsed-css.js
@@ -1,0 +1,109 @@
+// Desktop collapsed sidebar (issue #33): collapsed means FULLY collapsed.
+// The 56px icon rail is gone — body.app[data-sidebar-rail] hides the entire
+// sidebar (zero-width, not a strip). Reopen affordances, mirroring the phone /
+// short-landscape drawer pattern: the app-shell .app-nav-toggle chip appears
+// top-left and opens the sidebar as an overlay drawer
+// (body[data-sidebar-rail][data-sidebar-open]); ⌘B and the in-header mode
+// toggle still cycle back to pane. Session navigation from the drawer closes
+// it (htmx:beforeRequest), so the drawer never hangs over a fresh session.
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+
+const css = fs.readFileSync(path.resolve(__dirname, "../assets/style.css"), "utf8");
+const sidebarSrc = fs.readFileSync(path.resolve(__dirname, "../assets/sidebar.js"), "utf8");
+
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+function ruleBody(selector) {
+  const i = css.indexOf(selector);
+  if (i < 0) return null;
+  const open = css.indexOf("{", i);
+  const close = css.indexOf("}", open);
+  return css.slice(open + 1, close);
+}
+
+// 1) Collapsed = hidden: the whole sidebar leaves the layout.
+const hiddenBody = ruleBody("body.app[data-sidebar-rail] #sidebar");
+pass(!!hiddenBody && /display:\s*none/.test(hiddenBody),
+  "collapsed mode (data-sidebar-rail) must hide #sidebar entirely (display:none), not shrink it to a strip");
+
+// 2) The 56px rail strip is gone: no rail-mode rule may set a 56px width.
+pass(!/\[data-sidebar-rail\][^{}]*\{[^}]*56px/.test(css),
+  "no data-sidebar-rail rule may size a 56px rail — the strip is retired");
+
+// 3) No rail-mode per-element strip styling survives (the sidebar is hidden
+// whole, so hiding .sb-row text columns etc. is dead weight).
+pass(!/body\.app\[data-sidebar-rail\]\s+\.sb-row/.test(css),
+  "collapsed mode must not restyle .sb-row (the whole sidebar is hidden)");
+
+// 4) The drag resizer is a sibling of #sidebar, so it still needs its own hide.
+const resizerBody = ruleBody("body.app[data-sidebar-rail] .sidebar-resizer");
+pass(!!resizerBody && /display:\s*none/.test(resizerBody),
+  "collapsed mode must hide the sidebar resizer");
+
+// 5) Reopen affordance: the app-shell nav toggle chip appears when collapsed
+// (it is display:none on desktop otherwise).
+const chipBody = ruleBody("body.app[data-sidebar-rail] .app-nav-toggle");
+pass(!!chipBody && /display:\s*inline-flex/.test(chipBody) && /position:\s*fixed/.test(chipBody),
+  "collapsed mode must reveal the .app-nav-toggle chip (fixed) so the sidebar can be reopened");
+
+// 6) The chip reopens the sidebar as an overlay drawer over the workspace.
+const drawerBody = ruleBody("body.app[data-sidebar-rail][data-sidebar-open] #sidebar");
+pass(!!drawerBody && /display:\s*block/.test(drawerBody) && /position:\s*fixed/.test(drawerBody),
+  "collapsed + open must show #sidebar as a fixed overlay drawer");
+
+// 7) The workspace header makes room for the floating chip.
+pass(/body\.app\[data-sidebar-rail\]\s+\.workspace-header\s*\{[^}]*padding-left:\s*calc\(var\(--tap-min\)/.test(css),
+  "collapsed mode must pad the workspace header clear of the floating nav chip");
+
+// --- Behavioral: on a desktop viewport with a pinned collapsed mode, the
+// chip opens the drawer and navigating from inside the sidebar closes it. ---
+(async () => {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body class="app">
+    <button class="app-nav-toggle" data-sidebar-toggle>☰</button>
+    <aside id="sidebar"><a class="sb-row" href="/thread/1">session</a></aside>
+    <main id="workspace"></main>
+  </body></html>`, { runScripts: "outside-only", pretendToBeVisual: true, url: "http://localhost/" });
+  const w = dom.window;
+  w.localStorage.setItem("serf-hub.sidebar.rail", "rail");
+  // Desktop viewport (≥1200px): explicit rail pins the collapsed state.
+  w.matchMedia = (q) => ({
+    matches: q === "(min-width: 1200px)",
+    addEventListener() {}, addListener() {},
+  });
+  w.fetch = () => new Promise(() => {});
+  w.htmx = { process() {} };
+  w.SerfAppwire = { onNotification() {}, onConnectionRestored() {} };
+  w.eval(sidebarSrc);
+
+  pass(w.document.body.hasAttribute("data-sidebar-rail"),
+    "pinned rail pref sets data-sidebar-rail on desktop (collapsed)");
+  pass(!w.document.body.hasAttribute("data-sidebar-open"), "drawer starts closed");
+
+  w.document.querySelector(".app-nav-toggle").dispatchEvent(new w.MouseEvent("click", { bubbles: true, cancelable: true }));
+  pass(w.document.body.hasAttribute("data-sidebar-open"),
+    "clicking the nav chip opens the collapsed sidebar drawer");
+
+  // Session navigation from inside the drawer closes it (htmx:beforeRequest).
+  const row = w.document.querySelector("#sidebar .sb-row");
+  const evt = new w.Event("htmx:beforeRequest", { bubbles: true, cancelable: true });
+  Object.defineProperty(evt, "detail", { value: { elt: row } });
+  w.document.dispatchEvent(evt);
+  pass(!w.document.body.hasAttribute("data-sidebar-open"),
+    "navigating to a session from the drawer closes it");
+
+  // ⌘B cycles rail → pane, lifting the collapsed state entirely.
+  w.document.dispatchEvent(new w.KeyboardEvent("keydown", { key: "b", metaKey: true, bubbles: true, cancelable: true }));
+  pass(!w.document.body.hasAttribute("data-sidebar-rail"),
+    "⌘B cycles collapsed → pane (sidebar re-pinned open)");
+  pass(w.SerfSidebar.readSidebarMode() === "pane", "⌘B persists the pane mode");
+
+  if (failures.length > 0) {
+    for (const f of failures) console.log(f);
+    process.exit(1);
+  }
+  console.log("PASS: desktop collapsed sidebar — hidden, chip reopens drawer, ⌘B re-pins");
+  process.exit(0);
+})();

--- a/cmd/serf-hub/jstest/test-sidebar-density-css.js
+++ b/cmd/serf-hub/jstest/test-sidebar-density-css.js
@@ -11,13 +11,11 @@ function ruleBody(selector) {
 const fails = [];
 const menuBtn = ruleBody(".sb-menu-btn");
 if (!/min-height:\s*24px/.test(menuBtn) || !/min-width:\s*24px/.test(menuBtn)) fails.push("reveal button must be >=24px");
-// Rail mode (56px icon-only collapsed sidebar) must hide the ENTIRE
-// .sb-section archived-section toggle, exactly like the legacy
-// .tier-header/.sidebar-section-header disclosure headers are hidden there
-// — otherwise its "Archived (N)" label has no width constraint and bleeds
-// out of the 56px rail into the workspace pane.
-const railHidesSbSection = /body\.app\[data-sidebar-rail\][^{}]*\.sb-section[^{}]*\{([^{}]*)\}/.exec(css);
-if (!railHidesSbSection || !/display:\s*none/.test(railHidesSbSection[1])) fails.push("rail mode (data-sidebar-rail) must hide .sb-section entirely (display:none)");
+// Collapsed mode (data-sidebar-rail) hides the ENTIRE sidebar (issue #33 —
+// the 56px icon rail was retired), so no per-element rail rules (e.g. hiding
+// .sb-section to stop its "Archived (N)" label bleeding out of the strip) may
+// survive: the whole-hide contract lives in test-sidebar-collapsed-css.js.
+if (/body\.app\[data-sidebar-rail\][^{}]*\.sb-section/.test(css)) fails.push("collapsed mode must not carry per-element .sb-section strip styling (the whole sidebar is hidden)");
 if (fails.length) { fails.forEach((f) => console.log("FAIL: " + f)); process.exit(1); }
 console.log("ok sidebar density/contrast floor");
 process.exit(0);

--- a/cmd/serf-hub/jstest/test-sidebar-row-layout.js
+++ b/cmd/serf-hub/jstest/test-sidebar-row-layout.js
@@ -95,16 +95,11 @@ if (!/\.sb-row:hover \.sb-menu-btn,\s*\.sb-row:focus-within \.sb-menu-btn\s*\{[^
   fails.push("hovering/focusing the row must fade the ⋯ menu in");
 }
 
-// Rail-collapsed mode (56px icon rail) must hide title/row-end, leaving
-// only the status icon visible.
-const railBlock = css.slice(css.indexOf('body.app[data-sidebar-rail] .sb-row {'));
-const railSnippet = railBlock.slice(0, railBlock.indexOf('@container'));
-if (!/\.sb-row \.title[^;{}]*\{[^}]*display:\s*none/.test(railSnippet) &&
-    !/\.title[\s\S]{0,80}display:\s*none/.test(railSnippet)) {
-  fails.push("rail mode must hide .sb-row .title");
-}
-if (!/\.row-end[\s\S]{0,120}display:\s*none/.test(railSnippet)) {
-  fails.push("rail mode must hide .sb-row .row-end");
+// Collapsed mode (data-sidebar-rail) hides the whole sidebar (issue #33 — the
+// 56px icon rail that used to hide title/row-end inside a narrow strip is
+// retired), so no rail-scoped .sb-row styling may survive.
+if (/body\.app\[data-sidebar-rail\]\s+\.sb-row/.test(css)) {
+  fails.push("collapsed mode must not restyle .sb-row (the whole sidebar is hidden)");
 }
 
 if (fails.length) {

--- a/cmd/serf-hub/jstest/test-sidebar-tristate.js
+++ b/cmd/serf-hub/jstest/test-sidebar-tristate.js
@@ -49,10 +49,10 @@ assert(w.SerfSidebar.readSidebarMode() === "rail", "auto cycles to rail");
 assert(w.localStorage.getItem("serf-hub.sidebar.rail") === "rail", "cycle persists to storage");
 
 // Phone band (max-width: 767px): the off-canvas drawer governs, never the
-// 56px rail — body[data-sidebar-rail] must stay unset for every mode, or the
-// rail CSS (width:56px !important-free but higher-specificity) shrinks the
-// drawer to an unusable strip. The persisted pref is untouched: a rail pref
-// still applies when the same browser is back on a tablet/desktop viewport.
+// collapsed state — body[data-sidebar-rail] must stay unset for every mode, or
+// the collapsed CSS (display:none on #sidebar, higher specificity) kills the
+// drawer entirely. The persisted pref is untouched: a rail pref still applies
+// when the same browser is back on a tablet/desktop viewport.
 w = makeWindow(null, false, true);
 assert(!w.document.body.hasAttribute("data-sidebar-rail"), "auto on phone → no rail attr (drawer governs)");
 assert(w.document.body.getAttribute("data-sidebar-mode") === "auto", "phone auto still records the setting");

--- a/cmd/serf-hub/templates/partials/settings/theme.html
+++ b/cmd/serf-hub/templates/partials/settings/theme.html
@@ -29,10 +29,10 @@
       <div class="val-radio-group" data-sidebar-mode-picker>
         <label class="val-radio"><input type="radio" name="sidebar-mode" value="auto"> Auto</label>
         <label class="val-radio"><input type="radio" name="sidebar-mode" value="pane"> Pane</label>
-        <label class="val-radio"><input type="radio" name="sidebar-mode" value="rail"> Rail</label>
+        <label class="val-radio"><input type="radio" name="sidebar-mode" value="rail"> Collapsed</label>
       </div>
     </dd>
-    <p class="help">Desktop only. Rail mode collapses the sidebar to 56px (icons + dots); Auto rails below 1200px and expands above it. <code>⌘B</code> cycles rail → pane → auto.</p>
+    <p class="help">Desktop only. Collapsed hides the sidebar entirely — reopen it with the ☰ chip (top-left) as an overlay drawer; Auto collapses below 1200px and expands above it. <code>⌘B</code> cycles collapsed → pane → auto.</p>
   </div>
   <div class="row">
     <dt>Font size</dt>

--- a/docs/web-ui/design-system.md
+++ b/docs/web-ui/design-system.md
@@ -145,7 +145,7 @@ Design rule: **one scannable primary line per entry; status on a left rail or gl
 detail demoted to a mono chip; deep detail hidden until expanded.** Content column capped ~720px.
 
 **Breakpoint ladder + wide band (2026-07-19 addendum).** Phone ≤767px; tablet 768–1199px
-(side panes hidden, sidebar auto-rails — see §5); desktop 1200–1799px; wide ≥1800px.
+(side panes hidden, sidebar auto-collapses — see §5); desktop 1200–1799px; wide ≥1800px.
 The prose measure holds 720px at **every** width; the machine bleed (`--measure-machine`)
 is 1000px below the wide band and 1200px at/above it. Left edges never move.
 
@@ -271,10 +271,18 @@ collapsed archived stubs — the whole header is the toggle; the chevron is deco
 top margin between a project and whatever precedes it — group separation reads as a subtle
 rhythm break, not a void. Tap floors are untouched (32px desktop / 52px mobile min-height).
 
-**Tri-state mode (2026-07-19 addendum).** The sidebar mode is `auto | rail | pane`,
-persisted per-browser. `auto` (the default) rails below 1200px and expands at/above it;
-`rail`/`pane` pin the state. ⌘B cycles `rail → pane → auto`. The legacy binary
-preference migrates: collapsed→`rail`, expanded→`pane`, unset→`auto`.
+**Tri-state mode (2026-07-19 addendum; collapsed = hidden since issue #33).** The
+sidebar mode is `auto | rail | pane`, persisted per-browser (`rail` is the legacy
+name for the collapsed state). `auto` (the default) collapses below 1200px and expands
+at/above it; `rail`/`pane` pin the state. ⌘B cycles `rail → pane → auto`. The legacy
+binary preference migrates: collapsed→`rail`, expanded→`pane`, unset→`auto`.
+
+**Collapsed means fully collapsed.** There is no 56px icon rail: the sidebar leaves
+the layout entirely. The app-shell nav chip (`.app-nav-toggle`, hidden on desktop
+otherwise) floats top-left and reopens the sidebar as an **overlay drawer**
+(`body[data-sidebar-rail][data-sidebar-open]`) — the same pattern as the phone and
+short-landscape bands, including outside-click / Escape close and close-on-navigate.
+⌘B or the in-header mode toggle cycle back to `pane` to re-pin it.
 
 ---
 


### PR DESCRIPTION
Closes #33.

## Summary

On desktop the sidebar's collapsed mode showed a 56px icon "rail" strip. Collapsed now means collapsed: the sidebar leaves the layout entirely, and the app-shell ☰ chip (hidden on desktop otherwise) floats top-left to reopen it as an overlay drawer — the same pattern the phone band (d92d49c1) and the short-landscape band already use.

## Design

- **What replaced the rail:** nothing. `body.app[data-sidebar-rail]` (the tri-state's single effective-state flag) now sets `#sidebar { display: none }` and hides the sibling drag-resizer; all per-element strip styling (hiding `.sb-row` text columns, section headers, tier labels, archive buttons inside the 56px strip) is deleted as dead weight.
- **Reopen affordances:** the persistent `.app-nav-toggle` ☰ chip appears fixed top-left while collapsed and toggles `body[data-sidebar-open]`; a new `body.app[data-sidebar-rail][data-sidebar-open] #sidebar` rule shows the sidebar as a fixed overlay drawer (`var(--sidebar-w, 260px)`, max 88vw). Outside-click, Escape, and navigating to a session (`htmx:beforeRequest`) close it — all pre-existing wiring. ⌘B / the in-header mode toggle still cycle `rail → pane → auto`, re-pinning the sidebar open. The workspace header gets left padding while collapsed so its title clears the chip (plus a connection-banner offset).
- **Breakpoint behavior:** phone (≤767px) unchanged — the drawer-or-nothing behavior from d92d49c1 stands, and `data-sidebar-rail` is still never set there (its `display:none` would now kill the drawer). Tablet (768–1199px) `auto` still collapses below 1200px, now as full-hide + drawer instead of the strip. Short-landscape's `!important` drawer rules are unaffected.
- **Kept stable:** the tri-state machinery, the `serf-hub.sidebar.rail` storage key, binary-pref migration, the `data-sidebar-rail` attribute name, and `panes.js`'s resizer-disable — renaming the mode would orphan stored prefs for no behavior gain. The settings label now reads "Collapsed".

## Test evidence

- TDD: new `test-sidebar-collapsed-css.js` failed RED on the old strip CSS (6 assertions: sidebar not hidden, 56px still sized, `.sb-row` strip styling, no chip, no drawer rule, no header padding), then passed GREEN after the style.css change. `test-sidebar-density-css.js` / `test-sidebar-row-layout.js` assertions deliberately updated from strip-hiding to anti-strip contracts (that IS the behavior change).
- Full jstest suite green (`run-all.sh` exit 0, "jstest: all tests passed"); focused sidebar tests re-run green on the rebased commit; `go test ./cmd/serf-hub/` ok.
