### PR TITLE
webui: fold archived sessions behind one disclosure, grouped by project (#44)

### DIFF
--- a/cmd/serf-hub/assets/sidebar.js
+++ b/cmd/serf-hub/assets/sidebar.js
@@ -382,24 +382,33 @@
   }
 
   // flatten emits one keyed element descriptor per rendered row/section in
-  // order: NeedsYou, Pinned, active projects, Archived (N), Test runs (N).
-  // Render session rows grouped under project section headers; expansion +
-  // lazy children are honored via model.expanded.
+  // order: NeedsYou, Pinned, active projects, Archived sessions (N),
+  // Test runs (N). Render session rows grouped under project section headers;
+  // expansion + lazy children are honored via model.expanded.
   function flatten(tree) {
     var out = [];
     (tree.needs_you || []).forEach(function (n) { if (!n.__drop) { out.push(n); pushChildren(out, n, []); } });
     (tree.favorites || []).forEach(function (n) { if (!n.__drop) { out.push(n); pushChildren(out, n, []); } });
-    (tree.projects || []).forEach(function (p) { pushProject(out, p); });
+    (tree.projects || []).forEach(function (p) { pushProject(out, p, true); });
     pushArchivedSection(out, tree);
     pushTestRunsSection(out, tree);
     return out;
   }
-  function pushProject(out, p) {
+  // skipArchived diverts tier:"archived" sessions out of an ACTIVE project's
+  // inline list — they fold into the "Archived sessions" section instead
+  // (#44). Sections (archived projects, test runs) pass false: their buckets
+  // are server-decided and render every session they carry.
+  function pushProject(out, p, skipArchived) {
     // Project header is itself a keyed element (data-row-id="header:<key>").
-    out.push({ row_id: "header:" + p.key, __project: p });
-    if (!isExpanded(p.key, p.default_expanded)) return;
+    // An archived-sessions group header keys on __groupKey ("archived:<key>")
+    // so it never collides with — or shares expansion state with — the active
+    // project's own header.
+    var hkey = p.__groupKey || p.key;
+    out.push({ row_id: "header:" + hkey, __project: p });
+    if (!isExpanded(hkey, p.default_expanded)) return;
     (p.sessions || []).forEach(function (n) {
       if (n.__drop) return;
+      if (skipArchived && n.tier === "archived") return;
       n.__projectKey = p.key;
       if (n.kind === "cluster") { pushCluster(out, n); return; }
       out.push(n);
@@ -481,8 +490,53 @@
       list.forEach(function (p) { if (markKey) p[markKey] = true; pushProject(out, p); });
     }
   }
+  // The "Archived sessions" section (#44) folds EVERY archived session away
+  // behind one top-level disclosure, grouped by project inside it:
+  //   - archived projects (tree.archived_projects) render as session-less
+  //     stubs that lazy-hydrate on expand — unchanged pre-#44 behavior;
+  //   - each ACTIVE project with archived-tier sessions gets a per-project
+  //     sub-heading (row_id "header:archived:<key>", expansion key
+  //     "archived:<key>") showing the project name, revealing only that
+  //     project's archived sessions. Those sessions already ride the /api/tree
+  //     snapshot inside their project, so the group needs no lazy fetch.
+  // The header count is the number of archived sessions the section holds
+  // (a stub contributes its session_count until hydrated).
   function pushArchivedSection(out, tree) {
-    pushSection(out, tree.archived_projects || [], SECTION_ARCHIVED, "Archived", "__archived");
+    var stubs = tree.archived_projects || [];
+    var groups = archivedGroups(tree);
+    if (!stubs.length && !groups.length) return; // no chrome for an empty bucket
+    var count = 0;
+    stubs.forEach(function (p) { count += p.sessions ? visibleCount(p.sessions) : (p.session_count || 0); });
+    groups.forEach(function (g) { count += visibleCount(g.sessions); });
+    out.push({ row_id: SECTION_ARCHIVED, __section: true, key: SECTION_ARCHIVED, label: "Archived sessions", count: count });
+    if (model.expanded.has(SECTION_ARCHIVED)) {
+      stubs.forEach(function (p) { p.__archived = true; pushProject(out, p); });
+      groups.forEach(function (g) { pushProject(out, g); });
+    }
+  }
+  function visibleCount(sessions) {
+    var n = 0;
+    (sessions || []).forEach(function (s) { if (!s.__drop) n++; });
+    return n;
+  }
+  function archivedGroupKey(key) { return "archived:" + key; }
+  // archivedGroups synthesizes one project-header-shaped group per active
+  // project that has archived-tier sessions. __groupKey gives the header its
+  // own row_id/expansion key; __menuProject points the ⋯ menu at the real
+  // project (its key/working_dir/counts) so project actions stay correct.
+  function archivedGroups(tree) {
+    var groups = [];
+    (tree.projects || []).forEach(function (p) {
+      var archived = (p.sessions || []).filter(function (n) { return !n.__drop && n.tier === "archived"; });
+      if (!archived.length) return;
+      groups.push({
+        key: p.key, name: p.name, working_dir: p.working_dir,
+        sessions: archived,
+        __groupKey: archivedGroupKey(p.key),
+        __menuProject: p,
+      });
+    });
+    return groups;
   }
   function pushTestRunsSection(out, tree) {
     pushSection(out, tree.test_runs || [], SECTION_TEST_RUNS, "Test runs", null);
@@ -635,14 +689,19 @@
 
   function buildProjectHeader(p) {
     var d = document.createElement("div");
+    // __groupKey scopes an archived-sessions group header (#44) to its own
+    // row_id + expansion key; __menuProject keeps the ⋯ menu bound to the
+    // real project. Plain projects leave both unset and behave exactly as
+    // before.
+    var hkey = p.__groupKey || p.key;
     // NOTE: intentionally NOT "sb-row" — a project header is not a session
     // row, and the existing template/CSS (partials/sidebar.html, style.css)
     // already style ".project-header" as its own standalone class.
     d.className = "project-header";
-    d.setAttribute("data-row-id", "header:" + p.key);
+    d.setAttribute("data-row-id", "header:" + hkey);
     d.setAttribute("data-project-key", p.key);
     d.setAttribute("role", "button");
-    d.setAttribute("aria-expanded", String(isExpanded(p.key, p.default_expanded)));
+    d.setAttribute("aria-expanded", String(isExpanded(hkey, p.default_expanded)));
     // Disclosure affordance: same "›" idiom as sb-children-chevron /
     // cluster-chevron. Decorative span (aria-hidden) — the header itself is
     // the toggle and carries aria-expanded, which style.css uses to rotate
@@ -651,7 +710,7 @@
     d.querySelector(".project-name").textContent = p.name;
     setProjectCount(d, p);
     setProjectRollup(d, p);
-    d.addEventListener("click", function () { toggleExpanded(p.key); });
+    d.addEventListener("click", function () { toggleExpanded(hkey); });
     var menuBtn = document.createElement("button");
     menuBtn.type = "button";
     menuBtn.className = "sb-menu-btn btn-icon";
@@ -660,13 +719,13 @@
     menuBtn.textContent = "⋯"; // ⋯
     menuBtn.addEventListener("click", function (e) {
       e.preventDefault(); e.stopPropagation();
-      openMenu(menuBtn, projectMenuItems(p));
+      openMenu(menuBtn, projectMenuItems(p.__menuProject || p));
     });
     d.appendChild(menuBtn);
     return d;
   }
   function patchProjectHeader(el, p) {
-    el.setAttribute("aria-expanded", String(isExpanded(p.key, p.default_expanded)));
+    el.setAttribute("aria-expanded", String(isExpanded(p.__groupKey || p.key, p.default_expanded)));
     setProjectCount(el, p);
     setProjectRollup(el, p);
   }
@@ -778,6 +837,8 @@
   function restoreExpanded(tree) {
     var all = (tree.projects || []).concat(tree.archived_projects || [], tree.test_runs || []);
     all.forEach(function (p) { restoreExpansionPref(p.key); });
+    // Archived-sessions group headers (#44) persist under their own key.
+    (tree.projects || []).forEach(function (p) { restoreExpansionPref(archivedGroupKey(p.key)); });
     SECTION_KEYS.forEach(restoreExpansionPref);
     restoreInactiveExpansion(tree.needs_you || []);
     restoreInactiveExpansion(tree.favorites || []);
@@ -945,11 +1006,26 @@
     return (
       searchNodes(tree.needs_you, routeID, []) ||
       searchNodes(tree.favorites, routeID, []) ||
-      searchProjects(tree.projects, routeID, []) ||
+      searchActiveProjects(tree.projects, routeID) ||
       searchProjects(tree.archived_projects, routeID, [SECTION_ARCHIVED]) ||
       searchProjects(tree.test_runs, routeID, [SECTION_TEST_RUNS]) ||
       null
     );
+  }
+  // Active projects split their reveal chain by tier (#44): a non-archived
+  // match reveals the project itself; an archived-tier match sits behind the
+  // "Archived sessions" section and its per-project group header.
+  function searchActiveProjects(projects, routeID) {
+    for (var i = 0; i < (projects || []).length; i++) {
+      var p = projects[i];
+      var active = [], archived = [];
+      (p.sessions || []).forEach(function (n) { (n.tier === "archived" ? archived : active).push(n); });
+      var found = searchNodes(active, routeID, [p.key]);
+      if (found) return found;
+      found = searchNodes(archived, routeID, [SECTION_ARCHIVED, archivedGroupKey(p.key)]);
+      if (found) return found;
+    }
+    return null;
   }
   function searchProjects(projects, routeID, prefix) {
     for (var i = 0; i < (projects || []).length; i++) {

--- a/cmd/serf-hub/jstest/test-sidebar-archived-sessions.js
+++ b/cmd/serf-hub/jstest/test-sidebar-archived-sessions.js
@@ -1,0 +1,149 @@
+// Archived sessions (#44): archived-tier sessions no longer render inline
+// under their active project. They fold away behind the top-level
+// "Archived sessions" disclosure (the renamed section:archived), and inside
+// it they group under per-project sub-headings showing the project name.
+// Active sessions must render exactly as before.
+const fs = require("fs");
+const { JSDOM } = require("jsdom");
+const src = fs.readFileSync(__dirname + "/../assets/sidebar.js", "utf8");
+const iconsSrc = fs.readFileSync(__dirname + "/../assets/icons.js", "utf8");
+
+function boot(url) {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body><aside id="sidebar"></aside></body></html>`, {
+    runScripts: "outside-only", pretendToBeVisual: true, url: url || "http://localhost/",
+  });
+  const w = dom.window;
+  const posts = [];
+  w.fetch = (u, opts) => {
+    if (opts && opts.method === "POST") { posts.push({ url: u, body: JSON.parse(opts.body) }); return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) }); }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(emptyTree()) });
+  };
+  w.htmx = { process() {} };
+  w.SerfAppwire = { onNotification() {}, onConnectionRestored() {} };
+  w.eval(iconsSrc);
+  w.eval(src);
+  return { w, posts };
+}
+function emptyTree() {
+  return { needs_you: [], favorites: [], projects: [], archived_projects: [], test_runs: [], attentionSummary: { needsYou: 0, error: 0, working: 0 } };
+}
+function treeWithArchivedSessions() {
+  var t = emptyTree();
+  t.projects = [{
+    key: "p1", name: "proj-one", working_dir: "/w/p1", default_expanded: true,
+    sessions: [
+      { row_id: "project:p1:local:01A", ref: "local:01A", session_id: "01A", title: "active one", state: "active", kind: "session", tier: "current" },
+      { row_id: "project:p1:local:01B", ref: "local:01B", session_id: "01B", title: "recent one", state: "ended", kind: "session", tier: "recent" },
+      { row_id: "project:p1:local:01C", ref: "local:01C", session_id: "01C", title: "old one", state: "ended", kind: "session", tier: "archived" },
+      { row_id: "project:p1:local:01D", ref: "local:01D", session_id: "01D", title: "old two", state: "ended", kind: "session", tier: "archived" },
+    ],
+  }];
+  // An archived project stub (session-less; lazy-hydrates on expand) — the
+  // pre-existing section content, unchanged by #44.
+  t.archived_projects = [{ key: "ap1", name: "old-proj", working_dir: "/w/old", is_archived: true, session_count: 1, sessions: null }];
+  return t;
+}
+
+const { w, posts } = boot();
+const tree = treeWithArchivedSessions();
+w.SerfSidebar.renderTree(tree);
+
+// 1. The top-level disclosure exists, labeled "Archived sessions (N)" where
+//    N counts the archived sessions inside it (2 from the active project + 1
+//    from the archived stub), collapsed by default.
+const section = w.document.querySelector('[data-row-id="section:archived"]');
+if (!section) throw new Error("archived section header must render when archived sessions exist");
+if (!/Archived sessions \(3\)/.test(section.textContent)) {
+  throw new Error('section header must show label "Archived sessions (N)", got ' + JSON.stringify(section.textContent));
+}
+if (section.getAttribute("aria-expanded") !== "false") {
+  throw new Error('archived section must be collapsed by default, got aria-expanded=' + JSON.stringify(section.getAttribute("aria-expanded")));
+}
+
+// 2. The active project renders its non-archived sessions inline exactly as
+//    before (default_expanded), but its archived-tier sessions do NOT render
+//    inline — they live behind the section.
+if (!w.document.querySelector('[data-row-id="project:p1:local:01A"]')) throw new Error("current-tier session must render inline under its active project");
+if (!w.document.querySelector('[data-row-id="project:p1:local:01B"]')) throw new Error("recent-tier session must render inline under its active project");
+if (w.document.querySelector('[data-row-id="project:p1:local:01C"]')) throw new Error("archived session must NOT render inline under its active project");
+if (w.document.querySelector('[data-row-id="project:p1:local:01D"]')) throw new Error("archived session must NOT render inline under its active project");
+
+// 3. Expanding the section reveals per-project sub-headings: the archived
+//    stub (existing behavior) and a group header for the active project's
+//    archived sessions showing the project name — collapsed by default.
+section.dispatchEvent(new w.MouseEvent("click", { bubbles: true }));
+if (!w.document.querySelector('[data-row-id="header:ap1"]')) throw new Error("archived project stub header must render inside the expanded section");
+const group = w.document.querySelector('[data-row-id="header:archived:p1"]');
+if (!group) throw new Error("active project's archived sessions must group under a per-project sub-heading inside the section");
+if ((group.textContent || "").indexOf("proj-one") === -1) throw new Error("the archived-sessions sub-heading must show the project name, got " + JSON.stringify(group.textContent));
+if (group.getAttribute("aria-expanded") !== "false") {
+  throw new Error("the per-project archived group must be collapsed by default, got aria-expanded=" + JSON.stringify(group.getAttribute("aria-expanded")));
+}
+if (w.document.querySelector('[data-row-id="project:p1:local:01C"]')) throw new Error("archived sessions must stay hidden until their project group is expanded");
+
+// 4. Expanding the group renders ONLY the archived sessions; active sessions
+//    remain exactly where they were. Expansion persists under the group key.
+group.dispatchEvent(new w.MouseEvent("click", { bubbles: true }));
+if (!w.document.querySelector('[data-row-id="project:p1:local:01C"]')) throw new Error("archived session must render once its project group is expanded");
+if (!w.document.querySelector('[data-row-id="project:p1:local:01D"]')) throw new Error("archived session must render once its project group is expanded");
+if (!w.document.querySelector('[data-row-id="project:p1:local:01A"]')) throw new Error("active sessions must remain rendered under the active project");
+if (w.localStorage.getItem("serf-hub.sidebar.expanded.archived:p1") !== "true") {
+  throw new Error("archived group expansion must persist under its own key");
+}
+
+// 5. DOM identity: the section header node survives a re-render (keyed
+//    reconcile), like every other keyed element.
+const section2 = w.document.querySelector('[data-row-id="section:archived"]');
+section2.__probe = true;
+w.SerfSidebar.renderTree(tree);
+const section3 = w.document.querySelector('[data-row-id="section:archived"]');
+if (!section3 || section3.__probe !== true) throw new Error("section header must keep DOM node identity across re-renders");
+
+// 6. An archived session's row menu offers Unarchive (not Archive), and
+//    clicking it POSTs /api/archive with archived:false.
+const archivedRow = w.document.querySelector('[data-row-id="project:p1:local:01C"]');
+const menuBtn = archivedRow.querySelector(".sb-menu-btn");
+if (!menuBtn) throw new Error("archived session row must carry a ⋯ menu button");
+menuBtn.dispatchEvent(new w.MouseEvent("click", { bubbles: true }));
+const menu = w.document.querySelector(".sb-menu");
+if (!menu) throw new Error("clicking ⋯ must open a menu");
+const items = [].map.call(menu.querySelectorAll(".sb-menu-item"), (e) => e.textContent);
+if (items.some((t) => /^Archive$/.test(t))) throw new Error("an archived session's menu must not offer plain Archive, got " + JSON.stringify(items));
+const unarchive = [].find.call(menu.querySelectorAll(".sb-menu-item"), (e) => /Unarchive/.test(e.textContent));
+if (!unarchive) throw new Error("an archived session's menu must offer Unarchive, got " + JSON.stringify(items));
+unarchive.dispatchEvent(new w.MouseEvent("click", { bubbles: true }));
+const last = posts[posts.length - 1];
+if (!last || last.url !== "/api/archive" || last.body.kind !== "session" || last.body.archived !== false) {
+  throw new Error("Unarchive must POST /api/archive {kind:session, archived:false}, got " + JSON.stringify(last));
+}
+
+// 7. Empty archive: no archived projects and no archived-tier sessions in any
+//    active project -> no section chrome at all.
+const empty = boot();
+const activeOnly = emptyTree();
+activeOnly.projects = [{
+  key: "p2", name: "proj-two", working_dir: "/w/p2", default_expanded: true,
+  sessions: [{ row_id: "project:p2:local:02A", ref: "local:02A", session_id: "02A", title: "live", state: "active", kind: "session", tier: "current" }],
+}];
+empty.w.SerfSidebar.renderTree(activeOnly);
+if (empty.w.document.querySelector('[data-row-id="section:archived"]')) {
+  throw new Error("no Archived sessions section may render when nothing is archived");
+}
+
+// 8. Deep-link auto-reveal: a URL targeting an archived session of an active
+//    project expands the section + the project group and marks the row
+//    data-active.
+const deep = boot("http://localhost/s/01D");
+deep.w.SerfSidebar.renderTree(treeWithArchivedSessions());
+const revealed = deep.w.document.querySelector('[data-row-id="project:p1:local:01D"]');
+if (!revealed) throw new Error("deep-link to an archived session must auto-reveal it through the section + project group");
+if (!revealed.hasAttribute("data-active")) throw new Error("the auto-revealed archived session must be marked data-active");
+if (deep.w.localStorage.getItem("serf-hub.sidebar.expanded.section:archived") !== "true") {
+  throw new Error("auto-reveal must persist the section expansion key");
+}
+if (deep.w.localStorage.getItem("serf-hub.sidebar.expanded.archived:p1") !== "true") {
+  throw new Error("auto-reveal must persist the archived project-group expansion key");
+}
+
+console.log("ok sidebar archived sessions: folded behind top-level disclosure, grouped by project, active list untouched");
+process.exit(0); // sidebar.js's 60s idle-resync interval keeps the event loop alive otherwise

--- a/cmd/serf-hub/jstest/test-sidebar-density-css.js
+++ b/cmd/serf-hub/jstest/test-sidebar-density-css.js
@@ -14,7 +14,7 @@ if (!/min-height:\s*24px/.test(menuBtn) || !/min-width:\s*24px/.test(menuBtn)) f
 // Rail mode (56px icon-only collapsed sidebar) must hide the ENTIRE
 // .sb-section archived-section toggle, exactly like the legacy
 // .tier-header/.sidebar-section-header disclosure headers are hidden there
-// — otherwise its "Archived (N)" label has no width constraint and bleeds
+// — otherwise its "Archived sessions (N)" label has no width constraint and bleeds
 // out of the 56px rail into the workspace pane.
 const railHidesSbSection = /body\.app\[data-sidebar-rail\][^{}]*\.sb-section[^{}]*\{([^{}]*)\}/.exec(css);
 if (!railHidesSbSection || !/display:\s*none/.test(railHidesSbSection[1])) fails.push("rail mode (data-sidebar-rail) must hide .sb-section entirely (display:none)");

--- a/cmd/serf-hub/jstest/test-sidebar-sections.js
+++ b/cmd/serf-hub/jstest/test-sidebar-sections.js
@@ -1,7 +1,9 @@
-// Sidebar sections: a keyed "Archived (N)" divider, collapsed by default,
-// that reuses pushProject/buildProjectHeader/buildRow for its content once
-// expanded, with an Unarchive (not Archive) row-menu action for the projects
-// it contains.
+// Sidebar sections: a keyed "Archived sessions (N)" divider, collapsed by
+// default, that reuses pushProject/buildProjectHeader/buildRow for its
+// content once expanded, with an Unarchive (not Archive) row-menu action for
+// the projects it contains. (Renamed from "Archived (N)" in #44, which also
+// folds active projects' archived-tier sessions into this section, grouped
+// per project — see test-sidebar-archived-sessions.js.)
 const fs = require("fs");
 const { JSDOM } = require("jsdom");
 const src = fs.readFileSync(__dirname + "/../assets/sidebar.js", "utf8");
@@ -47,8 +49,8 @@ const tree = treeWithArchived();
 w.SerfSidebar.renderTree(tree);
 const header = w.document.querySelector('[data-row-id="section:archived"]');
 if (!header) throw new Error("archived section header must render when archived_projects is non-empty");
-if (!/Archived \(1\)/.test(header.textContent)) {
-  throw new Error('section header must show label "Archived (N)", got ' + JSON.stringify(header.textContent));
+if (!/Archived sessions \(1\)/.test(header.textContent)) {
+  throw new Error('section header must show label "Archived sessions (N)", got ' + JSON.stringify(header.textContent));
 }
 if (header.getAttribute("aria-expanded") !== "false") {
   throw new Error('collapsed section header must have aria-expanded="false", got ' + JSON.stringify(header.getAttribute("aria-expanded")));
@@ -105,5 +107,5 @@ if (last.body.kind !== "project" || last.body.id !== "apk1" || last.body.archive
   throw new Error("Unarchive POST body wrong: " + JSON.stringify(last.body));
 }
 
-console.log("ok sidebar sections: archived (N) collapsed-by-default + identity + unarchive menu");
+console.log("ok sidebar sections: archived sessions (N) collapsed-by-default + identity + unarchive menu");
 process.exit(0); // sidebar.js's 60s idle-resync interval keeps the event loop alive otherwise

--- a/docs/web-ui/design-system.md
+++ b/docs/web-ui/design-system.md
@@ -253,6 +253,12 @@ Project-first, ranked by recency, with disclosure folding. Tiers top→bottom:
   subagents" past ~3.
 - **RECENT** — touched in ~last day; collapsed.
 - **OLDER** — collapsed.
+- **ARCHIVED SESSIONS (N)** — one top-level disclosure, collapsed by default, folding away
+  everything archived so it stops cluttering the active list. N counts the archived sessions
+  inside. Expanding reveals per-project sub-headings (project name, own disclosure chevron):
+  archived projects ride as session-less stubs that lazy-hydrate on expand, and each active
+  project with archived-tier sessions gets a group revealing only those sessions (they already
+  ride the tree snapshot, so no fetch). Active projects never list archived sessions inline.
 - **TEST RUNS (N)** — auto-bucket the disposable `serf-e2e-*` single-session sprawl into one
   collapsed group so it stops drowning real projects.
 


### PR DESCRIPTION
## Summary

Archived-tier sessions of active projects no longer render inline in the sidebar's project session list. They fold away behind the existing top-level archived section — renamed **"Archived (N)" → "Archived sessions (N)"** — collapsed by default, and inside it everything archived is grouped under per-project sub-headings showing the project name. Active sessions render exactly as before.

## Design choices

- **One top-level disclosure** (`section:archived`, same expansion key, so persisted user state carries over). Inside it, two kinds of per-project groups:
  1. archived projects (`tree.archived_projects`) — unchanged: session-less stubs that lazy-hydrate from `/api/tree/project?key=` on expand;
  2. a synthetic group per **active** project with archived-tier sessions, revealing only those sessions — they already ride the `/api/tree` snapshot, so **no lazy fetch**.
- **Grouping source for project names:** the tree payload's `project.name` (server-computed basename of the canonical working dir). No new wire fields.
- **Row-id / expansion-key separation:** group headers use `header:archived:<key>` / expansion key `archived:<key>` (`__groupKey`), never colliding with or sharing state with the active project's own `header:<key>`. Session row ids are unchanged, so the keyed reconcile preserves node identity when a row moves between lists. The group ⋯ menu binds to the real project (`__menuProject`).
- **Default state:** collapsed at both levels (section + each group), matching the existing section pattern; no chrome when the archive is empty.
- **Header count:** N counts archived **sessions** (stubs contribute `session_count` until hydrated).
- **Deep-link auto-reveal:** `findRevealChain` splits an active project's reveal chain by tier — archived matches reveal `[section:archived, archived:<key>]` and mark the row `data-active`.
- **Scope guards:** only `tree.projects` sessions are diverted; `test_runs` / `archived_projects` bucketing stays server-side.
- **CSS:** no changes — reuses `.sb-section`, `.project-header`, chevrons, and rows verbatim.

## Test evidence (TDD)

- **RED:** new `cmd/serf-hub/jstest/test-sidebar-archived-sessions.js` failed before implementation: `section header must show label "Archived sessions (N)", got "Archived (1)"`.
- **GREEN:** same test passes after the sidebar.js change (covers: no inline archived rows, collapsed-by-default section + groups, per-project grouping, expansion persistence, Unarchive menu, empty-archive chrome, deep-link reveal).
- **Full suite:** `sh run-all.sh` → every `test-*.js` OK, "jstest: all tests passed". One pre-existing test (`test-sidebar-sections.js`) was updated for the intentional label rename.
- `docs/web-ui/design-system.md` §5 Sidebar documents the new tier.

Closes #44
