### PR TITLE
agent,hub,tui,webui: aside command — fork session into a side thread (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ checks, see [`cmd/serf-hub/README.md`](cmd/serf-hub/README.md).
 - **Workspace pane** with a two-tier conversation: messages (user pills + assistant body) at the primary reading tier, tool calls and diffs as muted margin annotations.
 - **New session** at `/new` — prompt-first, pick model and working dir, click spawn.
 - **Edit-to-fork**: hover any prior user message, click `✎ edit`, hit ⌘↵, label the original branch, confirm. The new branch becomes active; the original is preserved as a sibling fork.
+- **Aside**: `/aside` (TUI) or the *Aside: fork to side thread* palette command (web UI) forks the current session at its tip into a side thread with the same permissions and config — for asking a distracting question without derailing the main session.
 - **Transparent resume**: click any closed session, type, send. The daemon spawns from where it left off — same identity throughout.
 - **⌘K search** across live + past sessions.
 - **Settings** for theme (light/dark/system), notification preferences (all opt-in), and read-only inspection of providers and MCP setup.

--- a/agent/aside.go
+++ b/agent/aside.go
@@ -1,0 +1,48 @@
+package agent
+
+import (
+	"fmt"
+
+	"github.com/spf13/afero"
+
+	"primeradiant.com/serf/agent/schema"
+	"primeradiant.com/serf/agent/transcript"
+)
+
+// AsideSession creates a new session branched from a parent session at its
+// tip: the child's transcript is a complete copy of the parent's, with no
+// divergent edit. The child inherits the parent's profile, model, and config
+// (sandbox mode, tool allowances — everything persisted in the session meta),
+// records the parent in its lineage, and gets its own fresh session ID, so it
+// runs as a side thread of the main session. The parent's transcript and meta
+// are left untouched.
+//
+// Use case: asking a distracting question about the main session without
+// derailing it — the user asks in the aside thread while the parent continues.
+func AsideSession(stateDir, parentID string) (string, error) {
+	return asideSessionFS(afero.NewOsFs(), stateDir, parentID)
+}
+
+func asideSessionFS(fs afero.Fs, stateDir, parentID string) (string, error) {
+	parentHeader, allEntries, err := readForkParent(fs, stateDir, parentID, 10*1024*1024)
+	if err != nil {
+		return "", err
+	}
+
+	// Load parent meta — required for copying fields to the child.
+	parentMeta, err := schema.LoadSessionMetaWithFS(fs, stateDir, parentID)
+	if err != nil {
+		return "", fmt.Errorf("load parent session meta: %w", err)
+	}
+
+	deps := forkSessionDeps{
+		newWriter: func(fs afero.Fs, path string, header transcript.Header) (forkTranscriptWriter, error) {
+			return transcript.NewWriterWithFS(fs, path, header)
+		},
+		saveMeta:     schema.SaveSessionMetaWithFS,
+		maxScanToken: 10 * 1024 * 1024,
+	}
+	// The child shares the parent's full transcript, so the first turn unique
+	// to this branch is one past the parent's tip.
+	return writeForkChild(fs, stateDir, parentID, parentHeader, parentMeta, allEntries, len(allEntries)+1, nil, deps)
+}

--- a/agent/aside_test.go
+++ b/agent/aside_test.go
@@ -1,0 +1,208 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"primeradiant.com/serf/agent/execenv"
+	"primeradiant.com/serf/agent/schema"
+	"primeradiant.com/serf/agent/transcript"
+	"primeradiant.com/serf/identifier"
+	"primeradiant.com/serf/llm"
+)
+
+// buildAsideParentSession creates a parent session with a 4-entry transcript
+// (USER, ASSISTANT, USER, ASSISTANT) and a meta carrying a distinctive config
+// (sandbox mode + tool-round cap) so tests can assert the aside child inherits
+// the parent's permissions and configuration verbatim.
+func buildAsideParentSession(t *testing.T) (stateDir, parentID string) {
+	t.Helper()
+	stateDir, parentID = buildParentSession(t)
+
+	meta, err := schema.LoadSessionMeta(stateDir, parentID)
+	if err != nil {
+		t.Fatalf("LoadSessionMeta(parent): %v", err)
+	}
+	meta.Config.Sandbox = "workspace-write"
+	if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
+		t.Fatalf("SaveSessionMeta(parent): %v", err)
+	}
+	return stateDir, parentID
+}
+
+// TestAsideSession_CopiesFullTranscriptAtTip verifies the aside contract: the
+// child is a complete copy of the parent transcript — including the trailing
+// assistant turn a divergent fork cannot end on — and inherits the parent's
+// profile, model, and config (permissions) through its meta.
+func TestAsideSession_CopiesFullTranscriptAtTip(t *testing.T) {
+	t.Parallel()
+	stateDir, parentID := buildAsideParentSession(t)
+
+	childID, err := AsideSession(stateDir, parentID)
+	if err != nil {
+		t.Fatalf("AsideSession: %v", err)
+	}
+	if err := identifier.ValidateSessionID(childID); err != nil {
+		t.Fatalf("child session ID %q: %v", childID, err)
+	}
+	if childID == parentID {
+		t.Fatalf("childID should differ from parentID, got %q", childID)
+	}
+
+	// Child transcript is the full parent transcript: 4 entries ending on the
+	// final ASSISTANT turn.
+	childTranscriptPath := filepath.Join(stateDir, sessionsSubdir, childID+".transcript.jsonl")
+	header, entries, _, err := readTranscript(childTranscriptPath)
+	if err != nil {
+		t.Fatalf("readTranscript(child): %v", err)
+	}
+	if header.ParentSessionID != parentID {
+		t.Errorf("child header ParentSessionID: got %q, want %q", header.ParentSessionID, parentID)
+	}
+	if len(entries) != 4 {
+		t.Fatalf("child transcript entry count: got %d, want 4", len(entries))
+	}
+	last := entries[len(entries)-1]
+	if last.Turn.Kind != schema.TurnAssistant || last.Turn.Message.Text() != "second reply" {
+		t.Errorf("last child entry: got kind=%q text=%q, want assistant %q",
+			last.Turn.Kind, last.Turn.Message.Text(), "second reply")
+	}
+
+	// Child meta: lineage at the tip, inherited config, fresh counters derived
+	// from the copied entries.
+	childMeta, err := schema.LoadSessionMeta(stateDir, childID)
+	if err != nil {
+		t.Fatalf("LoadSessionMeta(child): %v", err)
+	}
+	if childMeta.ParentSessionID != parentID {
+		t.Errorf("child ParentSessionID: got %q, want %q", childMeta.ParentSessionID, parentID)
+	}
+	if childMeta.DivergenceTurn != 5 {
+		t.Errorf("child DivergenceTurn: got %d, want 5 (first turn past the shared tip)", childMeta.DivergenceTurn)
+	}
+	if childMeta.TurnCount != 2 {
+		t.Errorf("child TurnCount: got %d, want 2", childMeta.TurnCount)
+	}
+	if childMeta.AcceptedInputTurns != 2 {
+		t.Errorf("child AcceptedInputTurns: got %d, want 2", childMeta.AcceptedInputTurns)
+	}
+	if childMeta.ProfileID != "openai" || childMeta.Model != "gpt-5.2" {
+		t.Errorf("child profile/model: got %q/%q, want openai/gpt-5.2", childMeta.ProfileID, childMeta.Model)
+	}
+	if childMeta.Config.Sandbox != "workspace-write" {
+		t.Errorf("child sandbox mode: got %q, want %q (inherited permissions)", childMeta.Config.Sandbox, "workspace-write")
+	}
+	if childMeta.Config.MaxToolRoundsPerInput != 50 {
+		t.Errorf("child MaxToolRoundsPerInput: got %d, want 50", childMeta.Config.MaxToolRoundsPerInput)
+	}
+	if childMeta.ForkLabel != "" {
+		t.Errorf("child ForkLabel should be empty, got %q", childMeta.ForkLabel)
+	}
+
+	// The parent meta is untouched: an aside does not relabel the main branch.
+	parentMeta, err := schema.LoadSessionMeta(stateDir, parentID)
+	if err != nil {
+		t.Fatalf("LoadSessionMeta(parent): %v", err)
+	}
+	if parentMeta.ForkLabel != "" {
+		t.Errorf("parent ForkLabel: got %q, want empty (aside leaves the parent untouched)", parentMeta.ForkLabel)
+	}
+}
+
+// TestAsideSession_ChildRestoresAsSideThread proves the aside child is a
+// resumable session whose lineage survives the restore+meta-rewrite cycle,
+// i.e. it stays addressable as a child of the main session in the tree.
+func TestAsideSession_ChildRestoresAsSideThread(t *testing.T) {
+	t.Parallel()
+	stateDir, parentID := buildAsideParentSession(t)
+
+	childID, err := AsideSession(stateDir, parentID)
+	if err != nil {
+		t.Fatalf("AsideSession: %v", err)
+	}
+	childMeta, err := schema.LoadSessionMeta(stateDir, childID)
+	if err != nil {
+		t.Fatalf("LoadSessionMeta(child): %v", err)
+	}
+
+	sess, err := RestoreSessionFromMeta(llm.NewClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), childMeta, stateDir)
+	if err != nil {
+		t.Fatalf("RestoreSessionFromMeta: %v", err)
+	}
+	defer sess.Close()
+
+	rewritten := sess.Meta()
+	if rewritten.ParentSessionID != parentID {
+		t.Errorf("rewritten ParentSessionID: got %q, want %q", rewritten.ParentSessionID, parentID)
+	}
+	if rewritten.DivergenceTurn != 5 {
+		t.Errorf("rewritten DivergenceTurn: got %d, want 5", rewritten.DivergenceTurn)
+	}
+	if rewritten.Config.Sandbox != "workspace-write" {
+		t.Errorf("rewritten sandbox mode: got %q, want inherited %q", rewritten.Config.Sandbox, "workspace-write")
+	}
+}
+
+// TestAsideSession_EmptyParentTranscript pins behavior for a session with no
+// turns yet: the aside child is an empty copy diverging at turn 1.
+func TestAsideSession_EmptyParentTranscript(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	parentID := "01PARENTEMPTY0000000000AS"
+
+	tw, err := transcript.NewWriter(filepath.Join(stateDir, sessionsSubdir, parentID+".transcript.jsonl"), transcript.Header{
+		SessionID:  parentID,
+		CreatedAt:  time.Now().UTC(),
+		ProfileID:  "openai",
+		Model:      "gpt-5.2",
+		WorkingDir: "/tmp/test",
+	})
+	if err != nil {
+		t.Fatalf("transcript.NewWriter: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("Close transcript: %v", err)
+	}
+	if err := schema.SaveSessionMeta(stateDir, schema.SessionMeta{
+		ID:        parentID,
+		ProfileID: "openai",
+		Model:     "gpt-5.2",
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveSessionMeta: %v", err)
+	}
+
+	childID, err := AsideSession(stateDir, parentID)
+	if err != nil {
+		t.Fatalf("AsideSession: %v", err)
+	}
+	childMeta, err := schema.LoadSessionMeta(stateDir, childID)
+	if err != nil {
+		t.Fatalf("LoadSessionMeta(child): %v", err)
+	}
+	if childMeta.DivergenceTurn != 1 || childMeta.TurnCount != 0 || childMeta.AcceptedInputTurns != 0 {
+		t.Errorf("child meta divergence/turns: got %d/%d/%d, want 1/0/0",
+			childMeta.DivergenceTurn, childMeta.TurnCount, childMeta.AcceptedInputTurns)
+	}
+}
+
+// TestAsideSession_RejectsMissingParent verifies a missing parent transcript
+// returns an error instead of creating an orphaned child.
+func TestAsideSession_RejectsMissingParent(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+
+	childID, err := AsideSession(stateDir, "NONEXISTENT_SESSION")
+	if err == nil {
+		t.Error("AsideSession with missing parent should return an error")
+	}
+	if childID != "" {
+		t.Errorf("AsideSession child id = %q, want empty on error", childID)
+	}
+	if entries, _ := os.ReadDir(filepath.Join(stateDir, sessionsSubdir)); len(entries) != 0 {
+		t.Errorf("aside created artifacts for a missing parent: %v", entries)
+	}
+}

--- a/agent/fork.go
+++ b/agent/fork.go
@@ -57,75 +57,9 @@ func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn 
 		return "", fmt.Errorf("divergenceTurn must be >= 1, got %d", divergenceTurn)
 	}
 
-	transcriptPath := filepath.Join(stateDir, sessionsSubdir, parentID+".transcript.jsonl")
-
-	// Read the raw transcript lines so we can replay entry lines into the child.
-	f, err := fs.Open(transcriptPath)
+	parentHeader, allEntries, err := readForkParent(fs, stateDir, parentID, deps.maxScanToken)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return "", fmt.Errorf("parent transcript not found for session %s", parentID)
-		}
-		return "", fmt.Errorf("open parent transcript: %w", err)
-	}
-	defer func() { _ = f.Close() }() // read-only handle; close error is immaterial
-
-	maxScanToken := deps.maxScanToken
-	if maxScanToken <= 0 {
-		maxScanToken = 10 * 1024 * 1024
-	}
-	reader := bufio.NewReaderSize(f, min(64*1024, maxScanToken))
-
-	// The first non-empty complete line is the header.
-	var parentHeader transcript.Header
-	for {
-		line, complete, _, readErr := transcript.ReadLine(reader, maxScanToken)
-		if readErr != nil {
-			return "", fmt.Errorf("reading parent transcript header: %w", readErr)
-		}
-		if !complete {
-			return "", errors.New("parent transcript is empty")
-		}
-		line = bytes.TrimSpace(line)
-		if len(line) == 0 {
-			continue
-		}
-		parentHeader, err = transcript.DecodeHeader(line)
-		if err != nil {
-			return "", fmt.Errorf("parsing parent transcript header: %w", err)
-		}
-		break
-	}
-
-	// Collect all entry lines from the parent transcript.
-	// divergenceTurn is a 1-based index into the full entry list (all turns, not just
-	// USER_INPUT). The entry at position divergenceTurn (1-based) must be a USER_INPUT
-	// turn; it is replaced by the edited message in the child. All entries before it
-	// form the prefix.
-	//
-	// Example with transcript [U1, A1, U2, A2] and divergenceTurn=3:
-	//   entries[2] (1-based: turn 3) = U2. Prefix = [U1, A1].
-	//   Child = [U1, A1, edited-U2].
-	var allEntries []transcript.Entry
-
-	for {
-		line, complete, _, readErr := transcript.ReadLine(reader, maxScanToken)
-		if readErr != nil {
-			return "", fmt.Errorf("reading parent transcript entries: %w", readErr)
-		}
-		if !complete {
-			break
-		}
-		line = bytes.TrimSpace(line)
-		if len(line) == 0 {
-			continue
-		}
-
-		entry, err := transcript.DecodeEntry(line)
-		if err != nil {
-			return "", fmt.Errorf("parsing parent transcript entry: %w", err)
-		}
-
-		allEntries = append(allEntries, entry)
+		return "", err
 	}
 
 	// Validate that divergenceTurn points to a valid entry in the parent transcript.
@@ -148,6 +82,95 @@ func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn 
 		return "", fmt.Errorf("load parent session meta: %w", err)
 	}
 
+	childID, err := writeForkChild(fs, stateDir, parentID, parentHeader, parentMeta, prefixEntries, divergenceTurn, &editedMessage, deps)
+	if err != nil {
+		return "", err
+	}
+
+	// Update the parent meta with the fork label if provided.
+	if parentForkLabel != "" {
+		parentMeta.ForkLabel = parentForkLabel
+		if err := deps.saveMeta(fs, stateDir, parentMeta); err != nil {
+			return "", fmt.Errorf("update parent session meta with fork label: %w", err)
+		}
+	}
+
+	return childID, nil
+}
+
+// readForkParent loads the parent transcript's header and full entry list.
+// divergenceTurn indexing in ForkSession is 1-based into this entry list (all
+// turns, not just USER_INPUT).
+func readForkParent(fs afero.Fs, stateDir, parentID string, maxScanToken int) (transcript.Header, []transcript.Entry, error) {
+	transcriptPath := filepath.Join(stateDir, sessionsSubdir, parentID+".transcript.jsonl")
+
+	// Read the raw transcript lines so we can replay entry lines into the child.
+	f, err := fs.Open(transcriptPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return transcript.Header{}, nil, fmt.Errorf("parent transcript not found for session %s", parentID)
+		}
+		return transcript.Header{}, nil, fmt.Errorf("open parent transcript: %w", err)
+	}
+	defer func() { _ = f.Close() }() // read-only handle; close error is immaterial
+
+	if maxScanToken <= 0 {
+		maxScanToken = 10 * 1024 * 1024
+	}
+	reader := bufio.NewReaderSize(f, min(64*1024, maxScanToken))
+
+	// The first non-empty complete line is the header.
+	var parentHeader transcript.Header
+	for {
+		line, complete, _, readErr := transcript.ReadLine(reader, maxScanToken)
+		if readErr != nil {
+			return transcript.Header{}, nil, fmt.Errorf("reading parent transcript header: %w", readErr)
+		}
+		if !complete {
+			return transcript.Header{}, nil, errors.New("parent transcript is empty")
+		}
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		parentHeader, err = transcript.DecodeHeader(line)
+		if err != nil {
+			return transcript.Header{}, nil, fmt.Errorf("parsing parent transcript header: %w", err)
+		}
+		break
+	}
+
+	// Collect all entry lines from the parent transcript.
+	var allEntries []transcript.Entry
+	for {
+		line, complete, _, readErr := transcript.ReadLine(reader, maxScanToken)
+		if readErr != nil {
+			return transcript.Header{}, nil, fmt.Errorf("reading parent transcript entries: %w", readErr)
+		}
+		if !complete {
+			break
+		}
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+
+		entry, err := transcript.DecodeEntry(line)
+		if err != nil {
+			return transcript.Header{}, nil, fmt.Errorf("parsing parent transcript entry: %w", err)
+		}
+
+		allEntries = append(allEntries, entry)
+	}
+	return parentHeader, allEntries, nil
+}
+
+// writeForkChild writes the child transcript (prefix entries plus, when
+// editedMessage is non-nil, a replacement USER_INPUT turn carrying that text)
+// and saves the child meta. divergenceTurn is recorded in the child meta as
+// the first turn unique to this branch; editedMessage == nil means the branch
+// diverges past the parent's tip with no replacement turn (the aside case).
+func writeForkChild(fs afero.Fs, stateDir, parentID string, parentHeader transcript.Header, parentMeta schema.SessionMeta, prefixEntries []transcript.Entry, divergenceTurn int, editedMessage *string, deps forkSessionDeps) (string, error) {
 	// Mint a new child session ID.
 	childID, err := identifier.NewSessionID()
 	if err != nil {
@@ -177,7 +200,7 @@ func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn 
 		return "", fmt.Errorf("create child transcript: %w", err)
 	}
 	// Safety net for early error returns; the success path closes tw explicitly
-	// below (line ~165) and checks that error, after which this defer is a no-op.
+	// below and checks that error, after which this defer is a no-op.
 	defer func() { _ = tw.Close() }()
 
 	modelResponses := 0
@@ -195,12 +218,15 @@ func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn 
 		}
 	}
 
-	// Append the edited turn as a new USER_INPUT turn.
-	editedTurn := schema.NewTurn(schema.TurnUserInput, llm.User(editedMessage))
-	if err := tw.Append(editedTurn); err != nil {
-		return "", fmt.Errorf("append edited turn to child transcript: %w", err)
+	// Append the edited turn as a new USER_INPUT turn when this is a
+	// divergence fork (aside forks pass nil and copy the tip verbatim).
+	if editedMessage != nil {
+		editedTurn := schema.NewTurn(schema.TurnUserInput, llm.User(*editedMessage))
+		if err := tw.Append(editedTurn); err != nil {
+			return "", fmt.Errorf("append edited turn to child transcript: %w", err)
+		}
+		acceptedInputTurns++
 	}
-	acceptedInputTurns++
 
 	if err := tw.Close(); err != nil {
 		return "", fmt.Errorf("close child transcript: %w", err)
@@ -225,14 +251,6 @@ func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn 
 
 	if err := deps.saveMeta(fs, stateDir, childMeta); err != nil {
 		return "", fmt.Errorf("save child session meta: %w", err)
-	}
-
-	// Update the parent meta with the fork label if provided.
-	if parentForkLabel != "" {
-		parentMeta.ForkLabel = parentForkLabel
-		if err := deps.saveMeta(fs, stateDir, parentMeta); err != nil {
-			return "", fmt.Errorf("update parent session meta with fork label: %w", err)
-		}
 	}
 
 	return childID, nil

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -685,6 +685,12 @@ type ThreadForkParams struct {
 	Label         string `json:"label,omitempty"`
 	ModelProvider string `json:"modelProvider,omitempty"`
 	Model         string `json:"model,omitempty"`
+	// Aside forks a local serf thread at its tip instead of at a source turn:
+	// the child is a complete copy of the parent session (same permissions and
+	// config via the inherited session meta) and opens as a side thread. Aside
+	// is mutually exclusive with SourceTurnID, EditedInput, and Label, and is
+	// only supported for local serf threads.
+	Aside bool `json:"aside,omitempty"`
 }
 
 type ThreadForkResponse struct {

--- a/cmd/serf-hub/app_aside_test.go
+++ b/cmd/serf-hub/app_aside_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"primeradiant.com/serf/agent/schema"
+	"primeradiant.com/serf/appwire"
+	"primeradiant.com/serf/cmd/serf-hub/internal/hubcore"
+)
+
+// TestHubRPCThreadForkAsideCreatesSideThread verifies the aside mode of
+// thread/fork: a local session is forked at its tip (no source turn, no
+// edited input), and the child inherits the parent session's identity and
+// config through its meta with lineage pointing at the parent.
+func TestHubRPCThreadForkAsideCreatesSideThread(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, "projects", "project-aside-0000000000")
+	parentID := buildRPCParentSession(t, stateDir)
+	past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+	if err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{Past: past})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	resp, err := client.ThreadFork(context.Background(), appwire.ThreadForkParams{
+		Ref:   "local:" + parentID,
+		Aside: true,
+	})
+	if err != nil {
+		t.Fatalf("ThreadFork(aside): %v", err)
+	}
+	if resp.Thread.ID == "" || resp.Thread.ID == parentID || resp.Thread.Serf.Ref != "local:"+resp.Thread.ID {
+		t.Fatalf("thread=%+v", resp.Thread)
+	}
+
+	childMeta, err := schema.LoadSessionMeta(stateDir, resp.Thread.ID)
+	if err != nil {
+		t.Fatalf("LoadSessionMeta(child): %v", err)
+	}
+	if childMeta.ParentSessionID != parentID {
+		t.Fatalf("child meta=%+v", childMeta)
+	}
+	// buildRPCParentSession writes 3 entries (U, A, U); the aside child copies
+	// all of them and diverges one past the tip.
+	if childMeta.DivergenceTurn != 4 {
+		t.Fatalf("child DivergenceTurn=%d, want 4", childMeta.DivergenceTurn)
+	}
+	if childMeta.ProfileID != "openai" || childMeta.Model != "gpt-5" {
+		t.Fatalf("child profile/model=%q/%q, want openai/gpt-5", childMeta.ProfileID, childMeta.Model)
+	}
+}
+
+// TestHubRPCThreadForkAsideRejectsTurnFields pins the contract that aside is
+// mutually exclusive with divergent-fork fields.
+func TestHubRPCThreadForkAsideRejectsTurnFields(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, "projects", "project-aside-0000000000")
+	parentID := buildRPCParentSession(t, stateDir)
+	past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+	if err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{Past: past})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	err := client.Request(context.Background(), appwire.MethodThreadFork, appwire.ThreadForkParams{
+		Ref:          "local:" + parentID,
+		Aside:        true,
+		SourceTurnID: "1",
+		EditedInput:  "edit",
+	}, &appwire.ThreadForkResponse{})
+	if err == nil {
+		t.Fatal("ThreadFork(aside+turn fields) succeeded, want invalid-params rejection")
+	}
+	var wire appwire.WireError
+	if !errors.As(err, &wire) || wire.Code != appwire.CodeInvalidParams {
+		t.Fatalf("error=%v, want InvalidParams wire error", err)
+	}
+}
+
+// TestHubRPCThreadForkAsideUnavailableForNonLocal pins that aside is a
+// local-serf-session feature: remote sources are never invoked with it.
+func TestHubRPCThreadForkAsideUnavailableForNonLocal(t *testing.T) {
+	source := &forkingRelaySource{
+		relayBroadcastSource: relayBroadcastSource{
+			id: "codex",
+			thread: appwire.Thread{
+				ID:        "th_aside",
+				SessionID: "th_aside",
+				Source:    "codex",
+				Serf:      appwire.SerfThread{Ref: "codex:th_aside", Capabilities: appwire.ThreadCapabilities{ForkFromTurn: true}},
+			},
+			notifications: make(chan appwire.Notification, 1),
+			canceled:      make(chan struct{}, 1),
+		},
+	}
+	srv := httptest.NewUnstartedServer(nil)
+	web := NewWebServer(hubcore.WebConfig{HubAddr: srv.Listener.Addr().String(), Past: hubcore.NewPastIndex("")})
+	web.sources.Add(source)
+	srv.Config.Handler = web.Handler()
+	srv.Start()
+	defer srv.Close()
+
+	client := dialHubRPC(t, srv)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	err := client.Request(context.Background(), appwire.MethodThreadFork, appwire.ThreadForkParams{
+		Ref:   "codex:th_aside",
+		Aside: true,
+	}, &appwire.ThreadForkResponse{})
+	if err == nil {
+		t.Fatal("ThreadFork(aside) succeeded for a non-local source")
+	}
+	if source.forkCalled {
+		t.Fatal("aside reached the non-local source")
+	}
+	var wire appwire.WireError
+	if !errors.As(err, &wire) || wire.Code != appwire.CodeUnavailable {
+		t.Fatalf("error=%v, want Unavailable wire error", err)
+	}
+}

--- a/cmd/serf-hub/app_aside_test.go
+++ b/cmd/serf-hub/app_aside_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
@@ -136,5 +138,50 @@ func TestHubRPCThreadForkAsideUnavailableForNonLocal(t *testing.T) {
 	var wire appwire.WireError
 	if !errors.As(err, &wire) || wire.Code != appwire.CodeUnavailable {
 		t.Fatalf("error=%v, want Unavailable wire error", err)
+	}
+}
+
+// TestWeb_Aside_CallsAsideSession verifies the REST fallback the webui command
+// palette uses when appwire is unavailable: POST /s/<id>/aside forks the
+// session at its tip and returns the child session id.
+func TestWeb_Aside_CallsAsideSession(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, "projects", "project-aside-0000000000")
+	parentID := buildRPCParentSession(t, stateDir)
+	past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+	if err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+
+	web := NewWebServer(hubcore.WebConfig{
+		HubAddr:  "127.0.0.1:9180",
+		Roster:   hubcore.NewRoster(t.TempDir(), nil),
+		Past:     past,
+		StateDir: stateDir,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/s/"+parentID+"/aside", nil)
+	req.Host = "127.0.0.1:9180"
+	req.Header.Set("Origin", "http://127.0.0.1:9180")
+	rec := httptest.NewRecorder()
+	web.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%q", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		ChildSessionID string `json:"child_session_id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v body=%q", err, rec.Body.String())
+	}
+	if body.ChildSessionID == "" || body.ChildSessionID == parentID {
+		t.Fatalf("child_session_id=%q", body.ChildSessionID)
+	}
+	childMeta, err := schema.LoadSessionMeta(stateDir, body.ChildSessionID)
+	if err != nil {
+		t.Fatalf("LoadSessionMeta(child): %v", err)
+	}
+	if childMeta.ParentSessionID != parentID || childMeta.DivergenceTurn != 4 {
+		t.Fatalf("child meta=%+v", childMeta)
 	}
 }

--- a/cmd/serf-hub/app_threadlifecycle.go
+++ b/cmd/serf-hub/app_threadlifecycle.go
@@ -26,6 +26,7 @@ var (
 	hubRosterRefresh   = func(r *hubcore.Roster) { r.Refresh() }
 	hubRosterList      = func(r *hubcore.Roster) []hubcore.LiveEntry { return r.List() }
 	hubForkSession     = agent.ForkSession
+	hubAsideSession    = agent.AsideSession
 	hubEnsureSource    = func(ctx context.Context, launcher *codexlaunch.CodexLauncher, id string, sources *appsource.Registry) (appsource.Source, error) {
 		return launcher.EnsureSource(ctx, id, sources)
 	}
@@ -307,6 +308,9 @@ func hubThreadFork(ctx context.Context, cfg hubcore.WebConfig, sources *appsourc
 		return appwire.ThreadForkResponse{}, err
 	}
 	if ref.SourceID != "local" {
+		if params.Aside {
+			return appwire.ThreadForkResponse{}, appwire.Unavailable("aside is only supported for local serf threads")
+		}
 		source, err := sourceForThreadWithManagedLaunch(ctx, cfg, sources, params.Ref, "")
 		if err != nil {
 			return appwire.ThreadForkResponse{}, err
@@ -317,6 +321,34 @@ func hubThreadFork(ctx context.Context, cfg hubcore.WebConfig, sources *appsourc
 			}
 		}
 		return source.ForkThread(ctx, params)
+	}
+	if params.Aside {
+		if strings.TrimSpace(params.SourceTurnID) != "" || strings.TrimSpace(params.EditedInput) != "" || strings.TrimSpace(params.Label) != "" {
+			return appwire.ThreadForkResponse{}, appwire.InvalidParams("aside does not accept sourceTurnId, editedInput, or label")
+		}
+		stateDir := cfg.StateDir
+		if cfg.Past != nil {
+			if pe, ok := cfg.Past.Find(ref.ThreadID); ok {
+				stateDir = pe.StateDir
+			}
+		}
+		if stateDir == "" {
+			return appwire.ThreadForkResponse{}, appwire.Unavailable("state dir not resolvable for parent thread")
+		}
+		childID, err := hubAsideSession(stateDir, ref.ThreadID)
+		if err != nil {
+			return appwire.ThreadForkResponse{}, err
+		}
+		if cfg.Past != nil {
+			_ = cfg.Past.Rebuild()
+		}
+		childRef := appwire.Ref{SourceID: "local", ThreadID: childID}.String()
+		return appwire.ThreadForkResponse{Thread: appwire.Thread{
+			ID:        childID,
+			SessionID: childID,
+			Source:    "local",
+			Serf:      appwire.SerfThread{Ref: childRef},
+		}}, nil
 	}
 	turn, err := parseSourceTurnID(params.SourceTurnID)
 	if err != nil {

--- a/cmd/serf-hub/assets/appwire.js
+++ b/cmd/serf-hub/assets/appwire.js
@@ -610,6 +610,19 @@
     });
   }
 
+  // asideThread forks the session at its tip (thread/fork aside mode) into a
+  // side thread that inherits the session's permissions and config. Used by
+  // the /aside palette command.
+  function asideThread(sessionId) {
+    return request(METHOD.threadFork, {
+      ref: refForSession(sessionId),
+      aside: true,
+    }).then((resp) => {
+      const thread = resp.thread || {};
+      return { ref: threadRef(thread), session_id: threadID(thread) };
+    });
+  }
+
   function firstNonEmpty() {
     for (const value of arguments) {
       if (value) return value;
@@ -1100,6 +1113,7 @@
     setModel,
     setReasoningEffort,
     forkThread,
+    asideThread,
     eventsFromThread,
     eventsFromTurns,
     activeTurnIDFromThread,

--- a/cmd/serf-hub/assets/search.js
+++ b/cmd/serf-hub/assets/search.js
@@ -206,6 +206,33 @@
       });
   }
 
+  // asideSession forks the current session at its tip into a side thread
+  // (same permissions and config) and opens it, leaving the main session
+  // untouched. AppWire thread/fork aside mode when available, else the
+  // /s/<id>/aside REST fallback.
+  function asideSession(ctx) {
+    if (!ctx.sessionId) return Promise.resolve();
+    const promise = (window.SerfAppwire && typeof window.SerfAppwire.asideThread === "function")
+      ? window.SerfAppwire.asideThread(ctx.sessionId)
+      : fetch("/s/" + encodeURIComponent(ctx.sessionId) + "/aside", { method: "POST" })
+          .then(function (resp) {
+            if (!resp.ok) {
+              return Promise.resolve(typeof resp.text === "function" ? resp.text() : "").then(function (body) {
+                throw new Error(String(body || "").trim() || ("HTTP " + resp.status));
+              });
+            }
+            return resp.json();
+          });
+    return Promise.resolve(promise).then(function (result) {
+      const childID = result && (result.session_id || result.child_session_id || result.ref);
+      if (!childID) throw new Error("aside returned no child session");
+      // Refresh sidebar so the side thread shows up, then open it.
+      if (window.htmx) htmx.trigger(document.body, "sidebar:refresh");
+      Nav.go("/s/" + encodeURIComponent(childID));
+      return result;
+    });
+  }
+
   function postSession(ctx, action) {
     if (!ctx.sessionId) return Promise.resolve();
     const turnId = activeTurnId();
@@ -328,6 +355,11 @@
         run: (ctx) => postSession(ctx, "interrupt") },
       { id: "clear", title: "Clear context", hint: "start fresh in this session", keywords: [], scope: "session",
         run: (ctx) => postSession(ctx, "clear") },
+      // aside — fork this session at its tip into a side thread (same
+      // permissions and config) and open it, for asking a distracting
+      // question without derailing the main session.
+      { id: "aside", title: "Aside: fork to side thread", hint: "side question, same permissions", keywords: ["fork", "side"], scope: "session",
+        run: (ctx) => asideSession(ctx) },
       { id: "shutdown", title: "Shut down daemon", hint: "ends this session", keywords: ["kill"], scope: "session",
         run: (ctx) => {
           const p = postSession(ctx, "shutdown");

--- a/cmd/serf-hub/jstest/test-search-aside.js
+++ b/cmd/serf-hub/jstest/test-search-aside.js
@@ -1,0 +1,135 @@
+// JSDOM tests for the search palette's /aside command: fork the current
+// session at its tip into a side thread and open it.
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+
+// thread-state.js defines window.SerfThreadState; production loads it first
+// (templates/app.html), so prepend it here.
+const threadStateSrc = fs.readFileSync(path.resolve(__dirname, "../assets/thread-state.js"), "utf8");
+const searchSrc = threadStateSrc + "\n" + fs.readFileSync(path.resolve(__dirname, "../assets/search.js"), "utf8");
+
+const failures = [];
+const pass = (cond, msg) => { if (!cond) failures.push("FAIL: " + msg); };
+
+function paletteHTML() {
+  return `
+    <dialog id="search-dialog">
+      <div class="search-dialog-inner">
+        <header class="search-dialog-header">
+          <span class="search-icon">🔍</span>
+          <input id="search-input" type="text" placeholder="search live + past sessions">
+          <span class="search-dialog-hint">esc</span>
+        </header>
+        <div id="search-results" class="search-results"></div>
+      </div>
+    </dialog>`;
+}
+
+function makeDom(extraBody, opts) {
+  const url = (opts && opts.url) || "http://localhost/";
+  return new JSDOM(`<!DOCTYPE html><html><body>${paletteHTML()}${extraBody || ""}</body></html>`,
+    { runScripts: "outside-only", pretendToBeVisual: true, url: url });
+}
+
+async function loadAndOpen(dom) {
+  const { window } = dom;
+  const dlg = window.document.getElementById("search-dialog");
+  if (typeof dlg.showModal !== "function") {
+    dlg.showModal = function () { this.setAttribute("open", ""); this.open = true; };
+    dlg.close = function () { this.removeAttribute("open"); this.open = false; };
+  }
+  window.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve({ live: [], past: [] }) });
+  window.eval(searchSrc);
+  await new Promise(r => setTimeout(r, 30)); // let DOMContentLoaded fire
+  return { window: window, dialog: dlg, input: window.document.getElementById("search-input"), results: window.document.getElementById("search-results") };
+}
+
+function tick(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+async function runAside(ctx) {
+  ctx.window.SerfSearch.open();
+  ctx.input.value = "/aside";
+  ctx.input.dispatchEvent(new ctx.window.Event("input", { bubbles: true }));
+  await tick(20);
+  ctx.input.dispatchEvent(new ctx.window.KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+  await tick(30);
+}
+
+(async function run() {
+  // -------- Scenario 1: "/aside" filters to the Aside command --------
+  {
+    const dom = makeDom(`<div id="conversation" data-session-id="01S" data-state="live"></div>`,
+      { url: "http://localhost/s/01S" });
+    const ctx = await loadAndOpen(dom);
+    ctx.window.SerfSearch.open();
+    ctx.input.value = "/asi";
+    ctx.input.dispatchEvent(new ctx.window.Event("input", { bubbles: true }));
+    await tick(20);
+    pass(/Aside/.test(ctx.results.innerHTML), '"/asi" matches the Aside command');
+  }
+
+  // -------- Scenario 2: appwire path forks at tip and opens the side thread --------
+  {
+    const dom = makeDom(`<div id="conversation" data-session-id="01S" data-state="live"></div>`,
+      { url: "http://localhost/s/01S" });
+    const ctx = await loadAndOpen(dom);
+    const calls = [];
+    const navs = [];
+    let sidebarRefresh = 0;
+    ctx.window.SerfAppwire = {
+      asideThread: (sessionId) => {
+        calls.push(sessionId);
+        return Promise.resolve({ ref: "local:child1", session_id: "child1" });
+      },
+    };
+    ctx.window.htmx = { trigger: () => { sidebarRefresh += 1; } };
+    ctx.window.SerfSearch.Nav.go = (url) => { navs.push(url); };
+    await runAside(ctx);
+    pass(calls.length === 1 && calls[0] === "01S", "asideThread called once with current session id (got " + JSON.stringify(calls) + ")");
+    pass(navs.length === 1 && navs[0] === "/s/child1", "navigates to the aside child session (got " + JSON.stringify(navs) + ")");
+    pass(sidebarRefresh === 1, "sidebar refresh triggered so the side thread shows up");
+    pass(ctx.dialog.open === false, "dialog closes after aside succeeds");
+  }
+
+  // -------- Scenario 3: REST fallback posts to /s/<id>/aside --------
+  {
+    const dom = makeDom(`<div id="conversation" data-session-id="01S" data-state="live"></div>`,
+      { url: "http://localhost/s/01S" });
+    const ctx = await loadAndOpen(dom);
+    const fetches = [];
+    const navs = [];
+    ctx.window.fetch = (url, opts) => {
+      fetches.push({ url: url, method: opts && opts.method });
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ child_session_id: "child2" }) });
+    };
+    ctx.window.SerfSearch.Nav.go = (url) => { navs.push(url); };
+    await runAside(ctx);
+    pass(fetches.length === 1 && fetches[0].url === "/s/01S/aside" && fetches[0].method === "POST",
+      "REST fallback posts to /s/01S/aside (got " + JSON.stringify(fetches) + ")");
+    pass(navs.length === 1 && navs[0] === "/s/child2", "REST fallback navigates to the child session (got " + JSON.stringify(navs) + ")");
+  }
+
+  // -------- Scenario 4: failure keeps the palette open with an inline error --------
+  {
+    const dom = makeDom(`<div id="conversation" data-session-id="01S" data-state="live"></div>`,
+      { url: "http://localhost/s/01S" });
+    const ctx = await loadAndOpen(dom);
+    const navs = [];
+    ctx.window.SerfAppwire = {
+      asideThread: () => Promise.reject(new Error("aside is only supported for local serf threads")),
+    };
+    ctx.window.SerfSearch.Nav.go = (url) => { navs.push(url); };
+    await runAside(ctx);
+    pass(navs.length === 0, "failed aside does not navigate");
+    pass(ctx.dialog.open === true, "dialog stays open after aside failure");
+    pass(/aside is only supported for local serf threads/.test(ctx.results.innerHTML),
+      "inline palette error shows the failure (got " + JSON.stringify(ctx.results.textContent) + ")");
+  }
+
+  if (failures.length) {
+    console.error(failures.join("\n"));
+    process.exit(1);
+  }
+  console.log("ok");
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/cmd/serf-hub/web_session.go
+++ b/cmd/serf-hub/web_session.go
@@ -551,12 +551,56 @@ func (s *WebServer) handleAPIFork(w http.ResponseWriter, r *http.Request, parent
 	})
 }
 
+func (s *WebServer) handleAside(w http.ResponseWriter, r *http.Request, parentID string) {
+	childID, err := s.asideSession(parentID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"child_session_id": childID}) //nolint:errcheck
+}
+
+// asideSession forks the parent session at its tip into a side thread that
+// inherits the parent's permissions and config (agent.AsideSession).
+func (s *WebServer) asideSession(parentID string) (string, error) {
+	stateDir, err := s.stateDirForSession(parentID)
+	if err != nil {
+		return "", err
+	}
+	childID, err := agent.AsideSession(stateDir, parentID)
+	if err != nil {
+		return "", err
+	}
+	// Refresh past index so the new session shows up immediately in the sidebar.
+	if s.cfg.Past != nil {
+		_ = s.cfg.Past.Rebuild()
+	}
+	return childID, nil
+}
+
 func (s *WebServer) forkSession(parentID string, body forkRequest) (string, error) {
-	// Resolve the state dir for the parent session. Forks must write into
-	// the same project's state-dir as the parent (so they appear in the
-	// project tree). Past index knows the per-project state-dir; cfg.StateDir
-	// is the parent of all projects and would point ForkSession at the wrong
-	// directory.
+	stateDir, err := s.stateDirForSession(parentID)
+	if err != nil {
+		return "", err
+	}
+
+	childID, err := agent.ForkSession(stateDir, parentID, body.Turn, body.EditedMessage, body.Label)
+	if err != nil {
+		return "", err
+	}
+	// Refresh past index so the new session shows up immediately in the sidebar.
+	if s.cfg.Past != nil {
+		_ = s.cfg.Past.Rebuild()
+	}
+	return childID, nil
+}
+
+// stateDirForSession resolves the state dir for a session. Branches must write
+// into the same project's state-dir as the parent (so they appear in the
+// project tree). Past index knows the per-project state-dir; cfg.StateDir is
+// the parent of all projects and would point the fork at the wrong directory.
+func (s *WebServer) stateDirForSession(parentID string) (string, error) {
 	var stateDir string
 	if s.cfg.Past != nil {
 		if pe, ok := s.cfg.Past.Find(parentID); ok {
@@ -569,16 +613,7 @@ func (s *WebServer) forkSession(parentID string, body forkRequest) (string, erro
 	if stateDir == "" {
 		return "", errors.New("state dir not resolvable for parent session")
 	}
-
-	childID, err := agent.ForkSession(stateDir, parentID, body.Turn, body.EditedMessage, body.Label)
-	if err != nil {
-		return "", err
-	}
-	// Refresh past index so the new session shows up immediately in the sidebar.
-	if s.cfg.Past != nil {
-		_ = s.cfg.Past.Rebuild()
-	}
-	return childID, nil
+	return stateDir, nil
 }
 
 // waitForRosterMatch polls the roster until it sees a daemon with the given PID

--- a/cmd/serf-hub/web_workspace.go
+++ b/cmd/serf-hub/web_workspace.go
@@ -63,6 +63,12 @@ func (s *WebServer) handleSession(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.handleFork(w, r, id)
+	case "aside":
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST required", http.StatusMethodNotAllowed)
+			return
+		}
+		s.handleAside(w, r, id)
 	case "interrupt":
 		s.handleSessionAction(w, r, id, "interrupt")
 	case "compact":

--- a/cmd/serf-tui/hub_aside_test.go
+++ b/cmd/serf-tui/hub_aside_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"primeradiant.com/serf/appwire"
+	"primeradiant.com/serf/internal/appserver"
+)
+
+// TestSendHubAsideForksAtTip verifies the /aside dispatch sends thread/fork in
+// aside mode — no source turn, no edited input — and reports the child ref.
+func TestSendHubAsideForksAtTip(t *testing.T) {
+	app := appserver.NewServer(appserver.ServerConfig{
+		ServerName: "hub",
+		SourceID:   "local",
+		Features:   appwire.FeatureSet{},
+	})
+	var got appwire.ThreadForkParams
+	appserver.HandleTyped(app.Router(), appwire.MethodThreadFork, func(_ context.Context, params appwire.ThreadForkParams) (appwire.ThreadForkResponse, error) {
+		got = params
+		return appwire.ThreadForkResponse{Thread: appwire.Thread{
+			ID:        "child1",
+			SessionID: "child1",
+			Source:    "local",
+			Serf:      appwire.SerfThread{Ref: "local:child1"},
+		}}, nil
+	})
+	client, cleanup := newTUIAppWireClient(t, app)
+	defer cleanup()
+
+	msg := sendHubAside(client, appwire.Ref{SourceID: "local", ThreadID: "01PARENT"})()
+	forkMsg, ok := msg.(hubForkMsg)
+	if !ok || forkMsg.err != nil {
+		t.Fatalf("msg=%T err=%v", msg, forkMsg.err)
+	}
+	if !forkMsg.aside {
+		t.Fatal("hubForkMsg.aside = false, want true for the /aside path")
+	}
+	if got.Ref != "local:01PARENT" {
+		t.Fatalf("params.Ref=%q, want local:01PARENT", got.Ref)
+	}
+	if !got.Aside {
+		t.Fatalf("params.Aside=%v, want true", got.Aside)
+	}
+	if got.SourceTurnID != "" || got.EditedInput != "" || got.Label != "" {
+		t.Fatalf("aside must not carry divergent-fork fields: %+v", got)
+	}
+	if forkMsg.resp.Ref != "local:child1" {
+		t.Fatalf("fork response ref=%q, want local:child1", forkMsg.resp.Ref)
+	}
+}
+
+// TestHubModelAsideCommandDispatches verifies /aside runs from the session
+// slash-command path when the source advertises fork.
+func TestHubModelAsideCommandDispatches(t *testing.T) {
+	m := newSessionHubModel(nil)
+	m.detail.Capabilities.Fork = true
+	m.session.setInputValue("/aside")
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("/aside should dispatch an async command when fork is available")
+	}
+}
+
+// TestHubModelAsideCommandUnavailableWithoutFork pins the capability gate:
+// without an advertised fork capability the command explains itself instead of
+// issuing an RPC.
+func TestHubModelAsideCommandUnavailableWithoutFork(t *testing.T) {
+	m := newSessionHubModel(nil)
+	m.detail.Capabilities.Fork = false
+	m.session.setInputValue("/aside")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatal("/aside must not issue an RPC when fork is unavailable")
+	}
+	um := updated.(hubModel)
+	got := um.sessionView()
+	if !strings.Contains(got, "Aside is not available for this session.") {
+		t.Fatalf("unavailable notice missing:\n%s", got)
+	}
+}
+
+// TestHubModelAsideFailureMessage verifies an aside failure is attributed to
+// the aside command, not to fork-from-turn.
+func TestHubModelAsideFailureMessage(t *testing.T) {
+	m := newSessionHubModel(nil)
+	m.detail.Capabilities.Fork = true
+
+	updated, _ := m.Update(hubForkMsg{aside: true, err: errors.New("appwire thread/fork: boom")})
+	um := updated.(hubModel)
+	got := um.sessionView()
+	if !strings.Contains(got, "Aside failed: appwire thread/fork: boom") {
+		t.Fatalf("aside failure message missing:\n%s", got)
+	}
+}
+
+// TestHubModelHelpIncludesAside pins /aside in help and palette when fork is
+// advertised, and its absence otherwise.
+func TestHubModelHelpIncludesAside(t *testing.T) {
+	m := newSessionHubModel(nil)
+	m.detail.Capabilities = hubSessionCapabilities{Fork: true}
+	help := hubSlashCommandHelp(m.detail.Capabilities)
+	if !strings.Contains(help, "/aside") {
+		t.Fatalf("help missing /aside with fork capability:\n%s", help)
+	}
+
+	m.detail.Capabilities = hubSessionCapabilities{Send: true}
+	help = hubSlashCommandHelp(m.detail.Capabilities)
+	if strings.Contains(help, "/aside") {
+		t.Fatalf("help advertised /aside without fork capability:\n%s", help)
+	}
+}

--- a/cmd/serf-tui/hub_command_registry.go
+++ b/cmd/serf-tui/hub_command_registry.go
@@ -283,6 +283,24 @@ var hubCommandRegistry = []hubCommandDefinition{
 		},
 	},
 	{
+		Name:               "aside",
+		Summary:            "Fork session into a side thread",
+		PaletteLabel:       "/aside",
+		PaletteDetail:      "fork this session into a side thread (same permissions and config)",
+		Scopes:             hubCommandSession,
+		UnavailableAction:  "aside",
+		UnavailableSummary: "Aside is not available for this session.",
+		Available:          capabilityAvailable(func(c hubSessionCapabilities) bool { return c.Fork }, "source does not advertise fork"),
+		Run: func(m *hubModel, _ string) tea.Cmd {
+			ref, ok := m.currentRef()
+			if !ok {
+				m.addSessionSystem("Session ref is invalid.")
+				return nil
+			}
+			return sendHubAside(m.client, ref)
+		},
+	},
+	{
 		Name:               "shutdown",
 		Summary:            "Stop this resumable session",
 		PaletteLabel:       "/shutdown",

--- a/cmd/serf-tui/hub_commands.go
+++ b/cmd/serf-tui/hub_commands.go
@@ -86,9 +86,13 @@ type hubGoalMsg struct {
 	err     error
 }
 
+// hubForkMsg reports the result of a thread/fork call. aside distinguishes the
+// /aside tip-fork (side thread) from the divergent fork-from-turn flow so
+// failures are attributed to the right command.
 type hubForkMsg struct {
-	resp hubRefResponse
-	err  error
+	resp  hubRefResponse
+	err   error
+	aside bool
 }
 
 type hubSpawnMsg struct {
@@ -684,6 +688,20 @@ func sendHubFork(client *appwire.Client, ref appwire.Ref, req hubForkRequest) te
 			Label:        req.Label,
 		})
 		return hubForkMsg{resp: hubRefResponse{Ref: resp.Thread.Serf.Ref}, err: err}
+	}
+}
+
+// sendHubAside issues the /aside fork: thread/fork in aside mode forks the
+// session at its tip into a side thread that inherits this session's
+// permissions and config. The success path mirrors fork: the update loop opens
+// the returned child thread.
+func sendHubAside(client *appwire.Client, ref appwire.Ref) tea.Cmd {
+	return func() tea.Msg {
+		resp, err := client.ThreadFork(context.Background(), appwire.ThreadForkParams{
+			Ref:   ref.String(),
+			Aside: true,
+		})
+		return hubForkMsg{resp: hubRefResponse{Ref: resp.Thread.Serf.Ref}, err: err, aside: true}
 	}
 }
 

--- a/cmd/serf-tui/hub_model_test.go
+++ b/cmd/serf-tui/hub_model_test.go
@@ -3557,7 +3557,7 @@ func TestHubModelHelpAndPaletteShareSessionCommands(t *testing.T) {
 	}
 	palette := m.commandPalette.View()
 
-	for _, command := range []string{"/help", "/tasks", "/agents", "/auth", "/login", "/logout", "/model", "/effort", "/clear", "/fork", "/shutdown", "/theme", "/dashboard", "/project"} {
+	for _, command := range []string{"/help", "/tasks", "/agents", "/auth", "/login", "/logout", "/model", "/effort", "/clear", "/fork", "/aside", "/shutdown", "/theme", "/dashboard", "/project"} {
 		if !strings.Contains(help, command) {
 			t.Fatalf("help missing command %q:\n%s", command, help)
 		}

--- a/cmd/serf-tui/hub_update.go
+++ b/cmd/serf-tui/hub_update.go
@@ -377,7 +377,11 @@ func (m hubModel) updateImpl(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.forkDraft != nil {
 				m.forkDraft.Submitting = false
 			}
-			m.recordSessionError("Fork failed: " + msg.err.Error())
+			if msg.aside {
+				m.recordSessionError("Aside failed: " + msg.err.Error())
+			} else {
+				m.recordSessionError("Fork failed: " + msg.err.Error())
+			}
 			return m, nil
 		}
 		m.clearSessionError()

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -93,7 +93,7 @@ no router (reserved).
 | `thread/turns/items/list` | unimplemented | `ThreadTurnItemsListParams` | `ThreadTurnItemsListResponse` | Codex-parity: paginated items for one turn. Experimental even in Codex (returns method-not-supported) and served by no serf router. |
 | `thread/start` | hub | `ThreadStartParams` | `ThreadStartResponse` | Starts a new thread and attaches a live-update relay. |
 | `thread/resume` | hub | `ThreadResumeParams` | `ThreadResumeResponse` | Resumes an existing session and attaches its relay. |
-| `thread/fork` | hub | `ThreadForkParams` | `ThreadForkResponse` | Forks a thread from a source turn, optionally with edited input. |
+| `thread/fork` | hub | `ThreadForkParams` | `ThreadForkResponse` | Forks a thread from a source turn, optionally with edited input. With `aside: true` (local serf threads only; mutually exclusive with sourceTurnId/editedInput/label), forks the session at its tip into a side thread that inherits the parent's permissions and config. |
 | `thread/clear` | both | `ThreadClearParams` | `ThreadClearResponse` | Clears the thread's conversation (rejected while a turn is processing). |
 | `thread/model/set` | both | `ThreadModelSetParams` | `EmptyResponse` | Changes the session's model/provider. |
 | `serf/thread/name/set` | both | `ThreadNameSetParams` | `EmptyResponse` | Sets a user-chosen session title (rename). |

--- a/docs/subagent-runtime-contracts.md
+++ b/docs/subagent-runtime-contracts.md
@@ -221,6 +221,10 @@ Fork and subagent are **distinct relations** sharing lineage fields, kept explic
 - **Fork copies history; a subagent starts fresh.** `ForkSession` (`agent/fork.go`)
   replays the parent's first `divergenceTurn-1` entries into the child transcript; a
   spawned subagent gets a new empty session with only a lineage pointer.
+  `AsideSession` (`agent/aside.go`) is the degenerate fork at the tip: it copies the
+  parent's full transcript with no divergent edit, records `DivergenceTurn` one past
+  the tip, and inherits the parent's config — the machinery behind the `/aside`
+  side-thread command.
 - **Lineage lives in metadata and headers, discoverable without reading transcript
   bodies.** `SessionMeta` (`agent/schema/snapshot.go`) carries `ParentSessionID`,
   `DivergenceTurn`, `ForkLabel`, and `IsSubagent`; the transcript `Header`


### PR DESCRIPTION
## Summary

Adds an `aside` command that forks the current session at its tip into a side thread with the same permissions and config — for asking a distracting question about the main session without derailing it. Built on the existing fork machinery rather than introducing a new session-tree concept.

Closes #43

## Design

- **Fork mechanics** — new `agent.AsideSession(stateDir, parentID)`: a fork at the tip. The child transcript is a complete copy of the parent's (no divergent edit, may end on an assistant turn — something `ForkSession` cannot express), child meta records `ParentSessionID` and `DivergenceTurn = len(entries)+1`, and the parent is left untouched. `agent/fork.go` was refactored to share the parent-scan (`readForkParent`) and child-write (`writeForkChild`) machinery between both operations; `ForkSession` behavior is unchanged.
- **Config/permission inheritance** — the child meta inherits the parent's `Config` (sandbox mode, tool allowances, etc.), ProfileID, Model, and EnvInfo, exactly like `ForkSession`; on resume the child restores from that meta, so it runs with identical permissions and config.
- **RPC** — additive `aside` flag on appwire `thread/fork` params (aside *is* a fork mode; TUI and webui already speak `thread/fork`). Hub: local refs + `aside:true` → `agent.AsideSession`; combined with sourceTurnId/editedInput/label → InvalidParams; non-local (Codex) refs → Unavailable.
- **Side-thread model** — no session-tree redesign: the aside child is an ordinary fork-kind session appearing under its parent via existing `ParentSessionID` lineage (sidebar / past index), and opening it resumes a normal serf session.
- **Command surface** (both existing patterns):
  - TUI `/aside` (session scope, gated on the advertised fork capability): sends `thread/fork{aside:true}` and opens the returned child thread; failures surface as `Aside failed: …`.
  - WebUI palette command "Aside: fork to side thread": `SerfAppwire.asideThread` → `thread/fork{aside:true}`, with a `POST /s/<id>/aside` REST fallback (snake_case `{child_session_id}`). Success: sidebar refresh + navigate to the child; failure: palette stays open with an inline error.

## Test evidence

TDD per layer (RED captured, then GREEN); all deterministic — scripted appwire servers/transports and temp-dir session state, no LLM/network/credentials.

- agent: `TestAsideSession_CopiesFullTranscriptAtTip` (4-entry copy incl. trailing assistant turn, config/sandbox inheritance, lineage, parent untouched), restore-as-side-thread, empty-parent, missing-parent.
- hub: `TestHubRPCThreadForkAsideCreatesSideThread`, `…RejectsTurnFields` (InvalidParams), `…UnavailableForNonLocal`; REST `TestWeb_Aside_CallsAsideSession`.
- tui: `TestSendHubAsideForksAtTip`, dispatch, capability gate, `Aside failed:` attribution, help/palette inclusion.
- webui: `jstest/test-search-aside.js` — filter match, appwire path (asideThread + navigate + sidebar refresh), REST fallback, failure keeps palette open with inline error.

Full suites green on the rebased tree (byte-identical to the tested lane): `go test ./agent ./appwire ./cmd/serf-tui ./cmd/serf-hub/...`, full jstest loop (196 files), `go vet`, `make lint-naming lint-internal fuzz-registry-check fuzz-gap-check`.
