### PR TITLE
webui: fork any message into the composer for editing (#42)

### DIFF
--- a/agent/cov_w3init_fork_test.go
+++ b/agent/cov_w3init_fork_test.go
@@ -73,7 +73,7 @@ func TestW3Init_ForkSession_OpenError(t *testing.T) {
 	id := "01W3FORKOPENDENIED0000001"
 	fs := fault.FS(afero.NewMemMapFs(), fault.FromBytes([]byte{0}))
 
-	_, err := forkSessionFS(fs, stateDir, id, 1, "x", "")
+	_, _, err := forkSessionFS(fs, stateDir, id, 1, "x", false, "")
 	if err == nil || !strings.Contains(err.Error(), "open parent transcript") {
 		t.Fatalf("err = %v, want open parent transcript error", err)
 	}
@@ -120,7 +120,7 @@ func TestW3Init_ForkSession_NewWriterError(t *testing.T) {
 		Fs:                   base,
 		parentTranscriptPath: parentPath,
 	}
-	_, err := forkSessionFS(fs, stateDir, id, 1, "x", "")
+	_, _, err := forkSessionFS(fs, stateDir, id, 1, "x", false, "")
 	if err == nil || !strings.Contains(err.Error(), "create child transcript") {
 		t.Fatalf("err = %v, want create child transcript error", err)
 	}

--- a/agent/fork.go
+++ b/agent/fork.go
@@ -28,11 +28,27 @@ import (
 // If parentForkLabel is non-empty, the parent's meta is updated with that label so the
 // parent branch can be identified in session listings.
 func ForkSession(stateDir, parentID string, divergenceTurn int, editedMessage, parentForkLabel string) (string, error) {
-	return forkSessionFS(afero.NewOsFs(), stateDir, parentID, divergenceTurn, editedMessage, parentForkLabel)
+	childID, _, err := forkSessionFS(afero.NewOsFs(), stateDir, parentID, divergenceTurn, editedMessage, false, parentForkLabel)
+	return childID, err
 }
 
-func forkSessionFS(fs afero.Fs, stateDir, parentID string, divergenceTurn int, editedMessage, parentForkLabel string) (string, error) {
-	return forkSessionWithDeps(fs, stateDir, parentID, divergenceTurn, editedMessage, parentForkLabel, forkSessionDeps{
+// ForkSessionAtUserTurn creates a new session branched from a parent session at a
+// given divergence turn WITHOUT appending a replacement message (issue #42).
+//
+// divergenceTurn is a 1-based index into the parent's full entry list (all turns,
+// not just USER_INPUT) and must point at a USER_INPUT turn. The child transcript
+// contains only the entries BEFORE that turn, so opening the fork never auto-runs
+// anything: the original text of the diverging user message is returned to the
+// caller, which hands it back to the user for editing and explicit submission.
+//
+// If parentForkLabel is non-empty, the parent's meta is updated with that label so
+// the parent branch can be identified in session listings.
+func ForkSessionAtUserTurn(stateDir, parentID string, divergenceTurn int, parentForkLabel string) (childID, originalInput string, err error) {
+	return forkSessionFS(afero.NewOsFs(), stateDir, parentID, divergenceTurn, "", true, parentForkLabel)
+}
+
+func forkSessionFS(fs afero.Fs, stateDir, parentID string, divergenceTurn int, editedMessage string, deferInput bool, parentForkLabel string) (string, string, error) {
+	return forkSessionWithDeps(fs, stateDir, parentID, divergenceTurn, editedMessage, deferInput, parentForkLabel, forkSessionDeps{
 		newWriter: func(fs afero.Fs, path string, header transcript.Header) (forkTranscriptWriter, error) {
 			return transcript.NewWriterWithFS(fs, path, header)
 		},
@@ -52,9 +68,9 @@ type forkSessionDeps struct {
 	maxScanToken int
 }
 
-func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn int, editedMessage, parentForkLabel string, deps forkSessionDeps) (string, error) {
+func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn int, editedMessage string, deferInput bool, parentForkLabel string, deps forkSessionDeps) (string, string, error) {
 	if divergenceTurn < 1 {
-		return "", fmt.Errorf("divergenceTurn must be >= 1, got %d", divergenceTurn)
+		return "", "", fmt.Errorf("divergenceTurn must be >= 1, got %d", divergenceTurn)
 	}
 
 	transcriptPath := filepath.Join(stateDir, sessionsSubdir, parentID+".transcript.jsonl")
@@ -63,9 +79,9 @@ func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn 
 	f, err := fs.Open(transcriptPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", fmt.Errorf("parent transcript not found for session %s", parentID)
+			return "", "", fmt.Errorf("parent transcript not found for session %s", parentID)
 		}
-		return "", fmt.Errorf("open parent transcript: %w", err)
+		return "", "", fmt.Errorf("open parent transcript: %w", err)
 	}
 	defer func() { _ = f.Close() }() // read-only handle; close error is immaterial
 
@@ -80,10 +96,10 @@ func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn 
 	for {
 		line, complete, _, readErr := transcript.ReadLine(reader, maxScanToken)
 		if readErr != nil {
-			return "", fmt.Errorf("reading parent transcript header: %w", readErr)
+			return "", "", fmt.Errorf("reading parent transcript header: %w", readErr)
 		}
 		if !complete {
-			return "", errors.New("parent transcript is empty")
+			return "", "", errors.New("parent transcript is empty")
 		}
 		line = bytes.TrimSpace(line)
 		if len(line) == 0 {
@@ -91,7 +107,7 @@ func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn 
 		}
 		parentHeader, err = transcript.DecodeHeader(line)
 		if err != nil {
-			return "", fmt.Errorf("parsing parent transcript header: %w", err)
+			return "", "", fmt.Errorf("parsing parent transcript header: %w", err)
 		}
 		break
 	}
@@ -110,7 +126,7 @@ func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn 
 	for {
 		line, complete, _, readErr := transcript.ReadLine(reader, maxScanToken)
 		if readErr != nil {
-			return "", fmt.Errorf("reading parent transcript entries: %w", readErr)
+			return "", "", fmt.Errorf("reading parent transcript entries: %w", readErr)
 		}
 		if !complete {
 			break
@@ -122,7 +138,7 @@ func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn 
 
 		entry, err := transcript.DecodeEntry(line)
 		if err != nil {
-			return "", fmt.Errorf("parsing parent transcript entry: %w", err)
+			return "", "", fmt.Errorf("parsing parent transcript entry: %w", err)
 		}
 
 		allEntries = append(allEntries, entry)
@@ -130,13 +146,13 @@ func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn 
 
 	// Validate that divergenceTurn points to a valid entry in the parent transcript.
 	if divergenceTurn > len(allEntries) {
-		return "", fmt.Errorf("divergenceTurn %d exceeds parent turn count %d", divergenceTurn, len(allEntries))
+		return "", "", fmt.Errorf("divergenceTurn %d exceeds parent turn count %d", divergenceTurn, len(allEntries))
 	}
 
 	// The entry at the divergence position must be a USER_INPUT turn.
 	divergenceEntry := allEntries[divergenceTurn-1]
 	if divergenceEntry.Turn.Kind != schema.TurnUserInput {
-		return "", fmt.Errorf("entry at divergenceTurn %d is not a USER_INPUT turn (got %s)", divergenceTurn, divergenceEntry.Turn.Kind)
+		return "", "", fmt.Errorf("entry at divergenceTurn %d is not a USER_INPUT turn (got %s)", divergenceTurn, divergenceEntry.Turn.Kind)
 	}
 
 	// Prefix is all entries before the divergence position.
@@ -145,13 +161,13 @@ func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn 
 	// Load parent meta — required for copying fields to the child.
 	parentMeta, err := schema.LoadSessionMetaWithFS(fs, stateDir, parentID)
 	if err != nil {
-		return "", fmt.Errorf("load parent session meta: %w", err)
+		return "", "", fmt.Errorf("load parent session meta: %w", err)
 	}
 
 	// Mint a new child session ID.
 	childID, err := identifier.NewSessionID()
 	if err != nil {
-		return "", fmt.Errorf("generate child session ID: %w", err)
+		return "", "", fmt.Errorf("generate child session ID: %w", err)
 	}
 
 	// Build the child transcript header from the parent's fields.
@@ -174,7 +190,7 @@ func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn 
 	childTranscriptPath := filepath.Join(stateDir, sessionsSubdir, childID+".transcript.jsonl")
 	tw, err := deps.newWriter(fs, childTranscriptPath, childHeader)
 	if err != nil {
-		return "", fmt.Errorf("create child transcript: %w", err)
+		return "", "", fmt.Errorf("create child transcript: %w", err)
 	}
 	// Safety net for early error returns; the success path closes tw explicitly
 	// below (line ~165) and checks that error, after which this defer is a no-op.
@@ -185,7 +201,7 @@ func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn 
 	// Replay prefix entries into the child transcript.
 	for _, entry := range prefixEntries {
 		if err := tw.Append(entry.Turn); err != nil {
-			return "", fmt.Errorf("append prefix turn to child transcript: %w", err)
+			return "", "", fmt.Errorf("append prefix turn to child transcript: %w", err)
 		}
 		if entry.Turn.Kind == schema.TurnAssistant {
 			modelResponses++
@@ -195,15 +211,19 @@ func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn 
 		}
 	}
 
-	// Append the edited turn as a new USER_INPUT turn.
-	editedTurn := schema.NewTurn(schema.TurnUserInput, llm.User(editedMessage))
-	if err := tw.Append(editedTurn); err != nil {
-		return "", fmt.Errorf("append edited turn to child transcript: %w", err)
+	// Append the edited turn as a new USER_INPUT turn, unless the caller asked
+	// to defer the input (issue #42): then the child ends at the prefix and the
+	// original message text goes back to the caller for editing instead.
+	if !deferInput {
+		editedTurn := schema.NewTurn(schema.TurnUserInput, llm.User(editedMessage))
+		if err := tw.Append(editedTurn); err != nil {
+			return "", "", fmt.Errorf("append edited turn to child transcript: %w", err)
+		}
+		acceptedInputTurns++
 	}
-	acceptedInputTurns++
 
 	if err := tw.Close(); err != nil {
-		return "", fmt.Errorf("close child transcript: %w", err)
+		return "", "", fmt.Errorf("close child transcript: %w", err)
 	}
 
 	// Build and save the child meta.
@@ -224,16 +244,16 @@ func forkSessionWithDeps(fs afero.Fs, stateDir, parentID string, divergenceTurn 
 	}
 
 	if err := deps.saveMeta(fs, stateDir, childMeta); err != nil {
-		return "", fmt.Errorf("save child session meta: %w", err)
+		return "", "", fmt.Errorf("save child session meta: %w", err)
 	}
 
 	// Update the parent meta with the fork label if provided.
 	if parentForkLabel != "" {
 		parentMeta.ForkLabel = parentForkLabel
 		if err := deps.saveMeta(fs, stateDir, parentMeta); err != nil {
-			return "", fmt.Errorf("update parent session meta with fork label: %w", err)
+			return "", "", fmt.Errorf("update parent session meta with fork label: %w", err)
 		}
 	}
 
-	return childID, nil
+	return childID, divergenceEntry.Turn.Message.Text(), nil
 }

--- a/agent/fork_at_test.go
+++ b/agent/fork_at_test.go
@@ -1,0 +1,152 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"primeradiant.com/serf/agent/schema"
+	"primeradiant.com/serf/identifier"
+)
+
+// TestForkSessionAtUserTurn_CopiesPrefixWithoutAppendingInput verifies the
+// deferred-input fork (issue #42): the child transcript contains only the
+// entries BEFORE the divergence turn — the diverging USER_INPUT turn itself
+// is NOT copied or replaced — and the original text of that turn is returned
+// so the caller can hand it back for editing before submission. The forked
+// session must therefore never auto-run the message on open.
+func TestForkSessionAtUserTurn_CopiesPrefixWithoutAppendingInput(t *testing.T) {
+	t.Parallel()
+	stateDir, parentID := buildParentSession(t)
+
+	childID, originalInput, err := ForkSessionAtUserTurn(stateDir, parentID, 3, "original branch")
+	if err != nil {
+		t.Fatalf("ForkSessionAtUserTurn: %v", err)
+	}
+	if err := identifier.ValidateSessionID(childID); err != nil {
+		t.Fatalf("child session ID %q: %v", childID, err)
+	}
+	if childID == parentID {
+		t.Fatalf("childID should differ from parentID, got %q", childID)
+	}
+	if originalInput != "second task" {
+		t.Errorf("originalInput: got %q, want %q", originalInput, "second task")
+	}
+
+	// Child meta assertions.
+	childMeta, err := schema.LoadSessionMeta(stateDir, childID)
+	if err != nil {
+		t.Fatalf("LoadSessionMeta(child): %v", err)
+	}
+	if childMeta.ParentSessionID != parentID {
+		t.Errorf("child ParentSessionID: got %q, want %q", childMeta.ParentSessionID, parentID)
+	}
+	if childMeta.DivergenceTurn != 3 {
+		t.Errorf("child DivergenceTurn: got %d, want 3", childMeta.DivergenceTurn)
+	}
+	// Prefix [U1, A1] has one assistant turn and one accepted user input.
+	if childMeta.TurnCount != 1 {
+		t.Errorf("child TurnCount: got %d, want 1", childMeta.TurnCount)
+	}
+	if childMeta.AcceptedInputTurns != 1 {
+		t.Errorf("child AcceptedInputTurns: got %d, want 1", childMeta.AcceptedInputTurns)
+	}
+
+	// Parent meta carries the fork label.
+	parentMeta, err := schema.LoadSessionMeta(stateDir, parentID)
+	if err != nil {
+		t.Fatalf("LoadSessionMeta(parent): %v", err)
+	}
+	if parentMeta.ForkLabel != "original branch" {
+		t.Errorf("parent ForkLabel: got %q, want %q", parentMeta.ForkLabel, "original branch")
+	}
+
+	// Child transcript must contain ONLY the prefix entries [U1, A1] — no
+	// trailing USER_INPUT turn that would auto-run on resume.
+	childTranscriptPath := filepath.Join(stateDir, sessionsSubdir, childID+".transcript.jsonl")
+	_, entries, _, err := readTranscript(childTranscriptPath)
+	if err != nil {
+		t.Fatalf("readTranscript(child): %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("child transcript entry count: got %d, want 2 (prefix only)", len(entries))
+	}
+	if entries[0].Turn.Kind != schema.TurnUserInput || entries[0].Turn.Message.Text() != "first task" {
+		t.Errorf("entries[0]: got kind=%q text=%q, want USER_INPUT %q", entries[0].Turn.Kind, entries[0].Turn.Message.Text(), "first task")
+	}
+	if entries[1].Turn.Kind != schema.TurnAssistant || entries[1].Turn.Message.Text() != "first reply" {
+		t.Errorf("entries[1]: got kind=%q text=%q, want ASSISTANT %q", entries[1].Turn.Kind, entries[1].Turn.Message.Text(), "first reply")
+	}
+	data, err := os.ReadFile(childTranscriptPath)
+	if err != nil {
+		t.Fatalf("ReadFile(child transcript): %v", err)
+	}
+	if strings.Contains(string(data), "second task") {
+		t.Error("child transcript must not contain the diverging user message")
+	}
+}
+
+// TestForkSessionAtUserTurn_FirstTurnProducesEmptyChild verifies that forking
+// at the very first user message yields a child with no transcript entries —
+// the conversation rewinds to before anything was entered.
+func TestForkSessionAtUserTurn_FirstTurnProducesEmptyChild(t *testing.T) {
+	t.Parallel()
+	stateDir, parentID := buildParentSession(t)
+
+	childID, originalInput, err := ForkSessionAtUserTurn(stateDir, parentID, 1, "")
+	if err != nil {
+		t.Fatalf("ForkSessionAtUserTurn: %v", err)
+	}
+	if originalInput != "first task" {
+		t.Errorf("originalInput: got %q, want %q", originalInput, "first task")
+	}
+	childTranscriptPath := filepath.Join(stateDir, sessionsSubdir, childID+".transcript.jsonl")
+	_, entries, _, err := readTranscript(childTranscriptPath)
+	if err != nil {
+		t.Fatalf("readTranscript(child): %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("child transcript entry count: got %d, want 0", len(entries))
+	}
+}
+
+// TestForkSessionAtUserTurn_RejectsNonUserDivergence verifies the divergence
+// turn must point at a USER_INPUT entry, matching ForkSession semantics.
+func TestForkSessionAtUserTurn_RejectsNonUserDivergence(t *testing.T) {
+	t.Parallel()
+	stateDir, parentID := buildParentSession(t)
+
+	_, _, err := ForkSessionAtUserTurn(stateDir, parentID, 2, "")
+	if err == nil {
+		t.Fatal("ForkSessionAtUserTurn(divergenceTurn=2, an ASSISTANT entry) should return an error")
+	}
+	if !strings.Contains(err.Error(), "USER_INPUT") {
+		t.Errorf("error should mention USER_INPUT, got %v", err)
+	}
+}
+
+// TestForkSessionAtUserTurn_RejectsOutOfRange verifies divergenceTurn=0 and
+// divergenceTurn beyond the parent's entry count both error.
+func TestForkSessionAtUserTurn_RejectsOutOfRange(t *testing.T) {
+	t.Parallel()
+	stateDir, parentID := buildParentSession(t)
+
+	if _, _, err := ForkSessionAtUserTurn(stateDir, parentID, 0, ""); err == nil {
+		t.Error("ForkSessionAtUserTurn(divergenceTurn=0) should return an error")
+	}
+	if _, _, err := ForkSessionAtUserTurn(stateDir, parentID, 10, ""); err == nil {
+		t.Error("ForkSessionAtUserTurn(divergenceTurn=10) should return an error when the parent has 4 entries")
+	}
+}
+
+// TestForkSessionAtUserTurn_RejectsMissingParent verifies a missing parent
+// transcript errors instead of creating a child.
+func TestForkSessionAtUserTurn_RejectsMissingParent(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+
+	if _, _, err := ForkSessionAtUserTurn(stateDir, "NONEXISTENT_SESSION", 1, ""); err == nil {
+		t.Error("ForkSessionAtUserTurn with missing parent should return an error")
+	}
+}

--- a/agent/session_aux_exact_fuzz_test.go
+++ b/agent/session_aux_exact_fuzz_test.go
@@ -185,7 +185,7 @@ func FuzzForkExactFaultProgram(f *testing.F) {
 			deps := forkSessionDeps{maxScanToken: 64, newWriter: func(fs afero.Fs, path string, h transcript.Header) (forkTranscriptWriter, error) {
 				return transcript.NewWriterWithFS(fs, path, h)
 			}, saveMeta: schema.SaveSessionMetaWithFS}
-			_, _ = forkSessionWithDeps(fs, state, id, 1, "x", "", deps)
+			_, _, _ = forkSessionWithDeps(fs, state, id, 1, "x", false, "", deps)
 			return
 		}
 		fs, state, id := fuzzAuxParentFS(t)
@@ -218,16 +218,16 @@ func FuzzForkExactFaultProgram(f *testing.F) {
 			},
 		}
 		if mode == 2 {
-			_, _ = forkSessionFS(fuzzAuxOpenFaultFS{Fs: fs}, state, id, 1, "x", "")
+			_, _, _ = forkSessionFS(fuzzAuxOpenFaultFS{Fs: fs}, state, id, 1, "x", false, "")
 			return
 		}
 		if mode == 3 {
 			_ = fs.Remove(filepath.Join(state, sessionsSubdir, id+".meta.json"))
 		}
 		if mode == 9 {
-			_, _ = forkSessionWithDeps(fs, state, id, 4, "edit", "", deps)
+			_, _, _ = forkSessionWithDeps(fs, state, id, 4, "edit", false, "", deps)
 		}
-		_, _ = forkSessionWithDeps(fs, state, id, 3, "edit", "label", deps)
+		_, _, _ = forkSessionWithDeps(fs, state, id, 3, "edit", false, "label", deps)
 	})
 }
 
@@ -281,11 +281,11 @@ func fuzzAuxForkBasic(t *testing.T) {
 		id   string
 		turn int
 	}{{"missing", 0}, {"missing", 1}} {
-		_, _ = forkSessionFS(fs, "/state", tc.id, tc.turn, "x", "")
+		_, _, _ = forkSessionFS(fs, "/state", tc.id, tc.turn, "x", false, "")
 	}
 	_ = fs.MkdirAll("/state/sessions", 0o755)
 	_ = afero.WriteFile(fs, "/state/sessions/empty.transcript.jsonl", nil, 0o644)
-	_, _ = forkSessionFS(fs, "/state", "empty", 1, "x", "")
+	_, _, _ = forkSessionFS(fs, "/state", "empty", 1, "x", false, "")
 }
 
 func fuzzAuxForkCorrupt(t *testing.T) {
@@ -297,7 +297,7 @@ func fuzzAuxForkCorrupt(t *testing.T) {
 	} {
 		id := string(rune('a' + i))
 		_ = afero.WriteFile(fs, "/state/sessions/"+id+".transcript.jsonl", body, 0o644)
-		_, err := forkSessionFS(fs, "/state", id, 1, "x", "")
+		_, _, err := forkSessionFS(fs, "/state", id, 1, "x", false, "")
 		if i == 1 && !errors.Is(err, transcript.ErrUnsupportedFormat) {
 			t.Fatalf("mixed transcript error = %v, want transcript.ErrUnsupportedFormat", err)
 		}
@@ -331,7 +331,7 @@ func fuzzAuxForkSuccess(t *testing.T, label bool) {
 	if label {
 		forkLabel = "branch"
 	}
-	child, err := forkSessionFS(fs, state, id, 3, "edit", forkLabel)
+	child, _, err := forkSessionFS(fs, state, id, 3, "edit", false, forkLabel)
 	if err != nil || child == "" {
 		t.Fatalf("fork = %q, %v", child, err)
 	}

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -91,7 +91,7 @@ var Methods = []MethodSpec{
 	{MethodThreadTurnItemsList, ThreadTurnItemsListParams{}, ThreadTurnItemsListResponse{}, ScopeUnimplemented, "Codex-parity: paginated items for one turn. Experimental even in Codex (returns method-not-supported) and served by no serf router."},
 	{MethodThreadStart, ThreadStartParams{}, ThreadStartResponse{}, ScopeHub, "Starts a new thread and attaches a live-update relay."},
 	{MethodThreadResume, ThreadResumeParams{}, ThreadResumeResponse{}, ScopeHub, "Resumes an existing session and attaches its relay."},
-	{MethodThreadFork, ThreadForkParams{}, ThreadForkResponse{}, ScopeHub, "Forks a thread from a source turn, optionally with edited input."},
+	{MethodThreadFork, ThreadForkParams{}, ThreadForkResponse{}, ScopeHub, "Forks a thread from a source turn, either replacing the turn with edited input or deferring the original input back to the client for editing (deferInput)."},
 	{MethodThreadClear, ThreadClearParams{}, ThreadClearResponse{}, ScopeBoth, "Clears the thread's conversation (rejected while a turn is processing)."},
 	{MethodThreadModelSet, ThreadModelSetParams{}, EmptyResponse{}, ScopeBoth, "Changes the session's model/provider."},
 	{MethodSerfThreadNameSet, ThreadNameSetParams{}, EmptyResponse{}, ScopeBoth, "Sets a user-chosen session title (rename)."},

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -685,10 +685,19 @@ type ThreadForkParams struct {
 	Label         string `json:"label,omitempty"`
 	ModelProvider string `json:"modelProvider,omitempty"`
 	Model         string `json:"model,omitempty"`
+	// DeferInput forks at the source turn WITHOUT appending a replacement
+	// message: the child thread holds only the entries before the turn, and
+	// the turn's original text comes back in ThreadForkResponse.OriginalInput
+	// so the client can stage it for editing and explicit submission (the
+	// fork never auto-runs the message). Mutually exclusive with EditedInput.
+	DeferInput bool `json:"deferInput,omitempty"`
 }
 
 type ThreadForkResponse struct {
 	Thread Thread `json:"thread"`
+	// OriginalInput is the source turn's original user text, set only when
+	// the fork was requested with DeferInput.
+	OriginalInput string `json:"originalInput,omitempty"`
 }
 
 type TurnStartParams struct {

--- a/cmd/serf-hub/app_rpc_test.go
+++ b/cmd/serf-hub/app_rpc_test.go
@@ -6898,6 +6898,95 @@ func TestHubRPCThreadForkCreatesForkedThread(t *testing.T) {
 	}
 }
 
+// TestHubRPCThreadForkDeferInput verifies the fork-from-message flow (issue
+// #42): deferInput forks the thread at the source turn WITHOUT appending a
+// replacement message, so the child transcript holds only the prefix and the
+// response carries the original input text for the client to stage in its
+// composer. The forked session must not auto-run the message.
+func TestHubRPCThreadForkDeferInput(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, "projects", "project-fork-0000000000")
+	parentID := buildRPCParentSession(t, stateDir)
+	past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+	if err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{Past: past})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	resp, err := client.ThreadFork(context.Background(), appwire.ThreadForkParams{
+		Ref:          "local:" + parentID,
+		SourceTurnID: "3",
+		DeferInput:   true,
+	})
+	if err != nil {
+		t.Fatalf("ThreadFork: %v", err)
+	}
+	if resp.Thread.ID == "" || resp.Thread.ID == parentID || resp.Thread.Serf.Ref != "local:"+resp.Thread.ID {
+		t.Fatalf("thread=%+v", resp.Thread)
+	}
+	if resp.OriginalInput != "second task" {
+		t.Fatalf("OriginalInput=%q, want %q", resp.OriginalInput, "second task")
+	}
+	childMeta, err := schema.LoadSessionMeta(stateDir, resp.Thread.ID)
+	if err != nil {
+		t.Fatalf("LoadSessionMeta(child): %v", err)
+	}
+	if childMeta.ParentSessionID != parentID || childMeta.DivergenceTurn != 3 {
+		t.Fatalf("child meta=%+v", childMeta)
+	}
+	// The child transcript must contain only the prefix entries [U1, A1]:
+	// no trailing USER_INPUT turn that would auto-run on open.
+	raw, err := os.ReadFile(filepath.Join(stateDir, "sessions", resp.Thread.ID+".transcript.jsonl"))
+	if err != nil {
+		t.Fatalf("read child transcript: %v", err)
+	}
+	if strings.Contains(string(raw), "second task") {
+		t.Fatalf("deferred fork must not copy the diverging user message:\n%s", raw)
+	}
+}
+
+// TestHubRPCThreadForkDeferInputRejectsEditedInput verifies that deferInput
+// and editedInput are mutually exclusive: one either replaces the message
+// inline (editedInput) or hands it back for editing (deferInput), never both.
+func TestHubRPCThreadForkDeferInputRejectsEditedInput(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, "projects", "project-fork-0000000000")
+	parentID := buildRPCParentSession(t, stateDir)
+	past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+	if err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{Past: past})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	err := client.Request(context.Background(), appwire.MethodThreadFork, appwire.ThreadForkParams{
+		Ref:          "local:" + parentID,
+		SourceTurnID: "3",
+		EditedInput:  "second task, edited",
+		DeferInput:   true,
+	}, &appwire.ThreadForkResponse{})
+	if err == nil {
+		t.Fatal("ThreadFork with both editedInput and deferInput should fail")
+	}
+	var wire appwire.WireError
+	if !errors.As(err, &wire) || wire.Code != appwire.CodeInvalidParams {
+		t.Fatalf("error=%v, want InvalidParams", err)
+	}
+}
+
 type fakeRPCSpawner struct {
 	spawn        func(context.Context, hubcore.SpawnRequest) (rendezvous.Entry, error)
 	resume       func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error)

--- a/cmd/serf-hub/app_threadlifecycle.go
+++ b/cmd/serf-hub/app_threadlifecycle.go
@@ -26,6 +26,7 @@ var (
 	hubRosterRefresh   = func(r *hubcore.Roster) { r.Refresh() }
 	hubRosterList      = func(r *hubcore.Roster) []hubcore.LiveEntry { return r.List() }
 	hubForkSession     = agent.ForkSession
+	hubForkSessionAt   = agent.ForkSessionAtUserTurn
 	hubEnsureSource    = func(ctx context.Context, launcher *codexlaunch.CodexLauncher, id string, sources *appsource.Registry) (appsource.Source, error) {
 		return launcher.EnsureSource(ctx, id, sources)
 	}
@@ -322,7 +323,10 @@ func hubThreadFork(ctx context.Context, cfg hubcore.WebConfig, sources *appsourc
 	if err != nil {
 		return appwire.ThreadForkResponse{}, appwire.InvalidParams(err.Error())
 	}
-	if strings.TrimSpace(params.EditedInput) == "" {
+	if params.DeferInput && strings.TrimSpace(params.EditedInput) != "" {
+		return appwire.ThreadForkResponse{}, appwire.InvalidParams("editedInput and deferInput are mutually exclusive")
+	}
+	if !params.DeferInput && strings.TrimSpace(params.EditedInput) == "" {
 		return appwire.ThreadForkResponse{}, appwire.InvalidParams("editedInput is required")
 	}
 	stateDir := cfg.StateDir
@@ -334,7 +338,12 @@ func hubThreadFork(ctx context.Context, cfg hubcore.WebConfig, sources *appsourc
 	if stateDir == "" {
 		return appwire.ThreadForkResponse{}, appwire.Unavailable("state dir not resolvable for parent thread")
 	}
-	childID, err := hubForkSession(stateDir, ref.ThreadID, turn, params.EditedInput, params.Label)
+	var childID, originalInput string
+	if params.DeferInput {
+		childID, originalInput, err = hubForkSessionAt(stateDir, ref.ThreadID, turn, params.Label)
+	} else {
+		childID, err = hubForkSession(stateDir, ref.ThreadID, turn, params.EditedInput, params.Label)
+	}
 	if err != nil {
 		return appwire.ThreadForkResponse{}, err
 	}
@@ -342,18 +351,22 @@ func hubThreadFork(ctx context.Context, cfg hubcore.WebConfig, sources *appsourc
 		_ = cfg.Past.Rebuild()
 	}
 	childRef := appwire.Ref{SourceID: "local", ThreadID: childID}.String()
-	return appwire.ThreadForkResponse{Thread: appwire.Thread{
-		ID:        childID,
-		SessionID: childID,
-		Source:    "local",
-		Serf:      appwire.SerfThread{Ref: childRef},
-	}}, nil
+	return appwire.ThreadForkResponse{
+		Thread: appwire.Thread{
+			ID:        childID,
+			SessionID: childID,
+			Source:    "local",
+			Serf:      appwire.SerfThread{Ref: childRef},
+		},
+		OriginalInput: originalInput,
+	}, nil
 }
 
 func threadForkRequiresTurnCapability(params appwire.ThreadForkParams) bool {
 	return strings.TrimSpace(params.SourceTurnID) != "" ||
 		strings.TrimSpace(params.EditedInput) != "" ||
-		strings.TrimSpace(params.Label) != ""
+		strings.TrimSpace(params.Label) != "" ||
+		params.DeferInput
 }
 
 func parseSourceTurnID(raw string) (int, error) {

--- a/cmd/serf-hub/assets/appwire.js
+++ b/cmd/serf-hub/assets/appwire.js
@@ -604,9 +604,17 @@
       sourceTurnId: String(body.turn || ""),
       editedInput: body.edited_message || "",
       label: body.label || "",
+      // defer_input (issue #42): fork WITHOUT replacing the turn — the child
+      // holds only the prefix and the response's originalInput comes back so
+      // the renderer can stage it in the fork's composer for editing.
+      deferInput: body.defer_input === true,
     }).then((resp) => {
       const thread = resp.thread || {};
-      return { ref: threadRef(thread), session_id: threadID(thread) };
+      return {
+        ref: threadRef(thread),
+        session_id: threadID(thread),
+        original_input: resp.originalInput || "",
+      };
     });
   }
 

--- a/cmd/serf-hub/assets/drafts.js
+++ b/cmd/serf-hub/assets/drafts.js
@@ -75,6 +75,26 @@
     }
   }
 
+  // writeFor stores a draft for a session by ID — no live form required. The
+  // fork-from-message flow (issue #42) uses it to stage the original message
+  // in the fork child's composer before navigating there; the child's own
+  // bind() then restores it like any typed draft. Blank content removes the
+  // key, matching write().
+  function writeFor(sessionId, value) {
+    const s = storage();
+    if (!s) return;
+    const session = String(sessionId || "").trim() || FALLBACK_SESSION;
+    try {
+      if (String(value || "").trim() === "") {
+        s.removeItem(PREFIX + session);
+      } else {
+        s.setItem(PREFIX + session, String(value));
+      }
+    } catch (e) {
+      /* storage unavailable or full — the fork still opens, just empty */
+    }
+  }
+
   // bind restores any stored draft into the composer's textarea and mirrors
   // subsequent edits into storage. Never overwrites content the textarea
   // already has (e.g. a re-bound composer mid-typing). Returns true when a
@@ -125,5 +145,5 @@
     return restored;
   }
 
-  window.SerfDrafts = { keyFor, read, write, clear, bind };
+  window.SerfDrafts = { keyFor, read, write, writeFor, clear, bind };
 })();

--- a/cmd/serf-hub/assets/renderer.js
+++ b/cmd/serf-hub/assets/renderer.js
@@ -257,6 +257,11 @@
       this.currentMessageId = null;
       this.userTurnIndex = 0;            // counts user turns rendered (for fork divergence)
       this.entryIndex = 0;               // counts ALL entries rendered (matches transcript entry index)
+      // Fork-from-message (issue #42): the most recent user message's
+      // transcript entry index + text, so an assistant message's fork action
+      // can fork at the prompt that produced it (retry semantics).
+      this.lastUserForkTurn = 0;
+      this.lastUserForkText = "";
       this.cheapToolCluster = null;      // current cluster div for batching cheap reads
       // Image attachments are owned by the SerfComposerAttachments helper
       // (kata r6a1/65mm — paste/drop/file-picker all funnel through it). The
@@ -1260,6 +1265,8 @@
       this.currentMessageId = null;
       this.userTurnIndex = 0;
       this.entryIndex = 0;
+      this.lastUserForkTurn = 0;
+      this.lastUserForkText = "";
       this.cheapToolCluster = null;
       this.subagentModule = null;
       this.currentTurnHasAgentWork = false;
@@ -1479,10 +1486,12 @@
             this.lastFinalizedAssistantEl = null;
             taskDescriptions.clear();
             taskDetails.clear();
-            this.lastCurrentTaskId = null;
-            this.userTurnIndex = 0;
-            this.entryIndex = 0;
-            this.currentTurnHasAgentWork = false;
+          this.lastCurrentTaskId = null;
+          this.userTurnIndex = 0;
+          this.entryIndex = 0;
+          this.lastUserForkTurn = 0;
+          this.lastUserForkText = "";
+          this.currentTurnHasAgentWork = false;
             this.clearAgentQuestion();
             // Drop any pending image attachments and let the composer-
             // attachments helper repaint the (now empty) chip container.
@@ -1994,6 +2003,12 @@
       wrap.className = "user-message";
       wrap.dataset.entryIdx = String(entryIdx || "");
       wrap.dataset.userTurn = String(this.userTurnIndex || "");
+      // Fork-from-message (issue #42): remember this message as the fork
+      // point for any assistant message that follows it.
+      if (Number(entryIdx) > 0) {
+        this.lastUserForkTurn = Number(entryIdx);
+        this.lastUserForkText = text || "";
+      }
       // Quiet "You" tag anchors the demoted user prompt (design-system #2:
       // never emphasize the user's own message). It is a sibling of the pill
       // so .pill.textContent stays the clean prompt text.
@@ -2045,6 +2060,18 @@
       edit.className = "action edit"; edit.textContent = "✎ edit";
       edit.onclick = () => this.startEdit(wrap, pill, text);
       actions.appendChild(copy); actions.appendChild(edit);
+      // Fork (issue #42): branch the conversation at this message and re-enter
+      // its text in the fork's composer, ready for editing and submission.
+      if (Number(entryIdx) > 0) {
+        const fork = document.createElement("button");
+        fork.type = "button";
+        fork.className = "action fork";
+        fork.textContent = "⎇ fork";
+        fork.title = "fork the conversation from this message";
+        fork.setAttribute("aria-label", "fork the conversation from this message");
+        fork.onclick = () => this.startFork(Number(entryIdx), text);
+        actions.appendChild(fork);
+      }
       wrap.appendChild(tag); wrap.appendChild(pill); wrap.appendChild(actions);
       this.conversation.appendChild(wrap);
       return wrap;
@@ -2404,6 +2431,10 @@
         if (typeof data.turn === "number" && data.turn > 0) {
           wrap.dataset.entryIdx = String(data.turn);
           this.entryIndex = Math.max(this.entryIndex, data.turn);
+          // The server echo carries the authoritative transcript entry index
+          // for the fork point; the local echo's was only inferred.
+          this.lastUserForkTurn = data.turn;
+          this.lastUserForkText = data.text || this.lastUserForkText;
         }
         if (turnId) wrap.dataset.turnId = turnId;
         delete wrap.dataset.localEcho;
@@ -2516,6 +2547,65 @@
       input.select();
     },
 
+    // startFork forks the session at a transcript entry index WITHOUT running
+    // anything (issue #42): the child session holds only the entries before
+    // that user message, and the original message text is staged in the
+    // child's composer (sticky per-session draft) so the user edits and
+    // submits it explicitly — the fork never auto-runs the message.
+    async startFork(forkTurn, originalText) {
+      const turn = parseInt(forkTurn, 10);
+      if (!turn || turn < 1) return;
+      try {
+        const json = window.SerfAppwire
+          ? await window.SerfAppwire.forkThread(this.sessionId, { turn, defer_input: true })
+          : await fetch("/s/" + encodeURIComponent(this.sessionId) + "/fork", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ turn, defer_input: true }),
+            }).then(async (resp) => {
+              if (!resp.ok) throw new Error(await resp.text());
+              return resp.json();
+            });
+        // Stage the message text as the fork child's composer draft. Prefer
+        // the server-authoritative original from the transcript; fall back to
+        // the rendered text the action was bound with.
+        const childSession = json.session_id || json.child_session_id || "";
+        const composerText = json.original_input || originalText || "";
+        if (childSession && composerText && window.SerfDrafts && typeof window.SerfDrafts.writeFor === "function") {
+          window.SerfDrafts.writeFor(childSession, composerText);
+        }
+        // Refresh sidebar so the new fork shows up.
+        if (window.htmx) htmx.trigger(document.body, "sidebar:refresh");
+        // Navigate to the forked session; its composer binds the staged draft.
+        window.location.href = "/s/" + encodeURIComponent(json.ref || json.child_session_id || json.session_id);
+      } catch (e) {
+        this.appendBanner("error", "fork failed: " + e.message, { source: "hub", title: "Hub fork error" });
+      }
+    },
+
+    // appendMessageForkAction adds the fork-from-message affordance (issue
+    // #42) to an assistant message: fork at the user prompt that produced
+    // this reply and stage that prompt in the fork's composer (retry
+    // semantics). Idempotent; a message with no recorded fork point (before
+    // any user input) gets no action.
+    appendMessageForkAction(el) {
+      if (!el || !el.dataset) return;
+      const turn = parseInt(el.dataset.forkTurn || "0", 10);
+      if (!turn || turn < 1) return;
+      if (el.querySelector(".msg-fork")) return;
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "action fork msg-fork";
+      btn.textContent = "⎇ fork";
+      btn.title = "fork the conversation from the prompt that produced this message";
+      btn.setAttribute("aria-label", "fork the conversation from the prompt that produced this message");
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this.startFork(turn, el.dataset.forkText || "");
+      });
+      el.appendChild(btn);
+    },
+
     beginAssistantMessage() {
       this.removeColdStartSkeleton();
       this.endCheapCluster();
@@ -2527,6 +2617,13 @@
       el.className = "assistant-message";
       el.classList.add("streaming");
       el.dataset.turnId = this.activeTurnId || "";
+      // Fork-from-message (issue #42): an assistant message forks at the user
+      // prompt that produced it — the conversation rewinds to before that
+      // prompt and the prompt text is staged in the fork's composer.
+      if (this.lastUserForkTurn > 0) {
+        el.dataset.forkTurn = String(this.lastUserForkTurn);
+        el.dataset.forkText = this.lastUserForkText || "";
+      }
       this.conversation.appendChild(el);
       this.activeMessages.set(id, { el, textBuf: "" });
     },
@@ -2541,9 +2638,14 @@
       const el = document.createElement("div");
       el.className = "assistant-message";
       el.dataset.turnId = this.activeTurnId || "";
+      if (this.lastUserForkTurn > 0) {
+        el.dataset.forkTurn = String(this.lastUserForkTurn);
+        el.dataset.forkText = this.lastUserForkText || "";
+      }
       try { el.innerHTML = window.marked.parse(text); }
       catch (e) { el.textContent = text; }
       this.conversation.appendChild(el);
+      this.appendMessageForkAction(el);
       return el;
     },
 
@@ -2690,6 +2792,7 @@
             try { last.innerHTML = window.marked.parse(finalText); }
             catch (e) { last.textContent = finalText; }
             if (meta) last.appendChild(meta); // re-parse destroyed children; the badge rides back
+            this.appendMessageForkAction(last); // dataset.forkTurn survives the re-parse
             return;
           }
         }
@@ -2709,6 +2812,7 @@
       }
       m.el.classList.remove("streaming");
       this.renderAssistantMessage(m, finalText);
+      this.appendMessageForkAction(m.el);
       this.lastFinalizedAssistantEl = m.el;
     },
 
@@ -5192,6 +5296,8 @@
         currentMessageId: this.currentMessageId,
         userTurnIndex: this.userTurnIndex,
         entryIndex: this.entryIndex,
+        lastUserForkTurn: this.lastUserForkTurn,
+        lastUserForkText: this.lastUserForkText,
         cheapToolCluster: this.cheapToolCluster,
         subagentModule: this.subagentModule,
         lastUserText: this.lastUserText,
@@ -5230,6 +5336,8 @@
       this.currentMessageId = null;
       this.userTurnIndex = 0;
       this.entryIndex = 0;
+      this.lastUserForkTurn = 0;
+      this.lastUserForkText = "";
       this.cheapToolCluster = null;
       this.subagentModule = null;
       this.activeTurnId = "";

--- a/cmd/serf-hub/assets/style.css
+++ b/cmd/serf-hub/assets/style.css
@@ -2478,6 +2478,25 @@ button.composer-model-value .caret { color: var(--ink-3); }
 }
 .assistant-message:hover .turn-meta,
 .assistant-message:focus-within .turn-meta { opacity: 1; }
+/* Fork-from-message action (issue #42): same quiet reveal as .turn-meta —
+   hidden at rest, revealed on hover or keyboard focus within the message,
+   and stripped of button chrome so it stays inline quiet text. */
+.assistant-message .msg-fork {
+  margin-left: var(--space-2);
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--ink-2);
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  white-space: nowrap;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--motion-fast);
+}
+.assistant-message:hover .msg-fork,
+.assistant-message:focus-within .msg-fork { opacity: 1; }
+.assistant-message .msg-fork:hover { color: var(--ink); }
 
 /* Frozen-head/raw-tail streaming (long messages): the tail is plain pre-wrap
    text with the one sanctioned streaming caret; finalization replaces it with

--- a/cmd/serf-hub/cov_exact_web_session_fuzz_test.go
+++ b/cmd/serf-hub/cov_exact_web_session_fuzz_test.go
@@ -253,7 +253,7 @@ func FuzzCovExactWebSession(f *testing.F) {
 		}
 		localWeb = NewWebServer(hubcore.WebConfig{RunDir: runDir, Roster: localRoster, Past: past, Spawner: exactWebSessionSpawner{resume: resume}})
 		call(func(w http.ResponseWriter, r *http.Request) { localWeb.handleSend(w, r, localID) }, http.MethodPost, "/s/"+localID+"/send", `{"text":"resume"}`)
-		_, _ = localWeb.forkSession(localID, forkRequest{Turn: 3, EditedMessage: "edited", Label: "branch"})
+		_, _, _ = localWeb.forkSession(localID, forkRequest{Turn: 3, EditedMessage: "edited", Label: "branch"})
 
 		rosterOnly := NewWebServer(hubcore.WebConfig{Roster: hubcore.NewRosterWithEntries(hubcore.LiveEntry{Entry: rendezvous.Entry{PID: 33, Address: "127.0.0.1:1"}, SessionID: "roster-only"})})
 		call(func(w http.ResponseWriter, r *http.Request) { rosterOnly.handleSend(w, r, "roster-only") }, http.MethodPost, "/s/roster-only/send", `{"text":"hi"}`)

--- a/cmd/serf-hub/cov_session_tree_pass3_fuzz_test.go
+++ b/cmd/serf-hub/cov_session_tree_pass3_fuzz_test.go
@@ -186,7 +186,7 @@ func FuzzSessionTreePass3(f *testing.F) {
 					web.handleFork(rec, req, "missing")
 				}
 			}
-			_, _ = web.forkSession("missing", forkRequest{})
+			_, _, _ = web.forkSession("missing", forkRequest{})
 			_ = waitForRosterMatch(hubcore.NewRosterWithEntries(), "missing", 1, 0)
 		case 15:
 			dir := t.TempDir()

--- a/cmd/serf-hub/jstest/test-appwire-fork-defer.js
+++ b/cmd/serf-hub/jstest/test-appwire-fork-defer.js
@@ -1,0 +1,92 @@
+// appwire forkThread defer-input mapping (issue #42): the browser client must
+// send deferInput (and no editedInput) on thread/fork when the renderer asks
+// for a deferred fork, and must surface the response's originalInput as
+// original_input so the renderer can stage it in the fork's composer.
+const fs = require("fs");
+const vm = require("vm");
+
+const SRC = fs.readFileSync(__dirname + "/../assets/appwire.js", "utf8");
+const sent = [];
+
+function assert(cond, msg) {
+  if (!cond) {
+    console.error("FAIL: " + msg);
+    process.exit(1);
+  }
+}
+
+class FakeWebSocket {
+  constructor(url) {
+    this.url = url;
+    this.readyState = FakeWebSocket.OPEN;
+    this.listeners = new Map();
+    setTimeout(() => this.dispatch("open", {}), 0);
+  }
+
+  addEventListener(name, handler) {
+    const handlers = this.listeners.get(name) || [];
+    handlers.push(handler);
+    this.listeners.set(name, handlers);
+  }
+
+  send(raw) {
+    const msg = JSON.parse(raw);
+    sent.push(msg);
+    setTimeout(() => {
+      if (msg.method === "thread/fork") {
+        this.dispatch("message", {
+          data: JSON.stringify({
+            id: msg.id,
+            result: {
+              thread: { id: "01CHILD", sessionId: "01CHILD", serf: { ref: "local:01CHILD" } },
+              originalInput: "original prompt text",
+            },
+          }),
+        });
+        return;
+      }
+      this.dispatch("message", {
+        data: JSON.stringify({ id: msg.id, result: { serverInfo: { name: "fake" } } }),
+      });
+    }, 0);
+  }
+
+  dispatch(name, event) {
+    for (const handler of this.listeners.get(name) || []) handler(event);
+  }
+}
+FakeWebSocket.OPEN = 1;
+
+const context = {
+  window: {
+    addEventListener() {},
+    location: { protocol: "http:", host: "127.0.0.1:9180", pathname: "/" },
+  },
+  document: { addEventListener() {}, querySelector() { return null; }, body: { dataset: {} } },
+  WebSocket: FakeWebSocket,
+  fetch: async () => ({ ok: true, json: async () => ({}) }),
+  console,
+  setTimeout,
+};
+context.globalThis = context;
+vm.createContext(context);
+vm.runInContext(SRC, context);
+
+(async () => {
+  const out = await context.window.SerfAppwire.forkThread("01HOST", { turn: 3, defer_input: true });
+
+  const fork = sent.find((m) => m.method === "thread/fork");
+  assert(fork, "thread/fork request should be sent");
+  assert(fork.params.sourceTurnId === "3", "sourceTurnId should be the turn, got " + JSON.stringify(fork.params));
+  assert(fork.params.deferInput === true, "deferInput should map from defer_input, got " + JSON.stringify(fork.params));
+  assert(!fork.params.editedInput, "editedInput must be empty in the defer flow, got " + JSON.stringify(fork.params));
+  assert(out.ref === "local:01CHILD", "ref should pass through, got " + JSON.stringify(out));
+  assert(out.session_id === "01CHILD", "session_id should pass through, got " + JSON.stringify(out));
+  assert(out.original_input === "original prompt text", "originalInput should map to original_input, got " + JSON.stringify(out));
+
+  console.log("PASS: appwire forkThread maps deferInput and originalInput");
+  process.exit(0);
+})().catch((err) => {
+  console.error("FAIL: " + (err && err.message));
+  process.exit(1);
+});

--- a/cmd/serf-hub/jstest/test-renderer-fork-from-message.js
+++ b/cmd/serf-hub/jstest/test-renderer-fork-from-message.js
@@ -1,0 +1,210 @@
+// Fork-from-message (issue #42): every transcript message carries a fork
+// affordance. Activating it forks the session at the point where that message
+// was entered — for an assistant message, at the user prompt that produced
+// it — and stages the original message text in the forked session's composer
+// (via the sticky per-session draft) ready for editing. The forked session
+// must NOT auto-run the message: forkThread goes out with defer_input and no
+// startTurn/turn-start call is made.
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+
+const DRAFTS_SRC = fs.readFileSync(path.resolve(__dirname, "../assets/drafts.js"), "utf8");
+
+// spyOnLocationHref patches the jsdom Location implementation to capture
+// navigation targets (same technique as test-renderer-fork-ref.js).
+function spyOnLocationHref(window) {
+  const loc = window.location;
+  const implSym = Object.getOwnPropertySymbols(loc)
+    .find((s) => s.toString() === "Symbol(impl)");
+  if (!implSym) throw new Error("jsdom location impl symbol not found — jsdom API changed?");
+  const impl = loc[implSym];
+  const navigations = [];
+  const origNavigate = impl._locationObjectSetterNavigate.bind(impl);
+  impl._locationObjectSetterNavigate = (url) => {
+    navigations.push("/" + url.path.join("/"));
+  };
+  return { navigations, restore: () => { impl._locationObjectSetterNavigate = origNavigate; } };
+}
+
+function newHarness(sessionId, seed) {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>
+    <div class="workspace-actions">
+      <button data-tasks-trigger><span class="panel-toggle-label">tasks</span></button>
+      <button data-details-trigger><span class="panel-toggle-label">details</span></button>
+    </div>
+    <header class="workspace-header" data-session-id="${sessionId}"></header>
+    <div id="conversation" data-session-id="${sessionId}" data-state="active"></div>
+    <form data-input-form data-session-id="${sessionId}">
+      <textarea class="message-input"></textarea>
+    </form>
+  </body></html>`, {
+    runScripts: "outside-only",
+    pretendToBeVisual: true,
+    url: "http://localhost/s/" + sessionId,
+  });
+
+  const { window } = dom;
+  for (const [k, v] of Object.entries(seed || {})) window.localStorage.setItem(k, v);
+  window.marked = { parse: (t) => t };
+  window.fetch = () => Promise.resolve({
+    ok: true, json: () => Promise.resolve({}), text: () => Promise.resolve(""),
+  });
+
+  window.eval(DRAFTS_SRC);
+  require(path.resolve(__dirname, "./load-renderer")).evalRenderer(window);
+  const conv = window.document.getElementById("conversation");
+  window.SerfRenderer.init(conv);
+
+  const locationSpy = spyOnLocationHref(window);
+  return { window, conv, locationSpy };
+}
+
+// makeForkAppwire records forkThread/startTurn calls and resolves forkThread
+// with a child session + the server-authoritative original input text.
+function makeForkAppwire(calls, originalInput) {
+  return {
+    forkThread: (sessionId, body) => {
+      calls.push({ name: "forkThread", sessionId, body });
+      return Promise.resolve({
+        ref: "local:01CHILD",
+        session_id: "01CHILD",
+        original_input: originalInput,
+      });
+    },
+    startTurn: () => {
+      calls.push({ name: "startTurn" });
+      return Promise.resolve({});
+    },
+    refForSession: (s) => "local:" + s,
+    onNotification: () => () => {},
+    onConnectionLost: () => () => {},
+    tasks: () => Promise.resolve([]),
+    readThread: () => Promise.resolve({}),
+  };
+}
+
+const failures = [];
+function pass(cond, msg) { if (!cond) failures.push("FAIL: " + msg); }
+
+async function settle() { await new Promise((r) => setTimeout(r, 30)); }
+
+(async () => {
+  // -----------------------------------------------------------------------
+  // 1. User message: fork action renders in the actions row; clicking it
+  //    forks with defer_input at the message's transcript entry index, stages
+  //    the server-returned original text as the child session's draft, and
+  //    navigates to the fork — without any startTurn (no auto-run).
+  // -----------------------------------------------------------------------
+  {
+    const { window, conv, locationSpy } = newHarness("01HOST");
+    await settle();
+
+    const calls = [];
+    window.SerfAppwire = makeForkAppwire(calls, "hello world");
+
+    window.SerfRenderer.handleData("USER_INPUT", { text: "hello world", turn: 3 });
+    await settle();
+
+    const forkBtn = conv.querySelector(".user-message .user-message-actions .action.fork");
+    pass(!!forkBtn, "user message should render a fork action");
+    pass(forkBtn && forkBtn.tagName === "BUTTON", "fork action must be a <button>, got " + (forkBtn && forkBtn.tagName));
+    pass(forkBtn && forkBtn.getAttribute("type") === "button", "fork button must be type=button");
+    if (forkBtn) forkBtn.click();
+    await settle();
+
+    const forkCalls = calls.filter((c) => c.name === "forkThread");
+    pass(forkCalls.length === 1, "expected exactly one forkThread call, got " + forkCalls.length);
+    if (forkCalls.length) {
+      pass(forkCalls[0].body.turn === 3, "forkThread body.turn should be the message entry index 3, got " + JSON.stringify(forkCalls[0].body));
+      pass(forkCalls[0].body.defer_input === true, "forkThread body.defer_input should be true, got " + JSON.stringify(forkCalls[0].body));
+      pass(!forkCalls[0].body.edited_message, "forkThread must not send edited_message in the defer flow, got " + JSON.stringify(forkCalls[0].body));
+    }
+    pass(calls.filter((c) => c.name === "startTurn").length === 0, "fork must not auto-run the message (no startTurn)");
+    pass(
+      window.localStorage.getItem("serf-hub.draft.01CHILD") === "hello world",
+      "child session draft should hold the original message, got " +
+        JSON.stringify(window.localStorage.getItem("serf-hub.draft.01CHILD"))
+    );
+    const nav = locationSpy.navigations[0];
+    pass(nav === "/s/" + encodeURIComponent("local:01CHILD"), "expected navigation to the fork child, got " + nav);
+  }
+
+  // -----------------------------------------------------------------------
+  // 2. Assistant message: the fork action forks at the USER PROMPT that
+  //    produced the reply (retry semantics), staging that prompt's text.
+  // -----------------------------------------------------------------------
+  {
+    const { window, conv, locationSpy } = newHarness("01HOST");
+    await settle();
+
+    const calls = [];
+    window.SerfAppwire = makeForkAppwire(calls, "original prompt");
+
+    window.SerfRenderer.handleData("USER_INPUT", { text: "original prompt", turn: 1 });
+    window.SerfRenderer.handleData("ASSISTANT_TEXT_START", {});
+    window.SerfRenderer.handleData("ASSISTANT_TEXT_END", { text: "the reply" });
+    await settle();
+
+    const forkBtn = conv.querySelector(".assistant-message .msg-fork");
+    pass(!!forkBtn, "assistant message should render a fork action");
+    if (forkBtn) forkBtn.click();
+    await settle();
+
+    const forkCalls = calls.filter((c) => c.name === "forkThread");
+    pass(forkCalls.length === 1, "expected exactly one forkThread call, got " + forkCalls.length);
+    if (forkCalls.length) {
+      pass(forkCalls[0].body.turn === 1, "assistant fork should target the producing user prompt's entry index 1, got " + JSON.stringify(forkCalls[0].body));
+      pass(forkCalls[0].body.defer_input === true, "forkThread body.defer_input should be true, got " + JSON.stringify(forkCalls[0].body));
+    }
+    pass(
+      window.localStorage.getItem("serf-hub.draft.01CHILD") === "original prompt",
+      "child session draft should hold the producing prompt, got " +
+        JSON.stringify(window.localStorage.getItem("serf-hub.draft.01CHILD"))
+    );
+    const nav = locationSpy.navigations[0];
+    pass(nav === "/s/" + encodeURIComponent("local:01CHILD"), "expected navigation to the fork child, got " + nav);
+  }
+
+  // -----------------------------------------------------------------------
+  // 3. SerfDrafts.writeFor: stores a draft for an arbitrary session id (the
+  //    not-yet-visited fork child) and removes it for blank content.
+  // -----------------------------------------------------------------------
+  {
+    const { window } = newHarness("01HOST");
+    pass(typeof window.SerfDrafts.writeFor === "function", "SerfDrafts.writeFor must exist");
+    if (typeof window.SerfDrafts.writeFor === "function") {
+      window.SerfDrafts.writeFor("01OTHER", "staged text");
+      pass(
+        window.localStorage.getItem("serf-hub.draft.01OTHER") === "staged text",
+        "writeFor should store under the target session key, got " +
+          JSON.stringify(window.localStorage.getItem("serf-hub.draft.01OTHER"))
+      );
+      window.SerfDrafts.writeFor("01OTHER", "   ");
+      pass(
+        window.localStorage.getItem("serf-hub.draft.01OTHER") === null,
+        "writeFor with blank text should remove the draft"
+      );
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // 4. Opening the fork child restores the staged draft into the composer,
+  //    ready for editing — and does NOT submit it.
+  // -----------------------------------------------------------------------
+  {
+    const { window } = newHarness("01CHILD", { "serf-hub.draft.01CHILD": "original prompt" });
+    await settle();
+    const ta = window.document.querySelector("form[data-input-form] .message-input");
+    pass(ta.value === "original prompt", "child composer should be pre-populated with the original message, got " + JSON.stringify(ta.value));
+  }
+
+  if (failures.length === 0) {
+    console.log("PASS: fork-from-message stages the original message in the fork composer's draft");
+    process.exit(0);
+  }
+  for (const f of failures) console.log(f);
+  process.exit(1);
+})();

--- a/cmd/serf-hub/web_session.go
+++ b/cmd/serf-hub/web_session.go
@@ -518,13 +518,17 @@ func (s *WebServer) handleFork(w http.ResponseWriter, r *http.Request, parentID 
 		return
 	}
 
-	childID, err := s.forkSession(parentID, body)
+	childID, originalInput, err := s.forkSession(parentID, body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"child_session_id": childID}) //nolint:errcheck
+	resp := map[string]string{"child_session_id": childID}
+	if originalInput != "" {
+		resp["original_input"] = originalInput
+	}
+	json.NewEncoder(w).Encode(resp) //nolint:errcheck
 }
 
 func (s *WebServer) handleAPIFork(w http.ResponseWriter, r *http.Request, parentID string) {
@@ -538,7 +542,7 @@ func (s *WebServer) handleAPIFork(w http.ResponseWriter, r *http.Request, parent
 		return
 	}
 
-	childID, err := s.forkSession(parentID, body)
+	childID, _, err := s.forkSession(parentID, body)
 	if err != nil {
 		writeAPIError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -551,7 +555,7 @@ func (s *WebServer) handleAPIFork(w http.ResponseWriter, r *http.Request, parent
 	})
 }
 
-func (s *WebServer) forkSession(parentID string, body forkRequest) (string, error) {
+func (s *WebServer) forkSession(parentID string, body forkRequest) (string, string, error) {
 	// Resolve the state dir for the parent session. Forks must write into
 	// the same project's state-dir as the parent (so they appear in the
 	// project tree). Past index knows the per-project state-dir; cfg.StateDir
@@ -567,18 +571,24 @@ func (s *WebServer) forkSession(parentID string, body forkRequest) (string, erro
 		stateDir = s.cfg.StateDir
 	}
 	if stateDir == "" {
-		return "", errors.New("state dir not resolvable for parent session")
+		return "", "", errors.New("state dir not resolvable for parent session")
 	}
 
-	childID, err := agent.ForkSession(stateDir, parentID, body.Turn, body.EditedMessage, body.Label)
+	var childID, originalInput string
+	var err error
+	if body.DeferInput {
+		childID, originalInput, err = agent.ForkSessionAtUserTurn(stateDir, parentID, body.Turn, body.Label)
+	} else {
+		childID, err = agent.ForkSession(stateDir, parentID, body.Turn, body.EditedMessage, body.Label)
+	}
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	// Refresh past index so the new session shows up immediately in the sidebar.
 	if s.cfg.Past != nil {
 		_ = s.cfg.Past.Rebuild()
 	}
-	return childID, nil
+	return childID, originalInput, nil
 }
 
 // waitForRosterMatch polls the roster until it sees a daemon with the given PID

--- a/cmd/serf-hub/web_test.go
+++ b/cmd/serf-hub/web_test.go
@@ -3847,6 +3847,91 @@ func TestWeb_Fork_CallsForkSession(t *testing.T) {
 	}
 }
 
+// TestWeb_Fork_DeferInput verifies the fork-from-message REST flow (issue
+// #42): POST /s/<id>/fork with defer_input forks at the turn without
+// appending a replacement message, and the response carries the original
+// input text so the client can stage it in the composer for editing.
+func TestWeb_Fork_DeferInput(t *testing.T) {
+	root := t.TempDir()
+	proj := filepath.Join(root, "projects", "project-x-0123456789")
+
+	parentID := "02wMz5Txv5aIxgf9yVdd0N"
+	sessionsDir := filepath.Join(proj, "sessions")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tpath := filepath.Join(sessionsDir, parentID+".transcript.jsonl")
+	tw, err := transcript.NewWriter(tpath, transcript.Header{
+		SessionID: parentID, ProfileID: "openai", Model: "gpt-5",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Append(schema.NewTurn(schema.TurnUserInput, llm.User("first task"))); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Append(schema.NewTurn(schema.TurnAssistant, llm.Assistant("first reply"))); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Append(schema.NewTurn(schema.TurnUserInput, llm.User("second task"))); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.SaveSessionMeta(proj, schema.SessionMeta{
+		ID: parentID, UpdatedAt: time.Now(), OriginalPrompt: "test fork",
+		ProfileID: "openai", Model: "gpt-5",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+	if err := idx.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+
+	web := NewWebServer(hubcore.WebConfig{
+		HubAddr:  "127.0.0.1:9180",
+		Roster:   hubcore.NewRoster(t.TempDir(), nil),
+		Past:     idx,
+		StateDir: proj,
+	})
+	reqBody := strings.NewReader(`{"turn":3,"defer_input":true}`)
+	req := httptest.NewRequest(http.MethodPost, "/s/"+parentID+"/fork", reqBody)
+	req.Host = "127.0.0.1:9180"
+	req.Header.Set("Origin", "http://127.0.0.1:9180")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	web.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%q", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		ChildSessionID string `json:"child_session_id"`
+		OriginalInput  string `json:"original_input"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v body=%q", err, rec.Body.String())
+	}
+	if resp.ChildSessionID == "" || resp.ChildSessionID == parentID {
+		t.Fatalf("child_session_id=%q", resp.ChildSessionID)
+	}
+	if resp.OriginalInput != "second task" {
+		t.Errorf("original_input=%q, want %q", resp.OriginalInput, "second task")
+	}
+	// The child transcript must hold only the prefix: no trailing USER_INPUT
+	// turn that would auto-run the message on open.
+	raw, err := os.ReadFile(filepath.Join(sessionsDir, resp.ChildSessionID+".transcript.jsonl"))
+	if err != nil {
+		t.Fatalf("read child transcript: %v", err)
+	}
+	if strings.Contains(string(raw), "second task") {
+		t.Errorf("deferred fork must not copy the diverging user message:\n%s", raw)
+	}
+}
+
 // TestWeb_ApiSearch_FiltersPast populates the past index with two metas,
 // queries for one by name, and asserts only that result is returned.
 func TestWeb_ApiSearch_FiltersPast(t *testing.T) {

--- a/cmd/serf-hub/web_types.go
+++ b/cmd/serf-hub/web_types.go
@@ -302,6 +302,10 @@ type forkRequest struct {
 	Turn          int    `json:"turn"`
 	EditedMessage string `json:"edited_message"`
 	Label         string `json:"label"`
+	// DeferInput forks at the turn WITHOUT appending a replacement message:
+	// the child holds only the prefix, and the response carries the original
+	// input text so the client can stage it in the composer (issue #42).
+	DeferInput bool `json:"defer_input"`
 }
 
 // daemonStatus is the subset of /status fields the hub cares about.

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -93,7 +93,7 @@ no router (reserved).
 | `thread/turns/items/list` | unimplemented | `ThreadTurnItemsListParams` | `ThreadTurnItemsListResponse` | Codex-parity: paginated items for one turn. Experimental even in Codex (returns method-not-supported) and served by no serf router. |
 | `thread/start` | hub | `ThreadStartParams` | `ThreadStartResponse` | Starts a new thread and attaches a live-update relay. |
 | `thread/resume` | hub | `ThreadResumeParams` | `ThreadResumeResponse` | Resumes an existing session and attaches its relay. |
-| `thread/fork` | hub | `ThreadForkParams` | `ThreadForkResponse` | Forks a thread from a source turn, optionally with edited input. |
+| `thread/fork` | hub | `ThreadForkParams` | `ThreadForkResponse` | Forks a thread from a source turn, either replacing the turn with edited input or deferring the original input back to the client for editing (deferInput). |
 | `thread/clear` | both | `ThreadClearParams` | `ThreadClearResponse` | Clears the thread's conversation (rejected while a turn is processing). |
 | `thread/model/set` | both | `ThreadModelSetParams` | `EmptyResponse` | Changes the session's model/provider. |
 | `serf/thread/name/set` | both | `ThreadNameSetParams` | `EmptyResponse` | Sets a user-chosen session title (rename). |
@@ -761,6 +761,7 @@ _(no fields)_
 | `label` | `string` | yes |  |
 | `modelProvider` | `string` | yes |  |
 | `model` | `string` | yes |  |
+| `deferInput` | `bool` | yes |  |
 
 
 ### `ThreadForkResponse`
@@ -768,6 +769,7 @@ _(no fields)_
 | Field | Go type | Omitempty | Embedded |
 |-------|---------|-----------|----------|
 | `thread` | `appwire.Thread` |  |  |
+| `originalInput` | `string` | yes |  |
 
 
 ### `ThreadListParams`

--- a/docs/subagent-runtime-contracts.md
+++ b/docs/subagent-runtime-contracts.md
@@ -221,6 +221,12 @@ Fork and subagent are **distinct relations** sharing lineage fields, kept explic
 - **Fork copies history; a subagent starts fresh.** `ForkSession` (`agent/fork.go`)
   replays the parent's first `divergenceTurn-1` entries into the child transcript; a
   spawned subagent gets a new empty session with only a lineage pointer.
+- **A fork may defer the diverging input.** `ForkSessionAtUserTurn` (`agent/fork.go`)
+  writes only the prefix (no replacement user turn) and returns the original message
+  text, so the web UI's fork-from-message flow can stage it in the composer for
+  editing before explicit submission — the forked session never auto-runs it. The
+  divergence turn must still be a `USER_INPUT` entry; both variants record the same
+  `ParentSessionID`/`DivergenceTurn` lineage.
 - **Lineage lives in metadata and headers, discoverable without reading transcript
   bodies.** `SessionMeta` (`agent/schema/snapshot.go`) carries `ParentSessionID`,
   `DivergenceTurn`, `ForkLabel`, and `IsSubagent`; the transcript `Header`


### PR DESCRIPTION
Closes #42.

## Summary

Every message in the hub web UI transcript now carries a quiet `⎇ fork` affordance. Activating it forks the session at the point where that message was entered — using the underlying serf fork machinery — and pre-populates the forked session's composer with the original message text, ready for editing and explicit submission. The forked session does **not** auto-run the message.

## Design

**Fork machinery (found + extended).** The base already had `agent.ForkSession` (copies the transcript prefix and *appends* a replacement user turn, so the child auto-runs it) plus the hub `thread/fork` RPC and REST `/s/<id>/fork`. What was missing for this issue was a fork that stops at the prefix and hands the original text back:

- `agent.ForkSessionAtUserTurn` — a `deferInput` variant of the shared fork internals: the child transcript holds only the entries before the divergence turn (still required to be a `USER_INPUT` entry), lineage meta (`ParentSessionID`/`DivergenceTurn`/parent `ForkLabel`) is identical, and the diverging message's original text is returned to the caller.
- Wire: `ThreadForkParams.deferInput` + `ThreadForkResponse.originalInput` (appwire; `deferInput` and `editedInput` are mutually exclusive, empty `editedInput` still errors as before — the old edit-fork contract is unchanged), and `defer_input`/`original_input` on the REST endpoint (snake_case per the naming gate).

**Fork-point semantics.** Forking a user message rewinds to just before it (child = entries `[1..N-1]`) and stages its text. Forking an *assistant* message resolves to the user prompt that produced it (retry semantics): the composer is staged with that prompt, satisfying "populating the input box with the original message" uniformly — the divergence point must be a `USER_INPUT` turn, and a user cannot re-enter an assistant message.

**Edit-before-submit flow.** `startFork` sends `thread/fork` with `deferInput` (REST fallback identical), stages the server-authoritative `originalInput` as the fork child's sticky per-session composer draft (`SerfDrafts.writeFor`), refreshes the sidebar, and navigates to the fork. The existing `SerfDrafts.bind` path restores the draft into the composer on arrival; nothing runs until the user submits.

**Live-echo indexing.** The renderer tracks the authoritative transcript entry index per user message (server echo corrects the local echo's inferred index in `promoteLocalUserMessage`); the hub rejects any stale/non-`USER_INPUT` divergence turn cleanly, so no silent wrong forks.

**Overlap with #43.** #43's concurrent lane builds its own session-fork machinery for `aside`. `ForkSessionAtUserTurn` is a 1-flag variant of the existing shared fork path and should converge with whatever fork helper #43 lands at merge time; the `deferInput`/`originalInput` appwire fields are also natural carriers for #43's webui wiring.

## Test evidence

TDD throughout (3 observed RED→GREEN cycles; RED outputs in the commits' accompanying report):

- `agent/fork_at_test.go` — 5 tests: prefix-only child + original text return, first-turn empty child, non-`USER_INPUT` divergence rejection, out-of-range, missing parent.
- `cmd/serf-hub/app_rpc_test.go` — `TestHubRPCThreadForkDeferInput` (response carries `OriginalInput`, child transcript has no trailing user turn), `TestHubRPCThreadForkDeferInputRejectsEditedInput` (mutual exclusion → `InvalidParams`).
- `cmd/serf-hub/web_test.go` — `TestWeb_Fork_DeferInput` (REST `defer_input` → `original_input`, prefix-only child).
- `cmd/serf-hub/jstest/test-renderer-fork-from-message.js` — fork affordance on user + assistant messages, `defer_input` RPC body, draft staged for the child, navigation, no auto-run (`startTurn` never called), composer pre-populated on the child page.
- `cmd/serf-hub/jstest/test-appwire-fork-defer.js` — wire mapping of `deferInput`/`originalInput`.

Full suites on the rebased commits (this branch): `go build ./...` clean; `go test ./agent ./appwire ./cmd/serf-hub` all ok; `go vet` clean; `jstest/run-all.sh` (196 files) all passed; `make lint-naming` / `make lint-generated` pass. All tests deterministic (temp-dir transcripts, hub RPC test server, JSDOM — no credentials/network/ambient state).

Docs: regenerated `docs/appwire-protocol.md` (contract change) and updated `docs/subagent-runtime-contracts.md` (deferred-input fork lineage note).
