### PR TITLE
openai: normalize a trailing /v1 in the Responses API URL (fixes #65)

### DIFF
--- a/llm/providers/openai/adapter.go
+++ b/llm/providers/openai/adapter.go
@@ -995,16 +995,27 @@ func (a *Adapter) chatCompletionsURL() string {
 	return base + "/v1/chat/completions"
 }
 
+// responsesURL returns the Responses API URL for this adapter, derived from
+// BaseURL and ResponsesPath. Like chatCompletionsURL, it normalizes a
+// trailing /v1 on BaseURL so a base of either "https://host" or
+// "https://host/v1" resolves to the same "https://host/v1/..." URL instead
+// of doubling the /v1 segment. Custom ResponsesPath values that don't start
+// with /v1 (e.g. the ChatGPT/Codex backend path) are left untouched — only
+// the conventional /v1 prefix is deduplicated, never silently stripped from
+// an explicit custom path.
 func (a *Adapter) responsesURL() string {
 	base := strings.TrimRight(a.BaseURL, "/")
 	path := a.ResponsesPath
 	if path == "" {
 		path = defaultResponsesPath
 	}
-	if strings.HasPrefix(path, "/") {
-		return base + path
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
 	}
-	return base + "/" + path
+	if strings.HasSuffix(base, "/v1") && (path == "/v1" || strings.HasPrefix(path, "/v1/")) {
+		base = strings.TrimSuffix(base, "/v1")
+	}
+	return base + path
 }
 
 func (a *Adapter) requiresStreamingComplete() bool {

--- a/llm/providers/openai/url_test.go
+++ b/llm/providers/openai/url_test.go
@@ -1,0 +1,84 @@
+package openai
+
+import "testing"
+
+// TestResponsesURL_NormalizesTrailingV1 covers issue #65: a BaseURL that
+// already ends in /v1 must not double the /v1 segment on the Responses API
+// URL, matching the normalization chatCompletionsURL already performs for
+// the Chat Completions fallback.
+func TestResponsesURL_NormalizesTrailingV1(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		baseURL string
+		path    string // ResponsesPath override; "" uses the default
+		want    string
+	}{
+		{
+			name:    "base without trailing /v1 gets /v1/responses appended",
+			baseURL: "https://host.example",
+			want:    "https://host.example/v1/responses",
+		},
+		{
+			name:    "base with trailing /v1 is not doubled",
+			baseURL: "https://host.example/v1",
+			want:    "https://host.example/v1/responses",
+		},
+		{
+			name:    "base with trailing /v1/ (slash) is not doubled",
+			baseURL: "https://host.example/v1/",
+			want:    "https://host.example/v1/responses",
+		},
+		{
+			name:    "default OpenAI base URL is unaffected",
+			baseURL: defaultAPIBaseURL,
+			want:    defaultAPIBaseURL + defaultResponsesPath,
+		},
+		{
+			name:    "custom path prefix is kept explicit, not stripped",
+			baseURL: "https://host.example/v1",
+			path:    "custom",
+			want:    "https://host.example/v1/custom",
+		},
+		{
+			name:    "codex backend path (no /v1 prefix) is untouched",
+			baseURL: "https://chatgpt.com/backend-api/codex",
+			path:    defaultCodexResponses,
+			want:    "https://chatgpt.com/backend-api/codex" + defaultCodexResponses,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &Adapter{BaseURL: tc.baseURL, ResponsesPath: tc.path}
+			if got := a.responsesURL(); got != tc.want {
+				t.Fatalf("responsesURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestChatCompletionsURL_NormalizesTrailingV1 pins the existing behavior of
+// chatCompletionsURL that responsesURL now mirrors.
+func TestChatCompletionsURL_NormalizesTrailingV1(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		baseURL string
+		want    string
+	}{
+		{
+			name:    "base without trailing /v1 gets /v1/chat/completions appended",
+			baseURL: "https://host.example",
+			want:    "https://host.example/v1/chat/completions",
+		},
+		{
+			name:    "base with trailing /v1 is not doubled",
+			baseURL: "https://host.example/v1",
+			want:    "https://host.example/v1/chat/completions",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &Adapter{BaseURL: tc.baseURL}
+			if got := a.chatCompletionsURL(); got != tc.want {
+				t.Fatalf("chatCompletionsURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`OPENAI_BASE_URL` values that already end in `/v1` (a common convention for OpenAI-compatible endpoints) caused the OpenAI Responses API request to be sent to a doubled path such as `.../v1/v1/responses`, which 404s. The sibling Chat Completions fallback path was unaffected because `chatCompletionsURL()` already normalized this case; `responsesURL()` did not.

## Root cause

`chatCompletionsURL()` checks whether `BaseURL` already ends in `/v1` and avoids re-adding it. `responsesURL()` instead concatenated `BaseURL` with the Responses path (`/v1/responses` by default) unconditionally, so a base of `https://host.example/v1` produced `https://host.example/v1/v1/responses`.

## Fix

`responsesURL()` now mirrors `chatCompletionsURL()`'s approach: if `BaseURL` ends in `/v1` and the effective Responses path itself starts with `/v1` (the default `/v1/responses`, or an explicit path in that form), the duplicate `/v1` segment on the base is dropped before concatenation. A custom `ResponsesPath` that does *not* start with `/v1` (for example the ChatGPT/Codex backend path) is left untouched — the normalization only removes the duplicate conventional prefix, it never silently strips an explicit custom path.

Behavior after the fix:

- `https://host.example` -> `https://host.example/v1/responses`
- `https://host.example/v1` -> `https://host.example/v1/responses`

## Test plan

Added `llm/providers/openai/url_test.go` with table-driven tests covering:

- `responsesURL()` with a base URL that has no trailing `/v1` (unchanged behavior)
- `responsesURL()` with a base URL ending in `/v1` (the regression case from this issue) — with and without a trailing slash
- `responsesURL()` with the default OpenAI base URL (unaffected)
- `responsesURL()` with a custom `ResponsesPath` that doesn't start with `/v1`, confirming it is kept explicit rather than stripped
- `responsesURL()` with the ChatGPT/Codex backend path, confirming it is untouched
- `chatCompletionsURL()` with and without a trailing `/v1`, pinning the existing behavior this fix mirrors

```
go test ./llm/providers/openai/...
ok  	primeradiant.com/serf/llm/providers/openai	2.970s
```

All package tests pass, `go vet ./llm/providers/openai/...` is clean, and `gofmt -l` reports no formatting issues on the changed files.

Fixes #65
