### PR TITLE
fix(openaicompat): reject tool-result images instead of dropping them (fixes #18)

### DIFF
--- a/llm/providers/openaicompat/adapter_test.go
+++ b/llm/providers/openaicompat/adapter_test.go
@@ -541,6 +541,98 @@ func TestAdapter_Complete_ToolResults(t *testing.T) {
 	}
 }
 
+func TestBuildRequestBody_RejectsToolResultImage(t *testing.T) {
+	tests := []struct {
+		name           string
+		imageMediaType string
+	}{
+		{name: "explicit media type", imageMediaType: "image/png"},
+		{name: "defaulted/empty media type", imageMediaType: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := llm.Request{
+				Model: "gpt-4.1-mini",
+				Messages: []llm.Message{{
+					Role: llm.RoleTool,
+					Content: []llm.ContentPart{{
+						Kind: llm.ContentToolResult,
+						ToolResult: &llm.ToolResultData{
+							ToolCallID:     "call_img",
+							Content:        "screenshot",
+							ImageData:      []byte{0x89, 0x50, 0x4e, 0x47},
+							ImageMediaType: tt.imageMediaType,
+						},
+					}},
+				}},
+			}
+			_, err := buildRequestBody(req, true, ModelCompat{})
+			if err == nil {
+				t.Fatal("buildRequestBody accepted tool-result image")
+			}
+			if !strings.Contains(err.Error(), "tool-result images") {
+				t.Fatalf("error=%v, want tool-result image explanation", err)
+			}
+			var configErr *llm.ConfigurationError
+			if !errors.As(err, &configErr) {
+				t.Fatalf("expected ConfigurationError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+func TestAdapter_Complete_ToolResultImage_ReturnsErrorWithoutDispatch(t *testing.T) {
+	a := &Adapter{APIKey: "k", BaseURL: "http://unused"}
+	_, err := a.Complete(context.Background(), llm.Request{
+		Model: "gpt-4.1-mini",
+		Messages: []llm.Message{{
+			Role: llm.RoleTool,
+			Content: []llm.ContentPart{{
+				Kind: llm.ContentToolResult,
+				ToolResult: &llm.ToolResultData{
+					ToolCallID:     "call_img",
+					Content:        "screenshot",
+					ImageData:      []byte{0x89, 0x50, 0x4e, 0x47},
+					ImageMediaType: "image/png",
+				},
+			}},
+		}},
+	})
+	if err == nil {
+		t.Fatal("Complete accepted tool-result image")
+	}
+	var configErr *llm.ConfigurationError
+	if !errors.As(err, &configErr) {
+		t.Fatalf("expected ConfigurationError, got %T: %v", err, err)
+	}
+}
+
+func TestAdapter_Stream_ToolResultImage_ReturnsErrorWithoutDispatch(t *testing.T) {
+	a := &Adapter{APIKey: "k", BaseURL: "http://unused"}
+	_, err := a.Stream(context.Background(), llm.Request{
+		Model: "gpt-4.1-mini",
+		Messages: []llm.Message{{
+			Role: llm.RoleTool,
+			Content: []llm.ContentPart{{
+				Kind: llm.ContentToolResult,
+				ToolResult: &llm.ToolResultData{
+					ToolCallID:     "call_img",
+					Content:        "screenshot",
+					ImageData:      []byte{0x89, 0x50, 0x4e, 0x47},
+					ImageMediaType: "image/png",
+				},
+			}},
+		}},
+	})
+	if err == nil {
+		t.Fatal("Stream accepted tool-result image")
+	}
+	var configErr *llm.ConfigurationError
+	if !errors.As(err, &configErr) {
+		t.Fatalf("expected ConfigurationError, got %T: %v", err, err)
+	}
+}
+
 func TestBuildRequestBody_SanitizesMalformedHistoricalToolCallArguments(t *testing.T) {
 	body, err := buildRequestBody(llm.Request{
 		Model: "m",

--- a/llm/providers/openaicompat/request.go
+++ b/llm/providers/openaicompat/request.go
@@ -10,6 +10,10 @@ import (
 )
 
 func buildRequestBody(req llm.Request, stream bool, mc ModelCompat) (map[string]any, error) {
+	if requestHasToolResultImages(req) {
+		return nil, &llm.ConfigurationError{Message: "openai-compatible chat completions does not support tool-result images"}
+	}
+
 	quirks := mc.Quirks
 	body := map[string]any{
 		"model": req.Model,
@@ -559,6 +563,26 @@ func buildMultimodalParts(parts []llm.ContentPart) []map[string]any {
 		}
 	}
 	return out
+}
+
+// requestHasToolResultImages reports whether any tool-result content part in
+// req carries inline image bytes. The Chat Completions wire format only
+// permits text content on a "role":"tool" message, so a tool result with
+// non-empty ImageData cannot be represented and must be rejected explicitly
+// (mirroring the first-party OpenAI Chat Completions fallback in
+// providers/openai) rather than silently dropped by toChatMessages.
+func requestHasToolResultImages(req llm.Request) bool {
+	for _, m := range req.Messages {
+		if m.Role != llm.RoleTool {
+			continue
+		}
+		for _, p := range m.Content {
+			if p.Kind == llm.ContentToolResult && p.ToolResult != nil && len(p.ToolResult.ImageData) > 0 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func toolCallsFromParts(parts []llm.ContentPart) []map[string]any {


### PR DESCRIPTION
## Summary

The OpenAI-compatible Chat Completions request builder serialized only the
text `Content` of a tool result and never checked `ImageData`, so any image
bytes attached to a tool result (`llm.ToolResultData.ImageData` /
`ImageMediaType`) were silently dropped before the request was ever sent.
The request still succeeded with text only, and nothing indicated that the
image had been discarded, making the loss hard to diagnose.

Serf's first-party OpenAI Chat Completions fallback already handles this
correctly: it rejects an image-bearing tool result explicitly before
building the request, because the Chat Completions wire format only
supports text content on a `"role": "tool"` message.

Fixes #18.

## Fix

`buildRequestBody` in the openai-compatible adapter now checks, before
building the request body, whether any tool-result content part carries
non-empty `ImageData` (regardless of `ImageMediaType`, including a
defaulted/empty one). If so, it returns an explicit
`llm.ConfigurationError` ("openai-compatible chat completions does not
support tool-result images") instead of silently continuing. `Complete`
and `Stream` already propagate `buildRequestBody`'s error, so both paths
now fail before any HTTP request reaches the network, rather than
dispatching a request that quietly omits the image.

Text-only tool results are unaffected and continue to serialize exactly
as before, including existing provider quirks (`RequireToolResultName`,
`RequireAssistantAfterToolResult`, etc.).

## Testing

Added unit tests in `llm/providers/openaicompat/adapter_test.go`:

- `TestBuildRequestBody_RejectsToolResultImage` — `buildRequestBody` returns
  a `ConfigurationError` mentioning "tool-result images" for a tool result
  carrying `ImageData`, both with an explicit `image/png` media type and
  with an empty/defaulted one.
- `TestAdapter_Complete_ToolResultImage_ReturnsErrorWithoutDispatch` —
  `Complete` returns the same error without touching the configured
  server (`BaseURL: "http://unused"`).
- `TestAdapter_Stream_ToolResultImage_ReturnsErrorWithoutDispatch` — same
  for `Stream`.

```
go build ./...
go test ./llm/providers/openaicompat/...
go test ./llm/...
```

All green.
