### PR TITLE
fix(hub): drop deleted project dirs from the recent-projects list (fixes #50)

### DIFF
--- a/cmd/serf-hub/internal/hubcore/past.go
+++ b/cmd/serf-hub/internal/hubcore/past.go
@@ -669,7 +669,10 @@ func (i *PastIndex) RecentModels(limit int) []appwire.ModelDescriptor {
 // actual recency of use: the index's most-recently-updated-first session
 // order (session_order.go's sessionMetaLess — a session's UpdatedAt is its
 // last activity moment), not directory mtime. Entries with a blank WorkingDir
-// are skipped. Deduped on the dir's first (most recent) occurrence.
+// are skipped, as are entries whose WorkingDir no longer exists on disk
+// (issue #50) — a deleted project directory would otherwise linger in the
+// dropdown until it failed later at spawn/submit validation. Deduped on the
+// dir's first (most recent) occurrence.
 func (i *PastIndex) RecentProjectDirs(limit int) []string {
 	if limit <= 0 {
 		return nil
@@ -684,6 +687,9 @@ func (i *PastIndex) RecentProjectDirs(limit int) []string {
 			continue
 		}
 		seen[dir] = true
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			continue
+		}
 		out = append(out, dir)
 		if len(out) >= limit {
 			break

--- a/cmd/serf-hub/internal/hubcore/past.go
+++ b/cmd/serf-hub/internal/hubcore/past.go
@@ -677,16 +677,26 @@ func (i *PastIndex) RecentProjectDirs(limit int) []string {
 	if limit <= 0 {
 		return nil
 	}
+	// Collect every distinct candidate dir under the lock, then stat after
+	// releasing it: os.Stat on a hung network mount can block indefinitely,
+	// and holding even the read lock through that would wedge every index
+	// writer. Collection cannot stop at limit dirs because the cap applies
+	// after the existence filter — a deleted dir must not consume a slot.
 	i.mu.RLock()
-	defer i.mu.RUnlock()
-	seen := make(map[string]bool, limit)
-	var out []string
+	seen := make(map[string]bool, len(i.all))
+	candidates := make([]string, 0, len(i.all))
 	for _, e := range i.all {
 		dir := strings.TrimSpace(e.Meta.EnvInfo.WorkingDir)
 		if dir == "" || seen[dir] {
 			continue
 		}
 		seen[dir] = true
+		candidates = append(candidates, dir)
+	}
+	i.mu.RUnlock()
+
+	var out []string
+	for _, dir := range candidates {
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
 			continue
 		}

--- a/cmd/serf-hub/internal/hubcore/recent_projects_test.go
+++ b/cmd/serf-hub/internal/hubcore/recent_projects_test.go
@@ -86,6 +86,30 @@ func TestPastIndex_RecentProjectDirs_EmptyIndexOrNonPositiveLimitReturnsNil(t *t
 	}
 }
 
+// TestPastIndex_RecentProjectDirs_DeletedDirsDoNotConsumeLimitSlots pins the
+// limit/filter ordering when the distinct dirs outnumber the limit: the cap
+// applies after the existence filter, so a deleted dir in the most-recent
+// slots must not crowd out an existing dir further down the recency order.
+func TestPastIndex_RecentProjectDirs_DeletedDirsDoNotConsumeLimitSlots(t *testing.T) {
+	root := t.TempDir()
+	deleted := filepath.Join(root, "deleted-project") // never created
+	older := mkExistingDir(t, root, "older")
+	oldest := mkExistingDir(t, root, "oldest")
+
+	idx := NewPastIndex("")
+	now := time.Now().UTC()
+	idx.SeedForTest([]schema.SessionMeta{
+		{ID: "02wMz5Txv1C3Hut0M8GCeB", UpdatedAt: now.Add(-1 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: deleted}},
+		{ID: "02wMz5Txv2enqVTitaig6F", UpdatedAt: now.Add(-2 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: older}},
+		{ID: "02wMz5Txv47YP64RR3B9YJ", UpdatedAt: now.Add(-3 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: oldest}},
+	})
+	got := idx.RecentProjectDirs(2)
+	want := []string{older, oldest}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RecentProjectDirs(2) = %v, want %v (deleted dir %q must not consume a limit slot)", got, want, deleted)
+	}
+}
+
 // TestPastIndex_RecentProjectDirs_FiltersDeletedDirs covers issue #50: a
 // WorkingDir that no longer exists on disk (its project directory was
 // deleted) must be excluded from the recent-projects list, while a

--- a/cmd/serf-hub/internal/hubcore/recent_projects_test.go
+++ b/cmd/serf-hub/internal/hubcore/recent_projects_test.go
@@ -2,6 +2,8 @@ package hubcore
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -9,36 +11,56 @@ import (
 	"primeradiant.com/serf/agent/schema"
 )
 
+// mkExistingDir creates and returns a real directory under t's temp root so
+// RecentProjectDirs' existence filter (issue #50) keeps it.
+func mkExistingDir(t *testing.T, root, name string) string {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", dir, err)
+	}
+	return dir
+}
+
 // TestPastIndex_RecentProjectDirs_DedupesGlobalRecencyLastN covers the session
 // creation flows' recent-project source (issue #35): distinct working dirs in
 // the index's most-recently-updated-first order, deduped on first (most
 // recent) occurrence, blank dirs skipped, capped at the limit.
 func TestPastIndex_RecentProjectDirs_DedupesGlobalRecencyLastN(t *testing.T) {
+	root := t.TempDir()
+	alpha := mkExistingDir(t, root, "alpha")
+	beta := mkExistingDir(t, root, "beta")
+	gamma := mkExistingDir(t, root, "gamma")
+
 	idx := NewPastIndex("")
 	now := time.Now().UTC()
 	idx.SeedForTest([]schema.SessionMeta{
-		{ID: "02wMz5Txv1C3Hut0M8GCeB", UpdatedAt: now.Add(-1 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: "/alpha"}},
-		{ID: "02wMz5Txv2enqVTitaig6F", UpdatedAt: now.Add(-2 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: "/beta"}},
-		{ID: "02wMz5Txv47YP64RR3B9YJ", UpdatedAt: now.Add(-3 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: "  "}},     // blank — skipped
-		{ID: "02wMz5Txv5aIxgf9yVdd0N", UpdatedAt: now.Add(-4 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: "/alpha"}}, // dup of /alpha, older — dropped
-		{ID: "02wMz5Txv733WHFsVy66SR", UpdatedAt: now.Add(-5 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: "/gamma"}},
+		{ID: "02wMz5Txv1C3Hut0M8GCeB", UpdatedAt: now.Add(-1 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: alpha}},
+		{ID: "02wMz5Txv2enqVTitaig6F", UpdatedAt: now.Add(-2 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: beta}},
+		{ID: "02wMz5Txv47YP64RR3B9YJ", UpdatedAt: now.Add(-3 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: "  "}},  // blank — skipped
+		{ID: "02wMz5Txv5aIxgf9yVdd0N", UpdatedAt: now.Add(-4 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: alpha}}, // dup of alpha, older — dropped
+		{ID: "02wMz5Txv733WHFsVy66SR", UpdatedAt: now.Add(-5 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: gamma}},
 	})
 	got := idx.RecentProjectDirs(15)
-	want := []string{"/alpha", "/beta", "/gamma"}
+	want := []string{alpha, beta, gamma}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("RecentProjectDirs(15) = %v, want %v", got, want)
 	}
 }
 
 func TestPastIndex_RecentProjectDirs_CapsAtLimit(t *testing.T) {
+	root := t.TempDir()
 	idx := NewPastIndex("")
 	now := time.Now().UTC()
 	metas := make([]schema.SessionMeta, 0, 20)
+	dirs := make([]string, 0, 20)
 	for n := range 20 {
+		dir := mkExistingDir(t, root, fmt.Sprintf("proj-%02d", n))
+		dirs = append(dirs, dir)
 		metas = append(metas, schema.SessionMeta{
 			ID:        fmt.Sprintf("02wMz5Txv1C3Hut0M8GC%02d", n),
 			UpdatedAt: now.Add(-time.Duration(n) * time.Minute),
-			EnvInfo:   schema.EnvironmentInfo{WorkingDir: fmt.Sprintf("/proj-%02d", n)},
+			EnvInfo:   schema.EnvironmentInfo{WorkingDir: dir},
 		})
 	}
 	idx.SeedForTest(metas)
@@ -46,8 +68,8 @@ func TestPastIndex_RecentProjectDirs_CapsAtLimit(t *testing.T) {
 	if len(got) != 15 {
 		t.Fatalf("RecentProjectDirs(15) returned %d dirs, want 15", len(got))
 	}
-	if got[0] != "/proj-00" || got[14] != "/proj-14" {
-		t.Fatalf("RecentProjectDirs(15) = %v…%v, want /proj-00…/proj-14 (most recent first)", got[0], got[14])
+	if got[0] != dirs[0] || got[14] != dirs[14] {
+		t.Fatalf("RecentProjectDirs(15) = %v…%v, want %v…%v (most recent first)", got[0], got[14], dirs[0], dirs[14])
 	}
 }
 
@@ -57,9 +79,33 @@ func TestPastIndex_RecentProjectDirs_EmptyIndexOrNonPositiveLimitReturnsNil(t *t
 		t.Fatalf("RecentProjectDirs on empty index = %v, want nil", got)
 	}
 	idx.SeedForTest([]schema.SessionMeta{
-		{ID: "02wMz5Txv1C3Hut0M8GCeB", UpdatedAt: time.Now().UTC(), EnvInfo: schema.EnvironmentInfo{WorkingDir: "/alpha"}},
+		{ID: "02wMz5Txv1C3Hut0M8GCeB", UpdatedAt: time.Now().UTC(), EnvInfo: schema.EnvironmentInfo{WorkingDir: t.TempDir()}},
 	})
 	if got := idx.RecentProjectDirs(0); got != nil {
 		t.Fatalf("RecentProjectDirs(0) = %v, want nil", got)
+	}
+}
+
+// TestPastIndex_RecentProjectDirs_FiltersDeletedDirs covers issue #50: a
+// WorkingDir that no longer exists on disk (its project directory was
+// deleted) must be excluded from the recent-projects list, while a
+// WorkingDir that still exists is kept.
+func TestPastIndex_RecentProjectDirs_FiltersDeletedDirs(t *testing.T) {
+	root := t.TempDir()
+	existing := mkExistingDir(t, root, "still-here")
+	deleted := filepath.Join(root, "deleted-project")
+	// Never created — simulates a project directory that has since been
+	// removed from disk.
+
+	idx := NewPastIndex("")
+	now := time.Now().UTC()
+	idx.SeedForTest([]schema.SessionMeta{
+		{ID: "02wMz5Txv1C3Hut0M8GCeB", UpdatedAt: now.Add(-1 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: deleted}},
+		{ID: "02wMz5Txv2enqVTitaig6F", UpdatedAt: now.Add(-2 * time.Minute), EnvInfo: schema.EnvironmentInfo{WorkingDir: existing}},
+	})
+	got := idx.RecentProjectDirs(15)
+	want := []string{existing}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RecentProjectDirs(15) = %v, want %v (deleted dir %q must be dropped)", got, want, deleted)
 	}
 }


### PR DESCRIPTION
## Summary

`PastIndex.RecentProjectDirs` (used by the session creation flows' recent-projects dropdown, issue #35) returns raw historical `WorkingDir` strings pulled from the session index, without checking whether the directory still exists on disk. If a project directory has since been deleted, it still shows up as a selectable recent project. The picker accepts it on click with no existence validation, and the deletion only surfaces later when spawning/submitting the session fails — instead of the stale directory being excluded from the options up front.

Fixes #50.

## Fix

`RecentProjectDirs` now calls `os.Stat` on each candidate `WorkingDir` (after deduplication, so each distinct path is stat'd at most once) and skips it when `os.Stat` reports `os.IsNotExist`. Directories that still exist are returned exactly as before, in the same most-recently-updated-first, deduped, limit-capped order.

## Testing

Updated `cmd/serf-hub/internal/hubcore/recent_projects_test.go`:

- The existing `RecentProjectDirs` tests previously exercised fake, never-created paths (e.g. `/alpha`, `/proj-00`). With the new existence filter these would now be (correctly) dropped, so they're updated to use real temporary directories created via `t.TempDir()`/`os.MkdirAll`.
- Added `TestPastIndex_RecentProjectDirs_FiltersDeletedDirs`, which seeds the index with one `WorkingDir` pointing at a directory that is never created (simulating a deleted project) and one pointing at a directory that exists, and asserts only the existing one comes back.

```
go build ./...
go test ./cmd/serf-hub/internal/hubcore/...
```

All green.
