### PR TITLE
server: guarantee the queued-input wake instead of dropping it

### DIFF
--- a/cmd/serf/serve.go
+++ b/cmd/serf/serve.go
@@ -1030,12 +1030,7 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 					srv.SetState(string(agent.SessionProcessing))
 				})
 			} else if msg.QueuedInput {
-				result, processed, processErr = sess.ProcessPendingUserInput(turnCtx, func(turnID string) {
-					srv.SetCancelFunc(cancelTurn)
-					setMutationRunner(cancelTurn, runnerDone)
-					srv.SetProcessingTurn(turnID)
-					srv.SetState(string(agent.SessionProcessing))
-				})
+				_ = sess
 			} else {
 				result, processErr = sess.ProcessInputKind(turnCtx, msg.Text, msg.Images, msg.Kind)
 			}

--- a/cmd/serf/serve.go
+++ b/cmd/serf/serve.go
@@ -1030,7 +1030,12 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 					srv.SetState(string(agent.SessionProcessing))
 				})
 			} else if msg.QueuedInput {
-				_ = sess
+				result, processed, processErr = sess.ProcessPendingUserInput(turnCtx, func(turnID string) {
+					srv.SetCancelFunc(cancelTurn)
+					setMutationRunner(cancelTurn, runnerDone)
+					srv.SetProcessingTurn(turnID)
+					srv.SetState(string(agent.SessionProcessing))
+				})
 			} else {
 				result, processErr = sess.ProcessInputKind(turnCtx, msg.Text, msg.Images, msg.Kind)
 			}

--- a/server/pending_user_input_wake_test.go
+++ b/server/pending_user_input_wake_test.go
@@ -1,0 +1,255 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"primeradiant.com/serf/agent"
+	"primeradiant.com/serf/agent/execenv"
+	"primeradiant.com/serf/agent/provider"
+	"primeradiant.com/serf/appwire"
+	"primeradiant.com/serf/llm"
+)
+
+// TestSubmitPendingUserInput_DeliveredOnceTheSlotFrees pins that a queued-input
+// wake is guaranteed, not best-effort.
+//
+// The queued-input wake is the ONLY way ProcessPendingUserInput is ever reached:
+// cmd/serf/serve.go:1033 runs it in response to a QueuedInput message and
+// nothing else calls it. Unlike a durable start — which processNextServeInput
+// probes for unconditionally at the top of every loop iteration — there is no
+// second path to the work. A dropped wake therefore strands a message the client
+// has already been told was accepted.
+func TestSubmitPendingUserInput_DeliveredOnceTheSlotFrees(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+
+	// Occupy the single slot with unrelated input.
+	srv.SubmitContinuation("keep the slot busy")
+	srv.SubmitPendingUserInput("session-under-full-slot")
+
+	occupant := <-srv.InputCh()
+	if occupant.Kind != agent.EntryContinuation {
+		t.Fatalf("first message Kind = %v, want EntryContinuation (the occupant)", occupant.Kind)
+	}
+
+	select {
+	case msg := <-srv.InputCh():
+		if !msg.QueuedInput {
+			t.Fatalf("message = %#v, want QueuedInput", msg)
+		}
+		if msg.SessionID != "session-under-full-slot" {
+			t.Fatalf("SessionID = %q, want session-under-full-slot", msg.SessionID)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("the dropped queued-input wake was never redelivered: a durably accepted message runs never, because nothing polls ProcessPendingUserInput")
+	}
+}
+
+// TestSubmitPendingUserInput_RepeatedDropsWakeOnce pins that the re-arm
+// coalesces, for the same reason SubmitNotification's does.
+//
+// One wake settles any number of dropped ones: the wake runs the queue head as
+// its own turn, and that turn's drain tail runs whatever else accumulated —
+// selectDrainNextAction returns runQueued at every tail, and its awaiting branch
+// keeps the queued-input rung live while holding every other rung. Re-arming per
+// drop would push a burst of turns onto a session that only needed one.
+func TestSubmitPendingUserInput_RepeatedDropsWakeOnce(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+
+	srv.SubmitContinuation("keep the slot busy")
+	for range 5 {
+		srv.SubmitPendingUserInput("session-under-full-slot")
+	}
+
+	if occupant := <-srv.InputCh(); occupant.Kind != agent.EntryContinuation {
+		t.Fatalf("first message Kind = %v, want EntryContinuation (the occupant)", occupant.Kind)
+	}
+	select {
+	case msg := <-srv.InputCh():
+		if !msg.QueuedInput {
+			t.Fatalf("message = %#v, want QueuedInput", msg)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("the dropped queued-input wakes were never redelivered")
+	}
+
+	// Negative assertion: nothing to poll for, so this waits a fixed moment and
+	// asserts the absence of a second wake.
+	time.Sleep(250 * time.Millisecond)
+	select {
+	case extra := <-srv.InputCh():
+		t.Fatalf("a second wake arrived (%#v): repeated drops must coalesce into one re-arm", extra)
+	default:
+	}
+}
+
+// TestSubmitPendingUserInput_DoesNotBlockItsCaller pins the constraint that
+// forces the re-arm onto a parked goroutine rather than onto the caller.
+//
+// The wake is called synchronously from AcceptClientMutationQueue, which runs on
+// the AppWire request handler goroutine. A blocking send there would stall the
+// client's turn/queue response behind the serve loop.
+func TestSubmitPendingUserInput_DoesNotBlockItsCaller(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SubmitContinuation("keep the slot busy")
+
+	returned := make(chan struct{})
+	go func() {
+		defer close(returned)
+		srv.SubmitPendingUserInput("session-under-full-slot")
+	}()
+	select {
+	case <-returned:
+	case <-time.After(10 * time.Second):
+		t.Fatal("SubmitPendingUserInput blocked on a full channel; it runs on the AppWire request handler goroutine and must not")
+	}
+}
+
+// TestQueuedInputRunsAfterItsWakeIsDropped is the kata's acceptance case, driven
+// through the real seams rather than through a stand-in for the serve loop.
+//
+// A message the client queued is durably accepted while the one input slot is
+// occupied, so its wake is dropped. The assertions then follow the message the
+// rest of the way: the re-armed wake lands, it names this session, and the work
+// it names is really there and really runs.
+//
+// The wake wiring below is the exact callback cmd/serf/serve.go:690-692
+// installs, so this test exercises the production seam and not a paraphrase of
+// it. There is deliberately no consumer loop here: a hand-written reader that
+// branched on message kind would be a second implementation of the serve loop,
+// free to drift from the real one while staying green.
+func TestQueuedInputRunsAfterItsWakeIsDropped(t *testing.T) {
+	const queuedText = "run me even though my wake was dropped"
+
+	adapter := &queuedInputRecordingAdapter{}
+	stateDir := t.TempDir()
+	client := llm.NewClient()
+	client.Register(adapter)
+	sess, err := agent.NewSession(
+		client,
+		provider.NewOpenAIProfile("gpt-5.2"),
+		execenv.NewLocalExecutionEnvironment(stateDir),
+		agent.SessionConfig{StateDir: stateDir},
+	)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+
+	srv := NewServer(ServerConfig{})
+	sess.SetPendingUserInputWakeFunc(func() { srv.SubmitPendingUserInput(sess.ID()) })
+
+	// Occupy the one slot, exactly as a job-completion notification does while a
+	// question is pending. That occupant is what makes the wake below drop.
+	srv.SubmitContinuation("keep the slot busy")
+
+	if _, err := sess.AcceptClientMutationQueue(appwire.TurnQueueParams{
+		ClientMutationID: "cm-queued-under-full-slot",
+		Input:            []appwire.InputItem{{Type: "text", Text: queuedText}},
+	}); err != nil {
+		t.Fatalf("AcceptClientMutationQueue: %v", err)
+	}
+
+	// The serve loop consumes the occupant, freeing the slot.
+	if occupant := <-srv.InputCh(); occupant.Kind != agent.EntryContinuation {
+		t.Fatalf("first message Kind = %v, want EntryContinuation (the occupant)", occupant.Kind)
+	}
+
+	select {
+	case msg := <-srv.InputCh():
+		if !msg.QueuedInput {
+			t.Fatalf("message = %#v, want QueuedInput", msg)
+		}
+		if msg.SessionID != sess.ID() {
+			t.Fatalf("SessionID = %q, want this session %q", msg.SessionID, sess.ID())
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatalf("the queued message was durably accepted and its wake dropped; nothing ever came back for it, so %q runs never", queuedText)
+	}
+
+	_, ran, err := sess.ProcessPendingUserInput(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ProcessPendingUserInput: %v", err)
+	}
+	if !ran {
+		t.Fatal("the redelivered wake named no runnable work; it arrived, but too late or for the wrong session")
+	}
+	if !adapter.sawText(queuedText) {
+		t.Fatalf("the turn ran but the model never saw %q; the wake landed and the payload did not", queuedText)
+	}
+}
+
+// queuedInputRecordingAdapter ends every turn immediately and records the
+// request text it was given, so a test can assert the queued payload actually
+// reached the model rather than trusting that a turn ran.
+type queuedInputRecordingAdapter struct {
+	mu   sync.Mutex
+	seen []string
+}
+
+func (a *queuedInputRecordingAdapter) Name() string { return "openai" }
+
+func (a *queuedInputRecordingAdapter) Complete(ctx context.Context, req llm.Request) (llm.Response, error) {
+	var text strings.Builder
+	for _, msg := range req.Messages {
+		for _, part := range msg.Content {
+			text.WriteString(part.Text)
+			text.WriteString("\n")
+		}
+	}
+	a.mu.Lock()
+	a.seen = append(a.seen, text.String())
+	a.mu.Unlock()
+
+	if !requestHasTool(req, "communicate") {
+		return llm.Response{
+			Provider: a.Name(),
+			Model:    req.Model,
+			Message:  llm.Assistant(`{"name":"queued input wake"}`),
+		}, nil
+	}
+	args, _ := json.Marshal(map[string]any{
+		"message":  "done",
+		"end_turn": true,
+		"output": map[string]any{
+			"message":   "",
+			"data":      map[string]any{},
+			"artifacts": []string{},
+		},
+	})
+	return llm.Response{
+		Provider: a.Name(),
+		Model:    req.Model,
+		Message: llm.Message{
+			Role: llm.RoleAssistant,
+			Content: []llm.ContentPart{{
+				Kind: llm.ContentToolCall,
+				ToolCall: &llm.ToolCallData{
+					ID:        "communicate-queued-input",
+					Name:      "communicate",
+					Arguments: args,
+					Type:      "function",
+				},
+			}},
+		},
+	}, nil
+}
+
+func (a *queuedInputRecordingAdapter) Stream(context.Context, llm.Request) (llm.Stream, error) {
+	return nil, llm.ErrStreamUnsupported
+}
+
+func (a *queuedInputRecordingAdapter) sawText(want string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, seen := range a.seen {
+		if strings.Contains(seen, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/server/server.go
+++ b/server/server.go
@@ -344,7 +344,12 @@ type Server struct {
 	// notification kick that found the input slot full. It coalesces further
 	// drops into that one parked send. See SubmitNotification.
 	notifyWakeRearmed bool
-	inputCh           chan InputMessage
+	// pendingUserInputWakeRearmed is notifyWakeRearmed's counterpart for the
+	// queued-input wake. Each guaranteed wake needs its own flag: one shared
+	// flag would let a parked notification swallow a queued-input kick, which is
+	// the very drop both are here to prevent. See SubmitPendingUserInput.
+	pendingUserInputWakeRearmed bool
+	inputCh                     chan InputMessage
 	hubToken          string
 	sameOrigin        httpguard.SameOriginPolicy
 }
@@ -746,43 +751,32 @@ func (s *Server) SubmitContinuation(prompt string) {
 // 1-slot input channel. It is wired from serve.go via Session.SetNotifyFunc
 // (the agent module must not import server).
 //
-// The wake is GUARANTEED, not best-effort. A kick that finds the slot occupied
-// is re-armed on a goroutine that parks on the send and completes it the moment
-// the slot frees. Dropping it outright is only safe for a session that is
-// mid-turn, where the drain loop's tail gate re-checks the queue; an idle
-// session has no tail to run, so a dropped kick leaves a finished job unheard
-// until some unrelated input happens along. There is no timer and no poll here:
-// the parked send IS the wait for channel availability.
+// The wake is GUARANTEED, not best-effort (see submitGuaranteedWake for how).
+// Dropping it outright is only safe for a session that is mid-turn, where the
+// drain loop's tail gate re-checks the queue; an idle session has no tail to
+// run, so a dropped kick leaves a finished job unheard until some unrelated
+// input happens along.
 //
-// The call itself never blocks, and repeated drops coalesce into the one parked
-// send — the queue that wake drains is drained whole, so one wake settles any
-// number of dropped kicks.
+// Repeated drops coalescing into one parked send is safe here because the queue
+// that wake drains is drained whole, so one wake settles any number of dropped
+// kicks.
 func (s *Server) SubmitNotification() {
-	select {
-	case s.inputCh <- InputMessage{Kind: agent.EntryNotification}:
-		return
-	default:
-	}
-	s.mu.Lock()
-	if s.notifyWakeRearmed {
-		s.mu.Unlock()
-		return
-	}
-	s.notifyWakeRearmed = true
-	s.mu.Unlock()
-	go func() {
-		s.inputCh <- InputMessage{Kind: agent.EntryNotification}
-		// Cleared only after the send lands, so every kick dropped while this
-		// one was parked is covered by it.
-		s.mu.Lock()
-		s.notifyWakeRearmed = false
-		s.mu.Unlock()
-	}()
+	s.submitGuaranteedWake(InputMessage{Kind: agent.EntryNotification}, &s.notifyWakeRearmed)
 }
 
 // SubmitClientMutationStart wakes the serve loop after a turn/start intent is
 // durably accepted. The loop claims the stored payload and identity from the
 // named session rather than carrying either through this process-local signal.
+//
+// This wake is best-effort, and deliberately so: the serve loop probes for a
+// runnable durable start at the top of every iteration, before it blocks on this
+// channel (processNextServeInput). That probe is the backstop, and it is a
+// complete one — for a kick to be dropped here the channel must be non-empty, so
+// the loop cannot be blocked indefinitely; it consumes that message and probes
+// again. Re-arming this wake the way the two guaranteed ones are re-armed would
+// make it worse rather than redundant: the parked message names a session, the
+// loop discards a start message whose SessionID is not the live session, and the
+// coalescing flag would meanwhile have suppressed the later, correct kick.
 func (s *Server) SubmitClientMutationStart(sessionID string) {
 	select {
 	case s.inputCh <- InputMessage{ClientMutationStart: true, SessionID: sessionID}:
@@ -794,9 +788,65 @@ func (s *Server) SubmitClientMutationStart(sessionID string) {
 // SubmitClientMutationStart it names the session rather than carrying the
 // payload, so the loop reads whatever the journal actually owns at the moment
 // it claims.
+//
+// The wake is GUARANTEED, for the same reason SubmitNotification's is and with
+// more at stake. A QueuedInput message is the only thing that reaches
+// ProcessPendingUserInput; unlike a durable start there is no probe, so nothing
+// comes back for a dropped kick. The stranding is real and quiet: a job
+// notification occupying the slot while a question is pending is refused by the
+// entry gate, so no turn runs, so no drain tail sweeps the queue — and the
+// client has already been handed a receipt saying its message was accepted.
+//
+// One wake settles any number of dropped ones. The wake runs the queue head as
+// its own turn and that turn's drain tail runs the rest: selectDrainNextAction
+// returns runQueued at every tail, and its awaiting branch keeps the
+// queued-input rung live while holding every other rung.
 func (s *Server) SubmitPendingUserInput(sessionID string) {
+	s.submitGuaranteedWake(
+		InputMessage{QueuedInput: true, SessionID: sessionID},
+		&s.pendingUserInputWakeRearmed,
+	)
+}
+
+// submitGuaranteedWake delivers msg on the 1-slot input channel without ever
+// blocking its caller and without ever dropping the wake. It is the shared shape
+// behind SubmitNotification and SubmitPendingUserInput; each passes its own
+// re-arm flag, which must be guarded by s.mu and used by that wake alone.
+//
+// A kick that finds the slot occupied is re-armed on a goroutine that parks on
+// the send and completes it the moment the slot frees. There is no timer and no
+// poll: the parked send IS the wait for channel availability. Not blocking the
+// caller is a requirement, not an optimization — these wakes run synchronously
+// on the AppWire request handler goroutine, and a blocking send there would
+// stall a client's response behind the serve loop.
+//
+// rearmed is cleared only after the send lands, so every kick dropped while this
+// one was parked is covered by it. That coalescing is safe only for a wake whose
+// work is drained whole rather than one item at a time; both callers document
+// why theirs is.
+//
+// The parked goroutine outlives a serve loop that stops reading, for the life of
+// the process. Server has no shutdown lifecycle to select against, and inventing
+// one to close a per-process-exit goroutine is a worse trade than the goroutine.
+// Consolidating both wakes here means that exposure is one fact about this
+// codebase, and one line to change if Server ever grows such a lifecycle.
+func (s *Server) submitGuaranteedWake(msg InputMessage, rearmed *bool) {
 	select {
-	case s.inputCh <- InputMessage{QueuedInput: true, SessionID: sessionID}:
+	case s.inputCh <- msg:
+		return
 	default:
 	}
+	s.mu.Lock()
+	if *rearmed {
+		s.mu.Unlock()
+		return
+	}
+	*rearmed = true
+	s.mu.Unlock()
+	go func() {
+		s.inputCh <- msg
+		s.mu.Lock()
+		*rearmed = false
+		s.mu.Unlock()
+	}()
 }

--- a/server/server.go
+++ b/server/server.go
@@ -350,8 +350,8 @@ type Server struct {
 	// the very drop both are here to prevent. See SubmitPendingUserInput.
 	pendingUserInputWakeRearmed bool
 	inputCh                     chan InputMessage
-	hubToken          string
-	sameOrigin        httpguard.SameOriginPolicy
+	hubToken                    string
+	sameOrigin                  httpguard.SameOriginPolicy
 }
 
 // SetRetrySafeTurnFunctions installs the authoritative retry-safe mutation


### PR DESCRIPTION
Closes kata gbbm.

`SubmitPendingUserInput` was a bare `select`/`default` drop. When the one-slot `inputCh` was full, the wake vanished and a durably accepted `turn/queue` was stranded with nothing scheduled to come back for it.

The stranding sequence, traced end to end:

1. Session posts an `ask_user`, turn ends in `SessionAwaiting`; its drain tail already ran with an empty queue.
2. A job finishes, `SubmitNotification` fills the slot.
3. Client sends `turn/queue`. It commits durably, returns a receipt saying Applied, then its wake finds the slot full and is dropped.
4. The serve loop takes the notification. The entry gate refuses every non-user kind while a question is pending, so no turn runs and there is no drain tail to pick up the queue.
5. The loop blocks on the channel. The accepted message never runs.

## What changed

`submitGuaranteedWake` — extracted, and now shared by `SubmitNotification` and `SubmitPendingUserInput`. On a full slot it parks one goroutine on the send behind a re-arm flag cleared only once the send lands. Blast radius is `server/server.go` only.

Coalescing is safe for the same reason it is for notifications, and the reason was checked rather than assumed: `selectDrainNextAction` returns `runQueued` at every turn tail, and the awaiting branch keeps the queued-input rung live. One delivered wake runs the head, and that turn's own drain tail sweeps the rest.

## The kata's own claim about client starts is wrong

The kata "corrects" an earlier reviewer by saying client-start wakes have no polling backstop. They do. `processNextServeInput` probes `ClientMutationStart` unconditionally at the top of every iteration before it blocks, `ProcessClientMutationStart` returns `processed=false` cheaply when nothing is runnable, and `TestProcessNextServeInputClaimsDurableStartAfterCoalescedWake` already pins it. The backstop is complete rather than lucky: a dropped start wake implies a non-empty channel, so the loop cannot be parked and always re-probes after consuming.

So `SubmitClientMutationStart` is deliberately left best-effort. Adding a parked send there would also be actively wrong — the parked message carries a `SessionID`, and the serve loop discards start messages naming a non-live session, so a re-arm landing after `setSession` would be discarded while having suppressed a later correct wake.

## Verification

`make merge-approval-gate` green (289s). Reverting the re-arm times out the three delivery tests at 10s. Deleting the coalescing guard trips both the new test and the pre-existing `TestSubmitNotification_RepeatedDropsWakeOnce`, which is the evidence the helper is genuinely shared and the notification guarantee is intact.

## Provenance

Reconstructed after the original worktree was destroyed. Two repair commits sit on top: a gofmt fix (the lane ran build, test and vet, but not gofmt, so `make lint` failed), and the removal of a reviewer's deliberate mutation to `cmd/serf/serve.go` that the reconstruction had captured and committed as if it were lane work. That mutation gutted the `QueuedInput` dispatch; with it reapplied, `TestE2E_QueuedInputRunsWhileAQuestionIsPending` fails at 182s, and with it removed the same test passes in 2.8s.

Known residue: the goroutine parked on a send never completes if the serve loop exits first. `Server` has no shutdown lifecycle to select against — only a `SetShutdownFunc` callback — so inventing one was out of scope. `SubmitNotification` already had this exposure; the extraction means it is now one fact to fix rather than two copies.