### PR TITLE
agent: weigh conversation, not hook records, in the re-injection detector

### DIFF
--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -1696,6 +1696,13 @@ func (s *Session) logPluginLoadDiag(p plugin.Instance) {
 // is the anomaly: on a true resume the kind is "resume", which startup-only
 // matchers (startup|clear|compact) must not match, so delivered should be 0.
 // The entry is tagged outcome=failure in that case so it greps out of the noise.
+//
+// The history it weighs is conversation, counted by conversationHistoryTurns,
+// never the raw length of s.history. A dispatch seeds a HOOK_COMPLETED turn per
+// hook it runs (the runner's HookEnd callback records them before
+// RunSessionStartFor returns), so a detector reading raw history would count its
+// own dispatch as prior history and flag every fresh session that runs a
+// SessionStart hook — the dilution kata 6p54 was filed for.
 func (s *Session) logSessionStartHookDispatch(kind plugin.SessionStartKind, delivered int) {
 	if s == nil || s.stateDir == "" {
 		return
@@ -1704,7 +1711,7 @@ func (s *Session) logSessionStartHookDispatch(kind plugin.SessionStartKind, deli
 	if k == "" {
 		k = string(plugin.SessionStartKindStartup)
 	}
-	historyTurns := len(s.history)
+	historyTurns := s.conversationHistoryTurns()
 	outcome := "success"
 	var failures []string
 	if delivered > 0 && (historyTurns > 0 || s.modelResponses > 0) {
@@ -1726,6 +1733,25 @@ func (s *Session) logSessionStartHookDispatch(kind plugin.SessionStartKind, deli
 		return
 	}
 	_ = log.Append(entry)
+}
+
+// conversationHistoryTurns counts the turns of actual conversation in history,
+// excluding the HOOK_COMPLETED records that only report that a hook ran. It
+// answers "does this session already carry a conversation?" — the question the
+// re-injection detector asks — with a number no hook dispatch can inflate.
+func (s *Session) conversationHistoryTurns() int {
+	if s == nil {
+		return 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, t := range s.history {
+		if t.Kind != schema.TurnHookCompleted {
+			n++
+		}
+	}
+	return n
 }
 
 func (s *Session) runDeferredRestoreSideEffects() error {

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -1697,7 +1697,7 @@ func (s *Session) logPluginLoadDiag(p plugin.Instance) {
 // matchers (startup|clear|compact) must not match, so delivered should be 0.
 // The entry is tagged outcome=failure in that case so it greps out of the noise.
 //
-// The history it weighs is conversation, counted by conversationHistoryTurns,
+// The history it weighs is conversation, counted by conversationSignals,
 // never the raw length of s.history. A dispatch seeds a HOOK_COMPLETED turn per
 // hook it runs (the runner's HookEnd callback records them before
 // RunSessionStartFor returns), so a detector reading raw history would count its
@@ -1711,19 +1711,19 @@ func (s *Session) logSessionStartHookDispatch(kind plugin.SessionStartKind, deli
 	if k == "" {
 		k = string(plugin.SessionStartKindStartup)
 	}
-	historyTurns := s.conversationHistoryTurns()
+	historyTurns, modelResponses := s.conversationSignals()
 	outcome := "success"
 	var failures []string
-	if delivered > 0 && (historyTurns > 0 || s.modelResponses > 0) {
+	if delivered > 0 && (historyTurns > 0 || modelResponses > 0) {
 		outcome = "failure"
 		failures = append(failures, fmt.Sprintf(
 			"SessionStart hooks re-injected: kind=%s delivered=%d on a session with prior history (historyTurns=%d modelResponses=%d) — a resume/restart should pass kind=resume and deliver 0",
-			k, delivered, historyTurns, s.modelResponses))
+			k, delivered, historyTurns, modelResponses))
 	}
 	entry := sessionlog.SessionLogEntry{
 		Kind:     "advisory",
 		Action:   "session_start_hooks",
-		Summary:  fmt.Sprintf("SessionStart hooks dispatched: kind=%s delivered=%d historyTurns=%d modelResponses=%d", k, delivered, historyTurns, s.modelResponses),
+		Summary:  fmt.Sprintf("SessionStart hooks dispatched: kind=%s delivered=%d historyTurns=%d modelResponses=%d", k, delivered, historyTurns, modelResponses),
 		Outcome:  outcome,
 		Failures: failures,
 	}
@@ -1735,23 +1735,27 @@ func (s *Session) logSessionStartHookDispatch(kind plugin.SessionStartKind, deli
 	_ = log.Append(entry)
 }
 
-// conversationHistoryTurns counts the turns of actual conversation in history,
-// excluding the HOOK_COMPLETED records that only report that a hook ran. It
-// answers "does this session already carry a conversation?" — the question the
-// re-injection detector asks — with a number no hook dispatch can inflate.
-func (s *Session) conversationHistoryTurns() int {
+// conversationSignals reports the two numbers the re-injection detector weighs,
+// read together under one lock so they describe the same instant.
+//
+// The turn count is conversation only, excluding the HOOK_COMPLETED records
+// that report a hook ran. It answers "does this session already carry a
+// conversation?" — the question the detector asks — with a number no hook
+// dispatch can inflate. modelResponses is guarded by the same mutex (see the
+// field's documentation on Session), and the detector reaches it on the drain
+// path, where steering turns append from other goroutines.
+func (s *Session) conversationSignals() (historyTurns, modelResponses int) {
 	if s == nil {
-		return 0
+		return 0, 0
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	n := 0
 	for _, t := range s.history {
 		if t.Kind != schema.TurnHookCompleted {
-			n++
+			historyTurns++
 		}
 	}
-	return n
+	return historyTurns, s.modelResponses
 }
 
 func (s *Session) runDeferredRestoreSideEffects() error {

--- a/agent/session_start_reinjection_test.go
+++ b/agent/session_start_reinjection_test.go
@@ -1,0 +1,134 @@
+package agent
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+
+	"primeradiant.com/serf/agent/execenv"
+	"primeradiant.com/serf/agent/internal/sessionlog"
+	"primeradiant.com/serf/agent/schema"
+	"primeradiant.com/serf/llm"
+)
+
+// sessionStartHookDispatchEntry returns the single session_start_hooks advisory
+// written by a session's SessionStart dispatch.
+func sessionStartHookDispatchEntry(t *testing.T, stateDir, sessionID string) sessionlog.SessionLogEntry {
+	t.Helper()
+	log := mustNewSessionLog(t, filepath.Join(stateDir, sessionsSubdir, sessionID+".log.jsonl"))
+	var found []sessionlog.SessionLogEntry
+	for _, e := range log.Entries() {
+		if e.Action == "session_start_hooks" {
+			found = append(found, e)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("session_start_hooks entries = %d, want 1; log: %+v", len(found), log.Entries())
+	}
+	return found[0]
+}
+
+// The re-injection detector must not count the HOOK_COMPLETED turns produced by
+// the very dispatch it is judging. Those turns land in s.history through the
+// runner's HookEnd callback before RunSessionStartFor returns, so a detector
+// that counts raw history sees prior history on a session that has none — and
+// tags outcome=failure on every fresh session that runs a SessionStart hook,
+// which is most of them. That dilution is the whole complaint (kata 6p54): a
+// failure tag that fires on the ordinary case cannot grep out of the noise.
+func TestSessionStartDispatchOnFreshSessionIsNotFlaggedAsReinjection(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	client := llm.NewClient()
+	client.Register(&fakeAdapter{name: "openai"})
+
+	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
+		StateDir:   dir,
+		PluginDirs: []string{hookPluginDir(t, "echo FRESH_SESSION_CONTEXT")},
+		testOnly:   testConfig{metaFS: afero.NewMemMapFs()},
+	})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	go func() {
+		for range sess.Events() {
+		}
+	}()
+	defer sess.Close()
+
+	entry := sessionStartHookDispatchEntry(t, dir, sess.ID())
+	// Guard against a vacuous pass: a dispatch that delivered nothing could
+	// never trip the detector, so the silence would prove nothing.
+	if !strings.Contains(entry.Summary, "delivered=1") {
+		t.Fatalf("summary = %q, want delivered=1 — the hook must actually deliver context for this test to mean anything", entry.Summary)
+	}
+	if !strings.Contains(entry.Summary, "historyTurns=0") {
+		t.Errorf("summary = %q, want historyTurns=0 — the dispatch's own HOOK_COMPLETED turns are not prior history", entry.Summary)
+	}
+	if entry.Outcome != "success" {
+		t.Errorf("outcome = %q, want success on a fresh session; failures = %v", entry.Outcome, entry.Failures)
+	}
+	if len(entry.Failures) != 0 {
+		t.Errorf("failures = %v, want none on a fresh session", entry.Failures)
+	}
+}
+
+// The other half of the detector's contract: it must still fire on the anomaly
+// it exists to catch — a dispatch delivering context to a session that already
+// carries real conversation. Restoring with prior history and a resume-matched
+// SessionStart hook reproduces exactly that.
+func TestSessionStartDispatchIntoRestoredHistoryIsFlaggedAsReinjection(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	adapter := &fakeAdapter{name: "openai", steps: []func(req llm.Request) llm.Response{
+		func(req llm.Request) llm.Response { return finalResponse("done") },
+	}}
+	client := llm.NewClient()
+	client.Register(adapter)
+
+	meta := schema.SessionMeta{
+		ID:        "01KREINJECTIONDETECTOR00000",
+		ProfileID: "test",
+		Model:     "gpt-5.2",
+		Config:    schema.ConfigSnapshot{PluginDirs: []string{newResumeHookPluginDir(t)}},
+		TurnCount: 1,
+	}
+	sess, err := RestoreSessionFromMetaWithConfig(
+		client,
+		NewOpenAIProfile("gpt-5.2"),
+		execenv.NewLocalExecutionEnvironment(t.TempDir()),
+		meta,
+		RestoreSessionConfig{
+			StateDir: stateDir,
+			resumeHistory: []schema.Turn{
+				schema.NewTurn(schema.TurnUserInput, llm.User("prior user task")),
+				schema.NewTurn(schema.TurnAssistant, llm.Assistant("prior assistant answer")),
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
+	}
+	go func() {
+		for range sess.Events() {
+		}
+	}()
+	defer sess.Close()
+
+	// Resume SessionStart hooks are deferred until the first user turn.
+	if _, err := sess.ProcessInput(t.Context(), "current user task", nil); err != nil {
+		t.Fatalf("ProcessInput: %v", err)
+	}
+
+	entry := sessionStartHookDispatchEntry(t, stateDir, sess.ID())
+	if entry.Outcome != "failure" {
+		t.Fatalf("outcome = %q, want failure — context delivered into a session with prior history is the anomaly; summary = %q", entry.Outcome, entry.Summary)
+	}
+	if !strings.Contains(entry.Summary, "historyTurns=2") {
+		t.Errorf("summary = %q, want historyTurns=2 — the two restored conversation turns", entry.Summary)
+	}
+	if len(entry.Failures) != 1 || !strings.Contains(entry.Failures[0], "re-injected") {
+		t.Errorf("failures = %v, want one re-injection diagnostic", entry.Failures)
+	}
+}

--- a/agent/session_start_reinjection_test.go
+++ b/agent/session_start_reinjection_test.go
@@ -60,11 +60,11 @@ func TestSessionStartDispatchOnFreshSessionIsNotFlaggedAsReinjection(t *testing.
 	entry := sessionStartHookDispatchEntry(t, dir, sess.ID())
 	// Guard against a vacuous pass: a dispatch that delivered nothing could
 	// never trip the detector, so the silence would prove nothing.
-	if !strings.Contains(entry.Summary, "delivered=1") {
-		t.Fatalf("summary = %q, want delivered=1 — the hook must actually deliver context for this test to mean anything", entry.Summary)
+	if !strings.Contains(entry.Summary, "delivered=1 ") {
+		t.Fatalf("summary = %q, want delivered=1 followed by a delimiter — the hook must actually deliver context for this test to mean anything", entry.Summary)
 	}
-	if !strings.Contains(entry.Summary, "historyTurns=0") {
-		t.Errorf("summary = %q, want historyTurns=0 — the dispatch's own HOOK_COMPLETED turns are not prior history", entry.Summary)
+	if !strings.Contains(entry.Summary, "historyTurns=0 ") {
+		t.Errorf("summary = %q, want historyTurns=0 followed by a delimiter — the dispatch's own HOOK_COMPLETED turns are not prior history", entry.Summary)
 	}
 	if entry.Outcome != "success" {
 		t.Errorf("outcome = %q, want success on a fresh session; failures = %v", entry.Outcome, entry.Failures)
@@ -125,8 +125,8 @@ func TestSessionStartDispatchIntoRestoredHistoryIsFlaggedAsReinjection(t *testin
 	if entry.Outcome != "failure" {
 		t.Fatalf("outcome = %q, want failure — context delivered into a session with prior history is the anomaly; summary = %q", entry.Outcome, entry.Summary)
 	}
-	if !strings.Contains(entry.Summary, "historyTurns=2") {
-		t.Errorf("summary = %q, want historyTurns=2 — the two restored conversation turns", entry.Summary)
+	if !strings.Contains(entry.Summary, "historyTurns=2 ") {
+		t.Errorf("summary = %q, want historyTurns=2 followed by a delimiter — the two restored conversation turns", entry.Summary)
 	}
 	if len(entry.Failures) != 1 || !strings.Contains(entry.Failures[0], "re-injected") {
 		t.Errorf("failures = %v, want one re-injection diagnostic", entry.Failures)


### PR DESCRIPTION
Closes kata 6p54.

`logSessionStartHookDispatch` exists to catch a suspected real bug: SessionStart hooks firing again when an existing session is resumed. It tags that anomaly `outcome=failure` so it greps out of the noise. It was firing on demonstrably fresh sessions instead, which dilutes the one signal it exists to produce.

## Root cause — the ordering the kata left open

The detector was counting its own footprint. Traced hop by hop:

- `initPlugins` runs the SessionStart hooks (session_init.go:1475).
- The runner's event callback routes every `HookEnd` through `emitHookCompleted`, which calls `recordTurn`.
- `recordTurn` appends to `s.history` unconditionally.
- `logSessionStartHookDispatch` is called after `RunSessionStartFor` returns.

So `len(s.history) >= 1` on any fresh session that runs a SessionStart hook, and the `historyTurns > 0` disjunct was always satisfied.

Reproduced live on a fresh `NewSession` with one hook: `outcome=failure ... kind=startup delivered=1 historyTurns=1 modelResponses=0` — the kata's field report, exactly.

## What changed

The detector now weighs conversation, via `conversationSignals`, which counts every turn except `TurnHookCompleted`. The condition keeps its shape; it just stops being fed a number the dispatch polluted.

**Not** `modelResponses > 0` alone, which the kata floats. That would work for both probe cases and still be wrong: `modelResponses` is seeded from `meta.TurnCount` on restore, so a resumed session whose model never got to answer carries real history with `modelResponses == 0`, and the detector would go blind on exactly the re-injection it exists to catch.

Why count rather than snapshot-before-dispatch: both shapes can drift, but the drift differs in whether a test catches it. A future dispatch that appends a non-HOOK_COMPLETED turn turns the fresh-session test red. A future call site that samples late is new untested code by definition.

`conversationSignals` returns `historyTurns` and `modelResponses` together under one `s.mu` acquisition. `Session` documents both as guarded by that mutex, and the detector reaches this on the drain path where steering turns append from other goroutines.

## Forks

Traced, and there is nothing to exempt. `ForkSession`/`ForkSessionAtUserTurn` only write a child transcript and meta; they never construct a `Session`. The child opens through the ordinary restore path, which forces `SessionStartKindResume`. `/clear` builds a fresh session with empty history. No path dispatches `kind=startup` into inherited history.

## Verification

`make merge-approval-gate` green on the Go side. Both tests carry executed mutations: restoring `len(s.history)` reproduces the kata's field report byte for byte, and `if false && ...` on the condition turns the anomaly test red — that second one is the guard against a fix that silences the detector wholesale, which is what a naive reading of this kata produces.

The gate's one failure is `Composer.integration.test.tsx`, kata 3p22's known load-flake. It fails on untouched main under load, passes 3/3 in isolation here, and this diff is two Go files.

## Provenance

Reconstructed after the original worktree was destroyed. The second commit rebuilds the code review's finding: the first commit took `s.mu` for history and then read `s.modelResponses` bare three times on the same expression, claiming to fix an unguarded read while leaving one a line later.