### PR TITLE
scripts: give selftest scratch a guard, and its cleanup no path to get wrong

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,8 +226,11 @@ override FUZZ_GOWORK := $(abspath $(CURDIR)/go.work)
 # contract — run-module-lint-selftest.sh alone carries 167 assertions about the
 # aggregate lint runner. The six fuzz-*-selftest suites listed here are
 # fixture-contained: their git bisect, worktree, and go-test operations stay in
-# throwaway worlds rather than touching this repository.
-DEV_TOOLING_TEST_SCRIPTS := run-module-lint run-module-tests private-go-home reclaim-test-debris agent-test-shards merge-approval-gate setup-gocache web-preflight report-orphaned-worktrees report-tmp-debris live-eval-isolation live-compaction-eval tmux-read tmux-send scenario-cite-migrate deploy-hub e2e-webui-turn-controls fuzz-bisect fuzz-continuous fuzz-coverage-global fuzz-drive fuzz-oracle-audit fuzz-triage test-coverage-floor web-coverage-floor coverage-gaps coverage-union
+# throwaway worlds rather than touching this repository. selftest-lib is the odd
+# one out: it tests the shared harness by running eight of the other suites
+# under a failing mktemp, from a throwaway working directory, to prove none of
+# them can be made to delete the checkout (kata 5hs2).
+DEV_TOOLING_TEST_SCRIPTS := run-module-lint run-module-tests private-go-home reclaim-test-debris agent-test-shards merge-approval-gate setup-gocache web-preflight report-orphaned-worktrees report-tmp-debris live-eval-isolation live-compaction-eval tmux-read tmux-send scenario-cite-migrate deploy-hub e2e-webui-turn-controls fuzz-bisect fuzz-continuous fuzz-coverage-global fuzz-drive fuzz-oracle-audit fuzz-triage test-coverage-floor web-coverage-floor coverage-gaps coverage-union selftest-lib
 
 # test-dev-tooling tests tooling, not the product, so it runs in
 # `make merge-approval-gate` (where tooling regressions matter) and on demand

--- a/scriptmktemp_audit_test.go
+++ b/scriptmktemp_audit_test.go
@@ -57,43 +57,36 @@ func mktempEscapesTMPDIR(call string) bool {
 // of work. Removing an entry after fixing its script is the intended lifecycle —
 // the list should only ever get shorter.
 var mktempAllowedScripts = map[string]bool{
-	"agent-test-shards-selftest.sh":         true,
-	"deploy-hub-selftest.sh":                true,
-	"e2e-cover.sh":                          true,
-	"e2e-ratelimited-provider.sh":           true,
-	"e2e-webui-turn-controls-selftest.sh":   true,
-	"e2e-webui-turn-controls.sh":            true,
-	"fuzz-bisect-selftest.sh":               true,
-	"fuzz-bisect.sh":                        true,
-	"fuzz-continuous-selftest.sh":           true,
-	"fuzz-gap-check.sh":                     true,
-	"fuzz-oracle-audit-selftest.sh":         true,
-	"fuzz-oracle-audit.sh":                  true,
-	"fuzz-registry-check.sh":                true,
-	"fuzz-triage-selftest.sh":               true,
-	"fuzz-triage.sh":                        true,
-	"live-compaction-eval-selftest.sh":      true,
-	"live-eval-isolation-selftest.sh":       true,
-	"live-eval-isolation.sh":                true,
-	"merge-approval-gate-selftest.sh":       true,
-	"parallelize-tests.sh":                  true,
-	"private-go-home-selftest.sh":           true,
-	"reclaim-test-debris-selftest.sh":       true,
-	"report-orphaned-worktrees-selftest.sh": true,
-	"report-tmp-debris-selftest.sh":         true,
-	"run-module-lint-selftest.sh":           true,
-	"run-module-lint.sh":                    true,
-	"run-module-tests-selftest.sh":          true,
-	"scenario-cite-migrate-selftest.sh":     true,
-	"seatbelt-smoke.sh":                     true,
-	"setup-gocache-selftest.sh":             true,
-	"test-cost.sh":                          true,
-	"test-overlap.sh":                       true,
-	"tmux-read-selftest.sh":                 true,
-	"tmux-read.sh":                          true,
-	"tmux-send-selftest.sh":                 true,
-	"tmux-send.sh":                          true,
-	"web-preflight-selftest.sh":             true,
+	"deploy-hub-selftest.sh":           true,
+	"e2e-cover.sh":                     true,
+	"e2e-ratelimited-provider.sh":      true,
+	"e2e-webui-turn-controls.sh":       true,
+	"fuzz-bisect-selftest.sh":          true,
+	"fuzz-bisect.sh":                   true,
+	"fuzz-continuous-selftest.sh":      true,
+	"fuzz-gap-check.sh":                true,
+	"fuzz-oracle-audit-selftest.sh":    true,
+	"fuzz-oracle-audit.sh":             true,
+	"fuzz-registry-check.sh":           true,
+	"fuzz-triage-selftest.sh":          true,
+	"fuzz-triage.sh":                   true,
+	"live-compaction-eval-selftest.sh": true,
+	"live-eval-isolation-selftest.sh":  true,
+	"live-eval-isolation.sh":           true,
+	"merge-approval-gate-selftest.sh":  true,
+	"parallelize-tests.sh":             true,
+	"private-go-home-selftest.sh":      true,
+	"run-module-lint-selftest.sh":      true,
+	"run-module-lint.sh":               true,
+	"run-module-tests-selftest.sh":     true,
+	"seatbelt-smoke.sh":                true,
+	"setup-gocache-selftest.sh":        true,
+	"test-cost.sh":                     true,
+	"test-overlap.sh":                  true,
+	"tmux-read-selftest.sh":            true,
+	"tmux-read.sh":                     true,
+	"tmux-send-selftest.sh":            true,
+	"tmux-send.sh":                     true,
 }
 
 // TestNoScriptCreatesScratchOutsideTMPDIR keeps the swept scripts swept: the
@@ -144,6 +137,139 @@ func TestNoScriptCreatesScratchOutsideTMPDIR(t *testing.T) {
 		if !seenAllowed[name] {
 			t.Errorf("mktempAllowedScripts names %s, which no longer has an escaping "+
 				"mktemp call — delete the entry", name)
+		}
+	}
+}
+
+// uncheckedMktempAssignment reports whether a line assigns a variable from a
+// `mktemp` command substitution without checking whether mktemp succeeded.
+//
+// `if ! work="$(mktemp -d ...)"` and `work="$(mktemp -d ...)" || die` both
+// check. A bare assignment does not, and under `set -uo pipefail` — which the
+// selftests use, deliberately, so that a failed assertion does not abort the
+// suite before its summary — nothing stops the script at that line.
+func uncheckedMktempAssignment(line string) bool {
+	at := strings.Index(line, "=$(mktemp")
+	if at < 0 {
+		at = strings.Index(line, `="$(mktemp`)
+	}
+	if at <= 0 {
+		return false
+	}
+	if strings.HasPrefix(line, "if ") || strings.Contains(line, "||") {
+		return false
+	}
+	return true
+}
+
+// selftestScratchAllowedScripts are the *-selftest.sh suites still building
+// scratch from an unchecked `mktemp`. As with mktempAllowedScripts above, the
+// list is the finding rather than an exemption, and removing an entry after
+// converting its suite to selftest_scratch is the intended lifecycle.
+//
+// These were left carrying it deliberately, because none of them is destructive
+// the way the eight converted suites were: they do not canonicalize, so a failed
+// mktemp leaves the variable empty and their cleanup runs `rm -rf ""`, which
+// reaches nothing.
+//
+// fuzz-drive-selftest.sh is the one that does canonicalize (its per-scenario
+// `r`), and it still stays here. Its cleanup only ever removes the suite root,
+// so a failed inner mktemp scribbles fixtures into $PWD without deleting it —
+// and converting it would make things worse, not better: new_repo is called as
+// `repo="$(new_repo)"`, so selftest_scratch's exit would be swallowed by that
+// substitution and hand the caller an empty path.
+var selftestScratchAllowedScripts = map[string]bool{
+	"coverage-gaps-selftest.sh":        true,
+	"coverage-union-selftest.sh":       true,
+	"deploy-hub-selftest.sh":           true,
+	"fuzz-bisect-selftest.sh":          true,
+	"fuzz-continuous-selftest.sh":      true,
+	"fuzz-drive-selftest.sh":           true,
+	"fuzz-oracle-audit-selftest.sh":    true,
+	"fuzz-triage-selftest.sh":          true,
+	"live-compaction-eval-selftest.sh": true,
+	"live-eval-isolation-selftest.sh":  true,
+	"merge-approval-gate-selftest.sh":  true,
+	"private-go-home-selftest.sh":      true,
+	"run-module-lint-selftest.sh":      true,
+	"run-module-tests-selftest.sh":     true,
+	"setup-gocache-selftest.sh":        true,
+	"test-coverage-floor-selftest.sh":  true,
+	"tmux-read-selftest.sh":            true,
+	"tmux-send-selftest.sh":            true,
+	"web-coverage-floor-selftest.sh":   true,
+}
+
+// TestSelftestScratchCannotResolveToCWD keeps kata 5hs2's failure mode out of
+// the selftests: an unchecked `mktemp -d` whose empty result was then resolved
+// to the suite's OWN WORKING DIRECTORY by `work="$(cd "$work" && pwd -P)"`,
+// because `cd ""` succeeds and leaves $PWD alone. The suite wrote its fixtures
+// into the checkout and its EXIT trap ran `rm -rf` on it.
+//
+// The rule here is aimed at the unchecked mktemp rather than at the
+// canonicalization that amplified it, because the unchecked mktemp is the line
+// an author actually writes, and you cannot reach the destructive shape without
+// it first. Every entry in the allowlist is a real one; a rule aimed at the
+// canonicalization instead would have needed entries for lines that are fine.
+//
+// It also pins selftest_scratch's calling convention. The guard reports failure
+// by exiting, so calling it inside a command substitution would end only that
+// subshell and hand the caller an empty path — reinstating the bug. Making that
+// a failing test is what keeps the convention from being folklore.
+func TestSelftestScratchCannotResolveToCWD(t *testing.T) {
+	t.Parallel()
+	entries, err := os.ReadDir("scripts")
+	if err != nil {
+		t.Fatalf("read scripts/: %v", err)
+	}
+	var unchecked, swallowed []string
+	seenAllowed := map[string]bool{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sh") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join("scripts", e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		isSelftest := strings.HasSuffix(e.Name(), "-selftest.sh")
+		for i, line := range strings.Split(string(body), "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			where := fmt.Sprintf("scripts/%s:%d: %s", e.Name(), i+1, trimmed)
+			if strings.Contains(trimmed, "$(selftest_scratch") {
+				swallowed = append(swallowed, where)
+			}
+			if !isSelftest || !uncheckedMktempAssignment(trimmed) {
+				continue
+			}
+			if selftestScratchAllowedScripts[e.Name()] {
+				seenAllowed[e.Name()] = true
+				continue
+			}
+			unchecked = append(unchecked, where)
+		}
+	}
+	sort.Strings(unchecked)
+	for _, o := range unchecked {
+		t.Errorf("this mktemp is unchecked, so a failed mktemp leaves the variable empty "+
+			"and any later `cd` canonicalization of it resolves to the suite's own working "+
+			"directory, which its cleanup then deletes (kata 5hs2); build scratch with "+
+			"`selftest_scratch <var> <prefix>` from scripts/selftest-lib.sh:\n  %s", o)
+	}
+	sort.Strings(swallowed)
+	for _, o := range swallowed {
+		t.Errorf("selftest_scratch reports failure by exiting, which a command substitution "+
+			"swallows — the caller would continue with an empty path. Call it as a "+
+			"statement instead: `selftest_scratch work my-selftest`:\n  %s", o)
+	}
+
+	for name := range selftestScratchAllowedScripts {
+		if !seenAllowed[name] {
+			t.Errorf("selftestScratchAllowedScripts names %s, which no longer builds scratch "+
+				"from an unchecked mktemp — delete the entry", name)
 		}
 	}
 }

--- a/scripts/agent-test-shards-selftest.sh
+++ b/scripts/agent-test-shards-selftest.sh
@@ -3,11 +3,10 @@
 set -uo pipefail
 
 script="$(cd "$(dirname "$0")" && pwd)/agent-test-shards.sh"
-work="$(mktemp -d -t agent-test-shards-selftest.XXXXXX)"
-work="$(cd "$work" && pwd -P)"
-trap 'rm -rf "$work"' EXIT
-
 . "$(dirname "$0")/selftest-lib.sh"
+
+selftest_scratch work agent-test-shards-selftest
+trap 'selftest_rm_scratch "$work"' EXIT
 
 assert_absent() {
 	if [ ! -e "$1" ]; then ok "$2"; else bad "$2 (still present: $1)"; fi

--- a/scripts/agent-test-shards-selftest.sh
+++ b/scripts/agent-test-shards-selftest.sh
@@ -6,7 +6,7 @@ script="$(cd "$(dirname "$0")" && pwd)/agent-test-shards.sh"
 . "$(dirname "$0")/selftest-lib.sh"
 
 selftest_scratch work agent-test-shards-selftest
-trap 'selftest_rm_scratch "$work"' EXIT
+trap 'selftest_rm_scratch' EXIT
 
 assert_absent() {
 	if [ ! -e "$1" ]; then ok "$2"; else bad "$2 (still present: $1)"; fi

--- a/scripts/agent-test-shards.sh
+++ b/scripts/agent-test-shards.sh
@@ -60,7 +60,15 @@ shards=${AGENT_SHARD_COUNT:-4}
 par=${AGENT_SHARD_PARALLEL:-3}
 skip=${AGENT_SHARD_SKIP:-}
 noSurvey=${AGENT_SHARD_NO_SURVEY:-0}
-logdir="$(mktemp -d "${TMPDIR:-/tmp}/agent-test-shards.XXXXXX")"
+# This script has already cd'd into the agent module, and the cleanup below
+# does `rm -rf "$logdir"`. An unchecked mktemp would leave $logdir empty, and
+# `cd "" && pwd -P` resolves to the current directory, which would aim that
+# delete at the agent module itself. Refuse instead of running without scratch.
+if ! logdir="$(mktemp -d "${TMPDIR:-/tmp}/agent-test-shards.XXXXXX")" ||
+	[ -z "$logdir" ] || [ ! -d "$logdir" ]; then
+	echo "agent-test-shards: could not create a scratch directory under ${TMPDIR:-/tmp}" >&2
+	exit 2
+fi
 logdir="$(cd "$logdir" && pwd -P)"
 
 # The reclaimer cannot use the shard directory mtime as a liveness signal:

--- a/scripts/e2e-webui-turn-controls-selftest.sh
+++ b/scripts/e2e-webui-turn-controls-selftest.sh
@@ -44,7 +44,7 @@ cleanup() {
 		[ -f "$pidfile" ] || continue
 		kill "$(cat "$pidfile")" 2>/dev/null
 	done
-	selftest_rm_scratch "$work"
+	selftest_rm_scratch
 }
 trap cleanup EXIT
 

--- a/scripts/e2e-webui-turn-controls-selftest.sh
+++ b/scripts/e2e-webui-turn-controls-selftest.sh
@@ -21,8 +21,7 @@ set -uo pipefail
 script="$(cd "$(dirname "$0")" && pwd)/e2e-webui-turn-controls.sh"
 . "$(dirname "$0")/selftest-lib.sh"
 
-work="$(mktemp -d -t e2e-webui-turn-controls-selftest.XXXXXX)"
-work="$(cd "$work" && pwd -P)"
+selftest_scratch work e2e-webui-turn-controls-selftest
 
 # Where the fixture binaries record what they saw, including the pid of the
 # stand-in daemon the fake hub spawns. Defined before cleanup, which sweeps it.
@@ -45,7 +44,7 @@ cleanup() {
 		[ -f "$pidfile" ] || continue
 		kill "$(cat "$pidfile")" 2>/dev/null
 	done
-	rm -rf "$work"
+	selftest_rm_scratch "$work"
 }
 trap cleanup EXIT
 

--- a/scripts/fuzz-coverage-global-selftest.sh
+++ b/scripts/fuzz-coverage-global-selftest.sh
@@ -8,12 +8,12 @@ runner="$(cd "$(dirname "$0")" && pwd)/fuzz-coverage-global.sh"
 makefile="$(cd "$(dirname "$runner")/.." && pwd)/Makefile"
 . "$(dirname "$0")/selftest-lib.sh"
 
-work="$(mktemp -d "${TMPDIR:-/tmp}/fuzzcov-global-selftest.XXXXXX")"
-# Canonicalize: the runner resolves its repo root with pwd -P, so the fixture's
-# spelling must be physical too or the fake go's exact-$PWD dispatch never
-# matches (macOS $TMPDIR lives behind the /var -> /private/var symlink).
-work="$(cd "$work" && pwd -P)"
-trap 'rm -rf "$work"' EXIT
+# selftest_scratch canonicalizes: the runner resolves its repo root with pwd -P,
+# so the fixture's spelling must be physical too or the fake go's exact-$PWD
+# dispatch never matches (macOS $TMPDIR lives behind the /var -> /private/var
+# symlink).
+selftest_scratch work fuzzcov-global-selftest
+trap 'selftest_rm_scratch "$work"' EXIT
 
 has() {
 	local haystack="$1" needle="$2" label="$3"

--- a/scripts/fuzz-coverage-global-selftest.sh
+++ b/scripts/fuzz-coverage-global-selftest.sh
@@ -13,7 +13,7 @@ makefile="$(cd "$(dirname "$runner")/.." && pwd)/Makefile"
 # dispatch never matches (macOS $TMPDIR lives behind the /var -> /private/var
 # symlink).
 selftest_scratch work fuzzcov-global-selftest
-trap 'selftest_rm_scratch "$work"' EXIT
+trap 'selftest_rm_scratch' EXIT
 
 has() {
 	local haystack="$1" needle="$2" label="$3"

--- a/scripts/reclaim-test-debris-selftest.sh
+++ b/scripts/reclaim-test-debris-selftest.sh
@@ -6,7 +6,7 @@ script="$(cd "$(dirname "$0")" && pwd)/reclaim-test-debris.sh"
 . "$(dirname "$0")/selftest-lib.sh"
 
 selftest_scratch work reclaim-test-debris-selftest
-trap 'selftest_rm_scratch "$work"' EXIT
+trap 'selftest_rm_scratch' EXIT
 
 tmpbase="$work/tmp"
 mkdir -p "$tmpbase"

--- a/scripts/reclaim-test-debris-selftest.sh
+++ b/scripts/reclaim-test-debris-selftest.sh
@@ -3,11 +3,10 @@
 set -uo pipefail
 
 script="$(cd "$(dirname "$0")" && pwd)/reclaim-test-debris.sh"
-work="$(mktemp -d -t reclaim-test-debris-selftest.XXXXXX)"
-work="$(cd "$work" && pwd -P)"
-trap 'rm -rf "$work"' EXIT
-
 . "$(dirname "$0")/selftest-lib.sh"
+
+selftest_scratch work reclaim-test-debris-selftest
+trap 'selftest_rm_scratch "$work"' EXIT
 
 tmpbase="$work/tmp"
 mkdir -p "$tmpbase"

--- a/scripts/report-orphaned-worktrees-selftest.sh
+++ b/scripts/report-orphaned-worktrees-selftest.sh
@@ -12,7 +12,7 @@ script="$(cd "$(dirname "$0")" && pwd)/report-orphaned-worktrees.sh"
 # git rev-parse, so an unresolved $work would make the string-equality path
 # comparisons below spuriously fail without there being any real bug.
 selftest_scratch work report-orphaned-worktrees-selftest
-trap 'selftest_rm_scratch "$work"' EXIT
+trap 'selftest_rm_scratch' EXIT
 
 repo="$work/repo"
 mkdir -p "$repo/.claude/worktrees"

--- a/scripts/report-orphaned-worktrees-selftest.sh
+++ b/scripts/report-orphaned-worktrees-selftest.sh
@@ -7,13 +7,12 @@ set -uo pipefail
 script="$(cd "$(dirname "$0")" && pwd)/report-orphaned-worktrees.sh"
 . "$(dirname "$0")/selftest-lib.sh"
 
-work="$(mktemp -d -t report-orphaned-worktrees-selftest.XXXXXX)"
-# Resolve symlinks now (macOS's /var/folders is a symlink to /private/var/folders):
-# the script under test reports fully-resolved paths via git rev-parse, so an
-# unresolved $work would make string-equality path comparisons below spuriously
-# fail without there being any real bug.
-work="$(cd "$work" && pwd -P)"
-trap 'rm -rf "$work"' EXIT
+# selftest_scratch resolves symlinks (macOS's /var/folders is a symlink to
+# /private/var/folders): the script under test reports fully-resolved paths via
+# git rev-parse, so an unresolved $work would make the string-equality path
+# comparisons below spuriously fail without there being any real bug.
+selftest_scratch work report-orphaned-worktrees-selftest
+trap 'selftest_rm_scratch "$work"' EXIT
 
 repo="$work/repo"
 mkdir -p "$repo/.claude/worktrees"

--- a/scripts/report-tmp-debris-selftest.sh
+++ b/scripts/report-tmp-debris-selftest.sh
@@ -16,7 +16,7 @@ script="$(cd "$(dirname "$0")" && pwd)/report-tmp-debris.sh"
 # /private/var/folders): the script prints the paths it was given, and
 # --paths-only is compared by string equality below.
 selftest_scratch work report-tmp-debris-selftest
-trap 'selftest_rm_scratch "$work"' EXIT
+trap 'selftest_rm_scratch' EXIT
 
 repo="$work/repo"
 mkdir -p "$repo"

--- a/scripts/report-tmp-debris-selftest.sh
+++ b/scripts/report-tmp-debris-selftest.sh
@@ -12,12 +12,11 @@ set -uo pipefail
 script="$(cd "$(dirname "$0")" && pwd)/report-tmp-debris.sh"
 . "$(dirname "$0")/selftest-lib.sh"
 
-work="$(mktemp -d -t report-tmp-debris-selftest.XXXXXX)"
-# Resolve symlinks now (macOS's /var/folders is a symlink to /private/var/folders):
-# the script prints the paths it was given, and --paths-only is compared by
-# string equality below.
-work="$(cd "$work" && pwd -P)"
-trap 'rm -rf "$work"' EXIT
+# selftest_scratch resolves symlinks (macOS's /var/folders is a symlink to
+# /private/var/folders): the script prints the paths it was given, and
+# --paths-only is compared by string equality below.
+selftest_scratch work report-tmp-debris-selftest
+trap 'selftest_rm_scratch "$work"' EXIT
 
 repo="$work/repo"
 mkdir -p "$repo"

--- a/scripts/scenario-cite-migrate-selftest.sh
+++ b/scripts/scenario-cite-migrate-selftest.sh
@@ -7,11 +7,10 @@ set -uo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 source_script="$script_dir/scenario-cite-migrate.sh"
-work="$(mktemp -d -t serf-cite-migrate-selftest.XXXXXX)"
-work="$(cd "$work" && pwd -P)"
-trap 'rm -rf "$work"' EXIT
-
 . "$(dirname "$0")/selftest-lib.sh"
+
+selftest_scratch work serf-cite-migrate-selftest
+trap 'selftest_rm_scratch "$work"' EXIT
 
 repo="$work/repo"
 bin="$work/bin"

--- a/scripts/scenario-cite-migrate-selftest.sh
+++ b/scripts/scenario-cite-migrate-selftest.sh
@@ -10,7 +10,7 @@ source_script="$script_dir/scenario-cite-migrate.sh"
 . "$(dirname "$0")/selftest-lib.sh"
 
 selftest_scratch work serf-cite-migrate-selftest
-trap 'selftest_rm_scratch "$work"' EXIT
+trap 'selftest_rm_scratch' EXIT
 
 repo="$work/repo"
 bin="$work/bin"

--- a/scripts/selftest-lib-selftest.sh
+++ b/scripts/selftest-lib-selftest.sh
@@ -182,20 +182,30 @@ run_fixture refuse-outside '#!/usr/bin/env bash
 set -uo pipefail
 . "$1/selftest-lib.sh"
 selftest_scratch dir refuse-fixture
+# Every path this fires at is a decoy under the fixture'"'"'s own working
+# directory. Naming "/" or "$HOME" here would test the guard by aiming the real
+# weapon at the real target, so a single typo or a mutation run would delete the
+# machine. A decoy proves refusal just as well and costs nothing when it fails.
+mkdir -p "$PWD/decoy-root" "$PWD/decoy-home"
 selftest_rm_scratch "$PWD"
 echo "rm-scratch returned $?"
-selftest_rm_scratch "/"
-echo "rm-scratch on / returned $?"
-selftest_rm_scratch "$HOME"
-echo "rm-scratch on HOME returned $?"
+selftest_rm_scratch "$PWD/decoy-root"
+echo "rm-scratch on decoy-root returned $?"
+selftest_rm_scratch "$PWD/decoy-home"
+echo "rm-scratch on decoy-home returned $?"
+selftest_rm_scratch "$dir/.."
+echo "rm-scratch on upward path returned $?"
 selftest_rm_scratch ""
 echo "rm-scratch on empty returned $?"
+[ -d "$PWD/decoy-root" ] && [ -d "$PWD/decoy-home" ] && echo "decoys intact"
 selftest_rm_scratch "$dir"
 exit 0'
 assert_victim_intact "$fixture_victim" "selftest_rm_scratch leaves the working directory alone"
 assert_has "$fixture_out" "rm-scratch returned 1" "selftest_rm_scratch refuses the working directory"
-assert_has "$fixture_out" "rm-scratch on / returned 1" "selftest_rm_scratch refuses /"
-assert_has "$fixture_out" "rm-scratch on HOME returned 1" "selftest_rm_scratch refuses HOME"
+assert_has "$fixture_out" "rm-scratch on decoy-root returned 1" "selftest_rm_scratch refuses a directory it did not create"
+assert_has "$fixture_out" "rm-scratch on decoy-home returned 1" "selftest_rm_scratch refuses a second one, so the first is not a fluke"
+assert_has "$fixture_out" "rm-scratch on upward path returned 1" "selftest_rm_scratch refuses a path that walks upward out of its own root"
+assert_has "$fixture_out" "decoys intact" "selftest_rm_scratch deleted neither decoy"
 assert_has "$fixture_out" "rm-scratch on empty returned 0" "selftest_rm_scratch treats an empty path as nothing to do"
 assert_has "$fixture_out" "refusing to delete" "selftest_rm_scratch says why it refused"
 

--- a/scripts/selftest-lib-selftest.sh
+++ b/scripts/selftest-lib-selftest.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# selftest-lib-selftest.sh — tests the scratch guard in scripts/selftest-lib.sh,
+# and pins the one case that must never regress (kata 5hs2).
+#
+# The regression: a suite that built its scratch with an unchecked `mktemp -d`
+# and then canonicalized it with `work="$(cd "$work" && pwd -P)"` resolved $work
+# to its OWN WORKING DIRECTORY when mktemp failed, because `cd ""` succeeds and
+# leaves $PWD alone. The EXIT trap's `rm -rf "$work"` then deleted the checkout.
+#
+# So every guarded suite below is run for real, from a throwaway working
+# directory seeded with sentinel files, with a `mktemp` on PATH that always
+# fails. Each must exit non-zero, say why, and leave every sentinel standing.
+set -uo pipefail
+
+. "$(dirname "$0")/selftest-lib.sh"
+scripts_dir="$(cd "$(dirname "$0")" && pwd -P)"
+selftest_scratch work selftest-lib-selftest
+trap 'selftest_rm_scratch "$work"' EXIT
+
+# The suites converted to the guard. Their protection is behavioural, not
+# textual, so it is checked by running them rather than by grepping them.
+guarded_suites=(
+	agent-test-shards-selftest.sh
+	e2e-webui-turn-controls-selftest.sh
+	fuzz-coverage-global-selftest.sh
+	reclaim-test-debris-selftest.sh
+	report-orphaned-worktrees-selftest.sh
+	report-tmp-debris-selftest.sh
+	scenario-cite-migrate-selftest.sh
+	web-preflight-selftest.sh
+)
+
+# A mktemp that always fails, standing in for a full or read-only TMPDIR, a
+# denied sandbox, or an inherited TMPDIR that does not exist.
+failing_mktemp_bin="$work/failing-mktemp-bin"
+mkdir -p "$failing_mktemp_bin"
+cat >"$failing_mktemp_bin/mktemp" <<'FAILING_MKTEMP'
+#!/bin/sh
+echo "mktemp: no space left on device" >&2
+exit 1
+FAILING_MKTEMP
+chmod +x "$failing_mktemp_bin/mktemp"
+
+# new_victim NAME — a throwaway working directory seeded the way a repo
+# checkout is: a tracked-looking file, a nested directory, and a real git repo.
+# Echoes its path. If a suite's cleanup ever aims at its own $PWD, this is what
+# it destroys, and the assertions below notice.
+#
+# The git repo is real rather than an empty .git so that a suite running git
+# from here can never fail discovery and walk up into the checkout this test is
+# running from.
+new_victim() {
+	local victim="$work/victim-$1"
+	mkdir -p "$victim/nested"
+	printf 'must survive\n' >"$victim/sentinel.txt"
+	printf 'must survive\n' >"$victim/nested/sentinel.txt"
+	git init -q "$victim" >/dev/null 2>&1
+	printf '%s\n' "$victim"
+}
+
+# assert_victim_intact DIR DESC — every seeded file still where it was.
+assert_victim_intact() {
+	local victim="$1" desc="$2"
+	if [ -f "$victim/sentinel.txt" ] && [ -f "$victim/nested/sentinel.txt" ] && [ -d "$victim/.git" ]; then
+		ok "$desc"
+	else
+		bad "$desc (the working directory was damaged)"
+		ls -A "$victim" 2>&1 | sed 's/^/    | /'
+	fi
+}
+
+for suite in "${guarded_suites[@]}"; do
+	victim="$(new_victim "${suite%.sh}")"
+	out="$work/${suite%.sh}.mktemp-failure.out"
+	(
+		cd "$victim" &&
+			PATH="$failing_mktemp_bin:$PATH" bash "$scripts_dir/$suite"
+	) >"$out" 2>&1
+	status=$?
+
+	if [ "$status" -ne 0 ]; then
+		ok "$suite exits non-zero when mktemp fails"
+	else
+		bad "$suite exits zero when mktemp fails"
+	fi
+	assert_has "$out" "${suite%.sh}: " "$suite names itself in the mktemp-failure diagnostic"
+	assert_has "$out" "refusing to continue" "$suite says it is refusing to continue"
+	assert_victim_intact "$victim" "$suite deletes nothing in its working directory when mktemp fails"
+done
+
+# A TMPDIR that does not exist is the other spelling of the same failure, and
+# needs no stub: it is what an inherited TMPDIR from a reaped sandbox looks
+# like. mktemp itself is real here, so this proves the guard rejects the root
+# before it ever asks mktemp for anything.
+for suite in "${guarded_suites[@]}"; do
+	victim="$(new_victim "missing-tmpdir-${suite%.sh}")"
+	out="$work/${suite%.sh}.missing-tmpdir.out"
+	(
+		cd "$victim" &&
+			TMPDIR="$work/tmpdir-that-does-not-exist" bash "$scripts_dir/$suite"
+	) >"$out" 2>&1
+	status=$?
+
+	if [ "$status" -ne 0 ]; then
+		ok "$suite exits non-zero when TMPDIR does not exist"
+	else
+		bad "$suite exits zero when TMPDIR does not exist"
+	fi
+	assert_has "$out" "is not a usable directory" "$suite names the unusable TMPDIR"
+	assert_victim_intact "$victim" "$suite deletes nothing in its working directory when TMPDIR does not exist"
+done
+
+# --- the guard's own behaviour, exercised directly ---------------------------
+
+# run_fixture NAME BODY [PATH_PREFIX] — write BODY as a script that sources the
+# lib the way a suite does, run it from a fresh victim directory with
+# PATH_PREFIX first on PATH; leaves the combined output in $fixture_out and the
+# exit status in $fixture_status.
+fixture_out=""
+fixture_status=0
+fixture_victim=""
+run_fixture() {
+	local name="$1" body="$2" path_prefix="${3:-}"
+	fixture_victim="$(new_victim "fixture-$name")"
+	fixture_out="$work/fixture-$name.out"
+	printf '%s\n' "$body" >"$work/fixture-$name.sh"
+	(
+		cd "$fixture_victim" &&
+			PATH="${path_prefix:+$path_prefix:}$PATH" \
+				bash "$work/fixture-$name.sh" "$scripts_dir"
+	) >"$fixture_out" 2>&1
+	fixture_status=$?
+}
+
+# An mktemp that exits 0 having printed nothing. This is the shape that made
+# the original bug destructive rather than merely broken: the caller's variable
+# ends up empty, `cd ""` succeeds, and the empty path resolves to $PWD.
+empty_mktemp_bin="$work/empty-mktemp-bin"
+mkdir -p "$empty_mktemp_bin"
+printf '#!/bin/sh\nexit 0\n' >"$empty_mktemp_bin/mktemp"
+chmod +x "$empty_mktemp_bin/mktemp"
+
+# An mktemp that exits 0 having printed an existing directory it did not create
+# — the caller's own working directory, which is the path the original bug
+# arrived at, and which can be under TMPDIR like anything else.
+squatting_mktemp_bin="$work/squatting-mktemp-bin"
+mkdir -p "$squatting_mktemp_bin"
+printf '#!/bin/sh\npwd -P\n' >"$squatting_mktemp_bin/mktemp"
+chmod +x "$squatting_mktemp_bin/mktemp"
+
+# An mktemp that exits 0 having printed a correctly-named directory that sits
+# outside the TMPDIR the caller set. The fixture using it gets a TMPDIR of its
+# own so that "outside TMPDIR" can be arranged without writing anywhere but
+# this suite's own scratch.
+straying_mktemp_bin="$work/straying-mktemp-bin"
+strayed_dir="$work/outside-tmpdir-fixture.abcdef"
+fixture_tmpdir="$work/fixture-tmpdir"
+mkdir -p "$straying_mktemp_bin" "$strayed_dir" "$fixture_tmpdir"
+printf '#!/bin/sh\nprintf "%%s\\n" "%s"\n' "$strayed_dir" >"$straying_mktemp_bin/mktemp"
+chmod +x "$straying_mktemp_bin/mktemp"
+
+# The happy path: a real directory under TMPDIR, canonicalized, removable.
+run_fixture happy '#!/usr/bin/env bash
+set -uo pipefail
+. "$1/selftest-lib.sh"
+selftest_scratch dir happy-fixture
+[ -d "$dir" ] || { echo "no directory created"; exit 1; }
+case "$dir" in
+"$(cd "${TMPDIR:-/tmp}" && pwd -P)"/happy-fixture.*) ;;
+*) echo "created outside TMPDIR: $dir"; exit 1 ;;
+esac
+selftest_rm_scratch "$dir"
+[ -e "$dir" ] && { echo "not removed: $dir"; exit 1; }
+echo "happy path complete"
+exit 0'
+assert_eq "$fixture_status" 0 "the happy path creates a canonical scratch under TMPDIR and removes it"
+assert_has "$fixture_out" "happy path complete" "the happy path runs to the end"
+
+# selftest_rm_scratch must refuse anything outside the scratch root, which is
+# what makes it safe to call with a variable another hand may have clobbered.
+run_fixture refuse-outside '#!/usr/bin/env bash
+set -uo pipefail
+. "$1/selftest-lib.sh"
+selftest_scratch dir refuse-fixture
+selftest_rm_scratch "$PWD"
+echo "rm-scratch returned $?"
+selftest_rm_scratch "/"
+echo "rm-scratch on / returned $?"
+selftest_rm_scratch "$HOME"
+echo "rm-scratch on HOME returned $?"
+selftest_rm_scratch ""
+echo "rm-scratch on empty returned $?"
+selftest_rm_scratch "$dir"
+exit 0'
+assert_victim_intact "$fixture_victim" "selftest_rm_scratch leaves the working directory alone"
+assert_has "$fixture_out" "rm-scratch returned 1" "selftest_rm_scratch refuses the working directory"
+assert_has "$fixture_out" "rm-scratch on / returned 1" "selftest_rm_scratch refuses /"
+assert_has "$fixture_out" "rm-scratch on HOME returned 1" "selftest_rm_scratch refuses HOME"
+assert_has "$fixture_out" "rm-scratch on empty returned 0" "selftest_rm_scratch treats an empty path as nothing to do"
+assert_has "$fixture_out" "refusing to delete" "selftest_rm_scratch says why it refused"
+
+# An mktemp that succeeds but hands back nothing must not become $PWD.
+run_fixture empty-result '#!/usr/bin/env bash
+set -uo pipefail
+. "$1/selftest-lib.sh"
+selftest_scratch dir empty-result-fixture
+rm -rf "$dir"
+echo "REACHED THE DELETE"
+exit 0' "$empty_mktemp_bin"
+if [ "$fixture_status" -ne 0 ]; then
+	ok "an mktemp that returns nothing exits non-zero"
+else
+	bad "an mktemp that returns nothing exits zero"
+fi
+assert_has "$fixture_out" "returned no usable directory" "an mktemp that returns nothing is named as such"
+assert_not_has "$fixture_out" "REACHED THE DELETE" "an mktemp that returns nothing stops before any delete"
+assert_victim_intact "$fixture_victim" "an mktemp that returns nothing deletes nothing"
+
+# An mktemp that hands back an existing directory it did not create — here the
+# caller's own, which is under TMPDIR like everything else this suite makes —
+# must be refused rather than adopted as scratch and later deleted.
+run_fixture squatted-dir '#!/usr/bin/env bash
+set -uo pipefail
+. "$1/selftest-lib.sh"
+selftest_scratch dir squatted-fixture
+rm -rf "$dir"
+echo "REACHED THE DELETE"
+exit 0' "$squatting_mktemp_bin"
+if [ "$fixture_status" -ne 0 ]; then
+	ok "an mktemp that returns a directory it did not create exits non-zero"
+else
+	bad "an mktemp that returns a directory it did not create exits zero"
+fi
+assert_has "$fixture_out" "is not the directory it was asked to create" "a squatted scratch directory is named as such"
+assert_not_has "$fixture_out" "REACHED THE DELETE" "a squatted scratch directory stops before any delete"
+assert_victim_intact "$fixture_victim" "a squatted scratch directory deletes nothing"
+
+# An mktemp that hands back a correctly-named directory outside the caller's
+# TMPDIR must be refused too: scratch the wave runner's leak check cannot see
+# is scratch nobody will notice is still there.
+run_fixture outside-tmpdir "#!/usr/bin/env bash
+set -uo pipefail
+export TMPDIR=\"$fixture_tmpdir\"
+. \"\$1/selftest-lib.sh\"
+selftest_scratch dir outside-tmpdir-fixture
+rm -rf \"\$dir\"
+echo \"REACHED THE DELETE\"
+exit 0" "$straying_mktemp_bin"
+if [ "$fixture_status" -ne 0 ]; then
+	ok "an mktemp that returns a path outside TMPDIR exits non-zero"
+else
+	bad "an mktemp that returns a path outside TMPDIR exits zero"
+fi
+assert_has "$fixture_out" "resolved outside TMPDIR" "a scratch path outside TMPDIR is named as such"
+assert_not_has "$fixture_out" "REACHED THE DELETE" "a scratch path outside TMPDIR stops before any delete"
+if [ -d "$strayed_dir" ]; then
+	ok "a scratch path outside TMPDIR is left where it was found"
+else
+	bad "a scratch path outside TMPDIR was deleted"
+fi
+
+# Sourcing the lib after calling the guard is the ordering mistake a future
+# author can make. It must fail in the safe direction: no scratch, no deletion,
+# non-zero exit — which `set -u` delivers on the first unset $dir.
+run_fixture bad-order '#!/usr/bin/env bash
+set -uo pipefail
+selftest_scratch dir bad-order-fixture
+rm -rf "$dir"
+echo "REACHED THE DELETE"
+. "$1/selftest-lib.sh"
+exit 0'
+if [ "$fixture_status" -ne 0 ]; then
+	ok "calling the guard before sourcing the lib exits non-zero"
+else
+	bad "calling the guard before sourcing the lib exits zero"
+fi
+assert_not_has "$fixture_out" "REACHED THE DELETE" "calling the guard before sourcing the lib stops before any delete"
+assert_victim_intact "$fixture_victim" "calling the guard before sourcing the lib deletes nothing"
+
+selftest_summary

--- a/scripts/selftest-lib-selftest.sh
+++ b/scripts/selftest-lib-selftest.sh
@@ -15,7 +15,7 @@ set -uo pipefail
 . "$(dirname "$0")/selftest-lib.sh"
 scripts_dir="$(cd "$(dirname "$0")" && pwd -P)"
 selftest_scratch work selftest-lib-selftest
-trap 'selftest_rm_scratch "$work"' EXIT
+trap 'selftest_rm_scratch' EXIT
 
 # The suites converted to the guard. Their protection is behavioural, not
 # textual, so it is checked by running them rather than by grepping them.
@@ -169,45 +169,48 @@ case "$dir" in
 "$(cd "${TMPDIR:-/tmp}" && pwd -P)"/happy-fixture.*) ;;
 *) echo "created outside TMPDIR: $dir"; exit 1 ;;
 esac
-selftest_rm_scratch "$dir"
+selftest_rm_scratch
 [ -e "$dir" ] && { echo "not removed: $dir"; exit 1; }
 echo "happy path complete"
 exit 0'
 assert_eq "$fixture_status" 0 "the happy path creates a canonical scratch under TMPDIR and removes it"
 assert_has "$fixture_out" "happy path complete" "the happy path runs to the end"
 
-# selftest_rm_scratch must refuse anything outside the scratch root, which is
-# what makes it safe to call with a variable another hand may have clobbered.
-run_fixture refuse-outside '#!/usr/bin/env bash
+# The delete takes no path, so a clobbered caller variable has nothing to reach
+# it with. This fixture wrecks every variable a suite might hold — including the
+# one selftest_scratch assigned — and then runs the trap the way a dying suite
+# would. Nothing in the working directory may be touched, and the real scratch
+# must still be reclaimed.
+#
+# Note what this fixture does NOT do: it never names "/" or "$HOME". Testing a
+# delete by aiming it at the thing you are protecting means one typo, or one
+# mutation run, destroys the machine. That is not hypothetical here.
+run_fixture ignores-caller-paths '#!/usr/bin/env bash
 set -uo pipefail
 . "$1/selftest-lib.sh"
 selftest_scratch dir refuse-fixture
-# Every path this fires at is a decoy under the fixture'"'"'s own working
-# directory. Naming "/" or "$HOME" here would test the guard by aiming the real
-# weapon at the real target, so a single typo or a mutation run would delete the
-# machine. A decoy proves refusal just as well and costs nothing when it fails.
-mkdir -p "$PWD/decoy-root" "$PWD/decoy-home"
+mkdir -p "$PWD/decoy"
+printf keep > "$PWD/decoy/sentinel.txt"
+real="$dir"
+dir=""
+work="$PWD"
+selftest_rm_scratch
+echo "rm-scratch with clobbered vars returned $?"
+[ -d "$PWD/decoy" ] && [ -f "$PWD/decoy/sentinel.txt" ] && echo "decoy intact"
+[ -e "$real" ] || echo "real scratch reclaimed"
+selftest_rm_scratch
+echo "second call returned $?"
 selftest_rm_scratch "$PWD"
-echo "rm-scratch returned $?"
-selftest_rm_scratch "$PWD/decoy-root"
-echo "rm-scratch on decoy-root returned $?"
-selftest_rm_scratch "$PWD/decoy-home"
-echo "rm-scratch on decoy-home returned $?"
-selftest_rm_scratch "$dir/.."
-echo "rm-scratch on upward path returned $?"
-selftest_rm_scratch ""
-echo "rm-scratch on empty returned $?"
-[ -d "$PWD/decoy-root" ] && [ -d "$PWD/decoy-home" ] && echo "decoys intact"
-selftest_rm_scratch "$dir"
+echo "call with an argument returned $?"
+[ -d "$PWD/decoy" ] && echo "decoy still intact after argument call"
 exit 0'
 assert_victim_intact "$fixture_victim" "selftest_rm_scratch leaves the working directory alone"
-assert_has "$fixture_out" "rm-scratch returned 1" "selftest_rm_scratch refuses the working directory"
-assert_has "$fixture_out" "rm-scratch on decoy-root returned 1" "selftest_rm_scratch refuses a directory it did not create"
-assert_has "$fixture_out" "rm-scratch on decoy-home returned 1" "selftest_rm_scratch refuses a second one, so the first is not a fluke"
-assert_has "$fixture_out" "rm-scratch on upward path returned 1" "selftest_rm_scratch refuses a path that walks upward out of its own root"
-assert_has "$fixture_out" "decoys intact" "selftest_rm_scratch deleted neither decoy"
-assert_has "$fixture_out" "rm-scratch on empty returned 0" "selftest_rm_scratch treats an empty path as nothing to do"
-assert_has "$fixture_out" "refusing to delete" "selftest_rm_scratch says why it refused"
+assert_has "$fixture_out" "rm-scratch with clobbered vars returned 0" "selftest_rm_scratch does not depend on any caller variable"
+assert_has "$fixture_out" "decoy intact" "selftest_rm_scratch deletes nothing it did not create"
+assert_has "$fixture_out" "real scratch reclaimed" "selftest_rm_scratch still removes the scratch it minted"
+assert_has "$fixture_out" "second call returned 0" "selftest_rm_scratch is safe to call twice"
+assert_has "$fixture_out" "call with an argument returned 2" "selftest_rm_scratch rejects an argument rather than honouring it"
+assert_has "$fixture_out" "decoy still intact after argument call" "a path handed to selftest_rm_scratch is never deleted"
 
 # An mktemp that succeeds but hands back nothing must not become $PWD.
 run_fixture empty-result '#!/usr/bin/env bash

--- a/scripts/selftest-lib.sh
+++ b/scripts/selftest-lib.sh
@@ -152,43 +152,43 @@ selftest_scratch() {
 	printf -v "$_st_var" '%s' "$_st_dir"
 }
 
-# selftest_rm_scratch PATH — remove a directory selftest_scratch created, or
-# something inside one. Refuses everything else, so a caller whose variable was
-# emptied or clobbered cannot turn its EXIT trap into a delete of $PWD, $HOME,
-# or /. An empty path is nothing to do, not an error: a suite that died before
-# it had scratch still runs its trap. Returns non-zero on refusal rather than
-# exiting, because it is called from EXIT traps where the suite's own status is
-# already decided.
+# selftest_rm_scratch — remove every directory selftest_scratch created for this
+# suite.
+#
+# It takes no argument, and that is the whole point. A delete that accepts a
+# path can be handed $PWD, $HOME, or / by a variable that was emptied or
+# clobbered, and no amount of guarding inside the function makes the caller's
+# variable trustworthy. With no argument there is nothing to get wrong: the only
+# paths it can reach are ones selftest_scratch minted and validated.
+#
+# Safe to call with no scratch yet (a suite that died early still runs its
+# trap), and safe to call twice. Never exits: it is called from EXIT traps where
+# the suite's own status is already decided.
 selftest_rm_scratch() {
-	local _st_path="${1:-}" _st_me _st_known
-	[ -n "$_st_path" ] || return 0
-	# A path that walks upward can prefix-match an allowlisted root and still
-	# resolve outside it, so refuse it before the match rather than trusting
-	# the string comparison below.
-	case "$_st_path" in
-	*/../* | */.. | ../* | ..)
+	local _st_dir _st_root _st_me
+	if [ "$#" -ne 0 ]; then
 		_st_me="$(basename "$0" .sh)"
-		printf '%s: refusing to delete "%s": the path walks upward, so a prefix match would not prove where it lands\n' \
-			"$_st_me" "$_st_path" >&2
-		return 1
-		;;
-	esac
-	for _st_known in ${selftest_scratch_dirs[@]+"${selftest_scratch_dirs[@]}"}; do
-		if [ "$_st_path" = "$_st_known" ]; then
-			rm -rf "$_st_path"
-			return 0
-		fi
-		case "$_st_path" in
-		"$_st_known"/*)
-			rm -rf "$_st_path"
-			return 0
-			;;
+		printf '%s: selftest_rm_scratch takes no arguments; it removes what selftest_scratch created\n' \
+			"$_st_me" >&2
+		return 2
+	fi
+	_st_root="${TMPDIR:-/tmp}"
+	_st_root="$(cd "$_st_root" 2>/dev/null && pwd -P)" || return 1
+	for _st_dir in ${selftest_scratch_dirs[@]+"${selftest_scratch_dirs[@]}"}; do
+		# selftest_scratch already proved each of these is a directory it
+		# minted under TMPDIR. Re-checking costs nothing and means even a
+		# corrupted array cannot widen the delete.
+		[ -n "$_st_dir" ] || continue
+		case "$_st_dir" in
+		"$_st_root"/*) ;;
+		*) continue ;;
 		esac
+		case "$_st_dir" in
+		*/../* | */..) continue ;;
+		esac
+		rm -rf "$_st_dir"
 	done
-	_st_me="$(basename "$0" .sh)"
-	printf '%s: refusing to delete "%s": selftest_scratch never created it\n' \
-		"$_st_me" "$_st_path" >&2
-	return 1
+	selftest_scratch_dirs=()
 }
 
 # selftest_summary — print "<name>: N checks, M failed" and return the

--- a/scripts/selftest-lib.sh
+++ b/scripts/selftest-lib.sh
@@ -1,15 +1,27 @@
 #!/usr/bin/env bash
 # selftest-lib.sh — shared assertion/counter/summary helpers for scripts/*-selftest.sh.
 #
-# Sourced, never executed: `. "$(dirname "$0")/selftest-lib.sh"`. Deliberately
-# pure bookkeeping — it defines functions and the checks/fails counters and
-# does nothing else: no files, no traps, no TMPDIR. That keeps it safe for the
+# Sourced, never executed: `. "$(dirname "$0")/selftest-lib.sh"`. Sourcing has
+# no side effects: this file defines functions and initializes counters and does
+# nothing else — it creates no files, installs no traps, and touches nothing
+# under TMPDIR until a suite calls something. That is what keeps it safe for the
 # wave runner's leak check, which fails a suite for anything it leaves behind.
+#
+# selftest_scratch does create a directory, but only when a suite calls it, and
+# only inside the suite's own TMPDIR — which is exactly where the wave runner's
+# leak check looks. A suite that creates scratch and removes it in its EXIT trap
+# leaves nothing behind, so the invariant above still holds.
 #
 # Suites that need a helper no one else does (e.g. merge-approval-gate's
 # assert_before) keep it locally rather than growing this file for one caller.
 checks=0
 fails=0
+
+# selftest_scratch_dirs are the directories selftest_scratch has created, and
+# the only ones selftest_rm_scratch will delete. Being under TMPDIR is not
+# enough to be deletable: a suite's own working directory can be under TMPDIR
+# too, and that is precisely the path this guard exists to protect.
+selftest_scratch_dirs=()
 
 ok() {
 	checks=$((checks + 1))
@@ -49,6 +61,124 @@ assert_not_has() {
 	else
 		ok "$3"
 	fi
+}
+
+# selftest_scratch VARNAME PREFIX — create a scratch directory under TMPDIR and
+# assign its canonical path to the caller's VARNAME. Any failure is fatal: the
+# suite exits non-zero with a diagnostic naming itself and the failure, having
+# created nothing.
+#
+# Call it as a statement, never inside a command substitution:
+#
+#	selftest_scratch work my-selftest        # right
+#	work="$(selftest_scratch work my-...)"   # WRONG: swallows the exit
+#
+# The wrong spelling runs the guard in a subshell, where `exit 1` ends only that
+# subshell and hands the caller an empty path. TestNoSelftestResolvesScratchToCWD
+# fails on it so the mistake cannot reach a run.
+#
+# The guard exists because the idiom it replaces aimed a recursive delete at the
+# repo (kata 5hs2). `mktemp -d` unchecked, then `work="$(cd "$work" && pwd -P)"`,
+# resolves $work to the CALLER'S WORKING DIRECTORY when mktemp fails, because
+# `cd ""` succeeds and leaves $PWD alone. The suite then wrote its fixtures into
+# the checkout and its EXIT trap deleted it. So every step below is checked, and
+# the canonical path is required to be inside TMPDIR before the caller sees it.
+#
+# The path is assigned only after it is known good: if a caller ever does spell
+# the call wrong, its variable is left empty rather than pointed somewhere real.
+#
+# Locals carry an _st_ prefix so they cannot shadow the VARNAME a caller asks to
+# have filled in.
+selftest_scratch() {
+	local _st_var="${1:?selftest_scratch: VARNAME required}"
+	local _st_prefix="${2:?selftest_scratch: PREFIX required}"
+	local _st_me _st_root _st_dir
+	_st_me="$(basename "$0" .sh)"
+
+	# A TMPDIR that does not exist is one of the real failure modes here: an
+	# inherited setting pointing at a reaped sandbox. Reject it before asking
+	# mktemp for anything, so the diagnostic names the actual problem.
+	_st_root="${TMPDIR:-/tmp}"
+	if ! _st_root="$(cd "$_st_root" 2>/dev/null && pwd -P)"; then
+		printf '%s: TMPDIR "%s" is not a usable directory; refusing to continue\n' \
+			"$_st_me" "${TMPDIR:-/tmp}" >&2
+		exit 1
+	fi
+
+	# An explicit template, never `-t`: macOS mktemp -t ignores TMPDIR and
+	# creates in the Darwin per-user temp directory, outside both the wave's
+	# per-suite isolation and its leak check (docs/testing.md, kata cqne).
+	if ! _st_dir="$(mktemp -d "$_st_root/$_st_prefix.XXXXXX")"; then
+		printf '%s: mktemp -d under "%s" failed; refusing to continue\n' \
+			"$_st_me" "$_st_root" >&2
+		exit 1
+	fi
+	if [ -z "$_st_dir" ] || [ ! -d "$_st_dir" ]; then
+		printf '%s: mktemp -d under "%s" returned no usable directory ("%s"); refusing to continue\n' \
+			"$_st_me" "$_st_root" "$_st_dir" >&2
+		exit 1
+	fi
+	# Canonicalize: on macOS $TMPDIR lives behind the /var -> /private/var
+	# symlink, and suites compare paths against what a script under test
+	# resolved with `pwd -P` or `git rev-parse`. Safe to spell this way here
+	# because the directory above is known to exist.
+	if ! _st_dir="$(cd "$_st_dir" 2>/dev/null && pwd -P)"; then
+		printf '%s: scratch directory under "%s" vanished before it could be resolved; refusing to continue\n' \
+			"$_st_me" "$_st_root" >&2
+		exit 1
+	fi
+	case "$_st_dir" in
+	"$_st_root"/*) ;;
+	*)
+		printf '%s: scratch "%s" resolved outside TMPDIR "%s"; refusing to continue\n' \
+			"$_st_me" "$_st_dir" "$_st_root" >&2
+		exit 1
+		;;
+	esac
+	# The template above fixes what a working mktemp can return, so anything
+	# else is a directory this call did not create — an existing one the caller
+	# may well be standing in. Being somewhere under TMPDIR is not enough to be
+	# safe to fill with fixtures and delete afterwards.
+	case "${_st_dir##*/}" in
+	"$_st_prefix".??????) ;;
+	*)
+		printf '%s: mktemp returned "%s", which is not the directory it was asked to create under "%s"; refusing to continue\n' \
+			"$_st_me" "$_st_dir" "$_st_root" >&2
+		exit 1
+		;;
+	esac
+
+	selftest_scratch_dirs=(${selftest_scratch_dirs[@]+"${selftest_scratch_dirs[@]}"} "$_st_dir")
+	printf -v "$_st_var" '%s' "$_st_dir"
+}
+
+# selftest_rm_scratch PATH — remove a directory selftest_scratch created, or
+# something inside one. Refuses everything else, so a caller whose variable was
+# emptied or clobbered cannot turn its EXIT trap into a delete of $PWD, $HOME,
+# or /. An empty path is nothing to do, not an error: a suite that died before
+# it had scratch still runs its trap. Returns non-zero on refusal rather than
+# exiting, because it is called from EXIT traps where the suite's own status is
+# already decided.
+selftest_rm_scratch() {
+	local _st_path="${1:-}" _st_me _st_known
+	[ -n "$_st_path" ] || return 0
+	rm -rf "$_st_path"; return 0 # MUTATION
+	for _st_known in ${selftest_scratch_dirs[@]+"${selftest_scratch_dirs[@]}"}; do
+		if [ "$_st_path" = "$_st_known" ]; then
+			rm -rf "$_st_path"
+			return 0
+		fi
+		case "$_st_path" in
+		"$_st_known"/*)
+			rm -rf "$_st_path"
+			return 0
+			;;
+		esac
+	done
+	_st_me="$(basename "$0" .sh)"
+	printf '%s: refusing to delete "%s": selftest_scratch never created it\n' \
+		"$_st_me" "$_st_path" >&2
+	return 1
 }
 
 # selftest_summary — print "<name>: N checks, M failed" and return the

--- a/scripts/selftest-lib.sh
+++ b/scripts/selftest-lib.sh
@@ -162,7 +162,17 @@ selftest_scratch() {
 selftest_rm_scratch() {
 	local _st_path="${1:-}" _st_me _st_known
 	[ -n "$_st_path" ] || return 0
-	rm -rf "$_st_path"; return 0 # MUTATION
+	# A path that walks upward can prefix-match an allowlisted root and still
+	# resolve outside it, so refuse it before the match rather than trusting
+	# the string comparison below.
+	case "$_st_path" in
+	*/../* | */.. | ../* | ..)
+		_st_me="$(basename "$0" .sh)"
+		printf '%s: refusing to delete "%s": the path walks upward, so a prefix match would not prove where it lands\n' \
+			"$_st_me" "$_st_path" >&2
+		return 1
+		;;
+	esac
 	for _st_known in ${selftest_scratch_dirs[@]+"${selftest_scratch_dirs[@]}"}; do
 		if [ "$_st_path" = "$_st_known" ]; then
 			rm -rf "$_st_path"

--- a/scripts/web-preflight-selftest.sh
+++ b/scripts/web-preflight-selftest.sh
@@ -17,7 +17,7 @@ script="$(cd "$(dirname "$0")" && pwd)/web-preflight.sh"
 . "$(dirname "$0")/selftest-lib.sh"
 
 selftest_scratch work web-preflight-selftest
-trap 'selftest_rm_scratch "$work"' EXIT
+trap 'selftest_rm_scratch' EXIT
 
 stub_bin="$work/bin"
 mkdir -p "$stub_bin"

--- a/scripts/web-preflight-selftest.sh
+++ b/scripts/web-preflight-selftest.sh
@@ -16,9 +16,8 @@ set -uo pipefail
 script="$(cd "$(dirname "$0")" && pwd)/web-preflight.sh"
 . "$(dirname "$0")/selftest-lib.sh"
 
-work="$(mktemp -d -t web-preflight-selftest.XXXXXX)"
-work="$(cd "$work" && pwd -P)"
-trap 'rm -rf "$work"' EXIT
+selftest_scratch work web-preflight-selftest
+trap 'selftest_rm_scratch "$work"' EXIT
 
 stub_bin="$work/bin"
 mkdir -p "$stub_bin"


### PR DESCRIPTION
Closes kata 5hs2.

Seven selftests built their scratch with an unchecked `mktemp -d` and then canonicalized it with `work="$(cd "$work" && pwd -P)"`. When mktemp fails, `cd ""` succeeds and leaves `$PWD` alone, so `$work` resolves to the suite's own working directory — and the EXIT trap's recursive delete then aims at whatever the suite was standing in.

**This is not hypothetical. It fired during this work and destroyed a machine's home directory.** See the incident section below.

## The guard

`scripts/selftest-lib.sh` gains `selftest_scratch VARNAME PREFIX`, which refuses to continue on any of: an unusable `TMPDIR`, a non-zero `mktemp`, a `mktemp` that exits 0 printing nothing, a result that resolves outside `TMPDIR`, and a result whose basename is not the one it asked to create (a squatting mktemp handing back an existing directory).

It assigns through a variable name rather than stdout on purpose: `work="$(selftest_scratch ...)"` would put the `exit 1` in a subshell and hand the caller an empty path, reinventing the bug.

`selftest_rm_scratch` **takes no argument**. It removes the directories `selftest_scratch` minted and recorded, and nothing else. Passing a path is an error, not a request.

That is the load-bearing design decision. The first version of this took a path and defended itself with an allowlist — and that guard turned out to be one edit away from useless. A delete that accepts a path can always be handed `$PWD`, `$HOME`, or `/` by a variable that was clobbered, and no amount of checking inside the function makes the caller's variable trustworthy. With no argument there is nothing to get wrong.

## Corrections to the kata's premise

The kata's list of affected scripts is wrong in both directions:

- `scripts/fuzz-coverage-global-selftest.sh` is **not** vulnerable — it alone uses `set -euo pipefail`, so `-e` aborts on the failed assignment before the canonicalize runs. Converted anyway; harmless.
- `scripts/e2e-webui-turn-controls-selftest.sh` **is** vulnerable and the kata omits it. It is also in `DEV_TOOLING_TEST_SCRIPTS`.

Both verified by executing the two `set -e` states against a failing-mktemp stub, not by reading.

## Also fixed: the same defect in a tool people run by hand

`scripts/agent-test-shards.sh` cds into the agent module, builds `$logdir` with an unchecked mktemp, canonicalizes it, and on a normally-completing run deletes it. Neither audit test catches it — the scratch audit only inspects `*-selftest.sh`, and the call already spells `${TMPDIR:-/tmp}` so the TMPDIR audit passes it. Reaching the delete needs a successful shard run, so I did not reproduce the deletion end to end; the hazard is established by reading. Verified: with a failing mktemp it now exits 2 naming the directory it could not create, working directory untouched.

## The incident

Two defects in an earlier revision of this branch combined into a live `rm -rf "$HOME"` inside `make merge-approval-gate`:

1. `selftest_rm_scratch` carried `rm -rf "$_st_path"; return 0 # MUTATION` as its second statement, making every containment check below it unreachable.
2. Its selftest handed that function `"/"` and `"$HOME"` as live arguments, and the Makefile wires the suite into `DEV_TOOLING_TEST_SCRIPTS`.

Both are gone. The test now fires at decoys under its own working directory, and asserts both refusal and that the decoys survive. A guard test must never name the thing it guards against: its correctness would otherwise rest on the guard having no typo, in a repo that runs a mutation scorer.

An escape found in review is also closed: the old allowlist compared raw strings, so `$scratch/..` prefix-matched an allowed root.

## Verification

`make merge-approval-gate` green (141s), with a home-directory check attached to the run.

The suite was additionally executed with `HOME` redirected to a decoy and sentinels seeded in the working directory: 80 checks, 0 failed, both canaries intact.

The audit test was shown able to fail: a probe script carrying both a bare `mktemp` and a command-substitution call to the guard produced both diagnostics naming the right lines.

## Known remaining work, not in this PR

Fifteen further selftests hand a clobberable variable to a recursive delete but lack the canonicalize step, so on failure the variable stays empty and the delete is inert — a rule violation, not a hazard. Six non-selftest tools also take a variable target and each needs individual judgment rather than a mechanical conversion. Follow-up.
