### PR TITLE
agent: decide before claiming the queue head on an interrupt

### DIFF
--- a/agent/abort_error.go
+++ b/agent/abort_error.go
@@ -9,12 +9,12 @@ import (
 // isAbortError reports whether err's chain contains an *llm.AbortError — the
 // `var abort *llm.AbortError; errors.As(err, &abort)` fragment that
 // roundWasCancelled (failure_steering.go), isTurnCancellation
-// (session_stream.go), and queuedInputDrainContext (session_queue.go) each
+// (session_stream.go), and interruptDrainConfig (session_queue.go) each
 // reimplemented independently. It answers only that narrow question; each
 // call site still does something different with the answer beyond it —
 // roundWasCancelled ORs it with a bare context.Canceled check,
 // isTurnCancellation adds an llm.Error exclusion after it, and
-// queuedInputDrainContext discriminates it against a same-context check (see
+// interruptDrainConfig discriminates it against a same-context check (see
 // that function's own comment on the honest-Unwrap asymmetry). None of that
 // surrounding logic belongs here; collapsing it into one function would lose
 // the real behavioral differences between the three.

--- a/agent/session_dod_definition_test.go
+++ b/agent/session_dod_definition_test.go
@@ -1360,12 +1360,12 @@ func TestQueuedInputDrainRootAcceptsAbortErrorForCanceledMarkedTurn(t *testing.T
 	markedCtx := WithQueuedInputDrainOnInterrupt(turnCtx, rootCtx)
 	cancelTurn()
 
-	got, ok := queuedInputDrainContext(markedCtx, llm.NewAbortError("user canceled", context.Canceled))
+	cfg, ok := interruptDrainConfig(markedCtx, llm.NewAbortError("user canceled", context.Canceled))
 	if !ok {
-		t.Fatal("queuedInputDrainContext rejected AbortError from canceled marked turn")
+		t.Fatal("interruptDrainConfig rejected AbortError from canceled marked turn")
 	}
-	if got != rootCtx {
-		t.Fatal("queuedInputDrainContext did not return the root context")
+	if got := cfg.nextTurnContext(); got != rootCtx {
+		t.Fatal("nextTurnContext did not return the root context")
 	}
 }
 
@@ -1381,7 +1381,7 @@ func TestQueuedInputDrainRejectsAbortErrorWhenTurnLive(t *testing.T) {
 	markedCtx := WithQueuedInputDrainOnInterrupt(turnCtx, rootCtx)
 	// Do NOT cancel the turn: markedCtx.Err() == nil.
 
-	if _, ok := queuedInputDrainContext(markedCtx, llm.NewAbortError("subop canceled", context.Canceled)); ok {
+	if _, ok := interruptDrainConfig(markedCtx, llm.NewAbortError("subop canceled", context.Canceled)); ok {
 		t.Fatal("drained on an AbortError while the turn ctx was still live; the raw-Canceled-vs-AbortError asymmetry collapsed")
 	}
 }
@@ -1417,12 +1417,13 @@ func TestQueuedInputDrainContextUsesFreshCancelableTurnContext(t *testing.T) {
 	})
 	cancelTurn()
 
-	got, ok := queuedInputDrainContext(markedCtx, context.Canceled)
+	cfg, ok := interruptDrainConfig(markedCtx, context.Canceled)
 	if !ok {
-		t.Fatal("queuedInputDrainContext rejected canceled marked turn")
+		t.Fatal("interruptDrainConfig rejected canceled marked turn")
 	}
+	got := cfg.nextTurnContext()
 	if got == rootCtx {
-		t.Fatal("queuedInputDrainContext returned root context, want fresh turn context")
+		t.Fatal("nextTurnContext returned root context, want fresh turn context")
 	}
 	if got.Err() != nil {
 		t.Fatalf("fresh drain context is already canceled: %v", got.Err())

--- a/agent/session_goal.go
+++ b/agent/session_goal.go
@@ -266,16 +266,20 @@ func (s *Session) settleGoalOnIdle() bool {
 // terminal report when a turn ends in a system cancellation or error. It is a
 // no-op when there is no active goal, and — critically — when err is a genuine
 // user /interrupt: the goal stays active and resumes after the next completed
-// turn (spec §6). The discriminator is the queuedInputDrainContext bool, not the
+// turn (spec §6). The discriminator is the interruptDrainConfig bool, not the
 // WithQueuedInputDrainOnInterrupt marker (which is installed on every turn ctx and
 // so discriminates nothing); a DeadlineExceeded or provider error routes the goal
 // to blocked while the session remains available for later input.
+//
+// Classifying is all this wants, so it asks the classifier. Building the drain
+// context is what announces a new turn to the host, and no turn is starting
+// here — a goal decision must not tell the daemon a turn began.
 func (s *Session) terminateGoalOnError(ctx context.Context, err error) {
 	store := s.getOrCreateGoalStore()
 	if snap, ok := store.Snapshot(); !ok || snap.Status != goal.StatusActive {
 		return
 	}
-	if _, isUserInterrupt := queuedInputDrainContext(ctx, err); isUserInterrupt {
+	if _, isUserInterrupt := interruptDrainConfig(ctx, err); isUserInterrupt {
 		return // genuine user interrupt: leave the goal active
 	}
 	if goalRootShutdown(ctx, err) {

--- a/agent/session_goal_gate_test.go
+++ b/agent/session_goal_gate_test.go
@@ -183,13 +183,13 @@ func TestArmGoalContinuationNoIterationCap(t *testing.T) {
 
 // TestTerminateGoalOnErrorClassification: a plain error and a DeadlineExceeded
 // transition an active goal to blocked and emit EventGoalEnded; a context that
-// queuedInputDrainContext classifies as a genuine user interrupt leaves the goal
+// interruptDrainConfig classifies as a genuine user interrupt leaves the goal
 // active and emits no EventGoalEnded.
 func TestTerminateGoalOnErrorClassification(t *testing.T) {
 	t.Parallel()
 	// userInterruptCtx constructs a context exactly as production does for a
 	// genuine user /interrupt: a marked, cancelled turn context. Paired with a
-	// bare context.Canceled error, queuedInputDrainContext reports ok=true.
+	// bare context.Canceled error, interruptDrainConfig reports ok=true.
 	userInterruptCtx := func() context.Context {
 		root := context.Background()
 		turnCtx, cancel := context.WithCancel(root)

--- a/agent/session_goal_gate_test.go
+++ b/agent/session_goal_gate_test.go
@@ -249,6 +249,44 @@ func TestTerminateGoalOnErrorClassification(t *testing.T) {
 	}
 }
 
+// TestTerminateGoalOnErrorDoesNotAnnounceATurn pins the difference between
+// asking whether an interrupt is a user interrupt and acting on the answer.
+//
+// The host's next-turn factory is how a drained queue head announces itself:
+// cmd/serf serve publishes processing state and registers the new turn's cancel
+// from inside it. terminateGoalOnError only wants the classification, and no
+// turn is starting when a goal decides whether to stay active — invoking the
+// factory here tells the daemon a turn began that will never run, and nothing
+// downstream corrects it, because the interrupted SessionEnd has already fired.
+func TestTerminateGoalOnErrorDoesNotAnnounceATurn(t *testing.T) {
+	t.Parallel()
+	sess, stop := newGateSession(t)
+	defer stop()
+
+	root := context.Background()
+	turnCtx, cancel := context.WithCancel(root)
+	var factoryCalls int
+	marked := WithQueuedInputDrainOnInterruptHandler(turnCtx, root, func(parent context.Context) (context.Context, context.CancelFunc) {
+		factoryCalls++
+		next, cancelNext := context.WithCancel(parent)
+		return next, cancelNext
+	})
+	cancel()
+
+	store := sess.getOrCreateGoalStore()
+	store.Set("some objective", time.Now())
+
+	sess.terminateGoalOnError(marked, context.Canceled)
+
+	if factoryCalls != 0 {
+		t.Fatalf("the goal decision built %d next-turn context(s); it must build none. Constructing one announces a turn to the host that will never run", factoryCalls)
+	}
+	snap, ok := store.Snapshot()
+	if !ok || snap.Status != goal.StatusActive {
+		t.Fatalf("goal snapshot = %+v ok=%v, want still active: the classification itself must be unchanged", snap, ok)
+	}
+}
+
 // TestRoundCapSelection verifies the per-goal-turn round-cap selection (C13):
 // continuation turns clamp an unbounded or >GoalTurnMaxRounds config down to
 // GoalTurnMaxRounds; a config already <= the cap is left untouched; user-input

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -704,18 +704,24 @@ func (s *Session) processInputKindWithProvenance(ctx context.Context, input stri
 					})
 				}
 				if !closed {
-					if queued := s.popQueueHead(); strings.TrimSpace(queued.Text) != "" || len(queued.Images) > 0 {
-						if drainCtx, ok := queuedInputDrainContext(processCtx, err); ok {
+					// Decide, then claim. popQueueHead is a durable commit, and
+					// whether this interrupt may drain depends only on the turn's
+					// context and error -- never on the queue -- so there is
+					// nothing to learn by taking the head out first. Doing it in
+					// the other order costs a second commit to put the entry back,
+					// and the state between the two is a queue no client ever saw:
+					// a turn/promoteQueuedAsSteer landing there commits against the
+					// wrong entry (kata 9f5x).
+					if cfg, drainable := interruptDrainConfig(processCtx, err); drainable {
+						if queued := s.popQueueHead(); strings.TrimSpace(queued.Text) != "" || len(queued.Images) > 0 {
 							next = queued.Text
 							nextImages = queued.Images
-							processCtx = drainCtx
-							processCtx = withQueuedClientMutation(processCtx, queued)
+							processCtx = withQueuedClientMutation(cfg.nextTurnContext(), queued)
 							s.mu.Lock()
 							s.sessionEndEmitted = false
 							s.mu.Unlock()
 							continue
 						}
-						s.pushQueueHead(queued)
 					}
 				}
 			}

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -704,10 +704,20 @@ func (s *Session) queueChangedDataLocked() events.QueueChangedData {
 	}
 	return data
 }
-func queuedInputDrainContext(ctx context.Context, err error) (context.Context, bool) {
+// interruptDrainConfig reports whether an interrupted turn may consume the
+// queue head, and hands back the drain handler to run it under.
+//
+// It is a pure function of THIS turn's context and error: it reads no queue
+// state, and it commits nothing. That is what lets the interrupted-turn
+// recovery settle the question before it claims. Claiming first and asking
+// afterwards costs a durable commit to remove the head and a second to put it
+// back, and between them the durable queue is observably missing an entry that
+// is about to return -- which a turn/promoteQueuedAsSteer can sample and commit
+// against (kata 9f5x).
+func interruptDrainConfig(ctx context.Context, err error) (queuedInputDrainConfig, bool) {
 	cfg, ok := ctx.Value(queuedInputDrainContextKey{}).(queuedInputDrainConfig)
 	if !ok || cfg.rootCtx == nil {
-		return nil, false
+		return queuedInputDrainConfig{}, false
 	}
 	isAbort := isAbortError(err)
 	// A bare context.Canceled is this turn's own cancellation and always drains.
@@ -718,19 +728,34 @@ func queuedInputDrainContext(ctx context.Context, err error) (context.Context, b
 	bareCanceled := errors.Is(err, context.Canceled) && !isAbort
 	drainable := bareCanceled || (isAbort && errors.Is(ctx.Err(), context.Canceled))
 	if !drainable || errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return nil, false
+		return queuedInputDrainConfig{}, false
 	}
 	if cfg.rootCtx.Err() != nil {
-		return nil, false
+		return queuedInputDrainConfig{}, false
 	}
+	return cfg, true
+}
+
+// nextTurnContext returns the context the drained queue head runs under. It
+// carries the side effect of announcing the new turn to the host (cmd/serf's
+// handler publishes processing state and registers the turn's cancel), so it
+// runs only once the head is really claimed.
+//
+// It is total, and the totality is load-bearing: the head is already claimed
+// when this is called, so a failure here would have to put the entry back, and
+// that restore is the second durable commit this path exists to avoid. A
+// handler that installs no factory already drained under the root context
+// (WithQueuedInputDrainOnInterrupt); a factory that declines to build one now
+// does the same, which is the only answer that keeps the claim honest.
+func (cfg queuedInputDrainConfig) nextTurnContext() context.Context {
 	if cfg.nextCtx == nil {
-		return cfg.rootCtx, true
+		return cfg.rootCtx
 	}
-	nextCtx, _ := cfg.nextCtx(cfg.rootCtx)
-	if nextCtx == nil {
-		return nil, false
+	next, _ := cfg.nextCtx(cfg.rootCtx)
+	if next == nil {
+		return cfg.rootCtx
 	}
-	return nextCtx, true
+	return next
 }
 func (s *Session) drainSteering() []steeringMessage {
 	s.mu.Lock()

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -53,6 +53,14 @@ func WithQueuedInputDrainOnInterrupt(ctx context.Context, rootCtx context.Contex
 // WithQueuedInputDrainOnInterruptHandler marks ctx like
 // WithQueuedInputDrainOnInterrupt and lets callers install a fresh cancelable
 // context when queued input is drained after an interrupt.
+//
+// A nil nextCtx, or one that returns a nil context, means the drained turn runs
+// under rootCtx — the same as installing no handler at all. It does NOT mean
+// "do not drain": the recovery classifies the interrupt before it claims the
+// queue head, so by the time this factory is consulted the entry is already
+// claimed and refusing would strand it. A host that needs its own cancelation
+// registered for the drained turn must return a context here; under rootCtx no
+// per-turn cancel is registered, so an out-of-band interrupt will not reach it.
 func WithQueuedInputDrainOnInterruptHandler(ctx context.Context, rootCtx context.Context, nextCtx func(context.Context) (context.Context, context.CancelFunc)) context.Context {
 	if rootCtx == nil {
 		rootCtx = context.Background()

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -704,6 +704,7 @@ func (s *Session) queueChangedDataLocked() events.QueueChangedData {
 	}
 	return data
 }
+
 // interruptDrainConfig reports whether an interrupted turn may consume the
 // queue head, and hands back the drain handler to run it under.
 //

--- a/agent/session_queue_interrupt_claim_test.go
+++ b/agent/session_queue_interrupt_claim_test.go
@@ -73,7 +73,7 @@ func interruptClaimSession(t *testing.T) (*Session, func() [][]string) {
 // interruptedTurnContext returns the context an interrupted turn runs under,
 // wired the way cmd/serf serve wires it (a marked turn context with a
 // next-turn factory). rootLive=false cancels the root as well, which is what
-// makes the drain unavailable: queuedInputDrainContext refuses a root that is
+// makes the drain unavailable: interruptDrainConfig refuses a root that is
 // already done, and that refusal is the branch that used to restore the head.
 func interruptedTurnContext(t *testing.T, rootLive bool) context.Context {
 	t.Helper()

--- a/agent/session_queue_interrupt_claim_test.go
+++ b/agent/session_queue_interrupt_claim_test.go
@@ -1,0 +1,162 @@
+package agent
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"primeradiant.com/serf/agent/events"
+)
+
+// The interrupted-turn recovery in session_lifecycle.go is the one place that
+// takes the queue head away. Whether it may take it is decided entirely by this
+// turn's context and error -- interruptDrainConfig reads no queue state at all
+// -- so the decision must be made BEFORE the claim.
+//
+// Claiming first and asking afterwards costs one durable commit to remove the
+// head and a second to put it back, and between them the durable queue is
+// observably missing an entry that is about to return. turn/promoteQueuedAsSteer
+// is a compare-and-commit against exactly that state: a promote naming index 0
+// lands on the SECOND queued message, which no client ever saw at index 0
+// (kata 9f5x, found while root-causing n1zs).
+//
+// The oracle is the queue revision, because the revision is what makes a
+// transient state observable in the first place. Every durable queue change
+// bumps it and publishes the result. Zero bumps means no state existed for
+// anything to sample.
+
+// interruptClaimSession builds a session whose queue is durable, and returns it
+// alongside a collector of every queue state it publishes. The collector is the
+// client's-eye view: reflectDurableInputQueue emits one QUEUE_CHANGED per
+// durable commit, so a phantom state that reaches a client reaches this slice.
+//
+// Collecting closes the session first and joins the reader, so the result is
+// every event the session ever published rather than however many the reader
+// happened to have picked up -- a test that raced its own event stream could
+// only ever be green by accident.
+func interruptClaimSession(t *testing.T) (*Session, func() [][]string) {
+	t.Helper()
+	sess := newQueuePersistTestSession(t, t.TempDir())
+
+	var mu sync.Mutex
+	var published [][]string
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for ev := range sess.Events() {
+			data, ok := ev.Data.(events.QueueChangedData)
+			if !ok {
+				continue
+			}
+			mu.Lock()
+			published = append(published, append([]string(nil), data.Preview...))
+			mu.Unlock()
+		}
+	}()
+
+	var closeOnce sync.Once
+	closeSession := func() {
+		closeOnce.Do(func() {
+			sess.Close()
+			<-done
+		})
+	}
+	t.Cleanup(closeSession)
+	return sess, func() [][]string {
+		closeSession()
+		mu.Lock()
+		defer mu.Unlock()
+		return append([][]string(nil), published...)
+	}
+}
+
+// interruptedTurnContext returns the context an interrupted turn runs under,
+// wired the way cmd/serf serve wires it (a marked turn context with a
+// next-turn factory). rootLive=false cancels the root as well, which is what
+// makes the drain unavailable: queuedInputDrainContext refuses a root that is
+// already done, and that refusal is the branch that used to restore the head.
+func interruptedTurnContext(t *testing.T, rootLive bool) context.Context {
+	t.Helper()
+	root, cancelRoot := context.WithCancel(context.Background())
+	t.Cleanup(cancelRoot)
+	turnCtx, cancelTurn := context.WithCancel(root)
+	t.Cleanup(cancelTurn)
+	var nextCtx func(context.Context) (context.Context, context.CancelFunc)
+	nextCtx = func(parent context.Context) (context.Context, context.CancelFunc) {
+		next, cancel := context.WithCancel(parent)
+		t.Cleanup(cancel)
+		return WithQueuedInputDrainOnInterruptHandler(next, root, nextCtx), cancel
+	}
+	marked := WithQueuedInputDrainOnInterruptHandler(turnCtx, root, nextCtx)
+	cancelTurn()
+	if !rootLive {
+		cancelRoot()
+	}
+	return marked
+}
+
+// TestUndrainableInterruptMakesNoDurableQueueTransition is the kata's stop
+// condition stated directly: an interrupted turn that cannot run what it would
+// claim must leave the durable queue untouched, so no state exists for a
+// racing compare-and-commit to sample.
+func TestUndrainableInterruptMakesNoDurableQueueTransition(t *testing.T) {
+	sess, publishedQueues := interruptClaimSession(t)
+
+	queueOneMutation(t, sess, "queue-alpha", "alpha")
+	queueOneMutation(t, sess, "queue-bravo", "bravo")
+
+	before, _ := sess.ClientMutationProjection()
+	if before.Depth != 2 {
+		t.Fatalf("durable queue depth before the interrupt = %d, want 2; this test is not in the state it means to be", before.Depth)
+	}
+
+	// The drain is unavailable (dead root), so the recovery reaches the branch
+	// that used to pop the head and push it back.
+	_, _ = sess.ProcessInput(interruptedTurnContext(t, false), "interrupted turn", nil)
+
+	after, _ := sess.ClientMutationProjection()
+	if len(after.IDs) != 2 || after.IDs[0] != before.IDs[0] || after.IDs[1] != before.IDs[1] {
+		t.Fatalf("durable queue after the interrupt = %#v, want %#v unchanged", after.IDs, before.IDs)
+	}
+	if after.Revision != before.Revision {
+		t.Errorf("the queue revision moved from %d to %d across an interrupt that consumed nothing: the recovery claimed the head durably and then put it back, and every state between those two commits was a queue no client ever saw (kata 9f5x)",
+			before.Revision, after.Revision)
+	}
+
+	// The revision assertion proves no phantom state was durably committed;
+	// this proves no client was told one existed. "bravo alone" is the phantom
+	// by name: it is the queue with the head claimed and not yet returned, and
+	// it is the state a turn/promoteQueuedAsSteer naming index 0 would land on.
+	for _, preview := range publishedQueues() {
+		if len(preview) == 1 && preview[0] == "bravo" {
+			t.Errorf("the queue state %#v reached clients during the interrupt: a promote naming index 0 against it steers \"bravo\", which no client ever saw at index 0", preview)
+		}
+	}
+}
+
+// TestDrainableInterruptClaimsQueueHeadInOneDurableTransition is the other half
+// of the contract, and guards the obvious wrong fix: a recovery that closes the
+// window by never draining at all. A live root means the head runs, and it must
+// cost exactly one durable commit.
+func TestDrainableInterruptClaimsQueueHeadInOneDurableTransition(t *testing.T) {
+	sess, _ := interruptClaimSession(t)
+
+	queueOneMutation(t, sess, "queue-alpha", "alpha")
+	queueOneMutation(t, sess, "queue-bravo", "bravo")
+
+	before, _ := sess.ClientMutationProjection()
+	if before.Depth != 2 {
+		t.Fatalf("durable queue depth before the interrupt = %d, want 2", before.Depth)
+	}
+
+	_, _ = sess.ProcessInput(interruptedTurnContext(t, true), "interrupted turn", nil)
+
+	after, _ := sess.ClientMutationProjection()
+	if len(after.IDs) != 1 || after.IDs[0] != before.IDs[1] {
+		t.Fatalf("durable queue after the drain = %#v, want only %q: the interrupted turn must run the head it claimed", after.IDs, before.IDs[1])
+	}
+	if after.Revision != before.Revision+1 {
+		t.Fatalf("the drain cost %d durable queue transitions (revision %d -> %d), want exactly 1: claiming the head is one commit, and any second commit is a state a racing promote can sample",
+			after.Revision-before.Revision, before.Revision, after.Revision)
+	}
+}

--- a/agent/session_queue_lifecycle_program_fuzz_test.go
+++ b/agent/session_queue_lifecycle_program_fuzz_test.go
@@ -215,8 +215,12 @@ func qlifExerciseNotificationRetry(t *testing.T, s *Session, clk *agenttest.Fake
 func qlifExerciseQueueHelpers(t *testing.T, s *Session) {
 	t.Helper()
 	ctx := WithQueuedInputDrainOnInterrupt(context.Background(), nil)
-	if got, ok := queuedInputDrainContext(ctx, context.Canceled); !ok || got == nil {
-		t.Fatal("default queued-input drain context was rejected")
+	cfg, ok := interruptDrainConfig(ctx, context.Canceled)
+	if !ok {
+		t.Fatal("default queued-input drain config was rejected")
+	}
+	if got := cfg.nextTurnContext(); got == nil {
+		t.Fatal("default queued-input drain context was nil")
 	}
 
 	if s.hasPendingSteering() {
@@ -298,15 +302,29 @@ func qlifCheckDrainContext(t *testing.T, data []byte) {
 	case 6:
 		cancelTurn()
 	case 7:
+		// The factory declines to build a next-turn context. Draining is still
+		// allowed: by the time a context is wanted the queue head is already
+		// durably claimed, so refusing here would mean putting it back, and the
+		// pop/restore pair is the two-commit window kata 9f5x closed. A
+		// declining factory drains under the root context instead, exactly as a
+		// handler that installs no factory at all already did.
 		cancelTurn()
-		want = false
 	}
-	got, ok := queuedInputDrainContext(marked, err)
+	cfg, ok := interruptDrainConfig(marked, err)
 	if ok != want {
-		t.Fatalf("mode %d: queuedInputDrainContext ok=%v, want %v (err=%v)", mode, ok, want, err)
+		t.Fatalf("mode %d: interruptDrainConfig ok=%v, want %v (err=%v)", mode, ok, want, err)
 	}
-	if ok && (got == nil || got.Err() != nil) {
+	if !ok {
+		cancelTurn()
+		cancelRoot()
+		return
+	}
+	got := cfg.nextTurnContext()
+	if got == nil || got.Err() != nil {
 		t.Fatalf("mode %d: drain context = %#v, err=%v", mode, got, got.Err())
+	}
+	if mode == 7 && got != root {
+		t.Fatalf("mode 7: a declining factory must drain under the root context, got %#v", got)
 	}
 	if nextCanceled != nil {
 		nextCanceled()


### PR DESCRIPTION
Closes kata 9f5x.

The interrupted-turn recovery took the queue head out of durable state to ask a question it could have asked first:

```go
if queued := s.popQueueHead(); nonEmpty {          // durable commit 1, QueueRevision++
    if drainCtx, ok := queuedInputDrainContext(processCtx, err); ok {
        ... continue
    }
    s.pushQueueHead(queued)                        // durable commit 2, QueueRevision++
}
```

`clientMutationStore.mu` is released between them, and the decision in the gap reads only `processCtx` and `err` — it never touches queue state. So the entry was removed purely to ask a question that did not need it removed.

In that window `snapshot.InputQueue` is `[bravo]` when every client that ever observed the queue saw `[alpha, bravo]`. A `turn/promoteQueuedAsSteer` naming index 0 commits against `bravo` — the entry it named, at an index the client never saw it at. `popQueueHead` also calls `reflectDurableInputQueue`, so that phantom state is published to every subscriber.

## What changed

Reordered to **classify, claim, construct**. The classification is split out of the context construction, so the recovery decides whether it can drain before it touches the queue, and the head is claimed only on the path that will consume it.

The construction is deliberately kept second because *calling* it is the announcement — it fires `SetProcessing(true)`, `SetCancelFunc`, and `setMutationRunner` in the host. Announcing a turn before you know a head exists is a separate bug, which is exactly what the rider below fixes.

`queuedInputDrainContext` was then deleted rather than kept as a wrapper: after the reorder it had zero production callers, because `goalRootShutdown` reads the config value straight out of the context. Keeping it would have left a function in production that exists only to be tested, and a pinned original plus a split twin that must agree forever.

## The rider

`terminateGoalOnError` wanted only the classification bool — its own doc comment says so — but was calling the constructor to get it. With an active goal and a genuine user interrupt that fired the host's "a turn is starting" announcement for a turn that never runs.

It belongs in this commit: splitting the function forces every caller to choose, and leaving this one alone would have meant writing an explicit construction call to preserve a bug.

Review corrected my original account of the harm here, and the corrected version is narrower: `cmd/serf/serve.go` does reset the processing flag afterwards. What actually survives is a processing→idle flicker published after the interrupt's `SessionEnd` already said idle, and `currentCancel` being overwritten so `cancelTurn` is never called — one leaked context per interrupted goal turn.

## A pinned fuzz invariant was deleted, deliberately

`session_queue_lifecycle_program_fuzz_test.go` mode 7 pinned "a declining context factory means do not drain". Under the new order refusal is not available: by the time the factory is consulted the head is claimed, and refusing would strand it.

That invariant was unreachable in production anyway — the real factory in `cmd/serf/serve.go` returns unconditionally and can never return nil. The replacement behaviour (decline → drain under root) is what a handler with no factory installed already did, so it is consistent rather than novel. The now-silent contract change on the exported `WithQueuedInputDrainOnInterruptHandler` is documented on that function.

## Why the claim cannot strand an entry

`nextTurnContext` is total: `rootCtx` is guaranteed non-nil by the classifier's own guard, and a nil factory result falls back to it. Beyond that, `completeClientMutationTurnWithState` already returns any claimed-but-never-incorporated queue mutation, at turn completion and at startup — so even a panic cannot permanently strand the entry.

## Verification

`make merge-approval-gate` green (153s).

Independently reviewed, and because the original worktree and its report were destroyed, the reviewer designed and ran its own mutations rather than checking a list. Restoring the old two-commit shape produces both failures end to end:

```
--- FAIL: TestUndrainableInterruptMakesNoDurableQueueTransition
  the queue revision moved from 2 to 4 across an interrupt that consumed nothing
  the queue state []string{"bravo"} reached clients during the interrupt
```

Reintroducing the factory call in `terminateGoalOnError` reddens its guard with `factoryCalls=1`.

Note honestly: `TestDrainableInterruptClaimsQueueHeadInOneDurableTransition` passes under the old shape too. It is a regression guard against the obvious wrong fix — "close the window by never draining" — not proof of this change, and its own comment says so.

## Not addressed

The kata's fallback suggestion was to add `ExpectedQueueRevision` to `turn/promoteQueuedAsSteer`. That would contradict a normative table: `docs/superpowers/specs/2026-07-28-appwire-retry-safe-mutations-and-atomic-rejoin-design.md` gives promote `expectedTurnId` + `expectedEntryId`, and gives `expectedQueueRevision` only to `turn/drainAsSteer`. The single durable transition makes the wire change unnecessary.

`session_lifecycle.go`'s second pop/restore pair — the transcript-append-failure rollback — is the same two-commit shape with a much rarer trigger, and is left alone. Kata 91hp's interrupt-fence sampling is untouched.

Three normative specs still name the deleted `queuedInputDrainContext`. The semantics they describe are unchanged, so this is drift rather than contradiction, and editing a decision record is not a thing this PR should do unilaterally.

## Provenance

Reconstructed after the original worktree was destroyed by an unrelated accident. The first commit is a squashed reconstruction, followed by a gofmt repair and the review round.
