### PR TITLE
composer: track a submit for its whole duration, not just its refresh

### DIFF
--- a/cmd/serf-hub/frontend/src/panes/session/composer/Composer.test.tsx
+++ b/cmd/serf-hub/frontend/src/panes/session/composer/Composer.test.tsx
@@ -189,8 +189,8 @@ class PausedRecoveryReadStorage extends MutationOutboxIndexedDB {
 // the way a loaded machine makes the real work land: mount-to-activation
 // latency on this path measured 124-1246ms across 12 runs (kata 3c7t) while a
 // React flush is single-digit ms. Nothing waits on the delay - the tests await
-// the operation's own completion through settleRecoveryProjection - so the
-// number only has to be long enough that an unawaited path cannot have
+// the operation's own completion through flushPendingTurnsProjectionForTests -
+// so the number only has to be long enough that an unawaited path cannot have
 // finished yet.
 const SLOW_RECOVERY_WORK_MS = 150;
 

--- a/cmd/serf-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.test.ts
+++ b/cmd/serf-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.test.ts
@@ -117,6 +117,41 @@ test("a local commit failure reports the exact error and never creates optimisti
   expect(pending.result.current).toEqual([]);
 });
 
+// The settle helper can only await what registered with trackProjectionWork.
+// A submit whose work registers no earlier than its own completion is therefore
+// invisible to a flush that starts first: round one finds nothing outstanding,
+// declares the projection settled, and the test asserts against a pre-commit
+// snapshot. That is kata 3p22's flake, and it is a property, not a rate - so
+// this test pins the property and never counts failures.
+test("a flush cannot settle while a submit is still in flight", async () => {
+  let releaseSubmit: () => void = () => undefined;
+  const submitting = new Promise<void>((resolve) => {
+    releaseSubmit = resolve;
+  });
+
+  const submitted = submitWithPendingTracking(
+    { ref: "ref_a", method: "send", text: "in flight", onFailure: () => undefined },
+    () => submitting,
+  );
+
+  let flushResolved = false;
+  const flushing = flushPendingTurnsProjectionForTests().then(() => {
+    flushResolved = true;
+  });
+
+  // Give the flush every chance to finish early: more macrotask hops than its
+  // own settle round takes. If the submit is tracked, it cannot return here.
+  for (let hop = 0; hop < 5; hop += 1) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+  expect(flushResolved).toBe(false);
+
+  releaseSubmit();
+  await submitted;
+  await flushing;
+  expect(flushResolved).toBe(true);
+});
+
 test("recovery action wrappers refresh the durable projection", async () => {
   let mutationId = 0;
   const storage = new MutationOutboxIndexedDB({

--- a/cmd/serf-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
+++ b/cmd/serf-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
@@ -94,14 +94,18 @@ export async function settlePendingTurnsProjectionForTests(): Promise<number> {
 //
 // What it can settle is exactly what registers with trackProjectionWork, so a
 // round that found nothing is proof that nothing is left only while every
-// durable path registers before it can be observed. They all do now; the last
-// one that did not was submitWithPendingTracking, which registered nothing
-// until its own work had already finished, and a flush starting in that window
-// declared the projection settled with a send still in flight (kata 3p22).
+// durable path registers before it can be observed. Every path in THIS file
+// does: the last one that did not was submitWithPendingTracking, which
+// registered nothing until its own work had already finished, and a flush
+// starting in that window declared the projection settled with a send still in
+// flight (kata 3p22).
 //
-// Adding a durable path that is not tracked reopens that hole, and it reopens
-// it as a load-sensitive false green rather than a failure. pendingTurnsStore's
-// "a flush cannot settle while a submit is still in flight" pins the property.
+// That is a claim about this file, not about every caller. A path that starts
+// durable work and only registers it a microtask later is invisible to a round
+// that snapshots first - Composer's queueRecoveryPersistence chains that way
+// (kata 5meh). Adding one reopens the hole as a load-sensitive false green
+// rather than a failure. pendingTurnsStore's "a flush cannot settle while a
+// submit is still in flight" pins the property for the paths here.
 export async function flushPendingTurnsProjectionForTests(): Promise<void> {
   for (let round = 0; round < 10; round += 1) {
     let awaited = 0;

--- a/cmd/serf-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
+++ b/cmd/serf-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
@@ -100,12 +100,19 @@ export async function settlePendingTurnsProjectionForTests(): Promise<number> {
 // starting in that window declared the projection settled with a send still in
 // flight (kata 3p22).
 //
-// That is a claim about this file, not about every caller. A path that starts
-// durable work and only registers it a microtask later is invisible to a round
-// that snapshots first - Composer's queueRecoveryPersistence chains that way
-// (kata 5meh). Adding one reopens the hole as a load-sensitive false green
-// rather than a failure. pendingTurnsStore's "a flush cannot settle while a
-// submit is still in flight" pins the property for the paths here.
+// That is a claim about this file, not about every caller. The round below
+// snapshots synchronously, in the same tick as the call, so a caller that
+// starts durable work which only registers a microtask later is invisible to
+// it - but only if that same caller flushes without yielding first. Composer's
+// queueRecoveryPersistence chains that way and every one of its call sites
+// yields, which is why it was measured unreachable rather than fixed: zero
+// occurrences in 1422 test executions under load (kata 5meh, closed as an
+// audit).
+//
+// So the hazard is the pattern, not that instance. A new path that registers
+// late reopens it as a load-sensitive false green rather than a failure.
+// pendingTurnsStore's "a flush cannot settle while a submit is still in
+// flight" pins the property for the paths here.
 export async function flushPendingTurnsProjectionForTests(): Promise<void> {
   for (let round = 0; round < 10; round += 1) {
     let awaited = 0;

--- a/cmd/serf-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
+++ b/cmd/serf-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
@@ -92,12 +92,16 @@ export async function settlePendingTurnsProjectionForTests(): Promise<number> {
 // nothing outstanding. The bound is a tripwire for a livelock - it throws
 // rather than letting a test pass on a half-settled projection.
 //
-// What it can settle is exactly what registers with trackProjectionWork. Work
-// that never registers is invisible to this, and a round that found nothing is
-// therefore not a proof that nothing is left - the copies this replaces each
-// claimed it was. Kata 3p22 holds the measured flake that gap produces and its
-// fix. A test whose own action registers its work synchronously before calling
-// here - a click that goes through mutateThenRefresh, say - is not exposed.
+// What it can settle is exactly what registers with trackProjectionWork, so a
+// round that found nothing is proof that nothing is left only while every
+// durable path registers before it can be observed. They all do now; the last
+// one that did not was submitWithPendingTracking, which registered nothing
+// until its own work had already finished, and a flush starting in that window
+// declared the projection settled with a send still in flight (kata 3p22).
+//
+// Adding a durable path that is not tracked reopens that hole, and it reopens
+// it as a load-sensitive false green rather than a failure. pendingTurnsStore's
+// "a flush cannot settle while a submit is still in flight" pins the property.
 export async function flushPendingTurnsProjectionForTests(): Promise<void> {
   for (let round = 0; round < 10; round += 1) {
     let awaited = 0;
@@ -154,18 +158,29 @@ export interface SubmitWithPendingTrackingOptions {
 
 // The action resolves at the local IndexedDB commit boundary. Durable state,
 // not a component timer or text echo, is the only optimistic lifecycle.
-export async function submitWithPendingTracking(
+//
+// Registered with trackProjectionWork for its whole duration, not just for the
+// refresh it ends with. Every other durable path here is tracked from the call
+// that starts it; this one used to register nothing until `perform` had already
+// resolved, which left a window where a settle round found the set empty and
+// reported the projection settled while a send was still in flight (kata 3p22).
+// Tracking from the click is what makes one zero round genuine proof.
+export function submitWithPendingTracking(
   opts: SubmitWithPendingTrackingOptions,
   perform: () => Promise<void>,
 ): Promise<void> {
-  try {
-    await perform();
-  } catch (error) {
-    opts.onFailure(error);
-    throw error;
-  } finally {
-    await refreshPendingTurnsProjection(opts.ref);
-  }
+  return trackProjectionWork(
+    (async () => {
+      try {
+        await perform();
+      } catch (error) {
+        opts.onFailure(error);
+        throw error;
+      } finally {
+        await refreshPendingTurnsProjection(opts.ref);
+      }
+    })(),
+  );
 }
 
 const NO_ENTRIES: PendingTurnEntry[] = [];


### PR DESCRIPTION
Closes kata 3p22.

`Composer.integration.test.tsx` > "a plain send exposes its durable pending entry while the network remains unsettled" failed intermittently with `expected [] to have a length of 1`. Three separate workers reported it, on three branches, and two wrong diagnoses were filed before the mechanism was found. It failed three of this session's own gate runs, including one on untouched `main`.

## Mechanism

`flushPendingTurnsProjectionForTests` returns on the first round that reports zero outstanding work. That contract is sound only if every durable path registers with `trackProjectionWork` **before it can be observed**.

Every path in `pendingTurnsStore.ts` did, except one. `submitWithPendingTracking` registered nothing until `perform()` had already resolved — only its trailing `refreshPendingTurnsProjection` was tracked:

```ts
export async function submitWithPendingTracking(opts, perform) {
  try { await perform(); }                                   // <- nothing registered
  catch (error) { opts.onFailure(error); throw error; }
  finally { await refreshPendingTurnsProjection(opts.ref); } // <- tracked, but too late
}
```

So a test that clicks send and then flushes finds an empty set on round one, declares the projection settled, and asserts against a pre-commit snapshot.

## Fix

Wrap the whole operation, so the set is non-empty from the click. That makes one zero round genuine proof instead of a narrow race, and it matches how every other durable path in the file already behaves — `mutateThenRefresh` treats mutate+refresh as one tracked operation for retry, discard, update and resend.

## Why not the alternative

The kata also floats requiring two consecutive zero rounds, and records that it worked. It hardens the *observer* against one class of latecomer. Wrapping makes the invariant the observer's contract already depends on actually true, at the source, in one function — rather than changing the helper every test uses. Right by construction beats right twice in a row.

## Evidence

The kata's acceptance is explicit: *prove the helper cannot return while work is outstanding, rather than measuring that it usually does not.* So the proof is a property test, not a rate.

`"a flush cannot settle while a submit is still in flight"` holds a submit open and asserts the flush cannot resolve. **It fails deterministically without this change.** Independently attacked from both sides in review: with the fix, raising its hop loop from 5 to 200 still passes, because `Promise.allSettled` is waiting on a promise only the test can resolve — no hop count can beat it. With the fix reverted, lowering the loop to 1 still fails. The margin is not load-bearing.

Supporting measurements, offered as consistent-in-direction and nothing more — the sample sizes are far too small to confirm a rate, and per the kata's own argument the rate is not what this rests on:

| | result |
|---|---|
| new unit test, fix reverted | fails 3/3 |
| flaky oracle, whole file, fix reverted | 1/8 failed |
| flaky oracle, whole file, with fix | 12/12 pass |
| flaky oracle, 3-way concurrent load | 0/12 failed |
| composer suite / `src/panes/session` | 474 and 2301 tests green |

`make merge-approval-gate` green (212s).

## Also here

The `flushPendingTurnsProjectionForTests` doc comment described this gap as open; it now describes the invariant and, after review caught it overclaiming, says explicitly that the claim is about this file. A global counterexample exists — `Composer.tsx`'s `queueRecoveryPersistence` registers its durable work a microtask after the call returns, the same shape, not observed failing — filed as kata `5meh` and named in the comment.

A stale comment in `Composer.test.tsx` referred to `settleRecoveryProjection`, a helper a previous commit had already hoisted away.

## Note for anyone re-verifying

The kata's third comment gives a single filtered test as the reproduction. That no longer works: with the fix reverted at current `main`, the filtered invocation passed 8/8. The flake needs the file's other tests running alongside. Recorded on the kata.
