### PR TITLE
fix(tooling): arm the scratch cleanup trap before the scratch exists

### DIFF
--- a/scripts/coverage-union.sh
+++ b/scripts/coverage-union.sh
@@ -59,19 +59,23 @@ measured_for() { awk -v m="$1" '$1==m {print $2}' "$measured_file" 2>/dev/null; 
 # argument list as a redirection to a file named "0".
 pct_of() { awk -v c="$1" -v t="$2" 'BEGIN{printf "%.1f", (t > 0 ? 100 * c / t : 0)}'; }
 
-# An explicit template, not `mktemp -t`: macOS's mktemp ignores TMPDIR for -t and
-# uses the Darwin per-user temp directory instead, which put every run's scratch
-# outside the dev-tooling wave's per-suite isolation — and so outside the leftover
-# check that is supposed to catch exactly this.
+# An explicit path under TMPDIR, not `mktemp -t`: macOS's mktemp ignores TMPDIR
+# for -t and uses the Darwin per-user temp directory instead, which put every
+# run's scratch outside the dev-tooling wave's per-suite isolation — and so
+# outside the leftover check that is supposed to catch exactly this.
 tmpbase=${TMPDIR:-/tmp}
-work_dir="$(mktemp -d "${tmpbase%/}/serf-covunion.XXXXXX")"
-measured_file="$work_dir/measured.txt"
-: >"$measured_file"
+# The name is chosen and the trap armed BEFORE the directory exists; see
+# test-coverage-floor.sh for the signal window this closes. $$ is unique among
+# live processes, so concurrent runs cannot collide.
+work_dir="${tmpbase%/}/serf-covunion.$$"
 fail=0
 # A clean run leaves nothing behind; a failed one keeps the profiles and logs,
 # because the failure line printed their path.
 cleanup_work() { [ "$fail" -eq 0 ] && rm -rf "$work_dir"; }
 trap cleanup_work EXIT
+mkdir "$work_dir" || exit 1
+measured_file="$work_dir/measured.txt"
+: >"$measured_file"
 
 printf '%-10s %10s %10s %8s %8s %8s %8s\n' "module" "covered" "total" "union%" "test%" "fuzz%" "floor"
 for m in $modules; do

--- a/scripts/test-coverage-floor.sh
+++ b/scripts/test-coverage-floor.sh
@@ -71,14 +71,19 @@ floor_for() { awk -v m="$1" '$1==m {print $2}' "$floors_file" 2>/dev/null; }
 measured_for() { awk -v m="$1" '$1==m {print $2}' "$measured_file" 2>/dev/null; }
 
 
-# An explicit template, not `mktemp -t`: macOS's mktemp ignores TMPDIR for -t and
-# uses the Darwin per-user temp directory instead, which put every run's scratch
-# outside the dev-tooling wave's per-suite isolation — and so outside the leftover
-# check that is supposed to catch exactly this.
+# An explicit path under TMPDIR, not `mktemp -t`: macOS's mktemp ignores TMPDIR
+# for -t and uses the Darwin per-user temp directory instead, which put every
+# run's scratch outside the dev-tooling wave's per-suite isolation — and so
+# outside the leftover check that is supposed to catch exactly this.
 tmpbase=${TMPDIR:-/tmp}
-profiles_dir="$(mktemp -d "${tmpbase%/}/serf-testcov.XXXXXX")"
-measured_file="$profiles_dir/measured.txt"
-: >"$measured_file"
+# The name is chosen and the trap armed BEFORE the directory exists. With
+# `mktemp -d` first and the trap a few lines later, a signal could land after
+# the directory was created but before any cleanup knew about it — mid-mktemp
+# the shell does not even hold the name yet — and the scratch was abandoned.
+# The kill selftests signal a run the instant its scratch appears, which is
+# exactly that window. $$ is unique among live processes, so concurrent runs
+# cannot collide; a stale same-pid leftover makes the mkdir fail loudly.
+profiles_dir="${tmpbase%/}/serf-testcov.$$"
 fail=0
 # A clean run leaves nothing behind; a failed one keeps the profiles and the
 # per-module go test logs, because the failure line just printed their path and
@@ -87,6 +92,9 @@ fail=0
 # suite for.
 cleanup_profiles() { [ "$fail" -eq 0 ] && rm -rf "$profiles_dir"; }
 trap cleanup_profiles EXIT
+mkdir "$profiles_dir" || exit 1
+measured_file="$profiles_dir/measured.txt"
+: >"$measured_file"
 printf '%-10s %12s %12s %8s %8s\n' "module" "covered" "total" "cov%" "floor"
 for m in $modules; do
 	[ -f "$repo_root/$m/go.mod" ] || { printf '%-10s %s\n' "$m" "(no module)"; continue; }


### PR DESCRIPTION
## Root cause

Main's `build-and-test` flaked in the dev-tooling wave:

```
FAIL: a run killed by SIGHUP leaves no scratch behind (want '', got 'serf-testcov.2Rl7kO')
```

`scripts/test-coverage-floor.sh` created its scratch with `mktemp -d` and only installed the EXIT trap that removes it several lines later. The kill selftests (`scratch-selftest-lib.sh`) deliberately signal a run the instant its scratch appears — so a signal landing between the `mkdir(2)` inside mktemp and the `trap cleanup_profiles EXIT` line kills the run with cleanup unarmed, and the directory is abandoned. Mid-mktemp the shell doesn't even hold the directory's name yet, so no trap ordering alone could cover that stretch. The window is microseconds on an idle machine, which is why it only shows on a contended CI runner; the wave runs all 27 suites in parallel on a 2-vCPU host. It is signal-agnostic — CI just happened to lose the race on HUP (the selftest rolls the dice three times: TERM, INT, HUP).

Reproduction: injecting a `sleep 0.5` between mktemp and the trap makes the selftest fail verbatim for all three signals:

```
FAIL: a run killed by SIGTERM leaves no scratch behind (want '', got 'serf-testcov.HXVqEz')
FAIL: a run killed by SIGINT leaves no scratch behind (want '', got 'serf-testcov.qEUDr5')
FAIL: a run killed by SIGHUP leaves no scratch behind (want '', got 'serf-testcov.QnDxR0')
```

## Fix

Cleanup at the source, no sweeper: choose the scratch name first (`serf-testcov.$$` — unique among live processes), arm the EXIT trap, then `mkdir`. At every instant the directory exists, the cleanup that removes it is already installed. Applied to both runners whose selftests assert the kill contract: `scripts/test-coverage-floor.sh` and `scripts/coverage-union.sh` (identical latent race).

## Verification

- Injected `sleep 0.5` after `mkdir` (the scratch's most exposed moment) with the fix in place: all kill assertions pass.
- `test-coverage-floor-selftest.sh` + `coverage-union-selftest.sh` x25 iterations under `docker --cpus=1` (linux/bash 5.2): 0 failures.
- Same suites x20 on macOS (bash 3.2): 0 failures.
- shellcheck clean on both edited scripts.

Claude-Session: https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU