### PR TITLE
fix(web): let the goal chip yield the composer row to Stop at phone widths

### DIFF
--- a/cmd/serf-hub/frontend/src/panes/session/chrome/goalcontrol.module.css
+++ b/cmd/serf-hub/frontend/src/panes/session/chrome/goalcontrol.module.css
@@ -146,7 +146,12 @@
 /* The swap point: below 560px the full text chip can't fit the row (see this
  * file's sibling GoalControl.tsx header comment for the compression this
  * row's .body container performs), so the compact glyph trigger takes over
- * instead of the whole anchor vanishing. Never both at once. */
+ * instead of the whole anchor vanishing. Never both at once.
+ *
+ * The anchor drops its 30% share here too: that basis exists so the TEXT
+ * chip claims room to ellipsize in, but the glyph is fixed-size, and a
+ * shrinkable anchor narrower than its own trigger paints the glyph outside
+ * the box (a horizontal escape the transcript pane then scrolls for). */
 @container (max-width: 559px) {
   .chipButton {
     display: none;
@@ -154,5 +159,22 @@
 
   .compactTrigger {
     display: inline-flex;
+  }
+
+  .anchor {
+    flex: none;
+  }
+}
+
+/* The floor of the ladder: with the composer's Stop button on the row, a
+ * 390px phone leaves .body around 153px, and the goal glyph's non-negotiable
+ * 28px would come straight out of the model label - StatusRow's required
+ * facts (model, effort, context, queue) are the higher priority (statusrow.
+ * module.css's own reserve comment), so below this width the goal yields
+ * the line entirely. The popover stays reachable the moment the row widens
+ * again - typically when the turn ends and Stop leaves. */
+@container (max-width: 199px) {
+  .anchor {
+    display: none;
   }
 }


### PR DESCRIPTION
## Root cause

Main's `web` CI job fails in web-overflowguard at 390px:

```
390px ... FAIL - pressured footer model has zero visible width
390px ... FAIL - 3 horizontal scroll container(s)
```

Bisected to d57e09b54 "fix(turn-control): Stop is available whenever the session is not quiesced" (b194ac39d passes, d57e09b54 fails). Its Composer change (`Composer.tsx`: `showStop = model.status.type === "active" && model.capabilities.interrupt`) is correct wire behavior, but it puts a new ~50px Stop button on the composer control row for exactly the state the overflow harness pins (status active, interrupt capability on). The two "ui cleanup" commits are a color-token change only and are innocent.

At 390px the inline session chrome's `.body` container drops from ~203px to ~153px, below anything its compression ladder (statusrow/goalcontrol `@container` rules at 559/479/399px) anticipated. The two shrinkable flex items got crushed below their own min-content:

- the goal anchor (`goalcontrol.module.css` `.anchor`, `flex: 0 1 30%; min-width: 0`) narrowed to ~20px around its fixed 28px compact glyph trigger, which then painted outside the box - the source of the 3 reported horizontal scroll containers;
- the ModelSwitch trigger collapsed to 8px: its chevron escaped and its label (`model-switch-value`) hit zero width - the "pressured footer model has zero visible width" failure.

## Fix

Two rungs added to the existing `@container` ladder in `goalcontrol.module.css`, nothing touched in the guard:

- **≤559px** (where the glyph already replaces the text chip): `.anchor { flex: none; }` - the 30% basis exists for the chip's ellipsizing text; a shrinkable anchor narrower than its own fixed-size trigger can only paint the glyph outside itself.
- **≤199px of `.body`**: hide the goal anchor. StatusRow's required facts (model, effort, context, queue) outrank the goal chip, and at that width the glyph's 28px comes straight out of the model label. The popover returns as soon as the row widens - typically when the turn ends and Stop leaves the row.

## Verification

- `make test-web-browser`: PASS web-layoutguard, web-overflowguard, web-spawnguard (overflowguard green across the 390/700/1024/1400 sweep and the panel-collapse fixture)
- `make test-web`: PASS web-typecheck, web-test, web-lint

Claude-Session: https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU