### PR TITLE
fix(delegatestore): recover from a torn version header instead of failing every Open

### DIFF
--- a/agent/internal/delegatestore/store.go
+++ b/agent/internal/delegatestore/store.go
@@ -140,22 +140,7 @@ func (s *Store) initializeOrRecover() error {
 		return fmt.Errorf("delegatestore: stat %s: %w", s.path, err)
 	}
 	if info.Size() == 0 {
-		header, err := json.Marshal(versionRecord{Version: CurrentVersion})
-		if err != nil {
-			return fmt.Errorf("delegatestore: marshal version header: %w", err)
-		}
-		header = append(header, '\n')
-		n, err := s.ops.write(s.f, header)
-		if err == nil && n != len(header) {
-			err = io.ErrShortWrite
-		}
-		if err != nil {
-			return fmt.Errorf("delegatestore: write version header: %w", err)
-		}
-		if err := s.ops.sync(s.f); err != nil {
-			return fmt.Errorf("delegatestore: sync version header: %w", err)
-		}
-		return nil
+		return s.writeVersionHeader()
 	}
 
 	raw, err := os.ReadFile(s.path)
@@ -167,7 +152,14 @@ func (s *Store) initializeOrRecover() error {
 	if raw[len(raw)-1] != '\n' {
 		lastNewline := bytes.LastIndexByte(raw, '\n')
 		if lastNewline < 0 {
-			return errors.New("delegatestore: unterminated version header")
+			// A file with no newline at all can only be the initial version
+			// header write torn by a crash before its sync: every later append
+			// lands after a terminated header line. No committed events can
+			// exist, so truncating to zero and rewriting the header is lossless.
+			if err := s.ops.truncate(s.f, 0); err != nil {
+				return fmt.Errorf("delegatestore: truncate torn version header: %w", err)
+			}
+			return s.writeVersionHeader()
 		}
 		committed = raw[:lastNewline+1]
 		recoverOffset = int64(lastNewline + 1)
@@ -192,6 +184,27 @@ func (s *Store) initializeOrRecover() error {
 	}
 	if len(events) > 0 {
 		s.seq = events[len(events)-1].Seq
+	}
+	return nil
+}
+
+// writeVersionHeader writes and syncs a fresh version header. Callers must
+// ensure the file is empty with its offset at zero.
+func (s *Store) writeVersionHeader() error {
+	header, err := json.Marshal(versionRecord{Version: CurrentVersion})
+	if err != nil {
+		return fmt.Errorf("delegatestore: marshal version header: %w", err)
+	}
+	header = append(header, '\n')
+	n, err := s.ops.write(s.f, header)
+	if err == nil && n != len(header) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		return fmt.Errorf("delegatestore: write version header: %w", err)
+	}
+	if err := s.ops.sync(s.f); err != nil {
+		return fmt.Errorf("delegatestore: sync version header: %w", err)
 	}
 	return nil
 }

--- a/agent/internal/delegatestore/store_test.go
+++ b/agent/internal/delegatestore/store_test.go
@@ -377,6 +377,93 @@ func TestOpenRecoversOnlyUnterminatedTrailingBatch(t *testing.T) {
 	}
 }
 
+func TestOpenRecoversTornVersionHeader(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "delegates.jsonl")
+	if err := os.WriteFile(path, []byte(`{"vers`), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open with torn header: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	raw := mustReadFile(t, path)
+	if want := []byte("{\"version\":1}\n"); !bytes.Equal(raw, want) {
+		t.Fatalf("recovered bytes = %q, want fresh header %q", raw, want)
+	}
+	events, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("events = %#v, want empty store after torn-header recovery", events)
+	}
+	assigned, _, err := store.Append(make(State), createdEvent("dlg_alpha", ""))
+	if err != nil {
+		t.Fatalf("Append after recovery: %v", err)
+	}
+	if assigned.Seq != 1 {
+		t.Fatalf("assigned seq = %d, want 1", assigned.Seq)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen after recovery: %v", err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	events, err = reopened.Load()
+	if err != nil {
+		t.Fatalf("Load reopened: %v", err)
+	}
+	if len(events) != 1 || events[0].Seq != 1 || events[0].DelegateID != "dlg_alpha" {
+		t.Fatalf("reopened events = %#v, want the single appended create", events)
+	}
+}
+
+func TestOpenRecoversTornFirstBatchAfterCompleteHeader(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "delegates.jsonl")
+	header := []byte("{\"version\":1}\n")
+	raw := append(append([]byte(nil), header...), `{"events":[{"kind`...)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open with torn first batch: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if got := mustReadFile(t, path); !bytes.Equal(got, header) {
+		t.Fatalf("recovered bytes = %q, want header only %q", got, header)
+	}
+	events, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("events = %#v, want torn first batch discarded", events)
+	}
+}
+
+func TestOpenRejectsTerminatedMalformedHeader(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "delegates.jsonl")
+	raw := []byte("{\"version\":}\n")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if _, err := Open(path); err == nil || !strings.Contains(err.Error(), "version header") {
+		t.Fatalf("Open error = %v, want malformed terminated header rejection", err)
+	}
+	if got := mustReadFile(t, path); !bytes.Equal(got, raw) {
+		t.Fatalf("malformed terminated header bytes changed:\n got %q\nwant %q", got, raw)
+	}
+}
+
 func TestOpenRejectsTerminatedMalformedBatch(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "delegates.jsonl")
 	raw := []byte("{\"version\":1}\n{\"events\":[}\n")


### PR DESCRIPTION
## Problem

`initializeOrRecover` (`agent/internal/delegatestore/store.go`) returned `unterminated version header` without repairing when the log file had no newline at all. That state can only be produced by the very first Open's header write being torn by crash/power-loss before its sync, but the error was permanent: every subsequent Open failed identically, and `bootstrapDelegateResources` then failed session bootstrap forever.

## Fix

A file with no newline anywhere means zero committed events exist (every append lands after a terminated header line), so truncating to zero and rewriting a fresh header is lossless. This is the same recovery policy Open already applies to a torn trailing batch.

## Tests

- `TestOpenRecoversTornVersionHeader`: partial header recovers to a working empty store; append, replay, and a second Open all work (failed before the fix with `unterminated version header`).
- `TestOpenRecoversTornFirstBatchAfterCompleteHeader`: complete header + torn first event line still takes the existing torn-tail path.
- `TestOpenRejectsTerminatedMalformedHeader`: a terminated-but-malformed header still fails loudly, bytes untouched (unsupported version already pinned by `TestOpenRejectsUnknownVersion`).

Verified: `go test ./agent/internal/delegatestore/ -race -count=2`, `go test ./agent/ -race -short -run 'Delegate'`, `golangci-lint run ./...` in the agent module — all clean.

Claude-Session: https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU