### PR TITLE
fix(web): terminal protocol reason on initial connect + ticking delegate quiet age

### DIFF
--- a/cmd/serf-hub/frontend/src/panes/session/chrome/ActivityRowDetail.test.tsx
+++ b/cmd/serf-hub/frontend/src/panes/session/chrome/ActivityRowDetail.test.tsx
@@ -213,6 +213,24 @@ describe("ActivityRowDetail", () => {
     expect(screen.getByText(`running 12s · 0b · started ${localHHMM("2026-08-05T14:59:00Z")}`)).toBeTruthy();
   });
 
+  // quietForMs is frozen at snapshot time, and a quiet delegate emits no
+  // frames to refresh the snapshot: the displayed age must be re-derived
+  // from the quiet anchor and the ticking `now`, never the frozen number.
+  test("live delegate quiet age tracks the ticking clock, not the snapshot's quietForMs", () => {
+    render(
+      <ActivityRowDetail
+        row={delegateRow({
+          mandate: "Inspect the repo",
+          runStartedAt: "2026-08-05T14:59:00Z",
+          latestActivityAt: "2026-08-05T15:00:00Z",
+          quietForMs: 12_000,
+        })}
+        now={NOW + 30_000}
+      />,
+    );
+    expect(screen.getByText(`running 42s · 0b · started ${localHHMM("2026-08-05T14:59:00Z")}`)).toBeTruthy();
+  });
+
   test("terminal row meta drops the duplicated runtime and a successful exit code", () => {
     render(
       <ActivityRowDetail

--- a/cmd/serf-hub/frontend/src/panes/session/chrome/ActivityRowDetail.tsx
+++ b/cmd/serf-hub/frontend/src/panes/session/chrome/ActivityRowDetail.tsx
@@ -84,11 +84,15 @@ function metaText(row: ActivityJobRow | ActivityDelegateRow, now: number): strin
   const subject = subjectOf(row);
   const bytes = `${subject.outputBytes}b`;
   if (row.live) {
+    // The anchor wins over quietForMs: quietForMs is frozen at snapshot time
+    // and a quiet subject emits no frames to refresh it, while the anchor plus
+    // the ticking `now` keeps counting real silence. The frozen value is only
+    // a last resort for a snapshot with no anchor at all.
     const segments: string[] = [
-      subject.quietForMs !== undefined && subject.quietForMs !== null
-        ? `${subject.status} ${formatQuietAge(subject.quietForMs)}`
-        : subject.quietAnchor
-          ? `${subject.status} ${formatQuietAge(now - quietAnchorMillis(subject.quietAnchor))}`
+      subject.quietAnchor
+        ? `${subject.status} ${formatQuietAge(now - quietAnchorMillis(subject.quietAnchor))}`
+        : subject.quietForMs !== undefined && subject.quietForMs !== null
+          ? `${subject.status} ${formatQuietAge(subject.quietForMs)}`
           : subject.status,
       bytes,
     ];

--- a/cmd/serf-hub/frontend/src/panes/session/chrome/ActivityTree.test.tsx
+++ b/cmd/serf-hub/frontend/src/panes/session/chrome/ActivityTree.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { act, cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createElement, useState } from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -643,6 +643,25 @@ describe("ActivityTree", () => {
     expect(row.textContent).not.toContain("12s");
     expect(row.textContent).not.toContain("↑");
     expect(row.textContent).not.toContain("↓");
+  });
+
+  // quietForMs is frozen at snapshot time, and a quiet delegate emits no
+  // frames to refetch the snapshot: the dense row must re-derive the age from
+  // the quiet anchor and its own ticking clock, or "quiet 12s" sticks forever
+  // while the real silence grows.
+  test("a quiet delegate's age keeps ticking between snapshots", () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(NOW);
+    render(<ActivityTree tree={TREE} expandedFoldIDs={[]} onToggleFold={vi.fn()} />);
+
+    const row = screen.getByRole("treeitem", { name: "Inspect the repo" });
+    expect(row.textContent).toContain("12s");
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(row.textContent).toContain("42s");
+    expect(row.textContent).not.toContain("12s");
   });
 
   test("continuation strip renders after the session's rows and calls onContinue", async () => {

--- a/cmd/serf-hub/frontend/src/panes/session/chrome/ActivityTree.tsx
+++ b/cmd/serf-hub/frontend/src/panes/session/chrome/ActivityTree.tsx
@@ -157,9 +157,16 @@ function delegateMetaSegments(row: ActivityDelegateRow, now: number): MetaSegmen
   if (row.live) {
     const segments: MetaSegment[] = [{ key: "tokens", text: tokens ?? "—" }];
     if (!tokens) segments.push({ key: "status", text: delegateStatusText(delegate) });
-    const quiet =
-      delegate.quietForMs ??
-      (delegate.latestActivityAt ? Math.max(0, now - (parseMillis(delegate.latestActivityAt) ?? now)) : undefined);
+    // quietForMs arrives frozen at snapshot time, and a quiet delegate emits
+    // no frames to refresh the snapshot: derive the displayed age from the
+    // server's own quiet anchor (latestActivityAt, else runStartedAt — the
+    // same fallback the server computes quietForMs from) and the ticking
+    // `now`. The frozen value itself is only a last resort for a snapshot
+    // with no parseable anchor.
+    const quietAnchorAt = parseMillis(
+      delegate.latestActivityAt ?? (delegate.quietForMs != null ? delegate.runStartedAt : undefined),
+    );
+    const quiet = quietAnchorAt !== undefined ? Math.max(0, now - quietAnchorAt) : (delegate.quietForMs ?? undefined);
     if (quiet !== undefined) segments.push({ key: "quiet", text: formatQuietAge(quiet), tone: "quiet" });
     return segments;
   }

--- a/cmd/serf-hub/frontend/src/protocol/client.test.ts
+++ b/cmd/serf-hub/frontend/src/protocol/client.test.ts
@@ -110,6 +110,10 @@ describe("AppwireClient", () => {
       `AppwireClient: expected protocol ${APPWIRE_PROTOCOL_VERSION}, received serf-appwire-v1`,
     );
     expect(client.state).toBe("closed");
+    // ConnectionBanner keys its "reload this page" copy off terminalReason;
+    // a protocol close that fails to set it would show a Retry that can
+    // never succeed instead.
+    expect(client.terminalReason).toBe("protocol");
   });
 
   // The shape above is the one a server never sends: a daemon that disagrees
@@ -136,6 +140,9 @@ describe("AppwireClient", () => {
 
     await expect(connecting).rejects.toThrow(/incompatible/);
     expect(client.state).toBe("closed");
+    // Same contract as the mismatched-version test above: the initial
+    // connect must classify the close, not just the reconnect path.
+    expect(client.terminalReason).toBe("protocol");
   });
 
   test("connect is idempotent across concurrent callers", async () => {

--- a/cmd/serf-hub/frontend/src/protocol/client.ts
+++ b/cmd/serf-hub/frontend/src/protocol/client.ts
@@ -288,10 +288,23 @@ export class AppwireClient {
       // terminal failure — there is no prior "ready" to reconnect back to,
       // and connect() must reject rather than retry silently.
       this.teardownFailedSocket();
+      this.noteProtocolFailure(err);
       this.failAllPending(err instanceof Error ? err : new Error(String(err)));
       this.setState("closed");
       throw err;
     }
+  }
+
+  // noteProtocolFailure records the terminal reason when a handshake failure
+  // is one no retry can fix (see terminalReasonValue). Shared by the initial
+  // connect (performHandshake) and every reconnect attempt, so both paths
+  // leave the same evidence for ConnectionBanner's "reload this page" copy.
+  private noteProtocolFailure(error: unknown): boolean {
+    if (error instanceof ProtocolVersionMismatchError || error instanceof HandshakeRejectedError) {
+      this.terminalReasonValue = "protocol";
+      return true;
+    }
+    return false;
   }
 
   // dialAndHandshake dials a fresh socket and runs it through
@@ -401,8 +414,7 @@ export class AppwireClient {
       // that instead of scheduling another attempt on a closed client.
       if (this.isClosed()) return;
       this.teardownFailedSocket();
-      if (error instanceof ProtocolVersionMismatchError || error instanceof HandshakeRejectedError) {
-        this.terminalReasonValue = "protocol";
+      if (this.noteProtocolFailure(error)) {
         this.setState("closed");
         return;
       }


### PR DESCRIPTION
Two confirmed bugs from adversarial review of the web frontend.

## Bug 1: initial-connect handshake rejection never set `terminalReason`

`AppwireClient` only set `terminalReasonValue = "protocol"` in `attemptReconnect`'s catch. The initial-connect path (`performHandshake`) hits the same `ProtocolVersionMismatchError`/`HandshakeRejectedError`, tears down, and reaches "closed" with `terminalReason === null` - so ConnectionBanner showed the generic "Connection closed." with a Retry button that can never succeed, instead of "This page is out of date with the server. Reload to continue."

Fix: classify the failure in one shared helper (`noteProtocolFailure`) called from both `performHandshake`'s catch and `attemptReconnect`. Both initial-connect handshake-failure tests now pin `terminalReason` - the missing assertion is how this slipped through. (The banner-level test already pins the reload copy path-agnostically via a fake client's `terminalReason`.)

## Bug 2: delegate "quiet Xs" froze at its snapshot value

The activity panel refetches only on push frames, and a quiet delegate emits none - so the server-computed `quietForMs` frozen into the snapshot rendered "quiet 2s" forever while real silence grew. The old fallback path (`latestActivityAt` + the ticking clock) counted correctly but was only used when `quietForMs` was absent.

Fix: in both the dense row (`ActivityTree.delegateMetaSegments`) and the detail strip (`ActivityRowDetail.metaText`), derive the displayed age from the server's own quiet anchor (`latestActivityAt`, else `runStartedAt` - the same fallback the server computes `quietForMs` from, see `agent/session_tools_jobs.go`) and the ticking `now`. The frozen `quietForMs` remains only as a last resort for a snapshot with no parseable anchor.

## Testing

TDD: each new/strengthened test was confirmed failing before its fix. `make test-web` (web-typecheck, web-test, web-lint) passes.

Claude-Session: https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU