### PR TITLE
fix(fakellm): keep a cancelled round's goroutine off the session's state

### DIFF
--- a/test/e2e/fakellm/cmd/main.go
+++ b/test/e2e/fakellm/cmd/main.go
@@ -175,7 +175,11 @@ func newSessions() *sessions { return &sessions{byID: map[string]*sessionState{}
 const keysKept = 3
 
 // begin returns the state of the session making this request, advanced to
-// this round, and files it under the id this round's answer will carry.
+// this round, and files it under the id this round's answer will carry. The
+// round number and job flag are returned as values read under the lock:
+// answer runs on its own goroutine and a Stop puts two of a session's rounds
+// in flight at once, so reading state fields after the lock is released would
+// race with the next round's begin.
 //
 // Two boundaries are read out of the request rather than assumed:
 //
@@ -191,12 +195,12 @@ const keysKept = 3
 //     round that was recorded. The turn it belonged to is over, so this
 //     request opens a new one. (Measured against a live hub: a turn stopped
 //     during round 2 comes back replaying round 1's id.)
-func (s *sessions) begin(call *fakellm.Call) *sessionState {
+func (s *sessions) begin(call *fakellm.Call) (state *sessionState, round int, launchedJob bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	previous := call.PreviousToolCallID()
-	state := s.byID[previous] // a session's first round has no previous id
+	state = s.byID[previous] // a session's first round has no previous id
 	switch {
 	case state == nil:
 		state = &sessionState{}
@@ -212,25 +216,50 @@ func (s *sessions) begin(call *fakellm.Call) *sessionState {
 		delete(s.byID, state.keys[0])
 		state.keys = state.keys[1:]
 	}
-	return state
+	return state, state.turnRound, state.launchedJob
 }
 
-// endedTurn records that the answer just sent ends the session's turn, so its
+// endedTurn records that the answer to `call` ends the session's turn, so its
 // next round is round 1 of a new turn.
-func (s *sessions) endedTurn(state *sessionState) {
+//
+// It applies nothing unless `call` is still the round the session will replay.
+// A cancelled round's goroutine can reach here after the session's next turn
+// has already begun (its answer was discarded, so the session did not wait for
+// it); zeroing the count then would hand that turn extra rounds. By the time
+// that happens the new turn's begin has moved lastAnswered on, which is how
+// the stale write is recognised.
+func (s *sessions) endedTurn(state *sessionState, call *fakellm.Call) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if state.lastAnswered != call.ToolCallID() {
+		return
+	}
 	state.turnRound = 0
 }
 
-// answer holds one round for --hold and then replies to it.
+// launchedJob records that the answer to `call` carries the session's one
+// background job. Guarded like endedTurn: a round the session has already
+// abandoned must not mark a job it will never see as launched.
+func (s *sessions) launchedJob(state *sessionState, call *fakellm.Call) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if state.lastAnswered != call.ToolCallID() {
+		return
+	}
+	state.launchedJob = true
+}
+
+// answer holds one round for --hold and then replies to it. A round whose
+// request is cancelled while it is held — what a Stop does — is dropped
+// without touching the session's state: the session never records it, so the
+// turn that follows must find its count exactly where the last RECORDED round
+// left it.
 func answer(ctx context.Context, live *sessions, call *fakellm.Call, hold time.Duration, rounds int, jobRelease, notesDir string) {
-	state := live.begin(call)
-	round := state.turnRound
+	state, round, launchedJob := live.begin(call)
 	log.Printf("--- round %d: holding %s ---\n%s", round, hold, strings.Join(call.Texts(), "\n"))
 
 	endTurn := func(message string) {
-		live.endedTurn(state)
+		live.endedTurn(state, call)
 		call.RespondToolCall("communicate", map[string]any{
 			"message":  message,
 			"end_turn": true,
@@ -248,22 +277,24 @@ func answer(ctx context.Context, live *sessions, call *fakellm.Call, hold time.D
 	// session again, forever.
 	if jobRelease != "" {
 		switch {
-		case !state.launchedJob && round == 1:
+		case !launchedJob && round == 1:
 			log.Printf("round 1: launching a background job that waits for %s", jobRelease)
-			state.launchedJob = true
+			live.launchedJob(state, call)
 			call.RespondToolCall("shell", map[string]any{
 				"command": "while [ ! -f " + jobRelease + " ]; do sleep 0.5; done",
 				"mode":    "background",
 			})
 			return
-		case state.launchedJob && round == 2:
+		case launchedJob && round == 2:
 			log.Printf("round 2: ending the turn so the session goes idle holding the job")
 			endTurn("background job launched; idle until it finishes")
 			return
-		case state.launchedJob && round == 1:
+		case launchedJob && round == 1:
 			select {
 			case <-time.After(hold):
 			case <-ctx.Done():
+				return
+			case <-call.Cancelled():
 				return
 			}
 			log.Printf("round 1 of a later turn: ending it so the session goes back to idle")
@@ -275,6 +306,8 @@ func answer(ctx context.Context, live *sessions, call *fakellm.Call, hold time.D
 	select {
 	case <-time.After(hold):
 	case <-ctx.Done():
+		return
+	case <-call.Cancelled():
 		return
 	}
 
@@ -291,7 +324,7 @@ func answer(ctx context.Context, live *sessions, call *fakellm.Call, hold time.D
 		// Answering with text ends this session's turn. Leaving the round
 		// unanswered would hang it instead, with the reason only in this log.
 		log.Printf("round %d: stage note: %v", round, err)
-		live.endedTurn(state)
+		live.endedTurn(state, call)
 		call.RespondText(fmt.Sprintf("fake provider could not stage a note for round %d: %v", round, err))
 		return
 	}

--- a/test/e2e/fakellm/cmd/main_test.go
+++ b/test/e2e/fakellm/cmd/main_test.go
@@ -166,9 +166,10 @@ func (s *session) newTurn(text string) {
 //
 // Measured against a live hub and daemon: a turn stopped during round 2 comes
 // back replaying round 1's tool-call id, and the id the fake minted for round
-// 2 is never seen again. Discarding the answer here reproduces exactly that —
-// from the driver's side an answer nobody records and an answer nobody reads
-// are the same event.
+// 2 is never seen again. Discarding the answer here reproduces the transcript
+// half of that event; the other half — the request aborted while the driver is
+// still holding the round — is exercised for real by
+// TestACancelledRoundLeavesTheNextTurnItsOwnCount.
 func (s *session) stopInFlightRound(ctx context.Context) {
 	s.t.Helper()
 	recorded := append([]map[string]any(nil), s.messages...)
@@ -282,6 +283,78 @@ func TestTurnsAreCountedFromTheirOwnStart(t *testing.T) {
 	if got := s.round(ctx).name; got != "communicate" {
 		t.Errorf("turn 2 round 3: tool %q, want communicate (--rounds 3 ends every turn on its own third round)", got)
 	}
+}
+
+// TestACancelledRoundLeavesTheNextTurnItsOwnCount: what Stop actually does to
+// the driver is cancel the model request MID-HOLD -- the daemon aborts the
+// HTTP request while the answer goroutine is still waiting out --hold. That
+// goroutine must not go on to mutate the session's shared state: by the time
+// its hold expires the session's next turn has already begun, and an endTurn
+// side effect landing then zeroes the new turn's count, handing it extra
+// rounds (measured against HEAD: --rounds 3, cancel round 3 mid-hold, next
+// turn runs 4). stopInFlightRound cannot see this -- it waits for the answer
+// and only discards the transcript -- so this test cancels for real, with a
+// real hold.
+func TestACancelledRoundLeavesTheNextTurnItsOwnCount(t *testing.T) {
+	var logged syncBuffer
+	previous := log.Writer()
+	log.SetOutput(&logged)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	const hold = 300 * time.Millisecond
+	baseURL := startDriver(t, hold, 3, "")
+
+	s := newSession(t, baseURL, "stopped")
+	for round := 1; round <= 2; round++ {
+		if got := s.round(ctx).name; got != "read_file" {
+			t.Fatalf("turn 1 round %d: tool %q, want read_file", round, got)
+		}
+	}
+
+	// Round 3 -- the round that would end the turn -- is cancelled while the
+	// driver holds it, exactly as Stop cancels an in-flight model request.
+	// Nothing of it reaches the transcript.
+	recorded := append([]map[string]any(nil), s.messages...)
+	requestCtx, cancelRequest := context.WithCancel(ctx)
+	defer cancelRequest()
+	requestDone := make(chan struct{})
+	go func() {
+		defer close(requestDone)
+		_, _ = s.try(requestCtx)
+	}()
+	waitForLog(t, &logged, "--- round 3: holding")
+	cancelRequest()
+	<-requestDone
+	s.messages = recorded
+
+	// The operator sends something else. The turn that follows must get its
+	// full --rounds of its own, even while the cancelled round's hold is
+	// still running out.
+	s.newTurn("stop that and do this instead")
+	for round := 1; round <= 2; round++ {
+		if got := s.round(ctx).name; got != "read_file" {
+			t.Errorf("turn 2 round %d: tool %q, want read_file", round, got)
+		}
+	}
+	if got := s.round(ctx).name; got != "communicate" {
+		t.Errorf("turn 2 round 3: tool %q, want communicate (the cancelled round must not touch the new turn's count)", got)
+	}
+}
+
+// waitForLog blocks until the driver has logged substr, so a test can cancel
+// a round only once the driver is genuinely holding it.
+func waitForLog(t *testing.T, logged *syncBuffer, substr string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(logged.String(), substr) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("driver never logged %q", substr)
 }
 
 // TestARoundCountSurvivesCompaction: an operator compacting the very browser

--- a/test/e2e/fakellm/fakellm.go
+++ b/test/e2e/fakellm/fakellm.go
@@ -56,9 +56,16 @@ type Call struct {
 	Body map[string]any
 
 	toolCallID string
+	cancelled  <-chan struct{}
 	once       sync.Once
 	reply      chan reply
 }
+
+// Cancelled is closed when the requester has given up on this round -- a Stop
+// cancels the in-flight model request. An answer sent after that is
+// discarded, so a driver holding the round should stop holding, and must not
+// commit per-session side effects for a round the session will never record.
+func (c *Call) Cancelled() <-chan struct{} { return c.cancelled }
 
 type reply struct {
 	text     string
@@ -272,7 +279,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	call := &Call{Body: body, toolCallID: mintToolCallID(), reply: make(chan reply, 1)}
+	call := &Call{Body: body, toolCallID: mintToolCallID(), cancelled: r.Context().Done(), reply: make(chan reply, 1)}
 	select {
 	case s.calls <- call:
 	case <-r.Context().Done():


### PR DESCRIPTION
## Defect 1: a daemon-cancelled round still mutated shared session state

The standalone driver passed the serve loop's process-lifetime context into `answer`, so a round whose HTTP request the daemon cancelled (what Stop does) kept holding through the full `--hold` and then ran its side effects anyway. The `endTurn` branch zeroed `turnRound` on the shared `sessionState` after the session's next turn had begun, handing that turn extra rounds — empirically, `--rounds 3` with round 3 cancelled mid-hold made the next turn run 4 rounds. `launchedJob` was also read/written outside the `sessions` mutex in the same overlap window.

Fix:
- `fakellm.Call` now exposes the request's cancellation (`Cancelled()`, wired to `r.Context().Done()`), and both hold sites in `answer` wake on it and return without side effects.
- The side effects are guarded at the source: `endedTurn` and the new `launchedJob` method apply nothing unless the call is still the session's `lastAnswered` round, so a stale goroutine that loses the race at the instant its hold expires still cannot touch the turn that followed.
- `begin` returns the round number and job flag read under the lock instead of leaving `answer` to read shared fields afterwards.

## Defect 2: the Stop-simulation tests couldn't see it

`stopInFlightRound` waits for the driver's answer and only discards the transcript, and every driver test ran with `hold=0` — the overlap window was closed by construction. New `TestACancelledRoundLeavesTheNextTurnItsOwnCount` aborts the HTTP request mid-hold for real (synchronised on the driver's "holding" log line) and asserts the next turn gets exactly `--rounds` rounds. Against the previous driver it fails: turn 2 round 3 answers `read_file` instead of `communicate`. The transcript-shape tests are kept; they cover the other half of the event.

## Verification

- New test fails on the old driver, passes with the fix
- `go test ./test/e2e/fakellm/... -race -count=2` clean
- `go test ./cmd/serf-hub/...` (live-stack e2e consumers of fakellm, including the turn-control Stop tests) clean
- `golangci-lint run ./test/e2e/...` 0 issues

Claude-Session: https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU