### PR TITLE
fix(scenarios): repair six clusters of scenario-card rot against shipped behavior

### DIFF
--- a/test/scenarios/ask-subagent-invisible.md
+++ b/test/scenarios/ask-subagent-invisible.md
@@ -85,14 +85,15 @@ delegation-only tools for a coordinator.
    ships `Strict: &strictFalse`, so an unknown key is not rejected by schema validation —
    what actually fires for `max_wait_ms` is serf's own `invalid_request` check in
    `agent/session_tools.go#stableDelegateCreateTool`. There is no
-   `grant_tools` property, and `delegateTool`'s Go
-   handler (`agent/session_tools_jobs.go`) never reads one from `args`. The one live call
-   that could pass the `grantTools []string` parameter,
-   `prepareSubagentRunWithModelSelection` at `agent/job_delegate.go:362-365`, hard-codes
-   `nil` for it. The protected-grant rejection (`ask_user is root-only and cannot be granted
-   to subagents`, `agent/subagents.go:545`, off the `protectedGrantTools` gate list at
-   `:193-201`) is real and load-bearing, but today it is exercised only by
-   calling `Session.spawnAgent`/`prepareSubagentRun` (`agent/subagents.go:360,392` — neither
+   `grant_tools` property, and the delegate tool's Go handler
+   (`agent/session_tools.go#stableDelegateCreateTool`) never reads one from `args`. The one
+   live call that could pass the `grantTools []string` parameter,
+   `agent/subagents.go#Session.prepareStableDelegateRun`, hard-codes `nil` for it in its
+   `prepareSubagentRunFromSelection` call (`agent/subagents.go:548-550`). The
+   protected-grant rejection (`ask_user is root-only and cannot be granted
+   to subagents`, `agent/subagents.go:757`, off the `protectedGrantTools` gate list at
+   `:233-243`) is real and load-bearing, but today it is exercised only by
+   calling `Session.spawnAgent`/`prepareSubagentRun` (`agent/subagents.go:469,501` — neither
    has a non-test caller) directly at the Go level — which is
    exactly what `agent/subagents_test.go`'s `TestGrantToolsCannotRegrantAskUser` and
    `TestGrantToolsAskUserAliasNeverSilentlyGranted` do. Run those as the check for this part

--- a/test/scenarios/job-delegate-result-schema.md
+++ b/test/scenarios/job-delegate-result-schema.md
@@ -6,8 +6,9 @@
 reports `structured_result` with `structured_result_valid: true` — in
 the terminal notification frame the parent is woken with, and durably in
 the root's `delegates.jsonl`; (b) a deliberately schema-violating result
-is reported honestly: no structured result, and a machine-readable
-`structured_result_reason` in its place; (c) a follow-up turn in the same
+is reported honestly: the invalid payload is retained as sent, flagged
+`structured_result_valid: false` with a machine-readable
+`structured_result_reason` alongside it; (c) a follow-up turn in the same
 delegate conversation inherits the ORIGINAL `result_schema` although
 `delegate_send` has no schema argument. Delegate `status="completed"`
 never asserts task success — the structured fields are how the parent
@@ -104,12 +105,17 @@ own `transcript_ref`, the `delegate_send` result, or `delegates.jsonl`.
   packet's `"kind"` is `"reported"`, not `"terminal_error"`, and the
   delegate's outcome is `completed`
   (`agent/internal/delegatestore/record.go#PacketKind` has exactly those
-  two values) — while the structured fields report the violation: NO
-  `"structured_result"` key at all, `"structured_result_valid":false`,
-  and `"structured_result_reason":"schema_validation_failed"` in its
-  place (`agent/subagents.go#captureDelegateStructuredResult`). The prose
+  two values) — while the structured fields report the violation:
+  `"structured_result"` RETAINED with the invalid payload exactly as the
+  child sent it (`count` still the string `"banana"`),
+  `"structured_result_valid":false`, and
+  `"structured_result_reason":"schema_validation_failed"` alongside it
+  (`agent/subagents.go#captureDelegateStructuredResult` captures the
+  payload first and only then downgrades `valid` on the schema check;
+  retention of the invalid payload is pinned by
+  `agent/delegate_resource_runtime_test.go#TestDelegateResourceRuntime_InvalidStructuredResultIsBoundedAndExplained`). The prose
   report is still there as the packet's `message`. `delegates.jsonl` carries
-  the same durable valid/reason pair for DLG2 on its
+  the same retained payload and durable valid/reason pair for DLG2 on its
   `delegate_terminal_prepared` event, for the reason given under arm (a) —
   `delegate_run_finished` carries no packet on this path.
   <!-- pin: the reason vocabulary is implementation-defined
@@ -121,8 +127,12 @@ own `transcript_ref`, the `delegate_send` result, or `delegates.jsonl`.
        valid:false + populated reason is the normative assertion,
        the specific reason names the failure mode. -->
 - Falsification (silent coercion): `structured_result_valid` `true` with
-  `count` coerced to a number, or a structured result reported at all
-  despite the type violation — validation is decorative.
+  `count` coerced to a number, or `true` over the unmodified string
+  payload — validation is decorative. Also falsifying (silent drop): the
+  `structured_result` key ABSENT even though the child's invalid payload
+  reached capture — honest reporting retains the payload and marks it
+  invalid; only the missing/oversized/marshal-failure reasons
+  legitimately omit it.
 - Falsification (catastrophic honesty failure): the violating delegate's
   outcome is `failed` solely because the schema failed — schema
   validation describes the RESULT, not the lifecycle.
@@ -193,7 +203,8 @@ own `transcript_ref`, the `delegate_send` result, or `delegates.jsonl`.
   the call at all; final reason `schema_result_missing`) — record
   that as the provider-enforcement variant. The capture-time triplet
   remains normative for any payload that reaches capture invalid; that
-  path is unit-covered (`agent/job_delegate_test.go`).
+  path is unit-covered
+  (`agent/delegate_resource_runtime_test.go#TestDelegateResourceRuntime_InvalidStructuredResultIsBoundedAndExplained`).
 - Arm (c) must wait for the arm-(a) run to be terminal. Creation is
   asynchronous, so nothing about turn 1 proves it: DLG1 is terminal once
   its notification frame has rendered, which is what turn 2 establishes.

--- a/test/scenarios/job-nested-visibility.md
+++ b/test/scenarios/job-nested-visibility.md
@@ -13,7 +13,7 @@ identity and visibility"); (c) parent `job_stop` on the nested job
 routes to the live owner runtime and stops it — "Nested jobs" "Parent
 `job_stop` on a nested job routes to the owning session/runtime if
 live" specifies routing-if-live, so a live in-process owner yields a
-confirmed stop, NOT `not_controllable` (which "Job status and reason
+confirmed stop, NOT `not_controllable` (which "Status and reason
 model" reserves for a believed-live owner that cannot route/control,
 and restart loss is `stopped`/`runtime_lost`); (d) after the delegate
 is finished and the nested job is terminal, the forwarded job's
@@ -49,9 +49,9 @@ grant a `job.notification` delivery mints — is covered by
    > Do these steps in order. Report every tool result verbatim.
    > 1. Call job_list with NO include_nested and report every job_id
    >    and type.
-   > 2. Call job_list with include_nested true and report every
-   >    job_id, type, status, parent_delegate_id, parent_job_id, and
-   >    owner_session_id.
+   > 2. Call job_list with include_nested true and report EVERY row
+   >    exactly as the tool printed it, verbatim and unedited — do not
+   >    normalise, complete or reorder the fields.
    > 3. Call read_transcript with transcript_ref "job:<the NESTED
    >    shell job's job_id>" (from step 2 / the delegate's report).
    >    Report the full JSON.
@@ -70,18 +70,18 @@ grant a `job.notification` delivery mints — is covered by
   contains the DELEGATE row (a `dlg_...` id, `type` `delegate`, lifecycle
   `idle` once it has reported) and NOT the nested
   shell job. The step-2 listing adds exactly one more row: the nested
-  job with `type` `"shell"`, `status` `"running"`, `parent_delegate_id`
-  equal to the delegate's `delegate_id` and an EMPTY `parent_job_id` —
-  a delegate-owned shell is bound with `parentJobID` cleared and
-  `parentDelegateID` set to the delegate's lease
-  (`agent/jobs.go#jobManager.bindStableDelegateParent`), and
-  "`parent_job_id` never encodes delegate lineage" ("Vocabulary").
-  `parent_job_id` is shell-to-shell only. And `owner_session_id` NOT equal to
-  `$SID` (the child session owns the runtime — "Vocabulary" "For a
-  nested forwarded job, `owner_session_id` is the child/delegate
-  session that owns the runtime"). Do not ask for
-  `visible_to_session_id`: it is `json:"-"` on the row
-  (`agent/session_tools_jobs.go:1320-1322`, "kept for tooling but omitted
+  job with `type` `"shell"` and `status` `"running"` — that is ALL the
+  model-facing line carries. `job_list`'s text output is `formatJobList`
+  (`agent/session_tools_jobs.go#formatJobList`): one line per row of
+  `id  type  status`, a `depth=N` token only when non-zero, a label, and
+  a `[started · reason · exit · bytes]` tail. `parent_delegate_id`,
+  `parent_job_id` and `owner_session_id` live only on the structured
+  state (`agent/session_tools_jobs.go#jobListEntry`), which the model
+  never sees — asking the runner to report them from the listing invites
+  invented values, so the lineage/ownership assertions below are judged
+  from `jobs.jsonl` (step 4), never from the model's step-2 report. Do
+  not ask for `visible_to_session_id` either: it is `json:"-"` on the row
+  (`agent/session_tools_jobs.go:1093-1095`, "kept for tooling but omitted
   from the model wire"), so the model structurally cannot read it, and in
   a plain list it always equals the owner anyway. The visibility this arm
   is actually proving is that the row appears at all under
@@ -89,14 +89,13 @@ grant a `job.notification` delivery mints — is covered by
   the nested job leaks into the default listing, or appears with a
   different/namespaced id than the one the delegate reported — the
   parent-visible `job_id` must be the same opaque handle everywhere
-  ("Job identity and visibility" "the same opaque `job_id` in
-  notifications, `job_list`, `job_status`, `job_watch`, `job_stop`,
-  and the `job:<job_id>` transcript ref").
+  ("Job identity and visibility" "Each identity is used unchanged
+  across its typed list, status, watch, stop, notification, and
+  transcript surfaces").
 - The nested job OUTLIVES its creating delegate: the delegate is
   `completed` while the nested job still runs — background jobs are
-  not tied to the creating turn ("Summary" "durable enough to list,
-  inspect, notify about, and reconstruct after their creating turn
-  has ended").
+  owned by a session, not tied to the creating turn ("Summary" "A
+  **shell job** is asynchronous process work owned by a session").
 - Arm (b): the step-3 read returns a `# Shell Job job_...` envelope
   with `- status: running` and a fenced block containing
   `NEST_TOKEN_1` — the parent read its output through the
@@ -109,11 +108,11 @@ grant a `job.notification` delivery mints — is covered by
   runtime and confirmed ("Nested jobs" "routes to the owning
   session/runtime if live"). Falsification (the cited rule):
   a `not_controllable` error here, with the owner session live
-  in-process, is wrong — "Job status and reason model" and "Restart
+  in-process, is wrong — "Status and reason model" and "Restart
   behavior" reserve `not_controllable` for a believed-live owner that
   cannot route/control the job, and the shipped router routes any live
-  in-process owner directly (`agent/jobs_nested.go:342-356`,
-  `stopNestedOrLocal`, whose comment states exactly this — the cited
+  in-process owner directly (`agent/jobs_nested.go#stopNestedOrLocal`,
+  whose comment states exactly this — the cited
   `:76-78` is unrelated descendant-walk code).
 - Arm (d): the step-5 read — AFTER the delegate finished (long since
   terminal) and the nested job itself is now terminal — still returns
@@ -124,13 +123,20 @@ grant a `job.notification` delivery mints — is covered by
   read degrades to `not found` or an empty block once the jobs are
   terminal while retention obviously still holds (fresh session, tiny
   output).
-- Durable forwarding: the parent's `jobs.jsonl` contains forwarded
-  `job_started` and `job_finished` events for the nested job_id with
-  `parent_delegate_id` = the delegate's `delegate_id`, no
-  `parent_job_id`, and `owner_session_id` = the
-  child session — the durable substrate behind parent visibility
-  ("Nested jobs" "Shell jobs created by subagents are visible to the
-  parent through forwarded durable job events").
+- Durable forwarding — and the arm-(a) lineage/ownership evidence: the
+  parent's `jobs.jsonl` contains forwarded `job_started` and
+  `job_finished` events for the nested job_id with
+  `parent_delegate_id` = the delegate's `delegate_id`, an EMPTY
+  `parent_job_id` — a delegate-owned shell is bound with `parentJobID`
+  cleared and `parentDelegateID` set to the delegate's lease
+  (`agent/jobs.go#jobManager.bindStableDelegateParent`), and
+  "`parent_job_id` never encodes delegate lineage" ("Vocabulary");
+  `parent_job_id` is shell-to-shell only — and `owner_session_id` = the
+  child session, NOT `$SID` (the child session owns the runtime —
+  "Vocabulary" "For shell work, `owner_session_id` names the
+  process-owning session"). This journal is the durable substrate behind
+  parent visibility ("Nested jobs" "Shell jobs created by subagents are
+  visible to the parent through forwarded durable job events").
 - The nested job's own terminal (cancelled) notification is
   OWNER-SCOPED (spec §3/§10): it renders on the OWNER's (the child
   delegate's) rail, NOT on the parent's. The parent is told its

--- a/test/scenarios/job-watch-caller-notification-delivery.md
+++ b/test/scenarios/job-watch-caller-notification-delivery.md
@@ -19,7 +19,7 @@ watch two ways — implicit notify, and an explicit `send:{to:"caller"}`
 — and assert they were distinct coexisting watch keys. `send` was
 removed from the public schema by commit `9d0d777c6` (2026-06-22); it
 is now rejected with `additionalProperties 'send' not allowed`
-(`agent/session_tools_jobs_watch_test.go:240`) and there is exactly one
+(`agent/session_tools_jobs_watch_test.go:241`) and there is exactly one
 delivery model. That arm is gone. The idle-wake and coalescing arms are
 untouched by the removal and are what this card now covers.
 
@@ -132,8 +132,9 @@ Run 2:
   well past that). No notification appears mid-stream (inside a
   streaming model response) — but one MAY surface between tool rounds:
   mid-turn notifications queue for a safe turn boundary
-  ("Notifications" "If the parent is mid-turn, notifications queue for
-  a safe turn boundary"), so a between-rounds delivery during the
+  ("Notifications" "If the owner is mid-turn or awaiting an `ask_user`
+  reply, attention waits for the next safe boundary"), so a
+  between-rounds delivery during the
   paced essay is contract-true, not a leak.
 - Each rendered notification's `reason` references the LATEST tick that
   had fired by its delivery time — latest-wins per watch key; a

--- a/test/scenarios/job-watch-caller-send-no-deadlock.md
+++ b/test/scenarios/job-watch-caller-send-no-deadlock.md
@@ -115,8 +115,8 @@ executed by plan Phase 5.2 (`docs/superpowers/plans/2026-06-11-watch-mailbox.md`
 - Follow-up prompt: call `job_watch(operation="clear", watch_id=...)`
   for BOTH the step-3 self-watch and the step-4 observer watch. The
   parent can clear the observer's watch by id: a parent-source watch is
-  installed into the parent's own job manager (`parentInstallWatch`,
-  `agent/session_tools_jobs.go:218`).
+  installed into the parent's own job manager
+  (`agent/session_tools_jobs.go#Session.configureStableWatchOnSource`).
 - `job_stop` any observer follow-up still running; shut the session down
   (`POST /api/sessions/local:$SID/shutdown`); `rm -rf "$tmpdir"`.
 

--- a/test/scenarios/job-watch-output-match-catchup.md
+++ b/test/scenarios/job-watch-output-match-catchup.md
@@ -128,7 +128,7 @@ Phase 5.2.
 - There is no `send` variant to cover: `job_watch` delivers to the
   session that created the watch and rejects a `send` argument with
   `additionalProperties 'send' not allowed`
-  (`agent/session_tools_jobs_watch_test.go:240`). The detached
+  (`agent/session_tools_jobs_watch_test.go:241`). The detached
   terminal-flush config the old card pointed at is internal-only now.
 - Sequential one-shots share the watch key
   `(watcher_session_id, source identity, receiver identity, condition

--- a/test/scenarios/job-watch-passive-observer-noop-filter.md
+++ b/test/scenarios/job-watch-passive-observer-noop-filter.md
@@ -121,9 +121,18 @@ terminal `communicate(end_turn:true)` callbacks.
 - The observer's filtered-frame turn is a single terminal
   `communicate(end_turn=true)` carrying `PASSIVE_READ_OK
   delivery=<delivery_id>`, which the parent receives as an `<delegate-notification>` block. It should not emit visible assistant text in that
-  turn. `delegate_send(to="caller")` is NOT the callback path any more
-  and is a hard `invalid_request`
-  (`agent/session_tools_jobs.go:163`).
+  turn. `delegate_send(to="caller")` is NOT the callback path — it is a
+  live steering route that returns `action: "delivered"` and injects a
+  NON-terminal update into the parent without ending the observer's turn
+  (`agent/session_tools.go#stableDelegateSendTool` routes the `caller`
+  alias through
+  `agent/delegate_tree_steer.go#delegateTreeController.SteerCaller`;
+  `docs/job-control.md` "From inside a delegate, the contextual `caller`
+  target sends a non-terminal update to that delegate's controlling
+  caller"). An observer that substitutes it for the terminal
+  `communicate` never delivers the callback packet; score that as
+  prompt noncompliance, not a watch-delivery failure — and never expect
+  an `invalid_request` rejection, which is pre-`78342bbd3` rot.
 - The parent may stop after consuming the `PASSIVE_READ_OK` callback
   instead of emitting `PASSIVE_PARENT_DONE`. Do not use that final
   marker as pass/fail evidence; use the durable `jobs.jsonl` and
@@ -152,8 +161,9 @@ The parent watch report should show the broad watch ended as
 where tool_name=read_file, status=ok`, no dropped sends, and no
 self-loop verdict. Both watches are listed on the PARENT's report even
 though the observer created them — a parent-source watch is installed
-into the parent's own job manager (`parentInstallWatch`,
-`agent/session_tools_jobs.go:218`). The observer outline should show
+into the parent's own job manager
+(`agent/session_tools_jobs.go#Session.configureStableWatchOnSource`).
+The observer outline should show
 ignored broad frames as bare assistant text with no tool calls, and the
 successful filtered `read_file` frame as a single `communicate`.
 
@@ -185,9 +195,9 @@ successful filtered `read_file` frame as a single `communicate`.
   jobs before emitting the final marker. That is acceptable; the
   fluency signal to watch is whether it finds the filtered observer job
   without human steering.
-- If the filtered observer emits explanatory assistant text before the
-  `delegate_send`/`communicate` tool calls, treat that as prompt
-  noncompliance, not a watch-delivery failure.
+- If the filtered observer emits explanatory assistant text before its
+  `communicate` tool call, treat that as prompt noncompliance, not a
+  watch-delivery failure.
 
 ## Recorded Run
 

--- a/test/scenarios/recursion-coordinator-fanout.md
+++ b/test/scenarios/recursion-coordinator-fanout.md
@@ -3,9 +3,8 @@
 **What this covers**: recursive delegation behind the double opt-in
 (`docs/job-control.md` "Delegation allowance", "Nested jobs",
 "Capacity and discovery requirements") and the owner-scoped drive-down
-notification rule ("Nested jobs" "Terminal notifications for a
-parent-visible nested background job are **owner-scoped**"; recursion
-design spec §3/§9/§10). A root with a raised `MaxSubagentDepth` (=2, so
+notification rule ("Nested jobs" "Terminal attention is owner-scoped.";
+recursion design spec §3/§9/§10). A root with a raised `MaxSubagentDepth` (=2, so
 the root's own allowance is 2 — "Delegation allowance" "A root
 session's allowance equals `MaxSubagentDepth`") spawns a COORDINATOR
 delegate with `delegation_allowance=1`; the coordinator fans out 2-3
@@ -19,16 +18,16 @@ allowance" "**The grant rule.**"), a
 grant of 1 succeeds; (b) the allowance gate — the coordinator (allowance
 1 > 0) CAN delegate, a worker (allowance 0) CANNOT ("Delegation
 allowance" "**Availability matrix (allowance-gated).**"; "Nested jobs"
-"An observer sidecar started without an allowance (allowance 0, the
-default) is a leaf and cannot delegate");
+"allowance zero remains the default, so observer sidecars are leaves
+unless explicitly granted otherwise");
 (c) the COORDINATOR is driven to receive its workers' completions in
-its OWN turns (drive-down — "Notifications" "A parent **drives** a
-child for the child's own (delegate-owned) job notifications");
+its OWN turns (drive-down — "Notifications" "A parent drives an idle
+child so that child processes its own shell/watch attention");
 (d) **OWNER-SCOPED** — the
 ROOT's model is NEVER interrupted with a worker's terminal; the root is
 told ONLY when the COORDINATOR itself finishes ("Nested jobs"
-owner-scoped bullet; "Rollout (live vs. dark)" "**Live — nested-job
-terminal notifications are owner-scoped.**");
+owner-scoped bullet; "Shipped recursion and owner attention" "A session
+renders only attention for work it owns.");
 (e) visibility is preserved via `job_list(include_descendants=true)`,
 which surfaces the live tree with per-row `depth`
 ("Nested jobs" "walks the live descendant tree at read time");
@@ -39,7 +38,9 @@ resource `idle` with a last outcome of `stopped`/`stopped_by_parent`
 orphaned.
 
 This is the live-interface counterpart to the unit-level depth-N trees
-in `agent/job_delegate_test.go` / the §9 testing list. Recursion is
+in `agent/delegate_tree_stop_test.go` (e.g.
+`agent/delegate_tree_stop_test.go#TestDelegateControllerStopCancellationPlanIsLeafFirst`
+seeds a parent → child → grandchild tree) / the §9 testing list. Recursion is
 DARK by default ("Delegation allowance" "**Double opt-in (dark by
 default).**"); this card only runs with the raised config below.
 
@@ -56,7 +57,7 @@ default).**"); this card only runs with the raised config below.
   Raise `MaxSubagentDepth` to 2 on the spawn so the root's
   own allowance is 2 ("A root session's allowance equals
   `MaxSubagentDepth`"): pass it in `launch_overrides`. The
-  wire key is `maxSubagentDepth` (camelCase, `appwire/types.go:1708`):
+  wire key is `maxSubagentDepth` (camelCase, `appwire/types.go:2046`):
 
   ```json
   {"prompt":"...","model":"openai/gpt-5.5","working_dir":"$tmpdir",
@@ -175,7 +176,7 @@ default).**"); this card only runs with the raised config below.
   is REJECTED with the verbatim error
   `invalid_request: delegation_allowance must be less than your own allowance (2); valid grants: 0..1`
   ("Delegation allowance" "**The grant rule.**";
-  `agent/job_delegate.go:318`) — the `; valid grants: <range>`
+  `agent/delegate_runtime.go:836`) — the `; valid grants: <range>`
   suffix is part of the message, not an addition. The `(2)` proves the root's
   own allowance is 2 — i.e. `MaxSubagentDepth=2` took. Falsification:
   the call SUCCEEDS (the ceiling didn't apply — config not raised, or
@@ -204,8 +205,9 @@ default).**"); this card only runs with the raised config below.
   descendant tree at read time instead of one hop") — the root's OWN
   coordinator delegate carrying NO depth token (depth 0 is not printed),
   and the three worker delegates each carrying `depth=1`, each appearing
-  EXACTLY ONCE ("Nested jobs" "Dedupe rule: the owner session's durable
-  record is authoritative for a forwarded job"). Falsification: a worker
+  EXACTLY ONCE ("Nested jobs" "a forwarded copy of a `job_id` whose owner
+  is reached live during the walk is suppressed in favor of that owner's
+  record"). Falsification: a worker
   missing entirely (the live walk did not recurse into the live child), a
   worker line with no depth token (the walk mis-attributed the hop and
   scored it as the root's own), or a worker listed twice (a forwarded copy
@@ -232,8 +234,9 @@ default).**"); this card only runs with the raised config below.
   OWN turns (coordinator transcript).** After the coordinator ended its
   turn, the workers finish while it is idle; the coordinator's
   transcript shows a POST-IDLE notification turn (an `EntryNotification`
-  the parent drove — "Notifications" "is **driven** by its parent at
-  the parent's own loop boundaries", design §3) carrying the workers'
+  the parent drove — "Why drive-down, not a flat session scheduler"
+  "each parent starts one child's `EntryNotification` turn at a safe
+  loop boundary", design §3) carrying the workers'
   terminal completions. The coordinator's model — not the root's — is
   the one woken for them. Falsification: the coordinator's transcript
   has NO post-idle notification turn for the workers (the worker
@@ -248,8 +251,8 @@ default).**"); this card only runs with the raised config below.
   or `job_type="delegate"`."). The set of
   `<delegate-notification>` frames rendered on the ROOT's rail contains
   the COORDINATOR's terminal (COORD finishing — that is the root's OWN
-  direct delegate ending: "Nested jobs" "The parent is told only about
-  its OWN jobs, including its direct delegates' terminals").
+  direct delegate ending: "Notifications" "the parent renders only
+  its own shells and direct delegates").
 
   **The assertion is on the frame SUBJECT, and only the subject.** For
   every worker delegate_id the coordinator reported in
@@ -258,9 +261,8 @@ default).**"); this card only runs with the raised config below.
   card exists to catch): a worker's delegate_id IS the `delegate_id=` of
   a `<delegate-notification>` frame on the root's rail — the root was
   interrupted about a delegate a DESCENDANT created, which the
-  owner-scoped rule ("Nested jobs" owner-scoped bullet; "Rollout (live vs.
-  dark)" quotes Jesse's ruling, "an agent is never interrupted about a
-  *subagent's* children") forbids.
+  owner-scoped rule ("Nested jobs" "an ancestor is not interrupted
+  about a descendant's children") forbids.
 
   Do NOT run this as a substring search for a worker id across the root's
   rail, and do not fail the run on worker text appearing INSIDE a
@@ -410,16 +412,15 @@ default).**"); this card only runs with the raised config below.
   a short worker sleep (8s) keeps the window tight without racing the
   drive.
 - **Tree-wide cap is 50 ("Capacity and discovery requirements"
-  "**Tree-wide running-delegate cap.**"; "Rollout (live vs. dark)"
-  "**Live — the tree-wide running-delegate cap binds existing
-  fan-out.**"; `--max-concurrent-delegates`,
-  `defaultMaxConcurrentDelegateTurns`, `agent/tree_counter.go#defaultMaxConcurrentDelegateTurns`).** It was
+  "**Tree-wide running-delegate cap.**"; `--max-concurrent-delegates`,
+  `agent/tree_counter.go#defaultMaxConcurrentDelegateTurns`).** It was
   raised from the original hardcoded 16, and drive turns now budget
-  separately (`defaultMaxConcurrentDriveTurns` = 8, `:17`). This card's
+  separately (`agent/tree_counter.go#defaultMaxConcurrentDriveTurns` = 8).
+  This card's
   fan-out (1 coordinator + 3 workers = 4 running, then COORD2 + 2 = 3)
   stays well under the cap; a spawn/resume at the cap fails
   `tree_at_capacity: 50 delegate turn slots in use across this session tree (J delegate jobs, D drive turns). Wait for completions to free slots, job_stop work you no longer need, or narrow your fan-out and retry.`
-  (`agent/tree_counter.go:41-42`) — note "turn slots", not "jobs running",
+  (`agent/tree_counter.go:79-80`) — note "turn slots", not "jobs running",
   and the trailing jobs/drives split. Do not fan out wider here or the cap,
   not the owner-scoping, becomes the thing under test (the cap is
   exercised separately).

--- a/test/scenarios/recursion-deaf-coordinator-drivedown.md
+++ b/test/scenarios/recursion-deaf-coordinator-drivedown.md
@@ -45,7 +45,7 @@ IS the test, asserted on the coordinator's own transcript.
   per-spawn grant.** Raise `MaxSubagentDepth` to 2 via
   `launch_overrides` so the root's own allowance is 2 and a grant of 1
   is legal. The wire key is `maxSubagentDepth` (camelCase,
-  `appwire/types.go:1708`):
+  `appwire/types.go:2046`):
 
   ```json
   {"prompt":"...","model":"openai/gpt-5.5","working_dir":"$tmpdir",
@@ -119,9 +119,8 @@ IS the test, asserted on the coordinator's own transcript.
   worker job_id appears as the SUBJECT of a `<job-notification>` frame on
   the ROOT's rail, or a worker's completion text appears INSIDE one —
   the root was interrupted about a job its DESCENDANT created, which the
-  owner-scoped rule forbids ("Rollout (live vs. dark)" quotes Jesse's
-  ruling, "an agent is never interrupted about a *subagent's*
-  children"). Match on the frame
+  owner-scoped rule forbids ("Nested jobs" "an ancestor is not
+  interrupted about a descendant's children"). Match on the frame
   SUBJECT, not a bare substring: the worker ids and their
   `W1_DONE`/`W2_DONE` payloads legitimately appear in the COORDINATOR's
   transcript and in the root's forwarded durable records — that

--- a/test/scenarios/sidecar-approval-broker-communicate.md
+++ b/test/scenarios/sidecar-approval-broker-communicate.md
@@ -78,15 +78,25 @@ hand it back as an observer callback. Driving mechanism:
 - The parent does not use `job_list` or `job_status` as a waiting
   mechanism before the callback.
 - The watch has no dropped deliveries or self-loop verdict.
-- Falsification (dead surface): if the task asks the observer for
-  `delegate_send(to="caller")`, the call fails
-  `invalid_request: delegate_send sends to child delegate_id only;
-  observer callbacks use communicate(end_turn=true)`
-  (`agent/session_tools_jobs.go:163`). If the parent tries to install
+- Wrong-mechanism check: `delegate_send(to="caller")` is a LIVE route,
+  not an error — from inside a delegate it returns `action: "delivered"`
+  and injects a NON-terminal steering update into the parent
+  (`agent/session_tools.go#stableDelegateSendTool` routes the `caller`
+  alias through
+  `agent/delegate_tree_steer.go#delegateTreeController.SteerCaller`;
+  `docs/job-control.md` "From inside a delegate, the contextual `caller`
+  target sends a non-terminal update to that delegate's controlling
+  caller"). It does not end the observer's turn and it is NOT the
+  callback: an observer that "replies" that way never delivers the
+  terminal packet, so the parent gets a steering message instead of a
+  `<delegate-notification>` block. Score that as observer noncompliance
+  with the callback contract — never as a tool error; expecting an
+  `invalid_request` rejection here is pre-`78342bbd3` rot. If the parent
+  tries to install
   the watch itself with `target`/`send`, the schema rejects it with
   `additionalProperties 'target' not allowed` /
   `additionalProperties 'send' not allowed`
-  (`agent/session_tools_jobs_watch_test.go:239-240`). Either error means
+  (`agent/session_tools_jobs_watch_test.go:240-241`). That error means
   the run is following a pre-`9d0d777c6` recipe.
 
 ## Doctor audit

--- a/test/scenarios/sidecar-drift-detector-communicate.md
+++ b/test/scenarios/sidecar-drift-detector-communicate.md
@@ -54,7 +54,7 @@ reference card `job-watch-observer-snide-thread.md`.
 - The parent clears the watch before finishing. The parent can clear it
   by id even though the observer created it: a parent-source watch is
   installed into the parent's own job manager
-  (`parentInstallWatch`, `agent/session_tools_jobs.go:218`).
+  (`agent/session_tools_jobs.go#Session.configureStableWatchOnSource`).
 
 ## Doctor audit
 

--- a/test/scenarios/sidecar-handoff-packager-job-notification.md
+++ b/test/scenarios/sidecar-handoff-packager-job-notification.md
@@ -150,4 +150,4 @@ go run ./cmd/serf-doctor transcript "$OBSERVER_REF" --count job_status
   reading a job id out of the frame's prose does not conjure access.
 - The parent can clear a watch the observer created: a parent-source
   watch is installed into the parent's own job manager
-  (`parentInstallWatch`, `agent/session_tools_jobs.go:218`).
+  (`agent/session_tools_jobs.go#Session.configureStableWatchOnSource`).

--- a/test/scenarios/sidecar-memory-reminder-read-file.md
+++ b/test/scenarios/sidecar-memory-reminder-read-file.md
@@ -62,7 +62,7 @@ reference card `job-watch-observer-snide-thread.md`.
   `status: ok`, the `arguments_json` naming `memory.md`, and the
   `output:` containing `PROJECT_RULE: no-force-push` — everything the
   observer needs without an audit tool
-  (`writeAssistantToolWatchEvent`, `agent/job_watch.go:4874`).
+  (`agent/job_watch.go#writeAssistantToolWatchEvent`).
 - The observer emits `MEMORY_REMINDER` as its terminal
   `communicate(end_turn=true)`, which reaches the parent as an
   `<delegate-notification>` block.

--- a/test/scenarios/sidecar-quality-auditor-communicate.md
+++ b/test/scenarios/sidecar-quality-auditor-communicate.md
@@ -77,7 +77,7 @@ go run ./cmd/serf-doctor transcript "$OBSERVER_REF" --count delegate_send  # exp
   the callback to the parent").
 - The draft body is capped at 1000 characters inside the frame's
   `event: message:` field (`maxMessageChars` in
-  `writeCommunicateWatchEvent`, `agent/job_watch.go:4844`), with
+  `agent/job_watch.go#writeCommunicateWatchEvent`), with
   `truncated: true` when it is cut. Keep the draft short so the TODO
   stays inside the window.
 

--- a/test/scenarios/sidecar-secrets-monitor-read-file.md
+++ b/test/scenarios/sidecar-secrets-monitor-read-file.md
@@ -52,7 +52,7 @@ reference card `job-watch-observer-snide-thread.md`.
   `tool_name: read_file`, `status: ok`, and the read's `output:`
   including the fixture line — the frame is where the observer sees the
   secret, so no read grant or audit tool is involved
-  (`writeAssistantToolWatchEvent`, `agent/job_watch.go:4874`).
+  (`agent/job_watch.go#writeAssistantToolWatchEvent`).
 - The observer reports `SECRET_FINDING ... redacted=true
   source=sample.log` as its terminal `communicate(end_turn=true)`.
 - The observer's visible output does not repeat `sk-test-12345`.

--- a/test/scenarios/sidecar-stuckness-read-file-error.md
+++ b/test/scenarios/sidecar-stuckness-read-file-error.md
@@ -50,7 +50,7 @@ reference card `job-watch-observer-snide-thread.md`.
 - The missing `read_file` event delivers one frame, and that frame's
   `event:` block carries `kind: assistant.tool`, `tool_name:
   read_file`, `status: error`, and the `error:` text
-  (`writeAssistantToolWatchEvent`, `agent/job_watch.go:4874`) — the
+  (`agent/job_watch.go#writeAssistantToolWatchEvent`) — the
   observer decides from the frame, with no audit tools.
 - The observer emits one `STUCK_ALERT` carrying that frame's
   delivery_id, as its terminal `communicate(end_turn=true)`.

--- a/test/scenarios/sidecar-test-triage-shell-frame.md
+++ b/test/scenarios/sidecar-test-triage-shell-frame.md
@@ -29,8 +29,9 @@ this rewrite exists to remove. Why it cannot:
   `sidecar-handoff-packager-job-notification.md` covers.
 - What DOES carry the failing text across the session boundary is an
   `assistant.tool` frame: it includes the tool's own `output` (or
-  `error`) up to 1000 characters (`writeAssistantToolWatchEvent`,
-  `agent/job_watch.go:4874`). So the parent runs the failing command in
+  `error`) up to 1000 characters
+  (`agent/job_watch.go#writeAssistantToolWatchEvent`). So the parent
+  runs the failing command in
   the FOREGROUND and the signature rides the frame. The trigger is
   weaker than a live mid-stream match — it lands when the command
   returns, not when the line prints — which is the tradeoff the ruling


### PR DESCRIPTION
An adversarial review of the scenario-card corpus found six clusters where cards assert retired behavior or cite dead anchors. Every claim was re-verified against current main before editing; no production code changes. All root-package scenario audit tests pass (`go test .`).

## Per-card corrections

**test/scenarios/job-delegate-result-schema.md** (cluster 1)
- Arm (b) required "NO `structured_result` key at all" on a schema violation and scored any reported structured result as falsification. Production (`captureDelegateStructuredResult`, `agent/subagents.go`) retains the invalid payload and flags it `structured_result_valid:false` + `structured_result_reason:"schema_validation_failed"`, pinned by `TestDelegateResourceRuntime_InvalidStructuredResultIsBoundedAndExplained`. The arm now asserts retention + valid:false + reason; silent DROP became the falsification. Unit-coverage citation repointed from the deleted `agent/job_delegate_test.go` to the live test.

**test/scenarios/sidecar-approval-broker-communicate.md**, **test/scenarios/job-watch-passive-observer-noop-filter.md** (cluster 2)
- Both asserted a hard `invalid_request: delegate_send sends to child delegate_id only...` rejection for `delegate_send(to="caller")`. Since 78342bbd3 that is a live route: `stableDelegateSendTool` → `SteerCaller`, returning `action:"delivered"` as a non-terminal steering update (the doc sentence `TestJobControlContractPreservesContextualCallerRoute` pins). The steps now assert the routed behavior and score a caller-steer substituted for the terminal `communicate` as observer noncompliance, never a tool error. Dead `parentInstallWatch` cite in the passive-observer card repointed to `Session.configureStableWatchOnSource`.

**test/scenarios/job-nested-visibility.md** (cluster 3, plus 4/6)
- The card asked the runner to report `parent_delegate_id`/`parent_job_id`/`owner_session_id` "from the step-2 listing", but `formatJobList` prints only id/type/status/depth/label — those fields never reach the model, so the prompt invited invented values. The prompt now asks for verbatim rows (the recursion-coordinator-fanout pattern) and the lineage/ownership assertions moved to the card's own step-4 `jobs.jsonl` read. Dead doc quotes requoted from the rewritten `docs/job-control.md` (heading now "Status and reason model", identity/ownership wording); `visible_to_session_id` cite re-derived to `:1093-1095`; stop-router cite anchored to `#stopNestedOrLocal`.

**test/scenarios/recursion-coordinator-fanout.md** (clusters 4/5/6)
- The "Rollout (live vs. dark)" section is gone and several quoted sentences were reworded; all requoted from the current doc (owner-scoped, leaf-sidecar, drive-down/EntryNotification, walk dedupe, root-rail, ancestor-interruption, tree-cap anchors). Deleted `agent/job_delegate_test.go` citation repointed at the depth-N tree coverage in `agent/delegate_tree_stop_test.go`. Drifted line cites re-derived: `appwire/types.go:2046`, grant rule now `agent/delegate_runtime.go:836`, capacity message `agent/tree_counter.go:79-80`, drive-turn budget anchored to `#defaultMaxConcurrentDriveTurns`.

**test/scenarios/recursion-deaf-coordinator-drivedown.md** (same rot found by sweep)
- Same dead "Rollout (live vs. dark)" ruling quote and `appwire/types.go:1708` drift; fixed identically. (This card has deeper pre-rewrite forwarded-delegate-JobRecord language that deserves its own pass; not expanded here.)

**test/scenarios/job-watch-caller-notification-delivery.md** (cluster 4)
- The `:135` Notifications quote now matches the updated sentence the card's own header already carries ("If the owner is mid-turn or awaiting an `ask_user` reply, attention waits for the next safe boundary"); send-rejection test cite bumped to `:241`.

**test/scenarios/sidecar-drift-detector-communicate.md**, **test/scenarios/sidecar-handoff-packager-job-notification.md**, **test/scenarios/job-watch-caller-send-no-deadlock.md** (cluster 5)
- Dead symbol `parentInstallWatch` repointed to `agent/session_tools_jobs.go#Session.configureStableWatchOnSource`, which is where a parent-source watch is installed today.

**test/scenarios/sidecar-secrets-monitor-read-file.md**, **sidecar-stuckness-read-file-error.md**, **sidecar-memory-reminder-read-file.md**, **sidecar-test-triage-shell-frame.md**, **sidecar-quality-auditor-communicate.md** (cluster 6)
- `agent/job_watch.go:4874`/`:4844` drifted (now 4772/4739); anchored to `#writeAssistantToolWatchEvent` / `#writeCommunicateWatchEvent` so they survive future drift.

**test/scenarios/ask-subagent-invisible.md** (cluster 6)
- `prepareSubagentRunWithModelSelection` moved out of `agent/job_delegate.go`; the live nil-grantTools call is `Session.prepareStableDelegateRun` (`agent/subagents.go:548-550`), the protected-grant rejection is at `:757` off `protectedGrantTools` (`:233-243`), and `spawnAgent`/`prepareSubagentRun` sit at `:469`/`:501` (still no non-test caller — re-verified).

**test/scenarios/job-watch-output-match-catchup.md**: send-rejection test cite `:240`→`:241`.

## Why
Cards asserted retired behavior (pre-78342bbd3 caller rejection, pre-retention schema handling, fields the listing formatter never prints) and cited dead anchors (removed doc section, reworded sentences, deleted test file, deleted symbol, drifted line numbers). An agent executing them would fail healthy runs or grade improvisation as evidence.

Claude-Session: https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU