### PR TITLE
fix(agent): a Stop parks the queued message instead of running it (wms7)

### DIFF
--- a/agent/session_client_mutation_queue.go
+++ b/agent/session_client_mutation_queue.go
@@ -1179,16 +1179,24 @@ func (s *Session) finalizeIncorporatedSteering(clientMutationID string) error {
 // Queue transcript incorporation retains the payload and stable turn identity;
 // only durable terminal completion may remove the runnable execution.
 func (s *Session) completeClientMutationTurn(clientMutationID string) error {
-	return s.completeClientMutationTurnWithState(clientMutationID, "terminal")
+	_, err := s.completeClientMutationTurnWithState(clientMutationID, "terminal")
+	return err
 }
 
 func (s *Session) completeClientMutationInterruptedTurn(clientMutationID string) error {
-	return s.completeClientMutationTurnWithState(clientMutationID, "interrupted")
+	_, err := s.completeClientMutationTurnWithState(clientMutationID, "interrupted")
+	return err
 }
 
-func (s *Session) completeClientMutationTurnWithState(clientMutationID, executionState string) error {
+// completeClientMutationTurnWithState settles one client-mutation turn and
+// reports whether doing so finalized an interrupt fence naming that turn --
+// i.e. whether a Stop is what ended it. The drain loop needs that fact: a turn
+// ended by a Stop must leave the queue head parked (wms7's ruling), while a
+// turn ended by a bare host cancellation may still drain it, and by the time
+// the drain loop asks, the fence this call just finalized is already gone.
+func (s *Session) completeClientMutationTurnWithState(clientMutationID, executionState string) (stopFinalized bool, err error) {
 	returned := false
-	err := s.clientMutations.mutate(func(snapshot *clientMutationSnapshot) error {
+	err = s.clientMutations.mutate(func(snapshot *clientMutationSnapshot) error {
 		pending, ok := snapshot.PendingExecutions[clientMutationID]
 		if !ok {
 			return nil
@@ -1229,12 +1237,13 @@ func (s *Session) completeClientMutationTurnWithState(clientMutationID, executio
 			snapshot.ActiveTurnID = ""
 		}
 		if snapshot.InterruptFence != nil && snapshot.InterruptFence.ExpectedTurnID == pending.TurnID {
+			stopFinalized = true
 			return finalizeClientMutationInterrupt(snapshot, s.ID())
 		}
 		return nil
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 	if returned {
 		// The durable queue grew a message back. QueueDepth, QueuePreview,
@@ -1244,7 +1253,7 @@ func (s *Session) completeClientMutationTurnWithState(clientMutationID, executio
 		s.reflectDurableInputQueue()
 		s.wakeForPendingQueuedInput()
 	}
-	return nil
+	return stopFinalized, nil
 }
 
 // returnClaimedQueuedMutation puts a claimed queue entry back the way

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -643,17 +643,24 @@ func (s *Session) processInputKindWithProvenance(ctx context.Context, input stri
 		ranKind := nextKind
 		ranClientMutation := queuedClientMutationFromContext(processCtx)
 		out, progressed, err := s.processOneInput(processCtx, next, nextImages, nextKind, nextProvenance)
+		// True when the completion below finalized an interrupt fence naming
+		// this turn: a Stop is what ended it, and the drain branch further down
+		// must leave the queue head parked (wms7's ruling) rather than run the
+		// very message the user just stopped.
+		stopSettledThisTurn := false
 		if ranClientMutation.ClientMutationID != "" {
 			terminalState := "terminal"
 			if err != nil {
 				terminalState = "failed"
 			}
-			if completeErr := s.completeClientMutationTurnWithState(
+			stopFinalized, completeErr := s.completeClientMutationTurnWithState(
 				ranClientMutation.ClientMutationID,
 				terminalState,
-			); completeErr != nil {
+			)
+			if completeErr != nil {
 				err = errors.Join(err, fmt.Errorf("complete client mutation turn: %w", completeErr))
 			}
+			stopSettledThisTurn = stopFinalized
 		}
 		processCtx = context.WithValue(processCtx, queuedClientMutationContextKey{}, queuedClientMutationIdentity{})
 		// Follow-up turns (after the first) carry no attachments and are
@@ -703,7 +710,16 @@ func (s *Session) processInputKindWithProvenance(ctx context.Context, input stri
 						Interrupted: true,
 					})
 				}
-				if !closed {
+				// A turn ended by a Stop parks the queue head instead of running
+				// it (wms7's ruling): the user stopped this session's work, so
+				// nothing auto-starts, and the message waits for one of the
+				// ordinary wake paths. interruptDrainConfig cannot make that
+				// call -- it is a pure function of this turn's context and
+				// error, and a Stop's cancellation is indistinguishable there
+				// from a bare host cancellation -- and the fence that would
+				// mark the Stop was already finalized by the completion above,
+				// which is why the completion reports it here.
+				if !closed && !stopSettledThisTurn {
 					// Decide, then claim. popQueueHead is a durable commit, and
 					// whether this interrupt may drain depends only on the turn's
 					// context and error -- never on the queue -- so there is

--- a/agent/session_stop_and_queued_work_test.go
+++ b/agent/session_stop_and_queued_work_test.go
@@ -2,10 +2,13 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"primeradiant.com/serf/appwire"
+	"primeradiant.com/serf/llm"
 )
 
 // A Stop and a message queued behind it collide in an ordinary way, and the
@@ -53,9 +56,14 @@ func TestClaimedQueuedTurnIsReturnedWhenItNeverRan(t *testing.T) {
 	}
 
 	// The turn never incorporated its input. This is the call the drain loop
-	// makes next, unconditionally, at session_lifecycle.go:653.
-	if err := sess.completeClientMutationTurnWithState("queue-behind-stop", "terminal"); err != nil {
+	// makes next, unconditionally, at session_lifecycle.go:653. Returning the
+	// claim finalizes no fence, so it must not report a Stop settling the turn.
+	stopFinalized, err := sess.completeClientMutationTurnWithState("queue-behind-stop", "terminal")
+	if err != nil {
 		t.Fatalf("completeClientMutationTurnWithState: %v", err)
+	}
+	if stopFinalized {
+		t.Fatal("returning a claimed queued turn reported a Stop-finalized fence; there was no fence to finalize")
 	}
 
 	snapshot := sess.clientMutations.snapshot()
@@ -153,6 +161,220 @@ func TestStopIsHonestAboutAQueuedMessage(t *testing.T) {
 	snapshot := sess.clientMutations.snapshot()
 	if len(snapshot.InputQueue) != 1 {
 		t.Fatalf("the stop consumed the queued message: queue=%#v", snapshot.InputQueue)
+	}
+	if snapshot.InterruptFence != nil {
+		t.Fatalf("the stop left a fence behind: %#v", snapshot.InterruptFence)
+	}
+	if snapshot.ActiveTurnID != "" {
+		t.Fatalf("ActiveTurnID after the stop = %q, want empty", snapshot.ActiveTurnID)
+	}
+}
+
+// stopHoldAdapter is the model seam for the mid-turn Stop tests. Its first
+// call blocks until its context is cancelled, which is how a turn is held
+// mid-model-round for a Stop to land on. Any later call is a follow-on turn
+// the Stop should have prevented; it parks on releaseFollowOn so the test can
+// observe the Stop RPC blocked behind it rather than racing its completion.
+type stopHoldAdapter struct {
+	mu               sync.Mutex
+	calls            int
+	firstCallRunning chan struct{}
+	releaseFollowOn  chan struct{}
+}
+
+func newStopHoldAdapter() *stopHoldAdapter {
+	return &stopHoldAdapter{
+		firstCallRunning: make(chan struct{}),
+		releaseFollowOn:  make(chan struct{}),
+	}
+}
+
+func (a *stopHoldAdapter) Name() string { return "openai" }
+
+func (a *stopHoldAdapter) Calls() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.calls
+}
+
+func (a *stopHoldAdapter) Complete(ctx context.Context, req llm.Request) (llm.Response, error) {
+	a.mu.Lock()
+	a.calls++
+	n := a.calls
+	a.mu.Unlock()
+	if n == 1 {
+		close(a.firstCallRunning)
+		<-ctx.Done()
+		return llm.Response{}, ctx.Err()
+	}
+	select {
+	case <-a.releaseFollowOn:
+	case <-ctx.Done():
+		return llm.Response{}, ctx.Err()
+	}
+	return llm.Response{Provider: "openai", Model: req.Model, Message: llm.Assistant("done")}, nil
+}
+
+func (a *stopHoldAdapter) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	_ = ctx
+	_ = req
+	return nil, llm.ErrStreamUnsupported
+}
+
+// TestStopOnMidTurnMutationParksTheQueuedMessage is the wms7 ruling for a Stop
+// that cancels a running client-mutation turn with another message queued
+// behind it: the interrupted turn settles, the queued message stays on the
+// queue, nothing auto-starts, and the Stop RPC returns as soon as the
+// interrupted turn is settled.
+//
+// The wiring mirrors cmd/serf/serve.go's processMessage: a per-turn context
+// marked WithQueuedInputDrainOnInterruptHandler, a mutation runner whose
+// cancel+done pair backs the Stop's cancelAndWait, and a nextTurnCtx factory
+// that re-arms the runner for a drained turn. Before the fix, the drain loop
+// completed the cancelled turn (finalizing the interrupt fence) and then
+// drained the queue head anyway: the queued message ran as a follow-on turn
+// under the Stop's own chain, and the Stop RPC blocked until that whole turn
+// finished.
+func TestStopOnMidTurnMutationParksTheQueuedMessage(t *testing.T) {
+	dir := t.TempDir()
+	adapter := newStopHoldAdapter()
+	sess := newSession(t,
+		withAdapter(adapter),
+		withDir(dir),
+		withConfig(SessionConfig{
+			MaxSubagentDepth: 1,
+			NoProjectPrompts: true,
+			StateDir:         dir,
+			testOnly:         testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true},
+		}),
+	)
+
+	// The daemon's queued-input wake, installed before anything is queued so the
+	// installation itself does not fire it. The accept-time wake below counts
+	// once; the Stop must not add to it ("nothing auto-starts").
+	var wakeMu sync.Mutex
+	wakes := 0
+	sess.SetPendingUserInputWakeFunc(func() {
+		wakeMu.Lock()
+		wakes++
+		wakeMu.Unlock()
+	})
+	countWakes := func() int {
+		wakeMu.Lock()
+		defer wakeMu.Unlock()
+		return wakes
+	}
+
+	// serve.go:662-673's mutation-runner wiring, verbatim in shape. The root
+	// context stands in for the daemon's serve context: alive for the whole
+	// test, which is what makes the interrupt drainable at all.
+	root := t.Context()
+	runnerDone := make(chan struct{})
+	var runnerMu sync.Mutex
+	var runnerCancel context.CancelFunc
+	setRunner := func(cancel context.CancelFunc) {
+		runnerMu.Lock()
+		runnerCancel = cancel
+		runnerMu.Unlock()
+	}
+	cancelAndWaitMutationRunner := func() {
+		runnerMu.Lock()
+		cancel := runnerCancel
+		runnerMu.Unlock()
+		if cancel != nil {
+			cancel()
+		}
+		<-runnerDone
+	}
+	var nextTurnCtx func(context.Context) (context.Context, context.CancelFunc)
+	nextTurnCtx = func(rootCtx context.Context) (context.Context, context.CancelFunc) {
+		drainCtx, cancelDrain := context.WithCancel(rootCtx)
+		drainCtx = WithQueuedInputDrainOnInterruptHandler(drainCtx, rootCtx, nextTurnCtx)
+		setRunner(cancelDrain)
+		return drainCtx, cancelDrain
+	}
+	turnCtx, cancelTurn := context.WithCancel(root)
+	defer cancelTurn()
+	turnCtx = WithQueuedInputDrainOnInterruptHandler(turnCtx, root, nextTurnCtx)
+	setRunner(cancelTurn)
+
+	started, err := sess.AcceptClientMutationStart(appwire.TurnStartParams{
+		ClientMutationID: "turn-one",
+		Input:            []appwire.InputItem{{Type: "text", Text: "first message"}},
+	})
+	if err != nil {
+		t.Fatalf("AcceptClientMutationStart: %v", err)
+	}
+	runnerErr := make(chan error, 1)
+	go func() {
+		defer close(runnerDone)
+		_, _, err := sess.ProcessClientMutationStart(turnCtx, nil)
+		runnerErr <- err
+	}()
+	<-adapter.firstCallRunning
+
+	// The collision: a second message queued while turn one is mid-model-call.
+	queueOneMutation(t, sess, "queued-behind-stop", "run me later")
+	wakesBeforeStop := countWakes()
+
+	stopDone := make(chan struct{})
+	var stopResponse appwire.TurnInterruptResponse
+	var stopErr error
+	go func() {
+		defer close(stopDone)
+		stopResponse, stopErr = sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+			ClientMutationID: "stop-mid-turn",
+		}, cancelAndWaitMutationRunner)
+	}()
+	select {
+	case <-stopDone:
+	case <-time.After(10 * time.Second):
+		// The Stop is stuck behind a follow-on turn. Unstick it so the runner
+		// and the RPC can finish; the failure is already proven.
+		close(adapter.releaseFollowOn)
+		<-stopDone
+		t.Fatal("Stop did not return once the interrupted turn settled; it waited out a follow-on turn run from the drain loop")
+	}
+	if stopErr != nil {
+		t.Fatalf("InterruptClientMutation: %v", stopErr)
+	}
+	if stopResponse.Receipt.Disposition != appwire.MutationDispositionApplied ||
+		stopResponse.Receipt.TurnID != started.Turn.ID {
+		t.Fatalf("stop receipt = %#v, want applied against turn %q", stopResponse.Receipt, started.Turn.ID)
+	}
+	<-runnerDone
+	if err := <-runnerErr; !errors.Is(err, context.Canceled) {
+		t.Fatalf("interrupted turn returned %v, want its own cancellation", err)
+	}
+
+	// No second model call: the queued message did not run under the Stop's
+	// chain, and nothing auto-started it afterwards.
+	if got := adapter.Calls(); got != 1 {
+		t.Fatalf("model calls after the stop = %d, want 1; the drain loop ran the queued message the user just stopped", got)
+	}
+	if got := countWakes(); got != wakesBeforeStop {
+		t.Fatalf("queued-input wakes across the stop went %d -> %d; the stop armed an auto-start for the parked message", wakesBeforeStop, got)
+	}
+
+	// The queued message is still on the queue, durably and process-locally,
+	// with its accepted (not settled, not claimed) state intact.
+	snapshot := sess.clientMutations.snapshot()
+	if len(snapshot.InputQueue) != 1 || snapshot.InputQueue[0].ClientMutationID != "queued-behind-stop" {
+		t.Fatalf("durable queue after the stop = %#v, want the queued message parked", snapshot.InputQueue)
+	}
+	queuedRecord := snapshot.Journal["queued-behind-stop"]
+	if queuedRecord.OperationState == clientMutationOperationTerminal || queuedRecord.ExecutionState != "accepted" {
+		t.Fatalf("queued message record after the stop = %#v, want accepted and not terminal", queuedRecord)
+	}
+	if got := sess.QueueDepth(); got != 1 {
+		t.Fatalf("QueueDepth after the stop = %d, want 1", got)
+	}
+
+	// The interrupted turn settled, and settled clean: fence finalized, no
+	// stranded turn id.
+	turnOne := snapshot.Journal["turn-one"]
+	if turnOne.OperationState != clientMutationOperationTerminal || turnOne.ExecutionState != "interrupted" {
+		t.Fatalf("interrupted turn record = %#v, want terminal interrupted", turnOne)
 	}
 	if snapshot.InterruptFence != nil {
 		t.Fatalf("the stop left a fence behind: %#v", snapshot.InterruptFence)

--- a/cmd/serf-hub/e2e_control_invariant_test.go
+++ b/cmd/serf-hub/e2e_control_invariant_test.go
@@ -676,12 +676,19 @@ func TestE2E_ControlInvariantDuringPreTurnWorkAtATurnBoundary(t *testing.T) {
 	// claimed turn is cancelled and its message goes back on the queue, so
 	// nothing is lost and nothing auto-starts.
 	//
-	// Half of that ruling is already built. A turn claimed out of the queue that
+	// Most of that ruling is now built. A turn claimed out of the queue that
 	// never incorporates its input IS returned to the queue -- see
 	// agent/session_stop_and_queued_work_test.go's
-	// TestClaimedQueuedTurnIsReturnedWhenItNeverRan. What is missing is the
-	// cancellation ever reaching this turn, and three measurements narrow where
-	// it goes wrong:
+	// TestClaimedQueuedTurnIsReturnedWhenItNeverRan. And the MID-TURN half is
+	// fixed: a Stop that cancels a turn already producing, with a message
+	// queued behind it, settles the turn and parks the message -- the drain
+	// loop skips the queue head when the turn's completion finalized the Stop's
+	// interrupt fence, instead of running the very message the user stopped
+	// under the Stop's own chain (same file's
+	// TestStopOnMidTurnMutationParksTheQueuedMessage). What is missing is the
+	// cancellation ever reaching THIS turn -- one claimed at the boundary and
+	// still in its pre-turn work -- and three measurements narrow where it goes
+	// wrong:
 	//
 	//   - the mutation runner is armed when the Stop lands (cancel and done both
 	//     non-nil), so this is NOT a Stop firing into an empty slot;


### PR DESCRIPTION
## The contract (Jesse's wms7 ruling)

When a Stop (`turn/interrupt`) cancels a client-mutation turn that has another message queued behind it:

- the interrupted turn settles (`interrupted`, terminal, fence finalized, no stranded `ActiveTurnID`),
- the queued message **stays on the queue** with its durable `accepted` state intact,
- **nothing auto-starts** -- the message waits for the ordinary wake paths (a later user queue/steer/promote action, or session restore),
- the Stop RPC returns as soon as the interrupted turn is settled.

## What happened instead

Verified by executed repro on main: the drain loop completed the cancelled turn first (`agent/session_lifecycle.go` -> `completeClientMutationTurnWithState`), which finalized the Stop's interrupt fence -- and only then classified the interrupt via `interruptDrainConfig`, a pure function of the turn's context and error that cannot tell a Stop from a bare host cancellation. So it drained: `popQueueHead`'s fence guard saw an already-cleared fence, and the queued message ran ~25ms after the Stop, inline under the Stop's own chain. The Stop RPC blocked on `runnerDone` until that whole follow-on turn finished, and the queued mutation settled `failed` instead of staying queued.

## The mechanism

`completeClientMutationTurnWithState` now reports whether it finalized an interrupt fence naming the turn it settled -- the one fact that distinguishes "a Stop ended this turn" from "the host cancelled it", and which the finalization itself destroys before the drain loop can ask. The drain loop skips the queue-head drain when it did. The message simply stays queued; no wake is armed from this path.

`InterruptClientMutation`'s post-finalize wakes were examined and deliberately left alone: in the mid-turn Stop path the runner finalizes the fence during `cancelAndWait`, so the RPC returns through the already-terminal branch and never reaches them. They fire only when the Stop itself finalizes the fence, where they are load-bearing for the no-turn-running strand case (`TestStopWakesTheSessionForWorkItLeftQueued`).

## Compatibility

- PR #74's `TestDrainableInterruptClaimsQueueHeadInOneDurableTransition` stays green: its harness has no Stop and no fence, so nothing is reported and host cancellations still drain.
- PR #74's undrainable-interrupt one-transition property is preserved: the parked path makes no durable queue commit at all.
- New pin: `TestStopOnMidTurnMutationParksTheQueuedMessage` (agent-level, mirrors `cmd/serf/serve.go`'s runner wiring: `WithQueuedInputDrainOnInterruptHandler` + `cancelAndWaitMutationRunner`). Failing before (Stop stuck behind the drained follow-on turn until a 10s watchdog), passing after: one model call, Stop returns promptly, queue depth 1 with the durable record still `accepted`, no wake armed across the Stop.

## What remains of wms7 (the boundary window)

The e2e pin `TestE2E_ControlInvariantDuringPreTurnWorkAtATurnBoundary` (`cmd/serf-hub/e2e_control_invariant_test.go`) still measures its defect and is deliberately **not** flipped: its scenario is a Stop landing after the drain tail claims the next turn but before that turn produces, and the claimed turn's **pre-turn work does not observe its cancelled context** -- the model round runs anyway, exactly as before this change. That is a second, separate hole from the mid-turn one fixed here. All of the pin's assertions still take the pinned (defect) branch; its comments now record the mid-turn half as fixed and keep the boundary half named.

## Testing

- `go test ./agent/ -race -short -count=1` -- pass (full package)
- `go test ./cmd/serf/ ./server/ -race` -- pass
- `go test ./cmd/serf-hub/ -run 'TestE2E_'` -- all 17 pass
- `golangci-lint run ./...` from `agent/` -- 0 issues

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU