### PR TITLE
serf-doctor: post-merge follow-ups for --full-text/--text-max (PR #69)

### DIFF
--- a/agent/doctor/health.go
+++ b/agent/doctor/health.go
@@ -329,6 +329,9 @@ func RenderHealth(r HealthResult) string {
 	}
 	fmt.Fprintf(&b, "longest_identical_run: tool=%s length=%d all_errors=%t\n",
 		dash(r.LongestIdenticalRun.Tool), r.LongestIdenticalRun.Length, r.LongestIdenticalRun.AllErrors)
+	if r.LongestIdenticalRun.Length == 0 {
+		b.WriteString("  (counts structural tool calls only; repetition salvaged into turn text is invisible here — see transcript --full-text)\n")
+	}
 	fmt.Fprintf(&b, "truncation_warnings: %d\n", r.TruncationWarnings)
 	fmt.Fprintf(&b, "steering: %s\n", renderCounts(r.Steering))
 	fmt.Fprintf(&b, "jobs: by_terminal_reason=%s zero_output_terminal=%d\n",

--- a/agent/doctor/health_test.go
+++ b/agent/doctor/health_test.go
@@ -338,6 +338,22 @@ func TestRenderHealth_CompactTable(t *testing.T) {
 	}
 }
 
+// A zero-length longest_identical_run is not evidence of no repetition: the
+// metric counts only structural tool calls, and a salvaged partial response
+// carries its repeated calls as turn text, invisible here. The render must say
+// so and point at transcript --full-text; a nonzero run needs no caveat.
+func TestRenderHealth_ZeroIdenticalRunCarriesBlindnessCaveat(t *testing.T) {
+	out := RenderHealth(HealthResult{SessionID: "s"})
+	if !strings.Contains(out, "transcript --full-text") {
+		t.Errorf("zero-length run must carry the structural-blindness caveat pointing at transcript --full-text:\n%s", out)
+	}
+
+	withRun := RenderHealth(HealthResult{SessionID: "s", LongestIdenticalRun: IdenticalRun{Tool: "shell", Length: 4}})
+	if strings.Contains(withRun, "transcript --full-text") {
+		t.Errorf("nonzero run must not carry the caveat:\n%s", withRun)
+	}
+}
+
 // TestTranscriptHealth_NoResultToolCall covers the healthy-empty shape: a
 // session with no result-tool call at all has no "final end_turn=true" anchor,
 // so stale_notifications/user_corrections must both read zero, not guess.

--- a/agent/doctor/transcript.go
+++ b/agent/doctor/transcript.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"strings"
+	"unicode/utf8"
 
 	"primeradiant.com/serf/agent/schema"
 	"primeradiant.com/serf/agent/transcript"
@@ -387,12 +388,19 @@ func atoi(s string) int {
 	return n
 }
 
+// truncate caps s at maxLen bytes plus an ellipsis. The cap is a byte budget,
+// but the cut backs off to the previous rune boundary so a valid input never
+// yields invalid UTF-8: the kept prefix is at most maxLen bytes, never more.
 func truncate(s string, maxLen int) string {
 	s = strings.TrimSpace(s)
 	if len(s) <= maxLen {
 		return s
 	}
-	return s[:maxLen] + "…"
+	cut := maxLen
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "…"
 }
 
 func oneLine(s string) string {

--- a/agent/doctor/transcript.go
+++ b/agent/doctor/transcript.go
@@ -227,7 +227,7 @@ func summarizeTurn(index int, e transcript.Entry, resultTool string, textMax int
 			}
 			ts.ToolCalls = append(ts.ToolCalls, ToolCallSummary{
 				Name:       part.ToolCall.Name,
-				ArgPreview: truncate(string(part.ToolCall.Arguments), argPreviewMax),
+				ArgPreview: truncate(strings.TrimSpace(string(part.ToolCall.Arguments)), argPreviewMax),
 				IsResult:   part.ToolCall.Name == resultTool,
 			})
 		case llm.ContentToolResult:
@@ -391,8 +391,9 @@ func atoi(s string) int {
 // truncate caps s at maxLen bytes plus an ellipsis. The cap is a byte budget,
 // but the cut backs off to the previous rune boundary so a valid input never
 // yields invalid UTF-8: the kept prefix is at most maxLen bytes, never more.
+// It never trims: a caller that wants tidy edges trims before calling, so the
+// full-text tool-result path can report the result's bytes exactly.
 func truncate(s string, maxLen int) string {
-	s = strings.TrimSpace(s)
 	if len(s) <= maxLen {
 		return s
 	}

--- a/agent/doctor/transcript_test.go
+++ b/agent/doctor/transcript_test.go
@@ -283,6 +283,50 @@ func TestTranscript_TextMaxHonoursAnExplicitCap(t *testing.T) {
 	}
 }
 
+// A tool result's ContentPreview reports the result's bytes, not a tidied
+// version of them: trimming edge whitespace made --full-text (which promises
+// the result whole) lie about leading/trailing newlines, and made a
+// whitespace-only result vanish entirely (omitempty). Turn text keeps its
+// trim — that happens at summarizeTurn's call site, not inside truncate.
+func TestTranscript_ToolResultPreviewKeepsEdgeWhitespace(t *testing.T) {
+	base := t.TempDir()
+	bucket := stateHomeBucket(base, hash1)
+	sid := sidB
+	resultText := "\n\nleading newlines kept\n"
+	whitespaceOnly := "\n\t "
+	turns := []schema.Turn{
+		schema.NewTurn(schema.TurnToolResults, llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{
+			toolResult("read_file", resultText, false),
+			toolResult("shell", whitespaceOnly, false),
+		}}),
+	}
+	writeRichSession(t, bucket, sid, turns, nil, schema.SessionMeta{})
+
+	// --full-text: byte-exact, whole.
+	full, err := Transcript(base, sid, TranscriptOpts{TextMax: TextMaxFull})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := full.Turns[0].ToolResults[0].ContentPreview; got != resultText {
+		t.Errorf("full-text preview = %q, want the result byte-exact %q", got, resultText)
+	}
+	if got := full.Turns[0].ToolResults[1].ContentPreview; got != whitespaceOnly {
+		t.Errorf("full-text whitespace-only preview = %q, want %q (must not vanish)", got, whitespaceOnly)
+	}
+
+	// Default cap: same fidelity — the cap elides the tail, it does not tidy.
+	capped, err := Transcript(base, sid, TranscriptOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := capped.Turns[0].ToolResults[0].ContentPreview; got != resultText {
+		t.Errorf("default preview = %q, want %q", got, resultText)
+	}
+	if got := capped.Turns[0].ToolResults[1].ContentPreview; got != whitespaceOnly {
+		t.Errorf("default whitespace-only preview = %q, want %q", got, whitespaceOnly)
+	}
+}
+
 // truncate's cap is a byte budget, but the cut must land on a rune boundary:
 // slicing mid-rune emits invalid UTF-8, which --json then rewrites to U+FFFD.
 func TestTruncate_NeverCutsMidRune(t *testing.T) {

--- a/agent/doctor/transcript_test.go
+++ b/agent/doctor/transcript_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"primeradiant.com/serf/agent/schema"
 	"primeradiant.com/serf/agent/transcript"
@@ -279,6 +280,38 @@ func TestTranscript_TextMaxHonoursAnExplicitCap(t *testing.T) {
 	if got, want := r.Turns[0].Text, turnText[:textMax]+"…"; got != want {
 		t.Errorf("TextMax=%d turn text = %d bytes (%q), want the first %d bytes plus an ellipsis",
 			textMax, len(got), got, textMax)
+	}
+}
+
+// truncate's cap is a byte budget, but the cut must land on a rune boundary:
+// slicing mid-rune emits invalid UTF-8, which --json then rewrites to U+FFFD.
+func TestTruncate_NeverCutsMidRune(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"ascii cut", "abcdef", 4, "abcd…"},
+		{"cjk cut mid-rune backs off", "日本語", 4, "日…"},
+		{"cjk cut on boundary", "日本語", 6, "日本…"},
+		{"emoji cut mid-rune backs off", "a👍b", 3, "a…"},
+		{"emoji fits whole", "👍", 4, "👍"},
+		{"cut inside first rune backs off to empty", "👍👍", 3, "…"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncate(tc.in, tc.max)
+			if got != tc.want {
+				t.Errorf("truncate(%q, %d) = %q, want %q", tc.in, tc.max, got, tc.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("truncate(%q, %d) = %q is not valid UTF-8", tc.in, tc.max, got)
+			}
+			if kept := strings.TrimSuffix(got, "…"); len(kept) > tc.max {
+				t.Errorf("truncate(%q, %d) kept %d bytes before the ellipsis, over the byte budget", tc.in, tc.max, len(kept))
+			}
+		})
 	}
 }
 

--- a/cmd/serf-doctor/main.go
+++ b/cmd/serf-doctor/main.go
@@ -223,13 +223,6 @@ func cmdTranscript(args []string, stdout, stderr io.Writer) int {
 	}
 	base := doctor.ResolveStateBase(*stateDir)
 
-	// A non-positive cap reads as "no cap" by the usual CLI convention, but the
-	// library spells unbounded as --full-text; silently applying the 200-byte
-	// default instead would hide the very loop this flag exists to expose.
-	if *textMax <= 0 {
-		return fail(stderr, "transcript", errors.New("--text-max must be positive; use --full-text to render turns with no cap"))
-	}
-
 	if *count != "" {
 		res, err := doctor.Count(base, sel, *count)
 		if err != nil {
@@ -250,6 +243,15 @@ func cmdTranscript(args []string, stdout, stderr io.Writer) int {
 			return emitJSON(stdout, res)
 		}
 		return writeText(stdout, doctor.RenderHealth(res))
+	}
+
+	// A non-positive cap reads as "no cap" by the usual CLI convention, but the
+	// library spells unbounded as --full-text; silently applying the 200-byte
+	// default instead would hide the very loop this flag exists to expose. The
+	// check guards only this render: --full-text takes precedence over
+	// --text-max, and --count/--health never consume the cap at all.
+	if !*fullText && *textMax <= 0 {
+		return fail(stderr, "transcript", errors.New("--text-max must be positive; use --full-text to render turns with no cap"))
 	}
 
 	opts := doctor.TranscriptOpts{Format: *format, Range: *rangeArg, TextMax: *textMax}

--- a/cmd/serf-doctor/main_test.go
+++ b/cmd/serf-doctor/main_test.go
@@ -1250,3 +1250,39 @@ func TestRun_TranscriptRejectsNonPositiveTextMax(t *testing.T) {
 		}
 	}
 }
+
+// --full-text is documented to take precedence over --text-max, so giving both
+// must never be an error — even when the --text-max value alone would be
+// refused. Refusing `--text-max 0 --full-text` with "use --full-text" tells the
+// user to pass the flag they already passed.
+func TestRun_TranscriptFullTextOverridesNonPositiveTextMax(t *testing.T) {
+	base, sid, turnText := fixtureWithSalvagedLoop(t)
+
+	for _, arg := range []string{"0", "-1"} {
+		var out, errb bytes.Buffer
+		if code := run([]string{"transcript", sid, "--state-dir", base, "--text-max", arg, "--full-text"}, &out, &errb); code != 0 {
+			t.Fatalf("--text-max %s --full-text: exit %d, want 0; stderr=%s", arg, code, errb.String())
+		}
+		if !strings.Contains(out.String(), turnText) {
+			t.Errorf("--text-max %s --full-text did not render the whole turn text:\n%s", arg, out.String())
+		}
+	}
+}
+
+// --count and --health never consume --text-max, so a non-positive value must
+// not refuse them: the validation guards only the transcript render that will
+// actually apply the cap.
+func TestRun_TranscriptCountAndHealthIgnoreTextMax(t *testing.T) {
+	base, sid, _ := fixtureWithSalvagedLoop(t)
+
+	for _, extra := range [][]string{
+		{"--count", "manage_worktree"},
+		{"--health"},
+	} {
+		var out, errb bytes.Buffer
+		args := append([]string{"transcript", sid, "--state-dir", base, "--text-max", "0"}, extra...)
+		if code := run(args, &out, &errb); code != 0 {
+			t.Errorf("%v with --text-max 0: exit %d, want 0; stderr=%s", extra, code, errb.String())
+		}
+	}
+}


### PR DESCRIPTION
Four follow-up fixes from the post-merge review of PR #69 (serf-doctor `--full-text`/`--text-max`), each TDD'd with a failing test first.

## 1. `--full-text` precedence over `--text-max` validation (`cmd/serf-doctor/main.go`)

The `--text-max <= 0` rejection ran before the `--full-text` precedence assignment and before the `--count`/`--health` branches, so `--text-max 0 --full-text` was refused with an error telling the user to pass the flag they already passed, and `--count`/`--health` were refused over a flag they never consume. The validation now guards only the transcript render that actually applies the cap, and is skipped when `--full-text` has superseded it. Pinned by `TestRun_TranscriptFullTextOverridesNonPositiveTextMax` and `TestRun_TranscriptCountAndHealthIgnoreTextMax`; the existing rejection test still passes.

## 2. Mid-rune truncation (`agent/doctor/transcript.go`)

`truncate` sliced `s[:maxLen]` blind, emitting invalid UTF-8 when a multi-byte rune straddled the cap (`--json` rewrote the tail to U+FFFD). The cut now backs off to the previous rune boundary; the cap stays a byte budget (kept prefix never exceeds maxLen bytes). Pinned by table-driven `TestTruncate_NeverCutsMidRune` with CJK/emoji at the boundary asserting `utf8.ValidString` and the byte budget.

## 3. TrimSpace vs `--full-text` (`agent/doctor/transcript.go`)

`truncate` unconditionally TrimSpaced, so `--full-text` (documented: renders the preview "whole, with no byte cap") dropped edge whitespace and a whitespace-only tool result's ContentPreview vanished under `omitempty`. Trimming moved to the call sites that want tidy edges: turn text (already trimmed in `summarizeTurn`) and tool-call arg previews. Tool-result ContentPreview is now byte-exact, capped or not. Pinned by `TestTranscript_ToolResultPreviewKeepsEdgeWhitespace` under both default and `TextMaxFull`.

## 4. `--health` blindness caveat (`agent/doctor/health.go`)

`longest_identical_run` counts only structural tool calls, so a salvaged partial response — whose repeated calls survive as turn text — reads as length 0. When the run is zero, `RenderHealth` now appends a one-line caveat pointing at `transcript --full-text`. Human render only; JSON schema and `audit.go`'s machine read are untouched. Pinned by `TestRenderHealth_ZeroIdenticalRunCarriesBlindnessCaveat`.

## Verification

- `go test ./agent/doctor/ ./cmd/serf-doctor/ -race -count=1` — ok
- `golangci-lint run ./...` — 0 issues
- `gofmt -l` on changed packages — clean

Claude-Session: https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU