### PR TITLE
fix(agent): give the stand-down harness's warning oracle a drain barrier

### DIFF
--- a/agent/session_notification_standdown_test.go
+++ b/agent/session_notification_standdown_test.go
@@ -25,6 +25,10 @@ type standDownHarness struct {
 	// which the stand-down fires inline on the caller's goroutine.
 	woken chan struct{}
 
+	// drained receives one value per drain barrier the consumer observes; see
+	// warningsMatching.
+	drained chan struct{}
+
 	mu       sync.Mutex
 	wakes    int
 	warnings []string
@@ -32,12 +36,22 @@ type standDownHarness struct {
 
 func newStandDownHarness(t *testing.T) *standDownHarness {
 	t.Helper()
-	h := &standDownHarness{clock: agenttest.NewFakeClock(), woken: make(chan struct{}, 64)}
+	h := &standDownHarness{
+		clock:   agenttest.NewFakeClock(),
+		woken:   make(chan struct{}, 64),
+		drained: make(chan struct{}, 1),
+	}
 	h.sess = newTestSessionForEnvctx(t)
 	h.sess.clock = h.clock
 	// A real drain, not a flag: ConsumeEventsLossless is the only writer of
 	// authoritativeConsumer, and an unserved session never stands down at all.
 	h.sess.ConsumeEventsLossless(func(ev events.SessionEvent) {
+		// The drain barrier warningsMatching emits: nothing else in these
+		// tests loads a prompt, so every one of these is a barrier.
+		if ev.Kind == events.EventPromptLoaded {
+			h.drained <- struct{}{}
+			return
+		}
 		if ev.Kind != events.EventWarning {
 			return
 		}
@@ -71,7 +85,17 @@ func (h *standDownHarness) wakeCount() int {
 	return h.wakes
 }
 
+// warningsMatching counts delivered warnings containing substr. A warning
+// travels emit -> the session's buffered event channel -> the
+// ConsumeEventsLossless drain goroutine, so the count trails the emit: a
+// buffered send never yields the processor, and at GOMAXPROCS=1 the drain
+// goroutine stays runnable-but-unscheduled while the test goroutine reads a
+// stale count. The barrier rides the same FIFO stream, so once the consumer
+// hands it back every warning emitted before this call has been counted --
+// which makes the counts exact, not merely eventual.
 func (h *standDownHarness) warningsMatching(substr string) int {
+	h.sess.emit(events.EventPromptLoaded, events.PromptLoadedData{Label: "warningsMatching drain barrier"})
+	<-h.drained
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	n := 0


### PR DESCRIPTION
## Root cause

`TestNotificationStandDownWarnsOncePerStorageEpisode` failed CI's race gate and reproduces ~12/20 locally at `GOMAXPROCS=1`. The product's episode accounting is correct; the test's oracle races its own event drain.

The fresh failure's warning is emitted synchronously inside `standDown` (`mintRunningTurnID` -> `warnStoreUnhealthyOnce` -> `s.emit`) into the session's 256-slot buffered event channel. The test's warning counter is appended by the `ConsumeEventsLossless` drain goroutine, and the final assertion read the counter immediately after `standDown` returned with no happens-before edge. A non-blocking buffered send never yields the processor, so at `GOMAXPROCS=1` the drain goroutine sat runnable-but-unscheduled while the test asserted: the second warning was in the channel, not yet in the slice, and the count read 1. The earlier assertions usually survived because each loop iteration blocks on `<-h.woken`, which deschedules the test goroutine and lets the drain run — but every `warningsMatching` call had the same latent race (the ownerless-name test's "want exactly 1" could flake to 0 the same way).

The product path was checked for a real recovery/fresh-failure race: `warnStoreUnhealthyOnce`/`clearStoreUnhealthyWarning` are mutex-latched, mint/release/warn run on the serve goroutine, and any adverse interleaving over-warns rather than swallows a warning. No product change needed.

## Fix

`warningsMatching` now flushes the stream before counting: it emits a sentinel `EventPromptLoaded` through the same FIFO channel and blocks until the consumer hands it back, so every warning emitted before the call has been delivered and the counts are exact. No sleeps, no polling — the barrier is ordered by the channel itself. All four stand-down tests get the barrier for free since they all count through `warningsMatching`.

## Proof

- `GOMAXPROCS=1 go test ./agent/ -race -short -run 'TestNotificationStandDownWarnsOncePerStorageEpisode' -count=20`: 20/20 (was ~12/20 failing)
- `go test ./agent/ -race -short -run 'TestNotificationStandDown' -count=10` at default GOMAXPROCS: pass
- Full `go test ./agent/ -race -short -count=1`: pass
- `golangci-lint run ./...` from agent/: 0 issues (after `cache clean`; the cache held stale findings pointing at a deleted worktree)

Claude-Session: https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU