### PR TITLE
docs: tell the subagents plan what its work invalidates, and make its citations resolve

### DIFF
--- a/docs/superpowers/plans/2026-08-16-controllable-subagents.md
+++ b/docs/superpowers/plans/2026-08-16-controllable-subagents.md
@@ -175,11 +175,29 @@ cases exist.
       preseed keys, so the field is `""`.
 
       **The primary delegate turn therefore stays unaddressable however the
-      boundary emit is gated.** Name a mechanism that reserves, emits and
-      releases an identity on every child entry path — initial, resumed,
-      owner-input, continuation and notification. **Acceptance:** one test per
-      path asserting the child's published `activeTurnId` is a `turn_m<n>` the
-      child's own mutation store holds, not a projector `turn_<n>`.
+      boundary emit is gated.**
+
+      **Do not reach this by marking a child served.** `servedByDaemon()` is
+      exactly `authoritativeConsumer` (`agent/session_active_turn.go:32-36`),
+      and its only writer anywhere is `ConsumeEventsLossless`
+      (`agent/session_events.go:78`, which sets it at `:92`). So the cheapest
+      mechanism available — register the child, let the existing gate open — is
+      precisely the one `TestPreparedSubagentGetsNoAuthoritativeConsumer`
+      (`agent/session_lossless_events_test.go:238`) exists to forbid, and that
+      test states the cost: nothing in this package receives on a child's event
+      channel, so a child marked served does not fail, it **wedges** the moment
+      its buffer fills. That is a hang under load sitting behind a green suite,
+      which is worse than the bug this task fixes. Deleting the test to get past
+      it removes the only warning that shape of mistake has. If you take this
+      route anyway, you owe the argument for why the wedge cannot happen — not a
+      deleted test.
+
+      Name a mechanism that reserves, emits and releases an identity on every
+      child entry path — initial, resumed, owner-input, continuation and
+      notification. **Acceptance:** one test per path asserting the child's
+      published `activeTurnId` is a `turn_m<n>` the child's own mutation store
+      holds, not a projector `turn_<n>`. See Task 9 for the audit label and the
+      pinned tests this task falsifies.
 
 - [ ] **Task 4: Route accepted mutations to the addressed child, and prove the
       child stops.** Expect `SessionUnavailable` first — that is the routing gate
@@ -228,7 +246,8 @@ cases exist.
       deliberately. Note this also makes unserved *root* sessions (one-shot
       `serf run`) emit the boundary; state it rather than discover it. This gets
       turn *separation* on notification-driven child turns; it does not name any
-      other child turn — that is Task 3.
+      other child turn — that is Task 3. See Task 9 for the EntryKind audit
+      label this also invalidates.
 
 - [ ] **Task 6: Measure the added durable-write cost.**
 
@@ -241,6 +260,52 @@ cases exist.
       that child's next model request exactly once, and reaches neither the root
       nor a sibling delegate.
 
+- [ ] **Task 9: Update the EntryKind turn-opening audit and the tests that pin
+      what this plan removes.**
+
+      **Sequencing: this closes with Task 4, not after Task 8.** Its constraint
+      on Task 3's mechanism is stated inside Task 3, because it has to be read
+      before that mechanism is chosen. This task sits last in the file only
+      because renumbering would break the task cross-references above.
+
+      Tasks 3 and 4 falsify a label that nothing in the suite can catch.
+      `agent/entrykind_audit_test.go:78` records
+      `EntryDelegateAttention: unservedSoUnaddressable`, and the label's own
+      definition (`:30-33`) justifies that as "the kind only ever runs on a
+      child session, which has no authoritative consumer and takes no client
+      mutations". Task 4 makes the second clause false.
+
+      **The audit cannot notice.** Its header says so outright (`:15-20`): it
+      checks that every kind carries a label, NOT that the label is true, so the
+      table stays green while becoming a lie. This is not a documentation nit —
+      that table is what the next person reads to decide how a newly added kind
+      gets named, and `entryKindTurnOpening` was built by
+      `2026-08-16-one-turn-boundary.md` Task 4 for exactly this purpose.
+
+      Three tests pin behaviour this plan removes. Task 5 names the first; the
+      other two went unmentioned until this task:
+
+      | test | where | what it pins |
+      | --- | --- | --- |
+      | `TestUnservedSessionAnnouncesNoBoundary` | `agent/session_turn_boundary_test.go:599` | the boundary emit — Task 5 inverts it |
+      | `TestUnservedSessionNamesNoTurn` | `agent/session_turn_boundary_test.go:576` | the mint gate at `agent/session_active_turn.go:76-78`, which Task 3 must get past. It already carries a note anticipating this plan |
+      | `TestPreparedSubagentGetsNoAuthoritativeConsumer` | `agent/session_lossless_events_test.go:238` | that a child is never registered as served. A **constraint on Task 3**, not a test to invert — see Task 3 |
+
+      **Acceptance:**
+
+      - `entryKindTurnOpening[EntryDelegateAttention]` no longer reads
+        `unservedSoUnaddressable`, and its replacement is derived from what the
+        shipped mechanism actually does. Re-derive it; do not pick whichever
+        label makes the table compile.
+      - The label's definition comment no longer claims child sessions take no
+        client mutations, and no longer cites a test that no longer pins it.
+      - Each of the three tests above is deliberately inverted, re-pointed, or
+        (the third) left intact with its constraint honoured — each carrying a
+        comment naming the task that changed it and why.
+      - Reverting Task 3's mechanism makes the changed tests fail again. A test
+        inverted into a tautology passes both ways and guards nothing, which is
+        the failure this whole task exists to prevent.
+
 ## Definition of done
 
 - [ ] `make lint` (nine targets), `make build`, root suite, all seven module
@@ -251,3 +316,6 @@ cases exist.
 - [ ] Stopping one delegate leaves the root and its siblings running.
 - [ ] No control is offered on any thread that cannot honour it — and every
       control that IS offered has been shown to take effect on that thread.
+- [ ] The EntryKind turn-opening table (`agent/entrykind_audit_test.go`)
+      describes what the code now does, and every test this plan inverted was
+      shown to fail again when its task's mechanism is reverted.

--- a/docs/superpowers/plans/2026-08-16-controllable-subagents.md
+++ b/docs/superpowers/plans/2026-08-16-controllable-subagents.md
@@ -14,6 +14,16 @@ while a delegate was still uncontrollable. Every claim below was re-checked in
 the tree before this revision; each correction is marked where it sits. Steer had
 no task at all and now has Task 8.
 
+**Revision:** re-resolved 2026-08-17 against `64a891865` (kata `nf4r`). The
+re-check claimed above was true when written and had since decayed: **45 of the
+85 `file:line` citations in this document pointed at something other than what
+the prose claimed**, and are corrected here. Task 9 was added, because Tasks 3
+and 4 falsify a label in the EntryKind turn-opening audit that nothing in the
+suite can catch, and Task 3 gained the constraint that keeps its cheapest
+mechanism from deadlocking a child. **Treat a citation here as only as fresh as
+the newest revision line above** — this document has now drifted twice under
+headers asserting it had been checked, so re-resolve before relying on one.
+
 **Goal:** A subagent (delegate) thread in the web UI renders separated turns,
 shows busy while working, and supports Stop and Steer.
 
@@ -113,13 +123,20 @@ cases exist.
 
   **Why this is hard, which is the part worth carrying forward.** There is no
   per-thread source of truth to compute a capability set *from*. `appCapabilities`
-  (`server/appwire_runtime.go:1353-1376`) derives every field from server-wide
+  (`server/appwire_runtime.go:1353-1401`) derives every field from server-wide
   state: the callback registrations `s.steerFunc` / `s.steerWithImagesFunc`,
-  `s.cancelFunc`, `s.compactFunc`, `s.shutdownFunc`, `s.modelFunc`, `s.nameFunc`,
-  `s.queueFunc`, `s.goalFunc`, plus `s.appReservedTurnID` and the `processing`
+  `s.compactFunc`, `s.shutdownFunc`, `s.modelFunc`, `s.nameFunc`,
+  `s.queueFunc`, `s.goalFunc`, plus the sticky `s.interruptWired`
+  (`server/server.go:314`), `s.appReservedTurnID` and the `processing`
   flag. Each is one value on the `Server`, wired to the root session. Ask it about
   a descendant and it can only answer about the root — which is why the honest
   thing it does today is not answer at all.
+
+  Note `Interrupt` reads the sticky `s.interruptWired` and **deliberately not**
+  the per-turn `s.cancelFunc` — that read is what kata `5gdv` removed, because
+  the two are armed on different goroutines and a set sampled between them
+  advertised a turn that was running and could not be stopped. Do not
+  re-introduce it when making the set per-thread.
 
   So Task 2 is not "pass a thread id to `appCapabilities`". It is: give a
   descendant thread a state the capability set can be computed from, then fill
@@ -210,8 +227,10 @@ cases exist.
       - the daemon's interrupt callback cancels the **root** runner
         (`cmd/serf/serve.go:832` → `cancelAndWaitMutationRunner`,
         `cmd/serf/serve.go:662-673`). It reads `mutationRunnerCancel`
-        (declared `:646`), whose **only** writer is `setMutationRunner`
-        (`:648-651`), called from four places in the root serve loop: `:1010`,
+        (declared `:646`), which has two writers: `setMutationRunner`
+        (`:648-651`) arms it, and `clearMutationRunner` (`:653-660`) disarms it
+        when the run it belongs to is the one still recorded. `setMutationRunner`
+        is called from four places in the root serve loop: `:1010`,
         `:1020`, `:1032`, `:1039`. Note `:1010` is the drain-loop re-arm inside
         `nextTurnCtx` — it re-points the seam at `cancelDrain` mid-drain, and it
         is the path most likely to break when `requireRootMutationTarget` comes
@@ -229,10 +248,12 @@ cases exist.
       So this task needs per-child current-turn cancellation and completion-wait
       plumbing for **both** run types. **Acceptance:** the addressed child stops
       while the root and its sibling delegates keep running — assert all three,
-      not just the first.
+      not just the first. This task is what makes the EntryKind audit's label
+      false; Task 9 closes with it and is where that is dealt with.
 
       **Watch the session-scoped interrupt.** `InterruptClientMutation` reads
-      `snapshot.ActiveTurnID` as its target (`agent/session_client_mutation.go:464`)
+      `snapshot.ActiveTurnID` as its target (`agent/session_client_mutation.go:497`,
+      in the function declared at `:464`)
       with the precondition "the session is processing". That is the shape most
       likely to cancel the root by accident once `requireRootMutationTarget` comes
       down. Note `TurnInterruptParams` already carries `threadId`

--- a/docs/superpowers/plans/2026-08-16-controllable-subagents.md
+++ b/docs/superpowers/plans/2026-08-16-controllable-subagents.md
@@ -47,15 +47,15 @@ establish is that each child gets its own mutation file and that
 > are wrong, and the second would corrupt the transcript it was trying to protect.
 
 **A delegate does not run inside the parent's tool call.** The code says so
-outright: `agent/subagents.go:962-966` reads "Subagent execution must outlive the
-parent tool-call context", and `:967` builds the run context with
+outright: `agent/subagents.go:961-965` reads "Subagent execution must outlive the
+parent tool-call context", and `:966` builds the run context with
 `context.WithCancel(context.Background())`. Stable delegates do the same at
-`agent/delegate_tree_start.go:146`, `:206` and `:486`.
+`agent/delegate_tree_start.go:145`, `:205` and `:485`.
 
-Creation returns before the child finishes. `agent/delegate_runtime.go:923`
+Creation returns before the child finishes. `agent/delegate_runtime.go:924`
 launches the run and immediately returns a result carrying
 `RunningInBackground: true` (`agent/delegate_runtime.go:1533`), and the create
-tool refuses to wait at all — `agent/session_tools.go:176-177` rejects
+tool refuses to wait at all — `agent/session_tools.go:173-174` rejects
 `max_wait_ms` outright.
 
 So there are exactly two cases, and they need different answers:
@@ -68,7 +68,7 @@ So there are exactly two cases, and they need different answers:
    nothing to return.**
 2. **An inline `delegate_send` waiter.** The only call that can still be blocked
    on a child is `delegate_send` with `max_wait_ms > 0`
-   (`agent/session_tools.go:159` → `agent/delegate_runtime.go:638-648`). That
+   (`agent/session_tools.go:156` → `agent/delegate_runtime.go:639-648`). That
    waiter must be resolved. Note it *already* has a graceful degradation for a
    deadline: `agent/delegate_runtime.go:649-652` sets `TimedOut: true` and leaves
    the delegate running in background. A stop needs the analogous shape — resolve
@@ -84,8 +84,8 @@ cases exist.
 | --- | --- |
 | Every mutation handler rejects non-root threads with `SessionUnavailable("thread is not served by this daemon")` | `server/appwire_runtime.go:1087-1104` (`requireRootMutationTarget`), called first by **14** handlers: `:736`, `:773`, `:799`, `:822` (`handleAppTurnInterrupt`), `:840`, `:866`, `:891`, `:917`, `:946`, `:974`, `:987`, `:1012`, `:1049`, `:1067`. Re-derive with `grep -c` before scoping work off this — an earlier revision of this row said "ten", from a `grep | head` that silently truncated. |
 | Nothing routes an accepted mutation to a child session | the mutation path is wired to the root session only |
-| Descendant threads carry **no** capabilities at all | only the root fills them, at `server/appwire_runtime.go:1235`; the descendant list (`:548-552`) and `appThreadForID` (`:640-654`) stamp `ActiveTurnID` and nothing else |
-| Child sessions never mint a name — **and removing the `servedByDaemon()` gate is not enough** | `servedByDaemon()` gates the mint (`agent/session_active_turn.go:47-49`) and the boundary emit (`agent/session_lifecycle.go:1652`), but `mintRunningTurnID` is only *reached* for two entry kinds, and a delegate's primary run is neither. See Task 3. |
+| Descendant threads carry **no** capabilities at all | only the root fills them, at `server/appwire_runtime.go:1236`; the descendant list (`:548-552`) and `appThreadForID` (`:640-654`) stamp `ActiveTurnID` and nothing else |
+| Child sessions never mint a name — **and removing the `servedByDaemon()` gate is not enough** | `servedByDaemon()` gates the mint (`agent/session_active_turn.go:76-78`) and the boundary emit (`agent/session_lifecycle.go:1671`), but `mintRunningTurnID` is only *reached* for two entry kinds, and a delegate's primary run is neither. See Task 3. |
 
 ## Global Constraints
 
@@ -101,7 +101,7 @@ cases exist.
   > exactly one call site, `:229`, on the **root** egress path. Descendant egress
   > (`:311`) calls only `stampAppNotificationTarget`, and descendant `thread/read`
   > is assembled at `:258-289` / `:640-654` and never fills capabilities. Only the
-  > root sets them, at `:1235`.
+  > root sets them, at `:1236`.
 
   So descendant capabilities are **absent** on notifications
   (`ThreadStatusChangedParams.Capabilities` is `*ThreadCapabilities` with
@@ -113,7 +113,7 @@ cases exist.
 
   **Why this is hard, which is the part worth carrying forward.** There is no
   per-thread source of truth to compute a capability set *from*. `appCapabilities`
-  (`server/appwire_runtime.go:1352-1376`) derives every field from server-wide
+  (`server/appwire_runtime.go:1353-1376`) derives every field from server-wide
   state: the callback registrations `s.steerFunc` / `s.steerWithImagesFunc`,
   `s.cancelFunc`, `s.compactFunc`, `s.shutdownFunc`, `s.modelFunc`, `s.nameFunc`,
   `s.queueFunc`, `s.goalFunc`, plus `s.appReservedTurnID` and the `processing`
@@ -159,18 +159,18 @@ cases exist.
 
       **Why the `servedByDaemon()` gate is not the whole blocker.**
       `mintRunningTurnID` is only *reached* for two entry kinds:
-      `EntryNotification` (`agent/session_lifecycle.go:1042`) and
-      `EntryContinuation` (`:1100`). A delegate's initial, resumed and
-      owner-input runs are all `EntryUserInput` (`agent/subagents.go:1425-1428`,
-      reached from `agent/delegate_runtime.go:923`, `:624` and
-      `agent/subagents.go:1130`). That path takes its `StableTurnID` from
-      `queuedClientMutationFromContext` (`agent/session_lifecycle.go:1389`, spent
-      at `:1467`, `:1486`, `:1505`), and the only writers of that context value
+      `EntryNotification` (`agent/session_lifecycle.go:1040`) and
+      `EntryContinuation` (`:1123`). A delegate's initial, resumed and
+      owner-input runs are all `EntryUserInput` (`agent/subagents.go:1424-1426`,
+      reached from `agent/delegate_runtime.go:924`, `:625` and
+      `agent/subagents.go:1129`). That path takes its `StableTurnID` from
+      `queuedClientMutationFromContext` (`agent/session_lifecycle.go:1408`, spent
+      at `:1472`, `:1486`, `:1505`), and the only writers of that context value
       are the two **root** serve-loop entry points —
-      `ProcessClientMutationStart` (`agent/session_client_mutation.go:421`) and
+      `ProcessClientMutationStart` (`agent/session_client_mutation.go:422`) and
       `ProcessPendingUserInput` (`agent/session_client_mutation_queue.go:206`),
-      called only from `cmd/serf/serve.go:1026` and `:1033` — plus the drain-loop
-      re-wraps at `agent/session_lifecycle.go:717` and `:840`. A delegate run
+      called only from `cmd/serf/serve.go:1030` and `:1037` — plus the drain-loop
+      re-wraps at `agent/session_lifecycle.go:719` and `:841`. A delegate run
       context is rooted in `context.Background()` and carries only lease and
       preseed keys, so the field is `""`.
 
@@ -193,17 +193,17 @@ cases exist.
         (`cmd/serf/serve.go:832` → `cancelAndWaitMutationRunner`,
         `cmd/serf/serve.go:662-673`). It reads `mutationRunnerCancel`
         (declared `:646`), whose **only** writer is `setMutationRunner`
-        (`:648-651`), called from four places in the root serve loop: `:1008`,
-        `:1016`, `:1028`, `:1035`. Note `:1008` is the drain-loop re-arm inside
+        (`:648-651`), called from four places in the root serve loop: `:1010`,
+        `:1020`, `:1032`, `:1039`. Note `:1010` is the drain-loop re-arm inside
         `nextTurnCtx` — it re-points the seam at `cancelDrain` mid-drain, and it
         is the path most likely to break when `requireRootMutationTarget` comes
-        down. `srv.SetCancelFunc` (`:1007`, `:1015`, `:1027`, `:1034`) sits beside
+        down. `srv.SetCancelFunc` (`:1009`, `:1019`, `:1031`, `:1038`) sits beside
         these calls but is a **different** seam and does not feed this one; do not
         substitute one for the other;
-      - ordinary child runs cancel via `sub.cancel` (`agent/subagents.go:969`,
-        `:1342`; used by `cancelAgent` at `:1360-1378`);
+      - ordinary child runs cancel via `sub.cancel` (`agent/subagents.go:968`,
+        `:1341`; used by `cancelAgent` at `:1359-1378`);
       - notification-drive child turns use a local `driveCancel`
-        (`agent/subagents.go:1223`, used only at `:1229` and `:1240`) that is
+        (`agent/subagents.go:1222`, used only at `:1228` and `:1239`) that is
         never stored on `sub`, so `sub.cancel` cannot stop one;
       - stable delegates add a fourth, the controller's per-start record cancel
         (`agent/delegate_tree_stop.go:166-167`, `:293-294`, `:308-309`).
@@ -222,9 +222,9 @@ cases exist.
       select the child.
 
 - [ ] **Task 5: Turn separation and status.** Drop the `servedByDaemon()` gate on
-      the boundary emit (`agent/session_lifecycle.go:1652`) and invert
+      the boundary emit (`agent/session_lifecycle.go:1671`) and invert
       `TestUnservedSessionAnnouncesNoBoundary`
-      (`agent/session_turn_boundary_test.go:577`), which pins today's behaviour
+      (`agent/session_turn_boundary_test.go:599`), which pins today's behaviour
       deliberately. Note this also makes unserved *root* sessions (one-shot
       `serf run`) emit the boundary; state it rather than discover it. This gets
       turn *separation* on notification-driven child turns; it does not name any


### PR DESCRIPTION
Closes kata `nf4r`. Documentation only — `docs/superpowers/plans/2026-08-16-controllable-subagents.md`. No code touched.

## What the kata asked for, and where it was wrong

The plan describes work that invalidates the EntryKind audit and two pinned tests without saying so, leaving whoever executes it to discover that from a red suite.

The kata's own list was wrong. It says Task 5 names `TestPreparedSubagentGetsNoAuthoritativeConsumer`; `git log --all -S` over the plan returns nothing on any branch or revision, so the plan has never named it. Three of the kata's four line citations were also stale. Corrections filed on the kata.

The genuinely unmentioned pair is `TestPreparedSubagentGetsNoAuthoritativeConsumer` (`agent/session_lossless_events_test.go:238`) and `TestUnservedSessionNamesNoTurn` (`agent/session_turn_boundary_test.go:576`).

## The edit that matters most wasn't the one scoped

`servedByDaemon()` is exactly `authoritativeConsumer` (`agent/session_active_turn.go:32-36`), and its only writer anywhere is `ConsumeEventsLossless` (`agent/session_events.go:92`). `agent/session.go:110` says so directly: *"ConsumeEventsLossless is the ONLY writer … Do not add another way to set it: 'lossless with nobody reading' is a permanent wedge."*

So the cheapest route to Task 3 — mark child sessions served, let the existing gate open — is exactly what `TestPreparedSubagentGetsNoAuthoritativeConsumer` forbids, and the consequence is a **wedge**, not a test failure: nothing drains a child's event channel, so a child marked served hangs when its buffer fills.

That test is a constraint on which mechanism Task 3 may choose, not a pinned behaviour to invert in passing. "Here is the shortcut that will look like it works and then deadlock" is worth more to an executor than "invert these two tests".

The constraint sits in Task 3, where the decision is made. Task 9 carries the bookkeeping, with forward pointers from Tasks 3, 4 and 5. Reading in order, the warning arrives before the decision it constrains. Tasks were appended rather than renumbered, because the prose cross-references task numbers and renumbering would introduce the exact defect class this removes.

## The citation sweep

Every `file:line` in the document was re-resolved: **45 of 85 were wrong.**

Two were found only after review, and both are worth recording because they define the method's limits:

- `session_client_mutation.go:464` pointed at the function *declaration*; the read it cites is at `:497`. It passed the first pass because the drifted line landed on the same function's signature.
- `appCapabilities` was cited `:1352-1376` and "fixed" in pass one as a cosmetic boundary tightening to `:1353-1376`. The function runs to `:1401`, and six of the eight fields the prose enumerates sit outside that range. The start of the range was checked; whether the end covered the claim was not.

**The resolver is a filter, not a proof.** It reliably catches a missing file, an out-of-range line, and an orphaned bare reference. It cannot catch a wrong line inside the right construct, or a range whose bounds don't cover the claim — which is exactly the class that reads as verified. The report says so; an earlier draft claimed a clean sweep and that claim is retracted.

## Two factual errors in the plan, fixed while verifying

- `mutationRunnerCancel`'s "only writer" is not `setMutationRunner` alone — `clearMutationRunner` (`cmd/serf/serve.go:653-660`) also writes it.
- `appCapabilities` does **not** read `s.cancelFunc`, which the plan listed among its inputs. It reads `s.interruptWired && active && !closed`, and the source comments say "deliberately NOT the ambient cancelFunc" and "sticky where cancelFunc is per-turn, which is the whole difference". Kata `5gdv` removed that read because the two arm on different goroutines, so a set sampled between them advertised a turn that was running and could not be stopped. Task 2 now warns against re-introducing it — which is precisely when someone would, since routing capabilities per-thread is the change that invites it.

## Verification

`make merge-approval-gate` green (470s).

No mutation list: documentation change, no code under test. The falsifiable stand-in is the resolver re-run, with the limitation above stated rather than glossed.

Independently reviewed. The reviewer built its own resolver, checked all 96 citations and manually judged ~50 against prose, which is how the `:464` miss was found. Every one of the ~45 changed citations it re-resolved is correct.

The header now carries a dated record of this pass and the warning that a citation is only as fresh as the newest revision line — this document has now drifted twice under headers asserting it had been checked.
