### PR TITLE
fix(execenv): drain leader output before forced stream cleanup

### DIFF
--- a/agent/execenv/command_runtime.go
+++ b/agent/execenv/command_runtime.go
@@ -138,6 +138,7 @@ func (c *systemCommandRuntime) Start() error {
 	c.outputReader = reader
 	c.outputDone = make(chan error, 1)
 	go func() {
+		streamOutputCopyStart()
 		_, copyErr := io.Copy(commandOutputWriter{destination: c.combinedOutput}, reader)
 		c.outputDone <- copyErr
 	}()
@@ -157,32 +158,53 @@ func (c *systemCommandRuntime) Wait() error {
 	}
 
 	pipeClosed, canSignalGroup, pipeErr := waitForStreamPipeClose(c.outputReader, 0)
-	if pipeErr != nil {
-		_ = c.outputReader.Close()
-		if !outputDone {
-			outputErr = <-c.outputDone
-		}
-		return commandWaitError(processErr, outputErr, pipeErr)
-	}
-	if pipeClosed {
-		if !outputDone {
-			outputErr = <-c.outputDone
-		}
-		_ = c.outputReader.Close()
-		return commandWaitError(processErr, outputErr, nil)
+	if pipeErr != nil || pipeClosed {
+		return c.drainClosedPipe(processErr, outputDone, outputErr, pipeErr)
 	}
 	if !canSignalGroup {
-		_ = c.outputReader.Close()
-		if !outputDone {
-			outputErr = <-c.outputDone
-		}
-		return commandWaitError(processErr, c.forcedCloseOutputError(outputErr), nil)
+		return c.forceCloseOutput(processErr, outputDone, outputErr)
 	}
 
 	// Background commands remain owned by Serf. A live pipe writer after the
 	// leader exits is a managed descendant; only DetachCommand disowns one.
 	c.Terminate()
 	pipeClosed, _, pipeErr = waitForStreamPipeClose(c.outputReader, c.terminationGrace)
+	if pipeErr != nil || pipeClosed {
+		return c.drainClosedPipe(processErr, outputDone, outputErr, pipeErr)
+	}
+	c.Kill()
+	// A SIGKILL'd group releases the pipe as the kernel reaps it, which runs
+	// the copier to EOF; wait for it so output the leader wrote before exiting
+	// is delivered. Closing the reader first would truncate whatever the copier
+	// had not read yet. The window is bounded so an unkillable writer cannot
+	// hang Wait.
+	if !outputDone {
+		drainTimer := time.NewTimer(killedWriterDrainWindow)
+		defer drainTimer.Stop()
+		select {
+		case outputErr = <-c.outputDone:
+			outputDone = true
+		case <-drainTimer.C:
+		}
+	}
+	if outputDone {
+		_ = c.outputReader.Close()
+		return commandWaitError(processErr, outputErr, nil)
+	}
+	return c.forceCloseOutput(processErr, outputDone, outputErr)
+}
+
+// killedWriterDrainWindow bounds how long Wait allows a SIGKILL'd process group
+// to release the output pipe before force-closing the reader. Kernel teardown
+// normally closes the pipe within milliseconds; the bound only matters for a
+// writer stuck beyond SIGKILL (for example uninterruptible sleep).
+const killedWriterDrainWindow = 2 * time.Second
+
+// drainClosedPipe finishes Wait once the output pipe closed (or polling it
+// failed): join the copier before closing the reader so buffered output is
+// delivered, except after a poll failure, where closing first unblocks the
+// copier.
+func (c *systemCommandRuntime) drainClosedPipe(processErr error, outputDone bool, outputErr, pipeErr error) error {
 	if pipeErr != nil {
 		_ = c.outputReader.Close()
 		if !outputDone {
@@ -190,14 +212,16 @@ func (c *systemCommandRuntime) Wait() error {
 		}
 		return commandWaitError(processErr, outputErr, pipeErr)
 	}
-	if pipeClosed {
-		if !outputDone {
-			outputErr = <-c.outputDone
-		}
-		_ = c.outputReader.Close()
-		return commandWaitError(processErr, outputErr, nil)
+	if !outputDone {
+		outputErr = <-c.outputDone
 	}
-	c.Kill()
+	_ = c.outputReader.Close()
+	return commandWaitError(processErr, outputErr, nil)
+}
+
+// forceCloseOutput abandons a still-open pipe writer: close the reader to end
+// the copier, then suppress the local-close error it reports.
+func (c *systemCommandRuntime) forceCloseOutput(processErr error, outputDone bool, outputErr error) error {
 	_ = c.outputReader.Close()
 	if !outputDone {
 		outputErr = <-c.outputDone

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -760,6 +760,7 @@ var (
 	listReadDir            = os.ReadDir
 	streamBeforeSignalOnce = func(func()) {}
 	streamAfterTimer       = func(func()) {}
+	streamOutputCopyStart  = func() {}
 	wrapperWithPolicy      = func(w *sandbox.Wrapper, p sandbox.ResolvedPolicy) (*sandbox.Wrapper, error) { return w.WithPolicy(p) }
 	splitEditLines         = strings.Split
 	venvCandidateDirs      = func(root, binDir string) []string {

--- a/agent/execenv/streaming_test.go
+++ b/agent/execenv/streaming_test.go
@@ -132,6 +132,81 @@ func TestStreamCommandWaitStopsDescendantsAfterLeaderExit(t *testing.T) {
 	}
 }
 
+// TestStreamCommandWaitDeliversLeaderOutputThroughForcedCleanup pins that
+// output the leader wrote before exiting reaches the stream writer even when
+// Wait's descendant cleanup escalates to SIGKILL (zero grace) before the
+// output copier has read the pipe. A CI run on 2026-08-17 lost the leader's
+// READY line exactly this way: the copier goroutine had not been scheduled
+// when the kill path closed the reader, silently truncating buffered output.
+// The hook holds the copier until the process group is provably dead, so the
+// copier reads only after forced cleanup already ran.
+func TestStreamCommandWaitDeliversLeaderOutputThroughForcedCleanup(t *testing.T) {
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseCopier := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(releaseCopier)
+	orig := streamOutputCopyStart
+	streamOutputCopyStart = func() { <-release }
+	t.Cleanup(func() { streamOutputCopyStart = orig })
+
+	grace := time.Duration(0)
+	env := &LocalExecutionEnvironment{RootDir: t.TempDir(), terminationGrace: &grace}
+	if err := env.Initialize(); err != nil {
+		t.Fatal(err)
+	}
+
+	var mu sync.Mutex
+	var buf bytes.Buffer
+	// The background child ignores SIGTERM and keeps respawning, so the output
+	// pipe provably stays open until the SIGKILL escalation tears the group
+	// down. That forces Wait through the forced-cleanup path every run.
+	command := `sh -c 'trap "" TERM; while :; do sleep 1; done' & printf 'MARKER\n'; exit 0`
+	h, err := env.StreamCommand(context.Background(), command, "", nil, &lockedWriter{&mu, &buf})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	type waitResult struct {
+		code int
+		err  error
+	}
+	waitDone := make(chan waitResult, 1)
+	go func() {
+		code, waitErr := h.Wait()
+		waitDone <- waitResult{code: code, err: waitErr}
+	}()
+
+	// Group death proves Wait already ran Terminate and Kill; only then may the
+	// copier run, recreating the starved-copier schedule deterministically.
+	deadline := time.Now().Add(5 * time.Second)
+	for syscall.Kill(-h.Pid, 0) != syscall.ESRCH {
+		if time.Now().After(deadline) {
+			releaseCopier()
+			h.Signal()
+			<-waitDone
+			t.Fatalf("process group %d survived forced cleanup", h.Pid)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	releaseCopier()
+
+	select {
+	case result := <-waitDone:
+		if result.err != nil || result.code != 0 {
+			t.Fatalf("wait = (%d, %v), want (0, nil)", result.code, result.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Wait did not return after the copier was released")
+	}
+
+	mu.Lock()
+	got := buf.String()
+	mu.Unlock()
+	if !strings.Contains(got, "MARKER") {
+		t.Fatalf("leader output truncated by forced cleanup: %q", got)
+	}
+}
+
 func TestStreamCommandSignalStops(t *testing.T) {
 	env := &LocalExecutionEnvironment{RootDir: t.TempDir()}
 	_ = env.Initialize()


### PR DESCRIPTION
## Root cause

`TestStreamCommandWaitStopsDescendantsAfterLeaderExit/immediate_cleanup` flaked on CI at exactly 5s: the test's 5-second wait for the leader's `CHILD=... READY` line timed out with output `""`.

In `systemCommandRuntime.Wait`, when descendant cleanup escalates to SIGKILL (zero termination grace), the kill path closed the combined-output pipe reader immediately after signalling the group. If the output-copier goroutine had not yet been scheduled — routine on a loaded runner — everything the leader wrote before exiting was still buffered in the pipe and was silently truncated. This is a product bug, not a tight test deadline: a streamed command's final output vanishes whenever cleanup has to SIGKILL a lingering descendant before the copier catches up.

## Repro

Did not reproduce on macOS (40 runs). On Linux (Docker `golang:1.25`, `--cpus 2`, `-race`, 3 parallel test binaries x 40 iterations), 2 of 3 binaries hit the exact CI failure: `child did not start; output: ""` at 5.00s in `immediate_cleanup`.

## Fix

- After `Kill()`, Wait now waits for the SIGKILL'd group's kernel teardown to run the copier to EOF and joins it before closing the reader, so buffered leader output is delivered. The wait is bounded by a 2s drain window so a writer that survives SIGKILL (uninterruptible sleep) still cannot hang Wait — the property the forced close originally protected.
- New regression test `TestStreamCommandWaitDeliversLeaderOutputThroughForcedCleanup` holds the copier via a test hook until the process group is provably dead, deterministically recreating the starved-copier schedule. It fails every run on the old code and passes now.
- Shared pipe-drain/force-close handling extracted into `drainClosedPipe` / `forceCloseOutput` instead of triplicating it.

## Verification

- Linux (reproducing environment, with `--init`): 3 parallel binaries x 40 iterations at `--cpus 2` plus 60 serial iterations at `--cpus 1`, all `-race`: 180/180 PASS (also covers `TestDetachCommandSurvivesCleanup`, which never reproduced in 300+ iterations — its one earlier flake looks like plain load against its own 5s file-wait).
- macOS: `go test ./execenv/ -race -count=10` and a full single `-race` run: PASS.
- `golangci-lint run ./...` from `agent/`: 0 issues. `go vet`: clean.

Claude-Session: https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU