### PR TITLE
fix(tooling): close four confirmed coverage-tooling gaps from the adversarial review

### DIFF
--- a/scriptmktemp_audit_test.go
+++ b/scriptmktemp_audit_test.go
@@ -60,7 +60,6 @@ var mktempAllowedScripts = map[string]bool{
 	"deploy-hub-selftest.sh":           true,
 	"e2e-cover.sh":                     true,
 	"e2e-ratelimited-provider.sh":      true,
-	"e2e-webui-turn-controls.sh":       true,
 	"fuzz-bisect-selftest.sh":          true,
 	"fuzz-bisect.sh":                   true,
 	"fuzz-continuous-selftest.sh":      true,

--- a/scripts/coverage-union-selftest.sh
+++ b/scripts/coverage-union-selftest.sh
@@ -121,6 +121,19 @@ printf 'agent 100.0\n' >"$floors"
 PATH="$fake_bin:$PATH" TMPDIR="$tmphome" FAKE_GO_FAIL_ALL=1 bash "$script" --modules "nosuch" >"$out" 2>&1
 assert_has "$out" "(no module)" "a missing module is reported"
 
+# A FLOORED module that cannot be measured is an unenforced ratchet, not a
+# skippable row: under --check it must fail loudly. Without this, renaming or
+# deleting a floored module quietly disabled its floor while check stayed green.
+printf 'nosuch 50.0\n' >"$floors"
+run --modules "nosuch" --check >"$out" 2>&1
+assert_eq "$?" "1" "check fails when a floored module cannot be measured"
+assert_has "$out" "UNMEASURED: nosuch" "the unmeasurable floored module is named"
+
+# ...while a module nobody floored keeps its advisory skip.
+: >"$floors"
+run --modules "nosuch" --check >"$out" 2>&1
+assert_eq "$?" "0" "an unmeasurable module without a floor stays a reported skip"
+
 # A union denominator larger than both tracks means the tagged and untagged
 # builds disagree about block boundaries; the percentage would be nonsense.
 PATH="$fake_bin:$PATH" TMPDIR="$tmphome" FAKE_GO_SHIFT_FUZZ_BLOCKS=1 bash "$script" --modules "agent" >"$out" 2>&1

--- a/scripts/coverage-union.sh
+++ b/scripts/coverage-union.sh
@@ -59,6 +59,18 @@ measured_for() { awk -v m="$1" '$1==m {print $2}' "$measured_file" 2>/dev/null; 
 # argument list as a redirection to a file named "0".
 pct_of() { awk -v c="$1" -v t="$2" 'BEGIN{printf "%.1f", (t > 0 ? 100 * c / t : 0)}'; }
 
+# check_measurable MODULE WHY — a floored module that cannot be measured is an
+# unenforced ratchet, not a skippable row; see test-coverage-floor.sh for the
+# failure mode this closes. A module nobody floored keeps its advisory skip.
+check_measurable() {
+	$check || return 0
+	local floor
+	floor="$(floor_for "$1")"
+	[ -n "$floor" ] || return 0
+	echo "    UNMEASURED: $1 has a floor (${floor}%) but $2; the floor is not being enforced" >&2
+	fail=1
+}
+
 # An explicit path under TMPDIR, not `mktemp -t`: macOS's mktemp ignores TMPDIR
 # for -t and uses the Darwin per-user temp directory instead, which put every
 # run's scratch outside the dev-tooling wave's per-suite isolation — and so
@@ -79,7 +91,7 @@ measured_file="$work_dir/measured.txt"
 
 printf '%-10s %10s %10s %8s %8s %8s %8s\n' "module" "covered" "total" "union%" "test%" "fuzz%" "floor"
 for m in $modules; do
-	[ -f "$repo_root/$m/go.mod" ] || { printf '%-10s %s\n' "$m" "(no module)"; continue; }
+	[ -f "$repo_root/$m/go.mod" ] || { printf '%-10s %s\n' "$m" "(no module)"; check_measurable "$m" "no module exists at $m"; continue; }
 	name="$m"
 	[ "$name" = "." ] && name="root"
 	base="$work_dir/$(printf '%s' "$name" | tr / _)"
@@ -108,13 +120,13 @@ for m in $modules; do
 		fail=1; continue
 	fi
 
-	[ -f "$base.test.cov" ] || { printf '%-10s %s\n' "$m" "no test profile"; continue; }
+	[ -f "$base.test.cov" ] || { printf '%-10s %s\n' "$m" "no test profile"; check_measurable "$m" "the test track wrote no coverage profile"; continue; }
 	cat "$base.test.cov" "$base.fuzz.cov" 2>/dev/null >"$base.union.cov"
 
 	read -r tc tt < <(stmt_counts "$base.test.cov")
 	read -r fc ft < <(stmt_counts "$base.fuzz.cov")
 	read -r uc ut < <(stmt_counts "$base.union.cov")
-	[ "${ut:-0}" -gt 0 ] || { printf '%-10s %s\n' "$m" "no statements"; continue; }
+	[ "${ut:-0}" -gt 0 ] || { printf '%-10s %s\n' "$m" "no statements"; check_measurable "$m" "its profiles counted no statements"; continue; }
 
 	# A union denominator above both tracks means some block was counted twice
 	# because the two builds split it differently. A handful is expected and

--- a/scripts/e2e-webui-turn-controls.sh
+++ b/scripts/e2e-webui-turn-controls.sh
@@ -174,7 +174,15 @@ for value in "$hold" "$rounds"; do
 	fi
 done
 
-run="$(mktemp -d -t serf-e2e-webui.XXXXXX)"
+# An explicit template, not `mktemp -t`: macOS's mktemp ignores TMPDIR for -t
+# and uses the Darwin per-user temp directory instead, which puts the run
+# directory outside the dev-tooling wave's per-suite TMPDIR isolation — and so
+# outside the leftover check that is supposed to catch exactly this.
+tmpbase=${TMPDIR:-/tmp}
+if ! run="$(mktemp -d "${tmpbase%/}/serf-e2e-webui.XXXXXX")"; then
+	echo "e2e-webui-turn-controls: cannot create a run directory under ${tmpbase%/}" >&2
+	exit 1
+fi
 touch "$run/.e2e-webui-turn-controls" # the marker --stop refuses to delete without
 echo "e2e-webui-turn-controls: run directory $run" >&2
 

--- a/scripts/fuzz-coverage-global.sh
+++ b/scripts/fuzz-coverage-global.sh
@@ -268,13 +268,19 @@ case "$go_arch" in
 		;;
 esac
 
-# An explicit template, not `mktemp -t`: macOS's mktemp ignores TMPDIR for -t and
-# uses the Darwin per-user temp directory instead, which puts the scratch outside
-# the dev-tooling wave's per-suite isolation — and so outside the leftover check
-# that is supposed to catch exactly this.
+# An explicit path under TMPDIR, not `mktemp -t`: macOS's mktemp ignores TMPDIR
+# for -t and uses the Darwin per-user temp directory instead, which puts the
+# scratch outside the dev-tooling wave's per-suite isolation — and so outside
+# the leftover check that is supposed to catch exactly this.
 tmpbase=${TMPDIR:-/tmp}
-work="$(mktemp -d "${tmpbase%/}/serf-fuzzcov-global.XXXXXX")"
+# The name is chosen and the trap armed BEFORE the directory exists; see
+# test-coverage-floor.sh for the signal window this closes. $$ is unique among
+# live processes, so concurrent runs cannot collide. A failed mkdir means a
+# stale same-pid leftover this run does not own, so the trap is disarmed
+# before exiting rather than deleting it.
+work="${tmpbase%/}/serf-fuzzcov-global.$$"
 trap 'rm -rf "$work"' EXIT
+mkdir "$work" || { trap - EXIT; die "cannot create scratch directory $work"; }
 plan="$work/targets.tsv"
 groups="$work/groups.tsv"
 global_manifest="$work/global-profiles.tsv"

--- a/scripts/fuzz-coverage.sh
+++ b/scripts/fuzz-coverage.sh
@@ -17,14 +17,20 @@
 set -uo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
-# An explicit template, not `mktemp -t`: macOS's mktemp ignores TMPDIR for -t and
-# uses the Darwin per-user temp directory instead, which puts the scratch outside
-# the dev-tooling wave's per-suite isolation — and so outside the leftover check
-# the trap below is written to satisfy.
+# An explicit path under TMPDIR, not `mktemp -t`: macOS's mktemp ignores TMPDIR
+# for -t and uses the Darwin per-user temp directory instead, which puts the
+# scratch outside the dev-tooling wave's per-suite isolation — and so outside
+# the leftover check the trap below is written to satisfy.
 tmpbase=${TMPDIR:-/tmp}
-profiles_dir="$(mktemp -d "${tmpbase%/}/serf-fuzzcov.XXXXXX")"
-manifest="$profiles_dir/manifest.tsv"
+# The name is chosen and the trap armed BEFORE the directory exists; see
+# test-coverage-floor.sh for the signal window this closes. $$ is unique among
+# live processes, so concurrent runs cannot collide. A failed mkdir means a
+# stale same-pid leftover this run does not own, so the trap is disarmed
+# before exiting rather than deleting it.
+profiles_dir="${tmpbase%/}/serf-fuzzcov.$$"
 trap 'rm -rf "$profiles_dir"' EXIT
+mkdir "$profiles_dir" || { trap - EXIT; echo "fuzz-coverage: cannot create scratch directory $profiles_dir" >&2; exit 1; }
+manifest="$profiles_dir/manifest.tsv"
 
 fail=0
 while IFS=: read -r tag module pkg name cover focus; do

--- a/scripts/test-coverage-floor-selftest.sh
+++ b/scripts/test-coverage-floor-selftest.sh
@@ -56,6 +56,12 @@ done
 # signalled while its scratch directory exists.
 [ -n "${FAKE_GO_SLEEP:-}" ] && sleep "$FAKE_GO_SLEEP"
 [ -n "$prof" ] || { echo "fake go: no -coverprofile in: $*" >&2; exit 2; }
+# FAKE_GO_EMPTY_PROF simulates a run whose profile counts nothing — the shape
+# every module takes when stmt_counts itself breaks (e.g. no python3).
+if [ -n "${FAKE_GO_EMPTY_PROF:-}" ]; then
+	echo "mode: set" >"$prof"
+	exit 0
+fi
 case "$(basename "$PWD")" in
 	repo)  cov=1 ;;   # the "." module: 1 of 4 statements -> 25.0%
 	agent) cov=3 ;;   # 3 of 4 statements -> 75.0%
@@ -183,6 +189,27 @@ assert_has "$floors" ". 99.0" "bless keeps a higher existing floor"
 # A module directory with no go.mod is reported, not silently skipped.
 run --modules "nosuch" >"$out" 2>&1
 assert_has "$out" "(no module)" "a missing module is reported"
+
+# A FLOORED module that cannot be measured is an unenforced ratchet, not a
+# skippable row: under --check it must fail loudly. Without this, renaming or
+# deleting a floored module quietly disabled its floor while check stayed green.
+printf 'nosuch 50.0\n' >"$floors"
+run --modules "nosuch" --check >"$out" 2>&1
+assert_eq "$?" "1" "check fails when a floored module cannot be measured"
+assert_has "$out" "UNMEASURED: nosuch" "the unmeasurable floored module is named"
+
+# ...while a module nobody floored keeps its advisory skip.
+: >"$floors"
+run --modules "nosuch" --check >"$out" 2>&1
+assert_eq "$?" "0" "an unmeasurable module without a floor stays a reported skip"
+
+# The same enforcement covers the profile-counts-nothing shape, which is what
+# EVERY floored module degrades to when stmt_counts itself breaks.
+printf '. 25.0\nagent 75.0\n' >"$floors"
+FAKE_GO_EMPTY_PROF=1 run --check >"$out" 2>&1
+assert_eq "$?" "1" "check fails when a floored module's profile counts no statements"
+assert_has "$out" "no statements" "the empty measurement is reported"
+assert_has "$out" "UNMEASURED: agent" "the floored module with an empty measurement is named"
 
 help_out="$(bash "$script" --help 2>&1)"
 if echo "$help_out" | grep -q "^Usage:" && ! echo "$help_out" | grep -q "^set -uo pipefail"; then

--- a/scripts/test-coverage-floor.sh
+++ b/scripts/test-coverage-floor.sh
@@ -70,6 +70,20 @@ floor_for() { awk -v m="$1" '$1==m {print $2}' "$floors_file" 2>/dev/null; }
 # is unavailable. Reusing the floor_for lookup shape keeps both reads identical.
 measured_for() { awk -v m="$1" '$1==m {print $2}' "$measured_file" 2>/dev/null; }
 
+# check_measurable MODULE WHY — a floored module that cannot be measured is an
+# unenforced ratchet, not a skippable row. Under --check that fails loudly;
+# quietly continuing meant a module that stopped being measured (renamed,
+# profile lost, stmt_counts broken) kept passing on a floor nothing enforced.
+# A module nobody floored keeps its advisory skip.
+check_measurable() {
+	$check || return 0
+	local floor
+	floor="$(floor_for "$1")"
+	[ -n "$floor" ] || return 0
+	echo "    UNMEASURED: $1 has a floor (${floor}%) but $2; the floor is not being enforced" >&2
+	fail=1
+}
+
 
 # An explicit path under TMPDIR, not `mktemp -t`: macOS's mktemp ignores TMPDIR
 # for -t and uses the Darwin per-user temp directory instead, which put every
@@ -97,7 +111,7 @@ measured_file="$profiles_dir/measured.txt"
 : >"$measured_file"
 printf '%-10s %12s %12s %8s %8s\n' "module" "covered" "total" "cov%" "floor"
 for m in $modules; do
-	[ -f "$repo_root/$m/go.mod" ] || { printf '%-10s %s\n' "$m" "(no module)"; continue; }
+	[ -f "$repo_root/$m/go.mod" ] || { printf '%-10s %s\n' "$m" "(no module)"; check_measurable "$m" "no module exists at $m"; continue; }
 	name="$m"
 	[ "$name" = "." ] && name="root"   # or the profile and log land as dotfiles
 	prof="$profiles_dir/$(printf '%s' "$name" | tr / _).cov"
@@ -127,9 +141,9 @@ for m in $modules; do
 		printf '%-10s %s\n' "$m" "TEST FAILED (log: $log)"
 		fail=1; continue
 	fi
-	[ -f "$prof" ] || { printf '%-10s %s\n' "$m" "no profile"; continue; }
+	[ -f "$prof" ] || { printf '%-10s %s\n' "$m" "no profile"; check_measurable "$m" "the run wrote no coverage profile"; continue; }
 	read -r c t < <(stmt_counts "$prof")
-	[ "${t:-0}" -gt 0 ] || { printf '%-10s %s\n' "$m" "no statements"; continue; }
+	[ "${t:-0}" -gt 0 ] || { printf '%-10s %s\n' "$m" "no statements"; check_measurable "$m" "its profile counted no statements"; continue; }
 	pct="$(awk -v c="$c" -v t="$t" 'BEGIN{printf "%.1f", 100*c/t}')"
 	echo "$m $pct" >>"$measured_file"
 	floor="$(floor_for "$m")"

--- a/scripts/web-coverage-floor-selftest.sh
+++ b/scripts/web-coverage-floor-selftest.sh
@@ -19,7 +19,9 @@ floors="$work/floors.txt"
 # A synthetic report: two panes (one wholly untested), one store, and one file
 # sitting directly in src/. The untested pane is the point — it must land in the
 # denominator as 0%, not vanish, which is the false green coverage.include buys.
-cat >"$frontend/coverage/coverage-summary.json" <<JSON
+# It is kept as a template too, so the measuring-path checks below can hand it
+# to the fake npm as "the report this suite run wrote".
+cat >"$work/summary.json" <<JSON
 {
   "total": {"lines": {"total": 0, "covered": 0, "skipped": 0, "pct": 0}},
   "$frontend/src/panes/alpha.tsx": {"lines": {"total": 100, "covered": 50, "skipped": 0, "pct": 50}},
@@ -28,6 +30,7 @@ cat >"$frontend/coverage/coverage-summary.json" <<JSON
   "$frontend/src/auth.ts":         {"lines": {"total": 10,  "covered": 8,  "skipped": 0, "pct": 80}}
 }
 JSON
+cp "$work/summary.json" "$frontend/coverage/coverage-summary.json"
 
 run() { SERF_WEB_FRONTEND_DIR="$frontend" SERF_WEBCOV_FLOORS="$floors" bash "$script" --reuse "$@"; }
 
@@ -85,6 +88,50 @@ rm -f "$frontend/coverage/coverage-summary.json"
 run >"$out" 2>&1
 assert_eq "$?" "1" "a missing coverage summary exits non-zero"
 assert_has "$out" "no coverage summary" "the missing summary is explained"
+
+# ---- the measuring (non --reuse) path, against a fake npm ----
+# The fake stands in for `npm run test:coverage`: FAKE_NPM_REPORT names the
+# summary the run "writes" (vitest's reportOnFailure writes one on red too),
+# and FAKE_NPM_EXIT is the suite's status. No report env means the run died —
+# or reported somewhere else — before writing one.
+fake_bin="$work/bin"
+mkdir -p "$fake_bin"
+cat >"$fake_bin/npm" <<'FAKENPM'
+#!/bin/sh
+if [ -n "${FAKE_NPM_REPORT:-}" ]; then
+	mkdir -p coverage
+	cp "$FAKE_NPM_REPORT" coverage/coverage-summary.json
+fi
+exit "${FAKE_NPM_EXIT:-0}"
+FAKENPM
+chmod +x "$fake_bin/npm"
+measure() { PATH="$fake_bin:$PATH" SERF_WEB_FRONTEND_DIR="$frontend" SERF_WEBCOV_FLOORS="$floors" bash "$script" "$@"; }
+
+# A green suite that writes a fresh report clears its floors.
+printf 'panes 25.0\n' >"$floors"
+FAKE_NPM_REPORT="$work/summary.json" measure --check >"$out" 2>&1
+assert_eq "$?" "0" "a green suite with a fresh report passes check"
+
+# A red suite must fail --check even when the report it left clears every
+# floor: numbers measured under failing tests are not a pass.
+FAKE_NPM_REPORT="$work/summary.json" FAKE_NPM_EXIT=1 measure --check >"$out" 2>&1
+assert_eq "$?" "1" "a red suite fails check even when the numbers clear the floors"
+assert_has "$out" "SUITE FAILED" "the red suite is named as the reason"
+
+# A run that produced no fresh report must not measure the previous run's:
+# the stale summary here clears the floors, and used to pass check silently.
+cp "$work/summary.json" "$frontend/coverage/coverage-summary.json"
+measure --check >"$out" 2>&1
+assert_eq "$?" "1" "a run that wrote no fresh report fails check instead of measuring a stale one"
+assert_has "$out" "no coverage summary" "the missing fresh report is explained"
+
+# --bless from a red suite would ratchet floors onto numbers the tests do not
+# stand behind; it must refuse and leave the floor file alone.
+printf 'panes 25.0\n' >"$floors"
+FAKE_NPM_REPORT="$work/summary.json" FAKE_NPM_EXIT=1 measure --bless >"$out" 2>&1
+assert_eq "$?" "1" "bless refuses when the suite is red"
+assert_has "$out" "refusing" "the refusal is explained"
+assert_eq "$(cat "$floors")" "panes 25.0" "a refused bless leaves the floor file untouched"
 
 # --help prints the whole header and stops at the script body.
 help_out="$(bash "$script" --help 2>&1)"

--- a/scripts/web-coverage-floor-selftest.sh
+++ b/scripts/web-coverage-floor-selftest.sh
@@ -83,6 +83,14 @@ printf 'panes 99.0\n' >"$floors"
 run --bless >"$out" 2>&1
 assert_has "$floors" "panes 99.0" "bless keeps a higher existing floor"
 
+# A hand-written basis note explains why a floor was reset downward, exactly
+# like the two Go floor files. Rewriting a fixed header on every bless deleted
+# that reason the next time anyone raised a floor.
+printf '# why this basis changed: the denominator moved\npanes 25.0\n' >"$floors"
+run --bless >"$out" 2>&1
+assert_has "$floors" "why this basis changed" "bless preserves a hand-written header note"
+assert_has "$floors" "stores 90.0" "bless still records floors alongside the preserved note"
+
 # A missing report under --reuse is a clear failure, not a silent zero.
 rm -f "$frontend/coverage/coverage-summary.json"
 run >"$out" 2>&1

--- a/scripts/web-coverage-floor.sh
+++ b/scripts/web-coverage-floor.sh
@@ -146,9 +146,18 @@ fi
 if $bless; then
 	tmp="$(mktemp "${TMPDIR:-/tmp}/serf-floors.XXXXXX")"
 	{
-		echo "# Frontend (vitest) per-area LINE coverage floors."
-		echo "# Managed by scripts/web-coverage-floor.sh --bless. Raised upward only;"
-		echo "# a downward reset (denominator change, not a regression) is a hand edit."
+		# Carry the file's existing comment header through instead of restating a
+		# fixed one, exactly like the two Go floor scripts: a downward reset is a
+		# hand edit whose comment records WHY the basis changed, and rewriting the
+		# header on every bless deleted that reason the next time anyone raised a
+		# floor.
+		if grep -q '^#' "$floors_file" 2>/dev/null; then
+			awk '/^#/{print; next} {exit}' "$floors_file"
+		else
+			echo "# Frontend (vitest) per-area LINE coverage floors."
+			echo "# Managed by scripts/web-coverage-floor.sh --bless. Raised upward only;"
+			echo "# a downward reset (denominator change, not a regression) is a hand edit."
+		fi
 		while read -r area c t pct; do
 			old="$(floor_for "$area")"; keep="$pct"
 			[ -n "$old" ] && keep="$(awk -v a="$old" -v b="$pct" 'BEGIN{print (a>b)?a:b}')"

--- a/scripts/web-coverage-floor.sh
+++ b/scripts/web-coverage-floor.sh
@@ -54,9 +54,17 @@ done
 summary="$frontend/coverage/coverage-summary.json"
 floor_for() { awk -v a="$1" '$1==a {print $2}' "$floors_file" 2>/dev/null; }
 
+suite_failed=false
 if ! $reuse; then
+	# Delete the previous run's report before measuring. vitest writes a fresh
+	# one on green and (via reportOnFailure) on red, so any summary present
+	# after the run is this run's; without this, a run that died before
+	# reporting — or reported somewhere else — was silently measured against
+	# the previous run's numbers.
+	rm -f "$summary"
 	if ! ( cd "$frontend" && npm run test:coverage ) >/dev/null 2>&1; then
 		echo "web coverage: SUITE FAILED (see: cd $frontend && npm run test:coverage)" >&2
+		suite_failed=true
 		# reportOnFailure keeps a usable report on a red suite, so fall through and
 		# still report the numbers rather than losing the whole measurement.
 		[ -f "$summary" ] || exit 1
@@ -120,6 +128,20 @@ while read -r area c t pct; do
 		fi
 	fi
 done <"$rollup_file"
+
+# A red suite's numbers are reported above for the eyeball, but they are not a
+# pass and they are not a basis: floors it clears prove nothing about the
+# tests, and floors blessed from it would ratchet onto unverified numbers.
+if $suite_failed; then
+	if $check; then
+		echo "    the suite is red, so this measurement cannot pass --check" >&2
+		fail=1
+	fi
+	if $bless; then
+		echo "refusing to --bless floors from a red suite" >&2
+		exit 1
+	fi
+fi
 
 if $bless; then
 	tmp="$(mktemp "${TMPDIR:-/tmp}/serf-floors.XXXXXX")"


### PR DESCRIPTION
Four confirmed tooling bugs from the adversarial review, plus one small same-family cleanup. One commit per fix; every touched selftest extended and re-run.

## 1. web-coverage-floor.sh: a red or report-less suite run could pass --check and bless
When `npm run test:coverage` failed, the script printed "SUITE FAILED" and fell through without failing, so `--check` exited 0 off a (possibly stale) `coverage-summary.json`, and `--bless` blessed from the same state. Nothing verified the summary was written by this run.

Now the previous report is deleted before the suite runs (a run that writes no fresh report hits the "no coverage summary" failure instead of measuring a stale one), a red suite fails `--check` loudly, and `--bless` refuses on red without touching the floor file. Selftest grows a measuring-path section behind a fake npm covering: green+fresh passes, red fails even when the numbers clear the floors, report-less fails instead of measuring stale, and a red bless refuses leaving the floor file byte-identical.

## 2. test-coverage-floor.sh / coverage-union.sh: measurement-error paths degraded --check to green
The "(no module)", "no profile"/"no test profile", and "no statements" rows continued without `fail=1`, so a floored module that stopped being measured — renamed module, lost profile, or `stmt_counts` breaking (e.g. no python3) and turning every row into "no statements" — left its floor silently unenforced.

Both scripts now route those paths through `check_measurable`: under `--check`, a module with a floor entry fails with an `UNMEASURED:` line naming it and why; modules nobody floored keep their advisory skip. Both selftests grow the unmeasurable-floored-module cases, including the everything-counts-no-statements shape.

## 3. web-coverage-floor.sh --bless destroyed hand-written floor-file notes
Bless rewrote a fixed three-line header every time, deleting the comment a deliberate downward reset leaves to record why the basis changed — despite the script's own header promising the Go floor files' behavior. Bless now carries an existing comment header through, matching `test-coverage-floor.sh` and `coverage-union.sh`; the selftest gains the same note-preservation assertion the Go selftests carry.

## 4. e2e-webui-turn-controls.sh used `mktemp -d -t`
The exact TMPDIR-ignoring spelling this repo purged elsewhere: run directories escaped the dev-tooling wave's per-suite TMPDIR isolation on macOS. Replaced with the standard checked explicit template under `${TMPDIR:-/tmp}`, and the script's `mktempAllowedScripts` entry is deleted so the audit enforces the fix.

## 5. fuzz-coverage.sh / fuzz-coverage-global.sh: mktemp-then-trap signal window
Both still created their scratch several lines before arming the EXIT trap that removes it — the window PR #78 closed in the coverage ratchets. Applied the same pattern: pre-chosen `$$` name, trap armed first, then `mkdir`, with the trap disarmed on mkdir failure so a stale same-pid leftover this run does not own is left in place rather than deleted.

## Verification
- `web-coverage-floor-selftest.sh`: 26 checks, 0 failed
- `test-coverage-floor-selftest.sh`: 37 checks, 0 failed (SIGTERM/INT/HUP kill runs leave no scratch)
- `coverage-union-selftest.sh`: 20 checks, 0 failed (SIGTERM/INT/HUP kill runs leave no scratch)
- `e2e-webui-turn-controls-selftest.sh`: 61 checks, 0 failed
- `fuzz-coverage-global-selftest.sh`: 147 checks, 0 failed
- `go test .` at repo root (scriptmktemp/gate audits): ok
- shellcheck on every changed script: no new findings (pre-existing info-level notes on untouched lines unchanged)

Each behavioral fix was written test-first: the new selftest assertions were run and observed failing against the unfixed scripts before the fix landed.

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU