### PR TITLE
cmd/serf: stop the fake LLM reading the system prompt as a delivered frame

### DIFF
--- a/agent/prompts/sections/background-jobs.md
+++ b/agent/prompts/sections/background-jobs.md
@@ -70,6 +70,7 @@ For watch-driven tasks, complete this sequence:
 The observer callback is completion evidence for the observer's task; after it
 arrives, one final result message is enough unless the user asked for audit
 details. It reaches you as that observer delegate's ordinary terminal
-delegate-notification frame carrying its result packet, and it wakes you on its
-own, so ending your turn is how you wait for it. Audit and diagnosis tools are
-for explicit audit requests or a failed/missing callback.
+`<delegate-notification delegate_id="dlg_...">` frame carrying its result
+packet, and it wakes you on its own, so ending your turn is how you wait for
+it. Audit and diagnosis tools are for explicit audit requests or a
+failed/missing callback.

--- a/cmd/serf/run_drain_nested_test.go
+++ b/cmd/serf/run_drain_nested_test.go
@@ -38,11 +38,12 @@ func TestRunDrainsNestedDelegateSubtree(t *testing.T) {
 
 	step := func(req llm.Request) llm.Response {
 		text := requestFullText(req)
+		delivered := requestDeliveredText(req)
 		switch {
 		case strings.Contains(text, rootPrompt):
 			// Root coordinator.
 			switch {
-			case strings.Contains(text, "<delegate-notification"):
+			case strings.Contains(delivered, "<delegate-notification"):
 				return scriptedCommunicate(finalMsg)
 			case strings.Contains(text, "COORD-TASK"):
 				return scriptedCommunicate("root waiting on coordinator")
@@ -52,7 +53,7 @@ func TestRunDrainsNestedDelegateSubtree(t *testing.T) {
 		case strings.Contains(text, "COORD-TASK"):
 			// Mid-tree coordinator: delegate the worker, then wait for it.
 			switch {
-			case strings.Contains(text, "<delegate-notification"):
+			case strings.Contains(delivered, "<delegate-notification"):
 				return scriptedCommunicate("coordinator done")
 			case strings.Contains(text, "WORKER-TASK"):
 				return scriptedCommunicate("coordinator waiting on worker")

--- a/cmd/serf/run_drain_prompt_literal_test.go
+++ b/cmd/serf/run_drain_prompt_literal_test.go
@@ -91,7 +91,6 @@ func headString(s string, n int) string {
 		return strconv.Quote(s)
 	}
 	return strconv.Quote(s[:n]) + "... (" + strconv.Itoa(len(s)) + " bytes)"
-
 }
 
 // TestRunDrainsDelegatedJobTreeWhenSystemPromptNamesTheFrame is the zzpw
@@ -117,6 +116,21 @@ func TestRunDrainsManagedShellWhenSystemPromptNamesTheJobFrame(t *testing.T) {
 		t.Run(layout.name, func(t *testing.T) {
 			adapter := managedShellDrainScenario(t, "printf shell-ok", "completed",
 				namePromptLiteral(t, jobFramePromptLiteral, layout.asUser))
+			assertPromptLiteralReachedOpeningMessage(t, adapter, jobFramePromptLiteral)
+		})
+	}
+}
+
+// TestRunDrainCountsOnlyDeliveredJobFramesWhenSystemPromptNamesOne guards the
+// five running-count assertions in the chained-shell drain. Their failure mode
+// is the worse one: a prompt literal shifts every count by one, so the drain
+// still runs and the test still measures it, just wrongly. Nothing else covers
+// them — no prompt section names <job-notification>, so reverting those five
+// matchers to requestFullText leaves the whole drain suite green.
+func TestRunDrainCountsOnlyDeliveredJobFramesWhenSystemPromptNamesOne(t *testing.T) {
+	for _, layout := range promptLayouts {
+		t.Run(layout.name, func(t *testing.T) {
+			adapter := chainedShellDrainScenario(t, namePromptLiteral(t, jobFramePromptLiteral, layout.asUser))
 			assertPromptLiteralReachedOpeningMessage(t, adapter, jobFramePromptLiteral)
 		})
 	}
@@ -164,7 +178,7 @@ func TestSystemPromptOccupiesOnlyTheOpeningMessage(t *testing.T) {
 					t.Fatalf("request %d had no messages", i)
 				}
 				if !strings.Contains(req.Messages[0].Text(), sentinel) {
-					t.Fatalf("request %d: system prompt is not in message 0 (role %q); requestDeliveredText would now skip a real message instead of the prompt. message 0 opens %s",
+					t.Fatalf("request %d: system prompt is not in message 0 (role %q); requestDeliveredText skips message 0 to exclude the prompt, so it now excludes the wrong message and lets prompt text back into a delivery match. message 0 opens %s",
 						i, req.Messages[0].Role, headString(req.Messages[0].Text(), 200))
 				}
 				for j, m := range req.Messages[1:] {

--- a/cmd/serf/run_drain_prompt_literal_test.go
+++ b/cmd/serf/run_drain_prompt_literal_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -77,9 +78,20 @@ func assertPromptLiteralReachedOpeningMessage(t *testing.T, adapter *scriptedPro
 		t.Fatal("first request had no messages")
 	}
 	if !strings.Contains(reqs[0].Messages[0].Text(), literal) {
-		t.Fatalf("wire literal %q never reached the system prompt in message 0, so this test proves nothing; message 0 = %q",
-			literal, reqs[0].Messages[0].Text())
+		t.Fatalf("wire literal %q never reached the system prompt in message 0, so this test proves nothing; message 0 (role %q) opens %s",
+			literal, reqs[0].Messages[0].Role, headString(reqs[0].Messages[0].Text(), 200))
 	}
+}
+
+// headString renders the opening of s for a failure message. The assembled
+// system prompt is tens of kilobytes; a failure that dumps it whole buries the
+// line that explains it.
+func headString(s string, n int) string {
+	if len(s) <= n {
+		return strconv.Quote(s)
+	}
+	return strconv.Quote(s[:n]) + "... (" + strconv.Itoa(len(s)) + " bytes)"
+
 }
 
 // TestRunDrainsDelegatedJobTreeWhenSystemPromptNamesTheFrame is the zzpw
@@ -152,8 +164,8 @@ func TestSystemPromptOccupiesOnlyTheOpeningMessage(t *testing.T) {
 					t.Fatalf("request %d had no messages", i)
 				}
 				if !strings.Contains(req.Messages[0].Text(), sentinel) {
-					t.Fatalf("request %d: system prompt is not in message 0 (role %q); requestDeliveredText would now skip a real message instead of the prompt. message 0 = %q",
-						i, req.Messages[0].Role, req.Messages[0].Text())
+					t.Fatalf("request %d: system prompt is not in message 0 (role %q); requestDeliveredText would now skip a real message instead of the prompt. message 0 opens %s",
+						i, req.Messages[0].Role, headString(req.Messages[0].Text(), 200))
 				}
 				for j, m := range req.Messages[1:] {
 					if strings.Contains(m.Text(), sentinel) {

--- a/cmd/serf/run_drain_prompt_literal_test.go
+++ b/cmd/serf/run_drain_prompt_literal_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"primeradiant.com/serf/llm"
+)
+
+// The system prompt is text in the request, so a prompt section that spells a
+// wire frame literally is indistinguishable from a delivered frame to anything
+// matching on substrings (kata zzpw). These tests inject such a literal through
+// the real --system-prompt-append path and assert the drain still works, so a
+// prompt author can name a frame without breaking an end-to-end test.
+const (
+	delegateFramePromptLiteral = `<delegate-notification delegate_id="x">`
+	jobFramePromptLiteral      = `<job-notification job_id="x">`
+)
+
+// promptLayouts covers both request layouts buildModelRequest can produce. Under
+// SystemPromptAsUser the prompt is fused into the opening user turn instead of
+// getting its own system-role message, so a fix that merely filters system-role
+// messages would still leak the literal in the second case.
+var promptLayouts = []struct {
+	name   string
+	asUser bool
+}{
+	{name: "system role message", asUser: false},
+	{name: "fused into opening user turn", asUser: true},
+}
+
+// writeSystemPromptAppend writes a --system-prompt-append file carrying text and
+// returns its path. Prompt assembly silently skips an unreadable append path
+// (agent/session_prompts.go), so every caller must also confirm the text
+// actually reached the request; assertPromptLiteralReachedOpeningMessage is how.
+func writeSystemPromptAppend(t *testing.T, text string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "wire-literal-section.md")
+	if err := os.WriteFile(path, []byte(text), 0o600); err != nil {
+		t.Fatalf("write system prompt append: %v", err)
+	}
+	return path
+}
+
+// wireLiteralSection is prompt prose naming a frame the way a real section
+// under agent/prompts/sections/ would.
+func wireLiteralSection(literal string) string {
+	return "When the work finishes, its result reaches you as an ordinary terminal\n" +
+		"`" + literal + "` frame carrying the result packet.\n"
+}
+
+// namePromptLiteral installs the wire literal as an appended prompt section and
+// selects the request layout under test.
+func namePromptLiteral(t *testing.T, literal string, asUser bool) func(*runConfig) {
+	t.Helper()
+	path := writeSystemPromptAppend(t, wireLiteralSection(literal))
+	return func(cfg *runConfig) {
+		cfg.systemPromptAppend = []string{path}
+		cfg.systemPromptAsUser = asUser
+	}
+}
+
+// assertPromptLiteralReachedOpeningMessage fails unless the literal really is in
+// the assembled system prompt, in message 0. Without it a mistyped append path
+// would leave these tests passing vacuously, proving nothing about the hazard.
+func assertPromptLiteralReachedOpeningMessage(t *testing.T, adapter *scriptedProvider, literal string) {
+	t.Helper()
+	reqs := adapter.Requests()
+	if len(reqs) == 0 {
+		t.Fatal("scripted provider saw no requests")
+	}
+	if len(reqs[0].Messages) == 0 {
+		t.Fatal("first request had no messages")
+	}
+	if !strings.Contains(reqs[0].Messages[0].Text(), literal) {
+		t.Fatalf("wire literal %q never reached the system prompt in message 0, so this test proves nothing; message 0 = %q",
+			literal, reqs[0].Messages[0].Text())
+	}
+}
+
+// TestRunDrainsDelegatedJobTreeWhenSystemPromptNamesTheFrame is the zzpw
+// acceptance: the delegate drain must survive a prompt section that spells
+// <delegate-notification> literally. Before the fix the coordinator's fake LLM
+// matched the literal on its very first round, answered as though a delegate had
+// already completed, and never dispatched one.
+func TestRunDrainsDelegatedJobTreeWhenSystemPromptNamesTheFrame(t *testing.T) {
+	for _, layout := range promptLayouts {
+		t.Run(layout.name, func(t *testing.T) {
+			adapter := delegateDrainScenario(t, namePromptLiteral(t, delegateFramePromptLiteral, layout.asUser))
+			assertPromptLiteralReachedOpeningMessage(t, adapter, delegateFramePromptLiteral)
+		})
+	}
+}
+
+// TestRunDrainsManagedShellWhenSystemPromptNamesTheJobFrame is the same hazard
+// on the job frame, which the kata does not name. The managed-shell steps both
+// assert on and count "<job-notification", so a prompt literal there shifts a
+// count by one rather than losing a dispatch.
+func TestRunDrainsManagedShellWhenSystemPromptNamesTheJobFrame(t *testing.T) {
+	for _, layout := range promptLayouts {
+		t.Run(layout.name, func(t *testing.T) {
+			adapter := managedShellDrainScenario(t, "printf shell-ok", "completed",
+				namePromptLiteral(t, jobFramePromptLiteral, layout.asUser))
+			assertPromptLiteralReachedOpeningMessage(t, adapter, jobFramePromptLiteral)
+		})
+	}
+}
+
+// TestSystemPromptOccupiesOnlyTheOpeningMessage pins the invariant that
+// requestDeliveredText rests on: buildModelRequest (agent/session_model_call.go)
+// puts the whole system prompt in Messages[0] and nowhere else, in both request
+// layouts. requestDeliveredText skips the first message, not "the system
+// prompt"; those coincide only while this holds. If a future assembly path ever
+// left message 0 carrying real conversation instead, a delivery matcher would
+// silently ignore a genuinely delivered frame — a test passing when it should
+// fail, which is the same false green kata zzpw is about. This test is the loud
+// tripwire for that, and it uses a sentinel of its own rather than any prompt
+// wording, so editing a prompt section cannot break it.
+func TestSystemPromptOccupiesOnlyTheOpeningMessage(t *testing.T) {
+	const sentinel = "ZZPW-SYSTEM-PROMPT-SENTINEL"
+	for _, layout := range promptLayouts {
+		t.Run(layout.name, func(t *testing.T) {
+			adapter := &scriptedProvider{name: "openai", steps: []func(llm.Request) llm.Response{
+				func(llm.Request) llm.Response { return scriptedCommunicate("done") },
+			}}
+			installRunScriptedProvider(t, adapter)
+
+			var stdout, stderr bytes.Buffer
+			err := run(context.Background(), runConfig{
+				prompt:             "answer immediately",
+				model:              "openai/gpt-test",
+				workDir:            t.TempDir(),
+				systemPromptAppend: []string{writeSystemPromptAppend(t, sentinel+"\n")},
+				systemPromptAsUser: layout.asUser,
+				stdout:             &stdout,
+				stderr:             &stderr,
+			})
+			if err != nil {
+				t.Fatalf("run: %v\nstderr: %s", err, stderr.String())
+			}
+
+			reqs := adapter.Requests()
+			if len(reqs) == 0 {
+				t.Fatal("scripted provider saw no requests")
+			}
+			for i, req := range reqs {
+				if len(req.Messages) == 0 {
+					t.Fatalf("request %d had no messages", i)
+				}
+				if !strings.Contains(req.Messages[0].Text(), sentinel) {
+					t.Fatalf("request %d: system prompt is not in message 0 (role %q); requestDeliveredText would now skip a real message instead of the prompt. message 0 = %q",
+						i, req.Messages[0].Role, req.Messages[0].Text())
+				}
+				for j, m := range req.Messages[1:] {
+					if strings.Contains(m.Text(), sentinel) {
+						t.Fatalf("request %d: system prompt also appears in message %d (role %q); requestDeliveredText cannot exclude the prompt by skipping message 0 alone",
+							i, j+1, m.Role)
+					}
+				}
+			}
+		})
+	}
+}

--- a/cmd/serf/run_drain_test.go
+++ b/cmd/serf/run_drain_test.go
@@ -169,7 +169,6 @@ func TestRunDrainsDelegatedJobTreeBeforeExit(t *testing.T) {
 // choreography. It returns the scripted provider so a variant can inspect the
 // requests the session actually built.
 func delegateDrainScenario(t *testing.T, tweak func(*runConfig)) *scriptedProvider {
-	t.Helper()
 	tmp := t.TempDir()
 	childArtifact := filepath.Join(tmp, "child-artifact.txt")
 
@@ -266,7 +265,6 @@ func TestRunDrainsManagedShellBeforeExit(t *testing.T) {
 // the scripted provider so a variant can inspect the requests the session
 // actually built.
 func managedShellDrainScenario(t *testing.T, command, wantStatus string, tweak func(*runConfig)) *scriptedProvider {
-	t.Helper()
 	output := "shell-ok"
 	exit := 0
 	if wantStatus == "failed" {
@@ -321,6 +319,16 @@ func managedShellDrainScenario(t *testing.T, command, wantStatus string, tweak f
 }
 
 func TestRunDrainContinuesWhenNotificationTurnStartsAnotherShell(t *testing.T) {
+	chainedShellDrainScenario(t, nil)
+}
+
+// chainedShellDrainScenario drives two chained managed shells and asserts the
+// running count of delivered job notifications at every round. tweak, when
+// non-nil, adjusts the run config before the run so a variant can change how the
+// request is assembled without restating the choreography. It returns the
+// scripted provider so a variant can inspect the requests the session actually
+// built.
+func chainedShellDrainScenario(t *testing.T, tweak func(*runConfig)) *scriptedProvider {
 	// Shell A is gated so it cannot reach terminal completion until the drain
 	// starts; otherwise its notification can beat the tool-result model round
 	// and be folded into that request. Shell B needs no gate: it is launched
@@ -375,14 +383,17 @@ func TestRunDrainContinuesWhenNotificationTurnStartsAnotherShell(t *testing.T) {
 	installRunScriptedProvider(t, adapter)
 
 	var stdout, stderr bytes.Buffer
-	err := run(context.Background(), runConfig{
+	cfg := runConfig{
 		prompt:  "run chained managed shells and handle both completions",
 		model:   "openai/gpt-test",
 		workDir: t.TempDir(),
 		stdout:  &stdout,
 		stderr:  &stderr,
-	})
-	if err != nil {
+	}
+	if tweak != nil {
+		tweak(&cfg)
+	}
+	if err := run(context.Background(), cfg); err != nil {
 		t.Fatalf("run: %v\nstderr: %s", err, stderr.String())
 	}
 	if got := stdout.String(); got != "all shell work complete\n" {
@@ -391,4 +402,5 @@ func TestRunDrainContinuesWhenNotificationTurnStartsAnotherShell(t *testing.T) {
 	if got := len(adapter.Requests()); got != 5 {
 		t.Fatalf("model requests = %d, want exactly five", got)
 	}
+	return adapter
 }

--- a/cmd/serf/run_drain_test.go
+++ b/cmd/serf/run_drain_test.go
@@ -21,11 +21,43 @@ import (
 
 // requestFullText concatenates every request message's text, tool-call
 // arguments, and tool-result content so a scripted step can route on any of
-// them (delegate task text lives in the assistant tool-call arguments; the
-// re-drive turn is marked by a <job-notification> user message).
+// them (delegate task text lives in the assistant tool-call arguments).
+//
+// It includes the system prompt, so it answers "does this text appear anywhere
+// in the request", never "was this delivered to me". Route the session's own
+// task text on it; ask about arriving notification frames with
+// requestDeliveredText instead.
 func requestFullText(req llm.Request) string {
+	return messagesText(req.Messages)
+}
+
+// requestDeliveredText concatenates everything the session delivered to the
+// model after the opening message — the view a scripted step needs to ask
+// whether a notification frame has arrived.
+//
+// The system prompt is text in the request like any other, so matching a wire
+// frame over the whole request cannot tell a delivered frame from a prompt
+// section that merely names one; that is kata zzpw, which cost two mystifying
+// end-to-end failures. The prompt cannot be excluded by role: under
+// SystemPromptAsUser buildModelRequest fuses it into the opening user turn,
+// where it looks like any other user message. What is true in every layout is
+// that buildModelRequest (agent/session_model_call.go) puts the prompt in
+// message 0 and nowhere else, and a notification is never the opening message.
+// So the boundary is positional, and because it is an invariant of the assembly
+// rather than a property of the request,
+// TestSystemPromptOccupiesOnlyTheOpeningMessage pins it: if it ever stops
+// holding, that test fails loudly instead of this helper quietly skipping a real
+// delivered frame.
+func requestDeliveredText(req llm.Request) string {
+	if len(req.Messages) == 0 {
+		return ""
+	}
+	return messagesText(req.Messages[1:])
+}
+
+func messagesText(messages []llm.Message) string {
 	var b strings.Builder
-	for _, m := range req.Messages {
+	for _, m := range messages {
 		b.WriteString(m.Text())
 		b.WriteByte('\n')
 		for _, p := range m.Content {
@@ -134,8 +166,9 @@ func TestRunDrainsDelegatedJobTreeBeforeExit(t *testing.T) {
 // delegate ran to completion and its notification produced the coordinator's
 // real final answer. tweak, when non-nil, adjusts the run config before the run
 // so a variant can change how the request is assembled without restating the
-// choreography.
-func delegateDrainScenario(t *testing.T, tweak func(*runConfig)) {
+// choreography. It returns the scripted provider so a variant can inspect the
+// requests the session actually built.
+func delegateDrainScenario(t *testing.T, tweak func(*runConfig)) *scriptedProvider {
 	t.Helper()
 	tmp := t.TempDir()
 	childArtifact := filepath.Join(tmp, "child-artifact.txt")
@@ -148,10 +181,11 @@ func delegateDrainScenario(t *testing.T, tweak func(*runConfig)) {
 
 	step := func(req llm.Request) llm.Response {
 		text := requestFullText(req)
+		delivered := requestDeliveredText(req)
 		isRoot := strings.Contains(text, rootPrompt)
 		if isRoot {
 			switch {
-			case strings.Contains(text, "<delegate-notification"):
+			case strings.Contains(delivered, "<delegate-notification"):
 				// The delegate finished and its completion was drained back to the
 				// coordinator: emit the real final answer.
 				return scriptedCommunicate(finalMsg)
@@ -177,7 +211,8 @@ func delegateDrainScenario(t *testing.T, tweak func(*runConfig)) {
 	for range 16 {
 		steps = append(steps, step)
 	}
-	installRunScriptedProvider(t, &scriptedProvider{name: "openai", steps: steps})
+	adapter := &scriptedProvider{name: "openai", steps: steps}
+	installRunScriptedProvider(t, adapter)
 
 	var stdout, stderr bytes.Buffer
 	cfg := runConfig{
@@ -205,6 +240,7 @@ func delegateDrainScenario(t *testing.T, tweak func(*runConfig)) {
 	if strings.Contains(stderr.String(), "stopped_by_parent") {
 		t.Fatalf("child was SIGKILLed by Close() (stopped_by_parent) instead of draining to completion; stderr=%s", stderr.String())
 	}
+	return adapter
 }
 
 func TestRunDrainsManagedShellBeforeExit(t *testing.T) {
@@ -226,8 +262,10 @@ func TestRunDrainsManagedShellBeforeExit(t *testing.T) {
 // managedShellDrainScenario drives the managed-shell drain and asserts the
 // terminal job notification reached the model on its own third round. tweak,
 // when non-nil, adjusts the run config before the run so a variant can change
-// how the request is assembled without restating the choreography.
-func managedShellDrainScenario(t *testing.T, command, wantStatus string, tweak func(*runConfig)) {
+// how the request is assembled without restating the choreography. It returns
+// the scripted provider so a variant can inspect the requests the session
+// actually built.
+func managedShellDrainScenario(t *testing.T, command, wantStatus string, tweak func(*runConfig)) *scriptedProvider {
 	t.Helper()
 	output := "shell-ok"
 	exit := 0
@@ -238,19 +276,19 @@ func managedShellDrainScenario(t *testing.T, command, wantStatus string, tweak f
 	installHeldRunShell(t, newHeldShellExecutor(command, output, exit))
 	adapter := &scriptedProvider{name: "openai", steps: []func(llm.Request) llm.Response{
 		func(req llm.Request) llm.Response {
-			if strings.Contains(requestFullText(req), "<job-notification") {
+			if strings.Contains(requestDeliveredText(req), "<job-notification") {
 				t.Fatal("initial request unexpectedly contained a job notification")
 			}
 			return scriptedToolCalls(scriptedShellCall("shell_1", command, "background"))
 		},
 		func(req llm.Request) llm.Response {
-			if strings.Contains(requestFullText(req), "<job-notification") {
+			if strings.Contains(requestDeliveredText(req), "<job-notification") {
 				t.Fatal("tool-result request unexpectedly contained a job notification")
 			}
 			return scriptedCommunicate("waiting for shell")
 		},
 		func(req llm.Request) llm.Response {
-			text := requestFullText(req)
+			text := requestDeliveredText(req)
 			if !strings.Contains(text, "<job-notification") || !strings.Contains(text, `job_type="shell"`) || !strings.Contains(text, `status="`+wantStatus+`"`) {
 				t.Fatalf("notification request missing terminal shell status %q:\n%s", wantStatus, text)
 			}
@@ -279,6 +317,7 @@ func managedShellDrainScenario(t *testing.T, command, wantStatus string, tweak f
 	if got := len(adapter.Requests()); got != 3 {
 		t.Fatalf("model requests = %d, want exactly three", got)
 	}
+	return adapter
 }
 
 func TestRunDrainContinuesWhenNotificationTurnStartsAnotherShell(t *testing.T) {
@@ -298,31 +337,31 @@ func TestRunDrainContinuesWhenNotificationTurnStartsAnotherShell(t *testing.T) {
 	jobIDPattern := regexp.MustCompile(`job_id="([^"]+)"`)
 	adapter := &scriptedProvider{name: "openai", steps: []func(llm.Request) llm.Response{
 		func(req llm.Request) llm.Response {
-			if got := strings.Count(requestFullText(req), "<job-notification"); got != 0 {
+			if got := strings.Count(requestDeliveredText(req), "<job-notification"); got != 0 {
 				t.Fatalf("initial request notification count = %d, want 0", got)
 			}
 			return scriptedToolCalls(scriptedShellCall("shell_a", shellACommand, "background"))
 		},
 		func(req llm.Request) llm.Response {
-			if got := strings.Count(requestFullText(req), "<job-notification"); got != 0 {
+			if got := strings.Count(requestDeliveredText(req), "<job-notification"); got != 0 {
 				t.Fatalf("shell A tool-result request notification count = %d, want 0", got)
 			}
 			return scriptedCommunicate("waiting for A")
 		},
 		func(req llm.Request) llm.Response {
-			if got := strings.Count(requestFullText(req), "<job-notification"); got != 1 {
+			if got := strings.Count(requestDeliveredText(req), "<job-notification"); got != 1 {
 				t.Fatalf("shell A notification request count = %d, want 1", got)
 			}
 			return scriptedToolCalls(scriptedShellCall("shell_b", "printf shell-b", "background"))
 		},
 		func(req llm.Request) llm.Response {
-			if got := strings.Count(requestFullText(req), "<job-notification"); got != 1 {
+			if got := strings.Count(requestDeliveredText(req), "<job-notification"); got != 1 {
 				t.Fatalf("shell B tool-result request notification count = %d, want only A's notification", got)
 			}
 			return scriptedCommunicate("waiting for B")
 		},
 		func(req llm.Request) llm.Response {
-			text := requestFullText(req)
+			text := requestDeliveredText(req)
 			if got := strings.Count(text, "<job-notification"); got != 2 {
 				t.Fatalf("shell B notification request count = %d, want A and B", got)
 			}

--- a/cmd/serf/run_drain_test.go
+++ b/cmd/serf/run_drain_test.go
@@ -127,6 +127,16 @@ func installHeldRunShell(t *testing.T, executor *heldShellExecutor) {
 // produced on the post-completion <delegate-notification> turn, so its presence on
 // stdout proves the drain ran.
 func TestRunDrainsDelegatedJobTreeBeforeExit(t *testing.T) {
+	delegateDrainScenario(t, nil)
+}
+
+// delegateDrainScenario drives the delegate-drain scenario and asserts the
+// delegate ran to completion and its notification produced the coordinator's
+// real final answer. tweak, when non-nil, adjusts the run config before the run
+// so a variant can change how the request is assembled without restating the
+// choreography.
+func delegateDrainScenario(t *testing.T, tweak func(*runConfig)) {
+	t.Helper()
 	tmp := t.TempDir()
 	childArtifact := filepath.Join(tmp, "child-artifact.txt")
 
@@ -170,14 +180,18 @@ func TestRunDrainsDelegatedJobTreeBeforeExit(t *testing.T) {
 	installRunScriptedProvider(t, &scriptedProvider{name: "openai", steps: steps})
 
 	var stdout, stderr bytes.Buffer
-	err := run(context.Background(), runConfig{
+	cfg := runConfig{
 		prompt:  rootPrompt + ": delegate the build to a subagent and report BUILD-COMPLETE when it finishes.",
 		model:   "openai/gpt-test",
 		workDir: tmp,
 		verbose: true,
 		stdout:  &stdout,
 		stderr:  &stderr,
-	})
+	}
+	if tweak != nil {
+		tweak(&cfg)
+	}
+	err := run(context.Background(), cfg)
 	if err != nil {
 		t.Fatalf("run: %v\nstderr: %s", err, stderr.String())
 	}
@@ -204,54 +218,66 @@ func TestRunDrainsManagedShellBeforeExit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := "shell-ok"
-			exit := 0
-			if tt.wantStatus == "failed" {
-				output = "shell-failed"
-				exit = 7
-			}
-			installHeldRunShell(t, newHeldShellExecutor(tt.command, output, exit))
-			adapter := &scriptedProvider{name: "openai", steps: []func(llm.Request) llm.Response{
-				func(req llm.Request) llm.Response {
-					if strings.Contains(requestFullText(req), "<job-notification") {
-						t.Fatal("initial request unexpectedly contained a job notification")
-					}
-					return scriptedToolCalls(scriptedShellCall("shell_1", tt.command, "background"))
-				},
-				func(req llm.Request) llm.Response {
-					if strings.Contains(requestFullText(req), "<job-notification") {
-						t.Fatal("tool-result request unexpectedly contained a job notification")
-					}
-					return scriptedCommunicate("waiting for shell")
-				},
-				func(req llm.Request) llm.Response {
-					text := requestFullText(req)
-					if !strings.Contains(text, "<job-notification") || !strings.Contains(text, `job_type="shell"`) || !strings.Contains(text, `status="`+tt.wantStatus+`"`) {
-						t.Fatalf("notification request missing terminal shell status %q:\n%s", tt.wantStatus, text)
-					}
-					return scriptedCommunicate("shell notification handled")
-				},
-			}}
-			installRunScriptedProvider(t, adapter)
-
-			var stdout, stderr bytes.Buffer
-			err := run(context.Background(), runConfig{
-				prompt:  "run the managed shell and handle its completion",
-				model:   "openai/gpt-test",
-				workDir: t.TempDir(),
-				stdout:  &stdout,
-				stderr:  &stderr,
-			})
-			if err != nil {
-				t.Fatalf("run: %v\nstderr: %s", err, stderr.String())
-			}
-			if got := stdout.String(); !strings.Contains(got, "shell notification handled") {
-				t.Fatalf("stdout = %q, want final notification-turn result", got)
-			}
-			if got := len(adapter.Requests()); got != 3 {
-				t.Fatalf("model requests = %d, want exactly three", got)
-			}
+			managedShellDrainScenario(t, tt.command, tt.wantStatus, nil)
 		})
+	}
+}
+
+// managedShellDrainScenario drives the managed-shell drain and asserts the
+// terminal job notification reached the model on its own third round. tweak,
+// when non-nil, adjusts the run config before the run so a variant can change
+// how the request is assembled without restating the choreography.
+func managedShellDrainScenario(t *testing.T, command, wantStatus string, tweak func(*runConfig)) {
+	t.Helper()
+	output := "shell-ok"
+	exit := 0
+	if wantStatus == "failed" {
+		output = "shell-failed"
+		exit = 7
+	}
+	installHeldRunShell(t, newHeldShellExecutor(command, output, exit))
+	adapter := &scriptedProvider{name: "openai", steps: []func(llm.Request) llm.Response{
+		func(req llm.Request) llm.Response {
+			if strings.Contains(requestFullText(req), "<job-notification") {
+				t.Fatal("initial request unexpectedly contained a job notification")
+			}
+			return scriptedToolCalls(scriptedShellCall("shell_1", command, "background"))
+		},
+		func(req llm.Request) llm.Response {
+			if strings.Contains(requestFullText(req), "<job-notification") {
+				t.Fatal("tool-result request unexpectedly contained a job notification")
+			}
+			return scriptedCommunicate("waiting for shell")
+		},
+		func(req llm.Request) llm.Response {
+			text := requestFullText(req)
+			if !strings.Contains(text, "<job-notification") || !strings.Contains(text, `job_type="shell"`) || !strings.Contains(text, `status="`+wantStatus+`"`) {
+				t.Fatalf("notification request missing terminal shell status %q:\n%s", wantStatus, text)
+			}
+			return scriptedCommunicate("shell notification handled")
+		},
+	}}
+	installRunScriptedProvider(t, adapter)
+
+	var stdout, stderr bytes.Buffer
+	cfg := runConfig{
+		prompt:  "run the managed shell and handle its completion",
+		model:   "openai/gpt-test",
+		workDir: t.TempDir(),
+		stdout:  &stdout,
+		stderr:  &stderr,
+	}
+	if tweak != nil {
+		tweak(&cfg)
+	}
+	if err := run(context.Background(), cfg); err != nil {
+		t.Fatalf("run: %v\nstderr: %s", err, stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "shell notification handled") {
+		t.Fatalf("stdout = %q, want final notification-turn result", got)
+	}
+	if got := len(adapter.Requests()); got != 3 {
+		t.Fatalf("model requests = %d, want exactly three", got)
 	}
 }
 

--- a/docs/superpowers/plans/2026-08-09-owned-background-job-drain.md
+++ b/docs/superpowers/plans/2026-08-09-owned-background-job-drain.md
@@ -322,7 +322,7 @@ Add `TestRunDrainContinuesWhenNotificationTurnStartsAnotherShell`. Use five scri
 4. communicate `"waiting for B"`;
 5. after B's notification, communicate `"all shell work complete"`.
 
-Use `strings.Count(requestFullText(req), "<job-notification")` to distinguish the A-only and A-plus-B requests. Assert five requests, two distinct notification job IDs, and final stdout containing only the post-B completion result as the run's final answer.
+Use `strings.Count(requestDeliveredText(req), "<job-notification")` to distinguish the A-only and A-plus-B requests. Counting over `requestFullText` instead would include the system prompt, so a prompt section naming the frame would shift every count by one (kata zzpw). Assert five requests, two distinct notification job IDs, and final stdout containing only the post-B completion result as the run's final answer.
 
 - [ ] **Step 5: Add the foreground-promotion regression at the agent boundary**
 


### PR DESCRIPTION
Closes kata `zzpw`.

The system prompt is a message inside `llm.Request.Messages`, not a field beside them — `buildModelRequest` puts it at index 0 in all three of its branches. `requestFullText` concatenated every message, so `strings.Contains(text, "<delegate-notification")` in the fake LLM could not tell a delivered frame from a prompt section that merely named one.

The repo had been working around this silently: `agent/prompts/sections/background-jobs.md` wrote "delegate-notification frame" with the angle brackets removed, with nothing recording why.

Reproduced before touching anything: restoring the brackets turns both drain e2e tests red on the *dispatch* assertion — the fake matches on the coordinator's first round and answers `BUILD-COMPLETE` before a delegate exists.

## Fix

`requestDeliveredText(req)` concatenates `req.Messages[1:]`. Every notification matcher moves onto it. `requestFullText` keeps whole-request semantics for task routing, which genuinely needs the opening turn.

Two matchers the kata never named also moved: the managed-shell tests *count* `<job-notification` occurrences, where a prompt literal shifts a count rather than losing a dispatch — a subtler failure.

The workaround is gone. `background-jobs.md` names the frame with its brackets, permanently, and the tests stay green with it in the corpus.

## Why matchers and not an audit

The kata offered banning wire literals in `agent/prompts/sections/` instead, or as well. Rejected on merit:

- **The corpus already contains one, deliberately.** `background-jobs.md:52` spells `<system-reminder>`, a frame `job_watch.go:2386-2397` really produces. Prompt sections are themselves built out of tags — `<environment>`, `<git>`, `<agent>`, `<workspace>`, `<skill-catalog>`. An audit fires on intentional content on day one, and shipping it needs a hand-curated denylist of which tags are dangerous, which is the unwritten convention this kata complains about with a test wrapped around it.
- **It bans a legitimate thing.** Showing the model the exact shape of a frame it must recognise is good prompt writing.
- **It doesn't cover the class.** A user prompt, a tool result, or a file the agent reads that quotes a frame collides identically and lives nowhere near that directory.

## Positional, not role-based — and that choice is forced

Under `SystemPromptAsUser` the prompt is fused into the opening user turn with no distinguishing role. Role-filtering was run as a mutation: it **passes** the system-role layout and **fails** both fused cases. That is why every new test is tabled over both layouts — without the fused case the wrong fix looks correct.

A fully derived boundary ("everything since the first request this provider saw") was also rejected: the drain tests share one scripted provider between root and child sessions, so a child's opening turn would be misread as delivered content. It breaks on exactly the shape in question.

## The invariant is pinned, not assumed

`Messages[1:]` skips the first message, not "the system prompt". `TestSystemPromptOccupiesOnlyTheOpeningMessage` asserts the prompt is in message 0 **and nowhere else**, in both layouts, via the real `--system-prompt-append` path. Two mutations inside `buildModelRequest` break it loudly; in one, message 0 became a real `<environment_context>` turn — the silent-skip scenario.

Residual risk, stated precisely: eleven other files build `llm.Request` directly **today** and share the same `llm.Client` the scripted provider registers into (`session_tools.go:326`, three in `contextmgr`, `fork_summarize.go:23`, `hooks.go:114`, `tool_web_search.go`, `tool_web_fetch.go`, and more). All build single-user-message requests with no prompt at index 0. Nothing reaches them in these short tests, so this is latent, not live. The helper was deliberately not hardened against callers that do not exist yet.

## A vacuity trap worth knowing about

`agent/session_prompts.go:193-199` and `:311-315` both `continue` silently on an unreadable append path, so a typo in a test's prompt file would leave these tests passing while asserting nothing. Each new test asserts the literal actually reached message 0; the typo mutation goes red in all four subtests.

## Verification

`make merge-approval-gate` green (411s). Six mutations, all executed, in `.superpowers/zzpw-report.md`.

Independently reviewed. The reviewer ran two mutations of its own and found a real gap: the five `<job-notification` count matchers were moved but unguarded — reverting them left the suite green, because no prompt section names that frame and the acceptance test covered a different scenario. Closed with `chainedShellDrainScenario` plus `TestRunDrainCountsOnlyDeliveredJobFramesWhenSystemPromptNamesOne`, which is now red in both layouts with the revert: `initial request notification count = 1, want 0`.

One correction back to the reviewer, in the honest direction: it credited a tail-append mutation with failing in both layouts. As written — inside the non-fused `else` branch — it fails the system-role layout only, because the fused layout takes the other branch and never executes the mutation. Placed outside the if/else it does fail both. Both rows are in the report.
