### PR TITLE
fakellm: name the session on every round line the driver logs

### DIFF
--- a/scripts/e2e-webui-turn-controls.sh
+++ b/scripts/e2e-webui-turn-controls.sh
@@ -365,6 +365,11 @@ Ready. $mode_line
   Watch what actually reached the model each round:
     tail -f $run/fakellm.log
 
+  Sessions run at once and their rounds interleave. Each round line names its
+  session -- "session <tool-call-id> round N" -- so to follow just one, take
+  the name off its first round line and grep for it:
+    grep call_fakellm_1 $run/fakellm.log
+
   Watch the hub's own view of the RPCs:
     tail -f $run/hub.log
 

--- a/scripts/e2e-webui-turn-controls.sh
+++ b/scripts/e2e-webui-turn-controls.sh
@@ -367,8 +367,10 @@ Ready. $mode_line
 
   Sessions run at once and their rounds interleave. Each round line names its
   session -- "session <tool-call-id> round N" -- so to follow just one, take
-  the name off its first round line and grep for it:
-    grep call_fakellm_1 $run/fakellm.log
+  the name off its first round line and grep for it. Use -w: the ids are
+  numbered, so a bare call_fakellm_1 also matches call_fakellm_10 and up,
+  putting two sessions back in one view.
+    grep -w call_fakellm_1 $run/fakellm.log
 
   Watch the hub's own view of the RPCs:
     tail -f $run/hub.log

--- a/test/e2e/fakellm/cmd/main.go
+++ b/test/e2e/fakellm/cmd/main.go
@@ -23,6 +23,16 @@
 // exactly what reached the model — a steer that arrived shows up as a user
 // message in the following round.
 //
+// Because sessions overlap, every round line names its session, so a log with
+// several of them running is still readable one session at a time: grep it for
+// the name. The name is the tool-call id of the session's first round — a
+// token that session replays on every later request and that appears nowhere
+// else, so it also cross-references to the session's own api.jsonl. Nothing in
+// a chat-completions request supplies a session identity to use instead: there
+// is no user field, affinity headers are off for this instance type, and the
+// script hands the operator ONE spawn call to paste repeatedly, so prompt,
+// model and working directory are routinely identical.
+//
 // Usage:
 //
 //	fakellm [--hold 15s] [--rounds 20] <listen-addr>
@@ -135,6 +145,19 @@ func serve(ctx context.Context, srv *fakellm.Server, hold time.Duration, rounds 
 // --background-job-until gives each session one background job, on its first
 // turn, rather than one per turn or one per process.
 type sessionState struct {
+	// name is what the log calls this session: the tool-call id of the first
+	// round this driver saw from it, which is also the first key it was filed
+	// under. The session replays that id on its very next request, and every
+	// id the fake mints is unique, so the name is a token that appears in this
+	// session's transcript and no other's — an operator can grep it in
+	// fakellm.log and cross-check it against the session's api.jsonl.
+	//
+	// Fixed when the state is built and never written again. It is still read
+	// back out of begin under the lock rather than off the state afterwards:
+	// every other field here is rewritten by the next round's begin, and one
+	// field that happens to be safe unlocked is not a distinction worth
+	// leaving in a struct two goroutines share.
+	name string
 	// lastAnswered is the tool-call id of the most recent round this driver
 	// answered. A session replays the id of its last RECORDED round, so a
 	// request arriving under an older id says the answer after it never
@@ -176,10 +199,17 @@ const keysKept = 3
 
 // begin returns the state of the session making this request, advanced to
 // this round, and files it under the id this round's answer will carry. The
-// round number and job flag are returned as values read under the lock:
+// name, round number and job flag are returned as values read under the lock:
 // answer runs on its own goroutine and a Stop puts two of a session's rounds
 // in flight at once, so reading state fields after the lock is released would
 // race with the next round's begin.
+//
+// A session this driver has not served takes its name from the id minted for
+// this round. Nothing in a first request can supply one — no user field, and
+// prompt, model and working directory are identical across the sessions the
+// script's one spawn call produces — so the first round is the earliest point
+// a session can be named at all. From its second request on, the name is a
+// value the session itself sends back.
 //
 // Two boundaries are read out of the request rather than assumed:
 //
@@ -195,7 +225,7 @@ const keysKept = 3
 //     round that was recorded. The turn it belonged to is over, so this
 //     request opens a new one. (Measured against a live hub: a turn stopped
 //     during round 2 comes back replaying round 1's id.)
-func (s *sessions) begin(call *fakellm.Call) (state *sessionState, round int, launchedJob bool) {
+func (s *sessions) begin(call *fakellm.Call) (state *sessionState, name string, round int, launchedJob bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -203,7 +233,7 @@ func (s *sessions) begin(call *fakellm.Call) (state *sessionState, round int, la
 	state = s.byID[previous] // a session's first round has no previous id
 	switch {
 	case state == nil:
-		state = &sessionState{}
+		state = &sessionState{name: call.ToolCallID()}
 	case previous != state.lastAnswered:
 		state.turnRound = 0 // the round after `previous` was abandoned
 	}
@@ -216,7 +246,7 @@ func (s *sessions) begin(call *fakellm.Call) (state *sessionState, round int, la
 		delete(s.byID, state.keys[0])
 		state.keys = state.keys[1:]
 	}
-	return state, state.turnRound, state.launchedJob
+	return state, state.name, state.turnRound, state.launchedJob
 }
 
 // endedTurn records that the answer to `call` ends the session's turn, so its
@@ -255,8 +285,8 @@ func (s *sessions) launchedJob(state *sessionState, call *fakellm.Call) {
 // turn that follows must find its count exactly where the last RECORDED round
 // left it.
 func answer(ctx context.Context, live *sessions, call *fakellm.Call, hold time.Duration, rounds int, jobRelease, notesDir string) {
-	state, round, launchedJob := live.begin(call)
-	log.Printf("--- round %d: holding %s ---\n%s", round, hold, strings.Join(call.Texts(), "\n"))
+	state, name, round, launchedJob := live.begin(call)
+	log.Printf("--- session %s round %d: holding %s ---\n%s", name, round, hold, strings.Join(call.Texts(), "\n"))
 
 	endTurn := func(message string) {
 		live.endedTurn(state, call)
@@ -278,7 +308,7 @@ func answer(ctx context.Context, live *sessions, call *fakellm.Call, hold time.D
 	if jobRelease != "" {
 		switch {
 		case !launchedJob && round == 1:
-			log.Printf("round 1: launching a background job that waits for %s", jobRelease)
+			log.Printf("session %s round 1: launching a background job that waits for %s", name, jobRelease)
 			live.launchedJob(state, call)
 			call.RespondToolCall("shell", map[string]any{
 				"command": "while [ ! -f " + jobRelease + " ]; do sleep 0.5; done",
@@ -286,7 +316,7 @@ func answer(ctx context.Context, live *sessions, call *fakellm.Call, hold time.D
 			})
 			return
 		case launchedJob && round == 2:
-			log.Printf("round 2: ending the turn so the session goes idle holding the job")
+			log.Printf("session %s round 2: ending the turn so the session goes idle holding the job", name)
 			endTurn("background job launched; idle until it finishes")
 			return
 		case launchedJob && round == 1:
@@ -297,7 +327,7 @@ func answer(ctx context.Context, live *sessions, call *fakellm.Call, hold time.D
 			case <-call.Cancelled():
 				return
 			}
-			log.Printf("round 1 of a later turn: ending it so the session goes back to idle")
+			log.Printf("session %s round 1 of a later turn: ending it so the session goes back to idle", name)
 			endTurn("job-completion notification seen; going back to idle")
 			return
 		}
@@ -312,7 +342,7 @@ func answer(ctx context.Context, live *sessions, call *fakellm.Call, hold time.D
 	}
 
 	if round%rounds == 0 {
-		log.Printf("round %d: ending the turn", round)
+		log.Printf("session %s round %d: ending the turn", name, round)
 		endTurn(fmt.Sprintf("fake provider ended the turn after %d rounds", round))
 		return
 	}
@@ -323,7 +353,7 @@ func answer(ctx context.Context, live *sessions, call *fakellm.Call, hold time.D
 	if err != nil {
 		// Answering with text ends this session's turn. Leaving the round
 		// unanswered would hang it instead, with the reason only in this log.
-		log.Printf("round %d: stage note: %v", round, err)
+		log.Printf("session %s round %d: stage note: %v", name, round, err)
 		live.endedTurn(state, call)
 		call.RespondText(fmt.Sprintf("fake provider could not stage a note for round %d: %v", round, err))
 		return

--- a/test/e2e/fakellm/cmd/main.go
+++ b/test/e2e/fakellm/cmd/main.go
@@ -27,11 +27,17 @@
 // several of them running is still readable one session at a time: grep it for
 // the name. The name is the tool-call id of the session's first round — a
 // token that session replays on every later request and that appears nowhere
-// else, so it also cross-references to the session's own api.jsonl. Nothing in
-// a chat-completions request supplies a session identity to use instead: there
-// is no user field, affinity headers are off for this instance type, and the
-// script hands the operator ONE spawn call to paste repeatedly, so prompt,
-// model and working directory are routinely identical.
+// else, so it also cross-references to the session's own api.jsonl.
+//
+// Nothing in the request BODY supplies a session identity to use instead:
+// there is no user field, and the script hands the operator ONE spawn call to
+// paste repeatedly, so prompt, model and working directory are routinely
+// identical. The daemon does know its session id and sends it as the
+// session-affinity headers (session_id, x-client-request-id,
+// x-session-affinity), but only on an instance that sets
+// send_session_affinity_headers — a per-instance quirk the fixture's
+// providers.toml does not set. The tool-call id needs no provider
+// configuration to be true.
 //
 // Usage:
 //
@@ -205,11 +211,12 @@ const keysKept = 3
 // race with the next round's begin.
 //
 // A session this driver has not served takes its name from the id minted for
-// this round. Nothing in a first request can supply one — no user field, and
-// prompt, model and working directory are identical across the sessions the
-// script's one spawn call produces — so the first round is the earliest point
-// a session can be named at all. From its second request on, the name is a
-// value the session itself sends back.
+// this round. Nothing in a first request's BODY can supply one — no user
+// field, and prompt, model and working directory are identical across the
+// sessions the script's one spawn call produces — so with the request body as
+// the only channel, the first round is the earliest point a session can be
+// named at all. From its second request on, the name is a value the session
+// itself sends back.
 //
 // Two boundaries are read out of the request rather than assumed:
 //

--- a/test/e2e/fakellm/cmd/main_test.go
+++ b/test/e2e/fakellm/cmd/main_test.go
@@ -228,10 +228,138 @@ func TestRoundsAreCountedPerSession(t *testing.T) {
 	}
 }
 
+// TestConcurrentRoundLinesNameTheirSession: rounds are counted per session, so
+// sessions genuinely overlap and the log interleaves them. fakellm.log is the
+// only view scripts/e2e-webui-turn-controls.sh gives an operator of what
+// reached the model, and two `round 1` lines back to back with nothing between
+// them and their sessions is not a view of anything.
+//
+// The name has to be a token the session's own transcript carries, not a label
+// the log invents: the tool-call id of the first round this driver saw from it,
+// which the session replays on every request after that (fakellm.Call's
+// PreviousToolCallID). That is what makes `grep call_fakellm_3 fakellm.log`
+// return one session's run and nothing else.
+func TestConcurrentRoundLinesNameTheirSession(t *testing.T) {
+	var logged syncBuffer
+	previous := log.Writer()
+	log.SetOutput(&logged)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	// --rounds 3 so each session's third round is an "ending the turn" line as
+	// well: that line has to name its session too.
+	baseURL := startDriver(t, 0, 3, "")
+
+	// Both sessions run at once, on their own goroutines, so the driver is
+	// answering them from separate goroutines of its own and the log lines
+	// really do interleave -- the condition the operator is stuck with.
+	names := make([]string, 2)
+	var wg sync.WaitGroup
+	for i, name := range []string{"first", "second"} {
+		wg.Go(func() {
+			s := newSession(t, baseURL, name)
+			for round := 1; round <= 3; round++ {
+				call, err := s.try(ctx)
+				if err != nil {
+					t.Errorf("%s session round %d: %v", name, round, err)
+					return
+				}
+				if round == 1 {
+					names[i] = call.id
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	if names[0] == "" || names[1] == "" {
+		t.Fatalf("each session must report its first round's tool-call id, got %q and %q", names[0], names[1])
+	}
+	if names[0] == names[1] {
+		t.Fatalf("both sessions were handed the tool-call id %q; there is no handle to name them by", names[0])
+	}
+
+	text := logged.String()
+	for i, id := range names {
+		for round := 1; round <= 3; round++ {
+			want := fmt.Sprintf("session %s round %d: holding", id, round)
+			if !strings.Contains(text, want) {
+				t.Errorf("no log line %q: round %d of session %d cannot be told from the other session's", want, round, i+1)
+			}
+		}
+		want := fmt.Sprintf("session %s round 3: ending the turn", id)
+		if !strings.Contains(text, want) {
+			t.Errorf("no log line %q: the turn-ending line does not name its session", want)
+		}
+	}
+
+	// And nothing the driver says about a round may be anonymous. With two
+	// sessions in flight an unnamed line is unattributable by construction, so
+	// one line missed is the whole defect back again.
+	for _, line := range strings.Split(text, "\n") {
+		if strings.Contains(line, " round ") && !strings.Contains(line, "session ") {
+			t.Errorf("round line names no session: %q", line)
+		}
+	}
+}
+
+// TestASessionsNameOutlivesItsTurns: the script tells the operator to watch one
+// session for roughly hold x rounds seconds, and its turns start and end
+// underneath that. The name identifies the SESSION, so a turn boundary must not
+// re-mint it -- otherwise grepping the log for it returns one turn rather than
+// the run, which is the thing the operator was told to watch.
+func TestASessionsNameOutlivesItsTurns(t *testing.T) {
+	var logged syncBuffer
+	previous := log.Writer()
+	log.SetOutput(&logged)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	baseURL := startDriver(t, 0, 2, "")
+
+	s := newSession(t, baseURL, "long-lived")
+	first := s.round(ctx)
+	if first.name != "read_file" {
+		t.Fatalf("turn 1 round 1: tool %q, want read_file", first.name)
+	}
+	if got := s.round(ctx).name; got != "communicate" {
+		t.Fatalf("turn 1 round 2: tool %q, want communicate (--rounds 2 ends it)", got)
+	}
+	// The operator sends the next message. Same session, new turn.
+	s.newTurn("now do the other thing")
+	if got := s.round(ctx).name; got != "read_file" {
+		t.Fatalf("turn 2 round 1: tool %q, want read_file", got)
+	}
+	if got := s.round(ctx).name; got != "communicate" {
+		t.Fatalf("turn 2 round 2: tool %q, want communicate", got)
+	}
+
+	// Each line appears once per turn, under the SAME name. A name minted per
+	// turn rather than per session gives the second turn a different one, and
+	// every count here drops to 1.
+	text := logged.String()
+	for _, want := range []string{
+		fmt.Sprintf("session %s round 1: holding", first.id),
+		fmt.Sprintf("session %s round 2: holding", first.id),
+		fmt.Sprintf("session %s round 2: ending the turn", first.id),
+	} {
+		if got := strings.Count(text, want); got != 2 {
+			t.Errorf("log has %d lines %q, want 2 (one per turn): the name changed when the turn did", got, want)
+		}
+	}
+}
+
 // TestBackgroundJobModeAppliesToEverySession: --background-job-until answers
 // EACH session's first round with the background job, not just the first
 // session's.
 func TestBackgroundJobModeAppliesToEverySession(t *testing.T) {
+	var logged syncBuffer
+	previous := log.Writer()
+	log.SetOutput(&logged)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	baseURL := startDriver(t, 0, 20, "release-the-job")
@@ -251,6 +379,18 @@ func TestBackgroundJobModeAppliesToEverySession(t *testing.T) {
 			t.Errorf("%s session round 2: tool %q, want communicate (go idle holding the job)", name, idle.name)
 		} else if endTurn, _ := idle.args["end_turn"].(bool); !endTurn {
 			t.Errorf("%s session round 2: end_turn %v, want true", name, endTurn)
+		}
+
+		// This mode's own log lines have to be attributable too: the operator
+		// releases one job file and watches several sessions wake from it.
+		text := logged.String()
+		for _, want := range []string{
+			fmt.Sprintf("session %s round 1: launching a background job", launch.id),
+			fmt.Sprintf("session %s round 2: ending the turn so the session goes idle", launch.id),
+		} {
+			if !strings.Contains(text, want) {
+				t.Errorf("%s session: no log line %q", name, want)
+			}
 		}
 	}
 }
@@ -307,10 +447,17 @@ func TestACancelledRoundLeavesTheNextTurnItsOwnCount(t *testing.T) {
 	baseURL := startDriver(t, hold, 3, "")
 
 	s := newSession(t, baseURL, "stopped")
-	for round := 1; round <= 2; round++ {
-		if got := s.round(ctx).name; got != "read_file" {
-			t.Fatalf("turn 1 round %d: tool %q, want read_file", round, got)
-		}
+	// Round 1's id is this session's name in the driver's log. It is read here,
+	// from a round that completed before anything below runs concurrently, so
+	// the wait further down is keyed on a value the session has already
+	// reported -- a wait on a name minted by the very round being waited for
+	// would have nothing to match until the line it is waiting for exists.
+	first := s.round(ctx)
+	if first.name != "read_file" {
+		t.Fatalf("turn 1 round 1: tool %q, want read_file", first.name)
+	}
+	if got := s.round(ctx).name; got != "read_file" {
+		t.Fatalf("turn 1 round 2: tool %q, want read_file", got)
 	}
 
 	// Round 3 -- the round that would end the turn -- is cancelled while the
@@ -324,7 +471,7 @@ func TestACancelledRoundLeavesTheNextTurnItsOwnCount(t *testing.T) {
 		defer close(requestDone)
 		_, _ = s.try(requestCtx)
 	}()
-	waitForLog(t, &logged, "--- round 3: holding")
+	waitForLog(t, &logged, fmt.Sprintf("session %s round 3: holding", first.id))
 	cancelRequest()
 	<-requestDone
 	s.messages = recorded

--- a/test/e2e/fakellm/cmd/main_test.go
+++ b/test/e2e/fakellm/cmd/main_test.go
@@ -297,7 +297,7 @@ func TestConcurrentRoundLinesNameTheirSession(t *testing.T) {
 	// And nothing the driver says about a round may be anonymous. With two
 	// sessions in flight an unnamed line is unattributable by construction, so
 	// one line missed is the whole defect back again.
-	for _, line := range strings.Split(text, "\n") {
+	for line := range strings.SplitSeq(text, "\n") {
 		if strings.Contains(line, " round ") && !strings.Contains(line, "session ") {
 			t.Errorf("round line names no session: %q", line)
 		}


### PR DESCRIPTION
Closes kata `xmhx`.

Every round line the fake-LLM driver logged printed only `round %d`. Two concurrent sessions at round 1 emitted **byte-identical** blocks — not just identical prefixes, because the block is the round line plus `call.Texts()`, and both test sessions send the same prompt by design (the script hands the operator one spawn curl to paste repeatedly). So `call.Texts()` didn't disambiguate either.

Meanwhile `sessions.begin` already kept distinct per-session state, keyed on `call.PreviousToolCallID()`.

## Fix

Each session is named by the tool-call id of its first round — the id `begin` files the state under, and the id that session replays back on its next request. `sessionState` gains an immutable `name`, `begin` returns it, and all six round log lines become `session %s round %d`.

The package doc and the script's ready banner tell the operator how to grep one session out. The script is what the kata's "why it matters" is about, so naming the log without that would have fixed the log and not the workflow.

## The kata's proposed fix was rejected, with evidence

The kata suggests a header the harness sets and the fake echoes. serf supports it — `providercfg.InstanceConfig.Headers` exists. It is still wrong here, fatally rather than aesthetically: **a header is per-instance, not per-session.** `scripts/e2e-webui-turn-controls.sh` writes exactly one `[instances.fake]` and its banner hands the operator one spawn curl with instructions to paste it repeatedly. Every session that curl spawns would carry the identical header value. Getting distinct names would mean pre-declaring N instances and printing N curls, capping the session count and re-introducing the ambiguity the moment the operator pastes one twice — the documented workflow.

Why the tool-call id and not a driver-local ordinal: an ordinal is checkable against nothing outside the log. The tool-call id appears in that session's transcript and in `api.jsonl`, so `grep -w call_fakellm_3` ties the log to one session and nothing else. It also degrades better — when the driver loses a session, the id scheme's new name is the id of the round where the driver lost the thread, which is informative; a fresh ordinal appearing from nowhere is not.

## An honest limitation

"The naming comes from something the caller actually sent" holds from round 2 onward. A session's *first* request carries nothing session-unique — no `user` field, no previous id, and prompt/model/cwd identical by design — so the name is minted by the fake on round 1 and is caller-sent thereafter. That is the closest thing to caller-sent that exists on this wire, and it is a real handle rather than a fingerprint guess.

A genuinely caller-sent alternative exists and was **considered and deferred**: with `send_session_affinity_headers = true` the openai-compat adapter derives `session_id`/`x-client-request-id`/`x-session-affinity` from `req.SessionID` per request, which is assigned for every model request at `agent/session.go:1154`. It would be caller-sent on round 1 and would make the name the serf session id, matchable against the browser UI. Deferred because it is *additional* machinery — the tool-call id must remain as the fallback for any instance without the quirk enabled — and because it couples a test fixture's diagnostics to a production gateway-routing knob. Filed as its own kata; the tests here stay valid under either approach, since they assert on the name the driver reports rather than where it came from.

## Verification

`make merge-approval-gate` green (182s). Four mutations, all executed. `-race -count=2` clean.

Independently reviewed with a verdict of LAND. The reviewer ran all seven of the mutation claims and each matched message for message, including reproducing the red baseline's two identical `--- round 1: holding 0s ---` lines verbatim. It confirmed `name` is written once at construction under the lock and read only under the lock, and verified the sync-point argument directly: `s.round(ctx)` is a blocking HTTP call, so rounds 1 and 2 complete before any goroutine spawns, and the name is fixed at construction rather than by timing.

## A finding this surfaced, filed separately

Removing *only* `endedTurn`'s stale-round guard leaves `TestACancelledRoundLeavesTheNextTurnItsOwnCount` green — with `case <-call.Cancelled()` present, the cancelled goroutine returns from the hold before it ever reaches `endTurn`. Removing both halves does fail. The reviewer ran the full matrix and found `launchedJob`'s guard is dead on every path the package exercises too. So the guards added by `585d621df` are uncovered, and that test isolates neither. Out of scope here.

## One correction the reviewer prompted, in the other direction

A first draft of the package doc said the affinity headers carry no name "for this instance type", which is wrong — it is a per-instance quirk the script simply does not set. The review then offered a stronger reason: that `req.SessionID` is never assigned. That is also wrong, and this branch does not say it: `agent/session.go:1154` assigns it, and the session loop builds `llm.Request` directly rather than through `Generate`, which is why a `GenerateOptions` search misses it. The comment now scopes the claim to the request body, where it is true.
