### PR TITLE
e2e: a steering item is written at incorporation, not acceptance

### DIFF
--- a/cmd/serf-hub/e2e_control_without_turn_ids_test.go
+++ b/cmd/serf-hub/e2e_control_without_turn_ids_test.go
@@ -543,8 +543,9 @@ type = %q
 	if landedIn == running {
 		t.Fatalf("the steer was folded into the stopped turn %q instead of a later one", running)
 	}
-	// The steering item is written when the daemon ACCEPTS the steer, so it is
-	// present whether or not the model ever saw it. The model repeating the
+	// The steering item is written when a turn INCORPORATES the steer, not when
+	// the daemon accepts it, so its presence proves the running loop drained the
+	// message - and still not that the model read it. The model repeating the
 	// marker back is what proves delivery.
 	awaitModelEcho(ctx, t, client, ref, steerText)
 	t.Logf("live steer landed in turn %s and came back from the model", landedIn)
@@ -660,8 +661,9 @@ func awaitModelOutput(ctx context.Context, t *testing.T, client *appwire.Client,
 }
 
 // awaitModelEcho waits for text to come back as model output. Unlike a
-// steering item -- written when the daemon accepts the steer -- this can only
-// appear if the steer reached the model and the model answered it.
+// steering item -- written when a turn incorporates the steer, via
+// consumeSteeringMessage on the drain path -- this can only appear if the
+// steer reached the model and the model answered it.
 func awaitModelEcho(ctx context.Context, t *testing.T, client *appwire.Client, ref, text string) {
 	t.Helper()
 	deadline := time.Now().Add(3 * time.Minute)


### PR DESCRIPTION
Closes kata `kvb9`.

Two comments in `cmd/serf-hub/e2e_control_without_turn_ids_test.go` told the reader that accepting a steer writes the steering item. It is written when a turn drains and *incorporates* the message, through `consumeSteeringMessage`.

The distinction is the whole point of the surrounding assertions. The item's presence proves the running loop consumed the steer — a stronger claim than the receipt, and still weaker than the model echo, which is what proves delivery. As written, the comments collapsed that ladder into its bottom rung.

## A correction to this kata's own scoping

The kata (and my triage of it) said `consumeSteeringMessage` is reached only from `injectDrainedSteering`. It has **two** non-test callers:

- `agent/session_queue.go:855` — `injectDrainedSteering`
- `agent/session_provenance.go:85` — `drainSteeringForCommunicate`

Both are incorporation paths, so the conclusion holds; the single-caller claim did not. `drainSteeringForCommunicate`'s own doc says client-authored steering "crosses the same durable claim, transcript, and incorporation boundary as every other steering consumer before it becomes visible in that inbox", which is the stronger version of the point these comments are making.

## Verification

Four comment lines. `gofmt`, `go vet` and `go build` clean on `cmd/serf-hub`.

No mutation list: comment-only, nothing under test. The kata explicitly warned against inflating this into a behavioural test, and I did not.

`make merge-approval-gate` failed once on `TestDetachCommandSurvivesCleanup` in `agent/execenv` — a load flake unrelated to this diff, which touches one file in `cmd/serf-hub`. 3/3 green isolated on the same commit. Filed as kata `xykx` with both of today's occurrences; everything else in that gate passed.