### PR TITLE
test(serve): a boot-drained idle no longer satisfies the restoration milestone

### DIFF
--- a/cmd/serf/serve_model_switch_test.go
+++ b/cmd/serf/serve_model_switch_test.go
@@ -267,7 +267,19 @@ func TestServeModelSwitch_ProviderFailureRestoresCapability(t *testing.T) {
 				}
 				if params.Status.Type == appwire.ThreadStatusIdle &&
 					params.Capabilities != nil && params.Capabilities.ChangeModel {
-					record("idle with model capability")
+					// Boot parks the thread idle with ChangeModel too, and on a
+					// starved runner that status notification is still draining
+					// when the subscribe cut lands — the same drain the
+					// SystemPreludeTurnID filter above absorbs for
+					// turn/completed. An idle recorded before the failed turn
+					// proves nothing about restoration, so only one seen
+					// afterwards counts as the milestone.
+					onceMu.Lock()
+					afterFailure := seen["failed turn"]
+					onceMu.Unlock()
+					if afterFailure {
+						record("idle with model capability")
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Closes kata 6v5s. Unblocks the required build-and-test check that failed identically on #95 and #96.

CI failed TestServeModelSwitch_ProviderFailureRestoresCapability twice, both in under 0.25s, with:

    wait failed turn: structured milestone = "idle with model capability", want "failed turn"

A sub-second failure is the tell: capability restoration after a real failed turn cannot happen 70ms after boot. The boot sequence parks the thread idle with ChangeModel, and on a starved runner that status notification is still draining through the projection commit when the test's subscribe cut lands — the same drain the test already absorbs for turn/completed with its SystemPreludeTurnID filter. The status stream had no such guard, so a pre-turn idle satisfied the milestone and the strict ordering assertion fell over.

The fix records "idle with model capability" only once the failed turn has been seen. An idle observed before the failed turn proves nothing about restoration.

## Verification

- Deterministic reproduction: a 50ms delay injected at the top of Server.RecordAppEvent (uncommitted, both directions) makes the OLD test fail 5/5 with the byte-identical CI message at the same sub-second signature; the NEW test passes 5/5 under the same delay. Clean runs: 30/30 green, -race -count=3 green.
- Independent review (verdict LAND) traced the diagnosis through the projector: EventSessionStart emits threadStatus(idle) and stampCapabilitiesOnStatusChange stamps ChangeModel onto every status change, so the boot idle is exactly the shape the handler matches. It also proved the gate cannot hang: EventError (turn failed) is emitted before EventSessionEnd (idle) on the same goroutine, sequenced through one commit gate and one websocket, so the gated record always sees the failed turn first. The reviewer reproduced the mutation matrix independently, 3/3 both directions.
- merge-approval-gate run twice; both reds were flakes in suites this diff does not touch (TestInterruptTermsProcessGroupAndExits143 once — now kata ebnq; e2e-webui-turn-controls-selftest once — its live-stack boot false-redded two different gates today and is being addressed in the estate work). Both passed isolated re-runs 10/10 and 1/1 immediately after, and every other gate step was green in both runs.