### PR TITLE
fix(agent): fence attention wakes behind the closed-ancestor policy

### DIFF
--- a/agent/delegate_attention_ancestor_fence_test.go
+++ b/agent/delegate_attention_ancestor_fence_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -193,8 +192,9 @@ func TestDelegateAttentionWake_StoppingAncestorParksAttentionForLaterDelivery(t 
 // TestDelegateAttentionWake_PermanentClosedAncestorEscalatesToRootOnce drives
 // the hot path end to end: a resident root supervises an idle grandchild whose
 // pending attention sits under a parent delegate that closed permanently. The
-// wake must be refused, the attention durably resolved, and the root must
-// receive exactly one escalation notification -- replays append nothing new.
+// wake must be refused and the exact original message transferred to the root
+// under its original attention ID, with the source durably resolved -- replays
+// append nothing new.
 func TestDelegateAttentionWake_PermanentClosedAncestorEscalatesToRootOnce(t *testing.T) {
 	fixture := newColdStableDelegateFixture(t, "")
 	grandchildDelegateID := identifier.MustNewDelegateID()
@@ -274,21 +274,19 @@ func TestDelegateAttentionWake_PermanentClosedAncestorEscalatesToRootOnce(t *tes
 		t.Fatalf("read root attention fold: %v", err)
 	}
 	escalations := 0
-	escalationID := ""
 	for _, id := range rootFold.order {
-		if strings.HasPrefix(id, "unreachable:"+grandchildDelegateID+":") {
+		if id == attentionID {
 			escalations++
-			escalationID = id
 		}
 	}
 	if escalations != 1 {
-		t.Fatalf("root escalation notifications = %d, want exactly one", escalations)
+		t.Fatalf("root transferred attention entries = %d, want exactly one", escalations)
 	}
-	content := rootFold.content[escalationID].Text()
-	for _, want := range []string{grandchildDelegateID, fixture.delegateID, "1 undelivered message(s)"} {
-		if !strings.Contains(content, want) {
-			t.Fatalf("root escalation content %q omits %q", content, want)
-		}
+	if got := rootFold.content[attentionID].Text(); got != "undelivered grandchild message" {
+		t.Fatalf("root transferred attention content = %q, want the original message", got)
+	}
+	if _, resolved := rootFold.resolutions[attentionID]; resolved {
+		t.Fatal("root transferred attention arrived pre-resolved")
 	}
 	if !root.hasPendingRootDelegateAttention() {
 		t.Fatal("root escalation notification was not armed for the root model")
@@ -315,20 +313,21 @@ func TestDelegateAttentionWake_PermanentClosedAncestorEscalatesToRootOnce(t *tes
 	}
 	escalations = 0
 	for _, id := range rootFold.order {
-		if strings.HasPrefix(id, "unreachable:"+grandchildDelegateID+":") {
+		if id == attentionID {
 			escalations++
 		}
 	}
 	if escalations != 1 {
-		t.Fatalf("root escalation notifications after replay = %d, want exactly one", escalations)
+		t.Fatalf("root transferred attention entries after replay = %d, want exactly one", escalations)
 	}
 }
 
 // TestStableDelegateAttention_ColdRestoreEscalatesFencedDescendantOnce covers
 // the cold variant: restart with a permanently closed ancestor and an idle
-// descendant holding pending attention. Bootstrap must resolve the attention,
-// escalate once to the root transcript, arm no wake (no retry loop), and a
-// second bootstrap over the same durable state must not duplicate anything.
+// descendant holding pending attention. Bootstrap must transfer the original
+// message to the root transcript under its original identity, resolve the
+// source, arm no wake (no retry loop), and a second bootstrap over the same
+// durable state must not duplicate anything.
 func TestStableDelegateAttention_ColdRestoreEscalatesFencedDescendantOnce(t *testing.T) {
 	c, journalPath := newDelegateControllerTestHarness(t, 3, 1)
 	seedStableAttentionRepairDelegate(t, c, "dlg_parent", "", true)
@@ -350,7 +349,7 @@ func TestStableDelegateAttention_ColdRestoreEscalatesFencedDescendantOnce(t *tes
 		count := 0
 		content := ""
 		for _, id := range rootFold.order {
-			if strings.HasPrefix(id, "unreachable:dlg_child:") {
+			if id == attentionID {
 				count++
 				content = rootFold.content[id].Text()
 			}
@@ -371,12 +370,10 @@ func TestStableDelegateAttention_ColdRestoreEscalatesFencedDescendantOnce(t *tes
 	}
 	count, content := countEscalations()
 	if count != 1 {
-		t.Fatalf("cold root escalations = %d, want exactly one", count)
+		t.Fatalf("cold root transfers = %d, want exactly one", count)
 	}
-	for _, want := range []string{"dlg_child", "dlg_parent", "1 undelivered message(s)"} {
-		if !strings.Contains(content, want) {
-			t.Fatalf("cold escalation content %q omits %q", content, want)
-		}
+	if content != "attention" {
+		t.Fatalf("cold transferred content = %q, want the original message", content)
 	}
 	if delegateID, _, pending := fresh.delegateController.nextIdleDelegateAttention(); pending {
 		t.Fatalf("cold restore armed fenced attention for %s", delegateID)
@@ -395,9 +392,148 @@ func TestStableDelegateAttention_ColdRestoreEscalatesFencedDescendantOnce(t *tes
 	t.Cleanup(func() { _ = replay.closeOwnedDelegateStore() })
 	count, _ = countEscalations()
 	if count != 1 {
-		t.Fatalf("root escalations after replay bootstrap = %d, want exactly one", count)
+		t.Fatalf("root transfers after replay bootstrap = %d, want exactly one", count)
 	}
 	if replay.delegateController.hasPendingDelegateAttention() {
 		t.Fatal("replay bootstrap re-armed resolved fenced attention")
+	}
+}
+
+// TestStableDelegateAttention_EscalationCrashWindowSurvivesCascadeAndGrowth
+// pins the crash window BETWEEN the root transfer and the source resolution:
+// the transfer for attention A is durable in the root transcript, the source
+// is still pending, a further ancestor closes (the causally-linked cascade
+// that moved the nearest fenced ancestor), and a second attention B arrives at
+// the fenced child. Replay bootstrap must complete -- the per-attention
+// identity and content are immutable, so A replays as a no-op and B gets its
+// own transfer -- with exactly one root copy of each and both sources
+// resolved. The batch-hash design failed this permanently.
+func TestStableDelegateAttention_EscalationCrashWindowSurvivesCascadeAndGrowth(t *testing.T) {
+	c, journalPath := newDelegateControllerTestHarness(t, 4, 1)
+	seedStableAttentionRepairDelegate(t, c, "dlg_grand", "", true)
+	seedStableAttentionRepairDelegate(t, c, "dlg_parent", "dlg_grand", true)
+	seedStableAttentionRepairDelegate(t, c, "dlg_child", "dlg_parent", true)
+	const attentionA = "delegate:crash-window-a"
+	const attentionB = "delegate:crash-window-b"
+	childPath := transcriptPath(c.stateDir, "child-dlg_child")
+	rootPath := transcriptPath(c.stateDir, "root-session")
+	writeDelegateAttentionTranscript(t, childPath, "child-dlg_child", attentionA)
+	writeEmptyAttentionTranscript(t, transcriptPath(c.stateDir, "child-dlg_grand"), "child-dlg_grand")
+	writeEmptyAttentionTranscript(t, transcriptPath(c.stateDir, "child-dlg_parent"), "child-dlg_parent")
+	writeEmptyAttentionTranscript(t, rootPath, "root-session")
+
+	// The grandparent closes; escalation of A transfers to the root and then
+	// crashes before the source resolution becomes durable.
+	closeDelegateControllerResumability(t, c, "dlg_grand", "turn_budget_exhausted")
+	childFold, err := readDelegateAttentionFold(childPath, "child-dlg_child")
+	if err != nil {
+		t.Fatalf("read child attention before partial transfer: %v", err)
+	}
+	if _, err := appendColdDelegateAttentionMessageDurablyWithOpen(rootPath, "root-session", attentionA, childFold.content[attentionA], time.Unix(200, 0).UTC(), transcript.OpenWriterForSession); err != nil {
+		t.Fatalf("simulate partially completed transfer: %v", err)
+	}
+	// Before the restart, the cascade continues (the parent under the closed
+	// grandparent closes too) and a second attention reaches the fenced child.
+	closeDelegateControllerResumability(t, c, "dlg_parent", "turn_budget_exhausted")
+	appendDelegateAttentionTurn(t, childPath, "child-dlg_child", attentionB)
+	copyDelegateJournalForBootstrap(t, c, journalPath)
+
+	fresh := newAttentionRepairRoot(c.stateDir, nil)
+	if err := fresh.bootstrapDelegateResources(); err != nil {
+		t.Fatalf("replay bootstrap across the crash window: %v", err)
+	}
+	t.Cleanup(func() { _ = fresh.closeOwnedDelegateStore() })
+	rootFold, err := readDelegateAttentionFold(rootPath, "root-session")
+	if err != nil {
+		t.Fatalf("read root attention fold: %v", err)
+	}
+	counts := map[string]int{}
+	for _, id := range rootFold.order {
+		counts[id]++
+	}
+	if counts[attentionA] != 1 || counts[attentionB] != 1 {
+		t.Fatalf("root transfers after crash-window replay = %v, want exactly one of each", counts)
+	}
+	childFold, err = readDelegateAttentionFold(childPath, "child-dlg_child")
+	if err != nil {
+		t.Fatalf("read child attention after replay: %v", err)
+	}
+	if got := childFold.resolutions[attentionA]; got != delegateAttentionDiscarded {
+		t.Fatalf("crash-window attention %s resolution = %q, want discarded", attentionA, got)
+	}
+	if got := childFold.resolutions[attentionB]; got != delegateAttentionDiscarded {
+		t.Fatalf("late attention %s resolution = %q, want discarded", attentionB, got)
+	}
+	if fresh.delegateController.hasPendingDelegateAttention() {
+		t.Fatal("crash-window replay left fenced attention pending")
+	}
+}
+
+// TestDelegateAttentionWake_AncestorStopFenceParksUncoveredChild reaches the
+// ancestor fence's transient branch itself: the fold accepts a delegate
+// created under a parent whose subtree stop is already pending (this
+// controller's API refuses that ordering, so the state arrives only through a
+// restored journal), leaving a child whose own PendingStopSeq is clear under a
+// stopping ancestor. The fence must park the wake -- and must NOT classify the
+// stop as permanent, so no escalation fires -- and the attention delivers
+// normally once the stop completes.
+func TestDelegateAttentionWake_AncestorStopFenceParksUncoveredChild(t *testing.T) {
+	c, _ := newDelegateControllerTestHarness(t, 4, 2)
+	seedDelegateControllerIdle(t, c, "dlg_parent", "")
+	c.mu.Lock()
+	appended, err := c.appendLocked(delegatestore.Event{
+		Kind:                 delegatestore.EventDelegateSubtreeStopRequested,
+		DelegateID:           "dlg_parent",
+		SubtreeStopRequested: &delegatestore.SubtreeStopRequested{TargetDelegateID: "dlg_parent"},
+	})
+	c.mu.Unlock()
+	if err != nil {
+		t.Fatalf("append subtree stop request: %v", err)
+	}
+	requestSeq := appended[0].Seq
+	seedDelegateControllerIdle(t, c, "dlg_child", "dlg_parent")
+	child := &Session{}
+	c.mu.Lock()
+	c.live["dlg_child"] = &delegateLiveState{runtime: child}
+	childPendingStop := c.durable["dlg_child"].PendingStopSeq
+	c.mu.Unlock()
+	if childPendingStop != 0 {
+		t.Fatalf("child pending stop seq = %d, want 0 so only the ancestor fence can park it", childPendingStop)
+	}
+	const attentionID = "delegate:uncovered-child-wake"
+	if !c.noteDelegateAttention("dlg_child", attentionID) {
+		t.Fatal("note child attention")
+	}
+
+	if _, err := c.ReserveAttention(child, attentionID); !errors.Is(err, errDelegateTargetBusy) {
+		t.Fatalf("ReserveAttention under stopping ancestor = %v, want target_busy", err)
+	}
+	if delegateID, _, pending := c.nextIdleDelegateAttention(); pending {
+		t.Fatalf("nextIdleDelegateAttention offered %s under a stopping ancestor", delegateID)
+	}
+	if plans := c.permanentlyFencedDelegateAttention(); len(plans) != 0 {
+		t.Fatalf("stopping ancestor classified as permanent: %#v", plans)
+	}
+
+	c.mu.Lock()
+	_, err = c.appendLocked(delegatestore.Event{
+		Kind:                 delegatestore.EventDelegateSubtreeStopCompleted,
+		DelegateID:           "dlg_parent",
+		SubtreeStopCompleted: &delegatestore.SubtreeStopCompleted{RequestSeq: requestSeq},
+	})
+	c.mu.Unlock()
+	if err != nil {
+		t.Fatalf("append subtree stop completion: %v", err)
+	}
+	delegateID, gotAttentionID, pending := c.nextIdleDelegateAttention()
+	if !pending || delegateID != "dlg_child" || gotAttentionID != attentionID {
+		t.Fatalf("post-stop attention = delegate:%q attention:%q pending:%t, want the parked wake deliverable", delegateID, gotAttentionID, pending)
+	}
+	reservation, err := c.ReserveAttention(child, attentionID)
+	if err != nil {
+		t.Fatalf("ReserveAttention after ancestor stop completed: %v", err)
+	}
+	if _, err := c.CommitStart(reservation); err != nil {
+		t.Fatalf("CommitStart after ancestor stop completed: %v", err)
 	}
 }

--- a/agent/delegate_attention_ancestor_fence_test.go
+++ b/agent/delegate_attention_ancestor_fence_test.go
@@ -1,0 +1,403 @@
+package agent
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"primeradiant.com/serf/agent/internal/delegatestore"
+	"primeradiant.com/serf/agent/schema"
+	"primeradiant.com/serf/agent/transcript"
+	"primeradiant.com/serf/identifier"
+	"primeradiant.com/serf/llm"
+)
+
+func closeDelegateControllerResumability(t *testing.T, c *delegateTreeController, id, reason string) {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, err := c.appendLocked(delegatestore.Event{
+		Kind:               delegatestore.EventDelegateResumabilityClosed,
+		DelegateID:         id,
+		ResumabilityClosed: &delegatestore.ResumabilityClosed{Reason: reason},
+	}); err != nil {
+		t.Fatalf("close delegate %s resumability: %v", id, err)
+	}
+}
+
+// TestDelegateAttentionWake_ClosedAncestorRefusesReserveAndNextIdle reproduces
+// the confirmed probe: a permanently closed ancestor (turn-budget exhaustion)
+// must fence attention wakes for every descendant, exactly as admitLeaseLocked
+// fences running leases. Before the fix ReserveAttention admitted against the
+// target's own aggregate only and committed a generation whose every model
+// request would fail target_busy forever.
+func TestDelegateAttentionWake_ClosedAncestorRefusesReserveAndNextIdle(t *testing.T) {
+	c, _ := newDelegateControllerTestHarness(t, 4, 2)
+	seedDelegateControllerIdle(t, c, "dlg_parent", "")
+	seedDelegateControllerIdle(t, c, "dlg_child", "dlg_parent")
+	seedDelegateControllerIdle(t, c, "dlg_grandchild", "dlg_child")
+	child := &Session{}
+	grandchild := &Session{}
+	c.mu.Lock()
+	c.live["dlg_child"] = &delegateLiveState{runtime: child}
+	c.live["dlg_grandchild"] = &delegateLiveState{runtime: grandchild}
+	c.mu.Unlock()
+	const childAttentionID = "delegate:fenced-child"
+	const grandchildAttentionID = "delegate:fenced-grandchild"
+	if !c.noteDelegateAttention("dlg_child", childAttentionID) {
+		t.Fatal("note child attention")
+	}
+	if !c.noteDelegateAttention("dlg_grandchild", grandchildAttentionID) {
+		t.Fatal("note grandchild attention")
+	}
+
+	closeDelegateControllerResumability(t, c, "dlg_parent", "turn_budget_exhausted")
+
+	if _, err := c.ReserveAttention(child, childAttentionID); !errors.Is(err, errDelegateTargetBusy) {
+		t.Fatalf("ReserveAttention under closed parent = %v, want target_busy", err)
+	}
+	if _, err := c.ReserveAttention(grandchild, grandchildAttentionID); !errors.Is(err, errDelegateTargetBusy) {
+		t.Fatalf("ReserveAttention under closed grandparent = %v, want target_busy", err)
+	}
+	if delegateID, attentionID, pending := c.nextIdleDelegateAttention(); pending {
+		t.Fatalf("nextIdleDelegateAttention offered %s/%s under a closed ancestor", delegateID, attentionID)
+	}
+	c.mu.Lock()
+	childGeneration := c.durable["dlg_child"].Generation
+	grandchildGeneration := c.durable["dlg_grandchild"].Generation
+	c.mu.Unlock()
+	if childGeneration != 0 || grandchildGeneration != 0 {
+		t.Fatalf("generations under closed ancestor = child:%d grandchild:%d, want none committed", childGeneration, grandchildGeneration)
+	}
+}
+
+// TestDelegateAttentionWake_CommitStartRechecksAncestorFence covers the
+// reserve/commit race: the ancestor closes after ReserveAttention admitted the
+// wake. CommitStart must re-check the ancestor chain and refuse instead of
+// durably committing an inoperable generation.
+func TestDelegateAttentionWake_CommitStartRechecksAncestorFence(t *testing.T) {
+	c, _ := newDelegateControllerTestHarness(t, 4, 2)
+	seedDelegateControllerIdle(t, c, "dlg_parent", "")
+	seedDelegateControllerIdle(t, c, "dlg_child", "dlg_parent")
+	child := &Session{}
+	c.mu.Lock()
+	c.live["dlg_child"] = &delegateLiveState{runtime: child}
+	c.mu.Unlock()
+	const attentionID = "delegate:raced-wake"
+	if !c.noteDelegateAttention("dlg_child", attentionID) {
+		t.Fatal("note child attention")
+	}
+
+	reservation, err := c.ReserveAttention(child, attentionID)
+	if err != nil {
+		t.Fatalf("ReserveAttention with open ancestor: %v", err)
+	}
+	closeDelegateControllerResumability(t, c, "dlg_parent", "turn_budget_exhausted")
+
+	if _, err := c.CommitStart(reservation); !errors.Is(err, errDelegateTargetBusy) {
+		t.Fatalf("CommitStart after ancestor closed = %v, want target_busy", err)
+	}
+	c.mu.Lock()
+	generation := c.durable["dlg_child"].Generation
+	reservations := len(c.reservations)
+	c.mu.Unlock()
+	if generation != 0 {
+		t.Fatalf("committed generation %d under closed ancestor, want none", generation)
+	}
+	if reservations != 0 {
+		t.Fatalf("reservations after refused commit = %d, want released", reservations)
+	}
+	if turns, drives := c.capacityInUse(); turns != 0 || drives != 0 {
+		t.Fatalf("capacity after refused commit = (%d, %d), want released", turns, drives)
+	}
+}
+
+// TestDelegateAttentionWake_StoppingAncestorParksAttentionForLaterDelivery pins
+// the transient case: a pending subtree stop over the ancestor parks the
+// attention -- no wake, no resolution, no escalation -- and once the stop
+// completes with the ancestor still resumable the exact same attention is
+// deliverable again.
+func TestDelegateAttentionWake_StoppingAncestorParksAttentionForLaterDelivery(t *testing.T) {
+	c, _ := newDelegateControllerTestHarness(t, 4, 2)
+	seedDelegateControllerIdle(t, c, "dlg_parent", "")
+	seedDelegateControllerIdle(t, c, "dlg_child", "dlg_parent")
+	child := &Session{}
+	c.mu.Lock()
+	c.live["dlg_child"] = &delegateLiveState{runtime: child}
+	c.mu.Unlock()
+	const attentionID = "delegate:parked-wake"
+	if !c.noteDelegateAttention("dlg_child", attentionID) {
+		t.Fatal("note child attention")
+	}
+
+	c.mu.Lock()
+	appended, err := c.appendLocked(delegatestore.Event{
+		Kind:                 delegatestore.EventDelegateSubtreeStopRequested,
+		DelegateID:           "dlg_parent",
+		SubtreeStopRequested: &delegatestore.SubtreeStopRequested{TargetDelegateID: "dlg_parent"},
+	})
+	c.mu.Unlock()
+	if err != nil {
+		t.Fatalf("append subtree stop request: %v", err)
+	}
+	requestSeq := appended[0].Seq
+
+	if _, err := c.ReserveAttention(child, attentionID); !errors.Is(err, errDelegateTargetBusy) {
+		t.Fatalf("ReserveAttention during ancestor stop = %v, want target_busy", err)
+	}
+	if delegateID, _, pending := c.nextIdleDelegateAttention(); pending {
+		t.Fatalf("nextIdleDelegateAttention offered %s during ancestor stop", delegateID)
+	}
+	c.mu.Lock()
+	_, parked := c.attentionWakeIDs["dlg_child"][attentionID]
+	c.mu.Unlock()
+	if !parked {
+		t.Fatal("transient ancestor stop dropped the parked attention")
+	}
+	if plans := c.permanentlyFencedDelegateAttention(); len(plans) != 0 {
+		t.Fatalf("transient ancestor stop offered escalations %#v, want none", plans)
+	}
+
+	c.mu.Lock()
+	_, err = c.appendLocked(delegatestore.Event{
+		Kind:                 delegatestore.EventDelegateSubtreeStopCompleted,
+		DelegateID:           "dlg_parent",
+		SubtreeStopCompleted: &delegatestore.SubtreeStopCompleted{RequestSeq: requestSeq},
+	})
+	c.mu.Unlock()
+	if err != nil {
+		t.Fatalf("append subtree stop completion: %v", err)
+	}
+
+	delegateID, gotAttentionID, pending := c.nextIdleDelegateAttention()
+	if !pending || delegateID != "dlg_child" || gotAttentionID != attentionID {
+		t.Fatalf("post-stop attention = delegate:%q attention:%q pending:%t, want parked attention deliverable", delegateID, gotAttentionID, pending)
+	}
+	reservation, err := c.ReserveAttention(child, attentionID)
+	if err != nil {
+		t.Fatalf("ReserveAttention after ancestor resumed: %v", err)
+	}
+	if _, err := c.CommitStart(reservation); err != nil {
+		t.Fatalf("CommitStart after ancestor resumed: %v", err)
+	}
+	c.mu.Lock()
+	generation := c.durable["dlg_child"].Generation
+	trigger := c.durable["dlg_child"].Trigger
+	c.mu.Unlock()
+	if generation != 1 || trigger != delegatestore.TriggerAttention {
+		t.Fatalf("post-stop wake generation = %d trigger %q, want 1/attention", generation, trigger)
+	}
+}
+
+// TestDelegateAttentionWake_PermanentClosedAncestorEscalatesToRootOnce drives
+// the hot path end to end: a resident root supervises an idle grandchild whose
+// pending attention sits under a parent delegate that closed permanently. The
+// wake must be refused, the attention durably resolved, and the root must
+// receive exactly one escalation notification -- replays append nothing new.
+func TestDelegateAttentionWake_PermanentClosedAncestorEscalatesToRootOnce(t *testing.T) {
+	fixture := newColdStableDelegateFixture(t, "")
+	grandchildDelegateID := identifier.MustNewDelegateID()
+	grandchildSessionID := identifier.MustNewSessionID()
+
+	store, err := delegatestore.Open(delegateResourceStorePath(fixture.stateDir, fixture.meta.ID))
+	if err != nil {
+		t.Fatalf("open fixture delegate store: %v", err)
+	}
+	events, err := store.Load()
+	if err != nil {
+		t.Fatalf("load fixture delegate events: %v", err)
+	}
+	state, err := delegatestore.Fold(events)
+	if err != nil {
+		t.Fatalf("fold fixture delegate events: %v", err)
+	}
+	descriptor := cloneDelegateStartDescriptor(state[fixture.delegateID].Descriptor)
+	descriptor.ChildSessionID = grandchildSessionID
+	descriptor.TranscriptRef = encodeRef("", grandchildSessionID)
+	descriptor.ParentDelegateID = fixture.delegateID
+	_, _, err = store.AppendBatch(state, []delegatestore.Event{{
+		Kind:       delegatestore.EventDelegateCreated,
+		TS:         time.Unix(1_700_000_300, 0).UTC(),
+		DelegateID: grandchildDelegateID,
+		Created:    &delegatestore.DelegateCreated{Descriptor: descriptor},
+	}})
+	if closeErr := store.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		t.Fatalf("append grandchild delegate: %v", err)
+	}
+	grandchildMeta := fixture.meta
+	grandchildMeta.ID = grandchildSessionID
+	grandchildMeta.ParentSessionID = fixture.childID
+	grandchildMeta.IsSubagent = true
+	if err := schema.SaveSessionMeta(fixture.stateDir, grandchildMeta); err != nil {
+		t.Fatalf("save grandchild session meta: %v", err)
+	}
+	const attentionID = "delegate:undeliverable-under-closed-parent"
+	writer, err := transcript.NewWriter(transcriptPath(fixture.stateDir, grandchildSessionID), transcript.Header{
+		SessionID:       grandchildSessionID,
+		ParentSessionID: fixture.childID,
+		Task:            descriptor.Task,
+		ProfileID:       descriptor.ResolvedProfileID,
+		Model:           descriptor.ResolvedModel,
+		WorkingDir:      fixture.workspace,
+		Depth:           2,
+	})
+	if err != nil {
+		t.Fatalf("create grandchild transcript: %v", err)
+	}
+	turn := schema.NewTurn(schema.TurnSteering, llm.User("undelivered grandchild message"))
+	turn.AttentionID = attentionID
+	if err := writer.AppendDurable(turn); err != nil {
+		t.Fatalf("append grandchild attention: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close grandchild transcript: %v", err)
+	}
+
+	root := restoreSupervisionRoot(t, fixture, nil)
+	closeDelegateControllerResumability(t, root.delegateController, fixture.delegateID, "turn_budget_exhausted")
+
+	root.drivePendingStableDelegateAttention()
+
+	grandchildFold, err := readDelegateAttentionFold(transcriptPath(fixture.stateDir, grandchildSessionID), grandchildSessionID)
+	if err != nil {
+		t.Fatalf("read grandchild attention fold: %v", err)
+	}
+	if got := grandchildFold.resolutions[attentionID]; got != delegateAttentionDiscarded {
+		t.Fatalf("fenced grandchild attention resolution = %q, want discarded", got)
+	}
+	rootFold, err := readDelegateAttentionFold(transcriptPath(fixture.stateDir, fixture.meta.ID), fixture.meta.ID)
+	if err != nil {
+		t.Fatalf("read root attention fold: %v", err)
+	}
+	escalations := 0
+	escalationID := ""
+	for _, id := range rootFold.order {
+		if strings.HasPrefix(id, "unreachable:"+grandchildDelegateID+":") {
+			escalations++
+			escalationID = id
+		}
+	}
+	if escalations != 1 {
+		t.Fatalf("root escalation notifications = %d, want exactly one", escalations)
+	}
+	content := rootFold.content[escalationID].Text()
+	for _, want := range []string{grandchildDelegateID, fixture.delegateID, "1 undelivered message(s)"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("root escalation content %q omits %q", content, want)
+		}
+	}
+	if !root.hasPendingRootDelegateAttention() {
+		t.Fatal("root escalation notification was not armed for the root model")
+	}
+	if delegateID, _, pending := root.delegateController.nextIdleDelegateAttention(); pending {
+		t.Fatalf("nextIdleDelegateAttention still offers %s after escalation", delegateID)
+	}
+	root.delegateController.mu.Lock()
+	generation := root.delegateController.durable[grandchildDelegateID].Generation
+	root.delegateController.mu.Unlock()
+	if generation != 0 {
+		t.Fatalf("fenced grandchild committed generation %d, want none", generation)
+	}
+
+	// Replays are no-ops: the hot driver again and the cold restart repair both
+	// find the attention already resolved.
+	root.drivePendingStableDelegateAttention()
+	if err := repairPermanentlyUnreachableDelegateAttention(root.delegateController); err != nil {
+		t.Fatalf("replay cold repair: %v", err)
+	}
+	rootFold, err = readDelegateAttentionFold(transcriptPath(fixture.stateDir, fixture.meta.ID), fixture.meta.ID)
+	if err != nil {
+		t.Fatalf("re-read root attention fold: %v", err)
+	}
+	escalations = 0
+	for _, id := range rootFold.order {
+		if strings.HasPrefix(id, "unreachable:"+grandchildDelegateID+":") {
+			escalations++
+		}
+	}
+	if escalations != 1 {
+		t.Fatalf("root escalation notifications after replay = %d, want exactly one", escalations)
+	}
+}
+
+// TestStableDelegateAttention_ColdRestoreEscalatesFencedDescendantOnce covers
+// the cold variant: restart with a permanently closed ancestor and an idle
+// descendant holding pending attention. Bootstrap must resolve the attention,
+// escalate once to the root transcript, arm no wake (no retry loop), and a
+// second bootstrap over the same durable state must not duplicate anything.
+func TestStableDelegateAttention_ColdRestoreEscalatesFencedDescendantOnce(t *testing.T) {
+	c, journalPath := newDelegateControllerTestHarness(t, 3, 1)
+	seedStableAttentionRepairDelegate(t, c, "dlg_parent", "", true)
+	seedStableAttentionRepairDelegate(t, c, "dlg_child", "dlg_parent", true)
+	closeDelegateControllerResumability(t, c, "dlg_parent", "turn_budget_exhausted")
+	const attentionID = "delegate:cold-fenced-child"
+	childPath := transcriptPath(c.stateDir, "child-dlg_child")
+	writeDelegateAttentionTranscript(t, childPath, "child-dlg_child", attentionID)
+	writeEmptyAttentionTranscript(t, transcriptPath(c.stateDir, "child-dlg_parent"), "child-dlg_parent")
+	writeEmptyAttentionTranscript(t, transcriptPath(c.stateDir, "root-session"), "root-session")
+	copyDelegateJournalForBootstrap(t, c, journalPath)
+
+	countEscalations := func() (int, string) {
+		t.Helper()
+		rootFold, err := readDelegateAttentionFold(transcriptPath(c.stateDir, "root-session"), "root-session")
+		if err != nil {
+			t.Fatalf("read root attention fold: %v", err)
+		}
+		count := 0
+		content := ""
+		for _, id := range rootFold.order {
+			if strings.HasPrefix(id, "unreachable:dlg_child:") {
+				count++
+				content = rootFold.content[id].Text()
+			}
+		}
+		return count, content
+	}
+
+	fresh := newAttentionRepairRoot(c.stateDir, nil)
+	if err := fresh.bootstrapDelegateResources(); err != nil {
+		t.Fatalf("bootstrap fenced descendant repair: %v", err)
+	}
+	childFold, err := readDelegateAttentionFold(childPath, "child-dlg_child")
+	if err != nil {
+		t.Fatalf("read fenced child attention: %v", err)
+	}
+	if got := childFold.resolutions[attentionID]; got != delegateAttentionDiscarded {
+		t.Fatalf("cold fenced child resolution = %q, want discarded", got)
+	}
+	count, content := countEscalations()
+	if count != 1 {
+		t.Fatalf("cold root escalations = %d, want exactly one", count)
+	}
+	for _, want := range []string{"dlg_child", "dlg_parent", "1 undelivered message(s)"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("cold escalation content %q omits %q", content, want)
+		}
+	}
+	if delegateID, _, pending := fresh.delegateController.nextIdleDelegateAttention(); pending {
+		t.Fatalf("cold restore armed fenced attention for %s", delegateID)
+	}
+	if fresh.delegateController.hasPendingDelegateAttention() {
+		t.Fatal("cold restore left fenced attention pending, feeding an unbounded retry loop")
+	}
+	if err := fresh.closeOwnedDelegateStore(); err != nil {
+		t.Fatalf("close first bootstrap store: %v", err)
+	}
+
+	replay := newAttentionRepairRoot(c.stateDir, nil)
+	if err := replay.bootstrapDelegateResources(); err != nil {
+		t.Fatalf("replay bootstrap: %v", err)
+	}
+	t.Cleanup(func() { _ = replay.closeOwnedDelegateStore() })
+	count, _ = countEscalations()
+	if count != 1 {
+		t.Fatalf("root escalations after replay bootstrap = %d, want exactly one", count)
+	}
+	if replay.delegateController.hasPendingDelegateAttention() {
+		t.Fatal("replay bootstrap re-armed resolved fenced attention")
+	}
+}

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -443,37 +443,58 @@ func (s *Session) restoreColdDelegateAttentionRuntime(delegateID string) (*Sessi
 	return owner, sub, nil
 }
 
-// escalateUnreachableDelegateAttention resolves pending attention wakes that a
-// permanently closed ancestor fences off forever and surfaces one notification
-// per batch to the root session. Notification before resolution: a crash in
-// between replays into an idempotent no-op append and a second resolution
-// attempt, never a silently discarded message.
+// escalateUnreachableDelegateAttention transfers pending attention wakes that
+// a permanently closed ancestor fences off forever to the root session -- each
+// message under its own original identity and content, mirroring the cold
+// repair in repairPermanentlyUnreachableDelegateAttention. Transfer before
+// resolution: a crash in between replays into an idempotent no-op append and a
+// second resolution attempt, never a silently discarded message. A failing
+// delegate does not starve the rest of the batch.
 func (s *Session) escalateUnreachableDelegateAttention() bool {
 	progressed := false
+	var failures []error
 	for _, plan := range s.delegateController.permanentlyFencedDelegateAttention() {
 		if err := s.escalateOneUnreachableDelegateAttention(plan); err != nil {
-			s.emit(events.EventWarning, warningDataFromError("escalate unreachable delegate attention", err))
-			s.scheduleStableDelegateAttentionRetry()
-			return progressed
+			failures = append(failures, fmt.Errorf("delegate %s: %w", plan.delegateID, err))
+			continue
 		}
 		progressed = true
+	}
+	if len(failures) != 0 {
+		s.emit(events.EventWarning, warningDataFromError("escalate unreachable delegate attention", errors.Join(failures...)))
+		s.scheduleStableDelegateAttentionRetry()
 	}
 	return progressed
 }
 
 func (s *Session) escalateOneUnreachableDelegateAttention(plan delegateFencedAttentionEscalation) error {
-	notificationID := unreachableDelegateAttentionID(plan.delegateID, plan.attentionIDs)
-	content := unreachableDelegateAttentionContent(plan.delegateID, plan.ancestorID, len(plan.attentionIDs))
-	if _, err := s.appendDelegateNotificationDurably(notificationID, content); err != nil {
+	sourcePath, sourceSessionID, err := delegateTranscriptPathFromRef(s.delegateController.stateDir, plan.transcriptRef)
+	if err != nil {
 		return err
 	}
-	if err := s.armDelegateAttention(notificationID); err != nil {
+	fold, err := readDelegateAttentionFold(sourcePath, sourceSessionID)
+	if err != nil {
 		return err
 	}
-	if err := s.delegateController.resolveDelegateAttentionDurably(plan.runtime, plan.transcriptRef, plan.attentionIDs, delegateAttentionDiscarded); err != nil {
-		return err
+	for _, attentionID := range plan.attentionIDs {
+		message, exists := fold.content[attentionID]
+		if _, resolved := fold.resolutions[attentionID]; resolved || !exists {
+			// Already durably resolved (or never durable): only the stale
+			// process-local wake remains.
+			s.delegateController.forgetDelegateAttention(plan.delegateID, attentionID)
+			continue
+		}
+		if _, err := s.appendDelegateAttentionMessageDurably(attentionID, message); err != nil {
+			return err
+		}
+		if err := s.armDelegateAttention(attentionID); err != nil {
+			return err
+		}
+		if err := s.delegateController.resolveDelegateAttentionDurably(plan.runtime, plan.transcriptRef, []string{attentionID}, delegateAttentionDiscarded); err != nil {
+			return err
+		}
+		s.delegateController.forgetDelegateAttention(plan.delegateID, attentionID)
 	}
-	s.delegateController.forgetDelegateAttention(plan.delegateID, plan.attentionIDs...)
 	return nil
 }
 

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -443,13 +443,48 @@ func (s *Session) restoreColdDelegateAttentionRuntime(delegateID string) (*Sessi
 	return owner, sub, nil
 }
 
+// escalateUnreachableDelegateAttention resolves pending attention wakes that a
+// permanently closed ancestor fences off forever and surfaces one notification
+// per batch to the root session. Notification before resolution: a crash in
+// between replays into an idempotent no-op append and a second resolution
+// attempt, never a silently discarded message.
+func (s *Session) escalateUnreachableDelegateAttention() bool {
+	progressed := false
+	for _, plan := range s.delegateController.permanentlyFencedDelegateAttention() {
+		if err := s.escalateOneUnreachableDelegateAttention(plan); err != nil {
+			s.emit(events.EventWarning, warningDataFromError("escalate unreachable delegate attention", err))
+			s.scheduleStableDelegateAttentionRetry()
+			return progressed
+		}
+		progressed = true
+	}
+	return progressed
+}
+
+func (s *Session) escalateOneUnreachableDelegateAttention(plan delegateFencedAttentionEscalation) error {
+	notificationID := unreachableDelegateAttentionID(plan.delegateID, plan.attentionIDs)
+	content := unreachableDelegateAttentionContent(plan.delegateID, plan.ancestorID, len(plan.attentionIDs))
+	if _, err := s.appendDelegateNotificationDurably(notificationID, content); err != nil {
+		return err
+	}
+	if err := s.armDelegateAttention(notificationID); err != nil {
+		return err
+	}
+	if err := s.delegateController.resolveDelegateAttentionDurably(plan.runtime, plan.transcriptRef, plan.attentionIDs, delegateAttentionDiscarded); err != nil {
+		return err
+	}
+	s.delegateController.forgetDelegateAttention(plan.delegateID, plan.attentionIDs...)
+	return nil
+}
+
 func (s *Session) drivePendingStableDelegateAttention() bool {
 	if s == nil || s.delegateController == nil || !s.isRootDelegateAttentionReceiver() {
 		return false
 	}
+	escalated := s.escalateUnreachableDelegateAttention()
 	delegateID, _, pending := s.delegateController.nextIdleDelegateAttention()
 	if !pending {
-		return false
+		return escalated
 	}
 	owner, sub, err := s.restoreColdDelegateAttentionRuntime(delegateID)
 	if err != nil {

--- a/agent/delegate_tree_attention.go
+++ b/agent/delegate_tree_attention.go
@@ -143,6 +143,27 @@ func (c *delegateTreeController) hasPendingDelegateAttention() bool {
 	return false
 }
 
+// delegateAttentionWakeEligibleLocked reports whether delegateID could accept
+// an attention wake or an escalation right now, before the ancestor fence is
+// consulted. It is the shared eligibility predicate for ReserveAttention and
+// every wake-cache scan, so the driver, the retry loop, and the escalation
+// collector cannot disagree about the same delegate.
+func (c *delegateTreeController) delegateAttentionWakeEligibleLocked(delegateID string) bool {
+	aggregate := c.durable[delegateID]
+	if c.closing || aggregate == nil || aggregate.Phase != delegatestore.PhaseIdle || !aggregate.Resumable || aggregate.PendingStopSeq != 0 || c.reclamationCoversLocked(delegateID) {
+		return false
+	}
+	if live := c.live[delegateID]; live != nil && (live.binding != nil || live.recoveryRequired) {
+		return false
+	}
+	for _, record := range c.reservations {
+		if record.delegateID == delegateID {
+			return false
+		}
+	}
+	return true
+}
+
 // hasRunnableDelegateAttention reports whether the root driver has actionable
 // attention work: a wake it may commit, or attention it must escalate because
 // a permanently closed ancestor fences the wake off forever. Attention parked
@@ -154,11 +175,10 @@ func (c *delegateTreeController) hasRunnableDelegateAttention() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for delegateID, ids := range c.attentionWakeIDs {
-		aggregate := c.durable[delegateID]
-		if len(ids) == 0 || aggregate == nil || aggregate.Phase != delegatestore.PhaseIdle || !aggregate.Resumable || aggregate.PendingStopSeq != 0 {
+		if len(ids) == 0 || !c.delegateAttentionWakeEligibleLocked(delegateID) {
 			continue
 		}
-		blocked, closedAncestorID := c.ancestorFenceLocked(aggregate.Descriptor.ParentDelegateID)
+		blocked, closedAncestorID := c.ancestorFenceLocked(c.durable[delegateID].Descriptor.ParentDelegateID)
 		if !blocked || closedAncestorID != "" {
 			return true
 		}
@@ -186,11 +206,10 @@ func (c *delegateTreeController) nextIdleDelegateAttention() (string, string, bo
 	defer c.mu.Unlock()
 	delegateIDs := make([]string, 0, len(c.attentionWakeIDs))
 	for delegateID, ids := range c.attentionWakeIDs {
-		aggregate := c.durable[delegateID]
-		if len(ids) == 0 || aggregate == nil || aggregate.Phase != delegatestore.PhaseIdle || !aggregate.Resumable || aggregate.PendingStopSeq != 0 {
+		if len(ids) == 0 || !c.delegateAttentionWakeEligibleLocked(delegateID) {
 			continue
 		}
-		if blocked, _ := c.ancestorFenceLocked(aggregate.Descriptor.ParentDelegateID); blocked {
+		if blocked, _ := c.ancestorFenceLocked(c.durable[delegateID].Descriptor.ParentDelegateID); blocked {
 			continue
 		}
 		delegateIDs = append(delegateIDs, delegateID)
@@ -209,11 +228,10 @@ func (c *delegateTreeController) nextIdleDelegateAttention() (string, string, bo
 }
 
 // delegateFencedAttentionEscalation is one delegate's pending attention that a
-// permanently closed ancestor fences off forever. The root resolves it durably
-// and surfaces a notification in its place.
+// permanently closed ancestor fences off forever. The root transfers each
+// message to itself under the original identity and resolves the source.
 type delegateFencedAttentionEscalation struct {
 	delegateID    string
-	ancestorID    string
 	transcriptRef string
 	attentionIDs  []string
 	runtime       *Session
@@ -222,8 +240,9 @@ type delegateFencedAttentionEscalation struct {
 // permanentlyFencedDelegateAttention lists pending attention wakes whose
 // target sits under an ancestor that can never become resumable again. No
 // generation can ever deliver them, so the root escalates and resolves them
-// instead of retrying forever. Delegates with an in-flight generation or
-// reservation are skipped and picked up on a later pass.
+// instead of retrying forever. Delegates that are not wake-eligible (in-flight
+// generation, reservation, recovery, reclamation) are skipped and picked up on
+// a later pass.
 func (c *delegateTreeController) permanentlyFencedDelegateAttention() []delegateFencedAttentionEscalation {
 	if c == nil {
 		return nil
@@ -232,24 +251,10 @@ func (c *delegateTreeController) permanentlyFencedDelegateAttention() []delegate
 	defer c.mu.Unlock()
 	plans := make([]delegateFencedAttentionEscalation, 0)
 	for delegateID, ids := range c.attentionWakeIDs {
+		if len(ids) == 0 || !c.delegateAttentionWakeEligibleLocked(delegateID) {
+			continue
+		}
 		aggregate := c.durable[delegateID]
-		if len(ids) == 0 || aggregate == nil || aggregate.Phase != delegatestore.PhaseIdle || !aggregate.Resumable || aggregate.PendingStopSeq != 0 || c.reclamationCoversLocked(delegateID) {
-			continue
-		}
-		live := c.live[delegateID]
-		if live != nil && live.binding != nil {
-			continue
-		}
-		reserved := false
-		for _, record := range c.reservations {
-			if record.delegateID == delegateID {
-				reserved = true
-				break
-			}
-		}
-		if reserved {
-			continue
-		}
 		blocked, closedAncestorID := c.ancestorFenceLocked(aggregate.Descriptor.ParentDelegateID)
 		if !blocked || closedAncestorID == "" {
 			continue
@@ -260,12 +265,11 @@ func (c *delegateTreeController) permanentlyFencedDelegateAttention() []delegate
 		}
 		sort.Strings(attentionIDs)
 		var runtime *Session
-		if live != nil {
+		if live := c.live[delegateID]; live != nil {
 			runtime = live.runtime
 		}
 		plans = append(plans, delegateFencedAttentionEscalation{
 			delegateID:    delegateID,
-			ancestorID:    closedAncestorID,
 			transcriptRef: aggregate.Descriptor.TranscriptRef,
 			attentionIDs:  attentionIDs,
 			runtime:       runtime,

--- a/agent/delegate_tree_attention.go
+++ b/agent/delegate_tree_attention.go
@@ -143,6 +143,10 @@ func (c *delegateTreeController) hasPendingDelegateAttention() bool {
 	return false
 }
 
+// hasRunnableDelegateAttention reports whether the root driver has actionable
+// attention work: a wake it may commit, or attention it must escalate because
+// a permanently closed ancestor fences the wake off forever. Attention parked
+// under a transient ancestor stop is pending, not runnable.
 func (c *delegateTreeController) hasRunnableDelegateAttention() bool {
 	if c == nil {
 		return false
@@ -151,7 +155,11 @@ func (c *delegateTreeController) hasRunnableDelegateAttention() bool {
 	defer c.mu.Unlock()
 	for delegateID, ids := range c.attentionWakeIDs {
 		aggregate := c.durable[delegateID]
-		if len(ids) != 0 && aggregate != nil && aggregate.Phase == delegatestore.PhaseIdle && aggregate.Resumable && aggregate.PendingStopSeq == 0 {
+		if len(ids) == 0 || aggregate == nil || aggregate.Phase != delegatestore.PhaseIdle || !aggregate.Resumable || aggregate.PendingStopSeq != 0 {
+			continue
+		}
+		blocked, closedAncestorID := c.ancestorFenceLocked(aggregate.Descriptor.ParentDelegateID)
+		if !blocked || closedAncestorID != "" {
 			return true
 		}
 	}
@@ -179,9 +187,13 @@ func (c *delegateTreeController) nextIdleDelegateAttention() (string, string, bo
 	delegateIDs := make([]string, 0, len(c.attentionWakeIDs))
 	for delegateID, ids := range c.attentionWakeIDs {
 		aggregate := c.durable[delegateID]
-		if len(ids) != 0 && aggregate != nil && aggregate.Phase == delegatestore.PhaseIdle && aggregate.Resumable && aggregate.PendingStopSeq == 0 {
-			delegateIDs = append(delegateIDs, delegateID)
+		if len(ids) == 0 || aggregate == nil || aggregate.Phase != delegatestore.PhaseIdle || !aggregate.Resumable || aggregate.PendingStopSeq != 0 {
+			continue
 		}
+		if blocked, _ := c.ancestorFenceLocked(aggregate.Descriptor.ParentDelegateID); blocked {
+			continue
+		}
+		delegateIDs = append(delegateIDs, delegateID)
 	}
 	if len(delegateIDs) == 0 {
 		return "", "", false
@@ -194,6 +206,84 @@ func (c *delegateTreeController) nextIdleDelegateAttention() (string, string, bo
 	}
 	sort.Strings(attentionIDs)
 	return delegateID, attentionIDs[0], true
+}
+
+// delegateFencedAttentionEscalation is one delegate's pending attention that a
+// permanently closed ancestor fences off forever. The root resolves it durably
+// and surfaces a notification in its place.
+type delegateFencedAttentionEscalation struct {
+	delegateID    string
+	ancestorID    string
+	transcriptRef string
+	attentionIDs  []string
+	runtime       *Session
+}
+
+// permanentlyFencedDelegateAttention lists pending attention wakes whose
+// target sits under an ancestor that can never become resumable again. No
+// generation can ever deliver them, so the root escalates and resolves them
+// instead of retrying forever. Delegates with an in-flight generation or
+// reservation are skipped and picked up on a later pass.
+func (c *delegateTreeController) permanentlyFencedDelegateAttention() []delegateFencedAttentionEscalation {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	plans := make([]delegateFencedAttentionEscalation, 0)
+	for delegateID, ids := range c.attentionWakeIDs {
+		aggregate := c.durable[delegateID]
+		if len(ids) == 0 || aggregate == nil || aggregate.Phase != delegatestore.PhaseIdle || !aggregate.Resumable || aggregate.PendingStopSeq != 0 || c.reclamationCoversLocked(delegateID) {
+			continue
+		}
+		live := c.live[delegateID]
+		if live != nil && live.binding != nil {
+			continue
+		}
+		reserved := false
+		for _, record := range c.reservations {
+			if record.delegateID == delegateID {
+				reserved = true
+				break
+			}
+		}
+		if reserved {
+			continue
+		}
+		blocked, closedAncestorID := c.ancestorFenceLocked(aggregate.Descriptor.ParentDelegateID)
+		if !blocked || closedAncestorID == "" {
+			continue
+		}
+		attentionIDs := make([]string, 0, len(ids))
+		for attentionID := range ids {
+			attentionIDs = append(attentionIDs, attentionID)
+		}
+		sort.Strings(attentionIDs)
+		var runtime *Session
+		if live != nil {
+			runtime = live.runtime
+		}
+		plans = append(plans, delegateFencedAttentionEscalation{
+			delegateID:    delegateID,
+			ancestorID:    closedAncestorID,
+			transcriptRef: aggregate.Descriptor.TranscriptRef,
+			attentionIDs:  attentionIDs,
+			runtime:       runtime,
+		})
+	}
+	sort.Slice(plans, func(i, j int) bool { return plans[i].delegateID < plans[j].delegateID })
+	return plans
+}
+
+func (c *delegateTreeController) forgetDelegateAttention(delegateID string, attentionIDs ...string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, attentionID := range attentionIDs {
+		c.forgetDelegateAttentionLocked(delegateID, attentionID)
+	}
 }
 
 // armColdDelegateAttention admits a wake only after re-folding the exact cold

--- a/agent/delegate_tree_controller.go
+++ b/agent/delegate_tree_controller.go
@@ -448,17 +448,35 @@ func (c *delegateTreeController) admitLeaseLocked(lease delegateLease, phases ..
 	if live.recoveryRequired || aggregate.PendingStopSeq != 0 || !aggregate.Resumable || live.binding == nil || !live.binding.ready {
 		return nil, nil, errDelegateTargetBusy
 	}
-	for ancestorID := aggregate.Descriptor.ParentDelegateID; ancestorID != ""; {
-		ancestor := c.durable[ancestorID]
-		if ancestor == nil || ancestor.Phase == delegatestore.PhaseClosed || ancestor.PendingStopSeq != 0 || !ancestor.Resumable {
-			return nil, nil, errDelegateTargetBusy
-		}
-		ancestorID = ancestor.Descriptor.ParentDelegateID
+	if blocked, _ := c.ancestorFenceLocked(aggregate.Descriptor.ParentDelegateID); blocked {
+		return nil, nil, errDelegateTargetBusy
 	}
 	if slices.Contains(phases, aggregate.Phase) {
 		return aggregate, live, nil
 	}
 	return nil, nil, errDelegateTargetBusy
+}
+
+// ancestorFenceLocked walks the ancestor chain starting at parentID and
+// reports whether any ancestor refuses work under it -- the same policy
+// admitLeaseLocked applies to running leases. closedAncestorID identifies the
+// nearest ancestor whose refusal is permanent: resumability closes
+// monotonically (no event reopens it), so a missing or non-resumable ancestor
+// can never admit this subtree again. A blocked result with an empty
+// closedAncestorID is transient -- a pending subtree stop that clears when the
+// stop completes.
+func (c *delegateTreeController) ancestorFenceLocked(parentID string) (blocked bool, closedAncestorID string) {
+	for ancestorID := parentID; ancestorID != ""; {
+		ancestor := c.durable[ancestorID]
+		if ancestor == nil || !ancestor.Resumable {
+			return true, ancestorID
+		}
+		if ancestor.Phase == delegatestore.PhaseClosed || ancestor.PendingStopSeq != 0 {
+			return true, ""
+		}
+		ancestorID = ancestor.Descriptor.ParentDelegateID
+	}
+	return false, ""
 }
 
 func (c *delegateTreeController) Snapshot() delegateUpdatePlan {

--- a/agent/delegate_tree_controller.go
+++ b/agent/delegate_tree_controller.go
@@ -462,16 +462,23 @@ func (c *delegateTreeController) admitLeaseLocked(lease delegateLease, phases ..
 // admitLeaseLocked applies to running leases. closedAncestorID identifies the
 // nearest ancestor whose refusal is permanent: resumability closes
 // monotonically (no event reopens it), so a missing or non-resumable ancestor
-// can never admit this subtree again. A blocked result with an empty
-// closedAncestorID is transient -- a pending subtree stop that clears when the
-// stop completes.
+// can never admit this subtree again. PhaseClosed needs no separate check
+// because every fold transition into it requires !Resumable.
+//
+// A blocked result with an empty closedAncestorID is transient -- a pending
+// subtree stop that clears when the stop completes. The controller's own APIs
+// never leave a delegate outside the stop that covers its ancestor (the stop
+// request marks whole subtrees and creation under a stop is refused), so
+// callers that already checked the delegate's own PendingStopSeq reach this
+// branch only through a journal the fold accepts but this controller did not
+// emit; parking, not escalating, is the safe answer for such a journal.
 func (c *delegateTreeController) ancestorFenceLocked(parentID string) (blocked bool, closedAncestorID string) {
 	for ancestorID := parentID; ancestorID != ""; {
 		ancestor := c.durable[ancestorID]
 		if ancestor == nil || !ancestor.Resumable {
 			return true, ancestorID
 		}
-		if ancestor.Phase == delegatestore.PhaseClosed || ancestor.PendingStopSeq != 0 {
+		if ancestor.PendingStopSeq != 0 {
 			return true, ""
 		}
 		ancestorID = ancestor.Descriptor.ParentDelegateID

--- a/agent/delegate_tree_controller_test.go
+++ b/agent/delegate_tree_controller_test.go
@@ -474,7 +474,7 @@ var delegateControllerDormancyExpectedInventory = map[delegateControllerDormancy
 	{filename: "delegate_tree_restore.go", function: "(*delegateTreeController).executeDelegateAttentionCleanup", kind: "lifecycle method", symbol: "ReportAttentionResolved"}:         1,
 	{filename: "delegate_tree_restore.go", function: "(*delegateTreeController).executeDelegateAttentionCleanup", kind: "lifecycle method", symbol: "ReportAttentionConsumed"}:         1,
 	{filename: "delegate_tree_restore.go", function: "(*delegateTreeController).executeDelegateAttentionCleanup", kind: "lifecycle method", symbol: "ReportAttentionStabilized"}:       1,
-	{filename: "delegate_tree_restore.go", function: "(*delegateTreeController).executeDelegateAttentionCleanup", kind: "session attention method", symbol: "resolveAttentionDurably"}: 1,
+	{filename: "delegate_tree_restore.go", function: "(*delegateTreeController).resolveDelegateAttentionDurably", kind: "session attention method", symbol: "resolveAttentionDurably"}: 1,
 	{filename: "job_shell.go", function: "(*jobManager).beginStableDelegateShellReceipt", kind: "lifecycle method", symbol: "BeginShellWork"}:                                          1,
 	{filename: "job_shell.go", function: "(*stableDelegateShellReceipt).commit", kind: "lifecycle method", symbol: "CommitShellWork"}:                                                  1,
 	{filename: "job_shell.go", function: "(*stableDelegateShellReceipt).abort", kind: "lifecycle method", symbol: "AbortShellWork"}:                                                    1,

--- a/agent/delegate_tree_restore.go
+++ b/agent/delegate_tree_restore.go
@@ -2,9 +2,12 @@ package agent
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -300,7 +303,10 @@ func (c *delegateTreeController) closeMissingRestoreInputs(reasons map[string]st
 
 // repairPermanentlyUnreachableDelegateAttention transfers pending model-bound
 // input only after resumability has closed monotonically. Transcript I/O is
-// performed from an immutable tree snapshot without the controller mutex.
+// performed from an immutable tree snapshot without the controller mutex. It
+// also resolves the attention of live descendants that a permanently closed
+// ancestor fences off, escalating a notification to the root session so
+// nothing is lost silently and no wake retries forever.
 func repairPermanentlyUnreachableDelegateAttention(c *delegateTreeController) error {
 	if c == nil {
 		return errors.New("delegate controller is nil")
@@ -332,6 +338,22 @@ func repairPermanentlyUnreachableDelegateAttention(c *delegateTreeController) er
 			targetRef:        targetRef,
 		})
 	}
+	fenced := make([]delegateFencedAttentionEscalation, 0)
+	for id, aggregate := range c.durable {
+		if aggregate == nil || !aggregate.Resumable || aggregate.Phase != delegatestore.PhaseIdle || aggregate.PendingStopSeq != 0 {
+			continue
+		}
+		blocked, closedAncestorID := c.ancestorFenceLocked(aggregate.Descriptor.ParentDelegateID)
+		if !blocked || closedAncestorID == "" {
+			continue
+		}
+		fenced = append(fenced, delegateFencedAttentionEscalation{
+			delegateID:    id,
+			ancestorID:    closedAncestorID,
+			transcriptRef: aggregate.Descriptor.TranscriptRef,
+		})
+	}
+	sort.Slice(fenced, func(i, j int) bool { return fenced[i].delegateID < fenced[j].delegateID })
 	c.mu.Unlock()
 	if open == nil {
 		open = transcript.OpenWriterForSession
@@ -363,7 +385,50 @@ func repairPermanentlyUnreachableDelegateAttention(c *delegateTreeController) er
 			}
 		}
 	}
+	rootPath := transcriptPath(stateDir, rootSessionID)
+	for _, plan := range fenced {
+		sourcePath, sourceSessionID, err := delegateTranscriptPathFromRef(stateDir, plan.transcriptRef)
+		if err != nil {
+			return fmt.Errorf("fenced delegate %s source transcript: %w", plan.delegateID, err)
+		}
+		fold, err := readDelegateAttentionFold(sourcePath, sourceSessionID)
+		if err != nil {
+			return fmt.Errorf("fenced delegate %s attention fold: %w", plan.delegateID, err)
+		}
+		pending := fold.pendingIDs()
+		if len(pending) == 0 {
+			continue
+		}
+		sort.Strings(pending)
+		// Notification before resolution: a crash in between replays into an
+		// idempotent no-op append and a second resolution attempt, never a
+		// silently discarded message.
+		notificationID := unreachableDelegateAttentionID(plan.delegateID, pending)
+		content := unreachableDelegateAttentionContent(plan.delegateID, plan.ancestorID, len(pending))
+		if _, err := appendColdDelegateNotificationDurablyWithOpen(rootPath, rootSessionID, notificationID, content, now(), open); err != nil {
+			return fmt.Errorf("fenced delegate %s escalate attention: %w", plan.delegateID, err)
+		}
+		if err := appendColdAttentionResolutionWithOpen(sourcePath, sourceSessionID, pending, delegateAttentionDiscarded, open); err != nil {
+			return fmt.Errorf("fenced delegate %s resolve escalated attention: %w", plan.delegateID, err)
+		}
+	}
 	return nil
+}
+
+// unreachableDelegateAttentionID derives one deterministic notification
+// identity per escalated batch so crash replays append nothing new while a
+// later, different batch gets its own notification.
+func unreachableDelegateAttentionID(delegateID string, attentionIDs []string) string {
+	sum := sha256.Sum256([]byte(strings.Join(attentionIDs, "\n")))
+	return "unreachable:" + delegateID + ":" + hex.EncodeToString(sum[:8])
+}
+
+func unreachableDelegateAttentionContent(delegateID, ancestorID string, count int) string {
+	return fmt.Sprintf(
+		"<delegate-notification delegate_id=%q>%s</delegate-notification>",
+		html.EscapeString(delegateID),
+		html.EscapeString(fmt.Sprintf("delegate %s had %d undelivered message(s) when its ancestor %s closed", delegateID, count, ancestorID)),
+	)
 }
 
 func nearestReachableAttentionAncestorLocked(state delegatestore.State, parentID string) string {
@@ -506,22 +571,8 @@ func (c *delegateTreeController) executeDelegateAttentionCleanup(plan delegateAt
 		}
 		return c.ReportAttentionStabilized(plan.lease, plan.attentionID, plan.runtime)
 	}
-	if plan.runtime != nil {
-		if err := plan.runtime.resolveAttentionDurably([]string{plan.attentionID}, plan.disposition); err != nil {
-			return err
-		}
-	} else {
-		path, expectedSessionID, err := delegateTranscriptPathFromRef(c.stateDir, plan.transcriptRef)
-		if err != nil {
-			return err
-		}
-		open := c.attentionOpen
-		if open == nil {
-			open = transcript.OpenWriterForSession
-		}
-		if err := appendColdAttentionResolutionWithOpen(path, expectedSessionID, []string{plan.attentionID}, plan.disposition, open); err != nil {
-			return err
-		}
+	if err := c.resolveDelegateAttentionDurably(plan.runtime, plan.transcriptRef, []string{plan.attentionID}, plan.disposition); err != nil {
+		return err
 	}
 	if plan.disposition == delegateAttentionConsumed {
 		_, err := c.ReportAttentionConsumed(plan.lease, plan.attentionID, plan.runtime)
@@ -529,6 +580,24 @@ func (c *delegateTreeController) executeDelegateAttentionCleanup(plan delegateAt
 	}
 	_, err := c.ReportAttentionResolved(plan.requestSeq, plan.evidenceVersion, plan.delegateID, plan.attentionID, plan.disposition, plan.runtime)
 	return err
+}
+
+// resolveDelegateAttentionDurably appends attention resolution markers through
+// the resident runtime's one writer when it exists, and through a cold writer
+// on the receiver transcript otherwise.
+func (c *delegateTreeController) resolveDelegateAttentionDurably(runtime *Session, transcriptRef string, ids []string, disposition delegateAttentionResolution) error {
+	if runtime != nil {
+		return runtime.resolveAttentionDurably(ids, disposition)
+	}
+	path, expectedSessionID, err := delegateTranscriptPathFromRef(c.stateDir, transcriptRef)
+	if err != nil {
+		return err
+	}
+	open := c.attentionOpen
+	if open == nil {
+		open = transcript.OpenWriterForSession
+	}
+	return appendColdAttentionResolutionWithOpen(path, expectedSessionID, ids, disposition, open)
 }
 
 func (c *delegateTreeController) reconcileRuntimeLostFromEvidenceLocked() (delegateMutationPlans, error) {

--- a/agent/delegate_tree_restore.go
+++ b/agent/delegate_tree_restore.go
@@ -2,12 +2,9 @@ package agent
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -304,9 +301,9 @@ func (c *delegateTreeController) closeMissingRestoreInputs(reasons map[string]st
 // repairPermanentlyUnreachableDelegateAttention transfers pending model-bound
 // input only after resumability has closed monotonically. Transcript I/O is
 // performed from an immutable tree snapshot without the controller mutex. It
-// also resolves the attention of live descendants that a permanently closed
-// ancestor fences off, escalating a notification to the root session so
-// nothing is lost silently and no wake retries forever.
+// also transfers the attention of live descendants that a permanently closed
+// ancestor fences off to the root session -- each message under its own
+// original identity, so nothing is lost silently and no wake retries forever.
 func repairPermanentlyUnreachableDelegateAttention(c *delegateTreeController) error {
 	if c == nil {
 		return errors.New("delegate controller is nil")
@@ -338,7 +335,7 @@ func repairPermanentlyUnreachableDelegateAttention(c *delegateTreeController) er
 			targetRef:        targetRef,
 		})
 	}
-	fenced := make([]delegateFencedAttentionEscalation, 0)
+	fencedIDs := make([]string, 0, len(c.durable))
 	for id, aggregate := range c.durable {
 		if aggregate == nil || !aggregate.Resumable || aggregate.Phase != delegatestore.PhaseIdle || aggregate.PendingStopSeq != 0 {
 			continue
@@ -347,13 +344,17 @@ func repairPermanentlyUnreachableDelegateAttention(c *delegateTreeController) er
 		if !blocked || closedAncestorID == "" {
 			continue
 		}
-		fenced = append(fenced, delegateFencedAttentionEscalation{
-			delegateID:    id,
-			ancestorID:    closedAncestorID,
-			transcriptRef: aggregate.Descriptor.TranscriptRef,
+		fencedIDs = append(fencedIDs, id)
+	}
+	sort.Strings(fencedIDs)
+	for _, id := range fencedIDs {
+		// A live descendant fenced off permanently transfers straight to the
+		// root: an empty target is the existing "escalate to root" shape below.
+		plans = append(plans, delegateAttentionTransferPlan{
+			sourceDelegateID: id,
+			sourceRef:        c.durable[id].Descriptor.TranscriptRef,
 		})
 	}
-	sort.Slice(fenced, func(i, j int) bool { return fenced[i].delegateID < fenced[j].delegateID })
 	c.mu.Unlock()
 	if open == nil {
 		open = transcript.OpenWriterForSession
@@ -385,50 +386,7 @@ func repairPermanentlyUnreachableDelegateAttention(c *delegateTreeController) er
 			}
 		}
 	}
-	rootPath := transcriptPath(stateDir, rootSessionID)
-	for _, plan := range fenced {
-		sourcePath, sourceSessionID, err := delegateTranscriptPathFromRef(stateDir, plan.transcriptRef)
-		if err != nil {
-			return fmt.Errorf("fenced delegate %s source transcript: %w", plan.delegateID, err)
-		}
-		fold, err := readDelegateAttentionFold(sourcePath, sourceSessionID)
-		if err != nil {
-			return fmt.Errorf("fenced delegate %s attention fold: %w", plan.delegateID, err)
-		}
-		pending := fold.pendingIDs()
-		if len(pending) == 0 {
-			continue
-		}
-		sort.Strings(pending)
-		// Notification before resolution: a crash in between replays into an
-		// idempotent no-op append and a second resolution attempt, never a
-		// silently discarded message.
-		notificationID := unreachableDelegateAttentionID(plan.delegateID, pending)
-		content := unreachableDelegateAttentionContent(plan.delegateID, plan.ancestorID, len(pending))
-		if _, err := appendColdDelegateNotificationDurablyWithOpen(rootPath, rootSessionID, notificationID, content, now(), open); err != nil {
-			return fmt.Errorf("fenced delegate %s escalate attention: %w", plan.delegateID, err)
-		}
-		if err := appendColdAttentionResolutionWithOpen(sourcePath, sourceSessionID, pending, delegateAttentionDiscarded, open); err != nil {
-			return fmt.Errorf("fenced delegate %s resolve escalated attention: %w", plan.delegateID, err)
-		}
-	}
 	return nil
-}
-
-// unreachableDelegateAttentionID derives one deterministic notification
-// identity per escalated batch so crash replays append nothing new while a
-// later, different batch gets its own notification.
-func unreachableDelegateAttentionID(delegateID string, attentionIDs []string) string {
-	sum := sha256.Sum256([]byte(strings.Join(attentionIDs, "\n")))
-	return "unreachable:" + delegateID + ":" + hex.EncodeToString(sum[:8])
-}
-
-func unreachableDelegateAttentionContent(delegateID, ancestorID string, count int) string {
-	return fmt.Sprintf(
-		"<delegate-notification delegate_id=%q>%s</delegate-notification>",
-		html.EscapeString(delegateID),
-		html.EscapeString(fmt.Sprintf("delegate %s had %d undelivered message(s) when its ancestor %s closed", delegateID, count, ancestorID)),
-	)
 }
 
 func nearestReachableAttentionAncestorLocked(state delegatestore.State, parentID string) string {

--- a/agent/delegate_tree_start.go
+++ b/agent/delegate_tree_start.go
@@ -191,16 +191,11 @@ func (c *delegateTreeController) ReserveAttention(runtime *Session, attentionID 
 		return nil, errDelegateStaleLease
 	}
 	aggregate := c.durable[delegateID]
-	if attentionID == "" || aggregate == nil || aggregate.Phase != delegatestore.PhaseIdle || !aggregate.Resumable || aggregate.PendingStopSeq != 0 || live.binding != nil || live.recoveryRequired || c.reclamationCoversLocked(delegateID) {
+	if attentionID == "" || aggregate == nil || !c.delegateAttentionWakeEligibleLocked(delegateID) {
 		return nil, errDelegateTargetBusy
 	}
 	if blocked, _ := c.ancestorFenceLocked(aggregate.Descriptor.ParentDelegateID); blocked {
 		return nil, errDelegateTargetBusy
-	}
-	for _, existing := range c.reservations {
-		if existing.delegateID == delegateID {
-			return nil, errDelegateTargetBusy
-		}
 	}
 	if !c.reserveCapacityLocked(delegateDriveCapacity) {
 		return nil, errTreeAtCapacity

--- a/agent/delegate_tree_start.go
+++ b/agent/delegate_tree_start.go
@@ -194,6 +194,9 @@ func (c *delegateTreeController) ReserveAttention(runtime *Session, attentionID 
 	if attentionID == "" || aggregate == nil || aggregate.Phase != delegatestore.PhaseIdle || !aggregate.Resumable || aggregate.PendingStopSeq != 0 || live.binding != nil || live.recoveryRequired || c.reclamationCoversLocked(delegateID) {
 		return nil, errDelegateTargetBusy
 	}
+	if blocked, _ := c.ancestorFenceLocked(aggregate.Descriptor.ParentDelegateID); blocked {
+		return nil, errDelegateTargetBusy
+	}
 	for _, existing := range c.reservations {
 		if existing.delegateID == delegateID {
 			return nil, errDelegateTargetBusy
@@ -576,6 +579,11 @@ func (c *delegateTreeController) CommitStart(reservation *delegateStartReservati
 			return delegateStartCommit{}, errDelegateTargetBusy
 		}
 	} else if aggregate == nil || aggregate.Phase != delegatestore.PhaseIdle || aggregate.Generation+1 != record.generation {
+		cancel = c.releaseReservationLocked(record)
+		return delegateStartCommit{}, errDelegateTargetBusy
+	} else if blocked, _ := c.ancestorFenceLocked(aggregate.Descriptor.ParentDelegateID); blocked {
+		// Re-check the ancestor chain: an ancestor that closed between reserve
+		// and commit would make every model request of this generation fail.
 		cancel = c.releaseReservationLocked(record)
 		return delegateStartCommit{}, errDelegateTargetBusy
 	}

--- a/agent/session_attention.go
+++ b/agent/session_attention.go
@@ -306,11 +306,22 @@ func delegateAttentionResolutionTurn(attentionID string, disposition delegateAtt
 // item. Replaying the same identity and content is a no-op; reusing an identity
 // for different content is corruption.
 func (s *Session) appendDelegateNotificationDurably(attentionID, content string) (appended bool, err error) {
+	return s.appendDelegateAttentionMessageDurably(attentionID, llm.User(content))
+}
+
+// appendDelegateAttentionMessageDurably is the message-preserving core of
+// appendDelegateNotificationDurably. Escalation of a fenced delegate's
+// attention transfers the exact original message under its original identity,
+// so both the resident and the cold writers stay byte-identical on replay.
+func (s *Session) appendDelegateAttentionMessageDurably(attentionID string, message llm.Message) (appended bool, err error) {
 	if s == nil {
 		return false, errors.New("delegate attention session is nil")
 	}
 	if attentionID == "" {
 		return false, errors.New("delegate attention ID is empty")
+	}
+	if message.Role != llm.RoleUser || len(message.Content) == 0 {
+		return false, errors.New("delegate attention message is invalid")
 	}
 	s.attentionMu.Lock()
 	defer s.attentionMu.Unlock()
@@ -329,7 +340,6 @@ func (s *Session) appendDelegateNotificationDurably(attentionID, content string)
 	if err != nil {
 		return false, err
 	}
-	message := llm.User(content)
 	deliveryID := strings.TrimPrefix(attentionID, "delegate:")
 	if deliveryID != attentionID && fold.deliveryCommits[deliveryID] != "" {
 		_, durableFold, err := s.reopenAttentionTranscriptDurably(writer, path, sessionID)


### PR DESCRIPTION
## The bug (confirmed by an executed probe during adversarial review)

Attention wakes bypassed the closed-ancestor fence. `ReserveAttention`, the `CommitStart` re-check, and `nextIdleDelegateAttention` admitted against the target delegate's own aggregate only, while `admitLeaseLocked` walks the ancestor chain and refuses every model request under a closed/stopping/non-resumable ancestor.

Consequence: supervision woke an idle child with pending attention under a permanently closed ancestor (e.g. the parent hit `ResumabilityClosed` via turn-budget exhaustion). ReserveAttention + CommitStart durably committed a generation whose every `BeginModelRequest` failed `target_busy` forever — the error path then either consumed the attention unprocessed or re-armed it into a durable wake/fail loop appending a RunStarted+finish batch per cycle. Cold-path variant: restore refused correctly, so the root spun an unbounded warning/retry loop.

## The fix

- **Shared fence.** `admitLeaseLocked`'s ancestor walk is extracted into `ancestorFenceLocked` and applied in `ReserveAttention`, the `CommitStart` re-check (covering the reserve→commit race), and `nextIdleDelegateAttention`, so no wake path can commit a generation under a closed/stopping/non-resumable ancestor. The fence classifies the block: resumability closes monotonically (no event reopens it), so a missing or non-resumable ancestor is **permanent**; a pending subtree stop is **transient**. `PhaseClosed` needs no separate check (every fold transition into it requires `!Resumable`); the transient branch is reachable only through journals the fold accepts but this controller never emits (creation under a pending subtree stop), which is documented on the fence and pinned by a test that builds exactly such a journal and goes red if transient is mutated to permanent.
- **Permanent closure → per-message transfer to root.** Each stranded attention's **original message** moves to the root transcript under its **own original identity** (the same transfer mechanism `repairPermanentlyUnreachableDelegateAttention` already used for a closed delegate's own attention), then the source is durably resolved. Because identity and content are immutable per attention, a crash between the root append and the source resolution replays into a genuine no-op append plus a second resolution attempt — exactly-once regardless of closed-ancestor cascades or attention arriving mid-escalation, and the message text itself survives, so "nothing silently lost" is literal. The cold path folds fenced descendants into the existing transfer-plan loop (empty target = root); the hot path runs from `drivePendingStableDelegateAttention` via `appendDelegateAttentionMessageDurably` (the message-preserving core of `appendDelegateNotificationDurably`, keeping resident and cold writers byte-identical). Per-delegate escalation failures are collected and joined; one wedged delegate cannot starve the batch. The wake-cache scans, `ReserveAttention`, and the escalation collector share one eligibility predicate (`delegateAttentionWakeEligibleLocked`) so they cannot disagree.
- **Transient closure → park.** Ancestor stopping but resumable: the attention stays parked — no wake, no resolution, no escalation — and a later ancestor resume delivers it unchanged.

## Tests (red first, all confirmed failing before the corresponding change)

- `TestDelegateAttentionWake_ClosedAncestorRefusesReserveAndNextIdle` — the probe: red showed `ReserveAttention = <nil>` (wake admitted under closed ancestor)
- `TestDelegateAttentionWake_CommitStartRechecksAncestorFence` — red showed `CommitStart = <nil>` (inoperable generation durably committed)
- `TestDelegateAttentionWake_PermanentClosedAncestorEscalatesToRootOnce` — hot path with a resident root over a three-level tree; asserts refusal, per-message transfer of the original text under the original ID, durable source discard, exactly-once across hot-driver + cold-repair replays, no committed generation
- `TestStableDelegateAttention_ColdRestoreEscalatesFencedDescendantOnce` — cold restore; asserts transfer + resolution, no armed wake / retry fuel, second bootstrap duplicates nothing
- `TestStableDelegateAttention_EscalationCrashWindowSurvivesCascadeAndGrowth` — interrupts BETWEEN the root transfer and the source resolution, then closes a further ancestor (the cascade that moved the nearest fenced ancestor) and lands a second attention before replay; asserts bootstrap completes with exactly one root copy of each message and both sources resolved. Red under the batch design: `root transfers = map[delegate:crash-window-a:1 unreachable:dlg_child:8680…:1]` — the second message's text never reached root
- `TestDelegateAttentionWake_AncestorStopFenceParksUncoveredChild` — reaches the fence's transient branch itself via a fold-valid journal (child created under a pending ancestor stop, own `PendingStopSeq` clear); goes red if the transient classification is mutated to permanent (verified: mutation → `stopping ancestor classified as permanent`), and pins post-stop delivery
- `TestDelegateAttentionWake_StoppingAncestorParksAttentionForLaterDelivery` — pins the covered-subtree transient policy end to end

## Verification

- `go test ./agent/ -race -short -count=1` — pass (on current main, post-rebase)
- Delegate fuzzers (`serffuzz` tag, 20s each): `FuzzDelegateControllerTransitions`, `FuzzDelegateReclaimStopRestart`, `FuzzDelegateRestartEquivalence`, `FuzzDelegateAttentionFold`, `FuzzStableDelegateWatchDelivery` — all pass
- `golangci-lint run ./...` from `agent/` — 0 issues (after cache clean)

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU