### PR TITLE
fix(composer): two windows where a pending send lost its queue route

### DIFF
--- a/cmd/serf-hub/frontend/src/panes/session/composer/Composer.test.tsx
+++ b/cmd/serf-hub/frontend/src/panes/session/composer/Composer.test.tsx
@@ -1006,18 +1006,24 @@ function routedCalls(fake: FakeClient): string[] {
   return fake.calls.filter((c) => c.method === "turn/start" || c.method === "turn/queue").map((c) => c.method);
 }
 
-// The same race, in its WIDEST form. A cold "notLoaded" thread is one the hub
+// The same race, in its WIDEST form. A finished thread is one the hub
 // auto-resumes on the first turn/start, and resuming means spawning a daemon -
 // so the gap before any status frame arrives is seconds, not one frame.
+//
+// Both finished shapes reach it. "notLoaded" is a cold thread with no daemon
+// behind it (app_threadread.go's pastEntryThread) and "closed" is a session
+// that shut down in front of us; the hub hands the same resumable capability
+// set to both (app_threadread.go's pastThreadCapabilities, pushed at close by
+// stampClosedThreadCapabilities), so the fixture only varies the status.
 //
 // The daemon exists by the time the queue goes out: MutationDispatcher
 // serializes per targetRef, so the second mutation is not dispatched until the
 // first turn/start has returned a receipt, and that receipt is what the
 // auto-resume produced. turn/queue has no resume loop of its own
 // (app_rpc.go gives one to turn/start alone), and it does not need one here.
-async function mountColdResumedThread(): Promise<FakeClient> {
+async function mountColdResumedThread(statusType = "notLoaded"): Promise<FakeClient> {
   const fake = await mountComposer("ref_a", {
-    status: { type: "notLoaded" },
+    status: { type: statusType },
     serf: { ref: "ref_a", capabilities: PAST_THREAD_CAPABILITIES, queue: { revision: 0 } },
   });
   // The real daemon reserves a turn id on the first turn/start, so every later
@@ -1057,6 +1063,25 @@ async function mountColdResumedThread(): Promise<FakeClient> {
 test("a cold auto-resumed session queues the second message rather than bouncing it too", async () => {
   const user = userEvent.setup();
   const fake = await mountColdResumedThread();
+
+  await user.click(textarea());
+  await user.type(textarea(), "first message");
+  await user.click(submitButton());
+  await waitFor(() => expect(fake.calls.some((c) => c.method === "turn/start")).toBe(true));
+
+  await user.type(textarea(), "second message");
+  await user.click(submitButton());
+
+  await waitFor(() => expect(routedCalls(fake)).toHaveLength(2));
+  expect(routedCalls(fake)).toEqual(["turn/start", "turn/queue"]);
+});
+
+// A session that closed in front of us resumes on the same first turn/start,
+// through the same seconds-wide window - the status is the only difference, and
+// the daemon it wakes refuses a second turn/start exactly as readily.
+test("a closed session that a first message resumed queues the second message too", async () => {
+  const user = userEvent.setup();
+  const fake = await mountColdResumedThread("closed");
 
   await user.click(textarea());
   await user.type(textarea(), "first message");

--- a/cmd/serf-hub/frontend/src/panes/session/composer/Composer.test.tsx
+++ b/cmd/serf-hub/frontend/src/panes/session/composer/Composer.test.tsx
@@ -13,7 +13,12 @@ import { useCommandCatalog } from "../../../stores/commandCatalog";
 import { connectionStore } from "../../../stores/connection";
 import { MutationOutboxIndexedDB } from "../../../stores/mutationOutboxIndexedDB";
 import { prefsStore, resetPrefsStoreForTests } from "../../../stores/prefs";
-import { resetThreadsStoreForTests, setMutationStorageForTests, threadsStore } from "../../../stores/threads";
+import {
+  readMutationPersistence,
+  resetThreadsStoreForTests,
+  setMutationStorageForTests,
+  threadsStore,
+} from "../../../stores/threads";
 import { Toast } from "../../../widgets";
 import buttonStyles from "../../../widgets/button/button.module.css";
 import iconButtonStyles from "../../../widgets/iconbutton/iconbutton.module.css";
@@ -1144,6 +1149,88 @@ test("a turn/start pending for another client does not reroute this composer", a
 
   await waitFor(() => expect(routedCalls(fake)).toHaveLength(1));
   expect(routedCalls(fake)).toEqual(["turn/start"]);
+});
+
+// The same window as the tier-6 test above, with a hydrate landing in the
+// middle of it. A reconnect or a pane reopen re-reads the thread, and the read
+// answers with THIS client's still-unsettled send in pendingMutations while the
+// status has not moved off idle yet. Two things happen to the client's own
+// record of that send: the hydrate's identity reconciliation deletes the
+// durable outbox/optimistic record (threads.ts's reconcileIdentities ->
+// settleApplied), and pendingReconcile re-presents the same clientMutationId
+// from the authoritative projection. Routing must still see the send as this
+// client's own - it is the same send, described by a different source.
+test("a hydrate that reports this client's own in-flight send still routes the next message to the queue", async () => {
+  const user = userEvent.setup();
+  let readOverrides: Partial<Thread> = {
+    status: { type: "idle" },
+    serf: { ref: "ref_a", capabilities: DAEMON_IDLE_CAPABILITIES, queue: { revision: 0 } },
+  };
+  const fake = await mountComposer("ref_a", readOverrides);
+  fake.on("thread/read", () => readResponse("ref_a", readOverrides));
+  let firstSendId: string | undefined;
+  fake.on("turn/start", (params) => {
+    firstSendId ??= params.clientMutationId;
+    return {
+      receipt: {
+        clientMutationId: params.clientMutationId,
+        disposition: "applied" as const,
+        threadId: "thread_a",
+        projectionState: "pending" as const,
+      },
+      turn: { id: "turn_1", status: "inProgress" as const, itemsView: "" },
+    };
+  });
+  fake.on("turn/queue", (params) => ({
+    receipt: {
+      clientMutationId: params.clientMutationId,
+      disposition: "applied" as const,
+      threadId: "thread_a",
+      projectionState: "pending" as const,
+    },
+  }));
+
+  await user.type(textarea(), "first message");
+  await user.click(submitButton());
+  await waitFor(() => expect(firstSendId).toBeTruthy());
+
+  // The re-read the reconnect/reopen performs: same idle status and idle
+  // capability set as before, plus the daemon's own account of the send that is
+  // still in flight.
+  readOverrides = {
+    status: { type: "idle" },
+    serf: {
+      ref: "ref_a",
+      capabilities: DAEMON_IDLE_CAPABILITIES,
+      queue: { revision: 0 },
+      pendingMutations: [
+        {
+          clientMutationId: firstSendId as string,
+          method: "turn/start",
+          input: [{ type: "text", text: "first message" }],
+          executionState: "accepted",
+          projectionState: "pending",
+        },
+      ],
+    },
+  };
+  await act(async () => {
+    fake.emitNotification({ method: "serf/thread/resync", params: { threadId: "thr_ref_a", ref: "ref_a" } });
+  });
+  await waitFor(() => expect(threadsStore.getState().threads.get("ref_a")?.pendingMutations).toHaveLength(1));
+  // Wait out the settlement the publish drives, so the second message is
+  // composed in the harder of the two states this hydrate passes through: not
+  // merely re-described from the authoritative projection, but with the durable
+  // record it re-described GONE. (The transient first state, where the record
+  // still exists and only `source` has flipped, is pendingReconcile.test.ts's.)
+  await waitFor(async () => expect((await readMutationPersistence("ref_a")).optimistic).toHaveLength(0));
+  await flushPendingTurnsProjectionForTests();
+
+  await user.type(textarea(), "second message");
+  await user.click(submitButton());
+
+  await waitFor(() => expect(routedCalls(fake)).toHaveLength(2));
+  expect(routedCalls(fake)).toEqual(["turn/start", "turn/queue"]);
 });
 
 test("submitting an empty composer fires no request", async () => {

--- a/cmd/serf-hub/frontend/src/panes/session/composer/Composer.tsx
+++ b/cmd/serf-hub/frontend/src/panes/session/composer/Composer.tsx
@@ -542,15 +542,23 @@ export function Composer({ ref }: ComposerProps) {
   // with Conflict("turn is already active") - see tier 6 in
   // deriveSendQueueAvailability.
   //
-  // Authoritative entries are excluded deliberately, and tier 6 does not work
-  // without that. usePendingTurnEntries also surfaces model.pendingMutations,
-  // which is the DAEMON's session-wide mutation projection: it covers every
-  // client on the session, reducer.ts writes it only at hydrate, and no
-  // notification ever refreshes it. Feeding it to a routing decision would
-  // reroute this composer on another tab's or the TUI's in-flight send, from a
-  // snapshot that may be arbitrarily old - exactly the "daemon's state arriving
-  // late" that tier 6's own justification rests on not being.
-  const hasPendingSend = pendingSendEntries.some((entry) => entry.source !== "authoritative");
+  // Someone else's pending send is excluded deliberately, and tier 6 does not
+  // work without that. usePendingTurnEntries also surfaces
+  // model.pendingMutations, which is the DAEMON's session-wide mutation
+  // projection: it covers every client on the session, reducer.ts writes it only
+  // at hydrate, and no notification ever refreshes it. Feeding it to a routing
+  // decision would reroute this composer on another tab's or the TUI's in-flight
+  // send, from a snapshot that may be arbitrarily old - exactly the "daemon's
+  // state arriving late" that tier 6's own justification rests on not being.
+  //
+  // The question is whose send it is, which is what fromThisClient answers. It
+  // is deliberately not entry.source: that names the projection describing the
+  // row, and a hydrate landing mid-send re-describes THIS client's own
+  // unsettled send as "authoritative" (pendingReconcile's own doc comment).
+  // Reading routing off the presentation source therefore lost tier 6 for the
+  // sender at exactly the moment the daemon confirmed it had the send - the
+  // next message went to turn/start and bounced.
+  const hasPendingSend = pendingSendEntries.some((entry) => entry.fromThisClient);
   const tableAvailability = deriveSendQueueAvailability({
     statusType: model.status.type,
     capabilities: model.capabilities,

--- a/cmd/serf-hub/frontend/src/panes/session/composer/Composer.tsx
+++ b/cmd/serf-hub/frontend/src/panes/session/composer/Composer.tsx
@@ -568,16 +568,14 @@ export function Composer({ ref }: ComposerProps) {
   // advertises Send for an exited serf thread and auto-resumes it on the first
   // message (turn/start alone carries that resume loop - app_rpc.go). The
   // CAPABILITY is the authority for THAT question, not the availability table,
-  // which reports both-false for ended/closed because no turn is in flight to
-  // send to or queue behind.
+  // which reports both-false for a finished session with nothing pending,
+  // because no turn is in flight to send to or queue behind.
   //
-  // It only substitutes when the table has nothing to offer. Overriding
-  // unconditionally also clobbered "notLoaded", which is an ENDED_STATUSES
-  // member the table does NOT report both-false for: tier 6 resolves a cold
-  // thread's second message to queue-mode, and a blanket override turned it
-  // back into the turn/start that bounces. That is the widest instance of the
-  // race tier 6 exists for, not a corner - resuming a cold thread means
-  // spawning a daemon, so the window before any status frame is seconds.
+  // It only substitutes when the table has nothing to offer, which is what
+  // keeps it clear of tier 6. Overriding unconditionally turned every finished
+  // status' SECOND message back into the turn/start that bounces - the table
+  // answers queue-mode there, for the whole time the resume takes to produce a
+  // status frame, which for a session that has to spawn a daemon is seconds.
   const availability =
     ended && canSendWhenEnded && !tableAvailability.canSend && !tableAvailability.canQueue
       ? { canSend: true, canQueue: false }
@@ -1222,9 +1220,11 @@ export function Composer({ ref }: ComposerProps) {
                           aria-label="Send"
                           icon={<SendIcon />}
                           // canCompose comes from the availability table, which
-                          // reports both-false for ended/closed: it answers "can
-                          // this turn be sent to right now", and a follow-up to a
-                          // finished session resumes it first. The capability is
+                          // reports both-false for an idle finished session: it
+                          // answers "can this turn be sent to right now", and a
+                          // follow-up to a finished session resumes it first
+                          // (only once that resume is in flight does the table
+                          // have an answer of its own). The capability is
                           // the authority there, the same way it is for whether
                           // this card renders at all - otherwise a session the hub
                           // will happily resume shows a permanently dead Send.

--- a/cmd/serf-hub/frontend/src/panes/session/composer/queue/pendingReconcile.test.ts
+++ b/cmd/serf-hub/frontend/src/panes/session/composer/queue/pendingReconcile.test.ts
@@ -59,8 +59,14 @@ function model(overrides: Partial<ThreadModel> = {}): ThreadModel {
   };
 }
 
+// The ids this client's own durable projection has held. Empty unless a test
+// is specifically about a submission whose local record is already gone.
+const NOTHING_SUBMITTED_HERE: ReadonlySet<string> = new Set();
+
 test("two same-text outbox records remain distinct by client mutation identity", () => {
-  expect(reconcilePendingEntries("ref_a", [outbox("mutation_1"), outbox("mutation_2")], model())).toMatchObject([
+  expect(
+    reconcilePendingEntries("ref_a", [outbox("mutation_1"), outbox("mutation_2")], model(), NOTHING_SUBMITTED_HERE),
+  ).toMatchObject([
     { id: "mutation_1", text: "hello", source: "outbox" },
     { id: "mutation_2", text: "hello", source: "outbox" },
   ]);
@@ -79,6 +85,7 @@ test("the authoritative pending projection replaces the same outbox identity", (
       "ref_a",
       [outbox("mutation_1", "turn/steer", "keep steering")],
       model({ pendingMutations: [pending] }),
+      NOTHING_SUBMITTED_HERE,
     ),
   ).toEqual([
     expect.objectContaining({
@@ -88,6 +95,54 @@ test("the authoritative pending projection replaces the same outbox identity", (
       source: "authoritative",
     }),
   ]);
+});
+
+// `source` says which projection is DESCRIBING the row and flips to
+// "authoritative" the moment a hydrate reports the same clientMutationId.
+// Whose submission it is cannot flip with it - the id is the same submission
+// either way - and that is the question send/queue routing asks (tier 6 of
+// deriveSendQueueAvailability takes strictly this client's own sends).
+test("a locally submitted mutation stays this client's own once the authoritative projection describes it", () => {
+  const pending: PendingMutation = {
+    clientMutationId: "mutation_1",
+    method: "turn/start",
+    input: [{ type: "text", text: "hello" }],
+    executionState: "accepted",
+    projectionState: "pending",
+  };
+  expect(
+    reconcilePendingEntries("ref_a", [outbox("mutation_1")], model({ pendingMutations: [pending] }), new Set()),
+  ).toEqual([expect.objectContaining({ id: "mutation_1", source: "authoritative", fromThisClient: true })]);
+});
+
+// The hydrate that re-describes the row also settles the durable record behind
+// it (threads.ts's reconcileIdentities -> settleApplied), so the outbox list is
+// empty by the time the next message is composed. The submitted-here identities
+// are what carries the answer across that deletion.
+test("a mutation this client submitted stays its own after its durable record is settled away", () => {
+  const pending: PendingMutation = {
+    clientMutationId: "mutation_1",
+    method: "turn/start",
+    input: [{ type: "text", text: "hello" }],
+    executionState: "accepted",
+    projectionState: "pending",
+  };
+  expect(reconcilePendingEntries("ref_a", [], model({ pendingMutations: [pending] }), new Set(["mutation_1"]))).toEqual(
+    [expect.objectContaining({ id: "mutation_1", source: "authoritative", fromThisClient: true })],
+  );
+});
+
+test("a pending mutation this client never submitted is not its own", () => {
+  const pending: PendingMutation = {
+    clientMutationId: "mutation_from_another_client",
+    method: "turn/start",
+    input: [{ type: "text", text: "someone else's message" }],
+    executionState: "accepted",
+    projectionState: "pending",
+  };
+  expect(reconcilePendingEntries("ref_a", [], model({ pendingMutations: [pending] }), new Set(["mutation_1"]))).toEqual(
+    [expect.objectContaining({ id: "mutation_from_another_client", fromThisClient: false })],
+  );
 });
 
 test("a transcript item with the identity removes the optimistic projection regardless of text", () => {
@@ -112,6 +167,7 @@ test("a transcript item with the identity removes the optimistic projection rega
           },
         ],
       }),
+      NOTHING_SUBMITTED_HERE,
     ),
   ).toEqual([]);
 });
@@ -122,13 +178,19 @@ test("an authoritative queue identity is rendered by QueueStrip rather than dupl
       "ref_a",
       [outbox("mutation_1", "turn/queue")],
       model({ queue: { revision: 1, clientMutationIds: ["mutation_1"] } }),
+      NOTHING_SUBMITTED_HERE,
     ),
   ).toEqual([]);
 });
 
 test("blockedUnknown remains visible and is not converted by elapsed time", () => {
   expect(
-    reconcilePendingEntries("ref_a", [outbox("mutation_1", "turn/start", "uncertain", "blockedUnknown")], model()),
+    reconcilePendingEntries(
+      "ref_a",
+      [outbox("mutation_1", "turn/start", "uncertain", "blockedUnknown")],
+      model(),
+      NOTHING_SUBMITTED_HERE,
+    ),
   ).toEqual([
     expect.objectContaining({
       id: "mutation_1",

--- a/cmd/serf-hub/frontend/src/panes/session/composer/queue/pendingReconcile.ts
+++ b/cmd/serf-hub/frontend/src/panes/session/composer/queue/pendingReconcile.ts
@@ -14,6 +14,14 @@ export interface PendingTurnEntry {
   createdAt?: number;
   state: PendingTurnState;
   source: "outbox" | "optimistic" | "authoritative";
+  // Whether THIS client submitted the mutation. Separate from `source`, which
+  // names the projection currently DESCRIBING the row and flips to
+  // "authoritative" the moment a hydrate reports the same clientMutationId:
+  // one submission, two describers. Send/queue routing asks whose submission it
+  // is (deriveSendQueueAvailability's tier 6 counts strictly this client's own
+  // sends, never the daemon's session-wide projection of every client's), and
+  // that answer cannot change when a hydrate lands.
+  fromThisClient: boolean;
 }
 
 function pendingMethod(method: string): PendingMethod | undefined {
@@ -66,10 +74,16 @@ function outboxEntry(record: BrowserPendingRecord): PendingTurnEntry | undefined
     createdAt: record.createdAt,
     state: record.state,
     source: record.state === "accepted" ? "optimistic" : "outbox",
+    // A durable browser record IS this client's own submission.
+    fromThisClient: true,
   };
 }
 
-function authoritativeEntry(ref: string, mutation: PendingMutation): PendingTurnEntry | undefined {
+function authoritativeEntry(
+  ref: string,
+  mutation: PendingMutation,
+  fromThisClient: boolean,
+): PendingTurnEntry | undefined {
   const method = pendingMethod(mutation.method);
   if (!method) return undefined;
   return {
@@ -79,6 +93,7 @@ function authoritativeEntry(ref: string, mutation: PendingMutation): PendingTurn
     ...inputPreview(mutation.input),
     state: mutation.executionState === "claimed" ? "claimed" : "accepted",
     source: "authoritative",
+    fromThisClient,
   };
 }
 
@@ -86,10 +101,18 @@ function authoritativeEntry(ref: string, mutation: PendingMutation): PendingTurn
 // transport ambiguity; a separate durable optimistic record owns accepted but
 // not-yet-reflected input until pendingMutations, queue, or transcript state
 // replaces it.
+//
+// submittedHere is the set of client mutation ids this client itself submitted
+// (pendingTurnsStore owns it). The durable records answer that for as long as
+// they exist, and they do not outlast the hydrate that reports the same id:
+// publishing a read settles every authoritative identity out of durable storage
+// (threads.ts's reconcileIdentities). This set is what carries provenance past
+// that settlement.
 export function reconcilePendingEntries(
   ref: string,
   outbox: BrowserPendingRecord[],
   model: ThreadModel | undefined,
+  submittedHere: ReadonlySet<string>,
 ): PendingTurnEntry[] {
   const reflected = reflectedMutationIds(model);
   const entries = new Map<string, PendingTurnEntry>();
@@ -102,7 +125,11 @@ export function reconcilePendingEntries(
 
   for (const mutation of model?.pendingMutations ?? []) {
     if (reflected.has(mutation.clientMutationId)) continue;
-    const entry = authoritativeEntry(ref, mutation);
+    // Every entry placed so far came from a durable record of this client's, so
+    // an id already present is one this client submitted - whatever the daemon's
+    // projection is about to say about the same submission.
+    const fromThisClient = entries.has(mutation.clientMutationId) || submittedHere.has(mutation.clientMutationId);
+    const entry = authoritativeEntry(ref, mutation, fromThisClient);
     if (entry) entries.set(entry.id, entry);
   }
 

--- a/cmd/serf-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
+++ b/cmd/serf-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
@@ -26,12 +26,32 @@ interface PendingTurnsStoreState {
   outbox: Map<string, MutationOutboxRecord>;
   optimistic: Map<string, MutationOptimisticRecord>;
   recovery: Map<string, MutationRecoveryRecord>;
+  // Every client mutation id this client's own durable projection has held, for
+  // as long as this page lives. The durable records themselves are the primary
+  // evidence of "this client submitted it", and they are deliberately short
+  // lived: publishing an authoritative read settles every identity the daemon
+  // reports back out of storage (threads.ts's reconcileIdentities), including
+  // the still-unreflected sends it lists in pendingMutations. Provenance has to
+  // outlive the record, because routing asks about it after the hydrate too -
+  // see reconcilePendingEntries.
+  //
+  // Recorded from the projection read rather than the submit call because the
+  // clientMutationId is minted inside the durable enqueue, and the read that
+  // publishes that write always precedes any hydrate that could settle it: the
+  // daemon cannot report an id it has not been sent yet, and the send happens
+  // after the local commit this read follows.
+  //
+  // Ids only, one per mutation this page submits, never pruned - a page that
+  // submits enough sends for that to matter has far larger records than these
+  // in the durable stores it is reading from.
+  submittedHere: ReadonlySet<string>;
 }
 
 const pendingTurnsStore = createStore<PendingTurnsStoreState>(() => ({
   outbox: new Map(),
   optimistic: new Map(),
   recovery: new Map(),
+  submittedHere: new Set(),
 }));
 
 const refreshGenerations = new Map<string, number>();
@@ -128,6 +148,18 @@ export function refreshPendingTurnsProjection(ref?: string): Promise<boolean> {
   return trackProjectionWork(readProjectionIntoStore(ref));
 }
 
+function recordSubmittedHere(snapshot: {
+  outbox: MutationOutboxRecord[];
+  optimistic: MutationOptimisticRecord[];
+}): void {
+  const known = pendingTurnsStore.getState().submittedHere;
+  const discovered = [...snapshot.outbox, ...snapshot.optimistic]
+    .map((record) => record.clientMutationId)
+    .filter((id) => !known.has(id));
+  if (discovered.length === 0) return;
+  pendingTurnsStore.setState((state) => ({ submittedHere: new Set([...state.submittedHere, ...discovered]) }));
+}
+
 async function readProjectionIntoStore(ref?: string): Promise<boolean> {
   const epoch = refreshEpoch;
   const key = ref ?? "*";
@@ -136,6 +168,13 @@ async function readProjectionIntoStore(ref?: string): Promise<boolean> {
   try {
     const snapshot = await readMutationPersistence(ref);
     if (refreshEpoch !== epoch) return false;
+    // Provenance is monotonic knowledge about ids rather than a view of the
+    // records currently in storage, so it is published from every read of this
+    // epoch and in its own setState: a read a newer generation has already
+    // superseded still saw a record of this client's, and the newer read - taken
+    // later - may be looking at storage that record has since been settled out
+    // of. Skipping it there would leave the id known to nobody.
+    recordSubmittedHere(snapshot);
     if (generation < (appliedRefreshGenerations.get(key) ?? 0)) return true;
     appliedRefreshGenerations.set(key, generation);
     pendingTurnsStore.setState((state) => ({
@@ -201,16 +240,20 @@ const NO_BLOCKED: MutationOutboxRecord[] = [];
 export function usePendingTurnEntries(ref: string, method?: PendingMethod): PendingTurnEntry[] {
   const outbox = useStore(pendingTurnsStore, (state) => state.outbox);
   const optimistic = useStore(pendingTurnsStore, (state) => state.optimistic);
+  const submittedHere = useStore(pendingTurnsStore, (state) => state.submittedHere);
   const model = useThreadsStore((state) => state.threads.get(ref));
   useEffect(() => {
     void refreshPendingTurnsProjection(ref);
   }, [ref]);
   return useMemo(() => {
-    const matches = reconcilePendingEntries(ref, [...outbox.values(), ...optimistic.values()], model).filter(
-      (entry) => method === undefined || entry.method === method,
-    );
+    const matches = reconcilePendingEntries(
+      ref,
+      [...outbox.values(), ...optimistic.values()],
+      model,
+      submittedHere,
+    ).filter((entry) => method === undefined || entry.method === method);
     return matches.length > 0 ? matches : NO_ENTRIES;
-  }, [outbox, optimistic, model, ref, method]);
+  }, [outbox, optimistic, submittedHere, model, ref, method]);
 }
 
 export function useAwaitingFirstFrameSend(ref: string): boolean {
@@ -305,7 +348,12 @@ export function resetPendingTurnsStoreForTests(): void {
   // The epoch bump already voids anything still running against the previous
   // test's storage, so it is not this test's projection work to wait for.
   inFlightProjectionWork.clear();
-  pendingTurnsStore.setState({ outbox: new Map(), optimistic: new Map(), recovery: new Map() });
+  pendingTurnsStore.setState({
+    outbox: new Map(),
+    optimistic: new Map(),
+    recovery: new Map(),
+    submittedHere: new Set(),
+  });
 }
 
 // Keep the singleton projection warm when an authoritative pendingMutations

--- a/cmd/serf-hub/frontend/src/protocol/sendQueueAvailability.test.ts
+++ b/cmd/serf-hub/frontend/src/protocol/sendQueueAvailability.test.ts
@@ -173,10 +173,28 @@ describe("deriveSendQueueAvailability", () => {
     ).toEqual({ canSend: true, canQueue: false });
   });
 
-  test("tier 1 still wins: a pending send does not make an ended or closed session composable", () => {
+  // Tier 6 reaches inside tier 1 rather than being shadowed by it. A finished
+  // session is resumable - turn/start alone carries the hub's auto-resume
+  // (app_rpc.go) - so the first message wakes a daemon, and the seconds it
+  // takes to spawn are all window: the status still says the session is over
+  // while a turn this client submitted is already in flight. Routing the second
+  // message by the status alone sends another turn/start into the daemon that
+  // just started, which refuses it with Conflict("turn is already active"). The
+  // "notLoaded" spelling of the same race was fixed first and called the widest
+  // instance of it; nothing about that argument was specific to which finished
+  // status the thread happened to carry.
+  test("tier 6 reaches into tier 1: a pending send queues the next message on an ended or closed session", () => {
     for (const statusType of ["ended", "closed"]) {
       expect(
         deriveSendQueueAvailability({ statusType, capabilities: daemonIdleCapabilities(), hasPendingSend: true }),
+      ).toEqual({ canSend: false, canQueue: true });
+    }
+  });
+
+  test("tier 1 with nothing pending is unchanged: an ended or closed session offers neither action", () => {
+    for (const statusType of ["ended", "closed"]) {
+      expect(
+        deriveSendQueueAvailability({ statusType, capabilities: daemonIdleCapabilities(), hasPendingSend: false }),
       ).toEqual({ canSend: false, canQueue: false });
     }
   });

--- a/cmd/serf-hub/frontend/src/protocol/sendQueueAvailability.ts
+++ b/cmd/serf-hub/frontend/src/protocol/sendQueueAvailability.ts
@@ -3,7 +3,7 @@
 // send-vs-queue capability precedence (parity-m5-composer.md §A, lines
 // 64-71, citing cmd/serf-hub/assets/renderer.js:479-513):
 //
-//   1. ended/closed              -> send=false, queue=false
+//   1. ended/closed              -> send=false, queue=false (tier 6 first)
 //   2. [DROPPED - see below]
 //   3. active && capabilities.queue === false explicitly -> both false
 //   4. active                    -> send=false, queue=true (queue-mode default)
@@ -12,7 +12,9 @@
 //
 // Tier 6 is this codebase's own addition and sits BETWEEN 4 and 5 rather than
 // at the end of the list, which is why it is numbered out of order: the legacy
-// table it extends is quoted verbatim above.
+// table it extends is quoted verbatim above. It also decides tier 1's row
+// before that row's own answer applies - a finished session resumes on the
+// first message, so it holds this client's in-flight sends like any other.
 //
 // The legacy tier 2 ("the source already advertised live send/queue
 // capabilities for the CURRENT state, `liveCapabilitiesStatus === state`")
@@ -80,7 +82,22 @@ export function deriveSendQueueAvailability({
   capabilities,
   hasPendingSend,
 }: SendQueueAvailabilityInput): SendQueueAvailability {
-  if (statusType === "ended" || statusType === "closed") return BOTH_UNAVAILABLE;
+  // Tier 6 (below) reaches inside this tier rather than being shadowed by it. A
+  // finished session is resumable - turn/start alone carries the hub's
+  // auto-resume (app_rpc.go's resumeTurnStartThread) - so a first message wakes
+  // a daemon and the seconds that takes are all window: the status still reads
+  // terminal while a turn this client submitted is already in flight, and a
+  // second message routed by the status alone is another turn/start into the
+  // daemon that just started. It bounces the same way, with the same
+  // Conflict("turn is already active").
+  //
+  // With nothing of this client's pending, the answer is unchanged: no turn to
+  // send to and none to queue behind. Whether such a session can be written to
+  // at all is the SEND CAPABILITY's question, not this table's - the composer
+  // reads that separately for its follow-up card.
+  if (statusType === "ended" || statusType === "closed") {
+    return hasPendingSend ? QUEUE_MODE : BOTH_UNAVAILABLE;
+  }
 
   if (statusType === "active") {
     if (capabilities.queue === false) return BOTH_UNAVAILABLE;
@@ -119,6 +136,10 @@ export function deriveSendQueueAvailability({
   // Pinned live by cmd/serf-hub/e2e_control_without_turn_ids_test.go's
   // TestE2E_ASendThatRacedAStopStillRuns, which proves a queue accepted
   // against a session with nothing running reaches a real model request.
+  //
+  // The terminal branch at the top answers with this same rule, for the same
+  // reason - see its own comment for how a session the status calls finished
+  // comes to be holding one of this client's sends.
   if (hasPendingSend) return QUEUE_MODE;
 
   return PLAIN_SEND_MODE;


### PR DESCRIPTION
Two send-routing windows found in adversarial review, each ending in the same
daemon refusal: `Conflict("turn is already active")`, plus a recovery row the
user has to resend from.

## A hydrate landing mid-send lost tier 6

Routing asked the pending row which projection was DESCRIBING it. A hydrate
(reconnect, pane reopen) reports this client's own still-unsettled send in
`pendingMutations`, `pendingReconcile` replaces the local row with the daemon's
account of the same `clientMutationId`, and the composer's `hasPendingSend`
("some entry whose source is not authoritative") went false for the sender's own
in-flight send. The status still read idle throughout, so the next message
routed to `turn/start`.

Whose send it is cannot change when a hydrate lands, so entries now carry that
separately from `source`. The durable browser records answer it while they
exist - and they do not survive the hydrate either, since publishing a read
settles every authoritative identity out of storage (`reconcileIdentities` ->
`settleApplied`), which the mounted test waits for explicitly. `pendingTurnsStore`
therefore remembers the ids its own projection has held, and reconcile carries
provenance across that settlement. Presentation is untouched: `source` still
names the describing projection, and another client's pending send still leaves
this composer alone.

## Ended/closed bypassed tier 6 entirely

`deriveSendQueueAvailability` answered the terminal row before it ever consulted
tier 6. A finished session resumes on the first message (`turn/start` alone
carries the hub's auto-resume) and spawning that daemon takes seconds, all of
them with the status still reading "closed" - so the second message was routed
by the status alone into another `turn/start`. The terminal row now asks tier 6
first, exactly as the "notLoaded" spelling of this race already did. With
nothing pending the row is unchanged, and whether a finished session accepts
input at all remains the send capability's question.

## Tests

Red first, each pinned against the pre-fix code:

- `Composer.test.tsx`: a hydrate reporting this client's own in-flight send ->
  second message goes to `turn/queue` (was a second `turn/start`).
- `Composer.test.tsx`: a "closed" session resumed by the first message -> second
  message goes to `turn/queue` (was a second `turn/start`, which the fixture's
  daemon refuses with a real Conflict `WireError`).
- `pendingReconcile.test.ts`: provenance survives both the authoritative
  re-description and the durable record's deletion; a mutation this client never
  submitted is still not its own.
- `sendQueueAvailability.test.ts`: ended/closed with a pending send is
  queue-mode; with nothing pending it is unchanged.

One existing assertion changed meaning: "tier 1 still wins: a pending send does
not make an ended or closed session composable" is now the tier-6 case above.
Its no-pending half is kept as its own test.

`make test-web` passes (typecheck, vitest, lint).

Claude-Session: https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU