### PR TITLE
Coverage runners clean up after themselves; the janitor stops sweeping them

### DIFF
--- a/scenariotmppath_audit_test.go
+++ b/scenariotmppath_audit_test.go
@@ -68,7 +68,7 @@ var scenarioFixedTmpPathAllowedMentions = map[string][]string{
 		// behind). Naming it is the whole job, no run creates it, and two
 		// concurrent reclaims of one already-absent directory collide over
 		// nothing.
-		"3) /tmp/serf-gocache-k3",
+		"2) /tmp/serf-gocache-k3",
 		"gocache_debris='/tmp/serf-gocache-k3'",
 	},
 	"scripts/report-tmp-debris.sh": {

--- a/scripts/coverage-union-selftest.sh
+++ b/scripts/coverage-union-selftest.sh
@@ -19,6 +19,7 @@ mkdir -p "$repo/scripts" "$repo/agent"
 cp "$real_script" "$repo/scripts/coverage-union.sh"
 cp "$(dirname "$0")/gate-surface-lib.sh" "$repo/scripts/gate-surface-lib.sh"
 cp "$(dirname "$0")/covstmt-lib.sh" "$repo/scripts/covstmt-lib.sh"
+cp "$(dirname "$0")/covscratch-lib.sh" "$repo/scripts/covscratch-lib.sh"
 script="$repo/scripts/coverage-union.sh"
 floors="$repo/scripts/covunion-floors.txt"
 printf 'module fake\n\ngo 1.25\n' >"$repo/go.mod"
@@ -105,6 +106,15 @@ assert_scratch_inside_tmpdir
 assert_killed_run_cleans_up TERM
 assert_killed_run_cleans_up INT
 assert_killed_run_cleans_up HUP
+
+# The exits a trap cannot see, and the failed run that keeps its scratch on
+# purpose, are this script's own to reclaim: no janitor sweeps them.
+scratch_prefix=serf-covunion
+assert_reclaims_abandoned_scratch
+assert_keeps_concurrent_scratch
+printf 'nosuch 50.0\n' >"$floors"
+assert_failed_run_keeps_scratch_until_next_run run --modules "nosuch" --check
+: >"$floors"
 
 run --bless >"$out" 2>&1
 assert_has "$floors" "agent 100.0" "bless records the measured union floor"

--- a/scripts/coverage-union.sh
+++ b/scripts/coverage-union.sh
@@ -52,6 +52,8 @@ done
 
 . "$(dirname "${BASH_SOURCE[0]}")/gate-surface-lib.sh"
 . "$(dirname "${BASH_SOURCE[0]}")/covstmt-lib.sh"
+# How this run reclaims the leftovers of its own earlier runs; no janitor does.
+. "$(dirname "${BASH_SOURCE[0]}")/covscratch-lib.sh"
 
 floor_for() { awk -v m="$1" '$1==m {print $2}' "$floors_file" 2>/dev/null; }
 measured_for() { awk -v m="$1" '$1==m {print $2}' "$measured_file" 2>/dev/null; }
@@ -76,6 +78,10 @@ check_measurable() {
 # run's scratch outside the dev-tooling wave's per-suite isolation — and so
 # outside the leftover check that is supposed to catch exactly this.
 tmpbase=${TMPDIR:-/tmp}
+# Reclaim what earlier runs of THIS script abandoned here, before taking a name
+# of our own: a SIGKILLed run never reached its trap, and a failed run kept its
+# scratch on purpose. Nothing else sweeps either. See covscratch-lib.sh.
+reclaim_own_scratch "$tmpbase" serf-covunion
 # The name is chosen and the trap armed BEFORE the directory exists; see
 # test-coverage-floor.sh for the signal window this closes. $$ is unique among
 # live processes, so concurrent runs cannot collide. A failed mkdir means a

--- a/scripts/covscratch-lib.sh
+++ b/scripts/covscratch-lib.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# covscratch-lib.sh — the coverage runners' shared reclaim of their OWN
+# abandoned scratch, sourced by test-coverage-floor.sh, coverage-union.sh,
+# fuzz-coverage.sh and fuzz-coverage-global.sh.
+#
+# Sourced, never executed. Sourcing has no side effects: it defines one function
+# and touches nothing until a runner calls it.
+#
+# Why it exists: this project cleans up at the source, and nothing sweeps TMPDIR
+# on these runners' behalf — reclaim-test-debris.sh deliberately does not know
+# their prefixes. Two exit paths still leave a directory behind. A run killed by
+# SIGKILL (or an OOM kill, or a power cut) never reaches its trap. And
+# test-coverage-floor.sh and coverage-union.sh KEEP their scratch on a failed
+# run on purpose: the failure line printed its path, and the profiles and per-
+# module logs are the only record of why. So each runner reclaims those
+# leftovers itself, at the start of its next run — which is exactly when a
+# failed run's diagnostics stop being the current answer.
+#
+# One copy, not four: the pid rules below are subtle enough that a second
+# spelling would be a second thing to get wrong (see covstmt-lib.sh).
+
+# reclaim_own_scratch TMPBASE PREFIX — remove every "TMPBASE/PREFIX.<pid>"
+# directory whose pid is no longer running. Call it BEFORE creating this run's
+# own scratch. Never fatal: a leftover that cannot be removed is reported and
+# the run continues.
+reclaim_own_scratch() {
+	local tmpbase="${1%/}" prefix="$2" leftover pid
+	# A loop over the glob with an existence guard, never a bare expansion
+	# handed to rm: an unmatched glob passes through literally, and a TMPDIR
+	# holding a space would split into two arguments — both of which are
+	# arbitrary paths for a recursive delete.
+	for leftover in "$tmpbase/$prefix".*; do
+		[ -d "$leftover" ] || continue
+		# A reclaimer never follows a link out of TMPDIR, and nothing these
+		# runners create is one.
+		[ -L "$leftover" ] && continue
+		pid="${leftover##*.}"
+		case "$pid" in
+		'' | *[!0-9]*) continue ;;
+		esac
+		# The one thing that must never be touched is a live run's scratch. The
+		# dev-tooling wave gives each suite its own TMPDIR, but a developer can
+		# still start the same runner twice against one TMPDIR, and $$ is unique
+		# among live processes — so a concurrent run is always named after a pid
+		# that answers.
+		#
+		# That includes OUR pid: `kill -0 $$` always succeeds, so a stale
+		# same-pid leftover is kept and the caller's mkdir still fails loudly on
+		# it, rather than this deleting a directory it cannot tell apart from a
+		# live sibling.
+		#
+		# Pid reuse only ever keeps a leftover one round longer — the next run,
+		# under a different pid, reclaims it. For a recursive delete that is the
+		# right direction to fail.
+		kill -0 "$pid" 2>/dev/null && continue
+		rm -rf -- "$leftover" ||
+			printf '%s: could not reclaim abandoned scratch %s\n' "${0##*/}" "$leftover" >&2
+	done
+}

--- a/scripts/fuzz-coverage-global-selftest.sh
+++ b/scripts/fuzz-coverage-global-selftest.sh
@@ -111,6 +111,10 @@ assert_rapid_replays_opt_in_to_fuzz_tests() {
 repo="$work/repo"
 mkdir -p "$repo/scripts"
 cp "$runner" "$repo/scripts/fuzz-coverage-global.sh"
+# The runner sources its own-scratch reclaim from its own directory, so the
+# fixture needs the real library beside it. Later scenarios replace only the
+# runner, so this copy is made once.
+cp "$(dirname "$0")/covscratch-lib.sh" "$repo/scripts/covscratch-lib.sh"
 for module in added agent auth envvars fuzz invariant llm; do
 	mkdir -p "$repo/$module"
 done
@@ -910,5 +914,33 @@ reset_logs
 expect_failure FAKE_GO_LIST_FAIL=1
 has "$last_output" 'go list failed for module: .' 'go list failure is fatal'
 lacks "$(cat "$go_log")" $'\ttest ' 'go list failure invokes no replay'
+
+# A run killed by SIGKILL (or an OOM kill, or a power cut) never reaches the
+# runner's EXIT trap, and no janitor sweeps what it leaves — this project cleans
+# up at the source, so the next run of the same script reclaims it. A live
+# process's scratch is off limits: a developer can start this runner twice
+# against one TMPDIR, and pids are unique among live processes.
+echo '== abandoned scratch is reclaimed, a live one is not =='
+reset_logs
+tmphome="$work/tmp"
+mkdir -p "$tmphome"
+# A pid that has already exited AND been reaped, versus this suite's own pid,
+# which is live and is not the run being started.
+abandoned="$tmphome/serf-fuzzcov-global.$(bash -c 'echo $$')"
+concurrent="$tmphome/serf-fuzzcov-global.$$"
+mkdir -p "$abandoned" "$concurrent"
+run_runner TMPDIR="$tmphome" >/dev/null 2>&1
+if [ -e "$abandoned" ]; then
+	bad 'an abandoned scratch survived the next run, and nothing else sweeps it'
+else
+	ok 'the next run reclaims an abandoned scratch'
+fi
+if [ -d "$concurrent" ]; then
+	ok "a live process's scratch survives another run's reclaim"
+else
+	bad "a live process's scratch was reclaimed out from under it"
+fi
+rm -rf "$concurrent"
+assert_eq "$(ls -A "$tmphome")" "" 'the run itself leaves no scratch behind'
 
 selftest_summary

--- a/scripts/fuzz-coverage-global.sh
+++ b/scripts/fuzz-coverage-global.sh
@@ -29,6 +29,8 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+# How this run reclaims the leftovers of its own earlier runs; no janitor does.
+. "$(dirname "$0")/covscratch-lib.sh"
 go_work="$repo_root/go.work"
 go_bin="${SERF_FUZZ_GO:-go}"
 capped="${SERF_FUZZ_CAPPED:-$repo_root/scripts/run-capped.sh}"
@@ -273,6 +275,11 @@ esac
 # scratch outside the dev-tooling wave's per-suite isolation — and so outside
 # the leftover check that is supposed to catch exactly this.
 tmpbase=${TMPDIR:-/tmp}
+# Reclaim what earlier runs of THIS script abandoned here, before taking a name
+# of our own. The trap below covers every exit a shell can observe; SIGKILL, an
+# OOM kill and a power cut are not among them, and no janitor sweeps what they
+# leave. See covscratch-lib.sh for the pid rules.
+reclaim_own_scratch "$tmpbase" serf-fuzzcov-global
 # The name is chosen and the trap armed BEFORE the directory exists; see
 # test-coverage-floor.sh for the signal window this closes. $$ is unique among
 # live processes, so concurrent runs cannot collide. A failed mkdir means a

--- a/scripts/fuzz-coverage.sh
+++ b/scripts/fuzz-coverage.sh
@@ -17,11 +17,18 @@
 set -uo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+# How this run reclaims the leftovers of its own earlier runs; no janitor does.
+. "$(dirname "$0")/covscratch-lib.sh"
 # An explicit path under TMPDIR, not `mktemp -t`: macOS's mktemp ignores TMPDIR
 # for -t and uses the Darwin per-user temp directory instead, which puts the
 # scratch outside the dev-tooling wave's per-suite isolation — and so outside
 # the leftover check the trap below is written to satisfy.
 tmpbase=${TMPDIR:-/tmp}
+# Reclaim what earlier runs of THIS script abandoned here, before taking a name
+# of our own. The trap below covers every exit a shell can observe; SIGKILL, an
+# OOM kill and a power cut are not among them, and no janitor sweeps what they
+# leave. See covscratch-lib.sh for the pid rules.
+reclaim_own_scratch "$tmpbase" serf-fuzzcov
 # The name is chosen and the trap armed BEFORE the directory exists; see
 # test-coverage-floor.sh for the signal window this closes. $$ is unique among
 # live processes, so concurrent runs cannot collide. A failed mkdir means a

--- a/scripts/reclaim-test-debris-selftest.sh
+++ b/scripts/reclaim-test-debris-selftest.sh
@@ -62,41 +62,6 @@ else
 fi
 [ ! -e "$expired_shard" ] && ok "reclaim removes an expired heartbeat shard" || bad "reclaim keeps an expired heartbeat shard"
 
-# The coverage runners drop their profiles in per-run scratch directories and
-# remove them on every exit path a shell can see. SIGKILL is not one of those: a
-# `kill -9`, an OOM kill, or a power cut leaves the directory with nobody left to
-# run a trap, and each holds a full set of profiles. That is what a reclaimer is
-# for, and until these prefixes were listed nothing swept them — 61 directories
-# holding 1.5GB had accumulated in one developer's temp directory.
-#
-# No heartbeat here on purpose: a coverage run writes profiles continuously, so
-# the directory's own mtime is an honest liveness signal, and inventing a marker
-# would be a second mechanism saying the same thing.
-for prefix in serf-testcov serf-covunion serf-fuzzcov serf-fuzzcov-global; do
-	stale_cov="$tmpbase/$prefix.stale"
-	live_cov="$tmpbase/$prefix.live"
-	mkdir -p "$stale_cov" "$live_cov"
-	printf 'mode: set\n' >"$stale_cov/root.cov"
-	printf 'mode: set\n' >"$live_cov/root.cov"
-	touch -t 202001010000 "$stale_cov"
-
-	out="$work/$prefix-dry-run.out"
-	run_reclaim --dry-run >"$out" 2>&1
-	assert_has "$out" "would remove: $stale_cov" "an abandoned $prefix scratch is eligible"
-	if grep -qF "would remove: $live_cov" "$out"; then
-		bad "an in-flight $prefix scratch is eligible"
-	else
-		ok "an in-flight $prefix scratch is protected by its fresh mtime"
-	fi
-
-	run_reclaim --yes >"$work/$prefix-reclaim.out" 2>&1
-	[ ! -e "$stale_cov" ] && ok "reclaim removes the abandoned $prefix scratch" ||
-		bad "reclaim kept the abandoned $prefix scratch"
-	[ -d "$live_cov" ] && ok "reclaim leaves the in-flight $prefix scratch" ||
-		bad "reclaim removed the in-flight $prefix scratch"
-	rm -rf "$live_cov"
-done
-
 # Fake only the go boundary and point the debris path at throwaway fixtures.
 # The real reclaimer still performs its canonical directory resolution and
 # deletion decisions; no user GOCACHE or fixed /tmp debris path is touched.

--- a/scripts/reclaim-test-debris.sh
+++ b/scripts/reclaim-test-debris.sh
@@ -5,14 +5,15 @@
 #   1) $TMPDIR/agent-test-shards.*  — stale directories from failed or
 #      interrupted historical sharded `make test` runs; current green runs
 #      remove their directories (measured 103 dirs / ~4.2GB on 2026-07-31).
-#   2) $TMPDIR/serf-testcov.*, serf-covunion.*, serf-fuzzcov.*,
-#      serf-fuzzcov-global.* — per-run coverage scratch. Those runners remove
-#      their own scratch on every exit path a shell can observe, which SIGKILL,
-#      an OOM kill and a power cut are not; each abandoned directory holds a
-#      full set of profiles (measured 61 dirs / ~1.5GB on 2026-08-17).
-#   3) /tmp/serf-gocache-k3         — a one-off GOCACHE a session created to
+#   2) /tmp/serf-gocache-k3         — a one-off GOCACHE a session created to
 #      route around the external-volume stall and flagged for cleanup
 #      (recorded in kata r07s's filing).
+#
+# The coverage runners' scratch (serf-testcov.*, serf-covunion.*, serf-fuzzcov.*,
+# serf-fuzzcov-global.*) is deliberately NOT swept here, and adding it back is a
+# rule violation, not an improvement. This project cleans up at the source: each
+# runner removes its own abandoned leftovers at the start of its next run (see
+# covscratch-lib.sh), so nothing accumulates and no janitor is needed.
 #
 # Usage:
 #   scripts/reclaim-test-debris.sh --dry-run   # list what would go + totals
@@ -20,16 +21,14 @@
 #
 # Safety, in order of importance:
 #   - Deletes only DIRECTORIES sitting directly under $TMPDIR whose names
-#     start with one of the exact prefixes above. Symlinks never match (-type d
-#     under find's default -P), and nothing is ever followed out of $TMPDIR.
+#     start with the exact shard prefix. Symlinks never match (-type d under
+#     find's default -P), and nothing is ever followed out of $TMPDIR.
 #   - A directory modified in the last SERF_DEBRIS_MIN_AGE_MINUTES minutes
 #     (default 30) is KEPT: an in-flight `make test` writes into its shard
-#     dir continuously, and so does a coverage run into its profiles, so
-#     freshness is the "is anyone using this" signal.
+#     dir continuously, so freshness is the "is anyone using this" signal.
 #     Active shard runs also own a `.heartbeat` file and refresh it while they
 #     run; that marker is authoritative because appending an existing nested
-#     log does not update the shard directory itself. Coverage scratch has no
-#     marker and needs none — its profiles are written throughout the run.
+#     log does not update the shard directory itself.
 #   - The gocache path is refused outright if `go env GOCACHE` points at it:
 #     canonical filesystem identity, rather than spelling, decides whether it
 #     stopped being debris and became the machine's live build cache.
@@ -50,19 +49,7 @@ esac
 age_minutes=${SERF_DEBRIS_MIN_AGE_MINUTES:-30}
 tmpbase=${TMPDIR:-/tmp}
 tmpbase=${tmpbase%/}
-# Every per-run scratch prefix this reclaimer sweeps. The shard dirs come from
-# interrupted sharded `make test` runs; the four coverage prefixes come from the
-# coverage runners, which remove their scratch on every exit path a shell can
-# observe — but SIGKILL, an OOM kill and a power cut are not among those, and
-# each abandoned directory holds a full set of profiles (61 of them, 1.5GB, had
-# accumulated before these were listed).
-scratch_prefixes=(
-	'agent-test-shards.'
-	'serf-testcov.'
-	'serf-covunion.'
-	'serf-fuzzcov.'
-	'serf-fuzzcov-global.'
-)
+shard_prefix='agent-test-shards.'
 gocache_debris='/tmp/serf-gocache-k3'
 # The selftest may replace only the parent root; the fixed basename keeps this
 # cleanup target from becoming an arbitrary rm -rf input.
@@ -94,28 +81,22 @@ directory_is_fresh() {
 # link out of TMPDIR. A fresh directory or heartbeat keeps the entry;
 # everything else is old enough to reclaim, including legacy shard dirs with no
 # marker.
-# Only the shard dirs carry a heartbeat; a coverage scratch has no marker, so
-# heartbeat_status returns "absent" for it and freshness alone decides. That is
-# the right signal there: a coverage run writes profiles continuously, so an old
-# mtime means nobody is writing.
 shard_dirs=()
 kept=0
-for prefix in "${scratch_prefixes[@]}"; do
-	for d in "$tmpbase"/"${prefix}"*; do
-		[ -d "$d" ] || continue
-		[ -L "$d" ] && continue
-		heartbeat_state=3
-		if heartbeat_status "$d"; then
-			heartbeat_state=0
-		else
-			heartbeat_state=$?
-		fi
-		if directory_is_fresh "$d" || [ "$heartbeat_state" -eq 0 ] || [ "$heartbeat_state" -eq 2 ]; then
-			kept=$((kept + 1))
-		else
-			shard_dirs+=("$d")
-		fi
-	done
+for d in "$tmpbase"/"${shard_prefix}"*; do
+	[ -d "$d" ] || continue
+	[ -L "$d" ] && continue
+	heartbeat_state=3
+	if heartbeat_status "$d"; then
+		heartbeat_state=0
+	else
+		heartbeat_state=$?
+	fi
+	if directory_is_fresh "$d" || [ "$heartbeat_state" -eq 0 ] || [ "$heartbeat_state" -eq 2 ]; then
+		kept=$((kept + 1))
+	else
+		shard_dirs+=("$d")
+	fi
 done
 
 total_kb=0
@@ -125,7 +106,7 @@ if [ "${#shard_dirs[@]}" -gt 0 ]; then
 	done < <(du -sk "${shard_dirs[@]}" 2>/dev/null | awk '{print $1}')
 fi
 
-echo "scratch dirs under $tmpbase older than ${age_minutes}m: ${#shard_dirs[@]} ($((total_kb / 1024))MB); kept as possibly-live: $kept"
+echo "shard dirs under $tmpbase older than ${age_minutes}m: ${#shard_dirs[@]} ($((total_kb / 1024))MB); kept as possibly-live: $kept"
 
 filesystem_identity() {
 	local path="$1" identity

--- a/scripts/scratch-selftest-lib.sh
+++ b/scripts/scratch-selftest-lib.sh
@@ -21,6 +21,9 @@
 #   start_scratch_run — starts a run that BLOCKS with its scratch created, in the
 #                    background, and sets run_pid. Blocking is the point: the
 #                    scratch only exists while the run is in flight.
+#   run            — runs the script to completion under $tmphome, exiting zero
+#                    (used by the reclaim assertions below)
+#   scratch_prefix — the runner's scratch basename prefix, e.g. "serf-testcov"
 
 # await_scratch — returns 0 once $tmphome is non-empty, 1 after ~10s.
 await_scratch() {
@@ -74,4 +77,60 @@ assert_killed_run_cleans_up() {
 	await_no_scratch
 	assert_eq "$(ls -A "$tmphome")" "" "a run killed by SIG$signal leaves no scratch behind"
 	rm -rf "${tmphome:?}"/* 2>/dev/null
+}
+
+# assert_reclaims_abandoned_scratch — no janitor sweeps TMPDIR for these
+# runners; reclaim-test-debris.sh deliberately does not know their prefixes. A
+# scratch whose owner is gone — SIGKILLed, OOM-killed, or cut off with the
+# machine — is therefore the next run's problem, and the next run takes it.
+assert_reclaims_abandoned_scratch() {
+	local dead abandoned
+	# A pid that has already exited AND been reaped: the shell that printed its
+	# own pid is gone by the time the substitution returns.
+	dead="$(bash -c 'echo $$')"
+	abandoned="$tmphome/$scratch_prefix.$dead"
+	mkdir -p "$abandoned"
+	printf 'mode: set\n' >"$abandoned/root.cov"
+	run >/dev/null 2>&1
+	if [ -e "$abandoned" ]; then
+		bad "an abandoned scratch survived the next run, and nothing else sweeps it"
+	else
+		ok "the next run reclaims an abandoned scratch"
+	fi
+	rm -rf "${tmphome:?}"/* 2>/dev/null
+}
+
+# assert_keeps_concurrent_scratch — starting the same runner twice against one
+# TMPDIR is a supported thing to do, so the reclaim above must be scoped to
+# leftovers no live process owns. This suite's own pid stands in for the
+# concurrent run: it is live, it is not the run being started, and using it
+# needs no process to babysit.
+assert_keeps_concurrent_scratch() {
+	local concurrent="$tmphome/$scratch_prefix.$$"
+	mkdir -p "$concurrent"
+	printf 'mode: set\n' >"$concurrent/root.cov"
+	run >/dev/null 2>&1
+	if [ -d "$concurrent" ]; then
+		ok "a live process's scratch survives another run's reclaim"
+	else
+		bad "a live process's scratch was reclaimed out from under it"
+	fi
+	rm -rf "${tmphome:?}"/* 2>/dev/null
+}
+
+# assert_failed_run_keeps_scratch_until_next_run CMD... — a failed run keeps its
+# profiles and per-module logs on purpose: the failure line printed their path
+# and they are the only record of why. CMD is the caller's way of making the run
+# fail. Nothing sweeps what it leaves, so the NEXT run of the same script
+# removes it — which is exactly when a failed run's diagnostics stop being the
+# current answer.
+assert_failed_run_keeps_scratch_until_next_run() {
+	"$@" >/dev/null 2>&1
+	if [ -n "$(ls -A "$tmphome" 2>/dev/null)" ]; then
+		ok "a failed run keeps its scratch for diagnosis"
+	else
+		bad "a failed run discarded the profiles and logs its failure line named"
+	fi
+	run >/dev/null 2>&1
+	assert_eq "$(ls -A "$tmphome")" "" "the next run reclaims the failed run's scratch"
 }

--- a/scripts/test-coverage-floor-selftest.sh
+++ b/scripts/test-coverage-floor-selftest.sh
@@ -29,6 +29,7 @@ cp "$real_script" "$repo/scripts/test-coverage-floor.sh"
 # throwaway repo needs the real one beside it.
 cp "$(dirname "$0")/gate-surface-lib.sh" "$repo/scripts/gate-surface-lib.sh"
 cp "$(dirname "$0")/covstmt-lib.sh" "$repo/scripts/covstmt-lib.sh"
+cp "$(dirname "$0")/covscratch-lib.sh" "$repo/scripts/covscratch-lib.sh"
 script="$repo/scripts/test-coverage-floor.sh"
 floors="$repo/scripts/testcov-global-floors.txt"
 printf 'module fake\n\ngo 1.25\n' >"$repo/go.mod"
@@ -146,6 +147,15 @@ assert_scratch_inside_tmpdir
 assert_killed_run_cleans_up TERM
 assert_killed_run_cleans_up INT
 assert_killed_run_cleans_up HUP
+
+# The exits a trap cannot see, and the failed run that keeps its scratch on
+# purpose, are this script's own to reclaim: no janitor sweeps them.
+scratch_prefix=serf-testcov
+assert_reclaims_abandoned_scratch
+assert_keeps_concurrent_scratch
+printf '. 90.0\nagent 75.0\n' >"$floors"
+assert_failed_run_keeps_scratch_until_next_run run --check
+: >"$floors"
 
 # --bless must carry the MEASURED percentages through; the associative-array bug
 # silently wrote back stale floors here even when the rows above looked right.

--- a/scripts/test-coverage-floor.sh
+++ b/scripts/test-coverage-floor.sh
@@ -62,6 +62,8 @@ done
 # How a coverage number is counted, shared with every other script that
 # reports one; see covstmt-lib.sh for why a second copy is a hazard.
 . "$(dirname "${BASH_SOURCE[0]}")/covstmt-lib.sh"
+# How this run reclaims the leftovers of its own earlier runs; no janitor does.
+. "$(dirname "${BASH_SOURCE[0]}")/covscratch-lib.sh"
 
 floor_for() { awk -v m="$1" '$1==m {print $2}' "$floors_file" 2>/dev/null; }
 
@@ -90,6 +92,13 @@ check_measurable() {
 # run's scratch outside the dev-tooling wave's per-suite isolation — and so
 # outside the leftover check that is supposed to catch exactly this.
 tmpbase=${TMPDIR:-/tmp}
+# Reclaim what earlier runs of THIS script abandoned here, before taking a name
+# of our own. Two kinds accumulate: a run killed by SIGKILL never reached its
+# trap, and a failed run kept its scratch on purpose (see cleanup_profiles
+# below). Nothing else sweeps either — this project cleans up at the source —
+# and the moment a failed run's diagnostics stop being the current answer is the
+# moment the next run starts. See covscratch-lib.sh for the pid rules.
+reclaim_own_scratch "$tmpbase" serf-testcov
 # The name is chosen and the trap armed BEFORE the directory exists. With
 # `mktemp -d` first and the trap a few lines later, a signal could land after
 # the directory was created but before any cleanup knew about it — mid-mktemp


### PR DESCRIPTION
## The ruling

This project has a standing no-janitor decision: tests and scripts clean up at
the source. The dev-tooling wave enforces it by failing any suite that leaves
something in its private TMPDIR (`docs/superpowers/plans/2026-08-06-selftest-unwind.md`:
"Cleanup enforcement moves into the runner... That is the replacement for
janitorial reclamation.").

Commit 53f8e08cc broke it. It taught `scripts/reclaim-test-debris.sh` four
coverage prefixes — `serf-testcov.`, `serf-covunion.`, `serf-fuzzcov.`,
`serf-fuzzcov-global.` — which made a manual, out-of-band sweep the only thing
that ever removed a coverage runner's leftovers. Jesse ruled: enforce the rule.

## What changed

**The reclaimer stops sweeping coverage scratch** (868e882). The four prefixes
and their selftest coverage are gone; the header now says why re-adding them is
a rule violation rather than an improvement. The reclaimer keeps its two
pre-existing jobs — shard dirs and the one-off `/tmp/serf-gocache-k3`. The
fixed-tmp-path audit's allowlist keys on the header line's exact text, so the
renumbered entry follows it back.

**Each runner reclaims its own leftovers** (944c291). Before a run takes a
scratch name, it removes the leftovers of earlier runs of the same script in the
same tmpbase. The failed-run debugging story survives intact: a failed
`test-coverage-floor.sh` or `coverage-union.sh` still keeps its profiles and
per-module logs, and they live until the NEXT run of the same script — exactly
when their diagnostic value has expired.

## Design choices

**Scoped by pid liveness, not by age.** The wave gives each suite its own
TMPDIR, but a developer can still start the same runner twice against one
TMPDIR, and an age rule would delete the second run's scratch mid-run. `$$` is
unique among live processes, so `kill -0` on the name's pid suffix separates a
live sibling from an owner that is gone. Our own pid answers too, which
deliberately preserves the fde632f8c contract: a stale same-pid leftover is left
alone and the `mkdir` still fails loudly on it rather than this deleting a
directory it cannot tell apart from a live one. Pid reuse only ever keeps a
leftover one round longer — the right direction for a recursive delete to fail.

**All four runners, not just the two that keep on failure.**
`fuzz-coverage.sh` and `fuzz-coverage-global.sh` always delete their scratch, so
only the SIGKILL/OOM/power-cut case applies to them — but that accumulation was
part of what the janitor used to absorb, so leaving them out would just move the
leak. They pre-clean on the same terms.

**One copy of the rules.** `scripts/covscratch-lib.sh`, sourced by all four,
rather than four spellings of a subtle pid check (the covstmt-lib.sh
precedent). The glob is walked with an existence guard rather than expanded into
`rm`'s argv, so an unmatched pattern and a TMPDIR holding a space are both
non-events. A leftover that cannot be removed is reported, never fatal.

**Selftest helpers land in `scratch-selftest-lib.sh`**, which already exists as
the coverage runners' shared scratch harness. `fuzz-coverage.sh` has no selftest
of its own (it is not in `DEV_TOOLING_TEST_SCRIPTS`), so its one-line call runs
code the other three suites exercise.

## Known limitation, not fixed here

The review that prompted this work noted the reclaimer's "directory mtime =
liveness" premise is wrong for anything that writes once and then runs long.
With the coverage prefixes gone, the only remaining swept prefix is
`agent-test-shards.`, and it does not have that problem: `agent-test-shards.sh`
runs a heartbeat loop that touches `.heartbeat` throughout the run, and the
reclaimer treats a fresh heartbeat as authoritative precisely because appending
to a nested log does not update the shard directory. The residual case is a
*legacy* shard directory with no marker at all, which still falls back to mtime
plus the 30-minute floor. Narrow, pre-existing, and out of scope: not redesigning
the reclaimer here.

## Verification

- `go run ./cmd/serf-test-dev-tooling reclaim-test-debris test-coverage-floor coverage-union fuzz-coverage-global selftest-lib` — all PASS.
- `go test -count=1 -short .` at the repo root (the audits, including the fixed-tmp-path one) — ok.
- `shellcheck -x` on every changed script — no new class of finding. The only new
  one is `SC2154 scratch_prefix` in `scratch-selftest-lib.sh`, the same
  caller-provides-it warning that file already carries for `tmphome` and
  `run_pid`. (shellcheck is not wired into `make lint`.)
- Every new assertion was watched to fail first: stubbing `reclaim_own_scratch`
  to a no-op fails the abandoned-scratch and next-run checks in all three
  suites; removing the `kill -0` guard fails the concurrent-run check.
- Nothing in the Makefile or `.github/workflows/` invokes the reclaimer — the
  only reference is its selftest in `DEV_TOOLING_TEST_SCRIPTS`. Nothing under
  `test/scenarios/` or `docs/` referenced the coverage sweeps.

Manual demonstration, real `scripts/test-coverage-floor.sh` against a private
TMPDIR with a `go` that fails the test run:

```
### run 1 (induced failure)
.          TEST FAILED (log: .../tmp/serf-testcov.23090/root.log)
exit=1
### TMPDIR after run 1:
serf-testcov.23090
serf-testcov.23090/measured.txt
serf-testcov.23090/root.log
### run 2 (same induced failure, new pid)
.          TEST FAILED (log: .../tmp/serf-testcov.23130/root.log)
exit=1
### TMPDIR after run 2:
serf-testcov.23130
### run 1 scratch (serf-testcov.23090) still present?
NO - reclaimed
```

Claude-Session: https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU