### PR TITLE
test(agent): kata 49k3 — convert ~50 session*_test.go files to the metaFS seam

### DIFF
--- a/agent/session_ask_test.go
+++ b/agent/session_ask_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/goal"
 	"primeradiant.com/serf/agent/internal/hooks"
@@ -1241,6 +1243,7 @@ func newAskRestoreClient() *llm.Client {
 func TestAskUser_RestoreRederivesAwaiting(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	ask := askUserCall("ask1", askUserArgsValid())
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{
@@ -1249,7 +1252,7 @@ func TestAskUser_RestoreRederivesAwaiting(t *testing.T) {
 			func(req llm.Request) llm.Response { return toolCallResponse(ask) },
 		},
 	})
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -1266,7 +1269,7 @@ func TestAskUser_RestoreRederivesAwaiting(t *testing.T) {
 	meta := sess.Meta()
 	sess.Close()
 
-	restored, err := RestoreSessionFromMeta(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, dir)
+	restored, err := RestoreSessionFromMetaWithConfig(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("RestoreSessionFromMeta: %v", err)
 	}
@@ -1289,6 +1292,7 @@ func TestAskUser_RestoreRederivesAwaiting(t *testing.T) {
 func TestAskUser_RestoreRederivesAwaitingAcrossTrailingSteering(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	ask := askUserCall("ask1", askUserArgsValid())
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{
@@ -1297,7 +1301,7 @@ func TestAskUser_RestoreRederivesAwaitingAcrossTrailingSteering(t *testing.T) {
 			func(req llm.Request) llm.Response { return toolCallResponse(ask) },
 		},
 	})
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -1315,7 +1319,7 @@ func TestAskUser_RestoreRederivesAwaitingAcrossTrailingSteering(t *testing.T) {
 	meta := sess.Meta()
 	sess.Close()
 
-	restored, err := RestoreSessionFromMeta(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, dir)
+	restored, err := RestoreSessionFromMetaWithConfig(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("RestoreSessionFromMeta: %v", err)
 	}
@@ -1346,6 +1350,7 @@ func TestAskUser_RestoreRederivesAwaitingAcrossTrailingSteering(t *testing.T) {
 func TestAskUser_RestoreRederivesIdleAfterAnsweredAsk(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	ask := askUserCall("ask1", askUserArgsValid())
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{
@@ -1355,7 +1360,7 @@ func TestAskUser_RestoreRederivesIdleAfterAnsweredAsk(t *testing.T) {
 			func(req llm.Request) llm.Response { return finalResponse("thanks, using Postgres") },
 		},
 	})
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -1388,7 +1393,7 @@ func TestAskUser_RestoreRederivesIdleAfterAnsweredAsk(t *testing.T) {
 	meta := sess.Meta()
 	sess.Close()
 
-	restored, err := RestoreSessionFromMeta(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, dir)
+	restored, err := RestoreSessionFromMetaWithConfig(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("RestoreSessionFromMeta: %v", err)
 	}
@@ -1423,6 +1428,7 @@ func TestAskUser_RestoreRederivesIdleAfterAnsweredAsk(t *testing.T) {
 func TestAskUser_RestoreRederivesIdleAfterInterruptedAsk(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	id := "01ASKRESTOREINTERRUPTED"
 
 	askArgs, err := json.Marshal(askUserArgsValid())
@@ -1462,7 +1468,7 @@ func TestAskUser_RestoreRederivesIdleAfterInterruptedAsk(t *testing.T) {
 		Model:     "gpt-5.2",
 		Config:    (SessionConfig{}).toSnapshot(),
 	}
-	restored, err := RestoreSessionFromMeta(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, dir)
+	restored, err := RestoreSessionFromMetaWithConfig(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("RestoreSessionFromMeta: %v", err)
 	}
@@ -1513,6 +1519,7 @@ func TestAskUser_RestoreRederivesIdleAfterInterruptedAsk(t *testing.T) {
 func TestAskUser_RestoreRebuildsPendingHoldsEntryGate(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	ask := askUserCall("ask1", askUserArgsValid())
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{
@@ -1521,7 +1528,7 @@ func TestAskUser_RestoreRebuildsPendingHoldsEntryGate(t *testing.T) {
 			func(req llm.Request) llm.Response { return toolCallResponse(ask) },
 		},
 	})
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -1538,7 +1545,7 @@ func TestAskUser_RestoreRebuildsPendingHoldsEntryGate(t *testing.T) {
 	restoreAdapter := &fakeAdapter{name: "openai"}
 	restoreClient := llm.NewClient()
 	restoreClient.Register(restoreAdapter)
-	restored, err := RestoreSessionFromMeta(restoreClient, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, dir)
+	restored, err := RestoreSessionFromMetaWithConfig(restoreClient, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("RestoreSessionFromMeta: %v", err)
 	}
@@ -1578,6 +1585,7 @@ func TestAskUser_RestoreRebuildsPendingHoldsEntryGate(t *testing.T) {
 func TestAskUser_RestoreRebuildsPendingArmsSetGoalWithoutKick(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	ask := askUserCall("ask1", askUserArgsValid())
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{
@@ -1586,7 +1594,7 @@ func TestAskUser_RestoreRebuildsPendingArmsSetGoalWithoutKick(t *testing.T) {
 			func(req llm.Request) llm.Response { return toolCallResponse(ask) },
 		},
 	})
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -1600,7 +1608,7 @@ func TestAskUser_RestoreRebuildsPendingArmsSetGoalWithoutKick(t *testing.T) {
 	meta := sess.Meta()
 	sess.Close()
 
-	restored, err := RestoreSessionFromMeta(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, dir)
+	restored, err := RestoreSessionFromMetaWithConfig(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("RestoreSessionFromMeta: %v", err)
 	}
@@ -1639,6 +1647,7 @@ func TestAskUser_RestoreRebuildsPendingArmsSetGoalWithoutKick(t *testing.T) {
 func TestAskUser_RestoreRebuildsPendingRefusesCompact(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	ask := askUserCall("ask1", askUserArgsValid())
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{
@@ -1647,7 +1656,7 @@ func TestAskUser_RestoreRebuildsPendingRefusesCompact(t *testing.T) {
 			func(req llm.Request) llm.Response { return toolCallResponse(ask) },
 		},
 	})
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -1661,7 +1670,7 @@ func TestAskUser_RestoreRebuildsPendingRefusesCompact(t *testing.T) {
 	meta := sess.Meta()
 	sess.Close()
 
-	restored, err := RestoreSessionFromMeta(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, dir)
+	restored, err := RestoreSessionFromMetaWithConfig(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("RestoreSessionFromMeta: %v", err)
 	}
@@ -1686,6 +1695,7 @@ func TestAskUser_RestoreRebuildsPendingRefusesCompact(t *testing.T) {
 func TestAskUser_RestoreRebuildsPendingCountAndOrder(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	ask1 := askUserCall("ask1", askUserArgsValid()) // header "DB choice"
 	ask2Args := map[string]any{
 		"questions": []any{
@@ -1707,7 +1717,7 @@ func TestAskUser_RestoreRebuildsPendingCountAndOrder(t *testing.T) {
 			func(req llm.Request) llm.Response { return toolCallResponse(ask1, ask2) },
 		},
 	})
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -1724,7 +1734,7 @@ func TestAskUser_RestoreRebuildsPendingCountAndOrder(t *testing.T) {
 	meta := sess.Meta()
 	sess.Close()
 
-	restored, err := RestoreSessionFromMeta(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, dir)
+	restored, err := RestoreSessionFromMetaWithConfig(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("RestoreSessionFromMeta: %v", err)
 	}
@@ -1755,6 +1765,7 @@ func TestAskUser_RestoreRebuildsPendingCountAndOrder(t *testing.T) {
 func TestAskUser_RestoreGenericAwaitingKeepsPendingEmptyAndGoalKicks(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{
 		name: "openai",
@@ -1762,7 +1773,7 @@ func TestAskUser_RestoreGenericAwaitingKeepsPendingEmptyAndGoalKicks(t *testing.
 			func(req llm.Request) llm.Response { return finalResponse("here is my answer") },
 		},
 	})
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -1779,7 +1790,7 @@ func TestAskUser_RestoreGenericAwaitingKeepsPendingEmptyAndGoalKicks(t *testing.
 	meta := sess.Meta()
 	sess.Close()
 
-	restored, err := RestoreSessionFromMeta(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, dir)
+	restored, err := RestoreSessionFromMetaWithConfig(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("RestoreSessionFromMeta: %v", err)
 	}
@@ -1818,6 +1829,7 @@ func TestAskUser_RestoreGenericAwaitingKeepsPendingEmptyAndGoalKicks(t *testing.
 func TestAskUser_RestoreRebuildsPendingThenReplyClears(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	ask := askUserCall("ask1", askUserArgsValid())
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{
@@ -1826,7 +1838,7 @@ func TestAskUser_RestoreRebuildsPendingThenReplyClears(t *testing.T) {
 			func(req llm.Request) llm.Response { return toolCallResponse(ask) },
 		},
 	})
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -1847,7 +1859,7 @@ func TestAskUser_RestoreRebuildsPendingThenReplyClears(t *testing.T) {
 			func(req llm.Request) llm.Response { return finalResponse("thanks, using Postgres") },
 		},
 	})
-	restored, err := RestoreSessionFromMeta(restoreClient, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, dir)
+	restored, err := RestoreSessionFromMetaWithConfig(restoreClient, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("RestoreSessionFromMeta: %v", err)
 	}

--- a/agent/session_attention_test.go
+++ b/agent/session_attention_test.go
@@ -1524,7 +1524,7 @@ func TestDelegateAttention_RestoreReconcilesColdCommitBeforeProviderMetadata(t *
 		schema.SessionMeta{ID: rootSessionID, ProfileID: "openai", Model: "gpt-5.2", CreatedAt: time.Unix(100, 0).UTC()},
 		RestoreSessionConfig{
 			StateDir: stateDir,
-			testOnly: testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true},
+			testOnly: testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true, metaFS: afero.NewMemMapFs()},
 		},
 	)
 	if err != nil {
@@ -1767,7 +1767,7 @@ func TestDelegateAttention_PostAckArmReadFailureRetriesExactID(t *testing.T) {
 	clock := agenttest.NewFakeClock()
 	root := newSession(t,
 		withDir(stateDir),
-		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true, clock: clock}),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true, clock: clock, testOnly: testConfig{metaFS: afero.NewMemMapFs()}}),
 		withSteps(func(llm.Request) llm.Response {
 			return communicateResponse(true, "retried exact attention")
 		}),
@@ -2005,9 +2005,9 @@ func TestDelegateAttention_RestoreSessionStartCountsColdReplayAppend(t *testing.
 			MaxConcurrentDelegateTurns: 2,
 		}).toSnapshot(),
 	}
-	restored, err := RestoreSessionFromMeta(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(stateDir), meta, stateDir)
+	restored, err := RestoreSessionFromMetaWithConfig(newAskRestoreClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(stateDir), meta, RestoreSessionConfig{StateDir: stateDir, testOnly: testConfig{metaFS: afero.NewMemMapFs()}})
 	if err != nil {
-		t.Fatalf("RestoreSessionFromMeta: %v", err)
+		t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
 	}
 	defer restored.Close()
 	start, ok := resumeTurnSeedFindSessionStart(t, restored)
@@ -2420,7 +2420,7 @@ func TestRootDelegateAttention_DurableAppendWaitsForSourceSettlementBeforeWake(t
 	stateDir := t.TempDir()
 	root := newSession(t,
 		withDir(stateDir),
-		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true}),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true, testOnly: testConfig{metaFS: afero.NewMemMapFs()}}),
 	)
 	wakes := make(chan struct{}, 1)
 	root.SetNotifyFunc(func() { wakes <- struct{}{} })
@@ -2456,7 +2456,7 @@ func TestRootDelegateAttention_SuccessfulNotificationConsumesExactIDs(t *testing
 	requestSawAttention := false
 	root := newSession(t,
 		withDir(stateDir),
-		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true}),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true, testOnly: testConfig{metaFS: afero.NewMemMapFs()}}),
 		withSteps(func(req llm.Request) llm.Response {
 			requestSawAttention = requestContainsText(req, content)
 			return toolCallResponse(communicateCall("root-attention-consumed", "completion received"))
@@ -2491,7 +2491,7 @@ func TestRootDelegateAttention_FailedConsumptionRemainsPendingAndRearms(t *testi
 	clock := agenttest.NewFakeClock()
 	root := newSession(t,
 		withDir(stateDir),
-		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true, clock: clock}),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true, clock: clock, testOnly: testConfig{metaFS: afero.NewMemMapFs()}}),
 		withSteps(
 			func(llm.Request) llm.Response {
 				return toolCallResponse(communicateCall("root-attention-first", "first attempt"))
@@ -2550,6 +2550,7 @@ func TestRootDelegateAttention_FailedConsumptionRemainsPendingAndRearms(t *testi
 
 func TestRootDelegateAttention_RestoreRearmsPendingIDsWithoutProviderCall(t *testing.T) {
 	stateDir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	rootID := identifier.MustNewSessionID()
 	if err := os.MkdirAll(filepath.Join(stateDir, sessionsSubdir), 0o755); err != nil {
 		t.Fatalf("mkdir sessions: %v", err)
@@ -2570,13 +2571,13 @@ func TestRootDelegateAttention_RestoreRearmsPendingIDsWithoutProviderCall(t *tes
 		t.Fatalf("close root transcript: %v", err)
 	}
 	meta := schema.SessionMeta{ID: rootID, ProfileID: "openai", Model: "gpt-5.2"}
-	if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
+	if err := schema.SaveSessionMetaWithFS(metaFS, stateDir, meta); err != nil {
 		t.Fatalf("save root metadata: %v", err)
 	}
 	client := llm.NewClient()
 	adapter := &delegateAttentionListModelsAdapter{}
 	client.Register(adapter)
-	restored, err := RestoreSessionFromMeta(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(stateDir), meta, stateDir)
+	restored, err := RestoreSessionFromMetaWithConfig(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(stateDir), meta, RestoreSessionConfig{StateDir: stateDir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("restore root: %v", err)
 	}

--- a/agent/session_awaiting_test.go
+++ b/agent/session_awaiting_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/events"
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/schema"
@@ -241,12 +243,13 @@ func TestWireState_AwaitingOutranksAutonomy(t *testing.T) {
 // though the ball is in the user's court.
 func TestRestore_AgentLastTurnResumesAwaiting(t *testing.T) {
 	t.Parallel()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai", steps: []func(llm.Request) llm.Response{
 		func(req llm.Request) llm.Response { return finalResponse("answer") },
 	}})
 	dir := t.TempDir()
-	sess, err := NewSession(c, NewOpenAIProfile("test-model"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(c, NewOpenAIProfile("test-model"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,16 +261,16 @@ func TestRestore_AgentLastTurnResumesAwaiting(t *testing.T) {
 	id := sess.ID()
 	sess.Close()
 
-	meta, err := schema.LoadSessionMeta(dir, id)
+	meta, err := schema.LoadSessionMetaWithFS(metaFS, dir, id)
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
 
 	c2 := llm.NewClient()
 	c2.Register(&fakeAdapter{name: "openai"})
-	restored, err := RestoreSessionFromMeta(c2, NewOpenAIProfile("test-model"), execenv.NewLocalExecutionEnvironment(dir), meta, dir)
+	restored, err := RestoreSessionFromMetaWithConfig(c2, NewOpenAIProfile("test-model"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
-		t.Fatalf("RestoreSessionFromMeta: %v", err)
+		t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
 	}
 	defer restored.Close()
 	if got := restored.State(); got != SessionAwaiting {
@@ -284,13 +287,14 @@ func TestRestore_AgentLastTurnResumesAwaiting(t *testing.T) {
 // backward-walk against over-triggering on a dangling user turn.
 func TestRestore_UserLastTurnStaysIdle(t *testing.T) {
 	t.Parallel()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	blocker := make(chan struct{})
 	c.Register(&fakeAdapter{name: "openai", steps: []func(llm.Request) llm.Response{
 		func(req llm.Request) llm.Response { <-blocker; return finalResponse("late") },
 	}})
 	dir := t.TempDir()
-	sess, err := NewSession(c, NewOpenAIProfile("test-model"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(c, NewOpenAIProfile("test-model"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,16 +308,16 @@ func TestRestore_UserLastTurnStaysIdle(t *testing.T) {
 	id := sess.ID()
 	sess.Close()
 
-	meta, err := schema.LoadSessionMeta(dir, id)
+	meta, err := schema.LoadSessionMetaWithFS(metaFS, dir, id)
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
 
 	c2 := llm.NewClient()
 	c2.Register(&fakeAdapter{name: "openai"})
-	restored, err := RestoreSessionFromMeta(c2, NewOpenAIProfile("test-model"), execenv.NewLocalExecutionEnvironment(dir), meta, dir)
+	restored, err := RestoreSessionFromMetaWithConfig(c2, NewOpenAIProfile("test-model"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
-		t.Fatalf("RestoreSessionFromMeta: %v", err)
+		t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
 	}
 	defer restored.Close()
 	if got := restored.State(); got != SessionIdle {

--- a/agent/session_budget_test.go
+++ b/agent/session_budget_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/internal/goal"
@@ -52,6 +54,19 @@ func restoreBudgetSession(
 	stateDir string,
 	resumeHistory []schema.Turn,
 ) *Session {
+	return restoreBudgetSessionFS(t, client, meta, stateDir, resumeHistory, nil)
+}
+
+// restoreBudgetSessionFS is restoreBudgetSession with the session-meta IO
+// routed through metaFS (nil means the real OS filesystem).
+func restoreBudgetSessionFS(
+	t *testing.T,
+	client *llm.Client,
+	meta schema.SessionMeta,
+	stateDir string,
+	resumeHistory []schema.Turn,
+	metaFS afero.Fs,
+) *Session {
 	t.Helper()
 	restoreCfg := RestoreSessionConfig{
 		StateDir:      stateDir,
@@ -61,6 +76,7 @@ func restoreBudgetSession(
 			skipGitSnapshot:     true,
 			minimalSystemPrompt: true,
 			noSyncJobStore:      true,
+			metaFS:              metaFS,
 		},
 	}
 	sess, err := RestoreSessionFromMetaWithConfig(
@@ -227,7 +243,8 @@ func TestSession_TurnBudgetWarningAfterThresholdOnNextAcceptedTurn(t *testing.T)
 func TestSession_TurnBudgetWarningRestoresWithoutDuplication(t *testing.T) {
 	t.Parallel()
 	stateDir := t.TempDir()
-	sess, adapter, client := newBudgetSession(t, SessionConfig{MaxTurns: 7, StateDir: stateDir}, nil)
+	metaFS := afero.NewMemMapFs()
+	sess, adapter, client := newBudgetSession(t, SessionConfig{MaxTurns: 7, StateDir: stateDir, testOnly: testConfig{metaFS: metaFS}}, nil)
 	for _, input := range []string{"first", "second", "third"} {
 		if _, err := sess.ProcessInput(context.Background(), input, nil); err != nil {
 			t.Fatalf("ProcessInput(%q): %v", input, err)
@@ -243,7 +260,7 @@ func TestSession_TurnBudgetWarningRestoresWithoutDuplication(t *testing.T) {
 	meta.TurnBudgetWarningEmitted = false
 	sess.Close()
 
-	restored := restoreBudgetSession(t, client, meta, stateDir, nil)
+	restored := restoreBudgetSessionFS(t, client, meta, stateDir, nil, metaFS)
 	if _, err := restored.ProcessInput(context.Background(), "after restore", nil); err != nil {
 		t.Fatalf("restored ProcessInput: %v", err)
 	}

--- a/agent/session_client_mutation_persist_test.go
+++ b/agent/session_client_mutation_persist_test.go
@@ -487,11 +487,19 @@ func TestClientMutationPersist_RejectsIncompleteSnapshot(t *testing.T) {
 
 func TestNewSessionMutationSnapshotUsesSnakeCaseStorageKeys(t *testing.T) {
 	stateDir := t.TempDir()
-	sess := newQueuePersistTestSession(t, stateDir)
+	// Build the session inline (rather than via newQueuePersistTestSession) so
+	// the session-meta IO routes through an in-memory metaFS; the client
+	// mutation snapshot under test keeps writing to the real stateDir.
+	client := llm.NewClient()
+	client.Register(&fakeAdapter{name: "openai"})
+	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(stateDir), SessionConfig{StateDir: stateDir, testOnly: testConfig{metaFS: afero.NewMemMapFs()}})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
 	defer sess.Close()
 
 	const mutationID = "fresh-session-mutation"
-	_, err := sess.AcceptClientMutationStart(appwire.TurnStartParams{
+	_, err = sess.AcceptClientMutationStart(appwire.TurnStartParams{
 		ClientMutationID: mutationID,
 		Input:            []appwire.InputItem{{Type: "text", Text: "persist me"}},
 	})
@@ -608,6 +616,7 @@ func assertSnakeCaseStorageKeys(t *testing.T, scope string, object map[string]an
 
 func TestClientMutationPersist_RestoreRejectsMalformedSnapshot(t *testing.T) {
 	stateDir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	client := llm.NewClient()
 	client.Register(&fakeAdapter{name: "openai"})
 
@@ -615,7 +624,7 @@ func TestClientMutationPersist_RestoreRejectsMalformedSnapshot(t *testing.T) {
 		client,
 		NewOpenAIProfile("gpt-5.2"),
 		execenv.NewLocalExecutionEnvironment(stateDir),
-		SessionConfig{StateDir: stateDir},
+		SessionConfig{StateDir: stateDir, testOnly: testConfig{metaFS: metaFS}},
 	)
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
@@ -631,7 +640,7 @@ func TestClientMutationPersist_RestoreRejectsMalformedSnapshot(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	meta, err := schema.LoadSessionMeta(stateDir, sessionID)
+	meta, err := schema.LoadSessionMetaWithFS(metaFS, stateDir, sessionID)
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
@@ -640,7 +649,7 @@ func TestClientMutationPersist_RestoreRejectsMalformedSnapshot(t *testing.T) {
 		NewOpenAIProfile("gpt-5.2"),
 		execenv.NewLocalExecutionEnvironment(stateDir),
 		meta,
-		RestoreSessionConfig{StateDir: stateDir},
+		RestoreSessionConfig{StateDir: stateDir, testOnly: testConfig{metaFS: metaFS}},
 	)
 	if restored != nil {
 		restored.Close()

--- a/agent/session_config_test.go
+++ b/agent/session_config_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/events"
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/hooks"
@@ -29,11 +31,13 @@ import (
 func TestSession_SetReasoningEffort_FlushesMeta(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})
 
 	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		StateDir: dir,
+		testOnly: testConfig{metaFS: metaFS},
 	})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
@@ -47,7 +51,7 @@ func TestSession_SetReasoningEffort_FlushesMeta(t *testing.T) {
 	sessID := sess.ID()
 	sess.SetReasoningEffort("high")
 
-	meta, err := schema.LoadSessionMeta(dir, sessID)
+	meta, err := schema.LoadSessionMetaWithFS(metaFS, dir, sessID)
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
@@ -62,11 +66,13 @@ func TestSession_SetReasoningEffort_FlushesMeta(t *testing.T) {
 func TestSession_SetModel_FlushesMeta(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})
 
 	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		StateDir: dir,
+		testOnly: testConfig{metaFS: metaFS},
 	})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
@@ -80,7 +86,7 @@ func TestSession_SetModel_FlushesMeta(t *testing.T) {
 	sessID := sess.ID()
 	sess.SetModel("gpt-5.3")
 
-	meta, err := schema.LoadSessionMeta(dir, sessID)
+	meta, err := schema.LoadSessionMetaWithFS(metaFS, dir, sessID)
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
@@ -95,11 +101,13 @@ func TestSession_SetModel_FlushesMeta(t *testing.T) {
 func TestSession_SetTimeout_FlushesMeta(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})
 
 	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		StateDir: dir,
+		testOnly: testConfig{metaFS: metaFS},
 	})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
@@ -113,7 +121,7 @@ func TestSession_SetTimeout_FlushesMeta(t *testing.T) {
 	sessID := sess.ID()
 	sess.SetTimeout(45_000)
 
-	meta, err := schema.LoadSessionMeta(dir, sessID)
+	meta, err := schema.LoadSessionMetaWithFS(metaFS, dir, sessID)
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
@@ -125,11 +133,13 @@ func TestSession_SetTimeout_FlushesMeta(t *testing.T) {
 func TestSession_SetModelAndTimeout_NoOpAfterClose(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})
 
 	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		StateDir:                dir,
+		testOnly:                testConfig{metaFS: metaFS},
 		DefaultCommandTimeoutMS: 10_000,
 	})
 	if err != nil {
@@ -142,7 +152,7 @@ func TestSession_SetModelAndTimeout_NoOpAfterClose(t *testing.T) {
 	sessID := sess.ID()
 	sess.Close()
 
-	before, err := schema.LoadSessionMeta(dir, sessID)
+	before, err := schema.LoadSessionMetaWithFS(metaFS, dir, sessID)
 	if err != nil {
 		t.Fatalf("LoadSessionMeta before setters: %v", err)
 	}
@@ -150,7 +160,7 @@ func TestSession_SetModelAndTimeout_NoOpAfterClose(t *testing.T) {
 	sess.SetModel("gpt-5.3")
 	sess.SetTimeout(45_000)
 
-	after, err := schema.LoadSessionMeta(dir, sessID)
+	after, err := schema.LoadSessionMetaWithFS(metaFS, dir, sessID)
 	if err != nil {
 		t.Fatalf("LoadSessionMeta after setters: %v", err)
 	}
@@ -780,12 +790,13 @@ func setCompactionTestHistory(sess *Session) {
 func TestSession_CompactQueuesOneExactTranscriptReminder(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai", steps: []func(req llm.Request) llm.Response{
 		func(req llm.Request) llm.Response { return finalResponse("forced summary") },
 	}})
 
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -825,9 +836,10 @@ func TestSession_CompactNoArtifactQueuesNoTranscriptReminder(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
+			metaFS := afero.NewMemMapFs()
 			c := llm.NewClient()
 			c.Register(&fakeAdapter{name: "openai"})
-			sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+			sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 			if err != nil {
 				t.Fatalf("NewSession: %v", err)
 			}
@@ -848,12 +860,13 @@ func TestSession_CompactNoArtifactQueuesNoTranscriptReminder(t *testing.T) {
 func TestSession_DistinctCompactionsQueueOneTranscriptReminderEach(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai", steps: []func(req llm.Request) llm.Response{
 		func(req llm.Request) llm.Response { return finalResponse("first summary") },
 		func(req llm.Request) llm.Response { return finalResponse("second summary") },
 	}})
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -879,13 +892,14 @@ func TestSession_DistinctCompactionsQueueOneTranscriptReminderEach(t *testing.T)
 func TestSession_SummaryFailureAfterCheckpointQueuesOneTranscriptReminder(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeErrAdapter{name: "openai", steps: []func(req llm.Request) (llm.Response, error){
 		func(req llm.Request) (llm.Response, error) {
 			return llm.Response{}, llm.ErrorFromHTTPStatus("openai", 400, "summary rejected", nil, nil)
 		},
 	}})
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -904,9 +918,10 @@ func TestSession_SummaryFailureAfterCheckpointQueuesOneTranscriptReminder(t *tes
 func TestSession_ObservationMaskOnlyQueuesNoTranscriptReminder(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, ContextStrategy: "obs-mask"})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, ContextStrategy: "obs-mask", testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -948,10 +963,11 @@ func TestSession_NonPersistentCompactionQueuesNoTranscriptReminder(t *testing.T)
 func TestSession_CompactionReminderUsesTranscriptTool(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})
 
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}

--- a/agent/session_dod_definition_test.go
+++ b/agent/session_dod_definition_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/events"
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/agenttest"
@@ -288,6 +290,7 @@ func TestSession_EventSystem_NaturalCompletion_EmitsUserAndAssistantTextEventsIn
 func TestSession_EventSystem_UserInputCarriesTurnIndex(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{
 		name: "openai",
@@ -297,7 +300,7 @@ func TestSession_EventSystem_UserInputCarriesTurnIndex(t *testing.T) {
 		},
 	})
 
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}

--- a/agent/session_envctx_test.go
+++ b/agent/session_envctx_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/envctx"
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/schema"
@@ -49,6 +51,7 @@ func newTestSessionForEnvctx(t *testing.T, opts ...sessionOpt) *Session {
 				minimalSystemPrompt: true,
 				noSyncJobStore:      true,
 				envProbes:           &envctx.Probes{Now: func() time.Time { return envctxFixedTime }},
+				metaFS:              afero.NewMemMapFs(),
 			},
 		}),
 	}
@@ -66,7 +69,13 @@ func sendOneUserInput(t *testing.T, s *Session, text string) {
 // loadMetaForTest reloads the session's persisted meta.json from its state dir.
 func loadMetaForTest(t *testing.T, s *Session) schema.SessionMeta {
 	t.Helper()
-	meta, err := schema.LoadSessionMeta(s.stateDir, s.id)
+	var meta schema.SessionMeta
+	var err error
+	if fs := s.cfg.testOnly.metaFS; fs != nil {
+		meta, err = schema.LoadSessionMetaWithFS(fs, s.stateDir, s.id)
+	} else {
+		meta, err = schema.LoadSessionMeta(s.stateDir, s.id)
+	}
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
@@ -225,7 +234,7 @@ func TestRestoredSessionWithMatchingEnvContextStaysSilent(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	probes := &envctx.Probes{Now: func() time.Time { return envctxFixedTime }}
-	testCfg := testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true, envProbes: probes}
+	testCfg := testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true, envProbes: probes, metaFS: afero.NewMemMapFs()}
 
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai", steps: repeatFinalResponse(2, "ok")})
@@ -280,7 +289,7 @@ func TestRestoredSessionWithNilEnvContextReemitsFullBlock(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	probes := &envctx.Probes{Now: func() time.Time { return envctxFixedTime }}
-	testCfg := testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true, envProbes: probes}
+	testCfg := testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true, envProbes: probes, metaFS: afero.NewMemMapFs()}
 
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})

--- a/agent/session_failure_count_test.go
+++ b/agent/session_failure_count_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/schema"
 	"primeradiant.com/serf/llm"
@@ -39,7 +41,7 @@ func TestFailedToolCallsSnapshotStartsMeasuredAtZero(t *testing.T) {
 	// transcript and nothing in it has failed. The strip renders nothing either
 	// way, but only one of the two claims is something the strip may make.
 	dir := t.TempDir()
-	sess := newSession(t, withDir(dir), withConfig(SessionConfig{MaxSubagentDepth: 1, StateDir: dir}))
+	sess := newSession(t, withDir(dir), withConfig(SessionConfig{MaxSubagentDepth: 1, StateDir: dir, testOnly: testConfig{metaFS: afero.NewMemMapFs()}}))
 	defer sess.Close()
 
 	count, ok := sess.FailedToolCallsSnapshot()
@@ -53,7 +55,7 @@ func TestFailedToolCallsSnapshotStartsMeasuredAtZero(t *testing.T) {
 
 func TestFailedToolCallsSnapshotRisesAsFailuresAreRecorded(t *testing.T) {
 	dir := t.TempDir()
-	sess := newSession(t, withDir(dir), withConfig(SessionConfig{MaxSubagentDepth: 1, StateDir: dir}))
+	sess := newSession(t, withDir(dir), withConfig(SessionConfig{MaxSubagentDepth: 1, StateDir: dir, testOnly: testConfig{metaFS: afero.NewMemMapFs()}}))
 	defer sess.Close()
 
 	if err := sess.transcript.Append(failedShellResultTurn("call_1", 1)); err != nil {
@@ -86,7 +88,8 @@ func TestFailedToolCallsSnapshotCoversTheWholeSessionAfterResume(t *testing.T) {
 	// that restarted its count at 0 would under-report exactly like a windowed
 	// one, and under-reporting is the harm the count exists to prevent.
 	dir := t.TempDir()
-	sess := newSession(t, withDir(dir), withConfig(SessionConfig{MaxSubagentDepth: 1, StateDir: dir}))
+	metaFS := afero.NewMemMapFs()
+	sess := newSession(t, withDir(dir), withConfig(SessionConfig{MaxSubagentDepth: 1, StateDir: dir, testOnly: testConfig{metaFS: metaFS}}))
 	if err := sess.transcript.Append(failedShellResultTurn("call_1", 2)); err != nil {
 		t.Fatalf("append: %v", err)
 	}
@@ -96,7 +99,7 @@ func TestFailedToolCallsSnapshotCoversTheWholeSessionAfterResume(t *testing.T) {
 	resumed, err := RestoreSessionFromMetaWithConfig(
 		llm.NewClient(), NewOpenAIProfile("gpt-5.2"),
 		execenv.NewLocalExecutionEnvironment(dir), meta,
-		RestoreSessionConfig{StateDir: dir},
+		RestoreSessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}},
 	)
 	if err != nil {
 		t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
@@ -124,7 +127,8 @@ func TestFailedToolCallsSnapshotDoesNotChargeAForkChildTheParentsFailures(t *tes
 	// prefix. DivergenceTurn is where the child's own history begins, and it
 	// bounds the live count exactly as it bounds the token sum.
 	dir := t.TempDir()
-	parent := newSession(t, withDir(dir), withConfig(SessionConfig{MaxSubagentDepth: 1, StateDir: dir}))
+	metaFS := afero.NewMemMapFs()
+	parent := newSession(t, withDir(dir), withConfig(SessionConfig{MaxSubagentDepth: 1, StateDir: dir, testOnly: testConfig{metaFS: metaFS}}))
 	if err := parent.transcript.Append(failedShellResultTurn("call_1", 1)); err != nil {
 		t.Fatalf("append parent failure: %v", err)
 	}
@@ -140,7 +144,7 @@ func TestFailedToolCallsSnapshotDoesNotChargeAForkChildTheParentsFailures(t *tes
 	child, err := RestoreSessionFromMetaWithConfig(
 		llm.NewClient(), NewOpenAIProfile("gpt-5.2"),
 		execenv.NewLocalExecutionEnvironment(dir), childMeta,
-		RestoreSessionConfig{StateDir: dir},
+		RestoreSessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}},
 	)
 	if err != nil {
 		t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
@@ -161,7 +165,7 @@ func TestFailedToolCallsSnapshotSurvivesTheSessionEnding(t *testing.T) {
 	// daemon until the next read reroutes to disk. Its settled count has to
 	// still be there, or the figure vanishes at the moment it stops changing.
 	dir := t.TempDir()
-	sess := newSession(t, withDir(dir), withConfig(SessionConfig{MaxSubagentDepth: 1, StateDir: dir}))
+	sess := newSession(t, withDir(dir), withConfig(SessionConfig{MaxSubagentDepth: 1, StateDir: dir, testOnly: testConfig{metaFS: afero.NewMemMapFs()}}))
 	if err := sess.transcript.Append(erroredResultTurn("call_1")); err != nil {
 		t.Fatalf("append: %v", err)
 	}
@@ -180,7 +184,7 @@ func TestFailedToolCallsSnapshotIgnoresATranscriptItCouldNotOpen(t *testing.T) {
 	// Belt and braces on the load-bearing rule: a session whose writer was never
 	// installed reports absent rather than a fabricated clean run.
 	dir := t.TempDir()
-	sess := newSession(t, withDir(dir), withConfig(SessionConfig{MaxSubagentDepth: 1, StateDir: dir}))
+	sess := newSession(t, withDir(dir), withConfig(SessionConfig{MaxSubagentDepth: 1, StateDir: dir, testOnly: testConfig{metaFS: afero.NewMemMapFs()}}))
 	defer sess.Close()
 
 	sess.transcript = nil

--- a/agent/session_goal_par_test.go
+++ b/agent/session_goal_par_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/goal"
 	"primeradiant.com/serf/agent/schema"
@@ -13,18 +15,20 @@ import (
 )
 
 // newStateGoalSession builds a session whose StateDir is enabled (so maybeAutoSave
-// actually persists) and returns it alongside that dir and a stop func.
-func newStateGoalSession(t *testing.T) (*Session, string, func()) {
+// actually persists) and returns it alongside that dir, the in-memory meta fs
+// the session's meta IO is routed through, and a stop func.
+func newStateGoalSession(t *testing.T) (*Session, string, afero.Fs, func()) {
 	t.Helper()
 	stateDir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{StateDir: stateDir})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{StateDir: stateDir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
 	stop := drainEvents(sess)
-	return sess, stateDir, func() { sess.Close(); stop() }
+	return sess, stateDir, metaFS, func() { sess.Close(); stop() }
 }
 
 // TestGoalGateBlockIsPersisted pins /par A4 for the no-progress breaker path: the
@@ -33,7 +37,7 @@ func newStateGoalSession(t *testing.T) (*Session, string, func()) {
 // would be saved as still-active and wrongly resume on restart.
 func TestGoalGateBlockIsPersisted(t *testing.T) {
 	t.Parallel()
-	sess, stateDir, stop := newStateGoalSession(t)
+	sess, stateDir, metaFS, stop := newStateGoalSession(t)
 	defer stop()
 
 	store := sess.getOrCreateGoalStore()
@@ -47,7 +51,7 @@ func TestGoalGateBlockIsPersisted(t *testing.T) {
 		sess.armGoalContinuation(false, true)
 	}
 
-	meta, err := schema.LoadSessionMeta(stateDir, sess.ID())
+	meta, err := schema.LoadSessionMetaWithFS(metaFS, stateDir, sess.ID())
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
@@ -60,13 +64,13 @@ func TestGoalGateBlockIsPersisted(t *testing.T) {
 // runs after the defer-save too, so its block must be persisted by its own save.
 func TestGoalErrorBlockIsPersisted(t *testing.T) {
 	t.Parallel()
-	sess, stateDir, stop := newStateGoalSession(t)
+	sess, stateDir, metaFS, stop := newStateGoalSession(t)
 	defer stop()
 
 	sess.getOrCreateGoalStore().Set("ship it", time.Now())
 	sess.terminateGoalOnError(context.Background(), errors.New("provider exploded"))
 
-	meta, err := schema.LoadSessionMeta(stateDir, sess.ID())
+	meta, err := schema.LoadSessionMetaWithFS(metaFS, stateDir, sess.ID())
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
@@ -85,7 +89,7 @@ func TestGoalErrorBlockIsPersisted(t *testing.T) {
 // every shutdown.
 func TestGoalRootShutdownLeavesGoalActive(t *testing.T) {
 	t.Parallel()
-	sess, _, stop := newStateGoalSession(t)
+	sess, _, _, stop := newStateGoalSession(t)
 	defer stop()
 
 	sess.getOrCreateGoalStore().Set("long task", time.Now())
@@ -108,6 +112,7 @@ func TestGoalRootShutdownLeavesGoalActive(t *testing.T) {
 // its terminal report (the once-gate resets on load) and leave a stale chip.
 func TestGoalRestoreOnlyActive(t *testing.T) {
 	t.Parallel()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})
 	now := time.Now()
@@ -127,9 +132,9 @@ func TestGoalRestoreOnlyActive(t *testing.T) {
 	}
 
 	for _, status := range []string{string(goal.StatusComplete), string(goal.StatusBlocked)} {
-		sess, err := RestoreSessionFromMeta(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), metaFor(status), t.TempDir())
+		sess, err := RestoreSessionFromMetaWithConfig(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), metaFor(status), RestoreSessionConfig{StateDir: t.TempDir(), testOnly: testConfig{metaFS: metaFS}})
 		if err != nil {
-			t.Fatalf("RestoreSessionFromMeta(%s): %v", status, err)
+			t.Fatalf("RestoreSessionFromMetaWithConfig(%s): %v", status, err)
 		}
 		if _, ok := sess.getOrCreateGoalStore().Snapshot(); ok {
 			t.Fatalf("a %s goal must not be restored (/par #2)", status)
@@ -137,9 +142,9 @@ func TestGoalRestoreOnlyActive(t *testing.T) {
 		sess.Close()
 	}
 
-	sess, err := RestoreSessionFromMeta(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), metaFor(string(goal.StatusActive)), t.TempDir())
+	sess, err := RestoreSessionFromMetaWithConfig(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), metaFor(string(goal.StatusActive)), RestoreSessionConfig{StateDir: t.TempDir(), testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
-		t.Fatalf("RestoreSessionFromMeta(active): %v", err)
+		t.Fatalf("RestoreSessionFromMetaWithConfig(active): %v", err)
 	}
 	defer sess.Close()
 	snap, ok := sess.getOrCreateGoalStore().Snapshot()

--- a/agent/session_identifier_test.go
+++ b/agent/session_identifier_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/schema"
 	"primeradiant.com/serf/identifier"
@@ -73,6 +75,7 @@ func TestNewSessionReleasesOwnershipWhenInitializationFails(t *testing.T) {
 			return logger.ReserveSession(id)
 		},
 	}
+	cfg.testOnly.metaFS = afero.NewMemMapFs()
 	cfg.testOnly.sessionInitFault = func(point string) error {
 		if point == "new_job_manager" {
 			return errors.New("injected initialization failure")
@@ -98,8 +101,9 @@ func TestNewSessionReleasesOwnershipWhenInitializationFails(t *testing.T) {
 
 func TestRestoreSessionReloadsMetadataAfterOwnershipAcquisition(t *testing.T) {
 	stateDir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	meta := schema.SessionMeta{ID: "02wMz5Txv1C3Hut0M8GCeB"}
-	if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
+	if err := schema.SaveSessionMetaWithFS(metaFS, stateDir, meta); err != nil {
 		t.Fatal(err)
 	}
 	metaPath := filepath.Join(stateDir, sessionsSubdir, meta.ID+".meta.json")
@@ -116,8 +120,9 @@ func TestRestoreSessionReloadsMetadataAfterOwnershipAcquisition(t *testing.T) {
 				if id != meta.ID {
 					t.Fatalf("ownership ID = %q, want %q", id, meta.ID)
 				}
-				return os.Remove(metaPath)
+				return metaFS.Remove(metaPath)
 			},
+			testOnly: testConfig{metaFS: metaFS},
 		},
 	)
 	if err == nil {

--- a/agent/session_init_error_restore_program_fuzz_test.go
+++ b/agent/session_init_error_restore_program_fuzz_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/internal/clock"
@@ -122,6 +124,7 @@ func sierTestConfig() testConfig {
 	return testConfig{
 		skipGitSnapshot: true,
 		noSyncJobStore:  true,
+		metaFS:          afero.NewMemMapFs(),
 		environmentInfo: func(env execenv.ExecutionEnvironment, clk clock.Clock) schema.EnvironmentInfo {
 			return schema.EnvironmentInfo{WorkingDir: env.WorkingDirectory(), Platform: "sier", Today: clk.Now().UTC().Format("2006-01-02")}
 		},
@@ -253,9 +256,9 @@ func sierFallbackValidation(t *testing.T, r *sierReader, client *llm.Client, pro
 func sierRestoreWrapper(t *testing.T, client *llm.Client, profile *provider.Profile, env execenv.ExecutionEnvironment, stateDir string) {
 	t.Helper()
 	meta := sierMeta()
-	sess, err := RestoreSessionFromMeta(client, profile, env, meta, stateDir)
+	sess, err := RestoreSessionFromMetaWithConfig(client, profile, env, meta, RestoreSessionConfig{StateDir: stateDir, testOnly: testConfig{metaFS: afero.NewMemMapFs()}})
 	if err != nil {
-		t.Fatalf("RestoreSessionFromMeta: %v", err)
+		t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
 	}
 	defer sess.Close()
 	if sess.id != meta.ID {

--- a/agent/session_jobtree_drain_test.go
+++ b/agent/session_jobtree_drain_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/internal/jobstore"
 	"primeradiant.com/serf/agent/schema"
@@ -598,6 +600,7 @@ func TestDrainJobTreeBatchesQueuedShellNotifications(t *testing.T) {
 
 func TestDrainJobTreeConsumesRootDelegateAttentionBeforeCompletion(t *testing.T) {
 	stateDir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	const (
 		attentionID = "delegate:dlg_drain/delivery/1"
 		content     = `<delegate-notification delegate_id="dlg_drain">drain me</delegate-notification>`
@@ -605,7 +608,7 @@ func TestDrainJobTreeConsumesRootDelegateAttentionBeforeCompletion(t *testing.T)
 	requestSawAttention := false
 	root := newSession(t,
 		withDir(stateDir),
-		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true}),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true, testOnly: testConfig{metaFS: metaFS}}),
 		withSteps(func(req llm.Request) llm.Response {
 			requestSawAttention = requestContainsText(req, content)
 			return toolCallResponse(communicateCall("root-attention-drain", "root attention drained"))
@@ -660,6 +663,7 @@ func TestDrainJobTreeWaitsForRunningDelegate(t *testing.T) {
 		StateDir:         stateDir,
 		MaxSubagentDepth: 2,
 		NoProjectPrompts: true,
+		testOnly:         testConfig{metaFS: afero.NewMemMapFs()},
 	}))
 
 	// Background a delegate; it runs to completion in its own goroutine and

--- a/agent/session_lifecycle_tail_coverage_fuzz_test.go
+++ b/agent/session_lifecycle_tail_coverage_fuzz_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/internal/hooks"
@@ -287,7 +289,7 @@ func sltcNewToolSession(t *testing.T) *Session {
 		},
 	})
 	cfg := SessionConfig{NoProjectPrompts: true, StateDir: root, MaxToolRoundsPerInput: 1, clock: agenttest.NewFakeClock()}
-	cfg.testOnly = testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true}
+	cfg.testOnly = testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true, metaFS: afero.NewMemMapFs()}
 	s, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), &agenttest.DenyEnv{WorkDir: root, Seed: 101}, cfg)
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
@@ -321,6 +323,7 @@ func sltcNewSession(t *testing.T, bare, maxTurns bool) *Session {
 		skipGitSnapshot:     true,
 		minimalSystemPrompt: true,
 		noSyncJobStore:      true,
+		metaFS:              afero.NewMemMapFs(),
 	}
 	s, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), &agenttest.DenyEnv{WorkDir: root, Seed: 100}, cfg)
 	if err != nil {

--- a/agent/session_model_call_tail_coverage_fuzz_test.go
+++ b/agent/session_model_call_tail_coverage_fuzz_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/events"
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/internal/tool"
@@ -254,6 +256,7 @@ func modelCallTailSessionWithClient(t *testing.T, client *llm.Client, profile *p
 	cfg.testOnly.skipGitSnapshot = true
 	cfg.testOnly.minimalSystemPrompt = true
 	cfg.testOnly.noSyncJobStore = true
+	cfg.testOnly.metaFS = afero.NewMemMapFs()
 	s, err := NewSession(client, profile, &agenttest.DenyEnv{WorkDir: t.TempDir(), Seed: 100}, cfg)
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)

--- a/agent/session_model_stream_fuzz_test.go
+++ b/agent/session_model_stream_fuzz_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/schema"
@@ -581,6 +583,7 @@ func msfzNewPlanningSession(t *testing.T, cfg msfzPlanConfig) *Session {
 	sc := SessionConfig{
 		StateDir:         dir,
 		MaxSubagentDepth: 1,
+		testOnly:         testConfig{metaFS: afero.NewMemMapFs()},
 	}
 	if cfg.auto {
 		sc.OpenAIResponsesContinuation = "auto"

--- a/agent/session_model_test.go
+++ b/agent/session_model_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/events"
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/goal"
@@ -230,6 +232,7 @@ func TestSession_RetriesAfterPartialOutputAndResets(t *testing.T) {
 func TestSession_StreamErrorFlushesMetaJSON_AfterPauseTurnGap(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 
 	var streamCallCount int
@@ -271,6 +274,7 @@ func TestSession_StreamErrorFlushesMetaJSON_AfterPauseTurnGap(t *testing.T) {
 	policy := llm.RetryPolicy{MaxRetries: 0}
 	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		StateDir:       dir,
+		testOnly:       testConfig{metaFS: metaFS},
 		LLMRetryPolicy: &policy,
 	})
 	if err != nil {
@@ -289,7 +293,7 @@ func TestSession_StreamErrorFlushesMetaJSON_AfterPauseTurnGap(t *testing.T) {
 	sessID := sess.ID()
 	sess.Close()
 
-	meta, err := schema.LoadSessionMeta(dir, sessID)
+	meta, err := schema.LoadSessionMetaWithFS(metaFS, dir, sessID)
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
@@ -307,6 +311,7 @@ func TestSession_StreamErrorFlushesMetaJSON_AfterPauseTurnGap(t *testing.T) {
 func TestSession_EmitsReasoningSummaryDelta(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	commCall := communicateCall("c1", "the answer")
 	f := &streamingAdapter{
@@ -324,7 +329,7 @@ func TestSession_EmitsReasoningSummaryDelta(t *testing.T) {
 	c.Register(f)
 
 	policy := llm.RetryPolicy{MaxRetries: 0}
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, LLMRetryPolicy: &policy})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, LLMRetryPolicy: &policy, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -372,6 +377,7 @@ func TestSession_EmitsReasoningSummaryDelta(t *testing.T) {
 func TestSession_StreamErrorFlushesMetaJSON_FirstTurn(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	f := &streamingAdapter{
 		name: "openai",
@@ -384,6 +390,7 @@ func TestSession_StreamErrorFlushesMetaJSON_FirstTurn(t *testing.T) {
 	policy := llm.RetryPolicy{MaxRetries: 0}
 	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		StateDir:       dir,
+		testOnly:       testConfig{metaFS: metaFS},
 		LLMRetryPolicy: &policy,
 	})
 	if err != nil {
@@ -402,7 +409,7 @@ func TestSession_StreamErrorFlushesMetaJSON_FirstTurn(t *testing.T) {
 	sessID := sess.ID()
 	sess.Close()
 
-	meta, err := schema.LoadSessionMeta(dir, sessID)
+	meta, err := schema.LoadSessionMetaWithFS(metaFS, dir, sessID)
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
@@ -418,6 +425,7 @@ func TestSession_StreamErrorFlushesMetaJSON_FirstTurn(t *testing.T) {
 func TestSession_StreamErrorFlushesMetaJSON_AfterHappyTurn(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 
 	var streamCallCount int
@@ -464,6 +472,7 @@ func TestSession_StreamErrorFlushesMetaJSON_AfterHappyTurn(t *testing.T) {
 	policy := llm.RetryPolicy{MaxRetries: 0}
 	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		StateDir:       dir,
+		testOnly:       testConfig{metaFS: metaFS},
 		LLMRetryPolicy: &policy,
 	})
 	if err != nil {
@@ -482,7 +491,7 @@ func TestSession_StreamErrorFlushesMetaJSON_AfterHappyTurn(t *testing.T) {
 		t.Fatalf("turn 1 ProcessInput: %v", err)
 	}
 	sessID := sess.ID()
-	meta, err := schema.LoadSessionMeta(dir, sessID)
+	meta, err := schema.LoadSessionMetaWithFS(metaFS, dir, sessID)
 	if err != nil {
 		t.Fatalf("LoadSessionMeta after turn 1: %v", err)
 	}
@@ -497,7 +506,7 @@ func TestSession_StreamErrorFlushesMetaJSON_AfterHappyTurn(t *testing.T) {
 	}
 	sess.Close()
 
-	meta, err = schema.LoadSessionMeta(dir, sessID)
+	meta, err = schema.LoadSessionMetaWithFS(metaFS, dir, sessID)
 	if err != nil {
 		t.Fatalf("LoadSessionMeta after error turn: %v", err)
 	}
@@ -514,6 +523,7 @@ func TestSession_StreamErrorFlushesMetaJSON_AfterHappyTurn(t *testing.T) {
 func TestSession_EmptyResponseExhaustedFlushesMeta(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	// Each empty response increments modelResponses (the loop bumps it before
 	// retrying). After maxEmptyRetries=3 consecutive empties, the loop returns
@@ -533,6 +543,7 @@ func TestSession_EmptyResponseExhaustedFlushesMeta(t *testing.T) {
 
 	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		StateDir: dir,
+		testOnly: testConfig{metaFS: metaFS},
 	})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
@@ -551,7 +562,7 @@ func TestSession_EmptyResponseExhaustedFlushesMeta(t *testing.T) {
 	sessID := sess.ID()
 	sess.Close()
 
-	meta, err := schema.LoadSessionMeta(dir, sessID)
+	meta, err := schema.LoadSessionMetaWithFS(metaFS, dir, sessID)
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
@@ -569,6 +580,7 @@ func TestSession_EmptyResponseExhaustedFlushesMeta(t *testing.T) {
 func TestSession_BareTextWithoutResultToolFlushesMeta(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	bareStep := func(req llm.Request) llm.Response {
 		return llm.Response{Message: llm.Assistant("bare text without tool")}
@@ -583,6 +595,7 @@ func TestSession_BareTextWithoutResultToolFlushesMeta(t *testing.T) {
 
 	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		StateDir: dir,
+		testOnly: testConfig{metaFS: metaFS},
 	})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
@@ -601,7 +614,7 @@ func TestSession_BareTextWithoutResultToolFlushesMeta(t *testing.T) {
 	sessID := sess.ID()
 	sess.Close()
 
-	meta, err := schema.LoadSessionMeta(dir, sessID)
+	meta, err := schema.LoadSessionMetaWithFS(metaFS, dir, sessID)
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
@@ -618,6 +631,7 @@ func TestSession_BareTextWithoutResultToolFlushesMeta(t *testing.T) {
 func TestSession_MaxToolRoundsExitFlushesMeta(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	// Always return a non-communicate tool call — the model never delivers,
 	// so the loop runs until MaxToolRoundsPerInput is hit.
@@ -646,6 +660,7 @@ func TestSession_MaxToolRoundsExitFlushesMeta(t *testing.T) {
 
 	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		StateDir:              dir,
+		testOnly:              testConfig{metaFS: metaFS},
 		MaxToolRoundsPerInput: 1,
 	})
 	if err != nil {
@@ -666,7 +681,7 @@ func TestSession_MaxToolRoundsExitFlushesMeta(t *testing.T) {
 	sessID := sess.ID()
 	sess.Close()
 
-	meta, err := schema.LoadSessionMeta(dir, sessID)
+	meta, err := schema.LoadSessionMetaWithFS(metaFS, dir, sessID)
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
@@ -1752,6 +1767,7 @@ func TestSession_AgentQuiescenceReturnsNilError(t *testing.T) {
 func TestSession_ProviderErrorDoesNotRecordAssistantTurn(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	f := &streamingAdapter{
 		name: "openai",
@@ -1765,6 +1781,7 @@ func TestSession_ProviderErrorDoesNotRecordAssistantTurn(t *testing.T) {
 	policy := llm.RetryPolicy{MaxRetries: 0}
 	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.4"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		StateDir:       dir,
+		testOnly:       testConfig{metaFS: metaFS},
 		LLMRetryPolicy: &policy,
 	})
 	if err != nil {
@@ -1800,6 +1817,7 @@ func TestSession_ProviderErrorDoesNotRecordAssistantTurn(t *testing.T) {
 
 func TestSession_SingleAttemptMetadataRecorded(t *testing.T) {
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	client := llm.NewClient()
 	comm := communicateCall("c1", "ok")
 	client.Register(&fakeAdapter{
@@ -1815,7 +1833,7 @@ func TestSession_SingleAttemptMetadataRecorded(t *testing.T) {
 			},
 		},
 	})
-	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -1889,6 +1907,7 @@ func TestSession_SanitizesCustomAdapterEndpointMetadata(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
+			metaFS := afero.NewMemMapFs()
 			client := llm.NewClient()
 			client.Register(&fakeAdapter{
 				name: "openai",
@@ -1900,7 +1919,7 @@ func TestSession_SanitizesCustomAdapterEndpointMetadata(t *testing.T) {
 					},
 				},
 			})
-			sess, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+			sess, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 			if err != nil {
 				t.Fatalf("NewSession: %v", err)
 			}
@@ -2026,6 +2045,7 @@ func TestProviderErrorEmitsStructuredCause(t *testing.T) {
 func TestProviderErrorTranscriptRemainsSemanticOnly(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	f := &streamingAdapter{
 		name:      "openai",
@@ -2036,6 +2056,7 @@ func TestProviderErrorTranscriptRemainsSemanticOnly(t *testing.T) {
 	policy := llm.RetryPolicy{MaxRetries: 0}
 	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		StateDir:       dir,
+		testOnly:       testConfig{metaFS: metaFS},
 		LLMRetryPolicy: &policy,
 	})
 	if err != nil {

--- a/agent/session_namer_hook_test.go
+++ b/agent/session_namer_hook_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/schema"
 	"primeradiant.com/serf/llm"
@@ -15,6 +17,7 @@ import (
 func TestSessionNameFromPrompt_UpdatesMetaAndAdvisoryLog(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	adapter := &fakeAdapter{
 		name: "openai",
 		steps: []func(req llm.Request) llm.Response{
@@ -32,7 +35,7 @@ func TestSessionNameFromPrompt_UpdatesMetaAndAdvisoryLog(t *testing.T) {
 	client := llm.NewClient()
 	client.Register(adapter)
 	profile := NewOpenAIProfile("gpt-5.2")
-	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -53,7 +56,7 @@ func TestSessionNameFromPrompt_UpdatesMetaAndAdvisoryLog(t *testing.T) {
 		t.Fatal("NameUpdatedAt is zero")
 	}
 
-	persisted, err := schema.LoadSessionMeta(dir, sess.ID())
+	persisted, err := schema.LoadSessionMetaWithFS(metaFS, dir, sess.ID())
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
@@ -78,13 +81,14 @@ func TestSessionNameFromPrompt_UpdatesMetaAndAdvisoryLog(t *testing.T) {
 func TestSessionNameFromPrompt_LogsAdvisoryFailureWithoutFailingSession(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	adapter := &fakeAdapter{name: "openai", steps: []func(req llm.Request) llm.Response{
 		func(req llm.Request) llm.Response { return llm.Response{Message: llm.Assistant(`{"name":"!!!"}`)} },
 	}}
 	client := llm.NewClient()
 	client.Register(adapter)
 	profile := WithCheapModel(NewOpenAIProfile("gpt-5.2"), "gpt-4.1-nano")
-	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -114,10 +118,11 @@ func TestSessionNameFromPrompt_LogsAdvisoryFailureWithoutFailingSession(t *testi
 func TestSessionLaunchesInitialPromptNamerAsynchronously(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	client := llm.NewClient()
 	client.Register(&fakeAdapter{name: "openai"})
 	profile := WithCheapModel(NewOpenAIProfile("gpt-5.2"), "gpt-4.1-nano")
-	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -149,10 +154,11 @@ func TestSessionLaunchesInitialPromptNamerAsynchronously(t *testing.T) {
 func TestSessionInitialPromptNamerSkipsWhilePending(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	client := llm.NewClient()
 	client.Register(&fakeAdapter{name: "openai"})
 	profile := WithCheapModel(NewOpenAIProfile("gpt-5.2"), "gpt-4.1-nano")
-	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -196,6 +202,7 @@ func TestSessionInitialPromptNamerSkipsWhilePending(t *testing.T) {
 func TestSessionProcessInput_LaunchesInitialPromptNamer(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	client := llm.NewClient()
 	client.Register(&fakeAdapter{name: "openai", steps: []func(req llm.Request) llm.Response{
 		func(req llm.Request) llm.Response {
@@ -203,7 +210,7 @@ func TestSessionProcessInput_LaunchesInitialPromptNamer(t *testing.T) {
 		},
 	}})
 	profile := WithCheapModel(NewOpenAIProfile("gpt-5.2"), "gpt-4.1-nano")
-	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -234,10 +241,11 @@ func TestSessionProcessInput_LaunchesInitialPromptNamer(t *testing.T) {
 func TestSessionNameFromCompactionTurn_RefreshesPromptName(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	client := llm.NewClient()
 	client.Register(&fakeAdapter{name: "openai"})
 	profile := WithCheapModel(NewOpenAIProfile("gpt-5.2"), "gpt-4.1-nano")
-	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -281,10 +289,11 @@ func TestSessionNameFromCompactionTurn_RefreshesPromptName(t *testing.T) {
 func TestSessionNameFromCompactionTurn_SkipsNonCompactionAndManualName(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	client := llm.NewClient()
 	client.Register(&fakeAdapter{name: "openai"})
 	profile := WithCheapModel(NewOpenAIProfile("gpt-5.2"), "gpt-4.1-nano")
-	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -322,10 +331,11 @@ func TestSessionNameFromCompactionTurn_SkipsNonCompactionAndManualName(t *testin
 func TestSessionLaunchesCompactionNamerAsynchronously(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	client := llm.NewClient()
 	client.Register(&fakeAdapter{name: "openai"})
 	profile := WithCheapModel(NewOpenAIProfile("gpt-5.2"), "gpt-4.1-nano")
-	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -357,6 +367,7 @@ func TestSessionLaunchesCompactionNamerAsynchronously(t *testing.T) {
 func TestRestoreSessionFromMeta_PreservesManualNameAgainstCompaction(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	client := llm.NewClient()
 	client.Register(&fakeAdapter{name: "openai"})
 	meta := schema.SessionMeta{
@@ -368,9 +379,9 @@ func TestRestoreSessionFromMeta_PreservesManualNameAgainstCompaction(t *testing.
 		NameSource:    "manual",
 		NameUpdatedAt: time.Now().UTC(),
 	}
-	sess, err := RestoreSessionFromMeta(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, dir)
+	sess, err := RestoreSessionFromMetaWithConfig(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
-		t.Fatalf("RestoreSessionFromMeta: %v", err)
+		t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
 	}
 	defer sess.Close()
 

--- a/agent/session_namer_program_fuzz_test.go
+++ b/agent/session_namer_program_fuzz_test.go
@@ -11,6 +11,8 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/internal/sessionlog"
 	"primeradiant.com/serf/agent/schema"
@@ -183,6 +185,7 @@ func namerFuzzSchemaName(name string) string {
 func namerFuzzSessionLifecycle(t *testing.T, mode byte, text, name string) {
 	t.Helper()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	profile := WithCheapModel(NewOpenAIProfile("gpt-main"), "gpt-cheap")
 	body, err := json.Marshal(map[string]string{"name": name})
 	if err != nil {
@@ -193,7 +196,7 @@ func namerFuzzSessionLifecycle(t *testing.T, mode byte, text, name string) {
 	}}
 	client := llm.NewClient()
 	client.Register(adapter)
-	sess, err := NewSession(client, profile, &agenttest.DenyEnv{WorkDir: dir}, SessionConfig{StateDir: dir})
+	sess, err := NewSession(client, profile, &agenttest.DenyEnv{WorkDir: dir}, SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}

--- a/agent/session_openai_continuation_phase10_test.go
+++ b/agent/session_openai_continuation_phase10_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/schema"
@@ -13,6 +15,7 @@ import (
 
 func TestSession_OpenAIResponsesContinuationPhase10DeltaCarriesFullHistoryShadowEstimate(t *testing.T) {
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	adapter := &agenttest.FakeAdapter{
 		Provider:          "openai",
 		CanFallbackToChat: true,
@@ -47,6 +50,7 @@ func TestSession_OpenAIResponsesContinuationPhase10DeltaCarriesFullHistoryShadow
 		StateDir:                    dir,
 		OpenAIResponsesContinuation: "auto",
 		testOnly: testConfig{
+			metaFS: metaFS,
 			responsesContinuationSupportRegistry: map[llm.ResponsesEndpointFamily]llm.ResponsesContinuationSupport{
 				llm.ResponsesEndpointFamilyOpenAIPublic: phase4DIEnabledSupport(),
 			},
@@ -79,6 +83,7 @@ func TestSession_OpenAIResponsesContinuationPhase10DeltaCarriesFullHistoryShadow
 
 func TestSession_OpenAIResponsesContinuationPhase10ShadowUnavailableUsesFullHistory(t *testing.T) {
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	adapter := &agenttest.FakeAdapter{
 		Provider:          "openai",
 		CanFallbackToChat: true,
@@ -110,6 +115,7 @@ func TestSession_OpenAIResponsesContinuationPhase10ShadowUnavailableUsesFullHist
 		StateDir:                    dir,
 		OpenAIResponsesContinuation: "auto",
 		testOnly: testConfig{
+			metaFS: metaFS,
 			responsesContinuationSupportRegistry: map[llm.ResponsesEndpointFamily]llm.ResponsesContinuationSupport{
 				llm.ResponsesEndpointFamilyOpenAIPublic: phase4DIEnabledSupport(),
 			},
@@ -136,6 +142,7 @@ func TestSession_OpenAIResponsesContinuationPhase10ShadowUnavailableUsesFullHist
 
 func TestSession_OpenAIResponsesContinuationPhase10PressureUsesFullHistoryShadowWhenLarger(t *testing.T) {
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	adapter := &agenttest.FakeAdapter{
 		Provider:          "openai",
 		CanFallbackToChat: true,
@@ -156,6 +163,7 @@ func TestSession_OpenAIResponsesContinuationPhase10PressureUsesFullHistoryShadow
 		StateDir:                    dir,
 		OpenAIResponsesContinuation: "auto",
 		testOnly: testConfig{
+			metaFS: metaFS,
 			responsesContinuationSupportRegistry: map[llm.ResponsesEndpointFamily]llm.ResponsesContinuationSupport{
 				llm.ResponsesEndpointFamilyOpenAIPublic: phase4DIEnabledSupport(),
 			},

--- a/agent/session_openai_continuation_phase5b_test.go
+++ b/agent/session_openai_continuation_phase5b_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/schema"
 	"primeradiant.com/serf/llm"
@@ -23,6 +25,7 @@ import (
 func TestSession_TranscriptAPILogSeparationAndAttemptGroupJoin(t *testing.T) {
 	const credentialSentinel = "credential_phase5b_must_not_persist"
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/responses":
@@ -60,7 +63,10 @@ func TestSession_TranscriptAPILogSeparationAndAttemptGroupJoin(t *testing.T) {
 	}
 	client.Use(apiLogger)
 
-	sess, err := NewSession(client, NewOpenAIProfile("gpt-4.1-mini"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(client, NewOpenAIProfile("gpt-4.1-mini"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
+		StateDir: dir,
+		testOnly: testConfig{metaFS: metaFS},
+	})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}

--- a/agent/session_openai_continuation_phase9_test.go
+++ b/agent/session_openai_continuation_phase9_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/schema"
@@ -18,6 +20,7 @@ import (
 
 func TestSession_OpenAIResponsesContinuationPhase9FallbackCapableFakePathCarriesFullHistorySidecar(t *testing.T) {
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	adapter := &agenttest.FakeAdapter{
 		Provider:          "openai",
 		CanFallbackToChat: true,
@@ -37,6 +40,7 @@ func TestSession_OpenAIResponsesContinuationPhase9FallbackCapableFakePathCarries
 		StateDir:                    dir,
 		OpenAIResponsesContinuation: "auto",
 		testOnly: testConfig{
+			metaFS: metaFS,
 			responsesContinuationSupportRegistry: map[llm.ResponsesEndpointFamily]llm.ResponsesContinuationSupport{
 				llm.ResponsesEndpointFamilyOpenAIPublic: phase4DIEnabledSupport(),
 			},
@@ -87,6 +91,7 @@ func TestSession_OpenAIResponsesContinuationPhase9FallbackCapableFakePathCarries
 
 func TestSession_OpenAIResponsesContinuationPhase9RetryThroughRealAnchorSelection(t *testing.T) {
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	continuationErr := llm.ErrorFromHTTPStatus("openai", 404, "Previous response not found", map[string]any{
 		"error": map[string]any{
 			"code":    "previous_response_not_found",
@@ -113,6 +118,7 @@ func TestSession_OpenAIResponsesContinuationPhase9RetryThroughRealAnchorSelectio
 		StateDir:                    dir,
 		OpenAIResponsesContinuation: "auto",
 		testOnly: testConfig{
+			metaFS: metaFS,
 			responsesContinuationSupportRegistry: map[llm.ResponsesEndpointFamily]llm.ResponsesContinuationSupport{
 				llm.ResponsesEndpointFamilyOpenAIPublic: phase4DIEnabledSupport(),
 			},
@@ -154,6 +160,7 @@ func TestSession_OpenAIResponsesContinuationPhase9RetryThroughRealAnchorSelectio
 
 func TestSession_OpenAIResponsesContinuationPhase9FallbackReplaySanitizesMalformedToolCall(t *testing.T) {
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	const malformedArgs = `{"value": broken`
 
 	var mu sync.Mutex
@@ -214,6 +221,7 @@ func TestSession_OpenAIResponsesContinuationPhase9FallbackReplaySanitizesMalform
 		StateDir:                    dir,
 		OpenAIResponsesContinuation: "auto",
 		testOnly: testConfig{
+			metaFS: metaFS,
 			responsesContinuationSupportRegistry: map[llm.ResponsesEndpointFamily]llm.ResponsesContinuationSupport{
 				llm.ResponsesEndpointFamilyOpenAIPublic: phase4DIEnabledSupport(),
 			},
@@ -288,6 +296,7 @@ func TestSession_OpenAIResponsesContinuationPhase9FallbackReplaySanitizesMalform
 
 func TestSession_OpenAIResponsesContinuationPhase9DisabledStateUsesFullHistoryAfterRejection(t *testing.T) {
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	continuationErr := llm.ErrorFromHTTPStatus("openai", 404, "Previous response not found", map[string]any{
 		"error": map[string]any{
 			"code":    "previous_response_not_found",
@@ -314,6 +323,7 @@ func TestSession_OpenAIResponsesContinuationPhase9DisabledStateUsesFullHistoryAf
 		StateDir:                    dir,
 		OpenAIResponsesContinuation: "auto",
 		testOnly: testConfig{
+			metaFS: metaFS,
 			responsesContinuationSupportRegistry: map[llm.ResponsesEndpointFamily]llm.ResponsesContinuationSupport{
 				llm.ResponsesEndpointFamilyOpenAIPublic: phase4DIEnabledSupport(),
 			},
@@ -388,6 +398,7 @@ func TestSession_OpenAIResponsesContinuationPhase9DisabledStateUsesFullHistoryAf
 
 func TestSession_OpenAIResponsesContinuationPhase9DisabledStateDoesNotLeakToNewSession(t *testing.T) {
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	continuationErr := llm.ErrorFromHTTPStatus("openai", 404, "Previous response not found", map[string]any{
 		"error": map[string]any{
 			"code":    "previous_response_not_found",
@@ -409,7 +420,7 @@ func TestSession_OpenAIResponsesContinuationPhase9DisabledStateDoesNotLeakToNewS
 	}
 	firstClient := llm.NewClient()
 	firstClient.Register(firstAdapter)
-	firstSess := newPhase9ContinuationSession(t, dir, firstClient)
+	firstSess := newPhase9ContinuationSession(t, dir, firstClient, metaFS)
 	defer firstSess.Close()
 	drainSessionEvents(firstSess)
 	setPhase9ContinuationHistory(firstSess, phase9MatchingAnchor("resp_phase9_disabled_original"))
@@ -431,7 +442,7 @@ func TestSession_OpenAIResponsesContinuationPhase9DisabledStateDoesNotLeakToNewS
 	}
 	nextClient := llm.NewClient()
 	nextClient.Register(nextAdapter)
-	nextSess := newPhase9ContinuationSession(t, dir, nextClient)
+	nextSess := newPhase9ContinuationSession(t, dir, nextClient, metaFS)
 	defer nextSess.Close()
 	drainSessionEvents(nextSess)
 	setPhase9ContinuationHistory(nextSess, phase9MatchingAnchor("resp_phase9_disabled_new_session"))
@@ -570,6 +581,7 @@ func TestSession_OpenAIResponsesContinuationPhase9InterveningAssistantGateUsesFu
 func runPhase9GateSession(t *testing.T, history []schema.Turn) llm.Request {
 	t.Helper()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	adapter := &agenttest.FakeAdapter{
 		Provider:          "openai",
 		CanFallbackToChat: true,
@@ -589,6 +601,7 @@ func runPhase9GateSession(t *testing.T, history []schema.Turn) llm.Request {
 		StateDir:                    dir,
 		OpenAIResponsesContinuation: "auto",
 		testOnly: testConfig{
+			metaFS: metaFS,
 			responsesContinuationSupportRegistry: map[llm.ResponsesEndpointFamily]llm.ResponsesContinuationSupport{
 				llm.ResponsesEndpointFamilyOpenAIPublic: phase4DIEnabledSupport(),
 			},
@@ -628,12 +641,13 @@ func setPhase9ContinuationHistory(sess *Session, anchor schema.Turn) {
 	}
 }
 
-func newPhase9ContinuationSession(t *testing.T, dir string, client *llm.Client) *Session {
+func newPhase9ContinuationSession(t *testing.T, dir string, client *llm.Client, metaFS afero.Fs) *Session {
 	t.Helper()
 	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.4"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		StateDir:                    dir,
 		OpenAIResponsesContinuation: "auto",
 		testOnly: testConfig{
+			metaFS: metaFS,
 			responsesContinuationSupportRegistry: map[llm.ResponsesEndpointFamily]llm.ResponsesContinuationSupport{
 				llm.ResponsesEndpointFamilyOpenAIPublic: phase4DIEnabledSupport(),
 			},

--- a/agent/session_openai_malformed_tool_call_test.go
+++ b/agent/session_openai_malformed_tool_call_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/schema"
 	"primeradiant.com/serf/llm"
@@ -20,6 +22,7 @@ import (
 
 func TestSession_OpenAIResponsesMalformedToolCallRecoveryUsesSafeReplay(t *testing.T) {
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	const malformedArgs = `{"value": broken`
 
 	var mu sync.Mutex
@@ -90,6 +93,7 @@ func TestSession_OpenAIResponsesMalformedToolCallRecoveryUsesSafeReplay(t *testi
 
 	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		StateDir: dir,
+		testOnly: testConfig{metaFS: metaFS},
 	})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
@@ -195,6 +199,7 @@ func TestSession_OpenAIResponsesMalformedToolCallRecoveryUsesSafeReplay(t *testi
 				skipGitSnapshot:     true,
 				minimalSystemPrompt: true,
 				noSyncJobStore:      true,
+				metaFS:              metaFS,
 			},
 		},
 	)

--- a/agent/session_persistence_init_fuzz_test.go
+++ b/agent/session_persistence_init_fuzz_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/events"
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/agenttest"
@@ -48,6 +50,7 @@ func FuzzPersistentSessionInitRestoreProgram(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		program := decodePIFProgram(data)
 		root := t.TempDir()
+		metaFS := afero.NewMemMapFs()
 		t.Setenv(envvars.XDGConfigHome.Name, filepath.Join(root, "xdg"))
 		t.Setenv(envvars.SERFSessionOrigin.Name, "test")
 
@@ -55,7 +58,7 @@ func FuzzPersistentSessionInitRestoreProgram(f *testing.F) {
 		newClock := agenttest.NewFakeClock()
 		newClient, newAdapter := pifClient(t)
 		newEnv := pifNewDenyEnv(workspace, uint64(program.seed))
-		cfg := pifSessionConfig(program, stateDir, pluginDir, promptFile, appendFile, newClock)
+		cfg := pifSessionConfig(program, stateDir, pluginDir, promptFile, appendFile, newClock, metaFS)
 
 		fresh, err := NewSession(newClient, NewOpenAIProfile("gpt-5.2"), newEnv, cfg)
 		if err != nil {
@@ -63,7 +66,7 @@ func FuzzPersistentSessionInitRestoreProgram(f *testing.F) {
 		}
 		pifAssertFreshSession(t, fresh, program, workspace, promptFile, appendFile, newAdapter)
 
-		meta, err := schema.LoadSessionMeta(stateDir, fresh.ID())
+		meta, err := schema.LoadSessionMetaWithFS(metaFS, stateDir, fresh.ID())
 		if err != nil {
 			fresh.Close()
 			t.Fatalf("load fresh meta: %v", err)
@@ -87,7 +90,7 @@ func FuzzPersistentSessionInitRestoreProgram(f *testing.F) {
 				StateDir:                stateDir,
 				deferRestoreSideEffects: program.deferRestoreSideEffects,
 				clock:                   restoreClock,
-				testOnly:                pifTestConfig(),
+				testOnly:                pifTestConfig(metaFS),
 			},
 		)
 		if err != nil {
@@ -203,11 +206,12 @@ func pifClient(t *testing.T) (*llm.Client, *agenttest.ScriptedAdapter) {
 	return client, adapter
 }
 
-func pifTestConfig() testConfig {
+func pifTestConfig(metaFS afero.Fs) testConfig {
 	return testConfig{
 		skipGitSnapshot: true,
 		environmentInfo: pifEnvironmentInfo,
 		noSyncJobStore:  true,
+		metaFS:          metaFS,
 	}
 }
 
@@ -224,6 +228,7 @@ func pifSessionConfig(
 	program pifProgram,
 	stateDir, pluginDir, promptFile, appendFile string,
 	clk clock.Clock,
+	metaFS afero.Fs,
 ) SessionConfig {
 	agentName := ""
 	if program.pluginAgent {
@@ -242,7 +247,7 @@ func pifSessionConfig(
 		AgentName:          agentName,
 		SessionStartKind:   program.startKind,
 		clock:              clk,
-		testOnly:           pifTestConfig(),
+		testOnly:           pifTestConfig(metaFS),
 	}
 }
 

--- a/agent/session_queue_persist_test.go
+++ b/agent/session_queue_persist_test.go
@@ -19,6 +19,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/schema"
 	"primeradiant.com/serf/llm"
@@ -28,10 +30,16 @@ import (
 // working directory and its state dir, so meta.json/transcript/the new queue
 // file all land under the same tree a real daemon would use.
 func newQueuePersistTestSession(t *testing.T, dir string) *Session {
+	return newQueuePersistTestSessionWithFS(t, dir, nil)
+}
+
+// newQueuePersistTestSessionWithFS is newQueuePersistTestSession with the
+// session's meta.json IO rerouted to metaFS (nil = real OS filesystem).
+func newQueuePersistTestSessionWithFS(t *testing.T, dir string, metaFS afero.Fs) *Session {
 	t.Helper()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -43,14 +51,21 @@ func newQueuePersistTestSession(t *testing.T, dir string) *Session {
 // RestoreSessionFromMetaWithConfig (agent/session_init.go), the exact function
 // `serf serve --resume` uses.
 func restoreQueuePersistTestSession(t *testing.T, dir, id string) *Session {
+	return restoreQueuePersistTestSessionWithFS(t, dir, id, nil)
+}
+
+// restoreQueuePersistTestSessionWithFS is restoreQueuePersistTestSession with
+// the meta load (and the restored session's meta IO) rerouted to metaFS. It
+// must be the same fs the writing session used.
+func restoreQueuePersistTestSessionWithFS(t *testing.T, dir, id string, metaFS afero.Fs) *Session {
 	t.Helper()
-	meta, err := schema.LoadSessionMeta(dir, id)
+	meta, err := schema.LoadSessionMetaWithFS(metaFS, dir, id)
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})
-	restored, err := RestoreSessionFromMetaWithConfig(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{StateDir: dir})
+	restored, err := RestoreSessionFromMetaWithConfig(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
 		t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
 	}
@@ -70,7 +85,8 @@ func queuePersistFilePath(dir, id string) string {
 func TestQueuePersist_EnqueueMixedItems_SurvivesRestart(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	sess := newQueuePersistTestSession(t, dir)
+	metaFS := afero.NewMemMapFs()
+	sess := newQueuePersistTestSessionWithFS(t, dir, metaFS)
 	id := sess.ID()
 	ctx := context.Background()
 
@@ -99,7 +115,7 @@ func TestQueuePersist_EnqueueMixedItems_SurvivesRestart(t *testing.T) {
 	}
 	sess.Close()
 
-	restored := restoreQueuePersistTestSession(t, dir, id)
+	restored := restoreQueuePersistTestSessionWithFS(t, dir, id, metaFS)
 	defer restored.Close()
 
 	if got := restored.QueuePreview(); !reflect.DeepEqual(got, wantPreview) {
@@ -119,7 +135,8 @@ func TestQueuePersist_EnqueueMixedItems_SurvivesRestart(t *testing.T) {
 func TestQueuePersist_DaemonAndClientSteeringUseDistinctAuthorities(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	sess := newQueuePersistTestSession(t, dir)
+	metaFS := afero.NewMemMapFs()
+	sess := newQueuePersistTestSessionWithFS(t, dir, metaFS)
 	id := sess.ID()
 
 	sess.Steer("<SYSTEM-REMINDER>daemon nudge</SYSTEM-REMINDER>") // Source == "" (system-authored)
@@ -129,7 +146,7 @@ func TestQueuePersist_DaemonAndClientSteeringUseDistinctAuthorities(t *testing.T
 	}
 	sess.Close()
 
-	restored := restoreQueuePersistTestSession(t, dir, id)
+	restored := restoreQueuePersistTestSessionWithFS(t, dir, id, metaFS)
 	defer restored.Close()
 
 	got := restored.SteeringQueueSnapshot()
@@ -145,7 +162,8 @@ func TestQueuePersist_DaemonAndClientSteeringUseDistinctAuthorities(t *testing.T
 func TestQueuePersist_ClientSteeringDoesNotTouchLegacyFile(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	sess := newQueuePersistTestSession(t, dir)
+	metaFS := afero.NewMemMapFs()
+	sess := newQueuePersistTestSessionWithFS(t, dir, metaFS)
 	id := sess.ID()
 	path := queuePersistFilePath(dir, id)
 	defer sess.Close()
@@ -182,7 +200,8 @@ func TestQueuePersist_ClientSteeringDoesNotTouchLegacyFile(t *testing.T) {
 func TestQueuePersist_DrainAsSteer_SurvivesRestart(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	sess := newQueuePersistTestSession(t, dir)
+	metaFS := afero.NewMemMapFs()
+	sess := newQueuePersistTestSessionWithFS(t, dir, metaFS)
 	id := sess.ID()
 	ctx := context.Background()
 
@@ -205,7 +224,7 @@ func TestQueuePersist_DrainAsSteer_SurvivesRestart(t *testing.T) {
 	}
 	sess.Close()
 
-	restored := restoreQueuePersistTestSession(t, dir, id)
+	restored := restoreQueuePersistTestSessionWithFS(t, dir, id, metaFS)
 	defer restored.Close()
 
 	if depth := restored.QueueDepth(); depth != 0 {
@@ -219,7 +238,8 @@ func TestQueuePersist_DrainAsSteer_SurvivesRestart(t *testing.T) {
 func TestQueuePersist_PromoteQueuedAsSteer_SurvivesRestart(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	sess := newQueuePersistTestSession(t, dir)
+	metaFS := afero.NewMemMapFs()
+	sess := newQueuePersistTestSessionWithFS(t, dir, metaFS)
 	id := sess.ID()
 	ctx := context.Background()
 
@@ -243,7 +263,7 @@ func TestQueuePersist_PromoteQueuedAsSteer_SurvivesRestart(t *testing.T) {
 	}
 	sess.Close()
 
-	restored := restoreQueuePersistTestSession(t, dir, id)
+	restored := restoreQueuePersistTestSessionWithFS(t, dir, id, metaFS)
 	defer restored.Close()
 
 	if got := restored.QueuePreview(); !reflect.DeepEqual(got, wantPreview) {
@@ -260,7 +280,8 @@ func TestQueuePersist_PromoteQueuedAsSteer_SurvivesRestart(t *testing.T) {
 func TestQueuePersist_CancelQueued_SurvivesRestart(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	sess := newQueuePersistTestSession(t, dir)
+	metaFS := afero.NewMemMapFs()
+	sess := newQueuePersistTestSessionWithFS(t, dir, metaFS)
 	id := sess.ID()
 	ctx := context.Background()
 
@@ -282,7 +303,7 @@ func TestQueuePersist_CancelQueued_SurvivesRestart(t *testing.T) {
 	}
 	sess.Close()
 
-	restored := restoreQueuePersistTestSession(t, dir, id)
+	restored := restoreQueuePersistTestSessionWithFS(t, dir, id, metaFS)
 	defer restored.Close()
 
 	if got := restored.QueuePreview(); !reflect.DeepEqual(got, wantPreview) {
@@ -299,7 +320,8 @@ func TestQueuePersist_CancelQueued_SurvivesRestart(t *testing.T) {
 func TestQueuePersist_EmptyQueue_NoResidueOnDisk(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	sess := newQueuePersistTestSession(t, dir)
+	metaFS := afero.NewMemMapFs()
+	sess := newQueuePersistTestSessionWithFS(t, dir, metaFS)
 	id := sess.ID()
 	ctx := context.Background()
 	path := queuePersistFilePath(dir, id)
@@ -324,7 +346,7 @@ func TestQueuePersist_EmptyQueue_NoResidueOnDisk(t *testing.T) {
 	}
 	sess.Close()
 
-	restored := restoreQueuePersistTestSession(t, dir, id)
+	restored := restoreQueuePersistTestSessionWithFS(t, dir, id, metaFS)
 	defer restored.Close()
 	if depth := restored.QueueDepth(); depth != 1 {
 		t.Fatalf("restored QueueDepth = %d, want 1 (claimed input returns runnable)", depth)
@@ -334,7 +356,8 @@ func TestQueuePersist_EmptyQueue_NoResidueOnDisk(t *testing.T) {
 func TestQueuePersist_CrashBetweenClaimAndConsume_ReturnsRunnable(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	sess := newQueuePersistTestSession(t, dir)
+	metaFS := afero.NewMemMapFs()
+	sess := newQueuePersistTestSessionWithFS(t, dir, metaFS)
 	id := sess.ID()
 	ctx := context.Background()
 
@@ -356,7 +379,7 @@ func TestQueuePersist_CrashBetweenClaimAndConsume_ReturnsRunnable(t *testing.T) 
 	}
 	claimedRevision := sess.clientMutations.snapshot().QueueRevision
 
-	restored := restoreQueuePersistTestSession(t, dir, id)
+	restored := restoreQueuePersistTestSessionWithFS(t, dir, id, metaFS)
 	defer restored.Close()
 
 	gotTexts := restored.QueueTexts()
@@ -382,7 +405,8 @@ func TestQueuePersist_CrashBetweenClaimAndConsume_ReturnsRunnable(t *testing.T) 
 func TestQueuePersist_DrainSteering_CrashLosesAtMostInFlightItem(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	sess := newQueuePersistTestSession(t, dir)
+	metaFS := afero.NewMemMapFs()
+	sess := newQueuePersistTestSessionWithFS(t, dir, metaFS)
 	id := sess.ID()
 
 	sess.SteerFromUser("alpha")
@@ -414,7 +438,7 @@ func TestQueuePersist_DrainSteering_CrashLosesAtMostInFlightItem(t *testing.T) {
 		t.Fatalf("second pop = %q ok=%v, want bravo", second.Text, ok)
 	}
 
-	restored := restoreQueuePersistTestSession(t, dir, id)
+	restored := restoreQueuePersistTestSessionWithFS(t, dir, id, metaFS)
 	defer restored.Close()
 
 	// Claimed but unincorporated bravo returns to runnable state; charlie was

--- a/agent/session_queue_persist_test.go
+++ b/agent/session_queue_persist_test.go
@@ -59,7 +59,13 @@ func restoreQueuePersistTestSession(t *testing.T, dir, id string) *Session {
 // must be the same fs the writing session used.
 func restoreQueuePersistTestSessionWithFS(t *testing.T, dir, id string, metaFS afero.Fs) *Session {
 	t.Helper()
-	meta, err := schema.LoadSessionMetaWithFS(metaFS, dir, id)
+	var meta schema.SessionMeta
+	var err error
+	if metaFS != nil {
+		meta, err = schema.LoadSessionMetaWithFS(metaFS, dir, id)
+	} else {
+		meta, err = schema.LoadSessionMeta(dir, id)
+	}
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}

--- a/agent/session_recursion_test.go
+++ b/agent/session_recursion_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/schema"
 	"primeradiant.com/serf/llm"
@@ -94,13 +96,14 @@ func TestRestoredRootAllowanceFromConfig(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			metaFS := afero.NewMemMapFs()
 			meta := schema.SessionMeta{
 				ID:        "01TESTRESTOREROOT",
 				ProfileID: "openai",
 				Model:     "gpt-5.2",
 				Config:    (SessionConfig{MaxSubagentDepth: tc.maxSubagentDepth, NoProjectPrompts: true}).toSnapshot(),
 			}
-			sess, err := RestoreSessionFromMetaWithConfig(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), meta, RestoreSessionConfig{StateDir: t.TempDir()})
+			sess, err := RestoreSessionFromMetaWithConfig(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), meta, RestoreSessionConfig{StateDir: t.TempDir(), testOnly: testConfig{metaFS: metaFS}})
 			if err != nil {
 				t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
 			}

--- a/agent/session_resolve_profile_test.go
+++ b/agent/session_resolve_profile_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/provider"
 	"primeradiant.com/serf/agent/schema"
@@ -136,6 +138,7 @@ func TestSetModel_CrossProvider_WithoutResolver_NoSwap(t *testing.T) {
 func TestRestoreSessionFromMetaWithConfig_InstallsResolveProfile(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})
 	c.Register(&fakeAdapter{name: "anthropic"})
@@ -158,6 +161,7 @@ func TestRestoreSessionFromMetaWithConfig_InstallsResolveProfile(t *testing.T) {
 	sess, err := RestoreSessionFromMetaWithConfig(c, NewOpenAIProfile("gpt-5.4"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{
 		StateDir:       dir,
 		ResolveProfile: resolver,
+		testOnly:       testConfig{metaFS: metaFS},
 	})
 	if err != nil {
 		t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
@@ -180,6 +184,7 @@ func TestRestoreSessionFromMetaWithConfig_InstallsResolveProfile(t *testing.T) {
 func TestRestoreSessionFromMetaWithConfig_LayersModelFallbacks(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})
 
@@ -195,6 +200,7 @@ func TestRestoreSessionFromMetaWithConfig_LayersModelFallbacks(t *testing.T) {
 	sess, err := RestoreSessionFromMetaWithConfig(c, NewOpenAIProfile("gpt-5.4"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{
 		StateDir:       dir,
 		ModelFallbacks: []string{"openai/runtime-fallback"},
+		testOnly:       testConfig{metaFS: metaFS},
 	})
 	if err != nil {
 		t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
@@ -223,6 +229,7 @@ func TestRestoreSessionFromMetaWithConfig_LayersOpenAIResponsesContinuation(t *t
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			dir := t.TempDir()
+			metaFS := afero.NewMemMapFs()
 			c := llm.NewClient()
 			c.Register(&fakeAdapter{name: "openai"})
 			meta := schema.SessionMeta{
@@ -236,6 +243,7 @@ func TestRestoreSessionFromMetaWithConfig_LayersOpenAIResponsesContinuation(t *t
 			sess, err := RestoreSessionFromMetaWithConfig(c, NewOpenAIProfile("gpt-5.4"), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{
 				StateDir:                    dir,
 				OpenAIResponsesContinuation: tc.override,
+				testOnly:                    testConfig{metaFS: metaFS},
 			})
 			if err != nil {
 				t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)

--- a/agent/session_restore_close_status_program_fuzz_test.go
+++ b/agent/session_restore_close_status_program_fuzz_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/internal/clock"
@@ -287,6 +289,7 @@ func srspRuntimeAndStatus(t *testing.T, draw byte) {
 			skipGitSnapshot: true,
 			noSyncJobStore:  true,
 			environmentInfo: srspEnvironmentInfo,
+			metaFS:          afero.NewMemMapFs(),
 		},
 	})
 	if err != nil {

--- a/agent/session_restore_fork_fuzz_test.go
+++ b/agent/session_restore_fork_fuzz_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/oklog/ulid/v2"
+	"github.com/spf13/afero"
 
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/schema"
@@ -254,6 +255,7 @@ func FuzzRfzRestoreSessionFromMeta(f *testing.F) {
 		restoreCfg := RestoreSessionConfig{
 			StateDir:                stateDir,
 			deferRestoreSideEffects: r.intn(2) == 0,
+			testOnly:                testConfig{metaFS: afero.NewMemMapFs()},
 		}
 
 		sess, err := RestoreSessionFromMetaWithConfig(c, NewOpenAIProfile("gpt-5"), env, meta, restoreCfg)

--- a/agent/session_resume_hooks_test.go
+++ b/agent/session_resume_hooks_test.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/events"
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/plugin"
@@ -53,6 +55,7 @@ func newResumeHookPluginDir(t *testing.T) string {
 func restoredSessionWithResumeHook(t *testing.T, adapter *fakeAdapter) *Session {
 	t.Helper()
 	stateDir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	meta := schema.SessionMeta{
 		ID:        "01KRESUMEHOOKTEST0000000000",
 		ProfileID: "test",
@@ -71,6 +74,7 @@ func restoredSessionWithResumeHook(t *testing.T, adapter *fakeAdapter) *Session 
 		meta,
 		RestoreSessionConfig{
 			StateDir: stateDir,
+			testOnly: testConfig{metaFS: metaFS},
 			resumeHistory: []schema.Turn{
 				schema.NewTurn(schema.TurnUserInput, llm.User("prior user task")),
 				schema.NewTurn(schema.TurnAssistant, llm.Assistant("prior assistant answer")),

--- a/agent/session_resume_turn_program_fuzz_test.go
+++ b/agent/session_resume_turn_program_fuzz_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/events"
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/agenttest"
@@ -146,13 +148,14 @@ func rttRestoredSession(t *testing.T, program rttProgram) (*Session, *agenttest.
 	}
 	pluginDir := rttWriteResumeHookPlugin(t, root)
 	clk := agenttest.NewFakeClock()
+	metaFS := afero.NewMemMapFs()
 	cfg := SessionConfig{
 		StateDir:         stateDir,
 		MaxTurns:         program.maxTurns,
 		PluginDirs:       []string{pluginDir},
 		NoProjectPrompts: true,
 		clock:            clk,
-		testOnly:         rttTestConfig(),
+		testOnly:         rttTestConfig(metaFS),
 	}
 
 	// The initial session creates the real metadata/transcript pair. Its plugin
@@ -179,7 +182,7 @@ func rttRestoredSession(t *testing.T, program rttProgram) (*Session, *agenttest.
 				schema.NewTurn(schema.TurnAssistant, llm.Assistant(rttPriorAssistant)),
 			},
 			clock:    clk,
-			testOnly: rttTestConfig(),
+			testOnly: rttTestConfig(metaFS),
 		},
 	)
 	if err != nil {
@@ -203,10 +206,11 @@ func rttClient() (*llm.Client, *agenttest.ScriptedAdapter) {
 	return client, adapter
 }
 
-func rttTestConfig() testConfig {
+func rttTestConfig(metaFS afero.Fs) testConfig {
 	return testConfig{
 		skipGitSnapshot: true,
 		noSyncJobStore:  true,
+		metaFS:          metaFS,
 		environmentInfo: func(env execenv.ExecutionEnvironment, clk clock.Clock) schema.EnvironmentInfo {
 			return schema.EnvironmentInfo{
 				WorkingDir: env.WorkingDirectory(),

--- a/agent/session_set_model_test.go
+++ b/agent/session_set_model_test.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/provider"
 	"primeradiant.com/serf/agent/schema"
@@ -118,13 +120,14 @@ func TestSetModel_CrossProvider_ReturnsNilAndSwapsProfileID(t *testing.T) {
 func TestSetModel_CrashRestore_SwitchedModelSurvives(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})
 
 	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.4"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		NoProjectPrompts: true,
 		StateDir:         dir,
-		testOnly:         testConfig{skipGitSnapshot: true},
+		testOnly:         testConfig{skipGitSnapshot: true, metaFS: metaFS},
 	})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
@@ -136,7 +139,7 @@ func TestSetModel_CrashRestore_SwitchedModelSurvives(t *testing.T) {
 	sessID := sess.ID()
 	sess.Close()
 
-	meta, err := schema.LoadSessionMeta(dir, sessID)
+	meta, err := schema.LoadSessionMetaWithFS(metaFS, dir, sessID)
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
@@ -148,6 +151,7 @@ func TestSetModel_CrashRestore_SwitchedModelSurvives(t *testing.T) {
 	// (mirrors production: cmd/serf reconstructs the profile from meta.Model).
 	restored, err := RestoreSessionFromMetaWithConfig(c, NewOpenAIProfile(meta.Model), execenv.NewLocalExecutionEnvironment(dir), meta, RestoreSessionConfig{
 		StateDir: dir,
+		testOnly: testConfig{metaFS: metaFS},
 	})
 	if err != nil {
 		t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)

--- a/agent/session_stop_and_queued_work_test.go
+++ b/agent/session_stop_and_queued_work_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/appwire"
 	"primeradiant.com/serf/llm"
 )
@@ -42,7 +44,7 @@ func queueOneMutation(t *testing.T, sess *Session, clientMutationID, text string
 // follows must return the claim, because the entry is already out of the input
 // queue and the only other recovery for this state runs at startup.
 func TestClaimedQueuedTurnIsReturnedWhenItNeverRan(t *testing.T) {
-	sess := newQueuePersistTestSession(t, t.TempDir())
+	sess := newQueuePersistTestSessionWithFS(t, t.TempDir(), afero.NewMemMapFs())
 	defer sess.Close()
 
 	queueOneMutation(t, sess, "queue-behind-stop", "please still run me")
@@ -105,7 +107,7 @@ func TestClaimedQueuedTurnIsReturnedWhenItNeverRan(t *testing.T) {
 // with a message queued behind it would leave the session reporting itself as
 // working with a queue nobody drains.
 func TestStopWakesTheSessionForWorkItLeftQueued(t *testing.T) {
-	sess := newQueuePersistTestSession(t, t.TempDir())
+	sess := newQueuePersistTestSessionWithFS(t, t.TempDir(), afero.NewMemMapFs())
 	defer sess.Close()
 
 	queueOneMutation(t, sess, "queued-through-stop", "run me after the stop")
@@ -140,7 +142,7 @@ func TestStopWakesTheSessionForWorkItLeftQueued(t *testing.T) {
 // refusing while the UI says "working" is the failure the session-scoped rule
 // exists to prevent -- but it must not cost the queued message.
 func TestStopIsHonestAboutAQueuedMessage(t *testing.T) {
-	sess := newQueuePersistTestSession(t, t.TempDir())
+	sess := newQueuePersistTestSessionWithFS(t, t.TempDir(), afero.NewMemMapFs())
 	defer sess.Close()
 
 	queueOneMutation(t, sess, "queue-behind-stop", "please still run me")
@@ -237,6 +239,7 @@ func (a *stopHoldAdapter) Stream(ctx context.Context, req llm.Request) (llm.Stre
 // finished.
 func TestStopOnMidTurnMutationParksTheQueuedMessage(t *testing.T) {
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	adapter := newStopHoldAdapter()
 	sess := newSession(t,
 		withAdapter(adapter),
@@ -245,7 +248,7 @@ func TestStopOnMidTurnMutationParksTheQueuedMessage(t *testing.T) {
 			MaxSubagentDepth: 1,
 			NoProjectPrompts: true,
 			StateDir:         dir,
-			testOnly:         testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true},
+			testOnly:         testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true, metaFS: metaFS},
 		}),
 	)
 
@@ -390,7 +393,7 @@ func TestStopOnMidTurnMutationParksTheQueuedMessage(t *testing.T) {
 // that had been accepted but not yet finalized could still have the queue head
 // claimed out from under it.
 func TestQueueClaimRespectsAPendingInterruptFence(t *testing.T) {
-	sess := newQueuePersistTestSession(t, t.TempDir())
+	sess := newQueuePersistTestSessionWithFS(t, t.TempDir(), afero.NewMemMapFs())
 	defer sess.Close()
 
 	queueOneMutation(t, sess, "queued-under-fence", "do not claim me yet")

--- a/agent/session_tool_artifacts_test.go
+++ b/agent/session_tool_artifacts_test.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/tool"
 	"primeradiant.com/serf/agent/schema"
@@ -115,6 +117,7 @@ func artifactRestoreConfig(t *testing.T, stateDir string) RestoreSessionConfig {
 			skipGitSnapshot:     true,
 			minimalSystemPrompt: true,
 			noSyncJobStore:      true,
+			metaFS:              afero.NewMemMapFs(),
 		},
 		deferRestoreSideEffects: true,
 	}

--- a/agent/session_tools_jobs_lifecycle_fuzz_test.go
+++ b/agent/session_tools_jobs_lifecycle_fuzz_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/internal/clock"
@@ -188,6 +190,7 @@ func jtlpNewRootSession(t *testing.T) *Session {
 		environmentInfo:     jtlpEnvironmentInfo,
 		minimalSystemPrompt: true,
 		noSyncJobStore:      true,
+		metaFS:              afero.NewMemMapFs(),
 	}
 	root := newSession(t, withConfig(cfg))
 	return root

--- a/agent/session_tools_jobs_watch_test.go
+++ b/agent/session_tools_jobs_watch_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/internal/jobstore"
 	tooldefs "primeradiant.com/serf/agent/internal/tool"
 	"primeradiant.com/serf/agent/schema"
@@ -454,6 +456,7 @@ func TestJobWatchCanImmediatelyWatchReturnedBackgroundShellJob(t *testing.T) {
 		MaxSubagentDepth: 1,
 		NoProjectPrompts: true,
 		StateDir:         packageFixtureTempDir(t, "watch-state-*"),
+		testOnly:         testConfig{metaFS: afero.NewMemMapFs()},
 	}))
 	const token = "WATCH_OUTPUT_TOKEN_ONCE"
 

--- a/agent/session_tools_misc_contract_fuzz_test.go
+++ b/agent/session_tools_misc_contract_fuzz_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/internal/clock"
@@ -535,6 +537,7 @@ func stmNewSession(t *testing.T, program []byte) (*Session, *agenttest.DenyEnv, 
 		environmentInfo:     stmEnvironmentInfo,
 		minimalSystemPrompt: true,
 		noSyncJobStore:      true,
+		metaFS:              afero.NewMemMapFs(),
 	}
 	s, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), env, cfg)
 	if err != nil {

--- a/agent/session_tools_output_images_test.go
+++ b/agent/session_tools_output_images_test.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/events"
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/tool"
@@ -37,12 +39,16 @@ func newImageToolSession(t *testing.T, toolName, stateDir string, exec func() (a
 	dir := t.TempDir()
 	client := llm.NewClient()
 	client.Register(&fakeAdapter{name: "openai"})
-	sess, err := NewSession(client, NewOpenAIProfile("test-model"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
+	cfg := SessionConfig{
 		// explorer skips the vision side-channel; these tests are about the
 		// descriptor, not about describing the image.
 		AgentName: "explorer",
 		StateDir:  stateDir,
-	})
+	}
+	if stateDir != "" {
+		cfg.testOnly.metaFS = afero.NewMemMapFs()
+	}
+	sess, err := NewSession(client, NewOpenAIProfile("test-model"), execenv.NewLocalExecutionEnvironment(dir), cfg)
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}

--- a/agent/session_tools_shell_test.go
+++ b/agent/session_tools_shell_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/internal/jobstore"
@@ -537,6 +539,7 @@ func TestSessionCloseMarksBackgroundShellCancelledBeforeEnvCleanup(t *testing.T)
 func TestParentCloseMarksSubagentBackgroundShellCancelledBeforeSharedEnvCleanup(t *testing.T) {
 	t.Parallel()
 	stateDir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	workDir := t.TempDir()
 	env := execenv.NewLocalExecutionEnvironment(workDir)
 	c := llm.NewClient()
@@ -545,6 +548,7 @@ func TestParentCloseMarksSubagentBackgroundShellCancelledBeforeSharedEnvCleanup(
 	parent, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), env, SessionConfig{
 		StateDir:         stateDir,
 		MaxSubagentDepth: 1,
+		testOnly:         testConfig{metaFS: metaFS},
 	})
 	if err != nil {
 		t.Fatalf("NewSession parent: %v", err)
@@ -554,6 +558,7 @@ func TestParentCloseMarksSubagentBackgroundShellCancelledBeforeSharedEnvCleanup(
 	child, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), env, SessionConfig{
 		StateDir:         stateDir,
 		MaxSubagentDepth: 1,
+		testOnly:         testConfig{metaFS: metaFS},
 	})
 	if err != nil {
 		t.Fatalf("NewSession child: %v", err)
@@ -602,6 +607,7 @@ func TestParentCloseMarksSubagentBackgroundShellCancelledBeforeSharedEnvCleanup(
 func TestParentCloseRejectsSubagentShellStartedDuringClose(t *testing.T) {
 	t.Parallel()
 	stateDir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	workDir := t.TempDir()
 	env := execenv.NewLocalExecutionEnvironment(workDir)
 	modelEntered := make(chan struct{})
@@ -640,6 +646,7 @@ func TestParentCloseRejectsSubagentShellStartedDuringClose(t *testing.T) {
 	parent, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), env, SessionConfig{
 		StateDir:         stateDir,
 		MaxSubagentDepth: 1,
+		testOnly:         testConfig{metaFS: metaFS},
 	})
 	if err != nil {
 		t.Fatalf("NewSession parent: %v", err)
@@ -649,6 +656,7 @@ func TestParentCloseRejectsSubagentShellStartedDuringClose(t *testing.T) {
 	child, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), env, SessionConfig{
 		StateDir:         stateDir,
 		MaxSubagentDepth: 1,
+		testOnly:         testConfig{metaFS: metaFS},
 	})
 	if err != nil {
 		t.Fatalf("NewSession child: %v", err)
@@ -1304,6 +1312,9 @@ func newShellToolTestSession(t *testing.T, cfg SessionConfig) *Session {
 	t.Helper()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})
+	if cfg.StateDir != "" && cfg.testOnly.metaFS == nil {
+		cfg.testOnly.metaFS = afero.NewMemMapFs()
+	}
 	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), cfg)
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)

--- a/agent/session_tools_transcript_job_read_test.go
+++ b/agent/session_tools_transcript_job_read_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/internal/jobstore"
 	"primeradiant.com/serf/agent/internal/tool"
 	"primeradiant.com/serf/identifier"
@@ -116,7 +118,8 @@ func TestForeignTranscriptReadDoesNotBroadenJobTools(t *testing.T) {
 	stateHome := t.TempDir()
 	current := localJobProjectBucket(t, stateHome, localJobCurrentProject)
 	foreign := localJobProjectBucket(t, stateHome, localJobSiblingProject)
-	caller := newSession(t, withConfig(SessionConfig{StateDir: current, MaxSubagentDepth: 1}))
+	metaFS := afero.NewMemMapFs()
+	caller := newSession(t, withConfig(SessionConfig{StateDir: current, MaxSubagentDepth: 1, testOnly: testConfig{metaFS: metaFS}}))
 	foreignOwner := identifier.MustNewSessionID()
 	foreignJobID := identifier.MustNewJobID(foreignOwner)
 	seedLocalJobRecord(t, foreign, foreignOwner, foreignJobID, "/untrusted/decoy.log", "FOREIGN_MARKER\n", maxJobOutputRetentionBytes, false, 0, nil)

--- a/agent/session_tools_transcript_persistence_test.go
+++ b/agent/session_tools_transcript_persistence_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/internal/tool"
@@ -18,6 +20,7 @@ import (
 func TestSessionCanceledAPILogReadStaysOutOfSemanticTranscript(t *testing.T) {
 	const bodySentinel = "PRIVATE_CANCELED_API_BODY_SENTINEL"
 	stateDir := newBucket(t)
+	metaFS := afero.NewMemMapFs()
 	client := llm.NewClient()
 	client.Register(&agenttest.ScriptedAdapter{Provider: "openai"})
 	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{
@@ -28,6 +31,7 @@ func TestSessionCanceledAPILogReadStaysOutOfSemanticTranscript(t *testing.T) {
 			skipGitSnapshot:     true,
 			minimalSystemPrompt: true,
 			noSyncJobStore:      true,
+			metaFS:              metaFS,
 		},
 	})
 	if err != nil {

--- a/agent/session_tools_worktree_dispose_only_test.go
+++ b/agent/session_tools_worktree_dispose_only_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/tool"
 	"primeradiant.com/serf/llm"
@@ -148,6 +150,7 @@ func TestWorktreeAvailability_IsolatedCoordinatorDisposeOnlyAfterRestore(t *test
 	t.Parallel()
 	dir := t.TempDir()
 	stateDir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})
 
@@ -155,7 +158,7 @@ func TestWorktreeAvailability_IsolatedCoordinatorDisposeOnlyAfterRestore(t *test
 		StateDir:         stateDir,
 		MaxSubagentDepth: 3,
 		NoProjectPrompts: true,
-		testOnly:         testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true},
+		testOnly:         testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true, metaFS: metaFS},
 	}
 	cfg.spawn.parentSessionID = "parent-session-id"
 	cfg.spawn.depth = 1
@@ -170,7 +173,7 @@ func TestWorktreeAvailability_IsolatedCoordinatorDisposeOnlyAfterRestore(t *test
 
 	restoreCfg := RestoreSessionConfig{
 		StateDir: stateDir,
-		testOnly: testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true},
+		testOnly: testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true, metaFS: metaFS},
 	}
 	restoreCfg.spawn.parentSessionID = "parent-session-id"
 	restoreCfg.spawn.depth = 1

--- a/agent/session_tools_worktree_scripted_test.go
+++ b/agent/session_tools_worktree_scripted_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/internal/clock"
@@ -235,6 +237,7 @@ func newScriptedWorktreeSession(t *testing.T) *scriptedWorktreeSession {
 			minimalSystemPrompt:         true,
 			minimalWorktreeToolRegistry: true,
 			noSyncJobStore:              true,
+			metaFS:                      afero.NewMemMapFs(),
 			worktreeGitRunner: func(context.Context, execenv.ExecutionEnvironment) worktree.GitRunner {
 				return git.run
 			},

--- a/agent/session_tools_worktree_test.go
+++ b/agent/session_tools_worktree_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/tool"
 	"primeradiant.com/serf/agent/internal/worktree"
@@ -42,7 +44,8 @@ func TestWorktreeRootResolutionErrorDoesNotSelectFallbackIdentity(t *testing.T) 
 func TestRollbackFreshDelegateWorktreeUsesCarriedProjectMetadataDir(t *testing.T) {
 	root := t.TempDir()
 	stateDir := t.TempDir()
-	s := newSession(t, withDir(root), withConfig(SessionConfig{StateDir: stateDir}))
+	metaFS := afero.NewMemMapFs()
+	s := newSession(t, withDir(root), withConfig(SessionConfig{StateDir: stateDir, testOnly: testConfig{metaFS: metaFS}}))
 	project := identifier.Project{ID: "carried-project", CanonicalPath: root}
 	lanePath := filepath.Join(t.TempDir(), "alternate-project", "delegate")
 

--- a/agent/session_transcript_ready_test.go
+++ b/agent/session_transcript_ready_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/schema"
 	"primeradiant.com/serf/llm"
 )
@@ -40,7 +42,8 @@ func transcriptTurnKinds(t *testing.T, path string) []schema.TurnKind {
 func TestTurnRecordedBeforeTranscriptWriterExistsReachesTheFile(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	sess := newSession(t, withDir(dir), withConfig(SessionConfig{StateDir: dir, MaxSubagentDepth: 1}))
+	metaFS := afero.NewMemMapFs()
+	sess := newSession(t, withDir(dir), withConfig(SessionConfig{StateDir: dir, MaxSubagentDepth: 1, testOnly: testConfig{metaFS: metaFS}}))
 	go func() {
 		for range sess.Events() {
 		}
@@ -79,7 +82,8 @@ func TestTurnRecordedBeforeTranscriptWriterExistsReachesTheFile(t *testing.T) {
 func TestDurableTurnRecordedBeforeTranscriptWriterExistsReachesTheFile(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	sess := newSession(t, withDir(dir), withConfig(SessionConfig{StateDir: dir, MaxSubagentDepth: 1}))
+	metaFS := afero.NewMemMapFs()
+	sess := newSession(t, withDir(dir), withConfig(SessionConfig{StateDir: dir, MaxSubagentDepth: 1, testOnly: testConfig{metaFS: metaFS}}))
 	go func() {
 		for range sess.Events() {
 		}

--- a/agent/session_transcript_warning_ordering_test.go
+++ b/agent/session_transcript_warning_ordering_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/events"
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/llm"
@@ -33,6 +35,7 @@ func TestTranscriptCreateFailedWarningRidesAfterSessionStart(t *testing.T) {
 
 	cfg := SessionConfig{}
 	cfg.StateDir = t.TempDir()
+	cfg.testOnly.metaFS = afero.NewMemMapFs()
 	cfg.testOnly.sessionInitFault = func(point string) error {
 		if point == "new_transcript" {
 			return errTranscriptCreateFaultForTest

--- a/agent/session_turn_boundary_test.go
+++ b/agent/session_turn_boundary_test.go
@@ -7,10 +7,20 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/events"
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/appwire"
 )
+
+// withMetaFS routes the session's session-meta JSON IO through fs instead of
+// the real filesystem (kata 49k3). It mutates the config an earlier withConfig
+// installed, so it must be passed after any withConfig option — which
+// newTestSessionForEnvctx's base-then-opts ordering guarantees.
+func withMetaFS(fs afero.Fs) sessionOpt {
+	return func(o *sessionOpts) { o.cfg.testOnly.metaFS = fs }
+}
 
 // boundaryRecorder collects the events a served session emits. Registering a
 // real drain through ConsumeEventsLossless is also what marks the session
@@ -75,7 +85,8 @@ func indexOf(kinds []events.EventKind, k events.EventKind) int {
 // turn opens under an id the daemon's mutation preconditions reject, and every
 // Steer, Send and Stop aimed at it fails silently (kata 7vmd).
 func TestNotificationTurnAnnouncesOneNamedBoundary(t *testing.T) {
-	s := newTestSessionForEnvctx(t)
+	metaFS := afero.NewMemMapFs()
+	s := newTestSessionForEnvctx(t, withMetaFS(metaFS))
 	rec := serveAndRecord(t, s)
 	s.SteerKind("look at this", events.SteeringKindNotification)
 
@@ -104,7 +115,8 @@ func TestNotificationTurnAnnouncesOneNamedBoundary(t *testing.T) {
 // TestNotificationTurnAnnouncesOneNamedBoundary above, which drives the shape
 // that block skips entirely.
 func TestNotificationBoundaryPrecedesTheTurnsContent(t *testing.T) {
-	s := newTestSessionForEnvctx(t)
+	metaFS := afero.NewMemMapFs()
+	s := newTestSessionForEnvctx(t, withMetaFS(metaFS))
 	rec := serveAndRecord(t, s)
 	s.SteerKind("look at this", events.SteeringKindNotification)
 
@@ -136,8 +148,9 @@ func TestNotificationBoundaryPrecedesTheTurnsContent(t *testing.T) {
 // record) because acceptNotificationInput drops a hand-made in-memory
 // notification as undeliverable and refuses the wake.
 func TestNotificationBoundaryPrecedesItsJobReminder(t *testing.T) {
+	metaFS := afero.NewMemMapFs()
 	dir := t.TempDir()
-	s := newTestSessionForEnvctx(t, withDir(dir))
+	s := newTestSessionForEnvctx(t, withDir(dir), withMetaFS(metaFS))
 	rec := serveAndRecord(t, s)
 
 	jm, err := newJobManager(dir, s.ID(), s.enqueueJobNotification)
@@ -171,7 +184,8 @@ func TestNotificationBoundaryPrecedesItsJobReminder(t *testing.T) {
 // set, and mintRunningTurnID refuses to name the next agent turn, so an id
 // held past its turn wedges the session for the life of the process.
 func TestNotificationTurnReleasesItsTurnID(t *testing.T) {
-	s := newTestSessionForEnvctx(t)
+	metaFS := afero.NewMemMapFs()
+	s := newTestSessionForEnvctx(t, withMetaFS(metaFS))
 	serveAndRecord(t, s)
 	s.SteerKind("look at this", events.SteeringKindNotification)
 
@@ -188,7 +202,8 @@ func TestNotificationTurnReleasesItsTurnID(t *testing.T) {
 // with nothing to deliver — the commonest outcome — neither announces a turn
 // nor reserves an id for one that never runs.
 func TestRefusedNotificationWakeAnnouncesNoBoundary(t *testing.T) {
-	s := newTestSessionForEnvctx(t)
+	metaFS := afero.NewMemMapFs()
+	s := newTestSessionForEnvctx(t, withMetaFS(metaFS))
 	rec := serveAndRecord(t, s)
 
 	if _, err := s.ProcessInputKind(context.Background(), "", nil, EntryNotification); err != nil {
@@ -214,8 +229,9 @@ func TestRefusedNotificationWakeAnnouncesNoBoundary(t *testing.T) {
 // leaks, and the projection is left holding an open active turn whose close
 // finishNotificationNoop's sessionEndEmitted then suppresses.
 func TestRefusedDurableAppendAnnouncesNoBoundary(t *testing.T) {
+	metaFS := afero.NewMemMapFs()
 	dir := t.TempDir()
-	s := newTestSessionForEnvctx(t, withDir(dir))
+	s := newTestSessionForEnvctx(t, withDir(dir), withMetaFS(metaFS))
 	rec := serveAndRecord(t, s)
 
 	jm, err := newJobManager(dir, s.ID(), s.enqueueJobNotification)
@@ -258,8 +274,9 @@ func TestRefusedDurableAppendAnnouncesNoBoundary(t *testing.T) {
 // inline once that turn ends, by which point nothing is claimed and the wake
 // names itself. Nothing is lost, and no turn ever runs unnameable.
 func TestWakeStandsDownWhileAUserTurnIsClaimed(t *testing.T) {
+	metaFS := afero.NewMemMapFs()
 	dir := t.TempDir()
-	s := newTestSessionForEnvctx(t, withDir(dir))
+	s := newTestSessionForEnvctx(t, withDir(dir), withMetaFS(metaFS))
 	rec := serveAndRecord(t, s)
 
 	jm, err := newJobManager(dir, s.ID(), s.enqueueJobNotification)
@@ -313,7 +330,8 @@ func TestWakeStandsDownWhileAUserTurnIsClaimed(t *testing.T) {
 // woken for, with nothing left to raise it again until some unrelated wake
 // happens by. The decision has to come first, while nothing has been consumed.
 func TestStandDownConsumesNoWakeState(t *testing.T) {
-	s := newTestSessionForEnvctx(t)
+	metaFS := afero.NewMemMapFs()
+	s := newTestSessionForEnvctx(t, withMetaFS(metaFS))
 	serveSession(t, s)
 
 	s.attentionMu.Lock()
@@ -356,7 +374,8 @@ func TestStandDownConsumesNoWakeState(t *testing.T) {
 // loop's SetState(sess.WireState()) then publishes that. Every other refusal
 // on this path settles through finishNotificationNoop; this one must too.
 func TestStandDownSettlesTheProcessingTransition(t *testing.T) {
-	s := newTestSessionForEnvctx(t)
+	metaFS := afero.NewMemMapFs()
+	s := newTestSessionForEnvctx(t, withMetaFS(metaFS))
 	serveSession(t, s)
 
 	if err := s.ensureClientMutationStore(); err != nil {
@@ -396,7 +415,8 @@ func TestStandDownSettlesTheProcessingTransition(t *testing.T) {
 // for as long as the name stays held -- which a mutation store failing writes
 // makes forever. The guarantee is unchanged; only the timing is.
 func TestStandDownReArmsTheWake(t *testing.T) {
-	s := newTestSessionForEnvctx(t)
+	metaFS := afero.NewMemMapFs()
+	s := newTestSessionForEnvctx(t, withMetaFS(metaFS))
 	clk := agenttest.NewFakeClock()
 	s.clock = clk
 	serveSession(t, s)
@@ -470,7 +490,8 @@ func TestStandDownReArmsTheWake(t *testing.T) {
 // forgetRunningTurnNoOneOwns applies at load; here it decides whether asking
 // again can ever help.
 func TestStandDownDoesNotSpinOnAStaleName(t *testing.T) {
-	s := newTestSessionForEnvctx(t)
+	metaFS := afero.NewMemMapFs()
+	s := newTestSessionForEnvctx(t, withMetaFS(metaFS))
 	serveSession(t, s)
 
 	var mu sync.Mutex
@@ -513,8 +534,9 @@ func TestStandDownDoesNotSpinOnAStaleName(t *testing.T) {
 // Once the user's turn ends and gives the name back, the same wake names itself
 // and runs -- which is what the serve loop's tail gate provokes for real.
 func TestWakeResumesOnceTheUserTurnReleasesTheName(t *testing.T) {
+	metaFS := afero.NewMemMapFs()
 	dir := t.TempDir()
-	s := newTestSessionForEnvctx(t, withDir(dir))
+	s := newTestSessionForEnvctx(t, withDir(dir), withMetaFS(metaFS))
 	rec := serveAndRecord(t, s)
 
 	jm, err := newJobManager(dir, s.ID(), s.enqueueJobNotification)
@@ -574,7 +596,8 @@ func TestWakeResumesOnceTheUserTurnReleasesTheName(t *testing.T) {
 // reversing this deliberately — delegates would take durable names so they can
 // be stopped. When that lands, this test inverts rather than being deleted.
 func TestUnservedSessionNamesNoTurn(t *testing.T) {
-	s := newTestSessionForEnvctx(t) // no drain registered
+	metaFS := afero.NewMemMapFs()
+	s := newTestSessionForEnvctx(t, withMetaFS(metaFS)) // no drain registered
 
 	if s.servedByDaemon() {
 		t.Fatal("a session with no authoritative consumer reports itself served")
@@ -597,7 +620,8 @@ func TestUnservedSessionNamesNoTurn(t *testing.T) {
 // in-process subagent's projection and close and reopen turns on a delegate
 // thread no client can address.
 func TestUnservedSessionAnnouncesNoBoundary(t *testing.T) {
-	s := newTestSessionForEnvctx(t) // no drain registered
+	metaFS := afero.NewMemMapFs()
+	s := newTestSessionForEnvctx(t, withMetaFS(metaFS)) // no drain registered
 
 	var mu sync.Mutex
 	var forwarded []events.EventKind

--- a/agent/session_turn_completion_program_fuzz_test.go
+++ b/agent/session_turn_completion_program_fuzz_test.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/events"
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/internal/tool"
@@ -236,6 +238,7 @@ func tfpNewSession(t *testing.T, program tfpProgram, adapter *tfpAdapter) *Sessi
 			skipGitSnapshot:     true,
 			minimalSystemPrompt: true,
 			noSyncJobStore:      true,
+			metaFS:              afero.NewMemMapFs(),
 		},
 	}
 	if program.usesContinuation() {

--- a/agent/session_vision_effort_test.go
+++ b/agent/session_vision_effort_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/tool"
 	"primeradiant.com/serf/llm"
@@ -15,6 +17,7 @@ import (
 func TestDescribeImage_ClampsEffortToProfileLevels(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	var gotEffort string
 	adapter := &fakeAdapter{
 		name: "openai",
@@ -35,6 +38,7 @@ func TestDescribeImage_ClampsEffortToProfileLevels(t *testing.T) {
 	sess, err := NewSession(c, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		StateDir:        dir,
 		ReasoningEffort: "max",
+		testOnly:        testConfig{metaFS: metaFS},
 	})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)

--- a/agent/session_workmillis_test.go
+++ b/agent/session_workmillis_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/agenttest"
 	"primeradiant.com/serf/agent/schema"
@@ -191,9 +193,10 @@ func TestWorkMillis_CloseMidTurnCounts(t *testing.T) {
 func TestWorkMillis_InterruptThenCloseFlushesToDisk(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	clk := agenttest.NewFakeClock()
 	blocked := make(chan struct{})
-	sess := newSession(t, withConfig(SessionConfig{clock: clk, StateDir: dir}),
+	sess := newSession(t, withConfig(SessionConfig{clock: clk, StateDir: dir, testOnly: testConfig{metaFS: metaFS}}),
 		withAdapter(&blockingAdapter{name: "openai", blocked: blocked}))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -226,7 +229,7 @@ func TestWorkMillis_InterruptThenCloseFlushesToDisk(t *testing.T) {
 
 	sess.Close() // e.g. an explicit /shutdown with no further turn.
 
-	reloaded, err := schema.LoadSessionMeta(dir, sess.ID())
+	reloaded, err := schema.LoadSessionMetaWithFS(metaFS, dir, sess.ID())
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
@@ -246,8 +249,9 @@ func TestWorkMillis_InterruptThenCloseFlushesToDisk(t *testing.T) {
 func TestClose_MidTurnFlushesWorkAndUsageToDisk(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	clk := agenttest.NewFakeClock()
-	sess := newSession(t, withConfig(SessionConfig{clock: clk, StateDir: dir}))
+	sess := newSession(t, withConfig(SessionConfig{clock: clk, StateDir: dir, testOnly: testConfig{metaFS: metaFS}}))
 
 	sess.mu.Lock()
 	sess.state = SessionProcessing
@@ -262,7 +266,7 @@ func TestClose_MidTurnFlushesWorkAndUsageToDisk(t *testing.T) {
 
 	sess.Close()
 
-	reloaded, err := schema.LoadSessionMeta(dir, sess.ID())
+	reloaded, err := schema.LoadSessionMetaWithFS(metaFS, dir, sess.ID())
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}
@@ -284,6 +288,7 @@ func TestClose_MidTurnFlushesWorkAndUsageToDisk(t *testing.T) {
 func TestRestoreThenTurnAutosaveKeepsPriorTotals(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	metaFS := afero.NewMemMapFs()
 	clk := agenttest.NewFakeClock()
 	const delta = 2000 * time.Millisecond
 	turnUsage := llm.Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15}
@@ -316,9 +321,9 @@ func TestRestoreThenTurnAutosaveKeepsPriorTotals(t *testing.T) {
 		},
 	}
 
-	sess, err := RestoreSessionFromMeta(c, NewOpenAIProfile("gpt-5.2"), env, meta, dir)
+	sess, err := RestoreSessionFromMetaWithConfig(c, NewOpenAIProfile("gpt-5.2"), env, meta, RestoreSessionConfig{StateDir: dir, testOnly: testConfig{metaFS: metaFS}})
 	if err != nil {
-		t.Fatalf("RestoreSessionFromMeta: %v", err)
+		t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
 	}
 	defer sess.Close()
 	// Restore has no public hook to inject a fake clock (RestoreSessionConfig
@@ -339,7 +344,7 @@ func TestRestoreThenTurnAutosaveKeepsPriorTotals(t *testing.T) {
 
 	sess.maybeAutoSave()
 
-	reloaded, err := schema.LoadSessionMeta(dir, sess.ID())
+	reloaded, err := schema.LoadSessionMetaWithFS(metaFS, dir, sess.ID())
 	if err != nil {
 		t.Fatalf("LoadSessionMeta: %v", err)
 	}

--- a/agent/session_worktree_resume_test.go
+++ b/agent/session_worktree_resume_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/serf/agent/events"
 	"primeradiant.com/serf/agent/execenv"
 	"primeradiant.com/serf/agent/internal/worktree"
@@ -112,7 +114,7 @@ func (r *wtRepo) restoreWorktreeSession(t *testing.T, meta schema.SessionMeta, l
 	sess, err := RestoreSessionFromMetaWithConfig(
 		w3init_restoreClient(), NewOpenAIProfile("gpt-5.2"),
 		execenv.NewLocalExecutionEnvironment(launchDir), meta,
-		RestoreSessionConfig{StateDir: r.stateDir, testOnly: testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true}},
+		RestoreSessionConfig{StateDir: r.stateDir, testOnly: testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true, metaFS: afero.NewMemMapFs()}},
 	)
 	if err != nil {
 		t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
@@ -819,7 +821,8 @@ func TestInitInside_ForeignBareLockUnknownOwnerWarns(t *testing.T) {
 	wtGit(t, r.mainRoot, "worktree", "unlock", path)
 	wtGit(t, r.mainRoot, "worktree", "lock", path) // bare lock: no --reason
 
-	sess := newSession(t, withDir(path), withConfig(SessionConfig{MaxSubagentDepth: 1, StateDir: r.stateDir}))
+	metaFS := afero.NewMemMapFs()
+	sess := newSession(t, withDir(path), withConfig(SessionConfig{MaxSubagentDepth: 1, StateDir: r.stateDir, testOnly: testConfig{metaFS: metaFS}}))
 
 	msgs := warningMessages(sess)
 	if !anyContainsAll(msgs, path, "an unknown owner", "co-occupying") {
@@ -859,7 +862,8 @@ func TestInitInside_SymlinkSpelledCwdCanonicalizesStoredPathAndLockKey(t *testin
 		t.Fatalf("test setup: alias resolves to %q, want %q", resolved, path)
 	}
 
-	sess := newSession(t, withDir(alias), withConfig(SessionConfig{MaxSubagentDepth: 1, StateDir: r.stateDir}))
+	metaFS := afero.NewMemMapFs()
+	sess := newSession(t, withDir(alias), withConfig(SessionConfig{MaxSubagentDepth: 1, StateDir: r.stateDir, testOnly: testConfig{metaFS: metaFS}}))
 
 	if got := sess.Meta().WorktreePath; got != path {
 		t.Errorf("Meta().WorktreePath = %q, want canonical %q (symlink-spelled launch cwd escaped canonicalization)", got, path)


### PR DESCRIPTION
## Summary

Converts 50 `session*_test.go` files (~130 tests) to the `SessionConfig.testOnly.metaFS` seam introduced in gv1b (5cb55a381), eliminating real fsync-bearing session-meta disk IO from those tests. Closes kata 49k3.

- Direct `schema.SaveSessionMeta`/`LoadSessionMeta` calls in converted tests use the `*WithFS` variants on a shared `afero.NewMemMapFs()` per test.
- `RestoreSessionFromMeta` call sites route through `RestoreSessionFromMetaWithConfig` carrying the seam (`cfg.testOnly` propagates to the restored session).
- Work was fanned out to 6 isolated worker lanes and merged (`cf0cec860..9630b6073`), plus one post-merge integration fix (`e8cdaa45a`: nil-fs branch in `restoreQueuePersistTestSession` for 13 real-FS callers outside the converting batch).

## Left on the real filesystem (deliberately)

- Crash-flush tests asserting the real meta path (`TestSession_CtxCancellationFlushesMeta`, `TestSession_PanicFlushesMeta`)
- On-disk byte-compare / tree-snapshot tests (`TestSetModel_RejectionLeavesProfileMetaAndHistoryUnchanged`, `session_resume_integrity_test.go`)
- Ownership-ordering `os.Stat` test (`TestNewSessionAcquiresOwnershipBeforePersistingIdentity`)
- Fork tests (`ForkSession` hardcodes `afero.OsFs`, coupling meta+transcript IO)
- Delegate-attention cold-restore classifier tests; a `forceRealIO` test
- `session_fallback_test.go` (package `agent_test` cannot reach the unexported seam)
- IO-cost subjects: `session_perf_test.go`, `sessioninit_bench_test.go`, phase12 live test

## Verification

- `go vet ./agent` clean with and without `-tags serffuzz`
- `go test ./agent -count=1` passes
- serffuzz-tagged suite failure set identical to base `b5cfddf5c` (2 pre-existing transcript-fuzz failures tracked as kata 72k9) — zero new failures

## Timing

`go test ./agent -count=1`: **61.5s → 51.8s (−9.7s, −15.8%)** measured in a quiet window. Paired interleaved re-runs under load avg ~26 were too noisy to refine further (base itself swung 55–92s); directionally consistent with the bootstrap diagnosis of ~26.5s attributed to this mechanism.