### PR TITLE
fix(openai): dedup trailing /v1 in modelsURL

### DIFF
--- a/llm/providers/openai/adapter.go
+++ b/llm/providers/openai/adapter.go
@@ -982,33 +982,15 @@ func chatFallbackRequest(req llm.Request) llm.Request {
 	return fallbackReq
 }
 
-// chatCompletionsURL returns the /v1/chat/completions URL for this adapter,
-// derived from the same BaseURL used for the Responses API.
-func (a *Adapter) chatCompletionsURL() string {
-	base := strings.TrimRight(a.BaseURL, "/")
-	// If this adapter is pointed at an API-key-based OpenAI endpoint, the base
-	// is https://api.openai.com and completions lives at /v1/chat/completions.
-	// For custom base URLs we keep the same path convention.
-	if strings.HasSuffix(base, "/v1") {
-		return base + "/chat/completions"
-	}
-	return base + "/v1/chat/completions"
-}
-
-// responsesURL returns the Responses API URL for this adapter, derived from
-// BaseURL and ResponsesPath. Like chatCompletionsURL, it normalizes a
-// trailing /v1 on BaseURL so a base of either "https://host" or
-// "https://host/v1" resolves to the same "https://host/v1/..." URL instead
-// of doubling the /v1 segment. Custom ResponsesPath values that don't start
-// with /v1 (e.g. the ChatGPT/Codex backend path) are left untouched — only
-// the conventional /v1 prefix is deduplicated, never silently stripped from
-// an explicit custom path.
-func (a *Adapter) responsesURL() string {
-	base := strings.TrimRight(a.BaseURL, "/")
-	path := a.ResponsesPath
-	if path == "" {
-		path = defaultResponsesPath
-	}
+// joinBaseURLDedupV1 joins base and path, normalizing a trailing /v1 on base
+// so a BaseURL of either "https://host" or "https://host/v1" resolves to the
+// same "https://host/v1/..." URL instead of doubling the /v1 segment. This
+// lets OpenAI-compatible gateways be configured with either form. path values
+// that don't start with /v1 (e.g. the ChatGPT/Codex backend path) are left
+// untouched — only the conventional /v1 prefix is deduplicated, never
+// silently stripped from an explicit custom path.
+func joinBaseURLDedupV1(base, path string) string {
+	base = strings.TrimRight(base, "/")
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
@@ -1016,6 +998,22 @@ func (a *Adapter) responsesURL() string {
 		base = strings.TrimSuffix(base, "/v1")
 	}
 	return base + path
+}
+
+// chatCompletionsURL returns the /v1/chat/completions URL for this adapter,
+// derived from the same BaseURL used for the Responses API.
+func (a *Adapter) chatCompletionsURL() string {
+	return joinBaseURLDedupV1(a.BaseURL, "/v1/chat/completions")
+}
+
+// responsesURL returns the Responses API URL for this adapter, derived from
+// BaseURL and ResponsesPath.
+func (a *Adapter) responsesURL() string {
+	path := a.ResponsesPath
+	if path == "" {
+		path = defaultResponsesPath
+	}
+	return joinBaseURLDedupV1(a.BaseURL, path)
 }
 
 func (a *Adapter) requiresStreamingComplete() bool {
@@ -1048,7 +1046,7 @@ func (a *Adapter) modelsURL() string {
 		}
 		return u + sep + url.Values{"client_version": []string{codexClientVersion}}.Encode()
 	}
-	return strings.TrimRight(a.BaseURL, "/") + "/v1/models"
+	return joinBaseURLDedupV1(a.BaseURL, "/v1/models")
 }
 
 func (a *Adapter) usesCodexBackend() bool {

--- a/llm/providers/openai/url_test.go
+++ b/llm/providers/openai/url_test.go
@@ -82,3 +82,44 @@ func TestChatCompletionsURL_NormalizesTrailingV1(t *testing.T) {
 		})
 	}
 }
+
+// TestModelsURL_NormalizesTrailingV1 covers issue #13's validation finding: a
+// BaseURL that already ends in /v1 (the form gateway docs hand out, e.g.
+// OPENAI_BASE_URL=https://gateway/v1) must not double the /v1 segment on the
+// models list URL, matching the normalization responsesURL and
+// chatCompletionsURL already perform.
+func TestModelsURL_NormalizesTrailingV1(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		baseURL string
+		want    string
+	}{
+		{
+			name:    "base without trailing /v1 gets /v1/models appended",
+			baseURL: "https://host.example",
+			want:    "https://host.example/v1/models",
+		},
+		{
+			name:    "base with trailing /v1 is not doubled",
+			baseURL: "https://host.example/v1",
+			want:    "https://host.example/v1/models",
+		},
+		{
+			name:    "base with trailing /v1/ (slash) is not doubled",
+			baseURL: "https://host.example/v1/",
+			want:    "https://host.example/v1/models",
+		},
+		{
+			name:    "default OpenAI base URL is unaffected",
+			baseURL: defaultAPIBaseURL,
+			want:    defaultAPIBaseURL + "/v1/models",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &Adapter{BaseURL: tc.baseURL}
+			if got := a.modelsURL(); got != tc.want {
+				t.Fatalf("modelsURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `modelsURL()` in `llm/providers/openai/adapter.go` built its URL as `BaseURL + "/v1/models"` with no dedup for a `BaseURL` that already ends in `/v1`, unlike its siblings `chatCompletionsURL()` and `responsesURL()`.
- With `OPENAI_BASE_URL=https://gateway/v1` (the form OpenAI-compatible gateway docs hand out), the models probe hit `/v1/v1/models`, 404'd, and the model listing came back empty. Since `ListModels` is also used as the credential-validity probe (`cmd/serf-hub/app_credentials.go` ~line 108), a valid gateway credential read as broken.
- Found during issue #13's validation, demonstrated with a stub.
- Fix: extracted the trailing-`/v1` dedup logic already present in `responsesURL()` into a shared `joinBaseURLDedupV1` helper and used it in all three URL builders (`chatCompletionsURL`, `responsesURL`, `modelsURL`). Existing behavior of the first two is unchanged — their pinning tests in `url_test.go` still pass unmodified.

## Test plan
- [x] Added table cases for `modelsURL()` to `llm/providers/openai/url_test.go` (no suffix, `/v1`, `/v1/`, default base URL) — watched the `/v1` and `/v1/` cases fail red before the fix (`modelsURL() = "https://host.example/v1/v1/models", want "https://host.example/v1/models"`), then confirmed green after.
- [x] `go test ./llm/providers/openai/... -count=1` — pass
- [x] `go vet ./llm/providers/openai/...` — clean
- [x] `golangci-lint run ./...` (from `llm` module root) — 0 issues
- [x] `go build ./...` (from `llm` module root) — clean

Claude-Session: https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU