### PR TITLE
fix(tui): tie every job-notification block in a joined steering event

### DIFF
--- a/cmd/serf-tui/hub_notifications.go
+++ b/cmd/serf-tui/hub_notifications.go
@@ -233,12 +233,24 @@ func (m *hubModel) applyHubNotification(notification appwire.Notification) tea.C
 			}
 			if text != "" {
 				m.session.messages = append(m.session.messages, transcript.ChatMessage{Kind: transcript.MsgSteering, Text: text})
-				// Tie a job notification to its rail row: pull its result headline
-				// onto the matching run (keeps both — the notification stays in the
-				// flow, the rail shows the result).
-				if jobID, headline, isError, ok := transcript.ParseJobNotificationHeadline(text); ok && jobID != "" {
+				// Tie every job notification in this steering event to its rail
+				// row: pull each one's result headline onto the matching run
+				// (keeps both — the notification stays in the flow, the rail
+				// shows the result). One steering event can name several jobs —
+				// the daemon joins one poll tick's blocks with "\n" — so every
+				// tie must be applied, not just the first (issue #49).
+				if ties := transcript.ParseJobNotificationHeadlines(text); len(ties) > 0 {
 					reducer := m.sessionTranscriptReducer()
-					if reducer.ApplyTieHeadline(jobID, headline, isError) {
+					applied := false
+					for _, tie := range ties {
+						if tie.JobID == "" {
+							continue
+						}
+						if reducer.ApplyTieHeadline(tie.JobID, tie.Headline, tie.IsError) {
+							applied = true
+						}
+					}
+					if applied {
 						m.applySessionTranscriptReducer(reducer)
 					}
 				}

--- a/cmd/serf-tui/hub_notifications_test.go
+++ b/cmd/serf-tui/hub_notifications_test.go
@@ -140,6 +140,44 @@ func TestTUIStableDelegateShellRemainsJobAddressed(t *testing.T) {
 	}
 }
 
+// TestTUISteeringInjectedTiesEveryJobNotificationBlock is the end-to-end
+// repro for issue #49: the daemon joins every job's <job-notification> block
+// from one poll tick into a single steering event with "\n"
+// (agent/session_lifecycle.go), so a steering payload naming two jobs must
+// tie both rail rows to their own rich headline, not just the first (whose
+// body would otherwise swallow the rest under a greedy match).
+func TestTUISteeringInjectedTiesEveryJobNotificationBlock(t *testing.T) {
+	m := newTUIStableDelegateModel()
+	sendTUINotification(t, &m, appwire.NotifySerfJobStarted, appwire.SerfJobParams{
+		Ref: "local:root",
+		Job: appwire.SerfJobInfo{JobID: "job_A", JobType: "shell", Status: "running", Background: true},
+	})
+	sendTUINotification(t, &m, appwire.NotifySerfJobStarted, appwire.SerfJobParams{
+		Ref: "local:root",
+		Job: appwire.SerfJobInfo{JobID: "job_B", JobType: "shell", Status: "running", Background: true},
+	})
+
+	blockA := `<job-notification job_id="job_A" job_type="delegate" status="completed" exit_code="0">` +
+		`excerpt: {"data":{"test_summary":"all green","commit_hashes":["abcdef1234567890"],"concerns":["c1"]}}` +
+		`</job-notification>`
+	blockB := `<job-notification job_id="job_B" job_type="delegate" status="completed" exit_code="0">` +
+		`excerpt: {"data":{"test_summary":"3 passed","commit_hashes":["1234567890abcdef"]}}` +
+		`</job-notification>`
+	sendTUINotification(t, &m, appwire.NotifySerfSteeringInjected, appwire.SerfSteeringInjectedParams{
+		Ref:  "local:root",
+		Text: blockA + "\n" + blockB,
+	})
+
+	runA := requireTUIJobRun(t, &m, "job_A")
+	if want := "all green · abcdef12 · 1 concern"; runA.Headline != want {
+		t.Fatalf("job_A headline = %q, want %q (must not degrade to the bare status)", runA.Headline, want)
+	}
+	runB := requireTUIJobRun(t, &m, "job_B")
+	if want := "3 passed · 12345678"; runB.Headline != want {
+		t.Fatalf("job_B headline = %q, want %q (must still get a rail tie)", runB.Headline, want)
+	}
+}
+
 func TestTUIStableDelegateWatchAndObserverNoticesRemainVisible(t *testing.T) {
 	m := newTUIStableDelegateModel()
 	sendTUIStableDelegateNotification(t, &m, appwire.SerfDelegateInfo{

--- a/cmd/serf-tui/internal/transcript/job_notification.go
+++ b/cmd/serf-tui/internal/transcript/job_notification.go
@@ -8,8 +8,24 @@ import (
 )
 
 var (
-	jobNotificationRe     = regexp.MustCompile(`(?s)^<job-notification\s+([^>]*)>(.*)</job-notification>\s*$`)
-	jobNotificationAttrRe = regexp.MustCompile(`(\w+)="([^"]*)"`)
+	// jobNotificationBlockRe extracts each individual <job-notification …>…
+	// </job-notification> block. The match MUST be non-greedy and unanchored:
+	// the daemon joins every job's block from one poll tick into a single
+	// steering event with "\n" (agent/session_lifecycle.go), so a steering
+	// payload routinely carries several blocks. A greedy or "^...$"-anchored
+	// match would span from the first opening tag to the LAST closing tag,
+	// swallowing every block in between into one body - degrading the first
+	// job's rich headline to its bare status (the aggregated body no longer
+	// parses as that job's own excerpt JSON) and leaving every later job with
+	// no tie at all (issue #49). Non-greedy per-block matching is sound here
+	// because the producer HTML-entity-escapes body text
+	// (agent/job_notify.go's escapeNotificationText, kata 77sf), so a body
+	// never contains a literal '<' that could be mistaken for another
+	// block's opening tag. Mirrors the web side's splitNotificationBlocks
+	// (steeringClassify.ts), which carries the same "MUST be non-greedy"
+	// comment for the identical reason.
+	jobNotificationBlockRe = regexp.MustCompile(`(?s)<job-notification\s+([^>]*?)>(.*?)</job-notification>`)
+	jobNotificationAttrRe  = regexp.MustCompile(`(\w+)="([^"]*)"`)
 )
 
 // decodeNotificationEntities is the paired decoder for
@@ -30,24 +46,60 @@ func decodeNotificationEntities(s string) string {
 	return s
 }
 
-// ParseJobNotificationHeadline extracts the job id, a one-line result headline
-// (test summary / status · short commit · concern count), and whether it
-// reported a failure, from a <job-notification> steering payload. ok=false when
-// the text is not a job notification. Used to tie a notification to its rail row.
+// JobNotificationTie is one <job-notification> block's parsed result: the job
+// id it names, a one-line result headline (test summary / status · short
+// commit · concern count), and whether it reported a failure. Used to tie a
+// notification to its rail row.
+type JobNotificationTie struct {
+	JobID    string
+	Headline string
+	IsError  bool
+}
+
+// ParseJobNotificationHeadlines extracts every <job-notification> block's tie
+// from a steering payload. A single steering event can name several jobs (the
+// daemon joins one poll tick's blocks with "\n"), so callers that want to tie
+// every job named in the payload - not just the first - must use this rather
+// than ParseJobNotificationHeadline. Returns nil when the text carries no
+// <job-notification> block.
+func ParseJobNotificationHeadlines(text string) []JobNotificationTie {
+	matches := jobNotificationBlockRe.FindAllStringSubmatch(strings.TrimSpace(text), -1)
+	if matches == nil {
+		return nil
+	}
+	ties := make([]JobNotificationTie, 0, len(matches))
+	for _, m := range matches {
+		ties = append(ties, parseJobNotificationBlock(m[1], m[2]))
+	}
+	return ties
+}
+
+// ParseJobNotificationHeadline extracts the first <job-notification> block's
+// tie from text. ok=false when the text carries no job notification. Kept
+// for the common single-job case; a payload naming several jobs (see
+// ParseJobNotificationHeadlines) still returns only its first block's tie.
 func ParseJobNotificationHeadline(text string) (jobID, headline string, isError, ok bool) {
-	m := jobNotificationRe.FindStringSubmatch(strings.TrimSpace(text))
-	if m == nil {
+	ties := ParseJobNotificationHeadlines(text)
+	if len(ties) == 0 {
 		return "", "", false, false
 	}
+	tie := ties[0]
+	return tie.JobID, tie.Headline, tie.IsError, true
+}
+
+// parseJobNotificationBlock parses one already-split <job-notification>
+// block's raw attribute string and body into its tie.
+func parseJobNotificationBlock(attrsRaw, body string) JobNotificationTie {
 	attrs := map[string]string{}
-	for _, a := range jobNotificationAttrRe.FindAllStringSubmatch(m[1], -1) {
+	for _, a := range jobNotificationAttrRe.FindAllStringSubmatch(attrsRaw, -1) {
 		attrs[a[1]] = decodeNotificationEntities(a[2])
 	}
-	jobID = strings.TrimSpace(attrs["job_id"])
+	jobID := strings.TrimSpace(attrs["job_id"])
 	status := strings.ToLower(strings.TrimSpace(firstNonEmptyStr(attrs["status"], attrs["event"])))
 	exit := strings.TrimSpace(attrs["exit_code"])
-	isError = strings.Contains(status, "fail") || status == "error" || (exit != "" && exit != "0")
+	isError := strings.Contains(status, "fail") || status == "error" || (exit != "" && exit != "0")
 
+	var headline string
 	// Only a delegate's terminal block legitimately carries a communicate
 	// envelope in its excerpt (agent/session_tools_communicate.go writes it;
 	// agent/job_notify.go stamps job_type on every job block). Shell stdout
@@ -55,12 +107,12 @@ func ParseJobNotificationHeadline(text string) (jobID, headline string, isError,
 	// shape — the same gate the web parser applies (steeringClassify.ts,
 	// kata 9cnq; this is its TUI twin, kata sdvc).
 	if attrs["job_type"] == "delegate" {
-		headline = communicateHeadline(decodeNotificationEntities(m[2]))
+		headline = communicateHeadline(decodeNotificationEntities(body))
 	}
 	if headline == "" && status != "" {
 		headline = status
 	}
-	return jobID, headline, isError, true
+	return JobNotificationTie{JobID: jobID, Headline: headline, IsError: isError}
 }
 
 // communicateHeadline parses the communicate envelope that rides after an

--- a/cmd/serf-tui/internal/transcript/job_notification_test.go
+++ b/cmd/serf-tui/internal/transcript/job_notification_test.go
@@ -1,0 +1,126 @@
+package transcript
+
+import "testing"
+
+// Fixtures shared across the multi-block tests below: two delegate jobs, each
+// reporting a distinct rich headline through a communicate envelope excerpt.
+const (
+	jobNotificationBlockA = `<job-notification job_id="job_A" job_type="delegate" status="completed" exit_code="0">` +
+		`excerpt: {"data":{"test_summary":"all green","commit_hashes":["abcdef1234567890"],"concerns":["c1"]}}` +
+		`</job-notification>`
+	jobNotificationHeadlineA = "all green · abcdef12 · 1 concern"
+
+	jobNotificationBlockB = `<job-notification job_id="job_B" job_type="delegate" status="completed" exit_code="0">` +
+		`excerpt: {"data":{"test_summary":"3 passed","commit_hashes":["1234567890abcdef"]}}` +
+		`</job-notification>`
+	jobNotificationHeadlineB = "3 passed · 12345678"
+)
+
+func requireJobNotificationTie(t *testing.T, ties []JobNotificationTie, jobID string) JobNotificationTie {
+	t.Helper()
+	for _, tie := range ties {
+		if tie.JobID == jobID {
+			return tie
+		}
+	}
+	t.Fatalf("ties = %+v, want a tie for job %q", ties, jobID)
+	return JobNotificationTie{}
+}
+
+func TestParseJobNotificationHeadlines(t *testing.T) {
+	t.Run("single block unchanged", func(t *testing.T) {
+		ties := ParseJobNotificationHeadlines(jobNotificationBlockA)
+		if len(ties) != 1 {
+			t.Fatalf("len(ties) = %d, want 1: %+v", len(ties), ties)
+		}
+		tie := ties[0]
+		if tie.JobID != "job_A" {
+			t.Fatalf("JobID = %q, want job_A", tie.JobID)
+		}
+		if tie.Headline != jobNotificationHeadlineA {
+			t.Fatalf("Headline = %q, want %q", tie.Headline, jobNotificationHeadlineA)
+		}
+		if tie.IsError {
+			t.Fatal("IsError = true, want false")
+		}
+	})
+
+	t.Run("several job-notification blocks each parse individually (A then B)", func(t *testing.T) {
+		ties := ParseJobNotificationHeadlines(jobNotificationBlockA + "\n" + jobNotificationBlockB)
+		if len(ties) != 2 {
+			t.Fatalf("len(ties) = %d, want 2: %+v", len(ties), ties)
+		}
+		tieA := requireJobNotificationTie(t, ties, "job_A")
+		if tieA.Headline != jobNotificationHeadlineA || tieA.IsError {
+			t.Fatalf("job_A tie = %+v, want headline %q, no error", tieA, jobNotificationHeadlineA)
+		}
+		tieB := requireJobNotificationTie(t, ties, "job_B")
+		if tieB.Headline != jobNotificationHeadlineB || tieB.IsError {
+			t.Fatalf("job_B tie = %+v, want headline %q, no error", tieB, jobNotificationHeadlineB)
+		}
+	})
+
+	t.Run("several job-notification blocks each parse individually (B then A)", func(t *testing.T) {
+		ties := ParseJobNotificationHeadlines(jobNotificationBlockB + "\n" + jobNotificationBlockA)
+		if len(ties) != 2 {
+			t.Fatalf("len(ties) = %d, want 2: %+v", len(ties), ties)
+		}
+		tieA := requireJobNotificationTie(t, ties, "job_A")
+		if tieA.Headline != jobNotificationHeadlineA || tieA.IsError {
+			t.Fatalf("job_A tie = %+v, want headline %q, no error", tieA, jobNotificationHeadlineA)
+		}
+		tieB := requireJobNotificationTie(t, ties, "job_B")
+		if tieB.Headline != jobNotificationHeadlineB || tieB.IsError {
+			t.Fatalf("job_B tie = %+v, want headline %q, no error", tieB, jobNotificationHeadlineB)
+		}
+	})
+
+	t.Run("a block with isError", func(t *testing.T) {
+		text := `<job-notification job_id="job_E" status="failed" exit_code="1"></job-notification>`
+		ties := ParseJobNotificationHeadlines(text)
+		if len(ties) != 1 {
+			t.Fatalf("len(ties) = %d, want 1: %+v", len(ties), ties)
+		}
+		if !ties[0].IsError {
+			t.Fatal("IsError = false, want true")
+		}
+		if ties[0].Headline != "failed" {
+			t.Fatalf("Headline = %q, want failed", ties[0].Headline)
+		}
+	})
+
+	t.Run("text with no blocks", func(t *testing.T) {
+		ties := ParseJobNotificationHeadlines("just some steering text, no notification here")
+		if ties != nil {
+			t.Fatalf("ties = %+v, want nil", ties)
+		}
+	})
+}
+
+// TestParseJobNotificationHeadlineDelegatesToPlural pins the single-block
+// entry point (still used directly in a couple of call sites and tests) to
+// the same per-block parsing the multi-block entry point uses, so the two
+// never drift into divergent regexes.
+func TestParseJobNotificationHeadlineDelegatesToPlural(t *testing.T) {
+	jobID, headline, isErr, ok := ParseJobNotificationHeadline(jobNotificationBlockA)
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	if jobID != "job_A" {
+		t.Fatalf("jobID = %q, want job_A", jobID)
+	}
+	if headline != jobNotificationHeadlineA {
+		t.Fatalf("headline = %q, want %q", headline, jobNotificationHeadlineA)
+	}
+	if isErr {
+		t.Fatal("isError = true, want false")
+	}
+
+	// A steering event carrying several blocks: the singular entry point
+	// keeps returning only the first block's tie (its documented contract),
+	// never an aggregate across blocks.
+	jobID, headline, _, ok = ParseJobNotificationHeadline(jobNotificationBlockA + "\n" + jobNotificationBlockB)
+	if !ok || jobID != "job_A" || headline != jobNotificationHeadlineA {
+		t.Fatalf("multi-block input: jobID=%q headline=%q ok=%v, want job_A %q true", jobID, headline, ok, jobNotificationHeadlineA)
+	}
+}


### PR DESCRIPTION
## Summary
- fixes #49
- `cmd/serf-tui/internal/transcript/job_notification.go`'s regex was greedy and anchored (`^<job-notification ...>(.*)</job-notification>\s*$`). The daemon joins N job-notification blocks with `"\n"` into one steering event (`agent/session_lifecycle.go`), so on multi-block input the greedy body spanned from the first opening tag to the *last* closing tag: the first job's rich headline degraded to a bare status (its excerpt JSON no longer parsed once the body swallowed the second block's tags), and the second job never got a rail tie at all.
- Repro before the fix: A alone → `job_A` headline `"all green · abcdef12 · 1 concern"`; A+B joined → `job_A` headline degrades to `"completed"`, `job_B` never tied.
- Adds `ParseJobNotificationHeadlines(text) []JobNotificationTie`, matching each `<job-notification>...</job-notification>` block non-greedily and unanchored (mirrors the web side's `splitNotificationBlocks` fix in `steeringClassify.ts`, which carries the identical "MUST be non-greedy" comment). `ParseJobNotificationHeadline` is now a thin wrapper over the first tie, so there is one regex, not two.
- `hub_notifications.go`'s `NotifySerfSteeringInjected` handler now loops over every parsed tie and applies each via `ApplyTieHeadline` (already per-job-id), instead of only the first.

## Test plan
- [x] New unit tests in `cmd/serf-tui/internal/transcript/job_notification_test.go`: single block unchanged, A+B order, B+A order, a block with `isError`, text with no blocks.
- [x] New end-to-end test `TestTUISteeringInjectedTiesEveryJobNotificationBlock` in `cmd/serf-tui/hub_notifications_test.go` reproduces the reported bug through the real `NotifySerfSteeringInjected` handling path and asserts both rail rows get their own rich headline.
- [x] `go test ./cmd/serf-tui/... -race -count=1`
- [x] `go vet ./cmd/serf-tui/...`
- [x] `golangci-lint run ./...`

Claude-Session: https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU