### PR TITLE
fix(tui): show recent-project dropdown while spawn Dir prefill is untouched

### DIFF
--- a/cmd/serf-tui/hub_model.go
+++ b/cmd/serf-tui/hub_model.go
@@ -132,6 +132,13 @@ type hubModel struct {
 	// holds anything else.
 	spawnRecentDirs []string
 	spawnRecentIdx  int
+	// spawnDirPrefillUntouched is true when the Dir field still holds the
+	// open-time prefill from the selected project row (issue #51) and the
+	// user hasn't edited it yet. It makes the recent-projects dropdown (and
+	// tab-cycling into it) treat that prefill like an empty field, without
+	// weakening the pinned behavior of hiding recents once the user types a
+	// custom path.
+	spawnDirPrefillUntouched bool
 
 	detail  hubSessionDetail
 	session model

--- a/cmd/serf-tui/hub_spawn.go
+++ b/cmd/serf-tui/hub_spawn.go
@@ -115,6 +115,7 @@ func (m hubModel) updateSpawnKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.setSpawnDir("")
 			return m, nil
 		}
+		m.spawnDirPrefillUntouched = false
 		var cmd tea.Cmd
 		m.spawnDirInput, cmd = m.spawnDirInput.Update(msg)
 		m.spawnDir = strings.TrimSpace(m.spawnDirInput.Value())
@@ -248,16 +249,18 @@ func (m hubModel) spawnFieldPrefix(field hubSpawnField) string {
 }
 
 // nextSpawnRecentDir cycles the Dir field through the hub's most recently
-// used project dirs: from an empty field it fills the most recent one, and
-// from a recent option it advances (wrapping) to the next. It returns false
-// when the field holds a custom path, leaving tab to plain path completion.
+// used project dirs: from an empty field (or an untouched open-time prefill,
+// issue #51) it fills the most recent one, and from a recent option it
+// advances (wrapping) to the next. It returns false when the field holds a
+// user-edited custom path, leaving tab to plain path completion.
 func (m *hubModel) nextSpawnRecentDir(current string) (string, bool) {
 	if len(m.spawnRecentDirs) == 0 {
 		return "", false
 	}
 	cur := strings.TrimSpace(current)
-	if cur == "" {
+	if cur == "" || m.spawnDirPrefillUntouched {
 		m.spawnRecentIdx = 0
+		m.spawnDirPrefillUntouched = false
 		return m.spawnRecentDirs[0], true
 	}
 	if m.spawnRecentIdx >= 0 && m.spawnRecentIdx < len(m.spawnRecentDirs) && cur == m.spawnRecentDirs[m.spawnRecentIdx] {
@@ -268,11 +271,15 @@ func (m *hubModel) nextSpawnRecentDir(current string) (string, bool) {
 }
 
 // spawnRecentDirsVisible reports whether the Dir field's recent-project
-// dropdown options render: while the field is empty or shows one of the
-// recent options, hidden once the user types a custom path.
+// dropdown options render: while the field is empty, shows one of the
+// recent options, or still holds its untouched open-time prefill (issue
+// #51), hidden once the user types a custom path.
 func (m hubModel) spawnRecentDirsVisible() bool {
 	if len(m.spawnRecentDirs) == 0 {
 		return false
+	}
+	if m.spawnDirPrefillUntouched {
+		return true
 	}
 	cur := strings.TrimSpace(m.spawnDirInput.Value())
 	if cur == "" {
@@ -304,6 +311,7 @@ func (m *hubModel) openSpawnForm() {
 	m.resetSpawnForm()
 	m.spawnReturnMode = returnMode
 	m.setSpawnDir(dir)
+	m.spawnDirPrefillUntouched = dir != ""
 	m.spawnProject = project
 	m.mode = hubModeSpawn
 	m.err = nil
@@ -345,6 +353,7 @@ func (m *hubModel) setSpawnDir(dir string) {
 	m.spawnDir = dir
 	m.spawnDirInput = newSpawnDirInput()
 	m.spawnDirInput.SetValue(dir)
+	m.spawnDirPrefillUntouched = false
 	if m.spawnFocus == hubSpawnFieldDir {
 		m.spawnDirInput.Focus()
 	}

--- a/cmd/serf-tui/hub_spawn_recent_test.go
+++ b/cmd/serf-tui/hub_spawn_recent_test.go
@@ -97,3 +97,80 @@ func TestHubModelSpawnViewListsRecentProjects(t *testing.T) {
 		t.Fatalf("spawn view should hide recent options for a custom path:\n%s", view)
 	}
 }
+
+// spawnFormWithProjectPrefill opens the spawn form with a real project row
+// selected, so openSpawnForm prefills the Dir field the same way it does in
+// the TUI (issue #51's repro path) rather than via a direct setSpawnDir call.
+func spawnFormWithProjectPrefill(t *testing.T, workingDir string) hubModel {
+	t.Helper()
+	m := newHubModel(nil, "http://hub.test")
+	m.tree = hubTreeResponse{Projects: []hubTreeProject{{
+		Key:        "notrecent",
+		Name:       "not-recent",
+		WorkingDir: workingDir,
+		Sessions: []hubTreeNode{
+			{Ref: "local:01LIVE", SessionID: "01LIVE", Title: "live task", State: "idle", Project: "not-recent", Live: true},
+		},
+	}}}
+	m.rows = buildDashboardRows(m.tree)
+	m.selected = 1 // the session row under the project, not the launch row
+	m.openSpawnForm()
+	if m.spawnDir != workingDir {
+		t.Fatalf("spawnDir=%q, want %q (prefilled from selected row)", m.spawnDir, workingDir)
+	}
+	return m
+}
+
+// TestHubModelSpawnDirPrefillShowsRecentsUntilEdited covers issue #51: when
+// the Dir field is prefilled from the selected project row, that prefill
+// must not be treated like a user-typed custom path. Recents stay visible
+// until the user actually edits the field, then hide (preserving the
+// pinned custom-path behavior), and ctrl+u clearing restores visibility.
+func TestHubModelSpawnDirPrefillShowsRecentsUntilEdited(t *testing.T) {
+	m := spawnFormWithProjectPrefill(t, "/work/not-recent")
+	m.spawnRecentDirs = []string{"/proj/alpha", "/proj/beta"}
+	m.setSpawnFocus(hubSpawnFieldDir)
+
+	if !m.spawnRecentDirsVisible() {
+		t.Fatalf("recents should be visible while the prefill is untouched")
+	}
+	if view := m.spawnView(); !strings.Contains(view, "/proj/alpha") {
+		t.Fatalf("spawn view should list recent options for an untouched prefill:\n%s", view)
+	}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = updated.(hubModel)
+	if m.spawnRecentDirsVisible() {
+		t.Fatalf("recents should hide once the user edits the prefilled dir")
+	}
+	if view := m.spawnView(); strings.Contains(view, "/proj/alpha") {
+		t.Fatalf("spawn view should hide recent options after an edit:\n%s", view)
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
+	m = updated.(hubModel)
+	if !m.spawnRecentDirsVisible() {
+		t.Fatalf("ctrl+u clear should restore recents visibility")
+	}
+}
+
+// TestHubModelSpawnDirPrefillTabCyclesIntoRecents covers issue #51: tab must
+// reach the recent-projects list even when the Dir field holds the untouched
+// open-time prefill, not just when it's empty.
+func TestHubModelSpawnDirPrefillTabCyclesIntoRecents(t *testing.T) {
+	m := spawnFormWithProjectPrefill(t, "/work/not-recent")
+	m.spawnRecentDirs = []string{"/proj/alpha", "/proj/beta"}
+	m.setSpawnFocus(hubSpawnFieldDir)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(hubModel)
+	if m.spawnDir != "/proj/alpha" {
+		t.Fatalf("tab from untouched prefill dir=%q, want /proj/alpha (first recent project)", m.spawnDir)
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(hubModel)
+	if m.spawnDir != "/proj/beta" {
+		t.Fatalf("second tab dir=%q, want /proj/beta (cycling should continue normally after entering from the prefill)", m.spawnDir)
+	}
+}


### PR DESCRIPTION
## Summary
- Opening the spawn form from a selected project row prefills the Dir field (`openSpawnForm` → `setSpawnDir`), but `spawnRecentDirsVisible` and the tab-cycle entry (`nextSpawnRecentDir`) treated that prefill exactly like a user-typed custom path, hiding the recent-projects dropdown. ctrl+u (clearing the field) was the only way to reach recents.
- Fix keys on provenance, not content: a `spawnDirPrefillUntouched` flag is set when `openSpawnForm` prefills a non-empty Dir, and cleared the moment the user actually edits the field (typing, ctrl+u, or tab-cycling into a recent entry). While the flag is set, the field is treated like empty for visibility and tab-cycling. Once cleared, the existing (pinned) hide-on-custom-path behavior resumes exactly.
- This is a UX-judgment call — showing recents while the prefill is untouched — flagging in case Jesse wants a different behavior here.

Fixes #51

## Test plan
- [x] Red: added `TestHubModelSpawnDirPrefillShowsRecentsUntilEdited` and `TestHubModelSpawnDirPrefillTabCyclesIntoRecents` in `cmd/serf-tui/hub_spawn_recent_test.go`, confirmed both failed against pre-fix code (prefill hid recents; tab refused to cycle into them; a second tab after landing on a recent also regressed to re-showing the first recent instead of advancing — caught and fixed before commit).
- [x] Green: both new tests pass; existing pinned test `TestHubModelSpawnViewListsRecentProjects` (hides recents once a custom path is set) still passes unmodified; `TestHubModelSpawnDirTabCyclesRecentProjects` (empty-field tab-cycle) still passes unmodified.
- [x] `go test ./cmd/serf-tui/... -race -count=1` — all packages pass, pristine output.
- [x] `go vet ./...` — clean.
- [x] `golangci-lint run ./...` — 0 issues.

Claude-Session: https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU