### PR TITLE
fix(web): show request arguments on read_transcript and find_session_transcripts cards

### DIFF
--- a/cmd/serf-hub/frontend/src/panes/session/transcript/tools/readTranscript.test.tsx
+++ b/cmd/serf-hub/frontend/src/panes/session/transcript/tools/readTranscript.test.tsx
@@ -184,3 +184,35 @@ test("body renders nothing when there is no output at all", () => {
   const { container } = render(<Body item={item({ toolName: "read_transcript" })} live={false} />);
   expect(container.textContent).toBe("");
 });
+
+// --- body: the request arguments, so "what range/scope was asked for" is answerable ---
+
+test("body shows the pretty-printed request arguments, above the transcript content", () => {
+  const d = toolRendererFor("read_transcript");
+  const Body = d.body!;
+  const { container } = render(
+    <Body item={call({ transcript_ref: "local:01KABC", range: "last:40" }, MARKDOWN_ENVELOPE)} live={false} />,
+  );
+  const section = screen.getByRole("region", { name: "Tool call arguments" });
+  expect(section.textContent).toContain('"range": "last:40"');
+  const argsIndex = container.textContent!.indexOf('"range"');
+  const outputIndex = container.textContent!.indexOf("## Turn 1");
+  expect(argsIndex).toBeGreaterThanOrEqual(0);
+  expect(argsIndex).toBeLessThan(outputIndex);
+});
+
+test("body shows the request arguments above the raw output when the envelope isn't parseable JSON", () => {
+  const d = toolRendererFor("read_transcript");
+  const Body = d.body!;
+  const bad = item({
+    toolName: "read_transcript",
+    argumentsJSON: JSON.stringify({ transcript_ref: "local:01KABC", range: "last:5" }),
+    output: "plain text fallback",
+  });
+  const { container } = render(<Body item={bad} live={false} />);
+  const section = screen.getByRole("region", { name: "Tool call arguments" });
+  expect(section.textContent).toContain('"range": "last:5"');
+  const argsIndex = container.textContent!.indexOf('"range"');
+  const outputIndex = container.textContent!.indexOf("plain text fallback");
+  expect(argsIndex).toBeLessThan(outputIndex);
+});

--- a/cmd/serf-hub/frontend/src/panes/session/transcript/tools/readTranscript.tsx
+++ b/cmd/serf-hub/frontend/src/panes/session/transcript/tools/readTranscript.tsx
@@ -25,12 +25,13 @@
 // same three envelopes (agent/session_tools_transcript.go routes both through
 // execReadSessionTranscript). find_session_transcripts does NOT: it returns a
 // findSessionsEnvelope of match RECORDS (agent/session_tools_find.go), a list,
-// not a transcript - a different renderer's job, and none is registered for it,
-// so it keeps the raw-output default.
+// not a transcript - a different renderer's job. It has its own descriptor
+// (worktreeTool.tsx's findSessionsSummary registration), not this one.
 
 import type { ItemModel } from "../../../../protocol/model";
 import { CodeBlock } from "../../../../widgets";
 import { requireClass } from "../../../../widgets/internal/requireClass";
+import { MCPToolArguments } from "../MCPToolArguments";
 import type { ToolRenderProps } from "../toolRenderers";
 import { registerToolRenderer } from "../toolRenderers";
 import { clip, clipJobID, parseArgs, parseJSONObject, str } from "./helpers";
@@ -131,16 +132,24 @@ function extent(item: ItemModel): string | undefined {
   return rendered >= total ? `all ${total} turns` : `${rendered} of ${total} turns`;
 }
 
-function ReadTranscriptBody({ item }: ToolRenderProps) {
+function ReadTranscriptBody(props: ToolRenderProps) {
+  const { item } = props;
   const output = item.output ?? "";
   if (output === "") return null;
   const envelope = readEnvelope(item);
   // Not parseable JSON: show what actually came back rather than an empty
   // block - the envelope shape is documented, not guaranteed by this client.
-  if (!envelope?.content) return <CodeBlock text={output} copyLabel="Copy output" />;
+  if (!envelope?.content)
+    return (
+      <>
+        <MCPToolArguments {...props} />
+        <CodeBlock text={output} copyLabel="Copy output" />
+      </>
+    );
   const elided = envelope.elidedTurns ?? 0;
   return (
     <div>
+      <MCPToolArguments {...props} />
       {elided > 0 && (
         <div className={CLASS.elision} data-testid="read-transcript-elision">
           {elided} turn{elided === 1 ? "" : "s"} elided by the read's own budget

--- a/cmd/serf-hub/frontend/src/panes/session/transcript/tools/worktreeTool.test.tsx
+++ b/cmd/serf-hub/frontend/src/panes/session/transcript/tools/worktreeTool.test.tsx
@@ -269,6 +269,28 @@ test("find_session_transcripts: body head-clips the raw text output", () => {
   expect(screen.getByText("No matching sessions (scope: current_project).")).toBeTruthy();
 });
 
+test("find_session_transcripts: body shows the pretty-printed query above the output", () => {
+  const d = toolRendererFor("find_session_transcripts");
+  const Body = d.body!;
+  const args = JSON.stringify({ query: "flaky test" });
+  const { container } = render(
+    <Body
+      item={item({
+        toolName: "find_session_transcripts",
+        argumentsJSON: args,
+        output: "1 match (scope: current_project).",
+      })}
+      live={false}
+    />,
+  );
+  const section = screen.getByRole("region", { name: "Tool call arguments" });
+  expect(section.textContent).toContain('"query": "flaky test"');
+  const argsIndex = container.textContent!.indexOf('"query"');
+  const outputIndex = container.textContent!.indexOf("1 match (scope: current_project).");
+  expect(argsIndex).toBeGreaterThanOrEqual(0);
+  expect(argsIndex).toBeLessThan(outputIndex);
+});
+
 // A descriptor that is never imported by tools/index.ts is never registered in
 // the running app, however green its own tests are - this file imports the
 // module directly, so every assertion above would keep passing with the

--- a/cmd/serf-hub/frontend/src/panes/session/transcript/tools/worktreeTool.tsx
+++ b/cmd/serf-hub/frontend/src/panes/session/transcript/tools/worktreeTool.tsx
@@ -23,6 +23,8 @@
 // a `switch` that turned out to be a no-op reads "Already in", not
 // "Switched to", and an `already_disposed` dispose never claims a
 // dirty-discard, because nothing was torn down to discard.
+import { MCPToolArguments } from "../MCPToolArguments";
+import type { ToolRenderProps } from "../toolRenderers";
 import { registerToolRenderer } from "../toolRenderers";
 import { HeadClippedOutputBody } from "./bodies";
 import { clip, parseArgs, parseJSONObject, str } from "./helpers";
@@ -157,8 +159,21 @@ function findSessionsSummary(item: { argumentsJSON?: string; output?: string }):
   return count === undefined ? lead : `${lead} · ${count} ${noun}`;
 }
 
+// The row's body composes the request arguments above the head-clipped
+// output (matching defaultToolBody's own arrangement in toolRenderers.ts) so
+// "what was searched for" is answerable from the expanded card, not just the
+// summary line above it.
+function FindSessionTranscriptsBody(props: ToolRenderProps) {
+  return (
+    <>
+      <MCPToolArguments {...props} />
+      <HeadClippedOutputBody {...props} />
+    </>
+  );
+}
+
 registerToolRenderer({
   match: "find_session_transcripts",
   summary: findSessionsSummary,
-  body: HeadClippedOutputBody,
+  body: FindSessionTranscriptsBody,
 });


### PR DESCRIPTION
## Summary

fixes #5 - closes the one remaining gap: expandable tool cards for `read_transcript` and `find_session_transcripts` rendered the tool output but not the pretty-printed request arguments, so "what range/scope was requested?" / "what was searched for?" was unanswerable from the UI.

- `MCPToolArguments` (`cmd/serf-hub/frontend/src/panes/session/transcript/MCPToolArguments.tsx`) only ever rode `defaultToolBody` (`toolRenderers.ts` ~160-171). The two registered descriptors that override the default body dropped it:
  - `ReadTranscriptBody` (`tools/readTranscript.tsx` ~154-163)
  - the `find_session_transcripts` registration's `HeadClippedOutputBody` (`tools/worktreeTool.tsx` ~160-164)
- Fix: compose `MCPToolArguments` into both bodies, arguments above output, matching `defaultToolBody`'s own arrangement. `find_session_transcripts` gets its own small wrapper (`FindSessionTranscriptsBody`) rather than changing the shared `HeadClippedOutputBody`, since that helper is also used by `manage_worktree`'s body and this fix is scoped to the two transcript-search tools.
- Also fixes doc drift found during validation: the comment at `readTranscript.tsx` ~26-29 claimed `find_session_transcripts` has no registered renderer - false since cd4663a99, which gave it its own descriptor in `worktreeTool.tsx`.

The issue's other asks - expandable bodies, error auto-expand, and the fallback renderer - are already shipped and out of scope here.

## Test plan

- [x] Red: added failing tests asserting the expanded card shows the request's arguments (scope/range for `read_transcript`, query for `find_session_transcripts`), above the output
- [x] Green: implemented the composition, tests pass
- [x] `npx vitest run src/panes/session/transcript/tools/readTranscript.test.tsx src/panes/session/transcript/tools/worktreeTool.test.tsx`
- [x] `make test-web` (typecheck, test, lint all pass)

Claude-Session: https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU