### PR TITLE
fix(frontend): keep interstitial steering text positioned between notification cards

### DIFF
--- a/cmd/serf-hub/frontend/src/panes/session/transcript/messages/SteeringItem.test.tsx
+++ b/cmd/serf-hub/frontend/src/panes/session/transcript/messages/SteeringItem.test.tsx
@@ -436,6 +436,28 @@ test("a mixed notification steer keeps its wire-kind label on the leftover divid
   expect(screen.getByText("trailing steering prose")).toBeTruthy();
 });
 
+// issue #48: text between two notification blocks used to be stripped out
+// and re-merged into a single divider rendered AFTER both cards, so
+// "middle steering text" (written between the two blocks) rendered below
+// both instead of between them. Fragments must render in source order.
+test("text between two notification blocks renders as its own divider, positioned between the two cards (issue #48)", () => {
+  const secondBlock = `<job-notification job_id="job_8" event="failed" job_type="shell" status="failed" reason="bad" output_bytes="1" exit_code="3">
+Job job_8 failed.
+</job-notification>`;
+  const text = `${JOB_NOTIFICATION_STEERING}\n\nmiddle steering text\n\n${secondBlock}`;
+  const { container } = render(<SteeringItem item={item({ text })} turn={turn} live={false} />);
+
+  const nodes = Array.from(
+    container.querySelectorAll('[data-testid="notification-card"], [data-testid="steering-item"]'),
+  );
+  expect(nodes.map((n) => n.getAttribute("data-testid"))).toEqual([
+    "notification-card",
+    "steering-item",
+    "notification-card",
+  ]);
+  expect(nodes[1]?.textContent).toContain("middle steering text");
+});
+
 // The card's trigger is <job-notification> markup, not the kind: structured
 // markup cannot false-positive the way a prose pattern can, so a pre-Kind
 // transcript still gets its card.

--- a/cmd/serf-hub/frontend/src/panes/session/transcript/messages/SteeringItem.tsx
+++ b/cmd/serf-hub/frontend/src/panes/session/transcript/messages/SteeringItem.tsx
@@ -153,44 +153,54 @@ export const SteeringItem = memo(function SteeringItem({ item, sessionRef }: Ite
   // markup, which cannot false-positive, so a steer projected before the kind
   // field existed still renders its cards.
   const label = labelFor(kind);
-  const { notifications, leftover } = parseSteeringNotifications(item.text);
-  if (notifications.length > 0) {
+  const fragments = parseSteeringNotifications(item.text);
+  const hasNotification = fragments.some((f) => f.kind === "notification");
+  if (hasNotification) {
     return (
       <>
-        {notifications.map((n, index) => (
-          // rawText is NOT a safe key: a generic notification the daemon
-          // never gave a job_id (e.g. a watch-timeout retry, kata rail-nav
-          // React invariant) can appear more than once in the same steer
-          // with byte-identical text, and rawText was colliding on it -
-          // "Encountered two children with the same key" in the console,
-          // and downstream React reconciler corruption (an "Expected static
-          // flag was missing" internal invariant) on the next update once a
-          // streamed delta rebuilds this same item with another duplicate.
-          // notifications is a fresh, order-stable parse of this one item's
-          // text every render (parseSteeringNotifications above), never a
-          // diffed/reordered list, so the array index is a safe, stable
-          // identity here - same reasoning as ExcerptText's own index key in
-          // NotificationCard.tsx.
-          // biome-ignore lint/suspicious/noArrayIndexKey: index is stable - see comment above
-          <NotificationCard key={index} notification={n} sessionRef={sessionRef} />
-        ))}
-        {leftover && (
-          <SteeringDivider
-            id={item.id}
-            label={label ? `${STEERED}: ${label}` : STEERED}
-            text={leftover}
-            sessionRef={sessionRef}
-          />
+        {fragments.map((fragment, index) =>
+          fragment.kind === "notification" ? (
+            // rawText is NOT a safe key: a generic notification the daemon
+            // never gave a job_id (e.g. a watch-timeout retry, kata rail-nav
+            // React invariant) can appear more than once in the same steer
+            // with byte-identical text, and rawText was colliding on it -
+            // "Encountered two children with the same key" in the console,
+            // and downstream React reconciler corruption (an "Expected static
+            // flag was missing" internal invariant) on the next update once a
+            // streamed delta rebuilds this same item with another duplicate.
+            // fragments is a fresh, order-stable parse of this one item's
+            // text every render (parseSteeringNotifications above), never a
+            // diffed/reordered list, so the array index is a safe, stable
+            // identity here - same reasoning as ExcerptText's own index key in
+            // NotificationCard.tsx.
+            // biome-ignore lint/suspicious/noArrayIndexKey: index is stable - see comment above
+            <NotificationCard key={index} notification={fragment.notification} sessionRef={sessionRef} />
+          ) : (
+            // Each interstitial text span gets its own divider, positioned
+            // where it appeared in the original text (issue #48) rather than
+            // every span merged into one divider rendered after all cards. A
+            // per-fragment id keeps its collapsed/expanded state independent
+            // of any other divider on the same item.
+            <SteeringDivider
+              // biome-ignore lint/suspicious/noArrayIndexKey: index is stable - see comment above
+              key={index}
+              id={`${item.id}:${index}`}
+              label={label ? `${STEERED}: ${label}` : STEERED}
+              text={fragment.text}
+              sessionRef={sessionRef}
+            />
+          ),
         )}
       </>
     );
   }
 
+  const soleFragment = fragments[0];
   return (
     <SteeringDivider
       id={item.id}
       label={label ? `${STEERED}: ${label}` : STEERED}
-      text={leftover}
+      text={soleFragment?.kind === "text" ? soleFragment.text : ""}
       sessionRef={sessionRef}
     />
   );

--- a/cmd/serf-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
+++ b/cmd/serf-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
@@ -1,7 +1,17 @@
 // @vitest-environment node
 
 import { expect, test } from "vitest";
-import { type ParsedNotification, parseSteeringNotifications } from "./steeringClassify";
+import { type ParsedNotification, parseSteeringNotifications, type SteeringFragment } from "./steeringClassify";
+
+// notificationsOf flattens the ordered fragment list down to just its parsed
+// notifications, in order - most existing tests here only care about the
+// notifications themselves, not their position relative to interstitial text
+// (that positioning is covered separately below, issue #48).
+function notificationsOf(fragments: SteeringFragment[]): ParsedNotification[] {
+  return fragments
+    .filter((f): f is Extract<SteeringFragment, { kind: "notification" }> => f.kind === "notification")
+    .map((f) => f.notification);
+}
 
 // Non-undefined nth-notification accessor (noUncheckedIndexedAccess makes a
 // bare [i] possibly-undefined); throws with a clear message when absent.
@@ -42,7 +52,7 @@ done
 Job job_shell completed.
 </job-notification>`;
 
-  const { notifications } = parseSteeringNotifications(text);
+  const notifications = notificationsOf(parseSteeringNotifications(text));
   expect(notifications).toHaveLength(2);
   expect(notifications[0]).toMatchObject({
     type: "delegate",
@@ -55,7 +65,7 @@ Job job_shell completed.
 });
 
 test("a delegate-completion job-notification parses one block", () => {
-  const { notifications } = parseSteeringNotifications(oneBlock);
+  const notifications = notificationsOf(parseSteeringNotifications(oneBlock));
   expect(notifications).toHaveLength(1);
   const n = notif(notifications, 0);
   expect(n.title).toBe("Job completed");
@@ -68,7 +78,7 @@ test("prefers the job description over the generic delegate type", () => {
   const block = `<job-notification job_id="job_42" event="completed" job_type="delegate" description="Inspect the workspace" status="completed" reason="" output_bytes="12">
 Job job_42 completed.
 </job-notification>`;
-  const n = notif(parseSteeringNotifications(block).notifications, 0);
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
   expect(n.description).toBe("Inspect the workspace");
   expect(n.secondary).toBe("Inspect the workspace");
 });
@@ -77,7 +87,7 @@ test("retains failure metadata alongside a job description", () => {
   const block = `<job-notification job_id="job_42" event="completed" job_type="delegate" description="Inspect the workspace" status="completed" reason="boom" exit_code="2">
 Job job_42 completed.
 </job-notification>`;
-  const n = notif(parseSteeringNotifications(block).notifications, 0);
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
   expect(n.secondary).toBe("Inspect the workspace · exit 2 · boom");
 });
 
@@ -87,7 +97,7 @@ Job job_42 completed.
 excerpt:
 did the thing
 </job-notification>`;
-  const n = notif(parseSteeringNotifications(block).notifications, 0);
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
   expect(n.jobId).toBe("job_42");
   expect(n.jobType).toBe("delegate");
   expect(n.status).toBe("completed");
@@ -101,7 +111,7 @@ test("retains qualified remote child references", () => {
   const block = `<job-notification job_id="job_remote" event="completed" status="completed" transcript_ref="remote:child">
 done
 </job-notification>`;
-  expect(notif(parseSteeringNotifications(block).notifications, 0).transcriptRef).toBe("remote:child");
+  expect(notif(notificationsOf(parseSteeringNotifications(block)), 0).transcriptRef).toBe("remote:child");
 });
 
 test("drops missing, empty, and malformed child references", () => {
@@ -109,7 +119,7 @@ test("drops missing, empty, and malformed child references", () => {
   for (const ref of refs) {
     const attr = ref === undefined ? "" : ` transcript_ref="${ref}"`;
     const block = `<job-notification job_id="job_bad" event="completed" status="completed"${attr}>done</job-notification>`;
-    expect(notif(parseSteeringNotifications(block).notifications, 0).transcriptRef).toBeUndefined();
+    expect(notif(notificationsOf(parseSteeringNotifications(block)), 0).transcriptRef).toBeUndefined();
   }
 });
 
@@ -119,7 +129,7 @@ Job job_43 failed.
 excerpt:
 boom
 </job-notification>`;
-  const { notifications } = parseSteeringNotifications(two);
+  const notifications = notificationsOf(parseSteeringNotifications(two));
   expect(notifications).toHaveLength(2);
   expect(notif(notifications, 1).tone).toBe("error");
   // Each card's raw text is only its own block, never bleeding across boundaries.
@@ -131,28 +141,28 @@ test("an exhausted notification is a terminal, non-success (error) tone", () => 
   const block = `<job-notification job_id="j" event="exhausted" job_type="delegate" status="exhausted" reason="budget" output_bytes="0" budget="10" limit="10" resumable="false">
 Job j exhausted.
 </job-notification>`;
-  expect(notif(parseSteeringNotifications(block).notifications, 0).tone).toBe("error");
+  expect(notif(notificationsOf(parseSteeringNotifications(block)), 0).tone).toBe("error");
 });
 
 test("a nonzero exit code forces error tone even when the status is otherwise clean", () => {
   const block = `<job-notification job_id="j" event="completed" job_type="shell" status="completed" reason="" output_bytes="0" exit_code="1">
 Job j completed.
 </job-notification>`;
-  expect(notif(parseSteeringNotifications(block).notifications, 0).tone).toBe("error");
+  expect(notif(notificationsOf(parseSteeringNotifications(block)), 0).tone).toBe("error");
 });
 
 test("a job-less watch event classifies as a watch notification", () => {
   const block = `<job-notification job_id="" event="watch" job_type="" status="watch" reason="file changed" output_bytes="0">
 Watch event triggered: file changed.
 </job-notification>`;
-  const n = notif(parseSteeringNotifications(block).notifications, 0);
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
   expect(n.type).toBe("watch");
   expect(n.title).toBe("Watch triggered");
 });
 
 test("an Observer callback parses as a notification", () => {
-  const { notifications } = parseSteeringNotifications(
-    "Observer callback:\nmessage: something happened\noutput: details here",
+  const notifications = notificationsOf(
+    parseSteeringNotifications("Observer callback:\nmessage: something happened\noutput: details here"),
   );
   expect(notif(notifications, 0).title).toBe("Observer callback");
 });
@@ -164,19 +174,48 @@ test("an Observer callback with no output surfaces its message prose (not just t
   // The prose is then the ONLY content, so it must reach the card body (floor
   // parity-m4 §8:239 "body = observer-callback prose"), not be dropped to the
   // raw disclosure alone.
-  const { notifications } = parseSteeringNotifications(
-    "Observer callback:\nmessage: the sidecar noticed the build broke",
+  const notifications = notificationsOf(
+    parseSteeringNotifications("Observer callback:\nmessage: the sidecar noticed the build broke"),
   );
   const n = notif(notifications, 0);
   expect(n.title).toBe("Observer callback");
   expect(n.excerpt).toBe("the sidecar noticed the build broke");
 });
 
-test("leftover text around a notification block is preserved for a trailing divider", () => {
-  const { notifications, leftover } = parseSteeringNotifications(`some preface\n${oneBlock}\nsome epilogue`);
-  expect(notifications).toHaveLength(1);
-  expect(leftover).toContain("some preface");
-  expect(leftover).toContain("some epilogue");
+test("text around a notification block is kept as its own fragment before and after it, not merged into one leftover", () => {
+  const fragments = parseSteeringNotifications(`some preface\n${oneBlock}\nsome epilogue`);
+  expect(fragments.map((f) => f.kind)).toEqual(["text", "notification", "text"]);
+  expect(fragments[0]).toMatchObject({ kind: "text", text: "some preface" });
+  expect(fragments[2]).toMatchObject({ kind: "text", text: "some epilogue" });
+});
+
+// issue #48: splitNotificationBlocks used to replace every notification block
+// with "" and trim what remained into ONE leftover string, so interstitial
+// text between two cards lost its position and rendered after both cards
+// instead of between them. Fragments must stay in source order so each
+// interstitial span renders as its own divider, positioned where it was
+// written.
+test("interstitial text between two notification blocks stays positioned between them, not merged after both (issue #48)", () => {
+  const secondBlock = `<job-notification job_id="job_43" event="failed" job_type="shell" status="failed" reason="nonzero exit" output_bytes="4" exit_code="2">
+Job job_43 failed.
+excerpt:
+boom
+</job-notification>`;
+  const text = `lead-in\n${oneBlock}\n\nmiddle\n\n${secondBlock}\ntrailing`;
+
+  const fragments = parseSteeringNotifications(text);
+
+  expect(fragments.map((f) => f.kind)).toEqual(["text", "notification", "text", "notification", "text"]);
+  expect(fragments[0]).toMatchObject({ kind: "text", text: "lead-in" });
+  expect(fragments[2]).toMatchObject({ kind: "text", text: "middle" });
+  expect(fragments[4]).toMatchObject({ kind: "text", text: "trailing" });
+  const first = fragments[1];
+  const second = fragments[3];
+  if (first?.kind !== "notification" || second?.kind !== "notification") {
+    throw new Error("expected notification fragments at indices 1 and 3");
+  }
+  expect(first.notification.jobId).toBe("job_42");
+  expect(second.notification.jobId).toBe("job_43");
 });
 
 // --- kata 77sf: producer-escaped job output must not terminate or forge the
@@ -200,11 +239,13 @@ excerpt:
 ${escapeLikeProducer(dangerous)}
 </job-notification>`;
 
-  const { notifications, leftover } = parseSteeringNotifications(`preface\n${block}\nepilogue`);
+  const fragments = parseSteeringNotifications(`preface\n${block}\nepilogue`);
 
+  const notifications = notificationsOf(fragments);
   expect(notifications).toHaveLength(1);
-  expect(leftover).toContain("preface");
-  expect(leftover).toContain("epilogue");
+  expect(fragments.map((f) => f.kind)).toEqual(["text", "notification", "text"]);
+  expect(fragments[0]).toMatchObject({ kind: "text", text: "preface" });
+  expect(fragments[2]).toMatchObject({ kind: "text", text: "epilogue" });
   const n = notif(notifications, 0);
   expect(n.jobId).toBe("job_X");
   expect(n.excerpt).toBe(escapeLikeProducer(dangerous));
@@ -217,7 +258,7 @@ Job j completed.
 excerpt:
 {"message":"**done** with the work","data":{"concerns":["watch the edge case"]}}
 </job-notification>`;
-  const n = notif(parseSteeringNotifications(block).notifications, 0);
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
   expect(n.message).toBe("**done** with the work");
   expect(n.concerns).toEqual(["watch the edge case"]);
 });
@@ -235,7 +276,7 @@ Job j completed.
 excerpt:
 ${escapeLikeProducer(envelopeJson)}
 </job-notification>`;
-  const n = notif(parseSteeringNotifications(block).notifications, 0);
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
   expect(n.message).toBe("R & D done");
   expect(n.concerns).toEqual(["edge <case>"]);
 });
@@ -251,7 +292,7 @@ Job j completed.
 excerpt:
 {"message":"**literal shell output**","data":{"status":"ok","concerns":["from stdout"]}}
 </job-notification>`;
-  const n = notif(parseSteeringNotifications(block).notifications, 0);
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
   expect(n.message).toBeUndefined();
   expect(n.concerns).toEqual([]);
   expect(n.excerpt).toBe('{"message":"**literal shell output**","data":{"status":"ok","concerns":["from stdout"]}}');
@@ -265,7 +306,7 @@ Job j completed.
 excerpt:
 {"message":"**done**","data":{"concerns":["real concern"]}}
 </job-notification>`;
-  const n = notif(parseSteeringNotifications(block).notifications, 0);
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
   expect(n.message).toBe("**done**");
   expect(n.concerns).toEqual(["real concern"]);
 });

--- a/cmd/serf-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts
+++ b/cmd/serf-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts
@@ -75,20 +75,37 @@ function optionalNonNegativeInteger(attrs: Record<string, string>, key: string):
   return Number.isSafeInteger(value) && value >= 0 ? value : undefined;
 }
 
+// A notification-text fragment in source order: either a raw
+// <job|delegate-notification> block (still unparsed - the caller classifies
+// it) or a trimmed span of text between/around blocks. Splitting into
+// ordered fragments - instead of collecting every block and handing back one
+// merged leftover string - is what lets a caller keep interstitial text
+// pinned to its original position between two notification cards (issue #48)
+// rather than collapsing it into a single trailing divider.
+interface NotificationBlockFragment {
+  kind: "block" | "text";
+  text: string;
+}
+
 // splitJobNotificationBlocks extracts each individual <job-notification …>…
 // </job-notification> block. The per-block match MUST be non-greedy: a single
 // steering turn can carry several blocks joined by newlines, and a greedy match
 // would span the first opening tag to the last closing tag and aggregate
 // distinct notifications into one (contracts §17).
-function splitNotificationBlocks(text: string): { blocks: string[]; leftover: string } {
-  const blocks: string[] = [];
-  const leftover = text
-    .replace(/<(job|delegate)-notification\s+[^>]*>[\s\S]*?<\/\1-notification>/g, (block) => {
-      blocks.push(block);
-      return "";
-    })
-    .trim();
-  return { blocks, leftover };
+function splitNotificationBlocks(text: string): NotificationBlockFragment[] {
+  const pattern = /<(job|delegate)-notification\s+[^>]*>[\s\S]*?<\/\1-notification>/g;
+  const fragments: NotificationBlockFragment[] = [];
+  let cursor = 0;
+  for (const match of text.matchAll(pattern)) {
+    const index = match.index ?? 0;
+    const before = text.slice(cursor, index).trim();
+    if (before) fragments.push({ kind: "text", text: before });
+    fragments.push({ kind: "block", text: match[0] });
+    cursor = index + match[0].length;
+  }
+  const after = text.slice(cursor).trim();
+  if (after) fragments.push({ kind: "text", text: after });
+  return fragments;
 }
 
 function parseDelegateNotification(block: string): ParsedNotification | null {
@@ -303,24 +320,40 @@ function parseObserverCallback(stripped: string): ParsedNotification | null {
   };
 }
 
+// An ordered fragment of a parsed steer: either a notification card or a span
+// of plain text between/around cards, in the position it appeared in the
+// original text. SteeringItem.tsx renders these in order so interstitial
+// text stays where it was written (issue #48) instead of collapsing into one
+// trailing divider after every card.
+export type SteeringFragment =
+  | { kind: "notification"; notification: ParsedNotification }
+  | { kind: "text"; text: string };
+
 // Notification blocks are STRUCTURED markup (<job-notification …>) and a fixed
 // "Observer callback:\n" header, so reading them is parsing, not guessing: they
 // cannot false-positive the way a prose pattern like /completed all tasks/ can.
 // This is why the card's trigger stayed content-driven while the kind moved to
 // the wire, and why a pre-Kind transcript still renders its cards.
-export function parseSteeringNotifications(text: string): {
-  notifications: ParsedNotification[];
-  leftover: string;
-} {
+export function parseSteeringNotifications(text: string): SteeringFragment[] {
   const stripped = stripSystemReminder(text);
-  const { blocks, leftover } = splitNotificationBlocks(stripped);
-  const notifications = blocks
-    .map((block) =>
-      block.startsWith("<delegate-notification") ? parseDelegateNotification(block) : parseJobNotification(block),
-    )
-    .filter((n): n is ParsedNotification => n !== null);
-  if (notifications.length > 0) return { notifications, leftover };
+  const blockFragments = splitNotificationBlocks(stripped);
+  const fragments: SteeringFragment[] = [];
+  let sawNotification = false;
+  for (const frag of blockFragments) {
+    if (frag.kind === "text") {
+      fragments.push({ kind: "text", text: frag.text });
+      continue;
+    }
+    const notification = frag.text.startsWith("<delegate-notification")
+      ? parseDelegateNotification(frag.text)
+      : parseJobNotification(frag.text);
+    if (notification) {
+      fragments.push({ kind: "notification", notification });
+      sawNotification = true;
+    }
+  }
+  if (sawNotification) return fragments;
   const observer = parseObserverCallback(stripped);
-  if (observer) return { notifications: [observer], leftover: "" };
-  return { notifications: [], leftover: stripped };
+  if (observer) return [{ kind: "notification", notification: observer }];
+  return stripped ? [{ kind: "text", text: stripped }] : [];
 }


### PR DESCRIPTION
## Summary
- `splitNotificationBlocks` replaced every `<job|delegate-notification>` block with `""` and trimmed what remained into one merged `leftover` string, so `SteeringItem` rendered interstitial text as a single divider trailing every notification card instead of positioned where it actually appeared.
- `splitNotificationBlocks` and `parseSteeringNotifications` now return an ordered `fragments` list (`{kind: "block"|"text", text}` internally, `{kind: "notification"|"text"}` from the exported API), preserving source order.
- `SteeringItem` interleaves `NotificationCard`s with per-fragment `SteeringDivider`s in order, each with its own stable disclosure id (`${item.id}:${index}`).
- Confirmed no other consumers of either function exist in the repo.

fixes #48

## Test plan
- [x] Red first: added `steeringClassify.test.ts` case "interstitial text between two notification blocks stays positioned between them, not merged after both (issue #48)" and a `SteeringItem.test.tsx` DOM-order case; both failed against the old code (verified by temporarily reverting `SteeringItem.tsx` and re-running).
- [x] Updated existing tests that asserted on the old `{notifications, leftover}` shape.
- [x] `npx vitest run src/panes/session/transcript/messages/steeringClassify.test.ts src/panes/session/transcript/messages/SteeringItem.test.tsx` → 61 passed.
- [x] `make test-web` (typecheck, full vitest suite, biome lint) → all PASS.

Claude-Session: https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU