### PR TITLE
agent: shared-workspace delegate advisory and two posture prompt sections

### DIFF
--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -920,6 +920,9 @@ func (runtime delegateRuntime) create(ctx context.Context, args delegateArgs) de
 	if err := s.reclaimDelegateRuntimeCapacity(1); err != nil {
 		return delegateStartFailed(err)
 	}
+	// Read the overlap before this delegate is prepared or tracked, while the
+	// siblings it would join are still the only running children.
+	sharedWorkspaceAdvisory := s.sharedWorkspaceDelegateWarning(isolationName)
 	reservation, err := s.delegateController.ReserveCreate(actor, descriptor)
 	if err != nil {
 		return delegateStartFailed(err)
@@ -978,7 +981,12 @@ func (runtime delegateRuntime) create(ctx context.Context, args delegateArgs) de
 	bindStableDelegateActivity(prepared.sub.sess, s.delegateController, started.lease)
 	s.startDelegateQuietWatchdog(started.ctx, started.lease)
 	s.launchSubagentRun(prepared.runCtx, prepared.sub, prepared.runCancel, prepared.input, started.descriptor.Provenance)
-	return createResult(stableDelegateResult(started.descriptor, started.lease.delegateID, started.plan, plans, nil))
+	result := createResult(stableDelegateResult(started.descriptor, started.lease.delegateID, started.plan, plans, nil))
+	// The advisory rides the launched delegate's own result only: it is
+	// metadata for the caller's next isolation choice, not delegate output, not
+	// an EventWarning, and not durable job state a later delegate_send replays.
+	result.Warnings = appendUniqueStrings(result.Warnings, sharedWorkspaceAdvisory)
+	return result
 }
 
 func (s *Session) delegateActor(ctx context.Context) (delegateActor, error) {

--- a/agent/delegate_shared_workspace_test.go
+++ b/agent/delegate_shared_workspace_test.go
@@ -1,0 +1,184 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"primeradiant.com/serf/agent/internal/delegatestore"
+	"primeradiant.com/serf/llm"
+)
+
+// sharedWorkspaceBarrierAdapter parks every model request until it is released,
+// so a delegate launched in the background is observably RUNNING while the test
+// launches the next one. Entries are buffered and sent non-blocking: a second
+// parked child must not deadlock behind an undrained observation channel.
+type sharedWorkspaceBarrierAdapter struct {
+	entered chan string
+	release chan struct{}
+	once    sync.Once
+}
+
+func newSharedWorkspaceBarrierAdapter() *sharedWorkspaceBarrierAdapter {
+	return &sharedWorkspaceBarrierAdapter{
+		entered: make(chan string, 8),
+		release: make(chan struct{}),
+	}
+}
+
+func (a *sharedWorkspaceBarrierAdapter) Name() string { return "openai" }
+
+func (a *sharedWorkspaceBarrierAdapter) Complete(ctx context.Context, request llm.Request) (llm.Response, error) {
+	select {
+	case a.entered <- request.SessionID:
+	default:
+	}
+	select {
+	case <-a.release:
+	case <-ctx.Done():
+		return llm.Response{}, ctx.Err()
+	}
+	return llm.Response{Provider: "openai", Model: request.Model, Message: llm.Assistant("done")}, nil
+}
+
+func (a *sharedWorkspaceBarrierAdapter) Stream(context.Context, llm.Request) (llm.Stream, error) {
+	return nil, llm.ErrStreamUnsupported
+}
+
+func (a *sharedWorkspaceBarrierAdapter) releaseRuns() { a.once.Do(func() { close(a.release) }) }
+
+func (a *sharedWorkspaceBarrierAdapter) awaitRun(t *testing.T) {
+	t.Helper()
+	select {
+	case <-a.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("delegate never reached its first model request")
+	}
+}
+
+// TestSharedWorkspaceDelegateWarning covers the advisory's trigger table: it
+// fires only when a NEW non-isolated delegate would join a RUNNING non-isolated
+// sibling already working in the same directory.
+func TestSharedWorkspaceDelegateWarning(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name               string
+		requestedIsolation string
+		existingDelegate   bool
+		existingIsolation  string
+		existingElsewhere  bool
+		existingRunning    bool
+		existingDriving    bool
+		wantWarning        bool
+	}{
+		{name: "first shared delegate", wantWarning: false},
+		{name: "second shared delegate in the same directory", existingDelegate: true, existingRunning: true, wantWarning: true},
+		{name: "existing shared delegate is mid drive-down turn", existingDelegate: true, existingDriving: true, wantWarning: true},
+		{name: "new delegate takes worktree isolation", requestedIsolation: "worktree", existingDelegate: true, existingRunning: true, wantWarning: false},
+		{name: "existing delegate is worktree isolated", existingDelegate: true, existingIsolation: "worktree", existingRunning: true, wantWarning: false},
+		{name: "existing shared delegate works elsewhere", existingDelegate: true, existingElsewhere: true, existingRunning: true, wantWarning: false},
+		{name: "existing shared delegate is idle", existingDelegate: true, wantWarning: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			parentDir := t.TempDir()
+			parent := newSession(t, withDir(parentDir), withoutGitSnapshot())
+			if tc.existingDelegate {
+				childDir := parentDir
+				if tc.existingElsewhere {
+					childDir = t.TempDir()
+				}
+				child := newSession(t, withDir(childDir), withoutGitSnapshot())
+				parent.subagents.track(&subagent{
+					id:               child.id,
+					sess:             child,
+					stableDescriptor: &delegatestore.Descriptor{Isolation: tc.existingIsolation},
+					running:          tc.existingRunning,
+					driving:          tc.existingDriving,
+				})
+			}
+
+			warning := parent.sharedWorkspaceDelegateWarning(tc.requestedIsolation)
+			if !tc.wantWarning {
+				if warning != "" {
+					t.Fatalf("sharedWorkspaceDelegateWarning = %q, want no advisory", warning)
+				}
+				return
+			}
+			for _, want := range []string{parentDir, `isolation="worktree"`, "shared workspace"} {
+				if !strings.Contains(warning, want) {
+					t.Fatalf("warning missing %q: %q", want, warning)
+				}
+			}
+		})
+	}
+}
+
+// TestSharedWorkspaceDelegateWarning_ClosedDelegateIsNotRunning proves the
+// advisory reads live children only: a torn-down record retained as terminal
+// history must not make a fresh delegate look like a collision.
+func TestSharedWorkspaceDelegateWarning_ClosedDelegateIsNotRunning(t *testing.T) {
+	t.Parallel()
+	parentDir := t.TempDir()
+	parent := newSession(t, withDir(parentDir), withoutGitSnapshot())
+	child := newSession(t, withDir(parentDir), withoutGitSnapshot())
+	parent.subagents.track(&subagent{id: child.id, sess: child, running: true, closed: true})
+
+	if warning := parent.sharedWorkspaceDelegateWarning(""); warning != "" {
+		t.Fatalf("closed delegate produced advisory %q", warning)
+	}
+}
+
+// TestCreateDelegateSharedWorkspaceAdvisory drives the real create path: the
+// second concurrently running shared delegate still launches and carries exactly
+// one advisory, and the first one carries none.
+func TestCreateDelegateSharedWorkspaceAdvisory(t *testing.T) {
+	root, client, _ := newDelegateResourceBootstrapSession(t)
+	adapter := newSharedWorkspaceBarrierAdapter()
+	client.Register(adapter)
+	t.Cleanup(adapter.releaseRuns)
+
+	first := root.createDelegate(context.Background(), delegateArgs{Task: "hold the shared workspace"})
+	if first.Err != nil || first.DelegateID == "" {
+		t.Fatalf("first delegate did not launch: %+v", first)
+	}
+	if len(first.Warnings) != 0 {
+		t.Fatalf("first shared delegate warned: %q", first.Warnings)
+	}
+	adapter.awaitRun(t)
+
+	second := root.createDelegate(context.Background(), delegateArgs{Task: "join the shared workspace"})
+	if second.Err != nil || second.DelegateID == "" {
+		t.Fatalf("advisory blocked delegate launch: %+v", second)
+	}
+	if len(second.Warnings) != 1 {
+		t.Fatalf("second delegate warnings = %q, want exactly one advisory", second.Warnings)
+	}
+	for _, want := range []string{root.currentEnv().WorkingDirectory(), `isolation="worktree"`, "shared workspace"} {
+		if !strings.Contains(second.Warnings[0], want) {
+			t.Fatalf("warning missing %q: %q", want, second.Warnings[0])
+		}
+	}
+	adapter.awaitRun(t)
+
+	// The tool projection must surface the advisory to the model, once.
+	raw, err := stableDelegateCreateTool(context.Background(), root, map[string]any{"task": "third in the shared workspace"}, 8192)
+	if err != nil {
+		t.Fatalf("delegate tool: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		t.Fatalf("unmarshal delegate result: %v (%s)", err, raw)
+	}
+	warnings, ok := decoded["warnings"].([]any)
+	if !ok || len(warnings) != 1 {
+		t.Fatalf("delegate result warnings = %#v, want exactly one advisory (%s)", decoded["warnings"], raw)
+	}
+	if text, ok := warnings[0].(string); !ok || !strings.Contains(text, "shared workspace") {
+		t.Fatalf("delegate result warning = %#v, want the shared-workspace advisory", warnings[0])
+	}
+}

--- a/agent/prompts/sections/context-management.md.tmpl
+++ b/agent/prompts/sections/context-management.md.tmpl
@@ -1,0 +1,7 @@
+## Context management
+
+{{ if .HasTool "compact_context" }}After completing and reporting a task, and especially after a large
+implementation or review, consider `compact_context` before unrelated work.
+
+{{ end }}After two incomplete implement/review/fix cycles on the same task, stop repeating
+the loop. Report the evidence, reslice the task, or ask for direction.

--- a/agent/prompts/sections/verification.md
+++ b/agent/prompts/sections/verification.md
@@ -1,0 +1,11 @@
+## Verification
+
+A required gate counts as passed only when it actually ran and exited zero. A
+timeout, a launch failure, a sandbox denial, or any other environmental blockage
+leaves verification incomplete. Report the exact condition and its evidence
+rather than a broad green status.
+
+Before you change production behavior, prove whether a failure belongs to the
+product or is a fixture or environment failure. When the parent has an
+environment the child lacked, the parent must rerun the decisive incomplete gate
+itself rather than accept an unverified child result.

--- a/agent/prompts/templates/subagent.md.tmpl
+++ b/agent/prompts/templates/subagent.md.tmpl
@@ -28,6 +28,10 @@ is missing and, when it is obvious from the task, what kind of agent or tool wou
 be better suited.
 {{ end }}
 
+{{ section "verification" }}
+
+{{ section "context-management" }}
+
 {{ section "communicate" }}
 {{ end }}
 

--- a/agent/prompts/templates/system.md.tmpl
+++ b/agent/prompts/templates/system.md.tmpl
@@ -19,6 +19,10 @@
 
 {{ section "task-tracking" }}
 
+{{ section "verification" }}
+
+{{ section "context-management" }}
+
 {{ section "communicate" }}
 
 {{ if .HasAskUser }}

--- a/agent/section_resolver_test.go
+++ b/agent/section_resolver_test.go
@@ -873,3 +873,117 @@ func TestSectionResolver_DiskOverrideBeatsEmbeddedTemplate(t *testing.T) {
 		t.Fatalf("section = %q, want the disk override to win over the embedded .md.tmpl", got)
 	}
 }
+
+// postureSectionResolver builds an embedded-only resolver for the orchestration
+// posture sections, which carry no provider or agent variants.
+func postureSectionResolver(agent string) *sectionResolver {
+	return &sectionResolver{
+		provider: "openai",
+		agent:    agent,
+		agentFS:  bundled.Agents(),
+		sources:  []sectionSource{embedSource{fs: embeddedPrompts, prefix: "prompts/sections/"}},
+	}
+}
+
+// TestVerificationSectionDefinesIncompleteGates pins the verification posture:
+// a gate counts only when it ran and exited zero, everything else is reported as
+// incomplete with its exact condition, and the parent reruns what the child
+// could not.
+func TestVerificationSectionDefinesIncompleteGates(t *testing.T) {
+	t.Parallel()
+	section := postureSectionResolver("coordinator").Section("verification", promptData{Provider: "openai", Agent: "coordinator"})
+	for _, want := range []string{
+		"actually ran and exited zero", "timeout", "launch failure", "sandbox denial",
+		"environmental blockage", "verification incomplete", "fixture or environment failure",
+		"rerun the decisive incomplete gate",
+	} {
+		if !strings.Contains(section, want) {
+			t.Fatalf("verification section missing %q: %s", want, section)
+		}
+	}
+}
+
+// TestContextManagementSectionIsAdvisoryAndBounded pins the context-management
+// posture: compaction is a suggestion at a task boundary, and a stalled
+// implement/review/fix loop stops after two cycles instead of repeating.
+func TestContextManagementSectionIsAdvisoryAndBounded(t *testing.T) {
+	t.Parallel()
+	section := postureSectionResolver("coordinator").Section("context-management", promptData{
+		Provider: "openai", Agent: "coordinator",
+		CallableTools: map[string]bool{"compact_context": true},
+	})
+	for _, want := range []string{
+		"After completing and reporting a task", "compact_context", "before unrelated work",
+		"two incomplete implement/review/fix cycles", "Report the evidence", "reslice", "ask for direction",
+	} {
+		if !strings.Contains(section, want) {
+			t.Fatalf("context-management section missing %q: %s", want, section)
+		}
+	}
+}
+
+// TestContextManagementSection_SilentAboutAnUncallableCompactTool applies the
+// tool-mention rule (ruled 2026-08-06) to this section: a session without
+// compact_context keeps the stop rule and loses only the tool suggestion.
+func TestContextManagementSection_SilentAboutAnUncallableCompactTool(t *testing.T) {
+	t.Parallel()
+	section := postureSectionResolver("explorer").Section("context-management", promptData{Provider: "openai", Agent: "explorer"})
+	if strings.Contains(section, "compact_context") {
+		t.Fatalf("context-management section names a tool this session cannot call: %s", section)
+	}
+	if !strings.Contains(section, "two incomplete implement/review/fix cycles") {
+		t.Fatalf("tool-free context-management section lost its tool-independent guidance: %s", section)
+	}
+}
+
+// TestOrchestrationPostureTemplateInclusion checks where the posture lands: both
+// master templates carry verification and context management, and a leaf child
+// gets them without the delegation guidance it cannot act on.
+func TestOrchestrationPostureTemplateInclusion(t *testing.T) {
+	t.Parallel()
+	data := func(canDelegate bool) promptData {
+		return promptData{
+			Provider:       "openai",
+			Agent:          "coordinator",
+			WorkingDir:     "/tmp/test",
+			Model:          "gpt-5.4",
+			ResultToolName: "communicate",
+			CallableTools:  map[string]bool{"compact_context": true},
+			CanDelegate:    canDelegate,
+		}
+	}
+	posture := []string{"## Verification", "## Context management"}
+
+	root, _, err := postureSectionResolver("coordinator").RenderEmbedded(embeddedPrompts, "prompts/templates/", "system", data(true))
+	if err != nil {
+		t.Fatalf("render system: %v", err)
+	}
+	for _, marker := range append([]string{"## Delegation"}, posture...) {
+		if !strings.Contains(root, marker) {
+			t.Errorf("root prompt missing %q", marker)
+		}
+	}
+
+	leaf, _, err := postureSectionResolver("coordinator").RenderEmbedded(embeddedPrompts, "prompts/templates/", "subagent", data(false))
+	if err != nil {
+		t.Fatalf("render subagent: %v", err)
+	}
+	for _, marker := range posture {
+		if !strings.Contains(leaf, marker) {
+			t.Errorf("leaf child prompt missing %q", marker)
+		}
+	}
+	if strings.Contains(leaf, "## Delegation") {
+		t.Error("leaf child prompt should not contain the delegation section")
+	}
+
+	delegating, _, err := postureSectionResolver("coordinator").RenderEmbedded(embeddedPrompts, "prompts/templates/", "subagent", data(true))
+	if err != nil {
+		t.Fatalf("render delegating subagent: %v", err)
+	}
+	for _, marker := range append([]string{"## Delegation"}, posture...) {
+		if !strings.Contains(delegating, marker) {
+			t.Errorf("delegating child prompt missing %q", marker)
+		}
+	}
+}

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -466,6 +466,52 @@ func (s *Session) collectLiveShellsUnderTree(target string, out *[]string) {
 	}
 }
 
+// sharedWorkspaceDelegateWarning returns a non-blocking advisory when a new
+// non-isolated delegate would join a running non-isolated sibling already
+// working in this session's directory. The caller's isolation choice stays
+// authoritative: this inspects no files, takes no locks beyond the
+// manager-then-leaf discipline liveDirectSubagents already follows, creates no
+// worktree, and never blocks the spawn.
+//
+// A delegate's working directory is not a caller-supplied parameter: a delegate
+// either shares its parent's current directory or gets its own worktree lane, so
+// the only comparison is the parent's live working directory against each live
+// child's — which is also what catches a child that re-rooted itself.
+func (s *Session) sharedWorkspaceDelegateWarning(requestedIsolation string) string {
+	if s == nil || s.subagents == nil || strings.TrimSpace(requestedIsolation) != "" {
+		return ""
+	}
+	parentEnv := s.currentEnv()
+	if parentEnv == nil {
+		return ""
+	}
+	parentDir := parentEnv.WorkingDirectory()
+	target := canonicalOrClean(parentDir)
+	for _, sub := range s.liveDirectSubagents() {
+		sub.mu.Lock()
+		active := sub.running || sub.driving
+		isolation := ""
+		if sub.stableDescriptor != nil {
+			isolation = sub.stableDescriptor.Isolation
+		}
+		sub.mu.Unlock()
+		if !active || strings.TrimSpace(isolation) != "" {
+			continue
+		}
+		env := sub.sess.currentEnv()
+		if env != nil && canonicalOrClean(env.WorkingDirectory()) == target {
+			// Name the directory the way the caller knows it, not its canonical
+			// form: the comparison resolves symlinks, the advisory does not.
+			return fmt.Sprintf(
+				"shared workspace %q already has a running delegate; this delegate will still launch, "+
+					"but consider isolation=\"worktree\" to avoid file, report, branch, and Git-state collisions",
+				parentDir,
+			)
+		}
+	}
+	return ""
+}
+
 func (s *Session) spawnAgent(ctx context.Context, task, model, workingDir string, maxTurns int, agentType string, reasoningEffort string, parentTasks []taskpkg.TaskTemplate, grantTools []string) (any, error) {
 	selection, err := s.selectSubagentModel(ctx, model, agentType)
 	if err != nil {

--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -370,10 +370,13 @@ tools that default to deny.)
 `--sandbox-net off` governs the **tool plane**:
 
 - **Model-authored** spawned processes (the shell, `rg`, hook commands) get
-  `--unshare-net` — no network interfaces at all, so no TCP, UDP, or DNS. MCP server
-  subprocesses are the one exception: see "Hooks and MCP under a sandbox" below —
-  they are trusted infrastructure, not model-directed egress, and net=off does not
-  sever them (ruled by Jesse 2026-08-07, kata 83pm).
+  `--unshare-net` — no network interfaces at all, so no TCP, UDP, DNS, **or
+  loopback**. Loopback is the sharp edge: `net=off` may break tests that start or
+  connect to a local network server, which is why the `delegate` tool's
+  `sandbox_net` description says so up front. MCP server subprocesses are the one
+  exception: see "Hooks and MCP under a sandbox" below — they are trusted
+  infrastructure, not model-directed egress, and net=off does not sever them
+  (ruled by Jesse 2026-08-07, kata 83pm).
 - Serf-process tool egress — `web_fetch` and `web_search` — is disabled with a
   legible error. These are model-directed egress and stay refused under net=off
   regardless of the kata 83pm MCP carve-out.


### PR DESCRIPTION
fixes #108

The split-out remainder of tracker #20's project 5 (per-session scratch and
orchestration posture), plus a five-line doc residual from closed #19.

## Shared-workspace delegate advisory

`Session.sharedWorkspaceDelegateWarning` returns one non-blocking advisory when
a new non-isolated delegate would join a running non-isolated sibling already
working in the parent's directory. Nothing is blocked, no worktree is created,
no file is inspected, and the advisory is not persisted in the job record or
replayed on a later `delegate_send`.

Three adaptations from the plan's specification, which predates the
stable-delegate rework:

| Plan | Shipped | Why |
| --- | --- | --- |
| `sharedWorkspaceDelegateWarning(requestedIsolation, workingDir)` | drops `workingDir` | `delegate` has no working-directory parameter; a delegate either shares the parent's current directory or takes a worktree lane. The comparison is the parent's live working directory against each live child's, which also catches a child that re-rooted itself. |
| new immutable `subagent.isolation` field | `subagent.stableDescriptor.Isolation` | The committed identity already carries it, read under the same leaf lock, so a resumed worktree delegate is not misclassified as shared. |
| new singular `Warning` / `warning` field | existing `Warnings` / `warnings` | Delegate results already have a plural warnings channel that reaches the model; a singular sibling would duplicate it. |

## Posture prompt sections

`verification.md` and `context-management.md.tmpl`, wired into both master
templates after the workflow/delegation guidance and before the submission
contract, so a leaf child receives them without the delegation section it
cannot act on.

One adaptation: `context-management` names `compact_context`, so it is a
`.md.tmpl` that gates that sentence on `.HasTool "compact_context"`, per the
rule that a canned instruction never names a tool the session cannot call
(ruled 2026-08-06, after the plan was written). A session without the tool
keeps the two-cycle stop rule. The plan's own substring assertions did not
match the prose it prescribed ("rerun" vs "reruns", sentence-case openings), so
the tests assert the semantic clauses against the wording actually shipped.

## Doc residual

`docs/sandboxing.md` listed TCP, UDP, and DNS under `--sandbox-net off` and
stopped there. It now names loopback and the consequence — tests that start or
connect to a local network server break — matching the `sandbox_net` tool
description that has said so since #19.

## Out of scope

The plan's task 6 also appends isolation-choice guidance to `delegation.md`;
that is not in #108's scope and is still absent.

## Verification

- `go test ./agent/... -race -short -count=1` — pass
- `go test ./... -short -count=1` — pass
- `golangci-lint run ./...` from `agent/` — 0 issues

Red-first evidence: the delegate tests failed to compile on the missing helper;
the four prompt tests failed on empty sections and missing template markers.

Claude-Session: https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU