### PR TITLE
scripts: give e2e-ratelimited-provider --stop its sibling's marker gate

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -79,9 +79,12 @@ directory is named `<prefix>.$$`, the trap is armed before `mkdir` so a
 signal in the window abandons nothing, and the next run reclaims
 leftovers whose pid suffix no longer answers `kill -0`
 (scripts/covscratch-lib.sh). Every remaining variable-fed recursive
-delete in scripts/ lives on
-`TestNoScriptFeedsVariableToRecursiveDelete`'s count-pinned list with the
-reason it is allowed to exist, and the list only shrinks.
+delete in the repository's shell — scripts/ and the repo-root
+install.sh — lives on `TestNoScriptFeedsVariableToRecursiveDelete`'s
+count-pinned list with the reason it is allowed to exist. Some entries
+are permanent by design (the two sanctioned patterns' own deletes); the
+list grows only with an explicitly reviewed reason and shrinks as
+scripts convert or retire.
 
 Two parts of the rule the audit cannot hold, which is why it is written
 here for people. Its scan is textual and per-line, so four equally banned

--- a/scripts/e2e-ratelimited-provider.sh
+++ b/scripts/e2e-ratelimited-provider.sh
@@ -64,6 +64,16 @@ done
 # not re-derived, so --stop works from a fresh invocation with no shared
 # shell state.
 if [ -n "$stop_dir" ]; then
+	# The marker is checked FIRST, before a single file is read or a single
+	# signal is sent. --stop takes a path from the caller, and the marker is
+	# the one thing that distinguishes "a run of ours" from a typo pointing
+	# at something that matters — so a mistyped path that happens to hold a
+	# fake429.pid or a hub.pid must lose nothing at all, not just escape the
+	# deletion at the end.
+	if [ ! -f "$stop_dir/.e2e-ratelimited-provider" ]; then
+		echo "e2e-ratelimited-provider: $stop_dir is not one of this script's run directories (no .e2e-ratelimited-provider marker); not touching it" >&2
+		exit 2
+	fi
 	for pidfile in "$stop_dir/fake429.pid" "$stop_dir/hub.pid"; do
 		[ -f "$pidfile" ] || continue
 		pid="$(cat "$pidfile")"
@@ -87,6 +97,7 @@ fi
 # this script) cannot collide with each other or with a real hub — the same
 # reasoning docs/agentic-testing.md's setup checklist uses.
 run="$(mktemp -d -t serf-e2e-fake429.XXXXXX)"
+touch "$run/.e2e-ratelimited-provider" # the marker --stop refuses to delete without
 echo "e2e-ratelimited-provider: run directory $run" >&2
 
 echo "==> building fake429, serf, serf-hub, serf-tui" >&2


### PR DESCRIPTION
Lands the two review findings from #102's adversarial re-review that were still live after the merge (F2/F3 were already fixed on main by 3a0641b92).

**F1 (major): `e2e-ratelimited-provider.sh --stop` deletes whatever path it is handed.** The delete audit's shared reason claimed both e2e harnesses check a marker before their `--stop` delete; only the sibling did. Start now writes `.e2e-ratelimited-provider` into the run directory, and `--stop` refuses with exit 2 — before a single signal or delete — when the marker is absent. Same shape and voice as `e2e-webui-turn-controls.sh:141-150`; the shared allowlist reason is now true of both files, so the audit needed no change (counts unchanged, all three audits green).

**F4: docs/testing.md rule 1 overclaimed for its list.** "Only shrinks" was already false (permanent by-design entries; the install.sh scan-widening grew it), and "in scripts/" missed the repo-root install.sh the audit now covers. Now reads: permanent-by-design entries exist, the list grows only with an explicitly reviewed reason and shrinks as scripts convert or retire, scope is the repository's shell.

**Verification.** Guard proven with decoys, never live targets: `--stop /nonexistent` exits 2 deleting nothing; a markerless decoy holding a pidfile survives with exit 2 and contents intact; a marker-ed decoy with a dead pidfile is removed with exit 0. Plus a real start→stop round-trip (isolated `$HOME`, kernel-assigned ports): fake429 + hub boot, marker present, `--stop` kills both pids and removes the run dir. Three script audits green; dev-tooling wave 21/21; `make merge-approval-gate` green in a clean /tmp worktree, home canary 32 before and after. (First gate attempt redded on `could not import strconv ... go-build/...: no such file or directory` — a GOCACHE prune mid-run, environmental; the identical tree built clean and passed the full gate on the isolated re-run.)
