### PR TITLE
docs(prompts): say when a delegate should take a worktree lane

### DIFF
--- a/agent/prompts/sections/delegation.md
+++ b/agent/prompts/sections/delegation.md
@@ -54,3 +54,12 @@ never `git add -A` or `git add .` — so an unrelated dirty worktree can't end u
 in the commit. The subagent must report the commands run, test results, staged
 files, commit hash, pushed remote/branch, and final status. The parent must
 still verify the resulting repository state before reporting success.
+
+By default a delegate shares your working directory. That is right for
+read-only work: scouting, research, review, verification that only reads. Give
+a delegate `isolation="worktree"` (its own branch-and-checkout lane) whenever
+its edits could collide with anyone else's: two or more delegates writing in
+parallel, or a writing delegate while you keep editing yourself. One writer at
+a time in a shared directory is fine. Worktree lanes need a local git checkout;
+retire a lane with `manage_worktree` dispose when the delegate's work is merged
+or abandoned.


### PR DESCRIPTION
Closes the residual flagged in PR #114: the shared-workspace advisory suggests `isolation="worktree"` but the delegation prompt never explained when to prefer it.

The phrasing was chosen empirically per Jesse's suggestion: three candidate structures (rule-first prose, hazard-first, enumerated bullets) were each tested on Haiku and Sonnet subagents against six isolation-decision scenarios (read-only scout, parallel writers, writer-while-parent-edits, read-only reviewers, test-runner-while-idle, non-git directory). All three scored 6/6 on both models — the rule content survives any structure — so the tiebreak went to reasoning quality (this version's subjects cited the no-git-checkout constraint unprompted on the trick scenario) and prose fit with the section's voice.

Verified: full agent package `-race -short` green, including the bundled-prompt tool-mentions audit (the new text names `manage_worktree`, which delegating sessions serve).

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU