### PR TITLE
fix(serf-dev): review fixes for the agent-shards port (follow-up to #118)

### DIFF
--- a/cmd/serf-dev/agentshards.go
+++ b/cmd/serf-dev/agentshards.go
@@ -68,11 +68,6 @@ type shardsConfig struct {
 	stdout   io.Writer
 	stderr   io.Writer
 	signals  <-chan os.Signal
-	// handBackSignals returns the relayed signals to their default
-	// disposition, so a second one ends the process even while a shard is
-	// wedged. The script cleared its traps inside its first handler for
-	// exactly this reason.
-	handBackSignals func()
 }
 
 // runAgentShards is the subcommand entry: environment in, exit code out.
@@ -104,8 +99,6 @@ func runAgentShards(args []string) int {
 		stdout:   os.Stdout,
 		stderr:   os.Stderr,
 		signals:  signals,
-
-		handBackSignals: func() { signal.Stop(signals) },
 	})
 }
 
@@ -220,18 +213,20 @@ func runShards(cfg shardsConfig) int {
 				}
 				// A shard that ignores TERM would otherwise hold the run
 				// hostage forever: the wait for it never returns, and while
-				// signals are relayed here nothing takes their default
-				// action. Hand them back and re-raise, the way the script's
-				// first handler cleared its traps so the next Ctrl-C landed.
-				// The scratch directory stays on disk as the record.
+				// signals are relayed to this channel none of them takes its
+				// default action. So the second one leaves immediately, with
+				// the same 128+signal code the first would have exited on,
+				// and says where the logs it is abandoning are — os.Exit
+				// runs no deferred cleanup, so the scratch directory stays
+				// on disk as the record.
+				//
+				// The script got here by clearing its traps in the first
+				// handler and letting the next signal kill the shell.
+				// signal.Stop plus a re-raise is the direct translation and
+				// was tried; the re-raised signal does not reliably take the
+				// default action before the process continues, so this exits
+				// under its own power instead.
 				_, _ = fmt.Fprintf(cfg.stderr, "agent-shards: %s again — abandoning the running shards; logs: %s\n", signalNames[s], logdir)
-				if cfg.handBackSignals != nil {
-					cfg.handBackSignals()
-				}
-				_ = syscall.Kill(os.Getpid(), s)
-				// Re-raising is a no-op for a signal this process inherited
-				// as ignored (a HUP under nohup, say), and being deaf is the
-				// bug being fixed, so leave under our own power instead.
 				os.Exit(128 + int(s))
 			}
 		}()

--- a/cmd/serf-dev/agentshards.go
+++ b/cmd/serf-dev/agentshards.go
@@ -12,7 +12,13 @@ package main
 //
 //	AGENT_SHARD_COUNT      number of shards (default 4)
 //	AGENT_SHARD_PARALLEL   -parallel within each shard (default 3)
-//	AGENT_SHARD_SKIP       regex of tests to skip in every shard
+//	AGENT_SHARD_SKIP       regex handed to the SURVEY's -test.skip, and only
+//	                       to it: a skipped test draws no cost line, so it
+//	                       lands in no shard. The shards themselves never
+//	                       receive the flag, so on a cache hit or under
+//	                       AGENT_SHARD_NO_SURVEY the variable does nothing at
+//	                       all. The script behaved the same way; pinned by
+//	                       TestAgentShardsSkipOnlyReachesTheSurvey.
 //	AGENT_SHARD_NO_SURVEY  1 = ignore the cache and weight every test equally
 //	AGENT_SHARD_RESURVEY   1 = force the survey to re-run even on a cache hit
 //	AGENT_SHARD_CACHE_DIR  survey cache (default $(go env GOCACHE)/serf-agent-shards)
@@ -62,6 +68,11 @@ type shardsConfig struct {
 	stdout   io.Writer
 	stderr   io.Writer
 	signals  <-chan os.Signal
+	// handBackSignals returns the relayed signals to their default
+	// disposition, so a second one ends the process even while a shard is
+	// wedged. The script cleared its traps inside its first handler for
+	// exactly this reason.
+	handBackSignals func()
 }
 
 // runAgentShards is the subcommand entry: environment in, exit code out.
@@ -76,7 +87,9 @@ func runAgentShards(args []string) int {
 		_, _ = fmt.Fprintf(os.Stderr, "agent-shards: %v\n", err)
 		return 1
 	}
-	signals := make(chan os.Signal, 1)
+	// Two deep, because a second signal must be waiting when the first is
+	// still being handled.
+	signals := make(chan os.Signal, 2)
 	signal.Notify(signals, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(signals)
 	return runShards(shardsConfig{
@@ -91,6 +104,8 @@ func runAgentShards(args []string) int {
 		stdout:   os.Stdout,
 		stderr:   os.Stderr,
 		signals:  signals,
+
+		handBackSignals: func() { signal.Stop(signals) },
 	})
 }
 
@@ -115,6 +130,13 @@ func envFlag(name string) bool {
 
 // interrupter tracks live shard process groups and, on the first signal,
 // explains the interruption and TERMs every group so in-flight waits return.
+//
+// The Setpgid-here, TERM-the-negated-pgid-there pair is the same two lines
+// cmd/serf-test-dev-tooling/wave_unix.go uses on its suites, spelled twice on
+// purpose: each tool is a port of a different script and is checked for
+// parity against that script, not against its sibling. Two lines of overlap
+// buy less than a shared home would cost right now; the third caller is the
+// one to build it for.
 type interrupter struct {
 	mu     sync.Mutex
 	pgids  []int
@@ -184,16 +206,34 @@ func runShards(cfg shardsConfig) int {
 	in := &interrupter{}
 	if cfg.signals != nil {
 		go func() {
-			sig, ok := <-cfg.signals
-			if !ok {
-				return
+			first := true
+			for sig := range cfg.signals {
+				s, isSyscall := sig.(syscall.Signal)
+				if !isSyscall {
+					s = syscall.SIGTERM
+				}
+				if first {
+					first = false
+					_, _ = fmt.Fprintf(cfg.stderr, "agent-shards: interrupted by %s\n", signalNames[s])
+					in.interrupt(s)
+					continue
+				}
+				// A shard that ignores TERM would otherwise hold the run
+				// hostage forever: the wait for it never returns, and while
+				// signals are relayed here nothing takes their default
+				// action. Hand them back and re-raise, the way the script's
+				// first handler cleared its traps so the next Ctrl-C landed.
+				// The scratch directory stays on disk as the record.
+				_, _ = fmt.Fprintf(cfg.stderr, "agent-shards: %s again — abandoning the running shards; logs: %s\n", signalNames[s], logdir)
+				if cfg.handBackSignals != nil {
+					cfg.handBackSignals()
+				}
+				_ = syscall.Kill(os.Getpid(), s)
+				// Re-raising is a no-op for a signal this process inherited
+				// as ignored (a HUP under nohup, say), and being deaf is the
+				// bug being fixed, so leave under our own power instead.
+				os.Exit(128 + int(s))
 			}
-			s, isSyscall := sig.(syscall.Signal)
-			if !isSyscall {
-				s = syscall.SIGTERM
-			}
-			_, _ = fmt.Fprintf(cfg.stderr, "agent-shards: interrupted by %s\n", signalNames[s])
-			in.interrupt(s)
 		}()
 	}
 
@@ -321,7 +361,7 @@ func runShards(cfg shardsConfig) int {
 		}()
 	}
 
-	fail := launchFailed
+	var failed []int
 	for i, result := range results {
 		if result == nil {
 			continue
@@ -331,21 +371,31 @@ func runShards(cfg shardsConfig) int {
 			_, _ = fmt.Fprintf(cfg.stdout, "PASS  agent:%-2d %8s (%d tests)\n", i, fmt.Sprintf("%.2fs", r.seconds), len(bins[i]))
 		} else {
 			_, _ = fmt.Fprintf(cfg.stdout, "FAIL  agent:%-2d\n", i)
-			fail = true
+			failed = append(failed, i)
 		}
 	}
+	fail := launchFailed || len(failed) > 0
 	if code := in.exitCode(); code != 0 {
 		return code
 	}
 
 	if fail {
-		_, _ = fmt.Fprintln(cfg.stdout)
-		_, _ = fmt.Fprintln(cfg.stdout, "=== failing shard output ===")
-		for i := range bins {
-			log := filepath.Join(logdir, fmt.Sprintf("shard%d.log", i))
-			if fileMatches(log, shardRedLine) {
+		// Replay by verdict, never by matching failure markers in the log. A
+		// shard can fail with no `go test` marker anywhere in its output — a
+		// build error, an os.Exit, a killed process — and marker matching
+		// dropped exactly those, leaving the verdicts with the most to
+		// explain with nothing behind them (kata mjzx; run-module-tests.sh
+		// carries the same fix for the same reason). A shard that never
+		// started has no verdict and no log; its error is already on stderr.
+		if len(failed) > 0 {
+			_, _ = fmt.Fprintln(cfg.stdout)
+			_, _ = fmt.Fprintln(cfg.stdout, "=== failing shard output ===")
+			for _, i := range failed {
+				log := filepath.Join(logdir, fmt.Sprintf("shard%d.log", i))
 				_, _ = fmt.Fprintf(cfg.stdout, "----- agent:%d -----\n", i)
-				copyFileTo(cfg.stdout, log)
+				if !copyFileTo(cfg.stdout, log) {
+					_, _ = fmt.Fprintf(cfg.stdout, "(no output captured: %s is empty or missing)\n", log)
+				}
 			}
 		}
 		_, _ = fmt.Fprintln(cfg.stdout)
@@ -356,13 +406,11 @@ func runShards(cfg shardsConfig) int {
 	return 0
 }
 
-// The two red-line shapes the script grepped for, kept separate the way it
-// kept them: the survey excerpt never matched a bare FAIL summary line, the
-// failing-shard replay did.
-var (
-	surveyRedLine = regexp.MustCompile(`^(--- FAIL|panic:)`)
-	shardRedLine  = regexp.MustCompile(`^(FAIL|--- FAIL|panic:)`)
-)
+// surveyRedLine is the excerpt grep the script used when the survey pass came
+// back red. The survey has no per-shard verdict to sort by — it is one pass
+// over the whole suite whose log is pointed at in full — so the excerpt stays
+// a grep here.
+var surveyRedLine = regexp.MustCompile(`^(--- FAIL|panic:)`)
 
 // cachedSurveyPath resolves the survey cache file for this test set, or ""
 // when there is nowhere to cache. Cache trouble is never fatal — it only
@@ -425,14 +473,6 @@ func fileHasContent(path string) bool {
 	return err == nil && info.Size() > 0
 }
 
-func fileMatches(path string, re *regexp.Regexp) bool {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return false
-	}
-	return slices.ContainsFunc(strings.Split(string(data), "\n"), re.MatchString)
-}
-
 // replayMatching writes up to limit matching lines from a log, the script's
 // `grep | head` diagnostic excerpt.
 func replayMatching(w io.Writer, path string, re *regexp.Regexp, limit int) {
@@ -452,10 +492,13 @@ func replayMatching(w io.Writer, path string, re *regexp.Regexp, limit int) {
 	}
 }
 
-func copyFileTo(w io.Writer, path string) {
+// copyFileTo writes a whole log to w and reports whether there was anything
+// to write: a verdict with an empty log behind it is worth saying out loud.
+func copyFileTo(w io.Writer, path string) bool {
 	data, err := os.ReadFile(path)
-	if err != nil {
-		return
+	if err != nil || len(data) == 0 {
+		return false
 	}
 	_, _ = w.Write(data)
+	return true
 }

--- a/cmd/serf-dev/agentshards_e2e_test.go
+++ b/cmd/serf-dev/agentshards_e2e_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 	"testing"
@@ -176,6 +177,109 @@ func TestAgentShardsFailingShardRetainsEvidence(t *testing.T) {
 	if err != nil || len(logs) != 2 {
 		t.Fatalf("retained dir holds %v, want two shard logs", logs)
 	}
+	if got, want := replayedShards(t, out), verdictShards(t, out, "FAIL"); !slices.Equal(got, want) {
+		t.Fatalf("replay block covered shards %v, want exactly the FAIL verdicts %v:\n%s", got, want, out)
+	}
+}
+
+// verdictShards returns the shard indices reported with a verdict, in the
+// order the run reported them.
+func verdictShards(t *testing.T, out, verdict string) []int {
+	t.Helper()
+	var shards []int
+	for line := range strings.SplitSeq(out, "\n") {
+		var shard int
+		if _, err := fmt.Sscanf(line, verdict+"  agent:%d", &shard); err == nil {
+			shards = append(shards, shard)
+		}
+	}
+	return shards
+}
+
+// replayedShards returns the shard indices whose logs appear under the
+// failing-shard banner, in order.
+func replayedShards(t *testing.T, out string) []int {
+	t.Helper()
+	_, block, found := strings.Cut(out, "=== failing shard output ===")
+	if !found {
+		return nil
+	}
+	var shards []int
+	for line := range strings.SplitSeq(block, "\n") {
+		var shard int
+		if _, err := fmt.Sscanf(line, "----- agent:%d -----", &shard); err == nil {
+			shards = append(shards, shard)
+		}
+	}
+	return shards
+}
+
+// shardHolding reports which shard was assigned a test, read from the names
+// files the run left in its scratch directory.
+func shardHolding(t *testing.T, logdir, test string) int {
+	t.Helper()
+	names, err := filepath.Glob(filepath.Join(logdir, "shard*.names"))
+	if err != nil || len(names) == 0 {
+		t.Fatalf("no shard names files in %s: %v", logdir, err)
+	}
+	for _, file := range names {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("reading %s: %v", file, err)
+		}
+		if !slices.Contains(strings.Fields(string(data)), test) {
+			continue
+		}
+		var shard int
+		if _, err := fmt.Sscanf(filepath.Base(file), "shard%d.names", &shard); err != nil {
+			t.Fatalf("parsing shard index from %s: %v", file, err)
+		}
+		return shard
+	}
+	t.Fatalf("no shard was assigned %s (files: %v)", test, names)
+	return -1
+}
+
+// TestAgentShardsReplayIsByVerdictNotMarker pins both directions of the
+// failing-shard replay. A shard can fail with no `go test` marker anywhere in
+// its log — a build error, an os.Exit, an OOM kill — and selecting logs by
+// marker dropped exactly the verdicts with the most to explain (kata mjzx,
+// fixed in run-module-tests.sh for the same reason). The other direction
+// matters just as much: a green shard whose output happens to start a line
+// with FAIL must stay out of the block.
+func TestAgentShardsReplayIsByVerdictNotMarker(t *testing.T) {
+	cfg, stdout, stderr, tmp := e2eConfig(t)
+	cfg.noSurvey = true
+	t.Setenv("SHARD_FIXTURE_EXIT", "beta")
+	t.Setenv("SHARD_FIXTURE_NOISE", "1")
+
+	rc := runShards(cfg)
+	if rc != 1 {
+		t.Fatalf("markerless failure rc = %d, want 1\nstdout:\n%s\nstderr:\n%s", rc, stdout, stderr)
+	}
+	out := stdout.String()
+	failed := verdictShards(t, out, "FAIL")
+	if len(failed) != 1 {
+		t.Fatalf("expected exactly one FAIL verdict, got %v:\n%s", failed, out)
+	}
+	if got := replayedShards(t, out); !slices.Equal(got, failed) {
+		t.Fatalf("replay block covered shards %v, want exactly the FAIL verdicts %v:\n%s", got, failed, out)
+	}
+	if !strings.Contains(out, "fixture-beta exiting hard") {
+		t.Fatalf("the markerless failure's own output was not replayed:\n%s", out)
+	}
+
+	left := scratchLeftovers(t, tmp)
+	if len(left) != 1 {
+		t.Fatalf("markerless failure retained %v, want exactly one scratch dir", left)
+	}
+	noisy := shardHolding(t, left[0], "TestFixtureGamma")
+	if noisy == failed[0] {
+		t.Fatalf("fixture partition put the noisy test in the failing shard (%d); this run cannot pin green exclusion", noisy)
+	}
+	if strings.Contains(out, "fixture-gamma is green and only looks red") {
+		t.Fatalf("green shard %d was replayed because its output looks like a verdict:\n%s", noisy, out)
+	}
 }
 
 func TestAgentShardsRedSurveyFailsLoudly(t *testing.T) {
@@ -198,6 +302,32 @@ func TestAgentShardsRedSurveyFailsLoudly(t *testing.T) {
 	}
 	if len(scratchLeftovers(t, tmp)) != 1 {
 		t.Fatalf("red survey should retain its scratch for diagnosis")
+	}
+}
+
+// TestAgentShardsSkipOnlyReachesTheSurvey pins how far AGENT_SHARD_SKIP
+// actually reaches. The script only ever appended -test.skip to the survey
+// pass, and this port keeps that: skipping works by leaving a test out of the
+// cost table, so a run that does not survey does not skip. Fixing the wart —
+// threading the regex into the shard invocations and into the cache key —
+// means changing this pin with it.
+func TestAgentShardsSkipOnlyReachesTheSurvey(t *testing.T) {
+	t.Setenv("SHARD_FIXTURE_FAIL", "beta")
+
+	surveyed, stdout, stderr, _ := e2eConfig(t)
+	surveyed.skip = "^TestFixtureBeta$"
+	if rc := runShards(surveyed); rc != 0 {
+		t.Fatalf("surveyed run with the red test skipped: rc = %d, want 0\nstdout:\n%s\nstderr:\n%s", rc, stdout, stderr)
+	}
+
+	unsurveyed, stdout2, stderr2, _ := e2eConfig(t)
+	unsurveyed.skip = "^TestFixtureBeta$"
+	unsurveyed.noSurvey = true
+	if rc := runShards(unsurveyed); rc != 1 {
+		t.Fatalf("unsurveyed run: rc = %d, want 1 — AGENT_SHARD_SKIP reaches the shards now, so the interface comment and this pin are both stale\nstdout:\n%s\nstderr:\n%s", rc, stdout2, stderr2)
+	}
+	if !strings.Contains(stdout2.String(), "--- FAIL: TestFixtureBeta") {
+		t.Fatalf("the unsurveyed run failed for some reason other than the unskipped test:\n%s", stdout2)
 	}
 }
 
@@ -226,8 +356,9 @@ func buildSerfDev(t *testing.T) string {
 
 // startHeldRun starts the serf-dev binary against the fixture with one shard
 // held open, and returns the running command, the held test-binary pid, the
-// scratch TMPDIR, and the hold directory.
-func startHeldRun(t *testing.T) (*exec.Cmd, int, string, string) {
+// scratch TMPDIR, and the hold directory. extraEnv arms fixture behaviour in
+// the shard processes.
+func startHeldRun(t *testing.T, extraEnv ...string) (*exec.Cmd, int, string, string) {
 	t.Helper()
 	bin := buildSerfDev(t)
 	tmp := t.TempDir()
@@ -255,6 +386,7 @@ func startHeldRun(t *testing.T) (*exec.Cmd, int, string, string) {
 		"AGENT_SHARD_NO_SURVEY=1",
 		"AGENT_SHARD_CACHE_DIR="+filepath.Join(t.TempDir(), "cache"),
 	)
+	cmd.Env = append(cmd.Env, extraEnv...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Start(); err != nil {
@@ -282,6 +414,33 @@ func startHeldRun(t *testing.T) (*exec.Cmd, int, string, string) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
+}
+
+// awaitFile waits for a path to appear, failing with label if it never does.
+func awaitFile(t *testing.T, path, label string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s: %s never appeared", label, path)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// releaseHold unblocks a held shard by opening the write end of its FIFO.
+// Only safe while the shard is still reading: an open with no reader blocks.
+func releaseHold(t *testing.T, holdDir string) {
+	t.Helper()
+	fifo, err := os.OpenFile(filepath.Join(holdDir, "hold.fifo"), os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("opening hold fifo for release: %v", err)
+	}
+	_, _ = fifo.WriteString("x")
+	_ = fifo.Close()
 }
 
 func awaitPidGone(t *testing.T, pid int, label string) {
@@ -323,6 +482,69 @@ func TestAgentShardsSIGTERMExits143RetainsLogsReapsChildren(t *testing.T) {
 	awaitPidGone(t, heldPid, "held shard child after SIGTERM")
 }
 
+// TestAgentShardsSecondSignalEndsAWedgedRun pins the second Ctrl-C. A shard
+// that ignores TERM leaves the runner waiting on it forever; the script's
+// first handler cleared its traps, so the next signal took its default action
+// and ended the run. Relaying only one signal makes the runner deaf to every
+// signal after the first, and SIGKILL becomes the only way out.
+func TestAgentShardsSecondSignalEndsAWedgedRun(t *testing.T) {
+	cmd, heldPid, tmp, holdDir := startHeldRun(t, "SHARD_FIXTURE_IGNORE_TERM=1")
+
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("first SIGTERM: %v", err)
+	}
+	// The shard announcing the TERM it swallowed proves the runner handled
+	// the first signal and forwarded it, so the second is never mistaken for
+	// the first.
+	awaitFile(t, filepath.Join(holdDir, fmt.Sprintf("termed.%d", heldPid)),
+		"held shard never saw the runner's forwarded TERM")
+
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("second SIGTERM: %v", err)
+	}
+	// A deaf runner hangs here; the killer bounds the wait and its firing IS
+	// the failure.
+	killed := make(chan struct{})
+	killer := time.AfterFunc(20*time.Second, func() {
+		_ = cmd.Process.Signal(syscall.SIGKILL)
+		close(killed)
+	})
+	err := cmd.Wait()
+	timely := killer.Stop()
+	if !timely {
+		<-killed
+	}
+	// Whatever happened to the runner, the held shard is orphaned now: it
+	// ignores TERM, so KILL is what ends it.
+	_ = syscall.Kill(heldPid, syscall.SIGKILL)
+	awaitPidGone(t, heldPid, "held shard child after the run ended")
+	if !timely {
+		t.Fatalf("second SIGTERM did not end the runner; it had to be SIGKILLed after 20s (wait: %v)", err)
+	}
+
+	var exit *exec.ExitError
+	if !errors.As(err, &exit) {
+		t.Fatalf("second SIGTERM: runner exit = %v, want death by SIGTERM or exit 143", err)
+	}
+	status, ok := exit.Sys().(syscall.WaitStatus)
+	bySignal := ok && status.Signaled() && status.Signal() == syscall.SIGTERM
+	if !bySignal && exit.ExitCode() != 143 {
+		t.Fatalf("second SIGTERM: runner exit = %v, want death by SIGTERM or exit 143", err)
+	}
+	stderr := cmd.Stderr.(*bytes.Buffer).String()
+	if !strings.Contains(stderr, "interrupted by SIGTERM") {
+		t.Fatalf("first interruption not explained on stderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "SIGTERM again") {
+		t.Fatalf("second signal not explained on stderr:\n%s", stderr)
+	}
+	// The logs the first signal retained are still on disk for diagnosis.
+	want := filepath.Join(tmp, fmt.Sprintf("agent-test-shards.%d", cmd.Process.Pid))
+	if _, statErr := os.Stat(want); statErr != nil {
+		t.Fatalf("second-signal run's scratch %s not retained: %v", want, statErr)
+	}
+}
+
 func TestAgentShardsSIGKILLLeftoverIsReclaimedByNextRun(t *testing.T) {
 	cmd, heldPid, tmp, holdDir := startHeldRun(t)
 
@@ -338,12 +560,7 @@ func TestAgentShardsSIGKILLLeftoverIsReclaimedByNextRun(t *testing.T) {
 
 	// Release the orphaned held child (nothing reparents it once the runner
 	// is KILLed), and wait for it to be truly gone before reclaiming.
-	fifo, err := os.OpenFile(filepath.Join(holdDir, "hold.fifo"), os.O_WRONLY, 0)
-	if err != nil {
-		t.Fatalf("opening hold fifo for release: %v", err)
-	}
-	_, _ = fifo.WriteString("x")
-	_ = fifo.Close()
+	releaseHold(t, holdDir)
 	awaitPidGone(t, heldPid, "held shard child after release")
 
 	// The next run of the same tool — same TMPDIR, hold disarmed — reclaims

--- a/cmd/serf-dev/agentshards_e2e_test.go
+++ b/cmd/serf-dev/agentshards_e2e_test.go
@@ -523,13 +523,8 @@ func TestAgentShardsSecondSignalEndsAWedgedRun(t *testing.T) {
 	}
 
 	var exit *exec.ExitError
-	if !errors.As(err, &exit) {
-		t.Fatalf("second SIGTERM: runner exit = %v, want death by SIGTERM or exit 143", err)
-	}
-	status, ok := exit.Sys().(syscall.WaitStatus)
-	bySignal := ok && status.Signaled() && status.Signal() == syscall.SIGTERM
-	if !bySignal && exit.ExitCode() != 143 {
-		t.Fatalf("second SIGTERM: runner exit = %v, want death by SIGTERM or exit 143", err)
+	if !errors.As(err, &exit) || exit.ExitCode() != 143 {
+		t.Fatalf("second SIGTERM: runner exit = %v, want exit status 143", err)
 	}
 	stderr := cmd.Stderr.(*bytes.Buffer).String()
 	if !strings.Contains(stderr, "interrupted by SIGTERM") {

--- a/cmd/serf-dev/testdata/shardfixture/fixture_test.go
+++ b/cmd/serf-dev/testdata/shardfixture/fixture_test.go
@@ -1,12 +1,15 @@
 // Package shardfixture is the real test module serf-dev's agent-shards tests
-// run: a handful of tests with distinct costs, one that fails on command, and
-// one that holds until signaled — real work for a real toolchain, no fakes.
+// run: a handful of tests with distinct costs, one that fails on command, one
+// that dies without a `go test` failure marker, and one that holds until
+// signaled — real work for a real toolchain, no fakes.
 package shardfixture
 
 import (
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -14,12 +17,26 @@ import (
 func TestFixtureAlpha(t *testing.T) { time.Sleep(30 * time.Millisecond) }
 
 func TestFixtureBeta(t *testing.T) {
+	if os.Getenv("SHARD_FIXTURE_EXIT") == "beta" {
+		// A shard that dies with no "--- FAIL"/"FAIL"/"panic:" line anywhere
+		// in its log: the build error, os.Exit, and OOM class of failure that
+		// marker-matching replay used to drop on the floor.
+		fmt.Println("fixture-beta exiting hard as instructed by SHARD_FIXTURE_EXIT")
+		os.Exit(3)
+	}
 	if os.Getenv("SHARD_FIXTURE_FAIL") == "beta" {
 		t.Fatal("failing as instructed by SHARD_FIXTURE_FAIL")
 	}
 }
 
-func TestFixtureGamma(t *testing.T) { time.Sleep(10 * time.Millisecond) }
+func TestFixtureGamma(t *testing.T) {
+	if os.Getenv("SHARD_FIXTURE_NOISE") != "" {
+		// A green test whose output merely looks like a verdict: what
+		// marker-matching replay mistook for a failing shard.
+		fmt.Println("FAIL: fixture-gamma is green and only looks red")
+	}
+	time.Sleep(10 * time.Millisecond)
+}
 
 func TestFixtureDelta(t *testing.T) {}
 
@@ -38,6 +55,20 @@ func TestFixtureHold(t *testing.T) {
 	dir := os.Getenv("SHARD_FIXTURE_HOLD")
 	if dir == "" {
 		return
+	}
+	if os.Getenv("SHARD_FIXTURE_IGNORE_TERM") != "" {
+		// A shard that swallows the runner's TERM and keeps holding: the
+		// wedged case only a second signal can end. Each TERM is announced
+		// before it is dropped, so the test can tell "the runner forwarded
+		// it" from "the runner never got there".
+		terms := make(chan os.Signal, 1)
+		signal.Notify(terms, syscall.SIGTERM)
+		go func() {
+			for range terms {
+				termed := filepath.Join(dir, fmt.Sprintf("termed.%d", os.Getpid()))
+				_ = os.WriteFile(termed, []byte("termed\n"), 0o644)
+			}
+		}()
 	}
 	ready := filepath.Join(dir, fmt.Sprintf("held.%d", os.Getpid()))
 	if err := os.WriteFile(ready, []byte("held\n"), 0o644); err != nil {

--- a/internal/devtool/scratch/pid_other.go
+++ b/internal/devtool/scratch/pid_other.go
@@ -1,0 +1,12 @@
+//go:build !linux && !darwin
+
+package scratch
+
+// This platform has no signal-0 liveness check (syscall.Kill is unix-only,
+// and os.FindProcess succeeds for any pid on Windows), so every owner counts
+// as alive and nothing is ever reclaimed here: the mistake this package must
+// never make is deleting a live run's scratch. The dev tooling runs on
+// linux/darwin; this keeps the ports that import this library building
+// everywhere, the way cmd/serf-test-dev-tooling's wave_other.go does.
+
+func pidAlive(int) bool { return true }

--- a/internal/devtool/scratch/pid_unix.go
+++ b/internal/devtool/scratch/pid_unix.go
@@ -1,0 +1,15 @@
+//go:build linux || darwin
+
+package scratch
+
+import "syscall"
+
+// pidAlive reports whether a pid answers signal 0. EPERM is an answer: the
+// process exists, it just isn't ours, and an existing process keeps its
+// directory. (bash's `kill -0` reports EPERM as failure, so the shell
+// reclaimer would delete that directory; keeping it is the safe direction for
+// a recursive delete to differ in.)
+func pidAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}

--- a/internal/devtool/scratch/scratch.go
+++ b/internal/devtool/scratch/scratch.go
@@ -16,7 +16,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"primeradiant.com/serf/envvars"
 )
@@ -114,12 +113,18 @@ func ReclaimOwn(prefix string, warn io.Writer) {
 	reclaimOwn(base, prefix, warn)
 }
 
-// reclaimOwn is scripts/covscratch-lib.sh's reclaim_own_scratch, rule for
-// rule: directories only, direct children only, exact prefix match, symlinks
-// never matched or followed, and the one thing that must never be touched is
-// a live run's scratch — a live pid (including our own) always keeps its
-// directory. Pid reuse only ever keeps a leftover one round longer, which is
-// the right direction for a recursive delete to fail.
+// reclaimOwn is scripts/covscratch-lib.sh's reclaim_own_scratch with two safe
+// tightenings. Rule for rule: directories only, direct children only, exact
+// prefix match, symlinks never matched or followed, and the one thing that
+// must never be touched is a live run's scratch — a live pid (including our
+// own) always keeps its directory. Pid reuse only ever keeps a leftover one
+// round longer, which is the right direction for a recursive delete to fail.
+//
+// The two tightenings both keep MORE than the shell did, which is the same
+// right direction: an EPERM from signal 0 counts as alive here where bash's
+// `kill -0` reports failure and the shell would reclaim (pidAlive), and a
+// pid suffix above 1<<30 is treated as "not a pid" and kept where the shell
+// asked the kernel and reclaimed on its refusal (ownerPid).
 func reclaimOwn(base, prefix string, warn io.Writer) {
 	entries, err := os.ReadDir(base)
 	if err != nil {
@@ -170,12 +175,4 @@ func ownerPid(name string) int {
 		}
 	}
 	return pid
-}
-
-// pidAlive reports whether a pid answers signal 0. EPERM is an answer: the
-// process exists, it just isn't ours, and an existing process keeps its
-// directory.
-func pidAlive(pid int) bool {
-	err := syscall.Kill(pid, 0)
-	return err == nil || err == syscall.EPERM
 }

--- a/scripts/run-module-tests.sh
+++ b/scripts/run-module-tests.sh
@@ -307,6 +307,10 @@ run_module() {
 		# modules, so the added contention stretched the shard phase by more
 		# than the overlap saved (see kata fgqh).
 		local shardStatus=0
+		# `go run` collapses its child's exit code to 1 and reports the real
+		# one as an "exit status N" line on stderr, so the runner's 129/130/143
+		# signal exits survive in the binary but not through this call. Only
+		# zero-vs-nonzero is read below, so nothing here depends on them.
 		(cd .. && go run ./cmd/serf-dev agent-shards $test_flags) || shardStatus=$?
 		local subpkgs=()
 		local pkg


### PR DESCRIPTION
The review fixes for #118, which merged while they were being written. Same four commits, cherry-picked onto current `main` so this PR's diff is only the fixes. Full per-fix red/green evidence is in the comment on #118 (https://github.com/prime-radiant-inc/serf/pull/118#issuecomment-5324130695); the short version:

## F2 (blocking) — a second signal was swallowed

`signal.Notify` on a 1-buffered channel plus a handler that read exactly one signal left the runner deaf to every later HUP/INT/TERM: with `Notify` registered the default disposition is off, so a shard that ignores TERM held the run forever and only SIGKILL ended it. The relay now loops; the second signal exits `128+signal` immediately and names the logs it abandons (`os.Exit` runs no deferred cleanup, so the scratch directory survives as the record). Channel buffer 1 → 2 so the second signal is queued while the first is still being handled.

`signal.Stop` + re-raise is the literal translation of the script's `trap - HUP INT TERM` and was tried first; probing the real binary showed the re-raised signal does not take its default action before the process continues, so the direct exit is what actually ends the run. That is `c779ab4ca`.

Red, with an ignore-TERM fixture shard driving the real binary:

```
--- FAIL: TestAgentShardsSecondSignalEndsAWedgedRun (20.90s)
    second SIGTERM did not end the runner; it had to be SIGKILLed after 20s (wait: signal: killed)
```

## F3 — failing-shard replay selected logs by marker

Logs were chosen by grepping for `^(FAIL|--- FAIL|panic:)`, the selection-by-marker bug run-module-tests.sh:407 documents as fixed (kata mjzx). Red, one test covering both directions — the failing shard has no marker (`os.Exit(3)` after a println), the green shard prints a line starting with `FAIL`:

```
    replay block covered shards [0], want exactly the FAIL verdicts [1]:
        PASS  agent:0     0.05s (3 tests)
        FAIL  agent:1

        === failing shard output ===
        ----- agent:0 -----
        FAIL: fixture-gamma is green and only looks red
```

Replay now follows the verdict already in hand, an empty or missing log says so, and a shard that never launched gets no banner (its error is on stderr).

## F4 — `AGENT_SHARD_SKIP` documentation

The regex only ever reaches the survey's `-test.skip`, so it works by leaving a test out of the cost table; under `AGENT_SHARD_NO_SURVEY` or a primed cache it does nothing. The script behaved identically, so parity-first says document rather than fix. `TestAgentShardsSkipOnlyReachesTheSurvey` pins both halves, and a mutation check (threading `-test.skip` into the shard invocations) confirms the pin bites.

## F9 — `internal/devtool/scratch` did not build off unix

```
$ GOOS=windows go build ./internal/devtool/...
internal/devtool/scratch/scratch.go:179:17: undefined: syscall.Kill
```

Split into `pid_unix.go`/`pid_other.go`, following `cmd/serf-test-dev-tooling`'s `wave_unix.go`/`wave_other.go`. Off unix every owner counts as alive and nothing is reclaimed — the mistake this package must never make is deleting a live run's scratch. This matters because every later port of the tooling imports this library.

## Accuracy edits

- `scratch.go`: the reclaimer is the shell's rules **with two safe tightenings**, not "verbatim" — EPERM from signal 0 counts as alive (bash's `kill -0` reports failure there and the shell would reclaim), and a pid suffix above `1<<30` is kept rather than asked about. Both keep more than the shell did.
- run-module-tests.sh:310: `go run` collapses the child's exit code to 1 and prints the real one as an `exit status N` line, so the runner's 129/130/143 survive in the binary but not through the production invocation. Verified, not assumed. Nothing downstream reads more than zero-vs-nonzero.
- `agentshards.go`: a note that the Setpgid + TERM-the-group pair duplicates `wave_unix.go`'s two lines deliberately — each tool is checked for parity against its own script, and the third caller is the one to build a shared home for.

## Verification

- `go test -race -count=1 ./cmd/serf-dev/... ./internal/devtool/...` — ok
- `go test -count=1 -short .` (root audits) — ok
- `make test-dev-tooling` — 19/19
- `MODULES="agent" WEB=0 scripts/run-module-tests.sh -short -count=1` — `PASS  agent  13.08s`, rc 0
- `GOOS=windows go build ./internal/devtool/...` — passes (failed before)
- `golangci-lint run ./cmd/serf-dev/... ./internal/devtool/...` (clean cache) — 0 issues

No fakes: the tests compile and run a real fixture module with the real toolchain, and signals hit the real binary.

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU
