### PR TITLE
scripts: CAS-enforced merge-into-branch, refusing merges onto a moved ref

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-runtime build-go build-hub web-preflight build-web test-web test-web-browser build-tui build-doctor build-all build-linux build-namingcheck dist install install-home install-system test-install test-dev-tooling test test-short test-fuzz test-race merge-approval-gate vet lint lint-naming lint-gofmt lint-serffuzz lint-eval lint-internal lint-docs lint-golangci clean fuzz fuzz-seeds fuzz-nightly fuzz-triage fuzz-triage-selftest fuzz-continuous fuzz-continuous-selftest fuzz-coverage-global fuzz-coverage-global-selftest fuzz-bisect fuzz-bisect-selftest fuzz-oracle-audit fuzz-oracle-audit-selftest fuzz-mutation-score fuzz-ledger fuzz-coverage fuzz-gap-check fuzz-registry-check fuzz-goldens secret-scan fuzz-corpus-scan refresh-model-catalog test-coverage-floor test-coverage-floor-selftest web-coverage-floor web-coverage-floor-selftest coverage-gaps coverage-gaps-selftest coverage-union coverage-union-selftest
+.PHONY: build build-runtime build-go build-hub web-preflight build-web test-web test-web-browser build-tui build-doctor build-all build-linux build-namingcheck dist install install-home install-system test-install test-dev-tooling test test-short test-fuzz test-race merge-approval-gate vet lint lint-naming lint-gofmt lint-serffuzz lint-eval lint-internal lint-docs lint-golangci clean fuzz fuzz-seeds fuzz-nightly fuzz-triage fuzz-triage-selftest fuzz-continuous fuzz-continuous-selftest fuzz-coverage-global fuzz-coverage-global-selftest fuzz-bisect fuzz-bisect-selftest fuzz-oracle-audit fuzz-oracle-audit-selftest fuzz-mutation-score fuzz-ledger fuzz-coverage fuzz-gap-check fuzz-registry-check fuzz-goldens secret-scan fuzz-corpus-scan refresh-model-catalog test-coverage-floor test-coverage-floor-selftest web-coverage-floor web-coverage-floor-selftest coverage-gaps coverage-gaps-selftest coverage-union coverage-union-selftest merge-into-branch merge-into-branch-selftest
 
 LDFLAGS := -X primeradiant.com/serf/buildinfo.GitSHA=$$(git rev-parse --short HEAD) \
            -X primeradiant.com/serf/buildinfo.GitDirty=$$(git --no-optional-locks diff-files --quiet && echo "" || echo "true") \
@@ -231,7 +231,7 @@ override FUZZ_GOWORK := $(abspath $(CURDIR)/go.work)
 # the guard or the pid-suffixed covscratch pattern, is enforced statically by
 # the audits in scriptmktemp_audit_test.go, not by re-running suites under
 # sabotage (kata 5hs2).
-DEV_TOOLING_TEST_SCRIPTS := run-module-lint run-module-tests private-go-home merge-approval-gate setup-gocache web-preflight live-eval-isolation e2e-webui-turn-controls fuzz-bisect fuzz-continuous fuzz-coverage-global fuzz-drive fuzz-oracle-audit fuzz-triage test-coverage-floor web-coverage-floor coverage-gaps coverage-union scratch-lib
+DEV_TOOLING_TEST_SCRIPTS := run-module-lint run-module-tests private-go-home merge-approval-gate setup-gocache web-preflight live-eval-isolation e2e-webui-turn-controls fuzz-bisect fuzz-continuous fuzz-coverage-global fuzz-drive fuzz-oracle-audit fuzz-triage test-coverage-floor web-coverage-floor coverage-gaps coverage-union scratch-lib merge-into-branch
 
 # test-dev-tooling tests tooling, not the product, so it runs in
 # `make merge-approval-gate` (where tooling regressions matter) and on demand
@@ -431,6 +431,18 @@ coverage-union:
 
 coverage-union-selftest:
 	@scripts/coverage-union-selftest.sh
+
+# merge-into-branch merges SOURCE into TARGET by ref (refs/heads/TARGET),
+# never through a live checkout: it builds the merge in a private disposable
+# worktree and lands it with a `git update-ref` compare-and-swap, so a
+# concurrent branch switch on a shared checkout cannot land the merge on the
+# wrong branch (kata h2tb). `make merge-into-branch TARGET=main SOURCE=feature
+# MERGE_ARGS="--no-ff"`; see scripts/merge-into-branch.sh --help for flags.
+merge-into-branch:
+	@scripts/merge-into-branch.sh $(MERGE_ARGS) $(TARGET) $(SOURCE)
+
+merge-into-branch-selftest:
+	@scripts/merge-into-branch-selftest.sh
 
 # web-coverage-floor is the frontend counterpart: per-area vitest LINE coverage
 # ratcheted against scripts/webcov-floors.txt. CHECK=1 fails on a drop; BLESS=1

--- a/scripts/merge-into-branch-selftest.sh
+++ b/scripts/merge-into-branch-selftest.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# merge-into-branch-selftest.sh — deterministic integration test for
+# scripts/merge-into-branch.sh against real throwaway git repos: no faked git,
+# because the whole point of the tool is a real `git merge` plus a real
+# `git update-ref` compare-and-swap.
+#
+# Case 7 (race lost) is the kata's actual requirement: it reproduces the
+# incident by using SERF_MERGE_INTO_BRANCH_PRECAS_HOOK to move
+# refs/heads/target, deterministically, in the window the tool itself leaves
+# open between reading the branch's tip and writing it back — no sleep, no
+# poll, same discipline as the rest of this repo's selftests.
+#
+# Run: scripts/merge-into-branch-selftest.sh   (also: make merge-into-branch-selftest)
+set -uo pipefail
+
+tool="$(cd "$(dirname "$0")" && pwd)/merge-into-branch.sh"
+. "$(dirname "$0")/selftest-lib.sh"
+
+scratch_dir work merge-into-branch-selftest
+trap 'scratch_rm' EXIT
+
+# new_repo DIR BRANCH — an empty repo with a private identity, so nothing here
+# depends on the machine's ambient git config (this tool's whole point).
+new_repo() {
+	mkdir -p "$1"
+	git -C "$1" init -q -b "$2"
+	git -C "$1" config user.email selftest@example.com
+	git -C "$1" config user.name selftest
+}
+
+# commit REPO FILE CONTENT MSG
+commit() {
+	printf '%s\n' "$3" >"$1/$2"
+	git -C "$1" add "$2"
+	git -C "$1" commit -q -m "$4"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: fast-forward happy path, and proof the source checkout is untouched.
+# ---------------------------------------------------------------------------
+r="$work/ff"
+new_repo "$r" target
+commit "$r" f.txt base base
+old_sha="$(git -C "$r" rev-parse target)"
+git -C "$r" checkout -q -b feature
+commit "$r" f.txt "base
+more" add-more
+feature_sha="$(git -C "$r" rev-parse feature)"
+git -C "$r" checkout -q target
+
+out="$work/ff.out"
+"$tool" --repo "$r" target feature >"$out" 2>&1
+assert_eq "$?" "0" "fast-forward: exits zero"
+assert_eq "$(git -C "$r" rev-parse refs/heads/target)" "$feature_sha" "fast-forward: target ref advances to feature's tip"
+assert_has "$out" "updated refs/heads/target: $old_sha -> $feature_sha" "fast-forward: reports the exact old and new SHAs"
+# target already equals feature's own SHA (asserted above), so there is no
+# separate merge commit to check for.
+#
+# The checkout that has target checked out must never be touched: still on
+# target, and its WORKING FILE content is exactly what it was before the ref
+# moved (a ref update alone never rewrites a checkout's files — only a
+# checkout/reset run *in that checkout* would). `git status --porcelain`
+# legitimately starts reporting f.txt as staged-modified here: its on-disk
+# index still matches the OLD tree, and HEAD (via the moved branch) now
+# names the NEW one — that divergence is inherent to moving a ref out from
+# under a checkout and is not something this tool can or should paper over
+# without running commands inside that checkout. `git diff` (worktree vs
+# index only, blind to which commit HEAD names) is the precise "did anything
+# on disk change" check.
+assert_eq "$(git -C "$r" symbolic-ref -q HEAD)" "refs/heads/target" "fast-forward: source checkout is still on target"
+assert_eq "$(git -C "$r" diff)" "" "fast-forward: source checkout's worktree has no unstaged diff from its own index"
+assert_eq "$(cat "$r/f.txt")" "base" "fast-forward: source checkout's working file is untouched by the ref move"
+assert_eq "$(git -C "$r" worktree list --porcelain | grep -c '^worktree ')" "1" "fast-forward: no worktree left behind"
+
+# ---------------------------------------------------------------------------
+# Case 2: real merge on diverged branches, both parents correct, and the
+# incident scenario itself: the checkout has target checked out AND dirty
+# (uncommitted edit plus a deleted tracked file), same shape as the kata body.
+# ---------------------------------------------------------------------------
+r="$work/diverge"
+new_repo "$r" target
+commit "$r" base.txt base base
+commit "$r" plan.txt keep-me plan
+git -C "$r" checkout -q -b feature
+commit "$r" feature.txt feat feat-commit
+feature_sha="$(git -C "$r" rev-parse feature)"
+git -C "$r" checkout -q target
+commit "$r" target.txt tgt target-commit
+old_sha="$(git -C "$r" rev-parse target)"
+# Dirty state a concurrent session left behind, mirroring the kata: an edited
+# tracked file plus a deleted one.
+printf 'uncommitted edit\n' >"$r/base.txt"
+rm -f "$r/plan.txt"
+# git diff (worktree vs index) is exactly the edit + delete above, and is
+# blind to which commit HEAD names — see the fast-forward case for why that
+# is the right invariant to compare before/after instead of `git status`.
+dirty_before="$(git -C "$r" diff)"
+
+out="$work/diverge.out"
+"$tool" --repo "$r" target feature >"$out" 2>&1
+assert_eq "$?" "0" "real merge: exits zero"
+new_sha="$(git -C "$r" rev-parse refs/heads/target)"
+[ "$new_sha" != "$old_sha" ] && [ "$new_sha" != "$feature_sha" ]
+assert_eq "$?" "0" "real merge: target ref points at a NEW commit (neither old target nor feature)"
+assert_eq "$(git -C "$r" log -1 --format=%P "$new_sha")" "$old_sha $feature_sha" "real merge: parents are old-target-tip then feature-tip, in that order"
+assert_has "$out" "updated refs/heads/target: $old_sha -> $new_sha" "real merge: reports the exact old and new SHAs"
+# The dirty, checked-out working tree must be BYTE IDENTICAL to before the
+# tool ran: this is the incident's actual failure mode (a live checkout's
+# uncommitted work got disturbed), and it is what a private temp worktree
+# instead of `git -C "$r" merge` buys.
+assert_eq "$(git -C "$r" diff)" "$dirty_before" "real merge: pre-existing dirty state (edit + delete) is untouched"
+assert_eq "$(cat "$r/base.txt")" "uncommitted edit" "real merge: uncommitted edit survives verbatim"
+[ ! -e "$r/plan.txt" ]
+assert_eq "$?" "0" "real merge: the deleted file stays deleted, not resurrected"
+assert_eq "$(git -C "$r" symbolic-ref -q HEAD)" "refs/heads/target" "real merge: source checkout is still on target"
+
+# ---------------------------------------------------------------------------
+# Case 3: --ff-only refuses a real divergence; ref is untouched.
+# ---------------------------------------------------------------------------
+r="$work/ffonly-refuse"
+new_repo "$r" target
+commit "$r" f.txt base base
+git -C "$r" checkout -q -b feature
+commit "$r" feature.txt feat feat-commit
+feature_sha="$(git -C "$r" rev-parse feature)"
+git -C "$r" checkout -q target
+commit "$r" target.txt tgt target-commit
+old_sha="$(git -C "$r" rev-parse target)"
+
+out="$work/ffonly-refuse.out"
+"$tool" --repo "$r" --ff-only target feature >"$out" 2>&1
+rc=$?
+assert_eq "$rc" "1" "ff-only: a real divergence exits nonzero (merge-failure code)"
+assert_eq "$(git -C "$r" rev-parse refs/heads/target)" "$old_sha" "ff-only: target ref is untouched"
+assert_has "$out" "Not possible to fast-forward" "ff-only: names the reason it refused"
+assert_eq "$(git -C "$r" worktree list --porcelain | grep -c '^worktree ')" "1" "ff-only: no worktree left behind"
+
+# ---------------------------------------------------------------------------
+# Case 4: --no-ff forces a merge commit even though a fast-forward exists.
+# ---------------------------------------------------------------------------
+r="$work/noff-force"
+new_repo "$r" target
+commit "$r" f.txt base base
+old_sha="$(git -C "$r" rev-parse target)"
+git -C "$r" checkout -q -b feature
+commit "$r" f.txt "base
+more" add-more
+feature_sha="$(git -C "$r" rev-parse feature)"
+git -C "$r" checkout -q target
+
+out="$work/noff-force.out"
+"$tool" --repo "$r" --no-ff target feature >"$out" 2>&1
+assert_eq "$?" "0" "no-ff: exits zero"
+new_sha="$(git -C "$r" rev-parse refs/heads/target)"
+[ "$new_sha" != "$feature_sha" ]
+assert_eq "$?" "0" "no-ff: created a real merge commit instead of fast-forwarding"
+assert_eq "$(git -C "$r" log -1 --format=%P "$new_sha")" "$old_sha $feature_sha" "no-ff: parents are old-target-tip then feature-tip"
+
+# ---------------------------------------------------------------------------
+# Case 5: already merged is a no-op, not a spurious "updated" report.
+# ---------------------------------------------------------------------------
+r="$work/noop"
+new_repo "$r" target
+commit "$r" f.txt base base
+old_sha="$(git -C "$r" rev-parse target)"
+git -C "$r" branch already-in "$old_sha"
+commit "$r" f.txt "base
+more" add-more
+new_target_sha="$(git -C "$r" rev-parse target)"
+
+out="$work/noop.out"
+"$tool" --repo "$r" target already-in >"$out" 2>&1
+assert_eq "$?" "0" "no-op: exits zero when source is already merged"
+assert_eq "$(git -C "$r" rev-parse refs/heads/target)" "$new_target_sha" "no-op: target ref is unchanged"
+assert_has "$out" "already merged into refs/heads/target" "no-op: says so"
+assert_not_has "$out" "updated refs/heads/target" "no-op: does not claim to have updated the ref"
+
+# ---------------------------------------------------------------------------
+# Case 6: a genuine conflict fails loudly and changes nothing.
+# ---------------------------------------------------------------------------
+r="$work/conflict"
+new_repo "$r" target
+commit "$r" f.txt line1 base
+git -C "$r" checkout -q -b feature
+commit "$r" f.txt line1-feature feature-edit
+feature_sha="$(git -C "$r" rev-parse feature)"
+git -C "$r" checkout -q target
+commit "$r" f.txt line1-target target-edit
+old_sha="$(git -C "$r" rev-parse target)"
+
+out="$work/conflict.out"
+"$tool" --repo "$r" target feature >"$out" 2>&1
+assert_eq "$?" "1" "conflict: exits nonzero (merge-failure code)"
+assert_eq "$(git -C "$r" rev-parse refs/heads/target)" "$old_sha" "conflict: target ref is untouched"
+assert_has "$out" "CONFLICT" "conflict: names the conflict"
+assert_eq "$(git -C "$r" worktree list --porcelain | grep -c '^worktree ')" "1" "conflict: the conflicted temp worktree was discarded, not left behind"
+assert_eq "$(cat "$r/f.txt")" "line1-target" "conflict: source checkout's file is untouched"
+
+# ---------------------------------------------------------------------------
+# Case 7: THE KATA. refs/heads/target moves after preflight, before the CAS
+# write. The tool must refuse, and the sandbox must be untouched by the tool
+# itself — only the simulated concurrent session's move is visible afterward.
+# ---------------------------------------------------------------------------
+r="$work/race"
+new_repo "$r" target
+commit "$r" f.txt base base
+old_sha="$(git -C "$r" rev-parse target)"
+git -C "$r" checkout -q -b feature
+commit "$r" feature.txt feat feat-commit
+feature_sha="$(git -C "$r" rev-parse feature)"
+git -C "$r" checkout -q target
+
+# The "other session": a real commit built on target's tip, held on a side
+# branch so it exists in the object store WITHOUT moving refs/heads/target
+# yet. The hook below is the only thing that ever applies it — reproducing
+# "another session switched/advanced the branch between preflight and merge".
+git -C "$r" branch concurrent "$old_sha"
+git -C "$r" checkout -q concurrent
+commit "$r" concurrent.txt from-another-session concurrent-commit
+concurrent_sha="$(git -C "$r" rev-parse concurrent)"
+git -C "$r" checkout -q target
+
+hook="$work/race-hook.sh"
+cat >"$hook" <<HOOK
+#!/usr/bin/env bash
+git -C "$r" update-ref refs/heads/target "$concurrent_sha"
+HOOK
+chmod +x "$hook"
+
+out="$work/race.out"
+SERF_MERGE_INTO_BRANCH_PRECAS_HOOK="$hook" "$tool" --repo "$r" target feature >"$out" 2>&1
+rc=$?
+assert_eq "$rc" "3" "race: exits with the dedicated CAS-refused code"
+assert_eq "$(git -C "$r" rev-parse refs/heads/target)" "$concurrent_sha" "race: target ref is exactly the concurrent session's commit, nothing more"
+assert_has "$out" "refused" "race: says it refused"
+assert_has "$out" "expected $old_sha" "race: names the old value it preflighted"
+assert_has "$out" "now $concurrent_sha" "race: names what the ref actually holds now"
+assert_not_has "$out" "updated refs/heads/target" "race: never claims to have updated the ref"
+assert_eq "$(git -C "$r" symbolic-ref -q HEAD)" "refs/heads/target" "race: source checkout is still on target"
+assert_eq "$(git -C "$r" diff)" "" "race: source checkout's worktree has no unstaged diff from its own index"
+assert_eq "$(git -C "$r" worktree list --porcelain | grep -c '^worktree ')" "1" "race: the losing temp worktree was discarded, not left behind"
+assert_eq "$(git -C "$r" branch --list feature | tr -d ' *')" "feature" "race: feature branch itself untouched"
+
+# ---------------------------------------------------------------------------
+# Case 8/9: usage errors on a nonexistent target/source touch nothing.
+# ---------------------------------------------------------------------------
+r="$work/usage"
+new_repo "$r" target
+commit "$r" f.txt base base
+old_sha="$(git -C "$r" rev-parse target)"
+
+out="$work/usage-target.out"
+"$tool" --repo "$r" no-such-branch target >"$out" 2>&1
+assert_eq "$?" "2" "usage: nonexistent target branch is a usage error"
+assert_has "$out" "target branch does not exist" "usage: names the missing target"
+assert_eq "$(git -C "$r" rev-parse refs/heads/target)" "$old_sha" "usage: target ref untouched by a bad-target invocation"
+
+out="$work/usage-source.out"
+"$tool" --repo "$r" target no-such-ref >"$out" 2>&1
+assert_eq "$?" "2" "usage: nonexistent source is a usage error"
+assert_has "$out" "source does not resolve to a commit" "usage: names the unresolvable source"
+assert_eq "$(git -C "$r" rev-parse refs/heads/target)" "$old_sha" "usage: target ref untouched by a bad-source invocation"
+
+selftest_summary

--- a/scripts/merge-into-branch.sh
+++ b/scripts/merge-into-branch.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# merge-into-branch.sh — merge SOURCE into a local branch by ref, without ever
+# checking out or touching a live working tree, and without landing the result
+# if the branch moved underneath the merge (kata h2tb).
+#
+# The incident this exists to prevent: a controller preflighted "the shared
+# checkout is on main", another session switched that same checkout to a
+# different branch before the merge command ran, and `git merge` landed the
+# commit on the wrong branch. Recovery needed commit-tree/update-ref surgery.
+# The bug was operating through MUTABLE checkout state — "whatever HEAD is
+# right now" — between the preflight check and the write.
+#
+# This tool never reads or writes any existing checkout's HEAD or working
+# files. It resolves the target branch's CURRENT tip once, builds the merge in
+# a private, disposable worktree (so real `git merge` — conflict detection,
+# merge strategies, fast-forward included — does the actual work), and then
+# lands the result with a single atomic compare-and-swap:
+#
+#   git update-ref refs/heads/<target> <new> <old>
+#
+# update-ref takes a lock on the ref, re-reads its CURRENT value under that
+# lock, and only writes if it still equals <old>. If some other session moved
+# refs/heads/<target> after this script's preflight, the CAS fails atomically
+# and NOTHING is written — that race window is exactly what the incident hit,
+# and this is the enforcement point the kata asked for. No existing checkout
+# is touched in either the success or the failure path.
+#
+# Usage:
+#   scripts/merge-into-branch.sh [--repo PATH] [--ff-only|--no-ff] [-m MESSAGE] TARGET SOURCE
+#
+#     TARGET    a local branch name; the ref merged into is refs/heads/TARGET.
+#     SOURCE    any commit-ish to merge in (branch, tag, SHA, refs/remotes/...).
+#     --repo    the repository to operate on (default: the current directory).
+#               Any working directory inside the repo works, including a
+#               linked worktree — refs/heads/* is shared across all of them.
+#     --ff-only fail unless the merge is a fast-forward (like `git merge --ff-only`).
+#     --no-ff   always create a merge commit, even when a fast-forward is possible.
+#     -m MSG    merge commit message (default: "Merge SOURCE into TARGET").
+#               Ignored for a fast-forward, same as plain `git merge`.
+#
+#   With neither --ff-only nor --no-ff, the merge fast-forwards when possible
+#   and otherwise creates a real merge commit — deliberately NOT the operator's
+#   ambient `merge.ff`/`pull.ff` git config, which would make this tool's
+#   default behaviour depend on whose machine it runs on. It always passes an
+#   explicit `--ff` to git for exactly that reason (verified against a machine
+#   with `merge.ff = only` set globally, which otherwise silently turns the
+#   default mode into --ff-only).
+#
+# Exit codes:
+#   0   updated refs/heads/TARGET, or SOURCE was already merged (no-op)
+#   1   the merge itself failed: conflicts, or --ff-only could not fast-forward
+#   2   usage error: bad flags, or TARGET/SOURCE/--repo does not resolve
+#   3   refused: refs/heads/TARGET moved between preflight and the CAS write.
+#       The computed merge was NOT applied; refs/heads/TARGET is exactly what
+#       the other session left it as.
+#
+# Env seams (default is unset in production; used by the self-test to prove
+# the CAS deterministically, without sleeps or polling):
+#   SERF_MERGE_INTO_BRANCH_PRECAS_HOOK   if set, an executable run with no
+#     arguments after the merge commit is built but before the CAS write —
+#     the self-test's one chance to move refs/heads/TARGET and simulate the
+#     incident's concurrent branch switch.
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$script_dir/scratch-lib.sh"
+
+repo="."
+ff_mode="auto"
+message=""
+positional=()
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--repo)
+		[ $# -ge 2 ] || { echo "merge-into-branch: --repo needs a value" >&2; exit 2; }
+		repo="$2"; shift 2 ;;
+	--ff-only)
+		[ "$ff_mode" = "noff" ] && { echo "merge-into-branch: --ff-only conflicts with --no-ff" >&2; exit 2; }
+		ff_mode="ffonly"; shift ;;
+	--no-ff)
+		[ "$ff_mode" = "ffonly" ] && { echo "merge-into-branch: --no-ff conflicts with --ff-only" >&2; exit 2; }
+		ff_mode="noff"; shift ;;
+	-m | --message)
+		[ $# -ge 2 ] || { echo "merge-into-branch: $1 needs a value" >&2; exit 2; }
+		message="$2"; shift 2 ;;
+	-h | --help)
+		awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "${BASH_SOURCE[0]}"
+		exit 0 ;;
+	-*)
+		echo "merge-into-branch: unknown flag: $1 (try --help)" >&2
+		exit 2 ;;
+	*)
+		positional+=("$1"); shift ;;
+	esac
+done
+
+if [ "${#positional[@]}" -ne 2 ]; then
+	echo "usage: merge-into-branch.sh [--repo PATH] [--ff-only|--no-ff] [-m MESSAGE] TARGET SOURCE" >&2
+	exit 2
+fi
+target="${positional[0]}"
+source_ref="${positional[1]}"
+
+if ! repo="$(cd "$repo" 2>/dev/null && pwd -P)"; then
+	echo "merge-into-branch: --repo path does not exist: $repo" >&2
+	exit 2
+fi
+if ! git -C "$repo" rev-parse --git-dir >/dev/null 2>&1; then
+	echo "merge-into-branch: not a git repository: $repo" >&2
+	exit 2
+fi
+
+# Preflight: read the target branch's CURRENT tip exactly once. Everything
+# from here on treats this as the ONLY value refs/heads/TARGET is allowed to
+# have had when the CAS below runs — that is the whole enforcement.
+if ! old_sha="$(git -C "$repo" rev-parse --verify --quiet "refs/heads/$target")" || [ -z "$old_sha" ]; then
+	echo "merge-into-branch: target branch does not exist: refs/heads/$target" >&2
+	exit 2
+fi
+if ! source_sha="$(git -C "$repo" rev-parse --verify --quiet "${source_ref}^{commit}")" || [ -z "$source_sha" ]; then
+	echo "merge-into-branch: source does not resolve to a commit: $source_ref" >&2
+	exit 2
+fi
+
+[ -n "$message" ] || message="Merge $source_ref into $target"
+
+wt=""
+cleanup() {
+	# --force: the worktree may be mid-conflict (UU files, MERGE_HEAD) or,
+	# on the happy path, hold a commit that never got attached to any
+	# branch (the CAS lost the race) — either way it is entirely disposable
+	# and none of it belongs to any checkout a caller owns.
+	[ -n "$wt" ] && git -C "$repo" worktree remove --force "$wt" >/dev/null 2>&1
+	scratch_rm
+}
+trap cleanup EXIT
+scratch_dir wt merge-into-branch
+
+# --detach: check out the raw commit, never the branch name. TARGET may
+# already be checked out (with a caller's uncommitted work) in this repo or
+# another linked worktree; --detach never contends for that branch's lock and
+# never reads or writes those files.
+if ! add_err="$(git -C "$repo" worktree add --quiet --detach "$wt" "$old_sha" 2>&1)"; then
+	echo "merge-into-branch: could not create a private worktree at $old_sha:" >&2
+	printf '%s\n' "$add_err" | sed 's/^/    /' >&2
+	exit 1
+fi
+
+ff_flag="--ff"
+case "$ff_mode" in
+ffonly) ff_flag="--ff-only" ;;
+noff) ff_flag="--no-ff" ;;
+esac
+
+if merge_output="$(git -C "$wt" merge "$ff_flag" -m "$message" "$source_sha" 2>&1)"; then
+	merge_rc=0
+else
+	merge_rc=$?
+fi
+
+if [ "$merge_rc" -ne 0 ]; then
+	printf 'merge-into-branch: merge of %s into %s failed:\n' "$source_ref" "$target" >&2
+	printf '%s\n' "$merge_output" | sed 's/^/    /' >&2
+	exit 1
+fi
+
+new_sha="$(git -C "$wt" rev-parse HEAD)"
+
+if [ "$new_sha" = "$old_sha" ]; then
+	printf 'merge-into-branch: %s is already merged into refs/heads/%s (%s); nothing to do\n' \
+		"$source_ref" "$target" "$old_sha"
+	exit 0
+fi
+
+# The self-test's one hook: move refs/heads/TARGET here, deterministically,
+# to reproduce the incident's window between preflight and the write below.
+if [ -n "${SERF_MERGE_INTO_BRANCH_PRECAS_HOOK:-}" ]; then
+	"$SERF_MERGE_INTO_BRANCH_PRECAS_HOOK"
+fi
+
+if cas_err="$(git -C "$repo" update-ref "refs/heads/$target" "$new_sha" "$old_sha" 2>&1)"; then
+	printf 'merge-into-branch: updated refs/heads/%s: %s -> %s\n' "$target" "$old_sha" "$new_sha"
+	exit 0
+fi
+
+current_sha="$(git -C "$repo" rev-parse --verify --quiet "refs/heads/$target" 2>/dev/null)"
+printf 'merge-into-branch: refused: refs/heads/%s moved since preflight (expected %s, now %s); computed merge %s was NOT applied\n' \
+	"$target" "$old_sha" "${current_sha:-unresolvable}" "$new_sha" >&2
+printf '%s\n' "$cas_err" | sed 's/^/    git: /' >&2
+exit 3


### PR DESCRIPTION
Kata: h2tb (closed with this tool)

The incident this closes: a controller preflighted "the shared checkout is on main", a concurrent session switched that checkout's branch before the merge ran, and the merge landed on the wrong branch (39cde9bd1) — recovery needed commit-tree/update-ref surgery. The 2026-08-04 ruling deferred a helper but kept the kata open for exactly this CAS enforcement.

`scripts/merge-into-branch.sh` merges SOURCE into `refs/heads/TARGET` without touching any live checkout: the merge is built in a private detached disposable worktree and landed with atomic `git update-ref <target> <new> <old>` — if the ref moved after preflight, the CAS fails, exit 3, nothing written. Explicit `--ff`/`--ff-only`/`--no-ff` flags always passed to git, because this host's global `merge.ff=only` silently changes bare `git merge` semantics (found empirically during this work).

Verification: 47-check deterministic selftest registered in the dev-tooling wave (`go run ./cmd/serf-test-dev-tooling merge-into-branch` PASS), race case driven by a pre-CAS hook seam rather than sleeps. Five script mutations run for real, each caught — including dropping the CAS old-sha and rerouting the merge through the live checkout (the original incident, reproduced and refused).

https://claude.ai/code/session_017f6aYf3cJgkcg8PNAg62wX