### PR TITLE
feat(prompts): positive phase-transition rules for diagnostic work

### DIFF
--- a/agent/prompts/sections/communicate.md.tmpl
+++ b/agent/prompts/sections/communicate.md.tmpl
@@ -22,6 +22,11 @@ Report real milestones. A status marker is a requested user/caller-visible
 milestone; if internal progress should continue
 immediately through the next work tool, use `end_turn=false`.
 
+When a long or delegated task changes phase — for example moving from
+investigation to implementation — send one checkpoint through
+{{ .ResultToolName }} with `end_turn=false`: what's done,
+the current hypothesis or plan, the next concrete action, and any blockers.
+
 Watch-delivery and observer-callback flow: when handling a `job_watch` frame
 that needs no action, a short internal no-action disposition is enough. When a
 watched trigger is handed to an observer sidecar, Serf yields the caller turn and

--- a/agent/prompts/sections/verification.md
+++ b/agent/prompts/sections/verification.md
@@ -9,3 +9,8 @@ Before you change production behavior, prove whether a failure belongs to the
 product or is a fixture or environment failure. When the parent has an
 environment the child lacked, the parent must rerun the decisive incomplete gate
 itself rather than accept an unverified child result.
+
+Before interpreting a cross-model or cross-configuration comparison as a
+product or model-behavior failure, first prove one known-good smoke case on
+each participant — an infrastructure or configuration failure is not
+evidence about behavior under test.

--- a/agent/prompts/sections/workflow.md.tmpl
+++ b/agent/prompts/sections/workflow.md.tmpl
@@ -6,6 +6,10 @@ Never do arithmetic, format conversion, or data transformation in your head — 
 
 After initial inspection, establish the smallest runnable end-to-end path; let verification drive further exploration.
 
+Root-cause investigation ends at a positive condition, not a fixed step count: once the evidence isolates a concrete failing boundary and you can state one falsifiable hypothesis, stop surveying adjacent code and run the smallest test that could confirm or refute it. Restating the same hypothesis or re-planning the same test is not progress — once its shape is clear, write and run it.
+
+If a run of investigative tool calls adds no new evidence, stop and checkpoint: summarize the current hypothesis, then either execute the minimal test or report exactly what evidence is missing. This does not cap a legitimate broad investigation — it stops one that is circling the same ground.
+
 Before finishing, verify the actual required artifact or live state against every stated acceptance criterion. Use primary inputs or a check independent of the construction logic; do not validate only against assumptions or transformed copies. Being too careful is just as bad as not being careful enough.
 
 When you create or enter a fresh worktree, its dependency directories may be absent; copy or install the project's dependencies before running its gates.

--- a/agent/section_resolver_test.go
+++ b/agent/section_resolver_test.go
@@ -801,7 +801,7 @@ func TestWorkflowSectionDefinesRootCauseToActionTransition(t *testing.T) {
 	if exploration < 0 || transition < 0 || preFinish < 0 {
 		t.Fatalf("expected anchor lines not found: exploration=%d transition=%d preFinish=%d", exploration, transition, preFinish)
 	}
-	if !(exploration < transition && transition < preFinish) {
+	if exploration >= transition || transition >= preFinish {
 		t.Fatalf("transition rule out of place: want exploration(%d) < transition(%d) < preFinish(%d)", exploration, transition, preFinish)
 	}
 }
@@ -1017,7 +1017,7 @@ func TestCommunicateSectionReportsPhaseChangeCheckpoint(t *testing.T) {
 
 	milestones := strings.Index(section, "Report real milestones")
 	checkpoint := strings.Index(section, "changes phase")
-	if milestones < 0 || checkpoint < 0 || !(milestones < checkpoint) {
+	if milestones < 0 || checkpoint < 0 || milestones >= checkpoint {
 		t.Fatalf("checkpoint guidance out of place: want milestones(%d) < checkpoint(%d)", milestones, checkpoint)
 	}
 }

--- a/agent/section_resolver_test.go
+++ b/agent/section_resolver_test.go
@@ -770,6 +770,42 @@ func TestWorkflowSection_GatesItsToolMentions(t *testing.T) {
 	}
 }
 
+// TestWorkflowSectionDefinesRootCauseToActionTransition pins kata nbcf's
+// positive phase-transition rule: root-cause investigation ends when the
+// evidence isolates a boundary and one falsifiable hypothesis is stateable,
+// at which point the smallest test runs instead of more surveying. It also
+// pins the stall checkpoint (no new evidence -> summarize and act or report
+// the gap) and that both land between the existing "let verification drive
+// further exploration" line and the pre-finish verification line, not before
+// or after the whole section.
+func TestWorkflowSectionDefinesRootCauseToActionTransition(t *testing.T) {
+	t.Parallel()
+	section := postureSectionResolver("coordinator").Section("workflow", promptData{Provider: "openai", Agent: "coordinator"})
+	for _, want := range []string{
+		"falsifiable hypothesis",
+		"stop surveying adjacent code",
+		"smallest test that could confirm or refute it",
+		"adds no new evidence",
+		"summarize the current hypothesis",
+		"report exactly what evidence is missing",
+		"does not cap a legitimate broad investigation",
+	} {
+		if !strings.Contains(section, want) {
+			t.Fatalf("workflow section missing %q: %s", want, section)
+		}
+	}
+
+	exploration := strings.Index(section, "let verification drive further exploration")
+	transition := strings.Index(section, "falsifiable hypothesis")
+	preFinish := strings.Index(section, "Before finishing, verify the actual required artifact")
+	if exploration < 0 || transition < 0 || preFinish < 0 {
+		t.Fatalf("expected anchor lines not found: exploration=%d transition=%d preFinish=%d", exploration, transition, preFinish)
+	}
+	if !(exploration < transition && transition < preFinish) {
+		t.Fatalf("transition rule out of place: want exploration(%d) < transition(%d) < preFinish(%d)", exploration, transition, preFinish)
+	}
+}
+
 func TestReviewerTemplate_UsesCommunicateDecisionContract(t *testing.T) {
 	t.Parallel()
 	resolver := &sectionResolver{
@@ -903,6 +939,25 @@ func TestVerificationSectionDefinesIncompleteGates(t *testing.T) {
 	}
 }
 
+// TestVerificationSectionRequiresSmokeCaseBeforeMatrix pins kata nbcf's
+// harness-vs-product rule: before a cross-model or cross-configuration
+// comparison is read as a product/model-behavior finding, one known-good
+// smoke case must be proven on each participant first.
+func TestVerificationSectionRequiresSmokeCaseBeforeMatrix(t *testing.T) {
+	t.Parallel()
+	section := postureSectionResolver("coordinator").Section("verification", promptData{Provider: "openai", Agent: "coordinator"})
+	for _, want := range []string{
+		"cross-model or cross-configuration comparison",
+		"known-good smoke case",
+		"an infrastructure or configuration failure is not",
+		"evidence about behavior under test",
+	} {
+		if !strings.Contains(section, want) {
+			t.Fatalf("verification section missing %q: %s", want, section)
+		}
+	}
+}
+
 // TestContextManagementSectionIsAdvisoryAndBounded pins the context-management
 // posture: compaction is a suggestion at a task boundary, and a stalled
 // implement/review/fix loop stops after two cycles instead of repeating.
@@ -933,6 +988,37 @@ func TestContextManagementSection_SilentAboutAnUncallableCompactTool(t *testing.
 	}
 	if !strings.Contains(section, "two incomplete implement/review/fix cycles") {
 		t.Fatalf("tool-free context-management section lost its tool-independent guidance: %s", section)
+	}
+}
+
+// TestCommunicateSectionReportsPhaseChangeCheckpoint pins kata nbcf's
+// checkpoint-reporting rule: a long or delegated task that changes phase
+// (e.g. investigation to implementation) sends a non-terminal checkpoint
+// naming completed work, the current hypothesis/plan, the next concrete
+// action, and blockers, and it lands after the "Report real milestones"
+// paragraph rather than replacing it.
+func TestCommunicateSectionReportsPhaseChangeCheckpoint(t *testing.T) {
+	t.Parallel()
+	section := postureSectionResolver("coordinator").Section("communicate", promptData{
+		Provider: "openai", Agent: "coordinator", ResultToolName: "communicate",
+	})
+	for _, want := range []string{
+		"Report real milestones",
+		"changes phase",
+		"communicate with `end_turn=false`",
+		"current hypothesis or plan",
+		"next concrete action",
+		"any blockers",
+	} {
+		if !strings.Contains(section, want) {
+			t.Fatalf("communicate section missing %q: %s", want, section)
+		}
+	}
+
+	milestones := strings.Index(section, "Report real milestones")
+	checkpoint := strings.Index(section, "changes phase")
+	if milestones < 0 || checkpoint < 0 || !(milestones < checkpoint) {
+		t.Fatalf("checkpoint guidance out of place: want milestones(%d) < checkpoint(%d)", milestones, checkpoint)
 	}
 }
 

--- a/tools/tool-fluency/cmd/serf-fluency/nbcf_probe_test.go
+++ b/tools/tool-fluency/cmd/serf-fluency/nbcf_probe_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNBCFSeededConfigPathProbeLoadsAndValidates is an offline check (no live
+// model calls — see docs/testing.md's "keep it real only where model
+// behavior is the thing under test" boundary) for kata nbcf's opt-in
+// diagnose-then-fix eval scaffold. It proves three things deterministically:
+//
+//  1. the probe manifest under probes-nbcf/ parses and its prompt describes
+//     the SYMPTOM without leaking the seeded bug (the model must diagnose it);
+//  2. the fixture materializes with the bug still present, not pre-fixed;
+//  3. the probe's expectations actually distinguish a stalled transcript
+//     (no test run, no regression test, no completion report) from a
+//     completed one — proving the pass/fail gate is not a tautology.
+//
+// It does not run a live model. See probes-nbcf/README.md for that.
+func TestNBCFSeededConfigPathProbeLoadsAndValidates(t *testing.T) {
+	probes, err := loadProbes(filepath.Join("..", "..", "probes-nbcf"), "all")
+	if err != nil {
+		t.Fatalf("loadProbes: %v", err)
+	}
+	if len(probes) != 1 {
+		t.Fatalf("probes = %#v, want exactly 1", probes)
+	}
+	probe := probes[0]
+	if probe.ID != "diagnostic_fix.seeded_config_path" {
+		t.Fatalf("id = %q", probe.ID)
+	}
+	if probe.Tool != "shell" {
+		t.Fatalf("tool = %q, want shell", probe.Tool)
+	}
+	if !strings.Contains(probe.Prompt, "DIAGNOSIS_COMPLETE") {
+		t.Fatalf("prompt missing completion token: %q", probe.Prompt)
+	}
+
+	// The prompt must name the SYMPTOM, never the seeded bug's mechanism —
+	// diagnosing that is the model's job.
+	for _, giveaway := range []string{"os.Getenv", "Getenv(\"HOME\")", "ignores homeDir", "ignores the homeDir"} {
+		if strings.Contains(probe.Prompt, giveaway) {
+			t.Fatalf("prompt leaks the seeded bug via %q", giveaway)
+		}
+	}
+
+	work := t.TempDir()
+	if err := materializeFixture(work, probe.Fixture); err != nil {
+		t.Fatalf("materializeFixture: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(work, "configpath", "resolve.go"))
+	if err != nil {
+		t.Fatalf("reading materialized fixture: %v", err)
+	}
+	if !strings.Contains(string(src), "homeDir") {
+		t.Fatalf("materialized fixture lost the homeDir parameter: %s", src)
+	}
+	// The fixture ships the bug, not the fix: the fallback branch must not
+	// already use homeDir, or there is nothing left to diagnose.
+	if strings.Contains(string(src), "filepath.Join(homeDir") {
+		t.Fatalf("fixture is pre-fixed; the seeded bug must still be present: %s", src)
+	}
+
+	// A stalled transcript (never ran a test, never wrote the regression
+	// test, never reported completion) must fail expectations.
+	stalled := probeResult{
+		FinalOutput:         "still investigating the environment propagation",
+		CanonicalToolCounts: map[string]int{"shell": 0},
+	}
+	if findings := evaluateExpectations(work, probe, stalled); len(findings) == 0 {
+		t.Fatal("stalled transcript passed expectations; the gate is not discriminating")
+	}
+
+	// A completed transcript — regression test written, fix applied, tests
+	// run twice, completion token reported — must pass.
+	if err := os.WriteFile(filepath.Join(work, "configpath", "resolve_test.go"), []byte("package configpath\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	const buggyReturn = `return filepath.Join(os.Getenv("HOME"), ".serf", "providers.toml")`
+	const fixedReturn = `return filepath.Join(homeDir, ".serf", "providers.toml")`
+	fixedSrc := strings.Replace(string(src), buggyReturn, fixedReturn, 1)
+	if fixedSrc == string(src) {
+		t.Fatal("test setup did not actually rewrite the fallback branch — fixture text drifted from this test")
+	}
+	if err := os.WriteFile(filepath.Join(work, "configpath", "resolve.go"), []byte(fixedSrc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	completed := probeResult{
+		FinalOutput:         "DIAGNOSIS_COMPLETE: the fallback branch read the real HOME env var instead of the homeDir parameter. Fixed by joining homeDir directly.",
+		CanonicalToolCounts: map[string]int{"shell": 2},
+	}
+	if findings := evaluateExpectations(work, probe, completed); len(findings) != 0 {
+		t.Fatalf("completed transcript failed expectations: %#v", findings)
+	}
+}

--- a/tools/tool-fluency/probes-nbcf/README.md
+++ b/tools/tool-fluency/probes-nbcf/README.md
@@ -1,0 +1,147 @@
+# kata nbcf: diagnosis-to-action phase-transition eval (scaffold)
+
+Kata nbcf's acceptance has two halves. The first — positive phase-transition
+prompting in `agent/prompts/sections/workflow.md.tmpl`,
+`communicate.md.tmpl`, and `verification.md` — is implemented and covered by
+deterministic tests in `agent/section_resolver_test.go`. This directory is
+the **scaffold** for the second half: an opt-in agentic eval that measures
+whether the new prompting actually reduces analysis-churn on a seeded
+configuration-path failure, without a live model run happening in this
+worktree (kata rule: no live LLM API calls from an implementer).
+
+## What's here
+
+- `diagnostic_fix.seeded_config_path.yaml` — one tool-fluency probe manifest
+  (see `tools/tool-fluency/README.md` for the schema). It ships a tiny,
+  self-contained `configpath` Go package with a deliberately seeded
+  environment/configuration-path bug (modeled on the real HOME/XDG/
+  SERF_PROVIDERS_CONFIG precedence bug that kata nbcf's incident report
+  describes — see "Premise check" below) and a prompt describing the
+  *symptom* only. The model must diagnose the root cause, write one
+  regression test, apply the smallest fix, and verify, then report a
+  `DIAGNOSIS_COMPLETE` token.
+- `../cmd/serf-fluency/nbcf_probe_test.go` — an offline, deterministic test
+  (`go test ./tools/tool-fluency/cmd/serf-fluency/ -run
+  TestNBCFSeededConfigPathProbeLoadsAndValidates`) proving the manifest
+  parses, the fixture ships the bug (not the fix), and the pass/fail gate
+  actually discriminates a stalled transcript from a completed one. This is
+  the only part of the scaffold that runs today; it makes no LLM calls.
+
+It is deliberately **not** under `tools/tool-fluency/probes/`, so an ordinary
+`--probe all` run of the core suite never picks it up — this probe is far
+heavier (up to 40 tool rounds) and measures a different thing (phase
+discipline on a multi-step diagnose-and-fix task, not single-tool-call
+fluency).
+
+## Premise check (per kata nbcf's METHOD instructions)
+
+Before scaffolding this, I searched `agent/prompts/` for any existing
+phase-transition or analysis-budget language and found none — the premise
+that no such prompting exists on `origin/main` (`ea6cc396d`) holds.
+
+I also found that the *specific* incident kata nbcf describes (an agent
+stalling on HOME/XDG/`SERF_PROVIDERS_CONFIG` propagation during a
+tool-fluency run) already has its underlying bug fixed on main:
+`agent/internal/liveeval/paths.go` (commit `403e580c3`, "test(eval): gate
+live suites and resolve local paths") is that forced bounded fix, with
+`paths_test.go` pinning it. That fix is the *product* of the stall the kata
+wants to prevent recurring — it does not itself add the missing prompting.
+This probe seeds a fresh, analogous bug rather than reusing that one, both
+because the real one is already fixed and because reusing a fixed bug would
+make the eval untestable (there would be nothing left to diagnose).
+
+## How to run it (controller / whoever has live credentials)
+
+This eval compares CURRENT prompting (this repo before kata nbcf's commit)
+against CANDIDATE prompting (this repo including it) on the same seeded
+bug, across three models. Two binaries, not `--system-prompt-append`: the
+new rules are baked into the shipped sections, not appended text, so a fair
+A/B needs two `serf` builds.
+
+```sh
+# 1. Build the baseline (no phase-transition prompting) in a disposable
+#    worktree at this kata's base commit. Do not touch other worktrees;
+#    this creates a new one.
+git worktree add /tmp/nbcf-baseline-wt ea6cc396d
+(cd /tmp/nbcf-baseline-wt && go build -o /tmp/nbcf-baseline-serf ./cmd/serf)
+
+# 2. Build the candidate from this branch (kata/uq-nbcf, or wherever this
+#    landed on main).
+go build -o /tmp/nbcf-candidate-serf ./cmd/serf
+
+# 3. Run the probe against both binaries, for each model below. Repeat
+#    --repetitions 3+ per arm; single-shot runs are not comparable.
+for arm in baseline candidate; do
+  bin=/tmp/nbcf-$arm-serf
+  go run ./tools/tool-fluency/cmd/serf-fluency run \
+    --serf-bin "$bin" \
+    --model <provider/model> \
+    --probes-dir tools/tool-fluency/probes-nbcf \
+    --probe diagnostic_fix.seeded_config_path \
+    --reasoning-effort low \
+    --repetitions 3 \
+    --max-rounds 40 \
+    --out "/tmp/serf-nbcf-eval-$arm-<model-slug>"
+done
+
+# 4. Clean up the disposable worktree when done.
+git worktree remove /tmp/nbcf-baseline-wt
+```
+
+### The three required models (kata nbcf acceptance)
+
+| Kata's name | Model ref to actually use | Note |
+| --- | --- | --- |
+| GPT-5.6 Luna low | `openai/gpt-5.6-luna` | Real model (`llm/providers/openai/responses.go`'s `codexModelVariants`). |
+| the smallest supported GPT mini low | `openai/gpt-5.4-mini` | **Premise correction**: `gpt-5.6-mini` is not a real model — confirmed absent from `llm/data/litellm_model_catalog.json` and explicitly called out as such in `docs/superpowers/plans/2026-08-06-ws7-launch-validation.md`. `gpt-5.4-mini` is the smallest GPT mini this codebase actually supports (it's already `serf-fluency`'s own default model). |
+| Kimi K2.6 low | `kimi/kimi-k2.6` | Real model (`llm/providers/kimi/adapter_test.go`). |
+
+`low` is a valid reasoning-effort string for all three providers'
+`defaultEfforts` (`agent/provider/profile.go`). Pass `--fast-cheap-model`
+matching each arm's primary model, and `--clear-openai-api-key` for the
+OpenAI arms if running through OAuth per the main README's convention.
+
+### Reading results
+
+Compare, per arm and model: `results.jsonl`/`summary.json`'s
+`status` (passed/failed), `canonical_tool_counts`/`model_tool_counts`
+(`shell` count is a proxy for test-run iterations), and manually read the
+`state_dir` transcripts for the specific things the kata acceptance wants
+measured (see "What remains" — the runner does not compute these yet):
+how many tool rounds elapsed before the first `go test` call, whether the
+model read/greped the same file repeatedly without new information, and
+whether it reported `DIAGNOSIS_COMPLETE` with a coherent root cause versus
+converging on the wrong fix.
+
+## What remains for the controller
+
+This scaffold deliberately stops short of full kata nbcf acceptance:
+
+1. **The runner does not yet compute phase-transition metrics.**
+   `probeFile.Metrics` (`tools/tool-fluency/cmd/serf-fluency/main.go:161`)
+   is parsed from YAML but never read — `grep '\.Metrics\b'` in that
+   package has zero hits. The probe's `metrics:` block names the fields
+   kata nbcf's acceptance wants (`wants_investigative_call_count`,
+   `wants_repeated_read_or_grep_count`, `wants_tool_round_of_first_test_run`,
+   `wants_tool_round_of_first_source_edit`,
+   `wants_premature_fix_before_red_test_flag`) as a spec for that work, not
+   as something already wired up. Implementing it means walking
+   `doctor.TranscriptResult.Turns` (already available via
+   `allTranscriptToolCounts` in the same file) turn-by-turn instead of only
+   aggregating counts, and it should get its own offline unit test against a
+   synthetic transcript fixture before any live run is trusted to interpret
+   it.
+2. **No live runs have happened.** This worktree made zero LLM API calls,
+   per kata rule. The three-model A/B above needs to actually run.
+3. **No baseline-vs-candidate churn comparison exists yet.** That requires
+   (1) and (2) both done, then a report comparing analysis-churn metrics
+   between the baseline and candidate binaries per model, per kata
+   acceptance's "require a clear reduction in analysis churn without
+   increasing premature or incorrect fixes."
+4. **Report doc.** Once runs exist, write the comparison up (reports/
+   already holds the convention for this — see
+   `tools/tool-fluency/reports/2026-06-20-kimi-for-coding.md` for the
+   shape) including the exact commands, session IDs, and any
+   `blocked_infra`/`blocked_harness` results (which must not be read as
+   product/model findings — see the verification.md smoke-case rule this
+   kata just added).

--- a/tools/tool-fluency/probes-nbcf/diagnostic_fix.seeded_config_path.yaml
+++ b/tools/tool-fluency/probes-nbcf/diagnostic_fix.seeded_config_path.yaml
@@ -1,0 +1,103 @@
+# kata nbcf: opt-in agentic eval scaffold — seeded configuration-path failure.
+#
+# This probe is deliberately kept OUT of tools/tool-fluency/probes/ so it is
+# never swept into an ordinary `--probe all` run of the core tool-fluency
+# suite: it is much heavier (up to 40 shell rounds vs. 1-2 for a tool-use
+# probe) and its purpose is comparing PROMPTING variants against a
+# diagnose-then-fix workflow, not measuring single-tool-call fluency. Select
+# it explicitly:
+#
+#   go run ./tools/tool-fluency/cmd/serf-fluency run \
+#     --build \
+#     --model <provider/model> \
+#     --probes-dir tools/tool-fluency/probes-nbcf \
+#     --probe diagnostic_fix.seeded_config_path \
+#     --max-rounds 40 \
+#     --out /tmp/serf-nbcf-eval-<model-slug>
+#
+# See tools/tool-fluency/probes-nbcf/README.md for the full comparison
+# recipe (baseline vs. candidate prompting, the three required models, and
+# what metrics still need wiring into the runner).
+#
+# Seeded bug (do not repeat this line in the prompt — the model must find it
+# itself): ResolveProvidersConfig takes a homeDir parameter but the no-overrides
+# branch reads os.Getenv("HOME") instead of using it, so two calls with
+# different homeDir values silently collide on the real process HOME.
+schema: 1
+id: diagnostic_fix.seeded_config_path
+tool: shell
+prompt: |
+  The configpath package resolves the on-disk path to a provider config
+  file, following the same explicit-override / state-dir / home-dir
+  precedence Serf itself uses elsewhere. A caller reports a bug:
+
+    Calling ResolveProvidersConfig("", "", homeA) and then
+    ResolveProvidersConfig("", "", homeB) in the same process, with homeA
+    and homeB set to two different directories, returns the SAME path
+    both times — even though homeA != homeB. This breaks test isolation:
+    two isolated callers using different home directories end up pointed
+    at the same providers.toml and corrupt each other's state.
+
+  Diagnose the root cause in configpath/resolve.go. Add exactly one
+  regression test in configpath/resolve_test.go that fails before your fix
+  and passes after it — that file does not exist yet. Make the smallest
+  scoped fix; do not change ResolveProvidersConfig's signature or the
+  explicit/stateDir precedence, and do not touch anything outside the
+  configpath package. Run `go test ./configpath/...` to verify before you
+  report.
+
+  When done, report a message that starts with the exact token
+  DIAGNOSIS_COMPLETE followed by one sentence naming the root cause and one
+  sentence describing the fix.
+fixture:
+  files:
+    go.mod: |
+      module configpath
+
+      go 1.21
+    configpath/resolve.go: |
+      // Package configpath resolves the on-disk path to Serf's provider
+      // configuration file, mirroring the explicit-override / state-dir /
+      // home-dir precedence used elsewhere in the codebase.
+      package configpath
+
+      import (
+      	"os"
+      	"path/filepath"
+      )
+
+      // ResolveProvidersConfig returns the providers.toml path to use, given
+      // an explicit override, a configured state directory, and the caller's
+      // home directory. explicit wins outright; otherwise
+      // stateDir/providers.toml is used when stateDir is set; otherwise
+      // homeDir/.serf/providers.toml.
+      func ResolveProvidersConfig(explicit, stateDir, homeDir string) string {
+      	if explicit != "" {
+      		return explicit
+      	}
+      	if stateDir != "" {
+      		return filepath.Join(stateDir, "providers.toml")
+      	}
+      	return filepath.Join(os.Getenv("HOME"), ".serf", "providers.toml")
+      }
+expect:
+  calls:
+    - tool: shell
+      min: 2
+  artifacts:
+    - path: configpath/resolve_test.go
+      exists: true
+    - path: configpath/resolve.go
+      contains: homeDir string) string {
+  final_contains: ["DIAGNOSIS_COMPLETE"]
+metrics:
+  # Informational only today — tools/tool-fluency's Metrics field is parsed
+  # but not yet evaluated by the runner (grep `\.Metrics\b` in main.go: no
+  # hits). These name the kata nbcf acceptance metrics that still need a
+  # runner-side implementation; see probes-nbcf/README.md "What remains".
+  max_tool_calls: 40
+  wants_investigative_call_count: true
+  wants_repeated_read_or_grep_count: true
+  wants_tool_round_of_first_test_run: true
+  wants_tool_round_of_first_source_edit: true
+  wants_premature_fix_before_red_test_flag: true


### PR DESCRIPTION
Kata: nbcf (open — this lands the prompting half; the live multi-model eval remains)

The kata's failure mode: an agent that correctly isolates a failure boundary keeps re-analyzing instead of writing the first failing test, until a human forces the transition. Existing guidance bounds premature fixes but never defines when analysis is DONE.

Prompt changes (all additive, none weaken root-cause-first, no universal tool-call cap):
- `workflow.md.tmpl`: investigation ends at a positive condition — evidence isolates a boundary and one falsifiable hypothesis is statable; re-planning the same test is not progress. Plus a no-new-evidence checkpoint rule. Deliberately no hardcoded call-count threshold; the kata says the threshold must be validated by the eval, not copied.
- `communicate.md.tmpl`: phase-change checkpoint through the result tool (done / hypothesis / next action / blockers, end_turn=false).
- `verification.md`: smoke-case-before-matrix — infra failures are not behavior evidence.

Three deterministic composition tests pin presence and placement; five prompt mutations run RED/GREEN for real. Also: `tools/tool-fluency/probes-nbcf/` — the opt-in eval scaffold (seeded config-path bug fixture, offline validation test, README with the A/B recipe). Premise corrections recorded on the kata: the original incident's underlying bug is already fixed on main (403e580c3), and the kata's "gpt-5.6-mini" doesn't exist (gpt-5.4-mini is the real one).

https://claude.ai/code/session_017f6aYf3cJgkcg8PNAg62wX