### PR TITLE
fix(agent): preserve cancellation evidence for externally stopped delegates

### DIFF
--- a/agent/delegate_resource_retention_stop_test.go
+++ b/agent/delegate_resource_retention_stop_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"primeradiant.com/serf/agent/internal/agenttest"
@@ -101,37 +102,7 @@ func TestDelegateResourceStop_RequestFsyncPrecedesExternalCancellation(t *testin
 func TestDelegateResourceStop_ExternalCancellationPreservesRunEvidence(t *testing.T) {
 	c, _ := newDelegateControllerTestHarness(t, 1, 1)
 	seedDelegateControllerRunning(t, c, "dlg_target", "")
-
-	metadata := delegateTerminalPacketMetadata{
-		Task:        "rebuild the search index",
-		ScratchPath: "/abs/scratch/dlg_target",
-		Worktree:    &delegateTerminalWorktreeReport{Path: "/abs/worktree/dlg_target", Branch: "work", HeadSHA: "deadbeef"},
-	}
-	rawMetadata, err := json.Marshal(metadata)
-	if err != nil {
-		t.Fatalf("marshal metadata: %v", err)
-	}
-	rawMessage, err := json.Marshal("partial output gathered before cancellation")
-	if err != nil {
-		t.Fatalf("marshal message: %v", err)
-	}
-	runEvidence := &delegatestore.TerminalPacket{
-		Kind:     delegatestore.PacketTerminalError,
-		Message:  rawMessage,
-		Metadata: rawMetadata,
-	}
-
-	if _, _, _, err := c.StopSubtree(rootDelegateActor("root-session"), "dlg_target"); err != nil {
-		t.Fatalf("StopSubtree: %v", err)
-	}
-	if _, err := c.FinishGeneration(delegateLease{delegateID: "dlg_target", generation: 1}, delegateFinish{
-		outcome:     delegatestore.OutcomeCancelled,
-		disposition: delegatestore.DispositionTerminalError,
-		reason:      "cancelled",
-		packet:      runEvidence,
-	}); err != nil {
-		t.Fatalf("FinishGeneration for externally cancelled delegate: %v", err)
-	}
+	cancelDelegateWithRunEvidence(t, c, "dlg_target")
 
 	c.mu.Lock()
 	aggregate := c.durable["dlg_target"]
@@ -149,6 +120,165 @@ func TestDelegateResourceStop_ExternalCancellationPreservesRunEvidence(t *testin
 	worktree, _ := got["worktree"].(map[string]any)
 	if worktree == nil || worktree["path"] != "/abs/worktree/dlg_target" {
 		t.Fatalf("externally cancelled delegate lost its worktree evidence: %#v", got)
+	}
+}
+
+// cancelDelegateWithRunEvidence stops a running delegate and finishes its
+// generation the way an externally cancelled run loop does: with a terminal
+// packet that already carries the task, scratch path, and worktree it gathered
+// before the cancellation landed.
+func cancelDelegateWithRunEvidence(t *testing.T, c *delegateTreeController, delegateID string) {
+	t.Helper()
+	rawMetadata, err := json.Marshal(delegateTerminalPacketMetadata{
+		Task:        "rebuild the search index",
+		ScratchPath: "/abs/scratch/" + delegateID,
+		Worktree:    &delegateTerminalWorktreeReport{Path: "/abs/worktree/" + delegateID, Branch: "work", HeadSHA: "deadbeef"},
+	})
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	rawMessage, err := json.Marshal("partial output gathered before cancellation")
+	if err != nil {
+		t.Fatalf("marshal message: %v", err)
+	}
+	if _, _, _, err := c.StopSubtree(rootDelegateActor("root-session"), delegateID); err != nil {
+		t.Fatalf("StopSubtree: %v", err)
+	}
+	if _, err := c.FinishGeneration(delegateLease{delegateID: delegateID, generation: 1}, delegateFinish{
+		outcome:     delegatestore.OutcomeCancelled,
+		disposition: delegatestore.DispositionTerminalError,
+		reason:      "cancelled",
+		packet: &delegatestore.TerminalPacket{
+			Kind:     delegatestore.PacketTerminalError,
+			Message:  rawMessage,
+			Metadata: rawMetadata,
+		},
+	}); err != nil {
+		t.Fatalf("FinishGeneration for externally cancelled delegate: %v", err)
+	}
+}
+
+// completedDelegateStopResult builds the jobStopResult stopStableDelegate
+// hands to the evidence projection once a delegate stop has completed.
+func completedDelegateStopResult(delegateID string, actor delegateActor) jobStopResult {
+	reason := "stopped_by_parent"
+	return jobStopResult{
+		ID:             delegateID,
+		JobID:          delegateID,
+		Type:           "delegate",
+		Status:         string(delegateLifecycleIdle),
+		Reason:         &reason,
+		PreviousStatus: string(delegateLifecycleRunning),
+		Outcome:        "cancelled_by_request",
+		RequestedBy:    actor.describe(),
+	}
+}
+
+// TestDelegateResourceStop_JobStopProjectsPreservedEvidence closes the second
+// half of kata tpb0: retaining the packet is worth nothing unless job_stop's own
+// result carries that evidence and its footer renders it, so this drives the
+// exact projection and renderer the tool uses over real controller state.
+func TestDelegateResourceStop_JobStopProjectsPreservedEvidence(t *testing.T) {
+	c, _ := newDelegateControllerTestHarness(t, 1, 1)
+	root := &Session{id: "root-session", delegateRootSessionID: "root-session", delegateController: c}
+	c.rootRuntime = root
+	seedDelegateControllerRunning(t, c, "dlg_target", "")
+	cancelDelegateWithRunEvidence(t, c, "dlg_target")
+
+	stop := completedDelegateStopResult("dlg_target", rootDelegateActor("root-session"))
+	populateDelegateStopEvidence(&stop, root, "dlg_target")
+	if stop.ScratchPath != "/abs/scratch/dlg_target" {
+		t.Fatalf("job_stop scratch_path = %q, want the cancelled run's scratch dir", stop.ScratchPath)
+	}
+	if stop.Worktree == nil || stop.Worktree.Path != "/abs/worktree/dlg_target" ||
+		stop.Worktree.Branch != "work" || stop.Worktree.HeadSHA != "deadbeef" {
+		t.Fatalf("job_stop worktree = %#v, want the cancelled run's worktree", stop.Worktree)
+	}
+	if stop.Resumable == nil || !*stop.Resumable {
+		t.Fatalf("job_stop resumable = %#v, want true for a still-resumable delegate", stop.Resumable)
+	}
+
+	output := formatJobStop(stop)
+	for _, want := range []string{
+		"was running",
+		"requested by: root session root-session",
+		"resumable: yes",
+		"scratch: /abs/scratch/dlg_target",
+		"worktree: path=/abs/worktree/dlg_target, branch=work, head=deadbeef, 0 commits ahead, dirty=false",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("job_stop footer %q omits %q", output, want)
+		}
+	}
+}
+
+// TestDelegateResourceStop_JobStopReportsClosedResumability covers the other
+// resumable classification kata tpb0 promises: a delegate whose resumability is
+// already closed must say so, with the recorded reason, rather than leaving the
+// parent to guess whether retrying is even possible.
+func TestDelegateResourceStop_JobStopReportsClosedResumability(t *testing.T) {
+	c, _ := newDelegateControllerTestHarness(t, 1, 1)
+	root := &Session{id: "root-session", delegateRootSessionID: "root-session", delegateController: c}
+	c.rootRuntime = root
+	seedDelegateControllerRunning(t, c, "dlg_target", "")
+	cancelDelegateWithRunEvidence(t, c, "dlg_target")
+	c.mu.Lock()
+	_, err := c.appendLocked(delegatestore.Event{
+		Kind:               delegatestore.EventDelegateResumabilityClosed,
+		DelegateID:         "dlg_target",
+		ResumabilityClosed: &delegatestore.ResumabilityClosed{Reason: "turn_budget_exhausted"},
+	})
+	c.mu.Unlock()
+	if err != nil {
+		t.Fatalf("close delegate resumability: %v", err)
+	}
+
+	stop := completedDelegateStopResult("dlg_target", rootDelegateActor("root-session"))
+	populateDelegateStopEvidence(&stop, root, "dlg_target")
+	if stop.Resumable == nil || *stop.Resumable {
+		t.Fatalf("job_stop resumable = %#v, want false for a closed delegate", stop.Resumable)
+	}
+	if stop.NotResumableReason != "turn_budget_exhausted" {
+		t.Fatalf("job_stop not_resumable_reason = %q, want the recorded close reason", stop.NotResumableReason)
+	}
+	if output := formatJobStop(stop); !strings.Contains(output, "resumable: no (turn_budget_exhausted)") {
+		t.Fatalf("job_stop footer %q omits the closed-resumability reason", output)
+	}
+}
+
+// TestDelegateResourceStop_ShellStopFooterCarriesNoDelegateProvenance holds the
+// line the delegate footer must not cross: a shell job_stop renders exactly the
+// one-line job-family footer, with no cancellation provenance appended.
+func TestDelegateResourceStop_ShellStopFooterCarriesNoDelegateProvenance(t *testing.T) {
+	reason := "stopped_by_parent"
+	shell := jobStopResult{
+		ID:             "job_1",
+		JobID:          "job_1",
+		Type:           string(jobstore.JobShell),
+		Status:         string(jobstore.StatusCancelled),
+		Reason:         &reason,
+		PreviousStatus: string(jobstore.StatusRunning),
+		Outcome:        "cancelled_by_request",
+	}
+	want := "[shell job_1 · cancelled · cancelled_by_request · stopped_by_parent]"
+	if got := formatJobStop(shell); got != want {
+		t.Fatalf("shell job_stop footer = %q, want %q", got, want)
+	}
+}
+
+// TestDelegateResourceStop_CancellingActorIsNamed pins the provenance string
+// job_stop reports for each actor authorizeMutationLocked admits: the tree's
+// root session, or the exact parent delegate.
+func TestDelegateResourceStop_CancellingActorIsNamed(t *testing.T) {
+	if got, want := rootDelegateActor("root-session").describe(), "root session root-session"; got != want {
+		t.Fatalf("root actor describe() = %q, want %q", got, want)
+	}
+	parent := delegateActor{lease: &delegateLease{delegateID: "dlg_parent", generation: 2}}
+	if got, want := parent.describe(), "delegate dlg_parent"; got != want {
+		t.Fatalf("parent delegate actor describe() = %q, want %q", got, want)
+	}
+	if got := (delegateActor{}).describe(); got != "" {
+		t.Fatalf("unadmitted actor describe() = %q, want an empty description", got)
 	}
 }
 

--- a/agent/delegate_resource_retention_stop_test.go
+++ b/agent/delegate_resource_retention_stop_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"testing"
@@ -88,6 +89,66 @@ func TestDelegateResourceStop_RequestFsyncPrecedesExternalCancellation(t *testin
 	executeDelegateCancelPlan(plan)
 	if !fsyncedBeforeCancel {
 		t.Fatal("external cancellation ran before the durable stop request was readable")
+	}
+}
+
+// TestDelegateResourceStop_ExternalCancellationPreservesRunEvidence proves kata
+// tpb0's premise: FinishGeneration's PhaseStopping branch previously discarded
+// whatever the run loop had already captured (task, worktree, scratch path) and
+// replaced it with a bare "stopped by parent" packet carrying no metadata at
+// all. An externally cancelled delegate must retain that partial evidence so a
+// later job_status/delegate_send read can show it, instead of only "cancelled".
+func TestDelegateResourceStop_ExternalCancellationPreservesRunEvidence(t *testing.T) {
+	c, _ := newDelegateControllerTestHarness(t, 1, 1)
+	seedDelegateControllerRunning(t, c, "dlg_target", "")
+
+	metadata := delegateTerminalPacketMetadata{
+		Task:        "rebuild the search index",
+		ScratchPath: "/abs/scratch/dlg_target",
+		Worktree:    &delegateTerminalWorktreeReport{Path: "/abs/worktree/dlg_target", Branch: "work", HeadSHA: "deadbeef"},
+	}
+	rawMetadata, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	rawMessage, err := json.Marshal("partial output gathered before cancellation")
+	if err != nil {
+		t.Fatalf("marshal message: %v", err)
+	}
+	runEvidence := &delegatestore.TerminalPacket{
+		Kind:     delegatestore.PacketTerminalError,
+		Message:  rawMessage,
+		Metadata: rawMetadata,
+	}
+
+	if _, _, _, err := c.StopSubtree(rootDelegateActor("root-session"), "dlg_target"); err != nil {
+		t.Fatalf("StopSubtree: %v", err)
+	}
+	if _, err := c.FinishGeneration(delegateLease{delegateID: "dlg_target", generation: 1}, delegateFinish{
+		outcome:     delegatestore.OutcomeCancelled,
+		disposition: delegatestore.DispositionTerminalError,
+		reason:      "cancelled",
+		packet:      runEvidence,
+	}); err != nil {
+		t.Fatalf("FinishGeneration for externally cancelled delegate: %v", err)
+	}
+
+	c.mu.Lock()
+	aggregate := c.durable["dlg_target"]
+	c.mu.Unlock()
+	if aggregate == nil || aggregate.LatestPacket == nil {
+		t.Fatal("externally cancelled delegate has no latest terminal packet")
+	}
+	got := decodeDelegatePacketMetadata(t, *aggregate.LatestPacket)
+	if got["task"] != "rebuild the search index" {
+		t.Fatalf("externally cancelled delegate lost its task evidence: %#v", got)
+	}
+	if got["scratch_path"] != "/abs/scratch/dlg_target" {
+		t.Fatalf("externally cancelled delegate lost its scratch path evidence: %#v", got)
+	}
+	worktree, _ := got["worktree"].(map[string]any)
+	if worktree == nil || worktree["path"] != "/abs/worktree/dlg_target" {
+		t.Fatalf("externally cancelled delegate lost its worktree evidence: %#v", got)
 	}
 }
 

--- a/agent/delegate_resource_runtime_test.go
+++ b/agent/delegate_resource_runtime_test.go
@@ -1086,6 +1086,54 @@ func TestDelegateResourceRuntime_StableStopActiveCompletionReportsCancelledByReq
 	}
 }
 
+// TestDelegateResourceRuntime_StableStopReportsActorAndResumability proves kata
+// tpb0's job_stop enrichment end to end: the completed stop result names the
+// cancelling actor and the delegate's resumable classification, both in the
+// structured State and in the human-readable Output text a caller actually
+// reads.
+func TestDelegateResourceRuntime_StableStopReportsActorAndResumability(t *testing.T) {
+	harness := newStableStopRuntimeHarness(t)
+	waitCtx := newDelegateStopWaitBarrierContext()
+	result := make(chan stableJobStopInvocation, 1)
+	go func() {
+		value, err := jobStopTool(waitCtx, harness.root, map[string]any{
+			"target":      harness.fixture.delegateID,
+			"max_wait_ms": 60_000,
+		}, jobToolResultDefaultMaxChar)
+		result <- stableJobStopInvocation{value: value, err: err}
+	}()
+	select {
+	case invocation := <-result:
+		harness.release()
+		waitForStableSupervisionRun(t, harness.root, harness.fixture.childID)
+		t.Fatalf("positive stable stop returned before entering its wait: %#v, %v", invocation.value, invocation.err)
+	case <-waitCtx.entered:
+	}
+	harness.release()
+	invocation := <-result
+	assertStableStopCompleted(t, invocation, harness.fixture.delegateID, delegateLifecycleRunning, "cancelled_by_request")
+
+	state := stableJobStopState(t, invocation)
+	wantActor := "root session " + harness.root.id
+	if state.RequestedBy != wantActor {
+		t.Fatalf("job_stop requested_by = %q, want %q", state.RequestedBy, wantActor)
+	}
+	if state.Resumable == nil || !*state.Resumable {
+		t.Fatalf("job_stop resumable = %#v, want true for a fresh delegate", state.Resumable)
+	}
+
+	invoked, ok := invocation.value.(toolpkg.StateResult)
+	if !ok {
+		t.Fatalf("job_stop value = %T, want tool.StateResult", invocation.value)
+	}
+	if !strings.Contains(invoked.Output, "requested by: "+wantActor) {
+		t.Fatalf("job_stop human-readable output missing the cancelling actor: %q", invoked.Output)
+	}
+	if !strings.Contains(invoked.Output, "resumable: yes") {
+		t.Fatalf("job_stop human-readable output missing the resumable classification: %q", invoked.Output)
+	}
+}
+
 func TestDelegateResourceRuntime_StableStopIdleCompletionReportsAlreadyIdle(t *testing.T) {
 	fixture := newColdStableDelegateFixture(t, "")
 	root := restoreSupervisionRoot(t, fixture, nil)
@@ -1722,6 +1770,29 @@ func TestDelegateResourceRuntime_TerminalPacketPreservesTaskModelEffortTimingUsa
 	worktree, ok := metadata["worktree"].(map[string]any)
 	if !ok || worktree["path"] != "/repo/.worktrees/dlg_target" || worktree["branch"] != "delegate/dlg_target" || worktree["head_sha"] != "abc123" || worktree["ahead"] != float64(4) || worktree["dirty"] != true {
 		t.Fatalf("worktree metadata = %#v", metadata["worktree"])
+	}
+}
+
+// TestDelegateResourceRuntime_CancelledRunCapturesScratchPath proves kata tpb0's
+// scratch-path evidence requirement: a run that ends via ctx.Canceled (an
+// external stop, not a completion) still carries its absolute scratch
+// directory into the terminal packet metadata, the same way worktree evidence
+// already does regardless of outcome.
+func TestDelegateResourceRuntime_CancelledRunCapturesScratchPath(t *testing.T) {
+	finish := stableDelegateFinishFromRun(delegateTerminalRunInputs{
+		runErr:      context.Canceled,
+		descriptor:  delegatestore.Descriptor{Task: "rebuild the search index"},
+		scratchPath: "/abs/scratch/dlg_target",
+	})
+	if finish.outcome != delegatestore.OutcomeCancelled || finish.reason != "cancelled" {
+		t.Fatalf("cancelled run finish = outcome:%q reason:%q, want cancelled/cancelled", finish.outcome, finish.reason)
+	}
+	if finish.packet == nil {
+		t.Fatal("cancelled run terminal packet is nil")
+	}
+	metadata := decodeDelegatePacketMetadata(t, *finish.packet)
+	if got := metadata["scratch_path"]; got != "/abs/scratch/dlg_target" {
+		t.Fatalf("cancelled run metadata[scratch_path] = %#v, want the run's scratch dir", got)
 	}
 }
 

--- a/agent/delegate_tree_controller.go
+++ b/agent/delegate_tree_controller.go
@@ -91,6 +91,21 @@ type delegateActor struct {
 	lease         *delegateLease
 }
 
+// describe renders the actor as human-readable provenance for a cancellation
+// report (kata tpb0): the caller is always either the tree's root session or
+// the exact parent delegate (authorizeMutationLocked admits no other caller),
+// so this is a complete account of "who cancelled this" for job_stop's own
+// response. Empty for the zero value (no admitted actor).
+func (a delegateActor) describe() string {
+	if a.lease != nil {
+		return "delegate " + a.lease.delegateID
+	}
+	if a.rootSessionID != "" {
+		return "root session " + a.rootSessionID
+	}
+	return ""
+}
+
 type delegateLease struct {
 	delegateID string
 	generation uint64

--- a/agent/delegate_tree_finish.go
+++ b/agent/delegate_tree_finish.go
@@ -398,7 +398,17 @@ func (c *delegateTreeController) FinishGeneration(lease delegateLease, finish de
 		events = []delegatestore.Event{finished}
 
 	case delegatestore.PhaseStopping:
+		// An externally cancelled generation still reports whatever evidence its
+		// own run loop already gathered (task, worktree, scratch path — see
+		// delegateTerminalPacketMetadata) via finish.packet; only fall back to the
+		// bare synthetic packet when the run loop produced none at all (kata
+		// tpb0). The fold layer (applyRunFinished) still has final say: it
+		// replaces this with the bare packet when the owner is outside the
+		// stopped subtree or the packet isn't a terminal-error kind.
 		packet := delegateStoppedTerminalPacket()
+		if finish.packet != nil {
+			packet = cloneDelegateTerminalPacket(*finish.packet)
+		}
 		outcome = delegatestore.OutcomeStopped
 		disposition = delegatestore.DispositionTerminalError
 		reason = "stopped_by_parent"

--- a/agent/sandbox_delegate_create_test.go
+++ b/agent/sandbox_delegate_create_test.go
@@ -109,6 +109,32 @@ func TestPrepareSubagentRun_PerDelegateSandboxEnforced(t *testing.T) {
 
 }
 
+// TestPrepareSubagentRun_TerminalFinishCapturesScratchPath proves kata tpb0's
+// scratch-path wiring against a real sandboxed env: stableDelegateFinish reads
+// the delegate's own SessionScratchDir into the terminal packet metadata, the
+// same absolute path the sandboxed child actually has as $SERF_SCRATCH_DIR.
+func TestPrepareSubagentRun_TerminalFinishCapturesScratchPath(t *testing.T) {
+	lane, home := sbxLane(t)
+	facts := sbxBwrapFacts(home)
+	s := sbxDelegateSession(t, facts)
+
+	prepared := prepareWithDelegateSandbox(t, s, lane, &sandbox.SandboxPolicy{Mode: sandbox.ModeRestricted, Network: boolPtr(true)})
+
+	le, ok := prepared.sub.sess.currentEnv().(*execenv.LocalExecutionEnvironment)
+	if !ok || le.Wrapper == nil {
+		t.Fatal("sandboxed child env must have a kernel wrapper with a scratch dir")
+	}
+	wantScratch := le.SessionScratchDir()
+	if wantScratch == "" {
+		t.Fatal("sandboxed child env reports no scratch dir")
+	}
+
+	metadata := decodeDelegatePacketMetadata(t, *prepared.sub.stableDelegateFinish("", context.Canceled).packet)
+	if got := metadata["scratch_path"]; got != wantScratch {
+		t.Fatalf("terminal metadata[scratch_path] = %#v, want %q", got, wantScratch)
+	}
+}
+
 // TestPrepareSubagentRun_PerDelegateSandboxOverridesSandboxedParent: a tighter
 // per-delegate box (restricted) OVERRIDES a looser sandboxed parent (workspace-write
 // + an out-of-lane extra writable root). The child is restricted and the parent's

--- a/agent/session_tools_jobs.go
+++ b/agent/session_tools_jobs.go
@@ -897,8 +897,40 @@ func stopStableDelegate(ctx context.Context, s *Session, delegateID string, maxW
 	if maxWaitMS > 0 {
 		completed = waitForDelegateStopDone(ctx, s, result.done, clampJobBlockTimeout(maxWaitMS))
 	}
-	stop := stableDelegateStopResult(result, completed)
+	stop := stableDelegateStopResult(result, completed, actor.describe())
+	if completed {
+		populateDelegateStopEvidence(&stop, s, delegateID)
+	}
 	return tool.StateResult{Output: formatJobStop(stop), State: stop}, nil
+}
+
+// populateDelegateStopEvidence fills in the cancellation provenance kata tpb0
+// asks for once a stop has actually completed: whether this exact delegate
+// resource can still be resumed, and whatever partial scratch/worktree
+// evidence its run loop had already gathered (preserved through FinishGeneration's
+// PhaseStopping branch, see delegate_tree_finish.go). Reuses the same snapshot
+// row job_status and job_list already project — no new read path.
+func populateDelegateStopEvidence(stop *jobStopResult, s *Session, delegateID string) {
+	for _, row := range stableDelegateRowsForSession(s, true) {
+		if row.snapshot.id != delegateID {
+			continue
+		}
+		resumable := row.snapshot.resumable
+		stop.Resumable = &resumable
+		stop.NotResumableReason = row.snapshot.notResumableReason
+		if packet := row.snapshot.latestPacket; packet != nil && len(packet.Metadata) != 0 {
+			var metadata delegateTerminalPacketMetadata
+			if err := json.Unmarshal(packet.Metadata, &metadata); err == nil {
+				stop.ScratchPath = metadata.ScratchPath
+				if wt := metadata.Worktree; wt != nil {
+					stop.Worktree = &delegateWorktreeToolResult{
+						Path: wt.Path, Branch: wt.Branch, HeadSHA: wt.HeadSHA, Ahead: wt.Ahead, Dirty: wt.Dirty,
+					}
+				}
+			}
+		}
+		return
+	}
 }
 
 func waitForDelegateStopDone(ctx context.Context, s *Session, done <-chan struct{}, timeout time.Duration) bool {
@@ -919,7 +951,7 @@ func waitForDelegateStopDone(ctx context.Context, s *Session, done <-chan struct
 	}
 }
 
-func stableDelegateStopResult(result delegateStopResult, completed bool) jobStopResult {
+func stableDelegateStopResult(result delegateStopResult, completed bool, requestedBy string) jobStopResult {
 	reason := "stop_pending"
 	status := string(jobstore.StatusRunning)
 	outcome := "stop_requested"
@@ -936,6 +968,7 @@ func stableDelegateStopResult(result delegateStopResult, completed bool) jobStop
 		Reason:         &reason,
 		PreviousStatus: string(result.previousLifecycle),
 		Outcome:        outcome,
+		RequestedBy:    requestedBy,
 	}
 }
 
@@ -1143,10 +1176,25 @@ type jobStopResult struct {
 	Reason         *string `json:"reason"`
 	PreviousStatus string  `json:"previous_status"`
 	Outcome        string  `json:"outcome"`
+	// RequestedBy, Resumable, NotResumableReason, ScratchPath, and Worktree are
+	// delegate-only cancellation provenance (kata tpb0): who requested the
+	// stop, whether the same delegate resource can still be resumed, and
+	// whatever partial evidence its run loop had already gathered. Empty/nil
+	// for a shell job_stop and for a delegate stop that hasn't completed yet
+	// (status/outcome are still "running"/"stop_requested").
+	RequestedBy        string                      `json:"requested_by,omitempty"`
+	Resumable          *bool                       `json:"resumable,omitempty"`
+	NotResumableReason string                      `json:"not_resumable_reason,omitempty"`
+	ScratchPath        string                      `json:"scratch_path,omitempty"`
+	Worktree           *delegateWorktreeToolResult `json:"worktree,omitempty"`
 }
 
 // formatJobStop renders a job_stop result as a single plain-text line matching the
-// job-family footer style: [job <id> · <status> · <outcome> · <reason>].
+// job-family footer style: [job <id> · <status> · <outcome> · <reason>]. For a
+// completed delegate stop it appends the cancellation provenance kata tpb0
+// asks for: the requesting actor, the delegate's resumable classification,
+// and any partial scratch/worktree evidence its run loop had already
+// gathered before being cancelled.
 func formatJobStop(out jobStopResult) string {
 	id := out.ID
 	if id == "" {
@@ -1156,7 +1204,38 @@ func formatJobStop(out jobStopResult) string {
 	if out.Reason != nil && *out.Reason != "" {
 		parts = append(parts, *out.Reason)
 	}
-	return "[" + strings.Join(parts, " · ") + "]"
+	if out.Type == "delegate" && out.PreviousStatus != "" {
+		parts = append(parts, "was "+out.PreviousStatus)
+	}
+	var b strings.Builder
+	b.WriteString("[")
+	b.WriteString(strings.Join(parts, " · "))
+	b.WriteString("]")
+	if out.Type != "delegate" {
+		return b.String()
+	}
+	if out.RequestedBy != "" {
+		fmt.Fprintf(&b, "\nrequested by: %s", out.RequestedBy)
+	}
+	if out.Resumable != nil {
+		if *out.Resumable {
+			b.WriteString("\nresumable: yes")
+		} else {
+			reason := out.NotResumableReason
+			if reason == "" {
+				reason = "not resumable"
+			}
+			fmt.Fprintf(&b, "\nresumable: no (%s)", reason)
+		}
+	}
+	if out.ScratchPath != "" {
+		fmt.Fprintf(&b, "\nscratch: %s", out.ScratchPath)
+	}
+	if out.Worktree != nil {
+		fmt.Fprintf(&b, "\nworktree: path=%s, branch=%s, head=%s, %d commits ahead, dirty=%t",
+			out.Worktree.Path, out.Worktree.Branch, out.Worktree.HeadSHA, out.Worktree.Ahead, out.Worktree.Dirty)
+	}
+	return b.String()
 }
 
 // classifyStopOutcome distinguishes a stop that cancelled a live job from one that

--- a/agent/session_tools_jobs.go
+++ b/agent/session_tools_jobs.go
@@ -1179,9 +1179,11 @@ type jobStopResult struct {
 	// RequestedBy, Resumable, NotResumableReason, ScratchPath, and Worktree are
 	// delegate-only cancellation provenance (kata tpb0): who requested the
 	// stop, whether the same delegate resource can still be resumed, and
-	// whatever partial evidence its run loop had already gathered. Empty/nil
-	// for a shell job_stop and for a delegate stop that hasn't completed yet
-	// (status/outcome are still "running"/"stop_requested").
+	// whatever partial evidence its run loop had already gathered. All are
+	// empty/nil for a shell job_stop. RequestedBy is known at admission and so
+	// is reported on every delegate stop; the rest are read from the settled
+	// delegate row and stay empty/nil until the stop completes (status/outcome
+	// still "running"/"stop_requested").
 	RequestedBy        string                      `json:"requested_by,omitempty"`
 	Resumable          *bool                       `json:"resumable,omitempty"`
 	NotResumableReason string                      `json:"not_resumable_reason,omitempty"`

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -1772,6 +1772,12 @@ func (a *subagent) stableDelegateFinish(result string, runErr error) delegateFin
 		controller.mu.Unlock()
 	}
 	inputs.worktree = reporter.stableDelegateWorktreeReport(descriptor)
+	// SessionScratchDir is a reporting-only accessor (never provisions), so this
+	// is safe to read even on an externally cancelled run — it costs nothing and
+	// carries no side effect, matching the worktree report above.
+	if le, ok := a.sess.currentEnv().(*execenv.LocalExecutionEnvironment); ok {
+		inputs.scratchPath = le.SessionScratchDir()
+	}
 	finish := stableDelegateFinishFromRun(inputs)
 	if finish.outcome == delegatestore.OutcomeFailed && a.sess.hasSalvageFromFinalRound() && finish.packet != nil {
 		finish.packet.Warnings = appendUniqueStrings(finish.packet.Warnings, delegateSalvagedDraftNote)
@@ -1796,26 +1802,33 @@ type delegateTerminalRunInputs struct {
 	usage                   schema.CumulativeUsage
 	warnings                []string
 	worktree                *delegateWorktreeReport
+	scratchPath             string
 }
 
 type delegateTerminalPacketMetadata struct {
-	Outcome             delegatestore.OutcomeStatus     `json:"outcome,omitempty"`
-	Reason              string                          `json:"reason,omitempty"`
-	Task                string                          `json:"task,omitempty"`
-	Description         string                          `json:"description,omitempty"`
-	AgentType           string                          `json:"agent_type,omitempty"`
-	RequestedModel      string                          `json:"requested_model,omitempty"`
-	ResolvedProfileID   string                          `json:"resolved_profile_id,omitempty"`
-	ResolvedModel       string                          `json:"resolved_model,omitempty"`
-	ReasoningEffort     string                          `json:"reasoning_effort,omitempty"`
-	RunStartedAt        string                          `json:"run_started_at,omitempty"`
-	RunEndedAt          string                          `json:"run_ended_at,omitempty"`
-	LatestActivityAt    string                          `json:"latest_activity_at,omitempty"`
-	CumulativeUsage     *schema.CumulativeUsage         `json:"cumulative_usage,omitempty"`
-	Worktree            *delegateTerminalWorktreeReport `json:"worktree,omitempty"`
-	ExhaustionBudget    delegatestore.ExhaustionBudget  `json:"exhaustion_budget,omitempty"`
-	ExhaustionLimit     int                             `json:"exhaustion_limit,omitempty"`
-	ExhaustionResumable *bool                           `json:"resumable,omitempty"`
+	Outcome           delegatestore.OutcomeStatus     `json:"outcome,omitempty"`
+	Reason            string                          `json:"reason,omitempty"`
+	Task              string                          `json:"task,omitempty"`
+	Description       string                          `json:"description,omitempty"`
+	AgentType         string                          `json:"agent_type,omitempty"`
+	RequestedModel    string                          `json:"requested_model,omitempty"`
+	ResolvedProfileID string                          `json:"resolved_profile_id,omitempty"`
+	ResolvedModel     string                          `json:"resolved_model,omitempty"`
+	ReasoningEffort   string                          `json:"reasoning_effort,omitempty"`
+	RunStartedAt      string                          `json:"run_started_at,omitempty"`
+	RunEndedAt        string                          `json:"run_ended_at,omitempty"`
+	LatestActivityAt  string                          `json:"latest_activity_at,omitempty"`
+	CumulativeUsage   *schema.CumulativeUsage         `json:"cumulative_usage,omitempty"`
+	Worktree          *delegateTerminalWorktreeReport `json:"worktree,omitempty"`
+	// ScratchPath is the delegate's absolute per-session scratch directory
+	// (SessionScratchDir), reported for the same reason Worktree is: it is
+	// partial evidence a parent needs to recover after an externally cancelled
+	// run (kata tpb0), retained on disk regardless of outcome. Empty when the
+	// delegate never provisioned one (unsandboxed and no tool spawned yet).
+	ScratchPath         string                         `json:"scratch_path,omitempty"`
+	ExhaustionBudget    delegatestore.ExhaustionBudget `json:"exhaustion_budget,omitempty"`
+	ExhaustionLimit     int                            `json:"exhaustion_limit,omitempty"`
+	ExhaustionResumable *bool                          `json:"resumable,omitempty"`
 }
 
 type delegateTerminalWorktreeReport struct {
@@ -1947,6 +1960,7 @@ func delegateTerminalMetadataFromRun(inputs delegateTerminalRunInputs) delegateT
 			Dirty:   inputs.worktree.Dirty,
 		}
 	}
+	metadata.ScratchPath = inputs.scratchPath
 	return metadata
 }
 

--- a/docs/job-control.md
+++ b/docs/job-control.md
@@ -997,10 +997,13 @@ Return shape:
 (kata tpb0): who requested the stop, whether this exact delegate resource can
 still be resumed (the same classification `job_status` reports), and whatever
 partial scratch/worktree evidence its run loop had already gathered before
-being cancelled. All are omitted for a shell `job_stop` and for a delegate
-stop that has not completed yet (`status`/`outcome` still `running`/
-`stop_requested`). `job_stop` never infers or performs a retry/resume itself —
-the parent decides what to do with this evidence.
+being cancelled. All are omitted for a shell `job_stop`. `requested_by` is
+reported on every delegate stop, including one that has not completed yet;
+`resumable`, `not_resumable_reason`, `scratch_path`, and `worktree` are read
+from the settled delegate and are omitted until the stop completes
+(`status`/`outcome` still `running`/`stop_requested`). `job_stop` never infers
+or performs a retry/resume itself — the parent decides what to do with this
+evidence.
 
 ```mermaid
 stateDiagram-v2

--- a/docs/job-control.md
+++ b/docs/job-control.md
@@ -984,9 +984,23 @@ Return shape:
   "status": "idle",
   "reason": "stopped_by_parent",
   "previous_status": "running",
-  "outcome": "cancelled_by_request"
+  "outcome": "cancelled_by_request",
+  "requested_by": "root session sess_...",
+  "resumable": true,
+  "scratch_path": "/abs/path/to/scratch",
+  "worktree": {"path": "/abs/path/to/worktree", "branch": "delegate/dlg_...", "head_sha": "...", "ahead_commits": 0, "dirty": false}
 }
 ```
+
+`requested_by`, `resumable`, `not_resumable_reason`, `scratch_path`, and
+`worktree` are cancellation provenance for an externally stopped delegate
+(kata tpb0): who requested the stop, whether this exact delegate resource can
+still be resumed (the same classification `job_status` reports), and whatever
+partial scratch/worktree evidence its run loop had already gathered before
+being cancelled. All are omitted for a shell `job_stop` and for a delegate
+stop that has not completed yet (`status`/`outcome` still `running`/
+`stop_requested`). `job_stop` never infers or performs a retry/resume itself —
+the parent decides what to do with this evidence.
 
 ```mermaid
 stateDiagram-v2


### PR DESCRIPTION
Kata: tpb0 (closed with this fix)

At base, an externally cancelled delegate reported nothing: `FinishGeneration`'s `PhaseStopping` branch unconditionally replaced whatever evidence the run loop had gathered with a bare metadata-free "stopped by parent" packet, and `job_stop`'s footer dropped the already-computed previous phase. Jesse's recorded decision on the kata (2026-08-03) specifies the fix shape: report the cancelling actor, reason, lifecycle phase, scratch path, and partial artifacts, human-readable; cleanup stays manual; no auto retry/resume — the parent decides.

Changes (additive fields only — the recorded no-new-lifecycle-schema constraint holds):
- `PhaseStopping` now preserves `finish.packet` when the run loop produced one; the fold layer keeps final say.
- Scratch-path capture alongside the existing worktree capture in `stableDelegateFinish`.
- `job_stop` on a delegate target now reports `requested_by`, `resumable`/`not_resumable_reason`, `scratch_path`, `worktree`, and renders `previous_status`; all omitempty and delegate-gated, shell `job_stop` byte-for-byte unchanged. `docs/job-control.md` return-shape section extended to match.

Verification: four new tests, five mutations run for real (incl. reverting the packet preservation and skipping the evidence population); delegate-family suite under `-race` green; full `make lint`+`make test` green on the integration branch. Deferred, documented on the kata: threading this evidence into `delegate_send`'s footer, and durable actor persistence across restarts.

https://claude.ai/code/session_017f6aYf3cJgkcg8PNAg62wX