### PR TITLE
fix(agent): give the steering-only carrier turn a real identity

### DIFF
--- a/agent/entrykind_audit_test.go
+++ b/agent/entrykind_audit_test.go
@@ -76,6 +76,7 @@ var entryKindTurnOpening = map[EntryKind]turnOpening{
 	EntryContinuation:      opensOnItsContentEvent,
 	EntryNotification:      opensOnTurnStarted,
 	EntryDelegateAttention: unservedSoUnaddressable,
+	EntrySteeringCarrier:   opensOnTurnStarted,
 }
 
 func TestEveryEntryKindDeclaresHowItsTurnOpens(t *testing.T) {

--- a/agent/session_client_mutation_queue.go
+++ b/agent/session_client_mutation_queue.go
@@ -224,6 +224,18 @@ func (s *Session) ProcessPendingUserInput(ctx context.Context, onRunnable func(s
 		// callers rely on.
 		return "", false, nil
 	}
+	// Hand the claim back on EVERY exit, not just the ones that reach
+	// processOneInput's own deferred release. That defer is registered several
+	// early returns into the call: the entry gate refuses a closed session
+	// before it, and so does the cancellation check processOneInput makes
+	// before taking any name. A claim stranded on either is not recoverable --
+	// the pending steer still owns the id, so forgetRunningTurnNoOneOwns leaves
+	// it alone at load -- and every later turn/start is then refused with "turn
+	// is already active" for the life of the session, across restarts.
+	// releaseRunningTurnID compare-and-clears, so on the ordinary path (where
+	// the turn's own release already ran, or a later mutation took the slot)
+	// this is a no-op.
+	defer s.releaseRunningTurnID(turnID)
 	if onRunnable != nil {
 		onRunnable(turnID)
 	}

--- a/agent/session_client_mutation_queue.go
+++ b/agent/session_client_mutation_queue.go
@@ -174,7 +174,7 @@ func (s *Session) clientMutationQueue(params appwire.TurnQueueParams) (appwire.T
 
 // ProcessPendingUserInput runs input the user has already given but the session
 // has not delivered -- a queued message, or steering with no turn to land in --
-// as USER input, and reports whether it ran a turn.
+// and reports whether it ran a turn.
 //
 // It is the counterpart to ProcessClientMutationStart, and exists for the same
 // reason: the entry gate refuses every non-user kind while a question is
@@ -182,20 +182,23 @@ func (s *Session) clientMutationQueue(params appwire.TurnQueueParams) (appwire.T
 // loop that would run it. The gate is right to refuse autonomous wakes, and
 // this is not one -- it is the user speaking.
 //
-// Entering as EntryUserInput is also what makes the user's message supersede an
-// unanswered question, which is the intended semantic: someone who types
-// instead of answering has moved past it. The drain loop already agrees --
-// selectDrainNextAction runs queued input ahead of everything else while
-// awaiting.
+// A queued message enters as EntryUserInput, which is also what makes it
+// supersede an unanswered question: someone who types instead of answering has
+// moved past it. The drain loop already agrees -- selectDrainNextAction runs
+// queued input ahead of everything else while awaiting.
 //
 // A queued message runs as its own turn. Pending steering has no turn of its
-// own to run: it is drained into whatever turn is starting, so an empty user
-// turn is what carries it, exactly as the notification wake used to.
+// own to run: it is drained into a turn built to carry it, entering as
+// EntrySteeringCarrier -- a kind that passes the same pending-question gate as
+// EntryUserInput (steering is the user speaking too) but is not routed through
+// acceptUserInput, so it costs no MaxTurns slot and appends no empty user turn.
 //
 // onRunnable, when non-nil, is called with the turn id at the moment a claim
 // becomes real, so the daemon can publish the running turn and wire
-// cancellation to it before the turn starts producing. Steering has no such id
-// to report -- the turn it rides is one the session starts for itself.
+// cancellation to it before the turn starts producing. For steering that id is
+// claimSteeringCarrierTurn's -- one of the pending steer mutations' own
+// reserved ids, not a freshly minted one, so the id the client was told in its
+// Applied receipt is the id that actually runs.
 func (s *Session) ProcessPendingUserInput(ctx context.Context, onRunnable func(string)) (string, bool, error) {
 	if err := s.ensureClientMutationStore(); err != nil {
 		return "", false, err
@@ -212,8 +215,75 @@ func (s *Session) ProcessPendingUserInput(ctx context.Context, onRunnable func(s
 	if !s.hasPendingUserSteering() {
 		return "", false, nil
 	}
-	result, err := s.ProcessInputKind(ctx, "", nil, EntryUserInput)
+	turnID, ok := s.claimSteeringCarrierTurn()
+	if !ok {
+		// Another mutation already owns the active-turn slot, or an interrupt
+		// fence is ending one: this wake cannot name itself. Stand down rather
+		// than run unaddressable -- the steering stays queued for whichever
+		// turn runs next, the same stand-down contract mintRunningTurnID's
+		// callers rely on.
+		return "", false, nil
+	}
+	if onRunnable != nil {
+		onRunnable(turnID)
+	}
+	ctx = withSteeringCarrierTurn(ctx, turnID)
+	result, err := s.ProcessInputKind(ctx, "", nil, EntrySteeringCarrier)
 	return result, true, err
+}
+
+// steeringCarrierContextKey carries the turn id claimSteeringCarrierTurn
+// reserved from ProcessPendingUserInput down into processOneInput, the same
+// way queuedClientMutationContextKey carries a claimed queue entry's identity.
+type steeringCarrierContextKey struct{}
+
+func withSteeringCarrierTurn(ctx context.Context, turnID string) context.Context {
+	return context.WithValue(ctx, steeringCarrierContextKey{}, turnID)
+}
+
+func steeringCarrierTurnIDFromContext(ctx context.Context) string {
+	turnID, _ := ctx.Value(steeringCarrierContextKey{}).(string)
+	return turnID
+}
+
+// claimSteeringCarrierTurn reserves the durable turn identity for a wake whose
+// only job is to carry already-accepted user steering. It reuses the id the
+// head of the pending steering already reserved at its own acceptance --
+// reserveClientMutationTurnID, called from clientMutationSteer/Drain/Promote
+// -- rather than minting a fresh one, so the id returned in that mutation's
+// Applied receipt is the id that actually runs.
+//
+// Returns ok=false when nothing is claimable: an interrupt fence is ending a
+// turn, another mutation already holds the active-turn slot, or (a benign
+// race with whatever cleared hasPendingUserSteering's answer between the
+// caller's check and this call) no user steering is left pending. The caller
+// treats every case the same way -- stand down -- because the steering that
+// prompted the wake, if still queued, stays queued for whichever turn runs
+// next; nothing is lost by waiting.
+func (s *Session) claimSteeringCarrierTurn() (turnID string, ok bool) {
+	if err := s.ensureClientMutationStore(); err != nil {
+		s.emit(events.EventWarning, events.WarningData{Message: fmt.Sprintf("open client mutation store: %v", err)})
+		return "", false
+	}
+	if err := s.clientMutations.mutate(func(snapshot *clientMutationSnapshot) error {
+		if snapshot.InterruptFence != nil || snapshot.ActiveTurnID != "" {
+			return nil
+		}
+		for _, id := range snapshot.SteeringOrder {
+			pending, exists := snapshot.PendingExecutions[id]
+			if !exists || pending.ExecutionState != "accepted" || pending.TurnID == "" {
+				continue
+			}
+			snapshot.ActiveTurnID = pending.TurnID
+			turnID = pending.TurnID
+			return nil
+		}
+		return nil
+	}); err != nil {
+		s.emit(events.EventWarning, events.WarningData{Message: fmt.Sprintf("claim steering carrier turn failed: %v", err)})
+		return "", false
+	}
+	return turnID, turnID != ""
 }
 
 // AcceptClientMutationQueue durably accepts or replays one client-authored

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -400,6 +400,16 @@ const (
 	// EntryDelegateAttention is a controller-owned stable delegate generation
 	// whose exact model-bound input is already durable in the receiver transcript.
 	EntryDelegateAttention
+	// EntrySteeringCarrier is a turn whose only job is to carry already-accepted
+	// user steering that has no turn of its own to land in -- the wake
+	// ProcessPendingUserInput runs when nothing is queued but user steering is
+	// pending. It passes the pending-question gate the way EntryUserInput does
+	// (the user's steering supersedes an unanswered question just as a queued
+	// message would), but does not route through acceptUserInput: it carries no
+	// user text, so it skips MaxTurns, s.turns++, and the TurnUserInput
+	// transcript append, mirroring EntryNotification's accounting instead of
+	// EntryUserInput's.
+	EntrySteeringCarrier
 	// entryKindCount is the number of EntryKind values. Keep it last: the
 	// turn-opening audit (entrykind_audit_test.go) iterates up to it, so a kind
 	// added above this line must declare how its turn acquires an identity
@@ -589,7 +599,10 @@ func (s *Session) processInputKindWithProvenance(ctx context.Context, input stri
 	// wake source's own durable queue (jobstore notifications, the goal engine,
 	// the watch outbox) untouched, so it redelivers once the boundary drains
 	// after the user's reply. EntryUserInput is always accepted — it is how the
-	// reply resolves awaiting (spec §5.2).
+	// reply resolves awaiting (spec §5.2). EntrySteeringCarrier is accepted for
+	// the same reason a queued message is: the steering it carries is the user
+	// speaking, not an autonomous wake, so it must reach the model rather than
+	// wait behind a question the user has already moved past.
 	//
 	// Gated on the pending set, not raw state (attention-status-model v5
 	// reconciliation): SessionAwaiting used to imply "a question is pending" —
@@ -601,7 +614,7 @@ func (s *Session) processInputKindWithProvenance(ctx context.Context, input stri
 	// pending question is a stronger stop than the wake (a delegate finishing
 	// while the user reads a QUESTION must not silently resolve it out from
 	// under them); a general re-arm has nothing pending to protect.
-	if len(s.askPending) > 0 && kind != EntryUserInput {
+	if len(s.askPending) > 0 && kind != EntryUserInput && kind != EntrySteeringCarrier {
 		s.mu.Unlock()
 		return "", nil
 	}
@@ -1152,6 +1165,16 @@ func (s *Session) processOneInput(ctx context.Context, input string, images []Im
 		rootAttentionAccepted = true
 	} else if kind == EntryDelegateAttention {
 		s.acceptDelegateAttentionInput()
+	} else if kind == EntrySteeringCarrier {
+		// Also arrives already named: claimSteeringCarrierTurn reserved the id
+		// (the steering mutation's own, reserved at its acceptance) and
+		// published it into ActiveTurnID before ProcessPendingUserInput ever
+		// called ProcessInputKind, so onRunnable already handed it to the
+		// daemon and cancellation is wired before this point runs.
+		runningTurnID = steeringCarrierTurnIDFromContext(ctx)
+		if !s.acceptSteeringCarrierInput(ctx, runningTurnID) {
+			return "", false, nil
+		}
 	} else if err := s.acceptUserInput(ctx, input, images, inputProvenance, kind == EntryUserInput); err != nil {
 		return "", false, err
 	}
@@ -1708,6 +1731,41 @@ func (s *Session) acceptNotificationInput(ctx context.Context, turnID string) (p
 	}
 
 	// Drain any pending steering messages before the first LLM call (spec 2.5).
+	s.injectDrainedSteering()
+	return true
+}
+
+// acceptSteeringCarrierInput opens a turn whose only job is to carry
+// already-accepted user steering that has no turn of its own to land in. It
+// is acceptUserInput's notification-style sibling for this one shape: no
+// MaxTurns check, no s.turns++, no TurnUserInput transcript append, because
+// nothing about this turn is user-typed text -- the input already ran through
+// turn/steer's (or drain's, or promote's) accept path, and only needs
+// somewhere to land.
+//
+// turnID is the id claimSteeringCarrierTurn reserved and published to
+// ActiveTurnID before this call, and handed to the daemon via onRunnable
+// before the model call starts. It is one of the pending steer mutations' own
+// reserved ids -- not a freshly minted one -- so the id the client was told in
+// its Applied receipt is the id that actually runs, which is what lets an
+// interrupt's fence match the turn it cancels.
+//
+// It returns false when nothing is left to deliver -- a race with a turn that
+// drained the steering first between the wake deciding to run and this call
+// -- so the caller can stand down without opening a turn that carries
+// nothing.
+func (s *Session) acceptSteeringCarrierInput(ctx context.Context, turnID string) (proceed bool) {
+	if !s.hasPendingUserSteering() {
+		s.finishNotificationNoop()
+		return false
+	}
+	s.repairOrphanedToolResults("before accepting steering carrier")
+	// The announce precedes every content event of the turn, the same as
+	// acceptNotificationInput's boundary: content emitted before it would be
+	// attributed to the turn before this one.
+	if s.servedByDaemon() {
+		s.emit(events.EventTurnStarted, events.TurnStartedData{TurnID: turnID})
+	}
 	s.injectDrainedSteering()
 	return true
 }

--- a/agent/session_steering_carrier_test.go
+++ b/agent/session_steering_carrier_test.go
@@ -1,0 +1,168 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"primeradiant.com/serf/agent/schema"
+	"primeradiant.com/serf/appwire"
+)
+
+// Kata t9kt: the steering-only carrier turn ran as an empty user turn and was
+// never made runnable. Two defects, both properties of the four-line branch
+// that used to close ProcessPendingUserInput: (1) routing the steering-only
+// wake through acceptUserInput's full user-turn accounting meant a MaxTurns
+// ceiling failed the carrier turn before injectDrainedSteering ever ran,
+// stranding the Applied steering with nothing left to wake it; (2) onRunnable
+// was only ever called on the queued-message branch, so the carrier turn
+// never reserved or published a durable turn id, and the daemon never wired
+// cancellation to it.
+//
+// These two tests pin the acceptance criteria named in the kata.
+
+// TestSteeringOnlyCarrierDeliversAtMaxTurnsCeilingWithoutAnEmptyUserTurn is
+// acceptance criterion 1: a steering-only wake at the MaxTurns ceiling still
+// delivers its steering, and appends no empty user turn.
+//
+// Before the fix, ProcessPendingUserInput ran the steering-only branch as
+// ProcessInputKind(ctx, "", nil, EntryUserInput), which went through
+// acceptUserInput -- and acceptUserInput's MaxTurns check runs before its
+// injectDrainedSteering call. At the ceiling, claimDirectClientMutationTurn
+// returned budgetExhaustionError before the turn ever appended anything or
+// drained the steer, leaving the Applied mutation pending forever.
+func TestSteeringOnlyCarrierDeliversAtMaxTurnsCeilingWithoutAnEmptyUserTurn(t *testing.T) {
+	sess, adapter, _ := newBudgetSession(t, SessionConfig{MaxTurns: 1}, nil)
+	sess.mu.Lock()
+	sess.turns = 1 // already at the ceiling
+	sess.mu.Unlock()
+	if err := sess.ensureClientMutationStore(); err != nil {
+		t.Fatalf("ensureClientMutationStore: %v", err)
+	}
+	if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "cm-steer-at-ceiling",
+		Input:            []appwire.InputItem{{Type: "text", Text: "steer at the ceiling"}},
+	}); err != nil {
+		t.Fatalf("AcceptClientMutationSteer: %v", err)
+	}
+	historyBefore := len(budgetHistory(sess))
+
+	var reportedTurnID string
+	_, ran, err := sess.ProcessPendingUserInput(context.Background(), func(turnID string) {
+		reportedTurnID = turnID
+	})
+	if err != nil {
+		t.Fatalf("ProcessPendingUserInput at the MaxTurns ceiling: %v", err)
+	}
+	if !ran {
+		t.Fatal("ProcessPendingUserInput did not run; the steering was lost at the ceiling")
+	}
+	if reportedTurnID == "" {
+		t.Fatal("onRunnable was never called; the daemon cannot publish or cancel this turn")
+	}
+	if sess.hasPendingSteering() {
+		t.Fatal("steering is still pending after the carrier turn ran; it was accepted and never delivered")
+	}
+
+	history := budgetHistory(sess)
+	for _, turn := range history[historyBefore:] {
+		if turn.Kind == schema.TurnUserInput {
+			t.Fatalf("the carrier turn appended an empty user turn: %+v", turn)
+		}
+	}
+	if got := countBudgetSteering(history, "steer at the ceiling"); got != 1 {
+		t.Fatalf("delivered steering count = %d, want 1", got)
+	}
+
+	sess.mu.Lock()
+	turnsAfter := sess.turns
+	sess.mu.Unlock()
+	if turnsAfter != 1 {
+		t.Fatalf("s.turns = %d after the carrier turn, want unchanged at 1 (notification-style accounting, not a user turn)", turnsAfter)
+	}
+	requests := adapter.Requests()
+	if len(requests) != 1 {
+		t.Fatalf("model requests = %d, want 1; the steering must actually reach the model", len(requests))
+	}
+	// The steering must be drained into history BEFORE the first LLM call of
+	// the carrier turn (spec 2.5), not merely by the time the turn ends -- the
+	// round loop's own post-tool-round drain (session_tool_round.go) would
+	// eventually pick it up either way, which would pass this test for the
+	// wrong reason if it only checked the transcript after the turn returned.
+	if !requestHasExactUserMessage(requests[0], "steer at the ceiling") {
+		t.Fatalf("first model request missing the steering message: %+v", requests[0].Messages)
+	}
+}
+
+// TestSteeringOnlyCarrierInterruptCancelsTheModelRequestAndMatchesTurnAuthority
+// is acceptance criterion 2: an interrupt during a steering-only carrier turn
+// actually cancels the model request, and the projected turn id matches the
+// mutation's authority.
+//
+// Before the fix, onRunnable was never called on the steering-only branch, so
+// cmd/serf/serve.go never installed the daemon's cancellation callback for it
+// -- an interrupt would return Applied without cancelling anything. This test
+// drives a real in-flight model call (blockingAdapter) and a real
+// InterruptClientMutation, and checks the id ProcessPendingUserInput reports
+// is the same id the steer's own Applied receipt already promised the client.
+func TestSteeringOnlyCarrierInterruptCancelsTheModelRequestAndMatchesTurnAuthority(t *testing.T) {
+	blocked := make(chan struct{})
+	sess := newSession(t, withAdapter(&blockingAdapter{name: "openai", blocked: blocked}))
+	if err := sess.ensureClientMutationStore(); err != nil {
+		t.Fatalf("ensureClientMutationStore: %v", err)
+	}
+
+	steerResp, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "cm-steer-interrupt",
+		Input:            []appwire.InputItem{{Type: "text", Text: "steer me"}},
+	})
+	if err != nil {
+		t.Fatalf("AcceptClientMutationSteer: %v", err)
+	}
+	wantTurnID := steerResp.Receipt.TurnID
+	if wantTurnID == "" {
+		t.Fatal("the steer's own Applied receipt carried no turn id; this test cannot check authority")
+	}
+
+	turnCtx, cancelTurn := context.WithCancel(context.Background())
+	defer cancelTurn()
+
+	var reportedTurnID string
+	done := make(chan error, 1)
+	go func() {
+		_, _, procErr := sess.ProcessPendingUserInput(turnCtx, func(turnID string) {
+			reportedTurnID = turnID
+		})
+		done <- procErr
+	}()
+
+	<-blocked // the model call is genuinely in flight
+
+	if reportedTurnID != wantTurnID {
+		t.Fatalf("onRunnable reported turn %q, want the steer's own reserved turn %q -- the projected turn id does not match mutation authority", reportedTurnID, wantTurnID)
+	}
+	if got := sess.clientMutations.snapshot().ActiveTurnID; got != wantTurnID {
+		t.Fatalf("ActiveTurnID = %q while the carrier is running, want %q", got, wantTurnID)
+	}
+
+	cancels := 0
+	var procErr error
+	if _, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+		ClientMutationID: "interrupt-steering-carrier",
+	}, func() {
+		cancels++
+		cancelTurn()
+		procErr = <-done
+	}); err != nil {
+		t.Fatalf("InterruptClientMutation: %v", err)
+	}
+	if cancels != 1 {
+		t.Fatalf("interrupt's cancelAndWait ran %d times, want 1 -- the model request was not actually cancelled", cancels)
+	}
+	if !errors.Is(procErr, context.Canceled) {
+		t.Fatalf("ProcessPendingUserInput error after interrupt = %v, want context.Canceled", procErr)
+	}
+	if got := sess.clientMutations.snapshot().InterruptFence; got != nil {
+		t.Fatalf("interrupt fence left set: %#v", got)
+	}
+}

--- a/agent/session_steering_carrier_test.go
+++ b/agent/session_steering_carrier_test.go
@@ -166,3 +166,95 @@ func TestSteeringOnlyCarrierInterruptCancelsTheModelRequestAndMatchesTurnAuthori
 		t.Fatalf("interrupt fence left set: %#v", got)
 	}
 }
+
+// TestSteeringOnlyCarrierHandsBackAClaimTheTurnNeverUsed is the obligation the
+// claim takes on by publishing ActiveTurnID from OUTSIDE processOneInput:
+// whatever happens next, the id comes back.
+//
+// processOneInput's own deferred releaseRunningTurnID covers the turn once it
+// starts, but it is registered several early returns into the call --
+// processInputKindWithProvenance refuses a closed session before it, and
+// processOneInput checks its context for cancellation before it. A claim
+// stranded on either of those is permanent rather than merely untidy: the
+// pending steer that reserved the id still owns it, so forgetRunningTurnNoOneOwns
+// (the load-time sweep for ids nobody will settle) deliberately leaves it
+// alone, and AcceptClientMutationStart's precondition then refuses every later
+// turn/start with "turn is already active" -- across restarts, for the life of
+// the session.
+func TestSteeringOnlyCarrierHandsBackAClaimTheTurnNeverUsed(t *testing.T) {
+	cases := []struct {
+		name string
+		// arrange makes the wake fail before processOneInput registers its
+		// release, and reports the context to wake with.
+		arrange func(sess *Session) context.Context
+	}{
+		{
+			name: "turn context already cancelled",
+			arrange: func(*Session) context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+		},
+		{
+			name: "session closed",
+			arrange: func(sess *Session) context.Context {
+				sess.Close()
+				return context.Background()
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sess := newSession(t)
+			if err := sess.ensureClientMutationStore(); err != nil {
+				t.Fatalf("ensureClientMutationStore: %v", err)
+			}
+			if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+				ClientMutationID: "cm-steer-unused-claim",
+				Input:            []appwire.InputItem{{Type: "text", Text: "steer"}},
+			}); err != nil {
+				t.Fatalf("AcceptClientMutationSteer: %v", err)
+			}
+
+			ctx := tc.arrange(sess)
+			if _, _, err := sess.ProcessPendingUserInput(ctx, nil); err == nil {
+				t.Fatal("the wake reported success; this case is meant to fail before the turn runs")
+			}
+
+			if got := sess.clientMutations.snapshot().ActiveTurnID; got != "" {
+				t.Fatalf("ActiveTurnID = %q after a wake whose turn never ran: the claim was never handed back, "+
+					"and a pending steer owns it so nothing at load will clear it -- every later turn/start is refused", got)
+			}
+		})
+	}
+}
+
+// TestSteeringOnlyCarrierStrandedClaimWouldRefuseTheNextTurnStart names the
+// consequence the test above exists to prevent, on the one case where the
+// session is still open enough to prove it: a stranded claim is not a bookkeeping
+// wart, it is a session that can never start another turn.
+func TestSteeringOnlyCarrierStrandedClaimWouldRefuseTheNextTurnStart(t *testing.T) {
+	sess := newSession(t)
+	if err := sess.ensureClientMutationStore(); err != nil {
+		t.Fatalf("ensureClientMutationStore: %v", err)
+	}
+	if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "cm-steer-then-start",
+		Input:            []appwire.InputItem{{Type: "text", Text: "steer"}},
+	}); err != nil {
+		t.Fatalf("AcceptClientMutationSteer: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, _, err := sess.ProcessPendingUserInput(ctx, nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ProcessPendingUserInput on a cancelled context = %v, want context.Canceled", err)
+	}
+
+	if _, err := sess.AcceptClientMutationStart(appwire.TurnStartParams{
+		ClientMutationID: "cm-start-after-the-wake",
+		Input:            []appwire.InputItem{{Type: "text", Text: "hello"}},
+	}); err != nil {
+		t.Fatalf("turn/start after a wake that never ran: %v -- the carrier's claim is still holding the session's turn identity", err)
+	}
+}

--- a/agent/session_steering_wake_mid_turn_test.go
+++ b/agent/session_steering_wake_mid_turn_test.go
@@ -1,0 +1,143 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"primeradiant.com/serf/agent/internal/agenttest"
+	"primeradiant.com/serf/appwire"
+	"primeradiant.com/serf/llm"
+)
+
+// Kata dz5j: steering queued against a turn that ends without communicate
+// waits for the next user input.
+//
+// Neither of steering's two in-turn delivery paths covers a turn whose LAST
+// round produces no tool calls at all: the communicate inbox
+// (drainSteeringForCommunicate) requires the model to call the result tool,
+// and injectDrainedSteering's post-tool-round site (injectPostToolSteering,
+// session_tool_round.go) is only reached from the branch that handles a round
+// WITH tool calls -- a bare-text round takes the len(calls)==0 branch
+// (session_lifecycle.go) and, once the bare-text retry budget
+// (maxBareTextRetries) is spent, the turn ends there without ever reaching
+// either drain site.
+//
+// What this test settles is whether that gap actually strands the steering
+// today, or whether it is already closed by wakeForPendingSteering's
+// unconditional kick (agent/session_client_mutation_queue.go) -- added, per
+// its own doc comment, for exactly this race ("a turn can pass its final
+// steering drain and still own the turn id, so a steer arriving in that
+// window would be skipped ... and then never looked at again"). The turn
+// under test runs as a durable queued client mutation (turn/queue), so
+// ActiveTurnID is genuinely held while the steer lands mid-turn -- the same
+// shape the kata's own confirm recipe describes (a client mutation already
+// told Applied, sitting behind a turn that is really running).
+//
+// If the wake fires and the redelivery lands, the kata's defect is already
+// fixed at this commit and this test pins that; if not, it fails and names
+// the gap precisely.
+func TestSteeringArrivingMidTurnIsDeliveredByTheWakeAfterABareTextEnd(t *testing.T) {
+	var sess *Session
+	calls := 0
+	var steerOnce sync.Once
+	var steerErr error
+
+	adapter := &agenttest.ScriptedAdapter{
+		Provider: "openai",
+		Responder: func(req llm.Request) llm.Response {
+			calls++
+			if calls == 1 {
+				// Injected from inside the model call, mid-turn: the durable
+				// queue claim already set ActiveTurnID (popQueueHead, before
+				// ProcessInputKind ever ran), and this round has no tool call
+				// of its own, so it is also strictly after this turn's only
+				// possible in-turn drain point for THIS round.
+				steerOnce.Do(func() {
+					_, steerErr = sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+						ClientMutationID: "cm-steer-mid-turn",
+						Input:            []appwire.InputItem{{Type: "text", Text: "steer mid turn"}},
+					})
+				})
+			}
+			if calls <= maxBareTextRetries+1 {
+				// Bare text, no tool calls, for the whole of the first turn:
+				// it never calls the result tool and never has a tool round
+				// of its own, so neither in-turn steering drain site is ever
+				// reached, and the bare-text retry budget exhausts.
+				return llm.Response{Message: llm.Assistant("thinking, no tool yet")}
+			}
+			// The redelivery turn (ProcessPendingUserInput's carrier): end
+			// cleanly so the test can inspect what it delivered.
+			return communicateResponse(true, "done")
+		},
+	}
+	client := llm.NewClient()
+	client.Register(adapter)
+	sess = newSession(t, withClient(client))
+	if err := sess.ensureClientMutationStore(); err != nil {
+		t.Fatalf("ensureClientMutationStore: %v", err)
+	}
+	queueOneMutation(t, sess, "cm-first-turn", "go")
+
+	var wakeMu sync.Mutex
+	wakes := 0
+	sess.SetPendingUserInputWakeFunc(func() {
+		wakeMu.Lock()
+		wakes++
+		wakeMu.Unlock()
+	})
+	// SetPendingUserInputWakeFunc fires an immediate catch-up wake at
+	// registration when work is already pending (agent/session_client_mutation.go)
+	// -- exactly right for its real purpose (a message that survived a crash
+	// runs without waiting on something unrelated), but it means registering
+	// AFTER queueOneMutation counts one wake that has nothing to do with the
+	// steer this test is about. Reset here so the count below isolates the
+	// steer's own contribution.
+	wakeMu.Lock()
+	wakes = 0
+	wakeMu.Unlock()
+
+	// The first turn: the durably queued message, claimed and run.
+	if _, _, err := sess.ProcessPendingUserInput(context.Background(), nil); steerErr != nil {
+		t.Fatalf("AcceptClientMutationSteer (from inside the model call): %v", steerErr)
+	} else if !errors.Is(err, errBareTextWithoutResultTool) {
+		t.Fatalf("first turn error = %v, want errBareTextWithoutResultTool -- this test only exercises the gap when the turn ends without a result-tool call", err)
+	}
+
+	// The premise: the turn's own delivery paths did not drain it, and it was
+	// genuinely a running, durably-claimed turn while the steer landed. If
+	// either fails, the test is not exercising the shape the kata describes.
+	if got := sess.clientMutations.snapshot().ActiveTurnID; got != "" {
+		t.Fatalf("ActiveTurnID = %q after the first turn ended, want it released (this assertion runs after the turn returns, so it only confirms cleanup -- see the mid-turn check inside the adapter for the live claim)", got)
+	}
+	if !sess.hasPendingSteering() {
+		t.Fatal("steering was already delivered by the turn itself; this test's premise (a turn that ends bare-text never drains it) does not hold")
+	}
+
+	wakeMu.Lock()
+	gotWakes := wakes
+	wakeMu.Unlock()
+	if gotWakes == 0 {
+		t.Fatal("accepting a steer mid-turn did not wake the pending-user-input path; nothing will ever redeliver it once the turn ends")
+	}
+
+	// This is the redelivery the wake is FOR: the daemon's serve loop reacts
+	// to the wake by calling ProcessPendingUserInput (cmd/serf/serve.go). The
+	// wake's own delivery through the guaranteed 1-slot channel is proven
+	// independently by server/pending_user_input_wake_test.go; this call
+	// exercises the agent-side half of the same contract.
+	if _, ran, err := sess.ProcessPendingUserInput(context.Background(), nil); err != nil {
+		t.Fatalf("ProcessPendingUserInput: %v", err)
+	} else if !ran {
+		t.Fatal("the wake's redelivery named no runnable work; the steering that arrived mid-turn is stranded until the user speaks again")
+	}
+
+	if sess.hasPendingSteering() {
+		t.Fatal("steering is still pending after the redelivery ran")
+	}
+	if got := countBudgetSteering(budgetHistory(sess), "steer mid turn"); got != 1 {
+		t.Fatalf("delivered steering count = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
Katas: t9kt (fixed), dz5j (proven already fixed; pinning test added)

**t9kt.** The steering-only wake ran through `acceptUserInput` as a plain `EntryUserInput` turn: the MaxTurns gate fired before `injectDrainedSteering`, so a wake at the ceiling failed before delivering already-Applied steering; an empty user turn hit the transcript and the turn budget; and `onRunnable` never fired on that branch, so the daemon never wired cancellation — an interrupt could return Applied without cancelling anything.

Fix: a new `EntrySteeringCarrier` kind. It passes the pending-question gate like `EntryUserInput` (steering is the user speaking; supersede ruling holds) but mirrors `EntryNotification`'s accounting — no MaxTurns slot, no `s.turns++`, no empty transcript turn. `claimSteeringCarrierTurn` reuses the pending steer's own already-reserved turn id rather than minting, so the id in the client's Applied receipt is the id that actually runs, and `onRunnable` fires before the model call. Stand-down on unclaimable (interrupt fence, occupied slot) leaves the steering queued; the claimed id is released by `processOneInput`'s deferred compare-and-clear `releaseRunningTurnID`, so an unincorporated claim cannot strand `ActiveTurnID` (the known wedge class). EntryKind audit table extended for the new kind.

**dz5j.** Verified against pristine base (t9kt changes removed): `AcceptClientMutationSteer`'s unconditional `wakeForPendingSteering()` plus the daemon's guaranteed `SubmitPendingUserInput` wake already close the described gap. Premise correction recorded on the kata: `trySteerEnqueue` (no notify) is the daemon-authored path; the client `turn/steer` path wakes unconditionally. A pinning test guards the wake.

Verification: 8 mutations run RED/GREEN for real (incl. reverting to `EntryUserInput`, skipping `onRunnable`, minting fresh ids, gating the wake); one false-green in the new test self-caught and fixed (registration-time catch-up wake counted as the mid-turn wake). Full agent package suite `-count=1` green; central `make lint`+`make test` green on the integration branch.

Note for review sequencing: PR #122's EntryKind work (worktree-kata-test-truth) adds per-kind probes; when both land, `EntrySteeringCarrier` (declared `opensOnTurnStarted`) will want a probe of its own — flagged here so it isn't lost.

https://claude.ai/code/session_017f6aYf3cJgkcg8PNAg62wX