### PR TITLE
feat(agent): in-stream loop guard bounding a single assistant response

### DIFF
--- a/agent/events/payloads.go
+++ b/agent/events/payloads.go
@@ -303,14 +303,20 @@ const SteeringSourceUser = "user"
 // carried to the UI so a label is ground truth rather than a guess at the
 // message's prose. Absent kind means "unknown" and the UI claims nothing.
 const (
-	SteeringKindInterrupted       = "interrupted"
-	SteeringKindAgentMessage      = "agent-message"
-	SteeringKindHookContext       = "hook-context"
-	SteeringKindPrecompactHook    = "precompact-hook"
-	SteeringKindCompactNudge      = "compact-nudge"
-	SteeringKindImageDescription  = "image-description"
-	SteeringKindNoToolCalls       = "no-tool-calls"
-	SteeringKindLoopDetected      = "loop-detected"
+	SteeringKindInterrupted      = "interrupted"
+	SteeringKindAgentMessage     = "agent-message"
+	SteeringKindHookContext      = "hook-context"
+	SteeringKindPrecompactHook   = "precompact-hook"
+	SteeringKindCompactNudge     = "compact-nudge"
+	SteeringKindImageDescription = "image-description"
+	SteeringKindNoToolCalls      = "no-tool-calls"
+	SteeringKindLoopDetected     = "loop-detected"
+	// SteeringKindStreamLoop marks the kata d74b in-stream loop guard's
+	// nudge, distinct from SteeringKindLoopDetected (the older, cross-round
+	// detector on dispatched tool results): this one fires on a repeating
+	// cycle, raw call ceiling, or content chant caught WITHIN a single
+	// streaming response, before any of its calls dispatch.
+	SteeringKindStreamLoop        = "stream-loop"
 	SteeringKindTasksDone         = "tasks-done"
 	SteeringKindTaskNudge         = "task-nudge"
 	SteeringKindTaskInactive      = "task-inactive"
@@ -336,6 +342,7 @@ var AllSteeringKinds = []string{
 	SteeringKindImageDescription,
 	SteeringKindNoToolCalls,
 	SteeringKindLoopDetected,
+	SteeringKindStreamLoop,
 	SteeringKindTasksDone,
 	SteeringKindTaskNudge,
 	SteeringKindTaskInactive,

--- a/agent/events/payloads_test.go
+++ b/agent/events/payloads_test.go
@@ -101,6 +101,7 @@ func TestSteeringKindConstants(t *testing.T) {
 		"image-description":  SteeringKindImageDescription,
 		"no-tool-calls":      SteeringKindNoToolCalls,
 		"loop-detected":      SteeringKindLoopDetected,
+		"stream-loop":        SteeringKindStreamLoop,
 		"tasks-done":         SteeringKindTasksDone,
 		"task-nudge":         SteeringKindTaskNudge,
 		"task-inactive":      SteeringKindTaskInactive,

--- a/agent/provider_failure_e2e_test.go
+++ b/agent/provider_failure_e2e_test.go
@@ -247,8 +247,8 @@ func TestProviderFailureE2E_CapShapePersistsDraftForTheResumedTurn(t *testing.T)
 	t.Parallel()
 	const contentStep = 45 * time.Second
 	const deltasPerAttempt = 3 // window = 2 * contentStep = 90s, over the cap bound
-	draft := strings.Repeat("plan step. ", 400)
-	trickle := strings.Repeat("plan step. ", 40)
+	draft := nonChantingFiller("plan step.", 400)
+	trickle := nonChantingFiller("plan step.", 40)
 	p := &recoveringProvider{
 		answer: "splitting the plan into smaller writes",
 		fail: func(attempt int) func(*llm.ChanStream) {

--- a/agent/round_recorder_test.go
+++ b/agent/round_recorder_test.go
@@ -170,7 +170,7 @@ func TestRoundRecorder_HasConsumePhaseFailure(t *testing.T) {
 // draft, and the steering group must be the primary — not whichever group
 // happened to fail last.
 func TestRoundRecorder_FallbackTrickleNeverShadowsPrimaryPartial(t *testing.T) {
-	primaryDraft := strings.Repeat("draft ", 200)
+	primaryDraft := nonChantingFiller("draft", 200)
 	const trickle = "he"
 	permErr := llm.ErrorFromHTTPStatus("openai", 403, "cut off", nil, nil)
 	a := &scriptedStreamAdapter{

--- a/agent/session.go
+++ b/agent/session.go
@@ -567,6 +567,17 @@ type Session struct {
 	// stuck detection
 	loopDetectionCount int // how many times loop detection has fired
 
+	// stream loop guard (kata d74b): tracks whether the response
+	// consumeModelStream most recently returned was force-stopped mid-stream
+	// by the in-band loop guard (session_stream_loop_guard.go), so a SECOND
+	// consecutive trip escalates to a hard stop instead of nudging forever.
+	// streamLoopTripStreak resets to 0 on any response that completes
+	// without tripping. pendingStreamLoopNudge holds the steering text for
+	// an untripped-but-pending tier-1 trip until injectPostToolSteering
+	// delivers it as a steering turn and clears it.
+	streamLoopTripStreak   int
+	pendingStreamLoopNudge string
+
 	// transcript writer (nil when StateDir is empty, or when opening it failed)
 	transcript *transcript.Writer
 	// attentionMu serializes transcript-backed attention resolution for this

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -1288,6 +1288,17 @@ func (s *Session) processOneInput(ctx context.Context, input string, images []Im
 		progressed = progressed || s.callsMadeProgress(calls)
 
 		if len(calls) == 0 {
+			// Stream loop guard (kata d74b): a chant trip (reasoning-only
+			// runaway) has zero tool calls by construction, so this round
+			// never reaches injectPostToolSteering -- deliver any pending
+			// nudge here instead, before either exit below can skip it.
+			// Safe to insert immediately after this turn: with no tool
+			// calls there are no tool results whose provider-required
+			// adjacency to it this could disturb (see
+			// deliverPendingStreamLoopNudge's doc comment).
+			if abortErr := s.deliverPendingStreamLoopNudge(ctx); abortErr != nil {
+				return "", progressed, abortErr
+			}
 			// A bare-text (non-empty) response to a notification turn
 			// is the agent acknowledging a frame it has nothing to act on (it often
 			// already read the job's output itself). Finish idle instead of scolding it

--- a/agent/session_stream.go
+++ b/agent/session_stream.go
@@ -242,6 +242,63 @@ func (s *Session) consumeModelStream(ctx context.Context, req llm.Request, st ll
 	assistantStarted := false
 	finished := false
 
+	// Stream loop guard (kata d74b): bounds this one response, since nothing
+	// else in the stack does — see session_stream_loop_guard.go /
+	// session_stream_loop_chant.go for the detectors. guardTripped and
+	// hardStopErr are read after the loop to decide the streak reset and the
+	// tier-2 hard-stop return respectively.
+	loopGuard := newStreamLoopGuard()
+	contentChant := newStreamContentChant()
+	guardTripped := false
+	var hardStopErr error
+	// openToolCalls tracks tool-call IDs that have started but not yet
+	// ended. A trip detected while ANY call is open (e.g. real providers
+	// interleave parallel tool calls' deltas across multiple IDs) must not
+	// act immediately — forcing a finish would freeze that other call's
+	// arguments truncated into the response, exactly the "cut mid-arguments"
+	// the kata rules out. pendingTrip remembers the first trip detected
+	// until every open call closes, rather than relying on the detectors to
+	// re-trip later: a parallel call's own signature can break a cycle
+	// pattern that had already matched, so re-detection is not guaranteed.
+	openToolCalls := map[string]bool{}
+	var pendingTrip *loopTrip
+	recordTrip := func(trip *loopTrip) {
+		if pendingTrip == nil {
+			pendingTrip = trip
+		}
+	}
+	// applyPendingTrip performs the two-tier action for pendingTrip once no
+	// tool call is in flight — the only point a forced finish is a legal
+	// boundary rather than a cut. Returns true when it acted, meaning the
+	// caller must stop consuming the stream (tier 2 has already returned by
+	// the time this matters; tier 1 sets finished and expects the caller to
+	// break the labeled event loop).
+	applyPendingTrip := func() bool {
+		if pendingTrip == nil || len(openToolCalls) > 0 {
+			return false
+		}
+		trip := pendingTrip
+		guardTripped = true
+		s.mu.Lock()
+		s.streamLoopTripStreak++
+		streak := s.streamLoopTripStreak
+		s.mu.Unlock()
+		if streak >= 2 {
+			hardStopErr = llm.NewPermanentStreamError(req.Provider, streamLoopHardStopMessage(trip), nil)
+			return true
+		}
+		s.mu.Lock()
+		s.pendingStreamLoopNudge = streamLoopNudgeText(trip)
+		s.mu.Unlock()
+		reason := llm.FinishReasonStop
+		if len(toolArgs) > 0 {
+			reason = llm.FinishReasonToolCalls
+		}
+		acc.Process(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &llm.FinishReason{Reason: reason, Raw: "loop_guard:" + trip.Kind.String()}})
+		finished = true
+		return true
+	}
+
 	// firstContent/lastContent bound the content-event window — text, tool-arg
 	// (delta or end), and reasoning content only, never wall-clock attempt
 	// duration (spec: SSE keep-alives reset the read timer, so a stalled
@@ -326,6 +383,7 @@ func (s *Session) consumeModelStream(ctx context.Context, req llm.Request, st ll
 		emitAssistantDelta(message[len(prev):])
 	}
 
+streamEvents:
 	for ev := range st.Events() {
 		acc.Process(ev)
 		switch ev.Type {
@@ -338,12 +396,24 @@ func (s *Session) consumeModelStream(ctx context.Context, req llm.Request, st ll
 				noteContent()
 			}
 			emitAssistantDelta(ev.Delta)
+			if trip := contentChant.observe(ev.Delta); trip != nil {
+				recordTrip(trip)
+			}
+			if applyPendingTrip() {
+				break streamEvents
+			}
 		case llm.StreamEventReasoningDelta:
 			s.noteParentJobActivity(jobPhaseModelStreaming)
 			if ev.ReasoningDelta != "" {
 				noteContent()
 			}
 			emitReasoningDelta(ev.ReasoningDelta)
+			if trip := contentChant.observe(ev.ReasoningDelta); trip != nil {
+				recordTrip(trip)
+			}
+			if applyPendingTrip() {
+				break streamEvents
+			}
 		case llm.StreamEventToolCallStart:
 			s.noteParentJobActivity(jobPhaseModelStreaming)
 			if ev.ToolCall == nil || ev.ToolCall.ID == "" {
@@ -353,6 +423,7 @@ func (s *Session) consumeModelStream(ctx context.Context, req llm.Request, st ll
 			if _, ok := toolArgs[ev.ToolCall.ID]; !ok {
 				toolArgs[ev.ToolCall.ID] = &strings.Builder{}
 			}
+			openToolCalls[ev.ToolCall.ID] = true
 		case llm.StreamEventToolCallDelta:
 			s.noteParentJobActivity(jobPhaseModelStreaming)
 			if ev.ToolCall == nil || ev.ToolCall.ID == "" {
@@ -388,6 +459,17 @@ func (s *Session) consumeModelStream(ctx context.Context, req llm.Request, st ll
 			if toolNames[ev.ToolCall.ID] == s.resultToolName() {
 				emitCommunicatePreview(ev.ToolCall.ID)
 			}
+			delete(openToolCalls, ev.ToolCall.ID)
+			args := ""
+			if b := toolArgs[ev.ToolCall.ID]; b != nil {
+				args = b.String()
+			}
+			if trip := loopGuard.observeToolCall(toolNames[ev.ToolCall.ID], args); trip != nil {
+				recordTrip(trip)
+			}
+			if applyPendingTrip() {
+				break streamEvents
+			}
 		case llm.StreamEventFinish:
 			finished = true
 		case llm.StreamEventError:
@@ -397,6 +479,16 @@ func (s *Session) consumeModelStream(ctx context.Context, req llm.Request, st ll
 			err := llm.NewStreamError(req.Provider, "stream error", nil)
 			return sessionModelResponse{}, observe(err), err
 		}
+	}
+
+	if hardStopErr != nil {
+		// Tier 2: a second consecutive trip. Return directly rather than
+		// falling into the normal finished-response path below — there is no
+		// well-formed response to salvage into a "success" here, only a
+		// non-retryable error that ends the turn (llm.Classify treats
+		// NewPermanentStreamError as ErrorClassPermanent, so RetryStream does
+		// not spend its budget reproducing the same runaway).
+		return sessionModelResponse{}, observe(hardStopErr), hardStopErr
 	}
 
 	if !finished {
@@ -416,6 +508,16 @@ func (s *Session) consumeModelStream(ctx context.Context, req llm.Request, st ll
 	}
 	if resp.Model == "" {
 		resp.Model = req.Model
+	}
+	if !guardTripped {
+		// A clean completion breaks the streak: two trips only escalate to a
+		// hard stop when they are consecutive (kata: "second trip
+		// hard-stops", read together with the field citations against
+		// nudging forever — a session that occasionally loops but always
+		// recovers must not be punished for a trip two rounds ago).
+		s.mu.Lock()
+		s.streamLoopTripStreak = 0
+		s.mu.Unlock()
 	}
 	return sessionModelResponse{Response: *resp, StreamedAssistant: streamedAssistant}, observe(nil), nil
 }

--- a/agent/session_stream_loop_chant.go
+++ b/agent/session_stream_loop_chant.go
@@ -1,0 +1,103 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// streamContentChant detects a runaway model chanting the same short
+// passage over and over with no forward progress -- the reasoning-only
+// shape a raw tool-call counter is structurally blind to (cline #13041:
+// "Let me" x2865, tool_use_count=0). It is gemini-cli's content-loop check,
+// ported to Go: the trailing chunk of streamed text is compared against
+// everything seen so far, and a trip requires both enough repeats AND that
+// the text BETWEEN repeats is not itself varied -- the false-positive guard
+// the corrected writeup calls load-bearing, not polish.
+type streamContentChant struct {
+	buf     []rune
+	inFence bool
+}
+
+const (
+	// chantChunkRunes is the trailing-text window compared for repetition
+	// (gemini-cli's CONTENT_CHUNK_SIZE).
+	chantChunkRunes = 50
+	// chantThreshold is how many times the trailing chunk must recur before
+	// this is even considered a candidate chant (gemini-cli's
+	// CONTENT_LOOP_THRESHOLD).
+	chantThreshold = 10
+	// chantMaxBufRunes bounds memory and the per-delta scan cost: a
+	// legitimately long response pays the same bounded per-delta check as a
+	// short one, since the buffer never grows past this regardless of how
+	// much total text streams through it.
+	chantMaxBufRunes = 5000
+	// chantMaxDistinctPeriods is the false-positive guard: among the text
+	// spans BETWEEN consecutive occurrences of the repeated chunk, at most
+	// this many may be distinct before the match is judged a coincidental
+	// shared prefix (a numbered list, a repeated section header followed by
+	// different content each time) rather than a genuine chant.
+	chantMaxDistinctPeriods = chantThreshold / 2
+)
+
+func newStreamContentChant() *streamContentChant {
+	return &streamContentChant{}
+}
+
+// observe feeds one delta of streamed text -- assistant text or reasoning;
+// callers route both through the same tracker, since the pathology is
+// content repetition regardless of channel -- and reports a trip when it
+// detects chanting.
+func (c *streamContentChant) observe(delta string) *loopTrip {
+	if delta == "" {
+		return nil
+	}
+	if strings.Contains(delta, "```") {
+		// A fence boundary (open or close) invalidates whatever was
+		// building. Content inside a fence is never chant-tracked: real
+		// code legitimately repeats short, syntactically-forced substrings
+		// (braces, imports, boilerplate) far more than prose ever should.
+		c.buf = c.buf[:0]
+		c.inFence = !c.inFence
+		return nil
+	}
+	if c.inFence {
+		return nil
+	}
+	c.buf = append(c.buf, []rune(delta)...)
+	if len(c.buf) > chantMaxBufRunes {
+		c.buf = c.buf[len(c.buf)-chantMaxBufRunes:]
+	}
+	return c.checkChant()
+}
+
+func (c *streamContentChant) checkChant() *loopTrip {
+	n := len(c.buf)
+	if n < chantChunkRunes {
+		return nil
+	}
+	chunk := string(c.buf[n-chantChunkRunes:])
+	var starts []int
+	for i := 0; i+chantChunkRunes <= n; i++ {
+		if string(c.buf[i:i+chantChunkRunes]) == chunk {
+			starts = append(starts, i)
+		}
+	}
+	if len(starts) < chantThreshold {
+		return nil
+	}
+	// False-positive guard: the spans between consecutive occurrences of
+	// the repeated chunk ("periods") must themselves be mostly identical,
+	// not mostly unique.
+	recent := starts[len(starts)-chantThreshold:]
+	periods := map[string]bool{}
+	for i := 1; i < len(recent); i++ {
+		periods[string(c.buf[recent[i-1]:recent[i]])] = true
+	}
+	if len(periods) > chantMaxDistinctPeriods {
+		return nil
+	}
+	return &loopTrip{
+		Kind:   loopTripChant,
+		Detail: fmt.Sprintf("the same %d characters repeated %d times with no forward progress", chantChunkRunes, len(starts)),
+	}
+}

--- a/agent/session_stream_loop_chant_test.go
+++ b/agent/session_stream_loop_chant_test.go
@@ -45,12 +45,21 @@ func TestStreamContentChant_LongDistinctProse_NoTrip(t *testing.T) {
 
 // TestStreamContentChant_UniquePeriodsGuard_NoTrip pins the false-positive
 // guard the corrected writeup calls "load-bearing, not polish": a repeated
-// short PREFIX (e.g. a numbered-list template) followed by long, mutually
-// distinct text each time must not trip, because the text BETWEEN
-// occurrences of the repeated chunk is not itself repeating.
+// closing line (e.g. a numbered-list template's boilerplate footer) preceded
+// by long, mutually distinct text each time must not trip, because the text
+// BETWEEN occurrences of the repeated chunk is not itself repeating.
+//
+// The repeated chunk here is a SUFFIX, not a prefix: checkChant always
+// compares the buffer's trailing chantChunkRunes runes, so only a chunk that
+// recurs at the END of each observed delta is a real exercise of the
+// uniqueness guard -- a repeated PREFIX followed by varying body text would
+// never make the trailing chunk match at all, and would pass this test
+// trivially without ever reaching the guard it claims to pin (caught while
+// writing this test: revert chantMaxDistinctPeriods to 0 with a repeated
+// PREFIX fixture and nothing goes red).
 func TestStreamContentChant_UniquePeriodsGuard_NoTrip(t *testing.T) {
 	c := newStreamContentChant()
-	prefix := "### Finding\n\nSeverity: medium. Recommendation: review this section carefully before merging.\n\n"
+	closing := "Please flag this finding in the review thread before merging this change.\n\n"
 	distinctBodies := []string{
 		"The auth handler skips a nil check on the session token when the request arrives over the legacy header.",
 		"The retry loop does not reset its backoff counter after a successful attempt, so a later failure waits far too long.",
@@ -67,9 +76,9 @@ func TestStreamContentChant_UniquePeriodsGuard_NoTrip(t *testing.T) {
 	}
 	var trip *loopTrip
 	for i, body := range distinctBodies {
-		trip = c.observe(prefix + body + "\n\n")
+		trip = c.observe(body + " " + closing)
 		if trip != nil {
-			t.Fatalf("finding %d: unexpected trip %+v; the repeated prefix shares no repeating content between occurrences", i, trip)
+			t.Fatalf("finding %d: unexpected trip %+v; the repeated closing shares no repeating content between occurrences", i, trip)
 		}
 	}
 }
@@ -116,5 +125,38 @@ func TestStreamContentChant_CodeFenceResetsTracking(t *testing.T) {
 		if trip != nil {
 			t.Fatalf("block %d fenced code: unexpected trip %+v (fenced content must not accumulate into the chant buffer)", i, trip)
 		}
+	}
+}
+
+// TestStreamContentChant_FenceBoundaryClearsBuffer pins the reset mechanism
+// directly, at the buffer level (same package, so c.buf is reachable): a
+// fence-marker delta must clear whatever text had accumulated before it, not
+// merely skip accumulating the fenced content itself.
+//
+// This is a narrower and more direct property than
+// TestStreamContentChant_CodeFenceResetsTracking above: that test varies the
+// surrounding prose (a different file path each block), which passes
+// regardless of whether the reset runs, because inFence already blocks the
+// fenced content from ever reaching the buffer and the varying prose never
+// forms a repeating chunk on its own -- caught while writing this test:
+// deleting the reset line left that test green. Without the reset, pre-fence
+// text silently persists and gets prefixed onto whatever text follows the
+// fence, which is what this test pins directly by inspecting the buffer.
+func TestStreamContentChant_FenceBoundaryClearsBuffer(t *testing.T) {
+	c := newStreamContentChant()
+	before := "context established immediately before the fence opens here"
+	c.observe(before)
+	c.observe("```go\n")
+	c.observe("func Add(a, b int) int {\n\treturn a + b\n}\n")
+	c.observe("```\n\n")
+	after := "short tail resumed after the fence closes"
+	c.observe(after)
+
+	got := string(c.buf)
+	if strings.Contains(got, "context established") {
+		t.Fatalf("chant buffer = %q, want the fence boundary to have cleared the pre-fence text, not carried it across", got)
+	}
+	if !strings.Contains(got, after) {
+		t.Fatalf("chant buffer = %q, want it to contain the post-fence text %q", got, after)
 	}
 }

--- a/agent/session_stream_loop_chant_test.go
+++ b/agent/session_stream_loop_chant_test.go
@@ -1,0 +1,120 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStreamContentChant_RepeatedPhrase_Trips pins kata fixture (c): a
+// reasoning-only runaway chanting a short phrase with zero tool calls
+// (cline #13041: DeepSeek-V4-Flash, "Let me" x2865). The repeat count here
+// is reduced from the documented ~2865 for test speed; what matters is that
+// a short phrase repeated far past chantThreshold trips, fast.
+func TestStreamContentChant_RepeatedPhrase_Trips(t *testing.T) {
+	c := newStreamContentChant()
+	var trip *loopTrip
+	for i := 0; i < 300 && trip == nil; i++ {
+		trip = c.observe("Let me think about this carefully and check the file. ")
+	}
+	if trip == nil {
+		t.Fatal("expected a chant trip; got none after 300 repeats of a short phrase")
+	}
+	if trip.Kind != loopTripChant {
+		t.Fatalf("trip.Kind = %v, want loopTripChant", trip.Kind)
+	}
+}
+
+// TestStreamContentChant_LongDistinctProse_NoTrip is the plain negative:
+// ordinary varied prose, long enough to exceed the chunk size many times
+// over, must never trip.
+func TestStreamContentChant_LongDistinctProse_NoTrip(t *testing.T) {
+	c := newStreamContentChant()
+	words := strings.Fields(`the quick brown fox jumps over the lazy dog while a second
+		fox watches from the tree line and a third fox trots past the old barn near
+		the river where the water runs cold in autumn and warm in the height of
+		summer when the crops stand tall across the valley floor beneath a sky full
+		of slow moving clouds that drift toward the distant mountains every single
+		afternoon without fail as the season turns from green to gold and back again`)
+	for i := 0; i < 40; i++ {
+		delta := words[i%len(words)] + " " + words[(i+7)%len(words)] + " "
+		if trip := c.observe(delta); trip != nil {
+			t.Fatalf("delta %d: unexpected trip %+v on ordinary prose", i, trip)
+		}
+	}
+}
+
+// TestStreamContentChant_UniquePeriodsGuard_NoTrip pins the false-positive
+// guard the corrected writeup calls "load-bearing, not polish": a repeated
+// short PREFIX (e.g. a numbered-list template) followed by long, mutually
+// distinct text each time must not trip, because the text BETWEEN
+// occurrences of the repeated chunk is not itself repeating.
+func TestStreamContentChant_UniquePeriodsGuard_NoTrip(t *testing.T) {
+	c := newStreamContentChant()
+	prefix := "### Finding\n\nSeverity: medium. Recommendation: review this section carefully before merging.\n\n"
+	distinctBodies := []string{
+		"The auth handler skips a nil check on the session token when the request arrives over the legacy header.",
+		"The retry loop does not reset its backoff counter after a successful attempt, so a later failure waits far too long.",
+		"The cache key omits the tenant id, so two tenants can collide on the same cached response under load.",
+		"The migration script assumes UTC but the source table stores local time, so the backfill is off by the timezone offset.",
+		"The export path writes a temp file without a random suffix, so two concurrent exports clobber each other's output.",
+		"The websocket handler never unregisters a closed connection from the broadcast set, leaking one entry per disconnect.",
+		"The config loader silently ignores a malformed line instead of failing the load, so a typo disables a feature quietly.",
+		"The pagination cursor encodes an offset instead of a key, so a delete between pages skips or repeats a row.",
+		"The rate limiter buckets by IP alone, so a shared NAT exhausts the limit for every user behind it at once.",
+		"The health check only pings the primary replica, so a failed secondary never surfaces until a failover is attempted.",
+		"The template escapes HTML but not the attribute context, so a crafted value can still break out of a quoted attribute.",
+		"The log redaction list is case sensitive, so an uppercase secret key name slips through unredacted into the logs.",
+	}
+	var trip *loopTrip
+	for i, body := range distinctBodies {
+		trip = c.observe(prefix + body + "\n\n")
+		if trip != nil {
+			t.Fatalf("finding %d: unexpected trip %+v; the repeated prefix shares no repeating content between occurrences", i, trip)
+		}
+	}
+}
+
+// TestStreamContentChant_IdenticalPeriodsGuard_Trips is the guard's positive
+// case, run at the same chunk/threshold scale as the unique-periods test
+// above: the text between occurrences of the repeated chunk is ITSELF
+// repeating (a true chant), which the guard must allow through.
+func TestStreamContentChant_IdenticalPeriodsGuard_Trips(t *testing.T) {
+	c := newStreamContentChant()
+	unit := "### Finding\n\nSeverity: medium. Recommendation: review this section carefully before merging.\n\n"
+	var trip *loopTrip
+	for i := 0; i < 12 && trip == nil; i++ {
+		trip = c.observe(unit)
+	}
+	if trip == nil {
+		t.Fatal("expected a chant trip: the same unit repeated verbatim with nothing distinct between occurrences")
+	}
+}
+
+// TestStreamContentChant_CodeFenceResetsTracking pins kata fixture (e):
+// legitimate long code output with the SAME snippet repeated across several
+// separate fenced code blocks must not trip -- code-fence resets are
+// "load-bearing, not polish" per the corrected writeup.
+func TestStreamContentChant_CodeFenceResetsTracking(t *testing.T) {
+	c := newStreamContentChant()
+	snippet := "func Add(a, b int) int {\n\treturn a + b\n}\n"
+	files := []string{
+		"internal/mathutil/add.go", "pkg/calc/sum.go", "cmd/tool/helpers.go",
+		"internal/report/tally.go", "pkg/stats/reduce.go", "cmd/serve/util.go",
+		"internal/graph/weights.go", "pkg/queue/merge.go", "cmd/build/steps.go",
+		"internal/cache/evict.go", "pkg/sched/plan.go", "cmd/deploy/roll.go",
+		"internal/index/scan.go", "pkg/store/kv.go", "cmd/migrate/apply.go",
+		"internal/proxy/route.go", "pkg/auth/token.go", "cmd/watch/tail.go",
+		"internal/render/tmpl.go", "pkg/log/fields.go",
+	}
+	var trip *loopTrip
+	for i, path := range files {
+		trip = c.observe("The same small helper belongs in " + path + " as well, unchanged:\n\n")
+		if trip != nil {
+			t.Fatalf("block %d prose: unexpected trip %+v", i, trip)
+		}
+		trip = c.observe("```go\n" + snippet + "```\n\n")
+		if trip != nil {
+			t.Fatalf("block %d fenced code: unexpected trip %+v (fenced content must not accumulate into the chant buffer)", i, trip)
+		}
+	}
+}

--- a/agent/session_stream_loop_chant_test.go
+++ b/agent/session_stream_loop_chant_test.go
@@ -35,7 +35,7 @@ func TestStreamContentChant_LongDistinctProse_NoTrip(t *testing.T) {
 		summer when the crops stand tall across the valley floor beneath a sky full
 		of slow moving clouds that drift toward the distant mountains every single
 		afternoon without fail as the season turns from green to gold and back again`)
-	for i := 0; i < 40; i++ {
+	for i := range 40 {
 		delta := words[i%len(words)] + " " + words[(i+7)%len(words)] + " "
 		if trip := c.observe(delta); trip != nil {
 			t.Fatalf("delta %d: unexpected trip %+v on ordinary prose", i, trip)

--- a/agent/session_stream_loop_guard.go
+++ b/agent/session_stream_loop_guard.go
@@ -1,0 +1,213 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"primeradiant.com/serf/agent/events"
+)
+
+// streamLoopGuard detects a runaway SINGLE model response mid-stream (kata
+// d74b): a repeating cycle of tool-call signatures, or a raw tool-call count
+// far past anything a legitimate response needs. It is the shape of
+// gemini-cli's LoopDetectionService, ported to Go and to serf's stream event
+// model. One instance lives for exactly one consumeModelStream attempt --
+// state does not (and must not) survive past a single response, since the
+// hole this closes is specifically that nothing bounds one response.
+type streamLoopGuard struct {
+	// sigs holds one entry per completed tool call this response, in
+	// order: canonicalToolName + ":" + raw argument text. A cheap string
+	// join rather than a hash, matching the existing post-dispatch
+	// breaker's signature() convention (agent/internal/tool/breaker.go) --
+	// byte-identical arguments share a signature, differing JSON
+	// formatting does not.
+	sigs []string
+}
+
+// loopGuardCycleMaxLen and loopGuardCycleRepeats are gemini-cli's own
+// numbers (LoopDetectionService: cycle length k=1..5, repeated 5 times).
+// The corrected kata writeup calls for this exact shape: "a repeating CYCLE
+// of length k=1..5 repeated 5x."
+const (
+	loopGuardCycleMaxLen  = 5
+	loopGuardCycleRepeats = 5
+)
+
+// loopGuardRawCeiling is the backstop for shapes with no short cycle (kata:
+// "a HIGH raw tool-call ceiling per response as backstop... do not pick
+// 15" -- odysseus #3185 killed a legitimate 18-distinct-call round at that
+// threshold). Chosen with a wide safety margin above the only documented
+// legitimate shape (18 distinct calls, kata fixture (d)) while still
+// catching the second measured runaway shape (83 calls / 48 distinct
+// signatures / max repeat 12) well before it completes. See
+// .superpowers/uq-d74b-report.md for the full rationale and the tension
+// this number trades off.
+const loopGuardRawCeiling = 50
+
+// loopTripKind names which detector fired.
+type loopTripKind int
+
+const (
+	loopTripCycle loopTripKind = iota
+	loopTripCeiling
+	loopTripChant
+)
+
+func (k loopTripKind) String() string {
+	switch k {
+	case loopTripCycle:
+		return "cycle"
+	case loopTripCeiling:
+		return "ceiling"
+	case loopTripChant:
+		return "chant"
+	default:
+		return "unknown"
+	}
+}
+
+// loopTrip reports one guard trip: which detector fired and a human-readable
+// detail naming what repeated, for the tier-1 nudge and the tier-2 hard-stop
+// message alike.
+type loopTrip struct {
+	Kind   loopTripKind
+	Detail string
+}
+
+func newStreamLoopGuard() *streamLoopGuard {
+	return &streamLoopGuard{}
+}
+
+// observeToolCall records one COMPLETED tool call (StreamEventToolCallEnd --
+// the only point a call's name and arguments are both final) and reports a
+// trip if the running sequence now shows a cycle or has crossed the raw
+// ceiling. Cycle is checked first: it is the field's dominant shape (kata:
+// "our captured shape was A,B,C x76... every consecutive-identical detector
+// is structurally blind to it") and fires far earlier than the ceiling ever
+// could. The ceiling is checked second, as the backstop for shapes with no
+// short cycle.
+func (g *streamLoopGuard) observeToolCall(name, args string) *loopTrip {
+	g.sigs = append(g.sigs, name+":"+args)
+	if trip := g.checkCycle(); trip != nil {
+		return trip
+	}
+	if len(g.sigs) >= loopGuardRawCeiling {
+		return &loopTrip{
+			Kind:   loopTripCeiling,
+			Detail: fmt.Sprintf("%d tool calls in a single response, past the %d-call ceiling", len(g.sigs), loopGuardRawCeiling),
+		}
+	}
+	return nil
+}
+
+// checkCycle checks whether the most recently appended signature completes a
+// cycle of length k (1..5), repeated loopGuardCycleRepeats times
+// consecutively. For each k it looks at exactly the trailing k*R signatures
+// and asks whether they consist of R back-to-back copies of the trailing k
+// -- not "a cycle occurs somewhere in a wider window," which would fire on
+// coincidental repetition inside a long response; the last occurrence must
+// be the (r)th repeat with nothing else interleaved.
+func (g *streamLoopGuard) checkCycle() *loopTrip {
+	n := len(g.sigs)
+	for k := 1; k <= loopGuardCycleMaxLen; k++ {
+		need := k * loopGuardCycleRepeats
+		if n < need {
+			continue
+		}
+		window := g.sigs[n-need:]
+		pattern := window[:k]
+		matched := true
+		for i := k; i < need; i++ {
+			if window[i] != pattern[i%k] {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return &loopTrip{
+				Kind:   loopTripCycle,
+				Detail: describeCyclePattern(pattern),
+			}
+		}
+	}
+	return nil
+}
+
+// streamLoopNudgeText builds the tier-1 steering message for a stream-loop
+// trip: it names what repeated, wrapped as a SYSTEM-REMINDER to match every
+// other steering message's envelope (agent/task_reminders.go).
+func streamLoopNudgeText(trip *loopTrip) string {
+	var what string
+	switch trip.Kind {
+	case loopTripCycle:
+		what = fmt.Sprintf("You just repeated the same sequence of tool calls five times in a row within one response: %s. "+
+			"That response was cut off before it could repeat a sixth time.", trip.Detail)
+	case loopTripCeiling:
+		what = fmt.Sprintf("Your last response made %s. "+
+			"That response was cut off once it crossed the limit.", trip.Detail)
+	case loopTripChant:
+		what = fmt.Sprintf("Your last response was cut off because it was %s, with no forward progress.", trip.Detail)
+	}
+	return "<SYSTEM-REMINDER>\n" + what +
+		" This is a signal you are stuck, not a punishment. Stop and think about why your current approach is not working, " +
+		"then either try something different or report what you tried and what failed.\n" +
+		"</SYSTEM-REMINDER>"
+}
+
+// streamLoopHardStopMessage builds the tier-2 error message when a second
+// consecutive response trips the guard: unlike the tier-1 nudge, there is no
+// next response to read it, so it explains the failure for the turn's error
+// surface (emitTurnFailure) rather than steering a model that already had
+// its one chance to self-correct.
+func streamLoopHardStopMessage(trip *loopTrip) string {
+	return fmt.Sprintf("loop guard: two responses in a row were cut off for the same reason (%s: %s); stopping rather than nudging indefinitely", trip.Kind, trip.Detail)
+}
+
+// describeCyclePattern names the repeated call(s) for the nudge/hard-stop
+// message, e.g. "manage_worktree, task_list, communicate" for a k=3 cycle.
+// Signatures are "name:args"; only the name is surfaced -- the arguments are
+// often large or provider-internal and the tool name is what the model needs
+// to recognize it is repeating itself.
+func describeCyclePattern(pattern []string) string {
+	names := make([]string, len(pattern))
+	for i, sig := range pattern {
+		name := sig
+		for j := 0; j < len(sig); j++ {
+			if sig[j] == ':' {
+				name = sig[:j]
+				break
+			}
+		}
+		names[i] = name
+	}
+	out := names[0]
+	for _, n := range names[1:] {
+		out += ", " + n
+	}
+	return out
+}
+
+// deliverPendingStreamLoopNudge reads and clears s.pendingStreamLoopNudge and,
+// if one was pending, appends it as a steering turn. Two call sites need
+// this, not one: a response that made tool calls reaches it via
+// injectPostToolSteering (session_tool_round.go), positioned after tool
+// results so it never lands between a tool_use turn and its tool_result --
+// providers that require them adjacent would reject the next request. A
+// chant trip (kata fixture (c): reasoning-only, zero tool calls) never
+// reaches that function at all, since processOneInput branches away from it
+// whenever a round produces no tool calls; that branch calls this directly,
+// which is safe there precisely because there are no tool results whose
+// adjacency to the triggering turn this could disturb.
+func (s *Session) deliverPendingStreamLoopNudge(ctx context.Context) error {
+	s.mu.Lock()
+	nudge := s.pendingStreamLoopNudge
+	s.pendingStreamLoopNudge = ""
+	s.mu.Unlock()
+	if nudge == "" {
+		return nil
+	}
+	return s.withResponseSideEffects(ctx, func() {
+		s.emit(events.EventLoopDetection, events.LoopDetectionData{Message: nudge})
+		s.appendSteeringTurn(nudge, events.SteeringKindStreamLoop)
+	})
+}

--- a/agent/session_stream_loop_guard.go
+++ b/agent/session_stream_loop_guard.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"primeradiant.com/serf/agent/events"
 )
@@ -180,11 +181,7 @@ func describeCyclePattern(pattern []string) string {
 		}
 		names[i] = name
 	}
-	out := names[0]
-	for _, n := range names[1:] {
-		out += ", " + n
-	}
-	return out
+	return strings.Join(names, ", ")
 }
 
 // deliverPendingStreamLoopNudge reads and clears s.pendingStreamLoopNudge and,

--- a/agent/session_stream_loop_guard_delivery_test.go
+++ b/agent/session_stream_loop_guard_delivery_test.go
@@ -1,0 +1,136 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"primeradiant.com/serf/agent/events"
+	"primeradiant.com/serf/agent/schema"
+	"primeradiant.com/serf/llm"
+)
+
+// This file pins delivery of a stream-loop nudge queued by consumeModelStream
+// (session_stream.go) onto sess.pendingStreamLoopNudge: TestConsumeModelStream_*
+// already proves the field gets SET correctly; these tests prove it actually
+// reaches the transcript as a steering turn rather than sitting unread.
+//
+// Two call sites need to read it, not one: a response with tool calls reaches
+// injectPostToolSteering (after tool results, matching the pre-existing
+// cross-round detector's steering point), but a chant trip (kata fixture (c))
+// has ZERO tool calls by construction, so it takes processOneInput's separate
+// len(calls)==0 branch instead -- which never calls injectPostToolSteering at
+// all. Without its own delivery point there, exactly the shape the kata's
+// spec highlights as needing this guard (a reasoning-only runaway) would have
+// its nudge silently dropped, violating "re-prompt on trip, do not silently
+// suppress" (kata research citation: hermes-agent #41490).
+
+// findSteeringTurnByKind returns the first history turn tagged with the given
+// SteeringKind. It searches by kind rather than "the last steering turn"
+// because a round that also exercises the pre-existing no-tool-calls retry
+// path appends its OWN steering turns around the one under test here.
+func findSteeringTurnByKind(sess *Session, kind string) (schema.Turn, bool) {
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	for _, turn := range sess.history {
+		if turn.Kind == schema.TurnSteering && turn.SteeringKind == kind {
+			return turn, true
+		}
+	}
+	return schema.Turn{}, false
+}
+
+// TestDeliverPendingStreamLoopNudge_AppendsAndClears drives the helper
+// directly: a pending nudge becomes a steering turn tagged
+// SteeringKindStreamLoop, and the field is cleared so it cannot be delivered
+// twice.
+func TestDeliverPendingStreamLoopNudge_AppendsAndClears(t *testing.T) {
+	sess := newSession(t)
+	sess.mu.Lock()
+	sess.pendingStreamLoopNudge = "you are repeating yourself"
+	sess.mu.Unlock()
+
+	if err := sess.deliverPendingStreamLoopNudge(context.Background()); err != nil {
+		t.Fatalf("deliverPendingStreamLoopNudge: %v", err)
+	}
+
+	turn, ok := findSteeringTurnByKind(sess, events.SteeringKindStreamLoop)
+	if !ok {
+		t.Fatal("no SteeringKindStreamLoop turn appended")
+	}
+	if !strings.Contains(turn.Message.Text(), "repeating yourself") {
+		t.Errorf("turn text = %q, want it to carry the nudge", turn.Message.Text())
+	}
+
+	sess.mu.Lock()
+	remaining := sess.pendingStreamLoopNudge
+	historyLen := len(sess.history)
+	sess.mu.Unlock()
+	if remaining != "" {
+		t.Errorf("pendingStreamLoopNudge = %q, want cleared after delivery", remaining)
+	}
+
+	// A second call with nothing pending must not append another turn.
+	if err := sess.deliverPendingStreamLoopNudge(context.Background()); err != nil {
+		t.Fatalf("second deliverPendingStreamLoopNudge: %v", err)
+	}
+	sess.mu.Lock()
+	got := len(sess.history)
+	sess.mu.Unlock()
+	if got != historyLen {
+		t.Errorf("history grew from %d to %d on an empty pending nudge, want no-op", historyLen, got)
+	}
+}
+
+// TestInjectPostToolSteering_DeliversStreamLoopNudge covers the has-tool-calls
+// path: injectPostToolSteering must deliver a pending stream-loop nudge the
+// same way it delivers the cross-round detector's own warning.
+func TestInjectPostToolSteering_DeliversStreamLoopNudge(t *testing.T) {
+	sess := newSession(t)
+	sess.mu.Lock()
+	sess.pendingStreamLoopNudge = "cut off after a repeating cycle"
+	sess.mu.Unlock()
+
+	var toolSigs []string
+	var toolSigFailed []bool
+	if _, err := sess.injectPostToolSteering(context.Background(), nil, nil, &toolSigs, &toolSigFailed); err != nil {
+		t.Fatalf("injectPostToolSteering: %v", err)
+	}
+
+	if _, ok := findSteeringTurnByKind(sess, events.SteeringKindStreamLoop); !ok {
+		t.Fatal("no SteeringKindStreamLoop turn appended")
+	}
+}
+
+// TestProcessOneInput_ZeroToolCalls_DeliversStreamLoopNudge covers the
+// chant-shaped path directly: a round that produces NO tool calls never
+// reaches injectPostToolSteering, so processOneInput's own len(calls)==0
+// branch must deliver the nudge itself, or exactly the shape the kata's spec
+// highlights as needing this guard (a reasoning-only runaway, zero tool
+// calls) would have its nudge silently dropped. Simulates "consumeModelStream
+// just tripped" by presetting the field directly
+// (TestConsumeModelStream_LoopGuard_ChantShape already proves
+// consumeModelStream itself sets it correctly for this exact shape); this
+// test is only about whether the round loop reads it back out. The scripted
+// model reply is bare text with no tool call, which the round loop retries
+// (and eventually fails) via its own unrelated no-tool-calls budget -- ignored
+// here; only the presence of the stream-loop turn is under test.
+func TestProcessOneInput_ZeroToolCalls_DeliversStreamLoopNudge(t *testing.T) {
+	sess := newSession(t, withSteps(
+		func(req llm.Request) llm.Response {
+			return llm.Response{Message: llm.Assistant("I looked into it but did not call a tool.")}
+		},
+	))
+	sess.mu.Lock()
+	sess.pendingStreamLoopNudge = "chant trip: repeated the same passage"
+	sess.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, _ = sess.ProcessInput(ctx, "go", nil)
+
+	if _, ok := findSteeringTurnByKind(sess, events.SteeringKindStreamLoop); !ok {
+		t.Fatal("no SteeringKindStreamLoop turn appended")
+	}
+}

--- a/agent/session_stream_loop_guard_fixtures_test.go
+++ b/agent/session_stream_loop_guard_fixtures_test.go
@@ -1,0 +1,107 @@
+package agent
+
+import (
+	"fmt"
+	"testing"
+)
+
+// toolSig is a plain (name, args) pair -- the same shape observeToolCall
+// takes -- used to build the synthetic fixtures shared by the loop-guard
+// unit tests and its consumeModelStream integration tests.
+type toolSig struct{ name, args string }
+
+// buildEightyThreeCallNoCycleFixture reconstructs kata d74b's second measured
+// shape honestly: "83 calls / 48 distinct signatures / max repeat 12". The
+// captured stream itself is not in the repo (rebuilding the capture harness
+// was explicitly out of bounds), so this is a synthetic stand-in built to the
+// documented statistics, NOT a byte-for-byte replay.
+//
+// Construction: one "heavy" signature H repeats 12 times at absolute
+// positions 0,7,14,...,77 (gap 7, so it can never appear more than once in
+// any window the cycle detector examines -- max window is k*R=25). The other
+// 71 positions cycle through 47 distinct filler signatures in round-robin
+// order (period 47, far above the max cycle length of 5). Total: 12 + 71 =
+// 83 calls, 1 + 47 = 48 distinct signatures, max repeat = 12.
+//
+// Note this is an approximation of the captured incident's exact texture
+// (which interleaving pattern the real 48-signature/83-call stream actually
+// used is unknown -- only the three summary statistics were recorded), built
+// specifically to avoid the one property that would make the fixture beg the
+// question: it must not contain a short cycle, or the cycle detector would
+// trip it "by accident" and the test would prove nothing about the ceiling.
+func buildEightyThreeCallNoCycleFixture(t *testing.T) []toolSig {
+	t.Helper()
+	const total = 83
+	const heavyCount = 12
+	const heavyGap = 7 // 0,7,...,77 -> 12 positions, all < 83
+
+	heavy := toolSig{name: "manage_worktree", args: `{"op":"status"}`}
+	fillers := make([]toolSig, 47)
+	for i := range fillers {
+		fillers[i] = toolSig{name: fmt.Sprintf("tool_%02d", i), args: fmt.Sprintf(`{"call":%d}`, i)}
+	}
+
+	heavyPositions := make(map[int]bool, heavyCount)
+	for i := 0; i < heavyCount; i++ {
+		heavyPositions[i*heavyGap] = true
+	}
+
+	sigs := make([]toolSig, 0, total)
+	fillerIdx := 0
+	for pos := 0; pos < total; pos++ {
+		if heavyPositions[pos] {
+			sigs = append(sigs, heavy)
+			continue
+		}
+		sigs = append(sigs, fillers[fillerIdx%len(fillers)])
+		fillerIdx++
+	}
+
+	if got := countDistinctSigs(sigs); got != 48 {
+		t.Fatalf("fixture generator bug: %d distinct signatures, want 48", got)
+	}
+	if got := maxRepeatCount(sigs); got != heavyCount {
+		t.Fatalf("fixture generator bug: max repeat = %d, want %d", got, heavyCount)
+	}
+	if len(sigs) != total {
+		t.Fatalf("fixture generator bug: %d calls, want %d", len(sigs), total)
+	}
+	return sigs
+}
+
+func countDistinctSigs(sigs []toolSig) int {
+	seen := map[string]bool{}
+	for _, s := range sigs {
+		seen[s.name+":"+s.args] = true
+	}
+	return len(seen)
+}
+
+func maxRepeatCount(sigs []toolSig) int {
+	counts := map[string]int{}
+	max := 0
+	for _, s := range sigs {
+		key := s.name + ":" + s.args
+		counts[key]++
+		if counts[key] > max {
+			max = counts[key]
+		}
+	}
+	return max
+}
+
+// assertNoShortCycleAnywhere offline-checks every suffix of sigs for a
+// k=1..5 pattern repeated 5 times consecutively, using the same window
+// arithmetic checkCycle uses. It exists so the ceiling-fixture test's claim
+// ("this shape has no short cycle by construction") is verified mechanically
+// rather than trusted from the construction's math alone.
+func assertNoShortCycleAnywhere(t *testing.T, sigs []toolSig) {
+	t.Helper()
+	g := newStreamLoopGuard()
+	for i, s := range sigs {
+		g.sigs = append(g.sigs, s.name+":"+s.args)
+		if trip := g.checkCycle(); trip != nil {
+			t.Fatalf("fixture contains a short cycle at call %d: %+v (fixture is invalid for the ceiling-only test)", i+1, trip)
+		}
+	}
+}

--- a/agent/session_stream_loop_guard_fixtures_test.go
+++ b/agent/session_stream_loop_guard_fixtures_test.go
@@ -42,13 +42,13 @@ func buildEightyThreeCallNoCycleFixture(t *testing.T) []toolSig {
 	}
 
 	heavyPositions := make(map[int]bool, heavyCount)
-	for i := 0; i < heavyCount; i++ {
+	for i := range heavyCount {
 		heavyPositions[i*heavyGap] = true
 	}
 
 	sigs := make([]toolSig, 0, total)
 	fillerIdx := 0
-	for pos := 0; pos < total; pos++ {
+	for pos := range total {
 		if heavyPositions[pos] {
 			sigs = append(sigs, heavy)
 			continue
@@ -79,15 +79,15 @@ func countDistinctSigs(sigs []toolSig) int {
 
 func maxRepeatCount(sigs []toolSig) int {
 	counts := map[string]int{}
-	max := 0
+	maxCount := 0
 	for _, s := range sigs {
 		key := s.name + ":" + s.args
 		counts[key]++
-		if counts[key] > max {
-			max = counts[key]
+		if counts[key] > maxCount {
+			maxCount = counts[key]
 		}
 	}
-	return max
+	return maxCount
 }
 
 // assertNoShortCycleAnywhere offline-checks every suffix of sigs for a

--- a/agent/session_stream_loop_guard_integration_test.go
+++ b/agent/session_stream_loop_guard_integration_test.go
@@ -1,0 +1,447 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"primeradiant.com/serf/llm"
+)
+
+// This file drives the loop guard through consumeModelStream itself (kata
+// d74b's integration point: "agent/session_stream.go region"), reconstructing
+// the five documented runaway shapes as synthetic streams. The captured
+// streams are not in the repo and rebuilding the capture harness is out of
+// bounds by the kata's own terms; these are honest synthetic stand-ins built
+// to the documented shapes, not replays.
+//
+// Every scenario here runs consumeModelStream in a goroutine (started before
+// or concurrently with feeding events, so a fixture larger than
+// llm.NewChanStream's 128-event buffer never deadlocks the producer) with a
+// bounded timeout as a tripwire against a genuine hang. Every feed closure
+// calls st.CloseSend() once it is done sending, even the ones that
+// deliberately send only a PARTIAL fixture (fewer calls than the shape's
+// documented total): consumeModelStream's own deferred st.Close() blocks on
+// the producer side closing (llm.ChanStream.Close's documented contract), so
+// withholding CloseSend would hang consumeModelStream in its own cleanup
+// regardless of whether the guard tripped correctly -- a false failure, not
+// a signal. A partial feed plus an early CloseSend still proves the guard
+// stopped consuming early: an un-tripped implementation drains the partial
+// channel, sees it closed, and returns the "stream ended without finish
+// event" error instead of hanging, which the tests below assert against
+// directly (err == nil) rather than relying on a timeout to catch it.
+
+// runConsumeModelStream starts consumeModelStream on st in a goroutine, then
+// runs feed (typically a series of st.Send calls, ending in st.CloseSend())
+// on the calling goroutine, then waits up to 5s for consumeModelStream to
+// return -- failing the test on timeout as a last-resort tripwire, not the
+// primary correctness signal. Starting the consumer before or during feed
+// means a fixture larger than the stream's buffered channel capacity cannot
+// deadlock: Send blocks only until the concurrently-running consumer drains
+// it.
+func runConsumeModelStream(t *testing.T, sess *Session, req llm.Request, st llm.Stream, feed func()) (sessionModelResponse, attemptObservation, error) {
+	t.Helper()
+	type outcome struct {
+		resp sessionModelResponse
+		obs  attemptObservation
+		err  error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		resp, obs, err := sess.consumeModelStream(context.Background(), req, st)
+		done <- outcome{resp, obs, err}
+	}()
+	if feed != nil {
+		feed()
+	}
+	select {
+	case o := <-done:
+		return o.resp, o.obs, o.err
+	case <-time.After(5 * time.Second):
+		t.Fatal("consumeModelStream did not return; the guard did not stop the stream")
+		return sessionModelResponse{}, attemptObservation{}, nil
+	}
+}
+
+// sendToolCall writes a minimal Start+End pair for one completed tool call --
+// the shape TestConsumeModelStream_Observation_ToolCallEndOnlyThenError pins
+// as a real provider emission (google's adapter skips Delta entirely).
+func sendToolCall(st *llm.ChanStream, id, name, args string) {
+	st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallStart, ToolCall: &llm.ToolCallData{ID: id, Name: name}})
+	st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallEnd, ToolCall: &llm.ToolCallData{ID: id, Arguments: []byte(args)}})
+}
+
+// TestConsumeModelStream_LoopGuard_CycleShape is fixture (a): (manage_worktree,
+// task_list, communicate) repeating -- a k=3 cycle -- reconstructing the
+// kata's primary captured incident (228 calls from 4 argument blocks,
+// x76). The fixture only sends 20 calls' worth of events (well short of 76
+// repeats): if the guard works, it never needs the rest.
+func TestConsumeModelStream_LoopGuard_CycleShape(t *testing.T) {
+	sess := newSession(t)
+	req := llm.Request{Provider: "openai", Model: "gpt-5.2"}
+	st := llm.NewChanStream(nil)
+
+	pattern := []toolSig{
+		{"manage_worktree", `{"op":"list"}`},
+		{"task_list", `{}`},
+		{"communicate", `{"message":"still working","end_turn":false}`},
+	}
+	const sent = 20 // well past the 15-call trip point, short of the real incident's 228
+	// Sends only a partial fixture (20 of the shape's 228 calls), then closes
+	// the producer: consumeModelStream must stop consuming — and act on the
+	// trip — using only the first 15, never touching (let alone needing) the
+	// remaining 5 this fixture still provides.
+	resp, _, err := runConsumeModelStream(t, sess, req, st, func() {
+		for i := 0; i < sent; i++ {
+			p := pattern[i%3]
+			sendToolCall(st, callID(i), p.name, p.args)
+		}
+		st.CloseSend()
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil (a tier-1 trip forces a clean finish, not an error)", err)
+	}
+	calls := resp.Response.ToolCalls()
+	if len(calls) != 15 {
+		t.Fatalf("got %d tool calls, want exactly 15 (trip fires at the 5th repeat of the 3-call cycle)", len(calls))
+	}
+	for i, c := range calls {
+		want := pattern[i%3]
+		if c.Name != want.name || string(c.Arguments) != want.args {
+			t.Fatalf("call %d = %+v, want name=%q args=%q (no truncation/corruption at the cut point)", i, c, want.name, want.args)
+		}
+	}
+	if resp.Response.Finish.Reason != llm.FinishReasonToolCalls {
+		t.Fatalf("Finish.Reason = %q, want %q (a legal boundary: calls are complete, not cut mid-arguments)", resp.Response.Finish.Reason, llm.FinishReasonToolCalls)
+	}
+
+	sess.mu.Lock()
+	nudge := sess.pendingStreamLoopNudge
+	streak := sess.streamLoopTripStreak
+	sess.mu.Unlock()
+	if nudge == "" {
+		t.Fatal("pendingStreamLoopNudge is empty, want a nudge naming the repeated call")
+	}
+	if !containsAll(nudge, "manage_worktree", "task_list", "communicate") {
+		t.Fatalf("nudge = %q, want it to name the repeated calls", nudge)
+	}
+	if streak != 1 {
+		t.Fatalf("streamLoopTripStreak = %d, want 1 (first trip)", streak)
+	}
+}
+
+// TestConsumeModelStream_LoopGuard_CeilingShape is fixture (b): 83 calls, 48
+// distinct signatures, max repeat 12, built with no period-1..5 cycle
+// anywhere (see buildEightyThreeCallNoCycleFixture). Records, per the kata's
+// own instruction, which detector actually catches it.
+func TestConsumeModelStream_LoopGuard_CeilingShape(t *testing.T) {
+	sess := newSession(t)
+	req := llm.Request{Provider: "openai", Model: "gpt-5.2"}
+	st := llm.NewChanStream(nil)
+
+	sigs := buildEightyThreeCallNoCycleFixture(t)
+	resp, _, err := runConsumeModelStream(t, sess, req, st, func() {
+		for i, s := range sigs {
+			sendToolCall(st, callID(i), s.name, s.args)
+		}
+		st.CloseSend()
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	calls := resp.Response.ToolCalls()
+	if len(calls) != loopGuardRawCeiling {
+		t.Fatalf("got %d tool calls, want exactly %d (the ceiling, since this fixture has no short cycle)", len(calls), loopGuardRawCeiling)
+	}
+	sess.mu.Lock()
+	nudge := sess.pendingStreamLoopNudge
+	sess.mu.Unlock()
+	if !containsAll(nudge, "50") {
+		t.Fatalf("nudge = %q, want it to name the ceiling count", nudge)
+	}
+	t.Logf("shape (b) 83-call/48-distinct/max-repeat-12 fixture: caught by the CEILING detector at call %d, not the cycle detector", len(calls))
+}
+
+// TestConsumeModelStream_LoopGuard_ChantShape is fixture (c): a reasoning-only
+// runaway chanting a short phrase, zero tool calls (cline #13041 shape).
+func TestConsumeModelStream_LoopGuard_ChantShape(t *testing.T) {
+	sess := newSession(t)
+	req := llm.Request{Provider: "openai", Model: "gpt-5.2"}
+	st := llm.NewChanStream(nil)
+
+	const phrase = "Let me think about this carefully and check the file once more. "
+	const sent = 300
+	resp, _, err := runConsumeModelStream(t, sess, req, st, func() {
+		defer st.CloseSend()
+		for i := 0; i < sent; i++ {
+			st.Send(llm.StreamEvent{Type: llm.StreamEventReasoningDelta, ReasoningDelta: phrase})
+		}
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if len(resp.Response.ToolCalls()) != 0 {
+		t.Fatalf("got %d tool calls, want 0 (this shape is reasoning-only)", len(resp.Response.ToolCalls()))
+	}
+	if resp.Response.Finish.Reason != llm.FinishReasonStop {
+		t.Fatalf("Finish.Reason = %q, want %q (no tool calls pending)", resp.Response.Finish.Reason, llm.FinishReasonStop)
+	}
+	sess.mu.Lock()
+	nudge := sess.pendingStreamLoopNudge
+	sess.mu.Unlock()
+	if nudge == "" {
+		t.Fatal("pendingStreamLoopNudge is empty, want a nudge for the chant trip")
+	}
+}
+
+// TestConsumeModelStream_LoopGuard_EighteenDistinctCalls_NoTrip is fixture
+// (d): a legitimate round of 18 distinct tool calls must complete normally,
+// with a real StreamEventFinish -- the field's documented false positive
+// (odysseus #3185).
+func TestConsumeModelStream_LoopGuard_EighteenDistinctCalls_NoTrip(t *testing.T) {
+	sess := newSession(t)
+	req := llm.Request{Provider: "openai", Model: "gpt-5.2"}
+	st := llm.NewChanStream(nil)
+
+	resp, _, err := runConsumeModelStream(t, sess, req, st, func() {
+		for i := 0; i < 18; i++ {
+			sendToolCall(st, callID(i), distinctToolName(i), `{"n":`+itoaTest(i)+`}`)
+		}
+		st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &llm.FinishReason{Reason: llm.FinishReasonToolCalls}})
+		st.CloseSend()
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if len(resp.Response.ToolCalls()) != 18 {
+		t.Fatalf("got %d tool calls, want 18 (nothing truncated)", len(resp.Response.ToolCalls()))
+	}
+	sess.mu.Lock()
+	nudge := sess.pendingStreamLoopNudge
+	streak := sess.streamLoopTripStreak
+	sess.mu.Unlock()
+	if nudge != "" {
+		t.Fatalf("pendingStreamLoopNudge = %q, want empty: 18 distinct calls must never trip", nudge)
+	}
+	if streak != 0 {
+		t.Fatalf("streamLoopTripStreak = %d, want 0", streak)
+	}
+}
+
+// TestConsumeModelStream_LoopGuard_RepeatedCodeFences_NoTrip is fixture (e):
+// legitimate long code output with the same fenced snippet repeated across
+// several blocks must not trip chanting.
+func TestConsumeModelStream_LoopGuard_RepeatedCodeFences_NoTrip(t *testing.T) {
+	sess := newSession(t)
+	req := llm.Request{Provider: "openai", Model: "gpt-5.2"}
+	st := llm.NewChanStream(nil)
+
+	snippet := "func Add(a, b int) int {\n\treturn a + b\n}\n"
+	files := []string{
+		"internal/mathutil/add.go", "pkg/calc/sum.go", "cmd/tool/helpers.go",
+		"internal/report/tally.go", "pkg/stats/reduce.go", "cmd/serve/util.go",
+		"internal/graph/weights.go", "pkg/queue/merge.go", "cmd/build/steps.go",
+		"internal/cache/evict.go", "pkg/sched/plan.go", "cmd/deploy/roll.go",
+		"internal/index/scan.go", "pkg/store/kv.go", "cmd/migrate/apply.go",
+	}
+	resp, _, err := runConsumeModelStream(t, sess, req, st, func() {
+		st.Send(llm.StreamEvent{Type: llm.StreamEventTextStart, TextID: "t0"})
+		for _, path := range files {
+			st.Send(llm.StreamEvent{Type: llm.StreamEventTextDelta, TextID: "t0", Delta: "The same small helper belongs in " + path + " as well, unchanged:\n\n"})
+			st.Send(llm.StreamEvent{Type: llm.StreamEventTextDelta, TextID: "t0", Delta: "```go\n" + snippet + "```\n\n"})
+		}
+		st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &llm.FinishReason{Reason: llm.FinishReasonStop}})
+		st.CloseSend()
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	sess.mu.Lock()
+	nudge := sess.pendingStreamLoopNudge
+	sess.mu.Unlock()
+	if nudge != "" {
+		t.Fatalf("pendingStreamLoopNudge = %q, want empty: repeated fenced code must not trip chanting", nudge)
+	}
+	if resp.Response.Finish.Reason != llm.FinishReasonStop {
+		t.Fatalf("Finish.Reason = %q, want %q (unmodified: no trip occurred)", resp.Response.Finish.Reason, llm.FinishReasonStop)
+	}
+}
+
+// TestConsumeModelStream_LoopGuard_DefersUntilParallelCallCloses is the
+// "never cut mid-arguments" safety property applied to the case the plain
+// per-call check misses: a trip detected at one tool call's End must not
+// force a finish while a DIFFERENT, still-open parallel call (Started but
+// not yet Ended -- real providers stream parallel tool calls with
+// interleaved deltas across multiple call IDs) is in flight, or the forced
+// finish would freeze that call's arguments mid-stream into the response.
+func TestConsumeModelStream_LoopGuard_DefersUntilParallelCallCloses(t *testing.T) {
+	sess := newSession(t)
+	req := llm.Request{Provider: "openai", Model: "gpt-5.2"}
+	st := llm.NewChanStream(nil)
+
+	pattern := []toolSig{
+		{"manage_worktree", `{"op":"list"}`},
+		{"task_list", `{}`},
+		{"communicate", `{"message":"still working","end_turn":false}`},
+	}
+	resp, _, err := runConsumeModelStream(t, sess, req, st, func() {
+		// 14 calls of the cycle (not yet tripped: need=15).
+		for i := 0; i < 14; i++ {
+			p := pattern[i%3]
+			sendToolCall(st, callID(i), p.name, p.args)
+		}
+		// Open a distinct, parallel call and leave it mid-arguments.
+		st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallStart, ToolCall: &llm.ToolCallData{ID: "extra", Name: "long_running_call"}})
+		st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallDelta, ToolCall: &llm.ToolCallData{ID: "extra", Arguments: []byte(`{"partial":`)}})
+		// The 15th cycle call: this is where the trip would fire, but "extra" is
+		// still open.
+		p := pattern[14%3]
+		sendToolCall(st, callID(14), p.name, p.args)
+		// More time passes for the parallel call, still open.
+		st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallDelta, ToolCall: &llm.ToolCallData{ID: "extra", Arguments: []byte(`true}`)}})
+		// Now it closes -- this is the first legal boundary after the trip.
+		st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallEnd, ToolCall: &llm.ToolCallData{ID: "extra", Arguments: []byte(`{"partial":true}`)}})
+		st.CloseSend()
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	calls := resp.Response.ToolCalls()
+	if len(calls) != 16 {
+		t.Fatalf("got %d tool calls, want exactly 16 (15 cycle calls + the parallel call, all complete)", len(calls))
+	}
+	for _, c := range calls {
+		if c.ID == "extra" {
+			if string(c.Arguments) != `{"partial":true}` {
+				t.Fatalf(`"extra" call arguments = %q, want the COMPLETE %q -- a forced finish while it was still open would have frozen it mid-argument`, c.Arguments, `{"partial":true}`)
+			}
+		}
+	}
+	sess.mu.Lock()
+	nudge := sess.pendingStreamLoopNudge
+	sess.mu.Unlock()
+	if nudge == "" {
+		t.Fatal("pendingStreamLoopNudge is empty, want the deferred trip to still fire once the parallel call closes")
+	}
+}
+
+// TestConsumeModelStream_LoopGuard_SecondConsecutiveTrip_HardStops pins the
+// two-tier action: "first trip aborts the stream and injects a nudge naming
+// the repeated call; second trip hard-stops." The first response trips and
+// gets a soft, error-free forced finish (tier 1); when the very next
+// response ALSO trips, it must return a non-retryable error instead of
+// another soft finish (tier 2).
+func TestConsumeModelStream_LoopGuard_SecondConsecutiveTrip_HardStops(t *testing.T) {
+	sess := newSession(t)
+	req := llm.Request{Provider: "openai", Model: "gpt-5.2"}
+
+	pattern := []toolSig{
+		{"manage_worktree", `{"op":"list"}`},
+		{"task_list", `{}`},
+		{"communicate", `{"message":"still working","end_turn":false}`},
+	}
+	feedTrip := func(st *llm.ChanStream) func() {
+		return func() {
+			for i := 0; i < 15; i++ {
+				p := pattern[i%3]
+				sendToolCall(st, callID(i), p.name, p.args)
+			}
+			st.CloseSend()
+		}
+	}
+
+	// First response: tier 1, soft.
+	st1 := llm.NewChanStream(nil)
+	_, _, err1 := runConsumeModelStream(t, sess, req, st1, feedTrip(st1))
+	if err1 != nil {
+		t.Fatalf("first trip: err = %v, want nil", err1)
+	}
+	sess.mu.Lock()
+	streak1 := sess.streamLoopTripStreak
+	sess.mu.Unlock()
+	if streak1 != 1 {
+		t.Fatalf("streak after first trip = %d, want 1", streak1)
+	}
+
+	// Second, consecutive response: tier 2, hard stop.
+	st2 := llm.NewChanStream(nil)
+	_, obs2, err2 := runConsumeModelStream(t, sess, req, st2, feedTrip(st2))
+	if err2 == nil {
+		t.Fatal("second consecutive trip: err = nil, want a hard-stop error")
+	}
+	var le llm.Error
+	if !errors.As(err2, &le) {
+		t.Fatalf("second trip error %v does not satisfy llm.Error", err2)
+	}
+	if le.Retryable() {
+		t.Fatalf("second trip error is Retryable() == true, want false (retrying replays the same runaway pattern)")
+	}
+	if llm.Classify(err2) != llm.ErrorClassPermanent {
+		t.Fatalf("Classify(err2) = %v, want ErrorClassPermanent", llm.Classify(err2))
+	}
+	_ = obs2
+	sess.mu.Lock()
+	streak2 := sess.streamLoopTripStreak
+	sess.mu.Unlock()
+	if streak2 != 2 {
+		t.Fatalf("streak after second trip = %d, want 2", streak2)
+	}
+}
+
+// TestConsumeModelStream_LoopGuard_CleanRoundResetsStreak proves the streak
+// is about CONSECUTIVE trips, not a lifetime count: a clean round between two
+// tripped ones must reset it, so a session that occasionally loops but
+// always recovers is never hard-stopped.
+func TestConsumeModelStream_LoopGuard_CleanRoundResetsStreak(t *testing.T) {
+	sess := newSession(t)
+	req := llm.Request{Provider: "openai", Model: "gpt-5.2"}
+	pattern := []toolSig{
+		{"manage_worktree", `{"op":"list"}`},
+		{"task_list", `{}`},
+		{"communicate", `{"message":"still working","end_turn":false}`},
+	}
+	feedTrip := func(st *llm.ChanStream) func() {
+		return func() {
+			for i := 0; i < 15; i++ {
+				p := pattern[i%3]
+				sendToolCall(st, callID(i), p.name, p.args)
+			}
+			st.CloseSend()
+		}
+	}
+	feedClean := func(st *llm.ChanStream) func() {
+		return func() {
+			st.Send(llm.StreamEvent{Type: llm.StreamEventTextStart, TextID: "t0"})
+			st.Send(llm.StreamEvent{Type: llm.StreamEventTextDelta, TextID: "t0", Delta: "done"})
+			st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &llm.FinishReason{Reason: llm.FinishReasonStop}})
+			st.CloseSend()
+		}
+	}
+
+	st1 := llm.NewChanStream(nil)
+	if _, _, err := runConsumeModelStream(t, sess, req, st1, feedTrip(st1)); err != nil {
+		t.Fatalf("first trip: err = %v, want nil", err)
+	}
+	st2 := llm.NewChanStream(nil)
+	if _, _, err := runConsumeModelStream(t, sess, req, st2, feedClean(st2)); err != nil {
+		t.Fatalf("clean round: err = %v, want nil", err)
+	}
+	sess.mu.Lock()
+	streak := sess.streamLoopTripStreak
+	sess.mu.Unlock()
+	if streak != 0 {
+		t.Fatalf("streak after a clean round = %d, want 0 (streak resets)", streak)
+	}
+
+	// A trip AFTER the clean round must be treated as a first trip again,
+	// not a second consecutive one.
+	st3 := llm.NewChanStream(nil)
+	if _, _, err := runConsumeModelStream(t, sess, req, st3, feedTrip(st3)); err != nil {
+		t.Fatalf("trip after clean round: err = %v, want nil (tier 1, not tier 2)", err)
+	}
+}
+
+func callID(i int) string {
+	return "call_" + itoaTest(i)
+}

--- a/agent/session_stream_loop_guard_integration_test.go
+++ b/agent/session_stream_loop_guard_integration_test.go
@@ -93,7 +93,7 @@ func TestConsumeModelStream_LoopGuard_CycleShape(t *testing.T) {
 	// trip — using only the first 15, never touching (let alone needing) the
 	// remaining 5 this fixture still provides.
 	resp, _, err := runConsumeModelStream(t, sess, req, st, func() {
-		for i := 0; i < sent; i++ {
+		for i := range sent {
 			p := pattern[i%3]
 			sendToolCall(st, callID(i), p.name, p.args)
 		}
@@ -174,7 +174,7 @@ func TestConsumeModelStream_LoopGuard_ChantShape(t *testing.T) {
 	const sent = 300
 	resp, _, err := runConsumeModelStream(t, sess, req, st, func() {
 		defer st.CloseSend()
-		for i := 0; i < sent; i++ {
+		for range sent {
 			st.Send(llm.StreamEvent{Type: llm.StreamEventReasoningDelta, ReasoningDelta: phrase})
 		}
 	})
@@ -205,7 +205,7 @@ func TestConsumeModelStream_LoopGuard_EighteenDistinctCalls_NoTrip(t *testing.T)
 	st := llm.NewChanStream(nil)
 
 	resp, _, err := runConsumeModelStream(t, sess, req, st, func() {
-		for i := 0; i < 18; i++ {
+		for i := range 18 {
 			sendToolCall(st, callID(i), distinctToolName(i), `{"n":`+itoaTest(i)+`}`)
 		}
 		st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &llm.FinishReason{Reason: llm.FinishReasonToolCalls}})
@@ -287,7 +287,7 @@ func TestConsumeModelStream_LoopGuard_DefersUntilParallelCallCloses(t *testing.T
 	}
 	resp, _, err := runConsumeModelStream(t, sess, req, st, func() {
 		// 14 calls of the cycle (not yet tripped: need=15).
-		for i := 0; i < 14; i++ {
+		for i := range 14 {
 			p := pattern[i%3]
 			sendToolCall(st, callID(i), p.name, p.args)
 		}
@@ -343,7 +343,7 @@ func TestConsumeModelStream_LoopGuard_SecondConsecutiveTrip_HardStops(t *testing
 	}
 	feedTrip := func(st *llm.ChanStream) func() {
 		return func() {
-			for i := 0; i < 15; i++ {
+			for i := range 15 {
 				p := pattern[i%3]
 				sendToolCall(st, callID(i), p.name, p.args)
 			}
@@ -403,7 +403,7 @@ func TestConsumeModelStream_LoopGuard_CleanRoundResetsStreak(t *testing.T) {
 	}
 	feedTrip := func(st *llm.ChanStream) func() {
 		return func() {
-			for i := 0; i < 15; i++ {
+			for i := range 15 {
 				p := pattern[i%3]
 				sendToolCall(st, callID(i), p.name, p.args)
 			}

--- a/agent/session_stream_loop_guard_test.go
+++ b/agent/session_stream_loop_guard_test.go
@@ -47,7 +47,7 @@ func TestStreamLoopGuard_CycleDetection_DoesNotTripBeforeFiveRepeats(t *testing.
 		{"task_list", `{}`},
 		{"communicate", `{"message":"still working"}`},
 	}
-	for i := 0; i < 12; i++ {
+	for i := range 12 {
 		c := calls[i%3]
 		if trip := g.observeToolCall(c.name, c.args); trip != nil {
 			t.Fatalf("call %d: tripped early (%+v), want no trip before 15 calls", i+1, trip)
@@ -61,7 +61,7 @@ func TestStreamLoopGuard_CycleDetection_DoesNotTripBeforeFiveRepeats(t *testing.
 func TestStreamLoopGuard_CycleDetection_SingleCallRepeatedFiveTimes(t *testing.T) {
 	g := newStreamLoopGuard()
 	var trip *loopTrip
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		trip = g.observeToolCall("read_file", `{"path":"/x"}`)
 	}
 	if trip == nil {
@@ -78,7 +78,7 @@ func TestStreamLoopGuard_CycleDetection_SingleCallRepeatedFiveTimes(t *testing.T
 // nor the raw ceiling (well under it).
 func TestStreamLoopGuard_EighteenDistinctCalls_NoTrip(t *testing.T) {
 	g := newStreamLoopGuard()
-	for i := 0; i < 18; i++ {
+	for i := range 18 {
 		name := distinctToolName(i)
 		if trip := g.observeToolCall(name, `{"n":`+itoaTest(i)+`}`); trip != nil {
 			t.Fatalf("call %d (%s): unexpected trip %+v", i+1, name, trip)

--- a/agent/session_stream_loop_guard_test.go
+++ b/agent/session_stream_loop_guard_test.go
@@ -1,0 +1,152 @@
+package agent
+
+import "testing"
+
+// These tests drive the pure loop-guard detector directly (kata d74b): no
+// Session, no stream plumbing. The stream-loop integration (forcing a legal
+// stop mid-consumeModelStream) is covered separately in
+// session_stream_loop_guard_integration_test.go, matching the five documented
+// runaway shapes.
+
+// TestStreamLoopGuard_CycleDetection_TripsAtFifteenCalls pins the kata's
+// primary fixture: (manage_worktree, task_list, communicate) repeating, a
+// cycle of length k=3 that must trip once it has repeated 5 times (15 calls
+// in), not merely be present somewhere in a long response.
+func TestStreamLoopGuard_CycleDetection_TripsAtFifteenCalls(t *testing.T) {
+	g := newStreamLoopGuard()
+	calls := []struct{ name, args string }{
+		{"manage_worktree", `{"op":"list"}`},
+		{"task_list", `{}`},
+		{"communicate", `{"message":"still working"}`},
+	}
+	var trip *loopTrip
+	n := 0
+	for trip == nil {
+		c := calls[n%3]
+		trip = g.observeToolCall(c.name, c.args)
+		n++
+		if n > 30 {
+			t.Fatalf("cycle never tripped after %d calls", n)
+		}
+	}
+	if n != 15 {
+		t.Fatalf("cycle tripped after %d calls, want exactly 15 (k=3, R=5)", n)
+	}
+	if trip.Kind != loopTripCycle {
+		t.Fatalf("trip.Kind = %v, want loopTripCycle", trip.Kind)
+	}
+}
+
+// TestStreamLoopGuard_CycleDetection_DoesNotTripBeforeFiveRepeats checks the
+// boundary directly: four repeats of a 3-call cycle (12 calls) must not trip,
+// only the fifth repeat (the 15th call) does.
+func TestStreamLoopGuard_CycleDetection_DoesNotTripBeforeFiveRepeats(t *testing.T) {
+	g := newStreamLoopGuard()
+	calls := []struct{ name, args string }{
+		{"manage_worktree", `{"op":"list"}`},
+		{"task_list", `{}`},
+		{"communicate", `{"message":"still working"}`},
+	}
+	for i := 0; i < 12; i++ {
+		c := calls[i%3]
+		if trip := g.observeToolCall(c.name, c.args); trip != nil {
+			t.Fatalf("call %d: tripped early (%+v), want no trip before 15 calls", i+1, trip)
+		}
+	}
+}
+
+// TestStreamLoopGuard_CycleDetection_SingleCallRepeatedFiveTimes covers k=1:
+// the same call five times in a row trips as a cycle of length 1, the cheap
+// fast path the corrected writeup calls for alongside the general k=1..5 scan.
+func TestStreamLoopGuard_CycleDetection_SingleCallRepeatedFiveTimes(t *testing.T) {
+	g := newStreamLoopGuard()
+	var trip *loopTrip
+	for i := 0; i < 5; i++ {
+		trip = g.observeToolCall("read_file", `{"path":"/x"}`)
+	}
+	if trip == nil {
+		t.Fatal("expected a trip after 5 identical calls")
+	}
+	if trip.Kind != loopTripCycle {
+		t.Fatalf("trip.Kind = %v, want loopTripCycle", trip.Kind)
+	}
+}
+
+// TestStreamLoopGuard_EighteenDistinctCalls_NoTrip pins odysseus #3185's
+// false positive (kata comment): a legitimate round of ~18 DISTINCT tool
+// calls must never trip, neither the cycle detector (no repetition at all)
+// nor the raw ceiling (well under it).
+func TestStreamLoopGuard_EighteenDistinctCalls_NoTrip(t *testing.T) {
+	g := newStreamLoopGuard()
+	for i := 0; i < 18; i++ {
+		name := distinctToolName(i)
+		if trip := g.observeToolCall(name, `{"n":`+itoaTest(i)+`}`); trip != nil {
+			t.Fatalf("call %d (%s): unexpected trip %+v", i+1, name, trip)
+		}
+	}
+}
+
+// TestStreamLoopGuard_RawCeiling_TripsWithoutAnyCycle reconstructs the
+// kata's second measured shape -- 83 calls, 48 distinct signatures, max
+// repeat 12, deliberately built with NO period-1..5 pattern repeated 5
+// times consecutively anywhere -- and pins which detector catches it: the
+// ceiling, not the cycle detector (kata: "record honestly which detector
+// catches it; likely the ceiling").
+func TestStreamLoopGuard_RawCeiling_TripsWithoutAnyCycle(t *testing.T) {
+	sigs := buildEightyThreeCallNoCycleFixture(t)
+
+	// Self-check the fixture generator's own claim before trusting the
+	// detector's answer: assert directly (via the guard's own cycle
+	// checker) that no k=1..5/R=5 cycle exists anywhere in the full 83-call
+	// sequence, offline, before feeding it through observeToolCall.
+	assertNoShortCycleAnywhere(t, sigs)
+
+	g := newStreamLoopGuard()
+	var trip *loopTrip
+	n := 0
+	for i, sig := range sigs {
+		trip = g.observeToolCall(sig.name, sig.args)
+		n = i + 1
+		if trip != nil {
+			break
+		}
+	}
+	if trip == nil {
+		t.Fatalf("expected a trip within %d calls (ceiling=%d), got none", len(sigs), loopGuardRawCeiling)
+	}
+	if trip.Kind != loopTripCeiling {
+		t.Fatalf("trip.Kind = %v, want loopTripCeiling (the fixture has no short cycle by construction)", trip.Kind)
+	}
+	if n != loopGuardRawCeiling {
+		t.Fatalf("ceiling tripped at call %d, want exactly %d", n, loopGuardRawCeiling)
+	}
+}
+
+func itoaTest(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}
+
+func distinctToolName(i int) string {
+	names := []string{
+		"read_file", "write_file", "search_files", "manage_worktree", "task_list",
+		"communicate", "run_shell", "grep", "list_dir", "web_fetch",
+		"create_job", "watch", "ask_user", "compact", "delegate",
+		"note", "job_status", "cancel_job",
+	}
+	return names[i%len(names)]
+}

--- a/agent/session_tool_round.go
+++ b/agent/session_tool_round.go
@@ -406,6 +406,18 @@ func (s *Session) injectPostToolSteering(ctx context.Context, calls []llm.ToolCa
 		}
 	}
 
+	// Stream loop guard (kata d74b): consumeModelStream force-stopped the
+	// response just processed above and queued a nudge on pendingStreamLoopNudge
+	// (session_stream_loop_guard.go). Deliver it here, the same after-tool,
+	// before-next-model-call point the cross-round detector above uses, so the
+	// model reads it after seeing its own truncated calls and their results.
+	// (A response with NO tool calls -- a chant trip -- never reaches this
+	// function at all; processOneInput's len(calls)==0 branch delivers it
+	// there instead, via the same helper.)
+	if abortErr := s.deliverPendingStreamLoopNudge(ctx); abortErr != nil {
+		return false, abortErr
+	}
+
 	drained, err := s.drainPostToolWatchSends(ctx)
 	if err != nil {
 		return false, err

--- a/agent/settlement_salvage_test.go
+++ b/agent/settlement_salvage_test.go
@@ -186,7 +186,7 @@ func TestSettlement_StallStreakPersistsSteeringOnly(t *testing.T) {
 // point the next round at a response the provider never finalized.
 func TestSettlement_SalvagedDraftPersistsBeforeSteering(t *testing.T) {
 	t.Parallel()
-	draft := strings.Repeat("plan step. ", 1000) // ~11KB
+	draft := nonChantingFiller("plan step.", 1000) // ~11KB
 	var attempts int
 	a := &scriptedStreamAdapter{
 		provider: "openai",
@@ -369,7 +369,7 @@ func TestSettlement_InterruptWithNoSalvagePersistsNothing(t *testing.T) {
 // no failure marker.
 func TestSettlement_InterruptMidRetryGroupSalvagesPartial(t *testing.T) {
 	t.Parallel()
-	draft := strings.Repeat("plan step. ", 500) // ~5.5KB
+	draft := nonChantingFiller("plan step.", 500) // ~5.5KB
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	var attempts int
@@ -485,7 +485,7 @@ func TestSettlement_InterruptMidRetryGroupSalvagesPartial(t *testing.T) {
 // while the salvage belongs to the filter-killed group.
 func TestSettlement_InterruptNeverPersistsFilterTrippingSalvage(t *testing.T) {
 	t.Parallel()
-	draft := strings.Repeat("blocked step. ", 500)
+	draft := nonChantingFiller("blocked step.", 500)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	a := &scriptedStreamAdapter{
@@ -535,7 +535,7 @@ func TestSettlement_InterruptNeverPersistsFilterTrippingSalvage(t *testing.T) {
 // context-length rejection must still persist the primary group's partial.
 func TestSettlement_ContextLengthTerminalKeepsPrimarySalvage(t *testing.T) {
 	t.Parallel()
-	draft := strings.Repeat("plan step. ", 1000)
+	draft := nonChantingFiller("plan step.", 1000)
 	contextLenErr := llm.ErrorFromHTTPStatus("openai", 400, "context length exceeded", nil, nil)
 	if llm.Kind(contextLenErr) != llm.KindContextLength {
 		t.Fatalf("fixture kind = %v, want KindContextLength", llm.Kind(contextLenErr))

--- a/agent/testkit_test.go
+++ b/agent/testkit_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -143,4 +144,23 @@ func failAppendN(jm *jobManager, kind jobstore.EventKind, n int) *atomic.Int32 {
 		return orig(e)
 	}
 	return &attempts
+}
+
+// --- streamed-content filler ---
+
+// nonChantingFiller returns text of the same shape as strings.Repeat(unit+"
+// ", n) -- same word, same repeat count, comparable byte volume -- but with a
+// running index folded into each repetition, so no chantChunkRunes-wide
+// window stays byte-identical across chantThreshold occurrences the way pure
+// repetition would (session_stream_loop_guard_chant.go, kata d74b). Several
+// tests stream a large "draft" purely as cheap bulk filler for a cap/salvage
+// scenario, not to model a chanting response; without this, the stream loop
+// guard forces an early, error-free stop mid-content and the scripted
+// mid-stream failure those tests are built around never arrives.
+func nonChantingFiller(unit string, n int) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "%s%d ", unit, i)
+	}
+	return b.String()
 }

--- a/agent/testkit_test.go
+++ b/agent/testkit_test.go
@@ -159,7 +159,7 @@ func failAppendN(jm *jobManager, kind jobstore.EventKind, n int) *atomic.Int32 {
 // mid-stream failure those tests are built around never arrives.
 func nonChantingFiller(unit string, n int) string {
 	var b strings.Builder
-	for i := 0; i < n; i++ {
+	for i := range n {
 		fmt.Fprintf(&b, "%s%d ", unit, i)
 	}
 	return b.String()

--- a/cmd/serf-hub/frontend/src/panes/session/transcript/messages/SteeringItem.tsx
+++ b/cmd/serf-hub/frontend/src/panes/session/transcript/messages/SteeringItem.tsx
@@ -61,6 +61,7 @@ const KIND_LABELS: Record<LabelledKind, string> = {
   "image-description": "Image description",
   "no-tool-calls": "No tool calls",
   "loop-detected": "Loop detection",
+  "stream-loop": "Stream loop guard",
   "tasks-done": "Tasks done",
   "task-nudge": "Task nudge",
   "task-inactive": "Task list idle",

--- a/cmd/serf-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/serf-hub/frontend/src/protocol/types.gen.ts
@@ -1592,6 +1592,7 @@ export const STEERING_KINDS = [
   "image-description",
   "no-tool-calls",
   "loop-detected",
+  "stream-loop",
   "tasks-done",
   "task-nudge",
   "task-inactive",

--- a/llm/sdk_errors.go
+++ b/llm/sdk_errors.go
@@ -97,6 +97,22 @@ func NewStreamError(provider, message string, cause error) error {
 	}}
 }
 
+// NewPermanentStreamError reports a streaming failure the caller has already
+// decided must not be retried: retrying would re-run exactly the request
+// that produced the condition being reported. Unlike NewStreamError
+// (always retryable), Retryable() is false here, so Classify returns
+// ErrorClassPermanent and the retry chain gives up immediately instead of
+// spending its budget reproducing the same outcome. cause is optional,
+// exposed via Unwrap.
+func NewPermanentStreamError(provider, message string, cause error) error {
+	return &StreamError{nonHTTPBaseError{
+		provider:  provider,
+		message:   message,
+		retryable: false,
+		cause:     cause,
+	}}
+}
+
 // NewNoObjectGeneratedError reports that no valid object could be produced from
 // the model output. cause is the underlying parse/validation error, exposed via
 // Unwrap; pass nil when none applies.


### PR DESCRIPTION
Kata: d74b (closed with this feature)

The hole (documented on the kata from a real 320s/228-call incident): all four existing guards watch something else — max-rounds counts finished rounds, PhaseSilentStall needs zero content, RetryStream needs a failure, the tool breaker needs results. A single unbounded response was invisible. The provider survey on the kata found no API-side bound exists anywhere; detection must be ours.

Implements the plan from the kata's revised research comment (gemini-cli LoopDetectionService shape, the field's only in-stream detector):
- **Cycle detection** (k=1..5 repeated 5x) as primary — catches the captured (A,B,C)x76 shape after ~15 calls mid-stream, where every consecutive-identical detector in the field is structurally blind.
- **Raw call ceiling as backstop** — catches the 83-call/48-signature shape (confirmed: the cycle detector legitimately never fires on it). **Ceiling = 50 is the one judgment call in this PR**: the kata's citation argues for hundreds, but that figure is another product's telemetry cap; the only documented legitimate shape is 18 distinct calls, 50 is ~2.7x that, and nothing in the suite needs more. A first trip is soft (see below), which is what makes a lower ceiling safe. `loopGuardRawCeiling` is the constant to revisit if field data shows legitimate >50-call responses.
- **Content chanting** for the zero-tool-call runaway (cline's "Let me" x2865), gemini-cli's own constants, with the load-bearing false-positive guard (between-text uniqueness) and code-fence resets.
- **Two-tier action**: first trip forces a legal stop boundary (synthetic well-formed finish tagged `loop_guard:*`; already-streamed calls still dispatch, a steering nudge names what repeated, work continues next round). Only a second consecutive trip hard-stops via a new non-retryable `llm.NewPermanentStreamError`. A trip while another parallel tool call is open defers until every call closes — never a cut mid-arguments.
- Rejected-by-Jesse items confirmed absent: no default max_tokens cap, no disable_parallel_tool_use, no wall clock.

New steering kind `stream-loop` regenerated into the TS protocol union; the frontend's exhaustive KIND_LABELS net caught it and got its label (the net working as designed).

Verification: 22-test suite over the five documented stream shapes (two must-NOT-trip cases included); 13 production mutations run for real, incl. bracketing the ceiling from both sides; three real bugs found by the tests during development (nudge dropped on zero-tool-call rounds; six pre-existing tests using genuinely chant-shaped filler; two self-caught false-green tests). Full agent+llm suites, central make lint + make test (incl. web typecheck) green on the integration branch.

https://claude.ai/code/session_017f6aYf3cJgkcg8PNAg62wX