### PR TITLE
fix(tooling): test-cost cleans up its own scratch

### DIFF
--- a/scriptmktemp_audit_test.go
+++ b/scriptmktemp_audit_test.go
@@ -65,7 +65,6 @@ var mktempAllowedScripts = map[string]bool{
 	"fuzz-oracle-audit.sh":        true,
 	"fuzz-registry-check.sh":      true,
 	"fuzz-triage.sh":              true,
-	"test-cost.sh":                true,
 }
 
 // TestNoScriptCreatesScratchOutsideTMPDIR keeps the swept scripts swept: the
@@ -351,6 +350,10 @@ var recursiveDeleteAllowedLines = map[string]int{
 	"coverage-union.sh":       1,
 	"fuzz-coverage.sh":        1,
 	"fuzz-coverage-global.sh": 1,
+	// test-cost adopts the same pid-suffixed pattern as the runners above,
+	// for the same reasons; before this it minted with `mktemp -t` (outside
+	// any TMPDIR a caller set) and never deleted its scratch at all.
+	"test-cost.sh": 1,
 	// Owner-side reclamation of the coverage runners' own abandoned scratch:
 	// the delete IS the job. Targets come from a prefix glob walked with
 	// existence and symlink guards, scoped to basenames whose pid suffix no

--- a/scripts/test-cost.sh
+++ b/scripts/test-cost.sh
@@ -57,8 +57,23 @@ done
 [ -d "$dir" ] || die "no such directory: $dir"
 [ -n "$jsonOut" ] && jsonOut="$(cd "$(dirname "$jsonOut")" && pwd)/$(basename "$jsonOut")"
 
+# An explicit path under TMPDIR, not `mktemp -t`: macOS's mktemp ignores TMPDIR
+# for -t and uses the Darwin per-user temp directory instead — and this script
+# never deleted what it minted there, so every run leaked its compiled test
+# binary and logs. Same discipline as the coverage runners: reclaim what
+# earlier runs abandoned, then take a pid-suffixed name with the trap armed
+# BEFORE the directory exists, so a signal in the window abandons nothing.
+# SIGKILL leftovers wait for the next run's reclaim. A failed mkdir means a
+# stale same-pid leftover this run does not own, so the trap is disarmed
+# before exiting rather than deleting it.
+. "$(dirname "${BASH_SOURCE[0]}")/covscratch-lib.sh"
+tmpbase=${TMPDIR:-/tmp}
+reclaim_own_scratch "$tmpbase" test-cost
+work="${tmpbase%/}/test-cost.$$"
+trap 'rm -rf "$work"' EXIT
+mkdir "$work" || { trap - EXIT; die "scratch $work already exists or cannot be created"; }
+
 cd "$dir" || die "cannot enter $dir"
-work="$(mktemp -d -t test-cost.XXXXXX)"
 bin="$work/pkg.test"
 
 printf 'test-cost: building %s\n' "$dir" >&2


### PR DESCRIPTION
Step 1c of the dev-tooling spec v2 (#103): the last tool that leaked scratch on every run stops.

**The leak:** `test-cost.sh` minted with `mktemp -d -t` — on macOS that ignores TMPDIR and lands in the Darwin per-user temp directory, outside the dev-tooling wave's leftover isolation — and armed no trap, so every run abandoned its compiled `pkg.test` (~6MB) and logs.

**The fix** adopts the coverage runners' discipline verbatim: source `covscratch-lib.sh`, `reclaim_own_scratch` before minting, pid-suffixed name chosen and EXIT trap armed **before** `mkdir`, disarm-on-collision. Nothing here invents anything; it is the fourth-through-sixth lines of `coverage-union.sh` with test-cost's own voice.

**Audit updates, both watched RED first:** `test-cost.sh` leaves `mktempAllowedScripts` (the escaping mint is gone — the audit failed on the stale entry until removed) and joins `recursiveDeleteAllowedLines` pinned at 1 beside the runners whose pattern it adopts (the audit failed on the unpinned trap delete until pinned).

**Verified against the identifier module under isolated TMPDIRs:**
- clean run leaves nothing; TMPDIR honored;
- SIGKILL mid-run leaves `test-cost.<pid>`; the next run reclaims it (verified twice, pre- and post-rebase);
- TERM mid-build ran the trap but the delete raced the still-live linker and the directory survived holding only `pkg.test` — the next run's reclaim removed it, which is the designed recovery for exactly that class (the sibling runners' selftests dodge this race by group-killing);
- legacy `test-cost.XXXXXX` leftovers in the Darwin temp dir carry no pid and are not reclaimed; they age out with that directory.

**Gate:** `make merge-approval-gate` in a clean /tmp worktree at 3d266b2fc — 27 suites PASS, one red: `run-module-lint-selftest`'s interrupt-timing checks ("interrupt fake did not start"), a suite this diff does not touch; isolated re-run under its own TMPDIR passes 180/180, judged a load flake per the flakes policy. Home canary 32 before and after. Three script audits green; `bash -n` clean; shellcheck shows only the sibling-standard SC1091.