### PR TITLE
fix(devtool): ReclaimOwn refuses the prefixes Acquire refuses

### DIFF
--- a/internal/devtool/scratch/scratch.go
+++ b/internal/devtool/scratch/scratch.go
@@ -59,7 +59,7 @@ func Acquire(prefix string, warn io.Writer) (*Dir, error) {
 	if warn == nil {
 		warn = os.Stderr
 	}
-	if prefix == "" || strings.ContainsAny(prefix, "/.") {
+	if !validPrefix(prefix) {
 		return nil, fmt.Errorf("scratch: invalid prefix %q", prefix)
 	}
 	base, err := tmpBase()
@@ -104,6 +104,10 @@ func (d *Dir) Release() {
 func ReclaimOwn(prefix string, warn io.Writer) {
 	if warn == nil {
 		warn = os.Stderr
+	}
+	if !validPrefix(prefix) {
+		_, _ = fmt.Fprintf(warn, "scratch: not reclaiming: invalid prefix %q\n", prefix)
+		return
 	}
 	base, err := tmpBase()
 	if err != nil {
@@ -175,4 +179,12 @@ func ownerPid(name string) int {
 		}
 	}
 	return pid
+}
+
+// validPrefix mirrors one refusal across Acquire and ReclaimOwn: an empty
+// prefix would match every hidden dot-directory under TMPDIR, and a dot or
+// separator widens the match past the caller's own scratch. Both are
+// removal-adjacent, so both check.
+func validPrefix(prefix string) bool {
+	return prefix != "" && !strings.ContainsAny(prefix, "/.")
 }

--- a/internal/devtool/scratch/scratch_test.go
+++ b/internal/devtool/scratch/scratch_test.go
@@ -362,6 +362,36 @@ func TestReclaimAfterSIGKILL(t *testing.T) {
 	}
 }
 
+// ReclaimOwn must refuse the prefixes Acquire refuses: an empty prefix would
+// otherwise match every hidden dot-directory under TMPDIR and remove any
+// with a dead-pid suffix — another tool's ".cache.12345", say.
+func TestReclaimOwnRefusesInvalidPrefixesAndTouchesNothing(t *testing.T) {
+	for _, prefix := range []string{"", ".", "/", "a/b", "dot.ted"} {
+		t.Run(fmt.Sprintf("prefix=%q", prefix), func(t *testing.T) {
+			tmp := fixtureTMPDIR(t)
+			dead := deadPid(t)
+			decoys := []string{
+				filepath.Join(tmp, fmt.Sprintf(".cache.%d", dead)),
+				filepath.Join(tmp, fmt.Sprintf("..%d", dead)),
+				filepath.Join(tmp, fmt.Sprintf("dot.ted.%d", dead)),
+			}
+			for _, decoy := range decoys {
+				seedDir(t, decoy)
+			}
+			var warn bytes.Buffer
+			ReclaimOwn(prefix, &warn)
+			if !strings.Contains(warn.String(), fmt.Sprintf("invalid prefix %q", prefix)) {
+				t.Fatalf("refusal not reported for prefix %q; warnings: %q", prefix, warn.String())
+			}
+			for _, decoy := range decoys {
+				if _, err := os.Stat(filepath.Join(decoy, "marker")); err != nil {
+					t.Fatalf("ReclaimOwn(%q) touched decoy %s: %v", prefix, decoy, err)
+				}
+			}
+		})
+	}
+}
+
 // Guard against pid parsing quirks: strconv.Atoi accepts "+1" and "-1",
 // which "${leftover##*.}"-style suffixes never legitimately carry.
 func TestReclaimOwnRejectsSignedPidSuffixes(t *testing.T) {


### PR DESCRIPTION
Hardening from the #118 review discussion: `scratch.Acquire` refuses an empty prefix or one containing `.`/`/`, but exported `ReclaimOwn` — the removal-adjacent half — did not. An empty prefix turns the reclaim glob into "every dot-directory under TMPDIR whose suffix is a dead pid": another tool's `.cache.12345`, say.

The fix extracts the refusal into `validPrefix` and applies it at both doors, with a warning (not an error) on the ReclaimOwn side, matching its never-fatal contract.

**Red-first proof:** with the guard line reverted, `TestReclaimOwnRefusesInvalidPrefixesAndTouchesNothing` fails on every prefix in `{"", ".", "/", "a/b", "dot.ted"}` ("refusal not reported"); restored, it passes and the seeded dead-pid decoy directories (`.cache.<dead>`, `..<dead>`, `dot.ted.<dead>`) survive untouched.

**Rebase note:** rebased over #120, which moved `pidAlive` into `pid_unix.go`/`pid_other.go`; the conflict was resolved keeping main's platform split intact — this diff adds only `validPrefix` and its two call-site checks.

**Verification:** `go test ./internal/devtool/scratch/ -race` green; `go vet` clean; the three script audits green; `make merge-approval-gate` exit 0 in a clean /tmp worktree at fd939ba36 (28 PASS, no FAILs); home canary 32 before and after.