### PR TITLE
fix(tui): replay coalesced key bursts as the keystrokes the sender typed (kata fazd)

### DIFF
--- a/cmd/serf-tui/hub_keys.go
+++ b/cmd/serf-tui/hub_keys.go
@@ -8,16 +8,6 @@ import (
 )
 
 func (m hubModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	// A single pty read can carry several printable keystrokes: tmux
-	// coalesces rapid writes when the pane's reader lags, and bubbletea
-	// reports every rune of one read as one KeyMsg. Replay such a batch one
-	// rune at a time, or every handler below that matches on msg.String()
-	// sees one unmatchable "kkf" instead of three keys (kata fazd: "/ops"
-	// dropped on the dashboard, "kk" typed into the composer). Bracketed
-	// paste stays whole — it is text for whatever input has focus, not keys.
-	if msg.Type == tea.KeyRunes && len(msg.Runes) > 1 && !msg.Paste {
-		return m.replayKeyBurst(msg)
-	}
 	if msg.String() == "ctrl+x" && len(m.notices) > 0 {
 		m.dismissNotice()
 		return m, nil
@@ -112,6 +102,18 @@ func (m hubModel) updateDashboardKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	if m.dashboardFilterActive {
 		return m.updateHubFilterKey(msg)
+	}
+	// From here down, printable runes are commands, and a single pty read can
+	// carry several of them: tmux coalesces rapid writes when the pane's
+	// reader lags, and bubbletea reports every rune of one read as one
+	// KeyMsg. Replay such a batch one rune at a time or the switch below sees
+	// one unmatchable "/ops" instead of the keys the sender typed and drops
+	// it silently (kata fazd). Only here: everywhere a text surface has
+	// focus — the composer, the palette and dashboard filters, the panels —
+	// a batch IS the typed text and must stay whole (a split "/interrupt"
+	// in the composer would open the palette instead).
+	if msg.Type == tea.KeyRunes && len(msg.Runes) > 1 && !msg.Paste {
+		return m.replayKeyBurst(msg)
 	}
 	rows := m.dashboardRows()
 	switch msg.String() {

--- a/cmd/serf-tui/hub_keys.go
+++ b/cmd/serf-tui/hub_keys.go
@@ -8,6 +8,16 @@ import (
 )
 
 func (m hubModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// A single pty read can carry several printable keystrokes: tmux
+	// coalesces rapid writes when the pane's reader lags, and bubbletea
+	// reports every rune of one read as one KeyMsg. Replay such a batch one
+	// rune at a time, or every handler below that matches on msg.String()
+	// sees one unmatchable "kkf" instead of three keys (kata fazd: "/ops"
+	// dropped on the dashboard, "kk" typed into the composer). Bracketed
+	// paste stays whole — it is text for whatever input has focus, not keys.
+	if msg.Type == tea.KeyRunes && len(msg.Runes) > 1 && !msg.Paste {
+		return m.replayKeyBurst(msg)
+	}
 	if msg.String() == "ctrl+x" && len(m.notices) > 0 {
 		m.dismissNotice()
 		return m, nil
@@ -38,6 +48,28 @@ func (m hubModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.updateSpawnKey(msg)
 	}
 	return m.updateDashboardKey(msg)
+}
+
+// replayKeyBurst delivers a coalesced multi-rune KeyMsg as the individual
+// keystrokes the sender typed, threading the model through each one and
+// batching whatever commands they emit.
+func (m hubModel) replayKeyBurst(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+	model := tea.Model(m)
+	for _, r := range msg.Runes {
+		next, ok := model.(hubModel)
+		if !ok {
+			// A handler handed back a foreign model; stop replaying rather
+			// than guess at its key semantics.
+			break
+		}
+		var cmd tea.Cmd
+		model, cmd = next.updateKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}, Alt: msg.Alt})
+		if cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	return model, tea.Batch(cmds...)
 }
 
 func (m hubModel) updateDashboardKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/cmd/serf-tui/hub_keys.go
+++ b/cmd/serf-tui/hub_keys.go
@@ -108,10 +108,15 @@ func (m hubModel) updateDashboardKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// reader lags, and bubbletea reports every rune of one read as one
 	// KeyMsg. Replay such a batch one rune at a time or the switch below sees
 	// one unmatchable "/ops" instead of the keys the sender typed and drops
-	// it silently (kata fazd). Only here: everywhere a text surface has
-	// focus — the composer, the palette and dashboard filters, the panels —
-	// a batch IS the typed text and must stay whole (a split "/interrupt"
-	// in the composer would open the palette instead).
+	// it silently (kata fazd). Only here: where a text surface has focus —
+	// the composer, the palette and dashboard filters, the panels — a batch
+	// is the typed text and must stay whole (a split "/interrupt" in the
+	// composer would open the palette instead). Browse/transcript view is
+	// neither: a command mode whose coalesced runes still fall through to
+	// the composer as text, so the same word means different things at
+	// different delivery timings. That ambiguity is unresolved by design
+	// record (kata 7hh0); TestHubModelBrowseKeepsComposerVisibleAndTyping
+	// pins the coalesced behavior until it is decided.
 	if msg.Type == tea.KeyRunes && len(msg.Runes) > 1 && !msg.Paste {
 		return m.replayKeyBurst(msg)
 	}

--- a/cmd/serf-tui/hub_keys_batch_test.go
+++ b/cmd/serf-tui/hub_keys_batch_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// A pty delivers rapid keystrokes as one read burst under CPU contention
+// (tmux coalesces separate send-keys writes when the pane's reader lags; a
+// human typing fast does the same), and bubbletea reports every printable
+// rune of one read as a single KeyMsg. Key dispatch must apply those runes
+// individually — switching on msg.String() alone silently drops "/ops" on
+// the dashboard and types "kk" into the composer instead of moving the
+// transcript selection (kata fazd: two CI failures with exactly those
+// panes).
+
+func TestBatchedRunesApplyIndividuallyOnDashboard(t *testing.T) {
+	m := newHubModel(nil, "")
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/ops")})
+	got := updated.(hubModel)
+	if got.commandPalette == nil {
+		t.Fatalf("batched '/ops' must open the command palette and filter it; nothing happened")
+	}
+	if view := got.commandPalette.ViewWithMaxHeight(40); !strings.Contains(view, "ops") {
+		t.Fatalf("batched '/ops' opened the palette but did not filter it to 'ops':\n%s", view)
+	}
+}
+
+func TestBatchedPasteStaysOneMessage(t *testing.T) {
+	m := newHubModel(nil, "")
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/ops"), Paste: true})
+	got := updated.(hubModel)
+	if got.commandPalette != nil {
+		t.Fatalf("a bracketed paste of '/ops' is text, not keystrokes; it must not open the palette")
+	}
+}

--- a/cmd/serf-tui/hub_keys_batch_test.go
+++ b/cmd/serf-tui/hub_keys_batch_test.go
@@ -28,6 +28,18 @@ func TestBatchedRunesApplyIndividuallyOnDashboard(t *testing.T) {
 	}
 }
 
+func TestBatchedSlashCommandStaysComposerText(t *testing.T) {
+	m := newSessionHubModel(nil)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/interrupt")})
+	got := updated.(hubModel)
+	if got.commandPalette != nil {
+		t.Fatalf("a coalesced '/interrupt' typed at the composer must stay composer text; it opened the palette")
+	}
+	if got.session.input.Value() != "/interrupt" {
+		t.Fatalf("composer should hold the typed command, got %q", got.session.input.Value())
+	}
+}
+
 func TestBatchedPasteStaysOneMessage(t *testing.T) {
 	m := newHubModel(nil, "")
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/ops"), Paste: true})

--- a/cmd/serf-tui/hub_keys_batch_test.go
+++ b/cmd/serf-tui/hub_keys_batch_test.go
@@ -48,3 +48,24 @@ func TestBatchedPasteStaysOneMessage(t *testing.T) {
 		t.Fatalf("a bracketed paste of '/ops' is text, not keystrokes; it must not open the palette")
 	}
 }
+
+// bubbletea hands hub_keys.go a KeyMsg whose Runes are already decoded code
+// points (key.go's detectOneMsg runs utf8.DecodeRune per byte before ever
+// building the batch), so a multi-byte rune can never straddle a replay
+// boundary the way it could if replayKeyBurst iterated raw bytes instead of
+// msg.Runes. This pins that guarantee end to end: two multi-byte runes
+// (☕ U+2615, 3 bytes; ✈ U+2708, 3 bytes) replayed one at a time into the
+// command palette filter must come out byte-for-byte identical to typing
+// them as a single rune, not mangled or interleaved with the ASCII around
+// them.
+func TestBatchedRunesWithMultibyteRunesPreserveEncoding(t *testing.T) {
+	m := newHubModel(nil, "")
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/☕✈ops")})
+	got := updated.(hubModel)
+	if got.commandPalette == nil {
+		t.Fatalf("batched '/☕✈ops' must open the command palette; nothing happened")
+	}
+	if filter := got.commandPalette.ViewWithMaxHeight(40); !strings.Contains(filter, "Filter: ☕✈ops") {
+		t.Fatalf("batched multi-byte burst corrupted the filter text:\n%s", filter)
+	}
+}

--- a/cmd/serf-tui/tmux_e2e_test.go
+++ b/cmd/serf-tui/tmux_e2e_test.go
@@ -154,6 +154,31 @@ func TestTUITmuxE2E_DashboardProjectAndSpawn(t *testing.T) {
 	app.WaitForExit()
 }
 
+// A pty delivers rapid keystrokes as one read burst under CPU contention:
+// tmux coalesces separate send-keys writes when the pane's reader lags, and
+// bubbletea reports every printable rune of one read as a single KeyMsg.
+// That is how a loaded CI runner turned SendKeys("/")+TypeText("ops") into
+// one batched message the dashboard dropped on the floor, and k/k/f into
+// "kk" typed at the composer (kata fazd). One literal send-keys call IS that
+// burst, deterministically — no load required — so this pins that a
+// coalesced "/ops" behaves exactly like "/", "o", "p", "s" typed one at a
+// time.
+func TestTUITmuxE2E_BurstTypedKeysApplyIndividually(t *testing.T) {
+	t.Parallel()
+	requireTmux(t)
+	bin := buildTUIBinary(t)
+	hub := newTUIE2EHub(t)
+	defer hub.Close()
+	app := startTUITmux(t, bin, hub)
+	defer app.Close()
+
+	app.WaitForWithout([]string{"ended maintenance"}, "SERF LIVE", "live task", "ops task")
+	app.TypeText("/ops")
+	app.WaitForWithout([]string{"live task"}, "Command palette", "Filter: ops", "ops task")
+	app.SendKeys("Escape")
+	app.WaitFor("SERF LIVE", "live task", "ops task")
+}
+
 func TestTUITmuxE2E_AppShellPreservesLayoutAcrossWidths(t *testing.T) {
 	t.Parallel()
 	requireTmux(t)

--- a/cmd/serf-tui/tmux_e2e_test.go
+++ b/cmd/serf-tui/tmux_e2e_test.go
@@ -570,8 +570,16 @@ func TestTUITmuxE2E_FailedForkPreservesDraft(t *testing.T) {
 
 	app.SendKeys("Escape")
 	app.WaitFor("esc/i/q: compose", "f: fork selected user message")
+	// Await each selection render before the next press, the way
+	// TestTUITmuxE2E_BrowseAndFork does: consecutive printable command keys
+	// sent back-to-back can coalesce into one pty read on a loaded machine
+	// and arrive as a single batched KeyMsg, which browse mode reads as
+	// composer text rather than three commands (kata fazd — this test's CI
+	// failure pane had "kk" sitting in the composer).
 	app.SendKeys("k")
+	app.WaitFor("▶ ▍ ✓ exec")
 	app.SendKeys("k")
+	app.WaitFor("▶ ┃  > initial question")
 	app.SendKeys("f")
 	app.WaitFor("Fork draft from transcript position 1", "> initial question")
 	app.TypeText(" with edit")

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -563,6 +563,20 @@ usually wins this race on a healthy machine, which is consistent with the
 above rather than a counter-example to it. Treat the mechanism as
 evidence-backed, not directly observed.
 
+The pty lies in the other direction too. **An e2e test must await a render
+between consecutive printable command-mode key presses**: tmux coalesces
+back-to-back `send-keys` writes into one pty read when the pane's reader
+lags, bubbletea reports every printable rune of one read as a single
+KeyMsg, and a command mode that matches on `msg.String()` reads "kkf" as
+one unmatchable message instead of three keys (kata fazd — reproducible on
+an idle machine with one `send-keys -l` write). The dashboard replays such
+bursts rune by rune (`replayKeyBurst` in `cmd/serf-tui/hub_keys.go`), but
+browse mode's batch-as-text behavior is pinned pending a design decision
+(kata 7hh0), so its command sequences must never coalesce in the first
+place: see `TestTUITmuxE2E_FailedForkPreservesDraft`, which awaits the
+selection render after each `k`. Arrow and control keys are escape
+sequences and immune; only printable runes batch.
+
 ## A Test That Never Runs
 
 A test that does not execute is worse than a missing test: it reports the


### PR DESCRIPTION
## Root cause (diverges from the kata's filed theory)

Kata fazd filed both TestTUITmuxE2E CI failures as keystrokes lost between tmux send-keys and the bubbletea input loop, and prescribed a harness input-readiness probe. The input path never lost a byte. What actually happens:

1. Under CPU contention, tmux coalesces rapid `send-keys` writes into **one pty read burst** (a fast human typist does the same).
2. bubbletea 1.3.10 reports every printable rune of one read as **a single KeyMsg** (`key.go`: "we report the bunch of them as a single KeyRunes").
3. serf-tui's dispatch switches on `msg.String()` for single keys, so a batched message matches nothing: the dashboard **silently dropped** `"/ops"` (attempt 2's pristine pane, no palette, no trace), and browse mode fell through to the composer, which is why attempt 1's postmortem pane shows a stray `kk` sitting in the prompt with select-mode still active and `f` alone producing "Select a user message to fork."

Proof, deterministic, zero load: one `send-keys -l '/ops'` write against the real TUI + fake hub reproduces attempt 2's exact failure, and a temporary model-side keylog showed exactly one message arriving: `/ops`. The startup readiness probe (0c259b847) is untouched but cannot prevent this — attempt 1's loss struck a dozen successful keystrokes into the test, and even the probe's own retried `r` presses can coalesce.

## The fix

- **`updateDashboardKey` replays a non-paste multi-rune KeyMsg one rune at a time** (`replayKeyBurst`), threading the model through each so a `/`-opened palette receives the rest of the burst as its filter. Scoped to the dashboard's command branch only: everywhere a text surface has focus (composer, palette/dashboard filters, panels, compose-from-browse) a batch IS the typed text and stays whole — the first, global cut of this fix was rejected by the existing suite (a batched "draft" in browse fired the `f` fork binding mid-word; a coalesced `/interrupt` at the composer opened the palette).
- **Browse-mode command sequences must not coalesce in the first place**, since batch-as-text is that mode's pinned contract: `FailedForkPreservesDraft` now awaits each selection render between `k` presses, the pattern `BrowseAndFork` already used.
- Bracketed paste is exempt everywhere (pinned).

## Tests

- `TestBatchedRunesApplyIndividuallyOnDashboard` — batched `/ops` opens the palette filtered to "ops" (RED first: "nothing happened").
- `TestBatchedSlashCommandStaysComposerText` — coalesced `/interrupt` at the composer stays composer text (pins the scoping).
- `TestBatchedPasteStaysOneMessage` — paste exemption.
- `TestTUITmuxE2E_BurstTypedKeysApplyIndividually` — one literal send-keys write of `/ops` through the full tmux path (RED first with the CI failure's exact timeout message).

## Evidence

- 30× full TestTUITmuxE2E family soak: exit 0, zero failures.
- Full non-tmux `cmd/serf-tui` suite green with `-race`; golangci-lint 0 issues.
- `make merge-approval-gate` in a clean /tmp worktree: exit 0, home canary 32 before/after. One first-run red judged by isolated re-run per the flakes policy: `TestMakeWebCommandsContainNodeProcessState` — its fixture's fake-npm recorder tears multi-KB concurrent appends to a shared log under parallel load (the "not observed" strings are present but torn mid-line); 3×/3 green isolated, unrelated to this diff (worth its own kata).
- Also observed pre-existing and unrelated: `TestTUITmuxE2E_CtrlCRequiresDoublePressFromSession` load flake (the 1s double-press debounce window its own helper documents); 20/20 green isolated. Control chars are not runes and cannot batch.

Kata: fazd.

https://claude.ai/code/session_01D5AsxUYaemKcf1aMj7YpkX

## Behavior change worth naming: non-bracketed paste

On a terminal **without** bracketed paste, pasting onto the dashboard now executes each pasted character as a command, where pre-fix the coalesced chunk was silently dropped. This matches what every terminal app does with unbracketed paste (it is indistinguishable from fast typing by design), and bubbletea enables bracketed paste by default, so any modern terminal marks real pastes and keeps them whole (pinned by `TestBatchedPasteStaysOneMessage`). Named here so nobody rediscovers it as a surprise.

## Follow-up filed

- **kata 7hh0** — browse mode's rune ambiguity is a design decision, not an implementation detail: sequential "draft" fires the `f` fork-binding mid-word while a coalesced "draft" lands as composer text, and `TestHubModelBrowseKeepsComposerVisibleAndTyping` pins that accident of delivery pending Jesse's call. Flagged by this PR's adversarial review.
