### PR TITLE
fix(appserver): size the outbound buffer for a real burst; log evictions

### DIFF
--- a/cmd/serf-hub/app_rpc.go
+++ b/cmd/serf-hub/app_rpc.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -126,6 +127,9 @@ func newHubAppServer(cfg hubcore.WebConfig, sources *appsource.Registry) *appser
 		ServerName: "serf-hub",
 		Version:    Version,
 		SourceID:   "local",
+		Logf: func(format string, args ...any) {
+			fmt.Fprintf(os.Stderr, "[hub] "+format+"\n", args...)
+		},
 		Features: appwire.FeatureSet{
 			ThreadList:        true,
 			ThreadTurnsList:   true,

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -18,6 +18,10 @@ type ServerConfig struct {
 	// AdapterNativeInitialize keeps the shared JSON-RPC server usable in tests
 	// for adapters whose upstream protocol owns a different initialize shape.
 	AdapterNativeInitialize bool
+	// Logf reports server-initiated events a peer cannot see from its side of
+	// the socket — today, slow-consumer evictions, which close with a NORMAL
+	// status. Nil means silent.
+	Logf func(format string, args ...any)
 }
 
 type Server struct {
@@ -65,12 +69,36 @@ func (s *Server) CommitProjection(commit func() []SequencedNotification) {
 	disconnected := s.deliverNotifications(deliveries)
 	s.deliveryMu.Unlock()
 	for _, conn := range disconnected {
-		s.unregisterConnection(conn)
+		s.evictSlowConsumer(conn, "a projection commit")
 	}
 }
 
 func (s *Server) NewConnection(id string) *Connection {
-	return &Connection{id: id, server: s, send: make(chan appwire.Message, 32)}
+	// The outbound buffer is the hub-side half of the contract
+	// appwire.NotificationBufferCap documents for the client: it must hold any
+	// single legitimate burst even while the send loop waits for a scheduling
+	// slice, because a full buffer is answered with eviction. The two sides
+	// share one constant so neither peer can quietly become the smaller pipe
+	// (at 32 this side evicted live clients whose send loop napped through a
+	// turn-boundary burst on a loaded machine).
+	return &Connection{id: id, server: s, send: make(chan appwire.Message, appwire.NotificationBufferCap)}
+}
+
+func (s *Server) logf(format string, args ...any) {
+	if s.cfg.Logf != nil {
+		s.cfg.Logf(format, args...)
+	}
+}
+
+// evictSlowConsumer unregisters a connection whose outbound buffer is full.
+// The buffer holds appwire.NotificationBufferCap frames — any legitimate
+// burst fits — so a full one means the peer stopped draining, not that its
+// send loop lost a scheduling slice. Say so out loud: the socket closes with
+// a NORMAL status, so this line is the only artifact that tells an eviction
+// apart from the client hanging up.
+func (s *Server) evictSlowConsumer(conn *Connection, during string) {
+	s.logf("appserver: evicting connection %s during %s: outbound buffer full (%d frames), the consumer stopped draining", conn.id, during, cap(conn.send))
+	s.unregisterConnection(conn)
 }
 
 func (s *Server) registerConnection(conn *Connection) {
@@ -129,7 +157,7 @@ func (s *Server) Broadcast(threadID, method string, params any) {
 	disconnected := s.deliverNotifications(deliveries)
 	s.deliveryMu.Unlock()
 	for _, conn := range disconnected {
-		s.unregisterConnection(conn)
+		s.evictSlowConsumer(conn, "a sequenced broadcast")
 	}
 }
 
@@ -188,7 +216,7 @@ func (s *Server) BroadcastAll(method string, params any) {
 	s.mu.RUnlock()
 	for _, conn := range conns {
 		if !conn.enqueue(msg) {
-			s.unregisterConnection(conn)
+			s.evictSlowConsumer(conn, "a hub-wide broadcast")
 		}
 	}
 }
@@ -682,7 +710,7 @@ func (s *Server) releaseHydration(conn *Connection, threadID string, generation 
 	}
 	s.deliveryMu.Unlock()
 	if disconnected {
-		s.unregisterConnection(conn)
+		s.evictSlowConsumer(conn, "a hydration release replay")
 	}
 }
 

--- a/internal/appserver/server_test.go
+++ b/internal/appserver/server_test.go
@@ -1545,7 +1545,7 @@ func TestBurstWithinClientBufferBoundDoesNotEvict(t *testing.T) {
 
 	// The send loop never runs in this test: every frame stays queued, which
 	// is exactly a consumer waiting for a scheduling slice.
-	for i := 0; i < appwire.NotificationBufferCap; i++ {
+	for range appwire.NotificationBufferCap {
 		server.Broadcast("thread", "burst", nil)
 	}
 
@@ -1564,5 +1564,44 @@ func TestBurstWithinClientBufferBoundDoesNotEvict(t *testing.T) {
 	server.mu.RUnlock()
 	if !evicted {
 		t.Fatal("a consumer a full buffer past the bound was not evicted; the slow-consumer policy is gone, not retuned")
+	}
+}
+
+// TestSlowConsumerEvictionIsReported: eviction closes the socket with a
+// NORMAL close status, so a log line is the only artifact that distinguishes
+// "the hub evicted a slow consumer" from "the client hung up". The live flake
+// this package's burst test pins burned a day of CI reruns precisely because
+// this line did not exist.
+func TestSlowConsumerEvictionIsReported(t *testing.T) {
+	var logMu sync.Mutex
+	var logged []string
+	server := NewServer(ServerConfig{
+		ServerName: "serf-hub", Version: "test", SourceID: "local",
+		Logf: func(format string, args ...any) {
+			logMu.Lock()
+			logged = append(logged, fmt.Sprintf(format, args...))
+			logMu.Unlock()
+		},
+	})
+	conn := server.NewConnection("stuck")
+	server.registerConnection(conn)
+	conn.Subscribe("thread")
+	for i := 0; i < cap(conn.send); i++ {
+		conn.enqueue(appwire.Message{})
+	}
+
+	server.Broadcast("thread", "one-past-full", nil)
+
+	server.mu.RLock()
+	evicted := server.conns[conn.id] == nil
+	server.mu.RUnlock()
+	if !evicted {
+		t.Fatal("a consumer with a full outbound buffer was not evicted")
+	}
+	logMu.Lock()
+	defer logMu.Unlock()
+	joined := strings.Join(logged, "\n")
+	if !strings.Contains(joined, "stuck") || !strings.Contains(joined, "evict") {
+		t.Fatalf("the eviction left no log line naming the connection; logged:\n%s", joined)
 	}
 }

--- a/internal/appserver/server_test.go
+++ b/internal/appserver/server_test.go
@@ -1523,3 +1523,46 @@ func TestContextSubscriptionRegistrationSerializesWithConnectionTeardown(t *test
 		})
 	}
 }
+
+// TestBurstWithinClientBufferBoundDoesNotEvict pins the hub-side half of the
+// contract appwire.NotificationBufferCap documents for the client side: the
+// outbound buffer "must hold any single legitimate burst even while the
+// consumer waits for a scheduling slice". A connection is evicted for having
+// STOPPED draining, never for its send loop losing one scheduling slice while
+// a burst lands.
+//
+// Found live, not hypothesized: on a loaded CI runner the turn-boundary
+// notification burst outran the send-loop goroutine of
+// TestE2E_ControlInvariantDuringPreTurnWorkAtATurnBoundary's client, the hub
+// evicted it mid-test with a NORMAL close status and no log line, and the
+// test's Stop then failed with "use of closed network connection" — twice in
+// one day, on diffs that touched neither the hub nor the test.
+func TestBurstWithinClientBufferBoundDoesNotEvict(t *testing.T) {
+	server := NewServer(ServerConfig{ServerName: "serf-hub", Version: "test", SourceID: "local"})
+	conn := server.NewConnection("napping")
+	server.registerConnection(conn)
+	conn.Subscribe("thread")
+
+	// The send loop never runs in this test: every frame stays queued, which
+	// is exactly a consumer waiting for a scheduling slice.
+	for i := 0; i < appwire.NotificationBufferCap; i++ {
+		server.Broadcast("thread", "burst", nil)
+	}
+
+	server.mu.RLock()
+	still := server.conns[conn.id] == conn
+	server.mu.RUnlock()
+	if !still {
+		t.Fatalf("a burst of %d sequenced notifications evicted a consumer that had not stopped draining, only napped", appwire.NotificationBufferCap)
+	}
+
+	// The policy itself must survive: one frame past the bound is a consumer
+	// that stopped draining, and eviction is the correct answer.
+	server.Broadcast("thread", "one-past-the-bound", nil)
+	server.mu.RLock()
+	evicted := server.conns[conn.id] == nil
+	server.mu.RUnlock()
+	if !evicted {
+		t.Fatal("a consumer a full buffer past the bound was not evicted; the slow-consumer policy is gone, not retuned")
+	}
+}


### PR DESCRIPTION
Root-cause fix for the `TestE2E_ControlInvariantDuringPreTurnWorkAtATurnBoundary` CI flake (two sightings 2026-08-18, runs 32155439056 and 32158125306, both on diffs that touch neither the hub nor the test).

## Root cause — proven at the unit level, red-first

The hub's per-connection outbound buffer held **32 frames** while the client side of the same protocol documents **4096** (`appwire.NotificationBufferCap`) as what "must hold any single legitimate burst even while the consumer waits for a scheduling slice". A full buffer is answered with **eviction** — performed silently, with a NORMAL close status and no log line, so from the client (and the CI log) it is indistinguishable from the hub hanging up.

The amplifier that makes 32 reachable: every `thread/read` against a relay-session source runs a capture→release cycle, and `releaseHydration` replays the frames buffered during the capture into that channel in a tight loop under `deliveryMu`. The boundary test's sampler issues such reads continuously, precisely while the turn-boundary notification flurry lands and two concurrent pollers' responses share the same 32 slots. One scheduling nap of the send-loop goroutine → evicted; the test's next write (the Stop) fails with exactly the CI signature: `failed to write msg: use of closed network connection`. The same race is reachable in production by any hydration replay — a codex resume is ~160 frames against those 32 slots.

Ruled out along the way: client-side keepalive (15s interval vs a 0.92s failure), the client's own overflow teardown (4096 undrained vs tens of frames), and `request()` reply plumbing (buffered channels, removePending on every exit).

## The fix

- `Connection.send` is now sized by `appwire.NotificationBufferCap` — both peers share the one constant, so neither can quietly become the smaller pipe. The eviction **policy survives** at the honest threshold: a consumer a full 4096-frame buffer behind has stopped draining.
- Evictions are now loud: `ServerConfig.Logf` (wired to the hub's `[hub]` stderr) reports the connection id, the phase (projection commit / sequenced broadcast / hub-wide broadcast / hydration release replay), and the buffer size. The socket still closes with a NORMAL status, so this line is the only artifact that tells an eviction apart from the client hanging up — its absence is what made this flake cost a day of CI reruns.

## Evidence

- **Red-first**: `TestBurstWithinClientBufferBoundDoesNotEvict` watched failing on the old code — evicted at frame 33 of a 4096 burst ("a consumer that had not stopped draining, only napped"). Same test pins the retained policy: one frame past the bound still evicts. `TestSlowConsumerEvictionIsReported` red (compile: seam missing) → green.
- **Honest disclosure**: the e2e manifestation did **not** reproduce locally on Darwin — 10 runs under full-core load plus 15 with `GOMAXPROCS=1` propagated into the hub process, all green. macOS never napped the send loop long enough; the loaded Linux CI runner did, twice in one day. The linkage rests on the mechanism proof plus the exact match of the failure signature (silent NORMAL-close eviction → `net.ErrClosed` on the next write, no hub log line).
- **Post-fix soak**: the boundary e2e 30/30 green under full-core contention.
- `internal/appserver` green under `-race`; full `cmd/serf-hub` package green; `golangci-lint` 0 issues; `make merge-approval-gate` exit 0 in a clean worktree, home canary 32 before and after.

https://claude.ai/code/session_01D5AsxUYaemKcf1aMj7YpkX