### PR TITLE
fix(agent): close the drain's attention/finalizing straddle race

### DIFF
--- a/agent/session_jobtree_drain.go
+++ b/agent/session_jobtree_drain.go
@@ -126,11 +126,24 @@ func (jm *jobManager) hasRunningDrainJob() bool {
 
 // treeHasOutstandingWork reports whether this session or any live descendant in
 // its managed-job subtree still owes drain work: an outstanding managed job, a
-// pending job notification, a pending caller-targeted watch send, an in-flight
-// stable delegate run, or an in-flight drive turn. Close() cancels the whole
-// subtree, so the one-shot drain must settle all of it — a root whose direct
-// managed job finished after spawning its own fire-and-return managed job or
-// stable delegate is not quiescent until that descendant's work drains too.
+// pending job notification, a pending caller-targeted watch send, a pending
+// delegate delivery, an in-flight stable delegate run, or an in-flight drive
+// turn. Close() cancels the whole subtree, so the one-shot drain must settle
+// all of it — a root whose direct managed job finished after spawning its own
+// fire-and-return managed job or stable delegate is not quiescent until that
+// descendant's work drains too.
+//
+// hasPendingDelegateDeliveries matters here for a straddle PRI-2441's own fix
+// does not cover: acceptDelegateDeliveryPlan defers a delivery into that queue
+// (instead of delivering it inline) whenever the receiving session is
+// SessionProcessing at that instant — e.g. a second, unrelated delegate's
+// completion targeting this session while the drain's own notification turn is
+// already running one delivery. The defer calls notify() exactly once; nothing
+// else about the session's state changes. Without this check, that one wake can
+// be consumed by a later pass with the delivery still sitting unflushed, and
+// the drain declares quiescence with a real completion undelivered. kickDriveTree
+// (below) is what actually resolves a pending delivery once this check keeps the
+// drain from quiescing prematurely — the two halves both matter, see kickDriveTreeWith.
 //
 // A store read error is propagated (not folded into quiescence): the drain must
 // neither Close() on an unreadable store nor spin on it forever, so the loop
@@ -146,6 +159,9 @@ func (s *Session) treeHasOutstandingWork() (bool, error) {
 		}
 	}
 	if s.peekNotifications() > 0 {
+		return true, nil
+	}
+	if s.hasPendingDelegateDeliveries() {
 		return true, nil
 	}
 	if s.hasPendingRootDelegateAttention() {
@@ -192,7 +208,7 @@ func (s *Session) treeHasOutstandingWork() (bool, error) {
 // stall watchdog is allowed to give up, and it is deliberately narrow so it can
 // never cut legitimate work.
 //
-// The five live/deliverable components — any of them anywhere in the subtree
+// The six live/deliverable components — any of them anywhere in the subtree
 // means NOT stalled — are:
 //   - a managed job still in some jm.running (hasRunningDrainJob): live work such
 //     as a long build produces no drain progress for minutes yet is not wedged;
@@ -200,7 +216,9 @@ func (s *Session) treeHasOutstandingWork() (bool, error) {
 //     delegate JobRecord after the stable-resource cutover;
 //   - a driving child (sub.driving): a drive turn is in flight;
 //   - a pending caller-targeted watch send (hasPendingWatchSends): deliverable;
-//   - a queued notification at any level (peekNotifications > 0): deliverable now.
+//   - a queued notification at any level (peekNotifications > 0): deliverable now;
+//   - a pending delegate delivery (hasPendingDelegateDeliveries): deliverable —
+//     kickDriveTree flushes it every pass, so it never sits long enough to wedge.
 //
 // When outstanding is true but none of those exist, the outstanding work is
 // composed entirely of terminal-but-undelivered notifications that the
@@ -233,6 +251,9 @@ func (s *Session) subtreeHasLiveComponent() (bool, error) {
 		}
 	}
 	if s.peekNotifications() > 0 {
+		return true, nil
+	}
+	if s.hasPendingDelegateDeliveries() {
 		return true, nil
 	}
 	if s.hasPendingRootDelegateAttention() {
@@ -512,14 +533,29 @@ func waitDrainWake(ctx context.Context, wake <-chan struct{}, recheck <-chan tim
 	}
 }
 
-// kickDriveTree delivers pending watch sends and kicks drive-down at every level
-// of the live managed-job subtree, skipping stop-gated children (which are never
-// driven). drainPendingWatchSends already drives THIS session's direct children
-// (its trailing driveChildrenWithUndeliveredAttention pass), and recursing into
+// kickDriveTree delivers pending watch sends, flushes pending delegate
+// deliveries, and kicks drive-down at every level of the live managed-job
+// subtree, skipping stop-gated children (which are never driven).
+// drainPendingWatchSends already drives THIS session's direct children (its
+// trailing driveChildrenWithUndeliveredAttention pass), and recursing into
 // each child repeats that at every level — so outstanding work isolated in a
 // grandchild subtree makes progress even when the intervening session's own rail
 // carries no immediate signal. All the underlying operations are idempotent and
 // self-terminating, so repeated kicks are safe.
+//
+// Flushing delegate deliveries here matters specifically for the drain: a
+// delivery deferred by acceptDelegateDeliveryPlan (because the receiving
+// session was SessionProcessing at that instant) sits in pendingDelegateDeliveries
+// until something calls flushPendingDelegateDeliveries, and outside a live turn
+// nothing else will — the drain loop's own notification turns only run when
+// treeHasOutstandingWork already sees something to report, which a merely
+// PENDING delivery does not become until it is flushed. Without this call the
+// wake treeHasOutstandingWork now waits on (see its doc) would never resolve:
+// the drain would sit correctly refusing to quiesce, but nothing would ever
+// convert the pending delivery into the notification/attention state that lets
+// it quiesce for real. Calling it here, every pass, before the outstanding
+// check, closes that gap the same way rematerializeDurablePendings closes the
+// durable/in-memory job-notification gap just below.
 func (s *Session) kickDriveTree(ctx context.Context) error {
 	return s.kickDriveTreeWith(ctx, func(sess *Session, ctx context.Context) error {
 		return sess.drainPendingWatchSends(ctx)
@@ -528,6 +564,9 @@ func (s *Session) kickDriveTree(ctx context.Context) error {
 
 func (s *Session) kickDriveTreeWith(ctx context.Context, drain func(*Session, context.Context) error) error {
 	s.drivePendingStableDelegateAttention()
+	if err := s.flushPendingDelegateDeliveries(); err != nil {
+		return err
+	}
 	if err := s.rematerializeDurablePendings(); err != nil {
 		return err
 	}

--- a/agent/session_jobtree_drain.go
+++ b/agent/session_jobtree_drain.go
@@ -556,6 +556,20 @@ func waitDrainWake(ctx context.Context, wake <-chan struct{}, recheck <-chan tim
 // it quiesce for real. Calling it here, every pass, before the outstanding
 // check, closes that gap the same way rematerializeDurablePendings closes the
 // durable/in-memory job-notification gap just below.
+//
+// flushPendingDelegateDeliveries carries no s.state check of its own — its four
+// other call sites are all safe only because each runs ON the owning session's
+// own turn goroutine. This recursion instead calls it from the ANCESTOR's drain
+// goroutine, so a child that is actively running/driving/finalizing must be
+// skipped (see the busy check in the loop below), matching the gate
+// driveSubagentNotificationTurn already applies before touching a child's own
+// turn machinery: flushing into a busy child's history at a point its own round
+// loop did not choose can splice a delivery between an in-flight tool call and
+// its result. Only the flush is skipped, not the rest of the kick (watch-send
+// delivery and recursion into grandchildren still run) — the child's own
+// pending count still holds the ancestor's drain open via treeHasOutstandingWork
+// (which reads it recursively too), and the child's own turn flushes it at its
+// next natural boundary once it stops being busy.
 func (s *Session) kickDriveTree(ctx context.Context) error {
 	return s.kickDriveTreeWith(ctx, func(sess *Session, ctx context.Context) error {
 		return sess.drainPendingWatchSends(ctx)
@@ -563,9 +577,21 @@ func (s *Session) kickDriveTree(ctx context.Context) error {
 }
 
 func (s *Session) kickDriveTreeWith(ctx context.Context, drain func(*Session, context.Context) error) error {
+	return s.kickDriveTreeWithFlush(ctx, drain, true)
+}
+
+// kickDriveTreeWithFlush is kickDriveTreeWith's recursive body. flushDeliveries
+// gates only this session's own flushPendingDelegateDeliveries call — see
+// kickDriveTree's doc for why a busy child must not have it called on its
+// behalf from the ancestor's goroutine. The root/direct caller always passes
+// true: DrainJobTree only ever starts once the caller's own turn has already
+// ended (PRI-2441's premise), so the top-level session is never mid-turn here.
+func (s *Session) kickDriveTreeWithFlush(ctx context.Context, drain func(*Session, context.Context) error, flushDeliveries bool) error {
 	s.drivePendingStableDelegateAttention()
-	if err := s.flushPendingDelegateDeliveries(); err != nil {
-		return err
+	if flushDeliveries {
+		if err := s.flushPendingDelegateDeliveries(); err != nil {
+			return err
+		}
 	}
 	if err := s.rematerializeDurablePendings(); err != nil {
 		return err
@@ -574,11 +600,14 @@ func (s *Session) kickDriveTreeWith(ctx context.Context, drain func(*Session, co
 		return err
 	}
 	for _, sub := range s.liveDirectSubagents() {
+		sub.mu.Lock()
+		childBusy := sub.running || sub.driving || sub.finalizing
 		child := sub.sess
+		sub.mu.Unlock()
 		if child == nil || s.childStopGated(child.id) || s.childFatalRunGated(child.id) {
 			continue
 		}
-		if err := child.kickDriveTreeWith(ctx, drain); err != nil {
+		if err := child.kickDriveTreeWithFlush(ctx, drain, !childBusy); err != nil {
 			return err
 		}
 	}

--- a/agent/session_jobtree_drain.go
+++ b/agent/session_jobtree_drain.go
@@ -327,6 +327,22 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 	lastResult := ""
 	var stallStart time.Time
 	for {
+		// Take this pass's wake edge before it reads any state. treeHasOutstandingWork
+		// consults eight independent signals in sequence, so it is not a snapshot, and
+		// a completion that hands work UP the tree moves two of them in turn:
+		// deliverDelegatePacket arms the coordinator's root attention and only THEN
+		// does runSubagent clear the delegating subagent's finalizing flag. The pass
+		// reads the attention early and the flag late, so a pass that straddles the
+		// hand-off sees both false though at no instant were they both false — and
+		// returns "" while an armed delegate notification waits, leaving Close() to
+		// SIGKILL it (the PRI-2441 B1 flake).
+		//
+		// Every producer of drain-relevant work raises this wake, so it is the one
+		// signal that survives the straddle. Consuming the edge here and re-checking
+		// it below turns "I looked and saw nothing" into "I looked and saw nothing,
+		// and nothing moved while I looked" — the only claim that justifies letting
+		// Close() cancel the subtree.
+		takeDrainWake(wake)
 		// Deliver pending watch sends and kick drive-down at EVERY level of the
 		// subtree, not just direct children: outstanding work isolated in a
 		// grandchild (e.g. a restored or lost-wake watch send whose signal never
@@ -361,7 +377,15 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 			return lastResult, err
 		}
 		if !outstanding {
-			// Nothing pending and nothing outstanding anywhere in the subtree.
+			// Nothing pending and nothing outstanding anywhere in the subtree — but the
+			// scan above is not a snapshot. A wake raised since this pass took its edge
+			// means the tree moved while the scan ran, so re-run the pass instead of
+			// trusting a verdict assembled across the change. This terminates: a wake
+			// is only raised by a real state change, and a quiescent subtree raises
+			// none, so the confirming pass finds the edge clear and returns.
+			if takeDrainWake(wake) {
+				continue
+			}
 			return lastResult, nil
 		}
 		// Defense-in-depth stall watchdog. Outstanding work with NO live or
@@ -462,6 +486,18 @@ func newDrainWake() (chan struct{}, func()) {
 		case wake <- struct{}{}:
 		default:
 		}
+	}
+}
+
+// takeDrainWake consumes a pending wake edge without blocking and reports
+// whether one was there. The wake channel holds a single coalesced edge, so this
+// is "has anything signalled since I last asked", never a count.
+func takeDrainWake(wake <-chan struct{}) bool {
+	select {
+	case <-wake:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/agent/session_jobtree_drain_test.go
+++ b/agent/session_jobtree_drain_test.go
@@ -290,6 +290,69 @@ func TestKickDriveTreeFlushesPendingDelegateDeliveries(t *testing.T) {
 	}
 }
 
+// TestKickDriveTreeDoesNotFlushBusyChildsPendingDelegateDeliveries pins a
+// hazard in TestKickDriveTreeFlushesPendingDelegateDeliveries's own fix:
+// kickDriveTreeWith recurses into every live child (liveDirectSubagents
+// filters only on sub.closed) and, before this test, called
+// flushPendingDelegateDeliveries there unconditionally. flushPendingDelegateDeliveries
+// has no s.state check -- it was safe at its four pre-existing call sites only
+// because every one of them runs ON the owning session's own turn goroutine.
+// The drain's recursive call runs on the ANCESTOR's drain goroutine instead, so
+// flushing a child that is actively running/driving/finalizing can splice a
+// delivered notification into that child's history at a point its own round
+// loop did not choose -- e.g. between an in-flight assistant tool call and its
+// tool result, breaking message alternation. -race cannot catch this: every
+// lock is held correctly, the hazard is purely about WHEN the mutation lands,
+// not whether it races.
+//
+// driveSubagentNotificationTurn (subagents.go) already refuses to touch a
+// child where sub.running || sub.driving || sub.finalizing; this test holds
+// kickDriveTree to the same gate for the flush specifically. The child's own
+// delivery queue must still count as outstanding work (so the ancestor's drain
+// correctly keeps waiting on it) even though the ancestor must not be the one
+// to flush it — the child's own turn machinery flushes at its next natural
+// boundary instead.
+func TestKickDriveTreeDoesNotFlushBusyChildsPendingDelegateDeliveries(t *testing.T) {
+	t.Parallel()
+	root := newSession(t)
+	child := newSession(t)
+	sub := &subagent{id: child.ID(), sess: child, running: true}
+	root.subagents.mu.Lock()
+	root.subagents.subs[child.ID()] = sub
+	root.subagents.mu.Unlock()
+
+	child.delegateDeliveryMu.Lock()
+	child.pendingDelegateDeliveries = append(child.pendingDelegateDeliveries, delegateDeliveryPlan{})
+	child.delegateDeliveryMu.Unlock()
+
+	if err := root.kickDriveTree(context.Background()); err != nil {
+		t.Fatalf("kickDriveTree: %v", err)
+	}
+	if !child.hasPendingDelegateDeliveries() {
+		t.Fatal("kickDriveTree flushed a running child's pending delegate delivery; a busy child's own turn owns that mutation, not the ancestor's drain")
+	}
+
+	outstanding, err := root.treeHasOutstandingWork()
+	if err != nil {
+		t.Fatalf("treeHasOutstandingWork: %v", err)
+	}
+	if !outstanding {
+		t.Fatal("treeHasOutstandingWork = false with the running child's delegate delivery still pending; skipping the flush must not also drop it from the outstanding count")
+	}
+
+	// Once the child is no longer busy, its own turn boundary has passed and
+	// the ancestor's kick may flush it like any other idle child.
+	sub.mu.Lock()
+	sub.running = false
+	sub.mu.Unlock()
+	if err := root.kickDriveTree(context.Background()); err != nil && !errors.Is(err, errDelegateStaleLease) {
+		t.Fatalf("kickDriveTree: %v", err)
+	}
+	if child.hasPendingDelegateDeliveries() {
+		t.Fatal("kickDriveTree did not flush the child's pending delegate delivery once it stopped running")
+	}
+}
+
 // TestOutstandingDrainJobCountIncludesRunningManagedJobs verifies every owned
 // managed job keeps the drain open while it remains in the running map. Shell
 // execution mode is not part of that durable drain contract.

--- a/agent/session_jobtree_drain_test.go
+++ b/agent/session_jobtree_drain_test.go
@@ -115,6 +115,58 @@ func TestDrainJobTreeNoJobsReturnsImmediately(t *testing.T) {
 	}
 }
 
+// TestDrainJobTreeRescansWhenAWakeLandsMidPass pins the drain's quiescence
+// verdict against the completion hand-off a single pass can straddle.
+//
+// treeHasOutstandingWork reads eight independent signals in sequence, so it is
+// not a snapshot. A delegate completion hands its work UP the tree in two steps
+// — deliverDelegatePacket arms the coordinator's root attention (raising this
+// wake), then runSubagent clears the subagent's finalizing flag — while a pass
+// reads the attention EARLY and the flag LATE. A pass that straddles the two
+// steps sees both false even though at no instant were they both false, and the
+// drain then returns "" and lets Close() SIGKILL a delegate notification that
+// was already armed and waiting. That is the PRI-2441 B1 flake: a one-shot
+// `serf run` printing "waiting on delegate" instead of the coordinator's real
+// final answer.
+//
+// The wake is the one signal that survives the straddle, because every producer
+// of drain-relevant work raises it. So the pass consumes the wake edge BEFORE it
+// reads any state and re-checks it before concluding quiescence: a wake raised
+// in between means the tree moved under the scan and the verdict is stale. Here
+// the injected kick plays the concurrent completion, raising the wake mid-pass
+// while leaving every signal the pass reads false — exactly the state a
+// straddling pass observes.
+func TestDrainJobTreeRescansWhenAWakeLandsMidPass(t *testing.T) {
+	t.Parallel()
+	sess := newSession(t)
+
+	passes := 0
+	kick := func(context.Context) error {
+		passes++
+		if passes == 1 {
+			sess.notify()
+		}
+		return nil
+	}
+	process := func(context.Context, string, []ImageAttachment, EntryKind) (string, error) {
+		t.Error("drain ran a notification turn with nothing queued")
+		return "", nil
+	}
+
+	// recheck never fires: only the mid-pass wake may cause the second pass, so a
+	// lost wake cannot be masked by the periodic re-check.
+	res, err := sess.drainJobTreeWith(context.Background(), make(chan time.Time), kick, process)
+	if err != nil {
+		t.Fatalf("drainJobTreeWith: %v", err)
+	}
+	if res != "" {
+		t.Fatalf("drain result = %q, want empty (no drain turn ran)", res)
+	}
+	if passes != 2 {
+		t.Fatalf("drain passes = %d, want 2: a wake raised while a pass was deciding quiescence must invalidate that pass's verdict and force a re-scan", passes)
+	}
+}
+
 // TestOutstandingDrainJobCountIncludesRunningManagedJobs verifies every owned
 // managed job keeps the drain open while it remains in the running map. Shell
 // execution mode is not part of that durable drain contract.

--- a/agent/session_jobtree_drain_test.go
+++ b/agent/session_jobtree_drain_test.go
@@ -167,6 +167,129 @@ func TestDrainJobTreeRescansWhenAWakeLandsMidPass(t *testing.T) {
 	}
 }
 
+// TestTreeHasOutstandingWorkCountsPendingDelegateDeliveries pins a sibling gap
+// to the straddle above, through a different channel entirely:
+// pendingDelegateDeliveries.
+//
+// acceptDelegateDeliveryPlan defers a delivery into that queue instead of
+// delivering it immediately whenever the receiving session is
+// SessionProcessing at that instant -- e.g. a second, unrelated delegate's
+// completion targeting this session while the drain loop's own notification
+// turn is already running one delivery. The deferral calls notify() exactly
+// once, but treeHasOutstandingWork never reads pendingDelegateDeliveries at
+// all (unlike outstandingDrainJobCount, peekNotifications, and every attention
+// signal it does read). So once that one-shot wake is consumed, nothing about
+// this session's state says a completion is still owed, and the drain
+// concludes quiescence with a real delivery sitting undelivered -- letting
+// Close() SIGKILL it. Same PRI-2441 symptom, different signal the original fix
+// didn't touch.
+//
+// This test seeds the queue exactly the way acceptDelegateDeliveryPlan does
+// (append under delegateDeliveryMu) and asks the read function the drain loop
+// actually calls, so it is independent of how the entry got there.
+func TestTreeHasOutstandingWorkCountsPendingDelegateDeliveries(t *testing.T) {
+	t.Parallel()
+	sess := newSession(t)
+
+	sess.delegateDeliveryMu.Lock()
+	sess.pendingDelegateDeliveries = append(sess.pendingDelegateDeliveries, delegateDeliveryPlan{})
+	sess.delegateDeliveryMu.Unlock()
+
+	outstanding, err := sess.treeHasOutstandingWork()
+	if err != nil {
+		t.Fatalf("treeHasOutstandingWork: %v", err)
+	}
+	if !outstanding {
+		t.Fatal("treeHasOutstandingWork = false with a delegate delivery still pending; a deferred completion must keep the drain open")
+	}
+
+	live, err := sess.subtreeHasLiveComponent()
+	if err != nil {
+		t.Fatalf("subtreeHasLiveComponent: %v", err)
+	}
+	if !live {
+		t.Fatal("subtreeHasLiveComponent = false with a delegate delivery still pending; the stall watchdog must not treat this as a genuine wedge, since kickDriveTree flushes it every pass")
+	}
+}
+
+// TestDrainJobTreeWaitsWhilePendingDelegateDeliveryUnflushed proves the drain
+// loop itself, not just the read function, respects a pending delegate
+// delivery: with a kick that deliberately never flushes anything (isolating
+// treeHasOutstandingWork's verdict from kickDriveTree's own behavior, which
+// TestKickDriveTreeFlushesPendingDelegateDeliveries covers separately),
+// drainJobTreeWith must block rather than ever declaring quiescence, exactly
+// as TestDrainJobTreeReturnsOnContextCancel already pins for a stuck managed
+// job. recheck is left permanently unfired, so the only way this run ends is
+// wrongly quiescing (an immediate nil-error return, independent of ctx) or
+// correctly blocking in waitDrainWake until cancel() reaches it.
+func TestDrainJobTreeWaitsWhilePendingDelegateDeliveryUnflushed(t *testing.T) {
+	t.Parallel()
+	sess := newSession(t)
+
+	sess.delegateDeliveryMu.Lock()
+	sess.pendingDelegateDeliveries = append(sess.pendingDelegateDeliveries, delegateDeliveryPlan{})
+	sess.delegateDeliveryMu.Unlock()
+
+	kick := func(context.Context) error { return nil } // deliberately never flushes
+	process := func(context.Context, string, []ImageAttachment, EntryKind) (string, error) {
+		t.Error("drain ran a notification turn with nothing queued")
+		return "", nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := sess.drainJobTreeWith(ctx, make(chan time.Time), kick, process)
+		done <- err
+	}()
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("drainJobTreeWith error = %v, want context.Canceled: a pending delegate delivery must keep the drain open, not let it quiesce", err)
+		}
+	// TRIPWIRE: awaits done, drainJobTreeWith's own return signal, after
+	// cancel(); a correctly blocked drain observes ctx.Err() and returns as
+	// soon as it reaches waitDrainWake. 30s only fires on a genuine hang.
+	case <-time.After(30 * time.Second):
+		t.Fatal("drainJobTreeWith did not return after context cancellation")
+	}
+}
+
+// TestKickDriveTreeFlushesPendingDelegateDeliveries pins the other half of the
+// fix: counting a pending delivery as outstanding work only stops the drain
+// from a FALSE quiescence. Something still has to resolve it, or the drain
+// just waits out its stall timeout instead of making progress. kickDriveTree
+// runs at the top of every pass (before the outstanding check), alongside
+// drivePendingStableDelegateAttention and rematerializeDurablePendings -- the
+// same "drive whatever is waiting" role -- so it is where the flush belongs.
+//
+// The seeded entry is a placeholder with no live controller, not a delegate
+// produced by the real accept/defer path, so its OWN delivery attempt reports
+// errDelegateStaleLease (the same "something else already resolved this"
+// outcome a genuinely superseded delivery would produce) -- deliverDelegatePacket
+// checks plan.controller before anything else. flushPendingDelegateDeliveries
+// pops the queue entry before attempting delivery, so that pop -- not the
+// placeholder's delivery outcome -- is the fact this test pins: did
+// kickDriveTree reach into the queue at all.
+func TestKickDriveTreeFlushesPendingDelegateDeliveries(t *testing.T) {
+	t.Parallel()
+	sess := newSession(t)
+
+	sess.delegateDeliveryMu.Lock()
+	sess.pendingDelegateDeliveries = append(sess.pendingDelegateDeliveries, delegateDeliveryPlan{})
+	sess.delegateDeliveryMu.Unlock()
+
+	err := sess.kickDriveTree(context.Background())
+	if err != nil && !errors.Is(err, errDelegateStaleLease) {
+		t.Fatalf("kickDriveTree: %v", err)
+	}
+	if sess.hasPendingDelegateDeliveries() {
+		t.Fatal("kickDriveTree did not flush the pending delegate delivery")
+	}
+}
+
 // TestOutstandingDrainJobCountIncludesRunningManagedJobs verifies every owned
 // managed job keeps the drain open while it remains in the running map. Shell
 // execution mode is not part of that durable drain contract.


### PR DESCRIPTION
## Summary

- CI flake: `TestRunDrainsDelegatedJobTreeBeforeExit` (cmd/serf/run_drain_test.go) failed once expecting stdout to contain `BUILD-COMPLETE`, got `"waiting on delegate\n"`. This is a pre-existing race in the run-drain path, unrelated to the PR (#121) that happened to be merging when it fired.
- Root cause: `treeHasOutstandingWork` (agent/session_jobtree_drain.go) reads eight independent drain signals in sequence, not atomically. A delegate completion arms the coordinator's root attention (and raises the drain wake) *before* the finishing subagent clears its own `finalizing` flag. A drain pass that reads the attention flag early (before the arm) and the `finalizing` flag late (after the clear) sees both false — even though they were never simultaneously false — and wrongly concludes the tree is quiescent. `Close()` then SIGKILLs a delegate notification that was already armed and waiting.
- Fix: consume the wake channel's pending edge before each pass reads any state, and re-check it before trusting a "not outstanding" verdict. A wake landing during the scan means the tree moved under the read, so the pass re-loops instead of returning a stale quiescent result. No sleeps/retries — this closes the actual ordering gap.

## Reproduction evidence

- Baseline (origin/main, unfixed): stress run of `TestRunDrainsDelegatedJobTreeBeforeExit` under CPU contention, GOMAXPROCS=2, 12 parallel shards x 150 iterations (1800 runs total) — **3 failures**, all with the exact reported signature (`got stdout="waiting on delegate\n"`).
- Fixed binary, same harness, 12 shards x 300 iterations (3600 runs total) — **0 failures**.
- New deterministic unit test `TestDrainJobTreeRescansWhenAWakeLandsMidPass` reproduces the straddle without timing dependence: fails 100% of 20 runs against the old code, passes 100% of 50 runs against the fix.

## Sibling bug found in adversarial review (second commit)

Independent review of the straddle fix confirmed it (happens-before verified, deterministic test 10/10 red on main / 50/50 green with `-race`), but found a second, unrelated gap through a channel the straddle fix doesn't touch: `pendingDelegateDeliveries`.

`acceptDelegateDeliveryPlan` (agent/delegate_delivery.go:682) defers a delivery into that queue instead of delivering it inline whenever the receiving session is `SessionProcessing` at that instant — e.g. a second, unrelated delegate's completion targeting the coordinator while the drain loop's own notification turn is already running one delivery. The defer calls `notify()` exactly once. `treeHasOutstandingWork` never read `pendingDelegateDeliveries` at all, so once that one-shot wake was consumed by a later pass, nothing about the session's state said a completion was still owed — the drain declared quiescence with a real delivery sitting undelivered, and `Close()` would SIGKILL it. Same PRI-2441 symptom class, different signal.

Fix, two halves (both required — one alone either false-quiesces or livelocks):
- `treeHasOutstandingWork` and `subtreeHasLiveComponent` now read `hasPendingDelegateDeliveries()`, recursively through the existing child walk.
- `kickDriveTreeWith` now calls `flushPendingDelegateDeliveries()` every pass (alongside `drivePendingStableDelegateAttention` and `rematerializeDurablePendings`), so a pending delivery actually gets resolved instead of the drain just waiting on it forever.

Three new deterministic tests, confirmed red against the pre-fix code (via `git stash` of just the production change) and green after, including at count=50 under `-race`:
- `TestTreeHasOutstandingWorkCountsPendingDelegateDeliveries` — pins the read gap directly.
- `TestDrainJobTreeWaitsWhilePendingDelegateDeliveryUnflushed` — pins the loop-level behavior (mirrors this file's existing `TestDrainJobTreeReturnsOnContextCancel`: run in a goroutine, cancel, assert `context.Canceled` rather than a false quiescent return). An earlier version tried to force multiple passes by having a fake `kick` cancel on its 3rd call — that deadlocks by construction, since `kick` only runs once per pass and each pass blocks in `waitDrainWake` before the next `kick`. Caught by actually running the test rather than trusting the design, then rewritten around the existing pattern.
- `TestKickDriveTreeFlushesPendingDelegateDeliveries` — pins that `kickDriveTree` itself drains the queue.

Re-verified after this second fix: `go test ./agent/...` and `./cmd/serf/...` (count=1); the drain test family at count=50 under `-race`; the GOMAXPROCS=2 stress harness re-run (12 shards x 150 = 1800 runs) against the fully-fixed binary — 0 failures; `golangci-lint run ./cmd/serf/... ./agent/...` clean.

### Known follow-ups (not fixed here, flagged by the reviewer)

- `hasPendingDelegateAttentionArmRetry`'s entering-retry transition wakes `c.rootRuntime`, not necessarily the specific session whose *nested* drain loop is the one reading that flag. Plausible latent gap for nested delegate trees — unproven, not reproduced, out of scope for this PR.
- If `FinishGeneration`/`executeDelegateMutationPlans` itself fails on storage I/O, `finalizing` clears without a delivered notify. This is gated behind the finalization-recovery subsystem, which is designed to catch exactly this class of failure, but its interaction with the drain wasn't specifically re-verified here.

## Busy-child flush hazard found in second-round review (third commit)

A second round of independent review confirmed the sibling-bug fix correct for the reported gap (happens-before verified, deterministic tests 10/10 red on the pre-fix tip / 50/50 green with `-race`), but flagged a new hazard the fix's own mechanism introduced.

`kickDriveTreeWith` recurses into every live child (`liveDirectSubagents` filters only on `sub.closed`) and, as of the second commit, called `flushPendingDelegateDeliveries` there unconditionally. `flushPendingDelegateDeliveries` carries no `s.state` check of its own — it was safe at its four pre-existing call sites only because each one runs on the *owning session's own turn goroutine*. The drain's recursive call instead runs on the *ancestor's* drain goroutine, so it could call `deliverDelegatePacket` into a child that is actively `SessionProcessing` — e.g. a fire-and-forget delegate A mid-turn while its own grandchild G finishes. Every lock (`attentionMu`, `mu`, `AppendDurable`) is still held correctly, so `-race` would never flag this — the hazard is purely about *when* the mutation lands, not whether it races. Semantically it's still wrong: it can splice a delivered notification into A's history at a point A's own round loop did not choose, e.g. between an in-flight assistant tool call and its tool result, breaking LLM message alternation. `driveSubagentNotificationTurn` (subagents.go:1235-1243) already refuses to touch a child where `sub.running || sub.driving || sub.finalizing`; the drain's flush needed the same gate.

Fix: `kickDriveTreeWith`'s recursion now skips *only* the flush call for a busy child (`sub.running || sub.driving || sub.finalizing`), not the rest of the kick — `drainPendingWatchSends` and recursion into grandchildren still run, and the child's own pending count still holds the ancestor's drain open via `treeHasOutstandingWork` (which already reads it recursively). The busy child's own turn machinery flushes its queue at its next natural boundary once it stops being busy. The root/direct caller's own flush is unaffected: `DrainJobTree` only ever starts once the caller's own turn has ended, so the top-level session is never mid-turn at the point the drain calls it.

New deterministic test `TestKickDriveTreeDoesNotFlushBusyChildsPendingDelegateDeliveries`: a child marked `running=true` with a queued pending delivery must not have that queue flushed by the ancestor's `kickDriveTree`, while `treeHasOutstandingWork` still reports the tree outstanding because of it; once `running` flips false, the next kick flushes it normally. Confirmed red against the pre-gate tip (630bec7c5) — `kickDriveTree` errors with `errDelegateStaleLease` because it attempted the busy child's synthetic delivery — green after, stable at count=50 under `-race` alongside the straddle test and the three sibling-bug tests.

Re-verified after this third fix: `go test ./agent/...` and `./cmd/serf/...` (count=1); `go build`/`go vet -tags serffuzz ./agent/...` (the seed100 fuzz corpus calls `kickDriveTreeWith` directly with the unchanged 2-arg signature); the five-test drain family at count=50 under `-race`; the GOMAXPROCS=2 stress harness re-run (12 shards x 150 = 1800 runs) against the fully gated binary — 0 failures; `golangci-lint run ./cmd/serf/... ./agent/...` clean.

## Test plan

- [x] `go test ./agent/... -count=1` (full depth, no `-short`)
- [x] `go test ./cmd/serf/... -count=1`
- [x] `go test ./cmd/serf -run TestRunDrainsDelegatedJobTreeBeforeExit -count=50 -race` at GOMAXPROCS=1 and GOMAXPROCS=2
- [x] Stress reproduction re-run against the fixed binary (3600 runs, 0 failures)
- [x] Sibling-bug stress reproduction re-run against the fully-fixed binary (1800 runs, 0 failures)
- [x] Drain test family (`agent/session_jobtree_drain_test.go`, five tests including the busy-child gate) at count=50 under `-race`
- [x] `go build`/`go vet -tags serffuzz ./agent/...` (seed100 fuzz corpus calls `kickDriveTreeWith` directly)
- [x] Busy-child-gate stress reproduction re-run against the fully gated binary (1800 runs, 0 failures)
- [x] `golangci-lint run ./cmd/serf/... ./agent/...` clean

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU
