### PR TITLE
fix(scripts): actually unset CI in test-timing-budget-selftest.sh

### DIFF
--- a/scripts/test-timing-budget-selftest.sh
+++ b/scripts/test-timing-budget-selftest.sh
@@ -90,7 +90,7 @@ printf 'SUM\tpkgC\t16.0\n' >"$measured"
 printf '{"perTestCeilingSeconds": 2, "packages": {"pkgC": 10.0}}\n' >"$budget"
 env TMPDIR="$work/tmp" CI=true bash "$script" --no-web --budget "$budget" --measured "$measured" --check >"$out" 2>&1
 assert_eq "$?" "1" "CI=true with no --strict/--local flag is treated as strict"
-env TMPDIR="$work/tmp" bash "$script" --no-web --budget "$budget" --measured "$measured" --check >"$out" 2>&1
+env -u CI TMPDIR="$work/tmp" bash "$script" --no-web --budget "$budget" --measured "$measured" --check >"$out" 2>&1
 assert_eq "$?" "0" "an unset CI with no --strict/--local flag is treated as warn-only (local)"
 env TMPDIR="$work/tmp" CI=true bash "$script" --no-web --budget "$budget" --measured "$measured" --check --local >"$out" 2>&1
 assert_eq "$?" "0" "--local overrides CI=true"


### PR DESCRIPTION
## Summary

`scripts/test-timing-budget-selftest.sh`'s "CI auto-detection" block has a check asserting that an *unset* `$CI` is treated as warn-only:

```sh
env TMPDIR="$work/tmp" bash "$script" --no-web --budget "$budget" --measured "$measured" --check >"$out" 2>&1
assert_eq "$?" "0" "an unset CI with no --strict/--local flag is treated as warn-only (local)"
```

`env VAR=value command` only *sets* variables for the child process — it does not remove variables the child inherits from the parent. On a GitHub Actions runner (which always exports `CI=true`), the child still saw `CI=true`, so `test-timing-budget.sh`'s own `strict=$([ -n "${CI:-}" ] && echo true || echo false)` policy kicked in and the run exited 1, not 0. The check only ever passed locally, where `$CI` happens to be unset already — it was red on every CI run since it was introduced, including on the pre-rename `main` tip (found during PR #200 review).

## Fix

Use `env -u CI TMPDIR=... bash "$script" ...` so `CI` is actually removed for the child, regardless of the parent's environment. `env -u` is coreutils/BSD-compatible, available on both macOS and Ubuntu Actions runners.

Audited the rest of the file's `env VAR=...` calls: two others in the same block intentionally *set* `CI=true` (not unset anything), so they were unaffected — this was the only instance of the class in this script.

## Evidence

Before (CI=true exported, mimicking Actions):
```
FAIL: an unset CI with no --strict/--local flag is treated as warn-only (local) (want '0', got '1')
test-timing-budget-selftest: 36 checks, 1 failed
```
exit code 1.

After, both conditions:
```
test-timing-budget-selftest: 36 checks, 0 failed
```
exit code 0 with `CI=true` exported AND with `CI` unset.

Mutation check: forced `test-timing-budget.sh`'s `strict=` to always be `true` (breaking the warn-only-when-unset behavior) — the selftest correctly went red again on the same assertion, then was reverted.

Also ran the actual dev-tooling wave runner (`go run ./cmd/evener-test-dev-tooling test-timing-budget`) under both `CI=true` and unset — PASS both times. `go test . -run 'TestNoScript' -count=1` passes.

## Test plan
- [x] Reproduced red under `CI=true` before the fix
- [x] Green under `CI=true` after the fix
- [x] Green with `CI` unset after the fix
- [x] Mutation check: broke product script's warn-only behavior, confirmed selftest catches it, reverted
- [x] `go run ./cmd/evener-test-dev-tooling test-timing-budget` passes under both CI conditions
- [x] `go test . -run 'TestNoScript' -count=1` passes

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU