### PR TITLE
fix(migrate): repair legacy-path config left over from the Serf rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,16 @@ ancestor) to `.evener`. It refuses to overwrite a destination that already
 exists, so it's safe to run more than once. Pass `--dry-run` to preview the
 moves first, or `--verbose` to see every path it checked.
 
+Re-running it is also how you repair a machine that migrated before a fix
+landed: after moving each root (or finding it already moved), `evener-migrate`
+walks the destination and rewrites any leftover absolute references to the
+old `serf` path it finds inside text files there — for example a plugin
+marketplace registry that still points `git pull` at
+`.../config/serf/plugins/marketplaces/<name>`. It skips binaries and
+anything inside a Git working tree (a plugin marketplace clone, or a nested
+project checkout), so it's safe to run against a live install; files with
+nothing to rewrite are left untouched.
+
 If you skip this, the first Evener binary you run creates a fresh, empty
 `~/.evener` (and XDG config/state directories) — and once that empty
 directory exists, `evener-migrate` treats it as already migrated and skips

--- a/cmd/evener-migrate/main.go
+++ b/cmd/evener-migrate/main.go
@@ -140,27 +140,46 @@ func execute(opts options, stdout, stderr io.Writer) int {
 // returns statusSkipped. If src does not exist it returns statusSkipped
 // silently (or prints a message when verbose). When dryRun is true it reports
 // what would happen without moving.
+//
+// Whenever dst ends up existing after this call — whether because it was
+// just moved into place, it already existed, or a prior run already moved it
+// — migrate rewrites any leftover occurrences of src (the legacy absolute
+// path) inside dst's files to dst (see rewriteLegacyPaths). This is what
+// makes a re-run repair a machine that migrated before this rewrite existed:
+// the source is long gone, but stale absolute paths recorded inside the
+// already-migrated tree (e.g. a plugin marketplace registry's
+// installLocation) still get fixed.
 func migrate(m migration, dryRun, verbose bool, stdout, stderr io.Writer) status {
 	_, srcErr := os.Lstat(m.src)
-	if errors.Is(srcErr, os.ErrNotExist) {
-		if verbose {
-			_, _ = fmt.Fprintf(stdout, "skip  %s (source does not exist)\n", m.src)
-		}
-		return statusSkipped
-	}
-	if srcErr != nil {
+	srcMissing := errors.Is(srcErr, os.ErrNotExist)
+	if srcErr != nil && !srcMissing {
 		_, _ = fmt.Fprintf(stderr, "evener-migrate: stat %s: %v\n", m.src, srcErr)
 		return statusFailed
 	}
 
 	_, dstErr := os.Lstat(m.dst)
-	if dstErr == nil {
-		_, _ = fmt.Fprintf(stdout, "skip  %s -> %s (destination already exists)\n", m.src, m.dst)
-		return statusSkipped
-	}
-	if !errors.Is(dstErr, os.ErrNotExist) {
+	dstExists := dstErr == nil
+	if dstErr != nil && !errors.Is(dstErr, os.ErrNotExist) {
 		_, _ = fmt.Fprintf(stderr, "evener-migrate: stat %s: %v\n", m.dst, dstErr)
 		return statusFailed
+	}
+
+	if srcMissing {
+		if verbose {
+			_, _ = fmt.Fprintf(stdout, "skip  %s (source does not exist)\n", m.src)
+		}
+		if dstExists && !dryRun {
+			repairLegacyPaths(m, stdout, stderr)
+		}
+		return statusSkipped
+	}
+
+	if dstExists {
+		_, _ = fmt.Fprintf(stdout, "skip  %s -> %s (destination already exists)\n", m.src, m.dst)
+		if !dryRun {
+			repairLegacyPaths(m, stdout, stderr)
+		}
+		return statusSkipped
 	}
 
 	if dryRun {
@@ -173,7 +192,18 @@ func migrate(m migration, dryRun, verbose bool, stdout, stderr io.Writer) status
 		return statusFailed
 	}
 	_, _ = fmt.Fprintf(stdout, "moved  %s -> %s\n", m.src, m.dst)
+	repairLegacyPaths(m, stdout, stderr)
 	return statusMoved
+}
+
+// repairLegacyPaths rewrites any leftover references to m.src inside m.dst's
+// files. Errors are reported but non-fatal: the move itself already
+// succeeded, and a content-rewrite failure (e.g. a permission error on one
+// file) shouldn't be reported as a failed migration.
+func repairLegacyPaths(m migration, stdout, stderr io.Writer) {
+	if err := rewriteLegacyPaths(m.dst, m.src, m.dst, stdout); err != nil {
+		_, _ = fmt.Fprintf(stderr, "evener-migrate: rewriting legacy paths under %s: %v\n", m.dst, err)
+	}
 }
 
 // discoverProjectMigrations scans the current directory and ancestor git roots

--- a/cmd/evener-migrate/main_test.go
+++ b/cmd/evener-migrate/main_test.go
@@ -162,6 +162,119 @@ func TestExecuteDryRunMakesNoChanges(t *testing.T) {
 	}
 }
 
+func TestExecuteRewritesLegacyPathsAfterMove(t *testing.T) {
+	home := t.TempDir()
+	configBase := filepath.Join(home, ".config")
+	configSrc := filepath.Join(configBase, "serf")
+	pluginsDir := filepath.Join(configSrc, "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatalf("mkdir plugins dir: %v", err)
+	}
+	legacyMarketplaceDir := filepath.Join(configSrc, "plugins", "marketplaces", "acme")
+	registry := `{"acme":{"installLocation":"` + legacyMarketplaceDir + `"}}`
+	if err := os.WriteFile(filepath.Join(pluginsDir, "known_marketplaces.json"), []byte(registry), 0o600); err != nil {
+		t.Fatalf("write known_marketplaces.json: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := execute(baseOpts(home, t.TempDir()), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr = %q", code, stderr.String())
+	}
+
+	dstFile := filepath.Join(configBase, "evener", "plugins", "known_marketplaces.json")
+	got, err := os.ReadFile(dstFile)
+	if err != nil {
+		t.Fatalf("reading migrated registry: %v", err)
+	}
+	wantMarketplaceDir := filepath.Join(configBase, "evener", "plugins", "marketplaces", "acme")
+	want := `{"acme":{"installLocation":"` + wantMarketplaceDir + `"}}`
+	if string(got) != want {
+		t.Fatalf("migrated registry = %q, want %q", got, want)
+	}
+	if !strings.Contains(stdout.String(), "rewrote 1 path reference(s) in "+dstFile) {
+		t.Fatalf("stdout = %q, want a rewrite logged for %s", stdout.String(), dstFile)
+	}
+}
+
+func TestExecuteRerunRepairsAlreadyMigratedTree(t *testing.T) {
+	home := t.TempDir()
+	configBase := filepath.Join(home, ".config")
+	// Simulate a machine that already ran evener-migrate: .config/evener
+	// exists (so migrate() will skip the move), but the registry inside it
+	// still has the stale .config/serf path from before that first run.
+	pluginsDir := filepath.Join(configBase, "evener", "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatalf("mkdir plugins dir: %v", err)
+	}
+	legacyMarketplaceDir := filepath.Join(configBase, "serf", "plugins", "marketplaces", "acme")
+	registry := `{"acme":{"installLocation":"` + legacyMarketplaceDir + `"}}`
+	regFile := filepath.Join(pluginsDir, "known_marketplaces.json")
+	if err := os.WriteFile(regFile, []byte(registry), 0o600); err != nil {
+		t.Fatalf("write known_marketplaces.json: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := execute(baseOpts(home, t.TempDir()), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr = %q", code, stderr.String())
+	}
+
+	got, err := os.ReadFile(regFile)
+	if err != nil {
+		t.Fatalf("reading registry: %v", err)
+	}
+	wantMarketplaceDir := filepath.Join(configBase, "evener", "plugins", "marketplaces", "acme")
+	want := `{"acme":{"installLocation":"` + wantMarketplaceDir + `"}}`
+	if string(got) != want {
+		t.Fatalf("registry after re-run = %q, want %q (repaired in place)", got, want)
+	}
+	if !strings.Contains(stdout.String(), "rewrote 1 path reference(s) in "+regFile) {
+		t.Fatalf("stdout = %q, want a rewrite logged for %s", stdout.String(), regFile)
+	}
+
+	// Re-running again must be idempotent: no further rewrites reported.
+	var stdout2, stderr2 bytes.Buffer
+	code2 := execute(baseOpts(home, t.TempDir()), &stdout2, &stderr2)
+	if code2 != 0 {
+		t.Fatalf("second re-run code = %d, want 0; stderr = %q", code2, stderr2.String())
+	}
+	if strings.Contains(stdout2.String(), "rewrote") {
+		t.Fatalf("second re-run stdout = %q, want no further rewrites", stdout2.String())
+	}
+}
+
+func TestExecuteDryRunDoesNotRewriteContent(t *testing.T) {
+	home := t.TempDir()
+	configBase := filepath.Join(home, ".config")
+	configSrc := filepath.Join(configBase, "serf", "plugins")
+	if err := os.MkdirAll(configSrc, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	legacyMarketplaceDir := filepath.Join(configBase, "serf", "plugins", "marketplaces", "acme")
+	registry := `{"acme":{"installLocation":"` + legacyMarketplaceDir + `"}}`
+	regFile := filepath.Join(configSrc, "known_marketplaces.json")
+	if err := os.WriteFile(regFile, []byte(registry), 0o600); err != nil {
+		t.Fatalf("write known_marketplaces.json: %v", err)
+	}
+
+	opts := baseOpts(home, t.TempDir())
+	opts.dryRun = true
+	var stdout, stderr bytes.Buffer
+	code := execute(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr = %q", code, stderr.String())
+	}
+
+	got, err := os.ReadFile(regFile)
+	if err != nil {
+		t.Fatalf("reading registry: %v", err)
+	}
+	if string(got) != registry {
+		t.Fatalf("dry-run modified content: got %q, want unchanged %q", got, registry)
+	}
+}
+
 func TestExecuteMigratesXDGConfigAndState(t *testing.T) {
 	home := t.TempDir()
 	configBase := filepath.Join(home, ".config")

--- a/cmd/evener-migrate/rewrite.go
+++ b/cmd/evener-migrate/rewrite.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"unicode/utf8"
+
+	"primeradiant.com/evener/internal/legacypaths"
+)
+
+// maxRewriteFileSize caps how large a file rewriteLegacyPaths will read into
+// memory to scan for legacy path references. Session transcripts and API
+// logs can run into the hundreds of megabytes; skipping those is
+// deliberate — they are historical records, not live config, and repair-on-
+// rerun would otherwise re-read enormous files on every invocation for no
+// behavioral gain.
+const maxRewriteFileSize = 8 * 1024 * 1024 // 8 MiB
+
+// binarySniffWindow is how many leading bytes rewriteLegacyPaths inspects
+// for a NUL byte when deciding whether a file is binary.
+const binarySniffWindow = 8000
+
+// rewriteLegacyPaths walks dst and rewrites every occurrence of the old
+// legacy root prefix to new, in text files only. It is meant to be called
+// after a migration moves a root into place, and also when a re-run finds
+// the destination already migrated — so a re-run repairs config/state files
+// that still embed the pre-migration absolute path (e.g. a plugin
+// marketplace registry's installLocation).
+//
+// It skips:
+//   - directories that are themselves git working trees (contain a .git
+//     entry, file or dir) — plugin marketplaces are git clones and any
+//     legacy path they need repaired lives in the registry file beside them,
+//     not inside the clone; rewriting tracked file content would silently
+//     corrupt the checkout,
+//   - symlinks, since rewriting would edit whatever they point at, which may
+//     live outside the migrated tree,
+//   - files over maxRewriteFileSize,
+//   - files that sniff as binary (a NUL byte in the first
+//     binarySniffWindow bytes, or content that isn't valid UTF-8).
+//
+// Rewrites are idempotent: a file with no remaining occurrences of old is
+// left untouched and not reported. Each file actually changed is logged to
+// stdout with the file path and the number of replacements made.
+func rewriteLegacyPaths(dst, oldRoot, newRoot string, stdout io.Writer) error {
+	return filepath.WalkDir(dst, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if _, gitErr := os.Lstat(filepath.Join(path, ".git")); gitErr == nil {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Type()&fs.ModeSymlink != 0 || !d.Type().IsRegular() {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if info.Size() > maxRewriteFileSize {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+		if looksBinary(data) {
+			return nil
+		}
+
+		rewritten, n := legacypaths.Rewrite(string(data), oldRoot, newRoot)
+		if n == 0 {
+			return nil
+		}
+		if err := os.WriteFile(path, []byte(rewritten), info.Mode().Perm()); err != nil {
+			return fmt.Errorf("rewriting %s: %w", path, err)
+		}
+		_, _ = fmt.Fprintf(stdout, "rewrote %d path reference(s) in %s\n", n, path)
+		return nil
+	})
+}
+
+// looksBinary reports whether data should be treated as binary rather than
+// text: a NUL byte within the first binarySniffWindow bytes, or content
+// that isn't valid UTF-8.
+func looksBinary(data []byte) bool {
+	sniff := data
+	if len(sniff) > binarySniffWindow {
+		sniff = sniff[:binarySniffWindow]
+	}
+	return bytes.Contains(sniff, []byte{0}) || !utf8.Valid(data)
+}

--- a/cmd/evener-migrate/rewrite_test.go
+++ b/cmd/evener-migrate/rewrite_test.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRewriteLegacyPaths_RewritesTextFile(t *testing.T) {
+	dst := t.TempDir()
+	old := filepath.Join(t.TempDir(), "legacy-root") // any distinct absolute string works as "old"
+	nw := filepath.Join(t.TempDir(), "new-root")
+
+	target := filepath.Join(dst, "known_marketplaces.json")
+	body := `{"acme":{"installLocation":"` + old + `/marketplaces/acme"}}`
+	if err := os.WriteFile(target, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	if err := rewriteLegacyPaths(dst, old, nw, &stdout); err != nil {
+		t.Fatalf("rewriteLegacyPaths: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"acme":{"installLocation":"` + nw + `/marketplaces/acme"}}`
+	if string(got) != want {
+		t.Fatalf("rewritten content = %q, want %q", got, want)
+	}
+	if !strings.Contains(stdout.String(), "rewrote 1 path reference(s) in "+target) {
+		t.Fatalf("stdout = %q, want a log line naming the file and count", stdout.String())
+	}
+}
+
+func TestRewriteLegacyPaths_LeavesBinaryFileUntouched(t *testing.T) {
+	dst := t.TempDir()
+	old := filepath.Join(t.TempDir(), "legacy-root")
+	nw := filepath.Join(t.TempDir(), "new-root")
+
+	target := filepath.Join(dst, "index.db")
+	// A NUL byte anywhere in the sniff window marks this as binary.
+	body := append([]byte(old+"/some/path\x00binary-tail"), 0, 1, 2, 3)
+	if err := os.WriteFile(target, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	if err := rewriteLegacyPaths(dst, old, nw, &stdout); err != nil {
+		t.Fatalf("rewriteLegacyPaths: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Fatalf("binary file was modified: got %q, want unchanged %q", got, body)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want no rewrite logged for a binary file", stdout.String())
+	}
+}
+
+func TestRewriteLegacyPaths_SkipsGitDirectories(t *testing.T) {
+	dst := t.TempDir()
+	old := filepath.Join(t.TempDir(), "legacy-root")
+	nw := filepath.Join(t.TempDir(), "new-root")
+
+	repo := filepath.Join(dst, "marketplaces", "acme")
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A tracked-looking file with a legacy path reference: must not be
+	// touched, since it lives inside a git-managed working tree.
+	tracked := filepath.Join(repo, "marketplace.json")
+	body := `{"note":"` + old + `/somewhere"}`
+	if err := os.WriteFile(tracked, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Something living inside .git itself, in case the walk ever reaches it.
+	gitInternal := filepath.Join(repo, ".git", "config")
+	if err := os.WriteFile(gitInternal, []byte(old+"/somewhere"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	if err := rewriteLegacyPaths(dst, old, nw, &stdout); err != nil {
+		t.Fatalf("rewriteLegacyPaths: %v", err)
+	}
+
+	got, err := os.ReadFile(tracked)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != body {
+		t.Fatalf("file inside git-managed tree was modified: got %q, want unchanged %q", got, body)
+	}
+	gitGot, err := os.ReadFile(gitInternal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gitGot) != old+"/somewhere" {
+		t.Fatalf(".git internal file was modified: got %q", gitGot)
+	}
+}
+
+func TestRewriteLegacyPaths_SkipsFilesOverSizeCap(t *testing.T) {
+	dst := t.TempDir()
+	old := filepath.Join(t.TempDir(), "legacy-root")
+	nw := filepath.Join(t.TempDir(), "new-root")
+
+	target := filepath.Join(dst, "huge.jsonl")
+	body := old + "/x " + strings.Repeat("a", maxRewriteFileSize+1)
+	if err := os.WriteFile(target, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	if err := rewriteLegacyPaths(dst, old, nw, &stdout); err != nil {
+		t.Fatalf("rewriteLegacyPaths: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != body {
+		t.Fatalf("oversized file was modified")
+	}
+}
+
+func TestRewriteLegacyPaths_IdempotentSecondRun(t *testing.T) {
+	dst := t.TempDir()
+	old := filepath.Join(t.TempDir(), "legacy-root")
+	nw := filepath.Join(t.TempDir(), "new-root")
+
+	target := filepath.Join(dst, "meta.json")
+	body := `{"cwd":"` + old + `/proj"}`
+	if err := os.WriteFile(target, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var first bytes.Buffer
+	if err := rewriteLegacyPaths(dst, old, nw, &first); err != nil {
+		t.Fatalf("first pass: %v", err)
+	}
+	if !strings.Contains(first.String(), "rewrote 1 path reference(s)") {
+		t.Fatalf("first pass stdout = %q, want a rewrite logged", first.String())
+	}
+
+	var second bytes.Buffer
+	if err := rewriteLegacyPaths(dst, old, nw, &second); err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if second.Len() != 0 {
+		t.Fatalf("second pass stdout = %q, want no further rewrites (idempotent)", second.String())
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"cwd":"` + nw + `/proj"}`
+	if string(got) != want {
+		t.Fatalf("content = %q, want %q", got, want)
+	}
+}
+
+func TestRewriteLegacyPaths_SkipsSymlinks(t *testing.T) {
+	dst := t.TempDir()
+	old := filepath.Join(t.TempDir(), "legacy-root")
+	nw := filepath.Join(t.TempDir(), "new-root")
+
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	body := old + "/somewhere"
+	if err := os.WriteFile(outside, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dst, "link.txt")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := rewriteLegacyPaths(dst, old, nw, &stdout); err != nil {
+		t.Fatalf("rewriteLegacyPaths: %v", err)
+	}
+
+	got, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != body {
+		t.Fatalf("symlink target was modified: got %q, want unchanged %q", got, body)
+	}
+}

--- a/internal/legacypaths/legacypaths.go
+++ b/internal/legacypaths/legacypaths.go
@@ -1,0 +1,52 @@
+// Package legacypaths rewrites absolute path prefixes left over from the
+// Serf→Evener rename (see cmd/evener-migrate and internal/plugins). Any
+// state written before a machine was migrated may still carry paths rooted
+// under the old "serf" locations; this package supplies the one primitive
+// both the migration tool (rewriting file contents) and the plugins package
+// (rewriting stored path fields) use to repair them.
+package legacypaths
+
+import "strings"
+
+// Rewrite replaces every occurrence of oldRoot in content with newRoot, but
+// only when oldRoot is immediately followed by a path separator or any
+// other byte that could not extend the same path component (e.g. the
+// closing quote of a JSON string, or the end of content). This prevents a
+// false match against an unrelated, longer path component — oldRoot
+// "/a/.serf" must not match inside "/a/.serfbackup".
+//
+// It reports how many replacements were made. An empty oldRoot, or
+// oldRoot == newRoot, is a no-op.
+func Rewrite(content, oldRoot, newRoot string) (string, int) {
+	if oldRoot == "" || oldRoot == newRoot {
+		return content, 0
+	}
+
+	var b strings.Builder
+	n := 0
+	rest := content
+	for {
+		i := strings.Index(rest, oldRoot)
+		if i < 0 {
+			b.WriteString(rest)
+			break
+		}
+		end := i + len(oldRoot)
+		b.WriteString(rest[:i])
+		if end == len(rest) || !isPathContinuation(rest[end]) {
+			b.WriteString(newRoot)
+			n++
+		} else {
+			b.WriteString(rest[i:end])
+		}
+		rest = rest[end:]
+	}
+	return b.String(), n
+}
+
+// isPathContinuation reports whether b could be part of the same path
+// component as the byte before it (i.e. it does not mark a path boundary).
+func isPathContinuation(b byte) bool {
+	return b == '_' || b == '-' || b == '.' ||
+		(b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}

--- a/internal/legacypaths/legacypaths_test.go
+++ b/internal/legacypaths/legacypaths_test.go
@@ -1,0 +1,97 @@
+package legacypaths
+
+import "testing"
+
+func TestRewrite(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		old     string
+		new     string
+		want    string
+		wantN   int
+	}{
+		{
+			name:    "prefix followed by path separator",
+			content: "/a/.serf/plugins/x",
+			old:     "/a/.serf",
+			new:     "/a/.evener",
+			want:    "/a/.evener/plugins/x",
+			wantN:   1,
+		},
+		{
+			name:    "exact match at end of quoted JSON string",
+			content: `"installLocation":"/a/.serf"`,
+			old:     "/a/.serf",
+			new:     "/a/.evener",
+			want:    `"installLocation":"/a/.evener"`,
+			wantN:   1,
+		},
+		{
+			name:    "match at end of content with no trailing byte",
+			content: "/a/.serf",
+			old:     "/a/.serf",
+			new:     "/a/.evener",
+			want:    "/a/.evener",
+			wantN:   1,
+		},
+		{
+			name:    "unrelated longer path component is not touched",
+			content: "/a/.serfbackup/x",
+			old:     "/a/.serf",
+			new:     "/a/.evener",
+			want:    "/a/.serfbackup/x",
+			wantN:   0,
+		},
+		{
+			name:    "multiple occurrences all replaced",
+			content: "/a/.serf/one /a/.serf/two",
+			old:     "/a/.serf",
+			new:     "/a/.evener",
+			want:    "/a/.evener/one /a/.evener/two",
+			wantN:   2,
+		},
+		{
+			name:    "no occurrences leaves content untouched",
+			content: "nothing to see here",
+			old:     "/a/.serf",
+			new:     "/a/.evener",
+			want:    "nothing to see here",
+			wantN:   0,
+		},
+		{
+			name:    "empty old is a no-op",
+			content: "/a/.serf/x",
+			old:     "",
+			new:     "/a/.evener",
+			want:    "/a/.serf/x",
+			wantN:   0,
+		},
+		{
+			name:    "equal old and new is a no-op",
+			content: "/a/.serf/x",
+			old:     "/a/.serf",
+			new:     "/a/.serf",
+			want:    "/a/.serf/x",
+			wantN:   0,
+		},
+		{
+			name:    "idempotent: rewritten content has nothing left to match",
+			content: "/a/.evener/plugins/x",
+			old:     "/a/.serf",
+			new:     "/a/.evener",
+			want:    "/a/.evener/plugins/x",
+			wantN:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, n := Rewrite(tt.content, tt.old, tt.new)
+			if got != tt.want || n != tt.wantN {
+				t.Errorf("Rewrite(%q, %q, %q) = (%q, %d), want (%q, %d)",
+					tt.content, tt.old, tt.new, got, n, tt.want, tt.wantN)
+			}
+		})
+	}
+}

--- a/internal/plugins/marketplaces.go
+++ b/internal/plugins/marketplaces.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"primeradiant.com/evener/internal/legacypaths"
 )
 
 var (
@@ -59,7 +61,29 @@ func (m *Manager) loadMarketplaces() (Marketplaces, error) {
 	if mk == nil {
 		mk = Marketplaces{}
 	}
+	m.rerootLegacyInstallLocations(mk)
 	return mk, nil
+}
+
+// rerootLegacyInstallLocations rewrites any MarketplaceRef.InstallLocation
+// still rooted under the pre-rename legacy plugins root (see legacyRootFor)
+// to live under m.Root. A no-op when m.Root doesn't have the DefaultRoot
+// shape, or no ref has a legacy path. This self-heals a
+// known_marketplaces.json written before a Serf→Evener migration — e.g. the
+// "refreshing marketplace ...: chdir .../serf/plugins/marketplaces/name: no
+// such file or directory" failure — without requiring a fresh evener-migrate
+// run.
+func (m *Manager) rerootLegacyInstallLocations(mk Marketplaces) {
+	legacy := legacyRootFor(m.Root)
+	if legacy == "" {
+		return
+	}
+	for name, ref := range mk {
+		if rewritten, n := legacypaths.Rewrite(ref.InstallLocation, legacy, m.Root); n > 0 {
+			ref.InstallLocation = rewritten
+			mk[name] = ref
+		}
+	}
 }
 
 func (m *Manager) saveMarketplaces(mk Marketplaces) error {

--- a/internal/plugins/marketplaces_test.go
+++ b/internal/plugins/marketplaces_test.go
@@ -124,6 +124,73 @@ func TestRemoveMarketplace_DirectorySourceKeepsContents(t *testing.T) {
 	}
 }
 
+func TestLoadMarketplaces_RerootsLegacyInstallLocation(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "evener", "plugins")
+	legacyRoot := filepath.Join(filepath.Dir(filepath.Dir(root)), "serf", "plugins")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := NewManager(root)
+	stalePath := filepath.Join(legacyRoot, "marketplaces", "acme")
+	body := `{"acme":{"source":{"source":"github","repo":"o/acme"},"installLocation":"` +
+		filepath.ToSlash(stalePath) + `","lastUpdated":"2026-01-01T00:00:00Z"}}`
+	if err := os.WriteFile(m.marketplacesFile(), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mk, err := m.ListMarketplaces()
+	if err != nil {
+		t.Fatalf("ListMarketplaces: %v", err)
+	}
+	want := filepath.Join(root, "marketplaces", "acme")
+	got := mk["acme"].InstallLocation
+	if got != want {
+		t.Fatalf("InstallLocation = %q, want %q (rerooted under current plugins root)", got, want)
+	}
+}
+
+// TestRefreshMarketplace_RepairsLegacyInstallLocation reproduces the reported
+// bug directly: a known_marketplaces.json written before a Serf→Evener
+// migration still has installLocation rooted under the old .../serf/plugins
+// tree. Without rerooting at load, RefreshMarketplace would git-pull that
+// stale, now-nonexistent directory (the "chdir ...serf/plugins/marketplaces/
+// name: no such file or directory" failure). This asserts the git pull is
+// issued against the current root instead.
+func TestRefreshMarketplace_RepairsLegacyInstallLocation(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "evener", "plugins")
+	legacyRoot := filepath.Join(filepath.Dir(filepath.Dir(root)), "serf", "plugins")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := NewManager(root)
+	stalePath := filepath.Join(legacyRoot, "marketplaces", "acme")
+	body := `{"acme":{"source":{"source":"github","repo":"o/acme"},"installLocation":"` +
+		filepath.ToSlash(stalePath) + `","lastUpdated":"2026-01-01T00:00:00Z"}}`
+	if err := os.WriteFile(m.marketplacesFile(), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origPull := marketplaceGitPull
+	var pulledDir string
+	marketplaceGitPull = func(_ context.Context, dir string) error {
+		pulledDir = dir
+		return nil
+	}
+	t.Cleanup(func() { marketplaceGitPull = origPull })
+
+	if err := m.RefreshMarketplace(context.Background(), "acme"); err != nil {
+		t.Fatalf("RefreshMarketplace: %v", err)
+	}
+	want := filepath.Join(root, "marketplaces", "acme")
+	if pulledDir != want {
+		t.Fatalf("git pull dir = %q, want %q (current root, not stale legacy path)", pulledDir, want)
+	}
+	mk, _ := m.ListMarketplaces()
+	if mk["acme"].InstallLocation != want {
+		t.Fatalf("saved InstallLocation = %q, want %q", mk["acme"].InstallLocation, want)
+	}
+}
+
 func TestRefreshMarketplace_ClonesUnfetchedSeed(t *testing.T) {
 	if !gitAvailable() {
 		t.Skip("git not available")

--- a/internal/plugins/paths.go
+++ b/internal/plugins/paths.go
@@ -42,6 +42,24 @@ func DefaultRoot() string {
 	return filepath.Join(dir, "evener", "plugins")
 }
 
+// legacyRootFor returns what root would have been before the Serf→Evener
+// rename (see cmd/evener-migrate), or "" if root doesn't have the
+// DefaultRoot shape (.../evener/plugins) — e.g. a caller-supplied custom
+// root, which has no legacy equivalent to reroot from.
+//
+// installLocation/installPath values stored in known_marketplaces.json and
+// installed_plugins.json before a machine was migrated still carry this
+// legacy prefix; loadMarketplaces and LoadRegistry rewrite it to the current
+// root at load time so a stale value self-heals without requiring a fresh
+// evener-migrate run.
+func legacyRootFor(root string) string {
+	parent := filepath.Dir(root)
+	if filepath.Base(parent) != "evener" {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(parent), "serf", filepath.Base(root))
+}
+
 func (m *Manager) registryPath() string { return filepath.Join(m.Root, "installed_plugins.json") }
 func (m *Manager) marketplacesFile() string {
 	return filepath.Join(m.Root, "known_marketplaces.json")

--- a/internal/plugins/paths_test.go
+++ b/internal/plugins/paths_test.go
@@ -15,6 +15,37 @@ func TestDefaultRoot_UsesXDGConfigHome(t *testing.T) {
 	}
 }
 
+func TestLegacyRootFor(t *testing.T) {
+	cases := []struct {
+		name string
+		root string
+		want string
+	}{
+		{
+			name: "default-shaped root swaps evener for serf",
+			root: "/x/y/evener/plugins",
+			want: "/x/y/serf/plugins",
+		},
+		{
+			name: "custom root with no evener segment has no legacy equivalent",
+			root: "/store",
+			want: "",
+		},
+		{
+			name: "root whose parent isn't evener has no legacy equivalent",
+			root: "/x/y/notevener/plugins",
+			want: "",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := legacyRootFor(tt.root); got != tt.want {
+				t.Errorf("legacyRootFor(%q) = %q, want %q", tt.root, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestManagerPaths(t *testing.T) {
 	m := NewManager("/store")
 	cases := map[string]string{

--- a/internal/plugins/registry.go
+++ b/internal/plugins/registry.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"time"
+
+	"primeradiant.com/evener/internal/legacypaths"
 )
 
 var marshalRegistry = json.MarshalIndent
@@ -60,7 +63,26 @@ func LoadRegistry(path string) (Registry, error) {
 	if r.Plugins == nil {
 		r.Plugins = map[string][]InstallEntry{}
 	}
+	rerootLegacyInstallPaths(r, filepath.Dir(path))
 	return r, nil
+}
+
+// rerootLegacyInstallPaths rewrites any InstallEntry.InstallPath still
+// rooted under the pre-rename legacy plugins root (see legacyRootFor) to
+// live under root, the registry's current plugins root. A no-op when root
+// doesn't have the DefaultRoot shape, or no entry has a legacy path.
+func rerootLegacyInstallPaths(r Registry, root string) {
+	legacy := legacyRootFor(root)
+	if legacy == "" {
+		return
+	}
+	for _, entries := range r.Plugins {
+		for i := range entries {
+			if rewritten, n := legacypaths.Rewrite(entries[i].InstallPath, legacy, root); n > 0 {
+				entries[i].InstallPath = rewritten
+			}
+		}
+	}
 }
 
 // SaveRegistry writes r to path atomically, always at schema version 2.

--- a/internal/plugins/registry_test.go
+++ b/internal/plugins/registry_test.go
@@ -46,6 +46,45 @@ func TestSaveLoadRegistry_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestLoadRegistry_RerootsLegacyInstallPath(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "evener", "plugins")
+	legacyRoot := filepath.Join(filepath.Dir(filepath.Dir(root)), "serf", "plugins")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(root, "installed_plugins.json")
+	stalePath := filepath.Join(legacyRoot, "cache", "acme", "widget", "abc123")
+	body := `{"version":2,"plugins":{"widget@acme":[{"installPath":"` + filepath.ToSlash(stalePath) + `","version":"1.0.0","enabled":true}]}}`
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := LoadRegistry(p)
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	want := filepath.Join(root, "cache", "acme", "widget", "abc123")
+	got := r.Plugins["widget@acme"][0].InstallPath
+	if got != want {
+		t.Fatalf("InstallPath = %q, want %q (rerooted under current plugins root)", got, want)
+	}
+}
+
+func TestLoadRegistry_LeavesNonLegacyInstallPathAlone(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "installed_plugins.json")
+	body := `{"version":2,"plugins":{"widget@acme":[{"installPath":"/store/cache/acme/widget/abc123","version":"1.0.0","enabled":true}]}}`
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r, err := LoadRegistry(p)
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	if got := r.Plugins["widget@acme"][0].InstallPath; got != "/store/cache/acme/widget/abc123" {
+		t.Fatalf("InstallPath = %q, want unchanged", got)
+	}
+}
+
 func TestLoadRegistry_RejectsUnknownVersion(t *testing.T) {
 	p := filepath.Join(t.TempDir(), "installed_plugins.json")
 	os.WriteFile(p, []byte(`{"version":99,"plugins":{}}`), 0o644)


### PR DESCRIPTION
## Summary

After PR #200's Serf→Evener flag-day rename, `evener-migrate` moves the three roots (`~/.serf`, `~/.config/serf`, `~/.local/state/serf`) but didn't touch files *inside* the moved tree that had recorded an absolute path embedding the old root. The concrete symptom:

```
[hub] plugin auto-upgrade: refreshing marketplace "claude-plugins-official": git pull --ff-only --quiet: chdir /Users/jesse/.config/serf/plugins/marketplaces/claude-plugins-official: no such file or directory
```

`known_marketplaces.json`'s `installLocation` field (and `installed_plugins.json`'s `installPath`) are stored as absolute paths but are fully derivable from the plugins root at load time — `Root/marketplaces/<name>` for a git-backed marketplace, `Root/cache/<marketplace>/<plugin>/<sha>` for a cached plugin install. They were being trusted as-is instead of re-derived, so a value written before migration kept pointing at a directory that no longer exists.

## What changed

- **Reader-side self-heal** (`internal/plugins`): `loadMarketplaces` and `LoadRegistry` now reroot any stored `installLocation`/`installPath` still prefixed with the pre-rename plugins root (`.../serf/plugins`) to the current root (`.../evener/plugins`), at load time. This fixes the reported bug immediately on the next read/save, without requiring `evener-migrate` to run again.
- **`evener-migrate` repairs already-migrated trees**: after moving a root (or finding it already moved — the common case on a machine that migrated before this fix existed), it now walks the destination and rewrites any leftover absolute references to the legacy root inside text files there. It skips binaries (NUL-byte/UTF-8 sniff), symlinks, files over an 8 MiB cap, and anything inside a Git working tree (marketplace clones, nested project checkouts) — rewriting tracked file content would corrupt them. Rewrites are idempotent and each changed file is logged with its replacement count.
- New shared primitive `internal/legacypaths.Rewrite` does the actual boundary-aware prefix substitution (won't false-positive-match `.../.serfbackup` against a `.../.serf` prefix), used by both the migrate tool and the plugins reader fix.
- README's "Migrating from Serf" section now documents that re-running `evener-migrate` is the supported repair path.

## Root-cause call

Derive-at-read (option a from the investigation brief): the broken paths are mechanically derivable from the plugins root, so that's the durable fix. The `evener-migrate` content rewrite is the second layer — it repairs the on-disk JSON directly (and anything else under the migrated tree with the same problem) so a re-run is a complete, honest repair story even without the reader-side fix.

## Blast-radius survey (read-only, on the requester's real machine)

- `~/.config/evener/plugins/known_marketplaces.json` — `installLocation` (the reported bug; confirmed via `internal/plugins/marketplaces.go`'s `RefreshMarketplace` → `marketplaceGitPull(ctx, ref.InstallLocation)`).
- `~/.config/evener/plugins/installed_plugins.json` — same `installPath` shape (no plugins currently installed on this machine, but same code path).
- Session/job state JSONL/JSON under `~/.local/state/evener/projects/**` (meta.json, transcripts, api logs, jobs.jsonl, appwire-index.json) — historical records embedding old working-directory paths; not live config, but covered by the generic rewrite anyway.
- `~/.evener/run/logs/*.log` — rotated daemon logs with historical path references; one currently-open log target was still bound to the legacy path in a running, not-yet-restarted hub process (an in-memory runtime artifact, not a persisted file — resolves on hub restart, out of scope for a file rewrite).
- `~/.evener/index.db` (SQLite) — confirmed (via `grep -a`) to contain embedded legacy path fragments in job/delegate records. Correctly skipped by the binary sniff; fixing this would need a dedicated DB migration, not a text rewrite — flagged as a known, intentionally out-of-scope gap.
- Git worktrees nested under `~/.local/state/evener/projects/**/worktrees/**` — full checkouts with their own `.git` file; must not be touched (would corrupt tracked source). The rewrite walker skips any directory containing a `.git` entry.
- Plugin marketplace clones under `~/.config/evener/plugins/marketplaces/**` — real git clones; same skip rule applies, and it's correct since the registry lives one level up.

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/evener-migrate/... ./internal/plugins/... ./internal/legacypaths/...` — new tests red-before-green: `TestRefreshMarketplace_RepairsLegacyInstallLocation` reproduces the exact bug (asserts `git pull` targets the current root, not the stale one); `TestExecuteRerunRepairsAlreadyMigratedTree` proves a second `evener-migrate` run repairs a machine migrated before this fix, and is idempotent on a third run; `rewrite_test.go` covers binary/symlink/git-dir/size-cap skips.
- [x] `go test . -short` (root package)
- [x] `go vet ./...`, `gofmt -l .`
- [x] `golangci-lint run` on touched packages — 0 issues
- [x] `go run ./cmd/evener-namingcheck`, `go run ./cmd/evener-internalcheck` — clean

## What to run afterward

```
evener-migrate
```

Since all three roots are already migrated, this run hits the "destination already exists" / "source does not exist" skip paths for each — and now, on that path, it walks the destination and repairs `known_marketplaces.json` in place. (The reader-side fix in this PR also self-heals the marketplace registry on its own next load/save, independent of running `evener-migrate` again.)

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU