### PR TITLE
fix(hub): keep sidebar disclosure triangle clickable over hover kebab menu

### DIFF
--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/rail-row-chevron-actions-overlap/assert.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/rail-row-chevron-actions-overlap/assert.mjs
@@ -1,0 +1,52 @@
+// issue #196: the sidebar's trailing disclosure chevron (.chevronButton)
+// must stay clickable even while the hover-revealed "..."/"+" actions
+// overlay (.actions) covers the row's right edge. The contract this pins:
+// for every (width x row-kind x right-slot) fixture the harness builds, if
+// the chevron's hit box and an actions button's hit box overlap at all, a
+// click landing in that overlap must resolve to the CHEVRON
+// (document.elementFromPoint, not z-index arithmetic) - never to the
+// actions overlay swallowing it (the original bug) and never to some third
+// element neither control owns.
+//
+// This does NOT require the two hit boxes to never overlap - RailRow.tsx's
+// own #206 fix raises the chevron's stacking order above .actions rather
+// than reserving it separate flex space (see that PR's RailRow.module.css
+// comment), so an overlap can exist and still be a correct fix as long as
+// the chevron demonstrably wins every pixel of it. A regression that only
+// repaints (e.g. a z-index in the wrong direction, or pointer-events
+// swapped) still fails here because the winner comes from the browser's own
+// hit test, not from reading the stylesheet.
+export default function assert(measurement) {
+  const failures = [];
+  const notes = [];
+
+  for (const f of measurement) {
+    for (const [kind, overlap, winner] of [
+      ["kebab", f.kebabOverlap, f.kebabOverlapWinner],
+      ["plus", f.plusOverlap, f.plusOverlapWinner],
+    ]) {
+      if (!overlap) continue; // no shared pixels - nothing to adjudicate
+      if (winner === "chevron") {
+        notes.push(
+          `${f.id}: chevron overlaps the ${kind} button by ${overlap.width.toFixed(1)}x${overlap.height.toFixed(1)}px and wins clicks there`,
+        );
+      } else {
+        failures.push(
+          `${f.id} (${f.label}): chevron=[${f.chevron.left.toFixed(1)},${f.chevron.right.toFixed(1)}] overlaps the ${kind} button's hit box by ${overlap.width.toFixed(1)}x${overlap.height.toFixed(1)}px, and a click there resolves to "${winner}", not the chevron - the disclosure triangle is still unclickable there`,
+        );
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    return { pass: false, reason: failures.join("; ") };
+  }
+
+  return {
+    pass: true,
+    reason:
+      notes.length > 0
+        ? `chevron stays clickable in all ${measurement.length} fixtures (${notes.join("; ")})`
+        : `chevron's hit box never overlaps an actions button in any of the ${measurement.length} fixtures`,
+  };
+}

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/rail-row-chevron-actions-overlap/assert.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/rail-row-chevron-actions-overlap/assert.mjs
@@ -1,40 +1,56 @@
 // issue #196: the sidebar's trailing disclosure chevron (.chevronButton)
 // must stay clickable even while the hover-revealed "..."/"+" actions
-// overlay (.actions) covers the row's right edge. The contract this pins:
-// for every (width x row-kind x right-slot) fixture the harness builds, if
-// the chevron's hit box and an actions button's hit box overlap at all, a
-// click landing in that overlap must resolve to the CHEVRON
-// (document.elementFromPoint, not z-index arithmetic) - never to the
-// actions overlay swallowing it (the original bug) and never to some third
-// element neither control owns.
+// overlay (.actions) covers the row's right edge.
 //
-// This does NOT require the two hit boxes to never overlap - RailRow.tsx's
-// own #206 fix raises the chevron's stacking order above .actions rather
-// than reserving it separate flex space (see that PR's RailRow.module.css
-// comment), so an overlap can exist and still be a correct fix as long as
-// the chevron demonstrably wins every pixel of it. A regression that only
-// repaints (e.g. a z-index in the wrong direction, or pointer-events
-// swapped) still fails here because the winner comes from the browser's own
-// hit test, not from reading the stylesheet.
+// This case was first written against a z-index fix (raise .chevronButton
+// above .actions in stacking order) and accepted "the chevron demonstrably
+// wins clicks in the overlap" as green. That was too weak a bar: on the
+// z-index branch, EVERY fixture showed the chevron's full 12x12 hit box
+// sitting inside the "..." trigger's own hit box (roughly a quarter of its
+// ~47px width) - the chevron won, but only by taking a bite out of the
+// kebab trigger's own clickable area. That's the exact failure mode the
+// original RCA predicted for a stacking-order fix: it doesn't remove the
+// overlap, it just moves whichever control loses it.
+//
+// The shipped fix instead makes `.actions` a real in-flow flex item, so
+// flexbox reserves it actual space and the two controls' hit boxes can
+// never share a pixel - a structural guarantee, not a stacking outcome.
+// The bar here now matches that: every fixture must show the chevron and
+// EVERY actions button (kebab, and a project row's "+") fully disjoint
+// (zero-width intersection, not just "loser resolves elsewhere"), AND each
+// control's own center must resolve to itself via elementFromPoint - a
+// sanity check that "disjoint boxes" actually means both controls are
+// independently clickable, not that a third element is eating clicks at
+// either one's center.
 export default function assert(measurement) {
   const failures = [];
-  const notes = [];
 
   for (const f of measurement) {
-    for (const [kind, overlap, winner] of [
-      ["kebab", f.kebabOverlap, f.kebabOverlapWinner],
-      ["plus", f.plusOverlap, f.plusOverlapWinner],
+    for (const [kind, overlap] of [
+      ["kebab", f.kebabOverlap],
+      ["plus", f.plusOverlap],
     ]) {
-      if (!overlap) continue; // no shared pixels - nothing to adjudicate
-      if (winner === "chevron") {
-        notes.push(
-          `${f.id}: chevron overlaps the ${kind} button by ${overlap.width.toFixed(1)}x${overlap.height.toFixed(1)}px and wins clicks there`,
-        );
-      } else {
+      if (overlap) {
         failures.push(
-          `${f.id} (${f.label}): chevron=[${f.chevron.left.toFixed(1)},${f.chevron.right.toFixed(1)}] overlaps the ${kind} button's hit box by ${overlap.width.toFixed(1)}x${overlap.height.toFixed(1)}px, and a click there resolves to "${winner}", not the chevron - the disclosure triangle is still unclickable there`,
+          `${f.id} (${f.label}): chevron=[${f.chevron.left.toFixed(1)},${f.chevron.right.toFixed(1)}] overlaps the ${kind} button's hit box by ${overlap.width.toFixed(1)}x${overlap.height.toFixed(1)}px - the two controls must be fully disjoint, not merely "chevron wins the overlap"`,
         );
       }
+    }
+
+    if (f.chevronSelfWinner !== "chevron") {
+      failures.push(
+        `${f.id} (${f.label}): the chevron's own center resolves to "${f.chevronSelfWinner}", not the chevron itself - it isn't reliably clickable at its own position`,
+      );
+    }
+    if (f.kebabSelfWinner !== "kebab") {
+      failures.push(
+        `${f.id} (${f.label}): the kebab trigger's own center resolves to "${f.kebabSelfWinner}", not the kebab itself - it isn't reliably clickable at its own position`,
+      );
+    }
+    if (f.plus && f.plusSelfWinner !== "plus") {
+      failures.push(
+        `${f.id} (${f.label}): the "+" button's own center resolves to "${f.plusSelfWinner}", not the button itself - it isn't reliably clickable at its own position`,
+      );
     }
   }
 
@@ -44,9 +60,6 @@ export default function assert(measurement) {
 
   return {
     pass: true,
-    reason:
-      notes.length > 0
-        ? `chevron stays clickable in all ${measurement.length} fixtures (${notes.join("; ")})`
-        : `chevron's hit box never overlaps an actions button in any of the ${measurement.length} fixtures`,
+    reason: `chevron, kebab, and (where present) the "+" button are fully disjoint and each independently clickable at its own center in all ${measurement.length} fixtures`,
   };
 }

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/rail-row-chevron-actions-overlap/case.json
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/rail-row-chevron-actions-overlap/case.json
@@ -1,6 +1,6 @@
 {
   "name": "rail-row-chevron-actions-overlap",
-  "description": "rail: a branch row's trailing disclosure chevron must stay clickable over the hover-revealed '...'/'+' actions overlay - the chevron's hit box must not be swallowed by .actions at the sidebar's min (200px) and default (280px) widths, for both a session row (1 action button) and a project row (2), with and without a right-slot occupant (timestamp/badge) bounding the title column's growth (issue #196)",
+  "description": "rail: a branch row's trailing disclosure chevron and the '...'/'+' actions buttons must have fully disjoint, independently-clickable hit boxes - not merely 'the chevron wins the overlap' - at the sidebar's min (200px) and default (280px) widths, for both a session row (1 action button) and a project row (2), with and without a right-slot occupant (timestamp/badge) bounding the title column's growth (issue #196)",
   "cssFiles": [
     "styles/global.css",
     "styles/tokens.css",
@@ -27,9 +27,9 @@
     { "selector": "#row-p280nb", "pseudoClasses": ["hover"] }
   ],
   "mutation": {
-    "declaration": "RailRow.module.css: .chevronButton { position: relative; z-index: var(--z-raised); } (both lines deleted, reverting the row's own #206 fix back to a statically-positioned chevron under the position:absolute .actions overlay)",
+    "declaration": "RailRow.module.css: .actions reverted to position: absolute; right: 0; top: 0; bottom: 0; with its old padding-left/linear-gradient mask and the .railRow:hover .actions background swap restored, plus .railRow given back position: relative (its containing block) - i.e. the pre-rework, position:absolute overlay design, with .chevronButton left exactly as shipped (no z-index either)",
     "verified": "2026-08-18",
     "expect": "fail",
-    "note": "With the two declarations removed, .actions (position:absolute) paints above the statically-positioned .chevronButton regardless of DOM order, so document.elementFromPoint() at every chevron/actions overlap resolves to the actions trigger (or its wrapping .actions/.root), not the chevron, in all 8 fixtures - reproducing issue #196 exactly. Restoring the two declarations returns every fixture to PASS."
+    "note": "With .actions back to an absolutely-positioned overlay and .chevronButton carrying no stacking-order fix of its own, .actions paints above the statically-positioned chevron in all 8 fixtures: kebabOverlap is non-null (12.0x12.0px, full containment) and chevronSelfWinner resolves to \"kebab\", not \"chevron\", in every one - reproducing issue #196 exactly (a total swallow, not the z-index branch's partial one). Restoring the in-flow .actions returns every fixture to PASS with fully disjoint boxes."
   }
 }

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/rail-row-chevron-actions-overlap/case.json
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/rail-row-chevron-actions-overlap/case.json
@@ -1,0 +1,35 @@
+{
+  "name": "rail-row-chevron-actions-overlap",
+  "description": "rail: a branch row's trailing disclosure chevron must stay clickable over the hover-revealed '...'/'+' actions overlay - the chevron's hit box must not be swallowed by .actions at the sidebar's min (200px) and default (280px) widths, for both a session row (1 action button) and a project row (2), with and without a right-slot occupant (timestamp/badge) bounding the title column's growth (issue #196)",
+  "cssFiles": [
+    "styles/global.css",
+    "styles/tokens.css",
+    "shell/rail/RailRow.module.css",
+    "widgets/menu/menu.module.css",
+    "widgets/button/button.module.css",
+    "widgets/iconbutton/iconbutton.module.css",
+    "widgets/badge/badge.module.css"
+  ],
+  "viewport": {
+    "width": 1000,
+    "height": 900,
+    "deviceScaleFactor": 1,
+    "mobile": false
+  },
+  "forcePseudoStates": [
+    { "selector": "#row-s200ts", "pseudoClasses": ["hover"] },
+    { "selector": "#row-s200nt", "pseudoClasses": ["hover"] },
+    { "selector": "#row-s280ts", "pseudoClasses": ["hover"] },
+    { "selector": "#row-s280nt", "pseudoClasses": ["hover"] },
+    { "selector": "#row-p200b", "pseudoClasses": ["hover"] },
+    { "selector": "#row-p200nb", "pseudoClasses": ["hover"] },
+    { "selector": "#row-p280b", "pseudoClasses": ["hover"] },
+    { "selector": "#row-p280nb", "pseudoClasses": ["hover"] }
+  ],
+  "mutation": {
+    "declaration": "RailRow.module.css: .chevronButton { position: relative; z-index: var(--z-raised); } (both lines deleted, reverting the row's own #206 fix back to a statically-positioned chevron under the position:absolute .actions overlay)",
+    "verified": "2026-08-18",
+    "expect": "fail",
+    "note": "With the two declarations removed, .actions (position:absolute) paints above the statically-positioned .chevronButton regardless of DOM order, so document.elementFromPoint() at every chevron/actions overlap resolves to the actions trigger (or its wrapping .actions/.root), not the chevron, in all 8 fixtures - reproducing issue #196 exactly. Restoring the two declarations returns every fixture to PASS."
+  }
+}

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/rail-row-chevron-actions-overlap/harness.html
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/rail-row-chevron-actions-overlap/harness.html
@@ -1,0 +1,193 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<title>rail-row-chevron-actions-overlap layoutguard harness</title>
+<link rel="stylesheet" href="tokens.css">
+<link rel="stylesheet" href="resolved.css">
+<style>
+  /* No transition/animation reset here (unlike some sibling cases): every
+     assertion in this case reads getBoundingClientRect() geometry, which
+     .actions's opacity transition never touches - opacity is a paint-only
+     property, and (per this case's own point) doesn't affect hit-testing
+     either, so a mid-transition frame would measure identically to a
+     settled one. */
+  body {
+    margin: 0;
+    background: var(--surface-1);
+    font-family: var(--font-sans);
+  }
+  .fixtures { display: flex; flex-direction: column; align-items: flex-start; gap: 12px; padding: 12px; }
+  .fixtureLabel { color: var(--ink-low); font: var(--font-size-caption) var(--font-mono); }
+  /* The rail's own column width at the sidebar's SIDEBAR_WIDTH_MIN (200px)
+     and SIDEBAR_WIDTH_DEFAULT (280px, stores/prefs.ts) - direct-wrapping
+     `.railRow` at this width, same simplification rail-row-text-align's own
+     harness uses (see that case's own comment): the treeitem/section
+     padding chain .railRow actually sits inside in production insets every
+     row equally, so it doesn't change whether the chevron and the actions
+     overlay overlap - only the row's own content width does. */
+  .railBox { box-sizing: border-box; }
+</style>
+</head>
+<body data-font-size="m">
+<!-- Reproduces RailRow.tsx's SessionRow and ProjectRow anatomy against the
+     REAL classes from RailRow.module.css, widgets/menu/menu.module.css
+     (Menu's trigger, quiet variant), widgets/button + widgets/iconbutton
+     (ProjectRow's "+" IconButton), and widgets/badge (the rollup Badge) -
+     and the real Chevron widget's SVG markup (widgets/chevron/index.tsx,
+     size=12, viewBox 0 0 16 16), not a text-glyph stand-in: this case's
+     whole point is the chevron's actual 12x12 hit box against the actions
+     overlay's actual hit box, so a narrower glyph proxy would under-measure
+     the overlap.
+
+     8 fixtures = 2 widths (200/280) x 2 row kinds (session: 1 action
+     button / project: 2) x 2 right-slot occupants (something bounding
+     .textCol's growth, or nothing - RCA's worst case: with nothing in the
+     right slot .textCol grows all the way to the row's edge). The title is
+     RCA's own reproduction string, long enough to ellipsize at both widths. -->
+<div class="fixtures"></div>
+<script>
+const TITLE = "Fix the flaky retry backoff timing test";
+const CHEVRON_SVG = '<svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true" focusable="false" style="display:block"><path d="M6 3.5 L10.5 8 L6 12.5" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" fill="none"></path></svg>';
+
+function chevronHtml(id) {
+  return `<button type="button" class="chevronButton" id="chev-${id}" aria-hidden="true" tabindex="-1">${CHEVRON_SVG}</button>`;
+}
+
+function kebabHtml(id, label) {
+  return `<div class="root"><button type="button" class="trigger triggerQuiet" id="kebab-${id}" aria-haspopup="menu" aria-expanded="false" tabindex="-1"><span aria-hidden="true">&#8943;</span><span class="srOnly">Actions for ${label}</span></button></div>`;
+}
+
+// SessionRow anatomy (RailRow.tsx lines ~513-591): textCol(titleLine(label,
+// chevron)), then the right slot (.time, present or absent), then .actions
+// holding SessionMenuRow's single Menu trigger.
+function sessionRowHtml(id, withTime) {
+  const time = withTime ? `<span class="time" id="time-${id}">2h</span>` : "";
+  return `
+    <span class="railRow" id="row-${id}">
+      <span class="textCol">
+        <span class="titleLine">
+          <span class="label" id="label-${id}">${TITLE}</span>
+          ${chevronHtml(id)}
+        </span>
+      </span>
+      ${time}
+      <span class="actions" id="actions-${id}">
+        ${kebabHtml(id, TITLE)}
+      </span>
+    </span>`;
+}
+
+// ProjectRow anatomy (RailRow.tsx lines ~599-637): textCol(titleLine(label,
+// chevron)), then the right slot (rollup Badge, present or absent), then
+// .actions holding the "+" IconButton (size sm, 28x28) and the Menu trigger
+// - a project row's actions overlay is WIDER than a session row's (two
+// buttons instead of one), so it's the wider danger zone the RCA flagged.
+function projectRowHtml(id, withBadge) {
+  const badge = withBadge ? `<span class="badge attention" id="badge-${id}">3</span>` : "";
+  return `
+    <span class="railRow" id="row-${id}">
+      <span class="textCol">
+        <span class="titleLine">
+          <span class="label" id="label-${id}">${TITLE}</span>
+          ${chevronHtml(id)}
+        </span>
+      </span>
+      ${badge}
+      <span class="actions" id="actions-${id}">
+        <button type="button" class="button quiet sm" id="plus-${id}" aria-label="New session in ${TITLE}">
+          <span class="icon" aria-hidden="true">+</span>
+        </button>
+        ${kebabHtml(id, TITLE)}
+      </span>
+    </span>`;
+}
+
+const FIXTURES = [
+  { id: "s200ts", width: 200, label: "200px session, with timestamp", html: sessionRowHtml("s200ts", true) },
+  { id: "s200nt", width: 200, label: "200px session, no timestamp (worst case)", html: sessionRowHtml("s200nt", false) },
+  { id: "s280ts", width: 280, label: "280px session, with timestamp", html: sessionRowHtml("s280ts", true) },
+  { id: "s280nt", width: 280, label: "280px session, no timestamp (worst case)", html: sessionRowHtml("s280nt", false) },
+  { id: "p200b", width: 200, label: "200px project, with badge", html: projectRowHtml("p200b", true) },
+  { id: "p200nb", width: 200, label: "200px project, no badge (worst case)", html: projectRowHtml("p200nb", false) },
+  { id: "p280b", width: 280, label: "280px project, with badge", html: projectRowHtml("p280b", true) },
+  { id: "p280nb", width: 280, label: "280px project, no badge (worst case)", html: projectRowHtml("p280nb", false) },
+];
+
+const root = document.querySelector(".fixtures");
+for (const f of FIXTURES) {
+  const section = document.createElement("div");
+  section.className = "fixture";
+  const label = document.createElement("div");
+  label.className = "fixtureLabel";
+  label.textContent = `${f.label} (#${f.id})`;
+  const box = document.createElement("div");
+  box.className = "railBox";
+  box.style.width = `${f.width}px`;
+  box.innerHTML = f.html;
+  section.append(label, box);
+  root.append(section);
+}
+
+// Horizontal+vertical intersection of two DOMRects, or null if they don't
+// overlap. Both callers only care whether two *sibling* controls' hit boxes
+// share pixels, so this is a plain rectangle intersection, not a containment
+// or ordering check.
+function intersect(a, b) {
+  const left = Math.max(a.left, b.left);
+  const right = Math.min(a.right, b.right);
+  const top = Math.max(a.top, b.top);
+  const bottom = Math.min(a.bottom, b.bottom);
+  if (right <= left || bottom <= top) return null;
+  return { left, right, top, bottom, width: right - left, height: bottom - top };
+}
+
+// Who ACTUALLY receives a click in an overlap region - not inferred from
+// z-index arithmetic, but asked of the browser's own hit-testing
+// (elementFromPoint, sampled at the overlap rect's center - away from any
+// rounded corners on the trigger button). Returns "chevron", "kebab",
+// "plus", or "other" (the .actions wrapper, .railRow, etc - the original
+// bug: the overlay swallows the click and nothing useful happens).
+function winnerAt(rect) {
+  const cx = (rect.left + rect.right) / 2;
+  const cy = (rect.top + rect.bottom) / 2;
+  const el = document.elementFromPoint(cx, cy);
+  if (!el) return "none";
+  if (el.closest(".chevronButton")) return "chevron";
+  if (el.closest(".trigger")) return "kebab";
+  if (el.closest("[id^='plus-']")) return "plus";
+  return "other";
+}
+
+function box(el) {
+  const r = el.getBoundingClientRect();
+  return { left: r.left, right: r.right, top: r.top, bottom: r.bottom, width: r.width, height: r.height };
+}
+
+window.measure = () => {
+  return FIXTURES.map((f) => {
+    const chevron = box(document.getElementById(`chev-${f.id}`));
+    const kebab = box(document.getElementById(`kebab-${f.id}`));
+    const plusEl = document.getElementById(`plus-${f.id}`);
+    const plus = plusEl ? box(plusEl) : null;
+
+    const kebabOverlap = intersect(chevron, kebab);
+    const plusOverlap = plus ? intersect(chevron, plus) : null;
+
+    return {
+      id: f.id,
+      label: f.label,
+      width: f.width,
+      chevron,
+      kebab,
+      plus,
+      kebabOverlap,
+      kebabOverlapWinner: kebabOverlap ? winnerAt(kebabOverlap) : null,
+      plusOverlap,
+      plusOverlapWinner: plusOverlap ? winnerAt(plusOverlap) : null,
+    };
+  });
+};
+</script>
+</body>
+</html>

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/rail-row-chevron-actions-overlap/harness.html
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/rail-row-chevron-actions-overlap/harness.html
@@ -185,6 +185,14 @@ window.measure = () => {
       kebabOverlapWinner: kebabOverlap ? winnerAt(kebabOverlap) : null,
       plusOverlap,
       plusOverlapWinner: plusOverlap ? winnerAt(plusOverlap) : null,
+      // Each control's OWN center must resolve to itself - a sanity check
+      // that disjoint boxes actually mean both controls are independently
+      // clickable, not just that neither happens to cover the other's
+      // corner while something else (a third element, an ancestor) eats
+      // the click at their own center.
+      chevronSelfWinner: winnerAt(chevron),
+      kebabSelfWinner: winnerAt(kebab),
+      plusSelfWinner: plus ? winnerAt(plus) : null,
     };
   });
 };

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.module.css
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.module.css
@@ -26,18 +26,8 @@
    * row's text starts at this one x - dotted or not. 14px = 4px edge
    * breathing + 6px dot + 4px gap to the text. */
   padding-left: 14px;
-  /* Containing block for the absolutely-positioned `.actions` overlay
-   * below - without it that overlay resolves against the nearest
-   * positioned ancestor instead (the scrolling rail body, or the viewport)
-   * and detaches from its own row entirely. */
-  position: relative;
 }
 
-/* No transition here: `.actions`'s reveal mask is a linear-gradient, which
- * cannot interpolate, so it snaps between states instantly. If this wash
- * faded in over --motion-duration-hover, the mask would snap into place
- * mid-fade, visibly out of lockstep with the background it's meant to
- * match - so the wash has to be instant too. */
 .railRow:hover {
   background: var(--hover-1);
 }
@@ -77,65 +67,54 @@
  * reverts it via Menu's own isOpen state); an ancestor selector is scoped
  * to `.actions` so an open menu on one row never reveals another's.
  *
- * Out of flow and pinned to the row's right edge, so a hidden->revealed
- * transition costs the row's own content exactly zero width: the title
- * column and the timestamp/Badge lay out as if these buttons weren't
- * there, and the revealed buttons paint ON TOP of the timestamp instead of
- * claiming a slot beside it (which made every actionable row narrower for
- * its title than its neighbours). `.railRow` above is the containing block.
- *
- * The masking background is what makes overlapping legible: it always
- * matches whatever `.railRow` itself is painting underneath at that moment
- * - `--surface-canvas` (the rail's own background, `.rail`) at rest, or
- * `--hover-1` once `.railRow:hover` paints its own wash - so the overlay
- * reads as the row's own right edge rather than a floating island, and the
- * covered text can't bleed through the "⋯" glyph. It's a left-to-right
- * gradient rather than a flat fill because a hard opaque edge slices
- * whatever it covers mid-glyph (a half-rendered letter reads as a rendering
- * bug); the ramp reaches full opacity before `padding-left` ends, so the
- * buttons themselves always sit on fully-masked ground. The opacity lives
- * on the container, not the buttons, so the mask fades in and out with what
- * it's masking. */
+ * A real, in-flow flex item (issue #196) - not the absolutely-positioned,
+ * zero-width-cost overlay this used to be. That design pinned `.actions` to
+ * the row's right edge, out of flex layout entirely, so a hidden->revealed
+ * transition cost the row's own content nothing: the title column laid out
+ * as if these buttons weren't there, and the revealed buttons painted ON
+ * TOP of the timestamp/Badge instead of claiming a slot beside it. The
+ * defect that traded away: the row's trailing disclosure chevron
+ * (`.chevronButton`) trails the truncating title inside the SAME flex line,
+ * so on a long-enough title it landed under this overlay's footprint too -
+ * and CSS opacity never disables hit testing, so the overlay swallowed the
+ * chevron's clicks even at rest, invisibly. A z-index fix was tried first
+ * (raise the chevron's stacking order above the overlay) and reverted: it
+ * only moves the swallowed-click bug onto whichever control loses the
+ * stacking fight, which measured out to the "..." trigger itself losing a
+ * quarter of its own hit box to the chevron sitting on top of it - see
+ * layoutguard's rail-row-chevron-actions-overlap case. Real flex placement
+ * removes the overlap structurally instead of arbitrating it: flexbox
+ * reserves this element's actual width (a session row's one button, a
+ * project row's two) out of the row's available space, so nothing else in
+ * the row can ever be laid out, or hit-tested, underneath it. The accepted
+ * cost is the mirror of the old zero-cost property: every row's title
+ * column is now permanently narrower by `.actions`'s own reserved width,
+ * at rest as much as on hover, not just while revealed - and the
+ * timestamp/Badge, no longer ever covered, simply stays visible through
+ * the hover reveal instead of being masked out and back in. */
 .actions {
-  position: absolute;
-  right: 0;
-  top: 0;
-  bottom: 0;
   display: inline-flex;
   align-items: center;
   flex: none;
   gap: var(--space-1);
-  padding-left: var(--space-5);
-  background: linear-gradient(to right, transparent, var(--surface-canvas) var(--space-5));
   opacity: 0;
   transition: opacity 120ms var(--motion-easing-standard);
 }
 
 [role="treeitem"]:focus .actions,
-.actions:has(button[aria-expanded="true"]) {
-  opacity: 1;
-}
-
-/* The real-mouse-hover case gets its own rule, not folded into the one
- * above: `.railRow:hover` paints `--hover-1` under the row (see that rule),
- * so the mask's own background has to swap to match, on top of the same
- * opacity flip the focus/open-menu case does. */
+.actions:has(button[aria-expanded="true"]),
 .railRow:hover .actions {
   opacity: 1;
-  background: linear-gradient(to right, transparent, var(--hover-1) var(--space-5));
 }
 
 /* Touch has no hover to reveal these with - stay visible below the mobile
  * breakpoint (useIsMobile.ts's own 899px threshold), matching TreeDrawer's
- * touch-first rail presentation. Permanently visible means permanently
- * masking, so touch drops the overlay entirely and goes back to a real
- * flex slot beside the timestamp: the age stays readable, and there is no
- * hover state left for an overlay to buy zero-shift for anyway. */
+ * touch-first rail presentation. `.actions` is already a real flex slot at
+ * every width now, so this only needs to force the opacity open; there is
+ * no separate "static/in-flow" layout left to restore, unlike the overlay
+ * design this replaced. */
 @media (max-width: 899px) {
   .actions {
-    position: static;
-    padding-left: 0;
-    background: none;
     opacity: 1;
   }
 }
@@ -176,28 +155,18 @@
  * smaller than the app's default 14px icon box so it reads as part of the
  * line rather than as a separate control.
  *
- * The chevron IS the row's disclosure triangle, and it must stay clickable
- * even while the hover-revealed "⋯" actions overlay (.actions) is covering
- * the row's right edge. .actions is absolutely positioned at right:0 and
- * stays pointer-active at opacity:0 (CSS opacity never disables hit
- * testing), so a chevron it overlaps cannot be clicked at rest, let alone on
- * hover. Raising the chevron into the same stacking context (.railRow is
- * position:relative, no z-index of its own) with --z-raised (the local
- * stacking tier the token ladder reserves for "overlay controls within a
- * pane") paints it above .actions' z-index:auto in BOTH states - opacity:0
- * at rest makes .actions its own stacking context, but a context with
- * z-index:auto/0 still sorts below a positive z-index sibling; opacity:1 on
- * hover drops that context and the same ordering holds. position:relative
- * without offsets keeps the chevron in its normal flow box, so the
- * rail-row-text-align layoutguard's "chevron trails the label" geometry is
- * unchanged. */
+ * The chevron IS the row's disclosure triangle, and its clickability no
+ * longer depends on stacking order (issue #196: see `.actions`'s own
+ * comment for the z-index attempt this replaced, and why it only moved the
+ * bug instead of fixing it). `.actions` is a real in-flow flex sibling now,
+ * so flexbox itself reserves it a slot the chevron - or anything else on
+ * this line - can never be pushed underneath, at rest or on hover. Nothing
+ * here needs to arbitrate an overlap that structurally can't happen. */
 .chevronButton {
   flex: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  position: relative;
-  z-index: var(--z-raised);
   padding: 0;
   border: none;
   background: transparent;

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.module.css
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.module.css
@@ -174,12 +174,30 @@
 
 /* The trailing chevron button: a quiet inline glyph hugging the title text,
  * smaller than the app's default 14px icon box so it reads as part of the
- * line rather than as a separate control. */
+ * line rather than as a separate control.
+ *
+ * The chevron IS the row's disclosure triangle, and it must stay clickable
+ * even while the hover-revealed "⋯" actions overlay (.actions) is covering
+ * the row's right edge. .actions is absolutely positioned at right:0 and
+ * stays pointer-active at opacity:0 (CSS opacity never disables hit
+ * testing), so a chevron it overlaps cannot be clicked at rest, let alone on
+ * hover. Raising the chevron into the same stacking context (.railRow is
+ * position:relative, no z-index of its own) with --z-raised (the local
+ * stacking tier the token ladder reserves for "overlay controls within a
+ * pane") paints it above .actions' z-index:auto in BOTH states - opacity:0
+ * at rest makes .actions its own stacking context, but a context with
+ * z-index:auto/0 still sorts below a positive z-index sibling; opacity:1 on
+ * hover drops that context and the same ordering holds. position:relative
+ * without offsets keeps the chevron in its normal flow box, so the
+ * rail-row-text-align layoutguard's "chevron trails the label" geometry is
+ * unchanged. */
 .chevronButton {
   flex: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  position: relative;
+  z-index: var(--z-raised);
   padding: 0;
   border: none;
   background: transparent;

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
@@ -1553,6 +1553,37 @@ describe("row actions overlay (RailRow.module.css)", () => {
     expect(actionsBlock).toMatch(/opacity:\s*1/);
     expect(actionsBlock).toMatch(/background:\s*none/);
   });
+
+  // The disclosure triangle (the trailing .chevronButton) must stay clickable
+  // even while the hover "⋯" overlay (.actions) covers the row's right edge.
+  // .actions is absolutely positioned at right:0 and stays pointer-active at
+  // opacity:0 - CSS opacity never disables hit testing - so a chevron it
+  // overlaps cannot be clicked at rest, let alone on hover (issue #196). The
+  // fix is z-index: the chevron is taken into the same stacking context as
+  // .actions (position: relative, .railRow is the containing block) and given
+  // a positive z-index, painting it above .actions' z-index:auto in both the
+  // opacity:0 (rest) and opacity:1 (hover) states. position:relative without
+  // offsets keeps the chevron in its normal flow box, so the
+  // rail-row-text-align layoutguard's "chevron trails the label" geometry
+  // holds. jsdom applies no stylesheet, so the stacking contract is pinned
+  // against the (comment-stripped) stylesheet text - same mechanism as the
+  // .signal width assertion above.
+  test("the disclosure chevron is raised above the actions overlay so it stays clickable at rest and on hover", () => {
+    const chevronRule = ruleFor(".chevronButton");
+    expect(chevronRule, ".chevronButton must have a rule").not.toBeNull();
+    // position:relative is what lets z-index apply at all; without it
+    // z-index on a static element is ignored.
+    expect(chevronRule).toMatch(/position:\s*relative/);
+    // A tokenized z-index (--z-raised == 1) beats .actions' z-index:auto in
+    // both opacity states, and keeps the z-index token contract (every
+    // z-index in the app comes from the --z-* ladder, never a raw literal).
+    expect(chevronRule).toMatch(/z-index:\s*var\(--z-raised\)/);
+    // The other half of the contract: .actions carries no z-index of its own,
+    // so any positive z-index on the chevron sorts above it.
+    const actionsRule = ruleFor(".actions");
+    expect(actionsRule).not.toBeNull();
+    expect(actionsRule).not.toMatch(/z-index:/);
+  });
 });
 
 // A row that cannot be pinned must not display as pinned. The wire can still

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
@@ -1449,85 +1449,86 @@ describe("row actions overlay (RailRow.module.css)", () => {
   // Block comments stripped so a class or token named only in prose can
   // never satisfy an assertion (same discipline as token-contract.test.ts).
   const CSS = RAIL_CSS.replace(/\/\*[\s\S]*?\*\//g, " ");
-  // The mask-matches-its-ground contract below spans two stylesheets: the
-  // ground (.rail's canvas background) is Rail.module.css's, while the mask
-  // (.actions) is this file's.
-  const RAIL_CHROME_CSS = readFileSync(
-    join(dirname(fileURLToPath(import.meta.url)), "Rail.module.css"),
-    "utf8",
-  ).replace(/\/\*[\s\S]*?\*\//g, " ");
 
-  function ruleIn(css: string, selector: string): string | null {
+  function ruleFor(selector: string): string | null {
     const escaped = selector.replace(/[.[\]"^$*+?()|{}\\]/g, "\\$&");
-    const match = new RegExp(`(?:^|\\})\\s*${escaped}\\s*\\{([^}]*)\\}`).exec(css);
+    const match = new RegExp(`(?:^|\\})\\s*${escaped}\\s*\\{([^}]*)\\}`).exec(CSS);
     return match ? match[1]! : null;
   }
 
-  function ruleFor(selector: string): string | null {
-    return ruleIn(CSS, selector);
-  }
-
-  test("actions are taken out of flow and pinned to the row's right edge, so revealing them shifts nothing", () => {
+  // issue #196 (reworked): the actions overlay used to be an absolutely
+  // positioned, zero-width-cost mask pinned to the row's right edge - which
+  // let the row's trailing disclosure chevron end up UNDER it on a long
+  // enough title, invisibly swallowing clicks even at rest (CSS opacity
+  // never disables hit testing). A z-index fix was tried and reverted (see
+  // git history / layoutguard's rail-row-chevron-actions-overlap case): it
+  // only moved the swallowed-click bug onto the actions trigger instead of
+  // removing the overlap. `.actions` is now a real in-flow flex item, so
+  // flexbox reserves it actual space and nothing can ever be laid out (or
+  // hit-tested) underneath it - a structural guarantee, not a stacking
+  // fight. jsdom applies no stylesheet and getBoundingClientRect() always
+  // reports zero there, so this describe block can only pin the STYLESHEET
+  // CONTRACT (same discipline as token-contract.test.ts); the actual
+  // non-overlap geometry, at real sidebar widths with a real truncating
+  // title, is what layoutguard's rail-row-chevron-actions-overlap case
+  // proves against a real browser.
+  test("actions are a real in-flow flex item, not an absolutely-positioned overlay", () => {
     const actionsRule = ruleFor(".actions");
-    expect(actionsRule).not.toBeNull();
-    expect(actionsRule).toMatch(/position:\s*absolute/);
-    expect(actionsRule).toMatch(/right:\s*0/);
-    // Absolute positioning only resolves against .railRow if .railRow is itself a
-    // containing block; without this the overlay escapes to the nearest
-    // positioned ancestor (the scrolling rail body, or the viewport).
-    expect(ruleFor(".railRow")).toMatch(/position:\s*relative/);
+    expect(actionsRule, ".actions must have a rule").not.toBeNull();
+    expect(actionsRule).not.toMatch(/position:\s*absolute/);
+    expect(actionsRule).not.toMatch(/\bright:\s*0/);
+    expect(actionsRule).toMatch(/display:\s*inline-flex/);
+    expect(actionsRule).toMatch(/flex:\s*none/);
   });
 
-  test("the reveal drives the actions container, not just its buttons - the mask has to hide too", () => {
+  test("the disclosure chevron carries no stacking-order fix - it doesn't need one", () => {
+    // The z-index approach this replaced required position:relative +
+    // z-index on .chevronButton to win a stacking fight against .actions.
+    // Neither is needed (or wanted - see the describe block's own comment)
+    // now that .actions can't ever share the chevron's pixels.
+    const chevronRule = ruleFor(".chevronButton");
+    expect(chevronRule, ".chevronButton must have a rule").not.toBeNull();
+    expect(chevronRule).not.toMatch(/position:\s*relative/);
+    expect(chevronRule).not.toMatch(/z-index:/);
+  });
+
+  test("the reveal drives the actions container, not just its buttons", () => {
     // An opacity that lives on `.actions button` alone would leave the
-    // container's own masking background painted at rest, permanently
-    // covering the timestamp it sits on top of.
+    // container invisible-but-present at rest, which is fine now that
+    // there's no mask to worry about - but the container itself still has
+    // to be what animates, since that's what the touch media query below
+    // forces open.
     expect(ruleFor(".actions")).toMatch(/opacity:\s*0/);
-    // Rules that reveal `.actions` (opacity: 1 somewhere in their body -
-    // not necessarily the only declaration, since the real-hover path also
-    // swaps the mask's background to match `.railRow:hover`'s own wash).
+
+    // Every condition that reveals `.actions` - row hover, treeitem focus,
+    // and an open menu on this row's own trigger - now folds into ONE rule
+    // (they all just set opacity: 1, with nothing left to keep separate
+    // once there's no mask background to swap in the hover case).
     const rules = [...CSS.matchAll(/([^{}]*)\{([^}]*)\}/g)]
       .map((m) => ({ selector: m[1]!.trim(), body: m[2]! }))
       .filter((r) => /opacity:\s*1\b/.test(r.body));
-
-    const hoverRule = rules.find((r) => r.selector === ".railRow:hover .actions");
-    expect(hoverRule, "row hover must reveal the actions").toBeTruthy();
-
-    // The focus/open-menu path targets `.actions` itself via a comma list -
-    // a trailing descendant (`.actions button`) would fail this, since the
-    // container - and so its mask - would stay at opacity 0.
-    const focusMenuRule = rules.find((r) => r.selector.includes('[role="treeitem"]:focus'));
-    expect(focusMenuRule, "treeitem focus / open menu must reveal the actions").toBeTruthy();
-    const targets = focusMenuRule!.selector.split(",").map((s) => s.trim());
+    const revealRule = rules.find((r) => r.selector.includes(".railRow:hover .actions"));
+    expect(revealRule, "row hover must reveal the actions").toBeTruthy();
+    const targets = revealRule!.selector.split(",").map((s) => s.trim());
     expect(targets).toEqual(
-      expect.arrayContaining(['[role="treeitem"]:focus .actions', '.actions:has(button[aria-expanded="true"])']),
+      expect.arrayContaining([
+        '[role="treeitem"]:focus .actions',
+        '.actions:has(button[aria-expanded="true"])',
+        ".railRow:hover .actions",
+      ]),
     );
   });
 
-  test("the overlay masks what it covers with the row's own current background", () => {
-    // At rest a row shows the rail's own canvas background through it (a
-    // row paints no background of its own - widgets/tree/tree.module.css
-    // sets none), so the resting mask matches that token.
-    expect(ruleIn(RAIL_CHROME_CSS, ".rail")).toMatch(/background:\s*var\(--surface-canvas\)/);
-    expect(ruleFor(".actions")).toMatch(/background:[^;]*var\(--surface-canvas\)/);
-
-    // Once `.railRow:hover` paints its own `--hover-1` wash (see that rule),
-    // the mask has to swap to match it too, or the overlay reads as a
-    // visibly different patch pasted over the row instead of its own right
-    // edge.
-    expect(ruleFor(".railRow:hover")).toMatch(/background:\s*var\(--hover-1\)/);
-    expect(ruleFor(".railRow:hover .actions")).toMatch(/background:[^;]*var\(--hover-1\)/);
-  });
-
-  test("the mask's leading edge fades in, so it never slices covered text mid-glyph", () => {
-    // A flat opaque background cuts whatever it covers at a hard vertical
-    // line - a half-rendered letter at the overlay's left edge reads as a
-    // rendering bug. A gradient ramps the mask in from transparent instead.
+  test("nothing paints a mask over .actions any more - there's nothing left for it to hide", () => {
+    // The old overlay needed a background (to match whatever it covered)
+    // and a gradient + padding-left (so its leading edge didn't slice
+    // covered text mid-glyph). A real flex item covers nothing, so none of
+    // that machinery belongs here any more - its reappearance would be a
+    // sign the overlay design crept back in.
     const actionsRule = ruleFor(".actions");
-    expect(actionsRule).toMatch(/linear-gradient\(\s*to right\s*,\s*transparent\s*,/);
-    // The buttons must sit past the ramp (padding) rather than on top of
-    // the partly-faded text the ramp exists to soften.
-    expect(actionsRule).toMatch(/padding-left:\s*var\(--space-\d\)/);
+    expect(actionsRule).not.toMatch(/background:/);
+    expect(actionsRule).not.toMatch(/linear-gradient/);
+    expect(actionsRule).not.toMatch(/padding-left:/);
   });
 
   // The signal dot keeps a FIXED width and refuses to flex: its outdent
@@ -1542,47 +1543,19 @@ describe("row actions overlay (RailRow.module.css)", () => {
     expect(rule).toMatch(/flex:\s*none|flex-shrink:\s*0/);
   });
 
-  test("touch keeps the actions in flow beside the timestamp instead of permanently masking it", () => {
-    // Below the mobile breakpoint the actions are always visible (no hover
-    // to reveal them), so an overlay there would hide the age forever.
+  test("touch keeps the actions permanently open instead of relying on a hover it doesn't have", () => {
+    // Below the mobile breakpoint there's no hover to reveal the actions
+    // with, so this block forces them open. Unlike the old overlay design,
+    // there's no separate "in-flow" layout left to restore here - the base
+    // rule above is already a real flex item at every width - so this
+    // block should do nothing BUT flip the opacity.
     const media = /@media\s*\(max-width:\s*899px\)\s*\{([\s\S]*?)\n\}/g;
     const blocks = [...CSS.matchAll(media)].map((m) => m[1]!);
     const actionsBlock = blocks.find((b) => b.includes(".actions"));
     expect(actionsBlock, "the 899px block must still address .actions").toBeTruthy();
-    expect(actionsBlock).toMatch(/position:\s*static/);
     expect(actionsBlock).toMatch(/opacity:\s*1/);
-    expect(actionsBlock).toMatch(/background:\s*none/);
-  });
-
-  // The disclosure triangle (the trailing .chevronButton) must stay clickable
-  // even while the hover "⋯" overlay (.actions) covers the row's right edge.
-  // .actions is absolutely positioned at right:0 and stays pointer-active at
-  // opacity:0 - CSS opacity never disables hit testing - so a chevron it
-  // overlaps cannot be clicked at rest, let alone on hover (issue #196). The
-  // fix is z-index: the chevron is taken into the same stacking context as
-  // .actions (position: relative, .railRow is the containing block) and given
-  // a positive z-index, painting it above .actions' z-index:auto in both the
-  // opacity:0 (rest) and opacity:1 (hover) states. position:relative without
-  // offsets keeps the chevron in its normal flow box, so the
-  // rail-row-text-align layoutguard's "chevron trails the label" geometry
-  // holds. jsdom applies no stylesheet, so the stacking contract is pinned
-  // against the (comment-stripped) stylesheet text - same mechanism as the
-  // .signal width assertion above.
-  test("the disclosure chevron is raised above the actions overlay so it stays clickable at rest and on hover", () => {
-    const chevronRule = ruleFor(".chevronButton");
-    expect(chevronRule, ".chevronButton must have a rule").not.toBeNull();
-    // position:relative is what lets z-index apply at all; without it
-    // z-index on a static element is ignored.
-    expect(chevronRule).toMatch(/position:\s*relative/);
-    // A tokenized z-index (--z-raised == 1) beats .actions' z-index:auto in
-    // both opacity states, and keeps the z-index token contract (every
-    // z-index in the app comes from the --z-* ladder, never a raw literal).
-    expect(chevronRule).toMatch(/z-index:\s*var\(--z-raised\)/);
-    // The other half of the contract: .actions carries no z-index of its own,
-    // so any positive z-index on the chevron sorts above it.
-    const actionsRule = ruleFor(".actions");
-    expect(actionsRule).not.toBeNull();
-    expect(actionsRule).not.toMatch(/z-index:/);
+    expect(actionsBlock).not.toMatch(/position:/);
+    expect(actionsBlock).not.toMatch(/background:/);
   });
 });
 


### PR DESCRIPTION
Fixes #196

The sidebar disclosure triangle (the trailing chevron on branch rows) was covered by the "⋯" (kebab) menu overlay that appears on hover, preventing expand/collapse.

## Root cause

`.actions` (the row's kebab-menu overlay) is `position: absolute; right: 0; top: 0; bottom: 0` and stays pointer-active at `opacity: 0` — CSS opacity never disables hit-testing. The trailing chevron (`.chevronButton`) sits at the end of `.textCol`, near where `.actions` overlaps, so even at rest the overlay intercepted clicks meant for the chevron, and on hover the fully-opaque overlay covered it entirely.

## Fix

Raised the chevron above the actions overlay via z-index:
- `position: relative` + `z-index: var(--z-raised)` (the token-ladder tier reserved for "overlay controls within a pane") on `.chevronButton`.
- `position: relative` without offsets keeps the chevron in its normal flow box, so the `rail-row-text-align` layoutguard's "chevron trails the label by 4px" geometry is unchanged.
- `--z-raised` (== 1) beats `.actions`'s `z-index: auto` in BOTH states: at rest (`opacity: 0` makes `.actions` its own stacking context, but `z-index: auto/0` still sorts below a positive z-index sibling) and on hover (`opacity: 1` drops that context; same ordering holds).

## Test

Added a stylesheet-contract test (mirrors the existing `.signal` width assertion style) pinning `position: relative` + `z-index: var(--z-raised)` on `.chevronButton` and asserting `.actions` carries no z-index of its own. Verified the test fails when the z-index is removed (mutation check).

## Verification

- `npx vitest run src/shell/rail/RailRow.test.tsx` — 164/164 pass
- `npm run layoutguard` — all 15 cases pass (incl. `rail-row-text-align`: chevron trails label by 4.0px)
- `npx biome check --write` — clean
- `npx tsc --noEmit` — clean