### PR TITLE
test(agent): assert conforming event observed in ToolNameMapping_EventsUseCanonicalName

### DIFF
--- a/agent/session_dod_definition_test.go
+++ b/agent/session_dod_definition_test.go
@@ -2818,6 +2818,7 @@ func TestSession_ToolNameMapping_EventsUseCanonicalName(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
+	sawCanonical := false
 	for _, ev := range evs {
 		var name string
 		switch d := ev.Data.(type) {
@@ -2834,6 +2835,10 @@ func TestSession_ToolNameMapping_EventsUseCanonicalName(t *testing.T) {
 		if name != "grep" {
 			continue // other tools (from other events)
 		}
+		sawCanonical = true
+	}
+	if !sawCanonical {
+		t.Fatal("expected at least one event with canonical tool name 'grep', but none was observed (canonicalization may have returned an empty string on miss)")
 	}
 }
 


### PR DESCRIPTION
Fixes #165

The test passed vacuously: the loop only t.Fatal'd on the literal wrong value (grep_files) and continued everything else, so zero conforming events went green. Added a post-loop assertion that at least one grep-named event was observed, so a mutation returning empty on miss now turns the test red.