### PR TITLE
fix(agent): park pending user steering behind SteeringHeld gate on Stop

### DIFF
--- a/agent/doctor/mutations.go
+++ b/agent/doctor/mutations.go
@@ -33,11 +33,11 @@ type MutationReport struct {
 	InputQueue    []QueuedInputView    `json:"input_queue"`
 	// QueueHeld reports a queue parked by a Stop: the entries above are real and
 	// nothing will claim them until the user asks (kata wms7).
-	QueueHeld         bool                   `json:"queue_held"`
+	QueueHeld bool `json:"queue_held"`
 	// SteeringHeld reports pending user steering parked by a Stop: the steer
 	// stays in pending executions and nothing delivers it until the user asks
 	// (issue #174, #146 Option C — park in place).
-	SteeringHeld       bool                   `json:"steering_held"`
+	SteeringHeld      bool                   `json:"steering_held"`
 	PendingExecutions []PendingExecutionView `json:"pending_executions"`
 }
 

--- a/agent/doctor/mutations.go
+++ b/agent/doctor/mutations.go
@@ -34,6 +34,10 @@ type MutationReport struct {
 	// QueueHeld reports a queue parked by a Stop: the entries above are real and
 	// nothing will claim them until the user asks (kata wms7).
 	QueueHeld         bool                   `json:"queue_held"`
+	// SteeringHeld reports pending user steering parked by a Stop: the steer
+	// stays in pending executions and nothing delivers it until the user asks
+	// (issue #174, #146 Option C — park in place).
+	SteeringHeld       bool                   `json:"steering_held"`
 	PendingExecutions []PendingExecutionView `json:"pending_executions"`
 }
 
@@ -99,6 +103,7 @@ func Mutations(stateBase, selector string) (MutationReport, error) {
 	report.AcceptedTurns = store.AcceptedTurns
 	report.QueueRevision = store.QueueRevision
 	report.QueueHeld = store.QueueHeld
+	report.SteeringHeld = store.SteeringHeld
 	for _, record := range store.Journal {
 		view := MutationRecordView{
 			ClientMutationID: record.ClientMutationID,
@@ -155,6 +160,7 @@ type clientMutationStoreFile struct {
 	Journal                map[string]clientMutationStoreRecord  `json:"journal"`
 	InputQueue             []clientMutationStoreQueueEntry       `json:"input_queue"`
 	QueueHeld              bool                                  `json:"queue_held"`
+	SteeringHeld           bool                                  `json:"steering_held"`
 	QueueRevision          uint64                                `json:"queue_revision"`
 	NextTurnSequence       uint64                                `json:"next_turn_sequence"`
 	NextQueueEntrySequence uint64                                `json:"next_queue_entry_sequence"`
@@ -283,6 +289,9 @@ func RenderMutations(r MutationReport) string {
 	}
 	if r.QueueHeld {
 		fmt.Fprintf(&b, "queue: held (parked by a Stop; waiting on the user)\n")
+	}
+	if r.SteeringHeld {
+		fmt.Fprintf(&b, "steering: held (parked by a Stop; waiting on the user)\n")
 	}
 
 	fmt.Fprintf(&b, "pending executions: %d\n", len(r.PendingExecutions))

--- a/agent/doctor/mutations_test.go
+++ b/agent/doctor/mutations_test.go
@@ -15,6 +15,7 @@ const storeWithBothOutcomes = `{
   "active_turn_id": "01TURNSTART",
   "accepted_turns": 1,
   "queue_held": true,
+  "steering_held": true,
   "journal": {
     "cm-start": {
       "client_mutation_id": "cm-start",
@@ -280,6 +281,7 @@ func TestMutations_RenderCarriesTheDecisiveFields(t *testing.T) {
 		"input queue: 1 entry",
 		"q1  mutation=cm-queued  items=1",
 		"queue: held (parked by a Stop; waiting on the user)",
+		"steering: held (parked by a Stop; waiting on the user)",
 		"pending executions: 1",
 		"cm-start  method=turn/start  execution=running  turn=01TURNSTART  projection=pending",
 	} {

--- a/agent/session.go
+++ b/agent/session.go
@@ -798,7 +798,13 @@ func (s *Session) SetNotifyFunc(f func()) {
 	// during startup, before the user has said anything, and it is context for
 	// their first turn rather than work of its own -- so waking for it would
 	// start a turn nobody asked for, ahead of the opening prompt.
-	if pending || s.hasPendingUserSteering() || s.QueueDepth() > 0 || s.hasPendingDelegateDeliveries() || s.hasPendingRootDelegateAttention() || s.hasPendingStableDelegateAttention() || (s.jobManager != nil && s.jobManager.hasPendingStableWatchSettlementRetry()) {
+	//
+	// A steer parked by a Stop (SteeringHeld) is NOT counted: it is waiting on
+	// the user, not work in progress, and waking for it at attach would restart
+	// the session and deliver the steer the user just stopped -- the open
+	// steering rail issue #174 closes (issue #146, Option C — park in place).
+	steeringHeld := s.clientMutations != nil && s.clientMutations.steeringHeld()
+	if pending || (!steeringHeld && s.hasPendingUserSteering()) || s.QueueDepth() > 0 || s.hasPendingDelegateDeliveries() || s.hasPendingRootDelegateAttention() || s.hasPendingStableDelegateAttention() || (s.jobManager != nil && s.jobManager.hasPendingStableWatchSettlementRetry()) {
 		f()
 	}
 }

--- a/agent/session_client_mutation.go
+++ b/agent/session_client_mutation.go
@@ -184,6 +184,21 @@ type clientMutationSnapshot struct {
 	// review found it drifting on three of four writers, across restarts, and on
 	// a rejected promote.
 	QueueHeld              bool                                       `json:"queue_held,omitempty"`
+	// SteeringHeld parks pending user steering after a Stop, mirroring QueueHeld
+	// (issue #174): a Stop that lands at a turn boundary is Applied, and without
+	// this gate the still-OPEN steering rail restarts the session and delivers the
+	// steer to the model anyway. The steer never moves storage -- it stays in
+	// PendingExecutions/SteeringOrder where it already durably lives, so causal
+	// provenance is never at risk by construction (issue #146, Option C — park in
+	// place). Delivery stays a steering injection ("redirect"), not a converted
+	// new instruction.
+	//
+	// Durable for the same reason QueueHeld is: a daemon that restarts must not
+	// treat the parked steer as work to resume. Cleared on the same
+	// user-initiated-run triggers that clear QueueHeld (turn/start, turn/queue,
+	// turn/drainAsSteer, turn/promoteQueuedAsSteer), and deliberately NOT cleared
+	// on cancel-queued.
+	SteeringHeld           bool                                       `json:"steering_held,omitempty"`
 	QueueRevision          uint64                                     `json:"queue_revision"`
 	NextTurnSequence       uint64                                     `json:"next_turn_sequence"`
 	NextQueueEntrySequence uint64                                     `json:"next_queue_entry_sequence"`
@@ -269,6 +284,10 @@ func (s *Session) AcceptClientMutationStart(params appwire.TurnStartParams) (app
 		// new turn runs first and the drain loop takes the parked messages after
 		// it, which is the ordinary queue behaviour they were promised (wms7).
 		snapshot.QueueHeld = false
+		// A user-initiated run releases the parked steer too: the opening turn
+		// will drain the steering queue at its boundary, so the steer the Stop
+		// parked is delivered into it (issue #174).
+		snapshot.SteeringHeld = false
 		reserveClientMutationTurnID(snapshot, record)
 		record.ExecutionState = "accepted"
 		snapshot.BudgetReservations[record.ClientMutationID] = clientMutationBudgetReservation{
@@ -527,6 +546,14 @@ func (s *Session) InterruptClientMutation(
 		// runner on its way out and the drain loop is right behind it, so holding
 		// only at finalize leaves exactly the window the restart used (wms7).
 		snapshot.QueueHeld = true
+		// Park pending user steering at the same moment, mirroring QueueHeld
+		// (issue #174). Without this gate the steering rail stays OPEN after a
+		// Stop lands at a turn boundary: wakeForPendingSteering fires
+		// unconditionally below, restarts the session, and delivers the steer to
+		// the model anyway. The steer stays in PendingExecutions/SteeringOrder
+		// -- it never moves storage, so its causal provenance is never at risk
+		// (issue #146, Option C — park in place).
+		snapshot.SteeringHeld = true
 		return nil
 	})
 	if err != nil {
@@ -728,7 +755,11 @@ func (s *Session) SetPendingUserInputWakeFunc(wake func()) {
 	s.mu.Lock()
 	s.pendingUserInputWake = wake
 	s.mu.Unlock()
-	if wake != nil && (s.QueueDepth() > 0 || s.hasPendingUserSteering()) {
+	// A steer parked by a Stop (SteeringHeld) is not work to resume: waking for
+	// it at attach would restart the session and deliver the steer the user
+	// just stopped (issue #174, #146 Option C — park in place).
+	steeringHeld := s.clientMutations != nil && s.clientMutations.steeringHeld()
+	if wake != nil && (s.QueueDepth() > 0 || (!steeringHeld && s.hasPendingUserSteering())) {
 		wake()
 	}
 }
@@ -1195,6 +1226,16 @@ func (s *clientMutationStore) queueHeld() bool {
 	s.stateMu.RLock()
 	defer s.stateMu.RUnlock()
 	return s.state.QueueHeld
+}
+
+// steeringHeld reads the parked-steering flag without cloning the snapshot,
+// mirroring queueHeld. wakeForPendingSteering and the busy-state predicates
+// consult it so a Stop with pending user steering does not restart the session
+// or read as work in progress (issue #174).
+func (s *clientMutationStore) steeringHeld() bool {
+	s.stateMu.RLock()
+	defer s.stateMu.RUnlock()
+	return s.state.SteeringHeld
 }
 
 func (s *clientMutationStore) mutate(mutate func(*clientMutationSnapshot) error) error {

--- a/agent/session_client_mutation.go
+++ b/agent/session_client_mutation.go
@@ -183,7 +183,7 @@ type clientMutationSnapshot struct {
 	// process-local mirror -- the first attempt at this kata had one and the
 	// review found it drifting on three of four writers, across restarts, and on
 	// a rejected promote.
-	QueueHeld              bool                                       `json:"queue_held,omitempty"`
+	QueueHeld bool `json:"queue_held,omitempty"`
 	// SteeringHeld parks pending user steering after a Stop, mirroring QueueHeld
 	// (issue #174): a Stop that lands at a turn boundary is Applied, and without
 	// this gate the still-OPEN steering rail restarts the session and delivers the

--- a/agent/session_client_mutation_queue.go
+++ b/agent/session_client_mutation_queue.go
@@ -144,6 +144,8 @@ func (s *Session) clientMutationQueue(params appwire.TurnQueueParams) (appwire.T
 		}
 		// Queueing another message is re-engaging: release the wait.
 		snapshot.QueueHeld = false
+		// Re-engaging releases the parked steer too (issue #174).
+		snapshot.SteeringHeld = false
 		snapshot.InputQueue = append(snapshot.InputQueue, clientMutationQueueEntry{
 			ID:               record.StableQueueEntryIDs[0],
 			ClientMutationID: record.ClientMutationID,
@@ -279,6 +281,15 @@ func (s *Session) claimSteeringCarrierTurn() (turnID string, ok bool) {
 	}
 	if err := s.clientMutations.mutate(func(snapshot *clientMutationSnapshot) error {
 		if snapshot.InterruptFence != nil || snapshot.ActiveTurnID != "" {
+			return nil
+		}
+		// A Stop parks pending user steering until the user asks for something to
+		// run, the same way QueueHeld parks the input queue. Claiming the steering
+		// carrier here would hand the steer to a turn the Stop just ended, so it
+		// is refused -- mirroring popQueueHead's QueueHeld gate (issue #174). The
+		// steer stays in PendingExecutions/SteeringOrder; nothing moves, so its
+		// causal provenance is never at risk (issue #146, Option C).
+		if snapshot.SteeringHeld {
 			return nil
 		}
 		for _, id := range snapshot.SteeringOrder {
@@ -507,6 +518,15 @@ func (s *Session) clientMutationSteer(params appwire.TurnSteerParams) (appwire.T
 // no-ops, repeated kicks coalesce into one parked send, and a wake that cannot
 // name its turn stands down rather than running unaddressable.
 func (s *Session) wakeForPendingSteering() {
+	// A Stop parks pending user steering behind the SteeringHeld gate (issue
+	// #174). Waking here would restart the session and deliver the steer to the
+	// model anyway -- exactly the open steering rail the gate exists to close.
+	// The steer stays parked in PendingExecutions/SteeringOrder until a
+	// user-initiated run trigger clears the gate, so its causal provenance is
+	// never at risk (issue #146, Option C — park in place).
+	if s.clientMutations != nil && s.clientMutations.steeringHeld() {
+		return
+	}
 	// Only the user's own steering provokes a turn. Daemon-authored steering --
 	// the current-task reminder, hook context, a transcript pointer -- is
 	// context for whatever turn runs next, and the round loop drains it into
@@ -589,6 +609,9 @@ func (s *Session) clientMutationDrain(params appwire.TurnDrainAsSteerParams) (ap
 		// Draining IS the user asking for the queue to run. Below the effect
 		// rejection so a refused drain cannot unpark it.
 		snapshot.QueueHeld = false
+		// Draining is a user-initiated run, so the parked steer is released too
+		// (issue #174).
+		snapshot.SteeringHeld = false
 		for _, entry := range entries {
 			removeQueuedMutationSource(snapshot, entry, "transformed")
 		}
@@ -696,6 +719,9 @@ func (s *Session) clientMutationPromote(params appwire.TurnPromoteQueuedAsSteerP
 		// Promoting is the user picking one to run now. Below the effect
 		// rejection so a refused promote cannot unpark it.
 		snapshot.QueueHeld = false
+		// Promoting is a user-initiated run, so the parked steer is released too
+		// (issue #174).
+		snapshot.SteeringHeld = false
 		entry := snapshot.InputQueue[index]
 		snapshot.InputQueue = append(snapshot.InputQueue[:index], snapshot.InputQueue[index+1:]...)
 		snapshot.QueueRevision++

--- a/agent/session_steering_held_test.go
+++ b/agent/session_steering_held_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
+	"primeradiant.com/evener/agent/provenance"
+	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/appwire"
 )
 
@@ -251,5 +254,314 @@ func TestTurnStartClearMutation(t *testing.T) {
 
 	if sess.clientMutations.steeringHeld() {
 		t.Fatal("the SteeringHeld clear on turn/start is missing: the gate stays set after the user asked for a turn to run, so the parked steer is never delivered")
+	}
+}
+
+// TestASecondSteerWhileHeldStaysParked is the RCA's named trap (#146
+// Option C, "the one a naive implementation gets wrong"): a naive "clear
+// SteeringHeld everywhere QueueHeld is cleared" reading would clear it on
+// clientMutationSteer's own accept path, and that path calls
+// wakeForPendingSteering unconditionally -- reproducing the #146 restart,
+// retriggered by a second steer instead of by Stop. A steer arriving while
+// held must append to SteeringOrder and stay parked with the rest.
+func TestASecondSteerWhileHeldStaysParked(t *testing.T) {
+	sess := newQueuePersistTestSession(t, t.TempDir())
+	defer sess.Close()
+	serveSession(t, sess)
+
+	runningStartTurn(t, sess, "running-turn", "do the thing")
+	if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "steer-one",
+		Input:            []appwire.InputItem{{Type: "text", Text: "first redirect"}},
+	}); err != nil {
+		t.Fatalf("first steer: %v", err)
+	}
+	if _, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+		ClientMutationID: "stop-over-steering",
+	}, func() {}); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if !sess.clientMutations.steeringHeld() {
+		t.Fatal("precondition: Stop did not set SteeringHeld")
+	}
+
+	if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "steer-two",
+		Input:            []appwire.InputItem{{Type: "text", Text: "second redirect"}},
+	}); err != nil {
+		t.Fatalf("second steer: %v", err)
+	}
+
+	if !sess.clientMutations.steeringHeld() {
+		t.Fatal("a second steer accepted while held cleared SteeringHeld: this re-triggers the #146 restart bug via a second steer instead of Stop")
+	}
+	if claimedID, ok := sess.claimSteeringCarrierTurn(); ok {
+		t.Fatalf("claimSteeringCarrierTurn claimed turn %q after a second steer arrived while held", claimedID)
+	}
+}
+
+// TestDrainAsSteerReleasesTheParkedSteer is drainAsSteer's half of "sending
+// again releases a held steer" (RCA clear-trigger list). The queued entry is
+// added BEFORE the Stop so this test exercises drainAsSteer's own clear, not
+// turn/queue's.
+func TestDrainAsSteerReleasesTheParkedSteer(t *testing.T) {
+	sess := newQueuePersistTestSession(t, t.TempDir())
+	defer sess.Close()
+	serveSession(t, sess)
+
+	queueOneMutation(t, sess, "queued-behind", "and then this")
+	runningStartTurn(t, sess, "running-turn", "do the thing")
+	if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "steer-mid-round",
+		Input:            []appwire.InputItem{{Type: "text", Text: "actually do it this way"}},
+	}); err != nil {
+		t.Fatalf("steer: %v", err)
+	}
+	if _, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+		ClientMutationID: "stop-over-both",
+	}, func() {}); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if !sess.clientMutations.steeringHeld() || !sess.clientMutations.queueHeld() {
+		t.Fatal("precondition: Stop did not park both the queue and the steer")
+	}
+
+	revision := sess.clientMutations.snapshot().QueueRevision
+	if _, err := sess.AcceptClientMutationDrainAsSteer(appwire.TurnDrainAsSteerParams{
+		ClientMutationID:      "drain-after-stop",
+		ExpectedQueueRevision: revision,
+	}); err != nil {
+		t.Fatalf("drainAsSteer: %v", err)
+	}
+
+	if sess.clientMutations.steeringHeld() {
+		t.Fatal("drainAsSteer left SteeringHeld set: the user asked for the queue to run, and the parked steer should release with it")
+	}
+}
+
+// TestPromoteQueuedAsSteerReleasesTheParkedSteer is promoteQueuedAsSteer's
+// half of the same clear-trigger list.
+func TestPromoteQueuedAsSteerReleasesTheParkedSteer(t *testing.T) {
+	sess := newQueuePersistTestSession(t, t.TempDir())
+	defer sess.Close()
+	serveSession(t, sess)
+
+	queueOneMutation(t, sess, "queued-behind", "and then this")
+	runningStartTurn(t, sess, "running-turn", "do the thing")
+	if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "steer-mid-round",
+		Input:            []appwire.InputItem{{Type: "text", Text: "actually do it this way"}},
+	}); err != nil {
+		t.Fatalf("steer: %v", err)
+	}
+	if _, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+		ClientMutationID: "stop-over-both",
+	}, func() {}); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if !sess.clientMutations.steeringHeld() || !sess.clientMutations.queueHeld() {
+		t.Fatal("precondition: Stop did not park both the queue and the steer")
+	}
+
+	if _, err := sess.AcceptClientMutationPromoteQueuedAsSteer(appwire.TurnPromoteQueuedAsSteerParams{
+		ClientMutationID: "promote-after-stop",
+		Index:            0,
+	}); err != nil {
+		t.Fatalf("promoteQueuedAsSteer: %v", err)
+	}
+
+	if sess.clientMutations.steeringHeld() {
+		t.Fatal("promoteQueuedAsSteer left SteeringHeld set: the user picked something to run now, and the parked steer should release with it")
+	}
+}
+
+// TestDelegateSteerCallerUnaffectedByHold is the scope-predicate proof (#146):
+// enqueueDelegateCallerSteeringDurably (real Provenance, Source=="") never
+// touches PendingExecutions/SteeringOrder, the store SteeringHeld gates, so a
+// hold on the user's own steering must not block, clear, or otherwise
+// interact with delegate SteerCaller traffic.
+func TestDelegateSteerCallerUnaffectedByHold(t *testing.T) {
+	sess := newQueuePersistTestSession(t, t.TempDir())
+	defer sess.Close()
+	serveSession(t, sess)
+
+	runningStartTurn(t, sess, "running-turn", "do the thing")
+	if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "steer-mid-round",
+		Input:            []appwire.InputItem{{Type: "text", Text: "actually do it this way"}},
+	}); err != nil {
+		t.Fatalf("steer: %v", err)
+	}
+	if _, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+		ClientMutationID: "stop-over-steering",
+	}, func() {}); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if !sess.clientMutations.steeringHeld() {
+		t.Fatal("precondition: Stop did not set SteeringHeld")
+	}
+
+	before := len(sess.SteeringQueueSnapshot())
+	prov := &provenance.Causal{Chain: []provenance.Entry{{Kind: "job", JobID: "job-123"}}}
+	if err := sess.enqueueDelegateCallerSteeringDurably("delegate says redirect", prov); err != nil {
+		t.Fatalf("enqueueDelegateCallerSteeringDurably was blocked while SteeringHeld: %v", err)
+	}
+
+	after := sess.SteeringQueueSnapshot()
+	if len(after) != before+1 {
+		t.Fatalf("delegate steering did not land in the in-memory queue while held: got %d entries, want %d", len(after), before+1)
+	}
+	if !sess.clientMutations.steeringHeld() {
+		t.Fatal("a delegate steer while held cleared SteeringHeld: the store is scoped to user steering only and must not react to delegate traffic")
+	}
+	if !sess.hasPendingUserSteering() {
+		t.Fatal("hasPendingUserSteering went false after a delegate steer landed; the user's own held steer must still count")
+	}
+
+	// The delegate entry is delivered by the ungated injectDrainedSteering
+	// regardless of the hold -- proving delivery is not blocked structurally.
+	sess.injectDrainedSteering()
+	found := false
+	for _, turn := range sess.history {
+		if turn.Kind == schema.TurnSteering && turn.Message.Text() == "delegate says redirect" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("the delegate steer was never delivered into the transcript even though SteeringHeld only gates the durable user-steering claim path")
+	}
+}
+
+// TestAHeldSteerSurvivesRestart pins restart safety (#174): SteeringHeld is a
+// plain field on the durable snapshot, deliberately with no process-local
+// mirror (the QueueHeld review found the first attempt at that pattern
+// drifting on three of four writers). It must survive a full daemon restart
+// through the production resume path, and the claim gate must still refuse
+// after restore.
+func TestAHeldSteerSurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	sess := newQueuePersistTestSession(t, dir)
+	id := sess.ID()
+	serveSession(t, sess)
+
+	runningStartTurn(t, sess, "running-turn", "do the thing")
+	if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "steer-mid-round",
+		Input:            []appwire.InputItem{{Type: "text", Text: "actually do it this way"}},
+	}); err != nil {
+		t.Fatalf("steer: %v", err)
+	}
+	if _, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+		ClientMutationID: "stop-over-steering",
+	}, func() {}); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if !sess.clientMutations.steeringHeld() {
+		t.Fatal("precondition: Stop did not set SteeringHeld")
+	}
+	sess.Close()
+
+	restored := restoreQueuePersistTestSession(t, dir, id)
+	defer restored.Close()
+
+	if !restored.clientMutations.steeringHeld() {
+		t.Fatal("SteeringHeld did NOT survive a restart: the parked steer will be delivered on the next wake after restore")
+	}
+	if !restored.hasPendingUserSteering() {
+		t.Fatal("the restored session lost the parked user steer entirely")
+	}
+	if claimedID, ok := restored.claimSteeringCarrierTurn(); ok {
+		t.Fatalf("claimSteeringCarrierTurn claimed turn %q on a freshly restored session with SteeringHeld set", claimedID)
+	}
+}
+
+// TestParkedSteerStillProjectsAsAccepted is the wire-visibility half of
+// Option C (#146): the parked steer must keep projecting as a
+// PendingMutation with ExecutionState=="accepted" (never "claimed"), the
+// state ClientMutationProjection's own exclusion only drops for
+// method==turn/start||turn/queue AND state==incorporated -- so PendingChips
+// keeps rendering it.
+func TestParkedSteerStillProjectsAsAccepted(t *testing.T) {
+	sess := newQueuePersistTestSession(t, t.TempDir())
+	defer sess.Close()
+	serveSession(t, sess)
+
+	runningStartTurn(t, sess, "running-turn", "do the thing")
+	if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "steer-mid-round",
+		Input:            []appwire.InputItem{{Type: "text", Text: "actually do it this way"}},
+	}); err != nil {
+		t.Fatalf("steer: %v", err)
+	}
+	if _, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+		ClientMutationID: "stop-over-steering",
+	}, func() {}); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+
+	_, pending := sess.ClientMutationProjection()
+	var found *appwire.PendingMutation
+	for i := range pending {
+		if pending[i].ClientMutationID == "steer-mid-round" {
+			found = &pending[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("the parked steer disappeared from ClientMutationProjection's PendingMutations -- PendingChips has nothing to render")
+	}
+	if found.ExecutionState != "accepted" {
+		t.Fatalf("parked steer ExecutionState = %q, want %q (never claimed while held)", found.ExecutionState, "accepted")
+	}
+}
+
+// TestDrainJobTreeDoesNotHangWithAHeldSteer guards the exit path: DrainJobTree
+// must not hang or spin forever with SteeringHeld set and a steer durably
+// pending, since neither treeHasOutstandingWork nor drainSubtreeIsStalled
+// have any notion of queue/steering state -- the drain must simply see
+// nothing outstanding and return.
+func TestDrainJobTreeDoesNotHangWithAHeldSteer(t *testing.T) {
+	sess := newQueuePersistTestSession(t, t.TempDir())
+	defer sess.Close()
+	serveSession(t, sess)
+
+	runningStartTurn(t, sess, "running-turn", "do the thing")
+	if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "steer-mid-round",
+		Input:            []appwire.InputItem{{Type: "text", Text: "actually do it this way"}},
+	}); err != nil {
+		t.Fatalf("steer: %v", err)
+	}
+	if _, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+		ClientMutationID: "stop-over-steering",
+	}, func() {}); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if !sess.clientMutations.steeringHeld() {
+		t.Fatal("precondition: Stop did not set SteeringHeld")
+	}
+
+	// TRIPWIRE: this test awaits the real completion signal (done, below) --
+	// the bound is a hang guard only, sized well above the sub-millisecond
+	// work this session actually has (no managed jobs, no delegates), so it
+	// fires only if DrainJobTree genuinely wedges.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	done := make(chan struct{})
+	var result string
+	var err error
+	go func() {
+		result, err = sess.DrainJobTree(ctx)
+		close(done)
+	}()
+	select {
+	case <-done:
+		if err != nil {
+			t.Fatalf("DrainJobTree returned an error with steering held: %v", err)
+		}
+		if result != "" {
+			t.Fatalf("DrainJobTree ran a turn (%q) it should not have with nothing outstanding but a held steer", result)
+		}
+	case <-ctx.Done():
+		t.Fatal("DrainJobTree hung with SteeringHeld set and a pending user steer -- exit would SIGKILL the child instead of returning")
 	}
 }

--- a/agent/session_steering_held_test.go
+++ b/agent/session_steering_held_test.go
@@ -1,0 +1,255 @@
+package agent
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+)
+
+// TestStopParksPendingUserSteering is the #174 rail: a Stop that lands at a
+// turn boundary is Applied, and without the SteeringHeld gate the still-OPEN
+// steering rail restarts the session and delivers the steer to the model
+// anyway. The steer must stay parked -- no model round, no restart -- until the
+// user asks for something to run.
+//
+// The steer stays in PendingExecutions/SteeringOrder where it already durably
+// lives, so its causal provenance is never at risk (issue #146, Option C —
+// park in place). Delivery stays a steering injection, not a converted new
+// instruction.
+func TestStopParksPendingUserSteering(t *testing.T) {
+	sess := newQueuePersistTestSession(t, t.TempDir())
+	defer sess.Close()
+	serveSession(t, sess)
+
+	// A turn is running, the user steers it, and the steer has not been injected
+	// yet -- injection happens at a round boundary, so this is the state during
+	// any long tool call.
+	turnID := runningStartTurn(t, sess, "running-turn", "do the thing")
+	if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "steer-mid-round",
+		Input:            []appwire.InputItem{{Type: "text", Text: "actually do it this way"}},
+	}); err != nil {
+		t.Fatalf("AcceptClientMutationSteer: %v", err)
+	}
+	if !sess.hasPendingUserSteering() {
+		t.Fatal("the steer did not land as pending user steering; this test is not in the state it means to be")
+	}
+
+	cancels := 0
+	response, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+		ClientMutationID: "stop-over-pending-steering",
+	}, func() { cancels++ })
+	if err != nil {
+		t.Fatalf("Stop with a steer in flight was refused: %v", err)
+	}
+	if cancels != 1 {
+		t.Fatalf("Stop cancelled %d times, want exactly 1", cancels)
+	}
+	if response.Receipt.Disposition != appwire.MutationDispositionApplied {
+		t.Fatalf("Stop disposition = %q, want %q", response.Receipt.Disposition, appwire.MutationDispositionApplied)
+	}
+	if response.Receipt.TurnID != turnID {
+		t.Fatalf("Stop receipt turn = %q, want the running turn %q", response.Receipt.TurnID, turnID)
+	}
+
+	// The gate is set: the steer is parked behind SteeringHeld.
+	if !sess.clientMutations.steeringHeld() {
+		t.Fatal("Stop did not set SteeringHeld; the steering rail is still open and the steer will be delivered anyway")
+	}
+
+	// The pending-user-input wake is what would restart the session to deliver
+	// the steer. Install it AFTER the Stop so the count reflects only post-Stop
+	// wakes: at install time the steer is pending and the gate is set, so a
+	// wake that respects the gate fires zero times here.
+	var mu sync.Mutex
+	wakes := 0
+	sess.SetPendingUserInputWakeFunc(func() {
+		mu.Lock()
+		wakes++
+		mu.Unlock()
+	})
+
+	// The steer is still durably pending -- it never moved storage, so its
+	// causal provenance is intact (issue #146).
+	if !sess.hasPendingUserSteering() {
+		t.Fatal("the Stop consumed the user's steering: they typed it, it never reached the model, and it is gone")
+	}
+	snapshot := sess.clientMutations.snapshot()
+	if pending, ok := snapshot.PendingExecutions["steer-mid-round"]; !ok || pending.ExecutionState != "accepted" {
+		t.Fatalf("the parked steer is not still accepted in PendingExecutions: %#v", snapshot.PendingExecutions)
+	}
+
+	// wakeForPendingSteering must NOT fire while held: a fire here would restart
+	// the session and deliver the steer to the model anyway -- the open
+	// steering rail this gate exists to close.
+	sess.wakeForPendingSteering()
+	mu.Lock()
+	if wakes != 0 {
+		t.Fatalf("wakeForPendingSteering fired %d time(s) while SteeringHeld is set; the parked steer restarts the session", wakes)
+	}
+	mu.Unlock()
+
+	// claimSteeringCarrierTurn must refuse to claim while held: claiming would
+	// hand the steer to a turn the Stop just ended.
+	if claimedID, ok := sess.claimSteeringCarrierTurn(); ok {
+		t.Fatalf("claimSteeringCarrierTurn claimed turn %q while SteeringHeld is set; the parked steer is delivered to a turn the Stop just ended", claimedID)
+	}
+
+	// A parked steer must not make the session look busy: WireState reports
+	// idle, because nothing will move the steer until the user acts.
+	if got := sess.WireState(); got != string(SessionIdle) {
+		t.Fatalf("WireState with a parked steer = %q, want %q; a parked steer is waiting on the user, not work in progress", got, SessionIdle)
+	}
+}
+
+// TestTurnStartReleasesTheParkedSteer is the release half: a user-initiated
+// turn/start clears SteeringHeld, so the opening turn drains the parked steer
+// at its boundary and delivers it to the model.
+func TestTurnStartReleasesTheParkedSteer(t *testing.T) {
+	sess := newQueuePersistTestSession(t, t.TempDir())
+	defer sess.Close()
+	serveSession(t, sess)
+
+	runningStartTurn(t, sess, "running-turn", "do the thing")
+	if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "steer-mid-round",
+		Input:            []appwire.InputItem{{Type: "text", Text: "actually do it this way"}},
+	}); err != nil {
+		t.Fatalf("AcceptClientMutationSteer: %v", err)
+	}
+	cancels := 0
+	if _, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+		ClientMutationID: "stop-over-pending-steering",
+	}, func() { cancels++ }); err != nil {
+		t.Fatalf("Stop with a steer in flight was refused: %v", err)
+	}
+	if cancels != 1 {
+		t.Fatalf("Stop cancelled %d times, want exactly 1", cancels)
+	}
+	if !sess.clientMutations.steeringHeld() {
+		t.Fatal("precondition: Stop did not set SteeringHeld")
+	}
+
+	// The user speaks again. turn/start is the user asking for something to
+	// run, so the wait the Stop started is over -- for the queue AND the steer.
+	if _, err := sess.AcceptClientMutationStart(appwire.TurnStartParams{
+		ClientMutationID: "start-after-stop",
+		Input:            []appwire.InputItem{{Type: "text", Text: "next turn"}},
+	}); err != nil {
+		t.Fatalf("turn/start after the Stop: %v", err)
+	}
+
+	// The gate is cleared.
+	if sess.clientMutations.steeringHeld() {
+		t.Fatal("turn/start did not clear SteeringHeld; the parked steer stays parked even after the user asked for a turn to run")
+	}
+
+	// wakeForPendingSteering now fires again -- the steer is no longer parked,
+	// so the opening turn will drain it at its boundary.
+	var mu sync.Mutex
+	wakes := 0
+	sess.SetPendingUserInputWakeFunc(func() {
+		mu.Lock()
+		wakes++
+		mu.Unlock()
+	})
+	sess.wakeForPendingSteering()
+	mu.Lock()
+	if wakes == 0 {
+		t.Fatal("wakeForPendingSteering did not fire after SteeringHeld was cleared; the parked steer is never delivered")
+	}
+	mu.Unlock()
+}
+
+// TestStopParksPendingUserSteering_GuardMutation pins that the SteeringHeld
+// guard in wakeForPendingSteering is load-bearing: deleting it turns this test
+// red. Run with the guard removed from wakeForPendingSteering and the wake
+// fires while held, which the assertion rejects.
+//
+// This is the mutation test for requirement (c): deleting the SteeringHeld
+// guard turns a test red.
+func TestStopParksPendingUserSteering_GuardMutation(t *testing.T) {
+	sess := newQueuePersistTestSession(t, t.TempDir())
+	defer sess.Close()
+	serveSession(t, sess)
+
+	runningStartTurn(t, sess, "running-turn", "do the thing")
+	if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "steer-mid-round",
+		Input:            []appwire.InputItem{{Type: "text", Text: "actually do it this way"}},
+	}); err != nil {
+		t.Fatalf("AcceptClientMutationSteer: %v", err)
+	}
+	cancels := 0
+	if _, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+		ClientMutationID: "stop-over-pending-steering",
+	}, func() { cancels++ }); err != nil {
+		t.Fatalf("Stop with a steer in flight was refused: %v", err)
+	}
+	if !sess.clientMutations.steeringHeld() {
+		t.Fatal("precondition: Stop did not set SteeringHeld")
+	}
+
+	var mu sync.Mutex
+	wakes := 0
+	sess.SetPendingUserInputWakeFunc(func() {
+		mu.Lock()
+		wakes++
+		mu.Unlock()
+	})
+
+	// This is the call site the guard protects: the interrupt's tail calls it
+	// unconditionally, and so does every steer/drain/promote path. With the guard
+	// in place it no-ops while held; without the guard it fires and the parked
+	// steer restarts the session.
+	sess.wakeForPendingSteering()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if wakes != 0 {
+		t.Fatalf("the SteeringHeld guard in wakeForPendingSteering is missing: the wake fired %d time(s) while the steer is parked, restarting the session and delivering the steer the user just stopped", wakes)
+	}
+}
+
+// TestTurnStartClearMutation pins that the SteeringHeld clear on turn/start is
+// load-bearing: deleting it turns this test red. Run with the
+// `snapshot.SteeringHeld = false` line removed from AcceptClientMutationStart
+// and the gate stays set after turn/start, which the assertion rejects.
+//
+// This is the mutation test for requirement (d): deleting a clear turns a test
+// red.
+func TestTurnStartClearMutation(t *testing.T) {
+	sess := newQueuePersistTestSession(t, t.TempDir())
+	defer sess.Close()
+	serveSession(t, sess)
+
+	runningStartTurn(t, sess, "running-turn", "do the thing")
+	if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "steer-mid-round",
+		Input:            []appwire.InputItem{{Type: "text", Text: "actually do it this way"}},
+	}); err != nil {
+		t.Fatalf("AcceptClientMutationSteer: %v", err)
+	}
+	cancels := 0
+	if _, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+		ClientMutationID: "stop-over-pending-steering",
+	}, func() { cancels++ }); err != nil {
+		t.Fatalf("Stop with a steer in flight was refused: %v", err)
+	}
+	if !sess.clientMutations.steeringHeld() {
+		t.Fatal("precondition: Stop did not set SteeringHeld")
+	}
+
+	if _, err := sess.AcceptClientMutationStart(appwire.TurnStartParams{
+		ClientMutationID: "start-after-stop",
+		Input:            []appwire.InputItem{{Type: "text", Text: "next turn"}},
+	}); err != nil {
+		t.Fatalf("turn/start after the Stop: %v", err)
+	}
+
+	if sess.clientMutations.steeringHeld() {
+		t.Fatal("the SteeringHeld clear on turn/start is missing: the gate stays set after the user asked for a turn to run, so the parked steer is never delivered")
+	}
+}


### PR DESCRIPTION
Fixes #146, fixes #174

The steering rail of the Stop-at-turn-boundary fix: a Stop parks pending user steering behind a SteeringHeld gate mirroring QueueHeld. The steer stays in PendingExecutions/SteeringOrder (never moves storage), so causal provenance is never at risk. wakeForPendingSteering no longer fires unconditionally while held. Delivery stays a steering injection, not a converted new instruction.

Implements Jesse's Option C ruling from #146: park in place.