### PR TITLE
fix(agent): surface specific constraint failures in ask_user argument validation

### DIFF
--- a/agent/internal/tool/repair/explain.go
+++ b/agent/internal/tool/repair/explain.go
@@ -28,10 +28,13 @@ import (
 // name (the last segment of the deepest cause's KeywordLocation, e.g.
 // "maxLength"), supplied by the caller (offendingKeyword). When the field is
 // present and the keyword is a recognized value constraint (maxLength,
-// minLength, minItems, maxItems), the message names the actual constraint,
-// its limit, and the offending value/length instead of the generic "wrong
-// type or value" + required-list scaffolding — which otherwise sends the
-// caller debugging a parameter that was correctly supplied (issue #193).
+// minLength, minItems, maxItems, enum), the message names the actual
+// constraint, its limit, and the offending value/length instead of the
+// generic "wrong type or value" message — which otherwise sends the caller
+// debugging a parameter that was correctly supplied (issue #193). A present
+// field never gets the "Required arguments" tail, recognized keyword or not:
+// that tail lists already-satisfied sibling fields, which is misleading
+// regardless of whether the specific constraint can be detailed.
 func ExplainSchemaError(toolName string, params, args map[string]any, instanceLocation, constraintKeyword string) string {
 	var b strings.Builder
 
@@ -53,28 +56,27 @@ func ExplainSchemaError(toolName string, params, args map[string]any, instanceLo
 		}
 	}
 
-	// When a specific value constraint failed on a present field, surface
-	// that constraint (field, constraint name, limit, actual value/length)
-	// instead of the generic "wrong type or value" + required-list scaffolding.
-	if present && constraintKeyword != "" {
+	// A present-but-invalid field is a value-constraint violation, never a
+	// missing-argument problem — the "Required arguments" tail below (which
+	// lists already-satisfied sibling fields) is the misdirection issue #193
+	// reports, so it never applies here, regardless of whether the specific
+	// constraint keyword is one constraintMessage knows how to detail.
+	if present {
 		fullPath := field
 		if containerPath != "" {
 			fullPath = containerPath + "." + field
 		}
-		if specific := constraintMessage(toolName, fullPath, containerSchema, field, constraintKeyword, args, instanceLocation); specific != "" {
-			return specific
+		if constraintKeyword != "" {
+			if specific := constraintMessage(toolName, fullPath, containerSchema, field, constraintKeyword, args, instanceLocation); specific != "" {
+				return specific
+			}
 		}
+		return fmt.Sprintf("%s: argument %q has the wrong type or value.\nExample: %s", toolName, fullPath, minimalExample(params))
 	}
 
 	switch {
 	case !haveField:
 		fmt.Fprintf(&b, "%s: arguments did not match the schema.", toolName)
-	case present:
-		fullPath := field
-		if containerPath != "" {
-			fullPath = containerPath + "." + field
-		}
-		fmt.Fprintf(&b, "%s: argument %q has the wrong type or value.", toolName, fullPath)
 	case containerPath == "":
 		fmt.Fprintf(&b, "%s: missing required argument %q.", toolName, field)
 	default:
@@ -96,8 +98,8 @@ func ExplainSchemaError(toolName string, params, args map[string]any, instanceLo
 // constraintMessage renders a specific constraint-violation message for a
 // present field whose schema rejected it: the field's display path, the
 // constraint name, its limit, and the actual value/length. Returns "" when
-// the keyword is not one of the recognized length/count constraints
-// (maxLength, minLength, minItems, maxItems) or when the schema/value shape
+// the keyword is not one of the recognized constraints (maxLength,
+// minLength, minItems, maxItems, enum) or when the schema/value shape
 // doesn't match the keyword, so the caller falls back to the generic
 // "wrong type or value" message.
 func constraintMessage(toolName, displayPath string, containerSchema map[string]any, field, keyword string, args map[string]any, instanceLocation string) string {
@@ -108,35 +110,41 @@ func constraintMessage(toolName, displayPath string, containerSchema map[string]
 	value := resolveInstanceValue(args, instanceLocation)
 	switch keyword {
 	case "maxLength":
-		max, ok := schemaInt(fieldSchema["maxLength"])
+		limit, ok := schemaInt(fieldSchema["maxLength"])
 		if !ok {
 			return ""
 		}
 		s, _ := value.(string)
 		n := utf8.RuneCountInString(s)
-		return fmt.Sprintf("%s: argument %q exceeds maxLength (%d). Value %q is %d characters.", toolName, displayPath, max, s, n)
+		return fmt.Sprintf("%s: argument %q exceeds maxLength (%d). Value %q is %d characters.", toolName, displayPath, limit, s, n)
 	case "minLength":
-		min, ok := schemaInt(fieldSchema["minLength"])
+		limit, ok := schemaInt(fieldSchema["minLength"])
 		if !ok {
 			return ""
 		}
 		s, _ := value.(string)
 		n := utf8.RuneCountInString(s)
-		return fmt.Sprintf("%s: argument %q is below minLength (%d). Value %q is %d characters.", toolName, displayPath, min, s, n)
+		return fmt.Sprintf("%s: argument %q is below minLength (%d). Value %q is %d characters.", toolName, displayPath, limit, s, n)
 	case "maxItems":
-		max, ok := schemaInt(fieldSchema["maxItems"])
+		limit, ok := schemaInt(fieldSchema["maxItems"])
 		if !ok {
 			return ""
 		}
 		arr, _ := value.([]any)
-		return fmt.Sprintf("%s: argument %q exceeds maxItems (%d). Value has %d items.", toolName, displayPath, max, len(arr))
+		return fmt.Sprintf("%s: argument %q exceeds maxItems (%d). Value has %d items.", toolName, displayPath, limit, len(arr))
 	case "minItems":
-		min, ok := schemaInt(fieldSchema["minItems"])
+		limit, ok := schemaInt(fieldSchema["minItems"])
 		if !ok {
 			return ""
 		}
 		arr, _ := value.([]any)
-		return fmt.Sprintf("%s: argument %q is below minItems (%d). Value has %d items.", toolName, displayPath, min, len(arr))
+		return fmt.Sprintf("%s: argument %q is below minItems (%d). Value has %d items.", toolName, displayPath, limit, len(arr))
+	case "enum":
+		allowed := asStringSlice(fieldSchema["enum"])
+		if len(allowed) == 0 {
+			return ""
+		}
+		return fmt.Sprintf("%s: argument %q is not one of the allowed values: %s. Value is %q.", toolName, displayPath, strings.Join(allowed, ", "), fmt.Sprint(value))
 	}
 	return ""
 }
@@ -151,7 +159,7 @@ func resolveInstanceValue(args map[string]any, path string) any {
 		return nil
 	}
 	var cur any = args
-	for _, seg := range strings.Split(path, "/") {
+	for seg := range strings.SplitSeq(path, "/") {
 		if idx, isIdx := arrayIndex(seg); isIdx {
 			arr, ok := cur.([]any)
 			if !ok || idx < 0 || idx >= len(arr) {

--- a/agent/internal/tool/repair/explain.go
+++ b/agent/internal/tool/repair/explain.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 // ExplainSchemaError renders model-facing coaching for a call that failed
@@ -22,7 +23,16 @@ import (
 // — not a misleading top-level guess. Any segment the walk can't resolve
 // (malformed path, schema shape mismatch) falls back to treating the whole
 // original string as a single top-level field name.
-func ExplainSchemaError(toolName string, params, args map[string]any, instanceLocation string) string {
+//
+// constraintKeyword, when non-empty, is the failing JSON-Schema keyword's
+// name (the last segment of the deepest cause's KeywordLocation, e.g.
+// "maxLength"), supplied by the caller (offendingKeyword). When the field is
+// present and the keyword is a recognized value constraint (maxLength,
+// minLength, minItems, maxItems), the message names the actual constraint,
+// its limit, and the offending value/length instead of the generic "wrong
+// type or value" + required-list scaffolding — which otherwise sends the
+// caller debugging a parameter that was correctly supplied (issue #193).
+func ExplainSchemaError(toolName string, params, args map[string]any, instanceLocation, constraintKeyword string) string {
 	var b strings.Builder
 
 	containerSchema := params
@@ -40,6 +50,19 @@ func ExplainSchemaError(toolName string, params, args map[string]any, instanceLo
 			// top-level field name (today's flat behavior).
 			containerSchema, containerPath, field = params, "", instanceLocation
 			_, present = args[instanceLocation]
+		}
+	}
+
+	// When a specific value constraint failed on a present field, surface
+	// that constraint (field, constraint name, limit, actual value/length)
+	// instead of the generic "wrong type or value" + required-list scaffolding.
+	if present && constraintKeyword != "" {
+		fullPath := field
+		if containerPath != "" {
+			fullPath = containerPath + "." + field
+		}
+		if specific := constraintMessage(toolName, fullPath, containerSchema, field, constraintKeyword, args, instanceLocation); specific != "" {
+			return specific
 		}
 	}
 
@@ -68,6 +91,97 @@ func ExplainSchemaError(toolName string, params, args map[string]any, instanceLo
 	}
 	fmt.Fprintf(&b, "\nExample: %s", minimalExample(params))
 	return b.String()
+}
+
+// constraintMessage renders a specific constraint-violation message for a
+// present field whose schema rejected it: the field's display path, the
+// constraint name, its limit, and the actual value/length. Returns "" when
+// the keyword is not one of the recognized length/count constraints
+// (maxLength, minLength, minItems, maxItems) or when the schema/value shape
+// doesn't match the keyword, so the caller falls back to the generic
+// "wrong type or value" message.
+func constraintMessage(toolName, displayPath string, containerSchema map[string]any, field, keyword string, args map[string]any, instanceLocation string) string {
+	fieldSchema, _ := schemaProps(containerSchema)[field].(map[string]any)
+	if fieldSchema == nil {
+		return ""
+	}
+	value := resolveInstanceValue(args, instanceLocation)
+	switch keyword {
+	case "maxLength":
+		max, ok := schemaInt(fieldSchema["maxLength"])
+		if !ok {
+			return ""
+		}
+		s, _ := value.(string)
+		n := utf8.RuneCountInString(s)
+		return fmt.Sprintf("%s: argument %q exceeds maxLength (%d). Value %q is %d characters.", toolName, displayPath, max, s, n)
+	case "minLength":
+		min, ok := schemaInt(fieldSchema["minLength"])
+		if !ok {
+			return ""
+		}
+		s, _ := value.(string)
+		n := utf8.RuneCountInString(s)
+		return fmt.Sprintf("%s: argument %q is below minLength (%d). Value %q is %d characters.", toolName, displayPath, min, s, n)
+	case "maxItems":
+		max, ok := schemaInt(fieldSchema["maxItems"])
+		if !ok {
+			return ""
+		}
+		arr, _ := value.([]any)
+		return fmt.Sprintf("%s: argument %q exceeds maxItems (%d). Value has %d items.", toolName, displayPath, max, len(arr))
+	case "minItems":
+		min, ok := schemaInt(fieldSchema["minItems"])
+		if !ok {
+			return ""
+		}
+		arr, _ := value.([]any)
+		return fmt.Sprintf("%s: argument %q is below minItems (%d). Value has %d items.", toolName, displayPath, min, len(arr))
+	}
+	return ""
+}
+
+// resolveInstanceValue walks a JSON-Pointer-style path (e.g.
+// "questions/0/header") against the parsed args, alternating object-property
+// and array-index steps, and returns the value at that location (or nil when
+// any step can't be resolved). Mirrors the instance walk in
+// resolveSchemaErrorContainer without mutating it.
+func resolveInstanceValue(args map[string]any, path string) any {
+	if path == "" {
+		return nil
+	}
+	var cur any = args
+	for _, seg := range strings.Split(path, "/") {
+		if idx, isIdx := arrayIndex(seg); isIdx {
+			arr, ok := cur.([]any)
+			if !ok || idx < 0 || idx >= len(arr) {
+				return nil
+			}
+			cur = arr[idx]
+			continue
+		}
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil
+		}
+		cur = m[seg]
+	}
+	return cur
+}
+
+// schemaInt extracts an integer from a JSON-Schema numeric constraint value,
+// tolerating the float64/int/int64 forms a Go map[string]any or JSON-unmarshaled
+// schema may carry.
+func schemaInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case float64:
+		return int(n), true
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	}
+	return 0, false
 }
 
 // resolveSchemaErrorContainer walks instanceLocation (split on "/") against

--- a/agent/internal/tool/repair/explain_test.go
+++ b/agent/internal/tool/repair/explain_test.go
@@ -227,6 +227,112 @@ func TestExplainSchemaError_NestedPropertyWrongTypeOrValue(t *testing.T) {
 	}
 }
 
+// TestExplainSchemaError_ConstraintClasses covers every constraint keyword
+// issue #193's RCA confirmed hits the same generic-message bug: maxLength,
+// minItems, maxItems, and enum. Each case pins the exact constraint-detail
+// sentence and asserts the misleading "Required arguments" tail is gone.
+func TestExplainSchemaError_ConstraintClasses(t *testing.T) {
+	tests := []struct {
+		name             string
+		toolName         string
+		params           map[string]any
+		args             map[string]any
+		instanceLocation string
+		keyword          string
+		want             string
+	}{
+		{
+			name:     "maxLength",
+			toolName: "ask_user",
+			params:   askUserParamsForExplain(),
+			args: map[string]any{"questions": []any{map[string]any{
+				"header": strings.Repeat("x", 20), "question": "q", "options": []any{},
+			}}},
+			instanceLocation: "questions/0/header",
+			keyword:          "maxLength",
+			want:             `ask_user: argument "questions[0].header" exceeds maxLength (12). Value "xxxxxxxxxxxxxxxxxxxx" is 20 characters.`,
+		},
+		{
+			name:             "minItems",
+			toolName:         "ask_user",
+			params:           askUserParamsForExplain(),
+			args:             map[string]any{"questions": []any{}},
+			instanceLocation: "questions",
+			keyword:          "minItems",
+			want:             `ask_user: argument "questions" is below minItems (1). Value has 0 items.`,
+		},
+		{
+			name:     "maxItems",
+			toolName: "ask_user",
+			params:   askUserParamsForExplain(),
+			args: map[string]any{"questions": []any{
+				map[string]any{}, map[string]any{}, map[string]any{}, map[string]any{}, map[string]any{},
+			}},
+			instanceLocation: "questions",
+			keyword:          "maxItems",
+			want:             `ask_user: argument "questions" exceeds maxItems (4). Value has 5 items.`,
+		},
+		{
+			name:             "enum",
+			toolName:         "task_list",
+			params:           taskListParamsForExplain(),
+			args:             map[string]any{"action": "bogus"},
+			instanceLocation: "action",
+			keyword:          "enum",
+			want:             `task_list: argument "action" is not one of the allowed values: view, append, update. Value is "bogus".`,
+		},
+		{
+			name:     "nested enum",
+			toolName: "task_list",
+			params:   taskListParamsForExplain(),
+			args: map[string]any{
+				"action":  "update",
+				"updates": []any{map[string]any{"id": float64(1), "status": "bogus"}},
+			},
+			instanceLocation: "updates/0/status",
+			keyword:          "enum",
+			want:             `task_list: argument "updates[0].status" is not one of the allowed values: open, in_progress, done, cancelled. Value is "bogus".`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExplainSchemaError(tc.toolName, tc.params, tc.args, tc.instanceLocation, tc.keyword)
+			if got != tc.want {
+				t.Fatalf("got:\n%s\nwant:\n%s", got, tc.want)
+			}
+			if strings.Contains(got, "Required arguments") {
+				t.Fatalf("message must not include the generic required-arguments line: %q", got)
+			}
+		})
+	}
+}
+
+// TestExplainSchemaError_UnhandledKeywordFallsBackWithoutTail asserts the
+// "fall back gracefully" contract for constraint keywords with no dedicated
+// formatter (minimum, maximum, pattern, ...): the message degrades to the
+// generic "wrong type or value" sentence, but issue #193's misleading
+// "Required arguments" tail must NOT reappear just because the keyword is
+// unrecognized — the field is present either way.
+func TestExplainSchemaError_UnhandledKeywordFallsBackWithoutTail(t *testing.T) {
+	params := map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"limit": map[string]any{"type": "integer", "maximum": 100},
+		},
+		"required": []string{"limit"},
+	}
+	args := map[string]any{"limit": float64(500)}
+	got := ExplainSchemaError("list", params, args, "limit", "maximum")
+	want := "list: argument \"limit\" has the wrong type or value.\nExample: {\"limit\": 0}"
+	if got != want {
+		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+	if strings.Contains(got, "Required arguments") {
+		t.Fatalf("message must not include the generic required-arguments line: %q", got)
+	}
+}
+
 func TestExplainSchemaError_FlatTopLevelUnchanged(t *testing.T) {
 	// Regression: a single-segment instance location (today's only case)
 	// must still produce the unqualified "Required arguments:" line, with

--- a/agent/internal/tool/repair/explain_test.go
+++ b/agent/internal/tool/repair/explain_test.go
@@ -23,7 +23,7 @@ func editParamsForExplain() map[string]any {
 }
 
 func TestExplainSchemaError_NamesOffendingField(t *testing.T) {
-	msg := ExplainSchemaError("edit_file", editParamsForExplain(), map[string]any{"file_path": "/x"}, "old_string")
+	msg := ExplainSchemaError("edit_file", editParamsForExplain(), map[string]any{"file_path": "/x"}, "old_string", "")
 	if !strings.Contains(msg, `edit_file`) || !strings.Contains(msg, `"old_string"`) {
 		t.Fatalf("msg = %q", msg)
 	}
@@ -33,7 +33,7 @@ func TestExplainSchemaError_NamesOffendingField(t *testing.T) {
 }
 
 func TestExplainSchemaError_FallbackWhenUnknownField(t *testing.T) {
-	msg := ExplainSchemaError("edit_file", editParamsForExplain(), map[string]any{}, "")
+	msg := ExplainSchemaError("edit_file", editParamsForExplain(), map[string]any{}, "", "")
 	// Must still list required args + example even without a pinpointed field.
 	if !strings.Contains(msg, "file_path") || !strings.Contains(msg, "Example:") {
 		t.Fatalf("msg = %q", msg)
@@ -197,7 +197,7 @@ func TestExplainSchemaError_ArrayItemMissingRequiredField(t *testing.T) {
 		"action":  "update",
 		"updates": []any{map[string]any{"id": float64(1), "notes": "x"}},
 	}
-	got := ExplainSchemaError("task_list", params, args, "updates/0")
+	got := ExplainSchemaError("task_list", params, args, "updates/0", "")
 	want := "task_list: missing required argument \"status\" in updates[0].\n" +
 		"Required arguments in updates[0]: id (integer), status (string).\n" +
 		"Example: {\"action\": \"...\"}"
@@ -215,12 +215,15 @@ func TestExplainSchemaError_NestedPropertyWrongTypeOrValue(t *testing.T) {
 			"options":  []any{},
 		}},
 	}
-	got := ExplainSchemaError("ask_user", params, args, "questions/0/header")
-	want := "ask_user: argument \"questions[0].header\" has the wrong type or value.\n" +
-		"Required arguments in questions[0]: question (string), options (array).\n" +
-		"Example: {\"questions\": []}"
+	got := ExplainSchemaError("ask_user", params, args, "questions/0/header", "maxLength")
+	want := "ask_user: argument \"questions[0].header\" exceeds maxLength (12). Value \"xxxxxxxxxxxxxxxxxxxx\" is 20 characters."
 	if got != want {
 		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+	// The misleading "Required arguments" scaffolding must be gone — the
+	// actual constraint (maxLength) and value/length are surfaced instead.
+	if strings.Contains(got, "Required arguments") {
+		t.Fatalf("message must not include the generic required-arguments line: %q", got)
 	}
 }
 
@@ -228,7 +231,7 @@ func TestExplainSchemaError_FlatTopLevelUnchanged(t *testing.T) {
 	// Regression: a single-segment instance location (today's only case)
 	// must still produce the unqualified "Required arguments:" line, with
 	// no "in <container>" text anywhere.
-	msg := ExplainSchemaError("edit_file", editParamsForExplain(), map[string]any{"file_path": "/x"}, "old_string")
+	msg := ExplainSchemaError("edit_file", editParamsForExplain(), map[string]any{"file_path": "/x"}, "old_string", "")
 	want := "edit_file: missing required argument \"old_string\".\n" +
 		"Required arguments: file_path (string), old_string (string), new_string (string).\n" +
 		"Example: {\"file_path\": \"...\", \"new_string\": \"...\", \"old_string\": \"...\"}"
@@ -245,8 +248,8 @@ func TestExplainSchemaError_DoesNotMutateStringRequired(t *testing.T) {
 	params := editParamsForExplain()
 	params["required"] = required
 
-	first := ExplainSchemaError("edit_file", params, map[string]any{}, "")
-	second := ExplainSchemaError("edit_file", params, map[string]any{}, "")
+	first := ExplainSchemaError("edit_file", params, map[string]any{}, "", "")
+	second := ExplainSchemaError("edit_file", params, map[string]any{}, "", "")
 	if first != second {
 		t.Fatalf("explanation changed across calls:\nfirst:  %q\nsecond: %q", first, second)
 	}

--- a/agent/internal/tool/repair/repair_fuzz_test.go
+++ b/agent/internal/tool/repair/repair_fuzz_test.go
@@ -159,8 +159,8 @@ func FuzzRepairDiagnostics(f *testing.F) {
 			offendingField = ""
 		}
 
-		schemaMessage := ExplainSchemaError(toolName, params, args, offendingField)
-		if schemaMessage != ExplainSchemaError(toolName, params, args, offendingField) {
+		schemaMessage := ExplainSchemaError(toolName, params, args, offendingField, "")
+		if schemaMessage != ExplainSchemaError(toolName, params, args, offendingField, "") {
 			t.Fatalf("schema explanation was not deterministic: %q", schemaMessage)
 		}
 		if !strings.Contains(schemaMessage, "Example:") {

--- a/agent/session_tool_repair.go
+++ b/agent/session_tool_repair.go
@@ -71,7 +71,7 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 		}
 		healed, c := repair.RepairArgs(t.Definition.Parameters, args)
 		if err2 := t.Schema.Validate(healed); err2 != nil {
-			res.PrevalErr = repair.ExplainSchemaError(requestedVisible, t.Definition.Parameters, healed, offendingField(err2))
+			res.PrevalErr = repair.ExplainSchemaError(requestedVisible, t.Definition.Parameters, healed, offendingField(err2), offendingKeyword(err2))
 			return res
 		}
 		args = healed
@@ -111,4 +111,26 @@ func offendingField(err error) string {
 		ve = ve.Causes[0]
 	}
 	return strings.Trim(ve.InstanceLocation, "/")
+}
+
+// offendingKeyword extracts the failing JSON-Schema keyword's name from a
+// jsonschema validation error — the last segment of the deepest cause's
+// KeywordLocation (e.g. "maxLength" for a string that exceeded its limit, or
+// "required" for a missing required property). ExplainSchemaError uses it to
+// surface the actual constraint that rejected a present field instead of the
+// generic "wrong type or value" message. Returns "" when no keyword can be
+// pinpointed.
+func offendingKeyword(err error) string {
+	var ve *jsonschema.ValidationError
+	if !errors.As(err, &ve) {
+		return ""
+	}
+	for len(ve.Causes) > 0 {
+		ve = ve.Causes[0]
+	}
+	kw := strings.Trim(ve.KeywordLocation, "/")
+	if i := strings.LastIndex(kw, "/"); i >= 0 {
+		return kw[i+1:]
+	}
+	return kw
 }

--- a/agent/session_tool_repair_test.go
+++ b/agent/session_tool_repair_test.go
@@ -185,6 +185,24 @@ func TestPrepareToolCall_NestedSchemaErrors_NameRealFieldAndContainer(t *testing
 			t.Fatalf("PrevalErr =\n%s\nwant:\n%s", res.PrevalErr, want)
 		}
 	})
+
+	// The RCA for issue #193 confirmed enum is a second, independently
+	// affected constraint class: an invalid task_list action produced the
+	// same misleading "has the wrong type or value" + "Required arguments:
+	// action (string)." pair, even though action was present. Verify it
+	// through the real DefTaskList schema, not a hand-built fixture.
+	t.Run("task_list action bogus enum value", func(t *testing.T) {
+		call := llm.ToolCallData{ID: "c4", Name: "task_list",
+			Arguments: json.RawMessage(`{"action":"bogus"}`)}
+		res := prepareToolCall(call, reg.Get("task_list"), []string{"task_list"}, "task_list", "")
+		want := "task_list: argument \"action\" is not one of the allowed values: view, append, update. Value is \"bogus\"."
+		if res.PrevalErr != want {
+			t.Fatalf("PrevalErr =\n%s\nwant:\n%s", res.PrevalErr, want)
+		}
+		if strings.Contains(res.PrevalErr, "Required arguments") {
+			t.Fatalf("message must not include the generic required-arguments line: %q", res.PrevalErr)
+		}
+	})
 }
 
 // A non-length stop keeps the existing invalid-JSON coaching path.

--- a/agent/session_tool_repair_test.go
+++ b/agent/session_tool_repair_test.go
@@ -164,9 +164,23 @@ func TestPrepareToolCall_NestedSchemaErrors_NameRealFieldAndContainer(t *testing
 		call := llm.ToolCallData{ID: "c2", Name: "ask_user",
 			Arguments: json.RawMessage(`{"questions":[{"header":"way too long for a chip label","question":"q","options":[{"label":"a","detail":"a"},{"label":"b","detail":"b"}]}]}`)}
 		res := prepareToolCall(call, reg.Get("ask_user"), []string{"ask_user"}, "ask_user", "")
-		want := "ask_user: argument \"questions[0].header\" has the wrong type or value.\n" +
-			"Required arguments in questions[0]: question (string), options (array).\n" +
-			"Example: {\"questions\": []}"
+		want := "ask_user: argument \"questions[0].header\" exceeds maxLength (12). Value \"way too long for a chip label\" is 29 characters."
+		if res.PrevalErr != want {
+			t.Fatalf("PrevalErr =\n%s\nwant:\n%s", res.PrevalErr, want)
+		}
+		if strings.Contains(res.PrevalErr, "Required arguments") {
+			t.Fatalf("message must not include the generic required-arguments line: %q", res.PrevalErr)
+		}
+	})
+
+	// Issue #193 repro: a header exceeding the documented maxLength (12)
+	// must surface the actual constraint and value/length, not the misleading
+	// "Required arguments" message that claims question/options were missing.
+	t.Run("ask_user header Module & repo is 13 chars", func(t *testing.T) {
+		call := llm.ToolCallData{ID: "c3", Name: "ask_user",
+			Arguments: json.RawMessage(`{"questions":[{"header":"Module & repo","question":"q","options":[{"label":"a","detail":"a"},{"label":"b","detail":"b"}]}]}`)}
+		res := prepareToolCall(call, reg.Get("ask_user"), []string{"ask_user"}, "ask_user", "")
+		want := "ask_user: argument \"questions[0].header\" exceeds maxLength (12). Value \"Module & repo\" is 13 characters."
 		if res.PrevalErr != want {
 			t.Fatalf("PrevalErr =\n%s\nwant:\n%s", res.PrevalErr, want)
 		}


### PR DESCRIPTION
Fixes #193

When an optional field like header exceeds its maxLength constraint, the error now names the specific constraint and value instead of falling back to a generic 'required arguments' message that sends the caller debugging the wrong parameter.