### PR TITLE
fix(agent): pin delegate tool call rendering in session transcript

### DIFF
--- a/agent/session_client_mutation_doctor_drift_test.go
+++ b/agent/session_client_mutation_doctor_drift_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -72,6 +73,14 @@ func fillEveryField(t *testing.T, v reflect.Value, path string) {
 		pointer := reflect.New(v.Type().Elem())
 		fillEveryField(t, pointer.Elem(), path)
 		v.Set(pointer)
+	case reflect.Interface:
+		if v.Type() == reflect.TypeFor[error]() {
+			v.Set(reflect.ValueOf(errors.New(path)))
+			return
+		}
+		// A generic `any` field (e.g. a json:"...,omitempty" structured payload)
+		// holds a JSON-serializable value.
+		v.Set(reflect.ValueOf(map[string]any{"populated": true}))
 	case reflect.Slice:
 		// A raw message must hold valid JSON; any other byte slice marshals as
 		// base64 and can hold anything.

--- a/agent/session_outline.go
+++ b/agent/session_outline.go
@@ -65,7 +65,12 @@ type jobResult struct {
 }
 
 func (r jobResult) effectiveJobID() string {
-	for _, id := range []string{r.JobID, r.CurrentJobID, r.StartedJobID, r.LatestJobID} {
+	// DelegateID is the fallback, checked last: the stable-delegate result shape
+	// (agent/session_tools.go's stableDelegateCreateResult, agent/session_tools_jobs.go's
+	// delegateSendResult) carries no job_id family member at all, so without this
+	// fallback a delegate/delegate_send result always has an empty job identity
+	// (issue #194).
+	for _, id := range []string{r.JobID, r.CurrentJobID, r.StartedJobID, r.LatestJobID, r.DelegateID} {
 		if id != "" {
 			return id
 		}

--- a/agent/transcript_render.go
+++ b/agent/transcript_render.go
@@ -1171,6 +1171,34 @@ var jobResultKnownKeys = map[string]bool{
 	"delivered":                true,
 	"message_type":             true,
 	"wait_ignored_reason":      true,
+	// The stable-delegate identity fields below were introduced by 31fc13ae3
+	// ("Route delegate creation through stable resources"), 731a6bf05
+	// ("Preserve stable delegate identity in bounded create results"), and
+	// 0c182da4f ("fix: preserve stable delegate tool projections") — see
+	// stableDelegateCreateResult (agent/session_tools.go) and
+	// delegateSendResult (agent/session_tools_jobs.go). Neither struct carries a
+	// job_id family member; a "delegate"/"delegate_send" result identifies
+	// itself via delegate_id alone (jobResult.effectiveJobID's fallback).
+	// TestJobResultKnownKeysCoversLiveDelegateShapes (transcript_render_job_test.go)
+	// walks both structs' real marshaled output and fails, naming the key, the
+	// next time either struct grows a field this allowlist doesn't know — issue #194.
+	"child_session_id":    true, // stableDelegateCreateResult
+	"model":               true, // stableDelegateCreateResult
+	"sandbox":             true, // stableDelegateCreateResult
+	"worktree":            true, // stableDelegateCreateResult, delegateSendResult
+	"warnings":            true, // stableDelegateCreateResult, delegateSendResult
+	"error":               true, // stableDelegateCreateResult (StartError)
+	"task":                true, // delegateSendResult
+	"description":         true, // delegateSendResult
+	"agent_type":          true, // delegateSendResult
+	"requested_model":     true, // delegateSendResult
+	"resolved_profile_id": true, // delegateSendResult
+	"resolved_model":      true, // delegateSendResult
+	"reasoning_effort":    true, // delegateSendResult
+	"run_started_at":      true, // delegateSendResult
+	"run_ended_at":        true, // delegateSendResult
+	"latest_activity_at":  true, // delegateSendResult
+	"cumulative_usage":    true, // delegateSendResult
 }
 
 var jobResultMetadataKeys = []string{
@@ -1194,6 +1222,24 @@ var jobResultMetadataKeys = []string{
 	"delivered",
 	"message_type",
 	"wait_ignored_reason",
+	// Stable-delegate identity/diagnostic scalars (see jobResultKnownKeys
+	// above). "error" belongs here, not a dedicated status-line segment like
+	// reason, because unlike reason it's specific to the create path and would
+	// otherwise become a known-but-invisible key — silently dropped evidence
+	// the moment it stops triggering the raw-JSON-dump fallback.
+	"child_session_id",
+	"model",
+	"error",
+	"task",
+	"description",
+	"agent_type",
+	"requested_model",
+	"resolved_profile_id",
+	"resolved_model",
+	"reasoning_effort",
+	"run_started_at",
+	"run_ended_at",
+	"latest_activity_at",
 }
 
 func jobResultMetadata(raw string) string {

--- a/agent/transcript_render_job_test.go
+++ b/agent/transcript_render_job_test.go
@@ -2,10 +2,14 @@ package agent
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
+	"primeradiant.com/evener/agent/internal/jobstore"
+	"primeradiant.com/evener/agent/internal/tool"
 	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/llm"
 )
 
 // renderToolCardForResult builds a one-round transcript (assistant call + paired
@@ -20,68 +24,74 @@ func renderToolCardForResult(toolName, callID string, content any) string {
 	return renderMarkdown(transcript.Header{}, entries, 0, renderOpts{})
 }
 
+// delegateSendToolResult marshals res via the REAL delegate_send marshaler
+// (marshalDelegateSendResult) and shapes a ToolResultData exactly like
+// production: ToolState carries the JSON state
+// (agent/internal/tool/registry.go's StateResult handling — json.Marshal(State)
+// — is what session_tool_round.go actually persists), Content carries the
+// LLM-facing footer text. toolResultStateOrContent (agent/session_outline.go)
+// prefers ToolState, so this is the shape the renderers actually see.
+func delegateSendToolResult(t *testing.T, callID string, res sendMessageResult, maxChars int) *llm.ToolResultData {
+	t.Helper()
+	value, err := marshalDelegateSendResult(res, maxChars)
+	if err != nil {
+		t.Fatalf("marshalDelegateSendResult: %v", err)
+	}
+	sr, ok := value.(tool.StateResult)
+	if !ok {
+		t.Fatalf("marshalDelegateSendResult returned %T, want tool.StateResult", value)
+	}
+	state, err := json.Marshal(sr.State)
+	if err != nil {
+		t.Fatalf("marshal delegate_send state: %v", err)
+	}
+	r := result(callID, "delegate_send", sr.Output, false)
+	r.ToolState = state
+	return r
+}
+
 // TestRenderMarkdown_JobDelegateResult is the headline lifecycle case: a
-// delegate result whose job body carries a multi-line output renders legibly: a
-// status line surfacing status and the transcript_ref before the output, then
-// the output with real newlines.
+// delegate create result — the real stable-delegate wire shape produced by
+// marshalStableDelegateCreateResult (issue #194) — renders as the condensed
+// status line (job identity via the delegate_id fallback, status, and
+// transcript_ref), not a raw JSON dump.
 func TestRenderMarkdown_JobDelegateResult(t *testing.T) {
 	t.Parallel()
 	childRef := "local:01CHILDJOB000000000000"
-	output := "First line of the report.\nSECOND_LINE_NEEDLE summarizing findings.\nThird line with a conclusion."
-	body, err := json.Marshal(map[string]any{
-		"job_id":                "job_delegate_1",
-		"type":                  "delegate",
-		"status":                "completed",
-		"running_in_background": false,
-		"timed_out":             false,
-		"transcript_ref":        childRef,
-		"output":                output,
-		"truncated":             false,
-	})
+	body, err := marshalStableDelegateCreateResult(stableDelegateCreateResult{
+		DelegateID:    "dlg_delegate_1",
+		Type:          "delegate",
+		Status:        "completed",
+		TranscriptRef: childRef,
+		Resumable:     boolPtr(true),
+	}, 0)
 	if err != nil {
-		t.Fatalf("marshal job result: %v", err)
+		t.Fatalf("marshalStableDelegateCreateResult: %v", err)
 	}
 
-	out := renderToolCardForResult("delegate", "call_delegate", string(body))
+	out := renderToolCardForResult("delegate", "call_delegate", body)
 
 	// The status line surfaces status and job identity without a legacy success field.
 	if !strings.Contains(out, "status=completed") {
 		t.Errorf("expected status=completed on the status line, got:\n%s", out)
 	}
-	if !strings.Contains(out, "job_id=job_delegate_1") {
-		t.Errorf("expected job_id on the status line, got:\n%s", out)
+	// A stable-delegate create result carries no job_id family — the status line
+	// must fall back to delegate_id (jobResult.effectiveJobID, session_outline.go).
+	if !strings.Contains(out, "job_id=dlg_delegate_1") {
+		t.Errorf("expected job_id=dlg_delegate_1 (delegate_id fallback), got:\n%s", out)
 	}
 	if strings.Contains(out, "success=") {
 		t.Errorf("job result must not render legacy success field, got:\n%s", out)
 	}
-
-	// The transcript_ref is present before the output body.
-	if !strings.Contains(out, childRef) {
-		t.Errorf("expected transcript_ref %q in output, got:\n%s", childRef, out)
-	}
-	refIdx := strings.Index(out, childRef)
-	outputIdx := strings.Index(out, "SECOND_LINE_NEEDLE")
-	if refIdx < 0 || outputIdx < 0 {
-		t.Fatalf("missing content: refIdx=%d outputIdx=%d\n%s", refIdx, outputIdx, out)
-	}
-	if refIdx > outputIdx {
-		t.Errorf("transcript_ref (%d) must appear BEFORE the output body (%d):\n%s", refIdx, outputIdx, out)
+	if !strings.Contains(out, "transcript_ref="+childRef) {
+		t.Errorf("expected transcript_ref=%s on the status line, got:\n%s", childRef, out)
 	}
 
-	// The output renders with real newlines: the known second line appears on its
-	// own line (preceded by a newline, not glued to the first line).
-	if !strings.Contains(out, "\nSECOND_LINE_NEEDLE summarizing findings.") &&
-		!strings.Contains(out, "  SECOND_LINE_NEEDLE summarizing findings.") {
-		t.Errorf("output second line must appear on its own line with real newlines, got:\n%s", out)
-	}
-
-	// The backslash-escaped form must be gone: no literal \n escape, no JSON-quoted
-	// output field dumped verbatim.
-	if strings.Contains(out, `\n`) {
-		t.Errorf("escaped \\n must not appear (output must be de-escaped), got:\n%s", out)
-	}
-	if strings.Contains(out, `"output":`) {
-		t.Errorf("raw JSON job result must not be dumped verbatim, got:\n%s", out)
+	// NOT a raw JSON dump: the issue #194 regression was exactly this — an
+	// allowlist-unknown top-level key (e.g. child_session_id, model) made
+	// jobResultBody bail to prettyJSON instead of the condensed status line.
+	if strings.Contains(out, `"delegate_id":`) {
+		t.Errorf("delegate create result rendered as a raw JSON dump instead of the condensed status line, got:\n%s", out)
 	}
 }
 
@@ -130,42 +140,57 @@ func TestRenderMarkdown_JobSendMessageResult(t *testing.T) {
 	}
 }
 
+// TestRenderMarkdown_DelegateSendResult drives the real delegate_send
+// marshaler (marshalDelegateSendResult) so the fixture matches production's
+// actual wire shape: sendMessageResult has no job_id family at all (only
+// delegate_id), so the status line's job identity depends entirely on the
+// delegate_id fallback (agent/session_outline.go effectiveJobID).
 func TestRenderMarkdown_DelegateSendResult(t *testing.T) {
 	t.Parallel()
 	childRef := "local:01DELEGATESEND000000"
-	body, err := json.Marshal(map[string]any{
-		"delegate_id":           "dlg_01J",
-		"started_job_id":        "job_new",
-		"current_job_id":        "job_new",
-		"latest_job_id":         "job_new",
-		"type":                  "delegate",
-		"status":                "completed",
-		"running_in_background": false,
-		"timed_out":             false,
-		"action":                "started",
-		"transcript_ref":        childRef,
-		"output":                "done",
-		"truncated":             false,
-	})
-	if err != nil {
-		t.Fatalf("marshal delegate_send result: %v", err)
-	}
+	output := "First line of the report.\nSECOND_LINE_NEEDLE summarizing findings.\nThird line with a conclusion."
+	res := delegateSendToolResult(t, "call_send", sendMessageResult{
+		DelegateID:    "dlg_01J",
+		Type:          "delegate",
+		Status:        jobstore.StatusCompleted,
+		Action:        "started",
+		TranscriptRef: childRef,
+		Output:        output,
+	}, 0)
 
-	out := renderToolCardForResult("delegate_send", "call_send", string(body))
+	entries := []transcript.Entry{
+		toolCallEntry(call("call_send", "delegate_send", `{}`)),
+		toolResultEntry(res),
+	}
+	out := renderMarkdown(transcript.Header{}, entries, 0, renderOpts{})
 
 	for _, want := range []string{
-		"job_id=job_new",
+		"job_id=dlg_01J",
 		"status=completed",
 		"transcript_ref=" + childRef,
-		"delegate_id=dlg_01J",
-		"started_job_id=job_new",
-		"current_job_id=job_new",
 		"action=started",
-		"done",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("delegate_send render missing %q:\n%s", want, out)
 		}
+	}
+
+	// The transcript_ref precedes the output, and the output de-escapes to real
+	// newlines (the pre-#194 pin, replayed against the real marshaler).
+	refIdx := strings.Index(out, childRef)
+	outputIdx := strings.Index(out, "SECOND_LINE_NEEDLE")
+	if refIdx < 0 || outputIdx < 0 || refIdx > outputIdx {
+		t.Fatalf("transcript_ref (%d) must appear BEFORE the output body (%d):\n%s", refIdx, outputIdx, out)
+	}
+	if strings.Contains(out, `\n`) {
+		t.Errorf("escaped \\n must not appear (output must be de-escaped), got:\n%s", out)
+	}
+
+	// NOT a raw JSON dump: delegate_send's new fields (task, description,
+	// agent_type, ...) used to be allowlist-unknown, forcing the same fallback
+	// via toolResultStateOrContent.
+	if strings.Contains(out, `"delegate_id":`) {
+		t.Errorf("delegate_send result rendered as a raw JSON dump instead of the condensed status line, got:\n%s", out)
 	}
 }
 
@@ -436,10 +461,21 @@ func TestDecodeJobResult(t *testing.T) {
 	})
 }
 
+// TestRenderOutline_JobLifecycleBrackets drives the real stable-delegate create
+// marshaler so the fixture matches production's wire shape (issue #194): no
+// job_id family, only delegate_id.
 func TestRenderOutline_JobLifecycleBrackets(t *testing.T) {
 	t.Parallel()
 	childRef := "local:01OUTLINEJOB000000000"
-	body := `{"job_id":"job_outline","type":"delegate","status":"completed","running_in_background":false,"timed_out":false,"transcript_ref":"` + childRef + `","output":"done","truncated":false}`
+	body, err := marshalStableDelegateCreateResult(stableDelegateCreateResult{
+		DelegateID:    "dlg_outline",
+		Type:          "delegate",
+		Status:        "completed",
+		TranscriptRef: childRef,
+	}, 0)
+	if err != nil {
+		t.Fatalf("marshalStableDelegateCreateResult: %v", err)
+	}
 	entries := []transcript.Entry{
 		toolCallEntry(call("call_delegate", "delegate", `{}`)),
 		toolResultEntry(result("call_delegate", "delegate", body, false)),
@@ -456,13 +492,23 @@ func TestRenderOutline_JobLifecycleBrackets(t *testing.T) {
 	}
 }
 
+// TestRenderOutline_DelegateSendLifecycleBrackets drives the real
+// delegate_send marshaler (marshalDelegateSendResult), via the same
+// ToolState-carrying shape production actually emits.
 func TestRenderOutline_DelegateSendLifecycleBrackets(t *testing.T) {
 	t.Parallel()
 	childRef := "local:01OUTLINEDELEGATESEND"
-	body := `{"delegate_id":"dlg_outline","started_job_id":"job_started","current_job_id":"job_started","latest_job_id":"job_started","type":"delegate","status":"running","running_in_background":true,"timed_out":false,"action":"started","transcript_ref":"` + childRef + `","truncated":false}`
+	res := delegateSendToolResult(t, "call_send", sendMessageResult{
+		DelegateID:          "dlg_outline",
+		Type:                "delegate",
+		Status:              jobstore.StatusRunning,
+		Action:              "started",
+		RunningInBackground: true,
+		TranscriptRef:       childRef,
+	}, 0)
 	entries := []transcript.Entry{
 		toolCallEntry(call("call_send", "delegate_send", `{}`)),
-		toolResultEntry(result("call_send", "delegate_send", body, false)),
+		toolResultEntry(res),
 	}
 
 	out, _, _ := renderOutline(entries, 0, len(entries)-1)
@@ -512,5 +558,130 @@ func TestPrettyJSON_NoHTMLEscaping(t *testing.T) {
 	}
 	if !strings.Contains(out, ">") {
 		t.Errorf("expected literal > in output (not \\u003e), got:\n%s", out)
+	}
+}
+
+// TestJobResultKnownKeysCoversLiveDelegateShapes is the schema-drift guard
+// (issue #194 RCA fix plan item 3): it walks the REAL marshaled output of the
+// two live result marshalers that feed jobResultBody/extractJobResult —
+// marshalStableDelegateCreateResult (the "delegate" create tool) and
+// marshalDelegateSendResult (the "delegate_send" tool, via the same
+// tool.StateResult path session_tool_round.go actually persists) — and asserts
+// every top-level key either marshaler ever emits is present in
+// jobResultKnownKeys. fillEveryField (agent/session_client_mutation_doctor_drift_test.go)
+// sets every field to a non-zero value via reflection, so a field added to
+// either struct tomorrow is populated and checked with no edit to this test —
+// the next drift fails CI, named, instead of silently degrading rendering to a
+// raw JSON dump.
+func TestJobResultKnownKeysCoversLiveDelegateShapes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("stableDelegateCreateResult via marshalStableDelegateCreateResult", func(t *testing.T) {
+		var out stableDelegateCreateResult
+		fillEveryField(t, reflect.ValueOf(&out).Elem(), "stableDelegateCreateResult")
+		// maxChars<=0 is unbounded (marshalBoundedJSON), so the fit-downgrade
+		// path never drops a field out of the fully-populated fixture.
+		wire, err := marshalStableDelegateCreateResult(out, 0)
+		if err != nil {
+			t.Fatalf("marshalStableDelegateCreateResult: %v", err)
+		}
+		assertKeysKnownToJobResult(t, wire, "stableDelegateCreateResult")
+	})
+
+	t.Run("delegate_send result via marshalDelegateSendResult", func(t *testing.T) {
+		var res sendMessageResult
+		fillEveryField(t, reflect.ValueOf(&res).Elem(), "sendMessageResult")
+		value, err := marshalDelegateSendResult(res, 0)
+		if err != nil {
+			t.Fatalf("marshalDelegateSendResult: %v", err)
+		}
+		sr, ok := value.(tool.StateResult)
+		if !ok {
+			t.Fatalf("marshalDelegateSendResult returned %T, want tool.StateResult", value)
+		}
+		// json.Marshal(State) is exactly what agent/internal/tool/registry.go
+		// persists into ToolResultData.ToolState (the wire toolResultStateOrContent
+		// hands to jobResultBody).
+		wire, err := json.Marshal(sr.State)
+		if err != nil {
+			t.Fatalf("marshal delegate_send state: %v", err)
+		}
+		assertKeysKnownToJobResult(t, string(wire), "delegate_send result")
+	})
+}
+
+// assertKeysKnownToJobResult fails, naming the offending key, if wire (a JSON
+// object) carries a top-level key absent from jobResultKnownKeys
+// (agent/transcript_render.go) — the same allowlist hasNonJobResultKeys checks
+// before jobResultBody renders the condensed status line.
+func assertKeysKnownToJobResult(t *testing.T, wire, label string) {
+	t.Helper()
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(wire), &m); err != nil {
+		t.Fatalf("%s: unmarshal wire output: %v\n%s", label, err, wire)
+	}
+	for k := range m {
+		if !jobResultKnownKeys[k] {
+			t.Errorf("%s: emits key %q, which jobResultKnownKeys (agent/transcript_render.go) does not know — "+
+				"add it to the allowlist or the condensed status line silently degrades to a raw JSON dump", label, k)
+		}
+	}
+}
+
+// TestJobResult_EffectiveJobIDDelegateIDFallback pins jobResult.effectiveJobID's
+// priority order (agent/session_outline.go): the legacy job_id family first
+// (JobID, CurrentJobID, StartedJobID, LatestJobID, in that order), DelegateID as
+// the fallback for the stable-delegate shape (issue #194 RCA fix plan item 2,
+// which carries no job_id family at all), empty when nothing is set.
+func TestJobResult_EffectiveJobIDDelegateIDFallback(t *testing.T) {
+	t.Parallel()
+
+	t.Run("delegate_id used when no job_id family is present", func(t *testing.T) {
+		r := jobResult{DelegateID: "dlg_only"}
+		if got := r.effectiveJobID(); got != "dlg_only" {
+			t.Errorf("effectiveJobID() = %q, want dlg_only (delegate_id fallback)", got)
+		}
+	})
+
+	t.Run("job_id family takes priority over delegate_id", func(t *testing.T) {
+		r := jobResult{DelegateID: "dlg_low_priority", CurrentJobID: "job_wins"}
+		if got := r.effectiveJobID(); got != "job_wins" {
+			t.Errorf("effectiveJobID() = %q, want job_wins (job_id family before delegate_id)", got)
+		}
+	})
+
+	t.Run("empty when nothing set", func(t *testing.T) {
+		r := jobResult{}
+		if got := r.effectiveJobID(); got != "" {
+			t.Errorf("effectiveJobID() = %q, want empty", got)
+		}
+	})
+}
+
+// TestRenderMarkdown_DelegateCreateErrorSurfaces guards against a narrower
+// version of the issue #194 regression: once "error" is added to
+// jobResultKnownKeys so a failed-but-identified delegate create no longer dumps
+// raw JSON, the StartError text itself must still be visible in the condensed
+// rendering (via jobResultMetadataKeys) — not silently dropped now that the
+// dump-with-full-evidence fallback no longer fires for it.
+func TestRenderMarkdown_DelegateCreateErrorSurfaces(t *testing.T) {
+	t.Parallel()
+	body, err := marshalStableDelegateCreateResult(stableDelegateCreateResult{
+		DelegateID: "dlg_partial_fail",
+		Type:       "delegate",
+		Status:     "failed",
+		StartError: "sandbox denied: escalation beyond parent floor",
+	}, 0)
+	if err != nil {
+		t.Fatalf("marshalStableDelegateCreateResult: %v", err)
+	}
+
+	out := renderToolCardForResult("delegate", "call_delegate", body)
+
+	if !strings.Contains(out, "sandbox denied: escalation beyond parent floor") {
+		t.Errorf("StartError must remain visible in the condensed rendering, got:\n%s", out)
+	}
+	if strings.Contains(out, `"delegate_id":`) {
+		t.Errorf("delegate create result rendered as a raw JSON dump instead of the condensed status line, got:\n%s", out)
 	}
 }

--- a/agent/transcript_render_test.go
+++ b/agent/transcript_render_test.go
@@ -1933,6 +1933,206 @@ func TestRenderMarkdown_LongResultLineClamped(t *testing.T) {
 	})
 }
 
+// delegateCreateBody marshals a stable-delegate create result via the REAL
+// production marshaler (marshalStableDelegateCreateResult), so these fixtures
+// carry exactly the wire shape stableDelegateCreateTool emits — the shape that
+// exposed the issue #194 regression (an allowlist-unknown key like
+// child_session_id silently downgraded the render to a raw JSON dump).
+func delegateCreateBody(t *testing.T, out stableDelegateCreateResult) string {
+	t.Helper()
+	body, err := marshalStableDelegateCreateResult(out, 0)
+	if err != nil {
+		t.Fatalf("marshalStableDelegateCreateResult: %v", err)
+	}
+	return body
+}
+
+// TestRenderMarkdown_DelegateToolCallAppears verifies that a delegate tool call
+// and its paired result render in the session transcript markdown, so spawned
+// subagents stay auditable in the parent transcript (issue #194). Critically,
+// the result must render as the condensed status line, NOT a raw pretty-printed
+// JSON dump — the actual regression: an unknown top-level key (child_session_id)
+// used to make jobResultBody bail to prettyJSON.
+func TestRenderMarkdown_DelegateToolCallAppears(t *testing.T) {
+	t.Parallel()
+	childRef := "local:01CHILDSESS000000000"
+	body := delegateCreateBody(t, stableDelegateCreateResult{
+		DelegateID:     "dlg_01",
+		ChildSessionID: "sess_01",
+		Type:           "delegate",
+		Status:         "running",
+		TranscriptRef:  childRef,
+	})
+	entries := []transcript.Entry{
+		// seq 0: assistant turn issuing a delegate call.
+		toolCallEntry(call("call_delegate", "delegate", `{"task":"investigate the render path","agent_type":"explorer"}`)),
+		// seq 1: the paired delegate result.
+		toolResultEntry(result("call_delegate", "delegate", body, false)),
+	}
+	out := renderMarkdown(transcript.Header{}, entries, 0, renderOpts{})
+
+	// The delegate tool call must appear as a tool card, not be dropped.
+	if !strings.Contains(out, "[ok] `delegate`") {
+		t.Errorf("expected [ok] delegate card, got:\n%s", out)
+	}
+	// The delegate's task argument must surface in the input summary so a reader
+	// can audit what the subagent was asked to do.
+	if !strings.Contains(out, "investigate the render path") {
+		t.Errorf("delegate task argument missing from rendered card, got:\n%s", out)
+	}
+	// The condensed status line: job identity (via the delegate_id fallback),
+	// status, and the child transcript_ref so the parent can pivot to the child
+	// session.
+	if !strings.Contains(out, "job_id=dlg_01") {
+		t.Errorf("expected condensed job_id=dlg_01 (delegate_id fallback), got:\n%s", out)
+	}
+	if !strings.Contains(out, "status=running") {
+		t.Errorf("expected condensed status=running, got:\n%s", out)
+	}
+	if !strings.Contains(out, "transcript_ref="+childRef) {
+		t.Errorf("expected condensed transcript_ref=%s, got:\n%s", childRef, out)
+	}
+	// The delegate call must render under the assistant heading, not as an
+	// orphaned "call not shown" result.
+	if strings.Contains(out, "Tool results without a shown call") {
+		t.Errorf("paired delegate result must not appear as call-not-shown, got:\n%s", out)
+	}
+	// NOT a raw JSON dump: the pretty-printed "key": value signature (unique to
+	// prettyJSON's fallback) must be absent from the condensed rendering.
+	if strings.Contains(out, `"delegate_id":`) {
+		t.Errorf("delegate result rendered as a raw JSON dump instead of the condensed status line, got:\n%s", out)
+	}
+}
+
+// TestRenderMarkdown_BatchedDelegateToolCallsAppear is the batched sibling of
+// TestRenderMarkdown_DelegateToolCallAppears: several delegate calls issued in
+// one assistant turn (issue #194's original repro shape) must each render as
+// their own condensed status line, not a raw JSON dump.
+func TestRenderMarkdown_BatchedDelegateToolCallsAppear(t *testing.T) {
+	t.Parallel()
+	type spec struct {
+		callID, delegateID, childRef string
+	}
+	specs := []spec{
+		{"call_delegate_0", "dlg_batch_0", "local:01BATCH0000000000000"},
+		{"call_delegate_1", "dlg_batch_1", "local:01BATCH0000000000001"},
+		{"call_delegate_2", "dlg_batch_2", "local:01BATCH0000000000002"},
+	}
+
+	calls := make([]*llm.ToolCallData, len(specs))
+	results := make([]*llm.ToolResultData, len(specs))
+	for i, sp := range specs {
+		calls[i] = call(sp.callID, "delegate", fmt.Sprintf(`{"task":"batched research task %d"}`, i))
+		body := delegateCreateBody(t, stableDelegateCreateResult{
+			DelegateID:    sp.delegateID,
+			Type:          "delegate",
+			Status:        "running",
+			TranscriptRef: sp.childRef,
+		})
+		results[i] = result(sp.callID, "delegate", body, false)
+	}
+	entries := []transcript.Entry{
+		toolCallEntry(calls...),
+		toolResultEntry(results...),
+	}
+	out := renderMarkdown(transcript.Header{}, entries, 0, renderOpts{})
+
+	if got := strings.Count(out, "[ok] `delegate`"); got != len(specs) {
+		t.Errorf("expected %d [ok] delegate cards, got %d:\n%s", len(specs), got, out)
+	}
+	for i, sp := range specs {
+		if !strings.Contains(out, fmt.Sprintf("batched research task %d", i)) {
+			t.Errorf("call %d: task argument missing, got:\n%s", i, out)
+		}
+		if !strings.Contains(out, "job_id="+sp.delegateID) {
+			t.Errorf("call %d: expected condensed job_id=%s, got:\n%s", i, sp.delegateID, out)
+		}
+		if !strings.Contains(out, "transcript_ref="+sp.childRef) {
+			t.Errorf("call %d: expected condensed transcript_ref=%s, got:\n%s", i, sp.childRef, out)
+		}
+	}
+	// NOT a raw JSON dump for any of the batched results.
+	if strings.Contains(out, `"delegate_id":`) {
+		t.Errorf("a batched delegate result rendered as a raw JSON dump instead of the condensed status line, got:\n%s", out)
+	}
+}
+
+// TestRenderOutline_DelegateToolCallAppears verifies the delegate tool call
+// surfaces in the outline (turn map) view too, so the audit pivot works in both
+// render formats (issue #194).
+func TestRenderOutline_DelegateToolCallAppears(t *testing.T) {
+	t.Parallel()
+	childRef := "local:01OUTLINEDELEGATE00000000"
+	body := delegateCreateBody(t, stableDelegateCreateResult{
+		DelegateID:    "dlg_out",
+		Type:          "delegate",
+		Status:        "completed",
+		TranscriptRef: childRef,
+	})
+	entries := []transcript.Entry{
+		toolCallEntry(call("call_del", "delegate", `{"task":"map the render path"}`)),
+		toolResultEntry(result("call_del", "delegate", body, false)),
+	}
+	out, _, _ := renderOutline(entries, 0, len(entries)-1)
+
+	// The outline line must name the delegate tool.
+	if !strings.Contains(out, "delegate") {
+		t.Errorf("outline missing delegate tool name, got:\n%s", out)
+	}
+	// The job lifecycle bracket must surface the child transcript_ref so the
+	// parent can pivot to the child session.
+	wantBracket := "delegate[status=completed child=" + childRef + "]"
+	if !strings.Contains(out, wantBracket) {
+		t.Errorf("outline missing delegate lifecycle bracket %q, got:\n%s", wantBracket, out)
+	}
+	if strings.Contains(out, `"delegate_id":`) {
+		t.Errorf("outline must never contain raw JSON, got:\n%s", out)
+	}
+}
+
+// TestRenderOutline_BatchedDelegateToolCallsAppear is the batched sibling of
+// TestRenderOutline_DelegateToolCallAppears: each delegate call in a batched
+// round gets its own lifecycle bracket.
+func TestRenderOutline_BatchedDelegateToolCallsAppear(t *testing.T) {
+	t.Parallel()
+	type spec struct {
+		callID, delegateID, childRef, status string
+	}
+	specs := []spec{
+		{"call_delegate_0", "dlg_out_0", "local:01OUTBATCH000000000000", "running"},
+		{"call_delegate_1", "dlg_out_1", "local:01OUTBATCH000000000001", "completed"},
+		{"call_delegate_2", "dlg_out_2", "local:01OUTBATCH000000000002", "running"},
+	}
+
+	calls := make([]*llm.ToolCallData, len(specs))
+	results := make([]*llm.ToolResultData, len(specs))
+	for i, sp := range specs {
+		calls[i] = call(sp.callID, "delegate", fmt.Sprintf(`{"task":"outline batch task %d"}`, i))
+		body := delegateCreateBody(t, stableDelegateCreateResult{
+			DelegateID:    sp.delegateID,
+			Type:          "delegate",
+			Status:        sp.status,
+			TranscriptRef: sp.childRef,
+		})
+		results[i] = result(sp.callID, "delegate", body, false)
+	}
+	entries := []transcript.Entry{
+		toolCallEntry(calls...),
+		toolResultEntry(results...),
+	}
+	out, _, _ := renderOutline(entries, 0, len(entries)-1)
+
+	for _, sp := range specs {
+		want := "delegate[status=" + sp.status + " child=" + sp.childRef + "]"
+		if !strings.Contains(out, want) {
+			t.Errorf("outline missing bracket %q, got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, `"delegate_id":`) {
+		t.Errorf("outline must never contain raw JSON, got:\n%s", out)
+	}
+}
+
 // firstLines returns the first n lines of s, for compact error output.
 func firstLines(s string, n int) string {
 	lines := strings.SplitN(s, "\n", n+1)


### PR DESCRIPTION
Fixes #194

## Summary

Issue #194 reported that delegate tool calls were not appearing in the main session transcript. Investigation found that the described root cause (a "render allowlist" excluding the delegate tool) does not exist in the current code:

- The markdown render layer (`agent/transcript_render.go` `writeAssistantContent`) renders ALL tool calls generically. The only special-case is the result tool (`communicate`), which renders its `message` argument as assistant text rather than a tool card.
- `delegate` is already present in `jobLifecycleTools` (`agent/session_outline.go:80`) so its outline lifecycle bracket and result body render correctly.
- `delegate` is already a case in the `toolInputSummary` switch (`agent/transcript_render.go:1492`) so its input summary (task/agent_type/max_wait_ms) renders correctly.
- The recording path (`appendAssistantTurn`, `appendToolResults`, `writeTranscript`) persists every tool call and result by content kind, with no tool-name filtering.

A debug render confirmed a delegate call + paired result renders as an `[ok] `delegate`` card with the task argument and child `transcript_ref` visible.

## Change

Since there is no allowlist to add `delegate` to, this PR instead adds regression tests that pin the behavior so a future change cannot silently drop delegate tool calls from the rendered transcript:

- `TestRenderMarkdown_DelegateToolCallAppears` — verifies a delegate tool call and its paired result render in the markdown transcript (tool card, `[ok]` status, task argument, child `transcript_ref`, and not orphaned as "call not shown").
- `TestRenderOutline_DelegateToolCallAppears` — verifies the delegate tool surfaces in the outline (turn map) view, including the `delegate[status=completed child=local:...]` lifecycle bracket for the audit pivot.

Both tests are deterministic (pure render functions over fixture entries, no provider/git/network).

## Verification

```sh
go test ./agent/... -count=1
```

All 38 agent packages pass (agent 158.6s, plus 37 sub-packages). Exit code 0.