### PR TITLE
test(agent): drain FakeClock AfterFunc goroutines deterministically in sweep-cancel test

### DIFF
--- a/agent/internal/agenttest/clock.go
+++ b/agent/internal/agenttest/clock.go
@@ -88,11 +88,7 @@ func (f *FakeClock) AfterFunc(d time.Duration, fn func()) clock.Timer {
 	defer f.mu.Unlock()
 	w := &fakeWaiter{until: f.now.Add(d), fn: fn}
 	if d <= 0 {
-		f.dispatchWG.Add(1)
-		go func() {
-			defer f.dispatchWG.Done()
-			fn()
-		}()
+		f.dispatchWG.Go(fn)
 		return &fakeTimer{f: f, w: w}
 	}
 	f.addWaiterLocked(w)
@@ -208,11 +204,7 @@ func (f *FakeClock) addWaiterLocked(w *fakeWaiter) {
 
 func (f *FakeClock) fireLocked(w *fakeWaiter) {
 	if w.fn != nil {
-		f.dispatchWG.Add(1)
-		go func() {
-			defer f.dispatchWG.Done()
-			w.fn()
-		}()
+		f.dispatchWG.Go(w.fn)
 		return
 	}
 	select {

--- a/agent/internal/agenttest/clock.go
+++ b/agent/internal/agenttest/clock.go
@@ -21,6 +21,12 @@ type FakeClock struct {
 	now      time.Time
 	waiters  []*fakeWaiter
 	blockers []*blocker
+	// dispatchWG tracks every AfterFunc goroutine FakeClock has launched via
+	// `go fn()` (the d<=0 immediate-dispatch path and fireLocked's due-waiter
+	// path). Advance returns before those goroutines run; Drain waits on this
+	// group so a test can observe — deterministically, with no wall-clock sleep
+	// — whether a callback that should NOT have fired actually ran.
+	dispatchWG sync.WaitGroup
 }
 
 // fakeWaiter is one pending wait on virtual time: a timer/sleep/After delivers
@@ -82,7 +88,11 @@ func (f *FakeClock) AfterFunc(d time.Duration, fn func()) clock.Timer {
 	defer f.mu.Unlock()
 	w := &fakeWaiter{until: f.now.Add(d), fn: fn}
 	if d <= 0 {
-		go fn()
+		f.dispatchWG.Add(1)
+		go func() {
+			defer f.dispatchWG.Done()
+			fn()
+		}()
 		return &fakeTimer{f: f, w: w}
 	}
 	f.addWaiterLocked(w)
@@ -172,6 +182,25 @@ func (f *FakeClock) BlockedCount() int {
 	return len(f.waiters)
 }
 
+// Drain blocks until every AfterFunc goroutine FakeClock has dispatched so far
+// has completed. AfterFunc dispatches callbacks via `go fn()` (matching
+// time.AfterFunc), so Advance returns before a callback runs; Drain is the
+// bounded, deterministic way to wait for those goroutines instead of a
+// wall-clock sleep. It is the negative-assertion counterpart to BlockUntil:
+// BlockUntil waits for a goroutine to ARM a timer before virtual time moves;
+// Drain waits for a callback goroutine to FINISH after virtual time has fired
+// it (or after the d<=0 immediate-dispatch path launched it).
+//
+// All dispatchWG.Add calls happen under f.mu (in AfterFunc's d<=0 arm and in
+// fireLocked, both called while holding the lock), and a caller invokes Drain
+// only after the Advance that dispatched the goroutine has returned, so the
+// mutex release gives Drain's Wait a happens-before edge over every relevant
+// Add. Drain must not be called concurrently with ongoing AfterFunc scheduling
+// from callback goroutines (the sweep callback does not reschedule).
+func (f *FakeClock) Drain() {
+	f.dispatchWG.Wait()
+}
+
 func (f *FakeClock) addWaiterLocked(w *fakeWaiter) {
 	f.waiters = append(f.waiters, w)
 	f.notifyBlockersLocked()
@@ -179,7 +208,11 @@ func (f *FakeClock) addWaiterLocked(w *fakeWaiter) {
 
 func (f *FakeClock) fireLocked(w *fakeWaiter) {
 	if w.fn != nil {
-		go w.fn()
+		f.dispatchWG.Add(1)
+		go func() {
+			defer f.dispatchWG.Done()
+			w.fn()
+		}()
 		return
 	}
 	select {

--- a/agent/internal/agenttest/clock_test.go
+++ b/agent/internal/agenttest/clock_test.go
@@ -133,6 +133,35 @@ func TestFakeClockAfterFuncStop(t *testing.T) {
 	}
 }
 
+// TestFakeClockDrainWaitsForDispatchedAfterFunc pins Drain's contract: Advance
+// dispatches an AfterFunc via `go fn()`, so it returns before the callback runs;
+// Drain blocks until that goroutine has completed. Without Drain a negative
+// assertion ("the callback did not run") can only rely on a wall-clock sleep.
+func TestFakeClockDrainWaitsForDispatchedAfterFunc(t *testing.T) {
+	c := NewFakeClock()
+	done := make(chan struct{})
+	c.AfterFunc(time.Second, func() { close(done) })
+	c.Advance(time.Second)
+	// Advance has returned; the callback goroutine may not have started. Drain
+	// must block until it has completed, so the channel close is observable
+	// without any wall-clock wait.
+	c.Drain()
+	select {
+	case <-done:
+	default:
+		t.Fatal("Drain returned before the AfterFunc goroutine completed")
+	}
+}
+
+// TestFakeClockDrainNoPendingAfterFunc pins the no-op case: Drain returns
+// immediately when no AfterFunc goroutine is outstanding.
+func TestFakeClockDrainNoPendingAfterFunc(t *testing.T) {
+	c := NewFakeClock()
+	c.Drain() // must not block
+	c.Advance(5 * time.Second)
+	c.Drain() // must not block
+}
+
 func TestFakeClockBlockUntilCounts(t *testing.T) {
 	c := NewFakeClock()
 	if n := c.BlockedCount(); n != 0 {

--- a/agent/session_worktree_sweep_test.go
+++ b/agent/session_worktree_sweep_test.go
@@ -487,8 +487,12 @@ func TestP3Timer_CancelledByStopDoesNotFire(t *testing.T) {
 	r.s.stopLaneResidueSweepTimer()
 	clk.Advance(2 * laneSweepDelay)
 
-	// Give any (incorrectly) fired goroutine a chance to run before asserting.
-	time.Sleep(50 * time.Millisecond)
+	// AfterFunc dispatches via `go fn()`, so Advance returns before a wrongly-
+	// fired callback runs. Drain waits for any dispatched AfterFunc goroutine to
+	// finish — deterministically, with no wall-clock sleep — so a callback that
+	// (incorrectly) fired has fully run its registry mutation before we assert the
+	// lane is still present.
+	clk.Drain()
 	if !obs.lanePresent(path) {
 		t.Error("stopped open-pass timer still collected the lane")
 	}


### PR DESCRIPTION
Fixes #166

TestP3Timer_CancelledByStopDoesNotFire proved a negative with time.Sleep(50ms), but FakeClock.AfterFunc dispatches via go w.fn(), so Advance() returns before a wrongly-fired callback runs. Under fleet load the goroutine can be scheduled after the 50ms window, letting the t.Stop() deletion mutation pass. Added a Drain method to FakeClock that waits for pending AfterFunc goroutines to complete, replacing the wall-clock sleep with deterministic synchronization.