### PR TITLE
fix(test): teach FuzzInstallScript's fake archive about evener-migrate

### DIFF
--- a/install_fuzz_test.go
+++ b/install_fuzz_test.go
@@ -17,6 +17,15 @@ import (
 // discovery are replaced at the process boundary; installation and symlink
 // creation still execute through the real install.sh implementation.
 func FuzzInstallScript(f *testing.F) {
+	// installedBins reads EVENER_INSTALL_BINS from the Makefile — the same
+	// source of truth install.sh's `bins` line and `make dist` are built
+	// from — so the fake release archive below always matches what a real
+	// install actually ships, and a future binary addition can't silently
+	// leave this fixture (and the assertions against it) behind the way
+	// evener-migrate did.
+	bins := installedBins(f)
+	missingBin := bins[len(bins)-1]
+
 	for _, seed := range [][]byte{
 		{0, 0, 0, 0, 0}, // Linux/amd64, latest, complete archive, HOME.
 		{1, 1, 1, 0, 1}, // Darwin/arm64, versioned, complete archive, PREFIX.
@@ -71,7 +80,7 @@ while [ "$#" -gt 0 ]; do
 done
 exit 2
 `)
-		writeExecutable(t, filepath.Join(fakeBin, "tar"), `#!/bin/sh
+		writeExecutable(t, filepath.Join(fakeBin, "tar"), fmt.Sprintf(`#!/bin/sh
 dest=
 while [ "$#" -gt 0 ]; do
   if [ "$1" = -C ]; then dest=$2; break; fi
@@ -80,11 +89,11 @@ done
 [ -n "$dest" ] || exit 2
 [ "$EVENER_FUZZ_ARCHIVE_MODE" != 1 ] || exit 0
 mkdir -p "$dest/$EVENER_FUZZ_ARCHIVE_ROOT"
-for bin in evener evener-hub evener-tui evener-doctor; do
-  [ "$EVENER_FUZZ_ARCHIVE_MODE:$bin" = 2:evener-doctor ] && continue
+for bin in %s; do
+  [ "$EVENER_FUZZ_ARCHIVE_MODE:$bin" = 2:%s ] && continue
   printf '#!/bin/sh\nexit 0\n' > "$dest/$EVENER_FUZZ_ARCHIVE_ROOT/$bin"
 done
-`)
+`, strings.Join(bins, " "), missingBin))
 
 		home := filepath.Join(root, "home")
 		prefix := filepath.Join(root, "prefix")
@@ -140,7 +149,7 @@ done
 		if envMode == 3 {
 			bindir, shareDir = filepath.Join(root, "commands"), filepath.Join(root, "payload")
 		}
-		for _, bin := range []string{"evener", "evener-hub", "evener-tui", "evener-doctor"} {
+		for _, bin := range bins {
 			installed := filepath.Join(shareDir, bin)
 			info, statErr := os.Stat(installed)
 			if statErr != nil || info.Mode().Perm() != 0o755 {

--- a/install_test.go
+++ b/install_test.go
@@ -958,3 +958,31 @@ func exists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
 }
+
+// installedBins returns the EVENER_INSTALL_BINS list from the Makefile — the
+// single source of truth for which binaries a release install contains, and
+// the same source install.sh's `bins` line and `make dist` are kept in sync
+// with. Reading it here, rather than hardcoding a parallel copy, is what
+// makefile_audit_test.go's TestBuildAllBuildsEveryInstalledBinary already
+// does for build-all; FuzzInstallScript reuses it so a sixth binary can't
+// silently break its fixture archive the way evener-migrate broke it
+// (Release archive did not contain evener-migrate).
+func installedBins(t testing.TB) []string {
+	t.Helper()
+
+	body, err := os.ReadFile("Makefile")
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	for line := range strings.SplitSeq(string(body), "\n") {
+		if rest, ok := strings.CutPrefix(line, "EVENER_INSTALL_BINS :="); ok {
+			bins := strings.Fields(rest)
+			if len(bins) == 0 {
+				t.Fatal("EVENER_INSTALL_BINS assignment in Makefile has no binaries")
+			}
+			return bins
+		}
+	}
+	t.Fatal("EVENER_INSTALL_BINS assignment not found in Makefile")
+	return nil
+}

--- a/makefile_audit_test.go
+++ b/makefile_audit_test.go
@@ -270,20 +270,7 @@ func TestNoMakefileRecipeFeedsVariableToRecursiveDelete(t *testing.T) {
 // output flag, so it holds no opinion about staging directories or -ldflags.
 func TestBuildAllBuildsEveryInstalledBinary(t *testing.T) {
 	t.Parallel()
-	body, err := os.ReadFile("Makefile")
-	if err != nil {
-		t.Fatalf("read Makefile: %v", err)
-	}
-	var bins []string
-	for line := range strings.SplitSeq(string(body), "\n") {
-		if rest, ok := strings.CutPrefix(line, "EVENER_INSTALL_BINS :="); ok {
-			bins = strings.Fields(rest)
-			break
-		}
-	}
-	if len(bins) == 0 {
-		t.Fatal("EVENER_INSTALL_BINS assignment not found in Makefile")
-	}
+	bins := installedBins(t)
 	out, err := exec.Command("make", "-n", "build-all").CombinedOutput()
 	if err != nil {
 		t.Fatalf("make -n build-all: %v\n%s", err, out)


### PR DESCRIPTION
## Summary
- `FuzzInstallScript`'s fake release archive only wrote `evener`, `evener-hub`, `evener-tui`, and `evener-doctor`. PR #200 added `evener-migrate` to `install.sh`'s `bins` list and `make dist`, so install.sh's new "archive contains every bin" check now fails every complete-archive seed with `Release archive did not contain evener-migrate.`
- Derive the fixture's bin list, and the post-install verification list, from `EVENER_INSTALL_BINS` in the Makefile instead of a hardcoded copy — the same source of truth `TestBuildAllBuildsEveryInstalledBinary` (`makefile_audit_test.go`) already reads for the same class of bug. Extracted that Makefile-parsing logic into a shared `installedBins()` helper in `install_test.go` so a future binary addition can't leave the fuzz fixture behind again.

## Test plan
- [x] Reproduced red: `go test -tags evenerfuzz . -run FuzzInstallScript -count=1 -v` failed on seed#0, seed#1, seed#8 with `Release archive did not contain evener-migrate.`
- [x] Green after fix: same command, all 9 seeds pass
- [x] Brief `-fuzz FuzzInstallScript -fuzztime 20s` pass, no new failing corpus entries
- [x] `go test . -run Install -count=1 -v` (TestInstallScriptInstallsReleaseArchive, TestInstallHomeGeneratedHome, TestInstallScriptWarnsAboutLegacySerf, TestBuildAllBuildsEveryInstalledBinary) — all pass
- [x] `go test . -count=1` (full root package) — pass
- [x] `golangci-lint run .` (matches CI's `lint-golangci`, no `evenerfuzz` tag) — 0 issues
- [x] `go vet -tags evenerfuzz ./...` (matches `lint-evenerfuzz`) — clean

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU