### PR TITLE
fix(web): exclude issue-number refs from the hex-literal contract check

### DIFF
--- a/cmd/evener-hub/frontend/src/styles/token-contract.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/token-contract.test.ts
@@ -97,7 +97,11 @@ test("the dockview-theme.css naming exception is scoped to its exact path, not j
 //    `color-mix(in oklab, var(--accent) 40%, transparent)`) is normal
 //    token composition, not a new color; any raw hex/rgb/... smuggled
 //    into a color-mix() argument is still caught since this regex scans
-//    the whole file text, nesting notwithstanding.
+//    the whole file text, nesting notwithstanding. The hex branch excludes
+//    a leading "issue #"/"Issue #" - house style for citing a GitHub issue
+//    in a comment (pervasive outside src/styles too) - so a 3-hex-digit
+//    issue number (e.g. #196) doesn't false-positive as a hex color; a hex
+//    code left in a comment with no such prefix still trips it.
 // 2. NAMED_COLOR_RE - the CSS named-color keywords (red, white, black, ...;
 //    NOT transparent/currentColor, which aren't chromatic, and NOT CSS-wide
 //    keywords like inherit/initial/unset/revert/none/auto). Unlike (1),
@@ -113,7 +117,7 @@ test("the dockview-theme.css naming exception is scoped to its exact path, not j
 //    otherwise break DECLARATION_VALUE_RE's adjacency requirement and
 //    silently hide the declaration after it - see that regex's own
 //    comment for why.
-const COLOR_LITERAL_RE = /#[0-9a-fA-F]{3,8}\b|\b(?:rgba?|hsla?|oklch|oklab|lab|lch)\(/g;
+const COLOR_LITERAL_RE = /(?<!issue )(?<!Issue )#[0-9a-fA-F]{3,8}\b|\b(?:rgba?|hsla?|oklch|oklab|lab|lch)\(/g;
 
 // CSS Color Module Level 4 named colors (the full "extended color keywords"
 // list, including rebeccapurple) - https://www.w3.org/TR/css-color-4/#named-colors,
@@ -372,6 +376,25 @@ test("a comment containing a named color does not false-positive once stripped, 
 test("still catches hex/rgb/hsl/oklch literals alongside named colors", () => {
   expect(chromaticLiteralViolations(".foo { color: #ff0000; }")).toEqual(["#ff0000"]);
   expect(chromaticLiteralViolations(".foo { color: rgb(255, 0, 0); }")).toEqual(["rgb("]);
+});
+
+// An "issue #NNN"/"Issue #NNN" reference is house style for citing a GitHub
+// issue in a comment (grep any of agent/, cmd/, or this file's own siblings
+// for "issue #" - it's pervasive, predating this test). A 3-hex-digit issue
+// number (e.g. #196: 1, 9, 6 are all valid hex digits) is otherwise
+// indistinguishable from a 3-digit hex color to COLOR_LITERAL_RE, which
+// scans comment-intact text on purpose (see that regex's own comment) - so
+// without this exception, citing an issue whose number happens to look like
+// hex would trip a design-token contract that has nothing to do with the
+// citation. The exception is narrow (only the literal "issue #"/"Issue #"
+// prefix), so a hex code genuinely left in a comment - the case this
+// mechanism exists to catch - still trips it.
+test("an issue-number reference that looks like a hex literal is not a false positive", () => {
+  expect(chromaticLiteralViolations("/* a real flex item (issue #196) now */")).toEqual([]);
+  expect(chromaticLiteralViolations("/* Issue #196: see .actions above */")).toEqual([]);
+  // Not issue-prefixed: still a violation, proving the exception didn't
+  // broaden into "any #-prefixed hex-looking digits are fine".
+  expect(chromaticLiteralViolations("/* #196 alone, no issue prefix */")).toEqual(["#196"]);
 });
 
 // --- (b) the three attention-family vars stay on the allowlist ---------


### PR DESCRIPTION
## Summary

CI's `web` job has been red on `main` since PR #206 merged (commit 8aa834801). The `token-contract.test.ts` suite's `shell/rail/RailRow.module.css has no chromatic literal outside tokens.css` test fails with:

```
AssertionError: expected [ '#196', '#196' ] to deeply equal []
```

## Root cause

`RailRow.module.css`'s comments cite `issue #196` twice (documenting the rework of the actions overlay). `#196` is composed entirely of hex digits (1, 9, 6), so `token-contract.test.ts`'s `COLOR_LITERAL_RE` — which deliberately scans comment-intact file text to catch stray hex color codes left in comments — mistakes the issue citation for a 3-digit hex color literal.

`issue #NNN` (and `Issue #NNN`) is pervasive house style for citing a GitHub issue in a comment across the codebase (Go and TypeScript alike; `agent/`, `cmd/`, `internal/`, etc. all use it), predating this test. This is the first time a CSS file has cited an issue number that also happens to be a valid 3-8 char hex sequence, so the collision hadn't surfaced before.

## Why PR #206's own review missed it

`web` was already red on PR #206's own PR-head CI run (https://github.com/prime-radiant-inc/evener/actions/runs/32214885576/job/95954401832) before merge — it wasn't a passing check that then broke. It was merged anyway. Job-level CI history shows `web` passed clean through the PR #213/#205/#208 merges immediately before and turned red starting exactly at #206's merge commit, isolating the RailRow.module.css comments as the trigger (confirmed by local reproduction).

## Fix

Fix at the root: since `issue #NNN` is legitimate, established house style (not a stale/dead design token, and not something the CSS comment should be reworded away from), the fix narrows `COLOR_LITERAL_RE` in `token-contract.test.ts` to exclude a hex-looking literal immediately preceded by `issue `/`Issue `, so a real hex code left in a comment — the case this mechanism exists to catch — still trips it.

Added a poison test (`an issue-number reference that looks like a hex literal is not a false positive`) asserting both the exemption and that it stays narrow (a bare `#196` with no `issue` prefix still violates).

## Test plan
- [x] `npx vitest run src/styles/token-contract.test.ts` — 712/712 passing (was 1 failing)
- [x] `npx vitest run --maxWorkers=4 --exclude 'scripts/*.test.mjs'` — 6731/6731 passing
- [x] `make test-web` (typecheck + test + lint) — all PASS
- [x] `make build-web` — builds clean
- [x] `make test-web-browser` (layoutguard/overflowguard/spawnguard) — all PASS
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` on the touched file — clean

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU