### PR TITLE
fix(scenarios): repoint stale interrupt-marker citation (session_lifecycle.go:715 -> :720)

### DIFF
--- a/test/scenarios/workspace-title-bar-actions.md
+++ b/test/scenarios/workspace-title-bar-actions.md
@@ -227,7 +227,7 @@ head and runs it as a fresh user turn.
   The transcript records the partial tool output plus a system
   interrupt marker (a `STEERING` turn whose text contains
   `The user interrupted the previous turn`,
-  `agent/session_lifecycle.go:715`). The turn is reported
+  `agent/session_lifecycle.go:720`). The turn is reported
   `status=interrupted` on `turn/completed` — the `TurnStatus` enum has no
   `canceled` value at all (`appwire/types.go:166-171`), so a controller
   grepping for that literal will never find it. The session remains alive —


### PR DESCRIPTION
## Summary

- `TestScenarioQuotedLiteralsSitInsideTheCitedLineRange` has been red on `main` since PR merges landed (seen on the CI race-detector pass for #205, #206, #208's `CI` runs, all reporting the identical single finding).
- `test/scenarios/workspace-title-bar-actions.md:229` quotes `The user interrupted the previous turn` and cites `agent/session_lifecycle.go:715` for it. Commit `cc9e05207` ("test(agent): make Close_JoinsInFlightDispose actually prove the dispose/sweep join") inserted a 5-line `testOnly` seam above that statement, pushing it to line 720. The citation was not updated.
- Note: a prior repair (`55e4a36eb6`) had correctly repointed this same citation from `:702` to `:715` for an earlier drift — but that repair landed *before* `cc9e05207`'s insertion, so it was stale again by the time both were on `main`. This is not new corpus rot from today's PRs (#205/#206/#208/#209/#210); those PRs didn't touch `agent/session_lifecycle.go` or this card. Verified: `git diff --stat` between those PRs and `agent/session_lifecycle.go` / the card / the audit test is empty.

## Fix

Repoint the citation to `agent/session_lifecycle.go:720`, where the literal now lives (verified by reading the file at that line).

## Why this only showed up under `-race`

It isn't actually race-specific — the audit test has no concurrency (pure `os.ReadFile` + regexp), and it fails identically with and without `-race` (verified both ways locally). The appearance of "race-only" is a CI step-ordering artifact: `.github/workflows/ci.yml`'s `build-and-test` job runs `Test (race detector...)` (`make test-race`) *before* `Deterministic tests (full root suite...)` (`ROOT_FULL=1 WEB=0 make test`), and neither step sets `continue-on-error`. GitHub Actions steps run sequentially and a failing step halts the job, so once the race step fails, the plain step never runs and never gets a chance to also report red. Whichever `Test` step runs first is the one CI shows as failing; it says nothing about the test's actual relationship to `-race`.

## Test plan

- [x] `go test . -race -run TestScenarioQuotedLiteralsSitInsideTheCitedLineRange -count=1 -v` — PASS (was FAIL before the fix, reproducing CI exactly)
- [x] `go test . -run TestScenarioQuotedLiteralsSitInsideTheCitedLineRange -count=1 -v` — PASS (also FAIL before the fix, confirming it's not race-specific)
- [x] `go test . -run 'Scenario' -count=1 -v` — full scenario-audit family PASS
- [x] `go test . -count=1` — full root package PASS
- [x] No Go files touched (markdown scenario card only), so `make lint` was not required per the task's own criterion.

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU