### PR TITLE
fix(build): cross-compile cmd/evener-dev for GOOS=windows

### DIFF
--- a/cmd/evener-dev/agentshards.go
+++ b/cmd/evener-dev/agentshards.go
@@ -49,6 +49,7 @@ import (
 	"syscall"
 	"time"
 
+	"primeradiant.com/evener/internal/devtool/procgroup"
 	"primeradiant.com/evener/internal/devtool/scratch"
 )
 
@@ -122,14 +123,10 @@ func envFlag(name string) bool {
 }
 
 // interrupter tracks live shard process groups and, on the first signal,
-// explains the interruption and TERMs every group so in-flight waits return.
-//
-// The Setpgid-here, TERM-the-negated-pgid-there pair is the same two lines
-// cmd/evener-test-dev-tooling/wave_unix.go uses on its suites, spelled twice on
-// purpose: each tool is a port of a different script and is checked for
-// parity against that script, not against its sibling. Two lines of overlap
-// buy less than a shared home would cost right now; the third caller is the
-// one to build it for.
+// TERMs every group so in-flight waits return. The Setpgid/Terminate pair is
+// shared with module-lint via internal/devtool/procgroup, which this file
+// adopts as its third caller; the inline duplication it used to carry is
+// retired.
 type interrupter struct {
 	mu     sync.Mutex
 	pgids  []int
@@ -140,7 +137,7 @@ func (in *interrupter) add(pgid int) {
 	in.mu.Lock()
 	defer in.mu.Unlock()
 	if in.signal != 0 {
-		_ = syscall.Kill(-pgid, syscall.SIGTERM)
+		procgroup.Terminate(pgid)
 		return
 	}
 	in.pgids = append(in.pgids, pgid)
@@ -154,7 +151,7 @@ func (in *interrupter) interrupt(sig syscall.Signal) {
 	}
 	in.signal = sig
 	for _, pgid := range in.pgids {
-		_ = syscall.Kill(-pgid, syscall.SIGTERM)
+		procgroup.Terminate(pgid)
 	}
 }
 
@@ -338,9 +335,8 @@ func runShards(cfg shardsConfig) int {
 		cmd := exec.CommandContext(context.Background(), build, args...)
 		cmd.Dir = cfg.agentDir
 		cmd.Stdout, cmd.Stderr = log, log
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		started := time.Now()
-		err = cmd.Start()
+		err = procgroup.Start(cmd)
 		_ = log.Close()
 		if err != nil {
 			_, _ = fmt.Fprintf(cfg.stderr, "agent-shards: starting shard %d: %v\n", i, err)
@@ -436,8 +432,7 @@ func (cfg shardsConfig) runToLog(in *interrupter, logPath, dir, name string, arg
 	cmd := exec.CommandContext(context.Background(), name, args...)
 	cmd.Dir = dir
 	cmd.Stdout, cmd.Stderr = log, log
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	if err := cmd.Start(); err != nil {
+	if err := procgroup.Start(cmd); err != nil {
 		return err
 	}
 	in.add(cmd.Process.Pid)
@@ -451,8 +446,7 @@ func (cfg shardsConfig) captureChild(in *interrupter, dir, name string, args ...
 	cmd.Dir = dir
 	var out strings.Builder
 	cmd.Stdout = &out
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	if err := cmd.Start(); err != nil {
+	if err := procgroup.Start(cmd); err != nil {
 		return "", err
 	}
 	in.add(cmd.Process.Pid)

--- a/cmd/evener-dev/crossbuild_test.go
+++ b/cmd/evener-dev/crossbuild_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestCrossCompileWindows pins issue #182: cmd/evener-dev must build cleanly
+// for GOOS=windows with CGO disabled. agentshards.go historically called the
+// unix-only syscall.Kill and used syscall.SysProcAttr.Setpgid without a build
+// tag, so a cross-compile died with `undefined: syscall.Kill` and `unknown
+// field Setpgid`. This test fails until that file is split by build tags.
+//
+// It runs a real `go build` (cache-friendly, ~fast), so it is skipped under
+// -short. The env is forced to CGO_ENABLED=0 GOOS=windows regardless of host
+// OS, so the cross-compile is exercised on linux/darwin hosts (the common
+// case). On a Windows host the build is a native compile and the env vars are
+// a no-op, which is fine.
+func TestCrossCompileWindows(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: cross-compiles cmd/evener-dev for windows")
+	}
+
+	// Resolve the cmd/evener-dev directory from this test file's location,
+	// not from the test's working directory. This is robust against
+	// `go test -C` and worktree runs where the working dir may differ.
+	dir := filepath.Dir(testFile(t))
+	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+		// Fall back to the working directory, which for package main tests is
+		// the package source directory.
+		wd, derr := os.Getwd()
+		if derr != nil {
+			t.Fatalf("resolving package dir: stat %q: %v; getwd: %v", dir, err, derr)
+		}
+		dir = wd
+	}
+
+	out := filepath.Join(t.TempDir(), "evener-dev.exe")
+	cmd := exec.Command("go", "build", "-o", out, ".")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"CGO_ENABLED=0",
+		"GOOS=windows",
+	)
+	combined, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("cross-build cmd/evener-dev for GOOS=windows failed (issue #182):\n%v\n%s", err, combined)
+	}
+}
+
+// testFile returns the path of this test's source file via runtime.Caller.
+func testFile(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller: cannot locate test source file")
+	}
+	return file
+}


### PR DESCRIPTION
Adopt internal/devtool/procgroup for the five unix-only syscall sites in agentshards.go (Kill x2, SysProcAttr.Setpgid x3), fixing the GOOS=windows cross-build. Red-green TDD: TestCrossCompileWindows pins the regression.

Fixes #182