### PR TITLE
fix(test): drop dead 5s handler sleep in cancel tests

### DIFF
--- a/llm/providers/anthropic/adapter_test.go
+++ b/llm/providers/anthropic/adapter_test.go
@@ -2395,7 +2395,7 @@ func TestStream_IncludesWebSearchTool(t *testing.T) {
 
 func TestComplete_WrapsContextCanceled(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(5 * time.Second)
+		<-r.Context().Done()
 	}))
 	t.Cleanup(srv.Close)
 

--- a/llm/providers/anthropic/no_fixed_sleep_test.go
+++ b/llm/providers/anthropic/no_fixed_sleep_test.go
@@ -1,0 +1,107 @@
+package anthropic
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// extractFuncBody returns the body text (excluding the outermost braces) of the
+// top-level function named funcName in src. It returns ("", false) if the
+// function declaration is not found.
+func extractFuncBody(t *testing.T, src, funcName string) (string, bool) {
+	t.Helper()
+
+	needle := "func " + funcName + "("
+	idx := strings.Index(src, needle)
+	if idx < 0 {
+		return "", false
+	}
+
+	// Scan from idx to the opening brace of the function body, skipping over
+	// the parameter list and (optional) return signature. We track brace/paren
+	// nesting so signatures containing parens are handled.
+	depth := 0
+	start := -1
+	for i := idx; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case '{':
+			if depth == 0 {
+				start = i
+			}
+			depth++
+		case '}':
+			depth--
+			if start >= 0 && depth == 0 {
+				return src[start+1 : i], true
+			}
+		}
+	}
+	return "", false
+}
+
+// snippetAround returns a few lines of context around the first occurrence of
+// needle in body, for readable failure output.
+func snippetAround(t *testing.T, body, needle string) string {
+	t.Helper()
+	idx := strings.Index(body, needle)
+	if idx < 0 {
+		return needle
+	}
+	start := idx
+	for i := idx; i >= 0 && i > idx-200; i-- {
+		if body[i] == '\n' {
+			start = i + 1
+			break
+		}
+	}
+	end := idx + len(needle)
+	for i := end; i < len(body) && i < end+200; i++ {
+		if body[i] == '\n' {
+			end = i
+			break
+		}
+	}
+	return strings.TrimSpace(body[start:end])
+}
+
+// TestCancelHandlerHasNoFixedSleep pins issue #164: the
+// TestComplete_WrapsContextCanceled handler must not contain a fixed-duration
+// time.Sleep (which guards nothing because the context is cancelled BEFORE the
+// request), and must instead wait on <-r.Context().Done() like its sibling
+// deadline test.
+//
+// This test is RED until the 5s handler sleep in
+// TestComplete_WrapsContextCanceled is replaced with <-r.Context().Done().
+func TestCancelHandlerHasNoFixedSleep(t *testing.T) {
+	b, err := os.ReadFile("adapter_test.go")
+	if err != nil {
+		t.Fatalf("read adapter_test.go: %v", err)
+	}
+	src := string(b)
+
+	body, ok := extractFuncBody(t, src, "TestComplete_WrapsContextCanceled")
+	if !ok {
+		t.Fatalf("TestComplete_WrapsContextCanceled not found in adapter_test.go")
+	}
+
+	red := false
+
+	if strings.Contains(body, "time.Sleep(") {
+		red = true
+		t.Errorf("issue #164: TestComplete_WrapsContextCanceled handler contains a fixed-duration time.Sleep;\nthis sleep guards nothing because the context is cancelled before the request and adds ~5s of wall time per run via srv.Close().\noffending snippet:\n%s", snippetAround(t, body, "time.Sleep("))
+	}
+
+	if !strings.Contains(body, "<-r.Context().Done()") {
+		red = true
+		t.Errorf("issue #164: TestComplete_WrapsContextCanceled handler must wait on <-r.Context().Done() (mirroring TestComplete_WrapsContextDeadlineExceeded) instead of a fixed-duration sleep; <-r.Context().Done() not found in function body")
+	}
+
+	if red {
+		t.Fatalf("issue #164 red: cancel-test handler still uses a fixed-duration sleep and/or lacks <-r.Context().Done()")
+	}
+}

--- a/llm/providers/anthropic/no_fixed_sleep_test.go
+++ b/llm/providers/anthropic/no_fixed_sleep_test.go
@@ -1,107 +1,14 @@
 package anthropic
 
 import (
-	"os"
-	"strings"
 	"testing"
+
+	"primeradiant.com/evener/llm/providers/internal/testaudit"
 )
 
-// extractFuncBody returns the body text (excluding the outermost braces) of the
-// top-level function named funcName in src. It returns ("", false) if the
-// function declaration is not found.
-func extractFuncBody(t *testing.T, src, funcName string) (string, bool) {
-	t.Helper()
-
-	needle := "func " + funcName + "("
-	idx := strings.Index(src, needle)
-	if idx < 0 {
-		return "", false
-	}
-
-	// Scan from idx to the opening brace of the function body, skipping over
-	// the parameter list and (optional) return signature. We track brace/paren
-	// nesting so signatures containing parens are handled.
-	depth := 0
-	start := -1
-	for i := idx; i < len(src); i++ {
-		switch src[i] {
-		case '(':
-			depth++
-		case ')':
-			depth--
-		case '{':
-			if depth == 0 {
-				start = i
-			}
-			depth++
-		case '}':
-			depth--
-			if start >= 0 && depth == 0 {
-				return src[start+1 : i], true
-			}
-		}
-	}
-	return "", false
-}
-
-// snippetAround returns a few lines of context around the first occurrence of
-// needle in body, for readable failure output.
-func snippetAround(t *testing.T, body, needle string) string {
-	t.Helper()
-	idx := strings.Index(body, needle)
-	if idx < 0 {
-		return needle
-	}
-	start := idx
-	for i := idx; i >= 0 && i > idx-200; i-- {
-		if body[i] == '\n' {
-			start = i + 1
-			break
-		}
-	}
-	end := idx + len(needle)
-	for i := end; i < len(body) && i < end+200; i++ {
-		if body[i] == '\n' {
-			end = i
-			break
-		}
-	}
-	return strings.TrimSpace(body[start:end])
-}
-
 // TestCancelHandlerHasNoFixedSleep pins issue #164: the
-// TestComplete_WrapsContextCanceled handler must not contain a fixed-duration
-// time.Sleep (which guards nothing because the context is cancelled BEFORE the
-// request), and must instead wait on <-r.Context().Done() like its sibling
-// deadline test.
-//
-// This test is RED until the 5s handler sleep in
-// TestComplete_WrapsContextCanceled is replaced with <-r.Context().Done().
+// TestComplete_WrapsContextCanceled handler must wait on <-r.Context().Done()
+// like its sibling deadline test, never on a fixed-duration time.Sleep.
 func TestCancelHandlerHasNoFixedSleep(t *testing.T) {
-	b, err := os.ReadFile("adapter_test.go")
-	if err != nil {
-		t.Fatalf("read adapter_test.go: %v", err)
-	}
-	src := string(b)
-
-	body, ok := extractFuncBody(t, src, "TestComplete_WrapsContextCanceled")
-	if !ok {
-		t.Fatalf("TestComplete_WrapsContextCanceled not found in adapter_test.go")
-	}
-
-	red := false
-
-	if strings.Contains(body, "time.Sleep(") {
-		red = true
-		t.Errorf("issue #164: TestComplete_WrapsContextCanceled handler contains a fixed-duration time.Sleep;\nthis sleep guards nothing because the context is cancelled before the request and adds ~5s of wall time per run via srv.Close().\noffending snippet:\n%s", snippetAround(t, body, "time.Sleep("))
-	}
-
-	if !strings.Contains(body, "<-r.Context().Done()") {
-		red = true
-		t.Errorf("issue #164: TestComplete_WrapsContextCanceled handler must wait on <-r.Context().Done() (mirroring TestComplete_WrapsContextDeadlineExceeded) instead of a fixed-duration sleep; <-r.Context().Done() not found in function body")
-	}
-
-	if red {
-		t.Fatalf("issue #164 red: cancel-test handler still uses a fixed-duration sleep and/or lacks <-r.Context().Done()")
-	}
+	testaudit.RequireHandlerWaitsOnContextDone(t, "adapter_test.go", "TestComplete_WrapsContextCanceled")
 }

--- a/llm/providers/google/adapter_test.go
+++ b/llm/providers/google/adapter_test.go
@@ -1807,7 +1807,7 @@ func contentKinds(parts []llm.ContentPart) []string {
 
 func TestComplete_WrapsContextCanceled(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(5 * time.Second)
+		<-r.Context().Done()
 	}))
 	t.Cleanup(srv.Close)
 

--- a/llm/providers/google/no_fixed_sleep_test.go
+++ b/llm/providers/google/no_fixed_sleep_test.go
@@ -1,0 +1,107 @@
+package google
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// extractFuncBody returns the body text (excluding the outermost braces) of the
+// top-level function named funcName in src. It returns ("", false) if the
+// function declaration is not found.
+func extractFuncBody(t *testing.T, src, funcName string) (string, bool) {
+	t.Helper()
+
+	needle := "func " + funcName + "("
+	idx := strings.Index(src, needle)
+	if idx < 0 {
+		return "", false
+	}
+
+	// Scan from idx to the opening brace of the function body, skipping over
+	// the parameter list and (optional) return signature. We track brace/paren
+	// nesting so signatures containing parens are handled.
+	depth := 0
+	start := -1
+	for i := idx; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case '{':
+			if depth == 0 {
+				start = i
+			}
+			depth++
+		case '}':
+			depth--
+			if start >= 0 && depth == 0 {
+				return src[start+1 : i], true
+			}
+		}
+	}
+	return "", false
+}
+
+// snippetAround returns a few lines of context around the first occurrence of
+// needle in body, for readable failure output.
+func snippetAround(t *testing.T, body, needle string) string {
+	t.Helper()
+	idx := strings.Index(body, needle)
+	if idx < 0 {
+		return needle
+	}
+	start := idx
+	for i := idx; i >= 0 && i > idx-200; i-- {
+		if body[i] == '\n' {
+			start = i + 1
+			break
+		}
+	}
+	end := idx + len(needle)
+	for i := end; i < len(body) && i < end+200; i++ {
+		if body[i] == '\n' {
+			end = i
+			break
+		}
+	}
+	return strings.TrimSpace(body[start:end])
+}
+
+// TestCancelHandlerHasNoFixedSleep pins issue #164: the
+// TestComplete_WrapsContextCanceled handler must not contain a fixed-duration
+// time.Sleep (which guards nothing because the context is cancelled BEFORE the
+// request), and must instead wait on <-r.Context().Done() like its sibling
+// deadline test.
+//
+// This test is RED until the 5s handler sleep in
+// TestComplete_WrapsContextCanceled is replaced with <-r.Context().Done().
+func TestCancelHandlerHasNoFixedSleep(t *testing.T) {
+	b, err := os.ReadFile("adapter_test.go")
+	if err != nil {
+		t.Fatalf("read adapter_test.go: %v", err)
+	}
+	src := string(b)
+
+	body, ok := extractFuncBody(t, src, "TestComplete_WrapsContextCanceled")
+	if !ok {
+		t.Fatalf("TestComplete_WrapsContextCanceled not found in adapter_test.go")
+	}
+
+	red := false
+
+	if strings.Contains(body, "time.Sleep(") {
+		red = true
+		t.Errorf("issue #164: TestComplete_WrapsContextCanceled handler contains a fixed-duration time.Sleep;\nthis sleep guards nothing because the context is cancelled before the request and adds ~5s of wall time per run via srv.Close().\noffending snippet:\n%s", snippetAround(t, body, "time.Sleep("))
+	}
+
+	if !strings.Contains(body, "<-r.Context().Done()") {
+		red = true
+		t.Errorf("issue #164: TestComplete_WrapsContextCanceled handler must wait on <-r.Context().Done() (mirroring TestComplete_WrapsContextDeadlineExceeded) instead of a fixed-duration sleep; <-r.Context().Done() not found in function body")
+	}
+
+	if red {
+		t.Fatalf("issue #164 red: cancel-test handler still uses a fixed-duration sleep and/or lacks <-r.Context().Done()")
+	}
+}

--- a/llm/providers/google/no_fixed_sleep_test.go
+++ b/llm/providers/google/no_fixed_sleep_test.go
@@ -1,107 +1,14 @@
 package google
 
 import (
-	"os"
-	"strings"
 	"testing"
+
+	"primeradiant.com/evener/llm/providers/internal/testaudit"
 )
 
-// extractFuncBody returns the body text (excluding the outermost braces) of the
-// top-level function named funcName in src. It returns ("", false) if the
-// function declaration is not found.
-func extractFuncBody(t *testing.T, src, funcName string) (string, bool) {
-	t.Helper()
-
-	needle := "func " + funcName + "("
-	idx := strings.Index(src, needle)
-	if idx < 0 {
-		return "", false
-	}
-
-	// Scan from idx to the opening brace of the function body, skipping over
-	// the parameter list and (optional) return signature. We track brace/paren
-	// nesting so signatures containing parens are handled.
-	depth := 0
-	start := -1
-	for i := idx; i < len(src); i++ {
-		switch src[i] {
-		case '(':
-			depth++
-		case ')':
-			depth--
-		case '{':
-			if depth == 0 {
-				start = i
-			}
-			depth++
-		case '}':
-			depth--
-			if start >= 0 && depth == 0 {
-				return src[start+1 : i], true
-			}
-		}
-	}
-	return "", false
-}
-
-// snippetAround returns a few lines of context around the first occurrence of
-// needle in body, for readable failure output.
-func snippetAround(t *testing.T, body, needle string) string {
-	t.Helper()
-	idx := strings.Index(body, needle)
-	if idx < 0 {
-		return needle
-	}
-	start := idx
-	for i := idx; i >= 0 && i > idx-200; i-- {
-		if body[i] == '\n' {
-			start = i + 1
-			break
-		}
-	}
-	end := idx + len(needle)
-	for i := end; i < len(body) && i < end+200; i++ {
-		if body[i] == '\n' {
-			end = i
-			break
-		}
-	}
-	return strings.TrimSpace(body[start:end])
-}
-
 // TestCancelHandlerHasNoFixedSleep pins issue #164: the
-// TestComplete_WrapsContextCanceled handler must not contain a fixed-duration
-// time.Sleep (which guards nothing because the context is cancelled BEFORE the
-// request), and must instead wait on <-r.Context().Done() like its sibling
-// deadline test.
-//
-// This test is RED until the 5s handler sleep in
-// TestComplete_WrapsContextCanceled is replaced with <-r.Context().Done().
+// TestComplete_WrapsContextCanceled handler must wait on <-r.Context().Done()
+// like its sibling deadline test, never on a fixed-duration time.Sleep.
 func TestCancelHandlerHasNoFixedSleep(t *testing.T) {
-	b, err := os.ReadFile("adapter_test.go")
-	if err != nil {
-		t.Fatalf("read adapter_test.go: %v", err)
-	}
-	src := string(b)
-
-	body, ok := extractFuncBody(t, src, "TestComplete_WrapsContextCanceled")
-	if !ok {
-		t.Fatalf("TestComplete_WrapsContextCanceled not found in adapter_test.go")
-	}
-
-	red := false
-
-	if strings.Contains(body, "time.Sleep(") {
-		red = true
-		t.Errorf("issue #164: TestComplete_WrapsContextCanceled handler contains a fixed-duration time.Sleep;\nthis sleep guards nothing because the context is cancelled before the request and adds ~5s of wall time per run via srv.Close().\noffending snippet:\n%s", snippetAround(t, body, "time.Sleep("))
-	}
-
-	if !strings.Contains(body, "<-r.Context().Done()") {
-		red = true
-		t.Errorf("issue #164: TestComplete_WrapsContextCanceled handler must wait on <-r.Context().Done() (mirroring TestComplete_WrapsContextDeadlineExceeded) instead of a fixed-duration sleep; <-r.Context().Done() not found in function body")
-	}
-
-	if red {
-		t.Fatalf("issue #164 red: cancel-test handler still uses a fixed-duration sleep and/or lacks <-r.Context().Done()")
-	}
+	testaudit.RequireHandlerWaitsOnContextDone(t, "adapter_test.go", "TestComplete_WrapsContextCanceled")
 }

--- a/llm/providers/internal/testaudit/testaudit.go
+++ b/llm/providers/internal/testaudit/testaudit.go
@@ -1,0 +1,107 @@
+// Package testaudit provides source-level audits shared by provider test
+// suites. It is only imported from _test files, so it links into test
+// binaries only.
+package testaudit
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// RequireHandlerWaitsOnContextDone pins issue #164 for the named test in the
+// given file: its httptest handler must not contain a fixed-duration
+// time.Sleep (which guards nothing when the context is cancelled BEFORE the
+// request, and misleads readers into thinking timing matters), and must
+// instead wait on <-r.Context().Done() like the sibling deadline tests.
+// The path is resolved relative to the calling test's package directory.
+func RequireHandlerWaitsOnContextDone(t *testing.T, file, funcName string) {
+	t.Helper()
+
+	b, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+	src := string(b)
+
+	body, ok := extractFuncBody(src, funcName)
+	if !ok {
+		t.Fatalf("%s not found in %s", funcName, file)
+	}
+
+	red := false
+
+	if strings.Contains(body, "time.Sleep(") {
+		red = true
+		t.Errorf("issue #164: %s handler contains a fixed-duration time.Sleep;\nthe context is cancelled before the request, so the sleep guards nothing and misleads readers.\noffending snippet:\n%s", funcName, snippetAround(body, "time.Sleep("))
+	}
+
+	if !strings.Contains(body, "<-r.Context().Done()") {
+		red = true
+		t.Errorf("issue #164: %s handler must wait on <-r.Context().Done() (mirroring the sibling deadline tests) instead of a fixed-duration sleep; <-r.Context().Done() not found in function body", funcName)
+	}
+
+	if red {
+		t.Fatalf("issue #164: %s handler still uses a fixed-duration sleep and/or lacks <-r.Context().Done()", funcName)
+	}
+}
+
+// extractFuncBody returns the body text (excluding the outermost braces) of the
+// top-level function named funcName in src. It returns ("", false) if the
+// function declaration is not found.
+func extractFuncBody(src, funcName string) (string, bool) {
+	needle := "func " + funcName + "("
+	idx := strings.Index(src, needle)
+	if idx < 0 {
+		return "", false
+	}
+
+	// Scan from idx to the opening brace of the function body, skipping over
+	// the parameter list and (optional) return signature. We track brace/paren
+	// nesting so signatures containing parens are handled.
+	depth := 0
+	start := -1
+	for i := idx; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case '{':
+			if depth == 0 {
+				start = i
+			}
+			depth++
+		case '}':
+			depth--
+			if start >= 0 && depth == 0 {
+				return src[start+1 : i], true
+			}
+		}
+	}
+	return "", false
+}
+
+// snippetAround returns a few lines of context around the first occurrence of
+// needle in body, for readable failure output.
+func snippetAround(body, needle string) string {
+	idx := strings.Index(body, needle)
+	if idx < 0 {
+		return needle
+	}
+	start := idx
+	for i := idx; i >= 0 && i > idx-200; i-- {
+		if body[i] == '\n' {
+			start = i + 1
+			break
+		}
+	}
+	end := idx + len(needle)
+	for i := end; i < len(body) && i < end+200; i++ {
+		if body[i] == '\n' {
+			end = i
+			break
+		}
+	}
+	return strings.TrimSpace(body[start:end])
+}

--- a/llm/providers/internal/testaudit/testaudit_test.go
+++ b/llm/providers/internal/testaudit/testaudit_test.go
@@ -1,0 +1,52 @@
+package testaudit
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractFuncBody(t *testing.T) {
+	src := `package p
+
+func Before() { _ = "no" }
+
+func Target(t *testing.T) {
+	srv := New(func(w W, r R) {
+		<-r.Context().Done()
+	})
+	_ = srv
+}
+
+func After() { _ = "no" }
+`
+
+	body, ok := extractFuncBody(src, "Target")
+	if !ok {
+		t.Fatalf("Target not found")
+	}
+	for _, want := range []string{"<-r.Context().Done()", "_ = srv"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q:\n%s", want, body)
+		}
+	}
+	for _, reject := range []string{"Before", "After", `"no"`} {
+		if strings.Contains(body, reject) {
+			t.Errorf("body leaked neighboring code %q:\n%s", reject, body)
+		}
+	}
+
+	if _, ok := extractFuncBody(src, "Missing"); ok {
+		t.Errorf("extractFuncBody found a function that does not exist")
+	}
+}
+
+func TestSnippetAround(t *testing.T) {
+	body := "\tfirst line\n\ttime.Sleep(5 * time.Second)\n\tlast line\n"
+	got := snippetAround(body, "time.Sleep(")
+	if got != "time.Sleep(5 * time.Second)" {
+		t.Errorf("snippetAround = %q", got)
+	}
+	if snippetAround(body, "absent") != "absent" {
+		t.Errorf("snippetAround should echo a needle it cannot find")
+	}
+}


### PR DESCRIPTION
Replace the dead time.Sleep(5s) in TestComplete_WrapsContextCanceled (google + anthropic) with <-r.Context().Done(), mirroring the sibling deadline tests. The sleep guarded nothing (context cancelled before the request) and was dead code. Red-green TDD: TestCancelHandlerHasNoFixedSleep pins the regression in each provider package.

Fixes #164