### PR TITLE
fix(layoutguard): reject a widthMatrix placeholder with no matrix declared

### DIFF
--- a/cmd/evener-hub/frontend/scripts/layoutguard/widthMatrix.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/widthMatrix.mjs
@@ -46,6 +46,9 @@ const PLACEHOLDER = "__LAYOUTGUARD_WIDTH_MATRIX__";
 // declares no widthMatrix leaves the harness untouched.
 export function injectWidthMatrix(harnessSource, widthMatrix, caseName) {
   const normalized = normalizeWidthMatrix(widthMatrix, caseName);
+  if (normalized === null && harnessSource.includes(PLACEHOLDER)) {
+    throw new Error(`${caseName}: harness.html has ${PLACEHOLDER} but case.json declares no widthMatrix`);
+  }
   if (normalized === null) return harnessSource;
   if (!harnessSource.includes(PLACEHOLDER)) {
     throw new Error(`${caseName}: case.json declares widthMatrix but harness.html has no ${PLACEHOLDER} placeholder`);

--- a/cmd/evener-hub/frontend/scripts/layoutguard/widthMatrix.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/widthMatrix.mjs
@@ -43,7 +43,9 @@ const PLACEHOLDER = "__LAYOUTGUARD_WIDTH_MATRIX__";
 // Splices the normalized matrix into harness source as a JSON array literal,
 // replacing PLACEHOLDER wherever the harness's own fixture-building script
 // declares it (see cases/compact-session-footer/harness.html). A case that
-// declares no widthMatrix leaves the harness untouched.
+// declares no widthMatrix leaves the harness untouched - unless the harness
+// still carries the placeholder, which would ship the literal token into its
+// JS, so that mismatch is an error in both directions.
 export function injectWidthMatrix(harnessSource, widthMatrix, caseName) {
   const normalized = normalizeWidthMatrix(widthMatrix, caseName);
   if (normalized === null && harnessSource.includes(PLACEHOLDER)) {

--- a/cmd/evener-hub/frontend/scripts/layoutguard/widthMatrix.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/widthMatrix.test.mjs
@@ -67,8 +67,15 @@ describe("injectWidthMatrix", () => {
     );
   });
 
-  test("leaves the harness source untouched when the case has no widthMatrix", () => {
+  test("throws a clear error when the harness has the placeholder but the case declares no widthMatrix", () => {
     const source = `<script>\n${placeholder}\n</script>`;
+    expect(() => injectWidthMatrix(source, null, "stale-placeholder")).toThrow(
+      "stale-placeholder: harness.html has __LAYOUTGUARD_WIDTH_MATRIX__ but case.json declares no widthMatrix",
+    );
+  });
+
+  test("leaves the harness source untouched when the case has no widthMatrix and no placeholder", () => {
+    const source = `<script>\nconst fixtures = [];</script>`;
     expect(injectWidthMatrix(source, null, "no-matrix-case")).toBe(source);
   });
 });


### PR DESCRIPTION
Add the reverse check to injectWidthMatrix: when the harness contains __LAYOUTGUARD_WIDTH_MATRIX__ but case.json declares no widthMatrix, throw instead of shipping the literal token. Mirrors the existing forward check. Red-green TDD: widthMatrix.test.mjs pins the reverse throw.

Fixes #189