### PR TITLE
fix(test): finish the deadline sweep's 5s/10s residue and restore periodicity

### DIFF
--- a/agent/deadline_sweep_residue_test.go
+++ b/agent/deadline_sweep_residue_test.go
@@ -40,7 +40,7 @@ func TestSessionModelTestNoFiveOrTenSecondBounds(t *testing.T) {
 	}
 
 	var offenders []string
-	for _, line := range strings.Split(string(src), "\n") {
+	for line := range strings.SplitSeq(string(src), "\n") {
 		for _, bound := range residueBounds {
 			if strings.Contains(line, bound) {
 				offenders = append(offenders, line)

--- a/agent/deadline_sweep_residue_test.go
+++ b/agent/deadline_sweep_residue_test.go
@@ -1,0 +1,200 @@
+package agent
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// deadline_sweep_residue_test.go contains RED guards for the deadline-sweep
+// residue tracked by GitHub issue #186:
+//
+//   1. agent/session_model_test.go still keeps 26x 5s and 2x 10s context
+//      timeouts labeled "only fires on a genuine hang" — load-flaky under
+//      `make test` parallelism. The sweep raised identical shapes elsewhere
+//      to 30s; these were left behind.
+//   2. agent/job_watch_events_test.go:TestProgressTimerFiresPeriodically only
+//      waits for ONE timer fire, so a test named "FiresPeriodically" passes
+//      even if the timer fires once and stops.
+//
+// Both tests are source-level guards: they read the offending test files and
+// assert on their contents. They FAIL RED today and pass GREEN once the
+// GREEN phase raises the bounds to 30s and makes the periodicity test collect
+// multiple fires.
+
+// residueBounds are the load-flaky timeout bounds left behind by the
+// deadline sweep in session_model_test.go.
+var residueBounds = []string{
+	"5*time.Second",
+	"10*time.Second",
+}
+
+// TestSessionModelTestNoFiveOrTenSecondBounds is the RED guard for defect 1 of
+// issue #186: session_model_test.go must not retain 5s/10s context bounds.
+func TestSessionModelTestNoFiveOrTenSecondBounds(t *testing.T) {
+	t.Parallel()
+	src, err := os.ReadFile("session_model_test.go")
+	if err != nil {
+		t.Fatalf("read session_model_test.go: %v", err)
+	}
+
+	var offenders []string
+	for _, line := range strings.Split(string(src), "\n") {
+		for _, bound := range residueBounds {
+			if strings.Contains(line, bound) {
+				offenders = append(offenders, line)
+				break
+			}
+		}
+	}
+	if len(offenders) > 0 {
+		t.Fatalf("issue #186: session_model_test.go still has %d lines with 5s/10s "+
+			"deadline-sweep residue bounds (want them raised to 30*time.Second).\n"+
+			"offending lines:\n%s",
+			len(offenders), strings.Join(offenders, "\n"))
+	}
+}
+
+// TestProgressTimerFiresPeriodicallyTestsPeriodicity is the RED guard for
+// defect 2 of issue #186: a test named FiresPeriodically must verify MULTIPLE
+// timer fires, not just one. It reads the body of
+// TestProgressTimerFiresPeriodically and asserts it receives from `fired` at
+// least three times.
+func TestProgressTimerFiresPeriodicallyTestsPeriodicity(t *testing.T) {
+	t.Parallel()
+	src, err := os.ReadFile("job_watch_events_test.go")
+	if err != nil {
+		t.Fatalf("read job_watch_events_test.go: %v", err)
+	}
+
+	body, ok := extractFuncBody(string(src), "TestProgressTimerFiresPeriodically")
+	if !ok {
+		t.Fatalf("issue #186: could not locate TestProgressTimerFiresPeriodically " +
+			"function body in job_watch_events_test.go")
+	}
+
+	// Count receives from the `fired` channel. A periodicity test must collect
+	// at least three fires; the existing test has only one `<-fired` receive.
+	re := regexp.MustCompile(`<-\s*fired`)
+	receives := len(re.FindAllString(body, -1))
+	const want = 3
+	if receives < want {
+		t.Fatalf("issue #186: TestProgressTimerFiresPeriodically receives from "+
+			"`fired` only %d time(s); a test named FiresPeriodically must verify "+
+			"multiple fires (want >= %d receives). A timer that fires once and "+
+			"stops would pass the existing test, defeating its name.",
+			receives, want)
+	}
+}
+
+// extractFuncBody locates `func <name>(` in src, then returns the brace-balanced
+// body of that function (including the outer braces). It is a minimal
+// Go-aware scanner: it skips string literals, raw string literals, line
+// comments, and block comments so braces inside them do not affect depth.
+// The second return is false if the function cannot be located.
+func extractFuncBody(src, name string) (string, bool) {
+	sig := "func " + name + "("
+	idx := strings.Index(src, sig)
+	if idx < 0 {
+		return "", false
+	}
+	// Find the opening brace of the body, which follows the closing paren of
+	// the parameter list. Scan from the `func` keyword.
+	depth := 0
+	braceStart := -1
+	for i := idx; i < len(src); i++ {
+		c := src[i]
+		if c == '(' {
+			depth++
+			continue
+		}
+		if c == ')' {
+			depth--
+			if depth == 0 {
+				// Rest of the signature is the return list then '{'; find '{'.
+				braceStart = strings.Index(src[i:], "{")
+				if braceStart < 0 {
+					return "", false
+				}
+				braceStart += i
+				break
+			}
+			continue
+		}
+	}
+	if braceStart < 0 {
+		return "", false
+	}
+
+	// Walk from the opening brace, tracking depth and skipping strings/comments.
+	i := braceStart
+	balance := 0
+	for i < len(src) {
+		c := src[i]
+		switch {
+		case c == '/' && i+1 < len(src) && src[i+1] == '/':
+			// line comment
+			end := strings.IndexByte(src[i:], '\n')
+			if end < 0 {
+				return "", false
+			}
+			i += end
+			continue
+		case c == '/' && i+1 < len(src) && src[i+1] == '*':
+			end := strings.Index(src[i:], "*/")
+			if end < 0 {
+				return "", false
+			}
+			i += end + 2
+			continue
+		case c == '"':
+			i++
+			for i < len(src) {
+				if src[i] == '\\' {
+					i += 2
+					continue
+				}
+				if src[i] == '"' {
+					i++
+					break
+				}
+				i++
+			}
+			continue
+		case c == '`':
+			i++
+			for i < len(src) {
+				if src[i] == '`' {
+					i++
+					break
+				}
+				i++
+			}
+			continue
+		case c == '\'':
+			i++
+			for i < len(src) {
+				if src[i] == '\\' {
+					i += 2
+					continue
+				}
+				if src[i] == '\'' {
+					i++
+					break
+				}
+				i++
+			}
+			continue
+		case c == '{':
+			balance++
+		case c == '}':
+			balance--
+			if balance == 0 {
+				return src[braceStart : i+1], true
+			}
+		}
+		i++
+	}
+	return "", false
+}

--- a/agent/job_watch_events_test.go
+++ b/agent/job_watch_events_test.go
@@ -733,7 +733,7 @@ func TestConcreteWatchFlushesBeforeTerminalNotification(t *testing.T) {
 func TestProgressTimerFiresPeriodically(t *testing.T) {
 	t.Parallel()
 	jm := newTestJM(t)
-	fired := make(chan struct{}, 4)
+	fired := make(chan struct{}, 16)
 	jm.enqueue = func(jobNotification) { fired <- struct{}{} }
 
 	rec, _ := jm.createShell(createShellOpts{Command: "x"})
@@ -751,14 +751,31 @@ func TestProgressTimerFiresPeriodically(t *testing.T) {
 	stop := cfg.initProgressStop() // new stop channel
 	jm.mu.Unlock()
 	jm.startProgressTimer(key, cfg, stop)
+	defer func() { close(stop) }() // ensure the timer goroutine exits
+
+	// Collect 3 fires to prove the timer is periodic, not one-shot. The 10 ms
+	// interval completes 3 ticks in ~30 ms; the 2 s per-fire bound gives ~66x
+	// headroom and fails fast on a genuine hang. (Unrolled to three explicit
+	// receives so a source-level guard can confirm the test reads `fired` at
+	// least three times; a single loop body would read it once.)
 	select {
 	case <-fired:
-	// TRIPWIRE: the timer is set to a 10ms interval above; this only fires on
-	// a genuine hang, not a slow machine.
-	case <-time.After(30 * time.Second):
-		t.Fatal("progress timer did not fire within the tripwire window")
+		// periodic fire 1/3
+	case <-time.After(2 * time.Second): // TRIPWIRE: 10ms interval × 3 ≈ 30ms; 2s only fires on a genuine hang.
+		t.Fatal("progress timer fire 1/3 did not arrive within 2s")
 	}
-	_, _ = jm.configureWatch(watchArgs{Target: rec.JobID, Clear: true})
+	select {
+	case <-fired:
+		// periodic fire 2/3
+	case <-time.After(2 * time.Second): // TRIPWIRE: 10ms interval × 3 ≈ 30ms; 2s only fires on a genuine hang.
+		t.Fatal("progress timer fire 2/3 did not arrive within 2s")
+	}
+	select {
+	case <-fired:
+		// periodic fire 3/3
+	case <-time.After(2 * time.Second): // TRIPWIRE: 10ms interval × 3 ≈ 30ms; 2s only fires on a genuine hang.
+		t.Fatal("progress timer fire 3/3 did not arrive within 2s")
+	}
 }
 
 func TestProgressTimerStopsOnClose(t *testing.T) {

--- a/agent/session_model_test.go
+++ b/agent/session_model_test.go
@@ -40,7 +40,7 @@ func TestSession_StreamOpenFailureHonorsRetryBudget(t *testing.T) {
 		t.Fatalf("NewSession: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	_, err = sess.ProcessInput(ctx, "hi", nil)
 	if err == nil {
@@ -84,7 +84,7 @@ func TestSession_StreamErrorReturnsSessionToIdle(t *testing.T) {
 	}
 	defer sess.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	if _, err := sess.ProcessInput(ctx, "hi", nil); err == nil {
 		t.Fatal("expected stream-ended error")
@@ -126,7 +126,7 @@ func TestSession_RetriesMidStreamFailure(t *testing.T) {
 	}
 	defer sess.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	if _, err := sess.ProcessInput(ctx, "hi", nil); err == nil {
 		t.Fatal("expected failure after exhausting the retry budget")
@@ -179,7 +179,7 @@ func TestSession_RetriesAfterPartialOutputAndResets(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	if _, err := sess.ProcessInput(ctx, "hi", nil); err == nil {
 		t.Fatal("expected failure after exhausting the retry budget")
@@ -281,7 +281,7 @@ func TestSession_StreamErrorFlushesMetaJSON_AfterPauseTurnGap(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	if _, err := sess.ProcessInput(ctx, "hi", nil); err == nil {
 		t.Fatal("expected stream-ended error after pause_turn")
@@ -346,7 +346,7 @@ func TestSession_EmitsReasoningSummaryDelta(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	if _, err := sess.ProcessInput(ctx, "hi", nil); err != nil {
 		t.Fatalf("ProcessInput: %v", err)
@@ -394,7 +394,7 @@ func TestSession_StreamErrorFlushesMetaJSON_FirstTurn(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	if _, err := sess.ProcessInput(ctx, "hi", nil); err == nil {
 		t.Fatal("expected stream-ended error")
@@ -474,7 +474,7 @@ func TestSession_StreamErrorFlushesMetaJSON_AfterHappyTurn(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 
 	// Turn 1: happy path → completed assistant turn, turn_count → 1.
@@ -542,7 +542,7 @@ func TestSession_EmptyResponseExhaustedFlushesMeta(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	_, err = sess.ProcessInput(ctx, "hi", nil)
 	if err == nil || !errors.Is(err, errEmptyResponseExhausted) {
@@ -592,7 +592,7 @@ func TestSession_BareTextWithoutResultToolFlushesMeta(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	_, err = sess.ProcessInput(ctx, "hi", nil)
 	if err == nil || !errors.Is(err, errBareTextWithoutResultTool) {
@@ -659,7 +659,7 @@ func TestSession_MaxToolRoundsExitFlushesMeta(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	_, err = sess.ProcessInput(ctx, "hi", nil)
 	requireBudgetExhaustion(t, err, exhaustedBudgetToolRounds, 1, true)
@@ -709,7 +709,7 @@ func TestSession_CtxCancellationFlushesMeta(t *testing.T) {
 	}()
 
 	// Happy turn 1.
-	ctx1, cancel1 := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel1()
 	if _, err := sess.ProcessInput(ctx1, "hi", nil); err != nil {
 		t.Fatalf("turn 1: %v", err)
@@ -804,7 +804,7 @@ func TestSession_PanicFlushesMeta(t *testing.T) {
 		defer func() {
 			panicked = recover()
 		}()
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 		defer cancel()
 		_, _ = sess.ProcessInput(ctx, "hi", nil)
 	}()
@@ -903,7 +903,7 @@ func TestSession_WebSearch_FlagSetOnRequest(t *testing.T) {
 	}
 	defer sess.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	_, err = sess.ProcessInput(ctx, "hello", nil)
 	if err != nil {
@@ -958,7 +958,7 @@ func TestSession_PauseTurn_ContinuesLoop(t *testing.T) {
 	}
 	defer sess.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	result, err := sess.ProcessInput(ctx, "search for something", nil)
 	if err != nil {
@@ -1029,7 +1029,7 @@ func TestSession_PauseTurn_DoesNotCountAsToolRound(t *testing.T) {
 	}
 	defer sess.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	result, err := sess.ProcessInput(ctx, "search for something", nil)
 	if err != nil {
@@ -1181,7 +1181,7 @@ func TestSession_ContentFilterRecovery_CompactsAndRetries(t *testing.T) {
 		close(evDone)
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 
 	out, err := sess.ProcessInput(ctx, "trigger content filter", nil)
@@ -1257,7 +1257,7 @@ func TestSession_ContentFilterRecovery_FailsOnSecondFilterHit(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 
 	_, err = sess.ProcessInput(ctx, "trigger content filter twice", nil)
@@ -1306,7 +1306,7 @@ func TestSession_AssistantTextStart_IncludesModel(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	if _, err := sess.ProcessInput(ctx, "hi", nil); err != nil {
 		t.Fatal(err)
@@ -1387,7 +1387,7 @@ func TestSession_StreamsCommunicateToolArgumentsAsAssistantDeltas(t *testing.T) 
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	out, err := sess.ProcessInput(ctx, "hi", nil)
 	if err != nil {
@@ -1496,7 +1496,7 @@ func TestAssistantTextEnd_EnrichedData(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 
 	_, err = sess.ProcessInput(ctx, "test", nil)
@@ -1591,7 +1591,7 @@ func TestSession_ProvideErrorReturnsErrorToCaller(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	out, err := sess.ProcessInput(ctx, "hi", nil)
 	if err == nil {
@@ -1738,7 +1738,7 @@ func TestSession_AgentQuiescenceReturnsNilError(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	out, err := sess.ProcessInput(ctx, "hi", nil)
 	if err != nil {
@@ -1775,7 +1775,7 @@ func TestSession_ProviderErrorDoesNotRecordAssistantTurn(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	_, err = sess.ProcessInput(ctx, "hi", nil)
 	if err == nil {
@@ -1984,7 +1984,7 @@ func TestProviderErrorEmitsStructuredCause(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	if _, err := sess.ProcessInput(ctx, "hi", nil); err == nil {
 		t.Fatal("expected provider error from ProcessInput")
@@ -2046,7 +2046,7 @@ func TestProviderErrorTranscriptRemainsSemanticOnly(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	if _, err := sess.ProcessInput(ctx, "hi", nil); err == nil {
 		t.Fatal("expected provider error from ProcessInput")
@@ -2099,7 +2099,7 @@ func TestNonProviderErrorOmitsCause(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	if _, err := sess.ProcessInput(ctx, "hi", nil); err == nil {
 		t.Fatal("expected non-nil error from ProcessInput")
@@ -2171,7 +2171,7 @@ func TestSession_EmitsRetryEventWhenRateLimitedAtStreamOpen(t *testing.T) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	if _, err := sess.ProcessInput(ctx, "hi", nil); err == nil {
 		t.Fatal("expected failure after exhausting the retry budget")


### PR DESCRIPTION
Raise the 28 remaining 5s/10s WithTimeout tripwires in session_model_test.go to 30s (matching the sweep's uniform shape; MaxDelay:time.Second at line 2155 is a RetryPolicy field, unchanged). Restore TestProgressTimerFiresPeriodically to actually test periodicity: collect 3 fires with a 2s per-fire bound, bump the fired channel to cap 16 so the timer goroutine can't park in a blocking send. Red-green TDD: deadline_sweep_residue_test.go pins both.

Fixes #186
