### PR TITLE
fix(test): empty the deadline-audit allowlist

### DIFF
--- a/agent/deadline_audit_allowlist_test.go
+++ b/agent/deadline_audit_allowlist_test.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestDeadlineAuditAllowlistIsEmpty asserts that deadlineAuditAllowlist has
+// been emptied (issue #142). The list is the ratchet kata ww3g left behind:
+// every agent/*_test.go file that carried a bare wall-clock bound when the
+// audit was written. It only ever shrinks -- a conversion wave removes a
+// file's entry once every bound in it is either replaced by its real
+// completion signal or carries a "// TRIPWIRE:" marker. The last hold-back
+// was delegate_resource_runtime_test.go, held back because another kata was
+// redesigning a test in it; both branches are merged now, so the entry must
+// be gone. This test fails RED until the GREEN phase empties the map.
+func TestDeadlineAuditAllowlistIsEmpty(t *testing.T) {
+	if len(deadlineAuditAllowlist) != 0 {
+		t.Fatalf("deadlineAuditAllowlist should be empty (issue #142), has %d entries: %v",
+			len(deadlineAuditAllowlist), deadlineAuditAllowlist)
+	}
+}
+
+// TestDeadlineAuditCatchesFreshBareBound proves the "Done when" criterion of
+// issue #142: once the allowlist is empty, the audit must still catch a fresh
+// bare wall-clock bound in any agent test file. It writes a temp _test.go
+// file carrying a bare time.After(5 * time.Second) directly into the agent
+// package dir (the audit scans ".", not a t.TempDir), runs the audit with the
+// real (eventually empty) allowlist, asserts a finding for the temp file, and
+// removes the temp file via t.Cleanup. The temp file is not on the allowlist
+// under any phase, so this test passes both before and after the GREEN fix --
+// its purpose is to prove the audit still works once the list is empty.
+func TestDeadlineAuditCatchesFreshBareBound(t *testing.T) {
+	const tempFile = "zzz_fresh_offense_142_test.go"
+	source := `package agent
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFreshOffense142(t *testing.T) {
+	select {
+	case <-time.After(5 * time.Second):
+	}
+}
+`
+	if err := os.WriteFile(tempFile, []byte(source), 0o644); err != nil {
+		t.Fatalf("write temp offense: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(tempFile) })
+
+	findings, err := deadlineAuditFindings(".", deadlineAuditAllowlist)
+	if err != nil {
+		t.Fatalf("deadlineAuditFindings: %v", err)
+	}
+	found := false
+	for _, f := range findings {
+		if strings.Contains(f, tempFile) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("audit did not catch the fresh bare 5s bound in %s; findings: %v",
+			tempFile, findings)
+	}
+}

--- a/agent/deadline_audit_allowlist_test.go
+++ b/agent/deadline_audit_allowlist_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -24,15 +25,19 @@ func TestDeadlineAuditAllowlistIsEmpty(t *testing.T) {
 
 // TestDeadlineAuditCatchesFreshBareBound proves the "Done when" criterion of
 // issue #142: once the allowlist is empty, the audit must still catch a fresh
-// bare wall-clock bound in any agent test file. It writes a temp _test.go
-// file carrying a bare time.After(5 * time.Second) directly into the agent
-// package dir (the audit scans ".", not a t.TempDir), runs the audit with the
-// real (eventually empty) allowlist, asserts a finding for the temp file, and
-// removes the temp file via t.Cleanup. The temp file is not on the allowlist
-// under any phase, so this test passes both before and after the GREEN fix --
-// its purpose is to prove the audit still works once the list is empty.
+// bare wall-clock bound in the formerly-allowlisted file. It writes a fixture
+// named delegate_resource_runtime_test.go -- the last hold-back's exact name
+// -- carrying a bare time.After(5 * time.Second) into a t.TempDir, then runs
+// the audit over that dir with the REAL allowlist. A finding proves both that
+// the audit catches a fresh offense and that the real allowlist no longer
+// exempts the file by name; with the pre-#142 allowlist this test is RED.
+//
+// The fixture goes in a t.TempDir, never the live package dir: CI runs this
+// package's tests as concurrently-scheduled shards of one binary in the same
+// directory (cmd/evener-dev agent-shards), so a poison file written into "."
+// races another shard's TestNoBareWallClockDeadlineInAgentTests scan of ".".
 func TestDeadlineAuditCatchesFreshBareBound(t *testing.T) {
-	const tempFile = "zzz_fresh_offense_142_test.go"
+	const offendingFile = "delegate_resource_runtime_test.go"
 	source := `package agent
 
 import (
@@ -46,24 +51,24 @@ func TestFreshOffense142(t *testing.T) {
 	}
 }
 `
-	if err := os.WriteFile(tempFile, []byte(source), 0o644); err != nil {
-		t.Fatalf("write temp offense: %v", err)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, offendingFile), []byte(source), 0o600); err != nil {
+		t.Fatalf("write fixture offense: %v", err)
 	}
-	t.Cleanup(func() { _ = os.Remove(tempFile) })
 
-	findings, err := deadlineAuditFindings(".", deadlineAuditAllowlist)
+	findings, err := deadlineAuditFindings(dir, deadlineAuditAllowlist)
 	if err != nil {
 		t.Fatalf("deadlineAuditFindings: %v", err)
 	}
 	found := false
 	for _, f := range findings {
-		if strings.Contains(f, tempFile) {
+		if strings.Contains(f, offendingFile) {
 			found = true
 			break
 		}
 	}
 	if !found {
 		t.Fatalf("audit did not catch the fresh bare 5s bound in %s; findings: %v",
-			tempFile, findings)
+			offendingFile, findings)
 	}
 }

--- a/agent/deadline_audit_test.go
+++ b/agent/deadline_audit_test.go
@@ -342,12 +342,10 @@ var deadlineAuditTimeUnits = map[string]bool{
 // wave removes a file's entry once every bound in it is either replaced by
 // its real completion signal or carries a "// TRIPWIRE:" marker; it must
 // never gain a new entry, because that is exactly the regression this audit
-// exists to catch. agent/delegate_resource_runtime_test.go stays on this list
-// deliberately: another kata is redesigning a test in that file on a separate
-// branch (kata ww3g's partition holds it back rather than touching it here).
-var deadlineAuditAllowlist = map[string]bool{
-	"delegate_resource_runtime_test.go": true,
-}
+// exists to catch. The list is now empty: every file's bare bounds have been
+// converted (TRIPWIRE comment or named constant), and the audit catches any
+// new bare wall-clock bound in any agent test file.
+var deadlineAuditAllowlist = map[string]bool{}
 
 // deadlineAuditFindings scans the non-recursive *_test.go files directly in
 // dir and returns one finding per bare wall-clock bound, skipping any file

--- a/agent/delegate_resource_runtime_test.go
+++ b/agent/delegate_resource_runtime_test.go
@@ -266,7 +266,11 @@ func TestDelegateResourceRuntime_PostCommitFailureWaitsForPriorDelivery(t *testi
 	go func() {
 		outcomes <- (delegateRuntime{owner: root}).send(context.Background(), fixture.delegateID, "generation two restore failure", 60_000)
 	}()
-	waitForCondition(t, 5*time.Second, "post-commit failure queued behind prior delivery", func() bool {
+	// TRIPWIRE: the generation-two send has no dedicated completion signal -- it
+	// queues behind the prior delivery under c.mu -- so this polls the
+	// aggregate directly. The queue is set synchronously under the lock well
+	// before this returns; 30s only fires on a genuine hang.
+	waitForCondition(t, 30*time.Second, "post-commit failure queued behind prior delivery", func() bool {
 		c.mu.Lock()
 		defer c.mu.Unlock()
 		aggregate := c.durable[fixture.delegateID]
@@ -396,6 +400,12 @@ func TestDelegateResourceRuntime_StopOwnsColdRestoreBeforeSideEffects(t *testing
 // margin; it is dead time only on the green path.
 const parentCloseColdRestoreJoinWindow = time.Second
 
+// parentCloseFailedInlineResultWindow bounds how long a parent Close may take
+// to return without waiting for a failed generation's optional inline result.
+// This is a real assertion (Close must NOT wait), not a hang tripwire: the
+// test fails if Close is still blocked at this window, proving it waited.
+const parentCloseFailedInlineResultWindow = time.Second
+
 // TestDelegateResourceRuntime_ParentCloseWaitsForColdRestoreSideEffects proves the
 // ordering by a POSITIVE observation taken on the closing goroutine, not by
 // watching Close fail to return.
@@ -492,14 +502,14 @@ func TestDelegateResourceRuntime_ParentCloseWaitsForColdRestoreSideEffects(t *te
 			<-closeDone
 			t.Fatal("parent Close reached its in-flight-restore join before the cold restore's side effects ran")
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(30 * time.Second): // TRIPWIRE: real signal from a background close; 30s only fires on a genuine hang.
 		<-sendDone
 		<-closeDone
 		t.Fatal("parent Close never reached its in-flight-restore join")
 	}
 	select {
 	case <-closeDone:
-	case <-time.After(5 * time.Second):
+	case <-time.After(30 * time.Second): // TRIPWIRE: real signal from a background close; 30s only fires on a genuine hang.
 		t.Fatal("parent Close did not return after cold-restore side effects drained")
 	}
 	<-sendDone
@@ -537,7 +547,11 @@ func TestDelegateResourceRuntime_ParentCloseDoesNotWaitForFailedInlineResult(t *
 	go func() {
 		sendDone <- (delegateRuntime{owner: root}).send(ctx, fixture.delegateID, "failed generation two", 60_000)
 	}()
-	waitForCondition(t, 5*time.Second, "failed generation queued behind prior delivery", func() bool {
+	// TRIPWIRE: the failed-generation send has no dedicated completion signal --
+	// it queues behind the prior delivery under c.mu -- so this polls the
+	// aggregate directly. The queue is set synchronously under the lock well
+	// before this returns; 30s only fires on a genuine hang.
+	waitForCondition(t, 30*time.Second, "failed generation queued behind prior delivery", func() bool {
 		c.mu.Lock()
 		defer c.mu.Unlock()
 		aggregate := c.durable[fixture.delegateID]
@@ -561,7 +575,7 @@ func TestDelegateResourceRuntime_ParentCloseDoesNotWaitForFailedInlineResult(t *
 	<-closeReachedReconstructionWait
 	select {
 	case <-closeDone:
-	case <-time.After(time.Second):
+	case <-time.After(parentCloseFailedInlineResultWindow):
 		cancel()
 		<-sendDone
 		<-closeDone


### PR DESCRIPTION
Convert the four held-back sites in delegate_resource_runtime_test.go: two 5s hang tripwires get TRIPWIRE comments + 30s ceilings, the 1s real-assertion bound becomes a named constant, the fourth was already a named constant. Empty deadlineAuditAllowlist. Red-green TDD: deadline_audit_allowlist_test.go pins the list is empty and the audit catches a fresh bare bound.

Fixes #142