### PR TITLE
fix(hub): stamp DivergenceTurn on hub-synthesized fork SessionMetas

### DIFF
--- a/cmd/evener-hub/web_api_tree.go
+++ b/cmd/evener-hub/web_api_tree.go
@@ -894,6 +894,13 @@ func appThreadTreeEntries(thread appwire.Thread) (schema.SessionMeta, hubcore.Li
 		ParentSessionID: appThreadTreeParentSessionID(thread, ref),
 		IsSubagent:      thread.Evener.Kind == "subagent",
 	}
+	// Issue #152: a hub-synthesized fork (parent set, not a subagent) must
+	// stamp DivergenceTurn so the 96cp invariant (ParentSessionID != "" &&
+	// DivergenceTurn == 0 implies a spawned delegate) does not misclassify a
+	// remote fork as a delegate. Value 1 is the minimum legal fork turn.
+	if meta.ParentSessionID != "" && !meta.IsSubagent {
+		meta.DivergenceTurn = 1
+	}
 	if thread.GitInfo != nil {
 		meta.EnvInfo.GitBranch = thread.GitInfo.Branch
 		meta.EnvInfo.GitOriginURL = thread.GitInfo.OriginURL

--- a/cmd/evener-hub/web_api_tree_divergence_test.go
+++ b/cmd/evener-hub/web_api_tree_divergence_test.go
@@ -15,8 +15,8 @@ import (
 // applying the invariant.
 func TestAppThreadTreeEntries_ForkedRemoteThreadStampsDivergenceTurn(t *testing.T) {
 	thread := appwire.Thread{
-		Source:   "remote",
-		ID:       "child-thread-1",
+		Source:    "remote",
+		ID:        "child-thread-1",
 		SessionID: "child-session-1",
 		Evener: appwire.EvenerThread{
 			Ref:       "remote:child-thread-1",
@@ -36,6 +36,42 @@ func TestAppThreadTreeEntries_ForkedRemoteThreadStampsDivergenceTurn(t *testing.
 			"is violated. A hub-synthesized meta with a parent and zero divergence would be "+
 			"misclassified as a delegate by any consumer applying the invariant.", meta.ParentSessionID)
 	}
+	if meta.DivergenceTurn != 1 {
+		t.Fatalf("DivergenceTurn=%d; the stamp must be exactly 1 — the true divergence turn is "+
+			"unknowable from remote thread metadata, so 1 (the minimum legal fork turn) is the "+
+			"deliberate marker value, and any other value would masquerade as real turn data",
+			meta.DivergenceTurn)
+	}
+}
+
+// TestAppThreadTreeEntries_SubagentKeepsDivergenceTurnZero pins the stamp's
+// gate: a remote delegate (Kind "subagent") keeps DivergenceTurn 0 even though
+// its ParentRef sets ParentSessionID. Parent-set-with-zero-divergence IS the
+// delegate signal the 96cp invariant encodes; stamping a delegate would
+// misclassify it as a fork — the same bug issue #152 fixes, mirrored.
+func TestAppThreadTreeEntries_SubagentKeepsDivergenceTurnZero(t *testing.T) {
+	thread := appwire.Thread{
+		Source:    "remote",
+		ID:        "delegate-thread-1",
+		SessionID: "delegate-session-1",
+		Evener: appwire.EvenerThread{
+			Ref:       "remote:delegate-thread-1",
+			ParentRef: "remote:parent-thread-1",
+			Kind:      "subagent",
+		},
+	}
+	meta, _, ok := appThreadTreeEntries(thread)
+	if !ok {
+		t.Fatalf("appThreadTreeEntries returned ok=false for a thread with a valid ref")
+	}
+	if !meta.IsSubagent || meta.ParentSessionID == "" {
+		t.Fatalf("setup error: want a subagent with a parent, got IsSubagent=%v ParentSessionID=%q",
+			meta.IsSubagent, meta.ParentSessionID)
+	}
+	if meta.DivergenceTurn != 0 {
+		t.Fatalf("DivergenceTurn=%d on a delegate; must stay 0 — a stamped delegate would be "+
+			"misclassified as a fork by any consumer applying the 96cp invariant", meta.DivergenceTurn)
+	}
 }
 
 // TestAppThreadTreeEntries_NoParentLeavesDivergenceTurnZero pins the flip
@@ -43,8 +79,8 @@ func TestAppThreadTreeEntries_ForkedRemoteThreadStampsDivergenceTurn(t *testing.
 // a fork).
 func TestAppThreadTreeEntries_NoParentLeavesDivergenceTurnZero(t *testing.T) {
 	thread := appwire.Thread{
-		Source:   "remote",
-		ID:       "standalone-thread",
+		Source:    "remote",
+		ID:        "standalone-thread",
 		SessionID: "standalone-session",
 		Evener: appwire.EvenerThread{
 			Ref: "remote:standalone-thread",

--- a/cmd/evener-hub/web_api_tree_divergence_test.go
+++ b/cmd/evener-hub/web_api_tree_divergence_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+)
+
+// TestAppThreadTreeEntries_ForkedRemoteThreadStampsDivergenceTurn pins issue
+// #152: a remote thread with a ParentRef (forked) must not leave DivergenceTurn
+// at zero. The kata 96cp invariant is ParentSessionID != "" implies DivergenceTurn
+// >= 1 (every fork writer validates divergenceTurn >= 1; a zero with a parent
+// implies a spawned delegate). A hub-synthesized meta with ParentSessionID set
+// and DivergenceTurn 0 would be misclassified as a delegate by any consumer
+// applying the invariant.
+func TestAppThreadTreeEntries_ForkedRemoteThreadStampsDivergenceTurn(t *testing.T) {
+	thread := appwire.Thread{
+		Source:   "remote",
+		ID:       "child-thread-1",
+		SessionID: "child-session-1",
+		Evener: appwire.EvenerThread{
+			Ref:       "remote:child-thread-1",
+			ParentRef: "remote:parent-thread-1",
+		},
+	}
+	meta, _, ok := appThreadTreeEntries(thread)
+	if !ok {
+		t.Fatalf("appThreadTreeEntries returned ok=false for a thread with a valid ref")
+	}
+	if meta.ParentSessionID == "" {
+		t.Fatalf("ParentSessionID is empty; the thread's ParentRef did not resolve (setup error)")
+	}
+	if meta.DivergenceTurn == 0 {
+		t.Fatalf("issue #152: DivergenceTurn is 0 while ParentSessionID=%q is set; "+
+			"the kata 96cp invariant (ParentSessionID != \"\" implies DivergenceTurn >= 1, i.e. a fork not a delegate) "+
+			"is violated. A hub-synthesized meta with a parent and zero divergence would be "+
+			"misclassified as a delegate by any consumer applying the invariant.", meta.ParentSessionID)
+	}
+}
+
+// TestAppThreadTreeEntries_NoParentLeavesDivergenceTurnZero pins the flip
+// side: a thread with no ParentRef must leave DivergenceTurn at zero (it's not
+// a fork).
+func TestAppThreadTreeEntries_NoParentLeavesDivergenceTurnZero(t *testing.T) {
+	thread := appwire.Thread{
+		Source:   "remote",
+		ID:       "standalone-thread",
+		SessionID: "standalone-session",
+		Evener: appwire.EvenerThread{
+			Ref: "remote:standalone-thread",
+		},
+	}
+	meta, _, ok := appThreadTreeEntries(thread)
+	if !ok {
+		t.Fatalf("appThreadTreeEntries returned ok=false for a thread with a valid ref")
+	}
+	if meta.ParentSessionID != "" {
+		t.Fatalf("ParentSessionID=%q should be empty for a thread with no ParentRef", meta.ParentSessionID)
+	}
+	if meta.DivergenceTurn != 0 {
+		t.Fatalf("DivergenceTurn=%d should be 0 for a thread with no parent (not a fork)", meta.DivergenceTurn)
+	}
+}


### PR DESCRIPTION
## Issue #152

`appThreadTreeEntries` in `cmd/evener-hub/web_api_tree.go` synthesized a `schema.SessionMeta` for remote threads with `ParentSessionID` set but left `DivergenceTurn` at zero. The 96cp invariant (`ParentSessionID != "" && DivergenceTurn == 0` implies a spawned delegate) would misclassify a remote forked thread as a delegate.

## Fix

Stamp `DivergenceTurn = 1` on the synthesized meta, gated on `ParentSessionID != "" && !IsSubagent`:
- **Value 1** is the minimum legal fork divergence turn (fork validation requires `>= 1`), not a sentinel.
- **Real delegates** (`IsSubagent == true`) keep `DivergenceTurn == 0` by design — they are NOT stamped.
- **Only forks** (`IsSubagent == false`, `ParentSessionID` set) get stamped.

## Consumer audit

- `agent/session_tools_find.go:504-510` uses OR (`ParentSessionID != "" || DivergenceTurn > 0`) — stamping is neutral, it already sees `ParentSessionID`.
- No AND-invariant consumer exists in the codebase.
- Numeric-value consumers (`agent/session_state.go:159`, `agent/jobs_activity_past.go:28`) are unreachable by hub-synthesized metas (in-memory only, never persisted).

## Tests

Two pinning tests in `cmd/evener-hub/web_api_tree_divergence_test.go`:
- `TestAppThreadTreeEntries_ForkedRemoteThreadStampsDivergenceTurn` — fork with ParentRef gets `DivergenceTurn >= 1`
- `TestAppThreadTreeEntries_NoParentLeavesDivergenceTurnZero` — thread with no ParentRef stays at 0

```
go test ./cmd/evener-hub/ -run TestAppThreadTree -v   # 3/3 PASS
go vet ./cmd/evener-hub/                              # clean
go test ./cmd/evener-hub/ -short                      # PASS (36s)
```

Three independent GLM proposals were unanimous on this approach. Rejects document-only and sentinel (-1) approaches.