### PR TITLE
fix(e2e): keep hub-stack tests off the marketplace network (teardown race)

### DIFF
--- a/cmd/evener-hub/e2e_turn_control_test.go
+++ b/cmd/evener-hub/e2e_turn_control_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -611,6 +612,14 @@ func startHubStackOnProvider(t *testing.T, providersTOML, model string) hubStack
 	if err := os.WriteFile(filepath.Join(evenerConfigDir, "providers.toml"), []byte(providersTOML), 0o600); err != nil {
 		t.Fatalf("write providers.toml: %v", err)
 	}
+	// The plugin auto-upgrade daemon (on by default) refreshes every seeded
+	// marketplace on hub start, which is a real `git clone` of external GitHub
+	// repos. Tests must not reach the network -- and the clone outlives the
+	// SIGKILL in the cleanup below, racing t.TempDir removal. The cleanup's
+	// marketplaces-dir check is the guard for this isolation.
+	if err := os.WriteFile(filepath.Join(evenerConfigDir, "hub.toml"), []byte("plugin_auto_upgrade = false\n"), 0o600); err != nil {
+		t.Fatalf("write hub.toml: %v", err)
+	}
 
 	workDir := t.TempDir()
 	readable := filepath.Join(workDir, "NOTES.md")
@@ -651,6 +660,17 @@ func startHubStackOnProvider(t *testing.T, providersTOML, model string) hubStack
 		_ = hub.Process.Kill()
 		_ = hub.Wait()
 		_ = hubLog.Close()
+		// A hub under test must never sync marketplaces: the seeded defaults
+		// point at real GitHub repos, so a sync is a network clone of an
+		// external repo -- and Kill above is SIGKILL, which orphans an
+		// in-flight `git clone` child that then races t.TempDir's RemoveAll
+		// ("unlinkat ...: directory not empty"). hub.toml above turns the
+		// auto-upgrade daemon off; this names the failure if that isolation
+		// ever regresses, instead of leaving a teardown flake to diagnose.
+		marketplacesDir := filepath.Join(evenerConfigDir, "plugins", "marketplaces")
+		if _, statErr := os.Stat(marketplacesDir); !errors.Is(statErr, os.ErrNotExist) {
+			t.Errorf("the hub under test synced marketplaces into %s: e2e hubs must not clone external marketplace repos (network in tests, and the orphaned git child races TempDir cleanup)", marketplacesDir)
+		}
 		body, readErr := os.ReadFile(logPath)
 		if readErr == nil {
 			// Daemons are grandchildren the hub deliberately outlives, and


### PR DESCRIPTION
## Root cause

Every e2e test that spawns a real `evener-hub` (`startHubStackOnProvider` in `cmd/evener-hub/e2e_turn_control_test.go`) started it with only `providers.toml` written, so the hub ran with its default `plugin_auto_upgrade = true`. Hub startup then:

1. seeds the default marketplaces (`SeedDefaultMarketplaces`): pointers to the real GitHub repos `anthropics/claude-plugins-official` and `obra/superpowers-marketplace`, and
2. launches the plugin auto-upgrade daemon (`startPluginAutoUpgradeDaemon`), whose first tick runs immediately and calls `RefreshMarketplace` on each seeded pointer — a real `git clone` of those external repos into the test's `XDG_CONFIG_HOME/evener/plugins/marketplaces/<name>` (a `t.TempDir`).

The harness tears the hub down with `hub.Process.Kill()` (SIGKILL), so the hub never reaches its context-cancel/WaitGroup shutdown path and the in-flight `git clone` child is orphaned. The orphan kept writing while `t.TempDir`'s RemoveAll ran, failing teardown with `unlinkat .../marketplaces/claude-plugins-official/.git: directory not empty` (CI run 32220671756, `TestE2E_SteerWithNoTurnIDReachesTheModelAndTheTranscript` on merge commit 771aa0ea7). Any of the 17 hub-stack e2e cases could flake this way, and all of them were quietly hitting the real network.

## Fix

At the source, in the harness every hub-stack test shares:

- write `hub.toml` with `plugin_auto_upgrade = false` next to the `providers.toml` the harness already writes, so a test hub never starts the marketplace sync at all — no network, no clone, nothing to race; and
- assert in the harness cleanup that the hub never created `plugins/marketplaces` in its config home, so a regression of this isolation fails by name in every hub-stack test instead of resurfacing as a TempDir-removal flake.

## Evidence

- Red: with only the guard added, `TestE2E_SteerWithNoTurnIDReachesTheModelAndTheTranscript` fails: "the hub under test synced marketplaces into .../config/evener/plugins/marketplaces" — the exact CI condition, reproduced deterministically.
- Green: that test passes with `-count=3`; `go test -race ./cmd/evener-hub/` passes (full package, 176s); `go test ./cmd/evener-hub/ -run 'TestE2E_' -count=2` passes; `go test -race ./internal/plugins/` passes; `go vet` and `golangci-lint` clean.

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU