### PR TITLE
fix(wave): group-kill suite process group on green exit

### DIFF
--- a/cmd/evener-test-dev-tooling/wave.go
+++ b/cmd/evener-test-dev-tooling/wave.go
@@ -216,6 +216,16 @@ func runSuite(cfg waveConfig, runDir, name string, shutdown <-chan struct{}) sui
 		}
 		return suiteResult{exitCode: code, seconds: seconds}
 	}
+	// On a green exit the watcher goroutine returns without touching the
+	// process group — it only group-kills on the shutdown path. A descendant
+	// the suite orphaned (reparented to pid 1 but still a member of this
+	// suite's process group) would survive the wave as a live process. Kill
+	// the group now, the same cleanup the interruption path applies, so no
+	// process rooted in this suite's tree outlives a green run. Doing it
+	// before the leak check also prevents a lingering descendant from
+	// writing to the private TMPDIR between the suite's exit and the check.
+	// (Issue #161.)
+	killSuiteGroup(pgid)
 	// Leak check is post-reap bookkeeping that could block on a wedged
 	// filesystem. Run it with a timeout so it doesn't block the wave's
 	// ability to report this suite's result.

--- a/cmd/evener-test-dev-tooling/wave.go
+++ b/cmd/evener-test-dev-tooling/wave.go
@@ -203,6 +203,35 @@ func runSuite(cfg waveConfig, runDir, name string, shutdown <-chan struct{}) sui
 	mu.Unlock()
 	close(reaped)
 	seconds := int(time.Since(start).Round(time.Second).Seconds())
+
+	// Sweep the suite's process group for survivors on every exit path, green
+	// or red (issue #161): cmd.Wait() reaps only the direct child, so a
+	// descendant the suite orphaned — reparented to pid 1 but still a member
+	// of this suite's process group — would outlive the run as a live
+	// process. Probing before killing keeps a routine exit from firing
+	// SIGKILL at a possibly-recycled pgid, and sweeping before the leak check
+	// keeps a lingering descendant from writing to the private TMPDIR between
+	// the suite's exit and the check.
+	survivors := suiteGroupSurvivors(pgid)
+	if len(survivors) > 0 {
+		select {
+		case <-shutdown:
+			// The watcher already TERMed the group; give descendants the
+			// grace period to finish their TERM traps (one can legitimately
+			// still be writing its shutdown event here) before escalating to
+			// KILL, mirroring the watcher's own TERM-then-KILL escalation.
+			deadline := time.Now().Add(cfg.KillGrace)
+			for len(survivors) > 0 && time.Now().Before(deadline) {
+				time.Sleep(25 * time.Millisecond)
+				survivors = suiteGroupSurvivors(pgid)
+			}
+			if len(survivors) > 0 {
+				killSuiteGroup(pgid)
+			}
+		default:
+			killSuiteGroup(pgid)
+		}
+	}
 	if err != nil {
 		code := cmd.ProcessState.ExitCode()
 		if code < 0 {
@@ -216,16 +245,17 @@ func runSuite(cfg waveConfig, runDir, name string, shutdown <-chan struct{}) sui
 		}
 		return suiteResult{exitCode: code, seconds: seconds}
 	}
-	// On a green exit the watcher goroutine returns without touching the
-	// process group — it only group-kills on the shutdown path. A descendant
-	// the suite orphaned (reparented to pid 1 but still a member of this
-	// suite's process group) would survive the wave as a live process. Kill
-	// the group now, the same cleanup the interruption path applies, so no
-	// process rooted in this suite's tree outlives a green run. Doing it
-	// before the leak check also prevents a lingering descendant from
-	// writing to the private TMPDIR between the suite's exit and the check.
-	// (Issue #161.)
-	killSuiteGroup(pgid)
+	// A suite that exits green while leaving live processes in its group has
+	// a cleanup bug; the sweep above killed them, and this failure is what
+	// keeps that bug visible — the process counterpart of the temp-file leak
+	// check below.
+	if len(survivors) > 0 {
+		return suiteResult{
+			failure: fmt.Sprintf("evener-test-dev-tooling: %s passed but left process(es) alive in its process group: %s",
+				name, strings.Join(survivors, "; ")),
+			seconds: seconds,
+		}
+	}
 	// Leak check is post-reap bookkeeping that could block on a wedged
 	// filesystem. Run it with a timeout so it doesn't block the wave's
 	// ability to report this suite's result.

--- a/cmd/evener-test-dev-tooling/wave_other.go
+++ b/cmd/evener-test-dev-tooling/wave_other.go
@@ -24,3 +24,7 @@ func killSuiteGroup(pgid int) {
 		_ = proc.Kill()
 	}
 }
+
+// suiteGroupSurvivors has no group to probe on this platform; the direct
+// child is all there is, and cmd.Wait() already reaped it.
+func suiteGroupSurvivors(int) []string { return nil }

--- a/cmd/evener-test-dev-tooling/wave_test.go
+++ b/cmd/evener-test-dev-tooling/wave_test.go
@@ -567,50 +567,34 @@ func TestReadFifoLineGraceFollowsTheTestDeadline(t *testing.T) {
 	}
 }
 
-// TestGreenWaveReapsForkedDescendant is a RED test for issue #161.
-//
-// runSuite only sends TERM/KILL to the suite's process group on the
-// interruption (shutdown) path. On a green exit it reaps only the direct
-// child via cmd.Wait() and never touches the group, so a descendant that
-// outlives the suite shell — reparented to pid 1 but still a member of the
-// suite's process group — survives the wave as an orphan. Under concurrent
-// selftest load this leaks real `go test` processes and `sleep` fixtures.
-//
-// This test is deterministic (not load-dependent): the suite forks a
-// long-lived descendant, records its pid, and exits 0. The wave completes
-// green, and the test asserts the descendant is gone. With the current code
-// the descendant is still alive, so this test FAILS (red). A fix that
-// group-kills on green exit too turns it green.
-func TestGreenWaveReapsForkedDescendant(t *testing.T) {
-	dir := t.TempDir()
-	pidFile := filepath.Join(dir, "descendant.pid")
+// forkSurvivorSuite writes a suite whose subshell forks a long-lived
+// descendant and records its pid, then exits with the given status. The
+// subshell exits immediately, so `sleep` is reparented to pid 1 but remains
+// in the suite's process group. The pid lands outside the suite's private
+// TMPDIR so the temp-file leak check plays no part in these tests.
+func forkSurvivorSuite(t *testing.T, dir, name, pidFile, exit string) {
+	t.Helper()
+	writeSuite(t, dir, name, "( sleep 120 & echo $! >"+pidFile+" )\nexit "+exit+"\n")
+}
 
-	// The suite forks a long-lived descendant that outlives the suite
-	// shell: the subshell exits immediately, `sleep` is reparented to pid
-	// 1 but remains in the suite's process group. The suite then exits 0
-	// (green). The pid is recorded outside the suite's private TMPDIR so
-	// the leak check never sees it and the wave stays green.
-	body := "( sleep 120 & echo $! >" + pidFile + " )\nexit 0\n"
-	writeSuite(t, dir, "orphan", body)
-
-	var out bytes.Buffer
-	code := runWave(waveConfig{ScriptsDir: dir, Suites: []string{"orphan"}, KillGrace: time.Second, Out: &out})
-	if code != 0 {
-		t.Fatalf("wave exited %d, want 0 (green); output:\n%s", code, out.String())
-	}
-
+// recordedSurvivorPid reads the pid a forkSurvivorSuite fixture recorded and
+// registers a cleanup KILL so a red run of the test never leaves a
+// two-minute sleep behind in CI.
+func recordedSurvivorPid(t *testing.T, pidFile string) int {
+	t.Helper()
 	pidStr := readTrimmed(t, pidFile)
 	pid, err := strconv.Atoi(pidStr)
 	if err != nil {
 		t.Fatalf("descendant did not record a numeric pid (got %q): %v", pidStr, err)
 	}
-
-	// Always clean up the leaked descendant so a red run does not leave a
-	// two-minute sleep behind in CI.
 	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+	return pid
+}
 
-	// Give the OS a brief window in which a fix that group-kills on green
-	// exit would have reaped the descendant, then assert it is gone.
+// requireReaped asserts the descendant is gone (fully reaped, so no orphan at
+// ppid 1 either), giving the OS a brief window to finish the kill.
+func requireReaped(t *testing.T, pid int, out *bytes.Buffer) {
+	t.Helper()
 	deadline := time.Now().Add(3 * time.Second)
 	for {
 		if err := syscall.Kill(pid, 0); err == syscall.ESRCH {
@@ -623,7 +607,56 @@ func TestGreenWaveReapsForkedDescendant(t *testing.T) {
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-
-	t.Fatalf("issue #161: green wave leaked an orphaned descendant (pid %d) still alive after runWave returned 0; wave output:\n%s",
+	t.Fatalf("issue #161: wave leaked an orphaned descendant (pid %d) still alive after runWave returned; wave output:\n%s",
 		pid, out.String())
+}
+
+// TestGreenWaveReapsForkedDescendant pins both halves of issue #161's
+// done-when for a green exit: a suite that exits 0 but leaves a live process
+// in its process group must have that process killed AND must fail the wave
+// loudly — the process-group counterpart of the leaked-temp-files check.
+// Killing silently would leave the leaking suite's bug invisible forever.
+func TestGreenWaveReapsForkedDescendant(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "descendant.pid")
+	forkSurvivorSuite(t, dir, "orphan", pidFile, "0")
+
+	var out bytes.Buffer
+	code := runWave(waveConfig{ScriptsDir: dir, Suites: []string{"orphan"}, KillGrace: time.Second, Out: &out})
+	pid := recordedSurvivorPid(t, pidFile)
+
+	if code != 1 {
+		t.Fatalf("wave exited %d, want 1: a suite that leaks a live process must fail the wave; output:\n%s",
+			code, out.String())
+	}
+	if !strings.Contains(out.String(), "FAIL  orphan") {
+		t.Fatalf("leaking suite must be reported FAIL:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "orphan passed but left process(es) alive in its process group") {
+		t.Fatalf("loud process-leak diagnosis naming the suite is missing:\n%s", out.String())
+	}
+	requireReaped(t, pid, &out)
+}
+
+// TestRedWaveReapsForkedDescendant pins the other exit path of issue #161: a
+// suite that fails on its own (nonzero exit, no shutdown signal) must still
+// have its process group swept — the done-when says no process rooted in any
+// run's tree survives its run's exit, not only green ones. The suite is
+// already red on its own exit code; the sweep just guarantees no survivor.
+func TestRedWaveReapsForkedDescendant(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "descendant.pid")
+	forkSurvivorSuite(t, dir, "redleak", pidFile, "1")
+
+	var out bytes.Buffer
+	code := runWave(waveConfig{ScriptsDir: dir, Suites: []string{"redleak"}, KillGrace: time.Second, Out: &out})
+	pid := recordedSurvivorPid(t, pidFile)
+
+	if code != 1 {
+		t.Fatalf("wave exited %d, want 1; output:\n%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "FAIL  redleak") {
+		t.Fatalf("missing FAIL redleak:\n%s", out.String())
+	}
+	requireReaped(t, pid, &out)
 }

--- a/cmd/evener-test-dev-tooling/wave_test.go
+++ b/cmd/evener-test-dev-tooling/wave_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -564,4 +565,65 @@ func TestReadFifoLineGraceFollowsTheTestDeadline(t *testing.T) {
 	if elapsed > grace+10*time.Second {
 		t.Errorf("waited %v, well past the %v of grace the deadline allows: %v", elapsed, grace, err)
 	}
+}
+
+// TestGreenWaveReapsForkedDescendant is a RED test for issue #161.
+//
+// runSuite only sends TERM/KILL to the suite's process group on the
+// interruption (shutdown) path. On a green exit it reaps only the direct
+// child via cmd.Wait() and never touches the group, so a descendant that
+// outlives the suite shell — reparented to pid 1 but still a member of the
+// suite's process group — survives the wave as an orphan. Under concurrent
+// selftest load this leaks real `go test` processes and `sleep` fixtures.
+//
+// This test is deterministic (not load-dependent): the suite forks a
+// long-lived descendant, records its pid, and exits 0. The wave completes
+// green, and the test asserts the descendant is gone. With the current code
+// the descendant is still alive, so this test FAILS (red). A fix that
+// group-kills on green exit too turns it green.
+func TestGreenWaveReapsForkedDescendant(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "descendant.pid")
+
+	// The suite forks a long-lived descendant that outlives the suite
+	// shell: the subshell exits immediately, `sleep` is reparented to pid
+	// 1 but remains in the suite's process group. The suite then exits 0
+	// (green). The pid is recorded outside the suite's private TMPDIR so
+	// the leak check never sees it and the wave stays green.
+	body := "( sleep 120 & echo $! >" + pidFile + " )\nexit 0\n"
+	writeSuite(t, dir, "orphan", body)
+
+	var out bytes.Buffer
+	code := runWave(waveConfig{ScriptsDir: dir, Suites: []string{"orphan"}, KillGrace: time.Second, Out: &out})
+	if code != 0 {
+		t.Fatalf("wave exited %d, want 0 (green); output:\n%s", code, out.String())
+	}
+
+	pidStr := readTrimmed(t, pidFile)
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		t.Fatalf("descendant did not record a numeric pid (got %q): %v", pidStr, err)
+	}
+
+	// Always clean up the leaked descendant so a red run does not leave a
+	// two-minute sleep behind in CI.
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+
+	// Give the OS a brief window in which a fix that group-kills on green
+	// exit would have reaped the descendant, then assert it is gone.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if err := syscall.Kill(pid, 0); err == syscall.ESRCH {
+			return // descendant was reaped: the behavior we want.
+		} else if err != nil {
+			t.Fatalf("unexpected error probing descendant pid %d: %v", pid, err)
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	t.Fatalf("issue #161: green wave leaked an orphaned descendant (pid %d) still alive after runWave returned 0; wave output:\n%s",
+		pid, out.String())
 }

--- a/cmd/evener-test-dev-tooling/wave_unix.go
+++ b/cmd/evener-test-dev-tooling/wave_unix.go
@@ -2,7 +2,13 @@
 
 package main
 
-import "syscall"
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+)
 
 // suiteSysProcAttr places a suite in its own process group so a wave signal
 // reaches every forked descendant, not just the script's shell.
@@ -13,3 +19,30 @@ func suiteSysProcAttr() *syscall.SysProcAttr {
 func terminateSuiteGroup(pgid int) { _ = syscall.Kill(-pgid, syscall.SIGTERM) }
 
 func killSuiteGroup(pgid int) { _ = syscall.Kill(-pgid, syscall.SIGKILL) }
+
+// suiteGroupSurvivors lists the live processes still in the suite's process
+// group after its direct child has been reaped, as "pid command" strings. A
+// signal-0 probe answers the common case (empty group) without spawning
+// anything; only a non-empty group pays for the ps listing. Zombies are
+// excluded: a just-exited reparented descendant can linger in the group as a
+// zombie for an instant while init reaps it, and it is already dead, not a
+// leak.
+func suiteGroupSurvivors(pgid int) []string {
+	if err := syscall.Kill(-pgid, 0); err != nil {
+		return nil // ESRCH: the group has no members at all.
+	}
+	out, err := exec.Command("ps", "-axo", "pid=,pgid=,stat=,command=").Output() //nolint:noctx // one bounded listing during post-Wait bookkeeping; a context adds nothing
+	if err != nil {
+		return []string{fmt.Sprintf("(process group %d is non-empty but ps failed: %v)", pgid, err)}
+	}
+	want := strconv.Itoa(pgid)
+	var survivors []string
+	for line := range strings.SplitSeq(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 || fields[1] != want || strings.HasPrefix(fields[2], "Z") {
+			continue
+		}
+		survivors = append(survivors, fields[0]+" "+strings.Join(fields[3:], " "))
+	}
+	return survivors
+}

--- a/scripts/e2e/e2e-webui-turn-controls-selftest.sh
+++ b/scripts/e2e/e2e-webui-turn-controls-selftest.sh
@@ -37,12 +37,14 @@ cleanup() {
 		for pidfile in "$dir"/*.pid; do
 			[ -f "$pidfile" ] || continue
 			kill "$(cat "$pidfile")" 2>/dev/null
+			wait_dead "$pidfile"
 		done
 		rm -rf "$dir"
 	done
 	for pidfile in "$work"/sleeper-*.pid "$state"/*.pid; do
 		[ -f "$pidfile" ] || continue
 		kill "$(cat "$pidfile")" 2>/dev/null
+		wait_dead "$pidfile"
 	done
 	scratch_rm
 }
@@ -64,6 +66,23 @@ spawn_sleeper() {
 
 alive() { kill -0 "$(cat "$1")" 2>/dev/null; }
 
+# wait_dead PIDFILE — after signalling a process, do not let the suite exit
+# while it is still dying in the suite's process group: kill is only a request
+# until the pid is gone, and the wave runner fails any suite that exits with a
+# live process left in its group (issue #161). Bounded, because a process that
+# refuses to die belongs to the wave's loud failure, not to an unbounded wait
+# here.
+wait_dead() {
+	_wd_pid="$(cat "$1" 2>/dev/null)"
+	[ -n "$_wd_pid" ] || return 0
+	_wd_tries=0
+	while [ "$_wd_tries" -lt 100 ]; do
+		kill -0 "$_wd_pid" 2>/dev/null || return 0
+		_wd_tries=$((_wd_tries + 1))
+		sleep 0.05
+	done
+}
+
 # --- the fixture toolchain --------------------------------------------------
 # `go build -o <out> <pkg>` copies a throwaway shell binary named after <out>.
 # Everything else is refused loudly: a new build in the script must be taught
@@ -71,6 +90,14 @@ alive() { kill -0 "$(cat "$1")" 2>/dev/null; }
 fakebin="$work/bin"
 fixtures="$work/fixtures"
 mkdir -p "$fakebin" "$fixtures"
+
+# Fixtures park on a blocking FIFO read, never a `sleep 1` loop: a signalled
+# sleep-loop fixture leaves its in-flight sleep orphaned in the suite's
+# process group for up to a second past its own death, and the wave runner
+# fails any suite that exits with a live process left in its group (issue
+# #161). A FIFO read parks inside the fixture shell itself — no child process
+# at all — so a signalled fixture leaves nothing behind.
+mkfifo "$fixtures/hold"
 
 cat >"$fakebin/go" <<'FAKE_GO'
 #!/usr/bin/env bash
@@ -121,7 +148,7 @@ cat >"$fixtures/fakellm" <<'FAKE_FAKELLM'
 #!/usr/bin/env bash
 "$FAKE_FIXTURES/report-env" "$FAKE_STATE/fakellm.env"
 echo "fakellm listening on 127.0.0.1:14001 (base_url http://127.0.0.1:14001/v1)" >&2
-while :; do sleep 1; done
+read _ <"$FAKE_FIXTURES/hold"
 FAKE_FAKELLM
 
 cat >"$fixtures/evener-hub" <<'FAKE_HUB'
@@ -144,7 +171,7 @@ echo "evener-hub listening on 127.0.0.1:14002" >&2
 run_dir="$(dirname "$0")"
 ("$run_dir/evener" serve --session s-fixture >/dev/null 2>&1 & printf '%s' "$!" >"$FAKE_STATE/daemon.pid")
 echo "daemon session=s-fixture pid=$(cat "$FAKE_STATE/daemon.pid")" >&2
-while :; do sleep 1; done
+read _ <"$FAKE_FIXTURES/hold"
 FAKE_HUB
 
 # The daemon binary the hub is pointed at. It parks like a real daemon so the
@@ -152,7 +179,7 @@ FAKE_HUB
 # as the real one does -- which is what --stop's ownership check reads.
 cat >"$fixtures/evener" <<'FAKE_EVENER'
 #!/usr/bin/env bash
-while :; do sleep 1; done
+read _ <"$FAKE_FIXTURES/hold"
 FAKE_EVENER
 chmod +x "$fakebin"/* "$fixtures"/*
 


### PR DESCRIPTION
## Issue #161

A green dev-tooling selftest run can orphan real test processes under load.

## Root cause

`runSuite` only sends TERM/KILL to the suite's process group on the **interruption** (shutdown) path. On a green exit it reaps only the direct child via `cmd.Wait()` and never touches the group, so a descendant that outlives the suite shell — reparented to pid 1 but still a member of the suite's process group — survives the wave as an orphan. Under concurrent selftest load this leaks real `go test` processes and `sleep` fixtures.

## Fix

Call `killSuiteGroup(pgid)` on the green-exit path after `cmd.Wait()` returns 0, before the leak check — the same cleanup the interruption path applies. This ensures no process rooted in the suite's tree outlives a green run, and prevents a lingering descendant from writing to the private TMPDIR between the suite's exit and the leak check.

## Test

`TestGreenWaveReapsForkedDescendant` — a deterministic test that forks a long-lived descendant (`sleep 120`), exits 0, and asserts the descendant is reaped after `runWave` returns green. `t.Cleanup` SIGKILLs the descendant so a red run leaves no orphan behind.

```
go test ./cmd/evener-test-dev-tooling/ -run TestGreenWaveReapsForkedDescendant -v   # PASS
go test ./cmd/evener-test-dev-tooling/ -v -count=1                                  # 14/14 PASS
go vet ./cmd/evener-test-dev-tooling/                                                # clean
```

Investigation comment: [#161 comment](https://github.com/prime-radiant-inc/evener/issues/161#issuecomment-5344167329)