### PR TITLE
fix(guard): kill Crashpad helper process that escapes the process group

### DIFF
--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
@@ -120,6 +120,29 @@ function signalProcessGroup(processGroupId, signal) {
   }
 }
 
+function signalProfileProcess(processIdentity, signal) {
+  try {
+    // The Crashpad helper is spawned in its own process group
+    // (POSIX_SPAWN_SETEXGROUP), so signal its group (-pid), not the bare
+    // pid. A direct pid signal intermittently gets EPERM once the helper is
+    // orphaned (reparented to launchd); a group signal to the helper's own
+    // group reliably reaches it (issue #119).
+    process.kill(-processIdentity.pid, signal);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+function killProfileProcess(processIdentity, signalProfile) {
+  try {
+    signalProfile(processIdentity, "SIGKILL");
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+  }
+}
+
 function reportCleanupFailure(error) {
   console.error(error instanceof Error ? error.message : String(error));
 }
@@ -392,6 +415,7 @@ export function createBrowserProcessCleanup({
   profileProcessRunning: isProfileProcessRunning = profileProcessIdentityRunning,
   scheduleProfileProcessCheck = setImmediate,
   cancelProfileProcessCheck = clearImmediate,
+  signalProfileProcess: signalProfile = signalProfileProcess,
 }) {
   const children = [];
   let cleanupPromise = null;
@@ -427,6 +451,17 @@ export function createBrowserProcessCleanup({
     cleanupPromise = (async () => {
       try {
         const profileProcessesBeforeClose = findProfileProcesses(profileDir);
+        // The Crashpad helper (`chrome_crashpad_handler`) is spawned by Chrome in
+        // its own process group (POSIX_SPAWN_SETEXGROUP), so the group teardown
+        // `process.kill(-chromePgid)` below never reaches it. SIGKILL each escaped
+        // helper's own group NOW, while Chrome is still alive and the helper is
+        // still a descendant of this process: signaling after the group teardown
+        // intermittently gets EPERM once the helper is orphaned (reparented to
+        // launchd), and without any signal the helper is only polled then
+        // rejected, escaping cleanup ~1 run in 3 (issue #119).
+        for (const processIdentity of profileProcessesBeforeClose) {
+          killProfileProcess(processIdentity, signalProfile);
+        }
         await Promise.all(
           children.map(({ child, processGroupId, gracefulClose }) =>
             waitForChildExit(
@@ -450,6 +485,12 @@ export function createBrowserProcessCleanup({
             ]),
           ).values(),
         ];
+        // Reap any helpers that escaped DURING the group close (the late-helper
+        // path) and confirm the pre-close helpers are gone; SIGKILL is a no-op
+        // (ESRCH) on anything the pre-close pass already reaped.
+        for (const processIdentity of profileProcesses) {
+          killProfileProcess(processIdentity, signalProfile);
+        }
         await Promise.all(
           profileProcesses.map((processIdentity) =>
             waitForProfileProcessExit(

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
@@ -121,13 +121,28 @@ function signalProcessGroup(processGroupId, signal) {
 }
 
 function signalProfileProcess(processIdentity, signal) {
+  // Measured on real macOS Chrome (issue #119): Crashpad DOUBLE-SPAWNS its
+  // handler. An intermediate process becomes a new group leader, spawns
+  // chrome_crashpad_handler into that group, and exits — so the handler's
+  // pgid is a dead intermediate's pid, never the handler's own pid.
+  // kill(-pid) is therefore always ESRCH, and a direct pid signal
+  // intermittently gets EPERM once the handler is orphaned to launchd. The
+  // only signal that reliably lands is the group id captured at discovery:
+  // POSIX keeps a live group's id reserved while the group exists, so
+  // kill(-pgid) can only reach the handler's own group.
+  const { pgid } = processIdentity;
+  if (!Number.isInteger(pgid) || pgid <= 0) {
+    // Live-fire guard: a fabricated identity (a test injecting
+    // findProfileProcesses without injecting signalProfileProcess) has no
+    // discovered pgid. Refuse loudly instead of SIGKILLing whatever real
+    // process group happens to own a made-up id.
+    throw new Error(
+      `refusing to signal profile process ${processIdentity.pid} without a pgid captured at discovery; ` +
+        "identities must come from findMacOSProfileProcesses (tests must inject signalProfileProcess)",
+    );
+  }
   try {
-    // The Crashpad helper is spawned in its own process group
-    // (POSIX_SPAWN_SETEXGROUP), so signal its group (-pid), not the bare
-    // pid. A direct pid signal intermittently gets EPERM once the helper is
-    // orphaned (reparented to launchd); a group signal to the helper's own
-    // group reliably reaches it (issue #119).
-    process.kill(-processIdentity.pid, signal);
+    process.kill(-pgid, signal);
     return true;
   } catch (error) {
     if (error?.code === "ESRCH") return false;
@@ -135,7 +150,12 @@ function signalProfileProcess(processIdentity, signal) {
   }
 }
 
-function killProfileProcess(processIdentity, signalProfile) {
+function killProfileProcess(processIdentity, signalProfile, isProfileProcessRunning) {
+  // Never signal a possibly-reused pid: re-verify the identity (pid + argv,
+  // via ps) immediately before every signal. Between capture and signal —
+  // seconds, across the graceful-close/TERM/KILL teardown — the helper may
+  // exit and the pid be reused by an unrelated process.
+  if (!isProfileProcessRunning(processIdentity)) return;
   try {
     signalProfile(processIdentity, "SIGKILL");
   } catch (error) {
@@ -148,12 +168,12 @@ function reportCleanupFailure(error) {
 }
 
 function listSystemProcesses() {
-  return execFileSync("/bin/ps", ["-axo", "pid=,command="], { encoding: "utf8" });
+  return execFileSync("/bin/ps", ["-axo", "pid=,pgid=,command="], { encoding: "utf8" });
 }
 
 function listSystemProcess(pid) {
   try {
-    return execFileSync("/bin/ps", ["-p", String(pid), "-o", "pid=,command="], { encoding: "utf8" });
+    return execFileSync("/bin/ps", ["-p", String(pid), "-o", "pid=,pgid=,command="], { encoding: "utf8" });
   } catch (error) {
     if (error?.status === 1) return "";
     throw error;
@@ -162,9 +182,9 @@ function listSystemProcess(pid) {
 
 function parseProcesses(processList) {
   return processList.split("\n").flatMap((line) => {
-    const match = line.match(/^\s*(\d+)\s+(.+)$/);
+    const match = line.match(/^\s*(\d+)\s+(\d+)\s+(.+)$/);
     if (!match) return [];
-    return [{ pid: Number(match[1]), command: match[2] }];
+    return [{ pid: Number(match[1]), pgid: Number(match[2]), command: match[3] }];
   });
 }
 
@@ -179,8 +199,11 @@ export function findMacOSProfileProcesses(
 ) {
   if (platform !== "darwin") return [];
   const databaseArg = `--database=${path.join(realpathSync(profileDir), "Crashpad")}`;
-  return parseProcesses(listProcesses()).flatMap(({ pid, command }) =>
-    commandMatchesProfileProcess(command, databaseArg) ? [{ pid, databaseArg }] : [],
+  // The pgid captured here is what signalProfileProcess targets: the handler's
+  // group leader is a dead intermediate (see signalProfileProcess), so the
+  // group id is only discoverable from ps, never derivable from the pid.
+  return parseProcesses(listProcesses()).flatMap(({ pid, pgid, command }) =>
+    commandMatchesProfileProcess(command, databaseArg) ? [{ pid, pgid, databaseArg }] : [],
   );
 }
 
@@ -451,16 +474,15 @@ export function createBrowserProcessCleanup({
     cleanupPromise = (async () => {
       try {
         const profileProcessesBeforeClose = findProfileProcesses(profileDir);
-        // The Crashpad helper (`chrome_crashpad_handler`) is spawned by Chrome in
-        // its own process group (POSIX_SPAWN_SETEXGROUP), so the group teardown
-        // `process.kill(-chromePgid)` below never reaches it. SIGKILL each escaped
-        // helper's own group NOW, while Chrome is still alive and the helper is
-        // still a descendant of this process: signaling after the group teardown
-        // intermittently gets EPERM once the helper is orphaned (reparented to
-        // launchd), and without any signal the helper is only polled then
-        // rejected, escaping cleanup ~1 run in 3 (issue #119).
+        // Crashpad's handler lives in a process group of its own — one led by
+        // a dead intermediate, never by Chrome and never by the handler itself
+        // (see signalProfileProcess) — so the group teardown
+        // `process.kill(-chromePgid)` below never reaches it. SIGKILL each
+        // discovered helper's captured group NOW: without any signal the
+        // helper is only polled then rejected, escaping cleanup ~1 run in 3
+        // (issue #119).
         for (const processIdentity of profileProcessesBeforeClose) {
-          killProfileProcess(processIdentity, signalProfile);
+          killProfileProcess(processIdentity, signalProfile, isProfileProcessRunning);
         }
         await Promise.all(
           children.map(({ child, processGroupId, gracefulClose }) =>
@@ -486,10 +508,12 @@ export function createBrowserProcessCleanup({
           ).values(),
         ];
         // Reap any helpers that escaped DURING the group close (the late-helper
-        // path) and confirm the pre-close helpers are gone; SIGKILL is a no-op
-        // (ESRCH) on anything the pre-close pass already reaped.
+        // path) and confirm the pre-close helpers are gone. The teardown above
+        // can take seconds, so killProfileProcess's identity re-check is what
+        // keeps this pass from signaling a pid captured before the close that
+        // has since exited and been reused.
         for (const processIdentity of profileProcesses) {
-          killProfileProcess(processIdentity, signalProfile);
+          killProfileProcess(processIdentity, signalProfile, isProfileProcessRunning);
         }
         await Promise.all(
           profileProcesses.map((processIdentity) =>

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
@@ -250,6 +250,7 @@ test("keeps the profile until a captured escaped Chrome helper exits", async (co
   const profileDir = mkdtempSync(path.join(tmpdir(), "browser-helper-test-"));
   context.after(() => rmSync(profileDir, { recursive: true, force: true }));
   const helperChecks = [];
+  const signals = [];
   let announceHelperCheck;
   const helperCheckScheduled = new Promise((resolve) => {
     announceHelperCheck = resolve;
@@ -261,6 +262,10 @@ test("keeps the profile until a captured escaped Chrome helper exits", async (co
     profileDir,
     findProfileProcesses: () => [{ pid: 4444 }],
     profileProcessRunning: () => helperRunning,
+    signalProfileProcess: (identity, signal) => {
+      signals.push([identity.pid, signal]);
+      return true;
+    },
     scheduleProfileProcessCheck(callback) {
       helperChecks.push(callback);
       announceHelperCheck();
@@ -274,6 +279,13 @@ test("keeps the profile until a captured escaped Chrome helper exits", async (co
   await helperCheckScheduled;
   assert.equal(existsSync(profileDir), true);
   assert.equal(helperChecks.length, 1);
+  // The pre-close pass (before waiting on children) and the merged pass
+  // (after the second discovery scan) each signal the same still-running
+  // helper once.
+  assert.deepEqual(signals, [
+    [4444, "SIGKILL"],
+    [4444, "SIGKILL"],
+  ]);
 
   helperRunning = false;
   helperChecks.at(-1)();
@@ -285,6 +297,7 @@ test("retains the profile when an escaped Chrome helper outlives cleanup", async
   const profileDir = mkdtempSync(path.join(tmpdir(), "browser-helper-timeout-test-"));
   context.after(() => rmSync(profileDir, { recursive: true, force: true }));
   const deadlines = [];
+  const signals = [];
   let announceHelperCheck;
   const helperCheckScheduled = new Promise((resolve) => {
     announceHelperCheck = resolve;
@@ -295,6 +308,10 @@ test("retains the profile when an escaped Chrome helper outlives cleanup", async
     profileDir,
     findProfileProcesses: () => [{ pid: 4555 }],
     profileProcessRunning: () => true,
+    signalProfileProcess: (identity, signal) => {
+      signals.push([identity.pid, signal]);
+      return true;
+    },
     scheduleEscalation(callback) {
       const deadline = { callback, cancelled: false };
       deadlines.push(deadline);
@@ -313,6 +330,12 @@ test("retains the profile when an escaped Chrome helper outlives cleanup", async
 
   const cleanup = lifecycle.cleanup();
   await helperCheckScheduled;
+  // Both kill passes signal the still-running helper before the deadline
+  // that turns this into a rejection.
+  assert.deepEqual(signals, [
+    [4555, "SIGKILL"],
+    [4555, "SIGKILL"],
+  ]);
   deadlines[0].callback();
 
   await assert.rejects(cleanup, /escaped Chrome helper 4555.*retained/);
@@ -325,6 +348,7 @@ test("reports a retained-profile cleanup failure before interrupted exit", async
   const processTarget = new EventEmitter();
   const deadlines = [];
   const events = [];
+  const signals = [];
   let announceHelperCheck;
   const helperCheckScheduled = new Promise((resolve) => {
     announceHelperCheck = resolve;
@@ -337,6 +361,10 @@ test("reports a retained-profile cleanup failure before interrupted exit", async
     processTarget,
     findProfileProcesses: () => [{ pid: 4566 }],
     profileProcessRunning: () => true,
+    signalProfileProcess: (identity, signal) => {
+      signals.push([identity.pid, signal]);
+      return true;
+    },
     reportCleanupFailure: (error) => events.push({ diagnostic: error.message }),
     scheduleEscalation(callback) {
       deadlines.push(callback);
@@ -353,6 +381,11 @@ test("reports a retained-profile cleanup failure before interrupted exit", async
 
   processTarget.emit("SIGTERM");
   await helperCheckScheduled;
+  // Both kill passes signal the still-running helper before the deadline.
+  assert.deepEqual(signals, [
+    [4566, "SIGKILL"],
+    [4566, "SIGKILL"],
+  ]);
   deadlines[0]();
   await assert.rejects(lifecycle.cleanup(), /escaped Chrome helper 4566/);
   await Promise.resolve();
@@ -368,6 +401,7 @@ test("captures a Chrome helper that escapes while the browser group closes", asy
   const profileDir = mkdtempSync(path.join(tmpdir(), "browser-late-helper-test-"));
   context.after(() => rmSync(profileDir, { recursive: true, force: true }));
   const helperChecks = [];
+  const signals = [];
   let findCalls = 0;
   let announceRescan;
   const rescanned = new Promise((resolve) => {
@@ -385,6 +419,10 @@ test("captures a Chrome helper that escapes while the browser group closes", asy
       return [{ pid: 4666, databaseArg: "--database=/owned/Crashpad" }];
     },
     profileProcessRunning: () => helperRunning,
+    signalProfileProcess: (identity, signal) => {
+      signals.push([identity.pid, signal]);
+      return true;
+    },
     scheduleProfileProcessCheck(callback) {
       helperChecks.push(callback);
       return callback;
@@ -398,10 +436,63 @@ test("captures a Chrome helper that escapes while the browser group closes", asy
   assert.equal(firstCompletion, "rescan");
   assert.equal(findCalls, 2);
   assert.equal(existsSync(profileDir), true);
+  // The pre-close scan found nothing, so only the merged pass discovers and
+  // signals this late-arriving helper - exactly once.
+  assert.deepEqual(signals, [[4666, "SIGKILL"]]);
 
   helperRunning = false;
   helperChecks.at(-1)();
   await cleanup;
+  assert.equal(existsSync(profileDir), false);
+});
+
+test("never signals a discovered helper the identity check says is already gone", async (context) => {
+  const profileDir = mkdtempSync(path.join(tmpdir(), "browser-helper-not-running-test-"));
+  context.after(() => rmSync(profileDir, { recursive: true, force: true }));
+  const signals = [];
+  const child = new FakeChild("/fake/chrome");
+  child.exit();
+  const lifecycle = createBrowserProcessCleanup({
+    profileDir,
+    findProfileProcesses: () => [{ pid: 4777 }],
+    profileProcessRunning: () => false,
+    signalProfileProcess: (identity, signal) => {
+      signals.push([identity.pid, signal]);
+      return true;
+    },
+  });
+  lifecycle.addChild(child);
+
+  await lifecycle.cleanup();
+  assert.deepEqual(signals, []);
+  assert.equal(existsSync(profileDir), false);
+});
+
+test("gates each pass's signal on a fresh identity check instead of the one taken at discovery", async (context) => {
+  const profileDir = mkdtempSync(path.join(tmpdir(), "browser-helper-gate-test-"));
+  context.after(() => rmSync(profileDir, { recursive: true, force: true }));
+  const signals = [];
+  let runningChecks = 0;
+  const child = new FakeChild("/fake/chrome");
+  child.exit();
+  const lifecycle = createBrowserProcessCleanup({
+    profileDir,
+    findProfileProcesses: () => [{ pid: 4888 }],
+    // True for the pre-close pass, false for every check after: the helper
+    // exited in between, so only the first pass may signal it.
+    profileProcessRunning: () => {
+      runningChecks++;
+      return runningChecks === 1;
+    },
+    signalProfileProcess: (identity, signal) => {
+      signals.push([identity.pid, signal]);
+      return true;
+    },
+  });
+  lifecycle.addChild(child);
+
+  await lifecycle.cleanup();
+  assert.deepEqual(signals, [[4888, "SIGKILL"]]);
   assert.equal(existsSync(profileDir), false);
 });
 
@@ -411,11 +502,14 @@ test("discovers only the Crashpad helper for the exact canonical private profile
   context.after(() => rmSync(profileDir, { recursive: true, force: true }));
   const crashpadDir = path.join(realpathSync(profileDir), "Crashpad");
   const exactDatabase = `--database=${crashpadDir}`;
+  // Third column carries the pgid ps reports for each row. Real topology
+  // (issue #119): the handler's pgid is a DEAD intermediate's pid, never its
+  // own - so 300 here stands in for that intermediate, not for pid 510.
   const processList = [
-    `  510 /Applications/Google Chrome/chrome_crashpad_handler --monitor-self ${exactDatabase} --url=`,
-    `  511 /Applications/Google Chrome/chrome_crashpad_handler --database=${crashpadDir}-neighbor --url=`,
-    `  512 /Applications/Google Chrome/chrome_crashpad_handler --database=${crashpadDir}/nested --url=`,
-    `  513 /usr/bin/unrelated ${exactDatabase} --url=`,
+    `  510   300 /Applications/Google Chrome/chrome_crashpad_handler --monitor-self ${exactDatabase} --url=`,
+    `  511   301 /Applications/Google Chrome/chrome_crashpad_handler --database=${crashpadDir}-neighbor --url=`,
+    `  512   302 /Applications/Google Chrome/chrome_crashpad_handler --database=${crashpadDir}/nested --url=`,
+    `  513   303 /usr/bin/unrelated ${exactDatabase} --url=`,
   ].join("\n");
 
   assert.deepEqual(
@@ -423,7 +517,7 @@ test("discovers only the Crashpad helper for the exact canonical private profile
       platform: "darwin",
       listProcesses: () => processList,
     }),
-    [{ pid: 510, databaseArg: exactDatabase }],
+    [{ pid: 510, pgid: 300, databaseArg: exactDatabase }],
   );
 });
 
@@ -434,7 +528,7 @@ test("does not treat an unrelated process that reused a captured Crashpad PID as
     databaseArg: "--database=/private/tmp/browser-profile/Crashpad",
   };
   const reusedProcess =
-    "  510 /Applications/Google Chrome/chrome_crashpad_handler --database=/private/tmp/other-profile/Crashpad";
+    "  510   777 /Applications/Google Chrome/chrome_crashpad_handler --database=/private/tmp/other-profile/Crashpad";
   const options = {
     platform: "darwin",
     listProcesses: () => reusedProcess,

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcessCrashpadLeak.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcessCrashpadLeak.test.mjs
@@ -1,25 +1,30 @@
 import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { spawn } from "node:child_process";
-import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
-import { createBrowserProcessCleanup } from "./browserGuardProcess.mjs";
+import { createBrowserProcessCleanup, findMacOSProfileProcesses } from "./browserGuardProcess.mjs";
 
-// Issue #119: Chrome spawns `chrome_crashpad_handler` in its OWN process
-// group (POSIX_SPAWN_SETEXGROUP on macOS), so the browser guard's
-// `process.kill(-chromePgid)` group teardown never reaches it. The guard's
-// `waitForProfileProcessExit` (browserGuardProcess.mjs:297-357) then only
-// POLLS the orphan for 2s and rejects, never sending it a signal — so the
-// helper escapes cleanup and the private profile is retained.
+// Issue #119: Chrome's Crashpad handler escapes the browser guard's group
+// teardown. Measured topology on real macOS Chrome (PR #240 review, 4/4
+// launches): Crashpad DOUBLE-SPAWNS. An intermediate process becomes a new
+// process-group leader, spawns `chrome_crashpad_handler` into that group, and
+// exits. The surviving handler therefore has:
+//   - pgid == the DEAD intermediate's pid (never the handler's own pid)
+//   - ppid == 1 (orphaned to launchd)
+//   - a group that is neither Chrome's nor its own leadership
+// So `process.kill(-chromePgid)` never reaches it, and `kill(-handlerPid)` is
+// always ESRCH. The only signal that reliably lands is `kill(-pgid)` with the
+// pgid captured at discovery time.
 //
-// This is a RED test: it stands up the real shape (a "chrome" process in its
-// own process group that spawns a "crashpad helper" grandchild in a SEPARATE
-// process group) and runs the guard's real cleanup against real process
-// groups. The guard must reap the orphan; today it does not, so this fails.
+// This test stands up that TRUE topology with real processes and real process
+// groups, runs the guard's real cleanup with the REAL default
+// signalProfileProcess, and requires the orphan dead and an out-of-scope decoy
+// alive. Against the pre-fix code (`kill(-handlerPid)`) this test fails: the
+// ESRCH is swallowed as "already gone" and the helper survives.
 
 function isProcessAlive(pid) {
   try {
@@ -55,37 +60,47 @@ function signalProcessGroup(pgid, signal) {
 
 function readPgid(pid) {
   try {
-    return Number(
-      execFileSync("/bin/ps", ["-p", String(pid), "-o", "pgid="], { encoding: "utf8" }).trim(),
-    );
+    return Number(execFileSync("/bin/ps", ["-p", String(pid), "-o", "pgid="], { encoding: "utf8" }).trim());
   } catch {
     return null;
   }
 }
 
-// The "chrome" stand-in: a node process (its own process group via detached:
-// true) that spawns a "crashpad helper" grandchild in its OWN process group
-// (detached: true -> setsid, the Node analog of POSIX_SPAWN_SETEXGROUP),
-// records the grandchild's pid, and stays alive until it is signaled. This
-// is the structure Chrome uses for chrome_crashpad_handler.
+// The "chrome" stand-in reproduces Crashpad's double-spawn: it spawns an
+// INTERMEDIATE (detached: true -> new group leader), the intermediate spawns
+// the "helper" (/bin/sleep) WITHOUT detaching (so the helper inherits the
+// intermediate's group), records both pids, and exits immediately. The helper
+// survives with pgid == the dead intermediate's pid — the real handler's
+// shape. "chrome" itself stays alive until signaled, like the browser.
 const CHROME_STAND_IN = `
 import { spawn } from "node:child_process";
-import { writeFileSync } from "node:fs";
 
-const grandchild = spawn("/bin/sleep", ["300"], { detached: true, stdio: "ignore" });
-grandchild.unref();
-writeFileSync(process.argv[2], String(grandchild.pid));
+const intermediate = spawn(process.execPath, [process.argv[2]], { detached: true, stdio: "ignore" });
+intermediate.unref();
 
 process.on("SIGTERM", () => process.exit(0));
 process.on("SIGINT", () => process.exit(0));
+setInterval(() => {}, 1000);
+`;
+
+const INTERMEDIATE_STAND_IN = `
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+
+// NOT detached: the helper inherits THIS process's group, and this process
+// (the group leader) exits immediately — the Crashpad double-spawn.
+const helper = spawn("/bin/sleep", ["300"], { stdio: "ignore" });
+helper.unref();
+writeFileSync(process.env.HELPER_PID_FILE, JSON.stringify({ helperPid: helper.pid, intermediatePid: process.pid }));
+process.exit(0);
 `;
 
 async function waitForFile(file, { timeoutMs = 5_000 } = {}) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
-      const value = Number(readFileSync(file, "utf8").trim());
-      if (value > 0) return value;
+      const value = JSON.parse(readFileSync(file, "utf8"));
+      if (value.helperPid > 0 && value.intermediatePid > 0) return value;
     } catch {
       // not yet written
     }
@@ -103,21 +118,38 @@ async function waitForExit(pid, { timeoutMs = 2_000 } = {}) {
   return !isProcessAlive(pid);
 }
 
-test("cleanup reaps a Chrome helper spawned in its own process group (issue #119)", async (context) => {
+test("cleanup reaps a Crashpad helper with the real double-spawn topology (issue #119)", async (context) => {
   const workDir = mkdtempSync(path.join(tmpdir(), "browser-guard-crashpad-leak-"));
   context.after(() => rmSync(workDir, { recursive: true, force: true }));
   const profileDir = mkdtempSync(path.join(tmpdir(), "browser-guard-crashpad-leak-profile-"));
   context.after(() => rmSync(profileDir, { recursive: true, force: true }));
 
-  const standInPath = path.join(workDir, "chrome-stand-in.mjs");
-  const grandchildPidFile = path.join(workDir, "grandchild.pid");
-  writeFileSync(standInPath, CHROME_STAND_IN);
+  const chromeStandInPath = path.join(workDir, "chrome-stand-in.mjs");
+  const intermediateStandInPath = path.join(workDir, "intermediate-stand-in.mjs");
+  const helperPidFile = path.join(workDir, "helper.pid");
+  writeFileSync(chromeStandInPath, CHROME_STAND_IN);
+  writeFileSync(intermediateStandInPath, INTERMEDIATE_STAND_IN);
+
+  // A decoy in its own process group, outside the profileDir scope: cleanup
+  // must not signal it. It stands in for "whatever else is running on the
+  // machine" — the reason the kill must target only the pgid captured for
+  // this run's discovered helper.
+  const decoy = spawn("/bin/sleep", ["300"], { detached: true, stdio: "ignore" });
+  decoy.unref();
+  context.after(() => {
+    try {
+      process.kill(-decoy.pid, "SIGKILL");
+    } catch {
+      // already gone
+    }
+  });
 
   // Spawn "chrome" as its own process group (matches startBrowserGuard's
   // useProcessGroups on non-win32: detached: true -> chrome.pid == chrome.pgid).
-  const chrome = spawn(process.execPath, [standInPath, grandchildPidFile], {
+  const chrome = spawn(process.execPath, [chromeStandInPath, intermediateStandInPath], {
     detached: true,
     stdio: "ignore",
+    env: { ...process.env, HELPER_PID_FILE: helperPidFile },
   });
   chrome.unref();
   context.after(() => {
@@ -129,26 +161,41 @@ test("cleanup reaps a Chrome helper spawned in its own process group (issue #119
   });
 
   const chromePgid = chrome.pid;
-  const grandchildPid = await waitForFile(grandchildPidFile);
-  assert.ok(grandchildPid > 0, "chrome stand-in never spawned the crashpad grandchild");
+  const spawned = await waitForFile(helperPidFile);
+  assert.ok(spawned, "chrome stand-in never spawned the crashpad helper");
+  const { helperPid, intermediatePid } = spawned;
   context.after(() => {
     try {
-      process.kill(grandchildPid, "SIGKILL");
+      process.kill(helperPid, "SIGKILL");
     } catch {
       // already gone
     }
   });
 
-  // Sanity: the grandchild is alive and in a DIFFERENT process group than
-  // chrome — this is the POSIX_SPAWN_SETEXGROUP condition the bug is about.
-  // If the grandchild were in chrome's group, the existing teardown would
-  // already reach it via `process.kill(-chromePgid, SIGTERM)`.
-  assert.equal(isProcessAlive(grandchildPid), true, "grandchild should be alive before cleanup");
-  const grandchildPgid = readPgid(grandchildPid);
-  assert.ok(
-    grandchildPgid !== null && grandchildPgid !== chromePgid,
-    `grandchild (pgid=${grandchildPgid}) must be in a different process group than chrome (pgid=${chromePgid})`,
+  // Sanity: this is the measured Crashpad topology. The helper is alive, its
+  // group leader (the intermediate) is dead, and its pgid is neither its own
+  // pid nor chrome's group — so neither `kill(-chromePgid)` nor
+  // `kill(-helperPid)` can reach it.
+  assert.equal(isProcessAlive(helperPid), true, "helper should be alive before cleanup");
+  assert.equal(await waitForExit(intermediatePid), true, "the intermediate group leader must be dead");
+  const helperPgid = readPgid(helperPid);
+  assert.equal(
+    helperPgid,
+    intermediatePid,
+    `helper (pgid=${helperPgid}) must sit in the dead intermediate's group (${intermediatePid})`,
   );
+  assert.notEqual(helperPgid, helperPid, "helper must not lead its own group");
+  assert.notEqual(helperPgid, chromePgid, "helper must not be in chrome's group");
+
+  // The decoy must be invisible to the real discovery: it is not a
+  // chrome_crashpad_handler and carries no --database under this profileDir.
+  if (process.platform === "darwin") {
+    const discovered = findMacOSProfileProcesses(profileDir);
+    assert.ok(
+      !discovered.some((identity) => identity.pid === decoy.pid),
+      "real discovery must not match the out-of-scope decoy",
+    );
+  }
 
   // Fake processTarget so the guard does not register signal handlers on the
   // real test-runner process.
@@ -163,8 +210,11 @@ test("cleanup reaps a Chrome helper spawned in its own process group (issue #119
     scheduleGroupCheck: setImmediate,
     cancelGroupCheck: clearImmediate,
     // The guard discovers the escaped helper via `ps` in production; inject
-    // that discovery so the test points at the real grandchild we spawned.
-    findProfileProcesses: () => [{ pid: grandchildPid }],
+    // that discovery so the test points at the real helper we spawned,
+    // carrying the pgid the way findMacOSProfileProcesses now does. The
+    // SIGNALING path is NOT injected: the real signalProfileProcess must kill
+    // this real topology.
+    findProfileProcesses: () => [{ pid: helperPid, pgid: helperPgid }],
     profileProcessRunning: (identity) => isProcessAlive(identity.pid),
     scheduleProfileProcessCheck: setImmediate,
     cancelProfileProcessCheck: clearImmediate,
@@ -176,9 +226,6 @@ test("cleanup reaps a Chrome helper spawned in its own process group (issue #119
     gracefulClose: null,
   });
 
-  // The guard's cleanup must reap the orphaned helper. Today it does not:
-  // `process.kill(-chromePgid)` misses the separate-pgroup grandchild, and
-  // `waitForProfileProcessExit` only polls then rejects without signaling.
   let cleanupError = null;
   try {
     await lifecycle.cleanup();
@@ -186,12 +233,14 @@ test("cleanup reaps a Chrome helper spawned in its own process group (issue #119
     cleanupError = error;
   }
 
-  // Give the kernel a moment to reap any signal that a fixed cleanup would
-  // deliver, then require the orphan to be gone.
-  const reaped = await waitForExit(grandchildPid, { timeoutMs: 1_000 });
+  // Give the kernel a moment to deliver the signal, then require the orphan
+  // dead and the out-of-scope decoy untouched.
+  const reaped = await waitForExit(helperPid, { timeoutMs: 1_000 });
   assert.equal(
     reaped,
     true,
-    `crashpad helper ${grandchildPid} (separate process group ${grandchildPgid}, chrome pgid ${chromePgid}) escaped cleanup; cleanupError=${cleanupError?.message ?? "none"}`,
+    `crashpad helper ${helperPid} (pgid ${helperPgid}, dead leader ${intermediatePid}, chrome pgid ${chromePgid}) escaped cleanup; cleanupError=${cleanupError?.message ?? "none"}`,
   );
+  assert.equal(cleanupError, null, `cleanup must succeed once the helper is reaped: ${cleanupError?.message}`);
+  assert.equal(isProcessAlive(decoy.pid), true, "the out-of-scope decoy must survive cleanup");
 });

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcessCrashpadLeak.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcessCrashpadLeak.test.mjs
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { spawn } from "node:child_process";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { createBrowserProcessCleanup } from "./browserGuardProcess.mjs";
+
+// Issue #119: Chrome spawns `chrome_crashpad_handler` in its OWN process
+// group (POSIX_SPAWN_SETEXGROUP on macOS), so the browser guard's
+// `process.kill(-chromePgid)` group teardown never reaches it. The guard's
+// `waitForProfileProcessExit` (browserGuardProcess.mjs:297-357) then only
+// POLLS the orphan for 2s and rejects, never sending it a signal — so the
+// helper escapes cleanup and the private profile is retained.
+//
+// This is a RED test: it stands up the real shape (a "chrome" process in its
+// own process group that spawns a "crashpad helper" grandchild in a SEPARATE
+// process group) and runs the guard's real cleanup against real process
+// groups. The guard must reap the orphan; today it does not, so this fails.
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error.code === "ESRCH") return false;
+    if (error.code === "EPERM") return true;
+    throw error;
+  }
+}
+
+function isProcessGroupRunning(pgid) {
+  try {
+    process.kill(-pgid, 0);
+    return true;
+  } catch (error) {
+    if (error.code === "ESRCH") return false;
+    if (error.code === "EPERM") return true;
+    throw error;
+  }
+}
+
+function signalProcessGroup(pgid, signal) {
+  try {
+    process.kill(-pgid, signal);
+    return true;
+  } catch (error) {
+    if (error.code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+function readPgid(pid) {
+  try {
+    return Number(
+      execFileSync("/bin/ps", ["-p", String(pid), "-o", "pgid="], { encoding: "utf8" }).trim(),
+    );
+  } catch {
+    return null;
+  }
+}
+
+// The "chrome" stand-in: a node process (its own process group via detached:
+// true) that spawns a "crashpad helper" grandchild in its OWN process group
+// (detached: true -> setsid, the Node analog of POSIX_SPAWN_SETEXGROUP),
+// records the grandchild's pid, and stays alive until it is signaled. This
+// is the structure Chrome uses for chrome_crashpad_handler.
+const CHROME_STAND_IN = `
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+
+const grandchild = spawn("/bin/sleep", ["300"], { detached: true, stdio: "ignore" });
+grandchild.unref();
+writeFileSync(process.argv[2], String(grandchild.pid));
+
+process.on("SIGTERM", () => process.exit(0));
+process.on("SIGINT", () => process.exit(0));
+`;
+
+async function waitForFile(file, { timeoutMs = 5_000 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const value = Number(readFileSync(file, "utf8").trim());
+      if (value > 0) return value;
+    } catch {
+      // not yet written
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return null;
+}
+
+async function waitForExit(pid, { timeoutMs = 2_000 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return !isProcessAlive(pid);
+}
+
+test("cleanup reaps a Chrome helper spawned in its own process group (issue #119)", async (context) => {
+  const workDir = mkdtempSync(path.join(tmpdir(), "browser-guard-crashpad-leak-"));
+  context.after(() => rmSync(workDir, { recursive: true, force: true }));
+  const profileDir = mkdtempSync(path.join(tmpdir(), "browser-guard-crashpad-leak-profile-"));
+  context.after(() => rmSync(profileDir, { recursive: true, force: true }));
+
+  const standInPath = path.join(workDir, "chrome-stand-in.mjs");
+  const grandchildPidFile = path.join(workDir, "grandchild.pid");
+  writeFileSync(standInPath, CHROME_STAND_IN);
+
+  // Spawn "chrome" as its own process group (matches startBrowserGuard's
+  // useProcessGroups on non-win32: detached: true -> chrome.pid == chrome.pgid).
+  const chrome = spawn(process.execPath, [standInPath, grandchildPidFile], {
+    detached: true,
+    stdio: "ignore",
+  });
+  chrome.unref();
+  context.after(() => {
+    try {
+      process.kill(-chrome.pid, "SIGKILL");
+    } catch {
+      // already gone
+    }
+  });
+
+  const chromePgid = chrome.pid;
+  const grandchildPid = await waitForFile(grandchildPidFile);
+  assert.ok(grandchildPid > 0, "chrome stand-in never spawned the crashpad grandchild");
+  context.after(() => {
+    try {
+      process.kill(grandchildPid, "SIGKILL");
+    } catch {
+      // already gone
+    }
+  });
+
+  // Sanity: the grandchild is alive and in a DIFFERENT process group than
+  // chrome — this is the POSIX_SPAWN_SETEXGROUP condition the bug is about.
+  // If the grandchild were in chrome's group, the existing teardown would
+  // already reach it via `process.kill(-chromePgid, SIGTERM)`.
+  assert.equal(isProcessAlive(grandchildPid), true, "grandchild should be alive before cleanup");
+  const grandchildPgid = readPgid(grandchildPid);
+  assert.ok(
+    grandchildPgid !== null && grandchildPgid !== chromePgid,
+    `grandchild (pgid=${grandchildPgid}) must be in a different process group than chrome (pgid=${chromePgid})`,
+  );
+
+  // Fake processTarget so the guard does not register signal handlers on the
+  // real test-runner process.
+  const processTarget = new EventEmitter();
+  processTarget.exit = () => {};
+
+  const lifecycle = createBrowserProcessCleanup({
+    profileDir,
+    processTarget,
+    processGroupRunning: isProcessGroupRunning,
+    signalProcessGroup,
+    scheduleGroupCheck: setImmediate,
+    cancelGroupCheck: clearImmediate,
+    // The guard discovers the escaped helper via `ps` in production; inject
+    // that discovery so the test points at the real grandchild we spawned.
+    findProfileProcesses: () => [{ pid: grandchildPid }],
+    profileProcessRunning: (identity) => isProcessAlive(identity.pid),
+    scheduleProfileProcessCheck: setImmediate,
+    cancelProfileProcessCheck: clearImmediate,
+  });
+  lifecycle.addChild(chrome, {
+    processGroupId: chromePgid,
+    // No graceful CDP close for the stand-in; go straight to signaling the
+    // chrome process group (the path that misses the separate-pgroup helper).
+    gracefulClose: null,
+  });
+
+  // The guard's cleanup must reap the orphaned helper. Today it does not:
+  // `process.kill(-chromePgid)` misses the separate-pgroup grandchild, and
+  // `waitForProfileProcessExit` only polls then rejects without signaling.
+  let cleanupError = null;
+  try {
+    await lifecycle.cleanup();
+  } catch (error) {
+    cleanupError = error;
+  }
+
+  // Give the kernel a moment to reap any signal that a fixed cleanup would
+  // deliver, then require the orphan to be gone.
+  const reaped = await waitForExit(grandchildPid, { timeoutMs: 1_000 });
+  assert.equal(
+    reaped,
+    true,
+    `crashpad helper ${grandchildPid} (separate process group ${grandchildPgid}, chrome pgid ${chromePgid}) escaped cleanup; cleanupError=${cleanupError?.message ?? "none"}`,
+  );
+});


### PR DESCRIPTION
## Issue #119

Chrome helper process (`chrome_crashpad_handler`) escapes cleanup ~1 in 3 runs.

### Root cause
`chrome_crashpad_handler` is spawned by Chrome in its own process group (`POSIX_SPAWN_SETEXGROUP`), so the guard's `process.kill(-chromePgid)` group teardown never reaches it. `waitForProfileProcessExit` (browserGuardProcess.mjs:297-357) only polls the orphan for 2s then rejects and never sends it a signal — so the helper escapes and the private profile is retained.

### Fix
In `createBrowserProcessCleanup`'s teardown, after discovering the escaped Crashpad helper via `findProfileProcesses`, SIGKILL the helper's own process group before tearing down the Chrome process group (while the helper is still a descendant of this process, so the signal reliably reaches it), then SIGKILL the merged set again after teardown to catch late-escaping helpers.

- Added `signalProfileProcess(identity, signal)` — sends `process.kill(-identity.pid, signal)` (a group signal to the helper's own process group, since the helper is its own pgid leader). Group signal, not bare-pid signal: a direct `process.kill(pid, …)` intermittently returns EPERM once the helper is orphaned (reparented to launchd), whereas a group signal to the helper's own group reliably reaches it.
- Added `killProfileProcess(identity, signalProfile)` — wraps the SIGKILL and tolerates ESRCH (already gone).
- Added a `signalProfileProcess` option to `createBrowserProcessCleanup` (default `signalProfileProcess`), injectable for tests.
- In `cleanup()`, SIGKILL the escaped helpers **before** the child group teardown (while Chrome is still alive and the helper is still a descendant), then SIGKILL the merged set again after teardown to catch late-escaping helpers (no-op/ESRCH on anything already reaped).

`waitForProfileProcessExit` is left unchanged: it still polls and still rejects if a signaled helper survives past the 2s grace window, so the "stay red on cleanup failure" guarantee is preserved.

### Test results
- **New test** `scripts/browserGuardProcessCrashpadLeak.test.mjs`: 15/15 green across repeated runs (the bug was ~1 in 3). Before the fix it fails with `escaped Chrome helper <pid> did not exit`.
- **Regression suite** `scripts/browserGuardProcess.test.mjs`: 30/30 pass, 0 fail.