### PR TITLE
fix(agent): add per-response tool-call bound to consumeModelStream

### DIFF
--- a/agent/session_stream.go
+++ b/agent/session_stream.go
@@ -59,6 +59,15 @@ type attemptObservation struct {
 // the two readers must not drift.
 const modelRetryFailFastAfter = 4
 
+// maxToolCallsPerResponse is the in-stream per-response backstop for GitHub
+// issue #94: the maximum number of complete tool calls a single streamed
+// assistant response may carry before consumeModelStream stops it. See the
+// bound's comment in the event loop for the full rationale. Legitimate
+// agent operation rarely exceeds 10-20 tool calls per response; 40 is
+// high enough to never trip in normal use and low enough to stop a runaway
+// (the captured incident streamed 228) before it streams indefinitely.
+const maxToolCallsPerResponse = 40
+
 // emitModelRetry builds the RetryPolicy.OnRetry hook that reports each retry of
 // req on the session event bus. Attempt counts retries (the first retry is 1);
 // MaxAttempts is the full budget including the initial try, so a consumer can
@@ -242,6 +251,10 @@ func (s *Session) consumeModelStream(ctx context.Context, req llm.Request, st ll
 	assistantStarted := false
 	finished := false
 
+	// toolCallsInResponse counts complete tool calls emitted in this single
+	// streamed response. It backs the per-response runaway bound below.
+	toolCallsInResponse := 0
+
 	// firstContent/lastContent bound the content-event window — text, tool-arg
 	// (delta or end), and reasoning content only, never wall-clock attempt
 	// duration (spec: SSE keep-alives reset the read timer, so a stalled
@@ -387,6 +400,25 @@ func (s *Session) consumeModelStream(ctx context.Context, req llm.Request, st ll
 			}
 			if toolNames[ev.ToolCall.ID] == s.resultToolName() {
 				emitCommunicatePreview(ev.ToolCall.ID)
+			}
+			// Per-response tool-call bound (GitHub issue #94): the four
+			// existing runaway guards all watch between rounds or for
+			// silence/failure. A loud never-terminating response — the
+			// model streams an unbounded number of tool calls without
+			// completing a round — touches none of them. This bound is
+			// the in-stream backstop the prior-art survey (issue #94)
+			// identified: when a single response exceeds
+			// maxToolCallsPerResponse complete tool calls, stop the stream
+			// with a non-retryable error so the retry loop does not
+			// re-stream the same runaway. 40 is well above any legitimate
+			// multi-tool response (10-20 is typical) and well below the
+			// 228-call incident that motivated the bound.
+			toolCallsInResponse++
+			if toolCallsInResponse > maxToolCallsPerResponse {
+				err := llm.NewPermanentStreamError(req.Provider,
+					"per-response tool-call bound exceeded: "+strconv.Itoa(toolCallsInResponse)+
+						" tool calls in one response (limit "+strconv.Itoa(maxToolCallsPerResponse)+")", nil)
+				return sessionModelResponse{}, observe(err), err
 			}
 		case llm.StreamEventFinish:
 			finished = true

--- a/agent/session_stream_perresponse_bound_test.go
+++ b/agent/session_stream_perresponse_bound_test.go
@@ -1,0 +1,138 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/llm"
+)
+
+// TestConsumeModelStream_PerResponseToolCallBound is a RED test for GitHub
+// issue #94: "Nothing bounds a single assistant response — runaway model
+// streams until user interrupts."
+//
+// Root cause (from the issue's investigation): consumeModelStream's event loop
+// (agent/session_stream.go) has no in-stream per-response tool-call guard —
+// neither cycle detection nor a high raw-call backstop. All four existing
+// guards watch between rounds or on silence/failure, and a loud never-
+// terminating response touches none of them:
+//
+//   - MaxToolRoundsPerInput counts tool ROUNDS; a response that never
+//     completes never finishes a round.
+//   - PhaseSilentStall fires only on ZERO content events; every tool-call
+//     emission calls noteContent(), so a runaway reads as healthy activity.
+//   - RetryStream's cap rule applies only to a stream that FAILED; a runaway
+//     never fails, it just never ends.
+//   - The tool breaker (agent/internal/tool/breaker.go) keys on tool RESULTS;
+//     nothing executes during the response (dispatch is after StreamEventFinish).
+//
+// This test reproduces the incident's exact shape — a single streamed response
+// containing many tool calls built from a short repeating cycle (A,B,C),
+// byte-identical, many times over — and asserts that a per-response bound
+// fires and stops the stream before all of them are consumed. With the current
+// code no such bound exists, so consumeModelStream happily drains every event
+// and returns nil: the test fails (RED) because it expects a bound.
+func TestConsumeModelStream_PerResponseToolCallBound(t *testing.T) {
+	t.Parallel()
+
+	const (
+		cycleLen   = 3  // A,B,C — the incident's distinct-signature count
+		repeat     = 20 // 20 × 3 = 60 tool calls in one response
+		totalCalls = cycleLen * repeat
+		// A per-response bound must fire well before the incident's 228 calls.
+		// Any sane bound (cycle detection trips ~15, backstop in the hundreds)
+		// stops the stream before totalCalls. We assert the stream did NOT
+		// complete all of them.
+	)
+
+	sess := newSession(t)
+	req := llm.Request{Provider: "openai", Model: "gpt-5.2"}
+	st := llm.NewChanStream(nil)
+
+	// Build three distinct tool-call argument blocks (the cycle members),
+	// then emit them as stream events repeat times in a single response.
+	type cycleMember struct {
+		id   string
+		name string
+		args []byte
+	}
+	cycle := []cycleMember{
+		{id: "call_a", name: "manage_worktree", args: []byte(`{"action":"create","path":"/tmp/a"}`)},
+		{id: "call_b", name: "task_list", args: []byte(`{"action":"view"}`)},
+		{id: "call_c", name: "communicate", args: []byte(`{"message":"status","end_turn":false}`)},
+	}
+
+	// Emit the tool-call stream events. Each member is sent as Start → Delta
+	// (args) → End, exactly the shape a real provider stream carries.
+	go func() {
+		defer st.CloseSend()
+		for r := 0; r < repeat; r++ {
+			for _, m := range cycle {
+				// Unique IDs across the whole stream so the accumulator
+				// records each as a distinct call (matching the incident,
+				// where every call had a unique id even when args repeated).
+				id := fmt.Sprintf("%s_%d", m.id, r)
+				st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallStart, ToolCall: &llm.ToolCallData{ID: id, Name: m.name}})
+				st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallDelta, ToolCall: &llm.ToolCallData{ID: id, Arguments: m.args}})
+				st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallEnd, ToolCall: &llm.ToolCallData{ID: id, Name: m.name, Arguments: m.args}})
+			}
+		}
+		// A healthy stream terminates with a Finish event. A runaway never
+		// does, but we emit it so that, IF a bound existed and stopped the
+		// stream early, the absence of Finish is attributable to the bound
+		// rather than to a malformed test stream. (The bound would return
+		// before reaching this CloseSend-driven finish in the error path.)
+		finish := llm.FinishReason{Reason: "tool_calls"}
+		st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &finish})
+	}()
+
+	type outcome struct {
+		resp sessionModelResponse
+		obs  attemptObservation
+		err  error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		resp, obs, err := sess.consumeModelStream(context.Background(), req, st)
+		done <- outcome{resp, obs, err}
+	}()
+
+	var got outcome
+	select {
+	case got = <-done:
+		// returned
+	case <-time.After(30 * time.Second): // TRIPWIRE: in-process ChanStream with no real I/O; only fires on a genuine hang.
+		t.Fatal("consumeModelStream did not finish")
+	}
+
+	// RED assertion: a per-response tool-call bound (cycle detection or a raw
+	// call backstop) MUST fire and stop the stream before it consumes all
+	// totalCalls. With the current code no bound exists, so consumeModelStream
+	// drains every event and returns a response carrying all totalCalls tool
+	// calls — this branch is what makes the test RED.
+	stoppedByBound := got.err != nil
+	callsConsumed := len(got.resp.Response.ToolCalls())
+
+	if !stoppedByBound {
+		if callsConsumed >= totalCalls {
+			t.Errorf("RED for issue #94: consumeModelStream consumed all %d tool calls in one response "+
+				"and returned nil — no per-response bound fired. A runaway model (the incident: 228 calls, "+
+				"76 repetitions of a 3-call cycle) is unbounded. Expected a bound (cycle detection or raw-call "+
+				"backstop) to stop the stream; got err=nil, calls=%d.",
+				totalCalls, callsConsumed)
+		} else {
+			t.Errorf("consumeModelStream stopped early (calls=%d < %d) but returned no error; "+
+				"expected either the bound's error or all calls. err=%v",
+				callsConsumed, totalCalls, got.err)
+		}
+	}
+
+	// If a bound did fire (it will not, today), it must be a non-nil error that
+	// the turn loop can classify — not a silent swallow. This guards against a
+	// future implementation that stops the stream but loses the signal.
+	if stoppedByBound && got.err == nil {
+		t.Errorf("bound returned a nil error; expected a non-nil error so the turn loop can classify the stop")
+	}
+}

--- a/llm/sdk_errors.go
+++ b/llm/sdk_errors.go
@@ -97,6 +97,25 @@ func NewStreamError(provider, message string, cause error) error {
 	}}
 }
 
+// NewPermanentStreamError reports a streaming failure that must not be
+// retried: the stream was stopped for a reason re-running it cannot fix,
+// such as a per-response runaway bound tripping mid-stream (the model
+// emitted an unbounded number of tool calls in one response and would do
+// so again on retry). cause is exposed via Unwrap; pass nil when none
+// applies. It carries the same StreamError type as NewStreamError so
+// existing errors.As(err, &StreamError) and errors.As(err, &llm.Error)
+// handling apply, but Retryable() returns false, so Classify() reports
+// ErrorClassPermanent and the retry loop short-circuits rather than
+// re-streaming the same runaway.
+func NewPermanentStreamError(provider, message string, cause error) error {
+	return &StreamError{nonHTTPBaseError{
+		provider:  provider,
+		message:   message,
+		retryable: false,
+		cause:     cause,
+	}}
+}
+
 // NewNoObjectGeneratedError reports that no valid object could be produced from
 // the model output. cause is the underlying parse/validation error, exposed via
 // Unwrap; pass nil when none applies.


### PR DESCRIPTION
GitHub issue #94: nothing bounded a single assistant response, so a runaway model streamed an unbounded number of tool calls in one response (the captured incident streamed 228) until the user interrupted.

All four existing runaway guards are structurally blind to a loud never-terminating response:
- **MaxToolRoundsPerInput** counts tool ROUNDS; a response that never completes never finishes a round.
- **PhaseSilentStall** fires only on ZERO content events; every tool-call emission calls `noteContent()`, so a runaway reads as healthy activity.
- **RetryStream's cap rule** applies only to a stream that FAILED; a runaway never fails, it just never ends.
- **The tool breaker** keys on tool RESULTS; nothing executes during the response (dispatch is after `StreamEventFinish`).

## Changes

```diff
llm/sdk_errors.go
+ NewPermanentStreamError  // non-retryable StreamError: same type so errors.As handling applies, Retryable() returns false
agent/session_stream.go
+ const maxToolCallsPerResponse = 40  // in-stream per-response backstop
+ toolCallsInResponse counter + bound check in StreamEventToolCallEnd case
agent/session_stream_perresponse_bound_test.go  (new)
+ TestConsumeModelStream_PerResponseToolCallBound  // streams 60 tool calls in a repeating A,B,C cycle, asserts the bound stops the stream
```

This adds an in-stream per-response backstop in `consumeModelStream`'s event loop: when a single response exceeds `maxToolCallsPerResponse` (40) complete tool calls, the stream stops with a non-retryable error so the retry loop short-circuits rather than re-streaming the same runaway. 40 is well above any legitimate multi-tool response (10-20 is typical) and well below the 228-call incident that motivated the bound.

## Verification

- `go test ./agent/ -run TestConsumeModelStream_PerResponseToolCallBound -v -count=1` — PASS
- `go test ./agent/ -short -count=1` — PASS (no regressions, 79.7s)
- `go test ./llm/ -short -count=1` — PASS
- `go vet ./agent/ ./llm/` — clean

Closes #94.