### PR TITLE
fix(web): give spawn the composer's control row on a phone (#198)

### DIFF
--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/spawn-attach-in-card/assert.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/spawn-attach-in-card/assert.mjs
@@ -4,8 +4,9 @@
 // spawn.module.css turned into `position: fixed; bottom: 0` inside its 899px
 // media block, so the card's own control row detached from the card and became
 // a page-level band. Measured in this same harness on the pre-fix CSS at
-// 390x844: the card spans y=8..205 while the control row (and the attach
-// button inside it) sits at y=768..844.
+// 390x844: the card is 12,12 366x106 while the control row is 0,767 390x77,
+// with the attach button at 16,784 44x44 - two thirds of a phone screen away
+// from the prompt it attaches to.
 //
 // The session composer has never had this problem - it keeps attach, the model
 // trigger and the send verb inside the card's control row at every width

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/spawn-attach-in-card/assert.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/spawn-attach-in-card/assert.mjs
@@ -1,0 +1,89 @@
+// Issue #198 / the rejected PR #242: on a phone the spawn pane's attach button
+// was stranded at the bottom of the VIEWPORT, nowhere near the prompt it
+// attaches to. Spawn passed PromptCard a controlsClassName that
+// spawn.module.css turned into `position: fixed; bottom: 0` inside its 899px
+// media block, so the card's own control row detached from the card and became
+// a page-level band. Measured in this same harness on the pre-fix CSS at
+// 390x844: the card spans y=8..205 while the control row (and the attach
+// button inside it) sits at y=768..844.
+//
+// The session composer has never had this problem - it keeps attach, the model
+// trigger and the send verb inside the card's control row at every width
+// (Composer.tsx's leading/actions slots) - so the fix is to render the same
+// shape, and this case is what pins it there.
+//
+// Four geometric claims, and one placement claim aimed at the OTHER way this
+// has been got wrong:
+//
+//   1. The control row is not a fixed band. `position: fixed` is the
+//      mechanism; naming it directly means a reintroduction fails here for
+//      the reason it is wrong rather than only through its symptoms.
+//   2. Everything in the row - the row itself, attach, the model trigger,
+//      Start - is inside the card. That is the containment the fixed band
+//      broke, and it is what "reuse the composer's UI" means geometrically.
+//   3. The model trigger is actually on screen at phone width. It is the
+//      whole of issue #198's second half (setting the model from the card),
+//      and a display:none typo would otherwise pass claim 2 vacuously - a box
+//      with no size is trivially "contained".
+//   4. Attach sits BELOW the writing surface, not on top of it. PR #242's
+//      first attempt overlaid the paperclip on the textarea's lower-right
+//      corner, where typed text runs underneath it. The composer puts it in
+//      the row under the field; so does this.
+const TOLERANCE = 0.5; // sub-pixel layout rounding, not a fudge factor
+
+function describe(b) {
+  if (b === null) return "missing";
+  return `${b.left.toFixed(1)},${b.top.toFixed(1)} ${b.width.toFixed(1)}x${b.height.toFixed(1)}`;
+}
+
+function escapes(child, parent) {
+  return (
+    child.left < parent.left - TOLERANCE ||
+    child.top < parent.top - TOLERANCE ||
+    child.right > parent.right + TOLERANCE ||
+    child.bottom > parent.bottom + TOLERANCE
+  );
+}
+
+export default function assert(m) {
+  const failures = [];
+  const missing = ["card", "field", "controls", "attach", "start", "modelTrigger"].filter((k) => m[k] === null);
+  if (missing.length > 0) {
+    return {
+      pass: false,
+      reason: `the harness is missing ${missing.join(", ")} - nothing else can be measured without them`,
+    };
+  }
+
+  if (m.controls.position === "fixed") {
+    failures.push(
+      `the control row is position: fixed (${describe(m.controls)}) - it is a viewport band, not the card's own row`,
+    );
+  }
+  for (const [name, box] of [
+    ["the control row", m.controls],
+    ["the attach button", m.attach],
+    ["the model trigger", m.modelTrigger],
+    ["the Start button", m.start],
+  ]) {
+    if (escapes(box, m.card)) {
+      failures.push(`${name} (${describe(box)}) is outside the prompt card (${describe(m.card)})`);
+    }
+  }
+  if (m.modelGateDisplay === "none" || m.modelTrigger.width <= 1 || m.modelTrigger.height <= 1) {
+    failures.push(
+      `the model trigger is not on screen at ${m.viewport.width}px (display: ${m.modelGateDisplay}, box ${describe(m.modelTrigger)}) - the card is where a phone sets the model`,
+    );
+  }
+  if (m.attach.top < m.field.bottom - TOLERANCE) {
+    failures.push(
+      `the attach button (${describe(m.attach)}) overlaps the writing surface (${describe(m.field)}) instead of sitting in the row beneath it`,
+    );
+  }
+
+  if (failures.length > 0) return { pass: false, reason: failures.join("; ") };
+  return {
+    pass: true,
+    reason: `at ${m.viewport.width}x${m.viewport.height} the control row is ${m.controls.position}, and attach (${describe(m.attach)}), the model trigger (${describe(m.modelTrigger)}) and Start (${describe(m.start)}) all sit inside the card (${describe(m.card)}) below the field`,
+  };
+}

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/spawn-attach-in-card/case.json
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/spawn-attach-in-card/case.json
@@ -1,0 +1,25 @@
+{
+  "name": "spawn-attach-in-card",
+  "description": "spawn's prompt card keeps its whole control row - attach, the model trigger, and Start - inside the card at phone width, exactly where the session composer keeps them (issue #198)",
+  "cssFiles": [
+    "styles/tokens.css",
+    "styles/global.css",
+    "widgets/promptcard/promptcard.module.css",
+    "widgets/textarea/textarea.module.css",
+    "widgets/button/button.module.css",
+    "widgets/tooltip/tooltip.module.css",
+    "panes/session/chrome/modelswitch.module.css",
+    "panes/spawn/spawn.module.css"
+  ],
+  "viewport": {
+    "width": 390,
+    "height": 844,
+    "deviceScaleFactor": 2,
+    "mobile": true
+  },
+  "mutation": {
+    "declaration": "spawn.module.css: the @media (max-width: 899px) .actionBand block (position: fixed; bottom: 0; min-height: 76px) restored, with the control row spelled class=\"controls actionBand\" and the attach button as its direct child - i.e. exactly what Spawn.tsx's controlsClassName={CLASS.actionBand} produced before this case existed",
+    "verified": "2026-08-19",
+    "expect": "fail"
+  }
+}

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/spawn-attach-in-card/harness.html
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/spawn-attach-in-card/harness.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=390, initial-scale=1">
+<title>spawn attach-in-card layoutguard harness</title>
+<link rel="stylesheet" href="tokens.css">
+<link rel="stylesheet" href="resolved.css">
+<style>
+  * { transition: none !important; animation: none !important; }
+  /* PaneScaffold's content slot around the form. Only the inset matters here:
+     it is what makes "inside the card" a claim about the card rather than
+     about the viewport edge. */
+  body { margin: 0; padding: var(--space-3); }
+
+  /* IconButton renders button.module.css's base + variant classes plus
+     iconbutton.module.css's OWN .xs square, and BOTH files define `.xs`. CSS
+     Modules keeps those distinct in production; a raw-stylesheet harness
+     cannot, so iconbutton's rule is spelled here under a name of its own
+     (the same dodge compact-session-footer's .attachmentControl documents),
+     phone tap floor included - that floor is what now carries the touch
+     target the deleted action band used to hard-code. */
+  .attachmentControl { width: 24px; height: 24px; padding: 0; }
+  @media (max-width: 899px) {
+    .attachmentControl { min-width: var(--tap-min); min-height: var(--tap-min); }
+  }
+
+  /* Same collision, other direction: widgets/popover and modelswitch both own
+     a local `.trigger`. popover.module.css's whole rule is one declaration
+     (`display: inline-flex`, popover.module.css:6-8), so the wrapper span it
+     renders around the trigger carries it here under its own name and
+     popover.module.css stays out of cssFiles. */
+  .popoverTrigger { display: inline-flex; }
+</style>
+</head>
+<body>
+<!-- panes/spawn/Spawn.tsx's prompt card, verbatim against the real class
+     names: PromptCard's .card wrapping a seamless autoGrow Textarea over its
+     .controls row, with the attach IconButton and the ModelSwitchTrigger in
+     the leading slot and the Start Button in .actions.
+
+     The textarea carries the --textarea-min-lines: 6 inline custom property
+     the widget sets from minLines={6}, because that floor is the card's
+     height at rest here: nothing in this harness runs autoGrow's measuring
+     effect, and a card sized by an unmeasured field would be a card the
+     product never renders. -->
+<div class="form">
+  <div class="card" data-card>
+    <textarea class="textarea seamless" data-field aria-label="Prompt" style="--textarea-min-lines: 6" placeholder="What should the agent work on? Leave blank to start it dormant."></textarea>
+    <div class="controls" data-controls>
+      <div class="leading">
+        <button class="button quiet xs attachmentControl" data-attach type="button" aria-label="Attach image"><span class="icon">+</span></button>
+        <span class="modelTrigger" data-model-gate><span class="popoverTrigger"><button class="trigger" data-model-trigger type="button" title="(default)"><span class="value">(default)</span><span class="chevron">v</span> <span class="srOnly">&mdash; change model</span></button></span></span>
+      </div>
+      <div class="actions">
+        <span class="wrapper"><button class="button primary xs" data-start type="button" aria-label="Start"><span class="icon">&gt;</span><span class="submitLabel">Start</span></button></span>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+window.measure = () => {
+  const box = (selector) => {
+    const el = document.querySelector(selector);
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    return { left: r.left, top: r.top, right: r.right, bottom: r.bottom, width: r.width, height: r.height };
+  };
+  const controls = document.querySelector("[data-controls]");
+  const gate = document.querySelector("[data-model-gate]");
+  return {
+    viewport: { width: window.innerWidth, height: window.innerHeight },
+    card: box("[data-card]"),
+    field: box("[data-field]"),
+    controls: controls === null ? null : { ...box("[data-controls]"), position: getComputedStyle(controls).position },
+    attach: box("[data-attach]"),
+    start: box("[data-start]"),
+    modelTrigger: box("[data-model-trigger]"),
+    // Read from the gating wrapper, not the button: it is the wrapper that
+    // spawn.module.css switches on at the breakpoint, and a button under a
+    // display:none ancestor keeps its own computed display while its box
+    // collapses (kata bsq9).
+    modelGateDisplay: gate === null ? "missing" : getComputedStyle(gate).display,
+  };
+};
+</script>
+</body>
+</html>

--- a/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
@@ -17,6 +17,25 @@ const WIDTHS = [390, 899, 900];
 // measured at the widest the product allows it to get.
 const STAGED_ATTACHMENTS = 8;
 const TILE_PX = 80;
+// tokens.css's --tap-min, the platform touch floor the widgets' own phone
+// blocks apply (2026-07-30-mobile-session-layout-design.md, decision 4).
+const TAP_MIN_PX = 44;
+
+// Sub-pixel layout rounding, not a fudge factor - the same 1px slack every
+// other geometric comparison in this file already allows.
+function contains(parent, child) {
+  return (
+    child.left >= parent.left - 1 &&
+    child.top >= parent.top - 1 &&
+    child.right <= parent.right + 1 &&
+    child.bottom <= parent.bottom + 1
+  );
+}
+
+function describeBox(box) {
+  if (box === null) return "missing";
+  return `${box.left.toFixed(1)},${box.top.toFixed(1)} ${box.width.toFixed(1)}x${box.height.toFixed(1)}`;
+}
 
 async function measureAt(cdpPort, vitePort, width) {
   const page = await connectPage(cdpPort);
@@ -78,16 +97,76 @@ function assertResult(result, expectedWidth) {
   if (visible(result.mobileIntro) !== mobile)
     failures.push(`prompt orientation visibility is wrong at ${expectedWidth}px`);
 
+  // Issue #198: the prompt card is the composer, so its control row holds the
+  // composer's controls in the composer's place - at EVERY width, which is why
+  // this block is outside the mobile branch. The pane used to pass PromptCard a
+  // class that spawn.module.css turned into `position: fixed; bottom: 0` inside
+  // its 899px block: the row left the card and became a page-level band with the
+  // attach button stranded at the foot of the screen, nowhere near the prompt.
+  const card = result.promptCard;
+  if (card.card === null || card.controls === null) {
+    failures.push(`the prompt card or its control row is missing: ${JSON.stringify(card)}`);
+  } else {
+    if (card.controls.position === "fixed") {
+      failures.push(`the control row is position: fixed at ${expectedWidth}px - a viewport band, not the card's row`);
+    }
+    for (const [name, box] of [
+      ["control row", card.controls],
+      ["attach button", card.attach],
+      ["Start button", card.submit],
+    ]) {
+      if (box === null) {
+        failures.push(`the ${name} is not in the measured tree`);
+      } else if (!contains(card.card, box)) {
+        failures.push(`the ${name} (${describeBox(box)}) is outside the prompt card (${describeBox(card.card)})`);
+      }
+    }
+    // The attach button belongs in the row BENEATH the writing surface, not
+    // overlaid on its corner where typed text runs under it - the placement
+    // PR #242 tried and this pane rejected.
+    if (card.attach !== null && card.field !== null && card.attach.top < card.field.bottom - 1) {
+      failures.push(
+        `the attach button (${describeBox(card.attach)}) overlaps the prompt field (${describeBox(card.field)})`,
+      );
+    }
+    // The card's model trigger is the PHONE's Model field: desktop sets the
+    // model in the configuration row below, so an in-card trigger there would
+    // be a second control for one setting.
+    if (visible(card.modelSlot) !== mobile) {
+      failures.push(`the card's model trigger visibility is wrong at ${expectedWidth}px`);
+    }
+    if (mobile) {
+      if (card.modelTrigger === null) {
+        failures.push("the card's model trigger is not in the measured tree at a mobile width");
+      } else if (!contains(card.card, card.modelTrigger)) {
+        failures.push(
+          `the card's model trigger (${describeBox(card.modelTrigger)}) is outside the prompt card (${describeBox(card.card)})`,
+        );
+      }
+    }
+  }
+
   if (mobile) {
-    const action = result.actionBand;
-    if (action.position !== "fixed") failures.push(`action band position is ${action.position}, expected fixed`);
-    if (Math.abs(action.left) > 1 || Math.abs(action.bottom) > 1 || Math.abs(action.right - expectedWidth) > 1) {
-      failures.push(`action band is not viewport-pinned: ${JSON.stringify(action)}`);
+    // The tap floor the deleted action band used to hard-code now comes from
+    // the widgets' own phone blocks (button.module.css / iconbutton.module.css,
+    // both keyed to --tap-min). Measured, not assumed: that is the whole reason
+    // deleting the band was safe.
+    for (const [name, box] of [
+      ["attach button", card.attach],
+      ["Start button", card.submit],
+    ]) {
+      if (box !== null && box.height < TAP_MIN_PX - 0.5) {
+        failures.push(`the ${name} is ${box.height}px tall, below the ${TAP_MIN_PX}px touch floor`);
+      }
     }
-    if (action.width < expectedWidth - 1 || Number.parseFloat(action.minHeight) < 76 || action.height < 76) {
-      failures.push(`action band geometry is too small: ${JSON.stringify(action)}`);
+    if (card.attach !== null && card.attach.width < TAP_MIN_PX - 0.5) {
+      failures.push(`the attach button is ${card.attach.width}px wide, below the ${TAP_MIN_PX}px touch floor`);
     }
-    if (result.rows.length !== 6) failures.push(`expected 6 mobile setting rows, found ${result.rows.length}`);
+    // Model left this list for the card (issue #198), so five rows, not six.
+    if (result.rows.length !== 5) failures.push(`expected 5 mobile setting rows, found ${result.rows.length}`);
+    if (result.rows.some((row) => row.label === "Model")) {
+      failures.push("the mobile setting rows still carry a Model row - the prompt card owns that setting now");
+    }
     for (const row of result.rows) {
       if (row.minHeight !== "48px" || row.height < 48)
         failures.push(`row ${row.label} is below 48px: ${JSON.stringify(row)}`);
@@ -105,8 +184,6 @@ function assertResult(result, expectedWidth) {
     ) {
       failures.push(`prompt orientation is not persistently accessible: ${JSON.stringify(prompt)}`);
     }
-  } else {
-    if (result.actionBand.position === "fixed") failures.push("desktop action band unexpectedly remains fixed");
   }
 
   // Staged attachments (kata 289v). The harness stages them through the
@@ -201,7 +278,7 @@ async function main() {
       const failures = assertResult(result, width);
       if (failures.length === 0) {
         console.log(
-          `${width}px ... PASS - Spawn breakpoint, action band, rows, accessibility, ${STAGED_ATTACHMENTS} staged attachment tiles, and overflow`,
+          `${width}px ... PASS - Spawn breakpoint, in-card control row, rows, accessibility, ${STAGED_ATTACHMENTS} staged attachment tiles, and overflow`,
         );
       } else {
         failed++;

--- a/cmd/evener-hub/frontend/src/dev/spawnguard-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/spawnguard-entry.tsx
@@ -3,8 +3,8 @@
 // This deliberately renders Spawn with the production widgets, CSS modules,
 // and client boundary. The scripted client keeps the page deterministic while
 // leaving the browser to answer the questions jsdom cannot: which branch of
-// the breakpoint won, where the fixed action band landed, and whether any
-// rendered box escaped the viewport.
+// the breakpoint won, where the prompt card's control row and everything in it
+// actually landed, and whether any rendered box escaped the viewport.
 import { createRoot } from "react-dom/client";
 import Spawn from "../panes/spawn/Spawn";
 import { FakeClient } from "../protocol/testing/fakeClient";
@@ -203,10 +203,36 @@ function measureAttachments() {
   };
 }
 
+// The prompt card and everything in its control row. Issue #198: attach, the
+// model trigger and Start belong INSIDE the card at every width, the way the
+// session composer has always had them - this pane used to hand the row a
+// class that turned it into a `position: fixed` viewport band on a phone, so
+// the paperclip sat at the foot of the screen instead of under the prompt.
+// Every reading here is a box the guard compares against the card's own.
+function measurePromptCard() {
+  const card = document.querySelector<HTMLElement>('[data-testid="spawn-prompt-card"]');
+  const controls = document.querySelector<HTMLElement>('[data-testid="spawn-controls"]');
+  const field = document.querySelector<HTMLElement>('[data-testid="spawn-prompt-card"] textarea');
+  const attach = document.querySelector<HTMLElement>('[data-testid="spawn-attach"]');
+  const submit = document.querySelector<HTMLElement>('[data-testid="spawn-submit"]');
+  const modelTrigger = document.querySelector<HTMLElement>('[data-testid="spawn-model-trigger"]');
+  const modelSlot = document.querySelector<HTMLElement>('[data-testid="spawn-model-slot"]');
+  return {
+    card: card ? boxOf(card) : null,
+    controls: controls ? { ...boxOf(controls), position: getComputedStyle(controls).position } : null,
+    field: field ? boxOf(field) : null,
+    attach: attach ? boxOf(attach) : null,
+    submit: submit ? boxOf(submit) : null,
+    modelTrigger: modelTrigger ? boxOf(modelTrigger) : null,
+    // The breakpoint switches the SLOT, and a button under a display:none
+    // ancestor keeps its own computed display while only its box collapses
+    // (kata bsq9) - so the verdict is read from the slot, by the same shared
+    // predicate every other reading here uses.
+    modelSlot: readVisibility(modelSlot, "spawn model slot"),
+  };
+}
+
 function measureSpawn() {
-  const actionBand = document.querySelector<HTMLElement>('[data-testid="spawn-mobile-actions"]');
-  const actionBox = actionBand?.getBoundingClientRect();
-  const actionStyle = actionBand ? getComputedStyle(actionBand) : null;
   const mobileConfigElement = document.querySelector<HTMLElement>('[data-testid="spawn-mobile-config"]');
   const desktopConfigElement = mobileConfigElement?.previousElementSibling as HTMLElement | null;
   const rows = Array.from(document.querySelectorAll<HTMLElement>('[data-testid="mobile-spawn-row"]')).map((row) => {
@@ -231,15 +257,7 @@ function measureSpawn() {
     mobileIntro: visibility('[data-testid="spawn-mobile-prompt-intro"]'),
     desktopTitle: visibility('[data-testid="pane-title-desktop"]'),
     mobileTitle: visibility('[data-testid="pane-title-mobile"]'),
-    actionBand: {
-      position: actionStyle?.position ?? "missing",
-      left: actionBox?.left ?? null,
-      right: actionBox?.right ?? null,
-      bottom: actionBox ? window.innerHeight - actionBox.bottom : null,
-      width: actionBox?.width ?? null,
-      minHeight: actionStyle?.minHeight ?? "",
-      height: actionBox?.height ?? null,
-    },
+    promptCard: measurePromptCard(),
     rows,
     attachments: measureAttachments(),
     accessiblePrompt: {

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ModelSwitch.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ModelSwitch.tsx
@@ -1,19 +1,16 @@
-// ModelSwitch: the mid-session model-switch trigger. The current model label
-// IS the trigger (quiet hover affordance + a small chevron) - clicking it
-// opens the SAME rich catalog picker the spawn flow uses (ModelCatalogPanel:
-// search over one always-expanded grouped list, capability/cost/context
-// metadata, Recent, provider diagnostics in place), in the SAME shared
-// floating Popover (widgets/popover, closeOnScroll={false}) - so opening it
-// never shifts the status row's layout and a scroll never dismisses it.
+// ModelSwitch: the mid-session model switch. The control itself - the label as
+// the trigger, the shared catalog picker in a floating popover - is
+// ModelSwitchTrigger, which the spawn pane renders too (issue #198); this binds
+// it to a thread: which model is current, whether the wire allows a switch, and
+// what a pick DOES.
 //
-// The launchable SET still comes from threadsStore.listModels() (session-
-// lifetime cached in the store, da1b43f85's own doc comment - a repeat call
-// after the first is effectively free) since that's what's actually valid to
-// switch THIS session to; mergeScopedCatalog enriches those bare provider/
-// model pairs with the unscoped /api/models catalog's metadata, exactly the
-// way ModelField.tsx's settings (unscoped) call site already does - so this
-// reuses both the rendering AND the enrichment plumbing rather than
-// duplicating either.
+// The launchable SET comes from threadsStore.listModels() (session-lifetime
+// cached in the store, da1b43f85's own doc comment - a repeat call after the
+// first is effectively free) since that's what's actually valid to switch THIS
+// session to; mergeScopedCatalog enriches those bare provider/model pairs with
+// the unscoped /api/models catalog's metadata, exactly the way ModelField.tsx's
+// settings (unscoped) call site already does - so this reuses both the
+// rendering AND the enrichment plumbing rather than duplicating either.
 //
 // reasoningEffortLevels/supportsReasoning need no special handling here:
 // StatusRow already re-renders from the live ThreadModel on every store
@@ -21,22 +18,14 @@
 // case, which updates the reasoning ladder alongside modelProvider/model),
 // the existing ReasoningEffortControl picks up the new model's profile
 // for free.
-import { useRef, useState } from "react";
-import { friendlyLaunchErrorMessage, sessionActionError, sessionActionHeadline } from "../../../protocol/errors";
+import { useCallback } from "react";
+import { sessionActionError } from "../../../protocol/errors";
 import type { ThreadModel } from "../../../protocol/model";
 import { threadsStore } from "../../../stores/threads";
-import {
-  Chevron,
-  type ModelCatalog,
-  type ModelCatalogEntry,
-  ModelCatalogPanel,
-  Popover,
-  useToasts,
-} from "../../../widgets";
-import { requireClass } from "../../../widgets/internal/requireClass";
+import { type ModelCatalog, type ModelCatalogEntry, useToasts } from "../../../widgets";
 import { fetchModelCatalog } from "../../../widgets/modelCatalog/catalogClient";
 import { mergeScopedCatalog } from "../../../widgets/modelCatalog/scopedCatalog";
-import styles from "./modelswitch.module.css";
+import { ModelSwitchTrigger } from "./ModelSwitchTrigger";
 import { modelLabel } from "./statusFormat";
 
 export interface ModelSwitchProps {
@@ -44,21 +33,8 @@ export interface ModelSwitchProps {
   model: ThreadModel;
 }
 
-const CLASS = {
-  trigger: requireClass(styles.trigger, "modelswitch.module.css", "trigger"),
-  value: requireClass(styles.value, "modelswitch.module.css", "value"),
-  chevron: requireClass(styles.chevron, "modelswitch.module.css", "chevron"),
-  srOnly: requireClass(styles.srOnly, "modelswitch.module.css", "srOnly"),
-  popoverPanel: requireClass(styles.popoverPanel, "modelswitch.module.css", "popoverPanel"),
-};
-
 export function ModelSwitch({ sessionRef, model }: ModelSwitchProps) {
   const toasts = useToasts();
-  const [open, setOpen] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [catalog, setCatalog] = useState<ModelCatalog | null>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
 
   // changeModel is the ONLY gate, and it is the wire's own answer: the hub
   // advertises it for a cold exited thread as well as a live one (cmd/evener-hub/
@@ -73,47 +49,15 @@ export function ModelSwitch({ sessionRef, model }: ModelSwitchProps) {
   const disabled = !model.capabilities.changeModel;
   const currentModelLabel = modelLabel(model.modelProvider, model.model);
 
-  async function openPicker() {
-    if (disabled) return;
-    setOpen(true);
-    setError(null);
-    setLoading(true);
-    try {
-      const [scoped, enrichment] = await Promise.all([
-        threadsStore.getState().listModels(),
-        fetchModelCatalog().catch(() => null),
-      ]);
-      setCatalog(mergeScopedCatalog(scoped.data, enrichment));
-    } catch (err) {
-      // Not sessionActionError: that composes its detail from errorText,
-      // which is the RAW rejection text - fine for a WireError (the hub
-      // wrote it for a person) but not for AppwireClient's own internal
-      // "cannot call ... while state is closed" rejections, which is
-      // exactly what a mid-teardown model/list lands here. Same headline
-      // rule (sessionActionHeadline), friendlyLaunchErrorMessage detail
-      // instead - it also replaces the daemon-missing family's raw
-      // launch-check text with actionable copy (T3).
-      const headline = sessionActionHeadline("Couldn't load models", err);
-      setError(`${headline}: ${friendlyLaunchErrorMessage(err)}`);
-    } finally {
-      setLoading(false);
-    }
-  }
+  const loadCatalog = useCallback(async (): Promise<ModelCatalog> => {
+    const [scoped, enrichment] = await Promise.all([
+      threadsStore.getState().listModels(),
+      fetchModelCatalog().catch(() => null),
+    ]);
+    return mergeScopedCatalog(scoped.data, enrichment);
+  }, []);
 
-  // Popover's FocusScope is opted out of focus management (autoFocus={false})
-  // so the panel's input can own focus and its selection - which makes
-  // restoring focus to the trigger on close this component's job.
-  function closePicker() {
-    setOpen(false);
-    triggerRef.current?.focus();
-  }
-
-  async function handlePick(entry: ModelCatalogEntry) {
-    // Optimistic close (no rollback on failure) - matches the legacy
-    // picker's own convention (parity-m5-composer.md §H): "Selecting a
-    // model closes the picker immediately... a rejection surfaces as a
-    // toast, with no rollback of the (already-closed) picker."
-    setOpen(false);
+  async function handlePick(entry: ModelCatalogEntry): Promise<void> {
     try {
       await threadsStore.getState().setModel(sessionRef, entry.provider, entry.model);
     } catch (err) {
@@ -122,55 +66,14 @@ export function ModelSwitch({ sessionRef, model }: ModelSwitchProps) {
   }
 
   return (
-    <Popover
-      open={open}
-      onClose={closePicker}
-      // The picker's own list scrolls, and the transcript behind it scrolls
-      // too: neither may dismiss a picker mid-interaction.
-      closeOnScroll={false}
-      // The panel's input owns focus and its own text selection - see
-      // closePicker for why FocusScope must not manage focus here.
-      autoFocus={false}
-      trigger={
-        <button
-          ref={triggerRef}
-          type="button"
-          className={CLASS.trigger}
-          data-testid="model-switch-trigger"
-          title={currentModelLabel}
-          onClick={() => (open ? closePicker() : void openPicker())}
-          disabled={disabled}
-        >
-          {/* Plain text, not a Chip: the trigger already draws the control's
-              own hover box, and a bordered chip inside it reads as a double
-              border - the same rule widgets/pathfield's and
-              widgets/modelCatalog's triggers follow. */}
-          <span className={CLASS.value} data-testid="model-switch-value">
-            {currentModelLabel}
-          </span>
-          <span className={CLASS.chevron} aria-hidden="true">
-            <Chevron direction="down" />
-          </span>{" "}
-          {/* That separating space is load-bearing: the accessible name is this
-              button's children concatenated, and each child's own text is
-              trimmed first, so a space INSIDE either span would be dropped and
-              the name would run together as "…sonnet-4-5— change model". A
-              whitespace-only text node between them survives that trim and
-              renders nothing of its own (an all-whitespace anonymous flex item
-              is not laid out). */}
-          <span className={CLASS.srOnly}>— change model</span>
-        </button>
-      }
-    >
-      <div className={CLASS.popoverPanel}>
-        <ModelCatalogPanel
-          loading={loading}
-          error={error}
-          catalog={catalog}
-          value={currentModelLabel}
-          onPick={(entry) => void handlePick(entry)}
-        />
-      </div>
-    </Popover>
+    <ModelSwitchTrigger
+      label={currentModelLabel}
+      value={currentModelLabel}
+      disabled={disabled}
+      loadCatalog={loadCatalog}
+      onPick={(entry) => void handlePick(entry)}
+      data-testid="model-switch-trigger"
+      valueTestId="model-switch-value"
+    />
   );
 }

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ModelSwitchTrigger.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ModelSwitchTrigger.test.tsx
@@ -1,0 +1,190 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, test, vi } from "vitest";
+import { WireError } from "../../../protocol/errors";
+import type { ModelCatalog } from "../../../widgets";
+import { ModelSwitchTrigger } from "./ModelSwitchTrigger";
+import rawStyles from "./modelswitch.module.css";
+
+afterEach(cleanup);
+
+function catalog(): ModelCatalog {
+  return {
+    models: [
+      { provider: "anthropic", model: "claude-sonnet-4-5", displayName: "Sonnet 4.5" },
+      { provider: "openai", model: "gpt-5.5", displayName: "GPT-5.5" },
+    ],
+    recent: [],
+  };
+}
+
+function renderTrigger(overrides: Partial<Parameters<typeof ModelSwitchTrigger>[0]> = {}) {
+  const props = {
+    label: "anthropic/claude-sonnet-4-5",
+    value: "anthropic/claude-sonnet-4-5",
+    loadCatalog: vi.fn(async () => catalog()),
+    onPick: vi.fn(),
+    "data-testid": "trigger",
+    valueTestId: "trigger-value",
+    ...overrides,
+  };
+  return { props, ...render(<ModelSwitchTrigger {...props} />) };
+}
+
+// The label the caller supplies is the whole visible text; the action rides
+// along visually-hidden so the spoken name says both. This is the contract
+// ModelSwitch's own accessible-name test depends on, now owned here.
+test("the label is the visible text and the spoken name also names the action", () => {
+  renderTrigger();
+  expect(screen.getByTestId("trigger-value").textContent).toBe("anthropic/claude-sonnet-4-5");
+  expect(screen.getByRole("button", { name: "anthropic/claude-sonnet-4-5 — change model" })).toBe(
+    screen.getByTestId("trigger"),
+  );
+});
+
+// The whitespace text node between the chevron and the screen-reader suffix is
+// load-bearing: each child's text is trimmed before the accessible name is
+// concatenated, so without it the name runs together. Asserted as the rendered
+// name rather than as markup, since the name is the thing that matters.
+test("the accessible name does not run the label into the action", () => {
+  renderTrigger({ label: "openai/gpt-5.5" });
+  expect(screen.getByTestId("trigger").textContent).not.toContain("gpt-5.5— change model");
+});
+
+test("the label carries no box of its own - plain text, not a bordered chip", () => {
+  renderTrigger();
+  const label = screen.getByTestId("trigger-value");
+  expect(label.className).toBe(rawStyles.value);
+  expect(label.querySelector("*")).toBeNull();
+});
+
+// type="button": this trigger renders inside surfaces that can sit within a
+// form (the spawn pane's advanced options reach a real one), and a default
+// submit type would make opening the picker submit it.
+test("the trigger is a non-submitting button", () => {
+  renderTrigger();
+  expect((screen.getByTestId("trigger") as HTMLButtonElement).type).toBe("button");
+});
+
+test("disabled refuses to open the picker at all", async () => {
+  const user = userEvent.setup();
+  const loadCatalog = vi.fn(async () => catalog());
+  renderTrigger({ disabled: true, loadCatalog });
+
+  expect((screen.getByTestId("trigger") as HTMLButtonElement).disabled).toBe(true);
+  await user.click(screen.getByTestId("trigger"));
+  expect(loadCatalog).not.toHaveBeenCalled();
+  expect(screen.queryByRole("combobox")).toBeNull();
+});
+
+// Value-controlled: this component reports the pick and holds no model state of
+// its own, so the caller decides what a pick MEANS (the session sends
+// thread/model/set; the spawn pane records the choice for its next launch).
+test("picking reports the entry to the caller and closes the picker without changing the label", async () => {
+  const user = userEvent.setup();
+  const onPick = vi.fn();
+  renderTrigger({ onPick });
+
+  await user.click(screen.getByTestId("trigger"));
+  const combobox = await screen.findByRole("combobox");
+  await waitFor(() => expect(screen.getAllByRole("option")).toHaveLength(2));
+  await user.clear(combobox);
+  await user.keyboard("gpt");
+  await user.click(await screen.findByRole("option", { name: /gpt-5\.5/i }));
+
+  expect(onPick).toHaveBeenCalledWith(expect.objectContaining({ provider: "openai", model: "gpt-5.5" }));
+  await waitFor(() => expect(screen.queryByRole("combobox")).toBeNull());
+  // The label is the caller's to change; this component never rewrites it.
+  expect(screen.getByTestId("trigger-value").textContent).toBe("anthropic/claude-sonnet-4-5");
+});
+
+test("the panel pre-fills and marks the caller's value, which need not be the label", async () => {
+  const user = userEvent.setup();
+  renderTrigger({ label: "(default)", value: "openai/gpt-5.5" });
+
+  await user.click(screen.getByTestId("trigger"));
+  const combobox = (await screen.findByRole("combobox")) as HTMLInputElement;
+  expect(combobox.value).toBe("openai/gpt-5.5");
+});
+
+test("opening shows a loading state until the catalog resolves", async () => {
+  const user = userEvent.setup();
+  const box: { resolve: ((c: ModelCatalog) => void) | null } = { resolve: null };
+  renderTrigger({ loadCatalog: vi.fn(() => new Promise<ModelCatalog>((resolve) => (box.resolve = resolve))) });
+
+  await user.click(screen.getByTestId("trigger"));
+  expect(screen.getByRole("status", { name: "Loading" })).toBeTruthy();
+  box.resolve?.(catalog());
+  await waitFor(() => expect(screen.getByRole("combobox")).toBeTruthy());
+});
+
+// A plain Error's own message is internal detail, so the framing replaces it
+// with a generic sentence rather than leaking the raw text - the same framing
+// (sessionActionHeadline + friendlyLaunchErrorMessage) the session's model
+// switch has always used, now owned here for both callers.
+test("a failed catalog load surfaces a friendly message inline, keeping the field and the trigger", async () => {
+  const user = userEvent.setup();
+  renderTrigger({
+    loadCatalog: vi.fn(async () => {
+      throw new Error("catalog boom");
+    }),
+  });
+
+  await user.click(screen.getByTestId("trigger"));
+
+  const alert = await screen.findByRole("alert");
+  expect(alert.textContent).toBe("Couldn't load models: Something went wrong.");
+  expect(alert.textContent).not.toMatch(/catalog boom/i);
+  expect(screen.queryByRole("listbox")).toBeNull();
+  expect(screen.getByRole("combobox")).toBeTruthy();
+  expect(screen.getByTestId("trigger")).toBeTruthy();
+});
+
+// T3, the first-run worst moment: the hub answered but no agent daemon could be
+// reached, so the headline names the session start and the detail is actionable
+// copy rather than the launch-check's own raw text.
+test("a daemon-missing load shows actionable copy under the session-start headline", async () => {
+  const user = userEvent.setup();
+  renderTrigger({
+    loadCatalog: vi.fn(async () => {
+      throw new WireError("evener launch-check timed out", -32014, { evenerErrorInfo: "hubLaunch" });
+    }),
+  });
+
+  await user.click(screen.getByTestId("trigger"));
+
+  const alert = await screen.findByRole("alert");
+  expect(alert.textContent).toBe(
+    "Couldn't start this session: No agent daemon responded for this project. Start one by running evener in the repo, then retry.",
+  );
+  expect(alert.textContent).not.toMatch(/launch-check timed out/i);
+});
+
+// Popover runs with autoFocus={false} so the panel's input owns focus, which
+// makes restoring focus to the trigger on close this component's job.
+test("Escape closes the picker and returns focus to the trigger", async () => {
+  const user = userEvent.setup();
+  renderTrigger();
+
+  const trigger = screen.getByTestId("trigger");
+  await user.click(trigger);
+  await screen.findByRole("combobox");
+  await user.keyboard("{Escape}");
+
+  await waitFor(() => expect(screen.queryByRole("combobox")).toBeNull());
+  expect(document.activeElement).toBe(trigger);
+});
+
+// The picker's own list scrolls and whatever is behind it scrolls too: neither
+// may dismiss it mid-interaction (closeOnScroll={false}).
+test("a scroll does not close the open picker", async () => {
+  const user = userEvent.setup();
+  renderTrigger();
+
+  await user.click(screen.getByTestId("trigger"));
+  await screen.findByRole("combobox");
+  await waitFor(() => expect(screen.getAllByRole("option")).toHaveLength(2));
+  window.dispatchEvent(new Event("scroll"));
+
+  expect(screen.getByRole("combobox")).toBeTruthy();
+});

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ModelSwitchTrigger.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ModelSwitchTrigger.tsx
@@ -1,0 +1,155 @@
+// ModelSwitchTrigger: the app's one "the model label IS the button" control.
+// A quiet trigger carrying the current model plus a small chevron, opening the
+// SAME rich catalog picker every other model surface uses (ModelCatalogPanel:
+// search over one always-expanded grouped list, capability/cost/context
+// metadata, Recent, provider diagnostics in place) in the SAME shared floating
+// Popover (widgets/popover, closeOnScroll={false}) - so opening it never
+// shifts the row it sits in and a scroll never dismisses it.
+//
+// Value-controlled and presentational. It owns only the picker's transient
+// state (open/loading/error/catalog) and nothing about WHOSE model it is: the
+// caller supplies the label, the current qualified value, a loader, and what a
+// pick means. The session's mid-turn switch (ModelSwitch) sends
+// thread/model/set; the spawn pane records the choice for its next launch
+// (panes/spawn/Spawn.tsx). Both get the identical affordance because it is the
+// identical component, which is the whole point of issue #198.
+import { useRef, useState } from "react";
+import { friendlyLaunchErrorMessage, sessionActionHeadline } from "../../../protocol/errors";
+import { Chevron, type ModelCatalog, type ModelCatalogEntry, ModelCatalogPanel, Popover } from "../../../widgets";
+import { requireClass } from "../../../widgets/internal/requireClass";
+import styles from "./modelswitch.module.css";
+
+export interface ModelSwitchTriggerProps {
+  /** The trigger's visible text. Usually the current qualified model id, but a
+   * caller with no model chosen yet shows its own empty-value word instead
+   * ("(default)", or a required-choice label) - which is why this is separate
+   * from `value`. */
+  label: string;
+  /** The current qualified "provider/model" (or "" for none), passed straight
+   * to the panel: it pre-fills the search field, marks the current row, and
+   * scrolls it into view. */
+  value: string;
+  /** Loads the catalog on open. Rejections are framed and shown inside the
+   * open panel rather than thrown away or toasted. */
+  loadCatalog: () => Promise<ModelCatalog>;
+  /** Reports the chosen entry. The picker closes optimistically first, so a
+   * caller whose own write fails surfaces that its own way (parity-m5-composer
+   * §H: no rollback of an already-closed picker). */
+  onPick: (entry: ModelCatalogEntry) => void;
+  disabled?: boolean;
+  "data-testid"?: string;
+  /** Hook for the visible label span, so a test can read the value without the
+   * screen-reader suffix riding along in the button's own textContent. */
+  valueTestId?: string;
+}
+
+const CLASS = {
+  trigger: requireClass(styles.trigger, "modelswitch.module.css", "trigger"),
+  value: requireClass(styles.value, "modelswitch.module.css", "value"),
+  chevron: requireClass(styles.chevron, "modelswitch.module.css", "chevron"),
+  srOnly: requireClass(styles.srOnly, "modelswitch.module.css", "srOnly"),
+  popoverPanel: requireClass(styles.popoverPanel, "modelswitch.module.css", "popoverPanel"),
+};
+
+export function ModelSwitchTrigger({
+  label,
+  value,
+  loadCatalog,
+  onPick,
+  disabled = false,
+  "data-testid": testId,
+  valueTestId,
+}: ModelSwitchTriggerProps) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [catalog, setCatalog] = useState<ModelCatalog | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  async function openPicker(): Promise<void> {
+    if (disabled) return;
+    setOpen(true);
+    setError(null);
+    setLoading(true);
+    try {
+      setCatalog(await loadCatalog());
+    } catch (err) {
+      // Not sessionActionError: that composes its detail from errorText, which
+      // is the RAW rejection text - fine for a WireError (the hub wrote it for
+      // a person) but not for AppwireClient's own internal "cannot call ...
+      // while state is closed" rejections, which is exactly what a
+      // mid-teardown model/list lands here. Same headline rule
+      // (sessionActionHeadline), friendlyLaunchErrorMessage detail instead -
+      // it also replaces the daemon-missing family's raw launch-check text
+      // with actionable copy (T3).
+      const headline = sessionActionHeadline("Couldn't load models", err);
+      setError(`${headline}: ${friendlyLaunchErrorMessage(err)}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // Popover's FocusScope is opted out of focus management (autoFocus={false})
+  // so the panel's input can own focus and its selection - which makes
+  // restoring focus to the trigger on close this component's job.
+  function closePicker(): void {
+    setOpen(false);
+    triggerRef.current?.focus();
+  }
+
+  function handlePick(entry: ModelCatalogEntry): void {
+    // Optimistic close (no rollback on failure) - matches the legacy picker's
+    // own convention (parity-m5-composer.md §H): "Selecting a model closes the
+    // picker immediately... a rejection surfaces as a toast, with no rollback
+    // of the (already-closed) picker."
+    setOpen(false);
+    onPick(entry);
+  }
+
+  return (
+    <Popover
+      open={open}
+      onClose={closePicker}
+      // The picker's own list scrolls, and whatever sits behind it scrolls
+      // too: neither may dismiss a picker mid-interaction.
+      closeOnScroll={false}
+      // The panel's input owns focus and its own text selection - see
+      // closePicker for why FocusScope must not manage focus here.
+      autoFocus={false}
+      trigger={
+        <button
+          ref={triggerRef}
+          type="button"
+          className={CLASS.trigger}
+          data-testid={testId}
+          title={label}
+          onClick={() => (open ? closePicker() : void openPicker())}
+          disabled={disabled}
+        >
+          {/* Plain text, not a Chip: the trigger already draws the control's
+              own hover box, and a bordered chip inside it reads as a double
+              border - the same rule widgets/pathfield's and
+              widgets/modelCatalog's triggers follow. */}
+          <span className={CLASS.value} data-testid={valueTestId}>
+            {label}
+          </span>
+          <span className={CLASS.chevron} aria-hidden="true">
+            <Chevron direction="down" />
+          </span>{" "}
+          {/* That separating space is load-bearing: the accessible name is this
+              button's children concatenated, and each child's own text is
+              trimmed first, so a space INSIDE either span would be dropped and
+              the name would run together as "…sonnet-4-5— change model". A
+              whitespace-only text node between them survives that trim and
+              renders nothing of its own (an all-whitespace anonymous flex item
+              is not laid out). */}
+          <span className={CLASS.srOnly}>— change model</span>
+        </button>
+      }
+    >
+      <div className={CLASS.popoverPanel}>
+        <ModelCatalogPanel loading={loading} error={error} catalog={catalog} value={value} onPick={handlePick} />
+      </div>
+    </Popover>
+  );
+}

--- a/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.module.css
+++ b/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.module.css
@@ -105,10 +105,6 @@
   font-size: var(--font-size-caption);
 }
 
-.modelPanel {
-  margin-top: var(--space-2);
-}
-
 @media (max-width: 899px) {
   .config {
     display: block;

--- a/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.test.tsx
@@ -1,26 +1,13 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, expect, test, vi } from "vitest";
-import type { ModelCatalog } from "../../widgets";
 import { MobileSettingRows, type MobileSettingRowsProps } from "./MobileSettingRows";
 import { GLOBAL_LAST_WORKING_DIR_KEY, setGlobalLastWorkingDir } from "./spawnDefaults";
 
 afterEach(cleanup);
-
-const catalog: ModelCatalog = {
-  models: [
-    {
-      provider: "anthropic",
-      model: "claude-sonnet-4-5",
-      displayName: "Fast model",
-      supportsTools: true,
-    },
-  ],
-  recent: [],
-};
 
 function props(overrides: Partial<MobileSettingRowsProps> = {}): MobileSettingRowsProps {
   return {
@@ -30,11 +17,6 @@ function props(overrides: Partial<MobileSettingRowsProps> = {}): MobileSettingRo
       { value: "codex-cli", label: "codex-cli" },
     ],
     onHarnessChange: vi.fn(),
-    model: "",
-    modelDisplay: "(default)",
-    modelRequired: false,
-    loadCatalog: vi.fn(async () => catalog),
-    onModelChange: vi.fn(),
     cwd: "/tmp/project",
     onCwdChange: vi.fn(),
     complete: vi.fn(async () => []),
@@ -69,14 +51,31 @@ test("renders all Treatment A rows in order with full-row controls", () => {
   const rows = within(screen.getByTestId("mobile-spawn-config")).getAllByTestId("mobile-spawn-row");
   expect(rows.map((row) => row.getAttribute("data-label"))).toEqual([
     "Harness",
-    "Model",
     "Working directory",
     "Branch",
     "Reasoning effort",
     "Access mode",
   ]);
   expect(within(rows[0]!).getByRole("button", { name: /harness/i })).toBeTruthy();
-  expect(within(rows[3]!).queryByRole("button")).toBeNull();
+  // Branch is a read-only readout, not a picker.
+  expect(within(rows[2]!).queryByRole("button")).toBeNull();
+});
+
+// Issue #198: choosing a model is one act, so it uses one control everywhere -
+// the prompt card's ModelSwitchTrigger, the same one the session composer
+// carries. This list renders no model row and opens no model sheet, and the
+// bespoke "Use default" row that sheet used to carry went with it ("(default)"
+// is the trigger's own resting label).
+test("no model row and no model sheet - the prompt card owns that setting now", () => {
+  renderRows();
+
+  const labels = within(screen.getByTestId("mobile-spawn-config"))
+    .getAllByTestId("mobile-spawn-row")
+    .map((row) => row.getAttribute("data-label"));
+  expect(labels).not.toContain("Model");
+  expect(screen.queryByRole("button", { name: /^Model:/ })).toBeNull();
+  expect(screen.queryByRole("dialog", { name: "Choose model" })).toBeNull();
+  expect(screen.queryByText("Use default")).toBeNull();
 });
 
 test("option sheets commit a selection and return focus to the row", async () => {
@@ -93,20 +92,6 @@ test("option sheets commit a selection and return focus to the row", async () =>
   expect(onHarnessChange).toHaveBeenCalledWith("codex-cli");
   expect(screen.queryByRole("dialog", { name: "Choose harness" })).toBeNull();
   expect(document.activeElement).toBe(within(row).getByRole("button"));
-});
-
-test("the model sheet uses the existing searchable catalog panel", async () => {
-  const user = userEvent.setup();
-  const onModelChange = vi.fn();
-  renderRows({ onModelChange });
-
-  await user.click(screen.getByRole("button", { name: "Model: (default)" }));
-  const dialog = await screen.findByRole("dialog", { name: "Choose model" });
-  expect(within(dialog).getByRole("combobox", { name: "Model" })).toBeTruthy();
-  await user.click(within(dialog).getByRole("option", { name: /Fast model/ }));
-
-  expect(onModelChange).toHaveBeenCalledWith("anthropic/claude-sonnet-4-5");
-  await waitFor(() => expect(screen.queryByRole("dialog", { name: "Choose model" })).toBeNull());
 });
 
 test("the working-directory sheet uses the existing path panel and closes with Escape", async () => {

--- a/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.tsx
@@ -1,6 +1,14 @@
+// The phone's configuration list for the spawn pane: one tappable row per
+// setting, each opening a bottom Sheet.
+//
+// Model is deliberately NOT here. It is set from the prompt card itself, by
+// the same ModelSwitchTrigger the session composer carries (issue #198) - so
+// the one act of choosing a model looks and behaves the same wherever it
+// happens, instead of being a bespoke sheet on this surface and a popover
+// picker on every other.
 import { useEffect, useRef, useState } from "react";
-import type { ModelCatalog, ModelCatalogEntry, PathFieldPanelProps } from "../../widgets";
-import { ModelCatalogPanel, PathFieldPanel, Sheet } from "../../widgets";
+import type { PathFieldPanelProps } from "../../widgets";
+import { PathFieldPanel, Sheet } from "../../widgets";
 import { requireClass } from "../../widgets/internal/requireClass";
 import styles from "./MobileSettingRows.module.css";
 
@@ -13,11 +21,6 @@ export interface MobileSettingRowsProps {
   harness: string;
   harnessOptions: MobilePickerOption[];
   onHarnessChange: (value: string) => void;
-  model: string;
-  modelDisplay: string;
-  modelRequired: boolean;
-  loadCatalog: () => Promise<ModelCatalog>;
-  onModelChange: (value: string) => void;
   cwd: string;
   onCwdChange: (value: string) => void;
   complete: PathFieldPanelProps["complete"];
@@ -34,7 +37,7 @@ export interface MobileSettingRowsProps {
   onAccessChange: (value: string) => void;
 }
 
-type PickerName = "Harness" | "Model" | "Working directory" | "Reasoning effort" | "Access mode";
+type PickerName = "Harness" | "Working directory" | "Reasoning effort" | "Access mode";
 
 const CLASS = {
   config: requireClass(styles.config, "MobileSettingRows.module.css", "config"),
@@ -49,7 +52,6 @@ const CLASS = {
   option: requireClass(styles.option, "MobileSettingRows.module.css", "option"),
   optionSelected: requireClass(styles.optionSelected, "MobileSettingRows.module.css", "optionSelected"),
   selection: requireClass(styles.selection, "MobileSettingRows.module.css", "selection"),
-  modelPanel: requireClass(styles.modelPanel, "MobileSettingRows.module.css", "modelPanel"),
 };
 
 interface MobileSettingRowProps {
@@ -147,11 +149,6 @@ export function MobileSettingRows({
   harness,
   harnessOptions,
   onHarnessChange,
-  model,
-  modelDisplay,
-  modelRequired,
-  loadCatalog,
-  onModelChange,
   cwd,
   onCwdChange,
   complete,
@@ -168,37 +165,12 @@ export function MobileSettingRows({
   onAccessChange,
 }: MobileSettingRowsProps) {
   const [openPicker, setOpenPicker] = useState<PickerName | null>(null);
-  const [catalog, setCatalog] = useState<ModelCatalog | null>(null);
-  const [catalogError, setCatalogError] = useState<string | null>(null);
-  const [catalogLoading, setCatalogLoading] = useState(false);
   const lastTriggerRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
     if (openPicker !== null || lastTriggerRef.current === null) return;
     lastTriggerRef.current.focus();
   }, [openPicker]);
-
-  useEffect(() => {
-    if (openPicker !== "Model") return;
-    let active = true;
-    setCatalogLoading(true);
-    setCatalogError(null);
-    loadCatalog().then(
-      (next) => {
-        if (!active) return;
-        setCatalog(next);
-        setCatalogLoading(false);
-      },
-      (error: unknown) => {
-        if (!active) return;
-        setCatalogError(error instanceof Error ? error.message : String(error));
-        setCatalogLoading(false);
-      },
-    );
-    return () => {
-      active = false;
-    };
-  }, [loadCatalog, openPicker]);
 
   function closePicker(committedCwd = cwd): void {
     if (openPicker === "Working directory") onCwdPanelClose(committedCwd);
@@ -209,11 +181,6 @@ export function MobileSettingRows({
     const active = document.activeElement;
     if (active instanceof HTMLButtonElement) lastTriggerRef.current = active;
     setOpenPicker(name);
-  }
-
-  function changeModel(entry: ModelCatalogEntry): void {
-    onModelChange(`${entry.provider}/${entry.model}`);
-    setOpenPicker(null);
   }
 
   const harnessLabel = harnessOptions.find((option) => option.value === harness)?.label ?? harness;
@@ -228,12 +195,6 @@ export function MobileSettingRows({
           value={harnessLabel}
           onClick={() => open("Harness")}
           expanded={openPicker === "Harness"}
-        />
-        <MobileSettingRow
-          label="Model"
-          value={modelDisplay}
-          onClick={() => open("Model")}
-          expanded={openPicker === "Model"}
         />
         <MobileSettingRow
           label="Working directory"
@@ -281,34 +242,6 @@ export function MobileSettingRows({
         onClose={closePicker}
         onChange={onAccessChange}
       />
-
-      <Sheet open={openPicker === "Model"} side="bottom" onClose={closePicker} title="Choose model">
-        <div className={CLASS.sheetBody}>
-          {!modelRequired && (
-            <button
-              type="button"
-              className={CLASS.option}
-              aria-pressed={model === ""}
-              onClick={() => {
-                onModelChange("");
-                closePicker();
-              }}
-            >
-              <span>Use default</span>
-              {model === "" && <span className={CLASS.selection}>Selected</span>}
-            </button>
-          )}
-          <div className={CLASS.modelPanel}>
-            <ModelCatalogPanel
-              loading={catalogLoading}
-              error={catalogError}
-              catalog={catalog}
-              value={model}
-              onPick={changeModel}
-            />
-          </div>
-        </div>
-      </Sheet>
 
       <Sheet
         open={openPicker === "Working directory"}

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -114,12 +114,20 @@ function workingDir(): HTMLElement {
   return screen.getByLabelText("Working directory");
 }
 
-// The Model field's closed trigger (ModelField -> ModelCatalog): a plain
-// button, not a labelable control (see AdvancedOptions.tsx's own note on the
-// composite-widget label pattern), so it is found by its "— change model"
-// accessible-name suffix rather than by label.
+// The DESKTOP Model field's closed trigger (ModelField -> ModelCatalog): a
+// plain button, not a labelable control (see AdvancedOptions.tsx's own note on
+// the composite-widget label pattern), so it is found by its "— change model"
+// accessible-name suffix rather than by label - scoped to its own field
+// wrapper, because the prompt card now carries a second such button (the
+// phone-only ModelSwitchTrigger) and Advanced options can carry a third.
 function modelTrigger(): HTMLElement {
-  return screen.getByRole("button", { name: /change model/i });
+  return within(screen.getByTestId("spawn-desktop-model")).getByRole("button", { name: /change model/i });
+}
+
+/** The prompt card's own model trigger - the phone's way to set the model,
+ * and the same control the session composer carries (issue #198). */
+function cardModelTrigger(): HTMLElement {
+  return screen.getByTestId("spawn-model-trigger");
 }
 
 /** The trigger's rendered path. It also carries a chevron and a screen-reader
@@ -200,16 +208,65 @@ test("the configuration row is working directory, model and effort - and nothing
   expect(screen.getByLabelText("Effort")).toBeTruthy();
 });
 
-test("mobile Spawn exposes Treatment A rows and a pinned action band without losing auto-grow", async () => {
+// Issue #198: the phone's attach button and model trigger are the composer's,
+// in the composer's place - the card's own control row - rather than a fixed
+// band at the foot of the viewport and a bespoke sheet in the settings list.
+// The row order below is the whole remaining Treatment A list: Model left it
+// when the card took the job.
+test("mobile Spawn sets attachments and the model from inside the prompt card, not from the settings rows", async () => {
   renderSpawn(readyClient());
   await settled();
 
   const mobileConfig = screen.getByTestId("spawn-mobile-config");
   expect(
     [...mobileConfig.querySelectorAll<HTMLElement>("[data-testid='mobile-spawn-row']")].map((row) => row.dataset.label),
-  ).toEqual(["Harness", "Model", "Working directory", "Branch", "Reasoning effort", "Access mode"]);
-  expect(screen.getByTestId("spawn-mobile-actions").querySelector("[data-testid='spawn-submit']")).toBeTruthy();
+  ).toEqual(["Harness", "Working directory", "Branch", "Reasoning effort", "Access mode"]);
+
+  const card = screen.getByTestId("spawn-prompt-card");
+  const controls = screen.getByTestId("spawn-controls");
+  expect(card.contains(controls)).toBe(true);
+  expect(card.contains(screen.getByTestId("spawn-attach"))).toBe(true);
+  expect(card.contains(cardModelTrigger())).toBe(true);
+  expect(controls.querySelector("[data-testid='spawn-submit']")).toBeTruthy();
   expect(screen.getByRole("textbox", { name: "Prompt" }).style.getPropertyValue("--textarea-min-lines")).toBe("6");
+});
+
+// The card's trigger is the phone's Model field, so it has to say what that
+// field says: "(default)" while the hub's own default will do, the chosen id
+// once someone picks one.
+test("the card's model trigger reads (default) until a model is picked, then names it", async () => {
+  const user = userEvent.setup();
+  renderSpawn(readyClient());
+  await settled();
+
+  expect(screen.getByTestId("spawn-model-value").textContent).toBe("(default)");
+
+  await user.click(cardModelTrigger());
+  const combo = await screen.findByRole("combobox", { name: "Model" });
+  await user.clear(combo);
+  await user.type(combo, "gpt-5");
+  await user.click(await screen.findByText("openai/gpt-5"));
+
+  await waitFor(() => expect(screen.getByTestId("spawn-model-value").textContent).toBe("openai/gpt-5"));
+  // One model, one state: the desktop field reads the pick too.
+  expect(modelTrigger().textContent).toContain("openai/gpt-5");
+});
+
+// kata xgk8: a hub with no default to fall back on must not offer "(default)"
+// anywhere, including on the card - the word reads exactly like Effort's own
+// working default and invites a submit the daemon refuses.
+test("the card's model trigger names the required choice when the hub has no default", async () => {
+  const user = userEvent.setup();
+  renderSpawn(
+    readyClient((f) => {
+      f.on("evener/launch/resolve", () => ({ effective: { model: "" }, layers: {}, provenance: {} }));
+      f.on("model/list", () => ({ data: [] }));
+    }),
+  );
+  await settled();
+  await setWorkingDir(user, "/tmp/project");
+
+  await waitFor(() => expect(screen.getByTestId("spawn-model-value").textContent).toBe("Choose a model"));
 });
 
 test("mobile Spawn keeps the approved prompt hierarchy visible while the prompt is typed", async () => {
@@ -862,15 +919,15 @@ test("kata xgk8: an Advanced-options model override satisfies the requirement wi
 
   await user.click(screen.getByRole("button", { name: "Advanced options" }));
   const modelPickers = screen.getAllByRole("button", { name: /change model/i });
-  // [0] is the top-level chip; the Advanced-panel one is whichever else opens
-  // a picker - pick the last one added (Advanced options render after it).
+  // The Advanced-panel picker is the last one added: the card's trigger and
+  // the top-level chip both render above it.
   await user.click(modelPickers[modelPickers.length - 1]!);
   const combo = await screen.findByRole("combobox", { name: "Model" });
   await user.type(combo, "gpt-5");
   await user.click(await screen.findByText("openai/gpt-5"));
 
   await waitFor(() => expect((screen.getByTestId("spawn-submit") as HTMLButtonElement).disabled).toBe(false));
-  expect(screen.getAllByRole("button", { name: /change model/i })[0]?.textContent).toContain("(default)"); // top-level chip untouched
+  expect(modelTrigger().textContent).toContain("(default)"); // top-level chip untouched
 });
 
 // --- uncredentialed-default fallback ---------------------------------------

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -43,6 +43,7 @@ import { requireClass } from "../../widgets/internal/requireClass";
 import type { ModelCatalog, ModelCatalogEntry } from "../../widgets/modelCatalog";
 import { fetchModelCatalog } from "../../widgets/modelCatalog/catalogClient";
 import { mergeScopedCatalog } from "../../widgets/modelCatalog/scopedCatalog";
+import { ModelSwitchTrigger } from "../session/chrome/ModelSwitchTrigger";
 import { AttachmentTile } from "../session/composer/AttachmentTile";
 import { AttachIcon } from "../session/composer/attachments/AttachIcon";
 import { imageFilesFromClipboard } from "../session/composer/attachments/clipboard";
@@ -111,7 +112,8 @@ const CLASS = {
   branchSeparator: requireClass(styles.branchSeparator, "spawn.module.css", "branchSeparator"),
   notice: requireClass(styles.notice, "spawn.module.css", "notice"),
   attachments: requireClass(styles.attachments, "spawn.module.css", "attachments"),
-  actionBand: requireClass(styles.actionBand, "spawn.module.css", "actionBand"),
+  leading: requireClass(styles.leading, "spawn.module.css", "leading"),
+  modelTrigger: requireClass(styles.modelTrigger, "spawn.module.css", "modelTrigger"),
   mobileConfig: requireClass(styles.mobileConfig, "spawn.module.css", "mobileConfig"),
   mobilePromptIntro: requireClass(styles.mobilePromptIntro, "spawn.module.css", "mobilePromptIntro"),
   mobilePromptHeading: requireClass(styles.mobilePromptHeading, "spawn.module.css", "mobilePromptHeading"),
@@ -713,8 +715,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
         <Dropzone onFiles={(files) => attachments.ingestFiles(files, (message) => toasts.push("error", message))}>
           <PromptCard
             data-testid="spawn-prompt-card"
-            controlsClassName={CLASS.actionBand}
-            controlsTestId="spawn-mobile-actions"
+            controlsTestId="spawn-controls"
             field={
               <Textarea
                 ref={textareaRef}
@@ -741,15 +742,41 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
               />
             }
             leading={
-              <IconButton
-                label="Attach image"
-                icon={<AttachIcon />}
-                variant="quiet"
-                size="xs"
-                type="button"
-                data-testid="spawn-attach"
-                onClick={() => fileInputRef.current?.click()}
-              />
+              /* The composer's own leading cluster (Composer.tsx's .leading):
+                 attach, then the model trigger. Both stay INSIDE the card's
+                 control row at every width, which is what "reuse the
+                 composer's UI" means (issue #198) - the pane used to hand
+                 this row a class that turned it into a fixed viewport band on
+                 a phone, stranding the paperclip at the bottom of the screen,
+                 far from the prompt it attaches to. */
+              <div className={CLASS.leading}>
+                <IconButton
+                  label="Attach image"
+                  icon={<AttachIcon />}
+                  variant="quiet"
+                  size="xs"
+                  type="button"
+                  data-testid="spawn-attach"
+                  onClick={() => fileInputRef.current?.click()}
+                />
+                {/* Phone only (the class is display:none until the 899px
+                    block): desktop sets the model in the configuration row
+                    below, so an in-card trigger there would be a second
+                    control for one setting. The label follows the same rules
+                    the desktop field's does - the required-choice word when
+                    the hub has confirmed no default (kata xgk8), otherwise
+                    the chosen model or "(default)". */}
+                <span className={CLASS.modelTrigger} data-testid="spawn-model-slot">
+                  <ModelSwitchTrigger
+                    label={modelRequired ? MODEL_CHOOSE_LABEL : model || "(default)"}
+                    value={model}
+                    loadCatalog={loadCatalog}
+                    onPick={(entry) => handleModelChange(`${entry.provider}/${entry.model}`)}
+                    data-testid="spawn-model-trigger"
+                    valueTestId="spawn-model-value"
+                  />
+                </span>
+              </div>
             }
             actions={
               <Tooltip label={`Start the agent · ${chordLabel(["Mod", "Enter"])}`}>
@@ -828,7 +855,12 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
             )}
           </div>
 
-          <div className={CLASS.cfgModel}>
+          {/* data-testid on the wrapper, not the trigger: the trigger is
+              ModelCatalog's own button and has no hook to give, and the pane
+              now renders a SECOND "— change model" button (the card's
+              phone-only ModelSwitchTrigger). A test or a scenario driving the
+              desktop field has to say which one it means. */}
+          <div className={CLASS.cfgModel} data-testid="spawn-desktop-model">
             <span className={CLASS.fieldLabel} id="spawn-model-label">
               Model
             </span>
@@ -863,11 +895,6 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
             harness={harness || "evener"}
             harnessOptions={harnessOptions}
             onHarnessChange={handleHarnessChange}
-            model={model}
-            modelDisplay={modelRequired ? MODEL_CHOOSE_LABEL : model || "(default)"}
-            modelRequired={modelRequired}
-            loadCatalog={loadCatalog}
-            onModelChange={handleModelChange}
             cwd={cwd}
             onCwdChange={setCwd}
             complete={complete}

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawn.module.css
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawn.module.css
@@ -29,9 +29,27 @@
   }
 }
 
-.actionBand {
-  /* Desktop keeps PromptCard's normal in-card controls. Mobile overrides this
-   * row into the approved thumb-reachable surface. */
+/* The prompt card's leading cluster - the attach button, and on a phone the
+ * model trigger beside it. Deliberately identical to the session composer's
+ * own .leading (composer.module.css): the control row is the SAME object on
+ * both surfaces, so its leading slot lays out the same way rather than
+ * resembling it (issue #198). */
+.leading {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+/* Desktop already sets the model in the configuration row below the card
+ * (.cfgModel's own ModelField), so an in-card trigger there would be a second
+ * control for one setting. On a phone that whole row is gone (.cfg is
+ * display:none in the breakpoint block below) and this IS how the model gets
+ * set - the same control, in the same place, as the session composer's. */
+.modelTrigger {
+  display: none;
+  min-width: 0;
 }
 
 .mobileConfig {
@@ -163,9 +181,12 @@
   .form {
     width: 100%;
     max-width: none;
-    padding-bottom: calc(76px + env(safe-area-inset-bottom));
   }
 
+  /* 16px is the floor iOS Safari zooms the page to reach; a smaller field font
+   * makes focusing the prompt scale the whole layout. The min-height keeps the
+   * field a usable writing surface on a short viewport where the card's
+   * line-count floor would otherwise be all it gets. */
   .form textarea {
     font-size: 16px;
     min-height: 96px;
@@ -183,37 +204,7 @@
     display: block;
   }
 
-  .actionBand {
-    position: fixed;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    z-index: var(--z-sticky-bar);
-    min-height: 76px;
-    align-items: center;
-    padding: var(--space-3) var(--space-4) calc(var(--space-3) + env(safe-area-inset-bottom));
-    border-top: 1px solid var(--edge);
-    background: var(--surface-1);
-  }
-
-  .actionBand > button {
-    flex: 0 0 auto;
-    min-width: 44px;
-    min-height: 44px;
-  }
-
-  .actionBand > div {
-    flex: 1 1 auto;
-    min-width: 0;
-  }
-
-  .actionBand > div > span,
-  .actionBand > div > span > button {
-    display: block;
-    width: 100%;
-  }
-
-  .actionBand > div > span > button {
-    min-height: 52px;
+  .modelTrigger {
+    display: flex;
   }
 }

--- a/cmd/evener-hub/frontend/src/widgets/promptcard/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/promptcard/index.tsx
@@ -12,10 +12,6 @@ export interface PromptCardProps {
   /** Trailing control-row slot, after the spacer - the primary verb and
    * whatever sits beside it. */
   actions?: ReactNode;
-  /** Optional caller styling for the control row. Spawn uses this to pin the
-   * existing controls into its mobile action band without changing the shared
-   * composer layout. */
-  controlsClassName?: string;
   /** Optional stable hook for a caller-owned control-row behavior test. */
   controlsTestId?: string;
   /** Forwarded to the card element so a test can address it by a stable hook
@@ -50,7 +46,6 @@ export function PromptCard({
   leading,
   actions,
   hidden,
-  controlsClassName,
   controlsTestId,
   "data-testid": testId,
 }: PromptCardProps) {
@@ -58,7 +53,7 @@ export function PromptCard({
     <div className={CLASS.card} data-testid={testId} hidden={hidden} inert={hidden}>
       {field}
       {(leading !== undefined || actions !== undefined) && (
-        <div className={`${CLASS.controls} ${controlsClassName ?? ""}`} data-testid={controlsTestId}>
+        <div className={CLASS.controls} data-testid={controlsTestId}>
           {leading}
           <div className={CLASS.actions}>{actions}</div>
         </div>

--- a/cmd/evener-hub/frontend/src/widgets/promptcard/promptcard.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/promptcard/promptcard.test.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { afterEach, expect, test } from "vitest";
 import { Textarea } from "../textarea";
 import { PromptCard } from "./index";
+import promptCardStyles from "./promptcard.module.css";
 
 afterEach(cleanup);
 
@@ -20,7 +21,6 @@ function LiveCard(props: {
   leading?: React.ReactNode;
   actions?: React.ReactNode;
   hidden?: boolean;
-  controlsClassName?: string;
   controlsTestId?: string;
 }) {
   const [value, setValue] = useState("");
@@ -28,7 +28,6 @@ function LiveCard(props: {
     <PromptCard
       data-testid="card"
       hidden={props.hidden}
-      controlsClassName={props.controlsClassName}
       controlsTestId={props.controlsTestId}
       leading={props.leading}
       actions={props.actions}
@@ -75,17 +74,20 @@ test("renders the caller's leading and action controls", () => {
   expect(screen.getByRole("button", { name: "Send" })).toBeTruthy();
 });
 
+// The control row is the card's own, and only the card styles it: a caller
+// hook that let one reach in and restyle the row is how spawn turned it into a
+// fixed viewport band on a phone, stranding the attach button at the bottom of
+// the screen (issue #198). Callers get a testid and their own controls.
 test("forwards the caller's control-row hook without changing its child order", () => {
   render(
     <LiveCard
-      controlsClassName="mobile-action-band"
       controlsTestId="controls"
       leading={<button type="button">Attach</button>}
       actions={<button type="button">Send</button>}
     />,
   );
 
-  expect(screen.getByTestId("controls").className).toContain("mobile-action-band");
+  expect(screen.getByTestId("controls").className).toBe(promptCardStyles.controls);
   expect(screen.getByTestId("controls").querySelectorAll("button")).toHaveLength(2);
 });
 

--- a/docs/agentic-testing.md
+++ b/docs/agentic-testing.md
@@ -636,11 +636,20 @@ facts (`status-row-effort`, `status-row-context`, `status-row-cost`,
 `[data-testid="model-switch-trigger"]` / `[data-testid="model-switch-value"]`,
 `[data-testid="goal-popover"]`, `[data-testid="task-row"]`.
 
-**Spawn** (`panes/spawn/Spawn.tsx`): `[data-testid="spawn-prompt-card"]`,
+**Spawn** (`panes/spawn/Spawn.tsx`): `[data-testid="spawn-prompt-card"]`
+and its control row `[data-testid="spawn-controls"]`,
 `[data-testid="spawn-submit"]`, `[data-testid="spawn-attach"]`,
-`[data-testid="spawn-branch"]`. The model picker is the shared ARIA
-combobox in `widgets/modelCatalog/` — `role="option"` rows, not the
-legacy `.chip-picker-*` classes.
+`[data-testid="spawn-branch"]`. Two model controls, and only one of them
+is ever on screen: `[data-testid="spawn-desktop-model"]` wraps the
+desktop Model field's `ModelCatalog` trigger, while
+`[data-testid="spawn-model-trigger"]` (readout
+`[data-testid="spawn-model-value"]`) is the prompt card's own
+`ModelSwitchTrigger`, which the phone uses and a desktop width hides
+behind `[data-testid="spawn-model-slot"]`. Both carry the `— change
+model` screen-reader suffix, so address them by testid or filter on
+`offsetParent`. The picker itself is the shared ARIA combobox in
+`widgets/modelCatalog/` — `role="option"` rows, not the legacy
+`.chip-picker-*` classes.
 
 **Toasts** are the error channel for actions that fail without a
 dedicated surface: `section[aria-live="polite"][aria-label="Notifications"]`

--- a/test/scenarios/spawn-empty-prompt-starts-dormant.md
+++ b/test/scenarios/spawn-empty-prompt-starts-dormant.md
@@ -2,7 +2,7 @@
 
 **What this covers**: kata `ytpa`. The spawn pane's prompt placeholder
 reads `What should the agent work on? Leave blank to start it dormant.`
-(`panes/spawn/Spawn.tsx:729`). Submitting with the prompt empty must
+(`panes/spawn/Spawn.tsx:730`). Submitting with the prompt empty must
 honour that promise: create the session, start no turn, open it, and
 say so on the rail row.
 

--- a/test/scenarios/spawn-keyboard-contract.md
+++ b/test/scenarios/spawn-keyboard-contract.md
@@ -100,14 +100,19 @@ roles (`role="combobox"` with `aria-label="Model"`, `role="listbox"`,
    curl -s -H "Authorization: Bearer $TOKEN" "$HUB/api/tree" \
      | jq -c '[.. | objects | .ref? // empty] | unique'
    ```
-4. Open the picker and pick with Enter. The trigger is the only button
-   on the page carrying the screen-reader text `— change model`; assert
-   that before clicking it, because the pane also renders a hidden
-   mobile config block (`[data-testid="spawn-mobile-config"]`):
+4. Open the picker and pick with Enter. The desktop Model field's trigger
+   is the only VISIBLE button on the page carrying the screen-reader
+   text `— change model`; assert that before clicking it. The filter on
+   `offsetParent` is load bearing: the prompt card carries a second such
+   trigger for the phone (`[data-testid="spawn-model-trigger"]`), which
+   at this viewport is inside a `display: none` wrapper and so has no
+   `offsetParent` at all, and the mobile config block
+   (`[data-testid="spawn-mobile-config"]`) is hidden the same way:
    ```javascript
    (() => {
      const triggers = Array.from(document.querySelectorAll("button"))
-       .filter((b) => b.textContent.includes("change model"));
+       .filter((b) => b.textContent.includes("change model"))
+       .filter((b) => b.offsetParent !== null);
      if (triggers.length !== 1) return { port: location.port, triggers: triggers.length };
      triggers[0].click();
      return { port: location.port, triggers: 1 };
@@ -126,7 +131,10 @@ roles (`role="combobox"` with `aria-label="Model"`, `role="listbox"`,
      path: decodeURIComponent(location.pathname),
      // The trigger's own text is the value plus the screen-reader
      // "— change model" suffix: assert `contains`, never `equals`.
+     // Same visibility filter as step 4 - the hidden phone trigger reads
+     // the same model and would answer here otherwise.
      trigger: Array.from(document.querySelectorAll("button"))
+       .filter((b) => b.offsetParent !== null)
        .find((b) => b.textContent.includes("change model"))?.textContent,
      listbox: !!document.querySelector('[role="listbox"]'),
      options: document.querySelectorAll('[role="option"]').length,
@@ -165,7 +173,8 @@ roles (`role="combobox"` with `aria-label="Model"`, `role="listbox"`,
   exactly the hazard kata `t13x` removed, and every absence assertion
   below stops proving anything until it is gone again — so if this fails,
   stop and report it rather than continuing to Part B.
-- **Step 4-5 (picker Enter selects)**: exactly one trigger matched.
+- **Step 4-5 (picker Enter selects)**: exactly one VISIBLE trigger
+  matched.
   `listbox` is false (the popover closed), `trigger` contains the
   `provider/model` id of the highlighted row, `path` is still `/new`,
   and the step-3 snapshot is **identical** to the baseline. Falsify:
@@ -255,10 +264,17 @@ roles (`role="combobox"` with `aria-label="Model"`, `role="listbox"`,
   to exercise that composition, it is a different scenario, and
   `dirListSetting.test.tsx`'s "Enter on a directory row descends without
   submitting the add row" is its unit-level precedent.
-- **The desktop and mobile config blocks both live in the DOM.** Only
-  the desktop one renders the `ModelCatalog` trigger; the mobile rows
-  open a `Sheet` holding the panel directly
-  (`panes/spawn/MobileSettingRows.tsx:285-306`). At a desktop viewport
-  the sheet is closed, so exactly one `— change model` button and one
-  `[role="combobox"]` exist — step 4 asserts that rather than assuming
-  it, because a second match means you are driving the wrong one.
+- **Two `— change model` buttons live in the DOM, and only one of them
+  is on screen.** The desktop Model field renders a `ModelCatalog`
+  trigger (`panes/spawn/Spawn.tsx#ModelField`, inside
+  `[data-testid="spawn-desktop-model"]`); the prompt card renders a
+  `ModelSwitchTrigger` for the phone
+  (`[data-testid="spawn-model-trigger"]`), gated by a
+  `display: none` wrapper until the 899px breakpoint
+  (`panes/spawn/spawn.module.css`'s `.modelTrigger`). Both carry the
+  same screen-reader suffix and read the same model state, so a
+  name-only match at a desktop viewport picks whichever comes first in
+  the DOM — the hidden one. Filter on `offsetParent !== null`, as steps
+  4 and 5 do. The mobile settings list holds no model control at all
+  any more (issue #198 moved that job to the card), so its rows are not
+  a third match.

--- a/test/scenarios/web-file-picker-image.md
+++ b/test/scenarios/web-file-picker-image.md
@@ -195,7 +195,7 @@ combobox, as a real gesture.
   (`SID` is a 22-character UUIDv7 base62 payload). Falsify: it stays on
   `/new` with an error toast in
   `section[aria-live="polite"][aria-label="Notifications"]` — most
-  usefully `Image attachment is still processing.` (`Spawn.tsx:613`,
+  usefully `Image attachment is still processing.` (`Spawn.tsx:615`,
   the `hasPending` submit gate) or a `Spawn failed: …` line.
 - **Step 6 (composer staging)**: `view` is `View red.png`, `remove` is
   `Remove red.png`, `thumbSrc` starts `data:image/png;base64,`


### PR DESCRIPTION
## Issue #198: reuse the composer's UI in Spawn, for attachments and for setting the model

### Root cause

`Spawn.tsx` passed `PromptCard` a `controlsClassName={CLASS.actionBand}`, and
`spawn.module.css`'s `@media (max-width: 899px)` block made `.actionBand`
`position: fixed; bottom: 0`. The card's own control row therefore left the
card and became a page-level band, stranding the attach button at the foot of
the viewport, nowhere near the prompt it attaches to. Measured in the new
layoutguard harness at 390x844 against main: the card sits at `12,12 366x106`
while the control row sits at `0,767 390x77`.

The session composer has never had this problem — `Composer.tsx` keeps attach
and the model control inside the card's controls row at **all** widths. So the
fix is to render the same shape rather than a third placement that resembles
it.

### Fix

**Attach (Part A).** The mobile `.actionBand` overrides, the now-empty desktop
`.actionBand` rule, and the `.form` `padding-bottom` that reserved room for the
band are gone; `Spawn.tsx` drops `controlsClassName`. `PromptCard`'s
`controlsClassName` prop is deleted outright — a caller reaching in to restyle
the shared row is what made this possible. The row's touch targets survive on
the widgets' own phone blocks (`button.module.css` / `iconbutton.module.css`,
both keyed to `--tap-min`), which spawnguard now **measures** rather than
assumes. The 16px textarea font and its `min-height` stay: that is the iOS
zoom floor, not action-band compensation. Testid renamed
`spawn-mobile-actions` → `spawn-controls`.

**Model (Part B).** `ModelSwitchTrigger` is extracted from
`panes/session/chrome/ModelSwitch.tsx` as a value-controlled presentational
component (same directory, same `modelswitch.module.css`), keeping the
`— change model` screen-reader suffix, the load-bearing whitespace text node,
and the `sessionActionHeadline` + `friendlyLaunchErrorMessage` error framing.
`ModelSwitch` becomes a thin thread-bound wrapper and keeps its
`model-switch-trigger` / `model-switch-value` testids. Spawn's card renders
that same trigger in its leading slot beside attach, gated phone-only in CSS.
`MobileSettingRows` drops its Model row and its bespoke model sheet (6 rows → 5).

### Stated decisions

- **Effort stays in `MobileSettingRows`.** Combining model and effort into one
  pill the way the session status row does is a product call, not a bug fix;
  flagged, deliberately out of scope here.
- **The model sheet's "Use default" row is dropped.** Strict composer reuse:
  `(default)` is the trigger's own resting label, which is the composer's
  answer to the same question.
- **Desktop is untouched.** The configuration row's `ModelField` stays; the
  card's trigger is `display: none` above 899px, because two controls for one
  setting is worse than one.
- **No `<form>` / `onSubmit` anywhere in Spawn** (kata `t13x`;
  `test/scenarios/spawn-keyboard-contract.md` Part A greps for exactly this).

### Guards

- **New** `scripts/layoutguard/cases/spawn-attach-in-card/` (390x844): the
  control row is not `position: fixed`, and the row, attach, the model trigger
  and Start all sit inside the card, with attach below the field rather than
  overlaid on it. Authored red-first against main's markup and CSS; the
  mutation evidence is recorded in `case.json`.
- **Updated** `scripts/spawnguard/run.mjs` + `src/dev/spawnguard-entry.tsx`:
  the same containment at 390/899/900px, the 44px touch floor measured on the
  real buttons, the model trigger visible at 390/899 and hidden at 900, and
  five setting rows.

### Verification

- `npx tsc --noEmit --incremental false` — clean
- `npm test` — 343 files, 6764 tests passed
- `npm run lint` (`biome ci src`) — clean
- `npm run layoutguard` — 17/17 PASS
- `npm run spawnguard` — 390/899/900px PASS
- `npm run overflowguard` — PASS
- `go test ./` (root scenario/doc audits) — ok

Closes #198

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU
