### PR TITLE
feat(agent): in-stream loop guard, Phase 1 (#94)

### DIFF
--- a/agent/events/payloads.go
+++ b/agent/events/payloads.go
@@ -311,6 +311,7 @@ const (
 	SteeringKindImageDescription  = "image-description"
 	SteeringKindNoToolCalls       = "no-tool-calls"
 	SteeringKindLoopDetected      = "loop-detected"
+	SteeringKindStreamLoop        = "stream-loop"
 	SteeringKindTasksDone         = "tasks-done"
 	SteeringKindTaskNudge         = "task-nudge"
 	SteeringKindTaskInactive      = "task-inactive"
@@ -336,6 +337,7 @@ var AllSteeringKinds = []string{
 	SteeringKindImageDescription,
 	SteeringKindNoToolCalls,
 	SteeringKindLoopDetected,
+	SteeringKindStreamLoop,
 	SteeringKindTasksDone,
 	SteeringKindTaskNudge,
 	SteeringKindTaskInactive,

--- a/agent/events/payloads_test.go
+++ b/agent/events/payloads_test.go
@@ -101,6 +101,7 @@ func TestSteeringKindConstants(t *testing.T) {
 		"image-description":  SteeringKindImageDescription,
 		"no-tool-calls":      SteeringKindNoToolCalls,
 		"loop-detected":      SteeringKindLoopDetected,
+		"stream-loop":        SteeringKindStreamLoop,
 		"tasks-done":         SteeringKindTasksDone,
 		"task-nudge":         SteeringKindTaskNudge,
 		"task-inactive":      SteeringKindTaskInactive,

--- a/agent/session.go
+++ b/agent/session.go
@@ -578,6 +578,21 @@ type Session struct {
 	// stuck detection
 	loopDetectionCount int // how many times loop detection has fired
 
+	// stream loop guard (issue #94): tracks whether the response
+	// consumeModelStream most recently returned was force-stopped mid-stream
+	// by the in-band loop guard (session_stream_loop_guard.go), so a SECOND
+	// consecutive trip escalates to a hard stop instead of nudging forever.
+	// streamLoopTripStreak resets to 0 on any response that completes
+	// without tripping, and at the start of every turn (processOneInput), so
+	// a hard stop -- which returns before the clean-completion reset can run
+	// -- cannot leave the session permanently one trip from another hard
+	// stop. pendingStreamLoopNudge holds the steering text for a tier-1 trip
+	// until injectPostToolSteering delivers it as a steering turn and clears
+	// it; it is dropped rather than carried at turn start, since a nudge that
+	// missed its own turn would land out of context in an unrelated one.
+	streamLoopTripStreak   int
+	pendingStreamLoopNudge string
+
 	// transcript writer (nil when StateDir is empty, or when opening it failed)
 	transcript *transcript.Writer
 	// attentionMu serializes transcript-backed attention resolution for this

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -1282,6 +1282,15 @@ func modelFallbackEligible(err error, policy llm.RetryPolicy) bool {
 	if errors.As(err, &unhealthy) {
 		return false
 	}
+	// A loop-guard hard stop indicts the request, not the model: the runaway
+	// came from what was asked, so every fallback entry would reproduce it.
+	// Decided here for the same reason as the verdict above — the wrapped
+	// cause classifies ErrorClassPermanent, which the switch below reports
+	// eligible.
+	var loopStop *streamLoopHardStopError
+	if errors.As(err, &loopStop) {
+		return false
+	}
 	switch llm.Classify(err) {
 	case llm.ErrorClassPermanent, llm.ErrorClassFallback:
 		return true

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -1037,6 +1037,15 @@ func (s *Session) processOneInput(ctx context.Context, input string, images []Im
 	// beside comm's reset, under the lock already held (not via the
 	// clearAskPending helper, which takes s.mu itself and would deadlock).
 	s.askPending = nil
+	// Stream loop guard (issue #94): both fields are scoped to a turn, and
+	// only the clean-completion path in consumeModelStream zeroes the streak
+	// — which a tier-2 hard stop returns before reaching, leaving the streak
+	// at 2 so every later trip, in every later turn, hard-stops instantly
+	// with no tier-1 chance to self-correct. The pending nudge is dropped
+	// rather than carried: it describes a response from a turn that is over,
+	// and delivering it into an unrelated one lands it out of context.
+	s.streamLoopTripStreak = 0
+	s.pendingStreamLoopNudge = ""
 	s.mu.Unlock()
 	s.delegateDeliveryMu.Unlock()
 

--- a/agent/session_stream.go
+++ b/agent/session_stream.go
@@ -242,6 +242,66 @@ func (s *Session) consumeModelStream(ctx context.Context, req llm.Request, st ll
 	assistantStarted := false
 	finished := false
 
+	// Stream loop guard (issue #94): bounds this one response, since nothing
+	// else in the stack does — see session_stream_loop_guard.go for the
+	// detectors. guardTripped and hardStopErr are read after the loop to
+	// decide the streak reset and the tier-2 hard-stop return respectively.
+	loopGuard := newStreamLoopGuard()
+	guardTripped := false
+	var hardStopErr error
+	// openToolCalls tracks tool-call IDs that have started but not yet
+	// ended. A trip detected while ANY call is open (e.g. real providers
+	// interleave parallel tool calls' deltas across multiple IDs) must not
+	// act immediately — forcing a finish would freeze that other call's
+	// arguments truncated into the response, exactly the "cut mid-arguments"
+	// the spec rules out. pendingTrip remembers the first trip detected
+	// until every open call closes, rather than relying on the detectors to
+	// re-trip later: a parallel call's own signature can break a cycle
+	// pattern that had already matched, so re-detection is not guaranteed.
+	openToolCalls := map[string]bool{}
+	var pendingTrip *loopTrip
+	recordTrip := func(trip *loopTrip) {
+		if pendingTrip == nil {
+			pendingTrip = trip
+		}
+	}
+	// applyPendingTrip performs the two-tier action for pendingTrip once no
+	// tool call is in flight — the only point a forced finish is a legal
+	// boundary rather than a cut. Returns true when it acted, meaning the
+	// caller must stop consuming the stream (tier 1 sets finished and expects
+	// the caller to break the labeled event loop; tier 2 leaves hardStopErr
+	// for the early return below).
+	applyPendingTrip := func() bool {
+		if pendingTrip == nil || len(openToolCalls) > 0 {
+			return false
+		}
+		trip := pendingTrip
+		guardTripped = true
+		s.mu.Lock()
+		s.streamLoopTripStreak++
+		streak := s.streamLoopTripStreak
+		s.mu.Unlock()
+		if streak >= 2 {
+			// Wrapped in streamLoopHardStopError so modelFallbackEligible can
+			// exclude it by type: the wrapped cause classifies
+			// ErrorClassPermanent, which the fallback chain otherwise reads as
+			// "try the next model" — re-running the exact request that
+			// produced the runaway against every configured fallback.
+			hardStopErr = &streamLoopHardStopError{cause: llm.NewPermanentStreamError(req.Provider, streamLoopHardStopMessage(trip), nil)}
+			return true
+		}
+		s.mu.Lock()
+		s.pendingStreamLoopNudge = streamLoopNudgeText(trip)
+		s.mu.Unlock()
+		reason := llm.FinishReasonStop
+		if len(toolArgs) > 0 {
+			reason = llm.FinishReasonToolCalls
+		}
+		acc.Process(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &llm.FinishReason{Reason: reason, Raw: "loop_guard:" + trip.Kind.String()}})
+		finished = true
+		return true
+	}
+
 	// firstContent/lastContent bound the content-event window — text, tool-arg
 	// (delta or end), and reasoning content only, never wall-clock attempt
 	// duration (spec: SSE keep-alives reset the read timer, so a stalled
@@ -326,6 +386,7 @@ func (s *Session) consumeModelStream(ctx context.Context, req llm.Request, st ll
 		emitAssistantDelta(message[len(prev):])
 	}
 
+streamEvents:
 	for ev := range st.Events() {
 		acc.Process(ev)
 		switch ev.Type {
@@ -353,6 +414,7 @@ func (s *Session) consumeModelStream(ctx context.Context, req llm.Request, st ll
 			if _, ok := toolArgs[ev.ToolCall.ID]; !ok {
 				toolArgs[ev.ToolCall.ID] = &strings.Builder{}
 			}
+			openToolCalls[ev.ToolCall.ID] = true
 		case llm.StreamEventToolCallDelta:
 			s.noteParentJobActivity(jobPhaseModelStreaming)
 			if ev.ToolCall == nil || ev.ToolCall.ID == "" {
@@ -388,6 +450,17 @@ func (s *Session) consumeModelStream(ctx context.Context, req llm.Request, st ll
 			if toolNames[ev.ToolCall.ID] == s.resultToolName() {
 				emitCommunicatePreview(ev.ToolCall.ID)
 			}
+			delete(openToolCalls, ev.ToolCall.ID)
+			args := ""
+			if b := toolArgs[ev.ToolCall.ID]; b != nil {
+				args = b.String()
+			}
+			if trip := loopGuard.observeToolCall(toolNames[ev.ToolCall.ID], args); trip != nil {
+				recordTrip(trip)
+			}
+			if applyPendingTrip() {
+				break streamEvents
+			}
 		case llm.StreamEventFinish:
 			finished = true
 		case llm.StreamEventError:
@@ -397,6 +470,16 @@ func (s *Session) consumeModelStream(ctx context.Context, req llm.Request, st ll
 			err := llm.NewStreamError(req.Provider, "stream error", nil)
 			return sessionModelResponse{}, observe(err), err
 		}
+	}
+
+	if hardStopErr != nil {
+		// Tier 2: a second consecutive trip. Return directly rather than
+		// falling into the normal finished-response path below — there is no
+		// well-formed response to salvage into a "success" here, only a
+		// non-retryable error that ends the turn (llm.Classify treats
+		// NewPermanentStreamError as ErrorClassPermanent, so RetryStream does
+		// not spend its budget reproducing the same runaway).
+		return sessionModelResponse{}, observe(hardStopErr), hardStopErr
 	}
 
 	if !finished {
@@ -416,6 +499,15 @@ func (s *Session) consumeModelStream(ctx context.Context, req llm.Request, st ll
 	}
 	if resp.Model == "" {
 		resp.Model = req.Model
+	}
+	if !guardTripped {
+		// A clean completion breaks the streak: two trips only escalate to a
+		// hard stop when they are consecutive — a session that occasionally
+		// loops but always recovers must not be punished for a trip two
+		// rounds ago.
+		s.mu.Lock()
+		s.streamLoopTripStreak = 0
+		s.mu.Unlock()
 	}
 	return sessionModelResponse{Response: *resp, StreamedAssistant: streamedAssistant}, observe(nil), nil
 }

--- a/agent/session_stream.go
+++ b/agent/session_stream.go
@@ -260,11 +260,6 @@ func (s *Session) consumeModelStream(ctx context.Context, req llm.Request, st ll
 	// pattern that had already matched, so re-detection is not guaranteed.
 	openToolCalls := map[string]bool{}
 	var pendingTrip *loopTrip
-	recordTrip := func(trip *loopTrip) {
-		if pendingTrip == nil {
-			pendingTrip = trip
-		}
-	}
 	// applyPendingTrip performs the two-tier action for pendingTrip once no
 	// tool call is in flight — the only point a forced finish is a legal
 	// boundary rather than a cut. Returns true when it acted, meaning the
@@ -455,8 +450,12 @@ streamEvents:
 			if b := toolArgs[ev.ToolCall.ID]; b != nil {
 				args = b.String()
 			}
-			if trip := loopGuard.observeToolCall(toolNames[ev.ToolCall.ID], args); trip != nil {
-				recordTrip(trip)
+			// The first trip wins: a trip already waiting on an open parallel
+			// call must not be replaced by a later one, or the message would
+			// name whatever repeated last rather than what actually stopped
+			// the response.
+			if trip := loopGuard.observeToolCall(toolNames[ev.ToolCall.ID], args); trip != nil && pendingTrip == nil {
+				pendingTrip = trip
 			}
 			if applyPendingTrip() {
 				break streamEvents

--- a/agent/session_stream_loop_guard.go
+++ b/agent/session_stream_loop_guard.go
@@ -1,0 +1,129 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+)
+
+// streamLoopGuard detects a runaway SINGLE model response mid-stream (issue
+// #94): a repeating cycle of tool-call signatures, or a raw tool-call count
+// far past anything a legitimate response needs. It is the shape of
+// gemini-cli's LoopDetectionService, ported to Go and to evener's stream
+// event model. One instance lives for exactly one consumeModelStream attempt
+// -- state does not (and must not) survive past a single response, since the
+// hole this closes is specifically that nothing bounds one response.
+type streamLoopGuard struct {
+	// sigs holds one entry per completed tool call this response, in
+	// order: canonicalToolName + ":" + raw argument text. A cheap string
+	// join rather than a hash, matching the existing post-dispatch
+	// breaker's signature() convention (agent/internal/tool/breaker.go) --
+	// byte-identical arguments share a signature, differing JSON
+	// formatting does not.
+	sigs []string
+}
+
+// loopGuardCycleMaxLen and loopGuardCycleRepeats are gemini-cli's own
+// numbers (LoopDetectionService: cycle length k=1..5, repeated 5 times).
+// Issue #94's spec calls for this exact shape: "a repeating CYCLE of length
+// k=1..5 repeated 5x."
+const (
+	loopGuardCycleMaxLen  = 5
+	loopGuardCycleRepeats = 5
+)
+
+// loopGuardRawCeiling is the backstop for shapes with no short cycle (issue
+// #94: "a HIGH raw tool-call ceiling per response as backstop... do not pick
+// 15" -- odysseus #3185 killed a legitimate 18-distinct-call round at that
+// threshold). Chosen with a wide safety margin above the only documented
+// legitimate shape (18 distinct calls) while still catching the second
+// measured runaway shape (83 calls / 48 distinct signatures / max repeat 12)
+// well before it completes.
+const loopGuardRawCeiling = 50
+
+// loopTripKind names which detector fired.
+type loopTripKind int
+
+const (
+	loopTripCycle loopTripKind = iota
+	loopTripCeiling
+)
+
+func (k loopTripKind) String() string {
+	switch k {
+	case loopTripCycle:
+		return "cycle"
+	case loopTripCeiling:
+		return "ceiling"
+	default:
+		return "unknown"
+	}
+}
+
+// loopTrip reports one guard trip: which detector fired and a human-readable
+// detail naming what repeated, for the tier-1 nudge and the tier-2 hard-stop
+// message alike.
+type loopTrip struct {
+	Kind   loopTripKind
+	Detail string
+}
+
+// streamLoopHardStopError marks the tier-2 hard stop so the fallback chain can
+// exclude it by type. The wrapped cause classifies as ErrorClassPermanent,
+// which modelFallbackEligible would otherwise read as "try the next model" --
+// re-running the exact request that produced the runaway against every
+// configured fallback, the opposite of what the hard stop exists to do.
+type streamLoopHardStopError struct{ cause error }
+
+func (e *streamLoopHardStopError) Error() string { return e.cause.Error() }
+func (e *streamLoopHardStopError) Unwrap() error { return e.cause }
+
+func newStreamLoopGuard() *streamLoopGuard {
+	return &streamLoopGuard{}
+}
+
+// observeToolCall records one COMPLETED tool call (StreamEventToolCallEnd --
+// the only point a call's name and arguments are both final) and reports a
+// trip if the running sequence now shows a cycle or has crossed the raw
+// ceiling.
+func (g *streamLoopGuard) observeToolCall(name, args string) *loopTrip {
+	_ = name
+	_ = args
+	return nil
+}
+
+// checkCycle checks whether the most recently appended signature completes a
+// cycle of length k (1..5), repeated loopGuardCycleRepeats times
+// consecutively.
+func (g *streamLoopGuard) checkCycle() *loopTrip {
+	return nil
+}
+
+// streamLoopNudgeText builds the tier-1 steering message for a stream-loop
+// trip.
+func streamLoopNudgeText(trip *loopTrip) string {
+	_ = trip
+	return ""
+}
+
+// streamLoopHardStopMessage builds the tier-2 error message when a second
+// consecutive response trips the guard.
+func streamLoopHardStopMessage(trip *loopTrip) string {
+	_ = trip
+	return ""
+}
+
+// describeCyclePattern names the repeated call(s) for the nudge/hard-stop
+// message.
+func describeCyclePattern(pattern []string) string {
+	_ = pattern
+	return ""
+}
+
+// deliverPendingStreamLoopNudge reads and clears s.pendingStreamLoopNudge and,
+// if one was pending, appends it as a steering turn.
+func (s *Session) deliverPendingStreamLoopNudge(ctx context.Context) error {
+	_ = ctx
+	return nil
+}
+
+var _ = fmt.Sprintf

--- a/agent/session_stream_loop_guard.go
+++ b/agent/session_stream_loop_guard.go
@@ -3,6 +3,9 @@ package agent
 import (
 	"context"
 	"fmt"
+	"strings"
+
+	"primeradiant.com/evener/agent/events"
 )
 
 // streamLoopGuard detects a runaway SINGLE model response mid-stream (issue
@@ -84,46 +87,121 @@ func newStreamLoopGuard() *streamLoopGuard {
 // observeToolCall records one COMPLETED tool call (StreamEventToolCallEnd --
 // the only point a call's name and arguments are both final) and reports a
 // trip if the running sequence now shows a cycle or has crossed the raw
-// ceiling.
+// ceiling. Cycle is checked first: it is the field's dominant shape (the
+// captured incident was A,B,C x76, and every consecutive-identical detector is
+// structurally blind to it) and fires far earlier than the ceiling ever could.
+// The ceiling is checked second, as the backstop for shapes with no short
+// cycle.
 func (g *streamLoopGuard) observeToolCall(name, args string) *loopTrip {
-	_ = name
-	_ = args
+	g.sigs = append(g.sigs, name+":"+args)
+	if trip := g.checkCycle(); trip != nil {
+		return trip
+	}
+	if len(g.sigs) >= loopGuardRawCeiling {
+		return &loopTrip{
+			Kind:   loopTripCeiling,
+			Detail: fmt.Sprintf("%d tool calls in a single response, past the %d-call ceiling", len(g.sigs), loopGuardRawCeiling),
+		}
+	}
 	return nil
 }
 
 // checkCycle checks whether the most recently appended signature completes a
 // cycle of length k (1..5), repeated loopGuardCycleRepeats times
-// consecutively.
+// consecutively. For each k it looks at exactly the trailing k*R signatures
+// and asks whether they consist of R back-to-back copies of the trailing k
+// -- not "a cycle occurs somewhere in a wider window," which would fire on
+// coincidental repetition inside a long response; the last occurrence must
+// be the (r)th repeat with nothing else interleaved.
 func (g *streamLoopGuard) checkCycle() *loopTrip {
+	n := len(g.sigs)
+	for k := 1; k <= loopGuardCycleMaxLen; k++ {
+		need := k * loopGuardCycleRepeats
+		if n < need {
+			continue
+		}
+		window := g.sigs[n-need:]
+		pattern := window[:k]
+		matched := true
+		for i := k; i < need; i++ {
+			if window[i] != pattern[i%k] {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return &loopTrip{
+				Kind:   loopTripCycle,
+				Detail: describeCyclePattern(pattern),
+			}
+		}
+	}
 	return nil
 }
 
 // streamLoopNudgeText builds the tier-1 steering message for a stream-loop
-// trip.
+// trip: it names what repeated, wrapped as a SYSTEM-REMINDER to match every
+// other steering message's envelope (agent/task_reminders.go).
 func streamLoopNudgeText(trip *loopTrip) string {
-	_ = trip
-	return ""
+	var what string
+	switch trip.Kind {
+	case loopTripCycle:
+		what = fmt.Sprintf("You just repeated the same sequence of tool calls five times in a row within one response: %s. "+
+			"That response was cut off before it could repeat a sixth time.", trip.Detail)
+	case loopTripCeiling:
+		what = fmt.Sprintf("Your last response made %s. "+
+			"That response was cut off once it crossed the limit.", trip.Detail)
+	}
+	return "<SYSTEM-REMINDER>\n" + what +
+		" This is a signal you are stuck, not a punishment. Stop and think about why your current approach is not working, " +
+		"then either try something different or report what you tried and what failed.\n" +
+		"</SYSTEM-REMINDER>"
 }
 
 // streamLoopHardStopMessage builds the tier-2 error message when a second
-// consecutive response trips the guard.
+// consecutive response trips the guard: unlike the tier-1 nudge, there is no
+// next response to read it, so it explains the failure for the turn's error
+// surface (emitTurnFailure) rather than steering a model that already had
+// its one chance to self-correct.
 func streamLoopHardStopMessage(trip *loopTrip) string {
-	_ = trip
-	return ""
+	return fmt.Sprintf("loop guard: two responses in a row were cut off for the same reason (%s: %s); stopping rather than nudging indefinitely", trip.Kind, trip.Detail)
 }
 
 // describeCyclePattern names the repeated call(s) for the nudge/hard-stop
-// message.
+// message, e.g. "manage_worktree, task_list, communicate" for a k=3 cycle.
+// Signatures are "name:args"; only the name is surfaced -- the arguments are
+// often large or provider-internal and the tool name is what the model needs
+// to recognize it is repeating itself.
 func describeCyclePattern(pattern []string) string {
-	_ = pattern
-	return ""
+	names := make([]string, len(pattern))
+	for i, sig := range pattern {
+		name, _, found := strings.Cut(sig, ":")
+		if !found {
+			name = sig
+		}
+		names[i] = name
+	}
+	return strings.Join(names, ", ")
 }
 
 // deliverPendingStreamLoopNudge reads and clears s.pendingStreamLoopNudge and,
-// if one was pending, appends it as a steering turn.
+// if one was pending, appends it as a steering turn. injectPostToolSteering
+// (session_tool_round.go) is the only call site: both detectors key off
+// StreamEventToolCallEnd, so a trip is only ever possible once at least one
+// tool call has completed, which means the round always has tool calls and
+// always reaches that function. Delivering there positions the nudge after the
+// tool results, so it never lands between a tool_use turn and its tool_result
+// -- providers that require them adjacent would reject the next request.
 func (s *Session) deliverPendingStreamLoopNudge(ctx context.Context) error {
-	_ = ctx
-	return nil
+	s.mu.Lock()
+	nudge := s.pendingStreamLoopNudge
+	s.pendingStreamLoopNudge = ""
+	s.mu.Unlock()
+	if nudge == "" {
+		return nil
+	}
+	return s.withResponseSideEffects(ctx, func() {
+		s.emit(events.EventLoopDetection, events.LoopDetectionData{Message: nudge})
+		s.appendSteeringTurn(nudge, events.SteeringKindStreamLoop)
+	})
 }
-
-var _ = fmt.Sprintf

--- a/agent/session_stream_loop_guard_delivery_test.go
+++ b/agent/session_stream_loop_guard_delivery_test.go
@@ -1,0 +1,100 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/schema"
+)
+
+// This file pins delivery of a stream-loop nudge queued by consumeModelStream
+// (session_stream.go) onto sess.pendingStreamLoopNudge: TestConsumeModelStream_*
+// already proves the field gets SET correctly; these tests prove it actually
+// reaches the transcript as a steering turn rather than sitting unread.
+//
+// In Phase 1 there is exactly one reachable delivery site. Both detectors
+// (cycle and ceiling) key off StreamEventToolCallEnd, so a trip is only ever
+// possible once at least one tool call has completed -- which means the round
+// always has tool calls and always reaches injectPostToolSteering. Delivering
+// there puts the nudge after tool results, so it never lands between a
+// tool_use turn and its tool_result (providers that require them adjacent
+// would reject the next request).
+
+// findSteeringTurnByKind returns the first history turn tagged with the given
+// SteeringKind. It searches by kind rather than "the last steering turn"
+// because a round that also exercises the pre-existing no-tool-calls retry
+// path appends its OWN steering turns around the one under test here.
+func findSteeringTurnByKind(sess *Session, kind string) (schema.Turn, bool) {
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	for _, turn := range sess.history {
+		if turn.Kind == schema.TurnSteering && turn.SteeringKind == kind {
+			return turn, true
+		}
+	}
+	return schema.Turn{}, false
+}
+
+// TestDeliverPendingStreamLoopNudge_AppendsAndClears drives the helper
+// directly: a pending nudge becomes a steering turn tagged
+// SteeringKindStreamLoop, and the field is cleared so it cannot be delivered
+// twice.
+func TestDeliverPendingStreamLoopNudge_AppendsAndClears(t *testing.T) {
+	sess := newSession(t)
+	sess.mu.Lock()
+	sess.pendingStreamLoopNudge = "you are repeating yourself"
+	sess.mu.Unlock()
+
+	if err := sess.deliverPendingStreamLoopNudge(context.Background()); err != nil {
+		t.Fatalf("deliverPendingStreamLoopNudge: %v", err)
+	}
+
+	turn, ok := findSteeringTurnByKind(sess, events.SteeringKindStreamLoop)
+	if !ok {
+		t.Fatal("no SteeringKindStreamLoop turn appended")
+	}
+	if !strings.Contains(turn.Message.Text(), "repeating yourself") {
+		t.Errorf("turn text = %q, want it to carry the nudge", turn.Message.Text())
+	}
+
+	sess.mu.Lock()
+	remaining := sess.pendingStreamLoopNudge
+	historyLen := len(sess.history)
+	sess.mu.Unlock()
+	if remaining != "" {
+		t.Errorf("pendingStreamLoopNudge = %q, want cleared after delivery", remaining)
+	}
+
+	// A second call with nothing pending must not append another turn.
+	if err := sess.deliverPendingStreamLoopNudge(context.Background()); err != nil {
+		t.Fatalf("second deliverPendingStreamLoopNudge: %v", err)
+	}
+	sess.mu.Lock()
+	got := len(sess.history)
+	sess.mu.Unlock()
+	if got != historyLen {
+		t.Errorf("history grew from %d to %d on an empty pending nudge, want no-op", historyLen, got)
+	}
+}
+
+// TestInjectPostToolSteering_DeliversStreamLoopNudge covers the has-tool-calls
+// path: injectPostToolSteering must deliver a pending stream-loop nudge the
+// same way it delivers the cross-round detector's own warning.
+func TestInjectPostToolSteering_DeliversStreamLoopNudge(t *testing.T) {
+	sess := newSession(t)
+	sess.mu.Lock()
+	sess.pendingStreamLoopNudge = "cut off after a repeating cycle"
+	sess.mu.Unlock()
+
+	var toolSigs []string
+	var toolSigFailed []bool
+	if _, err := sess.injectPostToolSteering(context.Background(), nil, nil, &toolSigs, &toolSigFailed); err != nil {
+		t.Fatalf("injectPostToolSteering: %v", err)
+	}
+
+	if _, ok := findSteeringTurnByKind(sess, events.SteeringKindStreamLoop); !ok {
+		t.Fatal("no SteeringKindStreamLoop turn appended")
+	}
+}

--- a/agent/session_stream_loop_guard_e2e_test.go
+++ b/agent/session_stream_loop_guard_e2e_test.go
@@ -109,16 +109,18 @@ func turnIndexOfSteeringKind(history []schema.Turn, kind string) int {
 	return -1
 }
 
-// countToolResults counts tool-result content parts across every tool-results
-// turn in history.
-func countToolResults(history []schema.Turn) int {
+// countToolResults counts tool-result content parts whose call ID carries the
+// given round prefix, across every tool-results turn in history. The prefix
+// scopes the count to one scripted round, so the recovery round's own
+// communicate result never inflates it.
+func countToolResults(history []schema.Turn, idPrefix string) int {
 	n := 0
 	for _, turn := range history {
 		if turn.Kind != schema.TurnToolResults {
 			continue
 		}
 		for _, part := range turn.Message.Content {
-			if part.Kind == llm.ContentToolResult {
+			if part.Kind == llm.ContentToolResult && part.ToolResult != nil && strings.HasPrefix(part.ToolResult.ToolCallID, idPrefix+"_") {
 				n++
 			}
 		}
@@ -154,7 +156,7 @@ func TestProcessInput_StreamLoopGuard_TripDispatchesNudgesAndRecovers(t *testing
 
 	// The 15 calls that streamed before the cut must have dispatched, not been
 	// discarded: a guard that threw the response away would leave zero.
-	if got := countToolResults(history); got != 15 {
+	if got := countToolResults(history, "r1"); got != 15 {
 		t.Fatalf("dispatched tool results = %d, want 15 (the calls streamed before the trip, all of them, and none of the 5 the fixture sent afterwards)", got)
 	}
 
@@ -162,17 +164,25 @@ func TestProcessInput_StreamLoopGuard_TripDispatchesNudgesAndRecovers(t *testing
 	if steerIdx < 0 {
 		t.Fatal("no SteeringKindStreamLoop turn in history: the trip's nudge never reached the model")
 	}
-	lastResultsIdx := -1
+	// The nudge must sit after the tripped round's OWN results, never between
+	// the tool_use turn that carried those calls and their tool_result turn:
+	// providers that require the two adjacent would reject the next request.
+	tripResultsIdx := -1
 	for i, turn := range history {
-		if turn.Kind == schema.TurnToolResults {
-			lastResultsIdx = i
+		if turn.Kind != schema.TurnToolResults {
+			continue
+		}
+		for _, part := range turn.Message.Content {
+			if part.Kind == llm.ContentToolResult && part.ToolResult != nil && strings.HasPrefix(part.ToolResult.ToolCallID, "r1_") {
+				tripResultsIdx = i
+			}
 		}
 	}
-	if lastResultsIdx < 0 {
-		t.Fatal("no TurnToolResults turn in history")
+	if tripResultsIdx < 0 {
+		t.Fatal("no TurnToolResults turn carries the tripped round's results")
 	}
-	if steerIdx < lastResultsIdx {
-		t.Fatalf("stream-loop steering turn at index %d, tool results at %d: the nudge must land AFTER the tool results, never between a tool_use turn and its tool_result", steerIdx, lastResultsIdx)
+	if steerIdx < tripResultsIdx {
+		t.Fatalf("stream-loop steering turn at index %d, tripped round's tool results at %d: the nudge must land AFTER the tool results, never between a tool_use turn and its tool_result", steerIdx, tripResultsIdx)
 	}
 
 	nudge := history[steerIdx].Message.Text()

--- a/agent/session_stream_loop_guard_e2e_test.go
+++ b/agent/session_stream_loop_guard_e2e_test.go
@@ -1,0 +1,355 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/llm"
+)
+
+// The ported consumeModelStream tests all drive one function call in
+// isolation. These drive whole turns through ProcessInput instead, which is
+// the only way to prove the four things the unit level cannot see: that the
+// tool calls streamed before a tier-1 trip actually dispatch, that the pending
+// nudge reaches message history as a steering turn positioned after those tool
+// results, that the NEXT request carries it, and that a session survives a
+// tier-2 hard stop and accepts a later turn normally.
+
+// loopProbeTools are three registered no-op tools whose names form the k=3
+// cycle the primary captured incident had. Real tool names (rather than
+// communicate/manage_worktree) keep dispatch under the test's control: the
+// result tool would end the turn, which is not what a runaway does.
+var loopProbeTools = []string{"probe_alpha", "probe_beta", "probe_gamma"}
+
+// registerLoopProbeTools registers loopProbeTools as no-ops so the calls a
+// tripping round streams actually dispatch and produce tool results.
+func registerLoopProbeTools(sess *Session) {
+	for _, name := range loopProbeTools {
+		sess.RegisterTool(name, "no-op probe for the stream loop guard", map[string]any{
+			"type":                 "object",
+			"additionalProperties": true,
+		}, func(context.Context, any) (any, error) { return "ok", nil })
+	}
+}
+
+// scriptedRounds answers each successive Stream call with the next script in
+// the list, repeating the last one once the list runs out. The counter is the
+// per-call sequencer these turn-level tests need: one adapter serves every
+// round of every turn, and which round it is decides what the model "says".
+type scriptedRounds struct {
+	mu     sync.Mutex
+	n      int
+	rounds []func(*llm.ChanStream)
+}
+
+func (r *scriptedRounds) stream(st *llm.ChanStream) {
+	r.mu.Lock()
+	i := r.n
+	r.n++
+	r.mu.Unlock()
+	if i >= len(r.rounds) {
+		i = len(r.rounds) - 1
+	}
+	r.rounds[i](st)
+}
+
+func (r *scriptedRounds) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.n
+}
+
+// streamCycleTrip scripts one runaway response: the loopProbeTools cycle,
+// repeated past the 15-call trip point. It sends 20 calls, so a guard that
+// failed to stop the stream would dispatch 20 rather than 15 — the count is
+// the assertion that the cut happened at the right place, not merely that it
+// happened. idPrefix keeps tool-call IDs unique across rounds within one
+// session's history.
+func streamCycleTrip(idPrefix string) func(*llm.ChanStream) {
+	return func(st *llm.ChanStream) {
+		for i := range 20 {
+			name := loopProbeTools[i%len(loopProbeTools)]
+			id := idPrefix + "_" + itoaTest(i)
+			args := []byte(`{"probe":"` + name + `"}`)
+			st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallStart, ToolCall: &llm.ToolCallData{ID: id, Name: name, Type: "function"}})
+			st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallDelta, ToolCall: &llm.ToolCallData{ID: id, Arguments: args}})
+			st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallEnd, ToolCall: &llm.ToolCallData{ID: id, Name: name, Arguments: args}})
+		}
+		st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &llm.FinishReason{Reason: llm.FinishReasonToolCalls}})
+	}
+}
+
+// loopGuardSession wires a scripted-round adapter into a transcript-backed
+// session with the probe tools registered.
+func loopGuardSession(t *testing.T, rounds *scriptedRounds, fallbacks ...string) (*Session, *scriptedStreamAdapter) {
+	t.Helper()
+	a := &scriptedStreamAdapter{
+		provider: "openai",
+		script:   map[string]func(*llm.ChanStream){"primary": rounds.stream},
+	}
+	sess := settlementSession(t, a, fallbacks...)
+	registerLoopProbeTools(sess)
+	drainSessionEvents(sess)
+	return sess, a
+}
+
+// turnIndexOfSteeringKind returns the history index of the first steering turn
+// with the given kind, or -1.
+func turnIndexOfSteeringKind(history []schema.Turn, kind string) int {
+	for i, turn := range history {
+		if turn.Kind == schema.TurnSteering && turn.SteeringKind == kind {
+			return i
+		}
+	}
+	return -1
+}
+
+// countToolResults counts tool-result content parts across every tool-results
+// turn in history.
+func countToolResults(history []schema.Turn) int {
+	n := 0
+	for _, turn := range history {
+		if turn.Kind != schema.TurnToolResults {
+			continue
+		}
+		for _, part := range turn.Message.Content {
+			if part.Kind == llm.ContentToolResult {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// TestProcessInput_StreamLoopGuard_TripDispatchesNudgesAndRecovers is the
+// end-to-end shape the whole guard exists to produce: round 1 runs away, the
+// guard cuts it at a legal boundary, the calls it already streamed still
+// dispatch, the nudge lands as a steering turn AFTER those results, the next
+// request carries it, and round 2 completes cleanly with the streak back to
+// zero.
+func TestProcessInput_StreamLoopGuard_TripDispatchesNudgesAndRecovers(t *testing.T) {
+	rounds := &scriptedRounds{rounds: []func(*llm.ChanStream){
+		streamCycleTrip("r1"),
+		streamCommunicate("stopped repeating, here is the answer"),
+	}}
+	sess, a := loopGuardSession(t, rounds)
+
+	out, err := sess.ProcessInput(context.Background(), "go", nil)
+	if err != nil {
+		t.Fatalf("ProcessInput: %v", err)
+	}
+	if !strings.Contains(out, "stopped repeating") {
+		t.Fatalf("ProcessInput output = %q, want the round-2 answer", out)
+	}
+	if got := rounds.count(); got != 2 {
+		t.Fatalf("model called %d times, want exactly 2 (the tripped round, then the recovery round)", got)
+	}
+
+	history := sessionHistory(sess)
+
+	// The 15 calls that streamed before the cut must have dispatched, not been
+	// discarded: a guard that threw the response away would leave zero.
+	if got := countToolResults(history); got != 15 {
+		t.Fatalf("dispatched tool results = %d, want 15 (the calls streamed before the trip, all of them, and none of the 5 the fixture sent afterwards)", got)
+	}
+
+	steerIdx := turnIndexOfSteeringKind(history, events.SteeringKindStreamLoop)
+	if steerIdx < 0 {
+		t.Fatal("no SteeringKindStreamLoop turn in history: the trip's nudge never reached the model")
+	}
+	lastResultsIdx := -1
+	for i, turn := range history {
+		if turn.Kind == schema.TurnToolResults {
+			lastResultsIdx = i
+		}
+	}
+	if lastResultsIdx < 0 {
+		t.Fatal("no TurnToolResults turn in history")
+	}
+	if steerIdx < lastResultsIdx {
+		t.Fatalf("stream-loop steering turn at index %d, tool results at %d: the nudge must land AFTER the tool results, never between a tool_use turn and its tool_result", steerIdx, lastResultsIdx)
+	}
+
+	nudge := history[steerIdx].Message.Text()
+	if !containsAll(nudge, loopProbeTools[0], loopProbeTools[1], loopProbeTools[2]) {
+		t.Fatalf("nudge = %q, want it to name the repeated calls", nudge)
+	}
+
+	// The next request must actually carry the nudge, not merely have it sitting
+	// in history behind some filter.
+	reqs := a.Requests()
+	if len(reqs) < 2 {
+		t.Fatalf("adapter saw %d requests, want at least 2", len(reqs))
+	}
+	if next := modelVisibleText(reqs[1]); !strings.Contains(next, nudge) {
+		t.Fatalf("second request does not carry the nudge.\nnudge: %q\nrequest text: %q", nudge, next)
+	}
+
+	sess.mu.Lock()
+	streak := sess.streamLoopTripStreak
+	pending := sess.pendingStreamLoopNudge
+	sess.mu.Unlock()
+	if streak != 0 {
+		t.Fatalf("streamLoopTripStreak = %d after the clean recovery round, want 0", streak)
+	}
+	if pending != "" {
+		t.Fatalf("pendingStreamLoopNudge = %q after delivery, want empty", pending)
+	}
+}
+
+// TestProcessInput_StreamLoopGuard_HardStopEndsTurnAndSessionSurvives covers
+// the tier-2 path at turn level. Two consecutive tripping rounds inside ONE
+// turn must surface the hard stop out of ProcessInput itself rather than being
+// swallowed. The second turn is the real point: it opens with another tripping
+// round, and it must get a tier-1 nudge and recover — which is only possible
+// if the streak was zeroed at turn start. Without that reset the streak is
+// still 2 from the hard stop, the first trip of turn 2 escalates straight to
+// tier 2, and the session is permanently one trip away from failing every
+// turn.
+func TestProcessInput_StreamLoopGuard_HardStopEndsTurnAndSessionSurvives(t *testing.T) {
+	rounds := &scriptedRounds{rounds: []func(*llm.ChanStream){
+		streamCycleTrip("t1r1"),
+		streamCycleTrip("t1r2"),
+		streamCycleTrip("t2r1"),
+		streamCommunicate("recovered on the second turn"),
+	}}
+	sess, _ := loopGuardSession(t, rounds)
+
+	_, err := sess.ProcessInput(context.Background(), "go", nil)
+	if err == nil {
+		t.Fatal("ProcessInput returned nil after two consecutive tripping rounds, want the hard-stop error")
+	}
+	var loopStop *streamLoopHardStopError
+	if !errors.As(err, &loopStop) {
+		t.Fatalf("ProcessInput error = %v, want it to wrap *streamLoopHardStopError", err)
+	}
+	var le llm.Error
+	if !errors.As(err, &le) {
+		t.Fatalf("ProcessInput error %v does not satisfy llm.Error", err)
+	}
+	if le.Retryable() {
+		t.Fatal("hard-stop error is Retryable() == true, want false")
+	}
+
+	// The session must still be usable. Turn 2 trips once more, which is a
+	// FIRST trip again, so it earns a nudge and recovers.
+	out, err := sess.ProcessInput(context.Background(), "try again", nil)
+	if err != nil {
+		t.Fatalf("second ProcessInput after a hard stop: %v (a hard stop must end its turn, not the session)", err)
+	}
+	if !strings.Contains(out, "recovered on the second turn") {
+		t.Fatalf("second turn output = %q, want the recovery answer", out)
+	}
+	if got := rounds.count(); got != 4 {
+		t.Fatalf("model called %d times, want exactly 4 (two tripping rounds, then a trip and a recovery)", got)
+	}
+
+	sess.mu.Lock()
+	streak := sess.streamLoopTripStreak
+	sess.mu.Unlock()
+	if streak != 0 {
+		t.Fatalf("streamLoopTripStreak = %d after the recovery round, want 0", streak)
+	}
+}
+
+// TestProcessInput_StreamLoopGuard_TurnStartResetsStreakAndNudge observes the
+// reset directly rather than through its consequences. The adapter's script
+// runs after processOneInput's turn-start block, so reading the two fields
+// from inside the script is a read at exactly the moment the round loop is
+// about to begin.
+func TestProcessInput_StreamLoopGuard_TurnStartResetsStreakAndNudge(t *testing.T) {
+	var sess *Session
+	var streakAtEntry int
+	var nudgeAtEntry string
+	rounds := &scriptedRounds{rounds: []func(*llm.ChanStream){
+		func(st *llm.ChanStream) {
+			sess.mu.Lock()
+			streakAtEntry = sess.streamLoopTripStreak
+			nudgeAtEntry = sess.pendingStreamLoopNudge
+			sess.mu.Unlock()
+			streamCommunicate("fine")(st)
+		},
+	}}
+	sess, _ = loopGuardSession(t, rounds)
+
+	// State left over from an earlier turn that ended in a hard stop.
+	sess.mu.Lock()
+	sess.streamLoopTripStreak = 2
+	sess.pendingStreamLoopNudge = "stale nudge from a turn that is over"
+	sess.mu.Unlock()
+
+	if _, err := sess.ProcessInput(context.Background(), "go", nil); err != nil {
+		t.Fatalf("ProcessInput: %v", err)
+	}
+
+	if streakAtEntry != 0 {
+		t.Fatalf("streamLoopTripStreak at round-loop entry = %d, want 0 (a hard stop returns before the clean-completion reset can run, so the turn start has to do it)", streakAtEntry)
+	}
+	if nudgeAtEntry != "" {
+		t.Fatalf("pendingStreamLoopNudge at round-loop entry = %q, want empty (a nudge that missed its own turn lands out of context in an unrelated one)", nudgeAtEntry)
+	}
+	if _, ok := findSteeringTurnByKind(sess, events.SteeringKindStreamLoop); ok {
+		t.Fatal("a stale nudge was delivered as a steering turn in an unrelated turn")
+	}
+}
+
+// TestProcessInput_StreamLoopGuard_HardStopSkipsModelFallbacks is the
+// fallback-ineligibility fix proven end to end. A hard stop classifies as
+// ErrorClassPermanent, which modelFallbackEligible otherwise reads as "walk to
+// the next model" — re-running the exact request that produced the runaway
+// against every configured fallback, which is precisely what the hard stop
+// exists to prevent.
+func TestProcessInput_StreamLoopGuard_HardStopSkipsModelFallbacks(t *testing.T) {
+	rounds := &scriptedRounds{rounds: []func(*llm.ChanStream){
+		streamCycleTrip("r1"),
+		streamCycleTrip("r2"),
+	}}
+	sess, a := loopGuardSession(t, rounds, "fallback-b", "fallback-c")
+
+	_, err := sess.ProcessInput(context.Background(), "go", nil)
+	if err == nil {
+		t.Fatal("ProcessInput returned nil, want the hard-stop error")
+	}
+	// Assert the turn ended for the reason under test. A round loop that
+	// simply ran out of rounds also returns an error, which would let this
+	// test pass without a guard at all.
+	var loopStop *streamLoopHardStopError
+	if !errors.As(err, &loopStop) {
+		t.Fatalf("ProcessInput error = %v, want it to wrap *streamLoopHardStopError", err)
+	}
+
+	for _, model := range a.Models() {
+		if model != "primary" {
+			t.Fatalf("the fallback chain walked to %q after a loop-guard hard stop (models: %v); the hard stop must not be fallback-eligible", model, a.Models())
+		}
+	}
+}
+
+// TestModelFallbackEligible_StreamLoopHardStop is the narrow unit mirror of
+// TestModelFallbackEligible_ProviderUnhealthy: the marker type must be
+// excluded before llm.Classify runs, since the wrapped cause classifies
+// permanent and permanent is otherwise eligible.
+func TestModelFallbackEligible_StreamLoopHardStop(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"Bare", &streamLoopHardStopError{cause: llm.NewPermanentStreamError("openai", "loop guard: cycle", nil)}},
+		{"Wrapped", errors.Join(errors.New("provider error"), &streamLoopHardStopError{cause: llm.NewPermanentStreamError("openai", "loop guard: ceiling", nil)})},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if llm.Classify(tc.err) != llm.ErrorClassPermanent {
+				t.Fatalf("Classify(%v) = %v, want ErrorClassPermanent (the arm under test is only load-bearing because permanent is otherwise eligible)", tc.err, llm.Classify(tc.err))
+			}
+			if modelFallbackEligible(tc.err, llm.DefaultRetryPolicy()) {
+				t.Fatalf("modelFallbackEligible(%v) = true, want false", tc.err)
+			}
+		})
+	}
+}

--- a/agent/session_stream_loop_guard_e2e_test.go
+++ b/agent/session_stream_loop_guard_e2e_test.go
@@ -109,23 +109,24 @@ func turnIndexOfSteeringKind(history []schema.Turn, kind string) int {
 	return -1
 }
 
-// countToolResults counts tool-result content parts whose call ID carries the
-// given round prefix, across every tool-results turn in history. The prefix
-// scopes the count to one scripted round, so the recovery round's own
-// communicate result never inflates it.
-func countToolResults(history []schema.Turn, idPrefix string) int {
-	n := 0
-	for _, turn := range history {
+// roundToolResults reports how many tool results one scripted round produced
+// and the history index of the last turn carrying them. Results are matched by
+// the round's call-ID prefix, so a later round's own results never inflate the
+// count or move the index.
+func roundToolResults(history []schema.Turn, idPrefix string) (count, lastTurnIdx int) {
+	lastTurnIdx = -1
+	for i, turn := range history {
 		if turn.Kind != schema.TurnToolResults {
 			continue
 		}
 		for _, part := range turn.Message.Content {
 			if part.Kind == llm.ContentToolResult && part.ToolResult != nil && strings.HasPrefix(part.ToolResult.ToolCallID, idPrefix+"_") {
-				n++
+				count++
+				lastTurnIdx = i
 			}
 		}
 	}
-	return n
+	return count, lastTurnIdx
 }
 
 // TestProcessInput_StreamLoopGuard_TripDispatchesNudgesAndRecovers is the
@@ -156,8 +157,9 @@ func TestProcessInput_StreamLoopGuard_TripDispatchesNudgesAndRecovers(t *testing
 
 	// The 15 calls that streamed before the cut must have dispatched, not been
 	// discarded: a guard that threw the response away would leave zero.
-	if got := countToolResults(history, "r1"); got != 15 {
-		t.Fatalf("dispatched tool results = %d, want 15 (the calls streamed before the trip, all of them, and none of the 5 the fixture sent afterwards)", got)
+	dispatched, tripResultsIdx := roundToolResults(history, "r1")
+	if dispatched != 15 {
+		t.Fatalf("dispatched tool results = %d, want 15 (the calls streamed before the trip, all of them, and none of the 5 the fixture sent afterwards)", dispatched)
 	}
 
 	steerIdx := turnIndexOfSteeringKind(history, events.SteeringKindStreamLoop)
@@ -167,20 +169,6 @@ func TestProcessInput_StreamLoopGuard_TripDispatchesNudgesAndRecovers(t *testing
 	// The nudge must sit after the tripped round's OWN results, never between
 	// the tool_use turn that carried those calls and their tool_result turn:
 	// providers that require the two adjacent would reject the next request.
-	tripResultsIdx := -1
-	for i, turn := range history {
-		if turn.Kind != schema.TurnToolResults {
-			continue
-		}
-		for _, part := range turn.Message.Content {
-			if part.Kind == llm.ContentToolResult && part.ToolResult != nil && strings.HasPrefix(part.ToolResult.ToolCallID, "r1_") {
-				tripResultsIdx = i
-			}
-		}
-	}
-	if tripResultsIdx < 0 {
-		t.Fatal("no TurnToolResults turn carries the tripped round's results")
-	}
 	if steerIdx < tripResultsIdx {
 		t.Fatalf("stream-loop steering turn at index %d, tripped round's tool results at %d: the nudge must land AFTER the tool results, never between a tool_use turn and its tool_result", steerIdx, tripResultsIdx)
 	}

--- a/agent/session_stream_loop_guard_fixtures_test.go
+++ b/agent/session_stream_loop_guard_fixtures_test.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"fmt"
+	"testing"
+)
+
+// toolSig is a plain (name, args) pair -- the same shape observeToolCall
+// takes -- used to build the synthetic fixtures shared by the loop-guard
+// unit tests and its consumeModelStream integration tests.
+type toolSig struct{ name, args string }
+
+// buildEightyThreeCallNoCycleFixture reconstructs issue #94's second measured
+// shape honestly: "83 calls / 48 distinct signatures / max repeat 12". The
+// captured stream itself is not in the repo, so this is a synthetic stand-in
+// built to the documented statistics, NOT a byte-for-byte replay.
+//
+// Construction: one "heavy" signature H repeats 12 times at absolute
+// positions 0,7,14,...,77 (gap 7, so it can never appear more than once in
+// any window the cycle detector examines -- max window is k*R=25). The other
+// 71 positions cycle through 47 distinct filler signatures in round-robin
+// order (period 47, far above the max cycle length of 5). Total: 12 + 71 =
+// 83 calls, 1 + 47 = 48 distinct signatures, max repeat = 12.
+//
+// Note this is an approximation of the captured incident's exact texture
+// (which interleaving pattern the real 48-signature/83-call stream actually
+// used is unknown -- only the three summary statistics were recorded), built
+// specifically to avoid the one property that would make the fixture beg the
+// question: it must not contain a short cycle, or the cycle detector would
+// trip it "by accident" and the test would prove nothing about the ceiling.
+func buildEightyThreeCallNoCycleFixture(t *testing.T) []toolSig {
+	t.Helper()
+	const total = 83
+	const heavyCount = 12
+	const heavyGap = 7 // 0,7,...,77 -> 12 positions, all < 83
+
+	heavy := toolSig{name: "manage_worktree", args: `{"op":"status"}`}
+	fillers := make([]toolSig, 47)
+	for i := range fillers {
+		fillers[i] = toolSig{name: fmt.Sprintf("tool_%02d", i), args: fmt.Sprintf(`{"call":%d}`, i)}
+	}
+
+	heavyPositions := make(map[int]bool, heavyCount)
+	for i := range heavyCount {
+		heavyPositions[i*heavyGap] = true
+	}
+
+	sigs := make([]toolSig, 0, total)
+	fillerIdx := 0
+	for pos := range total {
+		if heavyPositions[pos] {
+			sigs = append(sigs, heavy)
+			continue
+		}
+		sigs = append(sigs, fillers[fillerIdx%len(fillers)])
+		fillerIdx++
+	}
+
+	if got := countDistinctSigs(sigs); got != 48 {
+		t.Fatalf("fixture generator bug: %d distinct signatures, want 48", got)
+	}
+	if got := maxRepeatCount(sigs); got != heavyCount {
+		t.Fatalf("fixture generator bug: max repeat = %d, want %d", got, heavyCount)
+	}
+	if len(sigs) != total {
+		t.Fatalf("fixture generator bug: %d calls, want %d", len(sigs), total)
+	}
+	return sigs
+}
+
+func countDistinctSigs(sigs []toolSig) int {
+	seen := map[string]bool{}
+	for _, s := range sigs {
+		seen[s.name+":"+s.args] = true
+	}
+	return len(seen)
+}
+
+func maxRepeatCount(sigs []toolSig) int {
+	counts := map[string]int{}
+	maxCount := 0
+	for _, s := range sigs {
+		key := s.name + ":" + s.args
+		counts[key]++
+		if counts[key] > maxCount {
+			maxCount = counts[key]
+		}
+	}
+	return maxCount
+}
+
+// assertNoShortCycleAnywhere offline-checks every suffix of sigs for a
+// k=1..5 pattern repeated 5 times consecutively, using the same window
+// arithmetic checkCycle uses. It exists so the ceiling-fixture test's claim
+// ("this shape has no short cycle by construction") is verified mechanically
+// rather than trusted from the construction's math alone.
+func assertNoShortCycleAnywhere(t *testing.T, sigs []toolSig) {
+	t.Helper()
+	g := newStreamLoopGuard()
+	for i, s := range sigs {
+		g.sigs = append(g.sigs, s.name+":"+s.args)
+		if trip := g.checkCycle(); trip != nil {
+			t.Fatalf("fixture contains a short cycle at call %d: %+v (fixture is invalid for the ceiling-only test)", i+1, trip)
+		}
+	}
+}

--- a/agent/session_stream_loop_guard_integration_test.go
+++ b/agent/session_stream_loop_guard_integration_test.go
@@ -57,6 +57,11 @@ func runConsumeModelStream(t *testing.T, sess *Session, req llm.Request, st llm.
 	select {
 	case o := <-done:
 		return o.resp, o.obs, o.err
+	// TRIPWIRE: every fixture here is in-memory and returns in single-digit
+	// milliseconds, so 5s is three orders of magnitude of headroom. It is not
+	// the correctness signal — the assertions after the select are — but a
+	// guard that fails to stop an unbounded stream hangs forever with no other
+	// signal to await, which is the failure this bound exists to report.
 	case <-time.After(5 * time.Second):
 		t.Fatal("consumeModelStream did not return; the guard did not stop the stream")
 		return sessionModelResponse{}, attemptObservation{}, nil
@@ -199,6 +204,43 @@ func TestConsumeModelStream_LoopGuard_EighteenDistinctCalls_NoTrip(t *testing.T)
 	}
 	if streak != 0 {
 		t.Fatalf("streamLoopTripStreak = %d, want 0", streak)
+	}
+}
+
+// TestConsumeModelStream_LoopGuard_StateDoesNotCarryAcrossResponses pins the
+// guard's scope: one instance per consumeModelStream attempt, never shared.
+// The hole it closes is specifically that nothing bounds ONE response, so
+// counting across responses would re-invent the between-responses blindness it
+// exists to fix -- two legitimate 30-call rounds in one session would trip the
+// ceiling on the second, having never come near it within either.
+func TestConsumeModelStream_LoopGuard_StateDoesNotCarryAcrossResponses(t *testing.T) {
+	sess := newSession(t)
+	req := llm.Request{Provider: "openai", Model: "gpt-5.2"}
+	const perRound = 30 // comfortably under the 50 ceiling alone, over it combined
+	feedDistinct := func(st *llm.ChanStream, round int) func() {
+		return func() {
+			for i := range perRound {
+				sendToolCall(st, callID(round*perRound+i), distinctToolName(i), `{"round":`+itoaTest(round)+`,"n":`+itoaTest(i)+`}`)
+			}
+			st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &llm.FinishReason{Reason: llm.FinishReasonToolCalls}})
+			st.CloseSend()
+		}
+	}
+	for round := range 2 {
+		st := llm.NewChanStream(nil)
+		resp, _, err := runConsumeModelStream(t, sess, req, st, feedDistinct(st, round))
+		if err != nil {
+			t.Fatalf("round %d: err = %v, want nil", round, err)
+		}
+		if got := len(resp.Response.ToolCalls()); got != perRound {
+			t.Fatalf("round %d: got %d tool calls, want %d (nothing truncated)", round, got, perRound)
+		}
+		sess.mu.Lock()
+		nudge := sess.pendingStreamLoopNudge
+		sess.mu.Unlock()
+		if nudge != "" {
+			t.Fatalf("round %d: pendingStreamLoopNudge = %q, want empty: %d distinct calls is well under the ceiling, and the guard must not be counting the previous response's calls", round, nudge, perRound)
+		}
 	}
 }
 

--- a/agent/session_stream_loop_guard_integration_test.go
+++ b/agent/session_stream_loop_guard_integration_test.go
@@ -1,0 +1,375 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/llm"
+)
+
+// This file drives the loop guard through consumeModelStream itself (issue
+// #94's integration point: "agent/session_stream.go region"), reconstructing
+// the documented runaway shapes as synthetic streams. The captured streams are
+// not in the repo; these are honest synthetic stand-ins built to the
+// documented shapes, not replays.
+//
+// Every scenario here runs consumeModelStream in a goroutine (started before
+// or concurrently with feeding events, so a fixture larger than
+// llm.NewChanStream's 128-event buffer never deadlocks the producer) with a
+// bounded timeout as a tripwire against a genuine hang. Every feed closure
+// calls st.CloseSend() once it is done sending, even the ones that
+// deliberately send only a PARTIAL fixture (fewer calls than the shape's
+// documented total): consumeModelStream's own deferred st.Close() blocks on
+// the producer side closing (llm.ChanStream.Close's documented contract), so
+// withholding CloseSend would hang consumeModelStream in its own cleanup
+// regardless of whether the guard tripped correctly -- a false failure, not
+// a signal. A partial feed plus an early CloseSend still proves the guard
+// stopped consuming early: an un-tripped implementation drains the partial
+// channel, sees it closed, and returns the "stream ended without finish
+// event" error instead of hanging, which the tests below assert against
+// directly (err == nil) rather than relying on a timeout to catch it.
+
+// runConsumeModelStream starts consumeModelStream on st in a goroutine, then
+// runs feed (typically a series of st.Send calls, ending in st.CloseSend())
+// on the calling goroutine, then waits up to 5s for consumeModelStream to
+// return -- failing the test on timeout as a last-resort tripwire, not the
+// primary correctness signal. Starting the consumer before or during feed
+// means a fixture larger than the stream's buffered channel capacity cannot
+// deadlock: Send blocks only until the concurrently-running consumer drains
+// it.
+func runConsumeModelStream(t *testing.T, sess *Session, req llm.Request, st llm.Stream, feed func()) (sessionModelResponse, attemptObservation, error) {
+	t.Helper()
+	type outcome struct {
+		resp sessionModelResponse
+		obs  attemptObservation
+		err  error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		resp, obs, err := sess.consumeModelStream(context.Background(), req, st)
+		done <- outcome{resp, obs, err}
+	}()
+	if feed != nil {
+		feed()
+	}
+	select {
+	case o := <-done:
+		return o.resp, o.obs, o.err
+	case <-time.After(5 * time.Second):
+		t.Fatal("consumeModelStream did not return; the guard did not stop the stream")
+		return sessionModelResponse{}, attemptObservation{}, nil
+	}
+}
+
+// sendToolCall writes a minimal Start+End pair for one completed tool call --
+// the shape TestConsumeModelStream_Observation_ToolCallEndOnlyThenError pins
+// as a real provider emission (google's adapter skips Delta entirely).
+func sendToolCall(st *llm.ChanStream, id, name, args string) {
+	st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallStart, ToolCall: &llm.ToolCallData{ID: id, Name: name}})
+	st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallEnd, ToolCall: &llm.ToolCallData{ID: id, Arguments: []byte(args)}})
+}
+
+// cyclePattern is the primary captured incident's shape: a k=3 cycle of
+// (manage_worktree, task_list, communicate).
+func cyclePattern() []toolSig {
+	return []toolSig{
+		{"manage_worktree", `{"op":"list"}`},
+		{"task_list", `{}`},
+		{"communicate", `{"message":"still working","end_turn":false}`},
+	}
+}
+
+// TestConsumeModelStream_LoopGuard_CycleShape is fixture (a): (manage_worktree,
+// task_list, communicate) repeating -- a k=3 cycle -- reconstructing the
+// primary captured incident (228 calls from 4 argument blocks, x76). The
+// fixture only sends 20 calls' worth of events (well short of 76 repeats): if
+// the guard works, it never needs the rest.
+func TestConsumeModelStream_LoopGuard_CycleShape(t *testing.T) {
+	sess := newSession(t)
+	req := llm.Request{Provider: "openai", Model: "gpt-5.2"}
+	st := llm.NewChanStream(nil)
+
+	pattern := cyclePattern()
+	const sent = 20 // well past the 15-call trip point, short of the real incident's 228
+	// Sends only a partial fixture (20 of the shape's 228 calls), then closes
+	// the producer: consumeModelStream must stop consuming — and act on the
+	// trip — using only the first 15, never touching (let alone needing) the
+	// remaining 5 this fixture still provides.
+	resp, _, err := runConsumeModelStream(t, sess, req, st, func() {
+		for i := range sent {
+			p := pattern[i%3]
+			sendToolCall(st, callID(i), p.name, p.args)
+		}
+		st.CloseSend()
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil (a tier-1 trip forces a clean finish, not an error)", err)
+	}
+	calls := resp.Response.ToolCalls()
+	if len(calls) != 15 {
+		t.Fatalf("got %d tool calls, want exactly 15 (trip fires at the 5th repeat of the 3-call cycle)", len(calls))
+	}
+	for i, c := range calls {
+		want := pattern[i%3]
+		if c.Name != want.name || string(c.Arguments) != want.args {
+			t.Fatalf("call %d = %+v, want name=%q args=%q (no truncation/corruption at the cut point)", i, c, want.name, want.args)
+		}
+	}
+	if resp.Response.Finish.Reason != llm.FinishReasonToolCalls {
+		t.Fatalf("Finish.Reason = %q, want %q (a legal boundary: calls are complete, not cut mid-arguments)", resp.Response.Finish.Reason, llm.FinishReasonToolCalls)
+	}
+
+	sess.mu.Lock()
+	nudge := sess.pendingStreamLoopNudge
+	streak := sess.streamLoopTripStreak
+	sess.mu.Unlock()
+	if nudge == "" {
+		t.Fatal("pendingStreamLoopNudge is empty, want a nudge naming the repeated call")
+	}
+	if !containsAll(nudge, "manage_worktree", "task_list", "communicate") {
+		t.Fatalf("nudge = %q, want it to name the repeated calls", nudge)
+	}
+	if streak != 1 {
+		t.Fatalf("streamLoopTripStreak = %d, want 1 (first trip)", streak)
+	}
+}
+
+// TestConsumeModelStream_LoopGuard_CeilingShape is fixture (b): 83 calls, 48
+// distinct signatures, max repeat 12, built with no period-1..5 cycle
+// anywhere (see buildEightyThreeCallNoCycleFixture). Records which detector
+// actually catches it.
+func TestConsumeModelStream_LoopGuard_CeilingShape(t *testing.T) {
+	sess := newSession(t)
+	req := llm.Request{Provider: "openai", Model: "gpt-5.2"}
+	st := llm.NewChanStream(nil)
+
+	sigs := buildEightyThreeCallNoCycleFixture(t)
+	resp, _, err := runConsumeModelStream(t, sess, req, st, func() {
+		for i, s := range sigs {
+			sendToolCall(st, callID(i), s.name, s.args)
+		}
+		st.CloseSend()
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	calls := resp.Response.ToolCalls()
+	if len(calls) != loopGuardRawCeiling {
+		t.Fatalf("got %d tool calls, want exactly %d (the ceiling, since this fixture has no short cycle)", len(calls), loopGuardRawCeiling)
+	}
+	sess.mu.Lock()
+	nudge := sess.pendingStreamLoopNudge
+	sess.mu.Unlock()
+	if !containsAll(nudge, "50") {
+		t.Fatalf("nudge = %q, want it to name the ceiling count", nudge)
+	}
+	t.Logf("shape (b) 83-call/48-distinct/max-repeat-12 fixture: caught by the CEILING detector at call %d, not the cycle detector", len(calls))
+}
+
+// TestConsumeModelStream_LoopGuard_EighteenDistinctCalls_NoTrip is fixture
+// (d): a legitimate round of 18 distinct tool calls must complete normally,
+// with a real StreamEventFinish -- the field's documented false positive
+// (odysseus #3185).
+func TestConsumeModelStream_LoopGuard_EighteenDistinctCalls_NoTrip(t *testing.T) {
+	sess := newSession(t)
+	req := llm.Request{Provider: "openai", Model: "gpt-5.2"}
+	st := llm.NewChanStream(nil)
+
+	resp, _, err := runConsumeModelStream(t, sess, req, st, func() {
+		for i := range 18 {
+			sendToolCall(st, callID(i), distinctToolName(i), `{"n":`+itoaTest(i)+`}`)
+		}
+		st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &llm.FinishReason{Reason: llm.FinishReasonToolCalls}})
+		st.CloseSend()
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if len(resp.Response.ToolCalls()) != 18 {
+		t.Fatalf("got %d tool calls, want 18 (nothing truncated)", len(resp.Response.ToolCalls()))
+	}
+	sess.mu.Lock()
+	nudge := sess.pendingStreamLoopNudge
+	streak := sess.streamLoopTripStreak
+	sess.mu.Unlock()
+	if nudge != "" {
+		t.Fatalf("pendingStreamLoopNudge = %q, want empty: 18 distinct calls must never trip", nudge)
+	}
+	if streak != 0 {
+		t.Fatalf("streamLoopTripStreak = %d, want 0", streak)
+	}
+}
+
+// TestConsumeModelStream_LoopGuard_DefersUntilParallelCallCloses is the
+// "never cut mid-arguments" safety property applied to the case the plain
+// per-call check misses: a trip detected at one tool call's End must not
+// force a finish while a DIFFERENT, still-open parallel call (Started but
+// not yet Ended -- real providers stream parallel tool calls with
+// interleaved deltas across multiple call IDs) is in flight, or the forced
+// finish would freeze that call's arguments mid-stream into the response.
+func TestConsumeModelStream_LoopGuard_DefersUntilParallelCallCloses(t *testing.T) {
+	sess := newSession(t)
+	req := llm.Request{Provider: "openai", Model: "gpt-5.2"}
+	st := llm.NewChanStream(nil)
+
+	pattern := cyclePattern()
+	resp, _, err := runConsumeModelStream(t, sess, req, st, func() {
+		// 14 calls of the cycle (not yet tripped: need=15).
+		for i := range 14 {
+			p := pattern[i%3]
+			sendToolCall(st, callID(i), p.name, p.args)
+		}
+		// Open a distinct, parallel call and leave it mid-arguments.
+		st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallStart, ToolCall: &llm.ToolCallData{ID: "extra", Name: "long_running_call"}})
+		st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallDelta, ToolCall: &llm.ToolCallData{ID: "extra", Arguments: []byte(`{"partial":`)}})
+		// The 15th cycle call: this is where the trip would fire, but "extra" is
+		// still open.
+		p := pattern[14%3]
+		sendToolCall(st, callID(14), p.name, p.args)
+		// More time passes for the parallel call, still open.
+		st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallDelta, ToolCall: &llm.ToolCallData{ID: "extra", Arguments: []byte(`true}`)}})
+		// Now it closes -- this is the first legal boundary after the trip.
+		st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallEnd, ToolCall: &llm.ToolCallData{ID: "extra", Arguments: []byte(`{"partial":true}`)}})
+		st.CloseSend()
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	calls := resp.Response.ToolCalls()
+	if len(calls) != 16 {
+		t.Fatalf("got %d tool calls, want exactly 16 (15 cycle calls + the parallel call, all complete)", len(calls))
+	}
+	for _, c := range calls {
+		if c.ID == "extra" {
+			if string(c.Arguments) != `{"partial":true}` {
+				t.Fatalf(`"extra" call arguments = %q, want the COMPLETE %q -- a forced finish while it was still open would have frozen it mid-argument`, c.Arguments, `{"partial":true}`)
+			}
+		}
+	}
+	sess.mu.Lock()
+	nudge := sess.pendingStreamLoopNudge
+	sess.mu.Unlock()
+	if nudge == "" {
+		t.Fatal("pendingStreamLoopNudge is empty, want the deferred trip to still fire once the parallel call closes")
+	}
+}
+
+// TestConsumeModelStream_LoopGuard_SecondConsecutiveTrip_HardStops pins the
+// two-tier action: "first trip aborts the stream and injects a nudge naming
+// the repeated call; second trip hard-stops." The first response trips and
+// gets a soft, error-free forced finish (tier 1); when the very next
+// response ALSO trips, it must return a non-retryable error instead of
+// another soft finish (tier 2) -- and that error must be excluded from the
+// model-fallback walk, or the hard stop would simply re-run the runaway
+// against every configured fallback model.
+func TestConsumeModelStream_LoopGuard_SecondConsecutiveTrip_HardStops(t *testing.T) {
+	sess := newSession(t)
+	req := llm.Request{Provider: "openai", Model: "gpt-5.2"}
+
+	pattern := cyclePattern()
+	feedTrip := func(st *llm.ChanStream) func() {
+		return func() {
+			for i := range 15 {
+				p := pattern[i%3]
+				sendToolCall(st, callID(i), p.name, p.args)
+			}
+			st.CloseSend()
+		}
+	}
+
+	// First response: tier 1, soft.
+	st1 := llm.NewChanStream(nil)
+	_, _, err1 := runConsumeModelStream(t, sess, req, st1, feedTrip(st1))
+	if err1 != nil {
+		t.Fatalf("first trip: err = %v, want nil", err1)
+	}
+	sess.mu.Lock()
+	streak1 := sess.streamLoopTripStreak
+	sess.mu.Unlock()
+	if streak1 != 1 {
+		t.Fatalf("streak after first trip = %d, want 1", streak1)
+	}
+
+	// Second, consecutive response: tier 2, hard stop.
+	st2 := llm.NewChanStream(nil)
+	_, obs2, err2 := runConsumeModelStream(t, sess, req, st2, feedTrip(st2))
+	if err2 == nil {
+		t.Fatal("second consecutive trip: err = nil, want a hard-stop error")
+	}
+	var le llm.Error
+	if !errors.As(err2, &le) {
+		t.Fatalf("second trip error %v does not satisfy llm.Error", err2)
+	}
+	if le.Retryable() {
+		t.Fatalf("second trip error is Retryable() == true, want false (retrying replays the same runaway pattern)")
+	}
+	if llm.Classify(err2) != llm.ErrorClassPermanent {
+		t.Fatalf("Classify(err2) = %v, want ErrorClassPermanent", llm.Classify(err2))
+	}
+	var loopStop *streamLoopHardStopError
+	if !errors.As(err2, &loopStop) {
+		t.Fatalf("second trip error %v is not a *streamLoopHardStopError; without that marker the fallback chain re-runs the runaway on every fallback model", err2)
+	}
+	_ = obs2
+	sess.mu.Lock()
+	streak2 := sess.streamLoopTripStreak
+	sess.mu.Unlock()
+	if streak2 != 2 {
+		t.Fatalf("streak after second trip = %d, want 2", streak2)
+	}
+}
+
+// TestConsumeModelStream_LoopGuard_CleanRoundResetsStreak proves the streak
+// is about CONSECUTIVE trips, not a lifetime count: a clean round between two
+// tripped ones must reset it, so a session that occasionally loops but
+// always recovers is never hard-stopped.
+func TestConsumeModelStream_LoopGuard_CleanRoundResetsStreak(t *testing.T) {
+	sess := newSession(t)
+	req := llm.Request{Provider: "openai", Model: "gpt-5.2"}
+	pattern := cyclePattern()
+	feedTrip := func(st *llm.ChanStream) func() {
+		return func() {
+			for i := range 15 {
+				p := pattern[i%3]
+				sendToolCall(st, callID(i), p.name, p.args)
+			}
+			st.CloseSend()
+		}
+	}
+	feedClean := func(st *llm.ChanStream) func() {
+		return func() {
+			st.Send(llm.StreamEvent{Type: llm.StreamEventTextStart, TextID: "t0"})
+			st.Send(llm.StreamEvent{Type: llm.StreamEventTextDelta, TextID: "t0", Delta: "done"})
+			st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &llm.FinishReason{Reason: llm.FinishReasonStop}})
+			st.CloseSend()
+		}
+	}
+
+	st1 := llm.NewChanStream(nil)
+	if _, _, err := runConsumeModelStream(t, sess, req, st1, feedTrip(st1)); err != nil {
+		t.Fatalf("first trip: err = %v, want nil", err)
+	}
+	st2 := llm.NewChanStream(nil)
+	if _, _, err := runConsumeModelStream(t, sess, req, st2, feedClean(st2)); err != nil {
+		t.Fatalf("clean round: err = %v, want nil", err)
+	}
+	sess.mu.Lock()
+	streak := sess.streamLoopTripStreak
+	sess.mu.Unlock()
+	if streak != 0 {
+		t.Fatalf("streak after a clean round = %d, want 0 (streak resets)", streak)
+	}
+
+	// A trip AFTER the clean round must be treated as a first trip again,
+	// not a second consecutive one.
+	st3 := llm.NewChanStream(nil)
+	if _, _, err := runConsumeModelStream(t, sess, req, st3, feedTrip(st3)); err != nil {
+		t.Fatalf("trip after clean round: err = %v, want nil (tier 1, not tier 2)", err)
+	}
+}
+
+func callID(i int) string {
+	return "call_" + itoaTest(i)
+}

--- a/agent/session_stream_loop_guard_test.go
+++ b/agent/session_stream_loop_guard_test.go
@@ -72,6 +72,31 @@ func TestStreamLoopGuard_CycleDetection_SingleCallRepeatedFiveTimes(t *testing.T
 	}
 }
 
+// TestStreamLoopGuard_SixCycle_FallsToTheCeilingNotTheCycleDetector pins
+// loopGuardCycleMaxLen's upper edge, which is otherwise unobservable: a cycle
+// longer than 5 is deliberately out of the cycle detector's reach (gemini-cli's
+// k=1..5), and the raw ceiling is what catches it instead. Widening the
+// constant would change which detector fires and how early, so the boundary is
+// a decision worth pinning rather than a number free to drift.
+func TestStreamLoopGuard_SixCycle_FallsToTheCeilingNotTheCycleDetector(t *testing.T) {
+	g := newStreamLoopGuard()
+	var trip *loopTrip
+	n := 0
+	for trip == nil {
+		trip = g.observeToolCall(distinctToolName(n%6), `{"k":`+itoaTest(n%6)+`}`)
+		n++
+		if n > 100 {
+			t.Fatal("a 6-cycle never tripped at all; the ceiling must still backstop it")
+		}
+	}
+	if trip.Kind == loopTripCycle {
+		t.Fatalf("6-cycle tripped the CYCLE detector at call %d; loopGuardCycleMaxLen is %d, so a period of 6 must fall through to the ceiling instead", n, loopGuardCycleMaxLen)
+	}
+	if n != loopGuardRawCeiling {
+		t.Fatalf("6-cycle tripped at call %d, want the ceiling at %d", n, loopGuardRawCeiling)
+	}
+}
+
 // TestStreamLoopGuard_EighteenDistinctCalls_NoTrip pins odysseus #3185's
 // false positive: a legitimate round of ~18 DISTINCT tool calls must never
 // trip, neither the cycle detector (no repetition at all) nor the raw ceiling

--- a/agent/session_stream_loop_guard_test.go
+++ b/agent/session_stream_loop_guard_test.go
@@ -1,0 +1,169 @@
+package agent
+
+import "testing"
+
+// These tests drive the pure loop-guard detector directly (issue #94): no
+// Session, no stream plumbing. The stream-loop integration (forcing a legal
+// stop mid-consumeModelStream) is covered separately in
+// session_stream_loop_guard_integration_test.go, matching the documented
+// runaway shapes.
+
+// TestStreamLoopGuard_CycleDetection_TripsAtFifteenCalls pins the primary
+// fixture: (manage_worktree, task_list, communicate) repeating, a cycle of
+// length k=3 that must trip once it has repeated 5 times (15 calls in), not
+// merely be present somewhere in a long response.
+func TestStreamLoopGuard_CycleDetection_TripsAtFifteenCalls(t *testing.T) {
+	g := newStreamLoopGuard()
+	calls := []struct{ name, args string }{
+		{"manage_worktree", `{"op":"list"}`},
+		{"task_list", `{}`},
+		{"communicate", `{"message":"still working"}`},
+	}
+	var trip *loopTrip
+	n := 0
+	for trip == nil {
+		c := calls[n%3]
+		trip = g.observeToolCall(c.name, c.args)
+		n++
+		if n > 30 {
+			t.Fatalf("cycle never tripped after %d calls", n)
+		}
+	}
+	if n != 15 {
+		t.Fatalf("cycle tripped after %d calls, want exactly 15 (k=3, R=5)", n)
+	}
+	if trip.Kind != loopTripCycle {
+		t.Fatalf("trip.Kind = %v, want loopTripCycle", trip.Kind)
+	}
+}
+
+// TestStreamLoopGuard_CycleDetection_DoesNotTripBeforeFiveRepeats checks the
+// boundary directly: four repeats of a 3-call cycle (12 calls) must not trip,
+// only the fifth repeat (the 15th call) does.
+func TestStreamLoopGuard_CycleDetection_DoesNotTripBeforeFiveRepeats(t *testing.T) {
+	g := newStreamLoopGuard()
+	calls := []struct{ name, args string }{
+		{"manage_worktree", `{"op":"list"}`},
+		{"task_list", `{}`},
+		{"communicate", `{"message":"still working"}`},
+	}
+	for i := range 12 {
+		c := calls[i%3]
+		if trip := g.observeToolCall(c.name, c.args); trip != nil {
+			t.Fatalf("call %d: tripped early (%+v), want no trip before 15 calls", i+1, trip)
+		}
+	}
+}
+
+// TestStreamLoopGuard_CycleDetection_SingleCallRepeatedFiveTimes covers k=1:
+// the same call five times in a row trips as a cycle of length 1, the cheap
+// fast path the spec calls for alongside the general k=1..5 scan.
+func TestStreamLoopGuard_CycleDetection_SingleCallRepeatedFiveTimes(t *testing.T) {
+	g := newStreamLoopGuard()
+	var trip *loopTrip
+	for range 5 {
+		trip = g.observeToolCall("read_file", `{"path":"/x"}`)
+	}
+	if trip == nil {
+		t.Fatal("expected a trip after 5 identical calls")
+	}
+	if trip.Kind != loopTripCycle {
+		t.Fatalf("trip.Kind = %v, want loopTripCycle", trip.Kind)
+	}
+}
+
+// TestStreamLoopGuard_EighteenDistinctCalls_NoTrip pins odysseus #3185's
+// false positive: a legitimate round of ~18 DISTINCT tool calls must never
+// trip, neither the cycle detector (no repetition at all) nor the raw ceiling
+// (well under it).
+func TestStreamLoopGuard_EighteenDistinctCalls_NoTrip(t *testing.T) {
+	g := newStreamLoopGuard()
+	for i := range 18 {
+		name := distinctToolName(i)
+		if trip := g.observeToolCall(name, `{"n":`+itoaTest(i)+`}`); trip != nil {
+			t.Fatalf("call %d (%s): unexpected trip %+v", i+1, name, trip)
+		}
+	}
+}
+
+// TestStreamLoopGuard_FortyDistinctCalls_NoTrip widens the headroom claim
+// beyond odysseus #3185's 18: a long, genuinely varied round -- 40 distinct
+// signatures with no repeating period anywhere -- must still pass untouched,
+// proving the ceiling's margin is real rather than sitting just above the one
+// documented legitimate shape.
+func TestStreamLoopGuard_FortyDistinctCalls_NoTrip(t *testing.T) {
+	g := newStreamLoopGuard()
+	for i := range 40 {
+		// distinctToolName cycles through 18 names, so vary the arguments
+		// too: the signature is name+":"+args, and 40 distinct arguments
+		// make 40 distinct signatures.
+		name := distinctToolName(i)
+		if trip := g.observeToolCall(name, `{"step":`+itoaTest(i)+`}`); trip != nil {
+			t.Fatalf("call %d (%s): unexpected trip %+v, want 40 distinct calls to pass", i+1, name, trip)
+		}
+	}
+}
+
+// TestStreamLoopGuard_RawCeiling_TripsWithoutAnyCycle reconstructs the
+// second measured shape -- 83 calls, 48 distinct signatures, max repeat 12,
+// deliberately built with NO period-1..5 pattern repeated 5 times
+// consecutively anywhere -- and pins which detector catches it: the ceiling,
+// not the cycle detector.
+func TestStreamLoopGuard_RawCeiling_TripsWithoutAnyCycle(t *testing.T) {
+	sigs := buildEightyThreeCallNoCycleFixture(t)
+
+	// Self-check the fixture generator's own claim before trusting the
+	// detector's answer: assert directly (via the guard's own cycle
+	// checker) that no k=1..5/R=5 cycle exists anywhere in the full 83-call
+	// sequence, offline, before feeding it through observeToolCall.
+	assertNoShortCycleAnywhere(t, sigs)
+
+	g := newStreamLoopGuard()
+	var trip *loopTrip
+	n := 0
+	for i, sig := range sigs {
+		trip = g.observeToolCall(sig.name, sig.args)
+		n = i + 1
+		if trip != nil {
+			break
+		}
+	}
+	if trip == nil {
+		t.Fatalf("expected a trip within %d calls (ceiling=%d), got none", len(sigs), loopGuardRawCeiling)
+	}
+	if trip.Kind != loopTripCeiling {
+		t.Fatalf("trip.Kind = %v, want loopTripCeiling (the fixture has no short cycle by construction)", trip.Kind)
+	}
+	if n != loopGuardRawCeiling {
+		t.Fatalf("ceiling tripped at call %d, want exactly %d", n, loopGuardRawCeiling)
+	}
+}
+
+func itoaTest(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}
+
+func distinctToolName(i int) string {
+	names := []string{
+		"read_file", "write_file", "search_files", "manage_worktree", "task_list",
+		"communicate", "run_shell", "grep", "list_dir", "web_fetch",
+		"create_job", "watch", "ask_user", "compact", "delegate",
+		"note", "job_status", "cancel_job",
+	}
+	return names[i%len(names)]
+}

--- a/agent/session_tool_round.go
+++ b/agent/session_tool_round.go
@@ -406,6 +406,16 @@ func (s *Session) injectPostToolSteering(ctx context.Context, calls []llm.ToolCa
 		}
 	}
 
+	// Stream loop guard (issue #94): consumeModelStream force-stopped the
+	// response just processed above and queued a nudge on
+	// pendingStreamLoopNudge (session_stream_loop_guard.go). Deliver it here,
+	// the same after-tool, before-next-model-call point the cross-round
+	// detector above uses, so the model reads it after seeing its own
+	// truncated calls and their results.
+	if abortErr := s.deliverPendingStreamLoopNudge(ctx); abortErr != nil {
+		return false, abortErr
+	}
+
 	drained, err := s.drainPostToolWatchSends(ctx)
 	if err != nil {
 		return false, err

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/SteeringItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/SteeringItem.tsx
@@ -61,6 +61,7 @@ const KIND_LABELS: Record<LabelledKind, string> = {
   "image-description": "Image description",
   "no-tool-calls": "No tool calls",
   "loop-detected": "Loop detection",
+  "stream-loop": "Stream loop guard",
   "tasks-done": "Tasks done",
   "task-nudge": "Task nudge",
   "task-inactive": "Task list idle",

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -1592,6 +1592,7 @@ export const STEERING_KINDS = [
   "image-description",
   "no-tool-calls",
   "loop-detected",
+  "stream-loop",
   "tasks-done",
   "task-nudge",
   "task-inactive",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,10 +199,24 @@ branch never applies to a delegate.
 
 ### The repeated-call breaker
 
-Steering a stuck agent has two layers. `injectPostToolSteering`
+Steering a stuck agent has three layers. Above the other two, the **stream loop guard**
+(`agent/session_stream_loop_guard.go`) is the only one that acts *during* a response:
+`consumeModelStream` feeds it every completed tool call, and it stops the stream when
+the calls form a cycle of length 1–5 repeated five times, or when one response crosses
+50 raw calls. The others cannot see this, because both watch tool *results* and a
+runaway response never finishes a round to produce any. A trip always waits for every
+open tool call to close, so the forced finish lands on a legal boundary and never
+freezes a call's arguments mid-stream. The first trip is soft: the calls already
+streamed still dispatch, and a `stream-loop` steering turn naming what repeated lands
+after their results. A second consecutive trip ends the turn with a non-retryable error
+that is deliberately excluded from the model-fallback walk, since the runaway came from
+the request and every fallback would reproduce it. Both the streak and the pending
+nudge are scoped to one turn.
+
+Below it, `injectPostToolSteering`
 (`agent/session_tool_round.go`) watches a window of recent call signatures and, when
 `detectLoop` fires, injects steering — the structural intervention when every call in
-the window failed, today's tiered escalation otherwise. Underneath it,
+the window failed, today's tiered escalation otherwise. Underneath that,
 `Registry.ExecuteCall` (`agent/internal/tool/registry.go`) consults a ledger
 (`agent/internal/tool/breaker.go`) that every *dispatched* tool call passes through,
 native and MCP alike — a call refused before dispatch — by pre-validation, an unknown tool

--- a/llm/sdk_errors.go
+++ b/llm/sdk_errors.go
@@ -97,6 +97,22 @@ func NewStreamError(provider, message string, cause error) error {
 	}}
 }
 
+// NewPermanentStreamError reports a streaming failure the caller has already
+// decided must not be retried: retrying would re-run exactly the request that
+// produced the condition being reported. Unlike NewStreamError (always
+// retryable), Retryable() is false here, so Classify returns
+// ErrorClassPermanent and the retry chain gives up immediately instead of
+// spending its budget reproducing the same outcome. cause is optional, exposed
+// via Unwrap.
+func NewPermanentStreamError(provider, message string, cause error) error {
+	return &StreamError{nonHTTPBaseError{
+		provider:  provider,
+		message:   message,
+		retryable: false,
+		cause:     cause,
+	}}
+}
+
 // NewNoObjectGeneratedError reports that no valid object could be produced from
 // the model output. cause is the underlying parse/validation error, exposed via
 // Unwrap; pass nil when none applies.


### PR DESCRIPTION
Implements the Phase-1 spec from the "v2 spec: two independently-landable phases" comment on #94. Supersedes #130 and #241; neither is closed by this PR.

Nothing in evener bounds a single streamed response. All four existing runaway guards watch either *between* responses or for *silence*, and a runaway is loud and never completes a round: `--max-rounds` cannot advance while one response is still streaming, `PhaseSilentStall` requires zero content events, `RetryStream`'s cap rule only evaluates on `err != nil` and a runaway ends with an ordinary `tool_calls` finish, and the tool breaker is a post-dispatch write that never runs during the response itself. This adds the missing bound inside `consumeModelStream`'s event loop.

## Conformance to the #94 Phase-1 spec

| Spec item | Where |
|---|---|
| Take `session_stream_loop_guard.go` whole, minus `loopTripChant` | `agent/session_stream_loop_guard.go` |
| `loopGuardCycleMaxLen=5`, `loopGuardCycleRepeats=5`, `loopGuardRawCeiling=50` | same file |
| `llm.NewPermanentStreamError` after `NewStreamError` | `llm/sdk_errors.go` |
| `SteeringKindStreamLoop` + `AllSteeringKinds` + test map | `agent/events/payloads.go`, `payloads_test.go` |
| Regenerated `types.gen.ts` committed (Makefile staleness lint) | `cmd/evener-hub/frontend/src/protocol/types.gen.ts` |
| `"stream-loop": "Stream loop guard"` frontend label | `SteeringItem.tsx` |
| Session fields beside `loopDetectionCount` | `agent/session.go` |
| `consumeModelStream` wiring: guard state, `openToolCalls`, `applyPendingTrip`, `streamEvents:` label, `hardStopErr` early return, streak-reset tail | `agent/session_stream.go` |
| Delivery in `injectPostToolSteering` before `drainPostToolWatchSends` | `agent/session_tool_round.go` |
| Chant detector and all chant hunks dropped | not ported |
| `session_lifecycle.go` zero-calls delivery hook NOT ported (dead in Phase 1) | not ported |
| `nonChantingFiller` / `testkit_test.go` edits not ported | not ported |
| `describeCyclePattern` uses `strings.Cut` (modernize) | `session_stream_loop_guard.go` |
| Ported tests (6 integration + 2 delivery + the `checkCycle` unit/fixture files) | `*_integration_test.go`, `*_delivery_test.go`, `*_test.go`, `*_fixtures_test.go` |
| New tests, minimum 4 | see below |

Ported from #130's judged-sound half, commit e1fee75b3 on `kata/uq-d74b` — the half that review found "no false positive" against. Hand-ported at tip state with `primeradiant.com/serf` → `primeradiant.com/evener` rewrites; no cherry-pick (the module and `cmd/serf-hub` renames landed after the branch point).

## The two mandatory defect fixes

**(a) The tier-2 hard stop was fallback-eligible.** `NewPermanentStreamError` classifies `ErrorClassPermanent`, and `modelFallbackEligible` returns `true` for permanent — so a hard stop with `ModelFallbacks` configured re-ran the exact runaway-producing request against every fallback model, the opposite of what the constructor exists to do. Fixed with a `streamLoopHardStopError` wrapper excluded by `errors.As` before the `Classify` switch in `agent/session_init.go`, mirroring the `*llm.ProviderUnhealthyError` arm three lines above. Covered by `TestModelFallbackEligible_StreamLoopHardStop` (unit) and `TestProcessInput_StreamLoopGuard_HardStopSkipsModelFallbacks` (end to end, asserting `a.Models()` never leaves `primary`).

**(b) The streak and pending nudge leaked across turns.** Only a clean completion zeroed the streak, and a tier-2 hard stop returns before that runs — so the streak stayed at 2 forever, and every later trip in every later turn hard-stopped instantly with no tier-1 chance to self-correct. `processOneInput` now zeroes both fields at turn start, inside the `s.mu` block it already holds. The pending nudge is dropped rather than carried: it describes a response from a turn that is over, and delivering it into an unrelated one is the "stale nudge lands out of context" failure the review flagged. Covered by `TestProcessInput_StreamLoopGuard_TurnStartResetsStreakAndNudge` (reads both fields at round-loop entry, from inside the adapter script) and `TestProcessInput_StreamLoopGuard_HardStopEndsTurnAndSessionSurvives`.

## New tests

Every test on `kata/uq-d74b` drove `consumeModelStream` directly, so nothing proved the calls streamed before a trip actually dispatch, that the nudge reaches history, that the next request carries it, or that a session survives a hard stop. Five new ones, all through `ProcessInput`:

- `TestProcessInput_StreamLoopGuard_TripDispatchesNudgesAndRecovers` — round 1 runs away; asserts exactly 15 dispatched tool results (not 20, the fixture's full send), a `SteeringKindStreamLoop` turn positioned after those results, the nudge naming the repeated calls, the *second* request carrying that exact text, round 2 completing cleanly, and the streak back to 0.
- `TestProcessInput_StreamLoopGuard_HardStopEndsTurnAndSessionSurvives` — two consecutive tripping rounds in one turn surface the hard stop out of `ProcessInput` itself; the *next* turn opens with another tripping round and must recover on a tier-1 nudge, which is only possible if the streak was zeroed at turn start.
- `TestProcessInput_StreamLoopGuard_TurnStartResetsStreakAndNudge`
- `TestProcessInput_StreamLoopGuard_HardStopSkipsModelFallbacks`
- `TestModelFallbackEligible_StreamLoopHardStop`

Plus three beyond the spec, each closing a hole the mutation run exposed or the suite left open:

- `TestStreamLoopGuard_FortyDistinctCalls_NoTrip` — 40 distinct signatures pass untouched, so the ceiling's margin over odysseus #3185's 18 is asserted rather than assumed.
- `TestConsumeModelStream_LoopGuard_StateDoesNotCarryAcrossResponses` — two 30-call rounds in one session both complete; a session-scoped guard would trip the ceiling partway through the second, re-inventing the between-responses blindness this exists to fix.
- `TestStreamLoopGuard_SixCycle_FallsToTheCeilingNotTheCycleDetector` — pins `loopGuardCycleMaxLen`'s upper edge. Widening it 5→6 was the one mutation the suite failed to catch: every fixture uses a k=3 cycle, which the k=3 arm finds at 15 calls no matter how far the scan widens.

## Evidence

**Red first.** `2846aa6d0` lands the tests against stub declarations; 15 tests fail. `153af9b04` implements; all green. The negative controls (`EighteenDistinctCalls_NoTrip` at both levels, `FortyDistinctCalls_NoTrip`, `DoesNotTripBeforeFiveRepeats`) pass in the red state by construction — they exist to catch a detector that trips too eagerly, not one that never trips.

**Mutation checklist**, every item from the spec, applied to a clean tree and reverted (script drove it, output verbatim):

| Mutation | Red |
|---|---|
| `loopGuardCycleRepeats` 5→6 | `CycleShape`, `TripsAtFifteenCalls`, `SingleCallRepeatedFiveTimes`, `CleanRoundResetsStreak`, `DefersUntilParallelCallCloses`, `SecondConsecutiveTrip_HardStops`, `TripDispatchesNudgesAndRecovers` |
| `loopGuardCycleMaxLen` 5→6 | `SixCycle_FallsToTheCeilingNotTheCycleDetector` |
| `loopGuardCycleMaxLen` 5→2 | `TripsAtFifteenCalls`, `CycleShape`, + 6 more |
| `loopGuardRawCeiling` 50→51 | `CeilingShape` |
| `loopGuardRawCeiling` 50→49 | `CeilingShape` |
| `loopGuardRawCeiling` 50→18 | `EighteenDistinctCalls_NoTrip` (both levels), `FortyDistinctCalls_NoTrip`, `StateDoesNotCarryAcrossResponses`, `CeilingShape` |
| remove `len(openToolCalls) > 0` | `DefersUntilParallelCallCloses` |
| remove the streak increment | `SecondConsecutiveTrip_HardStops`, `CycleShape`, `HardStopEndsTurnAndSessionSurvives`, `HardStopSkipsModelFallbacks` |
| disable the `streak >= 2` branch | `SecondConsecutiveTrip_HardStops`, `HardStopEndsTurnAndSessionSurvives`, `HardStopSkipsModelFallbacks` |
| disable the clean-completion reset | `CleanRoundResetsStreak`, `HardStopEndsTurnAndSessionSurvives`, `TripDispatchesNudgesAndRecovers` |
| `NewPermanentStreamError` → `NewStreamError` (retryable) | `SecondConsecutiveTrip_HardStops`, `HardStopEndsTurnAndSessionSurvives` |
| remove the `errors.As(err, &loopStop)` exclusion | `ModelFallbackEligible_StreamLoopHardStop` (both cases), `HardStopSkipsModelFallbacks` |
| remove the turn-start reset | `TurnStartResetsStreakAndNudge`, `HardStopEndsTurnAndSessionSurvives` |
| remove the `injectPostToolSteering` delivery call | `InjectPostToolSteering_DeliversStreamLoopNudge`, `TripDispatchesNudgesAndRecovers` |
| make the guard state session-global | `StateDoesNotCarryAcrossResponses` |

The `loopGuardCycleMaxLen` 5→6 row is the honest one: it survived the ported suite, which is why `SixCycle_FallsToTheCeilingNotTheCycleDetector` exists. Widening the scan cannot make a k=3 cycle trip later, so no existing fixture could see it.

**Docs.** `docs/architecture.md`'s "Steering a stuck agent has two layers" went stale on landing; the section now describes all three and says why the older two are blind to this failure.

**Suites.** `go test ./...` and `go test -race ./agent/... ./llm/...` both clean. `make lint` (naming, gofmt, evenerfuzz, eval, internal, docs, golangci, generated, secret-scan) passes. `make test-web` passes typecheck, unit, and lint — `KIND_LABELS` is an exhaustive `Record` over the generated union, so the frontend build is what enforces the new kind having a label.

## Not in this PR

Phase 2's text-runaway (chant) detector, which the spec says needs a rebuilt algorithm rather than the v1 port: an amortized rolling-hash index, a two-tier entropy bar, buffer-based fence tracking, and a twelve-fixture negative suite. The `session_lifecycle.go` zero-tool-calls delivery hook and its test come back with it — both Phase-1 detectors key off `StreamEventToolCallEnd`, so a trip always has tool calls and that hook is unreachable until chant returns.

Also noted, not fixed: `internal/appprojector/appwire_projection.go` labels every `EventLoopDetection` "Loop detection" in the transcript bubble, while `SteeringItem.tsx` distinguishes `stream-loop` → "Stream loop guard". Same nudge, two labels depending on the surface. Pre-existing shape, flagged so it is not relitigated as new.

Closes nothing; #94 stays open for Phase 2.

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU
