### PR TITLE
test(agent): deflake cold-attention run-open assertion (#239)

### DIFF
--- a/agent/session_attention_test.go
+++ b/agent/session_attention_test.go
@@ -2615,11 +2615,15 @@ func TestDelegateAttention_RestartRearmsColdChildAndDrainsExactAttention(t *test
 	}
 
 	attentionEntered := make(chan struct{})
+	releaseAttention := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(releaseAttention) }) })
 	attentionSeen := false
 	fixture.adapter.steps = []func(llm.Request) llm.Response{
 		func(request llm.Request) llm.Response {
 			attentionSeen = requestContainsText(request, attentionContent)
 			close(attentionEntered)
+			<-releaseAttention
 			return communicateResponse(true, "cold attention handled")
 		},
 		func(llm.Request) llm.Response {
@@ -2643,6 +2647,12 @@ func TestDelegateAttention_RestartRearmsColdChildAndDrainsExactAttention(t *test
 	if _, err := root.ProcessInputKind(context.Background(), "", nil, EntryNotification); err != nil {
 		t.Fatalf("drive restored cold delegate attention: %v", err)
 	}
+	// Read the durable aggregate only while the attention run is blocked inside
+	// its provider request: the run-started fold (CurrentRunOpen=true) commits
+	// before the run launches, and the blocked request keeps the run-finished
+	// fold from clearing it. Reading without this synchronization races the
+	// whole async run and can observe open:false after it completes (#239).
+	<-attentionEntered
 	root.delegateController.mu.Lock()
 	aggregate := root.delegateController.durable[fixture.delegateID]
 	generation := aggregate.Generation
@@ -2652,10 +2662,10 @@ func TestDelegateAttention_RestartRearmsColdChildAndDrainsExactAttention(t *test
 	if generation != 1 || trigger != delegatestore.TriggerAttention || !open {
 		t.Fatalf("cold attention generation = generation:%d trigger:%q open:%t, want 1/attention/open", generation, trigger, open)
 	}
-	<-attentionEntered
 	if !attentionSeen {
 		t.Fatal("cold attention generation provider request omitted the exact durable attention")
 	}
+	releaseOnce.Do(func() { close(releaseAttention) })
 	waitForStableSupervisionRun(t, root, fixture.childID)
 	if _, err := root.DrainJobTree(context.Background()); err != nil {
 		t.Fatalf("drain cold delegate attention: %v", err)


### PR DESCRIPTION
## What

`TestDelegateAttention_RestartRearmsColdChildAndDrainsExactAttention` read the durable delegate aggregate immediately after `ProcessInputKind(..., EntryNotification)` returned, before synchronizing with the asynchronously launched attention run.

## Root cause

The issue's hypothesis pointed at the run *opening* late, but the fold code rules that out: `applyRunStarted` sets `Generation=1` and `CurrentRunOpen=true` atomically, so the observed CI signature `generation:1 trigger:"attention" open:false` can only arise *after* `applyRunFinished` folded — i.e. the entire attention run (commit-start → provider request → communicate → terminal fold) completed in the gap between `ProcessInputKind` returning and the test reacquiring `delegateController.mu`. Under CI scheduler load the reader goroutine loses that race.

Verified empirically: injecting a 500ms sleep between `ProcessInputKind` and the read reproduces the exact CI failure signature deterministically.

## Fix

Adopt the established pattern from the sibling test `TestDelegateAttention_SettledResidentChildStartsExactAttentionGeneration` (same file): block the attention run inside its first provider request on a release channel, wait for `<-attentionEntered` *before* reading the aggregate, then release and drain. `CommitStart` (which folds run-started, `CurrentRunOpen=true`) happens before `launchSubagentRun`, and the blocked provider step makes the run-finished fold impossible — so the read is now fully synchronized in both directions.

With the fix, the same injected 500ms delay cannot trip the assertion (verified).

## Verification

- `go test -race -count=30 -run TestDelegateAttention_RestartRearmsColdChildAndDrainsExactAttention ./agent` — 30/30 pass
- `go test -race -count=2 -run 'TestDelegateAttention_' ./agent` — whole family green
- `go vet ./agent` — clean

Fixes #239