### PR TITLE
test(e2e): join daemon shutdown in hub-stack teardown (#249)

### DIFF
--- a/cmd/evener-hub/e2e_turn_control_test.go
+++ b/cmd/evener-hub/e2e_turn_control_test.go
@@ -708,6 +708,7 @@ var daemonPIDPattern = regexp.MustCompile(`\bdaemon session=\S+ pid=(\d+)\b`)
 
 func reapDaemons(t *testing.T, hubLog string) {
 	t.Helper()
+	var procs []*os.Process
 	for _, match := range daemonPIDPattern.FindAllStringSubmatch(hubLog, -1) {
 		pid, err := strconv.Atoi(match[1])
 		if err != nil {
@@ -718,7 +719,43 @@ func reapDaemons(t *testing.T, hubLog string) {
 			continue
 		}
 		_ = proc.Signal(syscall.SIGTERM)
+		procs = append(procs, proc)
 	}
+	// SIGTERM only *asks* each daemon to shut down; the flush-and-close of its
+	// session state is asynchronous. Returning before the process exits leaves
+	// it writing under state/evener/projects/<project>/sessions while
+	// t.TempDir's RemoveAll runs, which is exactly the 'unlinkat ...:
+	// directory not empty' teardown race of #249. Join every daemon here:
+	// graceful exit first (serve's own shutdown drain budget is 30s), then
+	// SIGKILL the laggards. A process that is gone can no longer write, so
+	// RemoveAll after this point cannot lose the race.
+	for _, proc := range procs {
+		if waitForProcessExit(proc, 35*time.Second) {
+			continue
+		}
+		t.Logf("daemon pid %d ignored SIGTERM; escalating to SIGKILL", proc.Pid)
+		_ = proc.Signal(syscall.SIGKILL)
+		if !waitForProcessExit(proc, 5*time.Second) {
+			t.Logf("daemon pid %d still present after SIGKILL; it may be a zombie awaiting init's reap, which holds no writable fds", proc.Pid)
+		}
+	}
+}
+
+// waitForProcessExit polls until proc is gone or the timeout expires.
+// os.Process.Wait is unavailable here: daemons are the hub's children, not
+// the test binary's, so the test cannot reap them — after the hub's SIGKILL
+// they are reparented to init, which reaps. Signal 0 probes existence
+// without disturbing the process; a zombie still "exists", which is fine —
+// a zombie has already closed its fds and cannot write.
+func waitForProcessExit(proc *os.Process, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if err := proc.Signal(syscall.Signal(0)); err != nil {
+			return true
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return false
 }
 
 func awaitHubReady(t *testing.T, addr string) {


### PR DESCRIPTION
## What

`TestE2E_SteerLandsInTheNextTurnWhenItsTurnEnded` failed CI in `t.TempDir` cleanup — `unlinkat .../state/evener/projects/<project>/sessions: directory not empty` — with all of its own assertions green. Same species as the marketplace race fixed in #235, different writer: the **session store**, not a plugin clone.

## Root cause

`reapDaemons` (shared by every hub-stack e2e test) sent each daemon grandchild SIGTERM and returned immediately. A SIGTERM'd daemon shuts down *gracefully*: it flushes and closes session state under the sessions dir asynchronously. Pre-fix, nothing joined that shutdown, so the daemon was still writing when `t.TempDir`'s RemoveAll ran — RemoveAll reads the directory, the daemon adds an entry, `unlinkat` on the now-non-empty directory fails, and a cleanup failure fails the test.

Measured locally with a temporary probe: the daemon exits **27ms after SIGTERM** on an unloaded machine. That whole window raced RemoveAll before this fix; CI load stretches it.

## Fix

`reapDaemons` now joins every daemon after SIGTERM:

- 35s grace per daemon (just past serve's own 30s shutdown drain budget, so a healthy daemon always exits inside it),
- SIGKILL + a final bounded wait for laggards,
- exit probed with signal 0, because `os.Process.Wait` is unavailable for grandchildren (after the hub's SIGKILL they reparent to init, which reaps). A zombie still reads as "present" but has already closed its fds — it cannot write, so RemoveAll after the join cannot lose the race.

Cleanup ordering already guarantees the join precedes `t.TempDir` removal (stack cleanup registers after the `t.TempDir()\) calls, and cleanups run LIFO).

## Verification

- Probe experiment above confirms the pre-fix window exists locally and the join absorbs it
- `go test -count=1 -timeout 15m -run 'TestE2E_' ./cmd/evener-hub` — whole hub e2e family green (17.9s)
- `go vet ./cmd/evener-hub` — clean

Fixes #249