### PR TITLE
fuzz-bisect: parse git's quoted 'bad' term in the convergence line (#245)

### DIFF
--- a/scripts/fuzz/fuzz-bisect-selftest.sh
+++ b/scripts/fuzz/fuzz-bisect-selftest.sh
@@ -100,7 +100,9 @@ if printf '%s' "$out" | grep -q "$culprit_sha"; then
 else
 	bad "bisect did not name the introducing commit ($culprit_sha)"
 fi
-if printf '%s' "$out" | grep -qi "is the first bad commit"; then
+# git ≥2.55 quotes the bisect term ("is the first 'bad' commit", git.git
+# 0c0f93e7fa); older gits print "is the first bad commit". Match both.
+if printf '%s' "$out" | grep -qiE "is the first '?bad'? commit"; then
 	ok "bisect converged to a first bad commit"
 else
 	bad "bisect did not converge"

--- a/scripts/fuzz/fuzz-bisect.sh
+++ b/scripts/fuzz/fuzz-bisect.sh
@@ -139,11 +139,13 @@ echo "fuzz-bisect: bisecting $good..$bad …"
 git -C "$repo_root" bisect start "$bad" "$good" >/dev/null
 bisect_out="$(git -C "$repo_root" bisect run "$probe" 2>&1)"
 
-culprit="$(printf '%s\n' "$bisect_out" | grep -iE 'is the first bad commit' | head -n1)"
+# git ≥2.55 quotes the bisect terms ("is the first 'bad' commit", git.git
+# 0c0f93e7fa); older gits print "is the first bad commit". Match both.
+culprit="$(printf '%s\n' "$bisect_out" | grep -iE "is the first '?bad'? commit" | head -n1)"
 echo "==============================================================="
 if [ -n "$culprit" ]; then
 	echo "fuzz-bisect: introduced by:"
-	printf '%s\n' "$bisect_out" | sed -n '/is the first bad commit/,/^$/p' | sed 's/^/    /'
+	printf '%s\n' "$bisect_out" | sed -E -n "/is the first '?bad'? commit/,/^$/p" | sed 's/^/    /'
 else
 	echo "fuzz-bisect: bisection did not converge cleanly; raw output:"
 	printf '%s\n' "$bisect_out" | sed 's/^/    /'


### PR DESCRIPTION
## What

`make fuzz-bisect-selftest` intermittently failed CI with `FAIL: bisect did not converge` while its sibling check (`bisect identified the introducing commit`) passed — two same-minute `main` runs landed different outcomes.

## Root cause

Not a flake in the bisect itself — a **git version drift** across CI runners. git.git commit `0c0f93e7fa` ("bisect: print bisect terms in single quotes", May 2026, first released in git 2.55) changed the convergence line from

```
<sha> is the first bad commit
```

to

```
<sha> is the first 'bad' commit
```

Three literal-string matches in our tooling only knew the old form:

1. `scripts/fuzz/fuzz-bisect.sh:142` — culprit extraction. On new git it misses, so the tool misreports a cleanly converged bisect as "did not converge cleanly" and dumps raw output. **This makes the real tool (not just the selftest) useless on git ≥2.55.**
2. `scripts/fuzz/fuzz-bisect.sh:146` — the `sed` window that prints the culprit block.
3. `scripts/fuzz/fuzz-bisect-selftest.sh:103` — the convergence check.

The failing CI output matches exactly: raw output contains `<culprit_sha> is the first 'bad' commit` (so the culprit-sha check passes) while both convergence greps miss.

## Reproduction

Installed Homebrew git 2.55.0 (quoted output; uninstalled again afterwards, machine restored to Apple Git-155):

- pre-fix: `PATH=/opt/homebrew/bin:/Users/jesse/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/jesse/.local/share/mise/installs/ubi-jdx-fnox/latest:/Users/jesse/.local/bin:/Users/jesse/bin:/Users/jesse/.local/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/usr/bin:/bin:/Users/jesse/.cache/zsh4humans/v5/fzf/bin:/Users/jesse/.orbstack/bin:/Users/jesse/.claude/local/:/Users/jesse/go/bin:/opt/homebrew/Caskroom/miniconda/base/bin:/Users/jesse/.orbstack/bin bash scripts/fuzz/fuzz-bisect-selftest.sh` → `FAIL: bisect did not converge` (the CI signature, deterministic)
- post-fix: passes under git 2.55.0 **and** under Apple Git 2.50.1 (unquoted)

## Fix

All three sites now match optional single quotes around the term: `grep -iE "is the first '?bad'? commit"` (and `sed -E` for the range print). The script never customizes bisect terms, so `bad` is the only term in play; the match is exact about everything except the quotes.

## Verification

- Selftest 4/4 under git 2.55.0 (quoted) and 2.50.1 (unquoted) — see above
- No other `first bad commit` matches exist elsewhere in `scripts/`

Fixes #245