### PR TITLE
test(agent): deterministic regression test for the #243 drain-return flake

### DIFF
--- a/agent/subagent_owned_job_drain_test.go
+++ b/agent/subagent_owned_job_drain_test.go
@@ -356,15 +356,38 @@ func TestSubagentDrainReturnHandoffPreservesStableSteeringBeforeTerminalPublicat
 // merge every accepted send exactly as in the unperturbed test.
 func TestSubagentDrainReturnHandoffNoPhantomTurnInFinalizationWindow(t *testing.T) {
 	fixture := newOwnedJobDrainFixture(t)
-	// The hook fires on the finalization goroutine exactly inside the window:
-	// durable NotifyPending written, in-memory queue still empty (the stable
-	// path defers the enqueue), job still in the running map. Sleeping here is
-	// the deterministic stand-in for CI scheduler load: it is long enough that
-	// at least two 250ms recheck passes run rematerializeDurablePendings inside
-	// the window regardless of ticker phase.
+	// Hold the window open until the drain loop's own recheck has provably run
+	// rematerializeDurablePendings inside it: windowHeld blocks the
+	// finalization goroutine between the NotifyPending append and the
+	// NotifyDelivered transition, and the rematerialize-load hook — wired to
+	// the drain's 250ms recheck kick — proves the pass happened rather than
+	// assuming it from wall time.
+	windowHeld := make(chan struct{})
+	recheckSawWindow := make(chan struct{})
+	releaseWindow := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(releaseWindow) }) })
+	var pendingOnce, recheckOnce sync.Once
 	fixture.child.sess.jobManager.testOnlyAfterNotifyPendingAppend = func(string) {
-		time.Sleep(2*drainRecheckInterval + 100*time.Millisecond)
+		pendingOnce.Do(func() {
+			close(windowHeld)
+			<-releaseWindow
+		})
 	}
+	fixture.child.sess.jobManager.testOnlyAfterRematerializeDurableLoad = func() {
+		select {
+		case <-windowHeld:
+			recheckOnce.Do(func() { close(recheckSawWindow) })
+		default:
+		}
+	}
+	go func() {
+		select {
+		case <-recheckSawWindow:
+			releaseOnce.Do(func() { close(releaseWindow) })
+		case <-time.After(30 * time.Second): // TRIPWIRE: the drain's 250ms recheck fires rematerialize inside the window within one interval; 30s only fires on a genuine hang.
+		}
+	}()
 	requireDrainReturnHandoffMergesSteering(t, fixture)
 }
 

--- a/agent/subagent_owned_job_drain_test.go
+++ b/agent/subagent_owned_job_drain_test.go
@@ -340,7 +340,36 @@ func TestSubagentOwnedJobDrainAcceptsStableSteeringWithoutBlockingNotifications(
 }
 
 func TestSubagentDrainReturnHandoffPreservesStableSteeringBeforeTerminalPublication(t *testing.T) {
+	requireDrainReturnHandoffMergesSteering(t, newOwnedJobDrainFixture(t))
+}
+
+// TestSubagentDrainReturnHandoffNoPhantomTurnInFinalizationWindow is #243's
+// CI flake made deterministic: it holds armFinalizedJob's
+// NotifyPending→NotifyDelivered window open across multiple drain recheck
+// passes, so the drain loop's own kick → rematerializeDurablePendings provably
+// runs against the transiently-NotifyPending shell record with an empty
+// in-memory queue. The pre-#237 rematerialize re-enqueued that record, and the
+// drain ran a phantom notification turn BEFORE the handoff sends landed — the
+// phantom stole the continuation's slot (CI observed 12 provider requests with
+// none of the accepted sends in it). With the running-map skip the drain
+// cannot see the mid-finalization record at all, and the handoff below must
+// merge every accepted send exactly as in the unperturbed test.
+func TestSubagentDrainReturnHandoffNoPhantomTurnInFinalizationWindow(t *testing.T) {
 	fixture := newOwnedJobDrainFixture(t)
+	// The hook fires on the finalization goroutine exactly inside the window:
+	// durable NotifyPending written, in-memory queue still empty (the stable
+	// path defers the enqueue), job still in the running map. Sleeping here is
+	// the deterministic stand-in for CI scheduler load: it is long enough that
+	// at least two 250ms recheck passes run rematerializeDurablePendings inside
+	// the window regardless of ticker phase.
+	fixture.child.sess.jobManager.testOnlyAfterNotifyPendingAppend = func(string) {
+		time.Sleep(2*drainRecheckInterval + 100*time.Millisecond)
+	}
+	requireDrainReturnHandoffMergesSteering(t, fixture)
+}
+
+func requireDrainReturnHandoffMergesSteering(t *testing.T, fixture *ownedJobDrainFixture) {
+	t.Helper()
 	type handoffResult struct {
 		finalizing bool
 		running    bool


### PR DESCRIPTION
## Root cause (proven, not hypothesized)

The CI failure — 12 provider requests, none of the three accepted sends in the continuation — is the #140-family rematerialize race one level up from where #237 pinned it:

1. A stable-delegate child's shell completes. `armFinalizedJob` appends the durable `NotifyPending` event, and the stable path deliberately does **not** enqueue the in-memory notification (it routes through delegate attention instead). Between that append and `persistStableShellAttention`'s `NotifyDelivered` transition, the record reads as a stranded pending.
2. The child's finalization drain rechecks every 250ms; each pass runs `rematerializeDurablePendings`. On the observed commit (ef4ce7063, which predates #237) a recheck landing in that window re-enqueues the record — a phantom notification.
3. The drain runs a **phantom notification turn**, which consumes the request slot the test expects to be the merged continuation — before the drain-return handoff sends have landed. The sends arrive at the *next* turn, and the gen=2 attention run multiplies further requests — the count-12 signature.

## Reproduction

Holding the window open across ≥2 recheck passes via the `testOnlyAfterNotifyPendingAppend` hook reproduces the CI failure **byte-for-byte** on ef4ce7063:

```
--- FAIL: drain-return stable steering requests = count 12 resume false plain false second false
```

The identical experiment on main passes: #237's running-map skip makes the mid-finalization record invisible to rematerialize (the job stays in `jm.running` until after the `NotifyDelivered` append). ~5900 stress runs across race/non-race/GOMAXPROCS=1/CPU-saturation could not reproduce without the forced window — the flake needed CI-grade scheduler load to land a recheck inside a normally-microsecond window.

## What this PR changes

The #237 unit tests pin the rematerialize guard itself; nothing pinned the end-to-end consequence. This adds `TestSubagentDrainReturnHandoffNoPhantomTurnInFinalizationWindow`: the real drain loop, the real recheck cadence, the window held open deterministically, and the full handoff assertion (4 requests, all sends merged in the continuation). Red on the pre-#237 code, green on main.

The original test's body is extracted unchanged into `requireDrainReturnHandoffMergesSteering` and shared by both tests. No product code changes — the product fix already landed in #237.

## Verification

- New test: RED on ef4ce7063 with the exact CI signature; GREEN on main (3/3)
- `go test -race -count=5 -run 'TestSubagentDrain' ./agent` and `-run 'TestSubagentOwnedJobDrain|TestSubagentFinalization'` — green
- `go vet ./agent` — clean

Fixes #243