### PR TITLE
test: rebuild the assertion audit — 8 files, mutation-checked

### DIFF
--- a/agent/internal/delegatestore/store_test.go
+++ b/agent/internal/delegatestore/store_test.go
@@ -471,7 +471,7 @@ func TestOpenRejectsTerminatedMalformedBatch(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	if _, err := Open(path); err == nil || !strings.Contains(err.Error(), "batch") {
+	if _, err := Open(path); err == nil || !strings.Contains(err.Error(), "decode batch line") {
 		t.Fatalf("Open error = %v, want malformed terminated batch", err)
 	}
 	if got := mustReadFile(t, path); !bytes.Equal(got, raw) {

--- a/agent/internal/tool/definitions_test.go
+++ b/agent/internal/tool/definitions_test.go
@@ -770,11 +770,17 @@ func TestDefGrepContextLinesParam(t *testing.T) {
 		t.Errorf("context_lines type = %v, want integer", cl["type"])
 	}
 	desc, _ := cl["description"].(string)
-	if !strings.Contains(desc, "0") || !strings.Contains(desc, "10") {
+	// Pin the actual parameter semantics, not bare digit characters. "0" and
+	// "10" individually appear almost anywhere; the meaningful contracts are
+	// the range form and the explicit default marker.
+	if !strings.Contains(desc, "0-10") {
 		t.Errorf("context_lines description should document the 0-10 range, got: %q", desc)
 	}
-	if !strings.Contains(desc, "default") {
+	if !strings.Contains(desc, "default 0") {
 		t.Errorf("context_lines description should document the default of 0, got: %q", desc)
+	}
+	if !strings.Contains(desc, "context") {
+		t.Errorf("context_lines description should mention context lines, got: %q", desc)
 	}
 }
 

--- a/agent/section_resolver_test.go
+++ b/agent/section_resolver_test.go
@@ -652,8 +652,22 @@ func TestSubagentTemplate_StructuralRegression(t *testing.T) {
 		}
 	}
 
-	if !strings.Contains(result, "When you create or enter a fresh worktree, its dependency directories may be absent; copy or install the project's dependencies before running its gates.") {
-		t.Errorf("subagent prompt missing fresh-worktree dependency guidance; got:\n%s", result)
+	// The fresh-worktree guidance is a four-part contract: it applies on entering
+	// a worktree, warns that dependency directories may be missing, tells the
+	// agent to copy or install them, and scopes that to before the gates run.
+	// Pinned clause by clause against the case-folded section rather than as one
+	// sentence, so splitting the semicolon into two sentences (which recapitalizes
+	// the second clause) cannot break the test while the contract holds.
+	folded := strings.ToLower(result)
+	for _, want := range []string{
+		"fresh worktree",
+		"dependency directories may be absent",
+		"copy or install the project's dependencies",
+		"before running its gates",
+	} {
+		if !strings.Contains(folded, want) {
+			t.Errorf("subagent prompt missing fresh-worktree dependency guidance %q; got:\n%s", want, result)
+		}
 	}
 
 	// Subagent should NOT have root-only sections such as delegation, git-safety,

--- a/agent/subagent_owned_job_drain_test.go
+++ b/agent/subagent_owned_job_drain_test.go
@@ -573,95 +573,84 @@ func TestSubagentRunPreservesStructuredResultAcrossLateNotification(t *testing.T
 }
 
 func TestSubagentFinalizationRefusesResumeAndDriveUntilCallbackRestored(t *testing.T) {
-	for _, action := range []string{"explicit resume", "delegate send", "watch delegate send"} {
-		t.Run(action, func(t *testing.T) {
-			fixture := newOwnedJobDrainFixture(t)
-			finalizationEntered := make(chan struct{})
-			finalizationRelease := make(chan struct{})
-			var releaseOnce sync.Once
-			t.Cleanup(func() { releaseOnce.Do(func() { close(finalizationRelease) }) })
-			var finalizationOnce sync.Once
-			fixture.child.sess.cfg.testOnly.subagentAfterFinalStatePublish = func(got *subagent) {
-				finalizationOnce.Do(func() {
-					if got != fixture.child {
-						t.Errorf("finalization hook child = %p, want %p", got, fixture.child)
-					}
-					close(finalizationEntered)
-					<-finalizationRelease
-				})
+	// All three resume/deliver entry points converge on a single code path:
+	// delegateRuntime.send (explicit resume, delegate_send, and watch-origin
+	// stable send all route through Steer/ReserveStart/CommitStart). There is no
+	// distinct entry point to exercise, so the test runs a single case against
+	// that shared path rather than three identical copy-pasted iterations.
+	fixture := newOwnedJobDrainFixture(t)
+	finalizationEntered := make(chan struct{})
+	finalizationRelease := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(finalizationRelease) }) })
+	var finalizationOnce sync.Once
+	fixture.child.sess.cfg.testOnly.subagentAfterFinalStatePublish = func(got *subagent) {
+		finalizationOnce.Do(func() {
+			if got != fixture.child {
+				t.Errorf("finalization hook child = %p, want %p", got, fixture.child)
 			}
-			var armOnce sync.Once
-			fixture.drainClock.onDrainStop = func() {
-				armOnce.Do(func() {
-					if err := armOwnedJobDrainAttention(fixture.child.sess, "delegate:finalization-window-job", "finalization-window-job"); err != nil {
-						t.Errorf("arm finalization-window attention: %v", err)
-					}
-				})
-			}
-			fixture.env.releaseJob()
-			select {
-			case <-finalizationEntered:
-			case <-time.After(30 * time.Second): // TRIPWIRE: real signal from a background goroutine/job; 30s only fires on a genuine hang.
-				t.Fatal("subagent did not reach the post-publication finalization window")
-			}
-
-			fixture.child.mu.Lock()
-			running := fixture.child.running
-			fixture.child.mu.Unlock()
-			if running {
-				t.Fatal("finalization hook ran before running=false was published")
-			}
-			if fixture.parent.driveSubagentNotificationTurn(fixture.child) {
-				t.Fatal("automatic notification drive launched during callback restoration")
-			}
-
-			switch action {
-			case "explicit resume":
-				res := (delegateRuntime{owner: fixture.parent}).send(context.Background(), fixture.result.DelegateID, "resume too early", 0).result
-				if !errors.Is(res.Err, errDelegateTargetBusy) {
-					t.Fatalf("early explicit resume result = %+v, want target_busy", res)
-				}
-			case "delegate send":
-				res := (delegateRuntime{owner: fixture.parent}).send(context.Background(), fixture.result.DelegateID, "resume too early", 0).result
-				if !errors.Is(res.Err, errDelegateTargetBusy) {
-					t.Fatalf("early delegate_send result = %+v, want target_busy", res)
-				}
-			case "watch delegate send":
-				res := (delegateRuntime{owner: fixture.parent}).send(context.Background(), fixture.result.DelegateID, "resume too early", 0).result
-				if !errors.Is(res.Err, errDelegateTargetBusy) {
-					t.Fatalf("early watch-origin stable send result = %+v, want retryable target_busy", res)
-				}
-			}
-			if queue := fixture.child.sess.SteeringQueueSnapshot(); len(queue) != 0 {
-				t.Fatalf("child steering queue during finalization = %+v, want no delivery", queue)
-			}
-			if requests := fixture.adapter.Requests(); len(requests) != 2 {
-				t.Fatalf("provider requests during finalization = %d, want no resumed or automatic turn", len(requests))
-			}
-
-			releaseOnce.Do(func() { close(finalizationRelease) })
-			waitForOwnedJobDrainGeneration(t, fixture.child, fixture.freshHandled, "post-finalization attention generation")
-			select {
-			case <-fixture.runDone:
-			case <-time.After(30 * time.Second): // TRIPWIRE: real signal from a background goroutine/job; 30s only fires on a genuine hang.
-				t.Fatal("delegate did not finish after callback restoration")
-			}
-			if action == "explicit resume" {
-				fixture.child.sess.cfg.testOnly.subagentAfterFinalStatePublish = nil
-				resumed := (delegateRuntime{owner: fixture.parent}).send(context.Background(), fixture.result.DelegateID, "resume after finalization", 0).result
-				if resumed.Err != nil || resumed.Action != "started" {
-					t.Fatalf("explicit resume after finalization = %+v, want started", resumed)
-				}
-				fixture.child.mu.Lock()
-				resumedDone := fixture.child.done
-				fixture.child.mu.Unlock()
-				select {
-				case <-resumedDone:
-				case <-time.After(30 * time.Second): // TRIPWIRE: real signal from a background goroutine/job; 30s only fires on a genuine hang.
-					t.Fatal("explicit resume after finalization did not finish")
-				}
+			close(finalizationEntered)
+			<-finalizationRelease
+		})
+	}
+	var armOnce sync.Once
+	fixture.drainClock.onDrainStop = func() {
+		armOnce.Do(func() {
+			if err := armOwnedJobDrainAttention(fixture.child.sess, "delegate:finalization-window-job", "finalization-window-job"); err != nil {
+				t.Errorf("arm finalization-window attention: %v", err)
 			}
 		})
+	}
+	fixture.env.releaseJob()
+	select {
+	case <-finalizationEntered:
+	case <-time.After(30 * time.Second): // TRIPWIRE: real signal from a background goroutine/job; 30s only fires on a genuine hang.
+		t.Fatal("subagent did not reach the post-publication finalization window")
+	}
+
+	fixture.child.mu.Lock()
+	running := fixture.child.running
+	fixture.child.mu.Unlock()
+	if running {
+		t.Fatal("finalization hook ran before running=false was published")
+	}
+	if fixture.parent.driveSubagentNotificationTurn(fixture.child) {
+		t.Fatal("automatic notification drive launched during callback restoration")
+	}
+
+	// The shared send path (used by explicit resume, delegate_send, and
+	// watch-origin stable send) must refuse the message while the finalization
+	// callback holds the delegate, returning a retryable target_busy error.
+	res := (delegateRuntime{owner: fixture.parent}).send(context.Background(), fixture.result.DelegateID, "resume too early", 0).result
+	if !errors.Is(res.Err, errDelegateTargetBusy) {
+		t.Fatalf("early send during finalization = %+v, want target_busy", res)
+	}
+	if queue := fixture.child.sess.SteeringQueueSnapshot(); len(queue) != 0 {
+		t.Fatalf("child steering queue during finalization = %+v, want no delivery", queue)
+	}
+	if requests := fixture.adapter.Requests(); len(requests) != 2 {
+		t.Fatalf("provider requests during finalization = %d, want no resumed or automatic turn", len(requests))
+	}
+
+	releaseOnce.Do(func() { close(finalizationRelease) })
+	waitForOwnedJobDrainGeneration(t, fixture.child, fixture.freshHandled, "post-finalization attention generation")
+	select {
+	case <-fixture.runDone:
+	case <-time.After(30 * time.Second): // TRIPWIRE: real signal from a background goroutine/job; 30s only fires on a genuine hang.
+		t.Fatal("delegate did not finish after callback restoration")
+	}
+	fixture.child.sess.cfg.testOnly.subagentAfterFinalStatePublish = nil
+	resumed := (delegateRuntime{owner: fixture.parent}).send(context.Background(), fixture.result.DelegateID, "resume after finalization", 0).result
+	if resumed.Err != nil || resumed.Action != "started" {
+		t.Fatalf("explicit resume after finalization = %+v, want started", resumed)
+	}
+	fixture.child.mu.Lock()
+	resumedDone := fixture.child.done
+	fixture.child.mu.Unlock()
+	select {
+	case <-resumedDone:
+	case <-time.After(30 * time.Second): // TRIPWIRE: real signal from a background goroutine/job; 30s only fires on a genuine hang.
+		t.Fatal("explicit resume after finalization did not finish")
 	}
 }
 

--- a/agent/task_store_test.go
+++ b/agent/task_store_test.go
@@ -1416,8 +1416,12 @@ func TestTaskListTool_AppendWithDependsOn(t *testing.T) {
 	if viewRes.IsError {
 		t.Fatalf("view error: %s", viewRes.Output)
 	}
-	if !strings.Contains(viewRes.Output, "1") {
-		t.Fatalf("view output missing depends_on: %s", viewRes.Output)
+	// Verify the view renders the dependency. The "depends on:" prefix is
+	// specific to tasks that carry DependsOn, so it distinguishes a real
+	// dependency render from a bare task ID like "1" (which task A always
+	// prints regardless of whether dependencies are shown).
+	if !strings.Contains(viewRes.Output, "depends on: 1") {
+		t.Fatalf("view output missing depends_on rendering: %s", viewRes.Output)
 	}
 
 	// Verify store state directly.

--- a/cmd/evener-tui/hub_model_test.go
+++ b/cmd/evener-tui/hub_model_test.go
@@ -40,6 +40,22 @@ func collapseViewWhitespace(view string) string {
 	return strings.Join(strings.Fields(strings.ReplaceAll(view, "│", " ")), " ")
 }
 
+// collapseLabelPadding collapses each line's runs of whitespace to a single
+// space. The detail panes hand-maintain their column padding in the format
+// strings ("Project:  %s", "Live:     %d", "Hub ref:  %s"), so adding or
+// renaming a label rewrites the padding on every sibling line. Collapsing lets
+// a test keep the full "label value" pair — which is what catches a swapped
+// label or a wrong value — without pinning the alignment. Line structure is
+// preserved so a label at the end of one line can never bind to a value at the
+// start of the next.
+func collapseLabelPadding(view string) string {
+	lines := strings.Split(view, "\n")
+	for i, line := range lines {
+		lines[i] = strings.Join(strings.Fields(line), " ")
+	}
+	return strings.Join(lines, "\n")
+}
+
 func TestHubModelInitialFetchRendersLiveAndRecentRows(t *testing.T) {
 	client, cleanup := newTestHubClient(t, func(app *appserver.Server) {
 		appserver.HandleTyped(app.Router(), appwire.MethodThreadList, func(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
@@ -484,21 +500,21 @@ func TestHubModelDashboardWideDetailsFollowSelection(t *testing.T) {
 	m := sampleHubModel(140)
 	m.selected = 1
 
-	projectView := m.dashboardView()
-	for _, want := range []string{"details", "Project:  evener", "Live:     2", "Dir:      /Users/jesse/Documents/GitHub/prime-radiant-inc/evener"} {
+	projectView := collapseLabelPadding(m.dashboardView())
+	for _, want := range []string{"details", "Project: evener", "Live: 2", "Dir: /Users/jesse/Documents/GitHub/prime-radiant-inc/evener"} {
 		if !strings.Contains(projectView, want) {
 			t.Fatalf("wide dashboard project details missing %q:\n%s", want, projectView)
 		}
 	}
 
 	m.selected = dashboardRowIndex(m.dashboardRows(), "Restore hub TUI widgets")
-	sessionView := m.dashboardView()
-	for _, want := range []string{"details", "Session:  01EVENER", "Title:    Restore hub TUI widgets", "Ref:      local:01EVENER"} {
+	sessionView := collapseLabelPadding(m.dashboardView())
+	for _, want := range []string{"details", "Session: 01EVENER", "Title: Restore hub TUI widgets", "Ref: local:01EVENER"} {
 		if !strings.Contains(sessionView, want) {
 			t.Fatalf("wide dashboard session details missing %q:\n%s", want, sessionView)
 		}
 	}
-	if strings.Contains(sessionView, "Live:     2") {
+	if strings.Contains(sessionView, "Live: 2") {
 		t.Fatalf("wide details did not update after selection change:\n%s", sessionView)
 	}
 }
@@ -534,8 +550,8 @@ func TestHubModelDashboardWideDetailsShowDiagnosticSelection(t *testing.T) {
 	m := sampleHubModel(140)
 	m.err = errors.New("hub connection lost")
 
-	got := m.dashboardView()
-	for _, want := range []string{"Diagnostic", "hub connection lost", "Next:     refresh dashboard or check Hub health"} {
+	got := collapseLabelPadding(m.dashboardView())
+	for _, want := range []string{"Diagnostic", "hub connection lost", "Next: refresh dashboard or check Hub health"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("wide dashboard diagnostic details missing %q:\n%s", want, got)
 		}
@@ -2672,15 +2688,15 @@ func TestHubModelStatusUsesHubThreadTasksAndAuth(t *testing.T) {
 	if len(model.session.messages) != 0 {
 		t.Fatalf("/status should not append diagnostics to transcript history: %+v", model.session.messages)
 	}
-	plain := ansiPattern.ReplaceAllString(model.View(), "")
+	plain := collapseLabelPadding(ansiPattern.ReplaceAllString(model.View(), ""))
 	for _, want := range []string{
 		"status",
-		"Model:    gpt-5 (openai)",
-		"Dir:      /tmp/details",
-		"Turns:    2",
-		"Context:  42% used",
-		"Tasks:    1/2 done, 1 active",
-		"Auth:     openai oauth jesse@example.test",
+		"Model: gpt-5 (openai)",
+		"Dir: /tmp/details",
+		"Turns: 2",
+		"Context: 42% used",
+		"Tasks: 1/2 done, 1 active",
+		"Auth: openai oauth jesse@example.test",
 		"Recent errors:",
 		"turn_2: provider quota exceeded",
 	} {

--- a/cmd/evener-tui/hub_transcript_widgets_test.go
+++ b/cmd/evener-tui/hub_transcript_widgets_test.go
@@ -165,9 +165,11 @@ func TestDetailsDrawerShowsCapabilities(t *testing.T) {
 		Compact: true,
 	}
 
-	got := m.renderSessionDetails()
-	// "details" header is now an uppercase section label (DETAILS).
-	for _, want := range []string{"DETAILS", "Source:   codex-local", "Capabilities: send, steer, compact"} {
+	// "details" header is now an uppercase section label (DETAILS). The drawer's
+	// column padding is hand-maintained per format string, so collapse it and keep
+	// each label bound to its full value.
+	got := collapseLabelPadding(m.renderSessionDetails())
+	for _, want := range []string{"DETAILS", "Source: codex-local", "Capabilities: send, steer, compact"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("details drawer missing %q:\n%s", want, got)
 		}
@@ -203,12 +205,14 @@ func TestDetailsDrawerShowsHubDiagnostics(t *testing.T) {
 		},
 	}
 
-	plain := ansiPattern.ReplaceAllString(m.renderSessionDetails(), "")
+	// Column padding is hand-maintained per format string; collapse it so each
+	// label stays bound to its full value without pinning the alignment.
+	plain := collapseLabelPadding(ansiPattern.ReplaceAllString(m.renderSessionDetails(), ""))
 	for _, want := range []string{
-		"Hub ref:  local:01SEND",
-		"Web:      http://127.0.0.1:9180/s/local:01SEND",
-		"Context:  37% used",
-		"Branch:   wip/tui",
+		"Hub ref: local:01SEND",
+		"Web: http://127.0.0.1:9180/s/local:01SEND",
+		"Context: 37% used",
+		"Branch: wip/tui",
 		"Tools (2):",
 		"MCP [linear]: linear__search",
 		"MCP Servers (1):",
@@ -236,8 +240,8 @@ func TestDetailsDrawerShowsMissingDiagnostics(t *testing.T) {
 		Model:       "gpt-5.1",
 	}
 
-	got := m.renderSessionDetails()
-	for _, want := range []string{"Source:   codex", "Diagnostics: not reported by source"} {
+	got := collapseLabelPadding(m.renderSessionDetails())
+	for _, want := range []string{"Source: codex", "Diagnostics: not reported by source"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("details drawer missing %q:\n%s", want, got)
 		}

--- a/cmd/evener-tui/internal/msgrender/tool_renderers_test.go
+++ b/cmd/evener-tui/internal/msgrender/tool_renderers_test.go
@@ -110,8 +110,8 @@ func TestGrepRenderer(t *testing.T) {
 		t.Errorf("grep target should contain pattern: %q", r.Target(args))
 	}
 	result := r.Result(args, "match1\nmatch2\nmatch3", "", 0)
-	if !strings.Contains(result, "3") {
-		t.Errorf("grep result should count hits: %q", result)
+	if !strings.HasPrefix(result, "3 ") {
+		t.Errorf("grep result should count 3 hits: %q", result)
 	}
 }
 


### PR DESCRIPTION
Rebuilt from `main` after the REJECT review. The original 77-commit sweep is gone; nothing was carried forward without being re-argued and mutation-checked individually.

**72 files → 8. 68 files reverted to `main`.** Shrinking this PR was the point.

## What happened to each file

| Disposition | Count | Files |
|---|---|---|
| Kept (genuine strengthening) | 4 | `agent/internal/delegatestore/store_test.go`, `agent/task_store_test.go`, `cmd/evener-tui/internal/msgrender/tool_renderers_test.go`, `agent/internal/tool/definitions_test.go` (grep hunk only) |
| Kept (neutral cleanup) | 1 | `agent/subagent_owned_job_drain_test.go` |
| Rebuilt (brittleness fixed *without* losing content) | 3 | `agent/section_resolver_test.go`, `cmd/evener-tui/hub_model_test.go`, `cmd/evener-tui/hub_transcript_widgets_test.go` |
| Reverted to `main` | 68 | everything else the sweep touched |

The `TestDefAskUserDescriptionIsSpecVerbatim` half of `definitions_test.go` was reverted (the sweep dropped two of its six spec phrases and rewrote the doc comment to claim coverage the code no longer had). Only the `TestDefGrepContextLinesParam` half is kept.

## The three rebuilds

These are the only places the brittleness complaint survived scrutiny, and each is fixed by **normalizing the incidental and keeping the full content**, never by shortening the match.

1. **`section_resolver_test.go`** — the fresh-worktree guidance was pinned as one semicolon-joined sentence. Re-punctuating it into two sentences recapitalizes the second clause and breaks the test without changing what the prompt says. Now matched clause by clause (`fresh worktree` / `dependency directories may be absent` / `copy or install the project's dependencies` / `before running its gates`) against the case-folded section. Same content required; only inter-clause punctuation is free.

2. **`hub_model_test.go` + `hub_transcript_widgets_test.go`** — the dashboard details pane, the `/status` panel and the session details drawer hand-maintain their column alignment inside each format string (`"Project:  %s"`, `"Live:     %d"`, `"Hub ref:  %s"`), so renaming one label rewrites the padding on every sibling line. New `collapseLabelPadding` helper collapses each line's whitespace runs; assertions keep the **full `label value` pair** (`"Live: 2"`, `"Tasks: 1/2 done, 1 active"`, `"Hub ref: local:01SEND"`). Line structure is preserved, so a label ending one line can never bind to a value starting the next. The single-space status line (`"status: hub connected"`, `"auth: openai oauth"`) is untouched — it was never padded.

## Mutation table

Every kept or rebuilt file was mutation-checked: inject the plausible product bug the assertion guards, confirm this branch **fails**, revert.

| File | Product mutation injected | This branch | `main` |
|---|---|---|---|
| `agent/internal/delegatestore/store_test.go` | relabel the batch decode error to `"batch line %d is unreadable"` | **FAIL** | PASS (leak) |
| `agent/task_store_test.go` | delete the `(depends on: N)` clause from the task view | **FAIL** | PASS (leak) |
| `cmd/evener-tui/internal/msgrender/tool_renderers_test.go` | grep hit count off by one (`"2 hits"`) | **FAIL** | FAIL |
| " | grep summary reordered to `"hits: 3"` | **FAIL** | PASS (leak) |
| `agent/internal/tool/definitions_test.go` | `context_lines` documented as `"up to 10 (default 3)"` | **FAIL** | PASS (leak) |
| `agent/subagent_owned_job_drain_test.go` | `admitLeaseLocked` stops fencing on delegate phase — the send lands mid-finalization | **FAIL** | FAIL |
| `agent/section_resolver_test.go` | delete the fresh-worktree sentence from `workflow.md.tmpl` | **FAIL** (all 4 clauses) | FAIL |
| " | drop the copy/install action from the guidance | **FAIL** (2 clauses) | FAIL |
| " | *control:* re-punctuate into two sentences, contract intact | **PASS** | FAIL (false alarm) |
| `cmd/evener-tui/hub_model_test.go` | project details swap the Live and Recent counts | **FAIL** | FAIL |
| " | session details swap the Session ID and Title values | **FAIL** | FAIL |
| " | status panel swaps the Tasks and Auth labels | **FAIL** | FAIL |
| " | diagnostic `Next:` gives different recovery guidance | **FAIL** | FAIL |
| `cmd/evener-tui/hub_transcript_widgets_test.go` | drawer swaps the Hub ref and Source labels | **FAIL** | FAIL |
| " | drawer context percentage off by 10x | **FAIL** | FAIL |

No mutation the rejection listed survives on this branch, because every file those 19 mutations covered is back at `main`'s assertions.

## Broken gates, fixed

- **`make lint`** — PASS (7 modules, 89s). Both findings are gone by reversion: `agent/eval_probes_test.go` (the `modernize/stringscut` offender; the rewrite was neutral anyway, since `main` already matched label-scoped `"Expected answer: django/django"`) and `agent/task/task_store_test.go` (the `perfsprint` offender).
- **`make fuzz-registry-check`** — exit 0. `FuzzUserAgent` is **restored**, not deregistered: `llm/providers/kimicoding/kimicoding_test.go` is back at `main`, so `scripts/fuzz/fuzz-targets.txt:581` is live again. Deleting the target would have needed coordination with the fuzz floors work (#269 / #263); reverting sidesteps that entirely.

## Verification

- `make lint` — PASS (cache cleaned first).
- `make fuzz-registry-check` — exit 0, `FuzzUserAgent` present.
- `go test -race -count=1` green on every touched package: `./agent/`, `./agent/internal/delegatestore/`, `./agent/internal/tool/`, `./cmd/evener-tui/`, `./cmd/evener-tui/internal/msgrender/`.
- `gofmt -l` clean.
- No web files touched (all frontend changes reverted), so no `npm test` run is implicated.
- Rebased onto current `main` (`b0d491c0d`).

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU
