### PR TITLE
fix(agent): remove unused Session.SetTimeout public API

### DIFF
--- a/agent/doc.go
+++ b/agent/doc.go
@@ -38,8 +38,7 @@
 // goroutines may observe and steer it. These methods are safe to call
 // concurrently with a running turn: [Session.Events], [Session.State],
 // [Session.Meta], [Session.QueueDepth], [Session.Steer], [Session.Enqueue],
-// [Session.SetModel], [Session.SetReasoningEffort], [Session.SetTimeout], and
-// [Session.Close].
+// [Session.SetModel], [Session.SetReasoningEffort], and [Session.Close].
 //
 // [Session.Events] returns a channel that [Session.Close] closes, so a range
 // loop over it ends when the session closes. Close stops the session and is the

--- a/agent/session.go
+++ b/agent/session.go
@@ -1162,22 +1162,6 @@ func (s *Session) DroppedModelFallbacksFromLastSwitch() []string {
 	return s.lastDroppedModelFallbacks
 }
 
-// SetTimeout changes the default command timeout for shell tool invocations.
-// Takes effect on the next tool execution.
-func (s *Session) SetTimeout(timeoutMS int) {
-	s.mu.Lock()
-	if s.closingOrClosedLocked() {
-		s.mu.Unlock()
-		return
-	}
-	s.cfg.DefaultCommandTimeoutMS = timeoutMS
-	s.mu.Unlock()
-	// Flush meta.json so a daemon crash before the next happy-path turn
-	// boundary doesn't leave on-disk cfg stale. Kata wnfz. maybeAutoSave
-	// re-acquires s.mu via s.Meta(), so the lock must be released first.
-	s.maybeAutoSave()
-}
-
 // Rename sets a user-chosen session title. It records NameSource="user" so the
 // auto-namers (prompt + compaction) will never overwrite it — shouldApplySession
 // NameLocked and shouldNameFromCompaction both reject any source that is not
@@ -1329,7 +1313,7 @@ func (s *Session) maybeAppendEnvironmentContext() {
 
 // setEnvContextState updates the mu-guarded mirror of envTracker.State() that
 // Meta() reads, then flushes meta.json — mirroring the lock-then-release-then-
-// maybeAutoSave pattern used by SetReasoningEffort/SetTimeout/Rename (maybeAutoSave
+// maybeAutoSave pattern used by SetReasoningEffort/Rename (maybeAutoSave
 // re-acquires mu via Meta(), so it must not be called while mu is held).
 func (s *Session) setEnvContextState(st envctx.State) {
 	s.mu.Lock()

--- a/agent/session_config_test.go
+++ b/agent/session_config_test.go
@@ -89,10 +89,7 @@ func TestSession_SetModel_FlushesMeta(t *testing.T) {
 	}
 }
 
-// kata wnfz: SetTimeout mutates s.cfg.DefaultCommandTimeoutMS. Same crash
-// window: without flushing, on-disk meta.json keeps the previous timeout
-// until the next happy-path autosave.
-func TestSession_SetTimeout_FlushesMeta(t *testing.T) {
+func TestSession_SetModel_NoOpAfterClose(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	c := llm.NewClient()
@@ -100,37 +97,6 @@ func TestSession_SetTimeout_FlushesMeta(t *testing.T) {
 
 	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		StateDir: dir,
-	})
-	if err != nil {
-		t.Fatalf("NewSession: %v", err)
-	}
-	go func() {
-		for range sess.Events() {
-		}
-	}()
-	defer sess.Close()
-
-	sessID := sess.ID()
-	sess.SetTimeout(45_000)
-
-	meta, err := schema.LoadSessionMeta(dir, sessID)
-	if err != nil {
-		t.Fatalf("LoadSessionMeta: %v", err)
-	}
-	if meta.Config.DefaultCommandTimeoutMS != 45_000 {
-		t.Fatalf("meta.Config.DefaultCommandTimeoutMS: got %d want %d", meta.Config.DefaultCommandTimeoutMS, 45_000)
-	}
-}
-
-func TestSession_SetModelAndTimeout_NoOpAfterClose(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	c := llm.NewClient()
-	c.Register(&fakeAdapter{name: "openai"})
-
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
-		StateDir:                dir,
-		DefaultCommandTimeoutMS: 10_000,
 	})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
@@ -148,7 +114,6 @@ func TestSession_SetModelAndTimeout_NoOpAfterClose(t *testing.T) {
 	}
 
 	sess.SetModel("gpt-5.3")
-	sess.SetTimeout(45_000)
 
 	after, err := schema.LoadSessionMeta(dir, sessID)
 	if err != nil {
@@ -157,14 +122,8 @@ func TestSession_SetModelAndTimeout_NoOpAfterClose(t *testing.T) {
 	if after.Model != before.Model {
 		t.Fatalf("closed SetModel changed meta model: got %q want %q", after.Model, before.Model)
 	}
-	if after.Config.DefaultCommandTimeoutMS != before.Config.DefaultCommandTimeoutMS {
-		t.Fatalf("closed SetTimeout changed meta timeout: got %d want %d", after.Config.DefaultCommandTimeoutMS, before.Config.DefaultCommandTimeoutMS)
-	}
 	if got := sess.Meta().Model; got != before.Model {
 		t.Fatalf("closed SetModel changed in-memory model: got %q want %q", got, before.Model)
-	}
-	if got := sess.Meta().Config.DefaultCommandTimeoutMS; got != before.Config.DefaultCommandTimeoutMS {
-		t.Fatalf("closed SetTimeout changed in-memory timeout: got %d want %d", got, before.Config.DefaultCommandTimeoutMS)
 	}
 }
 
@@ -1878,51 +1837,6 @@ func TestSession_SetModel_TakesEffectOnNextCall(t *testing.T) {
 	}
 	if capturedModel != "new-model" {
 		t.Errorf("expected 'new-model', got %q", capturedModel)
-	}
-}
-
-func TestSession_SetTimeout(t *testing.T) {
-	t.Parallel()
-	c := llm.NewClient()
-	f := &fakeAdapter{
-		name: "openai",
-		steps: []func(req llm.Request) llm.Response{
-			func(req llm.Request) llm.Response {
-				return llm.Response{
-					Message: llm.Message{
-						Role: llm.RoleAssistant,
-						Content: []llm.ContentPart{
-							{Kind: llm.ContentToolCall, ToolCall: &llm.ToolCallData{ID: "1", Name: "shell", Arguments: json.RawMessage(`{"command":"echo hi"}`)}},
-						},
-					},
-				}
-			},
-			func(req llm.Request) llm.Response { return finalResponse("ok") },
-		},
-	}
-	c.Register(f)
-
-	env := &captureEnv{wd: "/tmp"}
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), env, SessionConfig{})
-	if err != nil {
-		t.Fatalf("NewSession: %v", err)
-	}
-	defer sess.Close()
-
-	sess.SetTimeout(30000)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
-	defer cancel()
-	if _, err := sess.ProcessInput(ctx, "run", nil); err != nil {
-		t.Fatalf("ProcessInput: %v", err)
-	}
-
-	got, ok := env.TimeoutForCommand("echo hi")
-	if !ok {
-		t.Fatal("expected ExecCommand call with 'echo hi'")
-	}
-	if got != 30000 {
-		t.Fatalf("shell timeout after SetTimeout: got %d want %d", got, 30000)
 	}
 }
 

--- a/agent/session_restore_close_status_program_fuzz_test.go
+++ b/agent/session_restore_close_status_program_fuzz_test.go
@@ -296,11 +296,9 @@ func srspRuntimeAndStatus(t *testing.T, draw byte) {
 
 	model := []string{"gpt-5.3", "gpt-4.1"}[int(draw)&1]
 	effort := []string{"high", "off", "none"}[int(draw)%3]
-	timeout := 1000 + int(draw)
 	name := "  srsp session  "
 	sess.SetModel(model)
 	sess.SetReasoningEffort(effort)
-	sess.SetTimeout(timeout)
 	sess.Rename(name)
 	sess.RegisterTool("srsp_custom", "status fixture", map[string]any{"type": "object"}, func(context.Context, any) (any, error) {
 		return "unused", nil
@@ -311,7 +309,7 @@ func srspRuntimeAndStatus(t *testing.T, draw byte) {
 		t.Fatalf("status tools lost custom/sort invariant: %+v", status.Tools)
 	}
 	meta := sess.Meta()
-	if meta.Model != model || meta.Config.ReasoningEffort != llm.NormalizeReasoningEffort(effort) || meta.Config.DefaultCommandTimeoutMS != timeout || meta.Name != strings.TrimSpace(name) {
+	if meta.Model != model || meta.Config.ReasoningEffort != llm.NormalizeReasoningEffort(effort) || meta.Name != strings.TrimSpace(name) {
 		t.Fatalf("runtime meta = %+v", meta)
 	}
 
@@ -340,11 +338,10 @@ func srspRuntimeAndStatus(t *testing.T, draw byte) {
 	sess.Close()
 	before := sess.Meta()
 	sess.SetModel("gpt-5.4")
-	sess.SetTimeout(timeout + 1)
 	sess.SetReasoningEffort("low")
 	sess.Rename("after close")
 	after := sess.Meta()
-	if after.Model != before.Model || after.Config.DefaultCommandTimeoutMS != before.Config.DefaultCommandTimeoutMS || after.Config.ReasoningEffort != before.Config.ReasoningEffort || after.Name != before.Name {
+	if after.Model != before.Model || after.Config.ReasoningEffort != before.Config.ReasoningEffort || after.Name != before.Name {
 		t.Fatalf("closed setters mutated meta: before=%+v after=%+v", before, after)
 	}
 }

--- a/agent/session_tool_registry.go
+++ b/agent/session_tool_registry.go
@@ -42,7 +42,7 @@ type toolDeps struct {
 	resultToolName func() string
 
 	// cmdTimeouts is a live getter for the default and max shell command
-	// timeouts. It reads cfg on every call so SetTimeout mutations are visible;
+	// timeouts. It reads cfg on every call so cfg mutations are visible;
 	// the values are NOT snapshotted at registration time.
 	cmdTimeouts func() (def, maxTimeout int)
 

--- a/test/scenarios/meta-flush-on-completion.md
+++ b/test/scenarios/meta-flush-on-completion.md
@@ -7,7 +7,9 @@ on an error / panic / ctx-cancellation / cfg setter without
 flushing. The fixes layered: explicit flush on the recoverable LLM
 error (`3tgv`), a deferred flush + panic recovery at the top of
 `processOneInput` (`ztne`), and explicit flush on `SetModel`/
-`SetReasoningEffort`/`SetTimeout` (`wnfz`).
+`SetReasoningEffort`/`SetTimeout` (`wnfz`). `SetTimeout` itself was
+later removed as dead public API (issue #163); `SetModel`/
+`SetReasoningEffort` still carry the same flush.
 
 ## Pre-state
 


### PR DESCRIPTION
## Summary

`Session.SetTimeout` was documented public API (listed in `agent/doc.go`'s concurrency-safe method list) with zero production callers — its only runtime writer of `s.cfg.DefaultCommandTimeoutMS` was itself, and every caller was a test. No CLI flag, RPC route, or hub path reached it. Per the issue's RCA, the fix is removal (YAGNI) rather than wiring it to a new surface, since doing so would require inventing a `--command-timeout` CLI flag from scratch that nothing currently calls for.

- Removed `Session.SetTimeout` from `agent/session.go`, including its doc comment, and updated the nearby `setEnvContextState` comment that listed it alongside `SetReasoningEffort`/`Rename`.
- Dropped `[Session.SetTimeout]` from the concurrency-safe method list in `agent/doc.go`.
- Deleted `TestSession_SetTimeout_FlushesMeta` and `TestSession_SetTimeout` (`agent/session_config_test.go`) — no coverage loss for the flush pattern, since `TestSession_SetReasoningEffort_FlushesMeta`/`TestSession_SetModel_FlushesMeta` already exercise the same `maybeAutoSave` mechanism.
- Stripped the `SetTimeout`-specific parts out of the shared no-op-after-close test (renamed `TestSession_SetModelAndTimeout_NoOpAfterClose` → `TestSession_SetModel_NoOpAfterClose`, keeping its `SetModel` coverage) and out of the restore/close/status fuzz harness (`agent/session_restore_close_status_program_fuzz_test.go`), which retain `SetModel`/`SetReasoningEffort` coverage.
- `DefaultCommandTimeoutMS` itself is untouched — it stays a construction-time/profile-default field (`agent/session_config.go`, `agent/session_init.go`), read live by the shell tool registry; only the runtime setter is gone.

Reference sweep: repo-wide `grep -rn "SetTimeout"` across all `.go` files (root module plus every workspace module: `agent`, `auth`, `envvars`, `fuzz`, `identifier`, `invariant`, `llm`) and across `docs/`, `cmd/evener-hub/frontend`, and the rest of the tree returns zero hits after this change. Historical dated design docs under `docs/superpowers/plans/` and `docs/superpowers/specs/` that narrate the original addition of `SetTimeout` (as a past design decision) were left as archival record, per the RCA's diff sketch, which didn't touch them.

Fixes #163

## Test plan

- [x] `go build ./...` (root + all workspace modules) — clean
- [x] `go test ./...` (root module) — all packages ok
- [x] `go test primeradiant.com/evener/agent/...` — all packages ok (one `TestLive_MCP_StdioServer` flake on the first full-suite run, confirmed unrelated to this change and non-reproducing: passes standalone and on a clean full-module rerun)
- [x] `go test` across the remaining workspace modules (`auth`, `envvars`, `fuzz`, `identifier`, `invariant`, `llm`) — all ok
- [x] `make lint` (golangci-lint cache cleaned first) — PASS across all 7 modules
- [x] Repo-wide grep confirms zero remaining `SetTimeout` references in any `.go` file, `docs/`, or the frontend

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU