### PR TITLE
Fixes #153: unify Makefile and scripts delete-safety audits on one hardened predicate

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -87,10 +87,15 @@ list grows only with an explicitly reviewed reason and shrinks as
 scripts convert or retire.
 
 Two parts of the rule the audit cannot hold, which is why it is written
-here for people. Its scan is textual and per-line, so four equally banned
-spellings are invisible to it: `find -exec rm`, `xargs rm`, a tab between
-`rm` and its flags, and a backslash-newline continuation that puts the
-flags or the path on the next line. And the count pin is narrower than it
+here for people. Its scan is textual, so `find -exec rm -rf {} +` and
+`xargs -I{} rm -rf {}` both read as deletes of the literal `{}`
+placeholder rather than a variable, and slip through — the operand is
+present and visibly not a variable, so neither is a shape the predicate
+can refuse. A recursive delete piped a path with no placeholder at all —
+the ordinary `| xargs rm -rf` shape, or a delete split across a
+backslash-newline continuation — is instead refused outright: the
+predicate cannot tell what it deletes, and treats that as unreadable
+rather than silently passing it. And the count pin is narrower than it
 sounds — it stops a file gaining an *extra* variable-fed delete and it
 fails a listed file whose lines went away, but it cannot see one blessed
 delete being swapped for a different one inside an already-listed file.

--- a/makefile_audit_test.go
+++ b/makefile_audit_test.go
@@ -10,107 +10,11 @@ import (
 	"testing"
 )
 
-// recipeLine trims one physical Makefile line to the shell text it contributes,
-// dropping make's trailing line-continuation backslash.
-//
-// The backslash has to go before anything counts words: left in place it is a
-// bare `\` field, which would read as the path operand of a `rm -rf \` whose
-// real target sits on the next line — exactly the shape the audit must refuse.
-func recipeLine(line string) string {
-	trimmed := strings.TrimSpace(line)
-	return strings.TrimSpace(strings.TrimSuffix(trimmed, `\`))
-}
-
-// recipeCommands splits one Makefile line into the shell commands it holds, so
-// a delete hiding behind `||` or `;` is examined on its own rather than as a
-// tail of whatever ran before it.
-//
-// The two spellings that open a nested command are separators too: a backtick,
-// and the `$$(` that is how a recipe writes shell command substitution (make
-// eats the first dollar, so `$(...)` alone is make's own expansion, never a
-// shell command). Without them a delete wrapped in one reads as an operand of
-// whatever encloses it and is never examined -- `trap` is caught only because
-// it leaves rm as a bare word.
-//
-// Bare braces and parentheses are deliberately NOT separators. `${TMPDIR:-/tmp}`
-// and `$(EVENER_DIST_BIN_DIR)` carry them, and splitting there would tear the
-// variable reference out of the very operand this audit exists to look at.
-func recipeCommands(line string) []string {
-	const sep = "\x00"
-	// `||` is listed before `|`, and `$$(` before either dollar-bearing form, so
-	// the longer operator wins when both match at the same index:
-	// strings.NewReplacer prefers the pattern given first on a tie.
-	return strings.Split(strings.NewReplacer(
-		"&&", sep, "||", sep, "|", sep, ";", sep, "$$(", sep, "`", sep,
-	).Replace(line), sep)
-}
-
-// namesRM reports whether a command word invokes rm.
-//
-// A prefixed or quoted spelling still names the same weapon: make's `@rm` and
-// `-rm`, the `'rm` that opens `trap 'rm -rf …'`, and a fully quoted `"rm"`. The
-// trap spelling matters most — an EXIT trap holding a recursive delete is what
-// deleted a checkout in kata 5hs2 — so it must not read as an ordinary word.
-//
-// Two indirect spellings reach rm without naming it directly. `$(RM)` is
-// defined by GNU make itself (as `rm -f`) and needs no declaration here to
-// work, and any absolute path ends in `/rm`. Both are ordinary things to write,
-// so both have to count.
-func namesRM(field string) bool {
-	word := strings.Trim(field, `@-+'"`)
-	return word == "rm" || word == "$(RM)" || word == "${RM}" || strings.HasSuffix(word, "/rm")
-}
-
-// rmArguments returns the words following an `rm` command word, and reports
-// whether the command invokes rm at all.
-//
-// Finding rm is deliberately separate from deciding the delete is recursive.
-// A recipe may put the command on one physical line and its flags on the next,
-// and a scan that only recognized an already-recursive delete would not see
-// `rm \` as anything at all — so the caller could not refuse it.
-func rmArguments(command string) ([]string, bool) {
-	fields := strings.Fields(command)
-	for i, f := range fields {
-		if namesRM(f) {
-			return fields[i+1:], true
-		}
-	}
-	return nil, false
-}
-
-// recursiveDelete classifies rm's arguments into the paths it would delete and
-// whether any flag among them makes the delete recursive.
-func recursiveDelete(args []string) (operands []string, recursive bool) {
-	for _, f := range args {
-		switch {
-		case f == "--recursive":
-			recursive = true
-		case strings.HasPrefix(f, "--"):
-			// Any other long option, including the bare `--` terminator.
-		case len(f) > 1 && strings.HasPrefix(f, "-"):
-			// A short-flag bundle: -r, -R, -rf, -fr all delete recursively.
-			if strings.ContainsAny(f, "rR") {
-				recursive = true
-			}
-		default:
-			operands = append(operands, strings.Trim(f, `'"`))
-		}
-	}
-	return operands, recursive
-}
-
-// operandComesFromVariable reports whether a recursive delete's target is
-// decided at run time rather than written out by the recipe's author.
-//
-// A recipe reaches the shell after make has expanded it, so three spellings put
-// a run-time value in an operand: `$(VAR)` and `${VAR}` are make's own, and
-// `$$name` is a shell variable make passes through. Every one of them can
-// expand to the empty string, or to a path nobody reviewed. Any `$` therefore
-// counts — make spells a literal dollar `$$` as well, so there is no
-// unambiguous literal dollar to exempt.
-func operandComesFromVariable(operand string) bool {
-	return strings.Contains(operand, "$")
-}
+// The rm-detection predicate this audit walks the Makefile with —
+// recursiveDeleteLineText, recursiveDeleteCommands, namesRM, rmArguments,
+// recursiveDelete, operandComesFromVariable — is shared with the scripts
+// audit's TestNoScriptFeedsVariableToRecursiveDelete and lives in
+// recursivedelete_audit_test.go; see that file's header for why (issue #153).
 
 // makefileVariableFedDeletes are the recipe lines that hand a variable to a
 // recursive delete today, each mapped to the reason it survives review.
@@ -120,8 +24,8 @@ func operandComesFromVariable(operand string) bool {
 // outright is the intended lifecycle. Keying on the whole line is deliberate.
 // It makes each site unique, and it means any edit to a listed line — even a
 // reworded message beside the delete — fails the audit and forces someone to
-// re-read the delete in that diff. Keys are the line as recipeLine normalizes
-// it, so they carry no trailing continuation backslash.
+// re-read the delete in that diff. Keys are the line as recursiveDeleteLineText
+// normalizes it, so they carry no trailing continuation backslash.
 var makefileVariableFedDeletes = map[string]string{
 	`rm -rf "$$dir" || finish_status=1;`: "test-web's log directory: minted on the same recipe by a checked " +
 		`mktemp -d "${TMPDIR:-/tmp}/evener-test-web.XXXXXX" || exit 1, ` +
@@ -163,16 +67,15 @@ func TestNoMakefileRecipeFeedsVariableToRecursiveDelete(t *testing.T) {
 	var unswept, unreadable []string
 	matched := map[string]int{}
 	for i, line := range strings.Split(string(body), "\n") {
-		trimmed := recipeLine(line)
+		// continues reports whether make joins the NEXT physical line onto
+		// this one, which is what makes a delete at the end of this line
+		// unreviewable.
+		trimmed, continues := recursiveDeleteLineText(line)
 		if strings.HasPrefix(trimmed, "#") {
 			continue
 		}
-		// Whether make joins the NEXT physical line onto this one. It is read
-		// before recipeLine strips the marker, and it is what makes a delete at
-		// the end of this line unreviewable.
-		continues := strings.HasSuffix(strings.TrimSpace(line), `\`)
 		where := fmt.Sprintf("Makefile:%d: %s", i+1, trimmed)
-		commands := recipeCommands(trimmed)
+		commands := recursiveDeleteCommands(trimmed, "$$(")
 		for c, command := range commands {
 			args, isRM := rmArguments(command)
 			if !isRM {
@@ -230,10 +133,7 @@ func TestNoMakefileRecipeFeedsVariableToRecursiveDelete(t *testing.T) {
 
 	sort.Strings(unreadable)
 	for _, o := range unreadable {
-		t.Errorf("this delete either runs on past the end of its line or names no path on "+
-			"it, so its flags or its target arrive somewhere nothing here can tie them back "+
-			"to the rm and no review can say what it deletes; keep the whole delete — rm, "+
-			"flags and path — on one line:\n  %s", o)
+		t.Errorf(recursiveDeleteUnreadableReason, o)
 	}
 
 	stale := make([]string, 0, len(makefileVariableFedDeletes))

--- a/recursivedelete_audit_test.go
+++ b/recursivedelete_audit_test.go
@@ -87,12 +87,18 @@ func recursiveDeleteCommands(line, nestOpen string) []string {
 // holding a recursive delete is what deleted a checkout in kata 5hs2 — so it
 // must not read as an ordinary word.
 //
+// Two more glued spellings reach rm with no space at all: a bare subshell
+// with nothing between the paren and the command, `(rm -rf "$x")`, and rm
+// backgrounded with nothing between it and the `&`, `sleep 1 &rm -rf $x`.
+// (PR #276 review: the pre-union scripts scanner's character-boundary check
+// already covered both — the field-based rewrite lost them until now.)
+//
 // Two indirect spellings reach rm without naming it directly. `$(RM)` is
 // defined by GNU make itself (as `rm -f`) and needs no declaration here to
 // work, and any absolute path ends in `/rm`. Both are ordinary things to
 // write, so both have to count.
 func namesRM(field string) bool {
-	word := strings.Trim(field, `@-+'"`)
+	word := strings.Trim(field, `@-+'"(&`)
 	return word == "rm" || word == "$(RM)" || word == "${RM}" || strings.HasSuffix(word, "/rm")
 }
 
@@ -232,6 +238,18 @@ func TestRecursiveDeletePredicateCatchesBothLineages(t *testing.T) {
 		{"delete hidden behind &&", `echo start && rm -rf $x`, shellOpen},
 		{"delete hidden behind ||", `mkdir -p "$x" || rm -rf $x`, shellOpen},
 		{"delete hidden behind ;", `cd /tmp; rm -rf $x`, shellOpen},
+		// PR #276 review finding: the old scripts scanner's boundary-char set
+		// included '(' and '&' — a bare subshell with no space after the
+		// paren, and rm glued directly to a backgrounding '&', both still
+		// invoked rm. namesRM's Trim-cutset approach dropped both when the
+		// scripts audit moved onto it.
+		{"bare subshell with no space after the paren", `(rm -rf "$SOME_VAR")`, shellOpen},
+		{"rm glued to a backgrounding &", `sleep 1 &rm -rf $x`, shellOpen},
+		// PR #276 review finding: real, but previously unproven by any
+		// committed poison case. strings.Fields splits on any whitespace,
+		// including a tab, so `rm` glued to its flags by a tab rather than a
+		// space is still its own field.
+		{"rm glued to its flags by a tab", "rm\t-rf $x", shellOpen},
 	}
 	for _, tc := range flaggedCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/recursivedelete_audit_test.go
+++ b/recursivedelete_audit_test.go
@@ -1,0 +1,319 @@
+package evener_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// This file holds the delete-safety predicate shared by
+// TestNoScriptFeedsVariableToRecursiveDelete (scriptmktemp_audit_test.go) and
+// TestNoMakefileRecipeFeedsVariableToRecursiveDelete (makefile_audit_test.go).
+//
+// The rule both audits hold is the one from kata 5hs2: a recursive delete
+// whose path arrives in a variable deletes whatever that variable happens to
+// hold, and an empty or clobbered expansion turns a scratch cleanup into a
+// delete of something a person would miss. A script and a Makefile recipe
+// are both shell underneath, so the shape of the hazard — and the shape of
+// the detector — is the same in both; only the file-walking, the allowlist
+// bookkeeping, and the failure-message attribution stay separate per caller,
+// deliberately: see each audit's own file.
+//
+// Before this file, each audit carried its own copy of the detector, and
+// they had drifted. The scripts copy (a single-pass textual scan for the
+// substring "rm ") missed make's `@`/`-`/`+` recipe-line prefixes,
+// `$(RM)`/`${RM}`, and a delete split across a backslash-continued line — all
+// of which the Makefile copy (split into commands, then into whitespace
+// fields) caught. This file is their union: every mutation either lineage's
+// test suite defended against still fires here. See issue #153.
+
+// recursiveDeleteLineText trims one physical line — a Makefile recipe line or
+// a shell script line, the continuation convention is identical in both — to
+// the shell text it contributes, and reports whether make or the shell will
+// join the NEXT physical line onto this one.
+//
+// The continuation backslash has to go before anything counts words: left in
+// place it is a bare `\` field, which would read as the path operand of an
+// `rm -rf \` whose real target sits on the next line — exactly the shape a
+// caller must refuse rather than silently pass.
+func recursiveDeleteLineText(line string) (text string, continues bool) {
+	trimmed := strings.TrimSpace(line)
+	continues = strings.HasSuffix(trimmed, `\`)
+	return strings.TrimSpace(strings.TrimSuffix(trimmed, `\`)), continues
+}
+
+// recursiveDeleteCommands splits one line's shell text into the separate
+// commands it holds, so a delete hiding behind `&&`, `||`, `|`, or `;` is
+// examined on its own rather than as a tail of whatever ran before it, and so
+// a delete wrapped in a nested command substitution — a backtick, or however
+// this dialect opens one — is examined instead of read as an operand of
+// whatever encloses it.
+//
+// nestOpen is the one place the two dialects differ. A shell script opens a
+// command substitution with "$(". A Makefile recipe cannot spell it that
+// way: make eats the first dollar sign in `$(...)`, so a recipe writes
+// "$$(" to leave the shell one dollar to open its own substitution with, and
+// "$(" alone in recipe text is make's OWN variable expansion
+// (`$(EVENER_DIST_BIN_DIR)`), which must not split here or the variable
+// reference would be torn out of the very operand this predicate exists to
+// look at. Bare braces (`${...}`) are never a separator, for the same
+// reason, in both dialects.
+//
+// A trailing "# comment" on an already-split command is stripped too — make
+// passes recipe text to the shell verbatim, so the shell's own comment rule
+// applies there as much as it does in a script. It is stripped per command,
+// after splitting, so a literal "#" earlier on the line cannot truncate a
+// different command's text.
+func recursiveDeleteCommands(line, nestOpen string) []string {
+	const sep = "\x00"
+	// "||" is listed before "|", and nestOpen before either dollar-bearing
+	// form, so the longer operator wins when both match at the same index:
+	// strings.NewReplacer prefers the pattern given first on a tie.
+	segments := strings.Split(strings.NewReplacer(
+		"&&", sep, "||", sep, "|", sep, ";", sep, nestOpen, sep, "`", sep,
+	).Replace(line), sep)
+	for i, segment := range segments {
+		if before, _, found := strings.Cut(segment, " #"); found {
+			segments[i] = before
+		}
+	}
+	return segments
+}
+
+// namesRM reports whether a command word invokes rm.
+//
+// A prefixed or quoted spelling still names the same weapon: make's `@rm`
+// and `-rm` recipe-line prefixes, the `'rm` that opens `trap 'rm -rf …'`,
+// and a fully quoted `"rm"`. The trap spelling matters most — an EXIT trap
+// holding a recursive delete is what deleted a checkout in kata 5hs2 — so it
+// must not read as an ordinary word.
+//
+// Two indirect spellings reach rm without naming it directly. `$(RM)` is
+// defined by GNU make itself (as `rm -f`) and needs no declaration here to
+// work, and any absolute path ends in `/rm`. Both are ordinary things to
+// write, so both have to count.
+func namesRM(field string) bool {
+	word := strings.Trim(field, `@-+'"`)
+	return word == "rm" || word == "$(RM)" || word == "${RM}" || strings.HasSuffix(word, "/rm")
+}
+
+// rmArguments returns the words following an `rm` command word, and reports
+// whether the command invokes rm at all.
+//
+// Finding rm is deliberately separate from deciding the delete is recursive.
+// A command may put the command word on one physical line and its flags on
+// the next (see recursiveDeleteLineText), and a scan that only recognized an
+// already-recursive delete would not see `rm \` as anything at all — so the
+// caller could not refuse it.
+func rmArguments(command string) ([]string, bool) {
+	fields := strings.Fields(command)
+	for i, f := range fields {
+		if namesRM(f) {
+			return fields[i+1:], true
+		}
+	}
+	return nil, false
+}
+
+// recursiveDelete classifies rm's arguments into the paths it would delete
+// and whether any flag among them makes the delete recursive.
+func recursiveDelete(args []string) (operands []string, recursive bool) {
+	for _, f := range args {
+		switch {
+		case f == "--recursive":
+			recursive = true
+		case strings.HasPrefix(f, "--"):
+			// Any other long option, including the bare `--` terminator.
+		case len(f) > 1 && strings.HasPrefix(f, "-"):
+			// A short-flag bundle: -r, -R, -rf, -fr all delete recursively.
+			if strings.ContainsAny(f, "rR") {
+				recursive = true
+			}
+		default:
+			operands = append(operands, strings.Trim(f, `'"`))
+		}
+	}
+	return operands, recursive
+}
+
+// operandComesFromVariable reports whether a recursive delete's target is
+// decided at run time rather than written out by the author.
+//
+// A Makefile recipe reaches the shell after make has expanded it, so three
+// spellings put a run-time value in an operand there: `$(VAR)` and `${VAR}`
+// are make's own, and `$$name` is a shell variable make passes through. A
+// script operand does the same with `$VAR`, `${VAR}`, or `$(cmd)`. Every one
+// of them can expand to the empty string, or to a path nobody reviewed. Any
+// `$` therefore counts — a Makefile recipe spells a literal dollar `$$`, so
+// there is no unambiguous literal dollar to exempt there either.
+func operandComesFromVariable(operand string) bool {
+	return strings.Contains(operand, "$")
+}
+
+// recursiveDeleteUnreadableReason explains, for both audits, why a caller
+// must refuse a recursive delete it cannot fully read rather than trying to
+// classify it. The reason is dialect-independent: it is about what the scan
+// itself cannot see, not about which file it is scanning.
+const recursiveDeleteUnreadableReason = "this delete either runs on past the end of its line or names no " +
+	"path on it, so its flags or its target arrive somewhere nothing here can tie them back " +
+	"to the rm and no review can say what it deletes; keep the whole delete — rm, flags and " +
+	"path — on one line:\n  %s"
+
+// recursiveDeleteVerdict runs the full predicate over one already
+// continuation-stripped line for tests: does any command on the line invoke
+// a recursive rm fed by a variable, and does any command invoke a recursive
+// rm this predicate cannot fully read. It exists so the predicate's coverage
+// is provable directly, without needing a Makefile or script fixture; the
+// two real audits keep their own per-command loops (makefile_audit_test.go,
+// scriptmktemp_audit_test.go) because their allowlist bookkeeping needs to
+// tell which specific command on a multi-delete line matched.
+func recursiveDeleteVerdict(line, nestOpen string, continues bool) (flagged, unreadable bool) {
+	commands := recursiveDeleteCommands(line, nestOpen)
+	for c, command := range commands {
+		args, isRM := rmArguments(command)
+		if !isRM {
+			continue
+		}
+		if continues && c == len(commands)-1 {
+			unreadable = true
+			continue
+		}
+		operands, recursive := recursiveDelete(args)
+		if !recursive {
+			continue
+		}
+		if len(operands) == 0 {
+			unreadable = true
+			continue
+		}
+		for _, operand := range operands {
+			if operandComesFromVariable(operand) {
+				flagged = true
+			}
+		}
+	}
+	return flagged, unreadable
+}
+
+// TestRecursiveDeletePredicateCatchesBothLineages is the union proof for
+// issue #153: every mutation either the old scripts detector
+// (recursiveDeleteTakingVariable, now retired) or the old Makefile detector
+// defended against still fires against the one predicate both audits now
+// share.
+func TestRecursiveDeletePredicateCatchesBothLineages(t *testing.T) {
+	t.Parallel()
+
+	const shellOpen = "$("
+	const makeOpen = "$$("
+
+	flaggedCases := []struct {
+		name     string
+		line     string
+		nestOpen string
+	}{
+		// Gap 1 (issue #153): make recipe-line prefixes. The old scripts
+		// scanner required a boundary character immediately before "rm "
+		// drawn from a fixed set that did not include '@', '-', or '+', so
+		// these three read as no match at all.
+		{"make silent prefix @rm", `@rm -rf $$dir`, makeOpen},
+		{"make ignore-errors prefix -rm", `-rm -rf $$dir`, makeOpen},
+		{"make always-run prefix +rm", `+rm -rf $$dir`, makeOpen},
+		// Gap 2 (issue #153): GNU make's built-in $(RM) (defined as `rm -f`)
+		// and the brace spelling ${RM}. The old scripts scanner searched for
+		// the literal substring "rm ", which neither of these contains.
+		{"make builtin $(RM)", `$(RM) -rf $$dir`, makeOpen},
+		{"make builtin ${RM}", `${RM} -rf $$dir`, makeOpen},
+		// Preserved from both lineages: the trap spelling that deleted a
+		// checkout in kata 5hs2, a backtick command substitution, and an
+		// absolute path invocation.
+		{"quoted trap spelling", `trap 'rm -rf $dir' EXIT`, shellOpen},
+		{"backtick command substitution", "x=`rm -rf $y`", shellOpen},
+		{"absolute path invocation", `/bin/rm -rf $x`, shellOpen},
+		{"double-quoted rm", `"rm" -rf $x`, shellOpen},
+		{"delete hidden behind &&", `echo start && rm -rf $x`, shellOpen},
+		{"delete hidden behind ||", `mkdir -p "$x" || rm -rf $x`, shellOpen},
+		{"delete hidden behind ;", `cd /tmp; rm -rf $x`, shellOpen},
+	}
+	for _, tc := range flaggedCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			flagged, unreadable := recursiveDeleteVerdict(tc.line, tc.nestOpen, false)
+			if !flagged {
+				t.Errorf("recursiveDeleteVerdict(%q) = flagged=false, want flagged=true", tc.line)
+			}
+			if unreadable {
+				t.Errorf("recursiveDeleteVerdict(%q) = unreadable=true, want false (this line is fully readable)", tc.line)
+			}
+		})
+	}
+
+	unreadableCases := []struct {
+		name      string
+		line      string
+		nestOpen  string
+		continues bool
+	}{
+		// Gap 3 (issue #153): a delete split across a backslash-continued
+		// line. The Makefile detector already refused this shape
+		// ("last-segment-on-continued-line refusal" in the issue); the old
+		// scripts scanner had no continuation awareness at all and would
+		// have silently passed a script that split its flags or path onto
+		// the next physical line.
+		{"rm as last command on a continued Makefile recipe line", `rm -rf`, makeOpen, true},
+		{"rm as last command on a continued script line", `rm -rf`, shellOpen, true},
+		// Bonus closure (documented as an accepted gap in docs/testing.md
+		// for the old scripts scanner): a recursive rm with no operand at
+		// all, because its target arrives over a pipe rather than as a
+		// command-line argument. Unifying on the Makefile detector's
+		// zero-operand refusal closes this for scripts too.
+		{"recursive rm with target piped in via xargs", `find . -name '*.tmp' -print0 | xargs -0 rm -rf`, shellOpen, false},
+	}
+	for _, tc := range unreadableCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, unreadable := recursiveDeleteVerdict(tc.line, tc.nestOpen, tc.continues)
+			if !unreadable {
+				t.Errorf("recursiveDeleteVerdict(%q, continues=%v) = unreadable=false, want true", tc.line, tc.continues)
+			}
+		})
+	}
+
+	// A line does not become unreadable just by virtue of continuing: only
+	// the LAST command on a continued line is unreadable, because "||"/";"
+	// close the delete before the continuation does. Confirm a delete
+	// earlier on a continued line still reads as flagged (readable, and
+	// variable-fed) rather than merely "not unreadable".
+	t.Run("delete followed by more commands on a continued line stays flagged and readable", func(t *testing.T) {
+		t.Parallel()
+		flagged, unreadable := recursiveDeleteVerdict(`rm -rf $x; echo done`, shellOpen, true)
+		if !flagged {
+			t.Error("want flagged=true for a readable delete earlier on a continued line")
+		}
+		if unreadable {
+			t.Error("want unreadable=false: the delete is not the last command on the line")
+		}
+	})
+
+	safeCases := []struct {
+		name     string
+		line     string
+		nestOpen string
+	}{
+		{"no rm at all", `echo hello`, shellOpen},
+		{"word merely containing rm is not a word boundary match", `confirm -rf $x`, shellOpen},
+		{"non-recursive delete of a variable path", `rm "$x"`, shellOpen},
+		{"recursive delete of an author-owned literal path", `rm -rf ./dist`, shellOpen},
+		{"docker --rm flag is not an rm invocation on its own", `docker run --rm alpine true`, shellOpen},
+	}
+	for _, tc := range safeCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			flagged, unreadable := recursiveDeleteVerdict(tc.line, tc.nestOpen, false)
+			if flagged {
+				t.Errorf("recursiveDeleteVerdict(%q) = flagged=true, want false", tc.line)
+			}
+			if unreadable {
+				t.Errorf("recursiveDeleteVerdict(%q) = unreadable=true, want false", tc.line)
+			}
+		})
+	}
+}

--- a/scriptmktemp_audit_test.go
+++ b/scriptmktemp_audit_test.go
@@ -235,71 +235,17 @@ func TestScratchDirCannotResolveToCWD(t *testing.T) {
 	}
 }
 
-// recursiveDeleteTakingVariable reports whether a line invokes `rm` with a
-// recursive flag and any argument that expands a variable. That shape is what
-// Jesse banned after kata 5hs2: a delete that accepts a path can be handed
-// $PWD, $HOME, or / by a variable that was emptied or clobbered, and no
-// checking inside the callee makes the caller's variable trustworthy. The safe
-// spellings take no argument at all (scratch_rm in scripts/scratch-lib.sh) or
-// live on the count-pinned list below with a reason.
+// The rm-detection predicate this audit walks scripts/ with —
+// recursiveDeleteLineText, recursiveDeleteCommands, namesRM, rmArguments,
+// recursiveDelete, operandComesFromVariable — is shared with the Makefile
+// audit's TestNoMakefileRecipeFeedsVariableToRecursiveDelete and lives in
+// recursivedelete_audit_test.go; see that file's header for why (issue #153).
 //
-// The scan is textual, so `find -exec rm` and `xargs rm` would slip past it,
-// as would `rm<TAB>flags` (the match requires "rm" followed by a space) and a
-// backslash-newline continuation that puts rm's arguments on the next line —
-// the scan is per-line. None of those spellings exist in the scanned scripts
-// today, and the policy in docs/testing.md covers them. A false positive is
-// impossible to suppress silently: the only way past the check is a reviewed
-// entry in recursiveDeleteAllowedLines.
-func recursiveDeleteTakingVariable(line string) bool {
-	rest := line
-	for {
-		at := strings.Index(rest, "rm ")
-		if at < 0 {
-			return false
-		}
-		ownWord := at == 0
-		if at > 0 {
-			switch rest[at-1] {
-			// `/bin/rm`, `$(rm ...)`, backticked, piped, chained, and
-			// trap-quoted (`trap 'rm -rf ...' EXIT`) spellings all still
-			// invoke rm; mid-word hits like "confirm " do not.
-			case ' ', '\t', ';', '(', '|', '&', '/', '`', '\'', '"':
-				ownWord = true
-			}
-		}
-		call := rest[at:]
-		rest = rest[at+len("rm "):]
-		if !ownWord {
-			continue
-		}
-		// Stop at whatever ends the command, so the next command's words are
-		// not mistaken for rm's arguments. A command substitution inside an
-		// argument gets truncated mid-arg by ")", which can only widen the
-		// match, never hide one.
-		for _, terminator := range []string{";", "|", "&&", "||", ")", "`", " #"} {
-			if i := strings.Index(call, terminator); i >= 0 {
-				call = call[:i]
-			}
-		}
-		fields := strings.Fields(call)
-		recursive := false
-		variable := false
-		for _, f := range fields[1:] {
-			if strings.HasPrefix(f, "-") && !strings.Contains(f, "$") {
-				if strings.ContainsAny(f, "rR") {
-					recursive = true
-				}
-				continue
-			}
-			if strings.Contains(f, "$") {
-				variable = true
-			}
-		}
-		if recursive && variable {
-			return true
-		}
-	}
-}
+// What the scan still cannot see, even shared: `find -exec rm` is a delete of
+// the literal `{}` operand, never a variable. None of that spelling exists in
+// the scanned scripts today, and the policy in docs/testing.md covers it. A
+// false positive is impossible to suppress silently: the only way past the
+// check is a reviewed entry in recursiveDeleteAllowedLines.
 
 // recursiveDeleteAllowedLines is every variable-fed recursive delete the
 // repository still contains, pinned to an exact count per script. The count
@@ -387,7 +333,7 @@ func TestNoScriptFeedsVariableToRecursiveDelete(t *testing.T) {
 	// user's shell, where a clobbered delete would be someone else's home.
 	allPaths := append([]string{"install.sh"}, paths...)
 	counts := map[string]int{}
-	var offenders []string
+	var offenders, unreadable []string
 	for _, path := range allPaths {
 		name := filepath.Base(path)
 		body, err := os.ReadFile(path)
@@ -395,16 +341,53 @@ func TestNoScriptFeedsVariableToRecursiveDelete(t *testing.T) {
 			t.Fatalf("read %s: %v", path, err)
 		}
 		for i, line := range strings.Split(string(body), "\n") {
-			trimmed := strings.TrimSpace(line)
+			// continues reports whether the shell joins the NEXT physical
+			// line onto this one, which is what makes a delete at the end
+			// of this line unreviewable.
+			trimmed, continues := recursiveDeleteLineText(line)
 			if strings.HasPrefix(trimmed, "#") {
 				continue
 			}
-			if !recursiveDeleteTakingVariable(trimmed) {
-				continue
-			}
-			counts[name]++
-			if counts[name] > recursiveDeleteAllowedLines[name] {
-				offenders = append(offenders, fmt.Sprintf("%s:%d: %s", path, i+1, trimmed))
+			where := fmt.Sprintf("%s:%d: %s", path, i+1, trimmed)
+			commands := recursiveDeleteCommands(trimmed, "$(")
+			for c, command := range commands {
+				args, isRM := rmArguments(command)
+				if !isRM {
+					continue
+				}
+				// An rm that is the LAST command on a continued line runs on
+				// into the next physical line, which may carry its
+				// recursion flag, its path, or both. Neither this line nor
+				// the next says what gets deleted, so the shape is refused
+				// outright rather than allowlisted: a delete that cannot be
+				// read cannot be reviewed.
+				if continues && c == len(commands)-1 {
+					unreadable = append(unreadable, where)
+					continue
+				}
+				operands, recursive := recursiveDelete(args)
+				if !recursive {
+					continue
+				}
+				// A recursive delete with no path at all takes its target
+				// from a pipe (`xargs rm -rf`), which is equally unreadable.
+				if len(operands) == 0 {
+					unreadable = append(unreadable, where)
+					continue
+				}
+				fromVariable := false
+				for _, operand := range operands {
+					if operandComesFromVariable(operand) {
+						fromVariable = true
+					}
+				}
+				if !fromVariable {
+					continue
+				}
+				counts[name]++
+				if counts[name] > recursiveDeleteAllowedLines[name] {
+					offenders = append(offenders, where)
+				}
 			}
 		}
 	}
@@ -413,6 +396,10 @@ func TestNoScriptFeedsVariableToRecursiveDelete(t *testing.T) {
 		t.Errorf("this recursive delete takes a variable a caller can clobber (kata 5hs2 "+
 			"deleted a home directory this way); mint scratch with `scratch_dir <var> <prefix>` "+
 			"and reclaim it with the no-argument `scratch_rm` from scripts/lib/scratch-lib.sh:\n  %s", o)
+	}
+	sort.Strings(unreadable)
+	for _, o := range unreadable {
+		t.Errorf(recursiveDeleteUnreadableReason, o)
 	}
 	for name, want := range recursiveDeleteAllowedLines {
 		if got := counts[name]; got < want {


### PR DESCRIPTION
## Summary
- `TestNoScriptFeedsVariableToRecursiveDelete` (scripts) and `TestNoMakefileRecipeFeedsVariableToRecursiveDelete` (Makefile) each carried their own copy of the variable-fed-recursive-delete matcher, and had drifted: the scripts copy (a single-pass textual scan for `"rm "`) missed make's `@`/`-`/`+` recipe-line prefixes, `$(RM)`/`${RM}`, and a delete split across a backslash-continued line — all of which the Makefile copy (split into commands, then into whitespace fields) already caught.
- Extracted the shared predicate into `recursivedelete_audit_test.go` (`recursiveDeleteLineText`, `recursiveDeleteCommands`, `namesRM`, `rmArguments`, `recursiveDelete`, `operandComesFromVariable`) and rewired both audits' loops onto it. Each audit keeps its own file-walking, allowlist bookkeeping (`recursiveDeleteAllowedLines`, `makefileVariableFedDeletes` — both unchanged), and Makefile/script line attribution.
- Adopting the Makefile detector's zero-operand refusal for scripts also closes a documented gap for the plain `| xargs rm -rf` shape, and Fields-based word matching closes the documented tab-between-`rm`-and-flags gap; updated `docs/testing.md` to match. `find -exec rm -rf {} +` and `xargs -I{} rm -rf {}` remain invisible, since their operand is a literal `{}` placeholder rather than a variable — documented, not fixed.

## Poison-case evidence
- `recursivedelete_audit_test.go`'s `TestRecursiveDeletePredicateCatchesBothLineages` is a permanent table-driven proof: `@rm`/`-rm`/`+rm` prefixes, `$(RM)`/`${RM}`, and last-command-on-a-continued-line all flag/refuse correctly, alongside the previously-covered trap/backtick/absolute-path spellings and false-positive guards (`confirm`, `docker --rm`).
- Manual mutation evidence (planted, watched fail, reverted — not left in the tree):
  - Makefile: added `@rm -rf "$$POISON_MUTATION_153"` after the `clean` recipe → `TestNoMakefileRecipeFeedsVariableToRecursiveDelete` FAILED on it.
  - Script: added a continuation-split `rm \` / `-rf "$POISON_MUTATION_153_DIR"` to `scripts/lib/gate-surface-lib.sh` → `TestNoScriptFeedsVariableToRecursiveDelete` FAILED on it (a gap the old scripts scanner had no continuation awareness to catch at all).

## Test plan
- [x] `go test . -run TestRecursiveDeletePredicateCatchesBothLineages -v -count=1` — all poison cases pass
- [x] `go test . -run 'TestNoScriptFeedsVariableToRecursiveDelete|TestNoMakefileRecipeFeedsVariableToRecursiveDelete|TestNoScriptCreatesScratchOutsideTMPDIR|TestScratchDirCannotResolveToCWD|TestBuildAllBuildsEveryInstalledBinary'` — pass against real Makefile/scripts content (no regression in allowlist counts)
- [x] `go test . -count=1` (full root package) — pass
- [x] `make lint` — pass (7 modules)
- [x] Manual mutation evidence for both a Makefile poison line and a script poison line (see above), reverted before commit

https://claude.ai/code/session_0134LFae5DzpDExkuhJTCNfU