### PR TITLE
Fix transcript autoscroll: open at bottom, disable when scrolled back

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/scrollMetrics.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/scrollMetrics.test.ts
@@ -7,18 +7,21 @@ import {
   readScrollMetrics,
 } from "./scrollMetrics";
 
-// isAtBottom: legacy parity threshold (docs/web-ui/parity/parity-m4-transcript.md
-// §15) - "within 50px of true bottom counts as at bottom".
+// isAtBottom: "at the bottom" means the reader is at the TRUE end of the
+// scrollable content, not merely near it. The threshold is a few pixels
+// (rounding-safe, far smaller than one line of text ~20px) so a reader who
+// has scrolled back even one line is NOT treated as at the bottom - the
+// legacy 50px value let autoscroll engage while scrolled comfortably back.
 test("isAtBottom: true when scrollTop+clientHeight exactly equals scrollHeight (pixel-perfect bottom)", () => {
   expect(isAtBottom({ scrollTop: 950, scrollHeight: 1000, clientHeight: 50 })).toBe(true);
 });
 
-test("isAtBottom: true within the 50px threshold", () => {
-  expect(isAtBottom({ scrollTop: 910, scrollHeight: 1000, clientHeight: 40 })).toBe(true); // gap = 50
+test("isAtBottom: true within the 4px threshold (rounding tolerance)", () => {
+  expect(isAtBottom({ scrollTop: 946, scrollHeight: 1000, clientHeight: 50 })).toBe(true); // gap = 4
 });
 
-test("isAtBottom: false just past the 50px threshold", () => {
-  expect(isAtBottom({ scrollTop: 909, scrollHeight: 1000, clientHeight: 40 })).toBe(false); // gap = 51
+test("isAtBottom: false just past the 4px threshold (one line of text is ~20px, far larger)", () => {
+  expect(isAtBottom({ scrollTop: 945, scrollHeight: 1000, clientHeight: 50 })).toBe(false); // gap = 5
 });
 
 test("isAtBottom: true for a short thread that doesn't scroll at all (scrollHeight <= clientHeight)", () => {
@@ -29,13 +32,13 @@ test("isAtBottom: false when scrolled far up", () => {
   expect(isAtBottom({ scrollTop: 0, scrollHeight: 5000, clientHeight: 500 })).toBe(false);
 });
 
-test("isAtBottom: accepts a custom threshold, overriding the 50px default", () => {
+test("isAtBottom: accepts a custom threshold, overriding the 4px default", () => {
   expect(isAtBottom({ scrollTop: 800, scrollHeight: 1000, clientHeight: 100 }, 100)).toBe(true); // gap = 100
-  expect(isAtBottom({ scrollTop: 800, scrollHeight: 1000, clientHeight: 100 }, 50)).toBe(false);
+  expect(isAtBottom({ scrollTop: 800, scrollHeight: 1000, clientHeight: 100 }, 4)).toBe(false);
 });
 
-test("AT_BOTTOM_THRESHOLD_PX is the legacy-matching 50px default", () => {
-  expect(AT_BOTTOM_THRESHOLD_PX).toBe(50);
+test("AT_BOTTOM_THRESHOLD_PX is the 4px default (rounding-safe, smaller than one line of text)", () => {
+  expect(AT_BOTTOM_THRESHOLD_PX).toBe(4);
 });
 
 // isNearTop: legacy parity threshold (parity doc §15) - "scrollTop < 200

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/scrollMetrics.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/scrollMetrics.ts
@@ -12,9 +12,15 @@ export interface ScrollMetrics {
   clientHeight: number;
 }
 
-// Legacy renderer.js parity (docs/web-ui/parity/parity-m4-transcript.md
-// §15): isNearBottom is "within 50px of true bottom".
-export const AT_BOTTOM_THRESHOLD_PX = 50;
+// "At the bottom" means the reader is at the TRUE end of the scrollable
+// content, not merely near it. A threshold of a few pixels tolerates the
+// sub-pixel rounding browsers apply to scrollTop/scrollHeight without ever
+// treating a reader who has scrolled back by even one line of text (~20px)
+// as "at the bottom" - the previous 50px legacy value let autoscroll engage
+// while the reader was comfortably scrolled back into history, yanking the
+// transcript underneath them. One line of text is far larger than 4px, so
+// this is effectively "truly at the bottom" while remaining rounding-safe.
+export const AT_BOTTOM_THRESHOLD_PX = 4;
 
 // Legacy renderer.js parity (same doc, §15): isNearTop is "scrollTop < 200".
 export const NEAR_TOP_THRESHOLD_PX = 200;

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.test.ts
@@ -897,6 +897,36 @@ describe("mount positioning", () => {
 // computed against the PREVIOUS session's scroll state. These tests prove the
 // ref change re-initializes all of that.
 describe("ref change on a persistent pane instance (sidebar click to a different session)", () => {
+  test("changing ref cancels a pending view anchor before the fresh-open scroll-to-bottom", () => {
+    const { ref, el, scrollToIndex } = makeListHandle();
+    scrollToIndex.mockImplementation((_index, options) => {
+      if (options.align === "end") el.scrollTop = 900;
+    });
+    const { measure } = makeMeasure({ scrollTop: 300, scrollHeight: 1200, clientHeight: 300 });
+    let positions: ViewAnchorPosition[] = [
+      { id: "ref-a-tool", sourceIndex: 4, index: 4, offset: -18, height: 40, isMessage: false },
+    ];
+    const { result, rerender } = renderHook(
+      ({ r }) =>
+        useTranscriptScroll({
+          ref: r,
+          model: model([turn("t1", ["i1"])]),
+          listRef: ref,
+          loadOlder: vi.fn(),
+          measure,
+          measureAnchors: () => positions,
+        }),
+      { initialProps: { r: "ref_a" } },
+    );
+
+    act(() => result.current.captureViewAnchor());
+    positions = [{ id: "ref-b-message", sourceIndex: 5, index: 0, offset: 0, height: 96, isMessage: true }];
+    rerender({ r: "ref_b" });
+    act(() => result.current.restoreViewAnchorAfterMeasurement());
+
+    expect(el.scrollTop).toBe(900);
+  });
+
   test("changing ref re-runs the scroll-to-bottom for the new session", () => {
     const { ref, scrollToIndex } = makeListHandle();
     const { measure } = makeMeasure(AT_BOTTOM);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.test.ts
@@ -886,6 +886,129 @@ describe("mount positioning", () => {
   });
 });
 
+// The Session pane is NOT keyed by ref (DockHost's PaneHost renders
+// <Component params=...> with no key), so clicking a different session in the
+// sidebar updates params.ref on the SAME mounted component instance. Without
+// a reset, useTranscriptScroll's per-mount refs (initializedRef,
+// wasAtBottomRef, baselineItemCountRef, firstTurnIdRef,
+// resolvedFailedTurnIdsRef, errorAnchorIndex) all persist across the ref
+// change, so the new session opens wherever the virtualizer defaults (the
+// scroll-to-bottom is skipped) and stick-to-bottom / pill counts are
+// computed against the PREVIOUS session's scroll state. These tests prove the
+// ref change re-initializes all of that.
+describe("ref change on a persistent pane instance (sidebar click to a different session)", () => {
+  test("changing ref re-runs the scroll-to-bottom for the new session", () => {
+    const { ref, scrollToIndex } = makeListHandle();
+    const { measure } = makeMeasure(AT_BOTTOM);
+    const { rerender } = renderHook(
+      ({ r }) =>
+        useTranscriptScroll({
+          ref: r,
+          model: model([turn("t1", ["i1"]), turn("t2", ["i2"])]),
+          listRef: ref,
+          loadOlder: vi.fn(),
+          measure,
+        }),
+      { initialProps: { r: "ref_a" } },
+    );
+    // Initial mount scrolled to bottom for ref_a.
+    expect(scrollToIndex).toHaveBeenCalledWith(1, { align: "end" });
+    scrollToIndex.mockClear();
+
+    // Sidebar click to a different session reuses the same hook instance.
+    rerender({ r: "ref_b" });
+
+    // The new session must also land at the bottom.
+    expect(scrollToIndex).toHaveBeenCalledWith(1, { align: "end" });
+  });
+
+  test("changing ref resets the pill count and baseline, so the new session doesn't inherit the old one's unseen count", () => {
+    const { ref, scrollToIndex } = makeListHandle();
+    const { measure } = makeMeasure(SCROLLED_AWAY);
+    const { result, rerender } = renderHook(
+      ({ r, m }) => useTranscriptScroll({ ref: r, model: m, listRef: ref, loadOlder: vi.fn(), measure }),
+      {
+        initialProps: {
+          r: "ref_a",
+          m: model([turn("t1", ["i1"])]),
+        },
+      },
+    );
+    // Append while scrolled away -> pill counts for ref_a.
+    rerender({ r: "ref_a", m: model([turn("t1", ["i1"]), turn("t2", ["i2"])]) });
+    expect(result.current.pillCount).toBe(1);
+
+    // Switch to ref_b (sidebar click). Pill must reset to 0 and the scroll-to-bottom must fire.
+    scrollToIndex.mockClear();
+    rerender({ r: "ref_b", m: model([turn("t1", ["i1"]), turn("t2", ["i2"])]) });
+
+    expect(result.current.pillCount).toBe(0);
+    expect(scrollToIndex).toHaveBeenCalledWith(1, { align: "end" });
+  });
+
+  test("changing ref clears an active error anchor so the new session doesn't inherit the old one's failed-turn anchor", () => {
+    const { ref, scrollToIndex } = makeListHandle();
+    const { measure } = makeMeasure(SCROLLED_AWAY);
+    const { result, rerender } = renderHook(
+      ({ r, m }) => useTranscriptScroll({ ref: r, model: m, listRef: ref, loadOlder: vi.fn(), measure }),
+      {
+        initialProps: {
+          r: "ref_a",
+          m: model([turn("t1", ["i1"])]),
+        },
+      },
+    );
+    // Append a failed turn on ref_a (scrolled away) -> becomes the error anchor.
+    rerender({ r: "ref_a", m: model([turn("t1", ["i1"]), turn("t2", ["i2"], { status: "failed" })]) });
+    expect(result.current.pillError).toBe(true);
+
+    // Switch to ref_b (no failed turn). The error anchor must clear.
+    scrollToIndex.mockClear();
+    rerender({ r: "ref_b", m: model([turn("t1", ["i1"]), turn("t2", ["i2"])]) });
+
+    expect(result.current.pillError).toBe(false);
+    expect(scrollToIndex).toHaveBeenCalledWith(1, { align: "end" });
+  });
+});
+
+// A same-ref remount (the model briefly goes undefined - e.g. a store resync
+// that clears the thread, or the same ref re-hydrating - so VirtualList
+// unmounts then remounts) must also re-run the scroll-to-bottom.
+// initializedRef was left true from the first hydration; without a reset the
+// remount skips the scroll-to-bottom and strands the reader at the top.
+describe("same-ref remount (model undefined -> defined on the same ref)", () => {
+  test("re-hydrating the same ref after the model went undefined re-runs the scroll-to-bottom", () => {
+    const list = makeListHandle();
+    const handle = list.ref.current;
+    const { measure } = makeMeasure(AT_BOTTOM);
+    const { result, rerender } = renderHook(
+      ({ m }) =>
+        useTranscriptScroll({
+          ref: "ref_a",
+          model: m,
+          listRef: list.ref,
+          loadOlder: vi.fn(),
+          measure,
+        }),
+      { initialProps: { m: model([turn("t1", ["i1"]), turn("t2", ["i2"])]) as ThreadModel | undefined } },
+    );
+    // Initial mount scrolled to bottom.
+    expect(list.scrollToIndex).toHaveBeenCalledWith(1, { align: "end" });
+    list.scrollToIndex.mockClear();
+
+    // Model goes undefined (VirtualList unmounts). listRef reads null.
+    (list.ref as { current: VirtualListHandle | null }).current = null;
+    rerender({ m: undefined as ThreadModel | undefined });
+    expect(result.current.pillCount).toBe(0);
+
+    // Model re-hydrates (VirtualList remounts). Must scroll to bottom again.
+    (list.ref as { current: VirtualListHandle | null }).current = handle;
+    rerender({ m: model([turn("t1", ["i1"]), turn("t2", ["i2"])]) });
+
+    expect(list.scrollToIndex).toHaveBeenCalledWith(1, { align: "end" });
+  });
+});
+
 describe("view-mode anchor preservation", () => {
   test("captures and restores the same stable entry and viewport offset", () => {
     const anchor = captureTopAnchor({ id: "turn-4", sourceIndex: 4, index: 4, offset: 18, isMessage: true });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts
@@ -242,6 +242,19 @@ export function useTranscriptScroll({
   const firstTurnIdRef = useRef<string | undefined>(undefined);
   const baselineItemCountRef = useRef(0);
   const initializedRef = useRef(false);
+  // The ref this hook's per-ref state was initialized for. The Session pane
+  // is NOT keyed by ref (DockHost's PaneHost renders <Component params=...>
+  // with no key), so clicking a different session in the sidebar updates
+  // params.ref on the SAME mounted component instance - useTranscriptScroll's
+  // own refs (initializedRef, wasAtBottomRef, baselineItemCountRef,
+  // firstTurnIdRef, resolvedFailedTurnIdsRef, errorAnchorIndex) all persist
+  // across that change. Without a reset, the new session opens wherever the
+  // virtualizer defaults (initializedRef is already true, so the mount
+  // effect's scroll-to-bottom is skipped) and stick-to-bottom / pill counts
+  // are computed against the PREVIOUS session's scroll state. refForInitRef
+  // detects the change and re-initializes every per-ref piece of state so
+  // the new session is treated as a fresh open (always land at the bottom).
+  const refForInitRef = useRef<string | undefined>(ref);
   const pendingViewAnchorRef = useRef<{
     anchor: ViewAnchor | undefined;
     proportion: number;
@@ -303,6 +316,15 @@ export function useTranscriptScroll({
   // own render condition exactly, so this flips at the SAME transition
   // VirtualList actually mounts at.
   const hasContent = !isDormantTranscript(model?.turns ?? []);
+  // Track hasContent transitions so a false->true flip (VirtualList remounts
+  // after the model briefly went undefined - e.g. a store resync that clears
+  // the thread, or the same ref re-hydrating) re-runs the one-time
+  // scroll-to-bottom. initializedRef alone can't see this: it was set true on
+  // the first hydration and never resets, so a remount on the SAME ref would
+  // skip the scroll-to-bottom and strand the reader at the virtualizer's
+  // default top position. (A ref CHANGE is handled separately by
+  // refForInitRef below; this handles the same-ref remount.)
+  const prevHasContentRef = useRef(hasContent);
   // Also kept in refs for the scroll listener/jumpToBottom, which are not
   // re-created on every render (see the effects below).
   const itemCountRef = useRef(itemCount);
@@ -406,6 +428,36 @@ export function useTranscriptScroll({
   // triggers no rerun.
   // biome-ignore lint/correctness/useExhaustiveDependencies: both flags below are deliberate, re-verified against this rule - see the two comments inside
   useLayoutEffect(() => {
+    // Ref change on a persistent Session instance (sidebar click to a
+    // different session reuses the pane - see refForInitRef's own comment):
+    // reset every per-ref piece of state so the new session is treated as a
+    // fresh open. This runs before the initializedRef guard below so that
+    // guard re-executes its scroll-to-bottom for the new ref.
+    //
+    // A same-ref remount (hasContent false->true: the model briefly went
+    // undefined and VirtualList unmounted, then re-hydrated) is caught here
+    // too: initializedRef was left true from the first hydration, so without
+    // this reset the remount would skip the scroll-to-bottom and strand the
+    // reader at the top.
+    //
+    // This block runs BEFORE the scroll-element null check below: a ref
+    // change or remount can land on a render where VirtualList hasn't mounted
+    // yet (model undefined), so `el` is null - the reset must still fire so
+    // the LATER render where VirtualList appears treats it as a fresh open.
+    const hasContentRemounted = !prevHasContentRef.current && hasContent;
+    if (refForInitRef.current !== ref || hasContentRemounted) {
+      refForInitRef.current = ref;
+      initializedRef.current = false;
+      wasAtBottomRef.current = true;
+      firstTurnIdRef.current = undefined;
+      baselineItemCountRef.current = 0;
+      resolvedFailedTurnIdsRef.current = new Set();
+      setErrorAnchorIndex(null);
+      errorAnchorIndexRef.current = null;
+      setPillCount(0);
+    }
+    prevHasContentRef.current = hasContent;
+
     const el = listRef.current?.getScrollElement();
     if (!el) return;
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts
@@ -451,6 +451,7 @@ export function useTranscriptScroll({
       wasAtBottomRef.current = true;
       firstTurnIdRef.current = undefined;
       baselineItemCountRef.current = 0;
+      pendingViewAnchorRef.current = null;
       resolvedFailedTurnIdsRef.current = new Set();
       setErrorAnchorIndex(null);
       errorAnchorIndexRef.current = null;

--- a/cmd/evener-hub/frontend/src/widgets/virtuallist/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/virtuallist/index.tsx
@@ -98,11 +98,13 @@ const DEFAULT_OVERSCAN = 6;
 
 // How close to the true end (px) counts as "following the tail" when
 // anchorToEnd is on. Matches the transcript scroll metrics' own
-// AT_BOTTOM_THRESHOLD_PX (panes/session/transcript/flow/scrollMetrics.ts) -
-// legacy renderer.js parity (docs/web-ui/parity/parity-m4-transcript.md
-// §15): "within 50px of true bottom". Duplicated rather than imported
-// because the import direction is panes -> widgets, never the reverse.
-const END_ANCHOR_THRESHOLD_PX = 50;
+// AT_BOTTOM_THRESHOLD_PX (panes/session/transcript/flow/scrollMetrics.ts):
+// a few pixels, rounding-safe but effectively "truly at the bottom" - the
+// reader who has scrolled back even one line of text (~20px) must NOT be
+// treated as following the tail, or the transcript yanks underneath them.
+// Duplicated rather than imported because the import direction is panes ->
+// widgets, never the reverse.
+const END_ANCHOR_THRESHOLD_PX = 4;
 
 /**
  * Windows `count` rows down to the visible range via @tanstack/react-virtual

--- a/cmd/evener-hub/frontend/src/widgets/virtuallist/virtuallist.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/virtuallist/virtuallist.test.tsx
@@ -407,13 +407,15 @@ describe("anchorToEnd", () => {
     return captured;
   }
 
-  test("on: the virtualizer anchors to the end, follows appends, and uses the 50px end threshold", () => {
+  test("on: the virtualizer anchors to the end, follows appends, and uses the 4px end threshold", () => {
     const resolved = captureResolvedOptions(true);
     expect(resolved.options.anchorTo).toBe("end");
     expect(resolved.options.followOnAppend).toBe(true);
-    // Same "within 50px of true bottom" as the transcript scroll metrics'
+    // Same "truly at the bottom" 4px threshold as the transcript scroll metrics'
     // AT_BOTTOM_THRESHOLD_PX - see END_ANCHOR_THRESHOLD_PX in ./index.tsx.
-    expect(resolved.options.scrollEndThreshold).toBe(50);
+    // A few pixels (rounding-safe, far smaller than one line of text ~20px) so
+    // a reader scrolled back even one line is NOT treated as following the tail.
+    expect(resolved.options.scrollEndThreshold).toBe(4);
   });
 
   test("off (default): upstream defaults hold - start-anchored, no append following", () => {


### PR DESCRIPTION
## Problem

Two linked autoscroll bugs in the transcript pane:

1. **Clicking into a transcript from the sidebar loads mid-transcript** instead of at the bottom.
2. **Autoscroll continues even when the user has scrolled back into history** — the transcript moves underneath the reader. It should be fully disabled when even one line scrolled back.

## Root cause

Both bugs share one root cause in `useTranscriptScroll`: its per-mount refs (`initializedRef`, `wasAtBottomRef`, `baselineItemCountRef`, `firstTurnIdRef`, `resolvedFailedTurnIdsRef`, `errorAnchorIndex`) are set once and never reset. But the Session pane is **not keyed by ref** — `DockHost`'s `PaneHost` renders `<Component params=...>` with no key — so clicking a different session in the sidebar updates `params.ref` on the *same mounted component instance*. The hook's refs all persist across that change.

- **Opens mid-transcript:** `initializedRef` was already `true` from the first session's hydration, so the mount effect's one-time `scrollToIndex(count-1, {align:"end"})` was skipped for every later session opened in that pane. The same-ref remount path (model briefly `undefined` → re-hydrated, e.g. a store resync) had the same flaw.
- **Autoscroll while scrolled back:** `wasAtBottomRef` etc. were stale from the *previous* session, so stick-to-bottom and pill counts were computed against the wrong scroll state. Independently, the 50px at-bottom threshold let autoscroll engage while comfortably scrolled back into history (one line of text is ~20px).

## Fix

**`useTranscriptScroll.ts`** — reset all per-ref state when `ref` changes (`refForInitRef`) or when `hasContent` flips false→true on the same ref (`prevHasContentRef`). The reset runs before the scroll-element null check so it still fires on renders where VirtualList hasn't mounted yet.

**`scrollMetrics.ts` + `widgets/virtuallist/index.tsx`** — tightened `AT_BOTTOM_THRESHOLD_PX` and `END_ANCHOR_THRESHOLD_PX` from 50 to 4: rounding-safe but far smaller than one line of text, so scrolling back even one line fully disables autoscroll (both the hook's stick-to-bottom and the virtualizer's `followOnAppend` / `wasAtEnd` resize-adjustment).

## Verification

Built a temporary diagnostic harness using the real `VirtualList` + `useTranscriptScroll` and exercised it in a real browser (Chrome), reproducing both bugs against the pre-fix code and confirming the fix:
- ref-change remount: now lands at bottom (was `scrollTop=0`, gap=3222)
- same-ref remount (model undefined→defined): now lands at bottom (was top)
- scrolled back 30px (one line, within old 50px threshold) + append: no yank, pill counts (was yank to bottom)
- at true bottom + append: sticks

## Tests

- 4 new tests in `useTranscriptScroll.test.ts`: ref-change re-runs scroll-to-bottom; ref-change resets pill/baseline; ref-change clears error anchor; same-ref remount re-runs scroll-to-bottom.
- Updated threshold assertions in `scrollMetrics.test.ts` and `virtuallist.test.tsx` (50 → 4).

## Gates

- `make test-web` — PASS (typecheck + test + lint)
- `make test-web-browser` — PASS (layoutguard + overflowguard + spawnguard)
