### PR TITLE
Resolve OpenAI Responses web search and effort ladder from the catalog

### DIFF
--- a/agent/provider/catalog_internal_test.go
+++ b/agent/provider/catalog_internal_test.go
@@ -218,3 +218,29 @@ func TestResolveOpenRouterAnthropicWebSearch(t *testing.T) {
 		map[string]*bool{}, map[string]bool{},
 		"anthropic/m", true)
 }
+
+// TestResolveWebSearch_PresenceAware pins the three-state contract: the catalog
+// saying true, the catalog saying false, and the catalog being silent are all
+// distinct. Passing a default that opposes the catalog is what makes this
+// falsifiable — asserting true against a true default would pass just as well
+// if the helper ignored the catalog entirely.
+func TestResolveWebSearch_PresenceAware(t *testing.T) {
+	tests := []struct {
+		name            string
+		model           string
+		providerDefault bool
+		want            bool
+	}{
+		{"catalog true overrides an opposing default", "gpt-5.6-luna", false, true},
+		{"catalog false overrides an opposing default", "us.openai.gpt-5.6-luna", true, false},
+		{"catalog silence keeps the default (true)", "not-a-catalogued-model", true, true},
+		{"catalog silence keeps the default (false)", "not-a-catalogued-model", false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveWebSearch(tc.model, tc.providerDefault); got != tc.want {
+				t.Errorf("resolveWebSearch(%q, %v) = %v, want %v", tc.model, tc.providerDefault, got, tc.want)
+			}
+		})
+	}
+}

--- a/agent/provider/openai_catalog_resolution_test.go
+++ b/agent/provider/openai_catalog_resolution_test.go
@@ -1,0 +1,69 @@
+package provider_test
+
+import (
+	"slices"
+	"testing"
+
+	"primeradiant.com/evener/agent/provider"
+	"primeradiant.com/evener/llm"
+)
+
+// Amazon Bedrock serves the GPT-5.6 family over an OpenAI-compatible Responses
+// endpoint that does not offer OpenAI's hosted tools, and rejects the entire
+// request — not just the tool — when web_search is present. Its inference-profile
+// IDs also resolved no catalog entry at all, so the effort ladder fell back to
+// the provider default and ClampReasoningEffort silently turned a max run into
+// an xhigh one.
+
+func TestOpenAIProfile_BedrockModelDisablesWebSearch(t *testing.T) {
+	for _, model := range []string{
+		"us.openai.gpt-5.6-luna",
+		"global.openai.gpt-5.6-luna",
+		"us.openai.gpt-5.6-sol",
+		"us.openai.gpt-5.6-terra",
+	} {
+		if provider.NewOpenAIProfile(model).SupportsWebSearch() {
+			t.Errorf("%s SupportsWebSearch() = true; Bedrock rejects the whole request when the hosted web_search tool is present", model)
+		}
+	}
+}
+
+// Without "max" in the ladder, ClampReasoningEffort returns the highest level it
+// does know, so a run asked for max silently becomes an xhigh run.
+func TestOpenAIProfile_BedrockModelKeepsMaxEffort(t *testing.T) {
+	levels := provider.NewOpenAIProfile("us.openai.gpt-5.6-luna").ReasoningEffortLevels()
+
+	if !slices.Contains(levels, "max") {
+		t.Fatalf("ReasoningEffortLevels() = %v, want it to contain %q", levels, "max")
+	}
+	if got := llm.ClampReasoningEffort("max", levels); got != "max" {
+		t.Errorf("ClampReasoningEffort(%q, %v) = %q, want %q", "max", levels, got, "max")
+	}
+}
+
+// An uncatalogued model must keep the provider default rather than inheriting
+// another model's answer.
+func TestOpenAIProfile_UncataloguedModelKeepsConstructorDefault(t *testing.T) {
+	if !provider.NewOpenAIProfile("not-a-catalogued-model").SupportsWebSearch() {
+		t.Error("SupportsWebSearch() = false for an uncatalogued model; want the constructor default true")
+	}
+}
+
+// Switching models on the same profile must re-resolve the capability. A stale
+// value is the dangerous direction in both senses: carrying false onto a model
+// that supports web search loses a capability, and carrying true onto a Bedrock
+// model restores the tool that makes the endpoint reject every request.
+func TestOpenAIProfile_WithModelReresolvesWebSearch(t *testing.T) {
+	toBedrock := provider.NewOpenAIProfile("gpt-5.6-luna").WithModel("us.openai.gpt-5.6-luna")
+	if toBedrock.SupportsWebSearch() {
+		t.Error("after WithModel to a Bedrock model, SupportsWebSearch() = true, want false")
+	}
+	if levels := toBedrock.ReasoningEffortLevels(); !slices.Contains(levels, "max") {
+		t.Errorf("after WithModel to a Bedrock model, ReasoningEffortLevels() = %v, want it to contain %q", levels, "max")
+	}
+
+	fromBedrock := provider.NewOpenAIProfile("us.openai.gpt-5.6-luna").WithModel("gpt-5.6-luna")
+	if !fromBedrock.SupportsWebSearch() {
+		t.Error("after WithModel away from a Bedrock model, SupportsWebSearch() = false, want the catalog's true")
+	}
+}

--- a/agent/provider/profile.go
+++ b/agent/provider/profile.go
@@ -24,6 +24,19 @@ func resolveEffortLevels(model string, providerDefault []string) []string {
 	return providerDefault
 }
 
+// resolveWebSearch reports whether the model's endpoint serves provider-native
+// web search, preferring the catalog over the provider default. Presence-aware:
+// the catalog being silent is not the same as it saying false, so an
+// uncatalogued model keeps the provider default.
+func resolveWebSearch(model string, providerDefault bool) bool {
+	if cat := llm.EmbeddedModelCatalog(); cat != nil {
+		if mi := cat.LookupModelInfo(model); mi != nil && mi.SupportsWebSearch != nil {
+			return *mi.SupportsWebSearch
+		}
+	}
+	return providerDefault
+}
+
 // Profile describes a provider's identity, model, tool definitions, and
 // capabilities, and produces derived profiles via WithModel and the With*
 // decorator functions. Construct one with NewOpenAIProfile or
@@ -721,12 +734,13 @@ func restampInstanceIdentity(p *Profile, behaviorTag, id string) *Profile {
 // catalog, providerOpts that depend on the model — is recomputed.
 //
 // True for providers whose constructors look up per-model state (every
-// openai-compat provider; openrouter-anthropic). False for providers
-// whose model-derived state is fixed at construction (openai, minimax)
+// openai-compat provider; openrouter-anthropic; openai, whose web-search
+// capability and effort ladder both come from the catalog). False for
+// providers whose model-derived state is fixed at construction (minimax)
 // or handled by the dedicated anthropic branch of WithModel.
 func rebuildOnSameProviderChange(behaviorTag string) bool {
 	switch behaviorTag {
-	case "kimi", "glm", "openrouter", "ollama", "openrouter-anthropic", "openai-compatible":
+	case "kimi", "glm", "openrouter", "ollama", "openrouter-anthropic", "openai-compatible", "openai":
 		return true
 	}
 	return false
@@ -796,6 +810,8 @@ func (p *Profile) WithModel(model string) *Profile {
 		switch p.behaviorTag {
 		case "openrouter-anthropic":
 			rebuilt = newOpenRouterAnthropicProfile(model)
+		case "openai":
+			rebuilt = NewOpenAIProfile(model)
 		default:
 			rebuilt = newOpenAICompatProfile(p.behaviorTag, model, 0, p.instModels)
 		}
@@ -821,7 +837,7 @@ func NewOpenAIProfile(model string) *Profile {
 		docFiles:        []string{"AGENTS.md", ".codex/instructions.md"},
 		reasoning:       true,
 		streaming:       true,
-		webSearch:       true,
+		webSearch:       resolveWebSearch(model, true),
 		defaultTimeout:  120_000,
 		knowledgeCutoff: "2025-06-01",
 		defaultEfforts:  []string{"low", "medium", "high", "xhigh"},

--- a/agent/provider/profile_overrides_test.go
+++ b/agent/provider/profile_overrides_test.go
@@ -271,7 +271,11 @@ func TestRebuildOnSameProviderChange(t *testing.T) {
 		{"openrouter", true},
 		{"ollama", true},
 		{"openrouter-anthropic", true},
-		{"openai", false},
+		// openai's constructor resolves per-model state from the catalog —
+		// the effort ladder via resolveEffortLevels and, since Bedrock, the
+		// web-search capability — so a model change has to rebuild or both
+		// go stale.
+		{"openai", true},
 		{"anthropic", false},
 		{"minimax", false},
 		{"google", false},

--- a/docs/superpowers/specs/2026-08-20-openai-profile-catalog-resolution-design.md
+++ b/docs/superpowers/specs/2026-08-20-openai-profile-catalog-resolution-design.md
@@ -1,0 +1,209 @@
+# Catalog Resolution for the OpenAI Responses Profile
+
+## Goal
+
+Make `NewOpenAIProfile` resolve its model metadata from the model catalog, and
+give Bedrock's OpenAI inference-profile IDs a catalog key to resolve to.
+
+One root cause produces four wrong values today. `NewOpenAIProfile`
+(`agent/provider/profile.go:814`) consults the catalog for exactly one field —
+effort levels, via `resolveEffortLevels` (`profile.go:16-24`) — and hardcodes
+the rest: `contextWindow: 400_000` (`:820`) and `webSearch: true` (`:824`).
+Separately, Bedrock addresses models as inference-profile IDs that LiteLLM has
+no key for, so even the one catalog-driven field misses.
+
+The immediate symptom is that Evener cannot talk to Bedrock at all:
+
+```
+bedrock error (status=0): responses.create(stream): web search is not supported
+for this request
+```
+
+But web search is the least of it. On a Bedrock instance today:
+
+| Value | Now | Correct |
+| --- | --- | --- |
+| Reasoning effort `max` | silently clamped to `xhigh` | `max` |
+| Context window | 400,000 | 272,000 |
+| Max output tokens | 0 | 128,000 |
+| Pricing | absent (`cost_usd` null) | $1.10/$6.60 per M |
+| Web search | requested, request rejected | not requested |
+
+The effort clamp is the dangerous one. `resolveEffortLevels` falls back to the
+profile default `low/medium/high/xhigh` (`:827`), which has no `max`;
+`ClampReasoningEffort` (`llm/types.go:699`) finds no level of rank ≥ `max` (6)
+and returns the highest available, `xhigh` (5). A run labelled "luna-max" would
+silently be an xhigh run.
+
+## Design
+
+### 1. Give Bedrock's OpenAI IDs a catalog key
+
+LiteLLM already carries the data, under `bedrock_mantle/openai.gpt-5.6-luna`:
+pricing, `max_input_tokens: 272000`, `max_output_tokens: 128000`,
+`supports_reasoning`, `supports_prompt_caching`,
+`supported_endpoints: ["/v1/responses"]`.
+
+The gap is naming, and it is narrow. LiteLLM files Anthropic's Bedrock models
+under region-prefixed keys that match what Bedrock advertises, but files
+OpenAI's under a `bedrock_mantle/` key with no such alias:
+
+| Bedrock inference-profile ID | resolves today |
+| --- | --- |
+| `us.anthropic.claude-opus-5` | yes |
+| `global.anthropic.claude-opus-5` | yes |
+| `us.anthropic.claude-sonnet-4-6` | yes |
+| `us.openai.gpt-5.6-luna` | **no** |
+| `global.openai.gpt-5.6-luna` | **no** |
+
+So this is not a general "normalize Bedrock IDs" problem. Add one alias step to
+`LookupModelInfo`'s existing fallback chain (`llm/model_catalog.go:121-150`),
+after the exact lookup and the last-path-segment retry: an ID matching
+`us.openai.<rest>` or `global.openai.<rest>` retries as
+`bedrock_mantle/openai.<rest>`.
+
+Deliberately not a general region-prefix stripper. Exact match runs first, so a
+general rule would never fire for the Anthropic IDs anyway, and a rule broad
+enough to rewrite arbitrary `us.*` IDs risks shadowing a legitimate model whose
+name happens to start that way. Refreshing the vendored snapshot does not remove
+the need for this: upstream LiteLLM still has no `us.openai.*` keys.
+
+### 2. Resolve context window and web search from the catalog
+
+Extend `NewOpenAIProfile` to take both from the catalog when it has an opinion,
+mirroring `resolveEffortLevels` exactly: a catalog value wins, silence falls
+back to the constructor default. Two small helpers alongside the existing one,
+not a new mechanism.
+
+Web search is safe to make catalog-driven: across both catalog files, 55
+OpenAI-family models declare `supports_web_search: true` and **zero** declare
+false. The change is a no-op for every model shipping today and can only alter
+what we explicitly ship an entry for.
+
+Context window is **not** a no-op, and that is the point — see "Behavior change"
+below.
+
+### 3. Ship the two fields LiteLLM lacks
+
+`applyOverrides` (`llm/model_catalog_embedded.go:64-70`) overlays per field onto
+a matching entry, so an override keyed to the Bedrock LiteLLM ID adds metadata
+without discarding upstream pricing or context:
+
+```json
+"bedrock_mantle/openai.gpt-5.6-luna": {
+  "_note": "Bedrock serves these over /v1/responses without OpenAI's hosted tools.",
+  "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
+  "supports_web_search": false
+}
+```
+
+Same for `gpt-5.6-sol` and `gpt-5.6-terra`. `refresh-model-catalog.sh` forbids
+hand-editing the vendored snapshot and names this file as where Evener-specific
+metadata belongs, so this is the sanctioned layer.
+
+Note what is *not* in that entry: context window and pricing. Those come from
+upstream and stay current through the refresh script.
+
+### 4. Context window stays per serving path
+
+`gpt-5.6-luna` has three different real context windows depending on how it is
+served: 272,000 on Codex/OAuth, 1,050,000 on the public API, 272,000 on Bedrock.
+A single catalog number cannot be right for all three, and the existing
+`gpt-5.6-luna` override records the OAuth figure per Jesse's 2026-07-28
+decision, sourced from codex-cli 0.145.0's `models_cache.json`.
+
+That override is unchanged. Bedrock does not read it — the alias resolves
+Bedrock IDs to `bedrock_mantle/openai.*`, a different key, which carries
+Bedrock's own 272,000. Each path gets its own answer from its own entry, with no
+new precedence rule.
+
+## Behavior change
+
+Making context window catalog-driven changes the OAuth path: `gpt-5.6-luna` goes
+from the hardcoded 400,000 to the override's 272,000.
+
+This is a correction, not a regression. The catalog `context_window` is consumed
+at `profile.go:956` (kimi), `:1051-1076` (openai-compat), and `:449`
+(`WithLiveModelInfo`, which never runs for the `openai` tag because
+`isOpenAICompatTag` excludes it, `cmdutil/cmdutil.go:41-47`). None of those
+reach `NewOpenAIProfile`. The 2026-07-28 decision has therefore never been in
+force on the openai/responses path, which has been over-reporting its window by
+47% — the direction that risks building a request the model rejects.
+
+It is still a live behavior change to the path the Terminal-Bench baseline runs
+on, so it must not land mid-measurement. Land it after the in-flight 89-task run
+completes, and treat the next full run as a new baseline rather than a
+continuation.
+
+## Validation
+
+- `LookupModelInfo` table test: `us.openai.gpt-5.6-luna` and
+  `global.openai.gpt-5.6-luna` resolve to the Bedrock entry; `us.anthropic.*`
+  and `global.anthropic.*` still resolve by exact match and are byte-identical
+  to today; an unrelated `us.`-prefixed ID that matches nothing still returns
+  nil. The alias must not shadow an exact hit.
+- Effort resolution through `NewOpenAIProfile` for a Bedrock ID yields levels
+  including `max`, and `llm.ClampReasoningEffort("max", levels)` returns `max`.
+  This is the failing test that proves the clamp; it fails today.
+- `NewOpenAIProfile` context window and web search: catalog value wins, catalog
+  silence falls back to the constructor default. Assert an explicit `true` for
+  web search as well as `false`, so the resolution is proven to carry a value
+  rather than only ever suppressing.
+- A regression test pinning OAuth `gpt-5.6-luna` to 272,000 through the profile,
+  so the 2026-07-28 decision is enforced by a test rather than by a catalog
+  entry nothing reads.
+- `applyOverrides` overlay test: the Bedrock entry gains effort levels and
+  `supports_web_search` while retaining LiteLLM's pricing and
+  `max_input_tokens`.
+- Confirm no other model's resolution moves: run the existing catalog and
+  profile suites and diff resolved metadata for a sample across providers.
+- `go test ./llm/... ./agent/provider/... -count=1`, then `make lint` and the
+  full gate.
+
+Acceptance is a live Bedrock session on an unpatched binary, asserting from the
+API log that the request carries `reasoning_effort: max` and no `web_search`
+tool. The earlier rehearsal used a throwaway patch to `profile.go:824` and
+proved only that the endpoint works once web search is gone; it exercised
+neither the catalog path nor the effort ladder.
+
+## Follow-ups, deliberately not bundled
+
+- **Refresh the vendored LiteLLM snapshot.** `--check` reports +72 added, −1
+  removed (`replicateopenai/gpt-oss-20b`), ~430 changed — clean, and it brings
+  Bedrock pricing current. Its own commit, after the benchmark, so a measurement
+  is never taken across a moving catalog.
+- **Terminal-Bench cannot use Bedrock yet.** The eval adapter uploads only the
+  binary, OAuth record, and CA bundle
+  (`harbor-runner/src/harbor_runner/serf_agent.py:59-70`), sets only
+  `SSL_CERT_FILE` and `XDG_STATE_HOME`, and hard-validates
+  `model_name == "openai/gpt-5.6-luna"`. No providers.toml reaches the
+  container. That is harbor-runner work.
+- **Credential hazard.** `CredentialTag` (`llm/providercfg/providercfg.go:177-186`)
+  returns the behavior tag unless it is `openai-compatible`; for `responses` the
+  tag is `openai`, so the base_url-aware escape hatch never applies and
+  `cmdutil/load_client.go:98` assigns the operator's OpenAI credential to the
+  instance. An openai/responses instance with a non-OpenAI `base_url` must set
+  `api_key` or `credential_headers` explicitly or it bearer-sends an OpenAI key
+  to a third party. Pre-existing; documentation fix.
+- **Bedrock model-shape gating.** `responsesLiteModel`
+  (`llm/providers/openai/responses.go:956`) and
+  `openAIModelSupports24hPromptCache` (`agent/session.go:1212`) match bare
+  `gpt-5.6`/`gpt-5` prefixes, which Bedrock inference-profile IDs never match, so
+  this model gets neither the gpt-5.6 request shape nor an Evener-sent
+  `prompt_cache_key`. Bedrock's own automatic caching covered the latter in
+  testing (uncached prompt tokens fell from 13,882 to 60-160 across ten steps),
+  so this is a correctness tidy, not a cost problem.
+
+## Out of scope
+
+Anthropic models on Bedrock. Their catalog IDs already resolve, but Bedrock's
+OpenAI-compatible endpoint returns 404 for them on both `/responses` and
+`/chat/completions` — it serves OpenAI models only. Reaching Claude on Bedrock
+needs a native Converse/InvokeModel adapter with SigV4, which is a provider
+adapter project, not a catalog change.
+
+Also out of scope: making Bedrock a first-class provider type, Bedrock SigV4
+authentication (the endpoint accepts a bearer API key), and any `providers.toml`
+surface for web search — the catalog already models this capability, and a
+second source of truth beside it would owe a precedence rule against
+`resolveOpenRouterAnthropicWebSearch` (`agent/provider/profile.go:997-1035`).

--- a/docs/superpowers/specs/2026-08-20-openai-profile-catalog-resolution-design.md
+++ b/docs/superpowers/specs/2026-08-20-openai-profile-catalog-resolution-design.md
@@ -2,208 +2,160 @@
 
 ## Goal
 
-Make `NewOpenAIProfile` resolve its model metadata from the model catalog, and
-give Bedrock's OpenAI inference-profile IDs a catalog key to resolve to.
+Let Evener talk to Amazon Bedrock's OpenAI-compatible Responses endpoint, by
+giving its inference-profile IDs a catalog key to resolve to and by taking the
+web-search capability from the catalog instead of hardcoding it.
 
-One root cause produces four wrong values today. `NewOpenAIProfile`
-(`agent/provider/profile.go:814`) consults the catalog for exactly one field —
-effort levels, via `resolveEffortLevels` (`profile.go:16-24`) — and hardcodes
-the rest: `contextWindow: 400_000` (`:820`) and `webSearch: true` (`:824`).
-Separately, Bedrock addresses models as inference-profile IDs that LiteLLM has
-no key for, so even the one catalog-driven field misses.
-
-The immediate symptom is that Evener cannot talk to Bedrock at all:
+Two things break today. `NewOpenAIProfile` (`agent/provider/profile.go:841`)
+hardcodes `webSearch: true`, and Bedrock rejects the entire request — not just
+the tool — when OpenAI's hosted `web_search` is present:
 
 ```
 bedrock error (status=0): responses.create(stream): web search is not supported
 for this request
 ```
 
-But web search is the least of it. On a Bedrock instance today:
-
-| Value | Now | Correct |
-| --- | --- | --- |
-| Reasoning effort `max` | silently clamped to `xhigh` | `max` |
-| Context window | 400,000 | 272,000 |
-| Max output tokens | 0 | 128,000 |
-| Pricing | absent (`cost_usd` null) | $1.10/$6.60 per M |
-| Web search | requested, request rejected | not requested |
-
-The effort clamp is the dangerous one. `resolveEffortLevels` falls back to the
-profile default `low/medium/high/xhigh` (`:827`), which has no `max`;
-`ClampReasoningEffort` (`llm/types.go:699`) finds no level of rank ≥ `max` (6)
-and returns the highest available, `xhigh` (5). A run labelled "luna-max" would
-silently be an xhigh run.
+Underneath that sits a quieter failure. Bedrock's IDs resolve no catalog entry
+at all, so `resolveEffortLevels` falls back to the profile default
+`low/medium/high/xhigh` (`:854`), and `ClampReasoningEffort`
+(`llm/types.go:699`) finds no level ranked at or above `max` (6) and returns the
+highest it knows, `xhigh` (5). A run asked for `max` silently becomes an xhigh
+run — a mislabeled measurement, which is worse than a failed one.
 
 ## Design
 
 ### 1. Give Bedrock's OpenAI IDs a catalog key
 
-LiteLLM already carries the data, under `bedrock_mantle/openai.gpt-5.6-luna`:
-pricing, `max_input_tokens: 272000`, `max_output_tokens: 128000`,
-`supports_reasoning`, `supports_prompt_caching`,
+LiteLLM already carries the data under `bedrock_mantle/openai.gpt-5.6-luna`:
+pricing, context, output cap, `supports_reasoning`, `supports_prompt_caching`,
 `supported_endpoints: ["/v1/responses"]`.
 
 The gap is naming, and it is narrow. LiteLLM files Anthropic's Bedrock models
-under region-prefixed keys that match what Bedrock advertises, but files
+under region-prefixed keys matching what Bedrock advertises, and files only
 OpenAI's under a `bedrock_mantle/` key with no such alias:
 
-| Bedrock inference-profile ID | resolves today |
+| Bedrock inference-profile ID | resolved before |
 | --- | --- |
 | `us.anthropic.claude-opus-5` | yes |
 | `global.anthropic.claude-opus-5` | yes |
-| `us.anthropic.claude-sonnet-4-6` | yes |
 | `us.openai.gpt-5.6-luna` | **no** |
 | `global.openai.gpt-5.6-luna` | **no** |
 
-So this is not a general "normalize Bedrock IDs" problem. Add one alias step to
-`LookupModelInfo`'s existing fallback chain (`llm/model_catalog.go:121-150`),
-after the exact lookup and the last-path-segment retry: an ID matching
-`us.openai.<rest>` or `global.openai.<rest>` retries as
-`bedrock_mantle/openai.<rest>`.
+`bedrockOpenAICatalogKey` (`llm/model_catalog.go`) maps `us.openai.<rest>` and
+`global.openai.<rest>` to `bedrock_mantle/openai.<rest>`, wired as a fallback in
+`LookupModelInfo` after the exact, last-segment, and dated-family lookups. Those
+two scopes are the complete set for OpenAI, not a sample — verified against
+`ListInferenceProfiles`, which returns only `us` and `global` for OpenAI models.
+Anthropic's models do use further scopes (`eu.`/`apac.`/`au.`/`jp.`), which is
+why this maps OpenAI's names specifically rather than region prefixes generally.
 
-Deliberately not a general region-prefix stripper. Exact match runs first, so a
-general rule would never fire for the Anthropic IDs anyway, and a rule broad
-enough to rewrite arbitrary `us.*` IDs risks shadowing a legitimate model whose
-name happens to start that way. Refreshing the vendored snapshot does not remove
-the need for this: upstream LiteLLM still has no `us.openai.*` keys.
+Refreshing the vendored snapshot does not remove the need for it: upstream still
+publishes no `us.openai.*` keys.
 
-### 2. Resolve context window and web search from the catalog
+### 2. Resolve web search from the catalog
 
-Extend `NewOpenAIProfile` to take both from the catalog when it has an opinion,
-mirroring `resolveEffortLevels` exactly: a catalog value wins, silence falls
-back to the constructor default. Two small helpers alongside the existing one,
-not a new mechanism.
-
-Web search is safe to make catalog-driven: across both catalog files, 55
-OpenAI-family models declare `supports_web_search: true` and **zero** declare
-false. The change is a no-op for every model shipping today and can only alter
-what we explicitly ship an entry for.
-
-Context window is **not** a no-op, and that is the point — see "Behavior change"
-below.
+`resolveWebSearch` mirrors the existing `resolveEffortLevels`: presence-aware,
+so a catalog value wins and catalog silence keeps the provider default. Safe by
+inspection — across both catalog files, 55 OpenAI-family models declare
+`supports_web_search: true` and zero declare false, so this changes no model
+shipping today and can only alter what we explicitly ship an entry for.
 
 ### 3. Ship the two fields LiteLLM lacks
 
-`applyOverrides` (`llm/model_catalog_embedded.go:64-70`) overlays per field onto
-a matching entry, so an override keyed to the Bedrock LiteLLM ID adds metadata
-without discarding upstream pricing or context:
+`applyOverrides` overlays per field onto a matching entry, so an override keyed
+to the Bedrock LiteLLM ID adds metadata without discarding upstream pricing or
+context. `bedrock_mantle/openai.gpt-5.6-{luna,sol,terra}` each gain the effort
+ladder including `max`, and `supports_web_search: false`.
 
-```json
-"bedrock_mantle/openai.gpt-5.6-luna": {
-  "_note": "Bedrock serves these over /v1/responses without OpenAI's hosted tools.",
-  "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
-  "supports_web_search": false
-}
-```
+Only those three. The other six `bedrock_mantle/openai.*` entries
+(`gpt-5.5`, the `gpt-oss` family) are not reachable: probing
+`us.openai.gpt-5.5` and `us.openai.gpt-oss-120b` returns *"The provided model
+identifier is invalid"*, so they are catalog rows without a serving path. Adding
+capability flags for them would be speculation.
 
-Same for `gpt-5.6-sol` and `gpt-5.6-terra`. `refresh-model-catalog.sh` forbids
-hand-editing the vendored snapshot and names this file as where Evener-specific
-metadata belongs, so this is the sanctioned layer.
+### 4. Rebuild the profile on model change
 
-Note what is *not* in that entry: context window and pricing. Those come from
-upstream and stay current through the refresh script.
+`rebuildOnSameProviderChange` did not list `openai`, so `WithModel`
+shallow-cloned and carried the old model's answers forward. That was already
+wrong before this change — the effort ladder has been catalog-derived since
+`resolveEffortLevels` existed — and adding a second catalog-derived field makes
+it load-bearing. `openai` now rebuilds through `NewOpenAIProfile`, alongside the
+openai-compat family and openrouter-anthropic.
 
-### 4. Context window stays per serving path
+Without this, both fixes fail open on every model switch, model-fallback hop
+(`agent/session_model_call.go:862`), and subagent model override
+(`agent/subagent_model_selection.go`): a switch onto a Bedrock model restores
+the tool that makes the endpoint reject every request.
 
-`gpt-5.6-luna` has three different real context windows depending on how it is
-served: 272,000 on Codex/OAuth, 1,050,000 on the public API, 272,000 on Bedrock.
-A single catalog number cannot be right for all three, and the existing
-`gpt-5.6-luna` override records the OAuth figure per Jesse's 2026-07-28
-decision, sourced from codex-cli 0.145.0's `models_cache.json`.
+## Explicitly not in this change
 
-That override is unchanged. Bedrock does not read it — the alias resolves
-Bedrock IDs to `bedrock_mantle/openai.*`, a different key, which carries
-Bedrock's own 272,000. Each path gets its own answer from its own entry, with no
-new precedence rule.
+**Context window.** An earlier draft also took `contextWindow` from the catalog,
+to put the 272,000 effective Codex/OAuth limit into force. That was removed, for
+two reasons found in review:
 
-## Behavior change
+- It does not work. `fillLiveModelMetadata` (`agent/live_model_metadata.go:41`)
+  runs unconditionally from `NewSession`, with no behavior-tag gate, and
+  `WithLiveModelInfo` overwrites the catalog window with the live one. Evener's
+  own Codex fixture reports `max_context_window: 400000`
+  (`llm/providers/openai/adapter_test.go:4216`), so a live session would still
+  have reported 400,000 while a constructor-level test claimed otherwise.
+- It regressed the bare `gpt-5.6` slug from 400,000 to LiteLLM's public-API
+  1,050,000, while Codex rewrites that slug to `gpt-5.6-sol` — which the same
+  change pins at 272,000. It also raised ~18 other OpenAI models above 400,000,
+  inconsistent with the override file's own stated Codex/OAuth policy.
 
-Making context window catalog-driven changes the OAuth path: `gpt-5.6-luna` goes
-from the hardcoded 400,000 to the override's 272,000.
+Getting it right means settling live-metadata precedence against explicit
+configuration and pinning the bare slug. That is its own change with its own
+spec. The web-search and effort fixes are unaffected: the plain `/v1/models`
+mapping (`llm/providers/openai/models.go:86-96`) populates neither
+`SupportsWebSearch` nor `ReasoningEffortLevels`, so live enumeration cannot
+clobber them.
 
-This is a correction, not a regression. The catalog `context_window` is consumed
-at `profile.go:956` (kimi), `:1051-1076` (openai-compat), and `:449`
-(`WithLiveModelInfo`, which never runs for the `openai` tag because
-`isOpenAICompatTag` excludes it, `cmdutil/cmdutil.go:41-47`). None of those
-reach `NewOpenAIProfile`. The 2026-07-28 decision has therefore never been in
-force on the openai/responses path, which has been over-reporting its window by
-47% — the direction that risks building a request the model rejects.
-
-It is still a live behavior change to the path the Terminal-Bench baseline runs
-on, so it must not land mid-measurement. Land it after the in-flight 89-task run
-completes, and treat the next full run as a new baseline rather than a
-continuation.
+**Anthropic on Bedrock.** Their catalog IDs already resolve, but Bedrock's
+OpenAI-compatible endpoint returns 404 for Anthropic models on both
+`/responses` and `/chat/completions` — it serves OpenAI models only. Reaching
+Claude on Bedrock needs a native Converse/InvokeModel adapter with SigV4.
 
 ## Validation
 
-- `LookupModelInfo` table test: `us.openai.gpt-5.6-luna` and
-  `global.openai.gpt-5.6-luna` resolve to the Bedrock entry; `us.anthropic.*`
-  and `global.anthropic.*` still resolve by exact match and are byte-identical
-  to today; an unrelated `us.`-prefixed ID that matches nothing still returns
-  nil. The alias must not shadow an exact hit.
-- Effort resolution through `NewOpenAIProfile` for a Bedrock ID yields levels
-  including `max`, and `llm.ClampReasoningEffort("max", levels)` returns `max`.
-  This is the failing test that proves the clamp; it fails today.
-- `NewOpenAIProfile` context window and web search: catalog value wins, catalog
-  silence falls back to the constructor default. Assert an explicit `true` for
-  web search as well as `false`, so the resolution is proven to carry a value
-  rather than only ever suppressing.
-- A regression test pinning OAuth `gpt-5.6-luna` to 272,000 through the profile,
-  so the 2026-07-28 decision is enforced by a test rather than by a catalog
-  entry nothing reads.
-- `applyOverrides` overlay test: the Bedrock entry gains effort levels and
-  `supports_web_search` while retaining LiteLLM's pricing and
-  `max_input_tokens`.
-- Confirm no other model's resolution moves: run the existing catalog and
-  profile suites and diff resolved metadata for a sample across providers.
-- `go test ./llm/... ./agent/provider/... -count=1`, then `make lint` and the
-  full gate.
+- `LookupModelInfo`: `us.openai.*` and `global.openai.*` resolve to the Bedrock
+  entry; `us.anthropic.*` and `global.anthropic.*` still resolve by exact match;
+  an unknown `us.openai.*` still returns nil.
+- `resolveWebSearch` presence-awareness, tested white-box with a provider
+  default that *opposes* the catalog. Asserting a catalog `true` against a
+  `true` default would pass even if the helper ignored the catalog entirely —
+  the original version of this test did exactly that, and a mutation test
+  caught it.
+- Profile-level: all four Bedrock GPT-5.6 IDs report web search off; the effort
+  ladder contains `max` and `ClampReasoningEffort("max", …)` returns `max`; an
+  uncatalogued model keeps the constructor default.
+- Model switch in both directions: onto a Bedrock model the capability must go
+  off and the ladder must gain `max`; away from one it must come back.
 
 Acceptance is a live Bedrock session on an unpatched binary, asserting from the
 API log that the request carries `reasoning_effort: max` and no `web_search`
-tool. The earlier rehearsal used a throwaway patch to `profile.go:824` and
-proved only that the endpoint works once web search is gone; it exercised
-neither the catalog path nor the effort ladder.
+tool. The earlier rehearsal used a throwaway patch and proved only that the
+endpoint works once web search is gone.
 
-## Follow-ups, deliberately not bundled
+## Follow-ups
 
-- **Refresh the vendored LiteLLM snapshot.** `--check` reports +72 added, −1
-  removed (`replicateopenai/gpt-oss-20b`), ~430 changed — clean, and it brings
-  Bedrock pricing current. Its own commit, after the benchmark, so a measurement
-  is never taken across a moving catalog.
+- **Context window per serving path**, as above — the substantive one.
 - **Terminal-Bench cannot use Bedrock yet.** The eval adapter uploads only the
   binary, OAuth record, and CA bundle
-  (`harbor-runner/src/harbor_runner/serf_agent.py:59-70`), sets only
-  `SSL_CERT_FILE` and `XDG_STATE_HOME`, and hard-validates
+  (`harbor-runner/src/harbor_runner/serf_agent.py:59-70`) and hard-validates
   `model_name == "openai/gpt-5.6-luna"`. No providers.toml reaches the
-  container. That is harbor-runner work.
+  container.
 - **Credential hazard.** `CredentialTag` (`llm/providercfg/providercfg.go:177-186`)
   returns the behavior tag unless it is `openai-compatible`; for `responses` the
-  tag is `openai`, so the base_url-aware escape hatch never applies and
-  `cmdutil/load_client.go:98` assigns the operator's OpenAI credential to the
-  instance. An openai/responses instance with a non-OpenAI `base_url` must set
-  `api_key` or `credential_headers` explicitly or it bearer-sends an OpenAI key
-  to a third party. Pre-existing; documentation fix.
+  tag is `openai`, so the base_url-aware escape hatch never applies and the
+  operator's OpenAI credential is assigned to the instance. An openai/responses
+  instance with a non-OpenAI `base_url` must set `api_key` or
+  `credential_headers` explicitly or it bearer-sends an OpenAI key to a third
+  party. Pre-existing; needs documenting.
 - **Bedrock model-shape gating.** `responsesLiteModel`
-  (`llm/providers/openai/responses.go:956`) and
-  `openAIModelSupports24hPromptCache` (`agent/session.go:1212`) match bare
-  `gpt-5.6`/`gpt-5` prefixes, which Bedrock inference-profile IDs never match, so
-  this model gets neither the gpt-5.6 request shape nor an Evener-sent
-  `prompt_cache_key`. Bedrock's own automatic caching covered the latter in
-  testing (uncached prompt tokens fell from 13,882 to 60-160 across ten steps),
-  so this is a correctness tidy, not a cost problem.
-
-## Out of scope
-
-Anthropic models on Bedrock. Their catalog IDs already resolve, but Bedrock's
-OpenAI-compatible endpoint returns 404 for them on both `/responses` and
-`/chat/completions` — it serves OpenAI models only. Reaching Claude on Bedrock
-needs a native Converse/InvokeModel adapter with SigV4, which is a provider
-adapter project, not a catalog change.
-
-Also out of scope: making Bedrock a first-class provider type, Bedrock SigV4
-authentication (the endpoint accepts a bearer API key), and any `providers.toml`
-surface for web search — the catalog already models this capability, and a
-second source of truth beside it would owe a precedence rule against
-`resolveOpenRouterAnthropicWebSearch` (`agent/provider/profile.go:997-1035`).
+  (`llm/providers/openai/responses.go:956`), `openAIModelSupports24hPromptCache`
+  (`agent/session.go:1212`), and `reasoningSummaryLevel`
+  (`responses.go:1009`) all match bare `gpt-5`/`gpt-5.6` prefixes that Bedrock
+  IDs never match, so this model gets neither the gpt-5.6 request shape, nor an
+  Evener-sent `prompt_cache_key`, nor `summary: "detailed"`. Bedrock's own
+  automatic caching covered the second in testing.

--- a/llm/data/evener_model_catalog_overrides.json
+++ b/llm/data/evener_model_catalog_overrides.json
@@ -121,6 +121,10 @@
     "_note": "Anthropic Opus 5. LiteLLM already supplies context, pricing, adaptive thinking and the effort flags; the overlay adds only claude5_request_shape, the generation-5 wire shape upstream does not express.",
     "claude5_request_shape": true
   },
+  "claude-mythos-5": {
+    "_note": "Anthropic Mythos 5, added upstream in the 2026-08-20 refresh. LiteLLM supplies context, pricing, adaptive thinking and the xhigh/max effort flags; the overlay adds only claude5_request_shape, without which the Anthropic request builder sends the pre-5 wire shape.",
+    "claude5_request_shape": true
+  },
   "gpt-5.6-sol": {
     "_note": "LiteLLM now supplies the public OpenAI API metadata. Evener overrides only the effective Codex/OAuth context window (272,000 in codex-cli 0.145.0 models_cache.json; public API is 1,050,000) per Jesse's 2026-07-28 decision, plus the existing max effort tier.",
     "context_window": 272000,

--- a/llm/data/evener_model_catalog_overrides.json
+++ b/llm/data/evener_model_catalog_overrides.json
@@ -125,6 +125,10 @@
     "_note": "Anthropic Mythos 5, added upstream in the 2026-08-20 refresh. LiteLLM supplies context, pricing, adaptive thinking and the xhigh/max effort flags; the overlay adds only claude5_request_shape, without which the Anthropic request builder sends the pre-5 wire shape.",
     "claude5_request_shape": true
   },
+  "claude-mythos-preview": {
+    "_note": "Added upstream alongside claude-mythos-5 with identical capability flags. isClaude5OrNewer's ID heuristic cannot classify it — 'preview' carries no numeric generation segment — so without this it would take the pre-5 wire shape and send sampling params upstream marks unsupported.",
+    "claude5_request_shape": true
+  },
   "gpt-5.6-sol": {
     "_note": "LiteLLM now supplies the public OpenAI API metadata. Evener overrides only the effective Codex/OAuth context window (272,000 in codex-cli 0.145.0 models_cache.json; public API is 1,050,000) per Jesse's 2026-07-28 decision, plus the existing max effort tier.",
     "context_window": 272000,
@@ -135,6 +139,39 @@
       "xhigh",
       "max"
     ]
+  },
+  "bedrock_mantle/openai.gpt-5.6-luna": {
+    "_note": "Amazon Bedrock serves the GPT-5.6 family over /v1/responses without OpenAI's hosted tools, so web search must be off or Bedrock rejects the entire request. LiteLLM supplies context, output cap and pricing for this serving path; the overlay adds only the effort ladder upstream does not express and that capability flag. Reached from the us./global. inference-profile IDs via bedrockOpenAICatalogKey.",
+    "reasoning_effort_levels": [
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max"
+    ],
+    "supports_web_search": false
+  },
+  "bedrock_mantle/openai.gpt-5.6-sol": {
+    "_note": "See bedrock_mantle/openai.gpt-5.6-luna.",
+    "reasoning_effort_levels": [
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max"
+    ],
+    "supports_web_search": false
+  },
+  "bedrock_mantle/openai.gpt-5.6-terra": {
+    "_note": "See bedrock_mantle/openai.gpt-5.6-luna.",
+    "reasoning_effort_levels": [
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max"
+    ],
+    "supports_web_search": false
   },
   "gpt-5.6-terra": {
     "_note": "LiteLLM supplies the public API metadata; see gpt-5.6-sol for Evener's intentional Codex/OAuth context override.",

--- a/llm/data/litellm_model_catalog.json
+++ b/llm/data/litellm_model_catalog.json
@@ -40,6 +40,7 @@
         "vector_store_cost_per_gb_per_day": 0.0
     },
     "1024-x-1024/50-steps/bedrock/amazon.nova-canvas-v1:0": {
+        "deprecation_date": "2026-09-30",
         "litellm_provider": "bedrock",
         "max_input_tokens": 2600,
         "mode": "image_generation",
@@ -110,6 +111,7 @@
         "output_cost_per_token": 1.88e-05
     },
     "ai21.jamba-1-5-large-v1:0": {
+        "deprecation_date": "2026-11-26",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 256000,
@@ -119,6 +121,7 @@
         "output_cost_per_token": 8e-06
     },
     "ai21.jamba-1-5-mini-v1:0": {
+        "deprecation_date": "2026-11-26",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 256000,
@@ -287,6 +290,7 @@
         "supports_vision": true
     },
     "amazon.nova-canvas-v1:0": {
+        "deprecation_date": "2026-09-30",
         "litellm_provider": "bedrock",
         "max_input_tokens": 2600,
         "mode": "image_generation",
@@ -294,6 +298,7 @@
         "supports_nova_canvas_image_edit": true
     },
     "us.amazon.nova-canvas-v1:0": {
+        "deprecation_date": "2026-09-30",
         "litellm_provider": "bedrock",
         "max_input_tokens": 2600,
         "mode": "image_generation",
@@ -620,6 +625,7 @@
         "mode": "image_generation"
     },
     "twelvelabs.marengo-embed-2-7-v1:0": {
+        "deprecation_date": "2026-11-30",
         "input_cost_per_token": 7e-05,
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
@@ -631,6 +637,7 @@
         "supports_image_input": true
     },
     "us.twelvelabs.marengo-embed-2-7-v1:0": {
+        "deprecation_date": "2026-11-30",
         "input_cost_per_token": 7e-05,
         "input_cost_per_video_per_second": 0.0007,
         "input_cost_per_audio_per_second": 0.00014,
@@ -645,6 +652,7 @@
         "supports_image_input": true
     },
     "eu.twelvelabs.marengo-embed-2-7-v1:0": {
+        "deprecation_date": "2026-11-30",
         "input_cost_per_token": 7e-05,
         "input_cost_per_video_per_second": 0.0007,
         "input_cost_per_audio_per_second": 0.00014,
@@ -730,6 +738,7 @@
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 1e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -755,6 +764,7 @@
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 1e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -859,6 +869,7 @@
         "supports_vision": true
     },
     "anthropic.claude-3-haiku-20240307-v1:0": {
+        "deprecation_date": "2026-09-10",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -890,6 +901,7 @@
         "cache_creation_input_token_cost": 1.875e-05
     },
     "anthropic.claude-3-sonnet-20240229-v1:0": {
+        "deprecation_date": "2026-07-30",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -918,6 +930,7 @@
     "anthropic.claude-opus-4-1-20250805-v1:0": {
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
+        "deprecation_date": "2027-01-08",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
@@ -973,6 +986,7 @@
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -1005,6 +1019,7 @@
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
@@ -1038,6 +1053,7 @@
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
@@ -1071,6 +1087,7 @@
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
@@ -1104,6 +1121,7 @@
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
@@ -1137,6 +1155,7 @@
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
@@ -1171,6 +1190,7 @@
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
@@ -1222,6 +1242,7 @@
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
@@ -1258,6 +1279,7 @@
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
@@ -1294,6 +1316,7 @@
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
@@ -1330,6 +1353,7 @@
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
@@ -1946,6 +1970,7 @@
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
@@ -1975,6 +2000,7 @@
         "prompt_cache_min_tokens": 2048
     },
     "anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.5e-06,
         "cache_creation_input_token_cost_above_1hr": 4e-06,
         "cache_read_input_token_cost": 2e-07,
@@ -2011,6 +2037,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "global.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.5e-06,
         "cache_creation_input_token_cost_above_1hr": 4e-06,
         "cache_read_input_token_cost": 2e-07,
@@ -2047,6 +2074,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "us.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,
@@ -2083,6 +2111,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "eu.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,
@@ -2119,6 +2148,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "au.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,
@@ -2155,6 +2185,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "jp.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,
@@ -2197,6 +2228,7 @@
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -2229,6 +2261,7 @@
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -2261,6 +2294,7 @@
         "cache_read_input_token_cost": 3.3e-07,
         "input_cost_per_token": 3.3e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -2293,6 +2327,7 @@
         "cache_read_input_token_cost": 3.3e-07,
         "input_cost_per_token": 3.3e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -2325,6 +2360,7 @@
         "cache_read_input_token_cost": 3.3e-07,
         "input_cost_per_token": 3.3e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -2357,6 +2393,7 @@
         "cache_read_input_token_cost": 3.3e-07,
         "input_cost_per_token": 3.3e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -2385,6 +2422,7 @@
     "anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2026-10-14",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
         "output_cost_per_token_above_200k_tokens": 2.25e-05,
@@ -2424,6 +2462,7 @@
         "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 1.2e-05,
         "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -2625,6 +2664,7 @@
         "supports_vision": true
     },
     "apac.anthropic.claude-3-5-sonnet-20240620-v1:0": {
+        "deprecation_date": "2026-07-30",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -2643,6 +2683,7 @@
     "apac.anthropic.claude-3-5-sonnet-20241022-v2:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2026-07-30",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -2660,6 +2701,7 @@
         "supports_vision": true
     },
     "apac.anthropic.claude-3-haiku-20240307-v1:0": {
+        "deprecation_date": "2026-09-10",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -2680,6 +2722,7 @@
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -2700,6 +2743,7 @@
         "prompt_cache_min_tokens": 4096
     },
     "apac.anthropic.claude-3-sonnet-20240229-v1:0": {
+        "deprecation_date": "2026-07-30",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -2718,6 +2762,7 @@
     "apac.anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2026-10-14",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
         "output_cost_per_token_above_200k_tokens": 2.25e-05,
@@ -2769,6 +2814,7 @@
         "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 1.32e-05,
         "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -2802,6 +2848,7 @@
     },
     "azure/codex-mini": {
         "cache_read_input_token_cost": 3.75e-07,
+        "deprecation_date": "2026-11-15",
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
@@ -2887,7 +2934,7 @@
         "input_cost_per_token": 5e-06,
         "output_cost_per_token": 2.5e-05,
         "litellm_provider": "azure_ai",
-        "max_input_tokens": 200000,
+        "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -2916,7 +2963,7 @@
         "input_cost_per_token": 5e-06,
         "output_cost_per_token": 2.5e-05,
         "litellm_provider": "azure_ai",
-        "max_input_tokens": 200000,
+        "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -3010,7 +3057,7 @@
         "input_cost_per_token": 5e-06,
         "output_cost_per_token": 2.5e-05,
         "litellm_provider": "azure_ai",
-        "max_input_tokens": 200000,
+        "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -3454,22 +3501,16 @@
     },
     "azure_ai/gpt-5.4-mini": {
         "cache_read_input_token_cost": 7.5e-08,
-        "cache_read_input_token_cost_above_272k_tokens": 1.5e-07,
         "cache_read_input_token_cost_priority": 1.5e-07,
-        "cache_read_input_token_cost_above_272k_tokens_priority": 3e-07,
         "input_cost_per_token": 7.5e-07,
-        "input_cost_per_token_above_272k_tokens": 1.5e-06,
         "input_cost_per_token_priority": 1.5e-06,
-        "input_cost_per_token_above_272k_tokens_priority": 3e-06,
         "litellm_provider": "azure_ai",
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 4.5e-06,
-        "output_cost_per_token_above_272k_tokens": 6.75e-06,
         "output_cost_per_token_priority": 9e-06,
-        "output_cost_per_token_above_272k_tokens_priority": 1.35e-05,
         "source": "https://ai.azure.com/catalog/models/gpt-5.4-mini",
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -3500,22 +3541,16 @@
     },
     "azure_ai/gpt-5.4-mini-2026-03-17": {
         "cache_read_input_token_cost": 7.5e-08,
-        "cache_read_input_token_cost_above_272k_tokens": 1.5e-07,
         "cache_read_input_token_cost_priority": 1.5e-07,
-        "cache_read_input_token_cost_above_272k_tokens_priority": 3e-07,
         "input_cost_per_token": 7.5e-07,
-        "input_cost_per_token_above_272k_tokens": 1.5e-06,
         "input_cost_per_token_priority": 1.5e-06,
-        "input_cost_per_token_above_272k_tokens_priority": 3e-06,
         "litellm_provider": "azure_ai",
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 4.5e-06,
-        "output_cost_per_token_above_272k_tokens": 6.75e-06,
         "output_cost_per_token_priority": 9e-06,
-        "output_cost_per_token_above_272k_tokens_priority": 1.35e-05,
         "source": "https://ai.azure.com/catalog/models/gpt-5.4-mini",
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -3546,22 +3581,16 @@
     },
     "azure_ai/gpt-5.4-nano": {
         "cache_read_input_token_cost": 2e-08,
-        "cache_read_input_token_cost_above_272k_tokens": 4e-08,
         "cache_read_input_token_cost_priority": 4e-08,
-        "cache_read_input_token_cost_above_272k_tokens_priority": 8e-08,
         "input_cost_per_token": 2e-07,
-        "input_cost_per_token_above_272k_tokens": 4e-07,
         "input_cost_per_token_priority": 4e-07,
-        "input_cost_per_token_above_272k_tokens_priority": 8e-07,
         "litellm_provider": "azure_ai",
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 1.25e-06,
-        "output_cost_per_token_above_272k_tokens": 1.875e-06,
         "output_cost_per_token_priority": 2.5e-06,
-        "output_cost_per_token_above_272k_tokens_priority": 3.75e-06,
         "source": "https://ai.azure.com/catalog/models/gpt-5.4-nano",
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -3592,22 +3621,16 @@
     },
     "azure_ai/gpt-5.4-nano-2026-03-17": {
         "cache_read_input_token_cost": 2e-08,
-        "cache_read_input_token_cost_above_272k_tokens": 4e-08,
         "cache_read_input_token_cost_priority": 4e-08,
-        "cache_read_input_token_cost_above_272k_tokens_priority": 8e-08,
         "input_cost_per_token": 2e-07,
-        "input_cost_per_token_above_272k_tokens": 4e-07,
         "input_cost_per_token_priority": 4e-07,
-        "input_cost_per_token_above_272k_tokens_priority": 8e-07,
         "litellm_provider": "azure_ai",
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 1.25e-06,
-        "output_cost_per_token_above_272k_tokens": 1.875e-06,
         "output_cost_per_token_priority": 2.5e-06,
-        "output_cost_per_token_above_272k_tokens_priority": 3.75e-06,
         "source": "https://ai.azure.com/catalog/models/gpt-5.4-nano",
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -3645,7 +3668,7 @@
         "comment": "Flat cost of $0.14 per M input tokens for Azure AI Foundry Model Router infrastructure. Use pattern: azure_ai/model_router/<deployment-name> where deployment-name is your Azure deployment (e.g., azure-model-router)"
     },
     "azure/eu/gpt-4o-2024-08-06": {
-        "deprecation_date": "2026-02-27",
+        "deprecation_date": "2027-04-14",
         "cache_read_input_token_cost": 1.375e-06,
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
@@ -3662,7 +3685,7 @@
         "supports_vision": true
     },
     "azure/eu/gpt-4o-2024-11-20": {
-        "deprecation_date": "2026-03-01",
+        "deprecation_date": "2027-04-14",
         "cache_creation_input_token_cost": 1.38e-06,
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
@@ -3679,6 +3702,7 @@
     },
     "azure/eu/gpt-4o-mini-2024-07-18": {
         "cache_read_input_token_cost": 8.3e-08,
+        "deprecation_date": "2027-04-14",
         "input_cost_per_token": 1.65e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
@@ -3760,6 +3784,7 @@
     },
     "azure/eu/gpt-5-2025-08-07": {
         "cache_read_input_token_cost": 1.375e-07,
+        "deprecation_date": "2027-02-09",
         "input_cost_per_token": 1.375e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
@@ -3792,6 +3817,7 @@
     },
     "azure/eu/gpt-5-mini-2025-08-07": {
         "cache_read_input_token_cost": 2.75e-08,
+        "deprecation_date": "2027-02-09",
         "input_cost_per_token": 2.75e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
@@ -3858,6 +3884,7 @@
     },
     "azure/eu/gpt-5.1-chat": {
         "cache_read_input_token_cost": 1.4e-07,
+        "deprecation_date": "2026-06-29",
         "input_cost_per_token": 1.38e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
@@ -3952,6 +3979,7 @@
     },
     "azure/eu/gpt-5-nano-2025-08-07": {
         "cache_read_input_token_cost": 5.5e-09,
+        "deprecation_date": "2027-02-09",
         "input_cost_per_token": 5.5e-08,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
@@ -3984,6 +4012,7 @@
     },
     "azure/eu/o1-2024-12-17": {
         "cache_read_input_token_cost": 8.25e-06,
+        "deprecation_date": "2026-10-21",
         "input_cost_per_token": 1.65e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
@@ -4029,6 +4058,7 @@
     },
     "azure/eu/o3-mini-2025-01-31": {
         "cache_read_input_token_cost": 6.05e-07,
+        "deprecation_date": "2026-10-01",
         "input_cost_per_token": 1.21e-06,
         "input_cost_per_token_batches": 6.05e-07,
         "litellm_provider": "azure",
@@ -4045,7 +4075,7 @@
     },
     "azure/global-standard/gpt-4o-2024-08-06": {
         "cache_read_input_token_cost": 1.25e-06,
-        "deprecation_date": "2026-02-27",
+        "deprecation_date": "2027-04-14",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
@@ -4062,7 +4092,7 @@
     },
     "azure/global-standard/gpt-4o-2024-11-20": {
         "cache_read_input_token_cost": 1.25e-06,
-        "deprecation_date": "2026-03-01",
+        "deprecation_date": "2027-04-14",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
@@ -4091,7 +4121,7 @@
         "supports_vision": true
     },
     "azure/global/gpt-4o-2024-08-06": {
-        "deprecation_date": "2026-02-27",
+        "deprecation_date": "2027-04-14",
         "cache_read_input_token_cost": 1.25e-06,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
@@ -4108,7 +4138,7 @@
         "supports_vision": true
     },
     "azure/global/gpt-4o-2024-11-20": {
-        "deprecation_date": "2026-03-01",
+        "deprecation_date": "2027-04-14",
         "cache_read_input_token_cost": 1.25e-06,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
@@ -4160,6 +4190,7 @@
     },
     "azure/global/gpt-5.1-chat": {
         "cache_read_input_token_cost": 1.25e-07,
+        "deprecation_date": "2026-06-29",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
@@ -4494,7 +4525,7 @@
         "supports_web_search": false
     },
     "azure/gpt-4.1-2025-04-14": {
-        "deprecation_date": "2026-11-04",
+        "deprecation_date": "2027-04-14",
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_batches": 1e-06,
@@ -4561,7 +4592,7 @@
         "supports_web_search": false
     },
     "azure/gpt-4.1-mini-2025-04-14": {
-        "deprecation_date": "2026-11-04",
+        "deprecation_date": "2027-04-14",
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 4e-07,
         "input_cost_per_token_batches": 2e-07,
@@ -4627,7 +4658,7 @@
         "supports_vision": true
     },
     "azure/gpt-4.1-nano-2025-04-14": {
-        "deprecation_date": "2026-11-04",
+        "deprecation_date": "2026-10-14",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "input_cost_per_token_batches": 5e-08,
@@ -4695,6 +4726,7 @@
         "supports_vision": true
     },
     "azure/gpt-4o-2024-05-13": {
+        "deprecation_date": "2026-10-01",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
@@ -4709,7 +4741,7 @@
         "supports_vision": true
     },
     "azure/gpt-4o-2024-08-06": {
-        "deprecation_date": "2026-02-27",
+        "deprecation_date": "2027-04-14",
         "cache_read_input_token_cost": 1.25e-06,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
@@ -4726,7 +4758,7 @@
         "supports_vision": true
     },
     "azure/gpt-4o-2024-11-20": {
-        "deprecation_date": "2026-03-01",
+        "deprecation_date": "2027-04-14",
         "cache_read_input_token_cost": 1.25e-06,
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
@@ -4743,6 +4775,7 @@
         "supports_vision": true
     },
     "azure/gpt-audio-2025-08-28": {
+        "deprecation_date": "2027-03-02",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
@@ -4774,6 +4807,7 @@
         "supports_vision": false
     },
     "azure/gpt-audio-1.5-2026-02-23": {
+        "deprecation_date": "2027-08-24",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
@@ -4805,6 +4839,7 @@
         "supports_vision": false
     },
     "azure/gpt-audio-mini-2025-10-06": {
+        "deprecation_date": "2027-04-06",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "azure",
@@ -4884,6 +4919,7 @@
     },
     "azure/gpt-4o-mini-2024-07-18": {
         "cache_read_input_token_cost": 7.5e-08,
+        "deprecation_date": "2027-04-14",
         "input_cost_per_token": 1.65e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
@@ -4951,6 +4987,7 @@
     "azure/gpt-realtime-2025-08-28": {
         "cache_creation_input_audio_token_cost": 4e-06,
         "cache_read_input_token_cost": 4e-06,
+        "deprecation_date": "2027-03-02",
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_image": 5e-06,
         "input_cost_per_token": 4e-06,
@@ -4983,6 +5020,7 @@
     "azure/gpt-realtime-1.5-2026-02-23": {
         "cache_creation_input_audio_token_cost": 4e-06,
         "cache_read_input_token_cost": 4e-06,
+        "deprecation_date": "2027-08-24",
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_image": 5e-06,
         "input_cost_per_token": 4e-06,
@@ -5120,6 +5158,7 @@
         "supports_tool_choice": true
     },
     "azure/gpt-4o-transcribe": {
+        "deprecation_date": "2026-10-15",
         "input_cost_per_audio_token": 2.5e-06,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
@@ -5132,6 +5171,7 @@
         ]
     },
     "azure/gpt-4o-transcribe-diarize": {
+        "deprecation_date": "2027-04-15",
         "input_cost_per_audio_token": 2.5e-06,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
@@ -5163,6 +5203,7 @@
     "azure/gpt-5.1-2025-11-13": {
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
+        "deprecation_date": "2027-05-15",
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_priority": 2.5e-06,
         "litellm_provider": "azure",
@@ -5200,6 +5241,7 @@
     "azure/gpt-5.1-chat-2025-11-13": {
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
+        "deprecation_date": "2026-06-29",
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_priority": 2.5e-06,
         "litellm_provider": "azure",
@@ -5236,6 +5278,7 @@
     "azure/gpt-5.1-codex-2025-11-13": {
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
+        "deprecation_date": "2027-05-15",
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_priority": 2.5e-06,
         "litellm_provider": "azure",
@@ -5269,6 +5312,7 @@
     "azure/gpt-5.1-codex-mini-2025-11-13": {
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_priority": 4.5e-08,
+        "deprecation_date": "2027-05-15",
         "input_cost_per_token": 2.5e-07,
         "input_cost_per_token_priority": 4.5e-07,
         "litellm_provider": "azure",
@@ -5333,6 +5377,7 @@
     },
     "azure/gpt-5-2025-08-07": {
         "cache_read_input_token_cost": 1.25e-07,
+        "deprecation_date": "2027-02-09",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
@@ -5365,6 +5410,7 @@
     },
     "azure/gpt-5-chat": {
         "cache_read_input_token_cost": 1.25e-07,
+        "deprecation_date": "2026-06-29",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
@@ -5398,6 +5444,7 @@
     },
     "azure/gpt-5-chat-latest": {
         "cache_read_input_token_cost": 1.25e-07,
+        "deprecation_date": "2026-06-29",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
@@ -5430,6 +5477,7 @@
     },
     "azure/gpt-5-codex": {
         "cache_read_input_token_cost": 1.25e-07,
+        "deprecation_date": "2027-03-17",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
@@ -5492,6 +5540,7 @@
     },
     "azure/gpt-5-mini-2025-08-07": {
         "cache_read_input_token_cost": 2.5e-08,
+        "deprecation_date": "2027-02-09",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
@@ -5556,6 +5605,7 @@
     },
     "azure/gpt-5-nano-2025-08-07": {
         "cache_read_input_token_cost": 5e-09,
+        "deprecation_date": "2027-02-09",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
@@ -5587,6 +5637,7 @@
         "supports_vision": true
     },
     "azure/gpt-5-pro": {
+        "deprecation_date": "2027-04-07",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
@@ -5651,6 +5702,7 @@
     },
     "azure/gpt-5.1-chat": {
         "cache_read_input_token_cost": 1.25e-07,
+        "deprecation_date": "2026-06-29",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
@@ -5715,6 +5767,7 @@
     },
     "azure/gpt-5.1-codex-max": {
         "cache_read_input_token_cost": 1.25e-07,
+        "deprecation_date": "2027-05-18",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
@@ -5809,6 +5862,7 @@
     "azure/gpt-5.2-2025-12-11": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
+        "deprecation_date": "2027-06-08",
         "input_cost_per_token": 1.75e-06,
         "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "azure",
@@ -5845,6 +5899,7 @@
     "azure/gpt-5.2-chat": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
+        "deprecation_date": "2026-06-29",
         "input_cost_per_token": 1.75e-06,
         "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "azure",
@@ -5879,6 +5934,7 @@
     "azure/gpt-5.2-chat-2025-12-11": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
+        "deprecation_date": "2026-05-13",
         "input_cost_per_token": 1.75e-06,
         "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "azure",
@@ -5912,6 +5968,7 @@
     },
     "azure/gpt-5.2-codex": {
         "cache_read_input_token_cost": 1.75e-07,
+        "deprecation_date": "2027-07-13",
         "input_cost_per_token": 1.75e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
@@ -5943,6 +6000,7 @@
     "azure/gpt-5.3-chat": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
+        "deprecation_date": "2026-06-29",
         "input_cost_per_token": 1.75e-06,
         "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "azure",
@@ -5976,6 +6034,7 @@
     },
     "azure/gpt-5.3-codex": {
         "cache_read_input_token_cost": 1.75e-07,
+        "deprecation_date": "2027-08-24",
         "input_cost_per_token": 1.75e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
@@ -6012,6 +6071,11 @@
         "max_tokens": 128000,
         "mode": "responses",
         "output_cost_per_token": 0.000168,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/batch",
             "/v1/responses"
@@ -6043,6 +6107,11 @@
         "max_tokens": 128000,
         "mode": "responses",
         "output_cost_per_token": 0.000168,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/batch",
             "/v1/responses"
@@ -6105,7 +6174,10 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true
     },
     "azure/us/gpt-5.4": {
         "cache_read_input_token_cost": 2.8e-07,
@@ -6140,7 +6212,10 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true
     },
     "azure/eu/gpt-5.4": {
         "cache_read_input_token_cost": 2.8e-07,
@@ -6175,13 +6250,17 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true
     },
     "azure/gpt-5.4-2026-03-05": {
         "cache_read_input_token_cost": 2.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 5e-07,
         "cache_read_input_token_cost_priority": 5e-07,
         "cache_read_input_token_cost_above_272k_tokens_priority": 1e-06,
+        "deprecation_date": "2027-09-02",
         "input_cost_per_token": 2.5e-06,
         "input_cost_per_token_above_272k_tokens": 5e-06,
         "input_cost_per_token_priority": 5e-06,
@@ -6216,11 +6295,15 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true
     },
     "azure/us/gpt-5.4-2026-03-05": {
         "cache_read_input_token_cost": 2.8e-07,
         "cache_read_input_token_cost_priority": 5.5e-07,
+        "deprecation_date": "2027-09-02",
         "input_cost_per_token": 2.75e-06,
         "input_cost_per_token_priority": 5.5e-06,
         "output_cost_per_token": 1.65e-05,
@@ -6251,11 +6334,15 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true
     },
     "azure/eu/gpt-5.4-2026-03-05": {
         "cache_read_input_token_cost": 2.8e-07,
         "cache_read_input_token_cost_priority": 5.5e-07,
+        "deprecation_date": "2027-09-02",
         "input_cost_per_token": 2.75e-06,
         "input_cost_per_token_priority": 5.5e-06,
         "output_cost_per_token": 1.65e-05,
@@ -6286,7 +6373,10 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true
     },
     "azure/gpt-5.4-pro": {
         "cache_read_input_token_cost": 3e-06,
@@ -6300,6 +6390,11 @@
         "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/batch",
             "/v1/responses"
@@ -6326,6 +6421,7 @@
     "azure/gpt-5.4-pro-2026-03-05": {
         "cache_read_input_token_cost": 3e-06,
         "cache_read_input_token_cost_above_272k_tokens": 6e-06,
+        "deprecation_date": "2027-09-07",
         "input_cost_per_token": 3e-05,
         "input_cost_per_token_above_272k_tokens": 6e-05,
         "litellm_provider": "azure",
@@ -6335,6 +6431,11 @@
         "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/batch",
             "/v1/responses"
@@ -6376,6 +6477,11 @@
         "output_cost_per_token_above_272k_tokens": 4.5e-05,
         "output_cost_per_token_priority": 6e-05,
         "output_cost_per_token_above_272k_tokens_priority": 9e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -6408,6 +6514,7 @@
         "cache_read_input_token_cost_above_272k_tokens": 1e-06,
         "cache_read_input_token_cost_priority": 1e-06,
         "cache_read_input_token_cost_above_272k_tokens_priority": 2e-06,
+        "deprecation_date": "2028-01-11",
         "input_cost_per_token": 5e-06,
         "input_cost_per_token_above_272k_tokens": 1e-05,
         "input_cost_per_token_priority": 1e-05,
@@ -6421,6 +6528,11 @@
         "output_cost_per_token_above_272k_tokens": 4.5e-05,
         "output_cost_per_token_priority": 6e-05,
         "output_cost_per_token_above_272k_tokens_priority": 9e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -6449,23 +6561,29 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/gpt-5.6-terra": {
-        "cache_read_input_token_cost": 2.5e-07,
-        "cache_read_input_token_cost_above_272k_tokens": 5e-07,
-        "cache_read_input_token_cost_priority": 5e-07,
-        "cache_read_input_token_cost_above_272k_tokens_priority": 1e-06,
-        "input_cost_per_token": 2.5e-06,
-        "input_cost_per_token_above_272k_tokens": 5e-06,
-        "input_cost_per_token_priority": 5e-06,
-        "input_cost_per_token_above_272k_tokens_priority": 1e-05,
+        "cache_read_input_token_cost": 2e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 4e-07,
+        "cache_read_input_token_cost_priority": 4e-07,
+        "cache_read_input_token_cost_above_272k_tokens_priority": 8e-07,
+        "deprecation_date": "2028-01-11",
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_above_272k_tokens": 4e-06,
+        "input_cost_per_token_priority": 4e-06,
+        "input_cost_per_token_above_272k_tokens_priority": 8e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "output_cost_per_token_above_272k_tokens": 2.25e-05,
-        "output_cost_per_token_priority": 3e-05,
-        "output_cost_per_token_above_272k_tokens_priority": 4.5e-05,
+        "output_cost_per_token": 1.2e-05,
+        "output_cost_per_token_above_272k_tokens": 1.8e-05,
+        "output_cost_per_token_priority": 2.4e-05,
+        "output_cost_per_token_above_272k_tokens_priority": 3.6e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -6494,23 +6612,29 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/gpt-5.6-luna": {
-        "cache_read_input_token_cost": 1e-07,
-        "cache_read_input_token_cost_above_272k_tokens": 2e-07,
-        "cache_read_input_token_cost_priority": 2e-07,
-        "cache_read_input_token_cost_above_272k_tokens_priority": 4e-07,
-        "input_cost_per_token": 1e-06,
-        "input_cost_per_token_above_272k_tokens": 2e-06,
-        "input_cost_per_token_priority": 2e-06,
-        "input_cost_per_token_above_272k_tokens_priority": 4e-06,
+        "cache_read_input_token_cost": 2e-08,
+        "cache_read_input_token_cost_above_272k_tokens": 4e-08,
+        "cache_read_input_token_cost_priority": 4e-08,
+        "cache_read_input_token_cost_above_272k_tokens_priority": 8e-08,
+        "deprecation_date": "2028-01-11",
+        "input_cost_per_token": 2e-07,
+        "input_cost_per_token_above_272k_tokens": 4e-07,
+        "input_cost_per_token_priority": 4e-07,
+        "input_cost_per_token_above_272k_tokens_priority": 8e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
-        "output_cost_per_token": 6e-06,
-        "output_cost_per_token_above_272k_tokens": 9e-06,
-        "output_cost_per_token_priority": 1.2e-05,
-        "output_cost_per_token_above_272k_tokens_priority": 1.8e-05,
+        "output_cost_per_token": 1.2e-06,
+        "output_cost_per_token_above_272k_tokens": 1.8e-06,
+        "output_cost_per_token_priority": 2.4e-06,
+        "output_cost_per_token_above_272k_tokens_priority": 3.6e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -6553,6 +6677,11 @@
         "output_cost_per_token": 3.3e-05,
         "output_cost_per_token_above_272k_tokens": 4.95e-05,
         "output_cost_per_token_priority": 8.25e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -6584,6 +6713,7 @@
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
+        "deprecation_date": "2028-01-11",
         "input_cost_per_token": 5.5e-06,
         "input_cost_per_token_above_272k_tokens": 1.1e-05,
         "input_cost_per_token_priority": 1.375e-05,
@@ -6595,6 +6725,11 @@
         "output_cost_per_token": 3.3e-05,
         "output_cost_per_token_above_272k_tokens": 4.95e-05,
         "output_cost_per_token_priority": 8.25e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -6623,20 +6758,26 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6-terra": {
-        "cache_read_input_token_cost": 2.75e-07,
-        "cache_read_input_token_cost_above_272k_tokens": 5.5e-07,
-        "cache_read_input_token_cost_priority": 6.875e-07,
-        "input_cost_per_token": 2.75e-06,
-        "input_cost_per_token_above_272k_tokens": 5.5e-06,
-        "input_cost_per_token_priority": 6.875e-06,
+        "cache_read_input_token_cost": 2.2e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 4.4e-07,
+        "cache_read_input_token_cost_priority": 5.5e-07,
+        "deprecation_date": "2028-01-11",
+        "input_cost_per_token": 2.2e-06,
+        "input_cost_per_token_above_272k_tokens": 4.4e-06,
+        "input_cost_per_token_priority": 5.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
-        "output_cost_per_token": 1.65e-05,
-        "output_cost_per_token_above_272k_tokens": 2.475e-05,
-        "output_cost_per_token_priority": 4.125e-05,
+        "output_cost_per_token": 1.32e-05,
+        "output_cost_per_token_above_272k_tokens": 1.98e-05,
+        "output_cost_per_token_priority": 3.3e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -6665,20 +6806,26 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6-luna": {
-        "cache_read_input_token_cost": 1.1e-07,
-        "cache_read_input_token_cost_above_272k_tokens": 2.2e-07,
-        "cache_read_input_token_cost_priority": 2.75e-07,
-        "input_cost_per_token": 1.1e-06,
-        "input_cost_per_token_above_272k_tokens": 2.2e-06,
-        "input_cost_per_token_priority": 2.75e-06,
+        "cache_read_input_token_cost": 2.2e-08,
+        "cache_read_input_token_cost_above_272k_tokens": 4.4e-08,
+        "cache_read_input_token_cost_priority": 5.5e-08,
+        "deprecation_date": "2028-01-11",
+        "input_cost_per_token": 2.2e-07,
+        "input_cost_per_token_above_272k_tokens": 4.4e-07,
+        "input_cost_per_token_priority": 5.5e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
-        "output_cost_per_token": 6.6e-06,
-        "output_cost_per_token_above_272k_tokens": 9.9e-06,
-        "output_cost_per_token_priority": 1.65e-05,
+        "output_cost_per_token": 1.32e-06,
+        "output_cost_per_token_above_272k_tokens": 1.98e-06,
+        "output_cost_per_token_priority": 3.3e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -6721,6 +6868,11 @@
         "output_cost_per_token": 3.3e-05,
         "output_cost_per_token_above_272k_tokens": 4.95e-05,
         "output_cost_per_token_priority": 8.25e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -6752,6 +6904,7 @@
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
+        "deprecation_date": "2028-01-11",
         "input_cost_per_token": 5.5e-06,
         "input_cost_per_token_above_272k_tokens": 1.1e-05,
         "input_cost_per_token_priority": 1.375e-05,
@@ -6763,6 +6916,11 @@
         "output_cost_per_token": 3.3e-05,
         "output_cost_per_token_above_272k_tokens": 4.95e-05,
         "output_cost_per_token_priority": 8.25e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -6791,20 +6949,26 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6-terra": {
-        "cache_read_input_token_cost": 2.75e-07,
-        "cache_read_input_token_cost_above_272k_tokens": 5.5e-07,
-        "cache_read_input_token_cost_priority": 6.875e-07,
-        "input_cost_per_token": 2.75e-06,
-        "input_cost_per_token_above_272k_tokens": 5.5e-06,
-        "input_cost_per_token_priority": 6.875e-06,
+        "cache_read_input_token_cost": 2.2e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 4.4e-07,
+        "cache_read_input_token_cost_priority": 5.5e-07,
+        "deprecation_date": "2028-01-11",
+        "input_cost_per_token": 2.2e-06,
+        "input_cost_per_token_above_272k_tokens": 4.4e-06,
+        "input_cost_per_token_priority": 5.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
-        "output_cost_per_token": 1.65e-05,
-        "output_cost_per_token_above_272k_tokens": 2.475e-05,
-        "output_cost_per_token_priority": 4.125e-05,
+        "output_cost_per_token": 1.32e-05,
+        "output_cost_per_token_above_272k_tokens": 1.98e-05,
+        "output_cost_per_token_priority": 3.3e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -6833,20 +6997,26 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6-luna": {
-        "cache_read_input_token_cost": 1.1e-07,
-        "cache_read_input_token_cost_above_272k_tokens": 2.2e-07,
-        "cache_read_input_token_cost_priority": 2.75e-07,
-        "input_cost_per_token": 1.1e-06,
-        "input_cost_per_token_above_272k_tokens": 2.2e-06,
-        "input_cost_per_token_priority": 2.75e-06,
+        "cache_read_input_token_cost": 2.2e-08,
+        "cache_read_input_token_cost_above_272k_tokens": 4.4e-08,
+        "cache_read_input_token_cost_priority": 5.5e-08,
+        "deprecation_date": "2028-01-11",
+        "input_cost_per_token": 2.2e-07,
+        "input_cost_per_token_above_272k_tokens": 4.4e-07,
+        "input_cost_per_token_priority": 5.5e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
-        "output_cost_per_token": 6.6e-06,
-        "output_cost_per_token_above_272k_tokens": 9.9e-06,
-        "output_cost_per_token_priority": 1.65e-05,
+        "output_cost_per_token": 1.32e-06,
+        "output_cost_per_token_above_272k_tokens": 1.98e-06,
+        "output_cost_per_token_priority": 3.3e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -6892,6 +7062,11 @@
         "output_cost_per_token_above_272k_tokens": 4.5e-05,
         "output_cost_per_token_priority": 6e-05,
         "output_cost_per_token_above_272k_tokens_priority": 9e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -6934,6 +7109,11 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -6976,6 +7156,11 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -7021,6 +7206,11 @@
         "output_cost_per_token_above_272k_tokens": 4.5e-05,
         "output_cost_per_token_priority": 6e-05,
         "output_cost_per_token_above_272k_tokens_priority": 9e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -7060,6 +7250,11 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -7099,6 +7294,11 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -7135,6 +7335,11 @@
         "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/batch",
             "/v1/responses"
@@ -7174,6 +7379,11 @@
         "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/batch",
             "/v1/responses"
@@ -7201,11 +7411,16 @@
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 7.5e-07,
         "litellm_provider": "azure",
-        "max_input_tokens": 1050000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 4.5e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -7229,18 +7444,24 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "supports_none_reasoning_effort": false,
-        "supports_xhigh_reasoning_effort": false
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
     },
     "azure/gpt-5.4-mini-2026-03-17": {
         "cache_read_input_token_cost": 7.5e-08,
+        "deprecation_date": "2027-09-21",
         "input_cost_per_token": 7.5e-07,
         "litellm_provider": "azure",
-        "max_input_tokens": 1050000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 4.5e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -7264,18 +7485,23 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "supports_none_reasoning_effort": false,
-        "supports_xhigh_reasoning_effort": false
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
     },
     "azure/gpt-5.4-nano": {
         "cache_read_input_token_cost": 2e-08,
         "input_cost_per_token": 2e-07,
         "litellm_provider": "azure",
-        "max_input_tokens": 1050000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 1.25e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -7299,18 +7525,24 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "supports_none_reasoning_effort": false,
-        "supports_xhigh_reasoning_effort": false
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
     },
     "azure/gpt-5.4-nano-2026-03-17": {
         "cache_read_input_token_cost": 2e-08,
+        "deprecation_date": "2027-09-21",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "azure",
-        "max_input_tokens": 1050000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 1.25e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -7334,11 +7566,12 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "supports_none_reasoning_effort": false,
-        "supports_xhigh_reasoning_effort": false
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
     },
     "azure/gpt-image-1": {
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2026-10-23",
         "input_cost_per_image_token": 1e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "azure",
@@ -7450,6 +7683,7 @@
     },
     "azure/gpt-image-1-mini": {
         "cache_read_input_token_cost": 2e-07,
+        "deprecation_date": "2027-04-07",
         "input_cost_per_image_token": 2.5e-06,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "azure",
@@ -7474,6 +7708,7 @@
     },
     "azure/gpt-image-1.5-2025-12-16": {
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2027-06-16",
         "input_cost_per_token": 5e-06,
         "input_cost_per_image_token": 8e-06,
         "litellm_provider": "azure",
@@ -7501,6 +7736,7 @@
     },
     "azure/gpt-image-2-2026-04-21": {
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2027-10-21",
         "input_cost_per_token": 5e-06,
         "input_cost_per_image_token": 8e-06,
         "litellm_provider": "azure",
@@ -7631,6 +7867,7 @@
     },
     "azure/o1-2024-12-17": {
         "cache_read_input_token_cost": 7.5e-06,
+        "deprecation_date": "2026-10-21",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
@@ -7736,7 +7973,7 @@
         "supports_vision": true
     },
     "azure/o3-2025-04-16": {
-        "deprecation_date": "2026-04-16",
+        "deprecation_date": "2026-10-21",
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "azure",
@@ -7767,6 +8004,7 @@
     },
     "azure/o3-deep-research": {
         "cache_read_input_token_cost": 2.5e-06,
+        "deprecation_date": "2026-12-26",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
@@ -7774,6 +8012,11 @@
         "max_tokens": 100000,
         "mode": "responses",
         "output_cost_per_token": 4e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -7814,6 +8057,7 @@
     },
     "azure/o3-mini-2025-01-31": {
         "cache_read_input_token_cost": 5.5e-07,
+        "deprecation_date": "2026-10-01",
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
@@ -7857,6 +8101,7 @@
         "supports_vision": true
     },
     "azure/o3-pro-2025-06-10": {
+        "deprecation_date": "2026-12-17",
         "input_cost_per_token": 2e-05,
         "input_cost_per_token_batches": 1e-05,
         "litellm_provider": "azure",
@@ -7917,6 +8162,7 @@
     },
     "azure/o4-mini-2025-04-16": {
         "cache_read_input_token_cost": 2.75e-07,
+        "deprecation_date": "2026-10-16",
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
@@ -7957,6 +8203,7 @@
         "output_cost_per_token": 0.0
     },
     "azure/text-embedding-3-large": {
+        "deprecation_date": "2028-02-09",
         "input_cost_per_token": 1.3e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 8191,
@@ -7965,7 +8212,7 @@
         "output_cost_per_token": 0.0
     },
     "azure/text-embedding-3-small": {
-        "deprecation_date": "2026-04-30",
+        "deprecation_date": "2028-02-09",
         "input_cost_per_token": 2e-08,
         "litellm_provider": "azure",
         "max_input_tokens": 8191,
@@ -7974,6 +8221,7 @@
         "output_cost_per_token": 0.0
     },
     "azure/text-embedding-ada-002": {
+        "deprecation_date": "2028-02-09",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 8191,
@@ -8005,17 +8253,19 @@
         ]
     },
     "azure/tts-1": {
+        "deprecation_date": "2026-12-15",
         "input_cost_per_character": 1.5e-05,
         "litellm_provider": "azure",
         "mode": "audio_speech"
     },
     "azure/tts-1-hd": {
+        "deprecation_date": "2026-12-15",
         "input_cost_per_character": 3e-05,
         "litellm_provider": "azure",
         "mode": "audio_speech"
     },
     "azure/us/gpt-4.1-2025-04-14": {
-        "deprecation_date": "2026-11-04",
+        "deprecation_date": "2027-04-14",
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 2.2e-06,
         "input_cost_per_token_batches": 1.1e-06,
@@ -8049,7 +8299,7 @@
         "supports_web_search": false
     },
     "azure/us/gpt-4.1-mini-2025-04-14": {
-        "deprecation_date": "2026-11-04",
+        "deprecation_date": "2027-04-14",
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 4.4e-07,
         "input_cost_per_token_batches": 2.2e-07,
@@ -8083,7 +8333,7 @@
         "supports_web_search": false
     },
     "azure/us/gpt-4.1-nano-2025-04-14": {
-        "deprecation_date": "2026-11-04",
+        "deprecation_date": "2026-10-14",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_token": 1.1e-07,
         "input_cost_per_token_batches": 6e-08,
@@ -8116,7 +8366,7 @@
         "supports_vision": true
     },
     "azure/us/gpt-4o-2024-08-06": {
-        "deprecation_date": "2026-02-27",
+        "deprecation_date": "2027-04-14",
         "cache_read_input_token_cost": 1.375e-06,
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
@@ -8133,7 +8383,7 @@
         "supports_vision": true
     },
     "azure/us/gpt-4o-2024-11-20": {
-        "deprecation_date": "2026-03-01",
+        "deprecation_date": "2027-04-14",
         "cache_creation_input_token_cost": 1.38e-06,
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
@@ -8150,6 +8400,7 @@
     },
     "azure/us/gpt-4o-mini-2024-07-18": {
         "cache_read_input_token_cost": 8.3e-08,
+        "deprecation_date": "2027-04-14",
         "input_cost_per_token": 1.65e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
@@ -8231,6 +8482,7 @@
     },
     "azure/us/gpt-5-2025-08-07": {
         "cache_read_input_token_cost": 1.375e-07,
+        "deprecation_date": "2027-02-09",
         "input_cost_per_token": 1.375e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
@@ -8263,6 +8515,7 @@
     },
     "azure/us/gpt-5-mini-2025-08-07": {
         "cache_read_input_token_cost": 2.75e-08,
+        "deprecation_date": "2027-02-09",
         "input_cost_per_token": 2.75e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
@@ -8295,6 +8548,7 @@
     },
     "azure/us/gpt-5-nano-2025-08-07": {
         "cache_read_input_token_cost": 5.5e-09,
+        "deprecation_date": "2027-02-09",
         "input_cost_per_token": 5.5e-08,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
@@ -8361,6 +8615,7 @@
     },
     "azure/us/gpt-5.1-chat": {
         "cache_read_input_token_cost": 1.4e-07,
+        "deprecation_date": "2026-06-29",
         "input_cost_per_token": 1.38e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
@@ -8455,6 +8710,7 @@
     },
     "azure/us/o1-2024-12-17": {
         "cache_read_input_token_cost": 8.25e-06,
+        "deprecation_date": "2026-10-21",
         "input_cost_per_token": 1.65e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
@@ -8499,7 +8755,7 @@
         "supports_vision": false
     },
     "azure/us/o3-2025-04-16": {
-        "deprecation_date": "2026-04-16",
+        "deprecation_date": "2026-10-21",
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 2.2e-06,
         "litellm_provider": "azure",
@@ -8530,6 +8786,7 @@
     },
     "azure/us/o3-mini-2025-01-31": {
         "cache_read_input_token_cost": 6.05e-07,
+        "deprecation_date": "2026-10-01",
         "input_cost_per_token": 1.21e-06,
         "input_cost_per_token_batches": 6.05e-07,
         "litellm_provider": "azure",
@@ -8546,6 +8803,7 @@
     },
     "azure/us/o4-mini-2025-04-16": {
         "cache_read_input_token_cost": 3.1e-07,
+        "deprecation_date": "2026-10-16",
         "input_cost_per_token": 1.21e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
@@ -8562,6 +8820,7 @@
         "supports_vision": true
     },
     "azure/whisper-1": {
+        "deprecation_date": "2026-12-15",
         "input_cost_per_second": 0.0001,
         "litellm_provider": "azure",
         "mode": "audio_transcription",
@@ -8615,6 +8874,268 @@
         "supported_endpoints": [
             "/v1/images/generations"
         ]
+    },
+    "azure_ai/FW-DeepSeek-V3.2": {
+        "cache_read_input_token_cost": 3.1e-07,
+        "input_cost_per_token": 6.2e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 163840,
+        "max_output_tokens": 163840,
+        "max_tokens": 163840,
+        "mode": "chat",
+        "output_cost_per_token": 1.85e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-DeepSeek-V4-Pro": {
+        "cache_read_input_token_cost": 1.65e-07,
+        "input_cost_per_token": 1.925e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 384000,
+        "max_tokens": 384000,
+        "mode": "chat",
+        "output_cost_per_token": 3.828e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5": {
+        "cache_read_input_token_cost": 2.2e-07,
+        "input_cost_per_token": 1.1e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3.52e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5.1": {
+        "cache_read_input_token_cost": 2.86e-07,
+        "input_cost_per_token": 1.54e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 202800,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.84e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5.2": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 1.54e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.84e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5.2-Fast": {
+        "cache_read_input_token_cost": 2.1e-07,
+        "input_cost_per_token": 2.1e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 6.6e-06,
+        "source": "https://docs.fireworks.ai/serverless/pricing",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-Inkling": {
+        "cache_read_input_token_cost": 1.7e-07,
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 4.05e-06,
+        "source": "https://fireworks.ai/models/fireworks/inkling",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-Kimi-K2.5": {
+        "cache_read_input_token_cost": 1.1e-07,
+        "input_cost_per_token": 6.6e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 3.3e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K2.6": {
+        "cache_read_input_token_cost": 1.76e-07,
+        "input_cost_per_token": 1.045e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K2.7-Code": {
+        "cache_read_input_token_cost": 2.1e-07,
+        "input_cost_per_token": 1.05e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K3": {
+        "cache_read_input_token_cost": 3.3e-07,
+        "input_cost_per_token": 3.3e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-05,
+        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-kimi-k3-through-fireworks-ai-on-microsoft-foundry/4540187",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-MiniMax-M2.5": {
+        "cache_read_input_token_cost": 3.3e-08,
+        "input_cost_per_token": 3.3e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 1.32e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-MiniMax-M3": {
+        "cache_read_input_token_cost": 6.6e-08,
+        "input_cost_per_token": 3.3e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 512000,
+        "max_output_tokens": 512000,
+        "max_tokens": 512000,
+        "mode": "chat",
+        "output_cost_per_token": 1.32e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Nemotron-3-Ultra-NVFP4": {
+        "cache_read_input_token_cost": 1.19e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 2.4e-06,
+        "source": "https://fireworks.ai/models/fireworks/nemotron-3-ultra-nvfp4",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
     },
     "azure_ai/MAI-Image-2.5": {
         "input_cost_per_image_token": 8e-06,
@@ -9233,6 +9754,24 @@
         "supports_tool_choice": true,
         "supports_web_search": true
     },
+    "azure_ai/grok-4.3": {
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 1.25e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 200000,
+        "max_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-grok-4-3-on-microsoft-foundry-latest-generation-agentic-capabilities/4517096",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
     "azure_ai/grok-4-fast-non-reasoning": {
         "input_cost_per_token": 2e-07,
         "output_cost_per_token": 5e-07,
@@ -9513,6 +10052,21 @@
         "output_cost_per_second": 0.0066027,
         "supports_tool_choice": true
     },
+    "bedrock/guardrails": {
+        "guardrail_cost_per_unit": {
+            "automatedReasoningPolicyUnits": 0.00017,
+            "contentPolicyImageUnits": 0.00075,
+            "contentPolicyUnits": 0.00015,
+            "contextualGroundingPolicyUnits": 0.0001,
+            "sensitiveInformationPolicyFreeUnits": 0.0,
+            "sensitiveInformationPolicyUnits": 0.0001,
+            "topicPolicyUnits": 0.00015,
+            "wordPolicyUnits": 0.0
+        },
+        "litellm_provider": "bedrock",
+        "mode": "guardrail",
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
     "bedrock/ap-northeast-1/1-month-commitment/anthropic.claude-instant-v1": {
         "input_cost_per_second": 0.01475,
         "litellm_provider": "bedrock",
@@ -9611,6 +10165,7 @@
         "output_cost_per_token": 2.22e-06,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_native_structured_output": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
@@ -9734,6 +10289,7 @@
         "output_cost_per_token": 2.22e-06,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_native_structured_output": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
@@ -9826,6 +10382,7 @@
         "output_cost_per_token": 2.22e-06,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_native_structured_output": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
@@ -9911,6 +10468,7 @@
         "output_cost_per_token": 2.22e-06,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_native_structured_output": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
@@ -10314,6 +10872,7 @@
         "output_cost_per_token": 2.22e-06,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_native_structured_output": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
@@ -10528,6 +11087,7 @@
         "output_cost_per_token": 1.85e-06,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_native_structured_output": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
@@ -10605,6 +11165,7 @@
         "output_cost_per_token": 1.85e-06,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_native_structured_output": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
@@ -10733,6 +11294,7 @@
         "output_cost_per_token": 1.5e-06
     },
     "bedrock/us-gov-east-1/anthropic.claude-3-5-sonnet-20240620-v1:0": {
+        "deprecation_date": "2026-07-30",
         "input_cost_per_token": 3.6e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -10749,6 +11311,7 @@
         "cache_creation_input_token_cost": 4.5e-06
     },
     "bedrock/us-gov-east-1/anthropic.claude-3-haiku-20240307-v1:0": {
+        "deprecation_date": "2026-09-10",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -10770,6 +11333,7 @@
         "cache_read_input_token_cost": 3.6e-07,
         "input_cost_per_token": 3.6e-06,
         "litellm_provider": "bedrock",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
@@ -10794,6 +11358,7 @@
         "cache_read_input_token_cost": 3.6e-07,
         "input_cost_per_token": 3.6e-06,
         "litellm_provider": "bedrock",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
@@ -10894,6 +11459,7 @@
     "bedrock/us-gov-west-1/anthropic.claude-3-7-sonnet-20250219-v1:0": {
         "cache_creation_input_token_cost": 4.5e-06,
         "cache_read_input_token_cost": 3.6e-07,
+        "deprecation_date": "2026-07-30",
         "input_cost_per_token": 3.6e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -10912,6 +11478,7 @@
         "supports_vision": true
     },
     "bedrock/us-gov-west-1/anthropic.claude-3-5-sonnet-20240620-v1:0": {
+        "deprecation_date": "2026-07-30",
         "input_cost_per_token": 3.6e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -10928,6 +11495,7 @@
         "cache_creation_input_token_cost": 4.5e-06
     },
     "bedrock/us-gov-west-1/anthropic.claude-3-haiku-20240307-v1:0": {
+        "deprecation_date": "2026-09-10",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -10949,6 +11517,7 @@
         "cache_read_input_token_cost": 3.6e-07,
         "input_cost_per_token": 3.6e-06,
         "litellm_provider": "bedrock",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
@@ -10973,6 +11542,7 @@
         "cache_read_input_token_cost": 3.6e-07,
         "input_cost_per_token": 3.6e-06,
         "litellm_provider": "bedrock",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
@@ -11157,6 +11727,7 @@
         "output_cost_per_token": 1.85e-06,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_native_structured_output": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
@@ -11414,6 +11985,7 @@
         "output_cost_per_token": 5e-07
     },
     "chatgpt-4o-latest": {
+        "deprecation_date": "2026-02-17",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -11454,6 +12026,7 @@
         "output_cost_per_token": 5e-06,
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_native_structured_output": true,
         "supports_computer_use": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
@@ -11476,6 +12049,7 @@
         "output_cost_per_token": 5e-06,
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_native_structured_output": true,
         "supports_computer_use": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
@@ -11517,6 +12091,7 @@
         "cache_creation_input_token_cost": 3e-07,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-08,
+        "deprecation_date": "2026-04-20",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
@@ -11535,7 +12110,7 @@
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 1.5e-06,
-        "deprecation_date": "2026-05-01",
+        "deprecation_date": "2026-01-05",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
@@ -11553,6 +12128,7 @@
     "claude-4-opus-20250514": {
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
+        "deprecation_date": "2026-06-15",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
@@ -11581,6 +12157,7 @@
         "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
         "cache_read_input_token_cost": 3e-07,
         "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+        "deprecation_date": "2026-06-15",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
         "litellm_provider": "anthropic",
@@ -11694,6 +12271,7 @@
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
+        "supports_native_structured_output": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
@@ -11751,6 +12329,7 @@
         "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
         "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "litellm_provider": "bedrock",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -11794,7 +12373,8 @@
         "supports_native_structured_output": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "prompt_cache_min_tokens": 1024
+        "prompt_cache_min_tokens": 1024,
+        "deprecation_date": "2026-08-05"
     },
     "claude-opus-4-1-20250805": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -11830,7 +12410,7 @@
         "cache_creation_input_token_cost_above_1hr": 3e-05,
         "cache_read_input_token_cost": 1.5e-06,
         "input_cost_per_token": 1.5e-05,
-        "deprecation_date": "2026-05-14",
+        "deprecation_date": "2026-06-15",
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 32000,
@@ -12171,7 +12751,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "claude-sonnet-4-20250514": {
-        "deprecation_date": "2026-05-14",
+        "deprecation_date": "2026-06-15",
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
@@ -12526,6 +13106,7 @@
     },
     "codex-mini-latest": {
         "cache_read_input_token_cost": 3.75e-07,
+        "deprecation_date": "2026-02-12",
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 200000,
@@ -12564,6 +13145,7 @@
         "supports_tool_choice": true
     },
     "cohere.command-r-plus-v1:0": {
+        "deprecation_date": "2026-08-19",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -12574,6 +13156,7 @@
         "supports_tool_choice": true
     },
     "cohere.command-r-v1:0": {
+        "deprecation_date": "2026-08-19",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -12764,6 +13347,7 @@
         "supports_vision": true
     },
     "dall-e-2": {
+        "deprecation_date": "2026-05-12",
         "input_cost_per_image": 0.02,
         "litellm_provider": "openai",
         "mode": "image_generation",
@@ -12774,6 +13358,7 @@
         ]
     },
     "dall-e-3": {
+        "deprecation_date": "2026-05-12",
         "input_cost_per_image": 0.04,
         "litellm_provider": "openai",
         "mode": "image_generation",
@@ -12823,6 +13408,103 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": false
+    },
+    "dashscope/deepseek-v4-flash": {
+        "cache_read_input_token_cost": 4e-08,
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "dashscope/deepseek-v4-flash-0731": {
+        "cache_read_input_token_cost": 4e-08,
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "dashscope/deepseek-v4-pro": {
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 2.4e-06,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "output_cost_per_token": 4.8e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "dashscope/glm-5.1": {
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 202745,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "dashscope/glm-5.2": {
+        "cache_read_input_token_cost": 2.8e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "dashscope/kimi-k2.7-code": {
+        "cache_read_input_token_cost": 1.9e-07,
+        "input_cost_per_token": 9.5e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 229376,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
     },
     "dashscope/qwen-coder": {
         "input_cost_per_token": 3e-07,
@@ -13567,6 +14249,73 @@
             }
         ]
     },
+    "dashscope/qwen3.7-max": {
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 2.5e-06,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 991808,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "dashscope/qwen3.7-plus": {
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 991808,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tiered_pricing": [
+            {
+                "cache_read_input_token_cost": 8e-08,
+                "input_cost_per_token": 4e-07,
+                "output_cost_per_token": 1.6e-06,
+                "range": [
+                    0,
+                    256000.0
+                ]
+            },
+            {
+                "cache_read_input_token_cost": 2.4e-07,
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_token": 4.8e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "dashscope/qwen3.8-max": {
+        "cache_read_input_token_cost": 2.5e-07,
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 991808,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "dashscope/qwq-plus": {
         "input_cost_per_token": 8e-07,
         "litellm_provider": "dashscope",
@@ -13707,6 +14456,25 @@
         "supports_tool_choice": true,
         "supports_output_config": true
     },
+    "databricks/databricks-claude-opus-4-6": {
+        "input_cost_per_token": 5.00003e-06,
+        "input_dbu_cost_per_token": 7.1429e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 2.5000010000000002e-05,
+        "output_dbu_cost_per_token": 0.000357143,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "databricks/databricks-claude-sonnet-4": {
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
@@ -13764,6 +14532,25 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "databricks/databricks-claude-sonnet-4-6": {
+        "input_cost_per_token": 2.9999900000000002e-06,
+        "input_dbu_cost_per_token": 4.2857e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.5000020000000002e-05,
+        "output_dbu_cost_per_token": 0.000214286,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "databricks/databricks-gemini-2-5-flash": {
         "input_cost_per_token": 3.0001999999999996e-07,
         "input_dbu_cost_per_token": 4.285999999999999e-06,
@@ -13794,6 +14581,74 @@
         "mode": "chat",
         "output_cost_per_token": 9.999990000000002e-06,
         "output_dbu_cost_per_token": 0.000142857,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
+    "databricks/databricks-gemini-3-1-flash-lite": {
+        "input_cost_per_token": 3.1248e-07,
+        "input_dbu_cost_per_token": 4.464e-06,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.87502e-06,
+        "output_dbu_cost_per_token": 2.6786e-05,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
+    "databricks/databricks-gemini-3-1-pro": {
+        "input_cost_per_token": 2.49998e-06,
+        "input_dbu_cost_per_token": 3.5714e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.5000020000000002e-05,
+        "output_dbu_cost_per_token": 0.000214286,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
+    "databricks/databricks-gemini-3-flash": {
+        "input_cost_per_token": 6.2503e-07,
+        "input_dbu_cost_per_token": 8.929e-06,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 3.74997e-06,
+        "output_dbu_cost_per_token": 5.3571e-05,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
+    "databricks/databricks-gemini-3-pro": {
+        "input_cost_per_token": 2.49998e-06,
+        "input_dbu_cost_per_token": 3.5714e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.5000020000000002e-05,
+        "output_dbu_cost_per_token": 0.000214286,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
         "supports_tool_choice": true
@@ -13841,6 +14696,126 @@
         "mode": "chat",
         "output_cost_per_token": 9.999990000000002e-06,
         "output_dbu_cost_per_token": 0.000142857,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-1-codex-max": {
+        "input_cost_per_token": 1.24999e-06,
+        "input_dbu_cost_per_token": 1.7857e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 9.999990000000002e-06,
+        "output_dbu_cost_per_token": 0.000142857,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-1-codex-mini": {
+        "input_cost_per_token": 2.4997e-07,
+        "input_dbu_cost_per_token": 3.571e-06,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.99997e-06,
+        "output_dbu_cost_per_token": 2.8571e-05,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-2": {
+        "input_cost_per_token": 1.75e-06,
+        "input_dbu_cost_per_token": 2.5e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.4e-05,
+        "output_dbu_cost_per_token": 0.0002,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-2-codex": {
+        "input_cost_per_token": 1.75e-06,
+        "input_dbu_cost_per_token": 2.5e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.4e-05,
+        "output_dbu_cost_per_token": 0.0002,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-3-codex": {
+        "input_cost_per_token": 1.75e-06,
+        "input_dbu_cost_per_token": 2.5e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.4e-05,
+        "output_dbu_cost_per_token": 0.0002,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-4": {
+        "input_cost_per_token": 2.49998e-06,
+        "input_dbu_cost_per_token": 3.5714e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.5000020000000002e-05,
+        "output_dbu_cost_per_token": 0.000214286,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-4-mini": {
+        "input_cost_per_token": 7.4998e-07,
+        "input_dbu_cost_per_token": 1.0714e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 4.50002e-06,
+        "output_dbu_cost_per_token": 6.4286e-05,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-4-nano": {
+        "input_cost_per_token": 1.9999e-07,
+        "input_dbu_cost_per_token": 2.857e-06,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.24999e-06,
+        "output_dbu_cost_per_token": 1.7857e-05,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
     },
     "databricks/databricks-gpt-5-mini": {
@@ -15264,6 +16239,17 @@
         "supports_tool_choice": true,
         "supports_function_calling": true
     },
+    "deepinfra/nvidia/NVIDIA-Nemotron-3.5-Lightning": {
+        "max_input_tokens": 262144,
+        "input_cost_per_token": 5e-08,
+        "output_cost_per_token": 2e-07,
+        "litellm_provider": "deepinfra",
+        "mode": "chat",
+        "source": "https://deepinfra.com/nvidia/NVIDIA-Nemotron-3.5-Lightning",
+        "supports_tool_choice": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true
+    },
     "deepinfra/nvidia/NVIDIA-Nemotron-Nano-9B-v2": {
         "max_tokens": 131072,
         "max_input_tokens": 131072,
@@ -15439,6 +16425,7 @@
         "output_cost_per_token": 1.85e-06,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_native_structured_output": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
@@ -15697,6 +16684,14 @@
             "notes": "TinyFish Search API"
         }
     },
+    "nimble/search": {
+        "input_cost_per_query": 0.005,
+        "litellm_provider": "nimble",
+        "mode": "search",
+        "metadata": {
+            "notes": "Nimble Search API pay-as-you-go list price: $5 per 1,000 searches, up to 100 results per search. Volume plans price differently."
+        }
+    },
     "elevenlabs/scribe_v1": {
         "input_cost_per_second": 6.11e-05,
         "litellm_provider": "elevenlabs",
@@ -15754,6 +16749,7 @@
         ]
     },
     "embed-english-light-v2.0": {
+        "deprecation_date": "2026-04-04",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",
         "max_input_tokens": 1024,
@@ -15770,6 +16766,7 @@
         "output_cost_per_token": 0.0
     },
     "embed-english-v2.0": {
+        "deprecation_date": "2026-04-04",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",
         "max_input_tokens": 4096,
@@ -15792,6 +16789,7 @@
         "supports_image_input": true
     },
     "embed-multilingual-v2.0": {
+        "deprecation_date": "2026-04-04",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",
         "max_input_tokens": 768,
@@ -15883,6 +16881,7 @@
         "input_cost_per_token": 1.1e-06,
         "deprecation_date": "2026-10-15",
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -15958,6 +16957,7 @@
         "cache_creation_input_token_cost": 3.75e-06
     },
     "eu.anthropic.claude-3-haiku-20240307-v1:0": {
+        "deprecation_date": "2026-09-10",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -15989,6 +16989,7 @@
         "cache_creation_input_token_cost": 1.875e-05
     },
     "eu.anthropic.claude-3-sonnet-20240229-v1:0": {
+        "deprecation_date": "2026-07-30",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -16059,6 +17060,7 @@
     "eu.anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2026-10-14",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
         "output_cost_per_token_above_200k_tokens": 2.25e-05,
@@ -16098,6 +17100,7 @@
         "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 1.32e-05,
         "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -16653,8 +17656,8 @@
         "input_cost_per_token": 6e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
         "mode": "chat",
         "output_cost_per_token": 3e-06,
         "source": "https://fireworks.ai/pricing",
@@ -16667,8 +17670,8 @@
         "input_cost_per_token": 9.5e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
         "mode": "chat",
         "output_cost_per_token": 4e-06,
         "source": "https://docs.fireworks.ai/serverless/pricing",
@@ -16683,8 +17686,8 @@
         "input_cost_per_token": 9.5e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
         "mode": "chat",
         "output_cost_per_token": 4e-06,
         "source": "https://docs.fireworks.ai/serverless/pricing",
@@ -17027,8 +18030,8 @@
         "input_cost_per_token": 6e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
         "mode": "chat",
         "output_cost_per_token": 3e-06,
         "source": "https://fireworks.ai/pricing",
@@ -17041,8 +18044,8 @@
         "input_cost_per_token": 9.5e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
         "mode": "chat",
         "output_cost_per_token": 4e-06,
         "source": "https://docs.fireworks.ai/serverless/pricing",
@@ -17057,8 +18060,8 @@
         "input_cost_per_token": 2e-06,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
         "mode": "chat",
         "output_cost_per_token": 8e-06,
         "source": "https://docs.fireworks.ai/serverless/pricing",
@@ -17073,8 +18076,8 @@
         "input_cost_per_token": 9.5e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
         "mode": "chat",
         "output_cost_per_token": 4e-06,
         "source": "https://docs.fireworks.ai/serverless/pricing",
@@ -17089,8 +18092,8 @@
         "input_cost_per_token": 1.9e-06,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
         "mode": "chat",
         "output_cost_per_token": 8e-06,
         "source": "https://docs.fireworks.ai/serverless/pricing",
@@ -17227,6 +18230,7 @@
         "supports_tool_choice": true
     },
     "ft:babbage-002": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 1.6e-06,
         "input_cost_per_token_batches": 2e-07,
         "litellm_provider": "text-completion-openai",
@@ -17238,6 +18242,7 @@
         "output_cost_per_token_batches": 2e-07
     },
     "ft:davinci-002": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 1.2e-05,
         "input_cost_per_token_batches": 1e-06,
         "litellm_provider": "text-completion-openai",
@@ -17249,6 +18254,7 @@
         "output_cost_per_token_batches": 1e-06
     },
     "ft:gpt-3.5-turbo": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_batches": 1.5e-06,
         "litellm_provider": "openai",
@@ -17262,6 +18268,7 @@
         "supports_tool_choice": true
     },
     "ft:gpt-3.5-turbo-0125": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16385,
@@ -17273,6 +18280,7 @@
         "supports_tool_choice": true
     },
     "ft:gpt-3.5-turbo-0613": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 4096,
@@ -17284,6 +18292,7 @@
         "supports_tool_choice": true
     },
     "ft:gpt-3.5-turbo-1106": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16385,
@@ -17295,6 +18304,7 @@
         "supports_tool_choice": true
     },
     "ft:gpt-4-0613": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 3e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 8192,
@@ -17401,6 +18411,7 @@
     },
     "ft:gpt-4.1-nano-2025-04-14": {
         "cache_read_input_token_cost": 5e-08,
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 2e-07,
         "input_cost_per_token_batches": 1e-07,
         "litellm_provider": "openai",
@@ -17419,6 +18430,7 @@
     },
     "ft:o4-mini-2025-04-16": {
         "cache_read_input_token_cost": 1e-06,
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 4e-06,
         "input_cost_per_token_batches": 2e-06,
         "litellm_provider": "openai",
@@ -18653,20 +19665,20 @@
         "web_search_billing_unit": "per_query"
     },
     "vertex_ai/gemini-3.6-flash": {
-        "cache_read_input_token_cost": 1.5e-07,
-        "cache_read_input_token_cost_flex": 7.5e-08,
-        "input_cost_per_token": 1.5e-06,
-        "input_cost_per_token_batches": 7.5e-07,
-        "input_cost_per_token_flex": 7.5e-07,
+        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost_flex": 3.75e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "input_cost_per_token_flex": 3.75e-07,
         "litellm_provider": "vertex_ai",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
-        "output_cost_per_reasoning_token": 7.5e-06,
-        "output_cost_per_token": 7.5e-06,
-        "output_cost_per_token_batches": 3.75e-06,
-        "output_cost_per_token_flex": 3.75e-06,
+        "output_cost_per_reasoning_token": 3.75e-06,
+        "output_cost_per_token": 3.75e-06,
+        "output_cost_per_token_batches": 1.875e-06,
+        "output_cost_per_token_flex": 1.875e-06,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -18696,9 +19708,63 @@
         "supports_vision": true,
         "supports_web_search": true,
         "supports_native_streaming": true,
-        "input_cost_per_token_priority": 2.7e-06,
-        "output_cost_per_token_priority": 1.35e-05,
-        "cache_read_input_token_cost_priority": 2.7e-07,
+        "input_cost_per_token_priority": 1.35e-06,
+        "output_cost_per_token_priority": 6.75e-06,
+        "cache_read_input_token_cost_priority": 1.35e-07,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "web_search_billing_unit": "per_query"
+    },
+    "vertex_ai/gemini-3.7-flash": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost_flex": 3.75e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "input_cost_per_token_flex": 3.75e-07,
+        "litellm_provider": "vertex_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 3.75e-06,
+        "output_cost_per_token": 3.75e-06,
+        "output_cost_per_token_batches": 1.875e-06,
+        "output_cost_per_token_flex": 1.875e-06,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_native_streaming": true,
+        "input_cost_per_token_priority": 1.35e-06,
+        "output_cost_per_token_priority": 6.75e-06,
+        "cache_read_input_token_cost_priority": 1.35e-07,
         "search_context_cost_per_query": {
             "search_context_size_low": 0.014,
             "search_context_size_medium": 0.014,
@@ -18893,6 +19959,7 @@
     },
     "gemini/gemini-robotics-er-1.5-preview": {
         "cache_read_input_token_cost": 0,
+        "deprecation_date": "2026-04-30",
         "input_cost_per_token": 3e-07,
         "input_cost_per_audio_token": 1e-06,
         "litellm_provider": "gemini",
@@ -18934,6 +20001,99 @@
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
         }
+    },
+    "gemini/gemini-robotics-er-2-preview": {
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_audio_token": 2e-06,
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 1e-05,
+        "output_cost_per_token": 1e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-robotics-er-2",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": false,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "web_search_billing_unit": "per_query"
+    },
+    "gemini/gemini-robotics-er-1.6-preview": {
+        "input_cost_per_audio_token": 2e-06,
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 5e-06,
+        "output_cost_per_token": 5e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-robotics-er",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": false,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "web_search_billing_unit": "per_query"
     },
     "gemini-2.5-computer-use-preview-10-2025": {
         "input_cost_per_token": 1.25e-06,
@@ -19042,6 +20202,7 @@
         "uses_embed_content": true
     },
     "gemini/gemini-embedding-001": {
+        "deprecation_date": "2028-05-14",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 2048,
@@ -19054,6 +20215,7 @@
         "tpm": 10000000
     },
     "gemini/gemini-embedding-2-preview": {
+        "deprecation_date": "2026-08-10",
         "input_cost_per_audio_per_second": 0.00016,
         "input_cost_per_image": 0.00012,
         "input_cost_per_token": 2e-07,
@@ -19263,6 +20425,7 @@
     },
     "gemini/gemini-2.5-flash-image": {
         "cache_read_input_token_cost": 3e-08,
+        "deprecation_date": "2026-10-02",
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "gemini",
@@ -19355,6 +20518,7 @@
         "supports_reasoning": false
     },
     "gemini/gemini-3-pro-image-preview": {
+        "deprecation_date": "2026-06-25",
         "input_cost_per_image": 0.0011,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_batches": 1e-06,
@@ -19440,6 +20604,7 @@
         "web_search_billing_unit": "per_query"
     },
     "gemini/gemini-3.1-flash-image-preview": {
+        "deprecation_date": "2026-06-25",
         "input_cost_per_token": 2.5e-07,
         "input_cost_per_token_batches": 1.25e-07,
         "litellm_provider": "gemini",
@@ -19571,6 +20736,7 @@
     },
     "gemini/gemini-2.5-flash-lite-preview-09-2025": {
         "cache_read_input_token_cost": 1e-08,
+        "deprecation_date": "2026-03-31",
         "input_cost_per_audio_token": 3e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "gemini",
@@ -19618,6 +20784,7 @@
     },
     "gemini/gemini-2.5-flash-preview-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
+        "deprecation_date": "2026-02-17",
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "gemini",
@@ -19952,6 +21119,7 @@
     },
     "gemini/gemini-3.1-flash-lite-preview": {
         "cache_read_input_token_cost": 2.5e-08,
+        "deprecation_date": "2026-05-25",
         "input_cost_per_audio_token": 5e-07,
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "gemini",
@@ -20004,6 +21172,7 @@
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_flex": 1.25e-08,
         "cache_read_input_token_cost_priority": 4.5e-08,
+        "deprecation_date": "2027-05-07",
         "input_cost_per_audio_token": 5e-07,
         "input_cost_per_token": 2.5e-07,
         "input_cost_per_token_batches": 1.25e-07,
@@ -20222,20 +21391,20 @@
         "web_search_billing_unit": "per_query"
     },
     "gemini/gemini-3.6-flash": {
-        "cache_read_input_token_cost": 1.5e-07,
-        "cache_read_input_token_cost_flex": 7.5e-08,
-        "input_cost_per_token": 1.5e-06,
-        "input_cost_per_token_batches": 7.5e-07,
-        "input_cost_per_token_flex": 7.5e-07,
+        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost_flex": 3.75e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "input_cost_per_token_flex": 3.75e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
-        "output_cost_per_reasoning_token": 7.5e-06,
-        "output_cost_per_token": 7.5e-06,
-        "output_cost_per_token_batches": 3.75e-06,
-        "output_cost_per_token_flex": 3.75e-06,
+        "output_cost_per_reasoning_token": 3.75e-06,
+        "output_cost_per_token": 3.75e-06,
+        "output_cost_per_token_batches": 1.875e-06,
+        "output_cost_per_token_flex": 1.875e-06,
         "rpm": 2000,
         "source": "https://ai.google.dev/pricing/gemini-3",
         "supported_endpoints": [
@@ -20268,9 +21437,66 @@
         "supports_web_search": true,
         "supports_native_streaming": true,
         "tpm": 800000,
-        "input_cost_per_token_priority": 2.7e-06,
-        "output_cost_per_token_priority": 1.35e-05,
-        "cache_read_input_token_cost_priority": 2.7e-07,
+        "input_cost_per_token_priority": 1.35e-06,
+        "output_cost_per_token_priority": 6.75e-06,
+        "cache_read_input_token_cost_priority": 1.35e-07,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "web_search_billing_unit": "per_query"
+    },
+    "gemini/gemini-3.7-flash": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost_flex": 3.75e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "input_cost_per_token_flex": 3.75e-07,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 3.75e-06,
+        "output_cost_per_token": 3.75e-06,
+        "output_cost_per_token_batches": 1.875e-06,
+        "output_cost_per_token_flex": 1.875e-06,
+        "rpm": 2000,
+        "source": "https://ai.google.dev/pricing/gemini-3",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_output": false,
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_native_streaming": true,
+        "tpm": 800000,
+        "input_cost_per_token_priority": 1.35e-06,
+        "output_cost_per_token_priority": 6.75e-06,
+        "cache_read_input_token_cost_priority": 1.35e-07,
         "search_context_cost_per_query": {
             "search_context_size_low": 0.014,
             "search_context_size_medium": 0.014,
@@ -20559,20 +21785,20 @@
         "web_search_billing_unit": "per_query"
     },
     "gemini-3.6-flash": {
-        "cache_read_input_token_cost": 1.5e-07,
-        "cache_read_input_token_cost_flex": 7.5e-08,
-        "input_cost_per_token": 1.5e-06,
-        "input_cost_per_token_batches": 7.5e-07,
-        "input_cost_per_token_flex": 7.5e-07,
+        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost_flex": 3.75e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "input_cost_per_token_flex": 3.75e-07,
         "litellm_provider": "vertex_ai-language-models",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
-        "output_cost_per_reasoning_token": 7.5e-06,
-        "output_cost_per_token": 7.5e-06,
-        "output_cost_per_token_batches": 3.75e-06,
-        "output_cost_per_token_flex": 3.75e-06,
+        "output_cost_per_reasoning_token": 3.75e-06,
+        "output_cost_per_token": 3.75e-06,
+        "output_cost_per_token_batches": 1.875e-06,
+        "output_cost_per_token_flex": 1.875e-06,
         "source": "https://ai.google.dev/pricing/gemini-3",
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -20603,9 +21829,64 @@
         "supports_vision": true,
         "supports_web_search": true,
         "supports_native_streaming": true,
-        "input_cost_per_token_priority": 2.7e-06,
-        "output_cost_per_token_priority": 1.35e-05,
-        "cache_read_input_token_cost_priority": 2.7e-07,
+        "input_cost_per_token_priority": 1.35e-06,
+        "output_cost_per_token_priority": 6.75e-06,
+        "cache_read_input_token_cost_priority": 1.35e-07,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "web_search_billing_unit": "per_query"
+    },
+    "gemini-3.7-flash": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost_flex": 3.75e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "input_cost_per_token_flex": 3.75e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 3.75e-06,
+        "output_cost_per_token": 3.75e-06,
+        "output_cost_per_token_batches": 1.875e-06,
+        "output_cost_per_token_flex": 1.875e-06,
+        "source": "https://ai.google.dev/pricing/gemini-3",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_output": false,
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_native_streaming": true,
+        "input_cost_per_token_priority": 1.35e-06,
+        "output_cost_per_token_priority": 6.75e-06,
+        "cache_read_input_token_cost_priority": 1.35e-07,
         "search_context_cost_per_query": {
             "search_context_size_low": 0.014,
             "search_context_size_medium": 0.014,
@@ -20771,18 +22052,21 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "gemini/imagen-4.0-fast-generate-001": {
+        "deprecation_date": "2026-08-17",
         "litellm_provider": "gemini",
         "mode": "image_generation",
         "output_cost_per_image": 0.02,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "gemini/imagen-4.0-generate-001": {
+        "deprecation_date": "2026-08-17",
         "litellm_provider": "gemini",
         "mode": "image_generation",
         "output_cost_per_image": 0.04,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "gemini/imagen-4.0-ultra-generate-001": {
+        "deprecation_date": "2026-08-17",
         "litellm_provider": "gemini",
         "mode": "image_generation",
         "output_cost_per_image": 0.06,
@@ -20866,6 +22150,7 @@
         "supports_web_search": false
     },
     "gemini/veo-2.0-generate-001": {
+        "deprecation_date": "2026-06-30",
         "litellm_provider": "gemini",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -21803,6 +23088,7 @@
         "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 1.2e-05,
         "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -21829,6 +23115,7 @@
     "global.anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2026-10-14",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
         "output_cost_per_token_above_200k_tokens": 2.25e-05,
@@ -21863,6 +23150,7 @@
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 1e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -21900,6 +23188,7 @@
         "supports_vision": true
     },
     "gpt-3.5-turbo": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "openai",
         "max_input_tokens": 16385,
@@ -21913,6 +23202,7 @@
         "supports_tool_choice": true
     },
     "gpt-3.5-turbo-0125": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "openai",
         "max_input_tokens": 16385,
@@ -21942,6 +23232,7 @@
         "supports_tool_choice": true
     },
     "gpt-3.5-turbo-16k": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16385,
@@ -21972,6 +23263,7 @@
         "output_cost_per_token": 2e-06
     },
     "gpt-4": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 3e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 8192,
@@ -22012,7 +23304,7 @@
         "supports_tool_choice": true
     },
     "gpt-4-0613": {
-        "deprecation_date": "2025-06-06",
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 3e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 8192,
@@ -22026,7 +23318,7 @@
         "supports_tool_choice": true
     },
     "gpt-4-1106-preview": {
-        "deprecation_date": "2026-03-26",
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -22041,6 +23333,7 @@
         "supports_tool_choice": true
     },
     "gpt-4-turbo": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -22057,6 +23350,7 @@
         "supports_vision": true
     },
     "gpt-4-turbo-2024-04-09": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -22073,6 +23367,7 @@
         "supports_vision": true
     },
     "gpt-4-turbo-preview": {
+        "deprecation_date": "2026-03-26",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -22101,6 +23396,11 @@
         "output_cost_per_token": 8e-06,
         "output_cost_per_token_batches": 4e-06,
         "output_cost_per_token_priority": 1.4e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.025,
+            "search_context_size_low": 0.025,
+            "search_context_size_medium": 0.025
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -22126,7 +23426,9 @@
     },
     "gpt-4.1-2025-04-14": {
         "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_priority": 8.75e-07,
         "input_cost_per_token": 2e-06,
+        "input_cost_per_token_priority": 3.5e-06,
         "input_cost_per_token_batches": 1e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 1047576,
@@ -22134,7 +23436,13 @@
         "max_tokens": 32768,
         "mode": "chat",
         "output_cost_per_token": 8e-06,
+        "output_cost_per_token_priority": 1.4e-05,
         "output_cost_per_token_batches": 4e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.025,
+            "search_context_size_low": 0.025,
+            "search_context_size_medium": 0.025
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -22172,6 +23480,11 @@
         "output_cost_per_token": 1.6e-06,
         "output_cost_per_token_batches": 8e-07,
         "output_cost_per_token_priority": 2.8e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.025,
+            "search_context_size_low": 0.025,
+            "search_context_size_medium": 0.025
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -22197,7 +23510,9 @@
     },
     "gpt-4.1-mini-2025-04-14": {
         "cache_read_input_token_cost": 1e-07,
+        "cache_read_input_token_cost_priority": 1.75e-07,
         "input_cost_per_token": 4e-07,
+        "input_cost_per_token_priority": 7e-07,
         "input_cost_per_token_batches": 2e-07,
         "litellm_provider": "openai",
         "max_input_tokens": 1047576,
@@ -22205,7 +23520,13 @@
         "max_tokens": 32768,
         "mode": "chat",
         "output_cost_per_token": 1.6e-06,
+        "output_cost_per_token_priority": 2.8e-06,
         "output_cost_per_token_batches": 8e-07,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.025,
+            "search_context_size_low": 0.025,
+            "search_context_size_medium": 0.025
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -22232,6 +23553,7 @@
     "gpt-4.1-nano": {
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_priority": 5e-08,
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 1e-07,
         "input_cost_per_token_batches": 5e-08,
         "input_cost_per_token_priority": 2e-07,
@@ -22267,7 +23589,10 @@
     },
     "gpt-4.1-nano-2025-04-14": {
         "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost_priority": 5e-08,
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 1e-07,
+        "input_cost_per_token_priority": 2e-07,
         "input_cost_per_token_batches": 5e-08,
         "litellm_provider": "openai",
         "max_input_tokens": 1047576,
@@ -22275,6 +23600,7 @@
         "max_tokens": 32768,
         "mode": "chat",
         "output_cost_per_token": 4e-07,
+        "output_cost_per_token_priority": 8e-07,
         "output_cost_per_token_batches": 2e-07,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -22322,6 +23648,7 @@
         "supports_vision": true
     },
     "gpt-4o-2024-05-13": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 5e-06,
         "input_cost_per_token_batches": 2.5e-06,
         "input_cost_per_token_priority": 8.75e-06,
@@ -22343,7 +23670,9 @@
     },
     "gpt-4o-2024-08-06": {
         "cache_read_input_token_cost": 1.25e-06,
+        "cache_read_input_token_cost_priority": 2.125e-06,
         "input_cost_per_token": 2.5e-06,
+        "input_cost_per_token_priority": 4.25e-06,
         "input_cost_per_token_batches": 1.25e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -22351,6 +23680,7 @@
         "max_tokens": 16384,
         "mode": "chat",
         "output_cost_per_token": 1e-05,
+        "output_cost_per_token_priority": 1.7e-05,
         "output_cost_per_token_batches": 5e-06,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -22363,7 +23693,9 @@
     },
     "gpt-4o-2024-11-20": {
         "cache_read_input_token_cost": 1.25e-06,
+        "cache_read_input_token_cost_priority": 2.125e-06,
         "input_cost_per_token": 2.5e-06,
+        "input_cost_per_token_priority": 4.25e-06,
         "input_cost_per_token_batches": 1.25e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -22371,6 +23703,7 @@
         "max_tokens": 16384,
         "mode": "chat",
         "output_cost_per_token": 1e-05,
+        "output_cost_per_token_priority": 1.7e-05,
         "output_cost_per_token_batches": 5e-06,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -22382,6 +23715,7 @@
         "supports_vision": true
     },
     "gpt-4o-audio-preview": {
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
@@ -22399,6 +23733,7 @@
         "supports_tool_choice": true
     },
     "gpt-4o-audio-preview-2024-12-17": {
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
@@ -22416,6 +23751,7 @@
         "supports_tool_choice": true
     },
     "gpt-4o-audio-preview-2025-06-03": {
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
@@ -22433,6 +23769,7 @@
         "supports_tool_choice": true
     },
     "gpt-audio": {
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
@@ -22502,6 +23839,7 @@
         "supports_vision": false
     },
     "gpt-audio-2025-08-28": {
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
@@ -22538,6 +23876,7 @@
         "supports_vision": false
     },
     "gpt-audio-mini": {
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "openai",
@@ -22574,6 +23913,7 @@
         "supports_vision": false
     },
     "gpt-audio-mini-2025-10-06": {
+        "deprecation_date": "2026-07-23",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "openai",
@@ -22670,7 +24010,9 @@
     },
     "gpt-4o-mini-2024-07-18": {
         "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost_priority": 1.25e-07,
         "input_cost_per_token": 1.5e-07,
+        "input_cost_per_token_priority": 2.5e-07,
         "input_cost_per_token_batches": 7.5e-08,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -22678,6 +24020,7 @@
         "max_tokens": 16384,
         "mode": "chat",
         "output_cost_per_token": 6e-07,
+        "output_cost_per_token_priority": 1e-06,
         "output_cost_per_token_batches": 3e-07,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.03,
@@ -22694,6 +24037,7 @@
         "supports_vision": true
     },
     "gpt-4o-mini-audio-preview": {
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "openai",
@@ -22711,6 +24055,7 @@
         "supports_tool_choice": true
     },
     "gpt-4o-mini-audio-preview-2024-12-17": {
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "openai",
@@ -22730,6 +24075,7 @@
     "gpt-4o-mini-realtime-preview": {
         "cache_creation_input_audio_token_cost": 3e-07,
         "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "openai",
@@ -22749,6 +24095,7 @@
     "gpt-4o-mini-realtime-preview-2024-12-17": {
         "cache_creation_input_audio_token_cost": 3e-07,
         "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "openai",
@@ -22793,6 +24140,7 @@
     },
     "gpt-4o-mini-search-preview-2025-03-11": {
         "cache_read_input_token_cost": 7.5e-08,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.5e-07,
         "input_cost_per_token_batches": 7.5e-08,
         "litellm_provider": "openai",
@@ -22802,6 +24150,11 @@
         "mode": "chat",
         "output_cost_per_token": 6e-07,
         "output_cost_per_token_batches": 3e-07,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.03,
+            "search_context_size_low": 0.025,
+            "search_context_size_medium": 0.0275
+        },
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
@@ -22843,6 +24196,7 @@
     },
     "gpt-4o-realtime-preview": {
         "cache_read_input_token_cost": 2.5e-06,
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
@@ -22861,6 +24215,7 @@
     },
     "gpt-4o-realtime-preview-2024-12-17": {
         "cache_read_input_token_cost": 2.5e-06,
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
@@ -22879,6 +24234,7 @@
     },
     "gpt-4o-realtime-preview-2025-06-03": {
         "cache_read_input_token_cost": 2.5e-06,
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
@@ -22923,6 +24279,7 @@
     },
     "gpt-4o-search-preview-2025-03-11": {
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 2.5e-06,
         "input_cost_per_token_batches": 1.25e-06,
         "litellm_provider": "openai",
@@ -22932,6 +24289,11 @@
         "mode": "chat",
         "output_cost_per_token": 1e-05,
         "output_cost_per_token_batches": 5e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.05,
+            "search_context_size_low": 0.03,
+            "search_context_size_medium": 0.035
+        },
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
@@ -22955,6 +24317,7 @@
     },
     "gpt-image-1.5": {
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2026-12-01",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
         "mode": "image_generation",
@@ -22969,6 +24332,7 @@
     },
     "gpt-image-1.5-2025-12-16": {
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2026-12-01",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
         "mode": "image_generation",
@@ -23356,6 +24720,11 @@
         "output_cost_per_token": 1e-05,
         "output_cost_per_token_flex": 5e-06,
         "output_cost_per_token_priority": 2e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -23395,6 +24764,11 @@
         "mode": "chat",
         "output_cost_per_token": 1e-05,
         "output_cost_per_token_priority": 2e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/responses"
@@ -23434,6 +24808,11 @@
         "mode": "chat",
         "output_cost_per_token": 1e-05,
         "output_cost_per_token_priority": 2e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/responses"
@@ -23464,6 +24843,7 @@
     "gpt-5.1-chat-latest": {
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_priority": 2.5e-06,
         "litellm_provider": "openai",
@@ -23473,6 +24853,11 @@
         "mode": "chat",
         "output_cost_per_token": 1e-05,
         "output_cost_per_token_priority": 2e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/responses"
@@ -23512,6 +24897,11 @@
         "mode": "chat",
         "output_cost_per_token": 1.4e-05,
         "output_cost_per_token_priority": 2.8e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -23552,6 +24942,11 @@
         "mode": "chat",
         "output_cost_per_token": 1.4e-05,
         "output_cost_per_token_priority": 2.8e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -23583,6 +24978,7 @@
     "gpt-5.2-chat-latest": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
+        "deprecation_date": "2026-08-10",
         "input_cost_per_token": 1.75e-06,
         "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "openai",
@@ -23592,6 +24988,11 @@
         "mode": "chat",
         "output_cost_per_token": 1.4e-05,
         "output_cost_per_token_priority": 2.8e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/responses"
@@ -23621,6 +25022,7 @@
     "gpt-5.3-chat-latest": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
+        "deprecation_date": "2026-08-10",
         "input_cost_per_token": 1.75e-06,
         "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "openai",
@@ -23630,6 +25032,11 @@
         "mode": "chat",
         "output_cost_per_token": 1.4e-05,
         "output_cost_per_token_priority": 2.8e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/responses"
@@ -23664,6 +25071,11 @@
         "max_tokens": 128000,
         "mode": "responses",
         "output_cost_per_token": 0.000168,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/batch",
             "/v1/responses"
@@ -23698,6 +25110,11 @@
         "max_tokens": 128000,
         "mode": "responses",
         "output_cost_per_token": 0.000168,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/batch",
             "/v1/responses"
@@ -23727,14 +25144,17 @@
     "gpt-5.6": {
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_272k_tokens": 1.25e-05,
+        "cache_creation_input_token_cost_above_272k_tokens_flex": 6.25e-06,
         "cache_creation_input_token_cost_flex": 3.125e-06,
         "cache_creation_input_token_cost_priority": 1.25e-05,
         "cache_read_input_token_cost": 5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+        "cache_read_input_token_cost_above_272k_tokens_flex": 5e-07,
         "cache_read_input_token_cost_flex": 2.5e-07,
         "cache_read_input_token_cost_priority": 1e-06,
         "input_cost_per_token": 5e-06,
         "input_cost_per_token_above_272k_tokens": 1e-05,
+        "input_cost_per_token_above_272k_tokens_flex": 5e-06,
         "input_cost_per_token_batches": 2.5e-06,
         "input_cost_per_token_flex": 2.5e-06,
         "input_cost_per_token_priority": 1e-05,
@@ -23745,11 +25165,17 @@
         "mode": "chat",
         "output_cost_per_token": 3e-05,
         "output_cost_per_token_above_272k_tokens": 4.5e-05,
+        "output_cost_per_token_above_272k_tokens_flex": 2.25e-05,
         "output_cost_per_token_batches": 1.5e-05,
         "output_cost_per_token_flex": 1.5e-05,
         "output_cost_per_token_priority": 6e-05,
         "regional_processing_uplift_multiplier_eu": 1.1,
         "regional_processing_uplift_multiplier_us": 1.1,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -23780,14 +25206,17 @@
     "gpt-5.6-sol": {
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_272k_tokens": 1.25e-05,
+        "cache_creation_input_token_cost_above_272k_tokens_flex": 6.25e-06,
         "cache_creation_input_token_cost_flex": 3.125e-06,
         "cache_creation_input_token_cost_priority": 1.25e-05,
         "cache_read_input_token_cost": 5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+        "cache_read_input_token_cost_above_272k_tokens_flex": 5e-07,
         "cache_read_input_token_cost_flex": 2.5e-07,
         "cache_read_input_token_cost_priority": 1e-06,
         "input_cost_per_token": 5e-06,
         "input_cost_per_token_above_272k_tokens": 1e-05,
+        "input_cost_per_token_above_272k_tokens_flex": 5e-06,
         "input_cost_per_token_batches": 2.5e-06,
         "input_cost_per_token_flex": 2.5e-06,
         "input_cost_per_token_priority": 1e-05,
@@ -23798,11 +25227,17 @@
         "mode": "chat",
         "output_cost_per_token": 3e-05,
         "output_cost_per_token_above_272k_tokens": 4.5e-05,
+        "output_cost_per_token_above_272k_tokens_flex": 2.25e-05,
         "output_cost_per_token_batches": 1.5e-05,
         "output_cost_per_token_flex": 1.5e-05,
         "output_cost_per_token_priority": 6e-05,
         "regional_processing_uplift_multiplier_eu": 1.1,
         "regional_processing_uplift_multiplier_us": 1.1,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -23831,31 +25266,40 @@
         "supports_xhigh_reasoning_effort": true
     },
     "gpt-5.6-terra": {
-        "cache_creation_input_token_cost": 3.125e-06,
-        "cache_creation_input_token_cost_above_272k_tokens": 6.25e-06,
-        "cache_creation_input_token_cost_flex": 1.5625e-06,
-        "cache_creation_input_token_cost_priority": 6.25e-06,
-        "cache_read_input_token_cost": 2.5e-07,
-        "cache_read_input_token_cost_above_272k_tokens": 5e-07,
-        "cache_read_input_token_cost_flex": 1.25e-07,
-        "cache_read_input_token_cost_priority": 5e-07,
-        "input_cost_per_token": 2.5e-06,
-        "input_cost_per_token_above_272k_tokens": 5e-06,
-        "input_cost_per_token_batches": 1.25e-06,
-        "input_cost_per_token_flex": 1.25e-06,
-        "input_cost_per_token_priority": 5e-06,
+        "cache_creation_input_token_cost": 2.5e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 5e-06,
+        "cache_creation_input_token_cost_above_272k_tokens_flex": 2.5e-06,
+        "cache_creation_input_token_cost_flex": 1.25e-06,
+        "cache_creation_input_token_cost_priority": 5e-06,
+        "cache_read_input_token_cost": 2e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 4e-07,
+        "cache_read_input_token_cost_above_272k_tokens_flex": 2e-07,
+        "cache_read_input_token_cost_flex": 1e-07,
+        "cache_read_input_token_cost_priority": 4e-07,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_above_272k_tokens": 4e-06,
+        "input_cost_per_token_above_272k_tokens_flex": 2e-06,
+        "input_cost_per_token_batches": 1e-06,
+        "input_cost_per_token_flex": 1e-06,
+        "input_cost_per_token_priority": 4e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "output_cost_per_token_above_272k_tokens": 2.25e-05,
-        "output_cost_per_token_batches": 7.5e-06,
-        "output_cost_per_token_flex": 7.5e-06,
-        "output_cost_per_token_priority": 3e-05,
+        "output_cost_per_token": 1.2e-05,
+        "output_cost_per_token_above_272k_tokens": 1.8e-05,
+        "output_cost_per_token_above_272k_tokens_flex": 9e-06,
+        "output_cost_per_token_batches": 6e-06,
+        "output_cost_per_token_flex": 6e-06,
+        "output_cost_per_token_priority": 2.4e-05,
         "regional_processing_uplift_multiplier_eu": 1.1,
         "regional_processing_uplift_multiplier_us": 1.1,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -23884,31 +25328,40 @@
         "supports_xhigh_reasoning_effort": true
     },
     "gpt-5.6-luna": {
-        "cache_creation_input_token_cost": 1.25e-06,
-        "cache_creation_input_token_cost_above_272k_tokens": 2.5e-06,
-        "cache_creation_input_token_cost_flex": 6.25e-07,
-        "cache_creation_input_token_cost_priority": 2.5e-06,
-        "cache_read_input_token_cost": 1e-07,
-        "cache_read_input_token_cost_above_272k_tokens": 2e-07,
-        "cache_read_input_token_cost_flex": 5e-08,
-        "cache_read_input_token_cost_priority": 2e-07,
-        "input_cost_per_token": 1e-06,
-        "input_cost_per_token_above_272k_tokens": 2e-06,
-        "input_cost_per_token_batches": 5e-07,
-        "input_cost_per_token_flex": 5e-07,
-        "input_cost_per_token_priority": 2e-06,
+        "cache_creation_input_token_cost": 2.5e-07,
+        "cache_creation_input_token_cost_above_272k_tokens": 5e-07,
+        "cache_creation_input_token_cost_above_272k_tokens_flex": 2.5e-07,
+        "cache_creation_input_token_cost_flex": 1.25e-07,
+        "cache_creation_input_token_cost_priority": 5e-07,
+        "cache_read_input_token_cost": 2e-08,
+        "cache_read_input_token_cost_above_272k_tokens": 4e-08,
+        "cache_read_input_token_cost_above_272k_tokens_flex": 2e-08,
+        "cache_read_input_token_cost_flex": 1e-08,
+        "cache_read_input_token_cost_priority": 4e-08,
+        "input_cost_per_token": 2e-07,
+        "input_cost_per_token_above_272k_tokens": 4e-07,
+        "input_cost_per_token_above_272k_tokens_flex": 2e-07,
+        "input_cost_per_token_batches": 1e-07,
+        "input_cost_per_token_flex": 1e-07,
+        "input_cost_per_token_priority": 4e-07,
         "litellm_provider": "openai",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
-        "output_cost_per_token": 6e-06,
-        "output_cost_per_token_above_272k_tokens": 9e-06,
-        "output_cost_per_token_batches": 3e-06,
-        "output_cost_per_token_flex": 3e-06,
-        "output_cost_per_token_priority": 1.2e-05,
+        "output_cost_per_token": 1.2e-06,
+        "output_cost_per_token_above_272k_tokens": 1.8e-06,
+        "output_cost_per_token_above_272k_tokens_flex": 9e-07,
+        "output_cost_per_token_batches": 6e-07,
+        "output_cost_per_token_flex": 6e-07,
+        "output_cost_per_token_priority": 2.4e-06,
         "regional_processing_uplift_multiplier_eu": 1.1,
         "regional_processing_uplift_multiplier_us": 1.1,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -23958,6 +25411,11 @@
         "output_cost_per_token_priority": 6e-05,
         "regional_processing_uplift_multiplier_eu": 1.1,
         "regional_processing_uplift_multiplier_us": 1.1,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -24007,6 +25465,11 @@
         "output_cost_per_token_priority": 6e-05,
         "regional_processing_uplift_multiplier_eu": 1.1,
         "regional_processing_uplift_multiplier_us": 1.1,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -24052,6 +25515,11 @@
         "output_cost_per_token_batches": 9e-05,
         "regional_processing_uplift_multiplier_eu": 1.1,
         "regional_processing_uplift_multiplier_us": 1.1,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/responses",
             "/v1/batch"
@@ -24097,6 +25565,11 @@
         "output_cost_per_token_batches": 9e-05,
         "regional_processing_uplift_multiplier_eu": 1.1,
         "regional_processing_uplift_multiplier_us": 1.1,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/responses",
             "/v1/batch"
@@ -24215,7 +25688,10 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true
     },
     "gpt-5.4-pro": {
         "cache_read_input_token_cost": 3e-06,
@@ -24235,6 +25711,11 @@
         "output_cost_per_token_batches": 9e-05,
         "regional_processing_uplift_multiplier_eu": 1.1,
         "regional_processing_uplift_multiplier_us": 1.1,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/responses",
             "/v1/batch"
@@ -24279,6 +25760,11 @@
         "output_cost_per_token_batches": 9e-05,
         "regional_processing_uplift_multiplier_eu": 1.1,
         "regional_processing_uplift_multiplier_us": 1.1,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/responses",
             "/v1/batch"
@@ -24314,7 +25800,7 @@
         "input_cost_per_token_batches": 3.75e-07,
         "input_cost_per_token_priority": 1.5e-06,
         "litellm_provider": "openai",
-        "max_input_tokens": 1050000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -24324,6 +25810,11 @@
         "output_cost_per_token_priority": 9e-06,
         "regional_processing_uplift_multiplier_eu": 1.1,
         "regional_processing_uplift_multiplier_us": 1.1,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -24360,7 +25851,7 @@
         "input_cost_per_token_batches": 3.75e-07,
         "input_cost_per_token_priority": 1.5e-06,
         "litellm_provider": "openai",
-        "max_input_tokens": 1050000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -24370,6 +25861,11 @@
         "output_cost_per_token_priority": 9e-06,
         "regional_processing_uplift_multiplier_eu": 1.1,
         "regional_processing_uplift_multiplier_us": 1.1,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -24404,7 +25900,7 @@
         "input_cost_per_token_flex": 1e-07,
         "input_cost_per_token_batches": 1e-07,
         "litellm_provider": "openai",
-        "max_input_tokens": 1050000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -24413,6 +25909,11 @@
         "output_cost_per_token_batches": 6.25e-07,
         "regional_processing_uplift_multiplier_eu": 1.1,
         "regional_processing_uplift_multiplier_us": 1.1,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -24447,7 +25948,7 @@
         "input_cost_per_token_flex": 1e-07,
         "input_cost_per_token_batches": 1e-07,
         "litellm_provider": "openai",
-        "max_input_tokens": 1050000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -24456,6 +25957,11 @@
         "output_cost_per_token_batches": 6.25e-07,
         "regional_processing_uplift_multiplier_eu": 1.1,
         "regional_processing_uplift_multiplier_us": 1.1,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -24488,11 +25994,16 @@
         "input_cost_per_token_batches": 7.5e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 400000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
+        "max_output_tokens": 272000,
+        "max_tokens": 272000,
         "mode": "responses",
         "output_cost_per_token": 0.00012,
         "output_cost_per_token_batches": 6e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/batch",
             "/v1/responses"
@@ -24520,15 +26031,21 @@
         "supports_minimal_reasoning_effort": true
     },
     "gpt-5-pro-2025-10-06": {
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 1.5e-05,
         "input_cost_per_token_batches": 7.5e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 400000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
+        "max_output_tokens": 272000,
+        "max_tokens": 272000,
         "mode": "responses",
         "output_cost_per_token": 0.00012,
         "output_cost_per_token_batches": 6e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/batch",
             "/v1/responses"
@@ -24559,6 +26076,7 @@
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_flex": 6.25e-08,
         "cache_read_input_token_cost_priority": 2.5e-07,
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_flex": 6.25e-07,
         "input_cost_per_token_priority": 2.5e-06,
@@ -24570,6 +26088,11 @@
         "output_cost_per_token": 1e-05,
         "output_cost_per_token_flex": 5e-06,
         "output_cost_per_token_priority": 2e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -24634,6 +26157,7 @@
     },
     "gpt-5-chat-latest": {
         "cache_read_input_token_cost": 1.25e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -24669,6 +26193,7 @@
     },
     "gpt-5-codex": {
         "cache_read_input_token_cost": 1.25e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 272000,
@@ -24676,6 +26201,11 @@
         "max_tokens": 128000,
         "mode": "responses",
         "output_cost_per_token": 1e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/responses"
         ],
@@ -24704,6 +26234,7 @@
     "gpt-5.1-codex": {
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_priority": 2.5e-06,
         "litellm_provider": "openai",
@@ -24713,6 +26244,11 @@
         "mode": "responses",
         "output_cost_per_token": 1e-05,
         "output_cost_per_token_priority": 2e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/responses"
         ],
@@ -24740,6 +26276,7 @@
     },
     "gpt-5.1-codex-max": {
         "cache_read_input_token_cost": 1.25e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 272000,
@@ -24747,6 +26284,11 @@
         "max_tokens": 128000,
         "mode": "responses",
         "output_cost_per_token": 1e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/responses"
         ],
@@ -24775,6 +26317,7 @@
     "gpt-5.1-codex-mini": {
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_priority": 4.5e-08,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 2.5e-07,
         "input_cost_per_token_priority": 4.5e-07,
         "litellm_provider": "openai",
@@ -24784,6 +26327,11 @@
         "mode": "responses",
         "output_cost_per_token": 2e-06,
         "output_cost_per_token_priority": 3.6e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/responses"
         ],
@@ -24812,6 +26360,7 @@
     "gpt-5.2-codex": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1.75e-06,
         "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "openai",
@@ -24821,6 +26370,11 @@
         "mode": "responses",
         "output_cost_per_token": 1.4e-05,
         "output_cost_per_token_priority": 2.8e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/responses"
         ],
@@ -24858,6 +26412,11 @@
         "mode": "responses",
         "output_cost_per_token": 1.4e-05,
         "output_cost_per_token_priority": 2.8e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/responses"
         ],
@@ -24898,6 +26457,11 @@
         "output_cost_per_token": 2e-06,
         "output_cost_per_token_flex": 1e-06,
         "output_cost_per_token_priority": 3.6e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -24929,6 +26493,7 @@
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_flex": 1.25e-08,
         "cache_read_input_token_cost_priority": 4.5e-08,
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 2.5e-07,
         "input_cost_per_token_flex": 1.25e-07,
         "input_cost_per_token_priority": 4.5e-07,
@@ -24940,6 +26505,11 @@
         "output_cost_per_token": 2e-06,
         "output_cost_per_token_flex": 1e-06,
         "output_cost_per_token_priority": 3.6e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -24980,6 +26550,11 @@
         "mode": "chat",
         "output_cost_per_token": 4e-07,
         "output_cost_per_token_flex": 2e-07,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -25010,7 +26585,9 @@
     "gpt-5-nano-2025-08-07": {
         "cache_read_input_token_cost": 5e-09,
         "cache_read_input_token_cost_flex": 2.5e-09,
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 5e-08,
+        "input_cost_per_token_priority": 2.5e-06,
         "input_cost_per_token_flex": 2.5e-08,
         "litellm_provider": "openai",
         "max_input_tokens": 272000,
@@ -25019,6 +26596,11 @@
         "mode": "chat",
         "output_cost_per_token": 4e-07,
         "output_cost_per_token_flex": 2e-07,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -25048,6 +26630,7 @@
     },
     "gpt-image-1": {
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2026-10-23",
         "input_cost_per_image_token": 1e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
@@ -25060,6 +26643,7 @@
     },
     "gpt-image-1-mini": {
         "cache_read_input_token_cost": 2e-07,
+        "deprecation_date": "2026-12-01",
         "input_cost_per_image_token": 2.5e-06,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "openai",
@@ -25073,6 +26657,7 @@
     "gpt-realtime": {
         "cache_creation_input_audio_token_cost": 4e-07,
         "cache_read_input_token_cost": 4e-07,
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_image": 5e-06,
         "input_cost_per_token": 4e-06,
@@ -25239,6 +26824,7 @@
     "gpt-realtime-mini": {
         "cache_creation_input_audio_token_cost": 3e-07,
         "cache_read_input_audio_token_cost": 3e-07,
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "openai",
@@ -25270,6 +26856,7 @@
     "gpt-realtime-2025-08-28": {
         "cache_creation_input_audio_token_cost": 4e-07,
         "cache_read_input_token_cost": 4e-07,
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_image": 5e-06,
         "input_cost_per_token": 4e-06,
@@ -25616,11 +27203,12 @@
         "supports_vision": true
     },
     "groq/llama-3.1-8b-instant": {
+        "deprecation_date": "2026-08-16",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "groq",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 8e-08,
         "supports_function_calling": true,
@@ -25628,9 +27216,10 @@
         "supports_tool_choice": true
     },
     "groq/llama-3.3-70b-versatile": {
+        "deprecation_date": "2026-08-16",
         "input_cost_per_token": 5.9e-07,
         "litellm_provider": "groq",
-        "max_input_tokens": 128000,
+        "max_input_tokens": 131072,
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
@@ -25651,7 +27240,28 @@
         "supports_response_schema": false,
         "supports_tool_choice": true
     },
+    "groq/meta-llama/llama-prompt-guard-2-22m": {
+        "input_cost_per_token": 3e-08,
+        "litellm_provider": "groq",
+        "max_input_tokens": 512,
+        "max_output_tokens": 512,
+        "max_tokens": 512,
+        "mode": "chat",
+        "output_cost_per_token": 3e-08,
+        "source": "https://console.groq.com/docs/models"
+    },
+    "groq/meta-llama/llama-prompt-guard-2-86m": {
+        "input_cost_per_token": 4e-08,
+        "litellm_provider": "groq",
+        "max_input_tokens": 512,
+        "max_output_tokens": 512,
+        "max_tokens": 512,
+        "mode": "chat",
+        "output_cost_per_token": 4e-08,
+        "source": "https://console.groq.com/docs/model/meta-llama/llama-prompt-guard-2-86m"
+    },
     "groq/meta-llama/llama-guard-4-12b": {
+        "deprecation_date": "2026-03-05",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 8192,
@@ -25661,6 +27271,7 @@
         "output_cost_per_token": 2e-07
     },
     "groq/meta-llama/llama-4-maverick-17b-128e-instruct": {
+        "deprecation_date": "2026-03-09",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 131072,
@@ -25674,6 +27285,7 @@
         "supports_vision": true
     },
     "groq/meta-llama/llama-4-scout-17b-16e-instruct": {
+        "deprecation_date": "2026-07-17",
         "input_cost_per_token": 1.1e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 131072,
@@ -25687,6 +27299,7 @@
         "supports_vision": true
     },
     "groq/moonshotai/kimi-k2-instruct-0905": {
+        "deprecation_date": "2026-04-15",
         "input_cost_per_token": 1e-06,
         "output_cost_per_token": 3e-06,
         "cache_read_input_token_cost": 5e-07,
@@ -25704,10 +27317,15 @@
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 131072,
-        "max_output_tokens": 32766,
-        "max_tokens": 32766,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
         "mode": "chat",
         "output_cost_per_token": 6e-07,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.005,
+            "search_context_size_low": 0.005,
+            "search_context_size_medium": 0.005
+        },
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_reasoning": true,
@@ -25720,10 +27338,15 @@
         "input_cost_per_token": 7.5e-08,
         "litellm_provider": "groq",
         "max_input_tokens": 131072,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
         "mode": "chat",
         "output_cost_per_token": 3e-07,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.005,
+            "search_context_size_low": 0.005,
+            "search_context_size_medium": 0.005
+        },
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_reasoning": true,
@@ -25740,13 +27363,37 @@
         "max_tokens": 65536,
         "mode": "chat",
         "output_cost_per_token": 3e-07,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.005,
+            "search_context_size_low": 0.005,
+            "search_context_size_medium": 0.005
+        },
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },
+    "groq/canopylabs/orpheus-v1-english": {
+        "input_cost_per_character": 2.2e-05,
+        "litellm_provider": "groq",
+        "max_input_tokens": 4000,
+        "max_output_tokens": 50000,
+        "max_tokens": 50000,
+        "mode": "audio_speech",
+        "source": "https://console.groq.com/docs/model/canopylabs/orpheus-v1-english"
+    },
+    "groq/canopylabs/orpheus-arabic-saudi": {
+        "input_cost_per_character": 4e-05,
+        "litellm_provider": "groq",
+        "max_input_tokens": 4000,
+        "max_output_tokens": 50000,
+        "max_tokens": 50000,
+        "mode": "audio_speech",
+        "source": "https://console.groq.com/docs/models"
+    },
     "groq/playai-tts": {
+        "deprecation_date": "2025-12-31",
         "input_cost_per_character": 5e-05,
         "litellm_provider": "groq",
         "max_input_tokens": 10000,
@@ -25754,7 +27401,23 @@
         "max_tokens": 10000,
         "mode": "audio_speech"
     },
+    "groq/qwen/qwen3.6-27b": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "source": "https://console.groq.com/docs/model/qwen/qwen3.6-27b",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "groq/qwen/qwen3-32b": {
+        "deprecation_date": "2026-07-17",
         "input_cost_per_token": 2.9e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 131000,
@@ -26212,6 +27875,7 @@
         "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 1.32e-05,
         "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -26241,6 +27905,7 @@
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -26963,6 +28628,93 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 4.25e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.0025,
+            "search_context_size_low": 0.0025,
+            "search_context_size_medium": 0.0025
+        },
+        "source": "https://dev.meta.ai/docs/getting-started/pricing-rate-limits",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_minimal_reasoning_effort": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "meta/muse-spark-1.2": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 1.25e-06,
+        "litellm_provider": "meta",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.25e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.0025,
+            "search_context_size_low": 0.0025,
+            "search_context_size_medium": 0.0025
+        },
+        "source": "https://dev.meta.ai/docs/getting-started/pricing-rate-limits",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_minimal_reasoning_effort": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "meta/muse-spark-1.2-contributor": {
+        "cache_read_input_token_cost": 2e-09,
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "meta",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 2e-07,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.0025,
+            "search_context_size_low": 0.0025,
+            "search_context_size_medium": 0.0025
+        },
         "source": "https://dev.meta.ai/docs/getting-started/pricing-rate-limits",
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -27367,6 +29119,7 @@
         "supports_native_structured_output": true
     },
     "mistral/codestral-2405": {
+        "deprecation_date": "2025-06-16",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 32000,
@@ -27417,6 +29170,7 @@
         "supports_tool_choice": true
     },
     "mistral/devstral-medium-2507": {
+        "deprecation_date": "2026-05-31",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -27431,6 +29185,7 @@
         "supports_tool_choice": true
     },
     "mistral/devstral-small-2505": {
+        "deprecation_date": "2025-11-30",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -27445,6 +29200,7 @@
         "supports_tool_choice": true
     },
     "mistral/devstral-small-2507": {
+        "deprecation_date": "2026-05-31",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -27473,6 +29229,7 @@
         "supports_tool_choice": true
     },
     "mistral/labs-devstral-small-2512": {
+        "deprecation_date": "2026-03-31",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 256000,
@@ -27515,6 +29272,7 @@
         "supports_tool_choice": true
     },
     "mistral/devstral-2512": {
+        "deprecation_date": "2026-07-31",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 256000,
@@ -27529,6 +29287,7 @@
         "supports_tool_choice": true
     },
     "mistral/magistral-medium-2506": {
+        "deprecation_date": "2025-11-30",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 40000,
@@ -27544,6 +29303,7 @@
         "supports_tool_choice": true
     },
     "mistral/magistral-medium-2509": {
+        "deprecation_date": "2026-07-31",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 40000,
@@ -27559,6 +29319,7 @@
         "supports_tool_choice": true
     },
     "mistral/magistral-medium-1-2-2509": {
+        "deprecation_date": "2026-07-31",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 40000,
@@ -27594,6 +29355,7 @@
         "source": "https://mistral.ai/pricing#api-pricing"
     },
     "mistral/mistral-ocr-2505-completion": {
+        "deprecation_date": "2026-05-31",
         "litellm_provider": "mistral",
         "ocr_cost_per_page": 0.001,
         "annotation_cost_per_page": 0.003,
@@ -27629,6 +29391,7 @@
         "supports_tool_choice": true
     },
     "mistral/magistral-small-2506": {
+        "deprecation_date": "2025-11-30",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 40000,
@@ -27659,6 +29422,7 @@
         "supports_tool_choice": true
     },
     "mistral/magistral-small-1-2-2509": {
+        "deprecation_date": "2026-07-31",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 40000,
@@ -27695,6 +29459,7 @@
         "mode": "embedding"
     },
     "mistral/mistral-large-2402": {
+        "deprecation_date": "2025-06-16",
         "input_cost_per_token": 4e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 32000,
@@ -27708,6 +29473,7 @@
         "supports_tool_choice": true
     },
     "mistral/mistral-large-2407": {
+        "deprecation_date": "2025-03-30",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -27721,6 +29487,7 @@
         "supports_tool_choice": true
     },
     "mistral/mistral-large-2411": {
+        "deprecation_date": "2026-05-31",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -27791,6 +29558,7 @@
         "supports_tool_choice": true
     },
     "mistral/mistral-medium-2312": {
+        "deprecation_date": "2025-06-16",
         "input_cost_per_token": 2.7e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 32000,
@@ -27803,6 +29571,7 @@
         "supports_tool_choice": true
     },
     "mistral/mistral-medium-2505": {
+        "deprecation_date": "2026-08-31",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 131072,
@@ -27816,6 +29585,7 @@
         "supports_tool_choice": true
     },
     "mistral/mistral-medium-2508": {
+        "deprecation_date": "2026-08-31",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 131072,
@@ -27863,6 +29633,7 @@
         "supports_vision": true
     },
     "mistral/mistral-medium-3-1-2508": {
+        "deprecation_date": "2026-08-31",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 131072,
@@ -27922,6 +29693,7 @@
         "supports_vision": true
     },
     "mistral/mistral-small-3-2-2506": {
+        "deprecation_date": "2026-07-31",
         "input_cost_per_token": 6e-08,
         "litellm_provider": "mistral",
         "max_input_tokens": 131072,
@@ -28024,6 +29796,7 @@
         "supports_tool_choice": true
     },
     "mistral/open-codestral-mamba": {
+        "deprecation_date": "2025-06-06",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 256000,
@@ -28036,6 +29809,7 @@
         "supports_tool_choice": true
     },
     "mistral/open-mistral-7b": {
+        "deprecation_date": "2025-03-30",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 32000,
@@ -28061,6 +29835,7 @@
         "supports_tool_choice": true
     },
     "mistral/open-mistral-nemo-2407": {
+        "deprecation_date": "2026-07-31",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -28074,6 +29849,7 @@
         "supports_tool_choice": true
     },
     "mistral/open-mixtral-8x22b": {
+        "deprecation_date": "2025-03-30",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 65336,
@@ -28087,6 +29863,7 @@
         "supports_tool_choice": true
     },
     "mistral/open-mixtral-8x7b": {
+        "deprecation_date": "2025-03-30",
         "input_cost_per_token": 7e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 32000,
@@ -28100,6 +29877,7 @@
         "supports_tool_choice": true
     },
     "mistral/pixtral-12b-2409": {
+        "deprecation_date": "2025-12-31",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -28114,6 +29892,7 @@
         "supports_vision": true
     },
     "mistral/pixtral-large-2411": {
+        "deprecation_date": "2026-05-31",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -29083,6 +30862,7 @@
     },
     "o1": {
         "cache_read_input_token_cost": 7.5e-06,
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 200000,
@@ -29102,6 +30882,7 @@
     },
     "o1-2024-12-17": {
         "cache_read_input_token_cost": 7.5e-06,
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 200000,
@@ -29120,6 +30901,7 @@
         "supports_vision": true
     },
     "o1-pro": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 0.00015,
         "input_cost_per_token_batches": 7.5e-05,
         "litellm_provider": "openai",
@@ -29152,6 +30934,7 @@
         "supports_vision": true
     },
     "o1-pro-2025-03-19": {
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 0.00015,
         "input_cost_per_token_batches": 7.5e-05,
         "litellm_provider": "openai",
@@ -29198,6 +30981,11 @@
         "output_cost_per_token": 8e-06,
         "output_cost_per_token_flex": 4e-06,
         "output_cost_per_token_priority": 1.4e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/responses",
             "/v1/chat/completions",
@@ -29223,13 +31011,25 @@
     },
     "o3-2025-04-16": {
         "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_flex": 2.5e-07,
+        "cache_read_input_token_cost_priority": 8.75e-07,
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 2e-06,
+        "input_cost_per_token_flex": 1e-06,
+        "input_cost_per_token_priority": 3.5e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "chat",
         "output_cost_per_token": 8e-06,
+        "output_cost_per_token_flex": 4e-06,
+        "output_cost_per_token_priority": 1.4e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/responses",
             "/v1/chat/completions",
@@ -29255,6 +31055,7 @@
     },
     "o3-deep-research": {
         "cache_read_input_token_cost": 2.5e-06,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1e-05,
         "input_cost_per_token_batches": 5e-06,
         "litellm_provider": "openai",
@@ -29264,6 +31065,11 @@
         "mode": "responses",
         "output_cost_per_token": 4e-05,
         "output_cost_per_token_batches": 2e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -29289,6 +31095,7 @@
     },
     "o3-deep-research-2025-06-26": {
         "cache_read_input_token_cost": 2.5e-06,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 1e-05,
         "input_cost_per_token_batches": 5e-06,
         "litellm_provider": "openai",
@@ -29298,6 +31105,11 @@
         "mode": "responses",
         "output_cost_per_token": 4e-05,
         "output_cost_per_token_batches": 2e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -29323,6 +31135,7 @@
     },
     "o3-mini": {
         "cache_read_input_token_cost": 5.5e-07,
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 200000,
@@ -29340,6 +31153,7 @@
     },
     "o3-mini-2025-01-31": {
         "cache_read_input_token_cost": 5.5e-07,
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 200000,
@@ -29365,6 +31179,11 @@
         "mode": "responses",
         "output_cost_per_token": 8e-05,
         "output_cost_per_token_batches": 4e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/responses",
             "/v1/batch"
@@ -29387,6 +31206,7 @@
         "supports_web_search": true
     },
     "o3-pro-2025-06-10": {
+        "deprecation_date": "2026-12-11",
         "input_cost_per_token": 2e-05,
         "input_cost_per_token_batches": 1e-05,
         "litellm_provider": "openai",
@@ -29396,6 +31216,11 @@
         "mode": "responses",
         "output_cost_per_token": 8e-05,
         "output_cost_per_token_batches": 4e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/responses",
             "/v1/batch"
@@ -29421,6 +31246,7 @@
         "cache_read_input_token_cost": 2.75e-07,
         "cache_read_input_token_cost_flex": 1.375e-07,
         "cache_read_input_token_cost_priority": 5e-07,
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 1.1e-06,
         "input_cost_per_token_flex": 5.5e-07,
         "input_cost_per_token_priority": 2e-06,
@@ -29432,6 +31258,11 @@
         "output_cost_per_token": 4.4e-06,
         "output_cost_per_token_flex": 2.2e-06,
         "output_cost_per_token_priority": 8e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supports_function_calling": true,
         "supports_parallel_function_calling": false,
         "supports_pdf_input": true,
@@ -29444,13 +31275,25 @@
     },
     "o4-mini-2025-04-16": {
         "cache_read_input_token_cost": 2.75e-07,
+        "cache_read_input_token_cost_flex": 1.375e-07,
+        "cache_read_input_token_cost_priority": 5e-07,
+        "deprecation_date": "2026-10-23",
         "input_cost_per_token": 1.1e-06,
+        "input_cost_per_token_flex": 5.5e-07,
+        "input_cost_per_token_priority": 2e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "chat",
         "output_cost_per_token": 4.4e-06,
+        "output_cost_per_token_flex": 2.2e-06,
+        "output_cost_per_token_priority": 8e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supports_function_calling": true,
         "supports_parallel_function_calling": false,
         "supports_pdf_input": true,
@@ -29463,6 +31306,7 @@
     },
     "o4-mini-deep-research": {
         "cache_read_input_token_cost": 5e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_batches": 1e-06,
         "litellm_provider": "openai",
@@ -29472,6 +31316,11 @@
         "mode": "responses",
         "output_cost_per_token": 8e-06,
         "output_cost_per_token_batches": 4e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -29497,6 +31346,7 @@
     },
     "o4-mini-deep-research-2025-06-26": {
         "cache_read_input_token_cost": 5e-07,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_batches": 1e-06,
         "litellm_provider": "openai",
@@ -29506,6 +31356,11 @@
         "mode": "responses",
         "output_cost_per_token": 8e-06,
         "output_cost_per_token_batches": 4e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -31190,6 +33045,17 @@
         "supports_tool_choice": true,
         "supports_video_input": true,
         "supports_vision": true
+    },
+    "openrouter/nvidia/nemotron-3.5-lightning": {
+        "input_cost_per_token": 5e-08,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 2e-07,
+        "source": "https://openrouter.ai/nvidia/nemotron-3.5-lightning",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
     },
     "openrouter/openai/gpt-3.5-turbo": {
         "input_cost_per_token": 1.5e-06,
@@ -32987,7 +34853,7 @@
         "supports_tool_choice": true,
         "supports_response_schema": true
     },
-    "replicateopenai/gpt-oss-20b": {
+    "replicate/openai/gpt-oss-20b": {
         "input_cost_per_token": 9e-08,
         "output_cost_per_token": 3.6e-07,
         "litellm_provider": "replicate",
@@ -34860,6 +36726,7 @@
         "supports_response_schema": true
     },
     "us.amazon.nova-premier-v1:0": {
+        "deprecation_date": "2026-09-14",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 1000000,
@@ -34911,6 +36778,7 @@
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -34986,6 +36854,7 @@
         "supports_vision": true
     },
     "us.anthropic.claude-3-haiku-20240307-v1:0": {
+        "deprecation_date": "2026-09-10",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -35017,6 +36886,7 @@
         "cache_creation_input_token_cost": 1.875e-05
     },
     "us.anthropic.claude-3-sonnet-20240229-v1:0": {
+        "deprecation_date": "2026-07-30",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -35035,6 +36905,7 @@
     "us.anthropic.claude-opus-4-1-20250805-v1:0": {
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
+        "deprecation_date": "2027-01-08",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
@@ -35069,6 +36940,7 @@
         "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 1.32e-05,
         "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -35103,6 +36975,7 @@
         "cache_creation_input_token_cost_above_1hr_above_200k_tokens": 1.44e-05,
         "cache_read_input_token_cost_above_200k_tokens": 7.2e-07,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -35127,6 +37000,7 @@
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -35177,6 +37051,7 @@
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -35208,6 +37083,7 @@
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -35238,6 +37114,7 @@
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -35266,6 +37143,7 @@
     "us.anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2026-10-14",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
         "output_cost_per_token_above_200k_tokens": 2.25e-05,
@@ -35316,6 +37194,7 @@
         "output_cost_per_token": 1.85e-06,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_native_structured_output": true,
         "supports_tool_choice": true
     },
     "eu.deepseek.v3.2": {
@@ -35328,6 +37207,7 @@
         "output_cost_per_token": 2.22e-06,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_native_structured_output": true,
         "supports_tool_choice": true
     },
     "us.meta.llama3-1-405b-instruct-v1:0": {
@@ -39898,69 +41778,86 @@
     },
     "xai/grok-4.20-multi-agent-beta-0309": {
         "cache_read_input_token_cost": 2e-07,
-        "input_cost_per_token": 2e-06,
+        "input_cost_per_token": 1.25e-06,
         "litellm_provider": "xai",
-        "max_input_tokens": 2000000,
-        "max_output_tokens": 2000000,
-        "max_tokens": 2000000,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
         "mode": "chat",
-        "output_cost_per_token": 6e-06,
+        "output_cost_per_token": 2.5e-06,
         "source": "https://docs.x.ai/docs/models",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "output_cost_per_token_above_200k_tokens": 5e-06,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "supports_response_schema": true
     },
     "xai/grok-4.20-beta-0309-reasoning": {
         "cache_read_input_token_cost": 2e-07,
-        "input_cost_per_token": 2e-06,
+        "input_cost_per_token": 1.25e-06,
         "litellm_provider": "xai",
-        "max_input_tokens": 2000000,
-        "max_output_tokens": 2000000,
-        "max_tokens": 2000000,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
         "mode": "chat",
-        "output_cost_per_token": 6e-06,
+        "output_cost_per_token": 2.5e-06,
         "source": "https://docs.x.ai/docs/models",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "output_cost_per_token_above_200k_tokens": 5e-06,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "supports_response_schema": true
     },
     "xai/grok-4.20-0309-reasoning": {
         "cache_read_input_token_cost": 2e-07,
-        "input_cost_per_token": 2e-06,
+        "input_cost_per_token": 1.25e-06,
         "litellm_provider": "xai",
-        "max_input_tokens": 2000000,
-        "max_output_tokens": 2000000,
-        "max_tokens": 2000000,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
         "mode": "chat",
-        "output_cost_per_token": 6e-06,
+        "output_cost_per_token": 2.5e-06,
         "source": "https://docs.x.ai/docs/models",
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "output_cost_per_token_above_200k_tokens": 5e-06,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true
     },
     "xai/grok-4.20-beta-0309-non-reasoning": {
         "cache_read_input_token_cost": 2e-07,
-        "input_cost_per_token": 2e-06,
+        "input_cost_per_token": 1.25e-06,
         "litellm_provider": "xai",
-        "max_input_tokens": 2000000,
-        "max_output_tokens": 2000000,
-        "max_tokens": 2000000,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
         "mode": "chat",
-        "output_cost_per_token": 6e-06,
+        "output_cost_per_token": 2.5e-06,
         "source": "https://docs.x.ai/docs/models",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "output_cost_per_token_above_200k_tokens": 5e-06,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "supports_response_schema": true
     },
     "xai/grok-4.3": {
         "cache_read_input_token_cost": 2e-07,
@@ -40005,8 +41902,8 @@
         "supports_web_search": true
     },
     "xai/grok-4.5": {
-        "cache_read_input_token_cost": 5e-07,
-        "cache_read_input_token_cost_above_200k_tokens": 1e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_above_200k_tokens": 4e-06,
         "litellm_provider": "xai",
@@ -40026,6 +41923,27 @@
         "supports_web_search": true
     },
     "xai/grok-4.5-latest": {
+        "cache_read_input_token_cost": 3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_above_200k_tokens": 4e-06,
+        "litellm_provider": "xai",
+        "max_input_tokens": 500000,
+        "max_output_tokens": 500000,
+        "max_tokens": 500000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "output_cost_per_token_above_200k_tokens": 1.2e-05,
+        "source": "https://docs.x.ai/docs/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
+    "xai/grok-4.6": {
         "cache_read_input_token_cost": 5e-07,
         "cache_read_input_token_cost_above_200k_tokens": 1e-06,
         "input_cost_per_token": 2e-06,
@@ -40037,7 +41955,7 @@
         "mode": "chat",
         "output_cost_per_token": 6e-06,
         "output_cost_per_token_above_200k_tokens": 1.2e-05,
-        "source": "https://docs.x.ai/docs/models",
+        "source": "https://docs.x.ai/developers/models",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
@@ -40060,51 +41978,64 @@
         "supports_web_search": true
     },
     "xai/grok-code-fast": {
-        "cache_read_input_token_cost": 2e-08,
-        "input_cost_per_token": 2e-07,
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 1e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 256000,
         "max_output_tokens": 256000,
         "max_tokens": 256000,
         "mode": "chat",
-        "output_cost_per_token": 1.5e-06,
+        "output_cost_per_token": 2e-06,
         "source": "https://docs.x.ai/docs/models",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "input_cost_per_token_above_200k_tokens": 2e-06,
+        "output_cost_per_token_above_200k_tokens": 4e-06,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "supports_response_schema": true,
+        "supports_vision": true
     },
     "xai/grok-code-fast-1": {
-        "cache_read_input_token_cost": 2e-08,
-        "input_cost_per_token": 2e-07,
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 1e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 256000,
         "max_output_tokens": 256000,
         "max_tokens": 256000,
         "mode": "chat",
-        "output_cost_per_token": 1.5e-06,
+        "output_cost_per_token": 2e-06,
         "source": "https://docs.x.ai/docs/models",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "deprecation_date": "2026-05-15"
+        "input_cost_per_token_above_200k_tokens": 2e-06,
+        "output_cost_per_token_above_200k_tokens": 4e-06,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "supports_response_schema": true,
+        "supports_vision": true
     },
     "xai/grok-code-fast-1-0825": {
-        "cache_read_input_token_cost": 2e-08,
-        "input_cost_per_token": 2e-07,
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 1e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 256000,
         "max_output_tokens": 256000,
         "max_tokens": 256000,
         "mode": "chat",
-        "output_cost_per_token": 1.5e-06,
+        "output_cost_per_token": 2e-06,
         "source": "https://docs.x.ai/docs/models",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "deprecation_date": "2026-05-15"
+        "input_cost_per_token_above_200k_tokens": 2e-06,
+        "output_cost_per_token_above_200k_tokens": 4e-06,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "supports_response_schema": true,
+        "supports_vision": true
     },
     "xai/grok-vision-beta": {
         "input_cost_per_image": 5e-06,
@@ -40144,6 +42075,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_native_structured_output": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
@@ -40341,6 +42273,7 @@
         "mode": "chat"
     },
     "openai/sora-2": {
+        "deprecation_date": "2026-09-24",
         "litellm_provider": "openai",
         "mode": "video_generation",
         "output_cost_per_video_per_second": 0.1,
@@ -40354,6 +42287,7 @@
         ]
     },
     "openai/sora-2-pro": {
+        "deprecation_date": "2026-09-24",
         "litellm_provider": "openai",
         "mode": "video_generation",
         "output_cost_per_video_per_second": 0.3,
@@ -42572,8 +44506,8 @@
         "input_cost_per_token": 2e-06,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
         "mode": "chat",
         "output_cost_per_token": 8e-06,
         "source": "https://docs.fireworks.ai/serverless/pricing",
@@ -42588,8 +44522,8 @@
         "input_cost_per_token": 1.9e-06,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
         "mode": "chat",
         "output_cost_per_token": 8e-06,
         "source": "https://docs.fireworks.ai/serverless/pricing",
@@ -44272,6 +46206,7 @@
         ]
     },
     "gpt-4o-mini-tts-2025-03-20": {
+        "deprecation_date": "2026-07-23",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
         "mode": "audio_speech",
@@ -44308,6 +46243,7 @@
         ]
     },
     "gpt-4o-mini-transcribe-2025-03-20": {
+        "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
@@ -44340,6 +46276,11 @@
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 1e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
@@ -44362,6 +46303,11 @@
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 1e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
@@ -44378,6 +46324,7 @@
         "cache_creation_input_audio_token_cost": 3e-07,
         "cache_read_input_audio_token_cost": 3e-07,
         "cache_read_input_token_cost": 6e-08,
+        "deprecation_date": "2026-07-23",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_image": 8e-07,
         "input_cost_per_token": 6e-07,
@@ -44458,6 +46405,7 @@
         "supports_audio_input": true
     },
     "sora-2": {
+        "deprecation_date": "2026-09-24",
         "litellm_provider": "openai",
         "mode": "video_generation",
         "output_cost_per_video_per_second": 0.1,
@@ -44471,6 +46419,7 @@
         ]
     },
     "sora-2-pro": {
+        "deprecation_date": "2026-09-24",
         "litellm_provider": "openai",
         "mode": "video_generation",
         "output_cost_per_video_per_second": 0.3,
@@ -44498,6 +46447,7 @@
     },
     "chatgpt-image-latest": {
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2026-12-01",
         "input_cost_per_image_token": 1e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
@@ -44809,6 +46759,21 @@
         "tpm": 250000,
         "rpm": 10,
         "gemini_audio_only_live": true
+    },
+    "gemini/gemini-3.1-flash-tts-preview": {
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "audio_speech",
+        "output_cost_per_token": 2e-05,
+        "source": "https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-tts-preview",
+        "supported_endpoints": [
+            "/v1/audio/speech"
+        ],
+        "tpm": 4000000,
+        "rpm": 10
     },
     "gemini-2.5-flash-preview-tts": {
         "input_cost_per_token": 3e-07,
@@ -45188,11 +47153,15 @@
     },
     "bedrock_mantle/openai.gpt-5.6-sol": {
         "input_cost_per_token": 5.5e-06,
+        "input_cost_per_token_above_272k_tokens": 1.1e-05,
         "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.375e-05,
         "cache_read_input_token_cost": 5.5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "output_cost_per_token": 3.3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.95e-05,
         "litellm_provider": "bedrock_mantle",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
@@ -45215,12 +47184,16 @@
         "supports_vision": true
     },
     "bedrock_mantle/openai.gpt-5.6-terra": {
-        "input_cost_per_token": 2.75e-06,
-        "cache_creation_input_token_cost": 3.4375e-06,
-        "cache_read_input_token_cost": 2.75e-07,
-        "output_cost_per_token": 1.65e-05,
+        "input_cost_per_token": 2.2e-06,
+        "input_cost_per_token_above_272k_tokens": 4.4e-06,
+        "cache_creation_input_token_cost": 2.75e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-06,
+        "cache_read_input_token_cost": 2.2e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 4.4e-07,
+        "output_cost_per_token": 1.32e-05,
+        "output_cost_per_token_above_272k_tokens": 1.98e-05,
         "litellm_provider": "bedrock_mantle",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
@@ -45243,12 +47216,16 @@
         "supports_vision": true
     },
     "bedrock_mantle/openai.gpt-5.6-luna": {
-        "input_cost_per_token": 1.1e-06,
-        "cache_creation_input_token_cost": 1.375e-06,
-        "cache_read_input_token_cost": 1.1e-07,
-        "output_cost_per_token": 6.6e-06,
+        "input_cost_per_token": 2.2e-07,
+        "input_cost_per_token_above_272k_tokens": 4.4e-07,
+        "cache_creation_input_token_cost": 2.75e-07,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-07,
+        "cache_read_input_token_cost": 2.2e-08,
+        "cache_read_input_token_cost_above_272k_tokens": 4.4e-08,
+        "output_cost_per_token": 1.32e-06,
+        "output_cost_per_token_above_272k_tokens": 1.98e-06,
         "litellm_provider": "bedrock_mantle",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
@@ -45565,6 +47542,7 @@
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_system_messages": true,
+        "supports_native_structured_output": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
@@ -45579,6 +47557,7 @@
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_system_messages": true,
+        "supports_native_structured_output": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
@@ -45588,6 +47567,7 @@
         "cache_read_input_token_cost": 1.2e-07,
         "input_cost_per_token": 1.2e-06,
         "litellm_provider": "bedrock",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -45613,6 +47593,7 @@
         "cache_read_input_token_cost": 1.2e-07,
         "input_cost_per_token": 1.2e-06,
         "litellm_provider": "bedrock",
+        "supports_tool_search": true,
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
@@ -45999,8 +47980,8 @@
         "input_cost_per_token_cache_hit": 2.8e-09,
         "litellm_provider": "deepseek",
         "max_input_tokens": 1000000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
         "mode": "chat",
         "output_cost_per_token": 2.8e-07,
         "source": "https://api-docs.deepseek.com/quick_start/pricing",
@@ -46012,6 +47993,7 @@
         "supports_native_streaming": true,
         "supports_parallel_function_calling": true,
         "supports_prompt_caching": true,
+        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
@@ -46024,8 +48006,8 @@
         "input_cost_per_token_cache_hit": 3.625e-09,
         "litellm_provider": "deepseek",
         "max_input_tokens": 1000000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
         "mode": "chat",
         "output_cost_per_token": 8.7e-07,
         "source": "https://api-docs.deepseek.com/quick_start/pricing",
@@ -46037,6 +48019,7 @@
         "supports_native_streaming": true,
         "supports_parallel_function_calling": true,
         "supports_prompt_caching": true,
+        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
@@ -46049,8 +48032,8 @@
         "input_cost_per_token_cache_hit": 2.8e-09,
         "litellm_provider": "deepseek",
         "max_input_tokens": 1000000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
         "mode": "chat",
         "output_cost_per_token": 2.8e-07,
         "source": "https://api-docs.deepseek.com/quick_start/pricing",
@@ -46062,6 +48045,7 @@
         "supports_native_streaming": true,
         "supports_parallel_function_calling": true,
         "supports_prompt_caching": true,
+        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
@@ -46074,8 +48058,8 @@
         "input_cost_per_token_cache_hit": 3.625e-09,
         "litellm_provider": "deepseek",
         "max_input_tokens": 1000000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
         "mode": "chat",
         "output_cost_per_token": 8.7e-07,
         "source": "https://api-docs.deepseek.com/quick_start/pricing",
@@ -46087,6 +48071,7 @@
         "supports_native_streaming": true,
         "supports_parallel_function_calling": true,
         "supports_prompt_caching": true,
+        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
@@ -46255,6 +48240,302 @@
         "supports_native_streaming": true,
         "supports_system_messages": true,
         "supports_tool_choice": true
+    },
+    "xai/grok-4.20-0309-non-reasoning": {
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 1.25e-06,
+        "litellm_provider": "xai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "source": "https://docs.x.ai/docs/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "output_cost_per_token_above_200k_tokens": 5e-06,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "supports_response_schema": true
+    },
+    "xai/grok-4.20-multi-agent-0309": {
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 1.25e-06,
+        "litellm_provider": "xai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "source": "https://docs.x.ai/docs/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "output_cost_per_token_above_200k_tokens": 5e-06,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "supports_response_schema": true
+    },
+    "xai/grok-build-0.1": {
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "xai",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 2e-06,
+        "source": "https://docs.x.ai/docs/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "input_cost_per_token_above_200k_tokens": 2e-06,
+        "output_cost_per_token_above_200k_tokens": 4e-06,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
+    "gpt-transcribe": {
+        "input_cost_per_second": 7.5e-05,
+        "litellm_provider": "openai",
+        "mode": "audio_transcription",
+        "source": "https://platform.openai.com/docs/models/gpt-transcribe",
+        "supported_endpoints": [
+            "/v1/audio/transcriptions",
+            "/v1/realtime/transcription_sessions"
+        ],
+        "supported_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true
+    },
+    "gpt-live-transcribe": {
+        "input_cost_per_second": 0.0002833333333333333,
+        "litellm_provider": "openai",
+        "mode": "audio_transcription",
+        "source": "https://platform.openai.com/docs/models/gpt-live-transcribe",
+        "supported_endpoints": [
+            "/v1/realtime",
+            "/v1/realtime/transcription_sessions"
+        ],
+        "supported_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true
+    },
+    "gpt-realtime-translate": {
+        "input_cost_per_second": 0.0005666666666666667,
+        "litellm_provider": "openai",
+        "max_input_tokens": 16000,
+        "max_output_tokens": 2000,
+        "max_tokens": 2000,
+        "mode": "realtime",
+        "source": "https://platform.openai.com/docs/models/gpt-realtime-translate",
+        "supported_modalities": [
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true
+    },
+    "claude-mythos-5": {
+        "cache_creation_input_token_cost": 1.25e-05,
+        "cache_creation_input_token_cost_above_1hr": 2e-05,
+        "cache_read_input_token_cost": 1e-06,
+        "input_cost_per_token": 1e-05,
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 5e-05,
+        "prompt_cache_min_tokens": 512,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "source": "https://docs.claude.com/en/docs/about-claude/models/overview",
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_max_reasoning_effort": true,
+        "supports_output_config": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "claude-mythos-preview": {
+        "cache_creation_input_token_cost": 1.25e-05,
+        "cache_creation_input_token_cost_above_1hr": 2e-05,
+        "cache_read_input_token_cost": 1e-06,
+        "input_cost_per_token": 1e-05,
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 5e-05,
+        "prompt_cache_min_tokens": 512,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "source": "https://docs.claude.com/en/docs/about-claude/models/overview",
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_max_reasoning_effort": true,
+        "supports_output_config": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "gemini/gemini-robotics-er-2-streaming-preview": {
+        "input_cost_per_audio_token": 2e-06,
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "gemini",
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.014,
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014
+        },
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
+        "supported_endpoints": [
+            "/v1/realtime"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "web_search_billing_unit": "per_query"
+    },
+    "mistral/mistral-small-2603": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "mistral",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "source": "https://docs.mistral.ai/models/model-cards/mistral-small-4-0-26-03",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "mistral/labs-leanstral-1-5": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "mistral",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 0.0,
+        "source": "https://docs.mistral.ai/models/model-cards/leanstral-1-5",
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "mistral/mistral-moderation-2603": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "mistral",
+        "max_input_tokens": 131072,
+        "mode": "moderation",
+        "output_cost_per_token": 0.0,
+        "source": "https://docs.mistral.ai/models/model-cards/mistral-moderation-26-03"
+    },
+    "mistral/voxtral-mini-2602": {
+        "input_cost_per_second": 5e-05,
+        "litellm_provider": "mistral",
+        "mode": "audio_transcription",
+        "source": "https://docs.mistral.ai/models/model-cards/voxtral-mini-transcribe-26-02",
+        "supported_endpoints": [
+            "/v1/audio/transcriptions"
+        ],
+        "supported_modalities": [
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true
+    },
+    "mistral/voxtral-mini-transcribe-realtime-2602": {
+        "input_cost_per_second": 0.0001,
+        "litellm_provider": "mistral",
+        "mode": "audio_transcription",
+        "source": "https://docs.mistral.ai/models/model-cards/voxtral-mini-transcribe-realtime-26-02",
+        "supported_endpoints": [
+            "/v1/audio/transcriptions"
+        ],
+        "supported_modalities": [
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true
+    },
+    "mistral/voxtral-mini-tts-2603": {
+        "litellm_provider": "mistral",
+        "mode": "audio_speech",
+        "output_cost_per_character": 1.6e-05,
+        "source": "https://docs.mistral.ai/models/model-cards/voxtral-tts-26-03",
+        "supported_endpoints": [
+            "/v1/audio/speech"
+        ],
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "audio"
+        ],
+        "supports_audio_output": true
     },
     "fallback_generalizations": {
         "rules": [

--- a/llm/model_catalog.go
+++ b/llm/model_catalog.go
@@ -108,6 +108,32 @@ func (c *ModelCatalog) ResolveAlias(alias string) (target *ModelInfo, ambiguous 
 	return target, false
 }
 
+// bedrockOpenAICatalogKey maps a Bedrock OpenAI inference-profile ID to the
+// LiteLLM key carrying its metadata, reporting whether the ref had that shape.
+//
+// This covers one specific upstream naming gap, not Bedrock IDs generally.
+// LiteLLM files Anthropic's Bedrock models under region-prefixed keys that
+// already match what Bedrock advertises ("us.anthropic.claude-opus-5"), so
+// those resolve on the exact lookup and must not be rewritten. Only the OpenAI
+// models are filed under a "bedrock_mantle/" key with no region-prefixed alias.
+// Keeping the rule this narrow avoids shadowing an unrelated model whose name
+// merely begins with a region prefix.
+//
+// The two scopes are the complete set, not a sample: Bedrock publishes its
+// OpenAI models under "us." and "global." inference profiles only, verified
+// against ListInferenceProfiles. Anthropic's models do use further scopes
+// (eu./apac./au./jp.), which is why this maps OpenAI's names specifically
+// rather than region prefixes generally.
+func bedrockOpenAICatalogKey(id string) (string, bool) {
+	for _, scope := range []string{"us.", "global."} {
+		rest, ok := strings.CutPrefix(id, scope+"openai.")
+		if ok && rest != "" {
+			return "bedrock_mantle/openai." + rest, true
+		}
+	}
+	return "", false
+}
+
 // LookupModelInfo resolves catalog metadata for a model ref that may carry an
 // Anthropic "[1m]" 1M-context suffix and/or a provider namespace (e.g.
 // "anthropic/claude-opus-4-5" served by an openrouter-anthropic instance). It
@@ -139,6 +165,11 @@ func (c *ModelCatalog) LookupModelInfo(modelID string) *ModelInfo {
 		// own; fall back to its family (claude-opus-4-5-YYYYMMDD → claude-opus-4-5).
 		if fam := familyModelID(id); fam != id {
 			mi = c.GetModelInfo(fam)
+		}
+	}
+	if mi == nil {
+		if alias, ok := bedrockOpenAICatalogKey(id); ok {
+			mi = c.GetModelInfo(alias)
 		}
 	}
 	if mi != nil && oneMillion {

--- a/llm/model_catalog_test.go
+++ b/llm/model_catalog_test.go
@@ -421,8 +421,8 @@ func TestEmbeddedModelCatalog_GPT56Family(t *testing.T) {
 	wantLevels := []string{"low", "medium", "high", "xhigh", "max"}
 	pricing := map[string][3]float64{ // in, out, cache-read $/MTok
 		"gpt-5.6-sol":   {5, 30, 0.5},
-		"gpt-5.6-terra": {2.5, 15, 0.25},
-		"gpt-5.6-luna":  {1, 6, 0.1},
+		"gpt-5.6-terra": {2, 12, 0.2},
+		"gpt-5.6-luna":  {0.2, 1.2, 0.02},
 	}
 	for id, p := range pricing {
 		mi := cat.GetModelInfo(id)
@@ -444,9 +444,13 @@ func TestEmbeddedModelCatalog_GPT56Family(t *testing.T) {
 		if !mi.SupportsTools || !mi.SupportsVision || !mi.SupportsReasoning {
 			t.Errorf("%s tools/vision/reasoning = %v/%v/%v, want all true", id, mi.SupportsTools, mi.SupportsVision, mi.SupportsReasoning)
 		}
-		if mi.InputCostPerMillion == nil || *mi.InputCostPerMillion != p[0] ||
-			mi.OutputCostPerMillion == nil || *mi.OutputCostPerMillion != p[1] {
-			t.Errorf("%s pricing = %v/%v, want %v/%v", id, mi.InputCostPerMillion, mi.OutputCostPerMillion, p[0], p[1])
+		// Per-million prices are scaled from per-token floats, so exact
+		// equality is not safe: upstream's 2e-07 scales to 0.19999999999999998,
+		// not 0.2. Compare all three the way cache-read already is.
+		if !floatPtrApproxEqual(mi.InputCostPerMillion, f64(p[0])) ||
+			!floatPtrApproxEqual(mi.OutputCostPerMillion, f64(p[1])) {
+			t.Errorf("%s pricing = %v/%v, want %v/%v",
+				id, floatPtrValue(mi.InputCostPerMillion), floatPtrValue(mi.OutputCostPerMillion), p[0], p[1])
 		}
 		if !floatPtrApproxEqual(mi.CacheReadInputCostPerMillion, f64(p[2])) {
 			t.Errorf("%s cache-read pricing = %v, want %v", id, mi.CacheReadInputCostPerMillion, p[2])
@@ -653,6 +657,15 @@ func TestEmbeddedCatalog_CacheTierPricing(t *testing.T) {
 }
 
 func f64(v float64) *float64 { return &v }
+
+// floatPtrValue renders a price for a failure message. Formatting the pointer
+// itself prints an address, which tells you a price is wrong but not what it is.
+func floatPtrValue(v *float64) any {
+	if v == nil {
+		return "nil"
+	}
+	return *v
+}
 
 func floatPtrApproxEqual(a, b *float64) bool {
 	if a == nil && b == nil {
@@ -1141,9 +1154,10 @@ func TestEmbeddedCatalog_DeepSeekV4Models(t *testing.T) {
 			t.Errorf("%s ContextWindow = %d, want 1000000", id, mi.ContextWindow)
 		}
 		// Upstream now defines these models; the slimmed override defers the
-		// output cap to LiteLLM's 8192 (an over-cap 400s at the provider).
-		if mi.MaxOutputTokens == nil || *mi.MaxOutputTokens != 8192 {
-			t.Errorf("%s MaxOutputTokens = %v, want upstream's 8192", id, mi.MaxOutputTokens)
+		// output cap to LiteLLM entirely, so this tracks whatever upstream
+		// publishes rather than pinning a number the refresh script moves.
+		if mi.MaxOutputTokens == nil || *mi.MaxOutputTokens != 393_216 {
+			t.Errorf("%s MaxOutputTokens = %v, want upstream's 393216", id, mi.MaxOutputTokens)
 		}
 		if !mi.SupportsEffortParameter {
 			t.Errorf("%s SupportsEffortParameter should be true", id)

--- a/llm/model_catalog_test.go
+++ b/llm/model_catalog_test.go
@@ -656,6 +656,46 @@ func TestEmbeddedCatalog_CacheTierPricing(t *testing.T) {
 	}
 }
 
+// TestLookupModelInfo_BedrockOpenAIInferenceProfile covers the one Bedrock
+// naming gap. LiteLLM files Anthropic's Bedrock models under region-prefixed
+// keys that match what Bedrock advertises, but files OpenAI's under
+// "bedrock_mantle/openai.<model>" with no such alias, so an OpenAI inference
+// profile resolves to nothing and the profile silently falls back to
+// constructor defaults for every field.
+func TestLookupModelInfo_BedrockOpenAIInferenceProfile(t *testing.T) {
+	cat := EmbeddedModelCatalog()
+	if cat == nil {
+		t.Fatal("embedded catalog nil")
+	}
+
+	for _, id := range []string{"us.openai.gpt-5.6-luna", "global.openai.gpt-5.6-luna"} {
+		mi := cat.LookupModelInfo(id)
+		if mi == nil {
+			t.Errorf("LookupModelInfo(%q) = nil, want the bedrock_mantle entry", id)
+			continue
+		}
+		if mi.MaxOutputTokens == nil {
+			t.Errorf("%s MaxOutputTokens = nil, want 128000", id)
+		} else if *mi.MaxOutputTokens != 128_000 {
+			t.Errorf("%s MaxOutputTokens = %d, want 128000", id, *mi.MaxOutputTokens)
+		}
+		if !mi.SupportsReasoning {
+			t.Errorf("%s SupportsReasoning = false, want true", id)
+		}
+	}
+
+	// Anthropic's Bedrock IDs already match upstream keys exactly. The alias
+	// must not disturb them, and must not invent a hit for an unknown ID.
+	for _, id := range []string{"us.anthropic.claude-opus-5", "global.anthropic.claude-opus-5"} {
+		if mi := cat.LookupModelInfo(id); mi == nil {
+			t.Errorf("LookupModelInfo(%q) = nil, want the existing exact match", id)
+		}
+	}
+	if mi := cat.LookupModelInfo("us.openai.not-a-real-model"); mi != nil {
+		t.Errorf("LookupModelInfo(unknown) = %+v, want nil", mi)
+	}
+}
+
 func f64(v float64) *float64 { return &v }
 
 // floatPtrValue renders a price for a failure message. Formatting the pointer


### PR DESCRIPTION
Unblocks Evener against Amazon Bedrock's OpenAI-compatible Responses endpoint, and fixes a silent reasoning-effort downgrade found along the way.

## The problem

Bedrock rejects the **entire request** — not just the tool — when OpenAI's hosted `web_search` is present, and `NewOpenAIProfile` hardcoded that capability on:

```
bedrock error (status=0): responses.create(stream): web search is not supported for this request
```

Underneath sat a quieter failure. Bedrock's inference-profile IDs resolved no catalog entry at all, so the effort ladder fell back to `low/medium/high/xhigh`. `ClampReasoningEffort` finds no level ranked at or above `max` and returns the highest it knows — so **a run asked for `max` silently became an `xhigh` run.** A mislabeled measurement is worse than a failed one.

## What changed

1. **`bedrockOpenAICatalogKey`** maps `us.openai.X` / `global.openai.X` to LiteLLM's `bedrock_mantle/openai.X`, as a fallback in `LookupModelInfo`. This is one narrow upstream naming gap, not a general one: LiteLLM already files Anthropic's Bedrock models under region-prefixed keys matching what Bedrock advertises, and files only OpenAI's without an alias. `ListInferenceProfiles` confirms `us.` and `global.` are the *complete* set for OpenAI, so the narrowness reflects the data rather than a guess.
2. **`resolveWebSearch`** mirrors the existing `resolveEffortLevels` — presence-aware, catalog wins, silence keeps the provider default. Across both catalog files 55 OpenAI-family models declare `supports_web_search: true` and **zero** declare false, so this changes nothing shipping today.
3. **Override entries** for the three Bedrock GPT-5.6 models supply only what LiteLLM lacks: the effort ladder including `max`, and `supports_web_search: false`. Pricing and context stay upstream so the refresh script keeps them current.
4. **`openai` joins the rebuild-on-model-change set.** Its effort ladder has been catalog-derived since `resolveEffortLevels` existed, so shallow-cloning already carried a stale ladder across a model switch. Adding a second catalog-derived field made that load-bearing — without this, both fixes fail open on every model switch, fallback hop, and subagent override.

Only three of the nine `bedrock_mantle/openai.*` entries get flags: probing `us.openai.gpt-5.5` and `us.openai.gpt-oss-120b` returns *"The provided model identifier is invalid"*, so the rest are catalog rows with no serving path.

## Catalog refresh (separate commit)

The vendored LiteLLM snapshot is refreshed: **+72 added, 1 removed, ~430 changed**. Three things needed handling rather than a mechanical bump:

- `claude-mythos-5` and `claude-mythos-preview` are new and read as Claude 5+; without `claude5_request_shape` the Anthropic builder sends them the **pre-5 wire shape**.
- GPT-5.6 Luna and Terra pricing dropped ~5x (Luna 1/6 to 0.2/1.2 per MTok); DeepSeek V4's output cap rose 8192 to 393216.
- Per-million prices are scaled from per-token floats, so exact equality is unsafe — upstream's `2e-07` scales to `0.19999999999999998`. All three prices now compare approximately, as cache-read already did, and failures print the price rather than a pointer address.

Two further upstream moves the refresh commit message does not call out, noted here for reviewers: `bedrock_mantle/openai.gpt-5.6-*` context went 272,000 to 1,000,000, and `gpt-5-pro`'s `max_output_tokens` went 128,000 to 272,000 (a wire value).

## Deliberately excluded: context window

An earlier revision also took `contextWindow` from the catalog, to put the 272,000 effective Codex/OAuth limit into force. It was removed after review found:

- **It doesn't work.** `fillLiveModelMetadata` runs unconditionally from `NewSession` with no behavior-tag gate, and `WithLiveModelInfo` overwrites the catalog window. Evener's own Codex fixture reports `max_context_window: 400000`, so a live session would still report 400,000 while a constructor-level test claimed otherwise.
- **It regressed the bare `gpt-5.6` slug** from 400,000 to 1,050,000, while Codex rewrites that slug to `gpt-5.6-sol` — pinned at 272,000 by the same change.

Settling live-metadata precedence against explicit configuration is its own change. The fixes here are unaffected: the plain `/v1/models` mapping populates neither `SupportsWebSearch` nor `ReasoningEffortLevels`, so live enumeration cannot clobber them.

## Testing

TDD throughout; every test was watched failing first. The white-box `resolveWebSearch` test passes a provider default that *opposes* the catalog — asserting a catalog `true` against a `true` default would pass even if the helper ignored the catalog, which the first version of that test did until a mutation test caught it.

`go test ./llm/... ./agent/... ./cmdutil/... ./cmd/...` and `make lint` (8 modules) pass.

**Not yet verified end-to-end on an unpatched binary.** The Bedrock rehearsal that proved the endpoint works used a throwaway patch. Acceptance should be a live session asserting from the API log that the request carries `reasoning_effort: max` and no `web_search` tool.

## Follow-ups

- Context window per serving path (the substantive one above)
- Terminal-Bench can't use Bedrock yet — the eval adapter ships no `providers.toml` into the container and hard-validates the model name
- `CredentialTag` returns `openai` for `responses`, so an openai/responses instance with a non-OpenAI `base_url` and no explicit `api_key` bearer-sends the operator's OpenAI credential to a third party (pre-existing; needs documenting)
- `responsesLiteModel`, `openAIModelSupports24hPromptCache`, and `reasoningSummaryLevel` all match bare `gpt-5`/`gpt-5.6` prefixes that Bedrock IDs never match

https://claude.ai/code/session_01R2gZgMAJ34xsyABHwUDZpz