### PR TITLE
fix(hub): auto-expand image file reads by default in transcript

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
@@ -225,8 +225,8 @@ test("suppress returning false renders the row normally", () => {
 
 // --- expand/collapse: collapsed by default, descriptor.autoExpand can pop
 // it open at settle (parity-m4-transcript.md's own Highlights: "every tool
-// row, including diffs, starts collapsed" - the only default-expanded
-// state anywhere is a failed shell call once it settles) ------------------
+// row, including diffs, starts collapsed" - the default-expanded states are
+// a failed shell call and an image read whose picture IS its output) -------
 
 test("a row with a body starts collapsed", () => {
   registerToolRenderer({ match: "tci_collapsed", summary: () => "s", body: () => <div>body text</div> });
@@ -346,7 +346,8 @@ test("a read_file image read renders its output image at the large (up-to-600px)
       live={false}
     />,
   );
-  expandRow();
+  // An image read auto-expands (the picture is the call's whole output), so
+  // the gallery is already mounted - no expandRow() toggle needed.
   const thumb = screen.getByTestId("image-gallery-thumb");
   expect(thumb.className.split(/\s+/)).toContain(galleryStyles.thumbLarge);
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
@@ -207,14 +207,15 @@ export const ToolCallItem = memo(function ToolCallItem({ item, live, sessionRef 
 
   // Every row with a body starts collapsed (parity-m4-transcript.md's own
   // Highlights: "every tool row, including diffs, starts collapsed" - the
-  // only default-expanded state anywhere is a failed call once it settles,
-  // via descriptor.autoExpand OR a tool error/denial (item.error, parity §11:
-  // "only failure earns the eye"; §2:100's force-open on error)). autoExpand
-  // only means anything once the call has actually finished (e.g. shell's own
-  // exit-code heuristic can't resolve mid-stream), so it is consulted exactly
-  // once, at the live -> settled transition, and stashed as autoDefault -
-  // never re-consulted on every render (both to honor that "once" contract and
-  // so a settled row's later re-renders never re-fight the reader's toggle).
+  // only default-expanded states are descriptor.autoExpand (a failed shell
+  // call once it settles, and an image read whose picture IS its output) OR
+  // a tool error/denial (item.error, parity §11: "only failure earns the
+  // eye"; §2:100's force-open on error)). autoExpand only means anything once
+  // the call has actually finished (e.g. shell's own exit-code heuristic
+  // can't resolve mid-stream), so it is consulted exactly once, at the live
+  // -> settled transition, and stashed as autoDefault - never re-consulted
+  // on every render (both to honor that "once" contract and so a settled
+  // row's later re-renders never re-fight the reader's toggle).
   //
   // The open/closed state itself lives in the shared disclosureStore keyed by
   // session ref plus item id, so it survives the VirtualList/dockview remount

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/fsTools.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/fsTools.test.tsx
@@ -106,6 +106,43 @@ test("read_file: plain text output (not the image/document marker) renders exact
   expect(screen.getByText("[not-a-marker] just text")).toBeTruthy();
 });
 
+// --- read_file autoExpand (image reads open by default) --------------------
+// The picture is an image read's whole output, so the row auto-expands to
+// show it without a click. A text or PDF read keeps the usual collapsed
+// default. autoExpand shares the body's own isImageRead detection, so the
+// auto-open and the empty body answer the same question.
+
+test("read_file: autoExpand is defined (parity with edit_file's own undefined check)", () => {
+  const d = toolRendererFor("read_file");
+  expect(d.autoExpand).toBeDefined();
+});
+
+test("read_file: an image read auto-expands - the picture is the call's whole output", () => {
+  const d = toolRendererFor("read_file");
+  expect(
+    d.autoExpand!(item({ toolName: "read_file", output: "[image: png, 178337 bytes, base64 data follows]" })),
+  ).toBe(true);
+});
+
+test("read_file: autoExpand still fires when an older daemon left the base64 payload in output (isImageRead shares the body's own detection)", () => {
+  const d = toolRendererFor("read_file");
+  expect(
+    d.autoExpand!(item({ toolName: "read_file", output: "[image: png, 3 bytes, base64 data follows]\nQUJD" })),
+  ).toBe(true);
+});
+
+test("read_file: a document (PDF) read does NOT auto-expand - no in-transcript preview duplicates its header", () => {
+  const d = toolRendererFor("read_file");
+  expect(
+    d.autoExpand!(item({ toolName: "read_file", output: "[document: pdf, 90210 bytes, base64 data follows]" })),
+  ).toBe(false);
+});
+
+test("read_file: plain text output does NOT auto-expand", () => {
+  const d = toolRendererFor("read_file");
+  expect(d.autoExpand!(item({ toolName: "read_file", output: "just text" }))).toBe(false);
+});
+
 // --- grep / grep_files / grep_search -----------------------------------
 
 test("grep: summary composes pattern, path, and hit count", () => {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/fsTools.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/fsTools.tsx
@@ -36,11 +36,22 @@ function readLineRange(args: Record<string, unknown>, output: string): string {
 // phrase (and minus any payload an older daemon left in output).
 const BINARY_PAYLOAD_HEADER = /^\[(image|document): [^\]]+, base64 data follows\]/;
 
+// isImageRead is the single source of truth for "this read_file call's output
+// is a picture, not text": the body renders nothing for it (the ImageGallery
+// carries the picture below), and autoExpand opens the row by default so the
+// picture is visible without a click. Sharing one predicate keeps the two
+// decisions from ever disagreeing - the body that renders nothing and the
+// auto-open that shows it both answer the same question.
+function isImageRead(item: ItemModel): boolean {
+  const match = BINARY_PAYLOAD_HEADER.exec(item.output ?? "");
+  return match !== null && match[1] === "image";
+}
+
 function ReadFileOutputBody({ item, live }: ToolRenderProps) {
   const output = item.output ?? "";
   const match = BINARY_PAYLOAD_HEADER.exec(output);
   if (match === null) return <TailFoldedOutputBody item={item} live={live} />;
-  if (match[1] === "image") return null;
+  if (isImageRead(item)) return null;
   return <CodeBlock text={match[0].replace(", base64 data follows]", "]")} copyLabel="Copy output" />;
 }
 
@@ -62,6 +73,12 @@ registerToolRenderer({
   // An image read displays the picture itself at up to 600px square, not a
   // 96px thumbnail - the picture IS this call's output.
   outputImageSize: "large",
+  // An image read auto-expands: the picture is the call's whole output, so it
+  // should be visible without a click. A text or PDF read keeps the usual
+  // collapsed default - isImageRead shares the body's own detection so the
+  // auto-open and the empty body can never disagree (the one can't open while
+  // the other still renders text for the same call).
+  autoExpand: isImageRead,
   summary(item: ItemModel) {
     const args = parseArgs(item.argumentsJSON);
     return `Read ${readFileTarget(item)} · ${readLineRange(args, item.output ?? "")}`;


### PR DESCRIPTION
## Problem

In the web UI transcript, a `read_file` call that reads an image collapses by default, so the picture — the call's whole output — is hidden behind a click. Every other tool row starts collapsed (the right default for text/diff/shell output), but an image read's body is the picture itself, so collapsing it hides the result rather than summarizing it.

## Fix

Auto-expand image reads by default. In `fsTools.tsx`, added an `isImageRead(item)` helper that detects an image read from the `[image: …, base64 data follows]` output header — the same detection the body already used to decide to render nothing — and set `autoExpand: isImageRead` on the `read_file` descriptor.

- Image reads: row opens by default; the picture is visible without a click.
- PDF/document reads: stay collapsed (no in-transcript preview duplicates the header).
- Plain-text reads: stay collapsed, unchanged.

The body was refactored to call `isImageRead` too, so the auto-open and the empty body share one source of truth and can never disagree (the one can't open while the other still renders text for the same call).

## Testing

- `fsTools.test.tsx`: 4 new tests — `autoExpand` is defined, true for image reads, false for PDF, false for plain text.
- `ToolCallItem.test.tsx`: updated the one pre-existing image-read test that called `expandRow()` — the row is now already open via auto-expand, so the gallery mounts without a toggle.
- `make test-web` green: web-typecheck, web-test (6716 tests), web-lint.
- `make test-web-browser` green: web-layoutguard, web-overflowguard, web-spawnguard.
