### PR TITLE
fix: show full OpenRouter model catalog in model picker

### DIFF
--- a/agent/session_set_model.go
+++ b/agent/session_set_model.go
@@ -161,27 +161,10 @@ func formatModelAlternatives(models []llm.ModelInfo, tag string, cat *llm.ModelC
 	return strings.Join(ids, ", ")
 }
 
-// modelSwitchVisible mirrors launchcheck's launchCheckModelVisible: non-chat
-// model IDs (embedding, media, etc.) are never valid switch targets, and the
-// "openrouter" tag additionally requires catalog tool support.
+// modelSwitchVisible delegates to the shared llm.ModelCatalog.VisibleLiveModel
+// rule so the in-session model-switch path, the launch-check path, and the hub
+// /api/models path share one visibility rule and cannot drift. See
+// VisibleLiveModel for the OpenRouter bare-live-ID resolution this fixes.
 func modelSwitchVisible(behaviorTag, modelID string, cat *llm.ModelCatalog) bool {
-	lower := strings.ToLower(modelID)
-	if strings.Contains(lower, "embedding") ||
-		strings.Contains(lower, "whisper") ||
-		strings.Contains(lower, "tts") ||
-		strings.Contains(lower, "dall-e") ||
-		strings.Contains(lower, "moderation") ||
-		strings.Contains(lower, "audio") ||
-		strings.Contains(lower, "transcribe") ||
-		strings.Contains(lower, "image") {
-		return false
-	}
-	if behaviorTag == "openrouter" {
-		if cat == nil {
-			return false
-		}
-		mi := cat.GetModelInfo(modelID)
-		return mi != nil && mi.SupportsTools
-	}
-	return true
+	return cat.VisibleLiveModel(behaviorTag, modelID)
 }

--- a/cmd/evener-hub/web_spawn.go
+++ b/cmd/evener-hub/web_spawn.go
@@ -389,22 +389,14 @@ func (s *WebServer) fetchLiveModels(ctx context.Context) []map[string]any {
 			continue
 		}
 		for _, m := range models {
-			lower := strings.ToLower(m.ID)
-			// Skip non-chat / non-completion models from the live list.
-			if strings.Contains(lower, "embedding") ||
-				strings.Contains(lower, "whisper") ||
-				strings.Contains(lower, "tts") ||
-				strings.Contains(lower, "dall-e") ||
-				strings.Contains(lower, "moderation") ||
-				strings.Contains(lower, "audio") ||
-				strings.Contains(lower, "transcribe") ||
-				strings.Contains(lower, "image") {
+			// VisibleLiveModel applies the shared non-chat skip rule and, for
+			// the openrouter tag, the catalog tools-capability filter. This is
+			// the same rule the launch-check path uses (llm.VisibleLiveModel),
+			// so the two live-model paths cannot drift.
+			if !cat.VisibleLiveModel(tag, m.ID) {
 				continue
 			}
 			mi := catalogModelInfo(cat, tag, m.ID)
-			if tag == "openrouter" && (mi == nil || !mi.SupportsTools) {
-				continue
-			}
 			// Use the registered provider name (prov), not m.Provider — wrapper
 			// adapters like openrouter forward to openaicompat which reports
 			// itself as "openai-compatible". The hub's spawn flow needs the
@@ -493,29 +485,12 @@ func (s *WebServer) overlayLiveEntries(entries []map[string]any) []map[string]an
 }
 
 func catalogModelInfo(cat *llm.ModelCatalog, behaviorTag, modelID string) *llm.ModelInfo {
-	// Canonicalized bare lookup first: LookupModelInfo handles the "[1m]"
-	// suffix, provider namespaces, and dated snapshots, and resolves evener's
-	// curated overrides — LiteLLM's provider-qualified entries (e.g.
-	// "openrouter/deepseek/deepseek-chat") often carry NULL capability flags
-	// where the canonical entry is richer. The exact tag-qualified key is the
-	// FALLBACK so openrouter-only listings (entries keyed solely
-	// "openrouter/<model>") still resolve instead of being dropped as not
-	// tool-capable. (The adapter's fillFromCatalog uses the opposite,
-	// exact-qualified-first order — it wants the provider-specific WIRE
-	// behavior, not the richest display metadata.)
-	if behaviorTag == "ollama" {
-		// Local ollama models are unrelated to same-named upstream catalog
-		// entries — the same bare-lookup suppression the profile and adapter
-		// paths apply. Only an explicit ollama/<model> entry counts.
-		return cat.GetModelInfo("ollama/" + modelID)
-	}
-	if mi := cat.LookupModelInfo(modelID); mi != nil {
-		return mi
-	}
-	if behaviorTag != "" {
-		return cat.GetModelInfo(behaviorTag + "/" + modelID)
-	}
-	return nil
+	// Delegates to the shared llm.ModelCatalog.ResolveLiveModelInfo rule so the
+	// hub /api/models path and the launch-check path share one resolution: bare
+	// LookupModelInfo first (handles "[1m]", provider namespaces, dated
+	// snapshots, curated overrides), then the exact tag-qualified key as a
+	// fallback so openrouter-only listings (keyed "openrouter/<model>") resolve.
+	return cat.ResolveLiveModelInfo(behaviorTag, modelID)
 }
 
 // behaviorTagFor resolves an instance name to its behavior tag via the loaded

--- a/cmd/evener/internal/launchcheck/launchcheck.go
+++ b/cmd/evener/internal/launchcheck/launchcheck.go
@@ -268,31 +268,19 @@ func launchCheckModelListUnavailable(err error) bool {
 }
 
 // launchCheckModelVisible reports whether modelID should appear in the launch
-// model list for a provider with the given behavior tag. It returns false for
-// non-chat model IDs (embedding, media, etc.) and, for the "openrouter" tag,
-// for models that are not in the catalog or lack tool support.
+// model list for a provider with the given behavior tag. It delegates to the
+// shared llm.ModelCatalog.VisibleLiveModel rule so the launch-check path and the
+// hub /api/models path cannot drift. See VisibleLiveModel for the OpenRouter
+// bare-live-ID vs prefix-keyed-catalog resolution this fixes.
 func launchCheckModelVisible(behaviorTag, modelID string, cat *llm.ModelCatalog) bool {
-	lower := strings.ToLower(modelID)
-	if strings.Contains(lower, "embedding") ||
-		strings.Contains(lower, "whisper") ||
-		strings.Contains(lower, "tts") ||
-		strings.Contains(lower, "dall-e") ||
-		strings.Contains(lower, "moderation") ||
-		strings.Contains(lower, "audio") ||
-		strings.Contains(lower, "transcribe") ||
-		strings.Contains(lower, "image") {
-		return false
-	}
-	if behaviorTag == "openrouter" {
-		mi := launchCheckCatalogModelInfo(cat, modelID)
-		return mi != nil && mi.SupportsTools
-	}
-	return true
+	return cat.VisibleLiveModel(behaviorTag, modelID)
 }
 
+// launchCheckCatalogModelInfo resolves catalog metadata for a live model ID,
+// delegating to the shared llm.ModelCatalog.ResolveLiveModelInfo so OpenRouter
+// bare live IDs (e.g. "anthropic/claude-sonnet-4.5") resolve against the
+// openrouter/-prefixed catalog entry. behaviorTag defaults to "openrouter" for
+// the launch-check path, which only calls this for openrouter instances.
 func launchCheckCatalogModelInfo(cat *llm.ModelCatalog, modelID string) *llm.ModelInfo {
-	if cat == nil {
-		return nil
-	}
-	return cat.GetModelInfo(modelID)
+	return cat.ResolveLiveModelInfo("openrouter", modelID)
 }

--- a/cmd/evener/internal/launchcheck/launchcheck_test.go
+++ b/cmd/evener/internal/launchcheck/launchcheck_test.go
@@ -352,6 +352,31 @@ func (launchCheckTimeoutError) Error() string   { return "timeout" }
 func (launchCheckTimeoutError) Timeout() bool   { return true }
 func (launchCheckTimeoutError) Temporary() bool { return true }
 
+// TestLaunchCheckModelVisible_OpenRouterBareLiveID is the regression test for the
+// bug where the launch-check model list showed only ~10 OpenRouter models.
+// OpenRouter's /v1/models endpoint returns bare IDs like
+// "anthropic/claude-sonnet-4.5", but the catalog keys them as
+// "openrouter/anthropic/claude-sonnet-4.5". Before the shared
+// llm.VisibleLiveModel rule, launchCheckCatalogModelInfo did an exact
+// GetModelInfo(bareID) that returned nil, so the tools filter dropped the model.
+// Now the shared ResolveLiveModelInfo applies the "openrouter/<id>" fallback.
+func TestLaunchCheckModelVisible_OpenRouterBareLiveID(t *testing.T) {
+	cat := llm.EmbeddedModelCatalog()
+
+	// Premise: only the prefixed key exists.
+	if cat.GetModelInfo("anthropic/claude-sonnet-4.5") != nil {
+		t.Fatal("test premise broken: bare anthropic/claude-sonnet-4.5 now exists as a key")
+	}
+	if cat.GetModelInfo("openrouter/anthropic/claude-sonnet-4.5") == nil {
+		t.Fatal("test premise broken: openrouter/anthropic/claude-sonnet-4.5 missing from catalog")
+	}
+
+	// The bare live ID must now survive the launch-check visibility filter.
+	if !launchCheckModelVisible("openrouter", "anthropic/claude-sonnet-4.5", cat) {
+		t.Error("bare OpenRouter live ID should be visible after the shared-helper fix")
+	}
+}
+
 func TestLaunchCheckRejectsUnsupportedProvider(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := RunLaunchCheck([]string{

--- a/llm/model_catalog.go
+++ b/llm/model_catalog.go
@@ -220,6 +220,90 @@ func (c *ModelCatalog) ListModels(provider string) []ModelInfo {
 	return out
 }
 
+// nonChatModelSubstrings identifies live /models IDs that are not text-completion
+// models. It is shared by every caller that filters a live model list down to
+// chat/completion models so the skip rule cannot drift between them.
+var nonChatModelSubstrings = []string{
+	"embedding", "whisper", "tts", "dall-e", "moderation", "audio", "transcribe", "image",
+}
+
+// IsChatModelID reports whether modelID names a text-completion model rather than
+// an embedding, audio, image, or moderation model. It is a substring check on the
+// lowercased ID, matching the skip rule the launch-check and hub /api/models paths
+// previously duplicated. A nil or empty ID reports false.
+func IsChatModelID(modelID string) bool {
+	if modelID == "" {
+		return false
+	}
+	lower := strings.ToLower(modelID)
+	for _, s := range nonChatModelSubstrings {
+		if strings.Contains(lower, s) {
+			return false
+		}
+	}
+	return true
+}
+
+// ResolveLiveModelInfo resolves catalog metadata for a model ID advertised by a
+// provider's live /models endpoint, keyed by the provider's behavior tag. It is
+// the single resolution rule for live model IDs:
+//
+//   - For the "ollama" tag, local models are unrelated to same-named upstream
+//     catalog entries, so only an explicit "ollama/<id>" key counts (bare lookup
+//     is suppressed).
+//   - Otherwise it tries LookupModelInfo(id) first (handles "[1m]" suffixes,
+//     provider-namespace stripping, dated-snapshot family fallbacks, and evener's
+//     curated overrides), then falls back to the exact tag-qualified key
+//     "tag/<id>" so provider-only listings (e.g. OpenRouter entries keyed solely
+//     "openrouter/<model>") still resolve.
+//
+// The OpenRouter case is the motivating bug: OpenRouter's /v1/models endpoint
+// returns bare IDs like "anthropic/claude-sonnet-4.5", but the embedded LiteLLM
+// catalog keys those models as "openrouter/anthropic/claude-sonnet-4.5". An exact
+// GetModelInfo(bareID) returns nil, so a tools-capability filter dropped nearly
+// every OpenRouter model. The tag-qualified fallback resolves them.
+//
+// Returns nil when the catalog is nil or nothing matches.
+func (c *ModelCatalog) ResolveLiveModelInfo(behaviorTag, modelID string) *ModelInfo {
+	if c == nil {
+		return nil
+	}
+	if behaviorTag == "ollama" {
+		// Local ollama models are unrelated to same-named upstream catalog
+		// entries — the same bare-lookup suppression the profile and adapter
+		// paths apply. Only an explicit ollama/<model> entry counts.
+		return c.GetModelInfo("ollama/" + modelID)
+	}
+	if mi := c.LookupModelInfo(modelID); mi != nil {
+		return mi
+	}
+	if behaviorTag != "" {
+		return c.GetModelInfo(behaviorTag + "/" + modelID)
+	}
+	return nil
+}
+
+// VisibleLiveModel reports whether modelID should appear in a live model list for
+// a provider with the given behavior tag. It returns false for non-chat model IDs
+// (IsChatModelID) and, for the "openrouter" tag, for models that do not resolve in
+// the catalog (ResolveLiveModelInfo) or lack tool support. Other behavior tags do
+// not gate on the catalog: a live /models entry is visible as long as it is a
+// chat model.
+//
+// This consolidates the visibility rule previously duplicated (and drifted)
+// between cmd/evener/internal/launchcheck.launchCheckModelVisible and
+// cmd/evener-hub/web_spawn.go's fetchLiveModels.
+func (c *ModelCatalog) VisibleLiveModel(behaviorTag, modelID string) bool {
+	if !IsChatModelID(modelID) {
+		return false
+	}
+	if behaviorTag != "openrouter" {
+		return true
+	}
+	mi := c.ResolveLiveModelInfo(behaviorTag, modelID)
+	return mi != nil && mi.SupportsTools
+}
+
 // GetLatestModel returns the model for the given provider that best matches the
 // requested capability, selecting the largest context window and breaking ties
 // by lexically greater ID. The capability filter (case-insensitive,

--- a/llm/model_catalog_test.go
+++ b/llm/model_catalog_test.go
@@ -1311,3 +1311,91 @@ func TestMaxOutputTokensFor(t *testing.T) {
 		t.Errorf("nil catalog: got %d, want 0", got)
 	}
 }
+
+// TestVisibleLiveModel_OpenRouterBareLiveID is the regression test for the bug
+// where an OpenRouter provider showed only ~10 models instead of the full
+// catalog. OpenRouter's /v1/models endpoint returns bare IDs like
+// "anthropic/claude-sonnet-4.5", but the embedded LiteLLM catalog keys OpenRouter
+// models as "openrouter/anthropic/claude-sonnet-4.5". The launch-check path did an
+// exact GetModelInfo(bareID) that returned nil, dropping nearly every model.
+// VisibleLiveModel resolves the bare ID via the tag-qualified fallback.
+func TestVisibleLiveModel_OpenRouterBareLiveID(t *testing.T) {
+	cat := EmbeddedModelCatalog()
+
+	// Premise: the catalog keys this model under the openrouter/ prefix only.
+	if cat.GetModelInfo("anthropic/claude-sonnet-4.5") != nil {
+		t.Fatal("test premise broken: bare anthropic/claude-sonnet-4.5 now exists as a key")
+	}
+	if cat.GetModelInfo("openrouter/anthropic/claude-sonnet-4.5") == nil {
+		t.Fatal("test premise broken: openrouter/anthropic/claude-sonnet-4.5 missing from catalog")
+	}
+
+	// The bare live ID must be visible: ResolveLiveModelInfo's tag-qualified
+	// fallback resolves it, and the entry supports tools.
+	if !cat.VisibleLiveModel("openrouter", "anthropic/claude-sonnet-4.5") {
+		t.Error("VisibleLiveModel(openrouter, anthropic/claude-sonnet-4.5) = false, want true")
+	}
+}
+
+// TestVisibleLiveModel_NonChatAndNonToolHidden verifies the two non-openrouter
+// gates: non-chat IDs are always hidden, and openrouter models without tool
+// support are hidden.
+func TestVisibleLiveModel_NonChatAndNonToolHidden(t *testing.T) {
+	cat := EmbeddedModelCatalog()
+
+	// Non-chat IDs are hidden regardless of tag.
+	for _, id := range []string{"text-embedding-3-small", "whisper-1", "tts-1"} {
+		if cat.VisibleLiveModel("openrouter", id) {
+			t.Errorf("non-chat model %q should be hidden", id)
+		}
+		if cat.VisibleLiveModel("openai", id) {
+			t.Errorf("non-chat model %q should be hidden for openai tag", id)
+		}
+	}
+
+	// An OpenRouter model that resolves but lacks tool support is hidden.
+	// openrouter/mistralai/mistral-7b-instruct has supports_function_calling=nil.
+	if mi := cat.ResolveLiveModelInfo("openrouter", "mistralai/mistral-7b-instruct"); mi == nil {
+		t.Skip("catalog changed: mistralai/mistral-7b-instruct no longer resolves via openrouter/ fallback")
+	} else if mi.SupportsTools {
+		t.Skip("catalog changed: mistralai/mistral-7b-instruct now supports tools")
+	}
+	if cat.VisibleLiveModel("openrouter", "mistralai/mistral-7b-instruct") {
+		t.Error("non-tool openrouter model should be hidden")
+	}
+
+	// A non-openrouter tag does not gate on the catalog: a chat model is visible
+	// even when absent from the catalog.
+	if !cat.VisibleLiveModel("openai", "some-uncataloged-chat-model") {
+		t.Error("uncataloged chat model should be visible for non-openrouter tag")
+	}
+
+	// Nil catalog: non-chat IDs are still hidden (IsChatModelID needs no catalog);
+	// chat IDs for openrouter are hidden (cannot resolve tools); chat IDs for
+	// other tags are visible.
+	var nilCat *ModelCatalog
+	if nilCat.VisibleLiveModel("openrouter", "text-embedding-3-small") {
+		t.Error("nil catalog: non-chat model should be hidden")
+	}
+	if nilCat.VisibleLiveModel("openrouter", "gpt-5") {
+		t.Error("nil catalog: openrouter chat model should be hidden (cannot verify tools)")
+	}
+	if !nilCat.VisibleLiveModel("openai", "gpt-5") {
+		t.Error("nil catalog: non-openrouter chat model should be visible")
+	}
+}
+
+// TestResolveLiveModelInfo_OllamaSuppressesBareLookup mirrors the hub's ollama
+// rule: a local ollama model named like an upstream catalog entry must not
+// inherit that entry's metadata — only an explicit ollama/<model> key counts.
+func TestResolveLiveModelInfo_OllamaSuppressesBareLookup(t *testing.T) {
+	cat := EmbeddedModelCatalog()
+	// glm-5.2 exists as a bare catalog key; an ollama instance serving "glm-5.2"
+	// must not pick it up.
+	if cat.GetModelInfo("glm-5.2") == nil {
+		t.Skip("catalog changed: glm-5.2 no longer a bare key")
+	}
+	if mi := cat.ResolveLiveModelInfo("ollama", "glm-5.2"); mi != nil {
+		t.Fatalf("ollama local model inherited upstream metadata: %+v", mi)
+	}
+}


### PR DESCRIPTION
## Problem

After adding an OpenRouter provider, the model picker showed only ~10 models instead of the full catalog.

## Root cause

OpenRouter's /v1/models endpoint returns bare IDs like `anthropic/claude-sonnet-4.5`, but the embedded LiteLLM catalog keys OpenRouter models as `openrouter/anthropic/claude-sonnet-4.5`. The model-picker visibility filter did an exact GetModelInfo(bareID) lookup that returned nil, so nearly every OpenRouter model was dropped -- only models whose bare ID happened to collide with a non-OpenRouter catalog key survived.

This visibility logic was **duplicated across three call sites** that had already drifted:
- `cmd/evener/internal/launchcheck` (the primary picker path -- launch-check) -- exact lookup, no fallback (the bug)
- `cmd/evener-hub/web_spawn.go` (the /api/models fallback) -- had the correct LookupModelInfo + openrouter/ fallback
- `agent/session_set_model.go` (in-session model switching) -- exact lookup, no fallback (same bug)

## Fix

Consolidate into a single shared rule in the `llm` package:

- **IsChatModelID** -- the non-chat skip list (embedding/whisper/tts/dall-e/moderation/audio/transcribe/image)
- **ResolveLiveModelInfo** -- catalog resolution for live model IDs: bare LookupModelInfo first (handles [1m] suffix, namespace stripping, dated-snapshot family fallback, curated overrides), then the tag/id tag-qualified fallback so openrouter-only listings resolve, with the ollama bare-lookup suppression preserved
- **VisibleLiveModel** -- the full visibility gate (non-chat skip + openrouter tools-capability filter)

All three call sites now delegate to these shared helpers, eliminating the drift surface.

## Verification

- `go build ./...` pass
- `go vet ./...` pass
- `make lint` (8 modules) pass
- `go test ./llm/` pass
- `go test ./cmd/evener/internal/launchcheck/` pass
- `go test ./cmd/evener-hub/` pass
- `go test ./agent/` pass
- Regression tests assert a bare OpenRouter live ID (anthropic/claude-sonnet-4.5) survives the filter
