### PR TITLE
test(agent): await quiet attention retry completion

### DIFF
--- a/agent/delegate_resource_supervision_test.go
+++ b/agent/delegate_resource_supervision_test.go
@@ -1282,6 +1282,10 @@ func TestDelegateResourceSupervision_QuietAttentionAppendFailureRetriesSameIdent
 	owner.cfg.testOnly.delegateAttentionReadFold = nil
 	nestedClock.Advance(jobNotificationRetryInitialDelay)
 	<-retryWake
+	// The wake is emitted inside the retry callback before it clears the
+	// resolved arm ID. Wait for that callback to finish before inspecting its
+	// final bookkeeping state.
+	nestedClock.Drain()
 	controller.mu.Lock()
 	ownerAttention := controller.durable["dlg_owner"].NeedsAttention
 	controller.mu.Unlock()


### PR DESCRIPTION
## Summary

Fix a race-detector-only test flake in `TestDelegateResourceSupervision_QuietAttentionAppendFailureRetriesSameIdentity`.

The test waited for `retryWake`, which is emitted inside the fake-clock callback before that callback clears the resolved arm ID, then immediately asserted the final bookkeeping state. Under CI package load, the assertion could run before callback completion.

Use the fake clock's existing `Drain()` completion handshake before inspecting the callback's final state.

## Failure evidence

PR #333's race gate failed with:

```text
nested quiet arm retry = attention:true retrying:true, want true/false
```

Production ordering confirms the fixture race: `armDelegateAttentionOnce` notifies before `scheduleDelegateAttentionArmRetryLocked` removes resolved IDs.

## Verification

- `go test -race ./agent -run '^TestDelegateResourceSupervision_QuietAttentionAppendFailureRetriesSameIdentity$' -count=100` — pass
- `go test -race ./agent -count=1` — pass
- Independent review — approved, no findings
