### PR TITLE
Resolve the cheap model to the session's own when a provider refuses it

### DIFF
--- a/agent/eval_probes.go
+++ b/agent/eval_probes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
@@ -37,11 +38,12 @@ func runRetentionProbes(ctx context.Context, client *llm.Client, profile *provid
 
 	// Build message history from session turns.
 	history := turnsToMessages(sessionHistory)
+	cheap := cheapmodel.New(client)
 
 	var correct int
 	results := make([]probeResult, 0, len(probeQuestions))
 	for _, pq := range probeQuestions {
-		isCorrect, err := runOneProbe(ctx, client, profile, history, pq)
+		isCorrect, err := runOneProbe(ctx, client, cheap, profile, history, pq)
 		if err != nil {
 			return 0, nil, fmt.Errorf("retention probe %q: %w", pq.Question, err)
 		}
@@ -61,7 +63,7 @@ func runRetentionProbes(ctx context.Context, client *llm.Client, profile *provid
 
 // runOneProbe sends a single probe question to the agent, then judges the
 // response against the expected answer. Returns true if the judge says correct.
-func runOneProbe(ctx context.Context, client *llm.Client, profile *provider.Profile, history []llm.Message, pq probeQuestion) (bool, error) {
+func runOneProbe(ctx context.Context, client *llm.Client, cheap *cheapmodel.Caller, profile *provider.Profile, history []llm.Message, pq probeQuestion) (bool, error) {
 	// Step 1: Ask the agent the probe question with the session history.
 	agentMessages := append(append([]llm.Message{}, history...), llm.User(pq.Question))
 	agentReq := llm.Request{
@@ -78,14 +80,11 @@ func runOneProbe(ctx context.Context, client *llm.Client, profile *provider.Prof
 
 	// Step 2: Judge the response using the cheap model with binary scoring.
 	judgePrompt := buildBinaryJudgePrompt(pq.Question, pq.Expected, agentAnswer)
-	cheapProvider, cheapModel := profile.CheapModelRef()
 	judgeReq := llm.Request{
-		Model:    cheapModel,
-		Provider: cheapProvider,
 		Messages: []llm.Message{llm.User(judgePrompt)},
 	}
 
-	judgeResp, err := client.Complete(ctx, judgeReq)
+	judgeResp, err := cheap.Complete(ctx, profile, judgeReq)
 	if err != nil {
 		return false, fmt.Errorf("judge call: %w", err)
 	}

--- a/agent/internal/cheapmodel/caller.go
+++ b/agent/internal/cheapmodel/caller.go
@@ -1,0 +1,133 @@
+// Package cheapmodel routes a session's auxiliary LLM calls and remembers
+// provider/model pairs that the provider has refused to serve.
+package cheapmodel
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+
+	"primeradiant.com/evener/agent/provider"
+	"primeradiant.com/evener/llm"
+)
+
+type route struct {
+	provider string
+	model    string
+}
+
+// Caller executes cheap-model requests for one session.
+type Caller struct {
+	client *llm.Client
+
+	mu      sync.Mutex
+	refused map[route]struct{}
+}
+
+// New returns a session-scoped cheap-model caller.
+func New(client *llm.Client) *Caller {
+	return &Caller{client: client, refused: make(map[route]struct{})}
+}
+
+// Complete resolves and executes a cheap-model request, falling back once to
+// the session model when the provider refuses the resolved model. It resolves
+// through the profile's cheap-model ref, which falls through to the provider's
+// default cheap model when the session configured none.
+func (c *Caller) Complete(ctx context.Context, profile *provider.Profile, req llm.Request) (llm.Response, error) {
+	cheapProvider, cheapModel := profile.CheapModelRef()
+	resp, _, err := c.run(ctx, profile, route{provider: cheapProvider, model: cheapModel}, req)
+	return resp, err
+}
+
+// CompleteConfigured is Complete for work too costly to hand to a model nobody
+// chose: it uses only an explicitly configured cheap model and runs on the
+// session's own model when none is configured, where Complete would fall
+// through to the provider's default cheap model.
+//
+// It reports whether it ran the session model, so a caller that layers routes
+// of its own on top of this one does not re-run a route already tried here.
+func (c *Caller) CompleteConfigured(ctx context.Context, profile *provider.Profile, req llm.Request) (resp llm.Response, ranSessionModel bool, err error) {
+	cheap := route{provider: profile.CheapProvider(), model: profile.ConfiguredCheapModel()}
+	if cheap.model == "" {
+		cheap = sessionModel(profile)
+	}
+	return c.run(ctx, profile, cheap, req)
+}
+
+// run executes one resolution. Both the cheap and the fallback attempt share
+// one API-attempt group so callers see a single logical attempt group covering
+// the whole resolution.
+func (c *Caller) run(ctx context.Context, profile *provider.Profile, cheap route, req llm.Request) (llm.Response, bool, error) {
+	ctx, scope := llm.BeginAPIAttemptGroupScope(ctx)
+	resp, ranSessionModel, err := c.complete(ctx, profile, cheap, req)
+	scope.SettleResult(err)
+	return resp, ranSessionModel, err
+}
+
+func (c *Caller) complete(ctx context.Context, profile *provider.Profile, cheap route, req llm.Request) (llm.Response, bool, error) {
+	active := sessionModel(profile)
+	if cheap != active && !c.serves(cheap) {
+		cheap = active
+	}
+
+	req.Provider, req.Model = cheap.provider, cheap.model
+	resp, err := c.client.Complete(ctx, req)
+	if err == nil || cheap == active || !refusesModel(err) {
+		return resp, cheap == active, err
+	}
+
+	req.Provider, req.Model = active.provider, active.model
+	fallbackResp, fallbackErr := c.client.Complete(ctx, req)
+	if fallbackErr != nil {
+		// Both failures matter to whoever reads this, so join them. The join
+		// order does not settle classification: llm.Kind resolves a joined
+		// error by a fixed precedence over the whole chain, under which the
+		// refusal's KindInvalidRequest outranks a terminal KindServer. What is
+		// load-bearing is WrapContextError, which lifts a bare context deadline
+		// on the fallback attempt into a KindTimeout — a kind that does outrank
+		// KindInvalidRequest — so a session model that ran out of time is not
+		// reported as a bad request.
+		fallbackErr = llm.WrapContextError(active.provider, fallbackErr)
+		return llm.Response{}, true, errors.Join(fallbackErr, err)
+	}
+	c.remember(cheap)
+	return fallbackResp, true, nil
+}
+
+func sessionModel(profile *provider.Profile) route {
+	return route{provider: profile.ID(), model: profile.Model()}
+}
+
+func (c *Caller) serves(r route) bool {
+	c.mu.Lock()
+	_, refused := c.refused[r]
+	c.mu.Unlock()
+	return !refused && c.client.ValidateModelCompatibility(r.provider, r.model) == nil
+}
+
+func (c *Caller) remember(r route) {
+	c.mu.Lock()
+	c.refused[r] = struct{}{}
+	c.mu.Unlock()
+}
+
+// refusesModel reports whether err is the provider saying it will not serve the
+// requested model at all, rather than rejecting this particular request.
+//
+// The two substrings are wordings observed in the field (Codex on a ChatGPT
+// account, and Bedrock). Matching them conservatively is deliberate: a broader
+// match would cost a session its cheap model over an ordinary bad request. The
+// price of that conservatism is maintenance — if a provider rewords its refusal
+// this reactive path silently stops firing and auxiliary calls fail instead of
+// falling back. That degradation is bounded because the proactive half of the
+// pair, serves(), already skips pairs the client's own model-compatibility
+// validator knows about, so a new wording costs the fallback, not the session.
+func refusesModel(err error) bool {
+	if llm.Classify(err) != llm.ErrorClassPermanent {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "model is not supported when using codex with a chatgpt account") ||
+		strings.Contains(message, "provided model identifier is invalid")
+}

--- a/agent/internal/cheapmodel/caller_test.go
+++ b/agent/internal/cheapmodel/caller_test.go
@@ -1,0 +1,400 @@
+package cheapmodel_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/internal/agenttest"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
+	"primeradiant.com/evener/agent/provider"
+	"primeradiant.com/evener/llm"
+	apilog "primeradiant.com/evener/llm/apilog"
+)
+
+func refusal(status int, message string) func(string, string) error {
+	return func(prov, _ string) error {
+		return llm.ErrorFromHTTPStatus(prov, status, message, nil, nil)
+	}
+}
+
+func servesOnly(name, served string, reject func(string, string) error) *agenttest.ModelTrackingAdapter {
+	a := &agenttest.ModelTrackingAdapter{Provider: name}
+	a.Respond = func(req llm.Request) (llm.Response, error) {
+		if req.Model != served {
+			return llm.Response{}, reject(name, req.Model)
+		}
+		return llm.Response{Message: llm.Assistant("answered")}, nil
+	}
+	return a
+}
+
+func clientWith(adapters ...llm.ProviderAdapter) *llm.Client {
+	client := llm.NewClient()
+	for _, adapter := range adapters {
+		client.Register(adapter)
+	}
+	return client
+}
+
+func complete(t *testing.T, caller *cheapmodel.Caller, profile *provider.Profile) (llm.Response, error) {
+	t.Helper()
+	return caller.Complete(context.Background(), profile, llm.Request{
+		Provider: "ignored",
+		Model:    "ignored",
+		Messages: []llm.Message{llm.User("hi")},
+	})
+}
+
+func TestCallerFallsBackAndRemembersObservedRefusals(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+	}{
+		{"codex", "The 'gpt-4.1-nano' model is not supported when using Codex with a ChatGPT account"},
+		{"bedrock", "The provided model identifier is invalid."},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			adapter := servesOnly("openai", "main", refusal(400, test.message))
+			caller := cheapmodel.New(clientWith(adapter))
+			profile := provider.NewOpenAIProfile("main")
+
+			for range 2 {
+				resp, err := complete(t, caller, profile)
+				if err != nil || strings.TrimSpace(resp.Text()) != "answered" {
+					t.Fatalf("Complete = (%q, %v), want answered", resp.Text(), err)
+				}
+			}
+			if got, want := adapter.Models(), []string{"gpt-4.1-nano", "main", "main"}; !slices.Equal(got, want) {
+				t.Fatalf("models = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestCallerDoesNotGeneralizeRequestErrorsIntoModelRefusals(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		message string
+	}{
+		{"invalid request", 400, "invalid field: response_format"},
+		{"access denied", 403, "request forbidden by organization policy"},
+		{"not found", 404, "requested resource not found"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			adapter := servesOnly("openai", "main", refusal(test.status, test.message))
+			caller := cheapmodel.New(clientWith(adapter))
+			profile := provider.NewOpenAIProfile("main")
+
+			for range 2 {
+				if _, err := complete(t, caller, profile); err == nil {
+					t.Fatal("Complete succeeded, want request error")
+				}
+			}
+			if got, want := adapter.Models(), []string{"gpt-4.1-nano", "gpt-4.1-nano"}; !slices.Equal(got, want) {
+				t.Fatalf("models = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// TestCallerIgnoresRefusalWordingOnARetryableError pins the permanence gate in
+// refusesModel: a transient failure that happens to carry refusal wording (a 429
+// whose body echoes the model-identifier complaint) is a "try again later", not
+// "this provider will never serve this model". Falling back on it would abandon
+// the cheap model over a blip, and latching it would make that abandonment
+// permanent for the session.
+func TestCallerIgnoresRefusalWordingOnARetryableError(t *testing.T) {
+	adapter := servesOnly("openai", "main", refusal(429, "The provided model identifier is invalid."))
+	caller := cheapmodel.New(clientWith(adapter))
+	profile := provider.NewOpenAIProfile("main")
+
+	for range 2 {
+		_, err := complete(t, caller, profile)
+		if err == nil {
+			t.Fatal("Complete succeeded, want the rate-limit error")
+		}
+		if llm.Classify(err) != llm.ErrorClassRetryable {
+			t.Fatalf("error class = %v, want retryable", llm.Classify(err))
+		}
+	}
+	// Two cheap attempts and no session-model attempt: no fallback, no latch.
+	if got, want := adapter.Models(), []string{"gpt-4.1-nano", "gpt-4.1-nano"}; !slices.Equal(got, want) {
+		t.Fatalf("models = %v, want %v", got, want)
+	}
+}
+
+// TestCallerDoesNotRetryWhenTheCheapModelIsTheSessionModel pins the cheap ==
+// active guard: with the cheap ref pointing at the session's own model there is
+// nothing to fall back to, so a refusal must surface after a single request
+// rather than repeating the identical call.
+func TestCallerDoesNotRetryWhenTheCheapModelIsTheSessionModel(t *testing.T) {
+	adapter := servesOnly("openai", "unreachable", refusal(400, "The provided model identifier is invalid."))
+	caller := cheapmodel.New(clientWith(adapter))
+	profile := provider.WithCheapModel(provider.NewOpenAIProfile("main"), "main")
+
+	_, err := complete(t, caller, profile)
+	if err == nil || !strings.Contains(err.Error(), "model identifier") {
+		t.Fatalf("Complete error = %v, want the refusal", err)
+	}
+	if got, want := adapter.Models(), []string{"main"}; !slices.Equal(got, want) {
+		t.Fatalf("models = %v, want %v (no identical retry)", got, want)
+	}
+}
+
+func TestCallerUsesStaticCompatibilityWithoutAProbe(t *testing.T) {
+	tracker := servesOnly("openai", "main", refusal(400, "unexpected model"))
+	adapter := &declaredModelAdapter{ModelTrackingAdapter: tracker, served: "main"}
+	caller := cheapmodel.New(clientWith(adapter))
+
+	if _, err := complete(t, caller, provider.NewOpenAIProfile("main")); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if got, want := tracker.Models(), []string{"main"}; !slices.Equal(got, want) {
+		t.Fatalf("models = %v, want %v", got, want)
+	}
+}
+
+func TestCallerReturnsBothErrorsWhenFallbackFails(t *testing.T) {
+	adapter := &agenttest.ModelTrackingAdapter{Provider: "openai"}
+	adapter.Respond = func(req llm.Request) (llm.Response, error) {
+		if req.Model == "gpt-4.1-nano" {
+			return llm.Response{}, llm.ErrorFromHTTPStatus("openai", 400,
+				"The provided model identifier is invalid.", nil, nil)
+		}
+		return llm.Response{}, context.DeadlineExceeded
+	}
+	caller := cheapmodel.New(clientWith(adapter))
+
+	_, err := complete(t, caller, provider.NewOpenAIProfile("main"))
+	if !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "model identifier") {
+		t.Fatalf("Complete error = %v, want refusal and deadline", err)
+	}
+	if got := llm.Kind(err); got != llm.KindTimeout {
+		t.Fatalf("error kind = %s, want fallback kind %s", got, llm.KindTimeout)
+	}
+}
+
+// TestCompleteConfiguredPrefersTheSessionModelOverAProviderDefault covers the
+// entry point summarization uses: with no cheap model configured it runs the
+// session's own model rather than the provider's default cheap one, and it says
+// so, so a caller layering its own routes does not repeat the session model.
+func TestCompleteConfiguredPrefersTheSessionModelOverAProviderDefault(t *testing.T) {
+	adapter := servesOnly("openai", "main", refusal(400, "unexpected model"))
+	caller := cheapmodel.New(clientWith(adapter))
+
+	resp, ranSessionModel, err := caller.CompleteConfigured(context.Background(),
+		provider.NewOpenAIProfile("main"), llm.Request{Messages: []llm.Message{llm.User("hi")}})
+	if err != nil || strings.TrimSpace(resp.Text()) != "answered" {
+		t.Fatalf("CompleteConfigured = (%q, %v), want answered", resp.Text(), err)
+	}
+	if !ranSessionModel {
+		t.Fatal("ranSessionModel = false, want true")
+	}
+	if got, want := adapter.Models(), []string{"main"}; !slices.Equal(got, want) {
+		t.Fatalf("models = %v, want %v", got, want)
+	}
+}
+
+// TestCompleteConfiguredReportsTheRoutesItRan covers the configured-cheap
+// branch: the cheap model runs first and the session model is reported only
+// once the caller has actually fallen back onto it.
+func TestCompleteConfiguredReportsTheRoutesItRan(t *testing.T) {
+	adapter := servesOnly("openai", "main", refusal(400, "The provided model identifier is invalid."))
+	adapter.Respond = func(req llm.Request) (llm.Response, error) {
+		switch req.Model {
+		case "cheap":
+			return llm.Response{Message: llm.Assistant("cheap answered")}, nil
+		case "main":
+			return llm.Response{Message: llm.Assistant("main answered")}, nil
+		}
+		return llm.Response{}, llm.ErrorFromHTTPStatus("openai", 400, "The provided model identifier is invalid.", nil, nil)
+	}
+	caller := cheapmodel.New(clientWith(adapter))
+	profile := provider.WithCheapModel(provider.NewOpenAIProfile("main"), "cheap")
+
+	resp, ranSessionModel, err := caller.CompleteConfigured(context.Background(), profile,
+		llm.Request{Messages: []llm.Message{llm.User("hi")}})
+	if err != nil || strings.TrimSpace(resp.Text()) != "cheap answered" {
+		t.Fatalf("CompleteConfigured = (%q, %v), want the cheap model's answer", resp.Text(), err)
+	}
+	if ranSessionModel {
+		t.Fatal("ranSessionModel = true after a cheap success, want false")
+	}
+
+	refusedProfile := provider.WithCheapModel(provider.NewOpenAIProfile("main"), "refused")
+	resp, ranSessionModel, err = caller.CompleteConfigured(context.Background(), refusedProfile,
+		llm.Request{Messages: []llm.Message{llm.User("hi")}})
+	if err != nil || strings.TrimSpace(resp.Text()) != "main answered" {
+		t.Fatalf("CompleteConfigured = (%q, %v), want the session model's answer", resp.Text(), err)
+	}
+	if !ranSessionModel {
+		t.Fatal("ranSessionModel = false after falling back, want true")
+	}
+}
+
+func TestCallerKeepsRefusalsAcrossModelSwitchButNotProviderSwitch(t *testing.T) {
+	openAI := &agenttest.ModelTrackingAdapter{Provider: "openai"}
+	openAI.Respond = func(req llm.Request) (llm.Response, error) {
+		if req.Model == "gpt-4.1-nano" {
+			return llm.Response{}, llm.ErrorFromHTTPStatus("openai", 400, "The provided model identifier is invalid.", nil, nil)
+		}
+		return llm.Response{Message: llm.Assistant("answered")}, nil
+	}
+	bedrock := servesOnly("bedrock", "bedrock-main", refusal(400, "The provided model identifier is invalid."))
+	caller := cheapmodel.New(clientWith(openAI, bedrock))
+
+	if _, err := complete(t, caller, provider.NewOpenAIProfile("main")); err != nil {
+		t.Fatalf("openai Complete: %v", err)
+	}
+	if _, err := complete(t, caller, provider.NewOpenAIProfile("main-2")); err != nil {
+		t.Fatalf("switched Complete: %v", err)
+	}
+	if got, want := openAI.Models(), []string{"gpt-4.1-nano", "main", "main-2"}; !slices.Equal(got, want) {
+		t.Fatalf("openai models = %v, want %v", got, want)
+	}
+	bedrockProfile := provider.WithProviderID(provider.NewOpenAIProfile("bedrock-main"), "bedrock")
+	if _, err := complete(t, caller, bedrockProfile); err != nil {
+		t.Fatalf("bedrock Complete: %v", err)
+	}
+	if got, want := bedrock.Models(), []string{"gpt-4.1-nano", "bedrock-main"}; !slices.Equal(got, want) {
+		t.Fatalf("bedrock models = %v, want %v", got, want)
+	}
+}
+
+type declaredModelAdapter struct {
+	*agenttest.ModelTrackingAdapter
+	served string
+}
+
+func (a *declaredModelAdapter) ValidateModel(model string) error {
+	if model == a.served {
+		return nil
+	}
+	return fmt.Errorf("model %s is not supported (served: %s)", model, a.served)
+}
+
+// recordingSink is an APIAttemptSink that also satisfies Middleware so it can be
+// registered on a client. It records attempts and settlements without durable
+// storage so tests can assert group/attempt/settlement counts.
+type recordingSink struct {
+	mu          sync.Mutex
+	attempts    []apilog.APIAttemptRecord
+	settlements []apilog.APIAttemptGroupSettlement
+}
+
+func (s *recordingSink) AppendAttempt(_ context.Context, rec apilog.APIAttemptRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.attempts = append(s.attempts, rec)
+	return nil
+}
+
+func (s *recordingSink) AppendSettlement(_ context.Context, rec apilog.APIAttemptGroupSettlement) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.settlements = append(s.settlements, rec)
+	return nil
+}
+
+func (s *recordingSink) WrapComplete(next llm.CompleteFunc) llm.CompleteFunc {
+	return func(ctx context.Context, req llm.Request) (llm.Response, error) {
+		return next(ctx, req)
+	}
+}
+
+func (s *recordingSink) WrapStream(next llm.StreamFunc) llm.StreamFunc {
+	return func(ctx context.Context, req llm.Request) (llm.Stream, error) {
+		return next(ctx, req)
+	}
+}
+
+func (s *recordingSink) snapshot() ([]apilog.APIAttemptRecord, []apilog.APIAttemptGroupSettlement) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.attempts), slices.Clone(s.settlements)
+}
+
+// attemptRecordingAdapter wraps ModelTrackingAdapter and emits a canonical
+// API attempt for each Complete call so a recordingSink can observe attempts.
+// Real HTTP transports do this in the transport layer; fake adapters must do
+// it explicitly.
+type attemptRecordingAdapter struct {
+	*agenttest.ModelTrackingAdapter
+}
+
+func (a *attemptRecordingAdapter) Complete(ctx context.Context, req llm.Request) (llm.Response, error) {
+	resp, err := a.ModelTrackingAdapter.Complete(ctx, req)
+	startedAt := time.Now()
+	meta := llm.APIAttemptMeta{
+		ProviderInstance: a.Provider,
+		RequestModel:     req.Model,
+		Method:           "POST",
+		Endpoint:         "https://" + a.Provider + ".invalid/v1/complete",
+		RequestBody:      []byte(`{"input":"test"}`),
+		StartedAt:        startedAt,
+	}
+	attempt := llm.BeginAPIAttempt(ctx, meta)
+	result := llm.APIAttemptResult{
+		StatusCode:   http.StatusOK,
+		ResponseBody: []byte(`{"output":"ok"}`),
+		Response:     &resp,
+		Outcome:      apilog.AttemptSuccess,
+		FinishedAt:   startedAt.Add(time.Millisecond),
+	}
+	if err != nil {
+		result.StatusCode = http.StatusBadRequest
+		result.Response = nil
+		result.Outcome = apilog.AttemptProviderReject
+		result.Err = err
+	}
+	attempt.Complete(result)
+	return resp, err
+}
+
+// TestCallerEmitsOneAttemptGroupForCheapAndFallback asserts that a fallback
+// resolution produces one shared API-attempt group: two attempts (cheap then
+// fallback) with the same group ID, and exactly one settlement.
+func TestCallerEmitsOneAttemptGroupForCheapAndFallback(t *testing.T) {
+	inner := servesOnly("openai", "main", refusal(400, "The provided model identifier is invalid."))
+	adapter := &attemptRecordingAdapter{ModelTrackingAdapter: inner}
+	sink := &recordingSink{}
+	client := llm.NewClient()
+	client.Register(adapter)
+	client.Use(sink)
+	caller := cheapmodel.New(client)
+
+	resp, err := complete(t, caller, provider.NewOpenAIProfile("main"))
+	if err != nil || strings.TrimSpace(resp.Text()) != "answered" {
+		t.Fatalf("Complete = (%q, %v), want answered", resp.Text(), err)
+	}
+
+	attempts, settlements := sink.snapshot()
+	if len(attempts) != 2 {
+		t.Fatalf("attempt count = %d, want 2 (cheap + fallback)", len(attempts))
+	}
+	if len(settlements) != 1 {
+		t.Fatalf("settlement count = %d, want 1", len(settlements))
+	}
+	groupID := attempts[0].AttemptGroupID
+	for i, a := range attempts {
+		if a.AttemptGroupID != groupID {
+			t.Fatalf("attempt %d group = %q, want %q (one shared group)", i+1, a.AttemptGroupID, groupID)
+		}
+	}
+	if settlements[0].AttemptGroupID != groupID {
+		t.Fatalf("settlement group = %q, want %q", settlements[0].AttemptGroupID, groupID)
+	}
+	if settlements[0].FinalAttemptCount != 2 {
+		t.Fatalf("settlement final attempt count = %d, want 2", settlements[0].FinalAttemptCount)
+	}
+}

--- a/agent/internal/contextmgr/attempt_group_test.go
+++ b/agent/internal/contextmgr/attempt_group_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
 	apilog "primeradiant.com/evener/llm/apilog"
@@ -68,7 +69,7 @@ func TestElicitNoteOwnsOneLogicalAttemptGroupAcrossRouteFallback(t *testing.T) {
 		&contextManagerAttemptAdapter{name: "anthropic", err: cheapErr},
 		&contextManagerAttemptAdapter{name: "openai", text: "- survived"},
 	)
-	cm := NewManager(WithCheapModel(NewOpenAIProfile("gpt-5.2"), "anthropic/claude-haiku-4-5-20251001"), client)
+	cm := NewManager(WithCheapModel(NewOpenAIProfile("gpt-5.2"), "anthropic/claude-haiku-4-5-20251001"), client, cheapmodel.New(client))
 
 	got, err := cm.ElicitNote(context.Background(), []schema.Turn{
 		{Kind: schema.TurnUserInput, Message: llm.User("preserve this")},
@@ -89,7 +90,7 @@ func TestSummarizeWithLLMOwnsOneLogicalAttemptGroupWhenAllRoutesFail(t *testing.
 		&contextManagerAttemptAdapter{name: "anthropic", err: cheapErr},
 		&contextManagerAttemptAdapter{name: "openai", err: activeErr},
 	)
-	cm := NewManager(WithCheapModel(NewOpenAIProfile("gpt-5.2"), "anthropic/claude-haiku-4-5-20251001"), client)
+	cm := NewManager(WithCheapModel(NewOpenAIProfile("gpt-5.2"), "anthropic/claude-haiku-4-5-20251001"), client, cheapmodel.New(client))
 	history := []schema.Turn{
 		{Kind: schema.TurnUserInput, Message: llm.User("task")},
 		{Kind: schema.TurnAssistant, Message: llm.Assistant("old")},

--- a/agent/internal/contextmgr/compaction_comparison_eval_test.go
+++ b/agent/internal/contextmgr/compaction_comparison_eval_test.go
@@ -17,7 +17,7 @@ package contextmgr
 // "<stateHome>/evener") finds the real record, builds a
 // client via llm.NewFromAvailableProviders (which threads StateHome from
 // XDG_STATE_HOME into the openai factory), and resolve the "openai" profile via
-// provider.ResolveProfileFromConfig. NewManager(profile, client) then summarizes
+// provider.ResolveProfileFromConfig. NewManager(profile, client, cheapmodel.New(client)) then summarizes
 // through the OAuth-backed Codex backend.
 //
 // Three arms per case (all combined-output scored):
@@ -38,6 +38,7 @@ import (
 	"testing"
 	"time"
 
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/internal/liveeval"
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
@@ -95,7 +96,7 @@ func newOAuthManager(t *testing.T) *Manager {
 		t.Fatalf("ResolveProfileFromConfig openai/%s: %v", evalModel, err)
 	}
 
-	return NewManager(prof, client)
+	return NewManager(prof, client, cheapmodel.New(client))
 }
 
 func liveEvalOAuthPaths(t *testing.T) (string, string) {

--- a/agent/internal/contextmgr/compaction_kind_test.go
+++ b/agent/internal/contextmgr/compaction_kind_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
 )
@@ -47,7 +48,7 @@ func TestSummarizeWithLLM_UsesTurnSummaryKind(t *testing.T) {
 	client := llm.NewClient()
 	client.Register(adapter)
 
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client, cheapmodel.New(client))
 
 	history := []schema.Turn{
 		{Kind: schema.TurnUserInput, Message: llm.User("Fix the auth bug")},
@@ -102,7 +103,7 @@ func TestSummarizeWithLLM_RoutesToCheapProvider(t *testing.T) {
 	client.Register(cheapAdapter)
 
 	profile := WithCheapModel(NewOpenAIProfile("gpt-5.2"), "anthropic/claude-haiku-4-5-20251001")
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 
 	history := []schema.Turn{
 		{Kind: schema.TurnUserInput, Message: llm.User("Fix the auth bug")},
@@ -119,7 +120,7 @@ func TestSummarizeWithLLM_RoutesToCheapProvider(t *testing.T) {
 func TestMaybeCompact_CallsOnCompactionTurn(t *testing.T) {
 	// Use a tiny context window to force checkpoint (L3).
 	profile := testProfile("openai", "test", 500)
-	cm := NewManager(profile, nil)
+	cm := NewManager(profile, nil, cheapmodel.New(nil))
 	cm.PreserveRecentTurns = 2
 
 	// Use assistant text (not tool results) so observation masking can't reduce pressure.

--- a/agent/internal/contextmgr/compaction_multineedle_eval_test.go
+++ b/agent/internal/contextmgr/compaction_multineedle_eval_test.go
@@ -35,6 +35,7 @@ import (
 	"testing"
 	"time"
 
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/envvars"
 	"primeradiant.com/evener/llm"
@@ -239,7 +240,7 @@ func managerForModel(t *testing.T, client *llm.Client, cfg providercfg.Config, m
 	if err != nil {
 		t.Fatalf("ResolveProfileFromConfig openai/%s: %v", model, err)
 	}
-	return NewManager(prof, client)
+	return NewManager(prof, client, cheapmodel.New(client))
 }
 
 // retention returns the fraction of the case's facts present in out.

--- a/agent/internal/contextmgr/compaction_seqfuzz_test.go
+++ b/agent/internal/contextmgr/compaction_seqfuzz_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
 
@@ -134,7 +135,7 @@ type compactionModel struct {
 }
 
 func newCompactionModel(preserveRecent int) *compactionModel {
-	cm := NewManager(testProfile("openai", "test", 1_000_000), nil)
+	cm := NewManager(testProfile("openai", "test", 1_000_000), nil, cheapmodel.New(nil))
 	cm.PreserveRecentTurns = preserveRecent
 	return &compactionModel{preserveRecent: preserveRecent, cm: cm}
 }

--- a/agent/internal/contextmgr/context_manager.go
+++ b/agent/internal/contextmgr/context_manager.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 
 	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
@@ -72,6 +73,7 @@ func WithCompactionTurnCallback(ctx context.Context, callback func(schema.Turn))
 type Manager struct {
 	profile  *provider.Profile
 	client   *llm.Client
+	cheap    *cheapmodel.Caller
 	cumUsage llm.Usage
 	mu       sync.Mutex
 
@@ -120,11 +122,15 @@ func (cm *Manager) handleCompactionTurn(ctx context.Context, turn schema.Turn) {
 	}
 }
 
-// NewManager creates a Manager with default thresholds.
-func NewManager(profile *provider.Profile, client *llm.Client) *Manager {
+// NewManager creates a Manager with default thresholds. cheap is the session's
+// auxiliary caller; it must be the one the rest of the session shares, so that
+// a model the provider refuses is learned once for the whole session rather
+// than once per compaction layer.
+func NewManager(profile *provider.Profile, client *llm.Client, cheap *cheapmodel.Caller) *Manager {
 	return &Manager{
 		profile:                  profile,
 		client:                   client,
+		cheap:                    cheap,
 		ObservationMaskThreshold: 0.60,
 		ThinkingClearThreshold:   0.70,
 		WarnThreshold:            0.75,
@@ -132,6 +138,10 @@ func NewManager(profile *provider.Profile, client *llm.Client) *Manager {
 		SummarizeThreshold:       0.95,
 		PreserveRecentTurns:      6,
 	}
+}
+
+func (cm *Manager) completeCheap(ctx context.Context, req llm.Request) (llm.Response, error) {
+	return cm.cheap.Complete(ctx, cm.currentProfile(), req)
 }
 
 func (cm *Manager) resultToolName() string {
@@ -1087,6 +1097,31 @@ func shouldFallbackSummarizationModel(ctx context.Context, err error) bool {
 	}
 }
 
+// completeSummarization runs prompt on the summarizer's routes. The cheap
+// caller owns the first rung — it picks the configured cheap model, or the
+// session model when none is configured, and handles a refused cheap model
+// itself. This adds the second rung: summarization treats a wider class of
+// failures than a model refusal as worth another model, and retries on the
+// session model — but only when the cheap caller has not already run it.
+func (cm *Manager) completeSummarization(ctx context.Context, profile *provider.Profile, prompt string) (llm.Response, error) {
+	routes := summarizationModels(profile)
+	if len(routes) == 0 {
+		return llm.Response{}, errors.New("summarization model is empty")
+	}
+	req := llm.Request{Messages: []llm.Message{llm.User(prompt)}}
+	callCtx, attemptGroupScope := llm.BeginAPIAttemptGroupScope(ctx)
+	resp, ranSessionModel, err := cm.cheap.CompleteConfigured(callCtx, profile, req)
+	if err != nil && !ranSessionModel && len(routes) > 1 && shouldFallbackSummarizationModel(ctx, err) {
+		// More than one route means the second is the session model, distinct
+		// from the configured cheap one; the caller ran only the cheap one.
+		sessionRoute := routes[len(routes)-1]
+		req.Provider, req.Model = sessionRoute.provider, sessionRoute.model
+		resp, err = cm.client.Complete(callCtx, req)
+	}
+	attemptGroupScope.SettleResult(err)
+	return resp, err
+}
+
 // defaultSummaryPrefix is the instruction block used when no caller instructions
 // are provided. It mandates seven specific sections and directs the LLM to
 // err on the side of verbosity.
@@ -1181,31 +1216,13 @@ func (cm *Manager) ElicitNote(ctx context.Context, history []schema.Turn) (strin
 		return "", errors.New("note elicitation requires an LLM client")
 	}
 	prof := cm.currentProfile()
-	routes := summarizationModels(prof)
-	if len(routes) == 0 {
+	if len(summarizationModels(prof)) == 0 {
 		return "", errors.New("no model available for note elicitation")
 	}
 	prompt := noteElicitationPrompt + "\n\n--- CONVERSATION SO FAR ---\n" + renderHistoryForElicit(history, noteElicitChars)
-	var resp llm.Response
-	var lastErr error
-	callCtx, attemptGroupScope := llm.BeginAPIAttemptGroupScope(ctx)
-	for _, route := range routes {
-		req := llm.Request{
-			Model:    route.model,
-			Provider: route.provider,
-			Messages: []llm.Message{llm.User(prompt)},
-		}
-		resp, lastErr = cm.client.Complete(callCtx, req)
-		if lastErr == nil {
-			break
-		}
-		if route != routes[len(routes)-1] && !shouldFallbackSummarizationModel(ctx, lastErr) {
-			break
-		}
-	}
-	attemptGroupScope.SettleResult(lastErr)
-	if lastErr != nil {
-		return "", lastErr
+	resp, err := cm.completeSummarization(ctx, prof, prompt)
+	if err != nil {
+		return "", err
 	}
 	return strings.TrimSpace(resp.Text()), nil
 }
@@ -1376,30 +1393,9 @@ func (cm *Manager) summarizeWithLLMSteered(ctx context.Context, history []schema
 	prompt := buildSummaryPrompt(b.String(), instructions)
 
 	sumProfile := cm.currentProfile()
-	routes := summarizationModels(sumProfile)
-	if len(routes) == 0 {
-		return nil, errors.New("summarization model is empty")
-	}
-	var resp llm.Response
-	var lastErr error
-	callCtx, attemptGroupScope := llm.BeginAPIAttemptGroupScope(ctx)
-	for _, route := range routes {
-		req := llm.Request{
-			Model:    route.model,
-			Provider: route.provider,
-			Messages: []llm.Message{llm.User(prompt)},
-		}
-		resp, lastErr = cm.client.Complete(callCtx, req)
-		if lastErr == nil {
-			break
-		}
-		if route != routes[len(routes)-1] && !shouldFallbackSummarizationModel(ctx, lastErr) {
-			break
-		}
-	}
-	attemptGroupScope.SettleResult(lastErr)
-	if lastErr != nil {
-		return nil, lastErr
+	resp, err := cm.completeSummarization(ctx, sumProfile, prompt)
+	if err != nil {
+		return nil, err
 	}
 
 	summaryText := "[CONTEXT SUMMARY]\n" + resp.Text() + "\n[END SUMMARY]"

--- a/agent/internal/contextmgr/context_manager_coverage_test.go
+++ b/agent/internal/contextmgr/context_manager_coverage_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
 )
@@ -15,7 +16,7 @@ import (
 // the system-prompt budget, and Remaining is the window minus that.
 func TestEstimateUsage_NoPriorMeasurement(t *testing.T) {
 	const window = 1_000_000
-	cm := NewManager(testProfile("openai", "gpt-5.2", window), nil)
+	cm := NewManager(testProfile("openai", "gpt-5.2", window), nil, cheapmodel.New(nil))
 	history := []schema.Turn{
 		{Kind: schema.TurnUserInput, Message: llm.User("write a parser for the config file")},
 		{Kind: schema.TurnAssistant, Message: llm.Assistant("Sure, here is the plan.")},
@@ -40,7 +41,7 @@ func TestEstimateUsage_NoPriorMeasurement(t *testing.T) {
 // the window, and Remaining must floor at 0 rather than go negative.
 func TestEstimateUsage_RemainingClampedToZero(t *testing.T) {
 	const window = 1_000
-	cm := NewManager(testProfile("openai", "gpt-5.2", window), nil)
+	cm := NewManager(testProfile("openai", "gpt-5.2", window), nil, cheapmodel.New(nil))
 	m := cm.EstimateUsage(nil, window*8)
 	if m.Used <= window {
 		t.Fatalf("Used = %d, want > window %d for this case", m.Used, window)
@@ -57,7 +58,7 @@ func TestApplyThresholdScale(t *testing.T) {
 	const eps = 1e-9
 
 	t.Run("scales every threshold, no clamp needed", func(t *testing.T) {
-		cm := NewManager(testProfile("openai", "gpt-5.2", 1_000), nil)
+		cm := NewManager(testProfile("openai", "gpt-5.2", 1_000), nil, cheapmodel.New(nil))
 		ApplyThresholdScale(cm, 0.5)
 		for _, c := range []struct {
 			name string
@@ -77,7 +78,7 @@ func TestApplyThresholdScale(t *testing.T) {
 	})
 
 	t.Run("clamps thresholds below the 0.20 floor", func(t *testing.T) {
-		cm := NewManager(testProfile("openai", "gpt-5.2", 1_000), nil)
+		cm := NewManager(testProfile("openai", "gpt-5.2", 1_000), nil, cheapmodel.New(nil))
 		ApplyThresholdScale(cm, 0.25) // 0.60*0.25=0.15 -> floor, 0.95*0.25=0.2375 stays
 		if d := cm.ObservationMaskThreshold - 0.20; d > eps || d < -eps {
 			t.Errorf("ObservationMask = %v, want clamped to 0.20", cm.ObservationMaskThreshold)
@@ -89,7 +90,7 @@ func TestApplyThresholdScale(t *testing.T) {
 
 	for _, scale := range []float64{0, 1.0} {
 		t.Run("no-op", func(t *testing.T) {
-			cm := NewManager(testProfile("openai", "gpt-5.2", 1_000), nil)
+			cm := NewManager(testProfile("openai", "gpt-5.2", 1_000), nil, cheapmodel.New(nil))
 			ApplyThresholdScale(cm, scale)
 			if cm.ObservationMaskThreshold != 0.60 || cm.SummarizeThreshold != 0.95 {
 				t.Errorf("scale %v changed thresholds: obs=%v sum=%v", scale, cm.ObservationMaskThreshold, cm.SummarizeThreshold)
@@ -101,10 +102,10 @@ func TestApplyThresholdScale(t *testing.T) {
 // TestHasClient covers the HasClient predicate (gremlins flagged
 // context_manager.go:1057 as not covered).
 func TestHasClient(t *testing.T) {
-	if NewManager(testProfile("openai", "gpt-5.2", 1_000), nil).HasClient() {
+	if NewManager(testProfile("openai", "gpt-5.2", 1_000), nil, cheapmodel.New(nil)).HasClient() {
 		t.Error("HasClient() = true for a nil client, want false")
 	}
-	if !NewManager(testProfile("openai", "gpt-5.2", 1_000), llm.NewClient()).HasClient() {
+	if !NewManager(testProfile("openai", "gpt-5.2", 1_000), llm.NewClient(), cheapmodel.New(llm.NewClient())).HasClient() {
 		t.Error("HasClient() = false with a client, want true")
 	}
 }
@@ -112,7 +113,7 @@ func TestHasClient(t *testing.T) {
 // TestElicitNote_RequiresClient covers the no-client guard in ElicitNote
 // (context_manager.go:1069).
 func TestElicitNote_RequiresClient(t *testing.T) {
-	cm := NewManager(testProfile("openai", "gpt-5.2", 1_000), nil)
+	cm := NewManager(testProfile("openai", "gpt-5.2", 1_000), nil, cheapmodel.New(nil))
 	if _, err := cm.ElicitNote(context.Background(), nil); err == nil {
 		t.Fatal("ElicitNote with no client: want an error")
 	}
@@ -132,7 +133,7 @@ func TestElicitNote_Success(t *testing.T) {
 	}
 	client := llm.NewClient()
 	client.Register(adapter)
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client, cheapmodel.New(client))
 
 	history := []schema.Turn{
 		{Kind: schema.TurnToolResults, Message: llm.ToolResultNamed("c1", "shell", "API key is secret-token-XYZ", false)},
@@ -170,7 +171,7 @@ func TestElicitNote_FallsBackAcrossModels(t *testing.T) {
 	client.Register(active)
 
 	profile := WithCheapModel(NewOpenAIProfile("gpt-5.2"), "anthropic/claude-haiku-4-5-20251001")
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 
 	got, err := cm.ElicitNote(context.Background(), []schema.Turn{
 		{Kind: schema.TurnUserInput, Message: llm.User("do the thing")},
@@ -183,6 +184,65 @@ func TestElicitNote_FallsBackAcrossModels(t *testing.T) {
 	}
 	if got != "- survived" {
 		t.Errorf("note = %q, want the active-route result", got)
+	}
+}
+
+func TestElicitNoteRemembersARefusedCheapModel(t *testing.T) {
+	cheapCalls, activeCalls := 0, 0
+	cheap := &stubSummarizeAdapter{name: "anthropic", respFn: func(llm.Request) (llm.Response, error) {
+		cheapCalls++
+		return llm.Response{}, llm.ErrorFromHTTPStatus("anthropic", 400, "The provided model identifier is invalid.", nil, nil)
+	}}
+	active := &stubSummarizeAdapter{name: "openai", respFn: func(llm.Request) (llm.Response, error) {
+		activeCalls++
+		return llm.Response{Message: llm.Assistant("- survived")}, nil
+	}}
+	client := llm.NewClient()
+	client.Register(cheap)
+	client.Register(active)
+	cm := NewManager(WithCheapModel(NewOpenAIProfile("gpt-5.2"), "anthropic/haiku"), client, cheapmodel.New(client))
+
+	for range 2 {
+		if _, err := cm.ElicitNote(context.Background(), nil); err != nil {
+			t.Fatalf("ElicitNote: %v", err)
+		}
+	}
+	if cheapCalls != 1 || activeCalls != 2 {
+		t.Fatalf("calls = cheap:%d active:%d, want cheap:1 active:2", cheapCalls, activeCalls)
+	}
+}
+
+// TestElicitNoteDoesNotRepeatARouteTheCheapCallerAlreadyRan pins the seam
+// between the two fallback ladders: once the cheap model is latched as refused,
+// the cheap caller runs the session model itself, so a fallback-eligible failure
+// there is terminal. Re-running the summarizer's own session-model route on top
+// would bill the same doomed request twice.
+func TestElicitNoteDoesNotRepeatARouteTheCheapCallerAlreadyRan(t *testing.T) {
+	activeCalls := 0
+	cheap := &stubSummarizeAdapter{name: "anthropic", respFn: func(llm.Request) (llm.Response, error) {
+		return llm.Response{}, llm.ErrorFromHTTPStatus("anthropic", 400, "The provided model identifier is invalid.", nil, nil)
+	}}
+	active := &stubSummarizeAdapter{name: "openai", respFn: func(llm.Request) (llm.Response, error) {
+		activeCalls++
+		if activeCalls == 1 {
+			return llm.Response{Message: llm.Assistant("- survived")}, nil
+		}
+		return llm.Response{}, llm.ErrorFromHTTPStatus("openai", 400, "active unavailable", nil, nil)
+	}}
+	client := llm.NewClient()
+	client.Register(cheap)
+	client.Register(active)
+	cm := NewManager(WithCheapModel(NewOpenAIProfile("gpt-5.2"), "anthropic/haiku"), client, cheapmodel.New(client))
+
+	// First call latches the cheap refusal by succeeding on the session model.
+	if _, err := cm.ElicitNote(context.Background(), nil); err != nil {
+		t.Fatalf("first ElicitNote: %v", err)
+	}
+	if _, err := cm.ElicitNote(context.Background(), nil); err == nil {
+		t.Fatal("second ElicitNote succeeded, want the session-model failure")
+	}
+	if activeCalls != 2 {
+		t.Fatalf("session-model calls = %d, want 2 (one per elicitation)", activeCalls)
 	}
 }
 

--- a/agent/internal/contextmgr/context_manager_test.go
+++ b/agent/internal/contextmgr/context_manager_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
@@ -112,7 +113,7 @@ func TestEstimateTokens_ImageDataDoesNotScaleWithByteLength(t *testing.T) {
 }
 
 func TestContextManager_AddUsage_Accumulates(t *testing.T) {
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil, cheapmodel.New(nil))
 	cm.AddUsage(llm.Usage{InputTokens: 100, OutputTokens: 50, TotalTokens: 150})
 	cm.AddUsage(llm.Usage{InputTokens: 200, OutputTokens: 100, TotalTokens: 300})
 
@@ -129,7 +130,7 @@ func TestContextManager_AddUsage_Accumulates(t *testing.T) {
 }
 
 func TestContextManager_CumulativeUsage_ThreadSafe(t *testing.T) {
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil, cheapmodel.New(nil))
 
 	var wg sync.WaitGroup
 	for range 100 {
@@ -667,7 +668,7 @@ func TestSummarizeWithLLM_DefaultsToActiveModel(t *testing.T) {
 	client := llm.NewClient()
 	client.Register(adapter)
 
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client, cheapmodel.New(client))
 
 	history := []schema.Turn{
 		{Kind: schema.TurnUserInput, Message: llm.User("Fix the auth bug")},
@@ -694,7 +695,7 @@ func TestSummarizeWithLLM_UsesConfiguredCompactionModel(t *testing.T) {
 	client.Register(adapter)
 
 	profile := provider.WithCheapModel(NewOpenAIProfile("gpt-5.2"), "gpt-5-mini")
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 
 	history := []schema.Turn{
 		{Kind: schema.TurnUserInput, Message: llm.User("task")},
@@ -720,7 +721,7 @@ func TestSummarizeWithLLM_FallsBackToActiveModelWhenConfiguredModelFails(t *test
 	client.Register(adapter)
 
 	profile := provider.WithCheapModel(NewOpenAIProfile("gpt-5.2"), "gpt-5-mini")
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 
 	history := []schema.Turn{
 		{Kind: schema.TurnUserInput, Message: llm.User("task")},
@@ -774,7 +775,7 @@ func TestSummarizeWithLLM_DoesNotFallbackOnCancellation(t *testing.T) {
 	client.Register(adapter)
 
 	profile := provider.WithCheapModel(NewOpenAIProfile("gpt-5.2"), "gpt-5-mini")
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	history := []schema.Turn{
 		{Kind: schema.TurnUserInput, Message: llm.User("task")},
 		{Kind: schema.TurnAssistant, Message: llm.Assistant("old")},
@@ -828,7 +829,7 @@ func TestSummarizeWithLLM_ReplacesOldHistory(t *testing.T) {
 	client := llm.NewClient()
 	client.Register(adapter)
 
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client, cheapmodel.New(client))
 
 	history := []schema.Turn{
 		{Kind: schema.TurnUserInput, Message: llm.User("task")},
@@ -866,7 +867,7 @@ func TestSummarizeWithLLM_PreservesRecentTurns(t *testing.T) {
 	client := llm.NewClient()
 	client.Register(adapter)
 
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client, cheapmodel.New(client))
 
 	history := []schema.Turn{
 		{Kind: schema.TurnUserInput, Message: llm.User("task")},
@@ -895,7 +896,7 @@ func TestSummarizeWithLLM_ErrorFallsBackGracefully(t *testing.T) {
 	client := llm.NewClient()
 	client.Register(adapter)
 
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client, cheapmodel.New(client))
 
 	history := []schema.Turn{
 		{Kind: schema.TurnUserInput, Message: llm.User("task")},
@@ -930,7 +931,7 @@ func makeBigHistory(targetTokens int) []schema.Turn {
 func TestMaybeCompact_NoCompactionBelow80Percent(t *testing.T) {
 	// At 70% pressure, no compaction should fire. Compaction starts at 80% (checkpoint).
 	profile := testProfile("openai", "test", 1000)
-	cm := NewManager(profile, nil)
+	cm := NewManager(profile, nil, cheapmodel.New(nil))
 	cm.PreserveRecentTurns = 2
 
 	// Create history filling ~70% of 1000 tokens = 700 tokens via tool results.
@@ -955,7 +956,7 @@ func TestMaybeCompact_NoCompactionBelow80Percent(t *testing.T) {
 }
 
 func TestMaybeCompact_BelowThreshold_NoAction(t *testing.T) {
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil, cheapmodel.New(nil))
 
 	// Small history, well below any threshold.
 	history := []schema.Turn{
@@ -983,7 +984,7 @@ func TestMaybeCompact_BelowThreshold_NoAction(t *testing.T) {
 
 func TestMaybeCompact_CheckpointThreshold(t *testing.T) {
 	profile := testProfile("openai", "test", 500)
-	cm := NewManager(profile, nil)
+	cm := NewManager(profile, nil, cheapmodel.New(nil))
 	cm.PreserveRecentTurns = 2
 
 	// Each assistant turn ~400 chars = 100 tokens. Need 85% of 500 = 425 tokens.
@@ -1024,7 +1025,7 @@ func TestMaybeCompact_CheckpointThreshold(t *testing.T) {
 
 func TestMaybeCompact_EmitsEvents(t *testing.T) {
 	profile := testProfile("openai", "test", 500)
-	cm := NewManager(profile, nil)
+	cm := NewManager(profile, nil, cheapmodel.New(nil))
 	cm.PreserveRecentTurns = 2
 
 	// Fill ~85% = 425 tokens (above 80% checkpoint threshold).
@@ -1062,7 +1063,7 @@ func TestMaybeCompact_EmitsEvents(t *testing.T) {
 
 func TestMaybeCompact_RespectsSysPromptSize(t *testing.T) {
 	profile := testProfile("openai", "test", 1000)
-	cm := NewManager(profile, nil)
+	cm := NewManager(profile, nil, cheapmodel.New(nil))
 	cm.PreserveRecentTurns = 2
 
 	// Small history, but giant system prompt.
@@ -1139,7 +1140,7 @@ func TestSummarizeWithLLM_AdjustsCutoffToAvoidOrphanedToolTurn(t *testing.T) {
 	}
 	client := llm.NewClient()
 	client.Register(adapter)
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client, cheapmodel.New(client))
 
 	history := []schema.Turn{
 		{Kind: schema.TurnUserInput, Message: llm.User("task")},
@@ -1233,7 +1234,7 @@ func TestSummarizeWithLLM_TruncatesPromptForCheapModel(t *testing.T) {
 	}
 	client := llm.NewClient()
 	client.Register(adapter)
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client, cheapmodel.New(client))
 
 	// Build history with enormous user messages — many times larger than any cheap model can handle.
 	history := []schema.Turn{
@@ -1271,7 +1272,7 @@ func TestSummarizeWithLLM_RequestsInterleavedConversationTimeline(t *testing.T) 
 	}
 	client := llm.NewClient()
 	client.Register(adapter)
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client, cheapmodel.New(client))
 
 	history := []schema.Turn{
 		{Kind: schema.TurnUserInput, Message: llm.User("first request")},
@@ -1296,7 +1297,7 @@ func TestSummarizeWithLLM_AdapterError_ReturnsError(t *testing.T) {
 	adapter := &errorAdapter{name: "openai"}
 	client := llm.NewClient()
 	client.Register(adapter)
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client, cheapmodel.New(client))
 
 	history := []schema.Turn{
 		{Kind: schema.TurnUserInput, Message: llm.User("task")},
@@ -1553,7 +1554,7 @@ func TestCheckpoint_IncludesWebSearchCount(t *testing.T) {
 // responses for pressure calculation instead of relying solely on char/4.
 func TestContextManager_UsesLastInputTokensForPressure(t *testing.T) {
 	profile := testProfile("openai", "test", 1000)
-	cm := NewManager(profile, nil)
+	cm := NewManager(profile, nil, cheapmodel.New(nil))
 
 	// Record that the last API response reported 550 input tokens for a 10-turn history.
 	cm.RecordInputTokens(550, 10)
@@ -1578,7 +1579,7 @@ func TestContextManager_UsesLastInputTokensForPressure(t *testing.T) {
 
 func TestContextManager_EstimateUsageReportsRemainingWindow(t *testing.T) {
 	profile := testProfile("openai", "test", 1000)
-	cm := NewManager(profile, nil)
+	cm := NewManager(profile, nil, cheapmodel.New(nil))
 	cm.RecordInputTokens(550, 10)
 
 	history := make([]schema.Turn, 11)
@@ -1592,7 +1593,7 @@ func TestContextManager_EstimateUsageReportsRemainingWindow(t *testing.T) {
 
 func TestContextManager_FallsBackToCharHeuristicWithoutMeasurement(t *testing.T) {
 	profile := testProfile("openai", "test", 1000)
-	cm := NewManager(profile, nil)
+	cm := NewManager(profile, nil, cheapmodel.New(nil))
 
 	// No RecordInputTokens called — should fall back to char/4.
 	history := []schema.Turn{
@@ -1609,7 +1610,7 @@ func TestContextManager_FallsBackToCharHeuristicWithoutMeasurement(t *testing.T)
 
 func TestContextManager_ResetsAfterCompaction(t *testing.T) {
 	profile := testProfile("openai", "test", 1000)
-	cm := NewManager(profile, nil)
+	cm := NewManager(profile, nil, cheapmodel.New(nil))
 	cm.PreserveRecentTurns = 2
 
 	// Record high token count.
@@ -1924,7 +1925,7 @@ func TestSummarizeWithLLM_SafeCutoffNegative_ReturnsUnchanged(t *testing.T) {
 	}
 	client := llm.NewClient()
 	client.Register(adapter)
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), client, cheapmodel.New(client))
 
 	// Same scenario as checkpoint test: cutoff walks to 0 → return -1.
 	history := []schema.Turn{
@@ -2011,7 +2012,7 @@ func TestMaybeCompact_SummarizeThreshold(t *testing.T) {
 	// message, but the preserved recent turns are large enough to keep
 	// pressure above 90% after checkpoint, forcing summarize.
 	profile := testProfile("openai", "test", 50)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	cm.PreserveRecentTurns = 1
 
 	// After checkpoint, result = [checkpoint_msg, recent_turn].
@@ -2086,7 +2087,7 @@ func startsWith(s, prefix string) bool {
 
 func TestPressure_ReturnsEstimate(t *testing.T) {
 	profile := testProfile("openai", "test", 1000)
-	cm := NewManager(profile, nil)
+	cm := NewManager(profile, nil, cheapmodel.New(nil))
 
 	history := []schema.Turn{
 		{Kind: schema.TurnAssistant, Message: llm.Assistant(strings.Repeat("x", 400))},
@@ -2101,7 +2102,7 @@ func TestPressure_ReturnsEstimate(t *testing.T) {
 
 func TestPressure_ZeroContextWindow(t *testing.T) {
 	profile := &provider.Profile{} // zero value reports ContextWindowSize() == 0
-	cm := NewManager(profile, nil)
+	cm := NewManager(profile, nil, cheapmodel.New(nil))
 
 	p := cm.Pressure(nil, 0)
 	if p != 0 {
@@ -2114,7 +2115,7 @@ func TestPressure_ZeroContextWindow(t *testing.T) {
 func TestContextManager_SetProfile_UpdatesContextWindow(t *testing.T) {
 	// Start with a 200K profile, switch to 1M. Pressure should reflect new window.
 	smallProfile := testProfile("anthropic", "claude-opus-4-6", 200_000)
-	cm := NewManager(smallProfile, nil)
+	cm := NewManager(smallProfile, nil, cheapmodel.New(nil))
 
 	// Record 100K tokens.
 	cm.RecordInputTokens(100_000, 5)
@@ -2154,7 +2155,7 @@ func TestForceCompact_RunsAllLayers(t *testing.T) {
 	client := llm.NewClient()
 	client.Register(adapter)
 	profile := testProfile("openai", "test", 100_000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	cm.PreserveRecentTurns = 2
 
 	history := []schema.Turn{
@@ -2191,7 +2192,7 @@ func TestForceCompact_RunsAllLayers(t *testing.T) {
 func TestForceCompact_FiresOnCompactionTurn_Checkpoint(t *testing.T) {
 	// ForceCompact should fire OnCompactionTurn for TurnCheckpoint (L3).
 	profile := testProfile("openai", "test", 100_000)
-	cm := NewManager(profile, nil) // no LLM client → L4 skipped
+	cm := NewManager(profile, nil, cheapmodel.New(nil)) // no LLM client → L4 skipped
 	cm.PreserveRecentTurns = 2
 
 	var callbackTurns []schema.TurnKind
@@ -2236,7 +2237,7 @@ func TestForceCompact_FiresOnCompactionTurn_Summary(t *testing.T) {
 	client.Register(adapter)
 
 	profile := testProfile("openai", "test", 100_000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	cm.PreserveRecentTurns = 2
 
 	var callbackTurns []schema.TurnKind
@@ -2277,7 +2278,7 @@ func TestForceCompact_BelowThreshold(t *testing.T) {
 	// Even with tiny history well below auto-compact thresholds,
 	// ForceCompact should still run the layers.
 	profile := testProfile("openai", "test", 1_000_000)
-	cm := NewManager(profile, nil) // no LLM client → summarize skipped
+	cm := NewManager(profile, nil, cheapmodel.New(nil)) // no LLM client → summarize skipped
 	cm.PreserveRecentTurns = 2
 
 	history := []schema.Turn{
@@ -2308,7 +2309,7 @@ func TestForceCompact_ReportsSummarized(t *testing.T) {
 	// With a nil client there is no summary layer, so ForceCompact should
 	// return false regardless of history length.
 	profile := testProfile("openai", "test", 100_000)
-	cm := NewManager(profile, nil) // nil client → no summary layer
+	cm := NewManager(profile, nil, cheapmodel.New(nil)) // nil client → no summary layer
 	cm.PreserveRecentTurns = 2
 
 	history := []schema.Turn{
@@ -2336,7 +2337,7 @@ func TestForceCompact_ReportsGeneratedSummary(t *testing.T) {
 	client.Register(adapter)
 	profile := testProfile("openai", "test", 100_000)
 
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	cm.PreserveRecentTurns = 2
 	history := []schema.Turn{
 		schema.NewTurn(schema.TurnUserInput, llm.User("first question")),
@@ -2356,7 +2357,7 @@ func TestForceCompact_ReportsGeneratedSummary(t *testing.T) {
 		{Kind: schema.TurnAttentionResolution, Message: llm.System("private marker"), AttentionResolution: &schema.AttentionResolutionInfo{AttentionID: "private", Disposition: "consumed"}},
 		schema.NewTurn(schema.TurnUserInput, llm.User("recent")),
 	}
-	shortCM := NewManager(profile, client)
+	shortCM := NewManager(profile, client, cheapmodel.New(client))
 	shortCM.PreserveRecentTurns = 2
 	if shortCM.ForceCompact(context.Background(), &short, "", func(events.EventKind, events.EventData) {}) {
 		t.Fatal("ForceCompact reported a pre-existing short summary as newly generated")

--- a/agent/internal/contextmgr/context_strategy_test.go
+++ b/agent/internal/contextmgr/context_strategy_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
 )
@@ -32,7 +33,7 @@ func TestCompactStrategyManageContext_Delegation(t *testing.T) {
 	// the 80% checkpoint threshold.
 	client := llm.NewClient()
 	profile := testProfile("openai", "test", 500)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	cm.PreserveRecentTurns = 2
 
 	cs := NewCompactStrategy(cm)

--- a/agent/internal/contextmgr/cov_s5_strategies_test.go
+++ b/agent/internal/contextmgr/cov_s5_strategies_test.go
@@ -6,12 +6,13 @@ import (
 	"strings"
 	"testing"
 
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
 )
 
 func TestCov_LastInputTokens(t *testing.T) {
-	cm := NewManager(testOpenAIProfileWithContextWindow(1000), llm.NewClient())
+	cm := NewManager(testOpenAIProfileWithContextWindow(1000), llm.NewClient(), cheapmodel.New(llm.NewClient()))
 	if got := cm.LastInputTokens(); got != 0 {
 		t.Errorf("fresh manager LastInputTokens = %d, want 0", got)
 	}
@@ -22,7 +23,7 @@ func TestCov_LastInputTokens(t *testing.T) {
 }
 
 func TestCov_CompactStrategy_AfterActionNoop(t *testing.T) {
-	cm := NewManager(testOpenAIProfileWithContextWindow(1000), llm.NewClient())
+	cm := NewManager(testOpenAIProfileWithContextWindow(1000), llm.NewClient(), cheapmodel.New(llm.NewClient()))
 	s := NewCompactStrategy(cm)
 	if err := s.AfterAction(context.Background(), nil, llm.NewClient()); err != nil {
 		t.Errorf("CompactStrategy.AfterAction should be a nil no-op, got %v", err)
@@ -37,7 +38,7 @@ func TestCov_CompactStrategy_AfterActionNoop(t *testing.T) {
 func TestCov_NewOODAStrategyConstructor(t *testing.T) {
 	profile := testOpenAIProfileWithContextWindow(1000)
 	host := &fakeStrategyHost{stateDir: t.TempDir(), id: "OODA-1", profile: profile}
-	ooda, err := NewOODAStrategy(NewManager(profile, llm.NewClient()), host)
+	ooda, err := NewOODAStrategy(NewManager(profile, llm.NewClient(), cheapmodel.New(llm.NewClient())), host)
 	if err != nil {
 		t.Fatalf("NewOODAStrategy: %v", err)
 	}
@@ -49,7 +50,7 @@ func TestCov_NewOODAStrategyConstructor(t *testing.T) {
 // MemoryCrystalsStrategy.ManageContext runs base compaction, then injects the
 // crystal bank when crystals are present.
 func TestCov_MemoryCrystals_ManageContextInjects(t *testing.T) {
-	cm := NewManager(testOpenAIProfileWithContextWindow(1_000_000), llm.NewClient())
+	cm := NewManager(testOpenAIProfileWithContextWindow(1_000_000), llm.NewClient(), cheapmodel.New(llm.NewClient()))
 	s := NewMemoryCrystalsStrategy(cm)
 
 	history := []schema.Turn{
@@ -112,14 +113,14 @@ func TestCov_RecursiveDistill_MicroSummarize(t *testing.T) {
 	client := llm.NewClient()
 	client.Register(adapter)
 
-	cm := NewManager(testOpenAIProfileWithContextWindow(1000), client)
+	cm := NewManager(testOpenAIProfileWithContextWindow(1000), client, cheapmodel.New(client))
 	s := NewRecursiveDistillStrategy(cm)
 
 	history := []schema.Turn{
 		{Kind: schema.TurnAssistant, Message: llm.Assistant("ran the build")},
 		{Kind: schema.TurnToolResults, Message: llm.ToolResultNamed("c1", "shell", "PASS", false)},
 	}
-	got, err := s.microSummarize(context.Background(), client, history)
+	got, err := s.microSummarize(context.Background(), history)
 	if err != nil {
 		t.Fatalf("microSummarize: %v", err)
 	}
@@ -136,7 +137,7 @@ func TestCov_RecursiveDistill_MicroSummarize(t *testing.T) {
 // RecursiveDistillStrategy.ManageContext injects the distilled hierarchy when
 // micro/macro summaries exist.
 func TestCov_RecursiveDistill_ManageContextInjects(t *testing.T) {
-	cm := NewManager(testOpenAIProfileWithContextWindow(1_000_000), llm.NewClient())
+	cm := NewManager(testOpenAIProfileWithContextWindow(1_000_000), llm.NewClient(), cheapmodel.New(llm.NewClient()))
 	s := NewRecursiveDistillStrategy(cm)
 	s.microSummaries = append(s.microSummaries, "did a thing")
 

--- a/agent/internal/contextmgr/cov_w3sub_context_manager_test.go
+++ b/agent/internal/contextmgr/cov_w3sub_context_manager_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
@@ -40,7 +41,7 @@ func TestW3Sub_SummarizeSteered_DigestArms(t *testing.T) {
 
 	profile := testOpenAIProfileWithContextWindow(1000)
 	client := ctxmgr_scriptedClient(profile.ID(), "handoff summary body", nil)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 
 	result, err := cm.summarizeWithLLMSteered(context.Background(), history, 1, "keep the plan")
 	if err != nil {
@@ -72,7 +73,7 @@ func TestW3Sub_SummarizeSteered_HistoryCharCap(t *testing.T) {
 
 	profile := testOpenAIProfileWithContextWindow(1000)
 	client := ctxmgr_scriptedClient(profile.ID(), "summary", nil)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 
 	result, err := cm.summarizeWithLLMSteered(context.Background(), history, 1, "")
 	if err != nil {
@@ -93,7 +94,7 @@ func TestW3Sub_SummarizeSteered_NoRoutes(t *testing.T) {
 	}
 	profile := provider.NewOpenAIProfile("") // empty model -> no routes
 	client := ctxmgr_scriptedClient("openai", "unused", nil)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 
 	if _, err := cm.summarizeWithLLMSteered(context.Background(), history, 1, ""); err == nil {
 		t.Fatalf("expected an empty-model error")
@@ -105,7 +106,7 @@ func TestW3Sub_SummarizeSteered_NoRoutes(t *testing.T) {
 // and a subsequent AddUsage accumulates on top of the seed rather than
 // replacing it.
 func TestSetCumulativeUsage(t *testing.T) {
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil, cheapmodel.New(nil))
 
 	cm.SetCumulativeUsage(llm.Usage{InputTokens: 10, OutputTokens: 20})
 	got := cm.CumulativeUsage()

--- a/agent/internal/contextmgr/ctxmgr_compaction_fuzz_test.go
+++ b/agent/internal/contextmgr/ctxmgr_compaction_fuzz_test.go
@@ -9,6 +9,7 @@ import (
 
 	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/internal/agenttest"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/fuzz/fault"
 	"primeradiant.com/evener/llm"
@@ -351,7 +352,7 @@ func FuzzCtxmgrSummarizeSteered(f *testing.F) {
 				profile = WithCheapModel(profile, "cheap-model")
 			}
 			client := ctxmgr_scriptedClient(profile.ID(), "handoff summary body", faultPlan)
-			cm := NewManager(profile, client)
+			cm := NewManager(profile, client, cheapmodel.New(client))
 
 			result, err := cm.summarizeWithLLMSteered(context.Background(), history, preserve, instructions)
 			return result, history, err
@@ -443,7 +444,7 @@ func FuzzCtxmgrCheckpointPredManageContext(f *testing.F) {
 
 			profile := testOpenAIProfileWithContextWindow(1000)
 			client := ctxmgr_scriptedClient(profile.ID(), "predicted checkpoint body", faultPlan)
-			cm := NewManager(profile, client)
+			cm := NewManager(profile, client, cheapmodel.New(client))
 			ctxmgr_manageThresholds(cm, thrSel, preserveSel)
 
 			s := NewCheckpointPredStrategy(cm)
@@ -488,7 +489,7 @@ func FuzzCtxmgrSessionLogManageContext(f *testing.F) {
 
 			profile := testOpenAIProfileWithContextWindow(1000)
 			client := ctxmgr_scriptedClient(profile.ID(), "session summary body", faultPlan)
-			cm := NewManager(profile, client)
+			cm := NewManager(profile, client, cheapmodel.New(client))
 			ctxmgr_manageThresholds(cm, thrSel, preserveSel)
 
 			host := &fakeStrategyHost{stateDir: t.TempDir(), id: "CTXMGR-FUZZ", profile: profile}

--- a/agent/internal/contextmgr/cxjs_obs_mask_fuzz_test.go
+++ b/agent/internal/contextmgr/cxjs_obs_mask_fuzz_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/fuzz/oracle"
@@ -143,7 +144,7 @@ func FuzzCxjsObsMaskManageContext(f *testing.F) {
 		run := func() []schema.Turn {
 			h := cxjs_cloneHistory(history)
 			profile := testOpenAIProfileWithContextWindow(1000)
-			cm := NewManager(profile, llm.NewClient())
+			cm := NewManager(profile, llm.NewClient(), cheapmodel.New(llm.NewClient()))
 			// Layer 1 always fires; Layer 2 (checkpoint) toggles via cpSel so both
 			// the mask-only and mask-then-checkpoint pipelines are exercised.
 			cm.ObservationMaskThreshold = 0
@@ -191,7 +192,7 @@ func cxjs_checkGuards(t *testing.T, history []schema.Turn, sysChars int) {
 	}
 
 	// Non-positive context window guard: a zero-value profile reports window 0.
-	cm := NewManager(&provider.Profile{}, llm.NewClient())
+	cm := NewManager(&provider.Profile{}, llm.NewClient(), cheapmodel.New(llm.NewClient()))
 	cm.ObservationMaskThreshold = 0
 	cm.CheckpointThreshold = 0
 	zeroStrat := NewObsMaskStrategy(cm)

--- a/agent/internal/contextmgr/forcecompact_doublelayer_seqfuzz_test.go
+++ b/agent/internal/contextmgr/forcecompact_doublelayer_seqfuzz_test.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
 
@@ -186,7 +187,7 @@ func newDoubleLayerModel(preserveRecent int, sawLayer2 *atomic.Bool) *doubleLaye
 	client := llm.NewClient()
 	client.Register(adapter)
 
-	cm := NewManager(testProfile("openai", "test", 1_000_000), client)
+	cm := NewManager(testProfile("openai", "test", 1_000_000), client, cheapmodel.New(client))
 	cm.PreserveRecentTurns = preserveRecent
 	return &doubleLayerModel{preserveRecent: preserveRecent, cm: cm, sawLayer2: sawLayer2}
 }

--- a/agent/internal/contextmgr/fork_summarize.go
+++ b/agent/internal/contextmgr/fork_summarize.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/internal/sessionlog"
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
@@ -16,17 +17,14 @@ import (
 // sessionlog.SessionLogEntry summarizing the most recent action in turns. The
 // prompt explicitly preserves failure signals so errors are not lost during
 // summarization.
-func forkSummarize(ctx context.Context, client *llm.Client, profile *provider.Profile, turns []schema.Turn, turnNumber int) (sessionlog.SessionLogEntry, error) {
+func forkSummarize(ctx context.Context, cheap *cheapmodel.Caller, profile *provider.Profile, turns []schema.Turn, turnNumber int) (sessionlog.SessionLogEntry, error) {
 	prompt := buildSummarizePrompt(turns)
 
-	cheapProvider, cheapModel := profile.CheapModelRef()
 	req := llm.Request{
-		Model:    cheapModel,
-		Provider: cheapProvider,
 		Messages: []llm.Message{llm.User(prompt)},
 	}
 
-	resp, err := client.Complete(ctx, req)
+	resp, err := cheap.Complete(ctx, profile, req)
 	if err != nil {
 		return sessionlog.SessionLogEntry{}, fmt.Errorf("fork summarize: %w", err)
 	}

--- a/agent/internal/contextmgr/fork_summarize_test.go
+++ b/agent/internal/contextmgr/fork_summarize_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/internal/sessionlog"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
@@ -45,7 +46,7 @@ func TestForkSummarize_RoutesToCheapProvider(t *testing.T) {
 		{Kind: schema.TurnToolResults, Message: llm.ToolResultNamed("c1", "shell", "PASS", false)},
 	}
 
-	if _, err := forkSummarize(context.Background(), client, profile, turns, 1); err != nil {
+	if _, err := forkSummarize(context.Background(), cheapmodel.New(client), profile, turns, 1); err != nil {
 		t.Fatalf("forkSummarize: %v", err)
 	}
 	if cheapAdapter.lastReq.Provider != "anthropic" {
@@ -86,7 +87,7 @@ func TestForkSummarize_Success(t *testing.T) {
 		{Kind: schema.TurnToolResults, Message: llm.ToolResultNamed("c1", "shell", "PASS", false)},
 	}
 
-	got, err := forkSummarize(context.Background(), client, profile, turns, 7)
+	got, err := forkSummarize(context.Background(), cheapmodel.New(client), profile, turns, 7)
 	if err != nil {
 		t.Fatalf("forkSummarize: %v", err)
 	}
@@ -142,7 +143,7 @@ func TestForkSummarize_Failure(t *testing.T) {
 		{Kind: schema.TurnToolResults, Message: llm.ToolResultNamed("c1", "shell", "./main.go:42:5: undefined: foo", true)},
 	}
 
-	got, err := forkSummarize(context.Background(), client, profile, turns, 12)
+	got, err := forkSummarize(context.Background(), cheapmodel.New(client), profile, turns, 12)
 	if err != nil {
 		t.Fatalf("forkSummarize: %v", err)
 	}
@@ -176,7 +177,7 @@ func TestForkSummarize_MalformedJSON(t *testing.T) {
 		{Kind: schema.TurnAssistant, Message: llm.Assistant("I'll read the file")},
 	}
 
-	_, err := forkSummarize(context.Background(), client, profile, turns, 1)
+	_, err := forkSummarize(context.Background(), cheapmodel.New(client), profile, turns, 1)
 	if err == nil {
 		t.Fatal("expected error for malformed JSON response, got nil")
 	}
@@ -214,7 +215,7 @@ func TestForkSummarize_ExtractsAction(t *testing.T) {
 		{Kind: schema.TurnToolResults, Message: llm.ToolResultNamed("c1", "edit_file", "OK", false)},
 	}
 
-	got, err := forkSummarize(context.Background(), client, profile, turns, 3)
+	got, err := forkSummarize(context.Background(), cheapmodel.New(client), profile, turns, 3)
 	if err != nil {
 		t.Fatalf("forkSummarize: %v", err)
 	}
@@ -252,7 +253,7 @@ func TestForkSummarize_UsesCheapModel(t *testing.T) {
 		{Kind: schema.TurnAssistant, Message: llm.Assistant("done")},
 	}
 
-	_, err := forkSummarize(context.Background(), client, profile, turns, 1)
+	_, err := forkSummarize(context.Background(), cheapmodel.New(client), profile, turns, 1)
 	if err != nil {
 		t.Fatalf("forkSummarize: %v", err)
 	}
@@ -273,7 +274,7 @@ func TestForkSummarize_LLMError(t *testing.T) {
 		{Kind: schema.TurnAssistant, Message: llm.Assistant("hello")},
 	}
 
-	_, err := forkSummarize(context.Background(), client, profile, turns, 1)
+	_, err := forkSummarize(context.Background(), cheapmodel.New(client), profile, turns, 1)
 	if err == nil {
 		t.Fatal("expected error when LLM returns error, got nil")
 	}

--- a/agent/internal/contextmgr/global_tails_fuzz_test.go
+++ b/agent/internal/contextmgr/global_tails_fuzz_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"primeradiant.com/evener/agent/internal/agenttest"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
 )
@@ -109,7 +110,7 @@ func gctManagerTails(t *testing.T, token string) {
 		Provider:       profile.ID(),
 		FaultResponder: func(llm.Request) error { return errors.New("scripted failure") },
 	})
-	cm := NewManager(profile, failing)
+	cm := NewManager(profile, failing, cheapmodel.New(failing))
 	if _, err := cm.ElicitNote(ctx, []schema.Turn{schema.NewTurn(schema.TurnUserInput, llm.User(token))}); err == nil {
 		t.Fatal("elicitation failure was swallowed")
 	}
@@ -118,7 +119,7 @@ func gctManagerTails(t *testing.T, token string) {
 	nonFallback.Register(&agenttest.ScriptedAdapter{Provider: profile.ID(), FaultResponder: func(llm.Request) error {
 		return errors.New("non-fallback")
 	}})
-	if _, err := NewManager(profile, nonFallback).ElicitNote(ctx, nil); err == nil {
+	if _, err := NewManager(profile, nonFallback, cheapmodel.New(nonFallback)).ElicitNote(ctx, nil); err == nil {
 		t.Fatal("non-fallback elicitation failure was swallowed")
 	}
 
@@ -156,7 +157,7 @@ func gctStrategyTails(t *testing.T, token string) {
 		schema.NewTurn(schema.TurnUserInput, llm.User("recent")),
 	}
 
-	cpCM := NewManager(profile, client)
+	cpCM := NewManager(profile, client, cheapmodel.New(client))
 	cpCM.PreserveRecentTurns = 1
 	cpCM.ObservationMaskThreshold = 0
 	cpCM.ThinkingClearThreshold = 0
@@ -169,7 +170,7 @@ func gctStrategyTails(t *testing.T, token string) {
 		t.Fatalf("checkpoint strategy callbacks=%d err=%v", cpCallbacks, err)
 	}
 
-	obsCM := NewManager(profile, nil)
+	obsCM := NewManager(profile, nil, cheapmodel.New(nil))
 	obsCM.PreserveRecentTurns = 1
 	obsCM.ObservationMaskThreshold = 0
 	obsCM.CheckpointThreshold = 0
@@ -180,20 +181,21 @@ func gctStrategyTails(t *testing.T, token string) {
 		t.Fatalf("obs strategy callbacks=%d err=%v", obsCallbacks, err)
 	}
 
-	rd := NewRecursiveDistillStrategy(NewManager(profile, client))
+	rd := NewRecursiveDistillStrategy(NewManager(profile, client, cheapmodel.New(client)))
 	rd.microSummaries = []string{"micro"}
-	if _, err := rd.microSummarize(ctx, client, append(longHistory, schema.NewTurn(schema.TurnToolResults, llm.ToolResultNamed("id", "shell", strings.Repeat("x", 101), false)))); err != nil {
+	if _, err := rd.microSummarize(ctx, append(longHistory, schema.NewTurn(schema.TurnToolResults, llm.ToolResultNamed("id", "shell", strings.Repeat("x", 101), false)))); err != nil {
 		t.Fatalf("micro summarize: %v", err)
 	}
-	if _, err := rd.macroSummarize(ctx, client, []string{strings.Repeat("m", 501)}); err != nil {
+	if _, err := rd.macroSummarize(ctx, []string{strings.Repeat("m", 501)}); err != nil {
 		t.Fatalf("macro summarize: %v", err)
 	}
 	failing := llm.NewClient()
 	failing.Register(&agenttest.ScriptedAdapter{Provider: profile.ID(), FaultResponder: func(llm.Request) error { return errors.New("distill failure") }})
-	if _, err := rd.microSummarize(ctx, failing, longHistory); err == nil {
+	failingRD := NewRecursiveDistillStrategy(NewManager(profile, failing, cheapmodel.New(failing)))
+	if _, err := failingRD.microSummarize(ctx, longHistory); err == nil {
 		t.Fatal("micro summarization failure was swallowed")
 	}
-	if _, err := rd.macroSummarize(ctx, failing, []string{"micro"}); err == nil {
+	if _, err := failingRD.macroSummarize(ctx, []string{"micro"}); err == nil {
 		t.Fatal("macro summarization failure was swallowed")
 	}
 
@@ -201,13 +203,13 @@ func gctStrategyTails(t *testing.T, token string) {
 	for i := 0; i < 110; i++ {
 		largePrediction = append(largePrediction, schema.NewTurn(schema.TurnAssistant, llm.Assistant(strings.Repeat("p", 300))))
 	}
-	if _, err := NewCheckpointPredStrategy(NewManager(profile, client)).predictiveCheckpoint(ctx, largePrediction, 0); err != nil {
+	if _, err := NewCheckpointPredStrategy(NewManager(profile, client, cheapmodel.New(client))).predictiveCheckpoint(ctx, largePrediction, 0); err != nil {
 		t.Fatalf("large predictive checkpoint: %v", err)
 	}
 	aggressiveMaskObservations([]schema.Turn{schema.NewTurn(schema.TurnToolResults, llm.ToolResultNamed("error", "shell", "keep", true))}, 0)
 
 	goodHost := &fakeStrategyHost{stateDir: t.TempDir(), id: "good", profile: profile}
-	sls, err := NewSessionLogStrategy(NewManager(profile, client), goodHost)
+	sls, err := NewSessionLogStrategy(NewManager(profile, client, cheapmodel.New(client)), goodHost)
 	if err != nil {
 		t.Fatalf("new session-log strategy: %v", err)
 	}
@@ -240,10 +242,10 @@ func gctStrategyTails(t *testing.T, token string) {
 		t.Fatalf("create unreadable session log: %v", err)
 	}
 	badHost := &fakeStrategyHost{stateDir: blockedRoot, id: "child", profile: profile}
-	if _, err := NewSessionLogStrategy(NewManager(profile, client), badHost); err == nil {
+	if _, err := NewSessionLogStrategy(NewManager(profile, client, cheapmodel.New(client)), badHost); err == nil {
 		t.Fatal("invalid nested session log path unexpectedly succeeded")
 	}
-	if _, err := NewOODAStrategy(NewManager(profile, client), badHost); err == nil {
+	if _, err := NewOODAStrategy(NewManager(profile, client, cheapmodel.New(client)), badHost); err == nil {
 		t.Fatal("invalid OODA session log path unexpectedly succeeded")
 	}
 
@@ -252,7 +254,7 @@ func gctStrategyTails(t *testing.T, token string) {
 		t.Fatalf("create append-blocked root: %v", err)
 	}
 	appendHost := &fakeStrategyHost{stateDir: appendRoot, id: "child", profile: profile}
-	appendSLS, err := NewSessionLogStrategy(NewManager(profile, client), appendHost)
+	appendSLS, err := NewSessionLogStrategy(NewManager(profile, client, cheapmodel.New(client)), appendHost)
 	if err != nil {
 		t.Fatalf("construct append-failing session log: %v", err)
 	}

--- a/agent/internal/contextmgr/manager_lifecycle_program_fuzz_test.go
+++ b/agent/internal/contextmgr/manager_lifecycle_program_fuzz_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/internal/sessionlog"
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
@@ -64,11 +65,11 @@ func cmgpRunManagerLifecycle(t *testing.T, program []byte) {
 	}
 	client := cmgpClient(active, cheap)
 	profile := WithCheapModel(testOpenAIProfileWithContextWindow(64), "anthropic/cheap")
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	cm.PreserveRecentTurns = 2
 	cm.Meta = CompactionMeta{SessionID: "cmgp-" + token, ActivatedSkills: []string{"testing", "fuzzing"}}
 
-	if !cm.HasClient() || NewManager(profile, nil).HasClient() {
+	if !cm.HasClient() || NewManager(profile, nil, cheapmodel.New(nil)).HasClient() {
 		t.Fatal("HasClient did not reflect the configured client")
 	}
 	if cm.resultToolName() != "communicate" {
@@ -133,7 +134,7 @@ func cmgpRunManagerLifecycle(t *testing.T, program []byte) {
 		respond: func(llm.Request) (llm.Response, error) { return llm.Response{}, errors.New("scripted summary failure") },
 	}, nil)
 	failureHistory := cmgpHistory(token + "-failure")
-	failureCM := NewManager(testOpenAIProfileWithContextWindow(64), failureClient)
+	failureCM := NewManager(testOpenAIProfileWithContextWindow(64), failureClient, cheapmodel.New(failureClient))
 	failureCM.PreserveRecentTurns = 2
 	failureCM.CheckpointThreshold = 0.0001
 	failureCM.SummarizeThreshold = 0.0001
@@ -145,7 +146,7 @@ func cmgpRunManagerLifecycle(t *testing.T, program []byte) {
 
 	// ForceCompact must apply the same two layers regardless of pressure.
 	forceHistory := cmgpHistory(token + "-force")
-	forceCM := NewManager(profile, client)
+	forceCM := NewManager(profile, client, cheapmodel.New(client))
 	forceCM.PreserveRecentTurns = 2
 	var forced cmgpEventLog
 	var forcedTurns []schema.Turn
@@ -161,7 +162,7 @@ func cmgpRunManagerLifecycle(t *testing.T, program []byte) {
 	}
 
 	nilHistory := cmgpHistory(token + "-nil")
-	nilCM := NewManager(profile, nil)
+	nilCM := NewManager(profile, nil, cheapmodel.New(nil))
 	nilCM.PreserveRecentTurns = 2
 	if nilCM.ForceCompact(ctx, &nilHistory, "", cmgpNoopEmit) {
 		t.Fatal("ForceCompact reported a summary without an LLM client")
@@ -173,14 +174,14 @@ func cmgpRunManagerLifecycle(t *testing.T, program []byte) {
 		schema.NewTurn(schema.TurnSummary, llm.User("[CONTEXT SUMMARY]\nprior\n[END SUMMARY]")),
 		schema.NewTurn(schema.TurnUserInput, llm.User("recent "+token)),
 	}
-	shortSummaryCM := NewManager(profile, client)
+	shortSummaryCM := NewManager(profile, client, cheapmodel.New(client))
 	shortSummaryCM.PreserveRecentTurns = len(shortSummaryHistory)
 	if shortSummaryCM.ForceCompact(ctx, &shortSummaryHistory, "", cmgpNoopEmit) {
 		t.Fatal("ForceCompact reported a pre-existing short summary as newly generated")
 	}
 
 	forceFailureHistory := cmgpHistory(token + "-force-failure")
-	forceFailureCM := NewManager(testOpenAIProfileWithContextWindow(64), failureClient)
+	forceFailureCM := NewManager(testOpenAIProfileWithContextWindow(64), failureClient, cheapmodel.New(failureClient))
 	forceFailureCM.PreserveRecentTurns = 2
 	var forceFailure cmgpEventLog
 	summarized := forceFailureCM.ForceCompact(ctx, &forceFailureHistory, "", forceFailure.emit)
@@ -190,7 +191,7 @@ func cmgpRunManagerLifecycle(t *testing.T, program []byte) {
 
 	cmgpCheckElicitNote(t, ctx, token, cm, cheap, active, profile, client)
 
-	zeroCM := NewManager(&provider.Profile{}, nil)
+	zeroCM := NewManager(&provider.Profile{}, nil, cheapmodel.New(nil))
 	zeroHistory := cmgpHistory(token + "-zero")
 	zeroCM.MaybeCompact(ctx, &zeroHistory, 0, cmgpNoopEmit)
 	if got := zeroCM.EstimateUsage(zeroHistory, 0); got != (schema.ContextMetrics{}) || zeroCM.Pressure(zeroHistory, 0) != 0 {
@@ -201,7 +202,7 @@ func cmgpRunManagerLifecycle(t *testing.T, program []byte) {
 func cmgpCheckThresholdScaling(t *testing.T, profile *provider.Profile) {
 	t.Helper()
 	for _, scale := range []float64{0, 1, 0.25, 0.5} {
-		cm := NewManager(profile, nil)
+		cm := NewManager(profile, nil, cheapmodel.New(nil))
 		ApplyThresholdScale(cm, scale)
 		if scale == 0 || scale == 1 {
 			if cm.ObservationMaskThreshold != 0.60 || cm.SummarizeThreshold != 0.95 {
@@ -218,10 +219,10 @@ func cmgpCheckThresholdScaling(t *testing.T, profile *provider.Profile) {
 func cmgpCheckElicitNote(t *testing.T, ctx context.Context, token string, cm *Manager, cheap, active *cmgpAdapter, profile *provider.Profile, client *llm.Client) {
 	t.Helper()
 	history := cmgpHistory(token)
-	if _, err := NewManager(profile, nil).ElicitNote(ctx, history); err == nil {
+	if _, err := NewManager(profile, nil, cheapmodel.New(nil)).ElicitNote(ctx, history); err == nil {
 		t.Fatal("ElicitNote without a client unexpectedly succeeded")
 	}
-	if _, err := NewManager(&provider.Profile{}, client).ElicitNote(ctx, history); err == nil {
+	if _, err := NewManager(&provider.Profile{}, client, cheapmodel.New(client)).ElicitNote(ctx, history); err == nil {
 		t.Fatal("ElicitNote without a model unexpectedly succeeded")
 	}
 	note, err := cm.ElicitNote(ctx, history)
@@ -345,7 +346,7 @@ func cmgpCheckSummarizerBehavior(t *testing.T, ctx context.Context, token string
 		schema.NewTurn(schema.TurnAssistant, llm.Assistant("tail assistant "+token)),
 		schema.NewTurn(schema.TurnUserInput, llm.User("tail user "+token)),
 	}
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	result, err := cm.summarizeWithLLMSteered(ctx, input, 2, "retain "+token)
 	if err != nil || len(result) != 3 || result[0].Kind != schema.TurnSummary || result[1].Message.Text() != input[len(input)-2].Message.Text() || result[2].Message.Text() != input[len(input)-1].Message.Text() {
 		t.Fatalf("scripted summary result = %#v, err=%v", cmgpKinds(result), err)
@@ -365,7 +366,7 @@ func cmgpCheckSummarizerBehavior(t *testing.T, ctx context.Context, token string
 	if err != nil || len(unchanged) != len(unsafe) || unchanged[0].Kind != schema.TurnUserInput {
 		t.Fatalf("unsafe summary cutoff = %#v, err=%v", cmgpKinds(unchanged), err)
 	}
-	if _, err := NewManager(&provider.Profile{}, client).summarizeWithLLMSteered(ctx, input, 2, ""); err == nil {
+	if _, err := NewManager(&provider.Profile{}, client, cheapmodel.New(client)).summarizeWithLLMSteered(ctx, input, 2, ""); err == nil {
 		t.Fatal("summary without a model unexpectedly succeeded")
 	}
 
@@ -375,7 +376,7 @@ func cmgpCheckSummarizerBehavior(t *testing.T, ctx context.Context, token string
 	fallbackActive := &cmgpAdapter{name: "openai", respond: func(llm.Request) (llm.Response, error) {
 		return llm.Response{Message: llm.Assistant("fallback " + token)}, nil
 	}}
-	fallbackCM := NewManager(profile, cmgpClient(fallbackActive, fallbackCheap))
+	fallbackCM := NewManager(profile, cmgpClient(fallbackActive, fallbackCheap), cheapmodel.New(cmgpClient(fallbackActive, fallbackCheap)))
 	if got, err := fallbackCM.summarizeWithLLMSteered(ctx, input, 2, ""); err != nil || len(got) == 0 || got[0].Kind != schema.TurnSummary || len(fallbackCheap.requests) != 1 || len(fallbackActive.requests) != 1 {
 		t.Fatalf("summary fallback = head:%v cheap:%d active:%d err:%v", cmgpHeadKind(got), len(fallbackCheap.requests), len(fallbackActive.requests), err)
 	}
@@ -385,7 +386,7 @@ func cmgpCheckSummarizerBehavior(t *testing.T, ctx context.Context, token string
 	stopActive := &cmgpAdapter{name: "openai", respond: func(llm.Request) (llm.Response, error) {
 		return llm.Response{Message: llm.Assistant("should not run")}, nil
 	}}
-	if _, err := NewManager(profile, cmgpClient(stopActive, stopCheap)).summarizeWithLLMSteered(ctx, input, 2, ""); err == nil || len(stopActive.requests) != 0 {
+	if _, err := NewManager(profile, cmgpClient(stopActive, stopCheap), cheapmodel.New(cmgpClient(stopActive, stopCheap))).summarizeWithLLMSteered(ctx, input, 2, ""); err == nil || len(stopActive.requests) != 0 {
 		t.Fatalf("non-fallback summary error used active route: err=%v active=%d", err, len(stopActive.requests))
 	}
 }
@@ -423,7 +424,7 @@ func cmgpRunStrategyContracts(t *testing.T, program []byte) {
 
 func cmgpCheckCompactAndCheckpointStrategies(t *testing.T, ctx context.Context, token string, profile *provider.Profile, client *llm.Client, history []schema.Turn) {
 	t.Helper()
-	compactCM := NewManager(profile, client)
+	compactCM := NewManager(profile, client, cheapmodel.New(client))
 	compact := NewCompactStrategy(compactCM)
 	if compact.Name() != "compact" || len(compact.Tools()) != 0 || compact.AfterAction(ctx, history, client) != nil {
 		t.Fatal("compact strategy contract changed")
@@ -436,11 +437,11 @@ func cmgpCheckCompactAndCheckpointStrategies(t *testing.T, ctx context.Context, 
 	if err := (&CheckpointPredStrategy{}).ManageContext(ctx, &compactHistory, 0, cmgpNoopEmit); err != nil {
 		t.Fatalf("nil checkpoint strategy: %v", err)
 	}
-	zeroCheckpoint := NewCheckpointPredStrategy(NewManager(&provider.Profile{}, nil))
+	zeroCheckpoint := NewCheckpointPredStrategy(NewManager(&provider.Profile{}, nil, cheapmodel.New(nil)))
 	if err := zeroCheckpoint.ManageContext(ctx, &compactHistory, 0, cmgpNoopEmit); err != nil {
 		t.Fatalf("zero-window checkpoint strategy: %v", err)
 	}
-	predCM := NewManager(profile, client)
+	predCM := NewManager(profile, client, cheapmodel.New(client))
 	cmgpAggressiveThresholds(predCM)
 	pred := NewCheckpointPredStrategy(predCM)
 	if pred.Name() != "checkpoint-pred" || len(pred.Tools()) != 0 || pred.AfterAction(ctx, history, client) != nil {
@@ -458,11 +459,11 @@ func cmgpCheckCompactAndCheckpointStrategies(t *testing.T, ctx context.Context, 
 	if err := (&ObsMaskStrategy{}).ManageContext(ctx, &compactHistory, 0, cmgpNoopEmit); err != nil {
 		t.Fatalf("nil observation-mask strategy: %v", err)
 	}
-	zeroObs := NewObsMaskStrategy(NewManager(&provider.Profile{}, nil))
+	zeroObs := NewObsMaskStrategy(NewManager(&provider.Profile{}, nil, cheapmodel.New(nil)))
 	if err := zeroObs.ManageContext(ctx, &compactHistory, 0, cmgpNoopEmit); err != nil {
 		t.Fatalf("zero-window observation-mask strategy: %v", err)
 	}
-	obsCM := NewManager(profile, client)
+	obsCM := NewManager(profile, client, cheapmodel.New(client))
 	cmgpAggressiveThresholds(obsCM)
 	obs := NewObsMaskStrategy(obsCM)
 	if obs.Name() != "obs-mask" || len(obs.Tools()) != 0 || obs.AfterAction(ctx, history, client) != nil {
@@ -483,7 +484,7 @@ func cmgpCheckMemoryStrategies(t *testing.T, ctx context.Context, token string, 
 	if err := NewMemoryCrystalsStrategy(nil).AfterAction(ctx, history, client); err != nil {
 		t.Fatalf("nil memory-crystal strategy: %v", err)
 	}
-	mem := NewMemoryCrystalsStrategy(NewManager(profile, client))
+	mem := NewMemoryCrystalsStrategy(NewManager(profile, client, cheapmodel.New(client)))
 	if mem.Name() != "memory-crystals" || len(mem.Tools()) != 0 {
 		t.Fatal("memory-crystal strategy contract changed")
 	}
@@ -504,7 +505,7 @@ func cmgpCheckMemoryStrategies(t *testing.T, ctx context.Context, token string, 
 	badClient := cmgpClient(&cmgpAdapter{name: "openai", respond: func(llm.Request) (llm.Response, error) {
 		return llm.Response{}, errors.New("crystal failure")
 	}}, nil)
-	badMem := NewMemoryCrystalsStrategy(NewManager(profile, badClient))
+	badMem := NewMemoryCrystalsStrategy(NewManager(profile, badClient, cheapmodel.New(badClient)))
 	if err := badMem.AfterAction(ctx, history[:3], badClient); err != nil || len(badMem.crystals) != 0 {
 		t.Fatalf("failed crystal action = crystals:%d err:%v", len(badMem.crystals), err)
 	}
@@ -512,7 +513,7 @@ func cmgpCheckMemoryStrategies(t *testing.T, ctx context.Context, token string, 
 	if err := NewRecursiveDistillStrategy(nil).AfterAction(ctx, history, client); err != nil {
 		t.Fatalf("nil recursive-distill strategy: %v", err)
 	}
-	distill := NewRecursiveDistillStrategy(NewManager(profile, client))
+	distill := NewRecursiveDistillStrategy(NewManager(profile, client, cheapmodel.New(client)))
 	if distill.Name() != "recursive-distill" || len(distill.Tools()) != 0 {
 		t.Fatal("recursive-distill strategy contract changed")
 	}
@@ -520,10 +521,10 @@ func cmgpCheckMemoryStrategies(t *testing.T, ctx context.Context, token string, 
 	if err := distill.AfterAction(ctx, longHistory, client); err != nil || len(distill.microSummaries) != 1 {
 		t.Fatalf("recursive micro distill = micros:%d err:%v", len(distill.microSummaries), err)
 	}
-	if _, err := distill.microSummarize(ctx, client, longHistory); err != nil {
+	if _, err := distill.microSummarize(ctx, longHistory); err != nil {
 		t.Fatalf("recursive direct micro summary: %v", err)
 	}
-	if _, err := distill.macroSummarize(ctx, client, []string{"one", "two"}); err != nil {
+	if _, err := distill.macroSummarize(ctx, []string{"one", "two"}); err != nil {
 		t.Fatalf("recursive direct macro summary: %v", err)
 	}
 	distillHistory := append([]schema.Turn(nil), history[:4]...)
@@ -542,7 +543,7 @@ func cmgpCheckSessionLogAndOODAStrategies(t *testing.T, ctx context.Context, tok
 		t.Fatalf("nil session-log strategy: %v", err)
 	}
 	zeroHost := &fakeStrategyHost{stateDir: t.TempDir(), id: "zero", profile: &provider.Profile{}}
-	zeroLog, err := NewSessionLogStrategy(NewManager(&provider.Profile{}, nil), zeroHost)
+	zeroLog, err := NewSessionLogStrategy(NewManager(&provider.Profile{}, nil, cheapmodel.New(nil)), zeroHost)
 	if err != nil {
 		t.Fatalf("NewSessionLogStrategy zero profile: %v", err)
 	}
@@ -551,7 +552,7 @@ func cmgpCheckSessionLogAndOODAStrategies(t *testing.T, ctx context.Context, tok
 	}
 
 	host := &fakeStrategyHost{stateDir: t.TempDir(), id: "session-log", profile: profile}
-	sls, err := NewSessionLogStrategy(NewManager(profile, client), host)
+	sls, err := NewSessionLogStrategy(NewManager(profile, client, cheapmodel.New(client)), host)
 	if err != nil {
 		t.Fatalf("NewSessionLogStrategy: %v", err)
 	}
@@ -590,13 +591,13 @@ func cmgpCheckSessionLogAndOODAStrategies(t *testing.T, ctx context.Context, tok
 		t.Fatalf("nil profile AfterAction: %v", err)
 	}
 	badHost := &fakeStrategyHost{stateDir: t.TempDir(), id: "bad", profile: profile}
-	badSLS, err := NewSessionLogStrategy(NewManager(profile, client), badHost)
-	if err != nil {
-		t.Fatalf("NewSessionLogStrategy bad response: %v", err)
-	}
 	badForkClient := cmgpClient(&cmgpAdapter{name: "openai", respond: func(llm.Request) (llm.Response, error) {
 		return llm.Response{Message: llm.Assistant("not JSON")}, nil
 	}}, nil)
+	badSLS, err := NewSessionLogStrategy(NewManager(profile, badForkClient, cheapmodel.New(badForkClient)), badHost)
+	if err != nil {
+		t.Fatalf("NewSessionLogStrategy bad response: %v", err)
+	}
 	if err := badSLS.AfterAction(ctx, cmgpLongHistory(token, 12), badForkClient); err != nil || badHost.sideFx != 0 || badSLS.log.Len() != 0 {
 		t.Fatalf("failed fork result = sidefx:%d log:%d err:%v", badHost.sideFx, badSLS.log.Len(), err)
 	}
@@ -605,7 +606,7 @@ func cmgpCheckSessionLogAndOODAStrategies(t *testing.T, ctx context.Context, tok
 	}
 
 	oodaHost := &fakeStrategyHost{stateDir: t.TempDir(), id: "ooda", profile: profile}
-	ooda, err := NewOODAStrategy(NewManager(profile, client), oodaHost)
+	ooda, err := NewOODAStrategy(NewManager(profile, client, cheapmodel.New(client)), oodaHost)
 	if err != nil {
 		t.Fatalf("NewOODAStrategy: %v", err)
 	}
@@ -638,20 +639,20 @@ func cmgpCheckSessionLogAndOODAStrategies(t *testing.T, ctx context.Context, tok
 
 func cmgpCheckForkSummarize(t *testing.T, ctx context.Context, token string, profile *provider.Profile, client *llm.Client, history []schema.Turn) {
 	t.Helper()
-	entry, err := forkSummarize(ctx, client, profile, history, 17)
+	entry, err := forkSummarize(ctx, cheapmodel.New(client), profile, history, 17)
 	if err != nil || entry.Turn != 17 || entry.Action != "shell" {
 		t.Fatalf("fork summary = %+v, %v", entry, err)
 	}
 	badJSON := cmgpClient(&cmgpAdapter{name: "openai", respond: func(llm.Request) (llm.Response, error) {
 		return llm.Response{Message: llm.Assistant("not JSON")}, nil
 	}}, nil)
-	if _, err := forkSummarize(ctx, badJSON, profile, history, 1); err == nil {
+	if _, err := forkSummarize(ctx, cheapmodel.New(badJSON), profile, history, 1); err == nil {
 		t.Fatal("invalid fork JSON unexpectedly succeeded")
 	}
 	failed := cmgpClient(&cmgpAdapter{name: "openai", respond: func(llm.Request) (llm.Response, error) {
 		return llm.Response{}, errors.New("fork failure")
 	}}, nil)
-	if _, err := forkSummarize(ctx, failed, profile, history, 1); err == nil {
+	if _, err := forkSummarize(ctx, cheapmodel.New(failed), profile, history, 1); err == nil {
 		t.Fatal("failed fork completion unexpectedly succeeded")
 	}
 	prompt := buildSummarizePrompt([]schema.Turn{

--- a/agent/internal/contextmgr/maybecompact_fc1_seqfuzz_test.go
+++ b/agent/internal/contextmgr/maybecompact_fc1_seqfuzz_test.go
@@ -9,6 +9,7 @@ import (
 
 	"pgregory.net/rapid"
 
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
 
@@ -114,7 +115,7 @@ type fc1MaybeCompactModel struct {
 
 func newFc1MaybeCompactModel(preserveRecent int) *fc1MaybeCompactModel {
 	// nil client: only the deterministic checkpoint layer can fire.
-	cm := NewManager(testProfile("openai", "test", fc1MaybeCompactWindow), nil)
+	cm := NewManager(testProfile("openai", "test", fc1MaybeCompactWindow), nil, cheapmodel.New(nil))
 	cm.PreserveRecentTurns = preserveRecent
 	return &fc1MaybeCompactModel{preserveRecent: preserveRecent, cm: cm}
 }

--- a/agent/internal/contextmgr/strategy_checkpoint_pred.go
+++ b/agent/internal/contextmgr/strategy_checkpoint_pred.go
@@ -219,15 +219,11 @@ Generate a checkpoint preserving:
 
 Write ONLY the checkpoint content. Be specific and concise (under 500 words). Focus on information the agent CANNOT re-derive from the codebase.`, b.String())
 
-	cp := s.cm.currentProfile()
-	cheapProvider, cheapModel := cp.CheapModelRef()
 	req := llm.Request{
-		Model:    cheapModel,
-		Provider: cheapProvider,
 		Messages: []llm.Message{llm.User(prompt)},
 	}
 
-	resp, err := s.cm.client.Complete(ctx, req)
+	resp, err := s.cm.completeCheap(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/internal/contextmgr/strategy_checkpoint_pred_test.go
+++ b/agent/internal/contextmgr/strategy_checkpoint_pred_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
 )
@@ -48,7 +49,7 @@ func TestPredictiveCheckpoint_AttentionResolutionDoesNotConsumeRecentSlots(t *te
 	client.Register(&fakeAdapter{name: "openai", steps: []func(llm.Request) llm.Response{
 		func(llm.Request) llm.Response { return llm.Response{Message: llm.Assistant("unexpected checkpoint")} },
 	}})
-	cm := NewManager(testOpenAIProfileWithContextWindow(1000), client)
+	cm := NewManager(testOpenAIProfileWithContextWindow(1000), client, cheapmodel.New(client))
 	got, err := NewCheckpointPredStrategy(cm).predictiveCheckpoint(context.Background(), history, 2)
 	if err != nil {
 		t.Fatalf("predictiveCheckpoint: %v", err)
@@ -61,7 +62,7 @@ func TestPredictiveCheckpoint_AttentionResolutionDoesNotConsumeRecentSlots(t *te
 func TestCheckpointPredStrategy_ManageContext_NoCompactionBelowThreshold(t *testing.T) {
 	client := llm.NewClient()
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	s := NewCheckpointPredStrategy(cm)
 
 	history := []schema.Turn{
@@ -86,7 +87,7 @@ func TestCheckpointPredStrategy_PredictiveCheckpoint_FallbackOnError(t *testing.
 	// to deterministic checkpoint.
 	client := llm.NewClient()
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	// Set very low thresholds so compaction fires.
 	cm.ObservationMaskThreshold = 0.0001
 	cm.ThinkingClearThreshold = 0.0001
@@ -161,7 +162,7 @@ func TestCheckpointPredStrategy_PredictiveCheckpoint_WithLLM(t *testing.T) {
 	client.Register(f)
 
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	cm.ObservationMaskThreshold = 0.0001
 	cm.ThinkingClearThreshold = 0.0001
 	cm.CheckpointThreshold = 0.0001
@@ -214,7 +215,7 @@ func TestCheckpointPredStrategy_PredictiveCheckpoint_TurnKind(t *testing.T) {
 	client.Register(f)
 
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	cm.ObservationMaskThreshold = 0.0001
 	cm.ThinkingClearThreshold = 0.0001
 	cm.CheckpointThreshold = 0.0001
@@ -250,7 +251,7 @@ func TestCheckpointPredStrategy_FiresOnCompactionTurn_FallbackCheckpoint(t *test
 	// the callback should fire with the checkpoint turn.
 	client := llm.NewClient()
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	cm.ObservationMaskThreshold = 0.0001
 	cm.ThinkingClearThreshold = 0.0001
 	cm.CheckpointThreshold = 0.0001
@@ -308,7 +309,7 @@ func TestCheckpointPredStrategy_FiresOnCompactionTurn_PredictiveCheckpoint(t *te
 	client.Register(f)
 
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	cm.ObservationMaskThreshold = 0.0001
 	cm.ThinkingClearThreshold = 0.0001
 	cm.CheckpointThreshold = 0.0001
@@ -380,7 +381,7 @@ func TestCheckpointPredStrategy_FiresOnCompactionTurn_Summarize(t *testing.T) {
 	client.Register(f)
 
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	// All thresholds very low so all layers fire.
 	cm.ObservationMaskThreshold = 0.0001
 	cm.ThinkingClearThreshold = 0.0001

--- a/agent/internal/contextmgr/strategy_host_test.go
+++ b/agent/internal/contextmgr/strategy_host_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/internal/sessionlog"
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
@@ -75,7 +76,7 @@ func TestSessionLogStrategy_OperatesWithFakeHost(t *testing.T) {
 
 	// Constructor accepts the fake host (not a real Session) and uses
 	// StateDir/ID to build the log path.
-	sls, err := NewSessionLogStrategy(NewManager(profile, client), host)
+	sls, err := NewSessionLogStrategy(NewManager(profile, client, cheapmodel.New(client)), host)
 	if err != nil {
 		t.Fatalf("newSessionLogStrategy with fake host: %v", err)
 	}
@@ -127,7 +128,7 @@ func TestSessionLogStrategy_AttentionResolutionDoesNotDisplaceRecentContext(t *t
 	client.Register(adapter)
 	profile := testOpenAIProfileWithContextWindow(1000)
 	host := &fakeStrategyHost{stateDir: t.TempDir(), id: "marker-window", profile: profile}
-	strategy, err := NewSessionLogStrategy(NewManager(profile, client), host)
+	strategy, err := NewSessionLogStrategy(NewManager(profile, client, cheapmodel.New(client)), host)
 	if err != nil {
 		t.Fatalf("NewSessionLogStrategy: %v", err)
 	}

--- a/agent/internal/contextmgr/strategy_memory_crystals.go
+++ b/agent/internal/contextmgr/strategy_memory_crystals.go
@@ -107,7 +107,7 @@ func (s *MemoryCrystalsStrategy) AfterAction(ctx context.Context, history []sche
 		recent = recent[len(recent)-6:]
 	}
 
-	crystal, err := s.crystallize(ctx, client, recent, turnCount)
+	crystal, err := s.crystallize(ctx, recent, turnCount)
 	if err != nil {
 		return nil //nolint:nilerr // crystallization is a best-effort optimization; failure is non-fatal
 	}
@@ -119,7 +119,7 @@ func (s *MemoryCrystalsStrategy) AfterAction(ctx context.Context, history []sche
 }
 
 // crystallize calls the cheap model to extract key facts from recent turns.
-func (s *MemoryCrystalsStrategy) crystallize(ctx context.Context, client *llm.Client, recent []schema.Turn, turnNumber int) (MemoryCrystal, error) {
+func (s *MemoryCrystalsStrategy) crystallize(ctx context.Context, recent []schema.Turn, turnNumber int) (MemoryCrystal, error) {
 	var b strings.Builder
 	for _, t := range recent {
 		switch t.Kind {
@@ -147,15 +147,11 @@ Recent action:
 %s
 Key facts (one line):`, b.String())
 
-	cp := s.cm.currentProfile()
-	cheapProvider, cheapModel := cp.CheapModelRef()
 	req := llm.Request{
-		Model:    cheapModel,
-		Provider: cheapProvider,
 		Messages: []llm.Message{llm.User(prompt)},
 	}
 
-	resp, err := client.Complete(ctx, req)
+	resp, err := s.cm.completeCheap(ctx, req)
 	if err != nil {
 		return MemoryCrystal{}, err
 	}

--- a/agent/internal/contextmgr/strategy_memory_crystals_test.go
+++ b/agent/internal/contextmgr/strategy_memory_crystals_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
 )
@@ -34,7 +35,7 @@ func TestMemoryCrystalsStrategy_AfterAction_SkipsNonThirdTurn(t *testing.T) {
 	client.Register(spy)
 
 	profile := NewOpenAIProfile("gpt-5.2")
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	s := NewMemoryCrystalsStrategy(cm)
 
 	// 2 turns — not a multiple of 3, so no crystallization.
@@ -60,7 +61,7 @@ func TestMemoryCrystalsStrategy_AttentionResolutionDoesNotAdvanceCadence(t *test
 	client := llm.NewClient()
 	spy := &fakeAdapter{name: "openai"}
 	client.Register(spy)
-	s := NewMemoryCrystalsStrategy(NewManager(NewOpenAIProfile("gpt-5.2"), client))
+	s := NewMemoryCrystalsStrategy(NewManager(NewOpenAIProfile("gpt-5.2"), client, cheapmodel.New(client)))
 	marker := schema.NewTurn(schema.TurnAttentionResolution, llm.System("private marker"))
 	marker.AttentionResolution = &schema.AttentionResolutionInfo{AttentionID: "private", Disposition: "consumed"}
 	history := []schema.Turn{
@@ -94,7 +95,7 @@ func TestMemoryCrystalsStrategy_AfterAction_CrystallizesEveryThird(t *testing.T)
 	client.Register(f)
 
 	profile := NewOpenAIProfile("gpt-5.2")
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	s := NewMemoryCrystalsStrategy(cm)
 
 	// 3 turns — multiple of 3, should trigger crystallization.
@@ -128,7 +129,7 @@ func TestMemoryCrystalsStrategy_AfterAction_CrystallizesEveryThird(t *testing.T)
 }
 
 func TestMemoryCrystalsStrategy_InjectCrystals(t *testing.T) {
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil, cheapmodel.New(nil))
 	s := NewMemoryCrystalsStrategy(cm)
 	s.crystals = []MemoryCrystal{
 		{Turn: 3, Action: "read_file", Facts: "Read auth.go, 200 lines"},
@@ -165,7 +166,7 @@ func TestMemoryCrystalsStrategy_InjectCrystals(t *testing.T) {
 }
 
 func TestMemoryCrystalsStrategy_InjectCrystals_RemovesOld(t *testing.T) {
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil, cheapmodel.New(nil))
 	s := NewMemoryCrystalsStrategy(cm)
 	s.crystals = []MemoryCrystal{
 		{Turn: 3, Action: "test", Facts: "new crystal"},
@@ -198,7 +199,7 @@ func TestMemoryCrystalsStrategy_InjectCrystals_RemovesOld(t *testing.T) {
 }
 
 func TestMemoryCrystalsStrategy_PruneOldCrystals(t *testing.T) {
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil, cheapmodel.New(nil))
 	s := NewMemoryCrystalsStrategy(cm)
 
 	// Add 25 crystals.

--- a/agent/internal/contextmgr/strategy_obs_mask_test.go
+++ b/agent/internal/contextmgr/strategy_obs_mask_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
 )
@@ -39,7 +40,7 @@ func TestObsMaskStrategy_AfterAction_Noop(t *testing.T) {
 func TestObsMaskStrategy_ManageContext_NoCompactionBelowThreshold(t *testing.T) {
 	client := llm.NewClient()
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	s := NewObsMaskStrategy(cm)
 
 	history := []schema.Turn{
@@ -156,7 +157,7 @@ func TestAggressiveMaskObservations_SkipsAlreadyMasked(t *testing.T) {
 func TestObsMaskStrategy_ManageContext_FiresOnCompactionTurn_Checkpoint(t *testing.T) {
 	client := llm.NewClient()
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	// Set thresholds so both layers fire.
 	cm.ObservationMaskThreshold = 0.0001
 	cm.CheckpointThreshold = 0.0001

--- a/agent/internal/contextmgr/strategy_ooda_test.go
+++ b/agent/internal/contextmgr/strategy_ooda_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/internal/sessionlog"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
@@ -42,7 +43,7 @@ func TestOODAStrategy_Tools_InheritsFromSessionLogStrategy(t *testing.T) {
 func TestOODAStrategy_ManageContext_NoOrientMessageWhenLogEmpty(t *testing.T) {
 	client := llm.NewClient()
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 
 	// Set thresholds high so no compaction occurs.
 	cm.ObservationMaskThreshold = 0.99
@@ -82,7 +83,7 @@ func TestOODAStrategy_ManageContext_NoOrientMessageWhenLogEmpty(t *testing.T) {
 func TestOODAStrategy_ManageContext_InjectsOrientMessageWhenLogHasEntries(t *testing.T) {
 	client := llm.NewClient()
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 
 	// Set thresholds high so no compaction occurs.
 	cm.ObservationMaskThreshold = 0.99
@@ -157,7 +158,7 @@ func TestOODAStrategy_ManageContext_InjectsOrientMessageWhenLogHasEntries(t *tes
 func TestOODAStrategy_ManageContext_OrientTextUsesTranscriptTools(t *testing.T) {
 	client := llm.NewClient()
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 
 	cm.ObservationMaskThreshold = 0.99
 	cm.ThinkingClearThreshold = 0.99
@@ -209,7 +210,7 @@ func TestOODAStrategy_ManageContext_OrientTextUsesTranscriptTools(t *testing.T) 
 func TestOODAStrategy_ManageContext_TruncatesVeryLargeLog(t *testing.T) {
 	client := llm.NewClient()
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 
 	// Set thresholds high so no compaction occurs.
 	cm.ObservationMaskThreshold = 0.99
@@ -269,7 +270,7 @@ func TestOODAStrategy_ManageContext_TruncatesVeryLargeLog(t *testing.T) {
 func TestOODAStrategy_ManageContext_AppliesCompactionLayers(t *testing.T) {
 	client := llm.NewClient()
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 
 	// Set low thresholds to trigger compaction.
 	cm.ObservationMaskThreshold = 0.05
@@ -379,7 +380,7 @@ func TestOODAStrategy_AfterAction_InheritsFromSessionLogStrategy(t *testing.T) {
 
 	ooda := &OODAStrategy{
 		SessionLogStrategy: &SessionLogStrategy{
-			cm:      NewManager(profile, client),
+			cm:      NewManager(profile, client, cheapmodel.New(client)),
 			log:     mustNewSessionLog(t, logPath),
 			session: &fakeStrategyHost{profile: profile},
 		},

--- a/agent/internal/contextmgr/strategy_recursive_distill.go
+++ b/agent/internal/contextmgr/strategy_recursive_distill.go
@@ -113,7 +113,7 @@ func (s *RecursiveDistillStrategy) AfterAction(ctx context.Context, history []sc
 
 	// Micro-summary every 10 turns.
 	if turnCount-s.lastMicroAt >= 10 {
-		micro, err := s.microSummarize(ctx, client, history)
+		micro, err := s.microSummarize(ctx, history)
 		if err == nil {
 			s.microSummaries = append(s.microSummaries, micro)
 			s.lastMicroAt = turnCount
@@ -121,7 +121,7 @@ func (s *RecursiveDistillStrategy) AfterAction(ctx context.Context, history []sc
 
 		// Macro-summary every 50 turns (when we've accumulated 5 micro-summaries).
 		if len(s.microSummaries) >= 5 && turnCount-s.lastMacroAt >= 50 {
-			macro, err := s.macroSummarize(ctx, client, s.microSummaries)
+			macro, err := s.macroSummarize(ctx, s.microSummaries)
 			if err == nil {
 				s.macroSummaries = append(s.macroSummaries, macro)
 				s.microSummaries = nil // Reset after folding into macro.
@@ -134,7 +134,7 @@ func (s *RecursiveDistillStrategy) AfterAction(ctx context.Context, history []sc
 }
 
 // microSummarize distills the last 10 turns into 1-2 sentences.
-func (s *RecursiveDistillStrategy) microSummarize(ctx context.Context, client *llm.Client, history []schema.Turn) (string, error) {
+func (s *RecursiveDistillStrategy) microSummarize(ctx context.Context, history []schema.Turn) (string, error) {
 	recent := history
 	if len(recent) > 10 {
 		recent = recent[len(recent)-10:]
@@ -165,15 +165,11 @@ func (s *RecursiveDistillStrategy) microSummarize(ctx context.Context, client *l
 %s
 Status update:`, b.String())
 
-	cp := s.cm.currentProfile()
-	cheapProvider, cheapModel := cp.CheapModelRef()
 	req := llm.Request{
-		Model:    cheapModel,
-		Provider: cheapProvider,
 		Messages: []llm.Message{llm.User(prompt)},
 	}
 
-	resp, err := client.Complete(ctx, req)
+	resp, err := s.cm.completeCheap(ctx, req)
 	if err != nil {
 		return "", err
 	}
@@ -182,7 +178,7 @@ Status update:`, b.String())
 }
 
 // macroSummarize folds multiple micro-summaries into a single overview sentence.
-func (s *RecursiveDistillStrategy) macroSummarize(ctx context.Context, client *llm.Client, micros []string) (string, error) {
+func (s *RecursiveDistillStrategy) macroSummarize(ctx context.Context, micros []string) (string, error) {
 	var b strings.Builder
 	for i, m := range micros {
 		fmt.Fprintf(&b, "%d. %s\n", i+1, m)
@@ -196,15 +192,11 @@ func (s *RecursiveDistillStrategy) macroSummarize(ctx context.Context, client *l
 %s
 Progress report:`, b.String())
 
-	cp := s.cm.currentProfile()
-	cheapProvider, cheapModel := cp.CheapModelRef()
 	req := llm.Request{
-		Model:    cheapModel,
-		Provider: cheapProvider,
 		Messages: []llm.Message{llm.User(prompt)},
 	}
 
-	resp, err := client.Complete(ctx, req)
+	resp, err := s.cm.completeCheap(ctx, req)
 	if err != nil {
 		return "", err
 	}

--- a/agent/internal/contextmgr/strategy_recursive_distill_test.go
+++ b/agent/internal/contextmgr/strategy_recursive_distill_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
 )
@@ -36,7 +37,7 @@ func TestRecursiveDistillStrategy_AfterAction_NoMicroBelowThreshold(t *testing.T
 	client.Register(f)
 
 	profile := NewOpenAIProfile("gpt-5.2")
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	s := NewRecursiveDistillStrategy(cm)
 
 	// 5 turns — not enough for micro-summary (needs 10).
@@ -62,7 +63,7 @@ func TestRecursiveDistillStrategy_AttentionResolutionDoesNotAdvanceCadence(t *te
 	client := llm.NewClient()
 	spy := &fakeAdapter{name: "openai"}
 	client.Register(spy)
-	s := NewRecursiveDistillStrategy(NewManager(NewOpenAIProfile("gpt-5.2"), client))
+	s := NewRecursiveDistillStrategy(NewManager(NewOpenAIProfile("gpt-5.2"), client, cheapmodel.New(client)))
 	history := make([]schema.Turn, 9, 10)
 	for i := range history {
 		history[i] = schema.NewTurn(schema.TurnAssistant, llm.Assistant("visible action"))
@@ -96,7 +97,7 @@ func TestRecursiveDistillStrategy_AfterAction_MicroAt10Turns(t *testing.T) {
 	client.Register(f)
 
 	profile := NewOpenAIProfile("gpt-5.2")
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	s := NewRecursiveDistillStrategy(cm)
 
 	// 10 turns — should trigger micro-summary.
@@ -149,7 +150,7 @@ func TestRecursiveDistillStrategy_AfterAction_MacroAt50Turns(t *testing.T) {
 	client.Register(f)
 
 	profile := NewOpenAIProfile("gpt-5.2")
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	s := NewRecursiveDistillStrategy(cm)
 
 	// Pre-populate with 4 micro-summaries (simulating turns 10-40).
@@ -189,7 +190,7 @@ func TestRecursiveDistillStrategy_AfterAction_MacroAt50Turns(t *testing.T) {
 }
 
 func TestRecursiveDistillStrategy_InjectDistilledContext(t *testing.T) {
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil, cheapmodel.New(nil))
 	s := NewRecursiveDistillStrategy(cm)
 	s.macroSummaries = []string{"Phase 1: investigated and found root cause."}
 	s.microSummaries = []string{"Applied fix to auth.go.", "Running tests."}
@@ -225,7 +226,7 @@ func TestRecursiveDistillStrategy_InjectDistilledContext(t *testing.T) {
 }
 
 func TestRecursiveDistillStrategy_InjectDistilledContext_RemovesOld(t *testing.T) {
-	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil)
+	cm := NewManager(NewOpenAIProfile("gpt-5.2"), nil, cheapmodel.New(nil))
 	s := NewRecursiveDistillStrategy(cm)
 	s.microSummaries = []string{"new summary"}
 

--- a/agent/internal/contextmgr/strategy_session_log.go
+++ b/agent/internal/contextmgr/strategy_session_log.go
@@ -241,8 +241,10 @@ func extractOriginalPromptLine(text, prefix string) string {
 }
 
 // AfterAction forks a summarization of the recent turns and appends the
-// result to the session log. Errors from the LLM are non-fatal.
-func (s *SessionLogStrategy) AfterAction(ctx context.Context, history []schema.Turn, client *llm.Client) error {
+// result to the session log. Errors from the LLM are non-fatal. The fork runs
+// on the manager's shared cheap caller, not on the client the host passes, so
+// that a cheap model the provider refuses is learned once per session.
+func (s *SessionLogStrategy) AfterAction(ctx context.Context, history []schema.Turn, _ *llm.Client) error {
 	if s.session == nil || s.session.Profile() == nil {
 		return nil
 	}
@@ -253,7 +255,7 @@ func (s *SessionLogStrategy) AfterAction(ctx context.Context, history []schema.T
 	if len(recent) > 10 {
 		recent = recent[len(recent)-10:]
 	}
-	entry, err := forkSummarize(ctx, client, s.session.Profile(), recent, len(history))
+	entry, err := forkSummarize(ctx, s.cm.cheap, s.session.Profile(), recent, len(history))
 	if err != nil {
 		return nil //nolint:nilerr // fork summarization is best-effort; failure must not fail the session
 	}

--- a/agent/internal/contextmgr/strategy_session_log_test.go
+++ b/agent/internal/contextmgr/strategy_session_log_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/internal/sessionlog"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
@@ -37,7 +38,7 @@ func TestSessionLogStrategy_Tools_Empty(t *testing.T) {
 func TestSessionLogStrategy_ManageContext_ObservationMaskAtHighPressure(t *testing.T) {
 	client := llm.NewClient()
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 
 	// Set a low observation mask threshold so compaction triggers on our test data.
 	cm.ObservationMaskThreshold = 0.05
@@ -114,7 +115,7 @@ func TestSessionLogStrategy_ManageContext_ObservationMaskAtHighPressure(t *testi
 func TestSessionLogStrategy_ManageContext_SessionLogCheckpointAtHighPressure(t *testing.T) {
 	client := llm.NewClient()
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 
 	// Set thresholds so checkpoint triggers but not summarize.
 	cm.ObservationMaskThreshold = 0.01
@@ -240,7 +241,7 @@ func TestSessionLogStrategy_AfterAction_CallsForkSummarizeAndAppendsToLog(t *tes
 	logPath := filepath.Join(dir, "test.log.jsonl")
 
 	sls := &SessionLogStrategy{
-		cm:      NewManager(profile, client),
+		cm:      NewManager(profile, client, cheapmodel.New(client)),
 		log:     mustNewSessionLog(t, logPath),
 		session: &fakeStrategyHost{profile: profile},
 	}
@@ -297,7 +298,7 @@ func TestSessionLogStrategy_AfterAction_LLMErrorIsNonFatal(t *testing.T) {
 	logPath := filepath.Join(dir, "test.log.jsonl")
 
 	sls := &SessionLogStrategy{
-		cm:      NewManager(profile, client),
+		cm:      NewManager(profile, client, cheapmodel.New(client)),
 		log:     mustNewSessionLog(t, logPath),
 		session: &fakeStrategyHost{profile: profile},
 	}
@@ -423,7 +424,7 @@ func TestSessionLogStrategy_SessionLogCheckpoint_ContainsTranscriptRecoveryPoint
 	logPath := filepath.Join(dir, "test.log.jsonl")
 
 	const sessionID = "sess-abc-123"
-	cm := NewManager(nil, nil)
+	cm := NewManager(nil, nil, cheapmodel.New(nil))
 	cm.Meta.AvailableTranscriptTools = []string{"read_transcript", "find_session_transcripts"}
 	sls := &SessionLogStrategy{
 		cm:      cm,
@@ -495,7 +496,7 @@ func TestSessionLogCheckpoint_AttentionResolutionDoesNotConsumeRecentSlots(t *te
 func TestSessionLogStrategy_FiresOnCompactionTurn_Checkpoint(t *testing.T) {
 	client := llm.NewClient()
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	cm.ObservationMaskThreshold = 0.0001
 	cm.ThinkingClearThreshold = 0.0001
 	cm.CheckpointThreshold = 0.0001
@@ -557,7 +558,7 @@ func TestSessionLogStrategy_FiresOnCompactionTurn_Summarize(t *testing.T) {
 	client.Register(f)
 
 	profile := testOpenAIProfileWithContextWindow(1000)
-	cm := NewManager(profile, client)
+	cm := NewManager(profile, client, cheapmodel.New(client))
 	// All thresholds very low so all layers fire.
 	cm.ObservationMaskThreshold = 0.0001
 	cm.ThinkingClearThreshold = 0.0001

--- a/agent/internal/contextmgr/summarize_obedience_eval_test.go
+++ b/agent/internal/contextmgr/summarize_obedience_eval_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/internal/liveeval"
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
@@ -362,7 +363,7 @@ func newRealSummarizerManager(t *testing.T) *Manager {
 		t.Skip("no profile could be built for available provider")
 	}
 
-	return NewManager(prof, client)
+	return NewManager(prof, client, cheapmodel.New(client))
 }
 
 // turnsFromText converts a raw text string into a slice of schema.Turns large

--- a/agent/internal/contextmgr/task8_strategy_fuzz_test.go
+++ b/agent/internal/contextmgr/task8_strategy_fuzz_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/internal/sessionlog"
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
@@ -85,7 +86,7 @@ func t8RunStrategyProgram(t *testing.T, program []byte, evidence string) {
 
 func t8RunMemoryCrystals(ctx context.Context, t *testing.T, profile *provider.Profile, client *llm.Client, history []schema.Turn, program []byte, userEvidence, terminalEvidence string) {
 	t.Helper()
-	strategy := NewMemoryCrystalsStrategy(NewManager(profile, client))
+	strategy := NewMemoryCrystalsStrategy(NewManager(profile, client, cheapmodel.New(client)))
 	steps := 1 + int(t8ProgramByte(program, 0)%24)
 	for step := 1; step <= steps; step++ {
 		if err := strategy.AfterAction(ctx, history[:step*3], client); err != nil {
@@ -110,7 +111,7 @@ func t8RunMemoryCrystals(ctx context.Context, t *testing.T, profile *provider.Pr
 
 func t8RunRecursiveDistill(ctx context.Context, t *testing.T, profile *provider.Profile, client *llm.Client, history []schema.Turn, program []byte, userEvidence, terminalEvidence string) {
 	t.Helper()
-	strategy := NewRecursiveDistillStrategy(NewManager(profile, client))
+	strategy := NewRecursiveDistillStrategy(NewManager(profile, client, cheapmodel.New(client)))
 	steps := 1 + int(t8ProgramByte(program, 1)%6)
 	for step := 1; step <= steps; step++ {
 		if err := strategy.AfterAction(ctx, history[:step*10], client); err != nil {
@@ -144,7 +145,7 @@ func t8RunRecursiveDistill(ctx context.Context, t *testing.T, profile *provider.
 func t8RunOODA(ctx context.Context, t *testing.T, profile *provider.Profile, client *llm.Client, history []schema.Turn, userEvidence, terminalEvidence string) {
 	t.Helper()
 	host := &fakeStrategyHost{stateDir: t.TempDir(), id: "task8-ooda", profile: profile}
-	strategy, err := NewOODAStrategy(NewManager(profile, client), host)
+	strategy, err := NewOODAStrategy(NewManager(profile, client, cheapmodel.New(client)), host)
 	if err != nil {
 		t.Fatalf("NewOODAStrategy: %v", err)
 	}
@@ -183,7 +184,7 @@ func t8RunOODA(ctx context.Context, t *testing.T, profile *provider.Profile, cli
 	if !strings.Contains(string(persisted), userEvidence) || !strings.Contains(string(persisted), terminalEvidence) {
 		t.Fatalf("persisted OODA log lost evidence: %q", persisted)
 	}
-	reopened, err := NewOODAStrategy(NewManager(profile, client), host)
+	reopened, err := NewOODAStrategy(NewManager(profile, client, cheapmodel.New(client)), host)
 	if err != nil {
 		t.Fatalf("reopen OODA strategy: %v", err)
 	}
@@ -202,7 +203,7 @@ func t8RunOODA(ctx context.Context, t *testing.T, profile *provider.Profile, cli
 
 func t8AssertUsageAndMetrics(t *testing.T, profile *provider.Profile, history []schema.Turn, program []byte) {
 	t.Helper()
-	cm := NewManager(profile, nil)
+	cm := NewManager(profile, nil, cheapmodel.New(nil))
 	base := int(t8ProgramByte(program, 3))
 	cm.SetCumulativeUsage(llm.Usage{InputTokens: base, OutputTokens: base / 2, TotalTokens: base + base/2})
 	cm.AddUsage(llm.Usage{InputTokens: 3, OutputTokens: 2, TotalTokens: 5})

--- a/agent/provider/profile.go
+++ b/agent/provider/profile.go
@@ -651,19 +651,6 @@ func (p *Profile) CrossProviderRef(ref string) bool {
 	return decidePrefixAction(p.behaviorTag, p.id, prefix) == prefixActionSwitch
 }
 
-// WithCommunicateOverridesFrom carries forward caller-applied tool-schema
-// overrides from original onto p, a freshly-rebuilt profile. The constructor for
-// the new profile/model handles model-derived state (context window, effort
-// levels, providerOpts, the new provider's default toolset); this layers caller
-// modifications back on top so WithCommunicateOutputSchema / WithAllowedDecisions
-// overrides survive both same-provider WithModel rebuilds AND cross-provider
-// switches performed by a resolver.
-//
-// Only the "communicate" tool is preserved — both With* helpers modify that tool
-// exclusively. Other tools recompute from the new constructor so the new
-// provider's defaults (toolNameMap, etc.) take effect.
-//
-// p is returned unchanged when either profile is nil.
 // withCheapModelFrom carries the cheap-model routing (set via WithCheapModel)
 // from original onto p. A constructor rebuild resets these to empty, so a
 // rebuild-based WithModel must restore them or side calls (naming, summarization,

--- a/agent/session.go
+++ b/agent/session.go
@@ -13,6 +13,7 @@ import (
 	"primeradiant.com/evener/agent/envctx"
 	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/internal/clock"
 	"primeradiant.com/evener/agent/internal/contextmgr"
 	"primeradiant.com/evener/agent/internal/goal"
@@ -72,6 +73,7 @@ type Session struct {
 	artifactStore          artifactStore
 	ownsArtifactStore      bool
 	client                 *llm.Client
+	cheap                  *cheapmodel.Caller
 	profile                *provider.Profile
 	resolveProfile         func(ref string) (*provider.Profile, error) // cross-provider resolver; may be nil
 	// lastDroppedModelFallbacks records the cfg.ModelFallbacks entries dropped

--- a/agent/session_attention_test.go
+++ b/agent/session_attention_test.go
@@ -21,6 +21,7 @@ import (
 	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/internal/agenttest"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/internal/contextmgr"
 	"primeradiant.com/evener/agent/internal/delegatestore"
 	"primeradiant.com/evener/agent/schema"
@@ -967,7 +968,7 @@ func TestDelegateAttention_ResolutionMarkerDoesNotSplitToolCallAndResult(t *test
 				schema.NewTurn(schema.TurnToolResults, llm.ToolResultNamed(callID, "probe", "real result", false)),
 				schema.NewTurn(schema.TurnAssistant, llm.Assistant("recent")),
 			}
-			manager := contextmgr.NewManager(NewOpenAIProfile("gpt-5.2"), nil)
+			manager := contextmgr.NewManager(NewOpenAIProfile("gpt-5.2"), nil, cheapmodel.New(nil))
 			manager.PreserveRecentTurns = test.preserveRecent
 			manager.ForceCompact(context.Background(), &history, "", func(events.EventKind, events.EventData) {})
 
@@ -2434,7 +2435,7 @@ func TestDelegateAttention_FailedTerminalDeliveryRetriesFromRootPump(t *testing.
 	t.Cleanup(func() { _ = rootWriter.Close() })
 	clock := agenttest.NewFakeClock()
 	root := &Session{id: "root-session", stateDir: c.stateDir, delegateController: c, events: make(chan events.SessionEvent, 16), profile: NewOpenAIProfile("gpt-5.2"), clock: clock}
-	root.contextMgr = contextmgr.NewManager(root.profile, nil)
+	root.contextMgr = contextmgr.NewManager(root.profile, nil, cheapmodel.New(nil))
 	root.sessionCtx, root.cancelFunc = context.WithCancel(context.Background())
 	t.Cleanup(root.cancelFunc)
 	root.attachTranscript(rootWriter)

--- a/agent/session_aux_exact_fuzz_test.go
+++ b/agent/session_aux_exact_fuzz_test.go
@@ -15,6 +15,7 @@ import (
 
 	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/internal/contextmgr"
 	"primeradiant.com/evener/agent/internal/hooks"
 	"primeradiant.com/evener/agent/plugin"
@@ -55,7 +56,7 @@ func FuzzSessionAuxExactProgram(f *testing.F) {
 			s := newSession(t)
 			s.contextMgr.CheckpointThreshold = 0
 			s.contextMgr.PreserveRecentTurns = 0
-			s.contextMgr = contextmgr.NewManager(s.profile, nil)
+			s.contextMgr = contextmgr.NewManager(s.profile, nil, cheapmodel.New(nil))
 			s.contextMgr.CheckpointThreshold = 0
 			s.contextMgr.PreserveRecentTurns = 0
 			s.maybeElicitNoteBeforeCompaction(context.Background(), []schema.Turn{schema.NewTurn(schema.TurnUserInput, llm.User("x"))}, 0)

--- a/agent/session_cheap_model_test.go
+++ b/agent/session_cheap_model_test.go
@@ -1,0 +1,90 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/internal/agenttest"
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/llm"
+)
+
+// TestCheapModelRefusalIsLearnedOnceForTheWholeSession is the wiring proof for
+// the cheap-model fallback: web_fetch and the context manager share one caller,
+// so a refusal learned by one is respected by the other. The policy itself is
+// tested in agent/internal/cheapmodel.
+func TestCheapModelRefusalIsLearnedOnceForTheWholeSession(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	page := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = fmt.Fprint(w, `<html><body><h1>Cheap Model Page</h1></body></html>`)
+	}))
+	t.Cleanup(page.Close)
+
+	// The served model answers with a session-log entry, which satisfies both
+	// consumers: web_fetch echoes the text, forkSummarize parses it.
+	entry, err := json.Marshal(map[string]any{
+		"action": "web_fetch", "summary": "Fetched a page.", "outcome": "success",
+	})
+	if err != nil {
+		t.Fatalf("marshal session log entry: %v", err)
+	}
+	// A Codex backend on a ChatGPT account: it serves its own model and refuses
+	// gpt-4.1-nano with an HTTP 400 (evener#313).
+	fa := &agenttest.ModelTrackingAdapter{Provider: "openai"}
+	fa.Respond = func(req llm.Request) (llm.Response, error) {
+		if req.Model != "test-model" {
+			return llm.Response{}, llm.ErrorFromHTTPStatus("openai", 400,
+				fmt.Sprintf("The '%s' model is not supported when using Codex with a ChatGPT account", req.Model), nil, nil)
+		}
+		return llm.Response{Message: llm.Assistant(string(entry))}, nil
+	}
+
+	c := llm.NewClient()
+	c.Register(fa)
+	sess, err := NewSession(c, NewOpenAIProfile("test-model"), execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{
+		ContextStrategy: "session-log",
+		StateDir:        t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	t.Cleanup(sess.Close)
+
+	res := sess.reg.ExecuteCall(context.Background(), sess.env, llm.ToolCallData{
+		ID:        "wf1",
+		Name:      "web_fetch",
+		Arguments: json.RawMessage(fmt.Sprintf(`{"url": %q, "question": "What is this page about?"}`, page.URL)),
+	})
+	if res.IsError {
+		t.Fatalf("web_fetch failed after the cheap model was refused: %s", res.Output)
+	}
+
+	// The context manager's summarizer is a different call site in a different
+	// package; it must inherit what web_fetch already paid to learn.
+	history := []schema.Turn{
+		{Kind: schema.TurnAssistant, Message: llm.Message{
+			Role: llm.RoleAssistant,
+			Content: []llm.ContentPart{
+				{Kind: llm.ContentToolCall, ToolCall: &llm.ToolCallData{
+					ID: "wf1", Name: "web_fetch", Arguments: json.RawMessage(`{"url":"x"}`),
+				}},
+			},
+		}},
+		{Kind: schema.TurnToolResults, Message: llm.ToolResultNamed("wf1", "web_fetch", "fetched", false)},
+	}
+	if err := sess.strategy.AfterAction(context.Background(), history, sess.client); err != nil {
+		t.Fatalf("AfterAction: %v", err)
+	}
+
+	want := []string{"gpt-4.1-nano", "test-model", "test-model"}
+	if got := fa.Models(); !slices.Equal(got, want) {
+		t.Fatalf("models addressed = %v, want %v", got, want)
+	}
+}

--- a/agent/session_go_tail_coverage_fuzz_test.go
+++ b/agent/session_go_tail_coverage_fuzz_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/afero"
 	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/internal/clock"
 	"primeradiant.com/evener/agent/internal/contextmgr"
 	"primeradiant.com/evener/agent/internal/tool"
@@ -224,7 +225,7 @@ func FuzzSessionGoTailCoverage(f *testing.F) {
 				id:         "autosave",
 				stateDir:   blocker,
 				profile:    profile,
-				contextMgr: contextmgr.NewManager(profile, nil),
+				contextMgr: contextmgr.NewManager(profile, nil, cheapmodel.New(nil)),
 				clock:      newTailCoverageClock(),
 				events:     make(chan events.SessionEvent, 1),
 			}

--- a/agent/session_hook_turn_test.go
+++ b/agent/session_hook_turn_test.go
@@ -13,6 +13,7 @@ import (
 
 	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/internal/contextmgr"
 	"primeradiant.com/evener/agent/internal/tool"
 	"primeradiant.com/evener/agent/schema"
@@ -261,7 +262,7 @@ func TestCompactedHookToolExchangeProjectsValidProviderMessages(t *testing.T) {
 				schema.NewTurn(schema.TurnToolResults, llm.ToolResultNamed(callID, "probe", "ok", false)),
 				schema.Turn{Kind: schema.TurnAssistant, Message: llm.Assistant("recent")},
 			)
-			cm := contextmgr.NewManager(NewOpenAIProfile("gpt-5.2"), nil)
+			cm := contextmgr.NewManager(NewOpenAIProfile("gpt-5.2"), nil, cheapmodel.New(nil))
 			cm.PreserveRecentTurns = tc.preserveRecent
 			cm.ForceCompact(context.Background(), &history, "", func(events.EventKind, events.EventData) {})
 

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -19,6 +19,7 @@ import (
 	"primeradiant.com/evener/agent/envctx"
 	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/internal/cheapmodel"
 	"primeradiant.com/evener/agent/internal/clock"
 	"primeradiant.com/evener/agent/internal/contextmgr"
 	"primeradiant.com/evener/agent/internal/goal"
@@ -1054,6 +1055,7 @@ func cacheReadPtr(n int64) *int {
 // The Session struct fields (client, profile, env, cfg) must already be set.
 // Returns the prompt sources so the caller can emit events after SessionStart.
 func (s *Session) initSessionState(sessionStartKind plugin.SessionStartKind, runSessionStartHooks bool) ([]promptSource, error) {
+	s.cheap = cheapmodel.New(s.client)
 	env := s.currentEnv()
 	ei := s.snapshotEnvironmentInfo(env)
 	ei.KnowledgeCutoff = s.profile.KnowledgeCutoff()
@@ -1135,7 +1137,7 @@ func (s *Session) initSessionState(sessionStartKind plugin.SessionStartKind, run
 		return nil, err
 	}
 
-	s.contextMgr = contextmgr.NewManager(s.profile, s.client)
+	s.contextMgr = contextmgr.NewManager(s.profile, s.client, s.cheap)
 	s.contextMgr.ResultToolName = s.resultToolName()
 
 	var reg *tool.Registry

--- a/agent/tool_web_fetch.go
+++ b/agent/tool_web_fetch.go
@@ -154,17 +154,14 @@ func (s *Session) webFetchWithRuntime(ctx context.Context, rawURL string, questi
 
 	// Call cheap model to answer the question.
 	p := s.currentProfile()
-	cheapProvider, cheapModel := p.CheapModelRef()
 	cheapReq := llm.Request{
-		Model:    cheapModel,
-		Provider: cheapProvider,
 		Messages: []llm.Message{
 			llm.System("You are a web content analyst. Read the provided content and answer the user's question concisely."),
 			llm.User(fmt.Sprintf("URL: %s\n\nQuestion: %s\n\nContent:\n%s", rawURL, question, readableContent)),
 		},
 	}
 
-	cheapResp, err := s.client.Complete(ctx, cheapReq)
+	cheapResp, err := s.cheap.Complete(ctx, p, cheapReq)
 	if err != nil {
 		return nil, fmt.Errorf("cheap model call failed: %w", err)
 	}

--- a/test/scenarios/workspace-title-bar-actions.md
+++ b/test/scenarios/workspace-title-bar-actions.md
@@ -243,8 +243,8 @@ head and runs it as a fresh user turn.
 - **Step 3 (compact)**: hub returns `204 No Content`. The transcript grows by
   one entry of `turn.kind = "CHECKPOINT"` (`agent/schema/turn.go:28`) whose
   text starts with `[CONTEXT CHECKPOINT]`
-  (`agent/internal/contextmgr/context_manager.go:998-1000`, the final
-  assembly that writes it first — not the old-format reader at `:802`)
+  (`agent/internal/contextmgr/context_manager.go:1010`, the final
+  assembly that writes it first — not the old-format reader at `:812`)
   and includes the prior
   user messages and agent replies summarized. `turn_count` is unchanged. The
   POST is synchronous over the whole compaction, which is **two** layers, not


### PR DESCRIPTION
Closes #325. Addresses the fallback half of #313 and #349.

## The failure

Auxiliary calls — `web_fetch`'s summarizer, compaction summaries and checkpoints, fork summaries, retention-probe judging — ask the profile for a cheap model, which for the `openai` behavior tag defaults to `gpt-4.1-nano`. That default is a per-provider guess, not a per-account fact, and two live provider paths reject it outright:

- **ChatGPT-account auth (#313)**: the Codex backend serves only its own model set and answers `The 'gpt-4.1-nano' model is not supported when using Codex with a ChatGPT account` (HTTP 400). Every `web_fetch` in the trial failed; the agent burned ~2m39s of a 900s budget falling back to hand-rolled `curl`.
- **Bedrock (#349)**: the OpenAI-compatible endpoint serves Bedrock slugs and answers `The provided model identifier is invalid` (HTTP 400). 5 of 6 trials across two task families lost the summarizer to one poisoned request each, then the fetch lane was dead for the run.

Each call site addressed the cheap model itself, so nothing could learn from a rejection and every site paid for it again.

## The design

One session-scoped owner: `cheapmodel.Caller` (`agent/internal/cheapmodel/caller.go`), built once in `initSessionState` and shared by every auxiliary call site. It owns the whole cheap→session decision:

- **Resolve.** `profile.CheapModelRef()` has exactly one production call site, inside the Caller.
- **Probe.** Before spending a request, the Caller asks the client's own static compatibility check (`ValidateModelCompatibility`, the same check that gates a model switch) whether the provider will serve the pair. That decides the ChatGPT-account case with zero wasted requests.
- **Retry once.** When the provider's reply says it will not serve the model at all, the Caller retries the same request on the session's own model and instance — never a third provider that happens to be registered.
- **Latch.** A refusal is recorded per `(provider, model)` and only when the retry succeeded: the same rejection on the session model means the cheap model was not the problem, so the caller gets its original error and the next call still tries the cheap model. Keying on the pair means a mid-session model switch gives the new profile's cheap model its own probe rather than inheriting a verdict about the old one's.
- **One attempt group.** The cheap attempt and the fallback attempt share a single API-attempt group, so the API log shows one logical call.

**What counts as a refusal** is deliberately narrow: a permanent-classified error carrying one of two wordings observed in the field. A broader match would cost a session its cheap model over an ordinary bad request. Transient failures (429, 5xx, a provider-flagged retryable 403) keep their normal retry semantics, buy no second call, and record nothing — including a 429 that happens to echo the refusal wording. The comment on `refusesModel` names the maintenance expectation: if a provider rewords, the reactive path degrades to "no fallback", and the proactive probe still covers pairs the client can know about.

**Consumers are thin.** `web_fetch`, the retention-probe judge, `forkSummarize` and the compaction strategies hand the Caller a request with no `Provider`/`Model` set and let it resolve. `contextmgr.NewManager` takes the session's Caller as an argument — it is the only constructor, so a manager cannot be built with a private refusal cache that relearns what `web_fetch` already paid for.

Summarization is the one consumer with a second rung of its own, because it treats a wider class of failures than a model refusal as worth another model (`shouldFallbackSummarizationModel`: `ErrorClassFallback`, or permanent + invalid-request/not-found/access-denied). It no longer re-derives which routes the Caller took: `Caller.CompleteConfigured` reports whether it reached the session model, and the summarizer's ladder stops there when it has. `CompleteConfigured` also declines an unconfigured provider-default cheap model — folding a whole context onto a nano model nobody chose is a quality regression, and that policy now lives with the Caller rather than in a consumer branch.

## Deliberately out of scope

- **The session namer.** Its enablement is gated on a cheap model being *configured*, precisely because naming is not worth the main model. Making it fall back would quietly reverse that cost decision.
- **A non-summarizing `web_fetch`.** It still fails when both models are refused; raw-fetch mode is the other half of #349.

## Test evidence

Policy is tested where it lives; one end-to-end test proves the session wiring.

`agent/internal/cheapmodel` (10 tests): both field-observed wire shapes (Codex-worded 400, Bedrock's unnamed-model 400) falling back and latching; a generic 400/403/404 neither falling back nor latching; a **429 carrying the refusal wording** neither falling back nor latching; **no second request when the cheap ref is the session model**; an adapter that declares its models never receiving the cheap request at all; the joined error when the fallback fails too, with `llm.Kind` reporting the fallback's timeout rather than the refusal's invalid-request; a refusal surviving a model switch but not a provider switch; `CompleteConfigured` preferring the session model over a provider default and reporting the routes it ran; and one shared API-attempt group across cheap + fallback.

`agent/internal/contextmgr` (2 added, plus the existing summarization suite): a refused cheap model is paid for once across repeated elicitations; and the summarizer does not re-run a route the Caller already ran — the case that previously double-fired, now driven by a test that failed before the fix.

`agent` (1 test): after `web_fetch` pays for the refusal, the context manager's summarizer — a different call site in a different package — goes straight to the session model. Models addressed across the session: `[gpt-4.1-nano, test-model, test-model]`.

Two mutation checks pin the guards a reviewer flagged as unproven, each watched to fail with the mutation applied and pass without it:

- deleting the permanence gate in `refusesModel` → caught by the retryable-429 test;
- deleting the `cheap == active` guard before the retry → caught by the identical-route test.

`contextmgr`'s `SessionLogStrategy.AfterAction` now ignores the client the host passes (the fork runs on the shared Caller), which had silently defanged a fuzz seed that injected a failing client; the parameter is `_` and the seed builds its manager on the failing client instead.

Gates run in the foreground on the final tree: `gofmt -l .` clean, `make build-go`, `make vet`, `make lint`, `WEB=0 make test` (all 8 modules green), `make fuzz-seeds`, and `go test -race` on `agent`, `agent/provider`, `agent/internal/cheapmodel`, `agent/internal/contextmgr`.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT
