### PR TITLE
feat: parse rich model metadata from provider /models endpoints

### DIFF
--- a/agent/session_set_model.go
+++ b/agent/session_set_model.go
@@ -119,7 +119,7 @@ func validateModelSwitchMembership(client *llm.Client, profile *provider.Profile
 	tag := client.BehaviorTagOf(profile.ID())
 	cat := llm.EmbeddedModelCatalog()
 	for _, m := range models {
-		if m.ID == profile.Model() && modelSwitchVisible(tag, m.ID, cat) {
+		if m.ID == profile.Model() && modelSwitchVisible(tag, m, cat) {
 			return nil
 		}
 	}
@@ -144,7 +144,7 @@ func formatModelAlternatives(models []llm.ModelInfo, tag string, cat *llm.ModelC
 	seen := make(map[string]bool, len(models))
 	var ids []string
 	for _, m := range models {
-		if !modelSwitchVisible(tag, m.ID, cat) || seen[m.ID] {
+		if !modelSwitchVisible(tag, m, cat) || seen[m.ID] {
 			continue
 		}
 		seen[m.ID] = true
@@ -164,7 +164,8 @@ func formatModelAlternatives(models []llm.ModelInfo, tag string, cat *llm.ModelC
 // modelSwitchVisible delegates to the shared llm.ModelCatalog.VisibleLiveModel
 // rule so the in-session model-switch path, the launch-check path, and the hub
 // /api/models path share one visibility rule and cannot drift. See
-// VisibleLiveModel for the OpenRouter bare-live-ID resolution this fixes.
-func modelSwitchVisible(behaviorTag, modelID string, cat *llm.ModelCatalog) bool {
-	return cat.VisibleLiveModel(behaviorTag, modelID)
+// VisibleLiveModel for the live-API-first tool-support resolution this
+// implements.
+func modelSwitchVisible(behaviorTag string, live llm.ModelInfo, cat *llm.ModelCatalog) bool {
+	return cat.VisibleLiveModel(behaviorTag, live)
 }

--- a/cmd/evener-hub/web_spawn.go
+++ b/cmd/evener-hub/web_spawn.go
@@ -390,9 +390,9 @@ func (s *WebServer) fetchLiveModels(ctx context.Context) []map[string]any {
 		}
 		for _, m := range models {
 			// VisibleLiveModel applies the shared non-chat skip rule and, for
-			// the openrouter tag, the catalog tools-capability filter. This is
-			// the same rule the launch-check path uses (llm.VisibleLiveModel),
-			// so the two live-model paths cannot drift.
+			// the openrouter tag, the live/catalog tool-capability filter.
+			// This is the same rule the launch-check path uses
+			// (llm.VisibleLiveModel), so the two live-model paths cannot drift.
 			if !cat.VisibleLiveModel(tag, m) {
 				continue
 			}
@@ -407,44 +407,67 @@ func (s *WebServer) fetchLiveModels(ctx context.Context) []map[string]any {
 				"model":        m.ID,
 				"display_name": prettifyModelDisplayName(m.ID),
 			}
+			// --- Live-first population: values parsed from the provider's
+			// /models response are authoritative when the provider reported
+			// them. The catalog only fills gaps the live response left open.
 			if m.ContextWindow > 0 {
 				entry["context_window"] = m.ContextWindow
 			}
-			if m.SupportsTools {
-				entry["supports_tools"] = true
+			if m.CapabilitiesAdvertised {
+				// The provider explicitly reported capabilities — emit them
+				// even when false (e.g. SupportsTools=false means the provider
+				// says no tools, which is different from "unknown").
+				entry["supports_tools"] = m.SupportsTools
+				entry["supports_vision"] = m.SupportsVision
+				entry["supports_reasoning"] = m.SupportsReasoning
+			} else {
+				// Provider didn't report capabilities — emit only the true
+				// values (zero-value false is not authoritative).
+				if m.SupportsTools {
+					entry["supports_tools"] = true
+				}
+				if m.SupportsReasoning {
+					entry["supports_reasoning"] = true
+				}
 			}
-			if m.SupportsReasoning {
-				entry["supports_reasoning"] = true
-			}
-			// Prefer effort levels the provider advertised live; fall back to the
-			// catalog below.
 			if len(m.ReasoningEffortLevels) > 0 {
 				entry["reasoning_effort_levels"] = m.ReasoningEffortLevels
 			}
-			// Keep catalog enrichment for metadata the live endpoint omits, but
-			// never replace a live token limit with a catalog value.
+			if m.InputCostPerMillion != nil {
+				entry["input_cost_per_million"] = *m.InputCostPerMillion
+			}
+			if m.OutputCostPerMillion != nil {
+				entry["output_cost_per_million"] = *m.OutputCostPerMillion
+			}
+			if m.MaxOutputTokens != nil {
+				entry["max_output_tokens"] = *m.MaxOutputTokens
+			}
+			// --- Catalog enrichment: fill fields the live response didn't
+			// provide. Never overwrite a live value with a catalog value.
 			if mi != nil {
 				if _, ok := entry["context_window"]; !ok && mi.ContextWindow > 0 {
 					entry["context_window"] = mi.ContextWindow
 				}
-				entry["input_cost_per_million"] = mi.InputCostPerMillion
-				entry["output_cost_per_million"] = mi.OutputCostPerMillion
-				if _, ok := entry["supports_tools"]; !ok {
+				if _, ok := entry["input_cost_per_million"]; !ok && mi.InputCostPerMillion != nil {
+					entry["input_cost_per_million"] = *mi.InputCostPerMillion
+				}
+				if _, ok := entry["output_cost_per_million"]; !ok && mi.OutputCostPerMillion != nil {
+					entry["output_cost_per_million"] = *mi.OutputCostPerMillion
+				}
+				if _, ok := entry["supports_tools"]; !ok && mi.SupportsTools {
 					entry["supports_tools"] = mi.SupportsTools
 				}
-				if _, ok := entry["supports_reasoning"]; !ok {
+				if _, ok := entry["supports_reasoning"]; !ok && mi.SupportsReasoning {
 					entry["supports_reasoning"] = mi.SupportsReasoning
 				}
 				if _, ok := entry["reasoning_effort_levels"]; !ok && len(mi.ReasoningEffortLevels) > 0 {
 					entry["reasoning_effort_levels"] = mi.ReasoningEffortLevels
 				}
-				if _, ok := entry["supports_vision"]; !ok {
+				if _, ok := entry["supports_vision"]; !ok && mi.SupportsVision {
 					entry["supports_vision"] = mi.SupportsVision
 				}
-				if mi.MaxOutputTokens != nil {
-					if _, ok := entry["max_output_tokens"]; !ok {
-						entry["max_output_tokens"] = *mi.MaxOutputTokens
-					}
+				if _, ok := entry["max_output_tokens"]; !ok && mi.MaxOutputTokens != nil {
+					entry["max_output_tokens"] = *mi.MaxOutputTokens
 				}
 				if mi.SupportsWebSearch != nil {
 					if _, ok := entry["supports_web_search"]; !ok {

--- a/cmd/evener-hub/web_spawn.go
+++ b/cmd/evener-hub/web_spawn.go
@@ -393,7 +393,7 @@ func (s *WebServer) fetchLiveModels(ctx context.Context) []map[string]any {
 			// the openrouter tag, the catalog tools-capability filter. This is
 			// the same rule the launch-check path uses (llm.VisibleLiveModel),
 			// so the two live-model paths cannot drift.
-			if !cat.VisibleLiveModel(tag, m.ID) {
+			if !cat.VisibleLiveModel(tag, m) {
 				continue
 			}
 			mi := catalogModelInfo(cat, tag, m.ID)

--- a/cmd/evener/internal/launchcheck/coverage_test.go
+++ b/cmd/evener/internal/launchcheck/coverage_test.go
@@ -137,7 +137,7 @@ func TestLaunchCheckPureHelpersRemainingBranches(t *testing.T) {
 		t.Fatal("nil error reported unavailable")
 	}
 	for _, id := range []string{"embedding", "whisper", "tts", "dall-e", "moderation", "audio", "transcribe", "image"} {
-		if launchCheckModelVisible("other", id, nil) {
+		if launchCheckModelVisible("other", llm.ModelInfo{ID: id}, nil) {
 			t.Fatalf("media model %q visible", id)
 		}
 	}
@@ -150,7 +150,7 @@ func FuzzLaunchCheckClassifiers(f *testing.F) {
 	f.Add("openrouter", "text-embedding-3-small", "http 403")
 	f.Add("openai", "gpt-5", "connection refused")
 	f.Fuzz(func(t *testing.T, tag, modelID, message string) {
-		_ = launchCheckModelVisible(tag, modelID, llm.EmbeddedModelCatalog())
+		_ = launchCheckModelVisible(tag, llm.ModelInfo{ID: modelID}, llm.EmbeddedModelCatalog())
 		_ = launchCheckModelListUnavailable(errors.New(message))
 	})
 }
@@ -279,13 +279,13 @@ func FuzzLaunchCheckProgram(f *testing.F) {
 			}
 		case 17:
 			for _, id := range []string{"embedding", "whisper", "tts", "dall-e", "moderation", "audio", "transcribe", "image"} {
-				if launchCheckModelVisible("other", id, nil) {
+				if launchCheckModelVisible("other", llm.ModelInfo{ID: id}, nil) {
 					t.Fatalf("media model %q visible", id)
 				}
 			}
 		case 18:
-			_ = launchCheckModelVisible("openrouter", "not-in-catalog", llm.EmbeddedModelCatalog())
-			_ = launchCheckModelVisible("openrouter", "gpt-5", llm.EmbeddedModelCatalog())
+			_ = launchCheckModelVisible("openrouter", llm.ModelInfo{ID: "not-in-catalog"}, llm.EmbeddedModelCatalog())
+			_ = launchCheckModelVisible("openrouter", llm.ModelInfo{ID: "gpt-5"}, llm.EmbeddedModelCatalog())
 			_ = launchCheckCatalogModelInfo(nil, "model")
 		case 19:
 			if len(value) < 8 {

--- a/cmd/evener/internal/launchcheck/launchcheck.go
+++ b/cmd/evener/internal/launchcheck/launchcheck.go
@@ -174,7 +174,7 @@ func launchCheckModels() ([]launchCheckModel, []appwire.ModelListDiagnostic, err
 		}
 		sort.Slice(models, func(i, j int) bool { return models[i].ID < models[j].ID })
 		for _, model := range models {
-			if !launchCheckModelVisible(tag, model.ID, cat) {
+			if !launchCheckModelVisible(tag, model, cat) {
 				continue
 			}
 			out = append(out, launchCheckModel{Provider: provider, Model: model.ID})
@@ -236,7 +236,7 @@ func validateLaunchCheckModel(ref cmdutil.ModelRef) error {
 	cat := llm.EmbeddedModelCatalog()
 	tag := client.BehaviorTagOf(ref.Provider)
 	for _, model := range models {
-		if model.ID == ref.Model && launchCheckModelVisible(tag, model.ID, cat) {
+		if model.ID == ref.Model && launchCheckModelVisible(tag, model, cat) {
 			return nil
 		}
 	}
@@ -267,13 +267,13 @@ func launchCheckModelListUnavailable(err error) bool {
 		strings.Contains(msg, "network is unreachable")
 }
 
-// launchCheckModelVisible reports whether modelID should appear in the launch
-// model list for a provider with the given behavior tag. It delegates to the
-// shared llm.ModelCatalog.VisibleLiveModel rule so the launch-check path and the
-// hub /api/models path cannot drift. See VisibleLiveModel for the OpenRouter
-// bare-live-ID vs prefix-keyed-catalog resolution this fixes.
-func launchCheckModelVisible(behaviorTag, modelID string, cat *llm.ModelCatalog) bool {
-	return cat.VisibleLiveModel(behaviorTag, modelID)
+// launchCheckModelVisible reports whether a live model should appear in the
+// launch model list for a provider with the given behavior tag. It delegates to
+// the shared llm.ModelCatalog.VisibleLiveModel rule so the launch-check path and
+// the hub /api/models path cannot drift. See VisibleLiveModel for the
+// live-API-first tool-support resolution this implements.
+func launchCheckModelVisible(behaviorTag string, live llm.ModelInfo, cat *llm.ModelCatalog) bool {
+	return cat.VisibleLiveModel(behaviorTag, live)
 }
 
 // launchCheckCatalogModelInfo resolves catalog metadata for a live model ID,

--- a/cmd/evener/internal/launchcheck/launchcheck_test.go
+++ b/cmd/evener/internal/launchcheck/launchcheck_test.go
@@ -337,11 +337,11 @@ func TestLaunchCheckModelVisibleFiltersByBehaviorTag(t *testing.T) {
 	cat := llm.EmbeddedModelCatalog()
 
 	// With the canonical tag "openrouter", a model absent from the catalog is hidden.
-	if launchCheckModelVisible("openrouter", "not-in-catalog-xyz", cat) {
+	if launchCheckModelVisible("openrouter", llm.ModelInfo{ID: "not-in-catalog-xyz"}, cat) {
 		t.Error("model not in catalog should be hidden when behaviorTag is openrouter")
 	}
 	// With a non-openrouter tag, any non-media model is visible.
-	if !launchCheckModelVisible("some-other-tag", "not-in-catalog-xyz", cat) {
+	if !launchCheckModelVisible("some-other-tag", llm.ModelInfo{ID: "not-in-catalog-xyz"}, cat) {
 		t.Error("model should be visible when behaviorTag is not openrouter")
 	}
 }
@@ -372,7 +372,7 @@ func TestLaunchCheckModelVisible_OpenRouterBareLiveID(t *testing.T) {
 	}
 
 	// The bare live ID must now survive the launch-check visibility filter.
-	if !launchCheckModelVisible("openrouter", "anthropic/claude-sonnet-4.5", cat) {
+	if !launchCheckModelVisible("openrouter", llm.ModelInfo{ID: "anthropic/claude-sonnet-4.5"}, cat) {
 		t.Error("bare OpenRouter live ID should be visible after the shared-helper fix")
 	}
 }

--- a/llm/model_catalog.go
+++ b/llm/model_catalog.go
@@ -51,7 +51,15 @@ type ModelInfo struct {
 	CacheReadInputCostPerMillion  *float64 `json:"cache_read_input_cost_per_million,omitempty"`
 	CacheCreation5mCostPerMillion *float64 `json:"cache_creation_5m_cost_per_million,omitempty"`
 	CacheCreation1hCostPerMillion *float64 `json:"cache_creation_1h_cost_per_million,omitempty"`
-	Aliases                       []string `json:"aliases,omitempty"`
+	// CapabilitiesAdvertised marks that the live /models endpoint reported
+	// capability metadata (e.g. OpenRouter's supported_parameters). When true,
+	// SupportsTools/SupportsVision/SupportsReasoning are authoritative values
+	// from the provider, not zero-value defaults — an explicit false means the
+	// provider says the model does NOT support that capability, and callers
+	// must not fall back to the catalog. When false (the provider didn't
+	// return capability metadata), callers should fall back to the catalog.
+	CapabilitiesAdvertised bool     `json:"capabilities_advertised,omitempty"`
+	Aliases                []string `json:"aliases,omitempty"`
 }
 
 // ModelCatalog holds a set of ModelInfo entries and a lazily-built index for
@@ -286,11 +294,14 @@ func (c *ModelCatalog) ResolveLiveModelInfo(behaviorTag, modelID string) *ModelI
 // VisibleLiveModel reports whether modelID should appear in a live model list for
 // a provider with the given behavior tag. It returns false for non-chat model IDs
 // (IsChatModelID) and, for the "openrouter" tag, for models that lack tool
-// support. Tool support is determined from the live ModelInfo first (parsed
-// from the provider's /models response — e.g. OpenRouter's supported_parameters
-// list), falling back to the embedded catalog (ResolveLiveModelInfo) when the
-// live response doesn't report it. Other behavior tags do not gate on the
-// catalog: a live /models entry is visible as long as it is a chat model.
+// support. When the live ModelInfo has CapabilitiesAdvertised=true (the
+// provider's /models response reported capability metadata, e.g.
+// OpenRouter's supported_parameters list), the live SupportsTools value is
+// authoritative — an explicit false hides the model even if the catalog says
+// it supports tools. When CapabilitiesAdvertised is false (the provider didn't
+// return capability metadata), it falls back to the embedded catalog
+// (ResolveLiveModelInfo). Other behavior tags do not gate on the catalog: a
+// live /models entry is visible as long as it is a chat model.
 //
 // This consolidates the visibility rule previously duplicated (and drifted)
 // between cmd/evener/internal/launchcheck.launchCheckModelVisible and
@@ -298,7 +309,8 @@ func (c *ModelCatalog) ResolveLiveModelInfo(behaviorTag, modelID string) *ModelI
 //
 // live is the ModelInfo returned by the provider's ListModels call. It carries
 // capability data parsed from the live /models response (SupportsTools,
-// SupportsVision, etc.) which takes priority over the catalog for visibility.
+// SupportsVision, etc.) which takes priority over the catalog for visibility
+// when the provider actually reported them.
 func (c *ModelCatalog) VisibleLiveModel(behaviorTag string, live ModelInfo) bool {
 	if !IsChatModelID(live.ID) {
 		return false
@@ -306,14 +318,14 @@ func (c *ModelCatalog) VisibleLiveModel(behaviorTag string, live ModelInfo) bool
 	if behaviorTag != "openrouter" {
 		return true
 	}
-	// Prefer live capability data: if the provider's /models response reports
-	// tool support (OpenRouter's supported_parameters includes "tools"), the
-	// model is visible regardless of whether the catalog knows about it.
-	if live.SupportsTools {
-		return true
+	// When the provider reported capability metadata, the live SupportsTools
+	// value is authoritative — true means visible, false means hidden, even
+	// if the catalog disagrees.
+	if live.CapabilitiesAdvertised {
+		return live.SupportsTools
 	}
-	// Fall back to the catalog when the live response doesn't report tool
-	// support — some providers' /models endpoints omit capability metadata.
+	// Fall back to the catalog when the live response doesn't report
+	// capability metadata — some providers' /models endpoints omit it.
 	mi := c.ResolveLiveModelInfo(behaviorTag, live.ID)
 	return mi != nil && mi.SupportsTools
 }

--- a/llm/model_catalog.go
+++ b/llm/model_catalog.go
@@ -285,22 +285,36 @@ func (c *ModelCatalog) ResolveLiveModelInfo(behaviorTag, modelID string) *ModelI
 
 // VisibleLiveModel reports whether modelID should appear in a live model list for
 // a provider with the given behavior tag. It returns false for non-chat model IDs
-// (IsChatModelID) and, for the "openrouter" tag, for models that do not resolve in
-// the catalog (ResolveLiveModelInfo) or lack tool support. Other behavior tags do
-// not gate on the catalog: a live /models entry is visible as long as it is a
-// chat model.
+// (IsChatModelID) and, for the "openrouter" tag, for models that lack tool
+// support. Tool support is determined from the live ModelInfo first (parsed
+// from the provider's /models response — e.g. OpenRouter's supported_parameters
+// list), falling back to the embedded catalog (ResolveLiveModelInfo) when the
+// live response doesn't report it. Other behavior tags do not gate on the
+// catalog: a live /models entry is visible as long as it is a chat model.
 //
 // This consolidates the visibility rule previously duplicated (and drifted)
 // between cmd/evener/internal/launchcheck.launchCheckModelVisible and
 // cmd/evener-hub/web_spawn.go's fetchLiveModels.
-func (c *ModelCatalog) VisibleLiveModel(behaviorTag, modelID string) bool {
-	if !IsChatModelID(modelID) {
+//
+// live is the ModelInfo returned by the provider's ListModels call. It carries
+// capability data parsed from the live /models response (SupportsTools,
+// SupportsVision, etc.) which takes priority over the catalog for visibility.
+func (c *ModelCatalog) VisibleLiveModel(behaviorTag string, live ModelInfo) bool {
+	if !IsChatModelID(live.ID) {
 		return false
 	}
 	if behaviorTag != "openrouter" {
 		return true
 	}
-	mi := c.ResolveLiveModelInfo(behaviorTag, modelID)
+	// Prefer live capability data: if the provider's /models response reports
+	// tool support (OpenRouter's supported_parameters includes "tools"), the
+	// model is visible regardless of whether the catalog knows about it.
+	if live.SupportsTools {
+		return true
+	}
+	// Fall back to the catalog when the live response doesn't report tool
+	// support — some providers' /models endpoints omit capability metadata.
+	mi := c.ResolveLiveModelInfo(behaviorTag, live.ID)
 	return mi != nil && mi.SupportsTools
 }
 

--- a/llm/model_catalog_test.go
+++ b/llm/model_catalog_test.go
@@ -1332,8 +1332,28 @@ func TestVisibleLiveModel_OpenRouterBareLiveID(t *testing.T) {
 
 	// The bare live ID must be visible: ResolveLiveModelInfo's tag-qualified
 	// fallback resolves it, and the entry supports tools.
-	if !cat.VisibleLiveModel("openrouter", "anthropic/claude-sonnet-4.5") {
-		t.Error("VisibleLiveModel(openrouter, anthropic/claude-sonnet-4.5) = false, want true")
+	// The live ModelInfo doesn't report SupportsTools (simulating an older
+	// /models response), so the catalog fallback determines visibility.
+	if !cat.VisibleLiveModel("openrouter", ModelInfo{ID: "anthropic/claude-sonnet-4.5"}) {
+		t.Error("VisibleLiveModel(openrouter, {anthropic/claude-sonnet-4.5}) = false, want true")
+	}
+}
+
+// TestVisibleLiveModel_OpenRouterLiveToolsShortCircuits verifies that when the
+// live /models response reports SupportsTools (e.g. OpenRouter's
+// supported_parameters includes "tools"), the model is visible even if it is
+// absent from the embedded catalog entirely. This is the live-API-first rule:
+// the catalog is enrichment, not the gate.
+func TestVisibleLiveModel_OpenRouterLiveToolsShortCircuits(t *testing.T) {
+	cat := EmbeddedModelCatalog()
+	// A model OpenRouter serves that the embedded catalog doesn't know about.
+	// (If it does exist, skip — the live-tools path is the point.)
+	if cat.GetModelInfo("stealth/ox-alpha") != nil {
+		t.Skip("catalog changed: stealth/ox-alpha now exists")
+	}
+	live := ModelInfo{ID: "stealth/ox-alpha", SupportsTools: true}
+	if !cat.VisibleLiveModel("openrouter", live) {
+		t.Error("live SupportsTools=true model should be visible even when absent from catalog")
 	}
 }
 
@@ -1345,10 +1365,10 @@ func TestVisibleLiveModel_NonChatAndNonToolHidden(t *testing.T) {
 
 	// Non-chat IDs are hidden regardless of tag.
 	for _, id := range []string{"text-embedding-3-small", "whisper-1", "tts-1"} {
-		if cat.VisibleLiveModel("openrouter", id) {
+		if cat.VisibleLiveModel("openrouter", ModelInfo{ID: id}) {
 			t.Errorf("non-chat model %q should be hidden", id)
 		}
-		if cat.VisibleLiveModel("openai", id) {
+		if cat.VisibleLiveModel("openai", ModelInfo{ID: id}) {
 			t.Errorf("non-chat model %q should be hidden for openai tag", id)
 		}
 	}
@@ -1360,13 +1380,13 @@ func TestVisibleLiveModel_NonChatAndNonToolHidden(t *testing.T) {
 	} else if mi.SupportsTools {
 		t.Skip("catalog changed: mistralai/mistral-7b-instruct now supports tools")
 	}
-	if cat.VisibleLiveModel("openrouter", "mistralai/mistral-7b-instruct") {
+	if cat.VisibleLiveModel("openrouter", ModelInfo{ID: "mistralai/mistral-7b-instruct"}) {
 		t.Error("non-tool openrouter model should be hidden")
 	}
 
 	// A non-openrouter tag does not gate on the catalog: a chat model is visible
 	// even when absent from the catalog.
-	if !cat.VisibleLiveModel("openai", "some-uncataloged-chat-model") {
+	if !cat.VisibleLiveModel("openai", ModelInfo{ID: "some-uncataloged-chat-model"}) {
 		t.Error("uncataloged chat model should be visible for non-openrouter tag")
 	}
 
@@ -1374,13 +1394,13 @@ func TestVisibleLiveModel_NonChatAndNonToolHidden(t *testing.T) {
 	// chat IDs for openrouter are hidden (cannot resolve tools); chat IDs for
 	// other tags are visible.
 	var nilCat *ModelCatalog
-	if nilCat.VisibleLiveModel("openrouter", "text-embedding-3-small") {
+	if nilCat.VisibleLiveModel("openrouter", ModelInfo{ID: "text-embedding-3-small"}) {
 		t.Error("nil catalog: non-chat model should be hidden")
 	}
-	if nilCat.VisibleLiveModel("openrouter", "gpt-5") {
+	if nilCat.VisibleLiveModel("openrouter", ModelInfo{ID: "gpt-5"}) {
 		t.Error("nil catalog: openrouter chat model should be hidden (cannot verify tools)")
 	}
-	if !nilCat.VisibleLiveModel("openai", "gpt-5") {
+	if !nilCat.VisibleLiveModel("openai", ModelInfo{ID: "gpt-5"}) {
 		t.Error("nil catalog: non-openrouter chat model should be visible")
 	}
 }

--- a/llm/model_catalog_test.go
+++ b/llm/model_catalog_test.go
@@ -1340,10 +1340,10 @@ func TestVisibleLiveModel_OpenRouterBareLiveID(t *testing.T) {
 }
 
 // TestVisibleLiveModel_OpenRouterLiveToolsShortCircuits verifies that when the
-// live /models response reports SupportsTools (e.g. OpenRouter's
-// supported_parameters includes "tools"), the model is visible even if it is
-// absent from the embedded catalog entirely. This is the live-API-first rule:
-// the catalog is enrichment, not the gate.
+// live /models response reports SupportsTools with CapabilitiesAdvertised
+// (e.g. OpenRouter's supported_parameters includes "tools"), the model is
+// visible even if it is absent from the embedded catalog entirely. This is the
+// live-API-first rule: the catalog is enrichment, not the gate.
 func TestVisibleLiveModel_OpenRouterLiveToolsShortCircuits(t *testing.T) {
 	cat := EmbeddedModelCatalog()
 	// A model OpenRouter serves that the embedded catalog doesn't know about.
@@ -1351,9 +1351,34 @@ func TestVisibleLiveModel_OpenRouterLiveToolsShortCircuits(t *testing.T) {
 	if cat.GetModelInfo("stealth/ox-alpha") != nil {
 		t.Skip("catalog changed: stealth/ox-alpha now exists")
 	}
-	live := ModelInfo{ID: "stealth/ox-alpha", SupportsTools: true}
+	live := ModelInfo{ID: "stealth/ox-alpha", CapabilitiesAdvertised: true, SupportsTools: true}
 	if !cat.VisibleLiveModel("openrouter", live) {
 		t.Error("live SupportsTools=true model should be visible even when absent from catalog")
+	}
+}
+
+// TestVisibleLiveModel_OpenRouterExplicitFalseOverridesCatalog verifies that
+// when the live /models response explicitly reports SupportsTools=false with
+// CapabilitiesAdvertised=true, the model is hidden even if the catalog says it
+// supports tools. This prevents stale catalog data from overriding the
+// provider's live capability report.
+func TestVisibleLiveModel_OpenRouterExplicitFalseOverridesCatalog(t *testing.T) {
+	cat := EmbeddedModelCatalog()
+	// Find a catalog model that supports tools (per openrouter/ key).
+	var catalogModelID string
+	for _, m := range cat.Models {
+		if m.Provider == "openrouter" && m.SupportsTools {
+			catalogModelID = m.ID
+			break
+		}
+	}
+	if catalogModelID == "" {
+		t.Skip("catalog changed: no openrouter model with SupportsTools found")
+	}
+	// Simulate the live API saying this model does NOT support tools.
+	live := ModelInfo{ID: catalogModelID, CapabilitiesAdvertised: true, SupportsTools: false}
+	if cat.VisibleLiveModel("openrouter", live) {
+		t.Errorf("live SupportsTools=false should override catalog SupportsTools=true for %q", catalogModelID)
 	}
 }
 

--- a/llm/providers/google/adapter_test.go
+++ b/llm/providers/google/adapter_test.go
@@ -2867,8 +2867,11 @@ func TestAdapter_ListModels(t *testing.T) {
 	if models[0].MaxOutputTokens == nil || *models[0].MaxOutputTokens != 65536 {
 		t.Errorf("models[0].MaxOutputTokens = %v, want 65536", models[0].MaxOutputTokens)
 	}
-	if !models[0].SupportsTools {
-		t.Errorf("models[0].SupportsTools = false, want true (generateContent implies tool support)")
+	// SupportsTools should NOT be inferred from generateContent — Google's
+	// supportedGenerationMethods lists API methods, not function-calling
+	// capability. The catalog fills it in for known models.
+	if models[0].SupportsTools {
+		t.Errorf("models[0].SupportsTools = true, want false (generateContent is not a tools capability flag)")
 	}
 	for _, m := range models {
 		if m.Provider != "google" {

--- a/llm/providers/google/adapter_test.go
+++ b/llm/providers/google/adapter_test.go
@@ -2825,11 +2825,15 @@ func TestAdapter_ListModels(t *testing.T) {
 				{
 					"name": "models/gemini-2.5-flash",
 					"displayName": "Gemini 2.5 Flash",
+					"inputTokenLimit": 1048576,
+					"outputTokenLimit": 65536,
 					"supportedGenerationMethods": ["generateContent", "countTokens"]
 				},
 				{
 					"name": "models/gemini-2.5-pro",
 					"displayName": "Gemini 2.5 Pro",
+					"inputTokenLimit": 1048576,
+					"outputTokenLimit": 65536,
 					"supportedGenerationMethods": ["generateContent", "countTokens"]
 				},
 				{
@@ -2856,6 +2860,15 @@ func TestAdapter_ListModels(t *testing.T) {
 	}
 	if models[0].DisplayName != "Gemini 2.5 Flash" {
 		t.Errorf("models[0].DisplayName = %q", models[0].DisplayName)
+	}
+	if models[0].ContextWindow != 1048576 {
+		t.Errorf("models[0].ContextWindow = %d, want 1048576", models[0].ContextWindow)
+	}
+	if models[0].MaxOutputTokens == nil || *models[0].MaxOutputTokens != 65536 {
+		t.Errorf("models[0].MaxOutputTokens = %v, want 65536", models[0].MaxOutputTokens)
+	}
+	if !models[0].SupportsTools {
+		t.Errorf("models[0].SupportsTools = false, want true (generateContent implies tool support)")
 	}
 	for _, m := range models {
 		if m.Provider != "google" {

--- a/llm/providers/google/models.go
+++ b/llm/providers/google/models.go
@@ -87,10 +87,11 @@ func (a *Adapter) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
 			DisplayName:   displayName,
 			ContextWindow: m.InputTokenLimit,
 		}
-		// Gemini models support tools when generateContent is in their
-		// supportedGenerationMethods list — the API doesn't expose a separate
-		// tools capability flag, so infer it from the generation method.
-		info.SupportsTools = true
+		// Google's supportedGenerationMethods lists API methods the model
+		// accepts (generateContent, embedContent, etc.), not function-calling
+		// capability. TTS and native-audio models also list generateContent
+		// but don't support tools. Leave SupportsTools at its zero value
+		// (false); the catalog fills it in for known models.
 		if m.OutputTokenLimit > 0 {
 			maxOut := m.OutputTokenLimit
 			info.MaxOutputTokens = &maxOut

--- a/llm/providers/google/models.go
+++ b/llm/providers/google/models.go
@@ -59,6 +59,8 @@ func (a *Adapter) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
 		Models []struct {
 			Name                       string   `json:"name"`
 			DisplayName                string   `json:"displayName"`
+			InputTokenLimit            int      `json:"inputTokenLimit"`
+			OutputTokenLimit           int      `json:"outputTokenLimit"`
 			SupportedGenerationMethods []string `json:"supportedGenerationMethods"`
 		} `json:"models"`
 	}
@@ -79,11 +81,21 @@ func (a *Adapter) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
 		if displayName == "" {
 			displayName = id
 		}
-		models = append(models, llm.ModelInfo{
-			ID:          id,
-			Provider:    "google",
-			DisplayName: displayName,
-		})
+		info := llm.ModelInfo{
+			ID:            id,
+			Provider:      "google",
+			DisplayName:   displayName,
+			ContextWindow: m.InputTokenLimit,
+		}
+		// Gemini models support tools when generateContent is in their
+		// supportedGenerationMethods list — the API doesn't expose a separate
+		// tools capability flag, so infer it from the generation method.
+		info.SupportsTools = true
+		if m.OutputTokenLimit > 0 {
+			maxOut := m.OutputTokenLimit
+			info.MaxOutputTokens = &maxOut
+		}
+		models = append(models, info)
 	}
 	sort.Slice(models, func(i, j int) bool { return models[i].ID < models[j].ID })
 	return models, nil

--- a/llm/providers/openaicompat/adapter_test.go
+++ b/llm/providers/openaicompat/adapter_test.go
@@ -1483,8 +1483,9 @@ func TestAdapter_ListModels(t *testing.T) {
 
 // TestAdapter_ListModels_OpenRouterRichFields verifies that the openai-compatible
 // adapter parses OpenRouter's extended /v1/models response fields:
-// supported_parameters (→ SupportsTools), architecture.input_modalities
-// (→ SupportsVision), reasoning (→ SupportsReasoning, ReasoningEffortLevels),
+// supported_parameters (→ SupportsTools, CapabilitiesAdvertised),
+// architecture.input_modalities (→ SupportsVision), reasoning
+// (→ SupportsReasoning, ReasoningEffortLevels, ThinkingAlwaysOn),
 // pricing.prompt/completion (→ InputCostPerMillion/OutputCostPerMillion),
 // and top_provider.max_completion_tokens (→ MaxOutputTokens).
 func TestAdapter_ListModels_OpenRouterRichFields(t *testing.T) {
@@ -1500,6 +1501,15 @@ func TestAdapter_ListModels_OpenRouterRichFields(t *testing.T) {
 					"reasoning": {"mandatory": false, "default_enabled": true, "supported_efforts": ["max", "high", "medium", "low"]},
 					"pricing": {"prompt": "0.000003", "completion": "0.000015"},
 					"top_provider": {"max_completion_tokens": 128000}
+				},
+				{
+					"id": "stealth/ox-alpha",
+					"context_length": 1048576,
+					"supported_parameters": ["tools", "reasoning", "reasoning_effort", "temperature"],
+					"architecture": {"input_modalities": ["text", "image", "video"]},
+					"reasoning": {"mandatory": true, "default_enabled": true, "supported_efforts": ["max", "high", "low"]},
+					"pricing": {"prompt": "0", "completion": "0"},
+					"top_provider": {"max_completion_tokens": 131072}
 				},
 				{
 					"id": "tencent/hy-mt2-1.8b",
@@ -1523,8 +1533,8 @@ func TestAdapter_ListModels_OpenRouterRichFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListModels: %v", err)
 	}
-	if len(models) != 3 {
-		t.Fatalf("got %d models, want 3", len(models))
+	if len(models) != 4 {
+		t.Fatalf("got %d models, want 4", len(models))
 	}
 
 	// Model 0 (alphabetical): anthropic/claude-sonnet-4.5 — rich fields parsed.
@@ -1534,6 +1544,9 @@ func TestAdapter_ListModels_OpenRouterRichFields(t *testing.T) {
 	}
 	if m.ContextWindow != 1000000 {
 		t.Errorf("ContextWindow = %d, want 1000000", m.ContextWindow)
+	}
+	if !m.CapabilitiesAdvertised {
+		t.Errorf("CapabilitiesAdvertised = false, want true (supported_parameters present)")
 	}
 	if !m.SupportsTools {
 		t.Errorf("SupportsTools = false, want true (supported_parameters includes \"tools\")")
@@ -1568,6 +1581,9 @@ func TestAdapter_ListModels_OpenRouterRichFields(t *testing.T) {
 	if m.ContextWindow != 262144 {
 		t.Errorf("ContextWindow = %d, want 262144", m.ContextWindow)
 	}
+	if m.CapabilitiesAdvertised {
+		t.Errorf("CapabilitiesAdvertised = true, want false (no supported_parameters)")
+	}
 	if m.SupportsTools {
 		t.Errorf("SupportsTools = true, want false (no supported_parameters)")
 	}
@@ -1581,10 +1597,45 @@ func TestAdapter_ListModels_OpenRouterRichFields(t *testing.T) {
 		t.Errorf("MaxOutputTokens = %v, want nil", m.MaxOutputTokens)
 	}
 
-	// Model 2: tencent/hy-mt2-1.8b — has fields but no "tools" in supported_parameters.
+	// Model 2: stealth/ox-alpha — mandatory reasoning, zero pricing (known-free).
 	m = models[2]
+	if m.ID != "stealth/ox-alpha" {
+		t.Fatalf("models[2].ID = %q, want stealth/ox-alpha", m.ID)
+	}
+	if !m.CapabilitiesAdvertised {
+		t.Errorf("CapabilitiesAdvertised = false, want true")
+	}
+	if !m.SupportsTools {
+		t.Errorf("SupportsTools = false, want true (supported_parameters includes \"tools\")")
+	}
+	if !m.SupportsReasoning {
+		t.Errorf("SupportsReasoning = false, want true (reasoning.mandatory is true)")
+	}
+	if !m.ThinkingAlwaysOn {
+		t.Errorf("ThinkingAlwaysOn = false, want true (reasoning.mandatory is true)")
+	}
+	// Zero pricing should be a pointer to 0.0, not nil — the model is known-free.
+	if m.InputCostPerMillion == nil {
+		t.Errorf("InputCostPerMillion = nil, want pointer to 0.0 (zero pricing is known-free)")
+	} else if *m.InputCostPerMillion != 0.0 {
+		t.Errorf("InputCostPerMillion = %v, want 0.0", *m.InputCostPerMillion)
+	}
+	if m.OutputCostPerMillion == nil {
+		t.Errorf("OutputCostPerMillion = nil, want pointer to 0.0 (zero pricing is known-free)")
+	} else if *m.OutputCostPerMillion != 0.0 {
+		t.Errorf("OutputCostPerMillion = %v, want 0.0", *m.OutputCostPerMillion)
+	}
+	if m.MaxOutputTokens == nil || *m.MaxOutputTokens != 131072 {
+		t.Errorf("MaxOutputTokens = %v, want 131072", m.MaxOutputTokens)
+	}
+
+	// Model 3: tencent/hy-mt2-1.8b — has supported_parameters but no "tools".
+	m = models[3]
 	if m.ID != "tencent/hy-mt2-1.8b" {
-		t.Fatalf("models[2].ID = %q, want tencent/hy-mt2-1.8b", m.ID)
+		t.Fatalf("models[3].ID = %q, want tencent/hy-mt2-1.8b", m.ID)
+	}
+	if !m.CapabilitiesAdvertised {
+		t.Errorf("CapabilitiesAdvertised = false, want true (supported_parameters present)")
 	}
 	if m.SupportsTools {
 		t.Errorf("SupportsTools = true, want false (supported_parameters lacks \"tools\")")
@@ -1593,10 +1644,64 @@ func TestAdapter_ListModels_OpenRouterRichFields(t *testing.T) {
 		t.Errorf("SupportsVision = true, want false (input_modalities is text-only)")
 	}
 	if m.SupportsReasoning {
-		t.Errorf("SupportsReasoning = true, want false (no reasoning object)")
+		t.Errorf("SupportsReasoning = true, want false (no reasoning object, no reasoning in supported_parameters)")
 	}
 	if m.MaxOutputTokens == nil || *m.MaxOutputTokens != 4096 {
 		t.Errorf("MaxOutputTokens = %v, want 4096", m.MaxOutputTokens)
+	}
+}
+
+// TestAdapter_ListModels_OptionalReasoning verifies that a reasoning object
+// with mandatory=false and default_enabled=false still sets SupportsReasoning
+// to true — the model CAN do reasoning, it's just opt-in. This was a reviewer
+// finding: the original code only set SupportsReasoning when mandatory=true or
+// default_enabled=true, missing the opt-in case.
+func TestAdapter_ListModels_OptionalReasoning(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"data": [
+				{
+					"id": "deepseek/deepseek-v4-flash",
+					"supported_parameters": ["reasoning", "temperature", "tools"],
+					"reasoning": {"mandatory": false, "default_enabled": false}
+				},
+				{
+					"id": "openrouter/auto",
+					"supported_parameters": ["reasoning", "reasoning_effort", "tools", "temperature"]
+				}
+			]
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{BaseURL: srv.URL, Client: srv.Client()}
+	models, err := a.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+
+	// deepseek/deepseek-v4-flash: reasoning object present with all-false →
+	// SupportsReasoning should be true (reasoning is supported, just opt-in).
+	m := models[0]
+	if m.ID != "deepseek/deepseek-v4-flash" {
+		t.Fatalf("models[0].ID = %q, want deepseek/deepseek-v4-flash", m.ID)
+	}
+	if !m.SupportsReasoning {
+		t.Errorf("SupportsReasoning = false, want true (reasoning object present = reasoning is supported)")
+	}
+	if m.ThinkingAlwaysOn {
+		t.Errorf("ThinkingAlwaysOn = true, want false (reasoning.mandatory is false)")
+	}
+
+	// openrouter/auto: no reasoning object but supported_parameters includes
+	// "reasoning" → SupportsReasoning should be true.
+	m = models[1]
+	if m.ID != "openrouter/auto" {
+		t.Fatalf("models[1].ID = %q, want openrouter/auto", m.ID)
+	}
+	if !m.SupportsReasoning {
+		t.Errorf("SupportsReasoning = false, want true (supported_parameters includes \"reasoning\")")
 	}
 }
 

--- a/llm/providers/openaicompat/adapter_test.go
+++ b/llm/providers/openaicompat/adapter_test.go
@@ -1481,6 +1481,125 @@ func TestAdapter_ListModels(t *testing.T) {
 	}
 }
 
+// TestAdapter_ListModels_OpenRouterRichFields verifies that the openai-compatible
+// adapter parses OpenRouter's extended /v1/models response fields:
+// supported_parameters (→ SupportsTools), architecture.input_modalities
+// (→ SupportsVision), reasoning (→ SupportsReasoning, ReasoningEffortLevels),
+// pricing.prompt/completion (→ InputCostPerMillion/OutputCostPerMillion),
+// and top_provider.max_completion_tokens (→ MaxOutputTokens).
+func TestAdapter_ListModels_OpenRouterRichFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"data": [
+				{
+					"id": "anthropic/claude-sonnet-4.5",
+					"context_length": 1000000,
+					"supported_parameters": ["tools", "reasoning", "reasoning_effort", "temperature"],
+					"architecture": {"input_modalities": ["text", "image", "file"]},
+					"reasoning": {"mandatory": false, "default_enabled": true, "supported_efforts": ["max", "high", "medium", "low"]},
+					"pricing": {"prompt": "0.000003", "completion": "0.000015"},
+					"top_provider": {"max_completion_tokens": 128000}
+				},
+				{
+					"id": "tencent/hy-mt2-1.8b",
+					"context_length": 8192,
+					"supported_parameters": ["max_tokens", "stop", "temperature"],
+					"architecture": {"input_modalities": ["text"]},
+					"pricing": {"prompt": "0.000000044", "completion": "0.000000177"},
+					"top_provider": {"max_completion_tokens": 4096}
+				},
+				{
+					"id": "kimi-for-coding",
+					"context_length": 262144
+				}
+			]
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{BaseURL: srv.URL, Client: srv.Client()}
+	models, err := a.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if len(models) != 3 {
+		t.Fatalf("got %d models, want 3", len(models))
+	}
+
+	// Model 0 (alphabetical): anthropic/claude-sonnet-4.5 — rich fields parsed.
+	m := models[0]
+	if m.ID != "anthropic/claude-sonnet-4.5" {
+		t.Fatalf("models[0].ID = %q, want anthropic/claude-sonnet-4.5", m.ID)
+	}
+	if m.ContextWindow != 1000000 {
+		t.Errorf("ContextWindow = %d, want 1000000", m.ContextWindow)
+	}
+	if !m.SupportsTools {
+		t.Errorf("SupportsTools = false, want true (supported_parameters includes \"tools\")")
+	}
+	if !m.SupportsVision {
+		t.Errorf("SupportsVision = false, want true (input_modalities includes \"image\")")
+	}
+	if !m.SupportsReasoning {
+		t.Errorf("SupportsReasoning = false, want true (reasoning.default_enabled is true)")
+	}
+	if m.ThinkingAlwaysOn {
+		t.Errorf("ThinkingAlwaysOn = true, want false (reasoning.mandatory is false)")
+	}
+	if len(m.ReasoningEffortLevels) != 4 {
+		t.Errorf("ReasoningEffortLevels = %v, want 4 entries", m.ReasoningEffortLevels)
+	}
+	if m.InputCostPerMillion == nil || *m.InputCostPerMillion != 3.0 {
+		t.Errorf("InputCostPerMillion = %v, want 3.0", m.InputCostPerMillion)
+	}
+	if m.OutputCostPerMillion == nil || *m.OutputCostPerMillion != 15.0 {
+		t.Errorf("OutputCostPerMillion = %v, want 15.0", m.OutputCostPerMillion)
+	}
+	if m.MaxOutputTokens == nil || *m.MaxOutputTokens != 128000 {
+		t.Errorf("MaxOutputTokens = %v, want 128000", m.MaxOutputTokens)
+	}
+
+	// Model 1: kimi-for-coding — no OpenRouter extensions, zero values.
+	m = models[1]
+	if m.ID != "kimi-for-coding" {
+		t.Fatalf("models[1].ID = %q, want kimi-for-coding", m.ID)
+	}
+	if m.ContextWindow != 262144 {
+		t.Errorf("ContextWindow = %d, want 262144", m.ContextWindow)
+	}
+	if m.SupportsTools {
+		t.Errorf("SupportsTools = true, want false (no supported_parameters)")
+	}
+	if m.SupportsVision {
+		t.Errorf("SupportsVision = true, want false (no input_modalities)")
+	}
+	if m.InputCostPerMillion != nil {
+		t.Errorf("InputCostPerMillion = %v, want nil", m.InputCostPerMillion)
+	}
+	if m.MaxOutputTokens != nil {
+		t.Errorf("MaxOutputTokens = %v, want nil", m.MaxOutputTokens)
+	}
+
+	// Model 2: tencent/hy-mt2-1.8b — has fields but no "tools" in supported_parameters.
+	m = models[2]
+	if m.ID != "tencent/hy-mt2-1.8b" {
+		t.Fatalf("models[2].ID = %q, want tencent/hy-mt2-1.8b", m.ID)
+	}
+	if m.SupportsTools {
+		t.Errorf("SupportsTools = true, want false (supported_parameters lacks \"tools\")")
+	}
+	if m.SupportsVision {
+		t.Errorf("SupportsVision = true, want false (input_modalities is text-only)")
+	}
+	if m.SupportsReasoning {
+		t.Errorf("SupportsReasoning = true, want false (no reasoning object)")
+	}
+	if m.MaxOutputTokens == nil || *m.MaxOutputTokens != 4096 {
+		t.Errorf("MaxOutputTokens = %v, want 4096", m.MaxOutputTokens)
+	}
+}
+
 func TestAdapter_Complete_Metadata_Propagated(t *testing.T) {
 	var sentBody map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/llm/providers/openaicompat/models.go
+++ b/llm/providers/openaicompat/models.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strconv"
+	"strings"
 
 	"primeradiant.com/evener/llm"
 	"primeradiant.com/evener/llm/providers/internal/transport"
@@ -48,14 +50,7 @@ func (a *Adapter) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
 	}
 
 	var result struct {
-		Data []struct {
-			ID string `json:"id"`
-			// context_length is reported by Kimi (kimi-for-coding = 262144) and
-			// OpenRouter; absent on stock OpenAI. When present it flows into the
-			// profile via WithLiveModelInfo so context management uses the model's
-			// real window instead of the 128K default.
-			ContextLength int `json:"context_length"`
-		} `json:"data"`
+		Data []openaiCompatModelEntry `json:"data"`
 	}
 	decodeErr := json.NewDecoder(resp.Body).Decode(&result)
 	if decodeErr != nil {
@@ -66,13 +61,136 @@ func (a *Adapter) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
 
 	models := make([]llm.ModelInfo, 0, len(result.Data))
 	for _, m := range result.Data {
-		models = append(models, llm.ModelInfo{
-			ID:            m.ID,
-			Provider:      "openai-compatible",
-			DisplayName:   m.ID,
-			ContextWindow: m.ContextLength,
-		})
+		models = append(models, m.modelInfo())
 	}
 	sort.Slice(models, func(i, j int) bool { return models[i].ID < models[j].ID })
 	return models, nil
+}
+
+// openaiCompatModelEntry is the wire shape of a single entry in the /v1/models
+// response. The core fields (id, context_length) are shared by every
+// OpenAI-compatible provider. The remaining fields are OpenRouter-specific
+// extensions that are silently absent on other providers (Kimi, GLM, Ollama,
+// stock OpenAI) — their omitempty / pointer/zero-value semantics keep those
+// providers working unchanged.
+type openaiCompatModelEntry struct {
+	ID            string `json:"id"`
+	ContextLength int    `json:"context_length"`
+
+	// OpenRouter extensions.
+	SupportedParameters []string `json:"supported_parameters"`
+	Architecture        struct {
+		InputModalities []string `json:"input_modalities"`
+	} `json:"architecture"`
+	Reasoning struct {
+		Mandatory        *bool    `json:"mandatory"`
+		DefaultEnabled   *bool    `json:"default_enabled"`
+		SupportedEfforts []string `json:"supported_efforts"`
+	} `json:"reasoning"`
+	Pricing struct {
+		Prompt     string `json:"prompt"`
+		Completion string `json:"completion"`
+	} `json:"pricing"`
+	TopProvider struct {
+		MaxCompletionTokens *int `json:"max_completion_tokens"`
+	} `json:"top_provider"`
+}
+
+// modelInfo converts a wire entry to the normalized llm.ModelInfo. The
+// provider stamp is "openai-compatible" (wrapper adapters like ollama rewrite
+// it to their own name). Rich OpenRouter fields are populated when present;
+// providers that don't return them leave the corresponding ModelInfo fields at
+// their zero values, so catalog enrichment in the profile/hub layer fills the
+// gaps.
+func (m openaiCompatModelEntry) modelInfo() llm.ModelInfo {
+	info := llm.ModelInfo{
+		ID:             m.ID,
+		Provider:       "openai-compatible",
+		DisplayName:    m.ID,
+		ContextWindow:  m.ContextLength,
+		SupportsTools:  openRouterSupportsTools(m.SupportedParameters),
+		SupportsVision: inputModalitiesIncludeVision(m.Architecture.InputModalities),
+	}
+	if m.Reasoning.Mandatory != nil && *m.Reasoning.Mandatory {
+		info.SupportsReasoning = true
+		info.ThinkingAlwaysOn = true
+	} else if m.Reasoning.DefaultEnabled != nil && *m.Reasoning.DefaultEnabled {
+		info.SupportsReasoning = true
+	}
+	if len(m.Reasoning.SupportedEfforts) > 0 {
+		info.SupportsReasoning = true
+		info.ReasoningEffortLevels = dedupStrings(m.Reasoning.SupportedEfforts)
+	}
+	if cost := perTokenCostToPerMillion(m.Pricing.Prompt); cost != nil {
+		info.InputCostPerMillion = cost
+	}
+	if cost := perTokenCostToPerMillion(m.Pricing.Completion); cost != nil {
+		info.OutputCostPerMillion = cost
+	}
+	if m.TopProvider.MaxCompletionTokens != nil && *m.TopProvider.MaxCompletionTokens > 0 {
+		maxOut := *m.TopProvider.MaxCompletionTokens
+		info.MaxOutputTokens = &maxOut
+	}
+	return info
+}
+
+// openRouterSupportsTools reports whether the model's supported_parameters list
+// includes "tools", indicating function-calling capability per OpenRouter's API.
+func openRouterSupportsTools(params []string) bool {
+	for _, p := range params {
+		if strings.EqualFold(strings.TrimSpace(p), "tools") {
+			return true
+		}
+	}
+	return false
+}
+
+// inputModalitiesIncludeVision reports whether the modality list includes
+// image input.
+func inputModalitiesIncludeVision(modalities []string) bool {
+	for _, mod := range modalities {
+		switch strings.ToLower(strings.TrimSpace(mod)) {
+		case "image", "images", "vision":
+			return true
+		}
+	}
+	return false
+}
+
+// perTokenCostToPerMillion parses a per-token cost string (as returned by
+// OpenRouter's pricing fields, e.g. "0.000002") and converts it to
+// per-million-token cost. Returns nil for empty, "0", or unparseable values.
+func perTokenCostToPerMillion(perToken string) *float64 {
+	perToken = strings.TrimSpace(perToken)
+	if perToken == "" || perToken == "0" || perToken == "0.0" {
+		return nil
+	}
+	v, err := strconv.ParseFloat(perToken, 64)
+	if err != nil || v <= 0 {
+		return nil
+	}
+	perMillion := v * 1_000_000
+	return &perMillion
+}
+
+// dedupStrings returns a copy of the input with duplicates removed, preserving
+// order.
+func dedupStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	seen := make(map[string]bool, len(in))
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }

--- a/llm/providers/openaicompat/models.go
+++ b/llm/providers/openaicompat/models.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"sort"
 	"strconv"
@@ -104,22 +105,36 @@ type openaiCompatModelEntry struct {
 // gaps.
 func (m openaiCompatModelEntry) modelInfo() llm.ModelInfo {
 	info := llm.ModelInfo{
-		ID:             m.ID,
-		Provider:       "openai-compatible",
-		DisplayName:    m.ID,
-		ContextWindow:  m.ContextLength,
-		SupportsTools:  openRouterSupportsTools(m.SupportedParameters),
-		SupportsVision: inputModalitiesIncludeVision(m.Architecture.InputModalities),
+		ID:            m.ID,
+		Provider:      "openai-compatible",
+		DisplayName:   m.ID,
+		ContextWindow: m.ContextLength,
 	}
-	if m.Reasoning.Mandatory != nil && *m.Reasoning.Mandatory {
-		info.SupportsReasoning = true
-		info.ThinkingAlwaysOn = true
-	} else if m.Reasoning.DefaultEnabled != nil && *m.Reasoning.DefaultEnabled {
-		info.SupportsReasoning = true
+	// When the provider returns supported_parameters, capability fields are
+	// authoritative — set CapabilitiesAdvertised so callers don't fall back
+	// to the catalog and override explicit values (including false).
+	if len(m.SupportedParameters) > 0 {
+		info.CapabilitiesAdvertised = true
+		info.SupportsTools = openRouterSupportsTools(m.SupportedParameters)
+		info.SupportsVision = inputModalitiesIncludeVision(m.Architecture.InputModalities)
+		// "reasoning" or "reasoning_effort" in supported_parameters indicates
+		// reasoning support even when the reasoning object is absent or all
+		// its fields are false/opt-in.
+		if openRouterSupportsReasoning(m.SupportedParameters) {
+			info.SupportsReasoning = true
+		}
 	}
-	if len(m.Reasoning.SupportedEfforts) > 0 {
+	// The reasoning object, when present, refines reasoning metadata. Its
+	// presence alone (even all-false) means reasoning is supported — the
+	// model can do reasoning, it's just opt-in.
+	if m.Reasoning.Mandatory != nil || m.Reasoning.DefaultEnabled != nil || len(m.Reasoning.SupportedEfforts) > 0 {
 		info.SupportsReasoning = true
-		info.ReasoningEffortLevels = dedupStrings(m.Reasoning.SupportedEfforts)
+		if m.Reasoning.Mandatory != nil && *m.Reasoning.Mandatory {
+			info.ThinkingAlwaysOn = true
+		}
+		if len(m.Reasoning.SupportedEfforts) > 0 {
+			info.ReasoningEffortLevels = dedupStrings(m.Reasoning.SupportedEfforts)
+		}
 	}
 	if cost := perTokenCostToPerMillion(m.Pricing.Prompt); cost != nil {
 		info.InputCostPerMillion = cost
@@ -145,6 +160,19 @@ func openRouterSupportsTools(params []string) bool {
 	return false
 }
 
+// openRouterSupportsReasoning reports whether the model's supported_parameters
+// list includes "reasoning" or "reasoning_effort", indicating the model can
+// produce reasoning/thinking output even when the reasoning object is absent.
+func openRouterSupportsReasoning(params []string) bool {
+	for _, p := range params {
+		isReasoning := strings.EqualFold(strings.TrimSpace(p), "reasoning")
+		if isReasoning || strings.EqualFold(strings.TrimSpace(p), "reasoning_effort") {
+			return true
+		}
+	}
+	return false
+}
+
 // inputModalitiesIncludeVision reports whether the modality list includes
 // image input.
 func inputModalitiesIncludeVision(modalities []string) bool {
@@ -159,14 +187,19 @@ func inputModalitiesIncludeVision(modalities []string) bool {
 
 // perTokenCostToPerMillion parses a per-token cost string (as returned by
 // OpenRouter's pricing fields, e.g. "0.000002") and converts it to
-// per-million-token cost. Returns nil for empty, "0", or unparseable values.
+// per-million-token cost. Returns nil for empty or unparseable values. A valid
+// "0" or "0.0" returns a pointer to 0.0 — the model is known-free, which is
+// distinct from "no pricing data." Non-finite results (NaN, +Inf) are rejected.
 func perTokenCostToPerMillion(perToken string) *float64 {
 	perToken = strings.TrimSpace(perToken)
-	if perToken == "" || perToken == "0" || perToken == "0.0" {
+	if perToken == "" {
 		return nil
 	}
 	v, err := strconv.ParseFloat(perToken, 64)
-	if err != nil || v <= 0 {
+	if err != nil {
+		return nil
+	}
+	if math.IsNaN(v) || math.IsInf(v, 0) {
 		return nil
 	}
 	perMillion := v * 1_000_000

--- a/llm/providers/openaicompat/models_fuzz_test.go
+++ b/llm/providers/openaicompat/models_fuzz_test.go
@@ -23,6 +23,7 @@ import (
 func FuzzOpenaicompatListModels(f *testing.F) {
 	f.Add(200, []byte(`{"data":[{"id":"kimi-for-coding","context_length":262144},{"id":"llama3","context_length":8192}]}`))
 	f.Add(200, []byte(`{"data":[{"id":"m1"},{"id":"m0"}]}`))
+	f.Add(200, []byte(`{"data":[{"id":"anthropic/claude-sonnet-4.5","context_length":1000000,"supported_parameters":["tools","reasoning"],"architecture":{"input_modalities":["text","image"]},"reasoning":{"mandatory":false,"default_enabled":true,"supported_efforts":["high","low"]},"pricing":{"prompt":"0.000003","completion":"0.000015"},"top_provider":{"max_completion_tokens":128000}}]}`))
 	f.Add(200, []byte(`{"data":[]}`))
 	f.Add(200, []byte(`{}`))
 	f.Add(200, []byte(`not json`))


### PR DESCRIPTION
## Summary

Follow-up to #339. The embedded catalog is no longer the gate for OpenRouter model visibility — the provider's live `/models` API is now the source of truth, with the catalog as enrichment-only.

## Changes

### 1. Parse rich OpenRouter fields from `/v1/models` (`llm/providers/openaicompat/models.go`)

The openaicompat adapter previously parsed only `id` and `context_length`. It now also parses:

- **`supported_parameters`** → `SupportsTools` (true when the list contains `"tools"`)
- **`architecture.input_modalities`** → `SupportsVision` (true when it includes `"image"`)
- **`reasoning`** → `SupportsReasoning`, `ReasoningEffortLevels`, `ThinkingAlwaysOn` (when `mandatory: true`)
- **`pricing.prompt` / `pricing.completion`** → `InputCostPerMillion` / `OutputCostPerMillion` (per-token cost × 1M)
- **`top_provider.max_completion_tokens`** → `MaxOutputTokens`

All fields are optional — other openai-compatible providers (Kimi, GLM, Ollama) that don't return them are unaffected.

### 2. Live-API-first visibility gating (`llm/model_catalog.go`)

`VisibleLiveModel` now accepts the live `ModelInfo` from `ListModels` instead of just an ID string. For the openrouter tag:
- If `live.SupportsTools` is true (parsed from `supported_parameters`), the model is **visible regardless of catalog**.
- Otherwise, falls back to the catalog (`ResolveLiveModelInfo`) — preserving existing behavior for providers whose `/models` endpoint doesn't report capabilities.

All three callers updated: `launchcheck.go` (2 call sites), `web_spawn.go` (1), `agent/session_set_model.go` (2).

### 3. Parse Google token limits (`llm/providers/google/models.go`)

Google's `/v1beta/models` returns `inputTokenLimit` and `outputTokenLimit` — previously discarded. Now parsed into `ContextWindow` and `MaxOutputTokens`. Also sets `SupportsTools = true` for models with `generateContent` in `supportedGenerationMethods`.

## Tests added

- `TestVisibleLiveModel_OpenRouterLiveToolsShortCircuits` — a model with `SupportsTools=true` absent from the catalog is visible for openrouter
- `TestAdapter_ListModels_OpenRouterRichFields` — verifies all 6 OpenRouter extension fields parse correctly; verifies a model without extensions gets zero values (Kimi/Ollama compatibility)
- Google `adapter_test.go` — assertions for `inputTokenLimit` → `ContextWindow`, `outputTokenLimit` → `MaxOutputTokens`, `SupportsTools`
- Fuzz test seed with OpenRouter rich-field JSON

## Gates

- `go build ./...` ✅
- `go vet ./...` ✅
- `make lint` (8 modules) ✅
- `go test` — llm, launchcheck, hub, agent — all ✅