### PR TITLE
Make the glob walk cancellable and stop it following symlink loops

### DIFF
--- a/agent/cov_w3sub_session_tools_file_test.go
+++ b/agent/cov_w3sub_session_tools_file_test.go
@@ -34,7 +34,7 @@ func (e *w3sub_readFileEnv) EditFile(string, string, string, bool) (string, erro
 	return "", errors.New("not implemented")
 }
 func (e *w3sub_readFileEnv) FileExists(string) bool { return false }
-func (e *w3sub_readFileEnv) Glob(string, string, ...bool) ([]string, error) {
+func (e *w3sub_readFileEnv) Glob(context.Context, string, string, ...bool) ([]string, error) {
 	return nil, errors.New("not implemented")
 }
 func (e *w3sub_readFileEnv) Grep(string, string, string, bool, int, string, ...int) (string, error) {

--- a/agent/execenv/cov_s4_local_test.go
+++ b/agent/execenv/cov_s4_local_test.go
@@ -37,7 +37,7 @@ func TestGlob_DefaultBase_NewestFirstTiesByPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := env.Glob("*.go", "")
+	got, err := env.Glob(t.Context(), "*.go", "")
 	if err != nil {
 		t.Fatalf("Glob: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestGlob_RelativeAndAbsoluteBase(t *testing.T) {
 	}
 	env := NewLocalExecutionEnvironment(dir)
 
-	rel, err := env.Glob("*.txt", "sub")
+	rel, err := env.Glob(t.Context(), "*.txt", "sub")
 	if err != nil {
 		t.Fatalf("Glob relative base: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestGlob_RelativeAndAbsoluteBase(t *testing.T) {
 		t.Fatalf("Glob relative base = %v, want [%s]", rel, filepath.Join(sub, "c.txt"))
 	}
 
-	abs, err := env.Glob("*.txt", sub)
+	abs, err := env.Glob(t.Context(), "*.txt", sub)
 	if err != nil {
 		t.Fatalf("Glob absolute base: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestGlob_DoublestarPattern(t *testing.T) {
 	}
 	env := NewLocalExecutionEnvironment(dir)
 
-	got, err := env.Glob("**/*.txt", "")
+	got, err := env.Glob(t.Context(), "**/*.txt", "")
 	if err != nil {
 		t.Fatalf("Glob doublestar: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestGlob_BraceAlternatives(t *testing.T) {
 		}
 	}
 
-	got, err := NewLocalExecutionEnvironment(dir).Glob("*.{ts,tsx,css}", "")
+	got, err := NewLocalExecutionEnvironment(dir).Glob(t.Context(), "*.{ts,tsx,css}", "")
 	if err != nil {
 		t.Fatalf("Glob brace alternatives: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestGlob_BraceAlternatives(t *testing.T) {
 func TestGlob_InvalidPattern(t *testing.T) {
 	dir := t.TempDir()
 	env := NewLocalExecutionEnvironment(dir)
-	if _, err := env.Glob("[", ""); err == nil {
+	if _, err := env.Glob(t.Context(), "[", ""); err == nil {
 		t.Fatal("expected error for malformed glob pattern")
 	}
 }

--- a/agent/execenv/execenv.go
+++ b/agent/execenv/execenv.go
@@ -143,7 +143,9 @@ type ExecutionEnvironment interface {
 	// Glob returns paths matching the shell-style pattern, rooted at basePath.
 	// Dotfiles/dirs (.git, .claude/worktrees/x, ...) and gitignored paths are
 	// excluded by default; pass includeIgnored(true) to restore them.
-	Glob(pattern string, basePath string, includeIgnored ...bool) ([]string, error)
+	// A `**` walk over a large tree can run for minutes, so ctx bounds it:
+	// cancelling ctx aborts the walk and returns ctx's error.
+	Glob(ctx context.Context, pattern string, basePath string, includeIgnored ...bool) ([]string, error)
 	// Grep searches files for pattern and returns matches formatted per
 	// outputMode ("content" (default), "files_with_matches", or "count").
 	// contextLines, when given (0-10), includes that many lines of context
@@ -169,5 +171,5 @@ type GlobExcluder interface {
 	// GlobWithExclusions behaves like Glob but also returns the number of
 	// candidate matches dropped by the default dotfile/gitignore exclusion
 	// (always 0 when includeIgnored is true).
-	GlobWithExclusions(pattern, basePath string, includeIgnored bool) (matches []string, excluded int, err error)
+	GlobWithExclusions(ctx context.Context, pattern, basePath string, includeIgnored bool) (matches []string, excluded int, err error)
 }

--- a/agent/execenv/gitignore_perf_test.go
+++ b/agent/execenv/gitignore_perf_test.go
@@ -22,7 +22,7 @@ func BenchmarkGlobRepoTree(b *testing.B) {
 	}
 	env := NewLocalExecutionEnvironment(repoRoot)
 	for b.Loop() {
-		matches, err := env.Glob("agent/*.go", "")
+		matches, err := env.Glob(b.Context(), "agent/*.go", "")
 		if err != nil {
 			b.Fatalf("Glob: %v", err)
 		}

--- a/agent/execenv/gitpath_mainroot_test.go
+++ b/agent/execenv/gitpath_mainroot_test.go
@@ -39,7 +39,9 @@ func (f *fakeExecEnv) FileExists(path string) bool {
 	}
 	return false
 }
-func (f *fakeExecEnv) Glob(string, string, ...bool) ([]string, error) { return nil, nil }
+func (f *fakeExecEnv) Glob(context.Context, string, string, ...bool) ([]string, error) {
+	return nil, nil
+}
 func (f *fakeExecEnv) Grep(string, string, string, bool, int, string, ...int) (string, error) {
 	return "", nil
 }

--- a/agent/execenv/glob_cancel_test.go
+++ b/agent/execenv/glob_cancel_test.go
@@ -1,0 +1,133 @@
+package execenv
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"testing/fstest"
+	"time"
+)
+
+// globLoopFixture builds a tree holding one real match plus a directory
+// symlink that points back at the tree root — the shape /proc/<pid>/root has,
+// where following the link re-enters the tree it lives in. It returns the
+// fixture root and the absolute path of the one file a `**` glob should match.
+func globLoopFixture(t *testing.T) (root, wantMatch string) {
+	t.Helper()
+	root = t.TempDir()
+	nest := filepath.Join(root, "deep", "nest")
+	if err := os.MkdirAll(nest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wantMatch = filepath.Join(nest, "needle.txt")
+	if err := os.WriteFile(wantMatch, []byte("found\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(root, filepath.Join(root, "deep", "loop")); err != nil {
+		t.Skipf("directory symlinks unavailable on this platform: %v", err)
+	}
+	return root, wantMatch
+}
+
+// TestGlobDoesNotTraverseDirectorySymlinkLoops is the unit-scale reproduction
+// of #369: find_files with a `**` pattern rooted at / never returned because
+// the walk followed /proc/<pid>/root back to / and recursed. The glob must
+// terminate and must report the single real match, not the copies reachable
+// through the loop.
+func TestGlobDoesNotTraverseDirectorySymlinkLoops(t *testing.T) {
+	root, wantMatch := globLoopFixture(t)
+
+	// t.Context() is cancelled when the test ends, so a walk that ignores the
+	// loop bound unwinds instead of spinning on past the failure.
+	ctx := t.Context()
+
+	type outcome struct {
+		matches []string
+		err     error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		matches, err := NewLocalExecutionEnvironment(root).Glob(ctx, "**/needle.txt", root, true)
+		done <- outcome{matches, err}
+	}()
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("Glob over a symlink loop: %v", got.err)
+		}
+		if want := []string{wantMatch}; !reflect.DeepEqual(got.matches, want) {
+			t.Fatalf("Glob over a symlink loop = %v, want %v (the loop must not be traversed)", got.matches, want)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("Glob over a directory symlink loop did not terminate")
+	}
+}
+
+// cancelAfterNthReadDir cancels the walk's context part-way through the
+// traversal, on the nth ReadDir, so the glob is interrupted mid-walk rather
+// than before it starts.
+type cancelAfterNthReadDir struct {
+	fs.FS
+	n      int
+	calls  int
+	cancel context.CancelFunc
+}
+
+func (c *cancelAfterNthReadDir) ReadDir(name string) ([]fs.DirEntry, error) {
+	c.calls++
+	if c.calls == c.n {
+		c.cancel()
+	}
+	return fs.ReadDir(c.FS, name)
+}
+
+// TestGlobMatchesStopsOnContextCancellation proves the other half of #369: an
+// in-flight glob must abort when its context is cancelled and report the
+// cancellation, so job_stop and session teardown can actually stop a walk
+// instead of only asking. doublestar swallows I/O errors, so a cancelled walk
+// would otherwise come back as a short result with a nil error.
+func TestGlobMatchesStopsOnContextCancellation(t *testing.T) {
+	tree := fstest.MapFS{}
+	for _, dir := range []string{"a", "b", "c", "d", "e", "f", "g", "h"} {
+		for _, sub := range []string{"one", "two", "three"} {
+			tree[filepath.Join(dir, sub, "needle.txt")] = &fstest.MapFile{Data: []byte("x")}
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	counter := &cancelAfterNthReadDir{FS: tree, n: 3, cancel: cancel}
+	fsys := cancelFS{ctx: ctx, fsys: counter}
+
+	matches, err := globMatches(ctx, fsys, "**/needle.txt")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("globMatches after mid-walk cancellation = (%v, %v), want context.Canceled", matches, err)
+	}
+	if matches != nil {
+		t.Fatalf("globMatches after cancellation returned partial matches %v, want none", matches)
+	}
+	// The walk must stop at the cancellation, not run the tree out: 8 dirs
+	// with 3 subdirs each is 30+ ReadDir calls when it completes.
+	if counter.calls > 6 {
+		t.Fatalf("walk kept reading after cancellation: %d ReadDir calls", counter.calls)
+	}
+}
+
+// TestGlobWithExclusionsReportsCancellation checks the same contract through
+// the exported entry point the find_files tool calls, so the cancellation is
+// surfaced to the tool rather than being flattened into an empty result.
+func TestGlobWithExclusionsReportsCancellation(t *testing.T) {
+	root, _ := globLoopFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	matches, excluded, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(ctx, "**/needle.txt", root, true)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("GlobWithExclusions with a cancelled context = (%v, %d, %v), want context.Canceled", matches, excluded, err)
+	}
+}

--- a/agent/execenv/glob_grep_scoping_test.go
+++ b/agent/execenv/glob_grep_scoping_test.go
@@ -49,7 +49,7 @@ func TestGlob_ExcludesDotDirsAndGitignoredByDefault(t *testing.T) {
 	dir := writeScopingFixture(t)
 	env := NewLocalExecutionEnvironment(dir)
 
-	got, err := env.Glob("**/*", dir)
+	got, err := env.Glob(t.Context(), "**/*", dir)
 	if err != nil {
 		t.Fatalf("Glob: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestGlob_IncludeIgnoredRestoresExcludedPaths(t *testing.T) {
 	dir := writeScopingFixture(t)
 	env := NewLocalExecutionEnvironment(dir)
 
-	got, err := env.Glob("**/*", dir, true)
+	got, err := env.Glob(t.Context(), "**/*", dir, true)
 	if err != nil {
 		t.Fatalf("Glob: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestSandboxedGlob_ExcludesDotDirsAndGitignoredByDefault(t *testing.T) {
 	env, _, worktree := sandboxedEnv(t, sandbox.ModeReadOnly)
 	writeScopingFixtureAt(t, worktree)
 
-	got, err := env.Glob("**/*", worktree)
+	got, err := env.Glob(t.Context(), "**/*", worktree)
 	if err != nil {
 		t.Fatalf("Glob: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestSandboxedGlob_IncludeIgnoredRestoresExcludedPaths(t *testing.T) {
 	env, _, worktree := sandboxedEnv(t, sandbox.ModeReadOnly)
 	writeScopingFixtureAt(t, worktree)
 
-	got, err := env.Glob("**/*", worktree, true)
+	got, err := env.Glob(t.Context(), "**/*", worktree, true)
 	if err != nil {
 		t.Fatalf("Glob: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestGlobWithExclusions_ReportsExcludedCountWhenFullyFiltered(t *testing.T) 
 	dir := writeScopingFixture(t)
 	env := NewLocalExecutionEnvironment(dir)
 
-	matches, excluded, err := env.GlobWithExclusions("node_modules/**/*.js", dir, false)
+	matches, excluded, err := env.GlobWithExclusions(t.Context(), "node_modules/**/*.js", dir, false)
 	if err != nil {
 		t.Fatalf("GlobWithExclusions: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestGlobWithExclusions_ReportsExcludedCountWhenFullyFiltered(t *testing.T) 
 		t.Fatal("expected a non-zero excluded count for a fully-filtered glob")
 	}
 
-	matches, excluded, err = env.GlobWithExclusions("node_modules/**/*.js", dir, true)
+	matches, excluded, err = env.GlobWithExclusions(t.Context(), "node_modules/**/*.js", dir, true)
 	if err != nil {
 		t.Fatalf("GlobWithExclusions include_ignored: %v", err)
 	}
@@ -227,7 +227,7 @@ func TestSandboxedGlobWithExclusions_ReportsExcludedCountWhenFullyFiltered(t *te
 	env, _, worktree := sandboxedEnv(t, sandbox.ModeReadOnly)
 	writeScopingFixtureAt(t, worktree)
 
-	matches, excluded, err := env.GlobWithExclusions("node_modules/**/*.js", worktree, false)
+	matches, excluded, err := env.GlobWithExclusions(t.Context(), "node_modules/**/*.js", worktree, false)
 	if err != nil {
 		t.Fatalf("GlobWithExclusions: %v", err)
 	}

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bmatcuk/doublestar/v4"
 	"github.com/spf13/afero"
 	"primeradiant.com/evener/agent/internal/tool/repair"
 	"primeradiant.com/evener/agent/sandbox"
@@ -1272,8 +1271,12 @@ func (e *LocalExecutionEnvironment) ListDirectory(path string, depth int) ([]Dir
 // Dotfiles/dirs (.git, .claude/worktrees/x, ...) and gitignored paths are
 // excluded by default, matching grepNative's long-standing hidden-file skip
 // plus new .gitignore awareness; pass includeIgnored(true) to restore them.
-func (e *LocalExecutionEnvironment) Glob(pattern string, basePath string, includeIgnored ...bool) ([]string, error) {
-	matches, _, err := e.GlobWithExclusions(pattern, basePath, len(includeIgnored) > 0 && includeIgnored[0])
+//
+// The walk is bounded by ctx: cancelling it aborts an in-flight glob and
+// returns ctx's error. Directory symlinks are never traversed, so a `**`
+// pattern over a tree that links back into itself still terminates.
+func (e *LocalExecutionEnvironment) Glob(ctx context.Context, pattern string, basePath string, includeIgnored ...bool) ([]string, error) {
+	matches, _, err := e.GlobWithExclusions(ctx, pattern, basePath, len(includeIgnored) > 0 && includeIgnored[0])
 	return matches, err
 }
 
@@ -1284,7 +1287,7 @@ func (e *LocalExecutionEnvironment) Glob(pattern string, basePath string, includ
 // count never includes matches dropped by sandbox masking — that's a
 // separate security boundary, not something to describe to the caller as
 // "gitignored".
-func (e *LocalExecutionEnvironment) GlobWithExclusions(pattern string, basePath string, includeIgnored bool) ([]string, int, error) {
+func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, pattern string, basePath string, includeIgnored bool) ([]string, int, error) {
 	patterns, err := expandSearchPattern(pattern)
 	if err != nil {
 		return nil, 0, err
@@ -1299,9 +1302,9 @@ func (e *LocalExecutionEnvironment) GlobWithExclusions(pattern string, basePath 
 	if sfs := e.sandbox(); sfs != nil {
 		// Sandboxed: the base is policy-checked and the walk refuses symlink
 		// traversal (no out-of-root match) and drops masked matches.
-		return sfs.glob("glob", base, pattern, includeIgnored)
+		return sfs.glob(ctx, "glob", base, pattern, includeIgnored)
 	}
-	fsys := os.DirFS(base)
+	fsys := cancelFS{ctx: ctx, fsys: os.DirFS(base)}
 	var ignores *ignoreSet
 	if !includeIgnored {
 		// No masking concept off the sandboxed path: no-op skip.
@@ -1311,7 +1314,7 @@ func (e *LocalExecutionEnvironment) GlobWithExclusions(pattern string, basePath 
 	var abs []string
 	excluded := 0
 	for _, pattern := range patterns {
-		matches, err := doublestar.Glob(fsys, pattern)
+		matches, err := globMatches(ctx, fsys, pattern)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/agent/execenv/local_edge_program_fuzz_test.go
+++ b/agent/execenv/local_edge_program_fuzz_test.go
@@ -189,7 +189,7 @@ func runLocalEdgeContractProgram(t *testing.T, program []byte) localEdgeTrace {
 	} else {
 		trace.GrepError = "best-effort-empty"
 	}
-	if _, err := env.Glob("[", ""); err == nil {
+	if _, err := env.Glob(t.Context(), "[", ""); err == nil {
 		t.Fatal("Glob malformed pattern unexpectedly succeeded")
 	}
 

--- a/agent/execenv/local_operations_program_fuzz_test.go
+++ b/agent/execenv/local_operations_program_fuzz_test.go
@@ -179,25 +179,25 @@ func runLocalFilesystemOperationProgram(t *testing.T, program []byte) localFiles
 			t.Fatalf("set fixture mtime: %v", err)
 		}
 	}
-	ordered, err := env.Glob("order-*.txt", "")
+	ordered, err := env.Glob(t.Context(), "order-*.txt", "")
 	if err != nil {
 		t.Fatalf("Glob ordered = %v", err)
 	}
 	if got, want := localFilesystemProgramRelativePaths(t, root, ordered), []string{"order-new.txt", "order-b.txt", "order-a.txt"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("Glob mtime order = %v, want %v", got, want)
 	}
-	relativeGo, err := env.Glob("*.go", "pkg")
+	relativeGo, err := env.Glob(t.Context(), "*.go", "pkg")
 	if err != nil || !reflect.DeepEqual(localFilesystemProgramRelativePaths(t, root, relativeGo), []string{filepath.Join("pkg", "main.go")}) {
 		t.Fatalf("Glob relative base = %v, %v", relativeGo, err)
 	}
-	absoluteGo, err := env.Glob("*.go", filepath.Join(root, "pkg"))
+	absoluteGo, err := env.Glob(t.Context(), "*.go", filepath.Join(root, "pkg"))
 	if err != nil || !reflect.DeepEqual(localFilesystemProgramRelativePaths(t, root, absoluteGo), []string{filepath.Join("pkg", "main.go")}) {
 		t.Fatalf("Glob absolute base = %v, %v", absoluteGo, err)
 	}
-	if matches, err := env.Glob("no-match-*.txt", ""); err != nil || len(matches) != 0 {
+	if matches, err := env.Glob(t.Context(), "no-match-*.txt", ""); err != nil || len(matches) != 0 {
 		t.Fatalf("Glob no-match = %v, %v", matches, err)
 	}
-	if _, err := env.Glob("[", ""); err == nil {
+	if _, err := env.Glob(t.Context(), "[", ""); err == nil {
 		t.Fatal("Glob malformed pattern unexpectedly succeeded")
 	}
 	trace.Globs = append(trace.Globs,

--- a/agent/execenv/rungit_test.go
+++ b/agent/execenv/rungit_test.go
@@ -89,13 +89,15 @@ type argvOnlyEnv struct {
 	gotWorkingDir string
 }
 
-func (e *argvOnlyEnv) Initialize() error                              { return nil }
-func (e *argvOnlyEnv) Cleanup()                                       {}
-func (e *argvOnlyEnv) WorkingDirectory() string                       { return "" }
-func (e *argvOnlyEnv) Platform() string                               { return "test" }
-func (e *argvOnlyEnv) OSVersion() string                              { return "test" }
-func (e *argvOnlyEnv) FileExists(string) bool                         { return false }
-func (e *argvOnlyEnv) Glob(string, string, ...bool) ([]string, error) { return nil, nil }
+func (e *argvOnlyEnv) Initialize() error        { return nil }
+func (e *argvOnlyEnv) Cleanup()                 {}
+func (e *argvOnlyEnv) WorkingDirectory() string { return "" }
+func (e *argvOnlyEnv) Platform() string         { return "test" }
+func (e *argvOnlyEnv) OSVersion() string        { return "test" }
+func (e *argvOnlyEnv) FileExists(string) bool   { return false }
+func (e *argvOnlyEnv) Glob(context.Context, string, string, ...bool) ([]string, error) {
+	return nil, nil
+}
 func (e *argvOnlyEnv) Grep(string, string, string, bool, int, string, ...int) (string, error) {
 	return "", nil
 }
@@ -126,13 +128,15 @@ type shellOnlyEnv struct {
 	gotWorkingDir string
 }
 
-func (e *shellOnlyEnv) Initialize() error                              { return nil }
-func (e *shellOnlyEnv) Cleanup()                                       {}
-func (e *shellOnlyEnv) WorkingDirectory() string                       { return "" }
-func (e *shellOnlyEnv) Platform() string                               { return "test" }
-func (e *shellOnlyEnv) OSVersion() string                              { return "test" }
-func (e *shellOnlyEnv) FileExists(string) bool                         { return false }
-func (e *shellOnlyEnv) Glob(string, string, ...bool) ([]string, error) { return nil, nil }
+func (e *shellOnlyEnv) Initialize() error        { return nil }
+func (e *shellOnlyEnv) Cleanup()                 {}
+func (e *shellOnlyEnv) WorkingDirectory() string { return "" }
+func (e *shellOnlyEnv) Platform() string         { return "test" }
+func (e *shellOnlyEnv) OSVersion() string        { return "test" }
+func (e *shellOnlyEnv) FileExists(string) bool   { return false }
+func (e *shellOnlyEnv) Glob(context.Context, string, string, ...bool) ([]string, error) {
+	return nil, nil
+}
 func (e *shellOnlyEnv) Grep(string, string, string, bool, int, string, ...int) (string, error) {
 	return "", nil
 }

--- a/agent/execenv/sandbox_escape_test.go
+++ b/agent/execenv/sandbox_escape_test.go
@@ -132,7 +132,7 @@ func TestEscape_DenylistReadEveryTool(t *testing.T) {
 			if env.FileExists(key) {
 				t.Error("file_exists(denylisted): must be false")
 			}
-			if _, err := env.Glob("*", ssh); !isDeniedErr(err) {
+			if _, err := env.Glob(t.Context(), "*", ssh); !isDeniedErr(err) {
 				t.Errorf("glob(denylisted base): want denial, got %v", err)
 			}
 			if _, err := env.Grep("KEY", ssh, "", false, 10, "content"); !isDeniedErr(err) {

--- a/agent/execenv/sandbox_tools_test.go
+++ b/agent/execenv/sandbox_tools_test.go
@@ -711,7 +711,7 @@ func TestGlobRestrictedOutsideRefused(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(home, "x.txt"), []byte("y"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_, err := env.Glob("*.txt", home)
+	_, err := env.Glob(t.Context(), "*.txt", home)
 	mustDenied(t, err, "restricted glob outside worktree")
 }
 
@@ -734,7 +734,7 @@ func TestGlobSymlinkNoEscape(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(worktree, "real.txt"), []byte("ok"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	matches, err := env.Glob("**/*.txt", worktree)
+	matches, err := env.Glob(t.Context(), "**/*.txt", worktree)
 	if err != nil {
 		t.Fatalf("glob: %v", err)
 	}
@@ -761,7 +761,7 @@ func TestGlobSkipsMaskedMatches(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(home, "visible.txt"), []byte("y"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	matches, err := env.Glob("**/*.txt", home)
+	matches, err := env.Glob(t.Context(), "**/*.txt", home)
 	if err != nil {
 		t.Fatalf("glob: %v", err)
 	}
@@ -841,7 +841,7 @@ func TestSandboxBrowseBraceAlternatives(t *testing.T) {
 		}
 	}
 
-	matches, err := env.Glob("*.{ts,css}", worktree)
+	matches, err := env.Glob(t.Context(), "*.{ts,css}", worktree)
 	if err != nil {
 		t.Fatalf("sandbox glob brace alternatives: %v", err)
 	}
@@ -1015,7 +1015,7 @@ func TestGlobGrepOffIdentical(t *testing.T) {
 	}
 	off := NewLocalExecutionEnvironment(worktree)
 
-	matches, err := off.Glob("*.txt", worktree)
+	matches, err := off.Glob(t.Context(), "*.txt", worktree)
 	if err != nil || len(matches) != 1 || !strings.HasSuffix(matches[0], "a.txt") {
 		t.Fatalf("off glob = %v err %v", matches, err)
 	}

--- a/agent/execenv/search_patterns.go
+++ b/agent/execenv/search_patterns.go
@@ -1,10 +1,13 @@
 package execenv
 
 import (
+	"context"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 	"strings"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"primeradiant.com/evener/agent/internal/globpattern"
 )
 
@@ -14,6 +17,61 @@ func expandSearchPattern(pattern string) ([]string, error) {
 		return nil, fmt.Errorf("invalid glob pattern: %w", err)
 	}
 	return expanded, nil
+}
+
+// cancelFS wraps an fs.FS so a walk over it observes ctx. doublestar has no
+// context-aware entry point and reaches the filesystem only through Open,
+// ReadDir and Stat, so failing those three the moment ctx is done is what
+// makes an in-flight glob abortable — without it a `**` walk over a large
+// tree runs to completion no matter who asks it to stop.
+type cancelFS struct {
+	ctx  context.Context
+	fsys fs.FS
+}
+
+func (c cancelFS) Open(name string) (fs.File, error) {
+	if err := c.ctx.Err(); err != nil {
+		return nil, err
+	}
+	return c.fsys.Open(name)
+}
+
+func (c cancelFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if err := c.ctx.Err(); err != nil {
+		return nil, err
+	}
+	return fs.ReadDir(c.fsys, name)
+}
+
+func (c cancelFS) Stat(name string) (fs.FileInfo, error) {
+	if err := c.ctx.Err(); err != nil {
+		return nil, err
+	}
+	return fs.Stat(c.fsys, name)
+}
+
+// globMatches runs one expanded glob pattern against fsys, which must already
+// observe ctx (see cancelFS).
+//
+// WithNoFollow keeps `**` traversal from descending through directory
+// symlinks. Symlinks still match; they are just never walked into, because a
+// directory symlink can re-enter the tree it lives in — /proc/<pid>/root
+// points back at / — and a `**` walk that follows one has no reason to stop.
+// The sandboxed walk already refuses symlink traversal outright, so this also
+// brings the two paths into agreement.
+func globMatches(ctx context.Context, fsys fs.FS, pattern string) ([]string, error) {
+	matches, err := doublestar.Glob(fsys, pattern, doublestar.WithNoFollow())
+	// doublestar reports I/O errors only under WithFailOnIOErrors, which we
+	// don't want (an unreadable directory shouldn't fail the whole glob). So a
+	// cancelled walk surfaces here as a truncated result with a nil error;
+	// answer with the cancellation instead of a plausible-looking short list.
+	if cerr := ctx.Err(); cerr != nil {
+		return nil, cerr
+	}
+	if err != nil {
+		return nil, err
+	}
+	return matches, nil
 }
 
 func expandGrepFilter(filter string) ([]string, error) {

--- a/agent/execenv/securepath_browse_fdops_unix.go
+++ b/agent/execenv/securepath_browse_fdops_unix.go
@@ -4,6 +4,7 @@ package execenv
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -11,7 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/bmatcuk/doublestar/v4"
 	"golang.org/x/sys/unix"
 )
 
@@ -91,7 +91,7 @@ func toFsErr(err error) error {
 //
 // Dotfiles/dirs and gitignored paths are excluded by default (matching the
 // off path's Glob), unless includeIgnored is set.
-func (s *sandboxFS) glob(tool, base, pattern string, includeIgnored bool) ([]string, int, error) {
+func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includeIgnored bool) ([]string, int, error) {
 	patterns, err := expandSearchPattern(pattern)
 	if err != nil {
 		return nil, 0, err
@@ -102,7 +102,7 @@ func (s *sandboxFS) glob(tool, base, pattern string, includeIgnored bool) ([]str
 	}
 	defer func() { _ = unix.Close(baseFd) }()
 
-	fsys := &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s}
+	fsys := cancelFS{ctx: ctx, fsys: &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s}}
 	var ignores *ignoreSet
 	if !includeIgnored {
 		// Never list or read into a masked subtree while collecting
@@ -116,7 +116,7 @@ func (s *sandboxFS) glob(tool, base, pattern string, includeIgnored bool) ([]str
 	var abs []string
 	excluded := 0
 	for _, pattern := range patterns {
-		matches, err := doublestar.Glob(fsys, pattern)
+		matches, err := globMatches(ctx, fsys, pattern)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/agent/execenv/securepath_other.go
+++ b/agent/execenv/securepath_other.go
@@ -3,6 +3,7 @@
 package execenv
 
 import (
+	"context"
 	"fmt"
 	"os"
 )
@@ -70,7 +71,7 @@ func (s *sandboxFS) listDir(tool, abs string, depth int) ([]DirEntry, error) {
 	return nil, errSandboxUnsupported()
 }
 
-func (s *sandboxFS) glob(tool, base, pattern string, includeIgnored bool) ([]string, int, error) {
+func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includeIgnored bool) ([]string, int, error) {
 	return nil, 0, errSandboxUnsupported()
 }
 

--- a/agent/execenv/securepath_program_fuzz_test.go
+++ b/agent/execenv/securepath_program_fuzz_test.go
@@ -597,11 +597,11 @@ func pfsAssertGlob(t *testing.T, env *LocalExecutionEnvironment, fixture pfsFixt
 	t.Helper()
 	patterns := []string{"*.txt", "**/*.txt", "docs/**/*.txt", "masked/**/*.txt", "escape/**/*.txt"}
 	pattern := patterns[int(selector)%len(patterns)]
-	matches, err := env.Glob(pattern, ".")
+	matches, err := env.Glob(t.Context(), pattern, ".")
 	if err != nil {
 		t.Fatalf("glob(%q): %v", pattern, err)
 	}
-	again, err := env.Glob(pattern, ".")
+	again, err := env.Glob(t.Context(), pattern, ".")
 	if err != nil {
 		t.Fatalf("repeat glob(%q): %v", pattern, err)
 	}

--- a/agent/git_snapshot_test.go
+++ b/agent/git_snapshot_test.go
@@ -32,7 +32,7 @@ func (e *snapshotCountingEnv) EditFile(string, string, string, bool) (string, er
 	return "", nil
 }
 func (e *snapshotCountingEnv) FileExists(string) bool { return false }
-func (e *snapshotCountingEnv) Glob(string, string, ...bool) ([]string, error) {
+func (e *snapshotCountingEnv) Glob(context.Context, string, string, ...bool) ([]string, error) {
 	return nil, nil
 }
 func (e *snapshotCountingEnv) Grep(string, string, string, bool, int, string, ...int) (string, error) {

--- a/agent/internal/agenttest/env.go
+++ b/agent/internal/agenttest/env.go
@@ -31,11 +31,11 @@ func (f *FakeEnv) ExecCommand(_ context.Context, command string, _ int, _ string
 	return execenv.ExecResult{ExitCode: 1}, nil
 }
 
-func (f *FakeEnv) ReadFile(string, *int, *int) (string, error)           { return "", nil }
-func (f *FakeEnv) WriteFile(string, string) (string, error)              { return "", nil }
-func (f *FakeEnv) EditFile(string, string, string, bool) (string, error) { return "", nil }
-func (f *FakeEnv) FileExists(string) bool                                { return false }
-func (f *FakeEnv) Glob(string, string, ...bool) ([]string, error)        { return nil, nil }
+func (f *FakeEnv) ReadFile(string, *int, *int) (string, error)                     { return "", nil }
+func (f *FakeEnv) WriteFile(string, string) (string, error)                        { return "", nil }
+func (f *FakeEnv) EditFile(string, string, string, bool) (string, error)           { return "", nil }
+func (f *FakeEnv) FileExists(string) bool                                          { return false }
+func (f *FakeEnv) Glob(context.Context, string, string, ...bool) ([]string, error) { return nil, nil }
 func (f *FakeEnv) Grep(string, string, string, bool, int, string, ...int) (string, error) {
 	return "", nil
 }

--- a/agent/internal/agenttest/env_deny.go
+++ b/agent/internal/agenttest/env_deny.go
@@ -99,7 +99,7 @@ func (d *DenyEnv) FileExists(path string) bool {
 	return d.draw("exists", path)%2 == 0
 }
 
-func (d *DenyEnv) Glob(pattern string, basePath string, includeIgnored ...bool) ([]string, error) {
+func (d *DenyEnv) Glob(_ context.Context, pattern string, basePath string, includeIgnored ...bool) ([]string, error) {
 	h := d.draw("glob", pattern, basePath)
 	n := int(h % 4)
 	out := make([]string, 0, n)

--- a/agent/internal/agenttest/program_fuzz_test.go
+++ b/agent/internal/agenttest/program_fuzz_test.go
@@ -224,7 +224,7 @@ func assertAgenttestFakeEnv(t *testing.T, root string) {
 	if env.FileExists("x") {
 		t.Fatal("FakeEnv.FileExists = true")
 	}
-	if got, err := env.Glob("*", root); err != nil || got != nil {
+	if got, err := env.Glob(t.Context(), "*", root); err != nil || got != nil {
 		t.Fatalf("FakeEnv.Glob = %#v, %v", got, err)
 	}
 	if got, err := env.Grep("x", root, "", false, 1, ""); err != nil || got != "" {
@@ -308,7 +308,7 @@ func FuzzDenyEnvProgram(f *testing.F) {
 		if got := env.boundedText(0); got != "" {
 			t.Fatalf("DenyEnv.boundedText(0) = %q", got)
 		}
-		if matches, err := env.Glob("*", path); err != nil || len(matches) > 3 {
+		if matches, err := env.Glob(t.Context(), "*", path); err != nil || len(matches) > 3 {
 			t.Fatalf("DenyEnv.Glob = %#v, %v", matches, err)
 		}
 		if entries, err := env.ListDirectory(path, 0); err != nil || len(entries) > 3 {

--- a/agent/session_dod_test.go
+++ b/agent/session_dod_test.go
@@ -98,7 +98,7 @@ func (e *captureEnv) EditFile(path string, oldString string, newString string, r
 	return "", errors.New("not implemented")
 }
 func (e *captureEnv) FileExists(path string) bool { return false }
-func (e *captureEnv) Glob(pattern string, basePath string, includeIgnored ...bool) ([]string, error) {
+func (e *captureEnv) Glob(_ context.Context, pattern string, basePath string, includeIgnored ...bool) ([]string, error) {
 	return nil, errors.New("not implemented")
 }
 func (e *captureEnv) Grep(pattern string, path string, globFilter string, caseInsensitive bool, maxResults int, outputMode string, contextLines ...int) (string, error) {
@@ -157,7 +157,7 @@ func (e *timeoutEnv) EditFile(path string, oldString string, newString string, r
 	return "", errors.New("not implemented")
 }
 func (e *timeoutEnv) FileExists(path string) bool { return false }
-func (e *timeoutEnv) Glob(pattern string, basePath string, includeIgnored ...bool) ([]string, error) {
+func (e *timeoutEnv) Glob(_ context.Context, pattern string, basePath string, includeIgnored ...bool) ([]string, error) {
 	return nil, errors.New("not implemented")
 }
 func (e *timeoutEnv) Grep(pattern string, path string, globFilter string, caseInsensitive bool, maxResults int, outputMode string, contextLines ...int) (string, error) {

--- a/agent/session_tooldeps_test.go
+++ b/agent/session_tooldeps_test.go
@@ -34,7 +34,7 @@ func (e *readBeforeWriteEnv) EditFile(path string, oldString string, newString s
 	return "edited " + path, nil
 }
 func (e *readBeforeWriteEnv) FileExists(path string) bool { return e.existing[path] }
-func (e *readBeforeWriteEnv) Glob(pattern string, basePath string, includeIgnored ...bool) ([]string, error) {
+func (e *readBeforeWriteEnv) Glob(_ context.Context, pattern string, basePath string, includeIgnored ...bool) ([]string, error) {
 	return nil, errors.New("not implemented")
 }
 func (e *readBeforeWriteEnv) Grep(pattern string, path string, globFilter string, caseInsensitive bool, maxResults int, outputMode string, contextLines ...int) (string, error) {

--- a/agent/session_tools_shell.go
+++ b/agent/session_tools_shell.go
@@ -232,7 +232,6 @@ func registerShellTools(reg *tool.Registry, s *Session, deps *toolDeps) error {
 	if err := register(tool.RegisteredTool{
 		Tool: llm.Tool{Definition: tool.DefGlob(), ReadOnly: true},
 		Exec: func(ctx context.Context, env execenv.ExecutionEnvironment, args map[string]any) (any, error) {
-			_ = ctx
 			pat := stringArg(args, "pattern")
 			path := stringArg(args, "path")
 			includeIgnored := false
@@ -243,9 +242,9 @@ func registerShellTools(reg *tool.Registry, s *Session, deps *toolDeps) error {
 			var excluded int
 			var err error
 			if ge, ok := env.(execenv.GlobExcluder); ok {
-				matches, excluded, err = ge.GlobWithExclusions(pat, path, includeIgnored)
+				matches, excluded, err = ge.GlobWithExclusions(ctx, pat, path, includeIgnored)
 			} else {
-				matches, err = env.Glob(pat, path, includeIgnored)
+				matches, err = env.Glob(ctx, pat, path, includeIgnored)
 			}
 			if err != nil {
 				return "", err

--- a/agent/session_tools_shell_program_fuzz_test.go
+++ b/agent/session_tools_shell_program_fuzz_test.go
@@ -453,7 +453,7 @@ func (e *stpEnv) Grep(pattern, path, globFilter string, caseInsensitive bool, ma
 	return e.grepOutput, e.grepErr
 }
 
-func (e *stpEnv) Glob(pattern, path string, includeIgnored ...bool) ([]string, error) {
+func (e *stpEnv) Glob(_ context.Context, pattern, path string, includeIgnored ...bool) ([]string, error) {
 	e.globCalls = append(e.globCalls, stpGlobCall{pattern: pattern, path: path})
 	return append([]string(nil), e.globMatches...), e.globErr
 }

--- a/agent/session_tools_worktree_test.go
+++ b/agent/session_tools_worktree_test.go
@@ -183,7 +183,9 @@ func (fakeZeroExitErrEnv) ReadFile(string, *int, *int) (string, error)          
 func (fakeZeroExitErrEnv) WriteFile(string, string) (string, error)              { return "", nil }
 func (fakeZeroExitErrEnv) EditFile(string, string, string, bool) (string, error) { return "", nil }
 func (fakeZeroExitErrEnv) FileExists(string) bool                                { return false }
-func (fakeZeroExitErrEnv) Glob(string, string, ...bool) ([]string, error)        { return nil, nil }
+func (fakeZeroExitErrEnv) Glob(context.Context, string, string, ...bool) ([]string, error) {
+	return nil, nil
+}
 func (fakeZeroExitErrEnv) Grep(string, string, string, bool, int, string, ...int) (string, error) {
 	return "", nil
 }

--- a/agent/workspace_prompt_program_fuzz_test.go
+++ b/agent/workspace_prompt_program_fuzz_test.go
@@ -794,7 +794,7 @@ func (e *wppEnv) EditFile(string, string, string, bool) (string, error) {
 	return "", errors.New("wppEnv EditFile is not a filesystem")
 }
 func (e *wppEnv) FileExists(string) bool { return false }
-func (e *wppEnv) Glob(string, string, ...bool) ([]string, error) {
+func (e *wppEnv) Glob(context.Context, string, string, ...bool) ([]string, error) {
 	return nil, errors.New("wppEnv Glob is not a filesystem")
 }
 func (e *wppEnv) Grep(string, string, string, bool, int, string, ...int) (string, error) {


### PR DESCRIPTION
## The incident

In retest7 (`sam-cell-seg` trial UzmUsFz) a delegate called `find_files {"path": "/", "pattern": "**/convert_masks.py", "include_ignored": true}`. The call never returned, `job_stop` degraded to `stop_pending` forever because the delegate was inside an uninterruptible tool call, and the run burned 109 minutes of dead time before an external process killer fired.

## Why it hung

`LocalExecutionEnvironment.GlobWithExclusions` called `doublestar.Glob(os.DirFS(base), pattern)` with no context. Two independent problems:

1. **Unbounded walk.** With `base=/` and a `**` pattern the walk descends into `/proc`, where `/proc/<pid>/root` is a symlink back to `/`. doublestar follows directory symlinks by default, so the walk re-enters the tree it is already in and never finishes.
2. **Uncancellable.** No context reached the walk, so a stop request could only be *recorded*, never honored. That is what turned a model mistake that should have cost seconds into a session-long hang.

## The fix

**Cancellation.** `ExecutionEnvironment.Glob` and `GlobExcluder.GlobWithExclusions` now take a `context.Context`, threaded from the tool dispatch context the `find_files` handler already receives and discarded with `_ = ctx`. That context descends from the delegate's per-run context (`subagents.go`), which `job_stop` cancels — so the plumbing is real, not decorative. The `fs.FS` the walk runs over is wrapped in `cancelFS`, which fails `Open`/`ReadDir`/`Stat` once the context is done; doublestar reaches the filesystem only through those three, so the walk unwinds promptly. Because doublestar swallows I/O errors unless `WithFailOnIOErrors` is set (which we do not want — an unreadable directory should not fail the whole glob), a cancelled walk would otherwise come back as a plausible-looking short list with a nil error. `globMatches` reports the cancellation instead.

**Termination.** The walk now runs with `doublestar.WithNoFollow()`, so `**` traversal never descends through a directory symlink. Symlinks still *match*; they are just never walked into. This is the rule the sandboxed walk (`secureDirFS`) has always enforced, so the two paths now agree.

No path is special-cased. `/` and `/proc` are nowhere in the diff — the mechanism is fixed, not the instance.

## Test evidence

Three new tests in `agent/execenv/glob_cancel_test.go`, all watched failing before the fix:

- `TestGlobDoesNotTraverseDirectorySymlinkLoops` — a `t.TempDir()` fixture with one real match plus a directory symlink pointing back at the fixture root. Before: 16 matches, every one reached through the loop, cut off only by `PATH_MAX`. After: the single real match. Skips where `os.Symlink` cannot work.
- `TestGlobMatchesStopsOnContextCancellation` — cancels the context on the third `ReadDir` of a 24-entry `fstest.MapFS` tree. Before: `([], <nil>)`. After: `context.Canceled`, with the walk stopping inside 6 `ReadDir` calls instead of running the tree out.
- `TestGlobWithExclusionsReportsCancellation` — the same contract through the exported entry point the tool calls. Before: `([], 0, <nil>)`. After: `context.Canceled`.

## Gates

`make build-go`, `make vet`, `make lint`, `WEB=0 make test`, `go test -race` on `./agent/`, `./agent/execenv/...`, `./agent/internal/agenttest/...` — all green.

Two flake sets appeared on intermediate full-suite runs and each passed in isolation and did not recur: `TestLive_MCP_StdioServer` / `TestIntg_InitMCP_PluginProvidedServerMerges` (MCP stdio connect deadline under a loaded shard) and `TestResumeDaemonDetachesFromHubSession` / `TestSpawnDaemonDetachesFromHubSession` (hub daemon detach). Neither package touches the glob path. The third full-suite run was clean end to end.

Note on `lint-gofmt`: the Homebrew `gofmt` on this machine is Go 1.27 and false-flags three files this branch does not touch (`agent/delegate_tree_start.go`, `agent/responses_continuation_eligibility.go`, `agent/tool_args_fuzz_test.go`) over the 1.27 composite-literal indentation change. Lint was run against the repo-pinned Go 1.25.6 toolchain, under which those files are clean and this branch is clean.

## Scope note

`ExecutionEnvironment.Glob` growing a context parameter touches ~13 test doubles. That churn is deliberate: the alternative was leaving `Glob` context-free and having it hand `context.Background()` to `GlobWithExclusions`, which would have looked like plumbing while cancelling nothing.

Fixes #369

The drain half of this incident — a stop-requested, unresponsive delegate that the drain waits on forever — is #317, handled in a separate PR.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT