### PR TITLE
Stop waiting on a delegate that was told to stop and never answered

### DIFF
--- a/agent/delegate_tree_controller.go
+++ b/agent/delegate_tree_controller.go
@@ -154,8 +154,12 @@ type delegateSnapshot struct {
 	transcriptRef      string
 	notResumableReason string
 	latestActivityAt   time.Time
-	lastOutcome        *delegatestore.Outcome
-	latestPacket       *delegatestore.TerminalPacket
+	// pendingStopSeq is the sequence of a subtree stop admitted against this
+	// delegate and not yet completed; 0 when no stop is outstanding. It is what
+	// distinguishes a delegate that was ASKED to stop from one that has.
+	pendingStopSeq uint64
+	lastOutcome    *delegatestore.Outcome
+	latestPacket   *delegatestore.TerminalPacket
 }
 
 // stableDelegateWorktreeSnapshot is the process-local read model used by
@@ -622,6 +626,7 @@ func captureDelegateSnapshot(aggregate *delegatestore.Aggregate) delegateSnapsho
 		transcriptRef:      aggregate.Descriptor.TranscriptRef,
 		notResumableReason: aggregate.NotResumableReason,
 		latestActivityAt:   aggregate.LatestActivityAt,
+		pendingStopSeq:     aggregate.PendingStopSeq,
 		lastOutcome:        outcome,
 		latestPacket:       cloneStableTerminalPacket(aggregate.LatestPacket),
 	}

--- a/agent/session_jobtree_drain.go
+++ b/agent/session_jobtree_drain.go
@@ -423,7 +423,9 @@ func (jm *jobManager) describeUndisposedJobs(ids []string) string {
 // drive/recheck machinery is not converting — a stranded wedge. It walks the
 // same liveDirectSubagents / child gate path treeHasOutstandingWork does,
 // skipping stop-gated and fatally failed children identically (they are never
-// driven, so their leftover state is not a stall the drain can act on).
+// driven, so their leftover state is not a stall the drain can act on) — plus
+// a stop-requested child that has gone unresponsive, which is not live work
+// either (childStopRequestedAndUnresponsive).
 func (s *Session) drainSubtreeIsStalled() (bool, error) {
 	outstanding, err := s.treeHasOutstandingWork()
 	if err != nil {
@@ -468,7 +470,7 @@ func (s *Session) subtreeHasLiveComponent() (bool, error) {
 		active := sub.running || sub.finalizing || sub.driving
 		child := sub.sess
 		sub.mu.Unlock()
-		if child != nil && (s.childStopGated(child.id) || s.childFatalRunGated(child.id)) {
+		if child != nil && (s.childStopGated(child.id) || s.childFatalRunGated(child.id) || s.childStopRequestedAndUnresponsive(child.id)) {
 			continue
 		}
 		if active {
@@ -485,6 +487,70 @@ func (s *Session) subtreeHasLiveComponent() (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// childStopRequestedAndUnresponsive reports whether the direct stable delegate
+// backing childSessionID has a stop request pending against it and has shown no
+// parent-observable activity for drainStallTimeout.
+//
+// This is the delegate-shaped sibling of childStopGated. A stop that COMPLETES
+// leaves the settled outcome childStopGated recognizes; a stop the target
+// cannot honour leaves nothing at all — the delegate stays "running" forever
+// while job_stop reports stop_pending, because it is parked inside a tool call
+// that will never return. The drain then counts it as live work and waits for
+// the process to be killed from outside (#317, and the 109-minute field hang in
+// #369). A stop request the target has not acknowledged in that long is not
+// disposable by waiting, so it stops counting as a live component and the
+// existing stall watchdog announces the give-up.
+//
+// Activity is the signal the quiet watchdog already reads — the delegate's
+// latest transcript turn, API attempt or state write, folded into
+// latestActivityAt. A stop-requested delegate that is still winding down keeps
+// stamping it and keeps counting as live, so the drain still waits on it. The
+// bound is drainStallTimeout rather than a new knob: this is the same
+// "outstanding but nothing is happening" judgement the stall watchdog makes,
+// applied one level up. The watchdog then measures its own continuous-stall
+// window on top, so an abandonment needs two consecutive stall windows of
+// silence — deliberately conservative.
+func (s *Session) childStopRequestedAndUnresponsive(childSessionID string) bool {
+	row, ok := s.directStableDelegateForChildSession(childSessionID)
+	if !ok || row.pendingStopSeq == 0 {
+		return false
+	}
+	since := row.latestActivityAt
+	if since.IsZero() {
+		since = row.runStartedAt
+	}
+	if since.IsZero() {
+		// No activity stamp at all: nothing to measure silence against, so this
+		// says nothing and the delegate keeps its ordinary live/not-live verdict.
+		return false
+	}
+	return s.sclock().Now().Sub(since) >= drainStallTimeout
+}
+
+// subtreeUndisposableStoppedDelegates names the stop-requested, unresponsive
+// delegates (childStopRequestedAndUnresponsive) across this session and every
+// live, non-gated descendant, so the stall watchdog's give-up can say what it
+// abandoned rather than reporting an empty set of stuck managed jobs.
+func (s *Session) subtreeUndisposableStoppedDelegates() []string {
+	var ids []string
+	for _, sub := range s.liveDirectSubagents() {
+		sub.mu.Lock()
+		child := sub.sess
+		sub.mu.Unlock()
+		if child == nil || s.childStopGated(child.id) || s.childFatalRunGated(child.id) {
+			continue
+		}
+		if s.childStopRequestedAndUnresponsive(child.id) {
+			if row, ok := s.directStableDelegateForChildSession(child.id); ok {
+				ids = append(ids, row.id)
+			}
+			continue
+		}
+		ids = append(ids, child.subtreeUndisposableStoppedDelegates()...)
+	}
+	return ids
 }
 
 // subtreeOutstandingDrainJobIDs collects the outstanding managed job ids across
@@ -507,6 +573,23 @@ func (s *Session) subtreeOutstandingDrainJobIDs() []string {
 		ids = append(ids, child.subtreeOutstandingDrainJobIDs()...)
 	}
 	return ids
+}
+
+// drainStallGiveUpMessage renders the stall watchdog's give-up warning. It
+// names both kinds of thing the drain can be left holding — managed jobs the
+// machinery never delivered, and delegates that were told to stop and never
+// answered — and says "none" for an empty set rather than trailing off after a
+// colon, so the warning can never read as if it gave up on nothing.
+func drainStallGiveUpMessage(stuckJobs, undisposableDelegates []string) string {
+	describe := func(ids []string) string {
+		if len(ids) == 0 {
+			return "none"
+		}
+		return strings.Join(ids, ", ")
+	}
+	return fmt.Sprintf(
+		"job-tree drain stalled for %s with no live work; giving up so shutdown can proceed (stuck managed jobs: %s; undisposable stop-requested delegates: %s)",
+		drainStallTimeout, describe(stuckJobs), describe(undisposableDelegates))
 }
 
 // DrainJobTree keeps re-driving the coordinator on managed-job completions until no
@@ -752,13 +835,12 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 					continue
 				}
 				// The drain is wedged on undelivered work the machinery is not
-				// converting. Warn (naming the stuck managed job(s)) and return the last
-				// result with nil error so cmd/evener/run.go prints the coordinator's
-				// last answer and proceeds to Close(), rather than aborting the run.
-				ids := s.subtreeOutstandingDrainJobIDs()
-				s.emit(events.EventWarning, events.WarningData{Message: fmt.Sprintf(
-					"job-tree drain stalled for %s with no live work; giving up so shutdown can proceed (stuck managed jobs: %s)",
-					drainStallTimeout, strings.Join(ids, ", "))})
+				// converting. Warn (naming the stuck managed job(s) and any delegate
+				// abandoned as undisposable) and return the last result with nil error
+				// so cmd/evener/run.go prints the coordinator's last answer and
+				// proceeds to Close(), rather than aborting the run.
+				s.emit(events.EventWarning, events.WarningData{Message: drainStallGiveUpMessage(
+					s.subtreeOutstandingDrainJobIDs(), s.subtreeUndisposableStoppedDelegates())})
 				return lastResult, nil
 			}
 		}

--- a/agent/session_jobtree_drain_stopped_delegate_test.go
+++ b/agent/session_jobtree_drain_stopped_delegate_test.go
@@ -1,0 +1,176 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/internal/agenttest"
+	"primeradiant.com/evener/agent/internal/delegatestore"
+)
+
+// seedStopRequestedDelegate seeds a delegate on root that is mid-run with a
+// subtree stop already REQUESTED against it and never completed — the shape
+// job_stop leaves behind when it degrades to stop_pending because the target is
+// inside a tool call it cannot be interrupted out of. lastActivity is the
+// delegate's latest parent-observable activity. It returns the running subagent
+// row, tracked on root, plus the delegate id.
+func seedStopRequestedDelegate(t *testing.T, root *Session, id string, lastActivity time.Time) (childID, delegateID string) {
+	t.Helper()
+	child := newSession(t, withConfig(SessionConfig{NoProjectPrompts: true}))
+	descriptor := stableToolDescriptor(root, id, "")
+	descriptor.ChildSessionID = child.ID()
+
+	root.delegateController.mu.Lock()
+	_, err := root.delegateController.appendLocked(
+		delegatestore.Event{
+			Kind:       delegatestore.EventDelegateCreated,
+			DelegateID: id,
+			Created:    &delegatestore.DelegateCreated{Descriptor: descriptor},
+		},
+		delegateControllerRunStartedEvent(id, 1, delegatestore.TriggerInitial, lastActivity),
+		delegatestore.Event{
+			Kind:                 delegatestore.EventDelegateSubtreeStopRequested,
+			DelegateID:           id,
+			SubtreeStopRequested: &delegatestore.SubtreeStopRequested{TargetDelegateID: id},
+		},
+	)
+	root.delegateController.mu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The delegate's runtime is still "running" as far as the parent can see:
+	// nothing in the child has finished, so the subagent row keeps the drain's
+	// outstanding check true, exactly as it did in the field.
+	root.subagents.mu.Lock()
+	root.subagents.subs[child.ID()] = &subagent{id: child.ID(), sess: child, running: true}
+	root.subagents.mu.Unlock()
+	t.Cleanup(func() {
+		root.subagents.mu.Lock()
+		delete(root.subagents.subs, child.ID())
+		root.subagents.mu.Unlock()
+	})
+	return child.ID(), id
+}
+
+// stampDelegateActivity records parent-observable activity for a delegate at
+// `at`, the way a transcript turn, an API attempt or a state write does through
+// the controller's ReportActivity path.
+func stampDelegateActivity(root *Session, delegateID string, at time.Time) {
+	c := root.delegateController
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	live := c.live[delegateID]
+	if live == nil {
+		live = &delegateLiveState{}
+		c.live[delegateID] = live
+	}
+	live.activityAt = at
+}
+
+// TestDrainAbandonsStopRequestedDelegateGoneUnresponsive is the drain half of
+// the 109-minute field hang (#317, #369): the root asked to stop a delegate,
+// the delegate was wedged inside an uninterruptible tool call so the stop
+// degraded to stop_pending forever, and the drain kept counting the delegate as
+// live work until an external killer fired. Once a stop-requested delegate has
+// shown no activity for the stall bound it is undisposable, and the drain must
+// announce and give up rather than waiting for the process to be killed.
+func TestDrainAbandonsStopRequestedDelegateGoneUnresponsive(t *testing.T) {
+	clk := agenttest.NewFakeClock()
+	root := newSession(t, withConfig(SessionConfig{clock: clk, NoProjectPrompts: true, TurnEndsProcess: true}))
+	_, delegateID := seedStopRequestedDelegate(t, root, "dlg_wedged", clk.Now())
+
+	outstanding, err := root.treeHasOutstandingWork()
+	if err != nil || !outstanding {
+		t.Fatalf("precondition: a running delegate must be outstanding work, got outstanding=%v err=%v", outstanding, err)
+	}
+	if stalled, err := root.drainSubtreeIsStalled(); err != nil || stalled {
+		t.Fatalf("a stop-requested delegate that just showed activity must still be live, got stalled=%v err=%v", stalled, err)
+	}
+
+	// No activity for the whole bound: the stop can never be honoured.
+	clk.Advance(drainStallTimeout + time.Second)
+	if stalled, err := root.drainSubtreeIsStalled(); err != nil || !stalled {
+		t.Fatalf("a stop-requested delegate silent past the bound must stop counting as live, got stalled=%v err=%v", stalled, err)
+	}
+
+	// TRIPWIRE: the driver single-steps a frozen fake clock with hand-
+	// synchronized channels; nothing here waits on real I/O or a real clock.
+	// 30s only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	d := newStallDriver(ctx, root)
+	d.releaseKick(t)
+	d.assertParked(t, "the first pass only starts the stall clock")
+
+	clk.Advance(drainStallTimeout + time.Second)
+	d.recheck <- time.Time{}
+	d.releaseKick(t)
+
+	select {
+	case <-d.done:
+	// TRIPWIRE: awaits d.done, the drain goroutine's own completion signal.
+	// 30s only fires on a genuine hang.
+	case <-time.After(30 * time.Second):
+		t.Fatal("drain never gave up on a stop-requested, unresponsive delegate")
+	}
+	if d.err != nil {
+		t.Fatalf("give-up must return nil error so the run keeps its result, got %v", d.err)
+	}
+
+	warnings := collectStallWarnings(root)
+	if len(warnings) != 1 {
+		t.Fatalf("abandonment warnings = %d, want 1: %+v", len(warnings), warnings)
+	}
+	msg := warnings[0].Data.(events.WarningData).Message
+	if !strings.Contains(msg, delegateID) {
+		t.Fatalf("abandonment warning must name the delegate it gave up on, got %q", msg)
+	}
+}
+
+// TestDrainWaitsOnStopRequestedDelegateStillMakingProgress is the other half of
+// the contract: a stop request is not itself permission to abandon. A delegate
+// that keeps showing activity inside the bound is winding down normally, and
+// the drain must keep waiting on it however long the stop has been pending.
+func TestDrainWaitsOnStopRequestedDelegateStillMakingProgress(t *testing.T) {
+	clk := agenttest.NewFakeClock()
+	root := newSession(t, withConfig(SessionConfig{clock: clk, NoProjectPrompts: true, TurnEndsProcess: true}))
+	_, delegateID := seedStopRequestedDelegate(t, root, "dlg_winding_down", clk.Now())
+
+	// Well past the bound in absolute terms, but the delegate reported activity
+	// throughout, so it was never silent for the bound.
+	for range 4 {
+		clk.Advance(drainStallTimeout - time.Second)
+		stampDelegateActivity(root, delegateID, clk.Now())
+		if stalled, err := root.drainSubtreeIsStalled(); err != nil || stalled {
+			t.Fatalf("a stop-requested delegate still reporting activity must be waited on, got stalled=%v err=%v", stalled, err)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	d := newStallDriver(ctx, root)
+	d.releaseKick(t)
+	d.assertParked(t, "a progressing delegate must never be cut")
+
+	clk.Advance(drainStallTimeout - time.Second)
+	stampDelegateActivity(root, delegateID, clk.Now())
+	d.recheck <- time.Time{}
+	d.releaseKick(t)
+	d.assertParked(t, "activity inside the bound must keep resetting the stall clock")
+
+	if warnings := collectStallWarnings(root); len(warnings) != 0 {
+		t.Fatalf("a progressing delegate must emit no abandonment warning, got %+v", warnings)
+	}
+
+	cancel()
+	select {
+	case <-d.done:
+	// TRIPWIRE: awaits d.done after cancel(); the goroutine should observe
+	// ctx.Done() and return immediately. 30s only fires on a genuine hang.
+	case <-time.After(30 * time.Second):
+		t.Fatal("drain did not exit after context cancellation")
+	}
+}


### PR DESCRIPTION
## The incident

In retest7 (`sam-cell-seg` trial UzmUsFz) the root ran `job_stop` on a delegate wedged inside an uncancellable `find_files` call, got `stop_pending`, tried `delegate_send` and got `target_busy`, gave up and issued its terminal `communicate` — and the one-shot drain then waited on that "live" delegate for 6528 seconds, until an external process killer fired. 109 minutes. Every managed job had already exited cleanly; the drain had nothing legitimate left to wait for.

## Why it waited

`subtreeHasLiveComponent` counts a child as live work while its subagent row says `running || finalizing || driving`. A delegate parked inside a tool call that will never return stays `running` forever. The two escapes that already exist do not cover it:

- `childStopGated` reads a *settled* outcome (`OutcomeStopped` / `stopped_by_parent`). A stop the target cannot honour settles nothing, so the gate never closes.
- `drainStallTimeout` only bounds a subtree with **no** live component anywhere. One `running` child keeps the stall clock at zero, forever.

So the drain sat in its 250ms recheck making no progress and refusing to quiesce, which is the #317 shape exactly.

## The fix

A new predicate, `childStopRequestedAndUnresponsive`, is the delegate-shaped sibling of `childStopGated`: true when the direct stable delegate has a stop request pending against it (`pendingStopSeq != 0`, plumbed onto `delegateSnapshot` from the durable aggregate that already carried it) **and** has shown no parent-observable activity for `drainStallTimeout`. `subtreeHasLiveComponent` skips such a child alongside the two gates it already skips.

That is the whole mechanism. Once the child stops counting as a live component, the subtree is outstanding-with-nothing-live — precisely the condition the existing stall watchdog acts on. It measures its own continuous-stall window, re-checks the wake edge (so a tree that moves mid-verdict re-runs the pass rather than being cut), announces the give-up, and returns `lastResult` with a nil error so the run prints its answer and proceeds to `Close()`.

**Liveness signal.** `latestActivityAt` — the delegate's latest transcript turn, API attempt or state write, stamped through `noteParentJobActivity` → `ReportActivity` and folded into the durable aggregate. It is the same signal the 10-minute quiet watchdog reads, not a new one.

**No new knob.** The bound is `drainStallTimeout`, applied one level up: this is the same "outstanding but nothing is happening" judgement, asked about one delegate instead of a whole subtree. The watchdog's own window then stacks on top, so an abandonment needs two consecutive stall windows of continuous silence (4 minutes at the shipped default). That is deliberately conservative, and it means there is one number to tune, not two.

**Announcement.** The give-up warning now names the abandoned delegates alongside the stuck managed jobs, and renders an empty set as `none` rather than trailing off after a colon — in this scenario the managed-job list is legitimately empty, and the old text would have read as giving up on nothing.

## Test evidence

`agent/session_jobtree_drain_stopped_delegate_test.go`, both driven by `newStallDriver` (frozen fake clock, hand-synchronized single-stepping — no wall time):

- `TestDrainAbandonsStopRequestedDelegateGoneUnresponsive` — a delegate mid-run with a subtree stop requested and never completed, tracked as a `running` subagent. Asserts the tree is outstanding, that it is **not** stalled while activity is fresh, then advances past the bound. **Watched failing first:** `a stop-requested delegate silent past the bound must stop counting as live, got stalled=false`. After the fix the drain returns with one warning naming the delegate.
- `TestDrainWaitsOnStopRequestedDelegateStillMakingProgress` — the regression guard the requirement calls for. The same fixture, driven four stall-windows past the bound in absolute time while stamping activity inside each window: never stalled, drain stays parked, no warning. This one passes before and after; it exists to pin that a stop request is not by itself permission to abandon.

## Gates

`make build-go`, `make vet`, `make lint`, `WEB=0 make test`, `go test -race ./agent/` — all green.

The first full-suite run hit `TestSpawnDaemonDetachesFromHubSession` and `TestForkedDescendantIsReaped`, both known dev-tooling flakes; both passed in isolation and the next two full runs were clean end to end. Lint was run against the repo-pinned Go 1.25.6 toolchain — the Homebrew `gofmt` on this machine is Go 1.27 and false-flags three untouched files over the 1.27 composite-literal indentation change.

Fixes #317

The glob half of the same incident — `find_files` with a `**` pattern rooted at `/` following `/proc` symlink loops with no context to cancel it — is #369, in a separate PR.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT