### PR TITLE
Bound the glob walk by cycle detection instead of refusing every symlink

### DIFF
--- a/agent/execenv/gitignore.go
+++ b/agent/execenv/gitignore.go
@@ -1,6 +1,7 @@
 package execenv
 
 import (
+	"context"
 	"io/fs"
 	"path"
 	"strings"
@@ -123,13 +124,38 @@ func (s *ignoreSet) matches(relPath string, isDir bool) bool {
 }
 
 // globMatchIsDir reports whether m (a path relative to fsys, as returned by
-// doublestar.Glob) names a directory. doublestar's match strings carry no
-// type information of their own, so this stats the entry; a stat failure is
-// treated as "not a directory" (best-effort, matching the rest of this file's
-// error handling).
-func globMatchIsDir(fsys fs.FS, m string) bool {
+// the glob walk) names a directory. doublestar's match strings carry no type
+// information of their own, so this stats the entry; a stat failure is treated
+// as "not a directory" (best-effort, matching the rest of this file's error
+// handling).
+//
+// A cancelled walk is the exception. Reading the cancellation as "not a
+// directory" would quietly turn off every directory-only .gitignore rule and
+// hand the caller a plausible list with a nil error, which is the failure mode
+// the glob walk itself no longer has — so the cancellation is reported.
+func globMatchIsDir(ctx context.Context, fsys fs.FS, m string) (bool, error) {
 	info, err := fs.Stat(fsys, m)
-	return err == nil && info.IsDir()
+	if err != nil {
+		if cerr := ctx.Err(); cerr != nil {
+			return false, cerr
+		}
+		return false, nil
+	}
+	return info.IsDir(), nil
+}
+
+// globMatchExcluded reports whether the default dotfile/gitignore exclusion
+// drops the glob match m. Shared by the off and sandboxed glob so the two
+// arms exclude — and report a cancellation — identically.
+func globMatchExcluded(ctx context.Context, fsys fs.FS, ignores *ignoreSet, m string) (bool, error) {
+	if isDotPath(m) {
+		return true, nil
+	}
+	isDir, err := globMatchIsDir(ctx, fsys, m)
+	if err != nil {
+		return false, err
+	}
+	return ignores.matches(m, isDir), nil
 }
 
 // isDotPath reports whether any path component of relPath (slash-separated)

--- a/agent/execenv/glob_cancel_test.go
+++ b/agent/execenv/glob_cancel_test.go
@@ -6,84 +6,48 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 	"testing/fstest"
-	"time"
+
+	"primeradiant.com/evener/agent/sandbox"
 )
 
-// globLoopFixture builds a tree holding one real match plus a directory
-// symlink that points back at the tree root — the shape /proc/<pid>/root has,
-// where following the link re-enters the tree it lives in. It returns the
-// fixture root and the absolute path of the one file a `**` glob should match.
-func globLoopFixture(t *testing.T) (root, wantMatch string) {
-	t.Helper()
-	root = t.TempDir()
-	nest := filepath.Join(root, "deep", "nest")
-	if err := os.MkdirAll(nest, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	wantMatch = filepath.Join(nest, "needle.txt")
-	if err := os.WriteFile(wantMatch, []byte("found\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Symlink(root, filepath.Join(root, "deep", "loop")); err != nil {
-		t.Skipf("directory symlinks unavailable on this platform: %v", err)
-	}
-	return root, wantMatch
-}
-
-// TestGlobDoesNotTraverseDirectorySymlinkLoops is the unit-scale reproduction
-// of #369: find_files with a `**` pattern rooted at / never returned because
-// the walk followed /proc/<pid>/root back to / and recursed. The glob must
-// terminate and must report the single real match, not the copies reachable
-// through the loop.
-func TestGlobDoesNotTraverseDirectorySymlinkLoops(t *testing.T) {
-	root, wantMatch := globLoopFixture(t)
-
-	// t.Context() is cancelled when the test ends, so a walk that ignores the
-	// loop bound unwinds instead of spinning on past the failure.
-	ctx := t.Context()
-
-	type outcome struct {
-		matches []string
-		err     error
-	}
-	done := make(chan outcome, 1)
-	go func() {
-		matches, err := NewLocalExecutionEnvironment(root).Glob(ctx, "**/needle.txt", root, true)
-		done <- outcome{matches, err}
-	}()
-
-	select {
-	case got := <-done:
-		if got.err != nil {
-			t.Fatalf("Glob over a symlink loop: %v", got.err)
-		}
-		if want := []string{wantMatch}; !reflect.DeepEqual(got.matches, want) {
-			t.Fatalf("Glob over a symlink loop = %v, want %v (the loop must not be traversed)", got.matches, want)
-		}
-	case <-time.After(15 * time.Second):
-		t.Fatal("Glob over a directory symlink loop did not terminate")
-	}
-}
-
-// cancelAfterNthReadDir cancels the walk's context part-way through the
-// traversal, on the nth ReadDir, so the glob is interrupted mid-walk rather
-// than before it starts.
-type cancelAfterNthReadDir struct {
+// countingFS counts the ReadDir calls a walk makes and, when cancel is set,
+// cancels the walk's context on the cancelOn'th one.
+//
+// It must sit OUTSIDE the ctx-observing wrapper: a counter placed inside it
+// stops being reached the moment the wrapper starts short-circuiting, so it
+// can never show whether the walk kept going after the cancellation — which is
+// exactly the question a promptness assertion asks.
+type countingFS struct {
 	fs.FS
-	n      int
-	calls  int
-	cancel context.CancelFunc
+	cancelOn int
+	cancel   context.CancelFunc
+	calls    int
 }
 
-func (c *cancelAfterNthReadDir) ReadDir(name string) ([]fs.DirEntry, error) {
+func (c *countingFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	c.calls++
-	if c.calls == c.n {
+	if c.cancel != nil && c.calls == c.cancelOn {
 		c.cancel()
 	}
 	return fs.ReadDir(c.FS, name)
+}
+
+func (c *countingFS) Stat(name string) (fs.FileInfo, error) {
+	return fs.Stat(c.FS, name)
+}
+
+// globCancelTree is a 24-file tree deep enough that a completed `**` walk
+// takes many more ReadDir calls than an aborted one.
+func globCancelTree() fstest.MapFS {
+	tree := fstest.MapFS{}
+	for _, dir := range []string{"a", "b", "c", "d", "e", "f", "g", "h"} {
+		for _, sub := range []string{"one", "two", "three"} {
+			tree[filepath.Join(dir, sub, "needle.txt")] = &fstest.MapFile{Data: []byte("x")}
+		}
+	}
+	return tree
 }
 
 // TestGlobMatchesStopsOnContextCancellation proves the other half of #369: an
@@ -91,38 +55,81 @@ func (c *cancelAfterNthReadDir) ReadDir(name string) ([]fs.DirEntry, error) {
 // cancellation, so job_stop and session teardown can actually stop a walk
 // instead of only asking. doublestar swallows I/O errors, so a cancelled walk
 // would otherwise come back as a short result with a nil error.
+//
+// The promptness half is measured against a completed walk over the same tree
+// rather than a hand-picked constant, so the bound stays meaningful if
+// doublestar's traversal changes shape.
 func TestGlobMatchesStopsOnContextCancellation(t *testing.T) {
-	tree := fstest.MapFS{}
-	for _, dir := range []string{"a", "b", "c", "d", "e", "f", "g", "h"} {
-		for _, sub := range []string{"one", "two", "three"} {
-			tree[filepath.Join(dir, sub, "needle.txt")] = &fstest.MapFile{Data: []byte("x")}
-		}
+	tree := globCancelTree()
+
+	full := &countingFS{FS: cancelFS{ctx: t.Context(), fsys: tree}}
+	if _, err := globMatches(t.Context(), full, "**/needle.txt"); err != nil {
+		t.Fatalf("uncancelled globMatches: %v", err)
+	}
+	if full.calls < 20 {
+		t.Fatalf("completed walk took only %d ReadDir calls; the fixture is too small to measure promptness", full.calls)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	counter := &cancelAfterNthReadDir{FS: tree, n: 3, cancel: cancel}
-	fsys := cancelFS{ctx: ctx, fsys: counter}
+	counter := &countingFS{FS: cancelFS{ctx: ctx, fsys: tree}, cancelOn: 3, cancel: cancel}
 
-	matches, err := globMatches(ctx, fsys, "**/needle.txt")
+	matches, err := globMatches(ctx, counter, "**/needle.txt")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("globMatches after mid-walk cancellation = (%v, %v), want context.Canceled", matches, err)
 	}
 	if matches != nil {
 		t.Fatalf("globMatches after cancellation returned partial matches %v, want none", matches)
 	}
-	// The walk must stop at the cancellation, not run the tree out: 8 dirs
-	// with 3 subdirs each is 30+ ReadDir calls when it completes.
-	if counter.calls > 6 {
-		t.Fatalf("walk kept reading after cancellation: %d ReadDir calls", counter.calls)
+	// The walk must unwind at the cancelled call, not grind through the
+	// siblings its parent frames already listed. One extra call is slack for
+	// the frame that observes the cancellation.
+	if counter.calls > counter.cancelOn+1 {
+		t.Fatalf("walk kept reading after cancellation: %d ReadDir calls (a completed walk takes %d)", counter.calls, full.calls)
 	}
 }
 
-// TestGlobWithExclusionsReportsCancellation checks the same contract through
-// the exported entry point the find_files tool calls, so the cancellation is
+// TestGlobMatchesSurvivesAnUnreadableDirectory pins the property that makes
+// the abort safe to build on: aborting on the cancellation must not turn every
+// other I/O failure into a failed glob. A directory the walk cannot read is
+// still skipped, and the matches around it are still returned.
+func TestGlobMatchesSurvivesAnUnreadableDirectory(t *testing.T) {
+	root := t.TempDir()
+	for _, dir := range []string{"readable", "locked"} {
+		if err := os.MkdirAll(filepath.Join(root, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, dir, "needle.txt"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	locked := filepath.Join(root, "locked")
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+	if _, err := os.ReadDir(locked); err == nil {
+		t.Skip("this user can read a 0000 directory; cannot stage an unreadable directory")
+	}
+
+	matches, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), "**/needle.txt", root, true)
+	if err != nil {
+		t.Fatalf("Glob past an unreadable directory: %v", err)
+	}
+	want := []string{filepath.Join(root, "readable", "needle.txt")}
+	if len(matches) != 1 || matches[0] != want[0] {
+		t.Fatalf("Glob past an unreadable directory = %v, want %v", matches, want)
+	}
+}
+
+// TestGlobWithExclusionsReportsCancellation checks the contract through the
+// exported entry point the find_files tool calls, so the cancellation is
 // surfaced to the tool rather than being flattened into an empty result.
 func TestGlobWithExclusionsReportsCancellation(t *testing.T) {
-	root, _ := globLoopFixture(t)
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "needle.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -130,4 +137,122 @@ func TestGlobWithExclusionsReportsCancellation(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("GlobWithExclusions with a cancelled context = (%v, %d, %v), want context.Canceled", matches, excluded, err)
 	}
+}
+
+// TestGlobWithExclusionsStopsMidWalk is the exported-entry-point version of
+// the contract: a walk cancelled once it is already under way must come back
+// as a cancellation, not as the partial list it had collected by then.
+//
+// Promptness is not measured here and cannot be: the counter reaches the walk
+// only from inside GlobWithExclusions' own ctx wrapper, which short-circuits
+// before delegating, so post-cancellation calls never reach it. That
+// measurement lives in TestGlobMatchesStopsOnContextCancellation, where the
+// test owns the layering.
+func TestGlobWithExclusionsStopsMidWalk(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stubGlobBaseFS(t, func(string) fs.FS {
+		return &countingFS{FS: globCancelTree(), cancelOn: 3, cancel: cancel}
+	})
+
+	root := t.TempDir()
+	matches, excluded, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(ctx, "**/needle.txt", root, true)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("GlobWithExclusions cancelled mid-walk = (%v, %d, %v), want context.Canceled", matches, excluded, err)
+	}
+	if matches != nil {
+		t.Fatalf("GlobWithExclusions cancelled mid-walk returned partial matches %v, want none", matches)
+	}
+}
+
+// TestSandboxedGlobReportsCancellation covers the arm the off-sandbox tests
+// never reach: sandboxed sessions run the same walk over a secureDirFS, and a
+// cancellation there must surface as an error too rather than as a
+// plausible-looking empty result.
+func TestSandboxedGlobReportsCancellation(t *testing.T) {
+	env, _, worktree := sandboxedEnv(t, sandbox.ModeReadOnly)
+	nest := filepath.Join(worktree, "deep", "nest")
+	if err := os.MkdirAll(nest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nest, "needle.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sanity: the same glob finds the file when nobody cancels it, so a
+	// cancelled empty result cannot be mistaken for "there was nothing here".
+	found, _, err := env.GlobWithExclusions(t.Context(), "**/needle.txt", worktree, true)
+	if err != nil || len(found) != 1 {
+		t.Fatalf("sandboxed glob = (%v, %v), want the one needle", found, err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	matches, excluded, err := env.GlobWithExclusions(ctx, "**/needle.txt", worktree, true)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("sandboxed GlobWithExclusions with a cancelled context = (%v, %d, %v), want context.Canceled", matches, excluded, err)
+	}
+	if matches != nil {
+		t.Fatalf("sandboxed GlobWithExclusions after cancellation returned %v, want no matches", matches)
+	}
+}
+
+// TestGlobMatchIsDirReportsCancellation covers the post-walk gitignore check:
+// treating a cancelled stat as "not a directory" would silently disable
+// directory-only .gitignore rules and hand back a plausible result with a nil
+// error — the failure mode the walk itself no longer has.
+func TestGlobMatchIsDirReportsCancellation(t *testing.T) {
+	tree := fstest.MapFS{"dir/file.txt": &fstest.MapFile{Data: []byte("x")}}
+
+	isDir, err := globMatchIsDir(t.Context(), cancelFS{ctx: t.Context(), fsys: tree}, "dir")
+	if err != nil || !isDir {
+		t.Fatalf("globMatchIsDir(dir) = (%v, %v), want (true, nil)", isDir, err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	isDir, err = globMatchIsDir(ctx, cancelFS{ctx: ctx, fsys: tree}, "dir")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("globMatchIsDir after cancellation = (%v, %v), want context.Canceled", isDir, err)
+	}
+	if isDir {
+		t.Fatalf("globMatchIsDir after cancellation = true, want false")
+	}
+}
+
+// TestSortPathsByMtimeDescStopsOnCancellation pins the last uncancellable
+// stretch of the glob: stat'ing a large result set to order it. The check has
+// to sit inside the stat loop, so cancelling part-way through stops the
+// remaining stats rather than only being noticed once they are all done.
+func TestSortPathsByMtimeDescStopsOnCancellation(t *testing.T) {
+	paths := mtimeFixture(t, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stats := 0
+	stubSortPathStat(t, func(string) {
+		stats++
+		if stats == 3 {
+			cancel()
+		}
+	})
+
+	err := sortPathsByMtimeDesc(ctx, paths)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("sortPathsByMtimeDesc cancelled part-way = %v, want context.Canceled", err)
+	}
+	if stats > 3 {
+		t.Fatalf("sort kept stat'ing after cancellation: %d of %d stats", stats, len(paths))
+	}
+}
+
+// stubGlobBaseFS interposes on the fs.FS the off-sandbox glob walks, so a test
+// can drive the exported entry point over a filesystem it controls, and
+// restores the seam when the test ends.
+func stubGlobBaseFS(t *testing.T, open func(dir string) fs.FS) {
+	t.Helper()
+	orig := globBaseFS
+	globBaseFS = open
+	t.Cleanup(func() { globBaseFS = orig })
 }

--- a/agent/execenv/glob_walk_test.go
+++ b/agent/execenv/glob_walk_test.go
@@ -1,0 +1,266 @@
+package execenv
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"testing"
+	"testing/fstest"
+	"time"
+)
+
+// globLoopFixture builds a tree holding one real match plus a directory
+// symlink that points back at the tree root — the shape /proc/<pid>/root has,
+// where following the link re-enters the tree it lives in. It returns the
+// fixture root and the absolute path of the one file a `**` glob should match.
+func globLoopFixture(t *testing.T) (root, wantMatch string) {
+	t.Helper()
+	root = t.TempDir()
+	nest := filepath.Join(root, "deep", "nest")
+	if err := os.MkdirAll(nest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wantMatch = filepath.Join(nest, "needle.txt")
+	if err := os.WriteFile(wantMatch, []byte("found\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(root, filepath.Join(root, "deep", "loop")); err != nil {
+		t.Skipf("directory symlinks unavailable on this platform: %v", err)
+	}
+	return root, wantMatch
+}
+
+// globAliasFixture builds the shape this repo's own fleet layout documents:
+// one real directory of sources reachable under a second name through a
+// directory symlink (node_modules/lib -> ../packages/lib). The link points
+// sideways, never at one of its own ancestors, so nothing here is a cycle and
+// every source file must be reported under both names.
+func globAliasFixture(t *testing.T) (root string, wantBothPaths []string) {
+	t.Helper()
+	root = t.TempDir()
+	sources := filepath.Join(root, "packages", "lib")
+	if err := os.MkdirAll(sources, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"a.ts", "b.ts"} {
+		if err := os.WriteFile(filepath.Join(sources, name), []byte("export {}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(root, "node_modules"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("..", "packages", "lib"), filepath.Join(root, "node_modules", "lib")); err != nil {
+		t.Skipf("directory symlinks unavailable on this platform: %v", err)
+	}
+	return root, []string{
+		filepath.Join(root, "node_modules", "lib", "a.ts"),
+		filepath.Join(root, "node_modules", "lib", "b.ts"),
+		filepath.Join(root, "packages", "lib", "a.ts"),
+		filepath.Join(root, "packages", "lib", "b.ts"),
+	}
+}
+
+// sortedCopy returns paths in lexical order, so a test can compare match sets
+// without depending on the newest-mtime-first order Glob returns them in.
+func sortedCopy(paths []string) []string {
+	out := slices.Clone(paths)
+	slices.Sort(out)
+	return out
+}
+
+// TestGlobDoesNotTraverseDirectorySymlinkLoops is the unit-scale reproduction
+// of #369: find_files with a `**` pattern rooted at / never returned because
+// the walk followed /proc/<pid>/root back to / and recursed. The glob must
+// terminate and must report the single real match, not the copies reachable
+// through the loop.
+func TestGlobDoesNotTraverseDirectorySymlinkLoops(t *testing.T) {
+	root, wantMatch := globLoopFixture(t)
+
+	// t.Context() is cancelled when the test ends, so a walk that ignores the
+	// loop bound unwinds instead of spinning on past the failure.
+	ctx := t.Context()
+
+	type outcome struct {
+		matches []string
+		err     error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		matches, err := NewLocalExecutionEnvironment(root).Glob(ctx, "**/needle.txt", root, true)
+		done <- outcome{matches, err}
+	}()
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("Glob over a symlink loop: %v", got.err)
+		}
+		if want := []string{wantMatch}; !reflect.DeepEqual(got.matches, want) {
+			t.Fatalf("Glob over a symlink loop = %v, want %v (the loop must not be traversed)", got.matches, want)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("Glob over a directory symlink loop did not terminate")
+	}
+}
+
+// TestGlobReportsMatchesThroughANonCyclicDirectorySymlink pins the cost of
+// getting termination wrong: refusing every directory symlink (rather than
+// only the ones that re-enter the walk) silently drops every file reachable
+// through a node_modules-style link, which is exactly how this repo's own
+// fleets are laid out. Both names for the same sources must match.
+func TestGlobReportsMatchesThroughANonCyclicDirectorySymlink(t *testing.T) {
+	root, want := globAliasFixture(t)
+
+	got, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), "**/*.ts", root)
+	if err != nil {
+		t.Fatalf("Glob over an aliased directory: %v", err)
+	}
+	if gotSorted := sortedCopy(got); !reflect.DeepEqual(gotSorted, want) {
+		t.Fatalf("Glob(**/*.ts) = %v, want %v (matches through the symlinked name must not be dropped)", gotSorted, want)
+	}
+}
+
+// TestGlobLiteralAndWildcardSegmentsAgreeThroughASymlink covers the
+// self-inconsistency the same over-broad rule produced: doublestar never
+// consults directory-ness for the meta-free prefix of a pattern, so a
+// literally-spelled symlinked directory was traversed while a wildcard segment
+// naming that same directory was not. Spelling must not change the answer.
+func TestGlobLiteralAndWildcardSegmentsAgreeThroughASymlink(t *testing.T) {
+	root, _ := globAliasFixture(t)
+	env := NewLocalExecutionEnvironment(root)
+
+	literal, err := env.Glob(t.Context(), "node_modules/lib/*.ts", root)
+	if err != nil {
+		t.Fatalf("Glob with a literal symlinked segment: %v", err)
+	}
+	wildcard, err := env.Glob(t.Context(), "node_modules/*/*.ts", root)
+	if err != nil {
+		t.Fatalf("Glob with a wildcard segment: %v", err)
+	}
+	if len(literal) == 0 {
+		t.Fatalf("Glob(node_modules/lib/*.ts) = %v, want the two sources behind the link", literal)
+	}
+	if !reflect.DeepEqual(sortedCopy(literal), sortedCopy(wildcard)) {
+		t.Fatalf("Glob(node_modules/lib/*.ts) = %v but Glob(node_modules/*/*.ts) = %v; the two spellings must agree",
+			sortedCopy(literal), sortedCopy(wildcard))
+	}
+}
+
+// TestGlobWalkFSBoundsAFilesystemWithoutFileIdentity covers the backstop for
+// the case cycle detection cannot serve: a filesystem whose entries carry no
+// (device, inode) identity to compare. The walk is bounded by how many
+// listings it makes there, and running out says so rather than handing back
+// the short list it happened to collect.
+func TestGlobWalkFSBoundsAFilesystemWithoutFileIdentity(t *testing.T) {
+	tree := fstest.MapFS{"dir/file.txt": &fstest.MapFile{Data: []byte("x")}}
+	if info, err := fs.Stat(tree, "dir"); err != nil || hasFileIdentity(info) {
+		t.Fatalf("fstest.MapFS should carry no file identity: (%v, %v)", info, err)
+	}
+
+	w := &globWalkFS{FS: tree, ctx: t.Context(), listed: map[string]fs.FileInfo{}}
+	if _, err := w.ReadDir("dir"); err != nil {
+		t.Fatalf("first listing: %v", err)
+	}
+	w.unidentified = maxUnidentifiedGlobDirs
+	_, err := w.ReadDir("dir")
+	if err == nil {
+		t.Fatal("listing past the bound succeeded, want a refusal")
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("listing past the bound reported %v, which the walk skips silently; it must fail the glob", err)
+	}
+}
+
+// TestGlobWalkFSKnowsWhenIdentityIsAvailable pins the discrimination the
+// backstop turns on: an os-backed filesystem carries file identity and is
+// bounded by the cycle check, so it must never be counted against the bound.
+func TestGlobWalkFSKnowsWhenIdentityIsAvailable(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	w := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), listed: map[string]fs.FileInfo{}}
+	if _, err := w.ReadDir("sub"); err != nil {
+		t.Fatalf("listing an os-backed directory: %v", err)
+	}
+	if w.unidentified != 0 {
+		t.Fatalf("os-backed listing counted %d unidentified directories, want 0", w.unidentified)
+	}
+}
+
+// TestSortPathsByMtimeDescStatsEachPathOnce guards the post-walk phase against
+// the shape it had before: two Stat calls inside the sort comparator, so an
+// n-path result cost O(n log n) stats and a large one spent seconds in an
+// uninterruptible sort. Decorating once means exactly one stat per path.
+func TestSortPathsByMtimeDescStatsEachPathOnce(t *testing.T) {
+	paths := mtimeFixture(t, 8)
+
+	counts := map[string]int{}
+	stubSortPathStat(t, func(p string) { counts[p]++ })
+
+	if err := sortPathsByMtimeDesc(t.Context(), paths); err != nil {
+		t.Fatalf("sortPathsByMtimeDesc: %v", err)
+	}
+	if len(counts) != len(paths) {
+		t.Fatalf("stat'ed %d distinct paths, want %d", len(counts), len(paths))
+	}
+	for p, n := range counts {
+		if n != 1 {
+			t.Errorf("stat(%s) called %d times, want 1", p, n)
+		}
+	}
+}
+
+// TestSortPathsByMtimeDescOrdersNewestFirst pins the ordering contract the
+// decorate-sort-undecorate rewrite has to preserve.
+func TestSortPathsByMtimeDescOrdersNewestFirst(t *testing.T) {
+	paths := mtimeFixture(t, 4)
+	// Age them in reverse: paths[0] oldest ... paths[3] newest.
+	base := time.Now().Add(-time.Hour)
+	for i, p := range paths {
+		when := base.Add(time.Duration(i) * time.Minute)
+		if err := os.Chtimes(p, when, when); err != nil {
+			t.Fatal(err)
+		}
+	}
+	shuffled := []string{paths[1], paths[3], paths[0], paths[2]}
+	if err := sortPathsByMtimeDesc(t.Context(), shuffled); err != nil {
+		t.Fatalf("sortPathsByMtimeDesc: %v", err)
+	}
+	want := []string{paths[3], paths[2], paths[1], paths[0]}
+	if !reflect.DeepEqual(shuffled, want) {
+		t.Fatalf("sortPathsByMtimeDesc = %v, want newest first %v", shuffled, want)
+	}
+}
+
+// stubSortPathStat interposes on the stat seam sortPathsByMtimeDesc uses,
+// reporting every path it stats to observe before delegating to the real stat,
+// and restores the seam when the test ends.
+func stubSortPathStat(t *testing.T, observe func(path string)) {
+	t.Helper()
+	orig := sortPathStat
+	sortPathStat = func(p string) (os.FileInfo, error) {
+		observe(p)
+		return orig(p)
+	}
+	t.Cleanup(func() { sortPathStat = orig })
+}
+
+// mtimeFixture creates n files and returns their absolute paths.
+func mtimeFixture(t *testing.T, n int) []string {
+	t.Helper()
+	dir := t.TempDir()
+	paths := make([]string, 0, n)
+	for i := range n {
+		p := filepath.Join(dir, string(rune('a'+i))+".txt")
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		paths = append(paths, p)
+	}
+	return paths
+}

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -1273,12 +1273,21 @@ func (e *LocalExecutionEnvironment) ListDirectory(path string, depth int) ([]Dir
 // plus new .gitignore awareness; pass includeIgnored(true) to restore them.
 //
 // The walk is bounded by ctx: cancelling it aborts an in-flight glob and
-// returns ctx's error. Directory symlinks are never traversed, so a `**`
-// pattern over a tree that links back into itself still terminates.
+// returns ctx's error. It is also bounded by cycle detection — it will not
+// list a directory that is the same file as one of its own ancestors — so a
+// `**` pattern over a tree that links back into itself still terminates while
+// a directory symlink that points elsewhere is followed and matched normally.
+// (The sandboxed walk is stricter: it never follows a symlink at all, which is
+// a policy boundary rather than a termination measure.)
 func (e *LocalExecutionEnvironment) Glob(ctx context.Context, pattern string, basePath string, includeIgnored ...bool) ([]string, error) {
 	matches, _, err := e.GlobWithExclusions(ctx, pattern, basePath, len(includeIgnored) > 0 && includeIgnored[0])
 	return matches, err
 }
+
+// globBaseFS opens the filesystem the off-sandbox glob walks, rooted at the
+// resolved base directory; a variable so tests can drive the exported entry
+// point over a filesystem they control.
+var globBaseFS = os.DirFS
 
 // GlobWithExclusions implements GlobExcluder: same matching as Glob, but also
 // reports how many candidate matches the default dotfile/gitignore exclusion
@@ -1304,7 +1313,7 @@ func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, patt
 		// traversal (no out-of-root match) and drops masked matches.
 		return sfs.glob(ctx, "glob", base, pattern, includeIgnored)
 	}
-	fsys := cancelFS{ctx: ctx, fsys: os.DirFS(base)}
+	fsys := cancelFS{ctx: ctx, fsys: globBaseFS(base)}
 	var ignores *ignoreSet
 	if !includeIgnored {
 		// No masking concept off the sandboxed path: no-op skip.
@@ -1319,9 +1328,15 @@ func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, patt
 			return nil, 0, err
 		}
 		for _, m := range matches {
-			if !includeIgnored && (isDotPath(m) || ignores.matches(m, globMatchIsDir(fsys, m))) {
-				excluded++
-				continue
+			if !includeIgnored {
+				drop, err := globMatchExcluded(ctx, fsys, ignores, m)
+				if err != nil {
+					return nil, 0, err
+				}
+				if drop {
+					excluded++
+					continue
+				}
 			}
 			path := filepath.Join(base, m)
 			if _, ok := seen[path]; ok {
@@ -1331,7 +1346,9 @@ func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, patt
 			abs = append(abs, path)
 		}
 	}
-	sortPathsByMtimeDesc(abs)
+	if err := sortPathsByMtimeDesc(ctx, abs); err != nil {
+		return nil, 0, err
+	}
 	return abs, excluded, nil
 }
 

--- a/agent/execenv/search_patterns.go
+++ b/agent/execenv/search_patterns.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -50,21 +52,137 @@ func (c cancelFS) Stat(name string) (fs.FileInfo, error) {
 	return fs.Stat(c.fsys, name)
 }
 
-// globMatches runs one expanded glob pattern against fsys, which must already
-// observe ctx (see cancelFS).
+// maxUnidentifiedGlobDirs bounds a walk over a filesystem whose directories
+// carry no file identity, where globWalkFS's cycle check cannot work. The
+// bound counts directories listed rather than capping depth because a symlink
+// cycle costs unbounded *work*, not merely unbounded depth: one
+// /proc/<pid>/root hop re-enters the entire tree, so a shallow depth cap would
+// still admit a combinatorial re-walk while a deep one would truncate real
+// results. os-backed filesystems never reach this — the cycle check bounds
+// them — so exceeding it means the walk has lost its footing, and it is
+// reported as an error rather than as a short list.
+const maxUnidentifiedGlobDirs = 100_000
+
+// globWalkFS is the view of the filesystem a single doublestar walk runs over.
+// It supplies the two properties doublestar itself cannot:
 //
-// WithNoFollow keeps `**` traversal from descending through directory
-// symlinks. Symlinks still match; they are just never walked into, because a
-// directory symlink can re-enter the tree it lives in — /proc/<pid>/root
-// points back at / — and a `**` walk that follows one has no reason to stop.
-// The sandboxed walk already refuses symlink traversal outright, so this also
-// brings the two paths into agreement.
+// Termination. It refuses to list a directory that is the same file as one of
+// its own ancestors on this walk. That is the shape /proc/<pid>/root has —
+// following the link re-enters the tree it lives in — and it is why a `**`
+// glob rooted at / never returned (#369). Everything under such a directory is
+// already reachable at a shorter path, so refusing costs no matches. A
+// directory symlink pointing anywhere other than at its own ancestors
+// (node_modules/lib -> ../packages/lib, or /etc -> /private/etc on macOS) is
+// walked normally and its files match under both names.
+//
+// Abort. doublestar propagates a filesystem error only under
+// WithFailOnIOErrors; without it a cancelled walk keeps grinding through every
+// sibling its parent frames already listed. So the walk runs with that option
+// and this wrapper reports every failure other than the cancellation as
+// fs.ErrNotExist — the "this entry simply isn't there" answer doublestar
+// already skips over — which leaves cancellation as the only error that can
+// end a walk. An unreadable directory still does not fail the glob.
+type globWalkFS struct {
+	fs.FS
+	ctx context.Context
+	// listed holds the identity of every directory already listed, keyed by
+	// the path it was listed under, so the ancestor check costs a map lookup
+	// per level instead of a stat per level.
+	listed map[string]fs.FileInfo
+	// unidentified counts listed directories whose FileInfo carries no file
+	// identity — the only case maxUnidentifiedGlobDirs bounds.
+	unidentified int
+}
+
+func (w *globWalkFS) Stat(name string) (fs.FileInfo, error) {
+	info, err := fs.Stat(w.FS, name)
+	if err != nil {
+		return nil, w.hide("stat", name)
+	}
+	return info, nil
+}
+
+func (w *globWalkFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if err := w.admit(name); err != nil {
+		return nil, err
+	}
+	entries, err := fs.ReadDir(w.FS, name)
+	if err != nil {
+		return nil, w.hide("readdir", name)
+	}
+	return entries, nil
+}
+
+// admit reports whether the walk may list name, recording its identity so the
+// directories below it can be checked against it.
+func (w *globWalkFS) admit(name string) error {
+	info, err := fs.Stat(w.FS, name)
+	if err != nil {
+		return w.hide("stat", name)
+	}
+	if !hasFileIdentity(info) {
+		w.unidentified++
+		if w.unidentified > maxUnidentifiedGlobDirs {
+			return fmt.Errorf("glob walk made %d directory listings on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking", w.unidentified)
+		}
+		return nil
+	}
+	// The walk root is skipped: it has no ancestors to cycle back to, and
+	// path.Dir(".") is "." — scanning from there would find the root's own
+	// entry and refuse the second listing doublestar makes of every directory.
+	if name != "." {
+		for dir := path.Dir(name); ; dir = path.Dir(dir) {
+			if ancestor, ok := w.listed[dir]; ok && os.SameFile(ancestor, info) {
+				return w.hide("readdir", name)
+			}
+			if dir == "." {
+				break
+			}
+		}
+	}
+	w.listed[name] = info
+	return nil
+}
+
+// hide answers with the walk's cancellation when there is one — the walk runs
+// under WithFailOnIOErrors so that ends it immediately — and otherwise with
+// "not there", which doublestar skips past. See the type comment.
+func (w *globWalkFS) hide(op, name string) error {
+	if cerr := w.ctx.Err(); cerr != nil {
+		return cerr
+	}
+	return &fs.PathError{Op: op, Path: name, Err: fs.ErrNotExist}
+}
+
+// hasFileIdentity reports whether info carries the (device, inode) identity
+// os.SameFile compares. os.SameFile answers false for any FileInfo that did
+// not come from the os package — an fstest.MapFS entry, say — so comparing an
+// info against itself is how to tell "a different file" from "cannot tell".
+func hasFileIdentity(info fs.FileInfo) bool {
+	return os.SameFile(info, info)
+}
+
+// globMatches runs one expanded glob pattern against fsys, which must already
+// observe ctx (see cancelFS), through a fresh globWalkFS — fresh per pattern,
+// because the directories one pattern listed say nothing about whether another
+// pattern's walk is re-entering itself.
+//
+// GlobWalk rather than Glob: it ends the walk the moment the callback returns
+// an error, so a cancellation that lands between two filesystem calls stops
+// the walk at the next match instead of being noticed only after the tree runs
+// out.
 func globMatches(ctx context.Context, fsys fs.FS, pattern string) ([]string, error) {
-	matches, err := doublestar.Glob(fsys, pattern, doublestar.WithNoFollow())
-	// doublestar reports I/O errors only under WithFailOnIOErrors, which we
-	// don't want (an unreadable directory shouldn't fail the whole glob). So a
-	// cancelled walk surfaces here as a truncated result with a nil error;
-	// answer with the cancellation instead of a plausible-looking short list.
+	walk := &globWalkFS{FS: fsys, ctx: ctx, listed: map[string]fs.FileInfo{}}
+	var matches []string
+	err := doublestar.GlobWalk(walk, pattern, func(p string, _ fs.DirEntry) error {
+		if cerr := ctx.Err(); cerr != nil {
+			return cerr
+		}
+		matches = append(matches, p)
+		return nil
+	}, doublestar.WithFailOnIOErrors())
+	// A cancelled walk must not come back as a plausible-looking short list,
+	// so answer with the cancellation however the walk happened to unwind.
 	if cerr := ctx.Err(); cerr != nil {
 		return nil, cerr
 	}

--- a/agent/execenv/securepath_browse.go
+++ b/agent/execenv/securepath_browse.go
@@ -1,6 +1,7 @@
 package execenv
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -8,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // This file holds the platform-independent browse logic (the writability
@@ -169,18 +171,48 @@ func (a *grepAccum) finish() string {
 	return strings.Join(a.results, "\n")
 }
 
-// sortPathsByMtimeDesc sorts paths newest-modification-first, ties broken by path.
-// Shared by the off and sandboxed glob so their ordering is identical.
-func sortPathsByMtimeDesc(paths []string) {
-	sort.SliceStable(paths, func(i, j int) bool {
-		fi, _ := os.Stat(paths[i])
-		fj, _ := os.Stat(paths[j])
-		if fi == nil || fj == nil {
-			return paths[i] < paths[j]
+// sortPathStat is the stat the glob result ordering runs on; a variable so
+// tests can observe how many times each path is stat'ed.
+var sortPathStat = os.Stat
+
+// sortPathsByMtimeDesc sorts paths newest-modification-first, ties broken by
+// path. Shared by the off and sandboxed glob so their ordering is identical.
+//
+// Every path is stat'ed once up front rather than from inside the comparator,
+// which stat'ed O(n log n) times and left a large result set sorting for
+// seconds with nothing watching ctx. The stat loop checks ctx between paths,
+// so a cancelled glob stops here too and says so instead of handing back a
+// half-ordered list.
+func sortPathsByMtimeDesc(ctx context.Context, paths []string) error {
+	type dated struct {
+		path     string
+		mod      time.Time
+		modKnown bool
+	}
+	entries := make([]dated, len(paths))
+	for i, p := range paths {
+		if err := ctx.Err(); err != nil {
+			return err
 		}
-		if fi.ModTime() != fj.ModTime() {
-			return fi.ModTime().After(fj.ModTime())
+		entries[i] = dated{path: p}
+		if info, err := sortPathStat(p); err == nil {
+			entries[i].mod, entries[i].modKnown = info.ModTime(), true
 		}
-		return paths[i] < paths[j]
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		a, b := entries[i], entries[j]
+		// A path whose stat failed has no modification time to order by, so
+		// it falls back to path order — as it did when the comparator stat'ed.
+		if !a.modKnown || !b.modKnown {
+			return a.path < b.path
+		}
+		if !a.mod.Equal(b.mod) {
+			return a.mod.After(b.mod)
+		}
+		return a.path < b.path
 	})
+	for i, e := range entries {
+		paths[i] = e.path
+	}
+	return nil
 }

--- a/agent/execenv/securepath_browse_fdops_unix.go
+++ b/agent/execenv/securepath_browse_fdops_unix.go
@@ -121,9 +121,15 @@ func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includ
 			return nil, 0, err
 		}
 		for _, m := range matches {
-			if !includeIgnored && (isDotPath(m) || ignores.matches(m, globMatchIsDir(fsys, m))) {
-				excluded++
-				continue
+			if !includeIgnored {
+				drop, err := globMatchExcluded(ctx, fsys, ignores, m)
+				if err != nil {
+					return nil, 0, err
+				}
+				if drop {
+					excluded++
+					continue
+				}
 			}
 			p := filepath.Join(canonical, m)
 			if s.underMasked(p) {
@@ -136,7 +142,9 @@ func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includ
 			abs = append(abs, p)
 		}
 	}
-	sortPathsByMtimeDesc(abs)
+	if err := sortPathsByMtimeDesc(ctx, abs); err != nil {
+		return nil, 0, err
+	}
 	return abs, excluded, nil
 }
 

--- a/agent/execenv/securepath_edge_program_fuzz_test.go
+++ b/agent/execenv/securepath_edge_program_fuzz_test.go
@@ -424,7 +424,9 @@ func runSecurePathEdgeContractProgram(t *testing.T, program []byte) securePathEd
 
 	// The sort fallback must be deterministic even when stat fails for every path.
 	missing := []string{filepath.Join(base, "missing-b"), filepath.Join(base, "missing-a")}
-	sortPathsByMtimeDesc(missing)
+	if err := sortPathsByMtimeDesc(t.Context(), missing); err != nil {
+		t.Fatalf("missing-path sort: %v", err)
+	}
 	if !sort.StringsAreSorted(missing) {
 		t.Fatalf("missing-path sort = %v, want lexical order", missing)
 	}


### PR DESCRIPTION
Follow-ups to merged #377, from the reconciled finding list in #381. All five items, each with the measurement that motivated it.

## 1. WithNoFollow → (dev,ino) cycle detection (HIGH)

`WithNoFollow()` bought termination by refusing *every* directory symlink for *every* wildcard segment. Measured on a `node_modules/lib -> ../packages/lib` fixture, watched failing before the fix:

| pattern | before | after |
|---|---|---|
| `**/*.ts` | 2 of 4 | 4 |
| `node_modules/*/*.ts` | 0 | 2 |
| `*/hosts` rooted at `/` (macOS, `/etc -> private/etc`) | `[]` | `[/etc/hosts]` |

None of it was counted — the `excluded` counter never incremented for a symlink-skipped subtree, so the answer came back short and silent, eight lines below the comment promising it would not.

The walk now runs over a `globWalkFS` that refuses to list a directory that is the same file as one of its own **ancestors on that walk**. That is the loop shape exactly (`/proc/<pid>/root` points back at `/`), and everything under such a directory is already reachable at a shorter path, so refusing costs no matches and needs no counter. A link pointing sideways is walked normally.

Identity comes from `os.SameFile`, which works on both arms — `os.DirFS` and the sandboxed `secureDirFS` both return `*os.fileStat` — and is portable, unlike a `syscall.Stat_t` assertion. `hasFileIdentity` detects the no-identity case by comparing an info against itself, which `os.SameFile` answers false for anything not from the `os` package.

**Backstop, and why a count rather than a depth cap.** Where identity is unavailable, cycle detection cannot work, so the walk is bounded by directory listings made (100k). A cycle costs unbounded *work*, not merely unbounded depth: one `/proc/<pid>/root` hop re-enters the whole tree, so a shallow depth cap would still admit a combinatorial re-walk while a deep one would truncate real results. Exceeding the bound is an error, not a truncated list.

Measured, 200 pid-shaped directories each linking back to the root:
- cycle detection: 1 match, 8ms
- unprotected `doublestar.Glob`: still running at a 10s deadline, 616 duplicate matches so far

## 2. The false comments (`local.go:1276`, `search_patterns.go:57`)

Both claimed directory symlinks are never traversed and that this brought the two walks into agreement. Rewritten to describe cycle detection, and to say plainly that the sandboxed walk is stricter because refusing symlinks there is a policy boundary, not a termination measure. #381's item 2 (literal prefix followed, wildcard segment not) is now moot: `TestGlobLiteralAndWildcardSegmentsAgreeThroughASymlink` asserts the two spellings return the same set.

## 3. True abort, and a promptness test that can fail

The old assertion was unreachable: the `ReadDir` counter sat *inside* `cancelFS`, which short-circuits before delegating, so `counter.calls` pinned at `n` and `> 6` could never trip. The counter now sits outside the ctx wrapper, and the bound is measured against a completed walk over the same tree rather than a hand-picked constant.

Switched `doublestar.Glob` → `GlobWalk` with a ctx check in the callback. Option parity verified first: `Glob` already delegates to `doGlobWalk` for any mid-`**` pattern, both accept the same `GlobOption` set, and both sort-and-dedup alts.

The callback check alone is not a true abort, though — for `**/needle.txt` the user callback only fires on matches, so a cancelled walk still grinds. The abort comes from running the walk under `WithFailOnIOErrors` and having `globWalkFS` report every failure *other than* the cancellation as `fs.ErrNotExist` — the "not there" answer doublestar already skips past. That leaves cancellation as the only error that can end a walk. `TestGlobMatchesSurvivesAnUnreadableDirectory` pins the property this trades on: a 0000 directory is still skipped, not fatal.

Measured, cancelling mid-walk on a 20k-entry directory:
- before: **40,004** post-cancellation `ReadDir` calls
- after: **5** — it stops at the cancelled call

On the smaller fixture the existing test uses: 18 → 3, against 66 for a completed walk.

## 4. Cancellable, non-conflating post-walk phase

`sortPathsByMtimeDesc` did 2×`Stat` inside the sort comparator. Now decorate-sort-undecorate: measured **56 stats → 8** for 8 paths, with a ctx check between stats so a large result set can be abandoned. The comparator's fallback for a failed stat (order by path) is preserved exactly.

`globMatchIsDir` read a cancelled stat as "not a directory", which silently disabled every directory-only gitignore rule and returned a plausible list with a nil error — the failure mode the walk itself no longer has, six lines up. It now propagates the ctx error. The shared `globMatchExcluded` helper keeps the off and sandboxed arms identical rather than duplicating the check.

## 5. Coverage

- `TestGlobWithExclusionsStopsMidWalk` — mid-walk cancellation through the exported entry point, via a new `globBaseFS` seam (same pattern as the existing `secureBrowseWalkDir` / `secureBrowseReadFile` seams). Promptness is deliberately *not* asserted there and the test says why: a counter reachable only from inside `GlobWithExclusions`' own ctx wrapper cannot see post-cancellation calls. That measurement stays where the test owns the layering.
- `TestSandboxedGlobReportsCancellation` — the sandboxed arm had zero cancellation coverage. Includes a positive control so a cancelled empty result cannot be mistaken for "nothing was there".
- `TestGlobWithExclusionsReportsCancellation` no longer builds a symlink fixture it never needed, so it no longer inherits the symlink skip.
- New: `globMatchIsDir` cancellation, sort cancellation and stat-count, the identity-bound backstop, and identity detection on an os-backed FS.

## Gates

Run against the go.work-pinned Go 1.25.6 toolchain: `make build-go`, `make vet`, `make lint`, `make lint-evenerfuzz`, `make lint-fuzz-registry`, `make fuzz-seeds`, `WEB=0 make test`, `go test -race ./agent/execenv/...`, `go test -race ./agent/...` — all green, no flakes hit.

Glob throughput over this repo (2597 matches, `**/*.go`) is unchanged at ~33ms despite the extra stat per listing.

## Scope

Grep / `search_files` (#379) is deliberately untouched — separate PR.

Fixes #381
Refs #369 #377

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT
