### PR TITLE
fix: distinguish signal-killed shell jobs

### DIFF
--- a/agent/execenv/command_runtime.go
+++ b/agent/execenv/command_runtime.go
@@ -68,6 +68,7 @@ type systemCommandRuntime struct {
 	outputReader     *os.File
 	outputDone       chan error
 	terminationGrace time.Duration
+	signalName       string
 }
 
 type commandOutputWriteError struct {
@@ -147,6 +148,7 @@ func (c *systemCommandRuntime) Start() error {
 
 func (c *systemCommandRuntime) Wait() error {
 	processErr := c.cmd.Wait()
+	c.signalName = processSignalName(c.cmd.ProcessState)
 	if c.outputDone == nil {
 		return processErr
 	}
@@ -270,6 +272,19 @@ func (c *systemCommandRuntime) ExitCode(err error) (int, bool) {
 		return processExitCode(exitErr), true
 	}
 	return 0, false
+}
+
+// SignalName reports the signal recorded in the child's wait status. It is an
+// optional command-runtime capability so scripted and non-local runtimes keep
+// the existing commandRuntime contract. Wait must have returned first.
+func (c *systemCommandRuntime) SignalName() string { return c.signalName }
+
+func cmdSignalName(cmd commandRuntime) string {
+	reporter, ok := cmd.(interface{ SignalName() string })
+	if !ok {
+		return ""
+	}
+	return reporter.SignalName()
 }
 
 func (c *systemCommandRuntime) Terminate() { terminateProcessGroup(c.PID()) }

--- a/agent/execenv/execenv.go
+++ b/agent/execenv/execenv.go
@@ -108,10 +108,14 @@ type FileMutator interface {
 
 // StreamHandle is a running streamed process. Wait blocks until exit and returns
 // the exit code; Signal terminates the process group (SIGTERM then SIGKILL).
+// SignalName reports the signal that terminated the process, when the platform
+// exposes it; it must be called after Wait returns and may be nil for non-system
+// implementations.
 type StreamHandle struct {
-	Pid    int
-	Wait   func() (exitCode int, err error)
-	Signal func()
+	Pid        int
+	Wait       func() (exitCode int, err error)
+	Signal     func()
+	SignalName func() string
 }
 
 // ExecutionEnvironment abstracts the filesystem and command runner used by tools.

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -1774,9 +1774,10 @@ func (e *LocalExecutionEnvironment) StreamCommand(ctx context.Context, command, 
 	}
 
 	return &StreamHandle{
-		Pid:    pid,
-		Wait:   wait,
-		Signal: signal,
+		Pid:        pid,
+		Wait:       wait,
+		Signal:     signal,
+		SignalName: func() string { return cmdSignalName(cmd) },
 	}, nil
 }
 

--- a/agent/execenv/process_signal_other.go
+++ b/agent/execenv/process_signal_other.go
@@ -1,0 +1,10 @@
+//go:build !linux && !darwin
+
+package execenv
+
+import "os"
+
+// Non-Unix platforms do not expose a portable wait-status signal name through
+// os.ProcessState. The shell outcome still reports a negative exit code as a
+// signal termination; the platform-specific name is omitted when unavailable.
+func processSignalName(*os.ProcessState) string { return "" }

--- a/agent/execenv/process_signal_unix.go
+++ b/agent/execenv/process_signal_unix.go
@@ -1,0 +1,58 @@
+//go:build linux || darwin
+
+package execenv
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func processSignalName(state *os.ProcessState) string {
+	if state == nil {
+		return ""
+	}
+	ws, ok := state.Sys().(syscall.WaitStatus)
+	if !ok || !ws.Signaled() {
+		return ""
+	}
+	return signalName(ws.Signal())
+}
+
+func signalName(signal syscall.Signal) string {
+	known := map[syscall.Signal]string{
+		syscall.SIGHUP:    "SIGHUP",
+		syscall.SIGINT:    "SIGINT",
+		syscall.SIGQUIT:   "SIGQUIT",
+		syscall.SIGILL:    "SIGILL",
+		syscall.SIGTRAP:   "SIGTRAP",
+		syscall.SIGABRT:   "SIGABRT",
+		syscall.SIGFPE:    "SIGFPE",
+		syscall.SIGKILL:   "SIGKILL",
+		syscall.SIGBUS:    "SIGBUS",
+		syscall.SIGSEGV:   "SIGSEGV",
+		syscall.SIGSYS:    "SIGSYS",
+		syscall.SIGPIPE:   "SIGPIPE",
+		syscall.SIGALRM:   "SIGALRM",
+		syscall.SIGTERM:   "SIGTERM",
+		syscall.SIGURG:    "SIGURG",
+		syscall.SIGSTOP:   "SIGSTOP",
+		syscall.SIGTSTP:   "SIGTSTP",
+		syscall.SIGCONT:   "SIGCONT",
+		syscall.SIGCHLD:   "SIGCHLD",
+		syscall.SIGTTIN:   "SIGTTIN",
+		syscall.SIGTTOU:   "SIGTTOU",
+		syscall.SIGIO:     "SIGIO",
+		syscall.SIGXCPU:   "SIGXCPU",
+		syscall.SIGXFSZ:   "SIGXFSZ",
+		syscall.SIGVTALRM: "SIGVTALRM",
+		syscall.SIGPROF:   "SIGPROF",
+		syscall.SIGWINCH:  "SIGWINCH",
+		syscall.SIGUSR1:   "SIGUSR1",
+		syscall.SIGUSR2:   "SIGUSR2",
+	}
+	if name, ok := known[signal]; ok {
+		return name
+	}
+	return fmt.Sprintf("SIG%d", signal)
+}

--- a/agent/fuzz_fc2_shellterminal_test.go
+++ b/agent/fuzz_fc2_shellterminal_test.go
@@ -9,7 +9,7 @@ import (
 	"primeradiant.com/evener/agent/internal/jobstore"
 )
 
-// FuzzFc2ShellTerminalDecision drives shellTerminalDecision — the pure
+// FuzzFc2ShellTerminalDecision drives shellTerminalDecisionWithSignal — the pure
 // terminal-classification core lifted out of jobManager.shellTerminal — over the
 // full cross-product of stop request, runtime timeout, wait error, and exit code.
 // It is the non-timing decision arm of runShell: the wrapper only adds the jm.mu
@@ -39,9 +39,9 @@ func FuzzFc2ShellTerminalDecision(f *testing.F) {
 			waitErr = errors.New("wait failed")
 		}
 
-		status, reason := shellTerminalDecision(stopStatus, stopReason, exitCode, timedOut, waitErr)
+		status, reason := shellTerminalDecisionWithSignal(stopStatus, stopReason, exitCode, "", timedOut, waitErr)
 
-		status2, reason2 := shellTerminalDecision(stopStatus, stopReason, exitCode, timedOut, waitErr)
+		status2, reason2 := shellTerminalDecisionWithSignal(stopStatus, stopReason, exitCode, "", timedOut, waitErr)
 		if status != status2 || reason != reason2 {
 			t.Fatalf("non-deterministic: (%q,%q) vs (%q,%q)", status, reason, status2, reason2)
 		}

--- a/agent/fuzz_fc2_shellterminal_test.go
+++ b/agent/fuzz_fc2_shellterminal_test.go
@@ -63,6 +63,8 @@ func FuzzFc2ShellTerminalDecision(f *testing.F) {
 			wantStatus, wantReason = jobstore.StatusFailed, "wait_failed"
 		case exitCode == 0:
 			wantStatus, wantReason = jobstore.StatusCompleted, "exit_zero"
+		case exitCode < 0:
+			wantStatus, wantReason = jobstore.StatusFailed, "killed_by_signal"
 		default:
 			wantStatus, wantReason = jobstore.StatusFailed, "exit_nonzero"
 		}

--- a/agent/job_shell.go
+++ b/agent/job_shell.go
@@ -726,17 +726,6 @@ func (jm *jobManager) shellTerminalWithSignal(run *runningJob, exitCode int, sig
 	return status, reason, &code
 }
 
-// shellTerminalDecision is the pure terminal-classification core of shellTerminal:
-// given a shell run's stop request (if any) and its process outcome, it maps to the
-// terminal status and reason. Precedence: an explicit stop wins over everything,
-// then a runtime timeout, then a wait error, then the exit code (zero = completed,
-// negative = signal-killed, other non-zero = failed). It takes only value snapshots
-// (the caller reads run.stopStatus under jm.mu; the exit-code passthrough stays in
-// the wrapper), so the classification is fuzzable in isolation.
-func shellTerminalDecision(stopStatus jobstore.Status, stopReason string, exitCode int, timedOut bool, waitErr error) (jobstore.Status, string) {
-	return shellTerminalDecisionWithSignal(stopStatus, stopReason, exitCode, "", timedOut, waitErr)
-}
-
 func shellTerminalDecisionWithSignal(stopStatus jobstore.Status, stopReason string, exitCode int, signalName string, timedOut bool, waitErr error) (jobstore.Status, string) {
 	if stopStatus != "" {
 		return stopStatus, stopReason

--- a/agent/job_shell.go
+++ b/agent/job_shell.go
@@ -82,8 +82,9 @@ type shellResult struct {
 }
 
 type shellWaitResult struct {
-	exitCode int
-	err      error
+	exitCode   int
+	signalName string
+	err        error
 }
 
 type stableDelegateShellReceipt struct {
@@ -191,8 +192,12 @@ func runShell(ctx context.Context, jm *jobManager, se execenv.StreamingExecutor,
 
 	go func() {
 		code, err := handle.Wait()
+		signalName := ""
+		if handle.SignalName != nil {
+			signalName = handle.SignalName()
+		}
 		close(processDone)
-		waitCh <- shellWaitResult{exitCode: code, err: err}
+		waitCh <- shellWaitResult{exitCode: code, signalName: signalName, err: err}
 	}()
 
 	if args.MaxRuntimeMS > 0 {
@@ -244,7 +249,7 @@ func runShell(ctx context.Context, jm *jobManager, se execenv.StreamingExecutor,
 		if runtimeTimedOut.Load() {
 			return jm.finishForegroundRuntimeTimeout(run, wait)
 		}
-		status, reason, exitCode := jm.shellTerminal(run, wait.exitCode, runtimeTimedOut.Load(), wait.err)
+		status, reason, exitCode := jm.shellTerminalWithSignal(run, wait.exitCode, wait.signalName, runtimeTimedOut.Load(), wait.err)
 		output, total, truncated, _ := fullOutput(run.output)
 		// complete-or-handle (spec §0.6): defer keep/discard so marshalShellToolResult
 		// can apply both layers (embed budget + tool-result char bound) before deciding.
@@ -437,7 +442,7 @@ func (c *startOnlyContext) detachStart() {
 }
 
 func (jm *jobManager) finishForegroundRuntimeTimeout(run *runningJob, wait shellWaitResult) shellResult {
-	status, reason, exitCode := jm.shellTerminal(run, wait.exitCode, true, wait.err)
+	status, reason, exitCode := jm.shellTerminalWithSignal(run, wait.exitCode, wait.signalName, true, wait.err)
 	if err := jm.commitDelayedShell(run); err != nil {
 		if errors.Is(err, errDelayedShellStartForwardTerminalFailed) {
 			go jm.finalizeShellUntilDurable(run.rec.JobID, jobstore.StatusFailed, "forward_failed", nil)
@@ -657,7 +662,7 @@ func (jm *jobManager) discardDelayedShell(run *runningJob) {
 
 func (jm *jobManager) finalizeShellWhenDone(run *runningJob, waitCh <-chan shellWaitResult, runtimeTimedOut *atomic.Bool) {
 	wait := <-waitCh
-	status, reason, exitCode := jm.shellTerminal(run, wait.exitCode, runtimeTimedOut.Load(), wait.err)
+	status, reason, exitCode := jm.shellTerminalWithSignal(run, wait.exitCode, wait.signalName, runtimeTimedOut.Load(), wait.err)
 	jm.finalizeShellUntilDurable(run.rec.JobID, status, reason, exitCode)
 }
 
@@ -709,11 +714,15 @@ func shellFinalizeBackoff(attempt int) time.Duration {
 }
 
 func (jm *jobManager) shellTerminal(run *runningJob, exitCode int, timedOut bool, waitErr error) (jobstore.Status, string, *int) {
+	return jm.shellTerminalWithSignal(run, exitCode, "", timedOut, waitErr)
+}
+
+func (jm *jobManager) shellTerminalWithSignal(run *runningJob, exitCode int, signalName string, timedOut bool, waitErr error) (jobstore.Status, string, *int) {
 	code := exitCode
 	jm.mu.Lock()
 	stopStatus, stopReason := run.stopStatus, run.stopReason
 	jm.mu.Unlock()
-	status, reason := shellTerminalDecision(stopStatus, stopReason, exitCode, timedOut, waitErr)
+	status, reason := shellTerminalDecisionWithSignal(stopStatus, stopReason, exitCode, signalName, timedOut, waitErr)
 	return status, reason, &code
 }
 
@@ -721,10 +730,14 @@ func (jm *jobManager) shellTerminal(run *runningJob, exitCode int, timedOut bool
 // given a shell run's stop request (if any) and its process outcome, it maps to the
 // terminal status and reason. Precedence: an explicit stop wins over everything,
 // then a runtime timeout, then a wait error, then the exit code (zero = completed,
-// non-zero = failed). It takes only value snapshots (the caller reads run.stopStatus
-// under jm.mu; the exit-code passthrough stays in the wrapper), so the classification
-// is fuzzable in isolation.
+// negative = signal-killed, other non-zero = failed). It takes only value snapshots
+// (the caller reads run.stopStatus under jm.mu; the exit-code passthrough stays in
+// the wrapper), so the classification is fuzzable in isolation.
 func shellTerminalDecision(stopStatus jobstore.Status, stopReason string, exitCode int, timedOut bool, waitErr error) (jobstore.Status, string) {
+	return shellTerminalDecisionWithSignal(stopStatus, stopReason, exitCode, "", timedOut, waitErr)
+}
+
+func shellTerminalDecisionWithSignal(stopStatus jobstore.Status, stopReason string, exitCode int, signalName string, timedOut bool, waitErr error) (jobstore.Status, string) {
 	if stopStatus != "" {
 		return stopStatus, stopReason
 	}
@@ -736,6 +749,12 @@ func shellTerminalDecision(stopStatus jobstore.Status, stopReason string, exitCo
 	}
 	if exitCode == 0 {
 		return jobstore.StatusCompleted, "exit_zero"
+	}
+	if exitCode < 0 {
+		if signalName == "" {
+			return jobstore.StatusFailed, "killed_by_signal"
+		}
+		return jobstore.StatusFailed, "killed_by_signal: " + signalName
 	}
 	return jobstore.StatusFailed, "exit_nonzero"
 }

--- a/agent/job_shell_fuzz_test.go
+++ b/agent/job_shell_fuzz_test.go
@@ -157,7 +157,8 @@ var errFuzzShellWait = shfzShellError("wait failed")
 //     fake output, TotalBytes is its length, and (because output stays below the
 //     retention cap) it is not truncated and drops nothing;
 //   - exit-code contract: Wait error -> failed/wait_failed; else exit 0 ->
-//     completed/exit_zero; else failed/exit_nonzero; ExitCode echoes the fake;
+//     completed/exit_zero; else a negative exit -> failed/killed_by_signal and
+//     other non-zero exits -> failed/exit_nonzero; ExitCode echoes the fake;
 //   - deterministic: replaying the same inputs on a fresh manager yields an
 //     identical result summary.
 //
@@ -217,6 +218,8 @@ func shfz_wantForegroundStatus(in shfz_foregroundInputs) (status, reason string)
 		return string(jobstore.StatusFailed), "wait_failed"
 	case in.exitCode == 0:
 		return string(jobstore.StatusCompleted), "exit_zero"
+	case in.exitCode < 0:
+		return string(jobstore.StatusFailed), "killed_by_signal"
 	default:
 		return string(jobstore.StatusFailed), "exit_nonzero"
 	}

--- a/agent/job_shell_test.go
+++ b/agent/job_shell_test.go
@@ -160,6 +160,44 @@ func TestRunShellPipelineExitStatus(t *testing.T) {
 	}
 }
 
+func TestRunShellSignalKilledReportsSignalOutcome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("signal outcome contract is for the POSIX shell path")
+	}
+	jm, se := newShellTestRig(t)
+	res := runShell(context.Background(), jm, se, shellArgs{Command: "kill -KILL $$", BlockTimeoutMS: 5000})
+	if res.settle != nil {
+		if jobID := res.settle(false); jobID != "" {
+			t.Fatalf("discarded foreground shell returned job_id %q", jobID)
+		}
+	}
+	if res.Status != string(jobstore.StatusFailed) || res.Reason != "killed_by_signal: SIGKILL" {
+		t.Fatalf("res = %+v, want failed/killed_by_signal: SIGKILL", res)
+	}
+	if res.ExitCode == nil || *res.ExitCode != -1 {
+		t.Fatalf("exit code = %v, want -1 for a signal-killed process", res.ExitCode)
+	}
+}
+
+func TestRunShellBackgroundSignalKilledPersistsSignalOutcome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("signal outcome contract is for the POSIX shell path")
+	}
+	jm, se := newShellTestRig(t)
+	res := runShell(context.Background(), jm, se, shellArgs{Command: "kill -KILL $$", Background: true})
+	if res.JobID == "" || !res.RunningInBackground {
+		t.Fatalf("res = %+v, want a background job", res)
+	}
+	waitForShellDone(t, jm, res.JobID)
+	rec := loadShellRecord(t, jm, res.JobID)
+	if rec.Status != jobstore.StatusFailed || rec.Reason != "killed_by_signal: SIGKILL" {
+		t.Fatalf("record = %+v, want failed/killed_by_signal: SIGKILL", rec)
+	}
+	if rec.ExitCode == nil || *rec.ExitCode != -1 {
+		t.Fatalf("record exit code = %v, want -1 for a signal-killed process", rec.ExitCode)
+	}
+}
+
 type waitErrorStreamingExecutor struct{}
 
 type startErrorStreamingExecutor struct{}

--- a/docs/job-control.md
+++ b/docs/job-control.md
@@ -197,7 +197,7 @@ or `idle`; its prior generation is summarized separately in `last_outcome` with
 | `running` | shell or delegate status | A shell has a live or believed-live process, or a delegate has an open generation. | `stop_pending`, `foreground_timeout` for shell | progress/match as configured |
 | `idle` | delegate status | No delegate generation is processing; resumability is separate metadata. | usually `null` | none by lifecycle alone |
 | `completed` | shell status or delegate `last_outcome` | Work ended normally. | `exit_zero` for shell; otherwise usually `null` | typed terminal attention |
-| `failed` | shell status or delegate `last_outcome` | Created work ran or attempted to run and failed. | `exit_nonzero`, `start_failed`, `finalize_failed`, `forward_failed`, `missing_terminal`, `terminal_error`, `runtime_lost` as applicable | typed terminal attention |
+| `failed` | shell status or delegate `last_outcome` | Created work ran or attempted to run and failed. | `exit_nonzero`, `killed_by_signal: SIGNAL`, `start_failed`, `finalize_failed`, `forward_failed`, `missing_terminal`, `terminal_error`, `runtime_lost` as applicable | typed terminal attention |
 | `exhausted` | delegate `last_outcome` | A delegate generation reached its turn or tool-round budget. | `turn_budget_exhausted`, `tool_round_budget_exhausted` | delegate terminal packet |
 | `cancelled` | shell status or delegate `last_outcome` | Evener intentionally stopped work and confirmed cancellation. | `stopped_by_parent` | typed terminal attention |
 | `stopped` | shell status or delegate `last_outcome` | Work did not complete and Evener cannot attribute it to normal failure or confirmed cancellation. | `runtime_lost`, `cancelled`, `run_timeout` | typed terminal attention |


### PR DESCRIPTION
Fixes #389

## Root cause

`os/exec` reports a process terminated by a signal with `ExitCode() == -1`. The shell-job terminal classifier treated every nonzero code as `exit_nonzero`, destroying the wait-status signal and making an OOM kill look like a program failure.

## Real-path RED evidence

Added the regression before the production change and ran:

    go test ./agent -run '^TestRunShellSignalKilledReportsSignalOutcome$' -count=1 -v

It failed on the real `runShell` -> `LocalExecutionEnvironment.StreamCommand` lifecycle with:

    res = { ... Status:failed Reason:exit_nonzero ... }, want failed/killed_by_signal: SIGKILL

## Implementation

- Capture the platform wait-status signal in the existing streaming runtime without changing the command-runtime interface used by scripted implementations.
- Add Linux/Darwin `WaitStatus` extraction and a non-Unix no-name fallback.
- Preserve the `exit_code=-1` contract while reporting `killed_by_signal: SIGNAL`; ordinary nonzero exits, stop precedence, timeouts, and wait errors remain unchanged.
- Add foreground and durable background real-shell regressions; the background case asserts the persisted job record no longer resembles a program error.
- Document the new terminal reason. This PR does not include issue #390.

## Verification

Passed:

    go test ./agent -run '^TestRunShell(SignalKilledReportsSignalOutcome|BackgroundSignalKilledPersistsSignalOutcome)$' -count=1 -v
    go test ./agent -run '^$' -count=1
    go vet ./agent/...
    make lint-gofmt
    make lint-generated
    GOOS=linux go build ./...
    GOOS=darwin go build ./...
    GOOS=windows go build ./...
    GOOS=linux go vet -tags evenerfuzz ./...       # root plus all go.work modules
    GOOS=linux go vet -tags eval ./...             # root plus all go.work modules

A full `go test ./agent -count=1` completed earlier at HEAD before the final test-oracle/documentation-only edits (`ok .../agent 260.728s`). Two fresh full-suite retries after those edits were killed by the host with exit code `-1` and zero output while other workspace test/vet processes were concurrently resident; the constrained retry was killed the same way. This gate is therefore incomplete rather than claimed green.

Cross-platform test compilation passed for Linux and Darwin. Windows test compilation is blocked by pre-existing test-only uses of `syscall.Stat_t` and `syscall.Mkfifo` in `agent/delegate_resource_readonly_test.go` and `agent/delegate_tree_stop_test.go`; the production Windows build passes.

## Risks / limitations

- The reviewer subagent capability was unavailable in this session; no automated reviewer was dispatched. The final diff is limited to the shell runtime, outcome tests, fuzz oracles, and job-control documentation.
- Platforms without a portable `WaitStatus` signal name still receive the distinct `killed_by_signal` outcome and preserved negative exit code, without a signal suffix.