### PR TITLE
fix(lint): isolate golangci-lint cache per worktree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@
 GO_MODULES := . agent llm auth envvars invariant identifier
 FUZZ_GO_MODULES := $(GO_MODULES) fuzz
 
+# golangci-lint caches raw findings before path-based suppressions and
+# exclusions run. Keep that cache durable within this worktree, but never let
+# sibling checkouts share it. `?=` deliberately preserves an operator's
+# explicit GOLANGCI_LINT_CACHE override.
+GOLANGCI_LINT_CACHE ?= $(shell scripts/lib/golangci-lint-cache.sh)
+
 # DEV_TOOLING_TEST_SCRIPTS are the scripts/<name>-selftest.sh suites that pin
 # the behaviour of evener's own tooling. Each is offline, deterministic and works
 # only in throwaway fixtures, and each is the ONLY thing that pins its script's
@@ -16,7 +22,7 @@ FUZZ_GO_MODULES := $(GO_MODULES) fuzz
 # the guard or the pid-suffixed covscratch pattern, is enforced statically by
 # the audits in scriptmktemp_audit_test.go, not by re-running suites under
 # sabotage (kata 5hs2).
-DEV_TOOLING_TEST_SCRIPTS := lib/private-go-home gate/merge-approval-gate ops/setup-gocache web/web-preflight lib/live-eval-isolation fuzz/fuzz-bisect fuzz/fuzz-oracle-audit coverage/coverage-gaps gate/test-timing-budget lib/scratch-lib
+DEV_TOOLING_TEST_SCRIPTS := lib/private-go-home gate/merge-approval-gate ops/setup-gocache web/web-preflight lib/live-eval-isolation fuzz/fuzz-bisect fuzz/fuzz-oracle-audit coverage/coverage-gaps gate/test-timing-budget lib/scratch-lib lib/golangci-lint-cache
 
 define run_quiet_lint
 	@set -u; log="$$(mktemp "$${TMPDIR:-/tmp}/evener-lint-check.XXXXXX")" || exit 1; \

--- a/docs/developing-evener/conventions/naming.md
+++ b/docs/developing-evener/conventions/naming.md
@@ -166,14 +166,11 @@ make lint-golangci   # struct tags (and everything else golangci covers)
 make lint-naming     # TOML data files
 ```
 
-If `make lint` reports tagliatelle findings under `llm/providers/` or
-`server/appwire_` — paths those `path:` exclusions cover — check for a
-stale cache before believing them. golangci-lint's cache is shared across
-worktrees; when it replays entries recorded under a different checkout's
-absolute path, the reported paths come back as `../../…` and stop matching
-the anchored regexes. `golangci-lint cache clean` fixes it. Only the two
-`path:` exclusions are exposed this way; the per-package `overrides` match
-on package path and are immune.
+The Make lint targets use a worktree-scoped golangci-lint cache, so findings
+under `llm/providers/` or `server/appwire_` are evaluated against this tree's
+paths rather than a sibling checkout's. If an external invocation still uses
+the global cache, `make lint-cache-clean` clears only the Make-managed cache;
+use that invocation's own cache-clean command for its global cache.
 
 ## Adding a new surface
 

--- a/docs/developing-evener/linting.md
+++ b/docs/developing-evener/linting.md
@@ -104,14 +104,20 @@ exists to refuse.
 ## The golangci-lint cross-checkout cache hazard (issue #290)
 
 A content-identical checkout of this repo at a second path — a git worktree,
-in particular — poisons the shared `golangci-lint` cache (issue #290): the
+in particular — can poison a shared `golangci-lint` cache (issue #290): the
 cache keys on content, not path, so a lint run from one checkout can leave
 cache entries a second, path-sensitive checkout then reads as valid and
-silently produces wrong results. A worktree that runs `make lint` without an
-isolated cache does not just risk its own results — it can break the *main*
-checkout's `make lint` the moment the worktree is removed. Point
-`GOLANGCI_LINT_CACHE` at a private, worktree-scoped directory before running
-any lint command from a second checkout of this repo.
+silently produces wrong results. This affects both dropped `//nolint`
+suppression and phantom findings from path exclusions.
+
+Every Make-invoked golangci-lint process now gets a durable cache under
+`${XDG_CACHE_HOME:-$HOME/.cache}/evener/golangci-lint/`, keyed by the absolute
+worktree root. The cache is outside the repository, so gitleaks never scans
+it, and it is reused by later lint runs in the same worktree without being
+shared with siblings. `GOLANGCI_LINT_CACHE=/path make lint-golangci` remains an
+explicit escape hatch when a caller needs a particular cache. Reclaim only the
+current worktree's cache with `make lint-cache-clean`; this does not clean the
+user's global golangci-lint cache or sibling worktrees.
 
 ## Targets
 
@@ -124,6 +130,7 @@ any lint command from a second checkout of this repo.
 | `make lint-eval` | The compile floor for the //go:build eval sources: go vet under the tag, plus a tagliatelle-only golangci-lint pass. | The eval-tagged live-provider suites (context-compaction quality, forced notes) still compile. | Required CI (via make lint); local pre-merge. ~3.5s warm. | golangci-lint. Covers all of FUZZ_GO_MODULES, since eval sources could land in any module. | go vet -tags eval fails for any module, or the tagliatelle pass reports a casing violation. |
 | `make lint-internal` | Fail if any exported symbol in the agent/llm/providercfg libraries names a evener-internal type. | The agent/llm/providercfg libraries stay externally importable — no exported symbol leaks an internal type name. | Required CI (via make lint); local pre-merge. | None beyond the Go toolchain. | cmd/evener-internalcheck finds an exported symbol naming an internal type. |
 | `make lint-golangci` | golangci-lint across every workspace module, plus the second appwire-specific camelCase pass over server/appwire_*.go. See "The server/appwire_*.go camelCase regime" in docs/developing-evener/linting.md. | golangci-lint's full ruleset (struct-tag casing, formatting, exported-doc comments, and the rest) passes across every FUZZ_GO_MODULES workspace module, and the appwire camelCase regime holds for server/appwire_*.go. | Required CI (via make lint); local pre-merge. | golangci-lint. Runs against FUZZ_GO_MODULES, not GO_MODULES, so the fuzz module's ordinary Go is covered too. | Either golangci-lint run fails for any module. |
+| `make lint-cache-clean` | Remove the current worktree's golangci-lint cache without touching sibling worktrees or the user's global golangci-lint cache. | The current worktree's isolated cache can be reclaimed on demand. | Local cleanup after a tool upgrade or cache diagnosis. | golangci-lint. | golangci-lint cannot clean the configured worktree cache. |
 | `make lint-gofmt` | Keep every tracked Go source formatter-clean, including the tagged evenerfuzz/eval files golangci-lint's own gofmt pass never compiles. | `gofmt -l` reports nothing for any tracked .go file, tagged or not. | Required CI (via make lint); local pre-merge. | None beyond the Go toolchain. | Any tracked .go file is not gofmt-clean. |
 | `make lint-generated` | Fail if any committed generated output is stale: the two AppWire outputs and the six docs/developing-evener/ target tables. | docs/appwire-protocol.md, the generated TypeScript protocol types, and the marked target-table regions in docs/developing-evener/'s six family docs all match what `make generate` produces right now. | Required CI (via make lint); local pre-merge. | None beyond the Go toolchain. | `make generate` exits nonzero, an expected output is no longer tracked, or regenerated output differs from what is committed. |
 | `make lint-fuzz-registry` | Wrap `make fuzz-registry-check` so a fuzz target that lands without its registry row fails the required gate instead of sitting undetected. | Every native/Rapid fuzz target in the manifest (scripts/fuzz/fuzz-targets.txt) matches AST-discovered workspace declarations. | Required CI (via make lint); local pre-merge. Well under a second. | None beyond the Go toolchain; static AST analysis only. | A discovered fuzz target has no registry row, or a registry row has no discovered target. |

--- a/make/linting.mk
+++ b/make/linting.mk
@@ -115,6 +115,7 @@ lint-golangci:
 ## trigger: Local cleanup after a tool upgrade or cache diagnosis.
 ## requires: golangci-lint.
 ## fails-when: golangci-lint cannot clean the configured worktree cache.
+# lint-cache-clean is an intentional local cleanup action; keep it out of LINT_TARGETS so required lint runs can reuse the cache they are checking.
 lint-cache-clean:
 	@GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)" golangci-lint cache clean
 

--- a/make/linting.mk
+++ b/make/linting.mk
@@ -1,4 +1,4 @@
-.PHONY: lint lint-naming lint-gofmt lint-evenerfuzz lint-eval lint-internal lint-golangci lint-generated lint-fuzz-registry secret-scan
+.PHONY: lint lint-naming lint-gofmt lint-evenerfuzz lint-eval lint-internal lint-golangci lint-generated lint-fuzz-registry lint-cache-clean secret-scan
 
 # secret-scan runs gitleaks over the whole working tree using the committed
 # .gitleaks.toml ruleset. Part of the gate (`make lint`); skips with a warning
@@ -39,8 +39,8 @@ lint-naming:
 ## fails-when: go vet -tags evenerfuzz fails for any module, or the
 ##   tagliatelle pass reports a casing violation.
 lint-evenerfuzz:
-	$(call run_quiet_lint,for m in $(FUZZ_GO_MODULES); do (cd $$m && go vet -tags evenerfuzz ./...) || exit 1; done)
-	$(call run_quiet_lint,for m in $(FUZZ_GO_MODULES); do (cd $$m && golangci-lint run --allow-parallel-runners --build-tags evenerfuzz --enable-only tagliatelle ./...) || exit 1; done)
+	$(call run_quiet_lint,export GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)"; for m in $(FUZZ_GO_MODULES); do (cd $$m && go vet -tags evenerfuzz ./...) || exit 1; done)
+	$(call run_quiet_lint,export GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)"; for m in $(FUZZ_GO_MODULES); do (cd $$m && golangci-lint run --allow-parallel-runners --build-tags evenerfuzz --enable-only tagliatelle ./...) || exit 1; done)
 
 # lint-eval is the same compile floor for the //go:build eval sources: the
 # live-provider eval suites (context-compaction quality, forced notes). This tag
@@ -63,8 +63,8 @@ lint-evenerfuzz:
 ## fails-when: go vet -tags eval fails for any module, or the tagliatelle
 ##   pass reports a casing violation.
 lint-eval:
-	$(call run_quiet_lint,for m in $(FUZZ_GO_MODULES); do (cd $$m && go vet -tags eval ./...) || exit 1; done)
-	$(call run_quiet_lint,for m in $(FUZZ_GO_MODULES); do (cd $$m && golangci-lint run --allow-parallel-runners --build-tags eval --enable-only tagliatelle ./...) || exit 1; done)
+	$(call run_quiet_lint,export GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)"; for m in $(FUZZ_GO_MODULES); do (cd $$m && go vet -tags eval ./...) || exit 1; done)
+	$(call run_quiet_lint,export GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)"; for m in $(FUZZ_GO_MODULES); do (cd $$m && golangci-lint run --allow-parallel-runners --build-tags eval --enable-only tagliatelle ./...) || exit 1; done)
 
 # lint-internal fails if any exported symbol in the agent/llm/providercfg
 # libraries names a evener-internal type — keeping them externally importable.
@@ -106,8 +106,17 @@ lint-internal:
 ##   the fuzz module's ordinary Go is covered too.
 ## fails-when: Either golangci-lint run fails for any module.
 lint-golangci:
-	@MODULES="$(FUZZ_GO_MODULES)" go run ./cmd/evener-dev/bin dev module-lint
-	$(call run_quiet_lint,golangci-lint run --allow-parallel-runners --config .golangci-appwire.yml ./server/...)
+	@MODULES="$(FUZZ_GO_MODULES)" GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)" go run ./cmd/evener-dev/bin dev module-lint
+	$(call run_quiet_lint,GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)" golangci-lint run --allow-parallel-runners --config .golangci-appwire.yml ./server/...)
+
+## Remove the current worktree's golangci-lint cache without touching sibling
+## worktrees or the user's global golangci-lint cache.
+## proves: The current worktree's isolated cache can be reclaimed on demand.
+## trigger: Local cleanup after a tool upgrade or cache diagnosis.
+## requires: golangci-lint.
+## fails-when: golangci-lint cannot clean the configured worktree cache.
+lint-cache-clean:
+	@GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)" golangci-lint cache clean
 
 # lint-gofmt keeps EVERY tracked Go source formatter-clean, including the ~250
 # files behind //go:build evenerfuzz / eval. It is not redundant with the gofmt

--- a/makefiletargets_audit_test.go
+++ b/makefiletargets_audit_test.go
@@ -236,10 +236,14 @@ func TestEveryLintTargetIsPhonyAndHasARule(t *testing.T) {
 	}
 }
 
+const lintCacheCleanExemptionComment = "# lint-cache-clean is an intentional local cleanup action; keep it out of LINT_TARGETS so required lint runs can reuse the cache they are checking."
+
 // makefileLintingRuleNames returns every rule name declared in
 // make/linting.mk, excluding the `lint` alias itself (the target
-// LINT_TARGETS feeds, not a member of it) and directive lines like
-// .PHONY.
+// LINT_TARGETS feeds, not a member of it), the one explicitly documented local
+// cleanup action, and directive lines like .PHONY. The cleanup exception is
+// deliberately narrow and requires the exact adjacent comment next to that
+// one rule; it is not a general allowlist for disconnected lint rules.
 func makefileLintingRuleNames(t *testing.T) []string {
 	t.Helper()
 	raw, err := os.ReadFile("make/linting.mk")
@@ -247,13 +251,20 @@ func makefileLintingRuleNames(t *testing.T) []string {
 		t.Fatalf("reading make/linting.mk: %v", err)
 	}
 	var names []string
+	var previous string
 	for line := range strings.Lines(string(raw)) {
 		line = strings.TrimRight(line, "\n")
 		name, _, ok := ruleLineName(line)
 		if !ok || name == "lint" {
+			previous = line
+			continue
+		}
+		if name == "lint-cache-clean" && strings.TrimSpace(previous) == lintCacheCleanExemptionComment {
+			previous = line
 			continue
 		}
 		names = append(names, name)
+		previous = line
 	}
 	return names
 }
@@ -273,10 +284,10 @@ func makefileLintingRuleNames(t *testing.T) []string {
 // still runs it — but the required gate silently stopped calling it.
 //
 // Every one of make/linting.mk's rules was checked against `make -n lint`
-// before this test was written, and each is genuinely required: none is
-// exempt, so this test hardcodes no allowlist. If a future lint-family rule
-// is deliberately NOT gate material, say so in a comment next to its rule
-// rather than adding a silent skip here.
+// before this test was written, and each is genuinely required except for the
+// one explicitly documented local cleanup action above. That narrow exception
+// is recognized only for lint-cache-clean and only with its exact adjacent
+// comment; a future lint-family rule must not gain a silent skip here.
 func TestEveryLintingRuleIsInLintTargets(t *testing.T) {
 	t.Parallel()
 	rules := makefileLintingRuleNames(t)

--- a/scripts/lib/golangci-lint-cache-selftest.sh
+++ b/scripts/lib/golangci-lint-cache-selftest.sh
@@ -6,19 +6,24 @@ set -uo pipefail
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
 . "$repo_root/scripts/lib/selftest-lib.sh"
 
-scratch_dir work golangci-lint-cache-selftest
-
-seed="$work/seed"
-tree_a="$work/worktree A"
-tree_b="$work/worktree B"
+work=''
+seed=''
+tree_a=''
+tree_b=''
 cleanup() {
-	if [ -d "$seed/.git" ]; then
+	if [ -n "$seed" ] && [ -d "$seed/.git" ]; then
 		git -C "$seed" worktree remove --force "$tree_a" >/dev/null 2>&1 || :
 		git -C "$seed" worktree remove --force "$tree_b" >/dev/null 2>&1 || :
 	fi
 	scratch_rm
 }
 trap cleanup EXIT
+
+scratch_dir work golangci-lint-cache-selftest
+
+seed="$work/seed"
+tree_a="$work/worktree A"
+tree_b="$work/worktree B"
 
 helper="$repo_root/scripts/lib/golangci-lint-cache.sh"
 if [ ! -x "$helper" ]; then

--- a/scripts/lib/golangci-lint-cache-selftest.sh
+++ b/scripts/lib/golangci-lint-cache-selftest.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# golangci-lint-cache-selftest.sh — exercise cache isolation with the real
+# pinned linter in two git worktrees and two configuration states.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$repo_root/scripts/lib/selftest-lib.sh"
+
+scratch_dir work golangci-lint-cache-selftest
+
+seed="$work/seed"
+tree_a="$work/worktree A"
+tree_b="$work/worktree B"
+cleanup() {
+	if [ -d "$seed/.git" ]; then
+		git -C "$seed" worktree remove --force "$tree_a" >/dev/null 2>&1 || :
+		git -C "$seed" worktree remove --force "$tree_b" >/dev/null 2>&1 || :
+	fi
+	scratch_rm
+}
+trap cleanup EXIT
+
+helper="$repo_root/scripts/lib/golangci-lint-cache.sh"
+if [ ! -x "$helper" ]; then
+	bad "the production cache-path helper is missing or not executable"
+	selftest_summary
+	exit $?
+fi
+
+linter="$(command -v golangci-lint 2>/dev/null || true)"
+if [ -z "$linter" ]; then
+	bad "golangci-lint is not installed"
+	selftest_summary
+	exit $?
+fi
+if ! golangci-lint version 2>"$work/version.err" | grep -qF 'version 2.13.1'; then
+	bad "golangci-lint is not the pinned 2.13.1 version: $(cat "$work/version.err")"
+	selftest_summary
+	exit $?
+fi
+
+cache_home="$work/cache home"
+mkdir -p "$cache_home"
+
+make_worktrees() {
+	mkdir -p "$seed"
+	git init -q "$seed" || return 1
+	git -C "$seed" config user.email selftest@example.invalid
+	git -C "$seed" config user.name golangci-lint-cache-selftest
+	cat >"$seed/go.mod" <<'EOF'
+module example.com/golangci-cache-selftest
+
+go 1.27
+EOF
+	cat >"$seed/x.go" <<'EOF'
+package x
+
+type T struct {
+	MCPServers string `json:"mcpServers"`
+}
+EOF
+	cat >"$seed/suppressed.go" <<'EOF'
+package x
+
+type S struct {
+	MCPServers string `json:"mcpServers"` //nolint:tagliatelle // upstream wire key
+}
+EOF
+	cat >"$seed/.golangci.yml" <<EOF
+version: "2"
+linters:
+  default: none
+  enable:
+    - tagliatelle
+  settings:
+    tagliatelle:
+      case:
+        rules:
+          json: snake
+EOF
+	git -C "$seed" add go.mod x.go suppressed.go .golangci.yml
+	git -C "$seed" commit -qm fixture || return 1
+	git -C "$seed" worktree add --detach -q "$tree_a" HEAD || return 1
+	git -C "$seed" worktree add --detach -q "$tree_b" HEAD || return 1
+	cat >>"$tree_a/.golangci.yml" <<'EOF'
+  exclusions:
+    rules:
+      - path: ^x\.go$
+        linters:
+          - tagliatelle
+EOF
+}
+
+if ! make_worktrees; then
+	bad "could not create the two git worktree fixtures"
+	selftest_summary
+	exit $?
+fi
+
+cache_a="$(cd "$tree_a" && XDG_CACHE_HOME="$cache_home" "$helper")"
+cache_a_again="$(cd "$tree_a" && XDG_CACHE_HOME="$cache_home" "$helper")"
+cache_b="$(cd "$tree_b" && XDG_CACHE_HOME="$cache_home" "$helper")"
+assert_eq "$cache_a_again" "$cache_a" "one worktree reuses its stable cache path"
+if [ "$cache_a" != "$cache_b" ]; then
+	ok "different worktrees receive different cache paths"
+else
+	bad "different worktrees received the same cache path"
+fi
+case "$cache_a$cache_b" in
+	*" "*) ok "cache paths remain usable when worktree/cache roots contain spaces" ;;
+	*) bad "fixture did not exercise a space-containing cache path" ;;
+esac
+
+run_lint() {
+	local tree="$1" cache="$2" output="$3"
+	(cd "$tree" && XDG_CACHE_HOME="$cache_home" GOLANGCI_LINT_CACHE="$cache" \
+		"$linter" run --config .golangci.yml ./... >"$output" 2>&1)
+}
+
+if run_lint "$tree_a" "$cache_a" "$work/a.out"; then
+	ok "the excluded finding passes in configuration A"
+else
+	bad "configuration A unexpectedly reported a finding: $(cat "$work/a.out")"
+fi
+if run_lint "$tree_b" "$cache_b" "$work/b.out"; then
+	bad "configuration B unexpectedly passed without the exclusion"
+else
+	if grep -qF 'x.go:4:' "$work/b.out" && ! grep -qF 'suppressed.go' "$work/b.out" && ! grep -qF "$tree_a" "$work/b.out"; then
+		ok "configuration B reports its own finding, not a sibling path"
+	else
+		bad "configuration B failed without naming its own worktree: $(cat "$work/b.out")"
+	fi
+fi
+if [ -d "$cache_a" ] && [ -d "$cache_b" ] && [ "$cache_a" != "$cache_b" ]; then
+	ok "both real linter runs populate separate reusable cache directories"
+else
+	bad "real linter runs did not leave both isolated cache directories"
+fi
+case "$cache_a" in
+	"$tree_a"/*|"$tree_b"/*) bad "a cache directory is inside a worktree" ;;
+	*) ok "isolated caches stay outside the worktrees and secret-scan surface" ;;
+esac
+if make -s -C "$repo_root" GOLANGCI_LINT_CACHE="$cache_a" lint-cache-clean >"$work/clean.out" 2>&1; then
+	if [ ! -e "$cache_a" ] && [ -d "$cache_b" ]; then
+		ok "the current worktree cache is cleanable without touching its sibling"
+	else
+		bad "lint-cache-clean exited 0 but left the current cache: $(cat "$work/clean.out")"
+	fi
+else
+	bad "lint-cache-clean failed: $(cat "$work/clean.out")"
+fi
+
+selftest_summary

--- a/scripts/lib/golangci-lint-cache.sh
+++ b/scripts/lib/golangci-lint-cache.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Print the durable cache directory for the current worktree. The worktree
+# root is hashed so sibling checkouts cannot replay each other's findings, and
+# the cache stays outside the repository so whole-tree secret scans never read
+# it. The path is printed only; golangci-lint creates it on first use.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+cache_home="${XDG_CACHE_HOME:-${HOME:?HOME must be set}/.cache}"
+worktree_id="$(printf '%s' "$root" | shasum -a 256 | cut -c1-16)"
+printf '%s/evener/golangci-lint/%s\n' "$cache_home" "$worktree_id"


### PR DESCRIPTION
Fixes #290
Closes #384

## Root cause

golangci-lint caches raw findings before path-based `//nolint` suppression and path-exclusion processing, but its cache key does not include the checkout path. A shared user cache can therefore replay a sibling worktree's recorded path: covered suppressions are dropped, while anchored exclusions can miss phantom findings.

## RED evidence

Before the implementation existed, the new real-path selftest failed as expected:

```text
scripts/lib/golangci-lint-cache-selftest.sh
FAIL: the production cache-path helper is missing or not executable
... 1 checks, 1 failed
```

## Implementation

- Derive `GOLANGCI_LINT_CACHE` from the SHA-256 prefix of the absolute git worktree root.
- Store it under `${XDG_CACHE_HOME:-$HOME/.cache}/evener/golangci-lint/`, outside the repository and therefore outside whole-tree secret scans.
- Pass the quoted value to every Make-invoked golangci-lint path, including tagged passes, the Go module runner, and the AppWire pass; `?=` preserves explicit caller overrides.
- Add `make lint-cache-clean`, which cleans only the configured current-worktree cache.
- Add a real golangci-lint 2.13.1 selftest with two actual git worktrees, different exclusion/suppression configurations, space-containing paths, cache reuse, sibling isolation, and cleanup assertions.

## Verification

- `go version`: go1.27.0; `golangci-lint version`: 2.13.1.
- `scripts/lib/golangci-lint-cache-selftest.sh`: 8 checks, 0 failed.
- `make test-dev-tooling`: all 11 suites PASS, including `lib/golangci-lint-cache`.
- `go test ./cmd/evener-dev/...`: PASS (`cmd/evener-dev` 232.394s; `bin` has no tests).
- `make lint-golangci`: `PASS lint (8 modules, 245s)`.
- Post-commit `make lint`: `PASS lint (8 modules, 12s)`.
- `make generate`, generated-output check, and `git diff --check`: PASS.

## Risks and limitations

The automatic isolation covers Make-invoked linting. Editors or other direct golangci-lint callers that intentionally bypass Make still need to provide their own cache policy. Moving a worktree changes its root hash and intentionally starts a new cache; `make lint-cache-clean` reclaims the cache for the current root only.
