### PR TITLE
fix(server): bound live transcript snapshot copies

### DIFF
--- a/agent/session_jobtree_drain_undisposed_test.go
+++ b/agent/session_jobtree_drain_undisposed_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -440,6 +441,12 @@ func TestClearedWatchStartsAFreshAnnouncementEpisode(t *testing.T) {
 	t.Parallel()
 	var jobID string
 	watchArmed := make(chan struct{})
+	// budgetCrossed holds the watch-arming turn open until the test has driven
+	// the budget crossing. The escalation is turn-paced, so without the hold the
+	// drain can complete that turn and reach the final warning before the
+	// cleared notification is queued, and the fresh-episode assertions then read
+	// an episode the notification never interrupted.
+	budgetCrossed := make(chan struct{})
 	var clearedNoticeSeen atomic.Bool
 	adapter := &fakeAdapter{name: "openai"}
 	adapter.steps = []func(llm.Request) llm.Response{
@@ -451,6 +458,7 @@ func TestClearedWatchStartsAFreshAnnouncementEpisode(t *testing.T) {
 		},
 		func(llm.Request) llm.Response {
 			close(watchArmed)
+			<-budgetCrossed
 			return finalResponse("watching; it will finish")
 		},
 		func(req llm.Request) llm.Response {
@@ -480,6 +488,11 @@ func TestClearedWatchStartsAFreshAnnouncementEpisode(t *testing.T) {
 		res, err := sess.drainJobTreeWith(ctx, feedRechecks(ctx), sess.kickDriveTree, sess.ProcessInputKind)
 		done <- drainResult{res, err}
 	}()
+	// Registered after the join above so it runs before it: a t.Fatal between
+	// here and the release below would otherwise strand the held turn and leave
+	// the join waiting on a drain that can never finish.
+	releaseWatchTurn := sync.OnceFunc(func() { close(budgetCrossed) })
+	t.Cleanup(releaseWatchTurn)
 	select {
 	case <-watchArmed:
 	case d := <-done:
@@ -518,6 +531,7 @@ func TestClearedWatchStartsAFreshAnnouncementEpisode(t *testing.T) {
 	if stillLive {
 		t.Fatal("budget-crossing delivery left the watch live")
 	}
+	releaseWatchTurn()
 
 	d := <-done
 	if d.err != nil {

--- a/cmd/evener-hub/app_threadread.go
+++ b/cmd/evener-hub/app_threadread.go
@@ -138,12 +138,17 @@ func mergePastThreadForRead(cfg hubcore.WebConfig, params appwire.ThreadReadPara
 			params.Ref = appwire.Ref{SourceID: "local", ThreadID: live.SessionID}.String()
 		}
 	}
-	past, ok, err := pastThreadForRead(cfg, params)
-	if err != nil {
-		return appwire.Thread{}, err
-	}
+	entry, ok := pastEntryForRead(cfg, params)
 	if !ok {
 		return live, nil
+	}
+	// A live window is authoritative. Read saved turns only as the compatibility
+	// fallback for a live source that returned none; the metadata merged below
+	// does not use pastThreadForRead's full-transcript usage or failure scans.
+	includePastTurns := params.IncludeTurns && len(live.Turns) == 0
+	past, err := pastEntryThread(cfg, entry, includePastTurns)
+	if err != nil {
+		return appwire.Thread{}, err
 	}
 	if live.ID == "" {
 		live.ID = past.ID

--- a/cmd/evener-hub/app_threadread_test.go
+++ b/cmd/evener-hub/app_threadread_test.go
@@ -757,6 +757,50 @@ func TestPastEntryThreadAdvertisesResumableCapabilities(t *testing.T) {
 	}
 }
 
+func TestMergePastThreadForReadDoesNotReadSavedTurnsWhenLiveWindowPresent(t *testing.T) {
+	cfg, params := seedBoundedPastThread(t)
+	entry, ok := pastEntryForRead(cfg, params)
+	if !ok {
+		t.Fatal("past thread not found")
+	}
+	path := filepath.Join(entry.StateDir, "sessions", entry.Meta.ID+".transcript.jsonl")
+	if err := os.WriteFile(path, []byte(`{"kind":"header","format_version":1}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	liveTurns := []appwire.Turn{{ID: "turn_live", ItemsView: "full"}}
+
+	got, err := mergePastThreadForRead(cfg, params, appwire.Thread{
+		ID:        entry.Meta.ID,
+		SessionID: entry.Meta.ID,
+		Turns:     liveTurns,
+	})
+	if err != nil {
+		t.Fatalf("merge live window with unreadable saved transcript: %v", err)
+	}
+	if !reflect.DeepEqual(got.Turns, liveTurns) {
+		t.Fatalf("merged turns = %+v, want live window %+v", got.Turns, liveTurns)
+	}
+	if got.ModelProvider != entry.Meta.Model || got.CWD != entry.Meta.EnvInfo.WorkingDir {
+		t.Fatalf("merged metadata = model %q cwd %q, want %q %q", got.ModelProvider, got.CWD, entry.Meta.Model, entry.Meta.EnvInfo.WorkingDir)
+	}
+}
+
+func TestMergePastThreadForReadUsesSavedTurnsWhenLiveResponseHasNone(t *testing.T) {
+	cfg, params := seedBoundedPastThread(t)
+	entry, ok := pastEntryForRead(cfg, params)
+	if !ok {
+		t.Fatal("past thread not found")
+	}
+
+	got, err := mergePastThreadForRead(cfg, params, appwire.Thread{ID: entry.Meta.ID, SessionID: entry.Meta.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Turns) != entry.Meta.TurnCount {
+		t.Fatalf("merged turns = %d, want saved fallback %d", len(got.Turns), entry.Meta.TurnCount)
+	}
+}
+
 func TestPastThreadReadUsesBoundedSavedTranscript(t *testing.T) {
 	cfg, params := seedBoundedPastThread(t)
 	full, ok := requirePastThreadForRead(t, cfg, params)

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -663,11 +663,20 @@ func (s *Server) appProjectionThreadID() string {
 	return s.status.SessionID
 }
 
-// appAllTurns returns the whole installed snapshot for threadID, oldest-first.
-// It is the one authority: thread/read, the latest window, and older pages all
-// derive from this slice, so they cannot disagree with each other or with what
-// subscribers were sent.
+// appAllTurns returns a defensive copy of the whole installed snapshot for
+// threadID, oldest-first.
 func (s *Server) appAllTurns(threadID string) []appwire.Turn {
+	snapshot := s.appTurnSnapshotForID(threadID)
+	if snapshot == nil {
+		return nil
+	}
+	return snapshot.Snapshot()
+}
+
+// appTurnSnapshotForID selects the installed snapshot shared by full reads,
+// latest windows, and older pages. Callers use the snapshot's locking accessors
+// so the three views cannot disagree with each other or with subscriber state.
+func (s *Server) appTurnSnapshotForID(threadID string) *appTurnSnapshot {
 	s.mu.RLock()
 	snapshot := s.appTurns
 	installed := s.appThreadID == threadID && snapshot != nil && snapshot.threadID == threadID
@@ -681,7 +690,7 @@ func (s *Server) appAllTurns(threadID string) []appwire.Turn {
 	if !installed {
 		return nil
 	}
-	return snapshot.Snapshot()
+	return snapshot
 }
 
 func transcriptHeader(path string, maxLineBytes int) transcript.Header {
@@ -713,12 +722,20 @@ func transcriptHeader(path string, maxLineBytes int) transcript.Header {
 // and returns the cursor for the page before them. A limit of zero or less
 // returns the whole thread with no cursor.
 func (s *Server) appLatestTurns(threadID string, limit int) ([]appwire.Turn, string) {
-	return appwire.WindowTurns(s.appAllTurns(threadID), limit)
+	snapshot := s.appTurnSnapshotForID(threadID)
+	if snapshot == nil {
+		return nil, ""
+	}
+	return snapshot.Latest(limit)
 }
 
 // appPageTurns pages backward through the installed snapshot from cursor.
 func (s *Server) appPageTurns(threadID, cursor string, limit int) appwire.ThreadTurnsListResponse {
-	return appwire.PageTurns(s.appAllTurns(threadID), cursor, limit)
+	snapshot := s.appTurnSnapshotForID(threadID)
+	if snapshot == nil {
+		return appwire.ThreadTurnsListResponse{}
+	}
+	return snapshot.Page(cursor, limit)
 }
 
 // handleAppThreadTurnsList pages turns backward (older) for lazy transcript

--- a/server/appwire_turns.go
+++ b/server/appwire_turns.go
@@ -344,10 +344,29 @@ func (s *appTurnSnapshot) Snapshot() []appwire.Turn {
 	return s.snapshotLocked()
 }
 
+func (s *appTurnSnapshot) Latest(limit int) ([]appwire.Turn, string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	turns, cursor := appwire.WindowTurns(s.turns, limit)
+	return cloneAppTurns(turns), cursor
+}
+
+func (s *appTurnSnapshot) Page(cursor string, limit int) appwire.ThreadTurnsListResponse {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	page := appwire.PageTurns(s.turns, cursor, limit)
+	page.Data = cloneAppTurns(page.Data)
+	return page
+}
+
 func (s *appTurnSnapshot) snapshotLocked() []appwire.Turn {
-	turns := make([]appwire.Turn, len(s.turns))
+	return cloneAppTurns(s.turns)
+}
+
+func cloneAppTurns(source []appwire.Turn) []appwire.Turn {
+	turns := make([]appwire.Turn, len(source))
 	for i := range turns {
-		turns[i] = cloneAppTurn(s.turns[i])
+		turns[i] = cloneAppTurn(source[i])
 	}
 	return turns
 }

--- a/server/appwire_turns_paging_test.go
+++ b/server/appwire_turns_paging_test.go
@@ -101,6 +101,81 @@ func turnIDs(turns []appwire.Turn) []string {
 	return out
 }
 
+type cloneCountingJSONValue struct {
+	calls *int
+}
+
+func (v cloneCountingJSONValue) MarshalJSON() ([]byte, error) {
+	(*v.calls)++
+	return []byte(`{"value":"excluded"}`), nil
+}
+
+func installTurnSnapshotForTest(srv *Server, turns []appwire.Turn) {
+	srv.mu.Lock()
+	srv.appTurns = &appTurnSnapshot{threadID: "th_1", turns: turns}
+	srv.mu.Unlock()
+}
+
+func countedCloneTurn(id string, calls *int) appwire.Turn {
+	return appwire.Turn{
+		ID: id,
+		Error: &appwire.TurnError{
+			CodexErrorInfo: cloneCountingJSONValue{calls: calls},
+		},
+	}
+}
+
+func TestServerAppWireLatestWindowClonesOnlyReturnedTurns(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+	var excludedCloneCalls int
+	installTurnSnapshotForTest(srv, []appwire.Turn{
+		countedCloneTurn("turn_1", &excludedCloneCalls),
+		countedCloneTurn("turn_2", &excludedCloneCalls),
+		{ID: "turn_3", Items: []appwire.ThreadItem{{Raw: json.RawMessage(`{"value":"latest"}`)}}},
+	})
+
+	got, cursor := srv.appLatestTurns("th_1", 1)
+	if ids := turnIDs(got); !reflect.DeepEqual(ids, []string{"turn_3"}) || cursor != "2" {
+		t.Fatalf("latest window = %v (cursor %q), want [turn_3] (cursor 2)", ids, cursor)
+	}
+	if excludedCloneCalls != 0 {
+		t.Fatalf("latest window deep-cloned %d excluded turn value(s), want 0", excludedCloneCalls)
+	}
+
+	got[0].Items[0].Raw[0] = 'X'
+	again, _ := srv.appLatestTurns("th_1", 1)
+	if string(again[0].Items[0].Raw) != `{"value":"latest"}` {
+		t.Fatalf("latest window aliases installed state: %s", again[0].Items[0].Raw)
+	}
+}
+
+func TestServerAppWireOlderPageClonesOnlyReturnedTurns(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+	var excludedCloneCalls int
+	installTurnSnapshotForTest(srv, []appwire.Turn{
+		countedCloneTurn("turn_1", &excludedCloneCalls),
+		countedCloneTurn("turn_2", &excludedCloneCalls),
+		{ID: "turn_3", Items: []appwire.ThreadItem{{Raw: json.RawMessage(`{"value":"page"}`)}}},
+		countedCloneTurn("turn_4", &excludedCloneCalls),
+	})
+
+	got := srv.appPageTurns("th_1", "3", 1)
+	if ids := turnIDs(got.Data); !reflect.DeepEqual(ids, []string{"turn_3"}) || got.NextCursor != "2" {
+		t.Fatalf("older page = %v (cursor %q), want [turn_3] (cursor 2)", ids, got.NextCursor)
+	}
+	if excludedCloneCalls != 0 {
+		t.Fatalf("older page deep-cloned %d excluded turn value(s), want 0", excludedCloneCalls)
+	}
+
+	got.Data[0].Items[0].Raw[0] = 'X'
+	again := srv.appPageTurns("th_1", "3", 1)
+	if string(again.Data[0].Items[0].Raw) != `{"value":"page"}` {
+		t.Fatalf("older page aliases installed state: %s", again.Data[0].Items[0].Raw)
+	}
+}
+
 func TestDaemonThreadReadWindowsAndTurnsListPagesToHead(t *testing.T) {
 	srv := seedTranscriptServer(t, 4)
 	conn := srv.AppServer().NewConnection("test")


### PR DESCRIPTION
## Summary

- select latest-turn windows and older pages before deep-cloning snapshot data
- stop the Hub from reloading the saved transcript when a live response already contains turns
- preserve full snapshot reads, saved-turn fallback, cursor behavior, and defensive-copy isolation
- add deterministic regressions for excluded clone work and the live/past merge

## Root cause

A live reopen had two independent O(total transcript) stages:

1. The daemon called `Snapshot()` on every turn and item before applying `turnLimit: 40`.
2. After receiving that bounded live window, the Hub called `pastThreadForRead` with `IncludeTurns: true`, projected the complete saved transcript, then discarded those turns because the live response already had them.

On the live instance, a 7.1 MB transcript reopened in 1.16 seconds, while a 77.5 MB transcript took 12.12 and 12.31 seconds on consecutive reads. SQLite was not on this path.

The daemon now selects under the snapshot lock and clones only the selected turns. The Hub now merges metadata directly and reads saved turns only as the compatibility fallback when the live source returned none.

## Gate hygiene

The post-update gate exposed two pre-existing test races, both reproduced and root-caused rather than rerun away:

- PR #421 supplied the existing load-safe Go signal fixture for the dev-tooling process-group tests and was merged first.
- `TestClearedWatchStartsAFreshAnnouncementEpisode` raced its budget crossing against the arming turn finishing. This branch holds that turn until the crossing lands; the fix passed 200 focused repetitions and race-enabled repetitions.

## Verification

- new clone-bound tests: RED on the base, GREEN on this branch
- live/past merge regression: RED before the Hub fix, GREEN after
- `go test ./server -count=1`
- `go test ./cmd/evener-hub -count=1`
- focused `go test -race` for server and Hub regressions
- watch episode test: 200 repetitions at `-parallel=16`; focused race repetitions
- `make lint`
- `make vet`
- `make test`
