### PR TITLE
test(web): make Rail rename refresh deterministic

### DIFF
--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.test.tsx
@@ -599,7 +599,7 @@ describe("sections", () => {
     fireEvent.click(submit);
     await user.keyboard("{Enter}");
 
-    await vi.waitFor(() => expect(input.hasAttribute("disabled")).toBe(true));
+    expect(input.hasAttribute("disabled")).toBe(true);
     expect(submit.hasAttribute("disabled")).toBe(true);
     expect(screen.getByRole("button", { name: "Cancel" }).hasAttribute("disabled")).toBe(true);
     expect(mutationCalls.filter((call) => call.method === "PATCH")).toHaveLength(1);
@@ -629,12 +629,23 @@ describe("sections", () => {
     const heldRefresh = new Promise<Response>((resolve) => {
       releaseRefresh = resolve;
     });
+    let markRefreshStarted!: () => void;
+    const refreshStarted = new Promise<void>((resolve) => {
+      markRefreshStarted = resolve;
+    });
+    let markRefreshResponseConsumed!: () => void;
+    const refreshResponseConsumed = new Promise<void>((resolve) => {
+      markRefreshResponseConsumed = resolve;
+    });
     const prior = fetchMock.getMockImplementation();
     fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
       if ((init?.method ?? "GET") === "PATCH" && url === "/api/pin-sections/client") {
         const body = JSON.parse(init?.body as string) as unknown;
         mutationCalls.push({ method: "PATCH", path: url, body });
         return heldPatch;
+      }
+      if ((init?.method ?? "GET") === "GET" && url === "/api/tree" && pendingTreeRefresh) {
+        markRefreshStarted();
       }
       return prior?.(url, init) as Promise<Response>;
     });
@@ -653,7 +664,7 @@ describe("sections", () => {
     fireEvent.click(submit);
     fireEvent.click(submit);
 
-    await vi.waitFor(() => expect(input.hasAttribute("disabled")).toBe(true));
+    expect(input.hasAttribute("disabled")).toBe(true);
     expect(mutationCalls.filter((call) => call.method === "PATCH")).toHaveLength(1);
     expect(treeGetCallCount()).toBe(1);
     expect(screen.getByRole("dialog", { name: "Rename pin section" })).toBe(dialog);
@@ -667,7 +678,8 @@ describe("sections", () => {
       }),
     );
 
-    await vi.waitFor(() => expect(treeGetCallCount()).toBe(2));
+    await refreshStarted;
+    expect(treeGetCallCount()).toBe(2);
     expect(mutationCalls.filter((call) => call.method === "PATCH")).toHaveLength(1);
     expect(input.hasAttribute("disabled")).toBe(true);
     expect(submit.hasAttribute("disabled")).toBe(true);
@@ -675,9 +687,18 @@ describe("sections", () => {
     expect(screen.getByRole("dialog", { name: "Rename pin section" })).toBe(dialog);
     expect(within(screen.getByRole("region", { name: "Notifications" })).queryAllByText(/rename/i)).toHaveLength(0);
 
-    releaseRefresh(jsonResponse(NAMED_PIN_TREE));
+    releaseRefresh({
+      ...jsonResponse(NAMED_PIN_TREE),
+      json: async () => {
+        markRefreshResponseConsumed();
+        return NAMED_PIN_TREE;
+      },
+    });
 
-    await vi.waitFor(() => expect(screen.queryByRole("dialog", { name: "Rename pin section" })).toBeNull());
+    await act(async () => {
+      await refreshResponseConsumed;
+    });
+    expect(screen.queryByRole("dialog", { name: "Rename pin section" })).toBeNull();
     expect(mutationCalls.filter((call) => call.method === "PATCH")).toHaveLength(1);
     expect(treeGetCallCount()).toBe(2);
     expect(within(screen.getByRole("region", { name: "Notifications" })).queryAllByText(/rename/i)).toHaveLength(0);


### PR DESCRIPTION
## Summary

- Replace Rail rename timing/deadline polling with deterministic refresh-request and response-consumed barriers.
- Keep rename locked through exactly one authoritative refresh and close only after that refresh settles.
- No production change was necessary: `Rail.tsx` already awaits `treeStore.refresh()`.

Provenance: [PR #405 Sol integration review, 5013935953](https://github.com/prime-radiant-inc/evener/pull/405#pullrequestreview-5013935953)

## Verification

Green:

- Named Rail test
- 10x focused stress run
- 5x full Rail-file stress runs
- 5x constrained-worker Rail + Spawn runs
- `make test-web`
- `make test-web-browser`
- `npx biome check --write src/shell/rail/Rail.test.tsx`
- frontend Biome lint
- `make lint-gofmt lint-generated`
- `git diff --check`

`make lint` was attempted but is SIGTERM-incomplete during the unrelated `lint-evenerfuzz` phase; it is not reported as green.
