### PR TITLE
fix(web): preserve richer Spawn model catalog metadata

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -1186,58 +1186,105 @@ test("the classic ladder remains when the hub can't enumerate the model's own le
 
 // The pane-level modelCatalog (the Effort select's source of
 // reasoningEffortLevels) loads via a debounced /api/models enrichment, while
-// the picker loads its OWN catalog on open. If the pane-level enrichment
-// fails (transient 502, network blip) while the picker's succeeds, the picker
-// shows models WITH effort levels, but the pane-level catalog degrades to
-// label-only entries (no reasoningEffortLevels). Picking a model discards the
-// picker's entry metadata - only the qualified string reaches
-// handleModelChange - so the Effort select falls back to the generic ladder
-// instead of the model's own, even though the picker just displayed it.
-test("the Effort select uses the picked model's own ladder even when the pane-level catalog enrichment failed", async () => {
-  const user = userEvent.setup();
-  const models = [
-    {
-      provider: "openai",
-      model: "gpt-5",
-      supports_reasoning: true,
-      reasoning_effort_levels: ["minimal", "low", "medium", "high", "xhigh", "max"],
-    },
-  ];
-  // The picker opens before the 250ms debounce fires, so its /api/models call
-  // is the FIRST. Make it succeed (full enrichment). The pane-level debounced
-  // call is the SECOND — make it fail (502), so modelCatalog degrades to
-  // label-only entries with no reasoningEffortLevels.
-  let modelsApiCallCount = 0;
-  vi.stubGlobal(
-    "fetch",
-    vi.fn((url: string) => {
-      if (url.startsWith("/api/git/head")) {
-        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ branch: "main" }) } as Response);
-      }
-      if (url.startsWith("/api/models")) {
-        modelsApiCallCount += 1;
-        if (modelsApiCallCount === 2) {
-          // Pane-level enrichment fails: the catalog degrades to label-only.
-          return Promise.resolve({ ok: false, status: 502, json: () => Promise.resolve({}) } as Response);
+// the picker loads its OWN catalog on open. The two responses can complete in
+// either order: a failed enrichment produces a label-only entry, while the
+// picker has the model's full capability metadata. Neither completion is
+// allowed to downgrade the other.
+test.each(["pane response first", "picker response first"] as const)(
+  "the Effort select keeps the picked model's own ladder when the pane-level catalog enrichment failed (%s)",
+  async (completionOrder) => {
+    vi.useFakeTimers();
+    const models = [
+      {
+        provider: "openai",
+        model: "gpt-5",
+        supports_reasoning: true,
+        reasoning_effort_levels: ["minimal", "low", "medium", "high", "xhigh", "max"],
+      },
+    ];
+    const requests: Array<{ promise: Promise<Response>; resolve: (response: Response) => void }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (url.startsWith("/api/git/head")) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ branch: "main" }),
+          } as Response);
         }
-        return Promise.resolve({
-          ok: true,
-          status: 200,
-          json: () => Promise.resolve({ models, recent: [], diagnostics: [] }),
-        } as Response);
-      }
-      return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) } as Response);
-    }),
-  );
-  renderSpawn(readyClient());
-  await settled();
+        if (url.startsWith("/api/models")) {
+          let resolve!: (response: Response) => void;
+          const promise = new Promise<Response>((done) => {
+            resolve = done;
+          });
+          requests.push({ promise, resolve });
+          return promise;
+        }
+        return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) } as Response);
+      }),
+    );
+    try {
+      renderSpawn(readyClient());
 
-  await pickModel(user, "gpt-5", "openai/gpt-5");
-  // The picker had the model's own ladder; the Effort select must show it too
-  // immediately, not the generic fallback - the picker already loaded the
-  // entry with reasoningEffortLevels and must not discard that metadata.
-  expect(effortOptionLabels()).toEqual(["(default)", "minimal", "low", "medium", "high", "xhigh", "max", "none"]);
-});
+      if (completionOrder === "pane response first") {
+        vi.runOnlyPendingTimers();
+        expect(requests).toHaveLength(1);
+        fireEvent.click(modelTrigger());
+        expect(screen.getByRole("combobox", { name: "Model" })).toBeTruthy();
+        expect(requests).toHaveLength(2);
+      } else {
+        fireEvent.click(modelTrigger());
+        expect(screen.getByRole("combobox", { name: "Model" })).toBeTruthy();
+        expect(requests).toHaveLength(1);
+        vi.runOnlyPendingTimers();
+        expect(requests).toHaveLength(2);
+      }
+
+      const paneRequest = completionOrder === "pane response first" ? requests[0] : requests[1];
+      const pickerRequest = completionOrder === "pane response first" ? requests[1] : requests[0];
+      if (paneRequest === undefined || pickerRequest === undefined)
+        throw new Error("catalog request barrier was not reached");
+      const paneFallback = { ok: false, status: 502, json: () => Promise.resolve({}) } as Response;
+      const pickerCatalog = {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ models, recent: [], diagnostics: [] }),
+      } as Response;
+
+      if (completionOrder === "pane response first") {
+        await act(async () => {
+          paneRequest.resolve(paneFallback);
+          await paneRequest.promise;
+        });
+        await act(async () => {
+          pickerRequest.resolve(pickerCatalog);
+          await pickerRequest.promise;
+        });
+      } else {
+        await act(async () => {
+          pickerRequest.resolve(pickerCatalog);
+          await pickerRequest.promise;
+        });
+      }
+
+      const combo = screen.getByRole("combobox", { name: "Model" });
+      fireEvent.change(combo, { target: { value: "gpt-5" } });
+      fireEvent.click(screen.getByText("openai/gpt-5"));
+
+      if (completionOrder === "picker response first") {
+        await act(async () => {
+          paneRequest.resolve(paneFallback);
+          await paneRequest.promise;
+        });
+      }
+
+      expect(effortOptionLabels()).toEqual(["(default)", "minimal", "low", "medium", "high", "xhigh", "max", "none"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  },
+);
 
 // --- post-success reset (floor §1.14 L186, wave6-report.md gap) -----------
 //

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -1071,10 +1071,10 @@ function effortSelect(): HTMLSelectElement {
   return screen.getByLabelText("Effort") as HTMLSelectElement;
 }
 
-function effortOptionLabels(): string[] {
+function effortOptionValues(): string[] {
   return within(effortSelect())
     .getAllByRole("option")
-    .map((option) => option.textContent ?? "");
+    .map((option) => (option as HTMLOptionElement).value);
 }
 
 async function pickModel(user: ReturnType<typeof userEvent.setup>, query: string, qualified: string): Promise<void> {
@@ -1108,14 +1108,14 @@ test("the Effort select offers the selected model's own ladder and re-derives it
 
   await pickModel(user, "gpt-5", "openai/gpt-5");
   await waitFor(() =>
-    expect(effortOptionLabels()).toEqual(["(default)", "minimal", "low", "medium", "high", "xhigh", "max", "none"]),
+    expect(effortOptionValues()).toEqual(["", "minimal", "low", "medium", "high", "xhigh", "max", "none"]),
   );
 
   // A chosen level the next model's ladder doesn't name can't stay selected -
   // the select must never display a value it doesn't offer.
   await user.selectOptions(effortSelect(), "xhigh");
   await pickModel(user, "sonnet", "anthropic/claude-sonnet-4-5");
-  await waitFor(() => expect(effortOptionLabels()).toEqual(["(default)", "low", "medium", "high", "none"]));
+  await waitFor(() => expect(effortOptionValues()).toEqual(["", "low", "medium", "high", "none"]));
   expect(effortSelect().value).toBe("");
 });
 
@@ -1134,7 +1134,7 @@ test("a model the catalog says cannot reason disables the Effort select and clea
   await settled();
 
   await pickModel(user, "sonnet", "anthropic/claude-sonnet-4-5");
-  await waitFor(() => expect(effortOptionLabels()).toEqual(["(default)", "low", "medium", "high", "none"]));
+  await waitFor(() => expect(effortOptionValues()).toEqual(["", "low", "medium", "high", "none"]));
   await user.selectOptions(effortSelect(), "high");
 
   await pickModel(user, "gpt-5", "openai/gpt-5");
@@ -1170,7 +1170,7 @@ test("with Model left at '(default)', the Effort select follows the hub's resolv
   // fallback doesn't preselect it - Model stays "(default)" and the ladder
   // still has to be gpt-5's own.
   expect(modelTrigger().textContent).toContain("(default)");
-  await waitFor(() => expect(effortOptionLabels()).toEqual(["(default)", "low", "high", "none"]));
+  await waitFor(() => expect(effortOptionValues()).toEqual(["", "low", "high", "none"]));
 });
 
 test("the classic ladder remains when the hub can't enumerate the model's own levels", async () => {
@@ -1181,7 +1181,7 @@ test("the classic ladder remains when the hub can't enumerate the model's own le
   await settled();
 
   await pickModel(user, "gpt-5", "openai/gpt-5");
-  await waitFor(() => expect(effortOptionLabels()).toEqual(["(default)", "minimal", "low", "medium", "high", "none"]));
+  await waitFor(() => expect(effortOptionValues()).toEqual(["", "minimal", "low", "medium", "high", "none"]));
 });
 
 // The pane-level modelCatalog (the Effort select's source of
@@ -1279,7 +1279,7 @@ test.each(["pane response first", "picker response first"] as const)(
         });
       }
 
-      expect(effortOptionLabels()).toEqual(["(default)", "minimal", "low", "medium", "high", "xhigh", "max", "none"]);
+      expect(effortOptionValues()).toEqual(["", "minimal", "low", "medium", "high", "xhigh", "max", "none"]);
     } finally {
       vi.useRealTimers();
     }
@@ -1717,14 +1717,14 @@ test("an effort the fallback ladder cannot name is still offered, not silently s
   await settled();
 
   await pickModel(user, "gpt-5", "openai/gpt-5");
-  await waitFor(() => expect(effortOptionLabels()).toContain("xhigh"));
+  await waitFor(() => expect(effortOptionValues()).toContain("xhigh"));
   await user.selectOptions(effortSelect(), "xhigh");
 
   await pickModel(user, "sonnet", "anthropic/claude-sonnet-4-5");
   // The fallback ladder took over (it starts at "minimal", the real one did
   // not) and still offers the preserved level, because state still holds it.
-  await waitFor(() => expect(effortOptionLabels()).toContain("minimal"));
-  expect(effortOptionLabels()).toContain("xhigh");
+  await waitFor(() => expect(effortOptionValues()).toContain("minimal"));
+  expect(effortOptionValues()).toContain("xhigh");
 
   const displayed = effortSelect().value;
   expect(displayed).toBe("xhigh");

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -42,7 +42,7 @@ import { CloseIcon } from "../../widgets/dialog/CloseIcon";
 import { requireClass } from "../../widgets/internal/requireClass";
 import type { ModelCatalog, ModelCatalogEntry } from "../../widgets/modelCatalog";
 import { fetchModelCatalog } from "../../widgets/modelCatalog/catalogClient";
-import { mergeScopedCatalog } from "../../widgets/modelCatalog/scopedCatalog";
+import { mergeCatalogEntry, mergeCatalogSnapshot, mergeScopedCatalog } from "../../widgets/modelCatalog/scopedCatalog";
 import { ModelSwitchTrigger } from "../session/chrome/ModelSwitchTrigger";
 import { AttachmentTile } from "../session/composer/AttachmentTile";
 import { AttachIcon } from "../session/composer/attachments/AttachIcon";
@@ -380,7 +380,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     const settle = setTimeout(() => {
       loadCatalog().then(
         (catalog) => {
-          if (active) setModelCatalog(catalog);
+          if (active) setModelCatalog((previous) => mergeCatalogSnapshot(previous, catalog));
         },
         () => {},
       );
@@ -548,10 +548,8 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
       const key = `${entry.provider}/${entry.model}`;
       const idx = models.findIndex((m) => `${m.provider}/${m.model}` === key);
       if (idx >= 0) {
-        // Replace the existing entry (which may be label-only from a failed
-        // enrichment) with the picker's fully-enriched one.
         const nextModels = [...models];
-        nextModels[idx] = entry;
+        nextModels[idx] = mergeCatalogEntry(nextModels[idx], entry);
         return { models: nextModels, recent, diagnostics };
       }
       return { models: [...models, entry], recent, diagnostics };

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.test.ts
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.test.ts
@@ -3,7 +3,7 @@
 import { describe, expect, test } from "vitest";
 import type { ModelDescriptor } from "../../protocol/types.gen";
 import type { ModelCatalog } from "./index";
-import { mergeScopedCatalog } from "./scopedCatalog";
+import { mergeCatalogEntry, mergeCatalogSnapshot, mergeScopedCatalog } from "./scopedCatalog";
 
 const SCOPED: ModelDescriptor[] = [
   { provider: "anthropic", model: "claude-sonnet-4-5" },
@@ -83,5 +83,59 @@ describe("mergeScopedCatalog", () => {
       null,
     );
     expect(merged.models).toEqual([{ provider: "openai", model: "gpt-5", displayName: "" }]);
+  });
+
+  test("does not let a label-only response downgrade richer capabilities", () => {
+    const rich = {
+      provider: "openai",
+      model: "gpt-5",
+      displayName: "GPT-5",
+      supportsReasoning: true,
+      reasoningEffortLevels: ["minimal", "high", "max"],
+    };
+    const fallback = { provider: "openai", model: "gpt-5", displayName: "" };
+
+    expect(mergeCatalogEntry(rich, fallback)).toEqual(rich);
+    expect(mergeCatalogSnapshot({ models: [rich], recent: [] }, { models: [fallback], recent: [] }).models).toEqual([
+      rich,
+    ]);
+  });
+
+  test("applies a richer later response without changing its model identity", () => {
+    const existing = { provider: "openai", model: "gpt-5", displayName: "GPT-5" };
+    const richer = {
+      provider: "openai",
+      model: "gpt-5",
+      displayName: "GPT-5 reasoning",
+      supportsReasoning: true,
+      reasoningEffortLevels: ["low", "high"],
+    };
+
+    expect(mergeCatalogEntry(existing, richer)).toEqual(richer);
+  });
+
+  test("applies an explicit non-reasoning update instead of retaining stale levels", () => {
+    const existing = {
+      provider: "openai",
+      model: "gpt-5",
+      displayName: "GPT-5",
+      supportsReasoning: true,
+      reasoningEffortLevels: ["low", "high"],
+    };
+
+    expect(
+      mergeCatalogEntry(existing, {
+        provider: "openai",
+        model: "gpt-5",
+        displayName: "GPT-5",
+        supportsReasoning: false,
+      }),
+    ).toEqual({
+      provider: "openai",
+      model: "gpt-5",
+      displayName: "GPT-5",
+      supportsReasoning: false,
+      reasoningEffortLevels: [],
+    });
   });
 });

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.test.ts
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.test.ts
@@ -114,6 +114,73 @@ describe("mergeScopedCatalog", () => {
     expect(mergeCatalogEntry(existing, richer)).toEqual(richer);
   });
 
+  test("does not merge entries with different providers", () => {
+    const existing = {
+      provider: "openai",
+      model: "gpt-5",
+      displayName: "GPT-5",
+      supportsReasoning: true,
+    };
+    const incoming = {
+      provider: "anthropic",
+      model: "gpt-5",
+      displayName: "Claude",
+      supportsVision: true,
+    };
+
+    expect(mergeCatalogEntry(existing, incoming)).toEqual(incoming);
+  });
+
+  test("does not merge entries with different models", () => {
+    const existing = {
+      provider: "openai",
+      model: "gpt-5",
+      displayName: "GPT-5",
+      supportsReasoning: true,
+    };
+    const incoming = {
+      provider: "openai",
+      model: "gpt-5-mini",
+      displayName: "GPT-5 mini",
+      supportsVision: true,
+    };
+
+    expect(mergeCatalogEntry(existing, incoming)).toEqual(incoming);
+  });
+
+  test("applies explicit false and zero updates instead of treating them as missing", () => {
+    const existing = {
+      provider: "openai",
+      model: "gpt-5",
+      displayName: "GPT-5",
+      contextWindow: 128000,
+      supportsTools: true,
+      supportsVision: true,
+      maxOutputTokens: 16384,
+      supportsWebSearch: true,
+      supportsReasoning: true,
+      inputCostPerMillion: 3,
+      outputCostPerMillion: 15,
+      reasoningEffortLevels: ["low", "high"],
+    };
+    const incoming = {
+      provider: "openai",
+      model: "gpt-5",
+      displayName: "GPT-5",
+      contextWindow: 0,
+      supportsTools: false,
+      supportsVision: false,
+      maxOutputTokens: 0,
+      supportsWebSearch: false,
+      supportsReasoning: false,
+      inputCostPerMillion: 0,
+      outputCostPerMillion: 0,
+      reasoningEffortLevels: [],
+    };
+
+    expect(mergeCatalogEntry(existing, incoming)).toEqual(incoming);
+  });
+
   test("applies an explicit non-reasoning update instead of retaining stale levels", () => {
     const existing = {
       provider: "openai",

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.ts
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.ts
@@ -14,16 +14,19 @@ function key(provider: string, model: string): string {
   return `${provider}/${model}`;
 }
 
-// Catalog responses can arrive from more than one loader. Keep the stable
-// provider/model identity from the existing entry, and only let the incoming
-// response replace fields it actually knows. In particular, a scoped-list
-// fallback has displayName === "" and no capability fields; it must not erase
-// metadata a picker or an earlier enrichment already supplied.
+// Catalog responses can arrive from more than one loader. Entries are only
+// mergeable when their provider/model identities match; callers that merge
+// independently loaded catalogs must never create a hybrid identity. For a
+// same-identity merge, only let the incoming response replace fields it
+// actually knows. In particular, a scoped-list fallback has displayName === ""
+// and no capability fields; it must not erase metadata a picker or an earlier
+// enrichment already supplied.
 export function mergeCatalogEntry(
   existing: ModelCatalogEntry | undefined,
   incoming: ModelCatalogEntry,
 ): ModelCatalogEntry {
   if (existing === undefined) return incoming;
+  if (existing.provider !== incoming.provider || existing.model !== incoming.model) return incoming;
 
   const merged: ModelCatalogEntry = { ...existing };
   if (incoming.displayName !== "") merged.displayName = incoming.displayName;
@@ -47,7 +50,7 @@ export function mergeCatalogEntry(
     merged.reasoningEffortLevels = [];
   }
 
-  return { ...merged, provider: existing.provider, model: existing.model };
+  return merged;
 }
 
 // Apply a later catalog snapshot without allowing a less-informed snapshot to

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.ts
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.ts
@@ -14,6 +14,55 @@ function key(provider: string, model: string): string {
   return `${provider}/${model}`;
 }
 
+// Catalog responses can arrive from more than one loader. Keep the stable
+// provider/model identity from the existing entry, and only let the incoming
+// response replace fields it actually knows. In particular, a scoped-list
+// fallback has displayName === "" and no capability fields; it must not erase
+// metadata a picker or an earlier enrichment already supplied.
+export function mergeCatalogEntry(
+  existing: ModelCatalogEntry | undefined,
+  incoming: ModelCatalogEntry,
+): ModelCatalogEntry {
+  if (existing === undefined) return incoming;
+
+  const merged: ModelCatalogEntry = { ...existing };
+  if (incoming.displayName !== "") merged.displayName = incoming.displayName;
+
+  const optionalFields = [
+    "contextWindow",
+    "supportsTools",
+    "supportsVision",
+    "maxOutputTokens",
+    "supportsWebSearch",
+    "supportsReasoning",
+    "inputCostPerMillion",
+    "outputCostPerMillion",
+    "reasoningEffortLevels",
+  ] as const;
+  for (const field of optionalFields) {
+    const value = incoming[field];
+    if (value !== undefined) Object.assign(merged, { [field]: value });
+  }
+  if (incoming.supportsReasoning === false && incoming.reasoningEffortLevels === undefined) {
+    merged.reasoningEffortLevels = [];
+  }
+
+  return { ...merged, provider: existing.provider, model: existing.model };
+}
+
+// Apply a later catalog snapshot without allowing a less-informed snapshot to
+// downgrade entries already visible to the pane. The incoming model set still
+// owns membership and ordering, so changing cwd/harness cannot retain stale
+// models from the previous scope.
+export function mergeCatalogSnapshot(previous: ModelCatalog | null, incoming: ModelCatalog): ModelCatalog {
+  if (previous === null) return incoming;
+  const existing = new Map(previous.models.map((entry) => [key(entry.provider, entry.model), entry]));
+  return {
+    ...incoming,
+    models: incoming.models.map((entry) => mergeCatalogEntry(existing.get(key(entry.provider, entry.model)), entry)),
+  };
+}
+
 export function mergeScopedCatalog(scoped: ModelDescriptor[], enrichment: ModelCatalog | null): ModelCatalog {
   const byKey = new Map<string, ModelCatalogEntry>();
   for (const entry of enrichment?.models ?? []) byKey.set(key(entry.provider, entry.model), entry);


### PR DESCRIPTION
## Summary

Fixes the inherited Spawn Effort-ladder ordering defect identified in the Sol integration review for [PR #405 review](https://github.com/prime-radiant-inc/evener/pull/405#pullrequestreview-5013935953).

When the pane-level debounced catalog enrichment and the model picker complete in either order, a label-only fallback could replace an already enriched entry and drop `xhigh`/`max`. Catalog snapshots and picker updates now merge monotonically by provider/model identity: known incoming fields apply, unknown fallback fields do not downgrade richer capabilities, and explicit capability updates remain authoritative.

## Regression coverage

- Barrier-controlled Spawn regressions cover pane-response-first and picker-response-first completion orderings.
- No sleeps or deadline-based behavior; fake timers only release the production debounce barrier.
- Pure catalog merge tests cover fallback preservation, richer updates, identity preservation, and explicit non-reasoning updates.

## Verification

- `npx biome check --write` on all touched `src/` files
- Focused Spawn/catalog suite: 71 passed
- Focused ordering stress: 10 successful targeted runs, plus 5 final reruns after timer-barrier refinement
- `npm run typecheck`
- `make test-web`
- `make test-web-browser`
- `make lint`
- `make lint-gofmt lint-generated`
- `make secret-scan`
- `git diff --check`

No Rail or rendezvous paths were changed.