### PR TITLE
fix(tooling): avoid SIGPIPE in help selftests

### DIFF
--- a/scripts/coverage/coverage-gaps-selftest.sh
+++ b/scripts/coverage/coverage-gaps-selftest.sh
@@ -81,11 +81,32 @@ assert_has "$out" "no such profile" "the missing profile is named"
 bash "$script" "$profile" --by bogus >"$out" 2>&1
 assert_eq "$?" "2" "an unknown --by value is a usage error"
 
+help_header_ok() {
+	local help=$1
+	[[ "$help" == Usage:* || "$help" == *$'\nUsage:'* ]] &&
+		[[ "$help" != "set -uo pipefail"* && "$help" != *$'\nset -uo pipefail'* ]]
+}
+
 help_out="$(bash "$script" --help 2>&1)"
-if echo "$help_out" | grep -q "^Usage:" && ! echo "$help_out" | grep -q "^set -uo pipefail"; then
+if help_header_ok "$help_out"; then
 	ok "--help prints the whole header and stops at the script body"
 else
 	bad "--help is truncated or overran the header: $help_out"
 fi
+
+large_help_out=$'Usage: coverage-gaps.sh [options]\n'"$(printf 'valid help documentation\n%.0s' {1..4096})"
+large_help_status=0
+help_header_ok "$large_help_out" || large_help_status=$?
+assert_eq "$large_help_status" "0" "a large valid help stream is accepted without SIGPIPE status 141"
+
+malformed_help_out=$'Usage: coverage-gaps.sh [options]\nset -uo pipefail\n'
+malformed_help_status=0
+help_header_ok "$malformed_help_out" || malformed_help_status=$?
+assert_eq "$malformed_help_status" "1" "help containing the script body marker is rejected"
+
+missing_usage_help_out=$'coverage-gaps.sh [options]\n'
+missing_usage_help_status=0
+help_header_ok "$missing_usage_help_out" || missing_usage_help_status=$?
+assert_eq "$missing_usage_help_status" "1" "help without a Usage header is rejected"
 
 selftest_summary

--- a/scripts/gate/test-timing-budget-selftest.sh
+++ b/scripts/gate/test-timing-budget-selftest.sh
@@ -136,11 +136,32 @@ printf '{"packages": {"pkgA": 10.0}}\n' >"$budget"
 TMPDIR="$work/tmp-clean" bash "$script" --no-web --budget "$budget" --measured "$measured" --check --strict >/dev/null 2>&1
 assert_eq "$(ls -A "$work/tmp-clean")" "" "a clean run leaves no scratch directory behind"
 
+help_header_ok() {
+	local help=$1
+	[[ "$help" == Usage:* || "$help" == *$'\nUsage:'* ]] &&
+		[[ "$help" != "set -uo pipefail"* && "$help" != *$'\nset -uo pipefail'* ]]
+}
+
 help_out="$(bash "$script" --help 2>&1)"
-if echo "$help_out" | grep -q "^Usage:" && ! echo "$help_out" | grep -q "^set -uo pipefail"; then
+if help_header_ok "$help_out"; then
 	ok "--help prints the whole header and stops at the script body"
 else
 	bad "--help is truncated or overran the header: $help_out"
 fi
+
+large_help_out=$'Usage: test-timing-budget.sh [options]\n'"$(printf 'valid help documentation\n%.0s' {1..4096})"
+large_help_status=0
+help_header_ok "$large_help_out" || large_help_status=$?
+assert_eq "$large_help_status" "0" "a large valid help stream is accepted without SIGPIPE status 141"
+
+malformed_help_out=$'Usage: test-timing-budget.sh [options]\nset -uo pipefail\n'
+malformed_help_status=0
+help_header_ok "$malformed_help_out" || malformed_help_status=$?
+assert_eq "$malformed_help_status" "1" "help containing the script body marker is rejected"
+
+missing_usage_help_out=$'test-timing-budget.sh [options]\n'
+missing_usage_help_status=0
+help_header_ok "$missing_usage_help_out" || missing_usage_help_status=$?
+assert_eq "$missing_usage_help_status" "1" "help without a Usage header is rejected"
 
 selftest_summary


### PR DESCRIPTION
## Summary

- Replace pipefail-sensitive captured-help pipelines with complete-value Bash pattern assertions.
- Cover large valid help streams and reject body-overrun or missing-Usage malformed help in both identical selftests.

Provenance: [PR #426 review 5014121558](https://github.com/prime-radiant-inc/evener/pull/426#pullrequest-review-5014121558)

## Verification

- `make test-timing-budget-selftest` — 39/39
- `make coverage-gaps-selftest` — 22/22
- 25 repeated Bash timing selftest runs — 0 failures
- `make test-dev-tooling` — all 12 suites pass
- `make lint` — pass (8 modules)
- `make build`, `make vet`, `ROOT_FULL=1 WEB=0 make test`, `make test-race` — pass
- `make fuzz`, `make fuzz-gap-check`, required gitleaks scans — pass
- shell syntax/checks, generated-output, and `git diff --check` — pass