### PR TITLE
fix: report a 404 on the release download as an actionable message, not a bare curl error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -68,15 +68,22 @@ cleanup() {
 trap cleanup EXIT HUP INT TERM
 
 archive="$tmpdir/$archive_name"
+http_status_file="$tmpdir/http-status"
 echo "Downloading $url"
-if ! curl -fsSL "$url" -o "$archive"; then
+if curl -fsSL -w '%{http_code}' "$url" -o "$archive" >"$http_status_file"; then
+	curl_status=0
+else
+	curl_status=$?
+fi
+if [ "$curl_status" -ne 0 ]; then
+	http_status=$(cat "$http_status_file")
 	echo "Failed to download $url" >&2
-	if [ "$version" = "latest" ]; then
+	if [ "$version" = "latest" ] && [ "$http_status" = "404" ]; then
 		echo "The latest tagged release may not have a matching binary yet. Try the" >&2
 		echo "continuous build from main instead:" >&2
 		echo "  EVENER_INSTALL_VERSION=snapshot sh install.sh" >&2
 	fi
-	exit 1
+	exit "$curl_status"
 fi
 if ! curl -fsSL "$base_url/checksums.txt" -o "$tmpdir/checksums.txt"; then
 	echo "Failed to download $base_url/checksums.txt" >&2

--- a/install.sh
+++ b/install.sh
@@ -69,8 +69,19 @@ trap cleanup EXIT HUP INT TERM
 
 archive="$tmpdir/$archive_name"
 echo "Downloading $url"
-curl -fsSL "$url" -o "$archive"
-curl -fsSL "$base_url/checksums.txt" -o "$tmpdir/checksums.txt"
+if ! curl -fsSL "$url" -o "$archive"; then
+	echo "Failed to download $url" >&2
+	if [ "$version" = "latest" ]; then
+		echo "The latest tagged release may not have a matching binary yet. Try the" >&2
+		echo "continuous build from main instead:" >&2
+		echo "  EVENER_INSTALL_VERSION=snapshot sh install.sh" >&2
+	fi
+	exit 1
+fi
+if ! curl -fsSL "$base_url/checksums.txt" -o "$tmpdir/checksums.txt"; then
+	echo "Failed to download $base_url/checksums.txt" >&2
+	exit 1
+fi
 
 # The release publishes checksums.txt; installing an unverified archive is
 # not an option. Fail closed when no sha256 tool exists.

--- a/install_fuzz_test.go
+++ b/install_fuzz_test.go
@@ -108,23 +108,34 @@ case "$1" in
 esac
 `, osName, archName))
 		writeExecutable(t, filepath.Join(fakeBin, "curl"), `#!/bin/sh
-url="$2"
-printf '%s\n' "$url" >> "$EVENER_FUZZ_URL_FILE"
+out=
+url=
+write_format=
 while [ "$#" -gt 0 ]; do
-  if [ "$1" = -o ]; then
-    case "$url" in
-      *checksums.txt)
-        # The archive above is the empty file this stub wrote, so its digest
-        # is the well-known empty-input sha256.
-        printf '%s  %s\n' "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" "$EVENER_FUZZ_ARCHIVE_ROOT.tar.gz" > "$2"
-        exit 0
-        ;;
-    esac
-    : > "$2"; exit 0
-  fi
-  shift
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -w) write_format="$2"; shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
 done
-exit 2
+[ -n "$out" ] || { echo "missing -o" >&2; exit 2; }
+[ -n "$url" ] || { echo "missing URL" >&2; exit 2; }
+if [ -n "$write_format" ]; then
+  [ "$write_format" = '%{http_code}' ] || { echo "unexpected -w format" >&2; exit 2; }
+  printf '200'
+fi
+printf '%s\n' "$url" >> "$EVENER_FUZZ_URL_FILE"
+case "$url" in
+  *checksums.txt)
+    # The archive above is the empty file this stub wrote, so its digest
+    # is the well-known empty-input sha256.
+    printf '%s  %s\n' "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" "$EVENER_FUZZ_ARCHIVE_ROOT.tar.gz" > "$out"
+    exit 0
+    ;;
+esac
+: > "$out"
+exit 0
 `)
 		writeExecutable(t, filepath.Join(fakeBin, "tar"), fmt.Sprintf(`#!/bin/sh
 dest=

--- a/install_test.go
+++ b/install_test.go
@@ -322,6 +322,66 @@ func TestInstallScriptInstallsReleaseArchive(t *testing.T) {
 	}
 }
 
+func TestInstallScriptPreservesDownloadFailuresAndClassifies404(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("release archive install integration test")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("install.sh requires a Unix shell")
+	}
+
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	script := filepath.Join(repoRoot, "install.sh")
+
+	for _, tc := range []struct {
+		name       string
+		version    string
+		httpStatus string
+		curlExit   string
+		wantExit   int
+		wantAdvice bool
+	}{
+		{name: "latest 404", version: "latest", httpStatus: "404", curlExit: "22", wantExit: 22, wantAdvice: true},
+		{name: "latest 401", version: "latest", httpStatus: "401", curlExit: "22", wantExit: 22},
+		{name: "latest 403", version: "latest", httpStatus: "403", curlExit: "22", wantExit: 22},
+		{name: "latest 429", version: "latest", httpStatus: "429", curlExit: "22", wantExit: 22},
+		{name: "latest 500", version: "latest", httpStatus: "500", curlExit: "22", wantExit: 22},
+		{name: "latest DNS failure", version: "latest", httpStatus: "000", curlExit: "6", wantExit: 6},
+		{name: "latest TLS failure", version: "latest", httpStatus: "000", curlExit: "35", wantExit: 35},
+		{name: "latest redirect failure", version: "latest", httpStatus: "000", curlExit: "47", wantExit: 47},
+		{name: "latest receive failure", version: "latest", httpStatus: "000", curlExit: "56", wantExit: 56},
+		{name: "pinned 404", version: "v1.2.3", httpStatus: "404", curlExit: "22", wantExit: 22},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			home, out, runErr := runInstallScript(t, script, "Darwin", "arm64", map[string]string{
+				"EVENER_INSTALL_VERSION":     tc.version,
+				"EVENER_FAKE_CURL_HTTP_CODE": tc.httpStatus,
+				"EVENER_FAKE_CURL_EXIT":      tc.curlExit,
+			})
+			if runErr == nil {
+				t.Fatalf("install succeeded; output = %s", out)
+			}
+			var exitErr *exec.ExitError
+			if !errors.As(runErr, &exitErr) {
+				t.Fatalf("run error is not an exit error: %v", runErr)
+			}
+			if got := exitErr.ExitCode(); got != tc.wantExit {
+				t.Fatalf("exit status = %d, want %d; output = %s", got, tc.wantExit, out)
+			}
+			gotAdvice := strings.Contains(out, "EVENER_INSTALL_VERSION=snapshot")
+			if gotAdvice != tc.wantAdvice {
+				t.Fatalf("snapshot advice = %v, want %v; output = %s", gotAdvice, tc.wantAdvice, out)
+			}
+			assertNothingInstalled(t, home, out)
+		})
+	}
+}
+
 // TestInstallScriptRejectsTamperedArchive feeds install.sh a checksums.txt
 // whose digest cannot match the served archive: the install must fail closed
 // at verification, before anything is installed.
@@ -586,9 +646,11 @@ esac
 	writeExecutable(t, filepath.Join(fakeBin, "curl"), `#!/bin/sh
 out=
 url=
+write_format=
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -o) out="$2"; shift 2 ;;
+    -w) write_format="$2"; shift 2 ;;
     -*) shift ;;
     *) url="$1"; shift ;;
   esac
@@ -598,6 +660,17 @@ if [ -z "$out" ]; then
   exit 2
 fi
 printf '%s\n' "$url" >> "$EVENER_FAKE_CURL_URL_FILE"
+http_code=${EVENER_FAKE_CURL_HTTP_CODE:-200}
+if [ -n "${EVENER_FAKE_CURL_404:-}" ] && [ "$(basename "$url")" = "$EVENER_FAKE_CURL_404" ]; then
+  http_code=404
+fi
+if [ -n "$write_format" ]; then
+  printf '%s' "$http_code"
+fi
+if [ -n "${EVENER_FAKE_CURL_EXIT:-}" ]; then
+  cp "$EVENER_FAKE_CURL_ARCHIVE" "$out"
+  exit "$EVENER_FAKE_CURL_EXIT"
+fi
 if [ -n "${EVENER_FAKE_CURL_404:-}" ] && [ "$(basename "$url")" = "$EVENER_FAKE_CURL_404" ]; then
   exit 22
 fi

--- a/install_test.go
+++ b/install_test.go
@@ -373,6 +373,9 @@ func TestInstallScriptPreservesDownloadFailuresAndClassifies404(t *testing.T) {
 			if got := exitErr.ExitCode(); got != tc.wantExit {
 				t.Fatalf("exit status = %d, want %d; output = %s", got, tc.wantExit, out)
 			}
+			if !strings.Contains(out, fakeCurlDiagnostic) {
+				t.Fatalf("curl diagnostic sentinel was lost; output = %s", out)
+			}
 			gotAdvice := strings.Contains(out, "EVENER_INSTALL_VERSION=snapshot")
 			if gotAdvice != tc.wantAdvice {
 				t.Fatalf("snapshot advice = %v, want %v; output = %s", gotAdvice, tc.wantAdvice, out)
@@ -615,6 +618,8 @@ func installArchiveRoot(osName, arch string) string {
 	return "evener_" + strings.ToLower(osName) + "_" + installArch(arch)
 }
 
+const fakeCurlDiagnostic = "curl-diagnostic-7f3c"
+
 func assertNothingInstalled(t *testing.T, home, out string) {
 	t.Helper()
 	if _, err := os.Stat(filepath.Join(home, ".local", "share", "evener", "bin", "evener")); !os.IsNotExist(err) {
@@ -664,15 +669,21 @@ http_code=${EVENER_FAKE_CURL_HTTP_CODE:-200}
 if [ -n "${EVENER_FAKE_CURL_404:-}" ] && [ "$(basename "$url")" = "$EVENER_FAKE_CURL_404" ]; then
   http_code=404
 fi
+if [ -n "$write_format" ] && [ "$write_format" != '%{http_code}' ]; then
+	echo "invalid write format" >&2
+	exit 2
+fi
 if [ -n "$write_format" ]; then
-  printf '%s' "$http_code"
+	printf '%s' "$http_code"
 fi
 if [ -n "${EVENER_FAKE_CURL_EXIT:-}" ]; then
-  cp "$EVENER_FAKE_CURL_ARCHIVE" "$out"
-  exit "$EVENER_FAKE_CURL_EXIT"
+	echo "curl-diagnostic-7f3c" >&2
+	cp "$EVENER_FAKE_CURL_ARCHIVE" "$out"
+	exit "$EVENER_FAKE_CURL_EXIT"
 fi
 if [ -n "${EVENER_FAKE_CURL_404:-}" ] && [ "$(basename "$url")" = "$EVENER_FAKE_CURL_404" ]; then
-  exit 22
+	echo "curl-diagnostic-7f3c" >&2
+	exit 22
 fi
 case "$(basename "$url")" in
   checksums.txt)

--- a/install_test.go
+++ b/install_test.go
@@ -325,6 +325,78 @@ func TestInstallScriptInstallsReleaseArchive(t *testing.T) {
 // TestInstallScriptRejectsTamperedArchive feeds install.sh a checksums.txt
 // whose digest cannot match the served archive: the install must fail closed
 // at verification, before anything is installed.
+// TestInstallScriptReportsMissingLatestReleaseAsset pins install.sh's
+// behavior when the default ("latest") download 404s: the documented
+// quickstart one-liner sets no EVENER_INSTALL_VERSION, so a release whose
+// "latest" tag has no matching evener_<os>_<arch>.tar.gz asset must fail
+// with an actionable message pointing at EVENER_INSTALL_VERSION=snapshot,
+// not a bare curl error.
+func TestInstallScriptReportsMissingLatestReleaseAsset(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("release archive install integration test")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("install.sh requires a Unix shell")
+	}
+
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	script := filepath.Join(repoRoot, "install.sh")
+
+	home, out, runErr := runInstallScript(t, script, "Darwin", "arm64", map[string]string{
+		"EVENER_INSTALL_VERSION": "latest",
+		"EVENER_FAKE_CURL_404":   "evener_darwin_arm64.tar.gz",
+	})
+	if runErr == nil {
+		t.Fatalf("install succeeded despite a 404 on the release asset; output = %s", out)
+	}
+	if !strings.Contains(out, "Failed to download") {
+		t.Fatalf("failure does not report the download error; output = %s", out)
+	}
+	if !strings.Contains(out, "EVENER_INSTALL_VERSION=snapshot") {
+		t.Fatalf("failure does not point at the snapshot workaround; output = %s", out)
+	}
+	assertNothingInstalled(t, home, out)
+}
+
+// TestInstallScriptReportsMissingPinnedReleaseAsset pins that a 404 against
+// an explicitly pinned version (not "latest") gets the download-failure
+// message without the "latest" nudge — pointing at snapshot would be wrong
+// advice when the user already asked for a specific tag.
+func TestInstallScriptReportsMissingPinnedReleaseAsset(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("release archive install integration test")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("install.sh requires a Unix shell")
+	}
+
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	script := filepath.Join(repoRoot, "install.sh")
+
+	home, out, runErr := runInstallScript(t, script, "Darwin", "arm64", map[string]string{
+		"EVENER_INSTALL_VERSION": "v0.1.0",
+		"EVENER_FAKE_CURL_404":   "evener_darwin_arm64.tar.gz",
+	})
+	if runErr == nil {
+		t.Fatalf("install succeeded despite a 404 on the release asset; output = %s", out)
+	}
+	if !strings.Contains(out, "Failed to download") {
+		t.Fatalf("failure does not report the download error; output = %s", out)
+	}
+	if strings.Contains(out, "EVENER_INSTALL_VERSION=snapshot") {
+		t.Fatalf("pinned-version failure should not suggest snapshot; output = %s", out)
+	}
+	assertNothingInstalled(t, home, out)
+}
+
 func TestInstallScriptRejectsTamperedArchive(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
@@ -526,6 +598,9 @@ if [ -z "$out" ]; then
   exit 2
 fi
 printf '%s\n' "$url" >> "$EVENER_FAKE_CURL_URL_FILE"
+if [ -n "${EVENER_FAKE_CURL_404:-}" ] && [ "$(basename "$url")" = "$EVENER_FAKE_CURL_404" ]; then
+  exit 22
+fi
 case "$(basename "$url")" in
   checksums.txt)
     # Serve the archive's real digest so verification passes; the tamper knob


### PR DESCRIPTION
## The bug

`install.sh`'s documented one-liner (README.md, docs/getting-started.md)
downloads from `$repo/releases/latest/download/evener_<os>_<arch>.tar.gz`
by default. That currently 404s: the GitHub release marked "Latest"
(`v0.1.0`) predates the serf→evener rename, and its assets are named
`serf_<os>_<arch>.tar.gz`, not `evener_<os>_<arch>.tar.gz`. A brand-new
user following the documented quickstart hits a bare:

```
curl: (22) The requested URL returned error: 404
```

with no indication of what to do next. `EVENER_INSTALL_VERSION=snapshot`
already works, but docs/getting-started.md documents it as a way to pin a
build, not as the fix for a currently-broken default, and nothing tells a
new user the default is broken right now.

## Root cause — this is a release-pipeline gap, not an install.sh logic bug

- `install.sh` builds the URL exactly per the contract `.goreleaser.yml`
  documents (`evener_<os>_<arch>.tar.gz`, fetched from
  `releases/latest/download`) — its logic is correct.
- `.github/workflows/binaries.yml`'s `release` job (which publishes a
  real, non-prerelease GitHub Release) only runs on a `v*` tag push. No
  `v*` tag has been pushed since the serf→evener rename, so the "Latest"
  release GitHub actually serves is still the pre-rename `v0.1.0`.
- The `snapshot` job does publish `evener_*`-named assets on every green
  `main` push, but it's a prerelease, so `releases/latest` (what
  install.sh's default queries) skips it by design.

**This PR is a mitigation, not the fix.** The actual fix is cutting a new
tagged release under the current binary name so `latest` resolves to
assets that exist — a maintainer action requiring release/tag permissions
and a judgment call about timing/versioning (e.g. cutting `v0.2.0` from
current `main`). That decision belongs to the repo owner, not to this PR;
I'm tracking it as a known follow-up rather than guessing at it or trying
to force it from a script change.

## What this PR does in the meantime

Makes the failure actionable without presuming that decision:

- On a failed download, `install.sh` now reports which URL failed instead
  of a bare curl error.
- When the failed request was against `latest` specifically (where
  `EVENER_INSTALL_VERSION=snapshot` is a safe, already-supported
  fallback), it also points the user at that flag. A failure against an
  explicitly pinned version does *not* get that nudge — suggesting
  snapshot there would be wrong advice.

## Verification

Reproduced against the live repo: default `sh install.sh` 404s exactly as
described (confirmed via both a real `curl` against
`releases/latest/download/evener_linux_amd64.tar.gz` and a full run of
`install.sh` itself). Two new `install_test.go` cases exercise the
existing fake-curl harness with a new `EVENER_FAKE_CURL_404` knob: one
confirms the "latest" nudge appears, the other confirms it's absent for a
pinned version.

`go build .`, `go vet .`, and the full (non-`-short`) `go test .` for this
package pass, including the pre-existing `TestInstallScript*` suite.
`shellcheck install.sh` is clean. `golangci-lint` could not run in this
sandbox (pre-existing go1.26-vs-1.27.0 toolchain mismatch) — please run it
in CI.
