### PR TITLE
test(llm): make provider adapter tests load-safe under -race

### DIFF
--- a/llm/providers/anthropic/adapter_test.go
+++ b/llm/providers/anthropic/adapter_test.go
@@ -18,6 +18,22 @@ import (
 	"primeradiant.com/evener/llm"
 )
 
+type controlledStreamDeadlineContext struct {
+	context.Context
+	done <-chan struct{}
+}
+
+func (c controlledStreamDeadlineContext) Done() <-chan struct{} { return c.done }
+
+func (c controlledStreamDeadlineContext) Err() error {
+	select {
+	case <-c.done:
+		return context.DeadlineExceeded
+	default:
+		return nil
+	}
+}
+
 func TestAdapter_Complete_MapsToMessagesAPI_AndSetsBetaHeaders(t *testing.T) {
 	var gotBody map[string]any
 	gotBeta := ""
@@ -46,9 +62,9 @@ func TestAdapter_Complete_MapsToMessagesAPI_AndSetsBetaHeaders(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	// t.Context is the outer test timeout/tripwire. The handler entry channel
-	// is the synchronization boundary, so this test does not use a
-	// load-sensitive request deadline.
+	// Handler entry is the synchronization boundary. t.Context provides
+	// lifecycle cancellation only; the runner's -timeout remains the independent
+	// process tripwire.
 	result := make(chan struct {
 		resp llm.Response
 		err  error
@@ -74,12 +90,23 @@ func TestAdapter_Complete_MapsToMessagesAPI_AndSetsBetaHeaders(t *testing.T) {
 			err  error
 		}{resp: resp, err: err}
 	}()
+	var out struct {
+		resp llm.Response
+		err  error
+	}
 	select {
 	case <-requestStarted:
+		out = <-result
+	case out = <-result:
+		select {
+		case <-requestStarted:
+			// Handler entry was already observable; completion raced this select.
+		default:
+			t.Fatalf("Complete returned before handler received request: response=%#v error=%v", out.resp, out.err)
+		}
 	case <-t.Context().Done():
 		t.Fatalf("test context canceled before handler received request: %v", t.Context().Err())
 	}
-	out := <-result
 	resp, err := out.resp, out.err
 	if err != nil {
 		t.Fatalf("Complete: %v", err)
@@ -1267,6 +1294,7 @@ func TestAdapter_PromptCaching_AutomaticCaching(t *testing.T) {
 }
 
 func TestAdapter_Stream_ContextDeadline_EmitsRequestTimeoutError(t *testing.T) {
+	headersFlushed := make(chan error, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/v1/messages" {
 			w.WriteHeader(http.StatusNotFound)
@@ -1274,22 +1302,30 @@ func TestAdapter_Stream_ContextDeadline_EmitsRequestTimeoutError(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
-		if f, ok := w.(http.Flusher); ok {
-			f.Flush()
+		f, ok := w.(http.Flusher)
+		if !ok {
+			headersFlushed <- errors.New("response writer does not support flushing")
+			return
 		}
+		f.Flush()
+		headersFlushed <- nil
 		<-r.Context().Done()
 	}))
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
+	deadline := make(chan struct{})
+	ctx := controlledStreamDeadlineContext{Context: context.Background(), done: deadline}
 
 	st, err := a.Stream(ctx, llm.Request{Model: "claude-test", Messages: []llm.Message{llm.User("hi")}})
 	if err != nil {
 		t.Fatalf("Stream: %v", err)
 	}
 	defer st.Close() //nolint:errcheck
+	if err := <-headersFlushed; err != nil {
+		t.Fatal(err)
+	}
+	close(deadline)
 
 	var sawErr error
 	for ev := range st.Events() {

--- a/llm/providers/anthropic/adapter_test.go
+++ b/llm/providers/anthropic/adapter_test.go
@@ -21,8 +21,10 @@ import (
 func TestAdapter_Complete_MapsToMessagesAPI_AndSetsBetaHeaders(t *testing.T) {
 	var gotBody map[string]any
 	gotBeta := ""
+	requestStarted := make(chan struct{})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
 		if r.Method != http.MethodPost || r.URL.Path != "/v1/messages" {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -44,24 +46,41 @@ func TestAdapter_Complete_MapsToMessagesAPI_AndSetsBetaHeaders(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	resp, err := a.Complete(ctx, llm.Request{
-		Model: "claude-test",
-		Messages: []llm.Message{
-			llm.System("sys"),
-			llm.Developer("dev"),
-			llm.User("u1"),
-			llm.Assistant("a1"),
-			llm.ToolResultNamed("call1", "shell", "ok", false),
-		},
-		ProviderOptions: map[string]any{
-			"anthropic": map[string]any{
-				"beta_headers": "prompt-caching-2024-07-31",
+	// t.Context is the outer test timeout/tripwire. The handler entry channel
+	// is the synchronization boundary, so this test does not use a
+	// load-sensitive request deadline.
+	result := make(chan struct {
+		resp llm.Response
+		err  error
+	}, 1)
+	go func() {
+		resp, err := a.Complete(t.Context(), llm.Request{
+			Model: "claude-test",
+			Messages: []llm.Message{
+				llm.System("sys"),
+				llm.Developer("dev"),
+				llm.User("u1"),
+				llm.Assistant("a1"),
+				llm.ToolResultNamed("call1", "shell", "ok", false),
 			},
-		},
-	})
+			ProviderOptions: map[string]any{
+				"anthropic": map[string]any{
+					"beta_headers": "prompt-caching-2024-07-31",
+				},
+			},
+		})
+		result <- struct {
+			resp llm.Response
+			err  error
+		}{resp: resp, err: err}
+	}()
+	select {
+	case <-requestStarted:
+	case <-t.Context().Done():
+		t.Fatalf("test context canceled before handler received request: %v", t.Context().Err())
+	}
+	out := <-result
+	resp, err := out.resp, out.err
 	if err != nil {
 		t.Fatalf("Complete: %v", err)
 	}
@@ -211,8 +230,7 @@ func TestAdapter_Complete_HTTPErrorMapping_AuthenticationError(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	_, err := a.Complete(ctx, llm.Request{Model: "claude-test", Messages: []llm.Message{llm.User("hi")}})
 	if err == nil {
@@ -252,8 +270,7 @@ func TestAdapter_CountInputTokens_UsesMessagesCountTokensAPI(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	got, err := a.CountInputTokens(ctx, llm.Request{
 		Model: "claude-test",
@@ -305,8 +322,7 @@ func TestAdapter_CountInputTokens_HTTPErrorMapping(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	_, err := a.CountInputTokens(ctx, llm.Request{Model: "claude-test", Messages: []llm.Message{llm.User("hi")}})
 	if err == nil {
@@ -349,8 +365,7 @@ func TestAdapter_Stream_YieldsTextDeltasAndFinish(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	stream, err := a.Stream(ctx, llm.Request{Model: "claude-test", Messages: []llm.Message{llm.User("hi")}})
 	if err != nil {
@@ -438,8 +453,7 @@ func TestAdapter_Stream_TranslatesToolUseAndThinkingBlocks(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	stream, err := a.Stream(ctx, llm.Request{Model: "claude-test", Messages: []llm.Message{llm.User("hi")}})
 	if err != nil {
@@ -555,8 +569,7 @@ func TestAdapter_Stream_FinishReason_ToolCallTruncatedByMaxTokens(t *testing.T) 
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	stream, err := a.Stream(ctx, llm.Request{Model: "claude-test", Messages: []llm.Message{llm.User("hi")}})
 	if err != nil {
@@ -627,8 +640,7 @@ func TestAdapter_Stream_EmitsReasoningDeltas_SectionBreakBetweenBlocks(t *testin
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	effort := "high"
 	stream, err := a.Stream(ctx, llm.Request{Model: "claude-test", ReasoningEffort: &effort, Messages: []llm.Message{llm.User("hi")}})
@@ -683,8 +695,7 @@ func TestAdapter_Complete_ImageInput_URL_Data_AndFilePath(t *testing.T) {
 	_ = os.WriteFile(imgPath, []byte{0x89, 0x50, 0x4e, 0x47}, 0o644)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	msg := llm.Message{
 		Role: llm.RoleUser,
@@ -773,8 +784,7 @@ func TestAdapter_ThinkingBlocks_RoundTripIncludingRedacted(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	resp1, err := a.Complete(ctx, llm.Request{Model: "claude-test", Messages: []llm.Message{llm.User("hi")}})
 	if err != nil {
@@ -850,8 +860,7 @@ func TestAdapter_Complete_ResponseFormat_JSONSchema_InjectedIntoSystem(t *testin
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	schema := map[string]any{
 		"type": "object",
@@ -908,8 +917,7 @@ func TestAdapter_ProviderOptions_PassThrough(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	_, err := a.Complete(ctx, llm.Request{
 		Model:    "claude-test",
@@ -948,8 +956,7 @@ func TestAdapter_Complete_ToolChoice_MappedPerSpec(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	toolDef := llm.ToolDefinition{Name: "t1", Parameters: map[string]any{"type": "object", "properties": map[string]any{}}}
 
@@ -1051,8 +1058,7 @@ func TestAdapter_Complete_ToolParameters_DefaultToEmptyObjectSchema(t *testing.T
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	_, err := a.Complete(ctx, llm.Request{
 		Model:    "claude-test",
@@ -1093,8 +1099,7 @@ func TestAdapter_Complete_ToolParameters_DropsTopLevelCombinators(t *testing.T) 
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	_, err := a.Complete(ctx, llm.Request{
 		Model:    "claude-test",
@@ -1141,8 +1146,7 @@ func TestAdapter_Complete_ToolParameters_DropsTopLevelCombinators(t *testing.T) 
 
 func TestAdapter_Complete_RejectsAudioAndDocumentParts(t *testing.T) {
 	a := &Adapter{APIKey: "k", BaseURL: "http://example.com"}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	msgAudio := llm.Message{Role: llm.RoleUser, Content: []llm.ContentPart{{Kind: llm.ContentAudio, Audio: &llm.AudioData{URL: "https://example.com/a.wav"}}}}
 	_, err := a.Complete(ctx, llm.Request{Model: "claude-test", Messages: []llm.Message{msgAudio}})
@@ -1186,8 +1190,7 @@ func TestAdapter_PromptCaching_AutomaticCaching(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	_, err := a.Complete(ctx, llm.Request{
 		Model: "claude-test",
@@ -1321,8 +1324,7 @@ func TestAdapter_UsageCacheTokens_Mapped(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	resp, err := a.Complete(ctx, llm.Request{Model: "claude-test", Messages: []llm.Message{llm.User("hi")}})
 	if err != nil {
@@ -1356,8 +1358,7 @@ func TestAdapter_Complete_DefaultMaxTokens_FallsBackTo32000(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	_, err := a.Complete(ctx, llm.Request{
 		Model:    "claude-test",
@@ -1406,8 +1407,7 @@ func TestAdapter_Complete_FinishReason_Normalized(t *testing.T) {
 			t.Cleanup(srv.Close)
 
 			a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			defer cancel()
+			ctx := t.Context()
 
 			resp, err := a.Complete(ctx, llm.Request{Model: "claude-test", Messages: []llm.Message{llm.User("hi")}})
 			if err != nil {
@@ -1437,8 +1437,7 @@ func TestAdapter_Complete_FinishReason_ToolUse_Normalized(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	resp, err := a.Complete(ctx, llm.Request{Model: "claude-test", Messages: []llm.Message{llm.User("hi")}})
 	if err != nil {
@@ -1474,8 +1473,7 @@ func TestAdapter_Complete_FinishReason_ToolCallTruncatedByMaxTokens(t *testing.T
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	resp, err := a.Complete(ctx, llm.Request{Model: "claude-test", Messages: []llm.Message{llm.User("hi")}})
 	if err != nil {
@@ -1506,8 +1504,7 @@ func TestAdapter_Complete_ParallelToolCalls_ParsedCorrectly(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	resp, err := a.Complete(ctx, llm.Request{Model: "claude-test", Messages: []llm.Message{llm.User("hi")}})
 	if err != nil {
@@ -1563,8 +1560,7 @@ func TestAdapter_Complete_WebSearch_AddsServerTool(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	_, err := a.Complete(ctx, llm.Request{
 		Model:    "claude-test",
@@ -1637,8 +1633,7 @@ func TestAdapter_Complete_WebSearch_ParsesServerToolUseAndResult(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	resp, err := a.Complete(ctx, llm.Request{
 		Model:     "claude-test",
@@ -2352,8 +2347,7 @@ func TestStream_IncludesWebSearchTool(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	stream, err := a.Stream(ctx, llm.Request{
 		Model:    "claude-3-5-sonnet-20241022",
@@ -2466,8 +2460,7 @@ func TestAdapterTimeout_Stream_AcceptsAdapterTimeout(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "test", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	stream, err := a.Stream(ctx, llm.Request{
 		Model:    "claude-test",
@@ -2732,8 +2725,7 @@ func TestAdapter_Complete_WebSearchOnly_IncludesWebSearchTool(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "test-key", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	_, err := a.Complete(ctx, llm.Request{
 		Model:     "test",
@@ -3514,8 +3506,7 @@ func TestAdapter_Complete_ToolResultWithImageData(t *testing.T) {
 	toolResultMsg.Content[0].ToolResult.ImageMediaType = "image/png"
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	_, err := a.Complete(ctx, llm.Request{
 		Model: "claude-test",
@@ -3612,8 +3603,7 @@ func TestAdapter_Complete_ToolResultWithImageData_DefaultMediaType(t *testing.T)
 	// ImageMediaType left empty — should default to "image/png".
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	_, err := a.Complete(ctx, llm.Request{
 		Model: "claude-test",
@@ -3669,8 +3659,7 @@ func TestAdapter_Complete_WebSearchWithTools_NoDuplicateNames(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	// Simulate a tool list that includes a function-type web_search alongside
 	// other function tools, plus WebSearch=true which triggers the adapter to

--- a/llm/providers/openaicompat/adapter_test.go
+++ b/llm/providers/openaicompat/adapter_test.go
@@ -20,8 +20,10 @@ import (
 
 func TestAdapter_Complete_MapsToChatCompletionsAPI(t *testing.T) {
 	var gotBody map[string]any
+	requestStarted := make(chan struct{})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
 		if r.Method != http.MethodPost || r.URL.Path != "/chat/completions" {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -45,18 +47,35 @@ func TestAdapter_Complete_MapsToChatCompletionsAPI(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	resp, err := a.Complete(ctx, llm.Request{
-		Model: "gpt-4o",
-		Messages: []llm.Message{
-			llm.System("you are helpful"),
-			llm.User("hi"),
-			llm.Assistant("hey"),
-			llm.User("what?"),
-		},
-	})
+	// t.Context is the outer test timeout/tripwire. The handler entry channel
+	// is the synchronization boundary, so this test does not use a
+	// load-sensitive request deadline.
+	result := make(chan struct {
+		resp llm.Response
+		err  error
+	}, 1)
+	go func() {
+		resp, err := a.Complete(t.Context(), llm.Request{
+			Model: "gpt-4o",
+			Messages: []llm.Message{
+				llm.System("you are helpful"),
+				llm.User("hi"),
+				llm.Assistant("hey"),
+				llm.User("what?"),
+			},
+		})
+		result <- struct {
+			resp llm.Response
+			err  error
+		}{resp: resp, err: err}
+	}()
+	select {
+	case <-requestStarted:
+	case <-t.Context().Done():
+		t.Fatalf("test context canceled before handler received request: %v", t.Context().Err())
+	}
+	out := <-result
+	resp, err := out.resp, out.err
 	if err != nil {
 		t.Fatalf("Complete: %v", err)
 	}
@@ -430,8 +449,7 @@ func TestAdapter_Complete_ToolCalling(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	resp, err := a.Complete(ctx, llm.Request{
 		Model:    "gpt-4o",
@@ -501,8 +519,7 @@ func TestAdapter_Complete_ToolResults(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	resp, err := a.Complete(ctx, llm.Request{
 		Model: "gpt-4o",
@@ -618,8 +635,7 @@ func TestAdapter_Complete_HTTPError_MapsToErrorType(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	_, err := a.Complete(ctx, llm.Request{
 		Model:    "gpt-4o",
@@ -659,8 +675,7 @@ func TestAdapter_Stream_YieldsTextDeltasAndFinish(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	st, err := a.Stream(ctx, llm.Request{
 		Model:    "gpt-4o",
@@ -736,8 +751,7 @@ func TestAdapter_Stream_MidStreamReadFailure_SurfacesCause(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	st, err := a.Stream(ctx, llm.Request{Model: "gpt-4o", Messages: []llm.Message{llm.User("hi")}})
 	if err != nil {
@@ -780,8 +794,7 @@ func TestAdapter_Stream_ToolCalls(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	st, err := a.Stream(ctx, llm.Request{
 		Model:    "gpt-4o",
@@ -1027,8 +1040,7 @@ func TestAdapterTimeout_Stream_AcceptsAdapterTimeout(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "test", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	stream, err := a.Stream(ctx, llm.Request{
 		Model:    "test",
@@ -1981,8 +1993,7 @@ func TestStream_ReasoningContent_EmitsReasoningEvents(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	st, err := a.Stream(ctx, llm.Request{
 		Model:    "kimi-k2.5",
@@ -2065,8 +2076,7 @@ func TestStream_ReasoningThenToolCalls_ReasoningEndBeforeToolStart(t *testing.T)
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	st, err := a.Stream(ctx, llm.Request{
 		Model:    "kimi-k2.5",
@@ -2461,8 +2471,7 @@ func TestQuirks_FinishReasonMap_Streaming(t *testing.T) {
 			FinishReasonMap: map[string]string{"sensitive": "content_filter"},
 		},
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	st, err := a.Stream(ctx, llm.Request{
 		Model:    "glm-5",
@@ -2511,8 +2520,7 @@ func TestStream_ReasoningTokens_NilWhenProviderOmits(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	st, err := a.Stream(ctx, llm.Request{
 		Model:    "m",
@@ -2718,8 +2726,7 @@ func TestStream_ReasoningDetails_EmitsReasoningEvents(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	st, err := a.Stream(ctx, llm.Request{
 		Model:    "minimax/minimax-m2.7",

--- a/llm/providers/openaicompat/adapter_test.go
+++ b/llm/providers/openaicompat/adapter_test.go
@@ -47,9 +47,9 @@ func TestAdapter_Complete_MapsToChatCompletionsAPI(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
-	// t.Context is the outer test timeout/tripwire. The handler entry channel
-	// is the synchronization boundary, so this test does not use a
-	// load-sensitive request deadline.
+	// Handler entry is the synchronization boundary. t.Context provides
+	// lifecycle cancellation only; the runner's -timeout remains the independent
+	// process tripwire.
 	result := make(chan struct {
 		resp llm.Response
 		err  error
@@ -69,12 +69,23 @@ func TestAdapter_Complete_MapsToChatCompletionsAPI(t *testing.T) {
 			err  error
 		}{resp: resp, err: err}
 	}()
+	var out struct {
+		resp llm.Response
+		err  error
+	}
 	select {
 	case <-requestStarted:
+		out = <-result
+	case out = <-result:
+		select {
+		case <-requestStarted:
+			// Handler entry was already observable; completion raced this select.
+		default:
+			t.Fatalf("Complete returned before handler received request: response=%#v error=%v", out.resp, out.err)
+		}
 	case <-t.Context().Done():
 		t.Fatalf("test context canceled before handler received request: %v", t.Context().Err())
 	}
-	out := <-result
 	resp, err := out.resp, out.err
 	if err != nil {
 		t.Fatalf("Complete: %v", err)


### PR DESCRIPTION
## Summary

Make localhost adapter tests deterministic under aggregate `-race` load without changing provider behavior, request shape, or assertions.

## Root cause

`httptest.NewServer` completes listener setup before returning, so the failing path was not a server-readiness race. In the linked aggregate-race failures, the request's local 2s caller deadline was consumed by race/load scheduling before the localhost handler ran:

- PR #408 failed run: https://github.com/prime-radiant-inc/evener/actions/runs/32794839581 (job https://github.com/prime-radiant-inc/evener/actions/runs/32794839581/job/97643865615)
- PR #416 failed run: https://github.com/prime-radiant-inc/evener/actions/runs/32801079375 (job https://github.com/prime-radiant-inc/evener/actions/runs/32801079375/job/97661852658)

Both failed at `TestAdapter_Complete_MapsToMessagesAPI_AndSetsBetaHeaders` with `Post .../v1/messages: context deadline exceeded` at 2.00s. The OpenAI-compatible adapter package has the same historical load-sensitive local-deadline pattern.

`t.Context()` supplies test-lifecycle cancellation and is canceled just before cleanup; it does not carry the runner's configured `-timeout`. The independent process-level `go test -timeout` remains the runner-owned outer tripwire. Handler-entry channels plus buffered-result selection provide the request synchronization. No retries, sleeps, timeout inflation, or error suppression were added.

## Changes

- Anthropic: replace exactly 30 ordinary 2s request contexts with `t.Context()`.
- OpenAI-compatible: replace exactly 12 ordinary 2s request contexts with `t.Context()`.
- Add one real `requestStarted` handler-entry barrier to each mapping test; while waiting, also observe the buffered adapter result so pre-handler completion fails immediately rather than hanging until the process timeout. Preserve the existing response/body/header/request-shape assertions.
- Start the contractual Anthropic mid-stream deadline only after the real handler flushes SSE headers, then trigger `DeadlineExceeded` deterministically through a controlled context.
- Keep server cleanup test-owned through `t.Cleanup(srv.Close)`.

## Verification

Green:

- Focused mapping tests under `-race -count=100` for both providers with `GOMAXPROCS=1` and two CPU burner processes.
- Full `GOMAXPROCS=1 go test -race ./llm/... -count=1` under the same load; all llm modules passed.
- Ordinary and race suites for `./llm/providers/anthropic` and `./llm/providers/openaicompat`.
- `go vet ./llm/providers/anthropic ./llm/providers/openaicompat`.
- `git diff --check`.

Not run in this focused branch:

- Repository-wide `make test-race` / aggregate all-module race gate.
- Repository-wide `make lint`, `make vet`, `make merge-approval-gate`, and `make secret-scan`.
- A separate cross-provider smoke target (the full `go test -race ./llm/...` provider suites above did run).

The branch was rooted on `main` at `f39c1a76d60c3d33a57f2bb0c9b5fb4e0d1486a8`; the only changed files are the two adapter test files.