### PR TITLE
fix(hub): fence stale relay epoch publications

### DIFF
--- a/cmd/evener-hub/internal/appsource/relay_session.go
+++ b/cmd/evener-hub/internal/appsource/relay_session.go
@@ -27,6 +27,7 @@ type relaySession struct {
 	// fence before taking the write side so a blocked send can be interrupted
 	// without allowing a revoked epoch to enter a listener after replacement.
 	publishBoundary  sync.RWMutex
+	publishEntryHook func()
 	publicationEpoch uint64
 	publicationFence *relayPublicationFence
 
@@ -685,6 +686,9 @@ func (s *relaySession) publishToListenerAtEpoch(epoch uint64, fence *relayPublic
 	if epoch != 0 && (s.publicationEpoch != epoch || s.publicationFence != fence) {
 		s.publishBoundary.RUnlock()
 		return false
+	}
+	if hook := s.publishEntryHook; hook != nil {
+		hook()
 	}
 	select {
 	case listener.in <- delivery:

--- a/cmd/evener-hub/internal/appsource/relay_session.go
+++ b/cmd/evener-hub/internal/appsource/relay_session.go
@@ -597,7 +597,7 @@ func (s *relaySession) finishHandoff(epoch, generation uint64) bool {
 	startRecovery := false
 	if s.connection != nil && s.connection.epoch == epoch && s.connection.disconnected {
 		s.connection = nil
-		s.epoch++
+		s.advanceEpochLocked()
 		startRecovery = len(s.listeners) > 0 && !s.recovering
 		if startRecovery {
 			s.recovering = true

--- a/cmd/evener-hub/internal/appsource/relay_session.go
+++ b/cmd/evener-hub/internal/appsource/relay_session.go
@@ -20,6 +20,15 @@ type relaySession struct {
 	publishWake chan struct{}
 	publishMu   sync.Mutex
 	publishJobs []relayPublishJob
+	// publishBoundary makes epoch revocation and the handoff of a queued
+	// notification one linearizable operation. A publisher may block on the
+	// listener's private channel while holding the read side, but never while
+	// waiting for downstream acknowledgement. Revocation closes the epoch's
+	// fence before taking the write side so a blocked send can be interrupted
+	// without allowing a revoked epoch to enter a listener after replacement.
+	publishBoundary  sync.RWMutex
+	publicationEpoch uint64
+	publicationFence *relayPublicationFence
 
 	mu             sync.Mutex
 	epoch          uint64
@@ -63,8 +72,14 @@ type relayCapture struct {
 }
 
 type relayPublishJob struct {
+	epoch         uint64
+	fence         *relayPublicationFence
 	notifications []appwire.Notification
 	done          chan struct{}
+}
+
+type relayPublicationFence struct {
+	revoked chan struct{}
 }
 
 type relayListener struct {
@@ -95,14 +110,15 @@ type relayHandoff struct {
 func newRelaySession(connect relaySessionConnect, onIdle func(*relaySession)) *relaySession {
 	ctx, cancel := context.WithCancel(context.Background())
 	session := &relaySession{
-		ctx:         ctx,
-		cancel:      cancel,
-		connect:     connect,
-		onIdle:      onIdle,
-		commandGate: make(chan struct{}, 1),
-		publishWake: make(chan struct{}, 1),
-		leases:      map[uint64]*relaySessionLease{},
-		listeners:   map[uint64]*relayListener{},
+		ctx:              ctx,
+		cancel:           cancel,
+		connect:          connect,
+		onIdle:           onIdle,
+		commandGate:      make(chan struct{}, 1),
+		publishWake:      make(chan struct{}, 1),
+		leases:           map[uint64]*relaySessionLease{},
+		listeners:        map[uint64]*relayListener{},
+		publicationFence: &relayPublicationFence{revoked: make(chan struct{})},
 	}
 	session.commandGate <- struct{}{}
 	go session.publishLoop()
@@ -284,7 +300,7 @@ func (s *relaySession) ensureConnection(ctx context.Context) (*relayConnection, 
 		s.mu.Unlock()
 		return connection, nil
 	}
-	s.epoch++
+	s.advanceEpochLocked()
 	epoch := s.epoch
 	s.mu.Unlock()
 
@@ -331,7 +347,7 @@ func (s *relaySession) observe(epoch uint64, message appwire.Message, recvErr er
 	case message.Notification != nil:
 		notification := *message.Notification
 		if capture == nil {
-			s.queuePublishLocked([]appwire.Notification{notification}, nil)
+			s.queuePublishLocked(epoch, []appwire.Notification{notification}, nil)
 		} else if capture.epoch != epoch {
 			// A revoked epoch never contributes to the current feed.
 		} else if capture.cutSeen {
@@ -345,7 +361,7 @@ func (s *relaySession) observe(epoch uint64, message appwire.Message, recvErr er
 		// empty job is also a FIFO barrier for notifications accepted before
 		// this capture was installed.
 		capture.cutSeen = true
-		s.queuePublishLocked(capture.beforeCut, capture.flushed)
+		s.queuePublishLocked(capture.epoch, capture.beforeCut, capture.flushed)
 		capture.beforeCut = nil
 	}
 	s.mu.Unlock()
@@ -360,7 +376,7 @@ func (s *relaySession) disconnect(epoch uint64) {
 	if s.connection == nil {
 		// Revoke a connection attempt whose receive loop ended before the
 		// initialized client could be installed.
-		s.epoch++
+		s.advanceEpochLocked()
 		s.mu.Unlock()
 		return
 	}
@@ -381,7 +397,7 @@ func (s *relaySession) disconnect(epoch uint64) {
 		return
 	}
 	s.connection = nil
-	s.epoch++
+	s.advanceEpochLocked()
 	if capture != nil && capture.epoch == epoch {
 		s.capture = nil
 		capture.release.Do(func() {
@@ -430,7 +446,7 @@ func (s *relaySession) publishPendingResync(params appwire.ThreadReadParams) {
 		ThreadID: params.ThreadID,
 		Ref:      params.Ref,
 	}).Notification
-	s.queuePublishLocked([]appwire.Notification{resync}, nil)
+	s.queuePublishLocked(s.epoch, []appwire.Notification{resync}, nil)
 	s.mu.Unlock()
 }
 
@@ -495,7 +511,7 @@ func (s *relaySession) cancelCapture(capture *relayCapture) {
 		s.capture = nil
 		notifications := append(append([]appwire.Notification{}, capture.beforeCut...), capture.afterCut...)
 		if len(notifications) > 0 {
-			s.queuePublishLocked(notifications, nil)
+			s.queuePublishLocked(capture.epoch, notifications, nil)
 		}
 	}
 	capture.release.Do(func() {
@@ -572,7 +588,7 @@ func (s *relaySession) finishHandoff(epoch, generation uint64) bool {
 	}
 	s.capture = nil
 	if s.connection != nil && s.connection.epoch == epoch && len(capture.afterCut) > 0 {
-		s.queuePublishLocked(capture.afterCut, nil)
+		s.queuePublishLocked(capture.epoch, capture.afterCut, nil)
 	}
 	capture.release.Do(func() {
 		s.commandOwners--
@@ -594,8 +610,10 @@ func (s *relaySession) finishHandoff(epoch, generation uint64) bool {
 	return true
 }
 
-func (s *relaySession) queuePublishLocked(notifications []appwire.Notification, done chan struct{}) {
+func (s *relaySession) queuePublishLocked(epoch uint64, notifications []appwire.Notification, done chan struct{}) {
 	job := relayPublishJob{
+		epoch:         epoch,
+		fence:         s.publicationFence,
 		notifications: append([]appwire.Notification(nil), notifications...),
 		done:          done,
 	}
@@ -625,7 +643,7 @@ func (s *relaySession) publishLoop() {
 				s.publishJobs = s.publishJobs[1:]
 				s.publishMu.Unlock()
 				for _, notification := range job.notifications {
-					s.publishNotification(notification)
+					s.publishNotification(job.epoch, job.fence, notification)
 				}
 				if job.done != nil {
 					close(job.done)
@@ -635,7 +653,7 @@ func (s *relaySession) publishLoop() {
 	}
 }
 
-func (s *relaySession) publishNotification(notification appwire.Notification) {
+func (s *relaySession) publishNotification(epoch uint64, fence *relayPublicationFence, notification appwire.Notification) {
 	s.mu.Lock()
 	listeners := make([]*relayListener, 0, len(s.listeners))
 	for _, listener := range s.listeners {
@@ -644,13 +662,17 @@ func (s *relaySession) publishNotification(notification appwire.Notification) {
 	s.mu.Unlock()
 
 	for _, listener := range listeners {
-		if !s.publishToListener(listener, notification) && s.ctx.Err() != nil {
+		if !s.publishToListenerAtEpoch(epoch, fence, listener, notification) && s.ctx.Err() != nil {
 			return
 		}
 	}
 }
 
 func (s *relaySession) publishToListener(listener *relayListener, notification appwire.Notification) bool {
+	return s.publishToListenerAtEpoch(0, nil, listener, notification)
+}
+
+func (s *relaySession) publishToListenerAtEpoch(epoch uint64, fence *relayPublicationFence, listener *relayListener, notification appwire.Notification) bool {
 	ack := make(chan struct{})
 	var once sync.Once
 	delivery := RelayDelivery{
@@ -659,16 +681,28 @@ func (s *relaySession) publishToListener(listener *relayListener, notification a
 			once.Do(func() { close(ack) })
 		},
 	}
+	s.publishBoundary.RLock()
+	if epoch != 0 && (s.publicationEpoch != epoch || s.publicationFence != fence) {
+		s.publishBoundary.RUnlock()
+		return false
+	}
 	select {
 	case listener.in <- delivery:
 	case <-listener.ctx.Done():
+		s.publishBoundary.RUnlock()
 		s.removeListener(listener.id)
 		return false
 	case <-listener.done:
+		s.publishBoundary.RUnlock()
+		return false
+	case <-fenceRevoked(fence):
+		s.publishBoundary.RUnlock()
 		return false
 	case <-s.ctx.Done():
+		s.publishBoundary.RUnlock()
 		return false
 	}
+	s.publishBoundary.RUnlock()
 	select {
 	case <-ack:
 		return true
@@ -680,6 +714,27 @@ func (s *relaySession) publishToListener(listener *relayListener, notification a
 	case <-s.ctx.Done():
 		return false
 	}
+}
+
+// advanceEpochLocked revokes the old publication epoch at the same boundary
+// used by publishToListenerAtEpoch. The caller must hold s.mu.
+func (s *relaySession) advanceEpochLocked() {
+	if s.publicationFence == nil {
+		s.publicationFence = &relayPublicationFence{revoked: make(chan struct{})}
+	}
+	close(s.publicationFence.revoked)
+	s.publishBoundary.Lock()
+	s.epoch++
+	s.publicationEpoch = s.epoch
+	s.publicationFence = &relayPublicationFence{revoked: make(chan struct{})}
+	s.publishBoundary.Unlock()
+}
+
+func fenceRevoked(fence *relayPublicationFence) <-chan struct{} {
+	if fence == nil {
+		return nil
+	}
+	return fence.revoked
 }
 
 func (s *relaySession) removeListener(id uint64) {

--- a/cmd/evener-hub/internal/appsource/relay_session_test.go
+++ b/cmd/evener-hub/internal/appsource/relay_session_test.go
@@ -155,6 +155,44 @@ type relayPublicationBarrier struct {
 	listener *relayListener
 }
 
+type relayPublisherEntryBarrier struct {
+	session     *relaySession
+	entered     chan struct{}
+	release     chan struct{}
+	enteredOnce sync.Once
+	releaseOnce sync.Once
+}
+
+func newRelayPublisherEntryBarrier(t *testing.T, session *relaySession) *relayPublisherEntryBarrier {
+	t.Helper()
+	barrier := &relayPublisherEntryBarrier{
+		session: session,
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	session.publishBoundary.Lock()
+	session.publishEntryHook = func() {
+		barrier.enteredOnce.Do(func() { close(barrier.entered) })
+		<-barrier.release
+	}
+	session.publishBoundary.Unlock()
+	t.Cleanup(func() {
+		barrier.releasePublisher()
+		barrier.disable()
+	})
+	return barrier
+}
+
+func (b *relayPublisherEntryBarrier) releasePublisher() {
+	b.releaseOnce.Do(func() { close(b.release) })
+}
+
+func (b *relayPublisherEntryBarrier) disable() {
+	b.session.publishBoundary.Lock()
+	b.session.publishEntryHook = nil
+	b.session.publishBoundary.Unlock()
+}
+
 func newRelayPublicationBarrier(t *testing.T, session *relaySession, leaseID uint64) *relayPublicationBarrier {
 	t.Helper()
 	barrier := &relayPublicationBarrier{
@@ -894,18 +932,27 @@ func TestRelaySessionDisconnectRevokesBlockedPublicationBeforeRecovery(t *testin
 
 	session := relaySessionFor(t, source)
 	barrier := newRelayPublicationBarrier(t, session, lease.id)
+	entry := newRelayPublisherEntryBarrier(t, session)
 	session.mu.Lock()
 	epoch := session.epoch
+	fence := session.publicationFence
+	session.recovering = true
 	session.mu.Unlock()
 	staleDone := queueRelayNotificationAtEpoch(session, epoch, relayDelta("thread-1", "stale"))
 
-	// The stale publisher is now blocked on the listener's private input. The
-	// disconnect must revoke it before recovery can establish a replacement.
-	session.mu.Lock()
-	session.recovering = true
-	session.mu.Unlock()
-	session.disconnect(epoch)
+	// The entry barrier proves the stale job passed its old token check and
+	// acquired the publication read lock before revocation begins.
+	<-entry.entered
+	disconnectDone := make(chan struct{})
+	go func() {
+		session.disconnect(epoch)
+		close(disconnectDone)
+	}()
+	<-fence.revoked
+	entry.releasePublisher()
 	<-staleDone
+	<-disconnectDone
+	entry.disable()
 	<-barrier.listener.out
 	<-barrier.listener.out
 
@@ -954,21 +1001,27 @@ func TestRelaySessionPreparedHandoffDisconnectRevokesBlockedPublicationBeforeRec
 
 	session := relaySessionFor(t, source)
 	barrier := newRelayPublicationBarrier(t, session, lease.id)
+	entry := newRelayPublisherEntryBarrier(t, session)
 	session.mu.Lock()
 	epoch := session.epoch
+	fence := session.publicationFence
+	session.recovering = true
 	session.mu.Unlock()
 	staleDone := queueRelayNotificationAtEpoch(session, epoch, relayDelta("thread-1", "stale"))
 
 	// Ordinary disconnect only marks a prepared connection. The terminal
 	// handoff outcome is the deferred boundary that must revoke this epoch.
-	session.mu.Lock()
-	session.recovering = true
-	session.mu.Unlock()
+	<-entry.entered
 	session.disconnect(epoch)
-	if !result.result.Handoff.Commit() {
+	commitDone := make(chan bool, 1)
+	go func() { commitDone <- result.result.Handoff.Commit() }()
+	<-fence.revoked
+	entry.releasePublisher()
+	<-staleDone
+	if !<-commitDone {
 		t.Fatal("prepared handoff commit lost")
 	}
-	<-staleDone
+	entry.disable()
 	<-barrier.listener.out
 	<-barrier.listener.out
 

--- a/cmd/evener-hub/internal/appsource/relay_session_test.go
+++ b/cmd/evener-hub/internal/appsource/relay_session_test.go
@@ -150,6 +150,49 @@ func relayDelta(threadID, delta string) appwire.Notification {
 	}).Notification
 }
 
+type relayPublicationBarrier struct {
+	session  *relaySession
+	listener *relayListener
+}
+
+func newRelayPublicationBarrier(t *testing.T, session *relaySession, leaseID uint64) *relayPublicationBarrier {
+	t.Helper()
+	barrier := &relayPublicationBarrier{
+		session: session,
+	}
+	session.mu.Lock()
+	session.nextListener++
+	barrier.listener = &relayListener{
+		id:      session.nextListener,
+		leaseID: leaseID,
+		ctx:     t.Context(),
+		in:      make(chan RelayDelivery),
+		out:     make(chan RelayDelivery, 1),
+		done:    make(chan struct{}),
+	}
+	session.listeners[barrier.listener.id] = barrier.listener
+	// A one-slot output makes the two direct input sends a deterministic
+	// in->out barrier: the second send is accepted only after forward has
+	// consumed the first and is blocked on the full output buffer.
+	session.mu.Unlock()
+	go barrier.listener.forward()
+	barrier.listener.in <- RelayDelivery{}
+	barrier.listener.in <- RelayDelivery{}
+	t.Cleanup(func() {
+		session.removeListener(barrier.listener.id)
+		session.maybeIdle()
+	})
+	return barrier
+}
+
+func queueRelayNotificationAtEpoch(session *relaySession, epoch uint64, notification appwire.Notification) <-chan struct{} {
+	done := make(chan struct{})
+	session.mu.Lock()
+	session.queuePublishLocked(epoch, []appwire.Notification{notification}, done)
+	session.mu.Unlock()
+	return done
+}
+
 func TestRelaySessionSnapshotCutFlushesPreCutAndHoldsPostCut(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
@@ -826,6 +869,129 @@ func TestRelaySessionStaleEpochNotificationCannotPublish(t *testing.T) {
 		t.Fatalf("stale epoch published %+v", delivery.Notification)
 	default:
 	}
+}
+
+func TestRelaySessionDisconnectRevokesBlockedPublicationBeforeRecovery(t *testing.T) {
+	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
+	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
+	leaseValue, err := source.AcquireRelaySession(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease := leaseValue.(*relaySessionLease)
+	defer lease.Close()
+
+	read := readRelayAsync(context.Background(), lease, params)
+	call := <-daemon.reads
+	call.transport.recv <- appwire.ResponseMessage(call.request.ID, relaySnapshot("thread-1", "snapshot"))
+	result := <-read
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if !result.result.Handoff.Commit() {
+		t.Fatal("initial handoff commit lost")
+	}
+
+	session := relaySessionFor(t, source)
+	barrier := newRelayPublicationBarrier(t, session, lease.id)
+	session.mu.Lock()
+	epoch := session.epoch
+	session.mu.Unlock()
+	staleDone := queueRelayNotificationAtEpoch(session, epoch, relayDelta("thread-1", "stale"))
+
+	// The stale publisher is now blocked on the listener's private input. The
+	// disconnect must revoke it before recovery can establish a replacement.
+	session.mu.Lock()
+	session.recovering = true
+	session.mu.Unlock()
+	session.disconnect(epoch)
+	<-staleDone
+	<-barrier.listener.out
+	<-barrier.listener.out
+
+	session.mu.Lock()
+	session.recovering = false
+	session.mu.Unlock()
+	go session.recoverCanonicalFeed()
+	recoveryCall := <-daemon.reads
+	recoveryCall.transport.recv <- appwire.ResponseMessage(
+		recoveryCall.request.ID,
+		relaySnapshot("thread-1", "recovered"),
+	)
+	resync := <-barrier.listener.out
+	if resync.Notification.Method != appwire.NotifyEvenerThreadResync {
+		t.Fatalf("recovery delivery = %+v, want resync", resync.Notification)
+	}
+	resync.Acknowledge()
+
+	session.mu.Lock()
+	if session.publicationEpoch != session.epoch {
+		t.Fatalf("publication epoch = %d, authoritative epoch = %d", session.publicationEpoch, session.epoch)
+	}
+	session.mu.Unlock()
+}
+
+func TestRelaySessionPreparedHandoffDisconnectRevokesBlockedPublicationBeforeRecovery(t *testing.T) {
+	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
+	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
+	leaseValue, err := source.AcquireRelaySession(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease := leaseValue.(*relaySessionLease)
+	defer lease.Close()
+
+	read := readRelayAsync(context.Background(), lease, params)
+	call := <-daemon.reads
+	call.transport.recv <- appwire.ResponseMessage(call.request.ID, relaySnapshot("thread-1", "snapshot"))
+	result := <-read
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if !result.result.Handoff.Prepare() {
+		t.Fatal("current handoff could not pin its live continuation")
+	}
+
+	session := relaySessionFor(t, source)
+	barrier := newRelayPublicationBarrier(t, session, lease.id)
+	session.mu.Lock()
+	epoch := session.epoch
+	session.mu.Unlock()
+	staleDone := queueRelayNotificationAtEpoch(session, epoch, relayDelta("thread-1", "stale"))
+
+	// Ordinary disconnect only marks a prepared connection. The terminal
+	// handoff outcome is the deferred boundary that must revoke this epoch.
+	session.mu.Lock()
+	session.recovering = true
+	session.mu.Unlock()
+	session.disconnect(epoch)
+	if !result.result.Handoff.Commit() {
+		t.Fatal("prepared handoff commit lost")
+	}
+	<-staleDone
+	<-barrier.listener.out
+	<-barrier.listener.out
+
+	session.mu.Lock()
+	session.recovering = false
+	session.mu.Unlock()
+	go session.recoverCanonicalFeed()
+	recoveryCall := <-daemon.reads
+	recoveryCall.transport.recv <- appwire.ResponseMessage(
+		recoveryCall.request.ID,
+		relaySnapshot("thread-1", "recovered"),
+	)
+	resync := <-barrier.listener.out
+	if resync.Notification.Method != appwire.NotifyEvenerThreadResync {
+		t.Fatalf("recovery delivery = %+v, want resync", resync.Notification)
+	}
+	resync.Acknowledge()
+
+	session.mu.Lock()
+	if session.publicationEpoch != session.epoch {
+		t.Fatalf("publication epoch = %d, authoritative epoch = %d", session.publicationEpoch, session.epoch)
+	}
+	session.mu.Unlock()
 }
 
 func TestRelaySessionIdleClosesCanonicalConnectionAfterLastOwner(t *testing.T) {

--- a/cmd/evener-hub/internal/appsource/relay_session_test.go
+++ b/cmd/evener-hub/internal/appsource/relay_session_test.go
@@ -795,11 +795,32 @@ func TestRelaySessionStaleEpochNotificationCannotPublish(t *testing.T) {
 	result := <-read
 	result.result.Handoff.Commit()
 
+	session := relaySessionFor(t, source)
 	lease.session.mu.Lock()
 	staleEpoch := lease.session.connection.epoch
 	lease.session.mu.Unlock()
+	// Hold the publisher after it has accepted a live notification. This is an
+	// event barrier, not a timing assumption: the stale notification is queued
+	// behind the blocked job and the epoch is revoked before the publisher can
+	// dequeue it.
+	observeRelayFrame(t, session, relayDelta("thread-1", "barrier"))
+	barrier := <-deliveries
+	if got := decodeRelayDelta(t, barrier.Notification); got != "barrier" {
+		t.Fatalf("barrier delivery = %q, want barrier", got)
+	}
+	session.observe(staleEpoch, appwire.Message{Notification: new(relayDelta("thread-1", "stale"))}, nil)
 	lease.session.disconnect(staleEpoch)
-	lease.session.observe(staleEpoch, appwire.Message{Notification: new(relayDelta("thread-1", "stale"))}, nil)
+	recoveryCall := <-daemon.reads
+	recoveryCall.transport.recv <- appwire.ResponseMessage(
+		recoveryCall.request.ID,
+		relaySnapshot("thread-1", "recovered"),
+	)
+	barrier.Acknowledge()
+	resync := <-deliveries
+	if resync.Notification.Method != appwire.NotifyEvenerThreadResync {
+		t.Fatalf("recovery delivery = %+v, want resync", resync.Notification)
+	}
+	resync.Acknowledge()
 	select {
 	case delivery := <-deliveries:
 		t.Fatalf("stale epoch published %+v", delivery.Notification)


### PR DESCRIPTION
Fixes the failed CI run [32794911542 / job 97644072327](https://github.com/prime-radiant-inc/evener/actions/runs/32794911542/job/97644072327), where `TestRelaySessionStaleEpochNotificationCannotPublish` observed `evener/thread/resync` after epoch replacement.

- Tag queued notifications with their authoritative epoch and publication fence.
- Linearize epoch revocation against listener publication; revoke fences before the exclusive boundary so blocked sends can exit without deadlock.
- Preserve replacement-epoch resync publication.
- Add a deterministic real-relay event-barrier regression with no sleeps, timeouts, or prose oracles.

Local verification:
- Focused stale-epoch race test (`-count=100`) — PASS
- Complete appsource package and appsource+hub race checks — PASS
- `make lint` — PASS
- `make lint-gofmt lint-generated vet` — PASS
- `make secret-scan`, `git diff --check` — PASS
- `make mutation-floor` with go-gremlins v0.6.0 — PASS
- `make test-web` — PASS
- `ROOT_FULL=1 WEB=0 make test` — PASS (all Go modules)
- `make build && make test-dev-tooling` — PASS

The first combined `make test` run reported two frontend tests under concurrent Go/Node load; both passed in isolation and the standalone frontend gate passed. The first `make merge-approval-gate` run was terminated by the local execution limit after lint/build; its phases above were rerun independently and passed.