### PR TITLE
test(tui): rendezvous with ready hub handlers

### DIFF
--- a/cmd/evener-tui/tmux_e2e_test.go
+++ b/cmd/evener-tui/tmux_e2e_test.go
@@ -80,7 +80,7 @@ func TestTUITmuxE2E_DashboardProjectAndSpawn(t *testing.T) {
 	e2ecap.RequireProcessInspect(t)
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
@@ -174,7 +174,7 @@ func TestTUITmuxE2E_BurstTypedKeysApplyIndividually(t *testing.T) {
 	e2ecap.RequireProcessInspect(t)
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
@@ -192,7 +192,7 @@ func TestTUITmuxE2E_AppShellPreservesLayoutAcrossWidths(t *testing.T) {
 	e2ecap.RequireProcessInspect(t)
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
@@ -228,7 +228,7 @@ func TestTUITmuxE2E_DashboardNarrowWideStates(t *testing.T) {
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
 	hub.SetSessionTitle("01LIVE", "live dashboard task with a title long enough to truncate cleanly")
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 
 	wide := startTUITmuxSized(t, bin, hub, 140, 40)
 	defer wide.Close()
@@ -267,7 +267,7 @@ func TestTUITmuxE2E_DashboardFooterAnchorsToBottom(t *testing.T) {
 	e2ecap.RequireProcessInspect(t)
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmuxSized(t, bin, hub, 124, 18)
 	defer app.Close()
 
@@ -296,7 +296,7 @@ func TestTUITmuxE2E_DashboardRecentOnlyState(t *testing.T) {
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
 	hub.EndDashboardSessions()
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
@@ -322,7 +322,7 @@ func TestTUITmuxE2E_ProjectHistoryReadOnlyAndResume(t *testing.T) {
 	e2ecap.RequireProcessInspect(t)
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
@@ -357,7 +357,7 @@ func TestTUITmuxE2E_CodexSpawnUsesHarnessModelPicker(t *testing.T) {
 		{ID: "evener", Label: "evener", Kind: "evener"},
 		{ID: "codex-local", Label: "codex-local", Kind: "codex"},
 	})
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
@@ -392,7 +392,7 @@ func TestTUITmuxE2E_SessionCommandsAndNavigation(t *testing.T) {
 	e2ecap.RequireProcessInspect(t)
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	// The /help output (all session slash commands + the browse keybindings)
 	// is taller than the default 40-row pane's transcript viewport, which pins
 	// to the bottom and scrolls the "Available commands:" header off the top.
@@ -536,7 +536,7 @@ func TestTUITmuxE2E_BrowseAndFork(t *testing.T) {
 	// scrolling to keep it visible) so a user message can be reached and forked.
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
@@ -585,7 +585,7 @@ func TestTUITmuxE2E_FailedForkPreservesDraft(t *testing.T) {
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
 	hub.SetFailFork(true)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
@@ -626,7 +626,7 @@ func TestTUITmuxE2E_CapabilityGates(t *testing.T) {
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
 	hub.SetSessionCapabilities("01LIVE", appwire.ThreadCapabilities{})
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
@@ -697,7 +697,7 @@ func TestTUITmuxE2E_SessionCommandPalettePreservesDraft(t *testing.T) {
 	e2ecap.RequireProcessInspect(t)
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
@@ -722,7 +722,7 @@ func TestTUITmuxE2E_SessionLeadingSlashOpensPalette(t *testing.T) {
 	e2ecap.RequireProcessInspect(t)
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
@@ -738,7 +738,7 @@ func TestTUITmuxE2E_CtrlCRequiresDoublePressFromSession(t *testing.T) {
 	e2ecap.RequireProcessInspect(t)
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
@@ -760,7 +760,7 @@ func TestTUITmuxE2E_CtrlCRestoreMessageSurvivesAltScreenExit(t *testing.T) {
 	e2ecap.RequireProcessInspect(t)
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmuxAltScreen(t, bin, hub, 120, 28)
 	defer app.Close()
 
@@ -786,7 +786,7 @@ func TestTUITmuxE2E_ModelPickerShowsAuthRequiredModels(t *testing.T) {
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
 	hub.SetAuthRequiredModels(true)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
@@ -818,7 +818,7 @@ func TestTUITmuxE2E_SessionHeaderStatusAndComposerStates(t *testing.T) {
 	hub := newTUIE2EHub(t)
 	hub.SetSessionState("01LIVE", appwire.ThreadStatusActive)
 	hub.SetSessionContextPressure("01LIVE", 0.66)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
@@ -892,7 +892,7 @@ func TestTUITmuxE2E_HubStreamingAssistantDeltaBeforeRefresh(t *testing.T) {
 	e2ecap.RequireProcessInspect(t)
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
@@ -918,7 +918,7 @@ func TestTUITmuxE2E_HubStreamingToolGroupBeforeRefresh(t *testing.T) {
 	e2ecap.RequireProcessInspect(t)
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
@@ -944,7 +944,7 @@ func TestTUITmuxE2E_APIErrorsRenderInPlace(t *testing.T) {
 	e2ecap.RequireProcessInspect(t)
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
@@ -988,7 +988,7 @@ func TestTUITmuxE2E_CaptureStableDuringStream(t *testing.T) {
 	e2ecap.RequireProcessInspect(t)
 	bin := buildTUIBinary(t)
 	hub := newTUIE2EHub(t)
-	defer hub.Close()
+	registerTUIE2EHubCleanup(t, hub)
 	app := startTUITmuxSized(t, bin, hub, 200, 50)
 	defer app.Close()
 
@@ -1705,6 +1705,10 @@ type tuiE2EHub struct {
 	server    *httptest.Server
 	app       *appserver.Server
 	closeOnce sync.Once
+	closed    chan struct{}
+	// cleanupTrace is test-only instrumentation for the lifecycle regression;
+	// it stays nil for every normal E2E fixture.
+	cleanupTrace chan<- int
 	// ready is closed by the HTTP handler, not by httptest.NewServer's
 	// listener setup.  The latter only proves that a port was allocated; it
 	// does not prove that the server goroutine has reached the handler under a
@@ -1767,6 +1771,7 @@ func newTUIE2EHub(t *testing.T) *tuiE2EHub {
 		harnesses: []appwire.HarnessDescriptor{{ID: "evener", Label: "evener", Kind: "evener"}},
 		ready:     make(chan struct{}),
 		changed:   make(chan struct{}, 1),
+		closed:    make(chan struct{}),
 	}
 	h.addSession(&tuiE2ESession{
 		ID:           "01LIVE",
@@ -1948,7 +1953,55 @@ func (h *tuiE2EHub) URL() string {
 }
 
 func (h *tuiE2EHub) Close() {
-	h.closeOnce.Do(func() { h.server.Close() })
+	h.closeOnce.Do(func() {
+		if h.cleanupTrace != nil {
+			h.cleanupTrace <- 2
+		}
+		h.server.Close()
+		close(h.closed)
+	})
+}
+
+// registerTUIE2EHubCleanup deliberately uses t.Cleanup rather than defer.
+// The tmux starter registers its cleanup after this function returns, so the
+// testing package's LIFO cleanup order terminates the tmux client before this
+// joining httptest server is closed. That ordering also applies when a later
+// setup assertion calls Fatalf.
+func registerTUIE2EHubCleanup(t *testing.T, hub *tuiE2EHub) {
+	t.Helper()
+	t.Cleanup(hub.Close)
+}
+
+// TestTUITmuxE2EHubCleanupJoinsClientBeforeServer exercises the real WebSocket
+// handler lifetime that makes httptest.Server.Close a joining operation. The
+// client cleanup is registered after the hub cleanup, matching the tmux
+// starter's later t.Cleanup registration. If this is changed back to defer,
+// the helper returns and runs hub.Close while the client is still connected;
+// the test then blocks in the real server join instead of leaving an orphan.
+func TestTUITmuxE2EHubCleanupJoinsClientBeforeServer(t *testing.T) {
+	var hub *tuiE2EHub
+	trace := make(chan int, 2)
+	t.Run("setup-lifecycle", func(t *testing.T) {
+		hub = newTUIE2EHub(t)
+		hub.cleanupTrace = trace
+		transport, err := appwire.DialWebSocket(context.Background(), "ws"+strings.TrimPrefix(hub.URL(), "http")+"/rpc", hub.server.Client())
+		if err != nil {
+			t.Fatalf("dial test hub: %v", err)
+		}
+		registerTUIE2EHubCleanup(t, hub)
+		t.Cleanup(func() {
+			_ = transport.Close()
+			trace <- 1
+		})
+	})
+	if first, second := <-trace, <-trace; first != 1 || second != 2 {
+		t.Fatalf("cleanup order=%d,%d, want client then hub", first, second)
+	}
+	select {
+	case <-hub.closed:
+	default:
+		t.Fatal("hub cleanup did not join after client cleanup")
+	}
 }
 
 // notify wakes a waiter after a handler has observed a request or changed

--- a/cmd/evener-tui/tmux_e2e_test.go
+++ b/cmd/evener-tui/tmux_e2e_test.go
@@ -1701,9 +1701,20 @@ func normalizePane(s string) string {
 }
 
 type tuiE2EHub struct {
-	t      *testing.T
-	server *httptest.Server
-	app    *appserver.Server
+	t         *testing.T
+	server    *httptest.Server
+	app       *appserver.Server
+	closeOnce sync.Once
+	// ready is closed by the HTTP handler, not by httptest.NewServer's
+	// listener setup.  The latter only proves that a port was allocated; it
+	// does not prove that the server goroutine has reached the handler under a
+	// constrained scheduler.
+	ready chan struct{}
+	// changed is a coalescing notification for state observed by the wait
+	// helpers below.  Waiting on handler events avoids turning a 5-second hang
+	// backstop into a timer-driven polling loop.
+	changed       chan struct{}
+	readyRequests atomic.Int32
 
 	mu              sync.Mutex
 	order           []string
@@ -1754,6 +1765,8 @@ func newTUIE2EHub(t *testing.T) *tuiE2EHub {
 		sessions:  map[string]*tuiE2ESession{},
 		actions:   map[string]int{},
 		harnesses: []appwire.HarnessDescriptor{{ID: "evener", Label: "evener", Kind: "evener"}},
+		ready:     make(chan struct{}),
+		changed:   make(chan struct{}, 1),
 	}
 	h.addSession(&tuiE2ESession{
 		ID:           "01LIVE",
@@ -1837,13 +1850,52 @@ func newTUIE2EHub(t *testing.T) *tuiE2EHub {
 	app := appserver.NewServer(appserver.ServerConfig{ServerName: "evener-hub", SourceID: "local"})
 	h.app = app
 	h.registerHandlers(app)
+	var readyOnce sync.Once
 	h.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ready" {
+			h.readyRequests.Add(1)
+			readyOnce.Do(func() { close(h.ready) })
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		if r.URL.Path != "/rpc" {
 			http.NotFound(w, r)
 			return
 		}
 		app.ServeWebSocket(w, r)
 	}))
+	// Complete one real request through the installed handler before handing
+	// the address to the tmux child.  A bound listener alone is insufficient:
+	// on a loaded runner the child can otherwise spend its entire dial context
+	// waiting for net/http's serve goroutine to be scheduled.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.server.URL+"/ready", nil)
+	if err != nil {
+		cancel()
+		h.server.Close()
+		t.Fatalf("build hub readiness request: %v", err)
+	}
+	resp, err := h.server.Client().Do(req)
+	cancel()
+	if err != nil {
+		h.server.Close()
+		t.Fatalf("hub readiness request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		h.server.Close()
+		t.Fatalf("hub readiness status=%d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+	if got := h.readyRequests.Load(); got != 1 {
+		h.server.Close()
+		t.Fatalf("hub readiness handler calls=%d, want 1", got)
+	}
+	select {
+	case <-h.ready:
+	default:
+		h.server.Close()
+		t.Fatal("hub readiness request completed without handler readiness event")
+	}
 	return h
 }
 
@@ -1896,7 +1948,17 @@ func (h *tuiE2EHub) URL() string {
 }
 
 func (h *tuiE2EHub) Close() {
-	h.server.Close()
+	h.closeOnce.Do(func() { h.server.Close() })
+}
+
+// notify wakes a waiter after a handler has observed a request or changed
+// fixture state. Notifications are intentionally coalesced: every waiter
+// re-checks its predicate, so one wakeup is sufficient for a burst of RPCs.
+func (h *tuiE2EHub) notify() {
+	select {
+	case h.changed <- struct{}{}:
+	default:
+	}
 }
 
 func (h *tuiE2EHub) SetHarnesses(harnesses []appwire.HarnessDescriptor) {
@@ -2033,6 +2095,7 @@ func (h *tuiE2EHub) addSession(s *tuiE2ESession) {
 }
 
 func (h *tuiE2EHub) handleThreadList(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+	defer h.notify()
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.treeGets++
@@ -2058,6 +2121,7 @@ func (h *tuiE2EHub) handleThreadRead(ctx context.Context, params appwire.ThreadR
 }
 
 func (h *tuiE2EHub) handleModelList(_ context.Context, params appwire.ModelListParams) (appwire.ModelListResponse, error) {
+	defer h.notify()
 	h.mu.Lock()
 	authRequired := h.authRequired
 	h.mu.Unlock()
@@ -2079,11 +2143,13 @@ func (h *tuiE2EHub) handleModelList(_ context.Context, params appwire.ModelListP
 }
 
 func (h *tuiE2EHub) handleAuthStatus(_ context.Context, params appwire.AuthStatusParams) (appwire.AuthStatusResponse, error) {
+	defer h.notify()
 	h.recordAuthCall("status", params.Provider)
 	return appwire.AuthStatusResponse{Provider: "openai", Supported: true, ActiveSource: "signed-out"}, nil
 }
 
 func (h *tuiE2EHub) handleAuthLoginStart(_ context.Context, params appwire.AuthLoginStartParams) (appwire.AuthLoginStartResponse, error) {
+	defer h.notify()
 	h.recordAuthCall("login-start", params.Provider)
 	return appwire.AuthLoginStartResponse{
 		Provider: "openai",
@@ -2093,6 +2159,7 @@ func (h *tuiE2EHub) handleAuthLoginStart(_ context.Context, params appwire.AuthL
 }
 
 func (h *tuiE2EHub) handleAuthLoginComplete(_ context.Context, params appwire.AuthLoginCompleteParams) (appwire.AuthLoginCompleteResponse, error) {
+	defer h.notify()
 	h.recordAuthCall("login-complete", params.Provider)
 	h.mu.Lock()
 	h.authCompletions = append(h.authCompletions, params)
@@ -2109,6 +2176,7 @@ func (h *tuiE2EHub) handleAuthLoginComplete(_ context.Context, params appwire.Au
 }
 
 func (h *tuiE2EHub) handleAuthLogout(_ context.Context, params appwire.AuthLogoutParams) (appwire.AuthLogoutResponse, error) {
+	defer h.notify()
 	h.recordAuthCall("logout", params.Provider)
 	return appwire.AuthLogoutResponse{
 		Removed: true,
@@ -2117,6 +2185,7 @@ func (h *tuiE2EHub) handleAuthLogout(_ context.Context, params appwire.AuthLogou
 }
 
 func (h *tuiE2EHub) handleThreadStart(_ context.Context, params appwire.ThreadStartParams) (appwire.ThreadStartResponse, error) {
+	defer h.notify()
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.failSpawn {
@@ -2151,6 +2220,7 @@ func (h *tuiE2EHub) handleThreadStart(_ context.Context, params appwire.ThreadSt
 }
 
 func (h *tuiE2EHub) handleThreadResume(_ context.Context, params appwire.ThreadResumeParams) (appwire.ThreadResumeResponse, error) {
+	defer h.notify()
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.resumes = append(h.resumes, params)
@@ -2176,6 +2246,7 @@ func (h *tuiE2EHub) handleThreadResume(_ context.Context, params appwire.ThreadR
 }
 
 func (h *tuiE2EHub) handleTurnStart(_ context.Context, params appwire.TurnStartParams) (appwire.TurnStartResponse, error) {
+	defer h.notify()
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.failSend {
@@ -2186,6 +2257,7 @@ func (h *tuiE2EHub) handleTurnStart(_ context.Context, params appwire.TurnStartP
 }
 
 func (h *tuiE2EHub) handleTurnSteer(_ context.Context, params appwire.TurnSteerParams) (appwire.EmptyResponse, error) {
+	defer h.notify()
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.steers = append(h.steers, params)
@@ -2193,6 +2265,7 @@ func (h *tuiE2EHub) handleTurnSteer(_ context.Context, params appwire.TurnSteerP
 }
 
 func (h *tuiE2EHub) handleTurnQueue(_ context.Context, params appwire.TurnQueueParams) (appwire.EmptyResponse, error) {
+	defer h.notify()
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.queues = append(h.queues, params)
@@ -2200,6 +2273,7 @@ func (h *tuiE2EHub) handleTurnQueue(_ context.Context, params appwire.TurnQueueP
 }
 
 func (h *tuiE2EHub) handleTurnDrainAsSteer(_ context.Context, params appwire.TurnDrainAsSteerParams) (appwire.EmptyResponse, error) {
+	defer h.notify()
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.drains = append(h.drains, params)
@@ -2207,6 +2281,7 @@ func (h *tuiE2EHub) handleTurnDrainAsSteer(_ context.Context, params appwire.Tur
 }
 
 func (h *tuiE2EHub) handleTasksList(context.Context, appwire.TaskListParams) (appwire.TaskListResponse, error) {
+	defer h.notify()
 	h.mu.Lock()
 	fail := h.failTasks
 	h.mu.Unlock()
@@ -2217,6 +2292,7 @@ func (h *tuiE2EHub) handleTasksList(context.Context, appwire.TaskListParams) (ap
 }
 
 func (h *tuiE2EHub) handleThreadTranscriptList(_ context.Context, params appwire.ThreadTranscriptListParams) (appwire.ThreadTranscriptListResponse, error) {
+	defer h.notify()
 	id := threadIDFromParams(params.Ref, "")
 	if id != "01LIVE" {
 		return appwire.ThreadTranscriptListResponse{}, appwire.Unavailable("thread not found: " + id)
@@ -2228,16 +2304,19 @@ func (h *tuiE2EHub) handleThreadTranscriptList(_ context.Context, params appwire
 }
 
 func (h *tuiE2EHub) handleTurnInterrupt(context.Context, appwire.TurnInterruptParams) (appwire.EmptyResponse, error) {
+	defer h.notify()
 	h.recordAction("interrupt")
 	return appwire.EmptyResponse{}, nil
 }
 
 func (h *tuiE2EHub) handleThreadCompactStart(context.Context, appwire.ThreadCompactStartParams) (appwire.EmptyResponse, error) {
+	defer h.notify()
 	h.recordAction("compact")
 	return appwire.EmptyResponse{}, nil
 }
 
 func (h *tuiE2EHub) handleThreadModelSet(_ context.Context, params appwire.ThreadModelSetParams) (appwire.EmptyResponse, error) {
+	defer h.notify()
 	h.mu.Lock()
 	h.models = append(h.models, params.Model)
 	h.mu.Unlock()
@@ -2245,6 +2324,7 @@ func (h *tuiE2EHub) handleThreadModelSet(_ context.Context, params appwire.Threa
 }
 
 func (h *tuiE2EHub) handleThreadClear(context.Context, appwire.ThreadClearParams) (appwire.ThreadClearResponse, error) {
+	defer h.notify()
 	h.recordAction("clear")
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -2265,6 +2345,7 @@ func (h *tuiE2EHub) handleThreadClear(context.Context, appwire.ThreadClearParams
 }
 
 func (h *tuiE2EHub) handleThreadFork(_ context.Context, params appwire.ThreadForkParams) (appwire.ThreadForkResponse, error) {
+	defer h.notify()
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.failFork {
@@ -2580,12 +2661,16 @@ func (h *tuiE2EHub) WaitForActionCount(t *testing.T, action string, count int) i
 
 func (h *tuiE2EHub) waitFor(t *testing.T, pred func() bool, desc string) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	for {
 		if pred() {
 			return
 		}
-		time.Sleep(20 * time.Millisecond)
+		select {
+		case <-h.changed:
+		case <-timer.C:
+			t.Fatalf("timed out waiting for %s", desc)
+		}
 	}
-	t.Fatalf("timed out waiting for %s", desc)
 }

--- a/cmd/evener-tui/tmux_e2e_test.go
+++ b/cmd/evener-tui/tmux_e2e_test.go
@@ -1714,6 +1714,7 @@ type tuiE2EHub struct {
 	rpcClosing   bool
 	rpcStarts    atomic.Int32
 	rpcExits     atomic.Int32
+	rpcJoined    atomic.Bool
 	// rpcExitGate is test-only instrumentation that keeps one handler in its
 	// deferred exit path until the close event-driven rescue releases it.
 	rpcExitGate <-chan struct{}
@@ -1976,12 +1977,17 @@ func (h *tuiE2EHub) Close() {
 		// wait is safe because beginRPCHandler closes the admission gate before
 		// waiting, so no Add can race with Wait.
 		h.server.Close()
-		h.rpcWG.Wait()
+		h.joinRPCHandlers()
 		if h.cleanupTrace != nil {
 			h.cleanupTrace <- 4
 		}
 		close(h.closed)
 	})
+}
+
+func (h *tuiE2EHub) joinRPCHandlers() {
+	h.rpcWG.Wait()
+	h.rpcJoined.Store(true)
 }
 
 func (h *tuiE2EHub) beginRPCHandler() bool {
@@ -2066,6 +2072,9 @@ func TestTUITmuxE2EHubCleanupJoinsClientBeforeServer(t *testing.T) {
 	default:
 		t.Fatal("hub cleanup completed without the joined closed event")
 	}
+	if !hub.rpcJoined.Load() {
+		t.Fatal("hub cleanup completed without joining RPC handlers")
+	}
 }
 
 func TestTUITmuxE2EHubHandlerLifetimeEdges(t *testing.T) {
@@ -2079,6 +2088,9 @@ func TestTUITmuxE2EHubHandlerLifetimeEdges(t *testing.T) {
 		}
 		if got := hub.rpcExits.Load(); got != 0 {
 			t.Fatalf("RPC exits=%d, want 0", got)
+		}
+		if !hub.rpcJoined.Load() {
+			t.Fatal("zero-handler close did not complete the join")
 		}
 	})
 
@@ -2097,6 +2109,9 @@ func TestTUITmuxE2EHubHandlerLifetimeEdges(t *testing.T) {
 		}
 		if got := hub.rpcExits.Load(); got != 1 {
 			t.Fatalf("RPC exits=%d, want 1", got)
+		}
+		if !hub.rpcJoined.Load() {
+			t.Fatal("accept-error close did not complete the join")
 		}
 	})
 
@@ -2121,6 +2136,9 @@ func TestTUITmuxE2EHubHandlerLifetimeEdges(t *testing.T) {
 		}
 		if got := hub.rpcExits.Load(); got != 2 {
 			t.Fatalf("RPC exits=%d, want 2", got)
+		}
+		if !hub.rpcJoined.Load() {
+			t.Fatal("multiple-handler close did not complete the join")
 		}
 	})
 }

--- a/cmd/evener-tui/tmux_e2e_test.go
+++ b/cmd/evener-tui/tmux_e2e_test.go
@@ -1709,6 +1709,14 @@ type tuiE2EHub struct {
 	// cleanupTrace is test-only instrumentation for the lifecycle regression;
 	// it stays nil for every normal E2E fixture.
 	cleanupTrace chan<- int
+	rpcMu        sync.Mutex
+	rpcWG        sync.WaitGroup
+	rpcClosing   bool
+	rpcStarts    atomic.Int32
+	rpcExits     atomic.Int32
+	// rpcExitGate is test-only instrumentation that keeps one handler in its
+	// deferred exit path until the close event-driven rescue releases it.
+	rpcExitGate <-chan struct{}
 	// ready is closed by the HTTP handler, not by httptest.NewServer's
 	// listener setup.  The latter only proves that a port was allocated; it
 	// does not prove that the server goroutine has reached the handler under a
@@ -1867,6 +1875,10 @@ func newTUIE2EHub(t *testing.T) *tuiE2EHub {
 			http.NotFound(w, r)
 			return
 		}
+		if !h.beginRPCHandler() {
+			return
+		}
+		defer h.endRPCHandler()
 		app.ServeWebSocket(w, r)
 	}))
 	// Complete one real request through the installed handler before handing
@@ -1957,9 +1969,41 @@ func (h *tuiE2EHub) Close() {
 		if h.cleanupTrace != nil {
 			h.cleanupTrace <- 2
 		}
+		h.rpcMu.Lock()
+		h.rpcClosing = true
+		h.rpcMu.Unlock()
+		// Server.Close does not join hijacked WebSocket handlers. The explicit
+		// wait is safe because beginRPCHandler closes the admission gate before
+		// waiting, so no Add can race with Wait.
 		h.server.Close()
+		h.rpcWG.Wait()
+		if h.cleanupTrace != nil {
+			h.cleanupTrace <- 4
+		}
 		close(h.closed)
 	})
+}
+
+func (h *tuiE2EHub) beginRPCHandler() bool {
+	h.rpcMu.Lock()
+	defer h.rpcMu.Unlock()
+	if h.rpcClosing {
+		return false
+	}
+	h.rpcWG.Add(1)
+	h.rpcStarts.Add(1)
+	return true
+}
+
+func (h *tuiE2EHub) endRPCHandler() {
+	if h.rpcExitGate != nil {
+		<-h.rpcExitGate
+	}
+	if h.cleanupTrace != nil {
+		h.cleanupTrace <- 3
+	}
+	h.rpcExits.Add(1)
+	h.rpcWG.Done()
 }
 
 // registerTUIE2EHubCleanup deliberately uses t.Cleanup rather than defer.
@@ -1973,35 +2017,112 @@ func registerTUIE2EHubCleanup(t *testing.T, hub *tuiE2EHub) {
 }
 
 // TestTUITmuxE2EHubCleanupJoinsClientBeforeServer exercises the real WebSocket
-// handler lifetime that makes httptest.Server.Close a joining operation. The
-// client cleanup is registered after the hub cleanup, matching the tmux
-// starter's later t.Cleanup registration. If this is changed back to defer,
-// the helper returns and runs hub.Close while the client is still connected;
-// the test then blocks in the real server join instead of leaving an orphan.
+// handler lifetime separately from httptest.Server.Close: hijacked connections
+// are not part of that server's close wait, so the fixture owns an explicit
+// handler join. The event-driven rescue closes the client if a mutation starts
+// hub cleanup first, turning the wrong order into a structural order failure
+// instead of a test hang.
 func TestTUITmuxE2EHubCleanupJoinsClientBeforeServer(t *testing.T) {
 	var hub *tuiE2EHub
-	trace := make(chan int, 2)
+	trace := make(chan int, 4)
+	observed := make(chan int, 4)
+	rescueDone := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
 	t.Run("setup-lifecycle", func(t *testing.T) {
 		hub = newTUIE2EHub(t)
-		hub.cleanupTrace = trace
+		hub.rpcExitGate = release
 		transport, err := appwire.DialWebSocket(context.Background(), "ws"+strings.TrimPrefix(hub.URL(), "http")+"/rpc", hub.server.Client())
 		if err != nil {
 			t.Fatalf("dial test hub: %v", err)
 		}
+		hub.cleanupTrace = trace
+		go func() {
+			seen := [5]bool{}
+			for !seen[1] || !seen[2] || !seen[3] || !seen[4] {
+				event := <-trace
+				observed <- event
+				seen[event] = true
+				if event == 2 {
+					_ = transport.Close()
+					releaseOnce.Do(func() { close(release) })
+				}
+			}
+			close(rescueDone)
+		}()
 		registerTUIE2EHubCleanup(t, hub)
 		t.Cleanup(func() {
-			_ = transport.Close()
 			trace <- 1
+			_ = transport.Close()
 		})
 	})
-	if first, second := <-trace, <-trace; first != 1 || second != 2 {
-		t.Fatalf("cleanup order=%d,%d, want client then hub", first, second)
+	order := [4]int{<-observed, <-observed, <-observed, <-observed}
+	if order != [4]int{1, 2, 3, 4} {
+		t.Fatalf("cleanup/handler order=%v, want client, hub-start, handler-exit, hub-complete", order)
 	}
+	<-rescueDone
 	select {
 	case <-hub.closed:
 	default:
-		t.Fatal("hub cleanup did not join after client cleanup")
+		t.Fatal("hub cleanup completed without the joined closed event")
 	}
+}
+
+func TestTUITmuxE2EHubHandlerLifetimeEdges(t *testing.T) {
+	t.Run("zero-handlers-and-repeated-close", func(t *testing.T) {
+		hub := newTUIE2EHub(t)
+		registerTUIE2EHubCleanup(t, hub)
+		hub.Close()
+		hub.Close()
+		if got := hub.rpcStarts.Load(); got != 0 {
+			t.Fatalf("RPC starts=%d, want 0", got)
+		}
+		if got := hub.rpcExits.Load(); got != 0 {
+			t.Fatalf("RPC exits=%d, want 0", got)
+		}
+	})
+
+	t.Run("accept-error-returns-handler", func(t *testing.T) {
+		hub := newTUIE2EHub(t)
+		registerTUIE2EHubCleanup(t, hub)
+		resp, err := hub.server.Client().Get(hub.URL() + "/rpc")
+		if err != nil {
+			t.Fatalf("GET /rpc: %v", err)
+		}
+		_ = resp.Body.Close()
+		hub.Close()
+		hub.Close()
+		if got := hub.rpcStarts.Load(); got != 1 {
+			t.Fatalf("RPC starts=%d, want 1", got)
+		}
+		if got := hub.rpcExits.Load(); got != 1 {
+			t.Fatalf("RPC exits=%d, want 1", got)
+		}
+	})
+
+	t.Run("multiple-handlers", func(t *testing.T) {
+		hub := newTUIE2EHub(t)
+		first, err := appwire.DialWebSocket(context.Background(), "ws"+strings.TrimPrefix(hub.URL(), "http")+"/rpc", hub.server.Client())
+		if err != nil {
+			t.Fatalf("dial first handler: %v", err)
+		}
+		second, err := appwire.DialWebSocket(context.Background(), "ws"+strings.TrimPrefix(hub.URL(), "http")+"/rpc", hub.server.Client())
+		if err != nil {
+			_ = first.Close()
+			t.Fatalf("dial second handler: %v", err)
+		}
+		registerTUIE2EHubCleanup(t, hub)
+		_ = first.Close()
+		_ = second.Close()
+		hub.Close()
+		hub.Close()
+		if got := hub.rpcStarts.Load(); got != 2 {
+			t.Fatalf("RPC starts=%d, want 2", got)
+		}
+		if got := hub.rpcExits.Load(); got != 2 {
+			t.Fatalf("RPC exits=%d, want 2", got)
+		}
+	})
 }
 
 // notify wakes a waiter after a handler has observed a request or changed


### PR DESCRIPTION
## Summary

Fixes recurring tmux TUI E2E readiness failures observed in the PR #399/#412 CI runs:

- [BrowseAndFork failure](https://github.com/prime-radiant-inc/evener/actions/runs/32794987631): WebSocket handshake to localhost ended in `context deadline exceeded` before `EVENER LIVE`.
- [DashboardProjectAndSpawn failure](https://github.com/prime-radiant-inc/evener/actions/runs/32794805535): second spawn remained on the new-session prompt for 63.51s.

## Root cause and fix

The harness handed the tmux child a bound `httptest` address before proving that the installed HTTP handler had actually run. A constrained scheduler could leave the server's serve goroutine unscheduled long enough for the child's initial WebSocket dial context to expire. The harness now makes one `/ready` request through the installed handler, waits for that handler-installed event, and asserts the handler ran exactly once before launching tmux.

Hub request waits now block on coalesced handler notifications and retain one five-second hang backstop; they no longer poll fixture state every 20ms. Existing input-readiness probing, dead-pane/process assertions, dedicated tmux cleanup, socket removal, and test cleanup registration remain intact. Hub close is idempotent.

## Verification

- Focused pair: `go test ./cmd/evener-tui -run '^TestTUITmuxE2E_(BrowseAndFork|DashboardProjectAndSpawn)$' -count=5` — PASS on current-main merge head.
- Focused pair under 8 CPU spinners: `go test -race ./cmd/evener-tui -run '^TestTUITmuxE2E_(BrowseAndFork|DashboardProjectAndSpawn)$' -count=5` — PASS.
- Focused pair race without load, `-count=2` — PASS.
- Full `go test ./cmd/evener-tui -count=1` — PASS (40.747s before current-main merge; focused pair re-run after merge).
- `go vet ./cmd/evener-tui ./cmd/evener-hub` — PASS.
- `make lint-gofmt lint-generated` — PASS.
- `golangci-lint run ./cmd/evener-tui/... ./cmd/evener-hub/...` — 0 issues.
- `GOOS=windows/linux GOARCH=amd64 CGO_ENABLED=0 go test -c` for TUI and Windows hub — PASS.
- `git diff --check` — PASS.
- Short relevant hub tests — PASS before merge (`go test ./cmd/evener-hub -short -run '^(Test|Example)' -count=1`). A later broad hub package run on the merge head reproduced unrelated #421 detach rendezvous timeouts in `TestSpawnDaemonDetachesFromHubSession` and `TestResumeDaemonDetachesFromHubSession`; this PR does not change hub detach code.

## Scope

One focused test-harness file; no production behavior, retries, deadlines, serialization, or E2E coverage were weakened.
