### PR TITLE
fix(web): make Chrome guard readiness race-free

### DIFF
--- a/cmd/evener-hub/frontend/scripts/browserGuardCdp.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardCdp.mjs
@@ -46,11 +46,9 @@ function withTimeout(promise, ms, operation) {
 
 export function devtoolsHttpURL(endpoint, pathname) {
   const announced = new URL(endpoint.url);
-  announced.protocol = "http:";
-  announced.pathname = pathname;
-  announced.search = "";
-  announced.hash = "";
-  return announced.toString();
+  const host = endpoint.host ?? announced.hostname;
+  const port = endpoint.port ?? Number(announced.port || 80);
+  return `http://${host}:${port}${pathname}`;
 }
 
 function abortReason(signal) {
@@ -70,6 +68,29 @@ function delay(ms, signal) {
       reject(abortReason(signal));
     };
     signal.addEventListener("abort", abort, { once: true });
+  });
+}
+
+const startupFailures = new WeakSet();
+
+function raceWithFailure(promise, failure) {
+  if (!failure) return promise;
+  return Promise.race([
+    promise,
+    failure.then((error) => {
+      startupFailures.add(error);
+      throw error;
+    }),
+  ]);
+}
+
+function raceWithAbort(promise, signal) {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(abortReason(signal));
+  return new Promise((resolve, reject) => {
+    const abort = () => reject(abortReason(signal));
+    signal.addEventListener("abort", abort, { once: true });
+    promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
   });
 }
 
@@ -97,17 +118,18 @@ export function createStartupDeadline(ms = 30000) {
  * Chrome that could not launch must not abort - or be blamed for - the wait on
  * a Vite that is coming up fine.
  */
-export async function waitForHttp(url, label, launchFailed = () => null, { signal } = {}) {
+export async function waitForHttp(url, label, launchFailed = () => null, { signal, failure = null, fetchImpl = fetch } = {}) {
   for (let attempt = 0; attempt < 300; attempt++) {
     if (signal?.aborted) throw abortReason(signal);
     const launchError = launchFailed();
     if (launchError) throw launchError;
     try {
-      if ((await fetch(url, signal ? { signal } : undefined)).ok) return;
-    } catch {
+      if ((await raceWithFailure(raceWithAbort(fetchImpl(url, signal ? { signal } : undefined), signal), failure)).ok) return;
+    } catch (error) {
+      if (startupFailures.has(error) || signal?.aborted) throw startupFailures.has(error) ? error : abortReason(signal);
       // The child process is still starting.
     }
-    await delay(100, signal);
+    await raceWithFailure(delay(100, signal), failure);
   }
   throw new Error(`${label} never came up at ${url}`);
 }

--- a/cmd/evener-hub/frontend/scripts/browserGuardCdp.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardCdp.mjs
@@ -44,6 +44,47 @@ function withTimeout(promise, ms, operation) {
   ]).finally(() => clearTimeout(timer));
 }
 
+export function devtoolsHttpURL(endpoint, pathname) {
+  const announced = new URL(endpoint.url);
+  announced.protocol = "http:";
+  announced.pathname = pathname;
+  announced.search = "";
+  announced.hash = "";
+  return announced.toString();
+}
+
+function abortReason(signal) {
+  return signal?.reason ?? new Error("operation aborted");
+}
+
+function delay(ms, signal) {
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms));
+  if (signal.aborted) return Promise.reject(abortReason(signal));
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", abort);
+      resolve();
+    }, ms);
+    const abort = () => {
+      clearTimeout(timer);
+      reject(abortReason(signal));
+    };
+    signal.addEventListener("abort", abort, { once: true });
+  });
+}
+
+export function createStartupDeadline(ms = 30000) {
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(new Error(`browser startup deadline exceeded after ${ms}ms`)),
+    ms,
+  );
+  return {
+    signal: controller.signal,
+    clear: () => clearTimeout(timer),
+  };
+}
+
 /**
  * Poll a URL until it answers OK; the error names what never came up.
  *
@@ -56,16 +97,17 @@ function withTimeout(promise, ms, operation) {
  * Chrome that could not launch must not abort - or be blamed for - the wait on
  * a Vite that is coming up fine.
  */
-export async function waitForHttp(url, label, launchFailed = () => null) {
+export async function waitForHttp(url, label, launchFailed = () => null, { signal } = {}) {
   for (let attempt = 0; attempt < 300; attempt++) {
+    if (signal?.aborted) throw abortReason(signal);
     const launchError = launchFailed();
     if (launchError) throw launchError;
     try {
-      if ((await fetch(url)).ok) return;
+      if ((await fetch(url, signal ? { signal } : undefined)).ok) return;
     } catch {
       // The child process is still starting.
     }
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await delay(100, signal);
   }
   throw new Error(`${label} never came up at ${url}`);
 }
@@ -75,8 +117,8 @@ export async function waitForHttp(url, label, launchFailed = () => null) {
  * send() rejects on a CDP error response so a failing command can never read
  * as a successful measurement. Callers close() in a finally.
  */
-export async function connectPage(cdpPort) {
-  const targets = await (await fetch(`http://127.0.0.1:${cdpPort}/json/list`)).json();
+export async function connectPage(endpoint) {
+  const targets = await (await fetch(devtoolsHttpURL(endpoint, "/json/list"))).json();
   const target = targets.find((entry) => entry.type === "page");
   if (!target) throw new Error("chrome exposed no page target");
 

--- a/cmd/evener-hub/frontend/scripts/browserGuardCdp.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardCdp.test.mjs
@@ -36,6 +36,10 @@ test("preserves the announced endpoint host when building HTTP URLs", () => {
     devtoolsHttpURL({ url: "ws://localhost:43211/devtools/browser/test" }, "/json/list"),
     "http://localhost:43211/json/list",
   );
+  assert.equal(
+    devtoolsHttpURL({ url: "ws://127.0.0.1:80/devtools/browser/test", host: "127.0.0.1", port: 80 }, "/json/version"),
+    "http://127.0.0.1:80/json/version",
+  );
 });
 
 test("one startup deadline aborts the pending HTTP readiness phase", async (context) => {

--- a/cmd/evener-hub/frontend/scripts/browserGuardCdp.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardCdp.test.mjs
@@ -19,10 +19,36 @@ import { test } from "node:test";
 import {
   applyViewport,
   clearViewportOverride,
+  createStartupDeadline,
+  devtoolsHttpURL,
   evaluate,
   forcePseudoStates,
   navigateTo,
+  waitForHttp,
 } from "./browserGuardCdp.mjs";
+
+test("preserves the announced endpoint host when building HTTP URLs", () => {
+  assert.equal(
+    devtoolsHttpURL({ url: "ws://[::1]:43210/devtools/browser/test" }, "/json/version"),
+    "http://[::1]:43210/json/version",
+  );
+  assert.equal(
+    devtoolsHttpURL({ url: "ws://localhost:43211/devtools/browser/test" }, "/json/list"),
+    "http://localhost:43211/json/list",
+  );
+});
+
+test("one startup deadline aborts the pending HTTP readiness phase", async (context) => {
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+  const deadline = createStartupDeadline();
+  const pending = waitForHttp("http://127.0.0.1:1/json/version", "chrome", () => null, {
+    signal: deadline.signal,
+  });
+
+  context.mock.timers.tick(30_000);
+  await assert.rejects(pending, /browser startup deadline exceeded after 30000ms/);
+  deadline.clear();
+});
 
 const cdpModuleUrl = new URL("./browserGuardCdp.mjs", import.meta.url).href;
 

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
@@ -26,6 +26,12 @@ export function parseChromeDevToolsAnnouncement(line) {
   if (!line.startsWith(DEVTOOLS_ANNOUNCEMENT_PREFIX)) return null;
   const raw = line.slice(DEVTOOLS_ANNOUNCEMENT_PREFIX.length);
   if (!raw || /\s/.test(raw)) throw new Error(`malformed DevTools announcement URL: ${raw || "(empty)"}`);
+  const authority = raw.match(/^ws:\/\/(\[[^\]]+\]|[^/?#:]+):(\d+)(?:\/|$)/i);
+  if (!authority) throw new Error(`malformed DevTools announcement authority: ${raw}`);
+  const announcedPort = Number(authority[2]);
+  if (!Number.isInteger(announcedPort) || announcedPort < 1 || announcedPort > 65535) {
+    throw new Error(`invalid DevTools announcement port: ${raw}`);
+  }
 
   let endpoint;
   try {
@@ -37,22 +43,23 @@ export function parseChromeDevToolsAnnouncement(line) {
     throw new Error(`invalid DevTools announcement URL: ${raw}`);
   }
   if (!isLoopbackHost(endpoint.hostname)) throw new Error(`DevTools announcement is not loopback: ${raw}`);
-  if (!/^\d+$/.test(endpoint.port) || Number(endpoint.port) < 1 || Number(endpoint.port) > 65535) {
-    throw new Error(`invalid DevTools announcement port: ${raw}`);
-  }
   if (!/^\/devtools\/browser\/[^/]+$/.test(endpoint.pathname)) {
     throw new Error(`invalid DevTools announcement path: ${raw}`);
   }
-  return { url: endpoint.toString(), host: endpoint.hostname, port: Number(endpoint.port) };
+  return { url: raw, host: endpoint.hostname, port: announcedPort };
 }
 
-function withAbort(promise, signal) {
-  if (!signal) return promise;
-  if (signal.aborted) return Promise.reject(signal.reason ?? new Error("operation aborted"));
+function withAbort(promise, signal, failure = null) {
+  if (!signal && !failure) return promise;
+  if (signal?.aborted) return Promise.reject(signal.reason ?? new Error("operation aborted"));
+  const racers = [promise];
+  if (failure) racers.push(new Promise((_, reject) => failure.then(reject)));
+  const raced = Promise.race(racers);
+  if (!signal) return raced;
   return new Promise((resolve, reject) => {
     const abort = () => reject(signal.reason ?? new Error("operation aborted"));
     signal.addEventListener("abort", abort, { once: true });
-    promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
+    raced.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
   });
 }
 
@@ -447,11 +454,10 @@ function waitForProfileProcessExit(
 export async function requestBrowserClose(endpoint, fetchImpl = fetch, WebSocketImpl = WebSocket) {
   if (!endpoint) throw new Error("Chrome DevTools endpoint was not announced");
   const announced = new URL(endpoint.url);
-  announced.protocol = "http:";
-  announced.pathname = "/json/version";
-  announced.search = "";
-  announced.hash = "";
-  const response = await fetchImpl(announced.toString());
+  const host = endpoint.host ?? announced.hostname;
+  const port = endpoint.port ?? Number(announced.port || 80);
+  const httpURL = `http://${host}:${port}/json/version`;
+  const response = await fetchImpl(httpURL);
   if (!response.ok) throw new Error(`Chrome CDP endpoint returned ${response.status}`);
   const version = await response.json();
   if (!version.webSocketDebuggerUrl) throw new Error("Chrome CDP endpoint omitted its browser WebSocket");
@@ -653,7 +659,16 @@ export async function startBrowserGuard({
   let chromeLineBuffer = "";
   let resolveChromeReady;
   let rejectChromeReady;
+  let resolveChromeFailure;
+  let chromeFailureSettled = false;
   let chromeReadySettled = false;
+  const chromeFailure = new Promise((resolve) => {
+    resolveChromeFailure = (error) => {
+      if (chromeFailureSettled) return;
+      chromeFailureSettled = true;
+      resolve(error);
+    };
+  });
   const chromeReady = new Promise((resolve, reject) => {
     resolveChromeReady = (endpoint) => {
       if (chromeReadySettled) return;
@@ -670,6 +685,11 @@ export async function startBrowserGuard({
   // too so a child that exits while startup is being abandoned cannot become an
   // unhandled rejection during cleanup.
   chromeReady.catch(() => {});
+  const failChrome = (error) => {
+    chromeLaunchError ??= error;
+    resolveChromeFailure(error);
+    if (!chromeReadySettled) rejectChromeReady(error);
+  };
   const lifecycle = createBrowserProcessCleanup({
     profileDir,
     processTarget,
@@ -741,8 +761,7 @@ export async function startBrowserGuard({
       },
     );
     chrome.on("error", (error) => {
-      chromeLaunchError ??= error;
-      rejectChromeReady(error);
+      failChrome(error);
     });
     chrome.stderr?.on("data", (chunk) => {
       chromeErr += chunk;
@@ -754,8 +773,7 @@ export async function startBrowserGuard({
         try {
           endpoint = parseChromeDevToolsAnnouncement(line);
         } catch (error) {
-          chromeLaunchError ??= error;
-          rejectChromeReady(error);
+          failChrome(error);
           continue;
         }
         if (!endpoint) continue;
@@ -766,8 +784,7 @@ export async function startBrowserGuard({
           const error = new Error(
             `conflicting DevTools announcements: ${chromeEndpoint.url} and ${endpoint.url}`,
           );
-          chromeLaunchError ??= error;
-          rejectChromeReady(error);
+          failChrome(error);
           continue;
         }
         chromeEndpoint ??= endpoint;
@@ -779,8 +796,7 @@ export async function startBrowserGuard({
         `Chrome exited ${chromeEndpoint ? "after DevTools announcement " : "before DevTools readiness "}` +
           `(code ${code ?? "unknown"}, signal ${signal ?? "none"})`,
       );
-      chromeLaunchError ??= error;
-      if (!chromeReadySettled) rejectChromeReady(error);
+      failChrome(error);
     });
     lifecycle.addChild(chrome, {
       processGroupId: useProcessGroups && Number.isInteger(chrome.pid) ? chrome.pid : null,
@@ -799,12 +815,13 @@ export async function startBrowserGuard({
     getChromeError: () => chromeErr,
     getViteLaunchError: () => viteLaunchError,
     getChromeLaunchError: () => chromeLaunchError,
+    getChromeFailure: () => chromeFailure,
     chromeBinary: resolvedChrome,
     getChromeArgv: () => chromeArgv,
     // This promise is the process/devtools readiness handoff. The runner owns
     // its single startup deadline and passes its abort signal through both the
     // announcement and /json/version phases.
-    waitForChrome: ({ signal } = {}) => withAbort(chromeReady, signal),
+    waitForChrome: ({ signal } = {}) => withAbort(chromeReady, signal, chromeFailure),
     cleanup: lifecycle.cleanup,
   };
 }

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
@@ -12,8 +12,49 @@ const CHROME_CANDIDATES = [
 ];
 
 const CHILD_EXIT_GRACE_MS = 2_000;
-const CHROME_READINESS_TIMEOUT_MS = 30_000;
 const SIGNAL_EXIT_CODES = { SIGINT: 130, SIGTERM: 143 };
+const DEVTOOLS_ANNOUNCEMENT_PREFIX = "DevTools listening on ";
+
+function isLoopbackHost(hostname) {
+  if (hostname === "localhost" || hostname === "[::1]") return true;
+  const octets = hostname.split(".");
+  return octets.length === 4 && octets[0] === "127" && octets.every((octet) => /^(0|[1-9]\d*)$/.test(octet) && Number(octet) <= 255);
+}
+
+/** Parse one complete Chrome stderr announcement, or ignore an unrelated line. */
+export function parseChromeDevToolsAnnouncement(line) {
+  if (!line.startsWith(DEVTOOLS_ANNOUNCEMENT_PREFIX)) return null;
+  const raw = line.slice(DEVTOOLS_ANNOUNCEMENT_PREFIX.length);
+  if (!raw || /\s/.test(raw)) throw new Error(`malformed DevTools announcement URL: ${raw || "(empty)"}`);
+
+  let endpoint;
+  try {
+    endpoint = new URL(raw);
+  } catch {
+    throw new Error(`malformed DevTools announcement URL: ${raw}`);
+  }
+  if (endpoint.protocol !== "ws:" || endpoint.username || endpoint.password || endpoint.search || endpoint.hash) {
+    throw new Error(`invalid DevTools announcement URL: ${raw}`);
+  }
+  if (!isLoopbackHost(endpoint.hostname)) throw new Error(`DevTools announcement is not loopback: ${raw}`);
+  if (!/^\d+$/.test(endpoint.port) || Number(endpoint.port) < 1 || Number(endpoint.port) > 65535) {
+    throw new Error(`invalid DevTools announcement port: ${raw}`);
+  }
+  if (!/^\/devtools\/browser\/[^/]+$/.test(endpoint.pathname)) {
+    throw new Error(`invalid DevTools announcement path: ${raw}`);
+  }
+  return { url: endpoint.toString(), host: endpoint.hostname, port: Number(endpoint.port) };
+}
+
+function withAbort(promise, signal) {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(signal.reason ?? new Error("operation aborted"));
+  return new Promise((resolve, reject) => {
+    const abort = () => reject(signal.reason ?? new Error("operation aborted"));
+    signal.addEventListener("abort", abort, { once: true });
+    promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
+  });
+}
 
 /**
  * Format the diagnostic a browser guard prints when the stack will not come up.
@@ -403,8 +444,14 @@ function waitForProfileProcessExit(
   });
 }
 
-export async function requestBrowserClose(port, fetchImpl = fetch, WebSocketImpl = WebSocket) {
-  const response = await fetchImpl(`http://127.0.0.1:${port}/json/version`);
+export async function requestBrowserClose(endpoint, fetchImpl = fetch, WebSocketImpl = WebSocket) {
+  if (!endpoint) throw new Error("Chrome DevTools endpoint was not announced");
+  const announced = new URL(endpoint.url);
+  announced.protocol = "http:";
+  announced.pathname = "/json/version";
+  announced.search = "";
+  announced.hash = "";
+  const response = await fetchImpl(announced.toString());
   if (!response.ok) throw new Error(`Chrome CDP endpoint returned ${response.status}`);
   const version = await response.json();
   if (!version.webSocketDebuggerUrl) throw new Error("Chrome CDP endpoint omitted its browser WebSocket");
@@ -602,16 +649,16 @@ export async function startBrowserGuard({
   let viteLaunchError = null;
   let chromeLaunchError = null;
   let chromeArgv = [];
-  let cdpPort = 0;
+  let chromeEndpoint = null;
+  let chromeLineBuffer = "";
   let resolveChromeReady;
   let rejectChromeReady;
   let chromeReadySettled = false;
   const chromeReady = new Promise((resolve, reject) => {
-    resolveChromeReady = (port) => {
+    resolveChromeReady = (endpoint) => {
       if (chromeReadySettled) return;
       chromeReadySettled = true;
-      cdpPort = port;
-      resolve(port);
+      resolve(endpoint);
     };
     rejectChromeReady = (error) => {
       if (chromeReadySettled) return;
@@ -699,20 +746,45 @@ export async function startBrowserGuard({
     });
     chrome.stderr?.on("data", (chunk) => {
       chromeErr += chunk;
-      const match = chromeErr.match(/DevTools listening on ws:\/\/(?:127\.0\.0\.1|localhost|\[::1\]):(\d+)\//);
-      if (match) resolveChromeReady(Number(match[1]));
+      chromeLineBuffer += chunk.toString();
+      const lines = chromeLineBuffer.split(/\r\n|\r|\n/);
+      chromeLineBuffer = lines.pop() ?? "";
+      for (const line of lines) {
+        let endpoint;
+        try {
+          endpoint = parseChromeDevToolsAnnouncement(line);
+        } catch (error) {
+          chromeLaunchError ??= error;
+          rejectChromeReady(error);
+          continue;
+        }
+        if (!endpoint) continue;
+        // Identical duplicate announcements are harmless; a different valid
+        // endpoint invalidates startup rather than making listener order decide
+        // which browser to measure or close.
+        if (chromeEndpoint && chromeEndpoint.url !== endpoint.url) {
+          const error = new Error(
+            `conflicting DevTools announcements: ${chromeEndpoint.url} and ${endpoint.url}`,
+          );
+          chromeLaunchError ??= error;
+          rejectChromeReady(error);
+          continue;
+        }
+        chromeEndpoint ??= endpoint;
+        resolveChromeReady(endpoint);
+      }
     });
     chrome.once("exit", (code, signal) => {
-      if (chromeReadySettled) return;
       const error = new Error(
-        `Chrome exited before DevTools readiness (code ${code ?? "unknown"}, signal ${signal ?? "none"})`,
+        `Chrome exited ${chromeEndpoint ? "after DevTools announcement " : "before DevTools readiness "}` +
+          `(code ${code ?? "unknown"}, signal ${signal ?? "none"})`,
       );
       chromeLaunchError ??= error;
-      rejectChromeReady(error);
+      if (!chromeReadySettled) rejectChromeReady(error);
     });
     lifecycle.addChild(chrome, {
       processGroupId: useProcessGroups && Number.isInteger(chrome.pid) ? chrome.pid : null,
-      gracefulClose: () => closeBrowser(cdpPort),
+      gracefulClose: () => closeBrowser(chromeEndpoint),
     });
   } catch (error) {
     await lifecycle.cleanup();
@@ -721,7 +793,7 @@ export async function startBrowserGuard({
 
   return {
     vitePort,
-    cdpPort,
+    getChromeEndpoint: () => chromeEndpoint,
     profileDir,
     getViteError: () => viteErr,
     getChromeError: () => chromeErr,
@@ -729,21 +801,10 @@ export async function startBrowserGuard({
     getChromeLaunchError: () => chromeLaunchError,
     chromeBinary: resolvedChrome,
     getChromeArgv: () => chromeArgv,
-    // This promise is the process/devtools readiness handoff. The caller must
-    // use its returned port rather than probing a port selected before Chrome
-    // started, which could be claimed by another concurrent guard.
-    waitForChrome: () => {
-      let timer;
-      return Promise.race([
-        chromeReady,
-        new Promise((_, reject) => {
-          timer = setTimeout(
-            () => reject(new Error("Chrome DevTools readiness line never appeared")),
-            CHROME_READINESS_TIMEOUT_MS,
-          );
-        }),
-      ]).finally(() => clearTimeout(timer));
-    },
+    // This promise is the process/devtools readiness handoff. The runner owns
+    // its single startup deadline and passes its abort signal through both the
+    // announcement and /json/version phases.
+    waitForChrome: ({ signal } = {}) => withAbort(chromeReady, signal),
     cleanup: lifecycle.cleanup,
   };
 }

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
@@ -12,6 +12,7 @@ const CHROME_CANDIDATES = [
 ];
 
 const CHILD_EXIT_GRACE_MS = 2_000;
+const CHROME_READINESS_TIMEOUT_MS = 30_000;
 const SIGNAL_EXIT_CODES = { SIGINT: 130, SIGTERM: 143 };
 
 /**
@@ -593,7 +594,6 @@ export async function startBrowserGuard({
 }) {
   const resolvedChrome = chromeBinary ?? findChrome();
   const vitePort = await findAvailablePort();
-  const cdpPort = await findAvailablePort([vitePort]);
   const profileDir = mkdtempSync(path.join(tmpdir(), profilePrefix));
   let vite = null;
   let chrome = null;
@@ -602,6 +602,27 @@ export async function startBrowserGuard({
   let viteLaunchError = null;
   let chromeLaunchError = null;
   let chromeArgv = [];
+  let cdpPort = 0;
+  let resolveChromeReady;
+  let rejectChromeReady;
+  let chromeReadySettled = false;
+  const chromeReady = new Promise((resolve, reject) => {
+    resolveChromeReady = (port) => {
+      if (chromeReadySettled) return;
+      chromeReadySettled = true;
+      cdpPort = port;
+      resolve(port);
+    };
+    rejectChromeReady = (error) => {
+      if (chromeReadySettled) return;
+      chromeReadySettled = true;
+      reject(error);
+    };
+  });
+  // A guard normally awaits this promise, but attach a rejection handler here
+  // too so a child that exits while startup is being abandoned cannot become an
+  // unhandled rejection during cleanup.
+  chromeReady.catch(() => {});
   const lifecycle = createBrowserProcessCleanup({
     profileDir,
     processTarget,
@@ -649,7 +670,10 @@ export async function startBrowserGuard({
       "--headless=new",
       "--disable-gpu",
       ...chromeProfileIsolationArgs(platform),
-      `--remote-debugging-port=${cdpPort}`,
+      // Let Chrome bind the port itself and report the bound endpoint on stderr.
+      // Picking a free port, closing it, then asking Chrome to reuse it is a
+      // TOCTOU race when several guards start together.
+      "--remote-debugging-port=0",
       `--user-data-dir=${profileDir}`,
       "--no-first-run",
       "--disable-extensions",
@@ -671,9 +695,20 @@ export async function startBrowserGuard({
     );
     chrome.on("error", (error) => {
       chromeLaunchError ??= error;
+      rejectChromeReady(error);
     });
     chrome.stderr?.on("data", (chunk) => {
       chromeErr += chunk;
+      const match = chromeErr.match(/DevTools listening on ws:\/\/(?:127\.0\.0\.1|localhost|\[::1\]):(\d+)\//);
+      if (match) resolveChromeReady(Number(match[1]));
+    });
+    chrome.once("exit", (code, signal) => {
+      if (chromeReadySettled) return;
+      const error = new Error(
+        `Chrome exited before DevTools readiness (code ${code ?? "unknown"}, signal ${signal ?? "none"})`,
+      );
+      chromeLaunchError ??= error;
+      rejectChromeReady(error);
     });
     lifecycle.addChild(chrome, {
       processGroupId: useProcessGroups && Number.isInteger(chrome.pid) ? chrome.pid : null,
@@ -694,6 +729,21 @@ export async function startBrowserGuard({
     getChromeLaunchError: () => chromeLaunchError,
     chromeBinary: resolvedChrome,
     getChromeArgv: () => chromeArgv,
+    // This promise is the process/devtools readiness handoff. The caller must
+    // use its returned port rather than probing a port selected before Chrome
+    // started, which could be claimed by another concurrent guard.
+    waitForChrome: () => {
+      let timer;
+      return Promise.race([
+        chromeReady,
+        new Promise((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error("Chrome DevTools readiness line never appeared")),
+            CHROME_READINESS_TIMEOUT_MS,
+          );
+        }),
+      ]).finally(() => clearTimeout(timer));
+    },
     cleanup: lifecycle.cleanup,
   };
 }

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
@@ -848,6 +848,42 @@ test("a Vite that never launched aborts its own wait and is not blamed on Chrome
   assert.equal(existsSync(guard.profileDir), false);
 });
 
+test("hands the caller Chrome's dynamically bound DevTools port after delayed readiness", async (context) => {
+  const { guard, children } = await startFakeGuard();
+  reapOnTeardown(context, guard, children);
+
+  const ready = guard.waitForChrome();
+  setTimeout(() => {
+    children[1].stderr.emit(
+      "data",
+      "startup noise\nDevTools listening on ws://127.0.0.1:45678/devtools/browser/test\n",
+    );
+  }, 10);
+
+  assert.equal(await ready, 45678);
+  assert.equal(
+    guard.getChromeArgv().find((arg) => arg.startsWith("--remote-debugging-port=")),
+    "--remote-debugging-port=0",
+  );
+
+  const cleanup = guard.cleanup();
+  for (const child of children) child.exit();
+  await cleanup;
+});
+
+test("fails the readiness handoff immediately when Chrome start fails", async (context) => {
+  const { guard, children } = await startFakeGuard();
+  reapOnTeardown(context, guard, children);
+  const ready = guard.waitForChrome();
+  children[1].failLaunch(launchError("EACCES", "spawn /fake/chrome EACCES"));
+
+  await assert.rejects(ready, /spawn \/fake\/chrome EACCES/);
+
+  const cleanup = guard.cleanup();
+  children[0].exit();
+  await cleanup;
+});
+
 // FakeChild.failLaunch above is a MODEL of Node's failed-spawn behaviour, and a
 // model that cannot happen in production is a green test that guards nothing.
 // This runs the real thing: real spawn(), a real non-executable file for Chrome

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
@@ -102,8 +102,16 @@ test("allocates distinct local ports", async () => {
 
 test("parses only valid loopback DevTools announcement lines", () => {
   assert.equal(browserGuardProcess.parseChromeDevToolsAnnouncement("ordinary Chrome stderr"), null);
+  for (const port of [1, 80, 65535]) {
+    const endpoint = browserGuardProcess.parseChromeDevToolsAnnouncement(
+      `DevTools listening on ws://127.0.0.1:${port}/devtools/browser/id`,
+    );
+    assert.equal(endpoint.port, port);
+  }
   for (const line of [
+    "DevTools listening on ws://127.0.0.1:0/devtools/browser/id",
     "DevTools listening on ws://127.0.0.1:99999/not-a-devtools-path",
+    "DevTools listening on ws://127.0.0.1:65536/devtools/browser/id",
     "DevTools listening on ws://192.168.1.10:43210/devtools/browser/id",
     "DevTools listening on ws://127.0.0.1:43210/devtools/page/id",
     'DevTools listening on "ws://127.0.0.1:43210/devtools/browser/id"',
@@ -916,21 +924,72 @@ test("fails the production readiness handoff on a malformed announcement", async
   await cleanup;
 });
 
-test("keeps Chrome exit as a failure after readiness announcement", async (context) => {
+test("interrupts hanging HTTP readiness after Chrome exits", async (context) => {
   const { guard, children } = await startFakeGuard();
   reapOnTeardown(context, guard, children);
   const ready = guard.waitForChrome();
   children[1].stderr.emit("data", "DevTools listening on ws://localhost:43213/devtools/browser/ready\n");
-  await ready;
+  const endpoint = await ready;
+  const pending = waitForHttp(
+    "http://localhost:43213/json/version",
+    "chrome devtools endpoint",
+    guard.getChromeLaunchError,
+    { failure: guard.getChromeFailure(), fetchImpl: () => new Promise(() => {}) },
+  );
   children[1].emit("exit", 17, null);
 
-  assert.match(guard.getChromeLaunchError()?.message ?? "", /code 17/);
-  assert.match(guard.getChromeLaunchError()?.message ?? "", /signal none/);
+  await assert.rejects(pending, /Chrome exited after DevTools announcement \(code 17, signal none\)/);
+  assert.equal(endpoint.host, "localhost");
 
   const cleanup = guard.cleanup();
   children[0].exit();
   children[1].exit();
   await cleanup;
+});
+
+test("interrupts hanging HTTP readiness on a conflicting duplicate but not an identical one", async (context) => {
+  const { guard, children } = await startFakeGuard();
+  reapOnTeardown(context, guard, children);
+  const ready = guard.waitForChrome();
+  children[1].stderr.emit("data", "DevTools listening on ws://localhost:43216/devtools/browser/ready\n");
+  await ready;
+  children[1].stderr.emit("data", "DevTools listening on ws://localhost:43216/devtools/browser/ready\n");
+  const pending = waitForHttp(
+    "http://localhost:43216/json/version",
+    "chrome devtools endpoint",
+    guard.getChromeLaunchError,
+    { failure: guard.getChromeFailure(), fetchImpl: () => new Promise(() => {}) },
+  );
+  children[1].stderr.emit("data", "DevTools listening on ws://127.0.0.1:43217/devtools/browser/conflict\n");
+
+  await assert.rejects(pending, /conflicting DevTools announcements/);
+  const cleanup = guard.cleanup();
+  for (const child of children) child.exit();
+  await cleanup;
+  assert.equal(existsSync(guard.profileDir), false);
+});
+
+test("runner abort interrupts hanging HTTP readiness after an identical duplicate", async (context) => {
+  const { guard, children } = await startFakeGuard();
+  reapOnTeardown(context, guard, children);
+  const controller = new AbortController();
+  const ready = guard.waitForChrome({ signal: controller.signal });
+  children[1].stderr.emit("data", "DevTools listening on ws://localhost:43218/devtools/browser/ready\n");
+  await ready;
+  children[1].stderr.emit("data", "DevTools listening on ws://localhost:43218/devtools/browser/ready\n");
+  const pending = waitForHttp(
+    "http://localhost:43218/json/version",
+    "chrome devtools endpoint",
+    guard.getChromeLaunchError,
+    { signal: controller.signal, failure: guard.getChromeFailure(), fetchImpl: () => new Promise(() => {}) },
+  );
+  controller.abort(new Error("startup deadline"));
+
+  await assert.rejects(pending, /startup deadline/);
+  const cleanup = guard.cleanup();
+  for (const child of children) child.exit();
+  await cleanup;
+  assert.equal(existsSync(guard.profileDir), false);
 });
 
 test("cleans up through the announced endpoint host", async (context) => {
@@ -980,7 +1039,7 @@ test("requestBrowserClose uses the announced host and port", async () => {
   }
 
   await browserGuardProcess.requestBrowserClose(
-    { url: "ws://[::1]:43215/devtools/browser/close" },
+    { url: "ws://[::1]:43215/devtools/browser/close", host: "[::1]", port: 43215 },
     async (url) => {
       requests.push(url);
       return { ok: true, json: async () => ({ webSocketDebuggerUrl: "ws://[::1]:43215/devtools/browser/close" }) };

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
@@ -100,6 +100,18 @@ test("allocates distinct local ports", async () => {
   assert.ok(second > 0);
 });
 
+test("parses only valid loopback DevTools announcement lines", () => {
+  assert.equal(browserGuardProcess.parseChromeDevToolsAnnouncement("ordinary Chrome stderr"), null);
+  for (const line of [
+    "DevTools listening on ws://127.0.0.1:99999/not-a-devtools-path",
+    "DevTools listening on ws://192.168.1.10:43210/devtools/browser/id",
+    "DevTools listening on ws://127.0.0.1:43210/devtools/page/id",
+    'DevTools listening on "ws://127.0.0.1:43210/devtools/browser/id"',
+  ]) {
+    assert.throws(() => browserGuardProcess.parseChromeDevToolsAnnouncement(line));
+  }
+});
+
 test("disables Chrome crash reporting outside the private browser profile", async () => {
   const { guard, children } = await startFakeGuard();
   try {
@@ -787,10 +799,9 @@ test("a browser binary that could not be resolved says nothing was spawned", () 
 // reaps the Vite server and the private profile. These three cases pin the
 // listener, the attribution, and that cleanup still finishes.
 //
-// "The readiness wait" is waitForHttp, which polls for 30 seconds. A launch
-// that already failed has nothing to poll FOR, so the wait aborts with the
-// launch error itself rather than reporting a timeout against a subsystem that
-// was never running.
+// A launch that already failed has nothing to poll FOR, so the readiness handoff
+// aborts with the launch error itself rather than reporting a timeout against a
+// subsystem that was never running.
 const UNREACHABLE = "http://127.0.0.1:1/json/version";
 
 test("a Chrome that never launched aborts the readiness wait naming the launch error", async (context) => {
@@ -848,19 +859,19 @@ test("a Vite that never launched aborts its own wait and is not blamed on Chrome
   assert.equal(existsSync(guard.profileDir), false);
 });
 
-test("hands the caller Chrome's dynamically bound DevTools port after delayed readiness", async (context) => {
+test("hands the caller the complete IPv6 endpoint after CRLF chunked readiness", async (context) => {
   const { guard, children } = await startFakeGuard();
   reapOnTeardown(context, guard, children);
 
   const ready = guard.waitForChrome();
-  setTimeout(() => {
-    children[1].stderr.emit(
-      "data",
-      "startup noise\nDevTools listening on ws://127.0.0.1:45678/devtools/browser/test\n",
-    );
-  }, 10);
+  children[1].stderr.emit("data", "startup noise\rDevTools listening on ws://[::1]:43210/devtools/browser/");
+  children[1].stderr.emit("data", "chunked\r\n");
 
-  assert.equal(await ready, 45678);
+  assert.deepEqual(await ready, {
+    url: "ws://[::1]:43210/devtools/browser/chunked",
+    host: "[::1]",
+    port: 43210,
+  });
   assert.equal(
     guard.getChromeArgv().find((arg) => arg.startsWith("--remote-debugging-port=")),
     "--remote-debugging-port=0",
@@ -869,6 +880,115 @@ test("hands the caller Chrome's dynamically bound DevTools port after delayed re
   const cleanup = guard.cleanup();
   for (const child of children) child.exit();
   await cleanup;
+});
+
+test("rejects malformed and conflicting DevTools announcements", async (context) => {
+  const { guard, children } = await startFakeGuard();
+  reapOnTeardown(context, guard, children);
+  const ready = guard.waitForChrome();
+
+  children[1].stderr.emit("data", 'noise "DevTools listening on ws://127.0.0.1:99999/not-a-devtools-path"\n');
+  assert.equal(guard.getChromeLaunchError(), null);
+  children[1].stderr.emit("data", "DevTools listening on ws://127.0.0.1:43211/devtools/browser/first\n");
+  assert.deepEqual(await ready, {
+    url: "ws://127.0.0.1:43211/devtools/browser/first",
+    host: "127.0.0.1",
+    port: 43211,
+  });
+
+  children[1].stderr.emit("data", "DevTools listening on ws://localhost:43212/devtools/browser/second\n");
+  assert.match(guard.getChromeLaunchError()?.message ?? "", /conflicting DevTools announcements/);
+
+  const cleanup = guard.cleanup();
+  for (const child of children) child.exit();
+  await cleanup;
+});
+
+test("fails the production readiness handoff on a malformed announcement", async (context) => {
+  const { guard, children } = await startFakeGuard();
+  reapOnTeardown(context, guard, children);
+  const ready = guard.waitForChrome();
+  children[1].stderr.emit("data", "DevTools listening on ws://127.0.0.1:99999/not-a-devtools-path\n");
+  await assert.rejects(ready, /(?:malformed|invalid) DevTools announcement/);
+
+  const cleanup = guard.cleanup();
+  for (const child of children) child.exit();
+  await cleanup;
+});
+
+test("keeps Chrome exit as a failure after readiness announcement", async (context) => {
+  const { guard, children } = await startFakeGuard();
+  reapOnTeardown(context, guard, children);
+  const ready = guard.waitForChrome();
+  children[1].stderr.emit("data", "DevTools listening on ws://localhost:43213/devtools/browser/ready\n");
+  await ready;
+  children[1].emit("exit", 17, null);
+
+  assert.match(guard.getChromeLaunchError()?.message ?? "", /code 17/);
+  assert.match(guard.getChromeLaunchError()?.message ?? "", /signal none/);
+
+  const cleanup = guard.cleanup();
+  children[0].exit();
+  children[1].exit();
+  await cleanup;
+});
+
+test("cleans up through the announced endpoint host", async (context) => {
+  const endpoints = [];
+  const { guard, children } = await startFakeGuard({
+    closeBrowser(endpoint) {
+      endpoints.push(endpoint);
+      return Promise.resolve();
+    },
+  });
+  reapOnTeardown(context, guard, children);
+  const ready = guard.waitForChrome();
+  children[1].stderr.emit("data", "DevTools listening on ws://[::1]:43214/devtools/browser/cleanup\n");
+  assert.deepEqual(await ready, {
+    url: "ws://[::1]:43214/devtools/browser/cleanup",
+    host: "[::1]",
+    port: 43214,
+  });
+
+  const cleanup = guard.cleanup();
+  for (const child of children) child.exit();
+  await cleanup;
+  assert.deepEqual(endpoints, [
+    { url: "ws://[::1]:43214/devtools/browser/cleanup", host: "[::1]", port: 43214 },
+  ]);
+});
+
+test("requestBrowserClose uses the announced host and port", async () => {
+  const requests = [];
+  const sockets = [];
+  class FakeWebSocket extends EventEmitter {
+    constructor(url) {
+      super();
+      this.url = url;
+      sockets.push(this);
+      queueMicrotask(() => this.emit("open"));
+    }
+
+    addEventListener(type, listener) {
+      this.once(type, listener);
+    }
+
+    send(message) {
+      assert.deepEqual(JSON.parse(message), { id: 1, method: "Browser.close" });
+      queueMicrotask(() => this.emit("close"));
+    }
+  }
+
+  await browserGuardProcess.requestBrowserClose(
+    { url: "ws://[::1]:43215/devtools/browser/close" },
+    async (url) => {
+      requests.push(url);
+      return { ok: true, json: async () => ({ webSocketDebuggerUrl: "ws://[::1]:43215/devtools/browser/close" }) };
+    },
+    FakeWebSocket,
+  );
+  assert.deepEqual(requests, ["http://[::1]:43215/json/version"]);
+  assert.deepEqual(sockets.map((socket) => socket.url), ["ws://[::1]:43215/devtools/browser/close"]);
 });
 
 test("fails the readiness handoff immediately when Chrome start fails", async (context) => {
@@ -882,6 +1002,21 @@ test("fails the readiness handoff immediately when Chrome start fails", async (c
   const cleanup = guard.cleanup();
   children[0].exit();
   await cleanup;
+});
+
+test("aborts pending readiness without an unhandled rejection and still cleans up", async (context) => {
+  const { guard, children } = await startFakeGuard();
+  reapOnTeardown(context, guard, children);
+  const controller = new AbortController();
+  const pending = guard.waitForChrome({ signal: controller.signal });
+  const deadline = new Error("startup deadline");
+  controller.abort(deadline);
+
+  await assert.rejects(pending, deadline);
+  const cleanup = guard.cleanup();
+  for (const child of children) child.exit();
+  await cleanup;
+  assert.equal(existsSync(guard.profileDir), false);
 });
 
 // FakeChild.failLaunch above is a MODEL of Node's failed-spawn behaviour, and a
@@ -919,14 +1054,7 @@ test("a real non-executable Chrome is named by the diagnostic and still gets cle
   // The 'error' event is asynchronous, so the wait is what observes it - and it
   // must observe it in well under the 30 seconds the poll would otherwise take.
   const started = Date.now();
-  await assert.rejects(
-    waitForHttp(
-      `http://127.0.0.1:${guard.cdpPort}/json/version`,
-      "chrome devtools endpoint",
-      guard.getChromeLaunchError,
-    ),
-    /EACCES/,
-  );
+  await assert.rejects(guard.waitForChrome(), /EACCES/);
   assert.ok(Date.now() - started < 5_000, "the wait must abort on the launch error, not poll to its timeout");
 
   const message = browserGuardProcess.describeBrowserStartupFailure({

--- a/cmd/evener-hub/frontend/scripts/layoutguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/run.mjs
@@ -75,6 +75,8 @@ import {
   forcePseudoStates,
   navigateTo,
   realizedViewport,
+  createStartupDeadline,
+  devtoolsHttpURL,
   waitForFonts,
   waitForHttp,
 } from "../browserGuardCdp.mjs";
@@ -219,7 +221,7 @@ async function main() {
     throw new Error(describeBrowserStartupFailure({ error, subsystem: "launch" }));
   }
   const { vitePort } = guard;
-  let cdpPort;
+  let cdpEndpoint;
 
   let failed = 0;
   const warnings = [];
@@ -231,12 +233,14 @@ async function main() {
         describeBrowserStartupFailure({ error: err, subsystem: "vite", viteStderr: guard.getViteError() }),
       );
     }
+    const startupDeadline = createStartupDeadline();
     try {
-      cdpPort = await guard.waitForChrome();
+      cdpEndpoint = await guard.waitForChrome({ signal: startupDeadline.signal });
       await waitForHttp(
-        `http://127.0.0.1:${cdpPort}/json/version`,
+        devtoolsHttpURL(cdpEndpoint, "/json/version"),
         "chrome devtools endpoint",
         guard.getChromeLaunchError,
+        { signal: startupDeadline.signal },
       );
     } catch (err) {
       throw new Error(
@@ -249,9 +253,11 @@ async function main() {
           viteStderr: guard.getViteError(),
         }),
       );
+    } finally {
+      startupDeadline.clear();
     }
 
-    const page = await connectPage(cdpPort);
+    const page = await connectPage(cdpEndpoint);
     const emulation = { viewportApplied: false };
     if (process.env.LAYOUTGUARD_DEBUG) {
       page.ws.addEventListener("message", (event) => {

--- a/cmd/evener-hub/frontend/scripts/layoutguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/run.mjs
@@ -218,7 +218,8 @@ async function main() {
     // commonest environment failure there is and it reached here unframed.
     throw new Error(describeBrowserStartupFailure({ error, subsystem: "launch" }));
   }
-  const { vitePort, cdpPort } = guard;
+  const { vitePort } = guard;
+  let cdpPort;
 
   let failed = 0;
   const warnings = [];
@@ -231,6 +232,7 @@ async function main() {
       );
     }
     try {
+      cdpPort = await guard.waitForChrome();
       await waitForHttp(
         `http://127.0.0.1:${cdpPort}/json/version`,
         "chrome devtools endpoint",

--- a/cmd/evener-hub/frontend/scripts/layoutguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/run.mjs
@@ -240,7 +240,7 @@ async function main() {
         devtoolsHttpURL(cdpEndpoint, "/json/version"),
         "chrome devtools endpoint",
         guard.getChromeLaunchError,
-        { signal: startupDeadline.signal },
+        { signal: startupDeadline.signal, failure: guard.getChromeFailure() },
       );
     } catch (err) {
       throw new Error(

--- a/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
@@ -214,7 +214,7 @@ async function main() {
         devtoolsHttpURL(cdpEndpoint, "/json/version"),
         "chrome devtools endpoint",
         guard.getChromeLaunchError,
-        { signal: startupDeadline.signal },
+        { signal: startupDeadline.signal, failure: guard.getChromeFailure() },
       );
     } catch (err) {
       throw new Error(

--- a/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
@@ -191,7 +191,8 @@ async function main() {
     // commonest environment failure there is and it reached here unframed.
     throw new Error(describeBrowserStartupFailure({ error, subsystem: "launch" }));
   }
-  const { vitePort, cdpPort, cleanup } = guard;
+  const { vitePort, cleanup } = guard;
+  let cdpPort;
 
   let failed = 0;
   try {
@@ -207,6 +208,7 @@ async function main() {
       );
     }
     try {
+      cdpPort = await guard.waitForChrome();
       await waitForHttp(
         `http://127.0.0.1:${cdpPort}/json/version`,
         "chrome devtools endpoint",

--- a/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
@@ -38,7 +38,7 @@
 // launch (~10s).
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { connectPage, evaluate, navigateTo, waitForFonts, waitForHttp } from "../browserGuardCdp.mjs";
+import { connectPage, createStartupDeadline, devtoolsHttpURL, evaluate, navigateTo, waitForFonts, waitForHttp } from "../browserGuardCdp.mjs";
 import { describeBrowserStartupFailure, startBrowserGuard } from "../browserGuardProcess.mjs";
 
 const FRONTEND = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -49,8 +49,8 @@ const FRONTEND = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 // would have missed the original bug entirely.
 const DEFAULT_WIDTHS = [390, 700, 1024, 1400];
 
-async function measureAt(cdpPort, url) {
-  const page = await connectPage(cdpPort);
+async function measureAt(cdpEndpoint, url) {
+  const page = await connectPage(cdpEndpoint);
   const { send } = page;
   try {
     await navigateTo(page, url);
@@ -108,8 +108,8 @@ async function measureAt(cdpPort, url) {
 // menu directly: open Tasks, wait for the dock split to squeeze the main
 // composer's inline session chrome below 640px, then re-open the menu and
 // confirm "Tasks ✓".
-async function verifyPanelCollapse(cdpPort, url) {
-  const page = await connectPage(cdpPort);
+async function verifyPanelCollapse(cdpEndpoint, url) {
+  const page = await connectPage(cdpEndpoint);
   const { send } = page;
   try {
     await navigateTo(page, url);
@@ -192,7 +192,7 @@ async function main() {
     throw new Error(describeBrowserStartupFailure({ error, subsystem: "launch" }));
   }
   const { vitePort, cleanup } = guard;
-  let cdpPort;
+  let cdpEndpoint;
 
   let failed = 0;
   try {
@@ -207,12 +207,14 @@ async function main() {
         describeBrowserStartupFailure({ error: err, subsystem: "vite", viteStderr: guard.getViteError() }),
       );
     }
+    const startupDeadline = createStartupDeadline();
     try {
-      cdpPort = await guard.waitForChrome();
+      cdpEndpoint = await guard.waitForChrome({ signal: startupDeadline.signal });
       await waitForHttp(
-        `http://127.0.0.1:${cdpPort}/json/version`,
+        devtoolsHttpURL(cdpEndpoint, "/json/version"),
         "chrome devtools endpoint",
         guard.getChromeLaunchError,
+        { signal: startupDeadline.signal },
       );
     } catch (err) {
       throw new Error(
@@ -225,10 +227,12 @@ async function main() {
           viteStderr: guard.getViteError(),
         }),
       );
+    } finally {
+      startupDeadline.clear();
     }
 
     const panelCollapse = await verifyPanelCollapse(
-      cdpPort,
+      cdpEndpoint,
       `http://127.0.0.1:${vitePort}/overflowharness.html?w=1024&panels=1`,
     );
     if (
@@ -246,7 +250,7 @@ async function main() {
     }
 
     for (const width of sweep) {
-      const result = await measureAt(cdpPort, `http://127.0.0.1:${vitePort}/overflowharness.html?w=${width}`);
+      const result = await measureAt(cdpEndpoint, `http://127.0.0.1:${vitePort}/overflowharness.html?w=${width}`);
       let widthFailed = false;
       if (
         result.exceptionSafety.found !== 2 ||

--- a/cmd/evener-hub/frontend/scripts/shellguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/shellguard/run.mjs
@@ -114,7 +114,7 @@ async function main() {
         devtoolsHttpURL(cdpEndpoint, "/json/version"),
         "chrome devtools endpoint",
         guard.getChromeLaunchError,
-        { signal: startupDeadline.signal },
+        { signal: startupDeadline.signal, failure: guard.getChromeFailure() },
       );
     } catch (error) {
       throw new Error(

--- a/cmd/evener-hub/frontend/scripts/shellguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/shellguard/run.mjs
@@ -94,7 +94,8 @@ async function main() {
   } catch (error) {
     throw new Error(describeBrowserStartupFailure({ error, subsystem: "launch" }));
   }
-  const { vitePort, cdpPort, cleanup } = guard;
+  const { vitePort, cleanup } = guard;
+  let cdpPort;
 
   try {
     try {
@@ -105,6 +106,7 @@ async function main() {
       );
     }
     try {
+      cdpPort = await guard.waitForChrome();
       await waitForHttp(
         `http://127.0.0.1:${cdpPort}/json/version`,
         "chrome devtools endpoint",

--- a/cmd/evener-hub/frontend/scripts/shellguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/shellguard/run.mjs
@@ -17,6 +17,8 @@ import {
   clearViewportOverride,
   connectPage,
   evaluate,
+  createStartupDeadline,
+  devtoolsHttpURL,
   navigateTo,
   waitForFonts,
   waitForHttp,
@@ -30,8 +32,8 @@ const FRONTEND = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 // over - the exact condition the bug needed.
 const VIEWPORT = { width: 1400, height: 900 };
 
-async function measure(cdpPort, vitePort) {
-  const page = await connectPage(cdpPort);
+async function measure(cdpEndpoint, vitePort) {
+  const page = await connectPage(cdpEndpoint);
   const { send } = page;
   try {
     await applyViewport(send, VIEWPORT);
@@ -95,7 +97,7 @@ async function main() {
     throw new Error(describeBrowserStartupFailure({ error, subsystem: "launch" }));
   }
   const { vitePort, cleanup } = guard;
-  let cdpPort;
+  let cdpEndpoint;
 
   try {
     try {
@@ -105,12 +107,14 @@ async function main() {
         describeBrowserStartupFailure({ error, subsystem: "vite", viteStderr: guard.getViteError() }),
       );
     }
+    const startupDeadline = createStartupDeadline();
     try {
-      cdpPort = await guard.waitForChrome();
+      cdpEndpoint = await guard.waitForChrome({ signal: startupDeadline.signal });
       await waitForHttp(
-        `http://127.0.0.1:${cdpPort}/json/version`,
+        devtoolsHttpURL(cdpEndpoint, "/json/version"),
         "chrome devtools endpoint",
         guard.getChromeLaunchError,
+        { signal: startupDeadline.signal },
       );
     } catch (error) {
       throw new Error(
@@ -123,8 +127,10 @@ async function main() {
           viteStderr: guard.getViteError(),
         }),
       );
+    } finally {
+      startupDeadline.clear();
     }
-    const result = await measure(cdpPort, vitePort);
+    const result = await measure(cdpEndpoint, vitePort);
     const failures = assertResult(result);
     if (failures.length === 0) {
       console.log(

--- a/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
@@ -263,7 +263,7 @@ async function main() {
         devtoolsHttpURL(cdpEndpoint, "/json/version"),
         "chrome devtools endpoint",
         guard.getChromeLaunchError,
-        { signal: startupDeadline.signal },
+        { signal: startupDeadline.signal, failure: guard.getChromeFailure() },
       );
     } catch (error) {
       throw new Error(

--- a/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
@@ -8,7 +8,7 @@
 // and it has no dependency on provider credentials or the shared dev server.
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { applyViewport, clearViewportOverride, connectPage, evaluate, navigateTo, waitForFonts, waitForHttp } from "../browserGuardCdp.mjs";
+import { applyViewport, clearViewportOverride, connectPage, createStartupDeadline, devtoolsHttpURL, evaluate, navigateTo, waitForFonts, waitForHttp } from "../browserGuardCdp.mjs";
 import { describeBrowserStartupFailure, startBrowserGuard } from "../browserGuardProcess.mjs";
 
 const FRONTEND = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -37,8 +37,8 @@ function describeBox(box) {
   return `${box.left.toFixed(1)},${box.top.toFixed(1)} ${box.width.toFixed(1)}x${box.height.toFixed(1)}`;
 }
 
-async function measureAt(cdpPort, vitePort, width) {
-  const page = await connectPage(cdpPort);
+async function measureAt(cdpEndpoint, vitePort, width) {
+  const page = await connectPage(cdpEndpoint);
   const { send } = page;
   try {
     await applyViewport(send, { width, height: 900 });
@@ -245,7 +245,7 @@ async function main() {
     throw new Error(describeBrowserStartupFailure({ error, subsystem: "launch" }));
   }
   const { vitePort, cleanup } = guard;
-  let cdpPort;
+  let cdpEndpoint;
 
   let failed = 0;
   try {
@@ -256,12 +256,14 @@ async function main() {
         describeBrowserStartupFailure({ error: error, subsystem: "vite", viteStderr: guard.getViteError() }),
       );
     }
+    const startupDeadline = createStartupDeadline();
     try {
-      cdpPort = await guard.waitForChrome();
+      cdpEndpoint = await guard.waitForChrome({ signal: startupDeadline.signal });
       await waitForHttp(
-        `http://127.0.0.1:${cdpPort}/json/version`,
+        devtoolsHttpURL(cdpEndpoint, "/json/version"),
         "chrome devtools endpoint",
         guard.getChromeLaunchError,
+        { signal: startupDeadline.signal },
       );
     } catch (error) {
       throw new Error(
@@ -274,9 +276,11 @@ async function main() {
           viteStderr: guard.getViteError(),
         }),
       );
+    } finally {
+      startupDeadline.clear();
     }
     for (const width of WIDTHS) {
-      const result = await measureAt(cdpPort, vitePort, width);
+      const result = await measureAt(cdpEndpoint, vitePort, width);
       const failures = assertResult(result, width);
       if (failures.length === 0) {
         console.log(

--- a/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
@@ -244,7 +244,8 @@ async function main() {
     // commonest environment failure there is and it reached here unframed.
     throw new Error(describeBrowserStartupFailure({ error, subsystem: "launch" }));
   }
-  const { vitePort, cdpPort, cleanup } = guard;
+  const { vitePort, cleanup } = guard;
+  let cdpPort;
 
   let failed = 0;
   try {
@@ -256,6 +257,7 @@ async function main() {
       );
     }
     try {
+      cdpPort = await guard.waitForChrome();
       await waitForHttp(
         `http://127.0.0.1:${cdpPort}/json/version`,
         "chrome devtools endpoint",


### PR DESCRIPTION
## Summary

This is the review correction on the existing PR; it does not create a second PR.

The original run 32794771400 proves only that layoutguard's selected Chrome DevTools endpoint never appeared. It did not prove that another process stole the selected port: the guards ran serially, the log had no bind failure or announcement, and only showed delayed DBus startup diagnostics. The allocator close/rebind race is a real independent failure mechanism and remains removed, but it is stated here as a hypothesis rather than the observed cause.

## Corrected implementation

- Chrome still uses `--remote-debugging-port=0`; Chrome owns allocation atomically.
- A single runner-owned 30-second `AbortController` deadline covers both the complete stderr announcement handoff and `/json/version` HTTP readiness. There is no nested second 30-second ceiling or retry.
- Chrome exit remains an independent failure channel after announcement; code/signal is captured immediately and causes HTTP readiness to fail without waiting for timeout.
- Readiness parses complete CR/LF-delimited lines with `URL`, rejects malformed/non-loopback/non-WS/invalid-port/invalid-path announcements, preserves IPv4/IPv6/localhost endpoint details for HTTP, CDP, and cleanup, and rejects conflicting duplicates (identical duplicates are harmless).
- Deterministic production-path tests cover split chunks, CR/LF, unrelated/malformed/conflicting lines, host preservation, announce-then-exit, real EACCES through `waitForChrome`, shared deadline abort, pending abort cleanup/no unhandled rejection, and actual-endpoint cleanup.
- Geometry assertions, per-guard failure isolation, profiles, cleanup, Crashpad orphan detection, and all guard cases remain intact.

This resolves the requested changes and unblocks #414.

## Verification

- `node --test scripts/browserGuardProcess.test.mjs scripts/browserGuardCdp.test.mjs` — 48/48 passed
- `make test-web-browser` — layoutguard, overflowguard, shellguard, spawnguard passed
- `make test-web` — typecheck, frontend tests, Biome lint passed
- `make lint-generated lint-gofmt` — passed
- `GOMAXPROCS=2 go vet ./cmd/evener-hub/...` — passed
- `EVENER_GITLEAKS_REQUIRED=1 make secret-scan` — passed
- `node --check` on all eight changed `.mjs` files — passed
- `git diff --check` — passed
- Three repeated four-guard concurrent runs under eight CPU burners and lower guard scheduling priority — all 12 guard exits 0
- Process/profile residue audit after stress — no matching Chrome processes or private guard profiles

## Delivery

- Previous reviewed head: `950e7b6f3d8292dd3547799acc76cd01b2b1cf76`
- Corrected head: `fcf4307ea820cea7fddcd59dd72c57a2e20ac962`
- Base: `main`

No merge or approval requested.
