### PR TITLE
test: prevent detached fixture maintenance races

### DIFF
--- a/agent/internal/worktree/predicates_test.go
+++ b/agent/internal/worktree/predicates_test.go
@@ -85,13 +85,57 @@ func newPredicateMaintenanceProbe() *predicateMaintenanceProbe {
 	}
 }
 
+func predicateMaintenanceAutoEnabled(args []string) bool {
+	enabled := true
+	for i := 0; i < len(args); i++ {
+		var config string
+		switch {
+		case args[i] == "-c" && i+1 < len(args):
+			config = args[i+1]
+			i++
+		case strings.HasPrefix(args[i], "-c"):
+			config = args[i][2:]
+		default:
+			continue
+		}
+		key, value, ok := strings.Cut(config, "=")
+		if !ok || !strings.EqualFold(strings.TrimSpace(key), "maintenance.auto") {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(value)) {
+		case "false", "0", "no", "off":
+			enabled = false
+		default:
+			enabled = true
+		}
+	}
+	return enabled
+}
+
+func predicateQuiescentCommitArgs(args []string) []string {
+	commit := slices.Index(args, "commit")
+	if commit < 0 {
+		return args
+	}
+	quiescent := make([]string, 0, len(args)+2)
+	quiescent = append(quiescent, args[:commit]...)
+	quiescent = append(quiescent, "-c", "maintenance.auto=false")
+	return append(quiescent, args[commit:]...)
+}
+
 func (p *predicateMaintenanceProbe) run(underlyingRunner predicateGitRunner) predicateGitRunner {
 	return func(dir string, args ...string) (string, error) {
-		out, err := underlyingRunner(dir, args...)
+		commit := slices.Contains(args, "commit")
+		maintenanceAutoEnabled := commit && predicateMaintenanceAutoEnabled(args)
+		realArgs := args
+		if maintenanceAutoEnabled {
+			realArgs = predicateQuiescentCommitArgs(args)
+		}
+		out, err := underlyingRunner(dir, realArgs...)
 		if err != nil {
 			return out, err
 		}
-		if slices.Contains(args, "commit") && !slices.Contains(args, "maintenance.auto=false") {
+		if maintenanceAutoEnabled {
 			go func() {
 				lock := filepath.Join(dir, ".git", "objects", "maintenance.lock")
 				p.mutatorErr = os.WriteFile(lock, []byte("maintenance\n"), 0o644)
@@ -156,29 +200,29 @@ func buildPredicateRepoTemplate(run predicateGitRunner) (root, initialSHA string
 	}
 	root = filepath.Join(base, "repo")
 	if err := os.MkdirAll(root, 0o755); err != nil {
-		return "", "", err
+		return root, "", err
 	}
 	if _, err := run(root, "init", "-q", "-b", "main"); err != nil {
-		return "", "", err
+		return root, "", err
 	}
 	if _, err := run(root, "config", "user.email", "test@example.com"); err != nil {
-		return "", "", err
+		return root, "", err
 	}
 	if _, err := run(root, "config", "user.name", "Test"); err != nil {
-		return "", "", err
+		return root, "", err
 	}
 	if err := os.WriteFile(filepath.Join(root, "f.txt"), []byte("hi\n"), 0o644); err != nil {
-		return "", "", err
+		return root, "", err
 	}
 	if _, err := run(root, "add", "f.txt"); err != nil {
-		return "", "", err
+		return root, "", err
 	}
 	if _, err := run(root, "-c", "maintenance.auto=false", "commit", "-q", "-m", "init"); err != nil {
-		return "", "", err
+		return root, "", err
 	}
 	out, err := run(root, "rev-parse", "HEAD")
 	if err != nil {
-		return "", "", err
+		return root, "", err
 	}
 	return root, strings.TrimSpace(out), nil
 }
@@ -186,10 +230,17 @@ func buildPredicateRepoTemplate(run predicateGitRunner) (root, initialSHA string
 func TestPredicateFixturePublishesAfterSeedMaintenance(t *testing.T) {
 	probe := newPredicateMaintenanceProbe()
 	root, _, err := buildPredicateRepoTemplate(probe.run(runGitRaw))
+	if root != "" {
+		dir := filepath.Dir(root)
+		t.Cleanup(func() {
+			if removeErr := os.RemoveAll(dir); removeErr != nil {
+				t.Errorf("remove fixture: %v", removeErr)
+			}
+		})
+	}
 	if err != nil {
 		t.Fatalf("build repo template: %v", err)
 	}
-	defer os.RemoveAll(filepath.Dir(root))
 
 	destination := filepath.Join(t.TempDir(), "repo")
 	if err := os.CopyFS(destination, os.DirFS(root)); err != nil {
@@ -207,6 +258,97 @@ func TestPredicateFixturePublishesAfterSeedMaintenance(t *testing.T) {
 	}
 	if probe.publishedWhileActive {
 		t.Fatal("fixture publication overlapped the post-commit maintenance mutator")
+	}
+}
+
+func TestPredicateMaintenanceProbeUsesEffectiveBoolean(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		active bool
+	}{
+		{name: "false", args: []string{"-c", "maintenance.auto=false", "commit"}},
+		{name: "zero", args: []string{"-c", "maintenance.auto=0", "commit"}},
+		{name: "no", args: []string{"-c", "maintenance.auto=no", "commit"}},
+		{name: "off", args: []string{"-c", "maintenance.auto=off", "commit"}},
+		{name: "case insensitive false", args: []string{"-c", "maintenance.auto=FaLsE", "commit"}},
+		{name: "last false", args: []string{"-c", "maintenance.auto=true", "-c", "maintenance.auto=0", "commit"}},
+		{name: "true", args: []string{"-c", "maintenance.auto=true", "commit"}, active: true},
+		{name: "last true", args: []string{"-c", "maintenance.auto=0", "-c", "maintenance.auto=on", "commit"}, active: true},
+		{name: "absent", args: []string{"commit"}, active: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			probe := newPredicateMaintenanceProbe()
+			dir := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(dir, ".git", "objects"), 0o755); err != nil {
+				t.Fatalf("mkdir objects: %v", err)
+			}
+			var gotArgs []string
+			wrapped := probe.run(func(_ string, args ...string) (string, error) {
+				gotArgs = slices.Clone(args)
+				return "", nil
+			})
+			result := make(chan error, 1)
+			go func() {
+				_, err := wrapped(dir, test.args...)
+				result <- err
+			}()
+			if test.active {
+				<-probe.ready
+				probe.published()
+				if err := <-result; err != nil {
+					t.Fatalf("probe run: %v", err)
+				}
+				<-probe.exited
+				if probe.mutatorErr != nil {
+					t.Fatalf("maintenance mutator: %v", probe.mutatorErr)
+				}
+				if !probe.publishedWhileActive {
+					t.Fatal("expected publication overlap")
+				}
+				if !slices.Contains(gotArgs, "maintenance.auto=false") {
+					t.Fatalf("real runner args = %v, missing quiescent config", gotArgs)
+				}
+				return
+			}
+			if err := <-result; err != nil {
+				t.Fatalf("probe run: %v", err)
+			}
+			select {
+			case <-probe.ready:
+				t.Fatal("suppressed config launched synthetic maintenance")
+			default:
+			}
+			if !slices.Equal(gotArgs, test.args) {
+				t.Fatalf("real runner args = %v, want %v", gotArgs, test.args)
+			}
+		})
+	}
+}
+
+func TestPredicateFixtureSetupErrorRetainsCleanupRoot(t *testing.T) {
+	root, _, err := buildPredicateRepoTemplate(func(string, ...string) (string, error) {
+		return "", errors.New("injected setup error")
+	})
+	if root != "" {
+		dir := filepath.Dir(root)
+		t.Cleanup(func() {
+			if removeErr := os.RemoveAll(dir); removeErr != nil {
+				t.Errorf("remove fixture: %v", removeErr)
+			}
+			if _, statErr := os.Stat(dir); !errors.Is(statErr, os.ErrNotExist) {
+				t.Errorf("fixture root remains after cleanup: %v", statErr)
+			}
+		})
+		if _, statErr := os.Stat(dir); statErr != nil {
+			t.Fatalf("fixture root was not retained: %v", statErr)
+		}
+	} else {
+		t.Fatal("setup error did not retain fixture root")
+	}
+	if err == nil {
+		t.Fatal("injected setup error was not returned")
 	}
 }
 

--- a/agent/internal/worktree/predicates_test.go
+++ b/agent/internal/worktree/predicates_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -84,13 +85,13 @@ func newPredicateMaintenanceProbe() *predicateMaintenanceProbe {
 	}
 }
 
-func (p *predicateMaintenanceProbe) run(real predicateGitRunner) predicateGitRunner {
+func (p *predicateMaintenanceProbe) run(underlyingRunner predicateGitRunner) predicateGitRunner {
 	return func(dir string, args ...string) (string, error) {
-		out, err := real(dir, args...)
+		out, err := underlyingRunner(dir, args...)
 		if err != nil {
 			return out, err
 		}
-		if slicesContain(args, "commit") && !slicesContain(args, "maintenance.auto=false") {
+		if slices.Contains(args, "commit") && !slices.Contains(args, "maintenance.auto=false") {
 			go func() {
 				lock := filepath.Join(dir, ".git", "objects", "maintenance.lock")
 				p.mutatorErr = os.WriteFile(lock, []byte("maintenance\n"), 0o644)
@@ -120,15 +121,6 @@ func (p *predicateMaintenanceProbe) published() {
 		close(p.release)
 	default:
 	}
-}
-
-func slicesContain(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
 }
 
 func TestMain(m *testing.M) {

--- a/agent/internal/worktree/predicates_test.go
+++ b/agent/internal/worktree/predicates_test.go
@@ -66,6 +66,71 @@ var predicateRepoTemplate struct {
 	err  error
 }
 
+type predicateGitRunner func(string, ...string) (string, error)
+
+type predicateMaintenanceProbe struct {
+	ready                chan struct{}
+	release              chan struct{}
+	exited               chan struct{}
+	publishedWhileActive bool
+	mutatorErr           error
+}
+
+func newPredicateMaintenanceProbe() *predicateMaintenanceProbe {
+	return &predicateMaintenanceProbe{
+		ready:   make(chan struct{}),
+		release: make(chan struct{}),
+		exited:  make(chan struct{}),
+	}
+}
+
+func (p *predicateMaintenanceProbe) run(real predicateGitRunner) predicateGitRunner {
+	return func(dir string, args ...string) (string, error) {
+		out, err := real(dir, args...)
+		if err != nil {
+			return out, err
+		}
+		if slicesContain(args, "commit") && !slicesContain(args, "maintenance.auto=false") {
+			go func() {
+				lock := filepath.Join(dir, ".git", "objects", "maintenance.lock")
+				p.mutatorErr = os.WriteFile(lock, []byte("maintenance\n"), 0o644)
+				close(p.ready)
+				if p.mutatorErr != nil {
+					close(p.exited)
+					return
+				}
+				<-p.release
+				p.mutatorErr = os.Remove(lock)
+				close(p.exited)
+			}()
+			<-p.ready
+		}
+		return out, nil
+	}
+}
+
+func (p *predicateMaintenanceProbe) published() {
+	select {
+	case <-p.ready:
+		select {
+		case <-p.exited:
+		default:
+			p.publishedWhileActive = true
+		}
+		close(p.release)
+	default:
+	}
+}
+
+func slicesContain(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestMain(m *testing.M) {
 	code := m.Run()
 	if predicateRepoTemplate.root != "" {
@@ -79,7 +144,7 @@ func TestMain(m *testing.M) {
 func initRepo(t *testing.T) (root, initialSHA string) {
 	t.Helper()
 	predicateRepoTemplate.Do(func() {
-		predicateRepoTemplate.root, predicateRepoTemplate.sha, predicateRepoTemplate.err = buildPredicateRepoTemplate()
+		predicateRepoTemplate.root, predicateRepoTemplate.sha, predicateRepoTemplate.err = buildPredicateRepoTemplate(runGitRaw)
 	})
 	if predicateRepoTemplate.err != nil {
 		t.Fatalf("build repo template: %v", predicateRepoTemplate.err)
@@ -92,7 +157,7 @@ func initRepo(t *testing.T) (root, initialSHA string) {
 	return root, predicateRepoTemplate.sha
 }
 
-func buildPredicateRepoTemplate() (root, initialSHA string, err error) {
+func buildPredicateRepoTemplate(run predicateGitRunner) (root, initialSHA string, err error) {
 	base, err := os.MkdirTemp("", "evener-worktree-predicate-template-*")
 	if err != nil {
 		return "", "", err
@@ -101,29 +166,56 @@ func buildPredicateRepoTemplate() (root, initialSHA string, err error) {
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		return "", "", err
 	}
-	if _, err := runGitRaw(root, "init", "-q", "-b", "main"); err != nil {
+	if _, err := run(root, "init", "-q", "-b", "main"); err != nil {
 		return "", "", err
 	}
-	if _, err := runGitRaw(root, "config", "user.email", "test@example.com"); err != nil {
+	if _, err := run(root, "config", "user.email", "test@example.com"); err != nil {
 		return "", "", err
 	}
-	if _, err := runGitRaw(root, "config", "user.name", "Test"); err != nil {
+	if _, err := run(root, "config", "user.name", "Test"); err != nil {
 		return "", "", err
 	}
 	if err := os.WriteFile(filepath.Join(root, "f.txt"), []byte("hi\n"), 0o644); err != nil {
 		return "", "", err
 	}
-	if _, err := runGitRaw(root, "add", "f.txt"); err != nil {
+	if _, err := run(root, "add", "f.txt"); err != nil {
 		return "", "", err
 	}
-	if _, err := runGitRaw(root, "commit", "-q", "-m", "init"); err != nil {
+	if _, err := run(root, "-c", "maintenance.auto=false", "commit", "-q", "-m", "init"); err != nil {
 		return "", "", err
 	}
-	out, err := runGitRaw(root, "rev-parse", "HEAD")
+	out, err := run(root, "rev-parse", "HEAD")
 	if err != nil {
 		return "", "", err
 	}
 	return root, strings.TrimSpace(out), nil
+}
+
+func TestPredicateFixturePublishesAfterSeedMaintenance(t *testing.T) {
+	probe := newPredicateMaintenanceProbe()
+	root, _, err := buildPredicateRepoTemplate(probe.run(runGitRaw))
+	if err != nil {
+		t.Fatalf("build repo template: %v", err)
+	}
+	defer os.RemoveAll(filepath.Dir(root))
+
+	destination := filepath.Join(t.TempDir(), "repo")
+	if err := os.CopyFS(destination, os.DirFS(root)); err != nil {
+		t.Fatalf("copy repo template: %v", err)
+	}
+	probe.published()
+
+	select {
+	case <-probe.ready:
+		<-probe.exited
+	default:
+	}
+	if probe.mutatorErr != nil {
+		t.Fatalf("maintenance mutator: %v", probe.mutatorErr)
+	}
+	if probe.publishedWhileActive {
+		t.Fatal("fixture publication overlapped the post-commit maintenance mutator")
+	}
 }
 
 // addWorktree adds a worktree at <root>/<name> on a new branch <name>

--- a/agent/session_tools_worktree_create_test.go
+++ b/agent/session_tools_worktree_create_test.go
@@ -55,6 +55,71 @@ var (
 	intgMCPServerDir       string
 )
 
+type worktreeGitRunner func(string, ...string) (string, error)
+
+type worktreeMaintenanceProbe struct {
+	ready                chan struct{}
+	release              chan struct{}
+	exited               chan struct{}
+	publishedWhileActive bool
+	mutatorErr           error
+}
+
+func newWorktreeMaintenanceProbe() *worktreeMaintenanceProbe {
+	return &worktreeMaintenanceProbe{
+		ready:   make(chan struct{}),
+		release: make(chan struct{}),
+		exited:  make(chan struct{}),
+	}
+}
+
+func (p *worktreeMaintenanceProbe) run(real worktreeGitRunner) worktreeGitRunner {
+	return func(dir string, args ...string) (string, error) {
+		out, err := real(dir, args...)
+		if err != nil {
+			return out, err
+		}
+		if worktreeSlicesContain(args, "commit") && !worktreeSlicesContain(args, "maintenance.auto=false") {
+			go func() {
+				lock := filepath.Join(dir, ".git", "objects", "maintenance.lock")
+				p.mutatorErr = os.WriteFile(lock, []byte("maintenance\n"), 0o644)
+				close(p.ready)
+				if p.mutatorErr != nil {
+					close(p.exited)
+					return
+				}
+				<-p.release
+				p.mutatorErr = os.Remove(lock)
+				close(p.exited)
+			}()
+			<-p.ready
+		}
+		return out, nil
+	}
+}
+
+func worktreeSlicesContain(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *worktreeMaintenanceProbe) published() {
+	select {
+	case <-p.ready:
+		select {
+		case <-p.exited:
+		default:
+			p.publishedWhileActive = true
+		}
+		close(p.release)
+	default:
+	}
+}
+
 func TestMain(m *testing.M) {
 	for _, key := range []string{"GOCACHE", "GOPATH", "GOMODCACHE"} {
 		if out, err := exec.Command("go", "env", key).Output(); err == nil {
@@ -176,43 +241,7 @@ func wtGit(t *testing.T, dir string, args ...string) string {
 func worktreeBaseRepo(t *testing.T) (string, string) {
 	t.Helper()
 	wtBaseRepoOnce.Do(func() {
-		dir, err := os.MkdirTemp("", "evener-worktree-base-*")
-		if err != nil {
-			errWtBaseRepo = err
-			return
-		}
-		wtBaseRepoPath = dir
-
-		if _, err := runWorktreeGit(dir, "init", "-b", "main"); err != nil {
-			errWtBaseRepo = fmt.Errorf("git init: %w", err)
-			return
-		}
-		if _, err := runWorktreeGit(dir, "config", "user.email", "test@example.com"); err != nil {
-			errWtBaseRepo = fmt.Errorf("git config user.email: %w", err)
-			return
-		}
-		if _, err := runWorktreeGit(dir, "config", "user.name", "Test"); err != nil {
-			errWtBaseRepo = fmt.Errorf("git config user.name: %w", err)
-			return
-		}
-		if err := os.WriteFile(filepath.Join(dir, "README"), []byte("main-checkout\n"), 0o644); err != nil {
-			errWtBaseRepo = fmt.Errorf("write README: %w", err)
-			return
-		}
-		if _, err := runWorktreeGit(dir, "add", "README"); err != nil {
-			errWtBaseRepo = fmt.Errorf("git add README: %w", err)
-			return
-		}
-		if _, err := runWorktreeGit(dir, "commit", "-m", "initial"); err != nil {
-			errWtBaseRepo = fmt.Errorf("git commit: %w", err)
-			return
-		}
-		head, err := runWorktreeGit(dir, "rev-parse", "HEAD")
-		if err != nil {
-			errWtBaseRepo = fmt.Errorf("git rev-parse HEAD: %w", err)
-			return
-		}
-		wtBaseRepoHead = strings.TrimSpace(head)
+		wtBaseRepoPath, wtBaseRepoHead, errWtBaseRepo = buildWorktreeBaseRepo(runWorktreeGit)
 	})
 	if errWtBaseRepo != nil {
 		t.Fatalf("worktree base repo: %v", errWtBaseRepo)
@@ -220,9 +249,44 @@ func worktreeBaseRepo(t *testing.T) (string, string) {
 	return wtBaseRepoPath, wtBaseRepoHead
 }
 
+func buildWorktreeBaseRepo(run worktreeGitRunner) (path, head string, err error) {
+	dir, err := os.MkdirTemp("", "evener-worktree-base-*")
+	if err != nil {
+		return "", "", err
+	}
+	if _, err := run(dir, "init", "-b", "main"); err != nil {
+		return dir, "", fmt.Errorf("git init: %w", err)
+	}
+	if _, err := run(dir, "config", "user.email", "test@example.com"); err != nil {
+		return dir, "", fmt.Errorf("git config user.email: %w", err)
+	}
+	if _, err := run(dir, "config", "user.name", "Test"); err != nil {
+		return dir, "", fmt.Errorf("git config user.name: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README"), []byte("main-checkout\n"), 0o644); err != nil {
+		return dir, "", fmt.Errorf("write README: %w", err)
+	}
+	if _, err := run(dir, "add", "README"); err != nil {
+		return dir, "", fmt.Errorf("git add README: %w", err)
+	}
+	if _, err := run(dir, "-c", "maintenance.auto=false", "commit", "-m", "initial"); err != nil {
+		return dir, "", fmt.Errorf("git commit: %w", err)
+	}
+	head, err = run(dir, "rev-parse", "HEAD")
+	if err != nil {
+		return dir, "", fmt.Errorf("git rev-parse HEAD: %w", err)
+	}
+	return dir, strings.TrimSpace(head), nil
+}
+
 func copyWorktreeBaseRepo(t *testing.T, dst string) {
 	t.Helper()
 	base, _ := worktreeBaseRepo(t)
+	copyWorktreeBaseRepoFrom(t, base, dst)
+}
+
+func copyWorktreeBaseRepoFrom(t *testing.T, base, dst string) {
+	t.Helper()
 	for _, rel := range []string{
 		"README",
 		filepath.Join(".git", "HEAD"),
@@ -247,6 +311,31 @@ func copyWorktreeBaseRepo(t *testing.T, dst string) {
 		return linkWorktreeFixtureRelFileNoTest(base, dst, rel)
 	}); err != nil {
 		t.Fatalf("copy worktree base repo objects: %v", err)
+	}
+}
+
+func TestWorktreeFixturePublishesAfterSeedMaintenance(t *testing.T) {
+	probe := newWorktreeMaintenanceProbe()
+	base, _, err := buildWorktreeBaseRepo(probe.run(runWorktreeGit))
+	if err != nil {
+		t.Fatalf("build worktree base repo: %v", err)
+	}
+	defer os.RemoveAll(base)
+
+	destination := filepath.Join(t.TempDir(), "repo")
+	copyWorktreeBaseRepoFrom(t, base, destination)
+	probe.published()
+
+	select {
+	case <-probe.ready:
+		<-probe.exited
+	default:
+	}
+	if probe.mutatorErr != nil {
+		t.Fatalf("maintenance mutator: %v", probe.mutatorErr)
+	}
+	if probe.publishedWhileActive {
+		t.Fatal("fixture publication overlapped the post-commit maintenance mutator")
 	}
 }
 

--- a/agent/session_tools_worktree_create_test.go
+++ b/agent/session_tools_worktree_create_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -73,13 +74,13 @@ func newWorktreeMaintenanceProbe() *worktreeMaintenanceProbe {
 	}
 }
 
-func (p *worktreeMaintenanceProbe) run(real worktreeGitRunner) worktreeGitRunner {
+func (p *worktreeMaintenanceProbe) run(underlyingRunner worktreeGitRunner) worktreeGitRunner {
 	return func(dir string, args ...string) (string, error) {
-		out, err := real(dir, args...)
+		out, err := underlyingRunner(dir, args...)
 		if err != nil {
 			return out, err
 		}
-		if worktreeSlicesContain(args, "commit") && !worktreeSlicesContain(args, "maintenance.auto=false") {
+		if slices.Contains(args, "commit") && !slices.Contains(args, "maintenance.auto=false") {
 			go func() {
 				lock := filepath.Join(dir, ".git", "objects", "maintenance.lock")
 				p.mutatorErr = os.WriteFile(lock, []byte("maintenance\n"), 0o644)
@@ -96,15 +97,6 @@ func (p *worktreeMaintenanceProbe) run(real worktreeGitRunner) worktreeGitRunner
 		}
 		return out, nil
 	}
-}
-
-func worktreeSlicesContain(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
 }
 
 func (p *worktreeMaintenanceProbe) published() {

--- a/agent/session_tools_worktree_create_test.go
+++ b/agent/session_tools_worktree_create_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -74,13 +75,57 @@ func newWorktreeMaintenanceProbe() *worktreeMaintenanceProbe {
 	}
 }
 
+func worktreeMaintenanceAutoEnabled(args []string) bool {
+	enabled := true
+	for i := 0; i < len(args); i++ {
+		var config string
+		switch {
+		case args[i] == "-c" && i+1 < len(args):
+			config = args[i+1]
+			i++
+		case strings.HasPrefix(args[i], "-c"):
+			config = args[i][2:]
+		default:
+			continue
+		}
+		key, value, ok := strings.Cut(config, "=")
+		if !ok || !strings.EqualFold(strings.TrimSpace(key), "maintenance.auto") {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(value)) {
+		case "false", "0", "no", "off":
+			enabled = false
+		default:
+			enabled = true
+		}
+	}
+	return enabled
+}
+
+func worktreeQuiescentCommitArgs(args []string) []string {
+	commit := slices.Index(args, "commit")
+	if commit < 0 {
+		return args
+	}
+	quiescent := make([]string, 0, len(args)+2)
+	quiescent = append(quiescent, args[:commit]...)
+	quiescent = append(quiescent, "-c", "maintenance.auto=false")
+	return append(quiescent, args[commit:]...)
+}
+
 func (p *worktreeMaintenanceProbe) run(underlyingRunner worktreeGitRunner) worktreeGitRunner {
 	return func(dir string, args ...string) (string, error) {
-		out, err := underlyingRunner(dir, args...)
+		commit := slices.Contains(args, "commit")
+		maintenanceAutoEnabled := commit && worktreeMaintenanceAutoEnabled(args)
+		realArgs := args
+		if maintenanceAutoEnabled {
+			realArgs = worktreeQuiescentCommitArgs(args)
+		}
+		out, err := underlyingRunner(dir, realArgs...)
 		if err != nil {
 			return out, err
 		}
-		if slices.Contains(args, "commit") && !slices.Contains(args, "maintenance.auto=false") {
+		if maintenanceAutoEnabled {
 			go func() {
 				lock := filepath.Join(dir, ".git", "objects", "maintenance.lock")
 				p.mutatorErr = os.WriteFile(lock, []byte("maintenance\n"), 0o644)
@@ -309,10 +354,16 @@ func copyWorktreeBaseRepoFrom(t *testing.T, base, dst string) {
 func TestWorktreeFixturePublishesAfterSeedMaintenance(t *testing.T) {
 	probe := newWorktreeMaintenanceProbe()
 	base, _, err := buildWorktreeBaseRepo(probe.run(runWorktreeGit))
+	if base != "" {
+		t.Cleanup(func() {
+			if removeErr := os.RemoveAll(base); removeErr != nil {
+				t.Errorf("remove fixture: %v", removeErr)
+			}
+		})
+	}
 	if err != nil {
 		t.Fatalf("build worktree base repo: %v", err)
 	}
-	defer os.RemoveAll(base)
 
 	destination := filepath.Join(t.TempDir(), "repo")
 	copyWorktreeBaseRepoFrom(t, base, destination)
@@ -328,6 +379,96 @@ func TestWorktreeFixturePublishesAfterSeedMaintenance(t *testing.T) {
 	}
 	if probe.publishedWhileActive {
 		t.Fatal("fixture publication overlapped the post-commit maintenance mutator")
+	}
+}
+
+func TestWorktreeMaintenanceProbeUsesEffectiveBoolean(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		active bool
+	}{
+		{name: "false", args: []string{"-c", "maintenance.auto=false", "commit"}},
+		{name: "zero", args: []string{"-c", "maintenance.auto=0", "commit"}},
+		{name: "no", args: []string{"-c", "maintenance.auto=no", "commit"}},
+		{name: "off", args: []string{"-c", "maintenance.auto=off", "commit"}},
+		{name: "case insensitive false", args: []string{"-c", "maintenance.auto=FaLsE", "commit"}},
+		{name: "last false", args: []string{"-c", "maintenance.auto=true", "-c", "maintenance.auto=0", "commit"}},
+		{name: "true", args: []string{"-c", "maintenance.auto=true", "commit"}, active: true},
+		{name: "last true", args: []string{"-c", "maintenance.auto=0", "-c", "maintenance.auto=on", "commit"}, active: true},
+		{name: "absent", args: []string{"commit"}, active: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			probe := newWorktreeMaintenanceProbe()
+			dir := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(dir, ".git", "objects"), 0o755); err != nil {
+				t.Fatalf("mkdir objects: %v", err)
+			}
+			var gotArgs []string
+			wrapped := probe.run(func(_ string, args ...string) (string, error) {
+				gotArgs = slices.Clone(args)
+				return "", nil
+			})
+			result := make(chan error, 1)
+			go func() {
+				_, err := wrapped(dir, test.args...)
+				result <- err
+			}()
+			if test.active {
+				<-probe.ready
+				probe.published()
+				if err := <-result; err != nil {
+					t.Fatalf("probe run: %v", err)
+				}
+				<-probe.exited
+				if probe.mutatorErr != nil {
+					t.Fatalf("maintenance mutator: %v", probe.mutatorErr)
+				}
+				if !probe.publishedWhileActive {
+					t.Fatal("expected publication overlap")
+				}
+				if !slices.Contains(gotArgs, "maintenance.auto=false") {
+					t.Fatalf("real runner args = %v, missing quiescent config", gotArgs)
+				}
+				return
+			}
+			if err := <-result; err != nil {
+				t.Fatalf("probe run: %v", err)
+			}
+			select {
+			case <-probe.ready:
+				t.Fatal("suppressed config launched synthetic maintenance")
+			default:
+			}
+			if !slices.Equal(gotArgs, test.args) {
+				t.Fatalf("real runner args = %v, want %v", gotArgs, test.args)
+			}
+		})
+	}
+}
+
+func TestWorktreeFixtureSetupErrorRetainsCleanupRoot(t *testing.T) {
+	base, _, err := buildWorktreeBaseRepo(func(string, ...string) (string, error) {
+		return "", errors.New("injected setup error")
+	})
+	if base != "" {
+		t.Cleanup(func() {
+			if removeErr := os.RemoveAll(base); removeErr != nil {
+				t.Errorf("remove fixture: %v", removeErr)
+			}
+			if _, statErr := os.Stat(base); !errors.Is(statErr, os.ErrNotExist) {
+				t.Errorf("fixture root remains after cleanup: %v", statErr)
+			}
+		})
+		if _, statErr := os.Stat(base); statErr != nil {
+			t.Fatalf("fixture root was not retained: %v", statErr)
+		}
+	} else {
+		t.Fatal("setup error did not retain fixture root")
+	}
+	if err == nil {
+		t.Fatal("injected setup error was not returned")
 	}
 }
 


### PR DESCRIPTION
## Summary

Disable Git's detached auto-maintenance only for the seed commit of each immutable Git fixture. This keeps the fixture's shared publication/object walk boundary quiescent without changing production Git behavior or persistent repository configuration.

The failed evidence is [PR #411 run 32804713490](https://github.com/prime-radiant-inc/evener/actions/runs/32804713490), [job 97672438098](https://github.com/prime-radiant-inc/evener/actions/runs/32804713490/job/97672438098).

## Root cause

Git 2.55 can return from `git commit` while detached `git maintenance run --auto --quiet --detach` is still creating/removing `.git/objects/maintenance.lock`. The once-shared fixture was published immediately after the commit, and `os.CopyFS`/the live object walk could enumerate the lock and open it after maintenance removed it, producing `ENOENT`. The same shared-base/live-object-walk boundary exists in both fixtures:

- `agent/internal/worktree/predicates_test.go`
- `agent/session_tools_worktree_create_test.go`

The fix uses `git -c maintenance.auto=false commit ...` only for those seed commits. No production code, persistent config, lock skipping, retry, sleep, or serialization was added.

## Deterministic RED/GREEN proof

The test-only external-Git runner probes launch a post-commit mutator that creates `.git/objects/maintenance.lock`, signals `ready`, holds on `release`, removes the lock, then signals `exit`. The oracle is publication versus mutator lifecycle, not argv text:

- RED with the old seed commands: both lifecycle tests failed deterministically with `fixture publication overlapped the post-commit maintenance mutator`.
- GREEN with this commit: both lifecycle tests pass; the command-scoped setting prevents the mutator from launching.

## Verification

Passed:

- `go test ./agent/internal/worktree -count=1`
- `go test ./agent -run 'Worktree' -count=1`
- `go test -race ./agent/... -count=1`
- focused lifecycle race repeats (`-count=100`) for both packages
- `go vet ./agent/internal/worktree ./agent`
- `make lint-gofmt`
- `make lint-generated`
- `make lint-internal`
- `git diff --check`

Limits (not hidden):

- `go test -race ./agent/internal/worktree -count=100` reached Go's default 10-minute test timeout at 600.305s.
- `go test -race ./agent -run 'Test.*Worktree' -count=20` reached the same timeout at 600.854s.

Those high-count matrix runs are incomplete due the harness timeout; they did not report an assertion or race failure. Local focused repeats ran on Apple Git 2.50.1. The causal failure evidence above is specifically Git 2.55; this PR does not overclaim local Git-version equivalence.
