### PR TITLE
test(agent): lock rematerialize hook fixture assignment

### DIFF
--- a/agent/subagent_owned_job_drain_test.go
+++ b/agent/subagent_owned_job_drain_test.go
@@ -374,6 +374,7 @@ func TestSubagentDrainReturnHandoffNoPhantomTurnInFinalizationWindow(t *testing.
 			<-releaseWindow
 		})
 	}
+	fixture.child.sess.jobManager.mu.Lock()
 	fixture.child.sess.jobManager.testOnlyAfterRematerializeDurableLoad = func() {
 		select {
 		case <-windowHeld:
@@ -381,6 +382,7 @@ func TestSubagentDrainReturnHandoffNoPhantomTurnInFinalizationWindow(t *testing.
 		default:
 		}
 	}
+	fixture.child.sess.jobManager.mu.Unlock()
 	go func() {
 		select {
 		case <-recheckSawWindow:


### PR DESCRIPTION
## Summary

Fix the proven test-fixture data race that blocked PR #434. The test assigns
`jobManager.testOnlyAfterRematerializeDurableLoad` while the drain may already
be reading the hook in `rematerializeDurablePendings`.

The field contract in `agent/jobs.go` requires reads and writes under `jm.mu`.
This patch locks the child job manager only for the fixture assignment and
unlocks immediately. It does not change production code, hook lifecycle,
barriers, timeouts, comments, helper structure, or test semantics.

## Evidence

The failure is in CI run [32814484456](https://github.com/prime-radiant-inc/evener/actions/runs/32814484456), job [97699953835](https://github.com/prime-radiant-inc/evener/actions/runs/32814484456/job/97699953835): the race read is in `rematerializeDurablePendings`, and the previous write is `TestSubagentDrainReturnHandoffNoPhantomTurnInFinalizationWindow` at `agent/subagent_owned_job_drain_test.go:377`.

The related locked assignment in `TestSubagentFinalizationRematerializeLoadSnapshotStraddle` demonstrates the intended discipline.

## Validation

- `go test -race ./agent -run '^TestSubagentDrainReturnHandoffNoPhantomTurnInFinalizationWindow$' -count=100`
- `go test -race ./agent -run '^(TestRematerializeOwnedDrainJobPendings|TestSubagentFinalizationDrainReenqueueRaceDeterministic|TestSubagentFinalizationRematerializeLoadSnapshotStraddle)$' -count=20`
- `go test -race ./agent`
- `go vet ./agent`
- `gofmt -l` and `git diff --check`
