### PR TITLE
test: remove prompt prose oracles from watch coverage

### DIFF
--- a/agent/watch_pure_covtest_test.go
+++ b/agent/watch_pure_covtest_test.go
@@ -439,32 +439,6 @@ func TestCovWatchHistoryVisibleToSession(t *testing.T) {
 	}
 }
 
-// TestCovSelfInfluenceNotice covers selfInfluenceNotice (job_watch.go lines 2401-2413).
-func TestCovSelfInfluenceNotice(t *testing.T) {
-	// Not self-influenced → empty.
-	if got := selfInfluenceNotice(false, 0, false); got != "" {
-		t.Fatalf("not self = %q", got)
-	}
-
-	// Self, shallow → default message.
-	got := selfInfluenceNotice(true, 1, false)
-	if !strings.Contains(got, "this turn responded to your last message") {
-		t.Fatalf("shallow = %q", got)
-	}
-
-	// Self, deep → depth message.
-	got = selfInfluenceNotice(true, 3, false)
-	if !strings.Contains(got, "~3 exchanges deep") {
-		t.Fatalf("deep = %q", got)
-	}
-
-	// Self, truncated → truncated message.
-	got = selfInfluenceNotice(true, 0, true)
-	if !strings.Contains(got, "many exchanges deep") {
-		t.Fatalf("truncated = %q", got)
-	}
-}
-
 // TestCovWatchSendKeyMatchesWatchKey covers watchSendKeyMatchesWatchKey
 // (job_watch.go lines 4084-4094).
 func TestCovWatchSendKeyMatchesWatchKey(t *testing.T) {
@@ -883,14 +857,6 @@ func TestCovDelegateQuietAttentionContent(t *testing.T) {
 }
 
 // ---- subagents.go pure functions ----
-
-// TestCovCommunicateNudge covers communicateNudge (subagents.go lines 1475-1480).
-func TestCovCommunicateNudge(t *testing.T) {
-	got := communicateNudge("communicate")
-	if !strings.Contains(got, "communicate") || !strings.Contains(got, "end_turn=true") {
-		t.Fatalf("nudge = %q", got)
-	}
-}
 
 // TestCovFatalRunGatedSnapshot covers fatalRunGatedSnapshot (subagents.go lines 1456-1463).
 func TestCovFatalRunGatedSnapshot(t *testing.T) {


### PR DESCRIPTION
## Summary
- Remove the two copy-only prompt-prose assertions identified in the Sol post-merge audit of #422.
- Keep all production code and unrelated tests unchanged.

This is a post-merge correction for #422, addressing the first finding in the Sol audit: https://github.com/prime-radiant-inc/evener/pull/422#issuecomment-5406391527

## Scope
Only `agent/watch_pure_covtest_test.go` changed: `TestCovSelfInfluenceNotice` and `TestCovCommunicateNudge` were deleted in full.

## Verification
- `go test ./agent -count=1`
- `go test -race ./agent -count=1`
- `make lint`
- `make vet`
- `gofmt`/diff checks
- Targeted prompt-prose static audit
- Direct agent coverage: 91.0%; both affected production functions remain 100.0% covered

The scoped coverage-floor run was blocked by an unrelated existing `TestGrepRipgrepStopsWhenContextIsCanceled` startup failure and missing frontend `vitest`; no coverage-only code was added.