### PR TITLE
test(hubstart): honor production immediate-exit window

### DIFF
--- a/cmd/evener-tui/internal/hubstart/hub_start_covtest_test.go
+++ b/cmd/evener-tui/internal/hubstart/hub_start_covtest_test.go
@@ -79,7 +79,6 @@ func TestCovDialHubRPCWithFrameHandler(t *testing.T) {
 // TestCovStartLocalHubWithStateDir observes the child-process environment at
 // the process-launch boundary.
 func TestCovStartLocalHubWithStateDir(t *testing.T) {
-	withLocalHubImmediateExitWindow(t, 30*time.Second)
 	t.Setenv(stateDirHubHelperEnv, "1")
 	dir := t.TempDir()
 	stateDir := filepath.Join(dir, "state", "evener")
@@ -111,7 +110,6 @@ func TestCovStartLocalHubWithStateDir(t *testing.T) {
 
 // TestCovStartLocalHubNoLogFile exercises the DevNull branch (no log file).
 func TestCovStartLocalHubNoLogFile(t *testing.T) {
-	withLocalHubImmediateExitWindow(t, 30*time.Second)
 	t.Setenv(immediateExitHubHelperEnv, "1")
 	bin, err := os.Executable()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Remove the two `withLocalHubImmediateExitWindow(t, 30*time.Second)` calls from `hub_start_covtest_test.go`.
- Keep both coverage tests on the production `LocalHubImmediateExitWindow` of 750ms.

## Context

This is a minimal post-merge correction for the second Sol audit finding in merged PR #422:
https://github.com/prime-radiant-inc/evener/pull/422#issuecomment-5406391527

The audit identified that the two newly merged tests widened the immediate-exit deadline by 40x while asserting immediate-exit behavior. The production code, helper seam, assertions, test names, imports, and all other files are unchanged.

Related: #422

## Verification

- Focused tests: repeated under `-race`, constrained `GOMAXPROCS=1`/`-p=1`/`-parallel=1`, and four busy CPU-load processes.
- Complete hubstart tests and race suite pass.
- `make lint-gofmt`, `make lint`, `go vet ./...`, `make vet`, `go test ./...`, and `make test` pass.