### PR TITLE
fix(web): drop codeblock copy-icon resting background

### DIFF
--- a/cmd/evener-hub/frontend/src/widgets/codeblock/codeblock.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/codeblock/codeblock.module.css
@@ -27,7 +27,11 @@
 }
 
 /* Not a band across the block: an overlay strip in its top-right corner, out
- * of the content flow, so the block's whole height is content. */
+ * of the content flow, so the block's whole height is content. At rest it has
+ * no background so the copy icon reads as bare chrome; the hover wash appears
+ * only when the block itself is hovered (or focused via keyboard, mirroring
+ * .copy's opacity gate below) - matching the corner-copy pattern in
+ * usermessageitem.module.css's .actions. */
 .header {
   position: absolute;
   top: var(--space-1);
@@ -37,8 +41,13 @@
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-1) var(--space-2);
-  background: var(--hover-1);
+  background: transparent;
   border-radius: var(--radius-chip);
+}
+
+.root:hover .header,
+.header:focus-within {
+  background: var(--hover-1);
 }
 
 .language {

--- a/cmd/evener-hub/frontend/src/widgets/codeblock/codeblock.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/codeblock/codeblock.test.tsx
@@ -305,12 +305,19 @@ test("Copy preserves the original ANSI-bearing text exactly", async () => {
 });
 
 // The language/copy corner control is a floating pill, not a header band -
-// it sits on the hover-wash fill (matching other floating chrome) and draws
-// no border of its own.
-test("the language/copy header is a fill with no border", () => {
+// at rest it carries no background of its own (the copy icon reads as bare
+// chrome); the hover wash appears only on hover/focus, and it draws no border
+// of its own.
+test("the language/copy header has no resting fill and gains the hover wash on hover, with no border", () => {
   const here = dirname(fileURLToPath(import.meta.url));
   const css = stripCssComments(readFileSync(join(here, "codeblock.module.css"), "utf8"));
   const rule = /\.header\s*\{([^}]*)\}/.exec(css)?.[1] ?? "";
-  expect(rule).toContain("background: var(--hover-1)");
+  // At rest the header is transparent - no persistent background pill behind
+  // the corner copy icon (matching usermessageitem.module.css's .actions).
+  expect(rule).toContain("background: transparent");
+  expect(rule).not.toContain("--hover-1");
+  // The hover wash moves to a .root:hover .header / .header:focus-within rule,
+  // so the block hover (not a resting fill) is what brings the surface forward.
+  expect(css).toMatch(/\.root:hover\s+\.header/);
   expect(rule).not.toContain("border-bottom");
 });

--- a/cmd/evener-hub/frontend/src/widgets/codeblock/codeblock.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/codeblock/codeblock.test.tsx
@@ -316,8 +316,13 @@ test("the language/copy header has no resting fill and gains the hover wash on h
   // the corner copy icon (matching usermessageitem.module.css's .actions).
   expect(rule).toContain("background: transparent");
   expect(rule).not.toContain("--hover-1");
-  // The hover wash moves to a .root:hover .header / .header:focus-within rule,
-  // so the block hover (not a resting fill) is what brings the surface forward.
-  expect(css).toMatch(/\.root:hover\s+\.header/);
+  // The hover wash moves to one shared rule for block hover and keyboard focus.
+  const interactiveRule =
+    /(?<selectors>\.root:hover\s+\.header\s*,\s*\.header:focus-within)\s*\{(?<declarations>[^{}]*)\}/.exec(css);
+  expect(interactiveRule?.groups?.selectors?.split(",").map((selector) => selector.trim())).toEqual([
+    ".root:hover .header",
+    ".header:focus-within",
+  ]);
+  expect(interactiveRule?.groups?.declarations).toMatch(/(?:^|;)\s*background\s*:\s*var\(--hover-1\)\s*;?/);
   expect(rule).not.toContain("border-bottom");
 });


### PR DESCRIPTION
## What

The copy icons inset into the top-right corner of code blocks (tool output, shell commands, JSON arguments, fenced markdown blocks) sat on a persistent `--hover-1` background pill at all times. They should have no background except on hover.

## Root cause

The `CodeBlock` widget's `.header` — the absolutely-positioned corner strip holding the copy control and language label — had `background: var(--hover-1)` at rest. This is the single shared source: `ShellCommandBlock` wraps `CodeBlock`, the markdown widget reuses `codeblockStyles.header` for fenced blocks, and every tool-output renderer goes through `CodeBlock`. The chat-bubble copy icon (`UserMessage .actions`) already does the right thing (hidden at rest, shown on hover), as does this file's own `.copy` opacity gate — the corner header was the lone holdout.

## Change

In `codeblock.module.css`, `.header` is now `background: transparent` at rest; the `--hover-1` wash appears only on `.root:hover .header` and `.header:focus-within` (keyboard users get no hover).

Mirrors the existing corner-copy pattern in `usermessageitem.module.css`'s `.actions`.

## Files

- `cmd/evener-hub/frontend/src/widgets/codeblock/codeblock.module.css` — `.header` transparent at rest, hover-gated wash.
- `cmd/evener-hub/frontend/src/widgets/codeblock/codeblock.test.tsx` — updated the header-background test to assert transparent-at-rest + `.root:hover .header`; kept the no-border assertion.

## Verification

- `tsc --noEmit` — clean
- `biome ci src` — clean (946 files)
- `vitest run` — 367 files / 6922 tests pass (codeblock suite: 70 pass)
- `node --test scripts/*.test.mjs` — 38 pass
