### PR TITLE
test(server): measure bounded transcript header reads

### DIFF
--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"maps"
 	"os"
@@ -699,8 +700,11 @@ func transcriptHeader(path string, maxLineBytes int) transcript.Header {
 		return transcript.Header{}
 	}
 	defer file.Close() //nolint:errcheck // read-only file; close error is not actionable
+	return transcriptHeaderFromReader(file, maxLineBytes)
+}
 
-	reader := bufio.NewReaderSize(file, 64*1024)
+func transcriptHeaderFromReader(source io.Reader, maxLineBytes int) transcript.Header {
+	reader := bufio.NewReaderSize(source, transcriptHeaderReadBufferBytes)
 	for {
 		lineBytes, complete, _, err := transcript.ReadLine(reader, maxLineBytes)
 		if err != nil || !complete {

--- a/server/appwire_turns.go
+++ b/server/appwire_turns.go
@@ -18,6 +18,13 @@ import (
 // large turn.
 const appTranscriptMaxLineBytes = 128 << 20
 
+// transcriptHeaderReadBufferBytes bounds the prefetch for an ordinary header
+// line. The parser stops at that line; keeping this buffer finite prevents a
+// large historical transcript from crossing the reader boundary merely because
+// identity validation needs its header. Oversized headers are still governed
+// by the maxLineBytes limit passed to transcript.ReadLine.
+const transcriptHeaderReadBufferBytes = 64 * 1024
+
 var (
 	appTurnsEnsureTurnHook   func(string) bool
 	appTurnsItemForDeltaHook func(*appwire.ThreadItem)

--- a/server/appwire_turns_paging_test.go
+++ b/server/appwire_turns_paging_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -735,17 +736,34 @@ func TestTranscriptHeaderReadsOnlyLeadingHeader(t *testing.T) {
 		}
 		return path
 	}
-	small := writeNoAPICallTranscript(1)
 	large := writeNoAPICallTranscript(2000)
 	if got := transcriptHeader(large, appTranscriptMaxLineBytes).SessionID; got != "th_1" {
 		t.Fatalf("header session = %q, want th_1", got)
 	}
 
-	smallAllocs := testing.AllocsPerRun(3, func() { _ = transcriptHeader(small, appTranscriptMaxLineBytes) })
-	largeAllocs := testing.AllocsPerRun(3, func() { _ = transcriptHeader(large, appTranscriptMaxLineBytes) })
-	if largeAllocs > smallAllocs+10 {
-		t.Fatalf("large no-api_call identity validation inspected historical entries: allocations large=%.0f small=%.0f", largeAllocs, smallAllocs)
+	file, err := os.Open(large)
+	if err != nil {
+		t.Fatal(err)
 	}
+	defer file.Close() //nolint:errcheck // read-only fixture
+	counted := &countingHeaderReader{Reader: file}
+	if got := transcriptHeaderFromReader(counted, appTranscriptMaxLineBytes); got.SessionID != "th_1" {
+		t.Fatalf("counted header session = %q, want th_1", got.SessionID)
+	}
+	if counted.bytes > transcriptHeaderReadBufferBytes {
+		t.Fatalf("header validation read %d bytes from a %d-byte-bound reader", counted.bytes, transcriptHeaderReadBufferBytes)
+	}
+}
+
+type countingHeaderReader struct {
+	io.Reader
+	bytes int64
+}
+
+func (r *countingHeaderReader) Read(p []byte) (int, error) {
+	n, err := r.Reader.Read(p)
+	r.bytes += int64(n)
+	return n, err
 }
 
 // TestPreparedAppIdentityRejectsAnotherSessionsTranscript pins that preparation


### PR DESCRIPTION
## Root cause

The permanent race gate failure in run 32879537762, job 97905436755, was caused by `TestTranscriptHeaderReadsOnlyLeadingHeader` treating relative `testing.AllocsPerRun` results as an I/O oracle. Under CI contention, the same production path reported `large=29 small=18`; those heap counts vary with runtime/filesystem/buffer effects and do not establish that historical transcript entries were decoded.

`transcriptHeader` opens at offset zero, reads newline-framed records with `transcript.ReadLine`, skips leading blanks, decodes one header, and returns immediately. It does not scan historical entries. The production reader has a fixed 64 KiB prefetch boundary for ordinary headers.

## Change

- Keep the production path and malformed/truncated/oversized-line semantics unchanged while routing the parser through a reader helper.
- Replace the allocation comparison with a deterministic byte-bound assertion using a real opened transcript wrapped at the reader boundary.
- Assert the header identity and that validation reads no more than the production 64 KiB prefetch bound, even with 2000 historical entries.

A mutation that read the entire source before parsing made the focused test fail, proving the new oracle detects unbounded reads.

## Verification

- `go test -race ./server -run '^TestTranscriptHeaderReadsOnlyLeadingHeader$' -count=100`
- `go test -race ./server -count=1`
- `go test -race ./agent/transcript ./internal/apptranscript ./server -count=1`
- `make test-race` (all go.work modules; passed)
- `go vet ./server`
- `gofmt` and `git diff --check`

Fixes the exact-main CI failure from run 32879537762 / job 97905436755. No frontend or unrelated files changed.
