### PR TITLE
fix(agent): drain delegate attention after pending ask

### DIFF
--- a/agent/delegate_resource_retention_stop_test.go
+++ b/agent/delegate_resource_retention_stop_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"primeradiant.com/evener/agent/internal/agenttest"
 	"primeradiant.com/evener/agent/internal/delegatestore"
@@ -631,6 +632,19 @@ func TestDelegateResourceStop_TimeoutRaceCannotLeakStopMembership(t *testing.T) 
 		result <- runShell(context.Background(), jm, executor, shellArgs{Command: "timeout races stop", BlockTimeoutMS: 1})
 	}()
 	clock.BlockUntil(1)
+	// Capture the exact completion before cancellation. Finalization removes the
+	// job from jm.running before it resolves the stable-delegate receipt and
+	// closes done, so a lookup after the race can mistake "removed" for "done".
+	jm.mu.Lock()
+	runningJobs := len(jm.running)
+	var shellDone <-chan struct{}
+	for _, run := range jm.running {
+		shellDone = run.done
+	}
+	jm.mu.Unlock()
+	if runningJobs != 1 || shellDone == nil {
+		t.Fatalf("running shells before stop = %d, want one completion signal", runningJobs)
+	}
 	stopResult, cancelPlan, _, err := c.StopSubtree(rootDelegateActor("root-session"), lease.delegateID)
 	if err != nil {
 		t.Fatalf("StopSubtree: %v", err)
@@ -647,8 +661,12 @@ func TestDelegateResourceStop_TimeoutRaceCannotLeakStopMembership(t *testing.T) 
 	if got.settle != nil {
 		got.JobID = got.settle(true)
 	}
-	if got.JobID != "" {
-		waitForShellDone(t, jm, got.JobID)
+	select {
+	case <-shellDone:
+	// TRIPWIRE: the signalled in-process shell completes immediately; this only
+	// bounds a genuine finalization hang under load.
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout-race shell did not finish")
 	}
 	if _, err := c.FinishGeneration(lease, delegateFinish{}); err != nil {
 		t.Fatalf("FinishGeneration after shell race: %v", err)

--- a/agent/session_ask_test.go
+++ b/agent/session_ask_test.go
@@ -810,6 +810,97 @@ func TestAskUser_EntryGateRefusesNotificationWake(t *testing.T) {
 	}
 }
 
+func TestAskUser_ReplyDrainsRootDelegateAttentionRefusedAtEntryGate(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	ask := askUserCall("ask1", askUserArgsValid())
+	f := &fakeAdapter{
+		name: "openai",
+		steps: []func(req llm.Request) llm.Response{
+			func(req llm.Request) llm.Response { return toolCallResponse(ask) },
+			func(req llm.Request) llm.Response { return finalResponse("thanks, going with Postgres") },
+			func(req llm.Request) llm.Response { return finalResponse("delegate completion ack") },
+		},
+	}
+	sess := newSession(t,
+		withDir(stateDir),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true}),
+		withAdapter(f),
+	)
+	wakes := make(chan struct{}, 2)
+	sess.SetNotifyFunc(func() { wakes <- struct{}{} })
+
+	// TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if _, err := sess.ProcessInput(ctx, "which db should we use?", nil); err != nil {
+		t.Fatalf("ProcessInput: %v", err)
+	}
+
+	const (
+		firstAttentionID = "delegate:dlg_during_ask/delivery/1"
+		firstContent     = `<delegate-notification delegate_id="dlg_during_ask">review complete</delegate-notification>`
+	)
+	if appended, err := sess.appendDelegateNotificationDurably(firstAttentionID, firstContent); err != nil || !appended {
+		t.Fatalf("append root attention = appended:%t err:%v", appended, err)
+	}
+	if err := sess.armDelegateAttention(firstAttentionID); err != nil {
+		t.Fatalf("arm root attention: %v", err)
+	}
+	select {
+	case <-wakes:
+	default:
+		t.Fatal("root attention emitted no initial wake")
+	}
+
+	if _, err := sess.ProcessInputKind(ctx, "", nil, EntryNotification); err != nil {
+		t.Fatalf("ProcessInputKind(EntryNotification) while awaiting: %v", err)
+	}
+	if got := len(f.Requests()); got != 1 {
+		t.Fatalf("requests after refused wake = %d, want 1", got)
+	}
+	if !sess.hasPendingRootDelegateAttention() {
+		t.Fatal("refused wake discarded pending root delegate attention")
+	}
+
+	if _, err := sess.ProcessInput(ctx, "let's go with Postgres", nil); err != nil {
+		t.Fatalf("reply ProcessInput: %v", err)
+	}
+	requests := f.Requests()
+	if got := len(requests); got != 3 {
+		t.Fatalf("requests after reply = %d, want 3 (reply turn + root attention turn)", got)
+	}
+	if !requestContainsText(requests[2], firstContent) {
+		t.Error("root attention turn did not deliver the delegate notification to the model")
+	}
+	fold, err := readDelegateAttentionFold(transcriptPath(stateDir, sess.ID()), sess.ID())
+	if err != nil {
+		t.Fatalf("read root attention fold: %v", err)
+	}
+	if got := fold.resolutions[firstAttentionID]; got != delegateAttentionConsumed {
+		t.Errorf("root attention disposition = %q, want %q", got, delegateAttentionConsumed)
+	}
+	if sess.hasPendingRootDelegateAttention() {
+		t.Error("root delegate attention remains pending after the reply drain")
+	}
+
+	const (
+		secondAttentionID = "delegate:dlg_after_reply/delivery/1"
+		secondContent     = `<delegate-notification delegate_id="dlg_after_reply">second review complete</delegate-notification>`
+	)
+	if appended, err := sess.appendDelegateNotificationDurably(secondAttentionID, secondContent); err != nil || !appended {
+		t.Fatalf("append later root attention = appended:%t err:%v", appended, err)
+	}
+	if err := sess.armDelegateAttention(secondAttentionID); err != nil {
+		t.Fatalf("arm later root attention: %v", err)
+	}
+	select {
+	case <-wakes:
+	default:
+		t.Error("later root attention emitted no fresh wake")
+	}
+}
+
 // TestAskUser_EntryGateRefusesContinuationWake covers spec §5.3's entry gate for
 // EntryContinuation: refused before any state transition, state unchanged
 // throughout, no model request made. (The goal engine's own arm-vs-kick

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -516,7 +516,7 @@ func routeNoToolCalls(kind EntryKind, noContent bool) noCallsRoute {
 // drainInputs is the snapshot the drain loop feeds selectDrainNextAction after a
 // completed (non-error) turn: the kind of the turn that just ran, whether a goal
 // continuation is already deferred, the popped follow-up text and queued message
-// (its text plus image count), whether any job notifications are pending, and
+// (its text plus image count), whether any notification work is pending, and
 // whether the turn just rested SessionAwaiting (spec §5.3's drain-ladder gate).
 type drainInputs struct {
 	RanKind              EntryKind
@@ -540,7 +540,7 @@ const (
 	// notification pending, the resulting turn is the deferred continuation (if the
 	// fold arms one) or idle.
 	armGoalGate
-	// runNotification runs a pending job-notification turn next.
+	// runNotification runs a pending notification turn next.
 	runNotification
 	// runDeferredContInline runs an already-deferred goal continuation inline.
 	runDeferredContInline
@@ -839,7 +839,7 @@ func (s *Session) processInputKindWithProvenance(ctx context.Context, input stri
 		// goal-gate fold are side effects kept here; selectDrainNextAction is the pure
 		// priority decision over their results. popQueueHead is reached only when no
 		// follow-up is pending (it consumes a queued message), matching the original
-		// short-circuit; peekNotifications is likewise consulted only at its ladder
+		// short-circuit; notification work is likewise consulted only at its ladder
 		// rung and only for a non-notification, non-awaiting turn.
 		//
 		// awaiting reflects the boundary state the turn that just ran left behind
@@ -886,7 +886,7 @@ func (s *Session) processInputKindWithProvenance(ctx context.Context, input stri
 			strings.TrimSpace(queued.Text) == "" && len(queued.Images) == 0
 		notificationsPending := false
 		if noFollowUpOrQueued && !awaiting && ranKind != EntryNotification {
-			notificationsPending = s.peekNotifications() > 0
+			notificationsPending = s.peekNotifications() > 0 || s.hasPendingRootDelegateAttention()
 		}
 		action, skipGoalGate := selectDrainNextAction(drainInputs{
 			RanKind:              ranKind,
@@ -944,13 +944,13 @@ func (s *Session) processInputKindWithProvenance(ctx context.Context, input stri
 				haveDeferredCont = true
 			}
 		}
-		// Notification interleave (priority 3): a pending job notification runs
+		// Notification interleave (priority 3): pending notification work runs
 		// AFTER the fold above but BEFORE the deferred continuation, so it is
 		// transparent to goal accounting (the just-finished continuation already
-		// folded). The queue is consumed inside acceptNotificationInput when the
-		// EntryNotification turn runs (an empty queue there is a no-op, but the peek
-		// guards against it). After a notification turn this rung is skipped (selector
-		// gate) because job notifications may have been requeued.
+		// folded). Job notifications and root delegate attention are consumed inside
+		// acceptNotificationInput when the EntryNotification turn runs. After a
+		// notification turn this rung is skipped (selector gate) because notification
+		// work may have been requeued.
 		if action == runNotification {
 			next = ""
 			nextImages = nil
@@ -1115,12 +1115,12 @@ func (s *Session) processOneInput(ctx context.Context, input string, images []Im
 			// serve loop republishes that from WireState.
 			s.finishNotificationNoop()
 			// Ask for another wake. Nothing else will: the EntryNotification
-			// that got us here is consumed, the drain loop's tail gate counts
-			// job notifications alone (peekNotifications reads pendingJobNotifs
-			// and nothing else), and for delegate attention the wake flag we
-			// deliberately did NOT consume is itself what suppresses a new one
-			// -- armRootDelegateAttention notifies only when the flag is clear,
-			// and the retry scheduler returns early while it is set.
+			// that got us here is consumed, and the drain loop deliberately does
+			// not run another notification immediately after an EntryNotification
+			// turn. For delegate attention, the wake flag we deliberately did NOT
+			// consume is itself what suppresses a new one --
+			// armRootDelegateAttention notifies only when the flag is clear, and
+			// the retry scheduler returns early while it is set.
 			//
 			// The wake is guaranteed rather than best-effort, but it is PACED
 			// rather than immediate (kata ajg5). An immediate notify() pushes


### PR DESCRIPTION
## What

Resume a quiescent root session when stable delegate attention arrives while an `ask_user` question is pending. The session continues to hold the notification until the user replies, then processes it before returning idle.

## Root cause

The pending-ask entry gate correctly refused autonomous `EntryNotification` wakes so an async completion could not hide an unanswered question. Stable delegate attention, however, lives on a separate rail from job notifications. The post-reply drain checked only `pendingJobNotifs`, leaving the durable delegate attention armed. Later delegate completions saw the armed wake flag and coalesced without calling `notify()` again.

## Change

- Count pending root delegate attention at the existing notification drain rung.
- Preserve pending-ask refusal, drain priority, goal accounting, and the no-repeat notification gate.
- Add a regression test for ask → refused delegate wake → reply → payload delivery and durable consumption → fresh later wake.
- Stabilize the existing stop-timeout race test by capturing its exact shell-completion signal before cancellation; a late `jm.running` lookup could return during receipt cleanup.

## Files

- `agent/session_lifecycle.go`
- `agent/session_ask_test.go`
- `agent/delegate_resource_retention_stop_test.go`

## Verification

- `make lint`
- `make vet`
- `make test`
- `go test -race ./agent -run '^(TestAskUser_ReplyDrainsRootDelegateAttentionRefusedAtEntryGate|TestAskUser_EntryGateRefusesNotificationWake|TestRootDelegateAttention_SuccessfulNotificationConsumesExactIDs|TestStandDownReArmsTheWake)$' -count=10`
- `go test ./agent -run '^TestDelegateResourceStop_(TimeoutRaceCannotLeakStopMembership|ForegroundShellTimeoutReportsCommittedShellOnce|ForegroundShellTimeoutAbortsUncommittedReceipt)$' -count=1000`
- `go test -race ./agent -run '^TestDelegateResourceStop_(TimeoutRaceCannotLeakStopMembership|ForegroundShellTimeoutReportsCommittedShellOnce|ForegroundShellTimeoutAbortsUncommittedReceipt)$' -count=100`
