### PR TITLE
test(mcp): remove coverage-only timeout override

### DIFF
--- a/agent/cov_intg_mcp_test.go
+++ b/agent/cov_intg_mcp_test.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/schema"
@@ -188,6 +187,10 @@ func TestIntg_InitMCP_RegisterToolsError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSession must survive an MCP tool name exceeding the length limit, got: %v", err)
 	}
+	// Registration failure demotes the connection but leaves its live
+	// ClientSession owned by the Manager; take ownership before any assertion so
+	// fatal paths close the Manager, ClientSession, and subprocess too.
+	t.Cleanup(sess.Close)
 	if want := longName + "__echo"; sess.reg.Get(want) != nil {
 		t.Error("a failed server must contribute no callable tool")
 	}
@@ -331,7 +334,9 @@ func TestIntg_NewSession_LateErrorClosesMCPManager(t *testing.T) {
 	if sess != nil {
 		t.Fatal("expected a nil session on error")
 	}
-	intg_awaitMCPExitMarker(t, marker, 5*time.Second)
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Fatalf("MCP server exit marker %s missing after synchronous cleanup: %v", marker, statErr)
+	}
 }
 
 // TestIntg_RestoreSession_LateErrorClosesMCPManager is the restore-path
@@ -366,26 +371,8 @@ func TestIntg_RestoreSession_LateErrorClosesMCPManager(t *testing.T) {
 	if sess != nil {
 		t.Fatal("expected a nil session on error")
 	}
-	intg_awaitMCPExitMarker(t, marker, 5*time.Second)
-}
-
-// intg_awaitMCPExitMarker polls for the exit-marker file testdata/intgmcpserver
-// writes right before it exits (see main.go) and fails the test if it does not
-// appear within timeout. Manager.Close blocks on the subprocess's Cmd.Wait, so
-// a marker written by a Close'd server is already on disk by the time the
-// caller under test has returned; the poll only guards against incidental
-// scheduling jitter, not against a real close-vs-not-close race.
-func intg_awaitMCPExitMarker(t *testing.T, path string, timeout time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for {
-		if _, err := os.Stat(path); err == nil {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("MCP server exit marker %s never appeared; the underlying subprocess was not closed", path)
-		}
-		time.Sleep(10 * time.Millisecond)
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Fatalf("MCP server exit marker %s missing after synchronous cleanup: %v", marker, statErr)
 	}
 }
 

--- a/agent/cov_intg_mcp_test.go
+++ b/agent/cov_intg_mcp_test.go
@@ -75,13 +75,7 @@ func TestIntg_InitMCP_InlineServer(t *testing.T) {
 	bin := intg_buildMCPServer(t)
 
 	client := llm.NewClient()
-	cfg := SessionConfig{
-		MCPInline: []string{"intgsvc:" + bin},
-		testOnly: testConfig{
-			mcpConnectContext: t.Context(),
-			mcpConnectTimeout: new(time.Duration),
-		},
-	}
+	cfg := SessionConfig{MCPInline: []string{"intgsvc:" + bin}}
 	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), cfg)
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
@@ -126,13 +120,7 @@ func TestIntg_InitMCP_PluginProvidedServerMerges(t *testing.T) {
 	}
 
 	client := llm.NewClient()
-	cfg := SessionConfig{
-		PluginDirs: []string{dir},
-		testOnly: testConfig{
-			mcpConnectContext: t.Context(),
-			mcpConnectTimeout: new(time.Duration),
-		},
-	}
+	cfg := SessionConfig{PluginDirs: []string{dir}}
 	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), cfg)
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
@@ -195,13 +183,7 @@ func TestIntg_InitMCP_RegisterToolsError(t *testing.T) {
 	// dropped, but NewSession now survives instead of reporting the error.
 	longName := strings.Repeat("a", 60)
 	client := llm.NewClient()
-	cfg := SessionConfig{
-		MCPInline: []string{longName + ":" + bin},
-		testOnly: testConfig{
-			mcpConnectContext: t.Context(),
-			mcpConnectTimeout: new(time.Duration),
-		},
-	}
+	cfg := SessionConfig{MCPInline: []string{longName + ":" + bin}}
 	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), cfg)
 	if err != nil {
 		t.Fatalf("NewSession must survive an MCP tool name exceeding the length limit, got: %v", err)
@@ -235,13 +217,7 @@ func TestIntg_InitMCP_ConnectError(t *testing.T) {
 		t.Skipf("`true` not found: %v", err)
 	}
 	client := llm.NewClient()
-	cfg := SessionConfig{
-		MCPInline: []string{"deadsvc:" + truePath},
-		testOnly: testConfig{
-			mcpConnectContext: t.Context(),
-			mcpConnectTimeout: new(time.Duration),
-		},
-	}
+	cfg := SessionConfig{MCPInline: []string{"deadsvc:" + truePath}}
 	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), cfg)
 	if err != nil {
 		t.Fatalf("NewSession must survive a dead MCP server, got: %v", err)
@@ -343,10 +319,6 @@ func TestIntg_NewSession_LateErrorClosesMCPManager(t *testing.T) {
 	cfg := SessionConfig{
 		MCPInline:       []string{"intgsvc:" + bin + " " + marker},
 		ContextStrategy: "bogus-nonexistent-strategy",
-		testOnly: testConfig{
-			mcpConnectContext: t.Context(),
-			mcpConnectTimeout: new(time.Duration),
-		},
 	}
 	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), cfg)
 	if err == nil {
@@ -382,13 +354,7 @@ func TestIntg_RestoreSession_LateErrorClosesMCPManager(t *testing.T) {
 	sess, err := RestoreSessionFromMetaWithConfig(
 		w3init_restoreClient(), NewOpenAIProfile("gpt-5.2"),
 		execenv.NewLocalExecutionEnvironment(t.TempDir()), meta,
-		RestoreSessionConfig{
-			StateDir: stateDir,
-			testOnly: testConfig{
-				mcpConnectContext: t.Context(),
-				mcpConnectTimeout: new(time.Duration),
-			},
-		},
+		RestoreSessionConfig{StateDir: stateDir},
 	)
 	if err == nil {
 		sess.Close()

--- a/agent/internal/mcp/manager.go
+++ b/agent/internal/mcp/manager.go
@@ -139,7 +139,7 @@ func NewManager(ctx context.Context, configs []mcpconfig.ServerConfig, dials []f
 		return nil, nil
 	}
 
-	o := managerOptions{connectTimeout: 10 * time.Second}
+	var o managerOptions
 	for _, apply := range opts {
 		apply(&o)
 	}
@@ -159,7 +159,7 @@ func NewManager(ctx context.Context, configs []mcpconfig.ServerConfig, dials []f
 		}
 		go func(i int, cfg mcpconfig.ServerConfig, dial func(context.Context) (mcpsdk.Transport, error)) {
 			defer wg.Done()
-			mgr.conns[i] = connectOneWithTimeout(ctx, client, cfg, dial, o.connectTimeout)
+			mgr.conns[i] = connectOne(ctx, client, cfg, dial)
 		}(i, cfg, dial)
 	}
 	wg.Wait()
@@ -193,38 +193,27 @@ func NewManagerWithClock(ctx context.Context, configs []mcpconfig.ServerConfig, 
 	return mgr, outcomes
 }
 
-// connectOne is the package-local default used by direct tests and helpers.
-// It preserves NewManager's production 10s per-server timeout.
+// connectOne dials a transport via dial, connects to a single MCP server, and
+// discovers its tools — all bounded by a 10s timeout derived from ctx. Any
+// failure dialing, connecting, or listing tools yields a "failed" conn
+// recording the error; NewManager turns that into a connect-stage
+// ServerOutcome. dial is stored on the returned conn regardless of outcome.
 func connectOne(ctx context.Context, client *mcpsdk.Client, cfg mcpconfig.ServerConfig, dial func(context.Context) (mcpsdk.Transport, error)) conn {
-	return connectOneWithTimeout(ctx, client, cfg, dial, 10*time.Second)
-}
-
-// connectOneWithTimeout dials a transport, connects to one MCP server, and
-// discovers its tools under a child of ctx. A positive timeout adds a deadline;
-// a non-positive timeout adds cancellation only, preserving lifecycle
-// cancellation without layering a wall-clock deadline.
-func connectOneWithTimeout(ctx context.Context, client *mcpsdk.Client, cfg mcpconfig.ServerConfig, dial func(context.Context) (mcpsdk.Transport, error), timeout time.Duration) conn {
-	var connectCtx context.Context
-	var cancel context.CancelFunc
-	if timeout > 0 {
-		connectCtx, cancel = context.WithTimeout(ctx, timeout)
-	} else {
-		connectCtx, cancel = context.WithCancel(ctx)
-	}
+	perServerCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	transport, err := dial(connectCtx)
+	transport, err := dial(perServerCtx)
 	if err != nil {
 		return failedConn(cfg, dial, err)
 	}
 
-	session, err := client.Connect(connectCtx, transport, nil)
+	session, err := client.Connect(perServerCtx, transport, nil)
 	if err != nil {
 		return failedConn(cfg, dial, err)
 	}
 
 	// Discover tools from the server.
-	result, err := session.ListTools(connectCtx, nil)
+	result, err := session.ListTools(perServerCtx, nil)
 	if err != nil {
 		_ = session.Close()
 		return failedConn(cfg, dial, err)
@@ -261,8 +250,7 @@ func connectOneWithTimeout(ctx context.Context, client *mcpsdk.Client, cfg mcpco
 type Option func(*managerOptions)
 
 type managerOptions struct {
-	wrapper        *sandbox.Wrapper
-	connectTimeout time.Duration
+	wrapper *sandbox.Wrapper
 }
 
 // WithSandboxWrapper confines every stdio MCP server this manager spawns to the
@@ -270,13 +258,6 @@ type managerOptions struct {
 // is a no-op, so a non-sandboxed session behaves exactly as before.
 func WithSandboxWrapper(w *sandbox.Wrapper) Option {
 	return func(o *managerOptions) { o.wrapper = w }
-}
-
-// WithConnectTimeoutForTesting overrides NewManager's production 10s
-// per-server timeout. A non-positive duration retains parent cancellation but
-// adds no wall-clock deadline. It is only for hermetic real-transport tests.
-func WithConnectTimeoutForTesting(timeout time.Duration) Option {
-	return func(o *managerOptions) { o.connectTimeout = timeout }
 }
 
 // productionDial returns the default dial factory for cfg: build a fresh

--- a/agent/internal/mcp/manager_test.go
+++ b/agent/internal/mcp/manager_test.go
@@ -300,39 +300,26 @@ func TestMCPManager_Empty(t *testing.T) {
 
 func TestMCPManager_PerServerTimeout(t *testing.T) {
 	errDial := errors.New("stop after observing context")
-	tests := []struct {
-		name         string
-		opts         []Option
-		wantDeadline bool
-	}{
-		{name: "default is ten seconds", wantDeadline: true},
-		{name: "test lifecycle context only", opts: []Option{WithConnectTimeoutForTesting(0)}},
+	var deadline time.Time
+	var hasDeadline bool
+	before := time.Now()
+	mgr, outcomes := NewManager(t.Context(), []mcpconfig.ServerConfig{{Name: "ctx"}}, []func(context.Context) (mcpsdk.Transport, error){
+		func(ctx context.Context) (mcpsdk.Transport, error) {
+			deadline, hasDeadline = ctx.Deadline()
+			return nil, errDial
+		},
+	})
+	after := time.Now()
+	defer mgr.Close()
+
+	if len(outcomes) != 1 || !errors.Is(outcomes[0].Err, errDial) {
+		t.Fatalf("NewManager outcomes = %+v, want dial sentinel", outcomes)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var deadline time.Time
-			var hasDeadline bool
-			before := time.Now()
-			mgr, outcomes := NewManager(t.Context(), []mcpconfig.ServerConfig{{Name: "ctx"}}, []func(context.Context) (mcpsdk.Transport, error){
-				func(ctx context.Context) (mcpsdk.Transport, error) {
-					deadline, hasDeadline = ctx.Deadline()
-					return nil, errDial
-				},
-			}, tt.opts...)
-			after := time.Now()
-			defer mgr.Close()
-
-			if len(outcomes) != 1 || !errors.Is(outcomes[0].Err, errDial) {
-				t.Fatalf("NewManager outcomes = %+v, want dial sentinel", outcomes)
-			}
-			if hasDeadline != tt.wantDeadline {
-				t.Fatalf("connect context has deadline = %v, want %v", hasDeadline, tt.wantDeadline)
-			}
-			if tt.wantDeadline && (deadline.Before(before.Add(10*time.Second)) || deadline.After(after.Add(10*time.Second))) {
-				t.Fatalf("connect deadline = %v, want creation time + 10s in [%v, %v]", deadline, before.Add(10*time.Second), after.Add(10*time.Second))
-			}
-		})
+	if !hasDeadline {
+		t.Fatal("connect context has no deadline, want production 10s deadline")
+	}
+	if deadline.Before(before.Add(10*time.Second)) || deadline.After(after.Add(10*time.Second)) {
+		t.Fatalf("connect deadline = %v, want creation time + 10s in [%v, %v]", deadline, before.Add(10*time.Second), after.Add(10*time.Second))
 	}
 }
 

--- a/agent/session_config.go
+++ b/agent/session_config.go
@@ -261,14 +261,6 @@ type SessionConfig struct {
 // deterministic. Never set by app callers; never persisted (json:"-" on the
 // parent field).
 type testConfig struct {
-	// mcpConnectContext replaces initMCP's production 30s context. Hermetic
-	// real-transport tests supply a context canceled by their test lifecycle;
-	// nil preserves the production outer timeout.
-	mcpConnectContext context.Context
-	// mcpConnectTimeout, when non-nil, overrides the manager's production 10s
-	// per-server timeout. A pointer to zero retains lifecycle cancellation without
-	// adding a wall-clock deadline.
-	mcpConnectTimeout *time.Duration
 	// visionSideChannelTimeout overrides the production vision timeout only for
 	// deterministic package tests. Zero preserves the production timeout.
 	visionSideChannelTimeout time.Duration

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -1926,9 +1926,8 @@ func commandUnenforcedFieldWarnings(p plugin.Instance) []events.WarningData {
 	return out
 }
 
-// initMCP discovers and connects to MCP servers if configured. Production uses
-// a 30-second timeout since NewSession doesn't take a context; hermetic stdio
-// tests can instead bind initialization to their lifecycle context.
+// initMCP discovers and connects to MCP servers if configured.
+// Uses a 30-second timeout since NewSession doesn't take a context.
 func (s *Session) initMCP() error {
 	configs, cfgWarnings, err := mcpconfig.Discover(s.currentEnv(), s.cfg.MCPConfigFiles, s.cfg.MCPInline)
 	if err != nil {
@@ -1947,21 +1946,13 @@ func (s *Session) initMCP() error {
 		return nil
 	}
 
-	ctx := s.cfg.testOnly.mcpConnectContext
-	managerOpts := []mcp.Option{mcp.WithSandboxWrapper(s.sandboxWrapper())}
-	if ctx == nil {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-	}
-	if timeout := s.cfg.testOnly.mcpConnectTimeout; timeout != nil {
-		managerOpts = append(managerOpts, mcp.WithConnectTimeoutForTesting(*timeout))
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	// A server that fails to connect or register is not fatal: fold its outcome
 	// into a pending warning and keep going. A session with zero healthy MCP
 	// servers still constructs successfully.
-	mgr, connectOutcomes := mcp.NewManager(ctx, configs, nil, managerOpts...)
+	mgr, connectOutcomes := mcp.NewManager(ctx, configs, nil, mcp.WithSandboxWrapper(s.sandboxWrapper()))
 	mgr.OnReconnect = func(name string) {
 		s.emitDiagnosticWarning(reconnectRecoveryWarning(name))
 	}


### PR DESCRIPTION
## Summary
- remove PR #422's coverage-only MCP connect-timeout override and test config seams
- keep the production 30s init context and 10s per-server MCP deadline
- run the six real Session→stdio discovery paths under production behavior

## Audit rationale
The 48-hour overbuilding audit found that PR #422 added a zero timeout solely to avoid wall-clock waits in six coverage tests. Those tests now use readiness-driven assertions with the unchanged production deadline; healthy stdio discovery completes promptly, while lifecycle cancellation, errors, partial-server behavior, and timeout semantics remain production-owned.

## Verification
- six exact MCP integration tests: `-count=1`, `-count=20`, `-race -count=5`
- `go test ./agent/internal/mcp ./agent`
- `go test -race ./agent/internal/mcp`
- focused gofmt, vet, and diff checks

References #422