### PR TITLE
fix(agent-shards): fail closed on explicit run files

### DIFF
--- a/agent/session_tools_worktree_create_test.go
+++ b/agent/session_tools_worktree_create_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -172,12 +173,9 @@ func TestMain(m *testing.M) {
 	// flag.Set so the command-line value (absent here) does not clobber
 	// the file contents after m.Run calls flag.Parse internally.
 	flag.Parse()
-	if runFile := os.Getenv("EVENER_SHARD_RUN_FILE"); runFile != "" {
-		if data, err := os.ReadFile(runFile); err == nil {
-			if pattern := strings.TrimSpace(string(data)); pattern != "" {
-				flag.Set("test.run", pattern)
-			}
-		}
+	if err := configureShardRunFile(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "agent TestMain: %v\n", err)
+		os.Exit(2)
 	}
 
 	// The worktree tests reach git through `sh -c "git …"`, so PATH order decides
@@ -219,6 +217,28 @@ func TestMain(m *testing.M) {
 		_ = os.RemoveAll(intgMCPServerDir)
 	}
 	os.Exit(code)
+}
+
+func configureShardRunFile() error {
+	runFile, supplied := os.LookupEnv("EVENER_SHARD_RUN_FILE")
+	if !supplied {
+		return nil
+	}
+	data, err := os.ReadFile(runFile)
+	if err != nil {
+		return fmt.Errorf("EVENER_SHARD_RUN_FILE %q: read failed: %w", runFile, err)
+	}
+	pattern := strings.TrimSpace(string(data))
+	if pattern == "" {
+		return fmt.Errorf("EVENER_SHARD_RUN_FILE %q: run regex is empty", runFile)
+	}
+	if _, err := regexp.Compile(pattern); err != nil {
+		return fmt.Errorf("EVENER_SHARD_RUN_FILE %q: invalid run regex: %w", runFile, err)
+	}
+	if err := flag.Set("test.run", pattern); err != nil {
+		return fmt.Errorf("EVENER_SHARD_RUN_FILE %q: setting test.run failed: %w", runFile, err)
+	}
+	return nil
 }
 
 func packageFixtureTempDir(t *testing.T, pattern string) string {

--- a/cmd/evener-dev/agentshards.go
+++ b/cmd/evener-dev/agentshards.go
@@ -335,9 +335,6 @@ func runShards(cfg shardsConfig) int {
 		// MAX_ARG_STRLEN (128KB per single argument string). Write the
 		// regex to a file and hand the path via env so the test binary
 		// reads it in-process, never touching the execve argument list.
-		// The command-line -test.run is a permissive fallback for test
-		// binaries without TestMain env-var support; TestMain overrides
-		// it after flag.Parse by calling flag.Set with the file contents.
 		runFile := filepath.Join(logdir, fmt.Sprintf("shard%d.run", i))
 		if err := os.WriteFile(runFile, []byte(nameRegex(bin)), 0o644); err != nil {
 			_, _ = fmt.Fprintf(cfg.stderr, "agent-shards: %v\n", err)

--- a/cmd/evener-dev/agentshards_e2e_test.go
+++ b/cmd/evener-dev/agentshards_e2e_test.go
@@ -143,6 +143,81 @@ func TestAgentShardsRunFileHoldsRegex(t *testing.T) {
 	}
 }
 
+func TestShardRunFileExplicitFailuresAndValidSelection(t *testing.T) {
+	fixture := buildShardFixture(t)
+	fixtureDir := fixtureModule(t)
+	type testCase struct {
+		name       string
+		content    *string
+		path       string
+		wantExit   int
+		wantOutput string
+	}
+	valid := "^TestFixtureAlpha$\n"
+	empty := " \n\t"
+	invalid := "["
+	cases := []testCase{
+		{name: "unset", wantExit: 0, wantOutput: "--- PASS: TestFixtureAlpha"},
+		{name: "missing", path: "missing.run", wantExit: 2, wantOutput: "read failed"},
+		{name: "empty", content: &empty, path: "empty.run", wantExit: 2, wantOutput: "run regex is empty"},
+		{name: "invalid", content: &invalid, path: "invalid.run", wantExit: 2, wantOutput: "invalid run regex"},
+		{name: "valid", content: &valid, path: "valid.run", wantExit: 0, wantOutput: "--- PASS: TestFixtureAlpha"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var runFile string
+			if tc.content != nil {
+				runFile = filepath.Join(t.TempDir(), tc.path)
+				if err := os.WriteFile(runFile, []byte(*tc.content), 0o644); err != nil {
+					t.Fatalf("writing run file: %v", err)
+				}
+			} else if tc.path != "" {
+				runFile = filepath.Join(t.TempDir(), tc.path)
+			}
+			cmd := exec.Command(fixture, "-test.count=1", "-test.v")
+			cmd.Dir = fixtureDir
+			cmd.Env = slices.DeleteFunc(os.Environ(), func(value string) bool {
+				return strings.HasPrefix(value, "EVENER_SHARD_RUN_FILE=")
+			})
+			cmd.Env = append(cmd.Env, "GOWORK=off")
+			if runFile != "" {
+				cmd.Env = append(cmd.Env, "EVENER_SHARD_RUN_FILE="+runFile)
+			}
+			output, err := cmd.CombinedOutput()
+			if err == nil {
+				if tc.wantExit != 0 {
+					t.Fatalf("exit = 0, want %d; output:\n%s", tc.wantExit, output)
+				}
+			} else {
+				var exitErr *exec.ExitError
+				if !errors.As(err, &exitErr) || exitErr.ExitCode() != tc.wantExit {
+					t.Fatalf("exit = %v, want %d; output:\n%s", err, tc.wantExit, output)
+				}
+			}
+			if !strings.Contains(string(output), tc.wantOutput) {
+				t.Fatalf("output missing %q:\n%s", tc.wantOutput, output)
+			}
+			if tc.name == "valid" && strings.Contains(string(output), "--- PASS: TestFixtureBeta") {
+				t.Fatalf("valid handoff ran an unselected test:\n%s", output)
+			}
+		})
+	}
+}
+
+func buildShardFixture(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "shardfixture.test")
+	cmd := exec.Command("go", "test", "-c", "-o", bin, ".")
+	cmd.Dir = fixtureModule(t)
+	cmd.Env = append(slices.DeleteFunc(os.Environ(), func(value string) bool {
+		return strings.HasPrefix(value, "EVENER_SHARD_RUN_FILE=")
+	}), "GOWORK=off")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("building shard fixture: %v\n%s", err, output)
+	}
+	return bin
+}
+
 // passLineSeconds extracts each PASS line's reported wall seconds by shard.
 func passLineSeconds(t *testing.T, out string) map[int]float64 {
 	t.Helper()

--- a/cmd/evener-dev/testdata/shardfixture/fixture_test.go
+++ b/cmd/evener-dev/testdata/shardfixture/fixture_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"syscall"
 	"testing"
@@ -20,14 +21,33 @@ import (
 // when set, so agent-shards never puts the regex on the command line.
 func TestMain(m *testing.M) {
 	flag.Parse()
-	if runFile := os.Getenv("EVENER_SHARD_RUN_FILE"); runFile != "" {
-		if data, err := os.ReadFile(runFile); err == nil {
-			if pattern := strings.TrimSpace(string(data)); pattern != "" {
-				flag.Set("test.run", pattern)
-			}
-		}
+	if err := configureShardRunFile(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "shardfixture TestMain: %v\n", err)
+		os.Exit(2)
 	}
 	os.Exit(m.Run())
+}
+
+func configureShardRunFile() error {
+	runFile, supplied := os.LookupEnv("EVENER_SHARD_RUN_FILE")
+	if !supplied {
+		return nil
+	}
+	data, err := os.ReadFile(runFile)
+	if err != nil {
+		return fmt.Errorf("EVENER_SHARD_RUN_FILE %q: read failed: %w", runFile, err)
+	}
+	pattern := strings.TrimSpace(string(data))
+	if pattern == "" {
+		return fmt.Errorf("EVENER_SHARD_RUN_FILE %q: run regex is empty", runFile)
+	}
+	if _, err := regexp.Compile(pattern); err != nil {
+		return fmt.Errorf("EVENER_SHARD_RUN_FILE %q: invalid run regex: %w", runFile, err)
+	}
+	if err := flag.Set("test.run", pattern); err != nil {
+		return fmt.Errorf("EVENER_SHARD_RUN_FILE %q: setting test.run failed: %w", runFile, err)
+	}
+	return nil
 }
 
 func TestFixtureAlpha(t *testing.T) { time.Sleep(30 * time.Millisecond) }


### PR DESCRIPTION
## Summary

Focused follow-up to the PR #371 overbuilding audit. The shard run-file protocol remains necessary: the exact main test set is already over Linux's single-argument limit at the runner's 4-shard default, and CI's 8-shard pattern is too close to the limit to treat as robust.

The protocol now fails closed when `EVENER_SHARD_RUN_FILE` is explicitly supplied: read failures, empty/whitespace files, invalid regexes, and `flag.Set("test.run", ...)` failures report a clear error and exit 2. When the variable is unset, TestMain behavior is unchanged. The stale comment claiming a command-line fallback was removed.

## Measurements against exact main

Base: `8ac7b342a3cb3e8b4018efc7d5e1304c514e7965`

- Real agent test binary: 4,998 Test/Example names; 227,390-byte `-test.list` output.
- Matching cached survey: 4,998 cost entries.
- Cost-balanced maximum regex sizes: 2 shards 164,498 bytes; 4 shards 133,182 bytes; 8 shards 117,279 bytes.
- Linux `MAX_ARG_STRLEN`: 131,072 bytes; therefore 4 shards exceed the limit and 8 shards leave only ~10.5% margin.
- Darwin `kern.argmax` and local `getconf ARG_MAX`: 1,048,576 bytes; Linux's per-argument limit is the binding constraint.

## Tests

- Real fixture test-binary TDD: unset, missing, empty, invalid, and valid handoff cases.
- Agent-shards e2e: partition/selection, cleanup, failure evidence, survey, signal, and environment cases.
- Focused race handoff e2e.
- `make test-dev-tooling`, `make lint-gofmt`, `make vet`, `make lint`, and `WEB=0 make test-short` pass.
- A full `make test-short` run completed all Go modules but hit five unrelated pre-existing frontend Spawn/Rail failures (6,917/6,922 frontend tests passed); the required Go-only form passed.

References PR #371 and the 48-hour overbuilding audit.
