### PR TITLE
fix(agent): reject invalid task reasoning efforts

### DIFF
--- a/agent/session_task_effort_test.go
+++ b/agent/session_task_effort_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -30,6 +31,84 @@ func taskEffortToolCall(id, args string) llm.Response {
 			ToolCall: &llm.ToolCallData{ID: id, Name: "task_list", Arguments: json.RawMessage(args)},
 		}},
 	}}
+}
+
+func requireTaskEffortSchemaLevel(t *testing.T, req llm.Request, operation, level string) {
+	t.Helper()
+	for _, def := range req.Tools {
+		if def.Name != "task_list" {
+			continue
+		}
+		properties, ok := def.Parameters["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("task_list properties = %#v", def.Parameters["properties"])
+		}
+		operationSchema, ok := properties[operation].(map[string]any)
+		if !ok {
+			t.Fatalf("task_list %s schema = %#v", operation, properties[operation])
+		}
+		items, ok := operationSchema["items"].(map[string]any)
+		if !ok {
+			t.Fatalf("task_list %s items = %#v", operation, operationSchema["items"])
+		}
+		itemProperties, ok := items["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("task_list %s item properties = %#v", operation, items["properties"])
+		}
+		effortSchema, ok := itemProperties["reasoning_effort"].(map[string]any)
+		if !ok {
+			t.Fatalf("task_list %s reasoning_effort schema = %#v", operation, itemProperties["reasoning_effort"])
+		}
+		levels, ok := effortSchema["enum"].([]string)
+		if !ok {
+			t.Fatalf("task_list %s reasoning_effort enum = %#v", operation, effortSchema["enum"])
+		}
+		if slices.Contains(levels, level) {
+			return
+		}
+		t.Fatalf("task_list %s reasoning_effort enum = %v, want stale level %q admitted by metadata", operation, levels, level)
+	}
+	t.Fatal("request has no task_list tool definition")
+}
+
+func requireTaskHandlerError(t *testing.T, req llm.Request, callID string) {
+	t.Helper()
+	for _, message := range req.Messages {
+		for _, part := range message.Content {
+			if part.ToolResult == nil || part.ToolResult.ToolCallID != callID {
+				continue
+			}
+			if !part.ToolResult.IsError {
+				t.Fatalf("task_list result %s is not an error: %#v", callID, part.ToolResult)
+			}
+			if part.ToolResult.PrevalOnly {
+				t.Fatalf("task_list result %s was rejected before the handler: %#v", callID, part.ToolResult)
+			}
+			return
+		}
+	}
+	t.Fatalf("request has no task_list result for %s", callID)
+}
+
+func TestValidateTaskEffortNormalizesCanonicalValues(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, input, want string
+	}{
+		{name: "canonical", input: " HIGH ", want: "high"},
+		{name: "inherit", input: " InHerIt ", want: ""},
+		{name: "disable alias", input: " none ", want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateTaskEffort(tc.input)
+			if err != nil {
+				t.Fatalf("validateTaskEffort(%q): %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("validateTaskEffort(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
 }
 
 func requestEfforts(t *testing.T, reqs []llm.Request) []string {
@@ -106,6 +185,102 @@ func TestSession_TaskEffortOverride_AppliesPerRoundOnly(t *testing.T) {
 	}
 	if effort := sess.ReasoningEffort(); effort != "max" {
 		t.Fatalf("session configured effort = %q after tasks, want %q (task effort must not persist into session config)", effort, "max")
+	}
+}
+
+// An invalid task effort must reject the entire task update before it can
+// activate the task. Otherwise the next model request carries the invalid
+// override and a provider that rejects it can leave autonomous wakeups retrying
+// the same permanently poisoned request.
+func TestSession_TaskListRejectsInvalidEffortBeforeActivatingTask(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	c := llm.NewClient()
+
+	f := &fakeAdapter{
+		name: "openai",
+		steps: []func(req llm.Request) llm.Response{
+			func(req llm.Request) llm.Response {
+				requireTaskEffortSchemaLevel(t, req, "updates", "ultra")
+				return taskEffortToolCall("c1", `{"action":"append","tasks":[{"type":"implement","description":"first guard","prompt":"keep the first request valid","reasoning_effort":"high"},{"type":"implement","description":"second guard","prompt":"keep the second request valid","reasoning_effort":"low"}]}`)
+			},
+			func(req llm.Request) llm.Response {
+				return taskEffortToolCall("c2", `{"action":"update","updates":[{"id":1,"status":"done","reasoning_effort":"max"},{"id":2,"status":"in_progress","reasoning_effort":"ultra"}]}`)
+			},
+			func(req llm.Request) llm.Response {
+				requireTaskHandlerError(t, req, "c2")
+				return finalResponse("done")
+			},
+		},
+	}
+	c.Register(f)
+
+	// Model metadata is an external boundary and may advertise a stale level.
+	// The task handler must still enforce Evener's canonical vocabulary rather
+	// than trusting the schema enum as its only validation.
+	profile := provider.NewOpenAIProfile("gpt-5.2").WithLiveModelInfo(llm.ModelInfo{
+		ReasoningEffortLevels: []string{"minimal", "low", "medium", "high", "xhigh", "max", "ultra"},
+	})
+	sess, err := NewSession(c, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
+		ReasoningEffort: "max",
+	})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	defer cancel()
+	if _, err := sess.ProcessInput(ctx, "work the plan", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	tasks := sess.getOrCreateTaskStore().View()
+	if len(tasks) != 2 {
+		t.Fatalf("tasks = %#v, want the two valid appended tasks", tasks)
+	}
+	if tasks[0].Status != taskpkg.TaskOpen || tasks[0].ReasoningEffort != "high" || tasks[1].Status != taskpkg.TaskOpen || tasks[1].ReasoningEffort != "low" {
+		t.Fatalf("tasks after rejected update = %#v, want both original open tasks unchanged", tasks)
+	}
+	if got, want := requestEfforts(t, f.Requests()), []string{"max", "max", "max"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		t.Fatalf("request efforts = %v, want %v (invalid task effort must not cross the provider boundary)", got, want)
+	}
+}
+
+func TestSession_TaskListRejectsInvalidEffortBeforeAppendingTask(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	c := llm.NewClient()
+	f := &fakeAdapter{
+		name: "openai",
+		steps: []func(req llm.Request) llm.Response{
+			func(req llm.Request) llm.Response {
+				requireTaskEffortSchemaLevel(t, req, "tasks", "ultra")
+				return taskEffortToolCall("c1", `{"action":"append","tasks":[{"type":"implement","description":"valid step","prompt":"must roll back with the batch","reasoning_effort":"high"},{"type":"implement","description":"poisoned step","prompt":"must not persist","reasoning_effort":"ultra"}]}`)
+			},
+			func(req llm.Request) llm.Response {
+				requireTaskHandlerError(t, req, "c1")
+				return finalResponse("done")
+			},
+		},
+	}
+	c.Register(f)
+	profile := provider.NewOpenAIProfile("gpt-5.2").WithLiveModelInfo(llm.ModelInfo{
+		ReasoningEffortLevels: []string{"minimal", "low", "medium", "high", "xhigh", "max", "ultra"},
+	})
+	sess, err := NewSession(c, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{ReasoningEffort: "max"})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	defer cancel()
+	if _, err := sess.ProcessInput(ctx, "work the plan", nil); err != nil {
+		t.Fatal(err)
+	}
+	if tasks := sess.getOrCreateTaskStore().View(); len(tasks) != 0 {
+		t.Fatalf("tasks after rejected append = %#v, want none", tasks)
 	}
 }
 

--- a/agent/session_task_effort_test.go
+++ b/agent/session_task_effort_test.go
@@ -188,6 +188,107 @@ func TestSession_TaskEffortOverride_AppliesPerRoundOnly(t *testing.T) {
 	}
 }
 
+func TestSession_RestoreTaskEffortMigration_ReachesProviderSafely(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name           string
+		legacyEffort   string
+		wantEffort     string
+		wantTaskEffort string
+	}{
+		{name: "invalid inherits session", legacyEffort: "ultra", wantEffort: "max", wantTaskEffort: ""},
+		{name: "valid override wins", legacyEffort: " HIGH ", wantEffort: "high", wantTaskEffort: "high"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			stateDir := t.TempDir()
+			profile := provider.NewOpenAIProfile("gpt-5.2").WithLiveModelInfo(llm.ModelInfo{
+				// Include the stale level to prove restore sanitization does not
+				// trust provider metadata to validate the task override.
+				ReasoningEffortLevels: []string{"minimal", "low", "medium", "high", "xhigh", "max", "ultra"},
+			})
+
+			seedClient := llm.NewClient()
+			seedClient.Register(&fakeAdapter{name: "openai"})
+			seed, err := NewSession(seedClient, profile, execenv.NewLocalExecutionEnvironment(stateDir), SessionConfig{
+				StateDir:        stateDir,
+				ReasoningEffort: "max",
+			})
+			if err != nil {
+				t.Fatalf("NewSession: %v", err)
+			}
+			store := seed.getOrCreateTaskStore()
+			if _, err := store.Append([]taskpkg.TaskInput{{
+				Type:        taskpkg.TaskTypeImplement,
+				Description: "persisted task",
+				Prompt:      "resume this task",
+			}}); err != nil {
+				seed.Close()
+				t.Fatalf("Append: %v", err)
+			}
+			if err := store.Update([]taskpkg.TaskUpdate{{ID: 1, Status: taskpkg.TaskInProgress}}); err != nil {
+				seed.Close()
+				t.Fatalf("Update: %v", err)
+			}
+			meta := seed.Meta()
+			seed.Close()
+
+			// Install a legacy file over the real saved task JSON, preserving the
+			// task's identity and in-progress state while changing only effort.
+			taskPath := filepath.Join(stateDir, "tasks", meta.ID+".json")
+			legacyJSON, err := os.ReadFile(taskPath)
+			if err != nil {
+				t.Fatalf("read saved task JSON: %v", err)
+			}
+			var legacyTasks []taskpkg.Task
+			if err := json.Unmarshal(legacyJSON, &legacyTasks); err != nil {
+				t.Fatalf("unmarshal saved task JSON: %v", err)
+			}
+			legacyTasks[0].ReasoningEffort = tc.legacyEffort
+			legacyJSON, err = json.Marshal(legacyTasks)
+			if err != nil {
+				t.Fatalf("marshal legacy task JSON: %v", err)
+			}
+			if err := os.WriteFile(taskPath, legacyJSON, 0o644); err != nil {
+				t.Fatalf("install legacy task JSON: %v", err)
+			}
+
+			adapter := &fakeAdapter{name: "openai", steps: []func(llm.Request) llm.Response{
+				func(llm.Request) llm.Response { return finalResponse("resumed") },
+			}}
+			client := llm.NewClient()
+			client.Register(adapter)
+			restored, err := RestoreSessionFromMeta(client, profile, execenv.NewLocalExecutionEnvironment(stateDir), meta, stateDir)
+			if err != nil {
+				t.Fatalf("RestoreSessionFromMeta: %v", err)
+			}
+			defer restored.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter; only fires on a genuine restore hang.
+			defer cancel()
+			if _, err := restored.ProcessInput(ctx, "continue the persisted task", nil); err != nil {
+				t.Fatalf("ProcessInput after restore: %v", err)
+			}
+			reqs := adapter.Requests()
+			if len(reqs) != 1 {
+				t.Fatalf("provider requests = %d, want one; efforts=%v", len(reqs), requestEfforts(t, reqs))
+			}
+			if got := requestEfforts(t, reqs)[0]; got != tc.wantEffort {
+				t.Fatalf("provider effort = %q, want %q", got, tc.wantEffort)
+			}
+			for _, req := range reqs {
+				if req.ReasoningEffort != nil && *req.ReasoningEffort == "ultra" {
+					t.Fatal("invalid persisted effort reached provider request")
+				}
+			}
+			tasks := restored.getOrCreateTaskStore().View()
+			if len(tasks) != 1 || tasks[0].ID != 1 || tasks[0].Status != taskpkg.TaskInProgress || tasks[0].ReasoningEffort != tc.wantTaskEffort {
+				t.Fatalf("restored task = %+v, want preserved identity/status and effort %q", tasks, tc.wantTaskEffort)
+			}
+		})
+	}
+}
+
 // An invalid task effort must reject the entire task update before it can
 // activate the task. Otherwise the next model request carries the invalid
 // override and a provider that rejects it can leave autonomous wakeups retrying

--- a/agent/session_tools_task.go
+++ b/agent/session_tools_task.go
@@ -11,6 +11,7 @@ import (
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/internal/tool"
 	taskpkg "primeradiant.com/evener/agent/task"
+	"primeradiant.com/evener/llm"
 )
 
 // normalizeTaskEffort maps the "inherit" sentinel to "" (no override: the task
@@ -21,7 +22,15 @@ func normalizeTaskEffort(effort string) string {
 	if strings.EqualFold(strings.TrimSpace(effort), "inherit") {
 		return ""
 	}
-	return effort
+	return llm.NormalizeReasoningEffort(effort)
+}
+
+func validateTaskEffort(effort string) (string, error) {
+	normalized := normalizeTaskEffort(effort)
+	if err := llm.ValidateReasoningEffort(normalized); err != nil {
+		return "", err
+	}
+	return normalized, nil
 }
 
 // formatTaskList renders the task list as plain text, like a to-do list: one task
@@ -135,7 +144,11 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 					}
 					reasoningEffort := ""
 					if re, ok := m["reasoning_effort"].(string); ok {
-						reasoningEffort = normalizeTaskEffort(re)
+						var err error
+						reasoningEffort, err = validateTaskEffort(re)
+						if err != nil {
+							return nil, err
+						}
 					}
 					items = append(items, taskpkg.TaskInput{
 						Type:            taskType,
@@ -194,7 +207,11 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 						u.DependsOn = &depIDs
 					}
 					if re, ok := m["reasoning_effort"].(string); ok {
-						u.ReasoningEffort = normalizeTaskEffort(re)
+						var err error
+						u.ReasoningEffort, err = validateTaskEffort(re)
+						if err != nil {
+							return nil, err
+						}
 					}
 					updates = append(updates, u)
 				}

--- a/agent/task/task_store.go
+++ b/agent/task/task_store.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/spf13/afero"
+	"primeradiant.com/evener/llm"
 )
 
 // TaskTemplate defines a default task in an agent's workflow. When a session
@@ -197,6 +199,19 @@ func (s *TaskStore) Load() error {
 	var tasks []Task
 	if err := json.Unmarshal(data, &tasks); err != nil {
 		return fmt.Errorf("unmarshal tasks: %w", err)
+	}
+	// Persisted task files predate task-list effort validation and may contain
+	// an unsupported override. Normalize each task before publishing the loaded
+	// slice so a stale value cannot become a provider request after restore. The
+	// empty value is the existing inherit representation; keep all other task
+	// fields untouched. Load still assigns only after unmarshalling and
+	// normalization, so malformed input cannot partially replace the store.
+	for i := range tasks {
+		effort := strings.ToLower(strings.TrimSpace(tasks[i].ReasoningEffort))
+		if err := llm.ValidateReasoningEffort(effort); err != nil {
+			effort = ""
+		}
+		tasks[i].ReasoningEffort = effort
 	}
 	s.tasks = tasks
 

--- a/agent/task/task_store_test.go
+++ b/agent/task/task_store_test.go
@@ -1,7 +1,11 @@
 package task
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -40,6 +44,84 @@ func TestAppend_AssignsIDsStatusTypeAndStamps(t *testing.T) {
 	}
 	if added[0].CreatedAt == nil || added[0].UpdatedAt == nil {
 		t.Error("CreatedAt/UpdatedAt not stamped")
+	}
+}
+
+func TestLoad_NormalizesPersistedTaskEffortsWithoutChangingTaskState(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks", "s.json")
+	legacy := []Task{
+		{ID: 7, Description: "invalid", Prompt: "recover", Status: TaskInProgress, DependsOn: []int{3}, ReasoningEffort: " ultra "},
+		{ID: 3, Description: "valid", Prompt: "keep", Status: TaskDone, ReasoningEffort: " HIGH "},
+		{ID: 9, Description: "empty", Prompt: "inherit", Status: TaskOpen},
+	}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := NewTaskStore(dir, "s")
+	if err := store.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := store.View()
+	if len(got) != len(legacy) {
+		t.Fatalf("loaded %d tasks, want %d", len(got), len(legacy))
+	}
+	if got[0].ID != 7 || got[0].Status != TaskInProgress || got[0].ReasoningEffort != "" || len(got[0].DependsOn) != 1 || got[0].DependsOn[0] != 3 {
+		t.Fatalf("invalid task was not migrated without losing identity/state: %+v", got[0])
+	}
+	if got[1].ID != 3 || got[1].Status != TaskDone || got[1].ReasoningEffort != "high" {
+		t.Fatalf("valid task = %+v, want canonical high override", got[1])
+	}
+	if got[2].ReasoningEffort != "" {
+		t.Fatalf("empty effort = %q, want inherit representation", got[2].ReasoningEffort)
+	}
+
+	// The migrated store remains usable, and a subsequent atomic save must not
+	// reintroduce the stale value.
+	if _, err := store.Append([]TaskInput{{Description: "after restore", Prompt: "continue"}}); err != nil {
+		t.Fatalf("Append after migration: %v", err)
+	}
+	persisted, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(persisted, data) || len(persisted) == 0 {
+		t.Fatalf("save did not rewrite migrated task state: %s", persisted)
+	}
+	var saved []Task
+	if err := json.Unmarshal(persisted, &saved); err != nil {
+		t.Fatal(err)
+	}
+	if saved[0].ReasoningEffort != "" || saved[1].ReasoningEffort != "high" {
+		t.Fatalf("saved migrated efforts = [%q, %q], want [empty, high]", saved[0].ReasoningEffort, saved[1].ReasoningEffort)
+	}
+}
+
+func TestLoad_MalformedJSONDoesNotPartiallyReplaceStore(t *testing.T) {
+	dir := t.TempDir()
+	store := NewTaskStore(dir, "s")
+	added, err := store.Append([]TaskInput{{Description: "existing", Prompt: "keep"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "tasks", "s.json")
+	if err := os.WriteFile(path, []byte(`[{"id":99,"description":"partial"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Load(); err == nil {
+		t.Fatal("Load malformed JSON succeeded")
+	}
+	got := store.View()
+	if len(got) != 1 || got[0].ID != added[0].ID || got[0].Description != "existing" {
+		t.Fatalf("malformed Load partially replaced store: %+v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- validate task-level reasoning effort against Evener's canonical vocabulary before mutating the task store
- reject invalid append and update batches atomically, even when stale model metadata advertises an unsupported level
- cover stale-schema admission, handler-stage rejection, mixed-batch rollback, normalization, and provider request behavior

## Root cause

A stale model effort list admitted `ultra` through the `task_list` schema. The task handler persisted it without canonical validation. Once that task became active, autonomous turns repeatedly sent an invalid provider request and received HTTP 400.

## Test plan

- `make lint`
- `make vet`
- `make test`
