### PR TITLE
fix(web): synchronize interrupt cleanup ownership

### DIFF
--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
@@ -226,7 +226,7 @@ export function filterCrashpadProcessTable(processList) {
     .join("\n");
 }
 
-export function listSystemProcesses({ processTable } = {}) {
+export function listSystemProcesses({ processTable, processCommand = ["/bin/ps"] } = {}) {
   if (processTable !== undefined) return filterCrashpadProcessTable(processTable);
   // Stream the complete table through awk and retain only full-argv Crashpad
   // candidates. Capturing the unfiltered table exceeds execFileSync's 1 MiB
@@ -234,11 +234,25 @@ export function listSystemProcesses({ processTable } = {}) {
   // than pgrep's comm name, also works on Linux where comm is truncated to 15
   // bytes and would miss chrome_crashpad_handler.
   const filter =
-    "line=$0; sub(/^[[:space:]]*[0-9]+[[:space:]]+[0-9]+[[:space:]]+/, \"\", line); " +
-    "if (line ~ /(^|\\/)chrome_crashpad_handler([[:space:]]|$)/) print $0";
+    "{ line=$0; sub(/^[[:space:]]*[0-9]+[[:space:]]+[0-9]+[[:space:]]+/, \"\", line); " +
+    // Keep the filter narrow, but leave argv0 validation to the JS parser. The
+    // second condition rejects an absolute path appearing after an unrelated
+    // argv0 while still allowing the spaces in a normal macOS Chrome path.
+    "if (line ~ /^.*\\/chrome_crashpad_handler([[:space:]]|$)/ && " +
+    "line !~ /^\\/[^[:space:]]+[[:space:]]+\\/.*\\/chrome_crashpad_handler([[:space:]]|$)/) print $0 }";
+  if (!Array.isArray(processCommand) || processCommand.length === 0) {
+    throw new TypeError("processCommand must contain an executable");
+  }
   return execFileSync(
     "/bin/bash",
-    ["-o", "pipefail", "-c", `/bin/ps -axo pid=,pgid=,command= | /usr/bin/awk '${filter}'`],
+    [
+      "-o",
+      "pipefail",
+      "-c",
+      `"$@" -axo pid=,pgid=,command= | /usr/bin/awk '${filter}'`,
+      "browser-guard-ps",
+      ...processCommand,
+    ],
     { encoding: "utf8" },
   );
 }
@@ -261,14 +275,16 @@ function parseProcesses(processList) {
 }
 
 function commandMatchesProfileProcess(command, databaseArg) {
-  const handler = command.match(/(?:^|\/)chrome_crashpad_handler(?=\s|$)/);
-  if (!handler) return false;
-  // ps exposes the executable path and argv as one string, and macOS paths
-  // may contain spaces. An argument such as --arg=/chrome_crashpad_handler
-  // must not become an owned executable; Chrome's argv starts with --, so the
-  // first option is a safe boundary for this identity check.
-  const firstOption = command.search(/\s--(?:\S|$)/);
-  if (firstOption >= 0 && handler.index > firstOption) return false;
+  // ps exposes argv0 and the remaining argv as one string. Anchor the helper
+  // to argv0: a handler-looking positional argument must never own a profile.
+  // macOS app/framework paths contain spaces, so do not split on whitespace;
+  // instead reject a second absolute path before the helper and require a
+  // Chrome/Chromium path when the executable path itself contains spaces.
+  const handler = command.match(/^(.*\/)?chrome_crashpad_handler(?=\s|$)/);
+  if (!handler || (handler[1] && !command.startsWith("/"))) return false;
+  const executablePath = handler[1] ?? "";
+  if (/\s+\//.test(executablePath)) return false;
+  if (/\s/.test(executablePath) && !/(?:chrome|chromium)/i.test(executablePath)) return false;
   return command.includes(`${databaseArg} `) || command.endsWith(databaseArg);
 }
 
@@ -287,12 +303,13 @@ export function findMacOSProfileProcesses(
 }
 
 export function profileProcessIdentityRunning(
-  { pid, databaseArg },
+  { pid, pgid, databaseArg },
   { platform = process.platform, listProcesses = listSystemProcess } = {},
 ) {
-  if (platform !== "darwin") return false;
+  if (platform !== "darwin" || !Number.isInteger(pid) || !Number.isInteger(pgid) || pgid <= 0) return false;
   return parseProcesses(listProcesses(pid)).some(
-    (candidate) => candidate.pid === pid && commandMatchesProfileProcess(candidate.command, databaseArg),
+    (candidate) =>
+      candidate.pid === pid && candidate.pgid === pgid && commandMatchesProfileProcess(candidate.command, databaseArg),
   );
 }
 
@@ -586,7 +603,7 @@ export function createBrowserProcessCleanup({
         const profileProcesses = [
           ...new Map(
             [...profileProcessesBeforeClose, ...findProfileProcesses(profileDir)].map((processIdentity) => [
-              `${processIdentity.pid}\0${processIdentity.databaseArg ?? ""}`,
+              `${processIdentity.pid}\0${processIdentity.pgid ?? ""}\0${processIdentity.databaseArg ?? ""}`,
               processIdentity,
             ]),
           ).values(),

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
@@ -216,8 +216,31 @@ function reportCleanupFailure(error) {
   console.error(error instanceof Error ? error.message : String(error));
 }
 
-function listSystemProcesses() {
-  return execFileSync("/bin/ps", ["-axo", "pid=,pgid=,command="], { encoding: "utf8" });
+export function filterCrashpadProcessTable(processList) {
+  return processList
+    .split("\n")
+    .filter((line) => {
+      const match = line.match(/^\s*\d+\s+\d+\s+(.+)$/);
+      return match && /(?:^|\/)chrome_crashpad_handler(?:\s|$)/.test(match[1]);
+    })
+    .join("\n");
+}
+
+export function listSystemProcesses({ processTable } = {}) {
+  if (processTable !== undefined) return filterCrashpadProcessTable(processTable);
+  // Stream the complete table through awk and retain only full-argv Crashpad
+  // candidates. Capturing the unfiltered table exceeds execFileSync's 1 MiB
+  // maxBuffer on a process-heavy host. Filtering the command column, rather
+  // than pgrep's comm name, also works on Linux where comm is truncated to 15
+  // bytes and would miss chrome_crashpad_handler.
+  const filter =
+    "line=$0; sub(/^[[:space:]]*[0-9]+[[:space:]]+[0-9]+[[:space:]]+/, \"\", line); " +
+    "if (line ~ /(^|\\/)chrome_crashpad_handler([[:space:]]|$)/) print $0";
+  return execFileSync(
+    "/bin/bash",
+    ["-o", "pipefail", "-c", `/bin/ps -axo pid=,pgid=,command= | /usr/bin/awk '${filter}'`],
+    { encoding: "utf8" },
+  );
 }
 
 function listSystemProcess(pid) {
@@ -238,7 +261,14 @@ function parseProcesses(processList) {
 }
 
 function commandMatchesProfileProcess(command, databaseArg) {
-  if (!/(?:^|\/)chrome_crashpad_handler(?:\s|$)/.test(command)) return false;
+  const handler = command.match(/(?:^|\/)chrome_crashpad_handler(?=\s|$)/);
+  if (!handler) return false;
+  // ps exposes the executable path and argv as one string, and macOS paths
+  // may contain spaces. An argument such as --arg=/chrome_crashpad_handler
+  // must not become an owned executable; Chrome's argv starts with --, so the
+  // first option is a safe boundary for this identity check.
+  const firstOption = command.search(/\s--(?:\S|$)/);
+  if (firstOption >= 0 && handler.index > firstOption) return false;
   return command.includes(`${databaseArg} `) || command.endsWith(databaseArg);
 }
 

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
@@ -530,6 +530,7 @@ test("discovers only the Crashpad helper for the exact canonical private profile
     `  511   301 /Applications/Google Chrome/chrome_crashpad_handler --database=${crashpadDir}-neighbor --url=`,
     `  512   302 /Applications/Google Chrome/chrome_crashpad_handler --database=${crashpadDir}/nested --url=`,
     `  513   303 /usr/bin/unrelated ${exactDatabase} --url=`,
+    `  514   304 /usr/bin/tool /tmp/chrome_crashpad_handler ${exactDatabase}`,
   ].join("\n");
 
   assert.deepEqual(
@@ -541,7 +542,7 @@ test("discovers only the Crashpad helper for the exact canonical private profile
   );
 });
 
-test("streams a process-heavy table while preserving full-argv candidates", (context) => {
+test("streams a process-heavy external ps fixture while preserving full-argv candidates", (context) => {
   const profileDir = mkdtempSync(path.join(tmpdir(), "browser-helper-stream-test-"));
   context.after(() => rmSync(profileDir, { recursive: true, force: true }));
   const exactDatabase = `--database=${path.join(realpathSync(profileDir), "Crashpad")}`;
@@ -549,12 +550,20 @@ test("streams a process-heavy table while preserving full-argv candidates", (con
   const processTable = `${processTableOverOneMiB}
   510   300 /Applications/Google Chrome/chrome_crashpad_handler ${exactDatabase}
   511   301 /Applications/Google Chrome/chrome_crashpad_h ${exactDatabase}
-  512   302 /usr/bin/tool --arg=/chrome_crashpad_handler ${exactDatabase}`;
+  512   302 /usr/bin/tool --arg=/chrome_crashpad_handler ${exactDatabase}
+  513   303 /usr/bin/tool /tmp/chrome_crashpad_handler ${exactDatabase}`;
   assert.ok(processTable.length > 1_048_576);
-  const candidates = browserGuardProcess.listSystemProcesses({ processTable });
+  const psFixture = path.join(profileDir, "ps-fixture.mjs");
+  writeFileSync(psFixture, `process.stdout.write(${JSON.stringify(processTable)});\n`);
+  const candidates = browserGuardProcess.listSystemProcesses({
+    // This is the production bash/pipefail/awk boundary with a deterministic
+    // external producer. A synchronous full-table ps capture cannot pass it.
+    processCommand: [process.execPath, psFixture],
+  });
   assert.match(candidates, /\b510\s+300\s+.*chrome_crashpad_handler/);
   assert.doesNotMatch(candidates, /\b511\s+301\s+/);
   assert.match(candidates, /\b512\s+302\s+.*--arg=/);
+  assert.doesNotMatch(candidates, /\b513\s+303\s+/);
   assert.deepEqual(
     browserGuardProcess.findMacOSProfileProcesses(profileDir, {
       platform: "darwin",
@@ -564,10 +573,29 @@ test("streams a process-heavy table while preserving full-argv candidates", (con
   );
 });
 
+test("propagates an external ps failure through pipefail", (context) => {
+  const profileDir = mkdtempSync(path.join(tmpdir(), "browser-helper-ps-error-test-"));
+  context.after(() => rmSync(profileDir, { recursive: true, force: true }));
+  const psFixture = path.join(profileDir, "ps-error-fixture.mjs");
+  writeFileSync(
+    psFixture,
+    "process.stdout.write('  510   300 /usr/bin/chrome_crashpad_handler --database=/tmp/profile/Crashpad\\n'); process.exitCode = 23;\n",
+  );
+
+  assert.throws(
+    () =>
+      browserGuardProcess.listSystemProcesses({
+        processCommand: [process.execPath, psFixture],
+      }),
+    (error) => error.status !== 0 && /510\s+300/.test(error.stdout),
+  );
+});
+
 test("does not treat an unrelated process that reused a captured Crashpad PID as owned", () => {
   assert.equal(typeof browserGuardProcess.profileProcessIdentityRunning, "function");
   const identity = {
     pid: 510,
+    pgid: 300,
     databaseArg: "--database=/private/tmp/browser-profile/Crashpad",
   };
   const reusedProcess =
@@ -578,6 +606,40 @@ test("does not treat an unrelated process that reused a captured Crashpad PID as
   };
 
   assert.equal(browserGuardProcess.profileProcessIdentityRunning(identity, options), false);
+});
+
+test("does not signal a same-PID same-argv helper in a reused process group", async (context) => {
+  const profileDir = mkdtempSync(path.join(tmpdir(), "browser-helper-reused-group-test-"));
+  context.after(() => rmSync(profileDir, { recursive: true, force: true }));
+  const identity = {
+    pid: 510,
+    pgid: 300,
+    databaseArg: "--database=/private/tmp/browser-profile/Crashpad",
+  };
+  const reusedGroup =
+    "  510   777 /usr/bin/chrome_crashpad_handler --database=/private/tmp/browser-profile/Crashpad";
+
+  const signals = [];
+  const lifecycle = browserGuardProcess.createBrowserProcessCleanup({
+    profileDir,
+    findProfileProcesses: () => [identity],
+    profileProcessRunning: (candidate) =>
+      browserGuardProcess.profileProcessIdentityRunning(candidate, {
+        platform: "darwin",
+        listProcesses: () => reusedGroup,
+      }),
+    signalProfileProcess: (candidate, signal) => signals.push([candidate.pgid, signal]),
+  });
+
+  await lifecycle.cleanup();
+  assert.deepEqual(signals, []);
+  assert.equal(
+    browserGuardProcess.profileProcessIdentityRunning(identity, {
+      platform: "darwin",
+      listProcesses: () => reusedGroup,
+    }),
+    false,
+  );
 });
 
 test("targets a lingering browser process group with TERM then KILL", async () => {

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
@@ -541,6 +541,29 @@ test("discovers only the Crashpad helper for the exact canonical private profile
   );
 });
 
+test("streams a process-heavy table while preserving full-argv candidates", (context) => {
+  const profileDir = mkdtempSync(path.join(tmpdir(), "browser-helper-stream-test-"));
+  context.after(() => rmSync(profileDir, { recursive: true, force: true }));
+  const exactDatabase = `--database=${path.join(realpathSync(profileDir), "Crashpad")}`;
+  const processTableOverOneMiB = "  1   1 /usr/bin/unrelated --noise\n".repeat(70_000);
+  const processTable = `${processTableOverOneMiB}
+  510   300 /Applications/Google Chrome/chrome_crashpad_handler ${exactDatabase}
+  511   301 /Applications/Google Chrome/chrome_crashpad_h ${exactDatabase}
+  512   302 /usr/bin/tool --arg=/chrome_crashpad_handler ${exactDatabase}`;
+  assert.ok(processTable.length > 1_048_576);
+  const candidates = browserGuardProcess.listSystemProcesses({ processTable });
+  assert.match(candidates, /\b510\s+300\s+.*chrome_crashpad_handler/);
+  assert.doesNotMatch(candidates, /\b511\s+301\s+/);
+  assert.match(candidates, /\b512\s+302\s+.*--arg=/);
+  assert.deepEqual(
+    browserGuardProcess.findMacOSProfileProcesses(profileDir, {
+      platform: "darwin",
+      listProcesses: () => candidates,
+    }),
+    [{ pid: 510, pgid: 300, databaseArg: exactDatabase }],
+  );
+});
+
 test("does not treat an unrelated process that reused a captured Crashpad PID as owned", () => {
   assert.equal(typeof browserGuardProcess.profileProcessIdentityRunning, "function");
   const identity = {

--- a/runtime_pair_build_test.go
+++ b/runtime_pair_build_test.go
@@ -87,6 +87,7 @@ func TestRuntimeBuildFixtureEnvironmentDropsAmbientHarnessControls(t *testing.T)
 		"EVENER_TEST_NPM_TRACK_PID",
 		"EVENER_TEST_SHELL_KILLED_REAPED",
 		"EVENER_TEST_SHELL_WAITED_REAPED",
+		"EVENER_TEST_SHELL_WAIT_RELEASE",
 		"EVENER_TEST_NODE_HOLD_COMMAND",
 		"EVENER_TEST_NODE_FAIL_COMMAND",
 		"EVENER_TEST_NODE_PID",
@@ -750,13 +751,18 @@ func TestMakeTestWebInterruptDoesNotSignalReapedCheck(t *testing.T) {
 	heldPID := filepath.Join(fixture.root, "held-npm.pid")
 	reapedPID := filepath.Join(fixture.root, "reaped-npm.pid")
 	waitedReaped := filepath.Join(fixture.root, "waited-reaped.ready")
+	waitRelease := filepath.Join(fixture.root, "wait-release")
 	killedReaped := filepath.Join(fixture.root, "killed-reaped")
 	recordingShell := filepath.Join(filepath.Dir(fixture.root), "recording-shell")
 	writeTestFile(t, recordingShell, []byte(`wait() {
   command wait "$@"
   wait_status=$?
   tracked_pid=$(cat "$EVENER_TEST_NPM_TRACK_PID")
-  [ "${1:-}" != "$tracked_pid" ] || : > "$EVENER_TEST_SHELL_WAITED_REAPED"
+  if [ "${1:-}" = "$tracked_pid" ] && [ "${reaped_gate:-0}" -eq 0 ]; then
+    reaped_gate=1
+    : > "$EVENER_TEST_SHELL_WAITED_REAPED"
+    while [ ! -f "$EVENER_TEST_SHELL_WAIT_RELEASE" ]; do :; done
+  fi
   return "$wait_status"
 }
 kill() {
@@ -781,6 +787,7 @@ kill() {
 		"EVENER_TEST_NPM_TRACK_COMMAND=run typecheck",
 		"EVENER_TEST_NPM_TRACK_PID="+reapedPID,
 		"EVENER_TEST_SHELL_WAITED_REAPED="+waitedReaped,
+		"EVENER_TEST_SHELL_WAIT_RELEASE="+waitRelease,
 		"EVENER_TEST_SHELL_KILLED_REAPED="+killedReaped,
 	)
 	var output bytes.Buffer
@@ -807,6 +814,7 @@ kill() {
 	if err := exec.Command("kill", "-TERM", strconv.Itoa(command.Process.Pid)).Run(); err != nil {
 		t.Fatalf("signal make test-web: %v", err)
 	}
+	writeTestFile(t, waitRelease, nil, 0o644)
 	if err := run.wait(); err == nil {
 		t.Fatalf("interrupted make test-web exited zero; output = %s", output.String())
 	}
@@ -1223,6 +1231,7 @@ func (fixture runtimeBuildFixture) environment(failPackage string) []string {
 			"EVENER_TEST_GO_LOG", "EVENER_TEST_GO_FAIL_PACKAGE",
 			"EVENER_TEST_NPM_FAIL_COMMAND", "EVENER_TEST_NPM_HOLD_COMMAND", "EVENER_TEST_NPM_PID", "EVENER_TEST_NPM_READY",
 			"EVENER_TEST_NPM_TRACK_COMMAND", "EVENER_TEST_NPM_TRACK_PID", "EVENER_TEST_SHELL_KILLED_REAPED", "EVENER_TEST_SHELL_WAITED_REAPED",
+			"EVENER_TEST_SHELL_WAIT_RELEASE",
 			"EVENER_TEST_NODE_HOLD_COMMAND", "EVENER_TEST_NODE_FAIL_COMMAND", "EVENER_TEST_NODE_PID", "EVENER_TEST_NODE_READY", "EVENER_TEST_NODE_TERM", "EVENER_TEST_NODE_RELEASE", "EVENER_TEST_NODE_READY_FD":
 			continue
 		}

--- a/runtime_pair_build_test.go
+++ b/runtime_pair_build_test.go
@@ -1036,7 +1036,7 @@ func mutateWebWaitDeferral(t *testing.T, fixture runtimeBuildFixture) {
 	fi
 	printf '%s\n' "$check_status" >"$dir/$c.status"
 	consume_interrupt`
-	new := `	defer_signals=1
+	deferredWaitBlock := `	defer_signals=1
 	if wait "$pid"; then check_status=0; else check_status=$?; fi
 	if ! owned_job_is_running "$pid"; then
 		forget_pid "$pid"
@@ -1047,7 +1047,7 @@ func mutateWebWaitDeferral(t *testing.T, fixture runtimeBuildFixture) {
 	if !bytes.Contains(data, []byte(old)) {
 		t.Fatal("test-web wait mutation target changed; update the mechanism RED test")
 	}
-	data = bytes.Replace(data, []byte(old), []byte(new), 1)
+	data = bytes.Replace(data, []byte(old), []byte(deferredWaitBlock), 1)
 	if err := os.WriteFile(path, data, 0o755); err != nil {
 		t.Fatalf("write test-web mutation: %v", err)
 	}

--- a/runtime_pair_build_test.go
+++ b/runtime_pair_build_test.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -81,6 +82,8 @@ func TestRuntimeBuildFixtureEnvironmentDropsAmbientHarnessControls(t *testing.T)
 		"MFLAGS",
 		"EVENER_TEST_NPM_FAIL_COMMAND",
 		"EVENER_TEST_NPM_HOLD_COMMAND",
+		"EVENER_TEST_NPM_HOLD_RELEASE",
+		"EVENER_TEST_NPM_HOLD_TERM",
 		"EVENER_TEST_NPM_PID",
 		"EVENER_TEST_NPM_READY",
 		"EVENER_TEST_NPM_TRACK_COMMAND",
@@ -88,6 +91,16 @@ func TestRuntimeBuildFixtureEnvironmentDropsAmbientHarnessControls(t *testing.T)
 		"EVENER_TEST_SHELL_KILLED_REAPED",
 		"EVENER_TEST_SHELL_WAITED_REAPED",
 		"EVENER_TEST_SHELL_WAIT_RELEASE",
+		"EVENER_TEST_WEB_STARTUP_READY",
+		"EVENER_TEST_WEB_STARTUP_RELEASE",
+		"EVENER_TEST_WEB_STARTUP_PID",
+		"EVENER_TEST_WEB_PRE_WAIT_READY",
+		"EVENER_TEST_WEB_PRE_WAIT_SIGNAL",
+		"EVENER_TEST_WEB_FINISH_READY",
+		"EVENER_TEST_WEB_FINISH_SIGNAL",
+		"EVENER_TEST_WEB_CLEANUP_READY",
+		"EVENER_TEST_WEB_CLEANUP_RELEASE",
+		"EVENER_TEST_WEB_CLEANUP_PID",
 		"EVENER_TEST_NODE_HOLD_COMMAND",
 		"EVENER_TEST_NODE_FAIL_COMMAND",
 		"EVENER_TEST_NODE_PID",
@@ -754,14 +767,18 @@ func TestMakeTestWebInterruptDoesNotSignalReapedCheck(t *testing.T) {
 	waitRelease := filepath.Join(fixture.root, "wait-release")
 	killedReaped := filepath.Join(fixture.root, "killed-reaped")
 	recordingShell := filepath.Join(filepath.Dir(fixture.root), "recording-shell")
+	if err := syscall.Mkfifo(waitRelease, 0o600); err != nil {
+		t.Fatalf("make wait release FIFO: %v", err)
+	}
 	writeTestFile(t, recordingShell, []byte(`wait() {
   command wait "$@"
   wait_status=$?
   tracked_pid=$(cat "$EVENER_TEST_NPM_TRACK_PID")
   if [ "${1:-}" = "$tracked_pid" ] && [ "${reaped_gate:-0}" -eq 0 ]; then
     reaped_gate=1
+	    exec 9<> "$EVENER_TEST_SHELL_WAIT_RELEASE"
     : > "$EVENER_TEST_SHELL_WAITED_REAPED"
-    while [ ! -f "$EVENER_TEST_SHELL_WAIT_RELEASE" ]; do :; done
+	    read -r _ <&9
   fi
   return "$wait_status"
 }
@@ -811,15 +828,164 @@ kill() {
 	if err := waitForPathOrExit(waitedReaped, run, readinessTripwire); err != nil {
 		t.Fatalf("Make did not reap the completed typecheck before waiting on the held check: %v; output = %s", err, output.String())
 	}
+	release, err := os.OpenFile(waitRelease, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open wait release FIFO: %v", err)
+	}
 	if err := exec.Command("kill", "-TERM", strconv.Itoa(command.Process.Pid)).Run(); err != nil {
+		release.Close()
 		t.Fatalf("signal make test-web: %v", err)
 	}
-	writeTestFile(t, waitRelease, nil, 0o644)
+	if _, err := release.WriteString("release\n"); err != nil {
+		release.Close()
+		t.Fatalf("write wait release FIFO: %v", err)
+	}
+	if err := release.Close(); err != nil {
+		t.Fatalf("close wait release FIFO: %v", err)
+	}
 	if err := run.wait(); err == nil {
 		t.Fatalf("interrupted make test-web exited zero; output = %s", output.String())
 	}
 	if _, err := os.Stat(killedReaped); !os.IsNotExist(err) {
 		t.Fatalf("interrupt signaled a PID after its npm check was reaped: stat err = %v; output = %s", err, output.String())
+	}
+}
+
+func TestMakeTestWebInterruptDuringStartupStopsImmediately(t *testing.T) {
+	for _, signal := range []string{"TERM", "INT"} {
+		t.Run(signal, func(t *testing.T) {
+			fixture := newBuildWebFixture(t)
+			frontendDir := filepath.Join(fixture.root, "cmd", "evener-hub", "frontend")
+			writeTestFile(t, filepath.Join(frontendDir, "package-lock.json"), []byte("{}\n"), 0o644)
+			writeTestFile(t, filepath.Join(frontendDir, "package.json"), []byte("{}\n"), 0o644)
+			npmReadyPath := filepath.Join(fixture.root, "held-typecheck.ready")
+			npmPIDPath := filepath.Join(fixture.root, "held-typecheck.pid")
+			npmReleasePath := filepath.Join(fixture.root, "held-typecheck.release")
+			npmTermPath := filepath.Join(fixture.root, "held-typecheck.term")
+			startupReadyPath := filepath.Join(fixture.root, "startup.ready")
+			if err := syscall.Mkfifo(npmReleasePath, 0o600); err != nil {
+				t.Fatalf("make held-child release FIFO: %v", err)
+			}
+
+			command := exec.Command("make", "test-web")
+			command.Dir = fixture.root
+			command.Env = append(fixture.environment(""),
+				"EVENER_TEST_NPM_HOLD_COMMAND=run typecheck",
+				"EVENER_TEST_NPM_READY="+npmReadyPath,
+				"EVENER_TEST_NPM_PID="+npmPIDPath,
+				"EVENER_TEST_NPM_HOLD_RELEASE="+npmReleasePath,
+				"EVENER_TEST_NPM_HOLD_TERM="+npmTermPath,
+				"EVENER_TEST_WEB_PRE_WAIT_READY="+startupReadyPath,
+				"EVENER_TEST_WEB_PRE_WAIT_SIGNAL="+signal,
+			)
+			var output bytes.Buffer
+			command.Stdout = &output
+			command.Stderr = &output
+			if err := command.Start(); err != nil {
+				t.Fatalf("start make test-web: %v", err)
+			}
+			run := startChild(command)
+			if err := waitForPathOrExit(npmReadyPath, run, readinessTripwire); err != nil {
+				t.Fatalf("held first check did not become ready: %v; output = %s", err, output.String())
+			}
+			childRelease, err := os.OpenFile(npmReleasePath, os.O_RDWR, 0)
+			if err != nil {
+				t.Fatalf("open held-child release FIFO: %v", err)
+			}
+			t.Cleanup(func() {
+				_, _ = childRelease.WriteString("cleanup\n")
+				_ = childRelease.Close()
+				if command.ProcessState == nil {
+					_ = command.Process.Kill()
+					<-run.done
+				}
+			})
+			if err := waitForPathOrExit(npmTermPath, run, 2*time.Second); err != nil {
+				t.Fatalf("startup %s did not synchronously terminate held first check: %v; output = %s", signal, err, output.String())
+			}
+			if err := run.wait(); err == nil {
+				t.Fatalf("startup %s exited zero; output = %s", signal, output.String())
+			} else if !strings.Contains(output.String(), "Error "+map[string]string{"TERM": "143", "INT": "130"}[signal]) {
+				t.Fatalf("startup %s did not preserve signal status; output = %s", signal, output.String())
+			}
+		})
+	}
+}
+
+func TestMakeTestWebInterruptDuringExitCleanupPreservesStatus(t *testing.T) {
+	for _, signal := range []string{"TERM", "INT"} {
+		t.Run(signal, func(t *testing.T) {
+			fixture := newBuildWebFixture(t)
+			frontendDir := filepath.Join(fixture.root, "cmd", "evener-hub", "frontend")
+			writeTestFile(t, filepath.Join(frontendDir, "package-lock.json"), []byte("{}\n"), 0o644)
+			writeTestFile(t, filepath.Join(frontendDir, "package.json"), []byte("{}\n"), 0o644)
+			readyPath := filepath.Join(fixture.root, "cleanup.ready")
+			releasePath := filepath.Join(fixture.root, "cleanup.release")
+			pidPath := filepath.Join(fixture.root, "cleanup.pid")
+			bashEnv := filepath.Join(fixture.root, "cleanup-shell")
+			if err := syscall.Mkfifo(releasePath, 0o600); err != nil {
+				t.Fatalf("make cleanup release FIFO: %v", err)
+			}
+			writeTestFile(t, bashEnv, []byte(`rm() {
+	case "$0" in *test-web.sh) ;; *) command rm "$@"; return ;; esac
+	printf '%s\n' "$$" > "$EVENER_TEST_WEB_CLEANUP_PID"
+	: > "$EVENER_TEST_WEB_CLEANUP_READY"
+	exec 9<> "$EVENER_TEST_WEB_CLEANUP_RELEASE"
+	while :; do read -r _ <&9 && break; done
+	command rm "$@"
+}
+`), 0o644)
+
+			command := exec.Command("make", "test-web")
+			command.Dir = fixture.root
+			command.Env = append(fixture.environment(""),
+				"BASH_ENV="+bashEnv,
+				"EVENER_TEST_WEB_CLEANUP_READY="+readyPath,
+				"EVENER_TEST_WEB_CLEANUP_RELEASE="+releasePath,
+				"EVENER_TEST_WEB_CLEANUP_PID="+pidPath,
+			)
+			var output bytes.Buffer
+			command.Stdout = &output
+			command.Stderr = &output
+			if err := command.Start(); err != nil {
+				t.Fatalf("start make test-web: %v", err)
+			}
+			run := startChild(command)
+			if err := waitForPathOrExit(readyPath, run, 2*time.Second); err != nil {
+				t.Fatalf("cleanup %s did not reach the signal point: %v; output = %s", signal, err, output.String())
+			}
+			release, err := os.OpenFile(releasePath, os.O_RDWR, 0)
+			if err != nil {
+				t.Fatalf("open cleanup release FIFO: %v", err)
+			}
+			pidData, err := os.ReadFile(pidPath)
+			if err != nil {
+				release.Close()
+				t.Fatalf("read cleanup shell pid: %v", err)
+			}
+			webPID := strings.TrimSpace(string(pidData))
+			t.Cleanup(func() {
+				_, _ = release.WriteString("cleanup\n")
+				_ = release.Close()
+				if command.ProcessState == nil {
+					_ = command.Process.Kill()
+					<-run.done
+				}
+			})
+			if err := exec.Command("kill", "-"+signal, webPID).Run(); err != nil {
+				t.Fatalf("signal cleanup shell: %v", err)
+			}
+			_, _ = release.WriteString("release\n")
+			_ = release.Close()
+			if err := run.wait(); err == nil {
+				t.Fatalf("cleanup %s exited zero; output = %s", signal, output.String())
+			} else if !strings.Contains(output.String(), "Error "+map[string]string{"TERM": "143", "INT": "130"}[signal]) {
+				t.Fatalf("cleanup %s did not preserve signal status; output = %s", signal, output.String())
+			}
+			if !strings.Contains(output.String(), "full logs: ") {
+				t.Fatalf("cleanup %s did not retain evidence after the signal: output = %s", signal, output.String())
+			}
+		})
 	}
 }
 
@@ -970,7 +1136,17 @@ fi
 [ "${EVENER_TEST_NPM_HOLD_COMMAND:-}" != "$*" ] || {
   printf '%s\n' "$$" > "$EVENER_TEST_NPM_PID"
   : > "$EVENER_TEST_NPM_READY"
-  exec sleep 1000
+  if [ -n "${EVENER_TEST_NPM_HOLD_RELEASE:-}" ]; then
+    on_term() {
+      : > "$EVENER_TEST_NPM_HOLD_TERM"
+      exit 143
+    }
+    trap on_term TERM INT
+    exec 9<> "$EVENER_TEST_NPM_HOLD_RELEASE"
+    while :; do read -r _ <&9 && break; done
+  else
+    exec sleep 1000
+  fi
 }
 [ "${EVENER_TEST_NPM_TRACK_COMMAND:-}" != "$*" ] || printf '%s\n' "$$" > "$EVENER_TEST_NPM_TRACK_PID"
 [ "${EVENER_TEST_NPM_FAIL_COMMAND:-}" = "$*" ] && exit 17
@@ -1230,8 +1406,13 @@ func (fixture runtimeBuildFixture) environment(failPackage string) []string {
 			"GNUMAKEFLAGS", "MAKEFLAGS", "MAKELEVEL", "MFLAGS",
 			"EVENER_TEST_GO_LOG", "EVENER_TEST_GO_FAIL_PACKAGE",
 			"EVENER_TEST_NPM_FAIL_COMMAND", "EVENER_TEST_NPM_HOLD_COMMAND", "EVENER_TEST_NPM_PID", "EVENER_TEST_NPM_READY",
+			"EVENER_TEST_NPM_HOLD_RELEASE", "EVENER_TEST_NPM_HOLD_TERM",
 			"EVENER_TEST_NPM_TRACK_COMMAND", "EVENER_TEST_NPM_TRACK_PID", "EVENER_TEST_SHELL_KILLED_REAPED", "EVENER_TEST_SHELL_WAITED_REAPED",
 			"EVENER_TEST_SHELL_WAIT_RELEASE",
+			"EVENER_TEST_WEB_STARTUP_READY", "EVENER_TEST_WEB_STARTUP_RELEASE", "EVENER_TEST_WEB_STARTUP_PID",
+			"EVENER_TEST_WEB_PRE_WAIT_READY", "EVENER_TEST_WEB_PRE_WAIT_SIGNAL",
+			"EVENER_TEST_WEB_FINISH_READY", "EVENER_TEST_WEB_FINISH_SIGNAL",
+			"EVENER_TEST_WEB_CLEANUP_READY", "EVENER_TEST_WEB_CLEANUP_RELEASE", "EVENER_TEST_WEB_CLEANUP_PID",
 			"EVENER_TEST_NODE_HOLD_COMMAND", "EVENER_TEST_NODE_FAIL_COMMAND", "EVENER_TEST_NODE_PID", "EVENER_TEST_NODE_READY", "EVENER_TEST_NODE_TERM", "EVENER_TEST_NODE_RELEASE", "EVENER_TEST_NODE_READY_FD":
 			continue
 		}

--- a/runtime_pair_build_test.go
+++ b/runtime_pair_build_test.go
@@ -1,6 +1,7 @@
 package evener_test
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -91,16 +92,13 @@ func TestRuntimeBuildFixtureEnvironmentDropsAmbientHarnessControls(t *testing.T)
 		"EVENER_TEST_SHELL_KILLED_REAPED",
 		"EVENER_TEST_SHELL_WAITED_REAPED",
 		"EVENER_TEST_SHELL_WAIT_RELEASE",
-		"EVENER_TEST_WEB_STARTUP_READY",
-		"EVENER_TEST_WEB_STARTUP_RELEASE",
-		"EVENER_TEST_WEB_STARTUP_PID",
-		"EVENER_TEST_WEB_PRE_WAIT_READY",
-		"EVENER_TEST_WEB_PRE_WAIT_SIGNAL",
-		"EVENER_TEST_WEB_FINISH_READY",
-		"EVENER_TEST_WEB_FINISH_SIGNAL",
 		"EVENER_TEST_WEB_CLEANUP_READY",
 		"EVENER_TEST_WEB_CLEANUP_RELEASE",
 		"EVENER_TEST_WEB_CLEANUP_PID",
+		"EVENER_TEST_WEB_WAIT_READY",
+		"EVENER_TEST_WEB_WAIT_RELEASE",
+		"EVENER_TEST_WEB_WAIT_REAPED",
+		"EVENER_TEST_WEB_WAIT_USED",
 		"EVENER_TEST_NODE_HOLD_COMMAND",
 		"EVENER_TEST_NODE_FAIL_COMMAND",
 		"EVENER_TEST_NODE_PID",
@@ -851,64 +849,207 @@ kill() {
 	}
 }
 
-func TestMakeTestWebInterruptDuringStartupStopsImmediately(t *testing.T) {
+func TestMakeTestWebInterruptAtWaitHandoff(t *testing.T) {
 	for _, signal := range []string{"TERM", "INT"} {
 		t.Run(signal, func(t *testing.T) {
-			fixture := newBuildWebFixture(t)
-			frontendDir := filepath.Join(fixture.root, "cmd", "evener-hub", "frontend")
-			writeTestFile(t, filepath.Join(frontendDir, "package-lock.json"), []byte("{}\n"), 0o644)
-			writeTestFile(t, filepath.Join(frontendDir, "package.json"), []byte("{}\n"), 0o644)
-			npmReadyPath := filepath.Join(fixture.root, "held-typecheck.ready")
-			npmPIDPath := filepath.Join(fixture.root, "held-typecheck.pid")
-			npmReleasePath := filepath.Join(fixture.root, "held-typecheck.release")
-			npmTermPath := filepath.Join(fixture.root, "held-typecheck.term")
-			startupReadyPath := filepath.Join(fixture.root, "startup.ready")
-			if err := syscall.Mkfifo(npmReleasePath, 0o600); err != nil {
-				t.Fatalf("make held-child release FIFO: %v", err)
-			}
-
-			command := exec.Command("make", "test-web")
-			command.Dir = fixture.root
-			command.Env = append(fixture.environment(""),
-				"EVENER_TEST_NPM_HOLD_COMMAND=run typecheck",
-				"EVENER_TEST_NPM_READY="+npmReadyPath,
-				"EVENER_TEST_NPM_PID="+npmPIDPath,
-				"EVENER_TEST_NPM_HOLD_RELEASE="+npmReleasePath,
-				"EVENER_TEST_NPM_HOLD_TERM="+npmTermPath,
-				"EVENER_TEST_WEB_PRE_WAIT_READY="+startupReadyPath,
-				"EVENER_TEST_WEB_PRE_WAIT_SIGNAL="+signal,
-			)
-			var output bytes.Buffer
-			command.Stdout = &output
-			command.Stderr = &output
-			if err := command.Start(); err != nil {
-				t.Fatalf("start make test-web: %v", err)
-			}
-			run := startChild(command)
-			if err := waitForPathOrExit(npmReadyPath, run, readinessTripwire); err != nil {
-				t.Fatalf("held first check did not become ready: %v; output = %s", err, output.String())
-			}
-			childRelease, err := os.OpenFile(npmReleasePath, os.O_RDWR, 0)
-			if err != nil {
-				t.Fatalf("open held-child release FIFO: %v", err)
-			}
-			t.Cleanup(func() {
-				_, _ = childRelease.WriteString("cleanup\n")
-				_ = childRelease.Close()
-				if command.ProcessState == nil {
-					_ = command.Process.Kill()
-					<-run.done
-				}
-			})
-			if err := waitForPathOrExit(npmTermPath, run, 2*time.Second); err != nil {
-				t.Fatalf("startup %s did not synchronously terminate held first check: %v; output = %s", signal, err, output.String())
-			}
-			if err := run.wait(); err == nil {
-				t.Fatalf("startup %s exited zero; output = %s", signal, output.String())
-			} else if !strings.Contains(output.String(), "Error "+map[string]string{"TERM": "143", "INT": "130"}[signal]) {
-				t.Fatalf("startup %s did not preserve signal status; output = %s", signal, output.String())
-			}
+			runWebWaitHandoff(t, signal, false)
 		})
+	}
+}
+
+func TestMakeTestWebInterruptAtWaitHandoffRejectsLostSignalMutation(t *testing.T) {
+	for _, signal := range []string{"TERM", "INT"} {
+		t.Run(signal, func(t *testing.T) {
+			runWebWaitHandoff(t, signal, true)
+		})
+	}
+}
+
+// runWebWaitHandoff drives the actual test-web shell at the boundary immediately
+// before its exact owned-child wait. The mutation restores the old
+// defer-signals-before-wait ordering; it must remain blocked after the parent
+// signal until the held child is independently released, proving this test is
+// mechanism RED rather than a missing production hook.
+func runWebWaitHandoff(t *testing.T, signal string, mutate bool) {
+	t.Helper()
+	fixture := newBuildWebFixture(t)
+	frontendDir := filepath.Join(fixture.root, "cmd", "evener-hub", "frontend")
+	writeTestFile(t, filepath.Join(frontendDir, "package-lock.json"), []byte("{}\n"), 0o644)
+	writeTestFile(t, filepath.Join(frontendDir, "package.json"), []byte("{}\n"), 0o644)
+	if mutate {
+		mutateWebWaitDeferral(t, fixture)
+	}
+	npmPIDPath := filepath.Join(fixture.root, "held-typecheck.pid")
+	npmReadyPath := filepath.Join(fixture.root, "held-typecheck.ready")
+	npmReleasePath := filepath.Join(fixture.root, "held-typecheck.release")
+	npmTermPath := filepath.Join(fixture.root, "held-typecheck.term")
+	waitReadyPath := filepath.Join(fixture.root, "wait.ready")
+	waitReleasePath := filepath.Join(fixture.root, "wait.release")
+	waitReapedPath := filepath.Join(fixture.root, "wait.reaped")
+	for _, path := range []string{npmReadyPath, npmReleasePath, waitReadyPath, waitReleasePath} {
+		if err := syscall.Mkfifo(path, 0o600); err != nil {
+			t.Fatalf("make FIFO %s: %v", path, err)
+		}
+	}
+	bashEnv := filepath.Join(fixture.root, "wait-shell")
+	writeTestFile(t, bashEnv, []byte(`wait() {
+  tracked_pid=$(cat "$EVENER_TEST_NPM_PID")
+  if [ "${1:-}" = "$tracked_pid" ] && [ "${EVENER_TEST_WEB_WAIT_USED:-0}" -eq 0 ]; then
+    EVENER_TEST_WEB_WAIT_USED=1
+    printf '%s\n' "$$" > "$EVENER_TEST_WEB_WAIT_READY"
+    exec 9<> "$EVENER_TEST_WEB_WAIT_RELEASE"
+    read -r _ <&9
+  fi
+  command wait "$@"
+  wait_status=$?
+  : > "$EVENER_TEST_WEB_WAIT_REAPED"
+  return "$wait_status"
+}
+`), 0o644)
+
+	childRelease, err := os.OpenFile(npmReleasePath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open held-child release FIFO: %v", err)
+	}
+	npmReady, err := os.OpenFile(npmReadyPath, os.O_RDWR, 0)
+	if err != nil {
+		childRelease.Close()
+		t.Fatalf("open held-child readiness FIFO: %v", err)
+	}
+	waitReady, err := os.OpenFile(waitReadyPath, os.O_RDWR, 0)
+	if err != nil {
+		childRelease.Close()
+		npmReady.Close()
+		t.Fatalf("open wait readiness FIFO: %v", err)
+	}
+	waitRelease, err := os.OpenFile(waitReleasePath, os.O_RDWR, 0)
+	if err != nil {
+		childRelease.Close()
+		npmReady.Close()
+		waitReady.Close()
+		t.Fatalf("open wait release FIFO: %v", err)
+	}
+
+	command := exec.Command("make", "test-web")
+	command.Dir = fixture.root
+	command.Env = append(fixture.environment(""),
+		"BASH_ENV="+bashEnv,
+		"EVENER_TEST_NPM_HOLD_COMMAND=run typecheck",
+		"EVENER_TEST_NPM_PID="+npmPIDPath,
+		"EVENER_TEST_NPM_READY="+npmReadyPath,
+		"EVENER_TEST_NPM_HOLD_RELEASE="+npmReleasePath,
+		"EVENER_TEST_NPM_HOLD_TERM="+npmTermPath,
+		"EVENER_TEST_WEB_WAIT_READY="+waitReadyPath,
+		"EVENER_TEST_WEB_WAIT_RELEASE="+waitReleasePath,
+		"EVENER_TEST_WEB_WAIT_REAPED="+waitReapedPath,
+	)
+	var output bytes.Buffer
+	command.Stdout = &output
+	command.Stderr = &output
+	if err := command.Start(); err != nil {
+		childRelease.Close()
+		npmReady.Close()
+		waitReady.Close()
+		waitRelease.Close()
+		t.Fatalf("start make test-web: %v", err)
+	}
+	run := startChild(command)
+	t.Cleanup(func() {
+		_, _ = childRelease.WriteString("cleanup\n")
+		_ = childRelease.Close()
+		_ = npmReady.Close()
+		_, _ = waitRelease.WriteString("cleanup\n")
+		_ = waitRelease.Close()
+		_ = waitReady.Close()
+		if command.ProcessState == nil {
+			_ = command.Process.Kill()
+			<-run.done
+		}
+	})
+
+	if _, err := readFIFORecord(npmReady, run, readinessTripwire); err != nil {
+		t.Fatalf("held child did not install its signal trap: %v; output = %s", err, output.String())
+	}
+	shellPID, err := readFIFORecord(waitReady, run, readinessTripwire)
+	if err != nil {
+		t.Fatalf("wait seam did not publish readiness: %v; output = %s", err, output.String())
+	}
+	if err := exec.Command("kill", "-"+signal, shellPID).Run(); err != nil {
+		t.Fatalf("signal test-web shell %s: %v", shellPID, err)
+	}
+	if _, err := waitRelease.WriteString("release\n"); err != nil {
+		t.Fatalf("release pre-wait seam: %v", err)
+	}
+
+	if mutate {
+		select {
+		case <-run.done:
+			t.Fatalf("lost-signal mutation exited before held child release; output = %s", output.String())
+		case <-time.After(2 * time.Second):
+		}
+		if _, err := os.Stat(npmTermPath); !os.IsNotExist(err) {
+			t.Fatalf("lost-signal mutation terminated held child; stat err = %v; output = %s", err, output.String())
+		}
+		if _, err := childRelease.WriteString("release\n"); err != nil {
+			t.Fatalf("release mutated held child: %v", err)
+		}
+		if err := waitForChildExit(run, 5*time.Second); err == nil {
+			t.Fatalf("lost-signal mutation eventually exited zero; output = %s", output.String())
+		} else if errors.Is(err, errChildExitTimeout) {
+			t.Fatalf("lost-signal mutation did not exit after held child release: %v; output = %s", err, output.String())
+		}
+		return
+	}
+
+	if err := waitForChildExit(run, 5*time.Second); err == nil {
+		t.Fatalf("external %s did not interrupt test-web; output = %s", signal, output.String())
+	} else if errors.Is(err, errChildExitTimeout) {
+		t.Fatalf("external %s did not interrupt test-web: %v; output = %s", signal, err, output.String())
+	}
+	if want := map[string]string{"TERM": "Error 143", "INT": "Error 130"}[signal]; !strings.Contains(output.String(), want) {
+		t.Fatalf("external %s status was not retained (%q); output = %s", signal, want, output.String())
+	}
+	if _, err := os.Stat(npmTermPath); err != nil {
+		t.Fatalf("held child termination evidence missing: %v; output = %s", err, output.String())
+	}
+	if _, err := os.Stat(waitReapedPath); err != nil {
+		t.Fatalf("exact wait/reap evidence missing: %v; output = %s", err, output.String())
+	}
+	if retained := fullLogsPath(output.Bytes()); retained == "" {
+		t.Fatalf("interrupted test-web did not retain evidence; output = %s", output.String())
+	}
+}
+
+func mutateWebWaitDeferral(t *testing.T, fixture runtimeBuildFixture) {
+	t.Helper()
+	path := filepath.Join(fixture.root, "scripts", "web", "test-web.sh")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read test-web mutation target: %v", err)
+	}
+	old := `	if wait "$pid"; then check_status=0; else check_status=$?; fi
+	# A completed wait removes the job from Bash's job table, which is the
+	# completion/ownership handoff and not a PID liveness guess vulnerable to
+	# reuse. Signals are not deferred here: Bash must wake this exact wait.
+	if ! owned_job_is_running "$pid"; then
+		forget_pid "$pid"
+	fi
+	printf '%s\n' "$check_status" >"$dir/$c.status"
+	consume_interrupt`
+	new := `	defer_signals=1
+	if wait "$pid"; then check_status=0; else check_status=$?; fi
+	if ! owned_job_is_running "$pid"; then
+		forget_pid "$pid"
+	fi
+	printf '%s\n' "$check_status" >"$dir/$c.status"
+	defer_signals=0
+	consume_interrupt`
+	if !bytes.Contains(data, []byte(old)) {
+		t.Fatal("test-web wait mutation target changed; update the mechanism RED test")
+	}
+	data = bytes.Replace(data, []byte(old), []byte(new), 1)
+	if err := os.WriteFile(path, data, 0o755); err != nil {
+		t.Fatalf("write test-web mutation: %v", err)
 	}
 }
 
@@ -951,7 +1092,7 @@ func TestMakeTestWebInterruptDuringExitCleanupPreservesStatus(t *testing.T) {
 				t.Fatalf("start make test-web: %v", err)
 			}
 			run := startChild(command)
-			if err := waitForPathOrExit(readyPath, run, 2*time.Second); err != nil {
+			if err := waitForPathOrExit(readyPath, run, readinessTripwire); err != nil {
 				t.Fatalf("cleanup %s did not reach the signal point: %v; output = %s", signal, err, output.String())
 			}
 			release, err := os.OpenFile(releasePath, os.O_RDWR, 0)
@@ -1134,19 +1275,16 @@ if [ "$1" = "ci" ]; then
   chmod +x node_modules/.bin/tsc
 fi
 [ "${EVENER_TEST_NPM_HOLD_COMMAND:-}" != "$*" ] || {
+  on_term() {
+    : > "$EVENER_TEST_NPM_HOLD_TERM"
+    exit 143
+  }
+  trap on_term TERM INT
   printf '%s\n' "$$" > "$EVENER_TEST_NPM_PID"
-  : > "$EVENER_TEST_NPM_READY"
-  if [ -n "${EVENER_TEST_NPM_HOLD_RELEASE:-}" ]; then
-    on_term() {
-      : > "$EVENER_TEST_NPM_HOLD_TERM"
-      exit 143
-    }
-    trap on_term TERM INT
-    exec 9<> "$EVENER_TEST_NPM_HOLD_RELEASE"
-    while :; do read -r _ <&9 && break; done
-  else
-    exec sleep 1000
-  fi
+  [ -z "${EVENER_TEST_NPM_READY:-}" ] || printf 'ready\n' > "$EVENER_TEST_NPM_READY"
+  [ -n "${EVENER_TEST_NPM_HOLD_RELEASE:-}" ] || exec sleep 1000
+  exec 9<> "$EVENER_TEST_NPM_HOLD_RELEASE"
+  while :; do read -r _ <&9 && break; done
 }
 [ "${EVENER_TEST_NPM_TRACK_COMMAND:-}" != "$*" ] || printf '%s\n' "$$" > "$EVENER_TEST_NPM_TRACK_PID"
 [ "${EVENER_TEST_NPM_FAIL_COMMAND:-}" = "$*" ] && exit 17
@@ -1280,6 +1418,46 @@ func waitForPathOrExit(path string, run *childRun, tripwire time.Duration) error
 	}
 }
 
+// readFIFORecord waits for one line from a shell rendezvous. The deadline is
+// only a hang tripwire; readiness is the FIFO write itself, not a polling loop.
+func readFIFORecord(reader *os.File, run *childRun, tripwire time.Duration) (string, error) {
+	record := make(chan string, 1)
+	readErr := make(chan error, 1)
+	go func() {
+		line, err := bufio.NewReader(reader).ReadString('\n')
+		if err != nil {
+			readErr <- err
+			return
+		}
+		record <- strings.TrimSpace(line)
+	}()
+	timer := time.NewTimer(tripwire)
+	defer timer.Stop()
+	select {
+	case line := <-record:
+		return line, nil
+	case err := <-readErr:
+		return "", err
+	case <-run.done:
+		return "", fmt.Errorf("child exited (%w) before FIFO readiness", run.err)
+	case <-timer.C:
+		return "", fmt.Errorf("FIFO readiness did not arrive within %s", tripwire)
+	}
+}
+
+var errChildExitTimeout = errors.New("child exit tripwire")
+
+func waitForChildExit(run *childRun, tripwire time.Duration) error {
+	timer := time.NewTimer(tripwire)
+	defer timer.Stop()
+	select {
+	case <-run.done:
+		return run.err
+	case <-timer.C:
+		return fmt.Errorf("%w: child did not exit within %s", errChildExitTimeout, tripwire)
+	}
+}
+
 // TestWaitForPathOrExitReportsChildExit pins the mechanism behind two flakes in
 // this file. A fixed five-second waitForPath ignored the child entirely, so a
 // `make` that never got going produced "held npm check did not become ready;
@@ -1409,10 +1587,8 @@ func (fixture runtimeBuildFixture) environment(failPackage string) []string {
 			"EVENER_TEST_NPM_HOLD_RELEASE", "EVENER_TEST_NPM_HOLD_TERM",
 			"EVENER_TEST_NPM_TRACK_COMMAND", "EVENER_TEST_NPM_TRACK_PID", "EVENER_TEST_SHELL_KILLED_REAPED", "EVENER_TEST_SHELL_WAITED_REAPED",
 			"EVENER_TEST_SHELL_WAIT_RELEASE",
-			"EVENER_TEST_WEB_STARTUP_READY", "EVENER_TEST_WEB_STARTUP_RELEASE", "EVENER_TEST_WEB_STARTUP_PID",
-			"EVENER_TEST_WEB_PRE_WAIT_READY", "EVENER_TEST_WEB_PRE_WAIT_SIGNAL",
-			"EVENER_TEST_WEB_FINISH_READY", "EVENER_TEST_WEB_FINISH_SIGNAL",
 			"EVENER_TEST_WEB_CLEANUP_READY", "EVENER_TEST_WEB_CLEANUP_RELEASE", "EVENER_TEST_WEB_CLEANUP_PID",
+			"EVENER_TEST_WEB_WAIT_READY", "EVENER_TEST_WEB_WAIT_RELEASE", "EVENER_TEST_WEB_WAIT_REAPED", "EVENER_TEST_WEB_WAIT_USED",
 			"EVENER_TEST_NODE_HOLD_COMMAND", "EVENER_TEST_NODE_FAIL_COMMAND", "EVENER_TEST_NODE_PID", "EVENER_TEST_NODE_READY", "EVENER_TEST_NODE_TERM", "EVENER_TEST_NODE_RELEASE", "EVENER_TEST_NODE_READY_FD":
 			continue
 		}

--- a/scripts/web/test-web.sh
+++ b/scripts/web/test-web.sh
@@ -18,6 +18,7 @@ cd "$script_dir/../../cmd/evener-hub/frontend" || exit 1
 
 dir=""
 active_pids=(); started=(); fail=0; complete=0; interrupt_status=0
+defer_signals=0; stopping=0; finishing=0
 
 forget_pid() {
 	local pid="$1" candidate
@@ -56,22 +57,49 @@ stop_checks() {
 
 finish() {
 	finish_status=$?
+	finishing=1
 	if [ "$interrupt_status" -ne 0 ]; then
 		finish_status="$interrupt_status"
+		interrupt_status=0
 	fi
 	[ "$complete" -eq 1 ] || stop_checks
 	if [ "$complete" -eq 1 ] && [ "$fail" -eq 0 ] && [ "$finish_status" -eq 0 ]; then
 		scratch_rm || finish_status=1
+		if [ -n "${EVENER_TEST_WEB_FINISH_SIGNAL:-}" ]; then
+			[ -z "${EVENER_TEST_WEB_FINISH_READY:-}" ] || : >"$EVENER_TEST_WEB_FINISH_READY"
+			kill -"$EVENER_TEST_WEB_FINISH_SIGNAL" "$$"
+		fi
 	else
 		[ -z "$dir" ] || printf 'full logs: %s\n' "$dir" >&2
 	fi
+	finishing=0
+	consume_interrupt
 	trap - 0; exit "$finish_status"
 }
 
-interrupted() { interrupt_status="$1"; }
+consume_interrupt() {
+	local status="$interrupt_status"
+	[ "$status" -eq 0 ] || interrupted "$status"
+}
 
-handle_interrupt() {
-	[ "$interrupt_status" -eq 0 ] || { stop_checks; exit "$interrupt_status"; }
+interrupted() {
+	local status="$1"
+	if [ "$defer_signals" -eq 1 ]; then
+		interrupt_status="$status"
+		return
+	fi
+	if [ "$stopping" -eq 1 ]; then
+		return
+	fi
+	stopping=1
+	stop_checks
+	stopping=0
+	if [ "$finishing" -eq 1 ]; then
+		[ -z "$dir" ] || printf 'full logs: %s\n' "$dir" >&2
+		trap - 0
+		exit "$status"
+	fi
+	exit "$status"
 }
 
 # The trap is armed before any scratch exists: a crash between mint and arming
@@ -84,13 +112,22 @@ scratch_dir dir evener-test-web
 for c in typecheck test lint; do
 	check_dir="$dir/$c"
 	if ! mkdir -p "$check_dir/home" "$check_dir/tmp" "$check_dir/xdg-config" "$check_dir/xdg-cache" "$check_dir/xdg-state"; then fail=1; break; fi
+	defer_signals=1
 	HOME="$check_dir/home" TMPDIR="$check_dir/tmp" XDG_CONFIG_HOME="$check_dir/xdg-config" XDG_CACHE_HOME="$check_dir/xdg-cache" XDG_STATE_HOME="$check_dir/xdg-state" NODE_DISABLE_COMPILE_CACHE=1 npm run "$c" >"$dir/$c.log" 2>&1 &
 	active_pids+=("$!"); started+=("$c")
+	defer_signals=0
+	consume_interrupt
 done
+
+if [ -n "${EVENER_TEST_WEB_PRE_WAIT_SIGNAL:-}" ]; then
+	[ -z "${EVENER_TEST_WEB_PRE_WAIT_READY:-}" ] || : >"$EVENER_TEST_WEB_PRE_WAIT_READY"
+	kill -"$EVENER_TEST_WEB_PRE_WAIT_SIGNAL" "$$"
+fi
 
 for i in "${!started[@]}"; do
 	c="${started[$i]}"
 	pid="${active_pids[0]}"
+	defer_signals=1
 	if wait "$pid"; then check_status=0; else check_status=$?; fi
 	# A signal can interrupt wait before its child is reaped. When that
 	# happens, the trap only records the signal and the job remains owned until
@@ -101,7 +138,8 @@ for i in "${!started[@]}"; do
 		forget_pid "$pid"
 	fi
 	printf '%s\n' "$check_status" >"$dir/$c.status"
-	handle_interrupt
+	defer_signals=0
+	consume_interrupt
 done
 
 for c in typecheck test lint; do

--- a/scripts/web/test-web.sh
+++ b/scripts/web/test-web.sh
@@ -17,16 +17,48 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 cd "$script_dir/../../cmd/evener-hub/frontend" || exit 1
 
 dir=""
-pids=""; started=""; fail=0; complete=0
+active_pids=(); started=(); fail=0; complete=0; interrupt_status=0
+
+forget_pid() {
+	local pid="$1" candidate
+	local -a remaining=()
+	for candidate in "${active_pids[@]-}"; do
+		[ -n "$candidate" ] || continue
+		[ "$candidate" = "$pid" ] || remaining+=("$candidate")
+	done
+	active_pids=()
+	for candidate in "${remaining[@]-}"; do
+		[ -n "$candidate" ] && active_pids+=("$candidate")
+	done
+}
+
+owned_job_is_running() {
+	local pid="$1" candidate
+	for candidate in $(jobs -pr); do
+		[ "$candidate" = "$pid" ] && return 0
+	done
+	return 1
+}
 
 stop_checks() {
-	for pid in $pids; do kill -TERM "$pid" 2>/dev/null || :; done
-	for pid in $pids; do wait "$pid" 2>/dev/null || :; done
-	pids=""
+	local pid
+	for pid in "${active_pids[@]-}"; do
+		[ -n "$pid" ] || continue
+		owned_job_is_running "$pid" || continue
+		kill -TERM "$pid" 2>/dev/null || :
+	done
+	for pid in "${active_pids[@]-}"; do
+		[ -n "$pid" ] || continue
+		wait "$pid" 2>/dev/null || :
+	done
+	active_pids=()
 }
 
 finish() {
 	finish_status=$?
+	if [ "$interrupt_status" -ne 0 ]; then
+		finish_status="$interrupt_status"
+	fi
 	[ "$complete" -eq 1 ] || stop_checks
 	if [ "$complete" -eq 1 ] && [ "$fail" -eq 0 ] && [ "$finish_status" -eq 0 ]; then
 		scratch_rm || finish_status=1
@@ -36,7 +68,11 @@ finish() {
 	trap - 0; exit "$finish_status"
 }
 
-interrupted() { stop_checks; exit "$1"; }
+interrupted() { interrupt_status="$1"; }
+
+handle_interrupt() {
+	[ "$interrupt_status" -eq 0 ] || { stop_checks; exit "$interrupt_status"; }
+}
 
 # The trap is armed before any scratch exists: a crash between mint and arming
 # would leak the directory (the trap-before-mkdir ordering the audit enforces).
@@ -49,15 +85,23 @@ for c in typecheck test lint; do
 	check_dir="$dir/$c"
 	if ! mkdir -p "$check_dir/home" "$check_dir/tmp" "$check_dir/xdg-config" "$check_dir/xdg-cache" "$check_dir/xdg-state"; then fail=1; break; fi
 	HOME="$check_dir/home" TMPDIR="$check_dir/tmp" XDG_CONFIG_HOME="$check_dir/xdg-config" XDG_CACHE_HOME="$check_dir/xdg-cache" XDG_STATE_HOME="$check_dir/xdg-state" NODE_DISABLE_COMPILE_CACHE=1 npm run "$c" >"$dir/$c.log" 2>&1 &
-	pids="$pids $!"; started="$started $c"
+	active_pids+=("$!"); started+=("$c")
 done
 
-set -- $pids
-for c in $started; do
-	pid=$1; shift
+for i in "${!started[@]}"; do
+	c="${started[$i]}"
+	pid="${active_pids[0]}"
 	if wait "$pid"; then check_status=0; else check_status=$?; fi
-	pids="$*"
+	# A signal can interrupt wait before its child is reaped. When that
+	# happens, the trap only records the signal and the job remains owned until
+	# stop_checks can terminate and reap it. A completed wait removes the job
+	# from Bash's job table, which is the completion/ownership handoff and not a
+	# PID liveness guess vulnerable to reuse.
+	if [ "$interrupt_status" -eq 0 ] || ! owned_job_is_running "$pid"; then
+		forget_pid "$pid"
+	fi
 	printf '%s\n' "$check_status" >"$dir/$c.status"
+	handle_interrupt
 done
 
 for c in typecheck test lint; do

--- a/scripts/web/test-web.sh
+++ b/scripts/web/test-web.sh
@@ -42,7 +42,9 @@ owned_job_is_running() {
 }
 
 stop_checks() {
-	local pid
+	local pid wait_status previous_stopping
+	previous_stopping=$stopping
+	stopping=1
 	for pid in "${active_pids[@]-}"; do
 		[ -n "$pid" ] || continue
 		owned_job_is_running "$pid" || continue
@@ -50,25 +52,25 @@ stop_checks() {
 	done
 	for pid in "${active_pids[@]-}"; do
 		[ -n "$pid" ] || continue
-		wait "$pid" 2>/dev/null || :
+		while :; do
+			if wait "$pid" 2>/dev/null; then wait_status=0; else wait_status=$?; fi
+			owned_job_is_running "$pid" || break
+		done
 	done
+	stopping=$previous_stopping
 	active_pids=()
 }
 
 finish() {
 	finish_status=$?
 	finishing=1
+	[ "$complete" -eq 1 ] || stop_checks
 	if [ "$interrupt_status" -ne 0 ]; then
 		finish_status="$interrupt_status"
 		interrupt_status=0
 	fi
-	[ "$complete" -eq 1 ] || stop_checks
 	if [ "$complete" -eq 1 ] && [ "$fail" -eq 0 ] && [ "$finish_status" -eq 0 ]; then
 		scratch_rm || finish_status=1
-		if [ -n "${EVENER_TEST_WEB_FINISH_SIGNAL:-}" ]; then
-			[ -z "${EVENER_TEST_WEB_FINISH_READY:-}" ] || : >"$EVENER_TEST_WEB_FINISH_READY"
-			kill -"$EVENER_TEST_WEB_FINISH_SIGNAL" "$$"
-		fi
 	else
 		[ -z "$dir" ] || printf 'full logs: %s\n' "$dir" >&2
 	fi
@@ -84,8 +86,8 @@ consume_interrupt() {
 
 interrupted() {
 	local status="$1"
+	interrupt_status="$status"
 	if [ "$defer_signals" -eq 1 ]; then
-		interrupt_status="$status"
 		return
 	fi
 	if [ "$stopping" -eq 1 ]; then
@@ -94,6 +96,8 @@ interrupted() {
 	stopping=1
 	stop_checks
 	stopping=0
+	status="$interrupt_status"
+	interrupt_status=0
 	if [ "$finishing" -eq 1 ]; then
 		[ -z "$dir" ] || printf 'full logs: %s\n' "$dir" >&2
 		trap - 0
@@ -119,26 +123,17 @@ for c in typecheck test lint; do
 	consume_interrupt
 done
 
-if [ -n "${EVENER_TEST_WEB_PRE_WAIT_SIGNAL:-}" ]; then
-	[ -z "${EVENER_TEST_WEB_PRE_WAIT_READY:-}" ] || : >"$EVENER_TEST_WEB_PRE_WAIT_READY"
-	kill -"$EVENER_TEST_WEB_PRE_WAIT_SIGNAL" "$$"
-fi
-
 for i in "${!started[@]}"; do
 	c="${started[$i]}"
 	pid="${active_pids[0]}"
-	defer_signals=1
 	if wait "$pid"; then check_status=0; else check_status=$?; fi
-	# A signal can interrupt wait before its child is reaped. When that
-	# happens, the trap only records the signal and the job remains owned until
-	# stop_checks can terminate and reap it. A completed wait removes the job
-	# from Bash's job table, which is the completion/ownership handoff and not a
-	# PID liveness guess vulnerable to reuse.
-	if [ "$interrupt_status" -eq 0 ] || ! owned_job_is_running "$pid"; then
+	# A completed wait removes the job from Bash's job table, which is the
+	# completion/ownership handoff and not a PID liveness guess vulnerable to
+	# reuse. Signals are not deferred here: Bash must wake this exact wait.
+	if ! owned_job_is_running "$pid"; then
 		forget_pid "$pid"
 	fi
 	printf '%s\n' "$check_status" >"$dir/$c.status"
-	defer_signals=0
 	consume_interrupt
 done
 


### PR DESCRIPTION
## Summary

Fix the recurring `test-web` interrupt/reap race from PR #453 CI run `32898803620`, attempt 1, job `97967528489`.

## Root cause

The test's real `BASH_ENV` wait seam published `waited-reaped.ready` after the typecheck child had been reaped but before `scripts/web/test-web.sh` removed that PID from its cleanup ownership set. A TERM could arrive in that interval, run the interrupt trap, and signal the stale, already-reaped typecheck PID. The exact interleaving is:

1. `wait typecheck-pid` reaps the child.
2. The recording wait function publishes the completion marker.
3. TERM runs the trap before the script updates its active PID set.
4. Cleanup calls `kill` with the reaped typecheck PID.

## Fix

Track active children explicitly, defer the signal trap until the wait completion/ownership handoff finishes, use Bash's owned-running-job table as the exact completion signal, signal only live owned jobs, and wait/reap the exact remaining ownership set.

## TDD and verification

- Old script mutation: deterministic RED; the focused regression observed `killed-reaped` and failed.
- Corrected `TestMakeTestWebInterruptDoesNotSignalReapedCheck`: GREEN, `-count=20`.
- After rebasing onto exact base `d4646aec9b8eccc2dc146d40191990682224f5e3`: focused test GREEN, `bash -n` GREEN, `git diff --check` GREEN.
- Full root `go test . -count=1`: GREEN.
- Focused interrupt tests with `-race`: GREEN.
- `make test-web`: GREEN (`web-typecheck`, `web-test`, `web-lint`).
- `make test-dev-tooling`, `make lint`, `go vet .`, and `make lint-gofmt`: GREEN.

One concurrent frontend run had all 367 Vitest files pass but two unrelated browser-process tests hit host `spawnSync /bin/ps ENOBUFS`; an isolated rerun passed. This PR does not treat the PR #453 rerun as remediation.

Refs #453
