### PR TITLE
fix: keep WebSocket heartbeat responsive during long requests

### DIFF
--- a/cmd/evener-hub/frontend/src/protocol/client.ts
+++ b/cmd/evener-hub/frontend/src/protocol/client.ts
@@ -93,6 +93,7 @@ interface WireMessage {
 }
 
 interface PendingRequest {
+  method: MethodName;
   resolve: (result: unknown) => void;
   reject: (err: Error) => void;
   timer: ReturnType<typeof setTimeout>;
@@ -228,7 +229,7 @@ export class AppwireClient {
         this.pending.delete(id);
         reject(new RequestTimeoutError(`AppwireClient: "${method}" timed out after ${timeoutMs}ms`));
       }, timeoutMs);
-      this.pending.set(id, { resolve: resolve as (result: unknown) => void, reject, timer });
+      this.pending.set(id, { method, resolve: resolve as (result: unknown) => void, reject, timer });
       try {
         socket.send(JSON.stringify({ id, method, params }));
       } catch (err) {
@@ -462,6 +463,13 @@ export class AppwireClient {
     this.reconnectTimer = null;
   }
 
+  private hasPendingOrdinaryRequest(): boolean {
+    for (const slot of this.pending.values()) {
+      if (slot.method !== "ping") return true;
+    }
+    return false;
+  }
+
   // sendHeartbeat sends one app-level ping with an explicit HEARTBEAT_TIMEOUT_MS
   // deadline (reusing request()'s own timeout machinery rather than a second,
   // separately-tracked timer). An open-but-unresponsive socket never recovers
@@ -470,6 +478,7 @@ export class AppwireClient {
   // remains best-effort cleanup: a half-open transport may never emit onclose.
   private sendHeartbeat(): void {
     if (this.connectionState !== "ready") return;
+    if (this.hasPendingOrdinaryRequest()) return;
     const socket = this.socket;
     if (!socket) return;
     this.request("ping", {}, { timeoutMs: HEARTBEAT_TIMEOUT_MS }).catch(() => {

--- a/cmd/evener-hub/frontend/src/protocol/reconnect.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reconnect.test.ts
@@ -97,6 +97,78 @@ describe("AppwireClient heartbeat", () => {
     client.close();
   });
 
+  test("keeps heartbeat deferred until the last of multiple successful RPCs settles", async () => {
+    const { factory, sockets } = dialer();
+    const client = new AppwireClient({ url: "ws://x/rpc", socketFactory: factory });
+    await connectReady(sockets, client);
+    const socket = socketAt(sockets, 0);
+
+    const first = client.request("thread/list", { limit: 1 });
+    const second = client.request("thread/list", { limit: 2 }, { timeoutMs: HEARTBEAT_INTERVAL_MS + 1 });
+    const requests = sentFrames(socket).filter((frame) => frame.method === "thread/list");
+    if (requests.length !== 2 || typeof requests[0]?.id !== "number" || typeof requests[1]?.id !== "number") {
+      throw new Error("missing concurrent thread/list request ids");
+    }
+
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    expect(sentFrames(socket).filter((frame) => frame.method === "ping")).toHaveLength(0);
+
+    socket.receive({ id: requests[0].id, result: { data: [], nextCursor: "" } });
+    await first;
+    expect(sentFrames(socket).filter((frame) => frame.method === "ping")).toHaveLength(0);
+
+    socket.receive({ id: requests[1].id, result: { data: [], nextCursor: "" } });
+    await second;
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    expect(sentFrames(socket).filter((frame) => frame.method === "ping")).toHaveLength(1);
+    client.close();
+  });
+
+  test("resumes heartbeat after the last concurrent RPC ends with a wire error", async () => {
+    const { factory, sockets } = dialer();
+    const client = new AppwireClient({ url: "ws://x/rpc", socketFactory: factory });
+    await connectReady(sockets, client);
+    const socket = socketAt(sockets, 0);
+
+    const first = client.request("thread/list", { limit: 1 });
+    const second = client.request("thread/list", { limit: 2 });
+    const requests = sentFrames(socket).filter((frame) => frame.method === "thread/list");
+    if (requests.length !== 2 || typeof requests[0]?.id !== "number" || typeof requests[1]?.id !== "number") {
+      throw new Error("missing concurrent thread/list request ids");
+    }
+    socket.receive({ id: requests[0].id, result: { data: [], nextCursor: "" } });
+    await first;
+    socket.receive({ id: requests[1].id, error: { code: 409, message: "request rejected" } });
+    await expect(second).rejects.toThrow("request rejected");
+
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    expect(sentFrames(socket).filter((frame) => frame.method === "ping")).toHaveLength(1);
+    client.close();
+  });
+
+  test("resumes heartbeat after the last concurrent RPC times out", async () => {
+    const { factory, sockets } = dialer();
+    const client = new AppwireClient({ url: "ws://x/rpc", socketFactory: factory });
+    await connectReady(sockets, client);
+    const socket = socketAt(sockets, 0);
+
+    const first = client.request("thread/list", { limit: 1 });
+    const second = client.request("thread/list", { limit: 2 }, { timeoutMs: HEARTBEAT_INTERVAL_MS * 2 });
+    const requests = sentFrames(socket).filter((frame) => frame.method === "thread/list");
+    if (requests.length !== 2 || typeof requests[0]?.id !== "number") throw new Error("missing first request id");
+    socket.receive({ id: requests[0].id, result: { data: [], nextCursor: "" } });
+    await first;
+
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    expect(sentFrames(socket).filter((frame) => frame.method === "ping")).toHaveLength(0);
+    const timedOut = expect(second).rejects.toThrow(/timed out/);
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    await timedOut;
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    expect(sentFrames(socket).filter((frame) => frame.method === "ping")).toHaveLength(1);
+    client.close();
+  });
+
   test("sends a ping every 20s while ready, and again 20s later", async () => {
     const { factory, sockets } = dialer();
     const client = new AppwireClient({ url: "ws://x/rpc", socketFactory: factory });
@@ -130,6 +202,36 @@ describe("AppwireClient heartbeat", () => {
     await vi.advanceTimersByTimeAsync(HEARTBEAT_TIMEOUT_MS);
     expect(client.state).toBe("reconnecting");
     expect(states).toContain("reconnecting");
+  });
+
+  test("after multiple RPCs clear, an unanswered heartbeat detects half-open and reconnects", async () => {
+    const { factory, sockets } = dialer();
+    const client = new AppwireClient({ url: "ws://x/rpc", socketFactory: factory });
+    await connectReady(sockets, client);
+    const socket = socketAt(sockets, 0);
+    const first = client.request("thread/list", { limit: 1 });
+    const second = client.request("thread/list", { limit: 2 });
+    const requests = sentFrames(socket).filter((frame) => frame.method === "thread/list");
+    if (requests.length !== 2 || typeof requests[0]?.id !== "number" || typeof requests[1]?.id !== "number") {
+      throw new Error("missing concurrent thread/list request ids");
+    }
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    expect(sentFrames(socket).filter((frame) => frame.method === "ping")).toHaveLength(0);
+    socket.receive({ id: requests[0].id, result: { data: [], nextCursor: "" } });
+    socket.receive({ id: requests[1].id, result: { data: [], nextCursor: "" } });
+    await Promise.all([first, second]);
+
+    socket.autoInitialize = false;
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    expect(sentFrames(socket).filter((frame) => frame.method === "ping")).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_TIMEOUT_MS);
+    expect(client.state).toBe("reconnecting");
+
+    await vi.advanceTimersByTimeAsync(RECONNECT_BASE_MS);
+    socketAt(sockets, 1).open();
+    await flushUntil(() => client.state === "ready");
+    expect(client.state).toBe("ready");
+    client.close();
   });
 
   test("a heartbeat timeout reconnects when client-side close emits no close event", async () => {
@@ -284,18 +386,21 @@ describe("AppwireClient reconnect", () => {
     expect(notifications).toBe(1);
   });
 
-  test("a pending request at disconnect is rejected exactly once and is not replayed after reconnect", async () => {
+  test("multiple pending requests at disconnect are rejected once and heartbeat resumes after reconnect", async () => {
     const { factory, sockets } = dialer();
     const client = new AppwireClient({ url: "ws://x/rpc", socketFactory: factory });
     await connectReady(sockets, client);
 
-    const reqPromise = client.request("thread/list", { limit: 1 });
-    expect(sentFrames(socketAt(sockets, 0)).filter((f) => f.method === "thread/list")).toHaveLength(1);
+    const first = client.request("thread/list", { limit: 1 });
+    const second = client.request("thread/list", { limit: 2 });
+    expect(sentFrames(socketAt(sockets, 0)).filter((f) => f.method === "thread/list")).toHaveLength(2);
 
     socketAt(sockets, 0).closeFromServer(1006);
 
-    await expect(reqPromise).rejects.toThrow();
-    await expect(reqPromise).rejects.not.toBeInstanceOf(ConnectionClosedError);
+    await expect(first).rejects.toThrow();
+    await expect(first).rejects.not.toBeInstanceOf(ConnectionClosedError);
+    await expect(second).rejects.toThrow();
+    await expect(second).rejects.not.toBeInstanceOf(ConnectionClosedError);
 
     await vi.advanceTimersByTimeAsync(RECONNECT_BASE_MS);
     socketAt(sockets, 1).open();
@@ -304,6 +409,8 @@ describe("AppwireClient reconnect", () => {
     // Only the handshake rides the new socket: a queued turn/start retried
     // blind could double-fire, so the dropped request must never replay.
     expect(sentFrames(socketAt(sockets, 1)).map((f) => f.method)).toEqual(["initialize", "initialized"]);
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+    expect(sentFrames(socketAt(sockets, 1)).filter((f) => f.method === "ping")).toHaveLength(1);
   });
 
   test("requests attempted while reconnecting are rejected synchronously, not queued for replay", async () => {
@@ -507,8 +614,13 @@ describe("AppwireClient close() during heartbeat/reconnect", () => {
     await connectReady(sockets, client);
 
     expect(vi.getTimerCount()).toBeGreaterThan(0); // the heartbeat interval is armed
+    const first = client.request("thread/list", { limit: 1 });
+    const second = client.request("thread/list", { limit: 2 });
 
     client.close();
+
+    await expect(first).rejects.toBeInstanceOf(ConnectionClosedError);
+    await expect(second).rejects.toBeInstanceOf(ConnectionClosedError);
 
     expect(client.state).toBe("closed");
     expect(vi.getTimerCount()).toBe(0);

--- a/cmd/evener-hub/frontend/src/protocol/reconnect.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reconnect.test.ts
@@ -74,6 +74,29 @@ afterEach(() => {
 });
 
 describe("AppwireClient heartbeat", () => {
+  test("defers heartbeat while an ordinary request is pending, then resumes", async () => {
+    const { factory, sockets } = dialer();
+    const client = new AppwireClient({ url: "ws://x/rpc", socketFactory: factory });
+    await connectReady(sockets, client);
+    const socket = socketAt(sockets, 0);
+
+    const pending = client.request("thread/list", { limit: 1 });
+    const request = sentFrames(socket).find((frame) => frame.method === "thread/list");
+    if (typeof request?.id !== "number") throw new Error("missing thread/list request id");
+
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS + HEARTBEAT_TIMEOUT_MS - 1);
+
+    expect(client.state).toBe("ready");
+    expect(sentFrames(socket).filter((frame) => frame.method === "ping")).toHaveLength(0);
+
+    socket.receive({ id: request.id, result: { data: [], nextCursor: "" } });
+    await pending;
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+
+    expect(sentFrames(socket).filter((frame) => frame.method === "ping")).toHaveLength(1);
+    client.close();
+  });
+
   test("sends a ping every 20s while ready, and again 20s later", async () => {
     const { factory, sockets } = dialer();
     const client = new AppwireClient({ url: "ws://x/rpc", socketFactory: factory });

--- a/internal/appserver/appstack_seqfuzz_test.go
+++ b/internal/appserver/appstack_seqfuzz_test.go
@@ -155,18 +155,18 @@ func exerciseReceiveLoops(t rapidTB) {
 	runWebSocketReceiveLoop(context.Background(), closer, &stackTransport{
 		messages: []appwire.Message{appwire.NotificationMessage("ignored", nil)},
 		err:      normal,
-	}, c)
+	}, c, newWebSocketReadGate())
 	if closer.closes != 0 {
 		t.Fatalf("normal receive close count = %d", closer.closes)
 	}
-	runWebSocketReceiveLoop(context.Background(), closer, &stackTransport{err: errors.New("recv")}, c)
+	runWebSocketReceiveLoop(context.Background(), closer, &stackTransport{err: errors.New("recv")}, c, newWebSocketReadGate())
 	if closer.closes != 1 {
 		t.Fatalf("abnormal receive close count = %d", closer.closes)
 	}
 	c.closeSend()
 	runWebSocketReceiveLoop(context.Background(), closer, &stackTransport{
 		messages: []appwire.Message{appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodPing, nil)},
-	}, c)
+	}, c, newWebSocketReadGate())
 }
 
 type stackPinger struct {
@@ -185,17 +185,17 @@ func (p stackPinger) Ping(context.Context) error {
 func exerciseKeepalive(_ rapidTB) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	runWebSocketKeepalive(ctx, stackPinger{called: make(chan struct{}, 1)}, func() {}, time.Hour, time.Hour)
+	runWebSocketKeepalive(ctx, stackPinger{called: make(chan struct{}, 1)}, func() {}, newWebSocketReadGate(), time.Hour, time.Hour)
 
 	failed := make(chan struct{})
-	runWebSocketKeepalive(context.Background(), stackPinger{called: make(chan struct{}, 1), err: errors.New("ping")}, func() { close(failed) }, time.Nanosecond, time.Second)
+	runWebSocketKeepalive(context.Background(), stackPinger{called: make(chan struct{}, 1), err: errors.New("ping")}, func() { close(failed) }, newWebSocketReadGate(), time.Nanosecond, time.Second)
 	<-failed
 
 	ctx, cancel = context.WithCancel(context.Background())
 	called := make(chan struct{}, 1)
 	done := make(chan struct{})
 	go func() {
-		runWebSocketKeepalive(ctx, stackPinger{called: called}, cancel, time.Nanosecond, time.Second)
+		runWebSocketKeepalive(ctx, stackPinger{called: called}, cancel, newWebSocketReadGate(), time.Nanosecond, time.Second)
 		close(done)
 	}()
 	<-called

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -31,6 +31,8 @@ type Server struct {
 	subs                           *Subscriptions
 	keepalivePingInterval          time.Duration
 	keepalivePongTimeout           time.Duration
+	keepaliveTickerFactory         func(time.Duration) webSocketKeepaliveTicker
+	keepaliveDecision              func(bool)
 	projectionMu                   sync.Mutex
 	deliveryMu                     sync.Mutex
 	nextHydrationGeneration        uint64
@@ -44,12 +46,13 @@ type Server struct {
 
 func NewServer(cfg ServerConfig) *Server {
 	s := &Server{
-		cfg:                   cfg,
-		router:                NewRouter(),
-		subs:                  NewSubscriptions(),
-		conns:                 map[string]*Connection{},
-		keepalivePingInterval: keepalivePingInterval,
-		keepalivePongTimeout:  keepalivePongTimeout,
+		cfg:                    cfg,
+		router:                 NewRouter(),
+		subs:                   NewSubscriptions(),
+		conns:                  map[string]*Connection{},
+		keepalivePingInterval:  keepalivePingInterval,
+		keepalivePongTimeout:   keepalivePongTimeout,
+		keepaliveTickerFactory: newRealWebSocketKeepaliveTicker,
 	}
 	HandleTyped(s.router, appwire.MethodInitialize, s.initialize)
 	return s

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"time"
 
 	"primeradiant.com/evener/appwire"
 )
@@ -28,6 +29,8 @@ type Server struct {
 	cfg                            ServerConfig
 	router                         *Router
 	subs                           *Subscriptions
+	keepalivePingInterval          time.Duration
+	keepalivePongTimeout           time.Duration
 	projectionMu                   sync.Mutex
 	deliveryMu                     sync.Mutex
 	nextHydrationGeneration        uint64
@@ -41,10 +44,12 @@ type Server struct {
 
 func NewServer(cfg ServerConfig) *Server {
 	s := &Server{
-		cfg:    cfg,
-		router: NewRouter(),
-		subs:   NewSubscriptions(),
-		conns:  map[string]*Connection{},
+		cfg:                   cfg,
+		router:                NewRouter(),
+		subs:                  NewSubscriptions(),
+		conns:                 map[string]*Connection{},
+		keepalivePingInterval: keepalivePingInterval,
+		keepalivePongTimeout:  keepalivePongTimeout,
 	}
 	HandleTyped(s.router, appwire.MethodInitialize, s.initialize)
 	return s
@@ -429,10 +434,9 @@ func (c *Connection) HandleMessage(ctx context.Context, msg appwire.Message) app
 		return appwire.ErrorMessage(appwire.NewIntID(0), appwire.InvalidRequest("request message required"))
 	}
 	req := *msg.Request
-	// ping is a connection-level keepalive (the browser's app-level heartbeat,
-	// since browsers can't send WS ping frames from JS). Answer it directly,
-	// before the initialize gate and without the router, so it stays cheap and
-	// can't be starved by a busy handler.
+	// ping is the browser's app-level heartbeat (browsers cannot send WS ping
+	// frames from JS). It bypasses the router, but still runs in this serial
+	// receive/dispatch path and can therefore be starved by a busy handler.
 	if req.Method == appwire.MethodPing {
 		return appwire.ResponseMessage(req.ID, struct{}{})
 	}

--- a/internal/appserver/websocket.go
+++ b/internal/appserver/websocket.go
@@ -64,6 +64,10 @@ type realWebSocketKeepaliveTicker struct {
 func (t realWebSocketKeepaliveTicker) Chan() <-chan time.Time { return t.ticker.C }
 func (t realWebSocketKeepaliveTicker) Stop()                  { t.ticker.Stop() }
 
+func newRealWebSocketKeepaliveTicker(interval time.Duration) webSocketKeepaliveTicker {
+	return realWebSocketKeepaliveTicker{ticker: time.NewTicker(interval)}
+}
+
 type webSocketReadGate struct {
 	mu        sync.Mutex
 	available bool
@@ -136,7 +140,7 @@ func (s *Server) ServeWebSocket(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	gate := newWebSocketReadGate()
-	go runWebSocketKeepalive(ctx, ws, cancel, gate, s.keepalivePingInterval, s.keepalivePongTimeout)
+	go runWebSocketKeepaliveWithTicker(ctx, ws, cancel, gate, s.keepalivePongTimeout, s.keepaliveTickerFactory(s.keepalivePingInterval), s.keepaliveDecision)
 
 	runWebSocketReceiveLoop(ctx, ws, transport, conn, gate)
 }

--- a/internal/appserver/websocket.go
+++ b/internal/appserver/websocket.go
@@ -52,6 +52,18 @@ type webSocketPingAttempt struct {
 	deferred bool
 }
 
+type webSocketKeepaliveTicker interface {
+	Chan() <-chan time.Time
+	Stop()
+}
+
+type realWebSocketKeepaliveTicker struct {
+	ticker *time.Ticker
+}
+
+func (t realWebSocketKeepaliveTicker) Chan() <-chan time.Time { return t.ticker.C }
+func (t realWebSocketKeepaliveTicker) Stop()                  { t.ticker.Stop() }
+
 type webSocketReadGate struct {
 	mu        sync.Mutex
 	available bool
@@ -124,7 +136,7 @@ func (s *Server) ServeWebSocket(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	gate := newWebSocketReadGate()
-	go runWebSocketKeepalive(ctx, ws, cancel, gate, keepalivePingInterval, keepalivePongTimeout)
+	go runWebSocketKeepalive(ctx, ws, cancel, gate, s.keepalivePingInterval, s.keepalivePongTimeout)
 
 	runWebSocketReceiveLoop(ctx, ws, transport, conn, gate)
 }
@@ -155,14 +167,20 @@ func runWebSocketReceiveLoop(ctx context.Context, ws webSocketCloser, transport 
 // surfaces to the recv/send loops as context cancellation rather than an
 // indefinite block.
 func runWebSocketKeepalive(ctx context.Context, conn wsPinger, cancel context.CancelFunc, gate *webSocketReadGate, interval, timeout time.Duration) {
-	ticker := time.NewTicker(interval)
+	runWebSocketKeepaliveWithTicker(ctx, conn, cancel, gate, timeout, realWebSocketKeepaliveTicker{ticker: time.NewTicker(interval)}, nil)
+}
+
+func runWebSocketKeepaliveWithTicker(ctx context.Context, conn wsPinger, cancel context.CancelFunc, gate *webSocketReadGate, timeout time.Duration, ticker webSocketKeepaliveTicker, onDecision func(bool)) {
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		case <-ticker.Chan():
 			attemptCtx, attempt, ok := gate.beginPing(ctx)
+			if onDecision != nil {
+				onDecision(ok)
+			}
 			if !ok {
 				continue
 			}

--- a/internal/appserver/websocket.go
+++ b/internal/appserver/websocket.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -46,6 +47,60 @@ type wsPinger interface {
 	Ping(context.Context) error
 }
 
+type webSocketPingAttempt struct {
+	cancel   context.CancelFunc
+	deferred bool
+}
+
+type webSocketReadGate struct {
+	mu        sync.Mutex
+	available bool
+	active    *webSocketPingAttempt
+}
+
+func newWebSocketReadGate() *webSocketReadGate {
+	return &webSocketReadGate{available: true}
+}
+
+func (g *webSocketReadGate) readerAvailable() {
+	g.mu.Lock()
+	g.available = true
+	g.mu.Unlock()
+}
+
+func (g *webSocketReadGate) readerUnavailable() {
+	g.mu.Lock()
+	g.available = false
+	if g.active != nil {
+		g.active.deferred = true
+		g.active.cancel()
+	}
+	g.mu.Unlock()
+}
+
+func (g *webSocketReadGate) beginPing(parent context.Context) (context.Context, *webSocketPingAttempt, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if !g.available {
+		return nil, nil, false
+	}
+	ctx, cancel := context.WithCancel(parent)
+	attempt := &webSocketPingAttempt{cancel: cancel}
+	g.active = attempt
+	return ctx, attempt, true
+}
+
+func (g *webSocketReadGate) finishPing(attempt *webSocketPingAttempt) bool {
+	g.mu.Lock()
+	deferred := attempt.deferred
+	if g.active == attempt {
+		g.active = nil
+	}
+	g.mu.Unlock()
+	attempt.cancel()
+	return deferred
+}
+
 func (s *Server) ServeWebSocket(w http.ResponseWriter, r *http.Request) {
 	ws, err := websocket.Accept(w, r, nil)
 	if err != nil {
@@ -68,14 +123,17 @@ func (s *Server) ServeWebSocket(w http.ResponseWriter, r *http.Request) {
 		runWebSocketSendLoop(ctx, transport, conn.send)
 	}()
 
-	go runWebSocketKeepalive(ctx, ws, cancel, keepalivePingInterval, keepalivePongTimeout)
+	gate := newWebSocketReadGate()
+	go runWebSocketKeepalive(ctx, ws, cancel, gate, keepalivePingInterval, keepalivePongTimeout)
 
-	runWebSocketReceiveLoop(ctx, ws, transport, conn)
+	runWebSocketReceiveLoop(ctx, ws, transport, conn, gate)
 }
 
-func runWebSocketReceiveLoop(ctx context.Context, ws webSocketCloser, transport webSocketTransport, conn *Connection) {
+func runWebSocketReceiveLoop(ctx context.Context, ws webSocketCloser, transport webSocketTransport, conn *Connection, gate *webSocketReadGate) {
 	for {
+		gate.readerAvailable()
 		msg, err := transport.Recv(ctx)
+		gate.readerUnavailable()
 		if err != nil {
 			if websocket.CloseStatus(err) != websocket.StatusNormalClosure {
 				_ = ws.Close(websocket.StatusInternalError, err.Error())
@@ -96,7 +154,7 @@ func runWebSocketReceiveLoop(ctx context.Context, ws webSocketCloser, transport 
 // connection if a ping is not answered within timeout. A dead peer thus
 // surfaces to the recv/send loops as context cancellation rather than an
 // indefinite block.
-func runWebSocketKeepalive(ctx context.Context, conn wsPinger, cancel context.CancelFunc, interval, timeout time.Duration) {
+func runWebSocketKeepalive(ctx context.Context, conn wsPinger, cancel context.CancelFunc, gate *webSocketReadGate, interval, timeout time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
@@ -104,10 +162,15 @@ func runWebSocketKeepalive(ctx context.Context, conn wsPinger, cancel context.Ca
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			pingCtx, pingCancel := context.WithTimeout(ctx, timeout)
+			attemptCtx, attempt, ok := gate.beginPing(ctx)
+			if !ok {
+				continue
+			}
+			pingCtx, pingCancel := context.WithTimeout(attemptCtx, timeout)
 			err := conn.Ping(pingCtx)
 			pingCancel()
-			if err != nil {
+			deferred := gate.finishPing(attempt)
+			if err != nil && !deferred {
 				cancel()
 				return
 			}

--- a/internal/appserver/websocket_keepalive_test.go
+++ b/internal/appserver/websocket_keepalive_test.go
@@ -11,12 +11,34 @@ import (
 type scriptedPinger struct {
 	calls    atomic.Int64
 	failFrom int64 // ping number (1-based) at and after which Ping returns an error
+	started  chan int64
 }
 
 func (p *scriptedPinger) Ping(ctx context.Context) error {
 	n := p.calls.Add(1)
+	if p.started != nil {
+		select {
+		case p.started <- n:
+		default:
+		}
+	}
 	if p.failFrom > 0 && n >= p.failFrom {
 		return errors.New("ping failed")
+	}
+	return nil
+}
+
+type deferrablePinger struct {
+	calls   atomic.Int64
+	started chan int64
+}
+
+func (p *deferrablePinger) Ping(ctx context.Context) error {
+	n := p.calls.Add(1)
+	p.started <- n
+	if n == 1 {
+		<-ctx.Done()
+		return ctx.Err()
 	}
 	return nil
 }
@@ -26,7 +48,7 @@ func TestWebSocketKeepaliveCancelsConnectionWhenPingFails(t *testing.T) {
 	canceled := make(chan struct{})
 	pinger := &scriptedPinger{failFrom: 1}
 
-	go runWebSocketKeepalive(ctx, pinger, func() { close(canceled) }, time.Millisecond, 50*time.Millisecond)
+	go runWebSocketKeepalive(ctx, pinger, func() { close(canceled) }, newWebSocketReadGate(), time.Millisecond, 50*time.Millisecond)
 
 	select {
 	case <-canceled:
@@ -40,7 +62,7 @@ func TestWebSocketKeepaliveSurvivesHealthyPings(t *testing.T) {
 	canceled := make(chan struct{})
 	pinger := &scriptedPinger{failFrom: 0} // never fails
 
-	go runWebSocketKeepalive(ctx, pinger, func() { close(canceled) }, time.Millisecond, 50*time.Millisecond)
+	go runWebSocketKeepalive(ctx, pinger, func() { close(canceled) }, newWebSocketReadGate(), time.Millisecond, 50*time.Millisecond)
 
 	select {
 	case <-canceled:
@@ -59,7 +81,7 @@ func TestWebSocketKeepaliveStopsOnContextCancel(t *testing.T) {
 
 	go func() {
 		defer close(done)
-		runWebSocketKeepalive(ctx, pinger, func() {}, time.Millisecond, 50*time.Millisecond)
+		runWebSocketKeepalive(ctx, pinger, func() {}, newWebSocketReadGate(), time.Millisecond, 50*time.Millisecond)
 	}()
 
 	cancel()
@@ -67,5 +89,72 @@ func TestWebSocketKeepaliveStopsOnContextCancel(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("keepalive did not return after context cancellation")
+	}
+}
+
+func TestWebSocketKeepaliveDefersActivePingWhileReaderIsUnavailable(t *testing.T) {
+	ctx, stop := context.WithCancel(t.Context())
+	defer stop()
+	gate := newWebSocketReadGate()
+	pinger := &deferrablePinger{started: make(chan int64, 2)}
+	canceled := make(chan struct{}, 1)
+
+	go runWebSocketKeepalive(ctx, pinger, func() { canceled <- struct{}{} }, gate, time.Millisecond, time.Second)
+	select {
+	case got := <-pinger.started:
+		if got != 1 {
+			t.Fatalf("first ping = %d, want 1", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first ping did not start")
+	}
+
+	gate.readerUnavailable()
+	select {
+	case <-canceled:
+		t.Fatal("deferred ping canceled the connection")
+	default:
+	}
+
+	gate.readerAvailable()
+	select {
+	case got := <-pinger.started:
+		if got != 2 {
+			t.Fatalf("second ping = %d, want 2", got)
+		}
+		stop()
+	case <-time.After(time.Second):
+		t.Fatal("second ping did not start")
+	}
+	select {
+	case <-canceled:
+		t.Fatal("deferred ping canceled the connection")
+	default:
+	}
+}
+
+func TestWebSocketKeepaliveSkipsPingsWhileReaderIsUnavailable(t *testing.T) {
+	ctx, stop := context.WithCancel(t.Context())
+	defer stop()
+	gate := newWebSocketReadGate()
+	gate.readerUnavailable()
+	pinger := &scriptedPinger{started: make(chan int64, 1)}
+
+	go runWebSocketKeepalive(ctx, pinger, func() {}, gate, time.Millisecond, time.Second)
+	select {
+	case got := <-pinger.started:
+		t.Fatalf("ping %d started while reader was unavailable", got)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	gate.readerAvailable()
+	select {
+	case got := <-pinger.started:
+		if got != 1 {
+			t.Fatalf("resumed ping = %d, want 1", got)
+		}
+		stop()
+	case <-time.After(time.Second):
+		t.Fatal("ping did not resume after reader became available")
 	}
 }

--- a/internal/appserver/websocket_keepalive_test.go
+++ b/internal/appserver/websocket_keepalive_test.go
@@ -8,6 +8,33 @@ import (
 	"time"
 )
 
+type controlledKeepaliveTicker struct {
+	c       chan time.Time
+	stopped chan struct{}
+}
+
+func newControlledKeepaliveTicker() *controlledKeepaliveTicker {
+	return &controlledKeepaliveTicker{c: make(chan time.Time), stopped: make(chan struct{})}
+}
+
+func (t *controlledKeepaliveTicker) Chan() <-chan time.Time { return t.c }
+
+func (t *controlledKeepaliveTicker) Stop() {
+	select {
+	case <-t.stopped:
+	default:
+		close(t.stopped)
+	}
+}
+
+func (t *controlledKeepaliveTicker) Tick() {
+	select {
+	case t.c <- time.Time{}:
+	case <-t.stopped:
+		panic("controlled keepalive ticker stopped")
+	}
+}
+
 type scriptedPinger struct {
 	calls    atomic.Int64
 	failFrom int64 // ping number (1-based) at and after which Ping returns an error
@@ -139,22 +166,53 @@ func TestWebSocketKeepaliveSkipsPingsWhileReaderIsUnavailable(t *testing.T) {
 	gate := newWebSocketReadGate()
 	gate.readerUnavailable()
 	pinger := &scriptedPinger{started: make(chan int64, 1)}
+	ticker := newControlledKeepaliveTicker()
+	decision := make(chan bool, 2)
+	done := make(chan struct{})
 
-	go runWebSocketKeepalive(ctx, pinger, func() {}, gate, time.Millisecond, time.Second)
+	go func() {
+		defer close(done)
+		runWebSocketKeepaliveWithTicker(ctx, pinger, func() {}, gate, time.Second, ticker, func(ok bool) {
+			decision <- ok
+		})
+	}()
+	ticker.Tick()
+	select {
+	case got := <-decision:
+		if got {
+			t.Fatal("keepalive attempted a ping while reader was unavailable")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("keepalive did not observe the controlled tick")
+	}
 	select {
 	case got := <-pinger.started:
 		t.Fatalf("ping %d started while reader was unavailable", got)
-	case <-time.After(20 * time.Millisecond):
+	default:
 	}
 
 	gate.readerAvailable()
+	ticker.Tick()
 	select {
-	case got := <-pinger.started:
-		if got != 1 {
-			t.Fatalf("resumed ping = %d, want 1", got)
+	case got := <-decision:
+		if !got {
+			t.Fatal("keepalive did not observe reader availability")
 		}
-		stop()
+		select {
+		case ping := <-pinger.started:
+			if ping != 1 {
+				t.Fatalf("resumed ping = %d, want 1", ping)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("ping did not resume after reader became available")
+		}
 	case <-time.After(time.Second):
-		t.Fatal("ping did not resume after reader became available")
+		t.Fatal("keepalive did not observe reader availability")
+	}
+	stop()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("keepalive did not stop after cleanup")
 	}
 }

--- a/internal/appserver/websocket_test.go
+++ b/internal/appserver/websocket_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -47,17 +48,20 @@ func TestServeWebSocketHandlesAppWire(t *testing.T) {
 
 func TestServeWebSocketKeepsBusyRPCAliveAndDetectsIdlePeerLoss(t *testing.T) {
 	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
-	server.keepalivePingInterval = time.Millisecond
 	server.keepalivePongTimeout = 5 * time.Millisecond
+	ticker := newControlledKeepaliveTicker()
+	decision := make(chan bool, 2)
+	server.keepaliveTickerFactory = func(time.Duration) webSocketKeepaliveTicker { return ticker }
+	server.keepaliveDecision = func(ok bool) { decision <- ok }
 
 	handlerStarted := make(chan struct{})
 	releaseHandler := make(chan struct{})
-	var handlerBusy atomic.Bool
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseHandler) }) }
+	defer release()
 	HandleTyped(server.Router(), appwire.MethodThreadList, func(ctx context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
-		handlerBusy.Store(true)
 		close(handlerStarted)
 		<-releaseHandler
-		handlerBusy.Store(false)
 		return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_held"}}}, nil
 	})
 	httpServer := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
@@ -65,18 +69,13 @@ func TestServeWebSocketKeepsBusyRPCAliveAndDetectsIdlePeerLoss(t *testing.T) {
 
 	var answerPings atomic.Bool
 	answerPings.Store(true)
-	busyPingSeen := make(chan struct{}, 1)
 	idlePingSeen := make(chan struct{}, 1)
 	ctx := context.Background()
 	wsConn, _, err := websocket.Dial(ctx, "ws"+httpServer.URL[len("http"):], &websocket.DialOptions{
 		HTTPClient: httpServer.Client(),
 		OnPingReceived: func(context.Context, []byte) bool {
-			seen := idlePingSeen
-			if handlerBusy.Load() {
-				seen = busyPingSeen
-			}
 			select {
-			case seen <- struct{}{}:
+			case idlePingSeen <- struct{}{}:
 			default:
 			}
 			return answerPings.Load()
@@ -105,17 +104,18 @@ func TestServeWebSocketKeepsBusyRPCAliveAndDetectsIdlePeerLoss(t *testing.T) {
 		t.Fatal("ordinary RPC handler did not become ready")
 	}
 
-	// Keep the serial HandleMessage call held longer than the server's native
-	// ping interval plus pong deadline. The timer controls the requested hold
-	// duration; the assertions below use the RPC result and control-frame event,
-	// not elapsed time, as the behavior oracle.
-	hold := time.NewTimer(server.keepalivePingInterval + server.keepalivePongTimeout + server.keepalivePingInterval)
+	// Drive the actual ServeWebSocket keepalive goroutine while HandleMessage is
+	// held in the serial reader/dispatch path. The decision is emitted only
+	// after the gate has observed the busy reader, so release is not time-based.
+	ticker.Tick()
 	select {
-	case <-hold.C:
-		close(releaseHandler)
+	case attempted := <-decision:
+		if attempted {
+			t.Fatal("keepalive attempted a ping while the serial RPC handler was busy")
+		}
+		release()
 	case <-time.After(time.Second):
-		hold.Stop()
-		t.Fatal("held RPC did not reach its release point")
+		t.Fatal("keepalive did not report the busy-reader decision")
 	}
 
 	select {
@@ -126,16 +126,19 @@ func TestServeWebSocketKeepsBusyRPCAliveAndDetectsIdlePeerLoss(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("held RPC did not complete after exact release")
 	}
-	select {
-	case <-busyPingSeen:
-		t.Fatal("server pinged while the serial RPC handler was busy")
-	default:
-	}
-
 	// Once ordinary work is gone, an unanswered native ping must still retire
 	// the connection. The client remains a real coder/websocket peer, but stops
 	// answering control pings to model a silent half-open transport.
 	answerPings.Store(false)
+	ticker.Tick()
+	select {
+	case attempted := <-decision:
+		if !attempted {
+			t.Fatal("keepalive did not observe the available reader")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("keepalive did not report the idle-reader decision")
+	}
 	select {
 	case <-idlePingSeen:
 	case <-time.After(time.Second):

--- a/internal/appserver/websocket_test.go
+++ b/internal/appserver/websocket_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/coder/websocket"
 	"primeradiant.com/evener/appwire"
 )
 
@@ -40,6 +42,112 @@ func TestServeWebSocketHandlesAppWire(t *testing.T) {
 	}
 	if len(resp.Data) != 1 || resp.Data[0].ID != "th_1" {
 		t.Fatalf("resp=%+v", resp)
+	}
+}
+
+func TestServeWebSocketKeepsBusyRPCAliveAndDetectsIdlePeerLoss(t *testing.T) {
+	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
+	server.keepalivePingInterval = time.Millisecond
+	server.keepalivePongTimeout = 5 * time.Millisecond
+
+	handlerStarted := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	var handlerBusy atomic.Bool
+	HandleTyped(server.Router(), appwire.MethodThreadList, func(ctx context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+		handlerBusy.Store(true)
+		close(handlerStarted)
+		<-releaseHandler
+		handlerBusy.Store(false)
+		return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_held"}}}, nil
+	})
+	httpServer := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
+	defer httpServer.Close()
+
+	var answerPings atomic.Bool
+	answerPings.Store(true)
+	busyPingSeen := make(chan struct{}, 1)
+	idlePingSeen := make(chan struct{}, 1)
+	ctx := context.Background()
+	wsConn, _, err := websocket.Dial(ctx, "ws"+httpServer.URL[len("http"):], &websocket.DialOptions{
+		HTTPClient: httpServer.Client(),
+		OnPingReceived: func(context.Context, []byte) bool {
+			seen := idlePingSeen
+			if handlerBusy.Load() {
+				seen = busyPingSeen
+			}
+			select {
+			case seen <- struct{}{}:
+			default:
+			}
+			return answerPings.Load()
+		},
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	transport := appwire.NewWSTransport(wsConn)
+	client := appwire.NewClient(transport)
+	client.Start(ctx)
+	defer transport.Close() //nolint:errcheck // test cleanup
+
+	if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := client.ThreadList(ctx, appwire.ThreadListParams{})
+		result <- err
+	}()
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("ordinary RPC handler did not become ready")
+	}
+
+	// Keep the serial HandleMessage call held longer than the server's native
+	// ping interval plus pong deadline. The timer controls the requested hold
+	// duration; the assertions below use the RPC result and control-frame event,
+	// not elapsed time, as the behavior oracle.
+	hold := time.NewTimer(server.keepalivePingInterval + server.keepalivePongTimeout + server.keepalivePingInterval)
+	select {
+	case <-hold.C:
+		close(releaseHandler)
+	case <-time.After(time.Second):
+		hold.Stop()
+		t.Fatal("held RPC did not reach its release point")
+	}
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("held RPC failed after exact release: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("held RPC did not complete after exact release")
+	}
+	select {
+	case <-busyPingSeen:
+		t.Fatal("server pinged while the serial RPC handler was busy")
+	default:
+	}
+
+	// Once ordinary work is gone, an unanswered native ping must still retire
+	// the connection. The client remains a real coder/websocket peer, but stops
+	// answering control pings to model a silent half-open transport.
+	answerPings.Store(false)
+	select {
+	case <-idlePingSeen:
+	case <-time.After(time.Second):
+		t.Fatal("idle keepalive never attempted a native ping")
+	}
+	select {
+	case _, ok := <-client.Notifications():
+		for ok {
+			_, ok = <-client.Notifications()
+		}
+	case <-time.After(time.Second):
+		t.Fatal("idle ping failure did not close the websocket client")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Defer the browser app heartbeat while ordinary RPCs are pending, avoiding a heartbeat request that cannot be answered behind a long-running request.
- Skip/defer server-native pings while the single serial reader/handler is busy. This preserves the one-reader/one-writer design and retains native idle-ping reconnect behavior.
- Add deterministic root-cause evidence with a real-WebSocket starvation test that reproduces the long-request heartbeat failure.

## Verification

All focused, race, and full gates exited zero:

- `npx biome check --write cmd/evener-hub/frontend/src/protocol/client.ts cmd/evener-hub/frontend/src/protocol/reconnect.test.ts` (no tracked diff)
- `make test-web`
- `go test -race ./internal/appserver -count=1`
- `make lint`
- `make vet`
- `make test`

## Scope

Related #338 and follow-ups #448, #449, #450, and #451 remain open; this PR does not close them. Combined Rail, performance, and UI follow-ups are intentionally excluded from this PR.
