### PR TITLE
fix(agent): make ask_user headers forgiving

### DIFF
--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -833,7 +833,7 @@ func DefAskUser() llm.ToolDefinition {
 	return llm.ToolDefinition{
 		Name: "ask_user",
 		Description: "Ask the user structured questions. Asking yields the floor: when the round containing your `ask_user` call(s) completes, your turn ends and the session waits visibly for the reply (no timeout). Do the work that does not need answers first, then batch every question this decision point needs — several `ask_user` calls may share the round, and a `communicate` in the same round still delivers its message. The answers arrive in the user's next message: either the numbered `[answers]` form (one resolution per question: a selection, free text, \"you decide\" — choose with your judgment, honoring any stated leaning —, your stated fallback, or skipped — proceed on your best judgment, state the assumption, and do not immediately re-ask) or free prose; treat either as the reply to everything you asked. Any answer may carry a user note — read it; it can qualify or override the selection.\n\n" +
-			"- `questions`: 1–4 per call, each with an optional short `header` (omitted headers display as `Question N`), the full `question`, and 2–5 `options` (`{label, detail}`, labels unique). Set `multi_select` to allow several; set `recommended: true` on at most one option and put it first. For a single question, `question` + `options` may be given directly instead of the `questions` array.\n" +
+			"- `questions`: 1–4 per call, each with an optional display `header` (omitted headers display as `Question N`), the full `question`, and 2–5 `options` (`{label, detail}`, labels unique). Set `multi_select` to allow several; set `recommended: true` on at most one option and put it first. For a single question, `question` + `options` may be given directly instead of the `questions` array.\n" +
 			"- Do not add an \"Other\" or free-text option; the UI always offers one, plus \"you decide\".\n" +
 			"- Optional per question: `why` (one line: what the answer changes) and `if_unanswered` (the fallback you would take; the user can accept it with one tap).\n\n" +
 			"First try to resolve the question yourself with tools. Asking is how you end your turn when only the user can unblock the rest — finish the answer-independent work before you ask.",
@@ -850,7 +850,7 @@ func DefAskUser() llm.ToolDefinition {
 					"items": map[string]any{
 						"type": "object",
 						"properties": map[string]any{
-							"header":   map[string]any{"type": "string", "description": "Short chip/tab label."},
+							"header":   map[string]any{"type": "string", "description": "Display label; answer framing encodes delimiter characters when needed."},
 							"question": map[string]any{"type": "string", "description": "The full question text."},
 							"options": map[string]any{
 								"type":        "array",

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -833,7 +833,7 @@ func DefAskUser() llm.ToolDefinition {
 	return llm.ToolDefinition{
 		Name: "ask_user",
 		Description: "Ask the user structured questions. Asking yields the floor: when the round containing your `ask_user` call(s) completes, your turn ends and the session waits visibly for the reply (no timeout). Do the work that does not need answers first, then batch every question this decision point needs — several `ask_user` calls may share the round, and a `communicate` in the same round still delivers its message. The answers arrive in the user's next message: either the numbered `[answers]` form (one resolution per question: a selection, free text, \"you decide\" — choose with your judgment, honoring any stated leaning —, your stated fallback, or skipped — proceed on your best judgment, state the assumption, and do not immediately re-ask) or free prose; treat either as the reply to everything you asked. Any answer may carry a user note — read it; it can qualify or override the selection.\n\n" +
-			"- `questions`: 1–4 per call, each with an optional short `header` (≤12 chars; omitted headers display as `Question N`), the full `question`, and 2–5 `options` (`{label, detail}`, labels unique). Set `multi_select` to allow several; set `recommended: true` on at most one option and put it first. For a single question, `question` + `options` may be given directly instead of the `questions` array.\n" +
+			"- `questions`: 1–4 per call, each with an optional short `header` (omitted headers display as `Question N`), the full `question`, and 2–5 `options` (`{label, detail}`, labels unique). Set `multi_select` to allow several; set `recommended: true` on at most one option and put it first. For a single question, `question` + `options` may be given directly instead of the `questions` array.\n" +
 			"- Do not add an \"Other\" or free-text option; the UI always offers one, plus \"you decide\".\n" +
 			"- Optional per question: `why` (one line: what the answer changes) and `if_unanswered` (the fallback you would take; the user can accept it with one tap).\n\n" +
 			"First try to resolve the question yourself with tools. Asking is how you end your turn when only the user can unblock the rest — finish the answer-independent work before you ask.",
@@ -850,7 +850,7 @@ func DefAskUser() llm.ToolDefinition {
 					"items": map[string]any{
 						"type": "object",
 						"properties": map[string]any{
-							"header":   map[string]any{"type": "string", "maxLength": 12, "description": "Short chip/tab label."},
+							"header":   map[string]any{"type": "string", "description": "Short chip/tab label."},
 							"question": map[string]any{"type": "string", "description": "The full question text."},
 							"options": map[string]any{
 								"type":        "array",

--- a/agent/internal/tool/definitions_test.go
+++ b/agent/internal/tool/definitions_test.go
@@ -690,8 +690,8 @@ func TestDefManageWorktreeDescriptionCarriesUsagePolicy(t *testing.T) {
 }
 
 // TestDefAskUserSchema locks the ask_user input schema to spec §4.2: questions
-// 1-4 per call, each with optional header (<=12 chars)/question/options (2-5 of
-// {label, detail, recommended?}), multi_select, why, and if_unanswered.
+// 1-4 per call, each with optional header/question/options (2-5 of {label,
+// detail, recommended?}), multi_select, why, and if_unanswered.
 func TestDefAskUserSchema(t *testing.T) {
 	def := DefAskUser()
 	if def.Name != "ask_user" {
@@ -717,8 +717,11 @@ func TestDefAskUserSchema(t *testing.T) {
 			t.Fatalf("missing question property %q", k)
 		}
 	}
-	if props["header"].(map[string]any)["maxLength"] != 12 {
-		t.Fatal("header maxLength != 12")
+	if props["header"].(map[string]any)["type"] != "string" {
+		t.Fatal("header is not a string")
+	}
+	if _, ok := props["header"].(map[string]any)["maxLength"]; ok {
+		t.Fatal("header must not have a hard maxLength")
 	}
 	opts := props["options"].(map[string]any)
 	if opts["minItems"] != 2 || opts["maxItems"] != 5 {

--- a/agent/internal/tool/repair/explain_covtest_test.go
+++ b/agent/internal/tool/repair/explain_covtest_test.go
@@ -548,7 +548,7 @@ func TestExplainSchemaError_NoInstanceLocation(t *testing.T) {
 // TestExplainSchemaError_PresentFieldWithContainerPath covers the
 // present-field path with containerPath != "" (line 66-68).
 func TestExplainSchemaError_PresentFieldWithContainerPath(t *testing.T) {
-	params := askUserParamsForExplain()
+	params := askUserParamsWithHeaderMaxLengthForExplain()
 	args := map[string]any{
 		"questions": []any{map[string]any{
 			"header":   strings.Repeat("x", 20),

--- a/agent/internal/tool/repair/explain_test.go
+++ b/agent/internal/tool/repair/explain_test.go
@@ -161,7 +161,9 @@ func taskListParamsForExplain() map[string]any {
 	}
 }
 
-// askUserParamsForExplain mirrors DefAskUser's questions-item schema.
+// askUserParamsForExplain mirrors DefAskUser's questions-item schema. It stays
+// free of presentation-only limits so the fixture catches drift in the real
+// tool definition rather than preserving an obsolete header constraint.
 func askUserParamsForExplain() map[string]any {
 	return map[string]any{
 		"type":                 "object",
@@ -174,7 +176,7 @@ func askUserParamsForExplain() map[string]any {
 				"items": map[string]any{
 					"type": "object",
 					"properties": map[string]any{
-						"header":   map[string]any{"type": "string", "maxLength": 12},
+						"header":   map[string]any{"type": "string"},
 						"question": map[string]any{"type": "string"},
 						"options": map[string]any{
 							"type":     "array",
@@ -189,6 +191,16 @@ func askUserParamsForExplain() map[string]any {
 		},
 		"required": []string{"questions"},
 	}
+}
+
+// askUserParamsWithHeaderMaxLengthForExplain is a deliberately constrained
+// variant used only to exercise ExplainSchemaError's generic maxLength
+// formatter. The real ask_user schema intentionally does not impose this cap.
+func askUserParamsWithHeaderMaxLengthForExplain() map[string]any {
+	params := askUserParamsForExplain()
+	item := params["properties"].(map[string]any)["questions"].(map[string]any)["items"].(map[string]any)
+	item["properties"].(map[string]any)["header"] = map[string]any{"type": "string", "maxLength": 12}
+	return params
 }
 
 func TestExplainSchemaError_ArrayItemMissingRequiredField(t *testing.T) {
@@ -207,7 +219,7 @@ func TestExplainSchemaError_ArrayItemMissingRequiredField(t *testing.T) {
 }
 
 func TestExplainSchemaError_NestedPropertyWrongTypeOrValue(t *testing.T) {
-	params := askUserParamsForExplain()
+	params := askUserParamsWithHeaderMaxLengthForExplain()
 	args := map[string]any{
 		"questions": []any{map[string]any{
 			"header":   strings.Repeat("x", 20),
@@ -244,7 +256,7 @@ func TestExplainSchemaError_ConstraintClasses(t *testing.T) {
 		{
 			name:     "maxLength",
 			toolName: "ask_user",
-			params:   askUserParamsForExplain(),
+			params:   askUserParamsWithHeaderMaxLengthForExplain(),
 			args: map[string]any{"questions": []any{map[string]any{
 				"header": strings.Repeat("x", 20), "question": "q", "options": []any{},
 			}}},

--- a/agent/session_ask_test.go
+++ b/agent/session_ask_test.go
@@ -306,6 +306,24 @@ func TestAskUser_ValidCallPostsAckAndPending(t *testing.T) {
 	}
 }
 
+func TestAskUser_LongHeaderIsAcceptedAndPreserved(t *testing.T) {
+	t.Parallel()
+	sess := newAskTestSession(t, SessionConfig{})
+	args := askUserArgsValid()
+	const wantHeader = "Progress flavor"
+	args["questions"].([]any)[0].(map[string]any)["header"] = wantHeader
+
+	res := sess.reg.ExecuteCall(context.Background(), sess.env, askUserCall("c1", args))
+	if res.IsError {
+		t.Fatalf("ask_user with long header errored: %s", res.Output)
+	}
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	if got := sess.askPending[0].Header; got != wantHeader {
+		t.Fatalf("pending header = %q, want %q", got, wantHeader)
+	}
+}
+
 func TestAskUser_OmittedHeaderUsesEmptyInternalHeader(t *testing.T) {
 	t.Parallel()
 	sess := newAskTestSession(t, SessionConfig{})

--- a/agent/session_ask_test.go
+++ b/agent/session_ask_test.go
@@ -2143,6 +2143,19 @@ func TestAskUser_ShorthandDecodesToBatchEquivalent(t *testing.T) {
 	}
 }
 
+func TestAskUser_ShorthandSurvivesSessionPrevalidation(t *testing.T) {
+	t.Parallel()
+	sess := newAskTestSession(t, SessionConfig{})
+
+	res := sess.execTool(context.Background(), askUserCall("c1", askUserArgsShorthand()), "")
+	if res.IsError {
+		t.Fatalf("session ask_user shorthand errored: %s", res.FullOutput)
+	}
+	if got := sess.askPendingCount(); got != 1 {
+		t.Fatalf("askPendingCount = %d, want 1", got)
+	}
+}
+
 // TestAskUser_ShorthandWithAllOptionals verifies shorthand form with all
 // optional fields (header, why, if_unanswered, multi_select) normalizes correctly.
 func TestAskUser_ShorthandWithAllOptionals(t *testing.T) {

--- a/agent/session_tool_repair.go
+++ b/agent/session_tool_repair.go
@@ -71,6 +71,14 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 		res.Err = err
 		return res
 	}
+	if t.Definition.Name == "ask_user" {
+		normalized, err := normalizeAskArgs(args)
+		if err != nil {
+			res.PrevalErr = err.Error()
+			return res
+		}
+		args = normalized
+	}
 
 	if err := t.Schema.Validate(args); err != nil {
 		// A length stop that cut the stream before any argument byte leaves

--- a/agent/session_tool_repair_test.go
+++ b/agent/session_tool_repair_test.go
@@ -209,29 +209,12 @@ func TestPrepareToolCall_NestedSchemaErrors_NameRealFieldAndContainer(t *testing
 		}
 	})
 
-	t.Run("ask_user question header too long", func(t *testing.T) {
+	t.Run("ask_user accepts a long question header", func(t *testing.T) {
 		call := llm.ToolCallData{ID: "c2", Name: "ask_user",
 			Arguments: json.RawMessage(`{"questions":[{"header":"way too long for a chip label","question":"q","options":[{"label":"a","detail":"a"},{"label":"b","detail":"b"}]}]}`)}
 		res := prepareToolCall(call, reg.Get("ask_user"), []string{"ask_user"}, "ask_user", "")
-		want := "ask_user: argument \"questions[0].header\" exceeds maxLength (12). Value \"way too long for a chip label\" is 29 characters."
-		if res.PrevalErr != want {
-			t.Fatalf("PrevalErr =\n%s\nwant:\n%s", res.PrevalErr, want)
-		}
-		if strings.Contains(res.PrevalErr, "Required arguments") {
-			t.Fatalf("message must not include the generic required-arguments line: %q", res.PrevalErr)
-		}
-	})
-
-	// Issue #193 repro: a header exceeding the documented maxLength (12)
-	// must surface the actual constraint and value/length, not the misleading
-	// "Required arguments" message that claims question/options were missing.
-	t.Run("ask_user header Module & repo is 13 chars", func(t *testing.T) {
-		call := llm.ToolCallData{ID: "c3", Name: "ask_user",
-			Arguments: json.RawMessage(`{"questions":[{"header":"Module & repo","question":"q","options":[{"label":"a","detail":"a"},{"label":"b","detail":"b"}]}]}`)}
-		res := prepareToolCall(call, reg.Get("ask_user"), []string{"ask_user"}, "ask_user", "")
-		want := "ask_user: argument \"questions[0].header\" exceeds maxLength (12). Value \"Module & repo\" is 13 characters."
-		if res.PrevalErr != want {
-			t.Fatalf("PrevalErr =\n%s\nwant:\n%s", res.PrevalErr, want)
+		if res.PrevalErr != "" {
+			t.Fatalf("long header was rejected: %s", res.PrevalErr)
 		}
 	})
 

--- a/agent/session_tools_ask.go
+++ b/agent/session_tools_ask.go
@@ -161,8 +161,8 @@ func normalizeAskArgs(args map[string]any) (map[string]any, error) {
 }
 
 // parseAskQuestions extracts the askQuestions from an ask_user call's parsed
-// arguments. Schema-level shape (question/option counts, header maxLength,
-// required fields) is already enforced by the registry's JSON-Schema
+// arguments. Schema-level shape (question/option counts, required fields) is
+// already enforced by the registry's JSON-Schema
 // validation before the live Exec below ever runs (spec §5.1) — this checks
 // only the two semantic rules the schema cannot express: option labels
 // unique within a question, and at most one recommended option per

--- a/agent/session_tools_misc_contract_fuzz_test.go
+++ b/agent/session_tools_misc_contract_fuzz_test.go
@@ -468,9 +468,8 @@ func stmAskArgs(r *stmReader) map[string]any {
 	word := r.word()
 	return map[string]any{
 		"questions": []any{map[string]any{
-			// DefAskUser limits headers to 12 characters. Keep the fuzzed word in
-			// the body/detail fields while holding this structural field valid so
-			// the real handler, rather than argument repair, is the exercised seam.
+			// Keep this structural field stable so the real handler, rather than
+			// argument repair, is the exercised seam.
 			"header":   "Choice",
 			"question": "Choose " + word,
 			"options": []any{

--- a/cmd/evener-hub/frontend/src/panes/session/askShared.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/askShared.test.ts
@@ -123,6 +123,13 @@ test("answeredAskUserSuffix reads the answer back from a later [answers] reply",
   expect(answeredAskUserSuffix(threadModel([ask, reply]), ask)).toBe(' — answered: "Yes"');
 });
 
+test("answeredAskUserSuffix decodes a JSON-encoded unsafe header", () => {
+  const unsafeHeader = "A]B\nC";
+  const ask = item({ argumentsJSON: askUserArgs([{ ...ONE_QUESTION[0], header: unsafeHeader }]) });
+  const reply = userMessage({ text: '[answers]\n1. ["A]B\\nC"] → "Yes"' });
+  expect(answeredAskUserSuffix(threadModel([ask, reply]), ask)).toBe(' — answered: "Yes"');
+});
+
 test("answeredAskUserSuffix strips a trailing note from the recap", () => {
   const ask = item({ argumentsJSON: askUserArgs(ONE_QUESTION) });
   const reply = userMessage({ text: '[answers]\n1. [Deploy?] → "Yes" — note: "ship it now"' });

--- a/cmd/evener-hub/frontend/src/panes/session/askShared.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/askShared.test.ts
@@ -124,9 +124,9 @@ test("answeredAskUserSuffix reads the answer back from a later [answers] reply",
 });
 
 test("answeredAskUserSuffix decodes a JSON-encoded unsafe header", () => {
-  const unsafeHeader = "A]B\nC";
+  const unsafeHeader = "A]B\n<C&";
   const ask = item({ argumentsJSON: askUserArgs([{ ...ONE_QUESTION[0], header: unsafeHeader }]) });
-  const reply = userMessage({ text: '[answers]\n1. ["A]B\\nC"] → "Yes"' });
+  const reply = userMessage({ text: '[answers]\n1. ["A]B\\n<C&"] → "Yes"' });
   expect(answeredAskUserSuffix(threadModel([ask, reply]), ask)).toBe(' — answered: "Yes"');
 });
 

--- a/cmd/evener-hub/frontend/src/panes/session/askShared.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/askShared.test.ts
@@ -124,9 +124,9 @@ test("answeredAskUserSuffix reads the answer back from a later [answers] reply",
 });
 
 test("answeredAskUserSuffix decodes a JSON-encoded unsafe header", () => {
-  const unsafeHeader = "A]B\n<C&";
+  const unsafeHeader = "A]B\n<C&\u2028";
   const ask = item({ argumentsJSON: askUserArgs([{ ...ONE_QUESTION[0], header: unsafeHeader }]) });
-  const reply = userMessage({ text: '[answers]\n1. ["A]B\\n<C&"] → "Yes"' });
+  const reply = userMessage({ text: '[answers]\n1. ["A]B\\n<C&\\u2028"] → "Yes"' });
   expect(answeredAskUserSuffix(threadModel([ask, reply]), ask)).toBe(' — answered: "Yes"');
 });
 

--- a/cmd/evener-hub/frontend/src/panes/session/askShared.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/askShared.ts
@@ -1,6 +1,6 @@
 // Shared ask_user question/option parsing (wave-5 T4 extraction). Ground
 // truth: agent/internal/tool/definitions.go's DefAskUser gives the exact
-// argumentsJson shape - {questions:[{header?(<=12 chars), question,
+// argumentsJson shape - {questions:[{header?, question,
 // options:[{label,detail,recommended?}], multi_select?, why?,
 // if_unanswered?}]}, 1-4 questions. This used to live private to
 // transcript/tools/askUser.tsx (the wave-4 read-only tool-call renderer);

--- a/cmd/evener-hub/frontend/src/panes/session/askShared.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/askShared.ts
@@ -81,11 +81,10 @@ export function parseAskUserQuestions(item: ItemModel): AskUserQuestion[] | unde
 }
 
 // One line of a composed [answers] reply (askCompose.ts's composeAskAnswers,
-// byte-exact format): "N. [Header] → resolution text[ — note: "..."]". The
-// header is captured raw (never escaped by composeAskAnswers, unlike the
-// resolution's quoted strings), so this matches on brackets rather than
-// trying to unescape anything.
-const ASK_ANSWER_LINE_RE = /^\d+\.\s\[([^\]]*)\]\s→\s(.*)$/;
+// byte-exact format): "N. [Header] → resolution text[ — note: "..."]". Safe
+// headers are raw; headers containing ]/CR/LF are JSON strings, so their
+// delimiters cannot be mistaken for the framing brackets.
+const ASK_ANSWER_LINE_RE = /^\d+\.\s(?:\[([^\]\r\n]*)\]|\[("(?:\\.|[^"\\])*")\])\s→\s(.*)$/;
 
 // parseAskAnswerLines reads a composed [answers] reply's text back into a
 // header -> resolution-text map. The optional trailing " — note: ..." is
@@ -96,8 +95,17 @@ function parseAskAnswerLines(text: string): Map<string, string> {
   for (const line of text.split("\n")) {
     const m = ASK_ANSWER_LINE_RE.exec(line);
     if (!m) continue;
-    const header = m[1] ?? "";
-    const rest = m[2] ?? "";
+    let header = m[1] ?? "";
+    if (m[2] !== undefined) {
+      try {
+        const decoded = JSON.parse(m[2]);
+        if (typeof decoded !== "string") continue;
+        header = decoded;
+      } catch {
+        continue;
+      }
+    }
+    const rest = m[3] ?? "";
     const noteAt = rest.indexOf(" — note: ");
     map.set(header, noteAt === -1 ? rest : rest.slice(0, noteAt));
   }

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askCompose.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askCompose.test.ts
@@ -43,8 +43,8 @@ test("an option resolution joins labels with a comma, each quoted", () => {
 });
 
 test("an unsafe header is JSON-encoded so answer framing stays parseable", () => {
-  const text = composeAskAnswers([item({ header: "A]B\n<C&" })]);
-  expect(text).toBe('[answers]\n1. ["A]B\\n<C&"] → skipped (no answer)');
+  const text = composeAskAnswers([item({ header: "A]B\n<C&\u2028" })]);
+  expect(text).toBe('[answers]\n1. ["A]B\\n<C&\\u2028"] → skipped (no answer)');
 });
 
 test("a multi-select option resolution quotes each label separately, comma-joined", () => {

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askCompose.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askCompose.test.ts
@@ -42,6 +42,11 @@ test("an option resolution joins labels with a comma, each quoted", () => {
   expect(text).toBe('[answers]\n1. [Deploy?] → "Yes"');
 });
 
+test("an unsafe header is JSON-encoded so answer framing stays parseable", () => {
+  const text = composeAskAnswers([item({ header: "A]B\nC" })]);
+  expect(text).toBe('[answers]\n1. ["A]B\\nC"] → skipped (no answer)');
+});
+
 test("a multi-select option resolution quotes each label separately, comma-joined", () => {
   const text = composeAskAnswers([item({ resolution: { kind: "option", labels: ["Yes", "with, a comma"] } })]);
   expect(text).toBe('[answers]\n1. [Deploy?] → "Yes", "with, a comma"');

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askCompose.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askCompose.test.ts
@@ -43,8 +43,8 @@ test("an option resolution joins labels with a comma, each quoted", () => {
 });
 
 test("an unsafe header is JSON-encoded so answer framing stays parseable", () => {
-  const text = composeAskAnswers([item({ header: "A]B\nC" })]);
-  expect(text).toBe('[answers]\n1. ["A]B\\nC"] → skipped (no answer)');
+  const text = composeAskAnswers([item({ header: "A]B\n<C&" })]);
+  expect(text).toBe('[answers]\n1. ["A]B\\n<C&"] → skipped (no answer)');
 });
 
 test("a multi-select option resolution quotes each label separately, comma-joined", () => {

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askCompose.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askCompose.ts
@@ -30,7 +30,10 @@ export interface AskAnswerItem {
 
 function askAnswerHeader(header: string | undefined, index: number): string {
   const value = header ?? `Question ${index + 1}`;
-  return /[\]\r\n]/u.test(value) ? JSON.stringify(value) : value;
+  if (!/[\]\r\n]/u.test(value)) return value;
+  return JSON.stringify(value)
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
 }
 
 // quoteGoString mirrors Go's %q escaping (renderer.js:6975-6994) exactly:

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askCompose.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askCompose.ts
@@ -1,9 +1,8 @@
 // The [answers] reply composition (parity contracts-composer-queue-pending.md
-// §"Ask User"/test-ask-compose.js): byte-exact, golden-string tested, ported
-// verbatim from cmd/evener-hub/assets/renderer.js's composeAskAnswers/
-// askResolutionText/quoteGoString (renderer.js:6980-7031). This is not
-// cosmetic formatting - the composed text round-trips through the daemon's
-// own reply parser, so every character here is load-bearing.
+// §"Ask User"/test-ask-compose.js): byte-exact for the ordinary format and
+// golden-string tested against cmd/evener-hub/assets/renderer.js's
+// composeAskAnswers/askResolutionText/quoteGoString. Headers containing line
+// framing characters use JSON encoding so the composed text remains parseable.
 
 // AskResolution mirrors legacy's exactly-one-of-5-kinds rule (spec §4.3,
 // renderer.js:5874-5882): option (single or multi_select), free text,
@@ -18,7 +17,8 @@ export type AskResolution =
   | { kind: "skip" };
 
 // AskAnswerItem is the minimal shape composeAskAnswers needs from one
-// question: its header (for the "[Header]" tag), its current resolution,
+// question: its header (for the "[Header]" tag, JSON-encoded when it contains
+// framing characters), its current resolution,
 // its optional note, and - only for a fallback resolution - the model's own
 // if_unanswered text to embed verbatim.
 export interface AskAnswerItem {
@@ -29,7 +29,8 @@ export interface AskAnswerItem {
 }
 
 function askAnswerHeader(header: string | undefined, index: number): string {
-  return header ?? `Question ${index + 1}`;
+  const value = header ?? `Question ${index + 1}`;
+  return /[\]\r\n]/u.test(value) ? JSON.stringify(value) : value;
 }
 
 // quoteGoString mirrors Go's %q escaping (renderer.js:6975-6994) exactly:

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askdock.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askdock.module.css
@@ -73,6 +73,7 @@
   border: 1px solid var(--edge);
   border-radius: var(--radius-control);
   padding: var(--space-1) var(--space-2);
+  overflow-wrap: anywhere;
 }
 
 /* Selected is --accent (control selection, design-system.md §4 - same rule

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askquestioncard.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askquestioncard.module.css
@@ -20,8 +20,10 @@
 }
 
 .header {
+  min-width: 0;
   font-weight: var(--font-weight-semibold);
   color: var(--ink-hi);
+  overflow-wrap: anywhere;
 }
 
 .questionText {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/askUser.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/askUser.test.tsx
@@ -11,7 +11,7 @@ function item(overrides: Partial<ItemModel> = {}): ItemModel {
 }
 
 // Ground truth: agent/internal/tool/definitions.go's DefAskUser - exact
-// argumentsJson shape: {questions:[{header(<=12 chars), question,
+// argumentsJson shape: {questions:[{header, question,
 // options:[{label,detail,recommended?}], multi_select?, why?,
 // if_unanswered?}]}, 1-4 questions. ask_user's own Output is always the
 // SAME fixed string on success (agent/session_tools_ask.go's

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/askUser.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/askUser.tsx
@@ -3,7 +3,7 @@
 // unlike legacy's suppress-and-redirect-to-a-dock design, since the
 // composer-side answer flow is a separate wave-5 surface). Ground truth:
 // agent/internal/tool/definitions.go's DefAskUser gives the exact
-// argumentsJson shape - {questions:[{header?(<=12 chars), question,
+// argumentsJson shape - {questions:[{header?, question,
 // options:[{label,detail,recommended?}], multi_select?, why?,
 // if_unanswered?}]}, 1-4 questions. ask_user's own Output is a single
 // FIXED string on success (agent/session_tools_ask.go's askUserAckText,

--- a/cmd/evener-tui/question_overlay.go
+++ b/cmd/evener-tui/question_overlay.go
@@ -151,8 +151,12 @@ func composeAskAnswers(questions []askQuestion) string {
 
 func answerHeader(header string) string {
 	if strings.ContainsAny(header, "]\r\n") {
-		encoded, _ := json.Marshal(header)
-		return string(encoded)
+		var b strings.Builder
+		encoder := json.NewEncoder(&b)
+		encoder.SetEscapeHTML(false)
+		if err := encoder.Encode(header); err == nil {
+			return strings.TrimSuffix(b.String(), "\n")
+		}
 	}
 	return header
 }

--- a/cmd/evener-tui/question_overlay.go
+++ b/cmd/evener-tui/question_overlay.go
@@ -130,7 +130,8 @@ func pendingAskQuestions(messages []transcript.ChatMessage) []askQuestion {
 // ---- Compose: the §4.3 [answers] reply, byte-exact with the web's port ---
 // (cmd/evener-hub/assets/renderer.js composeAskAnswers, golden-tested by
 // cmd/evener-hub/jstest/test-ask-compose.js). strconv.Quote IS Go's %q verb,
-// so — unlike the JS port — no hand-rolled escaping is needed here.
+// so — unlike the JS port — no hand-rolled escaping is needed for resolutions;
+// unsafe headers use encoding/json on both surfaces.
 
 // composeAskAnswers renders the [answers] reply: global numbering in
 // posting order, one resolution per line, every line carrying its header
@@ -139,13 +140,21 @@ func composeAskAnswers(questions []askQuestion) string {
 	lines := make([]string, 0, len(questions)+1)
 	lines = append(lines, "[answers]")
 	for i, q := range questions {
-		line := fmt.Sprintf("%d. [%s] → %s", i+1, q.Header, askResolutionText(q))
+		line := fmt.Sprintf("%d. [%s] → %s", i+1, answerHeader(q.Header), askResolutionText(q))
 		if note := strings.TrimSpace(q.Note); note != "" {
 			line += " — note: " + strconv.Quote(note)
 		}
 		lines = append(lines, line)
 	}
 	return strings.Join(lines, "\n")
+}
+
+func answerHeader(header string) string {
+	if strings.ContainsAny(header, "]\r\n") {
+		encoded, _ := json.Marshal(header)
+		return string(encoded)
+	}
+	return header
 }
 
 // askResolutionText renders one question's resolution per spec §4.3's exact

--- a/cmd/evener-tui/question_overlay_test.go
+++ b/cmd/evener-tui/question_overlay_test.go
@@ -131,8 +131,8 @@ func TestComposeAskAnswers_UnresolvedComposesAsSkipped(t *testing.T) {
 }
 
 func TestComposeAskAnswers_EncodesUnsafeHeader(t *testing.T) {
-	questions := []askQuestion{{Header: "A]B\nC", Resolution: nil}}
-	want := "[answers]\n1. [\"A]B\\nC\"] → skipped (no answer)"
+	questions := []askQuestion{{Header: "A]B\n<C&", Resolution: nil}}
+	want := "[answers]\n1. [\"A]B\\n<C&\"] → skipped (no answer)"
 	if got := composeAskAnswers(questions); got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}

--- a/cmd/evener-tui/question_overlay_test.go
+++ b/cmd/evener-tui/question_overlay_test.go
@@ -131,8 +131,8 @@ func TestComposeAskAnswers_UnresolvedComposesAsSkipped(t *testing.T) {
 }
 
 func TestComposeAskAnswers_EncodesUnsafeHeader(t *testing.T) {
-	questions := []askQuestion{{Header: "A]B\n<C&", Resolution: nil}}
-	want := "[answers]\n1. [\"A]B\\n<C&\"] → skipped (no answer)"
+	questions := []askQuestion{{Header: "A]B\n<C&\u2028", Resolution: nil}}
+	want := "[answers]\n1. [\"A]B\\n<C&\\u2028\"] → skipped (no answer)"
 	if got := composeAskAnswers(questions); got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}

--- a/cmd/evener-tui/question_overlay_test.go
+++ b/cmd/evener-tui/question_overlay_test.go
@@ -130,6 +130,14 @@ func TestComposeAskAnswers_UnresolvedComposesAsSkipped(t *testing.T) {
 	}
 }
 
+func TestComposeAskAnswers_EncodesUnsafeHeader(t *testing.T) {
+	questions := []askQuestion{{Header: "A]B\nC", Resolution: nil}}
+	want := "[answers]\n1. [\"A]B\\nC\"] → skipped (no answer)"
+	if got := composeAskAnswers(questions); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
 func TestComposeAskAnswers_FallbackEmbedsStatedIfUnanswered(t *testing.T) {
 	questions := []askQuestion{{
 		Header:       "X",

--- a/docs/superpowers/plans/2026-07-03-ask-user.md
+++ b/docs/superpowers/plans/2026-07-03-ask-user.md
@@ -90,8 +90,11 @@ func TestDefAskUserSchema(t *testing.T) {
 			t.Fatalf("missing question property %q", k)
 		}
 	}
-	if props["header"].(map[string]any)["maxLength"] != 12 {
-		t.Fatal("header maxLength != 12")
+	if props["header"].(map[string]any)["type"] != "string" {
+		t.Fatal("header is not a string")
+	}
+	if _, ok := props["header"].(map[string]any)["maxLength"]; ok {
+		t.Fatal("header must not have a hard maxLength")
 	}
 	opts := props["options"].(map[string]any)
 	if opts["minItems"] != 2 || opts["maxItems"] != 5 {

--- a/docs/superpowers/plans/2026-08-06-ws6-validation-errors.md
+++ b/docs/superpowers/plans/2026-08-06-ws6-validation-errors.md
@@ -148,7 +148,7 @@ call-site proximity:
     *top-level* schema (unchanged behavior) before hardcoding it.
   - The former `questions[0].header` length reproduction is superseded: the
     current `DefAskUser` schema intentionally has no hard header-length cap.
-    Generic `maxLength` formatter coverage uses an independent constrained
+    Generic bounded-string formatter coverage uses an independent constrained
     fixture instead.
   - Regression case: flat top-level missing arg (existing behavior) still
     produces the unqualified `"Required arguments:"` line with no `"in "`

--- a/docs/superpowers/plans/2026-08-06-ws6-validation-errors.md
+++ b/docs/superpowers/plans/2026-08-06-ws6-validation-errors.md
@@ -146,9 +146,10 @@ call-site proximity:
     `` `task_list: missing required argument "status" in updates[0].\nRequired arguments in updates[0]: id (integer), status (string).\nExample: {"action": "..."}` `` —
     confirm the exact `Example:` line against `minimalExample` on the
     *top-level* schema (unchanged behavior) before hardcoding it.
-  - `questions[0].header` too long (present, invalid) → exact want:
-    `` `ask_user: argument "questions[0].header" has the wrong type or value.\nRequired arguments in questions[0]: question (string), options (array).\nExample: {"questions": [...]}` `` —
-    same caveat: confirm the real `Example:` line before hardcoding.
+  - The former `questions[0].header` length reproduction is superseded: the
+    current `DefAskUser` schema intentionally has no hard header-length cap.
+    Generic `maxLength` formatter coverage uses an independent constrained
+    fixture instead.
   - Regression case: flat top-level missing arg (existing behavior) still
     produces the unqualified `"Required arguments:"` line with no `"in "`
     text.

--- a/docs/superpowers/specs/2026-07-03-ask-user-question-tool-design.md
+++ b/docs/superpowers/specs/2026-07-03-ask-user-question-tool-design.md
@@ -30,7 +30,7 @@ Meanwhile a dedicated model-invoked question tool became table stakes across the
 
 ## 3. Prior art distilled (what we copy, what we avoid)
 
-We copy the convergent schema (questions[] + short `header` chip + 2–5 `{label, detail}` options + always-available free text), the convergent headless stance (remove the tool; never fabricate answers), and the convergent subagent stance (root-only, hard-enforced).
+We copy the convergent schema (questions[] + a `header` chip + 2–5 `{label, detail}` options + always-available free text), the convergent headless stance (remove the tool; never fabricate answers), and the convergent subagent stance (root-only, hard-enforced).
 
 We deliberately avoid five documented failure modes:
 
@@ -56,7 +56,7 @@ We also decline Codex's plan-mode-only gating (users file issues begging for the
 {
   "questions": [            // 1..4
     {
-      "header": "DB choice",        // optional, ≤12 chars; chip/tab label; omitted headers display as Question N
+	      "header": "DB choice",        // optional chip/tab label; delimiter characters are encoded in [answers] replies; omitted headers display as Question N
       "question": "Which datastore for the ingest path?",  // required
       "options": [                   // required, 2..5
         { "label": "Postgres", "detail": "matches prod; heavier local setup", "recommended": true },
@@ -89,7 +89,7 @@ The user's **next message is the answer**. The form composes it in a stable form
 4. [Endpoint] → free text: "use RDS, not self-hosted"
 ```
 
-Per question, exactly one resolution: a quoted selection (multi-select joins **quoted** labels: `→ "A", "B"` — unambiguous even when a label contains a comma), `free text: "…"`, `you decide` (optional `leaning`, then `note`, both quoted), `do your stated fallback ("…")` (only where `if_unanswered` exists), or `skipped (no answer)`. Question numbering is global across the turn's pending set in posting order — spanning multiple `ask_user` calls — and every line carries the header (or the stable fallback label `Question N`, 1-based within the call), so the reply stays unambiguous even when clients render the calls as separate cards. **Every** resolution line accepts the trailing `— note: "…"` suffix — the annotation is universal (Jesse's hard requirement), and renderers must offer the note affordance on every resolution path, question-level, not chip-only.
+Per question, exactly one resolution: a quoted selection (multi-select joins **quoted** labels: `→ "A", "B"` — unambiguous even when a label contains a comma), `free text: "…"`, `you decide` (optional `leaning`, then `note`, both quoted), `do your stated fallback ("…")` (only where `if_unanswered` exists), or `skipped (no answer)`. Question numbering is global across the turn's pending set in posting order — spanning multiple `ask_user` calls — and every line carries the header (or the stable fallback label `Question N`, 1-based within the call), so the reply stays unambiguous even when clients render the calls as separate cards. Headers containing `]`, CR, or LF are JSON-encoded inside the header brackets so the framing remains unambiguous. **Every** resolution line accepts the trailing `— note: "…"` suffix — the annotation is universal (Jesse's hard requirement), and renderers must offer the note affordance on every resolution path, question-level, not chip-only.
 
 The user may instead ignore the form and type anything: free prose **is** a valid reply, delivered verbatim as the user message. There is no daemon-side answer validation and no invalid-answer state — a reply is a reply; the form's structure lives in the client.
 
@@ -97,7 +97,7 @@ The user may instead ignore the form and type anything: free prose **is** a vali
 
 > Ask the user structured questions. Asking yields the floor: when the round containing your `ask_user` call(s) completes, your turn ends and the session waits visibly for the reply (no timeout). Do the work that does not need answers first, then batch every question this decision point needs — several `ask_user` calls may share the round, and a `communicate` in the same round still delivers its message. The answers arrive in the user's next message: either the numbered `[answers]` form (one resolution per question: a selection, free text, "you decide" — choose with your judgment, honoring any stated leaning —, your stated fallback, or skipped — proceed on your best judgment, state the assumption, and do not immediately re-ask) or free prose; treat either as the reply to everything you asked. Any answer may carry a user note — read it; it can qualify or override the selection.
 >
-> - `questions`: 1–4 per call, each with an optional short `header` (≤12 chars; omitted headers display as `Question N`, 1-based within the call), the full `question`, and 2–5 `options` (`{label, detail}`, labels unique). Set `multi_select` to allow several; set `recommended: true` on at most one option and put it first.
+> - `questions`: 1–4 per call, each with an optional display `header` (omitted headers display as `Question N`, 1-based within the call), the full `question`, and 2–5 `options` (`{label, detail}`, labels unique). Set `multi_select` to allow several; set `recommended: true` on at most one option and put it first.
 > - Do not add an "Other" or free-text option; the UI always offers one, plus "you decide".
 > - Optional per question: `why` (one line: what the answer changes) and `if_unanswered` (the fallback you would take; the user can accept it with one tap).
 >
@@ -115,7 +115,7 @@ The existing non-interactive section (`agent/prompts/sections/non-interactive.md
 
 ### 5.1 Asking ends the turn at its round's boundary
 
-The handler registers like any core tool (`registerCoreTools` → new `registerAskTool`, `agent/session_tool_registry.go`). It validates its input (label uniqueness, one `recommended` per question — schema constraints like counts and lengths are already enforced by the registry's JSON-Schema validation), adds the questions to the round's **pending set**, and returns a short ack as its tool result. The calls themselves are ordinary: several may share a round, siblings execute normally, and a `communicate` in the same round records its message exactly as today.
+The handler registers like any core tool (`registerCoreTools` → new `registerAskTool`, `agent/session_tool_registry.go`). It validates its input (label uniqueness, one `recommended` per question — schema constraints like counts are already enforced by the registry's JSON-Schema validation), adds the questions to the round's **pending set**, and returns a short ack as its tool result. The calls themselves are ordinary: several may share a round, siblings execute normally, and a `communicate` in the same round records its message exactly as today.
 
 The one new mechanism is a single check at the round boundary — the same place `deliverIfCommunicated` already decides whether the turn ends: **if the round posted questions, the turn ends**, and the boundary state is **`SessionAwaiting`** — a new session state alongside idle/processing/closed — instead of idle. `communicate` **composes, never collides**: an explicit `communicate` in the asking round contributes its user-facing message, and its `end_turn` value is moot because the asks already end the turn (Jesse's directive: multiple asks and a communicate in one round cause the turn end, together). A model that asks in what it meant as a mid-turn round simply ends its turn early — the tool description says asking yields the floor, and the boundary enforces it; remaining work continues after the reply.
 

--- a/fuzz/schemagen/schemagen_test.go
+++ b/fuzz/schemagen/schemagen_test.go
@@ -79,9 +79,9 @@ var fixtures = map[string]map[string]any{
 		},
 		"required": []string{"questions"},
 	},
-	// Mirrors ask_user's per-question header: a string with maxLength (the
-	// constraint TestToolArgsSchemaFuzz caught when schemagen's string
-	// generator first ignored minLength/maxLength entirely).
+	// A generic bounded string: the constraint TestToolArgsSchemaFuzz caught
+	// when schemagen's string generator first ignored minLength/maxLength
+	// entirely. This is not a copy of the ask_user header schema.
 	"bounded_string": {
 		"type":                 "object",
 		"additionalProperties": false,


### PR DESCRIPTION
## Summary
- remove the brittle 12-character limit from ask_user question headers
- preserve longer headers such as "Progress flavor" through tool execution
- update schema/repair fixtures and add regression coverage

## Verification
- make test
- make vet
- make lint
- make test-web