### PR TITLE
fix: resolve claimed delegate send waiters inline

### DIFF
--- a/agent/delegate_delivery.go
+++ b/agent/delegate_delivery.go
@@ -809,7 +809,9 @@ func (s *Session) acceptDelegateDeliveryPlan(plan delegateDeliveryPlan) (delegat
 	s.mu.Lock()
 	processing := s.state == SessionProcessing
 	s.mu.Unlock()
-	if processing {
+	// A waiter-bearing plan completes a tool executing in this processing turn.
+	// Deferring it behind that turn would make the turn wait on its own queue.
+	if processing && plan.waiter == nil {
 		s.pendingDelegateDeliveries = append(s.pendingDelegateDeliveries, plan)
 		shouldWake := !s.delegateDeliveryWake && !s.delegateDeliveryRetry.active
 		if shouldWake {

--- a/agent/delegate_tree_controller_test.go
+++ b/agent/delegate_tree_controller_test.go
@@ -453,7 +453,7 @@ var delegateControllerDormancyExpectedInventory = map[delegateControllerDormancy
 	{filename: "session_model_call.go", function: "(*Session).prepareModelRequestWithError", kind: "lifecycle method", symbol: "CompleteModelRequest"}:                                 1,
 	{filename: "session_model_call.go", function: "(*Session).prepareModelRequestWithError", kind: "lifecycle method", symbol: "AbortModelRequest"}:                                    1,
 	{filename: "session_tools.go", function: "stableDelegateSendTool", kind: "delivery commit method", symbol: "Complete"}:                                                             1,
-	{filename: "session_tools.go", function: "(*Session).appendToolResults", kind: "delivery commit method", symbol: "Complete"}:                                                       1,
+	{filename: "session_tools.go", function: "(*Session).appendToolResults", kind: "delivery commit method", symbol: "Complete"}:                                                       2,
 	{filename: "session_tools.go", function: "(*Session).appendToolResultsWithDeliveryCommitsDurably", kind: "delivery commit method", symbol: "Complete"}:                             2,
 	{filename: "session_tools.go", function: "(*Session).abortDelegateDeliveryCommits", kind: "delivery commit method", symbol: "Complete"}:                                            1,
 	{filename: "session_tools.go", function: "(*Session).queueDelegateDeliveryCommit", kind: "delivery commit method", symbol: "Complete"}:                                             1,

--- a/agent/delegate_tree_controller_test.go
+++ b/agent/delegate_tree_controller_test.go
@@ -453,6 +453,7 @@ var delegateControllerDormancyExpectedInventory = map[delegateControllerDormancy
 	{filename: "session_model_call.go", function: "(*Session).prepareModelRequestWithError", kind: "lifecycle method", symbol: "CompleteModelRequest"}:                                 1,
 	{filename: "session_model_call.go", function: "(*Session).prepareModelRequestWithError", kind: "lifecycle method", symbol: "AbortModelRequest"}:                                    1,
 	{filename: "session_tools.go", function: "stableDelegateSendTool", kind: "delivery commit method", symbol: "Complete"}:                                                             1,
+	{filename: "session_tools.go", function: "(*Session).appendToolResults", kind: "delivery commit method", symbol: "Complete"}:                                                       1,
 	{filename: "session_tools.go", function: "(*Session).appendToolResultsWithDeliveryCommitsDurably", kind: "delivery commit method", symbol: "Complete"}:                             2,
 	{filename: "session_tools.go", function: "(*Session).abortDelegateDeliveryCommits", kind: "delivery commit method", symbol: "Complete"}:                                            1,
 	{filename: "session_tools.go", function: "(*Session).queueDelegateDeliveryCommit", kind: "delivery commit method", symbol: "Complete"}:                                             1,

--- a/agent/delegate_waiter_deadlock_test.go
+++ b/agent/delegate_waiter_deadlock_test.go
@@ -1,0 +1,129 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"primeradiant.com/evener/agent/internal/tool"
+	"primeradiant.com/evener/llm"
+)
+
+func TestAcceptDelegateDeliveryPlanWhileProcessing(t *testing.T) {
+	t.Run("claimed inline waiter resolves immediately", func(t *testing.T) {
+		controller, _ := newDelegateControllerTestHarness(t, 1, 1)
+		root := &Session{id: "root-session", state: SessionProcessing, delegateController: controller}
+		controller.rootRuntime = root
+		seedDelegateControllerIdle(t, controller, "dlg_target", "")
+		lease, waiter := startDelegateDeliveryGeneration(t, controller, "dlg_target", true)
+		plan := finishDelegateDeliveryGeneration(t, controller, lease, "finished inline").deliveries[0]
+
+		plans, deferred, err := root.acceptDelegateDeliveryPlan(plan)
+		if err != nil {
+			t.Fatalf("acceptDelegateDeliveryPlan: %v", err)
+		}
+		if deferred {
+			t.Fatal("waiter-bearing delivery was deferred behind its own processing turn")
+		}
+		root.delegateDeliveryMu.Lock()
+		queued := len(root.pendingDelegateDeliveries)
+		root.delegateDeliveryMu.Unlock()
+		if queued != 0 {
+			t.Fatalf("pending deliveries = %d, want no queued inline plan", queued)
+		}
+		select {
+		case resolution := <-waiter.resolution:
+			if resolution.fallback || resolution.packet == nil || resolution.commit == nil {
+				t.Fatalf("inline resolution = %#v", resolution)
+			}
+			if _, err := resolution.commit.Complete(false); err != nil {
+				t.Fatalf("abort inline commit: %v", err)
+			}
+		default:
+			t.Fatal("accepted inline waiter was not resolved synchronously")
+		}
+		if len(plans.updates) != 0 || len(plans.deliveries) != 0 {
+			t.Fatalf("inline acceptance plans = %#v, want handoff only", plans)
+		}
+	})
+
+	t.Run("ordinary delivery remains deferred", func(t *testing.T) {
+		controller, _ := newDelegateControllerTestHarness(t, 1, 1)
+		root := &Session{id: "root-session", state: SessionProcessing, delegateController: controller}
+		controller.rootRuntime = root
+		seedDelegateControllerIdle(t, controller, "dlg_target", "")
+		lease, _ := startDelegateDeliveryGeneration(t, controller, "dlg_target", false)
+		plan := finishDelegateDeliveryGeneration(t, controller, lease, "finished in background").deliveries[0]
+
+		plans, deferred, err := root.acceptDelegateDeliveryPlan(plan)
+		if err != nil {
+			t.Fatalf("acceptDelegateDeliveryPlan: %v", err)
+		}
+		if !deferred {
+			t.Fatal("ordinary delivery bypassed processing-turn deferral")
+		}
+		root.delegateDeliveryMu.Lock()
+		defer root.delegateDeliveryMu.Unlock()
+		if len(root.pendingDelegateDeliveries) != 1 || root.pendingDelegateDeliveries[0].deliveryID != plan.deliveryID {
+			t.Fatalf("pending deliveries = %#v, want ordinary plan queued", root.pendingDelegateDeliveries)
+		}
+		if len(plans.updates) != 0 || len(plans.deliveries) != 0 {
+			t.Fatalf("deferred acceptance plans = %#v", plans)
+		}
+	})
+}
+
+func TestCanceledToolResultPersistenceAbortsClaimedInlineDelivery(t *testing.T) {
+	controller, _ := newDelegateControllerTestHarness(t, 1, 1)
+	root := &Session{id: "root-session", state: SessionProcessing, delegateController: controller}
+	controller.rootRuntime = root
+	seedDelegateControllerIdle(t, controller, "dlg_target", "")
+	lease, waiter := startDelegateDeliveryGeneration(t, controller, "dlg_target", true)
+	plan := finishDelegateDeliveryGeneration(t, controller, lease, "finished inline").deliveries[0]
+	if _, err := deliverDelegatePacket(plan, root); err != nil {
+		t.Fatalf("deliverDelegatePacket: %v", err)
+	}
+	resolution := <-waiter.resolution
+	if resolution.commit == nil {
+		t.Fatalf("inline resolution = %#v, want a delivery commit", resolution)
+	}
+	t.Cleanup(func() { _, _ = resolution.commit.Complete(false) })
+	root.queueDelegateDeliveryCommit("send-call", resolution.commit)
+
+	call := llm.ToolCallData{ID: "send-call", Name: "delegate_send", Type: "function"}
+	result := tool.ExecResult{ToolName: "delegate_send", CallID: call.ID, Output: "finished inline", FullOutput: "finished inline"}
+	part := llm.ContentPart{
+		Kind: llm.ContentToolResult,
+		ToolResult: &llm.ToolResultData{
+			ToolCallID: call.ID,
+			Name:       call.Name,
+			Content:    result.Output,
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := root.appendToolResults(ctx, []llm.ToolCallData{call}, []tool.ExecResult{result}, []llm.ContentPart{part}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("appendToolResults error = %v, want context canceled", err)
+	}
+
+	root.delegateDeliveryMu.Lock()
+	queuedCommits := len(root.delegateDeliveryCommits[call.ID])
+	root.delegateDeliveryMu.Unlock()
+	if queuedCommits != 0 {
+		t.Fatalf("queued commits after canceled persistence = %d, want none", queuedCommits)
+	}
+	controller.mu.Lock()
+	admissions := len(controller.deliveries)
+	pending := len(controller.durable["dlg_target"].PendingDeliveries)
+	controller.mu.Unlock()
+	if admissions != 0 {
+		t.Fatalf("delivery admissions after canceled persistence = %d, want aborted", admissions)
+	}
+	if pending != 1 {
+		t.Fatalf("durable pending deliveries = %d, want delivery retained for replay", pending)
+	}
+	replay := controller.ReplayDeliveries()
+	if len(replay) != 1 || replay[0].deliveryID != plan.deliveryID || replay[0].waiter != nil {
+		t.Fatalf("replay after canceled persistence = %#v, want one ordinary delivery", replay)
+	}
+}

--- a/agent/delegate_waiter_deadlock_test.go
+++ b/agent/delegate_waiter_deadlock_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"primeradiant.com/evener/agent/internal/tool"
+	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/llm"
 )
 
@@ -125,5 +126,84 @@ func TestCanceledToolResultPersistenceAbortsClaimedInlineDelivery(t *testing.T) 
 	replay := controller.ReplayDeliveries()
 	if len(replay) != 1 || replay[0].deliveryID != plan.deliveryID || replay[0].waiter != nil {
 		t.Fatalf("replay after canceled persistence = %#v, want one ordinary delivery", replay)
+	}
+}
+
+func TestCanceledAfterTakingInlineCommitAbortsBeforeDurableToolResult(t *testing.T) {
+	controller, _ := newDelegateControllerTestHarness(t, 1, 1)
+	root := &Session{id: "root-session", state: SessionProcessing, delegateController: controller}
+	controller.rootRuntime = root
+	path := transcriptPath(controller.stateDir, root.ID())
+	writer, err := transcript.NewWriter(path, transcript.Header{SessionID: root.ID()})
+	if err != nil {
+		t.Fatalf("create root transcript: %v", err)
+	}
+	root.attachTranscript(writer)
+	t.Cleanup(func() { _ = writer.Close() })
+
+	seedDelegateControllerIdle(t, controller, "dlg_target", "")
+	lease, waiter := startDelegateDeliveryGeneration(t, controller, "dlg_target", true)
+	plan := finishDelegateDeliveryGeneration(t, controller, lease, "finished inline").deliveries[0]
+	if _, err := deliverDelegatePacket(plan, root); err != nil {
+		t.Fatalf("deliverDelegatePacket: %v", err)
+	}
+	resolution := <-waiter.resolution
+	if resolution.commit == nil {
+		t.Fatalf("inline resolution = %#v, want a delivery commit", resolution)
+	}
+	t.Cleanup(func() { _, _ = resolution.commit.Complete(false) })
+	root.queueDelegateDeliveryCommit("send-call", resolution.commit)
+
+	controller.mu.Lock()
+	beforeEvidence := controller.evidenceVersion
+	controller.mu.Unlock()
+	ctx, cancel := context.WithCancel(context.Background())
+	hookCalls := 0
+	root.cfg.testOnly.delegateDeliveryCommitsTaken = func() {
+		hookCalls++
+		cancel()
+	}
+	call := llm.ToolCallData{ID: "send-call", Name: "delegate_send", Type: "function"}
+	result := tool.ExecResult{ToolName: call.Name, CallID: call.ID, Output: "finished inline", FullOutput: "finished inline"}
+	part := llm.ContentPart{
+		Kind: llm.ContentToolResult,
+		ToolResult: &llm.ToolResultData{
+			ToolCallID: call.ID,
+			Name:       call.Name,
+			Content:    result.Output,
+		},
+	}
+	appendErr := root.appendToolResults(ctx, []llm.ToolCallData{call}, []tool.ExecResult{result}, []llm.ContentPart{part})
+	if !errors.Is(appendErr, context.Canceled) {
+		t.Errorf("appendToolResults error = %v, want context canceled", appendErr)
+	}
+	if hookCalls != 1 {
+		t.Errorf("post-take hook calls = %d, want 1", hookCalls)
+	}
+
+	controller.mu.Lock()
+	evidenceDelta := controller.evidenceVersion - beforeEvidence
+	admissions := len(controller.deliveries)
+	pending := len(controller.durable["dlg_target"].PendingDeliveries)
+	controller.mu.Unlock()
+	if evidenceDelta != 1 {
+		t.Errorf("controller evidence delta = %d, want one exact abort", evidenceDelta)
+	}
+	if admissions != 0 {
+		t.Errorf("delivery admissions after cancellation = %d, want none", admissions)
+	}
+	if pending != 1 {
+		t.Errorf("durable pending deliveries = %d, want delivery retained", pending)
+	}
+	fold, err := readDelegateAttentionFold(path, root.ID())
+	if err != nil {
+		t.Fatalf("read root transcript fold: %v", err)
+	}
+	if callID := fold.deliveryCommits[plan.deliveryID]; callID != "" {
+		t.Errorf("persisted delivery commit = %q for %q, want none", callID, plan.deliveryID)
+	}
+	replay := controller.ReplayDeliveries()
+	if len(replay) != 1 || replay[0].deliveryID != plan.deliveryID || replay[0].waiter != nil {
+		t.Errorf("replay after post-take cancellation = %#v, want one ordinary delivery", replay)
 	}
 }

--- a/agent/session_config.go
+++ b/agent/session_config.go
@@ -292,6 +292,9 @@ type testConfig struct {
 	// delegateSendBeforePositiveWaitAdmission observes the boundary immediately
 	// before a positive-wait send reserves its start. Nil preserves production.
 	delegateSendBeforePositiveWaitAdmission func()
+	// delegateDeliveryCommitsTaken observes the tool-result boundary after inline
+	// delivery commits leave the pending map and before any transcript write.
+	delegateDeliveryCommitsTaken func()
 	// delegateAttentionReadFold replaces only resident attention verification
 	// reads. Nil preserves the production transcript fold.
 	delegateAttentionReadFold func(string, string) (delegateAttentionFold, error)

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -918,6 +918,22 @@ func (s *Session) appendToolResults(ctx context.Context, calls []llm.ToolCallDat
 	var persistErr error
 	if abortErr := s.withResponseSideEffects(ctx, func() {
 		commits := s.takeDelegateDeliveryCommits(calls)
+		if len(commits) != 0 {
+			if observe := s.cfg.testOnly.delegateDeliveryCommitsTaken; observe != nil {
+				observe()
+			}
+			// This is the last cancellation observation before transcript persistence.
+			// Once it passes, the durable append below owns the commit point and must
+			// finish rather than roll back a write that may already have started.
+			if persistErr = ctx.Err(); persistErr != nil {
+				for _, binding := range commits {
+					if binding.commit != nil {
+						_, _ = binding.commit.Complete(false)
+					}
+				}
+				return
+			}
+		}
 		persistedParts := projectToolResultsForTranscript(calls, results, parts)
 		live := llm.Message{Role: llm.RoleTool, Content: parts}
 		persisted := llm.Message{Role: llm.RoleTool, Content: persistedParts}

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -940,6 +940,13 @@ func (s *Session) appendToolResults(ctx context.Context, calls []llm.ToolCallDat
 		s.maybeAutoSave()
 		s.announceReadableToolResultImages(results)
 	}); abortErr != nil {
+		// The tool round will not persist, so release any inline delivery receipts
+		// it acquired before cancellation and leave their durable heads replayable.
+		for _, binding := range s.takeDelegateDeliveryCommits(calls) {
+			if binding.commit != nil {
+				_, _ = binding.commit.Complete(false)
+			}
+		}
 		if ctx.Err() != nil && !s.isClosingOrClosed() {
 			s.appendCanceledToolResults(calls, results, abortErr)
 		}

--- a/cmd/evener/serve_delegate_send_interrupt_test.go
+++ b/cmd/evener/serve_delegate_send_interrupt_test.go
@@ -305,7 +305,7 @@ func (d *waiterInterruptDaemon) mutationSnapshot(t *testing.T) waiterInterruptMu
 	return snapshot
 }
 
-func awaitWaiterInterruptSignal(t *testing.T, ctx context.Context, signal <-chan struct{}, label string) {
+func awaitWaiterInterruptSignal(ctx context.Context, t *testing.T, signal <-chan struct{}, label string) {
 	t.Helper()
 	select {
 	case <-signal:
@@ -324,11 +324,11 @@ func TestRunServeInterruptSettlesClaimedPositiveWaitDelegateSend(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TurnStart: %v", err)
 	}
-	awaitWaiterInterruptSignal(t, daemon.ctx, daemon.positiveWaitSeen, "positive-wait delegate_send start")
-	awaitWaiterInterruptSignal(t, daemon.ctx, daemon.adapter.childSecondEntered, "positive-wait delegate generation")
+	awaitWaiterInterruptSignal(daemon.ctx, t, daemon.positiveWaitSeen, "positive-wait delegate_send start")
+	awaitWaiterInterruptSignal(daemon.ctx, t, daemon.adapter.childSecondEntered, "positive-wait delegate generation")
 	daemon.server.armed.Store(true)
 	close(daemon.adapter.childMayFinish)
-	awaitWaiterInterruptSignal(t, daemon.ctx, daemon.terminalClaimed, "terminal delegate waiter claim")
+	awaitWaiterInterruptSignal(daemon.ctx, t, daemon.terminalClaimed, "terminal delegate waiter claim")
 	select {
 	case <-daemon.server.notification:
 		// The unfixed path has accepted and deferred the waiter-bearing plan.

--- a/cmd/evener/serve_delegate_send_interrupt_test.go
+++ b/cmd/evener/serve_delegate_send_interrupt_test.go
@@ -1,0 +1,398 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent"
+	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/provider"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/llm"
+	"primeradiant.com/evener/llm/providercfg"
+	"primeradiant.com/evener/server"
+)
+
+const (
+	waiterInterruptRootPrompt = "ROOT-WAITER-INTERRUPT"
+	waiterInterruptChildTask  = "CHILD-WAITER-INTERRUPT"
+)
+
+var waiterInterruptDelegateID = regexp.MustCompile(`dlg_[A-Za-z0-9_-]+`)
+
+type waiterInterruptAdapter struct {
+	initialTerminal    chan struct{}
+	childSecondEntered chan struct{}
+	childMayFinish     chan struct{}
+	afterSendEntered   chan struct{}
+
+	mu           sync.Mutex
+	rootCalls    int
+	childCalls   int
+	afterSendOne sync.Once
+}
+
+func newWaiterInterruptAdapter() *waiterInterruptAdapter {
+	return &waiterInterruptAdapter{
+		initialTerminal:    make(chan struct{}),
+		childSecondEntered: make(chan struct{}),
+		childMayFinish:     make(chan struct{}),
+		afterSendEntered:   make(chan struct{}),
+	}
+}
+
+func (a *waiterInterruptAdapter) Name() string { return "openai" }
+
+func (a *waiterInterruptAdapter) Complete(ctx context.Context, req llm.Request) (llm.Response, error) {
+	text := requestFullText(req)
+	if strings.Contains(text, waiterInterruptChildTask) && !strings.Contains(text, waiterInterruptRootPrompt) {
+		a.mu.Lock()
+		a.childCalls++
+		childCall := a.childCalls
+		a.mu.Unlock()
+		if childCall == 1 {
+			return scriptedCommunicate("initial child run finished"), nil
+		}
+		if childCall == 2 {
+			close(a.childSecondEntered)
+			select {
+			case <-a.childMayFinish:
+				return scriptedCommunicate("child finished inline"), nil
+			case <-ctx.Done():
+				return llm.Response{}, ctx.Err()
+			}
+		}
+		return scriptedCommunicate("unexpected child continuation"), nil
+	}
+
+	a.mu.Lock()
+	a.rootCalls++
+	call := a.rootCalls
+	a.mu.Unlock()
+	switch call {
+	case 1:
+		return scriptedDelegateCall("create_waiter_target", waiterInterruptChildTask), nil
+	case 2:
+		select {
+		case <-a.initialTerminal:
+		case <-ctx.Done():
+			return llm.Response{}, ctx.Err()
+		}
+		// Finish one ordinary tool round so the initial background delivery is
+		// flushed and its wake bit cannot mask the positive-wait delivery wake.
+		return scriptedToolCalls(scriptedForegroundShellCall("flush_initial_delivery", "printf flushed")), nil
+	case 3:
+		delegateID := waiterInterruptDelegateID.FindString(text)
+		if delegateID == "" {
+			return llm.Response{}, errors.New("delegate creation result carried no delegate id")
+		}
+		args, _ := json.Marshal(map[string]any{
+			"to":          delegateID,
+			"message":     "finish and report inline",
+			"max_wait_ms": 60_000,
+		})
+		return scriptedToolCalls(llm.ToolCallData{
+			ID:        "positive_wait_send",
+			Name:      "delegate_send",
+			Arguments: args,
+			Type:      "function",
+		}), nil
+	default:
+		a.afterSendOne.Do(func() { close(a.afterSendEntered) })
+		<-ctx.Done()
+		return llm.Response{}, ctx.Err()
+	}
+}
+
+func (a *waiterInterruptAdapter) Stream(context.Context, llm.Request) (llm.Stream, error) {
+	return nil, llm.ErrStreamUnsupported
+}
+
+type waiterInterruptServer struct {
+	*server.Server
+	notification chan struct{}
+	armed        atomic.Bool
+	once         sync.Once
+}
+
+func (s *waiterInterruptServer) SubmitNotification() {
+	if s.armed.Load() {
+		s.once.Do(func() { close(s.notification) })
+	}
+	s.Server.SubmitNotification()
+}
+
+type waiterInterruptDaemon struct {
+	adapter          *waiterInterruptAdapter
+	client           *appwire.Client
+	ctx              context.Context
+	ref              string
+	terminalClaimed  chan struct{}
+	positiveWaitSeen chan struct{}
+	turnEnded        chan struct{}
+	server           *waiterInterruptServer
+	stateDir         string
+	sessionID        string
+}
+
+func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
+	t.Helper()
+	adapter := newWaiterInterruptAdapter()
+	positiveWaitSeen := make(chan struct{})
+	terminalClaimed := make(chan struct{})
+	turnEnded := make(chan struct{})
+	var turnEndedOnce sync.Once
+	var positiveWaitOnce sync.Once
+	var initialTerminalOnce sync.Once
+	var terminalOnce sync.Once
+	var terminalMu sync.Mutex
+	initialTerminalSeen := false
+	secondGenerationRunning := false
+
+	deps := defaultServeDeps()
+	deps.ensureConfigDirs = func() error { return nil }
+	deps.seedMarketplaces = func() error { return nil }
+	deps.newClient = func(string, io.Writer) (*llm.Client, providercfg.Config, bool, func() error, error) {
+		client := llm.NewClient()
+		client.Register(adapter)
+		cfg := providercfg.Config{
+			Default:   "openai",
+			Instances: []providercfg.InstanceConfig{{Name: "openai", Type: "openai"}},
+		}
+		return client, cfg, true, func() error { return nil }, nil
+	}
+	var liveSession *agent.Session
+	deps.newSession = func(client *llm.Client, profile *provider.Profile, env execenv.ExecutionEnvironment, cfg agent.SessionConfig) (*agent.Session, error) {
+		cfg.LLMRetryPolicy = &llm.RetryPolicy{MaxRetries: 0}
+		sess, err := agent.NewSession(client, profile, env, cfg)
+		if err == nil {
+			liveSession = sess
+		}
+		return sess, err
+	}
+	var observedServer *server.Server
+	var waiterServer *waiterInterruptServer
+	deps.newServer = func(cfg server.ServerConfig) serveServer {
+		observedServer = server.NewServer(cfg)
+		waiterServer = &waiterInterruptServer{Server: observedServer, notification: make(chan struct{})}
+		return waiterServer
+	}
+	deps.bridge = func(_ serveServer, session *agent.Session, observer func(events.SessionEvent), onDrained func()) {
+		session.ConsumeEventsLossless(func(event events.SessionEvent) {
+			server.BridgeEvent(observedServer, event, observer)
+			switch event.Kind {
+			case events.EventToolCallStart:
+				if data, ok := event.Data.(events.ToolCallStartData); ok && data.ToolName == "delegate_send" {
+					positiveWaitOnce.Do(func() { close(positiveWaitSeen) })
+				}
+			case events.EventDelegateUpdated:
+				if data, ok := event.Data.(events.DelegateUpdatedData); ok {
+					terminalMu.Lock()
+					switch {
+					case !initialTerminalSeen && data.Terminal && data.Lifecycle == "idle":
+						initialTerminalSeen = true
+						initialTerminalOnce.Do(func() { close(adapter.initialTerminal) })
+					case initialTerminalSeen && !data.Terminal && data.Lifecycle == "running":
+						secondGenerationRunning = true
+					case secondGenerationRunning && data.Terminal && data.Lifecycle == "idle":
+						terminalOnce.Do(func() { close(terminalClaimed) })
+					}
+					terminalMu.Unlock()
+				}
+			case events.EventTurnEnded:
+				turnEndedOnce.Do(func() { close(turnEnded) })
+			}
+		}, onDrained)
+	}
+	deps.subscriberCount = func(_ serveServer, id string) int {
+		return observedServer.AppServer().SubscriberCount(id)
+	}
+
+	runDir := t.TempDir()
+	stateDir := t.TempDir()
+	done := make(chan error, 1)
+	go func() {
+		done <- runServeWithDeps([]string{
+			"--model", "openai/gpt-test",
+			"--addr", "127.0.0.1:0",
+			"--dir", t.TempDir(),
+			"--state-dir", stateDir,
+			"--run-dir", runDir,
+		}, deps)
+	}()
+
+	entry := waitForServeTestRendezvous(t, runDir)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	transport, err := appwire.DialWebSocket(ctx, "ws://"+entry.Address+"/rpc", http.DefaultClient)
+	if err != nil {
+		cancel()
+		t.Fatalf("DialWebSocket: %v", err)
+	}
+	client := appwire.NewClient(transport)
+	client.Start(context.WithoutCancel(ctx))
+	if _, err := client.Initialize(ctx, appwire.InitializeParams{
+		ClientInfo: appwire.ClientInfo{Name: "waiter-interrupt-test", Version: "test"},
+	}); err != nil {
+		client.Close()
+		cancel()
+		t.Fatalf("Initialize: %v", err)
+	}
+	t.Cleanup(func() {
+		client.Close()
+		if liveSession != nil {
+			liveSession.Close()
+		}
+		shutdownResp, shutdownErr := http.Post("http://"+entry.Address+"/shutdown", "", nil)
+		if shutdownErr == nil {
+			shutdownResp.Body.Close()
+		}
+		select {
+		case runErr := <-done:
+			if runErr != nil {
+				t.Errorf("runServeWithDeps: %v", runErr)
+			}
+		case <-ctx.Done():
+			t.Errorf("runServeWithDeps did not exit: %v", ctx.Err())
+		}
+		cancel()
+	})
+	return &waiterInterruptDaemon{
+		adapter:          adapter,
+		client:           client,
+		ctx:              ctx,
+		ref:              appwire.Ref{SourceID: "local", ThreadID: entry.SessionID}.String(),
+		terminalClaimed:  terminalClaimed,
+		positiveWaitSeen: positiveWaitSeen,
+		turnEnded:        turnEnded,
+		server:           waiterServer,
+		stateDir:         stateDir,
+		sessionID:        entry.SessionID,
+	}
+}
+
+type waiterInterruptMutationSnapshot struct {
+	QueueHeld      bool            `json:"queue_held"`
+	SteeringHeld   bool            `json:"steering_held"`
+	InterruptFence json.RawMessage `json:"interrupt_fence"`
+	Journal        map[string]struct {
+		OperationState string `json:"operation_state"`
+		ExecutionState string `json:"execution_state"`
+	} `json:"journal"`
+}
+
+func (d *waiterInterruptDaemon) mutationSnapshot(t *testing.T) waiterInterruptMutationSnapshot {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(d.stateDir, "mutations", d.sessionID+".json"))
+	if err != nil {
+		t.Fatalf("read client mutation snapshot: %v", err)
+	}
+	var snapshot waiterInterruptMutationSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		t.Fatalf("decode client mutation snapshot: %v", err)
+	}
+	return snapshot
+}
+
+func awaitWaiterInterruptSignal(t *testing.T, ctx context.Context, signal <-chan struct{}, label string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-ctx.Done():
+		t.Fatalf("waiting for %s: %v", label, ctx.Err())
+	}
+}
+
+func TestRunServeInterruptSettlesClaimedPositiveWaitDelegateSend(t *testing.T) {
+	daemon := startWaiterInterruptDaemon(t)
+	started, err := daemon.client.TurnStart(daemon.ctx, appwire.TurnStartParams{
+		ClientMutationID: "waiter-interrupt-turn",
+		Ref:              daemon.ref,
+		Input:            []appwire.InputItem{{Type: "text", Text: waiterInterruptRootPrompt}},
+	})
+	if err != nil {
+		t.Fatalf("TurnStart: %v", err)
+	}
+	awaitWaiterInterruptSignal(t, daemon.ctx, daemon.positiveWaitSeen, "positive-wait delegate_send start")
+	awaitWaiterInterruptSignal(t, daemon.ctx, daemon.adapter.childSecondEntered, "positive-wait delegate generation")
+	daemon.server.armed.Store(true)
+	close(daemon.adapter.childMayFinish)
+	awaitWaiterInterruptSignal(t, daemon.ctx, daemon.terminalClaimed, "terminal delegate waiter claim")
+	select {
+	case <-daemon.server.notification:
+		// The unfixed path has accepted and deferred the waiter-bearing plan.
+	case <-daemon.adapter.afterSendEntered:
+		// The fixed path resolved it inline and advanced the same root turn.
+	case <-daemon.ctx.Done():
+		t.Fatalf("waiting for delivery acceptance: %v", daemon.ctx.Err())
+	}
+
+	// The RPC itself awaits runnerDone; this deadline is only a deadlock tripwire,
+	// not the completion mechanism.
+	interruptCtx, cancelInterrupt := context.WithTimeout(daemon.ctx, 3*time.Second)
+	defer cancelInterrupt()
+	interrupt := appwire.TurnInterruptParams{ClientMutationID: "stop-claimed-waiter", Ref: daemon.ref}
+	if err := daemon.client.TurnInterrupt(interruptCtx, interrupt); err != nil {
+		t.Fatalf("TurnInterrupt did not settle the claimed inline waiter and runner: %v", err)
+	}
+	select {
+	case <-daemon.turnEnded:
+	default:
+		t.Fatal("TurnInterrupt returned before the interrupted runner emitted TURN_ENDED")
+	}
+	turns, err := daemon.client.ThreadTurnsList(daemon.ctx, appwire.ThreadTurnsListParams{Ref: daemon.ref})
+	if err != nil {
+		t.Fatalf("ThreadTurnsList: %v", err)
+	}
+	terminal := false
+	for _, turn := range turns.Data {
+		if turn.ID == started.Turn.ID {
+			terminal = turn.Status == "interrupted"
+		}
+	}
+	if !terminal {
+		t.Fatalf("turn %q was not terminalized as interrupted: %#v", started.Turn.ID, turns.Data)
+	}
+	if err := daemon.client.TurnInterrupt(daemon.ctx, interrupt); err != nil {
+		t.Fatalf("replay terminal interrupt: %v", err)
+	}
+
+	// The interrupt response is not enough by itself: read the durable mutation
+	// snapshot that future client mutations are serialized against. The runner
+	// must have terminalized the fence before the RPC returned.
+	stopped := daemon.mutationSnapshot(t)
+	interruptRecord := stopped.Journal[interrupt.ClientMutationID]
+	if len(stopped.InterruptFence) != 0 || interruptRecord.OperationState != "terminal" ||
+		interruptRecord.ExecutionState != "interrupted" {
+		t.Fatalf("non-terminal interrupt snapshot = %#v", stopped)
+	}
+	if !stopped.QueueHeld || !stopped.SteeringHeld {
+		t.Fatalf("Stop did not park both input rails before re-engagement: queue=%t steering=%t", stopped.QueueHeld, stopped.SteeringHeld)
+	}
+
+	// Queueing is a user re-engagement and clears both durable held gates in the
+	// same accepted mutation. Reading the snapshot again proves later client
+	// mutations are no longer trapped behind the completed interrupt.
+	if err := daemon.client.TurnQueue(daemon.ctx, appwire.TurnQueueParams{
+		ClientMutationID: "reengage-after-stop",
+		Ref:              daemon.ref,
+		Input:            []appwire.InputItem{{Type: "text", Text: "resume after stop"}},
+	}); err != nil {
+		t.Fatalf("TurnQueue after interrupt: %v", err)
+	}
+	reengaged := daemon.mutationSnapshot(t)
+	if reengaged.QueueHeld || reengaged.SteeringHeld {
+		t.Fatalf("re-engagement left a held input rail: queue=%t steering=%t", reengaged.QueueHeld, reengaged.SteeringHeld)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a deadlock when a positive-wait `delegate_send` completes while its owner session is processing a tool round. The claimed inline waiter was deferred behind the turn that was waiting for it, so Stop/interrupt could not withdraw or resolve it.

- Deliver waiter-bearing delegate plans immediately during `SessionProcessing`.
- Preserve deferral for ordinary non-inline deliveries.
- Abort claimed delivery commits when cancellation occurs before durable tool-result persistence, keeping delivery heads replayable.
- Add focused, cancellation-boundary, and real serve/AppWire Stop regressions.

## Verification

- `go test ./... -count=1`
- Focused and `-race` delegate/serve regressions
- `gofmt` and `git diff --check`

All passed.
