### PR TITLE
fix: idle subagents fold into inactive list, not active

### DIFF
--- a/cmd/evener-hub/internal/hubcore/production_subagent_sidebar_regression_test.go
+++ b/cmd/evener-hub/internal/hubcore/production_subagent_sidebar_regression_test.go
@@ -55,8 +55,35 @@ func TestBuildTree_ProjectsRunningInProcessSubagent(t *testing.T) {
 	parent := LiveEntry{PID: 1, SessionID: "parent", Status: appwire.ThreadStatusIdle, RunningSubagentIDs: []string{"child"}}
 	tree := BuildTreeAt(metas, []LiveEntry{parent}, nil, now)
 	child := tree.Projects[0].Current[0].Children[0]
+	if child.State != "idle" {
+		t.Fatalf("running in-process child state = %q, want idle (liveness is not activity)", child.State)
+	}
+	if tree.Projects[0].RollupState != "idle" || tree.Projects[0].Expanded {
+		t.Fatalf("project rollup = %q expanded=%v, want idle/false", tree.Projects[0].RollupState, tree.Projects[0].Expanded)
+	}
+}
+
+// TestBuildTree_ChildOwnLiveEntryBeatsParentProjection proves the removed
+// runningChildIDs override was wrong: a child with its own live entry
+// reporting "active" must keep that state even when its parent's daemon
+// lists it in RunningSubagentIDs with no RunningSubagentStates (which would
+// have fallen back to idle and overwritten the child's own truth).
+func TestBuildTree_ChildOwnLiveEntryBeatsParentProjection(t *testing.T) {
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	metas := []schema.SessionMeta{
+		{ID: "parent", UpdatedAt: now, EnvInfo: schema.EnvironmentInfo{WorkingDir: "/projects/evener"}},
+		{ID: "child", ParentSessionID: "parent", IsSubagent: true, UpdatedAt: now, EnvInfo: schema.EnvironmentInfo{WorkingDir: "/projects/evener"}},
+	}
+	live := []LiveEntry{
+		// Parent lists child as a running subagent but carries no state for it.
+		{PID: 1, SessionID: "parent", Status: appwire.ThreadStatusIdle, RunningSubagentIDs: []string{"child"}},
+		// Child has its own live entry reporting active — its own daemon truth.
+		{PID: 2, SessionID: "child", Status: appwire.ThreadStatusActive},
+	}
+	tree := BuildTreeAt(metas, live, nil, now)
+	child := tree.Projects[0].Current[0].Children[0]
 	if child.State != "active" {
-		t.Fatalf("running in-process child state = %q, want active", child.State)
+		t.Fatalf("child state = %q, want active (child's own live entry beats parent's no-state projection)", child.State)
 	}
 	if tree.Projects[0].RollupState != "active" || !tree.Projects[0].Expanded {
 		t.Fatalf("project rollup = %q expanded=%v, want active/true", tree.Projects[0].RollupState, tree.Projects[0].Expanded)

--- a/cmd/evener-hub/internal/hubcore/roster.go
+++ b/cmd/evener-hub/internal/hubcore/roster.go
@@ -31,9 +31,10 @@ type LiveEntry struct {
 	RunningSubagentIDs []string // in-process children reported by this daemon; not independently routable
 	// RunningSubagentStates carries each running child's own projected status
 	// ("active", "idle", ...) when the daemon reports it. A listed child with
-	// no entry has an unknown state (old daemon), NOT a settled one — callers
-	// must keep their previous fallback for that case. Keyed by child session
-	// ID; a defensive copy rides every List/Find like the IDs slice.
+	// no entry has an unknown state (old daemon) — callers must NOT treat
+	// liveness as activity, and fold a no-state child to idle rather than
+	// active. Keyed by child session ID; a defensive copy rides every
+	// List/Find like the IDs slice.
 	RunningSubagentStates map[string]string
 	Project               identifier.Project // canonical identity resolved at hub ingestion, when available
 }

--- a/cmd/evener-hub/internal/hubcore/tree.go
+++ b/cmd/evener-hub/internal/hubcore/tree.go
@@ -658,15 +658,17 @@ func BuildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decis
 	}
 
 	// runningSubagentState resolves a live in-process child's display state:
-	// the child's own projected status when its daemon carried one, else the
-	// historical "listed means working" fallback (old daemons, legacy job
-	// discovery). Liveness alone must not read as activity — a settled,
-	// resumable delegate stays listed while doing nothing.
+	// the child's own projected status when its daemon carried one, else "idle".
+	// Liveness alone must not read as activity — a settled, resumable delegate
+	// stays listed while doing nothing, and an old daemon that carried no state
+	// is no excuse to present a quiet child as working. Folding to idle keeps a
+	// no-state child in the rail's inactive list where it belongs, one click
+	// away — the conservative side, matching CURRENT_SUBAGENT_STATES' own logic.
 	runningSubagentState := func(id string) string {
 		if state, ok := runningSubagentStates[id]; ok {
 			return NormalizeState(state)
 		}
-		return "active"
+		return "idle"
 	}
 
 	// stateFor resolves the display state for a session ID.
@@ -705,18 +707,6 @@ func BuildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decis
 	dormantFor := func(id string) bool {
 		m, ok := metaMap[id]
 		return ok && m.TurnCount == 0 && m.AcceptedInputTurns == 0
-	}
-
-	// runningChildIDs is deliberately built from the live entries supplied to
-	// this tree build. A child can be running in-process without having its own
-	// rendezvous/live entry, so the child row must not rely on liveMap alone.
-	runningChildIDs := make(map[string]struct{})
-	for _, le := range live {
-		for _, childID := range le.RunningSubagentIDs {
-			if childID != "" {
-				runningChildIDs[childID] = struct{}{}
-			}
-		}
 	}
 
 	// Group metas by canonical project identity while preserving each record's
@@ -853,11 +843,14 @@ func BuildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decis
 		if parentDead {
 			state = "ended"
 			askPending = false
-		} else if kind == "subagent" {
-			if _, ok := runningChildIDs[m.ID]; ok {
-				state = runningSubagentState(m.ID)
-			}
 		}
+		// A subagent's state already resolved through stateFor above: its own
+		// live entry's status when it has one, else the parent's carried state
+		// (or idle when the daemon carried none — liveness is not activity).
+		// The previous override here was redundant for children without their
+		// own live entry (stateFor already calls runningSubagentState) and wrong
+		// for children WITH one (it overwrote the child's own daemon-reported
+		// status with the parent's projection).
 		node := TreeNode{
 			ID:         m.ID,
 			Title:      nodeTitle(m, kind),

--- a/cmd/evener-hub/internal/hubcore/tree_test.go
+++ b/cmd/evener-hub/internal/hubcore/tree_test.go
@@ -178,11 +178,14 @@ func fuzzScenarioBuildTree_ProjectsRunningSubagentOnChild(t *testing.T) {
 	if sessions[0].State != "idle" {
 		t.Fatalf("parent state = %q, want idle", sessions[0].State)
 	}
-	if sessions[0].Children[0].State != "active" {
-		t.Fatalf("child state = %q, want active", sessions[0].Children[0].State)
+	// The child is listed (in-process, resumable) but the daemon carried no
+	// state for it. Liveness is not activity: an old daemon or a settled
+	// delegate with no carried state folds to idle, not active.
+	if sessions[0].Children[0].State != "idle" {
+		t.Fatalf("child state = %q, want idle (liveness is not activity)", sessions[0].Children[0].State)
 	}
-	if project.RollupState != "active" || project.RollupLive != 1 || !project.Expanded {
-		t.Fatalf("project rollup = state %q live %d expanded %v, want active/1/true", project.RollupState, project.RollupLive, project.Expanded)
+	if project.RollupState != "idle" || project.RollupLive != 0 || project.Expanded {
+		t.Fatalf("project rollup = state %q live %d expanded %v, want idle/0/false", project.RollupState, project.RollupLive, project.Expanded)
 	}
 
 	tree = BuildTreeAt(metas, []LiveEntry{{PID: 1, SessionID: "01PARENT", Status: appwire.ThreadStatusIdle}}, nil, now)
@@ -198,7 +201,10 @@ func fuzzScenarioBuildTree_ProjectsRunningSubagentOnChild(t *testing.T) {
 // carries the descendant's own projected status (RunningSubagentStates), the
 // tree must render THAT state — an idle delegate folds into the rail's
 // inactive list — instead of blanket "active". An ID with no carried state
-// (old daemon, legacy job discovery) keeps the active fallback.
+// (old daemon, legacy job discovery) must NOT read as active: liveness
+// alone is not activity, and a settled-but-resumable delegate that the
+// daemon failed to carry a state for would otherwise sit in the current
+// list forever, inflating the working count.
 func fuzzScenarioBuildTree_RunningSubagentUsesCarriedState(t *testing.T) {
 	now := time.Date(2026, 7, 13, 20, 0, 0, 0, time.UTC)
 	metas := []schema.SessionMeta{
@@ -234,11 +240,11 @@ func fuzzScenarioBuildTree_RunningSubagentUsesCarriedState(t *testing.T) {
 	if states["01BUSY"] != "active" {
 		t.Errorf("active-carried child state = %q, want active", states["01BUSY"])
 	}
-	if states["01NOSTATE"] != "active" {
-		t.Errorf("no-state child state = %q, want active (old-daemon fallback)", states["01NOSTATE"])
+	if states["01NOSTATE"] != "idle" {
+		t.Errorf("no-state child state = %q, want idle (liveness is not activity)", states["01NOSTATE"])
 	}
-	// One genuinely working child keeps the project live; the idle one must
-	// not inflate the working count.
+	// One genuinely working child keeps the project live; the idle and
+	// no-state ones must not inflate the working count.
 	if project.RollupState != "active" || project.RollupLive != 1 {
 		t.Errorf("project rollup = state %q live %d, want active/1", project.RollupState, project.RollupLive)
 	}

--- a/docs/superpowers/plans/2026-08-25-navigation-transport-optimization.md
+++ b/docs/superpowers/plans/2026-08-25-navigation-transport-optimization.md
@@ -1,0 +1,1008 @@
+# Navigation Transport Optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Web UI's repeated monolithic `/api/tree` transfer with bounded, revisioned navigation resources that rebuild once per semantic revision and revalidate only affected loaded resources.
+
+**Architecture:** A per-`WebServer` `NavigationService` owns immutable tree projections, semantic resource revisions, single-flight construction, bounded representation caches, and typed AppWire invalidations. HTTP serves a small manifest plus bounded section, catalog, project, page, and session-location resources with ETag and gzip; the frontend uses one resource revalidator and resource-local last-good state rather than a monolithic tree refresh.
+
+**Tech Stack:** Go 1.26, `net/http`, `encoding/json`, `compress/gzip`, `golang.org/x/sync/singleflight`, AppWire code generation, React 19, TypeScript 6, Zustand 5, Vitest 4, Biome 2.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-tree-transport-optimization-design.md`
+
+## Global Constraints
+
+- Read `docs/developing-evener/testing.md` before changing tests.
+- Keep default tests deterministic and offline; use scripted AppWire/source boundaries.
+- One `NavigationService` belongs to one `WebServer`; no global cache or cross-auth sharing.
+- Hard limits: 64 sources; section/page limit 50; catalog limit 100; 2,000 session nodes; depth 32; 2 MiB session-resource JSON; 256 KiB manifest JSON; 512 KiB catalog JSON; uint32 offsets.
+- String limits: title 200 runes; project/source/pin label and branch 512 runes; ref/opaque ID 1,024 bytes; working directory 4,096 bytes.
+- Representation cache limits: 256 entries or 64 MiB estimated object + JSON + gzip bytes, whichever comes first.
+- Frontend hydration concurrency is four; at most one request per representation may be in flight.
+- AppWire sequence is transport-only. HTTP identity is `(resource key, generation_id, resource revision)`.
+- Every navigation response uses `Cache-Control: private, no-cache`; matching `If-None-Match` returns bodyless 304; gzip varies on `Accept-Encoding`.
+- Logs, metrics, and diagnostics never record raw URLs, query strings, keys, IDs, refs, titles, prompts, or paths.
+- A failed refresh preserves last-good resource data and reports a resource-local stale/error state.
+- The legacy `/api/tree` endpoint is a temporary adapter over `NavigationService`, never a second builder/cache.
+- Before each frontend gate, run `npx biome check --write` on touched files under `cmd/evener-hub/frontend/src/`.
+- Stage named paths only in every commit. Never use `git add .` or `git add -A`.
+
+## File and Responsibility Map
+
+### New backend files
+
+- `hubapi/navigation.go` — public REST resource and mutation metadata types.
+- `cmd/evener-hub/navigation_projection.go` — pure bounded projection from one immutable core snapshot.
+- `cmd/evener-hub/navigation_projection_test.go` — shape, ordering, bounds, fingerprints, and location tests.
+- `cmd/evener-hub/navigation_cache.go` — representation identity, single-flight, LRU, JSON/gzip variants.
+- `cmd/evener-hub/navigation_cache_test.go` — cache isolation, eviction, concurrent miss, ETag identity tests.
+- `cmd/evener-hub/navigation_service.go` — generation, sequence, resource revisions, coherent snapshot publication, clock scheduling.
+- `cmd/evener-hub/navigation_service_test.go` — dependency matrix, no-op, race, last-good, and scheduler tests.
+- `cmd/evener-hub/web_api_navigation.go` — route dispatch, validation, conditional/gzip HTTP responses.
+- `cmd/evener-hub/web_api_navigation_test.go` — endpoint, security, header, paging, and redaction tests.
+- `cmd/evener-hub/navigation_benchmark_test.go` — fixed legacy/new fixture and build/allocation/byte benchmarks.
+- `cmd/evener-hub/testdata/navigation_legacy_baseline.json` — checked-in fixed-clock baseline measurements.
+
+### New frontend files
+
+- `cmd/evener-hub/frontend/src/stores/navigation/types.ts` — resource keys and local resource-state types derived from generated wire types.
+- `cmd/evener-hub/frontend/src/stores/navigation/revalidator.ts` — one in-flight request per representation, target revisions, force tokens, ETags, aborts.
+- `cmd/evener-hub/frontend/src/stores/navigation/revalidator.test.ts` — concurrency, stale response, 304, generation, and wildcard tests.
+- `cmd/evener-hub/frontend/src/stores/navigation/store.ts` — manifest/section/catalog/project/location state and hydration actions.
+- `cmd/evener-hub/frontend/src/stores/navigation/store.test.ts` — boot, paging, reconnect, failures, mutations, and no-idle-fetch tests.
+- `cmd/evener-hub/frontend/src/stores/navigation/selectors.ts` — resource-local selectors for rail, attention, titles, and menus.
+- `cmd/evener-hub/frontend/src/stores/navigation/testing.ts` — deterministic resource fixtures for component tests.
+
+### Existing files with focused changes
+
+- `appwire/types.go`, `appwire/protocol.go` — capability and typed invalidation contract.
+- `internal/appserver/server.go` — initialize response hook for navigation capability state.
+- `cmd/evener-hub/app_rpc.go` — hub capability values.
+- `cmd/evener-hub/web.go` — service ownership and navigation routes.
+- `cmd/evener-hub/web_api_tree.go` — temporary adapter only; remove direct rebuild path.
+- `cmd/evener-hub/main.go`, `main_background.go` — producer hooks and service lifecycle.
+- `cmd/evener-hub/internal/hubcore/{archive,favorite,pin_section,past,roster,remotecache}.go` — content-gated producer signals.
+- `hubapi/client.go`, `hubapi/types.go` — new resource methods and legacy compatibility.
+- `cmd/evener-hub/frontend/src/protocol/types.gen.ts` — generated contract output.
+- `cmd/evener-hub/frontend/src/shell/rail/{Rail,railNodes,RailRow,railPending}.tsx|ts` — resource-backed rail.
+- `cmd/evener-hub/frontend/src/{notifications,shell,panes/session}/...` — reconnect, attention, deep-link, title, and menu consumers.
+
+---
+
+### Task 1: Freeze the Legacy Performance Baseline
+
+**Files:**
+- Create: `cmd/evener-hub/navigation_benchmark_test.go`
+- Create: `cmd/evener-hub/testdata/navigation_legacy_baseline.json`
+- Modify: `cmd/evener-hub/web_api_tree.go`
+- Test: `cmd/evener-hub/navigation_benchmark_test.go`
+
+**Interfaces:**
+- Produces: `newNavigationBenchmarkFixture(tb testing.TB) *WebServer`
+- Produces: `BenchmarkLegacyNavigationBaseline`
+- Produces: fixed `hubNavigationNow func() time.Time` seam used only to make response timestamps deterministic.
+
+- [ ] **Step 1: Write the failing deterministic fixture test**
+
+Add a test that builds exactly 20 non-Git project directories and 50 current sessions per project, fixes the clock, calls `/api/tree`, and compares response bytes plus allocation metadata with the checked-in baseline schema:
+
+```go
+type navigationBaseline struct {
+    ResponseBytes int64 `json:"response_bytes"`
+    AllocsBytes   int64 `json:"allocs_bytes_per_op"`
+    Projects      int   `json:"projects"`
+    Sessions      int   `json:"sessions"`
+}
+
+func TestLegacyNavigationBaselineFixture(t *testing.T) {
+    web := newNavigationBenchmarkFixture(t)
+    body := requestLegacyTree(t, web)
+    if !bytes.Contains(body, []byte(`"projects"`)) {
+        t.Fatal("legacy fixture did not exercise project rows")
+    }
+    if got := countLegacySessions(t, body); got != 1000 {
+        t.Fatalf("sessions=%d, want 1000", got)
+    }
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run: `go test ./cmd/evener-hub -run TestLegacyNavigationBaselineFixture -count=1`
+
+Expected: FAIL because the fixture helpers and fixed clock seam do not exist.
+
+- [ ] **Step 3: Add the minimal fixture, benchmark, and baseline file**
+
+Use IDs `session-%03d-%03d`, names built from the ID plus seven repetitions of `representative-title-data-`, and timestamps one minute apart under a fixed UTC time. The benchmark warms once, then measures the real handler:
+
+```go
+func BenchmarkLegacyNavigationBaseline(b *testing.B) {
+    web := newNavigationBenchmarkFixture(b)
+    _ = requestLegacyTree(b, web)
+    b.ReportAllocs()
+    b.ResetTimer()
+    for range b.N {
+        _ = requestLegacyTree(b, web)
+    }
+}
+```
+
+Record five 20-iteration samples and commit the median response bytes and `B/op` to the JSON baseline. Keep the observed 429 KB report in documentation only; the fixed fixture is the gate reference.
+
+- [ ] **Step 4: Run fixture and benchmark verification**
+
+Run:
+
+```bash
+go test ./cmd/evener-hub -run TestLegacyNavigationBaselineFixture -count=1
+go test ./cmd/evener-hub -run '^$' -bench BenchmarkLegacyNavigationBaseline -benchtime=20x -count=5 -benchmem
+```
+
+Expected: test PASS; benchmark reports five samples and no live/network dependency.
+
+- [ ] **Step 5: Commit the baseline**
+
+```bash
+git add cmd/evener-hub/navigation_benchmark_test.go cmd/evener-hub/testdata/navigation_legacy_baseline.json cmd/evener-hub/web_api_tree.go
+git commit -m "test(hub): freeze navigation transport baseline"
+```
+
+### Task 2: Add Navigation Wire and AppWire Contracts
+
+**Files:**
+- Create: `hubapi/navigation.go`
+- Create: `hubapi/navigation_test.go`
+- Modify: `appwire/types.go`
+- Modify: `appwire/protocol.go`
+- Modify: `appwire/protocol_test.go`
+- Modify: `internal/appserver/server.go`
+- Modify: `internal/appserver/server_test.go`
+- Modify: `cmd/evener-hub/app_rpc.go`
+- Modify: `cmd/evener-hub/appwire_catalog_test.go`
+- Generate: `cmd/evener-hub/frontend/src/protocol/types.gen.ts`
+
+**Interfaces:**
+- Produces: `hubapi.NavigationManifest`, `NavigationSectionResource`, `NavigationPinSectionCatalog`, `NavigationProjectCatalog`, `NavigationProjectResource`, `NavigationProjectPage`, `NavigationSessionLocation`, `NavigationMutation`.
+- Produces: `appwire.NavigationCapability`, `NavigationInvalidationTarget`, `NavigationInvalidatedPayload`.
+- Produces: `appwire.NotifyEvenerNavigationInvalidated`.
+
+- [ ] **Step 1: Write contract tests before types**
+
+Test exact JSON names, non-null arrays, target variants, and initialize capability version:
+
+```go
+func TestNavigationInvalidatedPayloadJSON(t *testing.T) {
+    payload := appwire.NavigationInvalidatedPayload{
+        GenerationID: "generation-a",
+        Sequence: 7,
+        Targets: []appwire.NavigationInvalidationTarget{{
+            Kind: appwire.NavigationTargetProject,
+            ProjectKey: "project-key",
+            Revision: 3,
+        }},
+    }
+    got, err := json.Marshal(payload)
+    if err != nil { t.Fatal(err) }
+    want := `{"generationId":"generation-a","sequence":7,"targets":[{"kind":"project","projectKey":"project-key","revision":3}]}`
+    if string(got) != want { t.Fatalf("got %s, want %s", got, want) }
+}
+```
+
+- [ ] **Step 2: Run contract tests and verify failure**
+
+Run: `go test ./hubapi ./appwire ./internal/appserver ./cmd/evener-hub -run 'Test.*Navigation' -count=1`
+
+Expected: compile FAIL because navigation types/constants are undefined.
+
+- [ ] **Step 3: Define exact Go contracts and initialize capability**
+
+Use named target-kind constants and one validated target struct:
+
+```go
+const (
+    NavigationTargetManifest          = "manifest"
+    NavigationTargetSection           = "section"
+    NavigationTargetPinCatalog        = "pin_catalog"
+    NavigationTargetPinSection        = "pin_section"
+    NavigationTargetCatalog           = "catalog"
+    NavigationTargetProject           = "project"
+    NavigationTargetAllLoadedProjects = "all_loaded_projects"
+)
+
+type NavigationCapability struct {
+    Version      int    `json:"version"`
+    GenerationID string `json:"generationId"`
+    Sequence     uint64 `json:"sequence"`
+}
+```
+
+Add `Navigation *NavigationCapability `json:"navigation,omitempty"`` to `InitializeResponse`. Add the hubapi resource structs exactly as specified, including explicit empty slices and optional fields.
+
+- [ ] **Step 4: Register the notification and regenerate TypeScript**
+
+Add the notification catalog entry, then run:
+
+```bash
+make generate
+go test ./hubapi ./appwire ./internal/appwirets ./internal/appserver ./cmd/evener-hub -run 'Test.*(Navigation|Catalog|Initialize)' -count=1
+```
+
+Expected: generated `types.gen.ts` includes capability, resource, target, and notification types; all focused tests PASS.
+
+- [ ] **Step 5: Commit contracts and generated output**
+
+```bash
+git add hubapi/navigation.go hubapi/navigation_test.go appwire/types.go appwire/protocol.go appwire/protocol_test.go internal/appserver/server.go internal/appserver/server_test.go cmd/evener-hub/app_rpc.go cmd/evener-hub/appwire_catalog_test.go cmd/evener-hub/frontend/src/protocol/types.gen.ts
+git commit -m "feat(protocol): define navigation resource contracts"
+```
+
+### Task 3: Build Pure Bounded Navigation Projections
+
+**Files:**
+- Create: `cmd/evener-hub/navigation_projection.go`
+- Create: `cmd/evener-hub/navigation_projection_test.go`
+- Modify: `cmd/evener-hub/web_api_tree.go`
+- Modify: `cmd/evener-hub/internal/hubcore/tree.go`
+- Test: `cmd/evener-hub/internal/hubcore/tree_test.go`
+
+**Interfaces:**
+- Consumes: Task 2 hubapi resource types.
+- Produces: `buildNavigationProjection(inputs navigationBuildInputs) (navigationProjection, error)`.
+- Produces: `navigationProjection.Resource(key navigationResourceKey) (any, navigationFingerprint, error)`.
+- Produces: `navigationResourceBounds` constants and `NavigationSessionLocation` index.
+
+- [ ] **Step 1: Write projection and hard-bound tests**
+
+Cover stable order, exact current fields, no sessions in the manifest/catalogs, 50/100 row limits, uint32 offset behavior, 2,000-node/32-level/2 MiB truncation, string truncation, malformed identity refusal, and location summaries.
+
+```go
+func TestNavigationSectionAppliesRecursiveBounds(t *testing.T) {
+    input := deepNavigationFixture(40)
+    projection, err := buildNavigationProjection(input)
+    if err != nil { t.Fatal(err) }
+    section := projection.LivePage(0, 50)
+    if !section.Truncated { t.Fatal("deep section must report truncation") }
+    if got := countNavigationNodes(section.Sessions); got > maxNavigationNodes {
+        t.Fatalf("nodes=%d, max=%d", got, maxNavigationNodes)
+    }
+}
+```
+
+- [ ] **Step 2: Run projection tests and verify failure**
+
+Run: `go test ./cmd/evener-hub ./cmd/evener-hub/internal/hubcore -run 'TestNavigation(Project|Section|Manifest|Location|Bounds)' -count=1`
+
+Expected: compile FAIL because projection functions do not exist.
+
+- [ ] **Step 3: Implement the pure projector**
+
+Move response shaping out of `handleAPITree` into pure functions that receive one immutable tree/live/decision/source snapshot. Derive row IDs, tier, pin membership, and display age at resource boundaries. Use one shared bounded traversal:
+
+```go
+type navigationTraversal struct {
+    nodes int
+    bytes int
+    depth int
+    truncated bool
+}
+
+func (p *navigationProjector) projectNodes(rows []hubcore.TreeNode, limit int) ([]hubapi.NavigationSessionSummary, int) {
+    // Stop before every row/branch that would exceed count, depth, or byte bounds.
+}
+```
+
+Do not call `Roster.Find`, SQLite stores, project resolution, or `time.Now` from recursive row projection.
+
+- [ ] **Step 4: Run projection tests and legacy agreement tests**
+
+Run:
+
+```bash
+go test ./cmd/evener-hub -run 'TestNavigation(Project|Section|Manifest|Location|Bounds|Projection)' -count=1
+go test ./cmd/evener-hub/internal/hubcore -run 'Test.*Tree' -count=1
+```
+
+Expected: PASS; current tree ordering/lineage tests remain green.
+
+- [ ] **Step 5: Commit the projector**
+
+```bash
+git add cmd/evener-hub/navigation_projection.go cmd/evener-hub/navigation_projection_test.go cmd/evener-hub/web_api_tree.go cmd/evener-hub/internal/hubcore/tree.go cmd/evener-hub/internal/hubcore/tree_test.go
+git commit -m "feat(hub): project bounded navigation resources"
+```
+
+### Task 4: Add the Single-Flight Representation Cache
+
+**Files:**
+- Create: `cmd/evener-hub/navigation_cache.go`
+- Create: `cmd/evener-hub/navigation_cache_test.go`
+- Modify: `go.mod`
+- Modify: `go.sum`
+
+**Interfaces:**
+- Produces: `navigationResourceKey` with canonical kind/key/tier/offset/limit identity.
+- Produces: `navigationRepresentation` with object, JSON, gzip, weak ETag, generation, revision, and size estimate.
+- Produces: `navigationRepresentationCache.Get(ctx, key, build)` and `Stats()`.
+
+- [ ] **Step 1: Write cache identity, single-flight, and eviction tests**
+
+```go
+func TestNavigationCacheConcurrentMissBuildsOnce(t *testing.T) {
+    cache := newNavigationRepresentationCache(256, 64<<20)
+    var calls atomic.Int32
+    build := func(context.Context) (navigationRepresentation, error) {
+        calls.Add(1)
+        return representationFixture("project:p1", 4), nil
+    }
+    runConcurrent(t, 20, func() { _, _ = cache.Get(t.Context(), projectKey("p1"), build) })
+    if got := calls.Load(); got != 1 { t.Fatalf("build calls=%d, want 1", got) }
+}
+```
+
+Test page identity changes with tier/offset/limit and encoding does not collide. Test 256-entry and 64 MiB LRU eviction.
+
+- [ ] **Step 2: Run cache tests and verify failure**
+
+Run: `go test ./cmd/evener-hub -run TestNavigationCache -count=1`
+
+Expected: compile FAIL because cache types are undefined.
+
+- [ ] **Step 3: Implement cache with `singleflight.Group` and LRU**
+
+Use `container/list` for LRU and the existing `golang.org/x/sync/singleflight` dependency. Build JSON and gzip once. Weak ETag format is:
+
+```go
+func navigationETag(key navigationResourceKey, generation string, revision uint64) string {
+    return fmt.Sprintf(`W/"nav-%s-%x-%d"`, generation, sha256.Sum256([]byte(key.String())), revision)
+}
+```
+
+Keep exact keys out of metrics and logs.
+
+- [ ] **Step 4: Run cache tests and race test**
+
+Run:
+
+```bash
+go test ./cmd/evener-hub -run TestNavigationCache -count=1
+go test -race ./cmd/evener-hub -run TestNavigationCache -count=1
+```
+
+Expected: PASS with one build under concurrent miss and bounded memory.
+
+- [ ] **Step 5: Commit the cache**
+
+```bash
+git add cmd/evener-hub/navigation_cache.go cmd/evener-hub/navigation_cache_test.go go.mod go.sum
+git commit -m "feat(hub): cache encoded navigation resources"
+```
+
+### Task 5: Implement `NavigationService` Revisions and Coherent Snapshots
+
+**Files:**
+- Create: `cmd/evener-hub/navigation_service.go`
+- Create: `cmd/evener-hub/navigation_service_test.go`
+- Modify: `cmd/evener-hub/web.go`
+- Modify: `cmd/evener-hub/internal/hubcore/config.go`
+- Modify: `cmd/evener-hub/internal/hubcore/treecache.go`
+
+**Interfaces:**
+- Consumes: Tasks 3–4 projector and cache.
+- Produces: `newNavigationService(navigationServiceConfig) *NavigationService`.
+- Produces: `Representation(ctx, navigationResourceKey) (navigationRepresentation, error)`.
+- Produces: `Invalidate(navigationChangeHint)` for source-driven refresh and `Refresh(ctx, navigationChangeHint) (hubapi.NavigationMutation, error)` for mutation paths that must return committed targets.
+- Produces: `Capability() appwire.NavigationCapability`, `Start(ctx)`, and `Stats()`.
+
+- [ ] **Step 1: Write service revision/dependency/coherence tests**
+
+Test no-op stability, exact dependent targets, `all_loaded_projects`, one core build for many resource misses, concurrent refresh, invalidation during build, 503 under context cancellation, last-good retention, generation isolation, and the next 24h/14d scheduler boundary.
+
+```go
+func TestNavigationServiceRejectsSnapshotInvalidatedDuringBuild(t *testing.T) {
+    source := newBlockingNavigationSource()
+    service := newTestNavigationService(source)
+    done := make(chan navigationRepresentation, 1)
+    go func() { rep, _ := service.Representation(t.Context(), manifestKey()); done <- rep }()
+    source.WaitForCapture(t)
+    service.Invalidate(navigationChangeHint{Projects: []string{"p1"}})
+    source.Release()
+    rep := <-done
+    if rep.Revision != service.CurrentRevision(manifestKey().Semantic()) {
+        t.Fatalf("published stale revision %d", rep.Revision)
+    }
+}
+```
+
+- [ ] **Step 2: Run service tests and verify failure**
+
+Run: `go test ./cmd/evener-hub -run TestNavigationService -count=1`
+
+Expected: compile FAIL because service APIs are undefined.
+
+- [ ] **Step 3: Implement per-server service ownership**
+
+Add `navigation *NavigationService` to `WebServer`; construct it after sources and before `appRPC`. The service captures source revisions, builds one core snapshot, rereads revisions before publish, and retries until context completion. Store resource fingerprints and increment only semantically changed resources. Start one next-boundary timer from main lifecycle context.
+
+- [ ] **Step 4: Run service tests, race tests, and old cache tests**
+
+Run:
+
+```bash
+go test ./cmd/evener-hub -run 'TestNavigationService|TestWeb.*TreeCache' -count=1
+go test -race ./cmd/evener-hub -run TestNavigationService -count=1
+go test ./cmd/evener-hub/internal/hubcore -run TestTreeCache -count=1
+```
+
+Expected: PASS. Legacy cache tests stay green until adapter retirement.
+
+- [ ] **Step 5: Commit the service**
+
+```bash
+git add cmd/evener-hub/navigation_service.go cmd/evener-hub/navigation_service_test.go cmd/evener-hub/web.go cmd/evener-hub/internal/hubcore/config.go cmd/evener-hub/internal/hubcore/treecache.go
+git commit -m "feat(hub): own revisioned navigation snapshots"
+```
+
+### Task 6: Serve Conditional Bounded Navigation HTTP Resources
+
+**Files:**
+- Create: `cmd/evener-hub/web_api_navigation.go`
+- Create: `cmd/evener-hub/web_api_navigation_test.go`
+- Create: `cmd/evener-hub/navigation_metrics.go`
+- Modify: `cmd/evener-hub/web.go`
+- Modify: `cmd/evener-hub/web_api.go`
+- Modify: `cmd/evener-hub/http_recorder.go`
+- Test: `cmd/evener-hub/http_recorder_test.go`
+
+**Interfaces:**
+- Consumes: `NavigationService.Representation`.
+- Produces: manifest, live/needs-you/pin, pin catalog, project catalog, project root/page, and session-location handlers.
+- Produces: `writeNavigationRepresentation(w, r, rep)`.
+
+- [ ] **Step 1: Write table-driven route/header/security tests**
+
+Test methods, limit/offset/tier validation, exact one-time path decoding, noncanonical encoding, absent keys, 50/100 limits, source cap, ETag/304, gzip, `Vary`, `Content-Length`, generation/revision headers, auth isolation, and redacted metrics.
+
+```go
+func TestNavigationManifestConditionalGzip(t *testing.T) {
+    web := newNavigationHTTPTestServer(t)
+    first := requestNavigation(t, web, "/api/navigation", "gzip", "")
+    if first.Header().Get("Content-Encoding") != "gzip" { t.Fatal("missing gzip") }
+    second := requestNavigation(t, web, "/api/navigation", "gzip", first.Header().Get("ETag"))
+    if second.Code != http.StatusNotModified || second.Body.Len() != 0 {
+        t.Fatalf("conditional response=%d bytes=%d", second.Code, second.Body.Len())
+    }
+}
+```
+
+- [ ] **Step 2: Run HTTP tests and verify failure**
+
+Run: `go test ./cmd/evener-hub -run 'TestNavigation.*(HTTP|Route|Conditional|Auth|Redact)' -count=1`
+
+Expected: FAIL with 404 or undefined handler helpers.
+
+- [ ] **Step 3: Implement routes and response writer**
+
+Register `/api/navigation` and `/api/navigation/` under the existing auth/CSP/recorder stack. Parse canonical identities into `navigationResourceKey`. Never pass decoded values to filesystem APIs. Write cached identity or gzip bytes directly and emit only route-class metrics.
+
+- [ ] **Step 4: Run HTTP, recorder, and security tests**
+
+Run:
+
+```bash
+go test ./cmd/evener-hub -run 'TestNavigation|TestHTTPRequestRecorder' -count=1
+go test -race ./cmd/evener-hub -run 'TestNavigation.*(HTTP|Auth)' -count=1
+```
+
+Expected: PASS; raw navigation key/ref values are absent from recorder/metric assertions.
+
+- [ ] **Step 5: Commit HTTP resources**
+
+```bash
+git add cmd/evener-hub/web_api_navigation.go cmd/evener-hub/web_api_navigation_test.go cmd/evener-hub/navigation_metrics.go cmd/evener-hub/web.go cmd/evener-hub/web_api.go cmd/evener-hub/http_recorder.go cmd/evener-hub/http_recorder_test.go
+git commit -m "feat(hub): serve conditional navigation resources"
+```
+
+### Task 7: Wire Typed Invalidation and Mutation Convergence
+
+**Files:**
+- Modify: `cmd/evener-hub/navigation_service.go`
+- Modify: `cmd/evener-hub/main.go`
+- Modify: `cmd/evener-hub/main_background.go`
+- Modify: `cmd/evener-hub/web_api_tree.go`
+- Modify: `cmd/evener-hub/web_api_archive.go`
+- Modify: `cmd/evener-hub/web_api_favorite.go`
+- Modify: `cmd/evener-hub/web_api_pin_section.go`
+- Modify: `cmd/evener-hub/web_api_rename.go`
+- Modify: `cmd/evener-hub/web_api_project_delete.go`
+- Modify: `cmd/evener-hub/web_api_session_delete.go`
+- Modify: `cmd/evener-hub/internal/hubcore/pin_section.go`
+- Modify: `cmd/evener-hub/internal/hubcore/remotecache.go`
+- Tests: matching `*_test.go` files for each producer/mutation.
+
+**Interfaces:**
+- Consumes: typed AppWire targets and `NavigationService.Refresh`.
+- Produces: one content-gated `evener/navigation/invalidated` event per changed refresh.
+- Produces: hub-owned REST mutation responses with `navigation` metadata.
+
+- [ ] **Step 1: Write producer and duplicate-prevention tests**
+
+Prove no-op roster/past/remote/store refresh emits no event, one real change emits one ordered event, unknown project scope emits `all_loaded_projects`, and a REST mutation returns the same target revisions later broadcast.
+
+```go
+func TestArchiveMutationReturnsAndBroadcastsSameNavigationTargets(t *testing.T) {
+    web, client := newNavigationMutationServer(t)
+    response := postArchive(t, web, "session", "local:s1", true)
+    event := readNavigationInvalidation(t, client)
+    if diff := cmp.Diff(response.Navigation.Targets, event.Targets); diff != "" {
+        t.Fatalf("targets mismatch (-response +event):\n%s", diff)
+    }
+    assertNoSecondNavigationEvent(t, client)
+}
+```
+
+- [ ] **Step 2: Run producer/mutation tests and verify failure**
+
+Run: `go test ./cmd/evener-hub ./cmd/evener-hub/internal/hubcore -run 'Test.*Navigation.*(Invalidate|Mutation|NoOp|Remote|Pin)' -count=1`
+
+Expected: FAIL because source hooks and mutation metadata are not wired.
+
+- [ ] **Step 3: Add content-gated producer hooks and publication**
+
+Compose existing roster/past/archive/favorite hooks with service refresh; add equivalent content-fingerprint hooks to pin sections and remote cache. Hub-owned REST mutations await `NavigationService.Refresh` and include its metadata. AppWire-routed daemon actions rely only on the hub invalidation event and do not synthesize navigation data in daemon result types.
+
+- [ ] **Step 4: Run all mutation and notification tests**
+
+Run:
+
+```bash
+go test ./cmd/evener-hub -run 'Test.*(Archive|Favorite|Pin|Rename|ProjectDelete|SessionDelete|Navigation)' -count=1
+go test ./cmd/evener-hub/internal/hubcore -run 'Test.*(Archive|Favorite|Pin|Remote|Roster|Past)' -count=1
+```
+
+Expected: PASS with legacy `evener/tree/changed` tests retained only for adapter compatibility.
+
+- [ ] **Step 5: Commit invalidation wiring**
+
+```bash
+git add cmd/evener-hub/navigation_service.go cmd/evener-hub/main.go cmd/evener-hub/main_background.go cmd/evener-hub/web_api_tree.go cmd/evener-hub/web_api_archive.go cmd/evener-hub/web_api_favorite.go cmd/evener-hub/web_api_pin_section.go cmd/evener-hub/web_api_rename.go cmd/evener-hub/web_api_project_delete.go cmd/evener-hub/web_api_session_delete.go cmd/evener-hub/web_api_archive_test.go cmd/evener-hub/web_api_favorite_test.go cmd/evener-hub/web_api_pin_section_test.go cmd/evener-hub/web_api_rename_test.go cmd/evener-hub/web_api_project_delete_test.go cmd/evener-hub/web_api_session_delete_test.go cmd/evener-hub/navigation_service_test.go cmd/evener-hub/internal/hubcore/pin_section.go cmd/evener-hub/internal/hubcore/pin_section_test.go cmd/evener-hub/internal/hubcore/remotecache.go cmd/evener-hub/internal/hubcore/remotecache_test.go
+git commit -m "feat(hub): publish scoped navigation invalidations"
+```
+
+### Task 8: Add Hub API Clients and the Thin Legacy Adapter
+
+**Files:**
+- Modify: `hubapi/client.go`
+- Modify: `hubapi/client_test.go`
+- Modify: `cmd/evener-hub/web_api_tree.go`
+- Modify: `cmd/evener-hub/web_api_tree_test.go`
+- Modify: `cmd/evener-hub/internal/hubcore/treecache.go`
+- Test: `cmd/evener-hub/web_api_tree_lastgood_test.go`
+
+**Interfaces:**
+- Produces: `Client.NavigationManifest`, `NavigationSection`, `NavigationPinSections`, `NavigationCatalog`, `NavigationProject`, `NavigationProjectPage`, `NavigationSessionLocation`.
+- Produces: conditional request result `{NotModified bool, ETag string, Value T}`.
+- Keeps: `Client.Tree` and `/api/tree` as deprecated compatibility adapters over `NavigationService`.
+
+- [ ] **Step 1: Write client and adapter tests**
+
+Test URL encoding, conditional headers, 304, typed errors, and prove repeated `/api/tree` adapter calls do not invoke legacy snapshot/build/project-resolution seams.
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+Run: `go test ./hubapi ./cmd/evener-hub -run 'Test.*NavigationClient|TestAPITree.*Adapter' -count=1`
+
+Expected: compile FAIL because client methods and adapter assertions are missing.
+
+- [ ] **Step 3: Implement conditional client helper and adapter**
+
+Add a generic private `getConditional` helper and typed methods. Rewrite `handleAPITree` to project the legacy shape from the current immutable service snapshot and cache the encoded legacy representation by navigation generation/revision. Mark `Client.Tree` deprecated in its doc comment.
+
+- [ ] **Step 4: Run client and legacy behavior suites**
+
+Run:
+
+```bash
+go test ./hubapi -count=1
+go test ./cmd/evener-hub -run 'Test.*(APITree|Navigation)' -count=1
+```
+
+Expected: PASS; legacy output semantics remain, but no request-time metadata scan/build occurs on cache hit.
+
+- [ ] **Step 5: Commit client and adapter**
+
+```bash
+git add hubapi/client.go hubapi/client_test.go cmd/evener-hub/web_api_tree.go cmd/evener-hub/web_api_tree_test.go cmd/evener-hub/web_api_tree_lastgood_test.go cmd/evener-hub/internal/hubcore/treecache.go
+git commit -m "feat(hubapi): add navigation resource clients"
+```
+
+### Task 9: Implement the Frontend Resource Revalidator
+
+**Files:**
+- Create: `cmd/evener-hub/frontend/src/stores/navigation/types.ts`
+- Create: `cmd/evener-hub/frontend/src/stores/navigation/revalidator.ts`
+- Create: `cmd/evener-hub/frontend/src/stores/navigation/revalidator.test.ts`
+- Modify: `cmd/evener-hub/frontend/src/protocol/testing/notifications.ts`
+
+**Interfaces:**
+- Consumes: generated navigation wire and invalidation types.
+- Produces: `ResourceKey`, `ResourceState<T>`, `NavigationRevalidator`.
+- Produces: `invalidate(target)`, `force(keys)`, `load(key, request)`, `resetGeneration(generationID)`.
+
+- [ ] **Step 1: Write fake-fetch revalidator tests**
+
+Cover one in-flight request, target revision raised mid-flight, one trailing request, newer response satisfying target, abort, stale discard, 304, `all_loaded_projects`, sequence-gap force token, and generation reset.
+
+```ts
+test("an invalidation during a request causes at most one trailing request", async () => {
+  const harness = revalidatorHarness();
+  const first = harness.load(projectRootKey("p1"));
+  harness.invalidate({ kind: "project", projectKey: "p1", revision: 2 });
+  harness.resolveNext(resourceResponse(1));
+  await first;
+  expect(harness.requests()).toHaveLength(2);
+  harness.resolveNext(resourceResponse(2));
+  await harness.settled();
+  expect(harness.state(projectRootKey("p1")).revision).toBe(2);
+});
+```
+
+- [ ] **Step 2: Run the test and verify failure**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/stores/navigation/revalidator.test.ts --maxWorkers=1`
+
+Expected: FAIL because modules do not exist.
+
+- [ ] **Step 3: Implement the generic revalidator**
+
+Use `AbortController`, ETag storage, `targetRevision`, and `forceToken`. Never set resource data to null on refresh error. Treat advertised capability protocol errors as errors; do not fall back.
+
+- [ ] **Step 4: Format and run focused tests**
+
+Run:
+
+```bash
+cd cmd/evener-hub/frontend
+npx biome check --write src/stores/navigation src/protocol/testing/notifications.ts
+npx vitest run src/stores/navigation/revalidator.test.ts --maxWorkers=1
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the revalidator**
+
+```bash
+git add cmd/evener-hub/frontend/src/stores/navigation/types.ts cmd/evener-hub/frontend/src/stores/navigation/revalidator.ts cmd/evener-hub/frontend/src/stores/navigation/revalidator.test.ts cmd/evener-hub/frontend/src/protocol/testing/notifications.ts
+git commit -m "feat(web): add navigation resource revalidator"
+```
+
+### Task 10: Implement the Frontend Navigation Store and Hydration
+
+**Files:**
+- Create: `cmd/evener-hub/frontend/src/stores/navigation/store.ts`
+- Create: `cmd/evener-hub/frontend/src/stores/navigation/store.test.ts`
+- Create: `cmd/evener-hub/frontend/src/stores/navigation/selectors.ts`
+- Create: `cmd/evener-hub/frontend/src/stores/navigation/testing.ts`
+- Modify: `cmd/evener-hub/frontend/src/App.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/notifications/index.ts`
+- Modify: `cmd/evener-hub/frontend/src/notifications/index.test.ts`
+
+**Interfaces:**
+- Consumes: Task 9 revalidator.
+- Produces: `navigationStore`, `useNavigationStore`, `initNavigation(client)`, project/section/catalog/page loaders, location lookup, and reset helper.
+- Produces: selectors for loaded global rows, project summaries/resources, attention summary, and session lookup.
+
+- [ ] **Step 1: Write store boot/reconnect/failure tests**
+
+Test capability absence fallback, capability version 1, manifest → first resources, concurrency four, empty-section skip, saved expansion hydration, no idle requests, typed invalidation, sequence gap, reconnect, 404 catalog recovery, and last-good errors.
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/stores/navigation/store.test.ts src/notifications/index.test.ts --maxWorkers=1`
+
+Expected: FAIL because store/init functions are undefined.
+
+- [ ] **Step 3: Implement store and notification ownership**
+
+Initialize from `InitializeResponse.navigation`. Fetch manifest first, then bounded visible resources under a four-request semaphore. Subscribe only to `evener/navigation/invalidated` for navigation. Keep `evener/attention/changed` in the dedicated alert state without navigation fetches. Capability absence calls the existing legacy store only during the migration release.
+
+- [ ] **Step 4: Format and run store/App tests**
+
+Run:
+
+```bash
+cd cmd/evener-hub/frontend
+npx biome check --write src/stores/navigation src/notifications/index.ts src/notifications/index.test.ts src/App.test.tsx
+npx vitest run src/stores/navigation/store.test.ts src/notifications/index.test.ts src/App.test.tsx --maxWorkers=2
+npm run typecheck
+```
+
+Expected: PASS; App test records no unexpected `/api/tree` on a version-1 server.
+
+- [ ] **Step 5: Commit the store**
+
+```bash
+git add cmd/evener-hub/frontend/src/stores/navigation/store.ts cmd/evener-hub/frontend/src/stores/navigation/store.test.ts cmd/evener-hub/frontend/src/stores/navigation/selectors.ts cmd/evener-hub/frontend/src/stores/navigation/testing.ts cmd/evener-hub/frontend/src/App.test.tsx cmd/evener-hub/frontend/src/notifications/index.ts cmd/evener-hub/frontend/src/notifications/index.test.ts
+git commit -m "feat(web): hydrate scoped navigation resources"
+```
+
+### Task 11: Migrate the Rail to Resource-Local Data
+
+**Files:**
+- Modify: `cmd/evener-hub/frontend/src/shell/rail/Rail.tsx`
+- Modify: `cmd/evener-hub/frontend/src/shell/rail/Rail.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/shell/rail/railNodes.ts`
+- Modify: `cmd/evener-hub/frontend/src/shell/rail/railNodes.test.ts`
+- Modify: `cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx`
+- Modify: `cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/shell/rail/railPending.ts`
+- Modify: `cmd/evener-hub/frontend/src/shell/rail/railPending.test.ts`
+- Modify: `cmd/evener-hub/frontend/src/shell/rail/railController.ts`
+- Test: `cmd/evener-hub/frontend/src/shell/rail/railController.test.ts`
+
+**Interfaces:**
+- Consumes: Task 10 selectors/loaders.
+- Produces: pure `NavigationRailModel` consumed by `railNodes`.
+- Preserves: expansion persistence, overflow rows, optimistic mutations, row/menu behavior, and rendering CSS.
+
+- [ ] **Step 1: Rewrite pure projection tests first**
+
+Express fixtures as manifest + section/catalog/project resources. Prove Live, pins, project tiers, archived/test groups, expansion, bounded page overflow, and stale project rows match current visible semantics.
+
+- [ ] **Step 2: Run rail projection/component tests and verify failure**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/shell/rail/railNodes.test.ts src/shell/rail/Rail.test.tsx --maxWorkers=2`
+
+Expected: type/test FAIL because rail still consumes `TreeResponse`.
+
+- [ ] **Step 3: Implement resource-backed rail and mutation convergence**
+
+Replace `treeStore` selectors with `navigationStore` selectors. Project expansion loads one project root; overflow loads one canonical page. Mutation success feeds returned navigation targets to the store, removes optimistic state after target satisfaction, and never calls a whole-tree refresh. AppWire-routed actions wait for invalidation only.
+
+- [ ] **Step 4: Format and run the complete rail suite**
+
+Run:
+
+```bash
+cd cmd/evener-hub/frontend
+npx biome check --write src/shell/rail
+npx vitest run src/shell/rail --maxWorkers=2
+npm run typecheck
+```
+
+Expected: PASS with no CSS changes unless a failing browser/geometry test requires one.
+
+- [ ] **Step 5: Commit the rail migration**
+
+```bash
+git add cmd/evener-hub/frontend/src/shell/rail/Rail.tsx cmd/evener-hub/frontend/src/shell/rail/Rail.test.tsx cmd/evener-hub/frontend/src/shell/rail/railNodes.ts cmd/evener-hub/frontend/src/shell/rail/railNodes.test.ts cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx cmd/evener-hub/frontend/src/shell/rail/railPending.ts cmd/evener-hub/frontend/src/shell/rail/railPending.test.ts cmd/evener-hub/frontend/src/shell/rail/railController.ts cmd/evener-hub/frontend/src/shell/rail/railController.test.ts
+git commit -m "feat(web): render rail from navigation resources"
+```
+
+### Task 12: Migrate Deep Links, Menus, Titles, and Attention
+
+**Files:**
+- Modify: `cmd/evener-hub/frontend/src/shell/AppShell.tsx`
+- Modify: `cmd/evener-hub/frontend/src/shell/AppShell.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.edge.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/threadTitle.ts`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/threadTitle.test.ts`
+- Modify: `cmd/evener-hub/frontend/src/notifications/attention.ts`
+- Modify: `cmd/evener-hub/frontend/src/notifications/attention.test.ts`
+- Modify: `cmd/evener-hub/frontend/src/notifications/title.ts`
+- Modify: `cmd/evener-hub/frontend/src/notifications/title.test.ts`
+- Modify: `cmd/evener-hub/frontend/src/notifications/favicon.ts`
+- Modify: `cmd/evener-hub/frontend/src/notifications/favicon.test.ts`
+- Modify: `cmd/evener-hub/frontend/src/shell/DockHost.tsx`
+- Modify: `cmd/evener-hub/frontend/src/shell/DockHost.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/Session.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/Session.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/welcome/Welcome.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/welcome/Welcome.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/shell/palette/CommandPalette.tsx`
+- Modify: `cmd/evener-hub/frontend/src/shell/palette/CommandPalette.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/shell/rail/needsYouCycle.ts`
+- Modify: `cmd/evener-hub/frontend/src/shell/rail/needsYouCycle.test.ts`
+- Modify: `cmd/evener-hub/frontend/src/shell/sessionMenu/SessionMenu.tsx`
+- Modify: `cmd/evener-hub/frontend/src/shell/sessionMenu/SessionMenu.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/shell/mobile/TreeDrawer.tsx`
+- Test: `cmd/evener-hub/frontend/src/shell/mobile/TreeDrawer.test.tsx`
+
+**Interfaces:**
+- Consumes: `NavigationSessionLocation` and Task 10 selectors.
+- Removes: project-tree ancestry scans and direct `findSessionNode` dependency.
+- Preserves: pane placement, needs-you cycling, menu eligibility/state, title fallback, and alert edge-fire semantics.
+
+- [ ] **Step 1: Write missing-location and collapsed-project tests**
+
+Prove a deep-linked child opens under its top-level owner without loading all projects; SessionChrome gets tier/pin/session summary from location; title falls back to location summary; attention notification updates counts without any navigation fetch.
+
+- [ ] **Step 2: Run focused consumer tests and verify failure**
+
+Run:
+
+```bash
+cd cmd/evener-hub/frontend
+npx vitest run src/shell/AppShell.test.tsx src/panes/session/chrome/SessionChrome.test.tsx src/notifications/attention.test.ts src/notifications/title.test.ts --maxWorkers=2
+```
+
+Expected: FAIL because consumers still scan `TreeResponse`.
+
+- [ ] **Step 3: Replace scans with location/resource selectors**
+
+Use the location endpoint on route/session demand; cache successful locations by generation/revision. Needs-you cycling, the command palette, Welcome, rail/mobile badges, and favicon/title state read bounded navigation resources. Title and menu code prefer live thread data, then location/session summary. Do not trigger project expansion solely for a title or menu.
+
+- [ ] **Step 4: Format and run shell/notification suites**
+
+Run:
+
+```bash
+cd cmd/evener-hub/frontend
+npx biome check --write src/shell/AppShell.tsx src/panes/session/chrome src/panes/session/threadTitle.ts src/notifications src/shell/mobile
+npx vitest run src/shell/AppShell.test.tsx src/shell/DockHost.test.tsx src/panes/session/chrome src/panes/session/Session.test.tsx src/panes/session/threadTitle.test.ts src/panes/welcome src/notifications src/shell/palette/CommandPalette.test.tsx src/shell/rail/needsYouCycle.test.ts src/shell/sessionMenu/SessionMenu.test.tsx src/shell/mobile/TreeDrawer.test.tsx --maxWorkers=2
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit secondary consumer migration**
+
+```bash
+git add cmd/evener-hub/frontend/src/shell/AppShell.tsx cmd/evener-hub/frontend/src/shell/AppShell.test.tsx cmd/evener-hub/frontend/src/shell/DockHost.tsx cmd/evener-hub/frontend/src/shell/DockHost.test.tsx cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.tsx cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.test.tsx cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.edge.test.tsx cmd/evener-hub/frontend/src/panes/session/Session.tsx cmd/evener-hub/frontend/src/panes/session/Session.test.tsx cmd/evener-hub/frontend/src/panes/session/threadTitle.ts cmd/evener-hub/frontend/src/panes/session/threadTitle.test.ts cmd/evener-hub/frontend/src/panes/welcome/Welcome.tsx cmd/evener-hub/frontend/src/panes/welcome/Welcome.test.tsx cmd/evener-hub/frontend/src/notifications/attention.ts cmd/evener-hub/frontend/src/notifications/attention.test.ts cmd/evener-hub/frontend/src/notifications/title.ts cmd/evener-hub/frontend/src/notifications/title.test.ts cmd/evener-hub/frontend/src/notifications/favicon.ts cmd/evener-hub/frontend/src/notifications/favicon.test.ts cmd/evener-hub/frontend/src/shell/palette/CommandPalette.tsx cmd/evener-hub/frontend/src/shell/palette/CommandPalette.test.tsx cmd/evener-hub/frontend/src/shell/rail/needsYouCycle.ts cmd/evener-hub/frontend/src/shell/rail/needsYouCycle.test.ts cmd/evener-hub/frontend/src/shell/sessionMenu/SessionMenu.tsx cmd/evener-hub/frontend/src/shell/sessionMenu/SessionMenu.test.tsx cmd/evener-hub/frontend/src/shell/mobile/TreeDrawer.tsx cmd/evener-hub/frontend/src/shell/mobile/TreeDrawer.test.tsx
+git commit -m "feat(web): use explicit navigation session locations"
+```
+
+### Task 13: Prove Integration, Observability, and Performance Budgets
+
+**Files:**
+- Modify: `cmd/evener-hub/navigation_benchmark_test.go`
+- Modify: `cmd/evener-hub/navigation_metrics.go`
+- Create: `cmd/evener-hub/navigation_integration_test.go`
+- Modify: `cmd/evener-hub/frontend/src/dev/shellguard-entry.tsx`
+- Modify: `test/scenarios/sidebar-expand-survives-live-resync.md`
+- Modify: `test/scenarios/sidebar-archived-testruns-reachability.md`
+- Modify: `test/scenarios/local-sidebar-url-stability.md`
+- Modify: `test/scenarios/sidebar-project-delete-full-cycle.md`
+- Modify: `test/scenarios/sidebar-rename-live-and-ended.md`
+- Modify: `test/scenarios/attention-needs-you-end-to-end.md`
+- Test: `cmd/evener-hub/frontend/src/App.test.tsx`
+
+**Interfaces:**
+- Consumes: complete server/client resource flow.
+- Produces: deterministic mandatory/expanded hydration measurements and diagnostics counters.
+
+- [ ] **Step 1: Add failing end-to-end request-count and performance assertions**
+
+Use a scripted source and real AppWire/HTTP paths. Assert idle zero requests; one status change affects only named loaded representations; mutation/event dedupe; reconnect/gap conditional revalidation; one build/resolution pass; and fixed budgets (15% uncompressed mandatory, 10% gzip mandatory, 35% gzip four-project expansion, 20% legacy `B/op`).
+
+- [ ] **Step 2: Run integration/benchmark tests and inspect failures**
+
+Run:
+
+```bash
+go test ./cmd/evener-hub -run TestNavigationIntegration -count=1
+go test ./cmd/evener-hub -run TestNavigationPerformanceBudgets -count=1
+go test ./cmd/evener-hub -run '^$' -bench 'Benchmark(Legacy|Navigation)' -benchtime=20x -count=5 -benchmem
+```
+
+Expected before final tuning: tests identify exact over-budget resources or duplicate request/build counts; do not loosen thresholds.
+
+- [ ] **Step 3: Fix root causes and expose redacted diagnostics**
+
+Use cached bytes for every hit, remove any accidental project/global refresh, and ensure diagnostics aggregate only resource class/status/bytes/duration/counter values. Update browser scenario assertions to inspect request counts and preserved behavior.
+
+- [ ] **Step 4: Run integration, frontend, and browser guards**
+
+Run:
+
+```bash
+go test ./cmd/evener-hub -run 'TestNavigation(Integration|Performance|Metrics)' -count=1
+cd cmd/evener-hub/frontend
+npx biome check --write src/dev/shellguard-entry.tsx src
+npm test
+cd ../../../..
+make test-web-browser
+```
+
+Expected: PASS. If Chrome is unavailable, report the exact prerequisite; do not claim the browser gate passed.
+
+- [ ] **Step 5: Commit proof and diagnostics**
+
+```bash
+git add cmd/evener-hub/navigation_benchmark_test.go cmd/evener-hub/navigation_metrics.go cmd/evener-hub/navigation_integration_test.go cmd/evener-hub/frontend/src/dev/shellguard-entry.tsx test/scenarios/sidebar-expand-survives-live-resync.md test/scenarios/sidebar-archived-testruns-reachability.md test/scenarios/local-sidebar-url-stability.md test/scenarios/sidebar-project-delete-full-cycle.md test/scenarios/sidebar-rename-live-and-ended.md test/scenarios/attention-needs-you-end-to-end.md
+git commit -m "test: prove scoped navigation performance"
+```
+
+### Task 14: Isolate the Legacy Adapter and Run Final Gates
+
+**Files:**
+- Create: `cmd/evener-hub/frontend/src/stores/navigation/legacyAdapter.ts`
+- Create: `cmd/evener-hub/frontend/src/stores/navigation/legacyAdapter.test.ts`
+- Delete: `cmd/evener-hub/frontend/src/stores/tree.ts`
+- Delete or migrate: `cmd/evener-hub/frontend/src/stores/tree.test.ts`
+- Delete or migrate: `cmd/evener-hub/frontend/src/stores/tree.edge.test.ts`
+- Create: `cmd/evener-hub/frontend/src/stores/navigation/noLegacyImports.test.ts`
+- Modify: production/test files named by that static test until only `legacyAdapter.ts` references `/api/tree`.
+- Modify: `docs/superpowers/specs/2026-08-25-tree-transport-optimization-design.md` with measured results and migration-release adapter status.
+
+**Interfaces:**
+- Removes: frontend `TreeResponse` authority, `refreshGeneration`, `inflightRefresh`, 250 ms tree debounce, stale client tree callbacks, and direct `/api/tree` fetches on capability version 1.
+- Retains: one capability-absent `legacyAdapter.ts`, plus thin server `/api/tree` and `hubapi.Client.Tree` adapters for the declared migration release only.
+
+- [ ] **Step 1: Add a static legacy-reference gate**
+
+Add a filesystem test that permits `/api/tree` only in
+`stores/navigation/legacyAdapter.ts`, forbids production imports from
+`stores/tree`, and forbids `evener/tree/changed`/`REFRESH_NOTIFICATIONS` in the
+version-1 navigation path.
+
+- [ ] **Step 2: Run the static gate and verify failure**
+
+Run: `rg -n 'stores/tree|/api/tree|evener/tree/changed|REFRESH_NOTIFICATIONS' cmd/evener-hub/frontend/src appwire cmd/evener-hub hubapi`
+
+Expected: current legacy store/imports appear and must be migrated or explicitly allowlisted.
+
+- [ ] **Step 3: Delete old frontend authority and migrate remaining tests/fixtures**
+
+Move reusable fixture builders to `stores/navigation/testing.ts`. Move only the
+one-shot legacy fetch/normalization needed for capability absence into
+`legacyAdapter.ts`; it owns no notification subscription, reconnect handler,
+timer, or global store. Remove the old store and refresh list. Run the static
+test repeatedly until it reports no legacy production import. Record the
+migration-release adapter and its explicit next-release removal gate in the
+spec results section.
+
+- [ ] **Step 4: Run formatting and canonical gates**
+
+Run in order:
+
+```bash
+cd cmd/evener-hub/frontend
+npx biome check --write src
+cd ../../../..
+make lint
+make vet
+make test
+make test-web-browser
+git diff --check
+```
+
+Expected: every command exits zero. A timeout, sandbox denial, or missing Chrome leaves that gate incomplete and must be reported exactly.
+
+- [ ] **Step 5: Review changed files and commit cleanup**
+
+```bash
+git status --short
+git diff --stat
+mapfile -t cleanup_paths < <(git diff --name-only --diff-filter=ACDMRT)
+printf '%s\n' "${cleanup_paths[@]}"
+for path in "${cleanup_paths[@]}"; do
+  case "$path" in
+    cmd/evener-hub/frontend/src/*|docs/superpowers/specs/2026-08-25-tree-transport-optimization-design.md) ;;
+    *) echo "unexpected cleanup path: $path" >&2; exit 1 ;;
+  esac
+done
+git add -- "${cleanup_paths[@]}"
+git commit -m "refactor(web): retire monolithic tree refreshes"
+```
+
+Verify the staged list contains only navigation implementation paths before committing. Do not stage unrelated workspace edits.
+
+## Post-Implementation Review and Delivery
+
+After every task, the subagent-driven executor must run a two-stage review:
+
+1. requirements/spec compliance for that task;
+2. code quality, race, security, and maintainability review.
+
+Fix Critical and Important findings before starting the next task. After Task 14, run `superpowers:verification-before-completion`, inspect the actual network/resource behavior against every acceptance criterion, and report:
+
+- commits created;
+- files changed;
+- focused and full gate results;
+- deterministic and live byte/request/allocation/build measurements;
+- adapter/fallback status and explicit removal release; and
+- any gate that could not run.

--- a/docs/superpowers/plans/2026-08-25-transcript-detail-configuration.md
+++ b/docs/superpowers/plans/2026-08-25-transcript-detail-configuration.md
@@ -1,0 +1,1205 @@
+# Unified Transcript Detail Configuration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Evener's fragmented transcript visibility controls with one five-level, Advanced-capable configuration that uses browser-local live views, hub-synced Desktop/Mobile defaults, and one production projector for every transcript surface and Settings preview.
+
+**Architecture:** A versioned AppWire contract and atomic hub store own synchronized defaults. A separate browser store owns local Desktop/Mobile active views and resolves local → hub → shipped precedence. A pure TypeScript projector converts the shared `ThreadModel` into stable visible entries; Session, read-only Transcript, and Settings previews render those entries through one `TranscriptBody`.
+
+**Tech Stack:** Go 1.26, AppWire JSON-RPC and code generation, afero-backed atomic state, TypeScript 6, React 19, Zustand 5, Vitest, Testing Library, CSS Modules, Popover, Sheet, RadioGroup, and headless-Chrome browser guards.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-transcript-detail-configuration-design.md`
+
+## Global Constraints
+
+- Read `docs/developing-evener/testing.md` before changing tests. Keep default tests deterministic and independent of provider credentials, network access, quota, current model behavior, ambient machine state, fixed sleeps, and polling races.
+- Use TDD for every task: add the smallest failing test, run it and confirm the expected failure, implement the minimum production behavior, then rerun the focused test.
+- Use a fresh `gpt-5.6-luna` implementation subagent for each task. After implementation, run separate specification-compliance and code-quality review gates before accepting the task.
+- Do not hand-edit `docs/appwire-protocol.md` or `cmd/evener-hub/frontend/src/protocol/types.gen.ts`; regenerate them with `go generate ./appwire` or `make generate`.
+- Preserve the pinned `evener.prefs.showCost` key and every legacy transcript boolean's exact `1`/`0` encoding during the compatibility release.
+- Mobile remains `(max-width: 899px)`. Do not add a second device breakpoint; use a container query only for narrow transcript chrome.
+- User/agent messages and critical rows are invariant. No regular or Custom configuration may hide questions, permission/escalation requests, active work, steering, warnings, denials, interrupted turns, failed turns, failed tools, non-zero hook failures, or recovery actions.
+- The live value is browser-local and layout-specific. It updates every local transcript, survives restart, synchronizes same-origin tabs, and never publishes to the hub.
+- Hub defaults are hub-scoped, layout-specific, revisioned, and durable. They sync to every paired client but do not create user/account identity.
+- Settings previews use fabricated data and the production projector. They never read `threadsStore`, call the network, show real transcript data, stream fake content, or create an inner scroll region.
+- Before frontend gates, run `npx biome check --write` on every touched file under `cmd/evener-hub/frontend/src/`.
+- Stage named paths only. Never use `git add .` or `git add -A`.
+
+---
+
+## File Structure
+
+### New Go files
+
+- `appwire/transcript_display.go` — wire config validation, strict patch decoding, shipped defaults, and conflict data.
+- `appwire/transcript_display_test.go` — protocol-domain tests for validation, strict decoding, defaults, and JSON shape.
+- `cmd/evener-hub/internal/hubcore/transcript_display_store.go` — mutex-protected, atomic, revisioned hub-default store.
+- `cmd/evener-hub/internal/hubcore/transcript_display_store_test.go` — default, persistence, revision, conflict, validation, and concurrency tests.
+- `cmd/evener-hub/internal/hubcore/transcript_display_store_write_test.go` — pre/post-rename durability fault tests.
+- `cmd/evener-hub/app_rpc_transcript_display.go` — GET/PATCH registration and successful-write notification.
+- `cmd/evener-hub/app_rpc_transcript_display_test.go` — typed and raw-wire RPC, two-client notification, conflict, and failure tests.
+
+### New frontend domain/store files
+
+- `cmd/evener-hub/frontend/src/transcriptDisplay/config.ts` — frontend domain unions, preset expansion, normalization, wire conversion, strict local codec, summary, and fingerprint.
+- `cmd/evener-hub/frontend/src/transcriptDisplay/config.test.ts` — exact vectors, Custom normalization, codec, precedence, and migration tests.
+- `cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts` — typed classification and projection to stable item, intent, and critical entries.
+- `cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts` — complete item/event matrix, invariants, ordering, grouping, and immutability.
+- `cmd/evener-hub/frontend/src/transcriptDisplay/renderContext.tsx` — effective config, metadata, surface, and disclosure-scope context for existing renderers.
+- `cmd/evener-hub/frontend/src/transcriptDisplay/previewFixture.ts` — deterministic fabricated `ThreadModel` used by Settings and the dev surface.
+- `cmd/evener-hub/frontend/src/stores/transcriptDisplay.ts` — local persistence, legacy migration/dual-write, same-origin synchronization, hub refresh/patch/notification, drafts, errors, and effective resolution.
+- `cmd/evener-hub/frontend/src/stores/transcriptDisplay.test.ts` — persistence, migration, synchronization, capability, reconnect, revision, and draft tests.
+
+### New frontend rendering/UI files
+
+- `cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx` — shared projected body for live, read-only, and preview surfaces.
+- `cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.test.tsx` — surface parity, regular/Custom levels, and preview behavior.
+- `cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptDetailControl.tsx` — compact live trigger, stepped radio control, Advanced editor, Popover/Sheet switching, and scope actions.
+- `cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptDetailControl.test.tsx` — keyboard, scope, Custom, Popover, Sheet, and reset tests.
+- `cmd/evener-hub/frontend/src/panes/session/transcript/transcriptDisplay.module.css` — toolbar, stepped track, Advanced groups, responsive container rules, and touch geometry.
+- `cmd/evener-hub/frontend/src/panes/session/transcript/flow/transcriptViewRegistry.ts` — pre-change capture and post-render restore coordination for all mounted transcripts.
+- `cmd/evener-hub/frontend/src/panes/session/transcript/flow/transcriptViewRegistry.test.ts` — multi-pane capture/restore/focus and lifecycle tests.
+- `cmd/evener-hub/frontend/src/panes/settings/sections/TranscriptDisplayCard.tsx` — one hub-default editor and production-backed example.
+- `cmd/evener-hub/frontend/src/panes/settings/sections/transcriptDisplayCard.module.css` — stacked card and non-scrolling preview layout.
+
+### Existing files with focused changes
+
+- `appwire/types.go`, `appwire/protocol.go`, `appwire/protocol_test.go` — methods, notification, feature bit, and typed wire payloads.
+- `docs/appwire-protocol.md`, `cmd/evener-hub/frontend/src/protocol/types.gen.ts` — generated outputs.
+- `cmd/evener-hub/internal/hubcore/config.go`, `cmd/evener-hub/main.go`, `cmd/evener-hub/web.go`, `cmd/evener-hub/app_rpc.go`, `cmd/evener-hub/app_rpc_test.go` — store injection, startup, capability, and handler registration.
+- `cmd/evener-hub/frontend/src/stores/connection.ts`, `cmd/evener-hub/frontend/src/shell/AppShell.tsx`, `cmd/evener-hub/frontend/src/shell/ConnectionBanner.tsx` and tests — retain handshake `FeatureSet` so older hubs produce an explicit unsupported state.
+- `cmd/evener-hub/frontend/src/stores/prefs.ts` and tests — export guarded legacy access/encoding adapters without changing existing keys.
+- `cmd/evener-hub/frontend/src/shell/useIsMobile.ts` and tests — one shared layout subscription usable before host remount.
+- `cmd/evener-hub/frontend/src/widgets/radiogroup/index.tsx` and tests — visible-label/accessibility-label split for the Full/Full detail stop.
+- `cmd/evener-hub/frontend/src/widgets/disclosure/disclosureStore.ts` and tests — explicit choice versus Full-entry baseline.
+- `cmd/evener-hub/frontend/src/panes/session/Session.tsx`, `session.module.css`, and tests — remove the two render trees and header selector; mount the shared body and local toolbar.
+- `cmd/evener-hub/frontend/src/panes/transcript/Transcript.tsx` and tests — preserve `job:` dispatch and replace duplicate turn rendering with the shared body.
+- `cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx`, `ToolCallItem.tsx`, `ToolCallCluster.tsx`, `types.ts`, `transcriptVisibility.ts`, message renderers, CSS, and focused tests — consume projection/context and preserve critical/disclosure rules.
+- `cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts` and tests — use config fingerprints and registry-driven external transitions.
+- `cmd/evener-hub/frontend/src/panes/settings/sections/transcript.tsx`, `transcript.module.css`, and tests — stacked Desktop/Mobile cards and hub-save behavior.
+- `cmd/evener-hub/frontend/src/panes/settings/sections/display.tsx` and tests — remove only estimated cost; retain Enter behavior.
+- `cmd/evener-hub/frontend/src/panes/settings/sections.ts` and tests — visible label `Transcript display`, stable route id `transcript`.
+- `cmd/evener-hub/frontend/src/dev/surface-sections/transcript.tsx` and tests — consume the shared deterministic preview fixture/body.
+- `cmd/evener-hub/frontend/src/panes/session/viewModes.ts` and tests — delete after their behavior moves into projector tests.
+- `cmd/evener-hub/frontend/src/dev/overflowharness-entry.tsx` and `cmd/evener-hub/frontend/scripts/overflowguard/run.mjs` — verify the live control and preview at representative widths.
+
+---
+
+### Task 1: Add the AppWire transcript-display contract
+
+**Files:**
+- Create: `appwire/transcript_display.go`
+- Create: `appwire/transcript_display_test.go`
+- Modify: `appwire/types.go`
+- Modify: `appwire/protocol.go`
+- Modify: `appwire/protocol_test.go`
+- Generate: `docs/appwire-protocol.md`
+- Generate: `cmd/evener-hub/frontend/src/protocol/types.gen.ts`
+
+**Interfaces:**
+- Produces wire methods `evener/settings/transcriptDisplay/get` and `evener/settings/transcriptDisplay/patch`.
+- Produces notification `evener/settings/transcriptDisplay/changed`.
+- Produces `FeatureSet.TranscriptDisplaySettings`.
+- Produces strict `DecodeTranscriptDisplayDefaultsPatchParams(json.RawMessage)` and `ValidateTranscriptDisplayConfig(TranscriptDisplayConfig) error` for Tasks 2 and 3.
+
+- [ ] **Step 1: Add failing protocol-domain tests**
+
+Create tests that pin the method/notification catalogs, feature JSON field, shipped defaults, exact preset/custom validation, unknown-field rejection, missing Custom boolean rejection, invalid enum/version rejection, and trailing-JSON rejection.
+
+```go
+func TestTranscriptDisplayShippedDefaults(t *testing.T) {
+    got := TranscriptDisplayShippedDefaults()
+    if got.Desktop.Config.Content.Level != TranscriptLevelTools || got.Mobile.Config.Content.Level != TranscriptLevelIntent {
+        t.Fatalf("defaults = %#v", got)
+    }
+    if got.Desktop.Revision != 0 || got.Mobile.Revision != 0 {
+        t.Fatalf("new revisions must be zero: %#v", got)
+    }
+}
+
+func TestDecodeTranscriptDisplayPatchRejectsIncompleteCustom(t *testing.T) {
+    raw := json.RawMessage(`{"layout":"desktop","expectedRevision":0,"config":{"version":1,"content":{"kind":"custom","custom":{"toolIntent":true}},"advanced":{"roundTimings":false,"tokenCounts":false,"estimatedCost":false,"systemEvents":false,"promptEvents":false,"hookExits":"none"}}}`)
+    if _, err := DecodeTranscriptDisplayDefaultsPatchParams(raw); err == nil {
+        t.Fatal("expected incomplete Custom vector to fail")
+    }
+}
+```
+
+- [ ] **Step 2: Run the focused tests and confirm the contract is absent**
+
+Run:
+
+```bash
+go test ./appwire -run 'TestTranscriptDisplay' -count=1
+```
+
+Expected: compile failure because the transcript-display types and functions do not exist.
+
+- [ ] **Step 3: Define wire constants and payload types**
+
+Add named layout, level, hook-detail, config, default, response, patch, changed-notification, and conflict-data types. Use camelCase JSON tags and non-omitempty Custom booleans.
+
+```go
+const (
+    MethodEvenerSettingsTranscriptDisplayGet   = "evener/settings/transcriptDisplay/get"
+    MethodEvenerSettingsTranscriptDisplayPatch = "evener/settings/transcriptDisplay/patch"
+    NotifyEvenerSettingsTranscriptDisplayChanged = "evener/settings/transcriptDisplay/changed"
+)
+
+type TranscriptDisplayDefaultsPatchParams struct {
+    Layout           TranscriptViewportClass `json:"layout"`
+    ExpectedRevision uint64                  `json:"expectedRevision"`
+    Config           TranscriptDisplayConfig `json:"config"`
+}
+
+type TranscriptDisplayDefault struct {
+    Revision uint64                  `json:"revision"`
+    Config   TranscriptDisplayConfig `json:"config"`
+}
+
+type TranscriptDisplayConflictData struct {
+    EvenerErrorInfo ErrorInfo               `json:"evenerErrorInfo"`
+    Layout          TranscriptViewportClass `json:"layout"`
+    Current         TranscriptDisplayDefault `json:"current"`
+}
+```
+
+Represent content with a discriminator plus nested Custom object so preset and Custom payloads cannot be confused:
+
+```go
+type TranscriptDisplayContent struct {
+    Kind   TranscriptContentKind          `json:"kind"`
+    Level  TranscriptLevel                `json:"level,omitempty"`
+    Custom *TranscriptDisplayCustomContent `json:"custom,omitempty"`
+}
+```
+
+- [ ] **Step 4: Implement strict decoding and validation**
+
+Use `json.Decoder.DisallowUnknownFields`, detect trailing values, inspect the raw nested Custom object for all four required boolean keys, and require exactly one content representation. Return `appwire.InvalidParams` at the RPC boundary; keep the validator itself as an ordinary error for store load validation.
+
+- [ ] **Step 5: Catalog the methods, global notification, and capability field**
+
+Add ScopeHub method specs and the global notification spec. Add `TranscriptDisplaySettings bool` to `FeatureSet`, but leave existing servers' zero value false. Task 3 advertises it only after both handlers are registered, so no intermediate commit claims support that does not exist.
+
+- [ ] **Step 6: Regenerate committed protocol outputs**
+
+Run:
+
+```bash
+go generate ./appwire
+```
+
+Expected: updates only `docs/appwire-protocol.md` and `cmd/evener-hub/frontend/src/protocol/types.gen.ts` for this contract.
+
+- [ ] **Step 7: Run protocol and generated-output tests**
+
+Run:
+
+```bash
+go test ./appwire ./internal/appwiredoc ./internal/appwirets -run 'TestTranscriptDisplay|TestGeneratedFileCurrent|TestCatalog' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the contract**
+
+```bash
+git add appwire/types.go appwire/protocol.go appwire/protocol_test.go appwire/transcript_display.go appwire/transcript_display_test.go docs/appwire-protocol.md cmd/evener-hub/frontend/src/protocol/types.gen.ts
+git commit -m "feat(appwire): define transcript display settings"
+```
+
+---
+
+### Task 2: Add the atomic hub-default store
+
+**Files:**
+- Create: `cmd/evener-hub/internal/hubcore/transcript_display_store.go`
+- Create: `cmd/evener-hub/internal/hubcore/transcript_display_store_test.go`
+- Create: `cmd/evener-hub/internal/hubcore/transcript_display_store_write_test.go`
+
+**Interfaces:**
+- Consumes Task 1's `appwire.TranscriptDisplayDefaultsResponse`, patch params/response, validator, shipped defaults, and conflict data.
+- Produces `NewTranscriptDisplayStore`, `Snapshot`, and `Patch` for Task 3.
+
+- [ ] **Step 1: Add failing store tests**
+
+Cover missing-root defaults, restart persistence, independent revisions, no-op patch behavior, stale same-layout conflict with canonical data, cross-layout concurrency, same-layout concurrency, malformed snapshot fallback/read-only error state, overflow, and strict snapshot decoding.
+
+```go
+func TestTranscriptDisplayStorePatchesLayoutsIndependently(t *testing.T) {
+    store, err := NewTranscriptDisplayStore(t.TempDir())
+    if err != nil { t.Fatal(err) }
+    desktop := appwire.TranscriptDisplayShippedDefaults().Desktop.Config
+    desktop.Content.Level = appwire.TranscriptLevelActivity
+    got, err := store.Patch(appwire.TranscriptDisplayDefaultsPatchParams{
+        Layout: appwire.TranscriptViewportDesktop, ExpectedRevision: 0, Config: desktop,
+    })
+    if err != nil { t.Fatal(err) }
+    if got.Revision != 1 || store.Snapshot().Mobile.Revision != 0 {
+        t.Fatalf("patch result=%#v snapshot=%#v", got, store.Snapshot())
+    }
+}
+```
+
+- [ ] **Step 2: Run the store tests and confirm the store is absent**
+
+```bash
+go test ./cmd/evener-hub/internal/hubcore -run 'TestTranscriptDisplayStore' -count=1
+```
+
+Expected: compile failure because `NewTranscriptDisplayStore` does not exist.
+
+- [ ] **Step 3: Implement the in-memory state and validation**
+
+Use one mutex and a snapshot with independent Desktop/Mobile records. `Snapshot` returns a deep value copy. `Patch` validates before locking, checks the selected revision under lock, rejects overflow, writes only the selected record, and increments only that revision.
+
+```go
+type TranscriptDisplayStore struct {
+    mu     sync.Mutex
+    fs     afero.Fs
+    root   string
+    state  transcriptDisplaySnapshot
+    loadErr error
+    faults transcriptDisplayStoreFaults
+}
+```
+
+A malformed durable file sets `loadErr`, serves shipped defaults, and rejects patches until repaired; it must not silently overwrite evidence. `NewTranscriptDisplayStore` returns the usable fallback store together with the load error, and callers must retain the non-nil store while reporting the error. Clean and missing snapshots return the store with a nil error.
+
+- [ ] **Step 4: Implement strict atomic persistence**
+
+Store `transcript-display/state.json` under `HubStateRoot`. Follow the deletion-store sequence: validate, marshal, mkdir `0700`, create a sibling temp file, write, `Sync`, close, rename, then sync the directory. Publish the in-memory state after rename even when post-rename directory sync reports an error.
+
+- [ ] **Step 5: Add pre/post-rename fault tests**
+
+Use afero plus `BeforeRename` and `AfterRename` hooks. Prove pre-rename failure preserves old memory/disk, while post-rename failure retains the new canonical memory value and reloads it from disk.
+
+- [ ] **Step 6: Run focused store tests including race detection**
+
+```bash
+go test -race ./cmd/evener-hub/internal/hubcore -run 'TestTranscriptDisplayStore' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the store**
+
+```bash
+git add cmd/evener-hub/internal/hubcore/transcript_display_store.go cmd/evener-hub/internal/hubcore/transcript_display_store_test.go cmd/evener-hub/internal/hubcore/transcript_display_store_write_test.go
+git commit -m "feat(hub): persist transcript display defaults"
+```
+
+---
+
+### Task 3: Expose hub-default GET, PATCH, and notifications
+
+**Files:**
+- Create: `cmd/evener-hub/app_rpc_transcript_display.go`
+- Create: `cmd/evener-hub/app_rpc_transcript_display_test.go`
+- Modify: `cmd/evener-hub/internal/hubcore/config.go`
+- Modify: `cmd/evener-hub/main.go`
+- Modify: `cmd/evener-hub/web.go`
+- Modify: `cmd/evener-hub/app_rpc.go`
+- Modify: `cmd/evener-hub/app_rpc_test.go`
+
+**Interfaces:**
+- Consumes Task 2's store and Task 1's strict raw decoder.
+- Produces live RPC methods and notification behavior consumed by the frontend store in Task 6.
+
+- [ ] **Step 1: Add failing RPC and registration tests**
+
+Use a real in-process AppWire server/client boundary. Cover GET defaults, PATCH persistence, raw unknown fields, stale conflict data, two-client BroadcastAll delivery, no notification on no-op/validation/conflict/durable failure, and the exact handler set.
+
+```go
+func TestHubRPCTranscriptDisplayPatchBroadcastsCanonicalValue(t *testing.T) {
+    store, err := hubcore.NewTranscriptDisplayStore(t.TempDir())
+    if err != nil { t.Fatal(err) }
+    hub := newHubRPCTestServer(t, hubcore.WebConfig{TranscriptDisplayStore: store})
+    defer hub.Close()
+
+    clientA := dialHubRPC(t, hub)
+    defer clientA.Close()
+    clientB := dialHubRPC(t, hub)
+    defer clientB.Close()
+    for _, client := range []*appwire.Client{clientA, clientB} {
+        if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+            t.Fatal(err)
+        }
+    }
+
+    config := appwire.TranscriptDisplayShippedDefaults().Desktop.Config
+    config.Content.Level = appwire.TranscriptLevelActivity
+    var result appwire.TranscriptDisplayDefaultsPatchResponse
+    if err := clientA.Request(context.Background(), appwire.MethodEvenerSettingsTranscriptDisplayPatch,
+        appwire.TranscriptDisplayDefaultsPatchParams{Layout: appwire.TranscriptViewportDesktop, ExpectedRevision: 0, Config: config}, &result); err != nil {
+        t.Fatal(err)
+    }
+    select {
+    case notification := <-clientB.Notifications():
+        if notification.Method != appwire.NotifyEvenerSettingsTranscriptDisplayChanged || result.Revision != 1 {
+            t.Fatalf("result=%#v notification=%#v", result, notification)
+        }
+    case <-t.Context().Done():
+        t.Fatal("notification was not delivered")
+    }
+}
+```
+
+- [ ] **Step 2: Run the focused hub tests and confirm methods are unregistered**
+
+```bash
+go test ./cmd/evener-hub -run 'TestHubRPC.*TranscriptDisplay|TestHubRPCRegistersExpectedHandlerSet' -count=1
+```
+
+Expected: FAIL with method-not-found or handler-set mismatch.
+
+- [ ] **Step 3: Wire the store into `WebConfig` and startup**
+
+Add `TranscriptDisplayStore *TranscriptDisplayStore` to `hubcore.WebConfig`. Production constructs it from `HubStateRoot` before `NewWebServer`; direct-test servers construct a store when none is injected. Retain a non-nil fallback store while surfacing load errors instead of silently discarding malformed state. In the same commit, set `FeatureSet.TranscriptDisplaySettings` true in the hub's `ServerConfig.Features`; older hubs and daemon servers keep the false zero value.
+
+- [ ] **Step 4: Register strict GET and PATCH handlers**
+
+Register GET with `HandleTyped`. Register PATCH with `Router.Handle` so Task 1's strict raw decoder runs before the store.
+
+```go
+func registerTranscriptDisplayHandlers(server *appserver.Server, store *hubcore.TranscriptDisplayStore) {
+    appserver.HandleTyped(server.Router(), appwire.MethodEvenerSettingsTranscriptDisplayGet,
+        func(context.Context, appwire.EmptyParams) (appwire.TranscriptDisplayDefaultsResponse, error) {
+            return store.Snapshot(), nil
+        })
+    server.Router().Handle(appwire.MethodEvenerSettingsTranscriptDisplayPatch,
+        func(_ context.Context, raw json.RawMessage) (any, error) {
+            params, err := appwire.DecodeTranscriptDisplayDefaultsPatchParams(raw)
+            if err != nil { return nil, appwire.InvalidParams(err.Error()) }
+            result, err := store.Patch(params)
+            if err != nil { return nil, err }
+            if result.Revision != params.ExpectedRevision {
+                server.BroadcastAll(appwire.NotifyEvenerSettingsTranscriptDisplayChanged,
+                    appwire.TranscriptDisplayDefaultsChangedParams(result))
+            }
+            return result, nil
+        })
+}
+```
+
+- [ ] **Step 5: Run hub RPC and restart tests**
+
+```bash
+go test ./cmd/evener-hub -run 'TestHubRPC.*TranscriptDisplay|TestHubRPCRegistersExpectedHandlerSet' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run hub package race tests for the new surface**
+
+```bash
+go test -race ./cmd/evener-hub/... -run 'Test.*TranscriptDisplay' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the RPC surface**
+
+```bash
+git add cmd/evener-hub/app_rpc_transcript_display.go cmd/evener-hub/app_rpc_transcript_display_test.go cmd/evener-hub/internal/hubcore/config.go cmd/evener-hub/main.go cmd/evener-hub/web.go cmd/evener-hub/app_rpc.go cmd/evener-hub/app_rpc_test.go
+git commit -m "feat(hub): sync transcript display defaults"
+```
+
+---
+
+### Task 4: Build the pure frontend configuration domain
+
+**Files:**
+- Create: `cmd/evener-hub/frontend/src/transcriptDisplay/config.ts`
+- Create: `cmd/evener-hub/frontend/src/transcriptDisplay/config.test.ts`
+- Modify: `cmd/evener-hub/frontend/src/stores/prefs.ts`
+- Modify: `cmd/evener-hub/frontend/src/stores/prefs.test.ts`
+
+**Interfaces:**
+- Produces `TranscriptDisplayConfigV1`, preset helpers, strict local codec, wire conversion, precedence, summary, fingerprint, and legacy migration/dual-write helpers for every later frontend task.
+
+- [ ] **Step 1: Add failing preset, codec, and migration tests**
+
+Pin all five exact vectors, cumulative ordering, Custom normalization, stable fingerprint/property order, malformed-as-absent local decoding, wire round trips, local → hub → shipped precedence, shipped defaults, Advanced counts, visible/hidden inventory, migration truth table, and exact legacy `1`/`0` writes.
+
+```ts
+it("expands the five cumulative content presets", () => {
+  expect(presetContent("chat")).toEqual({ toolIntent: false, toolCalls: false, reasoning: false, expandByDefault: false });
+  expect(presetContent("intent")).toEqual({ toolIntent: true, toolCalls: false, reasoning: false, expandByDefault: false });
+  expect(presetContent("tools")).toEqual({ toolIntent: true, toolCalls: true, reasoning: false, expandByDefault: false });
+  expect(presetContent("activity")).toEqual({ toolIntent: true, toolCalls: true, reasoning: true, expandByDefault: false });
+  expect(presetContent("full")).toEqual({ toolIntent: true, toolCalls: true, reasoning: true, expandByDefault: true });
+});
+```
+
+- [ ] **Step 2: Run the pure tests and confirm the module is absent**
+
+```bash
+cd cmd/evener-hub/frontend
+npx vitest run src/transcriptDisplay/config.test.ts
+```
+
+Expected: module-not-found failure.
+
+- [ ] **Step 3: Implement the domain unions and preset helpers**
+
+Use the approved frontend shape:
+
+```ts
+export type ContentSelection =
+  | { kind: "preset"; level: "chat" | "intent" | "tools" | "activity" | "full" }
+  | { kind: "custom"; toolIntent: boolean; toolCalls: boolean; reasoning: boolean; expandByDefault: boolean };
+
+export interface TranscriptDisplayConfigV1 {
+  readonly version: 1;
+  readonly content: ContentSelection;
+  readonly advanced: Readonly<{
+    roundTimings: boolean;
+    tokenCounts: boolean;
+    estimatedCost: boolean;
+    systemEvents: boolean;
+    promptEvents: boolean;
+    hookExits: "none" | "successful" | "all";
+  }>;
+}
+
+export interface HubTranscriptDisplayDefault {
+  readonly revision: number;
+  readonly config: TranscriptDisplayConfigV1;
+}
+```
+
+Export `presetContent`, `normalizeContent`, `normalizeConfig`, `resolveEffectiveConfig`, `configFingerprint`, `configSummary`, `advancedEnabledCount`, and `visibleCategoryInventory`.
+
+- [ ] **Step 4: Implement strict local and wire codecs**
+
+Parse local JSON from `unknown`; require exact version, discriminators, enums, booleans, and complete Custom shape. Encode normalized objects in stable property order. Map the generated AppWire interfaces to/from the frontend union without trusting optional generated fields.
+
+- [ ] **Step 5: Export guarded legacy adapters**
+
+Keep existing key names and bool encoding unchanged. Export narrow helpers from `prefs.ts` for reading key presence/value and writing/removing exact `1`/`0` values; do not expose unrestricted localStorage access.
+
+- [ ] **Step 6: Implement migration and dual-write helpers**
+
+Migrate only when neither new per-layout key exists and at least one legacy key is present. Inspect the exact legacy keys `evener.prefs.transcriptRoundTimings`, `evener.prefs.transcriptTokenCounts`, `evener.prefs.transcriptHookExitsAll`, `evener.prefs.transcriptHookExitsNormal`, `evener.prefs.transcriptPromptLoaded`, and `evener.prefs.showCost`. Produce Activity plus `systemEvents: true`; use fallbacks timings on, tokens off, prompt events on, cost off, and hooks off. Map normal-only to `successful` and any all-on value to `all`. Write the same migration to Desktop and Mobile. Do not delete old keys.
+
+- [ ] **Step 7: Run focused config and prefs tests**
+
+```bash
+npx vitest run src/transcriptDisplay/config.test.ts src/stores/prefs.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the frontend domain**
+
+```bash
+git add cmd/evener-hub/frontend/src/transcriptDisplay/config.ts cmd/evener-hub/frontend/src/transcriptDisplay/config.test.ts cmd/evener-hub/frontend/src/stores/prefs.ts cmd/evener-hub/frontend/src/stores/prefs.test.ts
+git commit -m "feat(web): model transcript display configuration"
+```
+
+---
+
+### Task 5: Build the pure transcript projector
+
+**Files:**
+- Create: `cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts`
+- Create: `cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts`
+- Read/retire later: `cmd/evener-hub/frontend/src/panes/session/viewModes.ts`
+- Read/retire later: `cmd/evener-hub/frontend/src/panes/session/transcript/transcriptVisibility.ts`
+
+**Interfaces:**
+- Consumes Task 4's normalized config/content vector.
+- Produces `projectThread(model, config): TranscriptProjection` for `TranscriptBody`, scroll anchors, render context, and preview inventory.
+
+- [ ] **Step 1: Add failing projector matrix tests**
+
+Cover every current `ItemModel.type` and relevant `eventKind`, all five levels, representative Custom vectors, blank tool purposes, failed tools, non-zero hooks, asks, approvals, steering, warnings, active rows, interrupted/failed turns, prompts, raw timings, unknown future kinds, order, stable IDs, source indexes, input immutability, and filter-before-grouping.
+
+```ts
+it("uses an intent proxy until the real tool row supersedes it", () => {
+  const model = threadWith(tool({ id: "tool-1", description: "Inspect the tree" }));
+  expect(projectThread(model, preset("intent")).turns[0]?.entries).toEqual([
+    expect.objectContaining({ kind: "intent", id: "intent:tool-1", rationale: "Inspect the tree" }),
+  ]);
+  expect(projectThread(model, preset("tools")).turns[0]?.entries).toEqual([
+    expect.objectContaining({ kind: "item", id: "tool-1" }),
+  ]);
+});
+```
+
+- [ ] **Step 2: Run the projector tests and confirm the module is absent**
+
+```bash
+cd cmd/evener-hub/frontend
+npx vitest run src/transcriptDisplay/projector.test.ts
+```
+
+Expected: module-not-found failure.
+
+- [ ] **Step 3: Define stable projected unions**
+
+```ts
+export type ProjectedEntry =
+  | { kind: "item"; id: string; turnId: string; sourceIndex: number; item: ItemModel; isMessage: boolean }
+  | { kind: "intent"; id: `intent:${string}`; turnId: string; sourceIndex: number; sourceItemId: string; rationale: string }
+  | { kind: "critical"; id: string; turnId: string; sourceIndex: number; sourceItemId?: string; item: ItemModel; summary: string };
+
+export interface ProjectedTurn {
+  readonly id: string;
+  readonly source: TurnModel;
+  readonly entries: readonly ProjectedEntry[];
+}
+
+export interface ProjectedAnchor {
+  readonly id: string;
+  readonly sourceIndex: number;
+  readonly index: number;
+  readonly isMessage: boolean;
+}
+
+export interface TranscriptMetadataVisibility {
+  readonly roundTimings: boolean;
+  readonly tokenCounts: boolean;
+  readonly estimatedCost: boolean;
+  readonly systemEvents: boolean;
+  readonly promptEvents: boolean;
+  readonly hookExits: HookExitDetail;
+}
+
+export interface TranscriptProjection {
+  readonly turns: readonly ProjectedTurn[];
+  readonly anchors: readonly ProjectedAnchor[];
+  readonly metadata: TranscriptMetadataVisibility;
+  readonly eligibleDisclosureIds: readonly string[];
+}
+```
+
+- [ ] **Step 4: Implement typed classification and critical invariants**
+
+Classify with `item.type`, `eventKind`, structured exit/status fields, and turn status. Never parse English message text. Unknown kinds produce item entries. A blank tool description produces the fixed neutral summary contract.
+
+- [ ] **Step 5: Implement projection, grouping input, and metadata**
+
+Filter before building tool/system groups. Preserve each source turn and provide a projected item array for renderers that count neighboring items. Emit anchors with source indexes, not projected indexes. Return metadata flags directly from config.
+
+- [ ] **Step 6: Run focused projector tests**
+
+```bash
+npx vitest run src/transcriptDisplay/projector.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the projector**
+
+```bash
+git add cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts
+git commit -m "feat(web): project transcript detail levels"
+```
+
+---
+
+### Task 6: Add browser-local and hub-default frontend state
+
+**Files:**
+- Create: `cmd/evener-hub/frontend/src/stores/transcriptDisplay.ts`
+- Create: `cmd/evener-hub/frontend/src/stores/transcriptDisplay.test.ts`
+- Modify: `cmd/evener-hub/frontend/src/stores/connection.ts`
+- Modify: `cmd/evener-hub/frontend/src/stores/connection.test.ts`
+- Modify: `cmd/evener-hub/frontend/src/shell/AppShell.tsx`
+- Modify: `cmd/evener-hub/frontend/src/shell/AppShell.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/shell/ConnectionBanner.tsx`
+- Modify: `cmd/evener-hub/frontend/src/shell/ConnectionBanner.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/shell/useIsMobile.ts`
+- Modify: `cmd/evener-hub/frontend/src/shell/useIsMobile.test.ts`
+
+**Interfaces:**
+- Consumes Task 1's generated methods/notification/feature bit and Task 4's codec/migration.
+- Produces `useEffectiveTranscriptDisplay`, local setters/reset, confirmed/draft hub setters, reconnect refresh, and unsupported/error state for UI tasks.
+
+- [ ] **Step 1: Add failing store tests**
+
+Cover shipped fallback, local-over-hub precedence, independent layouts, local restart, same-tab subscribers, BroadcastChannel, storage fallback, malformed channel/storage payloads, blocked/full storage warning, migration-once, exact dual-write, hub refresh, stale notification ignore, follower-only hub changes, local override stability, draft immediate preview, acknowledged commit, failed/conflict reversion, reconnect, replaced-client fencing, and older-hub unsupported state.
+
+```ts
+it("keeps a local Desktop view while a newer hub default updates followers", () => {
+  transcriptDisplayStore.getState().setLocal("desktop", preset("activity"));
+  transcriptDisplayStore.getState().applyHubChange({ layout: "desktop", revision: 2, config: preset("chat") });
+  expect(transcriptDisplayStore.getState().effective("desktop")).toEqual(preset("activity"));
+  expect(transcriptDisplayStore.getState().hub.desktop?.config).toEqual(preset("chat"));
+});
+```
+
+- [ ] **Step 2: Run the focused store tests and confirm the store is absent**
+
+```bash
+cd cmd/evener-hub/frontend
+npx vitest run src/stores/transcriptDisplay.test.ts src/stores/connection.test.ts src/shell/useIsMobile.test.ts
+```
+
+Expected: module-not-found or missing-feature-state failure.
+
+- [ ] **Step 3: Retain handshake features in the connection store**
+
+Extend connection state with `features?: FeatureSet`. Every handshake-driving caller sets `serverInfo` and `features` from one `InitializeResponse`. Clear stale features when replacing/closing a client. The transcript store remains `hubSupport: "unknown"` until a handshake completes, becomes `"supported"` only when `transcriptDisplaySettings === true`, and otherwise becomes `"unsupported"`. Tests must prove an older response with no field leaves the synced-default UI unsupported instead of issuing method-not-found requests.
+
+- [ ] **Step 4: Implement the Zustand store and effective selector**
+
+Use this stable state boundary:
+
+```ts
+interface TranscriptDisplayStoreState {
+  viewport: ViewportClass;
+  local: Partial<Record<ViewportClass, TranscriptDisplayConfigV1>>;
+  hub: Partial<Record<ViewportClass, HubTranscriptDisplayDefault>>;
+  drafts: Partial<Record<ViewportClass, TranscriptDisplayConfigV1>>;
+  hubLoading: boolean;
+  hubError: string | null;
+  storageWarning: string | null;
+  hubSupport: "unknown" | "supported" | "unsupported";
+  setLocal(layout: ViewportClass, config: TranscriptDisplayConfigV1): void;
+  clearLocal(layout: ViewportClass): void;
+  effective(layout?: ViewportClass): TranscriptDisplayConfigV1;
+  refreshHubDefaults(): Promise<void>;
+  patchHubDefault(layout: ViewportClass, config: TranscriptDisplayConfigV1): Promise<void>;
+}
+```
+
+- [ ] **Step 5: Implement per-layout persistence and same-origin sync**
+
+Use keys `evener.prefs.transcriptDisplay.desktop` and `.mobile`, plus `BroadcastChannel("evener.transcript-display.v1")`. Include a random per-tab source id, encoded config or null, and fingerprint. Listen to storage events as fallback. The origin tab updates Zustand directly. Never place hub values on this channel.
+
+- [ ] **Step 6: Implement legacy migration and dual-write**
+
+Run migration before loading local values. Set a visible storage warning when a write fails but preserve the in-memory value. Document and test that the most recently edited layout wins the lossy legacy global Advanced flags.
+
+- [ ] **Step 7: Implement hub refresh, patch, notifications, and reconnect fencing**
+
+Rewire the active AppWire client like `threads.ts`: detach the old notification/ready handlers, fetch immediately when already ready, refresh on every future ready generation, ignore stale async responses from replaced clients, and apply only newer revisions. Keep a confirmed hub record separate from a draft. Parse conflict error data narrowly and restore the canonical response.
+
+- [ ] **Step 8: Initialize the store before pane rendering**
+
+Call `initTranscriptDisplay()` in `AppShell` beside `initPrefs()`. Subscribe once to the existing mobile query and update the store's layout class before host swap whenever possible.
+
+- [ ] **Step 9: Run focused store/shell tests**
+
+```bash
+npx vitest run src/stores/transcriptDisplay.test.ts src/stores/connection.test.ts src/shell/useIsMobile.test.ts src/shell/AppShell.test.tsx src/shell/ConnectionBanner.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit frontend state**
+
+```bash
+git add cmd/evener-hub/frontend/src/stores/transcriptDisplay.ts cmd/evener-hub/frontend/src/stores/transcriptDisplay.test.ts cmd/evener-hub/frontend/src/stores/connection.ts cmd/evener-hub/frontend/src/stores/connection.test.ts cmd/evener-hub/frontend/src/shell/AppShell.tsx cmd/evener-hub/frontend/src/shell/AppShell.test.tsx cmd/evener-hub/frontend/src/shell/ConnectionBanner.tsx cmd/evener-hub/frontend/src/shell/ConnectionBanner.test.tsx cmd/evener-hub/frontend/src/shell/useIsMobile.ts cmd/evener-hub/frontend/src/shell/useIsMobile.test.ts
+git commit -m "feat(web): resolve local and hub transcript views"
+```
+
+---
+
+### Task 7: Make disclosure and render state configuration-aware
+
+**Files:**
+- Create: `cmd/evener-hub/frontend/src/transcriptDisplay/renderContext.tsx`
+- Modify: `cmd/evener-hub/frontend/src/widgets/disclosure/disclosureStore.ts`
+- Modify: `cmd/evener-hub/frontend/src/widgets/disclosure/disclosureStore.test.ts`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/types.ts`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallCluster.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallCluster.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/messages/SystemNoticeItem.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/messages/SystemNoticeItem.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/messages/TurnSeparator.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/messages/TurnSeparator.test.tsx`
+
+**Interfaces:**
+- Consumes Task 4 configs and Task 5's metadata/eligible-disclosure outputs in focused tests.
+- Produces configuration-aware renderer behavior that `TranscriptBody` can share without leaf `prefsStore` reads.
+- Keeps `TurnBlock`'s existing `TurnModel` call shape working through one temporary legacy-config adapter; Task 8 removes that adapter when every production caller supplies the shared provider.
+
+- [ ] **Step 1: Add failing disclosure-baseline tests**
+
+Prove Activity defaults eligible entries closed, entering Full clears prior closed overrides and opens current eligible ids once, a later manual collapse wins, new eligible ids default open in Full, returning to Full creates a new baseline, and preview scopes never collide with live scopes.
+
+- [ ] **Step 2: Run disclosure and renderer tests to confirm missing behavior**
+
+```bash
+cd cmd/evener-hub/frontend
+npx vitest run src/widgets/disclosure/disclosureStore.test.ts src/panes/session/transcript/ToolCallItem.test.tsx src/panes/session/transcript/ToolCallCluster.test.tsx src/panes/session/transcript/messages/ThinkBlock.test.tsx
+```
+
+Expected: failures showing local cluster state and always-collapsed defaults.
+
+- [ ] **Step 3: Separate explicit choices from baseline defaults**
+
+Extend the disclosure store with scoped baseline operations while preserving existing APIs:
+
+```ts
+export function beginDisclosureBaseline(scope: string, ids: readonly string[], open: boolean): void;
+export function disclosureDefault(scope: string, id: string, fallback: boolean): boolean;
+export function clearDisclosureScope(scope: string): void;
+```
+
+The baseline operation may clear explicit values only when entering Full, never on ordinary rerenders.
+
+- [ ] **Step 4: Add render context**
+
+Provide normalized config, projected metadata, surface (`live | readOnly | preview`), disclosure scope, and full-baseline generation. Existing memoized renderers must either consume context or include new props in their comparator; no renderer may remain stale after config changes. Give the context a test-only/transition default, and let `TurnBlock` construct one temporary compatibility value from the existing prefs when no provider is present. This keeps the current Session and read-only callers green until Task 8 moves both to `TranscriptBody`.
+
+- [ ] **Step 5: Convert tool, reasoning, system, notification, and metadata renderers**
+
+Remove direct `prefsStore` reads from leaf renderers and `TurnSeparator`. Convert `ToolCallCluster` and `NotificationCard` local disclosure state to scoped disclosure state. Preserve failed-tool auto-open as a fallback and preserve explicit user choices. Keep the temporary prefs-to-config adapter at the `TurnBlock` boundary only; no child renderer may read the old store.
+
+- [ ] **Step 6: Keep critical failures under hidden routine diagnostics**
+
+When hook diagnostics are `none`, render non-zero hooks through the compact critical projection. When full diagnostic rows are visible, avoid a duplicate critical row. Keep prompts/system events controlled only by Advanced fields.
+
+- [ ] **Step 7: Run focused renderer tests**
+
+```bash
+npx vitest run src/widgets/disclosure/disclosureStore.test.ts src/panes/session/transcript/TurnBlock.test.tsx src/panes/session/transcript/ToolCallItem.test.tsx src/panes/session/transcript/ToolCallCluster.test.tsx src/panes/session/transcript/messages/ThinkBlock.test.tsx src/panes/session/transcript/messages/SystemNoticeItem.test.tsx src/panes/session/transcript/messages/NotificationCard.test.tsx src/panes/session/transcript/messages/TurnSeparator.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit renderer state changes**
+
+```bash
+git add cmd/evener-hub/frontend/src/transcriptDisplay/renderContext.tsx cmd/evener-hub/frontend/src/widgets/disclosure/disclosureStore.ts cmd/evener-hub/frontend/src/widgets/disclosure/disclosureStore.test.ts cmd/evener-hub/frontend/src/panes/session/transcript/types.ts cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallCluster.tsx cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallCluster.test.tsx cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.tsx cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.test.tsx cmd/evener-hub/frontend/src/panes/session/transcript/messages/SystemNoticeItem.tsx cmd/evener-hub/frontend/src/panes/session/transcript/messages/SystemNoticeItem.test.tsx cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.tsx cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx cmd/evener-hub/frontend/src/panes/session/transcript/messages/TurnSeparator.tsx cmd/evener-hub/frontend/src/panes/session/transcript/messages/TurnSeparator.test.tsx
+git commit -m "refactor(web): render transcript from display context"
+```
+
+---
+
+### Task 8: Extract the shared projected TranscriptBody
+
+**Files:**
+- Create: `cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx`
+- Create: `cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/Session.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/Session.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/session.module.css`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/transcript/Transcript.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/transcript/Transcript.test.tsx`
+- Delete: `cmd/evener-hub/frontend/src/panes/session/viewModes.ts`
+- Delete: `cmd/evener-hub/frontend/src/panes/session/viewModes.test.ts`
+
+**Interfaces:**
+- Consumes Task 5 projector, Task 6 effective store, and Task 7 render context.
+- Produces one rendering path for Task 9 scroll coordination, Task 10 live controls, and Task 11 previews.
+
+- [ ] **Step 1: Add failing shared-body parity tests**
+
+Render one fabricated model through live, read-only, and preview surfaces. Assert equivalent projected content, no Intent/Tools purpose duplication, no preview virtual scroller, no read-only composer, and preserved `job:` dispatch.
+
+```tsx
+it("renders Intent through one body without raw tool rows", () => {
+  render(<TranscriptBody model={fixture} config={preset("intent")} surface="preview" disclosureScope="preview:test" />);
+  expect(screen.getByText("Inspect the tree")).toBeTruthy();
+  expect(screen.queryByTestId("tool-call-item")).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run body/session/transcript tests and confirm missing component**
+
+```bash
+cd cmd/evener-hub/frontend
+npx vitest run src/panes/session/transcript/TranscriptBody.test.tsx src/panes/session/Session.test.tsx src/panes/transcript/Transcript.test.tsx
+```
+
+Expected: module-not-found failure.
+
+- [ ] **Step 3: Implement `TranscriptBody`**
+
+Use props that keep common rendering central and surface-specific chrome injectable:
+
+```ts
+export interface TranscriptBodyProps {
+  model: ThreadModel;
+  config: TranscriptDisplayConfigV1;
+  surface: "live" | "readOnly" | "preview";
+  disclosureScope: string;
+  sessionRef?: string;
+  showSeenDividerTurnId?: string;
+  loadOlderRow?: ReactNode;
+  liveOverlay?: ReactNode;
+  listRef?: RefObject<VirtualListHandle | null>;
+  onMeasurementsChange?: () => void;
+}
+```
+
+Live/read-only use the common projected VirtualList; preview maps projected turns in normal page flow. Import renderer-registration barrels at this boundary. Update `TurnBlock` to accept the projected turn/entries and remove Task 7's temporary prefs-to-config adapter now that every production caller supplies `TranscriptRenderProvider`.
+
+- [ ] **Step 4: Replace Session's two render trees**
+
+Remove `viewMode`, `focusedEntries`, `viewRows`, the focused branch, and the header RadioGroup. Keep cold start, deleted state, flow overlay, seen divider, composer, liveness, pending chips, and escalation rail unchanged. Resolve the effective config from Task 6 and pass its fingerprint to scroll flow.
+
+- [ ] **Step 5: Replace read-only Transcript duplication**
+
+Keep `job:` dispatch, hydration, pane title, no-composer behavior, and older loading. Render thread content through `TranscriptBody surface="readOnly"`.
+
+- [ ] **Step 6: Retire old view modes**
+
+Delete `viewModes.ts` and its tests after every retained assertion exists in projector/body tests. Search for and remove all imports and CSS selectors used only by the old focused tree.
+
+- [ ] **Step 7: Run shared-body integration tests**
+
+```bash
+npx vitest run src/transcriptDisplay/projector.test.ts src/panes/session/transcript/TranscriptBody.test.tsx src/panes/session/Session.test.tsx src/panes/transcript/Transcript.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the shared body**
+
+```bash
+git add cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.test.tsx cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx cmd/evener-hub/frontend/src/panes/session/Session.tsx cmd/evener-hub/frontend/src/panes/session/Session.test.tsx cmd/evener-hub/frontend/src/panes/session/session.module.css cmd/evener-hub/frontend/src/panes/transcript/Transcript.tsx cmd/evener-hub/frontend/src/panes/transcript/Transcript.test.tsx
+git rm cmd/evener-hub/frontend/src/panes/session/viewModes.ts cmd/evener-hub/frontend/src/panes/session/viewModes.test.ts
+git commit -m "refactor(web): share transcript projection body"
+```
+
+---
+
+### Task 9: Preserve scroll and focus for every configuration source
+
+**Files:**
+- Create: `cmd/evener-hub/frontend/src/panes/session/transcript/flow/transcriptViewRegistry.ts`
+- Create: `cmd/evener-hub/frontend/src/panes/session/transcript/flow/transcriptViewRegistry.test.ts`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.test.ts`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx`
+- Modify: `cmd/evener-hub/frontend/src/stores/transcriptDisplay.ts`
+- Modify: `cmd/evener-hub/frontend/src/stores/transcriptDisplay.test.ts`
+
+**Interfaces:**
+- Produces registry registration and `transitionTranscriptViews(change)` used before local, tab, hub-follower, and layout changes.
+- Extends scroll flow to restore focus or focus the Detail trigger when the focused entry disappears.
+
+- [ ] **Step 1: Add failing multi-pane transition tests**
+
+Cover two mounted panes, capture-before-store-publish ordering, same-entry restore, nearest surviving message, normalized fallback, bottom follow, focused-entry survival, focused-entry removal, unregister, and breakpoint host-remount cache.
+
+- [ ] **Step 2: Run registry/scroll tests and confirm external transitions are unsupported**
+
+```bash
+cd cmd/evener-hub/frontend
+npx vitest run src/panes/session/transcript/flow/transcriptViewRegistry.test.ts src/panes/session/transcript/flow/useTranscriptScroll.test.ts
+```
+
+Expected: failures showing only click-local capture exists.
+
+- [ ] **Step 3: Implement the registry and transition order**
+
+```ts
+export interface CapturedTranscriptView {
+  readonly anchorId?: string;
+  readonly anchorOffset: number;
+  readonly normalizedOffset: number;
+  readonly followingBottom: boolean;
+  readonly focusedEntryId?: string;
+}
+
+export interface RegisteredTranscriptView {
+  id: string;
+  capture(): CapturedTranscriptView;
+  restore(captured: CapturedTranscriptView): void;
+  focusDetailTrigger(): void;
+  announce(summary: string): void;
+}
+
+export function registerTranscriptView(view: RegisteredTranscriptView): () => void;
+export function captureTranscriptViews(): ReadonlyMap<string, CapturedTranscriptView>;
+export function restoreTranscriptViews(captured: ReadonlyMap<string, CapturedTranscriptView>): void;
+export function transitionTranscriptViews(publish: () => void, summary: string): void;
+```
+
+Every effective-change path captures all mounted views, publishes the state, then schedules restore after measurement. Coalesce concurrent identical fingerprints; do not capture/announce on unrelated hub-default changes hidden by a local override.
+
+- [ ] **Step 4: Extend scroll anchors with focus and remount state**
+
+Use stable projected entry IDs and source indexes. Preserve the current exact/nearest/proportion algorithm. Cache the captured state briefly across the desktop/mobile host remount and consume it once; use no wall-clock sleeps.
+
+- [ ] **Step 5: Connect all store transition sources**
+
+Route local set/reset, BroadcastChannel, storage, applicable hub notification, and viewport change through one transition function. Hub drafts in Settings preview do not change live followers until acknowledged.
+
+- [ ] **Step 6: Run focused flow/store tests**
+
+```bash
+npx vitest run src/panes/session/transcript/flow/transcriptViewRegistry.test.ts src/panes/session/transcript/flow/useTranscriptScroll.test.ts src/stores/transcriptDisplay.test.ts src/panes/session/transcript/TranscriptBody.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit view preservation**
+
+```bash
+git add cmd/evener-hub/frontend/src/panes/session/transcript/flow/transcriptViewRegistry.ts cmd/evener-hub/frontend/src/panes/session/transcript/flow/transcriptViewRegistry.test.ts cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.test.ts cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx cmd/evener-hub/frontend/src/stores/transcriptDisplay.ts cmd/evener-hub/frontend/src/stores/transcriptDisplay.test.ts
+git commit -m "fix(web): preserve transcript view across detail changes"
+```
+
+---
+
+### Task 10: Add the compact live Detail control
+
+**Files:**
+- Create: `cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptDetailControl.tsx`
+- Create: `cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptDetailControl.test.tsx`
+- Create: `cmd/evener-hub/frontend/src/panes/session/transcript/transcriptDisplay.module.css`
+- Modify: `cmd/evener-hub/frontend/src/widgets/radiogroup/index.tsx`
+- Modify: `cmd/evener-hub/frontend/src/widgets/radiogroup/radiogroup.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/Session.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/transcript/Transcript.tsx`
+
+**Interfaces:**
+- Consumes Task 6 local/hub store and Task 4 config helpers.
+- Produces controlled `TranscriptDetailEditor` for Task 11 and the desktop Popover/mobile Sheet `TranscriptDetailControl` live wrapper.
+- Produces the Detail-trigger focus target used by Task 9.
+
+```ts
+export interface TranscriptDetailEditorProps {
+  value: TranscriptDisplayConfigV1;
+  onChange(value: TranscriptDisplayConfigV1): void;
+  disabled?: boolean;
+  compact?: boolean;
+}
+
+export interface TranscriptDetailControlProps {
+  layout: ViewportClass;
+  onEditHubDefaults(): void;
+  triggerRef?: Ref<HTMLButtonElement>;
+}
+```
+
+- [ ] **Step 1: Add failing accessibility and scope tests**
+
+Cover five visible labels, `Full` visible with `Full detail` accessible name, Arrow/Home/End behavior, Custom with no false preset, Advanced fieldsets, `Tools · 2 advanced`, local Desktop/Mobile scope, Use hub default, Edit hub defaults, explicit unsupported copy for older hubs, Desktop Popover, Mobile bottom Sheet, Escape/Close/focus return, and 44px control classes.
+
+- [ ] **Step 2: Run control/radio tests and confirm the control is absent**
+
+```bash
+cd cmd/evener-hub/frontend
+npx vitest run src/panes/session/transcript/TranscriptDetailControl.test.tsx src/widgets/radiogroup/radiogroup.test.tsx
+```
+
+Expected: module-not-found or missing accessible-label support.
+
+- [ ] **Step 3: Add visible/accessibility label support to RadioGroup**
+
+Extend `RadioGroupOption` with `accessibleLabel?: string`. Render the visible label unchanged and apply the accessible label to the radio option. Preserve existing roving focus and disabled behavior.
+
+- [ ] **Step 4: Implement the shared editor**
+
+The stepped track changes regular content only and preserves metrics/diagnostics. Advanced Content changes normalize to a preset or Custom. Advanced Metrics/Diagnostics remain independent. Critical rows render as locked-on explanatory fields, not writable values.
+
+- [ ] **Step 5: Implement Popover and Sheet wrappers**
+
+Use the existing `Popover` at Desktop and `Sheet side="bottom"` at Mobile. The trigger sits in transcript-local toolbar chrome above the scroller, not `PaneScaffold.actions`. Register its ref with Task 9 for focus fallback.
+
+- [ ] **Step 6: Add responsive and reduced-motion CSS**
+
+Use a container query for compact narrow desktop panes. Keep all stop labels visible, minimum 44px Mobile targets, non-color selected state, no horizontal scrolling, and reduced-motion rules.
+
+- [ ] **Step 7: Run focused control/body/session tests**
+
+```bash
+npx vitest run src/panes/session/transcript/TranscriptDetailControl.test.tsx src/widgets/radiogroup/radiogroup.test.tsx src/panes/session/transcript/TranscriptBody.test.tsx src/panes/session/Session.test.tsx src/panes/transcript/Transcript.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the live control**
+
+```bash
+git add cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptDetailControl.tsx cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptDetailControl.test.tsx cmd/evener-hub/frontend/src/panes/session/transcript/transcriptDisplay.module.css cmd/evener-hub/frontend/src/widgets/radiogroup/index.tsx cmd/evener-hub/frontend/src/widgets/radiogroup/radiogroup.test.tsx cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx cmd/evener-hub/frontend/src/panes/session/Session.tsx cmd/evener-hub/frontend/src/panes/transcript/Transcript.tsx
+git commit -m "feat(web): add live transcript detail control"
+```
+
+---
+
+### Task 11: Build stacked hub-default cards and production previews
+
+**Files:**
+- Create: `cmd/evener-hub/frontend/src/transcriptDisplay/previewFixture.ts`
+- Create: `cmd/evener-hub/frontend/src/panes/settings/sections/TranscriptDisplayCard.tsx`
+- Create: `cmd/evener-hub/frontend/src/panes/settings/sections/TranscriptDisplayCard.test.tsx`
+- Create: `cmd/evener-hub/frontend/src/panes/settings/sections/transcriptDisplayCard.module.css`
+- Modify: `cmd/evener-hub/frontend/src/panes/settings/sections/transcript.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/settings/sections/transcript.module.css`
+- Modify: `cmd/evener-hub/frontend/src/panes/settings/sections/transcript.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/settings/sections/display.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/settings/sections/display.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/settings/sections.ts`
+- Modify: `cmd/evener-hub/frontend/src/panes/settings/sections.test.ts`
+- Modify: `cmd/evener-hub/frontend/src/dev/surface-sections/transcript.tsx`
+- Modify: `cmd/evener-hub/frontend/src/dev/surface-sections/transcript.test.tsx`
+
+**Interfaces:**
+- Consumes Task 6 drafts/confirmed hub state, Task 10 `TranscriptDetailEditor`, and Task 8 preview body.
+- Produces the approved Settings UI and deterministic shared fixture.
+
+```ts
+export interface TranscriptDisplayCardProps {
+  layout: ViewportClass;
+  confirmed: HubTranscriptDisplayDefault;
+  draft?: TranscriptDisplayConfigV1;
+  localOverride?: TranscriptDisplayConfigV1;
+  saveState: "idle" | "saving" | "error";
+  error?: string;
+  onChange(config: TranscriptDisplayConfigV1): void;
+  onRetry(): void;
+}
+```
+
+- [ ] **Step 1: Add failing Settings and preview tests**
+
+Cover two stacked cards in Desktop-then-Mobile order, controls above examples, shared fixed scenario, `Example only—not your data`, visible/hidden inventory, no `threadsStore` or request on preview render, draft update before RPC completion, acknowledged save, failed/conflict reversion, retry, unsupported older-hub copy, local-override explanation, one Advanced disclosure row, and no success toast before confirmation.
+
+- [ ] **Step 2: Run Settings/display tests and confirm the old switch UI remains**
+
+```bash
+cd cmd/evener-hub/frontend
+npx vitest run src/panes/settings/sections/TranscriptDisplayCard.test.tsx src/panes/settings/sections/transcript.test.tsx src/panes/settings/sections/display.test.tsx src/panes/settings/sections.test.ts
+```
+
+Expected: failures because cards/fixture do not exist and estimated cost remains under Display.
+
+- [ ] **Step 3: Extract the deterministic preview fixture**
+
+Build one `ThreadModel` with user/agent messages, purpose-bearing successful tool and body, failed critical tool, reasoning, timing/token/cost, low-level system, prompt, and hook items. Use fixed timestamps only. Update the dev transcript surface to consume this fixture and production `TranscriptBody surface="preview"`.
+
+- [ ] **Step 4: Implement one default card**
+
+Each card renders device/current value, five-stop editor, one Advanced opener/summary, example below controls, textual inventory, confirmed/draft/error state, retry, and local-override explanation. Use an isolated preview disclosure scope.
+
+- [ ] **Step 5: Replace the Transcript settings section**
+
+Render Desktop then Mobile cards. Keep route id `transcript`; change visible label/heading to `Transcript display`. Explain hub sync and browser-local live overrides.
+
+- [ ] **Step 6: Move estimated cost and preserve compatibility**
+
+Remove only the estimated-cost row from Display; retain Enter-sends behavior. Advanced Metrics now owns cost. Keep legacy `showCost` adapters and dual-write tests.
+
+- [ ] **Step 7: Run Settings, preview, and dev-surface tests**
+
+```bash
+npx vitest run src/panes/settings/sections/TranscriptDisplayCard.test.tsx src/panes/settings/sections/transcript.test.tsx src/panes/settings/sections/display.test.tsx src/panes/settings/sections.test.ts src/panes/session/transcript/TranscriptBody.test.tsx src/dev/surface-sections/transcript.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Settings and preview UI**
+
+```bash
+git add cmd/evener-hub/frontend/src/transcriptDisplay/previewFixture.ts cmd/evener-hub/frontend/src/panes/settings/sections/TranscriptDisplayCard.tsx cmd/evener-hub/frontend/src/panes/settings/sections/TranscriptDisplayCard.test.tsx cmd/evener-hub/frontend/src/panes/settings/sections/transcriptDisplayCard.module.css cmd/evener-hub/frontend/src/panes/settings/sections/transcript.tsx cmd/evener-hub/frontend/src/panes/settings/sections/transcript.module.css cmd/evener-hub/frontend/src/panes/settings/sections/transcript.test.tsx cmd/evener-hub/frontend/src/panes/settings/sections/display.tsx cmd/evener-hub/frontend/src/panes/settings/sections/display.test.tsx cmd/evener-hub/frontend/src/panes/settings/sections.ts cmd/evener-hub/frontend/src/panes/settings/sections.test.ts cmd/evener-hub/frontend/src/dev/surface-sections/transcript.tsx cmd/evener-hub/frontend/src/dev/surface-sections/transcript.test.tsx
+git commit -m "feat(web): preview synced transcript defaults"
+```
+
+---
+
+### Task 12: Verify integration, responsive geometry, and compatibility
+
+**Files:**
+- Modify: `cmd/evener-hub/frontend/src/dev/overflowharness-entry.tsx`
+- Modify: `cmd/evener-hub/frontend/scripts/overflowguard/run.mjs`
+- Modify: `docs/superpowers/plans/2026-08-25-transcript-detail-configuration.md` (check completed boxes only)
+
+**Interfaces:**
+- Consumes the complete feature.
+- Produces verified repository state and gate evidence. No new product behavior belongs in this task except root-cause fixes for discovered failures.
+
+- [ ] **Step 1: Format all touched frontend source files**
+
+Run from `cmd/evener-hub/frontend` with the exact changed `src/` paths reported by `git diff --name-only`:
+
+```bash
+npx biome check --write src/transcriptDisplay src/stores/transcriptDisplay.ts src/panes/session src/panes/transcript src/panes/settings src/widgets/radiogroup src/widgets/disclosure src/shell src/dev/surface-sections/transcript.tsx
+```
+
+Expected: exit 0. Review every formatter change.
+
+- [ ] **Step 2: Run the complete focused Go surface**
+
+```bash
+go test ./appwire ./internal/appwiredoc ./internal/appwirets ./cmd/evener-hub/internal/hubcore ./cmd/evener-hub -run 'Test.*TranscriptDisplay|TestGeneratedFileCurrent|TestHubRPCRegistersExpectedHandlerSet' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the complete focused frontend surface**
+
+```bash
+cd cmd/evener-hub/frontend
+npx vitest run src/transcriptDisplay src/stores/transcriptDisplay.test.ts src/panes/session/transcript src/panes/session/Session.test.tsx src/panes/transcript/Transcript.test.tsx src/panes/settings/sections/TranscriptDisplayCard.test.tsx src/panes/settings/sections/transcript.test.tsx src/panes/settings/sections/display.test.tsx src/widgets/radiogroup/radiogroup.test.tsx src/widgets/disclosure/disclosureStore.test.ts src/shell/useIsMobile.test.ts src/shell/AppShell.test.tsx
+npm run typecheck
+npm run lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Add/adjust a real-browser overflow case and mutation-test it**
+
+Exercise 390px Mobile, 899px Mobile, 900px narrow desktop host, and a narrow dock pane. Assert the Detail trigger is reachable, the stepped control/sheet has no horizontal scroll, Settings cards stack, previews create no inner scroll, and 44px Mobile targets hold.
+
+Before accepting the guard, make one path-scoped temporary mutation that removes the relevant width/overflow rule, prove the guard fails on the named element, restore only that mutation with the documented path-scoped stash procedure, and rerun green.
+
+- [ ] **Step 5: Run canonical frontend gates**
+
+From repository root:
+
+```bash
+make test-web
+make test-web-browser
+```
+
+Expected: both exit 0. A missing Chrome/dependency is an incomplete gate, not a pass.
+
+- [ ] **Step 6: Run repository lint and static analysis**
+
+```bash
+make lint
+make vet
+```
+
+Expected: both exit 0. `make lint` must confirm generated outputs are current.
+
+- [ ] **Step 7: Run the full deterministic test gate**
+
+```bash
+make test
+```
+
+Expected: exit 0. Read every warning, skip, and retained-log path.
+
+- [ ] **Step 8: Run final status and diff checks**
+
+```bash
+git diff --check
+git status --short
+git log --oneline --decorate -15
+```
+
+Expected: no unstaged implementation changes, no unexpected untracked files, and one reviewed commit per accepted task.
+
+- [ ] **Step 9: Commit only root-cause fixes or browser-guard changes from verification**
+
+Stage the exact changed guard/test/fix paths and commit:
+
+```bash
+git commit -m "test(web): verify transcript detail layouts"
+```
+
+Skip this commit when verification required no file changes.

--- a/docs/superpowers/specs/2026-08-25-transcript-detail-configuration-design.md
+++ b/docs/superpowers/specs/2026-08-25-transcript-detail-configuration-design.md
@@ -1,0 +1,567 @@
+# Unified Transcript Detail Configuration Design
+
+**Date:** 2026-08-25
+**Status:** Approved
+
+## Summary
+
+Evener will replace its fragmented transcript visibility controls with one configuration model. A five-level control will cover ordinary reading. Advanced controls will expose independent content, metric, and diagnostic options.
+
+The live control and Settings serve different scopes:
+
+- The live control changes the active view for every session in the current browser and layout class. This browser-local choice survives restarts but never affects another machine.
+- Settings changes the Desktop and Mobile defaults stored by the hub. These defaults sync to every browser and device paired with that hub.
+
+The live Session pane, read-only Transcript pane, and Settings examples will use one typed projection pipeline. This removes the current divergence between the Everything and Intent render trees.
+
+## Goals
+
+1. Give regular users one clear progression from conversation to expanded detail.
+2. Let advanced users control transcript content, metrics, and diagnostics independently.
+3. Apply live changes to every local session without changing another machine.
+4. Sync Desktop and Mobile defaults across devices paired with one hub.
+5. Preview each hub default with fixed example data in Settings.
+6. Preserve critical information at every detail level.
+7. Preserve scroll position, focus, and explicit disclosure choices when visibility changes.
+8. Migrate explicit legacy browser preferences without weakening their storage contracts.
+
+## Non-goals
+
+This work will not:
+
+- create user accounts or sync preferences across independent hubs;
+- add named or user-created view profiles;
+- persist settings in session data or URLs;
+- create per-session or per-pane visibility overrides;
+- put custom visibility vectors in shared links;
+- fetch real transcript data for the Settings examples;
+- change the always-visible session-total cost in the footer.
+
+## Current system and constraints
+
+The current implementation has two independent visibility systems:
+
+- `Session.tsx` owns a transient `everything | intent` value and initializes every mount to `everything` (`cmd/evener-hub/frontend/src/panes/session/Session.tsx:124-137`). Everything renders full turns through `TurnBlock`; Intent builds a separate focused-entry tree (`Session.tsx:209-270,411-475`).
+- `prefs.ts` stores transcript metadata and system-item booleans in localStorage. Settings places timings, tokens, prompts, and hook exits under Transcript, but places estimated cost under Display (`cmd/evener-hub/frontend/src/stores/prefs.ts:21-35,216-260`; `panes/settings/sections/transcript.tsx:19-47`; `panes/settings/sections/display.tsx:46-58`).
+
+The split causes three visible problems:
+
+1. Everything couples each tool's stated purpose with its call row. Intent removes the call but offers no independent content controls.
+2. Intent bypasses `TurnBlock`, so it can hide failures, warnings, and other critical rows.
+3. The live selector sits in `PaneScaffold.actions`; the pane header is absent on Mobile, so Mobile has no live selector.
+
+Existing browser preferences use flat `evener.prefs.*` keys. Booleans use the exact strings `1` and `0`. In particular, `evener.prefs.showCost` is a pinned compatibility contract (`stores/prefs.ts:8-19,141-160`).
+
+Evener has no user principal or account settings service. Every paired browser uses the same hub capability. The new synced defaults therefore belong to one hub, not one human across independent hubs.
+
+## Vocabulary
+
+The design uses these terms consistently:
+
+- **Hub default:** The Desktop or Mobile configuration stored by one hub and sent to its paired clients.
+- **Local active view:** The Desktop or Mobile configuration stored by one browser. It overrides the matching hub default.
+- **Layout class:** `desktop` or `mobile`, classified by Evener's existing 899px boundary.
+- **Regular level:** One of the five named content presets.
+- **Advanced options:** Independent content, metric, and diagnostic controls.
+- **Critical row:** A row that remains visible at every level because it reports required interaction, active work, steering, warning, denial, interruption, or failure.
+
+## Regular detail levels
+
+The compact control presents five cumulative levels:
+
+| ID | Visible label | Content | Default disclosure state |
+| --- | --- | --- | --- |
+| `chat` | Chat | User and agent conversation | Collapsed where applicable |
+| `intent` | Intent | Chat plus each tool's stated purpose | Collapsed |
+| `tools` | Tools | Intent plus compact tool rows | Tool bodies collapsed |
+| `activity` | Activity | Tools plus reasoning | All eligible bodies collapsed |
+| `full` | Full detail | Same regular content as Activity | All visible eligible bodies open by default |
+
+The narrow stepped track may abbreviate **Full detail** to **Full**, but its accessible name and surrounding readout must use the full label.
+
+Selecting a regular level changes only the regular content vector. It preserves metric and diagnostic options because those options are Advanced-only.
+
+### Full detail and explicit disclosure choices
+
+Entering Full detail opens every currently visible eligible disclosure, including tool, reasoning, and enabled Advanced disclosure bodies. This transition clears prior per-item closed overrides for those entries and establishes a new open baseline. New eligible rows arrive open while Full detail remains active.
+
+After that transition, an explicit per-item collapse wins. The renderer must not reopen a row on every render. Moving to another level and entering Full detail again establishes another open baseline.
+
+## Always-visible critical content
+
+Every regular and Custom view shows compact representations of:
+
+- questions and other input requests;
+- permission and sandbox-escalation requests;
+- active or running work;
+- user steering that changed the run;
+- warnings and denials;
+- failed tool calls and non-zero hook failures;
+- interrupted or failed turns;
+- recovery actions the user can take.
+
+Low-detail views may omit arguments, output, and routine metadata from these rows, but they must preserve identity, status, and the available action. A tool call with no stated purpose renders a neutral summary such as **Action summary unavailable**; it never vanishes.
+
+## Advanced options
+
+Advanced opens one editor with three groups.
+
+### Content
+
+- Tool intent
+- Tool calls
+- Reasoning
+- Expand visible details by default
+
+These fields mirror the regular content vector. Changing one to a combination that matches a regular level normalizes back to that level. Any other combination becomes **Custom**. Custom has no falsely selected regular stop.
+
+### Metrics
+
+- Round timings
+- Token counts
+- Estimated cost
+
+These fields do not change the regular level label. The trigger summarizes additions, for example, **Tools · 2 advanced**. Round timings continues to control both the friendly round annotation and the corresponding raw timing item. Estimated cost controls per-round cost only; session-total cost remains visible in the footer.
+
+### Diagnostics
+
+- Low-level system events
+- System prompt and prompt-loaded events
+- Hook exit messages: `none`, `successful`, or `all`
+
+The hook field replaces the current overlapping `hookExitsNormal` and `hookExitsAll` booleans. Critical non-zero hook failures remain visible in compact form even when the field is `none`; `all` exposes their full diagnostic row.
+
+The Advanced summary and opener are one control, not separate affordances. It summarizes the whole editor, including Custom content and independent extras. Example states include **Advanced · 2 enabled ›** and **Advanced · Custom content · 2 extras ›**. The live popover or sheet uses the same editor and summary rules.
+
+## Configuration model
+
+The shared domain model will have this shape:
+
+```ts
+type ViewportClass = "desktop" | "mobile";
+type TranscriptLevel = "chat" | "intent" | "tools" | "activity" | "full";
+type HookExitDetail = "none" | "successful" | "all";
+
+type ContentSelection =
+  | { kind: "preset"; level: TranscriptLevel }
+  | {
+      kind: "custom";
+      toolIntent: boolean;
+      toolCalls: boolean;
+      reasoning: boolean;
+      expandByDefault: boolean;
+    };
+
+type TranscriptDisplayConfigV1 = Readonly<{
+  version: 1;
+  content: ContentSelection;
+  advanced: Readonly<{
+    roundTimings: boolean;
+    tokenCounts: boolean;
+    estimatedCost: boolean;
+    systemEvents: boolean;
+    promptEvents: boolean;
+    hookExits: HookExitDetail;
+  }>;
+}>;
+```
+
+User and agent messages do not appear as configurable fields. Critical content is also invariant.
+
+Named presets persist by semantic name. A future release may add ordinary content to a named level deliberately. Custom configurations persist a versioned snapshot; a migration must add future Custom fields with a conservative value rather than silently expanding an existing Custom view.
+
+A pure normalizer converts any Custom content vector that exactly matches a preset back to that preset.
+
+## State and precedence
+
+Evener will maintain two configuration layers for each layout class.
+
+### Hub defaults
+
+The hub stores one Desktop configuration and one Mobile configuration. Settings edits these values. The hub publishes changes to every paired client.
+
+A new hub starts with:
+
+- Desktop: Tools
+- Mobile: Intent
+- Advanced fields: all off
+
+These are presentation defaults, not session data.
+
+### Browser-local active views
+
+The browser stores one Desktop configuration and one Mobile configuration in localStorage. The live transcript control edits these values.
+
+A local change:
+
+- updates every open Session and read-only Transcript pane in that browser;
+- updates same-origin tabs through a browser synchronization channel;
+- survives browser restarts;
+- never publishes to the hub.
+
+A browser with no local value follows the matching hub default. The live editor offers **Use hub default**, which deletes the local value for the active layout class.
+
+### Resolution
+
+The effective configuration resolves in this order:
+
+```text
+browser-local active view
+  → hub default
+  → shipped default
+```
+
+A hub-default notification updates every local view that follows that default. A browser-local active view remains stable until the user changes or clears it.
+
+The Settings cards always edit and preview hub defaults. If the current browser has a local active view, Settings explains that the local view continues to override the edited default.
+
+### Browser synchronization
+
+The current preference store deliberately omits cross-tab synchronization. This feature adds synchronization for transcript display preferences only. A same-origin `BroadcastChannel` will notify other tabs; a storage-event path will provide a fallback where available. The originating tab updates its Zustand state directly.
+
+The channel carries browser-local configuration only. Hub defaults continue to arrive through the hub protocol.
+
+## Responsive behavior
+
+Evener will use its existing layout classifier:
+
+- Mobile: `(max-width: 899px)`
+- Desktop: 900px and wider
+
+The browser keeps separate local values for the two classes. Crossing the boundary applies the matching local value, or the matching hub default when no local value exists. Crossing back restores the other class's value.
+
+Every open transcript updates together. The design has no per-pane or per-session exceptions.
+
+The live trigger's compact layout responds to pane width with a container query. This avoids crowding narrow desktop dock panes without creating another device breakpoint.
+
+## Live control
+
+The live control replaces the current Everything/Intent selector.
+
+### Placement
+
+A small transcript-local toolbar sits above the transcript scroller and below critical escalation rails. It remains outside virtualized rows, so it neither scrolls away nor changes row indexing.
+
+The toolbar shows a compact trigger such as **Detail: Tools ▾**. It must remain visible on Mobile, where the pane header is absent.
+
+### Desktop
+
+Desktop opens an anchored popover containing:
+
+1. the five-stop control;
+2. the current scope, such as **Local Desktop view** or **Using hub default**;
+3. the single Advanced disclosure;
+4. **Use hub default** when a local value exists;
+5. a link to **Edit hub defaults**.
+
+### Mobile
+
+Mobile uses the same trigger but opens a bottom sheet. The sheet has a heading, a Close button, focus containment, focus return, and controls with 44px minimum touch targets.
+
+## Settings editor
+
+Settings will consolidate transcript visibility under **Settings → Transcript display**. Estimated cost moves out of Display; composer behavior remains there.
+
+The page contains two stacked cards:
+
+1. Desktop default
+2. Mobile default
+
+Each card presents:
+
+1. the device label and current level;
+2. the five-stop control;
+3. one Advanced summary/disclosure row;
+4. an example conversation directly below the controls;
+5. a textual inventory of shown and hidden categories.
+
+The page explains:
+
+- **Hub defaults sync to devices paired with this hub.**
+- **A live transcript choice is browser-local and does not change another machine.**
+
+Settings sends acknowledged hub mutations. It must not emit an unconditional success toast before durable confirmation.
+
+## Settings preview
+
+Each card uses the same fixed scenario so users can compare Desktop and Mobile settings. The fixture includes:
+
+- a user message;
+- a tool call with a stated purpose;
+- a successful tool row and body;
+- a failed critical tool row;
+- reasoning;
+- an agent response;
+- optional timing, token, and cost values;
+- optional system, prompt, and hook events.
+
+The preview runs through the production projector against fabricated `ThreadModel` data. It does not read `threadsStore`, use a network connection, or copy real user content.
+
+Each preview says **Example only—not your data**. It also lists visible and hidden categories in text. It has no fake streaming, inner scroll region, hover-only explanation, or whole-preview live region.
+
+Controls update the example immediately as a draft. A failed hub write restores the confirmed value and preview, then shows a retryable error.
+
+## Hub persistence and protocol
+
+The current `evener/settings/overview` RPC is read-only. Synced defaults require a new durable hub preference store and typed protocol methods.
+
+The protocol will support:
+
+- reading the canonical Desktop and Mobile defaults;
+- patching one layout class at a time;
+- returning the durable canonical value after a mutation;
+- notifying all paired clients when either default changes.
+
+Desktop and Mobile each carry a monotonic revision. A patch names one layout class and its expected revision, so edits to different classes cannot overwrite one another. The hub rejects a stale same-layout patch and returns the current canonical value for review instead of silently discarding either edit. The server validates the schema version, enum values, and complete Custom vector before writing. A malformed or unsupported request fails without changing the durable record.
+
+These methods use hub scope and the existing hub capability. They do not create a user identity. Every client paired with the hub may read or change the defaults, just as every paired client shares the same hub authority today.
+
+Hub writes must use the repository's existing durable-write pattern and survive restart. Notifications carry the layout class, revision, and canonical configuration; clients ignore stale revisions. A disconnected client refreshes both defaults after reconnect.
+
+## Projection and rendering architecture
+
+A side-effect-free transcript-display domain module will own:
+
+1. preset expansion;
+2. Custom normalization;
+3. effective-config resolution;
+4. typed item classification;
+5. projection to stable entries;
+6. metadata visibility flags;
+7. a stable configuration fingerprint.
+
+The data flow becomes:
+
+```text
+raw shared ThreadModel
+  → effective TranscriptDisplayConfigV1
+  → typed transcript projector
+  → stable projected turns and entries
+  → shared TranscriptBody
+```
+
+The live Session pane, read-only Transcript pane, and Settings examples will use `TranscriptBody`. The current separate focused-entry renderer will disappear.
+
+### Projection rules
+
+The projector will:
+
+- classify by `ItemModel.type` and typed `eventKind`;
+- filter before grouping so counts describe visible items;
+- preserve source order and source IDs;
+- create stable proxy IDs such as `intent:${item.id}`;
+- avoid mutating `ThreadModel` or `ItemModel`;
+- fail open for unknown item and event kinds.
+
+When Intent is visible but Tools is hidden, a command execution projects to an intent proxy. When Tools is visible, the real tool row supersedes the proxy and renders the stated purpose as its first line. The transcript never renders duplicate purpose text for one call.
+
+A protected tool failure may project to a compact critical entry when ordinary tools are hidden. It expands to the ordinary tool representation when Tools is visible.
+
+## Disclosure state
+
+The existing disclosure store remains the source of explicit per-item open and closed choices. The configuration supplies a default state, not a value that reasserts itself on every render.
+
+Entering Full detail establishes a new open baseline for visible eligible entries. Subsequent manual choices win. Activity and lower levels default eligible rows closed without deleting transcript data.
+
+The Settings examples use isolated disclosure scope so preview interactions cannot affect real sessions.
+
+## Scroll and focus preservation
+
+Every effective-configuration change uses the configuration fingerprint as the transcript view key.
+
+Before projection changes, each mounted transcript captures:
+
+- the top visible stable entry;
+- its viewport offset;
+- whether the reader is following the bottom;
+- the currently focused transcript entry, when any.
+
+After measurement, the pane restores the same entry and offset. If that entry is hidden, it restores the nearest surviving user or agent message. If none survives, it preserves normalized scroll position. A pane following the bottom remains at the bottom.
+
+The current click handler captures only the pane where the user clicked. The new mechanism must also handle changes from Settings, another local session, another tab, a hub notification, and a breakpoint crossing.
+
+If a change removes the focused entry, focus returns to the Detail trigger and a concise status announces the selected view. Evener must not announce every hidden or newly visible row.
+
+## Accessibility
+
+The five-stop control looks like a stepped slider but uses a labelled radio group. Each stop is a named radio option that pointer and voice input can address directly; Arrow, Home, and End keys move roving focus among the options.
+
+Requirements:
+
+- Keep all stop labels visible.
+- Expose **Full detail** as the accessible name when the track displays **Full**.
+- Use shape, text, or position in addition to color for selection.
+- Expose Custom as text; do not mark a nearest preset.
+- Give Mobile controls at least 44px touch targets.
+- Give the popover and sheet a heading and deterministic focus return.
+- Group Advanced options in labelled fieldsets.
+- Explain disabled dependent fields with text and retain their stored values.
+- Announce a committed preview change with a short polite status; do not make the preview itself live.
+- Respect reduced-motion settings.
+
+## Migration
+
+### Legacy browser keys
+
+The migration recognizes these existing values:
+
+- `transcriptRoundTimings`
+- `transcriptTokenCounts`
+- `transcriptHookExitsAll`
+- `transcriptHookExitsNormal`
+- `transcriptPromptLoaded`
+- `showCost`
+
+If any legacy visibility key exists and no new browser-local config exists, the browser writes equivalent local Desktop and Mobile configurations:
+
+- regular level: Activity;
+- low-level system events: on, matching the old Everything path;
+- round timings, tokens, prompt events, and estimated cost: existing values with their legacy fallbacks;
+- hook exits:
+  - all off → `none`
+  - normal on and all off → `successful`
+  - all on → `all`
+
+The legacy fallbacks are timings on, tokens off, prompt events on, estimated cost off, and hook exits off. These values reproduce the old browser's effective view rather than applying the new hub defaults during migration.
+
+The migrated configurations are local active views, not hub defaults. Migration on one browser must not change another machine.
+
+The migration cannot recover a current Intent selection because the old selector never persisted it.
+
+### Fresh-versus-untouched ambiguity
+
+A browser that never wrote a legacy key is indistinguishable from a fresh browser. It receives no synthetic local override and follows the new hub defaults: Desktop Tools and Mobile Intent.
+
+### Compatibility window
+
+The migration will not delete legacy keys. Browser-local Advanced changes will dual-write the legacy transcript flags and `showCost` for the first stable release that includes this feature. Boolean values keep the exact `1` and `0` encoding. Removing the adapters requires a separate, approved migration after older clients leave the supported set.
+
+An older client cannot represent the five-level selection because no legacy persistent key exists. It can still recover the dual-written metric and diagnostic flags.
+
+## Error handling
+
+### Browser storage
+
+Malformed or unsupported local values behave as absent. A blocked or full localStorage keeps the change live in memory and reports that it will not survive restart. The UI must not claim persistence when the write fails.
+
+### Hub state
+
+A missing hub record uses the shipped defaults. The hub rejects a malformed durable record at the storage boundary, reports the condition for diagnosis, and uses shipped defaults without hiding critical rows.
+
+A failed settings mutation leaves the last confirmed hub default active and offers retry. A disconnected browser keeps local controls available and refreshes hub defaults on reconnect.
+
+### Projection
+
+Unknown item and event kinds render as compact raw rows. Missing descriptions, metadata, pricing, or duration values omit only that optional field. They do not suppress the containing message, action, or failure.
+
+## Testing
+
+Default tests use fabricated models and scripted RPC boundaries. They never depend on provider credentials, network access, quota, or current model behavior.
+
+### Pure configuration tests
+
+- Expand each preset to its exact vector.
+- Prove the five regular vectors are cumulative.
+- Normalize every preset-shaped Custom vector.
+- Round-trip arbitrary versioned Custom configurations.
+- Preserve independent metric and diagnostic values across regular-level changes.
+- Reject malformed versions and enum values.
+
+### Projection tests
+
+- Cover every current item type and event kind.
+- Cover blank tool descriptions, failed tools, non-zero hooks, interrupted turns, and unknown future kinds.
+- Prove critical rows remain visible at every level.
+- Prove Tools supersedes its Intent proxy without duplicate purpose text.
+- Prove filtering precedes grouping and keeps counts accurate.
+- Prove projection preserves order, stable IDs, and source immutability.
+
+### Rendering tests
+
+- Render equivalent output in Session, read-only Transcript, and Settings previews.
+- Cover each regular level and representative Custom vectors.
+- Cover entering Full detail, manual collapse, new streaming rows, and leaving Full detail.
+- Cover Settings preview drafts, confirmed writes, and failed-write reversion.
+- Cover missing metrics and pricing without placeholders.
+
+### State and persistence tests
+
+- Resolve local view over hub default over shipped default.
+- Keep Desktop and Mobile values independent.
+- Update every local pane and same-origin tab without a hub publication.
+- Restore local values after restart.
+- Clear one layout with **Use hub default**.
+- Apply hub notifications only to followers.
+- Handle malformed and blocked browser storage.
+- Cover the legacy migration truth table and exact dual-write encoding.
+
+### Hub tests
+
+- Read shipped defaults from an empty store.
+- Persist Desktop and Mobile patches independently across restart.
+- Validate and reject malformed mutations.
+- Reject stale same-layout revisions and return the canonical value.
+- Notify every paired client with canonical values and monotonic revisions.
+- Ignore stale notifications.
+- Refresh after reconnect.
+- Cover failed durable writes and concurrent same-layout and cross-layout edits.
+
+### Scroll, responsive, and accessibility tests
+
+- Preserve anchors for local, cross-tab, hub, and breakpoint changes.
+- Preserve bottom-follow state.
+- Restore focus when a row disappears.
+- Switch at the existing 899px boundary and restore each class's local value.
+- Keep the live control reachable on Mobile and in a narrow desktop pane.
+- Verify radio-group keyboard behavior, visible labels, Custom state, sheet focus containment, focus return, and touch geometry.
+
+### Verification gates
+
+Implementation will run focused Go and Vitest tests, then:
+
+- `make test-web`
+- `make test-web-browser`
+- `make lint`
+- `make vet`
+- `make test`
+
+Frontend files under `src/` will pass the repository's required Biome formatting step before the frontend gates.
+
+## Alternatives considered
+
+### Persistent stepped toolbar
+
+A toolbar would make the five levels maximally discoverable. It would also consume vertical space in every transcript and crowd narrow panes. The approved design keeps a compact trigger visible and opens the full control on demand.
+
+### Native select
+
+A native select would provide strong platform accessibility and compact Mobile behavior. It would hide the progression from Chat to Full detail. The approved radio track preserves named, directly selectable stops while looking like the requested slider.
+
+### Layer-first editor
+
+A layer stack would explain how each preset is composed and scale to more categories. It would expose implementation concepts to regular users. The approved design puts the named ladder first and moves independent fields under Advanced.
+
+### Named view profiles
+
+Saved profiles would support reusable combinations such as cost audits or hook debugging. They would add naming, deletion, references, versioning, and conflict semantics without demonstrated demand. The approved design supports one local active view and two hub defaults.
+
+### Account-wide synchronization
+
+Account-wide defaults would sync across independent hubs. Evener has no user principal or shared settings service. The approved design uses one hub's existing pairing boundary and keeps live choices browser-local.
+
+## Acceptance criteria
+
+The design is implemented when:
+
+1. Every transcript uses one effective configuration and one projection pipeline.
+2. The live control offers Chat, Intent, Tools, Activity, and Full detail on Desktop and Mobile.
+3. Critical rows remain visible in every regular and Custom view.
+4. Advanced fields control content, metrics, and diagnostics independently.
+5. A live change updates all local sessions, survives restart, and does not change another machine.
+6. Settings stores separate Desktop and Mobile defaults on the hub and syncs them to paired clients.
+7. Settings shows stacked device cards with controls above production-backed example conversations.
+8. The preview contains no real transcript data and matches live projection semantics.
+9. Layout changes, local sync, hub updates, and breakpoint crossings preserve scroll and focus.
+10. Explicit legacy preferences migrate locally without deleting or re-encoding pinned keys.
+11. Storage and protocol failures remain visible and never produce a false saved state.
+12. The focused tests and repository gates pass.

--- a/docs/superpowers/specs/2026-08-25-tree-transport-optimization-design.md
+++ b/docs/superpowers/specs/2026-08-25-tree-transport-optimization-design.md
@@ -1,0 +1,957 @@
+# Navigation Transport Optimization Design
+
+**Date:** 2026-08-25
+**Status:** approved design, pending implementation plan
+**Scope:** replace the Web UI's monolithic `/api/tree` refresh path with revisioned, resource-scoped navigation snapshots while preserving current navigation behavior.
+
+## Problem
+
+The Web UI repeatedly transfers and parses a large `/api/tree` response. The observed response is about 429 KB. At one request every 10 seconds, that rate is about 151 MiB per hour and 3.5 GiB per day for one open tab.
+
+The current React client has no periodic `/api/tree` timer. It loads the tree once, then refetches the complete response after:
+
+- `thread/started`;
+- `thread/closed`;
+- `evener/attention/changed`;
+- `evener/tree/changed`;
+- an AppWire reconnect;
+- a successful rail mutation; or
+- a manual retry.
+
+Notification requests use a 250 ms trailing debounce. The debounce combines a close burst, but a later event or an event received while another request is in flight starts another full request. Older requests are not aborted. A generation guard prevents an old response from committing, but only after the browser has downloaded and parsed it.
+
+The backend memoizes the core `hubcore.Tree` by input version, remote generation, and a 30-second time bucket. That cache does not cover the complete request. Every request still:
+
+1. copies roster and past-index data;
+2. clones the remote-thread snapshot;
+3. resolves project identities;
+4. reads archive, favorite, and pin data;
+5. projects every REST row;
+6. serializes the complete response.
+
+The wire response also duplicates data. Every active and test project includes as many as 50 rows in each of three tiers even when the project is collapsed. A session can appear again in Live, Needs You, and a pin section. Only archived projects use lazy stubs.
+
+The server sends plain JSON without `ETag`, conditional revalidation, gzip, or a serialized-response cache. A deterministic 1,000-session probe produced a 574 KB response. On an Apple M5 Max, warm full requests took roughly 13–22 ms and allocated about 23 MiB per request. A synthetic gzip pass reduced the repetitive fixture to 18.6 KB; the exact production ratio remains unmeasured.
+
+## Goals
+
+The redesign must:
+
+- make idle navigation traffic zero after initial hydration, except after reconnect or a real semantic change;
+- bound each navigation response independently of sessions hidden in collapsed projects;
+- rebuild and serialize a resource once per semantic revision, not once per client request;
+- fetch only resources affected by a change;
+- prevent mutation responses, AppWire notifications, and overlapping refreshes from duplicating requests;
+- retain last-good data and isolate project failures;
+- preserve Live, Needs You, pins, project tiers, pagination, deep links, mutations, reconnect behavior, and notification semantics;
+- provide measurements that prove request, byte, allocation, and build reductions; and
+- retire the legacy tree architecture rather than maintain two permanent paths.
+
+## Non-Goals
+
+This design does not:
+
+- add Server-Sent Events or another live transport;
+- introduce an ordered patch log, replay protocol, or event-sourced client model;
+- change session transcript, task, activity, search, or mutation APIs except where a mutation returns navigation revision metadata;
+- virtualize rail rendering;
+- change project grouping, tier classification, attention ranking, pinning, or archive semantics; or
+- make HTTP caches shared across users or hubs.
+
+## Chosen Architecture
+
+Use **revisioned, resource-scoped pull**.
+
+HTTP remains authoritative. AppWire announces which bounded HTTP resources became stale. The client conditionally revalidates those resources. This model avoids both extremes:
+
+- hardening the existing monolith would still transfer the full tree after every real change;
+- a normalized delta stream would require patch ordering, replay retention, gap recovery, tombstones, and a more failure-prone client reducer.
+
+The design introduces a small manifest, bounded project resources, one server-side `NavigationService`, one typed invalidation, and one client-side resource revalidator.
+
+## Resource Model
+
+### Wire conventions
+
+All arrays are present and non-null. Optional scalar fields are omitted when
+unknown. `generation_id` is a non-empty opaque string. Revisions and AppWire
+sequences are nonnegative integers no greater than JavaScript's
+`Number.MAX_SAFE_INTEGER`. The server returns the existing JSON error envelope
+for 4xx and 5xx responses.
+
+Collection queries accept a nonnegative `offset` and a `limit` from 1 through
+the endpoint's hard maximum. Offsets are unsigned 32-bit integers. Implementations
+must index an immutable slice or indexed query directly rather than scan to the
+offset; an offset at or beyond the collection length returns 200 with an empty
+page and `remaining: 0`. Invalid enum, offset, limit, or extra pagination
+combinations return 400. Collection order is stable:
+
+- Live and Needs You retain the current authoritative tree order;
+- pin sections sort case-insensitively by name, then ID;
+- project catalogs retain the current project-bucket order; and
+- project tiers retain the current most-recent-first order.
+
+### Navigation manifest
+
+`GET /api/navigation` returns `NavigationManifest`:
+
+```text
+NavigationManifest {
+  generation_id: string
+  revision: number
+  sources: Source[]
+  attentionSummary: AttentionSummary
+  sections: {
+    live: ResourceDescriptor
+    needs_you: ResourceDescriptor
+    pin_sections: ResourceDescriptor
+  }
+  catalogs: {
+    projects: ResourceDescriptor
+    archived_projects: ResourceDescriptor
+    test_runs: ResourceDescriptor
+  }
+}
+
+ResourceDescriptor { count: number }
+Source { id: string, label: string, kind: string, online: bool }
+AttentionSummary { needsYou: number, error: number, working: number }
+```
+
+`generation_id` identifies one running server generation. `revision` is the
+manifest's monotonic revision within that generation. The manifest contains no
+session rows, project summaries, or pin-section descriptors. Hidden sessions
+therefore cannot enlarge it. A hub accepts at most 64 configured sources; startup
+rejects a larger source set. These rules make the manifest itself bounded.
+
+### Global section resources
+
+Global rows use bounded resources:
+
+- `GET /api/navigation/sections/live`;
+- `GET /api/navigation/sections/needs-you`; and
+- `GET /api/navigation/pin-sections/{id}`.
+
+Each returns:
+
+```text
+NavigationSectionResource {
+  generation_id: string
+  revision: number
+  sessions: NavigationSessionSummary[]
+  remaining: number
+  truncated: bool
+}
+```
+
+The first two endpoints and each pin section allow `offset` and `limit`, with a
+hard maximum of 50 top-level rows per response. Rows remain reachable through
+additional pages. A session shared by Live and Needs You can appear in both
+bounded resources; the client does not maintain a cross-resource entity graph.
+
+Pin-section descriptors use
+`GET /api/navigation/pin-sections?offset=<n>&limit=<n>`. The endpoint returns
+generation, revision, up to 100 `{id, name, count}` descriptors, and `remaining`:
+
+```text
+NavigationPinSectionCatalog {
+  generation_id: string
+  revision: number
+  pin_sections: PinSectionDescriptor[]
+  remaining: number
+}
+
+PinSectionDescriptor { id: string, name: string, count: number }
+```
+
+The manifest's pin-section count tells the client whether to load this catalog.
+
+`NavigationSessionSummary` contains only navigation data that current consumers
+use:
+
+- ref, host ID, and session ID;
+- title and project label;
+- state, kind, live, ask-pending, and dormant facts;
+- branch, cluster count, favorite, rename, and subagent-overflow facts when present;
+- updated timestamp; and
+- recursive children.
+
+Its exact shape is:
+
+```text
+NavigationSessionSummary {
+  ref: string
+  host_id: string
+  session_id: string
+  title: string
+  project: string
+  state: "errored" | "awaiting" | "active" | "warning" | "idle" | "ended" | "notLoaded"
+  kind: "session" | "subagent" | "fork" | "cluster"
+  branch?: string
+  cluster_count?: number
+  favorite?: bool
+  rename?: bool
+  live: bool
+  ask_pending?: bool
+  dormant?: bool
+  updated_at?: RFC3339 string
+  more_subagents?: number
+  omitted_descendants?: number
+  children: NavigationSessionSummary[]
+}
+```
+
+Clients derive `row_id`, pin-section membership, tier, and display age from the
+owning resource. The new wire contract omits the unused `model` field and the
+server-formatted `age` field.
+
+Every response that carries `NavigationSessionSummary` applies the same hard
+bounds: 50 top-level rows per page, 50 children per row, 2,000 total nodes, 32
+levels, and 2 MiB of uncompressed JSON. The encoder stops before a row or branch
+would cross a node, depth, or byte bound, sets resource-level `truncated: true`,
+and records `omitted_descendants` on the cut parent when known. Top-level rows
+not emitted remain reachable through the next page.
+
+The projection also enforces wire string bounds before byte accounting: titles
+remain capped at 200 runes; project/source/pin labels and branch names at 512
+runes; refs and opaque IDs at 1,024 bytes; and working directories at 4,096
+bytes. Display strings truncate rune-safely with an ellipsis. An identity that
+exceeds its validated bound is malformed input and produces an explicit row or
+resource error; it is never truncated into a different identity.
+
+The manifest has a 256 KiB uncompressed ceiling. Pin-descriptor and project-
+catalog pages have a 512 KiB uncompressed ceiling. With the source, row, and
+string caps these ceilings are defensive; a paged collection stops before the
+next descriptor would cross its ceiling and includes that descriptor in
+`remaining`. A manifest that violates its ceiling is an internal invariant
+failure and returns 500 rather than a partial authority document.
+
+### Project catalogs
+
+Project headers use three bounded catalog resources:
+
+- `GET /api/navigation/catalogs/projects`;
+- `GET /api/navigation/catalogs/archived-projects`; and
+- `GET /api/navigation/catalogs/test-runs`.
+
+Each catalog accepts `offset` and `limit`, with a hard maximum of 100 summaries
+per response, and returns:
+
+```text
+NavigationProjectCatalog {
+  generation_id: string
+  revision: number
+  projects: NavigationProjectSummary[]
+  remaining: number
+}
+```
+
+`NavigationProjectSummary` has this exact shape:
+
+```text
+NavigationProjectSummary {
+  key: string
+  name: string
+  working_dir?: string
+  rollup_state?: string
+  rollup_live?: number
+  rollup_attn?: number
+  default_expanded?: bool
+  more_current?: number
+  more_recent?: number
+  more_archived?: number
+  worktrees?: number
+  is_archived?: bool
+  favorite?: bool
+  session_count: number
+}
+```
+
+It preserves:
+
+- key and name;
+- working directory where currently exposed;
+- rollup state and counts;
+- default expansion;
+- tier overflow counts;
+- worktree count;
+- archived, favorite, and test-run placement; and
+- authoritative session count.
+
+Project summaries do not carry project-resource revisions. AppWire project
+targets invalidate loaded project representations directly; reconnect and event
+gap recovery conditionally revalidate them.
+
+### Project resource
+
+`GET /api/navigation/projects/{key}` returns one `NavigationProjectResource`:
+
+```text
+NavigationProjectResource {
+  generation_id: string
+  revision: number
+  key: string
+  current: NavigationTier
+  recent: NavigationTier
+  archived: NavigationTier
+  truncated: bool
+}
+
+NavigationTier {
+  sessions: NavigationSessionSummary[]
+  remaining: number
+}
+```
+
+Each tier returns the first bounded page. Every root and page request enforces a
+maximum of 50 top-level rows per tier and the common recursive-node, depth,
+string, and 2 MiB byte bounds defined above. A cut branch sets `truncated` and
+reports omitted descendants under the common contract.
+
+Existing top-level pagination moves under the project resource:
+
+`GET /api/navigation/projects/{key}?tier=<tier>&offset=<n>&limit=<n>`
+
+`tier` is exactly `current`, `recent`, or `archived`; offset is nonnegative; and
+limit is 1 through 50. A page response contains one `NavigationTier`, not all
+three tiers, and has this envelope:
+
+```text
+NavigationProjectPage {
+  generation_id: string
+  revision: number
+  key: string
+  tier: "current" | "recent" | "archived"
+  offset: number
+  sessions: NavigationSessionSummary[]
+  remaining: number
+  truncated: bool
+}
+```
+
+A project response owns its row tree. The client does not merge project rows
+into a global entity graph. This deliberate simplification avoids entity
+lifetime, garbage collection, and cross-resource merge rules. A globally
+visible session may exist once in a bounded global section and once in its
+loaded project, but duplication is bounded and resource ownership remains
+explicit.
+
+### Session location
+
+The current client scans every loaded project row to find a deep-linked session's top-level owner. The new API must make that relationship explicit.
+
+`GET /api/navigation/sessions/{ref}` returns:
+
+```text
+NavigationSessionLocation {
+  generation_id: string
+  revision: number
+  ref: string
+  top_level_ref: string
+  project_key?: string
+  top_level: bool
+}
+```
+
+`NavigationService` builds the location index with the immutable core tree. The
+endpoint carries generation and revision metadata but is read on
+demand and is not a long-lived client resource. A missing session returns 404.
+This endpoint avoids both a complete session-to-project map in the manifest and
+the existing session-detail path's full live-thread read.
+
+## Revision Model
+
+Revisions are comparable only within a `generation_id`.
+
+- `generation_id` is an opaque value created when the hub starts.
+- `sequence` is a JSON-safe nonnegative integer that increases for every navigation invalidation in that generation.
+- each resource revision is a JSON-safe nonnegative integer that increases only when that resource's semantic content changes.
+- validators include the generation and resource revision, so a hub restart cannot collide with an earlier cached representation.
+
+The client resets revision comparisons and conditionally revalidates loaded resources when `generation_id` changes.
+
+`sequence` belongs only to the ordered AppWire stream and initialize response.
+It is not part of an HTTP representation, response header, cache key, or ETag.
+HTTP resources carry only generation and resource revision. This separation
+keeps unrelated invalidations from changing cached response metadata.
+
+The server event is:
+
+```text
+evener/navigation/invalidated {
+  generation_id: string
+  sequence: number
+  targets: [
+    { kind: "manifest", revision: 44 },
+    { kind: "section", section: "live", revision: 12 },
+    { kind: "pin_catalog", revision: 9 },
+    { kind: "pin_section", section_id: "opaque-id", revision: 8 },
+    { kind: "catalog", catalog: "projects", revision: 21 },
+    { kind: "project", project_key: "opaque-key", revision: 18 },
+    { kind: "all_loaded_projects" }
+  ]
+}
+```
+
+The first AppWire initialize response and each reconnect response carry the
+current navigation `generation_id`, `sequence`, and capability version. AppWire
+preserves event order. A sequence gap causes conditional revalidation of the
+manifest and every loaded section, pin-descriptor page, catalog page, and
+project representation.
+Reconnect performs the same recovery, so the server needs no replay log.
+
+Section and pin-catalog targets apply to every loaded page of that collection.
+Catalog targets apply to every loaded page of that project catalog. Project
+targets apply to the root and every loaded tier page for that key. All those
+representations share the target's semantic revision but retain distinct ETags.
+When a producer cannot
+identify the affected project safely, it emits `all_loaded_projects`, which has
+no revision. The client conditionally revalidates every loaded project
+representation and accepts either a 304 or its current revision. Collapsed
+projects remain unloaded.
+
+## Server Architecture
+
+### `NavigationService`
+
+One service owns navigation state and presentation. It provides:
+
+1. a composite semantic generation;
+2. immutable core tree snapshots;
+3. per-resource revisions;
+4. cached manifest and project objects;
+5. cached encoded JSON;
+6. cached gzip representations;
+7. weak semantic ETags;
+8. bounded LRU eviction for project/page representations; and
+9. typed invalidation publication.
+
+Each `WebServer` owns exactly one `NavigationService`. The service and every
+cache it owns are scoped to that server's state root, source registry, stores,
+and auth guard. No cache is package-global or shared across WebServer instances,
+users, hubs, or auth scopes.
+
+HTTP handlers ask the service for an encoded resource. They do not copy metadata, resolve projects, query decision stores, rebuild rows, or encode JSON on a cache hit.
+
+The cache lookup occurs before expensive snapshot assembly. A representation
+key contains resource identity, server generation, and that resource's semantic
+revision. It does not contain every source generation.
+
+Stores that lack a cheap revision must expose one. After durable commit, a
+store compares the new content fingerprint with its prior fingerprint. It
+advances its source revision and emits a change set only when semantic content
+changed; a successful no-op write advances neither.
+
+The invalidator maps source changes to resource revisions through this
+dependency matrix:
+
+The shared **session projection fingerprint** covers every
+`NavigationSessionSummary` field and recursive membership: identity, title,
+project label, state, kind, branch, cluster count, favorite, rename, live,
+ask-pending, dormant, updated timestamp, subagent/descendant overflow, and child
+fingerprints. The core snapshot maintains reverse membership from a session ref
+to each section and project representation that currently contains it. A
+projection-fingerprint change advances every containing resource.
+
+| Resource | Dependencies |
+|---|---|
+| Manifest | sources, attention totals, global-section counts, pin-section count, project-catalog counts |
+| Pin catalog | pin definitions, names, order, and member counts |
+| Live section | membership/order plus every contained session projection fingerprint |
+| Needs You section | eligibility/membership/order, archive decisions, plus every contained session projection fingerprint |
+| Pin section | pin membership/order plus every contained session projection fingerprint |
+| Project catalog | every `NavigationProjectSummary` field, membership, placement, and order |
+| Project and pages | tier membership/order plus every contained session projection fingerprint and tier clock |
+| Session location | session identity, lineage, top-level status, and project membership |
+
+A source change advances only dependent resources. An unknown scope widens to
+the applicable catalog/section and loaded-project targets; it never forces an
+unrelated resource cache miss merely because a global store counter advanced.
+
+### Build and publication
+
+The service single-flights each representation key. Concurrent misses join one
+snapshot, build, encode, and compression operation.
+
+On the owning cache miss, the service:
+
+1. captures one immutable input snapshot;
+2. resolves each distinct project identity once;
+3. builds the core tree once;
+4. derives resource projections from that tree;
+5. encodes and compresses each requested resource once; and
+6. rereads the relevant source and resource revisions;
+7. discards and retries from a fresh snapshot if any dependency changed; and
+8. publishes the complete cache entry atomically only when the captured
+   revisions still match.
+
+Retry is bounded by the request context, not a fixed attempt count. If churn
+prevents a coherent capture before the context ends, the request returns 503
+and preserves the last-good entry. An invalidation that arrives during a build
+therefore cannot publish stale data under the new revision.
+
+A failed build or serialization does not replace the last-good entry. The request returns 5xx, and clients retain stale data with an error state.
+
+Project, section, and catalog resources may encode lazily. Their representation
+identity includes the canonical endpoint kind, validated key or section,
+canonical tier when present, offset, and limit. Their ETag includes that
+identity, generation, and semantic resource revision. The cache retains only
+the current generation and evicts least-recently-used entries after 256
+representations or 64 MiB of combined estimated object, encoded, and compressed
+bytes, whichever limit it reaches first. These defaults are named constants and
+observable through cache metrics.
+
+### Time-based classification
+
+The current cache's 30-second bucket changes relative age and tier calculations only when another request arrives. The new resource model must not poll merely to advance time.
+
+Rows carry timestamps; the browser derives display age. The service schedules
+the next actual 24-hour or 14-day tier boundary. At that boundary it advances
+the affected project revision. It advances an affected catalog only when tier
+overflow, placement, order, or another catalog summary field changes. The
+manifest advances only if that catalog change alters a manifest count. The
+scheduler always targets the earliest known boundary and resets when inputs
+change.
+
+### Change scoping
+
+One invalidator receives typed change sets from roster, past index, remote snapshots, archive, favorite, pins, and time classification.
+
+A change set identifies:
+
+- affected manifest descriptors, global sections, and catalogs;
+- affected old and new project keys;
+- affected pin sections; and
+- whether the project scope is unknown.
+
+The invalidator compares the affected resource's semantic fingerprint, advances
+each changed resource once, and emits one event. A project change invalidates a
+catalog only when membership, placement, order, or header data changed. It does
+not invalidate the manifest because the manifest contains only catalog counts,
+not project summaries or resource revisions. A section, pin, or catalog change
+invalidates the manifest only when a count stored in the manifest changed.
+
+Existing `thread/started`, `thread/closed`, and
+`evener/attention/changed` messages retain their own consumers, but they no
+longer invalidate navigation on the client. The empty `evener/tree/changed`
+notification retires after migration.
+
+## HTTP Semantics
+
+Navigation responses use:
+
+- `Cache-Control: private, no-cache`;
+- `Vary: Accept-Encoding`;
+- a weak ETag derived from resource ID, generation ID, and resource revision;
+- `Content-Encoding: gzip` when the client accepts gzip;
+- an accurate `Content-Length` for cached representations; and
+- `X-Evener-Navigation-Generation` and `X-Evener-Navigation-Revision` headers
+  matching the JSON body.
+
+A matching `If-None-Match` returns 304 with no body. A 304 still carries
+generation, revision, cache, ETag, and variation headers. Event sequence never
+appears in an HTTP representation or 304.
+
+`generated_at`, if retained for diagnosis, does not affect the ETag or semantic revision.
+
+Authentication remains the existing hub auth guard. The router URL-decodes each
+project key, pin-section ID, or session ref exactly once, rejects malformed or
+noncanonical encodings with 400, and validates the decoded identity against the
+same immutable authorized snapshot used to build the response. A well-formed
+identity absent from that snapshot returns 404. Arbitrary keys cannot select a
+filesystem path or bypass project membership.
+
+Responses are private because titles, project paths, and session state can be
+sensitive. Access logs record only route class, status, duration, and byte
+counts. Metrics, diagnostics, and ordinary access logs must not contain raw URL
+paths, query strings, project keys, pin IDs, titles, prompts, refs, or filesystem
+paths.
+
+## Client Architecture
+
+### Store shape
+
+Replace the singleton `TreeResponse` authority with:
+
+- manifest data and manifest resource state;
+- global-section and pin-section pages;
+- project-catalog pages;
+- project resources keyed by project key;
+- project detail/page state;
+- expansion state;
+- last-good values; and
+- one resource revalidator.
+
+Each resource state contains:
+
+```text
+ResourceState<T> {
+  generation_id
+  revision
+  target_revision
+  force_token
+  value
+  status
+  error
+}
+```
+
+`status` distinguishes initial loading, ready, refreshing, and stale-error states. An error never erases `value`.
+
+`force_token` is a client-local counter used only for revisionless recovery
+targets such as `all_loaded_projects`, reconnect, and sequence gaps. Advancing it
+requires one conditional revalidation; either a 304 or a valid 200 satisfies the
+token.
+
+### Revalidator
+
+The generic revalidator owns all navigation fetches.
+
+- At most one request per resource may run at once.
+- A typed invalidation raises `target_revision` for every loaded representation
+  covered by its target.
+- If an event arrives during a request, the revalidator performs at most one trailing request unless the completed response already satisfies the target.
+- A response commits only when its generation matches and its revision satisfies the current target.
+- An obsolete request is aborted when possible; a completed obsolete response is discarded.
+- Mutation responses and AppWire events enter the same target-revision path.
+- Unknown resource IDs and revision regressions record protocol errors and trigger manifest recovery.
+
+This replaces `refreshGeneration`, uncancelled overlapping whole-tree requests, feature-owned refresh calls, and notification-specific fetch timers.
+
+### Initial load and expansion
+
+On boot, the client:
+
+1. connects AppWire;
+2. conditionally fetches the manifest;
+3. fetches the first Live, Needs You, pin-descriptor, and active-project
+   catalog pages;
+4. fetches each discovered nonempty pin section and any other visible project
+   catalog pages;
+5. renders each resource as it arrives;
+6. combines saved expansion overrides with server defaults; and
+7. fetches expanded project resources with a concurrency limit of four.
+
+Collapsed projects issue no project request. Expanding one project loads that resource. Collapsing it may retain its bounded last-good cache entry until LRU eviction.
+
+### Live updates
+
+On `evener/navigation/invalidated`, the client raises targets only for named resources. It does not use a time-based debounce. Resource targets naturally coalesce.
+
+A successful mutation returns:
+
+```text
+navigation {
+  generation_id
+  targets
+}
+```
+
+The client feeds this metadata to the revalidator. When the matching AppWire event arrives, the resource target is already satisfied or in flight, so it causes no duplicate request.
+
+`evener/attention/changed` updates the dedicated alert, title, and badge state directly from its existing payload. It does not fetch navigation. The navigation invalidation independently updates Needs You membership or project rollups when those resources change.
+
+### Reconnect and gaps
+
+After reconnect, the client conditionally revalidates the manifest and every
+loaded section, catalog page, and project representation. If the server
+generation changed, it clears revision comparisons but keeps last-good values
+until replacements arrive. The initialize response seeds the new generation
+and current AppWire sequence.
+
+A sequence gap follows the same path. Recovery never guesses or applies a partial delta.
+
+## Failure Behavior
+
+### Manifest failure
+
+A failed initial load shows the existing navigation error/retry state. A failed refresh keeps the last-good manifest and marks it stale. Global navigation remains usable where its existing data permits.
+
+### Project failure
+
+A failed project request affects only that project. The expanded row shows an inline stale/error state and retry action while retaining old rows. Other projects and global sections remain usable.
+
+A project 404 removes its cached representations and conditionally revalidates
+the loaded page of its last-known catalog. If the catalog is unknown or the
+project may have moved, it revalidates loaded pages of all three project
+catalogs. It then revalidates the manifest if returned catalog counts changed.
+The client removes the project header only from an authoritative catalog
+response; it does not silently present an empty project as authoritative.
+
+Section and catalog failures follow the same resource-local rule. A failed next
+page preserves prior pages and leaves an explicit retry row at the failed
+boundary.
+
+### Protocol failure
+
+An unknown resource, impossible revision regression, generation mismatch inside one response, or contradictory 304 is a protocol error. The client records the condition and conditionally revalidates the manifest. It does not mutate state speculatively.
+
+### Server failure
+
+Build, store-read, serialization, or compression failures return a specific 5xx response and preserve last-good cached data. The server must not convert a failed input read into an empty authoritative resource.
+
+## Observability
+
+Measure the new boundary without logging sensitive values.
+
+Server metrics or structured diagnostics must include:
+
+- request count by resource class and status;
+- uncompressed and transferred bytes;
+- 200 and 304 counts;
+- object, encoded, and compressed cache hits and misses;
+- snapshot, project-resolution, tree-build, projection, encoding, and compression durations;
+- rows emitted by resource class;
+- cache entries, bytes, and evictions;
+- invalidations emitted by resource class; and
+- invalidations widened to `all_loaded_projects`.
+
+Client diagnostics must include:
+
+- invalidations received;
+- resource targets coalesced;
+- requests started, aborted, trailed, and completed;
+- 304 responses;
+- stale responses discarded;
+- reconnect and sequence-gap revalidations; and
+- resources in stale-error state.
+
+Diagnostics categorize resources as manifest, section, catalog, project,
+location, or page. They do not record project keys, pin IDs, session refs,
+titles, prompts, raw URLs, query strings, or paths.
+
+## Compatibility and Retirement
+
+The bundled UI and server ship together, but `hubapi.Client.Tree` exposes `/api/tree`. Migration therefore uses a temporary adapter.
+
+During migration:
+
+- `/api/tree` projects the legacy response from `NavigationService`'s immutable core snapshot;
+- the adapter has ETag and gzip support;
+- the adapter does not retain a separate snapshot builder, cache, or invalidator;
+- the bundled UI stops calling it; and
+- `hubapi` gains new manifest and project methods.
+
+Initialize advertises `navigationResources: 1`. Capability absence is the only
+condition that permits the bundled UI to use `/api/tree`. A server that
+advertises version 1 but returns an invalid resource response produces the
+resource's stale/error state; the client must not silently fall back and mask a
+protocol defect. An unsupported future capability version fails explicitly.
+
+The migration release supports the legacy UI path and `/api/tree` adapter. The
+next release removes the legacy UI path after browser and integration tests show
+zero fallback use against a version-1 server. That release also removes the
+server adapter unless the repository's published API policy requires waiting
+for a named breaking release; in that case `/api/tree` remains only as the thin
+adapter, is marked deprecated, and has an explicit removal version. It may not
+block removal of the old builder, store, notifications, or refresh policy.
+
+If public compatibility requires retaining `Client.Tree` after the server
+endpoint retires, that client method may assemble the legacy return type from
+the new bounded resources. The server must not retain the monolithic endpoint
+as a second architecture.
+
+## Rollout
+
+### Phase 1: baseline and service
+
+- Add current-path request, byte, duration, allocation, and row-count baselines.
+- Add store revisions and `NavigationService`.
+- Add new endpoints, HTTP validators, gzip, caches, and invalidation types.
+- Keep the existing UI unchanged.
+
+### Phase 2: client migration
+
+- Advertise navigation resources through the initialize capability response.
+- Add the resource store and revalidator.
+- Migrate rail rendering, attention consumers, deep links, titles, session menus, and mutation reconciliation.
+- Fall back to the legacy endpoint only when the server lacks the capability.
+
+### Phase 3: default and verify
+
+- Enable the new client path by default.
+- Compare live and deterministic metrics with the baseline.
+- Verify browser behavior and request counts under activity, mutation, reconnect, and failure.
+
+### Phase 4: retirement
+
+- Remove legacy refresh triggers and the old frontend tree store.
+- Remove `evener/tree/changed`.
+- Migrate `hubapi` consumers.
+- Remove temporary capability fallback in the release after the migration
+  release.
+- Remove the `/api/tree` adapter in that release or the explicitly named
+  breaking release required by published compatibility policy.
+
+## Testing
+
+Before changing tests, follow `docs/developing-evener/testing.md`.
+
+### Server unit tests
+
+Cover:
+
+- revision advancement and no-op stability;
+- producer content fingerprints and no-op writes;
+- exact and wildcard invalidation scopes;
+- the per-resource dependency matrix and unrelated-source changes;
+- generation changes;
+- immutable snapshot publication;
+- one snapshot and project-resolution pass per semantic revision;
+- concurrent cache-miss single-flight;
+- invalidation during build and compare-before-publish retry;
+- object, encoded, and compressed cache hits;
+- LRU entry and byte bounds;
+- ETag, `If-None-Match`, 304, gzip, and required headers;
+- canonical resource identity, distinct page ETags, pagination validation, and
+  hard row/depth/node caps;
+- two WebServer instances with isolated caches and auth scopes;
+- malformed, noncanonical, absent, and unauthorized project/pin/session keys;
+- access-log redaction;
+- exact time-boundary invalidation;
+- last-good behavior after store, build, encoding, and compression failures; and
+- concurrent readers during invalidation and eviction.
+
+### Frontend unit tests
+
+Cover:
+
+- initial manifest load and expansion hydration;
+- bounded section and catalog paging;
+- one in-flight request per resource;
+- target coalescing and one trailing request;
+- abort and stale-response rejection;
+- generation replacement;
+- sequence-gap recovery;
+- mutation and notification deduplication;
+- exact target fan-out across loaded pages and `all_loaded_projects`;
+- 304 handling;
+- manifest and project stale errors;
+- project 404 recovery;
+- attention updates without navigation fetches;
+- stale client detachment; and
+- deep-link owner resolution without a complete project tree.
+
+### Integration and browser tests
+
+Use a scripted source at the AppWire boundary and real Evener code below it. Prove that:
+
+- one status change emits scoped invalidation and updates exactly the affected
+  section/project resources, plus the manifest only when a displayed total or
+  descriptor count changed;
+- an unrelated collapsed project causes no request;
+- a mutation response and its AppWire event cause one revalidation;
+- reconnect and an injected sequence gap recover through conditional HTTP;
+- saved and default expansions hydrate correctly;
+- Live, Needs You, pins, projects, test runs, archived projects, pagination, titles, menus, and deep links preserve current behavior; and
+- failures remain isolated and retriable.
+
+Run the frontend formatter on touched `src/` files, then run the repository's required frontend, Go, lint, vet, and browser gates.
+
+### Performance fixtures
+
+Commit a fixed legacy baseline fixture with:
+
+- 20 non-Git project directories;
+- 50 top-level sessions per project and no children;
+- IDs `session-%03d-%03d`;
+- names formed from the ID, one space, and seven repetitions of
+  `representative-title-data-`;
+- a fixed UTC clock with sessions spaced one minute apart inside the Current
+  window; and
+- no live rows, remote sources, favorites, pins, archive decisions, or saved
+  expansions.
+
+The legacy benchmark warms `/api/tree` once, then runs 20 iterations per sample
+and five samples through the real HTTP handler with no `Accept-Encoding`. It
+records the median uncompressed response bytes and `B/op`. The probe that
+motivated this design produced about 574 KB and 23 MiB per request, but the
+checked-in fixed-clock baseline—not those conversational measurements—is the
+acceptance reference.
+
+Run the new path with the same fixture. **Mandatory hydration** means the
+manifest, first Live and Needs You pages, all pin-descriptor pages required to
+discover nonempty pins, all nonempty pin-section first pages, and the first
+active-project catalog page. It excludes project resources because this fixture
+has no default or saved expansions. Run mandatory hydration once with identity
+encoding and once with gzip.
+
+Run a second **expanded hydration** variant with the first four projects marked
+as saved expansions. It includes those four root project resources and runs with
+gzip. Record:
+
+- manifest, section, pin-catalog, project-catalog, and project bytes before and
+  after gzip;
+- cache-hit and cache-miss duration;
+- allocations;
+- project-resolution and tree-build call counts; and
+- request counts for boot, one change, one mutation, reconnect, and idle time.
+
+The warm allocation comparison measures a gzip-accepting manifest request after
+its object, JSON, and gzip caches are populated. Performance assertions use
+stable structural counts and the checked-in relative budgets, not host-specific
+absolute latency.
+
+## Acceptance Criteria
+
+On the observed dataset and the fixed deterministic fixture:
+
+1. After initial hydration, an idle UI issues zero navigation HTTP requests unless AppWire reconnects or semantic navigation state changes.
+2. One semantic change causes at most one request for each affected loaded
+   representation: manifest, section page, catalog page, project root, or
+   project tier page.
+3. A mutation and its matching AppWire notification do not duplicate a resource request.
+4. No more than one request per resource is in flight.
+5. Adding or changing sessions in an existing collapsed project adds no session
+   row to the manifest or catalogs. Any affected bounded project-summary scalar
+   may change.
+6. Fixed-fixture mandatory hydration uncompressed JSON bytes are no more than
+   15% of the checked-in legacy uncompressed JSON-byte baseline. This proves the
+   resource split independently of compression.
+7. Fixed-fixture mandatory hydration gzip-transferred body bytes are no more
+   than 10% of the checked-in legacy transferred-body baseline. Expanded
+   hydration with four saved projects is no more than 35% of that legacy
+   transferred-body baseline. Live diagnostics report mandatory,
+   default-expanded, and saved-expanded totals separately against the observed
+   429 KB request; arbitrary user-saved expansion is reported, not hidden inside
+   the mandatory budget.
+8. Matching validators return 304 with an empty body.
+9. A representation-cache hit performs no metadata copy, remote snapshot clone, project resolution, decision-store query, tree build, projection, JSON encoding, or compression.
+10. Across fixed-fixture mandatory or expanded hydration, one semantic revision
+    performs exactly one core-tree build and one distinct-project resolution
+    pass. Concurrent misses join that work. Cache hits perform zero additional
+    builds or resolution passes.
+11. The fixed-fixture warm manifest request uses no more than 20% of the
+   checked-in legacy `B/op` baseline, an allocation reduction of at least 80%.
+12. Deep links, Live, Needs You, pins, project tiers, pagination, titles, menus, mutations, reconnect, and stale-error behavior retain current semantics.
+13. Logs and metrics expose no title, prompt, ref, or path values.
+14. Every collection enforces its documented row, recursive-node, depth,
+    string, offset, and byte bounds and keeps overflow explicit.
+15. The standard lint, vet, test, frontend, and browser gates pass.
+
+## Risks and Mitigations
+
+### Too many small requests
+
+Global sections, catalog pages, and persisted expansions could cause a request
+burst after boot. Use the concurrency limit of four, skip empty sections, and
+fetch project resources only for expanded projects. Measure aggregate
+transferred bytes and request count, not manifest size alone.
+
+### Incorrect change scoping
+
+A missed project key could leave one resource stale. Producers emit
+`all_loaded_projects` when uncertain. Event-sequence gap recovery and reconnect
+revalidation provide independent repair paths.
+
+### Cache memory growth
+
+Encoded project pages can multiply by revision, page, and encoding. Keep only current-generation entries and enforce entry and byte bounds with observable eviction.
+
+### Temporary dual behavior
+
+A fallback can become permanent. The compatibility adapter must reuse `NavigationService`, and its deletion remains an explicit rollout phase and completion condition.
+
+### New consistency machinery
+
+Resource revisions add state. Keep all comparison and fetch scheduling inside one revalidator and all revision assignment inside one server service. Feature components render resource state but never implement their own refresh policy.

--- a/docs/superpowers/specs/2026-08-25-tree-transport-optimization-design.md
+++ b/docs/superpowers/specs/2026-08-25-tree-transport-optimization-design.md
@@ -350,14 +350,19 @@ NavigationSessionLocation {
   top_level_ref: string
   project_key?: string
   top_level: bool
+  tier?: "current" | "recent" | "archived" | "live" | "needs_you" | "pinned"
+  pin_section_id?: string
+  session?: NavigationSessionSummary
 }
 ```
 
 `NavigationService` builds the location index with the immutable core tree. The
 endpoint carries generation and revision metadata but is read on
-demand and is not a long-lived client resource. A missing session returns 404.
-This endpoint avoids both a complete session-to-project map in the manifest and
-the existing session-detail path's full live-thread read.
+demand and is not a long-lived client resource. When the ref has a navigation
+row, `session` carries its current bounded summary so pane titles and session
+menus do not depend on an expanded project. A missing session returns 404. This
+endpoint avoids both a complete session-to-project map in the manifest and the
+existing session-detail path's full live-thread read.
 
 ## Revision Model
 

--- a/docs/superpowers/specs/2026-08-25-tree-transport-optimization-design.md
+++ b/docs/superpowers/specs/2026-08-25-tree-transport-optimization-design.md
@@ -643,7 +643,7 @@ Collapsed projects issue no project request. Expanding one project loads that re
 
 On `evener/navigation/invalidated`, the client raises targets only for named resources. It does not use a time-based debounce. Resource targets naturally coalesce.
 
-A successful mutation returns:
+A successful hub-owned REST navigation mutation returns:
 
 ```text
 navigation {
@@ -652,7 +652,7 @@ navigation {
 }
 ```
 
-The client feeds this metadata to the revalidator. When the matching AppWire event arrives, the resource target is already satisfied or in flight, so it causes no duplicate request.
+The client feeds this metadata to the revalidator. When the matching AppWire event arrives, the resource target is already satisfied or in flight, so it causes no duplicate request. AppWire-routed daemon actions do not synthesize hub navigation metadata in daemon result types; they converge through the single hub invalidation event and never issue an eager navigation refresh.
 
 `evener/attention/changed` updates the dedicated alert, title, and badge state directly from its existing payload. It does not fetch navigation. The navigation invalidation independently updates Needs You membership or project rollups when those resources change.
 


### PR DESCRIPTION
## Problem

Idle subagents showed up as "active" in the web UI sidebar instead of moving to the "Inactive subagents" fold. A parent session would display "1 subagent working · main" even when the subagent was actually idle.

## Root cause

In `cmd/evener-hub/internal/hubcore/tree.go`, the `runningSubagentState` function returned `"active"` as its fallback when a subagent was listed in `RunningSubagentIDs` (in-process/resumable) but the daemon carried no state for it in `RunningSubagentStates`.

This directly contradicted the comment above it: *"Liveness alone must not read as activity — a settled, resumable delegate stays listed while doing nothing."*

The result: a settled-but-resumable delegate (idle stable delegate, old daemon, or legacy job discovery) rendered as `"active"`, inflating the parent's working subagent count and keeping it in the current list instead of the inactive fold.

## Fix

1. Changed the `runningSubagentState` fallback from `"active"` to `"idle"` — a no-state listed child now folds into the rail's inactive list where it belongs.
2. Removed the redundant `runningChildIDs` override in `buildNode`: `stateFor` already calls `runningSubagentState` for children without their own live entry, so the override was redundant in that case and **wrong** when the child *did* have its own live entry (it overwrote the child's own daemon-reported status with the parent's projection).

## Verification (TDD)

- Updated 3 existing tests that asserted the old "active" fallback to assert `"idle"` instead (watched them fail first)
- `go test ./cmd/evener-hub/...` — pass
- `go test ./agent/... ./server/...` — pass
- `go vet ./...` — clean
- `make test-web` (typecheck + test + lint) — pass (6933 frontend tests)

## Files changed

- `cmd/evener-hub/internal/hubcore/tree.go` — the fix
- `cmd/evener-hub/internal/hubcore/tree_test.go` — test updates
- `cmd/evener-hub/internal/hubcore/production_subagent_sidebar_regression_test.go` — test updates