### PR TITLE
fix(agent): exclude provider retries from drain liveness

### DIFF
--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -85,9 +85,10 @@ func (c *delegateTreeController) ReportActivity(lease delegateLease, at time.Tim
 	return c.ReportActivityPhase(lease, at, "")
 }
 
-// ReportActivityPhase records parent-visible progress. Provider retry/backoff is
-// deliberately not productive progress: it must not move the timestamp used by
-// one-shot drain liveness. Other phases retain the historical activity behavior.
+// ReportActivityPhase records parent-visible activity and separately advances
+// the one-shot drain's productive-liveness clock. Provider retry/backoff is
+// ordinary activity for supervision and reporting, but it is not productive
+// progress that should extend terminal drain grace.
 func (c *delegateTreeController) ReportActivityPhase(lease delegateLease, at time.Time, phase string) error {
 	if c == nil {
 		return errDelegateStaleLease
@@ -101,24 +102,23 @@ func (c *delegateTreeController) ReportActivityPhase(lease delegateLease, at tim
 		c.mu.Unlock()
 		return err
 	}
-	if phase == jobPhaseModelRetrying {
-		c.mu.Unlock()
-		return nil
-	}
-	if at.Before(live.activityAt) {
-		c.mu.Unlock()
-		return nil
-	}
 	rearm := live.quietNotified || live.quietClaim != nil && live.quietClaim.sequence == live.quietSequence
-	if at.Equal(live.activityAt) && !rearm {
+	activityChanged := at.After(live.activityAt) || at.Equal(live.activityAt) && rearm
+	productiveChanged := phase != jobPhaseModelRetrying && at.After(live.productiveActivityAt)
+	if !activityChanged && !productiveChanged {
 		c.mu.Unlock()
 		return nil
 	}
-	if rearm {
+	if activityChanged && rearm {
 		live.quietSequence++
 		live.quietNotified = false
 	}
-	live.activityAt = at
+	if activityChanged {
+		live.activityAt = at
+	}
+	if productiveChanged {
+		live.productiveActivityAt = at
+	}
 	c.evidenceVersion++
 	plan := c.capturedPlanLocked(aggregate.DelegateID)
 	c.mu.Unlock()

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -82,6 +82,13 @@ type delegateQuietAttentionClaim struct {
 }
 
 func (c *delegateTreeController) ReportActivity(lease delegateLease, at time.Time) error {
+	return c.ReportActivityPhase(lease, at, "")
+}
+
+// ReportActivityPhase records parent-visible progress. Provider retry/backoff is
+// deliberately not productive progress: it must not move the timestamp used by
+// one-shot drain liveness. Other phases retain the historical activity behavior.
+func (c *delegateTreeController) ReportActivityPhase(lease delegateLease, at time.Time, phase string) error {
 	if c == nil {
 		return errDelegateStaleLease
 	}
@@ -93,6 +100,10 @@ func (c *delegateTreeController) ReportActivity(lease delegateLease, at time.Tim
 	if err != nil {
 		c.mu.Unlock()
 		return err
+	}
+	if phase == jobPhaseModelRetrying {
+		c.mu.Unlock()
+		return nil
 	}
 	if at.Before(live.activityAt) {
 		c.mu.Unlock()
@@ -297,8 +308,8 @@ func bindStableDelegateActivityToOwner(child *Session, controller *delegateTreeC
 	child.mu.Lock()
 	child.cfg.spawn.parentDelegateID = lease.delegateID
 	child.cfg.spawn.forwardJobEvent = forward
-	child.cfg.spawn.parentJobActivity = func(string, string) {
-		_ = controller.ReportActivity(lease, child.sclock().Now())
+	child.cfg.spawn.parentJobActivity = func(_ string, phase string) {
+		_ = controller.ReportActivityPhase(lease, child.sclock().Now(), phase)
 	}
 	jm := child.jobManager
 	child.mu.Unlock()

--- a/agent/delegate_tree_controller.go
+++ b/agent/delegate_tree_controller.go
@@ -134,6 +134,7 @@ type delegateLiveState struct {
 	// encountered a finalization failure has completed all retained-runtime writes.
 	recoveryRunnerPending bool
 	activityAt            time.Time
+	productiveActivityAt  time.Time
 	quietSequence         uint64
 	quietNotified         bool
 	quietClaim            *delegateQuietAttentionClaim
@@ -154,6 +155,10 @@ type delegateSnapshot struct {
 	transcriptRef      string
 	notResumableReason string
 	latestActivityAt   time.Time
+	// latestProductiveActivityAt is the one-shot drain's liveness clock.
+	// Provider retry/backoff remains ordinary activity everywhere else, but it
+	// does not move this clock.
+	latestProductiveActivityAt time.Time
 	// pendingStopSeq is the sequence of a subtree stop admitted against this
 	// delegate and not yet completed; 0 when no stop is outstanding. It is what
 	// distinguishes a delegate that was ASKED to stop from one that has.
@@ -631,8 +636,13 @@ func (c *delegateTreeController) appendResumabilityClosureLocked(delegateID stri
 
 func (c *delegateTreeController) captureDelegateSnapshotLocked(id string) delegateSnapshot {
 	snapshot := captureDelegateSnapshot(c.durable[id])
-	if live := c.live[id]; live != nil && live.activityAt.After(snapshot.latestActivityAt) {
-		snapshot.latestActivityAt = live.activityAt
+	if live := c.live[id]; live != nil {
+		if live.activityAt.After(snapshot.latestActivityAt) {
+			snapshot.latestActivityAt = live.activityAt
+		}
+		if live.productiveActivityAt.After(snapshot.latestProductiveActivityAt) {
+			snapshot.latestProductiveActivityAt = live.productiveActivityAt
+		}
 	}
 	return snapshot
 }
@@ -652,24 +662,25 @@ func captureDelegateSnapshot(aggregate *delegatestore.Aggregate) delegateSnapsho
 		outcome = &value
 	}
 	return delegateSnapshot{
-		id:                 aggregate.DelegateID,
-		parentID:           aggregate.Descriptor.ParentDelegateID,
-		descriptor:         cloneDelegateStartDescriptor(aggregate.Descriptor),
-		generation:         aggregate.Generation,
-		lifecycle:          lifecycle,
-		phase:              aggregate.Phase,
-		currentRunOpen:     aggregate.CurrentRunOpen,
-		runStartedAt:       aggregate.RunStartedAt,
-		resumable:          aggregate.Resumable,
-		needsAttention:     aggregate.NeedsAttention,
-		revision:           aggregate.ProjectionRevision,
-		transcriptRef:      aggregate.Descriptor.TranscriptRef,
-		notResumableReason: aggregate.NotResumableReason,
-		latestActivityAt:   aggregate.LatestActivityAt,
-		pendingStopSeq:     aggregate.PendingStopSeq,
-		pendingStopAt:      aggregate.PendingStopAt,
-		lastOutcome:        outcome,
-		latestPacket:       cloneStableTerminalPacket(aggregate.LatestPacket),
+		id:                         aggregate.DelegateID,
+		parentID:                   aggregate.Descriptor.ParentDelegateID,
+		descriptor:                 cloneDelegateStartDescriptor(aggregate.Descriptor),
+		generation:                 aggregate.Generation,
+		lifecycle:                  lifecycle,
+		phase:                      aggregate.Phase,
+		currentRunOpen:             aggregate.CurrentRunOpen,
+		runStartedAt:               aggregate.RunStartedAt,
+		resumable:                  aggregate.Resumable,
+		needsAttention:             aggregate.NeedsAttention,
+		revision:                   aggregate.ProjectionRevision,
+		transcriptRef:              aggregate.Descriptor.TranscriptRef,
+		notResumableReason:         aggregate.NotResumableReason,
+		latestActivityAt:           aggregate.LatestActivityAt,
+		latestProductiveActivityAt: aggregate.LatestActivityAt,
+		pendingStopSeq:             aggregate.PendingStopSeq,
+		pendingStopAt:              aggregate.PendingStopAt,
+		lastOutcome:                outcome,
+		latestPacket:               cloneStableTerminalPacket(aggregate.LatestPacket),
 	}
 }
 

--- a/agent/delegate_tree_start.go
+++ b/agent/delegate_tree_start.go
@@ -464,6 +464,7 @@ func (c *delegateTreeController) CompleteStartInput(claim delegateInputClaim, co
 	}
 	live.binding.ready = true
 	live.activityAt = c.now()
+	live.productiveActivityAt = live.activityAt
 	c.evidenceVersion++
 	plans := delegateMutationPlans{updates: []delegateUpdatePlan{c.capturedPlanLocked(lease.delegateID)}}
 	plans.deliveries = append(plans.deliveries, c.replayDeliveriesForOwnerLocked(lease.delegateID)...)
@@ -809,6 +810,7 @@ func (c *delegateTreeController) CommitStart(reservation *delegateStartReservati
 		live.waiters[record.generation] = record.waiter
 	}
 	live.activityAt = startedAt
+	live.productiveActivityAt = startedAt
 	live.quietSequence = 1
 	live.quietNotified = false
 	live.quietClaim = nil

--- a/agent/delegate_tree_steer.go
+++ b/agent/delegate_tree_steer.go
@@ -186,6 +186,9 @@ func (c *delegateTreeController) CompleteSteerPersistence(claim *delegateSteerin
 				if entry.timestamp.After(live.activityAt) {
 					live.activityAt = entry.timestamp
 				}
+				if entry.timestamp.After(live.productiveActivityAt) {
+					live.productiveActivityAt = entry.timestamp
+				}
 			}
 			c.evidenceVersion++
 			return delegateMutationPlans{updates: []delegateUpdatePlan{c.capturedPlanLocked(claim.delegateID)}}, nil
@@ -203,6 +206,9 @@ func (c *delegateTreeController) CompleteSteerPersistence(claim *delegateSteerin
 	})
 	if entry.timestamp.After(live.activityAt) {
 		live.activityAt = entry.timestamp
+	}
+	if entry.timestamp.After(live.productiveActivityAt) {
+		live.productiveActivityAt = entry.timestamp
 	}
 	c.evidenceVersion++
 	return delegateMutationPlans{updates: []delegateUpdatePlan{c.capturedPlanLocked(claim.delegateID)}}, nil

--- a/agent/session_jobtree_drain.go
+++ b/agent/session_jobtree_drain.go
@@ -18,10 +18,10 @@ type drainAbandonedChild struct {
 }
 
 type drainGraceChild struct {
-	delegateID            string
-	generation            uint64
-	latestActivityAt      time.Time
-	secondWindowStartedAt time.Time
+	delegateID                 string
+	generation                 uint64
+	latestProductiveActivityAt time.Time
+	secondWindowStartedAt      time.Time
 }
 
 // DrainStallTimeout bounds how long the one-shot drain will keep blocking on a
@@ -532,8 +532,8 @@ func (s *Session) subtreeHasLiveComponent() (bool, error) {
 // admitLeaseLocked, which rejects on PendingStopSeq != 0, so a stop-requested
 // delegate CANNOT report activity at all. The honest first-window question for
 // that branch is how long the stop has gone unanswered. A never-stopped
-// delegate remains able to report genuine activity, so its branch deliberately
-// does read that stamp and restarts window one when it advances.
+// delegate remains able to report productive activity, so its branch
+// deliberately reads that clock and restarts window one when it advances.
 //
 // NO RUN COMPLETION. currentRunOpen is the "with no run-completion" half: a
 // delegate whose run has finished is not wedged, it is done, and its terminal
@@ -552,8 +552,9 @@ func (s *Session) subtreeHasLiveComponent() (bool, error) {
 //
 // For an explicit pending stop, window one starts at the durable request time.
 // For a never-stopped delegate it starts at the one-shot drain boundary and any
-// later admitted activity restarts it. Stop-requested rows cannot admit activity
-// (the controller fence above), so those two branches are intentionally distinct.
+// later admitted productive activity restarts it. Stop-requested rows cannot
+// admit activity (the controller fence above), so those two branches are
+// intentionally distinct.
 func delegateAbandonedByDrain(row delegateSnapshot, now, drainStartedAt time.Time) bool {
 	if !row.currentRunOpen {
 		return false
@@ -561,8 +562,8 @@ func delegateAbandonedByDrain(row delegateSnapshot, now, drainStartedAt time.Tim
 	since := row.pendingStopAt
 	if since.IsZero() {
 		since = drainStartedAt
-		if row.latestActivityAt.After(since) {
-			since = row.latestActivityAt
+		if row.latestProductiveActivityAt.After(since) {
+			since = row.latestProductiveActivityAt
 		}
 	}
 	if since.IsZero() {
@@ -632,9 +633,9 @@ func (s *Session) markDrainAbandonedDelegates(now, drainStartedAt time.Time) {
 			s.recordDrainGraceChild(child.id, row, now)
 			continue
 		}
-		if row.latestActivityAt.After(phase.latestActivityAt) {
-			// A never-stopped delegate proved it is alive. Restart window one at
-			// that activity stamp rather than carrying a stale phase forward.
+		if row.latestProductiveActivityAt.After(phase.latestProductiveActivityAt) {
+			// A never-stopped delegate made productive progress. Restart window
+			// one at that progress stamp rather than carrying a stale phase forward.
 			s.clearDrainGraceChild(child.id)
 			continue
 		}
@@ -654,7 +655,7 @@ func (s *Session) recordDrainGraceChild(childSessionID string, row delegateSnaps
 	}
 	s.drainGraceChildren[childSessionID] = drainGraceChild{
 		delegateID: row.id, generation: row.generation,
-		latestActivityAt: row.latestActivityAt, secondWindowStartedAt: now,
+		latestProductiveActivityAt: row.latestProductiveActivityAt, secondWindowStartedAt: now,
 	}
 }
 

--- a/agent/session_jobtree_drain_stopped_delegate_test.go
+++ b/agent/session_jobtree_drain_stopped_delegate_test.go
@@ -86,6 +86,33 @@ func newWedgedDelegateFixtureIn(t *testing.T, delegateID string, turnEndsProcess
 	return &wedgedDelegateFixture{root: root, child: child, delegateID: delegateID, lease: lease, clk: clk}
 }
 
+func TestRetryActivityDoesNotRefreshDrainLiveness(t *testing.T) {
+	f := newWedgedDelegateFixture(t, "dlg_retry")
+	productive := f.clk.Now()
+	f.clk.Advance(DrainStallTimeout - time.Second)
+	if err := f.root.delegateController.ReportActivityPhase(f.lease, f.clk.Now(), jobPhaseModelRetrying); err != nil {
+		t.Fatalf("retry activity: %v", err)
+	}
+	f.clk.Advance(2 * time.Second)
+	f.root.delegateController.mu.Lock()
+	got := f.root.delegateController.live[f.delegateID].activityAt
+	f.root.delegateController.mu.Unlock()
+	if !got.Equal(productive) {
+		t.Fatalf("retry refreshed productive activity to %v, want %v", got, productive)
+	}
+	f.clk.Advance(time.Second)
+	productive = f.clk.Now()
+	if err := f.root.delegateController.ReportActivityPhase(f.lease, productive, jobPhaseToolRunning); err != nil {
+		t.Fatalf("productive activity: %v", err)
+	}
+	f.root.delegateController.mu.Lock()
+	got = f.root.delegateController.live[f.delegateID].activityAt
+	f.root.delegateController.mu.Unlock()
+	if !got.Equal(productive) {
+		t.Fatalf("productive activity did not refresh liveness: got %v, want %v", got, productive)
+	}
+}
+
 // requestStop runs the REAL stop path — the one job_stop reaches — so the
 // pending-stop timestamp the drain reads is the one production writes.
 func (f *wedgedDelegateFixture) requestStop(t *testing.T) {

--- a/agent/session_jobtree_drain_stopped_delegate_test.go
+++ b/agent/session_jobtree_drain_stopped_delegate_test.go
@@ -67,9 +67,10 @@ func newWedgedDelegateFixtureIn(t *testing.T, delegateID string, turnEndsProcess
 	// point: without it every ReportActivity would be refused as a stale lease
 	// and the stop fence this fixture exists to demonstrate would be invisible.
 	c.live[delegateID] = &delegateLiveState{
-		runtime:    child,
-		binding:    &delegateRuntimeBinding{lease: lease, runtime: child, cancel: func() {}, ready: true},
-		activityAt: clk.Now(),
+		runtime:              child,
+		binding:              &delegateRuntimeBinding{lease: lease, runtime: child, cancel: func() {}, ready: true},
+		activityAt:           clk.Now(),
+		productiveActivityAt: clk.Now(),
 	}
 	c.mu.Unlock()
 	if err != nil {
@@ -122,6 +123,46 @@ func TestRetryActivityDoesNotRefreshDrainLiveness(t *testing.T) {
 	f.root.markDrainAbandonedDelegates(f.clk.Now(), drainStartedAt)
 	if !f.root.childDrainAbandoned(f.child.ID()) {
 		t.Fatal("expected terminal drain abandonment after retry and productive windows")
+	}
+}
+
+func TestRetryActivityRemainsParentVisible(t *testing.T) {
+	f := newWedgedDelegateFixture(t, "dlg_retry_visible")
+	bindStableDelegateActivityToOwner(f.child, f.root.delegateController, f.lease, f.root)
+	f.root.delegateController.mu.Lock()
+	beforeEvidence := f.root.delegateController.evidenceVersion
+	f.root.delegateController.mu.Unlock()
+
+	f.clk.Advance(time.Second)
+	retryAt := f.clk.Now()
+	f.child.emitModelRetry(llm.RetryPolicy{}, llm.Request{}, nil)(errors.New("429"), 1, time.Second)
+
+	f.root.delegateController.mu.Lock()
+	activityAt := f.root.delegateController.live[f.delegateID].activityAt
+	afterEvidence := f.root.delegateController.evidenceVersion
+	f.root.delegateController.mu.Unlock()
+	if !activityAt.Equal(retryAt) {
+		t.Fatalf("parent-visible activity = %s, want retry time %s", activityAt, retryAt)
+	}
+	if afterEvidence <= beforeEvidence {
+		t.Fatalf("retry activity did not advance controller evidence: %d -> %d", beforeEvidence, afterEvidence)
+	}
+
+	claim, err := f.root.delegateController.BeginQuietAttention(f.root, f.lease, retryAt.Add(delegateQuietWindow-time.Nanosecond))
+	if err != nil {
+		t.Fatalf("quiet attention before retry-relative threshold: %v", err)
+	}
+	if claim != nil {
+		_ = f.root.delegateController.CompleteQuietAttention(claim, false)
+		t.Fatal("retry activity stayed invisible to the quiet watchdog")
+	}
+
+	descriptor := stableToolDescriptor(f.root, f.delegateID, "")
+	descriptor.ChildSessionID = f.child.ID()
+	sub := &subagent{sess: f.child, startedAt: retryAt.Add(-time.Minute), stableDescriptor: &descriptor}
+	metadata := decodeDelegatePacketMetadata(t, *sub.stableDelegateFinish("", errors.New("failed")).packet)
+	if got := metadata["latest_activity_at"]; got != retryAt.Format(time.RFC3339Nano) {
+		t.Fatalf("terminal latest_activity_at = %#v, want %q", got, retryAt.Format(time.RFC3339Nano))
 	}
 }
 

--- a/agent/session_jobtree_drain_stopped_delegate_test.go
+++ b/agent/session_jobtree_drain_stopped_delegate_test.go
@@ -11,6 +11,7 @@ import (
 	"primeradiant.com/evener/agent/internal/agenttest"
 	"primeradiant.com/evener/agent/internal/delegatestore"
 	"primeradiant.com/evener/agent/internal/jobstore"
+	"primeradiant.com/evener/llm"
 )
 
 // wedgedDelegateFixture is a root with exactly one direct stable delegate that
@@ -88,28 +89,58 @@ func newWedgedDelegateFixtureIn(t *testing.T, delegateID string, turnEndsProcess
 
 func TestRetryActivityDoesNotRefreshDrainLiveness(t *testing.T) {
 	f := newWedgedDelegateFixture(t, "dlg_retry")
-	productive := f.clk.Now()
-	f.clk.Advance(DrainStallTimeout - time.Second)
-	if err := f.root.delegateController.ReportActivityPhase(f.lease, f.clk.Now(), jobPhaseModelRetrying); err != nil {
-		t.Fatalf("retry activity: %v", err)
+	bindStableDelegateActivityToOwner(f.child, f.root.delegateController, f.lease, f.root)
+	f.child.mu.Lock()
+	activity := f.child.cfg.spawn.parentJobActivity
+	f.child.mu.Unlock()
+	if activity == nil {
+		t.Fatal("production binding did not install parent activity callback")
 	}
-	f.clk.Advance(2 * time.Second)
-	f.root.delegateController.mu.Lock()
-	got := f.root.delegateController.live[f.delegateID].activityAt
-	f.root.delegateController.mu.Unlock()
-	if !got.Equal(productive) {
-		t.Fatalf("retry refreshed productive activity to %v, want %v", got, productive)
+	retry := f.child.emitModelRetry(llm.RetryPolicy{}, llm.Request{}, nil)
+	drainStartedAt := f.clk.Now()
+	f.clk.Advance(DrainStallTimeout)
+	retry(errors.New("429"), 1, time.Second)
+	f.root.markDrainAbandonedDelegates(f.clk.Now(), drainStartedAt)
+	if !f.root.childDrainGracePending(f.child.ID()) {
+		t.Fatal("first drain window did not arm")
+	}
+	f.clk.Advance(DrainStallTimeout - time.Nanosecond)
+	retry(errors.New("429"), 2, time.Second)
+	f.root.markDrainAbandonedDelegates(f.clk.Now(), drainStartedAt)
+	if !f.root.childDrainGracePending(f.child.ID()) || f.root.childDrainAbandoned(f.child.ID()) {
+		t.Fatal("retry-only callback restarted drain grace")
 	}
 	f.clk.Advance(time.Second)
-	productive = f.clk.Now()
-	if err := f.root.delegateController.ReportActivityPhase(f.lease, productive, jobPhaseToolRunning); err != nil {
-		t.Fatalf("productive activity: %v", err)
+	activity("child", jobPhaseToolRunning)
+	f.root.markDrainAbandonedDelegates(f.clk.Now(), drainStartedAt)
+	if f.root.childDrainGracePending(f.child.ID()) {
+		t.Fatal("productive progress did not rearm from the current point")
+	}
+	f.clk.Advance(DrainStallTimeout)
+	f.root.markDrainAbandonedDelegates(f.clk.Now(), drainStartedAt)
+	f.clk.Advance(DrainStallTimeout + time.Nanosecond)
+	f.root.markDrainAbandonedDelegates(f.clk.Now(), drainStartedAt)
+	if !f.root.childDrainAbandoned(f.child.ID()) {
+		t.Fatal("expected terminal drain abandonment after retry and productive windows")
+	}
+}
+
+func TestRetryActivityRejectsStaleLeaseWithoutMutation(t *testing.T) {
+	f := newWedgedDelegateFixture(t, "dlg_retry_stale")
+	f.root.delegateController.mu.Lock()
+	beforeAt := f.root.delegateController.live[f.delegateID].activityAt
+	beforeEvidence := f.root.delegateController.evidenceVersion
+	f.root.delegateController.mu.Unlock()
+	stale := delegateLease{delegateID: f.delegateID, generation: f.lease.generation + 1}
+	if err := f.root.delegateController.ReportActivityPhase(stale, f.clk.Now(), jobPhaseModelRetrying); !errors.Is(err, errDelegateStaleLease) {
+		t.Fatalf("stale retry error = %v, want %v", err, errDelegateStaleLease)
 	}
 	f.root.delegateController.mu.Lock()
-	got = f.root.delegateController.live[f.delegateID].activityAt
+	afterAt := f.root.delegateController.live[f.delegateID].activityAt
+	afterEvidence := f.root.delegateController.evidenceVersion
 	f.root.delegateController.mu.Unlock()
-	if !got.Equal(productive) {
-		t.Fatalf("productive activity did not refresh liveness: got %v, want %v", got, productive)
+	if !afterAt.Equal(beforeAt) || afterEvidence != beforeEvidence {
+		t.Fatalf("stale retry mutated activity/evidence: activity %v -> %v, evidence %d -> %d", beforeAt, afterAt, beforeEvidence, afterEvidence)
 	}
 }
 


### PR DESCRIPTION
Provider retry/backoff callbacks are parent activity signals, but they are not productive delegate progress. Keep the existing activity callback plumbing and classify the retry phase so one-shot drain grace is not refreshed by retry-only waiting. Productive phases continue to refresh liveness.

Fixes #353