### PR TITLE
test: close auth and job formatter fuzz gaps

### DIFF
--- a/agent/session_tools_jobs_fuzz_test.go
+++ b/agent/session_tools_jobs_fuzz_test.go
@@ -405,6 +405,9 @@ func FuzzJobtoolsFormat(f *testing.F) {
 	f.Add([]byte{1, 1, 1, 1, 1, 1, 1, 1})
 	f.Add([]byte{2, 3, 0, 5, 7, 9, 11, 1, 1, 0, 0, 4, 6})
 	f.Add([]byte{3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3})
+	// Zero jobs/events keep the prefix short; the tail selects a delegate stop
+	// with a non-empty previous status, pinning the delegate-only footer oracle.
+	f.Add([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 1, 1, 1})
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		r := &jobtools_reader{data: data}
@@ -428,8 +431,10 @@ func FuzzJobtoolsFormat(f *testing.F) {
 			PreviousStatus: r.str(),
 			Outcome:        r.str(),
 		}
+		// Append new draws after the established fields so existing corpus inputs
+		// retain their stable cursor meaning.
+		stop.Type = []string{"shell", "delegate"}[r.intn(2)]
 		oracle.Deterministic(t, formatJobStop, stop, func(a, b string) bool { return a == b })
-
 	})
 }
 

--- a/cmd/evener-hub/cov_auth_instances_fuzz_test.go
+++ b/cmd/evener-hub/cov_auth_instances_fuzz_test.go
@@ -59,8 +59,9 @@ func FuzzAuthInstancesFactories(f *testing.F) {
 		// expected values instead of discarding the result
 		// (docs/developing-evener/coverage.md's executed-vs-tested note on the
 		// evenerfuzz cov_* driver family).
-		if got := effectiveHubAuthEnv(map[string]string{"COV_AUTH": "1"}); got["COV_AUTH"] != "1" {
-			t.Fatalf("effectiveHubAuthEnv: COV_AUTH = %q, want \"1\"", got["COV_AUTH"])
+		t.Setenv("COV_AUTH", "ambient")
+		if got := effectiveHubAuthEnv(map[string]string{"COV_AUTH": "launch"}); got["COV_AUTH"] != "launch" {
+			t.Fatalf("effectiveHubAuthEnv: COV_AUTH = %q, want launch env to override ambient value", got["COV_AUTH"])
 		}
 		wantStateDir := filepath.Join(root, ".local", "state", "evener")
 		if runtime.GOOS == "windows" {
@@ -84,6 +85,8 @@ func FuzzAuthInstancesFactories(f *testing.F) {
 			{now.Add(-time.Second), authopenai.AuthStatus{Source: authopenai.AuthSourceOAuth, Expiry: now.Add(-time.Second), NeedsLogin: true}, true},
 			// Expires inside the 5-minute refresh window but not yet: signed in, needs refresh.
 			{now.Add(time.Minute), authopenai.AuthStatus{SignedIn: true, Source: authopenai.AuthSourceOAuth, Expiry: now.Add(time.Minute), NeedsRefresh: true}, true},
+			// Strictly distinguishes the 5-minute window from a 1-minute window.
+			{now.Add(3 * time.Minute), authopenai.AuthStatus{SignedIn: true, Source: authopenai.AuthSourceOAuth, Expiry: now.Add(3 * time.Minute), NeedsRefresh: true}, true},
 			// Comfortably valid: signed in, no refresh due.
 			{now.Add(time.Hour), authopenai.AuthStatus{SignedIn: true, Source: authopenai.AuthSourceOAuth, Expiry: now.Add(time.Hour)}, false},
 		} {


### PR DESCRIPTION
Closes #190

## Summary

- make the auth-environment precedence check deterministic by pre-setting a conflicting ambient value and proving the launch environment wins
- add a three-minute expiry case that distinguishes the five-minute refresh window from a one-minute mutation
- append an explicit shell/delegate type draw without shifting the established fuzz cursor, and add a delegate seed with non-empty previous status

This is test-only; production behavior, coverage floors, tolerances, and existing assertions are unchanged. The formatter seed makes the delegate branch reachable without treating model-facing prose as an oracle.

## Mutation evidence

Each requested mutation turned its focused target red:

- `5 * time.Minute` → `time.Minute`: `FuzzAuthInstancesFactories/seed#0` failed on the three-minute expiry
- launch env override → ambient-wins merge: `FuzzAuthInstancesFactories/seed#0` reported `ambient`, wanted launch override
- delete the delegate previous-status footer: the requested combined replay of `FuzzJobtoolsFormat|TestCovFormatJobStop` failed in the existing structured unit coverage, while the new committed seed guarantees the fuzzer also traverses the delegate/non-empty-previous-status branch

## Validation

- `go test -tags=evenerfuzz ./cmd/evener-hub -run '^FuzzAuthInstancesFactories$' -count=1`
- `go test -tags=evenerfuzz ./agent -run '^(FuzzJobtoolsFormat|TestCovFormatJobStop)$' -count=1`
- `make vet`
- `make fuzz-seeds`
- canonical `make merge-approval-gate`: lint and build passed, including the frontend production build; the full-test phase stopped on two unrelated tests (`TestLaunchCheckAcceptsCompatInstanceModel` received an environment-specific EOF from the reserved `example.test` host, and `TestCommunicate_StatusBatchedWithDelegateDoesNotEndTurn` produced a duplicate completion once). The communicate test then passed 20/20 in isolation. The base commit's current CI is independently red on an unrelated 10-minute race-test hang: https://github.com/prime-radiant-inc/evener/actions/runs/32933087748

Disclosure: I used Codex to assist with implementation and verification, and reviewed the final diff and test evidence.
