### PR TITLE
feat(agent): advertise bounded startup model availability

### DIFF
--- a/agent/delegate_resource_runtime_test.go
+++ b/agent/delegate_resource_runtime_test.go
@@ -2166,6 +2166,43 @@ func TestDelegateResourceRuntime_ColdIdleUsesCommittedConfigTemplatesAndToolCeil
 	}
 }
 
+func TestDelegateResourceRuntime_ColdIdleInheritsLiveLifetimeContext(t *testing.T) {
+	fixture := newColdStableDelegateFixture(t, "")
+	root, err := restoreDelegateResourceBootstrapSession(fixture.client, fixture.profile, fixture.workspace, fixture.meta, fixture.stateDir)
+	if err != nil {
+		t.Fatalf("restore root: %v", err)
+	}
+	defer root.Close()
+	owner, cancelOwner := context.WithCancel(context.Background())
+	root.cfg.LifetimeContext = owner
+	reservation, err := root.delegateController.ReserveStart(rootDelegateActor(root.id), fixture.delegateID)
+	if err != nil {
+		t.Fatalf("ReserveStart: %v", err)
+	}
+	started, err := root.delegateController.CommitStart(reservation)
+	if err != nil {
+		t.Fatalf("CommitStart: %v", err)
+	}
+	defer func() {
+		_, _ = root.delegateController.FailCommittedRestart(started.lease, delegatePermanentStartFailure(errors.New("test complete"), "construction_failed"))
+	}()
+	sub, restored, err := (delegateRuntime{owner: root}).restoreIdle(started)
+	if err != nil {
+		t.Fatalf("restoreIdle: %v", err)
+	}
+	if !restored {
+		t.Fatal("cold idle delegate was reported retained")
+	}
+	defer sub.sess.discardRestoredCandidate()
+
+	cancelOwner()
+	select {
+	case <-sub.sess.sessionCtx.Done():
+	default:
+		t.Fatal("restored stable delegate outlived the live parent lifetime context")
+	}
+}
+
 func TestDelegateResourceRuntime_ColdIdleReusesExactSharedRootTaskStore(t *testing.T) {
 	fixture := newColdStableDelegateFixture(t, "root")
 	root, err := restoreDelegateResourceBootstrapSession(fixture.client, fixture.profile, fixture.workspace, fixture.meta, fixture.stateDir)

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -1599,6 +1599,7 @@ func (runtime delegateRuntime) restoreIdle(started delegateStartCommit) (*subage
 		}
 	}
 	restoreCfg := RestoreSessionConfig{
+		LifetimeContext:         s.cfg.LifetimeContext,
 		StateDir:                s.stateDir,
 		Project:                 s.cfg.Project,
 		ResolveProfile:          s.resolveProfile,

--- a/agent/internal/modelavailability/modelavailability.go
+++ b/agent/internal/modelavailability/modelavailability.go
@@ -205,37 +205,49 @@ func (s *Snapshot) Page(token string, maxCount, maxBytes int) (Page, error) {
 	}
 	p := Page{Version: s.Version, Complete: s.Complete, Status: status, Provenance: "startup-frozen"}
 	if off >= len(s.Choices) {
-		p.Terminal = true
+		p = s.pageAtOffset(p, off, maxCount, maxBytes)
 		if p.SerializedBytes() > maxBytes {
 			return Page{}, errors.New("page envelope budget too small")
 		}
 		return p, nil
 	}
 	for off < len(s.Choices) && len(p.Choices)+len(p.Oversized) < maxCount {
-		candidate := s.Choices[off]
-		p.Choices = append(p.Choices, candidate)
-		if p.SerializedBytes() > maxBytes {
-			p.Choices = p.Choices[:len(p.Choices)-1]
-			p.Oversized = append(p.Oversized, off)
+		trial := p
+		trial.Choices = append(append([]string(nil), p.Choices...), s.Choices[off])
+		trial = s.pageAtOffset(trial, off+1, maxCount, maxBytes)
+		if trial.SerializedBytes() <= maxBytes {
+			p = trial
+			off++
+			continue
 		}
-		off++
-		if p.SerializedBytes() > maxBytes {
-			p.Oversized = p.Oversized[:len(p.Oversized)-1]
+		if len(p.Choices)+len(p.Oversized) > 0 {
 			break
 		}
+		trial = p
+		trial.Oversized = append(append([]int(nil), p.Oversized...), off)
+		trial = s.pageAtOffset(trial, off+1, maxCount, maxBytes)
+		if trial.SerializedBytes() > maxBytes {
+			return Page{}, errors.New("page envelope budget too small")
+		}
+		p = trial
+		off++
 	}
 	if len(p.Choices) == 0 && len(p.Oversized) == 0 {
 		return Page{}, errors.New("page envelope budget too small")
-	}
-	if off < len(s.Choices) {
-		p.Next = s.token(cursor{"model-list-v1", "root", s.Version, off, maxCount, maxBytes})
-	}
-	if off >= len(s.Choices) {
-		p.Terminal = true
 	}
 	if p.SerializedBytes() > maxBytes {
 		return Page{}, errors.New("page envelope budget too small")
 	}
 	return p, nil
 }
+
+func (s *Snapshot) pageAtOffset(p Page, off, maxCount, maxBytes int) Page {
+	p.Next = ""
+	p.Terminal = off >= len(s.Choices)
+	if !p.Terminal {
+		p.Next = s.token(cursor{"model-list-v1", "root", s.Version, off, maxCount, maxBytes})
+	}
+	return p
+}
+
 func (p Page) SerializedBytes() int { b, _ := json.Marshal(p); return len(b) }

--- a/agent/internal/modelavailability/modelavailability.go
+++ b/agent/internal/modelavailability/modelavailability.go
@@ -82,31 +82,7 @@ func Capture(parent context.Context, providers []string, requiredProvider string
 			models, err := fetch(ctx, name)
 			r := result{name: name, err: err}
 			if err == nil {
-				seen := make(map[string]bool)
-				var bytes int
-				for _, model := range models {
-					id, ok := safeModelID(model.ID)
-					if !ok {
-						r.limited = true
-						continue
-					}
-					model.ID = id
-					if visible != nil && !visible(name, model) {
-						continue
-					}
-					if seen[id] {
-						continue
-					}
-					choiceBytes := len(name) + 1 + len(id)
-					if len(r.ids) >= captureMaxModels || bytes+choiceBytes > captureMaxBytes {
-						r.limited = true
-						continue
-					}
-					seen[id] = true
-					r.ids = append(r.ids, id)
-					bytes += choiceBytes
-				}
-				sort.Strings(r.ids)
+				r.ids, r.limited, r.err = boundedModelIDs(ctx, name, models, visible)
 			}
 			select {
 			case out <- r:
@@ -191,6 +167,50 @@ func Capture(parent context.Context, providers []string, requiredProvider string
 	}
 	version := hex.EncodeToString(h.Sum(nil)[:12])
 	return Snapshot{Version: version, Complete: complete, Choices: choices, Status: status, key: key}
+}
+
+func boundedModelIDs(ctx context.Context, provider string, models []llm.ModelInfo, visible func(string, llm.ModelInfo) bool) ([]string, bool, error) {
+	seen := make(map[string]bool)
+	ids := make([]string, 0, min(len(models), captureMaxModels))
+	limited := false
+	var bytes int
+	for i, model := range models {
+		if err := ctx.Err(); err != nil {
+			return nil, false, err
+		}
+		if i >= captureMaxModels {
+			limited = true
+			break
+		}
+		id, ok := safeModelID(model.ID)
+		if !ok {
+			limited = true
+			continue
+		}
+		model.ID = id
+		if visible != nil && !visible(provider, model) {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, false, err
+		}
+		if seen[id] {
+			continue
+		}
+		choiceBytes := len(provider) + 1 + len(id)
+		if bytes+choiceBytes > captureMaxBytes {
+			limited = true
+			break
+		}
+		seen[id] = true
+		ids = append(ids, id)
+		bytes += choiceBytes
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	sort.Strings(ids)
+	return ids, limited, nil
 }
 
 func boundedProviders(providers []string, requiredProvider string) ([]string, bool) {

--- a/agent/internal/modelavailability/modelavailability.go
+++ b/agent/internal/modelavailability/modelavailability.go
@@ -1,0 +1,206 @@
+// Package modelavailability captures and serves the startup-frozen model choices
+// advertised by delegate.model. It deliberately has no provider knowledge: callers
+// supply the already-resolved provider-instance fetch function.
+package modelavailability
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"primeradiant.com/evener/llm"
+)
+
+type StatusKind string
+
+const (
+	StatusSuccess StatusKind = "success"
+	StatusEmpty   StatusKind = "empty-success"
+	StatusFailure StatusKind = "failure"
+	StatusTimeout StatusKind = "timeout"
+)
+
+type ProviderStatus struct {
+	Kind   StatusKind
+	Detail string
+}
+type Snapshot struct {
+	Version  string
+	Complete bool
+	Choices  []string
+	Status   map[string]ProviderStatus
+	key      []byte
+	mu       *sync.Mutex
+	used     map[string]bool
+}
+type Page struct {
+	Choices  []string
+	Next     string
+	Version  string
+	Complete bool
+	Status   map[string]ProviderStatus
+}
+
+// Inline limits keep the delegate schema prompt bounded; larger snapshots use
+// the read-only paginated surface instead of truncating a complete catalog.
+const (
+	DefaultInlineMaxCount = 128
+	DefaultInlineMaxBytes = 4096
+)
+
+func Capture(parent context.Context, providers []string, fetch func(context.Context, string) ([]llm.ModelInfo, error), budget time.Duration) Snapshot {
+	ctx, cancel := context.WithTimeout(parent, budget)
+	defer cancel()
+	providers = append([]string(nil), providers...)
+	sort.Strings(providers)
+	type result struct {
+		name   string
+		models []llm.ModelInfo
+		err    error
+	}
+	out := make(chan result, len(providers))
+	for _, name := range providers {
+		go func(name string) { m, e := fetch(ctx, name); out <- result{name, m, e} }(name)
+	}
+	status := map[string]ProviderStatus{}
+	set := map[string]bool{}
+	for received := 0; received < len(providers); received++ {
+		var r result
+		select {
+		case r = <-out:
+		case <-ctx.Done():
+			// A provider that ignores context must not extend startup past the
+			// single overall budget. Its result is deliberately not trusted.
+			received = len(providers)
+			for _, p := range providers {
+				if _, ok := status[p]; !ok {
+					status[p] = ProviderStatus{StatusTimeout, "model enumeration timed out"}
+				}
+			}
+		}
+		if r.name == "" {
+			break
+		}
+		if r.err != nil {
+			k := StatusFailure
+			if errors.Is(r.err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				k = StatusTimeout
+			}
+			status[r.name] = ProviderStatus{k, "model enumeration did not complete"}
+			continue
+		}
+		if len(r.models) == 0 {
+			status[r.name] = ProviderStatus{StatusEmpty, "provider verified no models"}
+		} else {
+			status[r.name] = ProviderStatus{StatusSuccess, "provider model enumeration succeeded"}
+		}
+		for _, m := range r.models {
+			if strings.TrimSpace(m.ID) != "" {
+				set[r.name+"/"+strings.TrimSpace(m.ID)] = true
+			}
+		}
+	}
+	choices := make([]string, 0, len(set))
+	for c := range set {
+		choices = append(choices, c)
+	}
+	sort.Strings(choices)
+	complete := len(providers) > 0
+	for _, p := range providers {
+		if status[p].Kind != StatusSuccess && status[p].Kind != StatusEmpty {
+			complete = false
+		}
+	}
+	key := make([]byte, 32)
+	_, _ = rand.Read(key)
+	h := sha256.New()
+	h.Write([]byte("model-snapshot-v1\x00"))
+	for _, c := range choices {
+		h.Write([]byte(c))
+		h.Write([]byte{0})
+	}
+	version := hex.EncodeToString(h.Sum(nil)[:12])
+	return Snapshot{Version: version, Complete: complete, Choices: choices, Status: status, key: key, mu: &sync.Mutex{}, used: map[string]bool{}}
+}
+
+func (s Snapshot) Inline(maxCount, maxBytes int) (string, bool) {
+	if !s.Complete || len(s.Choices) > maxCount {
+		return "", false
+	}
+	text := "Verified startup snapshot " + s.Version + ": " + strings.Join(s.Choices, ", ") + "."
+	if len([]byte(text)) > maxBytes {
+		return "", false
+	}
+	return text, true
+}
+
+type cursor struct {
+	Version string
+	Offset  int
+	Nonce   uint64
+}
+
+func (s *Snapshot) Page(token string, maxCount, maxBytes int) (Page, error) {
+	if s == nil || s.mu == nil || maxCount <= 0 || maxBytes <= 0 {
+		return Page{}, errors.New("invalid page bounds")
+	}
+	off := 0
+	if token != "" {
+		raw, e := base64.RawURLEncoding.DecodeString(token)
+		if e != nil || len(raw) <= 32 {
+			return Page{}, errors.New("invalid cursor")
+		}
+		payload, mac := raw[:len(raw)-32], raw[len(raw)-32:]
+		sum := sha256.Sum256(append(append([]byte(nil), s.key...), payload...))
+		if subtle.ConstantTimeCompare(mac, sum[:]) != 1 {
+			return Page{}, errors.New("invalid cursor")
+		}
+		var c cursor
+		if json.Unmarshal(payload, &c) != nil || c.Version != s.Version || c.Offset < 0 || c.Offset > len(s.Choices) {
+			return Page{}, errors.New("stale cursor")
+		}
+		token = string(raw)
+		s.mu.Lock()
+		if s.used[token] {
+			s.mu.Unlock()
+			return Page{}, errors.New("cursor already used")
+		}
+		s.used[token] = true
+		s.mu.Unlock()
+		off = c.Offset
+	}
+	end := off
+	used := 0
+	for end < len(s.Choices) && used+len([]byte(s.Choices[end]))+func() int {
+		if end > off {
+			return 1
+		}
+		return 0
+	}() <= maxBytes && end-off < maxCount {
+		if end > off {
+			used++
+		}
+		used += len([]byte(s.Choices[end]))
+		end++
+	}
+	if end == off {
+		return Page{}, fmt.Errorf("model choice exceeds byte budget")
+	}
+	p := Page{Choices: append([]string(nil), s.Choices[off:end]...), Version: s.Version, Complete: s.Complete, Status: s.Status}
+	if end < len(s.Choices) {
+		c, _ := json.Marshal(cursor{s.Version, end, 0})
+		sum := sha256.Sum256(append(append([]byte(nil), s.key...), c...))
+		p.Next = base64.RawURLEncoding.EncodeToString(append(c, sum[:]...))
+	}
+	return p, nil
+}

--- a/agent/internal/modelavailability/modelavailability.go
+++ b/agent/internal/modelavailability/modelavailability.go
@@ -12,7 +12,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"sort"
 	"strings"
 	"sync"
@@ -194,7 +193,7 @@ func (s *Snapshot) Page(token string, maxCount, maxBytes int) (Page, error) {
 		end++
 	}
 	if end == off {
-		return Page{}, fmt.Errorf("model choice exceeds byte budget")
+		return Page{}, errors.New("model choice exceeds byte budget")
 	}
 	p := Page{Choices: append([]string(nil), s.Choices[off:end]...), Version: s.Version, Complete: s.Complete, Status: s.Status}
 	if end < len(s.Choices) {

--- a/agent/internal/modelavailability/modelavailability.go
+++ b/agent/internal/modelavailability/modelavailability.go
@@ -1,13 +1,10 @@
-// Package modelavailability captures and serves the startup-frozen model choices
-// advertised by delegate.model. It deliberately has no provider knowledge: callers
-// supply the already-resolved provider-instance fetch function.
 package modelavailability
 
 import (
 	"context"
+	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
-	"crypto/subtle"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -30,8 +27,8 @@ const (
 )
 
 type ProviderStatus struct {
-	Kind   StatusKind
-	Detail string
+	Kind   StatusKind `json:"kind"`
+	Detail string     `json:"detail,omitempty"`
 }
 type Snapshot struct {
 	Version  string
@@ -40,21 +37,23 @@ type Snapshot struct {
 	Status   map[string]ProviderStatus
 	key      []byte
 	mu       *sync.Mutex
-	used     map[string]bool
 }
 type Page struct {
-	Choices  []string
-	Next     string
-	Version  string
-	Complete bool
-	Status   map[string]ProviderStatus
+	Choices    []string                  `json:"choices,omitempty"`
+	Oversized  []int                     `json:"oversized,omitempty"`
+	Next       string                    `json:"next,omitempty"`
+	Version    string                    `json:"version"`
+	Complete   bool                      `json:"complete"`
+	Terminal   bool                      `json:"terminal"`
+	Status     map[string]ProviderStatus `json:"status"`
+	Provenance string                    `json:"provenance"`
 }
 
-// Inline limits keep the delegate schema prompt bounded; larger snapshots use
-// the read-only paginated surface instead of truncating a complete catalog.
 const (
 	DefaultInlineMaxCount = 128
 	DefaultInlineMaxBytes = 4096
+	DefaultPageMaxBytes   = 4096
+	DefaultPageMaxCount   = 128
 )
 
 func Capture(parent context.Context, providers []string, fetch func(context.Context, string) ([]llm.ModelInfo, error), budget time.Duration) Snapshot {
@@ -69,44 +68,46 @@ func Capture(parent context.Context, providers []string, fetch func(context.Cont
 	}
 	out := make(chan result, len(providers))
 	for _, name := range providers {
-		go func(name string) { m, e := fetch(ctx, name); out <- result{name, m, e} }(name)
+		go func(name string) {
+			m, e := fetch(ctx, name)
+			select {
+			case out <- result{name, m, e}:
+			case <-ctx.Done():
+			}
+		}(name)
 	}
 	status := map[string]ProviderStatus{}
 	set := map[string]bool{}
-	for received := 0; received < len(providers); received++ {
-		var r result
+	received := 0
+	for received < len(providers) {
 		select {
-		case r = <-out:
-		case <-ctx.Done():
-			// A provider that ignores context must not extend startup past the
-			// single overall budget. Its result is deliberately not trusted.
-			received = len(providers)
-			for _, p := range providers {
-				if _, ok := status[p]; !ok {
-					status[p] = ProviderStatus{StatusTimeout, "model enumeration timed out"}
+		case r := <-out:
+			received++
+			if r.err != nil {
+				k := StatusFailure
+				if errors.Is(r.err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+					k = StatusTimeout
+				}
+				status[r.name] = ProviderStatus{k, "enumeration did not complete"}
+				continue
+			}
+			if len(r.models) == 0 {
+				status[r.name] = ProviderStatus{StatusEmpty, "provider verified no models"}
+			} else {
+				status[r.name] = ProviderStatus{StatusSuccess, "enumeration succeeded"}
+			}
+			for _, m := range r.models {
+				if id := strings.TrimSpace(m.ID); id != "" {
+					set[r.name+"/"+id] = true
 				}
 			}
-		}
-		if r.name == "" {
-			break
-		}
-		if r.err != nil {
-			k := StatusFailure
-			if errors.Is(r.err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				k = StatusTimeout
+		case <-ctx.Done():
+			for _, p := range providers {
+				if _, ok := status[p]; !ok {
+					status[p] = ProviderStatus{StatusTimeout, "enumeration timed out"}
+				}
 			}
-			status[r.name] = ProviderStatus{k, "model enumeration did not complete"}
-			continue
-		}
-		if len(r.models) == 0 {
-			status[r.name] = ProviderStatus{StatusEmpty, "provider verified no models"}
-		} else {
-			status[r.name] = ProviderStatus{StatusSuccess, "provider model enumeration succeeded"}
-		}
-		for _, m := range r.models {
-			if strings.TrimSpace(m.ID) != "" {
-				set[r.name+"/"+strings.TrimSpace(m.ID)] = true
-			}
+			received = len(providers)
 		}
 	}
 	choices := make([]string, 0, len(set))
@@ -123,83 +124,115 @@ func Capture(parent context.Context, providers []string, fetch func(context.Cont
 	key := make([]byte, 32)
 	_, _ = rand.Read(key)
 	h := sha256.New()
-	h.Write([]byte("model-snapshot-v1\x00"))
+	h.Write([]byte("model-snapshot-v2\x00"))
+	h.Write([]byte{byte(len(providers))})
+	for _, p := range providers {
+		h.Write([]byte(p))
+		h.Write([]byte{0})
+		b, _ := json.Marshal(status[p])
+		h.Write(b)
+	}
 	for _, c := range choices {
 		h.Write([]byte(c))
 		h.Write([]byte{0})
 	}
 	version := hex.EncodeToString(h.Sum(nil)[:12])
-	return Snapshot{Version: version, Complete: complete, Choices: choices, Status: status, key: key, mu: &sync.Mutex{}, used: map[string]bool{}}
+	return Snapshot{Version: version, Complete: complete, Choices: choices, Status: status, key: key, mu: &sync.Mutex{}}
 }
-
 func (s Snapshot) Inline(maxCount, maxBytes int) (string, bool) {
 	if !s.Complete || len(s.Choices) > maxCount {
 		return "", false
 	}
 	text := "Verified startup snapshot " + s.Version + ": " + strings.Join(s.Choices, ", ") + "."
-	if len([]byte(text)) > maxBytes {
-		return "", false
-	}
-	return text, true
+	return text, len([]byte(text)) <= maxBytes
 }
 
 type cursor struct {
-	Version string
-	Offset  int
-	Nonce   uint64
+	Schema   string `json:"schema"`
+	Binding  string `json:"binding"`
+	Snapshot string `json:"snapshot"`
+	Offset   int    `json:"offset"`
+	Count    int    `json:"count"`
+	Bytes    int    `json:"bytes"`
 }
 
+func (s *Snapshot) token(c cursor) string {
+	b, _ := json.Marshal(c)
+	mac := hmac.New(sha256.New, s.key)
+	mac.Write(b)
+	return base64.RawURLEncoding.EncodeToString(append(b, mac.Sum(nil)...))
+}
+func (s *Snapshot) decode(token string) (cursor, error) {
+	if len(token) > 1024 {
+		return cursor{}, errors.New("malformed cursor")
+	}
+	raw, e := base64.RawURLEncoding.DecodeString(token)
+	if e != nil || len(raw) <= 32 {
+		return cursor{}, errors.New("malformed cursor")
+	}
+	b, tag := raw[:len(raw)-32], raw[len(raw)-32:]
+	mac := hmac.New(sha256.New, s.key)
+	mac.Write(b)
+	if !hmac.Equal(tag, mac.Sum(nil)) {
+		return cursor{}, errors.New("cursor authentication failed")
+	}
+	var c cursor
+	d := json.NewDecoder(strings.NewReader(string(b)))
+	d.DisallowUnknownFields()
+	if d.Decode(&c) != nil || d.More() {
+		return cursor{}, errors.New("malformed cursor")
+	}
+	if c.Schema != "model-list-v1" || c.Binding == "" || c.Snapshot != s.Version || c.Offset < 0 || c.Offset > len(s.Choices) || c.Count <= 0 || c.Bytes <= 0 {
+		return cursor{}, errors.New("stale cursor")
+	}
+	return c, nil
+}
 func (s *Snapshot) Page(token string, maxCount, maxBytes int) (Page, error) {
-	if s == nil || s.mu == nil || maxCount <= 0 || maxBytes <= 0 {
+	if s == nil || s.mu == nil || maxCount <= 0 || maxCount > DefaultPageMaxCount || maxBytes <= 0 || maxBytes > DefaultPageMaxBytes {
 		return Page{}, errors.New("invalid page bounds")
 	}
 	off := 0
 	if token != "" {
-		raw, e := base64.RawURLEncoding.DecodeString(token)
-		if e != nil || len(raw) <= 32 {
-			return Page{}, errors.New("invalid cursor")
+		c, e := s.decode(token)
+		if e != nil {
+			return Page{}, e
 		}
-		payload, mac := raw[:len(raw)-32], raw[len(raw)-32:]
-		sum := sha256.Sum256(append(append([]byte(nil), s.key...), payload...))
-		if subtle.ConstantTimeCompare(mac, sum[:]) != 1 {
-			return Page{}, errors.New("invalid cursor")
-		}
-		var c cursor
-		if json.Unmarshal(payload, &c) != nil || c.Version != s.Version || c.Offset < 0 || c.Offset > len(s.Choices) {
-			return Page{}, errors.New("stale cursor")
-		}
-		token = string(raw)
-		s.mu.Lock()
-		if s.used[token] {
-			s.mu.Unlock()
-			return Page{}, errors.New("cursor already used")
-		}
-		s.used[token] = true
-		s.mu.Unlock()
 		off = c.Offset
 	}
-	end := off
-	used := 0
-	for end < len(s.Choices) && used+len([]byte(s.Choices[end]))+func() int {
-		if end > off {
-			return 1
-		}
-		return 0
-	}() <= maxBytes && end-off < maxCount {
-		if end > off {
-			used++
-		}
-		used += len([]byte(s.Choices[end]))
-		end++
+	status := s.Status
+	if status == nil {
+		status = map[string]ProviderStatus{}
 	}
-	if end == off {
-		return Page{}, errors.New("model choice exceeds byte budget")
+	p := Page{Version: s.Version, Complete: s.Complete, Status: status, Provenance: "startup-frozen"}
+	if off >= len(s.Choices) {
+		p.Terminal = true
+		return p, nil
 	}
-	p := Page{Choices: append([]string(nil), s.Choices[off:end]...), Version: s.Version, Complete: s.Complete, Status: s.Status}
-	if end < len(s.Choices) {
-		c, _ := json.Marshal(cursor{s.Version, end, 0})
-		sum := sha256.Sum256(append(append([]byte(nil), s.key...), c...))
-		p.Next = base64.RawURLEncoding.EncodeToString(append(c, sum[:]...))
+	for off < len(s.Choices) && len(p.Choices)+len(p.Oversized) < maxCount {
+		candidate := s.Choices[off]
+		p.Choices = append(p.Choices, candidate)
+		if p.SerializedBytes() > maxBytes {
+			p.Choices = p.Choices[:len(p.Choices)-1]
+			p.Oversized = append(p.Oversized, off)
+		}
+		off++
+		if p.SerializedBytes() > maxBytes {
+			p.Oversized = p.Oversized[:len(p.Oversized)-1]
+			break
+		}
+	}
+	if len(p.Choices) == 0 && len(p.Oversized) == 0 {
+		return Page{}, errors.New("page envelope budget too small")
+	}
+	if off < len(s.Choices) {
+		p.Next = s.token(cursor{"model-list-v1", "root", s.Version, off, maxCount, maxBytes})
+	}
+	if off >= len(s.Choices) {
+		p.Terminal = true
+	}
+	if p.SerializedBytes() > maxBytes {
+		return Page{}, errors.New("page envelope budget too small")
 	}
 	return p, nil
 }
+func (p Page) SerializedBytes() int { b, _ := json.Marshal(p); return len(b) }

--- a/agent/internal/modelavailability/modelavailability.go
+++ b/agent/internal/modelavailability/modelavailability.go
@@ -65,10 +65,10 @@ const (
 	captureMaxModelIDLen  = 256
 )
 
-func Capture(parent context.Context, providers []string, fetch func(context.Context, string) ([]llm.ModelInfo, error), visible func(string, llm.ModelInfo) bool, budget time.Duration) Snapshot {
+func Capture(parent context.Context, providers []string, requiredProvider string, fetch func(context.Context, string) ([]llm.ModelInfo, error), visible func(string, llm.ModelInfo) bool, budget time.Duration) Snapshot {
 	ctx, cancel := context.WithTimeout(parent, budget)
 	defer cancel()
-	providers, providerLimited := boundedProviders(providers)
+	providers, providerLimited := boundedProviders(providers, requiredProvider)
 	sort.Strings(providers)
 	type result struct {
 		name    string
@@ -193,13 +193,17 @@ func Capture(parent context.Context, providers []string, fetch func(context.Cont
 	return Snapshot{Version: version, Complete: complete, Choices: choices, Status: status, key: key}
 }
 
-func boundedProviders(providers []string) ([]string, bool) {
+func boundedProviders(providers []string, requiredProvider string) ([]string, bool) {
 	bounded := make([]string, 0, min(len(providers), captureMaxProviders))
 	limited := false
+	requiredPresent := false
 	for _, provider := range providers {
 		if !safeProviderName(provider) {
 			limited = true
 			continue
+		}
+		if provider == requiredProvider {
+			requiredPresent = true
 		}
 		at, found := slices.BinarySearch(bounded, provider)
 		if found {
@@ -215,6 +219,10 @@ func boundedProviders(providers []string) ([]string, bool) {
 		bounded = append(bounded, provider)
 		copy(bounded[at+1:], bounded[at:len(bounded)-1])
 		bounded[at] = provider
+	}
+	if requiredPresent && !slices.Contains(bounded, requiredProvider) {
+		bounded[len(bounded)-1] = requiredProvider
+		sort.Strings(bounded)
 	}
 	return bounded, limited
 }

--- a/agent/internal/modelavailability/modelavailability.go
+++ b/agent/internal/modelavailability/modelavailability.go
@@ -9,10 +9,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"primeradiant.com/evener/llm"
 )
@@ -24,6 +27,7 @@ const (
 	StatusEmpty   StatusKind = "empty-success"
 	StatusFailure StatusKind = "failure"
 	StatusTimeout StatusKind = "timeout"
+	StatusLimited StatusKind = "limited"
 )
 
 type ProviderStatus struct {
@@ -54,70 +58,116 @@ const (
 	DefaultInlineMaxBytes = 4096
 	DefaultPageMaxBytes   = 4096
 	DefaultPageMaxCount   = 128
+	// Capture bounds keep startup catalog work finite even when a provider
+	// returns an unexpectedly large or malformed model list.
+	captureMaxProviders   = 64
+	captureMaxModels      = 4096
+	captureMaxBytes       = 256 * 1024
+	captureMaxProviderLen = 128
+	captureMaxModelIDLen  = 256
 )
 
-func Capture(parent context.Context, providers []string, fetch func(context.Context, string) ([]llm.ModelInfo, error), budget time.Duration) Snapshot {
+func Capture(parent context.Context, providers []string, fetch func(context.Context, string) ([]llm.ModelInfo, error), visible func(string, llm.ModelInfo) bool, budget time.Duration) Snapshot {
 	ctx, cancel := context.WithTimeout(parent, budget)
 	defer cancel()
-	providers = append([]string(nil), providers...)
+	providers, providerLimited := boundedProviders(providers)
 	sort.Strings(providers)
 	type result struct {
-		name   string
-		models []llm.ModelInfo
-		err    error
+		name    string
+		ids     []string
+		err     error
+		limited bool
 	}
 	out := make(chan result, len(providers))
 	for _, name := range providers {
 		go func(name string) {
-			m, e := fetch(ctx, name)
+			models, err := fetch(ctx, name)
+			r := result{name: name, err: err}
+			if err == nil {
+				seen := make(map[string]bool)
+				var bytes int
+				for _, model := range models {
+					id, ok := safeModelID(model.ID)
+					if !ok {
+						r.limited = true
+						continue
+					}
+					model.ID = id
+					if visible != nil && !visible(name, model) {
+						continue
+					}
+					if seen[id] {
+						continue
+					}
+					choiceBytes := len(name) + 1 + len(id)
+					if len(r.ids) >= captureMaxModels || bytes+choiceBytes > captureMaxBytes {
+						r.limited = true
+						continue
+					}
+					seen[id] = true
+					r.ids = append(r.ids, id)
+					bytes += choiceBytes
+				}
+				sort.Strings(r.ids)
+			}
 			select {
-			case out <- result{name, m, e}:
+			case out <- r:
 			case <-ctx.Done():
 			}
 		}(name)
 	}
-	status := map[string]ProviderStatus{}
-	set := map[string]bool{}
+	results := make(map[string]result, len(providers))
 	received := 0
 	for received < len(providers) {
 		select {
 		case r := <-out:
 			received++
-			if r.err != nil {
-				k := StatusFailure
-				if errors.Is(r.err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
-					k = StatusTimeout
-				}
-				status[r.name] = ProviderStatus{k, "enumeration did not complete"}
-				continue
-			}
-			if len(r.models) == 0 {
-				status[r.name] = ProviderStatus{StatusEmpty, "provider verified no models"}
-			} else {
-				status[r.name] = ProviderStatus{StatusSuccess, "enumeration succeeded"}
-			}
-			for _, m := range r.models {
-				if id := strings.TrimSpace(m.ID); id != "" {
-					set[r.name+"/"+id] = true
-				}
-			}
+			results[r.name] = r
 		case <-ctx.Done():
-			for _, p := range providers {
-				if _, ok := status[p]; !ok {
-					status[p] = ProviderStatus{StatusTimeout, "enumeration timed out"}
-				}
-			}
 			received = len(providers)
 		}
 	}
-	choices := make([]string, 0, len(set))
-	for c := range set {
-		choices = append(choices, c)
-	}
-	sort.Strings(choices)
-	complete := len(providers) > 0
+	status := make(map[string]ProviderStatus, len(providers))
+	choices := make([]string, 0)
+	choiceBytes := 0
+	complete := len(providers) > 0 && !providerLimited
 	for _, p := range providers {
-		if status[p].Kind != StatusSuccess && status[p].Kind != StatusEmpty {
+		r, ok := results[p]
+		if !ok {
+			status[p] = ProviderStatus{StatusTimeout, "enumeration timed out"}
+			complete = false
+			continue
+		}
+		if r.err != nil {
+			kind := StatusFailure
+			if errors.Is(r.err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				kind = StatusTimeout
+			}
+			status[p] = ProviderStatus{kind, "enumeration did not complete"}
+			complete = false
+			continue
+		}
+		kind := StatusSuccess
+		detail := "enumeration succeeded"
+		if len(r.ids) == 0 {
+			kind = StatusEmpty
+			detail = "provider verified no models"
+		}
+		for _, id := range r.ids {
+			choice := p + "/" + id
+			if len(choices) >= captureMaxModels || choiceBytes+len(choice) > captureMaxBytes {
+				r.limited = true
+				continue
+			}
+			choices = append(choices, choice)
+			choiceBytes += len(choice)
+		}
+		if r.limited {
+			kind = StatusLimited
+			detail = "enumeration exceeded safe capture bounds"
+		}
+		status[p] = ProviderStatus{kind, detail}
+		if kind != StatusSuccess && kind != StatusEmpty {
 			complete = false
 		}
 	}
@@ -126,6 +176,11 @@ func Capture(parent context.Context, providers []string, fetch func(context.Cont
 	h := sha256.New()
 	h.Write([]byte("model-snapshot-v2\x00"))
 	h.Write([]byte{byte(len(providers))})
+	if complete {
+		h.Write([]byte{1})
+	} else {
+		h.Write([]byte{0})
+	}
 	for _, p := range providers {
 		h.Write([]byte(p))
 		h.Write([]byte{0})
@@ -138,6 +193,53 @@ func Capture(parent context.Context, providers []string, fetch func(context.Cont
 	}
 	version := hex.EncodeToString(h.Sum(nil)[:12])
 	return Snapshot{Version: version, Complete: complete, Choices: choices, Status: status, key: key, mu: &sync.Mutex{}}
+}
+
+func boundedProviders(providers []string) ([]string, bool) {
+	bounded := make([]string, 0, min(len(providers), captureMaxProviders))
+	limited := false
+	for _, provider := range providers {
+		if !safeProviderName(provider) {
+			limited = true
+			continue
+		}
+		at, found := slices.BinarySearch(bounded, provider)
+		if found {
+			continue
+		}
+		if len(bounded) == captureMaxProviders {
+			limited = true
+			if at == len(bounded) {
+				continue
+			}
+			bounded = bounded[:len(bounded)-1]
+		}
+		bounded = append(bounded, provider)
+		copy(bounded[at+1:], bounded[at:len(bounded)-1])
+		bounded[at] = provider
+	}
+	return bounded, limited
+}
+
+func safeProviderName(name string) bool {
+	return name == strings.TrimSpace(name) && safeIdentifier(name, captureMaxProviderLen)
+}
+
+func safeModelID(id string) (string, bool) {
+	id = strings.TrimSpace(id)
+	return id, safeIdentifier(id, captureMaxModelIDLen)
+}
+
+func safeIdentifier(value string, maxBytes int) bool {
+	if value == "" || len(value) > maxBytes || !utf8.ValidString(value) {
+		return false
+	}
+	for _, r := range value {
+		if unicode.IsSpace(r) || unicode.IsControl(r) || unicode.In(r, unicode.Cf, unicode.Co, unicode.Cs) {
+			return false
+		}
+	}
+	return true
 }
 func (s Snapshot) Inline(maxCount, maxBytes int) (string, bool) {
 	if !s.Complete || len(s.Choices) > maxCount {

--- a/agent/internal/modelavailability/modelavailability.go
+++ b/agent/internal/modelavailability/modelavailability.go
@@ -206,6 +206,9 @@ func (s *Snapshot) Page(token string, maxCount, maxBytes int) (Page, error) {
 	p := Page{Version: s.Version, Complete: s.Complete, Status: status, Provenance: "startup-frozen"}
 	if off >= len(s.Choices) {
 		p.Terminal = true
+		if p.SerializedBytes() > maxBytes {
+			return Page{}, errors.New("page envelope budget too small")
+		}
 		return p, nil
 	}
 	for off < len(s.Choices) && len(p.Choices)+len(p.Oversized) < maxCount {

--- a/agent/internal/modelavailability/modelavailability.go
+++ b/agent/internal/modelavailability/modelavailability.go
@@ -12,7 +12,6 @@ import (
 	"slices"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 	"unicode"
 	"unicode/utf8"
@@ -40,7 +39,6 @@ type Snapshot struct {
 	Choices  []string
 	Status   map[string]ProviderStatus
 	key      []byte
-	mu       *sync.Mutex
 }
 type Page struct {
 	Choices    []string                  `json:"choices,omitempty"`
@@ -192,7 +190,7 @@ func Capture(parent context.Context, providers []string, fetch func(context.Cont
 		h.Write([]byte{0})
 	}
 	version := hex.EncodeToString(h.Sum(nil)[:12])
-	return Snapshot{Version: version, Complete: complete, Choices: choices, Status: status, key: key, mu: &sync.Mutex{}}
+	return Snapshot{Version: version, Complete: complete, Choices: choices, Status: status, key: key}
 }
 
 func boundedProviders(providers []string) ([]string, bool) {
@@ -290,7 +288,7 @@ func (s *Snapshot) decode(token string) (cursor, error) {
 	return c, nil
 }
 func (s *Snapshot) Page(token string, maxCount, maxBytes int) (Page, error) {
-	if s == nil || s.mu == nil || maxCount <= 0 || maxCount > DefaultPageMaxCount || maxBytes <= 0 || maxBytes > DefaultPageMaxBytes {
+	if s == nil || len(s.key) == 0 || maxCount <= 0 || maxCount > DefaultPageMaxCount || maxBytes <= 0 || maxBytes > DefaultPageMaxBytes {
 		return Page{}, errors.New("invalid page bounds")
 	}
 	off := 0
@@ -298,6 +296,9 @@ func (s *Snapshot) Page(token string, maxCount, maxBytes int) (Page, error) {
 		c, e := s.decode(token)
 		if e != nil {
 			return Page{}, e
+		}
+		if c.Count != maxCount || c.Bytes != maxBytes {
+			return Page{}, errors.New("stale cursor")
 		}
 		off = c.Offset
 	}

--- a/agent/internal/modelavailability/modelavailability.go
+++ b/agent/internal/modelavailability/modelavailability.go
@@ -357,4 +357,4 @@ func (s *Snapshot) pageAtOffset(p Page, off, maxCount, maxBytes int) Page {
 	return p
 }
 
-func (p Page) SerializedBytes() int { b, _ := json.Marshal(p); return len(b) }
+func (p Page) SerializedBytes() int { b, _ := json.MarshalIndent(p, "", "  "); return len(b) }

--- a/agent/internal/modelavailability/modelavailability.go
+++ b/agent/internal/modelavailability/modelavailability.go
@@ -58,10 +58,10 @@ const (
 	DefaultPageMaxCount   = 128
 	// Capture bounds keep startup catalog work finite even when a provider
 	// returns an unexpectedly large or malformed model list.
-	captureMaxProviders   = 64
+	captureMaxProviders   = 16
 	captureMaxModels      = 4096
 	captureMaxBytes       = 256 * 1024
-	captureMaxProviderLen = 128
+	captureMaxProviderLen = 64
 	captureMaxModelIDLen  = 256
 )
 
@@ -220,7 +220,11 @@ func boundedProviders(providers []string) ([]string, bool) {
 }
 
 func safeProviderName(name string) bool {
-	return name == strings.TrimSpace(name) && safeIdentifier(name, captureMaxProviderLen)
+	if name != strings.TrimSpace(name) || !safeIdentifier(name, captureMaxProviderLen) {
+		return false
+	}
+	encoded, _ := json.Marshal(name)
+	return len(encoded) == len(name)+2
 }
 
 func safeModelID(id string) (string, bool) {

--- a/agent/internal/modelavailability/modelavailability_fuzz_test.go
+++ b/agent/internal/modelavailability/modelavailability_fuzz_test.go
@@ -4,6 +4,7 @@ import "testing"
 
 // FuzzCursorDecode keeps the authenticated continuation parser total for
 // arbitrary model-facing cursor bytes.
+// Registry: native:agent:./internal/modelavailability:FuzzCursorDecode::modelavailability.go
 func FuzzCursorDecode(f *testing.F) {
 	f.Add("not-a-cursor")
 	f.Add("")

--- a/agent/internal/modelavailability/modelavailability_fuzz_test.go
+++ b/agent/internal/modelavailability/modelavailability_fuzz_test.go
@@ -1,0 +1,14 @@
+package modelavailability
+
+import "testing"
+
+// FuzzCursorDecode keeps the authenticated continuation parser total for
+// arbitrary model-facing cursor bytes.
+func FuzzCursorDecode(f *testing.F) {
+	f.Add("not-a-cursor")
+	f.Add("")
+	s := testSnapshot("v1", true, "provider/model")
+	f.Fuzz(func(t *testing.T, token string) {
+		_, _ = s.Page(token, 1, 64)
+	})
+}

--- a/agent/internal/modelavailability/modelavailability_test.go
+++ b/agent/internal/modelavailability/modelavailability_test.go
@@ -77,6 +77,22 @@ func TestCaptureRejectsUnsafeModelIdentifiers(t *testing.T) {
 	}
 }
 
+func TestCaptureRejectsProviderNamesThatCouldExpandThePageEnvelope(t *testing.T) {
+	providers := []string{"safe", "bad&name", `bad"name`, strings.Repeat("x", 65)}
+	var calls atomic.Int32
+	snapshot := Capture(context.Background(), providers, func(context.Context, string) ([]llm.ModelInfo, error) {
+		calls.Add(1)
+		return []llm.ModelInfo{{ID: "model"}}, nil
+	}, nil, time.Second)
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("provider fetches = %d, want only the safe provider", got)
+	}
+	if snapshot.Complete || !slices.Equal(snapshot.Choices, []string{"safe/model"}) {
+		t.Fatalf("provider-sanitized snapshot = %#v", snapshot)
+	}
+}
+
 func TestCaptureEnforcesProviderModelAndByteBounds(t *testing.T) {
 	t.Run("providers", func(t *testing.T) {
 		providers := make([]string, 65)
@@ -88,14 +104,14 @@ func TestCaptureEnforcesProviderModelAndByteBounds(t *testing.T) {
 			calls.Add(1)
 			return []llm.ModelInfo{{ID: "model"}}, nil
 		}, nil, time.Second)
-		if got := calls.Load(); got != 64 {
-			t.Fatalf("provider fetches = %d, want bounded at 64", got)
+		if got := calls.Load(); got != 16 {
+			t.Fatalf("provider fetches = %d, want bounded at 16", got)
 		}
-		if snapshot.Complete || len(snapshot.Choices) != 64 {
+		if snapshot.Complete || len(snapshot.Choices) != 16 {
 			t.Fatalf("provider-bounded snapshot = %#v", snapshot)
 		}
-		if snapshot.Choices[0] != "provider-00/model" || snapshot.Choices[63] != "provider-63/model" {
-			t.Fatalf("provider bound was not deterministic: first=%q last=%q", snapshot.Choices[0], snapshot.Choices[63])
+		if snapshot.Choices[0] != "provider-00/model" || snapshot.Choices[15] != "provider-15/model" {
+			t.Fatalf("provider bound was not deterministic: first=%q last=%q", snapshot.Choices[0], snapshot.Choices[15])
 		}
 	})
 
@@ -131,6 +147,24 @@ func TestCaptureEnforcesProviderModelAndByteBounds(t *testing.T) {
 			t.Fatalf("byte truncation was not reported as incomplete: %#v", snapshot.Status)
 		}
 	})
+}
+
+func TestCaptureProviderBoundKeepsPublicPageEnvelopeUsable(t *testing.T) {
+	providers := make([]string, 65)
+	for i := range providers {
+		providers[i] = fmt.Sprintf("provider-%02d-%s", i, strings.Repeat("x", 52))
+	}
+	snapshot := Capture(context.Background(), providers, func(context.Context, string) ([]llm.ModelInfo, error) {
+		return []llm.ModelInfo{{ID: "model"}}, nil
+	}, nil, time.Second)
+
+	page, err := snapshot.Page("", DefaultPageMaxCount, DefaultPageMaxBytes)
+	if err != nil {
+		t.Fatalf("bounded capture produced an unusable page envelope: %v", err)
+	}
+	if got := page.SerializedBytes(); got > DefaultPageMaxBytes {
+		t.Fatalf("page envelope = %d bytes, exceeds %d", got, DefaultPageMaxBytes)
+	}
 }
 
 func TestRenderInlineRequiresCompleteCountAndUTF8ByteBounds(t *testing.T) {

--- a/agent/internal/modelavailability/modelavailability_test.go
+++ b/agent/internal/modelavailability/modelavailability_test.go
@@ -24,7 +24,7 @@ func TestCaptureKeepsSuccessfulChoicesWhenAnotherProviderFails(t *testing.T) {
 		}
 		return []llm.ModelInfo{{ID: "z"}, {ID: "a"}, {ID: "a"}}, nil
 	}
-	s := Capture(context.Background(), []string{"failed", "good"}, fetch, nil, time.Hour)
+	s := Capture(context.Background(), []string{"failed", "good"}, "", fetch, nil, time.Hour)
 	if s.Complete || len(s.Choices) != 2 || s.Choices[0] != "good/a" || s.Choices[1] != "good/z" {
 		t.Fatalf("snapshot = %#v", s)
 	}
@@ -38,7 +38,7 @@ func TestCaptureStopsAtOneDeterministicDeadline(t *testing.T) {
 	started := make(chan struct{}, 2)
 	done := make(chan Snapshot, 1)
 	go func() {
-		done <- Capture(parent, []string{"first", "second"}, func(ctx context.Context, _ string) ([]llm.ModelInfo, error) {
+		done <- Capture(parent, []string{"first", "second"}, "", func(ctx context.Context, _ string) ([]llm.ModelInfo, error) {
 			started <- struct{}{}
 			<-ctx.Done()
 			return nil, ctx.Err()
@@ -64,7 +64,7 @@ func TestCaptureRejectsUnsafeModelIdentifiers(t *testing.T) {
 		{ID: strings.Repeat("x", 257)},
 		{ID: string([]byte{0xff})},
 	}
-	snapshot := Capture(context.Background(), []string{"provider"}, func(context.Context, string) ([]llm.ModelInfo, error) {
+	snapshot := Capture(context.Background(), []string{"provider"}, "", func(context.Context, string) ([]llm.ModelInfo, error) {
 		return models, nil
 	}, nil, time.Second)
 
@@ -80,7 +80,7 @@ func TestCaptureRejectsUnsafeModelIdentifiers(t *testing.T) {
 func TestCaptureRejectsProviderNamesThatCouldExpandThePageEnvelope(t *testing.T) {
 	providers := []string{"safe", "bad&name", `bad"name`, strings.Repeat("x", 65)}
 	var calls atomic.Int32
-	snapshot := Capture(context.Background(), providers, func(context.Context, string) ([]llm.ModelInfo, error) {
+	snapshot := Capture(context.Background(), providers, "", func(context.Context, string) ([]llm.ModelInfo, error) {
 		calls.Add(1)
 		return []llm.ModelInfo{{ID: "model"}}, nil
 	}, nil, time.Second)
@@ -100,7 +100,7 @@ func TestCaptureEnforcesProviderModelAndByteBounds(t *testing.T) {
 			providers[i] = fmt.Sprintf("provider-%02d", len(providers)-1-i)
 		}
 		var calls atomic.Int32
-		snapshot := Capture(context.Background(), providers, func(_ context.Context, name string) ([]llm.ModelInfo, error) {
+		snapshot := Capture(context.Background(), providers, "", func(_ context.Context, name string) ([]llm.ModelInfo, error) {
 			calls.Add(1)
 			return []llm.ModelInfo{{ID: "model"}}, nil
 		}, nil, time.Second)
@@ -120,7 +120,7 @@ func TestCaptureEnforcesProviderModelAndByteBounds(t *testing.T) {
 		for i := range models {
 			models[i].ID = fmt.Sprintf("model-%04d", i)
 		}
-		snapshot := Capture(context.Background(), []string{"provider"}, func(context.Context, string) ([]llm.ModelInfo, error) {
+		snapshot := Capture(context.Background(), []string{"provider"}, "", func(context.Context, string) ([]llm.ModelInfo, error) {
 			return models, nil
 		}, nil, time.Second)
 		if len(snapshot.Choices) != 4096 || snapshot.Complete || snapshot.Status["provider"].Kind != StatusLimited {
@@ -133,7 +133,7 @@ func TestCaptureEnforcesProviderModelAndByteBounds(t *testing.T) {
 		for i := range models {
 			models[i].ID = fmt.Sprintf("%04d-%s", i, strings.Repeat("x", 195))
 		}
-		snapshot := Capture(context.Background(), []string{"provider"}, func(context.Context, string) ([]llm.ModelInfo, error) {
+		snapshot := Capture(context.Background(), []string{"provider"}, "", func(context.Context, string) ([]llm.ModelInfo, error) {
 			return models, nil
 		}, nil, time.Second)
 		var capturedBytes int
@@ -154,7 +154,7 @@ func TestCaptureProviderBoundKeepsPublicPageEnvelopeUsable(t *testing.T) {
 	for i := range providers {
 		providers[i] = fmt.Sprintf("provider-%02d-%s", i, strings.Repeat("x", 52))
 	}
-	snapshot := Capture(context.Background(), providers, func(context.Context, string) ([]llm.ModelInfo, error) {
+	snapshot := Capture(context.Background(), providers, "", func(context.Context, string) ([]llm.ModelInfo, error) {
 		return []llm.ModelInfo{{ID: "model"}}, nil
 	}, nil, time.Second)
 

--- a/agent/internal/modelavailability/modelavailability_test.go
+++ b/agent/internal/modelavailability/modelavailability_test.go
@@ -72,8 +72,8 @@ func TestPageReturnsBoundedEnvelopeAndProgressesOversizedOrEmptySnapshots(t *tes
 	if err != nil || !p.Terminal || len(p.Oversized) != 1 {
 		t.Fatalf("oversized page=%#v err=%v", p, err)
 	}
-	if got := p.SerializedBytes(); got > 1024 {
-		t.Fatalf("serialized bytes=%d", got)
+	if got := p.SerializedBytes(); got > 256 {
+		t.Fatalf("serialized bytes=%d, want at most 256", got)
 	}
 	empty := testSnapshot("v2", false)
 	p, err = empty.Page("", 1, 1024)

--- a/agent/internal/modelavailability/modelavailability_test.go
+++ b/agent/internal/modelavailability/modelavailability_test.go
@@ -82,6 +82,18 @@ func TestPageReturnsBoundedEnvelopeAndProgressesOversizedOrEmptySnapshots(t *tes
 	}
 }
 
+func TestPageRejectsTerminalEnvelopeOverByteBound(t *testing.T) {
+	s := testSnapshot("v1", false)
+	s.Status = map[string]ProviderStatus{
+		"provider": {Kind: StatusFailure, Detail: strings.Repeat("x", 256)},
+	}
+
+	page, err := s.Page("", 1, 128)
+	if err == nil {
+		t.Fatalf("Page returned oversized terminal envelope (%d bytes): %#v", page.SerializedBytes(), page)
+	}
+}
+
 func TestCursorRejectsUnknownFieldsAndIsIdempotent(t *testing.T) {
 	s := testSnapshot("v1", true, "p/a", "p/b")
 	p, err := s.Page("", 1, 1024)

--- a/agent/internal/modelavailability/modelavailability_test.go
+++ b/agent/internal/modelavailability/modelavailability_test.go
@@ -149,6 +149,56 @@ func TestCaptureEnforcesProviderModelAndByteBounds(t *testing.T) {
 	})
 }
 
+func TestCaptureStopsFilteringAtTheFirstHardBound(t *testing.T) {
+	models := make([]llm.ModelInfo, captureMaxModels+100)
+	for i := range models {
+		models[i].ID = fmt.Sprintf("model-%04d", i)
+	}
+	var visibilityCalls atomic.Int32
+	snapshot := Capture(context.Background(), []string{"provider"}, "", func(context.Context, string) ([]llm.ModelInfo, error) {
+		return models, nil
+	}, func(string, llm.ModelInfo) bool {
+		visibilityCalls.Add(1)
+		return true
+	}, time.Hour)
+
+	if got := visibilityCalls.Load(); got != captureMaxModels {
+		t.Fatalf("visibility checks = %d, want hard stop at %d", got, captureMaxModels)
+	}
+	if snapshot.Complete || len(snapshot.Choices) != captureMaxModels || snapshot.Status["provider"].Kind != StatusLimited {
+		t.Fatalf("hard-bounded snapshot: choices=%d complete=%v status=%#v", len(snapshot.Choices), snapshot.Complete, snapshot.Status)
+	}
+}
+
+func TestBoundedModelIDsRejectsCanceledResults(t *testing.T) {
+	models := []llm.ModelInfo{{ID: "first"}, {ID: "second"}}
+	t.Run("before filtering", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		var visibilityCalls int
+		ids, limited, err := boundedModelIDs(ctx, "provider", models, func(string, llm.ModelInfo) bool {
+			visibilityCalls++
+			return true
+		})
+		if !errors.Is(err, context.Canceled) || ids != nil || limited || visibilityCalls != 0 {
+			t.Fatalf("canceled result = ids:%q limited:%v calls:%d err:%v", ids, limited, visibilityCalls, err)
+		}
+	})
+
+	t.Run("during filtering", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		var visibilityCalls int
+		ids, limited, err := boundedModelIDs(ctx, "provider", models, func(string, llm.ModelInfo) bool {
+			visibilityCalls++
+			cancel()
+			return true
+		})
+		if !errors.Is(err, context.Canceled) || ids != nil || limited || visibilityCalls != 1 {
+			t.Fatalf("mid-filter cancellation = ids:%q limited:%v calls:%d err:%v", ids, limited, visibilityCalls, err)
+		}
+	})
+}
+
 func TestCaptureProviderBoundKeepsPublicPageEnvelopeUsable(t *testing.T) {
 	providers := make([]string, 65)
 	for i := range providers {

--- a/agent/internal/modelavailability/modelavailability_test.go
+++ b/agent/internal/modelavailability/modelavailability_test.go
@@ -6,8 +6,11 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,13 +27,92 @@ func TestCaptureUsesOneDeadlineAndKeepsSuccessfulPartialChoices(t *testing.T) {
 		}
 		return []llm.ModelInfo{{ID: "z"}, {ID: "a"}, {ID: "a"}}, nil
 	}
-	s := Capture(context.Background(), []string{"slow", "good"}, fetch, 30*time.Millisecond)
+	s := Capture(context.Background(), []string{"slow", "good"}, fetch, nil, 30*time.Millisecond)
 	if s.Complete || len(s.Choices) != 2 || s.Choices[0] != "good/a" || s.Choices[1] != "good/z" {
 		t.Fatalf("snapshot = %#v", s)
 	}
 	if s.Status["slow"].Kind != StatusTimeout || s.Status["good"].Kind != StatusSuccess {
 		t.Fatalf("status = %#v", s.Status)
 	}
+}
+
+func TestCaptureRejectsUnsafeModelIdentifiers(t *testing.T) {
+	models := []llm.ModelInfo{
+		{ID: "safe"},
+		{ID: " padded "},
+		{ID: "space inside"},
+		{ID: "line\nbreak"},
+		{ID: "bidi\u202eoverride"},
+		{ID: strings.Repeat("x", 257)},
+		{ID: string([]byte{0xff})},
+	}
+	snapshot := Capture(context.Background(), []string{"provider"}, func(context.Context, string) ([]llm.ModelInfo, error) {
+		return models, nil
+	}, nil, time.Second)
+
+	want := []string{"provider/padded", "provider/safe"}
+	if !slices.Equal(snapshot.Choices, want) {
+		t.Fatalf("choices = %q, want %q", snapshot.Choices, want)
+	}
+	if snapshot.Complete || snapshot.Status["provider"].Kind != StatusLimited {
+		t.Fatalf("unsafe omissions were not reported as incomplete: %#v", snapshot)
+	}
+}
+
+func TestCaptureEnforcesProviderModelAndByteBounds(t *testing.T) {
+	t.Run("providers", func(t *testing.T) {
+		providers := make([]string, 65)
+		for i := range providers {
+			providers[i] = fmt.Sprintf("provider-%02d", len(providers)-1-i)
+		}
+		var calls atomic.Int32
+		snapshot := Capture(context.Background(), providers, func(_ context.Context, name string) ([]llm.ModelInfo, error) {
+			calls.Add(1)
+			return []llm.ModelInfo{{ID: "model"}}, nil
+		}, nil, time.Second)
+		if got := calls.Load(); got != 64 {
+			t.Fatalf("provider fetches = %d, want bounded at 64", got)
+		}
+		if snapshot.Complete || len(snapshot.Choices) != 64 {
+			t.Fatalf("provider-bounded snapshot = %#v", snapshot)
+		}
+		if snapshot.Choices[0] != "provider-00/model" || snapshot.Choices[63] != "provider-63/model" {
+			t.Fatalf("provider bound was not deterministic: first=%q last=%q", snapshot.Choices[0], snapshot.Choices[63])
+		}
+	})
+
+	t.Run("models", func(t *testing.T) {
+		models := make([]llm.ModelInfo, 4097)
+		for i := range models {
+			models[i].ID = fmt.Sprintf("model-%04d", i)
+		}
+		snapshot := Capture(context.Background(), []string{"provider"}, func(context.Context, string) ([]llm.ModelInfo, error) {
+			return models, nil
+		}, nil, time.Second)
+		if len(snapshot.Choices) != 4096 || snapshot.Complete || snapshot.Status["provider"].Kind != StatusLimited {
+			t.Fatalf("model-bounded snapshot: choices=%d complete=%v status=%#v", len(snapshot.Choices), snapshot.Complete, snapshot.Status)
+		}
+	})
+
+	t.Run("bytes", func(t *testing.T) {
+		models := make([]llm.ModelInfo, 4096)
+		for i := range models {
+			models[i].ID = fmt.Sprintf("%04d-%s", i, strings.Repeat("x", 195))
+		}
+		snapshot := Capture(context.Background(), []string{"provider"}, func(context.Context, string) ([]llm.ModelInfo, error) {
+			return models, nil
+		}, nil, time.Second)
+		var capturedBytes int
+		for _, choice := range snapshot.Choices {
+			capturedBytes += len([]byte(choice))
+		}
+		if capturedBytes > 256*1024 {
+			t.Fatalf("captured choice bytes = %d, want at most %d", capturedBytes, 256*1024)
+		}
+		if snapshot.Complete || snapshot.Status["provider"].Kind != StatusLimited {
+			t.Fatalf("byte truncation was not reported as incomplete: %#v", snapshot.Status)
+		}
+	})
 }
 
 func TestRenderInlineRequiresCompleteCountAndUTF8ByteBounds(t *testing.T) {

--- a/agent/internal/modelavailability/modelavailability_test.go
+++ b/agent/internal/modelavailability/modelavailability_test.go
@@ -6,10 +6,10 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -17,22 +17,40 @@ import (
 	"primeradiant.com/evener/llm"
 )
 
-func TestCaptureUsesOneDeadlineAndKeepsSuccessfulPartialChoices(t *testing.T) {
-	started := make(chan struct{}, 2)
-	fetch := func(ctx context.Context, name string) ([]llm.ModelInfo, error) {
-		started <- struct{}{}
-		if name == "slow" {
-			<-ctx.Done()
-			return nil, ctx.Err()
+func TestCaptureKeepsSuccessfulChoicesWhenAnotherProviderFails(t *testing.T) {
+	fetch := func(_ context.Context, name string) ([]llm.ModelInfo, error) {
+		if name == "failed" {
+			return nil, errors.New("unavailable")
 		}
 		return []llm.ModelInfo{{ID: "z"}, {ID: "a"}, {ID: "a"}}, nil
 	}
-	s := Capture(context.Background(), []string{"slow", "good"}, fetch, nil, 30*time.Millisecond)
+	s := Capture(context.Background(), []string{"failed", "good"}, fetch, nil, time.Hour)
 	if s.Complete || len(s.Choices) != 2 || s.Choices[0] != "good/a" || s.Choices[1] != "good/z" {
 		t.Fatalf("snapshot = %#v", s)
 	}
-	if s.Status["slow"].Kind != StatusTimeout || s.Status["good"].Kind != StatusSuccess {
+	if s.Status["failed"].Kind != StatusFailure || s.Status["good"].Kind != StatusSuccess {
 		t.Fatalf("status = %#v", s.Status)
+	}
+}
+
+func TestCaptureStopsAtOneDeterministicDeadline(t *testing.T) {
+	parent := &deadlineBarrierContext{done: make(chan struct{})}
+	started := make(chan struct{}, 2)
+	done := make(chan Snapshot, 1)
+	go func() {
+		done <- Capture(parent, []string{"first", "second"}, func(ctx context.Context, _ string) ([]llm.ModelInfo, error) {
+			started <- struct{}{}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}, nil, time.Hour)
+	}()
+	<-started
+	<-started
+	close(parent.done)
+
+	s := <-done
+	if s.Complete || s.Status["first"].Kind != StatusTimeout || s.Status["second"].Kind != StatusTimeout {
+		t.Fatalf("deadline snapshot = %#v", s)
 	}
 }
 
@@ -148,6 +166,20 @@ func TestCursorIsOpaqueSnapshotBoundAndPagesByBytesAndCount(t *testing.T) {
 	}
 }
 
+func TestCursorRejectsChangedPageBounds(t *testing.T) {
+	s := testSnapshot("v1", true, "p/a", "p/b")
+	page, err := s.Page("", 1, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Page(page.Next, 2, 1024); err == nil {
+		t.Fatal("cursor accepted a changed count bound")
+	}
+	if _, err := s.Page(page.Next, 1, 512); err == nil {
+		t.Fatal("cursor accepted a changed byte bound")
+	}
+}
+
 func TestPageReturnsBoundedEnvelopeAndProgressesOversizedOrEmptySnapshots(t *testing.T) {
 	s := testSnapshot("v1", false, strings.Repeat("x", 1000))
 	p, err := s.Page("", 1, 256)
@@ -211,5 +243,21 @@ func TestCursorRejectsAuthenticatedUnknownAndTrailingFields(t *testing.T) {
 }
 
 func testSnapshot(version string, complete bool, choices ...string) Snapshot {
-	return Snapshot{Version: version, Complete: complete, Choices: choices, key: []byte("test-key"), mu: &sync.Mutex{}}
+	return Snapshot{Version: version, Complete: complete, Choices: choices, key: []byte("test-key")}
 }
+
+type deadlineBarrierContext struct {
+	done chan struct{}
+}
+
+func (*deadlineBarrierContext) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (c *deadlineBarrierContext) Done() <-chan struct{}     { return c.done }
+func (c *deadlineBarrierContext) Err() error {
+	select {
+	case <-c.done:
+		return context.DeadlineExceeded
+	default:
+		return nil
+	}
+}
+func (*deadlineBarrierContext) Value(any) any { return nil }

--- a/agent/internal/modelavailability/modelavailability_test.go
+++ b/agent/internal/modelavailability/modelavailability_test.go
@@ -2,6 +2,10 @@ package modelavailability
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
 	"strings"
 	"sync"
 	"testing"
@@ -46,22 +50,72 @@ func TestRenderInlineRequiresCompleteCountAndUTF8ByteBounds(t *testing.T) {
 
 func TestCursorIsOpaqueSnapshotBoundAndPagesByBytesAndCount(t *testing.T) {
 	s := testSnapshot("v1", true, "p/a", "p/b", "p/c")
-	page, err := s.Page("", 2, len([]byte("p/a\np/b")))
+	page, err := s.Page("", 2, 1024)
 	if err != nil || len(page.Choices) != 2 || page.Next == "" {
 		t.Fatalf("page = %#v, %v", page, err)
 	}
 	if page.Next == "2" {
 		t.Fatalf("cursor exposed offset: %q", page.Next)
 	}
-	next, err := s.Page(page.Next, 2, 100)
+	next, err := s.Page(page.Next, 2, 1024)
 	if err != nil || len(next.Choices) != 1 || next.Choices[0] != "p/c" {
 		t.Fatalf("next = %#v, %v", next, err)
 	}
-	if _, err := s.Page(page.Next, 2, 100); err == nil {
-		t.Fatal("cursor unexpectedly reusable")
+	if _, err := s.Page(page.Next, 2, 1024); err != nil {
+		t.Fatalf("cursor should be idempotent: %v", err)
+	}
+}
+
+func TestPageReturnsBoundedEnvelopeAndProgressesOversizedOrEmptySnapshots(t *testing.T) {
+	s := testSnapshot("v1", false, strings.Repeat("x", 1000))
+	p, err := s.Page("", 1, 256)
+	if err != nil || !p.Terminal || len(p.Oversized) != 1 {
+		t.Fatalf("oversized page=%#v err=%v", p, err)
+	}
+	if got := p.SerializedBytes(); got > 1024 {
+		t.Fatalf("serialized bytes=%d", got)
+	}
+	empty := testSnapshot("v2", false)
+	p, err = empty.Page("", 1, 1024)
+	if err != nil || !p.Terminal || p.Status == nil {
+		t.Fatalf("empty page=%#v err=%v", p, err)
+	}
+}
+
+func TestCursorRejectsUnknownFieldsAndIsIdempotent(t *testing.T) {
+	s := testSnapshot("v1", true, "p/a", "p/b")
+	p, err := s.Page("", 1, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = s.Page(p.Next, 1, 1024); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = s.Page(p.Next, 1, 1024); err != nil {
+		t.Fatalf("retry not idempotent: %v", err)
+	}
+}
+
+func TestCursorRejectsAuthenticatedUnknownAndTrailingFields(t *testing.T) {
+	s := testSnapshot("v1", true, "p/a")
+	payload := []byte(`{"schema":"model-list-v1","binding":"root","snapshot":"v1","offset":0,"count":1,"bytes":1024,"extra":1}`)
+	mac := hmac.New(sha256.New, s.key)
+	_, _ = mac.Write(payload)
+	token := base64.RawURLEncoding.EncodeToString(append(payload, mac.Sum(nil)...))
+	if _, err := s.Page(token, 1, 1024); err == nil {
+		t.Fatal("authenticated unknown field accepted")
+	}
+	valid := cursor{"model-list-v1", "root", "v1", 0, 1, 1024}
+	b, _ := json.Marshal(valid)
+	b = append(b, []byte(` {}`)...)
+	mac = hmac.New(sha256.New, s.key)
+	_, _ = mac.Write(b)
+	token = base64.RawURLEncoding.EncodeToString(append(b, mac.Sum(nil)...))
+	if _, err := s.Page(token, 1, 1024); err == nil {
+		t.Fatal("authenticated trailing data accepted")
 	}
 }
 
 func testSnapshot(version string, complete bool, choices ...string) Snapshot {
-	return Snapshot{Version: version, Complete: complete, Choices: choices, key: []byte("test-key"), mu: &sync.Mutex{}, used: map[string]bool{}}
+	return Snapshot{Version: version, Complete: complete, Choices: choices, key: []byte("test-key"), mu: &sync.Mutex{}}
 }

--- a/agent/internal/modelavailability/modelavailability_test.go
+++ b/agent/internal/modelavailability/modelavailability_test.go
@@ -1,0 +1,67 @@
+package modelavailability
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/llm"
+)
+
+func TestCaptureUsesOneDeadlineAndKeepsSuccessfulPartialChoices(t *testing.T) {
+	started := make(chan struct{}, 2)
+	fetch := func(ctx context.Context, name string) ([]llm.ModelInfo, error) {
+		started <- struct{}{}
+		if name == "slow" {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		return []llm.ModelInfo{{ID: "z"}, {ID: "a"}, {ID: "a"}}, nil
+	}
+	s := Capture(context.Background(), []string{"slow", "good"}, fetch, 30*time.Millisecond)
+	if s.Complete || len(s.Choices) != 2 || s.Choices[0] != "good/a" || s.Choices[1] != "good/z" {
+		t.Fatalf("snapshot = %#v", s)
+	}
+	if s.Status["slow"].Kind != StatusTimeout || s.Status["good"].Kind != StatusSuccess {
+		t.Fatalf("status = %#v", s.Status)
+	}
+}
+
+func TestRenderInlineRequiresCompleteCountAndUTF8ByteBounds(t *testing.T) {
+	s := testSnapshot("v1", true, "p/α", "p/β")
+	if got, ok := s.Inline(2, len([]byte("Verified startup snapshot v1: p/α, p/β."))); !ok || !strings.Contains(got, "p/β") {
+		t.Fatalf("inline = %q, %v", got, ok)
+	}
+	if _, ok := s.Inline(2, len([]byte("Verified startup snapshot v1: p/α, p/β."))-1); ok {
+		t.Fatal("inline exceeded exact UTF-8 byte bound")
+	}
+	partial := s
+	partial.Complete = false
+	if _, ok := partial.Inline(10, 1000); ok {
+		t.Fatal("partial snapshot was inlined")
+	}
+}
+
+func TestCursorIsOpaqueSnapshotBoundAndPagesByBytesAndCount(t *testing.T) {
+	s := testSnapshot("v1", true, "p/a", "p/b", "p/c")
+	page, err := s.Page("", 2, len([]byte("p/a\np/b")))
+	if err != nil || len(page.Choices) != 2 || page.Next == "" {
+		t.Fatalf("page = %#v, %v", page, err)
+	}
+	if page.Next == "2" {
+		t.Fatalf("cursor exposed offset: %q", page.Next)
+	}
+	next, err := s.Page(page.Next, 2, 100)
+	if err != nil || len(next.Choices) != 1 || next.Choices[0] != "p/c" {
+		t.Fatalf("next = %#v, %v", next, err)
+	}
+	if _, err := s.Page(page.Next, 2, 100); err == nil {
+		t.Fatal("cursor unexpectedly reusable")
+	}
+}
+
+func testSnapshot(version string, complete bool, choices ...string) Snapshot {
+	return Snapshot{Version: version, Complete: complete, Choices: choices, key: []byte("test-key"), mu: &sync.Mutex{}, used: map[string]bool{}}
+}

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -110,6 +110,10 @@ type DelegateSandboxSchema struct {
 	RequireNonOffModeForNetwork bool
 	SandboxDescription          string
 	SandboxNetDescription       string
+	// ModelDescription is appended to the model override description when a
+	// caller has captured a bounded, startup-frozen availability snapshot.
+	// Empty preserves the generic string contract.
+	ModelDescription string
 }
 
 // DefDelegate defines the delegate tool, which starts a NEW delegate
@@ -228,6 +232,9 @@ func DefDelegateWithSandbox(agentTypes []string, sandboxSchema DelegateSandboxSc
 	}
 	if sandboxSchema.SandboxNetDescription != "" {
 		props["sandbox_net"].(map[string]any)["description"] = strings.TrimSpace(props["sandbox_net"].(map[string]any)["description"].(string) + " " + sandboxSchema.SandboxNetDescription)
+	}
+	if sandboxSchema.ModelDescription != "" {
+		props["model"].(map[string]any)["description"] = strings.TrimSpace(props["model"].(map[string]any)["description"].(string) + " " + sandboxSchema.ModelDescription)
 	}
 	return def
 }

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -262,6 +262,24 @@ func DefDelegateSend() llm.ToolDefinition {
 	}
 }
 
+// DefModelList exposes a bounded read-only view of a startup-frozen model
+// snapshot. Cursor values are opaque and snapshot-authenticated by the agent.
+func DefModelList() llm.ToolDefinition {
+	return llm.ToolDefinition{
+		Name:        "model_list",
+		Description: "List choices from the startup-frozen model availability snapshot. This is read-only; use the opaque cursor returned for the next page. Pages are bounded by both max_count and max_bytes and are never truncated.",
+		Parameters: map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]any{
+				"cursor":    map[string]any{"type": "string", "description": "Opaque snapshot-bound continuation cursor; omit for the first page."},
+				"max_count": map[string]any{"type": "integer", "minimum": 1, "maximum": 128},
+				"max_bytes": map[string]any{"type": "integer", "minimum": 1, "maximum": 4096},
+			},
+		},
+	}
+}
+
 // DefJobWatch defines the job_watch tool, available to any session that can
 // run jobs; cross-session sources authorize themselves. eventKinds are the
 // model-facing session/job event-kind names available this session; they are

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -203,6 +203,9 @@ func DefDelegateWithSandbox(agentTypes []string, sandboxSchema DelegateSandboxSc
 		},
 	}
 	props := def.Parameters["properties"].(map[string]any)
+	if sandboxSchema.ModelDescription != "" {
+		props["model"].(map[string]any)["description"] = strings.TrimSpace(props["model"].(map[string]any)["description"].(string) + " " + sandboxSchema.ModelDescription)
+	}
 	if !sandboxSchema.Available {
 		delete(props, "sandbox")
 		delete(props, "sandbox_net")
@@ -245,9 +248,6 @@ func DefDelegateWithSandbox(agentTypes []string, sandboxSchema DelegateSandboxSc
 	}
 	if sandboxSchema.SandboxNetDescription != "" {
 		props["sandbox_net"].(map[string]any)["description"] = strings.TrimSpace(props["sandbox_net"].(map[string]any)["description"].(string) + " " + sandboxSchema.SandboxNetDescription)
-	}
-	if sandboxSchema.ModelDescription != "" {
-		props["model"].(map[string]any)["description"] = strings.TrimSpace(props["model"].(map[string]any)["description"].(string) + " " + sandboxSchema.ModelDescription)
 	}
 	return def
 }

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -116,6 +116,19 @@ type DelegateSandboxSchema struct {
 	ModelDescription string
 }
 
+const delegateModelOverrideDescription = "Model override. Default: the delegate captures your CURRENT model at the moment it is spawned (so a delegate spawned after you switch models inherits the new one, and one spawned before keeps the model it started with). An explicit value here pins the delegate to that model instead, regardless of your current or future model."
+
+// DelegateModelDescriptionAdditionBudget reports how many bytes may be
+// appended to the model parameter's fixed description without exceeding the
+// caller's total schema-description budget.
+func DelegateModelDescriptionAdditionBudget(maxBytes int) int {
+	budget := maxBytes - len([]byte(delegateModelOverrideDescription)) - 1
+	if budget < 0 {
+		return 0
+	}
+	return budget
+}
+
 // DefDelegate defines the delegate tool, which starts a NEW delegate
 // conversation (independent agentic work) and returns its durable stable identity.
 // agentTypes constrains the agent_type enum to the session's
@@ -162,7 +175,7 @@ func DefDelegateWithSandbox(agentTypes []string, sandboxSchema DelegateSandboxSc
 			"properties": map[string]any{
 				"task":                 map[string]any{"type": "string"},
 				"agent_type":           agentTypeSchema,
-				"model":                map[string]any{"type": "string", "description": "Model override. Default: the delegate captures your CURRENT model at the moment it is spawned (so a delegate spawned after you switch models inherits the new one, and one spawned before keeps the model it started with). An explicit value here pins the delegate to that model instead, regardless of your current or future model."},
+				"model":                map[string]any{"type": "string", "description": delegateModelOverrideDescription},
 				"reasoning_effort":     map[string]any{"type": "string", "description": "Reasoning effort for this delegate (low, medium, or high). Default inherits from parent.", "enum": []string{"low", "medium", "high"}},
 				"delegation_allowance": map[string]any{"type": "integer", "description": "0 (default): a leaf delegate that cannot itself delegate. >0: the delegate may delegate, granting onward allowances strictly smaller than this; must be strictly less than your own allowance. The allowance only takes effect if the chosen agent_type actually has the `delegate` tool: the built-in `subagent` role is a non-delegating leaf, so a >0 allowance on it is a silent no-op. For a multi-level tree, omit agent_type (the default role can delegate)."},
 				"watch_parent":         map[string]any{"type": "boolean", "description": "Grant this child permission to observe your session with job_watch(source=\"parent\"). This does not grant delegation or any transitive watch permission."},

--- a/agent/internal/tool/definitions_test.go
+++ b/agent/internal/tool/definitions_test.go
@@ -834,6 +834,17 @@ func TestDefDelegateWithSandboxIncludesVerifiedModelChoices(t *testing.T) {
 	}
 }
 
+func TestDefDelegateWithoutSandboxIncludesVerifiedModelChoices(t *testing.T) {
+	def := DefDelegateWithSandbox(nil, DelegateSandboxSchema{
+		ModelDescription: "Verified at startup (snapshot v1): openai/gpt-5.",
+	})
+	props := def.Parameters["properties"].(map[string]any)
+	model := props["model"].(map[string]any)
+	if got := model["description"].(string); !strings.Contains(got, "openai/gpt-5") {
+		t.Fatalf("model description = %q", got)
+	}
+}
+
 func TestDefModelListIsBoundedReadOnlyContract(t *testing.T) {
 	def := DefModelList()
 	if def.Name != "model_list" || def.Parameters["additionalProperties"] != false {

--- a/agent/internal/tool/definitions_test.go
+++ b/agent/internal/tool/definitions_test.go
@@ -820,3 +820,16 @@ func TestDefAskUserDescriptionIsSpecVerbatim(t *testing.T) {
 		}
 	}
 }
+
+func TestDefDelegateWithSandboxIncludesVerifiedModelChoices(t *testing.T) {
+	def := DefDelegateWithSandbox(nil, DelegateSandboxSchema{
+		Available:        true,
+		Modes:            []string{"off"},
+		ModelDescription: "Verified at startup (snapshot v1): openai/gpt-5, vertex/gemini-2.5.",
+	})
+	props := def.Parameters["properties"].(map[string]any)
+	model := props["model"].(map[string]any)
+	if got := model["description"].(string); !strings.Contains(got, "openai/gpt-5") {
+		t.Fatalf("model description = %q", got)
+	}
+}

--- a/agent/internal/tool/definitions_test.go
+++ b/agent/internal/tool/definitions_test.go
@@ -833,3 +833,10 @@ func TestDefDelegateWithSandboxIncludesVerifiedModelChoices(t *testing.T) {
 		t.Fatalf("model description = %q", got)
 	}
 }
+
+func TestDefModelListIsBoundedReadOnlyContract(t *testing.T) {
+	def := DefModelList()
+	if def.Name != "model_list" || def.Parameters["additionalProperties"] != false {
+		t.Fatalf("definition = %#v", def)
+	}
+}

--- a/agent/internal/tool/registry.go
+++ b/agent/internal/tool/registry.go
@@ -609,7 +609,9 @@ func (r *Registry) ExecuteCall(ctx context.Context, env execenv.ExecutionEnviron
 	// release the next identical call. Only failures park — a repeated
 	// identical *success* may still be the call that finally sees the world
 	// change, and refusing it would strand a session repeating its result tool.
-	judged := !breakerBypassed(ctx)
+	// model_list is an exact JSON continuation protocol. Repeating a page is a
+	// valid retry, and appending breaker text would corrupt its bounded envelope.
+	judged := !breakerBypassed(ctx) && name != "model_list"
 	if judged {
 		if failStreak, _, snippets := r.breaker.check(name, call.Arguments); failStreak >= breakerThreshold {
 			return truncateResult(name, callID, failureParkText(name, snippets), true, defaultToolLimit(name))

--- a/agent/live_model_metadata.go
+++ b/agent/live_model_metadata.go
@@ -69,11 +69,10 @@ func fillLiveModelMetadata(ctx context.Context, client *llm.Client, profile *pro
 // prior unvalidated behavior in that case.
 func resolveLiveModelProfileValidated(client *llm.Client, profile *provider.Profile) (*provider.Profile, liveModelEnumeration, error) {
 	filled, enumeration := resolveLiveModelProfileWithEnumerationTimeout(client, profile)
-	if enumeration.err != nil {
-		return filled, enumeration, nil
-	}
-	if err := validateModelSwitchMembership(client, filled, enumeration.models); err != nil {
-		return filled, enumeration, err
+	if enumeration.err == nil {
+		if err := validateModelSwitchMembership(client, filled, enumeration.models); err != nil {
+			return filled, enumeration, err
+		}
 	}
 	return filled, enumeration, nil
 }

--- a/agent/live_model_metadata.go
+++ b/agent/live_model_metadata.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -10,6 +11,11 @@ import (
 )
 
 const liveModelMetadataTimeout = 2 * time.Second
+
+type liveModelEnumeration struct {
+	models []llm.ModelInfo
+	err    error
+}
 
 func resolveLiveModelProfileWithTimeout(client *llm.Client, profile *provider.Profile) *provider.Profile {
 	ctx, cancel := context.WithTimeout(context.Background(), liveModelMetadataTimeout)
@@ -24,7 +30,7 @@ func resolveLiveModelProfileWithTimeout(client *llm.Client, profile *provider.Pr
 // enumerated list or the fetch's success flag; resolveLiveModelProfileValidated
 // is the membership-checking counterpart used by NewSession.
 func resolveLiveModelProfile(ctx context.Context, client *llm.Client, profile *provider.Profile) *provider.Profile {
-	filled, _, _ := fillLiveModelMetadata(ctx, client, profile)
+	filled, _ := fillLiveModelMetadata(ctx, client, profile)
 	return filled
 }
 
@@ -32,24 +38,25 @@ func resolveLiveModelProfile(ctx context.Context, client *llm.Client, profile *p
 // resolveLiveModelProfile, resolveLiveModelProfileValidated, and
 // resolveModelSwitchTarget: it fetches profile's provider instance's live
 // model list ONCE, fills live metadata onto profile when the requested model
-// is found, and returns the fetched list plus whether enumeration succeeded so
-// a caller can additionally run a membership check against the same list
-// without a second ListModels call (avoiding both the extra network latency
+// is found, and returns the fetched list or enumeration error so a caller can
+// additionally run a membership check against the same list or preserve the
+// failure in a startup snapshot without a second ListModels call (avoiding
+// both the extra network latency
 // and a TOCTOU window where the provider's list could change between two
-// calls). Fails open on a nil client/profile or any ListModels error: ok is
-// false, profile is returned unchanged, and models is nil.
-func fillLiveModelMetadata(ctx context.Context, client *llm.Client, profile *provider.Profile) (*provider.Profile, []llm.ModelInfo, bool) {
+// calls). The profile is returned unchanged on nil inputs or any ListModels
+// error; callers choose their own fail-open policy.
+func fillLiveModelMetadata(ctx context.Context, client *llm.Client, profile *provider.Profile) (*provider.Profile, liveModelEnumeration) {
 	if client == nil || profile == nil {
-		return profile, nil, false
+		return profile, liveModelEnumeration{err: errors.New("live model metadata inputs are nil")}
 	}
 	models, err := client.ListModels(ctx, profile.ID())
 	if err != nil {
-		return profile, nil, false
+		return profile, liveModelEnumeration{err: err}
 	}
 	if info, ok := liveModelInfoFor(models, profile.Model()); ok {
 		profile = profile.WithLiveModelInfo(info)
 	}
-	return profile, models, true
+	return profile, liveModelEnumeration{models: models}
 }
 
 // resolveLiveModelProfileValidated is NewSession's live-model seam: it fills
@@ -60,17 +67,17 @@ func fillLiveModelMetadata(ctx context.Context, client *llm.Client, profile *pro
 // list definitively doesn't carry. Fails open (nil error, profile unchanged
 // modulo any metadata fill) on any enumeration failure, matching NewSession's
 // prior unvalidated behavior in that case.
-func resolveLiveModelProfileValidated(client *llm.Client, profile *provider.Profile) (*provider.Profile, error) {
+func resolveLiveModelProfileValidated(client *llm.Client, profile *provider.Profile) (*provider.Profile, liveModelEnumeration, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), liveModelMetadataTimeout)
 	defer cancel()
-	filled, models, ok := fillLiveModelMetadata(ctx, client, profile)
-	if !ok {
-		return filled, nil
+	filled, enumeration := fillLiveModelMetadata(ctx, client, profile)
+	if enumeration.err != nil {
+		return filled, enumeration, nil
 	}
-	if err := validateModelSwitchMembership(client, filled, models); err != nil {
-		return filled, err
+	if err := validateModelSwitchMembership(client, filled, enumeration.models); err != nil {
+		return filled, enumeration, err
 	}
-	return filled, nil
+	return filled, enumeration, nil
 }
 
 func liveModelInfoFor(models []llm.ModelInfo, model string) (llm.ModelInfo, bool) {

--- a/agent/live_model_metadata.go
+++ b/agent/live_model_metadata.go
@@ -17,18 +17,18 @@ type liveModelEnumeration struct {
 	err    error
 }
 
-func resolveLiveModelProfileWithTimeout(client *llm.Client, profile *provider.Profile) *provider.Profile {
+func resolveLiveModelProfileWithEnumerationTimeout(client *llm.Client, profile *provider.Profile) (*provider.Profile, liveModelEnumeration) {
 	ctx, cancel := context.WithTimeout(context.Background(), liveModelMetadataTimeout)
 	defer cancel()
-	return resolveLiveModelProfile(ctx, client, profile)
+	return fillLiveModelMetadata(ctx, client, profile)
 }
 
 // resolveLiveModelProfile fills profile's live model metadata (context window,
 // reasoning support, etc.) from client's live model list when available.
 // Fails open (returns profile unchanged) on a nil client/profile or any
-// enumeration error — used by Restore and by tests that don't need the
-// enumerated list or the fetch's success flag; resolveLiveModelProfileValidated
-// is the membership-checking counterpart used by NewSession.
+// enumeration error — used by callers that don't need the enumerated list or
+// fetch result; resolveLiveModelProfileValidated is the membership-checking
+// counterpart used by NewSession.
 func resolveLiveModelProfile(ctx context.Context, client *llm.Client, profile *provider.Profile) *provider.Profile {
 	filled, _ := fillLiveModelMetadata(ctx, client, profile)
 	return filled
@@ -68,9 +68,7 @@ func fillLiveModelMetadata(ctx context.Context, client *llm.Client, profile *pro
 // modulo any metadata fill) on any enumeration failure, matching NewSession's
 // prior unvalidated behavior in that case.
 func resolveLiveModelProfileValidated(client *llm.Client, profile *provider.Profile) (*provider.Profile, liveModelEnumeration, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), liveModelMetadataTimeout)
-	defer cancel()
-	filled, enumeration := fillLiveModelMetadata(ctx, client, profile)
+	filled, enumeration := resolveLiveModelProfileWithEnumerationTimeout(client, profile)
 	if enumeration.err != nil {
 		return filled, enumeration, nil
 	}

--- a/agent/session.go
+++ b/agent/session.go
@@ -64,18 +64,19 @@ func (s *Session) nextJobTreeRevision(kind events.EventKind) (string, uint64, bo
 // history, registered tools, context-management state, subagents, plugins, MCP
 // connections, and persistence settings.
 type Session struct {
-	id                     string
-	cfg                    SessionConfig
-	delegateController     *delegateTreeController
-	delegateRootSessionID  string
-	owningDelegateID       string
-	ownsDelegateController bool
-	artifactStore          artifactStore
-	ownsArtifactStore      bool
-	client                 *llm.Client
-	cheap                  *cheapmodel.Caller
-	profile                *provider.Profile
-	resolveProfile         func(ref string) (*provider.Profile, error) // cross-provider resolver; may be nil
+	id                       string
+	cfg                      SessionConfig
+	delegateController       *delegateTreeController
+	delegateRootSessionID    string
+	owningDelegateID         string
+	ownsDelegateController   bool
+	artifactStore            artifactStore
+	ownsArtifactStore        bool
+	client                   *llm.Client
+	cheap                    *cheapmodel.Caller
+	profile                  *provider.Profile
+	resolveProfile           func(ref string) (*provider.Profile, error) // cross-provider resolver; may be nil
+	delegateModelDescription string
 	// lastDroppedModelFallbacks records the cfg.ModelFallbacks entries dropped
 	// by the most recent SetModel's post-switch revalidation (entries that no
 	// longer validate against the new profile). Nil until a switch drops any.

--- a/agent/session.go
+++ b/agent/session.go
@@ -20,6 +20,7 @@ import (
 	"primeradiant.com/evener/agent/internal/hooks"
 	"primeradiant.com/evener/agent/internal/installid"
 	"primeradiant.com/evener/agent/internal/mcp"
+	"primeradiant.com/evener/agent/internal/modelavailability"
 	"primeradiant.com/evener/agent/internal/tool"
 	"primeradiant.com/evener/agent/mcpconfig"
 	"primeradiant.com/evener/agent/plugin"
@@ -77,6 +78,7 @@ type Session struct {
 	profile                  *provider.Profile
 	resolveProfile           func(ref string) (*provider.Profile, error) // cross-provider resolver; may be nil
 	delegateModelDescription string
+	modelSnapshot            *modelavailability.Snapshot
 	// lastDroppedModelFallbacks records the cfg.ModelFallbacks entries dropped
 	// by the most recent SetModel's post-switch revalidation (entries that no
 	// longer validate against the new profile). Nil until a switch drops any.

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -1232,6 +1232,7 @@ func (s *Session) initSessionState(sessionStartKind plugin.SessionStartKind, run
 	reg.OverrideLimits(s.cfg.ToolOutputLimits)
 	enforceShellToolJSONLimit(reg)
 	enforceJobToolJSONLimits(reg)
+	enforceModelListJSONLimits(reg)
 	s.reg = reg
 
 	s.coreToolNames = reg.RegisteredNames()

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -281,6 +281,7 @@ func NewSession(client *llm.Client, profile *provider.Profile, env execenv.Execu
 		snapshot := modelavailability.Capture(context.Background(), names, func(ctx context.Context, name string) ([]llm.ModelInfo, error) {
 			return client.ListModels(ctx, name)
 		}, 2*time.Second)
+		s.modelSnapshot = &snapshot
 		if text, ok := snapshot.Inline(modelavailability.DefaultInlineMaxCount, modelavailability.DefaultInlineMaxBytes); ok {
 			s.delegateModelDescription = text
 		} else if len(snapshot.Choices) > 0 {

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -26,6 +26,7 @@ import (
 	"primeradiant.com/evener/agent/internal/hooks"
 	"primeradiant.com/evener/agent/internal/installid"
 	"primeradiant.com/evener/agent/internal/mcp"
+	"primeradiant.com/evener/agent/internal/modelavailability"
 	"primeradiant.com/evener/agent/internal/sessionlog"
 	"primeradiant.com/evener/agent/internal/tool"
 	"primeradiant.com/evener/agent/mcpconfig"
@@ -272,6 +273,21 @@ func NewSession(client *llm.Client, profile *provider.Profile, env execenv.Execu
 		artifactStore:                 store,
 		ownsArtifactStore:             ownsArtifactStore,
 		subscriberCountFn:             cfg.spawn.subscriberCount,
+	}
+	// Capture model availability once, before tool schemas are projected. The
+	// snapshot is startup-bound and never refreshed silently; failed providers
+	// remain visible as unverified rather than being mistaken for empty lists.
+	if names := client.ProviderNames(); len(names) > 0 {
+		snapshot := modelavailability.Capture(context.Background(), names, func(ctx context.Context, name string) ([]llm.ModelInfo, error) {
+			return client.ListModels(ctx, name)
+		}, 2*time.Second)
+		if text, ok := snapshot.Inline(modelavailability.DefaultInlineMaxCount, modelavailability.DefaultInlineMaxBytes); ok {
+			s.delegateModelDescription = text
+		} else if len(snapshot.Choices) > 0 {
+			s.delegateModelDescription = fmt.Sprintf("Startup model snapshot %s is incomplete or too large; use the model-list read tool to browse verified choices.", snapshot.Version)
+		} else {
+			s.delegateModelDescription = fmt.Sprintf("Startup model snapshot %s has no verified choices; provider availability is unverified.", snapshot.Version)
+		}
 	}
 	s.createdAt = s.sclock().Now().UTC()
 	s.initEnvContext(nil)

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -473,7 +473,7 @@ func inlineModelSnapshot(snapshot modelavailability.Snapshot) (string, bool) {
 // model selection before tool schemas are projected. Leaf sessions cannot
 // delegate, so they do not enumerate providers or register the browsing tool.
 func (s *Session) captureModelAvailability(selectedModels liveModelEnumeration) {
-	if s.delegationAllowance <= 0 {
+	if !s.hasConfiguredDelegateCapability() {
 		return
 	}
 	names := s.client.ProviderNames()
@@ -497,6 +497,23 @@ func (s *Session) captureModelAvailability(selectedModels liveModelEnumeration) 
 	} else {
 		s.delegateModelDescription = fmt.Sprintf("Startup model snapshot %s has no verified choices; provider availability is unverified.", snapshot.Version)
 	}
+}
+
+// hasConfiguredDelegateCapability applies the construction-time policy axes
+// that can remove delegate after core-tool registration. Capture runs before
+// that registration so its snapshot can shape the delegate schema, but a
+// session whose final policy excludes delegate must not enumerate providers.
+func (s *Session) hasConfiguredDelegateCapability() bool {
+	if s.delegationAllowance <= 0 || s.cfg.testOnly.minimalWorktreeToolRegistry {
+		return false
+	}
+	if len(s.cfg.spawn.allowedToolNames) > 0 && !hasString(s.cfg.spawn.allowedToolNames, "delegate") {
+		return false
+	}
+	if hasString(s.cfg.spawn.deniedToolNames, "delegate") {
+		return false
+	}
+	return len(s.cfg.spawn.toolNameCeiling) == 0 || hasString(s.cfg.spawn.toolNameCeiling, "delegate")
 }
 
 // RestoreSessionConfig carries runtime-only settings needed when restoring a

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -165,7 +165,7 @@ func NewSession(client *llm.Client, profile *provider.Profile, env execenv.Execu
 	if err := llm.ValidateReasoningEffort(cfg.ReasoningEffort); err != nil {
 		return nil, err
 	}
-	resolvedProfile, err := resolveLiveModelProfileValidated(client, profile)
+	resolvedProfile, selectedModels, err := resolveLiveModelProfileValidated(client, profile)
 	if err != nil {
 		return nil, err
 	}
@@ -278,11 +278,14 @@ func NewSession(client *llm.Client, profile *provider.Profile, env execenv.Execu
 	// snapshot is startup-bound and never refreshed silently; failed providers
 	// remain visible as unverified rather than being mistaken for empty lists.
 	if names := client.ProviderNames(); len(names) > 0 {
-		snapshot := modelavailability.Capture(context.Background(), names, func(ctx context.Context, name string) ([]llm.ModelInfo, error) {
+		snapshot := modelavailability.Capture(s.sessionCtx, names, func(ctx context.Context, name string) ([]llm.ModelInfo, error) {
+			if name == profile.ID() {
+				return append([]llm.ModelInfo(nil), selectedModels.models...), selectedModels.err
+			}
 			return client.ListModels(ctx, name)
 		}, 2*time.Second)
 		s.modelSnapshot = &snapshot
-		if text, ok := snapshot.Inline(modelavailability.DefaultInlineMaxCount, modelavailability.DefaultInlineMaxBytes); ok {
+		if text, ok := inlineModelSnapshot(snapshot); ok {
 			s.delegateModelDescription = text
 		} else if len(snapshot.Choices) > 0 {
 			s.delegateModelDescription = fmt.Sprintf("Startup model snapshot %s is incomplete or too large; use the model-list read tool to browse verified choices.", snapshot.Version)
@@ -475,6 +478,13 @@ func NewSession(client *llm.Client, profile *provider.Profile, env execenv.Execu
 	closeMCPManagerOnError = false
 	closeDelegateStoreOnError = false
 	return s, nil
+}
+
+func inlineModelSnapshot(snapshot modelavailability.Snapshot) (string, bool) {
+	return snapshot.Inline(
+		modelavailability.DefaultInlineMaxCount,
+		tool.DelegateModelDescriptionAdditionBudget(modelavailability.DefaultInlineMaxBytes),
+	)
 }
 
 // RestoreSessionConfig carries runtime-only settings needed when restoring a

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -274,25 +274,7 @@ func NewSession(client *llm.Client, profile *provider.Profile, env execenv.Execu
 		ownsArtifactStore:             ownsArtifactStore,
 		subscriberCountFn:             cfg.spawn.subscriberCount,
 	}
-	// Capture model availability once, before tool schemas are projected. The
-	// snapshot is startup-bound and never refreshed silently; failed providers
-	// remain visible as unverified rather than being mistaken for empty lists.
-	if names := client.ProviderNames(); len(names) > 0 {
-		snapshot := modelavailability.Capture(s.sessionCtx, names, func(ctx context.Context, name string) ([]llm.ModelInfo, error) {
-			if name == profile.ID() {
-				return append([]llm.ModelInfo(nil), selectedModels.models...), selectedModels.err
-			}
-			return client.ListModels(ctx, name)
-		}, 2*time.Second)
-		s.modelSnapshot = &snapshot
-		if text, ok := inlineModelSnapshot(snapshot); ok {
-			s.delegateModelDescription = text
-		} else if len(snapshot.Choices) > 0 {
-			s.delegateModelDescription = fmt.Sprintf("Startup model snapshot %s is incomplete or too large; use the model-list read tool to browse verified choices.", snapshot.Version)
-		} else {
-			s.delegateModelDescription = fmt.Sprintf("Startup model snapshot %s has no verified choices; provider availability is unverified.", snapshot.Version)
-		}
-	}
+	s.captureModelAvailability(selectedModels)
 	s.createdAt = s.sclock().Now().UTC()
 	s.initEnvContext(nil)
 	if err := s.bootstrapDelegateResources(); err != nil {
@@ -485,6 +467,33 @@ func inlineModelSnapshot(snapshot modelavailability.Snapshot) (string, bool) {
 		modelavailability.DefaultInlineMaxCount,
 		tool.DelegateModelDescriptionAdditionBudget(modelavailability.DefaultInlineMaxBytes),
 	)
+}
+
+// captureModelAvailability records the startup-bound catalog used by delegate
+// model selection before tool schemas are projected. Leaf sessions cannot
+// delegate, so they do not enumerate providers or register the browsing tool.
+func (s *Session) captureModelAvailability(selectedModels liveModelEnumeration) {
+	if s.delegationAllowance <= 0 {
+		return
+	}
+	names := s.client.ProviderNames()
+	if len(names) == 0 {
+		return
+	}
+	snapshot := modelavailability.Capture(s.sessionCtx, names, func(ctx context.Context, name string) ([]llm.ModelInfo, error) {
+		if name == s.profile.ID() {
+			return append([]llm.ModelInfo(nil), selectedModels.models...), selectedModels.err
+		}
+		return s.client.ListModels(ctx, name)
+	}, liveModelMetadataTimeout)
+	s.modelSnapshot = &snapshot
+	if text, ok := inlineModelSnapshot(snapshot); ok {
+		s.delegateModelDescription = text
+	} else if len(snapshot.Choices) > 0 {
+		s.delegateModelDescription = fmt.Sprintf("Startup model snapshot %s is incomplete or too large; use the model-list read tool to browse verified choices.", snapshot.Version)
+	} else {
+		s.delegateModelDescription = fmt.Sprintf("Startup model snapshot %s has no verified choices; provider availability is unverified.", snapshot.Version)
+	}
 }
 
 // RestoreSessionConfig carries runtime-only settings needed when restoring a
@@ -789,8 +798,9 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 	// Delegate reconciliation is durable, local startup work. Complete it before
 	// any provider metadata access so caller-delivery crash replay cannot depend
 	// on provider availability or latency.
-	profile = resolveLiveModelProfileWithTimeout(client, profile)
+	profile, selectedModels := resolveLiveModelProfileWithEnumerationTimeout(client, profile)
 	s.profile = profile
+	s.captureModelAvailability(selectedModels)
 	closeDelegateStoreOnError := true
 	defer func() {
 		if closeDelegateStoreOnError {

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -481,7 +481,7 @@ func (s *Session) captureModelAvailability(selectedModels liveModelEnumeration) 
 		return
 	}
 	catalog := llm.EmbeddedModelCatalog()
-	snapshot := modelavailability.Capture(s.sessionCtx, names, func(ctx context.Context, name string) ([]llm.ModelInfo, error) {
+	snapshot := modelavailability.Capture(s.sessionCtx, names, s.profile.ID(), func(ctx context.Context, name string) ([]llm.ModelInfo, error) {
 		if name == s.profile.ID() {
 			return append([]llm.ModelInfo(nil), selectedModels.models...), selectedModels.err
 		}

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -480,11 +480,14 @@ func (s *Session) captureModelAvailability(selectedModels liveModelEnumeration) 
 	if len(names) == 0 {
 		return
 	}
+	catalog := llm.EmbeddedModelCatalog()
 	snapshot := modelavailability.Capture(s.sessionCtx, names, func(ctx context.Context, name string) ([]llm.ModelInfo, error) {
 		if name == s.profile.ID() {
 			return append([]llm.ModelInfo(nil), selectedModels.models...), selectedModels.err
 		}
 		return s.client.ListModels(ctx, name)
+	}, func(name string, model llm.ModelInfo) bool {
+		return modelSwitchVisible(s.client.BehaviorTagOf(name), model, catalog)
 	}, liveModelMetadataTimeout)
 	s.modelSnapshot = &snapshot
 	if text, ok := inlineModelSnapshot(snapshot); ok {

--- a/agent/session_model_availability_test.go
+++ b/agent/session_model_availability_test.go
@@ -14,6 +14,7 @@ import (
 
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/internal/modelavailability"
+	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
 )
@@ -318,6 +319,38 @@ func TestNewSessionSnapshotUsesSharedModelVisibility(t *testing.T) {
 	want := []string{"openai/gpt-5.5", "router/tool-model"}
 	if sess.modelSnapshot == nil || !slices.Equal(sess.modelSnapshot.Choices, want) {
 		t.Fatalf("visible startup choices = %#v, want %q", sess.modelSnapshot, want)
+	}
+}
+
+func TestNewSessionBoundedSnapshotRetainsSelectedProvider(t *testing.T) {
+	const selectedName = "zz-selected-provider"
+	selected := &modelAvailabilityAdapter{models: []llm.ModelInfo{{ID: "gpt-5.5"}}}
+	selected.name = selectedName
+	client := llm.NewClient()
+	client.Register(selected)
+	nameToTag := map[string]string{selectedName: "openai"}
+	for i := 0; i < 16; i++ {
+		name := fmt.Sprintf("provider-%02d", i)
+		adapter := &modelAvailabilityAdapter{models: []llm.ModelInfo{{ID: "model"}}}
+		adapter.name = name
+		client.Register(adapter)
+		nameToTag[name] = "openai"
+	}
+	client.SetNameToTag(nameToTag)
+	profile := provider.WithProviderID(NewOpenAIProfile("gpt-5.5"), selectedName)
+
+	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+
+	want := selectedName + "/gpt-5.5"
+	if sess.modelSnapshot == nil || !slices.Contains(sess.modelSnapshot.Choices, want) {
+		t.Fatalf("bounded snapshot omitted selected provider choice %q: %#v", want, sess.modelSnapshot)
+	}
+	if sess.modelSnapshot.Complete {
+		t.Fatal("provider-bounded snapshot claimed to be complete")
 	}
 }
 

--- a/agent/session_model_availability_test.go
+++ b/agent/session_model_availability_test.go
@@ -405,6 +405,34 @@ func TestModelListToolReturnsEveryChoiceExactlyOnceWithinPageBound(t *testing.T)
 	}
 }
 
+func TestModelListToolPreservesJSONUnderConfiguredOutputLimit(t *testing.T) {
+	models := make([]llm.ModelInfo, modelavailability.DefaultInlineMaxCount)
+	for i := range models {
+		models[i].ID = fmt.Sprintf("model-%02d-%s", i, strings.Repeat("x", 12))
+	}
+	adapter := &modelAvailabilityAdapter{models: models}
+	adapter.name = "openai"
+	client := llm.NewClient()
+	client.Register(adapter)
+	sess, err := NewSession(
+		client,
+		NewOpenAIProfile(models[0].ID),
+		execenv.NewLocalExecutionEnvironment(t.TempDir()),
+		SessionConfig{ToolOutputLimits: map[string]schema.ToolOutputLimit{
+			"model_list": {MaxChars: 64, MaxLines: 1, Strategy: schema.TruncTail},
+		}},
+	)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+
+	page := executeModelListPage(t, sess, "", modelavailability.DefaultPageMaxCount, 512)
+	if len(page.Choices) == 0 {
+		t.Fatal("model_list returned no choices")
+	}
+}
+
 func TestModelListToolReturnsBoundedEmptyTerminalPage(t *testing.T) {
 	adapter := &modelAvailabilityAdapter{listErr: errors.New("enumeration unavailable")}
 	adapter.name = "openai"
@@ -439,6 +467,9 @@ func executeModelListPage(t *testing.T, sess *Session, cursor string, maxCount, 
 	})
 	if result.IsError {
 		t.Fatalf("model_list: %s", result.Output)
+	}
+	if result.Truncated {
+		t.Fatal("model_list output was generically truncated")
 	}
 	if len([]byte(result.Output)) > maxBytes {
 		t.Fatalf("public model_list output = %d bytes, exceeds %d", len([]byte(result.Output)), maxBytes)

--- a/agent/session_model_availability_test.go
+++ b/agent/session_model_availability_test.go
@@ -14,12 +14,16 @@ import (
 
 type modelAvailabilityAdapter struct {
 	fakeAdapter
-	models []llm.ModelInfo
-	calls  atomic.Int32
+	models  []llm.ModelInfo
+	calls   atomic.Int32
+	observe func(context.Context)
 }
 
-func (a *modelAvailabilityAdapter) ListModels(context.Context) ([]llm.ModelInfo, error) {
+func (a *modelAvailabilityAdapter) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
 	a.calls.Add(1)
+	if a.observe != nil {
+		a.observe(ctx)
+	}
 	return append([]llm.ModelInfo(nil), a.models...), nil
 }
 
@@ -49,5 +53,35 @@ func TestNewSessionReusesValidatedModelsAndBoundsDelegateSchema(t *testing.T) {
 	}
 	if !sess.reg.RegisteredNames()["model_list"] {
 		t.Fatal("model_list is not registered when the verified choices do not fit in the bounded schema description")
+	}
+}
+
+func TestNewSessionEnumeratesOtherProvidersUnderLifetimeContext(t *testing.T) {
+	type ownerContextKey struct{}
+	const ownerMarker = "one-shot-run"
+
+	selected := &modelAvailabilityAdapter{models: []llm.ModelInfo{{ID: "gpt-5.5"}}}
+	selected.name = "openai"
+	var inheritedOwner atomic.Bool
+	other := &modelAvailabilityAdapter{
+		models: []llm.ModelInfo{{ID: "claude-opus-4-6"}},
+		observe: func(ctx context.Context) {
+			inheritedOwner.Store(ctx.Value(ownerContextKey{}) == ownerMarker)
+		},
+	}
+	other.name = "anthropic"
+	client := llm.NewClient()
+	client.Register(selected)
+	client.Register(other)
+	owner := context.WithValue(context.Background(), ownerContextKey{}, ownerMarker)
+
+	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.5"), execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{LifetimeContext: owner})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+
+	if !inheritedOwner.Load() {
+		t.Fatal("other-provider model enumeration did not inherit the session lifetime context")
 	}
 }

--- a/agent/session_model_availability_test.go
+++ b/agent/session_model_availability_test.go
@@ -162,7 +162,7 @@ func TestRestoreSessionReusesSelectedModelsAndAdvertisesSnapshot(t *testing.T) {
 	}
 }
 
-func TestLeafSessionsSkipModelAvailabilityCapture(t *testing.T) {
+func TestSessionsWithoutDelegateCapabilitySkipModelAvailabilityCapture(t *testing.T) {
 	newClient := func() (*llm.Client, *modelAvailabilityAdapter, *modelAvailabilityAdapter) {
 		selected := &modelAvailabilityAdapter{models: []llm.ModelInfo{{ID: "gpt-5.5"}}}
 		selected.name = "openai"
@@ -227,6 +227,57 @@ func TestLeafSessionsSkipModelAvailabilityCapture(t *testing.T) {
 		restoreCfg.spawn.depth = 1
 		restoreCfg.spawn.parentSessionID = "parent-session"
 		restoreCfg.spawn.delegationAllowance = 0
+		sess, err := RestoreSessionFromMetaWithConfig(
+			client,
+			NewOpenAIProfile("gpt-5.5"),
+			execenv.NewLocalExecutionEnvironment(t.TempDir()),
+			meta,
+			restoreCfg,
+		)
+		if err != nil {
+			t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
+		}
+		defer sess.Close()
+		assertLeaf(t, sess, selected, other)
+	})
+
+	t.Run("fresh restricted by allowed tools", func(t *testing.T) {
+		client, selected, other := newClient()
+		cfg := SessionConfig{NoProjectPrompts: true}
+		cfg.spawn.depth = 1
+		cfg.spawn.parentSessionID = "parent-session"
+		cfg.spawn.delegationAllowance = 1
+		cfg.spawn.allowedToolNames = []string{"read_file"}
+		cfg.testOnly = testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true}
+		sess, err := NewSession(client, NewOpenAIProfile("gpt-5.5"), execenv.NewLocalExecutionEnvironment(t.TempDir()), cfg)
+		if err != nil {
+			t.Fatalf("NewSession: %v", err)
+		}
+		defer sess.Close()
+		assertLeaf(t, sess, selected, other)
+	})
+
+	t.Run("restored under tool ceiling", func(t *testing.T) {
+		client, selected, other := newClient()
+		meta := schema.SessionMeta{
+			ID:         ulid.Make().String(),
+			ProfileID:  "openai",
+			Model:      "gpt-5.5",
+			IsSubagent: true,
+			Config:     (SessionConfig{MaxSubagentDepth: 1, NoProjectPrompts: true}).toSnapshot(),
+		}
+		restoreCfg := RestoreSessionConfig{
+			StateDir: t.TempDir(),
+			testOnly: testConfig{
+				skipGitSnapshot:     true,
+				minimalSystemPrompt: true,
+				noSyncJobStore:      true,
+			},
+		}
+		restoreCfg.spawn.depth = 1
+		restoreCfg.spawn.parentSessionID = "parent-session"
+		restoreCfg.spawn.delegationAllowance = 1
+		restoreCfg.spawn.toolNameCeiling = []string{"communicate"}
 		sess, err := RestoreSessionFromMetaWithConfig(
 			client,
 			NewOpenAIProfile("gpt-5.5"),

--- a/agent/session_model_availability_test.go
+++ b/agent/session_model_availability_test.go
@@ -431,6 +431,10 @@ func TestModelListToolPreservesJSONUnderConfiguredOutputLimit(t *testing.T) {
 	if len(page.Choices) == 0 {
 		t.Fatal("model_list returned no choices")
 	}
+	repeated := executeModelListPage(t, sess, "", modelavailability.DefaultPageMaxCount, 512)
+	if !slices.Equal(repeated.Choices, page.Choices) || repeated.Next != page.Next || repeated.Terminal != page.Terminal {
+		t.Fatalf("repeated model_list page = %#v, want %#v", repeated, page)
+	}
 }
 
 func TestModelListToolReturnsBoundedEmptyTerminalPage(t *testing.T) {

--- a/agent/session_model_availability_test.go
+++ b/agent/session_model_availability_test.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/internal/modelavailability"
+	"primeradiant.com/evener/llm"
+)
+
+type modelAvailabilityAdapter struct {
+	fakeAdapter
+	models []llm.ModelInfo
+	calls  atomic.Int32
+}
+
+func (a *modelAvailabilityAdapter) ListModels(context.Context) ([]llm.ModelInfo, error) {
+	a.calls.Add(1)
+	return append([]llm.ModelInfo(nil), a.models...), nil
+}
+
+func TestNewSessionReusesValidatedModelsAndBoundsDelegateSchema(t *testing.T) {
+	models := make([]llm.ModelInfo, modelavailability.DefaultInlineMaxCount)
+	for i := range models {
+		models[i].ID = fmt.Sprintf("model-%03d-%s", i, strings.Repeat("x", 12))
+	}
+	adapter := &modelAvailabilityAdapter{
+		fakeAdapter: fakeAdapter{name: "openai"},
+		models:      models,
+	}
+	client := llm.NewClient()
+	client.Register(adapter)
+
+	sess, err := NewSession(client, NewOpenAIProfile(models[0].ID), execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+
+	if got := adapter.calls.Load(); got != 1 {
+		t.Fatalf("selected provider ListModels calls = %d, want one validation fetch reused by startup snapshot", got)
+	}
+	props := sess.delegateToolDefinition().Parameters["properties"].(map[string]any)
+	modelDescription := props["model"].(map[string]any)["description"].(string)
+	if got := len([]byte(modelDescription)); got > modelavailability.DefaultInlineMaxBytes {
+		t.Fatalf("delegate model description = %d bytes, exceeds %d-byte contract", got, modelavailability.DefaultInlineMaxBytes)
+	}
+	if !sess.reg.RegisteredNames()["model_list"] {
+		t.Fatal("model_list is not registered when the verified choices do not fit in the bounded schema description")
+	}
+}

--- a/agent/session_model_availability_test.go
+++ b/agent/session_model_availability_test.go
@@ -285,8 +285,7 @@ func TestModelListToolReturnsEveryChoiceExactlyOnceWithinPageBound(t *testing.T)
 	}
 	defer sess.Close()
 
-	registered := sess.reg.Get("model_list")
-	if registered == nil {
+	if sess.reg.Get("model_list") == nil {
 		t.Fatal("model_list is not registered")
 	}
 	const maxBytes = 512
@@ -294,20 +293,7 @@ func TestModelListToolReturnsEveryChoiceExactlyOnceWithinPageBound(t *testing.T)
 	cursor := ""
 	pages := 0
 	for {
-		raw, err := registered.Exec(context.Background(), sess.env, map[string]any{
-			"cursor": cursor, "max_count": float64(modelavailability.DefaultPageMaxCount), "max_bytes": float64(maxBytes),
-		})
-		if err != nil {
-			t.Fatalf("model_list page %d: %v", pages, err)
-		}
-		page := raw.(modelavailability.Page)
-		encoded, err := json.Marshal(page)
-		if err != nil {
-			t.Fatalf("marshal page %d: %v", pages, err)
-		}
-		if len(encoded) > maxBytes {
-			t.Fatalf("page %d = %d bytes, exceeds %d", pages, len(encoded), maxBytes)
-		}
+		page := executeModelListPage(t, sess, cursor, modelavailability.DefaultPageMaxCount, maxBytes)
 		if len(page.Oversized) != 0 {
 			t.Fatalf("page %d marked ordinary choices oversized: %v", pages, page.Oversized)
 		}
@@ -346,24 +332,36 @@ func TestModelListToolReturnsBoundedEmptyTerminalPage(t *testing.T) {
 	}
 	defer sess.Close()
 
-	registered := sess.reg.Get("model_list")
-	if registered == nil {
+	if sess.reg.Get("model_list") == nil {
 		t.Fatal("model_list is not registered")
 	}
 	const maxBytes = 512
-	raw, err := registered.Exec(context.Background(), sess.env, map[string]any{"max_bytes": float64(maxBytes)})
-	if err != nil {
-		t.Fatalf("model_list empty page: %v", err)
-	}
-	page := raw.(modelavailability.Page)
+	page := executeModelListPage(t, sess, "", modelavailability.DefaultPageMaxCount, maxBytes)
 	if !page.Terminal || len(page.Choices) != 0 || page.Next != "" {
 		t.Fatalf("empty page = %#v", page)
 	}
-	encoded, err := json.Marshal(page)
+}
+
+func executeModelListPage(t *testing.T, sess *Session, cursor string, maxCount, maxBytes int) modelavailability.Page {
+	t.Helper()
+	args, err := json.Marshal(map[string]any{
+		"cursor": cursor, "max_count": maxCount, "max_bytes": maxBytes,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(encoded) > maxBytes {
-		t.Fatalf("empty terminal page = %d bytes, exceeds %d", len(encoded), maxBytes)
+	result := sess.reg.ExecuteCall(context.Background(), sess.env, llm.ToolCallData{
+		ID: "model-list-page", Name: "model_list", Arguments: args,
+	})
+	if result.IsError {
+		t.Fatalf("model_list: %s", result.Output)
 	}
+	if len([]byte(result.Output)) > maxBytes {
+		t.Fatalf("public model_list output = %d bytes, exceeds %d", len([]byte(result.Output)), maxBytes)
+	}
+	var page modelavailability.Page
+	if err := json.Unmarshal([]byte(result.Output), &page); err != nil {
+		t.Fatalf("decode model_list output: %v", err)
+	}
+	return page
 }

--- a/agent/session_model_availability_test.go
+++ b/agent/session_model_availability_test.go
@@ -2,7 +2,10 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -17,12 +20,16 @@ type modelAvailabilityAdapter struct {
 	models  []llm.ModelInfo
 	calls   atomic.Int32
 	observe func(context.Context)
+	listErr error
 }
 
 func (a *modelAvailabilityAdapter) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
 	a.calls.Add(1)
 	if a.observe != nil {
 		a.observe(ctx)
+	}
+	if a.listErr != nil {
+		return nil, a.listErr
 	}
 	return append([]llm.ModelInfo(nil), a.models...), nil
 }
@@ -83,5 +90,103 @@ func TestNewSessionEnumeratesOtherProvidersUnderLifetimeContext(t *testing.T) {
 
 	if !inheritedOwner.Load() {
 		t.Fatal("other-provider model enumeration did not inherit the session lifetime context")
+	}
+}
+
+func TestModelListToolReturnsEveryChoiceExactlyOnceWithinPageBound(t *testing.T) {
+	models := make([]llm.ModelInfo, modelavailability.DefaultInlineMaxCount)
+	for i := range models {
+		models[i].ID = fmt.Sprintf("model-%03d-%s", i, strings.Repeat("x", 12))
+	}
+	adapter := &modelAvailabilityAdapter{models: models}
+	adapter.name = "openai"
+	client := llm.NewClient()
+	client.Register(adapter)
+	sess, err := NewSession(client, NewOpenAIProfile(models[0].ID), execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+
+	registered := sess.reg.Get("model_list")
+	if registered == nil {
+		t.Fatal("model_list is not registered")
+	}
+	const maxBytes = 512
+	var got []string
+	cursor := ""
+	pages := 0
+	for {
+		raw, err := registered.Exec(context.Background(), sess.env, map[string]any{
+			"cursor": cursor, "max_count": float64(modelavailability.DefaultPageMaxCount), "max_bytes": float64(maxBytes),
+		})
+		if err != nil {
+			t.Fatalf("model_list page %d: %v", pages, err)
+		}
+		page := raw.(modelavailability.Page)
+		encoded, err := json.Marshal(page)
+		if err != nil {
+			t.Fatalf("marshal page %d: %v", pages, err)
+		}
+		if len(encoded) > maxBytes {
+			t.Fatalf("page %d = %d bytes, exceeds %d", pages, len(encoded), maxBytes)
+		}
+		if len(page.Oversized) != 0 {
+			t.Fatalf("page %d marked ordinary choices oversized: %v", pages, page.Oversized)
+		}
+		got = append(got, page.Choices...)
+		pages++
+		if page.Terminal {
+			if page.Next != "" {
+				t.Fatalf("terminal page has continuation %q", page.Next)
+			}
+			break
+		}
+		if page.Next == "" {
+			t.Fatalf("non-terminal page %d has no continuation", pages-1)
+		}
+		cursor = page.Next
+		if pages > len(models) {
+			t.Fatal("model_list did not terminate")
+		}
+	}
+	if pages < 3 {
+		t.Fatalf("model_list returned %d pages, want first, middle, and terminal pages", pages)
+	}
+	if !slices.Equal(got, sess.modelSnapshot.Choices) {
+		t.Fatalf("paged choices differ from snapshot:\n got %q\nwant %q", got, sess.modelSnapshot.Choices)
+	}
+}
+
+func TestModelListToolReturnsBoundedEmptyTerminalPage(t *testing.T) {
+	adapter := &modelAvailabilityAdapter{listErr: errors.New("enumeration unavailable")}
+	adapter.name = "openai"
+	client := llm.NewClient()
+	client.Register(adapter)
+	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.5"), execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+
+	registered := sess.reg.Get("model_list")
+	if registered == nil {
+		t.Fatal("model_list is not registered")
+	}
+	const maxBytes = 512
+	raw, err := registered.Exec(context.Background(), sess.env, map[string]any{"max_bytes": float64(maxBytes)})
+	if err != nil {
+		t.Fatalf("model_list empty page: %v", err)
+	}
+	page := raw.(modelavailability.Page)
+	if !page.Terminal || len(page.Choices) != 0 || page.Next != "" {
+		t.Fatalf("empty page = %#v", page)
+	}
+	encoded, err := json.Marshal(page)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(encoded) > maxBytes {
+		t.Fatalf("empty terminal page = %d bytes, exceeds %d", len(encoded), maxBytes)
 	}
 }

--- a/agent/session_model_availability_test.go
+++ b/agent/session_model_availability_test.go
@@ -329,7 +329,7 @@ func TestNewSessionBoundedSnapshotRetainsSelectedProvider(t *testing.T) {
 	client := llm.NewClient()
 	client.Register(selected)
 	nameToTag := map[string]string{selectedName: "openai"}
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		name := fmt.Sprintf("provider-%02d", i)
 		adapter := &modelAvailabilityAdapter{models: []llm.ModelInfo{{ID: "model"}}}
 		adapter.name = name

--- a/agent/session_model_availability_test.go
+++ b/agent/session_model_availability_test.go
@@ -28,10 +28,8 @@ func TestNewSessionReusesValidatedModelsAndBoundsDelegateSchema(t *testing.T) {
 	for i := range models {
 		models[i].ID = fmt.Sprintf("model-%03d-%s", i, strings.Repeat("x", 12))
 	}
-	adapter := &modelAvailabilityAdapter{
-		fakeAdapter: fakeAdapter{name: "openai"},
-		models:      models,
-	}
+	adapter := &modelAvailabilityAdapter{models: models}
+	adapter.name = "openai"
 	client := llm.NewClient()
 	client.Register(adapter)
 

--- a/agent/session_model_availability_test.go
+++ b/agent/session_model_availability_test.go
@@ -10,8 +10,11 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/oklog/ulid/v2"
+
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/internal/modelavailability"
+	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
 )
 
@@ -91,6 +94,152 @@ func TestNewSessionEnumeratesOtherProvidersUnderLifetimeContext(t *testing.T) {
 	if !inheritedOwner.Load() {
 		t.Fatal("other-provider model enumeration did not inherit the session lifetime context")
 	}
+}
+
+func TestRestoreSessionReusesSelectedModelsAndAdvertisesSnapshot(t *testing.T) {
+	type ownerContextKey struct{}
+	const ownerMarker = "restored-run"
+
+	selected := &modelAvailabilityAdapter{models: []llm.ModelInfo{{ID: "gpt-5.5"}}}
+	selected.name = "openai"
+	var inheritedOwner atomic.Bool
+	other := &modelAvailabilityAdapter{
+		models: []llm.ModelInfo{{ID: "claude-opus-4-6"}},
+		observe: func(ctx context.Context) {
+			inheritedOwner.Store(ctx.Value(ownerContextKey{}) == ownerMarker)
+		},
+	}
+	other.name = "anthropic"
+	client := llm.NewClient()
+	client.Register(selected)
+	client.Register(other)
+	owner := context.WithValue(context.Background(), ownerContextKey{}, ownerMarker)
+	stateDir := t.TempDir()
+	meta := schema.SessionMeta{
+		ID:        ulid.Make().String(),
+		ProfileID: "openai",
+		Model:     "gpt-5.5",
+		Config:    (SessionConfig{MaxSubagentDepth: 1, NoProjectPrompts: true}).toSnapshot(),
+	}
+
+	sess, err := RestoreSessionFromMetaWithConfig(
+		client,
+		NewOpenAIProfile("gpt-5.5"),
+		execenv.NewLocalExecutionEnvironment(t.TempDir()),
+		meta,
+		RestoreSessionConfig{
+			LifetimeContext: owner,
+			StateDir:        stateDir,
+			testOnly: testConfig{
+				skipGitSnapshot:     true,
+				minimalSystemPrompt: true,
+				noSyncJobStore:      true,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
+	}
+	defer sess.Close()
+
+	if got := selected.calls.Load(); got != 1 {
+		t.Fatalf("selected provider ListModels calls = %d, want one metadata fetch reused by restored snapshot", got)
+	}
+	if got := other.calls.Load(); got != 1 {
+		t.Fatalf("other provider ListModels calls = %d, want one restored snapshot fetch", got)
+	}
+	if !inheritedOwner.Load() {
+		t.Fatal("other-provider model enumeration did not inherit the restored session lifetime context")
+	}
+	wantChoices := []string{"anthropic/claude-opus-4-6", "openai/gpt-5.5"}
+	if sess.modelSnapshot == nil || !slices.Equal(sess.modelSnapshot.Choices, wantChoices) {
+		t.Fatalf("restored model snapshot choices = %#v, want %q", sess.modelSnapshot, wantChoices)
+	}
+	properties := sess.delegateToolDefinition().Parameters["properties"].(map[string]any)
+	modelDescription := properties["model"].(map[string]any)["description"].(string)
+	if sess.delegateModelDescription == "" || !strings.HasSuffix(modelDescription, sess.delegateModelDescription) {
+		t.Fatal("restored delegate schema does not advertise its captured model snapshot")
+	}
+}
+
+func TestLeafSessionsSkipModelAvailabilityCapture(t *testing.T) {
+	newClient := func() (*llm.Client, *modelAvailabilityAdapter, *modelAvailabilityAdapter) {
+		selected := &modelAvailabilityAdapter{models: []llm.ModelInfo{{ID: "gpt-5.5"}}}
+		selected.name = "openai"
+		other := &modelAvailabilityAdapter{models: []llm.ModelInfo{{ID: "claude-opus-4-6"}}}
+		other.name = "anthropic"
+		client := llm.NewClient()
+		client.Register(selected)
+		client.Register(other)
+		return client, selected, other
+	}
+	assertLeaf := func(t *testing.T, sess *Session, selected, other *modelAvailabilityAdapter) {
+		t.Helper()
+		if got := selected.calls.Load(); got != 1 {
+			t.Fatalf("selected provider ListModels calls = %d, want one live metadata fetch", got)
+		}
+		if got := other.calls.Load(); got != 0 {
+			t.Fatalf("other provider ListModels calls = %d, want none for a leaf session", got)
+		}
+		if sess.modelSnapshot != nil {
+			t.Fatalf("leaf model snapshot = %#v, want nil", sess.modelSnapshot)
+		}
+		if sess.reg.Get("model_list") != nil {
+			t.Fatal("leaf registry contains model_list")
+		}
+		if sess.reg.Get("delegate") != nil {
+			t.Fatal("leaf registry contains delegate")
+		}
+	}
+
+	t.Run("fresh", func(t *testing.T) {
+		client, selected, other := newClient()
+		cfg := SessionConfig{NoProjectPrompts: true}
+		cfg.spawn.depth = 1
+		cfg.spawn.parentSessionID = "parent-session"
+		cfg.spawn.delegationAllowance = 0
+		cfg.testOnly = testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true}
+		sess, err := NewSession(client, NewOpenAIProfile("gpt-5.5"), execenv.NewLocalExecutionEnvironment(t.TempDir()), cfg)
+		if err != nil {
+			t.Fatalf("NewSession: %v", err)
+		}
+		defer sess.Close()
+		assertLeaf(t, sess, selected, other)
+	})
+
+	t.Run("restored", func(t *testing.T) {
+		client, selected, other := newClient()
+		meta := schema.SessionMeta{
+			ID:         ulid.Make().String(),
+			ProfileID:  "openai",
+			Model:      "gpt-5.5",
+			IsSubagent: true,
+			Config:     (SessionConfig{MaxSubagentDepth: 1, NoProjectPrompts: true}).toSnapshot(),
+		}
+		restoreCfg := RestoreSessionConfig{
+			StateDir: t.TempDir(),
+			testOnly: testConfig{
+				skipGitSnapshot:     true,
+				minimalSystemPrompt: true,
+				noSyncJobStore:      true,
+			},
+		}
+		restoreCfg.spawn.depth = 1
+		restoreCfg.spawn.parentSessionID = "parent-session"
+		restoreCfg.spawn.delegationAllowance = 0
+		sess, err := RestoreSessionFromMetaWithConfig(
+			client,
+			NewOpenAIProfile("gpt-5.5"),
+			execenv.NewLocalExecutionEnvironment(t.TempDir()),
+			meta,
+			restoreCfg,
+		)
+		if err != nil {
+			t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
+		}
+		defer sess.Close()
+		assertLeaf(t, sess, selected, other)
+	})
 }
 
 func TestModelListToolReturnsEveryChoiceExactlyOnceWithinPageBound(t *testing.T) {

--- a/agent/session_model_availability_test.go
+++ b/agent/session_model_availability_test.go
@@ -242,6 +242,34 @@ func TestLeafSessionsSkipModelAvailabilityCapture(t *testing.T) {
 	})
 }
 
+func TestNewSessionSnapshotUsesSharedModelVisibility(t *testing.T) {
+	selected := &modelAvailabilityAdapter{models: []llm.ModelInfo{
+		{ID: "gpt-5.5"},
+		{ID: "text-embedding-3-small"},
+	}}
+	selected.name = "openai"
+	other := &modelAvailabilityAdapter{models: []llm.ModelInfo{
+		{ID: "tool-model", CapabilitiesAdvertised: true, SupportsTools: true},
+		{ID: "tool-less-model", CapabilitiesAdvertised: true, SupportsTools: false},
+	}}
+	other.name = "router"
+	client := llm.NewClient()
+	client.Register(selected)
+	client.Register(other)
+	client.SetNameToTag(map[string]string{"router": "openrouter"})
+
+	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.5"), execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+
+	want := []string{"openai/gpt-5.5", "router/tool-model"}
+	if sess.modelSnapshot == nil || !slices.Equal(sess.modelSnapshot.Choices, want) {
+		t.Fatalf("visible startup choices = %#v, want %q", sess.modelSnapshot, want)
+	}
+}
+
 func TestModelListToolReturnsEveryChoiceExactlyOnceWithinPageBound(t *testing.T) {
 	models := make([]llm.ModelInfo, modelavailability.DefaultInlineMaxCount)
 	for i := range models {

--- a/agent/session_set_model.go
+++ b/agent/session_set_model.go
@@ -84,15 +84,15 @@ const modelSwitchEnumerationTimeout = 8 * time.Second
 func resolveModelSwitchTarget(client *llm.Client, profile *provider.Profile) (*provider.Profile, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), modelSwitchEnumerationTimeout)
 	defer cancel()
-	filled, models, ok := fillLiveModelMetadata(ctx, client, profile)
-	if !ok {
+	filled, enumeration := fillLiveModelMetadata(ctx, client, profile)
+	if enumeration.err != nil {
 		// Fail open unconditionally: a non-enumerable instance (adapter
 		// doesn't implement ModelLister) and any enumeration failure
 		// (timeout, auth error, etc.) both accept the switch, with no live
 		// metadata to fill.
 		return filled, nil
 	}
-	if err := validateModelSwitchMembership(client, filled, models); err != nil {
+	if err := validateModelSwitchMembership(client, filled, enumeration.models); err != nil {
 		return filled, err
 	}
 	return filled, nil

--- a/agent/session_tool_registry.go
+++ b/agent/session_tool_registry.go
@@ -12,7 +12,6 @@ import (
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/internal/artifactstore"
 	"primeradiant.com/evener/agent/internal/goal"
-	"primeradiant.com/evener/agent/internal/modelavailability"
 	"primeradiant.com/evener/agent/internal/tool"
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
@@ -380,7 +379,7 @@ func registerCoreTools(reg *tool.Registry, s *Session) error {
 		return err
 	}
 	if s.modelSnapshot != nil {
-		if _, inline := s.modelSnapshot.Inline(modelavailability.DefaultInlineMaxCount, modelavailability.DefaultInlineMaxBytes); !inline {
+		if _, inline := inlineModelSnapshot(*s.modelSnapshot); !inline {
 			if err := registerModelListTool(reg, s); err != nil {
 				return err
 			}

--- a/agent/session_tool_registry.go
+++ b/agent/session_tool_registry.go
@@ -12,6 +12,7 @@ import (
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/internal/artifactstore"
 	"primeradiant.com/evener/agent/internal/goal"
+	"primeradiant.com/evener/agent/internal/modelavailability"
 	"primeradiant.com/evener/agent/internal/tool"
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
@@ -377,6 +378,13 @@ func registerCoreTools(reg *tool.Registry, s *Session) error {
 	}
 	if err := registerStableDelegateTool(reg, s); err != nil {
 		return err
+	}
+	if s.modelSnapshot != nil {
+		if _, inline := s.modelSnapshot.Inline(modelavailability.DefaultInlineMaxCount, modelavailability.DefaultInlineMaxBytes); !inline {
+			if err := registerModelListTool(reg, s); err != nil {
+				return err
+			}
+		}
 	}
 	registerTaskTools(reg, deps)
 	registerGoalTools(reg, deps)

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -1224,7 +1224,9 @@ func (s *Session) delegateCapabilityRoster() string {
 }
 
 func (s *Session) delegateToolDefinition() llm.ToolDefinition {
-	definition := tool.DefDelegateWithSandbox(s.delegateAgentTypeNames(), s.delegateSandboxSchemaForEnv(s.env))
+	sandboxSchema := s.delegateSandboxSchemaForEnv(s.env)
+	sandboxSchema.ModelDescription = s.delegateModelDescription
+	definition := tool.DefDelegateWithSandbox(s.delegateAgentTypeNames(), sandboxSchema)
 	roster := s.delegateCapabilityRoster()
 	if roster == "" {
 		return definition
@@ -1282,7 +1284,9 @@ func (s *Session) profileWireToolDefs() []llm.ToolDefinition {
 	defs := s.profile.ToolDefinitions()
 	for i := range defs {
 		if defs[i].Name == "delegate" {
-			defs[i] = tool.DefDelegateWithSandbox(s.delegateAgentTypeNames(), s.delegateSandboxSchemaForEnv(s.env))
+			sandboxSchema := s.delegateSandboxSchemaForEnv(s.env)
+			sandboxSchema.ModelDescription = s.delegateModelDescription
+			defs[i] = tool.DefDelegateWithSandbox(s.delegateAgentTypeNames(), sandboxSchema)
 		}
 		defs[i] = wireToolDef(defs[i], nameMap, s.resultToolName())
 	}

--- a/agent/session_tools_model_list.go
+++ b/agent/session_tools_model_list.go
@@ -2,7 +2,8 @@ package agent
 
 import (
 	"context"
-	"fmt"
+	"errors"
+
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/internal/modelavailability"
 	"primeradiant.com/evener/agent/internal/tool"
@@ -22,7 +23,7 @@ func registerModelListTool(reg *tool.Registry, s *Session) error {
 				bytes = int(n)
 			}
 			if count > modelavailability.DefaultInlineMaxCount || bytes > modelavailability.DefaultInlineMaxBytes {
-				return nil, fmt.Errorf("page bounds exceed contract")
+				return nil, errors.New("page bounds exceed contract")
 			}
 			return s.modelSnapshot.Page(cursor, count, bytes)
 		},

--- a/agent/session_tools_model_list.go
+++ b/agent/session_tools_model_list.go
@@ -7,6 +7,7 @@ import (
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/internal/modelavailability"
 	"primeradiant.com/evener/agent/internal/tool"
+	"primeradiant.com/evener/agent/schema"
 )
 
 func registerModelListTool(reg *tool.Registry, s *Session) error {
@@ -28,4 +29,26 @@ func registerModelListTool(reg *tool.Registry, s *Session) error {
 			return s.modelSnapshot.Page(cursor, count, bytes)
 		},
 	})
+}
+
+func enforceModelListJSONLimits(reg *tool.Registry) {
+	if reg == nil {
+		return
+	}
+	registered := reg.Get("model_list")
+	if registered == nil {
+		return
+	}
+
+	override := schema.ToolOutputLimit{Strategy: registered.Limit.Strategy}
+	if registered.Limit.MaxChars < modelavailability.DefaultInlineMaxBytes {
+		override.MaxChars = modelavailability.DefaultInlineMaxBytes
+	}
+	if registered.Limit.MaxLines > 0 && registered.Limit.MaxLines <= modelavailability.DefaultInlineMaxBytes {
+		override.MaxLines = modelavailability.DefaultInlineMaxBytes + 1
+	}
+	if override.MaxChars == 0 && override.MaxLines == 0 {
+		return
+	}
+	reg.OverrideLimits(map[string]schema.ToolOutputLimit{"model_list": override})
 }

--- a/agent/session_tools_model_list.go
+++ b/agent/session_tools_model_list.go
@@ -1,0 +1,30 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/internal/modelavailability"
+	"primeradiant.com/evener/agent/internal/tool"
+)
+
+func registerModelListTool(reg *tool.Registry, s *Session) error {
+	return reg.Register(tool.RegisteredTool{
+		Definition: tool.DefModelList(), ReadOnly: true,
+		Exec: func(_ context.Context, _ execenv.ExecutionEnvironment, args map[string]any) (any, error) {
+			cursor, _ := args["cursor"].(string)
+			count := modelavailability.DefaultInlineMaxCount
+			bytes := modelavailability.DefaultInlineMaxBytes
+			if n, ok := args["max_count"].(float64); ok && n > 0 {
+				count = int(n)
+			}
+			if n, ok := args["max_bytes"].(float64); ok && n > 0 {
+				bytes = int(n)
+			}
+			if count > modelavailability.DefaultInlineMaxCount || bytes > modelavailability.DefaultInlineMaxBytes {
+				return nil, fmt.Errorf("page bounds exceed contract")
+			}
+			return s.modelSnapshot.Page(cursor, count, bytes)
+		},
+	})
+}

--- a/scripts/fuzz/fuzz-targets.txt
+++ b/scripts/fuzz/fuzz-targets.txt
@@ -670,3 +670,5 @@ native:.:./cmd/evener:FuzzSandboxHelpers
 native:.:./cmd/evener:FuzzServeResidualCoverage
 native:.:./cmd/evener:FuzzServeSeedCoverage
 native:.:./cmd/evener:FuzzUpgradeErrorSeedCoverage
+
+native:agent:./internal/modelavailability:FuzzCursorDecode


### PR DESCRIPTION
Implements Task 11 startup model availability projection and bounded read-only pagination.

Fixes #323