### PR TITLE
fix(agent): expose vision side-channel failures

### DIFF
--- a/agent/session.go
+++ b/agent/session.go
@@ -289,8 +289,9 @@ type Session struct {
 
 	reg *tool.Registry
 
-	steeringQueue []steeringMessage
-	followups     []string
+	steeringQueue    []steeringMessage
+	visionTurnOwners []*struct{ _ byte }
+	followups        []string
 
 	// activeProvenance is the causal provenance carried by the input currently
 	// being processed. It is stamped onto every event the turn emits, reset to

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 	"sync/atomic"
 
@@ -100,22 +99,6 @@ type steeringMessage struct {
 	turnOwner      *struct{ _ byte }                  `json:"-"`
 }
 
-func (s *Session) removeTurnOwnedSteering(owner *struct{ _ byte }) {
-	if owner == nil {
-		return
-	}
-	s.mu.Lock()
-	for i, entry := range slices.Backward(s.steeringQueue) {
-		if entry.turnOwner == owner {
-			s.steeringQueue = append(s.steeringQueue[:i], s.steeringQueue[i+1:]...)
-			s.mu.Unlock()
-			s.persistQueuesSnapshot()
-			return
-		}
-	}
-	s.mu.Unlock()
-}
-
 func (s *Session) removeAllTurnOwnedSteering() {
 	s.mu.Lock()
 	owners := make(map[*struct{ _ byte }]struct{}, len(s.visionTurnOwners))
@@ -132,6 +115,26 @@ func (s *Session) removeAllTurnOwnedSteering() {
 	s.visionTurnOwners = nil
 	s.mu.Unlock()
 	s.persistQueuesSnapshot()
+}
+
+func (s *Session) finishTurnOwnedSteering() {
+	s.mu.Lock()
+	s.visionTurnOwners = nil
+	s.mu.Unlock()
+}
+
+func (s *Session) trySteerTurnOwnedMessage(entry steeringMessage, owner *struct{ _ byte }) bool {
+	entry.turnOwner = owner
+	s.mu.Lock()
+	if s.closingOrClosedLocked() || (strings.TrimSpace(entry.Text) == "" && len(entry.Images) == 0) {
+		s.mu.Unlock()
+		return false
+	}
+	s.steeringQueue = append(s.steeringQueue, entry)
+	s.visionTurnOwners = append(s.visionTurnOwners, owner)
+	s.mu.Unlock()
+	s.persistQueuesSnapshot()
+	return true
 }
 
 func steeringInjectedDataFromMessage(msg steeringMessage) events.SteeringInjectedData {

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -116,6 +116,24 @@ func (s *Session) removeTurnOwnedSteering(owner *struct{ _ byte }) {
 	s.mu.Unlock()
 }
 
+func (s *Session) removeAllTurnOwnedSteering() {
+	s.mu.Lock()
+	owners := make(map[*struct{ _ byte }]struct{}, len(s.visionTurnOwners))
+	for _, owner := range s.visionTurnOwners {
+		owners[owner] = struct{}{}
+	}
+	filtered := s.steeringQueue[:0]
+	for _, entry := range s.steeringQueue {
+		if _, ok := owners[entry.turnOwner]; !ok {
+			filtered = append(filtered, entry)
+		}
+	}
+	s.steeringQueue = filtered
+	s.visionTurnOwners = nil
+	s.mu.Unlock()
+	s.persistQueuesSnapshot()
+}
+
 func steeringInjectedDataFromMessage(msg steeringMessage) events.SteeringInjectedData {
 	return events.SteeringInjectedData{
 		Text:             msg.Text,

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -101,6 +101,10 @@ type steeringMessage struct {
 
 func (s *Session) removeAllTurnOwnedSteering() {
 	s.mu.Lock()
+	if len(s.visionTurnOwners) == 0 {
+		s.mu.Unlock()
+		return
+	}
 	owners := make(map[*struct{ _ byte }]struct{}, len(s.visionTurnOwners))
 	for _, owner := range s.visionTurnOwners {
 		owners[owner] = struct{}{}

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -96,6 +96,23 @@ type steeringMessage struct {
 	// TaskCompletion carries typed dependency state for tasks-done steering so
 	// consumers do not need to parse the system-reminder prose.
 	TaskCompletion *events.TaskCompletionSteeringData `json:"task_completion,omitempty"`
+	turnOwner      *struct{ _ byte }                  `json:"-"`
+}
+
+func (s *Session) removeTurnOwnedSteering(owner *struct{ _ byte }) {
+	if owner == nil {
+		return
+	}
+	s.mu.Lock()
+	for i := len(s.steeringQueue) - 1; i >= 0; i-- {
+		if s.steeringQueue[i].turnOwner == owner {
+			s.steeringQueue = append(s.steeringQueue[:i], s.steeringQueue[i+1:]...)
+			s.mu.Unlock()
+			s.persistQueuesSnapshot()
+			return
+		}
+	}
+	s.mu.Unlock()
 }
 
 func steeringInjectedDataFromMessage(msg steeringMessage) events.SteeringInjectedData {

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync/atomic"
 
@@ -104,8 +105,8 @@ func (s *Session) removeTurnOwnedSteering(owner *struct{ _ byte }) {
 		return
 	}
 	s.mu.Lock()
-	for i := len(s.steeringQueue) - 1; i >= 0; i-- {
-		if s.steeringQueue[i].turnOwner == owner {
+	for i, entry := range slices.Backward(s.steeringQueue) {
+		if entry.turnOwner == owner {
 			s.steeringQueue = append(s.steeringQueue[:i], s.steeringQueue[i+1:]...)
 			s.mu.Unlock()
 			s.persistQueuesSnapshot()

--- a/agent/session_tool_round.go
+++ b/agent/session_tool_round.go
@@ -270,11 +270,24 @@ func (s *Session) persistToolResults(ctx context.Context, calls []llm.ToolCallDa
 				}
 			}
 			if vision.outcome == visionSideChannelOwnedTimeout || vision.outcome == visionSideChannelProviderFailure {
+				owner := &struct{ _ byte }{}
+				queued := false
 				if abortErr := s.withResponseSideEffects(ctx, func() {
-					s.SteerKind(visionFailureSteering(path, vision), events.SteeringKindImageDescription)
+					queued = s.trySteerMessage(steeringMessage{Text: visionFailureSteering(path, vision), Kind: events.SteeringKindImageDescription, turnOwner: owner})
 				}); abortErr != nil {
+					if queued {
+						s.removeTurnOwnedSteering(owner)
+					}
 					return abortErr
 				}
+				if err := ctx.Err(); err != nil {
+					if queued {
+						s.removeTurnOwnedSteering(owner)
+					}
+					return err
+				}
+			} else if vision.outcome == visionSideChannelParentCanceled {
+				return ctx.Err()
 			} else if vision.description != "" {
 				desc := vision.description + "\n" + formatVisionSideChannelStats(vision)
 				// Include the file path so the agent can correlate descriptions to

--- a/agent/session_tool_round.go
+++ b/agent/session_tool_round.go
@@ -280,6 +280,11 @@ func (s *Session) persistToolResults(ctx context.Context, calls []llm.ToolCallDa
 					}
 					return abortErr
 				}
+				if queued {
+					s.mu.Lock()
+					s.visionTurnOwners = append(s.visionTurnOwners, owner)
+					s.mu.Unlock()
+				}
 				if err := ctx.Err(); err != nil {
 					if queued {
 						s.removeTurnOwnedSteering(owner)
@@ -424,8 +429,12 @@ func (s *Session) injectPostToolSteering(ctx context.Context, calls []llm.ToolCa
 				s.emit(events.EventLoopDetection, events.LoopDetectionData{Message: warning})
 				s.appendSteeringTurn(warning, events.SteeringKindLoopDetected)
 			}); abortErr != nil {
+				s.removeAllTurnOwnedSteering()
 				return false, abortErr
 			}
+			s.mu.Lock()
+			s.visionTurnOwners = nil
+			s.mu.Unlock()
 		}
 	}
 

--- a/agent/session_tool_round.go
+++ b/agent/session_tool_round.go
@@ -261,20 +261,30 @@ func (s *Session) persistToolResults(ctx context.Context, calls []llm.ToolCallDa
 
 	for i, r := range results {
 		if len(r.ImageData) > 0 {
-			if desc := s.describeImageSteering(ctx, r); desc != "" {
+			vision := s.describeImageCall(ctx, r)
+			path := ""
+			if i < len(calls) {
+				var args map[string]any
+				if json.Unmarshal(calls[i].Arguments, &args) == nil {
+					path, _ = args["file_path"].(string)
+				}
+			}
+			if vision.outcome == visionSideChannelOwnedTimeout || vision.outcome == visionSideChannelProviderFailure {
+				if abortErr := s.withResponseSideEffects(ctx, func() {
+					s.SteerKind(visionFailureSteering(path, vision), events.SteeringKindImageDescription)
+				}); abortErr != nil {
+					return abortErr
+				}
+			} else if vision.description != "" {
+				desc := vision.description + "\n" + formatVisionSideChannelStats(vision)
 				// Include the file path so the agent can correlate descriptions to
 				// specific files when multiple images/documents are read in one round.
 				label := "Image description (from vision)"
 				if strings.HasPrefix(r.ImageMediaType, "application/pdf") {
 					label = "Document description (from content analysis)"
 				}
-				if i < len(calls) {
-					var args map[string]any
-					if json.Unmarshal(calls[i].Arguments, &args) == nil {
-						if path, ok := args["file_path"].(string); ok {
-							label += " for " + path
-						}
-					}
+				if path != "" {
+					label += " for " + path
 				}
 				if abortErr := s.withResponseSideEffects(ctx, func() {
 					s.SteerKind(label+": "+desc+"\n<system-reminder>Vision output is model-generated and is not byte-exact OCR. It may omit, misread, or silently normalize rendered text even when asked to transcribe it. Do not treat it as authoritative for exact-match or byte-exact transcription; use a real OCR tool or inspect the source instead.</system-reminder>",

--- a/agent/session_tool_round.go
+++ b/agent/session_tool_round.go
@@ -235,7 +235,12 @@ func toolBatchPanicError(value any) error {
 // images themselves — they immediately write code) and injects the description as
 // steering so the agent can use it. It returns the abort error if the turn is
 // canceled mid-persist.
-func (s *Session) persistToolResults(ctx context.Context, calls []llm.ToolCallData, results []tool.ExecResult) error {
+func (s *Session) persistToolResults(ctx context.Context, calls []llm.ToolCallData, results []tool.ExecResult) (retErr error) {
+	defer func() {
+		if retErr != nil {
+			s.removeAllTurnOwnedSteering()
+		}
+	}()
 	// Aggregate all tool results into a single TurnToolResults turn.
 	var parts []llm.ContentPart
 	for _, r := range results {
@@ -274,11 +279,9 @@ func (s *Session) persistToolResults(ctx context.Context, calls []llm.ToolCallDa
 				if abortErr := s.withResponseSideEffects(ctx, func() {
 					s.trySteerTurnOwnedMessage(steeringMessage{Text: visionFailureSteering(path, vision), Kind: events.SteeringKindImageDescription}, owner)
 				}); abortErr != nil {
-					s.removeAllTurnOwnedSteering()
 					return abortErr
 				}
 				if err := ctx.Err(); err != nil {
-					s.removeAllTurnOwnedSteering()
 					return err
 				}
 			} else if vision.outcome == visionSideChannelParentCanceled {
@@ -422,9 +425,6 @@ func (s *Session) injectPostToolSteering(ctx context.Context, calls []llm.ToolCa
 				s.removeAllTurnOwnedSteering()
 				return false, abortErr
 			}
-			s.mu.Lock()
-			s.visionTurnOwners = nil
-			s.mu.Unlock()
 		}
 	}
 

--- a/agent/session_tool_round.go
+++ b/agent/session_tool_round.go
@@ -271,24 +271,14 @@ func (s *Session) persistToolResults(ctx context.Context, calls []llm.ToolCallDa
 			}
 			if vision.outcome == visionSideChannelOwnedTimeout || vision.outcome == visionSideChannelProviderFailure {
 				owner := &struct{ _ byte }{}
-				queued := false
 				if abortErr := s.withResponseSideEffects(ctx, func() {
-					queued = s.trySteerMessage(steeringMessage{Text: visionFailureSteering(path, vision), Kind: events.SteeringKindImageDescription, turnOwner: owner})
+					s.trySteerTurnOwnedMessage(steeringMessage{Text: visionFailureSteering(path, vision), Kind: events.SteeringKindImageDescription}, owner)
 				}); abortErr != nil {
-					if queued {
-						s.removeTurnOwnedSteering(owner)
-					}
+					s.removeAllTurnOwnedSteering()
 					return abortErr
 				}
-				if queued {
-					s.mu.Lock()
-					s.visionTurnOwners = append(s.visionTurnOwners, owner)
-					s.mu.Unlock()
-				}
 				if err := ctx.Err(); err != nil {
-					if queued {
-						s.removeTurnOwnedSteering(owner)
-					}
+					s.removeAllTurnOwnedSteering()
 					return err
 				}
 			} else if vision.outcome == visionSideChannelParentCanceled {
@@ -440,6 +430,7 @@ func (s *Session) injectPostToolSteering(ctx context.Context, calls []llm.ToolCa
 
 	drained, err := s.drainPostToolWatchSends(ctx)
 	if err != nil {
+		s.removeAllTurnOwnedSteering()
 		return false, err
 	}
 	yieldToObserverCallback := drained.observerHandoff
@@ -454,8 +445,10 @@ func (s *Session) injectPostToolSteering(ctx context.Context, calls []llm.ToolCa
 		}
 		s.injectDrainedSteering()
 	}); abortErr != nil {
+		s.removeAllTurnOwnedSteering()
 		return false, abortErr
 	}
+	s.finishTurnOwnedSteering()
 	if hooks, ok := ctx.Value(sessionToolRoundHooksKey{}).(sessionToolRoundHooks); ok && hooks.beforeTaskReminder != nil {
 		hooks.beforeTaskReminder()
 	}
@@ -466,6 +459,7 @@ func (s *Session) injectPostToolSteering(ctx context.Context, calls []llm.ToolCa
 			s.appendSteeringTurn(reminder, kind)
 		}
 	}); abortErr != nil {
+		s.removeAllTurnOwnedSteering()
 		return false, abortErr
 	}
 	return yieldToObserverCallback, nil

--- a/agent/session_tool_round_test.go
+++ b/agent/session_tool_round_test.go
@@ -80,6 +80,37 @@ func TestInjectPostToolSteering_PersistsTaskReminderKind(t *testing.T) {
 	}
 }
 
+func TestInjectPostToolSteering_LoopDetectionKeepsVisionCleanupOwnedUntilDrainCompletes(t *testing.T) {
+	t.Parallel()
+	s := newTestSession(t)
+	enableLoopDetection := true
+	s.cfg.EnableLoopDetection = &enableLoopDetection
+	s.cfg.LoopDetectionWindow = 2
+	s.Steer("unrelated")
+	owner := &struct{ _ byte }{}
+	if !s.trySteerTurnOwnedMessage(steeringMessage{Text: "vision unavailable"}, owner) {
+		t.Fatal("failed to queue turn-owned steering")
+	}
+
+	calls := []llm.ToolCallData{
+		{Name: "read_file", Arguments: json.RawMessage(`{"file_path":"same"}`)},
+		{Name: "read_file", Arguments: json.RawMessage(`{"file_path":"same"}`)},
+	}
+	results := []tool.ExecResult{{}, {}}
+	var toolSigs []string
+	var toolSigFailed []bool
+	drainErr := errors.New("watch drain failed")
+	ctx := context.WithValue(context.Background(), sessionToolRoundHooksKey{}, sessionToolRoundHooks{drainErr: drainErr})
+	if _, err := s.injectPostToolSteering(ctx, calls, results, &toolSigs, &toolSigFailed); !errors.Is(err, drainErr) {
+		t.Fatalf("injectPostToolSteering error = %v, want %v", err, drainErr)
+	}
+
+	remaining := s.drainSteering()
+	if len(remaining) != 1 || remaining[0].Text != "unrelated" {
+		t.Fatalf("steering after aborted drain = %#v, want only unrelated entry", remaining)
+	}
+}
+
 func TestDelegateAttention_DeliveryCommitUsesCallerToolResultFsync(t *testing.T) {
 	c, _ := newDelegateControllerTestHarness(t, 1, 1)
 	seedDelegateControllerIdle(t, c, "dlg_target", "")

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -280,6 +281,8 @@ const (
 	visionSideChannelTimeout = 2 * time.Minute
 )
 
+var visionSideChannelTimeoutCause = errors.New("vision side-channel deadline")
+
 func (s *Session) visionSideChannelDuration() time.Duration {
 	if timeout := s.cfg.testOnly.visionSideChannelTimeout; timeout > 0 {
 		return timeout
@@ -336,7 +339,7 @@ func visionUnavailableSteering(path string) string {
 	if path == "" {
 		return "Vision is unavailable. Use OCR or inspect the source data, or continue without vision."
 	}
-	return fmt.Sprintf("Vision is unavailable for %s. Use OCR or inspect the source data, or continue without vision.", path)
+	return fmt.Sprintf("Vision is unavailable for %s. Use OCR or inspect the source data, or continue without vision.", strconv.Quote(path))
 }
 
 func visionFailureSteering(path string, result visionSideChannelResult) string {
@@ -344,7 +347,7 @@ func visionFailureSteering(path string, result visionSideChannelResult) string {
 		if path == "" {
 			return fmt.Sprintf("Vision is unavailable because the vision provider failed: %v. Use OCR or inspect the source data, or continue without vision.", result.err)
 		}
-		return fmt.Sprintf("Vision is unavailable for %s because the vision provider failed: %v. Use OCR or inspect the source data, or continue without vision.", path, result.err)
+		return fmt.Sprintf("Vision is unavailable for %s because the vision provider failed. Use OCR or inspect the source data, or continue without vision.", strconv.Quote(path))
 	}
 	return visionUnavailableSteering(path)
 }
@@ -426,7 +429,7 @@ func (s *Session) describeImageCall(ctx context.Context, r tool.ExecResult) visi
 	s.mu.Unlock()
 
 	visionTimeout := s.visionSideChannelDuration()
-	visionCtx, cancel := context.WithTimeout(ctx, visionTimeout)
+	visionCtx, cancel := context.WithTimeoutCause(ctx, visionTimeout, visionSideChannelTimeoutCause)
 	defer cancel()
 	req := llm.Request{
 		Model:    profile.Model(),
@@ -464,14 +467,19 @@ func (s *Session) describeImageCall(ctx context.Context, r tool.ExecResult) visi
 	elapsed = max(elapsed, 0)
 	if err != nil {
 		outcome := visionSideChannelProviderFailure
-		if ctx.Err() != nil {
+		cause := context.Cause(visionCtx)
+		if errors.Is(cause, visionSideChannelTimeoutCause) {
+			outcome = visionSideChannelOwnedTimeout
+		} else if ctx.Err() != nil {
 			// Parent cancellation owns races with the side-channel deadline. This
 			// prevents a stale unavailable steering message after a canceled turn.
 			outcome = visionSideChannelParentCanceled
 		} else if errors.Is(visionCtx.Err(), context.DeadlineExceeded) {
 			outcome = visionSideChannelOwnedTimeout
 		}
-		s.emit(events.EventWarning, events.WarningData{Message: fmt.Sprintf("vision side-channel failed: %v", err)})
+		if outcome != visionSideChannelParentCanceled {
+			s.emit(events.EventWarning, events.WarningData{Message: fmt.Sprintf("vision side-channel failed: %v", err)})
+		}
 		return visionSideChannelResult{elapsed: elapsed, outcome: outcome, err: err}
 	}
 

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -287,10 +287,21 @@ func (s *Session) visionSideChannelDuration() time.Duration {
 	return visionSideChannelTimeout
 }
 
+type visionSideChannelOutcome uint8
+
+const (
+	visionSideChannelSuccess visionSideChannelOutcome = iota
+	visionSideChannelOwnedTimeout
+	visionSideChannelParentCanceled
+	visionSideChannelProviderFailure
+)
+
 type visionSideChannelResult struct {
 	description string
 	elapsed     time.Duration
 	usage       llm.Usage
+	outcome     visionSideChannelOutcome
+	err         error
 }
 
 // visionSideChannelStats is the machine-readable accounting contract carried
@@ -334,6 +345,23 @@ func (s *Session) describeImageSteering(ctx context.Context, r tool.ExecResult) 
 	return result.description + "\n" + formatVisionSideChannelStats(result)
 }
 
+func visionUnavailableSteering(path string) string {
+	if path == "" {
+		return "Vision is unavailable. Use OCR or inspect the source data, or continue without vision."
+	}
+	return fmt.Sprintf("Vision is unavailable for %s. Use OCR or inspect the source data, or continue without vision.", path)
+}
+
+func visionFailureSteering(path string, result visionSideChannelResult) string {
+	if result.outcome == visionSideChannelProviderFailure && result.err != nil {
+		if path == "" {
+			return fmt.Sprintf("Vision is unavailable because the vision provider failed: %v. Use OCR or inspect the source data, or continue without vision.", result.err)
+		}
+		return fmt.Sprintf("Vision is unavailable for %s because the vision provider failed: %v. Use OCR or inspect the source data, or continue without vision.", path, result.err)
+	}
+	return visionUnavailableSteering(path)
+}
+
 func formatVisionSideChannelStats(result visionSideChannelResult) string {
 	stats := visionSideChannelStats{
 		ElapsedMS:      result.elapsed.Milliseconds(),
@@ -368,11 +396,11 @@ func visionUsageAvailable(usage llm.Usage) bool {
 
 func (s *Session) describeImageCall(ctx context.Context, r tool.ExecResult) visionSideChannelResult {
 	if len(r.ImageData) == 0 {
-		return visionSideChannelResult{}
+		return visionSideChannelResult{outcome: visionSideChannelSuccess}
 	}
 	// Skip for explorer agents — they're just inventorying files, not analyzing images.
 	if s.cfg.AgentName == "explorer" {
-		return visionSideChannelResult{}
+		return visionSideChannelResult{outcome: visionSideChannelSuccess}
 	}
 
 	// Use the caller's stated purpose as the vision prompt. The calling LLM
@@ -448,14 +476,23 @@ func (s *Session) describeImageCall(ctx context.Context, r tool.ExecResult) visi
 	elapsed := s.sclock().Now().Sub(start)
 	elapsed = max(elapsed, 0)
 	if err != nil {
+		outcome := visionSideChannelProviderFailure
+		if ctx.Err() != nil {
+			// Parent cancellation owns races with the side-channel deadline. This
+			// prevents a stale unavailable steering message after a canceled turn.
+			outcome = visionSideChannelParentCanceled
+		} else if errors.Is(visionCtx.Err(), context.DeadlineExceeded) {
+			outcome = visionSideChannelOwnedTimeout
+		}
 		s.emit(events.EventWarning, events.WarningData{Message: fmt.Sprintf("vision side-channel failed: %v", err)})
-		return visionSideChannelResult{}
+		return visionSideChannelResult{elapsed: elapsed, outcome: outcome, err: err}
 	}
 
 	return visionSideChannelResult{
 		description: strings.TrimSpace(resp.Message.Text()),
 		elapsed:     elapsed,
 		usage:       resp.Usage,
+		outcome:     visionSideChannelSuccess,
 	}
 }
 

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -343,9 +343,9 @@ func visionUnavailableSteering(path string) string {
 }
 
 func visionFailureSteering(path string, result visionSideChannelResult) string {
-	if result.outcome == visionSideChannelProviderFailure && result.err != nil {
+	if result.outcome == visionSideChannelProviderFailure {
 		if path == "" {
-			return fmt.Sprintf("Vision is unavailable because the vision provider failed: %v. Use OCR or inspect the source data, or continue without vision.", result.err)
+			return "Vision is unavailable because the vision provider failed. Use OCR or inspect the source data, or continue without vision."
 		}
 		return fmt.Sprintf("Vision is unavailable for %s because the vision provider failed. Use OCR or inspect the source data, or continue without vision.", strconv.Quote(path))
 	}

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -304,6 +304,12 @@ type visionSideChannelResult struct {
 	err         error
 }
 
+// describeImage makes a side-channel API call with no tools to describe an image
+// using the model's native vision. Returns the text description, or "" on error.
+func (s *Session) describeImage(ctx context.Context, r tool.ExecResult) string {
+	return s.describeImageCall(ctx, r).description
+}
+
 // visionSideChannelStats is the machine-readable accounting contract carried
 // in successful image-description steering. Token fields are present only when
 // the provider reported usage; usage_available distinguishes an unavailable
@@ -325,25 +331,6 @@ const (
 	visionSideChannelStatsClose = "</evener:vision_side_channel_stats>"
 	visionRequestContract       = "Observe the image faithfully and answer the caller's request. Vision is non-authoritative for exact text or bytes; use OCR or the source when exactness matters."
 )
-
-// describeImage makes a side-channel API call with no tools to describe an image
-// using the model's native vision. Returns the text description, or "" on error.
-// The call includes context from the current task so the description is relevant.
-func (s *Session) describeImage(ctx context.Context, r tool.ExecResult) string {
-	return s.describeImageCall(ctx, r).description
-}
-
-// describeImageSteering preserves describeImage's text contract while appending
-// machine-readable side-channel accounting to the model-facing steering
-// message. The accounting is emitted only after a non-empty response succeeds,
-// so failures cannot claim successful usage or latency.
-func (s *Session) describeImageSteering(ctx context.Context, r tool.ExecResult) string {
-	result := s.describeImageCall(ctx, r)
-	if result.description == "" {
-		return ""
-	}
-	return result.description + "\n" + formatVisionSideChannelStats(result)
-}
 
 func visionUnavailableSteering(path string) string {
 	if path == "" {

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -281,7 +281,7 @@ const (
 	visionSideChannelTimeout = 2 * time.Minute
 )
 
-var visionSideChannelTimeoutCause = errors.New("vision side-channel deadline")
+var errVisionSideChannelTimeout = errors.New("vision side-channel deadline")
 
 func (s *Session) visionSideChannelDuration() time.Duration {
 	if timeout := s.cfg.testOnly.visionSideChannelTimeout; timeout > 0 {
@@ -429,7 +429,7 @@ func (s *Session) describeImageCall(ctx context.Context, r tool.ExecResult) visi
 	s.mu.Unlock()
 
 	visionTimeout := s.visionSideChannelDuration()
-	visionCtx, cancel := context.WithTimeoutCause(ctx, visionTimeout, visionSideChannelTimeoutCause)
+	visionCtx, cancel := context.WithTimeoutCause(ctx, visionTimeout, errVisionSideChannelTimeout)
 	defer cancel()
 	req := llm.Request{
 		Model:    profile.Model(),
@@ -468,7 +468,7 @@ func (s *Session) describeImageCall(ctx context.Context, r tool.ExecResult) visi
 	if err != nil {
 		outcome := visionSideChannelProviderFailure
 		cause := context.Cause(visionCtx)
-		if errors.Is(cause, visionSideChannelTimeoutCause) {
+		if errors.Is(cause, errVisionSideChannelTimeout) {
 			outcome = visionSideChannelOwnedTimeout
 		} else if ctx.Err() != nil {
 			// Parent cancellation owns races with the side-channel deadline. This

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -478,7 +478,10 @@ func (s *Session) describeImageCall(ctx context.Context, r tool.ExecResult) visi
 			outcome = visionSideChannelOwnedTimeout
 		}
 		if outcome != visionSideChannelParentCanceled {
-			s.emit(events.EventWarning, events.WarningData{Message: fmt.Sprintf("vision side-channel failed: %v", err)})
+			// Provider errors can contain request URLs, bodies, IDs, or credentials.
+			// The user-facing steering below is deliberately sanitized, so keep the
+			// warning sanitized too rather than reintroducing the raw adapter error.
+			s.emit(events.EventWarning, events.WarningData{Message: "vision side-channel unavailable"})
 		}
 		return visionSideChannelResult{elapsed: elapsed, outcome: outcome, err: err}
 	}

--- a/agent/session_vision_effort_test.go
+++ b/agent/session_vision_effort_test.go
@@ -483,6 +483,7 @@ func TestDescribeImage_ParentCancellationDoesNotSteerUnavailable(t *testing.T) {
 	}()
 	select {
 	case <-started:
+	// TRIPWIRE: one second is far above the expected scripted adapter start signal.
 	case <-time.After(time.Second):
 		t.Fatal("vision call did not start")
 	}
@@ -492,6 +493,7 @@ func TestDescribeImage_ParentCancellationDoesNotSteerUnavailable(t *testing.T) {
 	}
 	select {
 	case <-canceled:
+	// TRIPWIRE: one second is far above the expected scripted parent cancellation signal.
 	case <-time.After(time.Second):
 		t.Fatal("vision call did not observe parent cancellation")
 	}
@@ -531,11 +533,13 @@ func TestPersistToolResults_VisionTimeoutSteersWithPathAndFallback(t *testing.T)
 	}
 	select {
 	case <-started:
+	// TRIPWIRE: one second is far above the expected scripted adapter start signal.
 	case <-time.After(time.Second):
 		t.Fatal("vision call did not start")
 	}
 	select {
 	case <-canceled:
+	// TRIPWIRE: one second is far above the expected scripted side deadline signal.
 	case <-time.After(time.Second):
 		t.Fatal("vision call did not observe its deadline")
 	}

--- a/agent/session_vision_effort_test.go
+++ b/agent/session_vision_effort_test.go
@@ -14,6 +14,7 @@ import (
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/internal/agenttest"
 	"primeradiant.com/evener/agent/internal/tool"
+	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
 )
 
@@ -584,8 +585,19 @@ func TestPersistToolResults_VisionFailureCanceledBeforeInjectionRemovesOnlyOwned
 		for range sess.Events() {
 		}
 	}()
-	sess.Steer("daemon survives")
-	sess.SteerFromUser("client survives")
+	daemon := steeringMessage{Text: "daemon survives", Images: []ImageAttachment{{MediaType: "image/png", Data: []byte("daemon-image"), Name: "daemon.png"}}, ClientMutationID: "daemon-mutation", StableTurnID: "daemon-turn", Source: "daemon-source", Kind: "daemon-kind", TaskCompletion: &events.TaskCompletionSteeringData{CompletionState: events.TaskCompletionWaitingForBlockingDelegates, BlockingDelegateIDs: []string{"delegate-daemon"}}}
+	client := steeringMessage{Text: "client survives", Images: []ImageAttachment{{MediaType: "image/jpeg", Data: []byte("client-image"), Name: "client.jpg"}}, ClientMutationID: "client-mutation", StableTurnID: "client-turn", Source: events.SteeringSourceUser, Kind: "client-kind", TaskCompletion: &events.TaskCompletionSteeringData{CompletionState: events.TaskCompletionReadyForFinalOutput, BlockingDelegateIDs: []string{"delegate-client"}}}
+	sess.mu.Lock()
+	sess.steeringQueue = append(sess.steeringQueue, daemon, client)
+	sess.mu.Unlock()
+	sess.persistQueuesSnapshot()
+	sess.mu.Lock()
+	before := append([]steeringMessage(nil), sess.steeringQueue...)
+	sess.mu.Unlock()
+	beforeJSON, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("marshal before queue: %v", err)
+	}
 	if err := sess.persistToolResults(context.Background(), []llm.ToolCallData{{ID: "c1", Name: "read_file"}}, []tool.ExecResult{{
 		CallID: "c1", ToolName: "read_file", ImageData: []byte("png"), ImageMediaType: "image/png",
 	}}); err != nil {
@@ -618,12 +630,67 @@ func TestPersistToolResults_VisionFailureCanceledBeforeInjectionRemovesOnlyOwned
 		t.Fatalf("injectPostToolSteering error = %v, want context.Canceled", err)
 	}
 	sess.mu.Lock()
-	defer sess.mu.Unlock()
 	if len(sess.visionTurnOwners) != 0 {
+		sess.mu.Unlock()
 		t.Fatalf("owners after canceled injection = %d, want 0", len(sess.visionTurnOwners))
 	}
-	if len(sess.steeringQueue) != 2 || sess.steeringQueue[0].Text != "daemon survives" || sess.steeringQueue[1].Text != "client survives" {
-		t.Fatalf("unrelated queue after canceled injection = %#v", sess.steeringQueue)
+	after := append([]steeringMessage(nil), sess.steeringQueue...)
+	sess.mu.Unlock()
+	afterJSON, err := json.Marshal(after)
+	if err != nil {
+		t.Fatalf("marshal after queue: %v", err)
+	}
+	// The owned entry is the final queue item; compare its removal without
+	// inspecting the private owner marker or weakening any public fields.
+	wantJSON, err := json.Marshal(before[:2])
+	if len(after) != 2 || err != nil || string(afterJSON) != string(wantJSON) {
+		t.Fatalf("unrelated queue fields/order changed: before=%s after=%s want=%s", beforeJSON, afterJSON, wantJSON)
+	}
+}
+
+func TestPersistToolResults_VisionFailureInjectsOnceAndDoesNotReappearNextBoundary(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	c := llm.NewClient()
+	c.Register(&immediateVisionFailureAdapter{name: "openai"})
+	sess, err := NewSession(c, NewOpenAIProfile("m"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	t.Cleanup(func() { sess.Close() })
+	go func() {
+		for range sess.Events() {
+		}
+	}()
+	if err := sess.persistToolResults(context.Background(), []llm.ToolCallData{{ID: "c1", Name: "read_file"}}, []tool.ExecResult{{CallID: "c1", ToolName: "read_file", ImageData: []byte("png"), ImageMediaType: "image/png"}}); err != nil {
+		t.Fatalf("persistToolResults: %v", err)
+	}
+	var sigs []string
+	var failed []bool
+	if _, err := sess.injectPostToolSteering(context.Background(), nil, nil, &sigs, &failed); err != nil {
+		t.Fatalf("injectPostToolSteering: %v", err)
+	}
+	sess.mu.Lock()
+	if len(sess.visionTurnOwners) != 0 || len(sess.steeringQueue) != 0 {
+		sess.mu.Unlock()
+		t.Fatalf("successful injection left queue/owners: %d/%d", len(sess.steeringQueue), len(sess.visionTurnOwners))
+	}
+	var visionTurns int
+	for _, turn := range sess.history {
+		if turn.Kind == schema.TurnSteering && strings.Contains(turn.Message.Text(), "Vision is unavailable because the vision provider failed") {
+			visionTurns++
+		}
+	}
+	sess.mu.Unlock()
+	if visionTurns != 1 {
+		t.Fatalf("vision steering turns = %d, want exactly 1", visionTurns)
+	}
+	// A later boundary must remain ordinary and must not resurrect the consumed entry.
+	sess.injectDrainedSteering()
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	if len(sess.steeringQueue) != 0 || len(sess.visionTurnOwners) != 0 {
+		t.Fatalf("subsequent boundary resurrected queue/owners: %d/%d", len(sess.steeringQueue), len(sess.visionTurnOwners))
 	}
 }
 

--- a/agent/session_vision_effort_test.go
+++ b/agent/session_vision_effort_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -643,7 +644,7 @@ func TestPersistToolResults_VisionFailureCanceledBeforeInjectionRemovesOnlyOwned
 	// The owned entry is the final queue item. Compare directly with the
 	// serialized pre-cancellation queue so in-place mutations of referenced
 	// metadata cannot make both expected and actual values change together.
-	if len(after) != 2 || string(afterJSON) != string(beforeJSON) {
+	if len(after) != 2 || !bytes.Equal(afterJSON, beforeJSON) {
 		t.Fatalf("unrelated queue fields/order changed: before=%s after=%s", beforeJSON, afterJSON)
 	}
 }

--- a/agent/session_vision_effort_test.go
+++ b/agent/session_vision_effort_test.go
@@ -382,8 +382,8 @@ func TestPersistToolResults_VisionErrorDoesNotClaimSuccessfulUsage(t *testing.T)
 	}}); err != nil {
 		t.Fatalf("persistToolResults: %v", err)
 	}
-	if steered := sess.drainSteering(); len(steered) != 0 {
-		t.Fatalf("failed vision call produced model steering: %#v", steered)
+	if steered := sess.drainSteering(); len(steered) != 1 || !strings.Contains(steered[0].Text, "vision failed") {
+		t.Fatalf("failed vision call steering = %#v, want one unavailable message", steered)
 	}
 }
 
@@ -449,8 +449,104 @@ func TestDescribeImage_CancelsTheSideChannelOnTimeout(t *testing.T) {
 	if gotErr != nil {
 		t.Fatal(gotErr)
 	}
+	if steered := sess.drainSteering(); len(steered) != 1 || !strings.Contains(steered[0].Text, "Vision is unavailable") {
+		t.Fatalf("timed-out vision call steering = %#v, want one unavailable message", steered)
+	}
+}
+
+func TestDescribeImage_ParentCancellationDoesNotSteerUnavailable(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	adapter := &contextBlockingAdapter{name: "openai", started: started, canceled: canceled}
+	c := llm.NewClient()
+	c.Register(adapter)
+	sess, err := NewSession(c, NewOpenAIProfile("m"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
+		StateDir: dir,
+		testOnly: testConfig{visionSideChannelTimeout: time.Second},
+	})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	t.Cleanup(func() { sess.Close() })
+	go func() {
+		for range sess.Events() {
+		}
+	}()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- sess.persistToolResults(ctx, []llm.ToolCallData{{ID: "c1", Name: "read_file"}}, []tool.ExecResult{{
+			CallID: "c1", ToolName: "read_file", ImageData: []byte("png"), ImageMediaType: "image/png",
+		}})
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("vision call did not start")
+	}
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("persistToolResults: %v", err)
+	}
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("vision call did not observe parent cancellation")
+	}
 	if steered := sess.drainSteering(); len(steered) != 0 {
-		t.Fatalf("timed-out vision call produced model steering: %#v", steered)
+		t.Fatalf("parent cancellation produced stale unavailable steering: %#v", steered)
+	}
+}
+
+func TestPersistToolResults_VisionTimeoutSteersWithPathAndFallback(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	adapter := &contextBlockingAdapter{name: "openai", started: started, canceled: canceled}
+	c := llm.NewClient()
+	c.Register(adapter)
+	sess, err := NewSession(c, NewOpenAIProfile("m"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
+		StateDir: dir,
+		testOnly: testConfig{visionSideChannelTimeout: 20 * time.Millisecond},
+	})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	t.Cleanup(func() { sess.Close() })
+	go func() {
+		for range sess.Events() {
+		}
+	}()
+
+	path := filepath.Join(dir, "image.png")
+	if err := sess.persistToolResults(context.Background(), []llm.ToolCallData{{
+		ID: "c1", Name: "read_file", Arguments: []byte(`{"file_path":"` + path + `"}`),
+	}}, []tool.ExecResult{{
+		CallID: "c1", ToolName: "read_file", ImageData: []byte("png"), ImageMediaType: "image/png",
+	}}); err != nil {
+		t.Fatalf("persistToolResults: %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("vision call did not start")
+	}
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("vision call did not observe its deadline")
+	}
+	steered := sess.drainSteering()
+	if len(steered) != 1 {
+		t.Fatalf("steering count = %d, want 1 (%#v)", len(steered), steered)
+	}
+	for _, want := range []string{"Vision is unavailable", path, "OCR", "source data", "continue without vision"} {
+		if !strings.Contains(steered[0].Text, want) {
+			t.Errorf("steering = %q, missing %q", steered[0].Text, want)
+		}
 	}
 }
 

--- a/agent/session_vision_effort_test.go
+++ b/agent/session_vision_effort_test.go
@@ -115,6 +115,49 @@ func TestDescribeImage_UsesLowEffortIndependentOfSession(t *testing.T) {
 	}
 }
 
+func TestDescribeImage_PreservesImageAndPDFRequestGoldens(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, media string
+		kind        llm.ContentKind
+		data        []byte
+	}{
+		{name: "image", media: "image/png", kind: llm.ContentImage, data: []byte("image-bytes")},
+		{name: "pdf", media: "application/pdf", kind: llm.ContentDocument, data: []byte("pdf-bytes")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			adapter := &fakeAdapter{name: "openai", steps: []func(req llm.Request) llm.Response{
+				func(req llm.Request) llm.Response {
+					return llm.Response{Message: llm.Assistant(visionOutputSentinel), Usage: llm.Usage{InputTokens: 2, OutputTokens: 3}}
+				},
+			}}
+			c := llm.NewClient()
+			c.Register(adapter)
+			sess, err := NewSession(c, NewOpenAIProfile("m"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+			if err != nil {
+				t.Fatalf("NewSession: %v", err)
+			}
+			t.Cleanup(func() { sess.Close() })
+			got := sess.describeImageCall(context.Background(), tool.ExecResult{ImageData: tc.data, ImageMediaType: tc.media, ImagePurpose: "golden purpose"})
+			if got.description != visionOutputSentinel || len(adapter.Requests()) != 1 {
+				t.Fatalf("result/requests = %#v/%d, want one successful attempt", got, len(adapter.Requests()))
+			}
+			part := adapter.Requests()[0].Messages[0].Content[1]
+			if part.Kind != tc.kind {
+				t.Fatalf("content kind = %q, want %q", part.Kind, tc.kind)
+			}
+			if tc.kind == llm.ContentImage {
+				if part.Image == nil || !bytes.Equal(part.Image.Data, tc.data) || part.Image.MediaType != tc.media || part.Image.Detail != "original" || part.Document != nil {
+					t.Fatalf("image content = %#v, want exact inline image golden", part)
+				}
+			} else if part.Document == nil || !bytes.Equal(part.Document.Data, tc.data) || part.Document.MediaType != tc.media || part.Document.FileName != "document.pdf" || part.Image != nil {
+				t.Fatalf("document content = %#v, want exact inline PDF golden", part)
+			}
+		})
+	}
+}
+
 func TestPersistToolResults_VisionSteeringIncludesLatencyAndUsage(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/agent/session_vision_effort_test.go
+++ b/agent/session_vision_effort_test.go
@@ -640,11 +640,11 @@ func TestPersistToolResults_VisionFailureCanceledBeforeInjectionRemovesOnlyOwned
 	if err != nil {
 		t.Fatalf("marshal after queue: %v", err)
 	}
-	// The owned entry is the final queue item; compare its removal without
-	// inspecting the private owner marker or weakening any public fields.
-	wantJSON, err := json.Marshal(before[:2])
-	if len(after) != 2 || err != nil || string(afterJSON) != string(wantJSON) {
-		t.Fatalf("unrelated queue fields/order changed: before=%s after=%s want=%s", beforeJSON, afterJSON, wantJSON)
+	// The owned entry is the final queue item. Compare directly with the
+	// serialized pre-cancellation queue so in-place mutations of referenced
+	// metadata cannot make both expected and actual values change together.
+	if len(after) != 2 || string(afterJSON) != string(beforeJSON) {
+		t.Fatalf("unrelated queue fields/order changed: before=%s after=%s", beforeJSON, afterJSON)
 	}
 }
 
@@ -665,6 +665,13 @@ func TestPersistToolResults_VisionFailureInjectsOnceAndDoesNotReappearNextBounda
 	if err := sess.persistToolResults(context.Background(), []llm.ToolCallData{{ID: "c1", Name: "read_file"}}, []tool.ExecResult{{CallID: "c1", ToolName: "read_file", ImageData: []byte("png"), ImageMediaType: "image/png"}}); err != nil {
 		t.Fatalf("persistToolResults: %v", err)
 	}
+	sess.mu.Lock()
+	if len(sess.steeringQueue) != 1 || len(sess.visionTurnOwners) != 1 {
+		sess.mu.Unlock()
+		t.Fatalf("pre-injection queue/owners = %d/%d, want 1/1", len(sess.steeringQueue), len(sess.visionTurnOwners))
+	}
+	queued := sess.steeringQueue[0]
+	sess.mu.Unlock()
 	var sigs []string
 	var failed []bool
 	if _, err := sess.injectPostToolSteering(context.Background(), nil, nil, &sigs, &failed); err != nil {
@@ -675,18 +682,27 @@ func TestPersistToolResults_VisionFailureInjectsOnceAndDoesNotReappearNextBounda
 		sess.mu.Unlock()
 		t.Fatalf("successful injection left queue/owners: %d/%d", len(sess.steeringQueue), len(sess.visionTurnOwners))
 	}
-	var visionTurns int
+	var steeringTurns []schema.Turn
 	for _, turn := range sess.history {
-		if turn.Kind == schema.TurnSteering && strings.Contains(turn.Message.Text(), "Vision is unavailable because the vision provider failed") {
-			visionTurns++
+		if turn.Kind == schema.TurnSteering {
+			steeringTurns = append(steeringTurns, turn)
 		}
 	}
 	sess.mu.Unlock()
-	if visionTurns != 1 {
-		t.Fatalf("vision steering turns = %d, want exactly 1", visionTurns)
+	if len(steeringTurns) != 1 {
+		t.Fatalf("steering turns = %d, want exactly 1", len(steeringTurns))
 	}
-	// A later boundary must remain ordinary and must not resurrect the consumed entry.
-	sess.injectDrainedSteering()
+	got := steeringTurns[0]
+	if got.Message.Text() != queued.Text || got.SteeringSource != queued.Source || got.SteeringKind != queued.Kind || got.ClientMutationID != queued.ClientMutationID || got.StableTurnID != queued.StableTurnID {
+		t.Fatalf("injected steering = text %q source %q kind %q mutation %q stable %q; want queued entry %#v", got.Message.Text(), got.SteeringSource, got.SteeringKind, got.ClientMutationID, got.StableTurnID, queued)
+	}
+	if queued.Kind != events.SteeringKindImageDescription || queued.Source != "" || queued.ClientMutationID != "" || queued.StableTurnID != "" || len(queued.Images) != 0 || queued.TaskCompletion != nil {
+		t.Fatalf("vision queue metadata = %#v, want exact daemon image-description entry", queued)
+	}
+	// A later full boundary must remain ordinary and must not resurrect the consumed entry.
+	if _, err := sess.injectPostToolSteering(context.Background(), nil, nil, &sigs, &failed); err != nil {
+		t.Fatalf("subsequent injectPostToolSteering: %v", err)
+	}
 	sess.mu.Lock()
 	defer sess.mu.Unlock()
 	if len(sess.steeringQueue) != 0 || len(sess.visionTurnOwners) != 0 {

--- a/agent/session_vision_effort_test.go
+++ b/agent/session_vision_effort_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -112,49 +111,6 @@ func TestDescribeImage_UsesLowEffortIndependentOfSession(t *testing.T) {
 	}
 	if requests[0].AdapterTimeout == nil || requests[0].AdapterTimeout.Request != visionSideChannelTimeout {
 		t.Fatalf("vision request timeout = %#v, want request=%s", requests[0].AdapterTimeout, visionSideChannelTimeout)
-	}
-}
-
-func TestDescribeImage_PreservesImageAndPDFRequestGoldens(t *testing.T) {
-	t.Parallel()
-	for _, tc := range []struct {
-		name, media string
-		kind        llm.ContentKind
-		data        []byte
-	}{
-		{name: "image", media: "image/png", kind: llm.ContentImage, data: []byte("image-bytes")},
-		{name: "pdf", media: "application/pdf", kind: llm.ContentDocument, data: []byte("pdf-bytes")},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			adapter := &fakeAdapter{name: "openai", steps: []func(req llm.Request) llm.Response{
-				func(req llm.Request) llm.Response {
-					return llm.Response{Message: llm.Assistant(visionOutputSentinel), Usage: llm.Usage{InputTokens: 2, OutputTokens: 3}}
-				},
-			}}
-			c := llm.NewClient()
-			c.Register(adapter)
-			sess, err := NewSession(c, NewOpenAIProfile("m"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
-			if err != nil {
-				t.Fatalf("NewSession: %v", err)
-			}
-			t.Cleanup(func() { sess.Close() })
-			got := sess.describeImageCall(context.Background(), tool.ExecResult{ImageData: tc.data, ImageMediaType: tc.media, ImagePurpose: "golden purpose"})
-			if got.description != visionOutputSentinel || len(adapter.Requests()) != 1 {
-				t.Fatalf("result/requests = %#v/%d, want one successful attempt", got, len(adapter.Requests()))
-			}
-			part := adapter.Requests()[0].Messages[0].Content[1]
-			if part.Kind != tc.kind {
-				t.Fatalf("content kind = %q, want %q", part.Kind, tc.kind)
-			}
-			if tc.kind == llm.ContentImage {
-				if part.Image == nil || !bytes.Equal(part.Image.Data, tc.data) || part.Image.MediaType != tc.media || part.Image.Detail != "original" || part.Document != nil {
-					t.Fatalf("image content = %#v, want exact inline image golden", part)
-				}
-			} else if part.Document == nil || !bytes.Equal(part.Document.Data, tc.data) || part.Document.MediaType != tc.media || part.Document.FileName != "document.pdf" || part.Image != nil {
-				t.Fatalf("document content = %#v, want exact inline PDF golden", part)
-			}
-		})
 	}
 }
 
@@ -388,6 +344,7 @@ func historyHasSteeringKind(sess *Session, kind string) bool {
 func TestPersistToolResults_VisionErrorDoesNotClaimSuccessfulUsage(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	const secret = "https://provider.invalid/body request-id=secret credential=secret"
 	adapter := &fakeErrAdapter{
 		name: "openai",
 		steps: []func(req llm.Request) (llm.Response, error){
@@ -396,7 +353,7 @@ func TestPersistToolResults_VisionErrorDoesNotClaimSuccessfulUsage(t *testing.T)
 				return llm.Response{
 					Message: llm.Assistant(visionOutputSentinel),
 					Usage:   llm.Usage{InputTokens: 101, OutputTokens: 13, ReasoningTokens: &reasoning},
-				}, errors.New("vision failed")
+				}, errors.New(secret)
 			},
 		},
 	}
@@ -409,11 +366,6 @@ func TestPersistToolResults_VisionErrorDoesNotClaimSuccessfulUsage(t *testing.T)
 		t.Fatalf("NewSession: %v", err)
 	}
 	t.Cleanup(func() { sess.Close() })
-	go func() {
-		for range sess.Events() {
-		}
-	}()
-
 	if err := sess.persistToolResults(context.Background(), []llm.ToolCallData{{
 		ID:        "c1",
 		Name:      "read_file",
@@ -427,47 +379,12 @@ func TestPersistToolResults_VisionErrorDoesNotClaimSuccessfulUsage(t *testing.T)
 	}}); err != nil {
 		t.Fatalf("persistToolResults: %v", err)
 	}
-	if steered := sess.drainSteering(); len(steered) != 1 || steered[0].Text != "Vision is unavailable for \"/tmp/a.png\" because the vision provider failed. Use OCR or inspect the source data, or continue without vision." {
-		t.Fatalf("failed vision call steering = %#v, want fixed sanitized message", steered)
+	steered := sess.drainSteering()
+	if len(steered) != 1 || steered[0].Kind != events.SteeringKindImageDescription {
+		t.Fatalf("failed vision call steering = %#v, want one image-description entry", steered)
 	}
-}
-
-func TestVisionFailureSteering_EmptyPathSanitizesProviderError(t *testing.T) {
-	const secret = "https://provider.invalid/body secret-request-id"
-	got := visionFailureSteering("", visionSideChannelResult{
-		outcome: visionSideChannelProviderFailure,
-		err:     errors.New(secret),
-	})
-	want := "Vision is unavailable because the vision provider failed. Use OCR or inspect the source data, or continue without vision."
-	if got != want {
-		t.Fatalf("steering = %q, want %q", got, want)
-	}
-	if strings.Contains(got, secret) {
-		t.Fatalf("steering leaked provider error: %q", got)
-	}
-}
-
-func TestDescribeImage_ProviderWarningSanitizesAdapterError(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	const secret = "https://provider.invalid/body request-id=secret credential=secret"
-	adapter := &fakeErrAdapter{
-		name: "openai",
-		steps: []func(req llm.Request) (llm.Response, error){
-			func(llm.Request) (llm.Response, error) { return llm.Response{}, errors.New(secret) },
-		},
-	}
-	c := llm.NewClient()
-	c.Register(adapter)
-	sess, err := NewSession(c, NewOpenAIProfile("m"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
-	if err != nil {
-		t.Fatalf("NewSession: %v", err)
-	}
-	t.Cleanup(func() { sess.Close() })
-
-	result := sess.describeImageCall(context.Background(), tool.ExecResult{ImageData: []byte("png"), ImageMediaType: "image/png"})
-	if result.outcome != visionSideChannelProviderFailure {
-		t.Fatalf("outcome = %v, want provider failure", result.outcome)
+	if steered[0].Text == "" || !strings.Contains(steered[0].Text, "/tmp/a.png") || strings.Contains(steered[0].Text, secret) {
+		t.Fatalf("failed vision call steering did not preserve the path or sanitize the provider error: %q", steered[0].Text)
 	}
 	for {
 		select {
@@ -479,15 +396,12 @@ func TestDescribeImage_ProviderWarningSanitizesAdapterError(t *testing.T) {
 			if !ok {
 				t.Fatalf("warning data = %T, want events.WarningData", ev.Data)
 			}
-			if warning.Message != "vision side-channel unavailable" {
-				t.Fatalf("warning = %q, want sanitized message", warning.Message)
-			}
-			if strings.Contains(warning.Message, secret) {
+			if warning.Message == "" || strings.Contains(warning.Message, secret) {
 				t.Fatalf("warning leaked adapter error: %q", warning.Message)
 			}
 			return
-		case <-time.After(time.Second):
-			t.Fatal("timed out waiting for vision warning")
+		default:
+			t.Fatal("vision failure did not emit a sanitized warning")
 		}
 	}
 }
@@ -503,23 +417,14 @@ func TestDescribeImage_CancelsTheSideChannelOnTimeout(t *testing.T) {
 		started:  started,
 		canceled: canceled,
 	}
-	c := llm.NewClient()
-	c.Register(blocking)
 	profile := NewOpenAIProfile("m").WithLiveModelInfo(llm.ModelInfo{
 		ReasoningEffortLevels: llm.ReasoningEffortVocabulary(),
 	})
-	sess, err := NewSession(c, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
+	sess := newSession(t, withAdapter(blocking), withProfile(profile), withDir(dir), withConfig(SessionConfig{
 		StateDir: dir,
 		testOnly: testConfig{visionSideChannelTimeout: 20 * time.Millisecond},
-	})
-	if err != nil {
-		t.Fatalf("NewSession: %v", err)
-	}
-	t.Cleanup(func() { sess.Close() })
-	go func() {
-		for range sess.Events() {
-		}
-	}()
+	}))
+	drainSessionEvents(sess)
 
 	done := make(chan struct{})
 	go func() {
@@ -554,8 +459,8 @@ func TestDescribeImage_CancelsTheSideChannelOnTimeout(t *testing.T) {
 	if gotErr != nil {
 		t.Fatal(gotErr)
 	}
-	if steered := sess.drainSteering(); len(steered) != 1 || !strings.Contains(steered[0].Text, "Vision is unavailable") {
-		t.Fatalf("timed-out vision call steering = %#v, want one unavailable message", steered)
+	if steered := sess.drainSteering(); len(steered) != 1 || steered[0].Kind != events.SteeringKindImageDescription || steered[0].Text == "" {
+		t.Fatalf("timed-out vision call steering = %#v, want one image-description failure entry", steered)
 	}
 }
 
@@ -565,20 +470,11 @@ func TestDescribeImage_ParentCancellationDoesNotSteerUnavailable(t *testing.T) {
 	started := make(chan struct{})
 	canceled := make(chan struct{})
 	adapter := &contextBlockingAdapter{name: "openai", started: started, canceled: canceled}
-	c := llm.NewClient()
-	c.Register(adapter)
-	sess, err := NewSession(c, NewOpenAIProfile("m"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
+	sess := newSession(t, withAdapter(adapter), withProfile(NewOpenAIProfile("m")), withDir(dir), withConfig(SessionConfig{
 		StateDir: dir,
 		testOnly: testConfig{visionSideChannelTimeout: time.Second},
-	})
-	if err != nil {
-		t.Fatalf("NewSession: %v", err)
-	}
-	t.Cleanup(func() { sess.Close() })
-	go func() {
-		for range sess.Events() {
-		}
-	}()
+	}))
+	drainSessionEvents(sess)
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
@@ -607,55 +503,38 @@ func TestDescribeImage_ParentCancellationDoesNotSteerUnavailable(t *testing.T) {
 	}
 }
 
-func TestPersistToolResults_VisionTimeoutSteersWithPathAndFallback(t *testing.T) {
+func TestPersistToolResults_ParentCancellationRemovesEarlierVisionFailure(t *testing.T) {
 	t.Parallel()
-	dir := t.TempDir()
 	started := make(chan struct{})
-	canceled := make(chan struct{})
-	adapter := &contextBlockingAdapter{name: "openai", started: started, canceled: canceled}
-	c := llm.NewClient()
-	c.Register(adapter)
-	sess, err := NewSession(c, NewOpenAIProfile("m"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
-		StateDir: dir,
-		testOnly: testConfig{visionSideChannelTimeout: 20 * time.Millisecond},
-	})
-	if err != nil {
-		t.Fatalf("NewSession: %v", err)
-	}
-	t.Cleanup(func() { sess.Close() })
+	adapter := &firstFailureThenBlockAdapter{name: "openai", started: started}
+	sess := newSession(t, withAdapter(adapter), withProfile(NewOpenAIProfile("m")))
+	drainSessionEvents(sess)
+	sess.Steer("unrelated")
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
 	go func() {
-		for range sess.Events() {
-		}
+		done <- sess.persistToolResults(ctx,
+			[]llm.ToolCallData{{ID: "c1", Name: "read_file"}, {ID: "c2", Name: "read_file"}},
+			[]tool.ExecResult{
+				{CallID: "c1", ToolName: "read_file", ImageData: []byte("first"), ImageMediaType: "image/png"},
+				{CallID: "c2", ToolName: "read_file", ImageData: []byte("second"), ImageMediaType: "image/png"},
+			},
+		)
 	}()
-
-	path := filepath.Join(dir, "image.png")
-	if err := sess.persistToolResults(context.Background(), []llm.ToolCallData{{
-		ID: "c1", Name: "read_file", Arguments: []byte(`{"file_path":"` + path + `"}`),
-	}}, []tool.ExecResult{{
-		CallID: "c1", ToolName: "read_file", ImageData: []byte("png"), ImageMediaType: "image/png",
-	}}); err != nil {
-		t.Fatalf("persistToolResults: %v", err)
-	}
 	select {
 	case <-started:
-	// TRIPWIRE: one second is far above the expected scripted adapter start signal.
+	// TRIPWIRE: the scripted second provider call closes started before waiting;
+	// this only fires if persistToolResults never reaches that call.
 	case <-time.After(time.Second):
-		t.Fatal("vision call did not start")
+		t.Fatal("second vision call did not start")
 	}
-	select {
-	case <-canceled:
-	// TRIPWIRE: one second is far above the expected scripted side deadline signal.
-	case <-time.After(time.Second):
-		t.Fatal("vision call did not observe its deadline")
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("persistToolResults error = %v, want context.Canceled", err)
 	}
-	steered := sess.drainSteering()
-	if len(steered) != 1 {
-		t.Fatalf("steering count = %d, want 1 (%#v)", len(steered), steered)
-	}
-	for _, want := range []string{"Vision is unavailable", path, "OCR", "source data", "continue without vision"} {
-		if !strings.Contains(steered[0].Text, want) {
-			t.Errorf("steering = %q, missing %q", steered[0].Text, want)
-		}
+	remaining := sess.drainSteering()
+	if len(remaining) != 1 || remaining[0].Text != "unrelated" {
+		t.Fatalf("steering after parent cancellation = %#v, want only unrelated entry", remaining)
 	}
 }
 
@@ -663,39 +542,18 @@ func TestPersistToolResults_VisionFailureCanceledBeforeInjectionRemovesOnlyOwned
 	t.Parallel()
 	dir := t.TempDir()
 	adapter := &immediateVisionFailureAdapter{name: "openai"}
-	c := llm.NewClient()
-	c.Register(adapter)
-	sess, err := NewSession(c, NewOpenAIProfile("m"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
-	if err != nil {
-		t.Fatalf("NewSession: %v", err)
-	}
-	t.Cleanup(func() { sess.Close() })
-	go func() {
-		for range sess.Events() {
-		}
-	}()
-	daemon := steeringMessage{Text: "daemon survives", Images: []ImageAttachment{{MediaType: "image/png", Data: []byte("daemon-image"), Name: "daemon.png"}}, ClientMutationID: "daemon-mutation", StableTurnID: "daemon-turn", Source: "daemon-source", Kind: "daemon-kind", TaskCompletion: &events.TaskCompletionSteeringData{CompletionState: events.TaskCompletionWaitingForBlockingDelegates, BlockingDelegateIDs: []string{"delegate-daemon"}}}
-	client := steeringMessage{Text: "client survives", Images: []ImageAttachment{{MediaType: "image/jpeg", Data: []byte("client-image"), Name: "client.jpg"}}, ClientMutationID: "client-mutation", StableTurnID: "client-turn", Source: events.SteeringSourceUser, Kind: "client-kind", TaskCompletion: &events.TaskCompletionSteeringData{CompletionState: events.TaskCompletionReadyForFinalOutput, BlockingDelegateIDs: []string{"delegate-client"}}}
-	sess.mu.Lock()
-	sess.steeringQueue = append(sess.steeringQueue, daemon, client)
-	sess.mu.Unlock()
-	sess.persistQueuesSnapshot()
-	sess.mu.Lock()
-	before := append([]steeringMessage(nil), sess.steeringQueue...)
-	sess.mu.Unlock()
-	beforeJSON, err := json.Marshal(before)
-	if err != nil {
-		t.Fatalf("marshal before queue: %v", err)
-	}
+	sess := newSession(t, withAdapter(adapter), withProfile(NewOpenAIProfile("m")), withDir(dir), withConfig(SessionConfig{StateDir: dir}))
+	drainSessionEvents(sess)
+	sess.Steer("unrelated")
 	if err := sess.persistToolResults(context.Background(), []llm.ToolCallData{{ID: "c1", Name: "read_file"}}, []tool.ExecResult{{
 		CallID: "c1", ToolName: "read_file", ImageData: []byte("png"), ImageMediaType: "image/png",
 	}}); err != nil {
 		t.Fatalf("persistToolResults: %v", err)
 	}
 	sess.mu.Lock()
-	if len(sess.visionTurnOwners) != 1 || len(sess.steeringQueue) != 3 {
+	if len(sess.visionTurnOwners) != 1 || len(sess.steeringQueue) != 2 {
 		sess.mu.Unlock()
-		t.Fatalf("published queue/owners = %d/%d, want 3/1", len(sess.steeringQueue), len(sess.visionTurnOwners))
+		t.Fatalf("published queue/owners = %d/%d, want 2/1", len(sess.steeringQueue), len(sess.visionTurnOwners))
 	}
 	sess.mu.Unlock()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -725,70 +583,25 @@ func TestPersistToolResults_VisionFailureCanceledBeforeInjectionRemovesOnlyOwned
 	}
 	after := append([]steeringMessage(nil), sess.steeringQueue...)
 	sess.mu.Unlock()
-	afterJSON, err := json.Marshal(after)
-	if err != nil {
-		t.Fatalf("marshal after queue: %v", err)
-	}
-	// The owned entry is the final queue item. Compare directly with the
-	// serialized pre-cancellation queue so in-place mutations of referenced
-	// metadata cannot make both expected and actual values change together.
-	if len(after) != 2 || !bytes.Equal(afterJSON, beforeJSON) {
-		t.Fatalf("unrelated queue fields/order changed: before=%s after=%s", beforeJSON, afterJSON)
+	if len(after) != 1 || after[0].Text != "unrelated" {
+		t.Fatalf("queue after canceled injection = %#v, want only unrelated entry", after)
 	}
 }
 
 func TestPersistToolResults_VisionFailureInjectsOnceAndDoesNotReappearNextBoundary(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	c := llm.NewClient()
-	c.Register(&immediateVisionFailureAdapter{name: "openai"})
-	sess, err := NewSession(c, NewOpenAIProfile("m"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
-	if err != nil {
-		t.Fatalf("NewSession: %v", err)
-	}
-	t.Cleanup(func() { sess.Close() })
-	go func() {
-		for range sess.Events() {
-		}
-	}()
+	sess := newSession(t, withAdapter(&immediateVisionFailureAdapter{name: "openai"}), withProfile(NewOpenAIProfile("m")), withDir(dir), withConfig(SessionConfig{StateDir: dir}))
+	drainSessionEvents(sess)
 	if err := sess.persistToolResults(context.Background(), []llm.ToolCallData{{ID: "c1", Name: "read_file"}}, []tool.ExecResult{{CallID: "c1", ToolName: "read_file", ImageData: []byte("png"), ImageMediaType: "image/png"}}); err != nil {
 		t.Fatalf("persistToolResults: %v", err)
 	}
-	sess.mu.Lock()
-	if len(sess.steeringQueue) != 1 || len(sess.visionTurnOwners) != 1 {
-		sess.mu.Unlock()
-		t.Fatalf("pre-injection queue/owners = %d/%d, want 1/1", len(sess.steeringQueue), len(sess.visionTurnOwners))
-	}
-	queued := sess.steeringQueue[0]
-	sess.mu.Unlock()
 	var sigs []string
 	var failed []bool
 	if _, err := sess.injectPostToolSteering(context.Background(), nil, nil, &sigs, &failed); err != nil {
 		t.Fatalf("injectPostToolSteering: %v", err)
 	}
-	sess.mu.Lock()
-	if len(sess.visionTurnOwners) != 0 || len(sess.steeringQueue) != 0 {
-		sess.mu.Unlock()
-		t.Fatalf("successful injection left queue/owners: %d/%d", len(sess.steeringQueue), len(sess.visionTurnOwners))
-	}
-	var steeringTurns []schema.Turn
-	for _, turn := range sess.history {
-		if turn.Kind == schema.TurnSteering {
-			steeringTurns = append(steeringTurns, turn)
-		}
-	}
-	sess.mu.Unlock()
-	if len(steeringTurns) != 1 {
-		t.Fatalf("steering turns = %d, want exactly 1", len(steeringTurns))
-	}
-	got := steeringTurns[0]
-	if got.Message.Text() != queued.Text || got.SteeringSource != queued.Source || got.SteeringKind != queued.Kind || got.ClientMutationID != queued.ClientMutationID || got.StableTurnID != queued.StableTurnID {
-		t.Fatalf("injected steering = text %q source %q kind %q mutation %q stable %q; want queued entry %#v", got.Message.Text(), got.SteeringSource, got.SteeringKind, got.ClientMutationID, got.StableTurnID, queued)
-	}
-	if queued.Kind != events.SteeringKindImageDescription || queued.Source != "" || queued.ClientMutationID != "" || queued.StableTurnID != "" || len(queued.Images) != 0 || queued.TaskCompletion != nil {
-		t.Fatalf("vision queue metadata = %#v, want exact daemon image-description entry", queued)
-	}
-	// A later full boundary must remain ordinary and must not resurrect the consumed entry.
+	// A later full boundary must not resurrect the consumed entry.
 	if _, err := sess.injectPostToolSteering(context.Background(), nil, nil, &sigs, &failed); err != nil {
 		t.Fatalf("subsequent injectPostToolSteering: %v", err)
 	}
@@ -796,6 +609,15 @@ func TestPersistToolResults_VisionFailureInjectsOnceAndDoesNotReappearNextBounda
 	defer sess.mu.Unlock()
 	if len(sess.steeringQueue) != 0 || len(sess.visionTurnOwners) != 0 {
 		t.Fatalf("subsequent boundary resurrected queue/owners: %d/%d", len(sess.steeringQueue), len(sess.visionTurnOwners))
+	}
+	var steeringTurns int
+	for _, turn := range sess.history {
+		if turn.Kind == schema.TurnSteering && turn.SteeringKind == events.SteeringKindImageDescription {
+			steeringTurns++
+		}
+	}
+	if steeringTurns != 1 {
+		t.Fatalf("image-description steering turns = %d, want exactly 1", steeringTurns)
 	}
 }
 
@@ -806,6 +628,28 @@ type contextBlockingAdapter struct {
 }
 
 type immediateVisionFailureAdapter struct{ name string }
+
+type firstFailureThenBlockAdapter struct {
+	name    string
+	started chan<- struct{}
+	calls   int
+}
+
+func (a *firstFailureThenBlockAdapter) Name() string { return a.name }
+
+func (a *firstFailureThenBlockAdapter) Complete(ctx context.Context, _ llm.Request) (llm.Response, error) {
+	if a.calls == 0 {
+		a.calls++
+		return llm.Response{}, errors.New("first vision failed")
+	}
+	close(a.started)
+	<-ctx.Done()
+	return llm.Response{}, ctx.Err()
+}
+
+func (a *firstFailureThenBlockAdapter) Stream(context.Context, llm.Request) (llm.Stream, error) {
+	return nil, errors.New("stream not used")
+}
 
 func (a *immediateVisionFailureAdapter) Name() string { return a.name }
 

--- a/agent/session_vision_effort_test.go
+++ b/agent/session_vision_effort_test.go
@@ -404,6 +404,51 @@ func TestVisionFailureSteering_EmptyPathSanitizesProviderError(t *testing.T) {
 	}
 }
 
+func TestDescribeImage_ProviderWarningSanitizesAdapterError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	const secret = "https://provider.invalid/body request-id=secret credential=secret"
+	adapter := &fakeErrAdapter{
+		name: "openai",
+		steps: []func(req llm.Request) (llm.Response, error){
+			func(llm.Request) (llm.Response, error) { return llm.Response{}, errors.New(secret) },
+		},
+	}
+	c := llm.NewClient()
+	c.Register(adapter)
+	sess, err := NewSession(c, NewOpenAIProfile("m"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	t.Cleanup(func() { sess.Close() })
+
+	result := sess.describeImageCall(context.Background(), tool.ExecResult{ImageData: []byte("png"), ImageMediaType: "image/png"})
+	if result.outcome != visionSideChannelProviderFailure {
+		t.Fatalf("outcome = %v, want provider failure", result.outcome)
+	}
+	for {
+		select {
+		case ev := <-sess.Events():
+			if ev.Kind != events.EventWarning {
+				continue
+			}
+			warning, ok := ev.Data.(events.WarningData)
+			if !ok {
+				t.Fatalf("warning data = %T, want events.WarningData", ev.Data)
+			}
+			if warning.Message != "vision side-channel unavailable" {
+				t.Fatalf("warning = %q, want sanitized message", warning.Message)
+			}
+			if strings.Contains(warning.Message, secret) {
+				t.Fatalf("warning leaked adapter error: %q", warning.Message)
+			}
+			return
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for vision warning")
+		}
+	}
+}
+
 func TestDescribeImage_CancelsTheSideChannelOnTimeout(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/agent/session_vision_effort_test.go
+++ b/agent/session_vision_effort_test.go
@@ -387,6 +387,21 @@ func TestPersistToolResults_VisionErrorDoesNotClaimSuccessfulUsage(t *testing.T)
 	}
 }
 
+func TestVisionFailureSteering_EmptyPathSanitizesProviderError(t *testing.T) {
+	const secret = "https://provider.invalid/body secret-request-id"
+	got := visionFailureSteering("", visionSideChannelResult{
+		outcome: visionSideChannelProviderFailure,
+		err:     errors.New(secret),
+	})
+	want := "Vision is unavailable because the vision provider failed. Use OCR or inspect the source data, or continue without vision."
+	if got != want {
+		t.Fatalf("steering = %q, want %q", got, want)
+	}
+	if strings.Contains(got, secret) {
+		t.Fatalf("steering leaked provider error: %q", got)
+	}
+}
+
 func TestDescribeImage_CancelsTheSideChannelOnTimeout(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/agent/session_vision_effort_test.go
+++ b/agent/session_vision_effort_test.go
@@ -382,8 +382,8 @@ func TestPersistToolResults_VisionErrorDoesNotClaimSuccessfulUsage(t *testing.T)
 	}}); err != nil {
 		t.Fatalf("persistToolResults: %v", err)
 	}
-	if steered := sess.drainSteering(); len(steered) != 1 || !strings.Contains(steered[0].Text, "vision failed") {
-		t.Fatalf("failed vision call steering = %#v, want one unavailable message", steered)
+	if steered := sess.drainSteering(); len(steered) != 1 || steered[0].Text != "Vision is unavailable for \"/tmp/a.png\" because the vision provider failed. Use OCR or inspect the source data, or continue without vision." {
+		t.Fatalf("failed vision call steering = %#v, want fixed sanitized message", steered)
 	}
 }
 
@@ -488,8 +488,8 @@ func TestDescribeImage_ParentCancellationDoesNotSteerUnavailable(t *testing.T) {
 		t.Fatal("vision call did not start")
 	}
 	cancel()
-	if err := <-done; err != nil {
-		t.Fatalf("persistToolResults: %v", err)
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("persistToolResults error = %v, want context.Canceled", err)
 	}
 	select {
 	case <-canceled:

--- a/agent/session_vision_effort_test.go
+++ b/agent/session_vision_effort_test.go
@@ -569,10 +569,80 @@ func TestPersistToolResults_VisionTimeoutSteersWithPathAndFallback(t *testing.T)
 	}
 }
 
+func TestPersistToolResults_VisionFailureCanceledBeforeInjectionRemovesOnlyOwnedSteering(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	adapter := &immediateVisionFailureAdapter{name: "openai"}
+	c := llm.NewClient()
+	c.Register(adapter)
+	sess, err := NewSession(c, NewOpenAIProfile("m"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	t.Cleanup(func() { sess.Close() })
+	go func() {
+		for range sess.Events() {
+		}
+	}()
+	sess.Steer("daemon survives")
+	sess.SteerFromUser("client survives")
+	if err := sess.persistToolResults(context.Background(), []llm.ToolCallData{{ID: "c1", Name: "read_file"}}, []tool.ExecResult{{
+		CallID: "c1", ToolName: "read_file", ImageData: []byte("png"), ImageMediaType: "image/png",
+	}}); err != nil {
+		t.Fatalf("persistToolResults: %v", err)
+	}
+	sess.mu.Lock()
+	if len(sess.visionTurnOwners) != 1 || len(sess.steeringQueue) != 3 {
+		sess.mu.Unlock()
+		t.Fatalf("published queue/owners = %d/%d, want 3/1", len(sess.steeringQueue), len(sess.visionTurnOwners))
+	}
+	sess.mu.Unlock()
+	ctx, cancel := context.WithCancel(context.Background())
+	hookEntered := make(chan struct{})
+	releaseHook := make(chan struct{})
+	ctx = context.WithValue(ctx, sessionToolRoundHooksKey{}, sessionToolRoundHooks{beforeSteering: func() {
+		close(hookEntered)
+		<-releaseHook
+	}})
+	var sigs []string
+	var failed []bool
+	done := make(chan error, 1)
+	go func() {
+		_, err := sess.injectPostToolSteering(ctx, nil, nil, &sigs, &failed)
+		done <- err
+	}()
+	<-hookEntered
+	cancel()
+	close(releaseHook)
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("injectPostToolSteering error = %v, want context.Canceled", err)
+	}
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	if len(sess.visionTurnOwners) != 0 {
+		t.Fatalf("owners after canceled injection = %d, want 0", len(sess.visionTurnOwners))
+	}
+	if len(sess.steeringQueue) != 2 || sess.steeringQueue[0].Text != "daemon survives" || sess.steeringQueue[1].Text != "client survives" {
+		t.Fatalf("unrelated queue after canceled injection = %#v", sess.steeringQueue)
+	}
+}
+
 type contextBlockingAdapter struct {
 	name     string
 	started  chan<- struct{}
 	canceled chan<- struct{}
+}
+
+type immediateVisionFailureAdapter struct{ name string }
+
+func (a *immediateVisionFailureAdapter) Name() string { return a.name }
+
+func (a *immediateVisionFailureAdapter) Complete(context.Context, llm.Request) (llm.Response, error) {
+	return llm.Response{}, errors.New("provider secret sentinel")
+}
+
+func (a *immediateVisionFailureAdapter) Stream(context.Context, llm.Request) (llm.Stream, error) {
+	return nil, errors.New("stream not used")
 }
 
 func (a *contextBlockingAdapter) Name() string { return a.name }


### PR DESCRIPTION
## Summary
- preserve typed vision side-channel outcomes
- surface side-channel timeout and provider failure to the model with file path and fallback guidance
- suppress stale steering on parent cancellation while preserving successful image/PDF behavior

Fixes #298