### PR TITLE
test: repair interrupt terminalization oracle

### DIFF
--- a/cmd/evener/serve_delegate_send_interrupt_test.go
+++ b/cmd/evener/serve_delegate_send_interrupt_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -31,6 +32,53 @@ const (
 )
 
 var waiterInterruptDelegateID = regexp.MustCompile(`dlg_[A-Za-z0-9_-]+`)
+
+type waiterMemoryAddr struct{}
+
+func (waiterMemoryAddr) Network() string { return "tcp" }
+func (waiterMemoryAddr) String() string  { return "waiter.test:80" }
+
+type waiterMemoryListener struct {
+	connections chan net.Conn
+	closed      chan struct{}
+	once        sync.Once
+}
+
+func newWaiterMemoryListener() *waiterMemoryListener {
+	return &waiterMemoryListener{connections: make(chan net.Conn), closed: make(chan struct{})}
+}
+
+func (l *waiterMemoryListener) Accept() (net.Conn, error) {
+	select {
+	case conn := <-l.connections:
+		return conn, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *waiterMemoryListener) Close() error {
+	l.once.Do(func() { close(l.closed) })
+	return nil
+}
+
+func (l *waiterMemoryListener) Addr() net.Addr { return waiterMemoryAddr{} }
+
+func (l *waiterMemoryListener) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
+	client, server := net.Pipe()
+	select {
+	case l.connections <- server:
+		return client, nil
+	case <-ctx.Done():
+		_ = client.Close()
+		_ = server.Close()
+		return nil, ctx.Err()
+	case <-l.closed:
+		_ = client.Close()
+		_ = server.Close()
+		return nil, net.ErrClosed
+	}
+}
 
 type waiterInterruptAdapter struct {
 	initialTerminal    chan struct{}
@@ -122,9 +170,30 @@ func (a *waiterInterruptAdapter) Stream(context.Context, llm.Request) (llm.Strea
 
 type waiterInterruptServer struct {
 	*server.Server
-	notification chan struct{}
-	armed        atomic.Bool
-	once         sync.Once
+	notification           chan struct{}
+	armed                  atomic.Bool
+	processingBarrierArmed atomic.Bool
+	processingFalseEntered chan struct{}
+	releaseProcessingFalse chan struct{}
+	processingBarrierOnce  sync.Once
+	processingReleaseOnce  sync.Once
+	once                   sync.Once
+}
+
+func (s *waiterInterruptServer) SetProcessing(processing bool) {
+	s.Server.SetProcessing(processing)
+	if !processing && s.processingBarrierArmed.Load() {
+		s.processingBarrierOnce.Do(func() { close(s.processingFalseEntered) })
+		<-s.releaseProcessingFalse
+	}
+}
+
+func (s *waiterInterruptServer) armProcessingBarrier() {
+	s.processingBarrierArmed.Store(true)
+}
+
+func (s *waiterInterruptServer) releaseProcessingBarrier() {
+	s.processingReleaseOnce.Do(func() { close(s.releaseProcessingFalse) })
 }
 
 func (s *waiterInterruptServer) SubmitNotification() {
@@ -135,16 +204,20 @@ func (s *waiterInterruptServer) SubmitNotification() {
 }
 
 type waiterInterruptDaemon struct {
-	adapter          *waiterInterruptAdapter
-	client           *appwire.Client
-	ctx              context.Context
-	ref              string
-	terminalClaimed  chan struct{}
-	positiveWaitSeen chan struct{}
-	turnEnded        chan struct{}
-	server           *waiterInterruptServer
-	stateDir         string
-	sessionID        string
+	adapter             *waiterInterruptAdapter
+	client              *appwire.Client
+	ctx                 context.Context
+	ref                 string
+	terminalClaimed     chan struct{}
+	positiveWaitSeen    chan struct{}
+	turnEnded           chan struct{}
+	sessionEndEntered   chan struct{}
+	releaseSessionEnd   chan struct{}
+	sessionEndProjected chan struct{}
+	releaseOnce         sync.Once
+	server              *waiterInterruptServer
+	stateDir            string
+	sessionID           string
 }
 
 func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
@@ -153,7 +226,12 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 	positiveWaitSeen := make(chan struct{})
 	terminalClaimed := make(chan struct{})
 	turnEnded := make(chan struct{})
+	sessionEndEntered := make(chan struct{})
+	releaseSessionEnd := make(chan struct{})
+	sessionEndProjected := make(chan struct{})
 	var turnEndedOnce sync.Once
+	var sessionEndEnteredOnce sync.Once
+	var sessionEndProjectedOnce sync.Once
 	var positiveWaitOnce sync.Once
 	var initialTerminalOnce sync.Once
 	var terminalOnce sync.Once
@@ -162,6 +240,8 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 	secondGenerationRunning := false
 
 	deps := defaultServeDeps()
+	memoryListener := newWaiterMemoryListener()
+	deps.listen = func(context.Context, string, string) (net.Listener, error) { return memoryListener, nil }
 	deps.ensureConfigDirs = func() error { return nil }
 	deps.seedMarketplaces = func() error { return nil }
 	deps.newClient = func(string, io.Writer) (*llm.Client, providercfg.Config, bool, func() error, error) {
@@ -186,12 +266,24 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 	var waiterServer *waiterInterruptServer
 	deps.newServer = func(cfg server.ServerConfig) serveServer {
 		observedServer = server.NewServer(cfg)
-		waiterServer = &waiterInterruptServer{Server: observedServer, notification: make(chan struct{})}
+		waiterServer = &waiterInterruptServer{
+			Server:                 observedServer,
+			notification:           make(chan struct{}),
+			processingFalseEntered: make(chan struct{}),
+			releaseProcessingFalse: make(chan struct{}),
+		}
 		return waiterServer
 	}
 	deps.bridge = func(_ serveServer, session *agent.Session, observer func(events.SessionEvent), onDrained func()) {
 		session.ConsumeEventsLossless(func(event events.SessionEvent) {
+			if data, ok := event.Data.(events.SessionEndData); ok && data.Interrupted {
+				sessionEndEnteredOnce.Do(func() { close(sessionEndEntered) })
+				<-releaseSessionEnd
+			}
 			server.BridgeEvent(observedServer, event, observer)
+			if data, ok := event.Data.(events.SessionEndData); ok && data.Interrupted {
+				sessionEndProjectedOnce.Do(func() { close(sessionEndProjected) })
+			}
 			switch event.Kind {
 			case events.EventToolCallStart:
 				if data, ok := event.Data.(events.ToolCallStartData); ok && data.ToolName == "delegate_send" {
@@ -224,18 +316,20 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 	stateDir := t.TempDir()
 	done := make(chan error, 1)
 	go func() {
-		done <- runServeWithDeps([]string{
+		runErr := runServeWithDeps([]string{
 			"--model", "openai/gpt-test",
 			"--addr", "127.0.0.1:0",
 			"--dir", t.TempDir(),
 			"--state-dir", stateDir,
 			"--run-dir", runDir,
 		}, deps)
+		done <- runErr
 	}()
 
 	entry := waitForServeTestRendezvous(t, runDir)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	transport, err := appwire.DialWebSocket(ctx, "ws://"+entry.Address+"/rpc", http.DefaultClient)
+	httpClient := &http.Client{Transport: &http.Transport{DialContext: memoryListener.DialContext}}
+	transport, err := appwire.DialWebSocket(ctx, "ws://"+entry.Address+"/rpc", httpClient)
 	if err != nil {
 		cancel()
 		t.Fatalf("DialWebSocket: %v", err)
@@ -254,7 +348,7 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 		if liveSession != nil {
 			liveSession.Close()
 		}
-		shutdownResp, shutdownErr := http.Post("http://"+entry.Address+"/shutdown", "", nil)
+		shutdownResp, shutdownErr := httpClient.Post("http://"+entry.Address+"/shutdown", "", nil)
 		if shutdownErr == nil {
 			shutdownResp.Body.Close()
 		}
@@ -269,17 +363,24 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 		cancel()
 	})
 	return &waiterInterruptDaemon{
-		adapter:          adapter,
-		client:           client,
-		ctx:              ctx,
-		ref:              appwire.Ref{SourceID: "local", ThreadID: entry.SessionID}.String(),
-		terminalClaimed:  terminalClaimed,
-		positiveWaitSeen: positiveWaitSeen,
-		turnEnded:        turnEnded,
-		server:           waiterServer,
-		stateDir:         stateDir,
-		sessionID:        entry.SessionID,
+		adapter:             adapter,
+		client:              client,
+		ctx:                 ctx,
+		ref:                 appwire.Ref{SourceID: "local", ThreadID: entry.SessionID}.String(),
+		terminalClaimed:     terminalClaimed,
+		positiveWaitSeen:    positiveWaitSeen,
+		turnEnded:           turnEnded,
+		sessionEndEntered:   sessionEndEntered,
+		releaseSessionEnd:   releaseSessionEnd,
+		sessionEndProjected: sessionEndProjected,
+		server:              waiterServer,
+		stateDir:            stateDir,
+		sessionID:           entry.SessionID,
 	}
+}
+
+func (d *waiterInterruptDaemon) releaseInterruptedSessionEnd() {
+	d.releaseOnce.Do(func() { close(d.releaseSessionEnd) })
 }
 
 type waiterInterruptMutationSnapshot struct {
@@ -314,8 +415,17 @@ func awaitWaiterInterruptSignal(ctx context.Context, t *testing.T, signal <-chan
 	}
 }
 
+func waiterInterruptTurnStatuses(turns []appwire.Turn) []string {
+	statuses := make([]string, 0, len(turns))
+	for _, turn := range turns {
+		statuses = append(statuses, turn.ID+"="+string(turn.Status))
+	}
+	return statuses
+}
+
 func TestRunServeInterruptSettlesClaimedPositiveWaitDelegateSend(t *testing.T) {
 	daemon := startWaiterInterruptDaemon(t)
+	defer daemon.releaseInterruptedSessionEnd()
 	started, err := daemon.client.TurnStart(daemon.ctx, appwire.TurnStartParams{
 		ClientMutationID: "waiter-interrupt-turn",
 		Ref:              daemon.ref,
@@ -343,9 +453,26 @@ func TestRunServeInterruptSettlesClaimedPositiveWaitDelegateSend(t *testing.T) {
 	interruptCtx, cancelInterrupt := context.WithTimeout(daemon.ctx, 3*time.Second)
 	defer cancelInterrupt()
 	interrupt := appwire.TurnInterruptParams{ClientMutationID: "stop-claimed-waiter", Ref: daemon.ref}
-	if err := daemon.client.TurnInterrupt(interruptCtx, interrupt); err != nil {
-		t.Fatalf("TurnInterrupt did not settle the claimed inline waiter and runner: %v", err)
+	daemon.server.armProcessingBarrier()
+	defer daemon.server.releaseProcessingBarrier()
+	interruptResult := make(chan error, 1)
+	go func() { interruptResult <- daemon.client.TurnInterrupt(interruptCtx, interrupt) }()
+	awaitWaiterInterruptSignal(daemon.ctx, t, daemon.server.processingFalseEntered, "runner SetProcessing(false) barrier")
+	select {
+	case err := <-interruptResult:
+		t.Fatalf("TurnInterrupt returned before runnerDone barrier release: %v", err)
+	default:
 	}
+	daemon.server.releaseProcessingBarrier()
+	select {
+	case err := <-interruptResult:
+		if err != nil {
+			t.Fatalf("TurnInterrupt did not settle the claimed inline waiter and runner: %v", err)
+		}
+	case <-interruptCtx.Done():
+		t.Fatalf("TurnInterrupt did not return after runnerDone barrier release: %v", interruptCtx.Err())
+	}
+	awaitWaiterInterruptSignal(daemon.ctx, t, daemon.sessionEndEntered, "interrupted SESSION_END bridge entry")
 	select {
 	case <-daemon.turnEnded:
 	default:
@@ -361,9 +488,32 @@ func TestRunServeInterruptSettlesClaimedPositiveWaitDelegateSend(t *testing.T) {
 			terminal = turn.Status == "interrupted"
 		}
 	}
-	if !terminal {
-		t.Fatalf("turn %q was not terminalized as interrupted: %#v", started.Turn.ID, turns.Data)
+	if terminal {
+		t.Fatalf("turn %q terminalized before its SESSION_END projection was released: %#v", started.Turn.ID, turns.Data)
 	}
+	stoppedBeforeProjection := daemon.mutationSnapshot(t)
+	interruptBeforeProjection := stoppedBeforeProjection.Journal[interrupt.ClientMutationID]
+	t.Logf("before SESSION_END projection: turns=%v interrupt=%#v fence=%s", waiterInterruptTurnStatuses(turns.Data), interruptBeforeProjection, stoppedBeforeProjection.InterruptFence)
+	if len(stoppedBeforeProjection.InterruptFence) != 0 || interruptBeforeProjection.OperationState != "terminal" ||
+		interruptBeforeProjection.ExecutionState != "interrupted" {
+		t.Fatalf("interrupt was not durably terminal before projection: %#v", stoppedBeforeProjection)
+	}
+	daemon.releaseInterruptedSessionEnd()
+	awaitWaiterInterruptSignal(daemon.ctx, t, daemon.sessionEndProjected, "interrupted SESSION_END projection")
+	turns, err = daemon.client.ThreadTurnsList(daemon.ctx, appwire.ThreadTurnsListParams{Ref: daemon.ref})
+	if err != nil {
+		t.Fatalf("ThreadTurnsList after SESSION_END projection: %v", err)
+	}
+	terminal = false
+	for _, turn := range turns.Data {
+		if turn.ID == started.Turn.ID {
+			terminal = turn.Status == "interrupted"
+		}
+	}
+	if !terminal {
+		t.Fatalf("turn %q was not terminalized after SESSION_END projection: %#v", started.Turn.ID, turns.Data)
+	}
+	t.Logf("after SESSION_END projection: turns=%v", waiterInterruptTurnStatuses(turns.Data))
 	if err := daemon.client.TurnInterrupt(daemon.ctx, interrupt); err != nil {
 		t.Fatalf("replay terminal interrupt: %v", err)
 	}

--- a/cmd/evener/serve_delegate_send_interrupt_test.go
+++ b/cmd/evener/serve_delegate_send_interrupt_test.go
@@ -418,7 +418,7 @@ func awaitWaiterInterruptSignal(ctx context.Context, t *testing.T, signal <-chan
 func waiterInterruptTurnStatuses(turns []appwire.Turn) []string {
 	statuses := make([]string, 0, len(turns))
 	for _, turn := range turns {
-		statuses = append(statuses, turn.ID+"="+string(turn.Status))
+		statuses = append(statuses, turn.ID+"="+turn.Status)
 	}
 	return statuses
 }

--- a/cmd/evener/serve_delegate_send_interrupt_test.go
+++ b/cmd/evener/serve_delegate_send_interrupt_test.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -33,94 +31,6 @@ const (
 )
 
 var waiterInterruptDelegateID = regexp.MustCompile(`dlg_[A-Za-z0-9_-]+`)
-
-type waiterInterruptWriteObserverListener struct {
-	net.Listener
-	observe func([]byte)
-}
-
-func (l *waiterInterruptWriteObserverListener) Accept() (net.Conn, error) {
-	conn, err := l.Listener.Accept()
-	if err != nil {
-		return nil, err
-	}
-	return &waiterInterruptWriteObserverConn{Conn: conn, observe: l.observe}, nil
-}
-
-type waiterInterruptWriteObserverConn struct {
-	net.Conn
-	mu       sync.Mutex
-	buffer   []byte
-	upgraded bool
-	observe  func([]byte)
-}
-
-func (c *waiterInterruptWriteObserverConn) Write(p []byte) (int, error) {
-	n, err := c.Conn.Write(p)
-	if n == 0 {
-		return n, err
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.buffer = append(c.buffer, p[:n]...)
-	if !c.upgraded {
-		const handshakeEnd = "\r\n\r\n"
-		end := bytes.Index(c.buffer, []byte(handshakeEnd))
-		if end < 0 {
-			return n, err
-		}
-		c.buffer = c.buffer[end+len(handshakeEnd):]
-		c.upgraded = true
-	}
-	for {
-		payload, ok := waiterInterruptNextWebSocketPayload(&c.buffer)
-		if !ok {
-			break
-		}
-		c.observe(payload)
-	}
-	return n, err
-}
-
-func waiterInterruptNextWebSocketPayload(buffer *[]byte) ([]byte, bool) {
-	b := *buffer
-	if len(b) < 2 || b[0]&0x70 != 0 || b[0]&0x0f != 1 {
-		if len(b) > 0 {
-			*buffer = b[1:]
-		}
-		return nil, len(b) > 0
-	}
-	if b[1]&0x80 != 0 {
-		*buffer = b[1:]
-		return nil, true
-	}
-	length := int(b[1] & 0x7f)
-	header := 2
-	switch length {
-	case 126:
-		if len(b) < 4 {
-			return nil, false
-		}
-		length = int(b[2])<<8 | int(b[3])
-		header = 4
-	case 127:
-		if len(b) < 10 {
-			return nil, false
-		}
-		if b[2] != 0 || b[3] != 0 || b[4] != 0 || b[5] != 0 {
-			*buffer = b[1:]
-			return nil, true
-		}
-		length = int(b[6])<<24 | int(b[7])<<16 | int(b[8])<<8 | int(b[9])
-		header = 10
-	}
-	if len(b) < header+length {
-		return nil, false
-	}
-	payload := append([]byte(nil), b[header:header+length]...)
-	*buffer = b[header+length:]
-	return payload, true
-}
 
 type waiterInterruptAdapter struct {
 	initialTerminal    chan struct{}
@@ -246,24 +156,24 @@ func (s *waiterInterruptServer) SubmitNotification() {
 }
 
 type waiterInterruptDaemon struct {
-	adapter                *waiterInterruptAdapter
-	client                 *appwire.Client
-	ctx                    context.Context
-	ref                    string
-	terminalClaimed        chan struct{}
-	positiveWaitSeen       chan struct{}
-	turnEnded              chan struct{}
-	sessionEndEntered      chan struct{}
-	releaseSessionEnd      chan struct{}
-	sessionEndProjected    chan struct{}
-	releaseOnce            sync.Once
-	server                 *waiterInterruptServer
-	stateDir               string
-	sessionID              string
-	interruptResponseID    *atomic.Value
-	interruptResponse      chan struct{}
-	processingReleased     *atomic.Bool
-	earlyInterruptResponse *atomic.Bool
+	adapter             *waiterInterruptAdapter
+	client              *appwire.Client
+	ctx                 context.Context
+	ref                 string
+	terminalClaimed     chan struct{}
+	positiveWaitSeen    chan struct{}
+	turnEnded           chan struct{}
+	sessionEndEntered   chan struct{}
+	releaseSessionEnd   chan struct{}
+	sessionEndProjected chan struct{}
+	releaseOnce         sync.Once
+	server              *waiterInterruptServer
+	stateDir            string
+	sessionID           string
+	interruptResponseID *atomic.Value
+	interruptResponse   chan struct{}
+	processingReleased  *atomic.Bool
+	earlyInterruptFrame *atomic.Bool
 }
 
 func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
@@ -273,7 +183,7 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 	interruptResponseCompleted := make(chan struct{})
 	var interruptResponseOnce sync.Once
 	var processingReleased atomic.Bool
-	var earlyInterruptResponse atomic.Bool
+	var earlyInterruptFrame atomic.Bool
 	positiveWaitSeen := make(chan struct{})
 	terminalClaimed := make(chan struct{})
 	turnEnded := make(chan struct{})
@@ -291,27 +201,6 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 	secondGenerationRunning := false
 
 	deps := defaultServeDeps()
-	listen := deps.listen
-	deps.listen = func(ctx context.Context, network, addr string) (net.Listener, error) {
-		listener, err := listen(ctx, network, addr)
-		if err != nil {
-			return nil, err
-		}
-		return &waiterInterruptWriteObserverListener{Listener: listener, observe: func(payload []byte) {
-			var message appwire.Message
-			if err := json.Unmarshal(payload, &message); err != nil || message.Kind() != appwire.MessageResponse {
-				return
-			}
-			id, _ := interruptResponseID.Load().(string)
-			if id == "" || message.IDString() != id {
-				return
-			}
-			if !processingReleased.Load() {
-				earlyInterruptResponse.Store(true)
-			}
-			interruptResponseOnce.Do(func() { close(interruptResponseCompleted) })
-		}}, nil
-	}
 	deps.ensureConfigDirs = func() error { return nil }
 	deps.seedMarketplaces = func() error { return nil }
 	deps.newClient = func(string, io.Writer) (*llm.Client, providercfg.Config, bool, func() error, error) {
@@ -408,6 +297,21 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 		t.Fatalf("DialWebSocket: %v", err)
 	}
 	client := appwire.NewClient(transport)
+	// The ordered handler observes the response frame before the client wakes
+	// the matching RPC, without duplicating the WebSocket framing layer.
+	client.SetOrderedFrameHandler(func(message appwire.Message, err error) {
+		if err != nil || message.Kind() != appwire.MessageResponse {
+			return
+		}
+		id, _ := interruptResponseID.Load().(string)
+		if id == "" || message.IDString() != id {
+			return
+		}
+		if !processingReleased.Load() {
+			earlyInterruptFrame.Store(true)
+		}
+		interruptResponseOnce.Do(func() { close(interruptResponseCompleted) })
+	})
 	client.Start(context.WithoutCancel(ctx))
 	if _, err := client.Initialize(ctx, appwire.InitializeParams{
 		ClientInfo: appwire.ClientInfo{Name: "waiter-interrupt-test", Version: "test"},
@@ -445,23 +349,23 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 		cancel()
 	})
 	return &waiterInterruptDaemon{
-		adapter:                adapter,
-		client:                 client,
-		ctx:                    ctx,
-		ref:                    appwire.Ref{SourceID: "local", ThreadID: entry.SessionID}.String(),
-		terminalClaimed:        terminalClaimed,
-		positiveWaitSeen:       positiveWaitSeen,
-		turnEnded:              turnEnded,
-		sessionEndEntered:      sessionEndEntered,
-		releaseSessionEnd:      releaseSessionEnd,
-		sessionEndProjected:    sessionEndProjected,
-		server:                 waiterServer,
-		stateDir:               stateDir,
-		sessionID:              entry.SessionID,
-		interruptResponseID:    &interruptResponseID,
-		interruptResponse:      interruptResponseCompleted,
-		processingReleased:     &processingReleased,
-		earlyInterruptResponse: &earlyInterruptResponse,
+		adapter:             adapter,
+		client:              client,
+		ctx:                 ctx,
+		ref:                 appwire.Ref{SourceID: "local", ThreadID: entry.SessionID}.String(),
+		terminalClaimed:     terminalClaimed,
+		positiveWaitSeen:    positiveWaitSeen,
+		turnEnded:           turnEnded,
+		sessionEndEntered:   sessionEndEntered,
+		releaseSessionEnd:   releaseSessionEnd,
+		sessionEndProjected: sessionEndProjected,
+		server:              waiterServer,
+		stateDir:            stateDir,
+		sessionID:           entry.SessionID,
+		interruptResponseID: &interruptResponseID,
+		interruptResponse:   interruptResponseCompleted,
+		processingReleased:  &processingReleased,
+		earlyInterruptFrame: &earlyInterruptFrame,
 	}
 }
 
@@ -561,8 +465,8 @@ func TestRunServeInterruptSettlesClaimedPositiveWaitDelegateSend(t *testing.T) {
 	case <-interruptCtx.Done():
 		t.Fatalf("TurnInterrupt response did not complete after runnerDone barrier release: %v", interruptCtx.Err())
 	}
-	if daemon.earlyInterruptResponse.Load() {
-		t.Fatal("TurnInterrupt response write completed before processing release")
+	if daemon.earlyInterruptFrame.Load() {
+		t.Fatal("TurnInterrupt response completed before runnerDone barrier release")
 	}
 	select {
 	case err := <-interruptResult:

--- a/cmd/evener/serve_delegate_send_interrupt_test.go
+++ b/cmd/evener/serve_delegate_send_interrupt_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -31,6 +33,94 @@ const (
 )
 
 var waiterInterruptDelegateID = regexp.MustCompile(`dlg_[A-Za-z0-9_-]+`)
+
+type waiterInterruptWriteObserverListener struct {
+	net.Listener
+	observe func([]byte)
+}
+
+func (l *waiterInterruptWriteObserverListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	return &waiterInterruptWriteObserverConn{Conn: conn, observe: l.observe}, nil
+}
+
+type waiterInterruptWriteObserverConn struct {
+	net.Conn
+	mu       sync.Mutex
+	buffer   []byte
+	upgraded bool
+	observe  func([]byte)
+}
+
+func (c *waiterInterruptWriteObserverConn) Write(p []byte) (int, error) {
+	n, err := c.Conn.Write(p)
+	if n == 0 {
+		return n, err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.buffer = append(c.buffer, p[:n]...)
+	if !c.upgraded {
+		const handshakeEnd = "\r\n\r\n"
+		end := bytes.Index(c.buffer, []byte(handshakeEnd))
+		if end < 0 {
+			return n, err
+		}
+		c.buffer = c.buffer[end+len(handshakeEnd):]
+		c.upgraded = true
+	}
+	for {
+		payload, ok := waiterInterruptNextWebSocketPayload(&c.buffer)
+		if !ok {
+			break
+		}
+		c.observe(payload)
+	}
+	return n, err
+}
+
+func waiterInterruptNextWebSocketPayload(buffer *[]byte) ([]byte, bool) {
+	b := *buffer
+	if len(b) < 2 || b[0]&0x70 != 0 || b[0]&0x0f != 1 {
+		if len(b) > 0 {
+			*buffer = b[1:]
+		}
+		return nil, len(b) > 0
+	}
+	if b[1]&0x80 != 0 {
+		*buffer = b[1:]
+		return nil, true
+	}
+	length := int(b[1] & 0x7f)
+	header := 2
+	switch length {
+	case 126:
+		if len(b) < 4 {
+			return nil, false
+		}
+		length = int(b[2])<<8 | int(b[3])
+		header = 4
+	case 127:
+		if len(b) < 10 {
+			return nil, false
+		}
+		if b[2] != 0 || b[3] != 0 || b[4] != 0 || b[5] != 0 {
+			*buffer = b[1:]
+			return nil, true
+		}
+		length = int(b[6])<<24 | int(b[7])<<16 | int(b[8])<<8 | int(b[9])
+		header = 10
+	}
+	if len(b) < header+length {
+		return nil, false
+	}
+	payload := append([]byte(nil), b[header:header+length]...)
+	*buffer = b[header+length:]
+	return payload, true
+}
 
 type waiterInterruptAdapter struct {
 	initialTerminal    chan struct{}
@@ -156,27 +246,34 @@ func (s *waiterInterruptServer) SubmitNotification() {
 }
 
 type waiterInterruptDaemon struct {
-	adapter             *waiterInterruptAdapter
-	client              *appwire.Client
-	ctx                 context.Context
-	ref                 string
-	terminalClaimed     chan struct{}
-	positiveWaitSeen    chan struct{}
-	turnEnded           chan struct{}
-	sessionEndEntered   chan struct{}
-	releaseSessionEnd   chan struct{}
-	sessionEndProjected chan struct{}
-	releaseOnce         sync.Once
-	server              *waiterInterruptServer
-	stateDir            string
-	sessionID           string
-	interruptResponseID *atomic.Value
-	interruptResponse   chan struct{}
+	adapter                *waiterInterruptAdapter
+	client                 *appwire.Client
+	ctx                    context.Context
+	ref                    string
+	terminalClaimed        chan struct{}
+	positiveWaitSeen       chan struct{}
+	turnEnded              chan struct{}
+	sessionEndEntered      chan struct{}
+	releaseSessionEnd      chan struct{}
+	sessionEndProjected    chan struct{}
+	releaseOnce            sync.Once
+	server                 *waiterInterruptServer
+	stateDir               string
+	sessionID              string
+	interruptResponseID    *atomic.Value
+	interruptResponse      chan struct{}
+	processingReleased     *atomic.Bool
+	earlyInterruptResponse *atomic.Bool
 }
 
 func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 	t.Helper()
 	adapter := newWaiterInterruptAdapter()
+	var interruptResponseID atomic.Value
+	interruptResponseCompleted := make(chan struct{})
+	var interruptResponseOnce sync.Once
+	var processingReleased atomic.Bool
+	var earlyInterruptResponse atomic.Bool
 	positiveWaitSeen := make(chan struct{})
 	terminalClaimed := make(chan struct{})
 	turnEnded := make(chan struct{})
@@ -194,6 +291,27 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 	secondGenerationRunning := false
 
 	deps := defaultServeDeps()
+	listen := deps.listen
+	deps.listen = func(ctx context.Context, network, addr string) (net.Listener, error) {
+		listener, err := listen(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		return &waiterInterruptWriteObserverListener{Listener: listener, observe: func(payload []byte) {
+			var message appwire.Message
+			if err := json.Unmarshal(payload, &message); err != nil || message.Kind() != appwire.MessageResponse {
+				return
+			}
+			id, _ := interruptResponseID.Load().(string)
+			if id == "" || message.IDString() != id {
+				return
+			}
+			if !processingReleased.Load() {
+				earlyInterruptResponse.Store(true)
+			}
+			interruptResponseOnce.Do(func() { close(interruptResponseCompleted) })
+		}}, nil
+	}
 	deps.ensureConfigDirs = func() error { return nil }
 	deps.seedMarketplaces = func() error { return nil }
 	deps.newClient = func(string, io.Writer) (*llm.Client, providercfg.Config, bool, func() error, error) {
@@ -290,18 +408,6 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 		t.Fatalf("DialWebSocket: %v", err)
 	}
 	client := appwire.NewClient(transport)
-	var interruptResponseID atomic.Value
-	interruptResponseCompleted := make(chan struct{})
-	var interruptResponseOnce sync.Once
-	client.SetOrderedFrameHandler(func(message appwire.Message, err error) {
-		if err != nil {
-			return
-		}
-		id, _ := interruptResponseID.Load().(string)
-		if id != "" && message.IDString() == id {
-			interruptResponseOnce.Do(func() { close(interruptResponseCompleted) })
-		}
-	})
 	client.Start(context.WithoutCancel(ctx))
 	if _, err := client.Initialize(ctx, appwire.InitializeParams{
 		ClientInfo: appwire.ClientInfo{Name: "waiter-interrupt-test", Version: "test"},
@@ -315,8 +421,8 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 		if liveSession != nil {
 			liveSession.Close()
 		}
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 3*time.Second)
-		shutdownReq, requestErr := http.NewRequestWithContext(shutdownCtx, http.MethodPost, "http://"+entry.Address+"/shutdown", nil)
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 3*time.Second)
+		shutdownReq, requestErr := http.NewRequestWithContext(cleanupCtx, http.MethodPost, "http://"+entry.Address+"/shutdown", nil)
 		var shutdownResp *http.Response
 		var shutdownErr error
 		if requestErr == nil {
@@ -327,33 +433,35 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 		if shutdownErr == nil {
 			shutdownResp.Body.Close()
 		}
-		shutdownCancel()
 		select {
 		case runErr := <-done:
 			if runErr != nil {
 				t.Errorf("runServeWithDeps: %v", runErr)
 			}
-		case <-ctx.Done():
-			t.Errorf("runServeWithDeps did not exit: %v", ctx.Err())
+		case <-cleanupCtx.Done():
+			t.Errorf("runServeWithDeps did not exit: %v", cleanupCtx.Err())
 		}
+		cleanupCancel()
 		cancel()
 	})
 	return &waiterInterruptDaemon{
-		adapter:             adapter,
-		client:              client,
-		ctx:                 ctx,
-		ref:                 appwire.Ref{SourceID: "local", ThreadID: entry.SessionID}.String(),
-		terminalClaimed:     terminalClaimed,
-		positiveWaitSeen:    positiveWaitSeen,
-		turnEnded:           turnEnded,
-		sessionEndEntered:   sessionEndEntered,
-		releaseSessionEnd:   releaseSessionEnd,
-		sessionEndProjected: sessionEndProjected,
-		server:              waiterServer,
-		stateDir:            stateDir,
-		sessionID:           entry.SessionID,
-		interruptResponseID: &interruptResponseID,
-		interruptResponse:   interruptResponseCompleted,
+		adapter:                adapter,
+		client:                 client,
+		ctx:                    ctx,
+		ref:                    appwire.Ref{SourceID: "local", ThreadID: entry.SessionID}.String(),
+		terminalClaimed:        terminalClaimed,
+		positiveWaitSeen:       positiveWaitSeen,
+		turnEnded:              turnEnded,
+		sessionEndEntered:      sessionEndEntered,
+		releaseSessionEnd:      releaseSessionEnd,
+		sessionEndProjected:    sessionEndProjected,
+		server:                 waiterServer,
+		stateDir:               stateDir,
+		sessionID:              entry.SessionID,
+		interruptResponseID:    &interruptResponseID,
+		interruptResponse:      interruptResponseCompleted,
+		processingReleased:     &processingReleased,
+		earlyInterruptResponse: &earlyInterruptResponse,
 	}
 }
 
@@ -446,11 +554,15 @@ func TestRunServeInterruptSettlesClaimedPositiveWaitDelegateSend(t *testing.T) {
 		t.Fatal("TurnInterrupt response completed before runnerDone barrier release")
 	default:
 	}
+	daemon.processingReleased.Store(true)
 	daemon.server.releaseProcessingBarrier()
 	select {
 	case <-daemon.interruptResponse:
 	case <-interruptCtx.Done():
 		t.Fatalf("TurnInterrupt response did not complete after runnerDone barrier release: %v", interruptCtx.Err())
+	}
+	if daemon.earlyInterruptResponse.Load() {
+		t.Fatal("TurnInterrupt response write completed before processing release")
 	}
 	select {
 	case err := <-interruptResult:
@@ -478,14 +590,16 @@ func TestRunServeInterruptSettlesClaimedPositiveWaitDelegateSend(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ThreadTurnsList: %v", err)
 	}
-	terminal := false
+	startedCount := 0
+	startedStatus := ""
 	for _, turn := range turns.Data {
 		if turn.ID == started.Turn.ID {
-			terminal = turn.Status == "interrupted"
+			startedCount++
+			startedStatus = turn.Status
 		}
 	}
-	if terminal {
-		t.Fatalf("turn %q terminalized before its SESSION_END projection was released: %#v", started.Turn.ID, turns.Data)
+	if startedCount != 1 || startedStatus != "inProgress" {
+		t.Fatalf("started turn was not exactly once and inProgress before SESSION_END projection: count=%d status=%q turns=%#v", startedCount, startedStatus, turns.Data)
 	}
 	stoppedBeforeProjection := daemon.mutationSnapshot(t)
 	interruptBeforeProjection := stoppedBeforeProjection.Journal[interrupt.ClientMutationID]
@@ -500,7 +614,7 @@ func TestRunServeInterruptSettlesClaimedPositiveWaitDelegateSend(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ThreadTurnsList after SESSION_END projection: %v", err)
 	}
-	terminal = false
+	terminal := false
 	for _, turn := range turns.Data {
 		if turn.ID == started.Turn.ID {
 			terminal = turn.Status == "interrupted"

--- a/cmd/evener/serve_delegate_send_interrupt_test.go
+++ b/cmd/evener/serve_delegate_send_interrupt_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -32,53 +31,6 @@ const (
 )
 
 var waiterInterruptDelegateID = regexp.MustCompile(`dlg_[A-Za-z0-9_-]+`)
-
-type waiterMemoryAddr struct{}
-
-func (waiterMemoryAddr) Network() string { return "tcp" }
-func (waiterMemoryAddr) String() string  { return "waiter.test:80" }
-
-type waiterMemoryListener struct {
-	connections chan net.Conn
-	closed      chan struct{}
-	once        sync.Once
-}
-
-func newWaiterMemoryListener() *waiterMemoryListener {
-	return &waiterMemoryListener{connections: make(chan net.Conn), closed: make(chan struct{})}
-}
-
-func (l *waiterMemoryListener) Accept() (net.Conn, error) {
-	select {
-	case conn := <-l.connections:
-		return conn, nil
-	case <-l.closed:
-		return nil, net.ErrClosed
-	}
-}
-
-func (l *waiterMemoryListener) Close() error {
-	l.once.Do(func() { close(l.closed) })
-	return nil
-}
-
-func (l *waiterMemoryListener) Addr() net.Addr { return waiterMemoryAddr{} }
-
-func (l *waiterMemoryListener) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
-	client, server := net.Pipe()
-	select {
-	case l.connections <- server:
-		return client, nil
-	case <-ctx.Done():
-		_ = client.Close()
-		_ = server.Close()
-		return nil, ctx.Err()
-	case <-l.closed:
-		_ = client.Close()
-		_ = server.Close()
-		return nil, net.ErrClosed
-	}
-}
 
 type waiterInterruptAdapter struct {
 	initialTerminal    chan struct{}
@@ -218,6 +170,8 @@ type waiterInterruptDaemon struct {
 	server              *waiterInterruptServer
 	stateDir            string
 	sessionID           string
+	interruptResponseID *atomic.Value
+	interruptResponse   chan struct{}
 }
 
 func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
@@ -240,8 +194,6 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 	secondGenerationRunning := false
 
 	deps := defaultServeDeps()
-	memoryListener := newWaiterMemoryListener()
-	deps.listen = func(context.Context, string, string) (net.Listener, error) { return memoryListener, nil }
 	deps.ensureConfigDirs = func() error { return nil }
 	deps.seedMarketplaces = func() error { return nil }
 	deps.newClient = func(string, io.Writer) (*llm.Client, providercfg.Config, bool, func() error, error) {
@@ -276,13 +228,17 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 	}
 	deps.bridge = func(_ serveServer, session *agent.Session, observer func(events.SessionEvent), onDrained func()) {
 		session.ConsumeEventsLossless(func(event events.SessionEvent) {
-			if data, ok := event.Data.(events.SessionEndData); ok && data.Interrupted {
-				sessionEndEnteredOnce.Do(func() { close(sessionEndEntered) })
-				<-releaseSessionEnd
+			if event.Kind == events.EventSessionEnd {
+				if data, ok := event.Data.(events.SessionEndData); ok && data.Interrupted {
+					sessionEndEnteredOnce.Do(func() { close(sessionEndEntered) })
+					<-releaseSessionEnd
+				}
 			}
 			server.BridgeEvent(observedServer, event, observer)
-			if data, ok := event.Data.(events.SessionEndData); ok && data.Interrupted {
-				sessionEndProjectedOnce.Do(func() { close(sessionEndProjected) })
+			if event.Kind == events.EventSessionEnd {
+				if data, ok := event.Data.(events.SessionEndData); ok && data.Interrupted {
+					sessionEndProjectedOnce.Do(func() { close(sessionEndProjected) })
+				}
 			}
 			switch event.Kind {
 			case events.EventToolCallStart:
@@ -328,13 +284,24 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 
 	entry := waitForServeTestRendezvous(t, runDir)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	httpClient := &http.Client{Transport: &http.Transport{DialContext: memoryListener.DialContext}}
-	transport, err := appwire.DialWebSocket(ctx, "ws://"+entry.Address+"/rpc", httpClient)
+	transport, err := appwire.DialWebSocket(ctx, "ws://"+entry.Address+"/rpc", http.DefaultClient)
 	if err != nil {
 		cancel()
 		t.Fatalf("DialWebSocket: %v", err)
 	}
 	client := appwire.NewClient(transport)
+	var interruptResponseID atomic.Value
+	interruptResponseCompleted := make(chan struct{})
+	var interruptResponseOnce sync.Once
+	client.SetOrderedFrameHandler(func(message appwire.Message, err error) {
+		if err != nil {
+			return
+		}
+		id, _ := interruptResponseID.Load().(string)
+		if id != "" && message.IDString() == id {
+			interruptResponseOnce.Do(func() { close(interruptResponseCompleted) })
+		}
+	})
 	client.Start(context.WithoutCancel(ctx))
 	if _, err := client.Initialize(ctx, appwire.InitializeParams{
 		ClientInfo: appwire.ClientInfo{Name: "waiter-interrupt-test", Version: "test"},
@@ -348,10 +315,19 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 		if liveSession != nil {
 			liveSession.Close()
 		}
-		shutdownResp, shutdownErr := httpClient.Post("http://"+entry.Address+"/shutdown", "", nil)
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 3*time.Second)
+		shutdownReq, requestErr := http.NewRequestWithContext(shutdownCtx, http.MethodPost, "http://"+entry.Address+"/shutdown", nil)
+		var shutdownResp *http.Response
+		var shutdownErr error
+		if requestErr == nil {
+			shutdownResp, shutdownErr = http.DefaultClient.Do(shutdownReq)
+		} else {
+			shutdownErr = requestErr
+		}
 		if shutdownErr == nil {
 			shutdownResp.Body.Close()
 		}
+		shutdownCancel()
 		select {
 		case runErr := <-done:
 			if runErr != nil {
@@ -376,6 +352,8 @@ func startWaiterInterruptDaemon(t *testing.T) *waiterInterruptDaemon {
 		server:              waiterServer,
 		stateDir:            stateDir,
 		sessionID:           entry.SessionID,
+		interruptResponseID: &interruptResponseID,
+		interruptResponse:   interruptResponseCompleted,
 	}
 }
 
@@ -456,14 +434,24 @@ func TestRunServeInterruptSettlesClaimedPositiveWaitDelegateSend(t *testing.T) {
 	daemon.server.armProcessingBarrier()
 	defer daemon.server.releaseProcessingBarrier()
 	interruptResult := make(chan error, 1)
-	go func() { interruptResult <- daemon.client.TurnInterrupt(interruptCtx, interrupt) }()
+	go func() {
+		requestCtx := appwire.WithRequestIDObserver(interruptCtx, func(id appwire.ID) {
+			daemon.interruptResponseID.Store(id.String())
+		})
+		interruptResult <- daemon.client.TurnInterrupt(requestCtx, interrupt)
+	}()
 	awaitWaiterInterruptSignal(daemon.ctx, t, daemon.server.processingFalseEntered, "runner SetProcessing(false) barrier")
 	select {
-	case err := <-interruptResult:
-		t.Fatalf("TurnInterrupt returned before runnerDone barrier release: %v", err)
+	case <-daemon.interruptResponse:
+		t.Fatal("TurnInterrupt response completed before runnerDone barrier release")
 	default:
 	}
 	daemon.server.releaseProcessingBarrier()
+	select {
+	case <-daemon.interruptResponse:
+	case <-interruptCtx.Done():
+		t.Fatalf("TurnInterrupt response did not complete after runnerDone barrier release: %v", interruptCtx.Err())
+	}
 	select {
 	case err := <-interruptResult:
 		if err != nil {
@@ -471,6 +459,14 @@ func TestRunServeInterruptSettlesClaimedPositiveWaitDelegateSend(t *testing.T) {
 		}
 	case <-interruptCtx.Done():
 		t.Fatalf("TurnInterrupt did not return after runnerDone barrier release: %v", interruptCtx.Err())
+	}
+	stopped := daemon.mutationSnapshot(t)
+	startRecord, startPresent := stopped.Journal["waiter-interrupt-turn"]
+	interruptRecord, interruptPresent := stopped.Journal[interrupt.ClientMutationID]
+	if len(stopped.InterruptFence) != 0 || !startPresent || !interruptPresent ||
+		startRecord.OperationState != "terminal" || startRecord.ExecutionState != "interrupted" ||
+		interruptRecord.OperationState != "terminal" || interruptRecord.ExecutionState != "interrupted" {
+		t.Fatalf("interrupt was not durably terminal immediately after TurnInterrupt: fence=%q start_present=%t start=%#v interrupt_present=%t interrupt=%#v", stopped.InterruptFence, startPresent, startRecord, interruptPresent, interruptRecord)
 	}
 	awaitWaiterInterruptSignal(daemon.ctx, t, daemon.sessionEndEntered, "interrupted SESSION_END bridge entry")
 	select {
@@ -521,12 +517,6 @@ func TestRunServeInterruptSettlesClaimedPositiveWaitDelegateSend(t *testing.T) {
 	// The interrupt response is not enough by itself: read the durable mutation
 	// snapshot that future client mutations are serialized against. The runner
 	// must have terminalized the fence before the RPC returned.
-	stopped := daemon.mutationSnapshot(t)
-	interruptRecord := stopped.Journal[interrupt.ClientMutationID]
-	if len(stopped.InterruptFence) != 0 || interruptRecord.OperationState != "terminal" ||
-		interruptRecord.ExecutionState != "interrupted" {
-		t.Fatalf("non-terminal interrupt snapshot = %#v", stopped)
-	}
 	if !stopped.QueueHeld || !stopped.SteeringHeld {
 		t.Fatalf("Stop did not park both input rails before re-engagement: queue=%t steering=%t", stopped.QueueHeld, stopped.SteeringHeld)
 	}


### PR DESCRIPTION
Test-only prerequisite that unblocks PR #473, #353, and other CI-gated issue PRs.

Repairs the interrupt test oracle to await interrupted SESSION_END projection while asserting durable terminalization immediately after TurnInterrupt returns. Adds deterministic SetProcessing(false)/runnerDone ordering coverage.

Does not fix or close #353. Production behavior is unchanged.