### PR TITLE
Own one-shot deadlines for rate-limit retries

### DIFF
--- a/agent/lifecycle_ops_test.go
+++ b/agent/lifecycle_ops_test.go
@@ -85,6 +85,70 @@ func TestRestoreSessionConfigUsesInjectedClock(t *testing.T) {
 	}
 }
 
+func TestRestoreSessionLifetimeOwnsRootAndChild(t *testing.T) {
+	owner, cancelOwner := context.WithCancel(context.Background())
+	client := llm.NewClient()
+	client.Register(&agenttest.ScriptedAdapter{
+		Provider:  "openai",
+		Responder: func(llm.Request) llm.Response { return agenttest.FinalResponse("done") },
+	})
+	meta := schema.SessionMeta{
+		ID:        ulid.Make().String(),
+		ProfileID: "openai",
+		Model:     "gpt-5.2",
+		Config:    (SessionConfig{MaxSubagentDepth: 1, NoProjectPrompts: true}).toSnapshot(),
+	}
+	restored, err := RestoreSessionFromMetaWithConfig(
+		client,
+		NewOpenAIProfile("gpt-5.2"),
+		&agenttest.DenyEnv{WorkDir: t.TempDir()},
+		meta,
+		RestoreSessionConfig{
+			LifetimeContext: owner,
+			StateDir:        t.TempDir(),
+			testOnly: testConfig{
+				skipGitSnapshot:     true,
+				minimalSystemPrompt: true,
+				noSyncJobStore:      true,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
+	}
+	t.Cleanup(restored.Close)
+
+	prepared := prepareSubagentForTreeRevisionTest(t, restored, "child task")
+	t.Cleanup(prepared.runCancel)
+	t.Cleanup(func() { releasePreparedTreeSlot(prepared) })
+	t.Cleanup(prepared.sub.sess.Close)
+
+	for name, done := range map[string]<-chan struct{}{
+		"root":      restored.sessionCtx.Done(),
+		"child":     prepared.sub.sess.sessionCtx.Done(),
+		"child run": prepared.runCtx.Done(),
+	} {
+		select {
+		case <-done:
+			t.Fatalf("%s context ended before owner cancellation", name)
+		default:
+		}
+	}
+
+	cancelOwner()
+	for name, done := range map[string]<-chan struct{}{
+		"root":      restored.sessionCtx.Done(),
+		"child":     prepared.sub.sess.sessionCtx.Done(),
+		"child run": prepared.runCtx.Done(),
+	} {
+		select {
+		case <-done:
+		default:
+			t.Fatalf("%s context outlived restored-session owner", name)
+		}
+	}
+}
+
 // TestLifecycleBackgroundShellQuiesces proves the C2 path: a turn that issues a
 // background shell tool call actually starts a background job, and quiesceJobs
 // drives it to a terminal status deterministically.

--- a/agent/session_config.go
+++ b/agent/session_config.go
@@ -31,7 +31,10 @@ import (
 // settings, and session persistence. Zero-valued fields are filled in by
 // applyDefaults where defaults apply.
 type SessionConfig struct {
-	artifactStore artifactStore
+	// LifetimeContext owns this session tree when supplied by a one-shot run.
+	// Nil preserves daemon/background ownership and is not persisted.
+	LifetimeContext context.Context `json:"-"`
+	artifactStore   artifactStore
 
 	// Project is the resolved canonical project identity for this launch. It is
 	// separate from the execution environment's active working directory, which

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -184,7 +184,11 @@ func NewSession(client *llm.Client, profile *provider.Profile, env execenv.Execu
 		ownsArtifactStore = true
 	}
 
-	sessCtx, sessCancel := context.WithCancel(context.Background())
+	owner := cfg.LifetimeContext
+	if owner == nil {
+		owner = context.Background()
+	}
+	sessCtx, sessCancel := context.WithCancel(owner)
 	initComplete := false
 	ownedSessionID := ""
 	defer func() {

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -464,6 +464,9 @@ func NewSession(client *llm.Client, profile *provider.Profile, env execenv.Execu
 // persisted session. Persisted fields still come from SessionMeta.Config; this
 // struct layers non-serialized values such as StateDir and ResolveProfile.
 type RestoreSessionConfig struct {
+	// LifetimeContext owns this restored session tree when supplied by a
+	// one-shot run. Nil preserves daemon/background ownership.
+	LifetimeContext             context.Context
 	StateDir                    string
 	Project                     identifier.Project
 	ResolveProfile              func(ref string) (*provider.Profile, error)
@@ -558,6 +561,7 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 	}()
 
 	cfg := configFromSnapshot(meta.Config)
+	cfg.LifetimeContext = restoreCfg.LifetimeContext
 	cfg.StateDir = restoreCfg.StateDir
 	cfg.Project = restoreCfg.Project
 	cfg.ResolveProfile = restoreCfg.ResolveProfile
@@ -670,7 +674,11 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 		}
 	}
 
-	sessCtx, sessCancel := context.WithCancel(context.Background())
+	owner := cfg.LifetimeContext
+	if owner == nil {
+		owner = context.Background()
+	}
+	sessCtx, sessCancel := context.WithCancel(owner)
 	delegationAllowance := cfg.spawn.delegationAllowance
 	if cfg.spawn.parentSessionID == "" {
 		// Root sessions derive their allowance from MaxSubagentDepth (already

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -1048,7 +1048,7 @@ func (s *Session) prepareSubagentRunFromSelection(
 	// child keeps running. Child cancellation is handled by subSess.Close(),
 	// including when the parent session closes. The per-run context lets
 	// parent stops interrupt this run without destroying the child session.
-	runCtx, runCancel := context.WithCancel(context.Background())
+	runCtx, runCancel := context.WithCancel(s.sessionCtx)
 	sub.mu.Lock()
 	sub.cancel = runCancel
 	sub.cancelRequested = false

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -626,6 +626,7 @@ func (s *Session) prepareStableDelegateRun(ctx context.Context, descriptor deleg
 func subagentConfigFromFrozenDescriptor(frozenConfig schema.ConfigSnapshot, parentCfg SessionConfig) SessionConfig {
 	subCfg := configFromSnapshot(frozenConfig.Clone())
 	subCfg.Project = parentCfg.Project
+	subCfg.LifetimeContext = parentCfg.LifetimeContext
 	subCfg.LLMRetryPolicy = parentCfg.LLMRetryPolicy
 	subCfg.LLMSleep = parentCfg.LLMSleep
 	subCfg.clock = parentCfg.clock

--- a/agent/turn_ends_process_test.go
+++ b/agent/turn_ends_process_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"testing"
 
 	"primeradiant.com/evener/agent/execenv"
@@ -90,5 +91,22 @@ func TestFrozenDescriptorTakesTurnEndsProcessFromTheLiveParent(t *testing.T) {
 				t.Fatal("frozen-descriptor merge dropped a descriptor-scoped field; the helper must still start from the snapshot")
 			}
 		})
+	}
+}
+
+func TestFrozenDescriptorTakesLifetimeContextFromLiveParent(t *testing.T) {
+	owner, cancelOwner := context.WithCancel(context.Background())
+	got := subagentConfigFromFrozenDescriptor(
+		SessionConfig{NoProjectPrompts: true}.toSnapshot(),
+		SessionConfig{LifetimeContext: owner},
+	)
+	if got.LifetimeContext == nil {
+		t.Fatal("frozen delegate dropped the live parent's lifetime context")
+	}
+	cancelOwner()
+	select {
+	case <-got.LifetimeContext.Done():
+	default:
+		t.Fatal("frozen delegate lifetime outlived the live parent")
 	}
 }

--- a/cmd/evener/main.go
+++ b/cmd/evener/main.go
@@ -185,6 +185,11 @@ func mainWithDeps(deps mainDeps) {
 		deps.exit(1)
 		return
 	}
+	if *flags.runTimeout < 0 {
+		_, _ = fmt.Fprintf(deps.stderr, "evener: invalid --timeout %s: must be non-negative\n", flags.runTimeout.String())
+		deps.exit(2)
+		return
+	}
 
 	ctx, cancel := deps.notify(context.Background(), os.Interrupt)
 	defer cancel()

--- a/cmd/evener/main.go
+++ b/cmd/evener/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"text/tabwriter"
+	"time"
 
 	"primeradiant.com/evener/agent"
 	"primeradiant.com/evener/buildinfo"
@@ -62,6 +63,7 @@ type runCLIFlags struct {
 	systemPromptAppend          stringSliceFlag
 	sandbox                     *string
 	sandboxNet                  *string
+	runTimeout                  *time.Duration
 }
 
 func main() {
@@ -218,6 +220,7 @@ func mainWithDeps(deps mainDeps) {
 		openAIResponsesContinuation: *flags.openAIResponsesContinuation,
 		sandboxMode:                 *flags.sandbox,
 		sandboxNet:                  *flags.sandboxNet,
+		runTimeout:                  *flags.runTimeout,
 		stdout:                      deps.stdout,
 		stderr:                      deps.stderr,
 		resume:                      *flags.resume,
@@ -273,6 +276,7 @@ func newRunFlagSet(stderr io.Writer) (*flag.FlagSet, *runCLIFlags) {
 	fs.Var(&flags.systemPromptAppend, "system-prompt-append", "path to append to system prompt `file` (repeatable)")
 	flags.sandbox = fs.String("sandbox", "off", "sandbox `mode`: off (default), read-only, workspace-write, or restricted")
 	flags.sandboxNet = fs.String("sandbox-net", "on", "sandbox network egress `on|off` (default on; only applies with a non-off --sandbox mode)")
+	flags.runTimeout = fs.Duration("timeout", 0, "overall one-shot run timeout (0 disables; rate-limit retries use their finite fallback)")
 
 	fs.Usage = func() {
 		printRunUsage(stderr, fs)

--- a/cmd/evener/run.go
+++ b/cmd/evener/run.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"primeradiant.com/evener/agent"
 	"primeradiant.com/evener/agent/events"
@@ -57,15 +58,16 @@ type runConfig struct {
 	stdout                    io.Writer
 	stderr                    io.Writer
 
-	skillsDirs                  []string // extra skill directories
-	mcpServers                  []string // --mcp inline specs
-	mcpConfigs                  []string // --mcp-config file paths
-	pluginDirs                  []string // --plugin-dir directories
-	noDefaultMarketplaces       bool     // --no-default-marketplaces
-	systemPromptAsUser          bool     // --system-prompt-as-user
-	openAIResponsesContinuation string   // --openai-responses-continuation
-	sandboxMode                 string   // --sandbox mode name (default "off")
-	sandboxNet                  string   // --sandbox-net on|off
+	skillsDirs                  []string      // extra skill directories
+	mcpServers                  []string      // --mcp inline specs
+	mcpConfigs                  []string      // --mcp-config file paths
+	pluginDirs                  []string      // --plugin-dir directories
+	noDefaultMarketplaces       bool          // --no-default-marketplaces
+	systemPromptAsUser          bool          // --system-prompt-as-user
+	openAIResponsesContinuation string        // --openai-responses-continuation
+	runTimeout                  time.Duration // --timeout; zero disables
+	sandboxMode                 string        // --sandbox mode name (default "off")
+	sandboxNet                  string        // --sandbox-net on|off
 
 	// Resume options.
 	resume       string // session ID to resume
@@ -100,6 +102,11 @@ var (
 )
 
 func run(ctx context.Context, cfg runConfig) error {
+	if cfg.runTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cfg.runTimeout)
+		defer cancel()
+	}
 	if cfg.stdout == nil {
 		cfg.stdout = os.Stdout
 	}

--- a/cmd/evener/run.go
+++ b/cmd/evener/run.go
@@ -285,6 +285,7 @@ func run(ctx context.Context, cfg runConfig) error {
 	}
 	if meta != nil {
 		sess, err = runRestoreSession(client, profile, env, *meta, agent.RestoreSessionConfig{
+			LifetimeContext:             ctx,
 			StateDir:                    stateDir,
 			Project:                     project,
 			ResolveProfile:              baseSessionCfg.ResolveProfile,

--- a/cmd/evener/run.go
+++ b/cmd/evener/run.go
@@ -107,6 +107,7 @@ func run(ctx context.Context, cfg runConfig) error {
 		ctx, cancel = context.WithTimeout(ctx, cfg.runTimeout)
 		defer cancel()
 	}
+	ctx = llm.WithRunBudget(ctx)
 	if cfg.stdout == nil {
 		cfg.stdout = os.Stdout
 	}
@@ -193,9 +194,15 @@ func run(ctx context.Context, cfg runConfig) error {
 		return err
 	}
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	client, provCfg, hasProvConfig, err := runLoadClient(llm.WithStateDir(stateDir))
 	if err != nil {
 		return fmt.Errorf("LLM client setup: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	reserveSession, closeAPILog, err := runAttachAPILogger(client, stateDir, cfg.stderr)
@@ -228,6 +235,7 @@ func run(ctx context.Context, cfg runConfig) error {
 
 	var sess *agent.Session
 	baseSessionCfg := agent.SessionConfig{
+		LifetimeContext:             ctx,
 		MaxToolRoundsPerInput:       cmdutil.MaxRoundsToConfig(cfg.maxRounds),
 		ShareTasksWithChildren:      cfg.shareTaskStore,
 		ResultToolName:              cfg.resultToolName,

--- a/cmd/evener/run_test.go
+++ b/cmd/evener/run_test.go
@@ -388,6 +388,60 @@ func TestRunResumeRunningReservesBeforeRestore(t *testing.T) {
 	}
 }
 
+func TestRunResumePassesTimeoutLifetimeToRestore(t *testing.T) {
+	adapter := &scriptedProvider{name: "openai"}
+	installRunScriptedProvider(t, adapter)
+	oldRestore := runRestoreSession
+	t.Cleanup(func() { runRestoreSession = oldRestore })
+
+	stateDir := t.TempDir()
+	meta := schema.SessionMeta{
+		ID:        "02wMz5Txv1C3Hut0M8GCeB",
+		ProfileID: "openai",
+		Model:     "gpt-test",
+		CreatedAt: time.Unix(1, 0).UTC(),
+		UpdatedAt: time.Unix(2, 0).UTC(),
+	}
+	if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
+		t.Fatalf("SaveSessionMeta: %v", err)
+	}
+
+	wantErr := errors.New("restore lifetime observed")
+	var restoredLifetime context.Context
+	runRestoreSession = func(_ *llm.Client, _ *provider.Profile, _ execenv.ExecutionEnvironment, _ schema.SessionMeta, cfg agent.RestoreSessionConfig) (*agent.Session, error) {
+		restoredLifetime = cfg.LifetimeContext
+		return nil, wantErr
+	}
+	startedAt := time.Now()
+	err := run(context.Background(), runConfig{
+		resume:                meta.ID,
+		workDir:               stateDir,
+		stateDir:              stateDir,
+		runTimeout:            time.Hour,
+		noDefaultMarketplaces: true,
+		stdout:                &bytes.Buffer{},
+		stderr:                &bytes.Buffer{},
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("run error = %v, want restore sentinel", err)
+	}
+	if restoredLifetime == nil {
+		t.Fatal("restore did not receive the one-shot lifetime context")
+	}
+	deadline, ok := restoredLifetime.Deadline()
+	if !ok {
+		t.Fatal("restored lifetime has no --timeout deadline")
+	}
+	if remaining := deadline.Sub(startedAt); remaining < 59*time.Minute || remaining > 61*time.Minute {
+		t.Fatalf("restored lifetime deadline = %s after start, want approximately one hour", remaining)
+	}
+	select {
+	case <-restoredLifetime.Done():
+	case <-time.After(time.Second):
+		t.Fatal("restored lifetime remained live after run returned")
+	}
+}
+
 func readResumeArtifacts(t *testing.T, stateDir, sessionID string, paths ...string) map[string]string {
 	t.Helper()
 	paths = append(paths, filepath.Join(stateDir, "sessions", sessionID+".meta.json"))

--- a/llm/api_attempt.go
+++ b/llm/api_attempt.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"sync"
 	"time"
@@ -295,7 +296,7 @@ func (g *APIAttemptGroup) SettleResult(ctx context.Context, err error) {
 	outcome := apilog.AttemptSuccess
 	useFinalAttemptOutcome := false
 	if err != nil {
-		if ctx != nil && ctx.Err() != nil {
+		if ctx != nil && (ctx.Err() != nil || errors.Is(err, ErrRunBudgetExhausted)) {
 			outcome = apilog.AttemptCallerCancel
 		} else {
 			useFinalAttemptOutcome = true

--- a/llm/api_attempt_group_test.go
+++ b/llm/api_attempt_group_test.go
@@ -398,6 +398,17 @@ func TestAPIAttemptGroupZeroAttemptCancellationSettlement(t *testing.T) {
 	}
 }
 
+func TestAPIAttemptGroupRunBudgetExhaustionSettlesAsCallerCancel(t *testing.T) {
+	sink := &recordingAPIAttemptSink{}
+	group := NewAPIAttemptGroup("ag_run_budget")
+	ctx := WithAPIAttemptSink(WithAPIAttemptGroup(context.Background(), group), sink)
+	group.SettleResult(ctx, runBudgetError{})
+	_, settlements, _ := sink.snapshot()
+	if len(settlements) != 1 || settlements[0].Outcome != apilog.AttemptCallerCancel {
+		t.Fatalf("settlement = %+v, want caller cancellation", settlements)
+	}
+}
+
 func TestClientSessionGroupSettlesFailuresBeforeProviderMiddleware(t *testing.T) {
 	tests := []struct {
 		name string

--- a/llm/retry.go
+++ b/llm/retry.go
@@ -1,6 +1,32 @@
 package llm
 
-import "time"
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrRunBudgetExhausted identifies retry exhaustion at an owned run's
+// shutdown reserve. It unwraps to context.DeadlineExceeded for callers.
+var ErrRunBudgetExhausted = errors.New("run budget exhausted")
+
+type runBudgetError struct{}
+
+func (runBudgetError) Error() string        { return ErrRunBudgetExhausted.Error() }
+func (runBudgetError) Unwrap() error        { return context.DeadlineExceeded }
+func (runBudgetError) Is(target error) bool { return target == ErrRunBudgetExhausted }
+
+type runBudgetContextKey struct{}
+
+// WithRunBudget marks ctx as the explicit one-shot run owner.
+func WithRunBudget(ctx context.Context) context.Context {
+	return context.WithValue(ctx, runBudgetContextKey{}, true)
+}
+
+func hasRunBudget(ctx context.Context) bool {
+	v, _ := ctx.Value(runBudgetContextKey{}).(bool)
+	return v
+}
 
 // RetryPolicy configures how retry attempts are spaced, including the maximum
 // number of retries, the exponential backoff delays, optional jitter, an

--- a/llm/retry.go
+++ b/llm/retry.go
@@ -29,6 +29,11 @@ type RetryPolicy struct {
 	// Now is the clock used to measure RateLimitWallBudget. Nil uses time.Now.
 	Now func() time.Time
 
+	// RateLimitShutdownReserve is held back from a caller deadline so the run
+	// can unwind cleanly instead of beginning another provider wait. Zero uses
+	// the package default reserve.
+	RateLimitShutdownReserve time.Duration
+
 	// OnRetry is invoked before sleeping for a retry attempt.
 	OnRetry func(err error, attempt int, delay time.Duration)
 }
@@ -44,14 +49,17 @@ type RetryPolicy struct {
 // still wins, and a shorter Retry-After/backoff schedule may settle earlier.
 func DefaultRetryPolicy() RetryPolicy {
 	return RetryPolicy{
-		MaxRetries:          10,
-		BaseDelay:           1 * time.Second,
-		MaxDelay:            60 * time.Second,
-		BackoffMultiplier:   2.0,
-		Jitter:              true,
-		RateLimitWallBudget: 30 * time.Minute,
+		MaxRetries:               10,
+		BaseDelay:                1 * time.Second,
+		MaxDelay:                 60 * time.Second,
+		BackoffMultiplier:        2.0,
+		Jitter:                   true,
+		RateLimitWallBudget:      30 * time.Minute,
+		RateLimitShutdownReserve: 30 * time.Second,
 	}
 }
+
+const defaultRateLimitShutdownReserve = 30 * time.Second
 
 // WallBudgetedRateLimit reports whether this policy gives a rate-limit error a
 // wall-clock budget instead of applying MaxRetries.
@@ -64,8 +72,4 @@ func (p RetryPolicy) now() time.Time {
 		return p.Now()
 	}
 	return time.Now()
-}
-
-func (p RetryPolicy) rateLimitBudgetRemains(err error, start time.Time) bool {
-	return p.WallBudgetedRateLimit(err) && p.now().Sub(start) < p.RateLimitWallBudget
 }

--- a/llm/retry_deadline_test.go
+++ b/llm/retry_deadline_test.go
@@ -11,7 +11,7 @@ func TestRetry_RateLimitDeadlineUsesRunBudget(t *testing.T) {
 	clk := newBudgetClock()
 	clk.now = time.Now()
 	policy := budgetPolicy(clk, 30*time.Minute)
-	ctx, cancel := context.WithDeadline(context.Background(), clk.now.Add(2*time.Minute))
+	ctx, cancel := context.WithDeadline(WithRunBudget(context.Background()), clk.now.Add(2*time.Minute))
 	defer cancel()
 	calls := 0
 	_, err := Retry(ctx, policy, clk.sleep, func() float64 { return .5 }, func() (Response, error) {
@@ -30,7 +30,7 @@ func TestRetryStream_RateLimitDeadlineUsesRunBudget(t *testing.T) {
 	clk := newBudgetClock()
 	clk.now = time.Now()
 	policy := budgetPolicy(clk, 30*time.Minute)
-	ctx, cancel := context.WithDeadline(context.Background(), clk.now.Add(2*time.Minute))
+	ctx, cancel := context.WithDeadline(WithRunBudget(context.Background()), clk.now.Add(2*time.Minute))
 	defer cancel()
 	calls := 0
 	err := RetryStream(ctx, RetryStreamOptions{Policy: policy, Sleep: clk.sleep}, func(context.Context) (AttemptReport, error) {
@@ -51,7 +51,7 @@ func TestRetry_RateLimitLongRunDeadlineOutlivesThirtyMinuteFallback(t *testing.T
 	policy := budgetPolicy(clk, 30*time.Minute)
 	policy.BaseDelay = time.Minute
 	policy.MaxDelay = time.Minute
-	ctx, cancel := context.WithDeadline(context.Background(), clk.now.Add(32*time.Minute))
+	ctx, cancel := context.WithDeadline(WithRunBudget(context.Background()), clk.now.Add(32*time.Minute))
 	defer cancel()
 	calls := 0
 	_, err := Retry(ctx, policy, clk.sleep, func() float64 { return .5 }, func() (Response, error) {

--- a/llm/retry_deadline_test.go
+++ b/llm/retry_deadline_test.go
@@ -1,0 +1,70 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRetry_RateLimitDeadlineUsesRunBudget(t *testing.T) {
+	clk := newBudgetClock()
+	clk.now = time.Now()
+	policy := budgetPolicy(clk, 30*time.Minute)
+	ctx, cancel := context.WithDeadline(context.Background(), clk.now.Add(2*time.Minute))
+	defer cancel()
+	calls := 0
+	_, err := Retry(ctx, policy, clk.sleep, func() float64 { return .5 }, func() (Response, error) {
+		calls++
+		return Response{}, rateLimit429()
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want run deadline exhaustion", err)
+	}
+	if calls != 7 {
+		t.Fatalf("calls = %d, want 7 (no request after reserve boundary)", calls)
+	}
+}
+
+func TestRetryStream_RateLimitDeadlineUsesRunBudget(t *testing.T) {
+	clk := newBudgetClock()
+	clk.now = time.Now()
+	policy := budgetPolicy(clk, 30*time.Minute)
+	ctx, cancel := context.WithDeadline(context.Background(), clk.now.Add(2*time.Minute))
+	defer cancel()
+	calls := 0
+	err := RetryStream(ctx, RetryStreamOptions{Policy: policy, Sleep: clk.sleep}, func(context.Context) (AttemptReport, error) {
+		calls++
+		return AttemptReport{}, rateLimit429()
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want run deadline exhaustion", err)
+	}
+	if calls != 7 {
+		t.Fatalf("calls = %d, want 7 (no request after reserve boundary)", calls)
+	}
+}
+
+func TestRetry_RateLimitLongRunDeadlineOutlivesThirtyMinuteFallback(t *testing.T) {
+	clk := newBudgetClock()
+	clk.now = time.Now()
+	policy := budgetPolicy(clk, 30*time.Minute)
+	policy.BaseDelay = time.Minute
+	policy.MaxDelay = time.Minute
+	ctx, cancel := context.WithDeadline(context.Background(), clk.now.Add(32*time.Minute))
+	defer cancel()
+	calls := 0
+	_, err := Retry(ctx, policy, clk.sleep, func() float64 { return .5 }, func() (Response, error) {
+		calls++
+		if calls > 31 {
+			return Response{Provider: "p", Model: "m", Message: Assistant("ok")}, nil
+		}
+		return Response{}, rateLimit429()
+	})
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	if calls != 32 {
+		t.Fatalf("calls = %d, want 32 (deadline budget must exceed old 30m fallback)", calls)
+	}
+}

--- a/llm/retry_util.go
+++ b/llm/retry_util.go
@@ -85,8 +85,8 @@ func Retry[T any](ctx context.Context, policy RetryPolicy, sleep SleepFunc, rand
 			return zero, err
 		}
 		if policy.WallBudgetedRateLimit(err) {
-			if !policy.rateLimitBudgetRemains(err, start) {
-				return zero, err
+			if !rateLimitBudgetRemains(ctx, policy, err, start) {
+				return zero, rateLimitBudgetExhausted(ctx, err)
 			}
 		} else if attempt >= maxRetries {
 			return zero, err
@@ -97,9 +97,9 @@ func Retry[T any](ctx context.Context, policy RetryPolicy, sleep SleepFunc, rand
 			return zero, err
 		}
 		if policy.WallBudgetedRateLimit(err) {
-			remaining := policy.RateLimitWallBudget - policy.now().Sub(start)
+			remaining := rateLimitRemaining(ctx, policy, start)
 			if remaining <= 0 {
-				return zero, err
+				return zero, rateLimitBudgetExhausted(ctx, err)
 			}
 			if delay > remaining {
 				// Do not start a wait that would carry the group beyond its wall
@@ -114,10 +114,38 @@ func Retry[T any](ctx context.Context, policy RetryPolicy, sleep SleepFunc, rand
 		if err := sleep(ctx, delay); err != nil {
 			return zero, err
 		}
-		if policy.WallBudgetedRateLimit(err) && !policy.rateLimitBudgetRemains(err, start) {
-			return zero, err
+		if policy.WallBudgetedRateLimit(err) && !rateLimitBudgetRemains(ctx, policy, err, start) {
+			return zero, rateLimitBudgetExhausted(ctx, err)
 		}
 	}
+}
+
+func rateLimitBudgetExhausted(ctx context.Context, original error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		return original
+	}
+	return context.DeadlineExceeded
+}
+
+func rateLimitShutdownReserve(policy RetryPolicy) time.Duration {
+	if policy.RateLimitShutdownReserve > 0 {
+		return policy.RateLimitShutdownReserve
+	}
+	return defaultRateLimitShutdownReserve
+}
+
+func rateLimitRemaining(ctx context.Context, policy RetryPolicy, start time.Time) time.Duration {
+	if deadline, ok := ctx.Deadline(); ok {
+		return deadline.Sub(policy.now()) - rateLimitShutdownReserve(policy)
+	}
+	return policy.RateLimitWallBudget - policy.now().Sub(start)
+}
+
+func rateLimitBudgetRemains(ctx context.Context, policy RetryPolicy, err error, start time.Time) bool {
+	return policy.WallBudgetedRateLimit(err) && rateLimitRemaining(ctx, policy, start) > 0
 }
 
 func retryDelay(policy RetryPolicy, randFloat func() float64, err error, n int) (time.Duration, bool) {

--- a/llm/retry_util.go
+++ b/llm/retry_util.go
@@ -72,6 +72,7 @@ func Retry[T any](ctx context.Context, policy RetryPolicy, sleep SleepFunc, rand
 	}
 	maxRetries := max(policy.MaxRetries, 0)
 	start := policy.now()
+	ownerBudget := ownedRunBudget(ctx)
 
 	for attempt := 0; ; attempt++ {
 		v, err := fn()
@@ -85,7 +86,7 @@ func Retry[T any](ctx context.Context, policy RetryPolicy, sleep SleepFunc, rand
 			return zero, err
 		}
 		if policy.WallBudgetedRateLimit(err) {
-			if !rateLimitBudgetRemains(ctx, policy, err, start) {
+			if !rateLimitBudgetRemains(ctx, policy, err, start, ownerBudget) {
 				return zero, rateLimitBudgetExhausted(ctx, err)
 			}
 		} else if attempt >= maxRetries {
@@ -97,7 +98,7 @@ func Retry[T any](ctx context.Context, policy RetryPolicy, sleep SleepFunc, rand
 			return zero, err
 		}
 		if policy.WallBudgetedRateLimit(err) {
-			remaining := rateLimitRemaining(ctx, policy, start)
+			remaining := rateLimitRemaining(ctx, policy, start, ownerBudget)
 			if remaining <= 0 {
 				return zero, rateLimitBudgetExhausted(ctx, err)
 			}
@@ -114,7 +115,7 @@ func Retry[T any](ctx context.Context, policy RetryPolicy, sleep SleepFunc, rand
 		if err := sleep(ctx, delay); err != nil {
 			return zero, err
 		}
-		if policy.WallBudgetedRateLimit(err) && !rateLimitBudgetRemains(ctx, policy, err, start) {
+		if policy.WallBudgetedRateLimit(err) && !rateLimitBudgetRemains(ctx, policy, err, start, ownerBudget) {
 			return zero, rateLimitBudgetExhausted(ctx, err)
 		}
 	}
@@ -127,6 +128,9 @@ func rateLimitBudgetExhausted(ctx context.Context, original error) error {
 	if _, ok := ctx.Deadline(); !ok {
 		return original
 	}
+	if hasRunBudget(ctx) {
+		return runBudgetError{}
+	}
 	return context.DeadlineExceeded
 }
 
@@ -137,15 +141,29 @@ func rateLimitShutdownReserve(policy RetryPolicy) time.Duration {
 	return defaultRateLimitShutdownReserve
 }
 
-func rateLimitRemaining(ctx context.Context, policy RetryPolicy, start time.Time) time.Duration {
+func ownedRunBudget(ctx context.Context) time.Duration {
+	if !hasRunBudget(ctx) {
+		return 0
+	}
 	if deadline, ok := ctx.Deadline(); ok {
-		return deadline.Sub(policy.now()) - rateLimitShutdownReserve(policy)
+		return time.Until(deadline)
+	}
+	return 0
+}
+
+func rateLimitRemaining(ctx context.Context, policy RetryPolicy, start time.Time, ownerBudget time.Duration) time.Duration {
+	if hasRunBudget(ctx) {
+		if ownerBudget > 0 {
+			// Snapshot native duration at group start, then consume it using
+			// the policy clock; fake clocks may use another epoch.
+			return ownerBudget - policy.now().Sub(start) - rateLimitShutdownReserve(policy)
+		}
 	}
 	return policy.RateLimitWallBudget - policy.now().Sub(start)
 }
 
-func rateLimitBudgetRemains(ctx context.Context, policy RetryPolicy, err error, start time.Time) bool {
-	return policy.WallBudgetedRateLimit(err) && rateLimitRemaining(ctx, policy, start) > 0
+func rateLimitBudgetRemains(ctx context.Context, policy RetryPolicy, err error, start time.Time, ownerBudget time.Duration) bool {
+	return policy.WallBudgetedRateLimit(err) && rateLimitRemaining(ctx, policy, start, ownerBudget) > 0
 }
 
 func retryDelay(policy RetryPolicy, randFloat func() float64, err error, n int) (time.Duration, bool) {

--- a/llm/stream_retry.go
+++ b/llm/stream_retry.go
@@ -132,8 +132,8 @@ func RetryStream(ctx context.Context, opts RetryStreamOptions, attempt StreamAtt
 			return err
 		}
 		if opts.Policy.WallBudgetedRateLimit(err) {
-			if !opts.Policy.rateLimitBudgetRemains(err, start) {
-				return err
+			if !rateLimitBudgetRemains(ctx, opts.Policy, err, start) {
+				return rateLimitBudgetExhausted(ctx, err)
 			}
 		} else if n >= maxRetries {
 			return err
@@ -143,9 +143,9 @@ func RetryStream(ctx context.Context, opts RetryStreamOptions, attempt StreamAtt
 			return err
 		}
 		if opts.Policy.WallBudgetedRateLimit(err) {
-			remaining := opts.Policy.RateLimitWallBudget - opts.Policy.now().Sub(start)
+			remaining := rateLimitRemaining(ctx, opts.Policy, start)
 			if remaining <= 0 {
-				return err
+				return rateLimitBudgetExhausted(ctx, err)
 			}
 			if delay > remaining {
 				// Wait only to the wall-budget boundary; do not start another
@@ -159,8 +159,8 @@ func RetryStream(ctx context.Context, opts RetryStreamOptions, attempt StreamAtt
 		if sleepErr := sleep(ctx, delay); sleepErr != nil {
 			return sleepErr
 		}
-		if opts.Policy.WallBudgetedRateLimit(err) && !opts.Policy.rateLimitBudgetRemains(err, start) {
-			return err
+		if opts.Policy.WallBudgetedRateLimit(err) && !rateLimitBudgetRemains(ctx, opts.Policy, err, start) {
+			return rateLimitBudgetExhausted(ctx, err)
 		}
 		// Discard partial output before re-running so the next attempt replaces
 		// what the failed one already streamed.

--- a/llm/stream_retry.go
+++ b/llm/stream_retry.go
@@ -86,6 +86,7 @@ func RetryStream(ctx context.Context, opts RetryStreamOptions, attempt StreamAtt
 	}
 	maxRetries := max(opts.Policy.MaxRetries, 0)
 	start := opts.Policy.now()
+	ownerBudget := ownedRunBudget(ctx)
 	// consumeStreak counts consecutive attempts whose Phase is PhaseConsume or
 	// PhaseSilentStall (the streak rule); capStreak counts the consecutive
 	// suffix of those that are also cap-shaped (the cap rule). PhaseOpen and
@@ -132,7 +133,7 @@ func RetryStream(ctx context.Context, opts RetryStreamOptions, attempt StreamAtt
 			return err
 		}
 		if opts.Policy.WallBudgetedRateLimit(err) {
-			if !rateLimitBudgetRemains(ctx, opts.Policy, err, start) {
+			if !rateLimitBudgetRemains(ctx, opts.Policy, err, start, ownerBudget) {
 				return rateLimitBudgetExhausted(ctx, err)
 			}
 		} else if n >= maxRetries {
@@ -143,7 +144,7 @@ func RetryStream(ctx context.Context, opts RetryStreamOptions, attempt StreamAtt
 			return err
 		}
 		if opts.Policy.WallBudgetedRateLimit(err) {
-			remaining := rateLimitRemaining(ctx, opts.Policy, start)
+			remaining := rateLimitRemaining(ctx, opts.Policy, start, ownerBudget)
 			if remaining <= 0 {
 				return rateLimitBudgetExhausted(ctx, err)
 			}
@@ -159,7 +160,7 @@ func RetryStream(ctx context.Context, opts RetryStreamOptions, attempt StreamAtt
 		if sleepErr := sleep(ctx, delay); sleepErr != nil {
 			return sleepErr
 		}
-		if opts.Policy.WallBudgetedRateLimit(err) && !rateLimitBudgetRemains(ctx, opts.Policy, err, start) {
+		if opts.Policy.WallBudgetedRateLimit(err) && !rateLimitBudgetRemains(ctx, opts.Policy, err, start, ownerBudget) {
 			return rateLimitBudgetExhausted(ctx, err)
 		}
 		// Discard partial output before re-running so the next attempt replaces


### PR DESCRIPTION
Refs #342

Adds explicit one-shot --timeout ownership and propagates the deadline through run/session/model contexts. Rate-limit waits use remaining deadline minus a 30s shutdown reserve; daemon/no-deadline retains the finite 30m fallback. Complete and Stream are symmetric, and deadline exhaustion returns cancellation rather than premature original 429 fatal settlement.

Scope is deadline ownership only; the shared quota coordinator/root priority remains a follow-up PR.