### PR TITLE
fix: strip encrypted reasoning on cross-provider openai replay

### DIFF
--- a/agent/diagnostic/diagnostic.go
+++ b/agent/diagnostic/diagnostic.go
@@ -305,5 +305,10 @@ func isProviderFailure(message string) bool {
 		// stream is what failed.
 		strings.Contains(message, "stream ended without") ||
 		strings.Contains(message, "stream error") ||
-		strings.Contains(message, "missing response in finish event")
+		strings.Contains(message, "missing response in finish event") ||
+		// Encrypted reasoning content replayed to a deployment that did not
+		// produce it (a mid-session provider switch on a legacy transcript
+		// without per-turn provenance). The transcript is fine; the provider
+		// rejected a foreign encrypted_content blob.
+		strings.Contains(message, "encrypted content is not supported")
 }

--- a/agent/diagnostic/diagnostic_test.go
+++ b/agent/diagnostic/diagnostic_test.go
@@ -211,6 +211,26 @@ func TestClassifyStreamTruncationAsProvider(t *testing.T) {
 	}
 }
 
+// TestClassifyEncryptedContentAsProvider covers the legacy-transcript fallback:
+// encrypted reasoning content replayed to a deployment that did not produce it
+// (a mid-session provider switch on a transcript without per-turn provenance).
+// The provider rejects the foreign blob; Classify must surface this as a
+// Provider error with the retry/switch-model hint, not an unclassified Evener error.
+//
+// The message deliberately omits the "error (status=N)" prefix so the
+// providerStatusPrefix regex does not fire: the only path to SourceProvider
+// here is the new "encrypted content is not supported" keyword. Removing the
+// keyword makes this test fail.
+func TestClassifyEncryptedContentAsProvider(t *testing.T) {
+	info := Classify("responses.create(stream) failed: encrypted content is not supported.")
+	if info.Source != SourceProvider {
+		t.Fatalf("Source=%q, want %q", info.Source, SourceProvider)
+	}
+	if info.Title != "Provider error" {
+		t.Fatalf("Title=%q, want Provider error", info.Title)
+	}
+}
+
 // TestFromFields_SourceOverridesClassify verifies that a recognised source
 // string forces the returned Info.Source regardless of what Classify would
 // pick from the (empty) message. Every declared source is listed: one that is

--- a/agent/session_model_call.go
+++ b/agent/session_model_call.go
@@ -1071,7 +1071,7 @@ func (rs replayScope) active() bool { return strings.TrimSpace(rs.BehaviorTag) !
 // builderFamily maps a behavior tag to the wire-format family whose request
 // builder serves it. web_search raw blocks are foreign JSON across families, and
 // the thinking rule is scoped per family (exact-model for anthropic, same-
-// provider for google). An unrecognized tag maps to itself so an unknown
+// provider for google and openai). An unrecognized tag maps to itself so an unknown
 // provider never silently shares a family with a known one.
 //
 // Sibling tags collapse to one family because they emit the *same* raw block
@@ -1100,10 +1100,13 @@ func builderFamily(tag string) string {
 // Empty provenance (legacy transcripts) is always eligible. anthropic-family
 // targets require an exact (instance id, requested model) match — the requested
 // model taken from ResponseRequestModel, or catalog-canonicalized ResponseModel
-// when the request-model field is empty (closes G12). google targets require
-// only the same instance id (its builder must replay prior tool-call thought
-// signatures regardless of model). Every other target keeps its own builder
-// guard, so expansion never strips thinking for it.
+// when the request-model field is empty (closes G12). google and openai targets
+// require the same instance id: google's builder must replay prior tool-call
+// thought signatures regardless of model, and openai Responses carries an
+// opaque encrypted_content blob that only its issuing deployment can decrypt
+// (a cross-deployment replay yields "Encrypted content is not supported").
+// Every other target keeps its own builder guard, so expansion never strips
+// thinking for it.
 func (rs replayScope) thinkingReplayEligible(t schema.Turn) bool {
 	if strings.TrimSpace(t.ResponseProvider) == "" {
 		return true
@@ -1111,7 +1114,7 @@ func (rs replayScope) thinkingReplayEligible(t schema.Turn) bool {
 	switch builderFamily(rs.BehaviorTag) {
 	case "anthropic":
 		return rs.Provider == t.ResponseProvider && rs.requestedModelMatches(t)
-	case "google":
+	case "google", "openai":
 		return rs.Provider == t.ResponseProvider
 	default:
 		return true

--- a/agent/session_replay_provenance_test.go
+++ b/agent/session_replay_provenance_test.go
@@ -180,17 +180,63 @@ func TestExpandHistory_Google_DifferentProvider_ThinkingAbsent(t *testing.T) {
 	}
 }
 
-// --- thinking, openai Responses + openai-compat targets (builder-guarded) ---
+// --- thinking, openai Responses target (same-deployment only) ---
+//
+// openai Responses carries an opaque encrypted_content blob that only its
+// issuing deployment can decrypt. A cross-deployment replay yields a 400
+// "Encrypted content is not supported.", so thinking from a different provider
+// is stripped; same-provider thinking (even across models) replays.
 
-func TestExpandHistory_OpenAIResponses_ThinkingUnfiltered(t *testing.T) {
+func TestExpandHistory_OpenAIResponses_SameProviderDifferentModel_ThinkingReplays(t *testing.T) {
+	t.Parallel()
+	turns := []schema.Turn{assistantThinkingTurn("openai", "gpt-5.4", "gpt-5.4")}
+	out := expandHistory(turns, replayScope{
+		Provider: "openai", Model: "gpt-5.6", BehaviorTag: "openai",
+		InFlightFrom: len(turns), canonicalModel: canonicalModelID,
+	})
+	if !hasContentKind(out, llm.ContentThinking) {
+		t.Fatal("openai same-provider thinking must replay across models")
+	}
+}
+
+func TestExpandHistory_OpenAIResponses_DifferentProvider_ThinkingAbsent(t *testing.T) {
 	t.Parallel()
 	turns := []schema.Turn{assistantThinkingTurn("anthropic", "claude-opus-4-6", "claude-opus-4-6")}
 	out := expandHistory(turns, replayScope{
 		Provider: "openai", Model: "gpt-5.4", BehaviorTag: "openai",
 		InFlightFrom: len(turns), canonicalModel: canonicalModelID,
 	})
-	if !hasContentKind(out, llm.ContentThinking) {
-		t.Fatal("openai Responses keeps its own reasoning guard; expansion must not strip thinking")
+	if hasContentKind(out, llm.ContentThinking) {
+		t.Fatal("openai cross-provider thinking replayed; want it stripped (encrypted_content is deployment-scoped)")
+	}
+	if !hasContentKind(out, llm.ContentText) {
+		t.Fatal("answer text must survive thinking stripping")
+	}
+}
+
+// TestExpandHistory_OpenAIResponses_DifferentProvider_RedactedThinkingAbsent
+// covers the redacted_thinking half of the filter loop: ContentRedThinking is
+// stripped under the same !keepThinking guard as ContentThinking, but no prior
+// test exercised it for the openai family.
+func TestExpandHistory_OpenAIResponses_DifferentProvider_RedactedThinkingAbsent(t *testing.T) {
+	t.Parallel()
+	turns := []schema.Turn{{
+		Kind: schema.TurnAssistant,
+		Message: llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{
+			{Kind: llm.ContentRedThinking, Thinking: &llm.ThinkingData{Text: "redacted"}},
+			{Kind: llm.ContentText, Text: "answer"},
+		}},
+		ResponseProvider: "anthropic",
+	}}
+	out := expandHistory(turns, replayScope{
+		Provider: "openai", Model: "gpt-5.4", BehaviorTag: "openai",
+		InFlightFrom: len(turns), canonicalModel: canonicalModelID,
+	})
+	if hasContentKind(out, llm.ContentRedThinking) {
+		t.Fatal("openai cross-provider redacted_thinking replayed; want it stripped")
+	}
+	if !hasContentKind(out, llm.ContentText) {
+		t.Fatal("answer text must survive redacted_thinking stripping")
 	}
 }
 


### PR DESCRIPTION
## Problem

When switching providers midway through a session, OpenAI Responses `encrypted_content` blobs from a different deployment were replayed verbatim and rejected with:

```
(status=400): responses.create(stream) failed: {"error":{"message":"Encrypted content is not supported.","type":"BadRequestError","param":null,"code":400}}
```

The `thinkingReplayEligible` provenance filter in `agent/session_model_call.go` already enforced same-provider rules for the `anthropic` and `google` families, but `openai` fell through to the `default` case (always eligible). The per-adapter guard in the OpenAI Responses builder (`responses.go:1170`) only skips OpenRouter-style JSON arrays (`IsOpenAICompatEncryptedReasoning`) — a genuine opaque `encrypted_content` blob from a *different* OpenAI deployment passes right through and gets rejected.

## Fix

**1. Extend `thinkingReplayEligible` to the `openai` family** (`agent/session_model_call.go`)

Added `"openai"` to the same-provider case alongside `"google"`. Now thinking/`encrypted_content` blocks are stripped from the outgoing request before it is built when replaying to a different OpenAI deployment. Same-provider stays eligible (the blob may still be valid within the same deployment). Empty provenance (legacy transcripts) stays eligible via the existing early return — no regression for old transcripts.

**2. Diagnostic keyword** (`agent/diagnostic/diagnostic.go`)

Added `"encrypted content is not supported"` to the `isProviderFailure` keyword list, so a legacy-transcript fallback (no per-turn provenance to filter on) surfaces as a Provider error with the retry/switch-model hint instead of an unclassified Evener error.

## What this does not change

- The stored transcript is untouched — the filter only affects the outgoing request (per the existing N4 design).
- The per-adapter guards in Anthropic and openaicompat remain as-is — they already handle cross-family correctly.
- `openai-compat` targets still fall to the `default` case and keep their own builder guard.

## Verification

- `go vet ./agent/...` — exit 0
- `agent/diagnostic` tests — pass (including new `TestClassifyEncryptedContentAsProvider`)
- `agent` replay provenance tests — all pass (including two new OpenAI cases)
- `make merge-approval-gate` — pass (lint 8 modules, build, full test suite, dev-tooling selftest wave)