### PR TITLE
fix(openai): a stalled /v1/responses stream is not an unsupported endpoint

### DIFF
--- a/llm/providers/openai/adapter.go
+++ b/llm/providers/openai/adapter.go
@@ -742,9 +742,11 @@ func (a *Adapter) completeViaChatCompletionsFallback(ctx context.Context, req ll
 }
 
 // Stream implements llm.ProviderAdapter. It tries the Responses API first; if
-// the stream closes with 200 OK but zero content events (a silent failure mode
-// observed for models that do not support /v1/responses), it automatically
-// falls back to /v1/chat/completions. Both failures are surfaced — never silent.
+// that stream closes cleanly with 200 OK but not one recognized Responses API
+// event (a silent failure mode observed for models that do not support
+// /v1/responses), it automatically falls back to /v1/chat/completions. A stream
+// that broke, stalled, or was cancelled is a transport failure and stays on the
+// Responses endpoint. Both failures are surfaced — never silent.
 func (a *Adapter) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
 	if a.Client == nil {
 		a.Client = &http.Client{Timeout: 0}
@@ -775,8 +777,8 @@ func (a *Adapter) Stream(ctx context.Context, req llm.Request) (llm.Stream, erro
 }
 
 // decodeStream proxies the Responses API stream in its own goroutine, watching
-// for the empty-stream sentinel. If the first Responses stream yields no content,
-// it retries that endpoint once before consulting Chat Completions fallback;
+// for the empty-stream sentinel. If the first Responses stream reports one, it
+// retries that endpoint once before consulting Chat Completions fallback;
 // otherwise it forwards Responses events verbatim. It owns closing the proxy
 // ChanStream and the underlying Responses stream.
 func (a *Adapter) decodeStream(out context.Context, proxy *llm.ChanStream, responsesStream llm.Stream, req llm.Request) {

--- a/llm/providers/openai/adapter_test.go
+++ b/llm/providers/openai/adapter_test.go
@@ -1126,6 +1126,128 @@ func TestStream_ResponsesContentThenMidStreamFailure_SurfacesCause(t *testing.T)
 	}
 }
 
+// TestStream_ResponsesStallBeforeContent_StaysOnResponses covers a Responses
+// stream that opens 200 OK, emits one event, then goes silent past the
+// configured StreamRead idle timeout. Silence is evidence about the network or
+// the provider's queue, never about which endpoints the model supports, so the
+// stall must terminate as a retryable stream error carrying the SSE read
+// timeout. Emitting the empty-stream sentinel instead retries Responses and
+// then hands the request to Chat Completions, which cannot serve a reasoning
+// model that also declares function tools (#484).
+func TestStream_ResponsesStallBeforeContent_StaysOnResponses(t *testing.T) {
+	var responsesHits, chatHits atomic.Int32
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/responses":
+			responsesHits.Add(1)
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte("data: {\"type\":\"response.created\",\"sequence_number\":0}\n\n"))
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			// Hold the connection open with nothing further to read: the
+			// decoder's idle timer, not the server, ends this stream.
+			select {
+			case <-release:
+			case <-r.Context().Done():
+			}
+		case "/v1/chat/completions":
+			chatHits.Add(1)
+			w.Header().Set("Content-Type", "text/event-stream")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	// Cleanups run last-registered-first: release the stalled handler before
+	// Close waits on it.
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
+
+	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+	stream, err := a.Stream(context.Background(), llm.Request{
+		Model:          "gpt-5.2",
+		Messages:       []llm.Message{llm.User("hi")},
+		AdapterTimeout: &llm.AdapterTimeout{StreamRead: 20 * time.Millisecond},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer stream.Close() //nolint:errcheck
+
+	_, streamErr := collectStreamEvents(t, stream)
+	if streamErr == nil {
+		t.Fatal("expected a StreamEventError after the stream stalled")
+	}
+	if errors.Is(streamErr, errEmptyResponsesStream) {
+		t.Fatalf("stall wrongly emitted the empty-stream fallback sentinel: %v", streamErr)
+	}
+	if !errors.Is(streamErr, llm.ErrSSEReadTimeout) {
+		t.Fatalf("stall error dropped the SSE read timeout cause: %v", streamErr)
+	}
+	if got := llm.Classify(streamErr); got != llm.ErrorClassRetryable {
+		t.Fatalf("Classify = %v, want retryable: %v", got, streamErr)
+	}
+	if got := responsesHits.Load(); got != 1 {
+		t.Fatalf("Responses hits = %d, want 1", got)
+	}
+	if got := chatHits.Load(); got != 0 {
+		t.Fatalf("Chat Completions hits = %d, want 0: %v", got, streamErr)
+	}
+}
+
+// TestStream_ResponsesReasoningItemThenClose_StaysOnResponses covers a
+// Responses stream that adds a reasoning output item and then closes before any
+// content event. A reasoning item is a Responses-API payload that an endpoint
+// not implementing the API cannot produce, so it proves the endpoint served the
+// request and rules out the empty-stream sentinel's "model may not support
+// /v1/responses" reading. The misclassification window is widest here: at high
+// reasoning effort a model can stream reasoning for a long time before the
+// first counted content event (#484).
+func TestStream_ResponsesReasoningItemThenClose_StaysOnResponses(t *testing.T) {
+	var responsesHits, chatHits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/responses":
+			responsesHits.Add(1)
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte("event: response.output_item.added\n" +
+				"data: {\"type\":\"response.output_item.added\",\"sequence_number\":12,\"output_index\":0," +
+				"\"item\":{\"id\":\"rs_1\",\"type\":\"reasoning\",\"summary\":[]}}\n\n"))
+		case "/v1/chat/completions":
+			chatHits.Add(1)
+			w.Header().Set("Content-Type", "text/event-stream")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+	stream, err := a.Stream(context.Background(), llm.Request{Model: "gpt-5.2", Messages: []llm.Message{llm.User("hi")}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer stream.Close() //nolint:errcheck
+
+	_, streamErr := collectStreamEvents(t, stream)
+	if streamErr == nil {
+		t.Fatal("expected a StreamEventError for a stream that never completed")
+	}
+	if errors.Is(streamErr, errEmptyResponsesStream) {
+		t.Fatalf("reasoning-only stream wrongly emitted the empty-stream fallback sentinel: %v", streamErr)
+	}
+	if got := llm.Classify(streamErr); got != llm.ErrorClassRetryable {
+		t.Fatalf("Classify = %v, want retryable: %v", got, streamErr)
+	}
+	if got := responsesHits.Load(); got != 1 {
+		t.Fatalf("Responses hits = %d, want 1", got)
+	}
+	if got := chatHits.Load(); got != 0 {
+		t.Fatalf("Chat Completions hits = %d, want 0: %v", got, streamErr)
+	}
+}
+
 func TestAdapter_Stream_CloseClosesResponsesStream(t *testing.T) {
 	requestDone := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/llm/providers/openai/adapter_test.go
+++ b/llm/providers/openai/adapter_test.go
@@ -1179,9 +1179,6 @@ func TestStream_ResponsesStallBeforeContent_StaysOnResponses(t *testing.T) {
 	if streamErr == nil {
 		t.Fatal("expected a StreamEventError after the stream stalled")
 	}
-	if errors.Is(streamErr, errEmptyResponsesStream) {
-		t.Fatalf("stall wrongly emitted the empty-stream fallback sentinel: %v", streamErr)
-	}
 	if !errors.Is(streamErr, llm.ErrSSEReadTimeout) {
 		t.Fatalf("stall error dropped the SSE read timeout cause: %v", streamErr)
 	}
@@ -1196,30 +1193,106 @@ func TestStream_ResponsesStallBeforeContent_StaysOnResponses(t *testing.T) {
 	}
 }
 
-// TestStream_ResponsesReasoningItemThenClose_StaysOnResponses covers a
-// Responses stream that adds a reasoning output item and then closes before any
-// content event. A reasoning item is a Responses-API payload that an endpoint
-// not implementing the API cannot produce, so it proves the endpoint served the
-// request and rules out the empty-stream sentinel's "model may not support
-// /v1/responses" reading. The misclassification window is widest here: at high
-// reasoning effort a model can stream reasoning for a long time before the
-// first counted content event (#484).
-func TestStream_ResponsesReasoningItemThenClose_StaysOnResponses(t *testing.T) {
-	var responsesHits, chatHits atomic.Int32
+// endpointHits counts requests per endpoint so a test can prove whether the
+// adapter re-attempted Responses or handed the request to Chat Completions.
+type endpointHits struct{ responses, chat atomic.Int32 }
+
+// responsesEndpointServer serves body as the whole Responses stream and an
+// empty 200 SSE response on Chat Completions, counting hits on both.
+func responsesEndpointServer(t *testing.T, body string) (*Adapter, *endpointHits) {
+	t.Helper()
+	var hits endpointHits
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/responses":
-			responsesHits.Add(1)
+			hits.responses.Add(1)
 			w.Header().Set("Content-Type", "text/event-stream")
-			_, _ = w.Write([]byte("event: response.output_item.added\n" +
-				"data: {\"type\":\"response.output_item.added\",\"sequence_number\":12,\"output_index\":0," +
-				"\"item\":{\"id\":\"rs_1\",\"type\":\"reasoning\",\"summary\":[]}}\n\n"))
+			_, _ = io.WriteString(w, body)
 		case "/v1/chat/completions":
-			chatHits.Add(1)
+			hits.chat.Add(1)
 			w.Header().Set("Content-Type", "text/event-stream")
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
+	}))
+	t.Cleanup(srv.Close)
+	return &Adapter{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}, &hits
+}
+
+// TestStream_RecognizedResponsesEventThenClose_StaysOnResponses covers a
+// Responses stream that closes cleanly after an event this decoder recognizes
+// but before any content. An endpoint that does not implement the Responses API
+// cannot emit these events at all, so their presence proves it served the
+// request: the stream was truncated, which is not a verdict on the endpoint.
+// The window is widest at high reasoning effort, where a model can stream
+// lifecycle and reasoning events for a long time before the first content
+// event (#484).
+func TestStream_RecognizedResponsesEventThenClose_StaysOnResponses(t *testing.T) {
+	cases := []struct {
+		name  string
+		event string
+	}{
+		{"lifecycle created", `{"type":"response.created","sequence_number":0,"response":{"id":"resp_1"}}`},
+		{"reasoning item", `{"type":"response.output_item.added","sequence_number":12,"output_index":0,"item":{"id":"rs_1","type":"reasoning","summary":[]}}`},
+		{"function call item", `{"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"shell"}}`},
+		{"message item", `{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","role":"assistant","content":[]}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, hits := responsesEndpointServer(t, "data: "+tc.event+"\n\n")
+			stream, err := a.Stream(context.Background(), llm.Request{Model: "gpt-5.2", Messages: []llm.Message{llm.User("hi")}})
+			if err != nil {
+				t.Fatalf("Stream: %v", err)
+			}
+			defer stream.Close() //nolint:errcheck
+
+			_, streamErr := collectStreamEvents(t, stream)
+			if streamErr == nil {
+				t.Fatal("expected a StreamEventError for a stream that never completed")
+			}
+			if got := llm.Classify(streamErr); got != llm.ErrorClassRetryable {
+				t.Fatalf("Classify = %v, want retryable: %v", got, streamErr)
+			}
+			if got := hits.responses.Load(); got != 1 {
+				t.Fatalf("Responses hits = %d, want 1 (the sentinel's re-attempt means the event was read as an empty stream): %v", got, streamErr)
+			}
+			if got := hits.chat.Load(); got != 0 {
+				t.Fatalf("Chat Completions hits = %d, want 0: %v", got, streamErr)
+			}
+		})
+	}
+}
+
+// TestStream_ResponsesReadFailureBeforeContent_StaysOnResponses covers a
+// Responses stream whose connection breaks before any event arrives. A read
+// that fails says nothing about which endpoints the model supports — the
+// endpoint never got to answer — so this must terminate as a retryable stream
+// error carrying its cause. Only a stream that closes cleanly having produced
+// no recognized event is evidence about endpoint capability (#484).
+func TestStream_ResponsesReadFailureBeforeContent_StaysOnResponses(t *testing.T) {
+	var responsesHits, chatHits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/chat/completions" {
+			chatHits.Add(1)
+			w.Header().Set("Content-Type", "text/event-stream")
+			return
+		}
+		responsesHits.Add(1)
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Errorf("ResponseWriter is not a Hijacker")
+			return
+		}
+		conn, bufrw, err := hj.Hijack()
+		if err != nil {
+			t.Errorf("hijack: %v", err)
+			return
+		}
+		defer conn.Close()
+		// Announce a chunked stream, then drop the socket without a single
+		// chunk: the body read fails before any event exists.
+		_, _ = bufrw.WriteString("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n")
+		_ = bufrw.Flush()
 	}))
 	t.Cleanup(srv.Close)
 
@@ -1232,19 +1305,44 @@ func TestStream_ResponsesReasoningItemThenClose_StaysOnResponses(t *testing.T) {
 
 	_, streamErr := collectStreamEvents(t, stream)
 	if streamErr == nil {
-		t.Fatal("expected a StreamEventError for a stream that never completed")
+		t.Fatal("expected a StreamEventError after the read failed")
 	}
-	if errors.Is(streamErr, errEmptyResponsesStream) {
-		t.Fatalf("reasoning-only stream wrongly emitted the empty-stream fallback sentinel: %v", streamErr)
-	}
-	if got := llm.Classify(streamErr); got != llm.ErrorClassRetryable {
-		t.Fatalf("Classify = %v, want retryable: %v", got, streamErr)
+	if errors.Unwrap(streamErr) == nil {
+		t.Fatalf("surfaced stream error dropped the underlying read cause: %v", streamErr)
 	}
 	if got := responsesHits.Load(); got != 1 {
-		t.Fatalf("Responses hits = %d, want 1", got)
+		t.Fatalf("Responses hits = %d, want 1 (a broken read was read as an unsupported endpoint): %v", got, streamErr)
 	}
 	if got := chatHits.Load(); got != 0 {
 		t.Fatalf("Chat Completions hits = %d, want 0: %v", got, streamErr)
+	}
+}
+
+// TestStream_UnrecognizedEventThenClose_FallsBackToChatCompletions holds the
+// line on the other side of the sentinel. An event type this decoder does not
+// know is forwarded raw and proves nothing about the endpoint, so a 200 stream
+// carrying only one of those and then closing cleanly is still an empty stream:
+// it must retry Responses once and then hand the request to Chat Completions.
+// Widening "recognized" to any "response.*" string would silently disable the
+// fallback for genuinely unsupported endpoints, and this is the test that
+// notices.
+func TestStream_UnrecognizedEventThenClose_FallsBackToChatCompletions(t *testing.T) {
+	a, hits := responsesEndpointServer(t, "data: {\"type\":\"response.some_future_event\",\"detail\":\"x\"}\n\n")
+	stream, err := a.Stream(context.Background(), llm.Request{Model: "gpt-5.2", Messages: []llm.Message{llm.User("hi")}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer stream.Close() //nolint:errcheck
+
+	_, streamErr := collectStreamEvents(t, stream)
+	if streamErr == nil {
+		t.Fatal("expected a StreamEventError from the Chat Completions fallback")
+	}
+	if got := hits.responses.Load(); got != 2 {
+		t.Fatalf("Responses hits = %d, want 2 (the sentinel's single re-attempt): %v", got, streamErr)
+	}
+	if got := hits.chat.Load(); got != 1 {
+		t.Fatalf("Chat Completions hits = %d, want 1 — the unsupported-endpoint fallback no longer fires: %v", got, streamErr)
 	}
 }
 

--- a/llm/providers/openai/responses.go
+++ b/llm/providers/openai/responses.go
@@ -223,7 +223,8 @@ func openAICodexUnsupportedRequestField(key string) bool {
 }
 
 // streamResponses is the raw Responses API streaming path.
-// It emits errEmptyResponsesStream if the stream closes 200 OK with zero content.
+// It emits errEmptyResponsesStream if the stream closes 200 OK without any
+// evidence that the endpoint served the request.
 func (a *Adapter) streamResponses(ctx context.Context, req llm.Request) (llm.Stream, error) {
 	parentCtx := ctx
 	sctx, cancel := context.WithCancel(ctx)
@@ -581,8 +582,8 @@ func responsesInbandError(data []byte) error {
 // decodeResponsesStream consumes the Responses API SSE stream in its own
 // goroutine: it translates each event into llm stream events and emits the final
 // accumulated Response on response.completed. It emits errEmptyResponsesStream if
-// the stream closes 200 OK with zero content. It owns closing the response body
-// and the ChanStream.
+// the stream closes 200 OK without any evidence that the endpoint served the
+// request. It owns closing the response body and the ChanStream.
 func (a *Adapter) decodeResponsesStream(sctx context.Context, cancel context.CancelFunc, resp *http.Response, s *llm.ChanStream, req llm.Request, _ []byte, attempt *transport.APIAttemptCapture) {
 	defer func() {
 		_ = resp.Body.Close()
@@ -595,8 +596,12 @@ func (a *Adapter) decodeResponsesStream(sctx context.Context, cancel context.Can
 	finished := false
 	var finalEvent *llm.StreamEvent
 	// sentContent tracks whether any meaningful content event was emitted.
-	// If the stream closes without content, we emit errEmptyResponsesStream.
 	sentContent := false
+	// sawReasoningItem records a reasoning output item — a Responses-API
+	// payload an endpoint that does not implement the API cannot produce. It
+	// proves the endpoint served this model before any content event, which a
+	// model at high reasoning effort can take a long time to reach.
+	sawReasoningItem := false
 	acc := newResponsesOutputAccumulator()
 
 	parseErr := llm.ParseSSE(sctx, resp.Body, func(ev llm.SSEEvent) error {
@@ -620,6 +625,9 @@ func (a *Adapter) decodeResponsesStream(sctx context.Context, cancel context.Can
 		switch typ {
 		case "response.output_item.added":
 			if item, ok := payload["item"].(map[string]any); ok {
+				if itemType, _ := item["type"].(string); itemType == "reasoning" {
+					sawReasoningItem = true
+				}
 				acc.HandleOutputItemAdded(item)
 			}
 		case "response.output_text.delta":
@@ -752,9 +760,17 @@ func (a *Adapter) decodeResponsesStream(sctx context.Context, cancel context.Can
 			// The provider reported a structured failure in-band; the decoded,
 			// typed error is the stream's terminal error in its own right.
 			terminalErr = fatal.Err
-		case !sentContent:
-			// Stream closed 200 OK with zero content: model likely does not
-			// support /v1/responses. Signal the caller to try Chat Completions.
+		case errors.Is(parseErr, llm.ErrSSEReadTimeout):
+			// The stream went idle past the read timeout. Silence is evidence
+			// about the network or the provider's queue, never about which
+			// endpoints the model supports, so it must stay a retryable stream
+			// error carrying its cause instead of handing the request to Chat
+			// Completions.
+			terminalErr = llm.NewStreamError("openai", "openai responses stream stalled without completion", parseErr)
+		case !sentContent && !sawReasoningItem:
+			// Stream closed 200 OK having produced nothing the Responses API
+			// alone can produce: model likely does not support /v1/responses.
+			// Signal the caller to try Chat Completions.
 			terminalErr = errEmptyResponsesStream
 		default:
 			// Content was streamed, then the stream ended without completion —

--- a/llm/providers/openai/responses.go
+++ b/llm/providers/openai/responses.go
@@ -579,11 +579,37 @@ func responsesInbandError(data []byte) error {
 	return inbandStreamError("responses.create(stream)", inband, raw)
 }
 
+// responsesAPIEventTypes are the event types this decoder recognizes as the
+// Responses API's own: the ones the decode switch below handles, plus the
+// lifecycle events OpenAI documents ahead of the first delta. An endpoint that
+// does not implement the Responses API cannot emit any of them, which is what
+// makes them proof that the endpoint served the request.
+//
+// Two deliberate exclusions keep that proof honest. An unrecognized
+// "response.*" type is not enough: it is forwarded raw precisely because this
+// decoder does not know what it is, so it cannot vouch for the endpoint. A bare
+// "error" envelope is not enough either — it is generic SSE, not this API. Both
+// leave the empty-stream sentinel armed.
+var responsesAPIEventTypes = map[string]struct{}{
+	"response.created":                       {},
+	"response.in_progress":                   {},
+	"response.content_part.added":            {},
+	"response.output_item.added":             {},
+	"response.output_item.done":              {},
+	"response.output_text.delta":             {},
+	"response.reasoning_summary_part.added":  {},
+	"response.reasoning_summary_text.delta":  {},
+	"response.function_call_arguments.delta": {},
+	"response.function_call_arguments.done":  {},
+	"response.completed":                     {},
+	"response.failed":                        {},
+}
+
 // decodeResponsesStream consumes the Responses API SSE stream in its own
 // goroutine: it translates each event into llm stream events and emits the final
 // accumulated Response on response.completed. It emits errEmptyResponsesStream if
-// the stream closes 200 OK without any evidence that the endpoint served the
-// request. It owns closing the response body and the ChanStream.
+// the stream closes cleanly, 200 OK, without a single recognized Responses API
+// event. It owns closing the response body and the ChanStream.
 func (a *Adapter) decodeResponsesStream(sctx context.Context, cancel context.CancelFunc, resp *http.Response, s *llm.ChanStream, req llm.Request, _ []byte, attempt *transport.APIAttemptCapture) {
 	defer func() {
 		_ = resp.Body.Close()
@@ -595,13 +621,12 @@ func (a *Adapter) decodeResponsesStream(sctx context.Context, cancel context.Can
 	reasoningStarted := false
 	finished := false
 	var finalEvent *llm.StreamEvent
-	// sentContent tracks whether any meaningful content event was emitted.
-	sentContent := false
-	// sawReasoningItem records a reasoning output item — a Responses-API
-	// payload an endpoint that does not implement the API cannot produce. It
-	// proves the endpoint served this model before any content event, which a
-	// model at high reasoning effort can take a long time to reach.
-	sawReasoningItem := false
+	// sawResponsesEvent records an event this decoder recognizes as belonging
+	// to the Responses API. It is the whole evidence the empty-stream sentinel
+	// rests on: an endpoint that does not implement the API cannot produce one,
+	// so seeing any of them proves the endpoint served this model — long before
+	// content arrives, which at high reasoning effort can take a while.
+	sawResponsesEvent := false
 	acc := newResponsesOutputAccumulator()
 
 	parseErr := llm.ParseSSE(sctx, resp.Body, func(ev llm.SSEEvent) error {
@@ -621,13 +646,13 @@ func (a *Adapter) decodeResponsesStream(sctx context.Context, cancel context.Can
 		if typ == "" {
 			typ = ev.Event
 		}
+		if _, ok := responsesAPIEventTypes[typ]; ok {
+			sawResponsesEvent = true
+		}
 
 		switch typ {
 		case "response.output_item.added":
 			if item, ok := payload["item"].(map[string]any); ok {
-				if itemType, _ := item["type"].(string); itemType == "reasoning" {
-					sawReasoningItem = true
-				}
 				acc.HandleOutputItemAdded(item)
 			}
 		case "response.output_text.delta":
@@ -638,7 +663,6 @@ func (a *Adapter) decodeResponsesStream(sctx context.Context, cancel context.Can
 			if delta == "" {
 				return nil
 			}
-			sentContent = true
 			if !textStarted {
 				textStarted = true
 				s.Send(llm.StreamEvent{Type: llm.StreamEventTextStart, TextID: textID})
@@ -649,7 +673,6 @@ func (a *Adapter) decodeResponsesStream(sctx context.Context, cancel context.Can
 			if delta == "" {
 				return nil
 			}
-			sentContent = true
 			s.Send(llm.StreamEvent{Type: llm.StreamEventReasoningDelta, ReasoningDelta: delta})
 		case "response.reasoning_summary_part.added":
 			// Detailed reasoning arrives as multiple summary parts; separate
@@ -666,7 +689,6 @@ func (a *Adapter) decodeResponsesStream(sctx context.Context, cancel context.Can
 				return nil
 			}
 			if !st.started {
-				sentContent = true
 				st.started = true
 				tc := llm.ToolCallData{ID: st.id, ItemID: st.itemID, Name: st.name, Type: "function"}
 				s.Send(llm.StreamEvent{Type: llm.StreamEventToolCallStart, ToolCall: &tc})
@@ -682,7 +704,6 @@ func (a *Adapter) decodeResponsesStream(sctx context.Context, cancel context.Can
 			switch {
 			case ok:
 				if !st.started {
-					sentContent = true
 					st.started = true
 					tc := llm.ToolCallData{ID: st.id, ItemID: st.itemID, Name: st.name, Type: "function"}
 					s.Send(llm.StreamEvent{Type: llm.StreamEventToolCallStart, ToolCall: &tc})
@@ -720,7 +741,6 @@ func (a *Adapter) decodeResponsesStream(sctx context.Context, cancel context.Can
 				s.Send(llm.StreamEvent{Type: llm.StreamEventTextEnd, TextID: textID})
 				textStarted = false
 			}
-			sentContent = true
 			rp := r
 			event := llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &r.Finish, Usage: &r.Usage, Response: &rp}
 			if attempt.Active() {
@@ -753,6 +773,11 @@ func (a *Adapter) decodeResponsesStream(sctx context.Context, cancel context.Can
 	var terminalErr error
 	var fatal *transport.FatalStreamError
 	if !finished {
+		// Every read failure is handled before the empty-stream sentinel, so
+		// the sentinel can only fire for a stream that closed cleanly. A read
+		// that broke, timed out, or was cancelled is evidence about the
+		// transport; only a clean close with nothing recognized on it is
+		// evidence about what the endpoint implements.
 		switch {
 		case sctx.Err() != nil:
 			terminalErr = llm.WrapContextError("openai", sctx.Err())
@@ -761,21 +786,24 @@ func (a *Adapter) decodeResponsesStream(sctx context.Context, cancel context.Can
 			// typed error is the stream's terminal error in its own right.
 			terminalErr = fatal.Err
 		case errors.Is(parseErr, llm.ErrSSEReadTimeout):
-			// The stream went idle past the read timeout. Silence is evidence
-			// about the network or the provider's queue, never about which
-			// endpoints the model supports, so it must stay a retryable stream
-			// error carrying its cause instead of handing the request to Chat
-			// Completions.
+			// The stream went idle past the read timeout. Named separately from
+			// the read failures below because a stall is the one an operator
+			// most often has to tell apart from a broken connection.
 			terminalErr = llm.NewStreamError("openai", "openai responses stream stalled without completion", parseErr)
-		case !sentContent && !sawReasoningItem:
-			// Stream closed 200 OK having produced nothing the Responses API
-			// alone can produce: model likely does not support /v1/responses.
-			// Signal the caller to try Chat Completions.
+		case parseErr != nil:
+			// The read failed. Surface its cause.
+			terminalErr = llm.NewStreamError("openai", "openai responses stream ended without completion", parseErr)
+		case !sawResponsesEvent:
+			// The stream closed cleanly, 200 OK, without a single event this
+			// decoder recognizes as the Responses API: the model likely does
+			// not support /v1/responses. Signal the caller to try Chat
+			// Completions.
 			terminalErr = errEmptyResponsesStream
 		default:
-			// Content was streamed, then the stream ended without completion —
-			// a genuine mid-stream read failure; surface its cause.
-			terminalErr = llm.NewStreamError("openai", "openai responses stream ended without completion", parseErr)
+			// The endpoint served real Responses events and then closed cleanly
+			// without response.completed — a truncated response, with no read
+			// error to report as its cause.
+			terminalErr = llm.NewStreamError("openai", "openai responses stream closed before response.completed", nil)
 		}
 	}
 	var response *llm.Response

--- a/llm/providers/openai/wire_capture_test.go
+++ b/llm/providers/openai/wire_capture_test.go
@@ -482,8 +482,8 @@ func TestResponsesStreamWireCaptureClassifiesSSEReadTimeoutAsProviderTimeout(t *
 	}
 	for range stream.Events() { //nolint:revive // Drain to the terminal timeout evidence.
 	}
-	if len(sink.attempts) != 2 {
-		t.Fatalf("canonical attempts = %d, want Responses plus existing empty-stream Chat fallback", len(sink.attempts))
+	if len(sink.attempts) != 1 {
+		t.Fatalf("canonical attempts = %d, want the single stalled Responses attempt (a stall is not the empty-stream sentinel, so it does not re-attempt the endpoint)", len(sink.attempts))
 	}
 	for i, attempt := range sink.attempts {
 		if attempt.Outcome != apilog.AttemptProviderTimeout {


### PR DESCRIPTION
Closes #484.

## Mechanism

`decodeResponsesStream` picks its terminal error from an ordered switch. The
SSE idle-read timeout (`llm.ErrSSEReadTimeout`, 30s by default via
`AdapterTimeout.StreamRead`) arrives as `parseErr`, not as a context error, so
a stream that opened 200 OK and then went quiet fell into `case !sentContent:`
and was labelled an endpoint-capability failure.

Everything downstream is deterministic from there. `Classify` maps the sentinel
to `ErrorClassFallback` on the "responses stream closed with no events" text;
`decodeStream` re-attempts `/v1/responses` once and then hands the request to
`/v1/chat/completions`, which is a hard 400 for any model combining
`reasoning_effort` with function tools. The session dies on a condition the
field evidence shows recovering on a single retry.

## The rule this implements

The sentinel now fires only when **both** hold:

1. **The stream closed cleanly** (`parseErr == nil`). Every read failure —
   timeout, broken socket, anything — is decided ahead of it. A read that
   failed is evidence about the transport; the endpoint never got to answer.
2. **Not one recognized Responses API event arrived.** An endpoint that does
   not implement the API cannot emit `response.created`,
   `response.output_item.added`, or any of their siblings, so seeing one proves
   it served the request.

That is what the sentinel's own message has always claimed ("closed with no
events") while the code tested for no *content* events. The gap between those
two was the bug.

```go
switch {
case sctx.Err() != nil:                        // caller/deadline
case errors.As(parseErr, &fatal):              // structured in-band failure
case errors.Is(parseErr, llm.ErrSSEReadTimeout): // stall, named for operators
case parseErr != nil:                          // any other read failure
case !sawResponsesEvent:                       // clean close, nothing recognized
default:                                       // clean close, truncated response
}
```

`sawResponsesEvent` is set from `responsesAPIEventTypes`, a curated set: the
event types the decode switch handles, plus the lifecycle events OpenAI
documents ahead of the first delta (`response.created`, `response.in_progress`,
`response.content_part.added`). It subsumes the old `sentContent` flag — every
content path runs inside a recognized event — so the five scattered
`sentContent = true` assignments are gone.

**Deliberately excluded, because the fallback has to keep working.**
Recognition is a set membership test, not a `response.` prefix test. An
unrecognized event type is forwarded raw precisely because this decoder cannot
say what it is, so it cannot vouch for the endpoint, and it leaves the sentinel
armed. A bare `error` envelope is generic SSE, not this API, and is excluded
for the same reason.

## Tests

Written first, watched fail:

- **`TestStream_RecognizedResponsesEventThenClose_StaysOnResponses`** (4 rows:
  `response.created`, and `response.output_item.added` carrying a reasoning,
  function_call, or message item). Each closes cleanly with no content. Pins
  one Responses attempt, zero Chat Completions hits, retryable classification.
  Three of the four rows failed before this change with `Responses hits = 2`
  and the request landing on Chat Completions.
- **`TestStream_ResponsesReadFailureBeforeContent_StaysOnResponses`** — a
  hijacking server announces a chunked stream and drops the socket without a
  single chunk, so the read fails before any event exists. Pins that the cause
  survives (`errors.Unwrap != nil`), one Responses attempt, zero Chat hits.
- **`TestStream_ResponsesStallBeforeContent_StaysOnResponses`** — one
  `response.created` frame, then silence past a 20ms `StreamRead`, driven
  through the real `ParseSSE` idle timer. Pins `errors.Is(err,
  llm.ErrSSEReadTimeout)`, retryable, one Responses attempt, zero Chat hits.

Regression guard, validated by mutation rather than by assertion:

- **`TestStream_UnrecognizedEventThenClose_FallsBackToChatCompletions`** — a
  200 stream carrying only `response.some_future_event`, closing cleanly, must
  still re-attempt Responses once and then fall back (2 Responses hits, 1 Chat
  hit). To prove it is a live guard I replaced the set lookup with
  `strings.HasPrefix(typ, "response.")` and re-ran: exactly two tests failed,
  this one and the pre-existing
  `TestResponsesInbandError_UnknownEventStillPassthrough`. Reverted after.

The four `TestStream_EmptyResponsesStream_*` tests, the unknown-event
passthrough test, and `TestStream_ResponsesContentThenMidStreamFailure_
SurfacesCause` — the pins for genuine unsupported-endpoint detection — are
untouched and green.

`TestResponsesStreamWireCaptureClassifiesSSEReadTimeoutAsProviderTimeout`
needed its attempt count moved from 2 to 1. Its subject, that an SSE-read
timeout is recorded as `provider_timeout`, is unchanged; the second attempt it
counted was the sentinel's re-attempt, which this PR removes.

Two assertions in the first revision of these tests could not fail in either
build state and were removed: `errors.Is(streamErr, errEmptyResponsesStream)`
(the sentinel is consumed inside `decodeStream` and never reaches a caller
whose fallback is enabled) and, in the reasoning case, a `Classify` check that
the Chat Completions error also satisfied. The endpoint hit counts are the
assertions doing the work.

## Downstream behavior change (intended, recorded here)

Post-fix, a persistent stall is retryable, so `RetryStream` fails fast after 4
attempts as `ProviderUnhealthyError{Shape:"stall"}`, which
`modelFallbackEligible` (`agent/session_init.go:1298`) excludes from model
fallback. Pre-fix the same condition became a permanent 400, which *was*
fallback-eligible. So the round now costs roughly 4 x `StreamRead` before
settling with steering, instead of dying on a 400. This is what
`docs/superpowers/specs/2026-08-07-provider-failure-feedback-design.md:194-204`
specifies for a consume-phase stall (it counts toward the streak, with its own
steering wording), so it is the documented design rather than a side effect.

## Gates

Pinned toolchain (go 1.27.0, golangci-lint 2.13.1 per `.tool-versions`),
looping workspace modules as the Makefile does. All foreground, all after the
final revision:

- `make lint` — PASS (8 modules), including `lint-evenerfuzz` and `lint-eval`;
  both also re-run standalone (each does host **and** `GOOS=linux` `go vet`
  under its tag across all 8 modules, plus tagliatelle).
- `make build` — PASS.
- `ROOT_FULL=1 make test` — PASS (7 Go modules + web).
- `make test-dev-tooling` — PASS (12 suites).
- `make fuzz-seeds` — PASS.
- `go test -race ./providers/openai/` — PASS.
- The four new/changed tests at `-count=15` — no flakes.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT
