### PR TITLE
fix: defer delegate delivery through input drain

### DIFF
--- a/agent/delegate_delivery.go
+++ b/agent/delegate_delivery.go
@@ -807,11 +807,17 @@ func (s *Session) acceptDelegateDeliveryPlan(plan delegateDeliveryPlan) (delegat
 	}
 	s.delegateDeliveryMu.Lock()
 	s.mu.Lock()
-	processing := s.state == SessionProcessing
+	// goalInTurn remains true across a terminal communicate's Idle transition
+	// until the enclosing ProcessInput drain has made its delivery cut.
+	processing := s.state == SessionProcessing || s.goalInTurn
 	s.mu.Unlock()
 	// A waiter-bearing plan completes a tool executing in this processing turn.
 	// Deferring it behind that turn would make the turn wait on its own queue.
-	if processing && plan.waiter == nil {
+	deferred := processing && plan.waiter == nil
+	if hook := s.cfg.testOnly.delegateDeliveryClassified; hook != nil {
+		hook(s, deferred)
+	}
+	if deferred {
 		s.pendingDelegateDeliveries = append(s.pendingDelegateDeliveries, plan)
 		shouldWake := !s.delegateDeliveryWake && !s.delegateDeliveryRetry.active
 		if shouldWake {

--- a/agent/session_communicate_test.go
+++ b/agent/session_communicate_test.go
@@ -350,13 +350,6 @@ type communicateSessionRoutedAdapter struct {
 	status     llm.ToolCallData
 	childDone  llm.ToolCallData
 	parentDone llm.ToolCallData
-
-	// childRequestSeen closes the instant the first child (delegate) model
-	// request arrives, so a caller can await that event directly instead of
-	// polling requestCounts(). It is the actual completion signal for "the
-	// delegate reached its model call" -- requestCounts() only reports state
-	// a poll would otherwise have to catch mid-transition.
-	childRequestSeen chan struct{}
 }
 
 func (*communicateSessionRoutedAdapter) Name() string { return "openai" }
@@ -376,9 +369,6 @@ func (a *communicateSessionRoutedAdapter) Complete(_ context.Context, req llm.Re
 		}
 	} else {
 		a.childRequests++
-		if a.childRequests == 1 && a.childRequestSeen != nil {
-			close(a.childRequestSeen)
-		}
 		response = toolCallResponse(a.childDone)
 	}
 	response.Provider = a.Name()
@@ -423,15 +413,39 @@ func TestCommunicate_StatusBatchedWithDelegateDoesNotEndTurn(t *testing.T) {
 	childDone := communicateCall("child_done", "CHILD_DONE")
 	parentDone := communicateCall("parent_done", "Parent saw the delegate complete.")
 	f := &communicateSessionRoutedAdapter{
-		delegate:         delegate,
-		status:           status,
-		childDone:        childDone,
-		parentDone:       parentDone,
-		childRequestSeen: make(chan struct{}),
+		delegate:   delegate,
+		status:     status,
+		childDone:  childDone,
+		parentDone: parentDone,
 	}
 	c.Register(f)
 
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: t.TempDir()})
+	rootIdle := make(chan struct{})
+	deliveryClassified := make(chan bool, 1)
+	var releaseChild sync.Once
+	t.Cleanup(func() { releaseChild.Do(func() { close(rootIdle) }) })
+	var boundaryOnce sync.Once
+	var deliveryWasDeferred bool
+	var sess *Session
+	cfg := SessionConfig{StateDir: t.TempDir()}
+	cfg.testOnly.subagentAfterFinalStatePublish = func(*subagent) { <-rootIdle }
+	cfg.testOnly.afterCommunicateBoundary = func(s *Session) {
+		if s != sess {
+			return
+		}
+		boundaryOnce.Do(func() {
+			releaseChild.Do(func() { close(rootIdle) })
+			deliveryWasDeferred = <-deliveryClassified
+		})
+	}
+	cfg.testOnly.delegateDeliveryClassified = func(s *Session, deferred bool) {
+		if s == sess {
+			deliveryClassified <- deferred
+		}
+	}
+
+	var err error
+	sess, err = NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), cfg)
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -446,19 +460,11 @@ func TestCommunicate_StatusBatchedWithDelegateDoesNotEndTurn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProcessInput: %v", err)
 	}
-	// The delegate child runs asynchronously and the parent turn does not wait
-	// for it, so Close here would cancel a child that has not yet reached its
-	// model call. Await the child's own completion signal (its adapter Complete
-	// call closes childRequestSeen) rather than polling requestCounts(), so
-	// this observes the transition itself instead of racing to catch it.
-	// TRIPWIRE: the child is a scripted in-process adapter call with no real
-	// I/O, so it normally closes the channel in well under a second; 30s only
-	// fires if the child genuinely never reaches its model call.
-	awaitWithin(t, 30*time.Second, "child delegate model request", func() {
-		<-f.childRequestSeen
-	})
 	sess.Close()
 
+	if !deliveryWasDeferred {
+		t.Fatal("delegate completion crossed the terminal boundary instead of waiting for the ProcessInput drain")
+	}
 	if strings.TrimSpace(out) != "Parent saw the delegate complete." {
 		t.Fatalf("ProcessInput returned %q, want parent final", out)
 	}

--- a/agent/session_config.go
+++ b/agent/session_config.go
@@ -269,6 +269,12 @@ type testConfig struct {
 	// cut is captured. Tests use it only to place deterministic finalize/cut
 	// ordering barriers. Nil in production.
 	beforeTerminalCommunicateAccept func()
+	// afterCommunicateBoundary observes the state transition at a completed
+	// communicate boundary. Nil in production.
+	afterCommunicateBoundary func(*Session)
+	// delegateDeliveryClassified observes whether an incoming waiterless delivery
+	// was deferred to the enclosing ProcessInput drain. Nil in production.
+	delegateDeliveryClassified func(*Session, bool)
 	// terminalCutAfterManagerLock observes captureTerminalNotificationCut after
 	// it owns jm.mu and before it reads durable/running/queue state. It permits a
 	// concurrent finalizer to prove which side of the cut owns the notification.

--- a/agent/session_tool_round.go
+++ b/agent/session_tool_round.go
@@ -510,5 +510,8 @@ func (s *Session) deliverIfCommunicated(ctx context.Context, askedThisRound bool
 		}
 	}
 	s.finishProcessingAtBoundary(ctx, boundaryState)
+	if hook := s.cfg.testOnly.afterCommunicateBoundary; hook != nil {
+		hook(s)
+	}
 	return true, text, nil
 }

--- a/agent/session_tools_worktree_branches_test.go
+++ b/agent/session_tools_worktree_branches_test.go
@@ -207,7 +207,7 @@ func TestRelPathUnderManagedDir(t *testing.T) {
 		if err := os.MkdirAll(sub, 0755); err != nil {
 			t.Fatalf("mkdir: %v", err)
 		}
-		rel, ok := relPathUnderManagedDir(sub, dir)
+		rel, ok := relPathUnderManagedDir(canonicalOrClean(sub), dir)
 		if !ok || rel != "subdir" {
 			t.Fatalf("rel=%q ok=%v", rel, ok)
 		}
@@ -240,7 +240,7 @@ func TestIsUnderManagedDir(t *testing.T) {
 		if err := os.MkdirAll(sub, 0755); err != nil {
 			t.Fatalf("mkdir: %v", err)
 		}
-		if !isUnderManagedDir(sub, dir) {
+		if !isUnderManagedDir(canonicalOrClean(sub), dir) {
 			t.Fatalf("expected true for path under dir")
 		}
 	})


### PR DESCRIPTION
## Summary

- keep waiterless delegate completion queued until the enclosing `ProcessInput` drain has made its delivery cut
- make the existing status-plus-delegate regression force the terminal-boundary ordering that failed twice in #470 CI
- canonicalize two managed-worktree test fixtures so they honor the helper contract on macOS symlinked temp roots

This is the focused prerequisite extracted from the unfinished #471 scope. It fixes the lifecycle race without bringing the provisional communicate-preview feature along.

## Verification

- red regression before the production condition change
- `go test ./agent -run '^TestCommunicate_StatusBatchedWithDelegateDoesNotEndTurn$' -count=100`
- `go test -race ./agent -run '^TestCommunicate_StatusBatchedWithDelegateDoesNotEndTurn$' -count=20`
- `go test ./agent`
- `go test ./agent -run '^(TestRelPathUnderManagedDir|TestIsUnderManagedDir)$' -count=1`