### PR TITLE
ci: run merge checks in parallel without stale revisions

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -8,6 +8,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -14,9 +14,8 @@ permissions:
   contents: read
 
 jobs:
-  # PRs, main pushes, and manual runs prove the release build produces the
-  # exact artifacts install.sh consumes; tags publish through the release
-  # job instead.
+  # Main pushes and manual runs prove the release build produces the exact
+  # artifacts install.sh consumes; tags publish through the release job instead.
   build:
     name: Build snapshot artifacts
     if: github.ref_type != 'tag'

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     tags: ["v*"]
   workflow_dispatch:
-  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,15 @@ jobs:
 
       - uses: ./.github/actions/setup-toolchain
 
+      - name: Read golangci-lint version
+        id: golangci-version
+        run: |
+          echo "version=$(awk '$1=="golangci-lint" {print $2}' .tool-versions)" >> "$GITHUB_OUTPUT"
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Install golangci-lint for dev-tooling self-tests
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" "v${{ steps.golangci-version.outputs.version }}"
+
       - name: Deterministic tests (full root suite; frontend covered by web job)
         run: ROOT_FULL=1 WEB=0 make test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -24,6 +28,73 @@ jobs:
       - name: Test, build, and browser guards
         run: make test-web && make build-web && make test-web-browser
 
+  static:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-toolchain
+
+      - name: Build runtime pair and all Go workspace packages
+        run: make build && make build-go
+
+      - name: Vet (all go.work modules)
+        run: make vet
+
+      - name: Read tool versions
+        id: tool-versions
+        run: |
+          echo "golangci=$(awk '$1=="golangci-lint" {print $2}' .tool-versions)" >> "$GITHUB_OUTPUT"
+          echo "gitleaks=$(awk '$1=="gitleaks" {print $2}' .tool-versions)" >> "$GITHUB_OUTPUT"
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Install golangci-lint
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" "v${{ steps.tool-versions.outputs.golangci }}"
+
+      - name: Install gitleaks
+        run: go install github.com/zricethezav/gitleaks/v8@v${{ steps.tool-versions.outputs.gitleaks }}
+
+      - name: Lint (make lint — every family of the local gate, all go.work modules)
+        env:
+          EVENER_GITLEAKS_REQUIRED: "1"
+        run: make lint
+
+      - name: Fuzz gap check (every decode/parse package has a target — static, fast)
+        run: make fuzz-gap-check
+
+      - name: Secret scan (gitleaks — committed fuzz corpora)
+        env:
+          EVENER_GITLEAKS_REQUIRED: "1"
+        run: make fuzz-corpus-scan
+
+  race:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-toolchain
+
+      - name: Test (race detector — the permanent -race gate, all go.work modules)
+        run: make test-race
+
+  tests-and-fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-toolchain
+
+      - name: Deterministic tests (full root suite; frontend covered by web job)
+        run: ROOT_FULL=1 WEB=0 make test
+
+      - name: Dev-tooling self-test wave (scripts/*-selftest.sh — tooling, not the product)
+        run: make test-dev-tooling
+
+      - name: Fuzz seed-corpus replay (committed crashers — no search, deterministic)
+        run: make fuzz
+
+  # Temporary compatibility job. Branch protection requires this context until
+  # the split jobs above have run successfully and protection is cut over.
   build-and-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
 
   snapshot-artifacts:
     name: Build snapshot artifacts
+    if: github.event_name == 'pull_request'
     needs: [static, race, tests-and-fuzz, web]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,6 @@ jobs:
       - name: Fuzz gap check (every decode/parse package has a target — static, fast)
         run: make fuzz-gap-check
 
-      - name: Secret scan (gitleaks — committed fuzz corpora)
-        env:
-          EVENER_GITLEAKS_REQUIRED: "1"
-        run: make fuzz-corpus-scan
-
   race:
     runs-on: ubuntu-latest
     steps:
@@ -101,6 +96,10 @@ jobs:
 
       - name: Fuzz seed-corpus replay (committed crashers — no search, deterministic)
         run: make fuzz
+
+  snapshot-artifacts:
+    needs: [static, race, tests-and-fuzz, web]
+    uses: ./.github/workflows/binaries.yml
 
   # Temporary compatibility job. Branch protection requires this context until
   # the split jobs above have run successfully and protection is cut over.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,35 @@ jobs:
         run: make fuzz
 
   snapshot-artifacts:
+    name: Build snapshot artifacts
     needs: [static, race, tests-and-fuzz, web]
-    uses: ./.github/workflows/binaries.yml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-toolchain
+
+      - name: Build snapshot
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: "~> v2"
+          args: release --snapshot --clean
+        env:
+          BUILD_CHANNEL: snapshot
+
+      - name: Inspect archives
+        run: for f in dist/*.tar.gz; do echo "== $f"; tar -tzf "$f"; done
+
+      - name: Upload archives
+        uses: actions/upload-artifact@v7
+        with:
+          name: evener-snapshot-artifacts
+          path: |
+            dist/*.tar.gz
+            dist/checksums.txt
+          if-no-files-found: error
 
   # Temporary compatibility job. Branch protection requires this context until
   # the split jobs above have run successfully and protection is cut over.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/docs/developing-evener/testing.md
+++ b/docs/developing-evener/testing.md
@@ -205,7 +205,8 @@ post-merge surface.
 
 Run it locally pre-merge and post-merge; `make merge-approval-gate` runs it as
 its third phase. The required CI equivalent is `ROOT_FULL=1 WEB=0 make test`,
-because the web job owns `make test-web` and the Go job must not duplicate it.
+because the web job owns `make test-web` and the deterministic Go job must not
+duplicate it.
 
 Requirements are the same as `make test`. `ROOT_FULL=1` enables no provider and
 no fuzz search. Any root or module failure is nonzero, and live tests stay
@@ -294,8 +295,8 @@ coverage, including those tests and the excluded root fuzz-tool packages, is
 explicitly owned and run by make fuzz. Ordinary make test remains the default
 local command and keeps the root wave in short mode unless ROOT_FULL=1 is
 explicitly set. The CI web job runs make test-web, make build-web, and
-make test-web-browser; the Go job runs ROOT_FULL=1 WEB=0 make test so frontend
-tests are not duplicated.
+make test-web-browser; the deterministic Go job runs ROOT_FULL=1 WEB=0 make
+test so frontend tests are not duplicated.
 
 The `make test` runner gives every Go module and frontend stream a distinct
 private `HOME` plus temporary and XDG roots beneath its per-run log directory.

--- a/internal/appserver/websocket_test.go
+++ b/internal/appserver/websocket_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -46,9 +45,8 @@ func TestServeWebSocketHandlesAppWire(t *testing.T) {
 	}
 }
 
-func TestServeWebSocketKeepsBusyRPCAliveAndDetectsIdlePeerLoss(t *testing.T) {
+func TestServeWebSocketKeepsBusyRPCAliveAndPingsWhenReaderIsIdle(t *testing.T) {
 	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
-	server.keepalivePongTimeout = 5 * time.Millisecond
 	ticker := newControlledKeepaliveTicker()
 	decision := make(chan bool, 2)
 	server.keepaliveTickerFactory = func(time.Duration) webSocketKeepaliveTicker { return ticker }
@@ -67,8 +65,6 @@ func TestServeWebSocketKeepsBusyRPCAliveAndDetectsIdlePeerLoss(t *testing.T) {
 	httpServer := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
 	defer httpServer.Close()
 
-	var answerPings atomic.Bool
-	answerPings.Store(true)
 	idlePingSeen := make(chan struct{}, 1)
 	ctx := context.Background()
 	wsConn, _, err := websocket.Dial(ctx, "ws"+httpServer.URL[len("http"):], &websocket.DialOptions{
@@ -78,7 +74,7 @@ func TestServeWebSocketKeepsBusyRPCAliveAndDetectsIdlePeerLoss(t *testing.T) {
 			case idlePingSeen <- struct{}{}:
 			default:
 			}
-			return answerPings.Load()
+			return true
 		},
 	})
 	if err != nil {
@@ -126,31 +122,28 @@ func TestServeWebSocketKeepsBusyRPCAliveAndDetectsIdlePeerLoss(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("held RPC did not complete after exact release")
 	}
-	// Once ordinary work is gone, an unanswered native ping must still retire
-	// the connection. The client remains a real coder/websocket peer, but stops
-	// answering control pings to model a silent half-open transport.
-	answerPings.Store(false)
-	ticker.Tick()
-	select {
-	case attempted := <-decision:
-		if !attempted {
+	// Receiving the RPC response does not order the send goroutine against the
+	// receive loop's next readerAvailable transition, so drive controlled ticks
+	// until the keepalive observes that transition and pings the idle peer.
+	availableDeadline := time.NewTimer(time.Second)
+	defer availableDeadline.Stop()
+	for {
+		ticker.Tick()
+		select {
+		case attempted := <-decision:
+			if attempted {
+				goto readerAvailable
+			}
+		case <-availableDeadline.C:
 			t.Fatal("keepalive did not observe the available reader")
 		}
-	case <-time.After(time.Second):
-		t.Fatal("keepalive did not report the idle-reader decision")
 	}
+
+readerAvailable:
 	select {
 	case <-idlePingSeen:
 	case <-time.After(time.Second):
 		t.Fatal("idle keepalive never attempted a native ping")
-	}
-	select {
-	case _, ok := <-client.Notifications():
-		for ok {
-			_, ok = <-client.Notifications()
-		}
-	case <-time.After(time.Second):
-		t.Fatal("idle ping failure did not close the websocket client")
 	}
 }
 


### PR DESCRIPTION
## Summary
- cancel obsolete pull-request revisions in CI and Build Binaries while preserving every main, tag, and manual run
- add independent static, race, and tests-and-fuzz lanes while temporarily retaining the required build-and-test compatibility job
- keep every existing build, vet, lint, deterministic, race, dev-tooling, fuzz, secret-scan, browser, and snapshot check

## Safe rollout
This PR intentionally retains `build-and-test`, the only currently required status context. After all new lanes pass live and this PR merges, branch protection will be updated to require `static`, `race`, `tests-and-fuzz`, `web`, and `Build snapshot artifacts`. A follow-up PR will then remove the compatibility monolith.

## Verification
- `actionlint .github/workflows/ci.yml .github/workflows/binaries.yml`
- `make lint-generated`
- `make merge-approval-gate` (596.17s, exit 0)
- live Actions checks on this PR are the integration proof for scheduling and context names