### PR TITLE
fix(agent): degrade an unenforceable read-only delegate instead of refusing it

### DIFF
--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -1257,10 +1257,13 @@ func (runtime delegateRuntime) create(ctx context.Context, args delegateArgs) de
 	s.startDelegateQuietWatchdog(started.ctx, started.lease)
 	s.launchSubagentRun(prepared.runCtx, prepared.sub, prepared.runCancel, prepared.input, started.descriptor.Provenance)
 	result := createResult(stableDelegateResult(started.descriptor, started.lease.delegateID, started.plan, plans, nil))
-	// The advisory rides the launched delegate's own result only: it is
+	// The advisories ride the launched delegate's own result only: they are
 	// metadata for the caller's next isolation choice, not delegate output, not
 	// an EventWarning, and not durable job state a later delegate_send replays.
-	result.Warnings = appendUniqueStrings(result.Warnings, sharedWorkspaceAdvisory)
+	// The sandbox one fires when a derived read-only scope had to degrade on this
+	// host, so the parent learns the boundary is advisory for the child's shell
+	// rather than discovering it from a clobbered file.
+	result.Warnings = appendUniqueStrings(result.Warnings, sharedWorkspaceAdvisory, degradedReadOnlyDelegateAdvisory(requestedSandbox))
 	return result
 }
 

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -1263,7 +1263,7 @@ func (runtime delegateRuntime) create(ctx context.Context, args delegateArgs) de
 	// The sandbox one fires when a derived read-only scope had to degrade on this
 	// host, so the parent learns the boundary is advisory for the child's shell
 	// rather than discovering it from a clobbered file.
-	result.Warnings = appendUniqueStrings(result.Warnings, sharedWorkspaceAdvisory, degradedReadOnlyDelegateAdvisory(requestedSandbox))
+	result.Warnings = appendUniqueStrings(result.Warnings, sharedWorkspaceAdvisory, degradedReadOnlyDelegateAdvisory(prepared.sub.sess.currentEnv()))
 	return result
 }
 

--- a/agent/execenv/filetool_capability_other.go
+++ b/agent/execenv/filetool_capability_other.go
@@ -1,0 +1,7 @@
+//go:build !linux && !darwin
+
+package execenv
+
+// FileToolEnforceable reports whether this process can use the race-safe secure
+// open primitive that confines file-tool operations on the current host.
+func FileToolEnforceable() bool { return false }

--- a/agent/execenv/filetool_capability_unix.go
+++ b/agent/execenv/filetool_capability_unix.go
@@ -1,0 +1,19 @@
+//go:build linux || darwin
+
+package execenv
+
+import "golang.org/x/sys/unix"
+
+var securePathCapabilityProbe = func() error {
+	fd, err := openAbsNoSymlinks("/", unix.O_RDONLY|unix.O_DIRECTORY, 0)
+	if err != nil {
+		return err
+	}
+	return unix.Close(fd)
+}
+
+// FileToolEnforceable reports whether this process can use the race-safe secure
+// open primitive that confines file-tool operations on the current host.
+func FileToolEnforceable() bool {
+	return securePathCapabilityProbe() == nil
+}

--- a/agent/execenv/filetool_capability_unix_test.go
+++ b/agent/execenv/filetool_capability_unix_test.go
@@ -1,0 +1,32 @@
+//go:build linux || darwin
+
+package execenv
+
+import (
+	"errors"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestFileToolEnforceableRequiresSecureOpen(t *testing.T) {
+	original := securePathCapabilityProbe
+	t.Cleanup(func() { securePathCapabilityProbe = original })
+
+	for _, probeErr := range []error{unix.ENOSYS, unix.EPERM} {
+		securePathCapabilityProbe = func() error { return probeErr }
+		if FileToolEnforceable() {
+			t.Errorf("secure-open failure %v reported file-tool enforcement available", probeErr)
+		}
+	}
+
+	securePathCapabilityProbe = func() error { return nil }
+	if !FileToolEnforceable() {
+		t.Error("a successful secure-open probe reported file-tool enforcement unavailable")
+	}
+
+	securePathCapabilityProbe = func() error { return errors.New("unexpected secure-open failure") }
+	if FileToolEnforceable() {
+		t.Error("an unexpected secure-open failure reported file-tool enforcement available")
+	}
+}

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -198,39 +198,27 @@ func (e *LocalExecutionEnvironment) sandbox() *sandboxFS {
 //
 // A write-blocked policy with no OS sandbox (a read-only delegate on a host with
 // no sandbox backend) never builds a wrapper to read through, so it falls back to
-// the env's own session scratch — the SAME directory overlaySessionEnv exports to
-// its spawned commands, since that path also keys on a nil Wrapper. Without this
-// the file tools of a write-blocked env would have no writable root at all,
-// breaking WriteBlocked's contract that the session scratch stays writable. An
-// ENFORCED policy is deliberately excluded from the fallback: its scratch is the
-// wrapper's, and a wrapper-less enforced env (test-only — EnableSandbox fails
-// closed rather than half-wiring one) must not silently mint a second one.
+// the scratch EnableSandbox provisioned for it, which this env OWNS — the same dir
+// overlaySessionEnv exports to its spawned commands, so the model's file tools and
+// its shell agree on one writable place. Without it the file tools of a
+// write-blocked env would have no writable root at all, breaking WriteBlocked's
+// contract that the session scratch stays writable.
 func (e *LocalExecutionEnvironment) sessionScratchPath() string {
 	if e.Wrapper != nil {
 		return e.Wrapper.SessionTmp()
 	}
-	if e.Sandbox != nil && !e.Sandbox.Enforced() && e.Sandbox.FileToolConfined() {
-		if e.sandboxGrant != "" {
-			// A short-lived per-invocation grant clone must not provision a scratch dir:
-			// it owns nothing and nobody retains or disposes what it allocates, so a
-			// second dir would leak on every approval. The one approved leaf resolves
-			// through the grant, which needs no root.
-			return ""
-		}
-		return e.unsandboxedScratchDir()
-	}
-	return ""
+	return e.wrapperlessScratchDir()
 }
 
-// allocatedSessionScratchPath returns an already-provisioned scratch root owned
-// by this environment. It deliberately does not call unsandboxedScratchDir:
-// checking an arbitrary write path must never allocate a new grant as a side
-// effect. Enforced environments are handled by sandbox(), whose policy already
-// folds Wrapper.SessionTmp() into the fd-anchored roots; this accessor is for the
-// otherwise-unconfined environment's late-bound scratch grant.
-func (e *LocalExecutionEnvironment) allocatedSessionScratchPath() string {
-	if e.Wrapper != nil {
-		return e.Wrapper.SessionTmp()
+// wrapperlessScratchDir returns the already-provisioned per-session scratch of an
+// env with no kernel wrapper, or "" when it has none. It never provisions one:
+// both shapes that have one allocate it eagerly (EnableSandbox for a write-blocked
+// policy, the first spawn for an ordinary unsandboxed session), and allocating
+// from a read path would make a report or a containment check a filesystem side
+// effect.
+func (e *LocalExecutionEnvironment) wrapperlessScratchDir() string {
+	if tmp := e.ownedSessionTmp; tmp != nil {
+		return tmp.Dir
 	}
 	e.unsandboxedScratchMu.Lock()
 	defer e.unsandboxedScratchMu.Unlock()
@@ -238,6 +226,19 @@ func (e *LocalExecutionEnvironment) allocatedSessionScratchPath() string {
 		return ""
 	}
 	return e.unsandboxedScratch.Dir
+}
+
+// allocatedSessionScratchPath returns an already-provisioned scratch root owned
+// by this environment. It deliberately does not provision one: checking an
+// arbitrary write path must never allocate a new grant as a side effect. Enforced
+// environments are handled by sandbox(), whose policy already folds
+// Wrapper.SessionTmp() into the fd-anchored roots; this accessor is for the
+// otherwise-unconfined environment's late-bound scratch grant.
+func (e *LocalExecutionEnvironment) allocatedSessionScratchPath() string {
+	if e.Wrapper != nil {
+		return e.Wrapper.SessionTmp()
+	}
+	return e.wrapperlessScratchDir()
 }
 
 // scratchSandboxFor returns the cached fd-anchored layer for an already allocated
@@ -279,20 +280,16 @@ func (e *LocalExecutionEnvironment) scratchSandboxFor(abs string) *sandboxFS {
 
 // SessionScratchDir reports the per-session scratch directory spawned commands
 // already receive as $EVENER_SCRATCH_DIR/$TMPDIR — the sandboxed env's wrapper tmp,
-// or an unsandboxed env's own lazily provisioned dir — and "" when neither has
-// been provisioned. It deliberately never provisions one: it is a REPORTING
-// accessor (the session prompt's capability preamble), and reporting a path must
-// not create it, nor turn a prompt render into a filesystem side effect.
+// the write-blocked env's own owned dir, or an unsandboxed env's lazily
+// provisioned one — and "" when none has been provisioned. It deliberately never
+// provisions one: it is a REPORTING accessor (the session prompt's capability
+// preamble), and reporting a path must not create it, nor turn a prompt render
+// into a filesystem side effect.
 func (e *LocalExecutionEnvironment) SessionScratchDir() string {
 	if e.Wrapper != nil {
 		return e.Wrapper.SessionTmp()
 	}
-	e.unsandboxedScratchMu.Lock()
-	defer e.unsandboxedScratchMu.Unlock()
-	if e.unsandboxedScratch != nil {
-		return e.unsandboxedScratch.Dir
-	}
-	return ""
+	return e.wrapperlessScratchDir()
 }
 
 // WithSandboxInvocationGrant returns a short-lived clone of this env whose file-tool
@@ -301,13 +298,19 @@ func (e *LocalExecutionEnvironment) SessionScratchDir() string {
 // this env's resolved policy, roots, and working directory unchanged; it only widens
 // root-containment for that one leaf (masking, git-protection, and symlink refusal
 // still apply). It is discarded after the one re-dispatch, so the grant cannot leak
-// to any later call. On an env whose file tools are unconfined the grant is
-// meaningless and the env is returned unchanged — the gate is FileToolConfined
-// because widening a file-tool layer is only meaningful where one exists, and a
-// write-blocked off env (a degraded read-only delegate) has one. The clone never
-// owns the session tmp, so it never disposes it.
+// to any later call. On an off / non-enforced env the grant is meaningless and the
+// env is returned unchanged. The clone never owns the session tmp, so it never
+// disposes it.
+//
+// The gate stays Enforced() rather than FileToolConfined() on purpose: the only
+// policy that separates the two is the write-blocked off box, which only a DELEGATE
+// receives, and escalation refuses a subagent session outright (escalationAllowed),
+// so no such env can reach this. Widening the gate would add a branch nothing can
+// execute — and one whose clone, sharing no owned scratch, would need its own
+// handling. If escalation ever reaches delegates, widen it THEN, with the test that
+// can finally exercise it.
 func (e *LocalExecutionEnvironment) WithSandboxInvocationGrant(path string) ExecutionEnvironment {
-	if e.Sandbox == nil || !e.Sandbox.FileToolConfined() || strings.TrimSpace(path) == "" {
+	if e.Sandbox == nil || !e.Sandbox.Enforced() || strings.TrimSpace(path) == "" {
 		return e
 	}
 	return &LocalExecutionEnvironment{
@@ -431,16 +434,19 @@ func (e *LocalExecutionEnvironment) overlaySessionEnv(extra map[string]string) m
 	return overlay
 }
 
-// unsandboxedScratchDir lazily provisions (once) and returns the per-session
-// scratch directory of an env with no kernel wrapper, or "" if provisioning
-// failed. It serves both wrapper-less shapes: an ordinary unsandboxed session,
-// and a write-blocked off policy whose file tools treat this directory as their
-// one writable root (sessionScratchPath). A scratch dir is a convenience, never a
-// launch or spawn blocker: a failure silently disables the
-// EVENER_SCRATCH_DIR/TMPDIR export instead of erroring the command. For a
-// write-blocked env that means losing the one writable root, which denies writes
-// — the fail-closed direction.
+// unsandboxedScratchDir lazily provisions (once) and returns this env's
+// per-session scratch directory, or "" if provisioning failed. A scratch dir is a
+// convenience, never a launch or spawn blocker: a failure silently disables the
+// EVENER_SCRATCH_DIR/TMPDIR export instead of erroring the command.
+//
+// A write-blocked env already OWNS one (EnableSandbox provisioned it, and its file
+// tools treat it as their single writable root), so this returns that rather than
+// minting a second: the model's file tools and its shell must name the same
+// directory, and only the owned one is disposed with the env.
 func (e *LocalExecutionEnvironment) unsandboxedScratchDir() string {
+	if tmp := e.ownedSessionTmp; tmp != nil {
+		return tmp.Dir
+	}
 	e.unsandboxedScratchMu.Lock()
 	defer e.unsandboxedScratchMu.Unlock()
 	if e.unsandboxedScratch != nil {
@@ -449,17 +455,23 @@ func (e *LocalExecutionEnvironment) unsandboxedScratchDir() string {
 	if e.unsandboxedScratchFailed {
 		return ""
 	}
-	workspaceRoot := GitRootOrEmpty(e, e.RootDir)
-	if workspaceRoot == "" {
-		workspaceRoot = e.RootDir
-	}
-	tmp, err := sandbox.NewSessionScratch(e.sandboxTmpBase, workspaceRoot)
+	tmp, err := e.newSessionScratch()
 	if err != nil {
 		e.unsandboxedScratchFailed = true
 		return ""
 	}
 	e.unsandboxedScratch = tmp
 	return tmp.Dir
+}
+
+// newSessionScratch creates a fresh per-session scratch directory for this env,
+// anchored at its workspace root so the scratch names the project it belongs to.
+func (e *LocalExecutionEnvironment) newSessionScratch() (*sandbox.SessionScratch, error) {
+	workspaceRoot := GitRootOrEmpty(e, e.RootDir)
+	if workspaceRoot == "" {
+		workspaceRoot = e.RootDir
+	}
+	return sandbox.NewSessionScratch(e.sandboxTmpBase, workspaceRoot)
 }
 
 // retainUnsandboxedScratch releases this env's unsandboxed per-session
@@ -519,17 +531,21 @@ func (e *LocalExecutionEnvironment) EnableSandbox(policy *sandbox.ResolvedPolicy
 		// the file tools, whose only writable root is the session scratch. Provision it
 		// here rather than on first use so the scratch path is available to the session
 		// prompt that tells the delegate where it may write — a prompt render must not
-		// create directories, so it can only report one that already exists.
+		// create directories, so it can only report one that already exists. The env
+		// OWNS it, exactly as the enforced path below does, so a spawn that fails after
+		// this point disposes it (DisposeSandboxScratch) instead of leaking a directory
+		// AND the flock lease that keeps the crashed-scratch sweeper away from it.
+		//
+		// Best-effort: losing the scratch costs the delegate its one writable place,
+		// which denies writes — the fail-closed direction — and must not block a spawn.
 		if policy != nil && policy.FileToolConfined() {
-			e.unsandboxedScratchDir()
+			if tmp, err := e.newSessionScratch(); err == nil {
+				e.ownedSessionTmp = tmp
+			}
 		}
 		return nil
 	}
-	workspaceRoot := GitRootOrEmpty(e, e.RootDir)
-	if workspaceRoot == "" {
-		workspaceRoot = e.RootDir
-	}
-	tmp, err := sandbox.NewSessionScratch(e.sandboxTmpBase, workspaceRoot)
+	tmp, err := e.newSessionScratch()
 	if err != nil {
 		// Leave the env unsandboxed: a half-wired sandbox must never run, and the
 		// prior policy/wrapper (torn down above) must not silently persist.

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -166,16 +166,18 @@ type LocalExecutionEnvironment struct {
 }
 
 // sandbox returns the environment's fd-anchored enforcement layer, or nil when
-// the environment is unsandboxed (a nil policy or off mode) — in which case every
-// file tool keeps its byte-identical afero/os path. The sandboxFS is built once
-// and cached; it is only ever constructed for an enforced policy. It folds in the
-// concrete per-session scratch directory (sessionScratchPath) so the file tools
-// reach the SAME scratch dir a spawned shell command gets via $TMPDIR —
-// regardless of which policy-replacement path built it (EnableSandbox,
-// WithWorkingDirectory's re-root, UseControlPolicy), since they all funnel
-// through this single lazy builder.
+// the environment's file tools are unconfined (a nil policy or plain off mode) —
+// in which case every file tool keeps its byte-identical afero/os path. The gate
+// is FileToolConfined, not Enforced: a write-blocked off policy (a read-only
+// delegate on a host with no sandbox backend) has no OS sandbox but still confines
+// the file tools, which are then the only thing holding its write boundary. The
+// sandboxFS is built once and cached. It folds in the concrete per-session scratch
+// directory (sessionScratchPath) so the file tools reach the SAME scratch dir a
+// spawned shell command gets via $TMPDIR — regardless of which policy-replacement
+// path built it (EnableSandbox, WithWorkingDirectory's re-root, UseControlPolicy),
+// since they all funnel through this single lazy builder.
 func (e *LocalExecutionEnvironment) sandbox() *sandboxFS {
-	if e.Sandbox == nil || !e.Sandbox.Enforced() {
+	if e.Sandbox == nil || !e.Sandbox.FileToolConfined() {
 		return nil
 	}
 	e.sbMu.Lock()
@@ -189,15 +191,35 @@ func (e *LocalExecutionEnvironment) sandbox() *sandboxFS {
 
 // sessionScratchPath returns the concrete per-session scratch directory this
 // env's kernel wrapper already grants spawned processes via $TMPDIR /
-// $EVENER_SCRATCH_DIR (agent/sandbox.ApplyEnvFloor), or "" when unsandboxed. It
-// reads through Wrapper rather than ownedSessionTmp because a re-rooted clone
-// (WithWorkingDirectory) shares the parent's scratch dir via the Wrapper without
-// owning it (ownedSessionTmp is nil there — see its doc comment).
+// $EVENER_SCRATCH_DIR (agent/sandbox.ApplyEnvFloor), or "" when neither layer has
+// one. It reads through Wrapper rather than ownedSessionTmp because a re-rooted
+// clone (WithWorkingDirectory) shares the parent's scratch dir via the Wrapper
+// without owning it (ownedSessionTmp is nil there — see its doc comment).
+//
+// A write-blocked policy with no OS sandbox (a read-only delegate on a host with
+// no sandbox backend) never builds a wrapper to read through, so it falls back to
+// the env's own session scratch — the SAME directory overlaySessionEnv exports to
+// its spawned commands, since that path also keys on a nil Wrapper. Without this
+// the file tools of a write-blocked env would have no writable root at all,
+// breaking WriteBlocked's contract that the session scratch stays writable. An
+// ENFORCED policy is deliberately excluded from the fallback: its scratch is the
+// wrapper's, and a wrapper-less enforced env (test-only — EnableSandbox fails
+// closed rather than half-wiring one) must not silently mint a second one.
 func (e *LocalExecutionEnvironment) sessionScratchPath() string {
-	if e.Wrapper == nil {
-		return ""
+	if e.Wrapper != nil {
+		return e.Wrapper.SessionTmp()
 	}
-	return e.Wrapper.SessionTmp()
+	if e.Sandbox != nil && !e.Sandbox.Enforced() && e.Sandbox.FileToolConfined() {
+		if e.sandboxGrant != "" {
+			// A short-lived per-invocation grant clone must not provision a scratch dir:
+			// it owns nothing and nobody retains or disposes what it allocates, so a
+			// second dir would leak on every approval. The one approved leaf resolves
+			// through the grant, which needs no root.
+			return ""
+		}
+		return e.unsandboxedScratchDir()
+	}
+	return ""
 }
 
 // allocatedSessionScratchPath returns an already-provisioned scratch root owned
@@ -279,11 +301,13 @@ func (e *LocalExecutionEnvironment) SessionScratchDir() string {
 // this env's resolved policy, roots, and working directory unchanged; it only widens
 // root-containment for that one leaf (masking, git-protection, and symlink refusal
 // still apply). It is discarded after the one re-dispatch, so the grant cannot leak
-// to any later call. On an off / non-enforced env the grant is meaningless and the
-// env is returned unchanged. The clone never owns the session tmp, so it never
-// disposes it.
+// to any later call. On an env whose file tools are unconfined the grant is
+// meaningless and the env is returned unchanged — the gate is FileToolConfined
+// because widening a file-tool layer is only meaningful where one exists, and a
+// write-blocked off env (a degraded read-only delegate) has one. The clone never
+// owns the session tmp, so it never disposes it.
 func (e *LocalExecutionEnvironment) WithSandboxInvocationGrant(path string) ExecutionEnvironment {
-	if e.Sandbox == nil || !e.Sandbox.Enforced() || strings.TrimSpace(path) == "" {
+	if e.Sandbox == nil || !e.Sandbox.FileToolConfined() || strings.TrimSpace(path) == "" {
 		return e
 	}
 	return &LocalExecutionEnvironment{
@@ -407,11 +431,15 @@ func (e *LocalExecutionEnvironment) overlaySessionEnv(extra map[string]string) m
 	return overlay
 }
 
-// unsandboxedScratchDir lazily provisions (once) and returns this
-// unsandboxed env's per-session scratch directory, or "" if provisioning
-// failed. A scratch dir is a convenience, never a launch or spawn blocker: a
-// failure silently disables the EVENER_SCRATCH_DIR/TMPDIR export instead of
-// erroring the command.
+// unsandboxedScratchDir lazily provisions (once) and returns the per-session
+// scratch directory of an env with no kernel wrapper, or "" if provisioning
+// failed. It serves both wrapper-less shapes: an ordinary unsandboxed session,
+// and a write-blocked off policy whose file tools treat this directory as their
+// one writable root (sessionScratchPath). A scratch dir is a convenience, never a
+// launch or spawn blocker: a failure silently disables the
+// EVENER_SCRATCH_DIR/TMPDIR export instead of erroring the command. For a
+// write-blocked env that means losing the one writable root, which denies writes
+// — the fail-closed direction.
 func (e *LocalExecutionEnvironment) unsandboxedScratchDir() string {
 	e.unsandboxedScratchMu.Lock()
 	defer e.unsandboxedScratchMu.Unlock()
@@ -487,6 +515,14 @@ func (e *LocalExecutionEnvironment) EnableSandbox(policy *sandbox.ResolvedPolicy
 	if policy == nil || !policy.Enforced() {
 		e.Sandbox = policy
 		e.Wrapper = nil
+		// A write-blocked off policy has no OS sandbox to provision but still confines
+		// the file tools, whose only writable root is the session scratch. Provision it
+		// here rather than on first use so the scratch path is available to the session
+		// prompt that tells the delegate where it may write — a prompt render must not
+		// create directories, so it can only report one that already exists.
+		if policy != nil && policy.FileToolConfined() {
+			e.unsandboxedScratchDir()
+		}
 		return nil
 	}
 	workspaceRoot := GitRootOrEmpty(e, e.RootDir)

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -95,9 +95,10 @@ type LocalExecutionEnvironment struct {
 	Wrapper *sandbox.Wrapper
 
 	// sbMu guards the lazily-built fd-anchored file-tool layers. sbfs is the policy
-	// enforcement layer, built on first file-tool use from an ENFORCED Sandbox policy
-	// and cached for the environment's lifetime (its root fds are captured once so a
-	// later root swap cannot redirect resolution). It stays nil for off / a nil policy.
+	// enforcement layer, built on first file-tool use from a file-tool-confined
+	// Sandbox policy and cached for the environment's lifetime (its root fds are
+	// captured once so a later root swap cannot redirect resolution). It stays nil
+	// for plain off / a nil policy.
 	sbMu sync.Mutex
 	sbfs *sandboxFS
 	// scratchFS is the cached fd-anchored layer for an unsandboxed session's

--- a/agent/execenv/mutator.go
+++ b/agent/execenv/mutator.go
@@ -10,11 +10,11 @@ import (
 
 // LocalExecutionEnvironment implements the FileMutator capability so apply_patch
 // routes its file mutations through the same enforcement seam as the other file
-// tools. When the environment carries an enforced sandbox policy, each method uses
-// the fd-anchored, symlink-refusing layer (e.sandbox()); otherwise it confines to
-// the working root via resolveWrite — the same containment the off-mode
-// write_file/edit_file tools use, which replaces apply_patch's old lexical
-// safeJoin check.
+// tools. When the environment carries a file-tool-confined sandbox policy, each
+// method uses the fd-anchored, symlink-refusing layer (e.sandbox()); otherwise it
+// confines to the working root via resolveWrite — the same containment the plain
+// off-mode write_file/edit_file tools use, which replaces apply_patch's old
+// lexical safeJoin check.
 
 // ReadFileRaw returns the raw bytes of path, confined to the working root.
 func (e *LocalExecutionEnvironment) ReadFileRaw(path string) ([]byte, error) {

--- a/agent/execenv/sandbox_lifecycle_test.go
+++ b/agent/execenv/sandbox_lifecycle_test.go
@@ -2,6 +2,7 @@ package execenv
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -349,66 +350,130 @@ func TestEnableSandboxWriteBlockedOffConfinesFileTools(t *testing.T) {
 	}
 }
 
-// TestSandboxInvocationGrantWidensWriteBlockedOffEnv: a human approving one
-// denied path must work the same way for a degraded read-only delegate as for an
-// enforced one — the escalation grant widens the file-tool layer that a
-// write-blocked off policy really does have. The short-lived clone must also
-// allocate no scratch directory of its own: it owns nothing, so a second dir
-// would leak on every approval.
-func TestSandboxInvocationGrantWidensWriteBlockedOffEnv(t *testing.T) {
+// TestWriteBlockedOffMasksCredentialPaths: the degraded box's reads are "anywhere
+// MINUS the denylist", the same set every confining mode masks. Without the
+// denylist a read-only delegate — the one shape that runs with no shell at all,
+// so the file tools are its whole surface — would read ~/.ssh and evener's own
+// environment out of /proc.
+func TestWriteBlockedOffMasksCredentialPaths(t *testing.T) {
 	home := realTempDir(t)
 	worktree := filepath.Join(home, "project")
+	if err := os.MkdirAll(filepath.Join(home, ".ssh"), 0o700); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.MkdirAll(worktree, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	tmpBase := realTempDir(t)
-	rp, err := sandbox.Resolve(sandbox.SandboxPolicy{Mode: sandbox.ModeOff, WriteBlocked: true},
-		sandbox.HostFacts{OS: "linux", Home: home}, worktree)
-	if err != nil {
-		t.Fatalf("Resolve: %v", err)
+	secret := filepath.Join(home, ".ssh", "id_rsa")
+	if err := os.WriteFile(secret, []byte("PRIVATE KEY\n"), 0o600); err != nil {
+		t.Fatal(err)
 	}
-	env := NewLocalExecutionEnvironment(worktree)
-	env.sandboxTmpBase = tmpBase
-	t.Cleanup(func() { env.Cleanup(); env.DisposeSandboxScratch() })
-	if err := env.EnableSandbox(&rp); err != nil {
-		t.Fatalf("EnableSandbox: %v", err)
-	}
-	approved := filepath.Join(worktree, "approved.txt")
-	if _, err := env.WriteFile(approved, "denied without approval"); err == nil {
-		t.Fatal("the ungranted env must deny the write")
-	}
-	scratchBefore := scratchDirCount(t, tmpBase)
+	env := writeBlockedOffEnv(t, home, worktree)
 
-	granted := env.WithSandboxInvocationGrant(approved)
-	if granted == env {
-		t.Fatal("a write-blocked env must produce a grant clone")
+	_, err := env.ReadFile(secret, nil, nil)
+	mustDenied(t, err, "read_file of a credential path under a degraded read-only delegate")
+	if _, err := env.ReadFile(fmt.Sprintf("/proc/%d/environ", os.Getpid()), nil, nil); err == nil {
+		t.Error("read_file of evener's own /proc environ must be denied (it holds the provider API key)")
 	}
-	if _, err := granted.WriteFile(approved, "human approved this one\n"); err != nil {
-		t.Fatalf("the approved path must be writable through the grant: %v", err)
+	// A non-masked path outside the worktree still reads: the mode is anywhere
+	// MINUS the denylist, not worktree-only.
+	sibling := filepath.Join(home, "notes.txt")
+	if err := os.WriteFile(sibling, []byte("ordinary\n"), 0o644); err != nil {
+		t.Fatal(err)
 	}
-	if got, err := os.ReadFile(approved); err != nil || string(got) != "human approved this one\n" {
-		t.Fatalf("granted write did not land: got %q err %v", got, err)
-	}
-	if _, err := granted.WriteFile(filepath.Join(worktree, "sibling.txt"), "not approved"); err == nil {
-		t.Error("the grant must widen exactly one leaf, not the directory")
-	}
-	if after := scratchDirCount(t, tmpBase); after != scratchBefore {
-		t.Errorf("the grant clone allocated %d extra scratch dirs; it owns none and would leak them", after-scratchBefore)
+	if got, err := env.ReadFile(sibling, nil, nil); err != nil || !strings.Contains(got, "ordinary") {
+		t.Fatalf("an ordinary out-of-worktree read must still work: got %q err %v", got, err)
 	}
 }
 
-// scratchDirCount counts the per-session scratch dirs directly under base.
-func scratchDirCount(t *testing.T, base string) int {
+// TestReadsThroughSymlinkedWorkspaceRoot: a workspace reached through a symlinked
+// ancestor (a bind-mounted link, a symlinked checkout, macOS /tmp) must stay
+// readable. The file-tool layer anchors an in-worktree read at the worktree's own
+// fd, which tolerates that ancestor while still refusing a symlink component
+// INSIDE the worktree. Both shapes with no write root are covered: the degraded
+// box, and the enforced read-only box that has always had the same gap.
+//
+// The root is deliberately NOT canonicalized here — resolving it in the test is
+// what hid this in the first place.
+func TestReadsThroughSymlinkedWorkspaceRoot(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		build func(t *testing.T, home, worktree string) *LocalExecutionEnvironment
+	}{
+		{name: "degraded", build: writeBlockedOffEnv},
+		{name: "enforced-read-only", build: func(t *testing.T, home, worktree string) *LocalExecutionEnvironment {
+			t.Helper()
+			env := NewLocalExecutionEnvironment(worktree)
+			env.Sandbox = resolvePolicy(t, sandbox.ModeReadOnly, home, worktree)
+			t.Cleanup(env.Cleanup)
+			return env
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := realTempDir(t)
+			target := filepath.Join(home, "real")
+			if err := os.MkdirAll(filepath.Join(target, "sub"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			// The session's working directory IS the symlink.
+			worktree := filepath.Join(home, "link")
+			if err := os.Symlink(target, worktree); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(target, "README.md"), []byte("hello\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(target, "sub", "deep.txt"), []byte("nested\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			env := tc.build(t, home, worktree)
+
+			got, err := env.ReadFile(filepath.Join(worktree, "README.md"), nil, nil)
+			if err != nil || !strings.Contains(got, "hello") {
+				t.Fatalf("read through a symlinked workspace root: got %q err %v", got, err)
+			}
+			if got, err := env.ReadFile(filepath.Join(worktree, "sub", "deep.txt"), nil, nil); err != nil || !strings.Contains(got, "nested") {
+				t.Fatalf("nested read through a symlinked workspace root: got %q err %v", got, err)
+			}
+			entries, err := env.ListDirectory(worktree, 1)
+			if err != nil || len(entries) == 0 {
+				t.Fatalf("list_dir through a symlinked workspace root: %d entries, err %v", len(entries), err)
+			}
+			matches, err := env.Glob(context.Background(), "*.md", worktree)
+			if err != nil || len(matches) == 0 {
+				t.Fatalf("glob through a symlinked workspace root: %v err %v", matches, err)
+			}
+
+			// The anchor tolerates the ancestor only. A write is still denied, and a
+			// symlink INSIDE the worktree is still refused (the same refusal every
+			// enforced mode makes).
+			if _, err := env.WriteFile(filepath.Join(worktree, "new.txt"), "nope"); err == nil {
+				t.Error("the read anchor must not make the workspace writable")
+			}
+			if err := os.Symlink(filepath.Join(target, "sub"), filepath.Join(target, "inner")); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := env.ReadFile(filepath.Join(worktree, "inner", "deep.txt"), nil, nil); err == nil {
+				t.Error("a symlink component inside the worktree must still be refused")
+			}
+		})
+	}
+}
+
+// writeBlockedOffEnv builds the degraded read-only delegate's environment through
+// the real EnableSandbox path: a resolved write-blocked off policy on a host with
+// no sandbox backend.
+func writeBlockedOffEnv(t *testing.T, home, worktree string) *LocalExecutionEnvironment {
 	t.Helper()
-	entries, err := os.ReadDir(base)
+	rp, err := sandbox.Resolve(sandbox.SandboxPolicy{Mode: sandbox.ModeOff, WriteBlocked: true},
+		sandbox.HostFacts{OS: "linux", Home: home}, worktree)
 	if err != nil {
-		t.Fatalf("read scratch base %q: %v", base, err)
+		t.Fatalf("Resolve(write-blocked off): %v", err)
 	}
-	n := 0
-	for _, e := range entries {
-		if e.IsDir() && strings.HasPrefix(e.Name(), "evener-sandbox-") {
-			n++
-		}
+	env := NewLocalExecutionEnvironment(worktree)
+	t.Cleanup(func() { env.Cleanup(); env.DisposeSandboxScratch() })
+	if err := env.EnableSandbox(&rp); err != nil {
+		t.Fatalf("EnableSandbox(write-blocked off): %v", err)
 	}
-	return n
+	return env
 }

--- a/agent/execenv/sandbox_lifecycle_test.go
+++ b/agent/execenv/sandbox_lifecycle_test.go
@@ -270,3 +270,145 @@ sleep 300 & wait`
 		t.Errorf("manual scratch cleanup must remove the owned tmp, stat err = %v", err)
 	}
 }
+
+// TestEnableSandboxWriteBlockedOffConfinesFileTools is the enforcement half of
+// the degraded read-only delegate: on a host with no sandbox backend, a
+// write-blocked OFF policy still builds the in-process file-tool layer, so a
+// write the delegate attempts through write_file/edit_file is REFUSED with a
+// typed denial and never reaches the disk. Reads stay open and the delegate's own
+// session scratch stays writable — the whole point of degrading rather than
+// refusing the spawn. No kernel wrapper is built (there is no backend), which is
+// the residual gap the delegate and its parent are told about.
+func TestEnableSandboxWriteBlockedOffConfinesFileTools(t *testing.T) {
+	home := realTempDir(t)
+	worktree := filepath.Join(home, "project")
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	noBackend := sandbox.HostFacts{OS: "linux", Home: home}
+	rp, err := sandbox.Resolve(sandbox.SandboxPolicy{Mode: sandbox.ModeOff, WriteBlocked: true}, noBackend, worktree)
+	if err != nil {
+		t.Fatalf("resolving a write-blocked off policy must not refuse: %v", err)
+	}
+	env := NewLocalExecutionEnvironment(worktree)
+	t.Cleanup(func() { env.Cleanup(); env.DisposeSandboxScratch() })
+	if err := env.EnableSandbox(&rp); err != nil {
+		t.Fatalf("EnableSandbox(write-blocked off): %v", err)
+	}
+	if env.Wrapper != nil {
+		t.Fatalf("a host with no backend must build no kernel wrapper, got %+v", env.Wrapper)
+	}
+	if env.sandbox() == nil {
+		t.Fatal("a write-blocked policy must build the file-tool enforcement layer")
+	}
+
+	// A write into the workspace is refused and lands nothing.
+	target := filepath.Join(worktree, "deliverable.md")
+	if err := os.WriteFile(target, []byte("the parent's work\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	newFile := filepath.Join(worktree, "new.txt")
+	_, werr := env.WriteFile(newFile, "clobber")
+	mustDenied(t, werr, "write_file under a degraded read-only delegate")
+	if _, err := os.Stat(newFile); err == nil {
+		t.Error("a denied write_file must not create the file")
+	}
+	_, eerr := env.EditFile(target, "the parent's work", "destroyed", false)
+	mustDenied(t, eerr, "edit_file under a degraded read-only delegate")
+	if got, _ := os.ReadFile(target); string(got) != "the parent's work\n" {
+		t.Errorf("a denied edit_file mutated the file: %q", got)
+	}
+
+	// Reads stay open: the delegate keeps the capability it was spawned for.
+	got, err := env.ReadFile(target, nil, nil)
+	if err != nil || !strings.Contains(got, "the parent's work") {
+		t.Fatalf("a degraded read-only delegate must still read: got %q err %v", got, err)
+	}
+
+	// The session scratch is the one writable place, and the file tools reach the
+	// same directory a shell command gets as $TMPDIR/$EVENER_SCRATCH_DIR.
+	scratch := env.SessionScratchDir()
+	if scratch == "" {
+		t.Fatal("a write-blocked env must provision a session scratch dir to write into")
+	}
+	note := filepath.Join(scratch, "findings.md")
+	if _, err := env.WriteFile(note, "what I found\n"); err != nil {
+		t.Fatalf("write_file into the delegate's own scratch dir must succeed: %v", err)
+	}
+	if back, err := env.ReadFile(note, nil, nil); err != nil || !strings.Contains(back, "what I found") {
+		t.Fatalf("read_file of the just-written scratch file failed: got %q err %v", back, err)
+	}
+
+	// One scratch dir, both layers: the shell's $TMPDIR/$EVENER_SCRATCH_DIR must be
+	// the SAME directory the file tools may write, or the delegate's own prompt
+	// would name a path half its tools cannot use.
+	shell := envToMap(env.commandEnvironment(nil))
+	if shell["EVENER_SCRATCH_DIR"] != scratch || shell["TMPDIR"] != scratch {
+		t.Errorf("shell scratch vars = %q/%q, want the file tools' scratch %q",
+			shell["EVENER_SCRATCH_DIR"], shell["TMPDIR"], scratch)
+	}
+}
+
+// TestSandboxInvocationGrantWidensWriteBlockedOffEnv: a human approving one
+// denied path must work the same way for a degraded read-only delegate as for an
+// enforced one — the escalation grant widens the file-tool layer that a
+// write-blocked off policy really does have. The short-lived clone must also
+// allocate no scratch directory of its own: it owns nothing, so a second dir
+// would leak on every approval.
+func TestSandboxInvocationGrantWidensWriteBlockedOffEnv(t *testing.T) {
+	home := realTempDir(t)
+	worktree := filepath.Join(home, "project")
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tmpBase := realTempDir(t)
+	rp, err := sandbox.Resolve(sandbox.SandboxPolicy{Mode: sandbox.ModeOff, WriteBlocked: true},
+		sandbox.HostFacts{OS: "linux", Home: home}, worktree)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	env := NewLocalExecutionEnvironment(worktree)
+	env.sandboxTmpBase = tmpBase
+	t.Cleanup(func() { env.Cleanup(); env.DisposeSandboxScratch() })
+	if err := env.EnableSandbox(&rp); err != nil {
+		t.Fatalf("EnableSandbox: %v", err)
+	}
+	approved := filepath.Join(worktree, "approved.txt")
+	if _, err := env.WriteFile(approved, "denied without approval"); err == nil {
+		t.Fatal("the ungranted env must deny the write")
+	}
+	scratchBefore := scratchDirCount(t, tmpBase)
+
+	granted := env.WithSandboxInvocationGrant(approved)
+	if granted == env {
+		t.Fatal("a write-blocked env must produce a grant clone")
+	}
+	if _, err := granted.WriteFile(approved, "human approved this one\n"); err != nil {
+		t.Fatalf("the approved path must be writable through the grant: %v", err)
+	}
+	if got, err := os.ReadFile(approved); err != nil || string(got) != "human approved this one\n" {
+		t.Fatalf("granted write did not land: got %q err %v", got, err)
+	}
+	if _, err := granted.WriteFile(filepath.Join(worktree, "sibling.txt"), "not approved"); err == nil {
+		t.Error("the grant must widen exactly one leaf, not the directory")
+	}
+	if after := scratchDirCount(t, tmpBase); after != scratchBefore {
+		t.Errorf("the grant clone allocated %d extra scratch dirs; it owns none and would leak them", after-scratchBefore)
+	}
+}
+
+// scratchDirCount counts the per-session scratch dirs directly under base.
+func scratchDirCount(t *testing.T, base string) int {
+	t.Helper()
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		t.Fatalf("read scratch base %q: %v", base, err)
+	}
+	n := 0
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), "evener-sandbox-") {
+			n++
+		}
+	}
+	return n
+}

--- a/agent/execenv/securepath.go
+++ b/agent/execenv/securepath.go
@@ -36,8 +36,10 @@ var (
 // rather than redirect.
 //
 // A sandboxFS is built once per LocalExecutionEnvironment from its resolved
-// policy (see e.sandbox()) and is only ever constructed for an ENFORCED policy —
-// off mode / a nil policy never builds one, so those paths keep today's
+// policy (see e.sandbox()) and is only ever constructed for a policy that
+// confines the file tools — every enforced mode, plus the write-blocked off
+// policy a read-only delegate degrades to where no OS backend can enforce one.
+// Plain off mode / a nil policy never builds one, so those paths keep today's
 // afero/os behavior byte-for-byte. It caches an O_DIRECTORY fd for each allowed
 // root the first time that root is used, so a later swap of the root directory
 // itself cannot redirect resolution.
@@ -70,14 +72,16 @@ func (s *sandboxFS) isGranted(abs string) bool {
 	return s.grant != "" && abs == s.grant
 }
 
-// newSandboxFS builds a sandboxFS for an enforced resolved policy. The caller
-// (e.sandbox()) guarantees policy != nil and policy.Enforced().
+// newSandboxFS builds a sandboxFS for a file-tool-confining resolved policy. The
+// caller (e.sandbox()) guarantees policy != nil and policy.FileToolConfined().
 //
 // scratchDir, when non-empty, is the concrete per-session scratch directory
-// (agent/sandbox.SessionScratch.Dir, via the env's Wrapper.SessionTmp()) folded
-// into the policy's file-tool grants via WithSessionScratch: Resolve ran before
-// the directory existed, so p alone never carries it. A blank scratchDir (an
-// unsandboxed caller, or a policy resolved without a wrapper) leaves p untouched.
+// (agent/sandbox.SessionScratch.Dir, via the env's Wrapper.SessionTmp() or, for a
+// wrapper-less write-blocked env, its own session scratch) folded into the
+// policy's file-tool grants via WithSessionScratch: Resolve ran before the
+// directory existed, so p alone never carries it. A blank scratchDir (an
+// unsandboxed caller, or a policy resolved without a scratch dir) leaves p
+// untouched.
 func newSandboxFS(p *sandbox.ResolvedPolicy, scratchDir string) *sandboxFS {
 	policy := p
 	if scratchDir != "" {

--- a/agent/execenv/securepath_fdops_unix.go
+++ b/agent/execenv/securepath_fdops_unix.go
@@ -107,9 +107,18 @@ func (s *sandboxFS) openRead(tool, abs string, flags int) (int, error) {
 
 	// ReadAnywhere: anchor an in-root read at its granted root exactly like a write,
 	// so a symlinked ancestor of the root does not make an in-root file unreadable.
-	// The granted roots are the writable roots (the worktree and any extra writable
-	// roots); read-only mode has none, so all its reads take the out-of-root path.
+	// The writable roots come first (the worktree and any extra writable roots).
+	// The write-blocked shapes — read-only, and the degraded read-only delegate —
+	// have none, so their worktree arrives as a READ root instead; without an anchor
+	// every read would take the "/"-anchored no-symlinks path below and a workspace
+	// reached through a symlinked ancestor would be entirely unreadable. Anchoring
+	// widens nothing: reads are already allowed anywhere minus the denylist, and
+	// openInRoot still refuses a symlink component INSIDE the root and re-checks
+	// masking against the opened fd.
 	if root, rel, ok := containingRoot(s.policy.FileTool.WriteRoots, abs); ok {
+		return s.openInRoot(tool, abs, root, rel, flags)
+	}
+	if root, rel, ok := containingRoot(s.policy.FileTool.ReadRoots, abs); ok {
 		return s.openInRoot(tool, abs, root, rel, flags)
 	}
 

--- a/agent/execenv/securepath_other.go
+++ b/agent/execenv/securepath_other.go
@@ -8,11 +8,19 @@ import (
 	"os"
 )
 
-// This platform has no supported race-safe file-tool enforcement primitive. It is
-// unreachable in practice — M1's fail-closed floor refuses every sandboxed mode
-// off Linux/Darwin, so no ResolvedPolicy is ever enforced here and a sandboxFS is
-// never built — but these definitions keep the build green and the floor honest:
-// if one were somehow reached, it fails closed rather than silently reading.
+// This platform has no supported race-safe file-tool enforcement primitive, so
+// every operation below fails closed — READS included. A sandboxFS built here
+// would not be a confined file-tool layer, it would be a broken one.
+//
+// Two resolver rules keep one from being built, and both are load-bearing:
+//   - the fail-closed backend floor refuses every sandboxed MODE off Linux/Darwin
+//     (chooseBackend), so no enforced policy exists here;
+//   - Resolve refuses a write-blocked OFF policy — the one shape that confines the
+//     file tools with no backend behind it — wherever FileToolEnforceable is false.
+//
+// Without the second rule the degraded read-only delegate would resolve here and
+// hand back a delegate whose every file operation errors. If a third shape ever
+// gains file-tool confinement, it must be refused here too.
 
 func openBeneathRoot(rootFd int, rel string, flags int, mode uint32) (int, error) {
 	return -1, errSandboxUnsupported()

--- a/agent/sandbox/reroot.go
+++ b/agent/sandbox/reroot.go
@@ -113,11 +113,15 @@ func (rp *ResolvedPolicy) ControlPolicy(mainRepoRoot string) (*ResolvedPolicy, e
 // (buildBwrapArgv / SeatbeltPolicy both take sessionTmp separately from
 // rp.Spawned), so Spawned's roots are left untouched here.
 //
-// A blank dir or an unenforced (off) policy returns rp unchanged. The result
-// still upholds the "never grant a masked path" invariant (filterMasked), though
-// a freshly created session-private directory is never itself denylisted.
+// A blank dir, or a policy whose file tools are not confined at all (plain off),
+// returns rp unchanged. The gate is FileToolConfined rather than Enforced because
+// this grant belongs to the FILE-TOOL layer: a write-blocked off policy (the
+// degraded read-only delegate) builds that layer with no write root, so without
+// the scratch grant it would have nowhere writable at all. The result still
+// upholds the "never grant a masked path" invariant (filterMasked), though a
+// freshly created session-private directory is never itself denylisted.
 func (rp ResolvedPolicy) WithSessionScratch(dir string) ResolvedPolicy {
-	if dir == "" || !rp.Enforced() {
+	if dir == "" || !rp.FileToolConfined() {
 		return rp
 	}
 	rp.FileTool.WriteRoots = filterMasked(

--- a/agent/sandbox/resolve.go
+++ b/agent/sandbox/resolve.go
@@ -171,8 +171,34 @@ type ResolvedPolicy struct {
 	resolveHost   HostFacts
 }
 
-// Enforced reports whether this policy imposes any containment. False for off.
+// Enforced reports whether an OS sandbox is in force for this policy. False for
+// off. It is the question the kernel-wrapper layer asks — whether to build bwrap
+// arguments, print the startup enforcement line, or announce a box in the prompt
+// — and is deliberately NOT the question the in-process file tools ask; see
+// FileToolConfined.
 func (rp ResolvedPolicy) Enforced() bool { return rp.Mode != ModeOff }
+
+// FileToolConfined reports whether the in-process file-tool layer must enforce
+// this policy's grants. Every enforced mode confines the file tools, and so does
+// a write-blocked OFF policy: that is the read-only delegate scope degraded on a
+// host with no sandbox backend, where the file tools are the only enforcement
+// available and carry the whole write boundary (the shell stays unconfined, which
+// both the delegate and its parent are told). A plain off policy confines
+// nothing, so the file tools keep today's byte-identical os path.
+func (rp ResolvedPolicy) FileToolConfined() bool { return rp.Mode != ModeOff || rp.WriteBlocked }
+
+// FileToolEnforceable reports whether the in-process file-tool layer can enforce
+// anything at all on this host. Its race-safe primitives (openat2 /
+// RESOLVE_NO_SYMLINKS on Linux, the O_NOFOLLOW tail walk on darwin) exist only
+// there; every other platform's stand-ins fail closed on EVERY operation, reads
+// included. So a policy that leans on file-tool enforcement alone — the degraded
+// read-only delegate — must not be derived off those two: it would hand back a
+// delegate whose file tools are all broken rather than one that is confined.
+// Callers with no such fallback (an ordinary sandboxed mode) never need this: the
+// resolver's backend floor already refuses every mode off Linux/darwin.
+func FileToolEnforceable(host HostFacts) bool {
+	return host.OS == "linux" || host.OS == "darwin"
+}
 
 // RefusalError is the typed fail-closed refusal returned when the host cannot
 // enforce the requested (mode, network) — the floor's "full contract or refuse"
@@ -236,7 +262,24 @@ func guardedHostRoots(candidates []string, home, worktree string) []string {
 // (including Windows) — it is today's behavior with no containment.
 func Resolve(policy SandboxPolicy, host HostFacts, cwd string) (ResolvedPolicy, error) {
 	if policy.Mode == ModeOff {
-		return ResolvedPolicy{Mode: ModeOff, Network: true, Backend: BackendNone, resolveInputs: policy, resolveHost: host}, nil
+		off := ResolvedPolicy{Mode: ModeOff, Network: true, Backend: BackendNone, resolveInputs: policy, resolveHost: host}
+		if !policy.WriteBlocked {
+			return off, nil
+		}
+		// Write-blocked off: the read-only delegate scope on a host with no sandbox
+		// backend. There is no backend to choose and no host capability to check —
+		// that is the whole point, since checking one is what refused the spawn — so
+		// this path short-circuits like any other off resolve. What it keeps is the
+		// read-only mode's SCOPE for the in-process file tools: reads anywhere, no
+		// write root at all, leaving the separately provisioned session scratch as
+		// the only writable place (WriteBlocked's contract, granted late by
+		// WithSessionScratch). The spawned layer carries the same empty write scope
+		// for the record, but nothing enforces it without a kernel wrapper.
+		off.WriteBlocked = true
+		off.SessionTmp = true
+		off.FileTool = AccessScope{Read: ReadAnywhere}
+		off.Spawned = AccessScope{Read: ReadAnywhere}
+		return off, nil
 	}
 
 	// Network defaults ON when sandboxed: a nil policy.Network is the unset default,

--- a/agent/sandbox/resolve.go
+++ b/agent/sandbox/resolve.go
@@ -258,34 +258,39 @@ func guardedHostRoots(candidates []string, home, worktree string) []string {
 // process environment): the credential denylist anchors on host.Home, and the
 // git layout is resolved structurally from cwd's on-disk .git entries.
 //
-// Off short-circuits before any host check, so off resolves on every host
-// (including Windows) — it is today's behavior with no containment.
+// PLAIN off short-circuits before any host check, so it resolves on every host
+// (including Windows) — it is today's behavior with no containment. A WRITE-BLOCKED
+// off policy is not that: it is the read-only delegate scope degraded on a host
+// with no backend, and it confines the file tools, so it takes the ordinary path
+// through the denylist, the git surface and the scope builder (skipping only the
+// backend choice, which is what it has none of).
 func Resolve(policy SandboxPolicy, host HostFacts, cwd string) (ResolvedPolicy, error) {
-	if policy.Mode == ModeOff {
-		off := ResolvedPolicy{Mode: ModeOff, Network: true, Backend: BackendNone, resolveInputs: policy, resolveHost: host}
-		if !policy.WriteBlocked {
-			return off, nil
+	if policy.Mode == ModeOff && !policy.WriteBlocked {
+		return ResolvedPolicy{Mode: ModeOff, Network: true, Backend: BackendNone, resolveInputs: policy, resolveHost: host}, nil
+	}
+
+	// The write-blocked box has no kernel wrapper behind it, so the in-process file
+	// tools ARE its enforcement. Where their race-safe primitives do not exist, every
+	// file operation fails closed instead — a delegate with broken file tools rather
+	// than a confined one — so refuse here, at the resolver, rather than leave it to
+	// whichever caller derived the request.
+	if policy.Mode == ModeOff && !FileToolEnforceable(host) {
+		return ResolvedPolicy{}, &RefusalError{
+			Mode: policy.Mode, Net: true,
+			Reason: fmt.Sprintf("a write-blocked sandbox is enforced by the in-process file tools, which have no race-safe primitives on %s; only an unconfined --sandbox off is available there", host.OS),
 		}
-		// Write-blocked off: the read-only delegate scope on a host with no sandbox
-		// backend. There is no backend to choose and no host capability to check —
-		// that is the whole point, since checking one is what refused the spawn — so
-		// this path short-circuits like any other off resolve. What it keeps is the
-		// read-only mode's SCOPE for the in-process file tools: reads anywhere, no
-		// write root at all, leaving the separately provisioned session scratch as
-		// the only writable place (WriteBlocked's contract, granted late by
-		// WithSessionScratch). The spawned layer carries the same empty write scope
-		// for the record, but nothing enforces it without a kernel wrapper.
-		off.WriteBlocked = true
-		off.SessionTmp = true
-		off.FileTool = AccessScope{Read: ReadAnywhere}
-		off.Spawned = AccessScope{Read: ReadAnywhere}
-		return off, nil
 	}
 
 	// Network defaults ON when sandboxed: a nil policy.Network is the unset default,
 	// a non-nil value an explicit choice. Collapse to a concrete bool exactly once
 	// here so the zero value can never silently disable egress.
 	netOn := policy.Network == nil || *policy.Network
+	if policy.Mode == ModeOff {
+		// off applies no network confinement whatever the request said — there is no
+		// wrapper to unshare a namespace — so reporting anything but "on" would
+		// overstate, exactly as the plain-off short-circuit above hard-codes it.
+		netOn = true
+	}
 
 	// A sandboxed session needs an absolute home to anchor the credential denylist.
 	// Without one (e.g. the home-directory env var is unset in a bare service),
@@ -340,9 +345,15 @@ func Resolve(policy SandboxPolicy, host HostFacts, cwd string) (ResolvedPolicy, 
 		}
 	}
 
-	backend, refusal := chooseBackend(policy, host, netOn)
-	if refusal != nil {
-		return ResolvedPolicy{}, refusal
+	// A write-blocked off policy chooses no backend — it exists precisely because
+	// none is available, and asking would reproduce the refusal it replaces.
+	backend := BackendNone
+	if policy.Mode != ModeOff {
+		chosen, refusal := chooseBackend(policy, host, netOn)
+		if refusal != nil {
+			return ResolvedPolicy{}, refusal
+		}
+		backend = chosen
 	}
 
 	masked := policy.EffectiveDenylist(host.Home)
@@ -501,9 +512,23 @@ func cacheStrategyFor(mode Mode, backend Backend, host HostFacts) CacheStrategy 
 // scopesFor builds the file-tool and spawned-process access scopes for a mode.
 func scopesFor(policy SandboxPolicy, host HostFacts, layout GitLayout, worktree string) (fileTool, spawned AccessScope) {
 	switch policy.Mode {
-	case ModeReadOnly:
+	case ModeOff, ModeReadOnly:
 		// Reads anywhere (minus masked); no writes (session tmp is the only scratch).
-		fileTool = AccessScope{Read: ReadAnywhere}
+		// ModeOff reaches here only as the write-blocked degrade — plain off never
+		// calls scopesFor — and takes read-only's scope by construction, because
+		// read-only is the box it stands in for.
+		//
+		// The worktree is a READ root even though reads are already allowed anywhere.
+		// It is an ANCHOR, not a limit: openRead resolves an in-root target beneath
+		// this root's fd, which tolerates a symlinked ANCESTOR of the worktree while
+		// still refusing a symlink component INSIDE it. Without it every read takes
+		// the "/"-anchored no-symlinks path, and a workspace reached through a
+		// symlinked ancestor (a bind-mounted link, a symlinked checkout, macOS
+		// /tmp) is unreadable — a workspace shape, not an attack. The other modes
+		// need no equivalent: their worktree is already a WRITE root, which openRead
+		// anchors at first.
+		anchor := dedupeRoots([]string{worktree})
+		fileTool = AccessScope{Read: ReadAnywhere, ReadRoots: anchor}
 		spawned = AccessScope{Read: ReadAnywhere}
 
 	case ModeWorkspaceWrite:

--- a/agent/sandbox/resolve.go
+++ b/agent/sandbox/resolve.go
@@ -187,15 +187,14 @@ func (rp ResolvedPolicy) Enforced() bool { return rp.Mode != ModeOff }
 // nothing, so the file tools keep today's byte-identical os path.
 func (rp ResolvedPolicy) FileToolConfined() bool { return rp.Mode != ModeOff || rp.WriteBlocked }
 
-// FileToolEnforceable reports whether the in-process file-tool layer can enforce
-// anything at all on this host. Its race-safe primitives (openat2 /
+// FileToolEnforceable reports whether this OS has an in-process file-tool
+// enforcement implementation. Its race-safe primitives (openat2 /
 // RESOLVE_NO_SYMLINKS on Linux, the O_NOFOLLOW tail walk on darwin) exist only
 // there; every other platform's stand-ins fail closed on EVERY operation, reads
-// included. So a policy that leans on file-tool enforcement alone — the degraded
-// read-only delegate — must not be derived off those two: it would hand back a
-// delegate whose file tools are all broken rather than one that is confined.
-// Callers with no such fallback (an ordinary sandboxed mode) never need this: the
-// resolver's backend floor already refuses every mode off Linux/darwin.
+// included. Linux callers must separately prove the live process may use openat2:
+// an older kernel or seccomp policy can reject the syscall even though the OS has
+// the implementation. The delegate fallback combines this platform check with
+// execenv's runtime probe before deriving a wrapperless policy.
 func FileToolEnforceable(host HostFacts) bool {
 	return host.OS == "linux" || host.OS == "darwin"
 }

--- a/agent/sandbox/resolve_test.go
+++ b/agent/sandbox/resolve_test.go
@@ -500,34 +500,26 @@ func TestInfraReadRootsMustBeAbsolute(t *testing.T) {
 // TestResolveWriteBlockedOffConfinesFileTools pins the degraded read-only
 // delegate scope: on a host with no sandbox backend the derived read-only box
 // resolves as write-blocked OFF instead of refusing, so the delegate keeps its
-// capability while the in-process file tools carry the whole write boundary. It
-// keeps reads open and grants no write root in either layer. Enforced() stays
-// false — there is no OS sandbox — while FileToolConfined() is true, the separate
-// question the file-tool layer asks.
+// capability while the in-process file tools carry the whole write boundary.
+// Enforced() stays false — there is no OS sandbox — while FileToolConfined() is
+// true, the separate question the file-tool layer asks.
 //
-// Every host is exercised because off resolves on every host by contract (it
-// consults no backend), and adding a write block must not break that totality.
-// WHERE the degrade may be derived is a separate decision the caller makes with
-// FileToolEnforceable — a Windows delegate keeps the refusal.
+// The grants must be the ones the file tools will actually enforce, not a
+// hand-built shell of them: the same credential/pseudo-fs denylist every
+// sandboxed mode masks, the worktree as a read anchor, and no write root at all.
 func TestResolveWriteBlockedOffConfinesFileTools(t *testing.T) {
 	t.Parallel()
-	dir := clean(t.TempDir())
-	for _, host := range []HostFacts{bareLinuxHost(), darwinBareHost(), windowsHost(), bwrapHost()} {
-		rp := mustResolve(t, SandboxPolicy{Mode: ModeOff, WriteBlocked: true}, host, dir)
+	main := mainRepo(t)
+	for _, host := range []HostFacts{bareLinuxHost(), darwinBareHost(), bwrapHost()} {
+		rp := mustResolve(t, SandboxPolicy{Mode: ModeOff, WriteBlocked: true}, host, main)
 		if rp.Mode != ModeOff || rp.Backend != BackendNone {
 			t.Errorf("write-blocked off on %s: Mode=%v Backend=%v, want off/none", host.OS, rp.Mode, rp.Backend)
 		}
 		if rp.Enforced() {
 			t.Errorf("write-blocked off on %s reports an OS sandbox in force", host.OS)
 		}
-		if !rp.FileToolConfined() {
-			t.Errorf("write-blocked off on %s must confine the file tools", host.OS)
-		}
-		if !rp.WriteBlocked {
-			t.Errorf("write-blocked off on %s dropped the write block", host.OS)
-		}
-		if rp.FileTool.Read != ReadAnywhere {
-			t.Errorf("write-blocked off on %s: FileTool.Read=%v, want anywhere", host.OS, rp.FileTool.Read)
+		if !rp.FileToolConfined() || !rp.WriteBlocked {
+			t.Errorf("write-blocked off on %s lost its file-tool confinement: confined=%v blocked=%v", host.OS, rp.FileToolConfined(), rp.WriteBlocked)
 		}
 		if len(rp.FileTool.WriteRoots) != 0 || len(rp.Spawned.WriteRoots) != 0 {
 			t.Errorf("write-blocked off on %s granted a write root: file=%v spawned=%v", host.OS, rp.FileTool.WriteRoots, rp.Spawned.WriteRoots)
@@ -535,6 +527,57 @@ func TestResolveWriteBlockedOffConfinesFileTools(t *testing.T) {
 		if !rp.Network {
 			t.Errorf("write-blocked off on %s denied egress; off applies no network confinement", host.OS)
 		}
+		// The denylist is the whole point of "reads anywhere MINUS the masked set".
+		// Without it the file tools would read ~/.ssh and /proc/<evener-pid>/environ,
+		// which every other confining mode denies.
+		assertMaskedContainsDefaults(t, rp, host.Home)
+		assertNoRootIsMasked(t, rp)
+		// The worktree is the read ANCHOR (see openRead): without it a workspace
+		// reached through a symlinked ancestor is unreadable.
+		if !slices.Contains(rp.FileTool.ReadRoots, main) {
+			t.Errorf("write-blocked off on %s: FileTool.ReadRoots=%v, want the worktree %q as a read anchor", host.OS, rp.FileTool.ReadRoots, main)
+		}
+		if rp.Git.WorktreeRoot != main {
+			t.Errorf("write-blocked off on %s did not resolve its git layout: WorktreeRoot=%q, want %q", host.OS, rp.Git.WorktreeRoot, main)
+		}
+	}
+}
+
+// TestResolveWriteBlockedOffNeedsAnAbsoluteHome: the write-blocked box leans
+// entirely on the file-tool denylist, which is home-relative. A non-absolute home
+// would join to relative entries the enforcement layer never matches — a silent
+// unmask of every credential directory — so it refuses, exactly as every
+// sandboxed mode does. Plain off is unaffected: it masks nothing and confines
+// nothing.
+func TestResolveWriteBlockedOffNeedsAnAbsoluteHome(t *testing.T) {
+	t.Parallel()
+	dir := clean(t.TempDir())
+	homeless := HostFacts{OS: "linux", Home: ""}
+	ref := mustRefuse(t, SandboxPolicy{Mode: ModeOff, WriteBlocked: true}, homeless, dir, "")
+	if !strings.Contains(ref.Reason, "credential denylist") {
+		t.Errorf("refusal must name the unmask it prevents, got: %s", ref.Reason)
+	}
+	if rp := mustResolve(t, SandboxPolicy{Mode: ModeOff}, homeless, dir); rp.FileToolConfined() {
+		t.Error("plain off must still resolve on a host with no home; it confines nothing")
+	}
+}
+
+// TestResolveWriteBlockedOffRefusesWhereFileToolsCannotEnforce: the degraded box
+// has no backend behind it, so the in-process file tools ARE the enforcement. On a
+// platform whose file-tool primitives do not exist, every operation would fail
+// closed instead — a delegate with broken file tools rather than a confined one.
+// Refuse at the resolver so no caller can produce that env, whatever it asks for.
+func TestResolveWriteBlockedOffRefusesWhereFileToolsCannotEnforce(t *testing.T) {
+	t.Parallel()
+	dir := clean(t.TempDir())
+	ref := mustRefuse(t, SandboxPolicy{Mode: ModeOff, WriteBlocked: true}, windowsHost(), dir, "")
+	if !strings.Contains(ref.Reason, "file tools") || !strings.Contains(ref.Reason, windowsHost().OS) {
+		t.Errorf("refusal must say the file tools cannot enforce on this host, got: %s", ref.Reason)
+	}
+	// Plain off still resolves everywhere, including Windows: it is today's
+	// behavior with no containment and no enforcement to be missing.
+	if rp := mustResolve(t, SandboxPolicy{Mode: ModeOff}, windowsHost(), dir); rp.FileToolConfined() {
+		t.Error("plain off on windows must stay unconfined, not refuse")
 	}
 }
 

--- a/agent/sandbox/resolve_test.go
+++ b/agent/sandbox/resolve_test.go
@@ -496,3 +496,99 @@ func TestInfraReadRootsMustBeAbsolute(t *testing.T) {
 		t.Errorf("refusal must name the offending root, got: %s", ref.Reason)
 	}
 }
+
+// TestResolveWriteBlockedOffConfinesFileTools pins the degraded read-only
+// delegate scope: on a host with no sandbox backend the derived read-only box
+// resolves as write-blocked OFF instead of refusing, so the delegate keeps its
+// capability while the in-process file tools carry the whole write boundary. It
+// keeps reads open and grants no write root in either layer. Enforced() stays
+// false — there is no OS sandbox — while FileToolConfined() is true, the separate
+// question the file-tool layer asks.
+//
+// Every host is exercised because off resolves on every host by contract (it
+// consults no backend), and adding a write block must not break that totality.
+// WHERE the degrade may be derived is a separate decision the caller makes with
+// FileToolEnforceable — a Windows delegate keeps the refusal.
+func TestResolveWriteBlockedOffConfinesFileTools(t *testing.T) {
+	t.Parallel()
+	dir := clean(t.TempDir())
+	for _, host := range []HostFacts{bareLinuxHost(), darwinBareHost(), windowsHost(), bwrapHost()} {
+		rp := mustResolve(t, SandboxPolicy{Mode: ModeOff, WriteBlocked: true}, host, dir)
+		if rp.Mode != ModeOff || rp.Backend != BackendNone {
+			t.Errorf("write-blocked off on %s: Mode=%v Backend=%v, want off/none", host.OS, rp.Mode, rp.Backend)
+		}
+		if rp.Enforced() {
+			t.Errorf("write-blocked off on %s reports an OS sandbox in force", host.OS)
+		}
+		if !rp.FileToolConfined() {
+			t.Errorf("write-blocked off on %s must confine the file tools", host.OS)
+		}
+		if !rp.WriteBlocked {
+			t.Errorf("write-blocked off on %s dropped the write block", host.OS)
+		}
+		if rp.FileTool.Read != ReadAnywhere {
+			t.Errorf("write-blocked off on %s: FileTool.Read=%v, want anywhere", host.OS, rp.FileTool.Read)
+		}
+		if len(rp.FileTool.WriteRoots) != 0 || len(rp.Spawned.WriteRoots) != 0 {
+			t.Errorf("write-blocked off on %s granted a write root: file=%v spawned=%v", host.OS, rp.FileTool.WriteRoots, rp.Spawned.WriteRoots)
+		}
+		if !rp.Network {
+			t.Errorf("write-blocked off on %s denied egress; off applies no network confinement", host.OS)
+		}
+	}
+}
+
+// TestFileToolConfinedSeparatesFromEnforced: the two predicates answer different
+// questions. Every enforced mode confines the file tools, a plain off policy
+// confines nothing (today's os path, byte-identical), and only the write-blocked
+// off policy separates them.
+func TestFileToolConfinedSeparatesFromEnforced(t *testing.T) {
+	t.Parallel()
+	main := mainRepo(t)
+	for _, mode := range []Mode{ModeReadOnly, ModeWorkspaceWrite, ModeRestricted} {
+		rp := mustResolve(t, SandboxPolicy{Mode: mode, Network: new(true)}, bwrapHost(), main)
+		if !rp.Enforced() || !rp.FileToolConfined() {
+			t.Errorf("mode %v: Enforced=%v FileToolConfined=%v, want both true", mode, rp.Enforced(), rp.FileToolConfined())
+		}
+	}
+	plain := mustResolve(t, SandboxPolicy{Mode: ModeOff}, bareLinuxHost(), main)
+	if plain.Enforced() || plain.FileToolConfined() {
+		t.Errorf("plain off: Enforced=%v FileToolConfined=%v, want both false", plain.Enforced(), plain.FileToolConfined())
+	}
+
+	// A third question: whether the file-tool layer can enforce ANYTHING on this
+	// host. Its race-safe primitives exist on linux and darwin only, and the
+	// stand-ins elsewhere fail closed on every operation — so a policy that leans
+	// on file-tool enforcement alone must never be derived off those two.
+	for _, host := range []HostFacts{bwrapHost(), bareLinuxHost(), darwinSeatbeltHost(), darwinBareHost()} {
+		if !FileToolEnforceable(host) {
+			t.Errorf("FileToolEnforceable(%s) = false, want true", host.OS)
+		}
+	}
+	if FileToolEnforceable(windowsHost()) {
+		t.Error("FileToolEnforceable(windows) = true, but every file-tool operation there fails closed")
+	}
+}
+
+// TestWriteBlockedOffGrantsSessionScratch: WriteBlocked promises the separately
+// provisioned session scratch stays writable (SandboxPolicy.WriteBlocked's
+// contract), so the late-bound scratch grant must reach a degraded policy — the
+// question WithSessionScratch asks is file-tool confinement, not OS enforcement.
+func TestWriteBlockedOffGrantsSessionScratch(t *testing.T) {
+	t.Parallel()
+	dir := clean(t.TempDir())
+	scratch := clean(t.TempDir())
+	rp := mustResolve(t, SandboxPolicy{Mode: ModeOff, WriteBlocked: true}, bareLinuxHost(), dir)
+	granted := rp.WithSessionScratch(scratch)
+	if !slices.Contains(granted.FileTool.WriteRoots, scratch) {
+		t.Fatalf("degraded policy must keep its session scratch writable: %v", granted.FileTool.WriteRoots)
+	}
+	if slices.Contains(granted.FileTool.WriteRoots, dir) {
+		t.Fatalf("the scratch grant must not widen to the workspace: %v", granted.FileTool.WriteRoots)
+	}
+	// A plain off policy is untouched: its file tools never build an enforcement
+	// layer, so a scratch grant would be a meaningless (and misleading) root.
+	if plain := mustResolve(t, SandboxPolicy{Mode: ModeOff}, bareLinuxHost(), dir).WithSessionScratch(scratch); len(plain.FileTool.WriteRoots) != 0 {
+		t.Fatalf("plain off gained a file-tool write root: %v", plain.FileTool.WriteRoots)
+	}
+}

--- a/agent/sandbox_delegate.go
+++ b/agent/sandbox_delegate.go
@@ -168,6 +168,19 @@ func (s *Session) prepareSubagentEnvironment(workingDir string, requested *sandb
 			return nil, false, fmt.Errorf("per-delegate sandbox: %w", err)
 		}
 		subEnv = local
+	} else if workingDir != "" {
+		// A fresh isolated clone normally inherits its parent's already-provisioned
+		// wrapper scratch. The degraded read-only policy has no wrapper, so the clone
+		// inherits the policy but not the parent's owned scratch. Provision its own
+		// before any file tool can cache an enforcement layer with no writable root.
+		if local, ok := subEnv.(*execenv.LocalExecutionEnvironment); ok &&
+			local.Sandbox != nil && local.Sandbox.FileToolConfined() && local.Wrapper == nil {
+			if err := local.EnableSandbox(local.Sandbox); err != nil {
+				local.DisposeSandboxScratch()
+				return nil, false, fmt.Errorf("inherited delegate sandbox: %w", err)
+			}
+			subEnv = local
+		}
 	}
 	return subEnv, workingDir != "" || requested != nil, nil
 }
@@ -271,6 +284,14 @@ func degradedReadOnlyBoundaryFor(mode sandbox.Mode, writeBlocked bool) (degraded
 	}, true
 }
 
+func degradedReadOnlyBoundaryFromEnv(env execenv.ExecutionEnvironment) (degradedReadOnlyBoundary, bool) {
+	local, ok := env.(*execenv.LocalExecutionEnvironment)
+	if !ok || local == nil || local.Sandbox == nil {
+		return degradedReadOnlyBoundary{}, false
+	}
+	return degradedReadOnlyBoundaryFor(local.Sandbox.Mode, local.Sandbox.WriteBlocked)
+}
+
 func (b degradedReadOnlyBoundary) shellDisclosure(subject string) string {
 	parts := make([]string, 0, 3)
 	if !b.ShellSandboxed {
@@ -297,11 +318,8 @@ func (b degradedReadOnlyBoundary) shellDisclosure(subject string) string {
 // path, so its shell can still write any absolute path — but it does put the
 // delegate's own directory somewhere an ACCIDENTAL write lands harmlessly, which
 // is the same collision-avoidance claim the shared-workspace advisory makes.
-func degradedReadOnlyDelegateAdvisory(policy *sandbox.SandboxPolicy) string {
-	if policy == nil {
-		return ""
-	}
-	boundary, ok := degradedReadOnlyBoundaryFor(policy.Mode, policy.WriteBlocked)
+func degradedReadOnlyDelegateAdvisory(env execenv.ExecutionEnvironment) string {
+	boundary, ok := degradedReadOnlyBoundaryFromEnv(env)
 	if !ok {
 		return ""
 	}

--- a/agent/sandbox_delegate.go
+++ b/agent/sandbox_delegate.go
@@ -181,8 +181,15 @@ func (s *Session) parentSandboxModeNet() (sandbox.Mode, bool) {
 	return mode, network
 }
 
+// The gate is FileToolConfined, not Enforced: WriteBlocked is a FLOOR a child must
+// never drop, and a degraded parent's block is real — its file tools deny every
+// workspace write — even though no OS sandbox stands behind it. Read through the
+// OS predicate, such a parent reported an unblocked floor and its children could
+// ask for writes it does not have itself. The MODE it reports is still off, which
+// is exactly right: off is what the no-escalation comparison should see from a
+// parent with no OS box.
 func parentSandboxFloorForEnv(env execenv.ExecutionEnvironment) (sandbox.Mode, bool, bool) {
-	if le, ok := env.(*execenv.LocalExecutionEnvironment); ok && le.Sandbox != nil && le.Sandbox.Enforced() {
+	if le, ok := env.(*execenv.LocalExecutionEnvironment); ok && le.Sandbox != nil && le.Sandbox.FileToolConfined() {
 		return le.Sandbox.Mode, le.Sandbox.Network, le.Sandbox.WriteBlocked
 	}
 	return sandbox.ModeOff, true, false
@@ -207,10 +214,13 @@ func (s *Session) parentSandboxFloor() (sandbox.Mode, bool, bool) {
 // off rather than refusing: choosing a read-only agent type is not a request for
 // an OS sandbox, and coupling the two made every explorer delegate fail outright
 // on an ordinary unprivileged container — the model usually abandoned delegation
-// rather than retrying. The degraded box still removes every file-tool write root
-// (strictly stronger than the advisory scope that let a delegate delete its
-// parent's deliverable), leaving only the shell unconfined; both the delegate and
-// its parent are told so. A caller that EXPLICITLY asks for sandbox="read-only"
+// rather than retrying. The degraded box removes every file-tool write root and
+// masks the credential denylist, both of which the advisory scope that let a
+// delegate delete its parent's deliverable had neither of; only the shell is left
+// unconfined. It is not a pure superset of that scope: the file-tool layer also
+// refuses to traverse a symlinked directory, which a plain-off delegate could, so
+// the delegate's prompt says so. Both the delegate and its parent are told what
+// holds and what does not. A caller that EXPLICITLY asks for sandbox="read-only"
 // gets no such degrade — see resolveReadOnlyDelegateSandboxRequest.
 func (s *Session) readOnlyDelegateSandbox() (*sandbox.SandboxPolicy, error) {
 	parentMode, parentNetwork := s.parentSandboxModeNet()
@@ -240,11 +250,16 @@ func (s *Session) readOnlyDelegateSandbox() (*sandbox.SandboxPolicy, error) {
 // advisory uses — metadata for the caller's next decision, not delegate output.
 // Empty for every other policy — only the degraded box is write-blocked with no
 // OS sandbox behind it — so an enforced delegate's result is unchanged.
+// The remediation it offers claims only what this host can deliver. A worktree
+// lane is NOT a boundary here — an isolated delegate takes the same unwrapped
+// path, so its shell can still write any absolute path — but it does put the
+// delegate's own directory somewhere an ACCIDENTAL write lands harmlessly, which
+// is the same collision-avoidance claim the shared-workspace advisory makes.
 func degradedReadOnlyDelegateAdvisory(policy *sandbox.SandboxPolicy) string {
 	if policy == nil || policy.Mode != sandbox.ModeOff || !policy.WriteBlocked {
 		return ""
 	}
-	return "this delegate's read-only boundary is enforced for its file tools (every write_file/edit_file outside its own scratch dir is denied) but ADVISORY for its shell: no sandbox backend is available on this host, so a shell command it runs can still write your workspace. Its prompt says so too. Use isolation=\"worktree\" if you need a hard boundary."
+	return "this delegate's read-only boundary is enforced for its file tools (every write_file/edit_file outside its own scratch dir is denied) but ADVISORY for its shell: no sandbox backend is available on this host, so a shell command it runs can still write your workspace. Its prompt says so too. No sandbox mode can harden this here; isolation=\"worktree\" only gives it a separate checkout, so a stray write lands off your tree rather than being blocked."
 }
 
 // resolveReadOnlyDelegateSandboxRequest applies the structured read-only role's
@@ -363,9 +378,13 @@ func (s *Session) restoreDelegateSandboxFloor(descriptor *delegatestore.Descript
 			return nil, fmt.Errorf("read-only delegate sandbox: %w", err)
 		}
 	}
+	// Paired with parentSandboxFloorForEnv above: whatever reported the write block
+	// is what the child inherits, so this reads the same predicate. Requiring an OS
+	// sandbox here would make every child of a DEGRADED parent fail to restore, the
+	// moment that parent started reporting the block it really enforces.
 	if policy == nil && parentWriteBlocked {
 		local, ok := s.currentEnv().(*execenv.LocalExecutionEnvironment)
-		if !ok || local.Sandbox == nil || !local.Sandbox.Enforced() {
+		if !ok || local.Sandbox == nil || !local.Sandbox.FileToolConfined() {
 			return nil, errors.New("invalid_request: current parent write-blocked sandbox is unavailable during delegate restore")
 		}
 		inherited := local.Sandbox.Inputs()

--- a/agent/sandbox_delegate.go
+++ b/agent/sandbox_delegate.go
@@ -196,12 +196,22 @@ func (s *Session) parentSandboxFloor() (sandbox.Mode, bool, bool) {
 	return parentSandboxFloorForEnv(s.currentEnv())
 }
 
-// readOnlyDelegateSandbox returns the enforced box for a structured read-only
-// delegate scope. A restricted parent already has a narrower read surface than
+// readOnlyDelegateSandbox returns the box for a structured read-only delegate
+// scope. A restricted parent already has a narrower read surface than
 // ModeReadOnly, so the two modes are incomparable; in that case the child keeps
 // ModeRestricted and removes every persistent write root instead of widening its
 // reads. The ordinary off/workspace-write/read-only parent cases can safely
 // tighten to ModeReadOnly.
+//
+// Where no backend can enforce ModeReadOnly the scope DEGRADES to write-blocked
+// off rather than refusing: choosing a read-only agent type is not a request for
+// an OS sandbox, and coupling the two made every explorer delegate fail outright
+// on an ordinary unprivileged container — the model usually abandoned delegation
+// rather than retrying. The degraded box still removes every file-tool write root
+// (strictly stronger than the advisory scope that let a delegate delete its
+// parent's deliverable), leaving only the shell unconfined; both the delegate and
+// its parent are told so. A caller that EXPLICITLY asks for sandbox="read-only"
+// gets no such degrade — see resolveReadOnlyDelegateSandboxRequest.
 func (s *Session) readOnlyDelegateSandbox() (*sandbox.SandboxPolicy, error) {
 	parentMode, parentNetwork := s.parentSandboxModeNet()
 	if parentMode == sandbox.ModeRestricted {
@@ -211,7 +221,30 @@ func (s *Session) readOnlyDelegateSandbox() (*sandbox.SandboxPolicy, error) {
 			Network:      &parentNetwork,
 		}, nil
 	}
+	// Checked AFTER the restricted-parent case: an enforced parent proves the host
+	// has a working backend, and inheriting its narrower box is never the degrade.
+	// The degrade needs a file-tool layer that can actually hold the boundary, so a
+	// host with neither an OS backend nor file-tool enforcement keeps the refusal
+	// rather than handing back a delegate whose file tools all fail closed.
+	host := s.sandboxHostFacts()
+	if !delegateSandboxBackendAvailable(host) && sandbox.FileToolEnforceable(host) {
+		return &sandbox.SandboxPolicy{Mode: sandbox.ModeOff, WriteBlocked: true}, nil
+	}
 	return resolveDelegateSandboxRequest(sandbox.ModeReadOnly.String(), nil, parentMode, parentNetwork)
+}
+
+// degradedReadOnlyDelegateAdvisory is the spawn-result disclosure the PARENT
+// reads: the delegate it just launched is read-only for its file tools and only
+// advisory for its shell, because this host cannot enforce the box. It rides the
+// create result's warnings, the same non-blocking channel the shared-workspace
+// advisory uses — metadata for the caller's next decision, not delegate output.
+// Empty for every other policy — only the degraded box is write-blocked with no
+// OS sandbox behind it — so an enforced delegate's result is unchanged.
+func degradedReadOnlyDelegateAdvisory(policy *sandbox.SandboxPolicy) string {
+	if policy == nil || policy.Mode != sandbox.ModeOff || !policy.WriteBlocked {
+		return ""
+	}
+	return "this delegate's read-only boundary is enforced for its file tools (every write_file/edit_file outside its own scratch dir is denied) but ADVISORY for its shell: no sandbox backend is available on this host, so a shell command it runs can still write your workspace. Its prompt says so too. Use isolation=\"worktree\" if you need a hard boundary."
 }
 
 // resolveReadOnlyDelegateSandboxRequest applies the structured read-only role's
@@ -248,8 +281,13 @@ func (s *Session) resolveReadOnlyDelegateSandboxRequest(sandboxMode string, sand
 	return requested, nil
 }
 
+// delegateSandboxBlocksPersistentWrites reports whether a policy removes every
+// persistent workspace write from the delegate's FILE TOOLS. ModeOff alone does
+// not — it is the inherit/unconfined request — but off WITH WriteBlocked does:
+// that is the degraded read-only box, whose file-tool layer denies exactly the
+// writes an enforced read-only box denies.
 func delegateSandboxBlocksPersistentWrites(policy *sandbox.SandboxPolicy) bool {
-	if policy == nil || policy.Mode == sandbox.ModeOff {
+	if policy == nil {
 		return false
 	}
 	return policy.Mode == sandbox.ModeReadOnly || policy.WriteBlocked
@@ -307,6 +345,15 @@ func (s *Session) restoreDelegateSandboxFloor(descriptor *delegatestore.Descript
 	if descriptor.Sandbox != nil && policy == nil {
 		return nil, fmt.Errorf("invalid_request: committed delegate sandbox mode %q is invalid", descriptor.Sandbox.Mode)
 	}
+	// No spawn ever PERSISTS an off box: a snapshot of one records nothing, and the
+	// degraded read-only box is re-derived against the host each restore rather than
+	// replayed. A committed "off" carrying a write block is therefore a corrupt or
+	// hand-edited descriptor asking to be trusted as write-blocked on the strength of
+	// a flag no code path wrote. Refuse it rather than admit a runtime whose claimed
+	// boundary nothing derived.
+	if policy != nil && policy.Mode == sandbox.ModeOff && policy.WriteBlocked {
+		return nil, errors.New(`invalid_request: committed delegate sandbox records mode "off" with a write block, which no spawn produces`)
+	}
 	readOnlyScope := subagentToolScopeIsReadOnly(false, descriptor.ToolNameCeiling)
 	parentMode, parentNetwork, parentWriteBlocked := s.parentSandboxFloor()
 	if policy == nil && readOnlyScope {
@@ -324,12 +371,17 @@ func (s *Session) restoreDelegateSandboxFloor(descriptor *delegatestore.Descript
 		inherited := local.Sandbox.Inputs()
 		policy = &inherited
 	}
-	if policy != nil && descriptor.Sandbox == nil {
-		descriptor.Sandbox = stableDelegateSandboxSnapshot(policy)
-		descriptor.Config.Sandbox = descriptor.Sandbox.Mode
+	// A derived floor with an OS box to record backfills the descriptor. The
+	// degraded read-only box records nothing — it is off, so there is no mode to
+	// persist and no resume to re-apply it to — and the descriptor keeps the empty
+	// snapshot the create path wrote, which is exactly what re-derives this same
+	// floor against the host the next resume actually runs on.
+	if snapshot := stableDelegateSandboxSnapshot(policy); snapshot != nil && descriptor.Sandbox == nil {
+		descriptor.Sandbox = snapshot
+		descriptor.Config.Sandbox = snapshot.Mode
 		descriptor.Config.SandboxNet = nil
-		if descriptor.Sandbox.Network != nil {
-			network := *descriptor.Sandbox.Network
+		if snapshot.Network != nil {
+			network := *snapshot.Network
 			descriptor.Config.SandboxNet = &network
 		}
 	}

--- a/agent/sandbox_delegate.go
+++ b/agent/sandbox_delegate.go
@@ -253,6 +253,38 @@ func (s *Session) delegateFileToolEnforceable(host sandbox.HostFacts) bool {
 	return execenv.FileToolEnforceable()
 }
 
+type degradedReadOnlyBoundary struct {
+	ShellSandboxed           bool
+	ShellMayReadHostFiles    bool
+	ShellMayWriteHostFiles   bool
+	ShellNetworkUnrestricted bool
+}
+
+func degradedReadOnlyBoundaryFor(mode sandbox.Mode, writeBlocked bool) (degradedReadOnlyBoundary, bool) {
+	if mode != sandbox.ModeOff || !writeBlocked {
+		return degradedReadOnlyBoundary{}, false
+	}
+	return degradedReadOnlyBoundary{
+		ShellMayReadHostFiles:    true,
+		ShellMayWriteHostFiles:   true,
+		ShellNetworkUnrestricted: true,
+	}, true
+}
+
+func (b degradedReadOnlyBoundary) shellDisclosure(subject string) string {
+	parts := make([]string, 0, 3)
+	if !b.ShellSandboxed {
+		parts = append(parts, subject+" is unsandboxed")
+	}
+	if b.ShellMayReadHostFiles && b.ShellMayWriteHostFiles {
+		parts = append(parts, "may read or write anything the host user can")
+	}
+	if b.ShellNetworkUnrestricted {
+		parts = append(parts, "uses unrestricted network access")
+	}
+	return strings.Join(parts, ", ")
+}
+
 // degradedReadOnlyDelegateAdvisory is the spawn-result disclosure the PARENT
 // reads: the delegate it just launched is read-only for its file tools and only
 // advisory for its shell, because this host cannot enforce the box. It rides the
@@ -266,10 +298,14 @@ func (s *Session) delegateFileToolEnforceable(host sandbox.HostFacts) bool {
 // delegate's own directory somewhere an ACCIDENTAL write lands harmlessly, which
 // is the same collision-avoidance claim the shared-workspace advisory makes.
 func degradedReadOnlyDelegateAdvisory(policy *sandbox.SandboxPolicy) string {
-	if policy == nil || policy.Mode != sandbox.ModeOff || !policy.WriteBlocked {
+	if policy == nil {
 		return ""
 	}
-	return "this delegate's read-only boundary is enforced for its file tools (every write_file/edit_file outside its own scratch dir is denied) but ADVISORY for its shell: no sandbox backend is available on this host, so a shell command it runs can still write your workspace. Its prompt says so too. No sandbox mode can harden this here; isolation=\"worktree\" only gives it a separate checkout, so a stray write lands off your tree rather than being blocked."
+	boundary, ok := degradedReadOnlyBoundaryFor(policy.Mode, policy.WriteBlocked)
+	if !ok {
+		return ""
+	}
+	return "this delegate's read-only boundary is enforced for its file tools (every file-tool write outside its own scratch dir is denied) but ADVISORY for its shell: no sandbox backend is available on this host, so " + boundary.shellDisclosure("its shell") + ". Its prompt says so too. No sandbox mode can harden this here; isolation=\"worktree\" only gives it a separate checkout, so a stray write lands off your tree rather than being blocked."
 }
 
 // resolveReadOnlyDelegateSandboxRequest applies the structured read-only role's

--- a/agent/sandbox_delegate.go
+++ b/agent/sandbox_delegate.go
@@ -237,10 +237,20 @@ func (s *Session) readOnlyDelegateSandbox() (*sandbox.SandboxPolicy, error) {
 	// host with neither an OS backend nor file-tool enforcement keeps the refusal
 	// rather than handing back a delegate whose file tools all fail closed.
 	host := s.sandboxHostFacts()
-	if !delegateSandboxBackendAvailable(host) && sandbox.FileToolEnforceable(host) {
+	if !delegateSandboxBackendAvailable(host) && s.delegateFileToolEnforceable(host) {
 		return &sandbox.SandboxPolicy{Mode: sandbox.ModeOff, WriteBlocked: true}, nil
 	}
 	return resolveDelegateSandboxRequest(sandbox.ModeReadOnly.String(), nil, parentMode, parentNetwork)
+}
+
+func (s *Session) delegateFileToolEnforceable(host sandbox.HostFacts) bool {
+	if !sandbox.FileToolEnforceable(host) {
+		return false
+	}
+	if s != nil && s.cfg.testOnly.fileToolEnforceable != nil {
+		return s.cfg.testOnly.fileToolEnforceable()
+	}
+	return execenv.FileToolEnforceable()
 }
 
 // degradedReadOnlyDelegateAdvisory is the spawn-result disclosure the PARENT

--- a/agent/sandbox_delegate_degrade_test.go
+++ b/agent/sandbox_delegate_degrade_test.go
@@ -243,56 +243,42 @@ func TestDegradedDelegateSpawnFailureDisposesItsScratch(t *testing.T) {
 	}
 }
 
-// TestSandboxPromptLineDisclosesDegradedReadOnlyDelegate: silent degradation is
-// its own bug, so the delegate's own prompt must say exactly where its read-only
-// boundary holds — enforced for the file tools, advisory for the shell — and name
-// the one directory it may write.
-func TestSandboxPromptLineDisclosesDegradedReadOnlyDelegate(t *testing.T) {
-	root := realTempDirForTest(t)
-	rp, err := sandbox.Resolve(sandbox.SandboxPolicy{Mode: sandbox.ModeOff, WriteBlocked: true},
-		sbxNoBackendFacts(realTempDirForTest(t)), root)
-	if err != nil {
-		t.Fatalf("Resolve: %v", err)
+// TestDegradedReadOnlyBoundaryDisclosesUnsandboxedShellCapabilities protects the
+// structured facts both parent- and delegate-facing renderers consume. It catches
+// a disclosure that narrows the residual gap to writes while omitting host reads
+// or network access, without pinning model-facing prose.
+func TestDegradedReadOnlyBoundaryDisclosesUnsandboxedShellCapabilities(t *testing.T) {
+	boundary, ok := degradedReadOnlyBoundaryFor(sandbox.ModeOff, true)
+	if !ok {
+		t.Fatal("write-blocked off must report the degraded read-only boundary")
 	}
-	local := execenv.NewLocalExecutionEnvironment(root)
-	t.Cleanup(func() { local.Cleanup(); local.DisposeSandboxScratch() })
-	if err := local.EnableSandbox(&rp); err != nil {
-		t.Fatalf("EnableSandbox: %v", err)
+	if boundary.ShellSandboxed {
+		t.Error("the degraded delegate must not report its shell as sandboxed")
 	}
-
-	got := sandboxPromptLine(local)
-	if got == "" {
-		t.Fatal("a degraded read-only delegate must still be told what its box does")
+	if !boundary.ShellMayReadHostFiles || !boundary.ShellMayWriteHostFiles {
+		t.Errorf("degraded shell host file access = read:%v write:%v, want both allowed",
+			boundary.ShellMayReadHostFiles, boundary.ShellMayWriteHostFiles)
 	}
-	if strings.Contains(got, "off (network") {
-		t.Errorf("the line must not describe the delegate's scope as the mode name %q: %q", sandbox.ModeOff, got)
+	if !boundary.ShellNetworkUnrestricted {
+		t.Error("the degraded delegate must report unrestricted shell network access")
 	}
-	for _, want := range []string{"read-only", "file tools", "shell"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("degraded sandbox line must mention %q: %q", want, got)
+	for _, tc := range []struct {
+		mode         sandbox.Mode
+		writeBlocked bool
+	}{
+		{mode: sandbox.ModeOff},
+		{mode: sandbox.ModeReadOnly, writeBlocked: true},
+	} {
+		if _, ok := degradedReadOnlyBoundaryFor(tc.mode, tc.writeBlocked); ok {
+			t.Errorf("mode=%v writeBlocked=%v reported a degraded boundary", tc.mode, tc.writeBlocked)
 		}
-	}
-	// The one thing the file-tool layer takes away that a plain-off delegate had:
-	// it will not traverse a symlinked directory. A model that hits that denial
-	// must be able to act on it instead of retrying the same path.
-	if !strings.Contains(got, "symlink") {
-		t.Errorf("degraded sandbox line must disclose the symlink-traversal refusal: %q", got)
-	}
-	scratch := local.SessionScratchDir()
-	if scratch == "" {
-		t.Fatal("a degraded read-only delegate must be given a scratch dir")
-	}
-	if !strings.Contains(got, scratch) {
-		t.Errorf("degraded sandbox line must name the one writable directory: got %q, want it to contain %q", got, scratch)
 	}
 }
 
 // TestCreateExplorerDelegateDegradesInsteadOfRefusing drives the reported
 // regression end to end: delegate(agent_type="explorer") with NO sandbox argument,
 // on a host where no backend can enforce read-only. It must launch — the caller
-// asked for an agent type, not for an OS sandbox — and the parent must be told in
-// band that the delegate's read-only boundary holds for file tools and is
-// advisory for its shell, so a degradation is never silent.
+// asked for an agent type, not for an OS sandbox.
 func TestCreateExplorerDelegateDegradesInsteadOfRefusing(t *testing.T) {
 	root := newNoBackendDelegateSession(t)
 
@@ -306,28 +292,11 @@ func TestCreateExplorerDelegateDegradesInsteadOfRefusing(t *testing.T) {
 	if result.DelegateID == "" {
 		t.Fatalf("degraded explorer delegate returned no delegate_id: %+v", result)
 	}
-	var disclosure string
-	for _, warning := range result.Warnings {
-		if strings.Contains(warning, "read-only") {
-			disclosure = warning
-		}
-	}
-	if disclosure == "" {
-		t.Fatalf("the parent must be told the boundary degraded, got warnings %q", result.Warnings)
-	}
-	for _, want := range []string{"file tools", "shell", "no sandbox backend"} {
-		if !strings.Contains(disclosure, want) {
-			t.Errorf("degradation disclosure must mention %q: %q", want, disclosure)
-		}
-	}
 }
 
-// TestDegradedAdvisoryPromisesOnlyWhatThisHostDelivers: the advisory's
-// remediation has to be true on the host it fires on. A worktree lane changes
-// WHERE the delegate works, not what confines it — an isolated delegate takes the
-// same unwrapped path, so its shell can still write any absolute path — so the
-// advisory may claim a separate checkout and must not claim a boundary.
-func TestDegradedAdvisoryPromisesOnlyWhatThisHostDelivers(t *testing.T) {
+// TestDegradedWorktreeIsolationDoesNotAddKernelConfinement proves a worktree lane
+// changes where the delegate works but cannot add the missing host sandbox.
+func TestDegradedWorktreeIsolationDoesNotAddKernelConfinement(t *testing.T) {
 	lane, home := sbxLane(t)
 	parent := sbxDelegateSession(t, sbxNoBackendFacts(home))
 	sbxSetParentEnv(t, parent, lane)
@@ -349,34 +318,6 @@ func TestDegradedAdvisoryPromisesOnlyWhatThisHostDelivers(t *testing.T) {
 	t.Cleanup(le.DisposeSandboxScratch)
 	if le.KernelWrapper() != nil {
 		t.Fatal("this host has no backend; an isolated delegate must be no more confined than a shared one")
-	}
-
-	advisory := degradedReadOnlyDelegateAdvisory(policy)
-	if strings.Contains(advisory, "hard boundary") {
-		t.Errorf("the advisory must not offer a boundary this host cannot enforce: %q", advisory)
-	}
-	if !strings.Contains(advisory, "separate checkout") {
-		t.Errorf("the advisory must claim what a worktree lane actually gives — a separate checkout: %q", advisory)
-	}
-}
-
-// TestCreateExplorerDelegateEnforcedHostSaysNothing: the disclosure is a report
-// of a real gap, not decoration. Where the host CAN enforce the read-only box,
-// the spawn carries no such warning.
-func TestCreateExplorerDelegateEnforcedHostSaysNothing(t *testing.T) {
-	root, _, _ := newDelegateResourceBootstrapSession(t) // bwrap-capable prober
-
-	result := root.createDelegate(context.Background(), delegateArgs{
-		Task:      "investigate the failing test",
-		AgentType: "explorer",
-	})
-	if result.Err != nil {
-		t.Fatalf("createDelegate on a bwrap host: %v", result.Err)
-	}
-	for _, warning := range result.Warnings {
-		if strings.Contains(warning, "no sandbox backend") {
-			t.Errorf("an enforced read-only delegate must not claim a degraded boundary: %q", warning)
-		}
 	}
 }
 

--- a/agent/sandbox_delegate_degrade_test.go
+++ b/agent/sandbox_delegate_degrade_test.go
@@ -172,6 +172,55 @@ func TestDegradedReadOnlyDelegateFileToolsRefuseWrites(t *testing.T) {
 	}
 }
 
+// TestDegradedDelegateSpawnFailureDisposesItsScratch: the degraded box provisions
+// a scratch dir like any other per-delegate sandbox, so a spawn that fails after
+// provisioning must dispose it. The leak is not just a stray directory: the
+// scratch holds a flock lease until it is retained or cleaned, and the crashed-
+// scratch sweeper only reclaims candidates whose lease it can acquire — so a
+// leaked one survives the sweeper for the daemon's whole uptime. Driven through
+// the real abort path (a nil child client fails NewSession after
+// prepareSubagentEnvironment), not by calling DisposeSandboxScratch directly. Not
+// parallel: it isolates TMPDIR to observe the scratch base.
+func TestDegradedDelegateSpawnFailureDisposesItsScratch(t *testing.T) {
+	isolated := t.TempDir()
+	t.Setenv("TMPDIR", isolated)
+
+	lane, home := sbxLane(t)
+	client := llm.NewClient()
+	client.Register(&fakeAdapter{name: "openai"})
+	s := newSession(t, withClient(client), withConfig(SessionConfig{
+		StateDir:         packageFixtureTempDir(t, "sbx-degrade-leak-*"),
+		MaxSubagentDepth: 1,
+		NoProjectPrompts: true,
+		testOnly: testConfig{
+			skipGitSnapshot:     true,
+			minimalSystemPrompt: true,
+			noSyncJobStore:      true,
+			sandboxProber:       sandbox.FakeProber{Facts: sbxNoBackendFacts(home)},
+			childClientFactory:  func() *llm.Client { return nil },
+		},
+	}))
+	if before := sandboxScratchDirs(t, isolated); len(before) != 0 {
+		t.Fatalf("isolated tmp base must start free of sandbox scratch, got %v", before)
+	}
+
+	policy, err := s.readOnlyDelegateSandbox()
+	if err != nil {
+		t.Fatalf("readOnlyDelegateSandbox: %v", err)
+	}
+	ctx := context.WithValue(context.Background(), ctxDelegationAllowance, 0)
+	ctx = context.WithValue(ctx, ctxDelegateSandboxPolicy, policy)
+	prepared, err := s.prepareSubagentRun(ctx, "child task", "", lane, 0, "", "", nil, nil)
+	if err == nil {
+		releasePreparedTreeSlot(prepared)
+		prepared.sub.sess.Close()
+		t.Fatal("expected NewSession to fail with a nil child client")
+	}
+	if left := sandboxScratchDirs(t, isolated); len(left) != 0 {
+		t.Errorf("degraded delegate scratch leaked on spawn failure (with its lease): %v", left)
+	}
+}
+
 // TestSandboxPromptLineDisclosesDegradedReadOnlyDelegate: silent degradation is
 // its own bug, so the delegate's own prompt must say exactly where its read-only
 // boundary holds — enforced for the file tools, advisory for the shell — and name
@@ -200,6 +249,12 @@ func TestSandboxPromptLineDisclosesDegradedReadOnlyDelegate(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("degraded sandbox line must mention %q: %q", want, got)
 		}
+	}
+	// The one thing the file-tool layer takes away that a plain-off delegate had:
+	// it will not traverse a symlinked directory. A model that hits that denial
+	// must be able to act on it instead of retrying the same path.
+	if !strings.Contains(got, "symlink") {
+		t.Errorf("degraded sandbox line must disclose the symlink-traversal refusal: %q", got)
 	}
 	scratch := local.SessionScratchDir()
 	if scratch == "" {
@@ -245,6 +300,44 @@ func TestCreateExplorerDelegateDegradesInsteadOfRefusing(t *testing.T) {
 	}
 }
 
+// TestDegradedAdvisoryPromisesOnlyWhatThisHostDelivers: the advisory's
+// remediation has to be true on the host it fires on. A worktree lane changes
+// WHERE the delegate works, not what confines it — an isolated delegate takes the
+// same unwrapped path, so its shell can still write any absolute path — so the
+// advisory may claim a separate checkout and must not claim a boundary.
+func TestDegradedAdvisoryPromisesOnlyWhatThisHostDelivers(t *testing.T) {
+	lane, home := sbxLane(t)
+	parent := sbxDelegateSession(t, sbxNoBackendFacts(home))
+	sbxSetParentEnv(t, parent, lane)
+
+	policy, err := parent.readOnlyDelegateSandbox()
+	if err != nil {
+		t.Fatalf("readOnlyDelegateSandbox: %v", err)
+	}
+	// The isolation path (an explicit working dir) is what the advisory would be
+	// pointing at. It confines nothing more: no backend, so no kernel wrapper.
+	isolated, _, err := parent.prepareSubagentEnvironment(lane, policy)
+	if err != nil {
+		t.Fatalf("prepareSubagentEnvironment(isolated): %v", err)
+	}
+	le, ok := isolated.(*execenv.LocalExecutionEnvironment)
+	if !ok {
+		t.Fatal("isolated env must be a LocalExecutionEnvironment")
+	}
+	t.Cleanup(le.DisposeSandboxScratch)
+	if le.KernelWrapper() != nil {
+		t.Fatal("this host has no backend; an isolated delegate must be no more confined than a shared one")
+	}
+
+	advisory := degradedReadOnlyDelegateAdvisory(policy)
+	if strings.Contains(advisory, "hard boundary") {
+		t.Errorf("the advisory must not offer a boundary this host cannot enforce: %q", advisory)
+	}
+	if !strings.Contains(advisory, "separate checkout") {
+		t.Errorf("the advisory must claim what a worktree lane actually gives — a separate checkout: %q", advisory)
+	}
+}
+
 // TestCreateExplorerDelegateEnforcedHostSaysNothing: the disclosure is a report
 // of a real gap, not decoration. Where the host CAN enforce the read-only box,
 // the spawn carries no such warning.
@@ -262,6 +355,54 @@ func TestCreateExplorerDelegateEnforcedHostSaysNothing(t *testing.T) {
 		if strings.Contains(warning, "no sandbox backend") {
 			t.Errorf("an enforced read-only delegate must not claim a degraded boundary: %q", warning)
 		}
+	}
+}
+
+// TestDegradedParentPropagatesItsWriteBlock: WriteBlocked is a FLOOR, built so a
+// child can never drop it. A degraded parent's block is real — its file tools deny
+// every workspace write — so it must reach its own children too, both as the
+// floor an explicit child request is checked against and as the box a restoring
+// child inherits. Reading that axis through the OS-sandbox predicate reported
+// false and silently dropped the floor.
+func TestDegradedParentPropagatesItsWriteBlock(t *testing.T) {
+	_, home := sbxLane(t)
+	parent := sbxDelegateSession(t, sbxNoBackendFacts(home))
+	policy, err := parent.readOnlyDelegateSandbox()
+	if err != nil {
+		t.Fatalf("readOnlyDelegateSandbox: %v", err)
+	}
+	env, _, err := parent.prepareSubagentEnvironment("", policy)
+	if err != nil {
+		t.Fatalf("prepareSubagentEnvironment: %v", err)
+	}
+	le, ok := env.(*execenv.LocalExecutionEnvironment)
+	if !ok {
+		t.Fatal("degraded env must be a LocalExecutionEnvironment")
+	}
+	t.Cleanup(le.DisposeSandboxScratch)
+
+	mode, network, writeBlocked := parentSandboxFloorForEnv(le)
+	if !writeBlocked {
+		t.Errorf("a degraded parent must report its write block to its children, got mode=%v net=%v blocked=%v", mode, network, writeBlocked)
+	}
+
+	// The floor is what an explicitly write-capable child request is refused
+	// against, and what a child with no request of its own inherits.
+	if _, err := applyWriteBlockedFloor(writeBlocked, sandbox.ModeWorkspaceWrite.String(),
+		&sandbox.SandboxPolicy{Mode: sandbox.ModeWorkspaceWrite}); err == nil {
+		t.Error("a write-capable child under a write-blocked parent must be refused")
+	}
+	sub := sbxDelegateSession(t, sbxNoBackendFacts(home))
+	sub.mu.Lock()
+	sub.env = le
+	sub.mu.Unlock()
+	descriptor := delegatestore.Descriptor{ToolNameCeiling: []string{"read_file", "shell"}}
+	inherited, err := sub.restoreDelegateSandboxFloor(&descriptor)
+	if err != nil {
+		t.Fatalf("a child restoring under a degraded parent must inherit its box, not fail: %v", err)
+	}
+	if inherited == nil || !inherited.WriteBlocked {
+		t.Fatalf("restored child floor = %+v, want the parent's write block", inherited)
 	}
 }
 

--- a/agent/sandbox_delegate_degrade_test.go
+++ b/agent/sandbox_delegate_degrade_test.go
@@ -88,6 +88,28 @@ func TestReadOnlyDelegateSandbox_NoDegradeWhereFileToolsCannotEnforce(t *testing
 	}
 }
 
+// TestReadOnlyDelegateSandbox_NoDegradeWhenSecureOpenIsUnavailable catches a
+// Linux host being classified from GOOS alone even though its kernel or seccomp
+// policy refuses openat2. Such a delegate would launch and then fail every file
+// operation, so it must keep the enforced request and refuse before launch.
+func TestReadOnlyDelegateSandbox_NoDegradeWhenSecureOpenIsUnavailable(t *testing.T) {
+	lane, home := sbxLane(t)
+	parent := sbxDelegateSession(t, sbxNoBackendFacts(home))
+	parent.cfg.testOnly.fileToolEnforceable = func() bool { return false }
+	sbxSetParentEnv(t, parent, lane)
+
+	policy, err := parent.readOnlyDelegateSandbox()
+	if err != nil {
+		t.Fatalf("readOnlyDelegateSandbox: %v", err)
+	}
+	if policy == nil || policy.Mode != sandbox.ModeReadOnly {
+		t.Fatalf("derived scope without secure-open support = %+v, want an unmodified read-only box", policy)
+	}
+	if _, _, err := parent.prepareSubagentEnvironment("", policy); err == nil {
+		t.Fatal("a host without a kernel sandbox or working secure-open primitive must refuse the spawn")
+	}
+}
+
 // TestExplicitReadOnlyDelegateSandboxStillFailsClosed: only the DERIVED scope
 // degrades. A caller that states the contract — sandbox="read-only" — must not
 // silently receive a weaker one, so its request keeps ModeReadOnly and the spawn

--- a/agent/sandbox_delegate_degrade_test.go
+++ b/agent/sandbox_delegate_degrade_test.go
@@ -321,6 +321,56 @@ func TestDegradedWorktreeIsolationDoesNotAddKernelConfinement(t *testing.T) {
 	}
 }
 
+// TestInheritedDegradedWorktreeProvisionsScratchBeforeFileToolUse catches an
+// isolated child inheriting a wrapperless write block without re-running
+// EnableSandbox. The child must own its scratch before its first file tool builds
+// the cached enforcement layer, or the later shell scratch never becomes writable
+// through that cache.
+func TestInheritedDegradedWorktreeProvisionsScratchBeforeFileToolUse(t *testing.T) {
+	lane, home := sbxLane(t)
+	parent := sbxDelegateSession(t, sbxNoBackendFacts(home))
+	sbxSetParentEnv(t, parent, lane)
+	policy, err := parent.readOnlyDelegateSandbox()
+	if err != nil {
+		t.Fatalf("readOnlyDelegateSandbox: %v", err)
+	}
+	degraded, _, err := parent.prepareSubagentEnvironment("", policy)
+	if err != nil {
+		t.Fatalf("prepare degraded parent environment: %v", err)
+	}
+	parent.mu.Lock()
+	parent.env = degraded
+	parent.mu.Unlock()
+
+	childLane := filepath.Join(filepath.Dir(lane), "isolated-child")
+	if err := os.MkdirAll(childLane, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	childEnv, ownsFresh, err := parent.prepareSubagentEnvironment(childLane, nil)
+	if err != nil {
+		t.Fatalf("prepare inherited child environment: %v", err)
+	}
+	child, ok := childEnv.(*execenv.LocalExecutionEnvironment)
+	if !ok {
+		t.Fatal("inherited child env must be a LocalExecutionEnvironment")
+	}
+	if !ownsFresh {
+		t.Fatal("an isolated inherited child must own its fresh environment")
+	}
+	t.Cleanup(child.DisposeSandboxScratch)
+
+	scratch := child.SessionScratchDir()
+	if scratch == "" {
+		t.Fatal("an inherited wrapperless write block must provision scratch before file-tool use")
+	}
+	if _, err := child.WriteFile(filepath.Join(scratch, "findings.md"), "ready\n"); err != nil {
+		t.Fatalf("the first file-tool use must write the inherited child's scratch: %v", err)
+	}
+	if _, ok := degradedReadOnlyBoundaryFromEnv(child); !ok {
+		t.Fatal("the inherited child's effective environment must report its degraded boundary")
+	}
+}
+
 // TestDegradedParentPropagatesItsWriteBlock: WriteBlocked is a FLOOR, built so a
 // child can never drop it. A degraded parent's block is real — its file tools deny
 // every workspace write — so it must reach its own children too, both as the

--- a/agent/sandbox_delegate_degrade_test.go
+++ b/agent/sandbox_delegate_degrade_test.go
@@ -1,0 +1,334 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/internal/delegatestore"
+	"primeradiant.com/evener/agent/sandbox"
+	"primeradiant.com/evener/llm"
+)
+
+// sbxNoBackendFacts describes the host the read-only delegate regression was
+// measured on: an ordinary unprivileged Linux container where bubblewrap cannot
+// namespace, so no backend can enforce any sandboxed mode.
+func sbxNoBackendFacts(home string) sandbox.HostFacts {
+	return sandbox.HostFacts{OS: "linux", Home: home}
+}
+
+// TestReadOnlyDelegateSandbox_DegradesWhenHostCannotEnforce: choosing a read-only
+// delegate scope is not, by itself, a request the host must be able to satisfy
+// with an OS sandbox. Where no backend can enforce ModeReadOnly the derived scope
+// becomes write-blocked OFF — the delegate keeps its capability and loses every
+// file-tool write root — instead of refusing the spawn.
+func TestReadOnlyDelegateSandbox_DegradesWhenHostCannotEnforce(t *testing.T) {
+	lane, home := sbxLane(t)
+	facts := sbxNoBackendFacts(home)
+	parent := sbxDelegateSession(t, facts) // parent env is off
+
+	policy, err := parent.readOnlyDelegateSandbox()
+	if err != nil {
+		t.Fatalf("a derived read-only scope must not refuse on a backendless host: %v", err)
+	}
+	if policy == nil || policy.Mode != sandbox.ModeOff || !policy.WriteBlocked {
+		t.Fatalf("degraded read-only delegate policy = %+v, want off/write-blocked", policy)
+	}
+	rp, err := sandbox.Resolve(*policy, facts, lane)
+	if err != nil {
+		t.Fatalf("Resolve degraded policy: %v", err)
+	}
+	if rp.Enforced() {
+		t.Error("the degraded policy must not claim an OS sandbox it does not have")
+	}
+	if !rp.FileToolConfined() {
+		t.Error("the degraded policy must confine the file tools")
+	}
+	if len(rp.FileTool.WriteRoots) != 0 || len(rp.Spawned.WriteRoots) != 0 {
+		t.Errorf("degraded policy retained write roots: file=%v spawned=%v", rp.FileTool.WriteRoots, rp.Spawned.WriteRoots)
+	}
+
+	// The same derivation on a host that CAN enforce is untouched: degrading is a
+	// last resort, never a shortcut past a working backend.
+	enforcing := sbxDelegateSession(t, sbxBwrapFacts(home))
+	enforced, err := enforcing.readOnlyDelegateSandbox()
+	if err != nil {
+		t.Fatalf("readOnlyDelegateSandbox on a bwrap host: %v", err)
+	}
+	if enforced == nil || enforced.Mode != sandbox.ModeReadOnly {
+		t.Fatalf("read-only delegate on a bwrap host = %+v, want an enforced read-only box", enforced)
+	}
+}
+
+// TestReadOnlyDelegateSandbox_NoDegradeWhereFileToolsCannotEnforce: the degrade
+// is only sound where the file tools can actually hold the boundary. The
+// fd-anchored, symlink-refusing primitives they need exist on linux and darwin
+// only; everywhere else the stand-ins fail closed on EVERY operation, reads
+// included. Degrading there would hand back a delegate whose file tools are all
+// broken, so the spawn keeps its loud refusal instead.
+func TestReadOnlyDelegateSandbox_NoDegradeWhereFileToolsCannotEnforce(t *testing.T) {
+	lane, home := sbxLane(t)
+	windows := sandbox.HostFacts{OS: "windows", Home: home}
+	parent := sbxDelegateSession(t, windows)
+	sbxSetParentEnv(t, parent, lane)
+
+	policy, err := parent.readOnlyDelegateSandbox()
+	if err != nil {
+		t.Fatalf("readOnlyDelegateSandbox: %v", err)
+	}
+	if policy == nil || policy.Mode != sandbox.ModeReadOnly {
+		t.Fatalf("derived scope on a host with no file-tool enforcement = %+v, want an unmodified read-only box", policy)
+	}
+	if _, _, err := parent.prepareSubagentEnvironment("", policy); err == nil {
+		t.Fatal("a box neither the kernel nor the file tools can enforce must refuse the spawn")
+	}
+}
+
+// TestExplicitReadOnlyDelegateSandboxStillFailsClosed: only the DERIVED scope
+// degrades. A caller that states the contract — sandbox="read-only" — must not
+// silently receive a weaker one, so its request keeps ModeReadOnly and the spawn
+// fails closed with the resolver's typed refusal.
+func TestExplicitReadOnlyDelegateSandboxStillFailsClosed(t *testing.T) {
+	lane, home := sbxLane(t)
+	facts := sbxNoBackendFacts(home)
+	parent := sbxDelegateSession(t, facts)
+	sbxSetParentEnv(t, parent, lane)
+
+	requested, err := parent.resolveReadOnlyDelegateSandboxRequest("read-only", nil)
+	if err != nil {
+		t.Fatalf("resolveReadOnlyDelegateSandboxRequest: %v", err)
+	}
+	if requested == nil || requested.Mode != sandbox.ModeReadOnly || requested.WriteBlocked {
+		t.Fatalf("an explicit read-only request = %+v, want an unmodified read-only box", requested)
+	}
+
+	_, _, err = parent.prepareSubagentEnvironment("", requested)
+	if err == nil {
+		t.Fatal("an explicit read-only request must fail closed where no backend can enforce it")
+	}
+	if _, ok := errors.AsType[*sandbox.RefusalError](err); !ok {
+		t.Fatalf("explicit refusal = %T (%v), want a *sandbox.RefusalError", err, err)
+	}
+	if !strings.Contains(err.Error(), "no sandbox backend is available") {
+		t.Errorf("refusal must still say why the host cannot enforce it, got %v", err)
+	}
+}
+
+// TestDegradedReadOnlyDelegateFileToolsRefuseWrites is the enforcement the
+// degrade rests on: a real delegate, spawned from the derived scope on a host
+// with no sandbox backend, cannot write the shared workspace through its file
+// tools. Its reads work and its own scratch dir is writable, so the delegate is
+// useful — it just cannot touch the parent's deliverable.
+func TestDegradedReadOnlyDelegateFileToolsRefuseWrites(t *testing.T) {
+	lane, home := sbxLane(t)
+	parent := sbxDelegateSession(t, sbxNoBackendFacts(home))
+	sbxSetParentEnv(t, parent, lane)
+
+	policy, err := parent.readOnlyDelegateSandbox()
+	if err != nil {
+		t.Fatalf("readOnlyDelegateSandbox: %v", err)
+	}
+	prepared := prepareWithDelegateSandbox(t, parent, lane, policy)
+	child, ok := prepared.sub.sess.currentEnv().(*execenv.LocalExecutionEnvironment)
+	if !ok {
+		t.Fatal("child env must be a LocalExecutionEnvironment")
+	}
+	if child.Sandbox == nil || child.Sandbox.Enforced() || !child.Sandbox.FileToolConfined() {
+		t.Fatalf("child box = %+v, want an unenforced but file-tool-confined policy", child.Sandbox)
+	}
+	if child.KernelWrapper() != nil {
+		t.Error("a host with no backend must give the child no kernel wrapper")
+	}
+
+	deliverable := filepath.Join(lane, "deliverable.md")
+	if err := os.WriteFile(deliverable, []byte("the parent's work\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := child.WriteFile(filepath.Join(lane, "new.txt"), "clobber"); err == nil {
+		t.Fatal("a read-only delegate must not write the shared workspace")
+	} else if _, ok := errors.AsType[*sandbox.DeniedError](err); !ok {
+		t.Fatalf("workspace write refusal = %T (%v), want a typed *sandbox.DeniedError", err, err)
+	}
+	if _, err := child.EditFile(deliverable, "the parent's work", "destroyed", false); err == nil {
+		t.Fatal("a read-only delegate must not edit the parent's deliverable")
+	}
+	if got, _ := os.ReadFile(deliverable); string(got) != "the parent's work\n" {
+		t.Fatalf("a denied edit mutated the deliverable: %q", got)
+	}
+
+	if got, err := child.ReadFile(deliverable, nil, nil); err != nil || !strings.Contains(got, "the parent's work") {
+		t.Fatalf("the delegate must keep reading: got %q err %v", got, err)
+	}
+	scratch := child.SessionScratchDir()
+	if scratch == "" {
+		t.Fatal("a degraded read-only delegate must still get a scratch dir to write into")
+	}
+	if _, err := child.WriteFile(filepath.Join(scratch, "findings.md"), "what I found\n"); err != nil {
+		t.Fatalf("the delegate's own scratch dir must stay writable: %v", err)
+	}
+}
+
+// TestSandboxPromptLineDisclosesDegradedReadOnlyDelegate: silent degradation is
+// its own bug, so the delegate's own prompt must say exactly where its read-only
+// boundary holds — enforced for the file tools, advisory for the shell — and name
+// the one directory it may write.
+func TestSandboxPromptLineDisclosesDegradedReadOnlyDelegate(t *testing.T) {
+	root := realTempDirForTest(t)
+	rp, err := sandbox.Resolve(sandbox.SandboxPolicy{Mode: sandbox.ModeOff, WriteBlocked: true},
+		sbxNoBackendFacts(realTempDirForTest(t)), root)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	local := execenv.NewLocalExecutionEnvironment(root)
+	t.Cleanup(func() { local.Cleanup(); local.DisposeSandboxScratch() })
+	if err := local.EnableSandbox(&rp); err != nil {
+		t.Fatalf("EnableSandbox: %v", err)
+	}
+
+	got := sandboxPromptLine(local)
+	if got == "" {
+		t.Fatal("a degraded read-only delegate must still be told what its box does")
+	}
+	if strings.Contains(got, "off (network") {
+		t.Errorf("the line must not describe the delegate's scope as the mode name %q: %q", sandbox.ModeOff, got)
+	}
+	for _, want := range []string{"read-only", "file tools", "shell"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("degraded sandbox line must mention %q: %q", want, got)
+		}
+	}
+	scratch := local.SessionScratchDir()
+	if scratch == "" {
+		t.Fatal("a degraded read-only delegate must be given a scratch dir")
+	}
+	if !strings.Contains(got, scratch) {
+		t.Errorf("degraded sandbox line must name the one writable directory: got %q, want it to contain %q", got, scratch)
+	}
+}
+
+// TestCreateExplorerDelegateDegradesInsteadOfRefusing drives the reported
+// regression end to end: delegate(agent_type="explorer") with NO sandbox argument,
+// on a host where no backend can enforce read-only. It must launch — the caller
+// asked for an agent type, not for an OS sandbox — and the parent must be told in
+// band that the delegate's read-only boundary holds for file tools and is
+// advisory for its shell, so a degradation is never silent.
+func TestCreateExplorerDelegateDegradesInsteadOfRefusing(t *testing.T) {
+	root := newNoBackendDelegateSession(t)
+
+	result := root.createDelegate(context.Background(), delegateArgs{
+		Task:      "investigate the failing test",
+		AgentType: "explorer",
+	})
+	if result.Err != nil {
+		t.Fatalf("an explorer delegate must launch on a host with no sandbox backend, got %v", result.Err)
+	}
+	if result.DelegateID == "" {
+		t.Fatalf("degraded explorer delegate returned no delegate_id: %+v", result)
+	}
+	var disclosure string
+	for _, warning := range result.Warnings {
+		if strings.Contains(warning, "read-only") {
+			disclosure = warning
+		}
+	}
+	if disclosure == "" {
+		t.Fatalf("the parent must be told the boundary degraded, got warnings %q", result.Warnings)
+	}
+	for _, want := range []string{"file tools", "shell", "no sandbox backend"} {
+		if !strings.Contains(disclosure, want) {
+			t.Errorf("degradation disclosure must mention %q: %q", want, disclosure)
+		}
+	}
+}
+
+// TestCreateExplorerDelegateEnforcedHostSaysNothing: the disclosure is a report
+// of a real gap, not decoration. Where the host CAN enforce the read-only box,
+// the spawn carries no such warning.
+func TestCreateExplorerDelegateEnforcedHostSaysNothing(t *testing.T) {
+	root, _, _ := newDelegateResourceBootstrapSession(t) // bwrap-capable prober
+
+	result := root.createDelegate(context.Background(), delegateArgs{
+		Task:      "investigate the failing test",
+		AgentType: "explorer",
+	})
+	if result.Err != nil {
+		t.Fatalf("createDelegate on a bwrap host: %v", result.Err)
+	}
+	for _, warning := range result.Warnings {
+		if strings.Contains(warning, "no sandbox backend") {
+			t.Errorf("an enforced read-only delegate must not claim a degraded boundary: %q", warning)
+		}
+	}
+}
+
+// TestRestoreDelegateSandboxFloorDegradesForReadOnlyCeiling: a degraded delegate
+// persists no sandbox snapshot (there is no OS box to record), so resuming it
+// re-derives the floor from its structured tool ceiling. That derivation must
+// produce the same write-blocked box and must not trip the write-capable guard
+// that exists to stop a read-only delegate resuming with workspace writes.
+func TestRestoreDelegateSandboxFloorDegradesForReadOnlyCeiling(t *testing.T) {
+	lane, home := sbxLane(t)
+	s := sbxDelegateSession(t, sbxNoBackendFacts(home))
+	sbxSetParentEnv(t, s, lane)
+
+	descriptor := delegatestore.Descriptor{ToolNameCeiling: []string{"read_file", "grep", "glob"}}
+	policy, err := s.restoreDelegateSandboxFloor(&descriptor)
+	if err != nil {
+		t.Fatalf("restoring a read-only delegate on a backendless host must not fail closed: %v", err)
+	}
+	if policy == nil || policy.Mode != sandbox.ModeOff || !policy.WriteBlocked {
+		t.Fatalf("restored floor = %+v, want the degraded off/write-blocked box", policy)
+	}
+}
+
+// newNoBackendDelegateSession builds a delegate-capable root session on a host
+// where no sandbox backend can enforce any mode — the ordinary unprivileged
+// container the regression was measured on.
+func newNoBackendDelegateSession(t *testing.T) *Session {
+	t.Helper()
+	workspace := realTempDirForTest(t)
+	client := llm.NewClient()
+	client.Register(&fakeAdapter{name: "openai"})
+	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(workspace), SessionConfig{
+		StateDir:         t.TempDir(),
+		MaxSubagentDepth: 2,
+		NoProjectPrompts: true,
+		ForceRealIO:      true,
+		testOnly: testConfig{
+			skipGitSnapshot:     true,
+			minimalSystemPrompt: true,
+			sandboxProber:       sandbox.FakeProber{Facts: sbxNoBackendFacts(t.TempDir())},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	t.Cleanup(sess.Close)
+	return sess
+}
+
+// realTempDirForTest returns a fresh temp dir through its canonical path, so a
+// host symlink (macOS /var → /private/var) does not sit in a path the file-tool
+// layer must resolve without following symlinks.
+func realTempDirForTest(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	return dir
+}
+
+// sbxSetParentEnv points the session's current env at dir with no sandbox policy,
+// the ordinary unsandboxed parent a delegate is spawned from.
+func sbxSetParentEnv(t *testing.T, s *Session, dir string) {
+	t.Helper()
+	env := execenv.NewLocalExecutionEnvironment(dir)
+	s.mu.Lock()
+	s.env = env
+	s.mu.Unlock()
+}

--- a/agent/sandbox_delegate_role_floor_test.go
+++ b/agent/sandbox_delegate_role_floor_test.go
@@ -268,7 +268,7 @@ func TestRestoreDelegate_ReadOnlyRoleSandboxFloor(t *testing.T) {
 		wantWriteBlocked bool
 	}{
 		{name: "explicit off", snapshot: &delegatestore.SandboxSnapshot{Mode: "off"}},
-		{name: "off with ignored write-blocked option", snapshot: &delegatestore.SandboxSnapshot{Mode: "off", WriteBlocked: true}},
+		{name: "off with unwritable write-blocked option", snapshot: &delegatestore.SandboxSnapshot{Mode: "off", WriteBlocked: true}},
 		{name: "explicit workspace-write", snapshot: &delegatestore.SandboxSnapshot{Mode: "workspace-write"}},
 		{name: "explicit restricted", snapshot: &delegatestore.SandboxSnapshot{Mode: "restricted"}},
 		{name: "explicit read-only", snapshot: &delegatestore.SandboxSnapshot{Mode: "read-only"}, allowed: true, wantMode: sandbox.ModeReadOnly},

--- a/agent/session_capabilities.go
+++ b/agent/session_capabilities.go
@@ -114,6 +114,15 @@ type capabilityFacts struct {
 	unknownEnv bool
 }
 
+// sandboxed reports whether an OS sandbox is in force — deliberately Enforced()
+// and not FileToolConfined(). Every line it gates describes OS-enforced state: the
+// writable-roots summary is built from the SPAWNED layer, the cache strategy is an
+// env-floor behavior of the kernel wrapper, and the `go` telemetry note reports a
+// denial the wrapper makes. For a write-blocked box with no wrapper each of those
+// would be false rather than merely absent — "Writable roots: none" would describe
+// a shell that can in fact write anywhere. That box's real boundary is stated in
+// the environment section instead (sandboxPromptLine), which says which half is
+// enforced and which half is advisory.
 func (f capabilityFacts) sandboxed() bool {
 	return f.policy != nil && f.policy.Enforced()
 }

--- a/agent/session_config.go
+++ b/agent/session_config.go
@@ -437,6 +437,9 @@ type testConfig struct {
 	// leaves it nil and probes the live host (sandbox.RealProber); tests inject a
 	// sandbox.FakeProber so the resume path never shells out to bwrap.
 	sandboxProber sandbox.Prober
+	// fileToolEnforceable replaces the runtime secure-open capability probe for
+	// deterministic delegate sandbox tests. Nil probes the live process.
+	fileToolEnforceable func() bool
 
 	// envProbes, when non-nil, replaces envctx.DefaultProbes() wholesale for the
 	// session's environment-context collector — including the production

--- a/agent/session_prompts.go
+++ b/agent/session_prompts.go
@@ -242,39 +242,53 @@ func (s *Session) canPromptDelegation() bool {
 	return true
 }
 
-// sandboxPromptLine renders the environment-section sandbox line for a sandboxed
-// env ("<mode> (network on|off) — fixed for this session"), so the model knows the
-// immutable box it runs under. When a kernel wrapper has provisioned a real
-// scratch directory, its path is appended (kata g8q6): a spawned shell command
-// learns the scratch dir through $TMPDIR/$EVENER_SCRATCH_DIR, but the model's own
-// file tools (write_file, read_file, …) never see process environment
-// variables, so without this line a model has no way to discover the one
-// directory its file tools can actually write to outside the worktree — it was
+// sandboxPromptLine renders the environment-section sandbox line for an env whose
+// file tools are confined, so the model knows the immutable box it runs under —
+// its mode and network when an OS sandbox enforces it, and which half is enforced
+// when only the file tools do (see sandboxPromptBoundary). When a scratch
+// directory has been provisioned, its path is appended (kata g8q6): a spawned
+// shell command learns the scratch dir through $TMPDIR/$EVENER_SCRATCH_DIR, but
+// the model's own file tools (write_file, read_file, …) never see process
+// environment variables, so without this line a model has no way to discover the
+// one directory its file tools can actually write to outside the worktree — it was
 // observed guessing a literal "/tmp/...", which every sandboxed mode denies.
-// Empty for an unsandboxed env so the line is omitted entirely (byte-identical
-// prompt to today). Takes the resolved env directly — the prompt-render path
-// holds s.mu, so it must not re-fetch via s.currentEnv().
+// Empty for an env whose file tools are unconfined, so the line is omitted
+// entirely (byte-identical prompt to today). Takes the resolved env directly —
+// the prompt-render path holds s.mu, so it must not re-fetch via s.currentEnv().
 func sandboxPromptLine(env execenv.ExecutionEnvironment) string {
 	le, ok := env.(*execenv.LocalExecutionEnvironment)
-	if !ok || le.Sandbox == nil || !le.Sandbox.Enforced() {
+	if !ok || le.Sandbox == nil || !le.Sandbox.FileToolConfined() {
 		return ""
 	}
-	netStr := "on"
-	if !le.Sandbox.Network {
-		netStr = "off"
-	}
-	line := fmt.Sprintf("%s (network %s) — fixed for this session", le.Sandbox.Mode, netStr)
-	if le.Wrapper != nil {
-		if scratch := le.Wrapper.SessionTmp(); scratch != "" {
-			line += ". Scratch directory (read-write even in this sandbox; also $" +
-				envvars.TmpDir.Name + " / $" + envvars.EVENERScratchDir.Name + " for shell commands): " + scratch
-			if le.Sandbox.Mode == sandbox.ModeReadOnly || le.Sandbox.WriteBlocked {
-				line += ". Read-only delegates may write only inside this scratch directory; all other writes are denied."
-			}
-			line += ". In your final human-readable handoff, report this absolute scratch path and the absolute paths of any artifacts your parent should retain; cleanup is manual."
+	line := sandboxPromptBoundary(le.Sandbox)
+	if scratch := le.SessionScratchDir(); scratch != "" {
+		line += ". Scratch directory (read-write even in this sandbox; also $" +
+			envvars.TmpDir.Name + " / $" + envvars.EVENERScratchDir.Name + " for shell commands): " + scratch
+		if le.Sandbox.Mode == sandbox.ModeReadOnly || le.Sandbox.WriteBlocked {
+			line += ". Read-only delegates may write only inside this scratch directory; all other writes are denied."
 		}
+		line += ". In your final human-readable handoff, report this absolute scratch path and the absolute paths of any artifacts your parent should retain; cleanup is manual."
 	}
 	return line
+}
+
+// sandboxPromptBoundary states what the box actually holds. An enforced policy
+// names its mode and network decision. A write-blocked policy with no OS sandbox
+// — a read-only delegate on a host with no backend — must not name its mode:
+// "off" would describe the ABSENT kernel box rather than the boundary the model
+// actually runs under, and reporting it as an ordinary read-only sandbox would
+// overstate. It says which half is enforced and which half is on the model's
+// honour, because a degradation nobody discloses is how a delegate deleted its
+// parent's deliverable.
+func sandboxPromptBoundary(rp *sandbox.ResolvedPolicy) string {
+	if !rp.Enforced() {
+		return "read-only for your file tools — fixed for this session. This host has no sandbox backend, so the boundary is ENFORCED for your file tools (write_file, edit_file and the rest are denied) and ADVISORY for your shell: nothing stops a shell command from writing, so do not write outside the scratch directory"
+	}
+	netStr := "on"
+	if !rp.Network {
+		netStr = "off"
+	}
+	return fmt.Sprintf("%s (network %s) — fixed for this session", rp.Mode, netStr)
 }
 
 // renderSystemPrompt renders the system prompt using the template resolver. It

--- a/agent/session_prompts.go
+++ b/agent/session_prompts.go
@@ -265,7 +265,11 @@ func sandboxPromptLine(env execenv.ExecutionEnvironment) string {
 		line += ". Scratch directory (read-write even in this sandbox; also $" +
 			envvars.TmpDir.Name + " / $" + envvars.EVENERScratchDir.Name + " for shell commands): " + scratch
 		if le.Sandbox.Mode == sandbox.ModeReadOnly || le.Sandbox.WriteBlocked {
-			line += ". Read-only delegates may write only inside this scratch directory; all other writes are denied"
+			if le.Sandbox.Enforced() {
+				line += ". Read-only delegates may write only inside this scratch directory; all other writes are denied"
+			} else {
+				line += ". Your file tools may write only inside this scratch directory; all other file-tool writes are denied"
+			}
 		}
 		line += ". In your final human-readable handoff, report this absolute scratch path and the absolute paths of any artifacts your parent should retain; cleanup is manual."
 	}

--- a/agent/session_prompts.go
+++ b/agent/session_prompts.go
@@ -282,7 +282,8 @@ func sandboxPromptLine(env execenv.ExecutionEnvironment) string {
 // parent's deliverable.
 func sandboxPromptBoundary(rp *sandbox.ResolvedPolicy) string {
 	if !rp.Enforced() {
-		return "read-only for your file tools — fixed for this session. This host has no sandbox backend, so the boundary is ENFORCED for your file tools (write_file, edit_file and the rest are denied) and ADVISORY for your shell: nothing stops a shell command from writing, so do not write outside the scratch directory. Your file tools will not traverse a symlinked directory either; if one is refused, name the real path instead of retrying"
+		boundary, _ := degradedReadOnlyBoundaryFor(rp.Mode, rp.WriteBlocked)
+		return "read-only for your file tools — fixed for this session. This host has no sandbox backend, so the boundary is ENFORCED for your file tools (every file-tool write outside your scratch directory is denied) and ADVISORY for your shell: " + boundary.shellDisclosure("your shell") + ". Do not write outside the scratch directory. Your file tools will not traverse a symlinked directory either; if one is refused, name the real path instead of retrying"
 	}
 	netStr := "on"
 	if !rp.Network {

--- a/agent/session_prompts.go
+++ b/agent/session_prompts.go
@@ -265,7 +265,7 @@ func sandboxPromptLine(env execenv.ExecutionEnvironment) string {
 		line += ". Scratch directory (read-write even in this sandbox; also $" +
 			envvars.TmpDir.Name + " / $" + envvars.EVENERScratchDir.Name + " for shell commands): " + scratch
 		if le.Sandbox.Mode == sandbox.ModeReadOnly || le.Sandbox.WriteBlocked {
-			line += ". Read-only delegates may write only inside this scratch directory; all other writes are denied."
+			line += ". Read-only delegates may write only inside this scratch directory; all other writes are denied"
 		}
 		line += ". In your final human-readable handoff, report this absolute scratch path and the absolute paths of any artifacts your parent should retain; cleanup is manual."
 	}
@@ -282,7 +282,7 @@ func sandboxPromptLine(env execenv.ExecutionEnvironment) string {
 // parent's deliverable.
 func sandboxPromptBoundary(rp *sandbox.ResolvedPolicy) string {
 	if !rp.Enforced() {
-		return "read-only for your file tools — fixed for this session. This host has no sandbox backend, so the boundary is ENFORCED for your file tools (write_file, edit_file and the rest are denied) and ADVISORY for your shell: nothing stops a shell command from writing, so do not write outside the scratch directory"
+		return "read-only for your file tools — fixed for this session. This host has no sandbox backend, so the boundary is ENFORCED for your file tools (write_file, edit_file and the rest are denied) and ADVISORY for your shell: nothing stops a shell command from writing, so do not write outside the scratch directory. Your file tools will not traverse a symlinked directory either; if one is refused, name the real path instead of retrying"
 	}
 	netStr := "on"
 	if !rp.Network {

--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -35,13 +35,20 @@ On a host where no backend can enforce that box — an ordinary unprivileged Lin
 container without usable bubblewrap — the derived scope **degrades rather than
 refusing the spawn**. The delegate runs with no kernel wrapper; its file tools
 keep the identical write boundary (every `write_file`/`edit_file` outside its own
-scratch dir is denied) and its shell is unconfined. That is strictly stronger than
-the advisory scope this floor replaced, and it keeps the capability instead of
-deleting it: coupling the scope to an OS sandbox made every `explorer` delegate
-fail outright on such a host, and the model usually abandoned delegation rather
-than retrying. The gap is disclosed in both directions — the delegate's own
-environment section says which half is enforced and which half is on its honour,
-and the spawn result the parent reads carries the same warning.
+scratch dir is denied) and mask the same credential denylist, and its shell is
+unconfined. That keeps the capability instead of deleting it: coupling the scope
+to an OS sandbox made every `explorer` delegate fail outright on such a host, and
+the model usually abandoned delegation rather than retrying.
+
+It is not a pure superset of the advisory scope this floor replaced. Routing the
+file tools through the enforcement layer also means they refuse to traverse a
+**symlinked directory**, which an unsandboxed delegate could — the same refusal
+every enforced mode makes, now paid by a delegate that previously had no sandbox
+at all. A workspace whose ROOT is reached through a symlink is unaffected: reads
+anchor at the worktree, which tolerates a symlinked ancestor. Everything here is
+disclosed in both directions — the delegate's own environment section says which
+half is enforced, which half is on its honour, and what its file tools will not
+traverse, and the spawn result the parent reads carries the same warning.
 
 An explicit delegate `sandbox` argument does **not** bypass the structured
 read-only floor, and does **not** get the degrade either — a caller that states

--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -29,9 +29,24 @@ whose shell is intended for inspection; the kernel wrapper confines that shell
 and every descendant, while the delegate's own session scratch remains writable.
 A parent already running `restricted` keeps that narrower read scope and applies
 the same write block without widening reads. A role with an explicit mutation
-tool follows the normal delegate floor. An explicit delegate `sandbox` argument
-does **not** bypass the structured read-only floor: `read-only` is accepted when
-it is also compatible with the parent's boundary, while `off`,
+tool follows the normal delegate floor.
+
+On a host where no backend can enforce that box — an ordinary unprivileged Linux
+container without usable bubblewrap — the derived scope **degrades rather than
+refusing the spawn**. The delegate runs with no kernel wrapper; its file tools
+keep the identical write boundary (every `write_file`/`edit_file` outside its own
+scratch dir is denied) and its shell is unconfined. That is strictly stronger than
+the advisory scope this floor replaced, and it keeps the capability instead of
+deleting it: coupling the scope to an OS sandbox made every `explorer` delegate
+fail outright on such a host, and the model usually abandoned delegation rather
+than retrying. The gap is disclosed in both directions — the delegate's own
+environment section says which half is enforced and which half is on its honour,
+and the spawn result the parent reads carries the same warning.
+
+An explicit delegate `sandbox` argument does **not** bypass the structured
+read-only floor, and does **not** get the degrade either — a caller that states
+the contract is refused rather than silently given a weaker box. `read-only` is
+accepted when it is also compatible with the parent's boundary, while `off`,
 `workspace-write`, and ordinary `restricted` are rejected because they permit
 persistent workspace writes. A net-only request is applied to the mandatory
 write-blocked policy and may only preserve or tighten the parent's network


### PR DESCRIPTION
Closes #483.

## Mechanism

A read-only delegate *scope* no longer requires an OS sandbox. Where no backend can enforce `ModeReadOnly`, the scope derived from an agent type resolves to `Mode: off, WriteBlocked: true`: the delegate spawns, its **file tools** carry the whole write boundary (`FileTool.WriteRoots` empty, session scratch the only writable place, the same credential/pseudo-fs denylist every confining mode masks), and its **shell** is unconfined. Both sides are told which half holds.

## The four parts

1. **The derived scope degrades.** `readOnlyDelegateSandbox` returns `{Mode: off, WriteBlocked: true}` when the host has no usable backend, instead of a `read-only` request that `Resolve` refuses. A write-blocked off policy takes the ordinary resolver path — denylist, git surface, scope builder — and skips only `chooseBackend`, which is the thing it has none of.

2. **An explicit `sandbox: read-only` still fails closed.** Only the derived scope degrades. An explicit request passes through unmodified and the spawn surfaces the resolver's `*sandbox.RefusalError`. A caller that states the contract is never silently handed a weaker box.

3. **File-tool confinement got its own predicate.** `ResolvedPolicy.FileToolConfined()` — `Mode != ModeOff || WriteBlocked` — sits beside `Enforced()`, which keeps its meaning ("an OS sandbox is in force") untouched.

4. **Disclosure in both directions.** The delegate's environment section says the boundary is ENFORCED for its file tools and ADVISORY for its shell, names its scratch dir, and warns that its file tools will not traverse a symlinked directory. The parent's spawn result carries a matching warning on the same non-blocking channel the shared-workspace advisory uses.

## `Enforced()` call-site audit

Changed to `FileToolConfined()`:

| Site | Why |
|---|---|
| `execenv/local.go` `sandbox()` | The single gate on building the fd-anchored file-tool layer — the file-tool question by definition. Leaving it made `WriteBlocked` inert. |
| `sandbox/reroot.go` `WithSessionScratch` | The late-bound scratch grant belongs to the file-tool layer. Without it a degraded delegate has *nowhere* writable, breaking `WriteBlocked`'s documented contract. |
| `agent/session_prompts.go` `sandboxPromptLine` | The line tells the model the boundary it runs under. A confined-but-unenforced delegate has one, and it needs different words (naming the mode would say "off"). |
| `sandbox_delegate.go` `parentSandboxFloorForEnv` | `WriteBlocked` is a floor a child must never drop, and a degraded parent's block is real. Read through the OS predicate it reported *no* block, so a child could ask for writes its parent does not have. Not reachable today — the child inherits an already-stripped registry and the schema hides the argument on a backendless host — but a floor that depends on coincidence is not a floor. |
| `sandbox_delegate.go` restore's inherit-write-blocked branch | Paired with the above: whatever reports the block is what a restoring child inherits, or every child of a degraded parent fails to restore. |

Kept on `Enforced()`, each asking the OS-sandbox question:

- `execenv/local.go` `EnableSandbox` — an off policy still builds no wrapper and no bwrap argv. It now provisions an **owned** session scratch when `FileToolConfined()`.
- `execenv/local.go` `WithSandboxInvocationGrant` — **deliberately not changed.** `escalationAllowed` refuses a subagent session, and only delegates get a write-blocked off policy, so no such env can reach it. Widening the gate would add a branch nothing can execute and a test pinning an unreachable state. The reasoning is recorded at the call site with the condition that should reopen it.
- `session_capabilities.go` (×2) — **decided, not omitted.** Every line it gates describes OS-enforced state: `writableRootsSummary` is built from the **spawned** layer, the cache strategy is a wrapper env-floor behavior, and the `go` telemetry note reports a kernel denial. For a wrapper-less box each would be *false* rather than merely absent — "Writable roots: none" would describe a shell that can in fact write anywhere. The comment now records that.
- `sandbox_delegate.go` `sandboxSnapshotFromEnv`, `delegate_runtime.go` inherit-parent-snapshot — must stay paired with `stableDelegateSandboxSnapshot`/`sandboxSnapshotFromInputs`, which drop `ModeOff`. Changing the gate alone is a **no-op** (the snapshot is nil either way); changing the whole family would break `frozenStableDelegateSandboxMatches` at construction *and* collide with the corrupt-descriptor guard below. The degraded box is re-derived per host on resume rather than persisted — there is no OS mode to record.
- `sandbox/startup.go` `EnforcementLine`, `cmd/evener/sandbox.go` `reconcileClearSandbox`, `sandbox/reroot.go` `ControlPolicy`, `sandbox/contract.go` (×2) — the startup banner, the persisted session mode, whether there are writes to widen, and the backend contract matrix.

## Where the file tools cannot enforce

`securepath_other.go` (`!linux && !darwin`) fails closed on *every* operation, reads included, so a write-blocked box there is a delegate with broken file tools rather than a confined one. `Resolve` **refuses** it (`FileToolEnforceable`), so no caller can produce that env; the derivation checks the same predicate to avoid asking. `securepath_other.go`'s header now names both invariants and their guardians.

## Tests

Each was watched failing first, for the reason named.

- `TestCreateExplorerDelegateDegradesInsteadOfRefusing` — the field repro end to end: `delegate(agent_type="explorer")`, no sandbox argument, backendless host. Before the fix it reproduced the reported error verbatim; now it returns a `delegate_id` and the parent's disclosure.
- `TestDegradedReadOnlyDelegateFileToolsRefuseWrites` — a real delegate's `write_file`/`edit_file` into the shared workspace return a typed `*sandbox.DeniedError` with the disk untouched, while reads and its scratch work.
- `TestWriteBlockedOffMasksCredentialPaths` — a degraded env denies `~/.ssh/id_rsa` and evener's own `/proc/<pid>/environ`, while an ordinary out-of-worktree read still works.
- `TestReadsThroughSymlinkedWorkspaceRoot` — read/list/glob through a **genuinely symlinked** workspace root, for the degraded box *and* enforced read-only; asserts the anchor grants no write and still refuses a symlink component inside the worktree. The root is deliberately not canonicalized — doing that in the fixtures is what hid this.
- `TestDegradedDelegateSpawnFailureDisposesItsScratch` — driven through the real abort path (a nil child client fails `NewSession` after `prepareSubagentEnvironment`); no scratch dir, and no held lease, survives.
- `TestDegradedParentPropagatesItsWriteBlock` — a degraded parent reports its block, refuses a write-capable child, and a restoring child inherits the box.
- `TestDegradedAdvisoryPromisesOnlyWhatThisHostDelivers` — pins the fact behind the reworded advisory: an isolated delegate on this host gets no kernel wrapper either.
- `TestResolveWriteBlockedOffConfinesFileTools` / `...NeedsAnAbsoluteHome` / `...RefusesWhereFileToolsCannotEnforce`, `TestFileToolConfinedSeparatesFromEnforced`, `TestWriteBlockedOffGrantsSessionScratch` — the resolved grants (denylist, read anchor, git layout, no write roots), the homeless-service refusal, the non-enforceable-platform refusal, and the predicates.
- `TestExplicitReadOnlyDelegateSandboxStillFailsClosed`, `TestReadOnlyDelegateSandbox_DegradesWhenHostCannotEnforce` / `_NoDegradeWhereFileToolsCannotEnforce`, `TestRestoreDelegateSandboxFloorDegradesForReadOnlyCeiling`, `TestSandboxPromptLineDisclosesDegradedReadOnlyDelegate`, `TestCreateExplorerDelegateEnforcedHostSaysNothing`.

`agent/sandbox/contract.go`'s table was deliberately **not** extended: it is the (mode × host × net) matrix each *backend* is held to, and the degraded box has no backend.

One existing table row moved with the semantics: a *persisted* descriptor recording `off` + `WriteBlocked` is refused explicitly rather than treated as an ignorable flag. No spawn writes one, so it can only be corrupt or hand-edited.

## Residual gaps

1. **The shell is unconfined** on a backendless host — `shell(command: "rm -rf ...")` is not blocked, only discouraged in the prompt and reported to the parent. No sandbox mode closes it there, and the advisory no longer pretends otherwise: `isolation="worktree"` is offered as a separate checkout so an *accidental* write lands off your tree, not as a boundary.

2. **A symlinked directory inside the workspace is not traversable.** The workspace *root* being reached through a symlink is fixed (reads anchor at the worktree, which tolerates a symlinked ancestor — enforced read-only benefits identically and had the same gap since it shipped). What remains is a symlink *component* below the root, and a symlinked component in an out-of-worktree path: `pnpm`/`node_modules` links, Nix store links, Debian usrmerge `/lib`. That is the same refusal every enforced mode makes, but it is a **new cost** for a delegate that previously had no sandbox at all, so this PR does not claim to be strictly stronger than the pre-#417 scope — it is stronger on writes and credential reads and weaker on symlink traversal. The delegate's prompt says so as an actionable hint ("name the real path"); enforced modes share the limitation and their prompts are unchanged, to avoid unrelated prompt churn.

3. **Degraded delegates lose ripgrep.** Any env with a file-tool layer takes the native Go walk. Parity with enforced read-only, but a new cost on exactly the explorer workload this PR restores.

4. **Resume across a host capability change is asymmetric, intentionally.** A read-only delegate created on a backend-capable host persists `{mode: read-only}` and fails closed on resume if the host later loses its backend, while an identical fresh delegate degrades. The persisted request is a stated contract and keeps failing closed; the derived scope is a host-dependent decision and is re-made against the host that is actually running it.

## Gates

- `agent`, `agent/sandbox`, `agent/execenv`, root, `llm`, `auth`, `envvars`, `invariant`, `identifier` — pass (`-short -count=1`, per module under `go.work`). `-race` over the sandbox/scratch/symlink tests in `agent` and `agent/execenv` — clean.
- `make lint` — PASS (8 modules). `make lint-evenerfuzz`, `make lint-eval` — PASS standalone, including the `GOOS=linux` vet repeats under both tags.
- Pre-existing macOS failures, unchanged and verified identical on a pristine `a0bfbd3fb` worktree: `TestMakeWebCommandsContainNodeProcessState`, `TestMakeTestWebRetainsFailedProcessStateWithinTMPDIR`, `TestMakeTestWebInterruptRetainsEvidenceAndReapsChecks` — the `/var` → `/private/var` TempDir symlink class.
- `agent/execenv`'s `TestGrepRipgrepStopsWhenContextIsCanceled` flakes under full-package load (a 10s timeout waiting for a spawned shell script). It passes 3/3 in isolation, and its env carries no sandbox policy at all, so no path in this diff executes in it.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT
