### PR TITLE
test(serve): await foreground shell settle events

### DIFF
--- a/cmd/evener/serve_tool_result_test.go
+++ b/cmd/evener/serve_tool_result_test.go
@@ -51,9 +51,11 @@ type serveShellNotificationSignals struct {
 	started       chan struct{}
 	completed     chan struct{}
 	turnComplete  chan struct{}
+	awaiting      chan struct{}
 	startedOnce   sync.Once
 	completedOnce sync.Once
 	turnOnce      sync.Once
+	awaitingOnce  sync.Once
 }
 
 func watchServeShellNotifications(client *appwire.Client, callID string) *serveShellNotificationSignals {
@@ -61,6 +63,7 @@ func watchServeShellNotifications(client *appwire.Client, callID string) *serveS
 		started:      make(chan struct{}),
 		completed:    make(chan struct{}),
 		turnComplete: make(chan struct{}),
+		awaiting:     make(chan struct{}),
 	}
 	go func() {
 		for notification := range client.Notifications() {
@@ -77,6 +80,11 @@ func watchServeShellNotifications(client *appwire.Client, callID string) *serveS
 				}
 			case appwire.NotifyTurnCompleted:
 				signals.turnOnce.Do(func() { close(signals.turnComplete) })
+			case appwire.NotifyThreadStatusChanged:
+				var params appwire.ThreadStatusChangedParams
+				if json.Unmarshal(notification.Params, &params) == nil && params.Status.Type == appwire.ThreadStatusAwaiting {
+					signals.awaitingOnce.Do(func() { close(signals.awaiting) })
+				}
 			}
 		}
 	}()
@@ -107,25 +115,6 @@ func transcriptToolResult(data []byte, callID string) (*llm.ToolResultData, bool
 		}
 	}
 	return nil, false
-}
-
-func waitForServeState(addr, want string, timeout time.Duration) bool {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		resp, err := http.Get("http://" + addr + "/status")
-		if err == nil {
-			var status struct {
-				State string `json:"state"`
-			}
-			decodeErr := json.NewDecoder(resp.Body).Decode(&status)
-			resp.Body.Close()
-			if decodeErr == nil && status.State == want {
-				return true
-			}
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return false
 }
 
 func dialServeToolResultClient(ctx context.Context, t *testing.T, addr, name, ref string) (*appwire.Client, *serveShellNotificationSignals) {
@@ -166,6 +155,9 @@ func runServeForegroundShellPersistenceCase(t *testing.T, mode foregroundShellSe
 	gatePath := filepath.Join(workDir, "shell-release")
 	shellCommand := fmt.Sprintf("while [ ! -f %s ]; do sleep 0.01; done; printf shell-complete", strconv.Quote(gatePath))
 	secondRequest := make(chan struct{})
+	secondResponseRelease := make(chan struct{})
+	releaseSecondResponse := sync.OnceFunc(func() { close(secondResponseRelease) })
+	defer releaseSecondResponse()
 	var secondOnce sync.Once
 	var secondRequestResult *llm.ToolResultData
 	installServeScriptedProvider(t, &scriptedProvider{
@@ -177,6 +169,7 @@ func runServeForegroundShellPersistenceCase(t *testing.T, mode foregroundShellSe
 			func(req llm.Request) llm.Response {
 				secondRequestResult, _ = requestToolResult(req, "shell_1")
 				secondOnce.Do(func() { close(secondRequest) })
+				<-secondResponseRelease
 				return scriptedCommunicate("shell persisted")
 			},
 		},
@@ -241,6 +234,15 @@ func runServeForegroundShellPersistenceCase(t *testing.T, mode foregroundShellSe
 	case <-ctx.Done():
 		t.Fatalf("second provider request after foreground shell: %v", ctx.Err())
 	}
+	if mode == foregroundShellNoSubscriber {
+		// Reaching the second provider request proves the shell result crossed the
+		// full tool boundary with zero subscribers. Attach only after that proof,
+		// while the response is still gated, so the terminal status event is an
+		// exact settle barrier instead of a wall-clock guess.
+		client, signals = dialServeToolResultClient(ctx, t, entry.Address, "settle-observer", ref)
+		defer client.Close()
+	}
+	releaseSecondResponse()
 	if secondRequestResult == nil {
 		t.Fatal("second provider request did not contain the foreground shell tool result")
 	}
@@ -272,13 +274,16 @@ func runServeForegroundShellPersistenceCase(t *testing.T, mode foregroundShellSe
 		case <-ctx.Done():
 			t.Fatalf("foreground shell never emitted item/completed: %v", ctx.Err())
 		}
-		select {
-		case <-signals.turnComplete:
-		case <-ctx.Done():
-			t.Fatalf("foreground shell turn never completed: %v", ctx.Err())
-		}
-	} else if !waitForServeState(entry.Address, "awaiting", time.Second) {
-		t.Fatal("no-subscriber foreground shell turn never settled to awaiting")
+	}
+	select {
+	case <-signals.turnComplete:
+	case <-ctx.Done():
+		t.Fatalf("foreground shell turn never completed: %v", ctx.Err())
+	}
+	select {
+	case <-signals.awaiting:
+	case <-ctx.Done():
+		t.Fatalf("foreground shell turn never settled to awaiting: %v", ctx.Err())
 	}
 
 	shutdownResp, err := http.Post("http://"+entry.Address+"/shutdown", "", nil)


### PR DESCRIPTION
## Summary

- replace the no-subscriber foreground-shell test's one-second `/status` poll with terminal AppWire event barriers
- gate the second scripted provider response so the settle observer is registered before the turn can complete
- preserve the zero-subscriber contract through foreground shell execution and tool-result delivery

## Root cause

The post-merge `race-root` job for #476 failed `TestRunServeForegroundShellPersistsToolResults/no-subscriber` with `no-subscriber foreground shell turn never settled to awaiting`. This was not a Go data-race report and is independent of #476's vision changes: the test and its polling assertion predate #476, and #476 changed only `agent/` vision ownership paths.

The test treated entry into the second provider request as if the enclosing turn were complete. It is not: the scripted response, final `communicate` call, drain settle, and terminal status event all happen afterward. Under whole-suite race-detector load, that unsynchronized gap exceeded the test's one-second polling deadline.

The test now blocks the second provider response on a channel. Once the second request proves the shell result crossed the provider boundary with zero subscribers, it attaches a settle observer, releases the response, and awaits both `turn/completed` and `thread/status/changed(awaiting)`. The synchronization mechanism is the real terminal event, not elapsed time.

## Red-green evidence

- RED: with the second response channel-blocked, the old `/status` assertion failed deterministically because it was waiting from a pre-completion marker
- GREEN: `go test -race ./cmd/evener -run '^TestRunServeForegroundShellPersistsToolResults$' -count=10`
- package race: `go test -race ./cmd/evener -count=1`
- package: `go test ./cmd/evener`
- #476 vision ownership/cancellation regression selection: passed in `./agent`
- `make vet`
- `make lint`

A loaded `make test` run also passed the touched `cmd/evener` package and web gate, but unrelated process-startup tests failed while at least three full gate jobs were running concurrently on the host. Clean focused reruns passed: the root FIFO handoff case 3/3 and both MCP integration cases 3/3.

## References

- #476
- failing run: https://github.com/prime-radiant-inc/evener/actions/runs/33017764983
- failing job: https://github.com/prime-radiant-inc/evener/actions/runs/33017764983/job/98340311143
