### PR TITLE
refactor: simplify degraded delegate boundary helpers

### DIFF
--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -1255,6 +1255,7 @@ func (runtime delegateRuntime) create(ctx context.Context, args delegateArgs) de
 	}
 	bindStableDelegateActivity(prepared.sub.sess, s.delegateController, started.lease)
 	s.startDelegateQuietWatchdog(started.ctx, started.lease)
+	degradedSandboxAdvisory := degradedReadOnlyDelegateAdvisory(prepared.sub.sess.currentEnv())
 	s.launchSubagentRun(prepared.runCtx, prepared.sub, prepared.runCancel, prepared.input, started.descriptor.Provenance)
 	result := createResult(stableDelegateResult(started.descriptor, started.lease.delegateID, started.plan, plans, nil))
 	// The advisories ride the launched delegate's own result only: they are
@@ -1263,7 +1264,7 @@ func (runtime delegateRuntime) create(ctx context.Context, args delegateArgs) de
 	// The sandbox one fires when a derived read-only scope had to degrade on this
 	// host, so the parent learns the boundary is advisory for the child's shell
 	// rather than discovering it from a clobbered file.
-	result.Warnings = appendUniqueStrings(result.Warnings, sharedWorkspaceAdvisory, degradedReadOnlyDelegateAdvisory(prepared.sub.sess.currentEnv()))
+	result.Warnings = appendUniqueStrings(result.Warnings, sharedWorkspaceAdvisory, degradedSandboxAdvisory)
 	return result
 }
 

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -236,10 +236,7 @@ func (e *LocalExecutionEnvironment) wrapperlessScratchDir() string {
 // Wrapper.SessionTmp() into the fd-anchored roots; this accessor is for the
 // otherwise-unconfined environment's late-bound scratch grant.
 func (e *LocalExecutionEnvironment) allocatedSessionScratchPath() string {
-	if e.Wrapper != nil {
-		return e.Wrapper.SessionTmp()
-	}
-	return e.wrapperlessScratchDir()
+	return e.sessionScratchPath()
 }
 
 // scratchSandboxFor returns the cached fd-anchored layer for an already allocated
@@ -287,10 +284,7 @@ func (e *LocalExecutionEnvironment) scratchSandboxFor(abs string) *sandboxFS {
 // preamble), and reporting a path must not create it, nor turn a prompt render
 // into a filesystem side effect.
 func (e *LocalExecutionEnvironment) SessionScratchDir() string {
-	if e.Wrapper != nil {
-		return e.Wrapper.SessionTmp()
-	}
-	return e.wrapperlessScratchDir()
+	return e.sessionScratchPath()
 }
 
 // WithSandboxInvocationGrant returns a short-lived clone of this env whose file-tool

--- a/agent/execenv/sandbox_lifecycle_test.go
+++ b/agent/execenv/sandbox_lifecycle_test.go
@@ -286,16 +286,7 @@ func TestEnableSandboxWriteBlockedOffConfinesFileTools(t *testing.T) {
 	if err := os.MkdirAll(worktree, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	noBackend := sandbox.HostFacts{OS: "linux", Home: home}
-	rp, err := sandbox.Resolve(sandbox.SandboxPolicy{Mode: sandbox.ModeOff, WriteBlocked: true}, noBackend, worktree)
-	if err != nil {
-		t.Fatalf("resolving a write-blocked off policy must not refuse: %v", err)
-	}
-	env := NewLocalExecutionEnvironment(worktree)
-	t.Cleanup(func() { env.Cleanup(); env.DisposeSandboxScratch() })
-	if err := env.EnableSandbox(&rp); err != nil {
-		t.Fatalf("EnableSandbox(write-blocked off): %v", err)
-	}
+	env := writeBlockedOffEnv(t, home, worktree)
 	if env.Wrapper != nil {
 		t.Fatalf("a host with no backend must build no kernel wrapper, got %+v", env.Wrapper)
 	}

--- a/agent/sandbox_delegate.go
+++ b/agent/sandbox_delegate.go
@@ -285,11 +285,8 @@ func degradedReadOnlyBoundaryFor(mode sandbox.Mode, writeBlocked bool) (degraded
 }
 
 func degradedReadOnlyBoundaryFromEnv(env execenv.ExecutionEnvironment) (degradedReadOnlyBoundary, bool) {
-	local, ok := env.(*execenv.LocalExecutionEnvironment)
-	if !ok || local == nil || local.Sandbox == nil {
-		return degradedReadOnlyBoundary{}, false
-	}
-	return degradedReadOnlyBoundaryFor(local.Sandbox.Mode, local.Sandbox.WriteBlocked)
+	mode, _, writeBlocked := parentSandboxFloorForEnv(env)
+	return degradedReadOnlyBoundaryFor(mode, writeBlocked)
 }
 
 func (b degradedReadOnlyBoundary) shellDisclosure(subject string) string {


### PR DESCRIPTION
## Summary

- Reuse the existing non-provisioning session scratch accessor for reporting and late-bound scratch grants.
- Reuse the parent sandbox-floor helper when identifying a degraded read-only boundary.
- Build the degraded lifecycle test with its existing real EnableSandbox fixture while retaining every enforcement assertion.
- Compute the child sandbox advisory before launching the delegate goroutine, avoiding post-launch Session.mu contention without changing warning text or ordering.

This is a behavior-preserving cleanup follow-up to #492.

## Review and scope

An independent exact-head review found no issues. Removing the internal ShellSandboxed field was attempted, but it broke the existing structured-boundary test; that cleanup was reverted instead of weakening or rewriting the test.

Intentionally excluded: process-wide capability caching, generic reroot or provisioning APIs, wider invocation grants, moving capability enforcement into EnableSandbox, and broader policy or disclosure redesign.

## Verification

- focused agent and execenv tests
- focused agent and execenv race tests
- make merge-approval-gate