### PR TITLE
agent: trim model snapshot capture work

### DIFF
--- a/agent/internal/modelavailability/modelavailability.go
+++ b/agent/internal/modelavailability/modelavailability.go
@@ -69,7 +69,6 @@ func Capture(parent context.Context, providers []string, requiredProvider string
 	ctx, cancel := context.WithTimeout(parent, budget)
 	defer cancel()
 	providers, providerLimited := boundedProviders(providers, requiredProvider)
-	sort.Strings(providers)
 	type result struct {
 		name    string
 		ids     []string

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -483,7 +483,7 @@ func (s *Session) captureModelAvailability(selectedModels liveModelEnumeration) 
 	catalog := llm.EmbeddedModelCatalog()
 	snapshot := modelavailability.Capture(s.sessionCtx, names, s.profile.ID(), func(ctx context.Context, name string) ([]llm.ModelInfo, error) {
 		if name == s.profile.ID() {
-			return append([]llm.ModelInfo(nil), selectedModels.models...), selectedModels.err
+			return selectedModels.models, selectedModels.err
 		}
 		return s.client.ListModels(ctx, name)
 	}, func(name string, model llm.ModelInfo) bool {


### PR DESCRIPTION
## Summary

- stop sorting the already-sorted bounded provider set a second time
- pass the selected provider's model slice directly into read-only snapshot capture
- preserve the bounded top-k provider algorithm and explicit `model_list` breaker exception

## Why

PR #475 intentionally bounds startup model-availability work. Two operations remained redundant: `boundedProviders` already returns deterministic sorted output, and `boundedModelIDs` ranges over `ModelInfo` values without mutating its input slice. Removing the extra sort and full-slice copy reduces startup work without changing the snapshot, cursor, provider-selection, or security contracts.

The broader alternatives from the simplify review were deliberately rejected: collecting every provider before sorting would make scratch work unbounded, and a generic per-tool breaker-policy field would add machinery for one explicit protocol exception.

## Verification

- `git diff --check origin/main...HEAD`
- `go test -race ./agent/internal/modelavailability -count=1`
- focused `agent` model snapshot/list tests under `-race`
- `make test` in isolation
- independent exact-head review: clean

Source PR: #475
