### PR TITLE
test(hub): trigger fingerprint deadline deterministically

### DIFF
--- a/cmd/evener-hub/navigation_service_test.go
+++ b/cmd/evener-hub/navigation_service_test.go
@@ -1076,7 +1076,6 @@ func TestNavigationServiceDeadlineInterruptsMidFingerprintWithoutPublication(t *
 	if _, err := service.Representation(t.Context(), navigationResourceKey{Kind: navigationResourceManifest}); err != nil {
 		t.Fatal(err)
 	}
-	service.buildTimeout = 30 * time.Millisecond
 	projectKey := (navigationResourceKey{Kind: navigationResourceProject, ProjectKey: "p1"}).Semantic()
 	beforeRevision := service.CurrentRevision(projectKey)
 	beforeStats := service.Stats()
@@ -1091,18 +1090,29 @@ func TestNavigationServiceDeadlineInterruptsMidFingerprintWithoutPublication(t *
 	previous := navigationFingerprintStringChunkContext
 	entered := make(chan struct{})
 	var matchingChunks atomic.Int32
-	var once sync.Once
 	navigationFingerprintStringChunkContext = func(ctx context.Context, chunk string) error {
-		if len(chunk) == maxNavigationTitleRunes && chunk[0] == 'x' && matchingChunks.Add(1) == rowCount/2 {
-			once.Do(func() { close(entered) })
+		if len(chunk) == maxNavigationTitleRunes && chunk[0] == 'x' && matchingChunks.Add(1) == 1 {
+			close(entered)
 			<-ctx.Done()
 		}
 		return ctx.Err()
 	}
 	t.Cleanup(func() { navigationFingerprintStringChunkContext = previous })
 
-	_, err := service.Refresh(t.Context(), navigationChangeHint{Projects: []string{"p1"}})
+	buildCtx := newTriggeredDeadlineContext(t.Context())
+	flight := &navigationBuildFlight{
+		done:    make(chan struct{}),
+		hint:    navigationChangeHint{Projects: []string{"p1"}},
+		mutated: true,
+	}
+	service.mu.Lock()
+	service.flight = flight
+	service.mu.Unlock()
+	go service.buildSnapshot(buildCtx, source.Revision(), flight)
 	<-entered
+	buildCtx.expire()
+	<-flight.done
+	err := flight.err
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("error = %v, want hashing deadline", err)
 	}
@@ -1110,7 +1120,7 @@ func TestNavigationServiceDeadlineInterruptsMidFingerprintWithoutPublication(t *
 	if !errors.As(err, &status) || status.StatusCode() != 503 {
 		t.Fatalf("error = %T %v, want typed 503", err, err)
 	}
-	if got := matchingChunks.Load(); got != rowCount/2 {
+	if got := matchingChunks.Load(); got != 1 {
 		t.Fatalf("fingerprinting continued after cancellation: %d chunks", got)
 	}
 	if got := service.CurrentRevision(projectKey); got != beforeRevision {
@@ -1125,6 +1135,32 @@ func TestNavigationServiceDeadlineInterruptsMidFingerprintWithoutPublication(t *
 	if publications := service.DrainPublications(); len(publications) != 0 {
 		t.Fatalf("canceled fingerprint published: %+v", publications)
 	}
+}
+
+type triggeredDeadlineContext struct {
+	context.Context
+	done chan struct{}
+}
+
+func newTriggeredDeadlineContext(parent context.Context) *triggeredDeadlineContext {
+	return &triggeredDeadlineContext{Context: parent, done: make(chan struct{})}
+}
+
+func (ctx *triggeredDeadlineContext) Done() <-chan struct{} {
+	return ctx.done
+}
+
+func (ctx *triggeredDeadlineContext) Err() error {
+	select {
+	case <-ctx.done:
+		return context.DeadlineExceeded
+	default:
+		return nil
+	}
+}
+
+func (ctx *triggeredDeadlineContext) expire() {
+	close(ctx.done)
 }
 
 type cancelAfterChecksContext struct {


### PR DESCRIPTION
## Summary

- replace the navigation fingerprint test's 30 ms / 250-chunk timing race with a manually triggered deadline
- drive the real `buildSnapshot` worker only after the fingerprint hook has definitely entered
- retain the typed 503 and no-revision/cache/capability/publication assertions

## Root cause

While validating #505, the `race-root` lane timed out in `TestNavigationServiceDeadlineInterruptsMidFingerprintWithoutPublication`. The test configured a 30 ms build deadline, but its hook closed `entered` only after 250 matching title chunks. Under whole-suite race-detector load, the deadline expired before that threshold. `Refresh` returned, then the test blocked forever on `<-entered` until the package-wide ten-minute timeout.

This is unrelated to #505's two-line model-availability cleanup. The affected test was introduced by #490.

The test now starts the real build worker with a test context that remains live until the first matching fingerprint chunk is reached. It then triggers `context.DeadlineExceeded`, waits for the worker's flight to finish, and applies the existing publication-state assertions. No production behavior changes.

## Evidence

- Original CI failure: https://github.com/prime-radiant-inc/evener/actions/runs/33041226180/job/98415050780
- Pre-fix focused test: 50 normal + 50 race passes, confirming the failure depends on whole-suite load
- Post-fix focused test: 100 normal + 100 race passes
- `go test -race ./cmd/evener-hub -count=1`
- `make lint`
- `make test`
- independent exact-head review: clean

## References

- #490
- #505
