### PR TITLE
Simplify split lint lane setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,16 +49,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: ./.github/actions/setup-toolchain
-
-      - name: Read tool versions
-        id: tool-versions
-        run: |
-          echo "golangci=$(awk '$1=="golangci-lint" {print $2}' .tool-versions)" >> "$GITHUB_OUTPUT"
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.work
 
       - name: Install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" "v${{ steps.tool-versions.outputs.golangci }}"
+        run: |
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          make tools-golangci
 
       - name: Lint (golangci-lint across all go.work modules)
         run: make lint-golangci
@@ -68,16 +66,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: ./.github/actions/setup-toolchain
-
-      - name: Read golangci-lint version
-        id: golangci-version
-        run: |
-          echo "version=$(awk '$1=="golangci-lint" {print $2}' .tool-versions)" >> "$GITHUB_OUTPUT"
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.work
 
       - name: Install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" "v${{ steps.golangci-version.outputs.version }}"
+        run: |
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          make tools-golangci
 
       - name: Lint tagged compile floors (evenerfuzz and eval)
         run: make lint-evenerfuzz lint-eval
@@ -87,16 +83,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: ./.github/actions/setup-toolchain
-
-      - name: Read gitleaks version
-        id: gitleaks-version
-        run: |
-          echo "version=$(awk '$1=="gitleaks" {print $2}' .tool-versions)" >> "$GITHUB_OUTPUT"
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.work
 
       - name: Install gitleaks
-        run: go install github.com/zricethezav/gitleaks/v8@v${{ steps.gitleaks-version.outputs.version }}
+        run: |
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          make tools-gitleaks
 
       - name: Lint repository structure, generated output, formatting, and secrets
         env:

--- a/docs/developing-evener/README.md
+++ b/docs/developing-evener/README.md
@@ -47,6 +47,8 @@ gates themselves — building, testing, linting, coverage, and fuzzing.
 | Command | Summary |
 | --- | --- |
 | `make tools` | Install the CI-pinned golangci-lint and gitleaks versions from .tool-versions, so a local make lint runs exactly what CI runs. |
+| `make tools-golangci` | Install the CI-pinned golangci-lint version from .tool-versions. |
+| `make tools-gitleaks` | Install the CI-pinned gitleaks version from .tool-versions. |
 | `make refresh-model-catalog` | Replace the vendored LiteLLM model-catalog snapshot with the current upstream and run the catalog sanity tests. |
 | `make generate` | Run the appwire and maketargetsdoc `go generate` directives: the AppWire protocol reference and frontend TypeScript declarations from appwire/protocol.go, and the per-family make-target tables in docs/developing-evener/. |
 | `make clean` | Remove the built binaries from the repo root. |

--- a/make/repo.mk
+++ b/make/repo.mk
@@ -1,14 +1,23 @@
-.PHONY: tools generate clean refresh-model-catalog help
+.PHONY: tools tools-golangci tools-gitleaks generate clean refresh-model-catalog help
 
 # tools installs the CI-pinned lint/scanner versions from .tool-versions, so
 # a local `make lint` runs exactly what CI runs.
 ## Install the CI-pinned golangci-lint and gitleaks versions from
 ## .tool-versions, so a local make lint runs exactly what CI runs.
 tools:
+	@$(MAKE) --no-print-directory tools-golangci
+	@$(MAKE) --no-print-directory tools-gitleaks
+
+## Install the CI-pinned golangci-lint version from .tool-versions.
+tools-golangci:
 	@set -eu; \
 	golangci=$$(awk '$$1=="golangci-lint" {print $$2}' .tool-versions); \
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$$(go env GOPATH)/bin" "v$$golangci"
+
+## Install the CI-pinned gitleaks version from .tool-versions.
+tools-gitleaks:
+	@set -eu; \
 	gitleaks=$$(awk '$$1=="gitleaks" {print $$2}' .tool-versions); \
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$$(go env GOPATH)/bin" "v$$golangci"; \
 	go install github.com/zricethezav/gitleaks/v8@v$$gitleaks
 
 # refresh-model-catalog replaces the vendored LiteLLM model-catalog snapshot


### PR DESCRIPTION
Follow-up to #494.

The three Go-only split lint lanes were using the repository's composite toolchain action, which installs both Go and Node and repeats the pinned Go-tool installation logic. This keeps those lanes focused on what they actually run:

- use `actions/setup-go` directly for the three Go-only lint lanes
- add narrow `tools-golangci` and `tools-gitleaks` Make targets
- preserve `make tools` as the aggregate installer
- keep the tagged compile-floor recipes explicit because the Makefile audit intentionally verifies their concrete build tags
- leave the broader dev-tooling lane unchanged because it is outside #494's split-lane scope

Verification at exact head `bb4fc37df1fd888594f931c0cf46ff3f1be6e913`:

- workflow YAML parse and actionlint
- dry-runs of the narrow and aggregate tool targets
- `TestMakeLintRunsEveryGateInLintTargets`
- `make lint-generated`
- `make lint`
- `make test`
- independent exact-head review: no findings
