### PR TITLE
Simplify vision failure cleanup state

### DIFF
--- a/agent/session_tool_round.go
+++ b/agent/session_tool_round.go
@@ -459,7 +459,6 @@ func (s *Session) injectPostToolSteering(ctx context.Context, calls []llm.ToolCa
 			s.appendSteeringTurn(reminder, kind)
 		}
 	}); abortErr != nil {
-		s.removeAllTurnOwnedSteering()
 		return false, abortErr
 	}
 	return yieldToObserverCallback, nil

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -304,7 +304,6 @@ type visionSideChannelResult struct {
 	elapsed     time.Duration
 	usage       llm.Usage
 	outcome     visionSideChannelOutcome
-	err         error
 }
 
 // describeImage makes a side-channel API call with no tools to describe an image
@@ -483,7 +482,7 @@ func (s *Session) describeImageCall(ctx context.Context, r tool.ExecResult) visi
 			// warning sanitized too rather than reintroducing the raw adapter error.
 			s.emit(events.EventWarning, events.WarningData{Message: "vision side-channel unavailable"})
 		}
-		return visionSideChannelResult{elapsed: elapsed, outcome: outcome, err: err}
+		return visionSideChannelResult{elapsed: elapsed, outcome: outcome}
 	}
 
 	return visionSideChannelResult{


### PR DESCRIPTION
Follow-up to #476.

This removes two pieces of state/control flow that no longer participate in behavior:

- stop retaining the raw provider error after the vision side-channel has classified it into the typed, sanitized outcome contract
- remove the cleanup call after `finishTurnOwnedSteering` has already finalized ownership; at that point the owner set is unconditionally empty, so the call can only return without changing or persisting the queue

All cleanup paths before ownership finalization remain intact. Cancellation rollback, exactly-once injection, sanitization, queue persistence, and image/PDF behavior are unchanged.

Verification at exact head `29286e9a81e8dc4828abde3afa9aac148c969762` on current main `2862b586de3be458f7943b1832409ea555e7ade6`:

- focused vision cancellation/ownership tests, 20 repetitions
- focused race-detector tests, 10 repetitions
- `make vet`
- `make lint`
- `make test`
- independent exact-head review: no findings
