### PR TITLE
refactor: deduplicate communicate preview bookkeeping

### DIFF
--- a/agent/session_model_call.go
+++ b/agent/session_model_call.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"sort"
 	"strings"
 	"time"
 
@@ -839,12 +838,7 @@ func (s *Session) callModelWithFallback(ctx context.Context, profile *provider.P
 		}
 	}
 	withPreviews := func(resp sessionModelResponse) sessionModelResponse {
-		ids := make([]string, 0, len(previewCalls))
-		for callID := range previewCalls {
-			ids = append(ids, callID)
-		}
-		sort.Strings(ids)
-		resp.CommunicatePreviewCallIDs = ids
+		resp.CommunicatePreviewCallIDs = sortedPreviewCallIDs(previewCalls)
 		return resp
 	}
 	policy := llm.DefaultRetryPolicy()

--- a/agent/session_stream.go
+++ b/agent/session_stream.go
@@ -34,6 +34,15 @@ type sessionModelResponse struct {
 	CommunicatePreviewCallIDs []string
 }
 
+func sortedPreviewCallIDs(calls map[string]struct{}) []string {
+	ids := make([]string, 0, len(calls))
+	for id := range calls {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
 // attemptObservation carries one consumeModelStream attempt's phase/stats back
 // to callModel's retry closure, feeding llm.RetryStream's early-stop rules.
 // Populated on every return path, including errors, so a mid-stream failure
@@ -130,11 +139,7 @@ func (s *Session) callModel(ctx context.Context, policy llm.RetryPolicy, profile
 		}
 	}
 	withPreviewCalls := func(resp sessionModelResponse) sessionModelResponse {
-		resp.CommunicatePreviewCallIDs = make([]string, 0, len(previewCalls))
-		for id := range previewCalls {
-			resp.CommunicatePreviewCallIDs = append(resp.CommunicatePreviewCallIDs, id)
-		}
-		sort.Strings(resp.CommunicatePreviewCallIDs)
+		resp.CommunicatePreviewCallIDs = sortedPreviewCallIDs(previewCalls)
 		return resp
 	}
 	defer func() {

--- a/internal/appprojector/appwire_projection.go
+++ b/internal/appprojector/appwire_projection.go
@@ -471,22 +471,17 @@ func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification
 			if _, committed := p.communicateCommittedCalls[data.CallID]; committed {
 				return out
 			}
-			if itemID := p.provisionalCommunicateItems[data.CallID]; itemID != "" {
-				p.communicateCommittedCalls[data.CallID] = struct{}{}
-				p.communicatePhases[data.CallID] = communicatePhaseCommitted
-				delete(p.provisionalCommunicateItems, data.CallID)
-				p.recordAssistantMessage(p.activeTurnID, text)
-				return append(out, p.notification(appwire.NotifyItemCompleted, appwire.ItemLifecycleParams{
-					ThreadID: p.threadID, Ref: p.ref, TurnID: p.activeTurnID,
-					Item: appwire.ThreadItem{Type: "agentMessage", ID: itemID, TurnID: p.activeTurnID, Text: text, Status: appwire.TurnStatusCompleted},
-				}))
+			itemID := p.provisionalCommunicateItems[data.CallID]
+			if itemID == "" {
+				itemID = p.nextItemID("assistant")
 			}
 			p.communicateCommittedCalls[data.CallID] = struct{}{}
 			p.communicatePhases[data.CallID] = communicatePhaseCommitted
-			item := appwire.ThreadItem{Type: "agentMessage", ID: p.nextItemID("assistant"), TurnID: p.activeTurnID, Text: text, Status: appwire.TurnStatusCompleted}
+			delete(p.provisionalCommunicateItems, data.CallID)
 			p.recordAssistantMessage(p.activeTurnID, text)
 			return append(out, p.notification(appwire.NotifyItemCompleted, appwire.ItemLifecycleParams{
-				ThreadID: p.threadID, Ref: p.ref, TurnID: p.activeTurnID, Item: item,
+				ThreadID: p.threadID, Ref: p.ref, TurnID: p.activeTurnID,
+				Item: appwire.ThreadItem{Type: "agentMessage", ID: itemID, TurnID: p.activeTurnID, Text: text, Status: appwire.TurnStatusCompleted},
 			}))
 		}
 		if p.matchesLastAssistantMessage(p.activeTurnID, text) {


### PR DESCRIPTION
Follow-up to #471.

Keeps the call-scoped communicate preview lifecycle and its separate retry/fallback ownership layers intact while removing two copied mechanics:

- select the provisional or newly minted item ID before applying the common commit transition once
- centralize deterministic preview call ID export for both ownership layers

Behavior is unchanged; this only reduces drift risk in the lifecycle bookkeeping.

Verification:
- `go test ./agent ./internal/appprojector -run CommunicatePreview -count=20`
- `go test -race ./agent ./internal/appprojector -run CommunicatePreview -count=10`
- `make vet`
- `make lint`
- `make test`

Independent exact-head review: clean.