### PR TITLE
ci: remove inert binaries concurrency policy

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -6,10 +6,6 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 permissions:
   contents: read
 


### PR DESCRIPTION
Follow-up to #489.

That PR moved pull-request snapshot builds into `ci.yml` and removed the `pull_request` trigger from `binaries.yml`, but left the pull-request cancellation block behind. For every remaining event (`push` and `workflow_dispatch`), the group falls back to the unique run ID and `cancel-in-progress` is false, so the block cannot serialize or cancel anything.

This removes only that dead configuration; main, tag, and manual behavior is unchanged.

Verification:
- `actionlint .github/workflows/binaries.yml`
- `make lint-generated`
- `make lint`

Independent exact-head review: clean.