### PR TITLE
docs: mark navigation transport design implemented

### DIFF
--- a/docs/superpowers/specs/2026-08-25-tree-transport-optimization-design.md
+++ b/docs/superpowers/specs/2026-08-25-tree-transport-optimization-design.md
@@ -1,7 +1,7 @@
 # Navigation Transport Optimization Design
 
 **Date:** 2026-08-25
-**Status:** approved design, pending implementation plan
+**Status:** Implemented by PR #490
 **Scope:** replace the Web UI's monolithic `/api/tree` refresh path with revisioned, resource-scoped navigation snapshots while preserving current navigation behavior.
 
 ## Problem


### PR DESCRIPTION
Follow-up to #463.

#463 introduced the navigation transport design, whose status still says the implementation plan is pending. PR #490 has since implemented the bounded navigation resources and retired the legacy tree path, and six current scenarios cite this design as their live contract.

Update only that stale status line. The navigation implementation plan remains durable history; the still-unimplemented transcript design and plan are untouched.

Verification:
- confirmed #490 is merged as `c266193adc17da4db427276bc3644d12f2fa4108`
- `make lint-generated`
- `make lint`

Independent exact-head review: clean.