### PR TITLE
fix(web): bound interrupt cleanup ownership

### DIFF
--- a/runtime_pair_build_test.go
+++ b/runtime_pair_build_test.go
@@ -98,6 +98,7 @@ func TestRuntimeBuildFixtureEnvironmentDropsAmbientHarnessControls(t *testing.T)
 		"EVENER_TEST_WEB_WAIT_READY",
 		"EVENER_TEST_WEB_WAIT_RELEASE",
 		"EVENER_TEST_WEB_WAIT_REAPED",
+		"EVENER_TEST_WEB_STALE_JOB",
 		"EVENER_TEST_WEB_WAIT_USED",
 		"EVENER_TEST_NODE_HOLD_COMMAND",
 		"EVENER_TEST_NODE_FAIL_COMMAND",
@@ -731,8 +732,10 @@ func TestMakeTestWebInterruptRetainsEvidenceAndReapsChecks(t *testing.T) {
 	if err := exec.Command("kill", "-TERM", strconv.Itoa(command.Process.Pid)).Run(); err != nil {
 		t.Fatalf("signal make test-web: %v", err)
 	}
-	if err := run.wait(); err == nil {
+	if err := waitForChildExit(run, 5*time.Second); err == nil {
 		t.Fatalf("interrupted make test-web exited zero; output = %s", output.String())
+	} else if errors.Is(err, errChildExitTimeout) {
+		t.Fatalf("interrupted make test-web did not reap checks: %v; output = %s", err, output.String())
 	}
 
 	retained := fullLogsPath(output.Bytes())
@@ -852,7 +855,7 @@ kill() {
 func TestMakeTestWebInterruptAtWaitHandoff(t *testing.T) {
 	for _, signal := range []string{"TERM", "INT"} {
 		t.Run(signal, func(t *testing.T) {
-			runWebWaitHandoff(t, signal, false)
+			runWebWaitHandoff(t, signal, false, false)
 		})
 	}
 }
@@ -860,9 +863,13 @@ func TestMakeTestWebInterruptAtWaitHandoff(t *testing.T) {
 func TestMakeTestWebInterruptAtWaitHandoffRejectsLostSignalMutation(t *testing.T) {
 	for _, signal := range []string{"TERM", "INT"} {
 		t.Run(signal, func(t *testing.T) {
-			runWebWaitHandoff(t, signal, true)
+			runWebWaitHandoff(t, signal, true, false)
 		})
 	}
+}
+
+func TestMakeTestWebInterruptHandlesStaleRunningJobAfterWaitLosesOwnership(t *testing.T) {
+	runWebWaitHandoff(t, "TERM", false, true)
 }
 
 // runWebWaitHandoff drives the actual test-web shell at the boundary immediately
@@ -870,7 +877,7 @@ func TestMakeTestWebInterruptAtWaitHandoffRejectsLostSignalMutation(t *testing.T
 // defer-signals-before-wait ordering; it must remain blocked after the parent
 // signal until the held child is independently released, proving this test is
 // mechanism RED rather than a missing production hook.
-func runWebWaitHandoff(t *testing.T, signal string, mutate bool) {
+func runWebWaitHandoff(t *testing.T, signal string, mutate, simulateStaleJob bool) {
 	t.Helper()
 	fixture := newBuildWebFixture(t)
 	frontendDir := filepath.Join(fixture.root, "cmd", "evener-hub", "frontend")
@@ -886,6 +893,12 @@ func runWebWaitHandoff(t *testing.T, signal string, mutate bool) {
 	waitReadyPath := filepath.Join(fixture.root, "wait.ready")
 	waitReleasePath := filepath.Join(fixture.root, "wait.release")
 	waitReapedPath := filepath.Join(fixture.root, "wait.reaped")
+	staleJobPath := filepath.Join(fixture.root, "stale-job")
+	staleJobControl := ""
+	if simulateStaleJob {
+		writeTestFile(t, staleJobPath, nil, 0o600)
+		staleJobControl = staleJobPath
+	}
 	for _, path := range []string{npmReadyPath, npmReleasePath, waitReadyPath, waitReleasePath} {
 		if err := syscall.Mkfifo(path, 0o600); err != nil {
 			t.Fatalf("make FIFO %s: %v", path, err)
@@ -903,7 +916,17 @@ func runWebWaitHandoff(t *testing.T, signal string, mutate bool) {
   command wait "$@"
   wait_status=$?
   : > "$EVENER_TEST_WEB_WAIT_REAPED"
+  if [ "${1:-}" = "$tracked_pid" ] && [ -n "${EVENER_TEST_WEB_STALE_JOB:-}" ] && [ -e "$EVENER_TEST_WEB_STALE_JOB" ]; then
+    return 127
+  fi
   return "$wait_status"
+}
+jobs() {
+  if [ -n "${EVENER_TEST_WEB_STALE_JOB:-}" ] && [ -e "$EVENER_TEST_WEB_STALE_JOB" ]; then
+    cat "$EVENER_TEST_NPM_PID"
+    return
+  fi
+  command jobs "$@"
 }
 `), 0o644)
 
@@ -942,6 +965,7 @@ func runWebWaitHandoff(t *testing.T, signal string, mutate bool) {
 		"EVENER_TEST_WEB_WAIT_READY="+waitReadyPath,
 		"EVENER_TEST_WEB_WAIT_RELEASE="+waitReleasePath,
 		"EVENER_TEST_WEB_WAIT_REAPED="+waitReapedPath,
+		"EVENER_TEST_WEB_STALE_JOB="+staleJobControl,
 	)
 	var output bytes.Buffer
 	command.Stdout = &output
@@ -955,6 +979,7 @@ func runWebWaitHandoff(t *testing.T, signal string, mutate bool) {
 	}
 	run := startChild(command)
 	t.Cleanup(func() {
+		_ = os.Remove(staleJobPath)
 		_, _ = childRelease.WriteString("cleanup\n")
 		_ = childRelease.Close()
 		_ = npmReady.Close()
@@ -1031,9 +1056,12 @@ func mutateWebWaitDeferral(t *testing.T, fixture runtimeBuildFixture) {
 	# A completed wait removes the job from Bash's job table, which is the
 	# completion/ownership handoff and not a PID liveness guess vulnerable to
 	# reuse. Signals are not deferred here: Bash must wake this exact wait.
+	# Defer cleanup only while that result is committed to the owned PID list.
+	defer_signals=1
 	if ! owned_job_is_running "$pid"; then
 		forget_pid "$pid"
 	fi
+	defer_signals=0
 	printf '%s\n' "$check_status" >"$dir/$c.status"
 	consume_interrupt`
 	deferredWaitBlock := `	defer_signals=1
@@ -1588,7 +1616,7 @@ func (fixture runtimeBuildFixture) environment(failPackage string) []string {
 			"EVENER_TEST_NPM_TRACK_COMMAND", "EVENER_TEST_NPM_TRACK_PID", "EVENER_TEST_SHELL_KILLED_REAPED", "EVENER_TEST_SHELL_WAITED_REAPED",
 			"EVENER_TEST_SHELL_WAIT_RELEASE",
 			"EVENER_TEST_WEB_CLEANUP_READY", "EVENER_TEST_WEB_CLEANUP_RELEASE", "EVENER_TEST_WEB_CLEANUP_PID",
-			"EVENER_TEST_WEB_WAIT_READY", "EVENER_TEST_WEB_WAIT_RELEASE", "EVENER_TEST_WEB_WAIT_REAPED", "EVENER_TEST_WEB_WAIT_USED",
+			"EVENER_TEST_WEB_WAIT_READY", "EVENER_TEST_WEB_WAIT_RELEASE", "EVENER_TEST_WEB_WAIT_REAPED", "EVENER_TEST_WEB_STALE_JOB", "EVENER_TEST_WEB_WAIT_USED",
 			"EVENER_TEST_NODE_HOLD_COMMAND", "EVENER_TEST_NODE_FAIL_COMMAND", "EVENER_TEST_NODE_PID", "EVENER_TEST_NODE_READY", "EVENER_TEST_NODE_TERM", "EVENER_TEST_NODE_RELEASE", "EVENER_TEST_NODE_READY_FD":
 			continue
 		}

--- a/scripts/web/test-web.sh
+++ b/scripts/web/test-web.sh
@@ -19,6 +19,7 @@ cd "$script_dir/../../cmd/evener-hub/frontend" || exit 1
 dir=""
 active_pids=(); started=(); fail=0; complete=0; interrupt_status=0
 defer_signals=0; stopping=0; finishing=0
+owner_subshell=$BASH_SUBSHELL
 
 forget_pid() {
 	local pid="$1" candidate
@@ -54,6 +55,9 @@ stop_checks() {
 		[ -n "$pid" ] || continue
 		while :; do
 			if wait "$pid" 2>/dev/null; then wait_status=0; else wait_status=$?; fi
+			# Negative and 127 statuses mean Bash no longer owns a child it can
+			# reap, even if its copied job table still reports that PID as running.
+			if [ "$wait_status" -lt 0 ] || [ "$wait_status" -eq 127 ]; then break; fi
 			owned_job_is_running "$pid" || break
 		done
 	done
@@ -63,6 +67,9 @@ stop_checks() {
 
 finish() {
 	finish_status=$?
+	# Async check shells inherit EXIT, but only this script's owner can reap
+	# active_pids or decide whether its evidence directory is complete.
+	[ "$BASH_SUBSHELL" -eq "$owner_subshell" ] || return "$finish_status"
 	finishing=1
 	[ "$complete" -eq 1 ] || stop_checks
 	if [ "$interrupt_status" -ne 0 ]; then
@@ -130,9 +137,12 @@ for i in "${!started[@]}"; do
 	# A completed wait removes the job from Bash's job table, which is the
 	# completion/ownership handoff and not a PID liveness guess vulnerable to
 	# reuse. Signals are not deferred here: Bash must wake this exact wait.
+	# Defer cleanup only while that result is committed to the owned PID list.
+	defer_signals=1
 	if ! owned_job_is_running "$pid"; then
 		forget_pid "$pid"
 	fi
+	defer_signals=0
 	printf '%s\n' "$check_status" >"$dir/$c.status"
 	consume_interrupt
 done


### PR DESCRIPTION
## Summary

- restrict `test-web.sh` cleanup to the shell that owns the active checks
- close the post-`wait` signal handoff race while preserving job-table ownership checks
- terminate cleanup when Bash reports no reapable child (`< 0` internally or documented status `127`)
- bound the focused interrupt regression with the existing child-exit tripwire and add a real-script status-127 oracle

This is a focused follow-up to #458. It addresses the root race timeout observed in [CI run 33047521970, job 98434918146](https://github.com/prime-radiant-inc/evener/actions/runs/33047521970/job/98434918146).

## Root cause

Under Linux contention, asynchronous check subshells inherit the `EXIT` trap and can observe sibling jobs they cannot reap. The owner shell can also receive `TERM` while committing a completed `wait` to `active_pids`. In either case Bash can report no reapable child while its copied job table still reports the PID as running, leaving cleanup spinning until the package timeout.

The fix preserves the #458 contract: signal only still-owned Bash jobs, terminate all concurrent web checks, synchronously reap them before exit, retain interrupt evidence/status, and avoid PID-liveness ownership checks that are vulnerable to PID reuse.

## Verification

- focused interrupt suite
- exact normal and race counts (`-count=20`)
- status-127 real-script oracle, including Linux race x20 and verified red/green
- original Linux reproducer under 32 CPU burners x100
- `make vet`
- `make lint`
- `make test`
- `make test-race RACE_SCOPE=root`