### PR TITLE
refactor(web): remove superseded Crashpad filter seam

### DIFF
--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
@@ -216,18 +216,7 @@ function reportCleanupFailure(error) {
   console.error(error instanceof Error ? error.message : String(error));
 }
 
-export function filterCrashpadProcessTable(processList) {
-  return processList
-    .split("\n")
-    .filter((line) => {
-      const match = line.match(/^\s*\d+\s+\d+\s+(.+)$/);
-      return match && /(?:^|\/)chrome_crashpad_handler(?:\s|$)/.test(match[1]);
-    })
-    .join("\n");
-}
-
-export function listSystemProcesses({ processTable, processCommand = ["/bin/ps"] } = {}) {
-  if (processTable !== undefined) return filterCrashpadProcessTable(processTable);
+export function listSystemProcesses({ processCommand = ["/bin/ps"] } = {}) {
   // Stream the complete table through awk and retain only full-argv Crashpad
   // candidates. Capturing the unfiltered table exceeds execFileSync's 1 MiB
   // maxBuffer on a process-heavy host. Filtering the command column, rather


### PR DESCRIPTION
## Summary

Remove the unused in-memory Crashpad process-table filter and its processTable injection option left behind by PR #458.

The final regression coverage already uses processCommand to exercise the real bash, pipefail, and awk streaming boundary. Keeping a second JavaScript filtering rule adds no coverage and can drift from production behavior.

This leaves the production streaming filter, process identity validation, external command injection, and all meaningful tests unchanged.

## Verification

- node --test cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs (46 pass)
- make test-web
- make vet
- make lint
- make test
- git diff --check
- independent exact-head review: clean

Refs #458