### PR TITLE
Remove superseded path validation REST surface

### DIFF
--- a/cmd/evener-hub/cov_core_api_pass4_fuzz_test.go
+++ b/cmd/evener-hub/cov_core_api_pass4_fuzz_test.go
@@ -131,8 +131,6 @@ func FuzzCoreAPIPass4(f *testing.F) {
 		call(http.MethodGet, "/api/git/head?cwd="+workingDir, "")
 		call(http.MethodGet, "/api/git/head?cwd=/definitely/missing/pass4", "")
 		call(http.MethodPost, "/api/git/head", "")
-		direct(web.handleAPIPathValidate, http.MethodGet, "/api/path/validate?path="+workingDir+"&kind=directory", "")
-		direct(web.handleAPIPathValidate, http.MethodPost, "/api/path/validate", "")
 		direct(web.handleAPIDirCreate, http.MethodPost, "/api/dirs/create", `{}`)
 		direct(web.handleAPIDirCreate, http.MethodPost, "/api/dirs/create", `{"path":"relative"}`)
 		direct(web.handleAPIDirCreate, http.MethodPost, "/api/dirs/create", `{"path":"`+workingDir+`"}`)

--- a/cmd/evener-hub/cov_web_core_api_test.go
+++ b/cmd/evener-hub/cov_web_core_api_test.go
@@ -91,7 +91,6 @@ func TestCovWebCoreAPIHelpersAndRoutes(t *testing.T) {
 		{http.MethodGet, "/_partials/s/id/unknown"},
 		{http.MethodGet, "/manifest.webmanifest"},
 		{http.MethodPost, "/api/health"}, {http.MethodGet, "/api/health"},
-		{http.MethodPost, "/api/path/validate"}, {http.MethodGet, "/api/path/validate?path=/tmp&kind=directory"},
 		{http.MethodPost, "/api/git/head"},
 	} {
 		_ = covWebRequest(t, web, tc.method, tc.target, "")

--- a/cmd/evener-hub/web.go
+++ b/cmd/evener-hub/web.go
@@ -163,7 +163,6 @@ func (s *WebServer) Handler() http.Handler {
 	mux.HandleFunc("/api/spawn", s.handleApiSpawn)
 	mux.HandleFunc("/api/models", s.handleApiModels)
 	mux.HandleFunc("/api/dirs/create", s.handleAPIDirCreate)
-	mux.HandleFunc("/api/path/validate", s.handleAPIPathValidate)
 	mux.HandleFunc("/api/git/head", s.handleApiGitHead)
 	mux.HandleFunc("/api/search", s.handleApiSearch)
 	mux.HandleFunc("/api/health", s.handleAPIHealth)

--- a/cmd/evener-hub/web_api.go
+++ b/cmd/evener-hub/web_api.go
@@ -19,7 +19,6 @@ import (
 	"primeradiant.com/evener/agent/diagnostic"
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/buildinfo"
-	"primeradiant.com/evener/cmd/evener-hub/internal/fspaths"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubedge"
 	"primeradiant.com/evener/envvars"
@@ -469,18 +468,6 @@ func (s *WebServer) handleAPIReasoningEffort(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
-}
-
-func (s *WebServer) handleAPIPathValidate(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		http.Error(w, "GET required", http.StatusMethodNotAllowed)
-		return
-	}
-	resp := fspaths.ValidateLaunchPath(appwire.PathValidateParams{
-		Path: r.URL.Query().Get("path"),
-		Kind: r.URL.Query().Get("kind"),
-	})
-	writeAPIJSON(w, http.StatusOK, resp)
 }
 
 // handleAPIDirCreate creates a directory (and any missing parents) at an

--- a/docs/superpowers/plans/2026-08-27-path-validate-rest-burndown.md
+++ b/docs/superpowers/plans/2026-08-27-path-validate-rest-burndown.md
@@ -1,0 +1,101 @@
+# Path Validate REST Burndown Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the duplicate `/api/path/validate` application JSON route
+and its route-only probes while preserving the existing
+`evener/path/validate` AppWire method and validation behavior.
+
+**Architecture:** This is a delete-and-document-correction migration. The
+typed AppWire method is the only application path-validation request surface;
+no new method, compatibility route, or HTTP fallback is introduced.
+
+**Tech Stack:** Go, AppWire, route/fuzz coverage, shell coverage harness,
+Markdown behavior contracts.
+
+**Spec:** [2026-08-27-path-validate-rest-burndown-design.md](../specs/2026-08-27-path-validate-rest-burndown-design.md)
+
+## Global Constraints
+
+- Preserve `evener/path/validate`, `fspaths.ValidateLaunchPath`, and the
+  existing AppWire handler/tests.
+- Remove only the duplicate HTTP route and route-specific probes.
+- Keep `/api/dirs/create` unchanged; it is a separate application API with no
+  AppWire equivalent in this slice.
+- Do not edit historical superpowers specs/plans.
+- Do not add tests whose only purpose is to assert that the old route is gone.
+- Before changing tests, follow `docs/developing-evener/testing.md`.
+- Run the required pre- and post-implementation four-reviewer
+  `simplify-code` passes.
+- Use explicit paths with `git add` after checking `git status`; never bypass
+  hooks.
+
+---
+
+## Task 1: Remove the HTTP route and handler
+
+**Files:**
+
+- Modify `cmd/evener-hub/web.go`.
+- Modify `cmd/evener-hub/web_api.go`.
+
+**Steps:**
+
+- [ ] Remove the `/api/path/validate` mux registration.
+- [ ] Remove `handleAPIPathValidate` and its now-unused HTTP-only import.
+- [ ] Leave the AppWire registration in `cmd/evener-hub/app_rpc.go` and
+      `fspaths.ValidateLaunchPath` unchanged.
+- [ ] Run `gofmt -w cmd/evener-hub/web.go cmd/evener-hub/web_api.go`.
+
+## Task 2: Remove route-only coverage and harness probes
+
+**Files:**
+
+- Modify `cmd/evener-hub/cov_web_core_api_test.go`.
+- Modify `cmd/evener-hub/cov_core_api_pass4_fuzz_test.go`.
+- Modify `scripts/coverage/e2e-cover.sh`.
+
+**Steps:**
+
+- [ ] Remove the route-table and direct-handler probes for
+      `/api/path/validate`.
+- [ ] Remove the coverage-harness curl for the deleted route and keep the
+      remaining shutdown comment concise.
+- [ ] Keep AppWire path-validation tests, fuzz coverage, and the unrelated
+      `/api/dirs/create` coverage.
+- [ ] Run `gofmt -w` on changed Go files and `git diff --check`.
+- [ ] Run `go test ./cmd/evener-hub`.
+
+## Task 3: Correct current parity contracts
+
+**Files:**
+
+- Modify `docs/web-ui/parity/parity-m6-surfaces.md`.
+- Modify `docs/web-ui/parity/parity-m7-settings.md`.
+
+**Steps:**
+
+- [ ] Replace the spawn preflight sentence that claims validation uses an HTTP
+      GET with the existing AppWire request behavior.
+- [ ] Remove the `launchconfig.validatePath` raw-fetch fallback claim and state
+      that it uses `evener/path/validate` through AppWire.
+- [ ] Do not rewrite historical superpowers documents.
+
+## Task 4: Re-audit, simplify, gate, and publish
+
+**Files:** None beyond Tasks 1–3.
+
+**Steps:**
+
+- [ ] Run `rg -n -S '/api/path/validate|handleAPIPathValidate'` and classify
+      only historical design references as remaining results.
+- [ ] Run `go test ./cmd/evener-hub`.
+- [ ] Run `make lint`.
+- [ ] Run `make vet`.
+- [ ] Run `make test`.
+- [ ] Run `git diff --check` and inspect the complete diff.
+- [ ] Run the required post-implementation `simplify-code` review and apply
+      only accepted quality-preserving suggestions.
+- [ ] Repeat focused tests and applicable gates after any review fix.
+- [ ] Fetch `origin/main`, rebase if it moved, push the branch, and open its
+      focused pull request.

--- a/docs/superpowers/specs/2026-08-27-path-validate-rest-burndown-design.md
+++ b/docs/superpowers/specs/2026-08-27-path-validate-rest-burndown-design.md
@@ -1,0 +1,46 @@
+# Remove the Superseded Path Validation REST Surface
+
+## Status
+
+Approved implementation slice: delete the duplicate `/api/path/validate`
+application JSON surface. The hub AppWire server and all current frontend
+consumers already use the typed `evener/path/validate` method, so this slice
+changes no wire contract and adds no compatibility fallback.
+
+## Evidence and scope
+
+The contract invariant is that all active consumers use `evener/path/validate`
+through AppWire. The caller audit at `origin/main` found no active production
+HTTP caller for `/api/path/validate`; `app_rpc.go` registers the AppWire method
+against the shared `fspaths.ValidateLaunchPath` implementation, and the
+launch-config, spawn, and settings consumers are current examples of that
+contract.
+
+The remaining HTTP references are the mux registration and handler, route-only
+coverage probes, one coverage-harness curl, and two current parity checklist
+sentences that still describe an HTTP fallback. Historical superpowers
+specs/plans are not current callers and remain unchanged.
+
+## Deletions and documentation cleanup
+
+- Remove `/api/path/validate` registration and `handleAPIPathValidate`.
+- Remove its route-only coverage and fuzz probes and the coverage-harness curl.
+- Update current parity docs to describe the AppWire validation request and
+  remove the REST fallback claim.
+
+## Non-goals
+
+- Do not change `evener/path/validate`, `fspaths.ValidateLaunchPath`, or its
+  AppWire handler and tests.
+- Do not change the unrelated `/api/dirs/create` route used by spawn preflight.
+- Do not add a test whose only purpose is to assert that the legacy route is
+  absent.
+- Do not rewrite historical design records.
+
+## Verification
+
+- Focused hub tests pass after route-only probes are removed.
+- The exact source/current-doc audit has no non-historical
+  `/api/path/validate` or `handleAPIPathValidate` references.
+- `make lint`, `make vet`, and `make test` pass after implementation and the
+  post-implementation simplify review.

--- a/docs/web-ui/parity/parity-m6-surfaces.md
+++ b/docs/web-ui/parity/parity-m6-surfaces.md
@@ -169,7 +169,7 @@ These are the findings most likely to bite a rewrite that "looks equivalent." Ea
 
 ### 1.13 Working-directory preflight
 
-- [ ] Before spawning, `GET /api/path/validate?path=&kind=dir` is checked; a failure of the CHECK ITSELF fails OPEN (spawn proceeds anyway) so a flaky validator never blocks a real spawn (`spawn.js:573-580`, code comment at 568-572)
+- [ ] Before spawning, `evener/path/validate` is checked; a failure of the CHECK ITSELF fails OPEN (spawn proceeds anyway) so a flaky validator never blocks a real spawn (`spawn.js:573-580`, code comment at 568-572)
 - [ ] Deterministic "not fixable by creating a directory" errors — literal strings `path is not a directory`, `absolute path required`, `path is required` — render an inline error and abort instead of offering to create (`spawn.js:582-588`)
 - [ ] Any other invalid-path reason offers an IN-FORM (not native `confirm()`) dialog: `` The directory `<path>` doesn't exist yet. Create it and start the session? `` with Cancel / "Create & start" buttons; "Create & start" receives initial focus (`spawn.js:527-566, 589-591`)
 - [ ] Declining aborts the submit with NO error shown (`spawn.js:559-561, 591`)

--- a/docs/web-ui/parity/parity-m7-settings.md
+++ b/docs/web-ui/parity/parity-m7-settings.md
@@ -894,9 +894,8 @@ hand-roll their own simpler collection editor directly against `launchconfig.get
 - [ ] `launchconfig` wraps 16 RPCs 1:1 through one `request(method, params)` →
       `EvenerAppwire.request`: `schema`→`evener/launch/schema`, `resolve`→`evener/launch/resolve`,
       `getLayer`→`evener/launch/getLayer`, `setLayer`→`evener/launch/setLayer`,
-      `trustRepo`→`evener/launch/trustRepo`, `validatePath`→`evener/path/validate` (via
-      `EvenerAppwire.validatePath` when present, else a raw `fetch("/api/path/validate?...")` GET
-      fallback); `authList`→`evener/auth/list`, `authStatus`→`evener/auth/status`,
+      `trustRepo`→`evener/launch/trustRepo`, `validatePath`→`evener/path/validate` over AppWire;
+      `authList`→`evener/auth/list`, `authStatus`→`evener/auth/status`,
       `authApiKeySet`→`evener/auth/apiKey/set`, `authLoginStart`→`evener/auth/login/start`,
       `authLoginComplete`→`evener/auth/login/complete`, `authLogout`→`evener/auth/logout`,
       `authDeviceStart`→`evener/auth/device/start`, `authDevicePoll`→`evener/auth/device/poll`;

--- a/scripts/coverage/e2e-cover.sh
+++ b/scripts/coverage/e2e-cover.sh
@@ -118,8 +118,7 @@ if command -v curl >/dev/null 2>&1; then
 		done
 	fi
 
-	# a couple of POSTs against validate/create (error paths, no real spawn).
-	curl -fsS --max-time 5 -X POST "$base/api/path/validate" -d '{}' >/dev/null 2>&1 || true
+	# Stop the coverage hub.
 	kill -TERM "$hub_pid" 2>/dev/null || true
 	wait "$hub_pid" 2>/dev/null || true
 fi


### PR DESCRIPTION
## Summary

- remove the unused `/api/path/validate` route and handler
- remove route-only coverage probes and the coverage-harness curl
- update current parity documentation to describe `evener/path/validate` over AppWire
- retain the AppWire method, shared validator, real callers, and meaningful AppWire coverage

This is the path-validation slice of the REST-to-AppWire migration. Historical
planning records are left unchanged.

## Verification

- `go test ./cmd/evener-hub`
- `make lint`
- `make vet`
- `make test`
- `git diff --check`
- fresh whole-branch review: clean