### PR TITLE
Fix live session project hydration in navigation

### DIFF
--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
@@ -2,6 +2,7 @@ import { type ChangeEvent, type CSSProperties, useCallback, useEffect, useId, us
 import { sessionPanelPaneType } from "../../panes/sessionPanels";
 import { errorText } from "../../protocol/errors";
 import type {
+  NavigationCatalogs,
   NavigationProjectPage,
   NavigationProjectResource,
   NavigationProjectSummary,
@@ -91,8 +92,7 @@ const CLASS = {
 };
 
 const ARCHIVED_SECTION_KEY = "section:archived";
-const catalogKinds = ["projects", "archived_projects", "test_runs"] as const;
-type CatalogKind = (typeof catalogKinds)[number];
+type CatalogKind = keyof NavigationCatalogs;
 
 interface RailSectionProps {
   title: string;

--- a/cmd/evener-hub/frontend/src/stores/navigation/store.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/navigation/store.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, expect, test, vi } from "vitest";
 import { WireError } from "../../protocol/errors";
 import { FakeClient } from "../../protocol/testing/fakeClient";
+import { navigationInvalidatedNotification } from "../../protocol/testing/notifications";
 import type { NavigationReadParams, NavigationReadResponse } from "../../protocol/types.gen";
 import { EXPANSION_STORAGE_KEY } from "../../shell/rail/railExpansion";
 import {
@@ -153,6 +154,45 @@ test("manifest is read first, count-zero resources are skipped, and defaults are
   expect(
     calls.some((x) => x.section === "needs_you" || x.catalog === "archived_projects" || x.catalog === "test_runs"),
   ).toBe(false);
+});
+
+test("manifest invalidation hydrates resources that become nonempty", async () => {
+  const calls: NavigationReadParams[] = [];
+  const sectionRequested = deferred<void>();
+  const catalogRequested = deferred<void>();
+  let populated = false;
+  const nextManifest = emptyManifest({
+    sections: { live: { count: 1 }, needs_you: { count: 0 }, pin_sections: { count: 0 } },
+    catalogs: { projects: { count: 1 }, archived_projects: { count: 0 }, test_runs: { count: 0 } },
+  });
+  const client = await init((params) => {
+    calls.push(params);
+    if (params.resource === "manifest")
+      return wire(populated ? nextManifest : emptyManifest(), "ok", populated ? '"two"' : '"one"', populated ? 2 : 1);
+    if (params.resource === "section") {
+      sectionRequested.resolve();
+      return wire({ sessions: [], remaining: 0, truncated: false });
+    }
+    if (params.resource === "catalog") {
+      catalogRequested.resolve();
+      return wire({ projects: [{ key: "project", default_expanded: false }], remaining: 0 });
+    }
+    return wire({ sessions: [], remaining: 0 });
+  });
+
+  expect(calls).toEqual([{ resource: "manifest" }]);
+  populated = true;
+  client.emitNotification(
+    navigationInvalidatedNotification({
+      generationId: generation,
+      sequence: 1,
+      targets: [{ kind: "manifest", revision: 2 }],
+    }),
+  );
+  await Promise.all([sectionRequested.promise, catalogRequested.promise]);
+
+  expect(calls).toContainEqual({ resource: "section", section: "live", offset: 0, limit: 50 });
+  expect(calls).toContainEqual({ resource: "catalog", catalog: "projects", offset: 0, limit: 100 });
 });
 
 test("validated manifest attention seeds the v1 summary before notifications", async () => {

--- a/cmd/evener-hub/frontend/src/stores/navigation/store.ts
+++ b/cmd/evener-hub/frontend/src/stores/navigation/store.ts
@@ -112,17 +112,39 @@ let revalidator: NavigationRevalidator | null = null;
 let unsubs: Array<() => void> = [];
 let bootEpoch = 0;
 let bootStartedEpoch = -1;
+let manifestFanout: { key: string; promise: Promise<void> } | null = null;
 const PAGE_LIMIT = 50;
 const CATALOG_LIMIT = 100;
+const NAVIGATION_CATALOGS = ["projects", "archived_projects", "test_runs"] as const;
 const key = (k: ResourceKey) => Object.freeze(k);
-function setResource(state: ResourceState, client = activeClient, epoch = bootEpoch): void {
-  if (client !== activeClient || epoch !== bootEpoch) return;
-  if (state.key.kind === "manifest") navigationStore.setState({ manifest: state as ResourceState<NavigationManifest> });
-  else {
-    const resources = new Map(navigationStore.getState().resources);
-    resources.set(keyID(state.key), state);
-    navigationStore.setState({ resources });
+function setResource(state: ResourceState): void {
+  if (state.key.kind === "manifest") {
+    navigationStore.setState({ manifest: state as ResourceState<NavigationManifest> });
+    return;
   }
+  const resources = new Map(navigationStore.getState().resources);
+  resources.set(keyID(state.key), state);
+  navigationStore.setState({ resources });
+}
+function publishResourceState(state: ResourceState): void {
+  setResource(state);
+  if (state.error instanceof NavigationProtocolError) {
+    navigationStore.setState({ protocolError: state.error });
+    if (state.key.kind !== "manifest") revalidator?.force([{ kind: "manifest" }]);
+  }
+}
+function coordinateManifestState(state: ResourceState, epoch: number): void {
+  if (
+    state.key.kind !== "manifest" ||
+    state.loading ||
+    state.stale ||
+    !state.data ||
+    !isNavigationManifest(state.data)
+  ) {
+    return;
+  }
+  navigationStore.setState({ attention: { changed: [], summary: state.data.attentionSummary } });
+  void fanOutManifestResources(state.data, epoch).catch(() => undefined);
 }
 class NavigationProtocolError extends Error {
   constructor(message: string) {
@@ -327,26 +349,7 @@ function load<T>(k: ResourceKey): Promise<ResourceState<T>> {
   const requestRevalidator = revalidator;
   const requestClient = activeClient;
   if (!requestClient) return Promise.reject(new Error("navigation is not initialized"));
-  const requestEpoch = bootEpoch;
-  const requestGeneration = requestRevalidator.generationID;
-  return requestRevalidator.load<T>(key(k), requestFor<T>(k, requestClient)).then((s) => {
-    if (
-      requestClient !== activeClient ||
-      requestEpoch !== bootEpoch ||
-      requestRevalidator !== revalidator ||
-      requestGeneration !== revalidator.generationID
-    )
-      return s as ResourceState<T>;
-    setResource(s);
-    if (k.kind === "manifest" && s.data && isNavigationManifest(s.data)) {
-      navigationStore.setState({ attention: { changed: [], summary: s.data.attentionSummary } });
-    }
-    if (s.error instanceof NavigationProtocolError) {
-      navigationStore.setState({ protocolError: s.error });
-      if (k.kind !== "manifest") requestRevalidator.force([{ kind: "manifest" }]);
-    }
-    return s as ResourceState<T>;
-  });
+  return requestRevalidator.load<T>(key(k), requestFor<T>(k, requestClient));
 }
 async function withProjectRecovery(projectKey: string): Promise<ResourceState<NavigationProjectResource>> {
   const first = await load<NavigationProjectResource>({ kind: "project", projectKey });
@@ -363,16 +366,14 @@ async function withProjectRecovery(projectKey: string): Promise<ResourceState<Na
     revalidator?.force([manifestKey]);
     const manifest = await load<NavigationManifest>(manifestKey).catch(() => null);
     if (manifest?.data && !manifest.error && !manifest.stale && isNavigationManifest(manifest.data)) {
-      const manifestData = manifest.data;
-      const catalogJobs = (["projects", "archived_projects", "test_runs"] as const)
-        .filter((catalog) => manifestData.catalogs[catalog].count > 0)
-        .map((catalog) =>
+      await Promise.all(
+        nonemptyCatalogs(manifest.data).map((catalog) =>
           navigationStore
             .getState()
             .loadCatalog(catalog)
             .catch(() => undefined),
-        );
-      await Promise.all(catalogJobs);
+        ),
+      );
     }
   } else {
     revalidator?.force(candidates.map((r) => r.key));
@@ -438,6 +439,9 @@ function actions() {
     },
   };
 }
+function nonemptyCatalogs(manifest: NavigationManifest): Array<(typeof NAVIGATION_CATALOGS)[number]> {
+  return NAVIGATION_CATALOGS.filter((catalog) => manifest.catalogs[catalog].count > 0);
+}
 
 async function boot(cap: NavigationCapability, epoch: number, client: AppwireClientLike): Promise<void> {
   if (client !== activeClient || epoch !== bootEpoch) return;
@@ -464,7 +468,7 @@ async function boot(cap: NavigationCapability, epoch: number, client: AppwireCli
   });
   if (bootStartedEpoch === epoch) return;
   bootStartedEpoch = epoch;
-  let manifest = await navigationStore
+  const manifest = await navigationStore
     .getState()
     .loadManifest()
     .catch(() => null);
@@ -473,34 +477,37 @@ async function boot(cap: NavigationCapability, epoch: number, client: AppwireCli
   // flight. The revalidator owns the trailing retry, so consume that retry
   // before deciding that boot has no manifest to fan out from.
   if (manifest.error) {
-    manifest = await navigationStore
+    await navigationStore
       .getState()
       .loadManifest()
       .catch(() => null);
-    if (!manifest || epoch !== bootEpoch || client !== activeClient) return;
   }
-  const m = manifest.data;
-  if (!m) return;
-  if (!isNavigationManifest(m)) {
-    navigationStore.setState({ protocolError: new Error("invalid navigation manifest") });
+}
+
+async function fanOutManifestResources(manifest: NavigationManifest, epoch: number): Promise<void> {
+  if (epoch !== bootEpoch || activeClient === null) return;
+  const manifestKey = `${manifest.generation_id}:${manifest.revision}`;
+  if (manifestFanout?.key === manifestKey) {
+    await manifestFanout.promise;
     return;
   }
+  const promise = hydrateManifestResources(manifest, epoch);
+  manifestFanout = { key: manifestKey, promise };
+  await promise;
+}
+
+async function hydrateManifestResources(manifest: NavigationManifest, epoch: number): Promise<void> {
   const jobs: Array<() => Promise<unknown>> = [];
-  if (m.sections.live.count > 0) jobs.push(() => navigationStore.getState().loadSection("live"));
-  if (m.sections.needs_you.count > 0) jobs.push(() => navigationStore.getState().loadSection("needs_you"));
-  if (m.sections.pin_sections.count > 0) jobs.push(() => navigationStore.getState().loadPinCatalog());
-  for (const c of ["projects", "archived_projects", "test_runs"] as const)
-    if (m.catalogs[c].count > 0) jobs.push(() => navigationStore.getState().loadCatalog(c));
+  if (manifest.sections.live.count > 0) jobs.push(() => navigationStore.getState().loadSection("live"));
+  if (manifest.sections.needs_you.count > 0) jobs.push(() => navigationStore.getState().loadSection("needs_you"));
+  if (manifest.sections.pin_sections.count > 0) jobs.push(() => navigationStore.getState().loadPinCatalog());
+  jobs.push(...nonemptyCatalogs(manifest).map((catalog) => () => navigationStore.getState().loadCatalog(catalog)));
   await runBounded(jobs, epoch);
   if (epoch !== bootEpoch || activeClient === null) return;
   const pinCatalog = navigationStore
     .getState()
     .resources.get(keyID({ kind: "pin_catalog", offset: 0, limit: CATALOG_LIMIT }));
   const pinSections = (pinCatalog?.data as NavigationPinSectionCatalog | null)?.pin_sections ?? [];
-  await runBounded(
-    pinSections.filter((p) => p.count > 0).map((p) => () => navigationStore.getState().loadPinSection(p.id)),
-    epoch,
-  );
   // Hydrate only visible/default-expanded projects. A small explicit worker
   // pool prevents a large catalog from monopolising the browser connection.
   const projects = selectSummaries();
@@ -508,7 +515,10 @@ async function boot(cap: NavigationCapability, epoch: number, client: AppwireCli
     .filter((p) => navigationStore.getState().expanded.get(p.key) ?? p.default_expanded)
     .map((p) => p.key);
   await runBounded(
-    pending.map((project) => () => hydrateProject(project, epoch)),
+    [
+      ...pinSections.filter((p) => p.count > 0).map((p) => () => navigationStore.getState().loadPinSection(p.id)),
+      ...pending.map((project) => () => hydrateProject(project, epoch)),
+    ],
     epoch,
   );
 }
@@ -554,6 +564,7 @@ export function initNavigation(
   unsubs = [];
   activeClient = client;
   bootEpoch++;
+  manifestFanout = null;
   const epoch = bootEpoch;
   const ownedClient = client;
   const start = (info?: InitializeResponse | NavigationCapability | null) => {
@@ -572,7 +583,13 @@ export function initNavigation(
     void boot(cap, epoch, ownedClient);
   };
   revalidator = new NavigationRevalidator();
-  unsubs.push(revalidator.subscribe((state) => setResource(state, ownedClient, epoch)));
+  unsubs.push(
+    revalidator.subscribe((state) => {
+      if (ownedClient !== activeClient || epoch !== bootEpoch) return;
+      publishResourceState(state);
+      coordinateManifestState(state, epoch);
+    }),
+  );
   unsubs.push(
     client.onNotification((n) => {
       if (ownedClient !== activeClient || epoch !== bootEpoch) return;
@@ -650,6 +667,7 @@ export function initNavigation(
       revalidator = null;
       activeClient = null;
       bootStartedEpoch = -1;
+      manifestFanout = null;
     }
   };
 }
@@ -663,5 +681,6 @@ export function resetNavigationStoreForTests(): void {
   revalidator = null;
   activeClient = null;
   bootStartedEpoch = -1;
+  manifestFanout = null;
   navigationStore.setState({ ...initial(), ...actions() });
 }

--- a/cmd/evener-hub/internal/hubcore/tree.go
+++ b/cmd/evener-hub/internal/hubcore/tree.go
@@ -704,11 +704,62 @@ func resolveProjectMap(metas []schema.SessionMeta, live []LiveEntry, strict bool
 	return projects, nil
 }
 
+// treeMetasWithLive combines indexed metadata with live-only project sessions.
+func treeMetasWithLive(metas []schema.SessionMeta, live []LiveEntry, now time.Time, resolvedProjects map[string]identifier.Project) ([]schema.SessionMeta, map[string]bool) {
+	effectiveMetas := append([]schema.SessionMeta(nil), metas...)
+	sessionIsIndexed := make(map[string]bool, len(metas))
+	for _, m := range effectiveMetas {
+		if m.ID == "" {
+			continue
+		}
+		sessionIsIndexed[m.ID] = true
+	}
+	// A newly-created daemon can appear in the roster before the past index's
+	// next rebuild. Give live sessions with a resolved project identity a
+	// temporary metadata record so they still populate that project's catalog.
+	// Pathless and unresolved live sessions remain in the flat Live tier until
+	// they acquire metadata or a project identity.
+	for _, le := range live {
+		if le.SessionID == "" || le.WorkingDir == "" {
+			continue
+		}
+		if _, resolved := resolvedProjects[le.WorkingDir]; !resolved {
+			continue
+		}
+		if _, exists := sessionIsIndexed[le.SessionID]; exists {
+			continue
+		}
+		startedAt := le.StartedAt
+		if startedAt.IsZero() {
+			startedAt = now
+		}
+		effectiveMetas = append(effectiveMetas, schema.SessionMeta{
+			ID:        le.SessionID,
+			CreatedAt: startedAt,
+			UpdatedAt: startedAt,
+			EnvInfo:   schema.EnvironmentInfo{WorkingDir: le.WorkingDir},
+		})
+		sessionIsIndexed[le.SessionID] = false
+	}
+	return effectiveMetas, sessionIsIndexed
+}
+
+func projectKeyForPath(path string, resolvedProjects map[string]identifier.Project) string {
+	if project := resolvedProjects[path]; project.ID != "" {
+		return project.ID
+	}
+	return "no-project"
+}
+
 // BuildTreeAtWithProjects assembles a tree using projects resolved by the
 // caller. The map is keyed by EffectiveWorkingDir; it prevents resolver calls
 // from leaking into grouping/sorting helpers.
 func BuildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decisions map[ArchiveKey]bool, now time.Time, resolvedProjects map[string]identifier.Project) Tree {
-	metas = append([]schema.SessionMeta(nil), metas...)
+	effectiveMetas, sessionIsIndexed := treeMetasWithLive(metas, live, now, resolvedProjects)
+	return buildTreeAtWithProjects(effectiveMetas, live, decisions, now, resolvedProjects, sessionIsIndexed)
+}
+
+func buildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decisions map[ArchiveKey]bool, now time.Time, resolvedProjects map[string]identifier.Project, sessionIsIndexed map[string]bool) Tree {
 	sort.SliceStable(metas, func(i, j int) bool {
 		return sessionMetaLess(metas[i], metas[j])
 	})
@@ -795,12 +846,19 @@ func BuildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decis
 	// AcceptedInputTurns was persisted still carries a TurnCount, so it is
 	// never mislabelled; and a session whose first turn is in flight, or which
 	// failed before any response, carries an accepted input, so the row never
-	// denies that the user asked it something. A session with no meta at all
-	// (a live entry the past index has not caught up with) reports false: the
-	// claim is only ever made from evidence.
+	// denies that the user asked it something. A synthetic live-only meta (or a
+	// live entry the past index has not caught up with) reports false: the claim
+	// is only ever made from indexed evidence.
 	dormantFor := func(id string) bool {
 		m, ok := metaMap[id]
-		return ok && m.TurnCount == 0 && m.AcceptedInputTurns == 0
+		if !ok {
+			return false
+		}
+		indexed, known := sessionIsIndexed[id]
+		if !known || !indexed {
+			return false
+		}
+		return m.TurnCount == 0 && m.AcceptedInputTurns == 0
 	}
 
 	// Group metas by canonical project identity while preserving each record's
@@ -1143,14 +1201,7 @@ func BuildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decis
 		if le.SessionID == "" {
 			continue
 		}
-		// Find the meta for this live entry.
-		var meta *schema.SessionMeta
-		for i := range metas {
-			if metas[i].ID == le.SessionID {
-				meta = &metas[i]
-				break
-			}
-		}
+		metaValue, hasMeta := metaMap[le.SessionID]
 		state := stateFor(le.SessionID)
 		node := TreeNode{
 			ID:         le.SessionID,
@@ -1159,13 +1210,13 @@ func BuildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decis
 			Dormant:    dormantFor(le.SessionID),
 			Kind:       "session",
 		}
-		if meta != nil {
-			kind := nodeKind(*meta)
+		if hasMeta {
+			kind := nodeKind(metaValue)
 			node.Kind = kind
-			node.Title = nodeTitle(*meta, kind)
-			node.Project = projectName(*meta)
-			node.CreatedAt = OrderCreatedAt(meta.CreatedAt, meta.UpdatedAt)
-			node.UpdatedAt = OrderUpdatedAt(meta.UpdatedAt, meta.CreatedAt)
+			node.Title = nodeTitle(metaValue, kind)
+			node.Project = projectName(metaValue)
+			node.CreatedAt = OrderCreatedAt(metaValue.CreatedAt, metaValue.UpdatedAt)
+			node.UpdatedAt = OrderUpdatedAt(metaValue.UpdatedAt, metaValue.CreatedAt)
 			node.Age = AgeString(node.UpdatedAt)
 		} else {
 			node.Title = ShortID(le.SessionID)
@@ -1234,12 +1285,10 @@ func BuildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decis
 		if lvl := promotedAttentionLevel(st, le.PendingEscalation); lvl != "needs_you" && lvl != "error" {
 			continue
 		}
+		metaValue, hasMeta := metaMap[le.SessionID]
 		var meta *schema.SessionMeta
-		for i := range metas {
-			if metas[i].ID == le.SessionID {
-				meta = &metas[i]
-				break
-			}
+		if hasMeta {
+			meta = &metaValue
 		}
 		// Same tierEligible call attention.go's AttentionSummary uses for its
 		// own inclusion check: only top-level (not a subagent, not a
@@ -1305,15 +1354,17 @@ func BuildProjectTree(metas []schema.SessionMeta, live []LiveEntry, decisions ma
 }
 
 // BuildProjectTreeAt is BuildProjectTree with an injected clock. It filters the
-// metas to the requested canonical project ID, runs the normal tree build on
-// that subset, and returns the resulting TreeProject (searching both the active
-// and archived lists). Explicit parent lineage determines a subagent's project,
-// even when the subagent runs from another effective directory. ok is false
-// when no project with that ID exists.
+// effective metadata to the requested canonical project ID, runs the normal
+// tree build on that subset, and returns the resulting TreeProject (searching
+// both the active and archived lists). Explicit parent lineage determines a
+// subagent's project, even when the subagent runs from another effective
+// directory. A project with only a live session is also eligible before its
+// metadata reaches the index. ok is false when no project with that ID exists.
 func BuildProjectTreeAt(metas []schema.SessionMeta, live []LiveEntry, decisions map[ArchiveKey]bool, now time.Time, projectID string) (TreeProject, bool) {
 	resolvedProjects := ResolveProjectMap(metas, live)
-	metaByID := make(map[string]schema.SessionMeta, len(metas))
-	for _, m := range metas {
+	effectiveMetas, sessionIsIndexed := treeMetasWithLive(metas, live, now, resolvedProjects)
+	metaByID := make(map[string]schema.SessionMeta, len(effectiveMetas))
+	for _, m := range effectiveMetas {
 		if m.ID != "" {
 			metaByID[m.ID] = m
 		}
@@ -1328,14 +1379,10 @@ func BuildProjectTreeAt(metas []schema.SessionMeta, live []LiveEntry, decisions 
 			seen[parent.ID] = true
 			m = parent
 		}
-		key := "no-project"
-		if project := resolvedProjects[EffectiveWorkingDir(m)]; project.ID != "" {
-			key = project.ID
-		}
-		return key == projectID
+		return projectKeyForPath(EffectiveWorkingDir(m), resolvedProjects) == projectID
 	}
-	subset := make([]schema.SessionMeta, 0, len(metas))
-	for _, m := range metas {
+	subset := make([]schema.SessionMeta, 0, len(effectiveMetas))
+	for _, m := range effectiveMetas {
 		if belongsToProject(m) {
 			subset = append(subset, m)
 		}
@@ -1343,7 +1390,7 @@ func BuildProjectTreeAt(metas []schema.SessionMeta, live []LiveEntry, decisions 
 	if len(subset) == 0 {
 		return TreeProject{}, false
 	}
-	tree := BuildTreeAtWithProjects(subset, live, decisions, now, resolvedProjects)
+	tree := buildTreeAtWithProjects(subset, live, decisions, now, resolvedProjects, sessionIsIndexed)
 	for _, p := range tree.Projects {
 		if p.Key == projectID {
 			return p, true

--- a/cmd/evener-hub/web_api_tree_test.go
+++ b/cmd/evener-hub/web_api_tree_test.go
@@ -205,8 +205,7 @@ func TestAPISessionDetailCarriesWorkMetricsForEndedSession(t *testing.T) {
 	}
 }
 
-func TestOrphanLiveGroupingUsesCanonicalProjectID(t *testing.T) {
-	t.Skip("orphan-live project grouping is covered by navigation projection tests; this unit test's project discovery depends on a seeded past index that the /api/tree retirement removed")
+func TestLiveSessionGroupsBeforePastIndex(t *testing.T) {
 	projectDir := filepath.Join(t.TempDir(), "foo")
 	if err := os.MkdirAll(projectDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -221,15 +220,21 @@ func TestOrphanLiveGroupingUsesCanonicalProjectID(t *testing.T) {
 	web := NewWebServer(hubcore.WebConfig{Past: hubcore.NewPastIndex(""), Roster: roster})
 	_, live, projects := web.navigationTreeInputs(context.Background())
 	tree := hubBuildNavigationTree(nil, live, map[hubcore.ArchiveKey]bool{}, projects)
-	// The orphan-live session must group under the canonical project ID.
-	found := false
-	for _, p := range tree.Projects {
-		if p.Key == project.ID {
-			found = true
-		}
+	if len(tree.Projects) != 1 {
+		t.Fatalf("projects = %d, want 1: %+v", len(tree.Projects), tree.Projects)
 	}
-	if !found {
-		t.Fatalf("orphan-live must use the canonical project ID; got %+v", tree.Projects)
+	if tree.Projects[0].Key != project.ID {
+		t.Fatalf("project key = %q, want canonical ID %q", tree.Projects[0].Key, project.ID)
+	}
+	if sessions := tree.Projects[0].Current; len(sessions) != 1 || sessions[0].ID != "01L" {
+		t.Fatalf("current sessions = %+v, want the live session", sessions)
+	}
+	lazy, ok := hubcore.BuildProjectTreeAt(nil, live, map[hubcore.ArchiveKey]bool{}, time.Now(), project.ID)
+	if !ok {
+		t.Fatalf("lazy project lookup did not find live project %q", project.ID)
+	}
+	if sessions := lazy.Current; len(sessions) != 1 || sessions[0].ID != "01L" {
+		t.Fatalf("lazy current sessions = %+v, want the live session", sessions)
 	}
 }
 


### PR DESCRIPTION
## Summary

- include resolved live sessions in the project tree before PastIndex catches up
- hydrate resources revealed by a later navigation manifest revision
- keep synthetic live-only rows conservative until indexed metadata exists

This fixes the installed-hub behavior where a newly-created session appeared in Live but not under Projects, and where a zero-count startup manifest prevented the sidebar from refreshing without a full reload.

## Verification

- `make lint`
- `make vet`
- `make test`
- `make test-web`
- focused hubcore/hub and navigation-store regression tests

The live Linux host supplied for diagnosis was still running an older dirty build; this PR contains the fix.