### PR TITLE
feat: expose skills as inline slash mentions

### DIFF
--- a/agent/plugin/plugin.go
+++ b/agent/plugin/plugin.go
@@ -274,6 +274,38 @@ func Load(dir string) (Instance, error) {
 	return lp, nil
 }
 
+// ManifestName resolves and validates only a plugin manifest. Batch callers
+// use it to apply the same first-manifest-wins duplicate policy before any
+// component loader runs, including callers that intentionally load skills
+// without agents, commands, hooks, or MCP configuration.
+func ManifestName(dir string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolving plugin dir %q: %w", dir, err)
+	}
+	resolved, err = pluginAbs(resolved)
+	if err != nil {
+		return "", fmt.Errorf("resolving plugin dir %q: %w", dir, err)
+	}
+
+	manifestPath := filepath.Join(resolved, ".claude-plugin", "plugin.json")
+	if _, err := pluginStat(manifestPath); err != nil {
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("reading plugin manifest %q: %w", manifestPath, err)
+		}
+		manifestPath = filepath.Join(resolved, ".codex-plugin", "plugin.json")
+	}
+	data, err := pluginReadFile(manifestPath)
+	if err != nil {
+		return "", fmt.Errorf("reading plugin manifest %q: %w", manifestPath, err)
+	}
+	manifest, err := ParseManifest(data)
+	if err != nil {
+		return "", fmt.Errorf("in plugin at %q: %w", resolved, err)
+	}
+	return manifest.Name, nil
+}
+
 // LoadAll loads plugins from multiple directories and checks for
 // duplicate plugin names.
 func LoadAll(dirs []string) ([]Instance, error) {
@@ -305,9 +337,12 @@ type SkippedPlugin struct {
 
 // LoadAllFailSoft loads each directory in dirs independently, the same way
 // LoadAll does, but never aborts the batch: a directory that fails to load or
-// duplicates an already-loaded plugin's name is recorded in the returned
-// skipped slice and passed over, instead of failing every other directory
-// too. Use this in batch contexts — session init, the hub's command catalog —
+// duplicates an already-selected plugin manifest name is recorded in the
+// returned skipped slice and passed over, instead of failing every other
+// directory too. Duplicate selection is first-manifest-wins, even when that
+// first plugin later fails an unrelated component load; this gives all batch
+// callers a deterministic selection policy that skill-only readers can share.
+// Use this in batch contexts — session init, the hub's command catalog —
 // where one broken or duplicate directory must not brick everything else;
 // callers that want LoadAll's fail-hard, abort-on-first-error behavior (e.g.
 // an explicit single-plugin install/validate operation) should keep using
@@ -318,6 +353,23 @@ func LoadAllFailSoft(dirs []string) ([]Instance, []SkippedPlugin) {
 	var skipped []SkippedPlugin
 
 	for _, dir := range dirs {
+		manifestName, err := ManifestName(dir)
+		if err != nil {
+			skipped = append(skipped, SkippedPlugin{
+				Dir:    dir,
+				Reason: fmt.Sprintf("skipping broken plugin at %q: %v", dir, err),
+			})
+			continue
+		}
+		if prevDir, ok := seen[manifestName]; ok {
+			skipped = append(skipped, SkippedPlugin{
+				Dir:    dir,
+				Name:   manifestName,
+				Reason: fmt.Sprintf("skipping duplicate plugin name %q at %q (already selected from %q)", manifestName, dir, prevDir),
+			})
+			continue
+		}
+		seen[manifestName] = dir
 		lp, err := Load(dir)
 		if err != nil {
 			skipped = append(skipped, SkippedPlugin{
@@ -326,15 +378,6 @@ func LoadAllFailSoft(dirs []string) ([]Instance, []SkippedPlugin) {
 			})
 			continue
 		}
-		if prevDir, ok := seen[lp.Manifest.Name]; ok {
-			skipped = append(skipped, SkippedPlugin{
-				Dir:    lp.Dir,
-				Name:   lp.Manifest.Name,
-				Reason: fmt.Sprintf("skipping duplicate plugin name %q at %q (already loaded from %q)", lp.Manifest.Name, lp.Dir, prevDir),
-			})
-			continue
-		}
-		seen[lp.Manifest.Name] = lp.Dir
 		plugins = append(plugins, lp)
 	}
 	return plugins, skipped

--- a/agent/plugin_selection_snapshot_test.go
+++ b/agent/plugin_selection_snapshot_test.go
@@ -143,7 +143,7 @@ func TestPluginSelectionExcludedContributionsDoNotInitialize(t *testing.T) {
 	}
 	selectedSkill := false
 	for _, skill := range ds.Skills {
-		if skill.Name == "one" {
+		if skill.Name == "selected:one" {
 			selectedSkill = true
 		}
 		if skill.Name == "excluded:one" {

--- a/agent/prompts/sections/skills.md.tmpl
+++ b/agent/prompts/sections/skills.md.tmpl
@@ -1,5 +1,5 @@
 {{ if .Skills }}<skill-catalog>
-{{ if .HasUseSkill }}Load a skill by calling use_skill with its name. The response includes the skill directory path for accessing scripts and other collateral.
+{{ if .HasUseSkill }}Load a skill by calling use_skill with its name. The response includes the skill directory path for accessing scripts and other collateral. Treat a slash token matching a canonical catalog name as a skill request only when it starts at message start or after whitespace and ends at message end or before whitespace, including inline prose; call use_skill with the exact catalog key before acting. Ignore paths, URLs, code or literal/negated mentions, and unknown names.
 {{ else }}Load a skill by reading its SKILL.md file path with read_file. The skill directory may contain scripts and other collateral.
 {{ end }}{{ range .Skills }}{{ if $.HasUseSkill }}- {{ .CatalogNameOrName }}: {{ .Description }} [{{ .Dir }}]
 {{ else }}- {{ .CatalogNameOrName }}: {{ .Description }} [{{ .SkillFile }}]

--- a/agent/session_prompts.go
+++ b/agent/session_prompts.go
@@ -159,14 +159,6 @@ func (s *Session) buildPromptData(env execenv.ExecutionEnvironment) promptData {
 	}
 
 	// Skills
-	hasUseSkill := false
-	for _, td := range s.profile.ToolDefinitions() {
-		if td.Name == "use_skill" {
-			hasUseSkill = true
-			break
-		}
-	}
-	data.HasUseSkill = hasUseSkill
 	for skillName, sm := range s.skills {
 		data.Skills = append(data.Skills, skillEntry{
 			Name: sm.Name, CatalogName: skillName, Description: sm.Description,
@@ -181,6 +173,7 @@ func (s *Session) buildPromptData(env execenv.ExecutionEnvironment) promptData {
 	// Prompting with canonical names while the API receives mapped names such as
 	// exec_command/grep_files/find_files is contradictory and confuses tool use.
 	actualDefs := append([]llm.ToolDefinition(nil), s.cachedToolDefs...)
+	data.HasUseSkill = toolNameSetFromDefinitions(actualDefs)["use_skill"]
 	data.CallableToolNames = toolNamesFromDefinitions(actualDefs)
 	data.UnavailableProfileToolNames = unavailableToolNames(profileDefs, actualDefs)
 

--- a/agent/session_skills_test.go
+++ b/agent/session_skills_test.go
@@ -26,6 +26,20 @@ func useSkillCall(id, skillName string) llm.ToolCallData {
 	}
 }
 
+func TestBuildPromptDataHasUseSkillTracksCallableDefinitions(t *testing.T) {
+	t.Parallel()
+	s := newTestSession(t)
+	s.cachedToolDefs = []llm.ToolDefinition{{Name: "read_file"}}
+	if s.buildPromptData(s.currentEnv()).HasUseSkill {
+		t.Fatal("unavailable use_skill was advertised")
+	}
+
+	s.cachedToolDefs = []llm.ToolDefinition{{Name: "read_file"}, {Name: "use_skill"}}
+	if !s.buildPromptData(s.currentEnv()).HasUseSkill {
+		t.Fatal("callable use_skill was not advertised")
+	}
+}
+
 // use_skill tests exercise provider profiles that expose the use_skill tool.
 
 func TestUseSkill_ReturnsBody(t *testing.T) {
@@ -82,6 +96,85 @@ func TestUseSkill_ReturnsBody(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected skill body 'Greet people warmly' in tool result of second request")
+	}
+}
+
+func TestUseSkill_InlineMentionPreservesUserInput(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	markGitRoot(t, root)
+	writeSkillMD(t, root, "greet", "---\nname: greet\ndescription: \"Greeting skill\"\n---\nGreet people warmly.\n")
+
+	c := llm.NewClient()
+	skillCall := useSkillCall("s1", "greet")
+	comm := communicateCall("c1", "done")
+	adapter := &fakeAdapter{
+		name: "anthropic",
+		steps: []func(req llm.Request) llm.Response{
+			func(req llm.Request) llm.Response { return toolCallResponse(skillCall) },
+			func(req llm.Request) llm.Response { return toolCallResponse(comm) },
+		},
+	}
+	c.Register(adapter)
+
+	sess, err := NewSession(c, newAnthropicProfile("claude-test"), execenv.NewLocalExecutionEnvironment(root), SessionConfig{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+
+	var eventsSeen []events.SessionEvent
+	eventsDone := make(chan struct{})
+	go func() {
+		defer close(eventsDone)
+		for ev := range sess.Events() {
+			eventsSeen = append(eventsSeen, ev)
+		}
+	}()
+
+	input := "Please use /greet for Jesse"
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	defer cancel()
+	if _, err := sess.ProcessInput(ctx, input, nil); err != nil {
+		t.Fatalf("ProcessInput: %v", err)
+	}
+	sess.Close()
+	<-eventsDone
+
+	var userInputs []string
+	for _, ev := range eventsSeen {
+		if ev.Kind != events.EventUserInput {
+			continue
+		}
+		data, ok := ev.Data.(events.UserInputData)
+		if ok {
+			userInputs = append(userInputs, data.Text)
+		}
+	}
+	if len(userInputs) != 1 || userInputs[0] != input {
+		t.Fatalf("user input events = %q, want complete sentence %q", userInputs, input)
+	}
+	if strings.Contains(userInputs[0], "Greet people warmly.") {
+		t.Fatal("inline mention expanded the skill body before the model turn")
+	}
+
+	requests := adapter.Requests()
+	if len(requests) < 2 {
+		t.Fatalf("expected tool follow-up request, got %d requests", len(requests))
+	}
+	foundSkillBody := false
+	for _, msg := range requests[1].Messages {
+		for _, part := range msg.Content {
+			if part.Kind != llm.ContentToolResult {
+				continue
+			}
+			content, _ := part.ToolResult.Content.(string)
+			if strings.Contains(content, "Greet people warmly.") {
+				foundSkillBody = true
+			}
+		}
+	}
+	if !foundSkillBody {
+		t.Fatal("scripted inline use_skill call did not return the skill body")
 	}
 }
 

--- a/agent/session_skills_test.go
+++ b/agent/session_skills_test.go
@@ -85,6 +85,31 @@ func TestUseSkill_ReturnsBody(t *testing.T) {
 	}
 }
 
+func TestStandaloneSkillActivationUsesCanonicalPluginName(t *testing.T) {
+	s := newTestSession(t)
+	s.skills = map[string]skill.SkillMeta{
+		"plugin:simplify": {Name: "simplify", SkillFile: writeSkillBodyFile(t, "plugin steps")},
+	}
+	_ = drainSlashEvents(s)
+
+	got, ok := s.expandSlashCommand(context.Background(), "/plugin:simplify")
+	if !ok || got != "plugin steps" {
+		t.Fatalf("expanded = %q, %v; want plugin skill body", got, ok)
+	}
+	var activated []string
+	for _, ev := range drainSlashEvents(s) {
+		if ev.Kind != events.EventSkillActivated {
+			continue
+		}
+		if data, ok := ev.Data.(events.SkillActivatedData); ok {
+			activated = append(activated, data.Name)
+		}
+	}
+	if len(activated) != 1 || activated[0] != "plugin:simplify" {
+		t.Fatalf("activation names = %v, want [plugin:simplify]", activated)
+	}
+}
+
 func TestUseSkill_NotFound_ReturnsError(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()

--- a/agent/session_skills_test.go
+++ b/agent/session_skills_test.go
@@ -28,16 +28,49 @@ func useSkillCall(id, skillName string) llm.ToolCallData {
 
 func TestBuildPromptDataHasUseSkillTracksCallableDefinitions(t *testing.T) {
 	t.Parallel()
-	s := newTestSession(t)
-	s.cachedToolDefs = []llm.ToolDefinition{{Name: "read_file"}}
-	if s.buildPromptData(s.currentEnv()).HasUseSkill {
-		t.Fatal("unavailable use_skill was advertised")
+	for _, tc := range []struct {
+		name   string
+		keep   []string
+		legacy bool
+		want   bool
+	}{
+		{name: "legacy uninitialized cache", legacy: true},
+		{name: "empty final cache"},
+		{name: "restricted final cache", keep: []string{"read_file"}},
+		{name: "callable final cache", keep: []string{"use_skill"}, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestSession(t)
+			if tc.legacy {
+				// A pre-cache/legacy session has no final definitions. This is the
+				// only direct assignment here; the other cases exercise the real
+				// registry restriction and rebuildToolDefsCache lifecycle below.
+				s.cachedToolDefs = nil
+			} else {
+				rebuildPromptToolCacheForTest(s, tc.keep...)
+			}
+			if got := s.buildPromptData(s.currentEnv()).HasUseSkill; got != tc.want {
+				t.Fatalf("HasUseSkill = %v, want %v", got, tc.want)
+			}
+		})
 	}
+}
 
-	s.cachedToolDefs = []llm.ToolDefinition{{Name: "read_file"}, {Name: "use_skill"}}
-	if !s.buildPromptData(s.currentEnv()).HasUseSkill {
-		t.Fatal("callable use_skill was not advertised")
+// rebuildPromptToolCacheForTest models the production final-tool restriction
+// boundary: restrict the initialized registry, then rebuild the cached provider
+// definitions that are sent to the model. HasUseSkill must follow this cache,
+// not the profile's larger initial definition set.
+func rebuildPromptToolCacheForTest(s *Session, keep ...string) {
+	allowed := make(map[string]bool, len(keep))
+	for _, name := range keep {
+		allowed[name] = true
 	}
+	for name := range s.reg.RegisteredNames() {
+		if !allowed[name] {
+			s.reg.Remove(name)
+		}
+	}
+	s.rebuildToolDefsCache()
 }
 
 // use_skill tests exercise provider profiles that expose the use_skill tool.
@@ -105,6 +138,8 @@ func TestUseSkill_InlineMentionPreservesUserInput(t *testing.T) {
 	markGitRoot(t, root)
 	writeSkillMD(t, root, "greet", "---\nname: greet\ndescription: \"Greeting skill\"\n---\nGreet people warmly.\n")
 
+	input := "Please use /greet for Jesse"
+	skillBody := "Greet people warmly."
 	c := llm.NewClient()
 	skillCall := useSkillCall("s1", "greet")
 	comm := communicateCall("c1", "done")
@@ -131,7 +166,6 @@ func TestUseSkill_InlineMentionPreservesUserInput(t *testing.T) {
 		}
 	}()
 
-	input := "Please use /greet for Jesse"
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
 	defer cancel()
 	if _, err := sess.ProcessInput(ctx, input, nil); err != nil {
@@ -161,6 +195,19 @@ func TestUseSkill_InlineMentionPreservesUserInput(t *testing.T) {
 	if len(requests) < 2 {
 		t.Fatalf("expected tool follow-up request, got %d requests", len(requests))
 	}
+	var requestUserTexts []string
+	for _, msg := range requests[0].Messages {
+		if msg.Role == llm.RoleUser {
+			requestUserTexts = append(requestUserTexts, msg.Text())
+		}
+	}
+	if len(requestUserTexts) == 0 || requestUserTexts[len(requestUserTexts)-1] != input {
+		t.Fatalf("provider user messages = %q, want final message exactly %q", requestUserTexts, input)
+	}
+	if strings.Contains(requestUserTexts[len(requestUserTexts)-1], skillBody) {
+		t.Fatal("provider request expanded the inline skill body before the model turn")
+	}
+
 	foundSkillBody := false
 	for _, msg := range requests[1].Messages {
 		for _, part := range msg.Content {

--- a/agent/session_slash_command.go
+++ b/agent/session_slash_command.go
@@ -4,17 +4,18 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"primeradiant.com/evener/agent/command"
 	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/plugin"
+	"primeradiant.com/evener/agent/skill"
 )
 
-// expandSlashCommand checks whether input invokes a loaded slash command — a
-// leading "/" followed by a command name known to s.pluginCommands — and, if
-// so, returns the expanded command body as the replacement input (ok=true).
+// expandSlashCommand checks whether input invokes a loaded slash command or
+// skill and, if so, returns its body as the replacement input (ok=true).
 // Anything else (plain chat text, or a "/"-prefixed word that names no loaded
-// command, e.g. a client-side-only UI command like /model) is returned
+// command or skill, e.g. a client-side-only UI command like /model) is returned
 // unchanged with ok=false, so the caller leaves input untouched and it flows
 // on as ordinary text.
 func (s *Session) expandSlashCommand(ctx context.Context, input string) (string, bool) {
@@ -22,31 +23,51 @@ func (s *Session) expandSlashCommand(ctx context.Context, input string) (string,
 	if !strings.HasPrefix(trimmed, "/") {
 		return input, false
 	}
-	name, args, _ := strings.Cut(trimmed[1:], " ")
+	commandInput := strings.TrimLeftFunc(trimmed[1:], unicode.IsSpace)
+	name := commandInput
+	args := ""
+	if i := strings.IndexFunc(commandInput, unicode.IsSpace); i >= 0 {
+		name, args = commandInput[:i], strings.TrimSpace(commandInput[i:])
+	}
 	if name == "" {
 		return input, false
 	}
-	cmd, ok := plugin.ResolveCommand(s.pluginCommands, name)
+	if cmd, ok := plugin.ResolveCommand(s.pluginCommands, name); ok {
+		if cmd.Source != "plugin" {
+			// Evener-wide commands expand inert: arguments substitute as text,
+			// nothing executes or reads (docs/skills.md).
+			return command.ExpandArgs(cmd.Body, args), true
+		}
+		expanded, err := command.Expand(ctx, cmd.Body, args, s.currentEnv())
+		if err != nil {
+			// A genuine Expand failure (as opposed to "not a plugin command",
+			// handled above) must not fail silently: without this, the user's
+			// "/name args" was submitted to the model as literal text with no
+			// indication their command never expanded. Still fall back to that
+			// literal-text submission (ok=false) — surfacing the failure doesn't
+			// mean blocking the input — but now with a visible warning.
+			s.emit(events.EventWarning, events.WarningData{
+				Message: fmt.Sprintf("expanding slash command /%s failed: %v", name, err),
+			})
+			return input, false
+		}
+		return expanded, true
+	}
+
+	catalogName, meta, ok := skill.ResolveSkill(s.skills, name)
 	if !ok {
 		return input, false
 	}
-	if cmd.Source != "plugin" {
-		// Evener-wide commands expand inert: arguments substitute as text,
-		// nothing executes or reads (docs/skills.md).
-		return command.ExpandArgs(cmd.Body, strings.TrimSpace(args)), true
-	}
-	expanded, err := command.Expand(ctx, cmd.Body, strings.TrimSpace(args), s.currentEnv())
+	body, err := skill.LoadSkillBody(meta)
 	if err != nil {
-		// A genuine Expand failure (as opposed to "not a plugin command",
-		// handled above) must not fail silently: without this, the user's
-		// "/name args" was submitted to the model as literal text with no
-		// indication their command never expanded. Still fall back to that
-		// literal-text submission (ok=false) — surfacing the failure doesn't
-		// mean blocking the input — but now with a visible warning.
 		s.emit(events.EventWarning, events.WarningData{
-			Message: fmt.Sprintf("expanding slash command /%s failed: %v", name, err),
+			Message: fmt.Sprintf("loading slash skill /%s failed: %v", name, err),
 		})
 		return input, false
 	}
-	return expanded, true
+	s.emit(events.EventSkillActivated, events.SkillActivatedData{Name: catalogName})
+	if args != "" {
+		body += "\n\nUser context:\n" + args
+	}
+	return body, true
 }

--- a/agent/session_slash_command_test.go
+++ b/agent/session_slash_command_test.go
@@ -11,8 +11,180 @@ import (
 	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/plugin"
+	"primeradiant.com/evener/agent/skill"
 	"primeradiant.com/evener/llm"
 )
+
+func writeSkillBodyFile(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "SKILL.md")
+	if err := os.WriteFile(path, []byte("---\nname: simplify\ndescription: test\n---\n"+body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func drainSlashEvents(s *Session) []events.SessionEvent {
+	var got []events.SessionEvent
+	for {
+		select {
+		case ev := <-s.Events():
+			got = append(got, ev)
+		default:
+			return got
+		}
+	}
+}
+
+func TestExpandSlashCommandStandaloneSkillResolution(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		skills     map[string]skill.SkillMeta
+		want       string
+		wantOK     bool
+		wantActive string
+	}{
+		{
+			name:  "body and context",
+			input: "/simplify this diff",
+			skills: map[string]skill.SkillMeta{
+				"simplify": {Name: "simplify", SkillFile: writeSkillBodyFile(t, "follow these steps")},
+			},
+			want:       "follow these steps\n\nUser context:\nthis diff",
+			wantOK:     true,
+			wantActive: "simplify",
+		},
+		{
+			name:  "plugin qualified",
+			input: "/plugin:simplify",
+			skills: map[string]skill.SkillMeta{
+				"plugin:simplify": {Name: "simplify", SkillFile: writeSkillBodyFile(t, "plugin steps")},
+			},
+			want:       "plugin steps",
+			wantOK:     true,
+			wantActive: "plugin:simplify",
+		},
+		{
+			name:  "tabs and newlines around context",
+			input: " \n/simplify \t this diff \n ",
+			skills: map[string]skill.SkillMeta{
+				"simplify": {Name: "simplify", SkillFile: writeSkillBodyFile(t, "follow these steps")},
+			},
+			want:       "follow these steps\n\nUser context:\nthis diff",
+			wantOK:     true,
+			wantActive: "simplify",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestSession(t)
+			s.skills = tt.skills
+			_ = drainSlashEvents(s)
+
+			got, ok := s.expandSlashCommand(context.Background(), tt.input)
+			if ok != tt.wantOK || got != tt.want {
+				t.Fatalf("expanded = %q, %v; want %q, %v", got, ok, tt.want, tt.wantOK)
+			}
+			var activated []string
+			for _, ev := range drainSlashEvents(s) {
+				if ev.Kind != events.EventSkillActivated {
+					continue
+				}
+				data, ok := ev.Data.(events.SkillActivatedData)
+				if ok {
+					activated = append(activated, data.Name)
+				}
+			}
+			if len(activated) != 1 || activated[0] != tt.wantActive {
+				t.Fatalf("activation names = %v, want [%q]", activated, tt.wantActive)
+			}
+		})
+	}
+}
+
+func TestExpandSlashCommandStandalonePreservesCommandPrecedence(t *testing.T) {
+	s := newTestSession(t)
+	s.skills = map[string]skill.SkillMeta{
+		"review": {Name: "review", SkillFile: writeSkillBodyFile(t, "skill body")},
+	}
+	s.pluginCommands = map[string]plugin.Command{
+		"review": {Name: "review", Body: "command $ARGUMENTS", Source: "project"},
+	}
+	_ = drainSlashEvents(s)
+
+	got, ok := s.expandSlashCommand(context.Background(), "/review diff")
+	if !ok || got != "command diff" {
+		t.Fatalf("expanded = %q, %v; want command expansion", got, ok)
+	}
+	for _, ev := range drainSlashEvents(s) {
+		if ev.Kind == events.EventSkillActivated {
+			t.Fatal("command precedence emitted a skill activation")
+		}
+	}
+}
+
+func TestExpandSlashCommandStandaloneUnknownAndAmbiguousFallThrough(t *testing.T) {
+	tests := []struct {
+		name   string
+		skills map[string]skill.SkillMeta
+		input  string
+	}{
+		{name: "unknown", skills: nil, input: "/missing context"},
+		{
+			name: "ambiguous suffix",
+			skills: map[string]skill.SkillMeta{
+				"one:review": {Name: "review", SkillFile: writeSkillBodyFile(t, "one")},
+				"two:review": {Name: "review", SkillFile: writeSkillBodyFile(t, "two")},
+			},
+			input: "/review context",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestSession(t)
+			s.skills = tt.skills
+			_ = drainSlashEvents(s)
+			got, ok := s.expandSlashCommand(context.Background(), tt.input)
+			if ok || got != tt.input {
+				t.Fatalf("expanded = %q, %v; want unchanged input", got, ok)
+			}
+			for _, ev := range drainSlashEvents(s) {
+				if ev.Kind == events.EventSkillActivated {
+					t.Fatal("fall-through emitted a skill activation")
+				}
+			}
+		})
+	}
+}
+
+func TestExpandSlashCommandStandaloneBodyLoadFailureWarnsWithoutActivation(t *testing.T) {
+	s := newTestSession(t)
+	s.skills = map[string]skill.SkillMeta{
+		"simplify": {Name: "simplify", SkillFile: filepath.Join(t.TempDir(), "missing", "SKILL.md")},
+	}
+	_ = drainSlashEvents(s)
+
+	got, ok := s.expandSlashCommand(context.Background(), "/simplify context")
+	if ok || got != "/simplify context" {
+		t.Fatalf("expanded = %q, %v; want unchanged input", got, ok)
+	}
+	var warned bool
+	for _, ev := range drainSlashEvents(s) {
+		if ev.Kind == events.EventSkillActivated {
+			t.Fatal("failed skill load emitted an activation")
+		}
+		if ev.Kind == events.EventWarning {
+			if data, ok := ev.Data.(events.WarningData); ok && strings.Contains(data.Message, "loading slash skill /simplify failed") {
+				warned = true
+			}
+		}
+	}
+	if !warned {
+		t.Fatal("failed skill load did not emit a warning")
+	}
+}
 
 // writeEvenerwideCommandFile creates <workDir>/.evener/commands/<name>.md.
 func writeEvenerwideCommandFile(t *testing.T, workDir, name, content string) {

--- a/agent/skill/skills.go
+++ b/agent/skill/skills.go
@@ -4,11 +4,21 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strings"
 
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/internal/frontmatter"
 )
+
+var slashAddressableNamePattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_-]*(?::[A-Za-z0-9_][A-Za-z0-9_-]*)?$`)
+
+// IsSlashAddressableName reports whether name is a canonical slash-addressable
+// skill name. Names are ASCII and may have one plugin separator.
+func IsSlashAddressableName(name string) bool {
+	return len(name) <= 128 && slashAddressableNamePattern.MatchString(name)
+}
 
 // SkillMeta holds discovery-time metadata for a single skill.
 type SkillMeta struct {
@@ -89,18 +99,49 @@ func LoadSkillBody(meta SkillMeta) (string, error) {
 	return doc.Body, nil
 }
 
+// CatalogEntries returns path-free skill metadata in canonical map-key order.
+func CatalogEntries(skills map[string]SkillMeta) []SkillMeta {
+	entries := make([]SkillMeta, 0, len(skills))
+	for key, meta := range skills {
+		entries = append(entries, SkillMeta{
+			Name:         key,
+			Description:  meta.Description,
+			AllowedTools: append([]string(nil), meta.AllowedTools...),
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+	return entries
+}
+
+// ResolveSkill resolves an exact catalog key, or a uniquely matching plugin
+// suffix for an unqualified name.
+func ResolveSkill(skills map[string]SkillMeta, name string) (catalogName string, meta SkillMeta, ok bool) {
+	if meta, ok := skills[name]; ok {
+		return name, meta, true
+	}
+	if strings.Contains(name, ":") {
+		return "", SkillMeta{}, false
+	}
+	for key, candidate := range skills {
+		parts := strings.SplitN(key, ":", 2)
+		if len(parts) != 2 || parts[1] != name {
+			continue
+		}
+		if ok {
+			return "", SkillMeta{}, false
+		}
+		catalogName, meta, ok = key, candidate, true
+	}
+	return catalogName, meta, ok
+}
+
 // ResolveSkillContent looks up a skill by name in a skills map and returns its body content.
 // Tries exact match first, then tries unnamespaced match (e.g., "tdd" matches "myplugin:tdd").
 // Returns ("", nil) if not found.
 func ResolveSkillContent(skills map[string]SkillMeta, name string) (string, error) {
-	if meta, ok := skills[name]; ok {
+	_, meta, ok := ResolveSkill(skills, name)
+	if ok {
 		return LoadSkillBody(meta)
-	}
-	for key, meta := range skills {
-		parts := strings.SplitN(key, ":", 2)
-		if len(parts) == 2 && parts[1] == name {
-			return LoadSkillBody(meta)
-		}
 	}
 	return "", nil
 }
@@ -121,6 +162,9 @@ func parseSkillFile(path string) (SkillMeta, bool) {
 	name, _ := doc.Meta["name"].(string)
 	desc, _ := doc.Meta["description"].(string)
 	if strings.TrimSpace(name) == "" || strings.TrimSpace(desc) == "" {
+		return SkillMeta{}, false
+	}
+	if !IsSlashAddressableName(name) {
 		return SkillMeta{}, false
 	}
 

--- a/agent/skill/skills_test.go
+++ b/agent/skill/skills_test.go
@@ -93,10 +93,10 @@ func TestResolveSkillContentRejectsAmbiguousSuffix(t *testing.T) {
 		"one:review": {Name: "review", SkillFile: write("one", "one")},
 		"two:review": {Name: "review", SkillFile: write("two", "two")},
 	}
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		body, err := ResolveSkillContent(skills, "review")
 		if err != nil || body != "" {
-			t.Fatalf("ambiguous resolution iteration %d = %q, %v", i, body, err)
+			t.Fatalf("ambiguous resolution = %q, %v", body, err)
 		}
 	}
 }

--- a/agent/skill/skills_test.go
+++ b/agent/skill/skills_test.go
@@ -1,0 +1,119 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestCatalogEntriesUsesCanonicalMapKeys(t *testing.T) {
+	skills := map[string]SkillMeta{
+		"plugin:simplify": {Name: "simplify", Description: "plugin copy", AllowedTools: []string{"read_file"}, Dir: "/tmp/plugin", SkillFile: "/tmp/plugin/SKILL.md"},
+		"simplify":        {Name: "simplify", Description: "project copy"},
+	}
+	wantSource := map[string]SkillMeta{
+		"plugin:simplify": {Name: "simplify", Description: "plugin copy", AllowedTools: []string{"read_file"}, Dir: "/tmp/plugin", SkillFile: "/tmp/plugin/SKILL.md"},
+		"simplify":        {Name: "simplify", Description: "project copy"},
+	}
+	got := CatalogEntries(skills)
+	if len(got) != 2 || got[0].Name != "plugin:simplify" || got[1].Name != "simplify" {
+		t.Fatalf("catalog names = %+v", got)
+	}
+	if !reflect.DeepEqual(skills, wantSource) {
+		t.Fatal("CatalogEntries mutated the source map")
+	}
+	if got[0].Dir != "" || got[0].SkillFile != "" || !reflect.DeepEqual(got[0].AllowedTools, []string{"read_file"}) {
+		t.Fatalf("catalog exposed filesystem metadata or aliased tools: %+v", got[0])
+	}
+	got[0].AllowedTools[0] = "mutated"
+	if skills["plugin:simplify"].AllowedTools[0] != "read_file" {
+		t.Fatal("CatalogEntries aliased AllowedTools")
+	}
+}
+
+func TestResolveSkillRejectsAmbiguousUnqualifiedName(t *testing.T) {
+	skills := map[string]SkillMeta{
+		"one:review": {Name: "review"},
+		"two:review": {Name: "review"},
+	}
+	if _, _, ok := ResolveSkill(skills, "review"); ok {
+		t.Fatal("ambiguous unqualified skill resolved")
+	}
+	if key, _, ok := ResolveSkill(skills, "one:review"); !ok || key != "one:review" {
+		t.Fatalf("qualified resolution = %q, %v", key, ok)
+	}
+}
+
+func TestIsSlashAddressableName(t *testing.T) {
+	long := make([]byte, 128)
+	for i := range long {
+		long[i] = 'a'
+	}
+	tooLong := append(append([]byte{}, long...), 'a')
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"a", true},
+		{"skill-2_name", true},
+		{"plugin:skill", true},
+		{string(long), true},
+		{"", false},
+		{"-skill", false},
+		{"_skill", true},
+		{"plugin:one:skill", false},
+		{"skill name", false},
+		{"Skill", true},
+		{string(tooLong), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsSlashAddressableName(tc.name); got != tc.want {
+				t.Fatalf("IsSlashAddressableName(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveSkillContentRejectsAmbiguousSuffix(t *testing.T) {
+	root := t.TempDir()
+	write := func(name, body string) string {
+		dir := filepath.Join(root, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(dir, "SKILL.md")
+		if err := os.WriteFile(path, []byte("---\nname: review\ndescription: test\n---\n"+body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	skills := map[string]SkillMeta{
+		"one:review": {Name: "review", SkillFile: write("one", "one")},
+		"two:review": {Name: "review", SkillFile: write("two", "two")},
+	}
+	for i := 0; i < 20; i++ {
+		body, err := ResolveSkillContent(skills, "review")
+		if err != nil || body != "" {
+			t.Fatalf("ambiguous resolution iteration %d = %q, %v", i, body, err)
+		}
+	}
+}
+
+func TestResolveSkillUsesUniqueSuffixAndExactPrecedence(t *testing.T) {
+	project := SkillMeta{Name: "project", Description: "project"}
+	plugin := SkillMeta{Name: "plugin:review", Description: "plugin"}
+	skills := map[string]SkillMeta{
+		"review":        project,
+		"plugin:review": plugin,
+	}
+	if key, meta, ok := ResolveSkill(skills, "review"); !ok || key != "review" || meta.Description != "project" {
+		t.Fatalf("exact resolution = %q, %+v, %v", key, meta, ok)
+	}
+
+	delete(skills, "review")
+	if key, meta, ok := ResolveSkill(skills, "review"); !ok || key != "plugin:review" || meta.Description != "plugin" {
+		t.Fatalf("unique suffix resolution = %q, %+v, %v", key, meta, ok)
+	}
+}

--- a/agent/status.go
+++ b/agent/status.go
@@ -163,13 +163,8 @@ func (s *Session) DetailedStatus() DetailedStatus {
 		ds.Tools = append(ds.Tools, ToolInfo{Name: name, Source: source})
 	}
 
-	// Skills (sorted by name).
-	for _, meta := range s.skills {
-		ds.Skills = append(ds.Skills, meta)
-	}
-	sort.Slice(ds.Skills, func(i, j int) bool {
-		return ds.Skills[i].Name < ds.Skills[j].Name
-	})
+	// Skills are projected through the canonical, path-free catalog helper.
+	ds.Skills = skill.CatalogEntries(s.skills)
 
 	// Plugins.
 	for _, p := range s.plugins {

--- a/agent/status_test.go
+++ b/agent/status_test.go
@@ -15,9 +15,24 @@ import (
 	"primeradiant.com/evener/agent/internal/delegatestore"
 	"primeradiant.com/evener/agent/internal/jobstore"
 	"primeradiant.com/evener/agent/plugin"
+	"primeradiant.com/evener/agent/skill"
 	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/llm"
 )
+
+func TestDetailedStatusUsesNamespacedSkillCatalogKey(t *testing.T) {
+	s := newTestSession(t)
+	s.skills = map[string]skill.SkillMeta{
+		"plugin:simplify": {Name: "simplify", Description: "rewrite", SkillFile: writeSkillBodyFile(t, "body")},
+	}
+	got := s.DetailedStatus()
+	if len(got.Skills) != 1 || got.Skills[0].Name != "plugin:simplify" {
+		t.Fatalf("skills = %+v", got.Skills)
+	}
+	if got.Skills[0].Dir != "" || got.Skills[0].SkillFile != "" {
+		t.Fatalf("skills exposed filesystem metadata: %+v", got.Skills[0])
+	}
+}
 
 func TestSession_DetailedStatus_DelegatesMatchControllerFoldAfterReopen(t *testing.T) {
 	fixture := newColdStableDelegateFixtureConfigured(t, "", func(descriptor *delegatestore.Descriptor) {

--- a/cmd/evener-hub/app_threadread.go
+++ b/cmd/evener-hub/app_threadread.go
@@ -231,11 +231,16 @@ func discoverPastThreadSkills(entry hubcore.PastEntry) []appwire.EvenerSkillInfo
 		maps.Copy(all, skill.DiscoverSkills(env, entry.Meta.Config.SkillsDirs...))
 	}
 
+	seenPluginNames := make(map[string]struct{}, len(entry.Meta.Config.PluginDirs))
 	for _, dir := range entry.Meta.Config.PluginDirs {
 		pluginName, ok := pastThreadPluginName(dir)
 		if !ok {
 			continue
 		}
+		if _, seen := seenPluginNames[pluginName]; seen {
+			continue
+		}
+		seenPluginNames[pluginName] = struct{}{}
 		pluginSkills := make(map[string]skill.SkillMeta)
 		skill.ScanSkillsDir(filepath.Join(dir, "skills"), pluginSkills)
 		for name, meta := range pluginSkills {

--- a/cmd/evener-hub/app_threadread.go
+++ b/cmd/evener-hub/app_threadread.go
@@ -2,13 +2,17 @@ package hub
 
 import (
 	"encoding/json"
+	"maps"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"primeradiant.com/evener/agent"
+	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/plugin"
 	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/skill"
 	taskpkg "primeradiant.com/evener/agent/task"
 	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/appwire"
@@ -26,6 +30,7 @@ func pastThreadForRead(cfg hubcore.WebConfig, params appwire.ThreadReadParams) (
 	if err != nil {
 		return thread, true, err
 	}
+	thread = attachPastThreadSkillCatalog(entry, thread)
 	// One thread, one transcript: this path can afford the full-transcript
 	// scans the per-entry list sweeps cannot (see stampDerivedSessionUsage).
 	return stampDerivedFailureCount(entry, stampDerivedSessionUsage(entry, thread)), true, nil
@@ -50,6 +55,7 @@ func pastThreadReadResponse(cfg hubcore.WebConfig, params appwire.ThreadReadPara
 	if err != nil {
 		return appwire.ThreadReadResponse{}, true, err
 	}
+	thread = attachPastThreadSkillCatalog(entry, thread)
 	var olderCursor string
 	thread.Turns, olderCursor, err = pastEntryLatestTurns(entry, params.TurnLimit)
 	if err != nil {
@@ -62,10 +68,11 @@ func pastThreadReadResponse(cfg hubcore.WebConfig, params appwire.ThreadReadPara
 func pastThreadTurnsList(cfg hubcore.WebConfig, params appwire.ThreadTurnsListParams) (appwire.ThreadTurnsListResponse, bool, error) {
 	readParams := appwire.ThreadReadParams{Ref: params.Ref, ThreadID: params.ThreadID, IncludeTurns: true}
 	if params.Limit <= 0 {
-		thread, ok, err := pastThreadForRead(cfg, readParams)
+		entry, ok := pastEntryForRead(cfg, readParams)
 		if !ok {
-			return appwire.ThreadTurnsListResponse{}, false, err
+			return appwire.ThreadTurnsListResponse{}, false, nil
 		}
+		thread, err := pastEntryThread(cfg, entry, true)
 		if err != nil {
 			return appwire.ThreadTurnsListResponse{}, true, err
 		}
@@ -150,6 +157,7 @@ func mergePastThreadForRead(cfg hubcore.WebConfig, params appwire.ThreadReadPara
 	if err != nil {
 		return appwire.Thread{}, err
 	}
+	past = attachPastThreadSkillCatalog(entry, past)
 	if live.ID == "" {
 		live.ID = past.ID
 	}
@@ -189,10 +197,61 @@ func mergePastThreadForRead(cfg hubcore.WebConfig, params appwire.ThreadReadPara
 	if live.Evener.Tasks == nil {
 		live.Evener.Tasks = past.Evener.Tasks
 	}
+	if live.Evener.Diagnostics == nil {
+		live.Evener.Diagnostics = past.Evener.Diagnostics
+	}
 	if params.IncludeTurns && len(live.Turns) == 0 {
 		live.Turns = past.Turns
 	}
 	return live, nil
+}
+
+// discoverPastThreadSkillCatalog reconstructs the metadata a session had at
+// start without loading any skill bodies. The order mirrors session startup:
+// embedded skills first, project and configured extra directories next, and
+// finally the skills exposed by configured plugins. Later layers overwrite an
+// earlier canonical key, just as they do during session initialization.
+//
+// This function is intentionally behind a package variable. Thread-list,
+// transcript-list, and turn-page sweeps must remain metadata-only and cheap;
+// their tests replace the seam to prove they never invoke cold discovery.
+var discoverPastThreadSkillCatalog = discoverPastThreadSkills
+
+func discoverPastThreadSkills(entry hubcore.PastEntry) []appwire.EvenerSkillInfo {
+	all := make(map[string]skill.SkillMeta)
+	if embedded, err := skill.EmbeddedSkills(); err == nil {
+		maps.Copy(all, embedded)
+	}
+
+	workingDir := strings.TrimSpace(entry.Meta.EnvInfo.WorkingDir)
+	if workingDir != "" {
+		env := execenv.NewLocalExecutionEnvironment(workingDir)
+		maps.Copy(all, skill.DiscoverSkills(env, entry.Meta.Config.SkillsDirs...))
+	}
+
+	loaded, _ := plugin.LoadAllFailSoft(entry.Meta.Config.PluginDirs)
+	for _, instance := range loaded {
+		maps.Copy(all, instance.Skills)
+	}
+
+	entries := skill.CatalogEntries(all)
+	result := make([]appwire.EvenerSkillInfo, 0, len(entries))
+	for _, entry := range entries {
+		result = append(result, appwire.EvenerSkillInfo{Name: entry.Name, Description: entry.Description})
+	}
+	return result
+}
+
+func attachPastThreadSkillCatalog(entry hubcore.PastEntry, thread appwire.Thread) appwire.Thread {
+	skills := discoverPastThreadSkillCatalog(entry)
+	if len(skills) == 0 {
+		return thread
+	}
+	if thread.Evener.Diagnostics == nil {
+		thread.Evener.Diagnostics = &appwire.EvenerDiagnostics{}
+	}
+	thread.Evener.Diagnostics.Skills = skills
+	return thread
 }
 
 // pastThreadCapabilities is what the hub can carry out for a thread with no

--- a/cmd/evener-hub/app_threadread.go
+++ b/cmd/evener-hub/app_threadread.go
@@ -157,7 +157,9 @@ func mergePastThreadForRead(cfg hubcore.WebConfig, params appwire.ThreadReadPara
 	if err != nil {
 		return appwire.Thread{}, err
 	}
-	past = attachPastThreadSkillCatalog(entry, past)
+	if live.Evener.Diagnostics == nil {
+		past = attachPastThreadSkillCatalog(entry, past)
+	}
 	if live.ID == "" {
 		live.ID = past.ID
 	}
@@ -229,9 +231,16 @@ func discoverPastThreadSkills(entry hubcore.PastEntry) []appwire.EvenerSkillInfo
 		maps.Copy(all, skill.DiscoverSkills(env, entry.Meta.Config.SkillsDirs...))
 	}
 
-	loaded, _ := plugin.LoadAllFailSoft(entry.Meta.Config.PluginDirs)
-	for _, instance := range loaded {
-		maps.Copy(all, instance.Skills)
+	for _, dir := range entry.Meta.Config.PluginDirs {
+		pluginName, ok := pastThreadPluginName(dir)
+		if !ok {
+			continue
+		}
+		pluginSkills := make(map[string]skill.SkillMeta)
+		skill.ScanSkillsDir(filepath.Join(dir, "skills"), pluginSkills)
+		for name, meta := range pluginSkills {
+			all[pluginName+":"+name] = meta
+		}
 	}
 
 	entries := skill.CatalogEntries(all)
@@ -240,6 +249,31 @@ func discoverPastThreadSkills(entry hubcore.PastEntry) []appwire.EvenerSkillInfo
 		result = append(result, appwire.EvenerSkillInfo{Name: entry.Name, Description: entry.Description})
 	}
 	return result
+}
+
+// pastThreadPluginName reads only the plugin manifest fields needed to locate
+// its skill directory. In particular, this does not load agents, commands,
+// hooks, or MCP configuration: a malformed unrelated component must not hide
+// otherwise valid plugin skills from a cold thread read.
+func pastThreadPluginName(dir string) (string, bool) {
+	for _, manifestPath := range []string{
+		filepath.Join(dir, ".claude-plugin", "plugin.json"),
+		filepath.Join(dir, ".codex-plugin", "plugin.json"),
+	} {
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", false
+		}
+		manifest, err := plugin.ParseManifest(data)
+		if err != nil {
+			return "", false
+		}
+		return manifest.Name, true
+	}
+	return "", false
 }
 
 func attachPastThreadSkillCatalog(entry hubcore.PastEntry, thread appwire.Thread) appwire.Thread {

--- a/cmd/evener-hub/app_threadread.go
+++ b/cmd/evener-hub/app_threadread.go
@@ -212,7 +212,9 @@ func mergePastThreadForRead(cfg hubcore.WebConfig, params appwire.ThreadReadPara
 // start without loading any skill bodies. The order mirrors session startup:
 // embedded skills first, project and configured extra directories next, and
 // finally the skills exposed by configured plugins. Later layers overwrite an
-// earlier canonical key, just as they do during session initialization.
+// earlier canonical key, just as they do during session initialization. Plugin
+// directories use the shared first-manifest-wins selection policy; a later
+// duplicate is skipped even if the selected plugin fails component loading.
 //
 // This function is intentionally behind a package variable. Thread-list,
 // transcript-list, and turn-page sweeps must remain metadata-only and cheap;
@@ -261,24 +263,8 @@ func discoverPastThreadSkills(entry hubcore.PastEntry) []appwire.EvenerSkillInfo
 // hooks, or MCP configuration: a malformed unrelated component must not hide
 // otherwise valid plugin skills from a cold thread read.
 func pastThreadPluginName(dir string) (string, bool) {
-	for _, manifestPath := range []string{
-		filepath.Join(dir, ".claude-plugin", "plugin.json"),
-		filepath.Join(dir, ".codex-plugin", "plugin.json"),
-	} {
-		data, err := os.ReadFile(manifestPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return "", false
-		}
-		manifest, err := plugin.ParseManifest(data)
-		if err != nil {
-			return "", false
-		}
-		return manifest.Name, true
-	}
-	return "", false
+	name, err := plugin.ManifestName(dir)
+	return name, err == nil
 }
 
 func attachPastThreadSkillCatalog(entry hubcore.PastEntry, thread appwire.Thread) appwire.Thread {

--- a/cmd/evener-hub/app_threadread_failures_test.go
+++ b/cmd/evener-hub/app_threadread_failures_test.go
@@ -266,6 +266,13 @@ func TestPastThreadTurnsListDoesNotDiscoverSkills(t *testing.T) {
 
 func TestMergePastThreadForReadKeepsLiveDiagnostics(t *testing.T) {
 	cfg, entry := seedPastSessionWithSkillFixtures(t)
+	var calls int
+	previous := discoverPastThreadSkillCatalog
+	discoverPastThreadSkillCatalog = func(hubcore.PastEntry) []appwire.EvenerSkillInfo {
+		calls++
+		return []appwire.EvenerSkillInfo{{Name: "unexpected"}}
+	}
+	t.Cleanup(func() { discoverPastThreadSkillCatalog = previous })
 	liveDiagnostics := &appwire.EvenerDiagnostics{Tools: []appwire.EvenerToolInfo{{Name: "live-tool"}}}
 	got, err := mergePastThreadForRead(cfg, appwire.ThreadReadParams{Ref: "local:" + entry.Meta.ID}, appwire.Thread{
 		ID: entry.Meta.ID, SessionID: entry.Meta.ID, Evener: appwire.EvenerThread{Diagnostics: liveDiagnostics},
@@ -275,5 +282,21 @@ func TestMergePastThreadForReadKeepsLiveDiagnostics(t *testing.T) {
 	}
 	if got.Evener.Diagnostics != liveDiagnostics || len(got.Evener.Diagnostics.Skills) != 0 || len(got.Evener.Diagnostics.Tools) != 1 {
 		t.Fatalf("live diagnostics were replaced or changed: %+v", got.Evener.Diagnostics)
+	}
+	if calls != 0 {
+		t.Fatalf("live diagnostics caused %d discarded discovery calls, want 0", calls)
+	}
+}
+
+func TestMergePastThreadForReadUsesPastDiagnosticsWhenLiveAbsent(t *testing.T) {
+	cfg, entry := seedPastSessionWithSkillFixtures(t)
+	got, err := mergePastThreadForRead(cfg, appwire.ThreadReadParams{Ref: "local:" + entry.Meta.ID}, appwire.Thread{
+		ID: entry.Meta.ID, SessionID: entry.Meta.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Evener.Diagnostics == nil || !hasSkill(got.Evener.Diagnostics.Skills, "project-skill") {
+		t.Fatalf("past diagnostics were not copied: %+v", got.Evener.Diagnostics)
 	}
 }

--- a/cmd/evener-hub/app_threadread_failures_test.go
+++ b/cmd/evener-hub/app_threadread_failures_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
 	"primeradiant.com/evener/identifier"
 	"primeradiant.com/evener/llm"
@@ -213,5 +215,65 @@ func TestPastEntryThread_DoesNotDeriveTheFailureCountOnTheListSweepPath(t *testi
 
 	if thread.Evener.FailedToolCalls != nil {
 		t.Fatalf("sweep projector reported %d failures; it must not scan transcripts", *thread.Evener.FailedToolCalls)
+	}
+}
+
+func TestPastThreadListDoesNotDiscoverSkills(t *testing.T) {
+	cfg, entry := seedPastSessionWithSkillFixtures(t)
+	var calls int
+	previous := discoverPastThreadSkillCatalog
+	discoverPastThreadSkillCatalog = func(hubcore.PastEntry) []appwire.EvenerSkillInfo {
+		calls++
+		return []appwire.EvenerSkillInfo{{Name: "unexpected"}}
+	}
+	t.Cleanup(func() { discoverPastThreadSkillCatalog = previous })
+
+	if _, err := pastEntryThread(cfg, entry, false); err != nil {
+		t.Fatal(err)
+	}
+	sources := appsource.NewRegistry()
+	live := appwire.Thread{ID: "live", SessionID: "live", Source: "fixture", Evener: appwire.EvenerThread{Ref: "fixture:live"}}
+	sources.Add(&listThreadSource{id: "fixture", thread: live, relayLifecycleSource: relayLifecycleSource{thread: live}})
+	if _, err := hubThreadList(context.Background(), cfg, sources, appwire.ThreadListParams{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := hubThreadTranscriptList(context.Background(), cfg, sources, appwire.ThreadTranscriptListParams{Ref: "fixture:live"}); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 0 {
+		t.Fatalf("thread/navigation sweep made %d cold skill-discovery calls, want 0", calls)
+	}
+}
+
+func TestPastThreadTurnsListDoesNotDiscoverSkills(t *testing.T) {
+	cfg, entry := seedPastSessionWithSkillFixtures(t)
+	var calls int
+	previous := discoverPastThreadSkillCatalog
+	discoverPastThreadSkillCatalog = func(hubcore.PastEntry) []appwire.EvenerSkillInfo {
+		calls++
+		return []appwire.EvenerSkillInfo{{Name: "unexpected"}}
+	}
+	t.Cleanup(func() { discoverPastThreadSkillCatalog = previous })
+
+	_, ok, err := pastThreadTurnsList(cfg, appwire.ThreadTurnsListParams{Ref: "local:" + entry.Meta.ID, Limit: 1})
+	if err != nil || !ok {
+		t.Fatalf("pastThreadTurnsList = %v, %v", err, ok)
+	}
+	if calls != 0 {
+		t.Fatalf("turn-page sweep made %d cold skill-discovery calls, want 0", calls)
+	}
+}
+
+func TestMergePastThreadForReadKeepsLiveDiagnostics(t *testing.T) {
+	cfg, entry := seedPastSessionWithSkillFixtures(t)
+	liveDiagnostics := &appwire.EvenerDiagnostics{Tools: []appwire.EvenerToolInfo{{Name: "live-tool"}}}
+	got, err := mergePastThreadForRead(cfg, appwire.ThreadReadParams{Ref: "local:" + entry.Meta.ID}, appwire.Thread{
+		ID: entry.Meta.ID, SessionID: entry.Meta.ID, Evener: appwire.EvenerThread{Diagnostics: liveDiagnostics},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Evener.Diagnostics != liveDiagnostics || len(got.Evener.Diagnostics.Skills) != 0 || len(got.Evener.Diagnostics.Tools) != 1 {
+		t.Fatalf("live diagnostics were replaced or changed: %+v", got.Evener.Diagnostics)
 	}
 }

--- a/cmd/evener-hub/app_threadread_test.go
+++ b/cmd/evener-hub/app_threadread_test.go
@@ -75,6 +75,132 @@ func TestAppThreadReadColdDelegatesMatchReconnectedDetailedStatus(t *testing.T) 
 	}
 }
 
+func TestPastThreadReadCarriesSkillCatalog(t *testing.T) {
+	cfg, entry := seedPastSessionWithSkillFixtures(t)
+	thread, ok, err := pastThreadForRead(cfg, appwire.ThreadReadParams{Ref: "local:" + entry.Meta.ID})
+	if err != nil || !ok {
+		t.Fatalf("pastThreadForRead = %v, %v", err, ok)
+	}
+	if thread.Evener.Diagnostics == nil {
+		t.Fatal("past thread has no diagnostics")
+	}
+	for _, want := range []string{"doctoring-evener", "project-skill", "extra-skill", "fixture-plugin:plugin-skill"} {
+		if !hasSkill(thread.Evener.Diagnostics.Skills, want) {
+			t.Fatalf("skills = %+v, missing %q", thread.Evener.Diagnostics.Skills, want)
+		}
+	}
+	for _, got := range thread.Evener.Diagnostics.Skills {
+		if strings.Contains(got.Name, string(filepath.Separator)) {
+			t.Fatalf("skill metadata contains a path: %+v", got)
+		}
+	}
+}
+
+func TestPastThreadReadCarriesExistingDelegateDiagnosticAlongsideSkills(t *testing.T) {
+	cfg, entry := seedPastSessionWithSkillFixtures(t)
+	delegateDir := filepath.Join(entry.StateDir, "sessions", entry.Meta.ID)
+	if err := os.MkdirAll(delegateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	descriptor := map[string]any{
+		"child_session_id": entry.Meta.ID, "transcript_ref": "local:" + entry.Meta.ID,
+		"owner_session_id": entry.Meta.ID, "task": "fixture task", "description": "fixture description",
+		"agent_type": "explorer", "resumable": true,
+		"tool_name_ceiling": []string{"communicate"},
+		"config":            map[string]any{},
+	}
+	batch, err := json.Marshal(map[string]any{"events": []any{map[string]any{
+		"kind": "delegate_created", "seq": 1, "ts": time.Unix(10, 0).UTC(),
+		"delegate_id": "dlg_fixture", "created": map[string]any{"descriptor": descriptor},
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal := append([]byte("{\"version\":1}\n"), append(batch, '\n')...)
+	if err := os.WriteFile(filepath.Join(delegateDir, "delegates.jsonl"), journal, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	thread, ok, err := pastThreadForRead(cfg, appwire.ThreadReadParams{Ref: "local:" + entry.Meta.ID})
+	if err != nil || !ok {
+		t.Fatalf("pastThreadForRead = %v, %v", err, ok)
+	}
+	if thread.Evener.Diagnostics == nil || len(thread.Evener.Diagnostics.Delegates) != 1 ||
+		!hasSkill(thread.Evener.Diagnostics.Skills, "project-skill") {
+		t.Fatalf("diagnostics = %+v", thread.Evener.Diagnostics)
+	}
+}
+
+func hasSkill(skills []appwire.EvenerSkillInfo, name string) bool {
+	for _, skill := range skills {
+		if skill.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func seedPastSessionWithSkillFixtures(t *testing.T) (hubcore.WebConfig, hubcore.PastEntry) {
+	t.Helper()
+	root := t.TempDir()
+	workingDir := filepath.Join(root, "project")
+	extraDir := filepath.Join(root, "extra-skills")
+	pluginDir := filepath.Join(root, "plugin")
+	writeSkillFixture(t, filepath.Join(workingDir, "skills"), "project-skill", "project description")
+	writeSkillFixture(t, extraDir, "extra-skill", "extra description")
+	if err := os.MkdirAll(filepath.Join(pluginDir, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := []byte(`{"name":"fixture-plugin"}`)
+	if err := os.WriteFile(filepath.Join(pluginDir, ".claude-plugin", "plugin.json"), manifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeSkillFixture(t, filepath.Join(pluginDir, "skills"), "plugin-skill", "plugin description")
+
+	stateDir := filepath.Join(root, "state", "projects", "project-repo-0000000000")
+	sessionID := "02wMz5Txv5aIxgf9yVdd0N"
+	if err := os.MkdirAll(filepath.Join(stateDir, "sessions"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Unix(1700000000, 0).UTC()
+	if err := schema.SaveSessionMeta(stateDir, schema.SessionMeta{
+		ID: sessionID, ProfileID: "openai", Model: "gpt-5",
+		EnvInfo:   schema.EnvironmentInfo{WorkingDir: workingDir},
+		Config:    schema.ConfigSnapshot{SkillsDirs: []string{extraDir}, PluginDirs: []string{pluginDir}},
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writer, err := transcript.NewWriter(filepath.Join(stateDir, "sessions", sessionID+".transcript.jsonl"), transcript.Header{SessionID: sessionID, CreatedAt: now, ProfileID: "openai", Model: "gpt-5"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	idx := hubcore.NewPastIndex(filepath.Join(root, "state", "projects", "*"))
+	if _, err := idx.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := idx.Find(sessionID)
+	if !ok {
+		t.Fatal("past entry not found")
+	}
+	return hubcore.WebConfig{Past: idx}, entry
+}
+
+func writeSkillFixture(t *testing.T, parent, name, description string) {
+	t.Helper()
+	dir := filepath.Join(parent, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "---\nname: " + name + "\ndescription: " + description + "\n---\nfixture body\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestHubThreadReadStableDelegateDoesNotExtractActivationID(t *testing.T) {
 	raw := json.RawMessage(`{"job_id":"job_retired_activation","delegate_id":"dlg_stable","status":"running"}`)
 	item := appwire.ThreadItem{Type: "commandExecution", ToolName: "delegate", Raw: bytes.Clone(raw), Status: appwire.TurnStatusInProgress}

--- a/cmd/evener-hub/app_threadread_test.go
+++ b/cmd/evener-hub/app_threadread_test.go
@@ -89,10 +89,43 @@ func TestPastThreadReadCarriesSkillCatalog(t *testing.T) {
 			t.Fatalf("skills = %+v, missing %q", thread.Evener.Diagnostics.Skills, want)
 		}
 	}
+	wantNames := []string{"doctoring-evener", "extra-skill", "fixture-plugin:plugin-skill", "project-skill"}
+	if len(thread.Evener.Diagnostics.Skills) != len(wantNames) {
+		t.Fatalf("skill catalog = %+v, want exactly %d entries", thread.Evener.Diagnostics.Skills, len(wantNames))
+	}
+	for i, want := range wantNames {
+		if got := thread.Evener.Diagnostics.Skills[i].Name; got != want {
+			t.Fatalf("skill catalog order = %+v, want %v", thread.Evener.Diagnostics.Skills, wantNames)
+		}
+	}
+	descriptions := map[string]string{
+		"extra-skill":                 "extra description",
+		"fixture-plugin:plugin-skill": "plugin description",
+		"project-skill":               "project description",
+		"doctoring-evener":            "extra override",
+	}
+	for _, got := range thread.Evener.Diagnostics.Skills {
+		if want, ok := descriptions[got.Name]; ok && got.Description != want {
+			t.Fatalf("%s description = %q, want %q", got.Name, got.Description, want)
+		}
+	}
 	for _, got := range thread.Evener.Diagnostics.Skills {
 		if strings.Contains(got.Name, string(filepath.Separator)) {
 			t.Fatalf("skill metadata contains a path: %+v", got)
 		}
+	}
+}
+
+func TestPastThreadReadResponseCarriesSkillCatalog(t *testing.T) {
+	cfg, entry := seedPastSessionWithSkillFixtures(t)
+	response, ok, err := pastThreadReadResponse(cfg, appwire.ThreadReadParams{
+		Ref: "local:" + entry.Meta.ID, IncludeTurns: true, TurnLimit: 1,
+	})
+	if err != nil || !ok {
+		t.Fatalf("pastThreadReadResponse = %v, %v", err, ok)
+	}
+	if response.Thread.Evener.Diagnostics == nil || !hasSkill(response.Thread.Evener.Diagnostics.Skills, "fixture-plugin:plugin-skill") {
+		t.Fatalf("bounded response diagnostics = %+v", response.Thread.Evener.Diagnostics)
 	}
 }
 
@@ -147,11 +180,13 @@ func seedPastSessionWithSkillFixtures(t *testing.T) (hubcore.WebConfig, hubcore.
 	extraDir := filepath.Join(root, "extra-skills")
 	pluginDir := filepath.Join(root, "plugin")
 	writeSkillFixture(t, filepath.Join(workingDir, "skills"), "project-skill", "project description")
+	writeSkillFixture(t, filepath.Join(workingDir, "skills"), "doctoring-evener", "project override")
 	writeSkillFixture(t, extraDir, "extra-skill", "extra description")
+	writeSkillFixture(t, extraDir, "doctoring-evener", "extra override")
 	if err := os.MkdirAll(filepath.Join(pluginDir, ".claude-plugin"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	manifest := []byte(`{"name":"fixture-plugin"}`)
+	manifest := []byte(`{"name":"fixture-plugin","mcpServers":123}`)
 	if err := os.WriteFile(filepath.Join(pluginDir, ".claude-plugin", "plugin.json"), manifest, 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/evener-hub/app_threadread_test.go
+++ b/cmd/evener-hub/app_threadread_test.go
@@ -171,6 +171,32 @@ func TestPastThreadSkillCatalogUsesFirstDuplicatePlugin(t *testing.T) {
 	}
 }
 
+func TestPastThreadSkillCatalogUsesFirstManifestDuplicatePlugin(t *testing.T) {
+	root := t.TempDir()
+	first := writeThreadSkillPlugin(t, root, "successful-duplicate", "same-skill", "broken first")
+	writeSkillFile(t, filepath.Join(first, "commands", "broken.md"), "---\ndescription: [\n---\nbody")
+	writeSkillFile(t, filepath.Join(first, "agents", "broken.md"), "---\ndescription: [\n---\nbody")
+	writeSkillFile(t, filepath.Join(first, "hooks", "hooks.json"), "{not json")
+	second := writeThreadSkillPlugin(t, root, "successful-duplicate", "same-skill", "valid later")
+	if _, err := plugin.Load(first); err == nil {
+		t.Fatal("broken first duplicate unexpectedly loaded")
+	}
+	if _, err := plugin.Load(second); err != nil {
+		t.Fatalf("valid later duplicate failed to load: %v", err)
+	}
+	loaded, skipped := plugin.LoadAllFailSoft([]string{first, second})
+	if len(loaded) != 0 || len(skipped) != 2 || skipped[1].Name != "successful-duplicate" {
+		t.Fatalf("startup duplicate selection = loaded=%+v skipped=%+v, want first manifest selected then skipped", loaded, skipped)
+	}
+
+	got := discoverPastThreadSkills(hubcore.PastEntry{Meta: schema.SessionMeta{Config: schema.ConfigSnapshot{
+		PluginDirs: []string{first, second},
+	}}})
+	if description := skillDescription(got, "successful-duplicate:same-skill"); description != "broken first" {
+		t.Fatalf("first-manifest duplicate description = %q, want broken first", description)
+	}
+}
+
 func TestPastThreadSkillLoaderIgnoresMalformedPluginComponents(t *testing.T) {
 	for _, tc := range []struct {
 		name  string

--- a/cmd/evener-hub/app_threadread_test.go
+++ b/cmd/evener-hub/app_threadread_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"primeradiant.com/evener/agent"
+	"primeradiant.com/evener/agent/plugin"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/appwire"
@@ -129,6 +130,76 @@ func TestPastThreadReadResponseCarriesSkillCatalog(t *testing.T) {
 	}
 }
 
+func TestPastThreadSkillCatalogLayerPrecedence(t *testing.T) {
+	t.Run("project overrides embedded", func(t *testing.T) {
+		workingDir := t.TempDir()
+		writeSkillFixture(t, filepath.Join(workingDir, "skills"), "doctoring-evener", "project wins")
+		got := discoverPastThreadSkills(hubcore.PastEntry{Meta: schema.SessionMeta{EnvInfo: schema.EnvironmentInfo{WorkingDir: workingDir}}})
+		if description := skillDescription(got, "doctoring-evener"); description != "project wins" {
+			t.Fatalf("project-over-embedded description = %q", description)
+		}
+	})
+
+	t.Run("skills dirs override project", func(t *testing.T) {
+		workingDir, extraDir := t.TempDir(), t.TempDir()
+		writeSkillFixture(t, filepath.Join(workingDir, "skills"), "layered-skill", "project value")
+		writeSkillFixture(t, extraDir, "layered-skill", "extra value")
+		got := discoverPastThreadSkills(hubcore.PastEntry{Meta: schema.SessionMeta{
+			EnvInfo: schema.EnvironmentInfo{WorkingDir: workingDir}, Config: schema.ConfigSnapshot{SkillsDirs: []string{extraDir}},
+		}})
+		if description := skillDescription(got, "layered-skill"); description != "extra value" {
+			t.Fatalf("SkillsDirs-over-project description = %q", description)
+		}
+	})
+
+	t.Run("plugin metadata is canonical", func(t *testing.T) {
+		pluginDir := writeThreadSkillPlugin(t, t.TempDir(), "metadata-plugin", "plugin-skill", "plugin value")
+		got := discoverPastThreadSkills(hubcore.PastEntry{Meta: schema.SessionMeta{Config: schema.ConfigSnapshot{PluginDirs: []string{pluginDir}}}})
+		if description := skillDescription(got, "metadata-plugin:plugin-skill"); description != "plugin value" {
+			t.Fatalf("plugin description = %q", description)
+		}
+	})
+}
+
+func TestPastThreadSkillCatalogUsesFirstDuplicatePlugin(t *testing.T) {
+	root := t.TempDir()
+	first := writeThreadSkillPlugin(t, root, "duplicate-plugin", "same-skill", "first value")
+	second := writeThreadSkillPlugin(t, root, "duplicate-plugin", "same-skill", "second value")
+	got := discoverPastThreadSkills(hubcore.PastEntry{Meta: schema.SessionMeta{Config: schema.ConfigSnapshot{PluginDirs: []string{first, second}}}})
+	if description := skillDescription(got, "duplicate-plugin:same-skill"); description != "first value" {
+		t.Fatalf("duplicate plugin description = %q, want first plugin value", description)
+	}
+}
+
+func TestPastThreadSkillLoaderIgnoresMalformedPluginComponents(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(t *testing.T, dir string)
+	}{
+		{name: "commands", setup: func(t *testing.T, dir string) {
+			writeSkillFile(t, filepath.Join(dir, "commands", "broken.md"), "---\ndescription: [\n---\nbody")
+		}},
+		{name: "agents", setup: func(t *testing.T, dir string) {
+			writeSkillFile(t, filepath.Join(dir, "agents", "broken.md"), "---\ndescription: [\n---\nbody")
+		}},
+		{name: "hooks", setup: func(t *testing.T, dir string) {
+			writeSkillFile(t, filepath.Join(dir, "hooks", "hooks.json"), "{not json")
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := writeThreadSkillPlugin(t, t.TempDir(), "malformed-plugin", "valid-skill", "valid value")
+			tc.setup(t, dir)
+			if _, err := plugin.Load(dir); err == nil {
+				t.Fatal("full plugin loader unexpectedly accepted malformed component")
+			}
+			got := discoverPastThreadSkills(hubcore.PastEntry{Meta: schema.SessionMeta{Config: schema.ConfigSnapshot{PluginDirs: []string{dir}}}})
+			if description := skillDescription(got, "malformed-plugin:valid-skill"); description != "valid value" {
+				t.Fatalf("skill-only loader lost valid skill: description=%q catalog=%+v", description, got)
+			}
+		})
+	}
+}
+
 func TestPastThreadReadCarriesExistingDelegateDiagnosticAlongsideSkills(t *testing.T) {
 	cfg, entry := seedPastSessionWithSkillFixtures(t)
 	delegateDir := filepath.Join(entry.StateDir, "sessions", entry.Meta.ID)
@@ -234,6 +305,38 @@ func writeSkillFixture(t *testing.T, parent, name, description string) {
 	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func writeThreadSkillPlugin(t *testing.T, root, pluginName, skillName, description string) string {
+	t.Helper()
+	dir := filepath.Join(root, pluginName+"-"+strings.ReplaceAll(description, " ", "-"))
+	if err := os.MkdirAll(filepath.Join(dir, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".claude-plugin", "plugin.json"), []byte(`{"name":"`+pluginName+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeSkillFixture(t, filepath.Join(dir, "skills"), skillName, description)
+	return dir
+}
+
+func writeSkillFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func skillDescription(skills []appwire.EvenerSkillInfo, name string) string {
+	for _, skill := range skills {
+		if skill.Name == name {
+			return skill.Description
+		}
+	}
+	return ""
 }
 
 func TestHubThreadReadStableDelegateDoesNotExtractActivationID(t *testing.T) {

--- a/cmd/evener-hub/app_transcripts.go
+++ b/cmd/evener-hub/app_transcripts.go
@@ -101,14 +101,15 @@ func hubTranscriptRoot(ctx context.Context, cfg hubcore.WebConfig, sources *apps
 		}
 		err = readErr
 	}
-	thread, ok, pastErr := pastThreadForRead(cfg, appwire.ThreadReadParams{Ref: ref, IncludeTurns: false})
+	entry, ok := pastEntryForRead(cfg, appwire.ThreadReadParams{Ref: ref})
+	if !ok {
+		return appwire.Thread{}, err
+	}
+	thread, pastErr := pastEntryThread(cfg, entry, false)
 	if pastErr != nil {
 		return appwire.Thread{}, pastErr
 	}
-	if ok {
-		return thread, nil
-	}
-	return appwire.Thread{}, err
+	return thread, nil
 }
 
 func threadRef(thread appwire.Thread) string {

--- a/cmd/evener-hub/app_transcripts_test.go
+++ b/cmd/evener-hub/app_transcripts_test.go
@@ -9,6 +9,7 @@ import (
 
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
 )
 
@@ -61,5 +62,31 @@ func TestHubRPCTranscriptTargetsUseEvenerParentRefs(t *testing.T) {
 	}
 	if resp.Data[1].Kind != "subagent" || resp.Data[1].Ref != "local:"+subID || resp.Data[1].TurnsUsed != 1 {
 		t.Fatalf("subagent target=%+v", resp.Data[1])
+	}
+}
+
+func TestHubTranscriptListPastFallbackDoesNotDiscoverSkills(t *testing.T) {
+	cfg, entry := seedPastSessionWithSkillFixtures(t)
+	sources := appsource.NewRegistry()
+	sources.Add(&pastFallbackRelaySource{readErr: appwire.SessionUnavailable("live source unavailable")})
+	var calls int
+	previous := discoverPastThreadSkillCatalog
+	discoverPastThreadSkillCatalog = func(hubcore.PastEntry) []appwire.EvenerSkillInfo {
+		calls++
+		return []appwire.EvenerSkillInfo{{Name: "unexpected"}}
+	}
+	t.Cleanup(func() { discoverPastThreadSkillCatalog = previous })
+
+	response, err := hubThreadTranscriptList(context.Background(), cfg, sources, appwire.ThreadTranscriptListParams{
+		Ref: "local:" + entry.Meta.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Data) == 0 || response.Data[0].Ref != "local:"+entry.Meta.ID {
+		t.Fatalf("transcript targets = %+v", response.Data)
+	}
+	if calls != 0 {
+		t.Fatalf("transcript-list fallback made %d cold skill-discovery calls, want 0", calls)
 	}
 }

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.test.tsx
@@ -2674,7 +2674,11 @@ test("slash completion keeps built-ins while hiding plugin commands for an expli
 
   await user.type(textarea(), "hi /re");
 
-  expect(slashOptions().map((el) => el.textContent)).toEqual([expect.stringContaining("/reasoning-effort")]);
+  expect(slashOptions().map((el) => el.textContent)).toEqual([
+    expect.stringContaining("/reasoning-effort"),
+    expect.stringContaining("/project"),
+    expect.stringContaining("/drain-as-steer"),
+  ]);
 });
 
 test("a focused thread skill completes inline text and submits the unchanged prose", async () => {

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.test.tsx
@@ -2614,11 +2614,14 @@ test("a trailing slash token opens a completion menu merging session-scoped buil
   await user.type(textarea(), "hi /re");
 
   // "re" matches the built-in /reasoning-effort too (mergeSlashCommands puts
-  // built-ins first), not just the two catalog entries.
+  // built-ins first), not just the two catalog entries. Fuzzy matching also
+  // finds the command labels whose "r" and "e" are separated.
   expect(slashOptions().map((el) => el.textContent)).toEqual([
     expect.stringContaining("/reasoning-effort"),
     expect.stringContaining("/review"),
     expect.stringContaining("/release"),
+    expect.stringContaining("/project"),
+    expect.stringContaining("/drain-as-steer"),
   ]);
 });
 
@@ -2674,6 +2677,45 @@ test("slash completion keeps built-ins while hiding plugin commands for an expli
   expect(slashOptions().map((el) => el.textContent)).toEqual([expect.stringContaining("/reasoning-effort")]);
 });
 
+test("a focused thread skill completes inline text and submits the unchanged prose", async () => {
+  const user = userEvent.setup();
+  const fake = await mountComposer("ref_slash_skill", {
+    evener: {
+      ref: "ref_slash_skill",
+      capabilities: FULL_CAPABILITIES,
+      queue: { revision: 0 },
+      diagnostics: { skills: [{ name: "simplify", description: "rewrite" }] },
+    },
+  });
+  fake.on("turn/start", (params) => ({
+    receipt: {
+      clientMutationId: params.clientMutationId,
+      disposition: "applied",
+      threadId: "thread_a",
+      projectionState: "reflected",
+    },
+    turn: { id: "turn_1", status: "inProgress", itemsView: "" },
+  }));
+
+  await user.type(textarea(), "Use /smp");
+  expect(slashOptions()).toHaveLength(1);
+  expect(slashOptions()[0]?.textContent).toContain("/simplify");
+
+  await user.click(slashOptions()[0]!);
+  expect(textarea().value).toBe("Use /simplify ");
+
+  await user.type(textarea(), "on this");
+  expect(textarea().value).toBe("Use /simplify on this");
+  await user.click(submitButton());
+
+  await waitFor(() => expect(fake.calls.some((call) => call.method === "turn/start")).toBe(true));
+  const call = fake.calls.find((candidate) => candidate.method === "turn/start");
+  expect(call?.params).toMatchObject({
+    ref: "ref_slash_skill",
+    input: [{ type: "text", text: "Use /simplify on this" }],
+  });
+});
+
 test("a mid-word slash never opens the menu", async () => {
   useCommandCatalog.setState({ commands: REVIEW_RELEASE_CATALOG, loaded: true });
   const user = userEvent.setup();
@@ -2699,17 +2741,21 @@ test("ArrowDown/ArrowUp move the highlighted option and wrap at both ends", asyn
   const user = userEvent.setup();
   await mountComposer("ref_slash7");
   await user.type(textarea(), "hi /re");
-  // Three matches: the built-in /reasoning-effort, then /review, /release.
+  // Five matches: three contiguous beginnings, then two fuzzy matches.
 
   expect(slashOptions()[0]?.getAttribute("aria-selected")).toBe("true");
   await user.keyboard("{ArrowDown}");
   expect(slashOptions()[1]?.getAttribute("aria-selected")).toBe("true");
   await user.keyboard("{ArrowDown}");
   expect(slashOptions()[2]?.getAttribute("aria-selected")).toBe("true");
+  await user.keyboard("{ArrowDown}");
+  expect(slashOptions()[3]?.getAttribute("aria-selected")).toBe("true");
+  await user.keyboard("{ArrowDown}");
+  expect(slashOptions()[4]?.getAttribute("aria-selected")).toBe("true");
   await user.keyboard("{ArrowDown}"); // wraps past the last option back to the first
   expect(slashOptions()[0]?.getAttribute("aria-selected")).toBe("true");
   await user.keyboard("{ArrowUp}"); // wraps the other way, back to the last
-  expect(slashOptions()[2]?.getAttribute("aria-selected")).toBe("true");
+  expect(slashOptions()[4]?.getAttribute("aria-selected")).toBe("true");
 });
 
 test("Tab commits the highlighted option: splices /name<space> at the token start, caret after the space", async () => {

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
@@ -216,9 +216,9 @@ export function Composer({ ref }: ComposerProps) {
     [activePluginNames, slashCatalog],
   );
   const sessionBuiltins = sessionBuiltinCommands({ sessionRef: ref, onPage: "session" });
-  const slashMenuCatalog = mergeSlashCommands(sessionBuiltins, visibleSlashCatalog);
+  const slashMenuCatalog = mergeSlashCommands(sessionBuiltins, visibleSlashCatalog, model?.skills ?? []);
   // The menu is only ever open when a token matched AND the merged catalog
-  // has at least one startsWith hit for it - a matched-but-empty token (e.g.
+  // has at least one fuzzy label hit for it - a matched-but-empty token (e.g.
   // "/zzz" against a real catalog) shows no menu at all, same as no token
   // matching.
   const slashItems = slashToken ? filterSlashMenuItems(slashMenuCatalog, slashToken.query) : [];

--- a/cmd/evener-hub/frontend/src/panes/session/composer/SlashCompletionMenu.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/SlashCompletionMenu.tsx
@@ -41,7 +41,13 @@ export function optionId(listboxId: string, index: number): string {
 
 export function SlashCompletionMenu({ id, items, highlightedIndex, onSelect }: SlashCompletionMenuProps) {
   return (
-    <div className={CLASS.menu} role="listbox" id={id} aria-label="Slash commands" data-testid="composer-slash-menu">
+    <div
+      className={CLASS.menu}
+      role="listbox"
+      id={id}
+      aria-label="Slash commands and skills"
+      data-testid="composer-slash-menu"
+    >
       {items.map((item, index) => {
         const active = index === highlightedIndex;
         return (

--- a/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.test.ts
@@ -1,7 +1,13 @@
 import { expect, test } from "vitest";
 import type { CommandDescriptor } from "../../../protocol/types.gen";
 import type { ScopedCommand } from "../../../shell/palette/commands";
-import { filterSlashMenuItems, mergeSlashCommands, parseSlashToken, spliceSlashCommand } from "./slashCompletion";
+import {
+  filterSlashMenuItems,
+  mergeSlashCommands,
+  parseSlashToken,
+  type SlashMenuItem,
+  spliceSlashCommand,
+} from "./slashCompletion";
 
 // --- parseSlashToken ---------------------------------------------------
 //
@@ -123,9 +129,88 @@ test("filterSlashMenuItems filters the merged list to labels starting with the q
   expect(filterSlashMenuItems(items, "RE").map((i) => i.label)).toEqual(["review", "release"]);
 });
 
+test("fuzzy matching finds simplify from a non-prefix query", () => {
+  const items = mergeSlashCommands([], [], [{ name: "simplify", description: "rewrite" }]);
+  expect(filterSlashMenuItems(items, "smp").map((item) => item.invocation)).toEqual(["/simplify"]);
+});
+
+test("skills merge after commands with canonical labels, invocations, and descriptions", () => {
+  const items = mergeSlashCommands(
+    [builtin("goal", "sets the session goal")],
+    [{ name: "review", description: "review the diff" }],
+    [{ name: "plugin:review", description: "review with the skill" }],
+  );
+  expect(items).toEqual([
+    { key: "builtin:goal", invocation: "/goal", label: "goal", hint: "sets the session goal", kind: "builtin" },
+    { key: "plugin::review", invocation: "/review", label: "review", hint: "review the diff", kind: "plugin" },
+    {
+      key: "skill:plugin:review",
+      invocation: "/plugin:review",
+      label: "plugin:review",
+      hint: "review with the skill",
+      kind: "skill",
+    },
+  ]);
+});
+
+test("fuzzy matching is case-insensitive and label-only", () => {
+  const items = mergeSlashCommands(
+    [],
+    [
+      { name: "review", description: "SMP appears only in the description" },
+      { name: "Simplify", description: "rewrite" },
+    ],
+  );
+  expect(filterSlashMenuItems(items, "SMP").map((item) => item.label)).toEqual(["Simplify"]);
+});
+
+test("fuzzy matching excludes labels that are not subsequences", () => {
+  const items = mergeSlashCommands([], [{ name: "simplify" }, { name: "sample" }, { name: "support" }]);
+  expect(filterSlashMenuItems(items, "smp").map((item) => item.label)).toEqual(["simplify", "sample"]);
+});
+
+test("ranking prefers exact, then beginning and contiguousness", () => {
+  const items: SlashMenuItem[] = [
+    { key: "scattered", invocation: "/axbyc", label: "axbyc", hint: "", kind: "skill" },
+    { key: "notBeginning", invocation: "/zabc", label: "zabc", hint: "", kind: "skill" },
+    { key: "exact", invocation: "/abc", label: "abc", hint: "", kind: "skill" },
+    { key: "contiguous", invocation: "/abcde", label: "abcde", hint: "", kind: "skill" },
+  ];
+  expect(filterSlashMenuItems(items, "abc").map((item) => item.key)).toEqual([
+    "exact",
+    "contiguous",
+    "scattered",
+    "notBeginning",
+  ]);
+});
+
+test("ranking prefers the narrowest span, then earliest match start", () => {
+  const items: SlashMenuItem[] = [
+    { key: "wide", invocation: "/a12e", label: "a12e", hint: "", kind: "skill" },
+    { key: "narrow", invocation: "/a1e", label: "a1e", hint: "", kind: "skill" },
+    { key: "late", invocation: "/xxae", label: "xxae", hint: "", kind: "skill" },
+    { key: "early", invocation: "/zae", label: "zae", hint: "", kind: "skill" },
+  ];
+  expect(filterSlashMenuItems(items, "ae").map((item) => item.key)).toEqual(["narrow", "wide", "early", "late"]);
+});
+
+test("ranking keeps original merge order for complete ties", () => {
+  const items: SlashMenuItem[] = [
+    { key: "first", invocation: "/ab", label: "ab", hint: "", kind: "skill" },
+    { key: "second", invocation: "/AB", label: "AB", hint: "", kind: "skill" },
+  ];
+  expect(filterSlashMenuItems(items, "a").map((item) => item.key)).toEqual(["first", "second"]);
+});
+
 test("filterSlashMenuItems with an empty query returns the whole merged list, in order", () => {
-  const items = mergeSlashCommands([builtin("goal", "sets the session goal")], CATALOG);
-  expect(filterSlashMenuItems(items, "").map((i) => i.label)).toEqual(["goal", "review", "release", "standup"]);
+  const items = mergeSlashCommands([builtin("goal", "sets the session goal")], CATALOG, [{ name: "simplify" }]);
+  expect(filterSlashMenuItems(items, "").map((i) => i.label)).toEqual([
+    "goal",
+    "review",
+    "release",
+    "standup",
+    "simplify",
+  ]);
 });
 
 test("filterSlashMenuItems matching nothing returns an empty list", () => {
@@ -137,12 +222,34 @@ test("a colon is a valid token character (a typed qualified prefix keeps the men
   expect(parseSlashToken("/plugin:re", 10)).toEqual({ start: 0, end: 10, query: "plugin:re" });
 });
 
+test("the slash token follows the documented bare or singly-qualified name grammar", () => {
+  expect(parseSlashToken("/-bad", 5)).toBeNull();
+  expect(parseSlashToken("/plugin:", 8)).toBeNull();
+  expect(parseSlashToken("/plugin:one:two", 16)).toBeNull();
+  expect(parseSlashToken(`/${"a".repeat(129)}`, 130)).toBeNull();
+});
+
 // --- spliceSlashCommand ---------------------------------------------------
 
 test("splices the chosen command in at the token start, with a trailing space, caret after the space", () => {
   const token = { start: 0, end: 2, query: "x" };
   const result = spliceSlashCommand("/x", token, "/review");
   expect(result).toEqual({ text: "/review ", caret: "/review ".length });
+});
+
+test("completion does not double a suffix space", () => {
+  const token = parseSlashToken("Use /sim on this", 8)!;
+  expect(spliceSlashCommand("Use /sim on this", token, "/simplify").text).toBe("Use /simplify on this");
+});
+
+test("completion does not double a suffix tab or newline", () => {
+  const tabText = "Use /sim\ton this";
+  const tabToken = parseSlashToken(tabText, "Use /sim".length)!;
+  expect(spliceSlashCommand(tabText, tabToken, "/simplify").text).toBe("Use /simplify\ton this");
+
+  const newlineText = "Use /sim\non this";
+  const newlineToken = parseSlashToken(newlineText, "Use /sim".length)!;
+  expect(spliceSlashCommand(newlineText, newlineToken, "/simplify").text).toBe("Use /simplify\non this");
 });
 
 test("splices a qualified plugin invocation in whole, not just the bare name", () => {
@@ -157,8 +264,8 @@ test("preserves text before the token", () => {
   expect(result).toEqual({ text: "hello /review ", caret: "hello /review ".length });
 });
 
-test("preserves text after the token (caret was mid-draft)", () => {
+test("preserves text after the token without adding a duplicate suffix space", () => {
   const token = { start: 0, end: 4, query: "rev" };
   const result = spliceSlashCommand("/rev and more", token, "/review");
-  expect(result).toEqual({ text: "/review  and more", caret: "/review ".length });
+  expect(result).toEqual({ text: "/review and more", caret: "/review".length });
 });

--- a/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.test.ts
@@ -219,6 +219,11 @@ test("repeated characters retain a beginning embedding that catches up later", (
   expect(filterSlashMenuItems(items, "abba").map((item) => item.key)).toEqual(["repeated", "competitor"]);
 });
 
+test("a full repeated subsequence is preserved when its best contiguous block is interior", () => {
+  const result = evaluateSlashLabel("babaa", "baaa");
+  expect(result.embedding).toEqual({ start: 0, end: 4, longestRun: 2 });
+});
+
 test("command and skill rows with the same name retain distinct keys", () => {
   const items = mergeSlashCommands(
     [builtin("review", "review command")],

--- a/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 import type { CommandDescriptor } from "../../../protocol/types.gen";
 import type { ScopedCommand } from "../../../shell/palette/commands";
 import {
+  evaluateSlashLabel,
   filterSlashMenuItems,
   mergeSlashCommands,
   parseSlashToken,
@@ -272,6 +273,14 @@ test("the slash token follows the documented bare or singly-qualified name gramm
 test("the parser accepts a name at the exact 128-character limit", () => {
   const name = "a".repeat(128);
   expect(parseSlashToken(`/${name}`, name.length + 1)).toEqual({ start: 0, end: name.length + 1, query: name });
+});
+
+test("max-length repeated fuzzy labels stay within the deterministic operation bound", () => {
+  const label = "a".repeat(128);
+  const query = "a".repeat(127);
+  const result = evaluateSlashLabel(label, query);
+  expect(result.embedding).toEqual({ start: 0, end: 126, longestRun: 127 });
+  expect(result.operations).toBeLessThan(5_000_000);
 });
 
 // --- spliceSlashCommand ---------------------------------------------------

--- a/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.test.ts
@@ -169,7 +169,7 @@ test("fuzzy matching excludes labels that are not subsequences", () => {
   expect(filterSlashMenuItems(items, "smp").map((item) => item.label)).toEqual(["simplify", "sample"]);
 });
 
-test("ranking prefers exact, then beginning and contiguousness", () => {
+test("ranking prefers exact, then contiguousness and beginning", () => {
   const items: SlashMenuItem[] = [
     { key: "scattered", invocation: "/axbyc", label: "axbyc", hint: "", kind: "skill" },
     { key: "notBeginning", invocation: "/zabc", label: "zabc", hint: "", kind: "skill" },
@@ -179,19 +179,19 @@ test("ranking prefers exact, then beginning and contiguousness", () => {
   expect(filterSlashMenuItems(items, "abc").map((item) => item.key)).toEqual([
     "exact",
     "contiguous",
-    "scattered",
     "notBeginning",
+    "scattered",
   ]);
 });
 
 test("ranking prefers the narrowest span, then earliest match start", () => {
   const items: SlashMenuItem[] = [
-    { key: "wide", invocation: "/a12e", label: "a12e", hint: "", kind: "skill" },
+    { key: "wide", invocation: "/za12e", label: "za12e", hint: "", kind: "skill" },
     { key: "narrow", invocation: "/a1e", label: "a1e", hint: "", kind: "skill" },
-    { key: "late", invocation: "/xxae", label: "xxae", hint: "", kind: "skill" },
-    { key: "early", invocation: "/zae", label: "zae", hint: "", kind: "skill" },
+    { key: "late", invocation: "/xxa1e", label: "xxa1e", hint: "", kind: "skill" },
+    { key: "early", invocation: "/za1e", label: "za1e", hint: "", kind: "skill" },
   ];
-  expect(filterSlashMenuItems(items, "ae").map((item) => item.key)).toEqual(["narrow", "wide", "early", "late"]);
+  expect(filterSlashMenuItems(items, "ae").map((item) => item.key)).toEqual(["narrow", "early", "late", "wide"]);
 });
 
 test("ranking keeps original merge order for complete ties", () => {
@@ -200,6 +200,38 @@ test("ranking keeps original merge order for complete ties", () => {
     { key: "second", invocation: "/AB", label: "AB", hint: "", kind: "skill" },
   ];
   expect(filterSlashMenuItems(items, "a").map((item) => item.key)).toEqual(["first", "second"]);
+});
+
+test("ranking chooses the best valid embedding instead of the first character occurrences", () => {
+  const items: SlashMenuItem[] = [
+    { key: "alternate", invocation: "/abxabc", label: "abxabc", hint: "", kind: "skill" },
+    { key: "competitor", invocation: "/a1bc", label: "a1bc", hint: "", kind: "skill" },
+  ];
+  expect(filterSlashMenuItems(items, "abc").map((item) => item.key)).toEqual(["alternate", "competitor"]);
+});
+
+test("command and skill rows with the same name retain distinct keys", () => {
+  const items = mergeSlashCommands(
+    [builtin("review", "review command")],
+    [],
+    [{ name: "review", description: "review skill" }],
+  );
+  expect(items.map((item) => ({ key: item.key, kind: item.kind, invocation: item.invocation }))).toEqual([
+    { key: "builtin:review", kind: "builtin", invocation: "/review" },
+    { key: "skill:review", kind: "skill", invocation: "/review" },
+  ]);
+});
+
+test("qualified skill labels can be filtered and spliced with their canonical invocation", () => {
+  const items = mergeSlashCommands([], [], [{ name: "plugin:review", description: "review skill" }]);
+  const [skill] = filterSlashMenuItems(items, "pr");
+  const text = "Use /pr on this";
+  const token = parseSlashToken(text, "Use /pr".length)!;
+  expect(skill?.label).toBe("plugin:review");
+  expect(spliceSlashCommand(text, token, skill!.invocation)).toEqual({
+    text: "Use /plugin:review on this",
+    caret: "Use /plugin:review".length,
+  });
 });
 
 test("filterSlashMenuItems with an empty query returns the whole merged list, in order", () => {
@@ -227,6 +259,11 @@ test("the slash token follows the documented bare or singly-qualified name gramm
   expect(parseSlashToken("/plugin:", 8)).toBeNull();
   expect(parseSlashToken("/plugin:one:two", 16)).toBeNull();
   expect(parseSlashToken(`/${"a".repeat(129)}`, 130)).toBeNull();
+});
+
+test("the parser accepts a name at the exact 128-character limit", () => {
+  const name = "a".repeat(128);
+  expect(parseSlashToken(`/${name}`, name.length + 1)).toEqual({ start: 0, end: name.length + 1, query: name });
 });
 
 // --- spliceSlashCommand ---------------------------------------------------

--- a/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.test.ts
@@ -210,6 +210,14 @@ test("ranking chooses the best valid embedding instead of the first character oc
   expect(filterSlashMenuItems(items, "abc").map((item) => item.key)).toEqual(["alternate", "competitor"]);
 });
 
+test("repeated characters retain a beginning embedding that catches up later", () => {
+  const items: SlashMenuItem[] = [
+    { key: "competitor", invocation: "/zabxba", label: "zabxba", hint: "", kind: "skill" },
+    { key: "repeated", invocation: "/aababa", label: "aababa", hint: "", kind: "skill" },
+  ];
+  expect(filterSlashMenuItems(items, "abba").map((item) => item.key)).toEqual(["repeated", "competitor"]);
+});
+
 test("command and skill rows with the same name retain distinct keys", () => {
   const items = mergeSlashCommands(
     [builtin("review", "review command")],

--- a/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.ts
@@ -123,10 +123,9 @@ interface SlashMatch {
   start: number;
 }
 
-interface SlashEmbedding {
+export interface SlashEmbedding {
   end: number;
   start: number;
-  currentRun: number;
   longestRun: number;
 }
 
@@ -141,55 +140,143 @@ function compareEmbeddings(a: SlashEmbedding, b: SlashEmbedding): number {
   return a.start - b.start;
 }
 
-function scoreSlashMatch(item: SlashMenuItem, query: string, index: number): SlashMatch | null {
-  const label = item.label.toLowerCase();
-  const firstCharacter = query[0];
-  if (firstCharacter === undefined) return null;
+export interface SlashMatchEvaluation {
+  embedding: SlashEmbedding | null;
+  operations: number;
+}
 
-  let embeddings: SlashEmbedding[] = [];
-  for (let labelIndex = 0; labelIndex < label.length; labelIndex += 1) {
-    if (label[labelIndex] === firstCharacter) {
-      embeddings.push({ end: labelIndex, start: labelIndex, currentRun: 1, longestRun: 1 });
+// evaluateSlashLabel finds the best valid embedding without enumerating all
+// subsequences. It first computes the maximum possible contiguous run (the
+// longest common substring), then considers every matching block of that
+// length. Prefix/suffix bounds represent every embedding that can achieve the
+// winning contiguousness while keeping the work polynomial.
+export function evaluateSlashLabel(rawLabel: string, rawQuery: string): SlashMatchEvaluation {
+  const label = rawLabel.toLowerCase();
+  const query = rawQuery.toLowerCase();
+  const queryLength = query.length;
+  const labelLength = label.length;
+  let operations = 0;
+  if (queryLength === 0 || labelLength === 0) return { embedding: null, operations };
+  if (label === query) {
+    return { embedding: { start: 0, end: queryLength - 1, longestRun: queryLength }, operations };
+  }
+
+  let longestRun = 0;
+  let previousRuns = new Array<number>(labelLength).fill(0);
+  for (let queryIndex = 0; queryIndex < queryLength; queryIndex += 1) {
+    const currentRuns = new Array<number>(labelLength).fill(0);
+    for (let labelIndex = 0; labelIndex < labelLength; labelIndex += 1) {
+      operations += 1;
+      if (query[queryIndex] !== label[labelIndex]) continue;
+      const previousRun = previousRuns[labelIndex - 1] ?? 0;
+      const run = queryIndex === 0 || labelIndex === 0 ? 1 : previousRun + 1;
+      currentRuns[labelIndex] = run;
+      longestRun = Math.max(longestRun, run);
+    }
+    previousRuns = currentRuns;
+  }
+  if (longestRun === 0) return { embedding: null, operations };
+
+  const fixedEnds = Array.from({ length: labelLength }, () =>
+    new Array<number | undefined>(queryLength + 1).fill(undefined),
+  );
+  for (let start = 0; start < labelLength; start += 1) {
+    operations += 1;
+    const row = fixedEnds[start];
+    if (!row || label[start] !== query[0]) continue;
+    row[1] = start;
+    for (let length = 2; length <= queryLength; length += 1) {
+      operations += 1;
+      const previousEnd = row[length - 1];
+      if (previousEnd === undefined) break;
+      const character = query[length - 1];
+      if (character === undefined) break;
+      const end = label.indexOf(character, previousEnd + 1);
+      operations += 1;
+      if (end < 0) break;
+      row[length] = end;
     }
   }
 
-  for (let queryIndex = 1; queryIndex < query.length; queryIndex += 1) {
-    const queryCharacter = query[queryIndex];
-    if (queryCharacter === undefined) return null;
-    const bestByState = new Map<string, SlashEmbedding>();
-    for (let labelIndex = 0; labelIndex < label.length; labelIndex += 1) {
-      if (label[labelIndex] !== queryCharacter) continue;
-      for (const previous of embeddings) {
-        if (previous.end >= labelIndex) continue;
-        const currentRun = labelIndex === previous.end + 1 ? previous.currentRun + 1 : 1;
-        const candidate: SlashEmbedding = {
-          end: labelIndex,
-          start: previous.start,
-          currentRun,
-          longestRun: Math.max(previous.longestRun, currentRun),
-        };
-        // Beginning and longestRun are both part of the eventual score, but a
-        // shorter run can catch up after later characters (and then beat a
-        // non-beginning embedding). Keep each Pareto-relevant combination
-        // until all query characters have been matched.
-        const stateKey = `${labelIndex}:${currentRun}:${candidate.start === 0 ? 1 : 0}:${candidate.longestRun}`;
-        const existing = bestByState.get(stateKey);
-        if (!existing || compareEmbeddings(candidate, existing) < 0) {
-          bestByState.set(stateKey, candidate);
+  const latestStarts = Array.from({ length: queryLength + 1 }, () =>
+    new Array<number | undefined>(labelLength + 1).fill(undefined),
+  );
+  for (let length = 1; length <= queryLength; length += 1) {
+    const row = latestStarts[length];
+    if (!row) continue;
+    for (let bound = 1; bound <= labelLength; bound += 1) {
+      for (let start = bound - 1; start >= 0; start -= 1) {
+        operations += 1;
+        const end = fixedEnds[start]?.[length];
+        if (end !== undefined && end < bound) {
+          row[bound] = start;
+          break;
         }
       }
     }
-    embeddings = [...bestByState.values()];
   }
 
-  if (embeddings.length === 0) return null;
-  const embedding = embeddings.reduce((best, candidate) => (compareEmbeddings(candidate, best) < 0 ? candidate : best));
-  const start = embedding.start;
-  const end = embedding.end;
+  const suffixEnds = Array.from({ length: queryLength + 1 }, () =>
+    new Array<number | undefined>(labelLength + 1).fill(undefined),
+  );
+  for (let start = 0; start < queryLength; start += 1) {
+    const row = suffixEnds[start];
+    if (!row) continue;
+    for (let bound = 0; bound <= labelLength; bound += 1) {
+      let end = bound - 1;
+      let matched = true;
+      for (let queryIndex = start; queryIndex < queryLength; queryIndex += 1) {
+        operations += 1;
+        const character = query[queryIndex];
+        if (character === undefined) {
+          matched = false;
+          break;
+        }
+        end = label.indexOf(character, end + 1);
+        operations += 1;
+        if (end < 0) {
+          matched = false;
+          break;
+        }
+      }
+      if (matched) row[bound] = end;
+    }
+  }
+
+  let best: SlashEmbedding | null = null;
+  const consider = (candidate: SlashEmbedding) => {
+    if (!best || compareEmbeddings(candidate, best) < 0) best = candidate;
+  };
+  for (let queryStart = 0; queryStart + longestRun <= queryLength; queryStart += 1) {
+    const block = query.slice(queryStart, queryStart + longestRun);
+    for (let labelStart = 0; labelStart + longestRun <= labelLength; labelStart += 1) {
+      operations += 1;
+      if (!label.startsWith(block, labelStart)) continue;
+      const blockEnd = labelStart + longestRun - 1;
+      const end =
+        queryStart + longestRun === queryLength ? blockEnd : suffixEnds[queryStart + longestRun]?.[blockEnd + 1];
+      if (end === undefined) continue;
+
+      const start = queryStart === 0 ? labelStart : latestStarts[queryStart]?.[labelStart];
+      if (start !== undefined) consider({ start, end, longestRun });
+
+      const beginningPrefixEnd = fixedEnds[0]?.[queryStart];
+      const begins =
+        queryStart === 0 ? labelStart === 0 : beginningPrefixEnd !== undefined && beginningPrefixEnd < labelStart;
+      if (begins && (start !== 0 || queryStart !== 0)) consider({ start: 0, end, longestRun });
+    }
+  }
+  return { embedding: best, operations };
+}
+
+function scoreSlashMatch(item: SlashMenuItem, query: string, index: number): SlashMatch | null {
+  const { embedding } = evaluateSlashLabel(item.label, query);
+  if (!embedding) return null;
+  const { start, end } = embedding;
   return {
     item,
     index,
-    exact: label === query,
+    exact: item.label.toLowerCase() === query,
     begins: start === 0,
     contiguousness: embedding.longestRun,
     span: end - start,

--- a/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.ts
@@ -168,7 +168,11 @@ function scoreSlashMatch(item: SlashMenuItem, query: string, index: number): Sla
           currentRun,
           longestRun: Math.max(previous.longestRun, currentRun),
         };
-        const stateKey = `${labelIndex}:${currentRun}`;
+        // Beginning and longestRun are both part of the eventual score, but a
+        // shorter run can catch up after later characters (and then beat a
+        // non-beginning embedding). Keep each Pareto-relevant combination
+        // until all query characters have been matched.
+        const stateKey = `${labelIndex}:${currentRun}:${candidate.start === 0 ? 1 : 0}:${candidate.longestRun}`;
         const existing = bestByState.get(stateKey);
         if (!existing || compareEmbeddings(candidate, existing) < 0) {
           bestByState.set(stateKey, candidate);

--- a/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.ts
@@ -146,10 +146,10 @@ export interface SlashMatchEvaluation {
 }
 
 // evaluateSlashLabel finds the best valid embedding without enumerating all
-// subsequences. It first computes the maximum possible contiguous run (the
-// longest common substring), then considers every matching block of that
-// length. Prefix/suffix bounds represent every embedding that can achieve the
-// winning contiguousness while keeping the work polynomial.
+// subsequences. It considers every contiguous block that can participate in a
+// full embedding, using precomputed prefix/suffix bounds to keep the search
+// polynomial. Unlike an unconstrained longest-common-substring shortcut, a
+// block is scored only when the rest of the query can be embedded around it.
 export function evaluateSlashLabel(rawLabel: string, rawQuery: string): SlashMatchEvaluation {
   const label = rawLabel.toLowerCase();
   const query = rawQuery.toLowerCase();
@@ -157,25 +157,25 @@ export function evaluateSlashLabel(rawLabel: string, rawQuery: string): SlashMat
   const labelLength = label.length;
   let operations = 0;
   if (queryLength === 0 || labelLength === 0) return { embedding: null, operations };
+  const firstCharacter = query[0];
+  if (firstCharacter === undefined) return { embedding: null, operations };
   if (label === query) {
     return { embedding: { start: 0, end: queryLength - 1, longestRun: queryLength }, operations };
   }
 
-  let longestRun = 0;
-  let previousRuns = new Array<number>(labelLength).fill(0);
-  for (let queryIndex = 0; queryIndex < queryLength; queryIndex += 1) {
-    const currentRuns = new Array<number>(labelLength).fill(0);
-    for (let labelIndex = 0; labelIndex < labelLength; labelIndex += 1) {
+  const nextPositions = new Map<string, Array<number | undefined>>();
+  for (const character of new Set(query)) {
+    const row = new Array<number | undefined>(labelLength + 1).fill(undefined);
+    let next: number | undefined;
+    for (let labelIndex = labelLength; labelIndex >= 0; labelIndex -= 1) {
       operations += 1;
-      if (query[queryIndex] !== label[labelIndex]) continue;
-      const previousRun = previousRuns[labelIndex - 1] ?? 0;
-      const run = queryIndex === 0 || labelIndex === 0 ? 1 : previousRun + 1;
-      currentRuns[labelIndex] = run;
-      longestRun = Math.max(longestRun, run);
+      row[labelIndex] = next;
+      if (labelIndex > 0 && label[labelIndex - 1] === character) next = labelIndex - 1;
     }
-    previousRuns = currentRuns;
+    nextPositions.set(character, row);
   }
-  if (longestRun === 0) return { embedding: null, operations };
+  const nextPosition = (character: string, bound: number): number | undefined =>
+    nextPositions.get(character)?.[Math.min(bound, labelLength)];
 
   const fixedEnds = Array.from({ length: labelLength }, () =>
     new Array<number | undefined>(queryLength + 1).fill(undefined),
@@ -183,7 +183,7 @@ export function evaluateSlashLabel(rawLabel: string, rawQuery: string): SlashMat
   for (let start = 0; start < labelLength; start += 1) {
     operations += 1;
     const row = fixedEnds[start];
-    if (!row || label[start] !== query[0]) continue;
+    if (!row || nextPosition(firstCharacter, start) !== start) continue;
     row[1] = start;
     for (let length = 2; length <= queryLength; length += 1) {
       operations += 1;
@@ -191,9 +191,9 @@ export function evaluateSlashLabel(rawLabel: string, rawQuery: string): SlashMat
       if (previousEnd === undefined) break;
       const character = query[length - 1];
       if (character === undefined) break;
-      const end = label.indexOf(character, previousEnd + 1);
+      const end = nextPosition(character, previousEnd + 1);
       operations += 1;
-      if (end < 0) break;
+      if (end === undefined) break;
       row[length] = end;
     }
   }
@@ -204,42 +204,36 @@ export function evaluateSlashLabel(rawLabel: string, rawQuery: string): SlashMat
   for (let length = 1; length <= queryLength; length += 1) {
     const row = latestStarts[length];
     if (!row) continue;
+    const startsByEnd = Array.from({ length: labelLength }, () => [] as number[]);
+    for (let start = 0; start < labelLength; start += 1) {
+      const end = fixedEnds[start]?.[length];
+      if (end !== undefined) startsByEnd[end]?.push(start);
+    }
+    let latest: number | undefined;
     for (let bound = 1; bound <= labelLength; bound += 1) {
-      for (let start = bound - 1; start >= 0; start -= 1) {
-        operations += 1;
-        const end = fixedEnds[start]?.[length];
-        if (end !== undefined && end < bound) {
-          row[bound] = start;
-          break;
-        }
-      }
+      operations += 1;
+      for (const start of startsByEnd[bound - 1] ?? []) latest = Math.max(latest ?? -1, start);
+      row[bound] = latest;
     }
   }
 
   const suffixEnds = Array.from({ length: queryLength + 1 }, () =>
     new Array<number | undefined>(labelLength + 1).fill(undefined),
   );
-  for (let start = 0; start < queryLength; start += 1) {
+  const emptySuffix = suffixEnds[queryLength];
+  if (emptySuffix) {
+    for (let bound = 0; bound <= labelLength; bound += 1) emptySuffix[bound] = bound - 1;
+  }
+  for (let start = queryLength - 1; start >= 0; start -= 1) {
     const row = suffixEnds[start];
-    if (!row) continue;
+    const nextRow = suffixEnds[start + 1];
+    if (!row || !nextRow) continue;
     for (let bound = 0; bound <= labelLength; bound += 1) {
-      let end = bound - 1;
-      let matched = true;
-      for (let queryIndex = start; queryIndex < queryLength; queryIndex += 1) {
-        operations += 1;
-        const character = query[queryIndex];
-        if (character === undefined) {
-          matched = false;
-          break;
-        }
-        end = label.indexOf(character, end + 1);
-        operations += 1;
-        if (end < 0) {
-          matched = false;
-          break;
-        }
-      }
-      if (matched) row[bound] = end;
+      operations += 1;
+      const character = query[start];
+      if (character === undefined) continue;
+      const first = nextPosition(character, bound);
+      if (first !== undefined) row[bound] = nextRow[first + 1];
     }
   }
 
@@ -247,23 +241,31 @@ export function evaluateSlashLabel(rawLabel: string, rawQuery: string): SlashMat
   const consider = (candidate: SlashEmbedding) => {
     if (!best || compareEmbeddings(candidate, best) < 0) best = candidate;
   };
-  for (let queryStart = 0; queryStart + longestRun <= queryLength; queryStart += 1) {
-    const block = query.slice(queryStart, queryStart + longestRun);
-    for (let labelStart = 0; labelStart + longestRun <= labelLength; labelStart += 1) {
-      operations += 1;
-      if (!label.startsWith(block, labelStart)) continue;
-      const blockEnd = labelStart + longestRun - 1;
-      const end =
-        queryStart + longestRun === queryLength ? blockEnd : suffixEnds[queryStart + longestRun]?.[blockEnd + 1];
-      if (end === undefined) continue;
+  for (let queryStart = 0; queryStart < queryLength; queryStart += 1) {
+    for (let labelStart = 0; labelStart < labelLength; labelStart += 1) {
+      let blockLength = 0;
+      while (
+        queryStart + blockLength < queryLength &&
+        labelStart + blockLength < labelLength &&
+        query[queryStart + blockLength] === label[labelStart + blockLength]
+      ) {
+        operations += 1;
+        blockLength += 1;
+        const blockEnd = labelStart + blockLength - 1;
+        const end =
+          queryStart + blockLength === queryLength ? blockEnd : suffixEnds[queryStart + blockLength]?.[blockEnd + 1];
+        if (end === undefined) continue;
 
-      const start = queryStart === 0 ? labelStart : latestStarts[queryStart]?.[labelStart];
-      if (start !== undefined) consider({ start, end, longestRun });
+        const start = queryStart === 0 ? labelStart : latestStarts[queryStart]?.[labelStart];
+        if (start !== undefined) consider({ start, end, longestRun: blockLength });
 
-      const beginningPrefixEnd = fixedEnds[0]?.[queryStart];
-      const begins =
-        queryStart === 0 ? labelStart === 0 : beginningPrefixEnd !== undefined && beginningPrefixEnd < labelStart;
-      if (begins && (start !== 0 || queryStart !== 0)) consider({ start: 0, end, longestRun });
+        const beginningPrefixEnd = fixedEnds[0]?.[queryStart];
+        const begins =
+          queryStart === 0 ? labelStart === 0 : beginningPrefixEnd !== undefined && beginningPrefixEnd < labelStart;
+        if (begins && (start !== 0 || queryStart !== 0)) {
+          consider({ start: 0, end, longestRun: blockLength });
+        }
+      }
     }
   }
   return { embedding: best, operations };

--- a/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.ts
@@ -9,7 +9,7 @@
 // text/caret state and the plugin slash-command catalog (stores/
 // commandCatalog.ts), the same catalog the modal command palette reads.
 
-import type { CommandDescriptor } from "../../../protocol/types.gen";
+import type { CommandDescriptor, EvenerSkillInfo } from "../../../protocol/types.gen";
 import { type ScopedCommand, slashCommandInvocation } from "../../../shell/palette/commands";
 
 export interface SlashToken {
@@ -21,16 +21,11 @@ export interface SlashToken {
   query: string;
 }
 
-// Beautiful UI's own trailing-token regex, slash-only: a "/" preceded by
-// start-of-string or whitespace, followed by zero or more word/hyphen/colon
-// characters, anchored at the END of whatever string it's run against. The
-// colon is this fork's own addition (Beautiful UI has no qualified-command
-// concept): a typed "/plugin:rev" must keep matching as ONE token through
-// the colon, or the menu closes the instant the user types past "/plugin"
-// into the qualifier - see filterSlashCommands' own note on matching
-// against `name` only, and Composer.tsx's commitSlashCompletion for the
-// qualified invocation this makes it possible to type manually.
-const TRAILING_SLASH_TOKEN_RE = /(^|\s)(\/)([\w:-]*)$/;
+// A slash token is a documented bare or singly-qualified catalog name. The
+// final negative lookahead is a strict end-of-input anchor: unlike `$`, it
+// does not match before a trailing newline. The catalog grammar is ASCII and
+// therefore its maximum 128 UTF-8 bytes is also 128 JavaScript characters.
+const TRAILING_SLASH_TOKEN_RE = /(^|\s)(\/)((?:[A-Za-z0-9_][A-Za-z0-9_-]*(?::[A-Za-z0-9_][A-Za-z0-9_-]*)?)?)(?![\s\S])/;
 
 // parseSlashToken looks for a slash token the caret trails, by running the
 // trailing-token regex against the text BEFORE the caret only - text after
@@ -47,6 +42,7 @@ export function parseSlashToken(text: string, caret: number): SlashToken | null 
   if (!match) return null;
   const leadIn = match[1] ?? "";
   const query = match[3] ?? "";
+  if (query.length > 128) return null;
   const start = match.index + leadIn.length;
   return { start, end: caret, query };
 }
@@ -77,7 +73,7 @@ export interface SlashMenuItem {
   // it no description at all (2026-08-14 decision: "the hint states what it
   // does, or its plugin provenance").
   hint: string;
-  kind: "builtin" | "plugin";
+  kind: "builtin" | "plugin" | "skill";
 }
 
 // mergeSlashCommands is the composer's own single merge point (2026-08-14,
@@ -92,7 +88,11 @@ export interface SlashMenuItem {
 // it from the FULL unfiltered list at submit time, so a typed invocation for
 // a momentarily-unavailable command still gets an honest "not available
 // right now" instead of silently being sent as a chat message.
-export function mergeSlashCommands(builtins: ScopedCommand[], catalog: CommandDescriptor[]): SlashMenuItem[] {
+export function mergeSlashCommands(
+  builtins: ScopedCommand[],
+  catalog: CommandDescriptor[],
+  skills: EvenerSkillInfo[] = [],
+): SlashMenuItem[] {
   const builtinItems: SlashMenuItem[] = builtins
     .filter((c) => c.unavailableReason === undefined)
     .map((c) => ({ key: `builtin:${c.id}`, invocation: `/${c.id}`, label: c.id, hint: c.hint, kind: "builtin" }));
@@ -103,16 +103,83 @@ export function mergeSlashCommands(builtins: ScopedCommand[], catalog: CommandDe
     hint: c.description || c.argumentHint || `plugin: ${c.pluginName ?? c.source ?? "unknown"}`,
     kind: "plugin",
   }));
-  return [...builtinItems, ...pluginItems];
+  const skillItems: SlashMenuItem[] = skills.map((skill) => ({
+    key: `skill:${skill.name}`,
+    invocation: `/${skill.name}`,
+    label: skill.name,
+    hint: skill.description ?? "",
+    kind: "skill",
+  }));
+  return [...builtinItems, ...pluginItems, ...skillItems];
 }
 
-// filterSlashMenuItems: startsWith on the item's own label, case-insensitive
-// (the same normalization shell/palette/commands.ts's own filterCommands
-// uses for its query). An empty query matches every item, in merge order
-// (built-ins first, then the catalog).
+interface SlashMatch {
+  item: SlashMenuItem;
+  index: number;
+  exact: boolean;
+  begins: boolean;
+  contiguousness: number;
+  span: number;
+  start: number;
+}
+
+function scoreSlashMatch(item: SlashMenuItem, query: string, index: number): SlashMatch | null {
+  const label = item.label.toLowerCase();
+  const positions: number[] = [];
+  let labelIndex = 0;
+  for (const queryCharacter of query) {
+    const matchIndex = label.indexOf(queryCharacter, labelIndex);
+    if (matchIndex < 0) return null;
+    positions.push(matchIndex);
+    labelIndex = matchIndex + 1;
+  }
+
+  let longestRun = 1;
+  let currentRun = 1;
+  for (let positionIndex = 1; positionIndex < positions.length; positionIndex += 1) {
+    const position = positions[positionIndex];
+    const previousPosition = positions[positionIndex - 1];
+    if (position !== undefined && previousPosition !== undefined && position === previousPosition + 1) {
+      currentRun += 1;
+      longestRun = Math.max(longestRun, currentRun);
+    } else {
+      currentRun = 1;
+    }
+  }
+
+  const start = positions[0] ?? 0;
+  const end = positions[positions.length - 1] ?? 0;
+  return {
+    item,
+    index,
+    exact: label === query,
+    begins: start === 0,
+    contiguousness: longestRun,
+    span: end - start,
+    start,
+  };
+}
+
+function compareSlashMatches(a: SlashMatch, b: SlashMatch): number {
+  if (a.exact !== b.exact) return a.exact ? -1 : 1;
+  if (a.begins !== b.begins) return a.begins ? -1 : 1;
+  if (a.contiguousness !== b.contiguousness) return b.contiguousness - a.contiguousness;
+  if (a.span !== b.span) return a.span - b.span;
+  if (a.start !== b.start) return a.start - b.start;
+  return a.index - b.index;
+}
+
+// filterSlashMenuItems matches only the item's own label, case-insensitively.
+// Empty queries preserve merge order; non-empty queries are ranked by the
+// documented exact/beginning/contiguousness/span/earliest/index tuple.
 export function filterSlashMenuItems(items: SlashMenuItem[], query: string): SlashMenuItem[] {
   const q = query.toLowerCase();
-  return items.filter((item) => item.label.toLowerCase().startsWith(q));
+  if (!q) return items;
+  return items
+    .map((item, index) => scoreSlashMatch(item, q, index))
+    .filter((match): match is SlashMatch => match !== null)
+    .sort(compareSlashMatches)
+    .map((match) => match.item);
 }
 
 export interface SlashSpliceResult {
@@ -129,7 +196,7 @@ export interface SlashSpliceResult {
 // inserted trailing space, ahead of any surviving trailing text.
 export function spliceSlashCommand(text: string, token: SlashToken, invocation: string): SlashSpliceResult {
   const before = text.slice(0, token.start);
-  const after = text.slice(token.end);
-  const inserted = `${invocation} `;
-  return { text: before + inserted + after, caret: before.length + inserted.length };
+  const suffix = text.slice(token.end);
+  const inserted = /^\s/.test(suffix) ? invocation : `${invocation} `;
+  return { text: before + inserted + suffix, caret: before.length + inserted.length };
 }

--- a/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.ts
@@ -123,38 +123,71 @@ interface SlashMatch {
   start: number;
 }
 
+interface SlashEmbedding {
+  end: number;
+  start: number;
+  currentRun: number;
+  longestRun: number;
+}
+
+function compareEmbeddings(a: SlashEmbedding, b: SlashEmbedding): number {
+  const aBegins = a.start === 0;
+  const bBegins = b.start === 0;
+  if (a.longestRun !== b.longestRun) return b.longestRun - a.longestRun;
+  if (aBegins !== bBegins) return aBegins ? -1 : 1;
+  const aSpan = a.end - a.start;
+  const bSpan = b.end - b.start;
+  if (aSpan !== bSpan) return aSpan - bSpan;
+  return a.start - b.start;
+}
+
 function scoreSlashMatch(item: SlashMenuItem, query: string, index: number): SlashMatch | null {
   const label = item.label.toLowerCase();
-  const positions: number[] = [];
-  let labelIndex = 0;
-  for (const queryCharacter of query) {
-    const matchIndex = label.indexOf(queryCharacter, labelIndex);
-    if (matchIndex < 0) return null;
-    positions.push(matchIndex);
-    labelIndex = matchIndex + 1;
-  }
+  const firstCharacter = query[0];
+  if (firstCharacter === undefined) return null;
 
-  let longestRun = 1;
-  let currentRun = 1;
-  for (let positionIndex = 1; positionIndex < positions.length; positionIndex += 1) {
-    const position = positions[positionIndex];
-    const previousPosition = positions[positionIndex - 1];
-    if (position !== undefined && previousPosition !== undefined && position === previousPosition + 1) {
-      currentRun += 1;
-      longestRun = Math.max(longestRun, currentRun);
-    } else {
-      currentRun = 1;
+  let embeddings: SlashEmbedding[] = [];
+  for (let labelIndex = 0; labelIndex < label.length; labelIndex += 1) {
+    if (label[labelIndex] === firstCharacter) {
+      embeddings.push({ end: labelIndex, start: labelIndex, currentRun: 1, longestRun: 1 });
     }
   }
 
-  const start = positions[0] ?? 0;
-  const end = positions[positions.length - 1] ?? 0;
+  for (let queryIndex = 1; queryIndex < query.length; queryIndex += 1) {
+    const queryCharacter = query[queryIndex];
+    if (queryCharacter === undefined) return null;
+    const bestByState = new Map<string, SlashEmbedding>();
+    for (let labelIndex = 0; labelIndex < label.length; labelIndex += 1) {
+      if (label[labelIndex] !== queryCharacter) continue;
+      for (const previous of embeddings) {
+        if (previous.end >= labelIndex) continue;
+        const currentRun = labelIndex === previous.end + 1 ? previous.currentRun + 1 : 1;
+        const candidate: SlashEmbedding = {
+          end: labelIndex,
+          start: previous.start,
+          currentRun,
+          longestRun: Math.max(previous.longestRun, currentRun),
+        };
+        const stateKey = `${labelIndex}:${currentRun}`;
+        const existing = bestByState.get(stateKey);
+        if (!existing || compareEmbeddings(candidate, existing) < 0) {
+          bestByState.set(stateKey, candidate);
+        }
+      }
+    }
+    embeddings = [...bestByState.values()];
+  }
+
+  if (embeddings.length === 0) return null;
+  const embedding = embeddings.reduce((best, candidate) => (compareEmbeddings(candidate, best) < 0 ? candidate : best));
+  const start = embedding.start;
+  const end = embedding.end;
   return {
     item,
     index,
     exact: label === query,
     begins: start === 0,
-    contiguousness: longestRun,
+    contiguousness: embedding.longestRun,
     span: end - start,
     start,
   };
@@ -162,8 +195,8 @@ function scoreSlashMatch(item: SlashMenuItem, query: string, index: number): Sla
 
 function compareSlashMatches(a: SlashMatch, b: SlashMatch): number {
   if (a.exact !== b.exact) return a.exact ? -1 : 1;
-  if (a.begins !== b.begins) return a.begins ? -1 : 1;
   if (a.contiguousness !== b.contiguousness) return b.contiguousness - a.contiguousness;
+  if (a.begins !== b.begins) return a.begins ? -1 : 1;
   if (a.span !== b.span) return a.span - b.span;
   if (a.start !== b.start) return a.start - b.start;
   return a.index - b.index;

--- a/cmd/evener-hub/frontend/src/protocol/__snapshots__/reducer.test.ts.snap
+++ b/cmd/evener-hub/frontend/src/protocol/__snapshots__/reducer.test.ts.snap
@@ -43,6 +43,7 @@ exports[`fixture basic-turn reduces to the expected model 1`] = `
   "reasoningEffort": undefined,
   "reasoningEffortLevels": [],
   "ref": "ref_1001",
+  "skills": [],
   "status": {
     "type": "idle",
   },
@@ -212,6 +213,7 @@ exports[`fixture queue-and-status reduces to the expected model 1`] = `
     "high",
   ],
   "ref": "ref_4001",
+  "skills": [],
   "status": {
     "type": "active",
   },
@@ -331,6 +333,7 @@ exports[`fixture streaming-with-reset reduces to the expected model 1`] = `
   "reasoningEffort": undefined,
   "reasoningEffortLevels": [],
   "ref": "ref_2001",
+  "skills": [],
   "status": {
     "type": "idle",
   },
@@ -458,6 +461,7 @@ exports[`fixture tool-and-jobs reduces to the expected model 1`] = `
   "reasoningEffort": undefined,
   "reasoningEffortLevels": [],
   "ref": "ref_3001",
+  "skills": [],
   "status": {
     "type": "idle",
   },

--- a/cmd/evener-hub/frontend/src/protocol/model.ts
+++ b/cmd/evener-hub/frontend/src/protocol/model.ts
@@ -5,6 +5,7 @@
 
 import type {
   EvenerDelegateInfo,
+  EvenerSkillInfo,
   EvenerTurnSlots,
   EvenerUsage,
   GoalState,
@@ -229,6 +230,7 @@ export interface ThreadModel {
   // independently max-merged because transcript activity is durable outside
   // the lifecycle event sequence.
   delegates?: EvenerDelegateInfo[];
+  skills?: EvenerSkillInfo[];
   turnSlots?: EvenerTurnSlots | null;
   // Bumped (to the reducer's frame time) by every evener/job/started and
   // evener/job/finished for this thread; the jobs panel re-fetches its list when

--- a/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
@@ -212,6 +212,26 @@ test("hydrateThread defaults missing skills and copies wire descriptors", () => 
   expect(model.skills?.[0]).not.toBe(skills[0]);
 });
 
+test("applyNotification preserves skills while applying a status update", () => {
+  const model = testHydrate({
+    evener: { diagnostics: { skills: [{ name: "plugin:simplify", description: "rewrite" }] } },
+  });
+  const notification: AnyNotification = {
+    method: "thread/status/changed",
+    params: {
+      threadId: model.threadId,
+      ref: model.ref,
+      status: { type: "active" },
+      capabilities: CAPABILITIES,
+    },
+  };
+
+  const next = applyNotification(model, notification, 2000);
+
+  expect(next).not.toBe(model);
+  expect(next.skills).toEqual([{ name: "plugin:simplify", description: "rewrite" }]);
+});
+
 function testEscalation(overrides: Partial<SandboxEscalationRequested> = {}): SandboxEscalationRequested {
   return {
     threadId: "thr_t",

--- a/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
@@ -129,7 +129,7 @@ const CAPABILITIES: ThreadCapabilities = {
 };
 
 type TestThreadOverrides = Omit<Partial<Thread>, "evener"> & {
-  evener?: Omit<Thread["evener"], "queue"> & { queue: Partial<QueueState> };
+  evener?: Partial<Omit<Thread["evener"], "queue">> & { queue?: Partial<QueueState> };
 };
 
 function testThread(overrides: TestThreadOverrides = {}): Thread {
@@ -194,6 +194,22 @@ test("hydrateThread preserves an explicit empty plugin inventory", () => {
 
 test("hydrateThread leaves diagnostics unavailable when the wire omits them", () => {
   expect(testHydrate().diagnostics).toBeUndefined();
+});
+
+test("hydrateThread retains canonical skill descriptors", () => {
+  const model = testHydrate({
+    evener: { diagnostics: { skills: [{ name: "plugin:simplify", description: "rewrite" }] } },
+  });
+  expect(model.skills).toEqual([{ name: "plugin:simplify", description: "rewrite" }]);
+});
+
+test("hydrateThread defaults missing skills and copies wire descriptors", () => {
+  expect(testHydrate().skills).toEqual([]);
+
+  const skills = [{ name: "plugin:simplify", description: "rewrite" }];
+  const model = testHydrate({ evener: { diagnostics: { skills } } });
+  expect(model.skills).not.toBe(skills);
+  expect(model.skills?.[0]).not.toBe(skills[0]);
 });
 
 function testEscalation(overrides: Partial<SandboxEscalationRequested> = {}): SandboxEscalationRequested {

--- a/cmd/evener-hub/frontend/src/protocol/reducer.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.ts
@@ -339,6 +339,7 @@ export function hydrateThread(resp: ThreadReadResponse, ref: string, now: number
       ? { diagnostics: { plugins: thread.evener.diagnostics.plugins?.map((plugin) => ({ name: plugin.name })) } }
       : {}),
     delegates: (thread.evener.diagnostics?.delegates ?? []).map(cloneStableDelegate),
+    skills: (thread.evener.diagnostics?.skills ?? []).map((skill) => ({ ...skill })),
     turnSlots: thread.evener.diagnostics?.turnSlots ? { ...thread.evener.diagnostics.turnSlots } : null,
     jobsUpdatedAt: null,
     jobsTreeRevision: null,


### PR DESCRIPTION
## Summary
- expose session skills in the web composer slash completion menu
- add deterministic fuzzy matching and standalone skill activation
- preserve canonical plugin names and cold-session metadata boundaries

## Verification
- `go test ./agent/skill ./agent ./cmd/evener-hub`
- frontend focused matrix: 293/293 tests
- TypeScript and Biome
- `make merge-approval-gate`

All passed.