### PR TITLE
feat: show resolved defaults in all launch-config surfaces

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/settings/sections/launchServer.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/launchServer.test.tsx
@@ -118,3 +118,71 @@ describe("save", () => {
     await waitFor(() => expect(screen.getByText("post-save warning")).toBeTruthy());
   });
 });
+
+describe("resolved-default labels", () => {
+  // A boolean field is the readable case: its unset marker is the generic
+  // "(default)", which the resolve's effective layer turns into
+  // "true (default)" / "false (default)".
+  const BOOL_SCHEMA: LaunchOptionSchemaResponse = {
+    options: [
+      {
+        field: "sandbox_net",
+        wireField: "sandboxNet",
+        label: "Sandbox network egress",
+        group: "Sandbox",
+        kind: "boolean",
+        perLaunch: true,
+        defaultableLayers: ["global", "project"],
+      },
+    ],
+  };
+
+  function boolOptionLabels(): (string | null)[] {
+    const select = screen.getByLabelText("Sandbox network egress") as HTMLSelectElement;
+    return Array.from(select.options).map((o) => o.textContent);
+  }
+
+  test("an unset field names the effective layer's value once the initial resolve lands", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/launch/schema", () => BOOL_SCHEMA);
+    fake.on("evener/launch/getLayer", () => ({}));
+    fake.on("evener/launch/resolve", () => ({
+      effective: { sandboxNet: true },
+      layers: {},
+      provenance: {},
+    }));
+    render(<LaunchServerSection sectionId="launch-evener" />);
+
+    await screen.findByLabelText("Sandbox network egress");
+    await waitFor(() => expect(boolOptionLabels()).toEqual(["true (default)", "true", "false"]));
+  });
+
+  test("a failed resolve leaves the plain (default) marker", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/launch/schema", () => BOOL_SCHEMA);
+    fake.on("evener/launch/getLayer", () => ({}));
+    fake.on("evener/launch/resolve", () => {
+      throw new Error("resolve failed");
+    });
+    render(<LaunchServerSection sectionId="launch-evener" />);
+
+    await screen.findByLabelText("Sandbox network egress");
+    expect(boolOptionLabels()).toEqual(["(default)", "true", "false"]);
+  });
+
+  test("saving refreshes the labels from setLayer's own returned resolved config", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/launch/schema", () => BOOL_SCHEMA);
+    fake.on("evener/launch/getLayer", () => ({}));
+    fake.on("evener/launch/resolve", () => ({ effective: { sandboxNet: true }, layers: {}, provenance: {} }));
+    fake.on("evener/launch/setLayer", () => ({ effective: { sandboxNet: false }, layers: {}, provenance: {} }));
+    render(<LaunchServerSection sectionId="launch-evener" />);
+
+    await screen.findByLabelText("Sandbox network egress");
+    await waitFor(() => expect(boolOptionLabels()).toEqual(["true (default)", "true", "false"]));
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Save launch defaults" }));
+    await waitFor(() => expect(boolOptionLabels()).toEqual(["false (default)", "true", "false"]));
+  });
+});

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/launchServer.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/launchServer.tsx
@@ -72,19 +72,19 @@ export function LaunchServerSection(_props: LaunchServerSectionProps) {
   // legacy local `cancelled` flag did.
   useConnectedEffect(async (isCancelled) => {
     try {
-      const schema = await launchConfigStore.getState().schema();
-      const current = await launchConfigStore.getState().getLayer("/", "global");
+      const [schema, current, resolved] = await Promise.all([
+        launchConfigStore.getState().schema(),
+        launchConfigStore.getState().getLayer("/", "global"),
+        launchConfigStore
+          .getState()
+          .resolve("/")
+          .catch(() => null),
+      ]);
       if (isCancelled()) return;
       setLoad({ phase: "ready", options: schema.options, current });
-      try {
-        const resolved = await launchConfigStore.getState().resolve("/");
-        if (!isCancelled()) {
-          setDiagnostics(resolved.diagnostics ?? []);
-          setResolvedDefaults(resolved.effective);
-        }
-      } catch {
-        // non-fatal: the form is fully usable without the diagnostics hint
-        // and the resolved-default labels
+      if (resolved && !isCancelled()) {
+        setDiagnostics(resolved.diagnostics ?? []);
+        setResolvedDefaults(resolved.effective);
       }
     } catch (err) {
       if (!isCancelled()) setLoad({ phase: "error", message: friendlyErrorMessage(err) });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/launchServer.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/launchServer.tsx
@@ -58,6 +58,11 @@ export interface LaunchServerSectionProps {
 export function LaunchServerSection(_props: LaunchServerSectionProps) {
   const [load, setLoad] = useState<LoadState>({ phase: "loading" });
   const [diagnostics, setDiagnostics] = useState<LaunchConfigDiagnostic[]>([]);
+  // The effective layer of the same resolve() that seeds the diagnostics
+  // panel: unset fields whose empty marker is generic prepend their entry
+  // here ("high (default)"). Undefined until the resolve lands - and forever,
+  // if it fails (the same non-fatal contract as the diagnostics).
+  const [resolvedDefaults, setResolvedDefaults] = useState<LaunchConfigLayer | undefined>(undefined);
 
   // useConnectedEffect (not a bare useEffect): a direct deep link to
   // /settings/launch-evener can mount this section before AppShell's own
@@ -73,9 +78,13 @@ export function LaunchServerSection(_props: LaunchServerSectionProps) {
       setLoad({ phase: "ready", options: schema.options, current });
       try {
         const resolved = await launchConfigStore.getState().resolve("/");
-        if (!isCancelled()) setDiagnostics(resolved.diagnostics ?? []);
+        if (!isCancelled()) {
+          setDiagnostics(resolved.diagnostics ?? []);
+          setResolvedDefaults(resolved.effective);
+        }
       } catch {
         // non-fatal: the form is fully usable without the diagnostics hint
+        // and the resolved-default labels
       }
     } catch (err) {
       if (!isCancelled()) setLoad({ phase: "error", message: friendlyErrorMessage(err) });
@@ -97,10 +106,14 @@ export function LaunchServerSection(_props: LaunchServerSectionProps) {
             options={load.options}
             layer="global"
             current={load.current}
+            resolvedDefaults={resolvedDefaults}
             successToast="Launch defaults saved"
             validatePath={(path, kind) => launchConfigStore.getState().validatePath(path, kind)}
             onSave={(config) => launchConfigStore.getState().setLayer("/", "global", config)}
-            onSaved={(resolved) => setDiagnostics(resolved.diagnostics ?? [])}
+            onSaved={(resolved) => {
+              setDiagnostics(resolved.diagnostics ?? []);
+              setResolvedDefaults(resolved.effective);
+            }}
           />
         </>
       )}

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/LaunchConfigForm.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/LaunchConfigForm.test.tsx
@@ -248,6 +248,37 @@ describe("rendering", () => {
     );
     expect(screen.getByText("default: evener")).toBeTruthy();
   });
+
+  test("threads resolvedDefaults down to unset fields, whose empty markers name the inherited value", () => {
+    render(
+      <LaunchConfigForm
+        options={OPTIONS}
+        layer="global"
+        current={{}}
+        resolvedDefaults={{ reasoningEffort: "high" }}
+        successToast="Launch defaults saved"
+        validatePath={OK_VALIDATE}
+        onSave={async () => RESOLVED}
+      />,
+    );
+    const select = screen.getByLabelText("Reasoning effort") as HTMLSelectElement;
+    expect(Array.from(select.options).map((o) => o.textContent)).toEqual(["high (default)", "high"]);
+  });
+
+  test("without resolvedDefaults the empty markers stay plain", () => {
+    render(
+      <LaunchConfigForm
+        options={OPTIONS}
+        layer="global"
+        current={{}}
+        successToast="Launch defaults saved"
+        validatePath={OK_VALIDATE}
+        onSave={async () => RESOLVED}
+      />,
+    );
+    const select = screen.getByLabelText("Reasoning effort") as HTMLSelectElement;
+    expect(Array.from(select.options).map((o) => o.textContent)).toEqual(["(default)", "high"]);
+  });
 });
 
 describe("validation blocks save", () => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/LaunchConfigForm.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/LaunchConfigForm.tsx
@@ -24,6 +24,7 @@ import { Button, useToasts } from "../../../../widgets";
 import { requireClass } from "../../../../widgets/internal/requireClass";
 import { EnvMapField, McpServerListField, ModelListField, PathListField } from "./collectionFields";
 import { PromptCompositeField, ScalarField } from "./fields";
+import { asEnvObjects, asMcpList, asStringList, inheritedItems } from "./inherited";
 import styles from "./LaunchConfigForm.module.css";
 import {
   buildFormState,
@@ -74,48 +75,11 @@ function formatSavedAt(): string {
   return `Saved at ${new Date().toLocaleTimeString()}`;
 }
 
-/** Inherited entries for a string-list (pathList/modelList) field: the
- * resolved effective value minus this layer's own items. The effective layer
- * already contains this layer's entries (resolve includes the layer being
- * edited), so subtracting the local keys yields exactly the inherited ones
- * under each kind's merge semantics. */
-function inheritedStrings(
-  option: LaunchOption,
-  resolvedDefaults: LaunchConfigLayer | undefined,
-  local: string[],
-): string[] {
-  if (!resolvedDefaults) return [];
-  const effective = (resolvedDefaults as Record<string, unknown>)[option.wireField];
-  if (!Array.isArray(effective)) return [];
-  const localSet = new Set(local);
-  return effective.filter((e) => !localSet.has(e));
-}
-
-/** Inherited entries for an envMap field: effective keys not overridden locally. */
-function inheritedEnvEntries(
-  option: LaunchOption,
-  resolvedDefaults: LaunchConfigLayer | undefined,
-  local: Record<string, string>,
-): { name: string; value: string }[] {
-  if (!resolvedDefaults) return [];
-  const effective = (resolvedDefaults as Record<string, unknown>)[option.wireField];
-  if (typeof effective !== "object" || effective === null || Array.isArray(effective)) return [];
-  return Object.entries(effective)
-    .filter(([name]) => !(name in local))
-    .map(([name, value]) => ({ name, value: String(value) }));
-}
-
-/** Inherited entries for an mcpServerList field: effective specs not present locally. */
-function inheritedMcpSpecs(
-  option: LaunchOption,
-  resolvedDefaults: LaunchConfigLayer | undefined,
-  local: MCPServerSpec[],
-): MCPServerSpec[] {
-  if (!resolvedDefaults) return [];
-  const effective = (resolvedDefaults as Record<string, unknown>)[option.wireField];
-  if (!Array.isArray(effective)) return [];
-  const localNames = new Set(local.map((s) => s.name));
-  return effective.filter((s) => !localNames.has(s.name));
+/** Reads the effective layer's value for a field, or undefined when no layer
+ * sets it (or the resolve hasn't landed). */
+function resolvedValue(option: LaunchOption, resolvedDefaults: LaunchConfigLayer | undefined): unknown {
+  if (!resolvedDefaults) return undefined;
+  return (resolvedDefaults as Record<string, unknown>)[option.wireField];
 }
 
 export function LaunchConfigForm({
@@ -233,6 +197,7 @@ export function LaunchConfigForm({
     }
 
     if (isCollectionKind(opt.kind)) {
+      const effective = resolvedValue(opt, resolvedDefaults);
       switch (opt.kind) {
         case "pathList":
           return (
@@ -241,7 +206,7 @@ export function LaunchConfigForm({
               items={state.lists[opt.wireField] ?? []}
               onChange={(v) => updateList(opt.wireField, v)}
               validatePath={validatePath}
-              inheritedItems={inheritedStrings(opt, resolvedDefaults, state.lists[opt.wireField] ?? [])}
+              inheritedItems={inheritedItems(effective, state.lists[opt.wireField] ?? [], (s) => s, asStringList)}
             />
           );
         case "modelList":
@@ -252,18 +217,21 @@ export function LaunchConfigForm({
               onChange={(v) => updateList(opt.wireField, v)}
               explicitEmpty={state.explicitEmpty[opt.wireField] ?? false}
               onExplicitEmptyChange={(checked) => updateExplicitEmpty(opt.wireField, checked)}
-              inheritedItems={inheritedStrings(opt, resolvedDefaults, state.lists[opt.wireField] ?? [])}
+              inheritedItems={inheritedItems(effective, state.lists[opt.wireField] ?? [], (s) => s, asStringList)}
             />
           );
-        case "envMap":
+        case "envMap": {
+          const localEnv = state.envMaps[opt.wireField] ?? {};
+          const localEntries = Object.entries(localEnv).map(([name, value]) => ({ name, value }));
           return (
             <EnvMapField
               option={opt}
-              value={state.envMaps[opt.wireField] ?? {}}
+              value={localEnv}
               onChange={(v) => updateEnvMap(opt.wireField, v)}
-              inheritedItems={inheritedEnvEntries(opt, resolvedDefaults, state.envMaps[opt.wireField] ?? {})}
+              inheritedItems={inheritedItems(effective, localEntries, (e) => e.name, asEnvObjects)}
             />
           );
+        }
         default: // mcpServerList
           return (
             <McpServerListField
@@ -271,7 +239,7 @@ export function LaunchConfigForm({
               items={state.mcpLists[opt.wireField] ?? []}
               onChange={(v) => updateMcpList(opt.wireField, v)}
               validateCommand={(command) => validatePath(command, "command")}
-              inheritedItems={inheritedMcpSpecs(opt, resolvedDefaults, state.mcpLists[opt.wireField] ?? [])}
+              inheritedItems={inheritedItems(effective, state.mcpLists[opt.wireField] ?? [], (s) => s.name, asMcpList)}
             />
           );
       }

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/LaunchConfigForm.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/LaunchConfigForm.tsx
@@ -59,6 +59,11 @@ export interface LaunchConfigFormProps {
   /** The (separately-fetched) global layer, project-layer callers only -
    * drives the inline "default: {value}" hints. */
   globalDefaults?: LaunchConfigLayer;
+  /** The effective layer of the caller's launch/resolve for this cwd
+   * (undefined until it lands or after it fails): unset fields whose empty
+   * marker is the generic one prepend their entry here - "high (default)",
+   * "true (use global default)". */
+  resolvedDefaults?: LaunchConfigLayer;
   successToast: string;
   validatePath: (path: string, kind: string) => Promise<PathValidateResponse>;
   onSave: (config: LaunchConfigLayer) => Promise<LaunchConfigResolved>;
@@ -74,6 +79,7 @@ export function LaunchConfigForm({
   layer,
   current,
   globalDefaults,
+  resolvedDefaults,
   successToast,
   validatePath,
   onSave,
@@ -231,6 +237,7 @@ export function LaunchConfigForm({
         onChange={(v) => updateScalar(opt.wireField, v)}
         globalDefaultHint={globalDefaultHint(opt.wireField, layer, globalDefaults)}
         error={fieldErrors[opt.wireField]}
+        resolvedDefaults={resolvedDefaults}
       />
     );
   }

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/LaunchConfigForm.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/LaunchConfigForm.tsx
@@ -74,6 +74,50 @@ function formatSavedAt(): string {
   return `Saved at ${new Date().toLocaleTimeString()}`;
 }
 
+/** Inherited entries for a string-list (pathList/modelList) field: the
+ * resolved effective value minus this layer's own items. The effective layer
+ * already contains this layer's entries (resolve includes the layer being
+ * edited), so subtracting the local keys yields exactly the inherited ones
+ * under each kind's merge semantics. */
+function inheritedStrings(
+  option: LaunchOption,
+  resolvedDefaults: LaunchConfigLayer | undefined,
+  local: string[],
+): string[] {
+  if (!resolvedDefaults) return [];
+  const effective = (resolvedDefaults as Record<string, unknown>)[option.wireField];
+  if (!Array.isArray(effective)) return [];
+  const localSet = new Set(local);
+  return effective.filter((e) => !localSet.has(e));
+}
+
+/** Inherited entries for an envMap field: effective keys not overridden locally. */
+function inheritedEnvEntries(
+  option: LaunchOption,
+  resolvedDefaults: LaunchConfigLayer | undefined,
+  local: Record<string, string>,
+): { name: string; value: string }[] {
+  if (!resolvedDefaults) return [];
+  const effective = (resolvedDefaults as Record<string, unknown>)[option.wireField];
+  if (typeof effective !== "object" || effective === null || Array.isArray(effective)) return [];
+  return Object.entries(effective)
+    .filter(([name]) => !(name in local))
+    .map(([name, value]) => ({ name, value: String(value) }));
+}
+
+/** Inherited entries for an mcpServerList field: effective specs not present locally. */
+function inheritedMcpSpecs(
+  option: LaunchOption,
+  resolvedDefaults: LaunchConfigLayer | undefined,
+  local: MCPServerSpec[],
+): MCPServerSpec[] {
+  if (!resolvedDefaults) return [];
+  const effective = (resolvedDefaults as Record<string, unknown>)[option.wireField];
+  if (!Array.isArray(effective)) return [];
+  const localNames = new Set(local.map((s) => s.name));
+  return effective.filter((s) => !localNames.has(s.name));
+}
+
 export function LaunchConfigForm({
   options,
   layer,
@@ -197,6 +241,7 @@ export function LaunchConfigForm({
               items={state.lists[opt.wireField] ?? []}
               onChange={(v) => updateList(opt.wireField, v)}
               validatePath={validatePath}
+              inheritedItems={inheritedStrings(opt, resolvedDefaults, state.lists[opt.wireField] ?? [])}
             />
           );
         case "modelList":
@@ -207,6 +252,7 @@ export function LaunchConfigForm({
               onChange={(v) => updateList(opt.wireField, v)}
               explicitEmpty={state.explicitEmpty[opt.wireField] ?? false}
               onExplicitEmptyChange={(checked) => updateExplicitEmpty(opt.wireField, checked)}
+              inheritedItems={inheritedStrings(opt, resolvedDefaults, state.lists[opt.wireField] ?? [])}
             />
           );
         case "envMap":
@@ -215,6 +261,7 @@ export function LaunchConfigForm({
               option={opt}
               value={state.envMaps[opt.wireField] ?? {}}
               onChange={(v) => updateEnvMap(opt.wireField, v)}
+              inheritedItems={inheritedEnvEntries(opt, resolvedDefaults, state.envMaps[opt.wireField] ?? {})}
             />
           );
         default: // mcpServerList
@@ -224,6 +271,7 @@ export function LaunchConfigForm({
               items={state.mcpLists[opt.wireField] ?? []}
               onChange={(v) => updateMcpList(opt.wireField, v)}
               validateCommand={(command) => validatePath(command, "command")}
+              inheritedItems={inheritedMcpSpecs(opt, resolvedDefaults, state.mcpLists[opt.wireField] ?? [])}
             />
           );
       }

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/collectionFields.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/collectionFields.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { FakeClient } from "../../../../protocol/testing/fakeClient";
@@ -348,6 +348,68 @@ describe("PathListField", () => {
     );
     expect(screen.getByText(/No skill directories configured/i)).toBeTruthy();
   });
+
+  test("inherited entries render as grayed ghost rows tagged (default), with no remove button", () => {
+    render(
+      <PathListField
+        option={pathListOption()}
+        items={["/opt/local-skills"]}
+        onChange={() => {}}
+        validatePath={async () => ({ path: "", valid: true })}
+        inheritedItems={["/etc/defaults/skills"]}
+      />,
+    );
+
+    const list = screen.getByRole("list", { name: "Skill directories" });
+    const rows = within(list).getAllByRole("listitem");
+    expect(rows).toHaveLength(2);
+    const [localRow, ghost] = rows as [HTMLElement, HTMLElement];
+    // Local row keeps its remove button.
+    expect(within(localRow).getByRole("button", { name: "Remove /opt/local-skills" })).toBeTruthy();
+    // Ghost row has no remove button and is tagged (default).
+    expect(ghost.textContent).toContain("/etc/defaults/skills");
+    expect(ghost.textContent).toContain("(default)");
+    expect(within(ghost).queryByRole("button")).toBeNull();
+  });
+
+  test("inherited entries suppress the empty message", () => {
+    render(
+      <PathListField
+        option={pathListOption()}
+        items={[]}
+        onChange={() => {}}
+        validatePath={async () => ({ path: "", valid: true })}
+        inheritedItems={["/etc/defaults/skills"]}
+      />,
+    );
+
+    expect(screen.queryByText(/No skill directories configured/i)).toBeNull();
+    expect(screen.getByText("/etc/defaults/skills")).toBeTruthy();
+  });
+
+  test("a local add that matches an inherited entry replaces its ghost", async () => {
+    const user = userEvent.setup();
+    connectPathLister({});
+    const onChange = vi.fn();
+    render(
+      <PathListField
+        option={pathListOption()}
+        items={[]}
+        onChange={onChange}
+        validatePath={async () => ({ path: "/etc/defaults/skills", valid: true })}
+        inheritedItems={["/etc/defaults/skills"]}
+      />,
+    );
+
+    // The ghost starts visible.
+    const list = screen.getByRole("list", { name: "Skill directories" });
+    expect(within(list).getByText("/etc/defaults/skills")).toBeTruthy();
+
+    // Add the same path locally.
+    await typePath(user, "/etc/defaults/skills");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(["/etc/defaults/skills"]));
+  });
 });
 
 describe("ModelListField", () => {
@@ -434,6 +496,44 @@ describe("ModelListField", () => {
     await user.click(screen.getByRole("button", { name: "Add" }));
     await waitFor(() => expect(onExplicitEmptyChange).toHaveBeenCalledWith(false));
   });
+
+  test("inherited fallbacks render as ghost rows tagged (default), with no remove button", () => {
+    render(
+      <ModelListField
+        option={modelFallbacksOption}
+        items={["openai/gpt-5-mini"]}
+        onChange={() => {}}
+        explicitEmpty={false}
+        onExplicitEmptyChange={() => {}}
+        inheritedItems={["anthropic/claude-haiku-4-5"]}
+      />,
+    );
+
+    const list = screen.getByRole("list", { name: "Model fallbacks" });
+    const rows = within(list).getAllByRole("listitem");
+    expect(rows).toHaveLength(2);
+    const [localRow, ghost] = rows as [HTMLElement, HTMLElement];
+    expect(within(localRow).getByRole("button", { name: "Remove openai/gpt-5-mini" })).toBeTruthy();
+    expect(ghost.textContent).toContain("anthropic/claude-haiku-4-5");
+    expect(ghost.textContent).toContain("(default)");
+    expect(within(ghost).queryByRole("button")).toBeNull();
+  });
+
+  test("inherited fallbacks suppress the empty message", () => {
+    render(
+      <ModelListField
+        option={modelFallbacksOption}
+        items={[]}
+        onChange={() => {}}
+        explicitEmpty={false}
+        onExplicitEmptyChange={() => {}}
+        inheritedItems={["anthropic/claude-haiku-4-5"]}
+      />,
+    );
+
+    const list = screen.getByRole("list", { name: "Model fallbacks" });
+    expect(within(list).getByText("anthropic/claude-haiku-4-5")).toBeTruthy();
+  });
 });
 
 describe("EnvMapField", () => {
@@ -504,6 +604,41 @@ describe("EnvMapField", () => {
     screen.getByRole("button", { name: "Remove FOO=bar" }).click();
     expect(onChange).toHaveBeenCalledWith({ BAZ: "qux" });
   });
+
+  test("inherited entries render as ghost rows tagged (default), with no remove button", () => {
+    render(
+      <EnvMapField
+        option={envOption}
+        value={{ LOCAL: "1" }}
+        onChange={() => {}}
+        inheritedItems={[{ name: "EDITOR", value: "vim" }]}
+      />,
+    );
+
+    const list = screen.getByRole("list", { name: "Environment variables" });
+    const rows = within(list).getAllByRole("listitem");
+    expect(rows).toHaveLength(2);
+    const [localRow, ghost] = rows as [HTMLElement, HTMLElement];
+    expect(within(localRow).getByRole("button", { name: "Remove LOCAL=1" })).toBeTruthy();
+    expect(ghost.textContent).toContain("EDITOR=vim");
+    expect(ghost.textContent).toContain("(default)");
+    expect(within(ghost).queryByRole("button")).toBeNull();
+  });
+
+  test("inherited entries suppress the empty message", () => {
+    render(
+      <EnvMapField
+        option={envOption}
+        value={{}}
+        onChange={() => {}}
+        inheritedItems={[{ name: "EDITOR", value: "vim" }]}
+      />,
+    );
+
+    const list = screen.getByRole("list", { name: "Environment variables" });
+    expect(within(list).getByText("EDITOR=vim")).toBeTruthy();
+    expect(within(list).queryByText(/No environment variables configured/i)).toBeNull();
+  });
 });
 
 describe("McpServerListField", () => {
@@ -561,5 +696,42 @@ describe("McpServerListField", () => {
     await user.click(screen.getByRole("button", { name: "Add" }));
     expect(validateCommand).not.toHaveBeenCalled();
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test("inherited servers render as ghost rows tagged (default), with no remove button", () => {
+    render(
+      <McpServerListField
+        option={mcpOption}
+        items={[{ name: "fs", command: "mcp-fs", args: ["--root", "/"] }]}
+        onChange={() => {}}
+        validateCommand={async () => ({ path: "", valid: true })}
+        inheritedItems={[{ name: "docs", command: "npx", args: ["docs-mcp"] }]}
+      />,
+    );
+
+    const list = screen.getByRole("list", { name: "MCP servers" });
+    const rows = within(list).getAllByRole("listitem");
+    expect(rows).toHaveLength(2);
+    const [localRow, ghost] = rows as [HTMLElement, HTMLElement];
+    expect(within(localRow).getByRole("button", { name: /Remove fs → mcp-fs/i })).toBeTruthy();
+    expect(ghost.textContent).toContain("docs → npx docs-mcp");
+    expect(ghost.textContent).toContain("(default)");
+    expect(within(ghost).queryByRole("button")).toBeNull();
+  });
+
+  test("inherited servers suppress the empty message", () => {
+    render(
+      <McpServerListField
+        option={mcpOption}
+        items={[]}
+        onChange={() => {}}
+        validateCommand={async () => ({ path: "", valid: true })}
+        inheritedItems={[{ name: "docs", command: "npx", args: ["docs-mcp"] }]}
+      />,
+    );
+
+    const list = screen.getByRole("list", { name: "MCP servers" });
+    expect(within(list).getByText("docs → npx docs-mcp")).toBeTruthy();
+    expect(within(list).queryByText(/No MCP servers configured/i)).toBeNull();
   });
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/collectionFields.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/collectionFields.tsx
@@ -72,6 +72,8 @@ interface StringListFieldProps {
   /** Replaces CollectionEditor's plain-text add field (modelList uses the
    * searchable model picker, so a model id is never hand-typed). */
   renderAddField?: (props: { value: string; onChange: (value: string) => void; disabled: boolean }) => ReactNode;
+  /** Inherited entries shown as grayed "(default)" ghost rows; [] when none. */
+  inheritedItems?: readonly string[];
 }
 
 function StringListField({
@@ -83,6 +85,7 @@ function StringListField({
   validateAdd,
   explicitEmpty,
   renderAddField,
+  inheritedItems = [],
 }: StringListFieldProps) {
   async function handleAdd(trimmed: string): Promise<CollectionAddResult> {
     const outcome = await validateAdd(trimmed);
@@ -98,6 +101,7 @@ function StringListField({
       <CollectionEditor<string>
         label={option.label}
         items={items}
+        inheritedItems={inheritedItems}
         getKey={(item) => item}
         renderItem={(item) => item}
         removeLabel={(item) => `Remove ${item}`}
@@ -119,6 +123,7 @@ export interface PathListFieldProps {
   items: string[];
   onChange: (items: string[]) => void;
   validatePath: (path: string, kind: string) => Promise<PathValidateResponse>;
+  inheritedItems?: readonly string[];
 }
 
 /** The pathList add field's empty-state text - the picker's closed trigger
@@ -146,7 +151,7 @@ function pathFieldKind(pathKind: string | undefined): PathFieldKind {
  * field-level error" / "uses valid.path if present else the raw trimmed input"
  * behaviors. The spawn pane's own Advanced-options pathList control shares that
  * same decision. */
-export function PathListField({ option, items, onChange, validatePath }: PathListFieldProps) {
+export function PathListField({ option, items, onChange, validatePath, inheritedItems }: PathListFieldProps) {
   const kind = pathFieldKind(option.pathKind);
   const placeholder = pathAddPlaceholder(kind);
   return (
@@ -157,6 +162,7 @@ export function PathListField({ option, items, onChange, validatePath }: PathLis
       addPlaceholder={placeholder}
       emptyMessage={`No ${option.label.toLowerCase()} configured.`}
       validateAdd={(trimmed) => validatePathListAdd(option, items, trimmed, validatePath)}
+      inheritedItems={inheritedItems}
       renderAddField={({ value, onChange: setDraft, disabled }) => (
         <div className={CLASS.pathAddRow}>
           <PathAddField
@@ -234,6 +240,7 @@ export interface ModelListFieldProps {
   onChange: (items: string[]) => void;
   explicitEmpty: boolean;
   onExplicitEmptyChange: (checked: boolean) => void;
+  inheritedItems?: readonly string[];
 }
 
 /**
@@ -245,7 +252,14 @@ export interface ModelListFieldProps {
  * RPC validates one in isolation), but now it can only be a real catalog
  * entry rather than an unverifiable typo.
  */
-export function ModelListField({ option, items, onChange, explicitEmpty, onExplicitEmptyChange }: ModelListFieldProps) {
+export function ModelListField({
+  option,
+  items,
+  onChange,
+  explicitEmpty,
+  onExplicitEmptyChange,
+  inheritedItems,
+}: ModelListFieldProps) {
   return (
     <StringListField
       option={option}
@@ -258,6 +272,7 @@ export function ModelListField({ option, items, onChange, explicitEmpty, onExpli
         return { ok: true, value: trimmed };
       }}
       explicitEmpty={{ checked: explicitEmpty, onChange: onExplicitEmptyChange, label: "No model fallbacks" }}
+      inheritedItems={inheritedItems}
       renderAddField={({ value, onChange: setDraft, disabled }) => (
         <div className={CLASS.modelAddRow}>
           <ModelAddField value={value} onChange={setDraft} disabled={disabled} />
@@ -304,6 +319,7 @@ export interface EnvMapFieldProps {
   option: LaunchOption; // kind: envMap
   value: Record<string, string>;
   onChange: (value: Record<string, string>) => void;
+  inheritedItems?: readonly EnvEntry[];
 }
 
 interface EnvEntry {
@@ -379,7 +395,7 @@ function EnvAddFields({
  * requiring a non-empty NAME, matching the legacy's own envMap behavior
  * exactly. EnvAddFields above is what composes that string now, from two
  * real boxes instead of asking the user to type the '=' themselves. */
-export function EnvMapField({ option, value, onChange }: EnvMapFieldProps) {
+export function EnvMapField({ option, value, onChange, inheritedItems = [] }: EnvMapFieldProps) {
   const entries: EnvEntry[] = Object.entries(value).map(([name, v]) => ({ name, value: v }));
 
   async function handleAdd(trimmed: string): Promise<CollectionAddResult> {
@@ -398,6 +414,7 @@ export function EnvMapField({ option, value, onChange }: EnvMapFieldProps) {
       <CollectionEditor<EnvEntry>
         label={option.label}
         items={entries}
+        inheritedItems={inheritedItems}
         getKey={(entry) => entry.name}
         renderItem={(entry) => `${entry.name}=${entry.value}`}
         removeLabel={(entry) => `Remove ${entry.name}=${entry.value}`}
@@ -425,6 +442,7 @@ export interface McpServerListFieldProps {
   items: MCPServerSpec[];
   onChange: (items: MCPServerSpec[]) => void;
   validateCommand: (command: string) => Promise<PathValidateResponse>;
+  inheritedItems?: readonly MCPServerSpec[];
 }
 
 function specKey(spec: MCPServerSpec): string {
@@ -440,7 +458,13 @@ function renderSpec(spec: MCPServerSpec): string {
  * (whitespace-split); the command token is validated via evener/path/validate
  * kind="command" before the row is accepted, matching the legacy's own
  * validateMCPCommandInput. */
-export function McpServerListField({ option, items, onChange, validateCommand }: McpServerListFieldProps) {
+export function McpServerListField({
+  option,
+  items,
+  onChange,
+  validateCommand,
+  inheritedItems = [],
+}: McpServerListFieldProps) {
   async function handleAdd(trimmed: string): Promise<CollectionAddResult> {
     const tokens = trimmed.split(/\s+/).filter(Boolean);
     const [name, command, ...args] = tokens;
@@ -457,6 +481,7 @@ export function McpServerListField({ option, items, onChange, validateCommand }:
       <CollectionEditor<MCPServerSpec>
         label={option.label}
         items={items}
+        inheritedItems={inheritedItems}
         getKey={specKey}
         renderItem={renderSpec}
         removeLabel={(spec) => `Remove ${renderSpec(spec)}`}

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/fields.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/fields.test.tsx
@@ -369,6 +369,124 @@ describe("ScalarField: boolean renders a literal true/false 3-state select", () 
   });
 });
 
+describe("ScalarField: resolved-default labels", () => {
+  const booleanOption = textOption({
+    field: "sandbox_net",
+    wireField: "sandboxNet",
+    label: "Sandbox network egress",
+    kind: "boolean",
+  });
+  const reasoningOption = textOption({
+    field: "reasoning_effort",
+    wireField: "reasoningEffort",
+    label: "Reasoning effort",
+    kind: "select",
+    choices: [
+      { value: "", label: "(default)" },
+      { value: "high", label: "high" },
+      { value: "max", label: "max" },
+    ],
+  });
+
+  test("a boolean's empty option names the resolved value in true/false wording", () => {
+    render(
+      <ScalarField
+        option={booleanOption}
+        layer="global"
+        value=""
+        onChange={() => {}}
+        resolvedDefaults={{ sandboxNet: true }}
+      />,
+    );
+    const select = screen.getByLabelText("Sandbox network egress") as HTMLSelectElement;
+    expect(Array.from(select.options).map((o) => o.textContent)).toEqual(["true (default)", "true", "false"]);
+  });
+
+  test("a select's empty option names the resolved value, with the layer's own marker wording", () => {
+    render(
+      <ScalarField
+        option={reasoningOption}
+        layer="global"
+        value=""
+        onChange={() => {}}
+        resolvedDefaults={{ reasoningEffort: "high" }}
+      />,
+    );
+    const globalSelect = screen.getByLabelText("Reasoning effort") as HTMLSelectElement;
+    expect(Array.from(globalSelect.options).map((o) => o.textContent)).toEqual(["high (default)", "high", "max"]);
+    cleanup();
+
+    render(
+      <ScalarField
+        option={reasoningOption}
+        layer="project"
+        value=""
+        onChange={() => {}}
+        resolvedDefaults={{ reasoningEffort: "high" }}
+      />,
+    );
+    const projectSelect = screen.getByLabelText("Reasoning effort") as HTMLSelectElement;
+    expect(Array.from(projectSelect.options).map((o) => o.textContent)).toEqual([
+      "high (use global default)",
+      "high",
+      "max",
+    ]);
+  });
+
+  test("a modelPicker's closed trigger names the resolved model", () => {
+    render(
+      <ScalarField
+        option={modelPickerOption()}
+        layer="global"
+        value=""
+        onChange={() => {}}
+        resolvedDefaults={{ model: "anthropic/claude-sonnet-4" }}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /change model/i }).textContent).toContain(
+      "anthropic/claude-sonnet-4 (default)",
+    );
+  });
+
+  test("a radio with a schema-supplied custom empty label is left unchanged", () => {
+    render(
+      <ScalarField
+        option={textOption({
+          field: "sandbox",
+          wireField: "sandbox",
+          label: "Sandbox",
+          kind: "radio",
+          choices: [
+            { value: "", label: "(inherit)" },
+            { value: "off", label: "off" },
+            { value: "workspace-write", label: "workspace-write" },
+          ],
+        })}
+        layer="global"
+        value=""
+        onChange={() => {}}
+        resolvedDefaults={{ sandbox: "workspace-write" }}
+      />,
+    );
+    const options = screen.getAllByRole("radio");
+    expect(options.map((o) => o.textContent)).toEqual(["(inherit)", "off", "workspace-write"]);
+  });
+
+  test("an unset field the effective layer doesn't set keeps the plain marker", () => {
+    render(
+      <ScalarField
+        option={reasoningOption}
+        layer="global"
+        value=""
+        onChange={() => {}}
+        resolvedDefaults={{ model: "anthropic/claude-sonnet-4" }}
+      />,
+    );
+    const select = screen.getByLabelText("Reasoning effort") as HTMLSelectElement;
+    expect(Array.from(select.options).map((o) => o.textContent)).toEqual(["(default)", "high", "max"]);
+  });
+});
+
 describe("ScalarField: radio renders RadioGroup bare (no FormRow double-labeling)", () => {
   test("renders a radiogroup with the schema's own choices plus the dedup'd empty entry", () => {
     render(

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/fields.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/fields.tsx
@@ -26,7 +26,7 @@
 // tsx's add-time validation both surface ONLY the custom inline error -
 // no native browser validation bubble.
 
-import type { LaunchOption } from "../../../../protocol/types.gen";
+import type { LaunchConfigLayer, LaunchOption } from "../../../../protocol/types.gen";
 import { extensionsStore } from "../../../../stores/extensions";
 import type { LaunchConfigLayerName } from "../../../../stores/launchConfig";
 import {
@@ -44,7 +44,7 @@ import {
 import { requireClass } from "../../../../widgets/internal/requireClass";
 import { fetchModelCatalog } from "../../../../widgets/modelCatalog/catalogClient";
 import styles from "./fields.module.css";
-import { emptyChoiceLabel, PROMPT_COMPOSITE_SPECS, resolvedEmptyChoice } from "./schema";
+import { emptyChoiceLabel, PROMPT_COMPOSITE_SPECS, resolvedDefaultLabel, resolvedEmptyChoice } from "./schema";
 
 const CLASS = {
   defaultHint: requireClass(styles.defaultHint, "fields.module.css", "defaultHint"),
@@ -144,14 +144,36 @@ export interface ScalarFieldProps {
    * `option.description`, matching FormRow's own error-takes-over-help
    * contract. Never set for any other kind. */
   error?: string;
+  /** The effective layer of the caller's launch/resolve for this cwd
+   * (undefined until it lands or after it fails): a field whose unset marker
+   * is the generic "(default)"/"(use global default)" prepends its entry
+   * here - "true (default)", "high (use global default)" - so the marker
+   * names what a session started now would inherit. */
+  resolvedDefaults?: LaunchConfigLayer;
 }
 
 /** Renders one non-collection LaunchOption per its `kind`. */
-export function ScalarField({ option, layer, value, onChange, globalDefaultHint, error }: ScalarFieldProps) {
+export function ScalarField({
+  option,
+  layer,
+  value,
+  onChange,
+  globalDefaultHint,
+  error,
+  resolvedDefaults,
+}: ScalarFieldProps) {
   const fieldId = `launch-field-${option.field}`;
+  // The resolved-default label for this field's empty marker, or undefined
+  // when there is nothing to name (schema.ts's resolvedDefaultLabel owns the
+  // rules; the custom-wording markers stay exactly as they were).
+  const resolvedLabel = resolvedDefaultLabel(option, layer, resolvedDefaults);
 
   if (option.kind === "radio") {
-    const options: RadioGroupOption[] = [resolvedEmptyChoice(option, layer), ...nonEmptyChoices(option)];
+    const empty = resolvedEmptyChoice(option, layer);
+    const options: RadioGroupOption[] = [
+      { value: "", label: resolvedLabel ?? empty.label },
+      ...nonEmptyChoices(option),
+    ];
     return (
       <div className={CLASS.radioBlock}>
         <RadioGroup label={option.label} value={value} onChange={onChange} options={options} />
@@ -162,14 +184,15 @@ export function ScalarField({ option, layer, value, onChange, globalDefaultHint,
   }
 
   if (option.kind === "select" || option.kind === "boolean") {
+    const empty = resolvedEmptyChoice(option, layer);
     const options: SelectOption[] =
       option.kind === "boolean"
         ? [
-            { value: "", label: resolvedEmptyChoice(option, layer).label },
+            { value: "", label: resolvedLabel ?? empty.label },
             { value: "true", label: "true" },
             { value: "false", label: "false" },
           ]
-        : [resolvedEmptyChoice(option, layer), ...nonEmptyChoices(option)];
+        : [{ value: "", label: resolvedLabel ?? empty.label }, ...nonEmptyChoices(option)];
     return (
       <FormRow label={option.label} htmlFor={fieldId} help={option.description}>
         <Select id={fieldId} value={value} onChange={(e) => onChange(e.target.value)} options={options} />
@@ -195,7 +218,12 @@ export function ScalarField({ option, layer, value, onChange, globalDefaultHint,
     return (
       <div className={CLASS.modelBlock}>
         <span className={CLASS.modelLabel}>{option.label}</span>
-        <ModelCatalog value={value} onChange={onChange} loadCatalog={() => fetchModelCatalog()} />
+        <ModelCatalog
+          value={value}
+          onChange={onChange}
+          loadCatalog={() => fetchModelCatalog()}
+          emptyLabel={resolvedLabel}
+        />
         {option.description && <p className={CLASS.modelHelp}>{option.description}</p>}
         <DefaultHint text={globalDefaultHint} />
       </div>

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/inherited.ts
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/inherited.ts
@@ -1,0 +1,44 @@
+// Shared inherited-items computation for collection controls: the entries a
+// session would inherit from lower config layers, rendered as grayed
+// "(default)" ghost rows by CollectionEditor. The effective layer already
+// contains the local overrides (resolve includes them), so subtracting the
+// local keys yields exactly the inherited entries under each kind's merge
+// semantics.
+import type { MCPServerSpec } from "../../../../protocol/types.gen";
+
+/** Effective value minus local entries, keyed by the caller's key extractor.
+ * Returns [] when the effective value is absent or the wrong shape. */
+export function inheritedItems<T>(
+  effective: unknown,
+  local: readonly T[],
+  key: (item: T) => string,
+  fromEffective: (value: unknown) => T[],
+): T[] {
+  const localKeys = new Set(local.map(key));
+  return fromEffective(effective).filter((item) => !localKeys.has(key(item)));
+}
+
+// --- shape adapters: coerce an unknown effective-layer value into the typed
+// array the caller's key extractor expects ---
+
+export function asStringList(value: unknown): string[] {
+  return Array.isArray(value) ? (value as string[]) : [];
+}
+
+export function asEnvEntries(value: unknown): [string, string][] {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? Object.entries(value as Record<string, string>)
+    : [];
+}
+
+/** Same as asEnvEntries but as {name, value} objects — the shape
+ * EnvMapField's inheritedItems prop expects. */
+export function asEnvObjects(value: unknown): { name: string; value: string }[] {
+  return asEnvEntries(value).map(([name, val]) => ({ name, value: val }));
+}
+
+export function asMcpList(value: unknown): MCPServerSpec[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "object" && item !== null && "name" in item)
+    ? (value as MCPServerSpec[])
+    : [];
+}

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/schema.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/schema.test.ts
@@ -13,6 +13,7 @@ import {
   optionSupportsLayer,
   PROMPT_COMPOSITE_SPECS,
   PROMPT_DEPENDENT_WIRE_FIELDS,
+  resolvedDefaultLabel,
   resolvedEmptyChoice,
   schemaPathKind,
 } from "./schema";
@@ -203,6 +204,74 @@ describe("resolvedEmptyChoice / emptyChoiceLabel", () => {
   test("emptyChoiceLabel is the generic per-layer placeholder text alone", () => {
     expect(emptyChoiceLabel("global")).toBe("(default)");
     expect(emptyChoiceLabel("project")).toBe("(use global default)");
+  });
+});
+
+describe("resolvedDefaultLabel", () => {
+  const booleanOpt = opt({ field: "sandbox_net", wireField: "sandboxNet", kind: "boolean" });
+  const selectOpt = opt({
+    field: "reasoning_effort",
+    wireField: "reasoningEffort",
+    kind: "select",
+    choices: [
+      { value: "", label: "(default)" },
+      { value: "high", label: "high" },
+    ],
+  });
+
+  test("undefined when there is no effective layer (the resolve hasn't landed or failed)", () => {
+    expect(resolvedDefaultLabel(selectOpt, "global", undefined)).toBeUndefined();
+  });
+
+  test("undefined when the effective layer doesn't set the field, or sets it empty", () => {
+    expect(resolvedDefaultLabel(selectOpt, "global", {})).toBeUndefined();
+    expect(resolvedDefaultLabel(selectOpt, "global", { reasoningEffort: "" })).toBeUndefined();
+  });
+
+  test("a boolean names the resolved value in the field's own true/false wording", () => {
+    expect(resolvedDefaultLabel(booleanOpt, "global", { sandboxNet: true })).toBe("true (default)");
+    expect(resolvedDefaultLabel(booleanOpt, "global", { sandboxNet: false })).toBe("false (default)");
+  });
+
+  test("the project layer keeps its own marker wording, value prepended", () => {
+    expect(resolvedDefaultLabel(booleanOpt, "project", { sandboxNet: true })).toBe("true (use global default)");
+    expect(resolvedDefaultLabel(selectOpt, "project", { reasoningEffort: "high" })).toBe("high (use global default)");
+  });
+
+  test("a select whose empty marker is the generic one names the resolved value", () => {
+    expect(resolvedDefaultLabel(selectOpt, "global", { reasoningEffort: "high" })).toBe("high (default)");
+  });
+
+  test("a modelPicker names the resolved model", () => {
+    const modelOpt = opt({ field: "model", wireField: "model", kind: "modelPicker" });
+    expect(resolvedDefaultLabel(modelOpt, "global", { model: "anthropic/claude-sonnet-4" })).toBe(
+      "anthropic/claude-sonnet-4 (default)",
+    );
+  });
+
+  test("a schema-supplied custom empty label is NOT rewritten - it already says what unset means", () => {
+    // sandbox's own "" choice is "(inherit)"; the Go "(default: off)" family
+    // likewise stays verbatim (out of scope for resolved labels).
+    const sandboxOpt = opt({
+      field: "sandbox",
+      wireField: "sandbox",
+      kind: "select",
+      choices: [
+        { value: "", label: "(inherit)" },
+        { value: "off", label: "off" },
+      ],
+    });
+    expect(resolvedDefaultLabel(sandboxOpt, "global", { sandbox: "workspace-write" })).toBeUndefined();
+    const continuationOpt = opt({
+      field: "openai_responses_continuation",
+      wireField: "openAIResponsesContinuation",
+      kind: "select",
+      choices: [
+        { value: "", label: "(default: off)" },
+        { value: "off", label: "off" },
+      ],
+    });
+    expect(resolvedDefaultLabel(continuationOpt, "global", { openAIResponsesContinuation: "auto" })).toBeUndefined();
   });
 });
 

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/schema.ts
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/schema.ts
@@ -172,6 +172,39 @@ export function resolvedEmptyChoice(opt: LaunchOption, layer: LaunchConfigLayerN
   return { value: "", label: emptyChoiceLabel(layer) };
 }
 
+// The two generic marker wordings. A resolved value only ever prepends onto
+// one of THESE: a schema-supplied custom empty label ("(inherit)", "Evener
+// default", the Go "(default: off)" family) already says what unset means in
+// that field's own terms and stays verbatim.
+const GENERIC_EMPTY_LABELS: ReadonlySet<string> = new Set(["(default)", "(use global default)"]);
+
+// resolvedDefaultLabel: the "<value> (default)" (global) / "<value> (use
+// global default)" (project) label for a field whose unset marker is the
+// generic one, once a launch/resolve effective layer is known - the value a
+// session started now would inherit for it, so "(default)" never stands in
+// for an answer the hub actually has. undefined when the effective layer
+// hasn't landed (or failed), doesn't set the field, or the field's empty
+// marker is a schema-supplied custom wording - in all of which the caller
+// keeps rendering resolvedEmptyChoice's label as-is. Booleans word the value
+// the way the field's own set options do ("true"/"false").
+export function resolvedDefaultLabel(
+  opt: LaunchOption,
+  layer: LaunchConfigLayerName,
+  effective: LaunchConfigLayer | undefined,
+): string | undefined {
+  if (!effective) return undefined;
+  const raw = (effective as Record<string, unknown>)[opt.wireField];
+  let value: string | undefined;
+  if (opt.kind === "boolean") {
+    value = raw === true ? "true" : raw === false ? "false" : undefined;
+  } else {
+    value = typeof raw === "string" && raw !== "" ? raw : undefined;
+  }
+  if (value === undefined) return undefined;
+  if (!GENERIC_EMPTY_LABELS.has(resolvedEmptyChoice(opt, layer).label)) return undefined;
+  return `${value} ${emptyChoiceLabel(layer)}`;
+}
+
 // --- form state: the React-side stand-in for the legacy's direct DOM state ---
 
 export interface LaunchFormState {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/schema.ts
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/schema.ts
@@ -196,7 +196,9 @@ export function resolvedDefaultLabel(
   const raw = (effective as Record<string, unknown>)[opt.wireField];
   let value: string | undefined;
   if (opt.kind === "boolean") {
-    value = raw === true ? "true" : raw === false ? "false" : undefined;
+    if (raw === true) value = "true";
+    else if (raw === false) value = "false";
+    else value = undefined;
   } else {
     value = typeof raw === "string" && raw !== "" ? raw : undefined;
   }

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/project.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/project.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { FakeClient } from "../../../protocol/testing/fakeClient";
@@ -125,5 +125,75 @@ describe("save", () => {
     await user.click(screen.getByRole("button", { name: "Save launch defaults" }));
     await screen.findByText(/^Saved at /);
     expect(screen.getAllByText("Project launch settings saved").length).toBeGreaterThan(0);
+  });
+});
+
+describe("resolved-default labels", () => {
+  // A boolean field is the readable case: on the project layer its unset
+  // marker is "(use global default)", which the resolve's effective layer
+  // turns into "true (use global default)".
+  const BOOL_SCHEMA: LaunchOptionSchemaResponse = {
+    options: [
+      {
+        field: "sandbox_net",
+        wireField: "sandboxNet",
+        label: "Sandbox network egress",
+        group: "Sandbox",
+        kind: "boolean",
+        perLaunch: true,
+        defaultableLayers: ["global", "project"],
+      },
+    ],
+  };
+
+  function boolOptionLabels(): (string | null)[] {
+    const select = screen.getByLabelText("Sandbox network egress") as HTMLSelectElement;
+    return Array.from(select.options).map((o) => o.textContent);
+  }
+
+  test("an unset field names the effective layer's value once resolve(cwd) lands", async () => {
+    setQueryCwd("/repo");
+    const fake = connectFakeClient();
+    fake.on("evener/launch/schema", () => BOOL_SCHEMA);
+    fake.on("evener/launch/getLayer", () => ({}));
+    fake.on("evener/launch/resolve", (params) => {
+      expect(params.cwd).toBe("/repo");
+      return { effective: { sandboxNet: true }, layers: {}, provenance: {} };
+    });
+    render(<ProjectSection sectionId="project" />);
+
+    await screen.findByLabelText("Sandbox network egress");
+    await waitFor(() => expect(boolOptionLabels()).toEqual(["true (use global default)", "true", "false"]));
+  });
+
+  test("a failed resolve leaves the plain (use global default) marker", async () => {
+    setQueryCwd("/repo");
+    const fake = connectFakeClient();
+    fake.on("evener/launch/schema", () => BOOL_SCHEMA);
+    fake.on("evener/launch/getLayer", () => ({}));
+    fake.on("evener/launch/resolve", () => {
+      throw new Error("resolve failed");
+    });
+    render(<ProjectSection sectionId="project" />);
+
+    await screen.findByLabelText("Sandbox network egress");
+    expect(boolOptionLabels()).toEqual(["(use global default)", "true", "false"]);
+  });
+
+  test("saving refreshes the labels from setLayer's own returned resolved config", async () => {
+    setQueryCwd("/repo");
+    const fake = connectFakeClient();
+    fake.on("evener/launch/schema", () => BOOL_SCHEMA);
+    fake.on("evener/launch/getLayer", () => ({}));
+    fake.on("evener/launch/resolve", () => ({ effective: { sandboxNet: true }, layers: {}, provenance: {} }));
+    fake.on("evener/launch/setLayer", () => ({ effective: { sandboxNet: false }, layers: {}, provenance: {} }));
+    render(<ProjectSection sectionId="project" />);
+
+    await screen.findByLabelText("Sandbox network egress");
+    await waitFor(() => expect(boolOptionLabels()).toEqual(["true (use global default)", "true", "false"]));
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Save launch defaults" }));
+    await waitFor(() => expect(boolOptionLabels()).toEqual(["false (use global default)", "true", "false"]));
   });
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/project.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/project.tsx
@@ -72,6 +72,12 @@ export interface ProjectSectionProps {
 export function ProjectSection(_props: ProjectSectionProps) {
   const cwd = useQueryCwd();
   const [load, setLoad] = useState<LoadState>({ phase: "loading" });
+  // The effective layer of a best-effort resolve(cwd): unset fields whose
+  // empty marker is generic prepend their entry here ("high (use global
+  // default)"). Undefined until the resolve lands, on a resolve failure, and
+  // cleared on every cwd change so one project's labels never leak into the
+  // next project's form.
+  const [resolvedDefaults, setResolvedDefaults] = useState<LaunchConfigLayer | undefined>(undefined);
 
   // useConnectedEffect (not a bare useEffect): a direct deep link to
   // /settings/project?cwd= can mount this section before AppShell's own
@@ -83,12 +89,20 @@ export function ProjectSection(_props: ProjectSectionProps) {
     async (isCancelled) => {
       if (!cwd) return;
       setLoad({ phase: "loading" });
+      setResolvedDefaults(undefined);
       try {
         const schema = await launchConfigStore.getState().schema();
         const current = await launchConfigStore.getState().getLayer(cwd, "project");
         const globalDefaults = await launchConfigStore.getState().getLayer(cwd, "global");
         if (isCancelled()) return;
         setLoad({ phase: "ready", options: schema.options, current, globalDefaults });
+        try {
+          const resolved = await launchConfigStore.getState().resolve(cwd);
+          if (!isCancelled()) setResolvedDefaults(resolved.effective);
+        } catch {
+          // non-fatal: the form is fully usable with the plain
+          // "(use global default)" markers
+        }
       } catch (err) {
         if (!isCancelled()) setLoad({ phase: "error", message: friendlyErrorMessage(err) });
       }
@@ -124,9 +138,11 @@ export function ProjectSection(_props: ProjectSectionProps) {
           layer="project"
           current={load.current}
           globalDefaults={load.globalDefaults}
+          resolvedDefaults={resolvedDefaults}
           successToast="Project launch settings saved"
           validatePath={(path, kind) => launchConfigStore.getState().validatePath(path, kind)}
           onSave={(config) => launchConfigStore.getState().setLayer(cwd, "project", config)}
+          onSaved={(resolved) => setResolvedDefaults(resolved.effective)}
         />
       )}
     </div>

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/project.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/project.tsx
@@ -91,18 +91,18 @@ export function ProjectSection(_props: ProjectSectionProps) {
       setLoad({ phase: "loading" });
       setResolvedDefaults(undefined);
       try {
-        const schema = await launchConfigStore.getState().schema();
-        const current = await launchConfigStore.getState().getLayer(cwd, "project");
-        const globalDefaults = await launchConfigStore.getState().getLayer(cwd, "global");
+        const [schema, current, globalDefaults, resolved] = await Promise.all([
+          launchConfigStore.getState().schema(),
+          launchConfigStore.getState().getLayer(cwd, "project"),
+          launchConfigStore.getState().getLayer(cwd, "global"),
+          launchConfigStore
+            .getState()
+            .resolve(cwd)
+            .catch(() => null),
+        ]);
         if (isCancelled()) return;
         setLoad({ phase: "ready", options: schema.options, current, globalDefaults });
-        try {
-          const resolved = await launchConfigStore.getState().resolve(cwd);
-          if (!isCancelled()) setResolvedDefaults(resolved.effective);
-        } catch {
-          // non-fatal: the form is fully usable with the plain
-          // "(use global default)" markers
-        }
+        if (resolved && !isCancelled()) setResolvedDefaults(resolved.effective);
       } catch (err) {
         if (!isCancelled()) setLoad({ phase: "error", message: friendlyErrorMessage(err) });
       }

--- a/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.test.tsx
@@ -68,6 +68,7 @@ function renderPanel(
       resolveConfig={resolveConfig as (o: unknown) => Promise<LaunchConfigResolved>}
       loadCatalog={loadCatalog}
       complete={complete}
+      resolvedDefaults={over.resolvedDefaults}
     >
       {children}
     </AdvancedOptions>,
@@ -123,6 +124,93 @@ test("a boolean control collects true/false and drops the (default)", async () =
   await user.selectOptions(screen.getByLabelText("No project prompts"), "On");
 
   expect(onOverridesChange).toHaveBeenLastCalledWith({ noProjectPrompts: true });
+});
+
+// --- resolved-default labels -------------------------------------------------
+//
+// The panel receives the effective layer of the pane's own launch/resolve as
+// `resolvedDefaults`: a control whose unset state reads "(default)" prepends
+// the value a session started now would inherit. Until the resolve lands (no
+// prop), the label stays plain "(default)".
+
+test("a boolean control's (default) option names the resolved default (On/Off)", async () => {
+  const user = userEvent.setup();
+  renderPanel(
+    [
+      option({ wireField: "noProjectPrompts", kind: "boolean", label: "No project prompts" }),
+      option({ wireField: "verbose", kind: "boolean", label: "Verbose event log" }),
+      option({ wireField: "nonInteractive", kind: "boolean", label: "Non-interactive" }),
+    ],
+    { resolvedDefaults: { noProjectPrompts: true, verbose: false } },
+  );
+
+  await user.click(screen.getByRole("button", { name: "Advanced options" }));
+
+  const labels = (name: string) =>
+    Array.from((screen.getByLabelText(name) as HTMLSelectElement).options).map((o) => o.textContent);
+  expect(labels("No project prompts")).toEqual(["On (default)", "On", "Off"]);
+  expect(labels("Verbose event log")).toEqual(["Off (default)", "On", "Off"]);
+  // No layer sets this one: the plain word stays.
+  expect(labels("Non-interactive")).toEqual(["(default)", "On", "Off"]);
+});
+
+test("a select control renders exactly one empty option, carrying the resolved default's label", async () => {
+  const user = userEvent.setup();
+  // reasoning_effort's real schema ships its OWN { value: "", label:
+  // "(default)" } choice (schema.go's reasoningChoices): the panel owns the
+  // empty option, so the schema's is dropped rather than duplicated.
+  renderPanel(
+    [
+      option({
+        wireField: "reasoningEffort",
+        kind: "select",
+        label: "Reasoning effort",
+        choices: [
+          { value: "", label: "(default)" },
+          { value: "high", label: "high" },
+          { value: "max", label: "max" },
+        ],
+      }),
+    ],
+    { resolvedDefaults: { reasoningEffort: "high" } },
+  );
+
+  await user.click(screen.getByRole("button", { name: "Advanced options" }));
+
+  const select = screen.getByLabelText("Reasoning effort") as HTMLSelectElement;
+  expect(Array.from(select.options).map((o) => o.textContent)).toEqual(["high (default)", "high", "max"]);
+  expect(Array.from(select.options).map((o) => o.value)).toEqual(["", "high", "max"]);
+});
+
+test("a select control without a resolved default dedupes the schema's own empty choice to a plain (default)", async () => {
+  const user = userEvent.setup();
+  renderPanel([
+    option({
+      wireField: "reasoningEffort",
+      kind: "select",
+      label: "Reasoning effort",
+      choices: [
+        { value: "", label: "(default)" },
+        { value: "high", label: "high" },
+      ],
+    }),
+  ]);
+
+  await user.click(screen.getByRole("button", { name: "Advanced options" }));
+
+  const select = screen.getByLabelText("Reasoning effort") as HTMLSelectElement;
+  expect(Array.from(select.options).map((o) => o.textContent)).toEqual(["(default)", "high"]);
+});
+
+test("a modelPicker control names the resolved default model", async () => {
+  const user = userEvent.setup();
+  renderPanel([option({ wireField: "fastCheapModel", kind: "modelPicker", label: "Fast cheap model" })], {
+    resolvedDefaults: { fastCheapModel: "openai/gpt-5" },
+  });
+
+  await user.click(screen.getByRole("button", { name: "Advanced options" }));
+
+  expect(screen.getByRole("button", { name: /change model/i }).textContent).toContain("openai/gpt-5 (default)");
 });
 
 test("an integer control collects a parsed number", async () => {

--- a/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.test.tsx
@@ -268,6 +268,94 @@ test("a browsable path control's trigger names the resolved default path", async
   expect(cpuTrigger.textContent).not.toContain("demo-trace");
 });
 
+// --- inherited collection rows ----------------------------------------------
+//
+// A collection control's own list holds only the user's per-launch additions;
+// entries the effective config would inherit used to be invisible ("None."
+// even when a session would pick up several). The panel renders them as
+// ghost rows - tagged "(default)", no remove button - computed as the
+// resolved effective value minus the user's local entries, which matches each
+// kind's merge semantics (pathList/mcps append, env per-key, modelFallbacks
+// replace) because resolvedDefaults is the resolve RPC's effective layer and
+// already contains the local overrides.
+
+test("a pathList control ghosts inherited entries, and a local add replaces its ghost", async () => {
+  const user = userEvent.setup();
+  renderPanel([option({ wireField: "skillsDirs", kind: "pathList", pathKind: "dir", label: "Skill directories" })], {
+    resolvedDefaults: { skillsDirs: ["/opt/skills"] },
+  });
+
+  await user.click(screen.getByRole("button", { name: "Advanced options" }));
+
+  const list = screen.getByRole("list", { name: "Skill directories" });
+  expect(within(list).queryByText("None.")).toBeNull();
+  const ghost = within(list).getByText("/opt/skills").closest("li") as HTMLElement;
+  expect(ghost.textContent).toContain("(default)");
+  expect(within(ghost).queryByRole("button")).toBeNull();
+
+  // Adding the same path locally turns it into an ordinary removable row and
+  // drops the ghost (the effective layer already contains the local entry).
+  await typePath(user, pathTrigger(/browse/i), "/opt/skills");
+  await user.click(screen.getByRole("button", { name: "Add" }));
+  const row = within(list).getByText("/opt/skills").closest("li") as HTMLElement;
+  expect(row.textContent).not.toContain("(default)");
+  expect(within(row).getByRole("button", { name: "Remove /opt/skills" })).toBeTruthy();
+  expect(within(list).getAllByRole("listitem")).toHaveLength(1);
+});
+
+test("a modelList control ghosts inherited fallbacks", async () => {
+  const user = userEvent.setup();
+  renderPanel([option({ wireField: "modelFallbacks", kind: "modelList", label: "Model fallbacks" })], {
+    resolvedDefaults: { modelFallbacks: ["openai/gpt-5"] },
+  });
+
+  await user.click(screen.getByRole("button", { name: "Advanced options" }));
+
+  const list = screen.getByRole("list", { name: "Model fallbacks" });
+  const ghost = within(list).getByText("openai/gpt-5").closest("li") as HTMLElement;
+  expect(ghost.textContent).toContain("(default)");
+  expect(within(ghost).queryByRole("button")).toBeNull();
+});
+
+test("an envMap control ghosts inherited entries, and a local override of the same key replaces its ghost", async () => {
+  const user = userEvent.setup();
+  renderPanel([option({ wireField: "env", kind: "envMap", label: "Env vars" })], {
+    resolvedDefaults: { env: { EDITOR: "vim", PAGER: "less" } },
+  });
+
+  await user.click(screen.getByRole("button", { name: "Advanced options" }));
+
+  const list = screen.getByRole("list", { name: "Env vars" });
+  expect(within(list).queryByText("None.")).toBeNull();
+  for (const text of ["EDITOR=vim", "PAGER=less"]) {
+    const ghost = within(list).getByText(text).closest("li") as HTMLElement;
+    expect(ghost.textContent).toContain("(default)");
+    expect(within(ghost).queryByRole("button")).toBeNull();
+  }
+
+  // Overriding one key locally replaces exactly that ghost row.
+  await user.type(screen.getByPlaceholderText("NAME=value"), "EDITOR=emacs{Enter}");
+  const row = within(list).getByText("EDITOR=emacs").closest("li") as HTMLElement;
+  expect(row.textContent).not.toContain("(default)");
+  expect(within(row).getByRole("button", { name: "Remove EDITOR" })).toBeTruthy();
+  expect(within(list).queryByText("EDITOR=vim")).toBeNull();
+  expect(within(list).getByText("PAGER=less")).toBeTruthy();
+});
+
+test("an mcpServerList control ghosts inherited servers", async () => {
+  const user = userEvent.setup();
+  renderPanel([option({ wireField: "mcps", kind: "mcpServerList", label: "MCP servers" })], {
+    resolvedDefaults: { mcps: [{ name: "docs", command: "npx", args: ["docs-mcp"] }] },
+  });
+
+  await user.click(screen.getByRole("button", { name: "Advanced options" }));
+
+  const list = screen.getByRole("list", { name: "MCP servers" });
+  const ghost = within(list).getByText("docs: npx docs-mcp").closest("li") as HTMLElement;
+  expect(ghost.textContent).toContain("(default)");
+  expect(within(ghost).queryByRole("button")).toBeNull();
+});
+
 test("an integer control collects a parsed number", async () => {
   const user = userEvent.setup();
   const { onOverridesChange } = renderPanel([option({ wireField: "maxRounds", kind: "integer", label: "Max rounds" })]);

--- a/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.test.tsx
@@ -213,6 +213,61 @@ test("a modelPicker control names the resolved default model", async () => {
   expect(screen.getByRole("button", { name: /change model/i }).textContent).toContain("openai/gpt-5 (default)");
 });
 
+test("an integer control's placeholder names the resolved default", async () => {
+  const user = userEvent.setup();
+  renderPanel(
+    [
+      option({ wireField: "maxRounds", kind: "integer", label: "Max rounds" }),
+      option({ wireField: "maxSubagentDepth", kind: "integer", label: "Max subagent depth" }),
+    ],
+    { resolvedDefaults: { maxRounds: 250 } },
+  );
+
+  await user.click(screen.getByRole("button", { name: "Advanced options" }));
+
+  expect((screen.getByLabelText("Max rounds") as HTMLInputElement).placeholder).toBe("250 (default)");
+  // No layer sets this one: the input stays bare, exactly as before.
+  expect((screen.getByLabelText("Max subagent depth") as HTMLInputElement).placeholder).toBe("");
+});
+
+test("a text control's placeholder names the resolved default, clipped when long", async () => {
+  const user = userEvent.setup();
+  renderPanel(
+    [
+      option({ wireField: "agent", kind: "text", label: "Agent" }),
+      option({ wireField: "systemPromptText", kind: "text", label: "System prompt text" }),
+    ],
+    { resolvedDefaults: { agent: "evener-canary", systemPromptText: "x".repeat(120) } },
+  );
+
+  await user.click(screen.getByRole("button", { name: "Advanced options" }));
+
+  expect((screen.getByLabelText("Agent") as HTMLInputElement).placeholder).toBe("evener-canary (default)");
+  // A long free-text default (a system prompt) is clipped, not dumped whole.
+  const promptPlaceholder = (screen.getByLabelText("System prompt text") as HTMLInputElement).placeholder;
+  expect(promptPlaceholder.endsWith("… (default)")).toBe(true);
+  expect(promptPlaceholder.length).toBeLessThan(80);
+});
+
+test("a browsable path control's trigger names the resolved default path", async () => {
+  const user = userEvent.setup();
+  renderPanel(
+    [
+      option({ wireField: "traceFile", kind: "path", pathKind: "outputFile", label: "Trace file" }),
+      option({ wireField: "cpuProfile", kind: "path", pathKind: "outputFile", label: "CPU profile" }),
+    ],
+    { resolvedDefaults: { traceFile: "/tmp/demo-trace.log" } },
+  );
+
+  await user.click(screen.getByRole("button", { name: "Advanced options" }));
+
+  expect(screen.getByRole("button", { name: /Trace file/i }).textContent).toContain("/tmp/demo-trace.log (default)");
+  // No layer sets this one: the plain "(default)" trigger stays.
+  const cpuTrigger = screen.getByRole("button", { name: /CPU profile/i });
+  expect(cpuTrigger.textContent).toContain("(default)");
+  expect(cpuTrigger.textContent).not.toContain("demo-trace");
+});
+
 test("an integer control collects a parsed number", async () => {
   const user = userEvent.setup();
   const { onOverridesChange } = renderPanel([option({ wireField: "maxRounds", kind: "integer", label: "Max rounds" })]);

--- a/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.tsx
@@ -56,6 +56,12 @@ export interface AdvancedOptionsProps {
   /** Rendered first inside the expanded panel, ahead of the schema controls
    * (9ct0: hosts the Access-mode field moved in from the top-level bar). */
   children?: ReactNode;
+  /** The effective layer of the pane's own launch/resolve for the current
+   * cwd (undefined until it lands or after it fails): a control whose unset
+   * state reads "(default)" prepends its entry here - "On (default)",
+   * "high (default)", "openai/gpt-5 (default)" - so the empty marker names
+   * what a session started now would actually inherit. */
+  resolvedDefaults?: LaunchConfigLayer;
 }
 
 export function AdvancedOptions({
@@ -66,6 +72,7 @@ export function AdvancedOptions({
   loadCatalog,
   complete,
   children,
+  resolvedDefaults,
 }: AdvancedOptionsProps) {
   const [open, setOpen] = useState(false);
   const [values, setValues] = useState<AdvancedValues>({});
@@ -130,6 +137,7 @@ export function AdvancedOptions({
               loadCatalog={loadCatalog}
               complete={complete}
               validatePath={validatePath}
+              resolvedDefaults={resolvedDefaults}
               onScalar={(v) => updateScalar(opt, v)}
               onValue={(field) => update(opt.wireField, field)}
             />
@@ -164,8 +172,33 @@ interface ControlProps {
   complete: (prefix: string, includeFiles: boolean) => Promise<string[]>;
   /** Gates a pathList add (the scalar path kinds validate through onScalar). */
   validatePath: (path: string, kind: string) => Promise<PathValidation>;
+  resolvedDefaults?: LaunchConfigLayer;
   onScalar: (value: string) => void;
   onValue: (field: AdvancedFieldValue) => void;
+}
+
+/** The effective layer's raw value for this field, or undefined when no layer
+ * sets it (or the resolve hasn't landed) - the source for every "<value>
+ * (default)" label below. */
+function resolvedValue(option: LaunchOption, resolvedDefaults: LaunchConfigLayer | undefined): unknown {
+  if (!resolvedDefaults) return undefined;
+  return (resolvedDefaults as Record<string, unknown>)[option.wireField];
+}
+
+/** The "<value> (default)" label for an unset string-valued control, or plain
+ * "(default)" when the effective layer doesn't set the field. */
+function stringDefaultLabel(option: LaunchOption, resolvedDefaults: LaunchConfigLayer | undefined): string {
+  const value = resolvedValue(option, resolvedDefaults);
+  return typeof value === "string" && value !== "" ? `${value} (default)` : "(default)";
+}
+
+/** The "<On|Off> (default)" label for an unset boolean control - the panel's
+ * own On/Off wording, matching the set values' display labels. */
+function booleanDefaultLabel(option: LaunchOption, resolvedDefaults: LaunchConfigLayer | undefined): string {
+  const value = resolvedValue(option, resolvedDefaults);
+  if (value === true) return "On (default)";
+  if (value === false) return "Off (default)";
+  return "(default)";
 }
 
 /** The schema's browsable path kinds, mapped onto the widget's. A "command"
@@ -182,7 +215,17 @@ function pathFieldKind(pathKind: string | undefined): PathFieldKind | null {
   }
 }
 
-function Control({ option, value, error, loadCatalog, complete, validatePath, onScalar, onValue }: ControlProps) {
+function Control({
+  option,
+  value,
+  error,
+  loadCatalog,
+  complete,
+  validatePath,
+  resolvedDefaults,
+  onScalar,
+  onValue,
+}: ControlProps) {
   const controlId = useId();
   const current = typeof value?.value === "string" ? value.value : "";
 
@@ -206,7 +249,7 @@ function Control({ option, value, error, loadCatalog, complete, validatePath, on
             value={current === "" ? BOOLEAN_DEFAULT : current}
             onChange={(e) => onScalar(e.target.value === BOOLEAN_DEFAULT ? "" : e.target.value)}
             options={[
-              { value: BOOLEAN_DEFAULT, label: "(default)" },
+              { value: BOOLEAN_DEFAULT, label: booleanDefaultLabel(option, resolvedDefaults) },
               { value: "true", label: "On" },
               { value: "false", label: "Off" },
             ]}
@@ -230,8 +273,14 @@ function Control({ option, value, error, loadCatalog, complete, validatePath, on
             value={current}
             onChange={(e) => onScalar(e.target.value)}
             options={[
-              { value: "", label: "(default)" },
-              ...(option.choices ?? []).map((c) => ({ value: c.value, label: c.label })),
+              // The panel owns the one empty option: the schema ships its own
+              // value:"" choice for some fields (reasoning_effort,
+              // context_strategy), which is dropped here rather than rendered
+              // as a second, indistinguishable "(default)".
+              { value: "", label: stringDefaultLabel(option, resolvedDefaults) },
+              ...(option.choices ?? [])
+                .filter((c) => (c.value ?? "") !== "")
+                .map((c) => ({ value: c.value, label: c.label })),
             ]}
           />
         </FormRow>
@@ -264,7 +313,12 @@ function Control({ option, value, error, loadCatalog, complete, validatePath, on
       return (
         <div className={CLASS.fieldBlock}>
           <span className={CLASS.fieldLabel}>{option.label}</span>
-          <ModelCatalog value={current} onChange={onScalar} loadCatalog={loadCatalog} />
+          <ModelCatalog
+            value={current}
+            onChange={onScalar}
+            loadCatalog={loadCatalog}
+            emptyLabel={stringDefaultLabel(option, resolvedDefaults)}
+          />
           {option.description && <p className={CLASS.fieldHelp}>{option.description}</p>}
         </div>
       );

--- a/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.tsx
@@ -18,6 +18,7 @@ import type { LaunchConfigLayer, LaunchConfigResolved, LaunchOption, MCPServerSp
 import type { ModelCatalog as ModelCatalogEnvelope, PathFieldKind } from "../../widgets";
 import { Button, CollectionEditor, FormRow, Input, ModelCatalog, PathField, RadioGroup, Select } from "../../widgets";
 import { requireClass } from "../../widgets/internal/requireClass";
+import { asEnvEntries, asMcpList, asStringList, inheritedItems } from "../settings/sections/launchShared/inherited";
 import { type PathValidation, validatePathListAdd } from "../settings/sections/launchShared/pathListAdd";
 import { schemaPathKind } from "../settings/sections/launchShared/schema";
 import styles from "./advancedOptions.module.css";
@@ -220,37 +221,6 @@ function inputDefaultPlaceholder(option: LaunchOption, resolvedDefaults: LaunchC
     return `${shown} (default)`;
   }
   return "";
-}
-
-/** The entries a collection control shows as grayed "(default)" ghost rows:
- * the effective layer's value minus the user's own local entries. The
- * resolved layer already contains the local overrides (Spawn resolves with
- * them), so subtracting the local keys yields exactly the inherited entries
- * under each kind's merge semantics - append lists (pathList, mcpServerList)
- * keep inherited entries alongside local ones, env keeps inherited keys the
- * user has not overridden, and replace-merge modelFallbacks yields nothing
- * once a local entry exists. [] when no layer sets the field (or the resolve
- * hasn't landed): the control then looks exactly as it did before. */
-function inheritedItems<T>(
-  effective: unknown,
-  local: readonly T[],
-  key: (item: T) => string,
-  fromEffective: (value: unknown) => T[],
-): T[] {
-  const localKeys = new Set(local.map(key));
-  return fromEffective(effective).filter((item) => !localKeys.has(key(item)));
-}
-
-function asStringList(value: unknown): string[] {
-  return Array.isArray(value) ? (value as string[]) : [];
-}
-
-function asEnvEntries(value: unknown): [string, string][] {
-  return isRecord(value) ? Object.entries(value) : [];
-}
-
-function asMcpList(value: unknown): MCPServerSpec[] {
-  return isMcpList(value) ? value : [];
 }
 
 /** The schema's browsable path kinds, mapped onto the widget's. A "command"

--- a/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.tsx
@@ -222,6 +222,37 @@ function inputDefaultPlaceholder(option: LaunchOption, resolvedDefaults: LaunchC
   return "";
 }
 
+/** The entries a collection control shows as grayed "(default)" ghost rows:
+ * the effective layer's value minus the user's own local entries. The
+ * resolved layer already contains the local overrides (Spawn resolves with
+ * them), so subtracting the local keys yields exactly the inherited entries
+ * under each kind's merge semantics - append lists (pathList, mcpServerList)
+ * keep inherited entries alongside local ones, env keeps inherited keys the
+ * user has not overridden, and replace-merge modelFallbacks yields nothing
+ * once a local entry exists. [] when no layer sets the field (or the resolve
+ * hasn't landed): the control then looks exactly as it did before. */
+function inheritedItems<T>(
+  effective: unknown,
+  local: readonly T[],
+  key: (item: T) => string,
+  fromEffective: (value: unknown) => T[],
+): T[] {
+  const localKeys = new Set(local.map(key));
+  return fromEffective(effective).filter((item) => !localKeys.has(key(item)));
+}
+
+function asStringList(value: unknown): string[] {
+  return Array.isArray(value) ? (value as string[]) : [];
+}
+
+function asEnvEntries(value: unknown): [string, string][] {
+  return isRecord(value) ? Object.entries(value) : [];
+}
+
+function asMcpList(value: unknown): MCPServerSpec[] {
+  return isMcpList(value) ? value : [];
+}
+
 /** The schema's browsable path kinds, mapped onto the widget's. A "command"
  * pathKind names an executable to resolve on PATH and "" names no path at all,
  * so neither is browsable - those stay plain text boxes. */
@@ -371,6 +402,7 @@ function Control({
             option={option}
             items={Array.isArray(value?.value) ? (value.value as string[]) : []}
             loadCatalog={loadCatalog}
+            resolvedDefaults={resolvedDefaults}
             onValue={onValue}
           />
         </CollectionSection>
@@ -383,6 +415,7 @@ function Control({
             items={Array.isArray(value?.value) ? (value.value as string[]) : []}
             complete={complete}
             validatePath={validatePath}
+            resolvedDefaults={resolvedDefaults}
             onValue={onValue}
           />
         </CollectionSection>
@@ -390,13 +423,23 @@ function Control({
     case "envMap":
       return (
         <CollectionSection option={option}>
-          <EnvControl option={option} value={isRecord(value?.value) ? value.value : {}} onValue={onValue} />
+          <EnvControl
+            option={option}
+            value={isRecord(value?.value) ? value.value : {}}
+            resolvedDefaults={resolvedDefaults}
+            onValue={onValue}
+          />
         </CollectionSection>
       );
     case "mcpServerList":
       return (
         <CollectionSection option={option}>
-          <McpControl option={option} value={isMcpList(value?.value) ? value.value : []} onValue={onValue} />
+          <McpControl
+            option={option}
+            value={isMcpList(value?.value) ? value.value : []}
+            resolvedDefaults={resolvedDefaults}
+            onValue={onValue}
+          />
         </CollectionSection>
       );
     default:
@@ -439,12 +482,14 @@ function PathListControl({
   items,
   complete,
   validatePath,
+  resolvedDefaults,
   onValue,
 }: {
   option: LaunchOption;
   items: string[];
   complete: (prefix: string, includeFiles: boolean) => Promise<string[]>;
   validatePath: (path: string, kind: string) => Promise<PathValidation>;
+  resolvedDefaults: LaunchConfigLayer | undefined;
   onValue: (field: AdvancedFieldValue) => void;
 }) {
   const pathKind = pathFieldKind(option.pathKind);
@@ -452,6 +497,7 @@ function PathListControl({
     <CollectionEditor<string>
       label={option.label}
       items={items}
+      inheritedItems={inheritedItems(resolvedValue(option, resolvedDefaults), items, (item) => item, asStringList)}
       getKey={(item) => item}
       renderItem={(item) => item}
       removeLabel={(item) => `Remove ${item}`}
@@ -508,17 +554,20 @@ function ModelListControl({
   option,
   items,
   loadCatalog,
+  resolvedDefaults,
   onValue,
 }: {
   option: LaunchOption;
   items: string[];
   loadCatalog: () => Promise<ModelCatalogEnvelope>;
+  resolvedDefaults: LaunchConfigLayer | undefined;
   onValue: (field: AdvancedFieldValue) => void;
 }) {
   return (
     <CollectionEditor<string>
       label={option.label}
       items={items}
+      inheritedItems={inheritedItems(resolvedValue(option, resolvedDefaults), items, (item) => item, asStringList)}
       getKey={(item) => item}
       renderItem={(item) => item}
       removeLabel={(item) => `Remove ${item}`}
@@ -546,10 +595,12 @@ function ModelListControl({
 function EnvControl({
   option,
   value,
+  resolvedDefaults,
   onValue,
 }: {
   option: LaunchOption;
   value: Record<string, string>;
+  resolvedDefaults: LaunchConfigLayer | undefined;
   onValue: (field: AdvancedFieldValue) => void;
 }) {
   const entries = Object.entries(value);
@@ -557,6 +608,7 @@ function EnvControl({
     <CollectionEditor<[string, string]>
       label={option.label}
       items={entries}
+      inheritedItems={inheritedItems(resolvedValue(option, resolvedDefaults), entries, ([name]) => name, asEnvEntries)}
       getKey={([name]) => name}
       renderItem={([name, val]) => `${name}=${val}`}
       removeLabel={([name]) => `Remove ${name}`}
@@ -581,16 +633,19 @@ function EnvControl({
 function McpControl({
   option,
   value,
+  resolvedDefaults,
   onValue,
 }: {
   option: LaunchOption;
   value: MCPServerSpec[];
+  resolvedDefaults: LaunchConfigLayer | undefined;
   onValue: (field: AdvancedFieldValue) => void;
 }) {
   return (
     <CollectionEditor<MCPServerSpec>
       label={option.label}
       items={value}
+      inheritedItems={inheritedItems(resolvedValue(option, resolvedDefaults), value, (spec) => spec.name, asMcpList)}
       getKey={(spec) => spec.name}
       renderItem={(spec) => `${spec.name}: ${spec.command} ${(spec.args ?? []).join(" ")}`.trim()}
       removeLabel={(spec) => `Remove ${spec.name}`}

--- a/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.tsx
@@ -201,6 +201,27 @@ function booleanDefaultLabel(option: LaunchOption, resolvedDefaults: LaunchConfi
   return "(default)";
 }
 
+/** The longest a resolved default runs in a placeholder before it is clipped:
+ * long free-text values (a system prompt) must not turn a placeholder into a
+ * wall of text. */
+const DEFAULT_PLACEHOLDER_MAX = 60;
+
+/** The placeholder naming the resolved default for the input-based controls
+ * (integer, text, and the browsable path widget): "<value> (default)", with
+ * long strings clipped. "" when no layer sets the field - the inputs stay
+ * bare then, exactly as they were before the resolved-default labels. */
+function inputDefaultPlaceholder(option: LaunchOption, resolvedDefaults: LaunchConfigLayer | undefined): string {
+  const value = resolvedValue(option, resolvedDefaults);
+  if (typeof value === "number" && Number.isFinite(value)) return `${value} (default)`;
+  if (typeof value === "string" && value.trim() !== "") {
+    const trimmed = value.trim();
+    const shown =
+      trimmed.length > DEFAULT_PLACEHOLDER_MAX ? `${trimmed.slice(0, DEFAULT_PLACEHOLDER_MAX - 1)}…` : trimmed;
+    return `${shown} (default)`;
+  }
+  return "";
+}
+
 /** The schema's browsable path kinds, mapped onto the widget's. A "command"
  * pathKind names an executable to resolve on PATH and "" names no path at all,
  * so neither is browsable - those stay plain text boxes. */
@@ -235,7 +256,12 @@ function Control({
   function textRow() {
     return (
       <FormRow label={option.label} htmlFor={controlId} help={option.description} error={error || undefined}>
-        <Input id={controlId} value={current} onChange={(e) => onScalar(e.target.value)} />
+        <Input
+          id={controlId}
+          value={current}
+          onChange={(e) => onScalar(e.target.value)}
+          placeholder={inputDefaultPlaceholder(option, resolvedDefaults) || undefined}
+        />
       </FormRow>
     );
   }
@@ -288,7 +314,13 @@ function Control({
     case "integer":
       return (
         <FormRow label={option.label} htmlFor={controlId} help={option.description}>
-          <Input id={controlId} type="number" value={current} onChange={(e) => onScalar(e.target.value)} />
+          <Input
+            id={controlId}
+            type="number"
+            value={current}
+            onChange={(e) => onScalar(e.target.value)}
+            placeholder={inputDefaultPlaceholder(option, resolvedDefaults) || undefined}
+          />
         </FormRow>
       );
     case "path": {
@@ -302,7 +334,17 @@ function Control({
       // evener/path/validate failure.
       return (
         <FormRow label={option.label} htmlFor={controlId} help={option.description} error={error || undefined}>
-          <PathField id={controlId} value={current} onChange={onScalar} kind={pathKind} complete={complete} />
+          <PathField
+            id={controlId}
+            value={current}
+            onChange={onScalar}
+            kind={pathKind}
+            complete={complete}
+            // The trigger's empty face names the resolved default path the way
+            // the selects' empty options do; undefined keeps its built-in
+            // "(default)" when no layer sets the field.
+            placeholder={inputDefaultPlaceholder(option, resolvedDefaults) || undefined}
+          />
         </FormRow>
       );
     }

--- a/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.test.tsx
@@ -166,6 +166,23 @@ test("a disabled reasoning row is read-only and exposes no picker affordance", (
   expect(row.textContent).not.toContain("›");
 });
 
+// The Reasoning effort row's resting label is looked up by value in the same
+// options list the desktop Effort select renders (Spawn.tsx's effortOptions),
+// so once launch/resolve names the inherited effort there - "high (default)"
+// - the row says it too, with no mobile-side code of its own.
+test("the reasoning row inherits a resolved-default label from its options list", () => {
+  renderRows({
+    reasoningEffort: "",
+    reasoningOptions: [
+      { value: "", label: "high (default)" },
+      { value: "low", label: "low" },
+    ],
+  });
+
+  const row = screen.getByTestId("mobile-spawn-config").querySelector('[data-label="Reasoning effort"]');
+  expect(row?.textContent).toContain("high (default)");
+});
+
 test("plugin sheet stays open across toggles, Done applies, and Cancel restores focus", async () => {
   const user = userEvent.setup();
   const onPluginSelectionChange = vi.fn();

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -1421,6 +1421,105 @@ test("kata xgk8: an Advanced-options model override satisfies the requirement wi
   expect(modelTrigger().textContent).toContain("(default)"); // top-level chip untouched
 });
 
+// --- resolved-default labels -------------------------------------------------
+//
+// A launch-config control whose unset state reads "(default)" names the value
+// a session started now would inherit instead: the field's entry in the
+// effective layer of evener/launch/resolve for the current working directory.
+// Until that resolve lands - or if it fails - the label stays plain
+// "(default)": an unresolved answer must never be dressed up as a known one.
+
+function effortOptionLabels(): (string | null)[] {
+  const select = screen.getByLabelText("Effort") as HTMLSelectElement;
+  return Array.from(select.options).map((o) => o.textContent);
+}
+
+test("Effort, Model, and the mobile rows name the resolved default once launch/resolve lands", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("evener/launch/resolve", () => ({
+      effective: { model: "anthropic/claude-sonnet-4-5", reasoningEffort: "high" },
+      layers: {},
+      provenance: {},
+    }));
+  });
+  renderSpawn(fake);
+  await settled();
+
+  // No working directory yet, so no resolve has run: plain "(default)".
+  expect(effortOptionLabels()[0]).toBe("(default)");
+  expect(screen.getByTestId("spawn-model-value").textContent).toBe("(default)");
+
+  await setWorkingDir(user, "/tmp/project");
+  await waitFor(() => expect(fake.calls.some((c) => c.method === "evener/launch/resolve")).toBe(true));
+
+  // Effort's empty option names the inherited effort.
+  await waitFor(() => expect(effortOptionLabels()[0]).toBe("high (default)"));
+  // The desktop Model field's closed trigger names the inherited model.
+  expect(modelTrigger().textContent).toContain("anthropic/claude-sonnet-4-5 (default)");
+  // The card's phone trigger follows the same rule the desktop field does.
+  expect(screen.getByTestId("spawn-model-value").textContent).toBe("anthropic/claude-sonnet-4-5 (default)");
+  // The mobile Reasoning effort row derives its resting label from the same
+  // options list, so it inherits the resolved wording too.
+  const mobileConfig = screen.getByTestId("spawn-mobile-config");
+  const effortRow = mobileConfig.querySelector('[data-label="Reasoning effort"]');
+  expect(effortRow?.textContent).toContain("high (default)");
+});
+
+test("the (default) labels stay plain when the resolve fails", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("evener/launch/resolve", () => {
+      throw new Error("resolve down");
+    });
+  });
+  renderSpawn(fake);
+  await settled();
+
+  await setWorkingDir(user, "/tmp/project");
+  await waitFor(() => expect(fake.calls.some((c) => c.method === "evener/launch/resolve")).toBe(true));
+  await act(async () => {}); // let the rejection's state writes land
+
+  expect(effortOptionLabels()[0]).toBe("(default)");
+  expect(modelTrigger().textContent).not.toContain("claude");
+  expect(screen.getByTestId("spawn-model-value").textContent).toBe("(default)");
+});
+
+// The Advanced panel's own unset labels resolve the same way, off the same
+// resolve the pane already runs: a boolean field reads "On (default)"/"Off
+// (default)" per the effective value.
+test("an Advanced-options boolean names the resolved default (On/Off)", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("evener/launch/schema", () => ({
+      options: [
+        {
+          field: "no_project_prompts",
+          wireField: "noProjectPrompts",
+          label: "No project prompts",
+          group: "general",
+          kind: "boolean",
+          perLaunch: true,
+        },
+      ],
+    }));
+    f.on("evener/launch/resolve", () => ({
+      effective: { model: "anthropic/claude-sonnet-4-5", noProjectPrompts: true },
+      layers: {},
+      provenance: {},
+    }));
+  });
+  renderSpawn(fake);
+  await settled();
+
+  await setWorkingDir(user, "/tmp/project");
+  await waitFor(() => expect(fake.calls.some((c) => c.method === "evener/launch/resolve")).toBe(true));
+
+  await user.click(screen.getByRole("button", { name: "Advanced options" }));
+  const select = screen.getByLabelText("No project prompts") as HTMLSelectElement;
+  expect(Array.from(select.options).map((o) => o.textContent)).toEqual(["On (default)", "On", "Off"]);
+});
+
 // --- uncredentialed-default fallback ---------------------------------------
 //
 // A resolved default whose provider has no credentials is a guaranteed

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -1466,6 +1466,43 @@ test("Effort, Model, and the mobile rows name the resolved default once launch/r
   expect(effortRow?.textContent).toContain("high (default)");
 });
 
+// Access mode is the chip-level face of the launch-config sandbox field
+// (floor §1.8), so it follows the same resolved-default rule: its empty
+// option names the inherited sandbox in the chip's own friendly wording.
+test("Access mode names the resolved sandbox default once launch/resolve lands", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("evener/launch/resolve", () => ({
+      effective: { sandbox: "workspace-write" },
+      layers: {},
+      provenance: {},
+    }));
+  });
+  renderSpawn(fake);
+  await settled();
+
+  // The desktop Access mode select lives inside the Advanced panel.
+  await user.click(screen.getByRole("button", { name: "Advanced options" }));
+  const accessOptionLabels = () => {
+    const select = screen.getByLabelText("Access mode") as HTMLSelectElement;
+    return Array.from(select.options).map((o) => o.textContent);
+  };
+
+  // No working directory yet, so no resolve has run: plain "(default)".
+  expect(accessOptionLabels()[0]).toBe("(default)");
+
+  await setWorkingDir(user, "/tmp/project");
+  await waitFor(() => expect(fake.calls.some((c) => c.method === "evener/launch/resolve")).toBe(true));
+
+  // The desktop Access mode select's empty option names the inherited sandbox.
+  await waitFor(() => expect(accessOptionLabels()[0]).toBe("Workspace write (default)"));
+  // The mobile Access mode row derives its resting label from the same
+  // options list, so it inherits the resolved wording too.
+  const mobileConfig = screen.getByTestId("spawn-mobile-config");
+  const accessRow = mobileConfig.querySelector('[data-label="Access mode"]');
+  expect(accessRow?.textContent).toContain("Workspace write (default)");
+});
+
 test("the (default) labels stay plain when the resolve fails", async () => {
   const user = userEvent.setup();
   const fake = readyClient((f) => {

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -190,6 +190,12 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
   // The hub's resolved default model for this cwd ("" until resolve confirms
   // one): what the Effort ladder keys off while Model reads "(default)".
   const [resolvedDefaultModel, setResolvedDefaultModel] = useState("");
+  // The whole effective layer of the same launch/resolve (null until it
+  // lands, or after it fails): every launch-config control whose unset state
+  // reads "(default)" prepends its entry here - "high (default)",
+  // "On (default)", "anthropic/claude-sonnet-4 (default)" - so the word
+  // "(default)" never stands in for an answer the hub actually knows.
+  const [resolvedDefaults, setResolvedDefaults] = useState<LaunchConfigLayer | null>(null);
   const pluginRevision = useExtensionsStore((state) => state.pluginRevision);
   const pluginSelectionSupported = harnessSupportsPluginSelection(harness, harnesses);
   const combinedOverrides = pluginSelectionSupported
@@ -508,12 +514,14 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     if (cwd.trim() === "") {
       setNoDefaultModel(false);
       setResolvedDefaultModel("");
+      setResolvedDefaults(null);
       return undefined;
     }
     let active = true;
     Promise.all([resolveConfig(advancedOverrides), loadModels().catch(() => null)]).then(
       ([result, models]) => {
         if (!active) return;
+        setResolvedDefaults(result.effective);
         const defaultModel = (result.effective.model ?? "").trim();
         setNoDefaultModel(defaultModel === "");
         setResolvedDefaultModel(defaultModel);
@@ -530,6 +538,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
         if (active) {
           setNoDefaultModel(false);
           setResolvedDefaultModel("");
+          setResolvedDefaults(null);
         }
       },
     );
@@ -564,8 +573,12 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     reasoningEffort !== "" && reasoningEffort !== "none" && !effortLevels.includes(reasoningEffort)
       ? reasoningEffort
       : null;
+  // The effort a session started now would inherit: prepended onto the empty
+  // option's "(default)" once launch/resolve has landed with one.
+  const resolvedEffortDefault =
+    typeof resolvedDefaults?.reasoningEffort === "string" ? resolvedDefaults.reasoningEffort.trim() : "";
   const effortOptions = [
-    { value: "", label: "(default)" },
+    { value: "", label: resolvedEffortDefault !== "" ? `${resolvedEffortDefault} (default)` : "(default)" },
     ...effortLevels.filter((level) => level !== "none").map((level) => ({ value: level, label: level })),
     ...(preservedEffort === null ? [] : [{ value: preservedEffort, label: preservedEffort }]),
     { value: "none", label: "none" },
@@ -871,10 +884,16 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
                     control for one setting. The label follows the same rules
                     the desktop field's does - the required-choice word when
                     the hub has confirmed no default (kata xgk8), otherwise
-                    the chosen model or "(default)". */}
+                    the chosen model, the resolved default model's own
+                    "<model> (default)", or plain "(default)" until the
+                    resolve lands. */}
                 <span className={CLASS.modelTrigger} data-testid="spawn-model-slot">
                   <ModelSwitchTrigger
-                    label={modelRequired ? MODEL_CHOOSE_LABEL : model || "(default)"}
+                    label={
+                      modelRequired
+                        ? MODEL_CHOOSE_LABEL
+                        : model || (resolvedDefaultModel !== "" ? `${resolvedDefaultModel} (default)` : "(default)")
+                    }
                     value={model}
                     loadCatalog={loadCatalog}
                     onPick={handleModelPickEntry}
@@ -977,7 +996,13 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
               loadModels={loadModels}
               harness={harness || undefined}
               cwd={cwd || undefined}
-              emptyLabel={modelRequired ? MODEL_CHOOSE_LABEL : undefined}
+              emptyLabel={
+                modelRequired
+                  ? MODEL_CHOOSE_LABEL
+                  : resolvedDefaultModel !== ""
+                    ? `${resolvedDefaultModel} (default)`
+                    : undefined
+              }
             />
             {modelRequired && (
               <p className={CLASS.modelNote} role="alert">
@@ -1076,6 +1101,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
           resolveConfig={resolveConfig}
           loadCatalog={loadCatalog}
           complete={complete}
+          resolvedDefaults={resolvedDefaults ?? undefined}
         >
           <FormRow label="Harness" htmlFor="spawn-harness">
             <Select

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -56,7 +56,7 @@ import { AttachIcon } from "../session/composer/attachments/AttachIcon";
 import { imageFilesFromClipboard } from "../session/composer/attachments/clipboard";
 import { type TextEditor, useAttachments } from "../session/composer/attachments/useAttachments";
 import { AdvancedOptions } from "./AdvancedOptions";
-import { ACCESS_MODE_OPTIONS } from "./accessMode";
+import { ACCESS_MODE_OPTIONS, accessModeDefaultLabel } from "./accessMode";
 import { resolveHeadBranch } from "./branch";
 import { harnessSupportsPluginSelection, harnessUsesEvenerModels } from "./harnessModels";
 import { MobileSettingRows } from "./MobileSettingRows";
@@ -583,6 +583,15 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     ...(preservedEffort === null ? [] : [{ value: preservedEffort, label: preservedEffort }]),
     { value: "none", label: "none" },
   ];
+  // Access mode is the chip-level face of the launch-config sandbox field
+  // (floor §1.8), so its empty option follows the same rule as Effort's:
+  // name the inherited sandbox in the chip's own friendly wording
+  // ("Workspace write (default)") once resolve lands, plain "(default)"
+  // until then.
+  const accessOptions = [
+    { value: "", label: accessModeDefaultLabel(resolvedDefaults?.sandbox ?? "") },
+    ...ACCESS_MODE_OPTIONS,
+  ];
 
   // A chosen effort the (new) model's ladder doesn't name can't stay selected
   // - the select must never display a value it doesn't offer, so the choice
@@ -1084,7 +1093,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
             reasoningDisabled={effortDisabled}
             onReasoningChange={setReasoningEffort}
             accessMode={accessMode}
-            accessOptions={[{ value: "", label: "(default)" }, ...ACCESS_MODE_OPTIONS]}
+            accessOptions={accessOptions}
             onAccessChange={setAccessMode}
             pluginPreview={pluginPreview.state}
             pluginSelection={pluginSelection}
@@ -1116,7 +1125,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
               id="spawn-access"
               value={accessMode}
               onChange={(e) => setAccessMode(e.target.value)}
-              options={[{ value: "", label: "(default)" }, ...ACCESS_MODE_OPTIONS]}
+              options={accessOptions}
             />
           </FormRow>
         </AdvancedOptions>

--- a/cmd/evener-hub/frontend/src/panes/spawn/accessMode.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/accessMode.test.ts
@@ -1,6 +1,12 @@
 // @vitest-environment node
 import { describe, expect, test } from "vitest";
-import { ACCESS_MODE_OPTIONS, mergeAccessModeSandbox, sandboxForAccessMode } from "./accessMode";
+import {
+  ACCESS_MODE_OPTIONS,
+  accessModeDefaultLabel,
+  accessModeForSandbox,
+  mergeAccessModeSandbox,
+  sandboxForAccessMode,
+} from "./accessMode";
 
 describe("ACCESS_MODE_OPTIONS", () => {
   test("is exactly four fixed rows in order full/read-only/workspace-write/restricted (floor §1.8)", () => {
@@ -25,6 +31,41 @@ describe("sandboxForAccessMode", () => {
   test("an unrecognized or empty mode maps to no sandbox", () => {
     expect(sandboxForAccessMode("")).toBe("");
     expect(sandboxForAccessMode("nonsense")).toBe("");
+  });
+});
+
+describe("accessModeForSandbox", () => {
+  test("is the exact inverse of sandboxForAccessMode for every fixed row", () => {
+    for (const option of ACCESS_MODE_OPTIONS) {
+      expect(accessModeForSandbox(sandboxForAccessMode(option.value))).toEqual(option);
+    }
+  });
+
+  test('maps sandbox "off" back to the Full access row', () => {
+    expect(accessModeForSandbox("off")).toEqual({ value: "full", label: "Full access" });
+  });
+
+  test("an unrecognized or empty sandbox has no row", () => {
+    expect(accessModeForSandbox("")).toBeUndefined();
+    expect(accessModeForSandbox("nonsense")).toBeUndefined();
+  });
+});
+
+describe("accessModeDefaultLabel", () => {
+  test("names the resolved sandbox in the chip's own friendly wording", () => {
+    expect(accessModeDefaultLabel("off")).toBe("Full access (default)");
+    expect(accessModeDefaultLabel("read-only")).toBe("Read-only (default)");
+    expect(accessModeDefaultLabel("workspace-write")).toBe("Workspace write (default)");
+    expect(accessModeDefaultLabel("restricted")).toBe("Restricted (default)");
+  });
+
+  test('stays plain "(default)" when nothing resolves (unset everywhere or resolve not landed)', () => {
+    expect(accessModeDefaultLabel("")).toBe("(default)");
+    expect(accessModeDefaultLabel("   ")).toBe("(default)");
+  });
+
+  test("a sandbox value outside the fixed rows is named raw rather than dropped", () => {
+    expect(accessModeDefaultLabel("custom-mode")).toBe("custom-mode (default)");
   });
 });
 

--- a/cmd/evener-hub/frontend/src/panes/spawn/accessMode.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/accessMode.ts
@@ -35,6 +35,26 @@ export function sandboxForAccessMode(mode: string): string {
   }
 }
 
+// Inverse of sandboxForAccessMode, for labelling: the access-mode row a
+// resolved launch-config `sandbox` value corresponds to. "off" maps back to
+// "full" (Full access); an unknown or empty sandbox has no row.
+export function accessModeForSandbox(sandbox: string): AccessModeOption | undefined {
+  const value = sandbox.trim() === "off" ? "full" : sandbox.trim();
+  return ACCESS_MODE_OPTIONS.find((option) => option.value === value);
+}
+
+// The empty option's label for the access-mode control: names the sandbox a
+// session started now would inherit, in the control's own friendly wording -
+// "Workspace write (default)". Plain "(default)" until a resolve lands with
+// one; a sandbox value outside the four fixed rows is named raw rather than
+// dropped (same rule the effort ladder's preserved values follow).
+export function accessModeDefaultLabel(resolvedSandbox: string): string {
+  const sandbox = resolvedSandbox.trim();
+  if (sandbox === "") return "(default)";
+  const option = accessModeForSandbox(sandbox);
+  return `${option?.label ?? sandbox} (default)`;
+}
+
 // Mirrors web_spawn.go:launchOverridesWithAccessMode. Merges the access-mode
 // sandbox into launch overrides ONLY when the advanced-options schema hasn't
 // already set `sandbox` explicitly (floor §1.8) - the schema value wins.

--- a/cmd/evener-hub/frontend/src/widgets/collectioneditor/collectioneditor.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/collectioneditor/collectioneditor.module.css
@@ -40,6 +40,24 @@
   font-size: var(--font-size-ui);
 }
 
+/* An inherited ("(default)") row: informational only, so it loses the filled
+ * surface and drops to mid-ink - the tag stands where a local row's remove
+ * button would be, keeping the two row shapes aligned. */
+.inherited {
+  border-style: dashed;
+  background: transparent;
+}
+
+.inherited .content {
+  color: var(--ink-mid);
+}
+
+.inheritedTag {
+  flex-shrink: 0;
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}
+
 .addForm {
   display: flex;
   align-items: center;

--- a/cmd/evener-hub/frontend/src/widgets/collectioneditor/collectioneditor.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/collectioneditor/collectioneditor.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { afterEach, describe, expect, test, vi } from "vitest";
@@ -182,6 +182,37 @@ test("the input and add button are disabled while onAdd is pending, and re-enabl
 
   resolveAdd({ ok: true });
   await waitFor(() => expect(input.disabled).toBe(false));
+});
+
+describe("inheritedItems", () => {
+  test("renders inherited rows below the local rows, tagged (default), with no remove button", () => {
+    render(<CollectionEditor<DirItem> {...baseProps({ inheritedItems: [{ path: "/etc/defaults/plugins" }] })} />);
+
+    const rows = within(screen.getByRole("list", { name: "Plugin directories" })).getAllByRole("listitem");
+    expect(rows).toHaveLength(3);
+    const [local1, local2, ghost] = rows as [HTMLElement, HTMLElement, HTMLElement];
+    expect(ghost.textContent).toContain("/etc/defaults/plugins");
+    expect(ghost.textContent).toContain("(default)");
+    // A ghost row is not the caller's to remove - no button at all.
+    expect(within(ghost).queryByRole("button")).toBeNull();
+    // The local rows keep theirs.
+    expect(within(local1).getByRole("button", { name: "Remove /opt/plugins" })).toBeTruthy();
+    expect(within(local2).getByRole("button", { name: "Remove /home/user/.evener/plugins" })).toBeTruthy();
+  });
+
+  test("inherited rows suppress the empty message when there are no local items", () => {
+    render(
+      <CollectionEditor<DirItem> {...baseProps({ items: [], inheritedItems: [{ path: "/etc/defaults/plugins" }] })} />,
+    );
+
+    expect(screen.queryByText("No plugin directories. Add one below.")).toBeNull();
+    expect(screen.getByText("/etc/defaults/plugins")).toBeTruthy();
+  });
+
+  test("the empty message still shows when local and inherited are both empty", () => {
+    render(<CollectionEditor<DirItem> {...baseProps({ items: [], inheritedItems: [] })} />);
+    expect(screen.getByText("No plugin directories. Add one below.")).toBeTruthy();
+  });
 });
 
 describe("renderAddField", () => {

--- a/cmd/evener-hub/frontend/src/widgets/collectioneditor/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/collectioneditor/index.tsx
@@ -28,6 +28,13 @@ export interface CollectionEditorProps<T> {
    * instance vs. plain dir row). */
   onRemove: (item: T) => void;
   emptyMessage: string;
+  /** Entries a session would inherit from lower config layers, rendered as
+   * grayed rows tagged "(default)" below the caller's own rows - no remove
+   * button, since they are not the caller's to remove. The caller computes
+   * the list (the effective value minus its own items, per the field's merge
+   * semantics); this widget only renders it. Inherited rows suppress
+   * `emptyMessage`: a field with inherited entries is not empty. */
+  inheritedItems?: readonly T[];
   /** Placeholder for the built-in plain-text add field. Unused (optional)
    * when `renderAddField` is given - the caller's own fields carry their
    * own placeholders then. */
@@ -63,6 +70,8 @@ const CLASS = {
   row: requireClass(styles.row, "collectioneditor.module.css", "row"),
   content: requireClass(styles.content, "collectioneditor.module.css", "content"),
   empty: requireClass(styles.empty, "collectioneditor.module.css", "empty"),
+  inherited: requireClass(styles.inherited, "collectioneditor.module.css", "inherited"),
+  inheritedTag: requireClass(styles.inheritedTag, "collectioneditor.module.css", "inheritedTag"),
   addForm: requireClass(styles.addForm, "collectioneditor.module.css", "addForm"),
   addField: requireClass(styles.addField, "collectioneditor.module.css", "addField"),
   visuallyHidden: requireClass(styles.visuallyHidden, "collectioneditor.module.css", "visuallyHidden"),
@@ -97,6 +106,7 @@ export function CollectionEditor<T>({
   removeLabel,
   onRemove,
   emptyMessage,
+  inheritedItems = [],
   addPlaceholder,
   addButtonLabel = "Add",
   onAdd,
@@ -125,21 +135,29 @@ export function CollectionEditor<T>({
   return (
     <div className={CLASS.root}>
       <ul aria-label={label} className={CLASS.list}>
-        {items.length === 0 ? (
+        {items.length === 0 && inheritedItems.length === 0 ? (
           <li className={CLASS.empty}>{emptyMessage}</li>
         ) : (
-          items.map((item) => (
-            <li key={getKey(item)} className={CLASS.row}>
-              <div className={CLASS.content}>{renderItem(item)}</div>
-              <IconButton
-                label={removeLabel(item)}
-                icon={<RemoveIcon />}
-                variant="quiet"
-                size="sm"
-                onClick={() => onRemove(item)}
-              />
-            </li>
-          ))
+          <>
+            {items.map((item) => (
+              <li key={getKey(item)} className={CLASS.row}>
+                <div className={CLASS.content}>{renderItem(item)}</div>
+                <IconButton
+                  label={removeLabel(item)}
+                  icon={<RemoveIcon />}
+                  variant="quiet"
+                  size="sm"
+                  onClick={() => onRemove(item)}
+                />
+              </li>
+            ))}
+            {inheritedItems.map((item) => (
+              <li key={`inherited:${getKey(item)}`} className={`${CLASS.row} ${CLASS.inherited}`}>
+                <div className={CLASS.content}>{renderItem(item)}</div>
+                <span className={CLASS.inheritedTag}>(default)</span>
+              </li>
+            ))}
+          </>
         )}
       </ul>
       <form className={CLASS.addForm} onSubmit={(event) => void handleSubmit(event)}>

--- a/cmd/evener-tui/hub_update_config.go
+++ b/cmd/evener-tui/hub_update_config.go
@@ -174,9 +174,26 @@ func (m hubModel) handleLaunchOverridesOpen(msg launchconfig.LaunchOverridesOpen
 	}
 	m.launchOverridesModal = &modal
 	if m.client != nil {
-		return m, launchconfig.CmdLaunchSchema(m.client)
+		// The resolve supplies the modal's "(default)" labels: unset
+		// overrides render the effective value a session started now would
+		// inherit for this working directory.
+		return m, tea.Batch(
+			launchconfig.CmdLaunchSchema(m.client),
+			launchconfig.CmdResolveLaunch(m.client, m.launchOverridesCWD(), nil),
+		)
 	}
 	return m, nil
+}
+
+// launchOverridesCWD is the working directory a session started now would
+// inherit — the spawn form's Dir when set, else the selected dashboard
+// project's directory — which is what the overrides modal resolves its
+// "(default)" labels against.
+func (m hubModel) launchOverridesCWD() string {
+	if dir := strings.TrimSpace(m.spawnDir); dir != "" {
+		return dir
+	}
+	return m.spawnWorkingDir()
 }
 
 func (m hubModel) handleLaunchOverridesResult(msg launchconfig.LaunchOverridesResultMsg) (tea.Model, tea.Cmd) {
@@ -514,11 +531,18 @@ func (m hubModel) handleLaunchResult(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.launchOverridesModal = &p
 		return m, cmd
 	}
+	var modalCmd tea.Cmd
+	if _, ok := msg.(launchconfig.LaunchResolveResultMsg); ok && m.launchOverridesModal != nil {
+		updated, cmd := m.launchOverridesModal.Update(msg)
+		p := updated.(launchconfig.LaunchOverridesModal)
+		m.launchOverridesModal = &p
+		modalCmd = cmd
+	}
 	if m.launchSettingsPanel != nil {
 		updated, cmd := m.launchSettingsPanel.Update(msg)
 		p := updated.(launchconfig.LaunchSettingsPanel)
 		m.launchSettingsPanel = &p
-		return m, cmd
+		return m, tea.Batch(modalCmd, cmd)
 	}
-	return m, nil
+	return m, modalCmd
 }

--- a/cmd/evener-tui/hub_update_config_covtest_test.go
+++ b/cmd/evener-tui/hub_update_config_covtest_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -377,23 +378,42 @@ func TestCovHandleLaunchOverridesOpen(t *testing.T) {
 		t.Fatal("cmd should be nil without client")
 	}
 
-	// With client: should produce a schema cmd.
-	called := false
+	// With client: opening the modal issues a schema fetch AND a launch
+	// resolve, so the modal can render resolved "(default)" labels for the
+	// directory a session started now would inherit.
+	schemaCalled := false
+	var resolveParams appwire.LaunchConfigResolveParams
 	client, cleanup := newTestHubClient(t, func(app *appserver.Server) {
 		appserver.HandleTyped(app.Router(), appwire.MethodEvenerLaunchSchema, func(context.Context, appwire.EmptyParams) (appwire.LaunchOptionSchemaResponse, error) {
-			called = true
+			schemaCalled = true
 			return appwire.LaunchOptionSchemaResponse{}, nil
+		})
+		appserver.HandleTyped(app.Router(), appwire.MethodEvenerLaunchResolve, func(_ context.Context, p appwire.LaunchConfigResolveParams) (appwire.LaunchConfigResolved, error) {
+			resolveParams = p
+			return appwire.LaunchConfigResolved{}, nil
 		})
 	})
 	defer cleanup()
 	m = newHubModel(client, "http://hub.test")
+	m.spawnDir = " /tmp/proj "
 	_, cmd = m.handleLaunchOverridesOpen(launchconfig.LaunchOverridesOpenMsg{})
 	if cmd == nil {
 		t.Fatal("cmd should not be nil with client")
 	}
-	result, ok := cmd().(launchconfig.LaunchSchemaResultMsg)
-	if !ok || result.Err != nil || !called {
-		t.Fatalf("launch schema result = %#v, called=%v", result, called)
+	batch, ok := cmd().(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("open cmd = %T, want tea.BatchMsg (schema + resolve)", cmd())
+	}
+	for _, sub := range batch {
+		if sub != nil {
+			_ = sub()
+		}
+	}
+	if !schemaCalled {
+		t.Fatal("open should issue a launch schema fetch")
+	}
+	if resolveParams.CWD != "/tmp/proj" {
+		t.Fatalf("resolve CWD = %q, want /tmp/proj (the spawn working dir)", resolveParams.CWD)
 	}
 }
 
@@ -1044,6 +1064,49 @@ func TestCovHandleLaunchResult(t *testing.T) {
 	after = got.(hubModel)
 	if after.launchOverridesModal != nil || after.launchSettingsPanel != nil || after.err != nil {
 		t.Fatalf("unrouted launch result mutated model: %#v", after)
+	}
+}
+
+// TestCovHandleLaunchResultRoutesResolveToModal: a resolve result updates an
+// open overrides modal's effective layer (so it renders resolved "(default)"
+// labels) while still reaching the settings panel when both are open.
+func TestCovHandleLaunchResultRoutesResolveToModal(t *testing.T) {
+	// Modal only: the modal consumes the resolve.
+	m := hubModel{session: newModel(nil)}
+	modal := launchconfig.NewLaunchOverridesModalWithSchema(appwire.LaunchConfigLayer{}, []appwire.LaunchOption{
+		{Field: "reasoning_effort", Label: "Reasoning effort", Kind: "select", PerLaunch: true},
+	})
+	m.launchOverridesModal = &modal
+	got, _ := m.handleLaunchResult(launchconfig.LaunchResolveResultMsg{Resolved: appwire.LaunchConfigResolved{
+		Effective: appwire.LaunchConfigLayer{ReasoningEffort: "high"},
+	}})
+	after := got.(hubModel)
+	if after.launchOverridesModal == nil {
+		t.Fatal("launchOverridesModal should still be set after resolve forwarded")
+	}
+	if v := after.launchOverridesModal.View(); !strings.Contains(v, "high (default)") {
+		t.Fatalf("modal view should render the resolved default label:\n%s", v)
+	}
+
+	// Modal and settings panel both open: both receive the resolve.
+	twoHundred := 200
+	m = hubModel{session: newModel(nil)}
+	fallbackModal := launchconfig.NewLaunchOverridesModal()
+	m.launchOverridesModal = &fallbackModal
+	panel := launchconfig.NewLaunchSettingsPanel(nil, "/cwd")
+	m.launchSettingsPanel = &panel
+	got, _ = m.handleLaunchResult(launchconfig.LaunchResolveResultMsg{Resolved: appwire.LaunchConfigResolved{
+		Effective: appwire.LaunchConfigLayer{MaxRounds: &twoHundred},
+	}})
+	after = got.(hubModel)
+	if after.launchOverridesModal == nil || after.launchSettingsPanel == nil {
+		t.Fatal("modal and panel should both remain set")
+	}
+	if v := after.launchOverridesModal.View(); !strings.Contains(v, "200 (default)") {
+		t.Fatalf("modal view should render the resolved default label:\n%s", v)
+	}
+	if v := after.launchSettingsPanel.View(); !strings.Contains(v, "200 (default)") {
+		t.Fatalf("settings panel view should still render the resolved default label:\n%s", v)
 	}
 }
 

--- a/cmd/evener-tui/internal/launchconfig/cov_rtui_launchconfig_test.go
+++ b/cmd/evener-tui/internal/launchconfig/cov_rtui_launchconfig_test.go
@@ -73,7 +73,7 @@ func TestLaunchOptionValue_AllFields(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.field, func(t *testing.T) {
-			value, editValue := launchOptionValue(appwire.LaunchOption{Field: tc.field}, layer)
+			value, editValue := launchOptionValue(appwire.LaunchOption{Field: tc.field}, layer, appwire.LaunchConfigLayer{})
 			if value != tc.wantValue {
 				t.Errorf("value = %q, want %q", value, tc.wantValue)
 			}
@@ -87,7 +87,7 @@ func TestLaunchOptionValue_AllFields(t *testing.T) {
 func TestLaunchOptionValue_Defaults(t *testing.T) {
 	empty := appwire.LaunchConfigLayer{}
 	for _, field := range []string{"agent", "max_rounds", "no_project_prompts", "verbose", "system_prompt_text"} {
-		value, _ := launchOptionValue(appwire.LaunchOption{Field: field}, empty)
+		value, _ := launchOptionValue(appwire.LaunchOption{Field: field}, empty, appwire.LaunchConfigLayer{})
 		if value != "(default)" {
 			t.Errorf("field %q value = %q, want (default)", field, value)
 		}
@@ -97,11 +97,11 @@ func TestLaunchOptionValue_Defaults(t *testing.T) {
 func TestLaunchOptionValue_ModelFallbacksVariants(t *testing.T) {
 	// nil → unset default; empty non-nil → explicit empty; populated → count.
 	nilLayer := appwire.LaunchConfigLayer{ModelFallbacks: nil}
-	if v, e := launchOptionValue(appwire.LaunchOption{Field: "model_fallbacks"}, nilLayer); v != "(default)" || e != "(default)" {
+	if v, e := launchOptionValue(appwire.LaunchOption{Field: "model_fallbacks"}, nilLayer, appwire.LaunchConfigLayer{}); v != "(default)" || e != "(default)" {
 		t.Fatalf("nil fallbacks = (%q,%q), want (default),(default)", v, e)
 	}
 	emptyLayer := appwire.LaunchConfigLayer{ModelFallbacks: []string{}}
-	if v, e := launchOptionValue(appwire.LaunchOption{Field: "model_fallbacks"}, emptyLayer); v != "0 entries (explicit)" || e != "[]" {
+	if v, e := launchOptionValue(appwire.LaunchOption{Field: "model_fallbacks"}, emptyLayer, appwire.LaunchConfigLayer{}); v != "0 entries (explicit)" || e != "[]" {
 		t.Fatalf("empty fallbacks = (%q,%q), want explicit,[]", v, e)
 	}
 }

--- a/cmd/evener-tui/internal/launchconfig/coverage_fuzz_test.go
+++ b/cmd/evener-tui/internal/launchconfig/coverage_fuzz_test.go
@@ -309,12 +309,12 @@ func exerciseRemainingStates(t *testing.T) {
 	panel.tab = launchTabProject
 	_ = panel.tabName()
 	_ = panel.currentLayer()
-	_ = launchSchemaRows(nil, appwire.LaunchConfigLayer{}, "global", launchSchemaRowsSettings)
-	_ = layerRowForOption(appwire.LaunchOption{Field: "model"}, appwire.LaunchConfigLayer{})
+	_ = launchSchemaRows(nil, appwire.LaunchConfigLayer{}, "global", launchSchemaRowsSettings, appwire.LaunchConfigLayer{})
+	_ = layerRowForOption(appwire.LaunchOption{Field: "model"}, appwire.LaunchConfigLayer{}, appwire.LaunchConfigLayer{})
 	b := true
-	_, _ = launchOptionValue(appwire.LaunchOption{Field: "sandbox_net"}, appwire.LaunchConfigLayer{SandboxNet: &b})
-	_, _ = launchOptionValue(appwire.LaunchOption{Field: "sandbox"}, appwire.LaunchConfigLayer{Sandbox: "x"})
-	_, _ = launchOptionValue(appwire.LaunchOption{Field: "mcps"}, appwire.LaunchConfigLayer{})
+	_, _ = launchOptionValue(appwire.LaunchOption{Field: "sandbox_net"}, appwire.LaunchConfigLayer{SandboxNet: &b}, appwire.LaunchConfigLayer{})
+	_, _ = launchOptionValue(appwire.LaunchOption{Field: "sandbox"}, appwire.LaunchConfigLayer{Sandbox: "x"}, appwire.LaunchConfigLayer{})
+	_, _ = launchOptionValue(appwire.LaunchOption{Field: "mcps"}, appwire.LaunchConfigLayer{}, appwire.LaunchConfigLayer{})
 	exerciseApplyEditBranches(t)
 
 	plugins := NewPluginsPanel()
@@ -381,7 +381,7 @@ func exerciseApplyEditBranches(t *testing.T) {
 	}
 	i := 1
 	tr := true
-	_ = layerRows(appwire.LaunchConfigLayer{MaxRounds: &i, NoProjectPrompts: &tr})
+	_ = layerRows(appwire.LaunchConfigLayer{MaxRounds: &i, NoProjectPrompts: &tr}, appwire.LaunchConfigLayer{})
 	originalMarshal := marshalMCPEditSpecs
 	marshalMCPEditSpecs = func([]mcpEditSpec) ([]byte, error) { return nil, errors.New("x") }
 	_ = mcpEditValue([]appwire.MCPServerSpec{{Name: "x"}})

--- a/cmd/evener-tui/internal/launchconfig/launch_overrides_modal.go
+++ b/cmd/evener-tui/internal/launchconfig/launch_overrides_modal.go
@@ -20,6 +20,7 @@ type LaunchOverridesOpenMsg struct {
 
 type LaunchOverridesModal struct {
 	cur       appwire.LaunchConfigLayer
+	effective appwire.LaunchConfigLayer
 	schema    []appwire.LaunchOption
 	cursor    int
 	done      bool
@@ -45,6 +46,13 @@ func (m LaunchOverridesModal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case LaunchSchemaResultMsg:
 		if v.Err == nil {
 			m.schema = v.Schema.Options
+		}
+	case LaunchResolveResultMsg:
+		// The resolve for the current working directory supplies the
+		// "(default)" labels: unset overrides render the effective value a
+		// session started now would inherit.
+		if v.Err == nil {
+			m.effective = v.Resolved.Effective
 		}
 	case tea.KeyMsg:
 		switch v.Type {
@@ -120,7 +128,7 @@ func (m LaunchOverridesModal) Done() bool { return m.done }
 
 func (m LaunchOverridesModal) rows() []layerRow {
 	if len(m.schema) > 0 {
-		return launchSchemaRows(m.schema, m.cur, launchLayerLaunch, launchSchemaRowsOverride)
+		return launchSchemaRows(m.schema, m.cur, launchLayerLaunch, launchSchemaRowsOverride, m.effective)
 	}
-	return layerRows(m.cur)
+	return layerRows(m.cur, m.effective)
 }

--- a/cmd/evener-tui/internal/launchconfig/launch_overrides_modal_test.go
+++ b/cmd/evener-tui/internal/launchconfig/launch_overrides_modal_test.go
@@ -120,3 +120,45 @@ func TestLaunchOverridesModal_ApplyEditMCPs(t *testing.T) {
 		t.Fatalf("MCPs=%+v", cur.MCPs)
 	}
 }
+
+// TestLaunchOverridesModal_ResolvedDefaultLabels: an unset override renders
+// the bare "(default)" label until a resolve result arrives, then renders the
+// resolved effective value with the "(default)" suffix — in both the schema
+// and fallback row paths.
+func TestLaunchOverridesModal_ResolvedDefaultLabels(t *testing.T) {
+	m := NewLaunchOverridesModalWithSchema(appwire.LaunchConfigLayer{}, []appwire.LaunchOption{
+		{Field: "reasoning_effort", Label: "Reasoning effort", Kind: "select", PerLaunch: true},
+	})
+	if v := m.View(); strings.Contains(v, "high (default)") {
+		t.Fatalf("no resolve yet, view should not show a resolved label:\n%s", v)
+	}
+	updated, _ := m.Update(LaunchResolveResultMsg{Resolved: appwire.LaunchConfigResolved{
+		Effective: appwire.LaunchConfigLayer{ReasoningEffort: "high"},
+	}})
+	m = updated.(LaunchOverridesModal)
+	if v := m.View(); !strings.Contains(v, "high (default)") {
+		t.Fatalf("schema rows should render the resolved default label:\n%s", v)
+	}
+
+	// Fallback (schema-less) rows follow the same rule.
+	twoHundred := 200
+	fallback := NewLaunchOverridesModal()
+	updated, _ = fallback.Update(LaunchResolveResultMsg{Resolved: appwire.LaunchConfigResolved{
+		Effective: appwire.LaunchConfigLayer{MaxRounds: &twoHundred},
+	}})
+	if v := updated.(LaunchOverridesModal).View(); !strings.Contains(v, "200 (default)") {
+		t.Fatalf("fallback rows should render the resolved default label:\n%s", v)
+	}
+}
+
+// TestLaunchOverridesModal_ResolveErrorKeepsPlainDefault: a failed resolve
+// leaves the bare "(default)" label in place.
+func TestLaunchOverridesModal_ResolveErrorKeepsPlainDefault(t *testing.T) {
+	m := NewLaunchOverridesModalWithSchema(appwire.LaunchConfigLayer{}, []appwire.LaunchOption{
+		{Field: "reasoning_effort", Label: "Reasoning effort", Kind: "select", PerLaunch: true},
+	})
+	updated, _ := m.Update(LaunchResolveResultMsg{Err: errOOM})
+	if v := updated.(LaunchOverridesModal).View(); !strings.Contains(v, "(default)") || strings.Contains(v, "high") {
+		t.Fatalf("failed resolve should keep the bare default label:\n%s", v)
+	}
+}

--- a/cmd/evener-tui/internal/launchconfig/launch_schema.go
+++ b/cmd/evener-tui/internal/launchconfig/launch_schema.go
@@ -23,7 +23,7 @@ const (
 	launchSchemaRowsOverride launchSchemaRowsMode = "override"
 )
 
-func launchSchemaRows(schema []appwire.LaunchOption, layer appwire.LaunchConfigLayer, layerName string, mode launchSchemaRowsMode) []layerRow {
+func launchSchemaRows(schema []appwire.LaunchOption, layer appwire.LaunchConfigLayer, layerName string, mode launchSchemaRowsMode, effective appwire.LaunchConfigLayer) []layerRow {
 	if len(schema) == 0 {
 		return nil
 	}
@@ -45,7 +45,7 @@ func launchSchemaRows(schema []appwire.LaunchOption, layer appwire.LaunchConfigL
 				continue
 			}
 		}
-		rows = append(rows, layerRowForOption(opt, layer))
+		rows = append(rows, layerRowForOption(opt, layer, effective))
 	}
 	return rows
 }
@@ -54,8 +54,8 @@ func launchOptionDefaultableInLayer(opt appwire.LaunchOption, layerName string) 
 	return slices.Contains(opt.DefaultableLayers, layerName)
 }
 
-func layerRowForOption(opt appwire.LaunchOption, layer appwire.LaunchConfigLayer) layerRow {
-	value, editValue := launchOptionValue(opt, layer)
+func layerRowForOption(opt appwire.LaunchOption, layer, effective appwire.LaunchConfigLayer) layerRow {
+	value, editValue := launchOptionValue(opt, layer, effective)
 	label := opt.Label
 	if label == "" {
 		label = opt.Field
@@ -72,7 +72,24 @@ func launchOptionUsesPathCompletion(opt appwire.LaunchOption) bool {
 	}
 }
 
-func launchOptionValue(opt appwire.LaunchOption, l appwire.LaunchConfigLayer) (string, string) {
+// launchOptionValue renders an option's display and edit values for a layer.
+// When the field is unset in the displayed layer (rendering the bare
+// "(default)" placeholder) but set in the resolved effective layer, the
+// display instead shows the resolved value with a " (default)" suffix —
+// formatted exactly as a set value would be. The edit value is never
+// suffixed: editing an unset field still starts from the unset placeholder.
+func launchOptionValue(opt appwire.LaunchOption, l, effective appwire.LaunchConfigLayer) (string, string) {
+	display, editValue := launchOptionLayerValue(opt, l)
+	if display != "(default)" {
+		return display, editValue
+	}
+	if resolved, _ := launchOptionLayerValue(opt, effective); resolved != "(default)" && resolved != "(unsupported)" {
+		return resolved + " (default)", editValue
+	}
+	return display, editValue
+}
+
+func launchOptionLayerValue(opt appwire.LaunchOption, l appwire.LaunchConfigLayer) (string, string) {
 	ptrIntStr := func(p *int) string {
 		if p == nil {
 			return "(default)"

--- a/cmd/evener-tui/internal/launchconfig/launch_schema_covtest_test.go
+++ b/cmd/evener-tui/internal/launchconfig/launch_schema_covtest_test.go
@@ -9,7 +9,7 @@ import (
 // --- launchSchemaRows: empty schema ---
 
 func TestCovLaunchSchemaRowsEmpty(t *testing.T) {
-	rows := launchSchemaRows(nil, appwire.LaunchConfigLayer{}, "global", launchSchemaRowsSettings)
+	rows := launchSchemaRows(nil, appwire.LaunchConfigLayer{}, "global", launchSchemaRowsSettings, appwire.LaunchConfigLayer{})
 	if rows != nil {
 		t.Fatalf("empty schema should return nil, got %v", rows)
 	}
@@ -19,7 +19,7 @@ func TestCovLaunchSchemaRowsEmpty(t *testing.T) {
 
 func TestCovLayerRowForOptionLabelFallback(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "my_field", Label: "", Kind: "text"}
-	row := layerRowForOption(opt, appwire.LaunchConfigLayer{})
+	row := layerRowForOption(opt, appwire.LaunchConfigLayer{}, appwire.LaunchConfigLayer{})
 	if row.label != "my_field" {
 		t.Fatalf("label fallback = %q, want my_field", row.label)
 	}
@@ -27,7 +27,7 @@ func TestCovLayerRowForOptionLabelFallback(t *testing.T) {
 
 func TestCovLayerRowForOptionLabelUsed(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "my_field", Label: "My Field", Kind: "text"}
-	row := layerRowForOption(opt, appwire.LaunchConfigLayer{})
+	row := layerRowForOption(opt, appwire.LaunchConfigLayer{}, appwire.LaunchConfigLayer{})
 	if row.label != "My Field" {
 		t.Fatalf("label = %q, want My Field", row.label)
 	}
@@ -37,7 +37,7 @@ func TestCovLayerRowForOptionLabelUsed(t *testing.T) {
 
 func TestCovLaunchOptionValueUnsupported(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "totally_unknown", Kind: "text"}
-	val, editVal := launchOptionValue(opt, appwire.LaunchConfigLayer{})
+	val, editVal := launchOptionValue(opt, appwire.LaunchConfigLayer{}, appwire.LaunchConfigLayer{})
 	if val != "(unsupported)" {
 		t.Fatalf("unsupported value = %q, want (unsupported)", val)
 	}
@@ -50,7 +50,7 @@ func TestCovLaunchOptionValueUnsupported(t *testing.T) {
 
 func TestCovLaunchOptionValueAgent(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "agent", Kind: "text"}
-	val, editVal := launchOptionValue(opt, appwire.LaunchConfigLayer{Agent: "evener"})
+	val, editVal := launchOptionValue(opt, appwire.LaunchConfigLayer{Agent: "evener"}, appwire.LaunchConfigLayer{})
 	if val != "evener" || editVal != "evener" {
 		t.Fatalf("agent = %q/%q", val, editVal)
 	}
@@ -58,7 +58,7 @@ func TestCovLaunchOptionValueAgent(t *testing.T) {
 
 func TestCovLaunchOptionValueModel(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "model", Kind: "modelPicker"}
-	val, editVal := launchOptionValue(opt, appwire.LaunchConfigLayer{Model: "gpt-5"})
+	val, editVal := launchOptionValue(opt, appwire.LaunchConfigLayer{Model: "gpt-5"}, appwire.LaunchConfigLayer{})
 	if val != "gpt-5" || editVal != "gpt-5" {
 		t.Fatalf("model = %q/%q", val, editVal)
 	}
@@ -66,7 +66,7 @@ func TestCovLaunchOptionValueModel(t *testing.T) {
 
 func TestCovLaunchOptionValueSandbox(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "sandbox", Kind: "select"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{Sandbox: "read-only"})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{Sandbox: "read-only"}, appwire.LaunchConfigLayer{})
 	if val != "read-only" {
 		t.Fatalf("sandbox = %q, want read-only", val)
 	}
@@ -74,7 +74,7 @@ func TestCovLaunchOptionValueSandbox(t *testing.T) {
 
 func TestCovLaunchOptionValueReasoningEffort(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "reasoning_effort", Kind: "select"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{ReasoningEffort: "high"})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{ReasoningEffort: "high"}, appwire.LaunchConfigLayer{})
 	if val != "high" {
 		t.Fatalf("reasoning_effort = %q, want high", val)
 	}
@@ -82,7 +82,7 @@ func TestCovLaunchOptionValueReasoningEffort(t *testing.T) {
 
 func TestCovLaunchOptionValueFastCheapModel(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "fast_cheap_model", Kind: "modelPicker"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{FastCheapModel: "mini"})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{FastCheapModel: "mini"}, appwire.LaunchConfigLayer{})
 	if val != "mini" {
 		t.Fatalf("fast_cheap_model = %q, want mini", val)
 	}
@@ -90,7 +90,7 @@ func TestCovLaunchOptionValueFastCheapModel(t *testing.T) {
 
 func TestCovLaunchOptionValueContextStrategy(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "context_strategy", Kind: "select"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{ContextStrategy: "compact"})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{ContextStrategy: "compact"}, appwire.LaunchConfigLayer{})
 	if val != "compact" {
 		t.Fatalf("context_strategy = %q, want compact", val)
 	}
@@ -98,7 +98,7 @@ func TestCovLaunchOptionValueContextStrategy(t *testing.T) {
 
 func TestCovLaunchOptionValueOpenAIResponsesContinuation(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "openai_responses_continuation", Kind: "select"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{OpenAIResponsesContinuation: "auto"})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{OpenAIResponsesContinuation: "auto"}, appwire.LaunchConfigLayer{})
 	if val != "auto" {
 		t.Fatalf("openai_responses_continuation = %q, want auto", val)
 	}
@@ -106,7 +106,7 @@ func TestCovLaunchOptionValueOpenAIResponsesContinuation(t *testing.T) {
 
 func TestCovLaunchOptionValueSystemPromptMode(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "system_prompt_mode", Kind: "select"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{SystemPromptMode: "custom"})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{SystemPromptMode: "custom"}, appwire.LaunchConfigLayer{})
 	if val != "custom" {
 		t.Fatalf("system_prompt_mode = %q, want custom", val)
 	}
@@ -114,7 +114,7 @@ func TestCovLaunchOptionValueSystemPromptMode(t *testing.T) {
 
 func TestCovLaunchOptionValueSystemPromptFile(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "system_prompt_file", Kind: "path"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{SystemPromptFile: "/path/to/file"})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{SystemPromptFile: "/path/to/file"}, appwire.LaunchConfigLayer{})
 	if val != "/path/to/file" {
 		t.Fatalf("system_prompt_file = %q, want /path/to/file", val)
 	}
@@ -122,7 +122,7 @@ func TestCovLaunchOptionValueSystemPromptFile(t *testing.T) {
 
 func TestCovLaunchOptionValueSystemPromptText(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "system_prompt_text", Kind: "text"}
-	val, editVal := launchOptionValue(opt, appwire.LaunchConfigLayer{SystemPromptText: "hello\nworld"})
+	val, editVal := launchOptionValue(opt, appwire.LaunchConfigLayer{SystemPromptText: "hello\nworld"}, appwire.LaunchConfigLayer{})
 	if val != "11 chars, 2 lines" || editVal != "hello\nworld" {
 		t.Fatalf("system_prompt_text = %q/%q, want exact summary and edit text", val, editVal)
 	}
@@ -130,7 +130,7 @@ func TestCovLaunchOptionValueSystemPromptText(t *testing.T) {
 
 func TestCovLaunchOptionValueSystemPromptAppendMode(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "system_prompt_append_mode", Kind: "select"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{SystemPromptAppendMode: "append"})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{SystemPromptAppendMode: "append"}, appwire.LaunchConfigLayer{})
 	if val != "append" {
 		t.Fatalf("system_prompt_append_mode = %q, want append", val)
 	}
@@ -138,7 +138,7 @@ func TestCovLaunchOptionValueSystemPromptAppendMode(t *testing.T) {
 
 func TestCovLaunchOptionValueSystemPromptAppendFile(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "system_prompt_append_file", Kind: "path"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{SystemPromptAppendFile: "/append"})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{SystemPromptAppendFile: "/append"}, appwire.LaunchConfigLayer{})
 	if val != "/append" {
 		t.Fatalf("system_prompt_append_file = %q, want /append", val)
 	}
@@ -146,7 +146,7 @@ func TestCovLaunchOptionValueSystemPromptAppendFile(t *testing.T) {
 
 func TestCovLaunchOptionValueSystemPromptAppendText(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "system_prompt_append_text", Kind: "text"}
-	val, editVal := launchOptionValue(opt, appwire.LaunchConfigLayer{SystemPromptAppendText: "append"})
+	val, editVal := launchOptionValue(opt, appwire.LaunchConfigLayer{SystemPromptAppendText: "append"}, appwire.LaunchConfigLayer{})
 	if val != "6 chars, 1 lines" || editVal != "append" {
 		t.Fatalf("system_prompt_append_text = %q/%q, want exact summary and edit text", val, editVal)
 	}
@@ -154,7 +154,7 @@ func TestCovLaunchOptionValueSystemPromptAppendText(t *testing.T) {
 
 func TestCovLaunchOptionValueSkillsDirs(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "skills_dirs", Kind: "pathList"}
-	val, editVal := launchOptionValue(opt, appwire.LaunchConfigLayer{SkillsDirs: []string{"/a", "/b"}})
+	val, editVal := launchOptionValue(opt, appwire.LaunchConfigLayer{SkillsDirs: []string{"/a", "/b"}}, appwire.LaunchConfigLayer{})
 	if val != "2 entries" || editVal != "/a, /b" {
 		t.Fatalf("skills_dirs = %q/%q", val, editVal)
 	}
@@ -162,7 +162,7 @@ func TestCovLaunchOptionValueSkillsDirs(t *testing.T) {
 
 func TestCovLaunchOptionValuePluginDirs(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "plugin_dirs", Kind: "pathList"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{PluginDirs: []string{"/p"}})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{PluginDirs: []string{"/p"}}, appwire.LaunchConfigLayer{})
 	if val != "1 entries" {
 		t.Fatalf("plugin_dirs = %q, want 1 entries", val)
 	}
@@ -170,7 +170,7 @@ func TestCovLaunchOptionValuePluginDirs(t *testing.T) {
 
 func TestCovLaunchOptionValueMCPConfigs(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "mcp_configs", Kind: "pathList"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{MCPConfigs: []string{"/c"}})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{MCPConfigs: []string{"/c"}}, appwire.LaunchConfigLayer{})
 	if val != "1 entries" {
 		t.Fatalf("mcp_configs = %q, want 1 entries", val)
 	}
@@ -178,7 +178,7 @@ func TestCovLaunchOptionValueMCPConfigs(t *testing.T) {
 
 func TestCovLaunchOptionValueMCPServers(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "mcps", Kind: "mcpServerList"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{MCPs: []appwire.MCPServerSpec{{Name: "x", Command: "c"}}})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{MCPs: []appwire.MCPServerSpec{{Name: "x", Command: "c"}}}, appwire.LaunchConfigLayer{})
 	if val != "1 entries" {
 		t.Fatalf("mcps = %q, want 1 entries", val)
 	}
@@ -186,7 +186,7 @@ func TestCovLaunchOptionValueMCPServers(t *testing.T) {
 
 func TestCovLaunchOptionValueEnv(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "env", Kind: "envMap"}
-	val, editVal := launchOptionValue(opt, appwire.LaunchConfigLayer{Env: map[string]string{"KEY": "val"}})
+	val, editVal := launchOptionValue(opt, appwire.LaunchConfigLayer{Env: map[string]string{"KEY": "val"}}, appwire.LaunchConfigLayer{})
 	if val != "1 entries" || editVal != "KEY=val" {
 		t.Fatalf("env = %q/%q", val, editVal)
 	}
@@ -194,7 +194,7 @@ func TestCovLaunchOptionValueEnv(t *testing.T) {
 
 func TestCovLaunchOptionValueVerbose(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "verbose", Kind: "boolean"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{}, appwire.LaunchConfigLayer{})
 	if val != "(default)" {
 		t.Fatalf("nil verbose = %q, want (default)", val)
 	}
@@ -202,7 +202,7 @@ func TestCovLaunchOptionValueVerbose(t *testing.T) {
 
 func TestCovLaunchOptionValueTraceFile(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "trace_file", Kind: "path"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{TraceFile: "/trace"})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{TraceFile: "/trace"}, appwire.LaunchConfigLayer{})
 	if val != "/trace" {
 		t.Fatalf("trace_file = %q, want /trace", val)
 	}
@@ -210,7 +210,7 @@ func TestCovLaunchOptionValueTraceFile(t *testing.T) {
 
 func TestCovLaunchOptionValueCPUProfile(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "cpu_profile", Kind: "path"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{CPUProfile: "/cpu"})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{CPUProfile: "/cpu"}, appwire.LaunchConfigLayer{})
 	if val != "/cpu" {
 		t.Fatalf("cpu_profile = %q, want /cpu", val)
 	}
@@ -218,7 +218,7 @@ func TestCovLaunchOptionValueCPUProfile(t *testing.T) {
 
 func TestCovLaunchOptionValueExportATIFPath(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "export_atif_path", Kind: "path"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{ExportATIFPath: "/atif"})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{ExportATIFPath: "/atif"}, appwire.LaunchConfigLayer{})
 	if val != "/atif" {
 		t.Fatalf("export_atif_path = %q, want /atif", val)
 	}
@@ -226,7 +226,7 @@ func TestCovLaunchOptionValueExportATIFPath(t *testing.T) {
 
 func TestCovLaunchOptionValueExportATIFProviderHandles(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "export_atif_provider_handles", Kind: "select"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{ExportATIFProviderHandles: "raw"})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{ExportATIFProviderHandles: "raw"}, appwire.LaunchConfigLayer{})
 	if val != "raw" {
 		t.Fatalf("export_atif_provider_handles = %q, want raw", val)
 	}
@@ -234,7 +234,7 @@ func TestCovLaunchOptionValueExportATIFProviderHandles(t *testing.T) {
 
 func TestCovLaunchOptionValueSandboxNet(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "sandbox_net", Kind: "boolean"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{}, appwire.LaunchConfigLayer{})
 	if val != "(default)" {
 		t.Fatalf("nil sandbox_net = %q, want (default)", val)
 	}
@@ -242,7 +242,7 @@ func TestCovLaunchOptionValueSandboxNet(t *testing.T) {
 
 func TestCovLaunchOptionValueMaxRounds(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "max_rounds", Kind: "integer"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{}, appwire.LaunchConfigLayer{})
 	if val != "(default)" {
 		t.Fatalf("nil max_rounds = %q, want (default)", val)
 	}
@@ -250,7 +250,7 @@ func TestCovLaunchOptionValueMaxRounds(t *testing.T) {
 
 func TestCovLaunchOptionValueAppReplaySize(t *testing.T) {
 	opt := appwire.LaunchOption{Field: "app_replay_size", Kind: "integer"}
-	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{})
+	val, _ := launchOptionValue(opt, appwire.LaunchConfigLayer{}, appwire.LaunchConfigLayer{})
 	if val != "(default)" {
 		t.Fatalf("nil app_replay_size = %q, want (default)", val)
 	}

--- a/cmd/evener-tui/internal/launchconfig/launch_schema_test.go
+++ b/cmd/evener-tui/internal/launchconfig/launch_schema_test.go
@@ -11,7 +11,7 @@ func TestSchemaRows_SettingsFiltersDefaultableLayerAndKeepsOrder(t *testing.T) {
 	schema := testLaunchSchema()
 
 	// Layer "project": app_replay_size is excluded because it is only defaultable in "global".
-	rows := launchSchemaRows(schema, appwire.LaunchConfigLayer{Agent: "evener", ReasoningEffort: "high", FastCheapModel: "mini"}, launchLayerProject, launchSchemaRowsSettings)
+	rows := launchSchemaRows(schema, appwire.LaunchConfigLayer{Agent: "evener", ReasoningEffort: "high", FastCheapModel: "mini"}, launchLayerProject, launchSchemaRowsSettings, appwire.LaunchConfigLayer{})
 	fields := rowFields(rows)
 	want := []string{"agent", "model", "reasoning_effort", "fast_cheap_model", "openai_responses_continuation", "system_prompt_file", "mcps", "verbose", "export_atif_provider_handles"}
 	if !reflect.DeepEqual(fields, want) {
@@ -21,7 +21,7 @@ func TestSchemaRows_SettingsFiltersDefaultableLayerAndKeepsOrder(t *testing.T) {
 	// Layer "global": app_replay_size IS included because it is defaultable in "global" but
 	// PerLaunch=false. This diverges from override mode (which filters by PerLaunch): settings
 	// mode must use DefaultableLayers, not PerLaunch, to include this field.
-	rows = launchSchemaRows(schema, appwire.LaunchConfigLayer{}, launchLayerGlobal, launchSchemaRowsSettings)
+	rows = launchSchemaRows(schema, appwire.LaunchConfigLayer{}, launchLayerGlobal, launchSchemaRowsSettings, appwire.LaunchConfigLayer{})
 	fields = rowFields(rows)
 	wantGlobal := []string{"agent", "model", "reasoning_effort", "fast_cheap_model", "openai_responses_continuation", "app_replay_size", "system_prompt_file", "mcps", "verbose", "export_atif_provider_handles"}
 	if !reflect.DeepEqual(fields, wantGlobal) {
@@ -31,7 +31,7 @@ func TestSchemaRows_SettingsFiltersDefaultableLayerAndKeepsOrder(t *testing.T) {
 
 func TestSchemaRows_OverrideFiltersPerLaunch(t *testing.T) {
 	schema := testLaunchSchema()
-	rows := launchSchemaRows(schema, appwire.LaunchConfigLayer{}, launchLayerLaunch, launchSchemaRowsOverride)
+	rows := launchSchemaRows(schema, appwire.LaunchConfigLayer{}, launchLayerLaunch, launchSchemaRowsOverride, appwire.LaunchConfigLayer{})
 	fields := rowFields(rows)
 	want := []string{"agent", "model", "reasoning_effort", "fast_cheap_model", "openai_responses_continuation", "system_prompt_file", "mcps", "verbose", "export_atif_provider_handles"}
 	if !reflect.DeepEqual(fields, want) {
@@ -53,7 +53,7 @@ func TestSchemaRows_PathFieldsRequestCompletion(t *testing.T) {
 	schema := []appwire.LaunchOption{
 		{Field: "system_prompt_file", Label: "System prompt file", Kind: "path", PathKind: "file", DefaultableLayers: []string{"global"}, PerLaunch: true},
 	}
-	rows := launchSchemaRows(schema, appwire.LaunchConfigLayer{}, launchLayerGlobal, launchSchemaRowsSettings)
+	rows := launchSchemaRows(schema, appwire.LaunchConfigLayer{}, launchLayerGlobal, launchSchemaRowsSettings, appwire.LaunchConfigLayer{})
 	if len(rows) != 1 || !rows[0].pathCompletion {
 		t.Fatalf("rows=%+v, want path completion", rows)
 	}
@@ -63,11 +63,11 @@ func TestSchemaRows_ModelFallbacksDistinguishesUnsetAndExplicitEmpty(t *testing.
 	schema := []appwire.LaunchOption{
 		{Field: "model_fallbacks", Label: "Model fallbacks", Kind: "modelList", DefaultableLayers: []string{"global"}, PerLaunch: true},
 	}
-	rows := launchSchemaRows(schema, appwire.LaunchConfigLayer{}, launchLayerGlobal, launchSchemaRowsSettings)
+	rows := launchSchemaRows(schema, appwire.LaunchConfigLayer{}, launchLayerGlobal, launchSchemaRowsSettings, appwire.LaunchConfigLayer{})
 	if len(rows) != 1 || rows[0].value != "(default)" || rows[0].editValue != "(default)" {
 		t.Fatalf("nil model_fallbacks row=%+v, want default", rows)
 	}
-	rows = launchSchemaRows(schema, appwire.LaunchConfigLayer{ModelFallbacks: []string{}}, launchLayerGlobal, launchSchemaRowsSettings)
+	rows = launchSchemaRows(schema, appwire.LaunchConfigLayer{ModelFallbacks: []string{}}, launchLayerGlobal, launchSchemaRowsSettings, appwire.LaunchConfigLayer{})
 	if len(rows) != 1 || rows[0].value != "0 entries (explicit)" || rows[0].editValue != "[]" {
 		t.Fatalf("empty model_fallbacks row=%+v, want explicit empty", rows)
 	}
@@ -80,7 +80,7 @@ func TestSchemaRows_MCPsExposeEditableRows(t *testing.T) {
 	rows := launchSchemaRows(schema, appwire.LaunchConfigLayer{MCPs: []appwire.MCPServerSpec{
 		{Name: "docs", Command: "sh", Args: []string{"-c", "docs"}},
 		{Name: "files", Command: "/bin/sh"},
-	}}, launchLayerGlobal, launchSchemaRowsSettings)
+	}}, launchLayerGlobal, launchSchemaRowsSettings, appwire.LaunchConfigLayer{})
 	if len(rows) != 1 {
 		t.Fatalf("rows=%+v, want one mcps row", rows)
 	}
@@ -96,7 +96,7 @@ func TestSchemaRows_OpenAIResponsesContinuationUsesStringDisplay(t *testing.T) {
 	schema := []appwire.LaunchOption{
 		{Field: "openai_responses_continuation", Label: "OpenAI Responses continuation", Kind: "select", DefaultableLayers: []string{"global"}, PerLaunch: true},
 	}
-	rows := launchSchemaRows(schema, appwire.LaunchConfigLayer{OpenAIResponsesContinuation: "auto"}, launchLayerGlobal, launchSchemaRowsSettings)
+	rows := launchSchemaRows(schema, appwire.LaunchConfigLayer{OpenAIResponsesContinuation: "auto"}, launchLayerGlobal, launchSchemaRowsSettings, appwire.LaunchConfigLayer{})
 	if len(rows) != 1 {
 		t.Fatalf("rows=%+v, want one openai_responses_continuation row", rows)
 	}
@@ -109,7 +109,7 @@ func TestSchemaRows_ExportATIFProviderHandlesUsesStringDisplay(t *testing.T) {
 	schema := []appwire.LaunchOption{
 		{Field: "export_atif_provider_handles", Label: "ATIF provider handles", Kind: "select", DefaultableLayers: []string{"global"}, PerLaunch: true},
 	}
-	rows := launchSchemaRows(schema, appwire.LaunchConfigLayer{ExportATIFProviderHandles: "raw-local"}, launchLayerGlobal, launchSchemaRowsSettings)
+	rows := launchSchemaRows(schema, appwire.LaunchConfigLayer{ExportATIFProviderHandles: "raw-local"}, launchLayerGlobal, launchSchemaRowsSettings, appwire.LaunchConfigLayer{})
 	if len(rows) != 1 {
 		t.Fatalf("rows=%+v, want one export_atif_provider_handles row", rows)
 	}
@@ -124,6 +124,75 @@ func rowFields(rows []layerRow) []string {
 		fields = append(fields, row.field)
 	}
 	return fields
+}
+
+// TestLaunchOptionValue_ResolvedDefaultLabels: a field unset in the displayed
+// layer but set in the resolved effective layer renders the resolved value
+// with a " (default)" suffix, formatted exactly like a set value. The edit
+// value keeps the unset placeholder so editing still starts blank.
+func TestLaunchOptionValue_ResolvedDefaultLabels(t *testing.T) {
+	tru := true
+	twoHundred := 200
+	effective := appwire.LaunchConfigLayer{
+		Model:            "anthropic/claude-sonnet-4",
+		ReasoningEffort:  "high",
+		MaxRounds:        &twoHundred,
+		Verbose:          &tru,
+		SystemPromptText: "hello\nworld",
+		ModelFallbacks:   []string{"openai/gpt-5-mini", "openai/gpt-5-nano"},
+	}
+	tests := []struct {
+		field         string
+		wantValue     string
+		wantEditValue string
+	}{
+		{"model", "anthropic/claude-sonnet-4 (default)", ""},
+		{"reasoning_effort", "high (default)", ""},
+		{"max_rounds", "200 (default)", "(default)"},
+		{"verbose", "true (default)", "(default)"},
+		{"system_prompt_text", "11 chars, 2 lines (default)", ""},
+		{"model_fallbacks", "2 entries (default)", "(default)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.field, func(t *testing.T) {
+			value, editValue := launchOptionValue(appwire.LaunchOption{Field: tc.field}, appwire.LaunchConfigLayer{}, effective)
+			if value != tc.wantValue {
+				t.Errorf("value = %q, want %q", value, tc.wantValue)
+			}
+			if editValue != tc.wantEditValue {
+				t.Errorf("editValue = %q, want %q", editValue, tc.wantEditValue)
+			}
+		})
+	}
+}
+
+// TestLaunchOptionValue_ResolvedDefaultOnlyWhenUnset: a value set in the
+// displayed layer always wins over the resolved default; a field unset in
+// both layers keeps the bare "(default)" label; a field whose unset display
+// is not "(default)" (entry-count lists) never gains the suffix.
+func TestLaunchOptionValue_ResolvedDefaultOnlyWhenUnset(t *testing.T) {
+	effective := appwire.LaunchConfigLayer{Model: "resolved/model", SkillsDirs: []string{"/a", "/b"}}
+	if v, _ := launchOptionValue(appwire.LaunchOption{Field: "model"}, appwire.LaunchConfigLayer{Model: "set/model"}, effective); v != "set/model" {
+		t.Fatalf("set value = %q, want set/model", v)
+	}
+	if v, _ := launchOptionValue(appwire.LaunchOption{Field: "model"}, appwire.LaunchConfigLayer{}, appwire.LaunchConfigLayer{}); v != "(default)" {
+		t.Fatalf("unset-everywhere value = %q, want (default)", v)
+	}
+	if v, _ := launchOptionValue(appwire.LaunchOption{Field: "skills_dirs"}, appwire.LaunchConfigLayer{}, effective); v != "0 entries" {
+		t.Fatalf("skills_dirs = %q, want 0 entries (no resolved-default suffix)", v)
+	}
+}
+
+// TestSchemaRows_ResolvedDefaultFlowsThrough: launchSchemaRows threads the
+// resolved effective layer into each row's display value.
+func TestSchemaRows_ResolvedDefaultFlowsThrough(t *testing.T) {
+	schema := []appwire.LaunchOption{
+		{Field: "reasoning_effort", Label: "Reasoning effort", Kind: "select", DefaultableLayers: []string{"global"}, PerLaunch: true},
+	}
+	rows := launchSchemaRows(schema, appwire.LaunchConfigLayer{}, launchLayerGlobal, launchSchemaRowsSettings, appwire.LaunchConfigLayer{ReasoningEffort: "high"})
+	if len(rows) != 1 || rows[0].value != "high (default)" {
+		t.Fatalf("rows=%+v, want resolved default label", rows)
+	}
 }
 
 func testLaunchSchema() []appwire.LaunchOption {

--- a/cmd/evener-tui/internal/launchconfig/launch_schema_test.go
+++ b/cmd/evener-tui/internal/launchconfig/launch_schema_test.go
@@ -43,7 +43,7 @@ func TestSchemaRows_ExcludesDedicatedPluginSelection(t *testing.T) {
 	rows := launchSchemaRows([]appwire.LaunchOption{
 		{Field: "agent", Label: "Agent", DefaultableLayers: []string{"global"}, PerLaunch: true},
 		{Field: "enabled_plugins", Label: "Plugins", Kind: "pluginSelection", DefaultableLayers: []string{"global"}, PerLaunch: true},
-	}, appwire.LaunchConfigLayer{}, launchLayerLaunch, launchSchemaRowsOverride)
+	}, appwire.LaunchConfigLayer{}, launchLayerLaunch, launchSchemaRowsOverride, appwire.LaunchConfigLayer{})
 	if fields := rowFields(rows); !reflect.DeepEqual(fields, []string{"agent"}) {
 		t.Fatalf("fields=%v, want only generic agent row", fields)
 	}

--- a/cmd/evener-tui/internal/launchconfig/launch_settings_panel.go
+++ b/cmd/evener-tui/internal/launchconfig/launch_settings_panel.go
@@ -226,12 +226,12 @@ type layerRow struct {
 
 func (p LaunchSettingsPanel) rowsForLayer(layerName string, l appwire.LaunchConfigLayer) []layerRow {
 	if len(p.schema) > 0 {
-		return launchSchemaRows(p.schema, l, layerName, launchSchemaRowsSettings)
+		return launchSchemaRows(p.schema, l, layerName, launchSchemaRowsSettings, p.resolved.Effective)
 	}
-	return layerRows(l)
+	return layerRows(l, p.resolved.Effective)
 }
 
-func layerRows(l appwire.LaunchConfigLayer) []layerRow {
+func layerRows(l, effective appwire.LaunchConfigLayer) []layerRow {
 	ptrIntStr := func(p *int) string {
 		if p == nil {
 			return "(default)"
@@ -247,6 +247,30 @@ func layerRows(l appwire.LaunchConfigLayer) []layerRow {
 		}
 		return "false"
 	}
+	// resolvedPtrIntStr/resolvedPtrBoolStr render a nil pointer as the
+	// resolved effective value with a " (default)" suffix, keeping the bare
+	// "(default)" label when the effective layer leaves the field unset too.
+	resolvedPtrIntStr := func(p, eff *int) string {
+		if p != nil {
+			return strconv.Itoa(*p)
+		}
+		if r := ptrIntStr(eff); r != "(default)" {
+			return r + " (default)"
+		}
+		return "(default)"
+	}
+	resolvedPtrBoolStr := func(p, eff *bool) string {
+		if p != nil {
+			if *p {
+				return "true"
+			}
+			return "false"
+		}
+		if r := ptrBoolStr(eff); r != "(default)" {
+			return r + " (default)"
+		}
+		return "(default)"
+	}
 	return []layerRow{
 		{"model", "model", l.Model, l.Model, false},
 		{"fast_cheap_model", "fast_cheap_model", l.FastCheapModel, l.FastCheapModel, false},
@@ -254,11 +278,11 @@ func layerRows(l appwire.LaunchConfigLayer) []layerRow {
 		{"reasoning_effort", "reasoning_effort", l.ReasoningEffort, l.ReasoningEffort, false},
 		{"context_strategy", "context_strategy", l.ContextStrategy, l.ContextStrategy, false},
 		{"openai_responses_continuation", "openai_responses_continuation", l.OpenAIResponsesContinuation, l.OpenAIResponsesContinuation, false},
-		{"max_rounds", "max_rounds", ptrIntStr(l.MaxRounds), ptrIntStr(l.MaxRounds), false},
-		{"max_subagent_depth", "max_subagent_depth", ptrIntStr(l.MaxSubagentDepth), ptrIntStr(l.MaxSubagentDepth), false},
-		{"max_concurrent_delegate_turns", "max_concurrent_delegate_turns", ptrIntStr(l.MaxConcurrentDelegateTurns), ptrIntStr(l.MaxConcurrentDelegateTurns), false},
-		{"max_retained_terminal", "max_retained_terminal", ptrIntStr(l.MaxRetainedTerminal), ptrIntStr(l.MaxRetainedTerminal), false},
-		{"no_project_prompts", "no_project_prompts", ptrBoolStr(l.NoProjectPrompts), ptrBoolStr(l.NoProjectPrompts), false},
+		{"max_rounds", "max_rounds", resolvedPtrIntStr(l.MaxRounds, effective.MaxRounds), ptrIntStr(l.MaxRounds), false},
+		{"max_subagent_depth", "max_subagent_depth", resolvedPtrIntStr(l.MaxSubagentDepth, effective.MaxSubagentDepth), ptrIntStr(l.MaxSubagentDepth), false},
+		{"max_concurrent_delegate_turns", "max_concurrent_delegate_turns", resolvedPtrIntStr(l.MaxConcurrentDelegateTurns, effective.MaxConcurrentDelegateTurns), ptrIntStr(l.MaxConcurrentDelegateTurns), false},
+		{"max_retained_terminal", "max_retained_terminal", resolvedPtrIntStr(l.MaxRetainedTerminal, effective.MaxRetainedTerminal), ptrIntStr(l.MaxRetainedTerminal), false},
+		{"no_project_prompts", "no_project_prompts", resolvedPtrBoolStr(l.NoProjectPrompts, effective.NoProjectPrompts), ptrBoolStr(l.NoProjectPrompts), false},
 		{"skills_dirs", "skills_dirs", fmt.Sprintf("%d entries", len(l.SkillsDirs)), strings.Join(l.SkillsDirs, ", "), true},
 		{"plugin_dirs", "plugin_dirs", fmt.Sprintf("%d entries", len(l.PluginDirs)), strings.Join(l.PluginDirs, ", "), true},
 		{"mcp_configs", "mcp_configs", fmt.Sprintf("%d entries", len(l.MCPConfigs)), strings.Join(l.MCPConfigs, ", "), true},

--- a/cmd/evener-tui/internal/launchconfig/launch_settings_panel_covtest_test.go
+++ b/cmd/evener-tui/internal/launchconfig/launch_settings_panel_covtest_test.go
@@ -699,7 +699,7 @@ func TestCovValidateLocalLaunchPathOutputFileParentMissing(t *testing.T) {
 // --- layerRows ---
 
 func TestCovLayerRowsWithNilPointers(t *testing.T) {
-	rows := layerRows(appwire.LaunchConfigLayer{})
+	rows := layerRows(appwire.LaunchConfigLayer{}, appwire.LaunchConfigLayer{})
 	byField := make(map[string]layerRow, len(rows))
 	for _, row := range rows {
 		byField[row.field] = row
@@ -719,7 +719,7 @@ func TestCovLayerRowsWithNilPointers(t *testing.T) {
 func TestCovLayerRowsWithSetPointers(t *testing.T) {
 	n := 5
 	b := true
-	rows := layerRows(appwire.LaunchConfigLayer{MaxRounds: &n, NoProjectPrompts: &b})
+	rows := layerRows(appwire.LaunchConfigLayer{MaxRounds: &n, NoProjectPrompts: &b}, appwire.LaunchConfigLayer{})
 	byField := make(map[string]layerRow, len(rows))
 	for _, row := range rows {
 		byField[row.field] = row

--- a/cmd/evener-tui/internal/launchconfig/launch_settings_panel_test.go
+++ b/cmd/evener-tui/internal/launchconfig/launch_settings_panel_test.go
@@ -114,7 +114,7 @@ func TestLaunchSettingsPanel_ProjectSchemaRowsExcludeGlobalOnly(t *testing.T) {
 }
 
 func TestLayerRows_IncludesFastCheapModel(t *testing.T) {
-	rows := layerRows(appwire.LaunchConfigLayer{FastCheapModel: "openai/gpt-5-mini"})
+	rows := layerRows(appwire.LaunchConfigLayer{FastCheapModel: "openai/gpt-5-mini"}, appwire.LaunchConfigLayer{})
 	for _, row := range rows {
 		if row.field == "fast_cheap_model" {
 			if row.value != "openai/gpt-5-mini" {
@@ -133,6 +133,50 @@ func TestApplyEdit_FastCheapModel(t *testing.T) {
 	}
 	if got.FastCheapModel != "openai/gpt-5-mini" {
 		t.Fatalf("FastCheapModel = %q, want openai/gpt-5-mini", got.FastCheapModel)
+	}
+}
+
+// TestLayerRows_ResolvedDefaultLabels: the non-schema fallback rows render a
+// nil pointer field as the resolved effective value with a " (default)"
+// suffix, while the edit value keeps the unset "(default)" placeholder.
+func TestLayerRows_ResolvedDefaultLabels(t *testing.T) {
+	twoHundred := 200
+	tru := true
+	rows := layerRows(appwire.LaunchConfigLayer{}, appwire.LaunchConfigLayer{MaxRounds: &twoHundred, NoProjectPrompts: &tru})
+	byField := make(map[string]layerRow, len(rows))
+	for _, row := range rows {
+		byField[row.field] = row
+	}
+	if row := byField["max_rounds"]; row.value != "200 (default)" || row.editValue != "(default)" {
+		t.Errorf("max_rounds = value %q editValue %q, want 200 (default)/(default)", row.value, row.editValue)
+	}
+	if row := byField["no_project_prompts"]; row.value != "true (default)" || row.editValue != "(default)" {
+		t.Errorf("no_project_prompts = value %q editValue %q, want true (default)/(default)", row.value, row.editValue)
+	}
+	if row := byField["max_subagent_depth"]; row.value != "(default)" {
+		t.Errorf("max_subagent_depth (unset everywhere) = %q, want (default)", row.value)
+	}
+}
+
+// TestLaunchSettingsPanel_ResolvedDefaultLabels: once a resolve lands, an
+// unset field renders the resolved effective value with the "(default)"
+// suffix; before any resolve, the label stays bare "(default)".
+func TestLaunchSettingsPanel_ResolvedDefaultLabels(t *testing.T) {
+	p := NewLaunchSettingsPanel(nil, "/cwd")
+	updated, _ := p.Update(LaunchSchemaResultMsg{Schema: appwire.LaunchOptionSchemaResponse{Options: []appwire.LaunchOption{
+		{Field: "reasoning_effort", Label: "Reasoning effort", Kind: "select", DefaultableLayers: []string{"global"}},
+	}}})
+	p = updated.(LaunchSettingsPanel)
+	updated, _ = p.Update(LaunchLayerResultMsg{Layer: "global", Data: appwire.LaunchConfigLayer{}})
+	p = updated.(LaunchSettingsPanel)
+	if v := p.View(); strings.Contains(v, "high (default)") {
+		t.Fatalf("pre-resolve view should not show a resolved label:\n%s", v)
+	}
+	updated, _ = p.Update(LaunchResolveResultMsg{Resolved: appwire.LaunchConfigResolved{
+		Effective: appwire.LaunchConfigLayer{ReasoningEffort: "high"},
+	}})
+	if v := updated.(LaunchSettingsPanel).View(); !strings.Contains(v, "high (default)") {
+		t.Fatalf("view should render the resolved default label:\n%s", v)
 	}
 }
 
@@ -188,7 +232,7 @@ func TestApplyEdit_SandboxValidatesMode(t *testing.T) {
 }
 
 func TestLayerRows_ListFieldsExposeEditableValues(t *testing.T) {
-	rows := layerRows(appwire.LaunchConfigLayer{SkillsDirs: []string{"/one", "/two"}})
+	rows := layerRows(appwire.LaunchConfigLayer{SkillsDirs: []string{"/one", "/two"}}, appwire.LaunchConfigLayer{})
 	for _, row := range rows {
 		if row.field == "skills_dirs" {
 			if row.value != "2 entries" {


### PR DESCRIPTION
## Summary

Every launch-config surface that rendered a plain `(default)` marker for unset fields now shows the **resolved value** a session would actually inherit: `high (default)`, `On (default)`, `250 (default)`, `openai/gpt-5 (default)`. Collection fields that showed `None.` despite inheriting entries now render grayed, non-removable `(default)`-tagged ghost rows.

## What changed

### Resolved-default labels (scalar fields)
- **Spawn pane** (`Spawn.tsx`, `AdvancedOptions.tsx`, `MobileSettingRows.tsx`): model field, effort select, access mode, and all advanced options (boolean, select, modelPicker, integer, text, path) prepend the resolved effective value to their `(default)` marker.
- **Settings** (`fields.tsx`, `schema.ts`, `LaunchConfigForm.tsx`, `project.tsx`, `launchServer.tsx`): same pattern for both global and project layers, with the project layer's `(use global default)` wording preserved.
- **TUI** (`launch_schema.go`, `launch_settings_panel.go`, `launch_overrides_modal.go`, `hub_update_config.go`): the settings panel and the ctrl+L overrides modal both show `<value> (default)`; the modal now receives the resolved effective layer via a resolve RPC on open.

### Collection ghost rows
- **Spawn pane** (`AdvancedOptions.tsx`): all four collection kinds (Model fallbacks, Skill/Plugin dirs, MCP config files, Env vars, MCP servers) compute inherited entries as effective-minus-local and pass them to `CollectionEditor`'s new `inheritedItems` prop.
- **Settings** (`collectionFields.tsx`, `LaunchConfigForm.tsx`): same ghost-row pattern threaded through all four collection field components.
- **`CollectionEditor` widget** (`index.tsx`, `collectioneditor.module.css`): new `inheritedItems` prop renders grayed, dashed, non-removable rows tagged `(default)` below the caller's own rows; `emptyMessage` only shows when both lists are empty.

### Simplify pass
- Extracted `inheritedItems<T>` + shape adapters to shared `launchShared/inherited.ts` (deduplicated from per-call-site copies).
- Parallelized `resolve()` with `schema()`/`getLayer()` in `project.tsx` and `launchServer.tsx` (one fewer round-trip to resolved labels).
- Replaced nested ternary in `schema.ts` with if/else-if.

## Merge semantics
Each collection kind computes ghost rows as effective-minus-local, which matches its merge rule because the resolve RPC's effective layer already contains the local overrides:
- **pathList / mcpServerList** (append): inherited entries show alongside local adds.
- **envMap** (per-key): inherited keys show unless overridden locally.
- **modelList** (replace): ghost auto-disappears once any local entry exists.

## Test plan
- `make test-web` (typecheck + vitest + biome): PASS
- `go test ./cmd/evener-tui/...`: PASS
- `make vet`: PASS
- 121/121 tests pass across all affected suites
- Live-verified in browser: spawn pane ghost rows (Skill dirs, Model fallbacks, Env vars) and scalar placeholders (Agent, Max rounds, Max subagent depth)

## Commits
1. `ea821c9dd` feat(tui): show resolved default in launch-config "(default)" labels
2. `af8932c48` feat(web): show resolved default in launch-config "(default)" labels
3. `b029d038c` feat(web): name the resolved sandbox in the Access mode "(default)" label
4. `0d2cbd988` feat(web): show resolved default as placeholder in scalar advanced options
5. `ac13c13f4` feat(web): ghost inherited entries in advanced collection controls
6. `5b0f19a14` feat(web): ghost inherited entries in Settings launch-config collections
7. `d7ccdcb8a` refactor(web): deduplicate inherited-items and parallelize resolve