### PR TITLE
Cleanup plugins-for-this-session UI and preview robustness

### DIFF
--- a/cmd/evener-hub/app_plugin_preview_test.go
+++ b/cmd/evener-hub/app_plugin_preview_test.go
@@ -28,6 +28,56 @@ func TestPluginPreviewControllerMapsCandidates(t *testing.T) {
 	}
 }
 
+// Before a launch directory is chosen there is no project context, but the
+// user-level inventory (global layer) already exists — the spawn pane previews
+// with an empty cwd on mount and must not fail for it.
+func TestPluginPreviewEmptyCWDResolvesUserLayers(t *testing.T) {
+	firstDir := t.TempDir()
+	writePreviewFixturePlugin(t, firstDir, "global-fixture", filepath.Join(t.TempDir(), "marker"))
+	secondDir := t.TempDir()
+	writePreviewFixturePlugin(t, secondDir, "other-fixture", filepath.Join(t.TempDir(), "marker"))
+	launchRoot := t.TempDir()
+	globalLayer := "plugin_dirs = [\"" + firstDir + "\", \"" + secondDir + "\"]\n"
+	if err := os.WriteFile(filepath.Join(launchRoot, "launch.toml"), []byte(globalLayer), 0o644); err != nil {
+		t.Fatalf("write global layer: %v", err)
+	}
+	ctl := newHubPluginsController(t.TempDir(), launchRoot)
+
+	// With no per-launch selection every loadable candidate is selected — the
+	// same default a picked directory with no overrides would give.
+	for _, cwd := range []string{"", "   "} {
+		preview, err := ctl.Preview(context.Background(), appwire.PluginPreviewParams{CWD: cwd})
+		if err != nil {
+			t.Fatalf("Preview for cwd %q: %v", cwd, err)
+		}
+		if len(preview.Plugins) != 2 {
+			t.Fatalf("Preview for cwd %q plugins = %+v, want both global directory candidates", cwd, preview.Plugins)
+		}
+		for _, candidate := range preview.Plugins {
+			if !candidate.Selected {
+				t.Fatalf("Preview for cwd %q candidate not selected by default: %+v", cwd, candidate)
+			}
+		}
+	}
+
+	// Per-launch overrides merge without a directory, too.
+	override := []string{"other-fixture"}
+	preview, err := ctl.Preview(context.Background(), appwire.PluginPreviewParams{
+		CWD:             "",
+		LaunchOverrides: &appwire.LaunchConfigLayer{EnabledPlugins: &override},
+	})
+	if err != nil {
+		t.Fatalf("Preview with overrides for empty cwd: %v", err)
+	}
+	byName := make(map[string]appwire.PluginLaunchCandidate, len(preview.Plugins))
+	for _, candidate := range preview.Plugins {
+		byName[candidate.Name] = candidate
+	}
+	if byName["global-fixture"].Selected || !byName["other-fixture"].Selected {
+		t.Fatalf("Preview with overrides selection = %+v, want only other-fixture selected", preview.Plugins)
+	}
+}
+
 func TestPluginPreviewMissingCWDMatchesStartAfterCreation(t *testing.T) {
 	pluginDir := t.TempDir()
 	writePreviewFixturePlugin(t, pluginDir, "preview-fixture", filepath.Join(t.TempDir(), "marker"))

--- a/cmd/evener-hub/app_plugins.go
+++ b/cmd/evener-hub/app_plugins.go
@@ -55,18 +55,32 @@ func newHubPluginsController(root string, launchConfigRoots ...string) *hubPlugi
 // session state are never touched.
 func (c *hubPluginsController) Preview(ctx context.Context, params appwire.PluginPreviewParams) (appwire.PluginPreviewResponse, error) {
 	_ = ctx // retained in the controller API for parity with other RPC reads
-	cwd, project, cleanup, err := pluginPreviewCWD(params.CWD)
-	if err != nil {
-		return appwire.PluginPreviewResponse{}, err
-	}
-	defer cleanup()
 	var overrides launchconfig.Layer
 	if params.LaunchOverrides != nil {
 		overrides = launchconfig.FromWire(*params.LaunchOverrides)
 	}
-	resolved, err := launchconfig.ResolveWithProject(c.launchConfigRoot, cwd, project, overrides)
-	if err != nil {
-		return appwire.PluginPreviewResponse{}, err
+	var resolved launchconfig.Resolved
+	if strings.TrimSpace(params.CWD) == "" {
+		// No launch directory chosen yet: the user-level inventory (global
+		// layer + per-launch overrides) is all that exists. Repo and project
+		// layers resolve once a directory is picked, and clients re-preview
+		// then.
+		userResolved, err := launchconfig.ResolveUserOnly(c.launchConfigRoot, overrides)
+		if err != nil {
+			return appwire.PluginPreviewResponse{}, err
+		}
+		resolved = userResolved
+	} else {
+		cwd, project, cleanup, err := pluginPreviewCWD(params.CWD)
+		if err != nil {
+			return appwire.PluginPreviewResponse{}, err
+		}
+		defer cleanup()
+		fullResolved, err := launchconfig.ResolveWithProject(c.launchConfigRoot, cwd, project, overrides)
+		if err != nil {
+			return appwire.PluginPreviewResponse{}, err
+		}
+		resolved = fullResolved
 	}
 	resolution, err := c.mgr.ResolveForLaunch(resolved.Effective.PluginDirs, resolved.Effective.EnabledPlugins)
 	if err != nil {

--- a/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
@@ -245,12 +245,16 @@ function assertResult(result, expectedWidth) {
     }
     if (result.plugins.sheet.height < 120) failures.push(`plugin sheet is too short to be usable: ${JSON.stringify(result.plugins.sheet)}`);
   }
-  if (result.plugins.filter === null || result.plugins.filter.width <= 1 || result.plugins.filter.height <= 1) {
-    failures.push(`plugin filter is not measurable at ${expectedWidth}px`);
-  } else if (mobile && result.plugins.filter.height < TAP_MIN_PX - 0.5) {
-    failures.push(`plugin filter is ${result.plugins.filter.height}px tall, below the ${TAP_MIN_PX}px touch floor`);
-  } else if (!mobile && result.plugins.filter.height >= 44) {
-    failures.push(`desktop plugin filter dimensions changed unexpectedly: ${JSON.stringify(result.plugins.filter)}`);
+  // The panel owns no filter and no scroll container: rows render the source
+  // subheading, counts and description under each name, and the list grows to
+  // fit them.
+  if (result.plugins.metadata === null || result.plugins.metadata.width <= 1 || result.plugins.metadata.height <= 1) {
+    failures.push(`plugin row metadata (source/counts/description) is not measurable at ${expectedWidth}px`);
+  }
+  if (result.plugins.listOverflowY !== "visible") {
+    failures.push(
+      `plugin list is a scroll container (overflow-y: ${result.plugins.listOverflowY}) at ${expectedWidth}px - it should expand to fit`,
+    );
   }
   if (result.plugins.switches.length === 0) {
     failures.push(`plugin switches are not measurable at ${expectedWidth}px`);

--- a/cmd/evener-hub/frontend/src/dev/spawnguard-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/spawnguard-entry.tsx
@@ -32,6 +32,7 @@ fake.on("evener/plugin/preview", () => ({
   plugins: [
     {
       name: "spawnguard-plugin",
+      description: "Spawnguard marketplace tools",
       source: "installed",
       marketplace: "spawnguard",
       selected: true,
@@ -43,6 +44,7 @@ fake.on("evener/plugin/preview", () => ({
     },
     {
       name: "spawnguard-directory",
+      description: "Directory-sourced helpers",
       source: "directory",
       path: "/tmp/spawnguard-plugin",
       selected: true,
@@ -280,7 +282,8 @@ function measureSpawn() {
   const pluginSheet = document.querySelector<HTMLElement>('[role="dialog"][aria-labelledby] h2')?.parentElement
     ?.parentElement;
   const start = document.querySelector<HTMLElement>('[data-testid="spawn-submit"]');
-  const pluginFilter = document.querySelector<HTMLElement>('[data-testid="plugin-selection-panel"] input');
+  const pluginList = document.querySelector<HTMLElement>('[data-testid="plugin-selection-list"]');
+  const pluginMetadata = document.querySelector<HTMLElement>('[data-testid="plugin-row-metadata"]');
   const pluginSwitches = Array.from(
     document.querySelectorAll<HTMLElement>('[data-testid="plugin-selection-panel"] [role="switch"]'),
   );
@@ -310,7 +313,12 @@ function measureSpawn() {
       row: pluginRow ? boxOf(pluginRow) : null,
       sheet: pluginSheet ? boxOf(pluginSheet) : null,
       start: start ? boxOf(start) : null,
-      filter: pluginFilter ? boxOf(pluginFilter) : null,
+      // The list must expand to fit its rows (the panel owns no scroll
+      // container), so the guard reads the computed overflow rather than a box.
+      listOverflowY: pluginList ? getComputedStyle(pluginList).overflowY : null,
+      // First row's subheading block (source, counts, description under the
+      // name) - the layout the rows are contracted to render.
+      metadata: pluginMetadata ? boxOf(pluginMetadata) : null,
       switches: pluginSwitches.map(boxOf),
     },
     overflow: scanHorizontalOverflow(),

--- a/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.tsx
@@ -12,7 +12,7 @@ import { Button, PathFieldPanel, Sheet } from "../../widgets";
 import { requireClass } from "../../widgets/internal/requireClass";
 import styles from "./MobileSettingRows.module.css";
 import { PluginSelectionPanel } from "./PluginSelectionPanel";
-import type { PluginSelectionState } from "./pluginSelectionState";
+import { type PluginSelectionState, selectedPluginNames } from "./pluginSelectionState";
 import type { PluginPreviewLoadState } from "./usePluginPreview";
 
 export interface MobilePickerOption {
@@ -214,11 +214,9 @@ export function MobileSettingRows({
       ? "Inspecting plugins…"
       : pluginPreview.status === "error"
         ? "Couldn't inspect plugins"
-        : `${
-            pluginPreview.response.plugins.filter((plugin) =>
-              pluginSelection.mode === "explicit" ? pluginSelection.names.includes(plugin.name) : plugin.selected,
-            ).length
-          } of ${pluginPreview.response.plugins.length}`;
+        : `${selectedPluginNames(pluginSelection, pluginPreview.response).length} of ${
+            pluginPreview.response.plugins.length
+          }`;
 
   return (
     <>

--- a/cmd/evener-hub/frontend/src/panes/spawn/PluginSelectionPanel.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/PluginSelectionPanel.test.tsx
@@ -53,16 +53,30 @@ function renderPanel(overrides: Partial<React.ComponentProps<typeof PluginSelect
 
 afterEach(cleanup);
 
-test("renders named switches, metadata, counts, and honest selected state", () => {
+test("renders named switches, source subheading, counts, and description", () => {
   renderPanel();
 
   expect(screen.getByRole("switch", { name: "alpha" }).getAttribute("aria-checked")).toBe("true");
   expect(screen.getByRole("switch", { name: "beta" }).getAttribute("aria-checked")).toBe("false");
-  expect(screen.getByText("@ acme")).toBeTruthy();
-  expect(screen.getByText("/tmp/beta")).toBeTruthy();
+  expect(screen.getByText("installed from acme")).toBeTruthy();
+  expect(screen.getByText("directory: /tmp/beta")).toBeTruthy();
   expect(screen.getByText("2 skills · 1 agent · 1 command")).toBeTruthy();
-  expect(screen.getByText("off for session")).toBeTruthy();
+  expect(screen.getByText("Alpha tools")).toBeTruthy();
   expect(screen.getByText("1 of 2 selected")).toBeTruthy();
+  expect(screen.queryByText(/for session$/)).toBeNull();
+  expect(screen.queryByText(/^Showing /)).toBeNull();
+});
+
+test("each row orders source subheading, then counts, then description", () => {
+  renderPanel();
+
+  const text = screen.getByTestId("plugin-selection-panel").textContent ?? "";
+  const sourceAt = text.indexOf("installed from acme");
+  const countsAt = text.indexOf("2 skills · 1 agent · 1 command");
+  const descriptionAt = text.indexOf("Alpha tools");
+  expect(sourceAt).toBeGreaterThanOrEqual(0);
+  expect(sourceAt).toBeLessThan(countsAt);
+  expect(countsAt).toBeLessThan(descriptionAt);
 });
 
 test("keyboard toggles a switch and materializes explicit selection", async () => {
@@ -76,49 +90,14 @@ test("keyboard toggles a switch and materializes explicit selection", async () =
   expect(onSelectionChange).toHaveBeenCalledWith({ mode: "explicit", names: ["alpha", "beta"] });
 });
 
-test("filters by name, source, and description and supports All and None", async () => {
+test("supports All and None", async () => {
   const user = userEvent.setup();
   const { onSelectionChange } = renderPanel();
-  const filter = screen.getByRole("searchbox", { name: "Filter plugins" });
 
-  await user.type(filter, "helpers");
-  expect(screen.queryByRole("switch", { name: "alpha" })).toBeNull();
-  expect(screen.getByRole("switch", { name: "beta" })).toBeTruthy();
-  await user.clear(filter);
   await user.click(screen.getByRole("button", { name: "None" }));
   expect(onSelectionChange).toHaveBeenLastCalledWith({ mode: "explicit", names: [] });
   await user.click(screen.getByRole("button", { name: "All" }));
   expect(onSelectionChange).toHaveBeenLastCalledWith({ mode: "explicit", names: ["alpha", "beta"] });
-});
-
-test("simultaneously mounted panels keep distinct filter label targets", () => {
-  render(
-    <>
-      <PluginSelectionPanel
-        preview={preview}
-        selection={{ mode: "default" }}
-        onSelectionChange={vi.fn()}
-        onRetry={vi.fn()}
-      />
-      <PluginSelectionPanel
-        preview={preview}
-        selection={{ mode: "default" }}
-        onSelectionChange={vi.fn()}
-        onRetry={vi.fn()}
-      />
-    </>,
-  );
-
-  const panels = screen.getAllByTestId("plugin-selection-panel");
-  expect(panels).toHaveLength(2);
-  const ids = panels.map((panel) => {
-    const label = within(panel).getByText("Filter plugins", { selector: "label" });
-    const input = within(panel).getByRole("searchbox") as HTMLInputElement;
-    expect(label.getAttribute("for")).toBe(input.id);
-    expect(input.id).not.toBe("");
-    return input.id;
-  });
-  expect(new Set(ids).size).toBe(2);
 });
 
 test("exposes diagnostics and blocking selection errors without relying on color", async () => {

--- a/cmd/evener-hub/frontend/src/panes/spawn/PluginSelectionPanel.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/PluginSelectionPanel.tsx
@@ -1,12 +1,13 @@
-import { type ReactElement, useId, useMemo, useState } from "react";
+import type { ReactElement } from "react";
 import type { PluginLaunchCandidate, PluginPreviewResponse } from "../../protocol/types.gen";
-import { Button, Input, Switch } from "../../widgets";
+import { Button, Switch } from "../../widgets";
 import { requireClass } from "../../widgets/internal/requireClass";
 import styles from "./pluginSelection.module.css";
 import {
   type PluginSelectionState,
   pluginSelectionIssues,
   selectAllPlugins,
+  selectedPluginNames,
   selectNoPlugins,
   setPluginSelected,
 } from "./pluginSelectionState";
@@ -22,15 +23,13 @@ export interface PluginSelectionPanelProps {
 const CLASS = {
   panel: requireClass(styles.panel, "pluginSelection.module.css", "panel"),
   tools: requireClass(styles.tools, "pluginSelection.module.css", "tools"),
-  filter: requireClass(styles.filter, "pluginSelection.module.css", "filter"),
   actions: requireClass(styles.actions, "pluginSelection.module.css", "actions"),
   list: requireClass(styles.list, "pluginSelection.module.css", "list"),
   row: requireClass(styles.row, "pluginSelection.module.css", "row"),
   metadata: requireClass(styles.metadata, "pluginSelection.module.css", "metadata"),
   source: requireClass(styles.source, "pluginSelection.module.css", "source"),
-  kind: requireClass(styles.kind, "pluginSelection.module.css", "kind"),
-  state: requireClass(styles.state, "pluginSelection.module.css", "state"),
   counts: requireClass(styles.counts, "pluginSelection.module.css", "counts"),
+  description: requireClass(styles.description, "pluginSelection.module.css", "description"),
   resultCount: requireClass(styles.resultCount, "pluginSelection.module.css", "resultCount"),
   diagnostics: requireClass(styles.diagnostics, "pluginSelection.module.css", "diagnostics"),
   errors: requireClass(styles.errors, "pluginSelection.module.css", "errors"),
@@ -38,8 +37,9 @@ const CLASS = {
 };
 
 function sourceLabel(plugin: PluginLaunchCandidate): string {
-  if (plugin.source === "installed" && plugin.marketplace) return `@ ${plugin.marketplace}`;
-  return plugin.path || plugin.source;
+  if (plugin.source === "installed" && plugin.marketplace) return `installed from ${plugin.marketplace}`;
+  if (plugin.path) return `${plugin.source}: ${plugin.path}`;
+  return plugin.source;
 }
 
 function componentCounts(plugin: PluginLaunchCandidate): string {
@@ -52,14 +52,6 @@ function componentCounts(plugin: PluginLaunchCandidate): string {
   return counts.length > 0 ? counts.join(" · ") : "No components";
 }
 
-function matchesFilter(plugin: PluginLaunchCandidate, query: string): boolean {
-  const haystack = [plugin.name, plugin.description, plugin.source, plugin.marketplace, plugin.path]
-    .filter(Boolean)
-    .join(" ")
-    .toLocaleLowerCase();
-  return haystack.includes(query);
-}
-
 export function PluginSelectionPanel({
   preview,
   selection,
@@ -67,17 +59,10 @@ export function PluginSelectionPanel({
   onSelectionChange,
   onRetry,
 }: PluginSelectionPanelProps): ReactElement {
-  const filterId = useId();
-  const [filter, setFilter] = useState("");
-  const query = filter.trim().toLocaleLowerCase();
-  const visiblePlugins = useMemo(
-    () => preview.plugins.filter((plugin) => matchesFilter(plugin, query)),
-    [preview.plugins, query],
-  );
   const selectedNames = selection.mode === "explicit" ? new Set(selection.names) : null;
   const issueNames =
     selectedNames ?? new Set(preview.plugins.filter((plugin) => plugin.selected).map((plugin) => plugin.name));
-  const selectedCount = preview.plugins.filter((plugin) => selectedNames?.has(plugin.name) ?? plugin.selected).length;
+  const selectedCount = selectedPluginNames(selection, preview).length;
   const selectionIssues = pluginSelectionIssues(selection, preview).filter(
     (issue) => !removeOnly || issueNames.has(issue.name),
   );
@@ -86,15 +71,8 @@ export function PluginSelectionPanel({
   return (
     <section className={CLASS.panel} data-testid="plugin-selection-panel" aria-label="Plugins for this session">
       <div className={CLASS.tools}>
-        <div className={CLASS.filter}>
-          <label htmlFor={filterId}>Filter plugins</label>
-          <Input
-            id={filterId}
-            type="search"
-            value={filter}
-            onChange={(event) => setFilter(event.target.value)}
-            placeholder="Filter plugins…"
-          />
+        <div className={CLASS.resultCount} role="status">
+          {selectedCount} of {preview.plugins.length} selected
         </div>
         <div className={CLASS.actions}>
           <Button
@@ -119,11 +97,8 @@ export function PluginSelectionPanel({
         </div>
       </div>
 
-      <div className={CLASS.resultCount} role="status">
-        {selectedCount} of {preview.plugins.length} selected
-      </div>
-      <div className={CLASS.list}>
-        {visiblePlugins.map((plugin) => {
+      <div className={CLASS.list} data-testid="plugin-selection-list">
+        {preview.plugins.map((plugin) => {
           const selected = selectedNames?.has(plugin.name) ?? plugin.selected;
           return (
             <div className={CLASS.row} key={plugin.name}>
@@ -135,22 +110,15 @@ export function PluginSelectionPanel({
                   if (!removeOnly || !next) onSelectionChange(setPluginSelected(selection, preview, plugin.name, next));
                 }}
               />
-              <div className={CLASS.metadata}>
+              <div className={CLASS.metadata} data-testid="plugin-row-metadata">
                 <span className={CLASS.source}>{sourceLabel(plugin)}</span>
                 <span className={CLASS.counts}>{componentCounts(plugin)}</span>
-                <span className={CLASS.state}>{selected ? "selected for session" : "off for session"}</span>
+                {plugin.description && <span className={CLASS.description}>{plugin.description}</span>}
               </div>
-              <span className={CLASS.kind}>{plugin.source === "installed" ? "installed" : plugin.source}</span>
             </div>
           );
         })}
       </div>
-      {preview.plugins.length > 0 && (
-        <div className={CLASS.resultCount}>
-          Showing {visiblePlugins.length} of {preview.plugins.length}
-          {visiblePlugins.length < preview.plugins.length ? " matching plugins" : " plugins"}
-        </div>
-      )}
       {preview.plugins.length === 0 && <p className={CLASS.empty}>No plugins are available for this session.</p>}
 
       {removeOnly && (

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -513,7 +513,10 @@ test("desktop plugin summary remains mounted with exact loading and error status
   await waitFor(() =>
     expect(screen.getByTestId("spawn-plugin-summary").textContent).toContain("Couldn't inspect plugins"),
   );
+  // The failure says WHY, and the retry is a small inline action.
+  expect(screen.getByTestId("spawn-plugin-summary").textContent).toContain("preview unavailable");
   expect(screen.getByTestId("spawn-plugin-summary").textContent).not.toContain("0 of 0");
+  expect(within(screen.getByTestId("spawn-plugin-summary")).getByRole("button", { name: "Retry" })).toBeTruthy();
 });
 
 const SPAWN_PLUGIN_PREVIEW: PluginPreviewResponse = {
@@ -541,6 +544,28 @@ const SPAWN_PLUGIN_PREVIEW: PluginPreviewResponse = {
     },
   ],
 };
+
+test("desktop plugin summary lists the configured plugin names", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("evener/plugin/preview", () => SPAWN_PLUGIN_PREVIEW);
+  });
+  renderSpawn(fake);
+  await settled();
+  await setWorkingDir(user, "/tmp/project");
+
+  await waitFor(() =>
+    expect(screen.getByTestId("spawn-plugin-summary").textContent).toContain("Configured plugins: alpha, beta"),
+  );
+  expect(screen.getByTestId("spawn-plugin-summary").textContent).not.toContain("session only");
+
+  await openDesktopPluginSelection(user);
+  await user.click(screen.getByRole("switch", { name: "beta" }));
+  await waitFor(() =>
+    expect(screen.getByTestId("spawn-plugin-summary").textContent).toContain("Configured plugins: alpha"),
+  );
+  expect(screen.getByTestId("spawn-plugin-summary").textContent).not.toContain("beta");
+});
 
 async function openDesktopPluginSelection(user: ReturnType<typeof userEvent.setup>): Promise<void> {
   await waitFor(() => expect(screen.getByTestId("spawn-plugin-disclosure")).toBeTruthy());
@@ -658,6 +683,10 @@ test("explicit selection blocks while refresh is pending but preview failure sti
   expect(extensionsStore.getState().pluginRevision).toBe(1);
   await waitFor(() => expect((screen.getByTestId("spawn-submit") as HTMLButtonElement).disabled).toBe(true));
   await waitFor(() => expect(explicitPreviewCalls).toBe(2));
+  // The refresh must not unmount the list: the previous plugins stay visible
+  // (and toggleable) while the new inspection is in flight.
+  expect(screen.getByRole("switch", { name: "alpha" })).toBeTruthy();
+  expect(screen.getByTestId("spawn-plugin-summary").textContent).toContain("Configured plugins: alpha");
 
   rejectRefresh(new Error("preview unavailable"));
   await waitFor(() => expect(screen.getAllByText("Couldn't inspect plugins").length).toBeGreaterThan(0));

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -67,6 +67,7 @@ import {
   type PluginSelectionState,
   pluginSelectionIssues,
   reconcilePluginSelection,
+  selectedPluginNames,
   withPluginSelection,
 } from "./pluginSelectionState";
 import { createDir, preflightDir } from "./preflight";
@@ -326,14 +327,11 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     // Re-running this effect for that selection change would restore old issues.
   }, [pluginPreview.state, pluginSelectionSupported]);
 
-  const previewResponse =
-    pluginSelectionSupported && (pluginPreview.state.status === "ready" || pluginPreview.state.status === "error")
-      ? (pluginPreview.state.response ?? null)
-      : null;
-  const selectedPluginCount =
-    previewResponse?.plugins.filter((plugin) =>
-      pluginSelection.mode === "explicit" ? pluginSelection.names.includes(plugin.name) : plugin.selected,
-    ).length ?? 0;
+  // A refresh triggered by a selection toggle keeps the previous response on
+  // the loading state (see usePluginPreview), so the disclosure and its list
+  // stay mounted instead of flashing an empty "Inspecting plugins…" panel.
+  const previewResponse = pluginSelectionSupported ? (pluginPreview.state.response ?? null) : null;
+  const configuredPluginNames = previewResponse ? selectedPluginNames(pluginSelection, previewResponse) : [];
   const currentSelectionIssues =
     pluginPreview.state.status === "ready" ? pluginSelectionIssues(pluginSelection, pluginPreview.state.response) : [];
   const explicitSelectionLoading =
@@ -1004,13 +1002,16 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
             {previewResponse === null && (
               <div className={CLASS.pluginSummary} data-testid="spawn-plugin-summary" role="status">
                 <strong>Plugins for this session</strong>
-                <span>
-                  {pluginPreview.state.status === "loading" ? "Inspecting plugins…" : "Couldn't inspect plugins"}
-                </span>
+                {pluginPreview.state.status === "loading" && <span>Inspecting plugins…</span>}
                 {pluginPreview.state.status === "error" && (
-                  <Button variant="secondary" size="xs" type="button" onClick={pluginPreview.retry}>
-                    Retry
-                  </Button>
+                  <>
+                    <span title={pluginPreview.state.message}>
+                      Couldn't inspect plugins: {pluginPreview.state.message}
+                    </span>
+                    <Button variant="quiet" size="xs" type="button" onClick={pluginPreview.retry}>
+                      Retry
+                    </Button>
+                  </>
                 )}
               </div>
             )}
@@ -1022,7 +1023,9 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
                   <div className={CLASS.pluginSummary} data-testid="spawn-plugin-summary">
                     <strong>Plugins for this session</strong>
                     <span>
-                      {selectedPluginCount} of {previewResponse.plugins.length} will load · session only
+                      {configuredPluginNames.length > 0
+                        ? `Configured plugins: ${configuredPluginNames.join(", ")}`
+                        : "Configured plugins: none"}
                     </span>
                   </div>
                 }

--- a/cmd/evener-hub/frontend/src/panes/spawn/pluginSelection.module.css
+++ b/cmd/evener-hub/frontend/src/panes/spawn/pluginSelection.module.css
@@ -37,28 +37,25 @@
 }
 
 .summary span {
+  overflow: hidden;
   color: var(--ink-low);
   font-size: var(--font-size-caption);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The summary column stretches its children; the error state's Retry stays a
+ * small inline action instead of growing into a full-width band. */
+.summary button {
+  align-self: flex-start;
 }
 
 .tools {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
+  justify-content: space-between;
   gap: var(--space-2);
   min-width: 0;
-}
-
-.filter {
-  display: flex;
-  flex: 1 1 auto;
-  flex-direction: column;
-  gap: var(--space-1);
-  min-width: 0;
-}
-
-.filter label {
-  color: var(--ink-mid);
-  font-size: var(--font-size-caption);
 }
 
 .actions {
@@ -69,31 +66,30 @@
 
 .list {
   min-width: 0;
-  max-height: 360px;
-  overflow-y: auto;
-  overscroll-behavior: contain;
 }
 
 .row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: var(--space-2);
-  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
   min-width: 0;
   padding: var(--space-2) 0;
   border-top: 1px solid var(--edge);
 }
 
+/* Indented to line up under the switch label: the 32px track plus the
+ * wrapper's --space-2 gap (the 899px media query below widens the hit target
+ * to 44px and adjusts this to match). */
 .metadata {
   display: flex;
   min-width: 0;
   flex-direction: column;
   gap: 2px;
+  padding-left: calc(32px + var(--space-2));
 }
 
 .source,
 .counts,
-.state,
 .resultCount {
   min-width: 0;
   overflow: hidden;
@@ -107,22 +103,10 @@
   color: var(--ink-mid);
 }
 
-.state {
-  color: var(--ink-mid);
-}
-
-.kind {
-  flex: none;
-  padding: 2px var(--space-1);
-  border: 1px solid var(--edge);
-  border-radius: var(--radius-pill);
-  color: var(--ink-mid);
-  font-size: var(--font-size-caption);
-  white-space: nowrap;
-}
-
-.resultCount {
+.description {
+  min-width: 0;
   color: var(--ink-low);
+  font-size: var(--font-size-caption);
 }
 
 .diagnostics,
@@ -167,34 +151,19 @@
   font-size: var(--font-size-ui);
 }
 
-@media (max-width: 559px) {
-  .tools {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .actions {
-    justify-content: flex-start;
-  }
-
-  .row {
-    grid-template-columns: minmax(0, 1fr) auto;
-  }
-}
-
 @media (max-width: 899px) {
   .desktopSurface {
     display: none;
   }
 
-  /* The shared Switch and Input keep their compact desktop geometry. On a
-   * phone this surface owns a larger hit target without changing the primitive
-   * used by the other desktop controls. The switch's pseudo track preserves
-   * the compact visual while the actual role=switch button is 44px square. */
-  .panel .filter input {
-    min-height: 44px;
+  .metadata {
+    padding-left: calc(44px + var(--space-2));
   }
 
+  /* The shared Switch keeps its compact desktop geometry. On a phone this
+   * surface owns a larger hit target without changing the primitive used by
+   * the other desktop controls. The switch's pseudo track preserves the
+   * compact visual while the actual role=switch button is 44px square. */
   .panel .row [role="switch"] {
     width: 44px;
     height: 44px;

--- a/cmd/evener-hub/frontend/src/panes/spawn/pluginSelectionState.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/pluginSelectionState.ts
@@ -15,6 +15,15 @@ function orderedNames(names: Iterable<string>, preview: PluginPreviewResponse): 
   return ordered;
 }
 
+// The one place the effective selection is derived: an explicit allow-list
+// wins over the preview's own selected flags, so the UI reflects a toggle the
+// moment it happens rather than after the re-preview it triggers settles.
+export function selectedPluginNames(selection: PluginSelectionState, preview: PluginPreviewResponse): string[] {
+  return preview.plugins
+    .filter((plugin) => (selection.mode === "explicit" ? selection.names.includes(plugin.name) : plugin.selected))
+    .map((plugin) => plugin.name);
+}
+
 export function withPluginSelection(overrides: LaunchConfigLayer, selection: PluginSelectionState): LaunchConfigLayer {
   const { enabledPlugins: _ignored, ...withoutSelection } = overrides;
   return selection.mode === "explicit"

--- a/cmd/evener-hub/frontend/src/panes/spawn/usePluginPreview.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/usePluginPreview.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { FakeClient } from "../../protocol/testing/fakeClient";
-import type { PluginPreviewResponse } from "../../protocol/types.gen";
+import type { LaunchConfigLayer, PluginPreviewResponse } from "../../protocol/types.gen";
 import { usePluginPreview } from "./usePluginPreview";
 
 const RESPONSE: PluginPreviewResponse = { plugins: [] };
@@ -97,6 +97,56 @@ describe("usePluginPreview", () => {
     expect(result.current.state).toEqual({ status: "loading" });
     await act(async () => {
       responses[1]!(RESPONSE);
+      await flush();
+    });
+    expect(result.current.state).toEqual({ status: "ready", response: RESPONSE });
+  });
+
+  test("keeps the previous response mounted while a same-cwd refresh loads", async () => {
+    vi.useFakeTimers();
+    const client = new FakeClient();
+    const responseA: PluginPreviewResponse = {
+      plugins: [
+        {
+          name: "a",
+          source: "test",
+          selected: true,
+          skillCount: 1,
+          agentCount: 0,
+          commandCount: 0,
+          hookCount: 0,
+          mcpCount: 0,
+        },
+      ],
+    };
+    let resolveRefresh!: (response: PluginPreviewResponse) => void;
+    let requests = 0;
+    client.on("evener/plugin/preview", () => {
+      requests += 1;
+      if (requests === 1) return responseA;
+      return new Promise<PluginPreviewResponse>((done) => (resolveRefresh = done));
+    });
+    const { result, rerender } = renderHook(
+      ({ overrides }: { overrides: LaunchConfigLayer }) =>
+        usePluginPreview({ client, cwd: "/repo", launchOverrides: overrides, pluginRevision: 0 }),
+      { initialProps: { overrides: {} } },
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+    });
+    expect(result.current.state).toEqual({ status: "ready", response: responseA });
+
+    // A selection toggle changes only the overrides: the panel keeps showing
+    // the previous plugins instead of collapsing to an empty loading state.
+    rerender({ overrides: { enabledPlugins: ["a"] } });
+    expect(result.current.state).toEqual({ status: "loading", response: responseA });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    await act(async () => {
+      resolveRefresh(RESPONSE);
       await flush();
     });
     expect(result.current.state).toEqual({ status: "ready", response: RESPONSE });

--- a/cmd/evener-hub/frontend/src/panes/spawn/usePluginPreview.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/usePluginPreview.ts
@@ -6,7 +6,7 @@ import type { LaunchConfigLayer, PluginPreviewResponse } from "../../protocol/ty
 export const PLUGIN_PREVIEW_DEBOUNCE_MS = 250;
 
 export type PluginPreviewLoadState =
-  | { status: "loading" }
+  | { status: "loading"; response?: PluginPreviewResponse }
   | { status: "ready"; response: PluginPreviewResponse }
   | { status: "error"; message: string; response?: PluginPreviewResponse };
 
@@ -26,7 +26,7 @@ export function usePluginPreview(args: UsePluginPreviewArgs): {
   const [retryRevision, setRetryRevision] = useState(0);
   const [state, setState] = useState<PluginPreviewLoadState>({ status: "loading" });
   const latestKey = useRef("");
-  const lastResponse = useRef<{ logicalKey: string; response: PluginPreviewResponse } | null>(null);
+  const lastResponse = useRef<{ cwd: string; logicalKey: string; response: PluginPreviewResponse } | null>(null);
   const launchOverridesRef = useRef(launchOverrides);
   launchOverridesRef.current = launchOverrides;
   const serializedOverrides = JSON.stringify(launchOverrides);
@@ -45,7 +45,14 @@ export function usePluginPreview(args: UsePluginPreviewArgs): {
     const logicalKey = `${baseKey}\u0000${pluginRevision}`;
     const requestKey = `${logicalKey}\u0000${retryRevision}`;
     latestKey.current = requestKey;
-    setState({ status: "loading" });
+    // Keep the previous response mounted while a same-cwd refresh (a selection
+    // toggle, a revision bump, a retry) is in flight, so the panel doesn't
+    // collapse to an empty loading state and back. A cwd change drops it: the
+    // stale list belongs to another directory.
+    const cached = lastResponse.current;
+    setState(
+      cached !== null && cached.cwd === cwd ? { status: "loading", response: cached.response } : { status: "loading" },
+    );
 
     const timer = setTimeout(() => {
       const currentOverrides = launchOverridesRef.current;
@@ -53,7 +60,7 @@ export function usePluginPreview(args: UsePluginPreviewArgs): {
       void client.request("evener/plugin/preview", params).then(
         (response) => {
           if (latestKey.current === requestKey) {
-            lastResponse.current = { logicalKey, response };
+            lastResponse.current = { cwd, logicalKey, response };
             setState({ status: "ready", response });
           }
         },

--- a/cmd/evener-hub/internal/launchconfig/resolver.go
+++ b/cmd/evener-hub/internal/launchconfig/resolver.go
@@ -25,6 +25,30 @@ func ResolveWithProject(stateRoot, cwd string, project identifier.Project, overr
 	return resolveFSWithProject(afero.NewOsFs(), stateRoot, cwd, project, overrides)
 }
 
+// ResolveUserOnly resolves the layers that exist before a launch directory is
+// chosen: the global (user) layer plus the per-launch overrides. Repo and
+// project layers are unknowable without a directory, so this answers "what
+// applies everywhere" — once a directory exists, the full Resolve supersedes
+// it.
+func ResolveUserOnly(stateRoot string, overrides Layer) (Resolved, error) {
+	return resolveUserOnlyFS(afero.NewOsFs(), stateRoot, overrides)
+}
+
+func resolveUserOnlyFS(fs afero.Fs, stateRoot string, overrides Layer) (Resolved, error) {
+	var pathDiags []Diagnostic
+	g, err := loadLayerFS(fs, filepath.Join(stateRoot, "launch.toml"))
+	if err != nil {
+		return Resolved{}, fmt.Errorf("global: %w", err)
+	}
+	g = validateAbsolutePaths(LayerGlobal, g, &pathDiags)
+	resolved, _ := mergeLayers(map[LayerName]Layer{
+		LayerGlobal: g,
+		LayerLaunch: overrides,
+	})
+	resolved.Diagnostics = append(resolved.Diagnostics, pathDiags...)
+	return resolved, nil
+}
+
 func resolveFS(fs afero.Fs, stateRoot, cwd string, overrides Layer) (Resolved, error) {
 	project, err := identifier.ResolveProject(cwd)
 	if err != nil {

--- a/cmd/evener-hub/internal/launchconfig/resolver.go
+++ b/cmd/evener-hub/internal/launchconfig/resolver.go
@@ -34,13 +34,23 @@ func ResolveUserOnly(stateRoot string, overrides Layer) (Resolved, error) {
 	return resolveUserOnlyFS(afero.NewOsFs(), stateRoot, overrides)
 }
 
-func resolveUserOnlyFS(fs afero.Fs, stateRoot string, overrides Layer) (Resolved, error) {
-	var pathDiags []Diagnostic
-	g, err := loadLayerFS(fs, filepath.Join(stateRoot, "launch.toml"))
+// loadGlobalLayerFS reads and validates the global layer, the one step shared
+// by a full directory resolution and the user-only preview before one exists.
+func loadGlobalLayerFS(fs afero.Fs, globalPath string) (Layer, []Diagnostic, error) {
+	g, err := loadLayerFS(fs, globalPath)
 	if err != nil {
-		return Resolved{}, fmt.Errorf("global: %w", err)
+		return Layer{}, nil, fmt.Errorf("global: %w", err)
 	}
-	g = validateAbsolutePaths(LayerGlobal, g, &pathDiags)
+	var diags []Diagnostic
+	g = validateAbsolutePaths(LayerGlobal, g, &diags)
+	return g, diags, nil
+}
+
+func resolveUserOnlyFS(fs afero.Fs, stateRoot string, overrides Layer) (Resolved, error) {
+	g, pathDiags, err := loadGlobalLayerFS(fs, filepath.Join(stateRoot, "launch.toml"))
+	if err != nil {
+		return Resolved{}, err
+	}
 	resolved, _ := mergeLayers(map[LayerName]Layer{
 		LayerGlobal: g,
 		LayerLaunch: overrides,
@@ -62,11 +72,11 @@ func resolveFSWithProject(fs afero.Fs, stateRoot, cwd string, project identifier
 	layers := map[LayerName]Layer{}
 	var pathDiags []Diagnostic
 
-	g, err := loadLayerFS(fs, paths.Global)
+	g, gDiags, err := loadGlobalLayerFS(fs, paths.Global)
 	if err != nil {
-		return Resolved{}, fmt.Errorf("global: %w", err)
+		return Resolved{}, err
 	}
-	g = validateAbsolutePaths(LayerGlobal, g, &pathDiags)
+	pathDiags = append(pathDiags, gDiags...)
 	layers[LayerGlobal] = g
 
 	// In-repo: load + hash + trust check.

--- a/cmd/evener-hub/internal/launchconfig/resolver_test.go
+++ b/cmd/evener-hub/internal/launchconfig/resolver_test.go
@@ -31,6 +31,32 @@ func TestDecodeTrustedRepoLayerRejectsEnabledPlugins(t *testing.T) {
 	}
 }
 
+func TestResolveUserOnlyMergesGlobalAndLaunch(t *testing.T) {
+	stateRoot := t.TempDir()
+	writeFile(t, filepath.Join(stateRoot, "launch.toml"), `plugin_dirs = ["/absolute/plugins", "relative/plugins"]
+`)
+	launch := []string{"launch-pick"}
+	resolved, err := ResolveUserOnly(stateRoot, Layer{EnabledPlugins: &launch})
+	if err != nil {
+		t.Fatalf("ResolveUserOnly: %v", err)
+	}
+	// The launch layer lands on top; the relative global plugin_dirs entry
+	// drops out with a diagnostic while the absolute one survives.
+	if resolved.Effective.EnabledPlugins == nil || !reflect.DeepEqual(*resolved.Effective.EnabledPlugins, launch) {
+		t.Fatalf("EnabledPlugins = %#v, want %v", resolved.Effective.EnabledPlugins, launch)
+	}
+	if !reflect.DeepEqual(resolved.Effective.PluginDirs, []string{"/absolute/plugins"}) {
+		t.Fatalf("PluginDirs = %v, want only the absolute entry", resolved.Effective.PluginDirs)
+	}
+	if len(resolved.Diagnostics) != 1 || resolved.Diagnostics[0].Layer != LayerGlobal || resolved.Diagnostics[0].Field != "plugin_dirs" {
+		t.Fatalf("Diagnostics = %#v, want one global plugin_dirs diagnostic", resolved.Diagnostics)
+	}
+	// No directory means no project identity and no repo status.
+	if resolved.Project != (identifier.Project{}) || resolved.Repo != nil {
+		t.Fatalf("Project/Repo = %+v/%+v, want both unset", resolved.Project, resolved.Repo)
+	}
+}
+
 func checkResolve_LayersMerge(t *testing.T) {
 	stateRoot := t.TempDir()
 	cwd := t.TempDir()


### PR DESCRIPTION
## Summary

Reworks the \"plugins for this session\" disclosure and fixes two robustness gaps that made the panel flake and flash.

### UI cleanup
- **Closed disclosure**: summary lists configured plugin names (`Configured plugins: superpowers, elements-of-style, …`) instead of `N of M will load · session only`.
- **Open panel**: removed the filter input, the scroll container, the `selected for session` state line, the `installed`/`directory` kind pill, and the bottom `Showing N of M` line. Each row now stacks: toggle + name → source subheading (`installed from <marketplace>` / `directory: <path>`) → component counts → the plugin's marketplace description. The list expands to fit rather than scrolling.

### Toggle-refresh flash
Toggling a plugin triggers a re-preview; the hook previously dropped to a bare loading state, unmounting the whole disclosure. `usePluginPreview` now carries the previous response through the same-cwd loading state (toggle, revision bump, retry) so the list stays mounted and interactive while the new inspection is in flight; a cwd change still drops the stale list.

### Empty-cwd flake
Previewing with no launch directory chosen used to fail with `InvalidParams(\"cwd: path is empty\")`, surfacing the error state on every mount. Added `launchconfig.ResolveUserOnly` (global layer + per-launch overrides) and branched on empty/whitespace cwd in the preview handler so the user-level plugin inventory resolves before a directory is picked; repo and project layers re-resolve once one is.

### Error-state UX
The failure summary now shows the server's message (`Couldn't inspect plugins: <message>`, truncated with full text on hover) with a small inline quiet Retry button instead of a full-width Retry wall.

### Consolidation
Extracted `selectedPluginNames(selection, preview)` into `pluginSelectionState` so Spawn, MobileSettingRows, and PluginSelectionPanel share one selection-predicate instead of three copies. Extracted `loadGlobalLayerFS` to deduplicate the global-layer load between full and user-only resolution. Updated the spawnguard browser fixture to assert the new layout (row metadata box, non-scrolling list) rather than the removed filter.

## Verification
- \`make test-web\` (typecheck + unit + Biome): PASS
- \`go test ./cmd/evener-hub/...\`: PASS
- \`make vet\`: PASS
- Real headless Chrome screenshots captured (closed + open, desktop + mobile) against the spawnguard page; all verified visually.
- \`make test-web-browser\` is blocked by a pre-existing Chrome-startup SIGTRAP on this host (reproduced identically on the clean tree); the spawnguard fixture was updated so it will pass on a Chrome-capable host/CI.

## Tested live
Built and restarted the hub on 9180 from this branch; the plugin list now appears on mount before a directory is picked.