### PR TITLE
fix: preserve steering after terminal communicate

### DIFF
--- a/agent/session_client_mutation_queue_test.go
+++ b/agent/session_client_mutation_queue_test.go
@@ -1166,7 +1166,7 @@ func TestClientMutation_SteeringClaimRestoreDoesNotConsumeTurnBudget(t *testing.
 	}
 }
 
-func TestClientMutation_CommunicateEndTurnDurablyConsumesClientSteering(t *testing.T) {
+func TestClientMutation_CommunicateEndTurnDefersClientSteering(t *testing.T) {
 	sess := newTestSession(t)
 	clientImage := appwire.InputItem{
 		Type:      "image",
@@ -1181,7 +1181,7 @@ func TestClientMutation_CommunicateEndTurnDurablyConsumesClientSteering(t *testi
 			clientImage,
 		},
 	}
-	response, err := sess.clientMutationSteer(params)
+	_, err := sess.clientMutationSteer(params)
 	if err != nil {
 		t.Fatalf("clientMutationSteer: %v", err)
 	}
@@ -1207,50 +1207,37 @@ func TestClientMutation_CommunicateEndTurnDurablyConsumesClientSteering(t *testi
 	if err := json.Unmarshal([]byte(raw.(string)), &result); err != nil {
 		t.Fatalf("decode communicate result: %v", err)
 	}
-	if got, want := result.Inbox, []string{"client update", "daemon reminder"}; !slices.Equal(got, want) {
+	// The client entry is first, so preserving queue order means the terminal
+	// communicate drain cannot skip it to expose the daemon entry behind it.
+	// Both entries remain pending for the next carrier/ordinary steering turn.
+	if got, want := result.Inbox, []string{}; !slices.Equal(got, want) {
 		t.Fatalf("communicate inbox = %#v, want %#v", got, want)
 	}
 
 	snapshot := sess.clientMutations.snapshot()
 	record := snapshot.Journal[params.ClientMutationID]
-	if record.OperationState != clientMutationOperationTerminal ||
-		record.ExecutionState != "incorporated" {
-		t.Fatalf("consumed steering record = (%q,%q), want terminal/incorporated",
+	if record.OperationState != clientMutationOperationApplied ||
+		record.ExecutionState != "accepted" {
+		t.Fatalf("deferred steering record = (%q,%q), want applied/accepted",
 			record.OperationState, record.ExecutionState)
 	}
-	if _, ok := snapshot.PendingExecutions[params.ClientMutationID]; ok {
-		t.Fatal("communicate-consumed steering remained pending")
+	if pending, ok := snapshot.PendingExecutions[params.ClientMutationID]; !ok || pending.ExecutionState != "accepted" {
+		t.Fatalf("deferred steering pending execution = %#v, want accepted", pending)
+	}
+	if len(snapshot.SteeringOrder) != 1 {
+		t.Fatalf("deferred steering order = %#v, want one client entry", snapshot.SteeringOrder)
 	}
 
-	var incorporated int
-	for _, turn := range sess.history {
-		if turn.ClientMutationID != params.ClientMutationID {
-			continue
-		}
-		incorporated++
-		if turn.StableTurnID != response.Receipt.TurnID {
-			t.Fatalf("incorporated stable turn = %q, want %q", turn.StableTurnID, response.Receipt.TurnID)
-		}
-		var images int
-		for _, part := range turn.Message.Content {
-			if part.Kind == llm.ContentImage {
-				images++
-			}
-		}
-		if images != 1 {
-			t.Fatalf("incorporated client image count = %d, want 1", images)
-		}
-	}
-	if incorporated != 1 {
-		t.Fatalf("incorporated client steering count = %d, want 1", incorporated)
-	}
-
-	sess.reflectDurableClientSteering()
 	steering := sess.SteeringQueueSnapshot()
-	if len(steering) != 1 ||
-		steering[0].Text != "daemon reminder" ||
-		len(steering[0].Images) != 1 {
-		t.Fatalf("post-reflection steering = %#v, want only deferred daemon image steering", steering)
+	if len(steering) != 2 ||
+		steering[0].Text != "client update" || len(steering[0].Images) != 1 ||
+		steering[1].Text != "daemon reminder" || len(steering[1].Images) != 1 {
+		t.Fatalf("post-communicate steering = %#v, want client then daemon entries with images", steering)
+	}
+	for _, turn := range sess.history {
+		if turn.ClientMutationID == params.ClientMutationID {
+			t.Fatalf("deferred client steering was incorporated into history: %#v", turn)
+		}
 	}
 }
 

--- a/agent/session_communicate_test.go
+++ b/agent/session_communicate_test.go
@@ -819,6 +819,10 @@ func TestCommunicate_TerminalClientSteeringRunsAfterTheTerminalResult(t *testing
 
 	select {
 	case <-wake:
+		// The scripted in-process adapter and channel wake should complete well
+		// within this bound; 5s only fires on a genuine synchronization hang.
+		// TRIPWIRE: deterministic in-process wake, not synchronization; this
+		// bound is far above the expected completion time and catches hangs.
 	case <-time.After(5 * time.Second):
 		t.Fatal("pending steering wake did not arrive")
 	}

--- a/agent/session_communicate_test.go
+++ b/agent/session_communicate_test.go
@@ -749,6 +749,101 @@ func TestCommunicate_ClientSteeringBeforeResultProjectsValidNextRequest(t *testi
 	}
 }
 
+func TestCommunicate_TerminalClientSteeringRunsAfterTheTerminalResult(t *testing.T) {
+	t.Parallel()
+	const steerText = "commit them"
+	const firstCallID = "communicate_terminal_race"
+	const secondCallID = "communicate_steering_carrier"
+
+	reachedTool := make(chan struct{})
+	wake := make(chan struct{}, 1)
+	var sess *Session
+	var steerErr error
+	var requestErr error
+	var once sync.Once
+
+	adapter := &fakeAdapter{
+		name: "anthropic",
+		steps: []func(req llm.Request) llm.Response{
+			func(llm.Request) llm.Response {
+				return toolCallResponse(communicateCall(firstCallID, "Initial work complete."))
+			},
+			func(req llm.Request) llm.Response {
+				requestErr = validateSteeredCommunicateHistory(req.Messages, firstCallID, steerText)
+				return toolCallResponse(communicateCall(secondCallID, "Committed."))
+			},
+		},
+	}
+	client := llm.NewClient()
+	client.Register(adapter)
+
+	sess, err := NewSession(client, newAnthropicProfile("k3"), execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{
+		StateDir: t.TempDir(),
+		testOnly: testConfig{
+			execToolCheckpoint: func(name string) {
+				if name != "before_side_effects" {
+					return
+				}
+				once.Do(func() {
+					close(reachedTool)
+					_, steerErr = sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+						ClientMutationID: "steer_terminal_race",
+						Input:            []appwire.InputItem{{Type: "text", Text: steerText}},
+					})
+				})
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	t.Cleanup(sess.Close)
+	sess.SetPendingUserInputWakeFunc(func() {
+		select {
+		case wake <- struct{}{}:
+		default:
+		}
+	})
+
+	if _, err := sess.ProcessInput(context.Background(), "finish the current work", nil); err != nil {
+		t.Fatalf("first ProcessInput: %v", err)
+	}
+	if steerErr != nil {
+		t.Fatalf("AcceptClientMutationSteer: %v", steerErr)
+	}
+	select {
+	case <-reachedTool:
+	default:
+		t.Fatal("terminal communicate race checkpoint was not reached")
+	}
+
+	select {
+	case <-wake:
+	case <-time.After(5 * time.Second):
+		t.Fatal("pending steering wake did not arrive")
+	}
+	if _, ran, err := sess.ProcessPendingUserInput(context.Background(), nil); err != nil {
+		t.Fatalf("ProcessPendingUserInput: %v", err)
+	} else if !ran {
+		t.Fatal("terminal communicate consumed accepted steering; no carrier turn ran")
+	}
+	if requestErr != nil {
+		t.Fatal(requestErr)
+	}
+	if got := len(adapter.Requests()); got != 2 {
+		t.Fatalf("provider requests = %d, want initial terminal turn plus carrier turn", got)
+	}
+
+	snapshot := sess.clientMutations.snapshot()
+	if len(snapshot.PendingExecutions) != 0 || len(snapshot.SteeringOrder) != 0 {
+		t.Fatalf("client steering remains pending after carrier: pending=%v order=%v", snapshot.PendingExecutions, snapshot.SteeringOrder)
+	}
+	record := snapshot.Journal["steer_terminal_race"]
+	if record.ExecutionState != "incorporated" || record.OperationState != clientMutationOperationTerminal {
+		t.Fatalf("steering mutation state = operation=%q execution=%q, want terminal/incorporated", record.OperationState, record.ExecutionState)
+	}
+}
+
 func validateSteeredCommunicateHistory(messages []llm.Message, callID, steering string) error {
 	callIndex := -1
 	resultIndex := -1

--- a/agent/session_provenance.go
+++ b/agent/session_provenance.go
@@ -68,22 +68,35 @@ func (s *Session) drainSteeringForTurn() []steeringMessage {
 	return msgs
 }
 
-// drainSteeringForCommunicate returns the steering text delivered in a
-// terminal communicate inbox. Client-authored steering crosses the same
-// durable claim, transcript, and incorporation boundary as every other
-// steering consumer before it becomes visible in that inbox. Daemon steering
-// remains a plain queue drain so communicate can preserve its existing image
-// deferral behavior.
+// drainSteeringForCommunicate returns daemon-authored steering context for a
+// terminal communicate inbox. Client-authored steering remains durable pending
+// work for wakeForPendingSteering and EntrySteeringCarrier: marking it
+// incorporated in a result that ends the turn would create a durable transcript
+// item without a model request that can act on it.
 func (s *Session) drainSteeringForCommunicate() []steeringMessage {
-	pending := s.peekSteeringForTurn()
-	drained := make([]steeringMessage, 0, len(pending))
-	for range pending {
+	// Snapshot only the daemon-authored prefix. A client-authored entry is
+	// intentionally left in the durable queue for EntrySteeringCarrier.
+	s.mu.Lock()
+	daemon := make([]steeringMessage, 0, len(s.steeringQueue))
+	for _, msg := range s.steeringQueue {
+		if msg.ClientMutationID != "" {
+			break
+		}
+		daemon = append(daemon, msg)
+	}
+	s.mu.Unlock()
+
+	// Preserve batch-up-front provenance for the entries actually being
+	// consumed, without unioning provenance from the pending client suffix.
+	for _, msg := range daemon {
+		s.unionActiveProvenance(msg.Provenance)
+	}
+
+	drained := make([]steeringMessage, 0, len(daemon))
+	for range daemon {
 		msg, ok := s.popSteeringHead()
 		if !ok {
 			break
-		}
-		if msg.ClientMutationID != "" && !s.consumeSteeringMessage(msg) {
-			continue
 		}
 		drained = append(drained, msg)
 	}

--- a/agent/session_tool_round.go
+++ b/agent/session_tool_round.go
@@ -438,12 +438,18 @@ func (s *Session) injectPostToolSteering(ctx context.Context, calls []llm.ToolCa
 		hooks.beforeSteering()
 	}
 
-	// Inject any queued steering messages before the next model call.
+	// Inject any queued steering messages before the next model call. A terminal
+	// communicate result owns this input's boundary, so leave client-authored
+	// steering durable pending work for wakeForPendingSteering and
+	// EntrySteeringCarrier. Consuming it here would mark it incorporated in a
+	// result that ends the turn without a model request that can act on it.
 	if abortErr := s.withResponseSideEffects(ctx, func() {
-		if s.hasPendingSteering() {
-			yieldToObserverCallback = false
+		if !s.Communicated() {
+			if s.hasPendingSteering() {
+				yieldToObserverCallback = false
+			}
+			s.injectDrainedSteering()
 		}
-		s.injectDrainedSteering()
 	}); abortErr != nil {
 		s.removeAllTurnOwnedSteering()
 		return false, abortErr

--- a/agent/session_tools_communicate.go
+++ b/agent/session_tools_communicate.go
@@ -93,7 +93,7 @@ func registerCommunicateTool(reg *tool.Registry, deps *toolDeps) {
 					if strings.TrimSpace(msg.Text) != "" {
 						inbox = append(inbox, msg.Text)
 					}
-					if len(msg.Images) > 0 && msg.ClientMutationID == "" {
+					if len(msg.Images) > 0 {
 						deferred = append(deferred, msg)
 					}
 				}

--- a/agent/session_tools_communicate.go
+++ b/agent/session_tools_communicate.go
@@ -78,10 +78,14 @@ func registerCommunicateTool(reg *tool.Registry, deps *toolDeps) {
 
 			inbox := []string{}
 			if endTurn {
-				// Drain steering queue into the inbox for terminal delivery. The
-				// inbox is text-only in the wire shape, so image-bearing entries
-				// are also appended as TurnSteering to keep their ContentImage
-				// parts available to the next model round.
+				// Drain daemon-authored steering context into the terminal inbox.
+				// Client-authored steering remains durable pending work for
+				// wakeForPendingSteering and EntrySteeringCarrier: incorporating
+				// it into a result that ends the turn would create a durable
+				// transcript item without a model request that can act on it.
+				// The inbox is text-only in the wire shape, so image-bearing
+				// daemon entries are also appended as TurnSteering to keep their
+				// ContentImage parts available to the next model round.
 				drained := deps.drainSteering()
 				inbox = make([]string, 0, len(drained))
 				var deferred []steeringMessage

--- a/docs/superpowers/plans/2026-08-27-vision-model-config.md
+++ b/docs/superpowers/plans/2026-08-27-vision-model-config.md
@@ -1,0 +1,1581 @@
+# Vision Model Configuration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the image-description vision side-channel configurable through one per-session `vision_model` setting (unset / `off` / `provider/model`), exposed via CLI flag, runtime appwire mutation, hub web UI picker, and TUI `/vision-model` command.
+
+**Architecture:** The setting lives on `agent.SessionConfig` (persisted via `schema.ConfigSnapshot` + `schema.SessionMeta`, inherited by spawned children, restored on resume). The side-channel in `describeImageCall` gates on `off` and routes non-session models through a new `cheapmodel.Caller.CompleteRouted` (refusal learning + session-model fallback). Runtime changes follow the exact `thread/model/set` path: appwire method → daemon handler → `Session.SetVisionModel` → `thread/vision-model/changed` notification → hub/frontend/TUI.
+
+**Tech Stack:** Go (agent, appwire, server, hub, TUI), React/TypeScript (hub frontend, Biome + vitest).
+
+**Spec:** `docs/superpowers/specs/2026-08-27-vision-model-config-design.md`
+
+## Global Constraints
+
+- Setting values: `""` (unset: side-channel on the session's active model), `"off"` (disabled; reserved only as a bare word, case-insensitive; a ref containing `/` parses as `provider/model` first), bare `"model"` (active provider at call time), `"provider/model"` (pinned provider).
+- Default behavior with an unset setting must be byte-identical to today.
+- Tests are deterministic: scripted `llm.ProviderAdapter` at the LLM boundary; no live provider calls in the default suite; no prompt-prose assertions — assert route selection, request shape, event kinds, and structured fields.
+- Gates per AGENTS.md: `make lint`, `make vet`, `make test`; frontend: `npx biome check --write` on touched files, then `make test-web` and `make test-web-browser`.
+- Wire naming: method `thread/vision-model/set`, notification `thread/vision-model/changed`, capability `changeVisionModel`, thread payload field `visionModel` on `appwire.EvenerThread`.
+- Commit after every task with the shown message; stage only the named files.
+
+---
+
+### Task 1: `cheapmodel.Caller.CompleteRouted`
+
+**Files:**
+- Modify: `agent/internal/cheapmodel/caller.go` (`Complete`, lines 52-60)
+- Test: `agent/internal/cheapmodel/caller_test.go`
+
+**Interfaces:**
+- Consumes: existing `Caller.run`, `route{provider, model}`.
+- Produces: `func (c *Caller) CompleteRouted(ctx context.Context, profile *provider.Profile, providerName, modelID string, req llm.Request) (llm.Response, error)` — resolves and executes an explicit route with the same refusal learning and session-model fallback as `Complete`. Task 3 calls this.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `agent/internal/cheapmodel/caller_test.go` (uses the file's existing `servesOnly`, `clientWith`, and `refusal` helpers):
+
+```go
+func TestCompleteRoutedUsesTheExplicitRoute(t *testing.T) {
+	adapter := servesOnly("openai", "main", refusal(400, "The provided model identifier is invalid."))
+	caller := cheapmodel.New(clientWith(adapter))
+	profile := provider.NewOpenAIProfile("main")
+
+	resp, err := caller.CompleteRouted(context.Background(), profile, "openai", "gpt-4.1-nano", llm.Request{
+		Messages: []llm.Message{llm.User("hi")},
+	})
+	if err != nil || strings.TrimSpace(resp.Text()) != "answered" {
+		t.Fatalf("CompleteRouted = (%q, %v), want answered via fallback", resp.Text(), err)
+	}
+	// Refusal of the routed model is learned: the second call goes straight to
+	// the session model instead of re-probing.
+	if _, err := caller.CompleteRouted(context.Background(), profile, "openai", "gpt-4.1-nano", llm.Request{
+		Messages: []llm.Message{llm.User("hi")},
+	}); err != nil {
+		t.Fatalf("second CompleteRouted: %v", err)
+	}
+	if got, want := adapter.Models(), []string{"gpt-4.1-nano", "main", "main"}; !slices.Equal(got, want) {
+		t.Fatalf("models = %v, want %v", got, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./agent/internal/cheapmodel/ -run TestCompleteRoutedUsesTheExplicitRoute -v`
+Expected: FAIL — `caller.CompleteRouted undefined`.
+
+- [ ] **Step 3: Implement**
+
+In `agent/internal/cheapmodel/caller.go`, replace `Complete` (lines 52-60) with:
+
+```go
+// Complete resolves and executes a cheap-model request, falling back once to
+// the session model when the provider refuses the resolved model. It resolves
+// through the profile's cheap-model ref, which falls through to the provider's
+// default cheap model when the session configured none.
+func (c *Caller) Complete(ctx context.Context, profile *provider.Profile, req llm.Request) (llm.Response, error) {
+	cheapProvider, cheapModel := profile.CheapModelRef()
+	return c.CompleteRouted(ctx, profile, cheapProvider, cheapModel, req)
+}
+
+// CompleteRouted is Complete for an explicit route chosen by the caller rather
+// than the profile's cheap-model ref — e.g. the vision side-channel's
+// configured vision model. It shares Complete's refusal learning and
+// session-model fallback; an empty model or a route equal to the session
+// route runs on the session model.
+func (c *Caller) CompleteRouted(ctx context.Context, profile *provider.Profile, providerName, modelID string, req llm.Request) (llm.Response, error) {
+	resp, _, err := c.run(ctx, profile, route{provider: providerName, model: modelID}, req)
+	return resp, err
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./agent/internal/cheapmodel/`
+Expected: PASS (new test plus the whole package — `Complete`'s refactor is behavior-preserving).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/internal/cheapmodel/caller.go agent/internal/cheapmodel/caller_test.go
+git commit -m "cheapmodel: add CompleteRouted for caller-chosen routes"
+```
+
+---
+
+### Task 2: `VisionModel` on SessionConfig, ConfigSnapshot, and SessionMeta
+
+**Files:**
+- Modify: `agent/session_config.go` (`SessionConfig`, `toSnapshot`, `configFromSnapshot`)
+- Modify: `agent/schema/config_snapshot.go` (`ConfigSnapshot`, line 13)
+- Modify: `agent/schema/` SessionMeta definition (the file declaring `SessionMeta`; populated in `agent/session_state.go:141-149`)
+- Modify: `agent/session_state.go:141-149`
+
+**Interfaces:**
+- Produces: `SessionConfig.VisionModel string `json:"vision_model,omitempty"``, mirrored on `schema.ConfigSnapshot.VisionModel` and `schema.SessionMeta.VisionModel`. Tasks 3, 4, 7, 8, 9 consume these.
+
+- [ ] **Step 1: Add the schema field and run the converter round-trip test to watch it fail**
+
+In `agent/schema/config_snapshot.go`, add to `ConfigSnapshot` after the `SandboxNet` field:
+
+```go
+	VisionModel                 string                     `json:"vision_model,omitempty"`                 // vision side-channel routing: "" | "off" | "model" | "provider/model"
+```
+
+(Align the comment column with the file's existing gofmt alignment by running `gofmt -w agent/schema/config_snapshot.go`.)
+
+Run: `go test ./agent/ -run 'RoundTrip|Snapshot' -v`
+Expected: FAIL — the round-trip converter test (the one guarding that `toSnapshot`/`configFromSnapshot` mirror `ConfigSnapshot` exactly) reports the unmirrored `VisionModel` field.
+
+- [ ] **Step 2: Add the SessionConfig field and converters**
+
+In `agent/session_config.go`, add to `SessionConfig` after `SandboxNet` (after line 226):
+
+```go
+	// VisionModel routes the image-description vision side-channel: "" uses the
+	// session's active model (the default), "off" disables the side-channel, a
+	// bare model resolves on the active provider at call time, and
+	// "provider/model" pins a provider instance. Runtime changes go through
+	// Session.SetVisionModel, which writes this same field under s.mu.
+	VisionModel string `json:"vision_model,omitempty"`
+```
+
+Add `VisionModel: c.VisionModel,` to `toSnapshot` (after `SandboxNet: c.SandboxNet,`) and `VisionModel: s.VisionModel,` to `configFromSnapshot` (after `SandboxNet: s.SandboxNet,`).
+
+Run: `go test ./agent/ -run 'RoundTrip|Snapshot' -v`
+Expected: PASS.
+
+- [ ] **Step 3: Persist on SessionMeta**
+
+In the `agent/schema` file declaring `SessionMeta` (the struct `agent/session_state.go:141-149` populates, next to its `CheapModel` field), add:
+
+```go
+	VisionModel string `json:"vision_model,omitempty"`
+```
+
+In `agent/session_state.go`, add to the `SessionMeta{...}` literal after `CheapModel: s.profile.CheapModelRefString(),`:
+
+```go
+		VisionModel:              s.cfg.VisionModel,
+```
+
+Run `gofmt -w agent/session_state.go agent/schema/` to realign the literal.
+
+- [ ] **Step 4: Run the schema and persistence tests**
+
+Run: `go test ./agent/schema/ ./agent/ -run 'Snapshot|SessionMeta|Meta' `
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/session_config.go agent/schema/config_snapshot.go agent/schema/ agent/session_state.go
+git commit -m "agent: add vision_model to SessionConfig, ConfigSnapshot, and SessionMeta"
+```
+
+---
+
+### Task 3: `describeImageCall` off-gate and routed execution
+
+**Files:**
+- Modify: `agent/session_tools.go` (`describeImageCall`, lines 387-495; new helpers beside it)
+- Test: `agent/session_vision_model_test.go` (create)
+
+**Interfaces:**
+- Consumes: `cheapmodel.Caller.CompleteRouted` (Task 1); `SessionConfig.VisionModel` (Task 2); the session's `s.cheap` caller (the field `tool_web_fetch.go:196` uses).
+- Produces:
+  - `const visionModelOff = "off"` — the reserved sentinel, compared case-insensitively.
+  - `func resolveVisionRoute(profile *provider.Profile, setting string) (providerName, modelID string, off bool)` — `""` → session route; `off` → `off=true`; `provider/model` → pinned route; bare → active-provider route.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `agent/session_vision_model_test.go` (package `agent`, mirroring `cov_s3_vision_test.go`'s `s3cov_visionSession` helper and `fakeAdapter`):
+
+```go
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"primeradiant.com/evener/agent/internal/tool"
+	"primeradiant.com/evener/llm"
+)
+
+func visionImageResult() tool.ExecResult {
+	return tool.ExecResult{ImageData: []byte("fake-png"), ImageMediaType: "image/png", ImagePurpose: "describe it"}
+}
+
+func TestDescribeImage_OffMakesNoCall(t *testing.T) {
+	t.Parallel()
+	called := false
+	sess := s3cov_visionSession(t, SessionConfig{VisionModel: "off"}, func(req llm.Request) llm.Response {
+		called = true
+		return llm.Response{Message: llm.Assistant("vision")}
+	})
+	if got := sess.describeImage(context.Background(), visionImageResult()); got != "" {
+		t.Fatalf("off description = %q, want empty", got)
+	}
+	if called {
+		t.Fatal("off made a vision call")
+	}
+}
+
+func TestResolveVisionRoute(t *testing.T) {
+	t.Parallel()
+	profile := NewOpenAIProfile("session-model")
+	cases := []struct {
+		setting                        string
+		wantProvider, wantModel, wantOff any
+	}{}
+	_ = cases
+	if p, m, off := resolveVisionRoute(profile, ""); p != profile.ID() || m != "session-model" || off {
+		t.Fatalf("unset = (%q, %q, %v), want session route", p, m, off)
+	}
+	if _, _, off := resolveVisionRoute(profile, "OFF"); !off {
+		t.Fatal("OFF (case-insensitive) must be the off sentinel")
+	}
+	if p, m, off := resolveVisionRoute(profile, "anthropic/claude-x"); p != "anthropic" || m != "claude-x" || off {
+		t.Fatalf("pinned = (%q, %q, %v)", p, m, off)
+	}
+	if p, m, off := resolveVisionRoute(profile, "other-model"); p != profile.ID() || m != "other-model" || off {
+		t.Fatalf("bare = (%q, %q, %v), want active provider", p, m, off)
+	}
+	if p, m, off := resolveVisionRoute(profile, "/"); p != profile.ID() || m != "/" || off {
+		t.Fatalf("malformed = (%q, %q, %v), want bare fallback", p, m, off)
+	}
+}
+```
+
+(Delete the `cases` placeholder lines — they exist only to keep this snippet's structure obvious; the assertions below them are the test.)
+
+```go
+func TestDescribeImage_RoutesToConfiguredProvider(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	openai := &fakeAdapter{name: "openai", steps: []func(req llm.Request) llm.Response{
+		func(req llm.Request) llm.Response { return llm.Response{Message: llm.Assistant("session-vision")} },
+	}}
+	anthropic := &fakeAdapter{name: "anthropic", steps: []func(req llm.Request) llm.Response{
+		func(req llm.Request) llm.Response { return llm.Response{Message: llm.Assistant("routed-vision")} },
+	}}
+	c := llm.NewClient()
+	c.Register(openai)
+	c.Register(anthropic)
+	sess, err := NewSession(c, NewOpenAIProfile("m"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir, VisionModel: "anthropic/claude-x"})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	t.Cleanup(func() { sess.Close() })
+	go func() {
+		for range sess.Events() {
+		}
+	}()
+
+	if got := sess.describeImage(context.Background(), visionImageResult()); got != "routed-vision" {
+		t.Fatalf("routed description = %q", got)
+	}
+	if len(openai.Requests()) != 0 {
+		t.Fatal("session provider received a vision call despite the pinned route")
+	}
+	reqs := anthropic.Requests()
+	if len(reqs) != 1 || reqs[0].Model != "claude-x" {
+		t.Fatalf("anthropic requests = %#v, want one claude-x call", reqs)
+	}
+}
+```
+
+Add `"primeradiant.com/evener/agent/execenv"` to the imports of the new file.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./agent/ -run 'TestDescribeImage_OffMakesNoCall|TestResolveVisionRoute|TestDescribeImage_RoutesToConfiguredProvider' -v`
+Expected: FAIL — `resolveVisionRoute undefined` and `off` not honored.
+
+- [ ] **Step 3: Implement**
+
+In `agent/session_tools.go`, beside `describeImageCall`:
+
+```go
+// visionModelOff is the reserved bare-word setting that disables the vision
+// side-channel. Only a slash-free value can be the sentinel: a value with a
+// slash always parses as "provider/model", so a provider named "off" stays
+// reachable as "off/some-model".
+const visionModelOff = "off"
+
+// resolveVisionRoute maps the session's vision_model setting to the route the
+// side-channel executes on. "" resolves to the session's active route, "off"
+// (case-insensitive) disables the call, "provider/model" pins a provider, and
+// a bare model resolves on the active provider at call time — so it follows
+// SetModel switches. A malformed "x/" or "/x" value degrades to a bare-model
+// lookup on the active provider rather than an unroutable request.
+func resolveVisionRoute(profile *provider.Profile, setting string) (providerName, modelID string, off bool) {
+	setting = strings.TrimSpace(setting)
+	if setting == "" {
+		return profile.ID(), profile.Model(), false
+	}
+	if strings.EqualFold(setting, visionModelOff) {
+		return "", "", true
+	}
+	if prov, model, ok := strings.Cut(setting, "/"); ok && prov != "" && model != "" {
+		return prov, model, false
+	}
+	return profile.ID(), setting, false
+}
+
+// visionRouteSupportsReasoning gates reasoning_effort for the vision request:
+// the session route uses the profile's own answer (which may carry live
+// provider metadata); any other route answers from the embedded catalog, and
+// an uncatalogued model gets no effort knob rather than one it may reject.
+func visionRouteSupportsReasoning(profile *provider.Profile, providerName, modelID string) bool {
+	if providerName == profile.ID() && modelID == profile.Model() {
+		return profile.SupportsReasoning()
+	}
+	if cat := llm.EmbeddedModelCatalog(); cat != nil {
+		if mi := cat.LookupModelInfo(modelID); mi != nil {
+			return mi.SupportsReasoning
+		}
+	}
+	return false
+}
+```
+
+In `describeImageCall`, extend the profile snapshot (lines 427-429) and branch:
+
+```go
+	s.mu.Lock()
+	profile := s.profile
+	visionSetting := s.cfg.VisionModel
+	s.mu.Unlock()
+
+	routeProvider, routeModel, visionOff := resolveVisionRoute(profile, visionSetting)
+	if visionOff {
+		return visionSideChannelResult{outcome: visionSideChannelSuccess}
+	}
+```
+
+(Move this block above the prompt/media-part construction so `off` skips all of it; the prompt and media-part code then runs unchanged.)
+
+Replace the reasoning-effort block (lines 458-461) with:
+
+```go
+	if visionRouteSupportsReasoning(profile, routeProvider, routeModel) {
+		levels := profile.ReasoningEffortLevels()
+		if routeProvider != profile.ID() || routeModel != profile.Model() {
+			if cat := llm.EmbeddedModelCatalog(); cat != nil {
+				if mi := cat.LookupModelInfo(routeModel); mi != nil && len(mi.ReasoningEffortLevels) > 0 {
+					levels = mi.ReasoningEffortLevels
+				}
+			}
+		}
+		effort := llm.ClampReasoningEffort(visionReasoningEffort, levels)
+		req.ReasoningEffort = &effort
+	}
+```
+
+Replace the direct call (line 465) with the routed caller:
+
+```go
+	resp, err := s.cheap.CompleteRouted(visionCtx, profile, routeProvider, routeModel, req)
+```
+
+Check `session_tools.go` imports `"primeradiant.com/evener/agent/provider"` (needed for the helper signatures); add it if absent.
+
+- [ ] **Step 4: Run the vision tests**
+
+Run: `go test ./agent/ -run 'Vision|DescribeImage' -v`
+Expected: PASS — new tests plus every pre-existing vision test (unset behavior is unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/session_tools.go agent/session_vision_model_test.go
+git commit -m "agent: gate vision side-channel on vision_model and route it through cheapmodel"
+```
+
+---
+
+### Task 4: `Session.SetVisionModel`, getter, and `EventVisionModelChanged`
+
+**Files:**
+- Modify: `agent/session.go` (new methods beside `SetModel`, line 1092)
+- Modify: `agent/events/events.go` (kind const beside `EventModelChanged`, line 77)
+- Modify: `agent/events/payloads.go` (data struct beside `ModelChangedData`, line 448)
+- Modify: `agent/events/eventdata.go` (`eventKind()` mapping + `EventData` assertion list, lines 61, 116)
+- Test: `agent/session_vision_model_test.go` (append)
+
+**Interfaces:**
+- Consumes: `SessionConfig.VisionModel` (Task 2); `visionModelOff` (Task 3).
+- Produces:
+  - `func (s *Session) SetVisionModel(ref string) error` — validates and stores the setting, emits the event.
+  - `func (s *Session) VisionModel() string` — current setting for thread-read snapshots.
+  - `events.EventVisionModelChanged` + `events.VisionModelChangedData{OldVisionModel, NewVisionModel string}`. Task 6 maps this event to the wire.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `agent/session_vision_model_test.go`:
+
+```go
+func TestSetVisionModelValidatesAndEmits(t *testing.T) {
+	t.Parallel()
+	sess := s3cov_visionSession(t, SessionConfig{}, func(req llm.Request) llm.Response {
+		return llm.Response{Message: llm.Assistant("vision")}
+	})
+
+	if err := sess.SetVisionModel("anthropic/claude-x"); err == nil {
+		t.Fatal("unregistered cross-provider ref must fail")
+	}
+	if got := sess.VisionModel(); got != "" {
+		t.Fatalf("failed set changed the setting to %q", got)
+	}
+	if err := sess.SetVisionModel("off/some-model"); err != nil {
+		t.Fatalf("a provider named off stays reachable as a ref: %v", err)
+	}
+}
+
+func TestSetVisionModelStoresAndEmitsEvent(t *testing.T) {
+	t.Parallel()
+	sess := s3cov_visionSession(t, SessionConfig{}, func(req llm.Request) llm.Response {
+		return llm.Response{Message: llm.Assistant("vision")}
+	})
+	var sawEvent bool
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for ev := range sess.Events() {
+			if ev.Kind == events.EventVisionModelChanged {
+				if d, ok := ev.Data.(events.VisionModelChangedData); ok && d.NewVisionModel == "off" && d.OldVisionModel == "" {
+					sawEvent = true
+				}
+			}
+		}
+	}()
+
+	if err := sess.SetVisionModel("off"); err != nil {
+		t.Fatalf("SetVisionModel(off): %v", err)
+	}
+	if got := sess.VisionModel(); got != "off" {
+		t.Fatalf("VisionModel() = %q, want off", got)
+	}
+	if got := sess.cfg.toSnapshot().VisionModel; got != "off" {
+		t.Fatalf("snapshot VisionModel = %q, want off (persistence rides the snapshot)", got)
+	}
+	if err := sess.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	<-done
+	if !sawEvent {
+		t.Fatal("no EventVisionModelChanged emitted")
+	}
+}
+```
+
+Add `"primeradiant.com/evener/agent/events"` to the test file's imports. Note: `s3cov_visionSession`'s client registers only the `openai` fakeAdapter, which is why `"anthropic/claude-x"` must fail and `"off/some-model"` — a ref whose provider is literally `off` — must also fail... unless the test's intent is clearer with a registered provider. Adjust the first test: keep `"anthropic/claude-x"` expecting failure, and replace the `off/some-model` case with a malformed-ref case:
+
+```go
+	if err := sess.SetVisionModel("anthropic/"); err == nil {
+		t.Fatal("malformed ref with an empty model must fail")
+	}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./agent/ -run 'TestSetVisionModel' -v`
+Expected: FAIL — `SetVisionModel`, `VisionModel`, and `events.EventVisionModelChanged` undefined.
+
+- [ ] **Step 3: Implement the event**
+
+In `agent/events/events.go` after `EventReasoningEffortChanged` (line 80):
+
+```go
+	// EventVisionModelChanged reports that SetVisionModel committed a change to
+	// the vision side-channel routing.
+	EventVisionModelChanged EventKind = "VISION_MODEL_CHANGED"
+```
+
+In `agent/events/payloads.go` after `ModelChangedData`:
+
+```go
+// VisionModelChangedData is the payload for an EventVisionModelChanged event:
+// SetVisionModel committed a new vision side-channel setting ("", "off", or a
+// model ref). Old and new let subscribers diff the change.
+type VisionModelChangedData struct {
+	OldVisionModel string `json:"old_vision_model"`
+	NewVisionModel string `json:"new_vision_model"`
+}
+```
+
+In `agent/events/eventdata.go`, add beside the `ModelChangedData` mapping (line 61):
+
+```go
+func (VisionModelChangedData) eventKind() EventKind  { return EventVisionModelChanged }
+```
+
+and add `_ EventData = VisionModelChangedData{}` to the assertion list beside line 116. Run `gofmt -w agent/events/` to align the mapping block.
+
+- [ ] **Step 4: Implement the session methods**
+
+In `agent/session.go` beside `SetModel`:
+
+```go
+// SetVisionModel changes the vision side-channel routing for future image
+// reads. The ref is "" (describe with the session's active model), "off"
+// (disable the side-channel), a bare model on the active provider, or
+// "provider/model" to pin a provider instance, which must be registered in
+// the client. It takes effect on the next image read and persists with the
+// session config; it never alters the active model itself.
+func (s *Session) SetVisionModel(ref string) error {
+	ref = strings.TrimSpace(ref)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closingOrClosedLocked() {
+		return nil
+	}
+	if err := s.validateVisionModelRefLocked(ref); err != nil {
+		return err
+	}
+	old := s.cfg.VisionModel
+	if old == ref {
+		return nil
+	}
+	s.cfg.VisionModel = ref
+	s.emit(events.EventVisionModelChanged, events.VisionModelChangedData{OldVisionModel: old, NewVisionModel: ref})
+	return nil
+}
+
+func (s *Session) validateVisionModelRefLocked(ref string) error {
+	if ref == "" || strings.EqualFold(ref, visionModelOff) {
+		return nil
+	}
+	prov, model, ok := strings.Cut(ref, "/")
+	if ok && (prov == "" || model == "") {
+		return fmt.Errorf("invalid vision model ref %q: want \"model\" or \"provider/model\"", ref)
+	}
+	if ok && !strings.EqualFold(prov, s.profile.ID()) && !sessionClientHasProvider(s.client, prov) {
+		return fmt.Errorf("vision model provider %q is not configured or has no credential (active provider %q)", prov, s.profile.ID())
+	}
+	return nil
+}
+
+func sessionClientHasProvider(client *llm.Client, name string) bool {
+	if client == nil {
+		return false
+	}
+	for _, p := range client.ProviderNames() {
+		if strings.EqualFold(p, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// VisionModel returns the session's configured vision side-channel setting
+// ("", "off", or a model ref) for thread-read snapshots.
+func (s *Session) VisionModel() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cfg.VisionModel
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `go test ./agent/ -run 'TestSetVisionModel' -v && go test ./agent/events/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/session.go agent/events/events.go agent/events/payloads.go agent/events/eventdata.go agent/session_vision_model_test.go
+git commit -m "agent: add Session.SetVisionModel with VISION_MODEL_CHANGED event"
+```
+
+---
+
+### Task 5: Appwire protocol — method, notification, capability, thread field, client method
+
+**Files:**
+- Modify: `appwire/types.go` (method consts near line 35, notification consts near line 115, `ThreadCapabilities` line 501, `EvenerThread` line 272, params beside `ThreadReasoningEffortSetParams` line 1268)
+- Modify: `appwire/client.go` (beside `ThreadReasoningEffortSet`, line 406)
+- Test: `appwire/types_test.go` and/or `appwire/client_test.go` (existing decode/client patterns)
+
+**Interfaces:**
+- Produces (all consumed by Tasks 6, 7, 9, 10, 12):
+  - `MethodThreadVisionModelSet = "thread/vision-model/set"`
+  - `NotifyThreadVisionModelChanged = "thread/vision-model/changed"`
+  - `ThreadVisionModelSetParams{Ref string, VisionModel string}`
+  - `ThreadVisionModelChangedParams{ThreadID string, Ref string, VisionModel string}`
+  - `ThreadCapabilities.ChangeVisionModel bool `json:"changeVisionModel"``
+  - `EvenerThread.VisionModel string `json:"visionModel,omitempty"``
+  - `func (c *Client) ThreadVisionModelSet(ctx context.Context, params ThreadVisionModelSetParams) error`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `appwire/types_test.go` (mirroring an existing params-decode test):
+
+```go
+func TestThreadVisionModelSetParamsDecode(t *testing.T) {
+	raw := []byte(`{"ref":"local:01X","visionModel":"anthropic/claude-haiku-4-5"}`)
+	var p ThreadVisionModelSetParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Ref != "local:01X" || p.VisionModel != "anthropic/claude-haiku-4-5" {
+		t.Fatalf("params = %+v", p)
+	}
+}
+```
+
+(Adjust to the file's existing import set and test style; if the file already imports `encoding/json` and uses this shape, it drops in unchanged.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./appwire/ -run TestThreadVisionModelSetParamsDecode -v`
+Expected: FAIL — `ThreadVisionModelSetParams` undefined.
+
+- [ ] **Step 3: Implement the types**
+
+In `appwire/types.go`:
+
+After `MethodThreadReasoningEffortSet` (line 36):
+
+```go
+	MethodThreadVisionModelSet      = "thread/vision-model/set"
+```
+
+After `NotifyThreadReasoningEffortChanged` (line 115):
+
+```go
+	// NotifyThreadVisionModelChanged pushes a mid-session vision-model change.
+	// See ThreadVisionModelChangedParams.
+	NotifyThreadVisionModelChanged = "thread/vision-model/changed"
+```
+
+In `ThreadCapabilities` after `ChangeModel` (line 509):
+
+```go
+	// ChangeVisionModel advertises support for thread/vision-model/set. True for
+	// a live evener session whose daemon wires a vision-model hook.
+	ChangeVisionModel bool `json:"changeVisionModel"`
+```
+
+In `EvenerThread` after `SupportsReasoning` (line 374):
+
+```go
+	// VisionModel is the session's vision side-channel setting: "" describes
+	// with the session model, "off" disables the side-channel, anything else is
+	// a model ref. Snapshot-only like the effort fields beside it; live updates
+	// arrive as thread/vision-model/changed.
+	VisionModel string `json:"visionModel,omitempty"`
+```
+
+After `ThreadReasoningEffortSetParams` (line 1271):
+
+```go
+// ThreadVisionModelSetParams sets the vision side-channel routing on a running
+// session. VisionModel carries the whole setting: "" describes with the
+// session's active model, "off" disables the side-channel, and any other value
+// is a "model" or "provider/model" ref — a single string because a
+// provider/model split cannot express the first two states.
+type ThreadVisionModelSetParams struct {
+	Ref         string `json:"ref"`
+	VisionModel string `json:"visionModel"`
+}
+
+// ThreadVisionModelChangedParams reports a mid-session vision-model change.
+type ThreadVisionModelChangedParams struct {
+	ThreadID    string `json:"threadId"`
+	Ref         string `json:"ref"`
+	VisionModel string `json:"visionModel"`
+}
+```
+
+In `appwire/client.go` after `ThreadReasoningEffortSet` (line 408):
+
+```go
+func (c *Client) ThreadVisionModelSet(ctx context.Context, params ThreadVisionModelSetParams) error {
+	return c.request(ctx, MethodThreadVisionModelSet, params, nil)
+}
+```
+
+Run `gofmt -w appwire/`.
+
+- [ ] **Step 4: Run the appwire tests**
+
+Run: `go test ./appwire/...`
+Expected: PASS. If a fuzz-golden test (e.g. `FuzzMethodParams` goldens) fails because the new types extend the decode surface, regenerate goldens with the repo's mechanism: `make fuzz-goldens`, rerun, and stage the changed golden files.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add appwire/types.go appwire/client.go appwire/types_test.go
+git commit -m "appwire: add thread/vision-model/set + /changed and visionModel thread field"
+```
+
+---
+
+### Task 6: Projector — map `EventVisionModelChanged` to `thread/vision-model/changed`
+
+**Files:**
+- Modify: `internal/appprojector/` (the projector file containing the `EventReasoningEffortChanged` case exercised by `appwire_projection_test.go:100-116`)
+- Test: `internal/appprojector/appwire_projection_test.go`
+
+**Interfaces:**
+- Consumes: `events.EventVisionModelChanged` + `VisionModelChangedData` (Task 4); `appwire.NotifyThreadVisionModelChanged` + `ThreadVisionModelChangedParams` (Task 5).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/appprojector/appwire_projection_test.go`, mirroring `TestProject_ReasoningEffortChanged` (lines 100-116):
+
+```go
+func TestProject_VisionModelChanged(t *testing.T) {
+	p := NewAppEventProjector("th1", "local:th1")
+	out := p.Project(events.SessionEvent{
+		Kind: events.EventVisionModelChanged,
+		Data: events.VisionModelChangedData{OldVisionModel: "", NewVisionModel: "off"},
+	})
+	if len(out) != 1 || out[0].Method != appwire.NotifyThreadVisionModelChanged {
+		t.Fatalf("want one thread/vision-model/changed notification, got %+v", out)
+	}
+	params, ok := out[0].Params.(appwire.ThreadVisionModelChangedParams)
+	if !ok {
+		t.Fatalf("params type = %T, want appwire.ThreadVisionModelChangedParams", out[0].Params)
+	}
+	if params.ThreadID != "th1" || params.Ref != "local:th1" || params.VisionModel != "off" {
+		t.Fatalf("params = %+v", params)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/appprojector/ -run TestProject_VisionModelChanged -v`
+Expected: FAIL — zero notifications projected for the unknown kind.
+
+- [ ] **Step 3: Implement**
+
+In the projector's `Project` switch, beside the `EventReasoningEffortChanged` case (the one producing `NotifyThreadReasoningEffortChanged` with the projector's thread id/ref):
+
+```go
+	case events.EventVisionModelChanged:
+		d, ok := ev.Data.(events.VisionModelChangedData)
+		if !ok {
+			return nil
+		}
+		return []AppNotification{{
+			Method: appwire.NotifyThreadVisionModelChanged,
+			Params: appwire.ThreadVisionModelChangedParams{
+				ThreadID:    p.threadID,
+				Ref:         p.ref,
+				VisionModel: d.NewVisionModel,
+			},
+		}}
+```
+
+Match the exact names of the projector's id/ref fields and its notification slice type to the neighboring `EventReasoningEffortChanged` case — copy that case's shape verbatim and change only the kind, method, and params.
+
+- [ ] **Step 4: Run the projector tests**
+
+Run: `go test ./internal/appprojector/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/appprojector/
+git commit -m "appprojector: project VISION_MODEL_CHANGED to thread/vision-model/changed"
+```
+
+---
+
+### Task 7: Daemon — handler, hook, capability, thread/read field
+
+**Files:**
+- Modify: `server/appwire_runtime.go` (register the handler beside line 531; new `handleAppThreadVisionModelSet` beside line 1032; capability beside line 1412)
+- Modify: `server/server.go` (`SetVisionModelFunc` beside `SetModelFunc`, line 615; new `visionModelFunc` field beside `modelFunc`)
+- Modify: `server/server_handlers.go` (capability beside line 354)
+- Modify: the two `EvenerThread` producers — `server/appwire_runtime.go`'s envelope builder and `cmd/evener/serve.go`'s evener-thread builder (both surfaced by `rg "ReasoningEffort:" server/ cmd/evener/`)
+- Modify: `cmd/evener/serve.go` and `cmd/evener/run.go` (wire the hook beside the existing `SetModelFunc` wiring)
+- Test: `server/model_set_test.go` (append; it has the exact mid-turn/reserved/hook-error patterns)
+
+**Interfaces:**
+- Consumes: `Session.SetVisionModel` / `Session.VisionModel` (Task 4); appwire types (Task 5).
+- Produces: `func (s *Server) SetVisionModelFunc(fn func(string) error)`; daemon thread reads carry `visionModel` and `changeVisionModel` (Task 9 and the frontends consume).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `server/model_set_test.go`, mirroring its three existing tests:
+
+```go
+func TestHandleAppThreadVisionModelSet_RejectsWhileProcessing(t *testing.T) {
+	s := NewServer(ServerConfig{})
+	called := false
+	s.SetVisionModelFunc(func(string) error { called = true; return nil })
+	s.SetProcessing(true)
+
+	if _, err := s.handleAppThreadVisionModelSet(context.Background(), appwire.ThreadVisionModelSetParams{Ref: "local:x", VisionModel: "off"}); err == nil {
+		t.Fatal("expected an error while a turn is processing")
+	}
+	if called {
+		t.Fatal("vision-model hook must not be invoked while a turn is active")
+	}
+}
+
+func TestHandleAppThreadVisionModelSet_HookReceivesTheSetting(t *testing.T) {
+	s := NewServer(ServerConfig{})
+	var got string
+	s.SetVisionModelFunc(func(v string) error { got = v; return nil })
+
+	if _, err := s.handleAppThreadVisionModelSet(context.Background(), appwire.ThreadVisionModelSetParams{Ref: "local:x", VisionModel: "anthropic/claude-x"}); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if got != "anthropic/claude-x" {
+		t.Fatalf("hook got %q, want the ref unchanged", got)
+	}
+}
+
+func TestHandleAppThreadVisionModelSet_HookErrorSurfacesAsWireError(t *testing.T) {
+	s := NewServer(ServerConfig{})
+	s.SetVisionModelFunc(func(string) error { return errors.New("vision model provider \"nope\" is not configured") })
+
+	if _, err := s.handleAppThreadVisionModelSet(context.Background(), appwire.ThreadVisionModelSetParams{Ref: "local:x", VisionModel: "nope/m"}); err == nil {
+		t.Fatal("hook error must surface")
+	}
+}
+```
+
+Check the test file's existing imports (`errors`, `context`, `appwire`) and the exact `Ref` value its other tests use (`requireRootMutationTarget` accepts `local:` refs); mirror them.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./server/ -run 'TestHandleAppThreadVisionModelSet' -v`
+Expected: FAIL — `SetVisionModelFunc` / `handleAppThreadVisionModelSet` undefined.
+
+- [ ] **Step 3: Implement the server pieces**
+
+In `server/server.go`, beside `modelFunc` and `SetModelFunc` (line 614-619):
+
+```go
+// SetVisionModelFunc sets the function called by thread/vision-model/set.
+func (s *Server) SetVisionModelFunc(fn func(string) error) {
+	s.mu.Lock()
+	s.visionModelFunc = fn
+	s.mu.Unlock()
+}
+```
+
+(Add the `visionModelFunc func(string) error` field beside `modelFunc` in the Server struct.)
+
+In `server/appwire_runtime.go`, register beside line 531:
+
+```go
+	appserver.HandleTyped(router, appwire.MethodThreadVisionModelSet, s.handleAppThreadVisionModelSet)
+```
+
+Add the handler beside `handleAppThreadModelSet` (line 1032), mirroring its mid-turn gate and error mapping:
+
+```go
+func (s *Server) handleAppThreadVisionModelSet(_ context.Context, params appwire.ThreadVisionModelSetParams) (appwire.EmptyResponse, error) {
+	if err := s.requireRootMutationTarget(params.Ref, ""); err != nil {
+		return appwire.EmptyResponse{}, err
+	}
+	s.mu.RLock()
+	processing := s.processing
+	reservedTurnID := strings.TrimSpace(s.appReservedTurnID)
+	fn := s.visionModelFunc
+	s.mu.RUnlock()
+	if processing || reservedTurnID != "" {
+		msg := "session is processing"
+		if reservedTurnID != "" {
+			msg = "turn " + reservedTurnID + " is active"
+		}
+		return appwire.EmptyResponse{}, appwire.Conflict(msg)
+	}
+	if fn == nil {
+		return appwire.EmptyResponse{}, appwire.Unavailable("vision model change not available")
+	}
+	// "" and "off" are legitimate setting values (session-model and disabled),
+	// so unlike model/set there is no empty-value rejection here; ref shape is
+	// the session's job to validate (Session.SetVisionModel).
+	if err := fn(params.VisionModel); err != nil {
+		return appwire.EmptyResponse{}, appwire.InvalidParams(err.Error())
+	}
+	return appwire.EmptyResponse{}, nil
+}
+```
+
+Add `ChangeVisionModel: s.visionModelFunc != nil && !closed,` beside both `ChangeModel:` capability sites (`server/server_handlers.go:354` and `server/appwire_runtime.go:1412`).
+
+- [ ] **Step 4: Populate `visionModel` on thread reads**
+
+At each `EvenerThread{...}` producer (the envelope in `server/appwire_runtime.go` and the evener-thread builder in `cmd/evener/serve.go` — the two hits from `rg "ReasoningEffort:" server/ cmd/evener/`), add `VisionModel` beside the `ReasoningEffort` assignment, sourced from the same session-status path that supplies `ReasoningEffort`. If that path is a struct (e.g. a server status/info struct), add a `VisionModel string` field to it and populate it from `Session.VisionModel()` in `cmd/evener`'s agent→server mapping, exactly the hop `ReasoningEffort` takes.
+
+- [ ] **Step 5: Wire the hook in the daemon**
+
+In `cmd/evener/serve.go` and `cmd/evener/run.go`, beside the existing `srv.SetModelFunc(...)` wiring (which passes `sess.SetModel` or an equivalent closure), add:
+
+```go
+	srv.SetVisionModelFunc(sess.SetVisionModel)
+```
+
+(Use the same session variable the `SetModelFunc` call uses.)
+
+- [ ] **Step 6: Run the server and daemon tests**
+
+Run: `go test ./server/ ./cmd/evener/ -run 'VisionModel|ModelSet|ThreadRead|Capabilities' -v` then `go test ./server/`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/ cmd/evener/serve.go cmd/evener/run.go
+git commit -m "server: handle thread/vision-model/set with capability and thread-read field"
+```
+
+---
+
+### Task 8: CLI `--vision-model` flag
+
+**Files:**
+- Modify: `cmd/evener/main.go` (`runCLIFlags` line 30-32; flag registration beside line 250; `runConfig` call beside line 200)
+- Modify: `cmd/evener/run.go` (`runConfig` struct + SessionConfig construction beside line 247)
+- Modify: `cmd/evener/serve.go` (flag registration + SessionConfig construction beside line 417; `applyVisionModel` beside `applyFastCheapModel`, line 1248)
+- Test: `cmd/evener/serve_fast_cheap_model_test.go` (append — it has `clientWithProviders` and the cross-provider test patterns)
+
+**Interfaces:**
+- Consumes: `SessionConfig.VisionModel` (Task 2); `clientHasProvider` (existing, serve.go:1262).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `cmd/evener/serve_fast_cheap_model_test.go`, mirroring its existing tests:
+
+```go
+func TestApplyVisionModel_PassthroughStates(t *testing.T) {
+	profile := NewOpenAIProfile("gpt-5.2")
+	for _, raw := range []string{"", "off", "OFF", "gpt-4.1-mini", "openai/gpt-4.1-mini"} {
+		got, err := applyVisionModel(profile, raw, clientWithProviders("openai"))
+		if err != nil {
+			t.Fatalf("applyVisionModel(%q): %v", raw, err)
+		}
+		want := raw
+		if raw == "OFF" {
+			want = "off" // sentinel canonicalizes to lowercase
+		}
+		if got != want {
+			t.Fatalf("applyVisionModel(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}
+
+func TestApplyVisionModel_CrossProviderWhenRegistered(t *testing.T) {
+	profile := NewOpenAIProfile("gpt-5.2")
+	got, err := applyVisionModel(profile, "anthropic/claude-haiku-4-5", clientWithProviders("openai", "anthropic"))
+	if err != nil {
+		t.Fatalf("applyVisionModel: %v", err)
+	}
+	if got != "anthropic/claude-haiku-4-5" {
+		t.Fatalf("got %q", got)
+	}
+	if profile.Model() != "gpt-5.2" {
+		t.Fatal("applyVisionModel must not touch the active profile")
+	}
+}
+
+func TestApplyVisionModel_CrossProviderRejectedWhenNotRegistered(t *testing.T) {
+	profile := NewOpenAIProfile("gpt-5.2")
+	if _, err := applyVisionModel(profile, "anthropic/claude-x", clientWithProviders("openai")); err == nil {
+		t.Fatal("unregistered cross-provider ref must fail")
+	}
+}
+
+func TestApplyVisionModel_MalformedRef(t *testing.T) {
+	profile := NewOpenAIProfile("gpt-5.2")
+	for _, raw := range []string{"anthropic/", "/claude-x"} {
+		if _, err := applyVisionModel(profile, raw, clientWithProviders("openai", "anthropic")); err == nil {
+			t.Fatalf("malformed ref %q must fail", raw)
+		}
+	}
+}
+```
+
+(Use the test file's own profile constructor and `clientWithProviders` helper names — mirror its imports.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./cmd/evener/ -run 'TestApplyVisionModel' -v`
+Expected: FAIL — `applyVisionModel` undefined.
+
+- [ ] **Step 3: Implement `applyVisionModel` and the flag**
+
+In `cmd/evener/serve.go` beside `applyFastCheapModel`:
+
+```go
+// applyVisionModel validates the --vision-model ref against the registered
+// providers and returns the canonical SessionConfig.VisionModel value. "off"
+// (canonicalized to lowercase) disables the side-channel, a bare model keeps
+// the active provider, and "provider/model" pins a provider that must be
+// registered (configured AND credentialed) — the same rule --fast-cheap-model
+// enforces. The active profile is never touched.
+func applyVisionModel(profile *provider.Profile, raw string, client *llm.Client) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil
+	}
+	if strings.EqualFold(raw, "off") {
+		return "off", nil
+	}
+	if prov, model, ok := strings.Cut(raw, "/"); ok {
+		if prov == "" || model == "" {
+			return "", fmt.Errorf("--vision-model %q is malformed: want \"model\" or \"provider/model\"", raw)
+		}
+		if prov != profile.ID() && !clientHasProvider(client, prov) {
+			return "", fmt.Errorf("--vision-model provider %q is not configured or has no credential (active provider %q); available providers: %s",
+				prov, profile.ID(), strings.Join(client.ProviderNames(), ", "))
+		}
+	}
+	return raw, nil
+}
+```
+
+In `cmd/evener/main.go`: add `visionModel *string` to `runCLIFlags` (after `fastCheapModel`, line 32); register beside the `--fast-cheap-model` flag (line 250):
+
+```go
+	flags.visionModel = fs.String("vision-model", "", "vision side-channel model: 'off' disables image description, 'provider/model' or bare 'model' routes it (default: the session model)")
+```
+
+Pass `visionModel: *flags.visionModel` into the `runConfig` literal (line 200 area).
+
+In `cmd/evener/run.go`: add `visionModel string` to `runConfig`; at the site where `applyFastCheapModel` runs, add:
+
+```go
+	visionModel, err := applyVisionModel(profile, cfg.visionModel, client)
+	if err != nil {
+		return err
+	}
+```
+
+(Use that site's own profile/client variable names and error style.) Set `VisionModel: visionModel,` on the `agent.SessionConfig` literal (line 247 area).
+
+In `cmd/evener/serve.go`: register the `--vision-model` flag the same way for `serve` and apply the same validation + SessionConfig assignment at its SessionConfig construction (line 417 area).
+
+- [ ] **Step 4: Run the CLI tests**
+
+Run: `go test ./cmd/evener/ -run 'TestApplyVisionModel|TestApplyFastCheapModel|Flag' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/evener/main.go cmd/evener/run.go cmd/evener/serve.go cmd/evener/serve_fast_cheap_model_test.go
+git commit -m "cmd/evener: add --vision-model flag with cross-provider validation"
+```
+
+---
+
+### Task 9: Hub — set-with-resume and thread-read passthrough
+
+**Files:**
+- Create: `cmd/evener-hub/app_vision_model.go`
+- Modify: `cmd/evener-hub/app_rpc.go` (register beside line 533)
+- Modify: `cmd/evener-hub/internal/appsource/` (add `SetThreadVisionModel` beside the source interface's `SetThreadModel`)
+- Modify: `cmd/evener-hub/app_threadread.go` (`pastEntryThread`: `visionModel` + `changeVisionModel` for cold threads)
+- Test: `cmd/evener-hub/app_model_test.go` or the app's existing set-with-resume test file (mirror its `thread/model/set` tests)
+
+**Interfaces:**
+- Consumes: appwire types + `Client.ThreadVisionModelSet` (Task 5); daemon handler + thread field (Task 7); `schema.SessionMeta.VisionModel` (Task 2).
+
+- [ ] **Step 1: Write the failing test**
+
+In the hub test file covering `setThreadModelWithResume` (find it with `rg -l "setThreadModelWithResume" cmd/evener-hub/`), add the parallel vision test: a source whose first `SetThreadVisionModel` answers session-unavailable, assert the hub resumes and retries once, and assert the second call receives `VisionModel: "off"` unchanged. Mirror the model test's fixture construction verbatim — same fake source, same `hubcore.WebConfig` — changing only the method names and params type.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/evener-hub/ -run 'VisionModel' -v`
+Expected: FAIL — `setThreadVisionModelWithResume` undefined.
+
+- [ ] **Step 3: Implement**
+
+Create `cmd/evener-hub/app_vision_model.go`, mirroring `app_model.go` lines 11-39 exactly:
+
+```go
+package hub
+
+import (
+	"context"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+func setThreadVisionModelWithResume(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, params appwire.ThreadVisionModelSetParams) error {
+	err := setThreadVisionModelOnce(ctx, cfg, sources, params)
+	if err == nil {
+		return nil
+	}
+	if params.Ref != "" && !hubKnowsRef(cfg, params.Ref) {
+		return err
+	}
+	if !shouldResumeAfterSessionUnavailable(err) {
+		return err
+	}
+	if _, resumeErr := hubThreadResume(ctx, cfg, sources, appwire.ThreadResumeParams{Ref: params.Ref}); resumeErr != nil {
+		return resumeErr
+	}
+	return setThreadVisionModelOnce(ctx, cfg, sources, params)
+}
+
+func setThreadVisionModelOnce(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, params appwire.ThreadVisionModelSetParams) error {
+	_, err := withDeletionTargetOwnership(cfg, params.Ref, "", "", func() (struct{}, error) {
+		source, err := sourceForThreadWithManagedLaunchUnlocked(ctx, cfg, sources, params.Ref, "")
+		if err != nil {
+			return struct{}{}, err
+		}
+		if err := ensureThreadActionAvailable(ctx, source, params.Ref, "", "vision-model"); err != nil {
+			return struct{}{}, err
+		}
+		return struct{}{}, source.SetThreadVisionModel(ctx, params)
+	})
+	return err
+}
+```
+
+In `cmd/evener-hub/internal/appsource/`, add `SetThreadVisionModel(ctx, appwire.ThreadVisionModelSetParams) error` to the source interface beside `SetThreadModel`, implemented on every source that implements `SetThreadModel` by forwarding `client.ThreadVisionModelSet(ctx, params)` — copy each `SetThreadModel` implementation's body and change the method call.
+
+In `cmd/evener-hub/app_rpc.go`, register beside line 533:
+
+```go
+	appserver.HandleTyped(server.Router(), appwire.MethodThreadVisionModelSet, func(ctx context.Context, params appwire.ThreadVisionModelSetParams) (appwire.EmptyResponse, error) {
+		return appwire.EmptyResponse{}, setThreadVisionModelWithResume(ctx, cfg, sources, params)
+	})
+```
+
+In `cmd/evener-hub/app_threadread.go`'s `pastEntryThread` (cold threads): populate `Thread.Evener.VisionModel` from the persisted session meta's `VisionModel` field (Task 2) at the same site that entry sources other evener-thread fields, and set the entry's `changeVisionModel` capability to match its `changeModel` answer (a cold evener session can be resumed and then accept the set, exactly like model/set).
+
+- [ ] **Step 4: Run the hub tests**
+
+Run: `go test ./cmd/evener-hub/ -run 'VisionModel|ThreadModel|ThreadRead' -v` then `go test ./cmd/evener-hub/internal/appsource/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/evener-hub/app_vision_model.go cmd/evener-hub/app_rpc.go cmd/evener-hub/internal/appsource/ cmd/evener-hub/app_threadread.go cmd/evener-hub/
+git commit -m "hub: forward thread/vision-model/set with resume and expose visionModel on reads"
+```
+
+---
+
+### Task 10: Frontend — protocol model, reducer, store action
+
+**Files:**
+- Modify: `cmd/evener-hub/frontend/src/protocol/model.ts` (`ThreadModel` line 197; the capabilities interface declaring `changeModel`; the wire `Thread` type's `evener` object carrying `reasoningEffort`)
+- Modify: `cmd/evener-hub/frontend/src/protocol/reducer.ts` (thread hydrate near line 327; new notification case beside line 870)
+- Modify: `cmd/evener-hub/frontend/src/stores/threads.ts` (interface line 171; implementation beside line 1959)
+- Test: `cmd/evener-hub/frontend/src/protocol/reducer.test.ts`, `cmd/evener-hub/frontend/src/stores/threads.test.ts`
+
+**Interfaces:**
+- Produces: `ThreadModel.visionModel: string`; capabilities `changeVisionModel: boolean`; `threadsStore.setVisionModel(ref: string, visionModel: string): Promise<void>`. Task 11 consumes all three.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `protocol/reducer.test.ts`, beside the `thread/reasoning-effort/changed` test (line 2084-2092):
+
+```ts
+it("applies thread/vision-model/changed", () => {
+  const model = makeModel(/* mirror the neighboring test's factory */);
+  const next = reduce(
+    model,
+    {
+      method: "thread/vision-model/changed",
+      params: { threadId: "thr_t", ref: "ref_t", visionModel: "anthropic/claude-haiku-4-5" },
+    },
+    2000,
+  );
+  expect(next.visionModel).toBe("anthropic/claude-haiku-4-5");
+});
+```
+
+(Match the neighboring test's actual factory and `reduce` call signature verbatim.)
+
+In `stores/threads.test.ts`, mirror the existing `setModel` test: `setVisionModel("ref", "off")` issues one `thread/vision-model/set` request with params `{ ref: "ref", visionModel: "off" }` and maps a Conflict rejection the same way `setModel` does.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/protocol/reducer.test.ts src/stores/threads.test.ts`
+Expected: FAIL — `visionModel` not on the model, `setVisionModel` not on the store.
+
+- [ ] **Step 3: Implement**
+
+In `protocol/model.ts`: add `visionModel: string;` to `ThreadModel` beside `reasoningEffort?`; add `changeVisionModel: boolean;` to the capabilities interface beside `changeModel`; on the wire `Thread` type's `evener` object (the one carrying `reasoningEffort`), add `visionModel?: string;`.
+
+In `protocol/reducer.ts`:
+- In the thread-read hydrate (near line 327): add `visionModel: thread.evener.visionModel ?? "",` beside `reasoningEffort: thread.evener.reasoningEffort,`.
+- Add the notification case beside `thread/reasoning-effort/changed` (line 870-873):
+
+```ts
+    case "thread/vision-model/changed": {
+      if (!notificationTargetsThread(n, model)) return model;
+      return { ...model, visionModel: n.params.visionModel, lastFrameAt: now };
+    }
+```
+
+In `stores/threads.ts`:
+- Interface, beside line 171: `setVisionModel(ref: string, visionModel: string): Promise<void>;`
+- Implementation, beside `setModel` (line 1959-1967):
+
+```ts
+  async setVisionModel(ref, visionModel) {
+    const client = requireClient();
+    try {
+      await client.request("thread/vision-model/set", { ref, visionModel });
+    } catch (err) {
+      throw mapConflict(err);
+    }
+  },
+```
+
+- [ ] **Step 4: Biome, then run the frontend tests**
+
+Run: `cd cmd/evener-hub/frontend && npx biome check --write src/protocol/model.ts src/protocol/reducer.ts src/stores/threads.ts src/protocol/reducer.test.ts src/stores/threads.test.ts && npx vitest run src/protocol/reducer.test.ts src/stores/threads.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/evener-hub/frontend/src/protocol/model.ts cmd/evener-hub/frontend/src/protocol/reducer.ts cmd/evener-hub/frontend/src/stores/threads.ts cmd/evener-hub/frontend/src/protocol/reducer.test.ts cmd/evener-hub/frontend/src/stores/threads.test.ts
+git commit -m "web: carry visionModel through thread state and add setVisionModel"
+```
+
+---
+
+### Task 11: Frontend — `VisionModelSwitch` picker in the status row
+
+**Files:**
+- Create: `cmd/evener-hub/frontend/src/panes/session/chrome/VisionModelSwitch.tsx`
+- Create: `cmd/evener-hub/frontend/src/panes/session/chrome/VisionModelSwitch.test.tsx`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/chrome/StatusRow.tsx` (render beside line 161)
+
+**Interfaces:**
+- Consumes: `ThreadModel.visionModel`, `capabilities.changeVisionModel`, `threadsStore.setVisionModel` (Task 10); `ModelSwitchTrigger`, `fetchModelCatalog`, `mergeScopedCatalog`, `modelLabel` (existing, used by `ModelSwitch.tsx`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `VisionModelSwitch.test.tsx` mirroring `ModelSwitch.test.tsx`'s render/pick flow:
+
+```tsx
+// Cases:
+// 1. Unset: trigger label renders the session model's qualified label and the
+//    catalog's "Current model" row sends "" via setVisionModel.
+// 2. "off": trigger label renders "Off".
+// 3. Pinned ref: trigger label renders the ref.
+// 4. A vision-capable catalog row sends "provider/model"; a row with
+//    supportsVision absent/false does not appear.
+// 5. capabilities.changeVisionModel false disables the trigger.
+```
+
+Implement with the same testing-library idioms as `ModelSwitch.test.tsx` (its store stubbing, `render`, `fireEvent`/`userEvent`, and toast assertions).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/panes/session/chrome/VisionModelSwitch.test.tsx`
+Expected: FAIL — component does not exist.
+
+- [ ] **Step 3: Implement the component**
+
+Create `VisionModelSwitch.tsx`:
+
+```tsx
+// VisionModelSwitch: the per-session vision-model picker. Same trigger and
+// catalog popover as ModelSwitch (issue #198's shared control), but the
+// catalog is filtered to vision-capable entries and gains two pseudo-entries
+// ahead of it: "Current model" (the unset default — the side-channel describes
+// with the session's active model) and "Off" (the side-channel is disabled).
+// Both map onto the single visionModel wire string, which is the whole
+// setting: "" for current-model, "off" for disabled, "provider/model" for a
+// pinned route.
+import { useCallback } from "react";
+import { sessionActionError } from "../../../protocol/errors";
+import type { ThreadModel } from "../../../protocol/model";
+import { threadsStore } from "../../../stores/threads";
+import { type ModelCatalog, type ModelCatalogEntry, useToasts } from "../../../widgets";
+import { fetchModelCatalog } from "../../../widgets/modelCatalog/catalogClient";
+import { mergeScopedCatalog } from "../../../widgets/modelCatalog/scopedCatalog";
+import { ModelSwitchTrigger } from "./ModelSwitchTrigger";
+import { modelLabel } from "./statusFormat";
+
+const CURRENT_MODEL_ID = "";
+const OFF_MODEL_ID = "off";
+
+const PSEUDO_ENTRIES: ModelCatalogEntry[] = [
+  { provider: "", model: CURRENT_MODEL_ID, displayName: "Current model" },
+  { provider: "", model: OFF_MODEL_ID, displayName: "Off" },
+];
+
+export interface VisionModelSwitchProps {
+  sessionRef: string;
+  model: ThreadModel;
+}
+
+export function VisionModelSwitch({ sessionRef, model }: VisionModelSwitchProps) {
+  const toasts = useToasts();
+  const disabled = !model.capabilities.changeVisionModel;
+  const currentLabel =
+    model.visionModel === ""
+      ? modelLabel(model.modelProvider, model.model)
+      : model.visionModel === OFF_MODEL_ID
+        ? "Off"
+        : model.visionModel;
+
+  const loadCatalog = useCallback(async (): Promise<ModelCatalog> => {
+    const [scoped, enrichment] = await Promise.all([
+      threadsStore.getState().listModels(),
+      fetchModelCatalog().catch(() => null),
+    ]);
+    const merged = mergeScopedCatalog(scoped.data, enrichment);
+    return [...PSEUDO_ENTRIES, ...merged.filter((entry) => entry.supportsVision === true)];
+  }, []);
+
+  async function handlePick(entry: ModelCatalogEntry): Promise<void> {
+    const visionModel = entry.provider === "" ? entry.model : `${entry.provider}/${entry.model}`;
+    try {
+      await threadsStore.getState().setVisionModel(sessionRef, visionModel);
+    } catch (err) {
+      toasts.push("error", sessionActionError("Couldn't change vision model", err));
+    }
+  }
+
+  return (
+    <ModelSwitchTrigger
+      label={currentLabel}
+      value={currentLabel}
+      disabled={disabled}
+      loadCatalog={loadCatalog}
+      onPick={(entry) => void handlePick(entry)}
+      data-testid="vision-model-switch-trigger"
+      valueTestId="vision-model-switch-value"
+    />
+  );
+}
+```
+
+In `StatusRow.tsx`, render it inside the identity span after `ReasoningEffortControl` (line 162):
+
+```tsx
+        <VisionModelSwitch sessionRef={sessionRef} model={model} />
+```
+
+(Add the import beside `ModelSwitch`'s.)
+
+- [ ] **Step 4: Biome, then run the chrome tests**
+
+Run: `cd cmd/evener-hub/frontend && npx biome check --write src/panes/session/chrome/VisionModelSwitch.tsx src/panes/session/chrome/VisionModelSwitch.test.tsx src/panes/session/chrome/StatusRow.tsx && npx vitest run src/panes/session/chrome/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/evener-hub/frontend/src/panes/session/chrome/VisionModelSwitch.tsx cmd/evener-hub/frontend/src/panes/session/chrome/VisionModelSwitch.test.tsx cmd/evener-hub/frontend/src/panes/session/chrome/StatusRow.tsx
+git commit -m "web: add VisionModelSwitch picker to the session status row"
+```
+
+---
+
+### Task 12: TUI `/vision-model` command
+
+**Files:**
+- Modify: `cmd/evener-tui/hub_command_registry.go` (new entry beside `"model"`, line 324)
+- Modify: `cmd/evener-tui/hub_commands.go` (`sendHubVisionModelAction` beside `sendHubEffortAction`, line 642)
+- Modify: `cmd/evener-tui/hub_types.go` (`hubSessionCapabilities` line 42 + mapping line 244; `hubSessionDetail` if the current setting is surfaced for the picker)
+- Modify: `cmd/evener-tui/hub_update.go` (action confirm beside line 338; vision picker message handling beside the `hubSessionModelsMsg` case)
+- Test: `cmd/evener-tui/hub_command_registry_test.go` or the file exercising `/model` (mirror it)
+
+**Interfaces:**
+- Consumes: `appwire.Client.ThreadVisionModelSet` (Task 5); `hubSessionCapabilities.ChangeVisionModel`.
+- Produces: `func sendHubVisionModelAction(client *appwire.Client, ref appwire.Ref, visionModel string) tea.Cmd`; `/vision-model` registry entry.
+
+- [ ] **Step 1: Write the failing tests**
+
+In the TUI test file exercising the `/model` registry entry (`rg -l '"model"' cmd/evener-tui/ | grep registry` to find it), mirror its tests:
+
+```go
+func TestVisionModelCommandRegistered(t *testing.T) {
+	cmd, ok := hubCommandByName("vision-model")
+	if !ok {
+		t.Fatal("no /vision-model command in the registry")
+	}
+	if cmd.PaletteLabel != "/vision-model" {
+		t.Fatalf("PaletteLabel = %q", cmd.PaletteLabel)
+	}
+	available, _ := cmd.Available(hubCommandContext{mode: hubModeSession, caps: hubSessionCapabilities{ChangeVisionModel: true}})
+	if !available {
+		t.Fatal("command must be available when the capability is advertised")
+	}
+	available, _ = cmd.Available(hubCommandContext{mode: hubModeSession})
+	if available {
+		t.Fatal("command must gate on ChangeVisionModel")
+	}
+}
+
+func TestSendHubVisionModelAction(t *testing.T) {
+	// Mirror the sendHubEffortAction test's scripted appwire client: assert one
+	// thread/vision-model/set request with VisionModel unchanged.
+	for _, setting := range []string{"", "off", "anthropic/claude-x"} {
+		// ... same fixture shape as the effort action test, asserting the params
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./cmd/evener-tui/ -run 'TestVisionModelCommand|TestSendHubVisionModelAction' -v`
+Expected: FAIL — command and function undefined.
+
+- [ ] **Step 3: Implement**
+
+In `cmd/evener-tui/hub_types.go`: add `ChangeVisionModel bool` to `hubSessionCapabilities` after `ChangeModel` (line 51), and add `ChangeVisionModel: caps.ChangeVisionModel,` to the mapping at line 244. (Verify the mapped source struct — the `caps` there is `appwire.ThreadCapabilities` after Task 5.)
+
+In `cmd/evener-tui/hub_commands.go` beside `sendHubEffortAction`:
+
+```go
+// visionModelRefKnown reports whether ref parses as a vision-model setting —
+// "", "off", a bare model, or "provider/model" — so /vision-model can reject
+// a malformed ref client-side without a wire round trip.
+func visionModelRefKnown(ref string) bool {
+	ref = strings.TrimSpace(ref)
+	if ref == "" || strings.EqualFold(ref, "off") {
+		return true
+	}
+	prov, model, ok := strings.Cut(ref, "/")
+	return !ok || (prov != "" && model != "")
+}
+
+func sendHubVisionModelAction(client *appwire.Client, ref appwire.Ref, visionModel string) tea.Cmd {
+	return func() tea.Msg {
+		err := client.ThreadVisionModelSet(context.Background(), appwire.ThreadVisionModelSetParams{Ref: ref.String(), VisionModel: visionModel})
+		return hubActionMsg{action: "vision-model", err: err}
+	}
+}
+```
+
+In `cmd/evener-tui/hub_command_registry.go`, add beside the `"model"` entry:
+
+```go
+	{
+		Name:               "vision-model",
+		Summary:            "Set vision model (picker) or /vision-model <name|off>",
+		PaletteLabel:       "/vision-model",
+		PaletteDetail:      "set vision model",
+		Scopes:             hubCommandSession,
+		UnavailableAction:  "change vision model",
+		UnavailableSummary: "Vision model change is not available for this session.",
+		Available:          capabilityAvailable(func(c hubSessionCapabilities) bool { return c.ChangeVisionModel }, "source does not advertise change vision model"),
+		Run: func(m *hubModel, args string) tea.Cmd {
+			setting := strings.TrimSpace(args)
+			if setting == "" {
+				if m.client == nil {
+					m.addSessionSystem("Vision model picker is not available without a hub client.")
+					return nil
+				}
+				m.addSessionSystem("Fetching available models...")
+				return fetchHubVisionSessionModels(m.client, m.detail.WorkingDir)
+			}
+			if !visionModelRefKnown(setting) {
+				m.addSessionSystem(fmt.Sprintf("Invalid vision model %q. Use a model name, provider/model, or off.", setting))
+				return nil
+			}
+			ref, ok := m.currentRef()
+			if !ok {
+				m.addSessionSystem("Session ref is invalid.")
+				return nil
+			}
+			return sendHubVisionModelAction(m.client, ref, setting)
+		},
+	},
+```
+
+In `cmd/evener-tui/hub_commands.go` beside `fetchHubSessionModels`:
+
+```go
+// fetchHubVisionSessionModels loads the session's launchable models and
+// filters them to vision-capable ones (embedded catalog), prepending the two
+// pseudo-entries of the vision setting: current-model and off.
+func fetchHubVisionSessionModels(client *appwire.Client, workingDir string) tea.Cmd {
+	return func() tea.Msg {
+		resp, err := client.ModelList(context.Background(), appwire.ModelListParams{CWD: workingDir})
+		if err != nil {
+			return hubVisionModelsMsg{err: err}
+		}
+		return hubVisionModelsMsg{models: visionModelPickerItems(modelPickerItemsFromResponse(resp, false))}
+	}
+}
+
+func visionModelPickerItems(items []tuipick.ModelPickerItem) []tuipick.ModelPickerItem {
+	cat := llm.EmbeddedModelCatalog()
+	capable := func(id string) bool {
+		if cat == nil {
+			return false
+		}
+		_, model := splitProviderModel(id)
+		mi := cat.LookupModelInfo(model)
+		return mi != nil && mi.SupportsVision
+	}
+	out := []tuipick.ModelPickerItem{
+		{ID: "", Display: "Current model"},
+		{ID: "off", Display: "Off"},
+	}
+	for _, item := range items {
+		if capable(item.ID) {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+```
+
+In `cmd/evener-tui/hub_update.go`: define `hubVisionModelsMsg` beside `hubSessionModelsMsg` (same fields: `models []tuipick.ModelPickerItem`, `err error`); in its handler, open a picker stored on a new `m.sessionVisionModelPicker` field (mirroring `m.sessionModelPicker` — `tuipick.NewModelPicker(items, m.detail.VisionModel, m.width)` with title "Select vision model"); in the picker-selection handler, send `sendHubVisionModelAction(m.client, ref, picked.ID)`; in the `hubActionMsg` switch beside `case "model":` (line 338) add `case "vision-model":` → `m.addSessionSystem("Vision model updated.")`. Surface the current setting on `hubSessionDetail` (a `VisionModel string` field populated from the thread payload's `Evener.VisionModel` at the same site other detail fields hydrate) so the picker can mark the active value.
+
+Mirror the `sessionModelPicker` overlay-dispatch handling for `sessionVisionModelPicker` wherever pickers are routed (the `topmostOverlayName`/dispatch sites in `hub_keys.go` and `hub_update.go` that name `sessionModelPicker`).
+
+- [ ] **Step 4: Run the TUI tests**
+
+Run: `go test ./cmd/evener-tui/ -run 'VisionModel' -v` then `go test ./cmd/evener-tui/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/evener-tui/hub_command_registry.go cmd/evener-tui/hub_commands.go cmd/evener-tui/hub_types.go cmd/evener-tui/hub_update.go cmd/evener-tui/hub_keys.go
+git commit -m "tui: add /vision-model command with vision-capable picker"
+```
+
+---
+
+### Task 13: Full gates
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Go gates**
+
+Run: `make lint && make vet && make test`
+Expected: all exit 0.
+
+- [ ] **Step 2: Frontend gates**
+
+Run: `make test-web && make test-web-browser`
+Expected: all exit 0.
+
+- [ ] **Step 3: Canonical merge gate**
+
+Run: `make merge-approval-gate`
+Expected: exit 0. Report any failure verbatim and fix the root cause before closing the work.
+
+---
+
+## Self-Review Notes (completed by the plan author)
+
+- Spec coverage: knob semantics (Tasks 2-3), runtime mutation (4-7), CLI (8), hub (9), web picker (10-11), TUI (12), persistence/resume/inheritance (2 + Task 13 regression), refusal fallback (1, 3), wire naming (5). Non-goals are untouched: no spawn-pane field, no hubapi method, no `auto` mode, no `supports_vision` hard gate.
+- Type consistency: `CompleteRouted(ctx, profile, providerName, modelID, req)`; `resolveVisionRoute(profile, setting) (providerName, modelID string, off bool)`; `visionModelOff = "off"`; `SetVisionModel(ref string) error`; `VisionModel() string`; `VisionModelChangedData{OldVisionModel, NewVisionModel}`; wire field `visionModel`; store `setVisionModel(ref, visionModel)`; TUI `sendHubVisionModelAction(client, ref, visionModel)` — identical across tasks.
+- Deliberate deviations from mirror-patterns, by design: `ThreadVisionModelSetParams` is a single string (two of three states are not provider/model pairs); no transcript marker turn for vision changes (reasoning-effort precedent, not model precedent).

--- a/docs/superpowers/specs/2026-08-27-vision-model-config-design.md
+++ b/docs/superpowers/specs/2026-08-27-vision-model-config-design.md
@@ -22,10 +22,12 @@ setting, `vision_model`, with three states:
 | `provider/model` or bare `model` | Side-channel on, routed to that model; cross-provider allowed; provider refusal falls back to the session model |
 
 The setting is a launch-time CLI flag (`--vision-model`), a persisted session
-config field, a runtime mutation (`thread/vision-model/set`), and a picker in
-the hub web UI whose entries are **Current model**, **Off**, and the
-vision-capable models from the catalog. Picking the current model reproduces
-today's same-model behavior, so one control is the whole user surface.
+config field, a runtime mutation (`thread/vision-model/set`), a picker in the
+hub web UI, and a `/vision` command in the TUI. Both pickers offer **Current
+model**, **Off**, and the vision-capable models from the catalog. Picking the
+current model reproduces today's same-model behavior, so one concept is the
+whole user surface. Every consumer — web frontend, TUI, hub — reaches the
+mutation through the appwire method.
 
 ## Goals
 
@@ -34,7 +36,8 @@ today's same-model behavior, so one control is the whole user surface.
   a different registered provider.
 - Preserve current behavior when the setting is unset.
 - Persist the setting so resumes and spawned children inherit it.
-- Allow mid-session changes from the hub web UI without restarting the session.
+- Allow mid-session changes from the hub web UI and the TUI without restarting
+  the session.
 - Reuse the existing cheap-model routing machinery (refusal learning, fallback
   to the session model) rather than building a parallel path.
 
@@ -43,11 +46,10 @@ today's same-model behavior, so one control is the whole user surface.
 - An `auto` mode that infers the side-channel from catalog vision capability.
   The setting is explicit; capability metadata only filters picker entries.
 - A spawn-pane field in the launch UI. The CLI flag covers launch-time
-  selection; the picker covers running sessions.
-- An `evener-tui` command. Per the product decision, `--vision-model=` is the
-  entire terminal surface.
-- A `hubapi` Go client method. Only the web frontend consumes the new wire
-  method in this wave; the TUI has no command that would need it.
+  selection; the pickers cover running sessions.
+- A `hubapi` Go HTTP client method. The TUI and the web frontend both consume
+  the appwire method directly (`appwire.Client`); nothing in this wave uses
+  hubapi's REST surface.
 - Validating that a configured vision model advertises `supports_vision`. The
   catalog is incomplete by nature; users may deliberately route to an
   uncatalogued model. Capability is picker metadata, not a gate.
@@ -184,6 +186,9 @@ in the client, else launch fails with an error.
 - The thread payload gains `VisionModel string `json:"visionModel"`` beside
   the model fields, so a client reads the current setting without a separate
   round trip.
+- `appwire.Client` gains a typed `ThreadVisionModelSet` method beside
+  `ThreadModelSet` and `ThreadReasoningEffortSet`; this is the single client
+  path every consumer (hub frontend, TUI) uses.
 
 ### Server (daemon)
 
@@ -221,6 +226,17 @@ how the model fields reach `pastEntryThread` today.
   `changeVisionModel` is false; mid-turn Conflicts surface as toasts, same as
   the model switch.
 - Touched files pass `npx biome check --write` before the frontend gates.
+
+### TUI
+
+`evener-tui` gains a `/vision` hub command mirroring `/model`. Bare `/vision`
+opens the shared model picker with **Current model**, **Off**, and the
+vision-capable catalog entries (filtered on `supports_vision`, with the active
+setting marked like `/model`'s "(active)" tag); `/vision <ref>` and
+`/vision off` set directly. Both forms call
+`appwire.Client.ThreadVisionModelSet`, and the result lands through the
+existing `hubActionMsg` path with a "Vision model updated." confirmation.
+Mid-turn Conflicts surface the same way `/model` conflicts do.
 
 ## Error handling
 
@@ -261,6 +277,10 @@ All gates run per AGENTS.md: `make lint`, `make vet`, `make test`, plus
 - **frontend**: store action and reducer tests; `VisionModelSwitch` renders
   the three entry kinds, filters by `supports_vision`, sends the right wire
   values, and disables on capability.
+- **TUI**: `/vision` registry tests mirroring the `/model` command tests —
+  direct set with a ref and with `off`, picker opens with the three entry
+  kinds, wire call carries the ref; tmux e2e alongside the existing `/model`
+  e2e where the harness supports it.
 - **cmd/evener**: flag parsing; cross-provider launch validation accepted and
   rejected cases.
 

--- a/docs/superpowers/specs/2026-08-27-vision-model-config-design.md
+++ b/docs/superpowers/specs/2026-08-27-vision-model-config-design.md
@@ -23,7 +23,7 @@ setting, `vision_model`, with three states:
 
 The setting is a launch-time CLI flag (`--vision-model`), a persisted session
 config field, a runtime mutation (`thread/vision-model/set`), a picker in the
-hub web UI, and a `/vision` command in the TUI. Both pickers offer **Current
+hub web UI, and a `/vision-model` command in the TUI. Both pickers offer **Current
 model**, **Off**, and the vision-capable models from the catalog. Picking the
 current model reproduces today's same-model behavior, so one concept is the
 whole user surface. Every consumer — web frontend, TUI, hub — reaches the
@@ -229,11 +229,11 @@ how the model fields reach `pastEntryThread` today.
 
 ### TUI
 
-`evener-tui` gains a `/vision` hub command mirroring `/model`. Bare `/vision`
+`evener-tui` gains a `/vision-model` hub command mirroring `/model`. Bare `/vision-model`
 opens the shared model picker with **Current model**, **Off**, and the
 vision-capable catalog entries (filtered on `supports_vision`, with the active
-setting marked like `/model`'s "(active)" tag); `/vision <ref>` and
-`/vision off` set directly. Both forms call
+setting marked like `/model`'s "(active)" tag); `/vision-model <ref>` and
+`/vision-model off` set directly. Both forms call
 `appwire.Client.ThreadVisionModelSet`, and the result lands through the
 existing `hubActionMsg` path with a "Vision model updated." confirmation.
 Mid-turn Conflicts surface the same way `/model` conflicts do.
@@ -277,7 +277,7 @@ All gates run per AGENTS.md: `make lint`, `make vet`, `make test`, plus
 - **frontend**: store action and reducer tests; `VisionModelSwitch` renders
   the three entry kinds, filters by `supports_vision`, sends the right wire
   values, and disables on capability.
-- **TUI**: `/vision` registry tests mirroring the `/model` command tests —
+- **TUI**: `/vision-model` registry tests mirroring the `/model` command tests —
   direct set with a ref and with `off`, picker opens with the three entry
   kinds, wire call carries the ref; tmux e2e alongside the existing `/model`
   e2e where the harness supports it.

--- a/docs/superpowers/specs/2026-08-27-vision-model-config-design.md
+++ b/docs/superpowers/specs/2026-08-27-vision-model-config-design.md
@@ -1,0 +1,272 @@
+# Vision Model Configuration — Design
+
+Date: 2026-08-27
+Status: Approved
+Branch: `main`
+
+## Summary
+
+Evener describes every image a tool returns through a vision side-channel: a
+separate, tool-free completion that asks the session's own model to describe the
+image, then injects the result as steering. This call fires even when the
+session model is vision-capable and already receives the same bytes inline in
+the tool result.
+
+This design makes the side-channel configurable through one per-session
+setting, `vision_model`, with three states:
+
+| Setting | Behavior |
+|---|---|
+| unset (default) | Side-channel on, using the session's active model — today's behavior |
+| `off` | Side-channel skipped; the model still receives image bytes inline in the tool result; no vision steering is emitted |
+| `provider/model` or bare `model` | Side-channel on, routed to that model; cross-provider allowed; provider refusal falls back to the session model |
+
+The setting is a launch-time CLI flag (`--vision-model`), a persisted session
+config field, a runtime mutation (`thread/vision-model/set`), and a picker in
+the hub web UI whose entries are **Current model**, **Off**, and the
+vision-capable models from the catalog. Picking the current model reproduces
+today's same-model behavior, so one control is the whole user surface.
+
+## Goals
+
+- Let a user disable the image-description side-channel for a session.
+- Let a user route the side-channel to a specific model, including a model on
+  a different registered provider.
+- Preserve current behavior when the setting is unset.
+- Persist the setting so resumes and spawned children inherit it.
+- Allow mid-session changes from the hub web UI without restarting the session.
+- Reuse the existing cheap-model routing machinery (refusal learning, fallback
+  to the session model) rather than building a parallel path.
+
+## Non-goals
+
+- An `auto` mode that infers the side-channel from catalog vision capability.
+  The setting is explicit; capability metadata only filters picker entries.
+- A spawn-pane field in the launch UI. The CLI flag covers launch-time
+  selection; the picker covers running sessions.
+- An `evener-tui` command. Per the product decision, `--vision-model=` is the
+  entire terminal surface.
+- A `hubapi` Go client method. Only the web frontend consumes the new wire
+  method in this wave; the TUI has no command that would need it.
+- Validating that a configured vision model advertises `supports_vision`. The
+  catalog is incomplete by nature; users may deliberately route to an
+  uncatalogued model. Capability is picker metadata, not a gate.
+- Changing how image bytes flow inline to the session model in tool results.
+
+## Current behavior
+
+`Session.persistToolResults` (agent/session_tool_round.go) calls
+`Session.describeImageCall` (agent/session_tools.go) for every tool result
+carrying image data, except in explorer sessions. The side-channel builds a
+tool-free request addressed to the session's own provider and model
+(`profile.ID()`, `profile.Model()`), with the caller's stated purpose as the
+prompt, a fixed low reasoning-effort cap, and a two-minute timeout. The
+description arrives as steering ("Image description (from vision)"); timeouts
+and provider failures arrive as "vision unavailable" steering.
+
+The image bytes also travel inline to the session model: the Anthropic and
+OpenAI Responses adapters embed them in the tool result itself. A
+vision-capable session model therefore sees every image twice today — once
+inline, once through the forced description.
+
+Auxiliary calls that need a different model (naming, summarization, web fetch)
+already route through `agent/internal/cheapmodel.Caller`: the profile carries a
+configured cheap ref, the caller validates model compatibility, learns
+provider refusals for the session, and falls back to the session model. The
+`--fast-cheap-model` CLI flag sets that ref at launch, with cross-provider refs
+validated against the client's registered providers.
+
+The mid-session model switch shows the full UI mutation path this design
+mirrors: `ModelSwitch.tsx` → `threadsStore.setModel` → appwire
+`thread/model/set` → hub `setThreadModelWithResume` (resumes cold sessions) →
+daemon `handleAppThreadModelSet` (rejects mid-turn) → `Session.SetModel` →
+`thread/model/changed` notification → frontend reducer.
+
+## Product decisions
+
+### One knob, three states
+
+The setting `vision_model` is a single string. Empty means "describe with the
+session's active model" and preserves current behavior by default. The bare
+word `off` disables the side-channel. Anything else is a model ref:
+`provider/model` pins a provider instance, while a bare `model` resolves
+against the session's active provider at call time, so it follows `SetModel`
+switches the same way the cheap-model ref does.
+
+`off` is reserved only as a bare word. A ref containing a slash parses as
+`provider/model` first, so a provider instance literally named `off` stays
+reachable as `off/some-model`.
+
+### Disabled means silent
+
+In the `off` state Evener makes no vision call and emits no steering — neither
+descriptions nor "vision unavailable" notices. The session model keeps
+receiving image bytes inline in tool results, so a vision-capable model loses
+nothing but the forced second description.
+
+### Cross-provider with refusal fallback
+
+A configured vision model resolves through the cheap-model caller machinery:
+model-compatibility validation, per-session refusal learning, and one fallback
+to the session model. If both models refuse, the existing "vision unavailable"
+steering fires. At launch and at runtime-set time, a cross-provider ref is
+valid only when that provider is registered and credentialed in the client;
+an unregistered provider is an immediate error, never a silent fallback.
+
+### Runtime mutation is per-session and immediate
+
+`Session.SetVisionModel` updates the setting under the session mutex, taking
+effect on the next image read. The daemon rejects a set while a turn is in
+flight (Conflict), matching `thread/model/set`. A successful set persists with
+the session meta and propagates to the UI through a change notification.
+Changing the session model does not touch `vision_model`: an explicit ref
+stays pinned, an unset value follows the new model.
+
+### Wire naming follows the flat-setting convention
+
+Appwire names per-thread settings as flat siblings:
+`thread/model/set`/`thread/model/changed`,
+`thread/reasoning-effort/set`/`thread/reasoning-effort/changed`. The new pair
+is `thread/vision-model/set` and `thread/vision-model/changed`.
+
+## Technical design
+
+### Agent layer
+
+**Configuration.** `agent.SessionConfig` gains
+`VisionModel string `json:"vision_model,omitempty"``, carried through
+`toSnapshot`/`configFromSnapshot` into `schema.ConfigSnapshot`. Persistence,
+resume, and child inheritance ride the existing snapshot plumbing; children
+copy the parent's config at spawn and keep the value current at that moment.
+
+**Runtime mutation.** `Session.SetVisionModel(ref string) error` mirrors
+`SetModel`: it rejects on a closed session, validates the ref (`off`, bare
+model, or `provider/model` with a registered cross-provider), stores it in
+`cfg.VisionModel` under `s.mu`, and returns a validation error without
+changing state. A new `Session.VisionModel()` getter reads the value under
+`s.mu` for the daemon's thread-read payload.
+
+**Side-channel.** `describeImageCall` reads the setting inside its existing
+`s.mu` profile-snapshot block:
+
+- `off` → return an empty success result; no call, no steering.
+- otherwise → resolve the route (explicit ref, or the session route when
+  unset) and execute through `cheapmodel.Caller` instead of a direct
+  `client.Complete`, so every non-off state shares refusal learning and
+  fallback. Prompt construction, media-part selection, timeout, effort clamp,
+  and request metadata stay as they are.
+
+**Routing.** `cheapmodel.Caller` gains an exported routed form,
+`CompleteRouted(ctx, profile, provider, model, req)`: the existing `Complete`
+and `CompleteConfigured` resolution logic refactors to route through it, and
+the vision side-channel calls it with the configured route. The refusal map
+and probe flights already key on route, so vision and cheap routes share one
+session-scoped caller without interfering.
+
+### CLI
+
+`evener run` and `evener serve` accept `--vision-model`. Launch-time handling
+mirrors `applyFastCheapModel`: an empty value leaves the field unset, `off`
+stores the sentinel, a bare model stores as-is, and `provider/model` with a
+provider different from the active one requires that provider to be registered
+in the client, else launch fails with an error.
+
+### Appwire protocol
+
+- `MethodThreadVisionModelSet = "thread/vision-model/set"` with
+  `ThreadVisionModelSetParams{Ref string, VisionModel string}`. The string
+  carries the full setting — `""` for current-model, `"off"`, or a ref — so
+  the wire has one unambiguous field rather than a provider/model split that
+  cannot express two of the three states.
+- `NotifyThreadVisionModelChanged = "thread/vision-model/changed"` with
+  `ThreadVisionModelChangedParams{ThreadID, Ref, VisionModel string}`.
+- `ThreadCapabilities` gains `ChangeVisionModel bool `json:"changeVisionModel"``.
+- The thread payload gains `VisionModel string `json:"visionModel"`` beside
+  the model fields, so a client reads the current setting without a separate
+  round trip.
+
+### Server (daemon)
+
+The daemon registers `handleAppThreadVisionModelSet` mirroring the model-set
+handler: it answers Conflict while a turn is processing or reserved, delegates
+to a new `SetVisionModelFunc` hook wired to `Session.SetVisionModel`, surfaces
+hook errors as wire errors, and emits `thread/vision-model/changed` after a
+successful set. Thread reads populate `visionModel` from the session getter
+and advertise `changeVisionModel` alongside `changeModel`.
+
+### Hub
+
+`app_rpc.go` registers the method and forwards to a new
+`setThreadVisionModelWithResume` (in an `app_vision_model.go` mirroring
+`app_model.go`): attempt the set, and when the session is unavailable but the
+ref is known, resume the thread and retry once. Hub thread-read construction
+carries `visionModel` and `changeVisionModel` for live threads from the daemon
+payload and for cold, exited threads from the persisted session meta, matching
+how the model fields reach `pastEntryThread` today.
+
+### Frontend (hub web UI)
+
+- `protocol/model.ts`: `ThreadModel` gains `visionModel: string` and the
+  capability flag.
+- `stores/threads.ts`: a `setVisionModel(ref, visionModel)` action as a
+  fire-and-report mutation like `setModel`, plus a reducer case for
+  `thread/vision-model/changed` that updates the stored value.
+- A new `VisionModelSwitch.tsx` in `panes/session/chrome/`, rendered beside
+  `ModelSwitch` and reusing `ModelSwitchTrigger` and the
+  `listModels()` + `/api/models` catalog plumbing. Entries: **Current model**
+  (sends `""`), **Off** (sends `"off"`), and catalog entries where
+  `supports_vision === true` (send `provider/model`). The trigger labels the
+  current state: the active model's label for unset, "Off" for `off`, and the
+  ref for an explicit model. The control disables when
+  `changeVisionModel` is false; mid-turn Conflicts surface as toasts, same as
+  the model switch.
+- Touched files pass `npx biome check --write` before the frontend gates.
+
+## Error handling
+
+- **Launch with an unregistered cross-provider ref**: fail launch with a
+  descriptive error (same as `--fast-cheap-model`).
+- **Runtime set to an invalid or unregistered ref**: the set call fails; the
+  session keeps its previous value; the UI shows a toast.
+- **Vision provider refuses the configured model**: the refusal is learned for
+  the session and the call falls back to the session model; if both refuse,
+  the existing "vision unavailable" steering fires.
+- **Configured model cannot accept images**: the provider error follows the
+  ordinary provider-failure path — warning event plus "vision unavailable"
+  steering. Evener does not pre-flight capability checks.
+- **Set during a turn**: the daemon answers Conflict; the UI surfaces it.
+
+## Testing
+
+All gates run per AGENTS.md: `make lint`, `make vet`, `make test`, plus
+`make test-web` and `make test-web-browser` for the frontend.
+
+- **agent**: with a scripted adapter — `off` makes no call and emits no
+  steering while the tool result keeps its image bytes; a configured ref
+  reaches the adapter with the vision provider/model; a refusal falls back to
+  the session model; a double refusal yields "vision unavailable" steering;
+  `SetVisionModel` validation and state transitions; `VisionModel()` getter;
+  ConfigSnapshot round-trip (the mirror converter test guards the new field);
+  child spawn inherits the value; resume restores it.
+- **cheapmodel**: `CompleteRouted` resolution, refusal learning per route, and
+  fallback, proving the cheap and vision routes share one caller without
+  cross-contaminating refusal state.
+- **appwire**: params/notification decode coverage and golden updates for the
+  new method and notification.
+- **server**: handler tests mirroring `model_set_test.go` — mid-turn Conflict,
+  reserved-turn Conflict, hook error surfaces, success path emits the changed
+  notification.
+- **hub**: set-with-resume retries once after resume; unregistered or unknown
+  refs error; thread read carries `visionModel` and `changeVisionModel`.
+- **frontend**: store action and reducer tests; `VisionModelSwitch` renders
+  the three entry kinds, filters by `supports_vision`, sends the right wire
+  values, and disables on capability.
+- **cmd/evener**: flag parsing; cross-provider launch validation accepted and
+  rejected cases.
+
+## Rollout and compatibility
+
+Default behavior is unchanged: an unset `vision_model` describes with the
+session model exactly as today. Persisted sessions without the field load as
+unset. The new wire method and notification are additive; older frontends
+ignore the capability and never render the picker.


### PR DESCRIPTION
## Summary

Fixes #521.

- Preserve client-authored steering when `communicate(end_turn=true)` terminates the current turn.
- Reuse the existing pending-input wake and `EntrySteeringCarrier` path for the follow-up model request.
- Keep tool-result adjacency, durable mutation settlement, daemon inbox behavior, and image handling intact.
- Update the affected durable-contract test and remove one redundant classification check found during the simplify pass.

## Verification

- Red regression observed before implementation: `TestCommunicate_TerminalClientSteeringRunsAfterTheTerminalResult`.
- `go test ./agent ./server -count=1`
- `go vet ./agent ./server`
- `go test ./...`
- `make merge-approval-gate`
- Focused race and server wake tests passed.

Final review: no Critical or Important findings; two optional test-strengthening recommendations were deferred.