### PR TITLE
Fix steering after hub restart

### DIFF
--- a/appwire/types.go
+++ b/appwire/types.go
@@ -11,10 +11,6 @@ import (
 // fail once, loudly, at initialize -- rather than agreeing there and then
 // disagreeing on every request.
 //
-// v4 requires child binaries launched by the hub to understand the
-// --plugin-root argument used for fresh sessions. A v3 child can pass the
-// launch check but then reject that argument before serving AppWire.
-//
 // v3 dropped expectedTurnId from turn/steer, turn/queue, turn/interrupt,
 // turn/drainAsSteer and turn/promoteQueuedAsSteer: control is session-scoped and
 // names no turn. A v2 daemon still requires that field, so a v3 client talking
@@ -22,7 +18,7 @@ import (
 // "Steer and Stop are broken again" instead of as a version skew. The pair is
 // reachable in ordinary operation because daemons outlive the hub that spawned
 // them, so an operator who rebuilds and restarts the hub has one.
-const ProtocolVersion = "evener-appwire-v4"
+const ProtocolVersion = "evener-appwire-v3"
 
 const (
 	MethodInitialize                  = "initialize"

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coder/websocket"
 	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/agent/transcript"
@@ -86,6 +87,133 @@ func TestHubRPCThreadListUsesAppWireRendezvous(t *testing.T) {
 	}
 	if len(resp.Data) != 1 || resp.Data[0].ID != "th_1" || resp.Data[0].Evener.Ref != "local:th_1" {
 		t.Fatalf("threads=%+v", resp.Data)
+	}
+}
+
+func TestHubRPCSteersSurvivingDaemonAfterHubRestart(t *testing.T) {
+	const (
+		daemonProtocol = "evener-appwire-v3"
+		threadID       = "th_compatible"
+		mutationID     = "mutation-compatible-steer"
+	)
+
+	steered := make(chan appwire.TurnSteerParams, 1)
+	daemonHTTP := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		transport := appwire.NewWSTransport(conn)
+		defer transport.Close() //nolint:errcheck // test server connection cleanup
+		for {
+			message, err := transport.Recv(r.Context())
+			if err != nil {
+				return
+			}
+			if message.Request == nil {
+				continue
+			}
+			switch message.Request.Method {
+			case appwire.MethodInitialize:
+				var params appwire.InitializeParams
+				if err := json.Unmarshal(message.Request.Params, &params); err != nil {
+					_ = transport.Send(r.Context(), appwire.ErrorMessage(message.Request.ID, appwire.InvalidParams(err.Error())))
+					continue
+				}
+				if params.ProtocolVersion != daemonProtocol {
+					_ = transport.Send(r.Context(), appwire.ErrorMessage(message.Request.ID, appwire.InvalidRequest(
+						fmt.Sprintf("protocol version %q is incompatible; want %q", params.ProtocolVersion, daemonProtocol),
+					)))
+					continue
+				}
+				_ = transport.Send(r.Context(), appwire.ResponseMessage(message.Request.ID, appwire.InitializeResponse{
+					ProtocolVersion: daemonProtocol,
+					SourceID:        "local",
+				}))
+			case appwire.MethodTurnSteer:
+				var params appwire.TurnSteerParams
+				if err := json.Unmarshal(message.Request.Params, &params); err != nil {
+					_ = transport.Send(r.Context(), appwire.ErrorMessage(message.Request.ID, appwire.InvalidParams(err.Error())))
+					continue
+				}
+				steered <- params
+				_ = transport.Send(r.Context(), appwire.ResponseMessage(message.Request.ID, appwire.TurnSteerResponse{
+					Receipt: appwire.MutationReceipt{
+						ClientMutationID: params.ClientMutationID,
+						Disposition:      appwire.MutationDispositionApplied,
+						ThreadID:         threadID,
+						ProjectionState:  appwire.MutationProjectionReflected,
+					},
+				}))
+			case appwire.MethodThreadRead:
+				_ = transport.Send(r.Context(), appwire.ResponseMessage(message.Request.ID, appwire.ThreadReadResponse{
+					Thread: appwire.Thread{
+						ID:        threadID,
+						SessionID: threadID,
+						Source:    "local",
+						Evener:    appwire.EvenerThread{Ref: "local:" + threadID},
+					},
+				}))
+			default:
+				_ = transport.Send(r.Context(), appwire.ErrorMessage(message.Request.ID, appwire.MethodNotFound(message.Request.Method)))
+			}
+		}
+	}))
+	defer daemonHTTP.Close()
+
+	runDir := t.TempDir()
+	writeRendezvous(t, runDir, rendezvous.Entry{
+		PID:       101,
+		Protocol:  daemonProtocol,
+		Endpoint:  "ws" + strings.TrimPrefix(daemonHTTP.URL, "http"),
+		SourceID:  "local",
+		ThreadID:  threadID,
+		SessionID: threadID,
+	})
+	roster := hubcore.NewRoster(runDir, fakeProber{sessionID: threadID, status: appwire.ThreadStatusActive})
+	roster.Refresh()
+
+	resumeCalls := 0
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{
+		RunDir:      runDir,
+		Roster:      roster,
+		Past:        hubcore.NewPastIndex(""),
+		ResumeLocks: hubcore.NewResumeLocks(),
+		Spawner: &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+			resumeCalls++
+			return rendezvous.Entry{}, errors.New("surviving daemon must be reused")
+		}},
+	})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	resumed, err := client.ThreadResume(t.Context(), appwire.ThreadResumeParams{Session: threadID})
+	if err != nil {
+		t.Fatalf("ThreadResume: %v", err)
+	}
+	if resumed.Thread.ID != threadID || resumeCalls != 0 {
+		t.Fatalf("resume = %+v, replacement calls = %d", resumed.Thread, resumeCalls)
+	}
+
+	var response appwire.TurnSteerResponse
+	err = client.Request(t.Context(), appwire.MethodTurnSteer, appwire.TurnSteerParams{
+		Ref:              "local:" + threadID,
+		ThreadID:         threadID,
+		ClientMutationID: mutationID,
+		Input:            []appwire.InputItem{{Type: "text", Text: "survived the hub restart"}},
+	}, &response)
+	if err != nil {
+		t.Fatalf("TurnSteer: %v", err)
+	}
+	if response.Receipt.ClientMutationID != mutationID || response.Receipt.ThreadID != threadID {
+		t.Fatalf("receipt = %+v", response.Receipt)
+	}
+	params := <-steered
+	if params.ClientMutationID != mutationID || inputTextForTest(params.Input) != "survived the hub restart" {
+		t.Fatalf("daemon steer params = %+v", params)
 	}
 }
 
@@ -6397,7 +6525,7 @@ func TestHubRPCModelListReportsEvenerLaunchDiagnostics(t *testing.T) {
 	bin := filepath.Join(dir, "fake-evener")
 	script := `#!/bin/sh
 if [ "$1" = "launch-check" ]; then
-  printf '{"protocol":"evener-appwire-v4","models":[{"provider":"ollama","model":"local"}],"diagnostics":[{"provider":"openai","source":"provider","title":"Provider error","message":"HTTP 403"}]}\n'
+  printf '{"protocol":"evener-appwire-v3","models":[{"provider":"ollama","model":"local"}],"diagnostics":[{"provider":"openai","source":"provider","title":"Provider error","message":"HTTP 403"}]}\n'
   exit 0
 fi
 exit 2

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coder/websocket"
 	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/agent/transcript"
@@ -98,78 +97,20 @@ func TestHubRPCSteersSurvivingDaemonAfterHubRestart(t *testing.T) {
 	)
 
 	steered := make(chan appwire.TurnSteerParams, 1)
-	daemonHTTP := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := websocket.Accept(w, r, nil)
-		if err != nil {
-			return
-		}
-		transport := appwire.NewWSTransport(conn)
-		defer transport.Close() //nolint:errcheck // test server connection cleanup
-		for {
-			message, err := transport.Recv(r.Context())
-			if err != nil {
-				return
-			}
-			if message.Request == nil {
-				continue
-			}
-			switch message.Request.Method {
-			case appwire.MethodInitialize:
-				var params appwire.InitializeParams
-				if err := json.Unmarshal(message.Request.Params, &params); err != nil {
-					_ = transport.Send(r.Context(), appwire.ErrorMessage(message.Request.ID, appwire.InvalidParams(err.Error())))
-					continue
-				}
-				if params.ProtocolVersion != daemonProtocol {
-					_ = transport.Send(r.Context(), appwire.ErrorMessage(message.Request.ID, appwire.InvalidRequest(
-						fmt.Sprintf("protocol version %q is incompatible; want %q", params.ProtocolVersion, daemonProtocol),
-					)))
-					continue
-				}
-				_ = transport.Send(r.Context(), appwire.ResponseMessage(message.Request.ID, appwire.InitializeResponse{
-					ProtocolVersion: daemonProtocol,
-					SourceID:        "local",
-				}))
-			case appwire.MethodTurnSteer:
-				var params appwire.TurnSteerParams
-				if err := json.Unmarshal(message.Request.Params, &params); err != nil {
-					_ = transport.Send(r.Context(), appwire.ErrorMessage(message.Request.ID, appwire.InvalidParams(err.Error())))
-					continue
-				}
-				steered <- params
-				_ = transport.Send(r.Context(), appwire.ResponseMessage(message.Request.ID, appwire.TurnSteerResponse{
-					Receipt: appwire.MutationReceipt{
-						ClientMutationID: params.ClientMutationID,
-						Disposition:      appwire.MutationDispositionApplied,
-						ThreadID:         threadID,
-						ProjectionState:  appwire.MutationProjectionReflected,
-					},
-				}))
-			case appwire.MethodThreadRead:
-				_ = transport.Send(r.Context(), appwire.ResponseMessage(message.Request.ID, appwire.ThreadReadResponse{
-					Thread: appwire.Thread{
-						ID:        threadID,
-						SessionID: threadID,
-						Source:    "local",
-						Evener:    appwire.EvenerThread{Ref: "local:" + threadID},
-					},
-				}))
-			default:
-				_ = transport.Send(r.Context(), appwire.ErrorMessage(message.Request.ID, appwire.MethodNotFound(message.Request.Method)))
-			}
-		}
-	}))
+	runDir := t.TempDir()
+	daemonHTTP := startAppwireTestDaemonWithProtocol(t, runDir, threadID, daemonProtocol, func(daemon *appserver.Server) {
+		appserver.HandleTyped(daemon.Router(), appwire.MethodTurnSteer, func(_ context.Context, params appwire.TurnSteerParams) (appwire.TurnSteerResponse, error) {
+			steered <- params
+			return appwire.TurnSteerResponse{Receipt: appwire.MutationReceipt{
+				ClientMutationID: params.ClientMutationID,
+				Disposition:      appwire.MutationDispositionApplied,
+				ThreadID:         threadID,
+				ProjectionState:  appwire.MutationProjectionReflected,
+			}}, nil
+		})
+	})
 	defer daemonHTTP.Close()
 
-	runDir := t.TempDir()
-	writeRendezvous(t, runDir, rendezvous.Entry{
-		PID:       101,
-		Protocol:  daemonProtocol,
-		Endpoint:  "ws" + strings.TrimPrefix(daemonHTTP.URL, "http"),
-		SourceID:  "local",
-		ThreadID:  threadID,
-		SessionID: threadID,
-	})
 	roster := hubcore.NewRoster(runDir, fakeProber{sessionID: threadID, status: appwire.ThreadStatusActive})
 	roster.Refresh()
 

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -5952,6 +5952,44 @@ func TestHubRPCTurnMutationsForwardWithoutDynamicCapabilityGates(t *testing.T) {
 	}
 }
 
+func TestHubRPCTurnSteerMissingLocalSessionReturnsTerminalRejection(t *testing.T) {
+	runDir := t.TempDir()
+	roster := hubcore.NewRoster(runDir, nil)
+	roster.Refresh()
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{
+		RunDir: runDir,
+		Roster: roster,
+		Past:   hubcore.NewPastIndex(""),
+	})
+	defer hub.Close()
+
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	params := appwire.TurnSteerParams{
+		Ref:              "local:missing",
+		ClientMutationID: "mutation-missing-session",
+		Input:            []appwire.InputItem{{Type: "text", Text: "steer"}},
+	}
+	var response appwire.TurnSteerResponse
+	err := client.Request(context.Background(), appwire.MethodTurnSteer, params, &response)
+	var wire appwire.WireError
+	if !errors.As(err, &wire) {
+		t.Fatalf("TurnSteer error %T=%v, want WireError", err, err)
+	}
+	data, ok := wire.Data.(map[string]any)
+	if !ok ||
+		data["evenerErrorInfo"] != string(appwire.ErrorSessionUnavailable) ||
+		data["clientMutationId"] != params.ClientMutationID ||
+		data["mutationOutcome"] != string(appwire.MutationOutcomeNotAccepted) ||
+		data["retryDisposition"] != string(appwire.RetryDispositionNone) {
+		t.Fatalf("wire=%+v data=%T %#v", wire, wire.Data, wire.Data)
+	}
+}
+
 func TestHubRPCThreadCompactStartResumesPastThread(t *testing.T) {
 	root := t.TempDir()
 	workingDir := t.TempDir()

--- a/cmd/evener-hub/frontend/src/protocol/client.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/client.test.ts
@@ -86,7 +86,7 @@ describe("AppwireClient", () => {
       id: 1,
       method: "initialize",
       params: {
-        protocolVersion: "evener-appwire-v3",
+        protocolVersion: APPWIRE_PROTOCOL_VERSION,
         clientInfo: DEFAULT_CLIENT_INFO,
         capabilities: DEFAULT_CAPABILITIES,
       },
@@ -134,7 +134,7 @@ describe("AppwireClient", () => {
       id: frame.id,
       error: {
         code: -32600,
-        message: `protocol version "evener-appwire-v2" is incompatible; want "evener-appwire-v3"`,
+        message: `protocol version "evener-appwire-v2" is incompatible; want "${APPWIRE_PROTOCOL_VERSION}"`,
       },
     });
 
@@ -488,7 +488,7 @@ describe("AppwireClient", () => {
       id: initialize.id,
       error: {
         code: -32600,
-        message: `protocol version "evener-appwire-v2" is incompatible; want "evener-appwire-v3"`,
+        message: `protocol version "evener-appwire-v2" is incompatible; want "${APPWIRE_PROTOCOL_VERSION}"`,
       },
     });
     await flushUntil(() => client.state === "closed");

--- a/cmd/evener-hub/frontend/src/protocol/client.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/client.test.ts
@@ -86,7 +86,7 @@ describe("AppwireClient", () => {
       id: 1,
       method: "initialize",
       params: {
-        protocolVersion: "evener-appwire-v4",
+        protocolVersion: "evener-appwire-v3",
         clientInfo: DEFAULT_CLIENT_INFO,
         capabilities: DEFAULT_CAPABILITIES,
       },
@@ -134,7 +134,7 @@ describe("AppwireClient", () => {
       id: frame.id,
       error: {
         code: -32600,
-        message: `protocol version "evener-appwire-v3" is incompatible; want "evener-appwire-v4"`,
+        message: `protocol version "evener-appwire-v2" is incompatible; want "evener-appwire-v3"`,
       },
     });
 
@@ -488,7 +488,7 @@ describe("AppwireClient", () => {
       id: initialize.id,
       error: {
         code: -32600,
-        message: `protocol version "evener-appwire-v3" is incompatible; want "evener-appwire-v4"`,
+        message: `protocol version "evener-appwire-v2" is incompatible; want "evener-appwire-v3"`,
       },
     });
     await flushUntil(() => client.state === "closed");

--- a/cmd/evener-hub/frontend/src/protocol/client.ts
+++ b/cmd/evener-hub/frontend/src/protocol/client.ts
@@ -22,7 +22,7 @@ export interface AppwireClientOptions {
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
-export const APPWIRE_PROTOCOL_VERSION = "evener-appwire-v4";
+export const APPWIRE_PROTOCOL_VERSION = "evener-appwire-v3";
 const DEFAULT_CLIENT_INFO = { name: "evener-web", version: "0.1.0" };
 const DEFAULT_CAPABILITIES = { experimentalApi: false };
 

--- a/cmd/evener-hub/frontend/src/protocol/testing/fakeClient.ts
+++ b/cmd/evener-hub/frontend/src/protocol/testing/fakeClient.ts
@@ -60,7 +60,7 @@ export type ConnectHandler = () => InitializeResponse | Promise<InitializeRespon
 // to script one just to get past the handshake.
 const DEFAULT_INITIALIZE_RESPONSE: InitializeResponse = {
   serverInfo: { name: "fake-evener-hub", version: "0.0.0" },
-  protocolVersion: "evener-appwire-v4",
+  protocolVersion: "evener-appwire-v3",
   sourceId: "fake",
   features: {
     threadList: false,

--- a/cmd/evener-hub/frontend/src/protocol/testing/fakeClient.ts
+++ b/cmd/evener-hub/frontend/src/protocol/testing/fakeClient.ts
@@ -5,7 +5,7 @@
 // the stores (src/stores/*) depend on, per AppwireClientLike below — with
 // scripted per-method request handlers and manual notification/ready/
 // state-change injection. No sockets, no timers.
-import type { AppwireClient, ConnectionState, TerminalReason } from "../client";
+import { APPWIRE_PROTOCOL_VERSION, type AppwireClient, type ConnectionState, type TerminalReason } from "../client";
 import type { AnyNotification, InitializeResponse, MethodName, MethodTypes } from "../types.gen";
 import { METHOD_NAMES, NOTIFICATION_NAMES } from "../types.gen";
 
@@ -60,7 +60,7 @@ export type ConnectHandler = () => InitializeResponse | Promise<InitializeRespon
 // to script one just to get past the handshake.
 const DEFAULT_INITIALIZE_RESPONSE: InitializeResponse = {
   serverInfo: { name: "fake-evener-hub", version: "0.0.0" },
-  protocolVersion: "evener-appwire-v3",
+  protocolVersion: APPWIRE_PROTOCOL_VERSION,
   sourceId: "fake",
   features: {
     threadList: false,

--- a/cmd/evener-hub/frontend/src/protocol/testing/fakeSocket.ts
+++ b/cmd/evener-hub/frontend/src/protocol/testing/fakeSocket.ts
@@ -3,6 +3,7 @@
 // client from the "server" side: open() to simulate the connection opening,
 // receive(obj) to simulate an incoming frame, and closeFromServer() to
 // simulate the server closing the connection unprompted.
+import { APPWIRE_PROTOCOL_VERSION } from "../client";
 import type { WebSocketLike } from "../transport";
 import type { InitializeResponse } from "../types.gen";
 
@@ -12,7 +13,7 @@ import type { InitializeResponse } from "../types.gen";
 // without duplicating the literal.
 export const FAKE_INITIALIZE_RESULT: InitializeResponse = {
   serverInfo: { name: "fake-evener-hub", version: "0.0.0-test" },
-  protocolVersion: "evener-appwire-v3",
+  protocolVersion: APPWIRE_PROTOCOL_VERSION,
   sourceId: "fake-source",
   features: {
     threadList: true,

--- a/cmd/evener-hub/frontend/src/protocol/testing/fakeSocket.ts
+++ b/cmd/evener-hub/frontend/src/protocol/testing/fakeSocket.ts
@@ -12,7 +12,7 @@ import type { InitializeResponse } from "../types.gen";
 // without duplicating the literal.
 export const FAKE_INITIALIZE_RESULT: InitializeResponse = {
   serverInfo: { name: "fake-evener-hub", version: "0.0.0-test" },
-  protocolVersion: "evener-appwire-v4",
+  protocolVersion: "evener-appwire-v3",
   sourceId: "fake-source",
   features: {
     threadList: true,

--- a/cmd/evener-hub/internal/appsource/local_daemon.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon.go
@@ -263,7 +263,7 @@ func (s *LocalDaemonSource) StartTurn(ctx context.Context, params appwire.TurnSt
 func (s *LocalDaemonSource) SteerTurn(ctx context.Context, params appwire.TurnSteerParams) (appwire.TurnSteerResponse, error) {
 	entry, err := s.entryForRef(params.Ref, params.ThreadID)
 	if err != nil {
-		return appwire.TurnSteerResponse{}, err
+		return appwire.TurnSteerResponse{}, localDaemonMutationEntryError(params.ClientMutationID, err)
 	}
 	var out appwire.TurnSteerResponse
 	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(client *appwire.Client) error {
@@ -285,7 +285,7 @@ func (s *LocalDaemonSource) ResolveSandboxEscalation(ctx context.Context, params
 func (s *LocalDaemonSource) InterruptTurn(ctx context.Context, params appwire.TurnInterruptParams) (appwire.TurnInterruptResponse, error) {
 	entry, err := s.entryForRef(params.Ref, params.ThreadID)
 	if err != nil {
-		return appwire.TurnInterruptResponse{}, err
+		return appwire.TurnInterruptResponse{}, localDaemonMutationEntryError(params.ClientMutationID, err)
 	}
 	var out appwire.TurnInterruptResponse
 	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(client *appwire.Client) error {
@@ -327,7 +327,7 @@ func (s *LocalDaemonSource) restInterrupt(ctx context.Context, entry rendezvous.
 func (s *LocalDaemonSource) QueueTurn(ctx context.Context, params appwire.TurnQueueParams) (appwire.TurnQueueResponse, error) {
 	entry, err := s.entryForRef(params.Ref, "")
 	if err != nil {
-		return appwire.TurnQueueResponse{}, err
+		return appwire.TurnQueueResponse{}, localDaemonMutationEntryError(params.ClientMutationID, err)
 	}
 	var out appwire.TurnQueueResponse
 	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(client *appwire.Client) error {
@@ -339,7 +339,7 @@ func (s *LocalDaemonSource) QueueTurn(ctx context.Context, params appwire.TurnQu
 func (s *LocalDaemonSource) DrainAsSteer(ctx context.Context, params appwire.TurnDrainAsSteerParams) (appwire.TurnDrainAsSteerResponse, error) {
 	entry, err := s.entryForRef(params.Ref, "")
 	if err != nil {
-		return appwire.TurnDrainAsSteerResponse{}, err
+		return appwire.TurnDrainAsSteerResponse{}, localDaemonMutationEntryError(params.ClientMutationID, err)
 	}
 	var out appwire.TurnDrainAsSteerResponse
 	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(client *appwire.Client) error {
@@ -351,7 +351,7 @@ func (s *LocalDaemonSource) DrainAsSteer(ctx context.Context, params appwire.Tur
 func (s *LocalDaemonSource) PromoteQueuedAsSteer(ctx context.Context, params appwire.TurnPromoteQueuedAsSteerParams) (appwire.TurnPromoteQueuedAsSteerResponse, error) {
 	entry, err := s.entryForRef(params.Ref, "")
 	if err != nil {
-		return appwire.TurnPromoteQueuedAsSteerResponse{}, err
+		return appwire.TurnPromoteQueuedAsSteerResponse{}, localDaemonMutationEntryError(params.ClientMutationID, err)
 	}
 	var out appwire.TurnPromoteQueuedAsSteerResponse
 	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(client *appwire.Client) error {
@@ -363,7 +363,7 @@ func (s *LocalDaemonSource) PromoteQueuedAsSteer(ctx context.Context, params app
 func (s *LocalDaemonSource) CancelQueued(ctx context.Context, params appwire.TurnCancelQueuedParams) (appwire.TurnCancelQueuedResponse, error) {
 	entry, err := s.entryForRef(params.Ref, "")
 	if err != nil {
-		return appwire.TurnCancelQueuedResponse{}, err
+		return appwire.TurnCancelQueuedResponse{}, localDaemonMutationEntryError(params.ClientMutationID, err)
 	}
 	var resp appwire.TurnCancelQueuedResponse
 	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(client *appwire.Client) error {
@@ -722,6 +722,22 @@ func localDaemonMutationCallError(clientMutationID string, err error) error {
 			RetryDisposition: appwire.RetryDispositionAutomatic,
 		},
 	}
+}
+
+func localDaemonMutationEntryError(clientMutationID string, err error) error {
+	var wire appwire.WireError
+	if !errors.As(err, &wire) {
+		return err
+	}
+	data, ok := wire.Data.(appwire.ErrorData)
+	if wire.Code != appwire.CodeUnavailable || !ok || data.EvenerErrorInfo != appwire.ErrorSessionUnavailable {
+		return err
+	}
+	data.ClientMutationID = clientMutationID
+	data.MutationOutcome = appwire.MutationOutcomeNotAccepted
+	data.RetryDisposition = appwire.RetryDispositionNone
+	wire.Data = data
+	return wire
 }
 
 func localDaemonInitializeError(err error) error {

--- a/cmd/evener-hub/internal/appsource/local_daemon_covtest_test.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon_covtest_test.go
@@ -32,8 +32,7 @@ func requireCovMutationError(t *testing.T, err error, want string, unavailable b
 	if unavailable {
 		wantWire := appwire.SessionUnavailable(want)
 		data, ok := wire.Data.(appwire.ErrorData)
-		wantData := wantWire.Data.(appwire.ErrorData)
-		if wire.Code != wantWire.Code || wire.Message != wantWire.Message || !ok || data.EvenerErrorInfo != wantData.EvenerErrorInfo {
+		if wire.Code != wantWire.Code || wire.Message != wantWire.Message || !ok || data.EvenerErrorInfo != appwire.ErrorSessionUnavailable {
 			t.Fatalf("wire error = %#v, want %#v", wire, wantWire)
 		}
 	}

--- a/cmd/evener-hub/internal/appsource/local_daemon_covtest_test.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon_covtest_test.go
@@ -31,9 +31,27 @@ func requireCovMutationError(t *testing.T, err error, want string, unavailable b
 	}
 	if unavailable {
 		wantWire := appwire.SessionUnavailable(want)
-		if wire.Code != wantWire.Code || wire.Message != wantWire.Message || wire.Data != wantWire.Data {
+		data, ok := wire.Data.(appwire.ErrorData)
+		wantData := wantWire.Data.(appwire.ErrorData)
+		if wire.Code != wantWire.Code || wire.Message != wantWire.Message || !ok || data.EvenerErrorInfo != wantData.EvenerErrorInfo {
 			t.Fatalf("wire error = %#v, want %#v", wire, wantWire)
 		}
+	}
+}
+
+func requireCovMutationRejection(t *testing.T, err error, want, mutationID string) {
+	t.Helper()
+	requireCovMutationError(t, err, want, true)
+	var wire appwire.WireError
+	if !errors.As(err, &wire) {
+		t.Fatalf("error %T = %v, want WireError", err, err)
+	}
+	data, ok := wire.Data.(appwire.ErrorData)
+	if !ok ||
+		data.ClientMutationID != mutationID ||
+		data.MutationOutcome != appwire.MutationOutcomeNotAccepted ||
+		data.RetryDisposition != appwire.RetryDispositionNone {
+		t.Fatalf("wire error = %#v, want terminal rejection for %q", wire, mutationID)
 	}
 }
 
@@ -41,10 +59,12 @@ func requireCovMutationError(t *testing.T, err error, want string, unavailable b
 // ref doesn't resolve to any thread (local_daemon.go:352-353).
 func TestCovPromoteQueuedAsSteerRefNotFound(t *testing.T) {
 	s := covMutationSource()
+	const mutationID = "mutation-promote-missing"
 	_, err := s.PromoteQueuedAsSteer(t.Context(), appwire.TurnPromoteQueuedAsSteerParams{
-		Ref: "local:missing",
+		Ref:              "local:missing",
+		ClientMutationID: mutationID,
 	})
-	requireCovMutationError(t, err, "thread not found: missing", true)
+	requireCovMutationRejection(t, err, "thread not found: missing", mutationID)
 }
 
 // TestCovPromoteQueuedAsSteerBadRef covers the error path where the ref is
@@ -71,10 +91,12 @@ func TestCovPromoteQueuedAsSteerSourceMismatch(t *testing.T) {
 // resolve to any thread (local_daemon.go:364-365).
 func TestCovCancelQueuedRefNotFound(t *testing.T) {
 	s := covMutationSource()
+	const mutationID = "mutation-cancel-missing"
 	_, err := s.CancelQueued(t.Context(), appwire.TurnCancelQueuedParams{
-		Ref: "local:missing",
+		Ref:              "local:missing",
+		ClientMutationID: mutationID,
 	})
-	requireCovMutationError(t, err, "thread not found: missing", true)
+	requireCovMutationRejection(t, err, "thread not found: missing", mutationID)
 }
 
 // TestCovCancelQueuedBadRef covers the error path where the ref is

--- a/cmd/evener-hub/spawn_test.go
+++ b/cmd/evener-hub/spawn_test.go
@@ -154,7 +154,7 @@ func TestHubSpawnerResumeLaunchCheckOmitsAmbientModel(t *testing.T) {
 	script := `#!/bin/sh
 if [ "$1" = "launch-check" ]; then
   printf '%s\n' "$@" > "$ARGS_OUT"
-  printf '{"protocol":"evener-appwire-v4"}\n'
+  printf '{"protocol":"evener-appwire-v3"}\n'
   exit 0
 fi
 if [ "$1" = "serve" ]; then
@@ -662,7 +662,7 @@ func TestHubSpawnerSpawnPassesHubTokenToDaemon(t *testing.T) {
 	bin := filepath.Join(dir, "fake-evener")
 	script := `#!/bin/sh
 if [ "$1" = "launch-check" ]; then
-  printf '{"protocol":"evener-appwire-v4"}\n'
+  printf '{"protocol":"evener-appwire-v3"}\n'
   exit 0
 fi
 if [ "$1" = "serve" ]; then
@@ -717,7 +717,7 @@ func TestHubSpawnerSpawnUsesConfiguredXDGStateHomeForStateDir(t *testing.T) {
 	bin := filepath.Join(dir, "fake-evener")
 	script := `#!/bin/sh
 if [ "$1" = "launch-check" ]; then
-  printf '{"protocol":"evener-appwire-v4"}\n'
+  printf '{"protocol":"evener-appwire-v3"}\n'
   exit 0
 fi
 if [ "$1" = "serve" ]; then
@@ -787,7 +787,7 @@ func TestHubSpawnerListsModelsFromEvenerLaunchContract(t *testing.T) {
 	bin := filepath.Join(dir, "fake-evener")
 	script := `#!/bin/sh
 if [ "$1" = "launch-check" ]; then
-  printf '{"protocol":"evener-appwire-v4","models":[{"provider":"openai","model":"gpt-5.5"}]}\n'
+  printf '{"protocol":"evener-appwire-v3","models":[{"provider":"openai","model":"gpt-5.5"}]}\n'
   exit 0
 fi
 exit 2
@@ -948,12 +948,12 @@ func TestProviderCredentialPreflightAcceptsOllama(t *testing.T) {
 	}
 }
 
-func TestValidateEvenerLaunchContractRejectsPreviousProtocolBinary(t *testing.T) {
+func TestValidateEvenerLaunchContractRejectsIncompatibleProtocolBinary(t *testing.T) {
 	evenerBinary := filepath.Join(t.TempDir(), "old-evener")
 	writeFakeEvener(t, evenerBinary, `#!/bin/sh
 case " $* " in
   *" --protocol evener-appwire-v3 "*)
-    printf '{"protocol":"evener-appwire-v3"}\n'
+    printf '{"protocol":"evener-appwire-v2"}\n'
     exit 0
     ;;
 esac
@@ -963,7 +963,7 @@ exit 2
 
 	err := validateEvenerLaunchContract(context.Background(), evenerBinary, "", nil)
 	if err == nil {
-		t.Fatal("validateEvenerLaunchContract accepted an evener-appwire-v3 child binary")
+		t.Fatal("validateEvenerLaunchContract accepted an evener-appwire-v2 child binary")
 	}
 	assertHubLaunchError(t, err)
 }
@@ -1617,7 +1617,7 @@ func TestHubSpawnerResumeAcceptsMaterializedOllamaConfig(t *testing.T) {
 	bin := filepath.Join(dir, "fake-evener")
 	script := `#!/bin/sh
 if [ "$1" = "launch-check" ]; then
-  printf '{"protocol":"evener-appwire-v4"}\n'
+  printf '{"protocol":"evener-appwire-v3"}\n'
   exit 0
 fi
 if [ "$1" = "serve" ]; then

--- a/cmd/evener-hub/web_test.go
+++ b/cmd/evener-hub/web_test.go
@@ -2161,8 +2161,22 @@ func TestWeb_ApiDirCreate(t *testing.T) {
 }
 
 func startAppwireTestDaemon(t *testing.T, dir, sessionID string, register func(*appserver.Server)) *httptest.Server {
+	return startAppwireTestDaemonWithProtocol(t, dir, sessionID, appwire.ProtocolVersion, register)
+}
+
+func startAppwireTestDaemonWithProtocol(t *testing.T, dir, sessionID, protocolVersion string, register func(*appserver.Server)) *httptest.Server {
 	t.Helper()
 	app := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
+	if protocolVersion != appwire.ProtocolVersion {
+		appserver.HandleTyped(app.Router(), appwire.MethodInitialize, func(_ context.Context, params appwire.InitializeParams) (appwire.InitializeResponse, error) {
+			if params.ProtocolVersion != protocolVersion {
+				return appwire.InitializeResponse{}, appwire.InvalidRequest(
+					fmt.Sprintf("protocol version %q is incompatible; want %q", params.ProtocolVersion, protocolVersion),
+				)
+			}
+			return appwire.InitializeResponse{ProtocolVersion: protocolVersion, SourceID: "local"}, nil
+		})
+	}
 	appserver.HandleTyped(app.Router(), appwire.MethodThreadRead, func(_ context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
 		ref := params.Ref
 		if ref == "" {
@@ -2202,7 +2216,7 @@ func startAppwireTestDaemon(t *testing.T, dir, sessionID string, register func(*
 	writeRendezvous(t, dir, rendezvous.Entry{
 		PID:        200,
 		Address:    strings.TrimPrefix(srv.URL, "http://"),
-		Protocol:   appwire.ProtocolVersion,
+		Protocol:   protocolVersion,
 		Endpoint:   "ws" + srv.URL[len("http"):] + "/rpc",
 		SourceID:   "local",
 		ThreadID:   sessionID,

--- a/cmd/evener/internal/launchcheck/launchcheck_test.go
+++ b/cmd/evener/internal/launchcheck/launchcheck_test.go
@@ -42,14 +42,14 @@ func TestLaunchCheckReportsProtocolAndValidatedModel(t *testing.T) {
 		t.Fatalf("launch check output=%+v", out)
 	}
 	// Literal check: catches a change to the ProtocolVersion constant value.
-	if out.Protocol != "evener-appwire-v4" {
-		t.Fatalf("out.Protocol=%q, want \"evener-appwire-v4\"", out.Protocol)
+	if out.Protocol != "evener-appwire-v3" {
+		t.Fatalf("out.Protocol=%q, want \"evener-appwire-v3\"", out.Protocol)
 	}
 }
 
 func TestLaunchCheckRejectsPreviousProtocolVersion(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	err := RunLaunchCheck([]string{"--protocol", "evener-appwire-v3", "--json"}, &stdout, &stderr)
+	err := RunLaunchCheck([]string{"--protocol", "evener-appwire-v2", "--json"}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "unsupported appwire protocol") {
 		t.Fatalf("RunLaunchCheck error = %v, want previous-protocol rejection", err)
 	}


### PR DESCRIPTION
## Summary

- keep AppWire at v3 because the plugin-root launch option is additive, allowing a restarted hub to rediscover and steer surviving v3 daemons
- return a correlated terminal rejection when a local mutation cannot be forwarded, so the browser outbox leaves its queued state
- cover restart resume and steering through the real hub RPC, using the shared AppWire test daemon

## Verification

- `make merge-approval-gate`
- `make vet`
- `make test-web-browser`