### PR TITLE
Remove stale tree REST residue

### DIFF
--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
@@ -1239,8 +1239,8 @@ describe("session row", () => {
 
   // A live-tier row's own Tier/PinSectionID/Rename fields must all survive the
   // duplicate projection. RailRow reads pin_section_id/rename directly,
-  // regardless of the session's real decisions, since handleAPITree's Live
-  // loop bypassed the tier-stamping helper entirely. RailRow never gated
+  // regardless of the session's real decisions, since the navigation
+  // projection stamps the live tier separately. RailRow never gated
   // these on tier itself - it just reads session.favorite/session.rename
   // directly, same as every other row - so once the hub fix landed, this
   // was already correct with no rail-side code change; pinned explicitly

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
@@ -366,9 +366,9 @@ function ActionsMenu({ label, items }: { label: string; items: MenuItem[] }) {
   );
 }
 
-// "no-project" is a synthetic bucket handleAPITree synthesizes for orphan
-// live sessions with no resolvable project (cmd/evener-hub/web_api_tree.go) -
-// it can appear in the wire's `projects` array like any other TreeProject,
+// "no-project" is a synthetic project bucket for orphan live sessions whose
+// project cannot be resolved (cmd/evener-hub/navigation_projection.go). It can
+// appear in the wire's `projects` array like any other TreeProject,
 // but the server rejects both archive and delete for this exact key
 // ("no-project is not a local project" - web_api_archive.go/
 // web_api_project_delete.go). Offering menu items that are guaranteed to

--- a/cmd/evener-hub/internal/hubcore/roster_test.go
+++ b/cmd/evener-hub/internal/hubcore/roster_test.go
@@ -822,7 +822,7 @@ func fuzzScenarioRoster_OnStatusChangeNotFiredWhenStatusUnchanged(t *testing.T) 
 // wires the pieces together: a session's status transition (as detected by
 // Roster.Refresh) drives PastIndex.RefreshOne, which re-reads the session's
 // on-disk meta and, on a genuine content delta, bumps the shared
-// InputsVersion counter the /api/tree memo keys on. Before this fix, that
+// InputsVersion counter the navigation memo keys on. Before this fix, that
 // bump only happened on PastIndex's own 60s Rebuild ticker.
 func fuzzScenarioRoster_StatusChangeDrivesPastIndexRefreshAndVersionBump(t *testing.T) {
 	stateRoot := t.TempDir()

--- a/cmd/evener-hub/internal/hubcore/tree.go
+++ b/cmd/evener-hub/internal/hubcore/tree.go
@@ -26,7 +26,7 @@ import (
 //     project's sessions are split into Current / Recent / Archived tiers.
 //   - ArchivedProjects is the collapsed group at the bottom: projects that are
 //     manually archived or whose every session is archived.
-//   - Live is the flat live list consumed by the /api/tree JSON endpoint and
+//   - Live is the flat live list consumed by the navigation projection and
 //     rendered as the rail's "Live" section. Archived sessions are excluded:
 //     an archived-but-still-running session is reachable under its project's
 //     Archived tier instead, because archive is a clearing verb.
@@ -504,9 +504,9 @@ func nodeTitle(m schema.SessionMeta, kind string) string {
 // maxTitleRunes caps sidebar node titles. Titles fall back to the session's
 // full OriginalPrompt, which can run to tens of kilobytes; a one-line sidebar
 // row only ever shows the first couple hundred characters, and shipping the
-// full prompt for every archived session made /api/tree megabytes heavier
-// than it needed to be. The full prompt remains available from the session
-// detail endpoints.
+// full prompt for every archived session made the navigation payload
+// megabytes heavier than it needed to be. The full prompt remains available
+// from the session detail endpoints.
 const maxTitleRunes = 200
 
 // truncateTitle caps s at maxTitleRunes runes, appending an ellipsis when it

--- a/cmd/evener-hub/main.go
+++ b/cmd/evener-hub/main.go
@@ -291,9 +291,9 @@ func runMain(args []string, stderr io.Writer, deps mainDeps) error {
 	// as a fallback when a session's project dir can't be found in the past index.
 	stateDir := filepath.Dir(filepath.Clean(strings.TrimSuffix(stateGlob, "*")))
 
-	// inputs is the shared inputs-version counter the /api/tree memo (TreeCache)
-	// keys on; bumped whenever an input to the tree changes so the next request
-	// recomputes instead of serving a stale memoized tree.
+	// inputs is the shared source-revision counter used by NavigationService and
+	// the remaining memoized tree projection; bumping it makes the next read
+	// observe changed navigation inputs instead of stale state.
 	inputs := &hubcore.InputsVersion{}
 
 	// Wire archive/favorite's content-delta-gated onChange hook (Task 10) to
@@ -480,8 +480,8 @@ func runMain(args []string, stderr io.Writer, deps mainDeps) error {
 	startHubPluginMaintenance(ctx, cfg, web, startBackground)
 	// Remote-thread cache refresher: refreshRemoteThreads (web_api_tree.go)
 	// walks every configured remote source's ListThreads, a synchronous
-	// network hop that used to run inline on every /api/tree request. Move it
-	// to a ~30s ticker + poke so a tree render never blocks on it; the tree
+	// network hop that used to run inline on every navigation read. Move it
+	// to a ~30s ticker + poke so a tree render never blocks on it; the navigation
 	// read path (remoteTreeThreads) reads remoteCache.Get() instead whenever
 	// RemoteThreadCache is configured.
 	startBackground(func() { refreshHubRemoteThreads(ctx, remotePoke, remoteCache, web) })

--- a/cmd/evener-hub/web.go
+++ b/cmd/evener-hub/web.go
@@ -40,9 +40,9 @@ type WebServer struct {
 	// liveModels caches raw live /models listings for this server; per-server
 	// so another WebServer (different provider config) never shares entries.
 	liveModels *modelsCache
-	// treeCache memoizes the complete /api/tree navigation generation — tree,
-	// attention, live entries, and favorite authority — by inputs-version,
-	// remote generation, and 30s time bucket (see hubcore.TreeCache).
+	// treeCache memoizes the shared tree projection used by the remaining
+	// mutation handlers. NavigationService owns AppWire navigation generations
+	// and captures its source directly rather than using this cache.
 	treeCache  *hubcore.TreeCache
 	manifestFS fs.FS
 

--- a/cmd/evener-hub/web_api_pin_section_test.go
+++ b/cmd/evener-hub/web_api_pin_section_test.go
@@ -445,13 +445,11 @@ func TestAPIPinSectionsNilStoreAndMethods(t *testing.T) {
 	}
 }
 
-// TestAPISessionPinSurvivesSubsequentTreeLoad proves a direct pin-API section
-// assignment is not disturbed by a later /api/tree read. Historically a
-// stored legacy favorite for the same session made handleAPITree's
-// migrate-on-read path (ensureLegacyPinsMigrated) silently reassign the
-// session into the "Pinned" section, clobbering the explicit assignment made
-// through /api/session-pin.
-func TestAPISessionPinSurvivesSubsequentTreeLoad(t *testing.T) {
+// TestAPISessionPinSurvivesSubsequentNavigationRead proves a direct pin-API
+// section assignment is not disturbed when the AppWire navigation projection
+// is rebuilt. A stored favorite for the same session must not override the
+// explicit assignment made through /api/session-pin.
+func TestAPISessionPinSurvivesSubsequentNavigationRead(t *testing.T) {
 	const sessionID = "session-a"
 	past := hubcore.NewPastIndex("")
 	past.SeedForTest([]schema.SessionMeta{topLevelMeta(sessionID)})
@@ -472,7 +470,7 @@ func TestAPISessionPinSurvivesSubsequentTreeLoad(t *testing.T) {
 	wantSectionID := assignedBody.Assignment.Section.ID
 
 	// Trigger the navigation projection directly to verify the pin assignment
-	// survives a navigation read (the replacement for the legacy /api/tree load).
+	// survives a navigation read through the AppWire projection.
 	if _, err := web.navigation.Representation(t.Context(), navigationResourceKey{Kind: navigationResourceManifest}); err != nil {
 		t.Fatalf("navigation representation: %v", err)
 	}

--- a/cmd/evener-hub/web_api_project_delete.go
+++ b/cmd/evener-hub/web_api_project_delete.go
@@ -439,7 +439,7 @@ func (s *WebServer) cleanupProjectDeletion(
 	}
 	if len(result.Deleted) > 0 {
 		// Refresh the roster before the bump and broadcast below, so the
-		// UI's immediate follow-up GET /api/tree is built from a roster that
+		// UI's immediate follow-up navigation read is built from a roster that
 		// already dropped the deleted sessions (their rendezvous files were
 		// just unlinked) instead of showing ghost rows until the 5s tick.
 		if s.cfg.Roster != nil {

--- a/cmd/evener-hub/web_api_project_delete_test.go
+++ b/cmd/evener-hub/web_api_project_delete_test.go
@@ -699,7 +699,7 @@ func TestProjectDeleteRefusesLiveSessionWhoseProbeTransientlyFails(t *testing.T)
 // TestProjectDeleteRefreshesRosterAndBustsTreeMemo pins the post-delete
 // freshness contract: a successful project delete must (1) refresh the
 // in-memory roster BEFORE poking the attention watcher, so the immediate
-// follow-up GET /api/tree the frontend issues is served from a roster that
+// follow-up navigation read issued by the frontend is served from a roster that
 // already dropped the deleted sessions instead of ghost rows until the next
 // 5s tick, and (2) bump the shared InputsVersion so the tree memo is busted
 // even when the past-index rebuild reports no delta.

--- a/cmd/evener-hub/web_api_session_delete_test.go
+++ b/cmd/evener-hub/web_api_session_delete_test.go
@@ -511,8 +511,9 @@ func TestAPISessionDeleteRetryScrubsPinAfterArtifactsAreAlreadyGone(t *testing.T
 // TestSessionDeleteRefreshesRosterAndBustsTreeMemo mirrors
 // TestProjectDeleteRefreshesRosterAndBustsTreeMemo for the single-session
 // handler: a successful delete must refresh the roster before PokeAttention
-// (no ghost rows in the immediate follow-up /api/tree) and bump the shared
-// InputsVersion so the tree memo is busted even without a past-index delta.
+// (no ghost rows in the immediate follow-up navigation read) and bump the
+// shared InputsVersion so the tree memo is busted even without a past-index
+// delta.
 func TestSessionDeleteRefreshesRosterAndBustsTreeMemo(t *testing.T) {
 	root := t.TempDir()
 	projectDir := filepath.Join(root, "project")

--- a/cmd/evener-hub/web_api_tree.go
+++ b/cmd/evener-hub/web_api_tree.go
@@ -131,10 +131,9 @@ func projectFavoritePresentation(presentation map[hubcore.ArchiveKey]bool) map[h
 	return projects
 }
 
-// memoTree returns the memoized full tree + attention summary, single-sourced
-// so callers never diverge on what "the tree" is. The full tree endpoint uses
-// memoTreeWithAuthority below when it also needs the exact raw snapshot used
-// to build this value.
+// memoTree returns the memoized tree projection retained by mutation handlers
+// that still need it. AppWire navigation reads are owned by NavigationService,
+// whose webNavigationSource captures a fresh source snapshot.
 func (s *WebServer) memoTree(ctx context.Context) (hubcore.Tree, appwire.AttentionSummary) {
 	tree, summary, _, _ := s.memoTreeWithAuthority(ctx)
 	return tree, summary
@@ -413,8 +412,8 @@ func (s *WebServer) remoteTreeThreads(ctx context.Context) []appwire.Thread {
 // remote source: it lists each source's threads (via listThreadsWithFallback,
 // which retains the last-known-good result across transient errors) and
 // backfills each thread's Source and Evener.Ref. This used to run inline on
-// every /api/tree request (as remoteTreeThreads); it now runs on a background
-// ~30s ticker + poke (main.go), Storing its result into a RemoteThreadCache
+// every navigation read (as remoteTreeThreads); it now runs on a background
+// ~30s ticker + poke (main.go), storing its result into a RemoteThreadCache
 // for remoteTreeThreads to read.
 func (s *WebServer) refreshRemoteThreads(ctx context.Context) []appwire.Thread {
 	return s.refreshRemoteThreadSnapshot(ctx).threads
@@ -1260,7 +1259,8 @@ func (s *WebServer) apiSessionDetail(id string) (hubapi.SessionDetail, bool) {
 		// A live rename lands in the persisted meta before the daemon thread
 		// reports the new Name; if the live thread carried no name (detail.Title
 		// fell back to the session id), prefer the resolved meta name so the
-		// session-detail endpoint agrees with /api/tree (WS3 T25 Bug 2).
+		// session-detail endpoint agrees with the navigation projection (WS3 T25
+		// Bug 2).
 		if detail.Title == "" || detail.Title == detail.SessionID {
 			if s.cfg.Roster != nil {
 				le, _ := s.cfg.Roster.Find(canonicalRouteID(id))

--- a/cmd/evener-hub/web_api_tree_deleted_workdir_test.go
+++ b/cmd/evener-hub/web_api_tree_deleted_workdir_test.go
@@ -18,7 +18,7 @@ import (
 // reason to mint a phantom "no-project" group named after the worktree leaf.
 // Two distinct dead lanes of the SAME project make the failure mode visible
 // pre-fix: two archived stubs sharing Key "no-project", which the rail then
-// hydrates from a single /api/tree/project?key=no-project detail — the
+// hydrates from a single navigation project-read detail — the
 // replicated archived rows this regression test guards.
 func TestAPITreeDeletedWorktreeSessionsStayInOriginalProject(t *testing.T) {
 	root := t.TempDir()

--- a/cmd/evener-hub/web_test.go
+++ b/cmd/evener-hub/web_test.go
@@ -536,11 +536,6 @@ func TestWeb_LocalSendUnavailableCapabilityDoesNotStartTurn(t *testing.T) {
 	}
 }
 
-// TestWeb_APITreeProjectUnknownKeyErrors is the /api/tree/project counterpart
-// of the deleted sidebar-project HTML-partial test: an empty key is a client
-// error (400, the handler's early-return validation) and an unrecognized key
-// is a 404 (the "not found in the memoized tree" branch) — distinct from the
-// old route, which 404'd on both.
 // TestStateLabel_ErroredAndNeedsYou pins the two label changes the errored
 // render lane requires: "awaiting" reads as "Your move" (not the flat,
 // unlabeled "Awaiting"), and "errored" gets its own human label rather than

--- a/docs/evener-hub-web-routing.md
+++ b/docs/evener-hub-web-routing.md
@@ -3,7 +3,8 @@
 Evener Hub uses a full-page app shell plus HTMX-loaded fragments.
 
 - User-facing page routes stay clean and deep-linkable: `/`, `/new`, `/s/:ref`, `/settings`, and `/settings/:section`.
-- AppWire and API routes stay under `/rpc` and `/api`.
+- AppWire requests use `/rpc`; HTTP routes that have not yet migrated stay
+  under `/api`.
 - Internal fragments live under `/_partials/*` and require `HX-Request: true`.
 
 Fragment routes:
@@ -20,17 +21,20 @@ Legacy fragment-looking paths such as `/sidebar`, `/workspace/spawn`, and
 `/s/:ref/state` are not public routes. Direct browser navigation should land on
 a page route or fail instead of rendering a fragment without the app shell.
 
-Sidebar routes (JSON, not fragments):
+Sidebar navigation (AppWire, not fragments):
 
-The sidebar is client-rendered: it fetches JSON and keeps its own keyed DOM,
-instead of swapping in a server-rendered HTML partial. `/_partials/sidebar`
-and `/_partials/sidebar/project` are gone — there is no server-rendered
-sidebar left to fragment-route.
+The sidebar is client-rendered: it reads typed navigation resources over the
+authenticated AppWire connection and keeps its own keyed DOM, instead of
+swapping in a server-rendered HTML partial. `/_partials/sidebar` and
+`/_partials/sidebar/project` are gone — there is no server-rendered sidebar
+left to fragment-route.
 
-- `GET /api/tree` — the sidebar's data source: the full navigation tree
-  (live sessions, projects, Needs-you, Pinned, archived projects, test runs).
-- `GET /api/tree/project?key=` — one project's node, keyed by its slug; used
-  to re-fetch a project the client has expanded.
+- `evener/navigation/read` — the typed sidebar read surface. Its `manifest`
+  resource provides the bounded descriptor/count index and attention summary;
+  `section`, `pin_catalog`, `pin_section`, `catalog`, `project`,
+  `project_page`, and `location` resources provide bounded rows and ownership
+  details. The canonical request shapes, pagination rules, and response
+  envelope are maintained in the [AppWire navigation resource matrix](developing-evener/agentic-testing.md).
 - `POST /api/favorite` — set or clear a session's or project's favorite
   (Pinned) decision.
 - `POST /api/project/delete` — delete every session under a project.

--- a/docs/superpowers/plans/2026-08-27-tree-rest-residue-burndown.md
+++ b/docs/superpowers/plans/2026-08-27-tree-rest-residue-burndown.md
@@ -1,0 +1,84 @@
+# Stale `/api/tree` REST Residue Cleanup Plan
+
+**Goal:** Remove executable and current-contract residue for the retired
+`/api/tree` endpoint without deleting the shared tree projection used by
+AppWire navigation.
+
+**Spec:** `docs/superpowers/specs/2026-08-27-tree-rest-residue-burndown-design.md`
+
+## Constraints
+
+- Work only from a refreshed `origin/main`.
+- Preserve navigation behavior and all meaningful tree/projection coverage.
+- Leave append-only fuzz route indices and historical records unchanged.
+- Do not add absence tests.
+- Use the required pre-implementation and post-implementation
+  `simplify-code` reviews.
+
+## Task 1: Remove executable/obsolete residue
+
+**Files:**
+
+- Modify `scripts/coverage/e2e-cover.sh`.
+- [x] Remove the `/api/tree` HTTP sweep entry. The refreshed `origin/main`
+already has no obsolete skipped tree-read test, so this branch does not delete
+one or claim that another test covers its local-input behavior. Keep all active
+tree and navigation tests.
+
+## Task 2: Correct active route language
+
+**Files:**
+
+- Modify only the stale `/api/tree` comment sites in
+  `cmd/evener-hub/main.go`, `web.go`, `web_api_tree.go`,
+  `web_api_project_delete.go`, `web_types.go`, and
+  `internal/hubcore/tree.go`, plus the related current test comment in
+  `internal/hubcore/roster_test.go`.
+- Modify only related current-test comments in
+  `web_api_session_delete_test.go`, `web_api_project_delete_test.go`,
+  `web_api_pin_section_test.go`, `web_api_tree_deleted_workdir_test.go`, and
+  `web_test.go` that describe follow-up navigation reads or projected refs.
+- Update current rail comments in `frontend/src/shell/rail/RailRow.tsx` and
+  `RailRow.test.tsx` that still name the retired tree handler.
+- Do not edit the append-only route registry or numeric fuzz seed.
+
+- [x] Describe the current navigation snapshot/AppWire read and shared projection
+semantics. Do not change identifiers, behavior, or historical documentation.
+
+## Task 3: Correct current parity documentation
+
+**Files:**
+
+- Modify the current route inventory in `docs/evener-hub-web-routing.md`.
+- Modify `docs/web-ui/parity/parity-m6-surfaces.md`.
+- Modify the live scenario cards that still use the retired route:
+  `test/scenarios/status-vocabulary-roundtrip.md`,
+  `test/scenarios/spawn-keyboard-contract.md`,
+  `test/scenarios/spawn-empty-prompt-starts-dormant.md`,
+  `test/scenarios/sidebar-favorite-pinned-across-reload.md`,
+  `test/scenarios/ask-web-answer.md`, and `test/scenarios/INDEX.md`.
+
+- [x] Replace current `/api/tree` claims with the existing AppWire navigation-read
+  contract, distinguishing the manifest's descriptors/attention summary from
+  the bounded row resources. Preserve the user-visible and notification
+  behavior each card documents. Leave historical parity/design records alone.
+
+## Task 4: Audit and verify
+
+- [x] Run a scoped residue audit that allowlists
+`internal/fuzzroutes/fuzzroutes.go` and `web_fuzz_test.go`'s append-only
+retired slot while distinguishing historical records. Read the testing guide
+before test changes. Run `gofmt` if needed, `git diff --check`,
+`go test ./cmd/evener-hub`, `make lint`, `make vet`, and `make test`. Run the
+required post-implementation `simplify-code` review and apply only
+quality-preserving fixes. Rebase, whole-branch review, and publication follow
+the standard finishing workflow.
+
+## Completion criteria
+
+- No active `/api/tree` executable probe or current-contract claim remains
+  outside the explicitly retained append-only fuzz registry/seed.
+- Shared tree/navigation implementation and meaningful behavior tests remain.
+- No behavior or AppWire wire contract changes.
+- Simplify passes, focused tests, repository gates, rebase verification, and
+  whole-branch review are all clean.

--- a/docs/superpowers/specs/2026-08-27-tree-rest-residue-burndown-design.md
+++ b/docs/superpowers/specs/2026-08-27-tree-rest-residue-burndown-design.md
@@ -1,0 +1,54 @@
+# Remove Stale `/api/tree` REST Residue
+
+## Status
+
+Approved implementation slice: clean up the retired `/api/tree` application
+JSON surface after navigation reads moved to `evener/navigation/read` over
+AppWire. No `/api/tree` route is registered on `origin/main`; the remaining
+active references are stale coverage or route language, while the tree
+projection code is still shared by navigation and must remain.
+
+## Evidence and invariant
+
+The route table in `cmd/evener-hub/web.go` has no `/api/tree` registration.
+Navigation reads are registered through `evener/navigation/read` in
+`cmd/evener-hub/app_rpc.go`, and `navigation_service.go` still consumes the
+tree-building helpers from `web_api_tree.go`. The migration invariant is:
+
+> No active executable probe or current contract describes `/api/tree` as a
+> live application API; shared navigation projection and behavior coverage
+> remain intact.
+
+## Scope
+
+- Remove `/api/tree` from the real-binary HTTP coverage sweep.
+- Confirm the refreshed base has no obsolete skipped test whose setup depends
+  on the retired tree-read path; do not add an absence test or claim that
+  another test covers deleted local-input behavior.
+- Update the exact active production/test comments that describe navigation
+  reads, shared tree projection, or qualified search refs.
+- Update the current M6 parity claim and live scenario cards to distinguish the
+  AppWire navigation manifest from its bounded section/catalog/project
+  resources instead of describing the retired URL.
+- Keep the tree cache, projection helpers, navigation tests, mutation
+  invalidation, and AppWire navigation contract unchanged.
+
+## Explicit exclusions
+
+- Do not remove or rename `web_api_tree.go` or `hubcore/tree.go`; those are
+  shared implementation layers for the AppWire navigation projection and
+  mutation invalidation.
+- Do not alter `internal/fuzzroutes/fuzzroutes.go`'s `/api/tree` entry or
+  `web_fuzz_test.go`'s numeric retired-route seed. Their route indices are
+  append-only corpus compatibility data.
+- Do not rewrite historical `docs/superpowers/**` or legacy parity/design
+  records whose purpose is to document the former REST behavior.
+- Do not add a test that asserts the old route is absent.
+
+## Expected result
+
+The active source and live-scenario audit finds no `/api/tree` route/probe or
+current-contract claim outside the explicitly retained append-only fuzz
+registry/seed and historical records. Navigation behavior remains served by
+`evener/navigation/read` and continues to use the existing shared tree
+projection.

--- a/docs/web-ui/parity/parity-m6-surfaces.md
+++ b/docs/web-ui/parity/parity-m6-surfaces.md
@@ -332,15 +332,15 @@ All from `search.js:326-517` unless noted:
 
 ### 3.6 Baseline fetch & edge-fire gating
 
-- [ ] Baseline comes from `GET /api/tree?summary=1` — deliberately summary-only, never the full tree, since this client only needs the badge counts (`notifications.js:222-227`, code comment at 220-221)
-- [ ] Baseline is (re-)fetched on init AND on every appwire reconnect (a dropped connection can miss broadcasts, so reconnect re-syncs rather than trusting the gap stayed empty) (`notifications.js:222-227, 288-289`)
-- [ ] `summary` stays `null` until that first baseline resolves; ALL edge-firing (OS + sound) is suppressed until a baseline exists — specifically so reloading the hub can never re-alert on attention that was ALREADY true before the page opened (`notifications.js:46-50, 217-221, 258, 261`)
-- [ ] Title/favicon counts (`applyCounts`) update UNCONDITIONALLY on every `evener/attention/changed` broadcast — even before a baseline exists, even while unfocused, even on a non-leader tab. Only the OS/sound edge-fire is gated on those conditions (`notifications.js:256-260`)
-- [ ] Edge-fire additionally requires the document be unfocused (checked AGAIN here, on top of the per-channel checks in §3.4/§3.5) and this tab be the elected leader (`notifications.js:261-263`)
-- [ ] Only entries that just transitioned INTO `needs_you`/`error` FROM something else fire at all — a level that was already alarming before the broadcast stays silent (`notifications.js:264-267`)
-- [ ] Within a qualifying transition, `loudScope` narrows further: `"asks"` (default) fires ONLY for an `askPending` transition or an `error`; `"all"` fires for every qualifying transition (`notifications.js:268-269`)
-- [ ] `os` and `sound` prefs are checked independently of each other even after the transition/loudScope gate passes — either, both, or neither can fire per event (`notifications.js:270-271`)
-- [ ] `renderer.js` dispatches a `evener hub:thread-status` DOM event on a live `THREAD_STATUS_CHANGED` frame for the currently-open thread; this module listens and re-fetches the baseline immediately, ahead of the next hub-side attention tick (`notifications.js:291-294`, out-of-scope caller)
+- [ ] Baseline comes from the AppWire `evener/navigation/read` `manifest` resource — the bounded navigation response carries `attentionSummary`, so this client never needs to fetch the full tree just for badge counts (`cmd/evener-hub/frontend/src/stores/navigation/store.ts:471-483`, `cmd/evener-hub/frontend/src/stores/navigation/store.ts:593-598`)
+- [ ] Baseline is (re-)fetched on init AND on every AppWire reconnect (a dropped connection can miss broadcasts, so reconnect re-syncs rather than trusting the gap stayed empty) (`cmd/evener-hub/frontend/src/notifications/index.ts:104-108,129-147`, `cmd/evener-hub/frontend/src/stores/navigation/store.ts:471-483`)
+- [ ] `summary` stays `null` until that first baseline resolves; ALL edge-firing (OS + sound) is suppressed until a baseline exists — specifically so reloading the hub can never re-alert on attention that was ALREADY true before the page opened (`cmd/evener-hub/frontend/src/notifications/index.ts:33,40-67`)
+- [ ] Title/favicon counts (`applyCounts`) update UNCONDITIONALLY on every `evener/attention/changed` broadcast — even before a baseline exists, even while unfocused, even on a non-leader tab. Only the OS/sound edge-fire is gated on those conditions (`cmd/evener-hub/frontend/src/notifications/index.ts:40-43,84-88`)
+- [ ] Edge-fire additionally requires the document be unfocused (checked AGAIN here, on top of the per-channel checks in §3.4/§3.5) and this tab be the elected leader (`cmd/evener-hub/frontend/src/notifications/index.ts:68-75`)
+- [ ] Only entries that just transitioned INTO `needs_you`/`error` FROM something else fire at all — a level that was already alarming before the broadcast stays silent (`cmd/evener-hub/frontend/src/notifications/attention.ts:48-58`)
+- [ ] Within a qualifying transition, `loudScope` narrows further: `"asks"` (default) fires ONLY for an `askPending` transition or an `error`; `"all"` fires for every qualifying transition (`cmd/evener-hub/frontend/src/notifications/attention.ts:48-58`)
+- [ ] `os` and `sound` prefs are checked independently of each other even after the transition/loudScope gate passes — either, both, or neither can fire per event (`cmd/evener-hub/frontend/src/notifications/index.ts:68-75`)
+- [ ] `evener/attention/changed` notifications update the navigation store's attention summary and changed entries, and the notifications engine consumes that store for counts and edge detection (`cmd/evener-hub/frontend/src/stores/navigation/store.ts:593-598`, `cmd/evener-hub/frontend/src/notifications/index.ts:110-114`)
 
 ### 3.7 Single-tab election
 

--- a/scripts/coverage/e2e-cover.sh
+++ b/scripts/coverage/e2e-cover.sh
@@ -99,7 +99,7 @@ if command -v curl >/dev/null 2>&1; then
 		webasset_routes=""
 	fi
 
-	for route in / /api/health /api/tree "/api/search?q=x" \
+	for route in / /api/health "/api/search?q=x" \
 		/credentials /auth \
 		/api/sessions/nonexistent /doc/file /nonexistent-route; do
 		curl -fsS --max-time 5 "$base$route" >/dev/null 2>&1 || true

--- a/test/scenarios/INDEX.md
+++ b/test/scenarios/INDEX.md
@@ -456,7 +456,7 @@ cards read is produced by the `job-watch-*` cards above.
 ## Sidebar (rebuilt)
 
 Live end-to-end coverage for the rebuilt client-rendered sidebar
-(`cmd/evener-hub/assets/sidebar.js` + `/api/tree`): needs-you, favorites/Pinned,
+(`cmd/evener-hub/frontend/src/shell/rail/Rail.tsx` + `evener/navigation/read`): needs-you, favorites/Pinned,
 top-level active-project session rows, and the row menu. Each card was
 verified against a real hub + a real model turn (`openai/gpt-5.4-mini`).
 
@@ -464,8 +464,9 @@ verified against a real hub + a real model turn (`openai/gpt-5.4-mini`).
   project's session rows survive a `doResync()` triggered by live activity in
   a different project; surfaced a real (non-blocking) bug where a collapsed
   project's `aria-expanded` renders the literal string `"undefined"`.
-- `sidebar-favorite-pinned-across-reload.md` — `POST /api/favorite` is
-  reflected in `/api/tree`'s `favorites[]` and renders as a Pinned row that
+- `sidebar-favorite-pinned-across-reload.md` — the persisted pin mutation is
+  reflected in the AppWire navigation manifest/pin-section resources and
+  renders as a Pinned row that
   survives a hard reload; confirms no `localStorage` favorite cache exists.
 - `sidebar-project-delete-full-cycle.md` — `POST /api/project/delete`'s full
   state machine: path-mismatch 400, live-session 409 (files intact),
@@ -477,7 +478,7 @@ verified against a real hub + a real model turn (`openai/gpt-5.4-mini`).
   (namer suppression via `name_source:"user"`); rename on an ended session
   edits the meta file directly with no rollback toast. Notes a possible
   follow-up bug: `/api/sessions/<id>`'s detail `title` field doesn't reflect
-  a live session's rename the way `/api/tree` and the meta file do.
+  a live session's rename the way the navigation projection and the meta file do.
 - `sidebar-archived-testruns-reachability.md` — the collapsed-by-default
   `Archived (N)` and `Test runs (N)` sections end to end: a project's full
   archive→unarchive round-trip via the row menu, and a
@@ -500,8 +501,8 @@ verified against a real hub + a real model turn (`openai/gpt-5.4-mini`).
 - `sidebar-project-order-lastactivity-feel.md` — a just-touched project
   surfaces at the top, promptly. The `LastActivity` comparator is
   already pinned by hubcore fuzz scenarios, so this card covers the
-  layer they cannot see: a completed turn propagating into `/api/tree`'s
-  memoized `Past.AllMetas()` input.
+  layer they cannot see: a completed turn propagating into the navigation
+  projection's memoized `Past.AllMetas()` input.
 
 ## Cost display & Display settings (Track C)
 

--- a/test/scenarios/ask-web-answer.md
+++ b/test/scenarios/ask-web-answer.md
@@ -260,7 +260,7 @@ leaves the daemon running, which then poisons the next run's state poll.
   entirely and exhaust the loop still reading `awaiting` — that is not a failure; step 8's
   outline read is the actual proof, independent of whether this loop observed the
   transition.
-- The hub's roster refresh (which feeds `/api/tree` and the rail) ticks every 5s
+- The hub's roster refresh (which feeds the navigation projection and the rail) ticks every 5s
   (`cmd/evener-hub/internal/hubcore/roster.go:451`); the direct `/api/sessions/local:<SID>`
   call talks to the live daemon and reflects `awaiting` sooner. Don't confuse the two
   cadences — see `ask-cross-session-notify.md` for the roster-level path.

--- a/test/scenarios/sidebar-favorite-pinned-across-reload.md
+++ b/test/scenarios/sidebar-favorite-pinned-across-reload.md
@@ -1,6 +1,6 @@
 # sidebar-favorite-pinned-across-reload: named pinned session sections survive reloads, reuse hidden empties, and leave project favorites unchanged
 
-**What this covers**: the named-section replacement for session favorites: `POST /api/session-pin`, `DELETE /api/session-pin`, `GET /api/pin-sections`, `PATCH /api/pin-sections/<id>`, `DELETE /api/pin-sections/<id>`, and `/api/tree`'s `pin_sections[]` plus per-row `pin_section_id`. It proves the sidebar is driven by durable server state, not optimistic client state, across raw API mutations and hard reloads.
+**What this covers**: the named-section replacement for session favorites: `POST /api/session-pin`, `DELETE /api/session-pin`, `GET /api/pin-sections`, `PATCH /api/pin-sections/<id>`, `DELETE /api/pin-sections/<id>`, and the AppWire navigation manifest/pin-section resources plus the location resource's `pin_section_id`. It proves the sidebar is driven by durable server state, not optimistic client state, across raw API mutations and hard reloads.
 
 **Surface**: see `docs/developing-evener/agentic-testing.md`, especially the setup checklist and the reminder that every `eval` must assert the scenario hub's own `location.port`. Use a **fresh Hub state directory** and a **dedicated Chrome profile** for this scenario only. Never reuse Jesse's real hub, real `$HOME`, or any fixed host port from another run.
 
@@ -56,9 +56,9 @@ Every browser `eval` below must return `location.port` and the check must assert
 }))()
 ```
 
-5. Raw API cross-check:
+5. Transport cross-check:
    - `GET /api/pin-sections` contains one `Client work` section with `member_count: 1`.
-   - `GET /api/tree` contains one `pin_sections[]` entry named `Client work`, and the pinned row carries its `pin_section_id`.
+   - AppWire `evener/navigation/read` `pin_catalog` contains one `pin_sections[]` entry named `Client work`. Use that descriptor's `id` as the `sectionId` for the `pin_section` read, verify that resource contains the pinned row, and verify the session's `location.pin_section_id` matches the same ID.
 
 ### 2. Pin a second session into existing **Client work**
 
@@ -89,7 +89,7 @@ Every browser `eval` below must return `location.port` and the check must assert
 ```
 
 4. Assert the visible top-level order is **Live**, **Client work**, **Research**, **Projects** (with any other standard headings preserving their normal positions around them) and that the hard reload still shows the assignments.
-5. Raw API cross-check after reload: `/api/tree` still reports `pin_sections` for **Client work** and **Research**.
+5. AppWire cross-check after reload: the `pin_catalog` resource still reports **Client work** and **Research**, and each `pin_section` resource still contains its assigned rows.
 
 ### 4. Collapse **Research**, reload, and verify disclosure state stays collapsed
 
@@ -114,7 +114,7 @@ Every browser `eval` below must return `location.port` and the check must assert
 3. Assert in the browser that the **Client work** heading disappears entirely.
 4. Raw API cross-check:
    - `GET /api/pin-sections` still includes **Client work** with `member_count: 0`.
-   - `GET /api/tree` no longer renders **Client work** in `pin_sections[]`.
+   - AppWire `pin_catalog` still reports **Client work** with count `0`, while its `pin_section` resource returns an empty `sessions` array and the rail omits the section.
 
 ### 7. Open another session’s picker and verify hidden **Client work** remains selectable
 
@@ -192,7 +192,7 @@ finally:
 PY
 ```
 
-2. Cross-check that the durable count increased even though the new member will stay hidden from `/api/tree`:
+2. Cross-check that the durable count increased even though the new member will stay hidden from the navigation rail:
 
 ```bash
 api "$HUB/api/pin-sections" |
@@ -217,7 +217,7 @@ raise SystemExit("seeded section missing from /api/pin-sections")'
 2. Confirm deletion.
 3. Raw API cross-check immediately after success:
    - `GET /api/pin-sections` no longer lists that section.
-   - affected sessions no longer carry its `pin_section_id` in `/api/tree`.
+   - the affected sessions' AppWire `location` resources no longer carry its `pin_section_id`.
 4. Hard reload via `/auth?token=$TOKEN&next=/`.
 5. Browser `eval` must confirm the same port and that the deleted section heading is still absent.
 
@@ -254,7 +254,7 @@ For every browser `eval` above, assert `location.port === "$EXPECTED_PORT"`. A p
 ## Sharp edges
 
 - Use raw API calls plus hard reloads for durability checks; an optimistic overlay is not sufficient evidence.
-- Empty sections are intentionally absent from `/api/tree`; only `GET /api/pin-sections` proves they still exist.
+- Empty sections are intentionally absent from the rendered navigation rail, while the navigation `pin_catalog` and `GET /api/pin-sections` retain them so the picker can offer hidden empties.
 - Hidden or dormant durable members must count toward delete confirmation even when the sidebar cannot currently render them.
 - The auth cookie is not port-scoped. A dedicated Chrome profile plus explicit `location.port` assertions are mandatory.
 - Do not introduce or look for a standalone **Add pinned section** sidebar control; creation is only through **Pin this session…** or **Move pinned session…**.

--- a/test/scenarios/spawn-empty-prompt-starts-dormant.md
+++ b/test/scenarios/spawn-empty-prompt-starts-dormant.md
@@ -72,13 +72,10 @@ and the session pane's empty state; anything else, grep `data-testid` in
    ```
 2. Poll `GET /api/sessions/local:$SID` for a few seconds and record
    `.state` and `.active_turn_id` throughout.
-3. Poll `GET /api/tree` until the session's node appears, then read its
-   `dormant` field:
-   ```bash
-   curl -s -H "Authorization: Bearer $TOKEN" "$HUB/api/tree" \
-     | jq --arg ref "local:$SID" '[.. | objects | select(.ref? == $ref)
-         | {ref, state, dormant, age}] | .[0]'
-   ```
+3. Poll the authenticated `/rpc` AppWire connection with
+   `evener/navigation/read` and
+   `{"resource":"location","ref":"local:$SID"}` until the session's
+   navigation location appears, then read its `session.dormant` field.
 4. Read the on-disk transcript: `go run ./cmd/evener doctor transcript
    "$SID" --state-dir "$state" --format outline --range last:20`.
 5. Repeat step 1 with a whitespace-only prompt (`"   \n  "`). The
@@ -119,8 +116,9 @@ and the session pane's empty state; anything else, grep `data-testid` in
   `active_turn_id` stays empty throughout. Falsify: a 4xx/5xx, or any
   poll catching `state: active` / a non-empty `active_turn_id` — a turn
   started from an empty input.
-- **Step 3 (dormant flag, exact)**: the node exists with `"dormant":
-  true` and `"state": "idle"`. Both, together: `idle` alone is also what
+- **Step 3 (dormant flag, exact)**: the AppWire location exists with
+  `location.session.dormant: true` and `location.session.state: "idle"`.
+  Both, together: `idle` alone is also what
   a session that ran and finished reports, which is the whole reason
   `Dormant` exists as a separate field. Falsify: `dormant` absent or
   `false` after the index has demonstrably caught up (the node itself is

--- a/test/scenarios/spawn-keyboard-contract.md
+++ b/test/scenarios/spawn-keyboard-contract.md
@@ -96,11 +96,14 @@ roles (`role="combobox"` with `aria-label="Model"`, `role="listbox"`,
    (see Sharp edges — that section is the one part of this pane with a
    real form in it, and it is not what this card is about).
 3. Snapshot the hub's session set, so "nothing spawned" is a comparison
-   rather than a feeling:
-   ```bash
-   curl -s -H "Authorization: Bearer $TOKEN" "$HUB/api/tree" \
-     | jq -c '[.. | objects | .ref? // empty] | unique'
-   ```
+   rather than a feeling. On the authenticated `/rpc` AppWire connection,
+   read the `manifest`, page through every non-empty global section and
+   project catalog until `remaining` is zero, read `pin_catalog` and every
+   non-empty `pin_section` through their remaining pages, then read each
+   returned project resource and page each `current`, `recent`, and
+   `archived` tier through its `remaining` pages with `project_page`. Collect
+   the refs from every response and save the resulting set for comparison
+   after the picker interaction.
 4. Open the picker and pick with Enter. The desktop Model field's trigger
    is the only VISIBLE button on the page carrying the screen-reader
    text `— change model`; assert that before clicking it. The filter on

--- a/test/scenarios/status-vocabulary-roundtrip.md
+++ b/test/scenarios/status-vocabulary-roundtrip.md
@@ -42,14 +42,17 @@ of which died with the vanilla frontend (`660376f78`). The rail row is now
    failure mode worth catching is not the duplication but the two rows
    disagreeing, and both rows are built server-side, so the exact assertion
    belongs here rather than in the DOM:
-   ```bash
-   curl -s -H "Authorization: Bearer $TOKEN" "$HUB/api/tree" \
-     | jq --arg ref "local:$SID" '
-         [ .. | objects | select(.ref? == $ref)
-           | {row_id, ref, state, ask_pending: (.ask_pending // false)} ]'
-   ```
-   Fields are `NavigationSessionSummary` (`hubapi/navigation.go#NavigationSessionSummary`): `row_id`, `ref`,
-   `state`, `ask_pending`.
+   On the authenticated `/rpc` AppWire connection, read the `live` and
+   `needs_you` sections with `evener/navigation/read`, read `pin_catalog` and
+   each nonempty `pin_section`, and read the target's `location` resource to
+   obtain its `project_key`. Then read
+   `{"resource":"project","projectKey":"<key>"}` and inspect its `current`,
+   `recent`, and `archived` session arrays. While any tier reports
+   `remaining > 0`, page that tier with `project_page` until it reaches zero.
+   Collect every returned copy of the target ref as the wire assertion.
+   Fields are `NavigationSessionSummary`
+   (`hubapi/navigation.go#NavigationSessionSummary`): `ref`, `state`,
+   `ask_pending`, and `project`.
 
 3. **[browser] The rail renders what the wire said.** Navigate to
    `/auth?token=$TOKEN&next=/s/local:$SID` and read every rendered copy:


### PR DESCRIPTION
## Summary

- remove the stale `/api/tree` real-binary coverage probe
- align active navigation comments, routing docs, parity notes, and live scenarios with AppWire resources
- preserve the shared tree projection, current navigation behavior, append-only fuzz route data, and dated historical records

## Verification

- make lint
- make vet
- make test
- make test-web
- make test-web-browser