### PR TITLE
Migrate /api/dirs/create to AppWire

### DIFF
--- a/appwire/client.go
+++ b/appwire/client.go
@@ -531,6 +531,12 @@ func (c *Client) PathsComplete(ctx context.Context, params PathsCompleteParams) 
 	return out, err
 }
 
+func (c *Client) DirsCreate(ctx context.Context, params DirsCreateParams) (DirsCreateResponse, error) {
+	var out DirsCreateResponse
+	err := c.request(ctx, MethodEvenerDirsCreate, params, &out)
+	return out, err
+}
+
 func (c *Client) ProjectsRecent(ctx context.Context, params ProjectsRecentParams) (ProjectsRecentResponse, error) {
 	var out ProjectsRecentResponse
 	err := c.request(ctx, MethodEvenerProjectsRecent, params, &out)

--- a/appwire/cov_rhub_appwire_test.go
+++ b/appwire/cov_rhub_appwire_test.go
@@ -235,6 +235,16 @@ func TestClientRequestWrappersRoundTrip(t *testing.T) {
 			}
 			return nil
 		}},
+		{"DirsCreate", MethodEvenerDirsCreate, `{"path":"/tmp/new"}`, DirsCreateResponse{Path: "/tmp/new", Created: true}, func(ctx context.Context, c *Client) error {
+			out, err := c.DirsCreate(ctx, DirsCreateParams{Path: "/tmp/new"})
+			if err != nil {
+				return err
+			}
+			if out.Path != "/tmp/new" || !out.Created {
+				return errors.New("DirsCreate decode mismatch")
+			}
+			return nil
+		}},
 		{"JobsList", MethodEvenerJobsList, `{"ref":"local:th"}`, JobsListResponse{Data: JobActivityTree{
 			Revision: 7,
 			Root: JobActivitySession{

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -118,6 +118,7 @@ var Methods = []MethodSpec{
 	{MethodEvenerThreadTranscriptsList, ThreadTranscriptListParams{}, ThreadTranscriptListResponse{}, ScopeHub, "Lists transcript targets (subagents/related threads) for a ref."},
 	{MethodEvenerSubagentPreview, EvenerSubagentPreviewParams{}, EvenerSubagentPreviewResponse{}, ScopeHub, "Reads a bounded lazy preview of a subagent transcript's latest direct items."},
 	{MethodEvenerPathsComplete, PathsCompleteParams{}, PathsCompleteResponse{}, ScopeHub, "Path autocompletion for a prefix."},
+	{MethodEvenerDirsCreate, DirsCreateParams{}, DirsCreateResponse{}, ScopeHub, "Creates a missing working directory and its parents for Spawn preflight."},
 	{MethodEvenerProjectsRecent, ProjectsRecentParams{}, ProjectsRecentResponse{}, ScopeHub, "Lists the most recently used project working directories (session creation path-dropdown options; default cap 15)."},
 	{MethodEvenerPathValidate, PathValidateParams{}, PathValidateResponse{}, ScopeHub, "Validates a launch path."},
 	{MethodEvenerNavigationRead, NavigationReadParams{}, NavigationReadResponse{}, ScopeHub, "Reads one bounded, revisioned hub navigation resource, optionally conditional on its ETag."},

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -51,6 +51,7 @@ const (
 	MethodEvenerThreadTranscriptsList = "evener/thread/transcripts/list"
 	MethodEvenerSubagentPreview       = "evener/subagentPreview"
 	MethodEvenerPathsComplete         = "evener/paths/complete"
+	MethodEvenerDirsCreate            = "evener/dirs/create"
 	MethodEvenerProjectsRecent        = "evener/projects/recent"
 	MethodEvenerPathValidate          = "evener/path/validate"
 	MethodEvenerNavigationRead        = "evener/navigation/read"
@@ -1551,6 +1552,17 @@ type PathsCompleteParams struct {
 
 type PathsCompleteResponse struct {
 	Data []string `json:"data"`
+}
+
+// DirsCreateParams requests creation of a working directory and any missing
+// parents for a Spawn preflight.
+type DirsCreateParams struct {
+	Path string `json:"path"`
+}
+
+type DirsCreateResponse struct {
+	Path    string `json:"path"`
+	Created bool   `json:"created"`
 }
 
 // ProjectsRecentParams selects how many recent project directories the hub

--- a/cmd/evener-hub/app_dirs.go
+++ b/cmd/evener-hub/app_dirs.go
@@ -1,0 +1,44 @@
+package hub
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/envvars"
+)
+
+// hubDirsCreate creates the working directory requested by Spawn. Stat errors
+// intentionally fall through to MkdirAll: the existing route treated an
+// inaccessible path the same as a missing path and let the filesystem return
+// the user-visible creation error.
+func hubDirsCreate(cfg hubcore.WebConfig, params appwire.DirsCreateParams) (appwire.DirsCreateResponse, error) {
+	path := strings.TrimSpace(params.Path)
+	if path == "" {
+		return appwire.DirsCreateResponse{}, appwire.InvalidParams("path is required")
+	}
+	if strings.HasPrefix(path, "~/") || path == "~" {
+		path = filepath.Join(envvars.Home.Getenv(), strings.TrimPrefix(path, "~"))
+	}
+	if !filepath.IsAbs(path) {
+		return appwire.DirsCreateResponse{}, appwire.InvalidParams("absolute path required")
+	}
+	path = filepath.Clean(path)
+	if info, err := os.Stat(path); err == nil {
+		if !info.IsDir() {
+			return appwire.DirsCreateResponse{}, appwire.Conflict("a file already exists at that path")
+		}
+		return appwire.DirsCreateResponse{Path: path, Created: false}, nil
+	}
+
+	mkdirAll := os.MkdirAll
+	if cfg.MkdirAll != nil {
+		mkdirAll = cfg.MkdirAll
+	}
+	if err := mkdirAll(path, 0o755); err != nil {
+		return appwire.DirsCreateResponse{}, appwire.InternalError(err.Error())
+	}
+	return appwire.DirsCreateResponse{Path: path, Created: true}, nil
+}

--- a/cmd/evener-hub/app_dirs_test.go
+++ b/cmd/evener-hub/app_dirs_test.go
@@ -1,0 +1,132 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+func TestHubRPCDirsCreate(t *testing.T) {
+	t.Run("creates nested directory and is idempotent", func(t *testing.T) {
+		root := t.TempDir()
+		target := filepath.Join(root, "missing", "nested")
+		client := newDirsCreateClient(t, hubcore.WebConfig{HubStateRoot: t.TempDir()})
+
+		created, err := client.DirsCreate(context.Background(), appwire.DirsCreateParams{
+			Path: "  " + filepath.Join(target, "..", "nested") + "  ",
+		})
+		if err != nil {
+			t.Fatalf("DirsCreate: %v", err)
+		}
+		if created.Path != target || !created.Created {
+			t.Fatalf("created=%+v, want cleaned path %q and Created=true", created, target)
+		}
+		if info, err := os.Stat(target); err != nil || !info.IsDir() {
+			t.Fatalf("created path stat: info=%v err=%v", info, err)
+		}
+
+		existing, err := client.DirsCreate(context.Background(), appwire.DirsCreateParams{Path: target})
+		if err != nil {
+			t.Fatalf("DirsCreate existing: %v", err)
+		}
+		if existing.Path != target || existing.Created {
+			t.Fatalf("existing=%+v, want Created=false", existing)
+		}
+	})
+
+	t.Run("expands home", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		client := newDirsCreateClient(t, hubcore.WebConfig{HubStateRoot: t.TempDir()})
+
+		want := filepath.Join(home, "nested")
+		got, err := client.DirsCreate(context.Background(), appwire.DirsCreateParams{Path: "~/nested"})
+		if err != nil {
+			t.Fatalf("DirsCreate: %v", err)
+		}
+		if got.Path != want || !got.Created {
+			t.Fatalf("got=%+v, want path %q and Created=true", got, want)
+		}
+	})
+
+	t.Run("classifies invalid and conflicting paths", func(t *testing.T) {
+		root := t.TempDir()
+		file := filepath.Join(root, "file")
+		if err := os.WriteFile(file, []byte("content"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		client := newDirsCreateClient(t, hubcore.WebConfig{HubStateRoot: t.TempDir()})
+
+		for _, test := range []struct {
+			name string
+			path string
+			code int
+			text string
+		}{
+			{name: "required", code: appwire.CodeInvalidParams, text: "path is required"},
+			{name: "absolute", path: "relative", code: appwire.CodeInvalidParams, text: "absolute path required"},
+			{name: "file", path: file, code: appwire.CodeConflict, text: "a file already exists at that path"},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				_, err := client.DirsCreate(context.Background(), appwire.DirsCreateParams{Path: test.path})
+				assertDirsCreateError(t, err, test.code, test.text)
+			})
+		}
+	})
+
+	t.Run("classifies mkdir failure as internal", func(t *testing.T) {
+		root := t.TempDir()
+		target := filepath.Join(root, "new")
+		var gotPath string
+		var gotMode os.FileMode
+		client := newDirsCreateClient(t, hubcore.WebConfig{
+			HubStateRoot: t.TempDir(),
+			MkdirAll: func(path string, mode os.FileMode) error {
+				gotPath = path
+				gotMode = mode
+				return errors.New("mkdir failed")
+			},
+		})
+
+		_, err := client.DirsCreate(context.Background(), appwire.DirsCreateParams{Path: target})
+		assertDirsCreateError(t, err, appwire.CodeInternalError, "mkdir failed")
+		if gotPath != target || gotMode != 0o755 {
+			t.Fatalf("MkdirAll(%q, %#o), want (%q, %#o)", gotPath, gotMode, target, os.FileMode(0o755))
+		}
+		if _, statErr := os.Stat(target); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("target stat err=%v, want not-exist", statErr)
+		}
+	})
+}
+
+func newDirsCreateClient(t *testing.T, cfg hubcore.WebConfig) *appwire.Client {
+	t.Helper()
+	hub := newHubRPCTestServer(t, cfg)
+	t.Cleanup(hub.Close)
+	client := dialHubRPC(t, hub)
+	t.Cleanup(func() { _ = client.Close() })
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	return client
+}
+
+func assertDirsCreateError(t *testing.T, err error, code int, message string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected AppWire error code=%d message=%q", code, message)
+	}
+	var wire appwire.WireError
+	if !errors.As(err, &wire) {
+		t.Fatalf("error=%T %v, want appwire.WireError", err, err)
+	}
+	if wire.Code != code || !strings.Contains(wire.Message, message) {
+		t.Fatalf("wire=%+v, want code=%d message containing %q", wire, code, message)
+	}
+}

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -770,7 +770,7 @@ func notifyPluginUpdated(server *appserver.Server) {
 const recentProjectDirsLimit = 15
 
 // registerMiscHandlers registers the remaining hub RPC handlers: search,
-// model list, task list, transcript list, directory completion, path
+// model list, task list, transcript list, directory operations, path
 // validation, and the harness descriptor list.
 func registerMiscHandlers(server *appserver.Server, cfg hubcore.WebConfig, sources *appsource.Registry) {
 	appserver.HandleTyped(server.Router(), appwire.MethodEvenerUpgrade, hubUpgrade)
@@ -794,6 +794,9 @@ func registerMiscHandlers(server *appserver.Server, cfg hubcore.WebConfig, sourc
 	})
 	appserver.HandleTyped(server.Router(), appwire.MethodEvenerPathsComplete, func(_ context.Context, params appwire.PathsCompleteParams) (appwire.PathsCompleteResponse, error) {
 		return fspaths.CompletePaths(params)
+	})
+	appserver.HandleTyped(server.Router(), appwire.MethodEvenerDirsCreate, func(_ context.Context, params appwire.DirsCreateParams) (appwire.DirsCreateResponse, error) {
+		return hubDirsCreate(cfg, params)
 	})
 	appserver.HandleTyped(server.Router(), appwire.MethodEvenerProjectsRecent, func(_ context.Context, params appwire.ProjectsRecentParams) (appwire.ProjectsRecentResponse, error) {
 		limit := params.Limit

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -9781,6 +9781,7 @@ func TestHubRPCRegistersExpectedHandlerSet(t *testing.T) {
 		appwire.MethodEvenerJobsOutput,
 		appwire.MethodEvenerThreadTranscriptsList,
 		appwire.MethodEvenerPathsComplete,
+		appwire.MethodEvenerDirsCreate,
 		appwire.MethodEvenerProjectsRecent,
 		appwire.MethodEvenerPathValidate,
 		appwire.MethodEvenerHarnessesList,

--- a/cmd/evener-hub/cov_core_api_pass4_fuzz_test.go
+++ b/cmd/evener-hub/cov_core_api_pass4_fuzz_test.go
@@ -129,17 +129,10 @@ func FuzzCoreAPIPass4(f *testing.F) {
 		call(http.MethodGet, "/api/git/head?cwd="+workingDir, "")
 		call(http.MethodGet, "/api/git/head?cwd=/definitely/missing/pass4", "")
 		call(http.MethodPost, "/api/git/head", "")
-		direct(web.handleAPIDirCreate, http.MethodPost, "/api/dirs/create", `{}`)
-		direct(web.handleAPIDirCreate, http.MethodPost, "/api/dirs/create", `{"path":"relative"}`)
-		direct(web.handleAPIDirCreate, http.MethodPost, "/api/dirs/create", `{"path":"`+workingDir+`"}`)
 		filePath := filepath.Join(root, "already-file")
 		if err := os.WriteFile(filePath, []byte("x"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		direct(web.handleAPIDirCreate, http.MethodPost, "/api/dirs/create", `{"path":"`+filePath+`"}`)
-		direct(web.handleAPIDirCreate, http.MethodPost, "/api/dirs/create", `{"path":"`+filepath.Join(root, "created-dir")+`"}`)
-		web.cfg.MkdirAll = func(string, os.FileMode) error { return errors.New("mkdir failed") }
-		direct(web.handleAPIDirCreate, http.MethodPost, "/api/dirs/create", `{"path":"`+filepath.Join(root, "new-dir")+`"}`)
 
 		call(http.MethodPost, "/api/sessions/local:ended/rename", `{"name":" ended renamed "}`)
 		call(http.MethodPost, "/api/sessions/local:missing/rename", `{"name":"x"}`)

--- a/cmd/evener-hub/cov_web_api_residue_pass5_fuzz_test.go
+++ b/cmd/evener-hub/cov_web_api_residue_pass5_fuzz_test.go
@@ -124,10 +124,6 @@ func FuzzWebAPIResiduePass5(f *testing.F) {
 		call(func(w http.ResponseWriter, r *http.Request) { web.handleAPIClear(w, r, "remote:live") }, "POST", "/", "")
 		call(func(w http.ResponseWriter, r *http.Request) { web.handleAPIModel(w, r, "remote:live") }, "POST", "/", `{"model":"/"}`)
 		call(func(w http.ResponseWriter, r *http.Request) { web.handleAPIReasoningEffort(w, r, "remote:live") }, "POST", "/", `{`)
-		call(web.handleAPIDirCreate, http.MethodGet, "/", "")
-		call(web.handleAPIDirCreate, "POST", "/", `{`)
-		call(web.handleAPIDirCreate, "POST", "/", `{"path":"~"}`)
-
 		call(func(w http.ResponseWriter, r *http.Request) { web.handleAPIRename(w, r, "ended") }, "POST", "/", `{"name":""}`)
 		call(func(w http.ResponseWriter, r *http.Request) { web.handleAPIRename(w, r, "ended") }, "POST", "/", `{"name":"new"}`)
 		web.refreshRenamedMeta("missing", "fallback")

--- a/cmd/evener-hub/cov_web_core_api_test.go
+++ b/cmd/evener-hub/cov_web_core_api_test.go
@@ -99,35 +99,8 @@ func TestCovWebCoreAPIHelpersAndRoutes(t *testing.T) {
 		call(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{}")), "missing")
 	}
 
-	// Directory listing and creation remain inside a temp root.
+	// Filesystem-backed API probes remain inside a temp root.
 	root := t.TempDir()
-	t.Setenv("HOME", root)
-	for _, name := range []string{"alpha", "Beta", ".hidden"} {
-		if err := os.Mkdir(filepath.Join(root, name), 0o755); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if err := os.Mkdir(filepath.Join(root, "alpha", ".git"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "file"), []byte("x"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	for _, target := range []string{} {
-		_ = covWebRequest(t, web, http.MethodGet, target, "")
-	}
-	for _, tc := range []struct{ method, body string }{
-		{http.MethodGet, ""}, {http.MethodPost, "{"}, {http.MethodPost, `{}`},
-		{http.MethodPost, `{"path":"relative"}`}, {http.MethodPost, `{"path":"~"}`},
-		{http.MethodPost, `{"path":"` + root + `/file"}`},
-		{http.MethodPost, `{"path":"` + root + `/created"}`},
-		{http.MethodPost, `{"path":"` + root + `/created"}`},
-	} {
-		_ = covWebRequest(t, web, tc.method, "/api/dirs/create", tc.body)
-	}
-
-	failWeb := NewWebServer(hubcore.WebConfig{MkdirAll: func(string, os.FileMode) error { return errors.New("mkdir failed") }})
-	_ = covWebRequest(t, failWeb, http.MethodPost, "/api/dirs/create", `{"path":"`+root+`/fail"}`)
 	gitWeb := NewWebServer(hubcore.WebConfig{GitHeadBranch: func(context.Context, string) (string, error) { return "branch", nil }})
 	_ = covWebRequest(t, gitWeb, http.MethodGet, "/api/git/head?cwd="+root, "")
 	gitWeb.cfg.GitHeadBranch = func(context.Context, string) (string, error) { return "", errors.New("git failed") }

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -105,6 +105,7 @@ function readyClient(configure?: (fake: FakeClient) => void): FakeClient {
   fake.on("evener/projects/recent", () => ({ data: [] }));
   fake.on("evener/paths/complete", () => ({ data: [] }));
   fake.on("evener/path/validate", () => ({ path: "", valid: true }));
+  fake.on("evener/dirs/create", ({ path }) => ({ path, created: true }));
   fake.on("evener/plugin/preview", () => ({ plugins: [] }));
   fake.on("thread/start", () => startResponse("local:abc123"));
   configure?.(fake);
@@ -179,13 +180,6 @@ beforeEach(() => {
   fetchMock = vi.fn((url: string) => {
     if (url.startsWith("/api/git/head")) {
       return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ branch: "main" }) } as Response);
-    }
-    if (url === "/api/dirs/create") {
-      return Promise.resolve({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve({ path: "/x", created: true }),
-      } as Response);
     }
     return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) } as Response);
   });
@@ -1196,6 +1190,7 @@ test("offers to create a missing directory, then creates it and spawns", async (
       valid: false,
       error: "stat /tmp/new: no such file or directory",
     }));
+    f.on("evener/dirs/create", () => ({ path: "/tmp/new", created: true }));
   });
   renderSpawn(fake);
   await settled();
@@ -1207,10 +1202,7 @@ test("offers to create a missing directory, then creates it and spawns", async (
   await user.click(await screen.findByRole("button", { name: "Create & start" }));
 
   await waitFor(() =>
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/dirs/create",
-      expect.objectContaining({ body: JSON.stringify({ path: "/tmp/new" }) }),
-    ),
+    expect(fake.calls).toContainEqual({ method: "evener/dirs/create", params: { path: "/tmp/new" } }),
   );
   await waitFor(() => expect(fake.calls.some((c) => c.method === "thread/start")).toBe(true));
   // doSpawn's busy reset is shared by both callers - handleCreateConfirm's

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -798,7 +798,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     setBusy(true);
     setBusyStartedAt(Date.now());
     try {
-      await createDir(path);
+      await createDir(client, path);
       await doSpawn();
     } catch (err) {
       // friendlyLaunchErrorMessage, not errorText: doSpawn's thread/start call

--- a/cmd/evener-hub/frontend/src/panes/spawn/preflight.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/preflight.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
+import { WireError } from "../../protocol/errors";
 import { FakeClient } from "../../protocol/testing/fakeClient";
 import { createDir, preflightDir } from "./preflight";
 
@@ -63,48 +64,21 @@ describe("preflightDir", () => {
 });
 
 describe("createDir", () => {
-  let fetchMock: ReturnType<typeof vi.fn>;
+  test("requests directory creation over AppWire", async () => {
+    const fake = new FakeClient("ready");
+    fake.on("evener/dirs/create", () => ({ path: "/tmp/new", created: true }));
 
-  function jsonResponse(body: unknown, status = 200): Response {
-    return {
-      ok: status >= 200 && status < 300,
-      status,
-      statusText: status === 200 ? "OK" : "Error",
-      json: () => Promise.resolve(body),
-    } as Response;
-  }
+    await createDir(fake, "/tmp/new");
 
-  beforeEach(() => {
-    fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-  });
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    vi.restoreAllMocks();
-  });
-
-  test("POSTs /api/dirs/create with the path", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({ path: "/tmp/new", created: true }));
-
-    await createDir("/tmp/new");
-
-    expect(fetchMock).toHaveBeenCalledWith("/api/dirs/create", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      credentials: "same-origin",
-      body: JSON.stringify({ path: "/tmp/new" }),
-    });
+    expect(fake.calls[0]).toEqual({ method: "evener/dirs/create", params: { path: "/tmp/new" } });
   });
 
   test("throws the server's error message on failure", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "a file already exists at that path" }, 409));
+    const fake = new FakeClient("ready");
+    fake.on("evener/dirs/create", () => {
+      throw new WireError("a file already exists at that path", -32013);
+    });
 
-    await expect(createDir("/tmp/file")).rejects.toThrow("a file already exists at that path");
-  });
-
-  test("falls back to the HTTP status when the error body has no message", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({}, 500));
-
-    await expect(createDir("/tmp/x")).rejects.toThrow("HTTP 500");
+    await expect(createDir(fake, "/tmp/file")).rejects.toThrow("a file already exists at that path");
   });
 });

--- a/cmd/evener-hub/frontend/src/panes/spawn/preflight.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/preflight.ts
@@ -1,6 +1,6 @@
 // preflight is the working-directory preflight seam (floor §1.13): validate
-// the cwd via appwire "evener/path/validate" and create it via REST
-// "POST /api/dirs/create" (no appwire method exists for creation - verified).
+// the cwd via appwire "evener/path/validate" and create it via appwire
+// "evener/dirs/create".
 // T1 defines the signatures + a minimal working body; T2 wires them into the
 // real submission flow and adds the "doesn't exist yet -> offer to create"
 // discrimination (the offer-create outcome + the in-form Create&start dialog,
@@ -37,21 +37,6 @@ export async function preflightDir(client: AppwireClientLike, path: string): Pro
   }
 }
 
-export async function createDir(path: string): Promise<void> {
-  const res = await fetch("/api/dirs/create", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "same-origin",
-    body: JSON.stringify({ path }),
-  });
-  if (!res.ok) {
-    let message = `HTTP ${res.status}`;
-    try {
-      const data = (await res.json()) as { error?: string };
-      if (data.error) message = data.error;
-    } catch {
-      // Non-JSON (or empty) error body: keep the HTTP status line.
-    }
-    throw new Error(message);
-  }
+export async function createDir(client: AppwireClientLike, path: string): Promise<void> {
+  await client.request("evener/dirs/create", { path });
 }

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -157,6 +157,15 @@ export interface DiagnosticCause {
   status?: number;
 }
 
+export interface DirsCreateParams {
+  path: string;
+}
+
+export interface DirsCreateResponse {
+  path: string;
+  created: boolean;
+}
+
 export interface EmptyParams {
 }
 
@@ -1754,6 +1763,7 @@ export const METHOD_NAMES = [
   "evener/thread/transcripts/list",
   "evener/subagentPreview",
   "evener/paths/complete",
+  "evener/dirs/create",
   "evener/projects/recent",
   "evener/path/validate",
   "evener/navigation/read",
@@ -1912,6 +1922,7 @@ export interface MethodTypes {
   "evener/thread/transcripts/list": { params: ThreadTranscriptListParams; result: ThreadTranscriptListResponse };
   "evener/subagentPreview": { params: EvenerSubagentPreviewParams; result: EvenerSubagentPreviewResponse };
   "evener/paths/complete": { params: PathsCompleteParams; result: PathsCompleteResponse };
+  "evener/dirs/create": { params: DirsCreateParams; result: DirsCreateResponse };
   "evener/projects/recent": { params: ProjectsRecentParams; result: ProjectsRecentResponse };
   "evener/path/validate": { params: PathValidateParams; result: PathValidateResponse };
   "evener/navigation/read": { params: NavigationReadParams; result: NavigationReadResponse };

--- a/cmd/evener-hub/internal/hubcore/config.go
+++ b/cmd/evener-hub/internal/hubcore/config.go
@@ -81,7 +81,7 @@ type WebConfig struct {
 	// shelling out, hitting the network, or mutating the real filesystem. These
 	// are the escapes a read-only harness cannot drive: the live-git probe
 	// (/api/git/head), the live-provider model query, and the directory creator
-	// (/api/dirs/create). See cmd/evener-hub's sandbox_test.go.
+	// (evener/dirs/create). See cmd/evener-hub's app_dirs_test.go.
 	GitHeadBranch func(ctx context.Context, dir string) (string, error) // nil → real `git`
 	LiveModels    func(ctx context.Context) []appwire.ModelDescriptor   // nil → real provider query
 	MkdirAll      func(path string, perm os.FileMode) error             // nil → os.MkdirAll

--- a/cmd/evener-hub/sandbox_selftest_test.go
+++ b/cmd/evener-hub/sandbox_selftest_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"testing"
 
@@ -52,7 +51,7 @@ func installDenyTransport(t *testing.T) *denyTransport {
 }
 
 // TestSandboxContainsMutatingHandlers is the B0 containment proof. It drives the
-// hub's MUTATING handlers — spawn, git-head, models, dir-create, an action verb
+// hub's MUTATING handlers — spawn, git-head, models, and an action verb
 // — through the full handler stack and asserts that none of them spawned a real
 // process, shelled out, hit the network, or created a file outside the sandbox.
 func TestSandboxContainsMutatingHandlers(t *testing.T) {
@@ -108,21 +107,7 @@ func TestSandboxContainsMutatingHandlers(t *testing.T) {
 		t.Fatalf("git/head did not use the seam: branch=%q want %q", gh.Branch, sandboxGitBranch)
 	}
 
-	// 3. dir-create: a path OUTSIDE the sandbox root is recorded but never made.
-	forbiddenRoot := t.TempDir() // outside s.Root
-	forbidden := filepath.Join(forbiddenRoot, "should-not-be-created", "deep")
-	rec = do(http.MethodPost, "/api/dirs/create", map[string]any{"path": forbidden})
-	if rec.Code != http.StatusOK {
-		t.Fatalf("dirs/create: want 200, got %d body=%s", rec.Code, rec.Body.String())
-	}
-	if _, err := os.Stat(forbidden); !os.IsNotExist(err) {
-		t.Fatalf("dir-create escaped the sandbox: %s exists on disk (err=%v)", forbidden, err)
-	}
-	if paths := s.Mkdir.Paths(); len(paths) != 1 || !strings.HasPrefix(paths[0], forbiddenRoot) {
-		t.Fatalf("dir-create did not reach the seam: recorded %v", paths)
-	}
-
-	// 5. action verb: clear on a non-live session resolves before any daemon
+	// 3. action verb: clear on a non-live session resolves before any daemon
 	// dial — a contained 404, not a hang or a network call.
 	rec = do(http.MethodPost, "/api/sessions/"+sandboxSessionID+"/clear", nil)
 	if rec.Code != http.StatusNotFound {

--- a/cmd/evener-hub/sandbox_test.go
+++ b/cmd/evener-hub/sandbox_test.go
@@ -38,7 +38,6 @@ const sandboxGitBranch = "sandbox-branch"
 //     a synthetic rendezvous entry with no address; no subprocess, no dial.
 //   - /api/git/head → GitHeadBranch seam returns sandboxGitBranch; no `git`.
 //   - model/list → LiveModels seam returns a fixed list; no provider network.
-//   - /api/dirs/create → MkdirAll seam records the path and creates nothing.
 //   - the action verbs (send/steer/queue/clear/...) → an empty Roster and an
 //     empty live-source set, so every verb resolves "thread not found" before it
 //     can dial a daemon.
@@ -57,7 +56,6 @@ type sandbox struct {
 	Web           *WebServer
 	Config        hubcore.WebConfig
 	Spawner       *recordingSpawner
-	Mkdir         *recordingMkdir
 	Root          string // temp root; the only filesystem subtree the hub may mutate
 	CWD           string // the seeded session's working dir, inside Root
 	Secret        []byte // planted ABOVE CWD; the path-escape oracle's tripwire
@@ -116,7 +114,6 @@ func newSandbox(tb testing.TB) *sandbox {
 	}
 
 	spawner := &recordingSpawner{}
-	mkdir := &recordingMkdir{}
 	cfg := hubcore.WebConfig{
 		HubAddr:             "127.0.0.1:9180",
 		HubStateRoot:        filepath.Join(root, "state"),
@@ -133,7 +130,6 @@ func newSandbox(tb testing.TB) *sandbox {
 		LiveModels: func(context.Context) []appwire.ModelDescriptor {
 			return []appwire.ModelDescriptor{{Provider: "sandbox", Model: "fake-model"}}
 		},
-		MkdirAll: mkdir.MkdirAll,
 		// AuthToken empty: the auth guard is disabled, so a fuzzed request reaches
 		// the real routes (per the Phase 4 spec).
 	}
@@ -141,7 +137,6 @@ func newSandbox(tb testing.TB) *sandbox {
 		Web:           NewWebServer(cfg),
 		Config:        cfg,
 		Spawner:       spawner,
-		Mkdir:         mkdir,
 		Root:          root,
 		CWD:           cwd,
 		Secret:        secret,
@@ -194,26 +189,4 @@ func (r *recordingSpawner) Resumes() []hubcore.ResumeRequest {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return append([]hubcore.ResumeRequest(nil), r.resumes...)
-}
-
-// recordingMkdir is the MkdirAll seam: it records each requested path and
-// creates nothing, so a fuzzed /api/dirs/create can never materialize a
-// directory on the real filesystem.
-type recordingMkdir struct {
-	mu    sync.Mutex
-	paths []string
-}
-
-func (m *recordingMkdir) MkdirAll(path string, _ os.FileMode) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.paths = append(m.paths, path)
-	return nil
-}
-
-// Paths returns a copy of every path a handler asked to create.
-func (m *recordingMkdir) Paths() []string {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return append([]string(nil), m.paths...)
 }

--- a/cmd/evener-hub/web.go
+++ b/cmd/evener-hub/web.go
@@ -164,7 +164,6 @@ func (s *WebServer) Handler() http.Handler {
 
 	// API
 	mux.HandleFunc("/api/spawn", s.handleApiSpawn)
-	mux.HandleFunc("/api/dirs/create", s.handleAPIDirCreate)
 	mux.HandleFunc("/api/git/head", s.handleApiGitHead)
 	mux.HandleFunc("/api/health", s.handleAPIHealth)
 	mux.HandleFunc("/api/mobile/pairing", s.handleAPIMobilePairing)

--- a/cmd/evener-hub/web_api.go
+++ b/cmd/evener-hub/web_api.go
@@ -19,7 +19,6 @@ import (
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/buildinfo"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubedge"
-	"primeradiant.com/evener/envvars"
 	"primeradiant.com/evener/hubapi"
 )
 
@@ -419,56 +418,6 @@ func (s *WebServer) handleAPIReasoningEffort(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
-}
-
-// handleAPIDirCreate creates a directory (and any missing parents) at an
-// absolute path, so the spawn flow can offer to create a proposed working
-// directory that does not exist yet. POST {"path": "..."}. Idempotent: an
-// existing directory succeeds (created:false); a file at that path is a
-// conflict. The hub already grants the user full filesystem reach for spawning,
-// so creating a directory they are about to launch into adds no new authority.
-func (s *WebServer) handleAPIDirCreate(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeAPIError(w, http.StatusMethodNotAllowed, "POST required")
-		return
-	}
-	var body struct {
-		Path string `json:"path"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeAPIError(w, http.StatusBadRequest, "invalid JSON body")
-		return
-	}
-	path := strings.TrimSpace(body.Path)
-	if path == "" {
-		writeAPIError(w, http.StatusBadRequest, "path is required")
-		return
-	}
-	if strings.HasPrefix(path, "~/") || path == "~" {
-		path = filepath.Join(envvars.Home.Getenv(), strings.TrimPrefix(path, "~"))
-	}
-	if !filepath.IsAbs(path) {
-		writeAPIError(w, http.StatusBadRequest, "absolute path required")
-		return
-	}
-	path = filepath.Clean(path)
-	if info, err := os.Stat(path); err == nil {
-		if !info.IsDir() {
-			writeAPIError(w, http.StatusConflict, "a file already exists at that path")
-			return
-		}
-		writeAPIJSON(w, http.StatusOK, map[string]any{"path": path, "created": false})
-		return
-	}
-	mkdirAll := os.MkdirAll
-	if s.cfg.MkdirAll != nil {
-		mkdirAll = s.cfg.MkdirAll
-	}
-	if err := mkdirAll(path, 0o755); err != nil {
-		writeAPIError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	writeAPIJSON(w, http.StatusOK, map[string]any{"path": path, "created": true})
 }
 
 // gitHeadBranch runs `git rev-parse --abbrev-ref HEAD` in dir and returns

--- a/cmd/evener-hub/web_fuzz_test.go
+++ b/cmd/evener-hub/web_fuzz_test.go
@@ -20,7 +20,7 @@ const fuzzSessionID = sandboxSessionID
 // fuzzReadOnlyRoutes is the allowlist of GET-only, non-mutating, non-networked
 // hub routes the handler fuzz drives — the single canonical list in
 // internal/fuzzroutes, shared with the corpus harvester so the two can't drift.
-// Mutating routes (/api/spawn, /api/dirs/create, the action verbs),
+// Mutating routes (/api/spawn, the action verbs),
 // routes that shell out (/api/git/head), and provider-probing model-list calls
 // are excluded so a fuzzed request can never touch the real environment.
 var fuzzReadOnlyRoutes = fuzzroutes.ReadOnly

--- a/cmd/evener-hub/web_mutating_fuzz_test.go
+++ b/cmd/evener-hub/web_mutating_fuzz_test.go
@@ -20,15 +20,14 @@ type mutRoute struct {
 }
 
 // mutatingRoutes are exactly the routes the Phase-4 read-only handler fuzz
-// excluded: the spawn/dir-create POSTs and the live-git
+// excluded: the spawn POST and the live-git
 // seam reads, and the session/turn action verbs (clear/model/effort/interrupt/
 // compact/shutdown/send/fork under /api/sessions, and steer/queue/drain-as-steer
 // under /s). Under the B0 sandbox every one of these is contained: spawn hits
-// the recording spawner, dir-create the recording mkdir, and git-head its
+// the recording spawner and git-head its
 // seams, and the action verbs resolve "not live" before any daemon dial.
 var mutatingRoutes = []mutRoute{
 	{http.MethodPost, "/api/spawn", true},
-	{http.MethodPost, "/api/dirs/create", true},
 	{http.MethodGet, "/api/git/head?cwd={id}", false},
 	{http.MethodPost, "/api/sessions/{id}/clear", false},
 	{http.MethodPost, "/api/sessions/{id}/model", true},
@@ -105,7 +104,6 @@ func FuzzWebMutatingHandler(f *testing.F) {
 		// otherwise reaches. Empty Data keeps the seed small (the per-image byte
 		// limit is 8 MiB, not worth a multi-MiB corpus entry).
 		{"/api/spawn", "", `{"harness":"evener","working_dir":"` + s.CWD + `","items":[{"type":"image"},{"type":"image"},{"type":"image"},{"type":"image"},{"type":"image"},{"type":"image"},{"type":"image"},{"type":"image"},{"type":"image"}]}`},
-		{"/api/dirs/create", "", `{"path":"` + s.CWD + `/new"}`},
 		{"/api/git/head?cwd={id}", s.CWD, ""},
 		{"/api/sessions/{id}/clear", sandboxSessionID, ""},
 		{"/api/sessions/{id}/model", sandboxSessionID, `{"model":"openai/gpt-5.5"}`},

--- a/cmd/evener-hub/web_test.go
+++ b/cmd/evener-hub/web_test.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -2075,84 +2074,6 @@ func TestWeb_APIFork_DeferInputParity(t *testing.T) {
 	if resp.OriginalInput != "second task" {
 		t.Errorf("original_input=%q, want %q", resp.OriginalInput, "second task")
 	}
-}
-
-// TestWeb_ApiModels_ReturnsListWithProviderEnv verifies the endpoint
-// shape — returns a JSON array of {provider, model, …} entries when
-// run against a live provider API. Skips unless live tests are explicitly
-// enabled and a real API key is set.
-// TestWeb_ApiDirCreate covers POST /api/dirs/create, used by the spawn flow to
-// create a proposed working directory that does not exist yet.
-func TestWeb_ApiDirCreate(t *testing.T) {
-	web := NewWebServer(hubcore.WebConfig{HubAddr: "127.0.0.1:9180"})
-	post := func(path string) *httptest.ResponseRecorder {
-		body := strings.NewReader(`{"path":` + strconv.Quote(path) + `}`)
-		req := httptest.NewRequest(http.MethodPost, "/api/dirs/create", body)
-		req.Host = "127.0.0.1:9180"
-		req.Header.Set("Content-Type", "application/json")
-		rec := httptest.NewRecorder()
-		web.Handler().ServeHTTP(rec, req)
-		return rec
-	}
-
-	t.Run("creates a missing directory and its parents", func(t *testing.T) {
-		target := filepath.Join(t.TempDir(), "missing", "nested")
-		rec := post(target)
-		if rec.Code != http.StatusOK {
-			t.Fatalf("status: %d body=%q", rec.Code, rec.Body.String())
-		}
-		var resp map[string]any
-		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("invalid JSON: %v", err)
-		}
-		if resp["created"] != true {
-			t.Errorf("expected created:true, got %v", resp["created"])
-		}
-		if info, err := os.Stat(target); err != nil || !info.IsDir() {
-			t.Errorf("directory was not created: err=%v", err)
-		}
-	})
-
-	t.Run("existing directory is idempotent", func(t *testing.T) {
-		target := t.TempDir()
-		rec := post(target)
-		if rec.Code != http.StatusOK {
-			t.Fatalf("status: %d body=%q", rec.Code, rec.Body.String())
-		}
-		var resp map[string]any
-		_ = json.Unmarshal(rec.Body.Bytes(), &resp)
-		if resp["created"] != false {
-			t.Errorf("expected created:false for an existing dir, got %v", resp["created"])
-		}
-	})
-
-	t.Run("file at the path is a conflict", func(t *testing.T) {
-		file := filepath.Join(t.TempDir(), "afile")
-		if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		rec := post(file)
-		if rec.Code != http.StatusConflict {
-			t.Errorf("expected 409 for a file path, got %d body=%q", rec.Code, rec.Body.String())
-		}
-	})
-
-	t.Run("relative path is rejected", func(t *testing.T) {
-		rec := post("relative/dir")
-		if rec.Code != http.StatusBadRequest {
-			t.Errorf("expected 400 for a relative path, got %d", rec.Code)
-		}
-	})
-
-	t.Run("GET is rejected", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/dirs/create?path=/tmp/x", nil)
-		req.Host = "127.0.0.1:9180"
-		rec := httptest.NewRecorder()
-		web.Handler().ServeHTTP(rec, req)
-		if rec.Code != http.StatusMethodNotAllowed {
-			t.Errorf("expected 405 for GET, got %d", rec.Code)
-		}
-	})
 }
 
 func startAppwireTestDaemon(t *testing.T, dir, sessionID string, register func(*appserver.Server)) *httptest.Server {

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -114,6 +114,7 @@ no router (reserved).
 | `evener/thread/transcripts/list` | hub | `ThreadTranscriptListParams` | `ThreadTranscriptListResponse` | Lists transcript targets (subagents/related threads) for a ref. |
 | `evener/subagentPreview` | hub | `EvenerSubagentPreviewParams` | `EvenerSubagentPreviewResponse` | Reads a bounded lazy preview of a subagent transcript's latest direct items. |
 | `evener/paths/complete` | hub | `PathsCompleteParams` | `PathsCompleteResponse` | Path autocompletion for a prefix. |
+| `evener/dirs/create` | hub | `DirsCreateParams` | `DirsCreateResponse` | Creates a missing working directory and its parents for Spawn preflight. |
 | `evener/projects/recent` | hub | `ProjectsRecentParams` | `ProjectsRecentResponse` | Lists the most recently used project working directories (session creation path-dropdown options; default cap 15). |
 | `evener/path/validate` | hub | `PathValidateParams` | `PathValidateResponse` | Validates a launch path. |
 | `evener/navigation/read` | hub | `NavigationReadParams` | `NavigationReadResponse` | Reads one bounded, revisioned hub navigation resource, optionally conditional on its ETag. |
@@ -379,6 +380,21 @@ An embedded type contributes its own fields inline.
 | Field | Go type | Omitempty | Embedded |
 |-------|---------|-----------|----------|
 | `commands` | `[]appwire.CommandDescriptor` |  |  |
+
+
+### `DirsCreateParams`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `path` | `string` |  |  |
+
+
+### `DirsCreateResponse`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `path` | `string` |  |  |
+| `created` | `bool` |  |  |
 
 
 ### `EmptyParams`

--- a/docs/superpowers/plans/2026-08-27-appwire-dirs-create.md
+++ b/docs/superpowers/plans/2026-08-27-appwire-dirs-create.md
@@ -1,0 +1,381 @@
+# AppWire Directory Creation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Spawn's REST directory creation request with the typed hub AppWire method `evener/dirs/create` while preserving behavior and deleting the retired REST route.
+
+**Architecture:** The hub owns one typed `evener/dirs/create` handler. A focused helper keeps path normalization, `os.Stat`, `MkdirAll`, and the existing injected filesystem seam together; the HTTP handler is deleted rather than retained as a compatibility path. Spawn calls that hub method through the existing shared AppWire client and keeps its current confirmation/error UI.
+
+**Tech Stack:** Go, JSON-RPC-style AppWire over WebSocket, React/TypeScript, Vitest, generated AppWire TypeScript/docs catalogs, Makefile verification gates.
+
+**Spec:** `docs/superpowers/specs/2026-08-27-appwire-dirs-create-design.md`
+
+## Global Constraints
+
+- Work only in `/Users/jesse/git/prime-radiant/evener/.worktrees/appwire-dirs-create` on `codex/appwire-dirs-create`.
+- Base the branch on the explicitly fetched `origin/main`; do not include model-list, navigation, or tree-residue changes.
+- Preserve the exact path normalization, `0755` creation mode, idempotent existing-directory result, conflict text, and internal failure text from `handleAPIDirCreate`.
+- The `/rpc` route remains the sole authenticated browser transport for this operation; do not add a REST fallback.
+- Read `docs/developing-evener/testing.md` before changing tests; default tests remain deterministic and provider/network independent.
+- Do not add an absence assertion for `/api/dirs/create`; delete obsolete route tests and keep meaningful AppWire behavior tests.
+- Run the four-angle read-only simplify-code review before implementation and again after implementation; apply only quality-preserving findings.
+
+---
+
+### Task 1: Commit the wire contract and behavior-first test plan
+
+**Files:**
+- Modify: `appwire/types.go` — add `MethodEvenerDirsCreate`, `DirsCreateParams`, and `DirsCreateResponse`.
+- Modify: `appwire/protocol.go` — add the `ScopeHub` catalog row.
+- Modify: `appwire/client.go` — add `Client.DirsCreate`.
+- Test: `appwire/cov_rhub_appwire_test.go` — add the typed wrapper round trip.
+- Test: `cmd/evener-hub/app_dirs_test.go` — add the real hub AppWire behavior contract.
+
+**Interfaces:**
+- Produces the wire method `evener/dirs/create`, params `{path:string}`, and result `{path:string,created:boolean}`.
+- The hub behavior test calls `client.DirsCreate(context.Context, appwire.DirsCreateParams)` against `newHubRPCTestServer`.
+
+- [ ] **Step 1: Write failing Go behavior tests.**
+
+  Add cases that call the not-yet-registered method through a real AppWire client and assert:
+
+  ```go
+  response, err := client.DirsCreate(context.Background(), appwire.DirsCreateParams{Path: target})
+  if err != nil { t.Fatal(err) }
+  if response.Path != filepath.Clean(target) || !response.Created { t.Fatalf("response=%+v", response) }
+  ```
+
+  Cover a missing nested directory, an existing directory returning
+  `Created:false`, a file returning `CodeConflict` and the existing message,
+  a relative path returning `CodeInvalidParams`, `~` expansion, and an injected
+  `MkdirAll` failure returning `CodeInternalError` with its message. Use temp
+  directories and `WebConfig.MkdirAll`; do not touch the real home or network.
+
+- [ ] **Step 2: Run the tests and verify the failure is the missing contract.**
+
+  Run:
+
+  ```bash
+  go test ./appwire ./cmd/evener-hub -run 'TestClientRequestWrappersRoundTrip|TestHubRPCDirsCreate' -count=1
+  ```
+
+  Expected: failure because `DirsCreate` and the hub method are not yet
+  defined/registered, not because of a malformed fixture.
+
+- [ ] **Step 3: Add the minimal wire declarations and wrapper.**
+
+  Follow the neighboring `PathsComplete` declarations:
+
+  ```go
+  MethodEvenerDirsCreate = "evener/dirs/create"
+
+  type DirsCreateParams struct {
+      Path string `json:"path"`
+  }
+
+  type DirsCreateResponse struct {
+      Path string `json:"path"`
+      Created bool `json:"created"`
+  }
+
+  func (c *Client) DirsCreate(ctx context.Context, params DirsCreateParams) (DirsCreateResponse, error) {
+      var out DirsCreateResponse
+      err := c.request(ctx, MethodEvenerDirsCreate, params, &out)
+      return out, err
+  }
+  ```
+
+  Add the catalog summary `Creates a missing working directory and its
+  parents for Spawn preflight.` and the wrapper round-trip case asserting the
+  method, params, and decoded response.
+
+- [ ] **Step 4: Run the test to confirm the remaining red state is server registration.**
+
+  Run the same focused command. Expected: the wrapper round trip passes and
+  the hub behavior test reports `method not found` until Task 2 registers the
+  handler.
+
+- [ ] **Step 5: Commit the contract tests and declarations.**
+
+  ```bash
+  git add appwire/types.go appwire/protocol.go appwire/client.go appwire/cov_rhub_appwire_test.go cmd/evener-hub/app_dirs_test.go
+  git commit -m "feat: define AppWire directory creation contract"
+  ```
+
+### Task 2: Run the pre-implementation simplify review
+
+**Files:**
+- Review: the Task 1 diff from `git diff @{upstream}...HEAD` plus any working diff.
+
+- [ ] **Step 1: Dispatch the four read-only simplify reviewers in parallel.**
+
+  Use the simplify-code skill at
+  `/Users/jesse/.codex/plugins/cache/simplify-code-dev/simplify-code/0.1.0/skills/simplify-code/SKILL.md`, assigning the Reuse, Simplification, Efficiency, and Altitude angles to separate reviewers. Reviewers do not edit.
+
+- [ ] **Step 2: Apply only quality-preserving findings.**
+
+  Deduplicate findings by line/mechanism. Do not delete or weaken behavior
+  tests, rename the new public method/types, or alter the wire behavior.
+
+- [ ] **Step 3: Re-run the focused tests and commit any review-only cleanup.**
+
+  ```bash
+  go test ./appwire ./cmd/evener-hub -run 'TestClientRequestWrappersRoundTrip|TestHubRPCDirsCreate' -count=1
+  git diff --check
+  git commit -am "refactor: simplify directory AppWire contract"
+  ```
+
+  Skip the cleanup commit when the reviewers report the contract is already
+  clear; record that result in the implementation handoff.
+
+### Task 3: Implement the hub operation and remove the REST route
+
+**Files:**
+- Create: `cmd/evener-hub/app_dirs.go` — focused hub directory-creation helper.
+- Modify: `cmd/evener-hub/app_rpc.go` — register `evener/dirs/create`.
+- Modify: `cmd/evener-hub/web.go` — remove `/api/dirs/create` registration.
+- Modify: `cmd/evener-hub/web_api.go` — remove `handleAPIDirCreate`.
+- Modify: `cmd/evener-hub/app_rpc_test.go` — include the new method in the exact hub-handler set.
+- Modify: `cmd/evener-hub/web_test.go` — delete the obsolete REST behavior test.
+- Modify: `cmd/evener-hub/cov_web_core_api_test.go` — remove only directory REST probes.
+- Modify: `cmd/evener-hub/cov_core_api_pass4_fuzz_test.go` — remove only direct REST-handler probes.
+- Modify: `cmd/evener-hub/web_mutating_fuzz_test.go` — remove the retired route and seed.
+- Modify: `cmd/evener-hub/web_fuzz_test.go` — remove the route from the explanatory exclusion comment.
+- Modify: `cmd/evener-hub/sandbox_test.go` and `cmd/evener-hub/sandbox_selftest_test.go` — remove the route-only recording seam and block.
+- Modify: `cmd/evener-hub/internal/hubcore/config.go` — update the seam comment to name the AppWire operation.
+
+**Interfaces:**
+- `hubDirsCreate(cfg hubcore.WebConfig, params appwire.DirsCreateParams) (appwire.DirsCreateResponse, error)` returns the typed result or one of the standard AppWire errors.
+- `registerMiscHandlers` registers the method with `appserver.HandleTyped`.
+
+- [ ] **Step 1: Run the red behavior test from Task 1.**
+
+  ```bash
+  go test ./cmd/evener-hub -run TestHubRPCDirsCreate -count=1
+  ```
+
+  Confirm it fails with AppWire method-not-found before writing production
+  behavior.
+
+- [ ] **Step 2: Extract the existing behavior into the focused helper.**
+
+  Move the exact sequence into `app_dirs.go`, returning:
+
+  ```go
+  if path == "" { return appwire.DirsCreateResponse{}, appwire.InvalidParams("path is required") }
+  if !filepath.IsAbs(path) { return appwire.DirsCreateResponse{}, appwire.InvalidParams("absolute path required") }
+  if info, err := os.Stat(path); err == nil {
+      if !info.IsDir() { return appwire.DirsCreateResponse{}, appwire.Conflict("a file already exists at that path") }
+      return appwire.DirsCreateResponse{Path: path, Created: false}, nil
+  }
+  if err := mkdirAll(path, 0o755); err != nil {
+      return appwire.DirsCreateResponse{}, appwire.InternalError(err.Error())
+  }
+  return appwire.DirsCreateResponse{Path: path, Created: true}, nil
+  ```
+
+  Keep `envvars.Home.Getenv()`, `filepath.Clean`, the `WebConfig.MkdirAll`
+  seam, and the current treatment of non-nil stat errors unchanged.
+
+- [ ] **Step 3: Register the typed handler and remove the HTTP route.**
+
+  Add:
+
+  ```go
+  appserver.HandleTyped(server.Router(), appwire.MethodEvenerDirsCreate,
+      func(_ context.Context, params appwire.DirsCreateParams) (appwire.DirsCreateResponse, error) {
+          return hubDirsCreate(cfg, params)
+      })
+  ```
+
+  Delete the HTTP registration and handler, then delete only their route
+  probes/fixtures. Retain the shared `MkdirAll` config seam for AppWire tests.
+
+- [ ] **Step 4: Update the exact hub handler-set test.**
+
+  Add `appwire.MethodEvenerDirsCreate` to the named expected set. Its empty
+  params dispatch may return invalid params, but it must not return
+  method-not-found.
+
+- [ ] **Step 5: Run the focused Go tests.**
+
+  ```bash
+  go test ./appwire ./cmd/evener-hub -run 'TestClientRequestWrappersRoundTrip|TestHubRPCDirsCreate|TestHubRPCRegistersExpectedHandlerSet' -count=1
+  ```
+
+  Expected: PASS, including the real filesystem and injected failure cases.
+
+- [ ] **Step 6: Commit the server implementation and route removal.**
+
+  ```bash
+  git add appwire cmd/evener-hub
+  git commit -m "feat: serve directory creation over AppWire"
+  ```
+
+### Task 4: Migrate Spawn preflight with TDD
+
+**Files:**
+- Modify: `cmd/evener-hub/frontend/src/panes/spawn/preflight.ts` — request the typed method.
+- Modify: `cmd/evener-hub/frontend/src/panes/spawn/preflight.test.ts` — replace fetch tests with FakeClient AppWire tests.
+- Modify: `cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx` — pass `client` to `createDir`.
+- Modify: `cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx` — script and assert the AppWire call.
+
+**Interfaces:**
+- `createDir(client: AppwireClientLike, path: string): Promise<void>` awaits `client.request("evener/dirs/create", {path})`.
+- `handleCreateConfirm` calls `createDir(client, path)` and keeps the existing catch/finally behavior.
+
+- [ ] **Step 1: Write the failing frontend request assertion.**
+
+  Replace the REST assertion with:
+
+  ```ts
+  const fake = new FakeClient("ready");
+  fake.on("evener/dirs/create", () => ({ path: "/tmp/new", created: true }));
+  await createDir(fake, "/tmp/new");
+  expect(fake.calls[0]).toEqual({ method: "evener/dirs/create", params: { path: "/tmp/new" } });
+  ```
+
+  Keep a rejection test using a `WireError` with the conflict message so the
+  caller's user-visible error path remains covered.
+
+- [ ] **Step 2: Run the frontend test and verify the expected red state.**
+
+  ```bash
+  cd cmd/evener-hub/frontend
+  npx vitest run src/panes/spawn/preflight.test.ts
+  ```
+
+  Expected: failure because `createDir` still has the old signature and REST
+  implementation.
+
+- [ ] **Step 3: Implement the smallest typed client change.**
+
+  ```ts
+  export async function createDir(client: AppwireClientLike, path: string): Promise<void> {
+    await client.request("evener/dirs/create", { path });
+  }
+  ```
+
+  Pass the already-injected `client` from `Spawn` at the one confirmation call
+  site. Do not add a second client or fetch fallback.
+
+- [ ] **Step 4: Update the integrated Spawn scenario.**
+
+  Script `evener/dirs/create` in the test's ready FakeClient and assert the
+  recorded method/params after clicking `Create & start`; retain the existing
+  assertion that `thread/start` occurs and the button re-enables.
+
+- [ ] **Step 5: Run focused frontend tests and formatting.**
+
+  ```bash
+  cd cmd/evener-hub/frontend
+  npx vitest run src/panes/spawn/preflight.test.ts src/panes/spawn/Spawn.test.tsx
+  npx biome check --write src/panes/spawn/preflight.ts src/panes/spawn/preflight.test.ts src/panes/spawn/Spawn.tsx src/panes/spawn/Spawn.test.tsx
+  ```
+
+  Expected: PASS with no REST call assertion remaining in these production
+  caller tests.
+
+- [ ] **Step 6: Commit the frontend migration.**
+
+  ```bash
+  git add cmd/evener-hub/frontend/src/panes/spawn
+  git commit -m "feat: use AppWire for Spawn directory creation"
+  ```
+
+### Task 5: Regenerate catalogs and update active documentation
+
+**Files:**
+- Modify: `cmd/evener-hub/frontend/src/protocol/types.gen.ts` — generated output.
+- Modify: `docs/appwire-protocol.md` — generated output.
+- Modify: `docs/web-ui/parity/parity-m6-surfaces.md` — active Spawn contract.
+
+- [ ] **Step 1: Run generation.**
+
+  ```bash
+  make generate
+  ```
+
+- [ ] **Step 2: Update the active parity contract.**
+
+  Change the acceptance step from POSTing `/api/dirs/create` to requesting
+  `evener/dirs/create` over the authenticated AppWire connection. Keep the
+  existing non-OK/error-message behavior expressed in AppWire terms.
+
+- [ ] **Step 3: Verify generated output and commit.**
+
+  ```bash
+  make generate
+  git diff --check
+  git add cmd/evener-hub/frontend/src/protocol/types.gen.ts docs/appwire-protocol.md docs/web-ui/parity/parity-m6-surfaces.md
+  git commit -m "docs: publish directory creation AppWire contract"
+  ```
+
+### Task 6: Run the post-implementation simplify review
+
+**Files:**
+- Review: the complete branch diff from `git diff @{upstream}...HEAD` plus any working diff.
+
+- [ ] **Step 1: Dispatch the four read-only simplify reviewers in parallel.**
+
+  Use the same simplify-code skill and the four Reuse, Simplification,
+  Efficiency, and Altitude angles. Reviewers must not edit.
+
+- [ ] **Step 2: Apply only quality-preserving findings.**
+
+  Do not alter the wire contract, route removal scope, tests, or user-visible
+  error behavior. Record skipped findings and why.
+
+- [ ] **Step 3: Run focused tests after review cleanup.**
+
+  ```bash
+  go test ./appwire ./cmd/evener-hub -run 'TestClientRequestWrappersRoundTrip|TestHubRPCDirsCreate|TestHubRPCRegistersExpectedHandlerSet' -count=1
+  cd cmd/evener-hub/frontend
+  npx vitest run src/panes/spawn/preflight.test.ts src/panes/spawn/Spawn.test.tsx
+  ```
+
+### Task 7: Verify the complete microproject and publish the PR
+
+**Files:**
+- Verify: all branch files; no additional source changes expected.
+
+- [ ] **Step 1: Audit route residue.**
+
+  ```bash
+  rg -n '/api/dirs/create|handleAPIDirCreate' --glob '!docs/superpowers/**' --glob '!docs/web-ui/parity/contracts-sidebar-search-settings.md' .
+  ```
+
+  Expected: no current source, test, active-doc, or generated reference; any
+  remaining archival record must be explicitly identified and left untouched.
+
+- [ ] **Step 2: Run the repository gates.**
+
+  ```bash
+  make lint
+  make vet
+  make test
+  make test-web
+  make test-web-browser
+  ```
+
+  Run `make help` first if the target descriptions have not been checked in
+  this worktree. All commands must exit zero; record any host-specific browser
+  limitation rather than claiming it passed.
+
+- [ ] **Step 3: Inspect the final branch.**
+
+  ```bash
+  git status --short --branch
+  git diff @{upstream}...HEAD --stat
+  git diff --check @{upstream}...HEAD
+  ```
+
+  Confirm the branch is clean, contains only this microproject, and is based
+  on current `origin/main`.
+
+- [ ] **Step 4: Publish but do not merge.**
+
+  Push `codex/appwire-dirs-create` and open a PR against `main` with a body
+  that names the contract, route removal, tests, generated artifacts, and any
+  unresolved risk. Return the exact branch, commit list, PR URL, and command
+  output to Jesse.

--- a/docs/superpowers/specs/2026-08-27-appwire-dirs-create-design.md
+++ b/docs/superpowers/specs/2026-08-27-appwire-dirs-create-design.md
@@ -1,0 +1,107 @@
+# AppWire Directory Creation Microproject
+
+## Goal
+
+Move Spawn's "Create & start" working-directory action from the authenticated
+hub REST route `POST /api/dirs/create` to the authenticated hub AppWire
+connection, then remove the retired REST route and only its route-specific
+coverage.
+
+## Findings and scope
+
+The existing `evener/paths/complete` method lists directory suggestions; it
+does not create directories. There is no current `evener/dirs/complete`
+method to reuse. The replacement is therefore a new, narrow hub-only method:
+`evener/dirs/create`.
+
+This slice owns only the Spawn preflight caller and the directory-creation
+operation. It does not change path validation, path completion, thread start,
+or any other REST route.
+
+## Wire contract
+
+Add `evener/dirs/create` to the AppWire catalog with these typed shapes:
+
+```go
+type DirsCreateParams struct {
+	Path string `json:"path"`
+}
+
+type DirsCreateResponse struct {
+	Path    string `json:"path"`
+	Created bool   `json:"created"`
+}
+```
+
+The method is `ScopeHub`. It is served by the hub, not forwarded to a daemon,
+because the hub owns the Spawn working-directory prompt and has the same
+filesystem authority as the existing route.
+
+The hub preserves the current operation exactly:
+
+1. Trim surrounding whitespace.
+2. Expand `~` and `~/...` using the configured home directory.
+3. Require an absolute path.
+4. Clean the path with `filepath.Clean`.
+5. If `os.Stat` finds a directory, return the cleaned path with
+   `created:false`.
+6. If `os.Stat` finds a file, return an AppWire conflict with the existing
+   message `a file already exists at that path`.
+7. For every other stat error, call the configured `MkdirAll` seam or
+   `os.MkdirAll` with mode `0755`, and return the cleaned path with
+   `created:true` on success.
+8. Return an AppWire internal error carrying the existing `MkdirAll` error
+   message when creation fails.
+
+Validation errors use `appwire.InvalidParams`: `path is required` and
+`absolute path required`. A malformed typed request is rejected by the shared
+AppWire typed-router decoder. The file conflict uses `appwire.Conflict`; a
+creation failure uses `appwire.InternalError`.
+
+The browser's `/rpc` endpoint is already behind the hub authentication guard,
+so the new call retains the same authenticated, same-origin authority as the
+REST request without adding a second auth mechanism.
+
+## Server changes
+
+- Add the method constant, typed params/result, catalog entry, Go client
+  wrapper, and regenerated TypeScript/docs catalog output.
+- Move the directory operation into a focused hub helper used by the typed
+  AppWire handler; retain `WebConfig.MkdirAll` as the deterministic test seam.
+- Register the method with `registerMiscHandlers`.
+- Remove `handleAPIDirCreate` and the `/api/dirs/create` mux registration.
+- Remove only HTTP-route probes, the obsolete HTTP behavior test, and the
+  sandbox/fuzz route entries. Keep directory behavior coverage through the
+  AppWire server/client path and focused helper seams.
+
+## Frontend changes
+
+- Change `createDir` to accept the existing `AppwireClientLike` and request
+  `evener/dirs/create` with `{path}`.
+- Pass the shell's client from `Spawn` through the confirmation flow.
+- Preserve the current promise rejection and user-visible
+  `friendlyLaunchErrorMessage` handling.
+- Replace fetch/REST assertions in Spawn preflight tests with typed FakeClient
+  request assertions. Do not retain tests whose purpose is proving that the
+  old REST route is absent.
+
+## Non-goals
+
+- No REST compatibility fallback or dual request path.
+- No protocol-version bump; this is an additive hub method consumed by the
+  matching hub/frontend build.
+- No changes to directory completion, path validation, spawn payloads, or
+  filesystem authority.
+- No edits to historical design/parity records solely to rewrite their past
+  references.
+
+## Verification
+
+- Watch new Go and frontend behavior tests fail before production changes,
+  then make them pass with the smallest implementation.
+- Run `make generate` and verify generated output is clean.
+- Run focused AppWire/hub and Spawn tests, then `make lint`, `make vet`,
+  `make test`, `make test-web`, and `make test-web-browser` where the host
+  supports the browser gate.
+- Audit current source, tests, and active docs for `/api/dirs/create` before
+  publishing the PR; historical records may retain their archival references.

--- a/docs/web-ui/parity/parity-m6-surfaces.md
+++ b/docs/web-ui/parity/parity-m6-surfaces.md
@@ -173,7 +173,7 @@ These are the findings most likely to bite a rewrite that "looks equivalent." Ea
 - [ ] Deterministic "not fixable by creating a directory" errors — literal strings `path is not a directory`, `absolute path required`, `path is required` — render an inline error and abort instead of offering to create (`spawn.js:582-588`)
 - [ ] Any other invalid-path reason offers an IN-FORM (not native `confirm()`) dialog: `` The directory `<path>` doesn't exist yet. Create it and start the session? `` with Cancel / "Create & start" buttons; "Create & start" receives initial focus (`spawn.js:527-566, 589-591`)
 - [ ] Declining aborts the submit with NO error shown (`spawn.js:559-561, 591`)
-- [ ] Accepting POSTs `/api/dirs/create`; on a non-OK response the inline error uses the response body's `.error` field when present, else falls back to `HTTP <status>` (`spawn.js:592-606`)
+- [ ] Requesting `evener/dirs/create` over the authenticated AppWire connection; a server error's message reaches the existing inline launch-error path (`spawn.js:592-606`)
 
 ### 1.14 Submission & result handling
 


### PR DESCRIPTION
## Summary

- define the typed, hub-scoped `evener/dirs/create` AppWire contract and handler
- migrate Spawn directory preflight from REST to the authenticated AppWire connection
- preserve path normalization, `MkdirAll` semantics, error classification, and fail-soft UI behavior
- regenerate protocol artifacts and remove the retired REST route and route-specific residue

## Scope

Based on current `main` at `c9bd0cd9ae6168d53d156e1b432e8d2ddf2362e8`. This PR is intentionally limited to `/api/dirs/create`; model-list, navigation, and tree-residue changes are excluded from the PR diff.

## Verification

- `make lint`
- `make vet`
- `make test`
- `make test-web-browser`
- focused AppWire/hub Go tests
- focused Spawn/preflight Vitest tests
- four-angle simplify-code review before and after implementation: no quality-only findings

The branch was rebuilt with the correct Git tree parent after the initial connector publication exposed a truncation marker in `app_rpc_test.go`; the raw remote file now begins with `package hub`.