### PR TITLE
Migrate git HEAD lookup to typed AppWire

### DIFF
--- a/appwire/client.go
+++ b/appwire/client.go
@@ -547,6 +547,12 @@ func (c *Client) ProjectsRecent(ctx context.Context, params ProjectsRecentParams
 	return out, err
 }
 
+func (c *Client) GitHead(ctx context.Context, params GitHeadParams) (GitHeadResponse, error) {
+	var out GitHeadResponse
+	err := c.request(ctx, MethodEvenerGitHead, params, &out)
+	return out, err
+}
+
 func (c *Client) NavigationRead(ctx context.Context, params NavigationReadParams) (NavigationReadResponse, error) {
 	var out NavigationReadResponse
 	err := c.request(ctx, MethodEvenerNavigationRead, params, &out)

--- a/appwire/git_head_test.go
+++ b/appwire/git_head_test.go
@@ -1,0 +1,51 @@
+package appwire
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestClientGitHeadRoundTrip(t *testing.T) {
+	written := roundTrip(t, MethodEvenerGitHead, GitHeadResponse{Head: "main"}, func(ctx context.Context, client *Client) error {
+		resp, err := client.GitHead(ctx, GitHeadParams{CWD: "/repo"})
+		if err != nil {
+			return err
+		}
+		if resp.Head != "main" {
+			return fmt.Errorf("head=%q, want main", resp.Head)
+		}
+		return nil
+	})
+	assertWrittenParams(t, "GitHead", written.Request.Params, `{"cwd":"/repo"}`)
+}
+
+func TestGitHeadResponseUsesHeadWireField(t *testing.T) {
+	got, err := json.Marshal(GitHeadResponse{Head: "main"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != `{"head":"main"}` {
+		t.Fatalf("GitHeadResponse JSON = %s, want head field", got)
+	}
+}
+
+func TestGitHeadMethodIsHubScoped(t *testing.T) {
+	for _, method := range Methods {
+		if method.Name != MethodEvenerGitHead {
+			continue
+		}
+		if method.Scope != ScopeHub {
+			t.Fatalf("git head scope=%q, want %q", method.Scope, ScopeHub)
+		}
+		if _, ok := method.Params.(GitHeadParams); !ok {
+			t.Fatalf("git head params=%T, want GitHeadParams", method.Params)
+		}
+		if _, ok := method.Result.(GitHeadResponse); !ok {
+			t.Fatalf("git head result=%T, want GitHeadResponse", method.Result)
+		}
+		return
+	}
+	t.Fatalf("method catalog missing %q", MethodEvenerGitHead)
+}

--- a/appwire/params_fuzz_test.go
+++ b/appwire/params_fuzz_test.go
@@ -12,7 +12,7 @@ import (
 // value of the method's concrete Params type (via reflection, so the shared
 // catalog is never mutated) and unmarshals the bytes into it. The oracle is
 // floor "no panic" plus a decode→encode→decode fixed point for any input that
-// decodes cleanly — this exercises all 46 methods' Params structs (field types,
+// decodes cleanly — this exercises every catalogued method's Params struct (field types,
 // tags, any custom UnmarshalJSON) through one harness, not the generic decoder.
 //
 // Focus note: the Params decode is stdlib struct-tag reflection, so the focus

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -122,6 +122,7 @@ var Methods = []MethodSpec{
 	{MethodEvenerDirsCreate, DirsCreateParams{}, DirsCreateResponse{}, ScopeHub, "Creates a missing working directory and its parents for Spawn preflight."},
 	{MethodEvenerProjectsRecent, ProjectsRecentParams{}, ProjectsRecentResponse{}, ScopeHub, "Lists the most recently used project working directories (session creation path-dropdown options; default cap 15)."},
 	{MethodEvenerPathValidate, PathValidateParams{}, PathValidateResponse{}, ScopeHub, "Validates a launch path."},
+	{MethodEvenerGitHead, GitHeadParams{}, GitHeadResponse{}, ScopeHub, "Reads git HEAD for a working directory."},
 	{MethodEvenerNavigationRead, NavigationReadParams{}, NavigationReadResponse{}, ScopeHub, "Reads one bounded, revisioned hub navigation resource, optionally conditional on its ETag."},
 	{MethodEvenerFavoriteSet, FavoriteSetParams{}, FavoriteSetResponse{}, ScopeHub, "Sets or clears a project favorite and returns the committed navigation invalidation targets."},
 	{MethodEvenerSearch, SearchParams{}, SearchResponse{}, ScopeHub, "Searches live and persisted sessions for the hub command palette."},

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -55,6 +55,7 @@ const (
 	MethodEvenerDirsCreate            = "evener/dirs/create"
 	MethodEvenerProjectsRecent        = "evener/projects/recent"
 	MethodEvenerPathValidate          = "evener/path/validate"
+	MethodEvenerGitHead               = "evener/git/head"
 	MethodEvenerNavigationRead        = "evener/navigation/read"
 	MethodEvenerFavoriteSet           = "evener/favorite/set"
 	MethodEvenerSearch                = "evener/search"
@@ -1656,6 +1657,17 @@ type PathValidateResponse struct {
 	Path  string `json:"path"`
 	Valid bool   `json:"valid"`
 	Error string `json:"error,omitempty"`
+}
+
+// GitHeadParams selects the working directory whose git HEAD should be read.
+type GitHeadParams struct {
+	CWD string `json:"cwd"`
+}
+
+// GitHeadResponse reports a branch name, detached short SHA, or an empty
+// string when the working directory has no readable git HEAD.
+type GitHeadResponse struct {
+	Head string `json:"head"`
 }
 
 type HarnessListParams struct{}

--- a/cmd/evener-hub/app_git_head.go
+++ b/cmd/evener-hub/app_git_head.go
@@ -1,0 +1,51 @@
+package hub
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/fspaths"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+var gitCommand = exec.CommandContext
+
+// hubGitHead resolves a working directory's git HEAD for the hub AppWire
+// method. Git and filesystem failures are intentionally represented as an
+// empty HEAD: the Spawn pane uses this value only as display metadata.
+func hubGitHead(ctx context.Context, cfg hubcore.WebConfig, params appwire.GitHeadParams) appwire.GitHeadResponse {
+	cwd, err := fspaths.CanonicalizeDir(params.CWD)
+	if err != nil {
+		return appwire.GitHeadResponse{}
+	}
+
+	resolve := resolveGitHead
+	if cfg.ResolveGitHead != nil {
+		resolve = cfg.ResolveGitHead
+	}
+	head, err := resolve(ctx, cwd)
+	if err != nil {
+		return appwire.GitHeadResponse{}
+	}
+	return appwire.GitHeadResponse{Head: head}
+}
+
+// resolveGitHead returns the current branch name or, in detached HEAD state,
+// the short commit SHA.
+func resolveGitHead(ctx context.Context, dir string) (string, error) {
+	out, err := gitCommand(ctx, "git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		return "", err
+	}
+	head := strings.TrimSpace(string(out))
+	if head != "HEAD" {
+		return head, nil
+	}
+	out, err = gitCommand(ctx, "git", "-C", dir, "rev-parse", "--short", "HEAD").Output()
+	if err != nil {
+		return head, nil //nolint:nilerr // the literal "HEAD" remains a valid best-effort result
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/cmd/evener-hub/app_git_head_test.go
+++ b/cmd/evener-hub/app_git_head_test.go
@@ -1,0 +1,86 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+func TestHubGitHeadFailSoft(t *testing.T) {
+	root := t.TempDir()
+	missing := filepath.Join(root, "missing")
+	calls := 0
+	cfg := hubcore.WebConfig{ResolveGitHead: func(context.Context, string) (string, error) {
+		calls++
+		return "", errors.New("git unavailable")
+	}}
+
+	for _, tc := range []struct {
+		name string
+		cwd  string
+	}{
+		{name: "empty cwd", cwd: "  "},
+		{name: "missing cwd", cwd: missing},
+		{name: "git error", cwd: root},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hubGitHead(context.Background(), cfg, appwire.GitHeadParams{CWD: tc.cwd})
+			if got.Head != "" {
+				t.Fatalf("head=%q, want empty", got.Head)
+			}
+		})
+	}
+	if calls != 1 {
+		t.Fatalf("git seam calls=%d, want 1 (only the existing directory)", calls)
+	}
+}
+
+func TestHubGitHeadNonGitDirectoryReturnsEmpty(t *testing.T) {
+	got := hubGitHead(context.Background(), hubcore.WebConfig{}, appwire.GitHeadParams{CWD: t.TempDir()})
+	if got.Head != "" {
+		t.Fatalf("head=%q, want empty for a non-git directory", got.Head)
+	}
+}
+
+func TestHubRPCGitHeadUsesCanonicalDirectory(t *testing.T) {
+	root := t.TempDir()
+	canonicalRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(t.TempDir(), "repo-link")
+	if err := os.Symlink(root, link); err != nil {
+		t.Fatal(err)
+	}
+	var gotDir string
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{
+		Past: hubcore.NewPastIndex(""),
+		ResolveGitHead: func(_ context.Context, dir string) (string, error) {
+			gotDir = dir
+			return "main", nil
+		},
+	})
+	defer hub.Close()
+
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	resp, err := client.GitHead(context.Background(), appwire.GitHeadParams{CWD: link})
+	if err != nil {
+		t.Fatalf("GitHead: %v", err)
+	}
+	if resp.Head != "main" {
+		t.Fatalf("head=%q, want main", resp.Head)
+	}
+	if gotDir != canonicalRoot {
+		t.Fatalf("git seam directory=%q, want %q", gotDir, canonicalRoot)
+	}
+}

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -773,9 +773,8 @@ func notifyPluginUpdated(server *appserver.Server) {
 // count (issue #35): the 15 most recently used projects.
 const recentProjectDirsLimit = 15
 
-// registerMiscHandlers registers the remaining hub RPC handlers: search,
-// model list, task list, transcript list, directory operations, path
-// validation, and the harness descriptor list.
+// registerMiscHandlers registers hub RPC handlers that are not owned by a
+// focused controller registration.
 func registerMiscHandlers(server *appserver.Server, cfg hubcore.WebConfig, sources *appsource.Registry) {
 	appserver.HandleTyped(server.Router(), appwire.MethodEvenerUpgrade, hubUpgrade)
 	appserver.HandleTyped(server.Router(), appwire.MethodEvenerSearch, func(_ context.Context, params appwire.SearchParams) (appwire.SearchResponse, error) {
@@ -818,6 +817,9 @@ func registerMiscHandlers(server *appserver.Server, cfg hubcore.WebConfig, sourc
 	})
 	appserver.HandleTyped(server.Router(), appwire.MethodEvenerPathValidate, func(_ context.Context, params appwire.PathValidateParams) (appwire.PathValidateResponse, error) {
 		return fspaths.ValidateLaunchPath(params), nil
+	})
+	appserver.HandleTyped(server.Router(), appwire.MethodEvenerGitHead, func(ctx context.Context, params appwire.GitHeadParams) (appwire.GitHeadResponse, error) {
+		return hubGitHead(ctx, cfg, params), nil
 	})
 	appserver.HandleTyped(server.Router(), appwire.MethodEvenerHarnessesList, func(context.Context, appwire.HarnessListParams) (appwire.HarnessListResponse, error) {
 		return appwire.HarnessListResponse{Data: launchHarnessDescriptors(cfg)}, nil

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -9867,6 +9867,7 @@ func TestHubRPCRegistersExpectedHandlerSet(t *testing.T) {
 		appwire.MethodEvenerDirsCreate,
 		appwire.MethodEvenerProjectsRecent,
 		appwire.MethodEvenerPathValidate,
+		appwire.MethodEvenerGitHead,
 		appwire.MethodEvenerHarnessesList,
 		appwire.MethodEvenerCommandList,
 		appwire.MethodEvenerSettingsOverview,

--- a/cmd/evener-hub/cov_core_api_pass4_fuzz_test.go
+++ b/cmd/evener-hub/cov_core_api_pass4_fuzz_test.go
@@ -90,7 +90,7 @@ func FuzzCoreAPIPass4(f *testing.F) {
 		web := NewWebServer(hubcore.WebConfig{
 			HubAddr: "127.0.0.1:9180", Past: past, Roster: hubcore.NewRosterWithEntries(),
 			PokeAttention: func() { poke++ },
-			GitHeadBranch: func(context.Context, string) (string, error) {
+			ResolveGitHead: func(context.Context, string) (string, error) {
 				if variant&1 != 0 {
 					return "", errors.New("git failed")
 				}
@@ -126,9 +126,9 @@ func FuzzCoreAPIPass4(f *testing.F) {
 		direct(func(w http.ResponseWriter, r *http.Request) { web.handleAPIReasoningEffort(w, r, "local:missing") }, http.MethodPost, "/effort", `{}`)
 		call(http.MethodPost, "/api/sessions/remote:thread/rename", `{"name":" renamed "}`)
 		call(http.MethodPost, "/api/sessions/remote:thread/model", `{`)
-		call(http.MethodGet, "/api/git/head?cwd="+workingDir, "")
-		call(http.MethodGet, "/api/git/head?cwd=/definitely/missing/pass4", "")
-		call(http.MethodPost, "/api/git/head", "")
+		_ = hubGitHead(context.Background(), web.cfg, appwire.GitHeadParams{CWD: workingDir})
+		_ = hubGitHead(context.Background(), web.cfg, appwire.GitHeadParams{CWD: "/definitely/missing/pass4"})
+		_ = hubGitHead(context.Background(), web.cfg, appwire.GitHeadParams{})
 		filePath := filepath.Join(root, "already-file")
 		if err := os.WriteFile(filePath, []byte("x"), 0o644); err != nil {
 			t.Fatal(err)
@@ -164,12 +164,12 @@ func FuzzCoreAPIPass4(f *testing.F) {
 				t.Fatalf("git %v: %v: %s", args, err, out)
 			}
 		}
-		_, _ = gitHeadBranch(context.Background(), repo)
+		_, _ = resolveGitHead(context.Background(), repo)
 		if out, err := exec.Command("git", "-C", repo, "checkout", "-q", "--detach").CombinedOutput(); err != nil {
 			t.Fatalf("detach: %v: %s", err, out)
 		}
-		_, _ = gitHeadBranch(context.Background(), repo)
-		_, _ = gitHeadBranch(context.Background(), filepath.Join(root, "missing"))
+		_, _ = resolveGitHead(context.Background(), repo)
+		_, _ = resolveGitHead(context.Background(), filepath.Join(root, "missing"))
 
 		_ = warningPayload([]byte(`{"warning":{"message":"nested"},"source":"daemon","title":"Title","hint":"Hint"}`))
 		_ = warningPayload([]byte(`{"message":"plain"}`))

--- a/cmd/evener-hub/cov_small_tails_pass6_fuzz_test.go
+++ b/cmd/evener-hub/cov_small_tails_pass6_fuzz_test.go
@@ -157,7 +157,7 @@ func FuzzSmallTailsPass6(f *testing.F) {
 			}
 			return exec.Command("false")
 		}
-		_, _ = gitHeadBranch(context.Background(), root)
+		_, _ = resolveGitHead(context.Background(), root)
 		gitCommand = oldGit
 
 		_ = workspaceDataFromAppThread(appwire.Thread{ID: "x", Source: "local", Preview: "preview", Status: appwire.ThreadStatus{Type: ""}})

--- a/cmd/evener-hub/cov_web_core_api_test.go
+++ b/cmd/evener-hub/cov_web_core_api_test.go
@@ -1,7 +1,6 @@
 package hub
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -90,7 +89,6 @@ func TestCovWebCoreAPIHelpersAndRoutes(t *testing.T) {
 		{http.MethodGet, "/_partials/s/id/unknown"},
 		{http.MethodGet, "/manifest.webmanifest"},
 		{http.MethodPost, "/api/health"}, {http.MethodGet, "/api/health"},
-		{http.MethodPost, "/api/git/head"},
 	} {
 		_ = covWebRequest(t, web, tc.method, tc.target, "")
 	}
@@ -99,12 +97,6 @@ func TestCovWebCoreAPIHelpersAndRoutes(t *testing.T) {
 		call(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{}")), "missing")
 	}
 
-	// Filesystem-backed API probes remain inside a temp root.
-	root := t.TempDir()
-	gitWeb := NewWebServer(hubcore.WebConfig{GitHeadBranch: func(context.Context, string) (string, error) { return "branch", nil }})
-	_ = covWebRequest(t, gitWeb, http.MethodGet, "/api/git/head?cwd="+root, "")
-	gitWeb.cfg.GitHeadBranch = func(context.Context, string) (string, error) { return "", errors.New("git failed") }
-	_ = covWebRequest(t, gitWeb, http.MethodGet, "/api/git/head?cwd="+root, "")
 }
 
 func TestCovWebCoreAPIDecisionValidation(t *testing.T) {

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -107,6 +107,7 @@ function readyClient(configure?: (fake: FakeClient) => void): FakeClient {
   fake.on("evener/paths/complete", () => ({ data: [] }));
   fake.on("evener/path/validate", () => ({ path: "", valid: true }));
   fake.on("evener/dirs/create", ({ path }) => ({ path, created: true }));
+  fake.on("evener/git/head", () => ({ head: "main" }));
   fake.on("evener/plugin/preview", () => ({ plugins: [] }));
   fake.on("thread/start", () => startResponse("local:abc123"));
   configure?.(fake);
@@ -169,8 +170,6 @@ async function settled(): Promise<void> {
   await screen.findByRole("button", { name: "Advanced options" });
 }
 
-let fetchMock: ReturnType<typeof vi.fn>;
-
 beforeAll(() => {
   globalThis.localStorage = new MemoryStorage() as unknown as Storage;
 });
@@ -178,13 +177,6 @@ beforeAll(() => {
 beforeEach(() => {
   localStorage.clear();
   modelListOverride = null;
-  fetchMock = vi.fn((url: string) => {
-    if (url.startsWith("/api/git/head")) {
-      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ branch: "main" }) } as Response);
-    }
-    return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) } as Response);
-  });
-  vi.stubGlobal("fetch", fetchMock);
 });
 
 afterEach(() => {
@@ -417,21 +409,20 @@ test("branch renders as a suffix on the directory row, not as an editable peer f
   await settled();
 
   await waitFor(() => expect(screen.getByTestId("spawn-branch").textContent).toContain("main"));
-  // Not a text box: it is a readout of the directory's HEAD, and the wire has
-  // nowhere to send a branch anyway (startThread.ts's own branch note).
+  // Not a text box: it is a readout of the directory's HEAD.
   expect(screen.queryByLabelText("Branch")).toBeNull();
   expect(screen.getByTestId("spawn-branch").querySelector("input")).toBeNull();
 });
 
 test("the branch readout is absent when the working directory has no resolvable HEAD", async () => {
-  // The default fetch mock 404s everything except /api/git/head; override it so
-  // HEAD resolution fails soft to "" the way branch.ts documents.
-  vi.stubGlobal(
-    "fetch",
-    vi.fn(() => Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) } as Response)),
-  );
   localStorage.setItem("evener-hub.spawn-defaults.global.working_dir", "/tmp/plain");
-  renderSpawn(readyClient());
+  renderSpawn(
+    readyClient((fake) => {
+      fake.on("evener/git/head", () => {
+        throw new Error("git head unavailable");
+      });
+    }),
+  );
   await settled();
 
   await waitFor(() => expectWorkingDir("/tmp/plain"));

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -366,12 +366,6 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     if (defaults.workingDir) setCwd(defaults.workingDir);
     if (defaults.accessMode) setAccessMode(defaults.accessMode);
     if (defaults.reasoningEffort) setReasoningEffort(defaults.reasoningEffort);
-    // The persisted branch is a fast first paint only - the HEAD resolution
-    // below always overrides it once it lands. Now that the readout is
-    // read-only, HEAD is the sole authority for what it says; a remembered
-    // value outliving the branch it named would be a lie in a field that
-    // presents itself as fact.
-    if (defaults.branch) setBranch(defaults.branch);
     // Writing the prompt is what starting an agent IS, so the caret starts
     // there rather than on whichever field happens to be first in the DOM.
     textareaRef.current?.focus();
@@ -472,13 +466,13 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
   useEffect(() => {
     if (cwd.trim() === "") return undefined;
     let active = true;
-    resolveHeadBranch(cwd).then((head) => {
+    resolveHeadBranch(client, cwd).then((head) => {
       if (active) setBranch(head);
     });
     return () => {
       active = false;
     };
-  }, [cwd]);
+  }, [client, cwd]);
 
   // Default-model preview (kata xgk8): thread/start resolves Model from the
   // SAME layered launch config this previews (app_threadlifecycle.go -
@@ -710,7 +704,6 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
       cwd,
       harness,
       model,
-      branch,
       accessMode,
       reasoningEffort,
       harnessUsesEvenerModels: usesEvenerModels,
@@ -720,7 +713,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     // marker-counter reset). The spawn pane is a dockview singleton that can
     // still be mounted behind the session pane this navigates to, so without
     // this an already-sent prompt/image stays staged and re-sendable if the
-    // user returns to it. Sticky defaults (harness/model/cwd/branch/access
+    // user returns to it. Sticky defaults (harness/model/cwd/access
     // mode, floor §1.9-§1.10) are deliberately left untouched - only the
     // one-shot prompt/attachments reset.
     updatePrompt("");
@@ -983,8 +976,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
             </FormRow>
             {/* Branch is a read-only HEAD readout, not a peer field: it rides
                 the directory row as a mono suffix ("~/code/evener · main") because
-                it is a PROPERTY of that directory, and the wire has nowhere to
-                send it anyway (startThread.ts's own branch comment). */}
+                it is a property of that directory. */}
             {branch !== "" && (
               <span className={CLASS.branch} data-testid="spawn-branch" title={`HEAD ${branch}`}>
                 <span className={CLASS.branchSeparator} aria-hidden="true">

--- a/cmd/evener-hub/frontend/src/panes/spawn/branch.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/branch.test.ts
@@ -1,50 +1,39 @@
 // @vitest-environment node
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
+import { FakeClient } from "../../protocol/testing/fakeClient";
 import { resolveHeadBranch } from "./branch";
 
-describe("resolveHeadBranch (floor §1.7, REST-only GET /api/git/head?cwd=)", () => {
-  let fetchMock: ReturnType<typeof vi.fn>;
-
-  function jsonResponse(body: unknown): Response {
-    return { ok: true, status: 200, json: () => Promise.resolve(body) } as Response;
-  }
+describe("resolveHeadBranch (floor §1.7, evener/git/head)", () => {
+  let client: FakeClient;
 
   beforeEach(() => {
-    fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-  });
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    vi.restoreAllMocks();
+    client = new FakeClient();
   });
 
-  test("GETs /api/git/head with the cwd query param and returns the branch", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({ branch: "main" }));
+  test("requests the cwd over AppWire and returns the branch", async () => {
+    client.on("evener/git/head", ({ cwd }) => {
+      expect(cwd).toBe("/home/me/my project");
+      return { head: "main" };
+    });
 
-    expect(await resolveHeadBranch("/home/me/my project")).toBe("main");
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/git/head?cwd=%2Fhome%2Fme%2Fmy%20project",
-      expect.objectContaining({ credentials: "same-origin" }),
-    );
+    expect(await resolveHeadBranch(client, "/home/me/my project")).toBe("main");
+    expect(client.calls).toEqual([{ method: "evener/git/head", params: { cwd: "/home/me/my project" } }]);
   });
 
   test("returns an empty string when the server reports no branch (not a git repo)", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({ branch: "" }));
-    expect(await resolveHeadBranch("/tmp/plain")).toBe("");
+    client.on("evener/git/head", () => ({ head: "" }));
+    expect(await resolveHeadBranch(client, "/tmp/plain")).toBe("");
   });
 
   test("fails soft to an empty string when the request throws", async () => {
-    fetchMock.mockRejectedValueOnce(new Error("network down"));
-    expect(await resolveHeadBranch("/tmp/x")).toBe("");
+    client.on("evener/git/head", () => {
+      throw new Error("hub unavailable");
+    });
+    expect(await resolveHeadBranch(client, "/tmp/x")).toBe("");
   });
 
-  test("fails soft to an empty string on a non-OK response", async () => {
-    fetchMock.mockResolvedValueOnce({ ok: false, status: 500, json: () => Promise.resolve({}) } as Response);
-    expect(await resolveHeadBranch("/tmp/x")).toBe("");
-  });
-
-  test("does not fetch for an empty cwd", async () => {
-    expect(await resolveHeadBranch("  ")).toBe("");
-    expect(fetchMock).not.toHaveBeenCalled();
+  test("does not request for an empty cwd", async () => {
+    expect(await resolveHeadBranch(client, "  ")).toBe("");
+    expect(client.calls).toHaveLength(0);
   });
 });

--- a/cmd/evener-hub/frontend/src/panes/spawn/branch.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/branch.ts
@@ -1,19 +1,16 @@
-// Branch/worktree HEAD auto-resolution (floor §1.7). REST-ONLY: appwire has no
-// git/head method, so this always goes through GET /api/git/head?cwd= (the
-// legacy no-ops the whole thing when appwire is present, spawn.js:376-379). The
-// resolved HEAD ref only fills the branch chip's DISPLAY - the branch value is
-// never sent on the wire (see startThread.ts's branch note). Fails soft: any
-// error yields "" (no branch shown), never a thrown error, so a flaky /api or a
-// non-git working dir never blocks the form.
-const FETCH_INIT: RequestInit = { credentials: "same-origin" };
+import type { AppwireClientLike } from "../../protocol/testing/fakeClient";
 
-export async function resolveHeadBranch(cwd: string): Promise<string> {
+// Branch/worktree HEAD auto-resolution (floor §1.7). The resolved HEAD ref
+// only fills the branch chip's DISPLAY - the branch value is never sent on the
+// wire (see startThread.ts's branch note). Fails soft: any error yields "" (no
+// branch shown), never a thrown error, so a disconnected hub or a non-git
+// working dir never blocks the form.
+
+export async function resolveHeadBranch(client: AppwireClientLike, cwd: string): Promise<string> {
   if (cwd.trim() === "") return "";
   try {
-    const res = await fetch(`/api/git/head?cwd=${encodeURIComponent(cwd)}`, FETCH_INIT);
-    if (!res.ok) return "";
-    const data = (await res.json()) as { branch?: string };
-    return data.branch ?? "";
+    const data = await client.request("evener/git/head", { cwd });
+    return data.head;
   } catch {
     return "";
   }

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawnDefaults.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawnDefaults.test.ts
@@ -64,8 +64,8 @@ describe("defaultsKeyFor", () => {
 
 describe("loadDefaultsBlob", () => {
   test("returns the parsed blob for a project", () => {
-    localStorage.setItem(defaultsKeyFor("/p"), JSON.stringify({ harness: "evener", branch: "main" }));
-    expect(loadDefaultsBlob("/p")).toEqual({ harness: "evener", branch: "main" });
+    localStorage.setItem(defaultsKeyFor("/p"), JSON.stringify({ harness: "evener", access_mode: "read-only" }));
+    expect(loadDefaultsBlob("/p")).toEqual({ harness: "evener", access_mode: "read-only" });
   });
 
   test("returns an empty object when absent or malformed", () => {
@@ -99,14 +99,13 @@ describe("resolveInitialDefaults", () => {
     expect(resolveInitialDefaults({}).model).toBe("openai/gpt-5");
   });
 
-  test("surfaces harness/branch/access/reasoning from the resolved project blob", () => {
+  test("surfaces harness/access/reasoning from the resolved project blob", () => {
     localStorage.setItem(
       defaultsKeyFor("/p"),
-      JSON.stringify({ harness: "evener", branch: "dev", access_mode: "read-only", reasoning_effort: "high" }),
+      JSON.stringify({ harness: "evener", access_mode: "read-only", reasoning_effort: "high" }),
     );
     expect(resolveInitialDefaults({ serverPrefillDir: "/p" })).toMatchObject({
       harness: "evener",
-      branch: "dev",
       accessMode: "read-only",
       reasoningEffort: "high",
       workingDir: "/p",
@@ -116,8 +115,8 @@ describe("resolveInitialDefaults", () => {
 
 describe("saveDefaults", () => {
   test("writes a per-project blob plus the global working_dir on every submit (floor §1.9, spawn.js:100)", () => {
-    saveDefaults({ cwd: "/p", harness: "evener", branch: "main", harnessUsesEvenerModels: true });
-    expect(loadDefaultsBlob("/p")).toMatchObject({ harness: "evener", branch: "main" });
+    saveDefaults({ cwd: "/p", harness: "evener", accessMode: "read-only", harnessUsesEvenerModels: true });
+    expect(loadDefaultsBlob("/p")).toMatchObject({ harness: "evener", access_mode: "read-only" });
     expect(localStorage.getItem(GLOBAL_WORKING_DIR_KEY)).toBe("/p");
   });
 
@@ -159,7 +158,7 @@ describe("modelValidityAgainstList (floor §1.10, spawn.js:154-175)", () => {
 
 describe("sweepStaleModels (floor §1.10)", () => {
   test("clears stale and malformed models across every blob, leaves unknown, and reports discards", () => {
-    localStorage.setItem(defaultsKeyFor("/a"), JSON.stringify({ model: "openai/gpt-4o", branch: "main" }));
+    localStorage.setItem(defaultsKeyFor("/a"), JSON.stringify({ model: "openai/gpt-4o", harness: "evener" }));
     localStorage.setItem(defaultsKeyFor("/b"), JSON.stringify({ model: "legacybare" }));
     localStorage.setItem(defaultsKeyFor("/c"), JSON.stringify({ model: "openrouter/x-anthropic" }));
     localStorage.setItem(defaultsKeyFor("/d"), JSON.stringify({ model: "openai/gpt-5" }));
@@ -167,7 +166,7 @@ describe("sweepStaleModels (floor §1.10)", () => {
     const result = sweepStaleModels(MODELS);
 
     // stale model cleared, blob otherwise preserved
-    expect(loadDefaultsBlob("/a")).toEqual({ branch: "main" });
+    expect(loadDefaultsBlob("/a")).toEqual({ harness: "evener" });
     // malformed model cleared AND the now-empty blob deleted outright
     expect(localStorage.getItem(defaultsKeyFor("/b"))).toBeNull();
     // unknown provider left untouched

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawnDefaults.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawnDefaults.ts
@@ -2,7 +2,7 @@
 // and cleanup (floor §1.10) for the spawn pane. All state lives in localStorage
 // under the `evener-hub.spawn-defaults.` namespace, distinct from prefs.ts's
 // `evener.prefs.` flat keys - these are per-project JSON blobs plus a few global
-// scalars, matching the legacy spawn.js key layout.
+// scalars.
 //
 // This is a per-device convenience layer (like the legacy), NOT the source of
 // truth for launch config - the daemon's own launch.toml layering is. A blob
@@ -27,7 +27,6 @@ const SCALAR_KEYS = new Set([GLOBAL_WORKING_DIR_KEY, GLOBAL_LAST_WORKING_DIR_KEY
 export interface SpawnDefaultsBlob {
   harness?: string;
   model?: string;
-  branch?: string;
   access_mode?: string;
   reasoning_effort?: string;
 }
@@ -36,7 +35,6 @@ export interface ResolvedDefaults {
   harness?: string;
   model?: string;
   workingDir?: string;
-  branch?: string;
   accessMode?: string;
   reasoningEffort?: string;
 }
@@ -95,11 +93,7 @@ export function setGlobalLastWorkingDir(dir: string): void {
 // Computes the spawn form's initial field values with the floor §1.9 layering:
 // the working dir comes from the server's ?dir= prefill first, else the global
 // last-resort; the remaining fields come from the resolved project blob, with
-// the global model layering UNDER any per-project model default. The legacy's
-// harness/branch/access-BEFORE-working_dir application order (spawn.js:1132-1138)
-// exists only so branch HEAD-resolution sees an explicit branch default - a
-// React consumer gets that for free by having the branch-resolution effect
-// respect an already-set branch value, so it is not modeled as ordering here.
+// the global model layering UNDER any per-project model default.
 export function resolveInitialDefaults(opts: { serverPrefillDir?: string }): ResolvedDefaults {
   const serverDir = opts.serverPrefillDir?.trim();
   const workingDir = serverDir && serverDir !== "" ? serverDir : (readRaw(GLOBAL_WORKING_DIR_KEY) ?? "").trim();
@@ -109,7 +103,6 @@ export function resolveInitialDefaults(opts: { serverPrefillDir?: string }): Res
     harness: blob.harness,
     model: model ?? undefined,
     workingDir: workingDir === "" ? undefined : workingDir,
-    branch: blob.branch,
     accessMode: blob.access_mode,
     reasoningEffort: blob.reasoning_effort,
   };
@@ -119,7 +112,6 @@ export interface SaveDefaultsInput {
   cwd: string;
   harness?: string;
   model?: string;
-  branch?: string;
   accessMode?: string;
   reasoningEffort?: string;
   // Whether the chosen harness uses evener models (kind === "evener"). Gates
@@ -138,12 +130,10 @@ function nonEmpty(value: string | undefined): string | undefined {
 export function saveDefaults(input: SaveDefaultsInput): void {
   const blob: SpawnDefaultsBlob = {};
   const harness = nonEmpty(input.harness);
-  const branch = nonEmpty(input.branch);
   const accessMode = nonEmpty(input.accessMode);
   const reasoningEffort = nonEmpty(input.reasoningEffort);
   const model = nonEmpty(input.model);
   if (harness) blob.harness = harness;
-  if (branch) blob.branch = branch;
   if (accessMode) blob.access_mode = accessMode;
   if (reasoningEffort) blob.reasoning_effort = reasoningEffort;
   if (model && input.harnessUsesEvenerModels) blob.model = model;

--- a/cmd/evener-hub/frontend/src/panes/spawn/startThread.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/startThread.test.ts
@@ -188,15 +188,6 @@ test("an advanced-schema sandbox wins over the access mode (floor §1.8)", async
   expect(fake.calls[0]?.params).toMatchObject({ launchOverrides: { sandbox: "workspace-write" } });
 });
 
-test("branch is display-only and is never sent on the wire (floor §1.7; thread/start has no branch field)", async () => {
-  const fake = new FakeClient("ready");
-  fake.on("thread/start", () => startResponse("local:r"));
-
-  await startThread(fake, { cwd: "/tmp/p", prompt: "go", branch: "feature/x" });
-
-  expect(fake.calls[0]?.params).toEqual({ cwd: "/tmp/p", input: [{ type: "text", text: "go" }] });
-});
-
 test("passes the direct optional fields (harness/model/provider/effort/overrides) through", async () => {
   const fake = new FakeClient("ready");
   fake.on("thread/start", () => startResponse("local:r"));

--- a/cmd/evener-hub/frontend/src/panes/spawn/startThread.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/startThread.ts
@@ -1,7 +1,7 @@
 // startThread is the thread/start seam: it starts a real session over appwire
 // "thread/start" (NOT the REST /api/spawn shim) and returns the created
 // thread's ref. T1 defines the signature + a minimal working body (bare
-// prompt + cwd -> real session); T2 fills the rest (branch/access-mode ->
+// prompt + cwd -> real session); T2 fills the rest (access-mode ->
 // launchOverrides, the schema engine, sticky defaults).
 import type { AppwireClientLike } from "../../protocol/testing/fakeClient";
 import type { InputItem, LaunchConfigLayer, ThreadStartParams } from "../../protocol/types.gen";
@@ -17,13 +17,6 @@ export interface SpawnRequest {
   modelProvider?: string; // evener-model harness: "<provider>/<model>" split -> provider half
   model?: string; // model id (bare id for a non-evener harness - floor §1.4)
   reasoningEffort?: string; // wire camelCase - floor §1.11
-  // branch is DISPLAY-ONLY (floor §1.7): the branch chip shows the resolved
-  // HEAD ref, but the wire has nowhere to carry it - appwire ThreadStartParams
-  // and LaunchConfigLayer both lack a branch field, and the legacy REST
-  // /api/spawn dropped req.Branch on the floor too (web_spawn.go:135-144, never
-  // threaded into ThreadStartParams). Accepted here so callers can pass the
-  // form value uniformly; startThread never sends it.
-  branch?: string;
   accessMode?: string; // merged -> launchOverrides.sandbox unless schema set it (floor §1.8)
   launchOverrides?: LaunchConfigLayer;
 }

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -395,6 +395,14 @@ export interface FeatureSet {
   auth: boolean;
 }
 
+export interface GitHeadParams {
+  cwd: string;
+}
+
+export interface GitHeadResponse {
+  head: string;
+}
+
 export interface GitInfo {
   sha?: string;
   branch?: string;
@@ -1791,6 +1799,7 @@ export const METHOD_NAMES = [
   "evener/dirs/create",
   "evener/projects/recent",
   "evener/path/validate",
+  "evener/git/head",
   "evener/navigation/read",
   "evener/favorite/set",
   "evener/search",
@@ -1953,6 +1962,7 @@ export interface MethodTypes {
   "evener/dirs/create": { params: DirsCreateParams; result: DirsCreateResponse };
   "evener/projects/recent": { params: ProjectsRecentParams; result: ProjectsRecentResponse };
   "evener/path/validate": { params: PathValidateParams; result: PathValidateResponse };
+  "evener/git/head": { params: GitHeadParams; result: GitHeadResponse };
   "evener/navigation/read": { params: NavigationReadParams; result: NavigationReadResponse };
   "evener/favorite/set": { params: FavoriteSetParams; result: FavoriteSetResponse };
   "evener/search": { params: SearchParams; result: SearchResponse };

--- a/cmd/evener-hub/internal/hubcore/config.go
+++ b/cmd/evener-hub/internal/hubcore/config.go
@@ -77,14 +77,14 @@ type WebConfig struct {
 	RelayHooks RelayLifecycleHooks // test-only relay lifecycle seams; nil in production
 
 	// Sandbox seams. Each is nil in production (the real implementation runs);
-	// a fuzz/test sandbox sets them so the matching mutating handler runs without
+	// a fuzz/test sandbox sets them so the matching handler runs without
 	// shelling out, hitting the network, or mutating the real filesystem. These
-	// are the escapes a read-only harness cannot drive: the live-git probe
-	// (/api/git/head), the live-provider model query, and the directory creator
-	// (evener/dirs/create). See cmd/evener-hub's app_dirs_test.go.
-	GitHeadBranch func(ctx context.Context, dir string) (string, error) // nil → real `git`
-	LiveModels    func(ctx context.Context) []appwire.ModelDescriptor   // nil → real provider query
-	MkdirAll      func(path string, perm os.FileMode) error             // nil → os.MkdirAll
+	// are the escapes a read-only harness cannot drive: the git-head AppWire
+	// method, the live-provider model query, and the directory creator. See
+	// cmd/evener-hub's sandbox_test.go.
+	ResolveGitHead func(ctx context.Context, dir string) (string, error) // nil → real `git`
+	LiveModels     func(ctx context.Context) []appwire.ModelDescriptor   // nil → real provider query
+	MkdirAll       func(path string, perm os.FileMode) error             // nil → os.MkdirAll
 }
 
 // Spawner forks a evener serve subprocess and waits for its rendezvous file to appear.

--- a/cmd/evener-hub/sandbox_selftest_test.go
+++ b/cmd/evener-hub/sandbox_selftest_test.go
@@ -51,9 +51,10 @@ func installDenyTransport(t *testing.T) *denyTransport {
 }
 
 // TestSandboxContainsMutatingHandlers is the B0 containment proof. It drives the
-// hub's MUTATING handlers — spawn, git-head, models, and an action verb
-// — through the full handler stack and asserts that none of them spawned a real
-// process, shelled out, hit the network, or created a file outside the sandbox.
+// hub's mutating handlers — spawn, models, directory creation, and an action
+// verb — through the full handler stack and exercises the git-head AppWire
+// handler directly; none may spawn a real process, shell out, hit the network,
+// or create a file outside the sandbox.
 func TestSandboxContainsMutatingHandlers(t *testing.T) {
 	deny := installDenyTransport(t)
 	s := newSandbox(t)
@@ -94,17 +95,18 @@ func TestSandboxContainsMutatingHandlers(t *testing.T) {
 		t.Fatalf("spawn did not reach the recording spawner: recorded %d spawns", got)
 	}
 
-	// 2. git-head: the response carries the seam's sentinel branch, proving no
-	// real `git` ran.
-	rec = do(http.MethodGet, "/api/git/head?cwd="+s.CWD, nil)
-	var gh struct {
-		Branch string `json:"branch"`
+	// 2. git-head: the AppWire response carries the seam's sentinel branch,
+	// proving no real `git` ran.
+	out, err := exactDispatch(context.Background(), t, s.Web.appRPC, appwire.MethodEvenerGitHead, appwire.GitHeadParams{CWD: s.CWD})
+	if err != nil {
+		t.Fatalf("git/head dispatch: %v", err)
 	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &gh); err != nil {
-		t.Fatalf("git/head body: %v", err)
+	gh, ok := out.(appwire.GitHeadResponse)
+	if !ok {
+		t.Fatalf("git/head response=%T, want appwire.GitHeadResponse", out)
 	}
-	if gh.Branch != sandboxGitBranch {
-		t.Fatalf("git/head did not use the seam: branch=%q want %q", gh.Branch, sandboxGitBranch)
+	if gh.Head != sandboxGitHead {
+		t.Fatalf("git/head did not use the seam: head=%q want %q", gh.Head, sandboxGitHead)
 	}
 
 	// 3. action verb: clear on a non-live session resolves before any daemon

--- a/cmd/evener-hub/sandbox_test.go
+++ b/cmd/evener-hub/sandbox_test.go
@@ -25,9 +25,9 @@ const sandboxSessionID = "01FUZZDOCSESSION0000000000"
 // supplies; finding it in a response body is a path-escape defect.
 const sandboxOutOfRootSecret = "FUZZ-OUT-OF-ROOT-SECRET-do-not-serve-9c1f2a"
 
-// sandboxGitBranch is the fixed branch the git-head seam reports. Its presence
-// in an /api/git/head response proves the seam ran instead of a real `git`.
-const sandboxGitBranch = "sandbox-branch"
+// sandboxGitHead is the fixed HEAD the git-head seam reports. Its presence
+// in an AppWire response proves the seam ran instead of a real `git`.
+const sandboxGitHead = "sandbox-branch"
 
 // sandbox is a fully contained hub for fuzzing/testing the MUTATING handlers.
 // The backend it wires cannot spawn a real agent, shell out, hit the network,
@@ -36,7 +36,7 @@ const sandboxGitBranch = "sandbox-branch"
 //
 //   - spawn (/api/spawn, thread/start) → Spawner records the request and returns
 //     a synthetic rendezvous entry with no address; no subprocess, no dial.
-//   - /api/git/head → GitHeadBranch seam returns sandboxGitBranch; no `git`.
+//   - evener/git/head → ResolveGitHead seam returns sandboxGitHead; no `git`.
 //   - model/list → LiveModels seam returns a fixed list; no provider network.
 //   - the action verbs (send/steer/queue/clear/...) → an empty Roster and an
 //     empty live-source set, so every verb resolves "thread not found" before it
@@ -124,8 +124,8 @@ func newSandbox(tb testing.TB) *sandbox {
 		ProvidersConfigPath: providersPath,
 		PluginRoot:          filepath.Join(root, "plugins"), // contain the marketplace/plugin store; "" would resolve to the real ~/.config/evener/plugins
 		Spawner:             spawner,
-		GitHeadBranch: func(context.Context, string) (string, error) {
-			return sandboxGitBranch, nil
+		ResolveGitHead: func(context.Context, string) (string, error) {
+			return sandboxGitHead, nil
 		},
 		LiveModels: func(context.Context) []appwire.ModelDescriptor {
 			return []appwire.ModelDescriptor{{Provider: "sandbox", Model: "fake-model"}}

--- a/cmd/evener-hub/web.go
+++ b/cmd/evener-hub/web.go
@@ -164,7 +164,6 @@ func (s *WebServer) Handler() http.Handler {
 
 	// API
 	mux.HandleFunc("/api/spawn", s.handleApiSpawn)
-	mux.HandleFunc("/api/git/head", s.handleApiGitHead)
 	mux.HandleFunc("/api/health", s.handleAPIHealth)
 	mux.HandleFunc("/api/mobile/pairing", s.handleAPIMobilePairing)
 	mux.HandleFunc("/api/archive", s.handleAPIArchive)

--- a/cmd/evener-hub/web_api.go
+++ b/cmd/evener-hub/web_api.go
@@ -1,15 +1,11 @@
 package hub
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/netip"
 	"net/url"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -23,7 +19,6 @@ import (
 )
 
 var (
-	gitCommand               = exec.CommandContext
 	mobileHostnameProfile    = idna.New(idna.MapForLookup(), idna.StrictDomainName(false), idna.CheckHyphens(false))
 	ensureAPIActionAvailable = func(s *WebServer, id, action string) error {
 		return s.ensureSessionActionAvailable(id, action)
@@ -418,49 +413,4 @@ func (s *WebServer) handleAPIReasoningEffort(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
-}
-
-// gitHeadBranch runs `git rev-parse --abbrev-ref HEAD` in dir and returns
-// the branch name. In detached HEAD state it falls back to the short SHA.
-func gitHeadBranch(ctx context.Context, dir string) (string, error) {
-	out, err := gitCommand(ctx, "git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD").Output()
-	if err != nil {
-		return "", err
-	}
-	branch := strings.TrimSpace(string(out))
-	if branch == "HEAD" {
-		// Detached HEAD — return short SHA instead.
-		out2, err2 := gitCommand(ctx, "git", "-C", dir, "rev-parse", "--short", "HEAD").Output()
-		if err2 != nil {
-			return branch, nil //nolint:nilerr // detached HEAD: short-SHA refinement is best-effort; the literal "HEAD" is a valid fallback
-		}
-		branch = strings.TrimSpace(string(out2))
-	}
-	return branch, nil
-}
-
-// handleApiGitHead returns the current git HEAD branch name for a given cwd.
-// Query param: cwd=<absolute path>. Returns {"branch": "<name>"} or {"branch": ""} on error.
-func (s *WebServer) handleApiGitHead(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeAPIError(w, http.StatusMethodNotAllowed, "GET required")
-		return
-	}
-	cwd := strings.TrimSpace(r.URL.Query().Get("cwd"))
-	gitHead := gitHeadBranch
-	if s.cfg.GitHeadBranch != nil {
-		gitHead = s.cfg.GitHeadBranch
-	}
-	branch := ""
-	if cwd != "" {
-		if abs, err := filepath.Abs(cwd); err == nil {
-			cwd = abs
-		}
-		if _, err := os.Stat(cwd); err == nil {
-			if out, err := gitHead(r.Context(), cwd); err == nil {
-				branch = out
-			}
-		}
-	}
-	writeAPIJSON(w, http.StatusOK, map[string]string{"branch": branch})
 }

--- a/cmd/evener-hub/web_appwire_fuzz_test.go
+++ b/cmd/evener-hub/web_appwire_fuzz_test.go
@@ -119,7 +119,7 @@ func buildParamsRegistry() *typegen.Registry {
 }
 
 // hubMethodNames returns the wire names of every catalog method, in order. The
-// B1 fuzz indexes into this so every one of the 46 appwire.Methods is reachable:
+// B1 fuzz indexes into this so every catalogued AppWire method is reachable:
 // the routed hub methods run their real app_*.go handler; connection-level
 // (initialize/ping) and unimplemented methods resolve to a structured
 // MethodNotFound through the same Dispatch path.

--- a/cmd/evener-hub/web_fuzz_test.go
+++ b/cmd/evener-hub/web_fuzz_test.go
@@ -20,9 +20,9 @@ const fuzzSessionID = sandboxSessionID
 // fuzzReadOnlyRoutes is the allowlist of GET-only, non-mutating, non-networked
 // hub routes the handler fuzz drives — the single canonical list in
 // internal/fuzzroutes, shared with the corpus harvester so the two can't drift.
-// Mutating routes (/api/spawn, the action verbs),
-// routes that shell out (/api/git/head), and provider-probing model-list calls
-// are excluded so a fuzzed request can never touch the real environment.
+// Mutating routes (/api/spawn, the action verbs) and provider-probing
+// model-list calls are excluded so a fuzzed request can never touch the real
+// environment.
 var fuzzReadOnlyRoutes = fuzzroutes.ReadOnly
 
 // newFuzzWebServer builds the contained sandbox hub and returns the server and

--- a/cmd/evener-hub/web_mutating_fuzz_test.go
+++ b/cmd/evener-hub/web_mutating_fuzz_test.go
@@ -20,15 +20,14 @@ type mutRoute struct {
 }
 
 // mutatingRoutes are exactly the routes the Phase-4 read-only handler fuzz
-// excluded: the spawn POST and the live-git
-// seam reads, and the session/turn action verbs (clear/model/effort/interrupt/
-// compact/shutdown/send/fork under /api/sessions, and steer/queue/drain-as-steer
-// under /s). Under the B0 sandbox every one of these is contained: spawn hits
-// the recording spawner and git-head its
-// seams, and the action verbs resolve "not live" before any daemon dial.
+// excluded: the spawn POST, the live-models seam read, and the session/turn
+// action verbs (clear/model/effort/interrupt/compact/shutdown/send/fork under
+// /api/sessions, and steer/queue/drain-as-steer under /s). Under the B0 sandbox
+// every one of these is contained: spawn hits the recording spawner, models its
+// seam, and the action verbs resolve "not live" before any daemon dial.
 var mutatingRoutes = []mutRoute{
 	{http.MethodPost, "/api/spawn", true},
-	{http.MethodGet, "/api/git/head?cwd={id}", false},
+	{http.MethodGet, "/api/models?harness={id}", false},
 	{http.MethodPost, "/api/sessions/{id}/clear", false},
 	{http.MethodPost, "/api/sessions/{id}/model", true},
 	{http.MethodPost, "/api/sessions/{id}/reasoning-effort", true},
@@ -70,7 +69,7 @@ func isServerFault(code int) bool {
 //   - no server fault (isServerFault: a 500 or non-deliberate 5xx is a defect);
 //   - never serve the out-of-root secret (path-escape tripwire);
 //   - never dial the network (the deny-transport tripwire) — no spawn reaches a
-//     real subprocess, no model/git call reaches a provider.
+//     real subprocess and no model call reaches a provider.
 //
 // The recording spawner and recording mkdir guarantee no real process or
 // directory is ever materialized regardless of input, so those escapes need no
@@ -104,7 +103,8 @@ func FuzzWebMutatingHandler(f *testing.F) {
 		// otherwise reaches. Empty Data keeps the seed small (the per-image byte
 		// limit is 8 MiB, not worth a multi-MiB corpus entry).
 		{"/api/spawn", "", `{"harness":"evener","working_dir":"` + s.CWD + `","items":[{"type":"image"},{"type":"image"},{"type":"image"},{"type":"image"},{"type":"image"},{"type":"image"},{"type":"image"},{"type":"image"},{"type":"image"}]}`},
-		{"/api/git/head?cwd={id}", s.CWD, ""},
+		{"/api/models?harness={id}", "evener", ""},
+		{"/api/models?harness={id}", "codex", ""},
 		{"/api/sessions/{id}/clear", sandboxSessionID, ""},
 		{"/api/sessions/{id}/model", sandboxSessionID, `{"model":"openai/gpt-5.5"}`},
 		{"/api/sessions/{id}/reasoning-effort", sandboxSessionID, `{"reasoning_effort":"high"}`},

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -118,6 +118,7 @@ no router (reserved).
 | `evener/dirs/create` | hub | `DirsCreateParams` | `DirsCreateResponse` | Creates a missing working directory and its parents for Spawn preflight. |
 | `evener/projects/recent` | hub | `ProjectsRecentParams` | `ProjectsRecentResponse` | Lists the most recently used project working directories (session creation path-dropdown options; default cap 15). |
 | `evener/path/validate` | hub | `PathValidateParams` | `PathValidateResponse` | Validates a launch path. |
+| `evener/git/head` | hub | `GitHeadParams` | `GitHeadResponse` | Reads git HEAD for a working directory. |
 | `evener/navigation/read` | hub | `NavigationReadParams` | `NavigationReadResponse` | Reads one bounded, revisioned hub navigation resource, optionally conditional on its ETag. |
 | `evener/favorite/set` | hub | `FavoriteSetParams` | `FavoriteSetResponse` | Sets or clears a project favorite and returns the committed navigation invalidation targets. |
 | `evener/search` | hub | `SearchParams` | `SearchResponse` | Searches live and persisted sessions for the hub command palette. |
@@ -543,6 +544,20 @@ _(no fields)_
 |-------|---------|-----------|----------|
 | `ok` | `bool` |  |  |
 | `navigation` | `appwire.NavigationMutation` |  |  |
+
+
+### `GitHeadParams`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `cwd` | `string` |  |  |
+
+
+### `GitHeadResponse`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `head` | `string` |  |  |
 
 
 ### `GoalSetParams`

--- a/docs/superpowers/plans/2026-08-27-appwire-git-head.md
+++ b/docs/superpowers/plans/2026-08-27-appwire-git-head.md
@@ -1,0 +1,77 @@
+# Git HEAD AppWire Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the Spawn pane's git HEAD lookup from `/api/git/head` to a typed hub-scoped AppWire method while preserving its display-only, fail-soft behavior and removing only the legacy route surface.
+
+**Architecture:** Add `evener/git/head` to the AppWire catalog with typed `GitHeadParams` and `GitHeadResponse`. Factor canonical directory validation, the injectable seam, and the `resolveGitHead` call into a hub handler helper. Register that helper on the hub router and call it from the generated frontend AppWire client. Remove the HTTP route and route-specific probes; keep the shared git helper and semantic tests.
+
+**Tech Stack:** Go AppWire server/client, generated Go/TypeScript protocol artifacts, React/TypeScript Spawn pane, Vitest, Go tests, Make gates.
+
+**Spec:** `docs/superpowers/specs/2026-08-27-appwire-git-head-design.md`
+
+## Global Constraints
+
+- Work in an isolated worktree created for this migration and publish the
+  finished tree to the PR branch.
+- Base the work on the explicitly fetched `origin/main` commit and do not
+  include model-list, navigation, or tree-residue changes.
+- Preserve empty-cwd skipping, stale-cwd fencing, missing/non-Git/error empty
+  success, detached HEAD short-SHA/`HEAD` fallback, and the configured
+  `ResolveGitHead` seam.
+- Use `make generate`; never hand-edit generated protocol output.
+- Remove the legacy route and route-specific residue without adding an absence
+  test for the old route.
+- Run the four-angle simplify-code review before implementation and after the
+  implementation; apply only quality-preserving findings.
+
+## Tasks
+
+- [x] Add the typed protocol contract. In `appwire/types.go`, define
+  `GitHeadParams{CWD string}` and `GitHeadResponse{Head string}`. In
+  `appwire/types.go` and `appwire/protocol.go`, add the ordered
+  `MethodEvenerGitHead = "evener/git/head"` hub-scoped catalog entry. In
+  `appwire/client.go`, add `Client.GitHead(ctx, GitHeadParams)` using the
+  standard request wrapper. Add round-trip and hub-scope coverage alongside
+  the existing AppWire wrapper tests.
+- [x] Generate protocol artifacts and update protocol-count comments affected
+  by the catalog addition. Run `make generate`, inspect the diff, and keep
+  only the generated documentation and TypeScript changes caused by this
+  method.
+- [x] Register the hub handler. Add a small resolver that trims `cwd`, skips
+  empty input, canonicalizes the existing directory through `fspaths`, selects
+  `WebConfig.ResolveGitHead` or `resolveGitHead`, and converts every lookup
+  failure to `{head:""}`. Register it in
+  `registerMiscHandlers` under `MethodEvenerGitHead`; test the configured seam
+  through an AppWire round trip and cover empty, missing, and error cases.
+- [x] Migrate the Spawn caller. Change `resolveHeadBranch` to accept the
+  typed AppWire client and call `client.request("evener/git/head", {cwd})`,
+  returning `data.head`.
+  Keep the empty-cwd fast path, fail-soft handling, and the effect's active
+  flag/dependency fencing. Update Spawn tests to script the AppWire method and
+  retain meaningful HEAD, empty, error, and stale-response behavior.
+- [x] Remove the REST surface and route-specific residue. Delete the HTTP
+  registration and handler, remove `/api/git/head` coverage/sandbox/fuzz
+  probes and REST-only comments, and update the active parity contract to
+  describe AppWire. Retain the shared `resolveGitHead` helper and its detached
+  HEAD semantic coverage; leave historical records untouched.
+- [x] Run the post-implementation simplify-code review and apply only
+  behavior-preserving quality findings. Re-run affected tests after any
+  change, then run `make generate`, focused Go/frontend tests, `make test-web`,
+  `make test-web-browser` when available, and the applicable repository gates.
+  Commit each coherent stage with a detailed message and publish a PR against
+  `main` without merging.
+
+## Verification Commands
+
+```sh
+git fetch origin
+git diff --check
+make generate
+go test ./appwire ./cmd/evener-hub -count=1
+cd cmd/evener-hub/frontend && npx vitest run src/panes/spawn/branch.test.ts src/panes/spawn/Spawn.test.tsx
+cd ../../..
+make test-web
+make test-web-browser
+make merge-approval-gate
+```

--- a/docs/superpowers/specs/2026-08-27-appwire-git-head-design.md
+++ b/docs/superpowers/specs/2026-08-27-appwire-git-head-design.md
@@ -1,0 +1,54 @@
+# Git HEAD AppWire Migration
+
+## Goal
+
+Replace the Spawn pane's `/api/git/head` request with a typed, hub-scoped
+AppWire method. The user-visible behavior remains the same while the HTTP
+route and its route-specific tests and wiring are removed.
+
+## Contract
+
+- Method: `evener/git/head`
+- Scope: `hub`
+- Parameters: `{ "cwd": string }`
+- Response: `{ "head": string }`
+- The response contains a branch name for a normal checkout, a short commit
+  SHA for detached HEAD, or an empty string when the directory cannot be
+  inspected or git cannot resolve its HEAD.
+- The request is fail-soft: invalid, missing, non-Git, and git-error cases
+  return a successful response with an empty `head`.
+- Whitespace-only `cwd` skips filesystem and git work and returns an empty
+  response. Non-empty paths pass through `fspaths.CanonicalizeDir`, which
+  requires an existing absolute directory and resolves symlinks before the
+  `resolveGitHead` helper runs.
+- `WebConfig.ResolveGitHead` is the injectable seam. A nil seam uses the real
+  `resolveGitHead` implementation, including detached HEAD short-SHA and
+  `HEAD` fallback behavior.
+
+## Caller and authentication
+
+`Spawn.tsx` continues to resolve the branch only for the display chip. It keeps
+the existing empty-cwd guard and active-request cleanup so a response for an
+old cwd cannot update the current form. The frontend calls the generated
+AppWire client method and does not send the resolved value when starting a
+thread.
+
+The method is registered on the hub AppWire server. Browser clients reach it
+through the existing authenticated `/rpc` endpoint, so removing the separate
+HTTP route does not create an unauthenticated path.
+
+## Removal boundary
+
+Remove the `/api/git/head` route, its HTTP handler, its route-specific coverage
+and sandbox probes, and the REST-only frontend branch caller/commentary. Keep
+the shared `resolveGitHead` helper, its injectable seam, meaningful git
+semantics coverage, and historical documentation that records past transport
+behavior. Do not add a test whose purpose is proving that the legacy route is
+absent.
+
+## Generated artifacts and verification
+
+Adding the method updates the AppWire catalog, Go types/client, and generated
+protocol documentation and TypeScript types through `make generate`. The
+implementation will run focused Go and frontend tests, the relevant browser
+gate, and the repository gates required by `AGENTS.md` before publication.

--- a/docs/web-ui/parity/parity-m6-surfaces.md
+++ b/docs/web-ui/parity/parity-m6-surfaces.md
@@ -109,10 +109,8 @@ These are the findings most likely to bite a rewrite that "looks equivalent." Ea
 
 ### 1.7 Branch/worktree chip
 
-- [ ] Free-text picker is seeded from the chip's current display text, blanked out if that text is literally the placeholder string `"(default)"` (`spawn.js:1391-1392`)
-- [ ] Setting `working_dir` (whether via chip pick or sticky-default replay) triggers `resolveAndSetHeadBranch`, which fetches `GET /api/git/head?cwd=` and fills the branch chip's DISPLAY text (not its hidden wire value) with the resolved HEAD ref, stashing the raw value in `display.dataset.resolvedHead` so "(default)" can later be explained (`spawn.js:365-367, 372-393`)
-- [ ] Branch auto-resolution is skipped once an explicit branch value exists — checked once before firing the fetch, and checked AGAIN after the fetch resolves, so a value the user picked while the request was in flight can't be clobbered by a late response (`spawn.js:375, 383-384`)
-- [ ] Branch auto-resolution is REST-only: when `window.EvenerAppwire` is present the function no-ops entirely, because appwire has no `git/head` RPC yet (`spawn.js:376-379`)
+- [ ] Setting the working directory resolves `evener/git/head` and displays the returned HEAD beside the directory; it is read-only and is neither persisted nor sent when starting a thread (`Spawn.tsx`, `branch.ts`)
+- [ ] Resolution failures and directories without a readable git HEAD leave the readout empty; stale responses are ignored after the working directory changes (`Spawn.tsx`, `branch.ts`)
 
 ### 1.8 Access-mode chip
 
@@ -122,7 +120,7 @@ These are the findings most likely to bite a rewrite that "looks equivalent." Ea
 ### 1.9 Sticky defaults / prefill layering (localStorage)
 
 - [ ] Per-project sticky-defaults key is `evener-hub.spawn-defaults.<workingDir|"global">`, a JSON blob (`spawn.js:51-53`)
-- [ ] On load, `harness`/`branch`/`access_mode` defaults are applied BEFORE `working_dir`, specifically so the HEAD-branch auto-resolution that `working_dir` triggers can already see whether an explicit branch default won (`spawn.js:1132-1138`, code comment at 1133-1134)
+- [ ] On load, project defaults restore harness, model, access mode, and reasoning effort; branch is derived from the current working directory rather than storage (`Spawn.tsx`, `spawnDefaults.ts`)
 - [ ] Model sticky-default is applied only when the current harness uses evener models AND a stored default value exists; otherwise `applyHarnessModelPolicy` runs instead to decide whether the chip should be blanked (`spawn.js:1145-1149`)
 - [ ] If the server didn't prefill `working_dir` (no `?dir=` etc.) and no stored default supplies one either, the GLOBAL `evener-hub.spawn-defaults.global.working_dir` key is consulted as a last resort (`spawn.js:84-88`)
 - [ ] The global model default (`evener-hub.spawn-defaults.global.model`) layers UNDER a more specific per-project model default when both exist (`spawn.js:81-83`)
@@ -178,7 +176,7 @@ These are the findings most likely to bite a rewrite that "looks equivalent." Ea
 ### 1.14 Submission & result handling
 
 - [ ] Submit handler always calls `e.preventDefault()` and rebuilds the entire payload from `FormData` — there is no native form POST path (`spawn.js:1243-1245`)
-- [ ] Payload shape: `{launch_overrides, prompt, harness, model, working_dir, branch, access_mode, agent, reasoning_effort, attachments}` (`spawn.js:1270-1288`)
+- [ ] AppWire `thread/start` sends the prompt/input, working directory, harness, model/provider, reasoning effort, and launch overrides; the resolved HEAD remains display-only (`startThread.ts`)
 - [ ] Prefers `window.EvenerAppwire.startThread(body)`; REST fallback POSTs `/api/spawn` with `attachments` re-encoded into `items: [{type:"image", mediaType, data(base64), name}]` and the raw `attachments` key stripped from the body first (`spawn.js:1305-1330`)
 - [ ] `spawnEncodeAttachmentData` base64-encodes in `0x8000`-byte chunks (avoids `String.fromCharCode.apply` argument-count blowups on large images) and duck-types ArrayBuffer/typed-array/cross-realm buffers rather than using `instanceof`, specifically to survive JSDOM-originated buffers in tests (`spawn.js:11-38`, code comment at 11-15)
 - [ ] REST failure path parses the response body as JSON looking for an `.error` field, falling back to the raw text for older plain-text error responses (`spawn.js:419-427, 1327`)


### PR DESCRIPTION
## Summary
- add the typed hub-scoped `evener/git/head` AppWire method and generated artifacts
- migrate the Spawn branch readout from REST to AppWire while preserving fail-soft and stale-cwd behavior
- remove `/api/git/head` and only its route-specific residue; retain shared git semantics coverage

## Verification
- `go test ./appwire ./cmd/evener-hub -count=1`
- `npx vitest run src/panes/spawn/branch.test.ts src/panes/spawn/Spawn.test.tsx`
- `make lint`
- `make vet`
- `make test-web`
- `make test-web-browser`

Rebased onto current `origin/main` (`c9bd0cd9ae6168d53d156e1b432e8d2ddf2362e8`).