### PR TITLE
test: sync TUI e2e mode transitions on outgoing chrome, not "enter send"

### DIFF
--- a/cmd/evener-tui/hub_model_test.go
+++ b/cmd/evener-tui/hub_model_test.go
@@ -1086,6 +1086,38 @@ func TestHubModelBrowseKeepsComposerVisibleAndTyping(t *testing.T) {
 	}
 }
 
+// TestHubModelBrowseFooterStillShowsEnterSend pins the rendering fact the
+// tmux e2e sync for issue #540 depends on: the browse-mode footer keeps the
+// composer panel — including its compose-mode "enter send" hint — on screen
+// (hub_session_view.go's scrollMode branch appends sessionComposerPanel, and
+// the composer panel's mode mapping does not special-case browse). "enter
+// send" therefore names compose chrome, never the browse→compose transition,
+// so TestTUITmuxE2E_SessionCommandsAndNavigation syncs that transition on
+// the DISAPPEARANCE of the browse action bar instead. A change that makes
+// the composer hints browse-aware (e.g. wiring composerFooterHints'
+// "scroll-browse" case into sessionComposerPanel) turns this test red and
+// must re-examine that e2e sync.
+func TestHubModelBrowseFooterStillShowsEnterSend(t *testing.T) {
+	m := newSessionHubModel(nil)
+	m.detail.Capabilities.Fork = true
+	m.detail.SourceLabel = "codex-local"
+	m.detail.Model = "gpt-5.3-codex"
+	m.width = 140
+	m.height = 40
+	m.session.width = 140
+	m.session.height = 40
+	m.session.messages = []transcript.ChatMessage{{Kind: transcript.MsgUser, Text: "request", TurnIndex: 1}}
+	m.enterSessionBrowse(false)
+
+	view := ansiPattern.ReplaceAllString(m.sessionView(), "")
+	if !strings.Contains(view, "esc/i/q: compose") {
+		t.Fatalf("browse footer should show the browse action bar:\n%s", view)
+	}
+	if !strings.Contains(view, "enter send") {
+		t.Fatalf("browse footer should keep the composer panel's compose hints on screen:\n%s", view)
+	}
+}
+
 func TestHubModelBrowseCtrlTTogglesAllToolEntries(t *testing.T) {
 	m := newSessionHubModel(nil)
 	m.width = 100

--- a/cmd/evener-tui/tmux_e2e_test.go
+++ b/cmd/evener-tui/tmux_e2e_test.go
@@ -423,8 +423,22 @@ func TestTUITmuxE2E_SessionCommandsAndNavigation(t *testing.T) {
 	// /fork drops into browse mode with the fork prompt and footer hint.
 	app.TypeLine("/fork")
 	app.WaitFor("Select a user message, then press f to fork.", "f: fork selected user message")
+	// The browse→compose transition must be synced on the DISAPPEARANCE of
+	// the browse action bar, not on "enter send": the browse footer keeps the
+	// composer panel — and with it the compose-mode "enter send" hint — on
+	// screen (hub_session_view.go's scrollMode branch), so a plain
+	// WaitFor("enter send") returns while the "i" can still be sitting
+	// unread in the pty. If "/help" is then written before the TUI's input
+	// reader consumes "i", tmux coalesces the two writes into one pty read,
+	// bubbletea reports "i/help" as a single KeyMsg, and browse mode drops
+	// it into the composer as draft text (kata fazd; fall-through pinned by
+	// kata 7hh0) — the TUI never leaves browse mode and /help never runs,
+	// which is the issue #540 flake. A frame showing "enter send" WITHOUT
+	// the browse action bar can only have been rendered from the post-"i"
+	// model, so this wait is a real happens-before edge: the "i" is provably
+	// consumed before "/help" is written.
 	app.SendKeys("i")
-	app.WaitFor("enter send")
+	app.WaitForWithout([]string{"esc/i/q: compose"}, "enter send")
 
 	// /help lists the slash commands and the browse keybindings.
 	app.TypeLine("/help")
@@ -491,8 +505,13 @@ func TestTUITmuxE2E_SessionCommandsAndNavigation(t *testing.T) {
 
 	app.TypeLine("/details")
 	app.WaitFor("Session:  01LIVE", "Dir:      "+tuiE2EProjectDir)
+	// Same sync rule as the /fork exit above: overlays do not change the
+	// footer, so "enter send" stays on screen while the details panel is
+	// open and cannot prove the Escape was consumed. Sync on the panel
+	// content's disappearance — a frame without it comes only from the
+	// post-Escape model.
 	app.SendKeys("Escape")
-	app.WaitFor("enter send")
+	app.WaitForWithout([]string{"Session:  01LIVE"}, "enter send")
 
 	app.TypeLine("/interrupt")
 	app.WaitFor("Interrupt sent.")


### PR DESCRIPTION
Closes #540

## Root cause (confirmed)

The flake was a test-side synchronization bug, not a product regression.

`TestTUITmuxE2E_SessionCommandsAndNavigation` synchronized the /fork browse→compose transition with `WaitFor("enter send")` — but **"enter send" is visible in browse mode too**. The browse-mode footer keeps the composer panel on screen (`hub_session_view.go`'s `scrollMode` branch appends `sessionComposerPanel().View()`), and the composer panel's mode mapping (`sessionComposerMode`/`composerModeForFooter`) does not special-case browse, so the compose-mode hint bar `enter send · shift+enter newline · …` renders while browsing. The wait therefore returned on its first poll, before the `i` keypress was necessarily consumed.

`TypeLine("/help")` then wrote `/help` + Enter into the pty within ~15–25ms. When the TUI's input read loop lags past that window (CPU-oversubscribed CI; the same scheduling gap `waitForInputReady` documents for startup), tmux coalesces the writes into one pty read, bubbletea reports the printable runes as a **single `KeyMsg("i/help")`**, and browse mode's key switch matches nothing — the batch falls through to the composer as draft text (the kata-7hh0-pinned behavior, `TestHubModelBrowseKeepsComposerVisibleAndTyping`). The trailing Enter parses separately and only toggles the browse selection (a no-op for a user message). The TUI stays in browse mode forever and `/help` never executes — exactly the CI failure pane (fork prompt as the last transcript line, no help output).

## Evidence

- **Deterministic reproduction** (kata-fazd style): delivering `i/help` in ONE `send-keys -l` write after entering /fork browse mode lands the TUI in the exact CI state — still browsing, fork prompt last, composer draft `i/help`, no help output. (Throwaway repro test, run against the real tmux harness; removed after use.)
- **Unit probe**: a browse-mode `sessionView()` render contains both `esc/i/q: compose` and `enter send` (now pinned permanently, see below). Same for the /details panel: overlays don't touch the footer, so `enter send` stays visible there as well.
- **Natural reproduction**: NOT caught locally — 6 consecutive runs of the full `TestTUITmuxE2E` family pre-fix passed (consistent with the issue's "load-sensitive; not reproduced locally"). The failure needs the reader to lag ~15–25ms at one exact point; the deterministic repro above is the failure evidence.

## Fix

Sync on chrome that names the post-transition state instead of text that doesn't: require `enter send` present **and the prior state's chrome absent on the same captured frame** (`WaitForWithout`). Such a frame can only have been rendered from the post-transition model (bubbletea renders the model after Update processes the key), so the mode key is provably consumed before the next input is written — a happens-before edge by construction. Torn-frame captures of the transition redraw either still show the outgoing chrome (keep polling) or postdate the model change (correct pass); no capture can satisfy the condition while the model still predates the key.

Two sites in `TestTUITmuxE2E_SessionCommandsAndNavigation` had this no-op sync; both fixed:

1. `SendKeys("i")` after /fork → `WaitForWithout([]string{"esc/i/q: compose"}, "enter send")`
2. `SendKeys("Escape")` after /details → `WaitForWithout([]string{"Session:  01LIVE"}, "enter send")`

No product code changes: the browse-mode batch fall-through is deliberately pinned pending a design decision (kata 7hh0, `hub_keys.go`), so per the repo's e2e discipline ("command sequences must never coalesce in the first place") the race belongs to the test's synchronization. Every other mode-adjacent key step in the tmux suite was audited: the remaining `WaitFor("enter send")` uses are positive syncs (text absent in the prior state), and the other browse-exit step is followed by Escape, which cannot merge into a printable batch.

Also adds `TestHubModelBrowseFooterStillShowsEnterSend`, pinning the rendering fact the sync depends on — it goes red if the composer hints ever become browse-aware (e.g. wiring `composerFooterHints`' currently-unwired "scroll-browse" case), forcing a re-examination of the e2e sync. Note that unwired case suggests making browse-mode hints mode-aware may be desirable UX follow-up (browse mode currently advertises "enter send"/"esc browse"), but that is a product behavior change and deliberately out of scope here.

## Verification

- `go test ./cmd/evener-tui/...` — pass (15 packages)
- `go test -race ./cmd/evener-tui -run 'TestTUITmuxE2E' -count=5` — pass (verified the tests run, not skip, under `-race`)
- `go test ./cmd/evener-tui -run 'TestTUITmuxE2E' -count=6` (pre-fix stress attempt) — pass, no natural repro
- `make vet` — pass
- `make lint-golangci` — pass
