### PR TITLE
test: extend outgoing-chrome sync to remaining no-op "enter send" waits

### DIFF
--- a/cmd/evener-tui/hub_model_test.go
+++ b/cmd/evener-tui/hub_model_test.go
@@ -1099,9 +1099,10 @@ func TestHubModelBrowseKeepsComposerVisibleAndTyping(t *testing.T) {
 // must re-examine that e2e sync.
 func TestHubModelBrowseFooterStillShowsEnterSend(t *testing.T) {
 	m := newSessionHubModel(nil)
-	m.detail.Capabilities.Fork = true
+	// Any ChipContext field switches the composer to the mode-aware hint bar
+	// that carries "enter send" (composer_panel.go's View); SourceLabel is
+	// the lightest trip.
 	m.detail.SourceLabel = "codex-local"
-	m.detail.Model = "gpt-5.3-codex"
 	m.width = 140
 	m.height = 40
 	m.session.width = 140

--- a/cmd/evener-tui/tmux_e2e_test.go
+++ b/cmd/evener-tui/tmux_e2e_test.go
@@ -578,8 +578,11 @@ func TestTUITmuxE2E_BrowseAndFork(t *testing.T) {
 	if forks := hub.Forks(); len(forks) != 0 {
 		t.Fatalf("invalid fork selection should not call hub: %+v", forks)
 	}
+	// Same sync rule as the /fork exit in SessionCommandsAndNavigation:
+	// "enter send" is visible in browse mode, so sync the transition on the
+	// action bar's disappearance, not on the hint text.
 	app.SendKeys("i")
-	app.WaitFor("enter send")
+	app.WaitForWithout([]string{"esc/i/q: compose"}, "enter send")
 	app.SendKeys("Escape")
 	app.WaitFor("esc/i/q: compose")
 	// These k presses must move the browse cursor up to the user message.
@@ -704,8 +707,13 @@ func TestTUITmuxE2E_CapabilityGates(t *testing.T) {
 		"/fork  browse and fork a user message  disabled: source does not advertise fork",
 		"/shutdown  stop this resumable session  disabled: source does not advertise shutdown",
 	)
+	// "enter send" is on screen while the palette is open (overlays do not
+	// change the footer), so it cannot prove the Escape was consumed — if
+	// the next text lands in the same pty read, "\x1b<text>" parses as
+	// alt+<key> and the palette stays open. Sync on the palette's
+	// disappearance instead.
 	app.SendKeys("Escape")
-	app.WaitFor("enter send")
+	app.WaitForWithout([]string{"Command palette"}, "enter send")
 
 	// Send is read-only when the source does not advertise it: the composer
 	// keeps the draft and the hub never receives the turn.


### PR DESCRIPTION
Refs #540

Follow-up to #541 (merged as 16fd82179 while this commit was in flight): the mandatory post-fix simplify pass on that diff produced one more commit, which landed after the merge. Same scope and reasoning as the parent PR; the four-angle review (reuse / simplification / efficiency / altitude) of the #541 diff found:

- **Altitude (applied):** `TestTUITmuxE2E_BrowseAndFork` had the identical `SendKeys("i")` + `WaitFor("enter send")` no-op sync — safe today only because the next key is Escape, which cannot merge into a printable batch. Now uses the same `WaitForWithout` edge so the trap cannot be inherited by a future edit.
- **Altitude (applied):** `TestTUITmuxE2E_CapabilityGates`' palette Escape had the latent escape+printable coalescing hazard (`"\x1b<text>"` parses as alt+key, leaving the palette open). Now syncs on the palette's disappearance.
- **Altitude (skipped, with justification):** the seven ctrl+x notice-dismissal waits share the `WaitFor("enter send")` shape, but ctrl+x is a control byte — the input parser always emits it as its own KeyMsg, so it cannot be absorbed into a printable batch. No race exists at those sites even under full coalescing.
- **Simplification (applied):** `TestHubModelBrowseFooterStillShowsEnterSend` setup trimmed to what the assertions exercise — one ChipContext field is what trips the mode-aware hint bar; the Fork capability and Model assignments were dead weight (verified empirically).
- **Reuse / efficiency:** no findings.

## Verification

- `go test ./cmd/evener-tui/...` — pass (15 packages)
- `go test ./cmd/evener-tui -run 'TestTUITmuxE2E_(SessionCommandsAndNavigation|BrowseAndFork|CapabilityGates)' -count=2` — pass (all three confirmed running, not skipped)
- gofmt clean
