### PR TITLE
feat(web): move verbosity to session menu

### DIFF
--- a/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
@@ -468,7 +468,10 @@ async function verifyChatFocus(cdpEndpoint, url) {
     await navigateTo(page, url);
     await evaluate(send, "window.settled");
     await waitForFonts(send);
-    return await evaluate(send, "window.inspectChatFocus()");
+    // Keep the async inspection reachable from the page global while CDP
+    // awaits it. Linux Chrome may otherwise collect the bare returned Promise
+    // between animation frames and reject Runtime.evaluate with -32000.
+    return await evaluate(send, "window.__overflowGuardChatFocus = window.inspectChatFocus()");
   } finally {
     await clearViewportOverride(send);
     page.close();

--- a/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
@@ -155,7 +155,6 @@ async function measureAt(cdpEndpoint, url, width) {
         throw error;
       }
     }
-    if (detail) await evaluate(send, "window.markLiveOwner?.()");
     const focus = detail ? await measureTrustedFocus(send) : null;
     const finalMeasurement = JSON.parse(await evaluate(send, "JSON.stringify(window.measure())"));
     return {
@@ -210,81 +209,24 @@ async function dispatchTrustedKey(send, key, code, windowsVirtualKeyCode) {
   await evaluate(send, "new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))");
 }
 
-async function waitForDesktopScrollbar(send) {
-  await evaluate(
-    send,
-    `new Promise((resolve, reject) => {
-      const panel = document.querySelector('[data-testid="transcript-detail-popover"] [role="dialog"]');
-      if (!panel) {
-        resolve(null);
-        return;
-      }
-      const track = panel.querySelector('[role="radiogroup"]');
-      if (!track) {
-        resolve(null);
-        return;
-      }
-      // A classic scrollbar can be laid out asynchronously after focus moves
-      // into an overflowing panel. Do not compare against a detached probe:
-      // headless Chromium can report that probe as an overlay scrollbar while
-      // the real panel acquires a 15px gutter on its next layout.
-      const geometry = () => {
-        const box = track.getBoundingClientRect();
-        return [
-          panel.scrollHeight,
-          panel.clientHeight,
-          panel.clientWidth,
-          track.clientWidth,
-          box.left,
-          box.right,
-          box.width,
-        ];
-      };
-      let previous = null;
-      let stable = 0;
-      let frames = 0;
-      const check = () => {
-        const current = geometry();
-        if (JSON.stringify(current) === JSON.stringify(previous)) stable++;
-        else stable = 0;
-        if (panel.scrollHeight > panel.clientHeight && stable >= 3) {
-          resolve({ geometry: current });
-          return;
-        }
-        if (++frames >= 120) {
-          reject(new Error('desktop Detail scrollbar geometry did not settle: geometry=' + JSON.stringify(current) + ', scroll=' + panel.scrollHeight + '/' + panel.clientHeight));
-          return;
-        }
-        previous = current;
-        requestAnimationFrame(check);
-      };
-      requestAnimationFrame(check);
-    })`,
-  );
-}
-
 async function measureTrustedFocus(send) {
   await evaluate(
     send,
     `(() => {
-      const editor = document.querySelector('section[aria-label="Transcript detail editor"]');
+      const owner = document.querySelector('[data-testid="transcript-detail-control"]');
+      const editor = owner?.querySelector('section[aria-label="Transcript detail editor"]');
       const segments = editor ? [...editor.querySelectorAll('[role="radio"]')] : [];
       segments[0]?.focus();
-      if (!editor || segments.length !== 6) throw new Error('live Detail focus fixture is incomplete');
+      if (!editor || segments.length !== 6) throw new Error('live Verbosity focus fixture is incomplete');
     })()`,
   );
-  // Chromium can report the pre-scrollbar content width until the first
-  // trusted keyboard interaction makes the overflowing Popover's scrollbar
-  // visible. Warm the control with the first transition before establishing
-  // the baseline; the transition itself remains in the asserted sequence.
-  await waitForDesktopScrollbar(send);
   const readState = async () =>
     evaluate(
       send,
       `(() => {
-        const editor = document.querySelector('section[aria-label="Transcript detail editor"]');
-        const segments = editor ? [...editor.querySelectorAll('[role="radio"]')] : [];
         const owner = document.querySelector('[data-testid="transcript-detail-control"]');
+        const editor = owner?.querySelector('section[aria-label="Transcript detail editor"]');
+        const segments = editor ? [...editor.querySelectorAll('[role="radio"]')] : [];
         const track = editor?.querySelector('[role="radiogroup"]');
         const trackBox = track?.getBoundingClientRect();
         const labels = segments.map((segment) => segment.querySelector('span')?.textContent?.trim() ?? segment.getAttribute('aria-label') ?? '');
@@ -302,6 +244,7 @@ async function measureTrustedFocus(send) {
         const inset = outlineWidth + outlineOffset;
         const painted = box ? { left: box.left - inset, right: box.right + inset, top: box.top - inset, bottom: box.bottom + inset } : null;
         let clipped = painted === null || painted.left < 0 || painted.right > window.innerWidth || painted.top < 0 || painted.bottom > window.innerHeight;
+        const clippingAncestors = [];
         for (let ancestor = focused?.parentElement; ancestor && ancestor !== document.body; ancestor = ancestor.parentElement) {
           const ancestorStyle = getComputedStyle(ancestor);
           const clipsX = ancestorStyle.overflowX !== 'visible';
@@ -312,8 +255,18 @@ async function measureTrustedFocus(send) {
             const clipTop = ancestorBox.top + ancestor.clientTop;
             const clipRight = clipLeft + ancestor.clientWidth;
             const clipBottom = clipTop + ancestor.clientHeight;
-            clipped = clipped || (clipsX && (painted.left < clipLeft || painted.right > clipRight));
-            clipped = clipped || (clipsY && (painted.top < clipTop || painted.bottom > clipBottom));
+            const clippedX = clipsX && (painted.left < clipLeft || painted.right > clipRight);
+            const clippedY = clipsY && (painted.top < clipTop || painted.bottom > clipBottom);
+            clippingAncestors.push({
+              tag: ancestor.tagName.toLowerCase(),
+              testId: ancestor.dataset.testid ?? null,
+              overflowX: ancestorStyle.overflowX,
+              overflowY: ancestorStyle.overflowY,
+              clip: { left: clipLeft, right: clipRight, top: clipTop, bottom: clipBottom },
+              clippedX,
+              clippedY,
+            });
+            clipped = clipped || clippedX || clippedY;
           }
         }
         return {
@@ -327,6 +280,7 @@ async function measureTrustedFocus(send) {
           outlineOffset,
           painted,
           clipped,
+          clippingAncestors,
           checkedLabels: segments.filter((segment) => segment.getAttribute('aria-checked') === 'true').map((segment) => segment.querySelector('span')?.textContent?.trim() ?? ''),
           track: trackBox ? { left: trackBox.left, right: trackBox.right, width: trackBox.width, clientWidth: track.clientWidth, scrollWidth: track.scrollWidth } : null,
           geometry,
@@ -334,7 +288,6 @@ async function measureTrustedFocus(send) {
       })()`,
     );
   await dispatchTrustedKey(send, "Home", "Home", 36);
-  await waitForDesktopScrollbar(send);
   const baseline = await readState();
   const first = await readState();
   for (let index = 0; index < 3; index++) await dispatchTrustedKey(send, "ArrowRight", "ArrowRight", 39);
@@ -391,6 +344,11 @@ async function verifyPanelCollapse(cdpEndpoint, url) {
         // its named container-width/fieldset-column invariant is exercised at
         // the narrow main-pane width as well.
         const detail = await window.inspectDetail(true);
+        const verbosityDialog = document.querySelector('[role="dialog"][aria-modal="true"]');
+        const closeVerbosity = verbosityDialog?.querySelector('button[aria-label="Close"]');
+        if (!closeVerbosity) throw new Error('Verbosity close button missing after dock-collapse measurement');
+        closeVerbosity.click();
+        await until(() => !document.querySelector('[role="dialog"][aria-modal="true"]'), 'Verbosity dialog close');
         const actionsAgain = actionsTrigger();
         if (!actionsAgain) throw new Error('session actions trigger missing');
         actionsAgain.click();
@@ -424,7 +382,86 @@ async function verifyPanelCollapse(cdpEndpoint, url) {
   }
 }
 
+async function verifyShortSessionMenu(cdpEndpoint, url) {
+  const page = await connectPage(cdpEndpoint);
+  const { send } = page;
+  try {
+    await applyViewport(send, { width: 844, height: 390, mobile: true });
+    await send("Emulation.setTouchEmulationEnabled", { enabled: true, maxTouchPoints: 1 });
+    await navigateTo(page, url);
+    await evaluate(send, "window.settled");
+    await waitForFonts(send);
+    await waitForDynamicViewport(send);
+    const initial = await evaluate(
+      send,
+      `(async () => {
+        const trigger = [...document.querySelectorAll('button')].find((button) =>
+          button.textContent?.includes('Session actions'),
+        );
+        if (!trigger) throw new Error('short-height Session actions trigger is missing');
+        trigger.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        trigger.click();
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        const animations = document.getAnimations().filter(
+          (animation) => animation.effect?.getTiming().iterations !== Number.POSITIVE_INFINITY,
+        );
+        await Promise.all(animations.map((animation) => animation.finished.catch(() => undefined)));
+        const menu = [...document.querySelectorAll('[role="menu"]')].find(
+          (candidate) => candidate.getAttribute('aria-labelledby') === trigger.id,
+        );
+        if (!menu) throw new Error('short-height Session menu is missing');
+        const box = menu.getBoundingClientRect();
+        return {
+          itemCount: menu.querySelectorAll('[role="menuitem"]').length,
+          top: box.top,
+          bottom: box.bottom,
+          clientHeight: menu.clientHeight,
+          scrollHeight: menu.scrollHeight,
+          overflowY: getComputedStyle(menu).overflowY,
+          viewportWidth: window.innerWidth,
+          viewportHeight: window.innerHeight,
+        };
+      })()`,
+    );
+    await dispatchTrustedKey(send, "End", "End", 35);
+    const focused = await evaluate(
+      send,
+      `(() => {
+        const trigger = [...document.querySelectorAll('button')].find((button) =>
+          button.textContent?.includes('Session actions'),
+        );
+        const menu = [...document.querySelectorAll('[role="menu"]')].find(
+          (candidate) => candidate.getAttribute('aria-labelledby') === trigger?.id,
+        );
+        if (!menu) throw new Error('short-height Session menu disappeared');
+        const items = [...menu.querySelectorAll('[role="menuitem"]')].filter(
+          (item) => item.getAttribute('aria-disabled') !== 'true',
+        );
+        const last = items.at(-1);
+        if (!last) throw new Error('short-height Session menu has no enabled item');
+        const menuBox = menu.getBoundingClientRect();
+        const lastBox = last.getBoundingClientRect();
+        const center = { x: (lastBox.left + lastBox.right) / 2, y: (lastBox.top + lastBox.bottom) / 2 };
+        const hit = document.elementFromPoint(center.x, center.y);
+        return {
+          activeIsLast: document.activeElement === last,
+          lastVisible: lastBox.top >= menuBox.top - 0.5 && lastBox.bottom <= menuBox.bottom + 0.5,
+          lastHitTestable: hit === last || (hit instanceof Node && last.contains(hit)),
+          scrollTop: menu.scrollTop,
+        };
+      })()`,
+    );
+    return { ...initial, ...focused };
+  } finally {
+    await send("Emulation.setTouchEmulationEnabled", { enabled: false }).catch(() => {});
+    await clearViewportOverride(send);
+    page.close();
+  }
+}
+
 function assertFieldsets(detail, label) {
+  const failures = [];
   if (!detail || !Number.isFinite(detail.rootRemPx) || detail.rootRemPx <= 0) {
     return [`${label} fieldset root rem measurement is missing`];
   }
@@ -433,12 +470,14 @@ function assertFieldsets(detail, label) {
   }
   const expectedColumns = detail.editorContainerWidth <= 34 * detail.rootRemPx ? 1 : 3;
   if (detail.fieldsetColumns !== expectedColumns) {
-    return [
+    failures.push(
       `${label} editor container is ${detail.editorContainerWidth}px (${detail.rootRemPx}px root rem), ` +
         `so fieldsets must use ${expectedColumns} column(s), found ${detail.fieldsetColumns ?? "unknown"}`,
-    ];
+    );
   }
-  return [];
+  if (!detail.fieldsetsNonOverlapping) failures.push(`${label} fieldsets overlap`);
+  if (expectedColumns === 1 && !detail.fieldsetStacked) failures.push(`${label} one-column fieldsets are not vertically stacked`);
+  return failures;
 }
 
 function assertDetail(result, width) {
@@ -493,7 +532,7 @@ function assertDetail(result, width) {
     }
   }
   if (!Array.isArray(result.scrollContainers) || result.scrollContainers.length === 0) {
-    failures.push("live Detail scroll-container ancestor measurements are missing");
+    failures.push("live Verbosity scroll-container ancestor measurements are missing");
   }
   const overflowingAncestors = (result.scrollContainers ?? []).filter(
     (container) => container.scrollWidth > container.clientWidth + GEOMETRY_TOLERANCE,
@@ -503,49 +542,53 @@ function assertDetail(result, width) {
   }
   const detail = result.detail;
   if (!detail?.found || !detail.triggerReachable || !detail.triggerHitTestable)
-    failures.push("Detail trigger is not reachable or is occluded at its center hit point");
-  if (!detail?.open) failures.push("Detail trigger did not open its production portal/sheet");
-  if (!detail?.portalContained) failures.push(`Detail portal/sheet escapes the viewport: ${JSON.stringify(detail?.panel)}`);
+    failures.push("Session actions trigger is not reachable or is occluded at its center hit point");
+  if (!detail?.open) failures.push("Verbosity did not open its production Dialog/Sheet");
+  if (!detail?.overlayContained) failures.push(`Verbosity Dialog/Sheet escapes the viewport: ${JSON.stringify(detail?.panel)}`);
   if ((detail?.horizontalOverflowCount ?? 1) !== 0) {
     failures.push(
-      `Detail control has ${detail?.horizontalOverflowCount ?? "unknown"} horizontal overflow element(s): ${JSON.stringify(detail?.overflowElements)}`,
+      `Verbosity has ${detail?.horizontalOverflowCount ?? "unknown"} horizontal overflow element(s): ${JSON.stringify(detail?.overflowElements)}`,
     );
   }
   const mobile = result.viewport?.mobile === true;
-  if (detail?.mobile !== mobile) failures.push(`Detail layout mode is ${detail?.mobile}, realized viewport mode is ${mobile}`);
-  failures.push(...assertFieldsets(detail, `${width}px Detail`));
-  const expectedTargets = mobile ? 29 : 28;
+  if (detail?.mobile !== mobile) failures.push(`Verbosity layout mode is ${detail?.mobile}, realized viewport mode is ${mobile}`);
+  failures.push(...assertFieldsets(detail, `${width}px Verbosity`));
+  const expectedTargets = 31;
   if ((detail?.targets?.length ?? 0) !== expectedTargets) {
-    failures.push(`Detail mounted ${detail?.targets?.length ?? "unknown"} interactive targets, expected ${expectedTargets}`);
+    failures.push(`Verbosity mounted ${detail?.targets?.length ?? "unknown"} interactive targets, expected ${expectedTargets}`);
+  }
+  if (!(detail?.targets ?? []).some((target) => target.kind === "menuitem" && target.label === "Verbosity…")) {
+    failures.push("Verbosity menu item target measurement is missing");
+  }
+  if (!(detail?.targets ?? []).some((target) => target.kind === "summary" && target.label.startsWith("Customize & advanced"))) {
+    failures.push("Verbosity Advanced summary target measurement is missing");
   }
   const switchLabels = detail?.targets?.filter((target) => target.kind === "switch-label") ?? [];
-  if (switchLabels.length !== 9) failures.push(`Detail mounted ${switchLabels.length} Switch label targets, expected 9`);
-  if (!detail?.popoverAnchored && !mobile) failures.push("Desktop Detail popover is not spatially anchored to its trigger");
-  if (!detail?.sheetBottomAnchored && mobile) failures.push("Mobile Detail sheet is not bottom-anchored");
-  if (!result.trigger) failures.push("live Detail trigger geometry is missing");
-  const popoverScroll = detail?.popoverScroll;
+  if (switchLabels.length !== 9) failures.push(`Verbosity mounted ${switchLabels.length} Switch label targets, expected 9`);
+  if (!detail?.dialogCentered && !mobile) failures.push("Desktop Verbosity Dialog is not centered in the viewport");
+  if (!detail?.sheetBottomAnchored && mobile) failures.push("Mobile Verbosity Sheet is not bottom-anchored");
+  if (!result.trigger) failures.push("Session actions trigger geometry is missing");
+  const overlayScroll = detail?.overlayScroll;
   if (
-    !mobile &&
-    (!popoverScroll?.connected ||
-      !popoverScroll.contained ||
-      !popoverScroll.expanded ||
-      !popoverScroll.scrollable ||
-      popoverScroll.scrollHeight <= popoverScroll.clientHeight ||
-      popoverScroll.afterTop <= popoverScroll.beforeTop)
+    (!overlayScroll?.connected ||
+      !overlayScroll.contained ||
+      !overlayScroll.scrollable ||
+      overlayScroll.scrollHeight <= overlayScroll.clientHeight ||
+      overlayScroll.afterTop <= overlayScroll.beforeTop)
   ) {
-    failures.push(`Desktop Detail dialog failed internal-scroll containment: ${JSON.stringify(popoverScroll)}`);
+    failures.push(`Verbosity Dialog/Sheet failed internal-scroll containment: ${JSON.stringify(overlayScroll)}`);
   }
   if (mobile) {
     const undersized = (detail?.targets ?? []).filter((target) => target.height < 44 - 0.5);
     const undersizedEffective = (detail?.effectiveTargets ?? []).filter((target) => target.height < 44 - 0.5);
     if (undersized.length > 0) {
       failures.push(
-        `Mobile Detail target(s) are below 44px: ${undersized.map((target) => `${target.kind}:${JSON.stringify(target.label)}=${target.height}`).join(", ")}`,
+        `Mobile Verbosity target(s) are below 44px: ${undersized.map((target) => `${target.kind}:${JSON.stringify(target.label)}=${target.height}`).join(", ")}`,
       );
     }
     if (undersizedEffective.length > 0) {
       failures.push(
-        `Mobile Detail effective target(s) are below 44px: ${undersizedEffective.map((target) => `${target.kind}:${JSON.stringify(target.label)}=${target.height}`).join(", ")}`,
+        `Mobile Verbosity effective target(s) are below 44px: ${undersizedEffective.map((target) => `${target.kind}:${JSON.stringify(target.label)}=${target.height}`).join(", ")}`,
       );
     }
   }
@@ -783,6 +826,43 @@ async function main() {
       startupDeadline.clear();
     }
 
+    const shortMenu = await verifyShortSessionMenu(
+      cdpEndpoint,
+      `http://127.0.0.1:${vitePort}/overflowharness.html?w=844`,
+    );
+    const shortMenuFailures = [];
+    if (shortMenu.viewportWidth !== 844 || shortMenu.viewportHeight !== 390) {
+      shortMenuFailures.push(`realized viewport=${shortMenu.viewportWidth}x${shortMenu.viewportHeight}`);
+    }
+    if (shortMenu.itemCount !== 9) shortMenuFailures.push(`items=${shortMenu.itemCount}, expected 9`);
+    if (shortMenu.top < 8 - GEOMETRY_TOLERANCE || shortMenu.bottom > 390 - 8 + GEOMETRY_TOLERANCE) {
+      shortMenuFailures.push(`bounds=${shortMenu.top}-${shortMenu.bottom}, expected within 8-382`);
+    }
+    if (
+      shortMenu.scrollHeight <= shortMenu.clientHeight ||
+      (shortMenu.overflowY !== "auto" && shortMenu.overflowY !== "scroll")
+    ) {
+      shortMenuFailures.push(
+        `vertical scroll=${shortMenu.scrollHeight}/${shortMenu.clientHeight}, overflow-y=${shortMenu.overflowY}`,
+      );
+    }
+    if (!shortMenu.activeIsLast || !shortMenu.lastVisible || !shortMenu.lastHitTestable || shortMenu.scrollTop <= 0) {
+      shortMenuFailures.push(
+        `End reachability=${JSON.stringify({
+          activeIsLast: shortMenu.activeIsLast,
+          lastVisible: shortMenu.lastVisible,
+          lastHitTestable: shortMenu.lastHitTestable,
+          scrollTop: shortMenu.scrollTop,
+        })}`,
+      );
+    }
+    if (shortMenuFailures.length > 0) {
+      failed++;
+      console.log(`short mobile menu ... FAIL - ${shortMenuFailures.join("; ")}`);
+    } else {
+      console.log("short mobile menu ... PASS - popup contained, scrollable, and last action keyboard/touch reachable");
+    }
+
     const panelCollapse = await verifyPanelCollapse(
       cdpEndpoint,
       `http://127.0.0.1:${vitePort}/overflowharness.html?w=1024&panels=1`,
@@ -797,7 +877,7 @@ async function main() {
       !panelCollapse.detail?.triggerHitTestable ||
       !panelCollapse.detail?.open ||
       panelCollapse.detail.horizontalOverflowCount !== 0 ||
-      !panelCollapse.detail.portalContained ||
+      !panelCollapse.detail.overlayContained ||
       panelFieldsetFailures.length > 0
     ) {
       failed++;
@@ -805,7 +885,7 @@ async function main() {
     } else {
       console.log(
         `panel collapse ... PASS - ${panelCollapse.mainWidth}px main pane, checked Tasks adornment visible, ` +
-          `reachable Detail popover, no horizontal overflow`,
+          `reachable Verbosity Dialog, no horizontal overflow`,
       );
     }
 
@@ -975,14 +1055,14 @@ async function main() {
       const detailFailures = assertDetail(result, width);
       if (detailFailures.length > 0) {
         failed++;
-        console.log(`${width}px Detail ... FAIL - ${detailFailures.join("; ")}`);
+        console.log(`${width}px Verbosity ... FAIL - ${detailFailures.join("; ")}`);
       } else {
         console.log(
-          `${width}px Detail ... PASS - trigger reachable, ${result.detail.mobile ? "sheet" : "popover"} contained, ` +
+          `${width}px Verbosity ... PASS - Session actions reachable, ${result.detail.mobile ? "Sheet" : "Dialog"} contained, ` +
             `no horizontal scroll${result.detail.mobile ? ", 44px targets" : ""}; ` +
             `final panel=${JSON.stringify(result.detail.panel)}, model=${result.footer.modelClientWidth}px` +
             `, root rem=${result.detail.rootRemPx}px, editor=${result.detail.editorContainerWidth}px/${result.detail.fieldsetColumns} fieldset columns` +
-            `${result.detail.mobile ? "" : `, internal scroll=${result.detail.popoverScroll.afterTop}/${result.detail.popoverScroll.scrollHeight} in ${result.detail.popoverScroll.clientHeight}px`}`,
+            `${result.detail.mobile ? "" : `, internal scroll=${result.detail.overlayScroll.afterTop}/${result.detail.overlayScroll.scrollHeight} in ${result.detail.overlayScroll.clientHeight}px`}`,
         );
       }
     }

--- a/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
@@ -580,7 +580,11 @@ function assertDetail(result, width) {
   }
   const switchLabels = detail?.targets?.filter((target) => target.kind === "switch-label") ?? [];
   if (switchLabels.length !== 9) failures.push(`Verbosity mounted ${switchLabels.length} Switch label targets, expected 9`);
-  if (!detail?.dialogCentered && !mobile) failures.push("Desktop Verbosity Dialog is not centered in the viewport");
+  if (!detail?.dialogCentered && !mobile) {
+    failures.push(
+      `Desktop Verbosity Dialog is not centered in the layout viewport: ${JSON.stringify({ panel: detail?.panel, viewport: result.viewport })}`,
+    );
+  }
   if (!detail?.sheetBottomAnchored && mobile) failures.push("Mobile Verbosity Sheet is not bottom-anchored");
   if (!result.trigger) failures.push("Session actions trigger geometry is missing");
   const overlayScroll = detail?.overlayScroll;

--- a/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
@@ -460,6 +460,21 @@ async function verifyShortSessionMenu(cdpEndpoint, url) {
   }
 }
 
+async function verifyChatFocus(cdpEndpoint, url) {
+  const page = await connectPage(cdpEndpoint);
+  const { send } = page;
+  try {
+    await applyViewport(send, { width: 1024, height: 900, mobile: false });
+    await navigateTo(page, url);
+    await evaluate(send, "window.settled");
+    await waitForFonts(send);
+    return await evaluate(send, "window.inspectChatFocus()");
+  } finally {
+    await clearViewportOverride(send);
+    page.close();
+  }
+}
+
 function assertFieldsets(detail, label) {
   const failures = [];
   if (!detail || !Number.isFinite(detail.rootRemPx) || detail.rootRemPx <= 0) {
@@ -861,6 +876,24 @@ async function main() {
       console.log(`short mobile menu ... FAIL - ${shortMenuFailures.join("; ")}`);
     } else {
       console.log("short mobile menu ... PASS - popup contained, scrollable, and last action keyboard/touch reachable");
+    }
+
+    const chatFocus = await verifyChatFocus(
+      cdpEndpoint,
+      `http://127.0.0.1:${vitePort}/overflowharness.html?w=1024`,
+    );
+    if (
+      !chatFocus.toolsRowFocused ||
+      !chatFocus.groupFound ||
+      chatFocus.groupOpen ||
+      !chatFocus.summaryIsActive ||
+      chatFocus.rationaleIsActive ||
+      !chatFocus.summaryVisible
+    ) {
+      failed++;
+      console.log(`Chat focus transition ... FAIL - ${JSON.stringify(chatFocus)}`);
+    } else {
+      console.log("Chat focus transition ... PASS - closed action summary visibly owns focus");
     }
 
     const panelCollapse = await verifyPanelCollapse(

--- a/cmd/evener-hub/frontend/src/dev/overflowharness-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/overflowharness-entry.tsx
@@ -951,8 +951,8 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
     sheetBottomAnchored: mobile && panelBox.bottom >= window.innerHeight - 1,
     dialogCentered:
       !mobile &&
-      Math.abs((panelBox.left + panelBox.right) / 2 - window.innerWidth / 2) <= 1 &&
-      Math.abs((panelBox.top + panelBox.bottom) / 2 - window.innerHeight / 2) <= 1,
+      Math.abs((panelBox.left + panelBox.right) / 2 - document.documentElement.clientWidth / 2) <= 1 &&
+      Math.abs((panelBox.top + panelBox.bottom) / 2 - document.documentElement.clientHeight / 2) <= 1,
     overlayScroll,
   };
 }

--- a/cmd/evener-hub/frontend/src/dev/overflowharness-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/overflowharness-entry.tsx
@@ -21,11 +21,13 @@ import Settings from "../panes/settings/Settings";
 import "../panes/sessionPanels";
 import { hydrateThread } from "../protocol/reducer";
 import { FakeClient } from "../protocol/testing/fakeClient";
-import type { ThreadCapabilities, ThreadReadResponse } from "../protocol/types.gen";
+import type { NavigationSessionLocation, ThreadCapabilities, ThreadReadResponse } from "../protocol/types.gen";
 import { ClientProvider } from "../shell/clientContext";
 import { DockHost } from "../shell/DockHost";
 import { workspaceStore } from "../shell/workspace";
 import { connectionStore } from "../stores/connection";
+import { navigationStore } from "../stores/navigation/store";
+import { keyID } from "../stores/navigation/types";
 import { threadsStore } from "../stores/threads";
 import { initTranscriptDisplay, transcriptDisplayStore } from "../stores/transcriptDisplay";
 import { makeTranscriptDisplayConfig } from "../transcriptDisplay/config";
@@ -214,6 +216,47 @@ connectionStore.getState().connect(fake);
 threadsStore.setState((s) => ({
   threads: new Map(s.threads).set(REF, hydrateThread(snapshot, REF, 1000)),
 }));
+const locationKey = { kind: "location", ref: REF } as const;
+const location: NavigationSessionLocation = {
+  generation_id: "overflow_generation",
+  revision: 1,
+  ref: REF,
+  top_level_ref: REF,
+  top_level: true,
+  tier: "current",
+  session: {
+    ref: REF,
+    host_id: "local",
+    session_id: snapshot.thread.sessionId,
+    title: snapshot.thread.name ?? REF,
+    project: "",
+    state: "active",
+    kind: "session",
+    live: true,
+    children: [],
+  },
+};
+navigationStore.setState({
+  mode: "v1",
+  clientGenerationID: location.generation_id,
+  resources: new Map([
+    [
+      keyID(locationKey),
+      {
+        key: locationKey,
+        data: location,
+        loadedRevision: location.revision,
+        targetRevision: null,
+        forceToken: 0,
+        etag: "overflow-location",
+        loading: false,
+        stale: false,
+        error: null,
+        generationID: location.generation_id,
+      },
+    ],
+  ]),
+});
 initTranscriptDisplay();
 // The browser guard must not inherit a developer's local transcript settings.
 // Activity plus both diagnostic families keeps the real system-prompt and raw
@@ -307,23 +350,22 @@ interface DetailGeometry {
   triggerHitTestable: boolean;
   trigger: { left: number; right: number; top: number; bottom: number; width: number; height: number } | null;
   open: boolean;
-  portalContained: boolean;
+  overlayContained: boolean;
   panel: { left: number; right: number; top: number; bottom: number; width: number; height: number } | null;
   horizontalOverflowCount: number;
-  targetHeights: number[];
   targets: Array<{ kind: string; label: string; height: number }>;
   fieldsetsFound: number;
   overflowElements: string[];
   fieldsetStacked: boolean;
+  fieldsetsNonOverlapping: boolean;
   rootRemPx: number;
   editorContainerWidth: number;
   fieldsetColumns: number;
   sheetBottomAnchored: boolean;
-  popoverAnchored: boolean;
-  popoverScroll: {
+  dialogCentered: boolean;
+  overlayScroll: {
     connected: boolean;
     contained: boolean;
-    expanded: boolean;
     scrollable: boolean;
     beforeTop: number;
     afterTop: number;
@@ -454,12 +496,6 @@ function effectiveTargetElement(element: HTMLElement): HTMLElement {
   return element;
 }
 
-function popoverGap(panel: ReturnType<typeof geometryOf>, trigger: ReturnType<typeof geometryOf>): number {
-  if (panel.bottom <= trigger.top) return trigger.top - panel.bottom;
-  if (panel.top >= trigger.bottom) return panel.top - trigger.bottom;
-  return 0;
-}
-
 function horizontalOverflowElements(root: Element): HTMLElement[] {
   return [root, ...Array.from(root.querySelectorAll<HTMLElement>("*"))].filter(
     (element): element is HTMLElement =>
@@ -478,16 +514,6 @@ function actualScrollContainers(root: Element): HTMLElement[] {
   });
 }
 
-function markLiveOwner(): boolean {
-  const trigger = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find((button) =>
-    button.textContent?.trim().startsWith("Detail:"),
-  );
-  const owner = trigger?.closest<HTMLElement>("div");
-  if (!owner) return false;
-  owner.dataset.testid = "transcript-detail-control";
-  return true;
-}
-
 function editorOwner(editor: HTMLElement): {
   surface: "live" | "settings";
   layout: "desktop" | "mobile";
@@ -502,7 +528,7 @@ function editorOwner(editor: HTMLElement): {
       ownerTestId,
     };
   }
-  const owner = document.querySelector<HTMLElement>('[data-testid="transcript-detail-control"]');
+  const owner = editor.closest<HTMLElement>('[data-testid="transcript-detail-control"]');
   return {
     surface: "live",
     layout: window.matchMedia("(max-width: 899px)").matches ? "mobile" : "desktop",
@@ -668,7 +694,7 @@ function measureSettings(): SettingsGeometry {
 async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
   const pane = document.getElementById("oh-pane");
   const trigger = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find((button) =>
-    button.textContent?.trim().startsWith("Detail:"),
+    button.textContent?.includes("Session actions"),
   );
   if (!pane || !trigger) {
     return {
@@ -678,23 +704,22 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
       triggerHitTestable: false,
       trigger: null,
       open: false,
-      portalContained: false,
+      overlayContained: false,
       panel: null,
       horizontalOverflowCount: 0,
-      targetHeights: [],
       targets: [],
       fieldsetsFound: 0,
       overflowElements: [],
       fieldsetStacked: false,
+      fieldsetsNonOverlapping: false,
       rootRemPx: 0,
       editorContainerWidth: 0,
       fieldsetColumns: 0,
       sheetBottomAnchored: false,
-      popoverAnchored: false,
-      popoverScroll: {
+      dialogCentered: false,
+      overlayScroll: {
         connected: false,
         contained: false,
-        expanded: false,
         scrollable: false,
         beforeTop: 0,
         afterTop: 0,
@@ -705,7 +730,8 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
     };
   }
   const mobile = window.matchMedia("(max-width: 899px)").matches;
-  markLiveOwner();
+  trigger.scrollIntoView({ block: "nearest", inline: "nearest" });
+  await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
   const paneBox = pane.getBoundingClientRect();
   const triggerBox = geometryOf(trigger);
   const triggerCenter = { x: (triggerBox.left + triggerBox.right) / 2, y: (triggerBox.top + triggerBox.bottom) / 2 };
@@ -722,14 +748,28 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
     triggerBox.bottom <= paneBox.bottom + 1;
   trigger.click();
   await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+  const menu = Array.from(document.querySelectorAll<HTMLElement>('[role="menu"]')).find(
+    (candidate) => candidate.getAttribute("aria-labelledby") === trigger.id,
+  );
+  const verbosityItem = Array.from(menu?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? []).find(
+    (item) => item.textContent?.trim() === "Verbosity…",
+  );
+  if (!verbosityItem) throw new Error("Session actions did not expose pane-only Verbosity…");
+  const verbosityTarget = {
+    kind: "menuitem",
+    label: "Verbosity…",
+    height: verbosityItem.getBoundingClientRect().height,
+  };
+  verbosityItem.click();
+  await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
   const finite = document
     .getAnimations()
     .filter((animation) => animation.effect?.getTiming().iterations !== Number.POSITIVE_INFINITY);
   await Promise.all(finite.map((animation) => animation.finished.catch(() => undefined)));
 
-  const panel = mobile
-    ? document.querySelector<HTMLElement>('[role="dialog"][aria-modal="true"]')
-    : document.querySelector<HTMLElement>('[data-testid="transcript-detail-popover"]');
+  const panel = Array.from(document.querySelectorAll<HTMLElement>('[role="dialog"][aria-modal="true"]')).find(
+    (dialog) => dialog.querySelector("h2")?.textContent?.trim() === "Verbosity",
+  );
   if (!panel) {
     return {
       found: true,
@@ -738,23 +778,22 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
       trigger: triggerBox,
       triggerHitTestable,
       open: false,
-      portalContained: false,
+      overlayContained: false,
       panel: null,
       horizontalOverflowCount: 0,
-      targetHeights: [],
       targets: [],
       fieldsetsFound: 0,
       overflowElements: [],
       fieldsetStacked: false,
+      fieldsetsNonOverlapping: false,
       rootRemPx: 0,
       editorContainerWidth: 0,
       fieldsetColumns: 0,
       sheetBottomAnchored: false,
-      popoverAnchored: false,
-      popoverScroll: {
+      dialogCentered: false,
+      overlayScroll: {
         connected: false,
         contained: false,
-        expanded: false,
         scrollable: false,
         beforeTop: 0,
         afterTop: 0,
@@ -764,6 +803,9 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
       effectiveTargets: [],
     };
   }
+  const owner = panel.querySelector<HTMLElement>('[data-testid="transcript-detail-control"]');
+  const editor = owner?.querySelector<HTMLElement>('section[aria-label="Transcript detail editor"]');
+  if (!owner || !editor) throw new Error("Verbosity Dialog/Sheet does not own its transcript editor");
   await waitForStablePanel(panel);
   if (includeAdvanced) {
     const advanced = Array.from(panel.querySelectorAll<HTMLElement>("summary")).find((summary) =>
@@ -779,7 +821,6 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
     await waitForStablePanel(panel);
   }
   const panelBox = geometryOf(panel);
-  const finalTriggerBox = geometryOf(trigger);
   const accessibleName = (element: Element): string => {
     const ariaLabel = element.getAttribute("aria-label");
     if (ariaLabel) return ariaLabel;
@@ -796,7 +837,7 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
   };
   const controls = [
     trigger,
-    ...Array.from(panel.querySelectorAll<HTMLElement>("button, select, [role=radio], [role=switch]")),
+    ...Array.from(panel.querySelectorAll<HTMLElement>("button, select, summary, [role=radio], [role=switch]")),
   ];
   const switchLabels = Array.from(panel.querySelectorAll<HTMLElement>('[role="switch"]')).flatMap((switchElement) => {
     const ids = switchElement.getAttribute("aria-labelledby")?.split(/\s+/) ?? [];
@@ -805,6 +846,7 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
       .filter((label): label is HTMLElement => label instanceof HTMLElement && panel.contains(label));
   });
   const targets = [
+    verbosityTarget,
     ...controls.map((element) => ({
       kind: element === trigger ? "trigger" : (element.getAttribute("role") ?? element.tagName.toLowerCase()),
       label: accessibleName(element),
@@ -816,10 +858,8 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
       height: element.getBoundingClientRect().height,
     })),
   ];
-  const targetHeights = targets.map((target) => target.height);
   const fieldsets = Array.from(panel.querySelectorAll<HTMLElement>("fieldset"));
   const fieldsetBoxes = fieldsets.map(geometryOf);
-  const editor = panel.querySelector<HTMLElement>('section[aria-label="Transcript detail editor"]');
   const editorStyle = editor ? getComputedStyle(editor) : null;
   const editorContainerWidth = editor
     ? editor.clientWidth -
@@ -832,53 +872,64 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
   }
   const fieldsetColumns = columnLefts.length;
   const rootRemPx = Number.parseFloat(getComputedStyle(document.documentElement).fontSize);
-  const effectiveTargets = controls.map((element) => {
-    const effectiveElement = effectiveTargetElement(element);
-    return {
-      kind: element === trigger ? "trigger" : (element.getAttribute("role") ?? element.tagName.toLowerCase()),
-      label: accessibleName(element),
-      height: effectiveElement.getBoundingClientRect().height,
-    };
-  });
+  const effectiveTargets = [
+    verbosityTarget,
+    ...controls.map((element) => {
+      const effectiveElement = effectiveTargetElement(element);
+      return {
+        kind: element === trigger ? "trigger" : (element.getAttribute("role") ?? element.tagName.toLowerCase()),
+        label: accessibleName(element),
+        height: effectiveElement.getBoundingClientRect().height,
+      };
+    }),
+  ];
   const fieldsetStacked =
     fieldsets.length === 3 &&
     fieldsetBoxes.every((box, index) => {
       const previous = fieldsetBoxes[index - 1];
       return index === 0 || (previous !== undefined && box.top >= previous.bottom - 1);
     });
-  let popoverScroll = {
+  const fieldsetsNonOverlapping = fieldsetBoxes.every((box, index) =>
+    fieldsetBoxes
+      .slice(index + 1)
+      .every(
+        (other) =>
+          box.right <= other.left + 1 ||
+          other.right <= box.left + 1 ||
+          box.bottom <= other.top + 1 ||
+          other.bottom <= box.top + 1,
+      ),
+  );
+  let overlayScroll = {
     connected: true,
     contained: true,
-    expanded: true,
     scrollable: false,
     beforeTop: 0,
     afterTop: 0,
     scrollHeight: 0,
     clientHeight: 0,
   };
-  if (!mobile) {
-    const scrollPanel = panel.querySelector<HTMLElement>('[role="dialog"]') ?? panel;
-    const beforeTop = scrollPanel.scrollTop;
-    const scrollable = scrollPanel.scrollHeight > scrollPanel.clientHeight;
-    scrollPanel.scrollTop = scrollPanel.scrollHeight;
-    scrollPanel.dispatchEvent(new Event("scroll"));
-    await waitForStablePanel(panel);
-    const scrolledPanelBox = geometryOf(panel);
-    popoverScroll = {
-      connected: panel.isConnected,
-      contained:
-        scrolledPanelBox.left >= -1 &&
-        scrolledPanelBox.right <= window.innerWidth + 1 &&
-        scrolledPanelBox.top >= -1 &&
-        scrolledPanelBox.bottom <= window.innerHeight + 1,
-      expanded: trigger.getAttribute("aria-expanded") === "true",
-      scrollable,
-      beforeTop,
-      afterTop: scrollPanel.scrollTop,
-      scrollHeight: scrollPanel.scrollHeight,
-      clientHeight: scrollPanel.clientHeight,
-    };
-  }
+  const scrollPanel = owner.parentElement;
+  if (!scrollPanel) throw new Error("Verbosity Dialog/Sheet scroll owner is missing");
+  const beforeTop = scrollPanel.scrollTop;
+  const scrollable = scrollPanel.scrollHeight > scrollPanel.clientHeight;
+  scrollPanel.scrollTop = scrollPanel.scrollHeight;
+  scrollPanel.dispatchEvent(new Event("scroll"));
+  await waitForStablePanel(panel);
+  const scrolledPanelBox = geometryOf(panel);
+  overlayScroll = {
+    connected: panel.isConnected,
+    contained:
+      scrolledPanelBox.left >= -1 &&
+      scrolledPanelBox.right <= window.innerWidth + 1 &&
+      scrolledPanelBox.top >= -1 &&
+      scrolledPanelBox.bottom <= window.innerHeight + 1,
+    scrollable,
+    beforeTop,
+    afterTop: scrollPanel.scrollTop,
+    scrollHeight: scrollPanel.scrollHeight,
+    clientHeight: scrollPanel.clientHeight,
+  };
   return {
     found: true,
     mobile,
@@ -886,14 +937,13 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
     trigger: triggerBox,
     triggerHitTestable,
     open: true,
-    portalContained:
+    overlayContained:
       panelBox.left >= -1 &&
       panelBox.right <= window.innerWidth + 1 &&
       panelBox.top >= -1 &&
       panelBox.bottom <= window.innerHeight + 1,
     panel: panelBox,
     horizontalOverflowCount: horizontalOverflowElements(panel).length,
-    targetHeights,
     targets,
     fieldsetsFound: fieldsets.length,
     effectiveTargets,
@@ -903,16 +953,16 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
         `${element.scrollWidth}/${element.clientWidth}x${element.scrollHeight}/${element.clientHeight}`,
     ),
     fieldsetStacked,
+    fieldsetsNonOverlapping,
     rootRemPx,
     editorContainerWidth,
     fieldsetColumns,
     sheetBottomAnchored: mobile && panelBox.bottom >= window.innerHeight - 1,
-    popoverAnchored:
+    dialogCentered:
       !mobile &&
-      panelBox.left <= finalTriggerBox.right + 1 &&
-      panelBox.right >= finalTriggerBox.left - 1 &&
-      popoverGap(panelBox, finalTriggerBox) <= 24,
-    popoverScroll,
+      Math.abs((panelBox.left + panelBox.right) / 2 - window.innerWidth / 2) <= 1 &&
+      Math.abs((panelBox.top + panelBox.bottom) / 2 - window.innerHeight / 2) <= 1,
+    overlayScroll,
   };
 }
 
@@ -1150,13 +1200,10 @@ function measure() {
     ? Array.from(liveEditorElement.querySelectorAll<HTMLElement>("fieldset")).map(geometryOf)
     : [];
   const triggerElement = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find((button) =>
-    button.textContent?.trim().startsWith("Detail:"),
+    button.textContent?.includes("Session actions"),
   );
   const triggerBox = triggerElement ? geometryOf(triggerElement) : null;
-  const scrollRoots = [
-    pane,
-    ...Array.from(document.querySelectorAll<HTMLElement>('[data-testid="transcript-detail-popover"], [role="dialog"]')),
-  ];
+  const scrollRoots = [pane, ...Array.from(document.querySelectorAll<HTMLElement>('[role="dialog"]'))];
   const scrollContainers = Array.from(new Set(scrollRoots.flatMap((root) => actualScrollContainers(root))));
   const quoteFontSize = subagentQuote ? Number.parseFloat(getComputedStyle(subagentQuote).fontSize) : 0;
   function statusGeometry(element: HTMLElement | null) {
@@ -1292,12 +1339,10 @@ declare global {
     measure: typeof measure;
     dump: typeof dump;
     inspectDetail: typeof inspectDetail;
-    markLiveOwner: typeof markLiveOwner;
     settled: Promise<true>;
   }
 }
 window.measure = measure;
 window.dump = dump;
 window.inspectDetail = inspectDetail;
-window.markLiveOwner = markLiveOwner;
 window.settled = settled;

--- a/cmd/evener-hub/frontend/src/dev/overflowharness-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/overflowharness-entry.tsx
@@ -860,12 +860,11 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
   ];
   const fieldsets = Array.from(panel.querySelectorAll<HTMLElement>("fieldset"));
   const fieldsetBoxes = fieldsets.map(geometryOf);
-  const editorStyle = editor ? getComputedStyle(editor) : null;
-  const editorContainerWidth = editor
-    ? editor.clientWidth -
-      (Number.parseFloat(editorStyle?.paddingLeft ?? "0") || 0) -
-      (Number.parseFloat(editorStyle?.paddingRight ?? "0") || 0)
-    : 0;
+  const editorStyle = getComputedStyle(editor);
+  const editorContainerWidth =
+    editor.clientWidth -
+    (Number.parseFloat(editorStyle.paddingLeft) || 0) -
+    (Number.parseFloat(editorStyle.paddingRight) || 0);
   const columnLefts: number[] = [];
   for (const box of fieldsetBoxes) {
     if (!columnLefts.some((left) => Math.abs(left - box.left) <= 0.5)) columnLefts.push(box.left);
@@ -900,15 +899,6 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
           other.bottom <= box.top + 1,
       ),
   );
-  let overlayScroll = {
-    connected: true,
-    contained: true,
-    scrollable: false,
-    beforeTop: 0,
-    afterTop: 0,
-    scrollHeight: 0,
-    clientHeight: 0,
-  };
   const scrollPanel = owner.parentElement;
   if (!scrollPanel) throw new Error("Verbosity Dialog/Sheet scroll owner is missing");
   const beforeTop = scrollPanel.scrollTop;
@@ -917,7 +907,7 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
   scrollPanel.dispatchEvent(new Event("scroll"));
   await waitForStablePanel(panel);
   const scrolledPanelBox = geometryOf(panel);
-  overlayScroll = {
+  const overlayScroll = {
     connected: panel.isConnected,
     contained:
       scrolledPanelBox.left >= -1 &&
@@ -930,6 +920,7 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
     scrollHeight: scrollPanel.scrollHeight,
     clientHeight: scrollPanel.clientHeight,
   };
+  const overflowingElements = horizontalOverflowElements(panel);
   return {
     found: true,
     mobile,
@@ -943,11 +934,11 @@ async function inspectDetail(includeAdvanced = true): Promise<DetailGeometry> {
       panelBox.top >= -1 &&
       panelBox.bottom <= window.innerHeight + 1,
     panel: panelBox,
-    horizontalOverflowCount: horizontalOverflowElements(panel).length,
+    horizontalOverflowCount: overflowingElements.length,
     targets,
     fieldsetsFound: fieldsets.length,
     effectiveTargets,
-    overflowElements: horizontalOverflowElements(panel).map(
+    overflowElements: overflowingElements.map(
       (element) =>
         `${element.tagName.toLowerCase()}.${element.className || "(no-class)"} ` +
         `${element.scrollWidth}/${element.clientWidth}x${element.scrollHeight}/${element.clientHeight}`,
@@ -1097,6 +1088,64 @@ function visibilityProbe(): VisibilityProbe {
     };
   } finally {
     host.remove();
+  }
+}
+
+interface ChatFocusMeasurement {
+  toolsRowFocused: boolean;
+  groupFound: boolean;
+  groupOpen: boolean;
+  summaryIsActive: boolean;
+  rationaleIsActive: boolean;
+  summaryVisible: boolean;
+  activeTag: string | null;
+  activeTestId: string | null;
+}
+
+async function inspectChatFocus(): Promise<ChatFocusMeasurement> {
+  const pane = document.getElementById("oh-pane");
+  if (!pane) throw new Error("Chat focus harness pane never mounted");
+  const layout = transcriptDisplayStore.getState().viewport;
+  const original = transcriptDisplayStore.getState().local[layout];
+  const waitFor = async <T,>(read: () => T | null | undefined, label: string): Promise<T> => {
+    for (let frame = 0; frame < 180; frame += 1) {
+      const value = read();
+      if (value !== null && value !== undefined) return value;
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    }
+    throw new Error(`Chat focus harness did not settle: ${label}`);
+  };
+  try {
+    transcriptDisplayStore.getState().setLocal(layout, makeTranscriptDisplayConfig({ kind: "preset", level: "tools" }));
+    const toolTrigger = await waitFor(
+      () => pane.querySelector<HTMLElement>('[data-view-anchor-id="i3b"] [data-testid="tool-row-trigger"]'),
+      "Tools row trigger",
+    );
+    toolTrigger.focus();
+    const toolsRowFocused = document.activeElement === toolTrigger;
+
+    transcriptDisplayStore.getState().setLocal(layout, makeTranscriptDisplayConfig({ kind: "preset", level: "chat" }));
+    const rationale = await waitFor(
+      () => pane.querySelector<HTMLElement>('[data-view-anchor-id="intent:i3b"]'),
+      "Chat intent rationale",
+    );
+    await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+    const group = rationale.closest<HTMLDetailsElement>('details[data-testid="intent-group"]');
+    const summary = group?.querySelector<HTMLElement>(":scope > summary");
+    const active = document.activeElement;
+    return {
+      toolsRowFocused,
+      groupFound: group !== null,
+      groupOpen: group?.open ?? false,
+      summaryIsActive: active === summary,
+      rationaleIsActive: active === rationale,
+      summaryVisible: summary ? isElementVisible(summary) : false,
+      activeTag: active?.tagName.toLowerCase() ?? null,
+      activeTestId: active instanceof HTMLElement ? (active.dataset.testid ?? null) : null,
+    };
+  } finally {
+    if (original) transcriptDisplayStore.getState().setLocal(layout, original);
+    else transcriptDisplayStore.getState().clearLocal(layout);
   }
 }
 
@@ -1339,10 +1388,12 @@ declare global {
     measure: typeof measure;
     dump: typeof dump;
     inspectDetail: typeof inspectDetail;
+    inspectChatFocus: typeof inspectChatFocus;
     settled: Promise<true>;
   }
 }
 window.measure = measure;
 window.dump = dump;
 window.inspectDetail = inspectDetail;
+window.inspectChatFocus = inspectChatFocus;
 window.settled = settled;

--- a/cmd/evener-hub/frontend/src/panes/session/Session.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/Session.test.tsx
@@ -307,10 +307,10 @@ test("shows the thread's live name once hydrated, not the raw ref", async () => 
   await waitFor(() => expect(screen.getByText("My session")).toBeTruthy());
 });
 
-test("keeps the live Detail control reachable above the transcript", async () => {
+test("omits the old live Detail toolbar while transcript and older-history content remain reachable", async () => {
   const fake = connectFakeClient();
-  fake.on("thread/read", () =>
-    readResponse("ref_a", {
+  fake.on("thread/read", () => ({
+    ...readResponse("ref_a", {
       turns: [
         {
           id: "turn_1",
@@ -320,8 +320,8 @@ test("keeps the live Detail control reachable above the transcript", async () =>
         },
       ],
     }),
-  );
-  const user = userEvent.setup();
+    olderCursor: "cursor_1",
+  }));
 
   render(
     <ClientProvider client={fake}>
@@ -329,12 +329,9 @@ test("keeps the live Detail control reachable above the transcript", async () =>
     </ClientProvider>,
   );
 
-  const trigger = await screen.findByRole("button", { name: /^Detail:/ });
-  expect(trigger.closest('[data-testid="transcript-virtual-list"]')).toBeNull();
-  await user.click(trigger);
-  expect(screen.getByRole("radio", { name: "Tools" })).toBeTruthy();
-  await user.click(screen.getByRole("button", { name: "Edit hub defaults" }));
-  expect(window.location.pathname).toBe("/settings/transcript");
+  expect(await screen.findByText("hello")).toBeTruthy();
+  expect(screen.getByTestId("load-older-row").textContent).not.toBe("");
+  expect(screen.queryByRole("button", { name: /^Detail:/ })).toBeNull();
   transcriptDisplayStore.setState({ viewport: "desktop" });
   transcriptDisplayStore.getState().setLocal("desktop", makeTranscriptDisplayConfig({ kind: "preset", level: "full" }));
   await waitFor(() =>

--- a/cmd/evener-hub/frontend/src/panes/session/Session.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/Session.tsx
@@ -54,7 +54,6 @@ import {
   transcriptRowsForProjection,
   transcriptSourceTurnRowIndexesForRows,
 } from "./transcript/TranscriptBody";
-import { TranscriptDetailControl } from "./transcript/TranscriptDetailControl";
 import { SandboxEscalationRail } from "./transcript/tools/sandboxEscalation";
 import { isDormantTranscript } from "./transcript/transcriptVisibility";
 import { useTranscript } from "./transcript/useTranscript";
@@ -189,7 +188,6 @@ export default function Session({ params, paneId, focused: paneFocused }: PanePr
   // here, even though the ref only ever populates once turns.length > 0
   // (see useTranscriptScroll's own "hasContent" handling for that).
   const virtualListRef = useRef<VirtualListHandle>(null);
-  const detailTriggerRef = useRef<HTMLButtonElement>(null);
   const announcementSequence = useRef(0);
   const [viewAnnouncement, setViewAnnouncement] = useState({ text: "", key: 0 });
   // SelectionQuote's own positioning/containment context (its header
@@ -290,17 +288,6 @@ export default function Session({ params, paneId, focused: paneFocused }: PanePr
         disclosureScope={`transcript:live:${ref}`}
         sessionRef={ref}
         viewId={paneId}
-        detailTriggerRef={detailTriggerRef}
-        toolbar={
-          <TranscriptDetailControl
-            layout={displayViewport}
-            triggerRef={detailTriggerRef}
-            onEditHubDefaults={() => {
-              const url = paneToURL("settings", { section: "transcript" });
-              if (url !== null) navigate(url);
-            }}
-          />
-        }
         onAnnounceViewChange={(summary) => {
           announcementSequence.current += 1;
           setViewAnnouncement({ text: `Transcript detail: ${summary}`, key: announcementSequence.current });

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.test.tsx
@@ -19,6 +19,8 @@ import { connectionStore } from "../../../stores/connection";
 import { navigationStore, resetNavigationStoreForTests } from "../../../stores/navigation/store";
 import { keyID } from "../../../stores/navigation/types";
 import { resetThreadsStoreForTests, threadsStore } from "../../../stores/threads";
+import { resetTranscriptDisplayStoreForTests, transcriptDisplayStore } from "../../../stores/transcriptDisplay";
+import { makeTranscriptDisplayConfig } from "../../../transcriptDisplay/config";
 import "../../sessionPanels";
 import { ActivityPanelBody } from "./ActivityPanel";
 import { resetGoalOverridesForTests } from "./GoalControl";
@@ -155,6 +157,7 @@ beforeEach(() => {
   resetActivitySummaryStoreForTests();
   resetGoalOverridesForTests();
   resetNavigationStoreForTests();
+  resetTranscriptDisplayStoreForTests();
 });
 
 afterEach(() => {
@@ -169,6 +172,7 @@ afterEach(() => {
   // test. Under isolate:false that is what a later file's own
   // connectionStore.connect() re-triggers via rewireClient.
   resetThreadsStoreForTests();
+  resetTranscriptDisplayStoreForTests();
 });
 
 function installMobileViewport(): () => void {
@@ -306,6 +310,84 @@ test("status row has no inline Details/Tasks/Activity buttons; they live in the 
   expect(screen.getByRole("menuitem", { name: "Details" })).toBeTruthy();
   expect(screen.getByRole("menuitem", { name: /Tasks/ })).toBeTruthy();
   expect(screen.getByRole("menuitem", { name: /Activity/ })).toBeTruthy();
+});
+
+test("desktop Session actions opens the full Verbosity Dialog, persists selection, and restores trigger focus", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  fake.on("thread/read", () => readResponse("ref_verbosity"));
+  await threadsStore.getState().ensureThread("ref_verbosity");
+
+  render(<SessionChrome ref="ref_verbosity" />);
+
+  const actions = screen.getByRole("button", { name: "Session actions" });
+  await user.click(actions);
+  await user.click(screen.getByRole("menuitem", { name: "Verbosity…" }));
+
+  const dialog = screen.getByRole("dialog", { name: "Verbosity" });
+  expect(dialog.getAttribute("aria-modal")).toBe("true");
+  expect(
+    within(dialog)
+      .getAllByRole("radio")
+      .map((radio) => radio.textContent),
+  ).toEqual(["Chat", "Intent", "Tools", "Activity", "Full", "Custom"]);
+  const activity = within(dialog).getByRole("radio", { name: "Activity" });
+  await user.click(activity);
+  expect(transcriptDisplayStore.getState().local.desktop).toEqual(
+    makeTranscriptDisplayConfig({ kind: "preset", level: "activity" }),
+  );
+  expect(document.activeElement).toBe(activity);
+
+  await user.keyboard("{Escape}");
+  expect(screen.queryByRole("dialog", { name: "Verbosity" })).toBeNull();
+  expect(document.activeElement).toBe(actions);
+
+  await user.click(actions);
+  await user.click(screen.getByRole("menuitem", { name: "Verbosity…" }));
+  await user.click(screen.getByRole("button", { name: "Close" }));
+  expect(screen.queryByRole("dialog", { name: "Verbosity" })).toBeNull();
+  expect(document.activeElement).toBe(actions);
+});
+
+test("desktop Verbosity keeps Edit hub defaults wired to Settings Transcript", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  fake.on("thread/read", () => readResponse("ref_verbosity_settings"));
+  await threadsStore.getState().ensureThread("ref_verbosity_settings");
+  window.history.replaceState({}, "", "/");
+
+  render(<SessionChrome ref="ref_verbosity_settings" />);
+  await user.click(screen.getByRole("button", { name: "Session actions" }));
+  await user.click(screen.getByRole("menuitem", { name: "Verbosity…" }));
+  await user.click(screen.getByRole("button", { name: "Edit hub defaults" }));
+
+  expect(window.location.pathname).toBe("/settings/transcript");
+});
+
+test("mobile Session actions opens the full Verbosity bottom Sheet", async () => {
+  const restoreViewport = installMobileViewport();
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  fake.on("thread/read", () => readResponse("ref_verbosity_mobile"));
+  await threadsStore.getState().ensureThread("ref_verbosity_mobile");
+
+  try {
+    render(<SessionChrome ref="ref_verbosity_mobile" />);
+    const actions = screen.getByRole("button", { name: "Session actions" });
+    await user.click(actions);
+    await user.click(screen.getByRole("menuitem", { name: "Verbosity…" }));
+
+    const sheet = screen.getByRole("dialog", { name: "Verbosity" });
+    expect(sheet.className).toContain("bottom");
+    expect(within(sheet).getAllByRole("radio")).toHaveLength(6);
+    expect(within(sheet).getByText(/^Customize & advanced/)).toBeTruthy();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog", { name: "Verbosity" })).toBeNull();
+    expect(document.activeElement).toBe(actions);
+  } finally {
+    restoreViewport();
+  }
 });
 
 test("menu Tasks item toggles the sessionTasks workspace pane on desktop", async () => {

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.tsx
@@ -9,10 +9,11 @@
 // (mirrors Session.tsx's own model lookup).
 //
 // The menu is the shared SessionMenu (2026-08-05-unified-session-context-
-// menu-design): Details/Tasks/Activity lead it at every width (there are no
-// inline triggers and no narrow-collapse - the status row's container-query
-// variants own compression inside .body instead), followed by Rename, the
-// tree-gated Pin/Archive/Delete organization group, and Shut down. The three
+// menu-design): Details/Tasks/Activity and pane-only Verbosity lead it at every
+// width (there are no inline triggers and no narrow-collapse - the status
+// row's container-query variants own compression inside .body instead),
+// followed by Rename, the tree-gated Pin/Archive/Delete organization group,
+// and Shut down. The three
 // panels stay mounted triggerless so their imperative handles still open the
 // mobile Sheets; ActivityPanel's refreshWhenHidden is unconditional because
 // the menu's "Activity · N" label reads the summary that refresh maintains.

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.tsx
@@ -21,12 +21,13 @@
 // composer is where you act on this session"; the command palette only
 // hands off to it - design-system.md §9) - so GoalControl below is the
 // goal chip + clear popover only.
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { sessionActionError } from "../../../protocol/errors";
 import type { NavigationSessionLocation } from "../../../protocol/types.gen";
 import { useClient } from "../../../shell/clientContext";
 import { closePanesForDeletedSessions } from "../../../shell/deletedSessionPanes";
 import { assignSessionPin, deleteSession, setArchived, unpinSession } from "../../../shell/rail/actions";
+import { navigate, paneToURL } from "../../../shell/routing";
 import { SessionMenu } from "../../../shell/sessionMenu/SessionMenu";
 import { useIsMobile } from "../../../shell/useIsMobile";
 import { isPaneOpen, useWorkspaceStore, workspaceStore } from "../../../shell/workspace";
@@ -39,6 +40,7 @@ import { Cadence, useToasts } from "../../../widgets";
 import { requireClass } from "../../../widgets/internal/requireClass";
 import { cadenceStateForStatus, NOW_TICK_MS, useNowTick } from "../liveness";
 import { navigationSummaryFor } from "../threadTitle";
+import { TranscriptDetailControl } from "../transcript/TranscriptDetailControl";
 import { ActivityPanel, type ActivityPanelHandle } from "./ActivityPanel";
 import { DetailsPanel, type DetailsPanelHandle } from "./DetailsPanel";
 import { GoalControl } from "./GoalControl";
@@ -71,6 +73,7 @@ export function SessionChrome({ ref: sessionRef, placement = "footer" }: Session
   const client = useClient();
   const model = useThreadsStore((s) => s.threads.get(sessionRef));
   const isMobile = useIsMobile();
+  const [verbosityOpen, setVerbosityOpen] = useState(false);
   const toasts = useToasts();
   const detailsOpen = useWorkspaceStore((s) => isPaneOpen(s, "sessionDetails", { ref: sessionRef }));
   const tasksOpen = useWorkspaceStore((s) => isPaneOpen(s, "sessionTasks", { ref: sessionRef }));
@@ -140,144 +143,156 @@ export function SessionChrome({ ref: sessionRef, placement = "footer" }: Session
   const activityLabel = activitySummary?.counts?.complete ? `Activity · ${activitySummary.counts.active}` : "Activity";
 
   return (
-    <div
-      className={placement === "composer" ? CLASS.inline : CLASS.chrome}
-      data-testid={placement === "composer" ? "session-chrome-inline" : "session-chrome"}
-    >
-      {placement === "composer" ? (
-        <div className={CLASS.body} data-testid="session-chrome-inline-status">
-          <StatusRow sessionRef={sessionRef} model={model} now={now} />
-          {/* Production mounts ONLY this placement (Composer.tsx), so the
+    <>
+      <div
+        className={placement === "composer" ? CLASS.inline : CLASS.chrome}
+        data-testid={placement === "composer" ? "session-chrome-inline" : "session-chrome"}
+      >
+        {placement === "composer" ? (
+          <div className={CLASS.body} data-testid="session-chrome-inline-status">
+            <StatusRow sessionRef={sessionRef} model={model} now={now} />
+            {/* Production mounts ONLY this placement (Composer.tsx), so the
               goal chip must ride here too — footer-only left it unreachable
               in the real app. */}
-          <GoalControl sessionRef={sessionRef} model={model} />
-        </div>
-      ) : (
-        /* .body owns compression (sessionchrome.module.css says why): its
+            <GoalControl sessionRef={sessionRef} model={model} />
+          </div>
+        ) : (
+          /* .body owns compression (sessionchrome.module.css says why): its
            inline-size container progressively simplifies status content, so
            .right - and with it the "..." menu - always shares this one line. */
-        <div className={CLASS.body} data-testid="session-chrome-body">
-          <span className={CLASS.cadenceSlot} data-testid="session-chrome-cadence">
-            <Cadence state={cadenceStateForStatus(model.status.type)} frameTimes={frameTimes} now={now} />
-          </span>
-          <StatusRow sessionRef={sessionRef} model={model} now={now} />
-          <GoalControl sessionRef={sessionRef} model={model} />
+          <div className={CLASS.body} data-testid="session-chrome-body">
+            <span className={CLASS.cadenceSlot} data-testid="session-chrome-cadence">
+              <Cadence state={cadenceStateForStatus(model.status.type)} frameTimes={frameTimes} now={now} />
+            </span>
+            <StatusRow sessionRef={sessionRef} model={model} now={now} />
+            <GoalControl sessionRef={sessionRef} model={model} />
+          </div>
+        )}
+        <div className={CLASS.right}>
+          <DetailsPanel ref={detailsRef} model={model} now={now} hideTrigger />
+          <TasksPanel ref={tasksRef} sessionRef={sessionRef} model={model} hideTrigger />
+          <ActivityPanel
+            ref={activityRef}
+            sessionRef={sessionRef}
+            model={model}
+            now={now}
+            hideTrigger
+            refreshWhenHidden
+          />
+          <SessionMenu
+            sessionRef={sessionRef}
+            title={model.name}
+            triggerLabel="Session actions"
+            canRename={model.capabilities.rename}
+            canShutdown={model.capabilities.shutdown}
+            session={menuSession}
+            panesOpen={{ details: detailsOpen, tasks: tasksOpen, activity: activityOpen }}
+            taskLabel={model.tasks ? `Tasks ${model.tasks.done}/${model.tasks.total}` : undefined}
+            activityLabel={activityLabel}
+            onOpenVerbosity={() => setVerbosityOpen(true)}
+            actions={{
+              onOpenPane: (pane) => {
+                if (pane === "details") openDetails();
+                else if (pane === "tasks") openTasks();
+                else openActivity();
+              },
+              // Failure convention (SessionMenu.tsx's header comment): the
+              // ADAPTER toasts with sessionActionError and rethrows, so a
+              // rejected action leaves SessionMenu's dialog open with its
+              // confirm button re-enabled; only success closes it.
+              onRename: async (name) => {
+                try {
+                  await threadsStore.getState().rename(sessionRef, name);
+                } catch (err) {
+                  toasts.push("error", sessionActionError("Couldn't rename session", err));
+                  throw err;
+                }
+              },
+              onShutdown: async () => {
+                const invalidation =
+                  navigation.mode === "v1"
+                    ? navigationStore
+                        .getState()
+                        .awaitNavigationInvalidation((payload) =>
+                          payload.targets.some(
+                            (target) =>
+                              target.kind === "all_loaded_projects" ||
+                              (target.kind === "section" &&
+                                (target.section === "live" || target.section === "needs_you")) ||
+                              (target.kind === "pin_section" && target.sectionId === menuSession?.pin_section_id) ||
+                              (target.kind === "project" && target.projectKey === location?.project_key),
+                          ),
+                        )
+                    : null;
+                void invalidation?.promise.catch(() => undefined);
+                try {
+                  await threadsStore.getState().shutdown(sessionRef);
+                  if (invalidation) {
+                    const payload = await invalidation.promise;
+                    await navigationStore.getState().awaitNavigationTargets(payload.targets, payload.generationId);
+                  }
+                } catch (err) {
+                  invalidation?.cancel();
+                  toasts.push("error", sessionActionError("Couldn't shut down session", err));
+                  throw err;
+                }
+              },
+              onPin: async (target) => {
+                try {
+                  const result = await assignSessionPin(client, sessionRef, target);
+                  navigationStore.getState().trackPinSection(result.assignment.section.id);
+                  if (result.navigation) await navigationStore.getState().applyNavigationMutation(result.navigation);
+                } catch (err) {
+                  toasts.push("error", sessionActionError("Couldn't assign pinned session", err));
+                  throw err;
+                }
+              },
+              onUnpin: async () => {
+                try {
+                  const result = await unpinSession(client, sessionRef);
+                  if (result.navigation) await navigationStore.getState().applyNavigationMutation(result.navigation);
+                } catch (err) {
+                  toasts.push("error", sessionActionError("Couldn't unpin session", err));
+                  throw err;
+                }
+              },
+              onToggleArchive: async () => {
+                if (!menuSession) return;
+                try {
+                  const result = await setArchived("session", menuSession.session_id, menuSession.tier !== "archived");
+                  if (result.navigation) await navigationStore.getState().applyNavigationMutation(result.navigation);
+                } catch (err) {
+                  toasts.push("error", sessionActionError("Couldn't update archive state", err));
+                  throw err;
+                }
+              },
+              onDelete: async () => {
+                try {
+                  const result = await deleteSession(client, sessionRef);
+                  if (result.navigation) await navigationStore.getState().applyNavigationMutation(result.navigation);
+                  closePanesForDeletedSessions(result.deleted);
+                  if (result.skipped.length > 0) {
+                    const reason = result.skipped[0]?.reason ?? "still in use";
+                    toasts.push("warning", `Couldn't delete "${model.name}": ${reason}`);
+                  }
+                } catch (err) {
+                  toasts.push("error", sessionActionError(`Couldn't delete "${model.name}"`, err));
+                  throw err;
+                }
+              },
+            }}
+          />
         </div>
-      )}
-      <div className={CLASS.right}>
-        <DetailsPanel ref={detailsRef} model={model} now={now} hideTrigger />
-        <TasksPanel ref={tasksRef} sessionRef={sessionRef} model={model} hideTrigger />
-        <ActivityPanel
-          ref={activityRef}
-          sessionRef={sessionRef}
-          model={model}
-          now={now}
-          hideTrigger
-          refreshWhenHidden
-        />
-        <SessionMenu
-          sessionRef={sessionRef}
-          title={model.name}
-          triggerLabel="Session actions"
-          canRename={model.capabilities.rename}
-          canShutdown={model.capabilities.shutdown}
-          session={menuSession}
-          panesOpen={{ details: detailsOpen, tasks: tasksOpen, activity: activityOpen }}
-          taskLabel={model.tasks ? `Tasks ${model.tasks.done}/${model.tasks.total}` : undefined}
-          activityLabel={activityLabel}
-          actions={{
-            onOpenPane: (pane) => {
-              if (pane === "details") openDetails();
-              else if (pane === "tasks") openTasks();
-              else openActivity();
-            },
-            // Failure convention (SessionMenu.tsx's header comment): the
-            // ADAPTER toasts with sessionActionError and rethrows, so a
-            // rejected action leaves SessionMenu's dialog open with its
-            // confirm button re-enabled; only success closes it.
-            onRename: async (name) => {
-              try {
-                await threadsStore.getState().rename(sessionRef, name);
-              } catch (err) {
-                toasts.push("error", sessionActionError("Couldn't rename session", err));
-                throw err;
-              }
-            },
-            onShutdown: async () => {
-              const invalidation =
-                navigation.mode === "v1"
-                  ? navigationStore
-                      .getState()
-                      .awaitNavigationInvalidation((payload) =>
-                        payload.targets.some(
-                          (target) =>
-                            target.kind === "all_loaded_projects" ||
-                            (target.kind === "section" &&
-                              (target.section === "live" || target.section === "needs_you")) ||
-                            (target.kind === "pin_section" && target.sectionId === menuSession?.pin_section_id) ||
-                            (target.kind === "project" && target.projectKey === location?.project_key),
-                        ),
-                      )
-                  : null;
-              void invalidation?.promise.catch(() => undefined);
-              try {
-                await threadsStore.getState().shutdown(sessionRef);
-                if (invalidation) {
-                  const payload = await invalidation.promise;
-                  await navigationStore.getState().awaitNavigationTargets(payload.targets, payload.generationId);
-                }
-              } catch (err) {
-                invalidation?.cancel();
-                toasts.push("error", sessionActionError("Couldn't shut down session", err));
-                throw err;
-              }
-            },
-            onPin: async (target) => {
-              try {
-                const result = await assignSessionPin(client, sessionRef, target);
-                navigationStore.getState().trackPinSection(result.assignment.section.id);
-                if (result.navigation) await navigationStore.getState().applyNavigationMutation(result.navigation);
-              } catch (err) {
-                toasts.push("error", sessionActionError("Couldn't assign pinned session", err));
-                throw err;
-              }
-            },
-            onUnpin: async () => {
-              try {
-                const result = await unpinSession(client, sessionRef);
-                if (result.navigation) await navigationStore.getState().applyNavigationMutation(result.navigation);
-              } catch (err) {
-                toasts.push("error", sessionActionError("Couldn't unpin session", err));
-                throw err;
-              }
-            },
-            onToggleArchive: async () => {
-              if (!menuSession) return;
-              try {
-                const result = await setArchived("session", menuSession.session_id, menuSession.tier !== "archived");
-                if (result.navigation) await navigationStore.getState().applyNavigationMutation(result.navigation);
-              } catch (err) {
-                toasts.push("error", sessionActionError("Couldn't update archive state", err));
-                throw err;
-              }
-            },
-            onDelete: async () => {
-              try {
-                const result = await deleteSession(client, sessionRef);
-                if (result.navigation) await navigationStore.getState().applyNavigationMutation(result.navigation);
-                closePanesForDeletedSessions(result.deleted);
-                if (result.skipped.length > 0) {
-                  const reason = result.skipped[0]?.reason ?? "still in use";
-                  toasts.push("warning", `Couldn't delete "${model.name}": ${reason}`);
-                }
-              } catch (err) {
-                toasts.push("error", sessionActionError(`Couldn't delete "${model.name}"`, err));
-                throw err;
-              }
-            },
-          }}
-        />
       </div>
-    </div>
+      <TranscriptDetailControl
+        open={verbosityOpen}
+        onClose={() => setVerbosityOpen(false)}
+        layout={isMobile ? "mobile" : "desktop"}
+        onEditHubDefaults={() => {
+          const url = paneToURL("settings", { section: "transcript" });
+          if (url !== null) navigate(url);
+        }}
+      />
+    </>
   );
 }

--- a/cmd/evener-hub/frontend/src/panes/session/session.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/session.module.css
@@ -58,6 +58,9 @@
 }
 
 .intent {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
   padding: 0 var(--space-3);
   color: var(--ink-mid);
   font-family: var(--font-sans);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.test.tsx
@@ -1,12 +1,18 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createRef, useState } from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { ItemModel, ThreadModel } from "../../../protocol/model";
 import { FakeClient } from "../../../protocol/testing/fakeClient";
 import { threadsStore } from "../../../stores/threads";
 import { makeTranscriptDisplayConfig } from "../../../transcriptDisplay/config";
 import { createTranscriptRenderContext, TranscriptRenderProvider } from "../../../transcriptDisplay/renderContext";
+import type { VirtualListHandle } from "../../../widgets";
 import { resetDisclosureStoreForTests } from "../../../widgets/disclosure/disclosureStore";
-import { captureTranscriptViews, resetTranscriptViewRegistryForTests } from "./flow/transcriptViewRegistry";
+import {
+  captureTranscriptViews,
+  resetTranscriptViewRegistryForTests,
+  transitionTranscriptViews,
+} from "./flow/transcriptViewRegistry";
 import { ToolCallCluster } from "./ToolCallCluster";
 import { TranscriptBody } from "./TranscriptBody";
 import { threadFingerprintForItem } from "./types";
@@ -356,6 +362,46 @@ describe("TranscriptBody", () => {
     expect(captureTranscriptViews().size).toBe(0);
   });
 
+  test("focuses the stable transcript region when a view change removes the focused row", async () => {
+    const announce = vi.fn();
+    const listRef = createRef<VirtualListHandle>();
+    let showChat: () => void = () => {
+      throw new Error("focus harness did not mount");
+    };
+    function FocusHarness() {
+      const [config, setConfig] = useState(preset("tools"));
+      showChat = () => setConfig(preset("chat"));
+      return (
+        <TranscriptBody
+          model={fixture}
+          config={config}
+          surface="live"
+          disclosureScope="live:focus-fallback"
+          viewId="focus-fallback"
+          listRef={listRef}
+          onAnnounceViewChange={announce}
+        />
+      );
+    }
+    render(<FocusHarness />);
+    const tool = await screen.findByTestId("tool-row-trigger");
+    tool.focus();
+    expect(document.activeElement).toBe(tool);
+    expect(document.querySelector('[data-view-anchor-id="tool_1"]')?.contains(tool)).toBe(true);
+    const capturedViews = captureTranscriptViews();
+    expect([...capturedViews.keys()]).toEqual(["focus-fallback"]);
+    expect(capturedViews.get("focus-fallback")?.focusedEntryId).toBe("tool_1");
+
+    act(() => {
+      transitionTranscriptViews(showChat, "Chat", {
+        fingerprint: "chat",
+      });
+    });
+
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole("region", { name: "Transcript" })));
+    expect(announce).toHaveBeenCalledWith("Chat");
+  });
+
   test("uses normal page flow for preview without an inner virtual scroller", () => {
     render(
       <TranscriptBody model={fixture} config={preset("tools")} surface="preview" disclosureScope="preview:test" />,
@@ -535,36 +581,6 @@ describe("TranscriptBody", () => {
       />,
     );
     expect(firstToolExpanded()).toBe("false");
-  });
-
-  test.each(["live", "readOnly"] as const)("places the detail toolbar above the %s scroller", (surface) => {
-    render(
-      <TranscriptBody
-        model={fixture}
-        config={preset("tools")}
-        surface={surface}
-        disclosureScope={`${surface}:toolbar`}
-        toolbar={<button type="button">Detail: Tools</button>}
-      />,
-    );
-
-    const toolbar = screen.getByRole("button", { name: "Detail: Tools" });
-    const scroller = screen.getByTestId("transcript-virtual-list");
-    expect(toolbar.compareDocumentPosition(scroller) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-  });
-
-  test("does not render a toolbar on the preview surface", () => {
-    render(
-      <TranscriptBody
-        model={fixture}
-        config={preset("tools")}
-        surface="preview"
-        disclosureScope="preview:toolbar"
-        toolbar={<button type="button">Detail: Tools</button>}
-      />,
-    );
-
-    expect(screen.queryByRole("button", { name: "Detail: Tools" })).toBeNull();
   });
 
   test("Tools/Full previews mount item and cluster renderers without threadsStore or RPC access", () => {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.test.tsx
@@ -362,7 +362,7 @@ describe("TranscriptBody", () => {
     expect(captureTranscriptViews().size).toBe(0);
   });
 
-  test("focuses the stable transcript region when a view change removes the focused row", async () => {
+  test("moves focus from a Tools row to its Chat intent proxy", async () => {
     const announce = vi.fn();
     const listRef = createRef<VirtualListHandle>();
     let showChat: () => void = () => {
@@ -398,8 +398,59 @@ describe("TranscriptBody", () => {
       });
     });
 
-    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole("region", { name: "Transcript" })));
+    const group = await screen.findByTestId("intent-group");
+    const summary = group.querySelector(":scope > summary");
+    if (!(summary instanceof HTMLElement)) throw new Error("Chat intent group summary did not render");
+    await waitFor(() => expect(document.activeElement).toBe(summary));
+    expect(group.hasAttribute("open")).toBe(false);
     expect(announce).toHaveBeenCalledWith("Chat");
+  });
+
+  test("focuses the Transcript region when a view change removes the focused row", async () => {
+    const announce = vi.fn();
+    const listRef = createRef<VirtualListHandle>();
+    const hiddenTools = makeTranscriptDisplayConfig({
+      kind: "custom",
+      toolIntent: false,
+      toolCalls: false,
+      reasoning: false,
+      expandByDefault: false,
+    });
+    let hideTools: () => void = () => {
+      throw new Error("focus fallback harness did not mount");
+    };
+    function FocusFallbackHarness() {
+      const [config, setConfig] = useState(preset("tools"));
+      hideTools = () => setConfig(hiddenTools);
+      return (
+        <TranscriptBody
+          model={fixture}
+          config={config}
+          surface="live"
+          disclosureScope="live:focus-region-fallback"
+          viewId="focus-region-fallback"
+          listRef={listRef}
+          onAnnounceViewChange={announce}
+        />
+      );
+    }
+    render(<FocusFallbackHarness />);
+    const tool = await screen.findByTestId("tool-row-trigger");
+    tool.focus();
+    expect(document.activeElement).toBe(tool);
+    expect(captureTranscriptViews().get("focus-region-fallback")?.focusedEntryId).toBe("tool_1");
+
+    act(() => {
+      transitionTranscriptViews(hideTools, "Custom content", {
+        fingerprint: "custom-without-tools",
+      });
+    });
+
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole("region", { name: "Transcript" })));
+    expect(document.body.contains(tool)).toBe(false);
+    expect(screen.queryByTestId("tool-call-item")).toBeNull();
+    expect(screen.queryByTestId("intent-group")).toBeNull();
+    expect(announce).toHaveBeenCalledWith("Custom content");
   });
 
   test("uses normal page flow for preview without an inner virtual scroller", () => {
@@ -687,12 +738,12 @@ describe("TranscriptBody", () => {
     );
     const crossGroup = screen.getAllByTestId("intent-group").at(-1);
     if (crossGroup === undefined) throw new Error("cross-turn intent group did not render");
-    expect(crossGroup?.getAttribute("data-transcript-row-id")).toBe("intent-group:intent:tool_a:intent:tool_c");
-    expect(crossGroup?.hasAttribute("open")).toBe(false);
+    expect(crossGroup?.getAttribute("data-transcript-row-id")).toBe("intent-group:intent:tool_a");
+    expect(crossGroup?.hasAttribute("open")).toBe(true);
     const crossSummary = crossGroup.querySelector("summary");
     if (crossSummary === null) throw new Error("cross-turn intent summary did not render");
     fireEvent.click(crossSummary);
-    expect(crossGroup?.hasAttribute("open")).toBe(true);
+    expect(crossGroup?.hasAttribute("open")).toBe(false);
     expect(single.hasAttribute("open")).toBe(true);
   });
 
@@ -714,9 +765,7 @@ describe("TranscriptBody", () => {
     expect(group[0]?.textContent).toContain("Three");
     expect(screen.queryAllByTestId("tool-call-item")).toHaveLength(0);
     expect(screen.getAllByTestId("transcript-row")).toHaveLength(2);
-    expect(screen.getAllByTestId("transcript-row")[0]?.getAttribute("data-row-id")).toBe(
-      "intent-group:intent:tool_a:intent:tool_c",
-    );
+    expect(screen.getAllByTestId("transcript-row")[0]?.getAttribute("data-row-id")).toBe("intent-group:intent:tool_a");
     expect(
       document.querySelector('[data-view-anchor-id="intent:tool_b"]')?.getAttribute("data-view-anchor-turn-id"),
     ).toBe("turn_b");
@@ -731,6 +780,230 @@ describe("TranscriptBody", () => {
       />,
     );
     expect(screen.getAllByTestId("transcript-row").map((row) => row.getAttribute("data-row-id"))).toEqual(rowIds);
+  });
+
+  test("a growing cross-turn group keeps its first-action row identity and manually closed state (catches last-id row key)", () => {
+    const config = makeTranscriptDisplayConfig({
+      kind: "custom",
+      toolIntent: true,
+      toolCalls: false,
+      reasoning: false,
+      expandByDefault: true,
+    });
+    const initial = { ...crossTurnFixture, turns: crossTurnFixture.turns.slice(0, 2) } as ThreadModel;
+    const finalTurn = crossTurnFixture.turns[2];
+    if (finalTurn === undefined || finalTurn.items[0] === undefined)
+      throw new Error("cross-turn stream fixture is incomplete");
+    const streamed = {
+      ...crossTurnFixture,
+      turns: [...initial.turns, { ...finalTurn, items: [finalTurn.items[0]] }],
+    } as ThreadModel;
+    const { rerender } = render(
+      <TranscriptBody model={initial} config={config} surface="preview" disclosureScope="preview:cross-stream" />,
+    );
+    const row = screen.getByTestId("transcript-row");
+    const rowId = row.getAttribute("data-row-id");
+    const group = screen.getByTestId("intent-group");
+    const summary = group.querySelector("summary");
+    if (summary === null) throw new Error("cross-turn streaming summary did not render");
+    expect(group.hasAttribute("open")).toBe(true);
+    fireEvent.click(summary);
+    expect(group.hasAttribute("open")).toBe(false);
+
+    rerender(
+      <TranscriptBody model={streamed} config={config} surface="preview" disclosureScope="preview:cross-stream" />,
+    );
+
+    expect(screen.getByTestId("transcript-row")).toBe(row);
+    expect(row.getAttribute("data-row-id")).toBe(rowId);
+    expect(screen.getByTestId("intent-group")).toBe(group);
+    expect(group.textContent).toContain("3 actions");
+    expect(group.hasAttribute("open")).toBe(false);
+  });
+
+  test("a terminal one-turn intent row extends across a streamed second turn without remounting", () => {
+    const initialTurn = crossTurnFixture.turns[0];
+    const streamedTurn = crossTurnFixture.turns[1];
+    if (initialTurn === undefined || streamedTurn === undefined) throw new Error("streaming fixture is incomplete");
+    const initial = { ...crossTurnFixture, turns: [{ ...initialTurn, durationMs: 1500 }] } as ThreadModel;
+    const streamed = {
+      ...crossTurnFixture,
+      turns: [
+        { ...initialTurn, durationMs: 1500 },
+        { ...streamedTurn, durationMs: 2500 },
+      ],
+    } as ThreadModel;
+    const config = makeTranscriptDisplayConfig({ kind: "preset", level: "chat" }, { roundTimings: true });
+    const { rerender } = render(
+      <TranscriptBody
+        model={initial}
+        config={config}
+        surface="live"
+        disclosureScope="live:one-to-two-turns"
+        showSeenDividerTurnId="turn_a"
+      />,
+    );
+    const row = screen.getByTestId("transcript-row");
+    const group = screen.getByTestId("intent-group");
+    const divider = screen.getByTestId("seen-divider");
+    const separator = screen.getByTestId("turn-separator");
+    const firstAnchor = document.querySelector('[data-view-anchor-id="intent:tool_a"]');
+    if (!(firstAnchor instanceof HTMLElement)) throw new Error("first streaming intent anchor did not render");
+    const summary = group.querySelector(":scope > summary");
+    if (!(summary instanceof HTMLElement)) throw new Error("one-turn intent summary did not render");
+    expect(row.getAttribute("data-row-id")).toBe("intent-group:intent:tool_a");
+    expect(divider.compareDocumentPosition(group) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+    expect(group.compareDocumentPosition(separator) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+    expect(separator.textContent).toContain("1.5s");
+    expect(firstAnchor.getAttribute("data-view-anchor-source-index")).toBe("0");
+    expect(group.hasAttribute("open")).toBe(false);
+    fireEvent.click(summary);
+    expect(group.hasAttribute("open")).toBe(true);
+
+    rerender(
+      <TranscriptBody
+        model={streamed}
+        config={config}
+        surface="live"
+        disclosureScope="live:one-to-two-turns"
+        showSeenDividerTurnId="turn_a"
+      />,
+    );
+
+    expect(screen.getByTestId("transcript-row")).toBe(row);
+    expect(row.getAttribute("data-row-id")).toBe("intent-group:intent:tool_a");
+    expect(screen.getByTestId("intent-group")).toBe(group);
+    expect(group.textContent).toContain("2 actions");
+    expect(group.hasAttribute("open")).toBe(true);
+    expect(group.getAttribute("data-transcript-source-turn-ids")).toBe("turn_a,turn_b");
+    expect(screen.getByTestId("seen-divider")).toBe(divider);
+    expect(divider.compareDocumentPosition(group) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+    expect(screen.getByTestId("turn-separator")).toBe(separator);
+    expect(group.compareDocumentPosition(separator) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+    expect(separator.textContent).toContain("2.5s");
+    expect(document.querySelector('[data-view-anchor-id="intent:tool_a"]')).toBe(firstAnchor);
+    expect(firstAnchor.getAttribute("data-view-anchor-source-index")).toBe("0");
+    expect(
+      document.querySelector('[data-view-anchor-id="intent:tool_b"]')?.getAttribute("data-view-anchor-source-index"),
+    ).toBe("1");
+  });
+
+  test("an actions-only failed turn renders one end cap after its terminal intent group", () => {
+    const failed = {
+      ...fixture,
+      turns: [
+        {
+          id: "failed_actions_only",
+          status: "failed",
+          error: { message: "Actions-only turn failed" },
+          items: [
+            {
+              id: "failed_action",
+              turnId: "failed_actions_only",
+              type: "commandExecution",
+              toolName: "shell",
+              description: "Run the failing action",
+              status: "completed",
+            },
+          ],
+        },
+      ],
+    } as unknown as ThreadModel;
+    render(
+      <TranscriptBody model={failed} config={preset("chat")} surface="preview" disclosureScope="failure:actions" />,
+    );
+
+    const group = screen.getByTestId("intent-group");
+    const failures = screen.getAllByTestId("turn-failure");
+    expect(failures).toHaveLength(1);
+    const failure = failures[0];
+    if (failure === undefined) throw new Error("actions-only failure end cap did not render");
+    expect(group.compareDocumentPosition(failure) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+  });
+
+  test("a failed turn with earlier visible content renders one end cap after its terminal intent group", () => {
+    const failed = {
+      ...fixture,
+      turns: [
+        {
+          id: "failed_with_message",
+          status: "failed",
+          error: { message: "Message turn failed" },
+          items: [
+            {
+              id: "failed_message",
+              turnId: "failed_with_message",
+              type: "agentMessage",
+              text: "Visible before the action",
+              status: "completed",
+            },
+            {
+              id: "failed_after_message",
+              turnId: "failed_with_message",
+              type: "commandExecution",
+              toolName: "shell",
+              description: "Run after the message",
+              status: "completed",
+            },
+          ],
+        },
+      ],
+    } as unknown as ThreadModel;
+    render(
+      <TranscriptBody model={failed} config={preset("chat")} surface="preview" disclosureScope="failure:message" />,
+    );
+
+    const message = screen.getByText("Visible before the action");
+    const group = screen.getByTestId("intent-group");
+    const failures = screen.getAllByTestId("turn-failure");
+    expect(failures).toHaveLength(1);
+    const failure = failures[0];
+    if (failure === undefined) throw new Error("message failure end cap did not render");
+    expect(message.compareDocumentPosition(group) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+    expect(group.compareDocumentPosition(failure) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+  });
+
+  test("a renderable failed-turn end cap is a grouping boundary between adjacent intent runs", () => {
+    const action = (id: string, turnId: string, description: string) => ({
+      id,
+      turnId,
+      type: "commandExecution",
+      toolName: "shell",
+      description,
+      status: "completed",
+    });
+    const failedBoundary = {
+      ...fixture,
+      turns: [
+        { id: "clean_before", status: "completed", items: [action("clean_action", "clean_before", "Before")] },
+        {
+          id: "failed_boundary",
+          status: "failed",
+          error: { message: "Boundary turn failed" },
+          items: [action("boundary_action", "failed_boundary", "Boundary")],
+        },
+        { id: "clean_after", status: "completed", items: [action("after_action", "clean_after", "After")] },
+      ],
+    } as unknown as ThreadModel;
+    render(
+      <TranscriptBody
+        model={failedBoundary}
+        config={preset("chat")}
+        surface="preview"
+        disclosureScope="failure:boundary"
+      />,
+    );
+
+    const groups = screen.getAllByTestId("intent-group");
+    expect(groups).toHaveLength(3);
+    expect(groups.map((group) => group.textContent)).toEqual(["1 actionBefore", "1 actionBoundary", "1 actionAfter"]);
+    const boundaryGroup = groups[1];
+    const afterGroup = groups[2];
+    if (boundaryGroup === undefined || afterGroup === undefined)
+      throw new Error("failure boundary groups did not render");
+    const failure = screen.getByTestId("turn-failure");
+    expect(boundaryGroup.compareDocumentPosition(failure) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+    expect(failure.compareDocumentPosition(afterGroup) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
   });
 
   test("does not merge intents across visible message or critical boundaries", () => {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode, RefObject } from "react";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { useStore } from "zustand";
 import type { ThreadModel } from "../../../protocol/model";
 import { transcriptDisplayStore } from "../../../stores/transcriptDisplay";
@@ -220,12 +220,8 @@ export interface TranscriptBodyProps {
   listRef?: RefObject<VirtualListHandle | null>;
   onMeasurementsChange?: () => void;
   trailingContent?: ReactNode;
-  toolbar?: ReactNode;
   /** Stable pane identity for host-remount scroll state; optional for callers. */
   viewId?: string;
-  /** Optional focus target supplied by the live Detail control. */
-  detailTriggerRef?: RefObject<HTMLElement | null>;
-  onFocusDetailTrigger?: () => void;
   onAnnounceViewChange?: (summary: string) => void;
 }
 
@@ -241,12 +237,10 @@ export function TranscriptBody({
   listRef,
   onMeasurementsChange,
   trailingContent,
-  toolbar,
   viewId,
-  detailTriggerRef,
-  onFocusDetailTrigger,
   onAnnounceViewChange,
 }: TranscriptBodyProps) {
+  const focusFallbackRef = useRef<HTMLElement>(null);
   const projection = useMemo(() => projectThread(model, config), [model, config]);
   const rows = useMemo(() => transcriptRowsForProjection(projection), [projection]);
   const openers = useMemo(() => exchangeOpenersFor(model.turns), [model.turns]);
@@ -280,8 +274,7 @@ export function TranscriptBody({
     listRef,
     anchorEntries: transcriptAnchorEntriesForRows(rows),
     renderedRowCount: rows.length,
-    detailTriggerRef,
-    focusDetailTrigger: onFocusDetailTrigger,
+    focusFallback: () => focusFallbackRef.current?.focus(),
     announce: onAnnounceViewChange,
   });
 
@@ -334,7 +327,13 @@ export function TranscriptBody({
   };
 
   const list = (
-    <div className={styles.transcriptList} data-testid="transcript-virtual-list">
+    <section
+      ref={focusFallbackRef}
+      className={styles.transcriptList}
+      data-testid="transcript-virtual-list"
+      aria-label="Transcript"
+      tabIndex={-1}
+    >
       <VirtualList
         ref={listRef}
         dynamic
@@ -351,7 +350,7 @@ export function TranscriptBody({
           }
         }}
       />
-    </div>
+    </section>
   );
 
   let content: ReactNode;
@@ -369,7 +368,6 @@ export function TranscriptBody({
       transcriptContent = (
         <FlowOverlay top={loadOlderRow} pill={liveOverlay}>
           <div className={styles.transcriptContent}>
-            {toolbar}
             {list}
             {trailingContent}
           </div>
@@ -380,7 +378,6 @@ export function TranscriptBody({
         <>
           {loadOlderRow}
           <div className={styles.transcriptContent}>
-            {toolbar}
             {list}
             {trailingContent}
           </div>

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode, RefObject } from "react";
 import { useMemo, useRef } from "react";
 import { useStore } from "zustand";
-import type { ThreadModel } from "../../../protocol/model";
+import type { ThreadModel, TurnModel } from "../../../protocol/model";
 import { transcriptDisplayStore } from "../../../stores/transcriptDisplay";
 import { configFingerprint, type TranscriptDisplayConfigV1 } from "../../../transcriptDisplay/config";
 import {
@@ -17,6 +17,7 @@ import { exchangeOpenersFor } from "./exchangeOpeners";
 import { FlowOverlay } from "./flow/FlowOverlay";
 import { useTranscriptViewRegistration } from "./flow/useTranscriptScroll";
 import { ProjectedIntentGroup, TurnBlock } from "./TurnBlock";
+import { asTurnError } from "./turnFailure";
 import "./messages";
 import "./tools";
 import styles from "../session.module.css";
@@ -38,6 +39,7 @@ export interface TranscriptIntentGroupRow {
   readonly entries: readonly IntentEntry[];
   readonly sourceTurnIndexes: readonly number[];
   readonly sourceTurnIds: readonly string[];
+  readonly separatorTurn?: TurnModel;
 }
 
 export type TranscriptBodyRow = TranscriptTurnRow | TranscriptIntentGroupRow;
@@ -59,6 +61,7 @@ interface CrossTurnIntentRun {
   readonly entries: readonly IntentEntry[];
   readonly sourceTurnIndexes: readonly number[];
   readonly sourceTurnIds: readonly string[];
+  readonly separatorTurn?: TurnModel;
 }
 
 function entryKey(turnIndex: number, entry: ProjectedEntry): string {
@@ -95,25 +98,20 @@ function turnRow(
 /**
  * Converts projected turns into the stable rows consumed by both the virtual
  * and preview layouts. A contiguous intent run that crosses a turn boundary
- * becomes one row; any visible item/critical/message entry breaks that run.
- * Single-turn intent groups remain inside TurnBlock so ordinary turn chrome is
- * unchanged.
+ * becomes one row; any visible item/critical/message entry or source turn with
+ * a renderable failure end cap breaks that run.
+ * Single-turn intent groups remain inside TurnBlock except for a terminal run:
+ * that run gets its eventual first-action row identity before a following turn
+ * streams in, while separator metadata preserves its ordinary turn chrome.
  */
 export function transcriptRowsForProjection(projection: TranscriptProjection): readonly TranscriptBodyRow[] {
   const flat: FlatEntry[] = projection.turns.flatMap((turn, turnIndex) =>
     turn.entries.map((entry) => ({ entry, turnIndex })),
   );
   const crossRunByEntry = new Map<string, CrossTurnIntentRun>();
-  let flatIndex = 0;
-  while (flatIndex < flat.length) {
-    const first = flat[flatIndex];
-    if (first?.entry.kind !== "intent") {
-      flatIndex += 1;
-      continue;
-    }
-    let end = flatIndex + 1;
-    while (end < flat.length && flat[end]?.entry.kind === "intent") end += 1;
-    const run = flat.slice(flatIndex, end);
+  const registerIntentRun = (start: number, end: number) => {
+    if (start >= end) return;
+    const run = flat.slice(start, end);
     const sourceTurnIndexes = [...new Set(run.map((item) => item.turnIndex))];
     let adjacentTurns = sourceTurnIndexes.length > 1;
     for (let index = 1; index < sourceTurnIndexes.length; index += 1) {
@@ -124,17 +122,42 @@ export function transcriptRowsForProjection(projection: TranscriptProjection): r
         break;
       }
     }
-    if (adjacentTurns) {
-      const entries = run.map((item) => item.entry).filter((entry): entry is IntentEntry => entry.kind === "intent");
-      const sourceTurnIds = sourceTurnIndexes.map((turnIndex) => projection.turns[turnIndex]?.id ?? "");
-      const group: CrossTurnIntentRun = {
-        id: `intent-group:${entries[0]?.id}:${entries.at(-1)?.id}`,
-        entries,
-        sourceTurnIndexes,
-        sourceTurnIds,
-      };
-      for (const item of run) crossRunByEntry.set(entryKey(item.turnIndex, item.entry), group);
+    const terminalSingleTurn = sourceTurnIndexes.length === 1 && end === flat.length;
+    if (!adjacentTurns && !terminalSingleTurn) return;
+    const entries = run.map((item) => item.entry).filter((entry): entry is IntentEntry => entry.kind === "intent");
+    const sourceTurnIds = sourceTurnIndexes.map((turnIndex) => projection.turns[turnIndex]?.id ?? "");
+    const finalSourceTurnIndex = sourceTurnIndexes.at(-1);
+    const group: CrossTurnIntentRun = {
+      id: `intent-group:${entries[0]?.id}`,
+      entries,
+      sourceTurnIndexes,
+      sourceTurnIds,
+      separatorTurn:
+        end === flat.length && finalSourceTurnIndex !== undefined
+          ? projection.turns[finalSourceTurnIndex]?.source
+          : undefined,
+    };
+    for (const item of run) crossRunByEntry.set(entryKey(item.turnIndex, item.entry), group);
+  };
+  let flatIndex = 0;
+  while (flatIndex < flat.length) {
+    const first = flat[flatIndex];
+    if (first?.entry.kind !== "intent") {
+      flatIndex += 1;
+      continue;
     }
+    let end = flatIndex + 1;
+    while (end < flat.length && flat[end]?.entry.kind === "intent") end += 1;
+    let cleanStart = flatIndex;
+    for (let cursor = flatIndex; cursor < end; cursor += 1) {
+      const candidate = flat[cursor];
+      const sourceTurn = candidate === undefined ? undefined : projection.turns[candidate.turnIndex]?.source;
+      if (sourceTurn && asTurnError(sourceTurn.error)) {
+        registerIntentRun(cleanStart, cursor);
+        cleanStart = cursor + 1;
+      }
+    }
+    registerIntentRun(cleanStart, end);
     flatIndex = end;
   }
 
@@ -164,6 +187,7 @@ export function transcriptRowsForProjection(projection: TranscriptProjection): r
           entries: run.entries,
           sourceTurnIndexes: run.sourceTurnIndexes,
           sourceTurnIds: run.sourceTurnIds,
+          separatorTurn: run.separatorTurn,
         });
         emittedRuns.add(run);
       }
@@ -297,6 +321,7 @@ export function TranscriptBody({
             entries={row.entries}
             rowId={row.id}
             sourceTurnIds={row.sourceTurnIds}
+            separatorTurn={row.separatorTurn}
             viewAnchorIndex={index}
             showSeenDivider={showSeenDivider && row.sourceTurnIds.includes(seenTurnId ?? "")}
           />

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptDetailControl.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptDetailControl.test.tsx
@@ -1,10 +1,10 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
-import { resetMobileViewportForTests } from "../../../shell/useIsMobile";
 import { resetTranscriptDisplayStoreForTests, transcriptDisplayStore } from "../../../stores/transcriptDisplay";
 import {
   type HubTranscriptDisplayDefault,
@@ -21,23 +21,6 @@ const hubMobile: HubTranscriptDisplayDefault = {
   revision: 5,
   config: makeTranscriptDisplayConfig({ kind: "preset", level: "intent" }),
 };
-
-function mobileQuery(matches: boolean): void {
-  const query = {
-    matches,
-    media: "(max-width: 899px)",
-    onchange: null,
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  } satisfies MediaQueryList;
-  vi.stubGlobal(
-    "matchMedia",
-    vi.fn(() => query),
-  );
-}
 
 function seedStore(overrides: Partial<Parameters<typeof transcriptDisplayStore.setState>[0]> = {}): void {
   transcriptDisplayStore.setState({
@@ -57,36 +40,48 @@ function config(level: "chat" | "intent" | "tools" | "activity" | "full"): Trans
   return makeTranscriptDisplayConfig({ kind: "preset", level });
 }
 
+function ControlledDetail({
+  layout,
+  onEditHubDefaults = () => {},
+}: {
+  layout: "desktop" | "mobile";
+  onEditHubDefaults?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open verbosity
+      </button>
+      <TranscriptDetailControl
+        open={open}
+        onClose={() => setOpen(false)}
+        layout={layout}
+        onEditHubDefaults={onEditHubDefaults}
+      />
+    </>
+  );
+}
+
 beforeEach(() => {
   resetTranscriptDisplayStoreForTests();
-  mobileQuery(false);
   seedStore();
 });
 
 afterEach(() => {
   cleanup();
   resetTranscriptDisplayStoreForTests();
-  resetMobileViewportForTests();
-  vi.unstubAllGlobals();
 });
 
-test("renders a desktop Popover with effective compact summary, scope, reset, and hub-default callback", async () => {
+test("renders a controlled desktop Dialog with full editor, scope, reset, and hub-default callback", async () => {
   const user = userEvent.setup();
   const onEditHubDefaults = vi.fn();
-  render(<TranscriptDetailControl layout="desktop" onEditHubDefaults={onEditHubDefaults} />);
+  render(<TranscriptDetailControl open onClose={() => {}} layout="desktop" onEditHubDefaults={onEditHubDefaults} />);
 
-  const trigger = screen.getByRole("button", { name: "Detail: Tools" });
-  expect(trigger.className).toMatch(/secondary/);
-  expect(trigger.className).toMatch(/sm/);
-  expect(trigger.getAttribute("aria-haspopup")).toBe("dialog");
-  expect(trigger.getAttribute("aria-expanded")).toBe("false");
-  await user.click(trigger);
-
-  expect(trigger.getAttribute("aria-expanded")).toBe("true");
-  const dialog = screen.getByRole("dialog", { name: "Transcript display details" });
-  expect(dialog.getAttribute("aria-modal")).toBe("false");
+  const dialog = screen.getByRole("dialog", { name: "Verbosity" });
+  expect(dialog.getAttribute("aria-modal")).toBe("true");
   expect(dialog.getAttribute("aria-labelledby")).not.toBeNull();
-  expect(screen.getByRole("heading", { name: "Transcript display details" })).toBeTruthy();
+  expect(screen.getByRole("heading", { name: "Verbosity" })).toBeTruthy();
 
   expect(screen.getByRole("radio", { name: "Tools" })).toBeTruthy();
   expect(screen.getByText("Using hub default")).toBeTruthy();
@@ -96,17 +91,13 @@ test("renders a desktop Popover with effective compact summary, scope, reset, an
   expect(editButton.className).toMatch(/quiet/);
   await user.click(screen.getByRole("button", { name: "Edit hub defaults" }));
   expect(onEditHubDefaults).toHaveBeenCalledOnce();
-  expect(trigger.getAttribute("aria-expanded")).toBe("false");
 });
 
-test("keeps the portaled desktop panel as the container for compact descendants", async () => {
-  const user = userEvent.setup();
-  render(<TranscriptDetailControl layout="desktop" onEditHubDefaults={() => {}} />);
+test("keeps the desktop Dialog body as the container for compact descendants", () => {
+  render(<TranscriptDetailControl open onClose={() => {}} layout="desktop" onEditHubDefaults={() => {}} />);
 
-  await user.click(screen.getByRole("button", { name: "Detail: Tools" }));
-
-  const portalPanel = screen.getByTestId("transcript-detail-popover");
-  expect(portalPanel.querySelector('[class*="detailPanel"]')).toBeTruthy();
+  const dialog = screen.getByRole("dialog", { name: "Verbosity" });
+  expect(dialog.querySelector('[class*="detailPanel"]')).toBeTruthy();
 
   const here = dirname(fileURLToPath(import.meta.url));
   const css = readFileSync(join(here, "transcriptDisplay.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
@@ -121,9 +112,7 @@ test("keeps the portaled desktop panel as the container for compact descendants"
 
 test("sets and clears only the browser-local value for the selected layout", async () => {
   const user = userEvent.setup();
-  render(<TranscriptDetailControl layout="desktop" onEditHubDefaults={() => {}} />);
-
-  await user.click(screen.getByRole("button", { name: "Detail: Tools" }));
+  render(<TranscriptDetailControl open onClose={() => {}} layout="desktop" onEditHubDefaults={() => {}} />);
   await user.click(screen.getByRole("radio", { name: "Activity" }));
 
   expect(transcriptDisplayStore.getState().local.desktop).toEqual(config("activity"));
@@ -138,16 +127,13 @@ test("sets and clears only the browser-local value for the selected layout", asy
   expect(screen.getByText("Using hub default")).toBeTruthy();
 });
 
-test("keeps Custom and Advanced extras truthful in the trigger and editor summary", async () => {
-  const user = userEvent.setup();
+test("keeps Custom and Advanced extras truthful in the editor summary", () => {
   const custom = makeTranscriptDisplayConfig(
     { kind: "custom", toolIntent: true, toolCalls: false, reasoning: true, expandByDefault: false },
     { roundTimings: true, systemEvents: true },
   );
   seedStore({ local: { desktop: custom } });
-  render(<TranscriptDetailControl layout="desktop" onEditHubDefaults={() => {}} />);
-
-  await user.click(screen.getByRole("button", { name: "Detail: Custom · 2 extras" }));
+  render(<TranscriptDetailControl open onClose={() => {}} layout="desktop" onEditHubDefaults={() => {}} />);
   expect(screen.getByText("Customize & advanced · Custom content · 2 extras")).toBeTruthy();
   expect(screen.getByText("Local Desktop view")).toBeTruthy();
 });
@@ -155,9 +141,8 @@ test("keeps Custom and Advanced extras truthful in the trigger and editor summar
 test("shows older-hub/loading/storage status without disabling local editing", async () => {
   const user = userEvent.setup();
   seedStore({ hubSupport: "unsupported", hubLoading: true, storageWarning: "Storage warning" });
-  render(<TranscriptDetailControl layout="desktop" onEditHubDefaults={() => {}} />);
+  render(<TranscriptDetailControl open onClose={() => {}} layout="desktop" onEditHubDefaults={() => {}} />);
 
-  await user.click(screen.getByRole("button", { name: "Detail: Tools" }));
   expect(screen.getByRole("status").textContent).toContain("Loading hub default");
   expect(screen.getByText(/older hub does not support transcript display defaults/)).toBeTruthy();
   expect(screen.getByRole("alert").textContent).toContain("Storage warning");
@@ -169,16 +154,13 @@ test("shows older-hub/loading/storage status without disabling local editing", a
 });
 
 test("consolidates passive status and failures into one announcement region each", async () => {
-  const user = userEvent.setup();
   seedStore({
     hubSupport: "unsupported",
     hubLoading: true,
     hubError: "Hub unavailable",
     storageWarning: "Storage warning",
   });
-  render(<TranscriptDetailControl layout="desktop" onEditHubDefaults={() => {}} />);
-
-  await user.click(screen.getByRole("button", { name: "Detail: Tools" }));
+  render(<TranscriptDetailControl open onClose={() => {}} layout="desktop" onEditHubDefaults={() => {}} />);
 
   const statuses = screen.getAllByRole("status");
   expect(statuses).toHaveLength(1);
@@ -194,49 +176,33 @@ test("consolidates passive status and failures into one announcement region each
 });
 
 test("deduplicates identical raw hub and storage failures while retaining hub context", async () => {
-  const user = userEvent.setup();
   seedStore({ hubError: "Same failure", storageWarning: "Same failure" });
-  render(<TranscriptDetailControl layout="desktop" onEditHubDefaults={() => {}} />);
-
-  await user.click(screen.getByRole("button", { name: "Detail: Tools" }));
+  render(<TranscriptDetailControl open onClose={() => {}} layout="desktop" onEditHubDefaults={() => {}} />);
 
   const alert = screen.getByRole("alert");
   expect(alert.querySelectorAll("p")).toHaveLength(1);
   expect(alert.textContent).toBe("Hub default status: Same failure");
 });
 
-test("does not dismiss the desktop Popover on internal or window scroll", async () => {
+test("controlled close requests dismissal without owning open state", async () => {
   const user = userEvent.setup();
-  render(<TranscriptDetailControl layout="desktop" onEditHubDefaults={() => {}} />);
+  const onClose = vi.fn();
+  render(<TranscriptDetailControl open onClose={onClose} layout="desktop" onEditHubDefaults={() => {}} />);
 
-  const trigger = screen.getByRole("button", { name: "Detail: Tools" });
-  await user.click(trigger);
-  const popover = screen.getByTestId("transcript-detail-popover");
-  const panel = popover.querySelector('[class*="detailPanel"]');
-  expect(panel).not.toBeNull();
-
-  fireEvent.scroll(panel as HTMLElement);
-  window.dispatchEvent(new Event("scroll"));
-
-  expect(trigger.getAttribute("aria-expanded")).toBe("true");
-  expect(screen.getByRole("dialog", { name: "Transcript display details" })).toBeTruthy();
+  await user.keyboard("{Escape}");
+  expect(onClose).toHaveBeenCalledOnce();
+  expect(screen.getByRole("dialog", { name: "Verbosity" })).toBeTruthy();
 });
 
-test("uses a bottom mobile Sheet and restores focus to the forwarded trigger ref", async () => {
+test("uses a controlled bottom mobile Sheet and restores focus to the external trigger", async () => {
   const user = userEvent.setup();
-  mobileQuery(true);
   seedStore({ local: { mobile: config("intent") } });
-  const triggerRef = { current: null } as React.RefObject<HTMLButtonElement | null>;
-  render(<TranscriptDetailControl layout="mobile" onEditHubDefaults={() => {}} triggerRef={triggerRef} />);
+  render(<ControlledDetail layout="mobile" />);
 
-  const trigger = screen.getByRole("button", { name: "Detail: Intent" });
-  expect(triggerRef.current).toBe(trigger);
-  expect(trigger.getAttribute("aria-haspopup")).toBe("dialog");
-  expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  const trigger = screen.getByRole("button", { name: "Open verbosity" });
   await user.click(trigger);
-  expect(trigger.getAttribute("aria-expanded")).toBe("true");
 
-  const dialog = screen.getByRole("dialog", { name: "Transcript display details" });
+  const dialog = screen.getByRole("dialog", { name: "Verbosity" });
   expect(dialog).toBeTruthy();
   expect(dialog.getAttribute("aria-modal")).toBe("true");
   expect(dialog.className).toContain("bottom");
@@ -245,17 +211,16 @@ test("uses a bottom mobile Sheet and restores focus to the forwarded trigger ref
   expect(screen.getByRole("button", { name: "Edit hub defaults" }).className).toMatch(/quiet/);
 
   await user.keyboard("{Escape}");
-  expect(screen.queryByRole("dialog", { name: "Transcript display details" })).toBeNull();
-  expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  expect(screen.queryByRole("dialog", { name: "Verbosity" })).toBeNull();
   expect(document.activeElement).toBe(trigger);
 });
 
-test("keeps Desktop focus after reset so Escape closes and restores trigger focus", async () => {
+test("keeps Desktop focus after reset so Escape closes and restores external trigger focus", async () => {
   const user = userEvent.setup();
   seedStore({ local: { desktop: config("activity") } });
-  render(<TranscriptDetailControl layout="desktop" onEditHubDefaults={() => {}} />);
+  render(<ControlledDetail layout="desktop" />);
 
-  const trigger = screen.getByRole("button", { name: "Detail: Activity" });
+  const trigger = screen.getByRole("button", { name: "Open verbosity" });
   await user.click(trigger);
   const useDefault = screen.getByRole("button", { name: "Use hub default" });
   const edit = screen.getByRole("button", { name: "Edit hub defaults" });
@@ -263,18 +228,16 @@ test("keeps Desktop focus after reset so Escape closes and restores trigger focu
 
   expect(document.activeElement).toBe(edit);
   await user.keyboard("{Escape}");
-  expect(screen.queryByRole("dialog", { name: "Transcript display details" })).toBeNull();
-  expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  expect(screen.queryByRole("dialog", { name: "Verbosity" })).toBeNull();
   expect(document.activeElement).toBe(trigger);
 });
 
-test("keeps Mobile focus after reset so Escape closes and restores trigger focus", async () => {
+test("keeps Mobile focus after reset so Escape closes and restores external trigger focus", async () => {
   const user = userEvent.setup();
-  mobileQuery(true);
   seedStore({ local: { mobile: config("activity") } });
-  render(<TranscriptDetailControl layout="mobile" onEditHubDefaults={() => {}} />);
+  render(<ControlledDetail layout="mobile" />);
 
-  const trigger = screen.getByRole("button", { name: "Detail: Activity" });
+  const trigger = screen.getByRole("button", { name: "Open verbosity" });
   await user.click(trigger);
   const useDefault = screen.getByRole("button", { name: "Use hub default" });
   const edit = screen.getByRole("button", { name: "Edit hub defaults" });
@@ -282,19 +245,16 @@ test("keeps Mobile focus after reset so Escape closes and restores trigger focus
 
   expect(document.activeElement).toBe(edit);
   await user.keyboard("{Escape}");
-  expect(screen.queryByRole("dialog", { name: "Transcript display details" })).toBeNull();
-  expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  expect(screen.queryByRole("dialog", { name: "Verbosity" })).toBeNull();
   expect(document.activeElement).toBe(trigger);
 });
 
 test("sets and resets only Mobile local state when Desktop local state already exists", async () => {
   const user = userEvent.setup();
-  mobileQuery(true);
   const desktopLocal = config("tools");
   seedStore({ local: { desktop: desktopLocal } });
-  render(<TranscriptDetailControl layout="mobile" onEditHubDefaults={() => {}} />);
+  render(<TranscriptDetailControl open onClose={() => {}} layout="mobile" onEditHubDefaults={() => {}} />);
 
-  await user.click(screen.getByRole("button", { name: "Detail: Intent" }));
   expect(screen.queryByRole("button", { name: "Use hub default" })).toBeNull();
   expect(screen.getByRole("button", { name: "Edit hub defaults" }).className).toMatch(/quiet/);
   await user.click(screen.getByRole("radio", { name: "Activity" }));
@@ -308,22 +268,21 @@ test("sets and resets only Mobile local state when Desktop local state already e
   expect(transcriptDisplayStore.getState().hub).toEqual({ desktop: hubDesktop, mobile: hubMobile });
 });
 
-test("composes the detail control only from shared Buttons and public widget APIs", () => {
+test("composes the controlled overlay only from shared Buttons and Dialog/Sheet public APIs", () => {
   const here = dirname(fileURLToPath(import.meta.url));
   const source = readFileSync(join(here, "TranscriptDetailControl.tsx"), "utf8");
 
-  expect(source).toMatch(/import \{ Button, Popover, Sheet \} from "\.\.\/\.\.\/\.\.\/widgets";/);
+  expect(source).toMatch(/import \{ Button, Dialog, Sheet \} from "\.\.\/\.\.\/\.\.\/widgets";/);
   expect(source).not.toMatch(/<button\b/);
-  expect(source.match(/<Button\b/g)).toHaveLength(3);
-  expect(source.match(/variant="secondary"/g)).toHaveLength(2);
+  expect(source.match(/<Button\b/g)).toHaveLength(2);
+  expect(source.match(/variant="secondary"/g)).toHaveLength(1);
   expect(source).toMatch(/<Button ref=\{editButtonRef\} size="sm" variant="quiet"/);
 });
 
-test("CSS keeps live detail layout-only with no private motion or chrome", () => {
+test("CSS keeps the shared overlay body layout-only with no private motion or chrome", () => {
   const here = dirname(fileURLToPath(import.meta.url));
   const css = readFileSync(join(here, "transcriptDisplay.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
 
-  expect(css).toMatch(/\.detailControl\s*\{/);
   expect(css).toMatch(/\.detailPanel\s*\{/);
   const directPanelRules = [...css.matchAll(/(^|\n)(?!\s*@)([^{}]+)\{([^{}]*)\}/gm)].filter((match) =>
     match[2]?.split(",").some((selector) => selector.trim() === ".detailPanel"),
@@ -333,14 +292,8 @@ test("CSS keeps live detail layout-only with no private motion or chrome", () =>
   expect(panelSelector.trim()).toBe(".detailPanel");
   const panelBody = directPanelRules[0]?.[3] ?? "";
   const panelProperties = [...panelBody.matchAll(/(?:^|;)\s*([a-z-]+)\s*:/g)].map((match) => match[1]).sort();
-  expect(panelProperties).toEqual(
-    ["box-sizing", "container-name", "container-type", "inline-size", "max-block-size", "overflow-y", "padding"].sort(),
-  );
-  expect(panelBody).toMatch(/box-sizing:\s*border-box/);
-  expect(panelBody).toMatch(/inline-size:\s*min\(42rem, calc\(100vw - var\(--space-8\)\)\)/);
-  expect(panelBody).toMatch(/padding:\s*var\(--space-4\)/);
-  expect(panelBody).toMatch(/max-block-size:\s*calc\(100dvh - var\(--space-8\)\)/);
-  expect(panelBody).toMatch(/overflow-y:\s*auto/);
+  expect(panelProperties).toEqual(["container-name", "container-type", "min-width"].sort());
+  expect(panelBody).toMatch(/min-width:\s*0/);
   expect(panelBody).not.toMatch(/background|box-shadow|border-radius/);
   expect(panelBody).not.toMatch(/(?:^|[;\n])\s*border(?:-[a-z-]+)?\s*:/);
   const statusMatch = /\.detailStatus,\s*\.detailWarning\s*\{([^}]*)\}/.exec(css);
@@ -353,7 +306,6 @@ test("CSS keeps live detail layout-only with no private motion or chrome", () =>
   expect(css).not.toMatch(/prefers-reduced-motion/);
   expect(css).toMatch(/@container\s+/);
   expect(css).not.toMatch(/@media\s*\([^)]*width/);
-  expect(css).not.toMatch(/\.detailControl\s*\{[^}]*container-type/);
   expect(css).not.toMatch(/\.detailSheetContent\s*\{[^}]*container-(?:type|name)/);
   expect(css).not.toMatch(/\.detailActions\s+button/);
   expect(css).not.toMatch(/\.detailSheetContent\s+\.detailActions/);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptDetailControl.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptDetailControl.tsx
@@ -1,29 +1,21 @@
-import type { Ref, RefObject } from "react";
-import { useId, useRef, useState } from "react";
-import { useIsMobile } from "../../../shell/useIsMobile";
+import type { RefObject } from "react";
+import { useRef } from "react";
 import { transcriptDisplayStore, useTranscriptDisplayStore } from "../../../stores/transcriptDisplay";
-import {
-  advancedEnabledCount,
-  contentSummary,
-  type EffectiveConfigSources,
-  resolveEffectiveConfig,
-  type ViewportClass,
-} from "../../../transcriptDisplay/config";
-import { Button, Popover, Sheet } from "../../../widgets";
+import { resolveEffectiveConfig, type ViewportClass } from "../../../transcriptDisplay/config";
+import { Button, Dialog, Sheet } from "../../../widgets";
 import { requireClass } from "../../../widgets/internal/requireClass";
 import { TranscriptDetailEditor } from "./TranscriptDetailEditor";
 import styles from "./transcriptDisplay.module.css";
 
 export interface TranscriptDetailControlProps {
+  open: boolean;
+  onClose(): void;
   layout: ViewportClass;
   onEditHubDefaults(): void;
-  triggerRef?: Ref<HTMLButtonElement>;
 }
 
 const CLASS = {
-  root: requireClass(styles.detailControl, "transcriptDisplay.module.css", "detailControl"),
   panel: requireClass(styles.detailPanel, "transcriptDisplay.module.css", "detailPanel"),
-  panelTitle: requireClass(styles.detailPanelTitle, "transcriptDisplay.module.css", "detailPanelTitle"),
   content: requireClass(styles.detailContent, "transcriptDisplay.module.css", "detailContent"),
   sheetContent: requireClass(styles.detailSheetContent, "transcriptDisplay.module.css", "detailSheetContent"),
   scope: requireClass(styles.detailScope, "transcriptDisplay.module.css", "detailScope"),
@@ -31,13 +23,6 @@ const CLASS = {
   warning: requireClass(styles.detailWarning, "transcriptDisplay.module.css", "detailWarning"),
   actions: requireClass(styles.detailActions, "transcriptDisplay.module.css", "detailActions"),
 };
-
-function summaryFor(sources: EffectiveConfigSources): string {
-  const normalized = resolveEffectiveConfig(sources);
-  const extras = advancedEnabledCount(normalized);
-  const content = contentSummary(normalized.content);
-  return extras === 0 ? `Detail: ${content}` : `Detail: ${content} · ${extras} extras`;
-}
 
 interface DetailPanelProps {
   layout: ViewportClass;
@@ -50,9 +35,8 @@ interface DetailPanelProps {
   onChange(value: ReturnType<typeof resolveEffectiveConfig>): void;
   onClearLocal(): void;
   onEditHubDefaults(): void;
-  showTitle: boolean;
-  headingId: string;
   showActions: boolean;
+  mobile: boolean;
   editButtonRef: RefObject<HTMLButtonElement | null>;
 }
 
@@ -94,9 +78,8 @@ function DetailPanel({
   onChange,
   onClearLocal,
   onEditHubDefaults,
-  showTitle,
-  headingId,
   showActions,
+  mobile,
   editButtonRef,
 }: DetailPanelProps) {
   const layoutName = layout === "desktop" ? "Desktop" : "Mobile";
@@ -110,12 +93,10 @@ function DetailPanel({
     failureMessages.set(storageWarning, storageWarning);
 
   return (
-    <div className={showTitle ? CLASS.content : CLASS.sheetContent}>
-      {showTitle && (
-        <h2 id={headingId} className={CLASS.panelTitle}>
-          Transcript display details
-        </h2>
-      )}
+    <div
+      className={mobile ? CLASS.sheetContent : `${CLASS.panel} ${CLASS.content}`}
+      data-testid="transcript-detail-control"
+    >
       <p className={CLASS.scope}>{localExists ? `Local ${layoutName} view` : "Using hub default"}</p>
       {statusMessages.length > 0 && (
         <div className={CLASS.status} role="status" aria-live="polite">
@@ -144,11 +125,9 @@ function DetailPanel({
   );
 }
 
-export function TranscriptDetailControl({ layout, onEditHubDefaults, triggerRef }: TranscriptDetailControlProps) {
-  const [open, setOpen] = useState(false);
-  const headingId = useId();
+export function TranscriptDetailControl({ open, onClose, layout, onEditHubDefaults }: TranscriptDetailControlProps) {
   const editButtonRef = useRef<HTMLButtonElement>(null);
-  const isMobile = useIsMobile();
+  const isMobile = layout === "mobile";
   const local = useTranscriptDisplayStore((state) => state.local[layout]);
   const hub = useTranscriptDisplayStore((state) => state.hub[layout]);
   const hubLoading = useTranscriptDisplayStore((state) => state.hubLoading);
@@ -156,14 +135,9 @@ export function TranscriptDetailControl({ layout, onEditHubDefaults, triggerRef 
   const hubSupport = useTranscriptDisplayStore((state) => state.hubSupport);
   const storageWarning = useTranscriptDisplayStore((state) => state.storageWarning);
   const effectiveConfig = resolveEffectiveConfig({ local, hub, layout });
-  const triggerLabel = summaryFor({ local, hub, layout });
-
-  function close(): void {
-    setOpen(false);
-  }
 
   function editHubDefaults(): void {
-    close();
+    onClose();
     onEditHubDefaults();
   }
 
@@ -179,9 +153,8 @@ export function TranscriptDetailControl({ layout, onEditHubDefaults, triggerRef 
       onChange={(next) => transcriptDisplayStore.getState().setLocal(layout, next)}
       onClearLocal={() => transcriptDisplayStore.getState().clearLocal(layout)}
       onEditHubDefaults={editHubDefaults}
-      showTitle={!isMobile}
-      headingId={headingId}
       showActions={!isMobile}
+      mobile={isMobile}
       editButtonRef={editButtonRef}
     />
   );
@@ -195,48 +168,13 @@ export function TranscriptDetailControl({ layout, onEditHubDefaults, triggerRef 
     />
   );
 
-  const trigger = (
-    <Button
-      ref={triggerRef}
-      size="sm"
-      variant="secondary"
-      aria-expanded={open}
-      aria-haspopup="dialog"
-      onClick={() => setOpen((current) => !current)}
-    >
-      {triggerLabel}
-    </Button>
-  );
-
-  return (
-    <div className={CLASS.root}>
-      {isMobile ? (
-        <>
-          {trigger}
-          <Sheet
-            open={open}
-            side="bottom"
-            size="wide"
-            onClose={close}
-            title="Transcript display details"
-            footer={footer}
-          >
-            {panel}
-          </Sheet>
-        </>
-      ) : (
-        <Popover
-          open={open}
-          onClose={close}
-          closeOnScroll={false}
-          trigger={trigger}
-          data-testid="transcript-detail-popover"
-        >
-          <div className={CLASS.panel} role="dialog" aria-modal="false" aria-labelledby={headingId}>
-            {panel}
-          </div>
-        </Popover>
-      )}
-    </div>
+  return isMobile ? (
+    <Sheet open={open} side="bottom" size="wide" onClose={onClose} title="Verbosity" footer={footer}>
+      {panel}
+    </Sheet>
+  ) : (
+    <Dialog open={open} onClose={onClose} title="Verbosity">
+      {panel}
+    </Dialog>
   );
 }

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptDetailControl.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptDetailControl.tsx
@@ -35,8 +35,6 @@ interface DetailPanelProps {
   onChange(value: ReturnType<typeof resolveEffectiveConfig>): void;
   onClearLocal(): void;
   onEditHubDefaults(): void;
-  showActions: boolean;
-  mobile: boolean;
   editButtonRef: RefObject<HTMLButtonElement | null>;
 }
 
@@ -78,10 +76,9 @@ function DetailPanel({
   onChange,
   onClearLocal,
   onEditHubDefaults,
-  showActions,
-  mobile,
   editButtonRef,
 }: DetailPanelProps) {
+  const isMobile = layout === "mobile";
   const layoutName = layout === "desktop" ? "Desktop" : "Mobile";
   const statusMessages: string[] = [];
   if (hubLoading) statusMessages.push("Loading hub default…");
@@ -94,7 +91,7 @@ function DetailPanel({
 
   return (
     <div
-      className={mobile ? CLASS.sheetContent : `${CLASS.panel} ${CLASS.content}`}
+      className={isMobile ? CLASS.sheetContent : `${CLASS.panel} ${CLASS.content}`}
       data-testid="transcript-detail-control"
     >
       <p className={CLASS.scope}>{localExists ? `Local ${layoutName} view` : "Using hub default"}</p>
@@ -113,7 +110,7 @@ function DetailPanel({
         </div>
       )}
       <TranscriptDetailEditor value={effectiveConfig} compact onChange={onChange} />
-      {showActions && (
+      {!isMobile && (
         <DetailActions
           localExists={localExists}
           editButtonRef={editButtonRef}
@@ -135,6 +132,15 @@ export function TranscriptDetailControl({ open, onClose, layout, onEditHubDefaul
   const hubSupport = useTranscriptDisplayStore((state) => state.hubSupport);
   const storageWarning = useTranscriptDisplayStore((state) => state.storageWarning);
   const effectiveConfig = resolveEffectiveConfig({ local, hub, layout });
+  const localExists = local !== undefined;
+
+  function setLocal(next: ReturnType<typeof resolveEffectiveConfig>): void {
+    transcriptDisplayStore.getState().setLocal(layout, next);
+  }
+
+  function clearLocal(): void {
+    transcriptDisplayStore.getState().clearLocal(layout);
+  }
 
   function editHubDefaults(): void {
     onClose();
@@ -144,26 +150,24 @@ export function TranscriptDetailControl({ open, onClose, layout, onEditHubDefaul
   const panel = (
     <DetailPanel
       layout={layout}
-      localExists={local !== undefined}
+      localExists={localExists}
       effectiveConfig={effectiveConfig}
       hubLoading={hubLoading}
       hubError={hubError}
       hubSupport={hubSupport}
       storageWarning={storageWarning}
-      onChange={(next) => transcriptDisplayStore.getState().setLocal(layout, next)}
-      onClearLocal={() => transcriptDisplayStore.getState().clearLocal(layout)}
+      onChange={setLocal}
+      onClearLocal={clearLocal}
       onEditHubDefaults={editHubDefaults}
-      showActions={!isMobile}
-      mobile={isMobile}
       editButtonRef={editButtonRef}
     />
   );
 
   const footer = (
     <DetailActions
-      localExists={local !== undefined}
+      localExists={localExists}
       editButtonRef={editButtonRef}
-      onClearLocal={() => transcriptDisplayStore.getState().clearLocal(layout)}
+      onClearLocal={clearLocal}
       onEditHubDefaults={editHubDefaults}
     />
   );

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
@@ -324,7 +324,7 @@ test("with both hook toggles off, only a non-zero hook survives as a compact cri
   expect(screen.getByTestId("system-notice-failure")).toBeTruthy();
 });
 
-test("a blank-purpose critical tool uses the projected neutral summary without a raw command summary", () => {
+test("a blank-purpose tool uses the projected neutral summary without a raw command summary", () => {
   const config = makeTranscriptDisplayConfig({ kind: "preset", level: "chat" });
   const blankPurpose = item({
     id: "critical-blank-purpose",
@@ -336,14 +336,182 @@ test("a blank-purpose critical tool uses the projected neutral summary without a
   });
   const { rerender } = render(withConfig(config, <TurnBlock turn={turn([blankPurpose], {}, config)} />));
 
-  expect(screen.getAllByTestId("tool-call-item")).toHaveLength(1);
-  expect(screen.getByTestId("tool-row-summary").textContent).toBe("Action summary unavailable");
+  expect(screen.queryAllByTestId("tool-call-item")).toHaveLength(0);
+  expect(screen.getByText("Action summary unavailable")).toBeTruthy();
   expect(screen.queryByText("Ran echo should-not-be-recomputed")).toBeNull();
 
   const tools = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
   rerender(withConfig(tools, <TurnBlock turn={turn([blankPurpose], {}, tools)} />));
   expect(screen.getAllByTestId("tool-call-item")).toHaveLength(1);
   expect(screen.getByTestId("tool-row-summary").textContent).toBe("Action summary unavailable");
+});
+
+test("Chat renders a closed action group that expands reasons without tool UI (catches missing Chat intent)", () => {
+  const config = makeTranscriptDisplayConfig({ kind: "preset", level: "chat" });
+  const action = item({
+    id: "chat-action",
+    type: "commandExecution",
+    toolName: "shell",
+    description: "Run focused checks",
+    output: "private tool output",
+    status: "completed",
+  });
+  render(withConfig(config, <TurnBlock turn={turn([action], { status: "completed" }, config)} />));
+
+  const group = screen.getByTestId("intent-group");
+  expect(group.hasAttribute("open")).toBe(false);
+  expect(screen.queryByTestId("tool-call-item")).toBeNull();
+
+  const summary = group.querySelector("summary");
+  if (summary === null) throw new Error("Chat intent summary did not render");
+  fireEvent.click(summary);
+  expect(group.hasAttribute("open")).toBe(true);
+  expect(screen.getByText("Run focused checks")).toBeTruthy();
+  expect(screen.queryByText("private tool output")).toBeNull();
+  expect(screen.queryByTestId("tool-call-item")).toBeNull();
+});
+
+test("Intent renders an open action group without a tool row (catches closed Intent default)", () => {
+  const config = makeTranscriptDisplayConfig({ kind: "preset", level: "intent" });
+  const action = item({
+    id: "intent-action",
+    type: "commandExecution",
+    toolName: "read_file",
+    description: "Read the configuration",
+    output: "private file output",
+    status: "completed",
+  });
+  render(withConfig(config, <TurnBlock turn={turn([action], { status: "completed" }, config)} />));
+
+  expect(screen.getByTestId("intent-group").hasAttribute("open")).toBe(true);
+  expect(screen.getByText("Read the configuration")).toBeTruthy();
+  expect(screen.queryByText("private file output")).toBeNull();
+  expect(screen.queryByTestId("tool-call-item")).toBeNull();
+});
+
+test("named Intent opens only its action group while generic interaction and system disclosures stay closed", () => {
+  const config = makeTranscriptDisplayConfig({ kind: "preset", level: "intent" }, { promptEvents: true });
+  const ordinaryAction = item({
+    id: "intent-ordinary",
+    type: "commandExecution",
+    toolName: "read_file",
+    description: "Read the configuration",
+    status: "completed",
+  });
+  const interaction = item({
+    id: "intent-question",
+    type: "commandExecution",
+    toolName: "ask_user",
+    description: "Ask about mode",
+    argumentsJSON: JSON.stringify({
+      questions: [{ header: "Mode", question: "Choose", options: [{ label: "Fast", detail: "" }] }],
+    }),
+    status: "completed",
+  });
+  const systemPrompt = systemItem("intent-system-prompt", {
+    eventKind: "system_prompt",
+    text: "System prompt details",
+    status: "completed",
+  });
+  render(
+    withConfig(
+      config,
+      <TurnBlock turn={turn([ordinaryAction, interaction, systemPrompt], { status: "completed" }, config)} />,
+    ),
+  );
+
+  expect(screen.getByTestId("intent-group").hasAttribute("open")).toBe(true);
+  expect(screen.getByTestId("tool-row-trigger").getAttribute("aria-expanded")).toBe("false");
+  expect(screen.getByTestId("system-notice-scaffold").hasAttribute("open")).toBe(false);
+});
+
+test("failed intent proxy renders the accessible FailureGlyph and neutral missing summary (catches full tool row)", () => {
+  const config = makeTranscriptDisplayConfig({ kind: "preset", level: "intent" });
+  const failedAction = item({
+    id: "failed-intent-action",
+    type: "commandExecution",
+    toolName: "shell",
+    description: "   ",
+    error: "command failed",
+    output: "sensitive failure output",
+    status: "failed",
+  });
+  render(withConfig(config, <TurnBlock turn={turn([failedAction], { status: "completed" }, config)} />));
+
+  expect(screen.getByTestId("intent-group")).toBeTruthy();
+  expect(screen.getByText("Action summary unavailable")).toBeTruthy();
+  expect(screen.getByRole("img", { name: "Failed" })).toBeTruthy();
+  expect(screen.queryByTestId("tool-call-item")).toBeNull();
+  expect(screen.queryByText("sensitive failure output")).toBeNull();
+});
+
+test("a growing Chat group keeps its first-action identity and manually opened state (catches last-id key)", () => {
+  const config = makeTranscriptDisplayConfig({
+    kind: "custom",
+    toolIntent: true,
+    toolCalls: false,
+    reasoning: false,
+    expandByDefault: false,
+  });
+  const first = item({
+    id: "stream-first",
+    type: "commandExecution",
+    description: "First action",
+    status: "completed",
+  });
+  const second = item({
+    id: "stream-second",
+    type: "commandExecution",
+    description: "Second action",
+    status: "completed",
+  });
+  const { rerender } = render(withConfig(config, <TurnBlock turn={turn([first], { status: "completed" }, config)} />));
+  const group = screen.getByTestId("intent-group");
+  const summary = group.querySelector("summary");
+  if (summary === null) throw new Error("Chat streaming summary did not render");
+  fireEvent.click(summary);
+  expect(group.hasAttribute("open")).toBe(true);
+
+  rerender(withConfig(config, <TurnBlock turn={turn([first, second], { status: "completed" }, config)} />));
+
+  expect(screen.getByTestId("intent-group")).toBe(group);
+  expect(group.textContent).toContain("2 actions");
+  expect(group.hasAttribute("open")).toBe(true);
+});
+
+test("a growing Intent group keeps its first-action identity and manually closed state (catches last-id key)", () => {
+  const config = makeTranscriptDisplayConfig({
+    kind: "custom",
+    toolIntent: true,
+    toolCalls: false,
+    reasoning: false,
+    expandByDefault: true,
+  });
+  const first = item({
+    id: "stream-first",
+    type: "commandExecution",
+    description: "First action",
+    status: "completed",
+  });
+  const second = item({
+    id: "stream-second",
+    type: "commandExecution",
+    description: "Second action",
+    status: "completed",
+  });
+  const { rerender } = render(withConfig(config, <TurnBlock turn={turn([first], { status: "completed" }, config)} />));
+  const group = screen.getByTestId("intent-group");
+  const summary = group.querySelector("summary");
+  if (summary === null) throw new Error("Intent streaming summary did not render");
+  expect(group.hasAttribute("open")).toBe(true);
+  fireEvent.click(summary);
+  expect(group.hasAttribute("open")).toBe(false);
+
+  rerender(withConfig(config, <TurnBlock turn={turn([first, second], { status: "completed" }, config)} />));
+
+  expect(screen.getByTestId("intent-group")).toBe(group);
+  expect(group.textContent).toContain("2 actions");
+  expect(group.hasAttribute("open")).toBe(false);
 });
 
 test("hookExitsAll renders full hook rows; hookExitsNormal keeps success rows plus a compact failure", () => {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx
@@ -17,6 +17,7 @@ import {
   type TranscriptRenderContextValue,
   useTranscriptRenderContext,
 } from "../../../transcriptDisplay/renderContext";
+import { FailureGlyph } from "../../../widgets";
 import {
   disclosureDefault,
   isDisclosureOpen,
@@ -100,6 +101,7 @@ export interface ProjectedIntentGroupProps {
   entries: readonly Extract<ProjectedEntry, { kind: "intent" }>[];
   rowId?: string;
   sourceTurnIds?: readonly string[];
+  separatorTurn?: TurnModel;
   viewAnchorIndex?: number;
   showSeenDivider?: boolean;
 }
@@ -108,15 +110,17 @@ export function ProjectedIntentGroup({
   entries,
   rowId,
   sourceTurnIds = [],
+  separatorTurn,
   viewAnchorIndex,
   showSeenDivider = false,
 }: ProjectedIntentGroupProps) {
   const context = useTranscriptRenderContext();
   const { config } = context;
   const scope = disclosureScopeForSession(context, undefined);
-  const identity = rowId ?? `intent-group:${entries[0]?.id ?? "empty"}:${entries.at(-1)?.id ?? "empty"}`;
+  const identity = rowId ?? `intent-group:${entries[0]?.id ?? "empty"}`;
   const disclosureKey = scopedDisclosureId(scope, identity);
-  const fallback = expandDetailsByDefault(config) || disclosureDefault(scope, identity, false);
+  const namedIntent = config.content.kind === "preset" && config.content.level === "intent";
+  const fallback = namedIntent || expandDetailsByDefault(config) || disclosureDefault(scope, identity, false);
   const open = isDisclosureOpen(disclosureKey, fallback);
   return (
     <>
@@ -141,11 +145,13 @@ export function ProjectedIntentGroup({
         <div className={transcriptStyles.intentGroupItems}>
           {entries.map((entry) => (
             <div key={entry.id} className={transcriptStyles.intent} {...projectedEntryAnchor(entry, viewAnchorIndex)}>
+              {entry.failed && <FailureGlyph />}
               {entry.rationale}
             </div>
           ))}
         </div>
       </details>
+      {separatorTurn && <TurnSeparator turn={separatorTurn} />}
     </>
   );
 }
@@ -204,11 +210,7 @@ export function TurnBlock({
         if (next?.kind === "intent") group.push(next);
       }
       renderedEntries.push(
-        <ProjectedIntentGroup
-          key={`intent-group:${group[0]?.id}:${group.at(-1)?.id}`}
-          entries={group}
-          viewAnchorIndex={viewAnchorIndex}
-        />,
+        <ProjectedIntentGroup key={`intent-group:${group[0]?.id}`} entries={group} viewAnchorIndex={viewAnchorIndex} />,
       );
       continue;
     }

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/transcriptViewRegistry.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/transcriptViewRegistry.test.ts
@@ -26,7 +26,6 @@ function view(id: string, snapshot: CapturedTranscriptView): RegisteredTranscrip
     id,
     capture: vi.fn(() => snapshot),
     restore: vi.fn(),
-    focusDetailTrigger: vi.fn(),
     announce: vi.fn(),
   };
 }

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/transcriptViewRegistry.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/transcriptViewRegistry.ts
@@ -12,7 +12,6 @@ export interface RegisteredTranscriptView {
   layout?: string;
   capture(): CapturedTranscriptView;
   restore(captured: CapturedTranscriptView): void;
-  focusDetailTrigger(): void;
   announce(summary: string): void;
 }
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.test.ts
@@ -1405,7 +1405,7 @@ describe("registered transcript view preservation", () => {
     el.remove();
   });
 
-  test("restores a surviving focused entry and focuses the Detail fallback when it disappears", () => {
+  test("restores a surviving focused entry and focuses the stable fallback when it disappears", () => {
     const list = makeListHandle();
     document.body.append(list.el);
     const oldAnchor = document.createElement("div");
@@ -1414,8 +1414,9 @@ describe("registered transcript view preservation", () => {
     const oldEntry = document.createElement("button");
     oldAnchor.append(oldEntry);
     list.el.append(oldAnchor);
-    const detail = document.createElement("button");
-    document.body.append(detail);
+    const fallback = document.createElement("div");
+    fallback.tabIndex = -1;
+    document.body.append(fallback);
     oldEntry.focus();
 
     let positions: ViewAnchorPosition[] = [
@@ -1434,7 +1435,7 @@ describe("registered transcript view preservation", () => {
           measureAnchors: () => positions,
           anchorEntries: entries,
           renderedRowCount: 2,
-          detailTriggerRef: { current: detail },
+          focusFallback: () => fallback.focus(),
         }),
       { initialProps: { viewKey: "everything", entries: anchorEntries } },
     );
@@ -1459,9 +1460,9 @@ describe("registered transcript view preservation", () => {
         });
       }, "Transcript display changed again");
     });
-    expect(document.activeElement).toBe(detail);
+    expect(document.activeElement).toBe(fallback);
     list.el.remove();
-    detail.remove();
+    fallback.remove();
   });
 
   test("waits for a virtualized source alias and restores the same descendant from Intent to Tools", () => {
@@ -1473,8 +1474,7 @@ describe("registered transcript view preservation", () => {
     const intentButton = document.createElement("button");
     intentAnchor.append(intentButton);
     list.el.append(intentAnchor);
-    const detail = document.createElement("button");
-    document.body.append(detail);
+    const focusFallback = vi.fn();
     intentButton.focus();
 
     let positions: ViewAnchorPosition[] = [
@@ -1493,7 +1493,7 @@ describe("registered transcript view preservation", () => {
           measureAnchors: () => positions,
           anchorEntries: entries,
           renderedRowCount: 2,
-          detailTriggerRef: { current: detail },
+          focusFallback,
         }),
       { initialProps: { viewKey: "intent", entries: intentEntries } },
     );
@@ -1509,7 +1509,7 @@ describe("registered transcript view preservation", () => {
       }, "Transcript display changed");
     });
     expect(list.scrollToIndex).toHaveBeenCalledWith(1, { align: "start" });
-    expect(document.activeElement).not.toBe(detail);
+    expect(focusFallback).not.toHaveBeenCalled();
 
     const toolAnchor = document.createElement("div");
     toolAnchor.dataset.viewAnchorId = "tool-1";
@@ -1521,9 +1521,8 @@ describe("registered transcript view preservation", () => {
     act(() => result.current.restoreAfterMeasurement());
 
     expect(document.activeElement).toBe(toolButton);
-    expect(document.activeElement).not.toBe(detail);
+    expect(focusFallback).not.toHaveBeenCalled();
     list.el.remove();
-    detail.remove();
   });
 });
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts
@@ -253,20 +253,33 @@ function focusNodeMatches(candidate: HTMLElement, metadata: CapturedFocusMetadat
   return metadata.sourceIndex === undefined || sourceIndex === undefined || sourceIndex === metadata.sourceIndex;
 }
 
-function focusAnchor(anchor: HTMLElement, metadata: CapturedFocusMetadata): void {
+function closedIntentSummary(anchor: HTMLElement): HTMLElement | undefined {
+  if (!anchor.dataset.viewAnchorId?.startsWith("intent:")) return undefined;
+  const details = anchor.closest<HTMLDetailsElement>('details[data-testid="intent-group"]:not([open])');
+  const summary = details?.querySelector(":scope > summary");
+  return summary instanceof HTMLElement ? summary : undefined;
+}
+
+function focusAnchor(anchor: HTMLElement, metadata: CapturedFocusMetadata): boolean {
+  const summary = closedIntentSummary(anchor);
+  if (summary) {
+    summary.focus();
+    if (summary.ownerDocument.activeElement === summary) return true;
+  }
   if (metadata.element.isConnected && anchor.contains(metadata.element)) {
     metadata.element.focus();
-    return;
+    if (metadata.element.ownerDocument.activeElement === metadata.element) return true;
   }
   const descendant = descendantAtPath(anchor, metadata.descendantPath);
   if (descendant && isFocusableDescendant(descendant)) {
     descendant.focus();
-    return;
+    if (descendant.ownerDocument.activeElement === descendant) return true;
   }
   // Production anchors are divs. Make only this programmatic fallback
   // focusable; tab order remains unchanged because -1 is not tabbable.
   anchor.tabIndex = -1;
   anchor.focus();
+  return anchor.ownerDocument.activeElement === anchor;
 }
 
 type FocusRestoreResult = "not-focused" | "restored" | "waiting" | "missing";
@@ -291,8 +304,7 @@ function focusCapturedEntry(
     focusNodeMatches(candidate, metadata),
   );
   if (focused) {
-    focusAnchor(focused, metadata);
-    return "restored";
+    return focusAnchor(focused, metadata) ? "restored" : "missing";
   }
 
   const logicalFocus = candidates.find((candidate) => focusCandidateMatches(candidate, metadata));
@@ -333,10 +345,6 @@ interface PendingTranscriptViewRestore {
   focusScrollRequested: boolean;
 }
 
-function focusFallbackForOptions(options: UseTranscriptViewRegistrationOptions): void {
-  options.focusFallback?.();
-}
-
 /**
  * Registers the shared body with the transition registry without taking
  * ownership of ordinary append/prepend scrolling. The body calls the result
@@ -367,7 +375,7 @@ export function useTranscriptViewRegistration(
       if (count > 0) currentOptions.listRef?.current?.scrollToIndex(count - 1, { align: "end" });
       const focusResult = focusCapturedEntry(el, pending.captured, candidates, currentOptions.listRef, pending);
       if (focusResult === "waiting") return;
-      if (focusResult === "missing") focusFallbackForOptions(currentOptions);
+      if (focusResult === "missing") currentOptions.focusFallback?.();
       pendingRef.current = null;
       return;
     }
@@ -404,7 +412,7 @@ export function useTranscriptViewRegistration(
 
     const focusResult = focusCapturedEntry(el, pending.captured, candidates, currentOptions.listRef, pending);
     if (focusResult === "waiting") return;
-    if (focusResult === "missing") focusFallbackForOptions(currentOptions);
+    if (focusResult === "missing") currentOptions.focusFallback?.();
     pendingRef.current = null;
   }, []);
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts
@@ -317,8 +317,7 @@ export interface UseTranscriptViewRegistrationOptions {
   measureAnchors?: (el: HTMLElement) => ViewAnchorPosition[];
   anchorEntries?: readonly Omit<ViewAnchorPosition, "offset" | "height">[];
   renderedRowCount?: number;
-  detailTriggerRef?: RefObject<HTMLElement | null>;
-  focusDetailTrigger?: () => void;
+  focusFallback?: () => void;
   announce?: (summary: string) => void;
 }
 
@@ -334,12 +333,8 @@ interface PendingTranscriptViewRestore {
   focusScrollRequested: boolean;
 }
 
-function focusDetailForOptions(options: UseTranscriptViewRegistrationOptions): void {
-  if (options.focusDetailTrigger) {
-    options.focusDetailTrigger();
-    return;
-  }
-  options.detailTriggerRef?.current?.focus();
+function focusFallbackForOptions(options: UseTranscriptViewRegistrationOptions): void {
+  options.focusFallback?.();
 }
 
 /**
@@ -372,7 +367,7 @@ export function useTranscriptViewRegistration(
       if (count > 0) currentOptions.listRef?.current?.scrollToIndex(count - 1, { align: "end" });
       const focusResult = focusCapturedEntry(el, pending.captured, candidates, currentOptions.listRef, pending);
       if (focusResult === "waiting") return;
-      if (focusResult === "missing") focusDetailForOptions(currentOptions);
+      if (focusResult === "missing") focusFallbackForOptions(currentOptions);
       pendingRef.current = null;
       return;
     }
@@ -409,7 +404,7 @@ export function useTranscriptViewRegistration(
 
     const focusResult = focusCapturedEntry(el, pending.captured, candidates, currentOptions.listRef, pending);
     if (focusResult === "waiting") return;
-    if (focusResult === "missing") focusDetailForOptions(currentOptions);
+    if (focusResult === "missing") focusFallbackForOptions(currentOptions);
     pendingRef.current = null;
   }, []);
 
@@ -435,15 +430,6 @@ export function useTranscriptViewRegistration(
     };
   }, []);
 
-  const focusDetailTrigger = useCallback(() => {
-    const currentOptions = optionsRef.current;
-    if (currentOptions.focusDetailTrigger) {
-      currentOptions.focusDetailTrigger();
-      return;
-    }
-    currentOptions.detailTriggerRef?.current?.focus();
-  }, []);
-
   const announce = useCallback((summary: string) => {
     optionsRef.current.announce?.(summary);
   }, []);
@@ -455,10 +441,9 @@ export function useTranscriptViewRegistration(
       layout,
       capture,
       restore,
-      focusDetailTrigger,
       announce,
     });
-  }, [announce, capture, enabled, focusDetailTrigger, id, layout, restore]);
+  }, [announce, capture, enabled, id, layout, restore]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: viewKey is deliberately trigger-only
   useLayoutEffect(() => {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/transcriptDisplay.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/transcriptDisplay.module.css
@@ -46,24 +46,10 @@
   }
 }
 
-.detailControl {
-  min-width: 0;
-}
-
 .detailPanel {
-  box-sizing: border-box;
-  inline-size: min(42rem, calc(100vw - var(--space-8)));
-  max-block-size: calc(100dvh - var(--space-8));
-  padding: var(--space-4);
-  overflow-y: auto;
+  min-width: 0;
   container-type: inline-size;
   container-name: transcript-detail-panel;
-}
-
-.detailPanelTitle {
-  margin: 0;
-  color: var(--ink-hi);
-  font-size: var(--font-size-pane-title);
 }
 
 .detailContent,

--- a/cmd/evener-hub/frontend/src/panes/transcript/Transcript.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/transcript/Transcript.test.tsx
@@ -1,5 +1,4 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { lazy } from "react";
 import { afterAll, afterEach, beforeEach, expect, test, vi } from "vitest";
 import { FakeClient } from "../../protocol/testing/fakeClient";
@@ -204,10 +203,10 @@ test("renders the thread's turns through the shared VirtualList/TurnBlock engine
   expect(within(screen.getByTestId("subagent-row")).getByText("Status: done")).toBeTruthy();
 });
 
-test("keeps the read-only Detail control reachable above the transcript", async () => {
+test("keeps transcript/history and projection announcements without standalone Detail or Verbosity controls", async () => {
   const fake = connectFakeClient();
-  fake.on("thread/read", () =>
-    readResponse("ref_a", {
+  fake.on("thread/read", () => ({
+    ...readResponse("ref_a", {
       turns: [
         {
           id: "turn_1",
@@ -217,8 +216,11 @@ test("keeps the read-only Detail control reachable above the transcript", async 
         },
       ],
     }),
-  );
-  const user = userEvent.setup();
+    olderCursor: "cursor_1",
+  }));
+  fake.on("thread/turns/list", () => {
+    throw new Error("older history unavailable");
+  });
 
   render(
     <ClientProvider client={fake}>
@@ -226,10 +228,10 @@ test("keeps the read-only Detail control reachable above the transcript", async 
     </ClientProvider>,
   );
 
-  const trigger = await screen.findByRole("button", { name: /^Detail:/ });
-  expect(trigger.closest('[data-testid="transcript-virtual-list"]')).toBeNull();
-  await user.click(trigger);
-  expect(screen.getByRole("radio", { name: "Tools" })).toBeTruthy();
+  expect(await screen.findByText("read me")).toBeTruthy();
+  expect(screen.getByTestId("load-older-row").textContent).not.toBe("");
+  expect(screen.queryByRole("button", { name: /^Detail:/ })).toBeNull();
+  expect(screen.queryByRole("menuitem", { name: "Verbosity…" })).toBeNull();
   transcriptDisplayStore.setState({ viewport: "desktop" });
   transcriptDisplayStore
     .getState()

--- a/cmd/evener-hub/frontend/src/panes/transcript/Transcript.tsx
+++ b/cmd/evener-hub/frontend/src/panes/transcript/Transcript.tsx
@@ -17,7 +17,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useStore } from "zustand";
 import type { PaneProps } from "../../shell/paneRegistry";
-import { navigate, paneToURL } from "../../shell/routing";
 import { connectionStore } from "../../stores/connection";
 import { threadsStore } from "../../stores/threads";
 import { transcriptDisplayStore } from "../../stores/transcriptDisplay";
@@ -27,7 +26,6 @@ import { VisuallyHidden } from "../../widgets/internal/VisuallyHidden";
 import { NOW_TICK_MS, SessionNowContext, useNowTick } from "../session/liveness";
 import { LoadOlderRow } from "../session/transcript/flow/LoadOlderRow";
 import { TranscriptBody } from "../session/transcript/TranscriptBody";
-import { TranscriptDetailControl } from "../session/transcript/TranscriptDetailControl";
 import { useTranscript } from "../session/transcript/useTranscript";
 import { JobLog } from "./JobLog";
 
@@ -86,7 +84,6 @@ function ThreadTranscript({ params, paneId }: { params: TranscriptParams; paneId
   // Session.tsx's own comment on the same wiring.
   const { model, loadingOlder, loadOlderReportingError, olderError } = useTranscript(ref);
   const listRef = useRef<VirtualListHandle>(null);
-  const detailTriggerRef = useRef<HTMLButtonElement>(null);
   const announcementSequence = useRef(0);
   const [viewAnnouncement, setViewAnnouncement] = useState({ text: "", key: 0 });
 
@@ -135,17 +132,6 @@ function ThreadTranscript({ params, paneId }: { params: TranscriptParams; paneId
           disclosureScope={`transcript:readOnly:${ref}`}
           sessionRef={ref}
           viewId={paneId}
-          detailTriggerRef={detailTriggerRef}
-          toolbar={
-            <TranscriptDetailControl
-              layout={displayViewport}
-              triggerRef={detailTriggerRef}
-              onEditHubDefaults={() => {
-                const url = paneToURL("settings", { section: "transcript" });
-                if (url !== null) navigate(url);
-              }}
-            />
-          }
           onAnnounceViewChange={(summary) => {
             announcementSequence.current += 1;
             setViewAnnouncement({ text: `Transcript detail: ${summary}`, key: announcementSequence.current });

--- a/cmd/evener-hub/frontend/src/shell/sessionMenu/SessionMenu.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/sessionMenu/SessionMenu.test.tsx
@@ -93,6 +93,31 @@ test("panes group leads with open-state checkmarks and dispatches onOpenPane", a
   expect(actions.onOpenPane).toHaveBeenCalledWith("tasks");
 });
 
+test("pane-only Verbosity follows Activity, precedes the first separator, and dispatches its callback", async () => {
+  const user = userEvent.setup();
+  const onOpenVerbosity = vi.fn();
+  renderMenu({ onOpenVerbosity });
+  await openMenu(user);
+
+  const menu = screen.getByRole("menu");
+  const verbosity = within(menu).getByRole("menuitem", { name: "Verbosity…" });
+  const activity = within(menu).getByRole("menuitem", { name: "Activity" });
+  const firstSeparator = within(menu).getAllByRole("separator")[0];
+  if (!firstSeparator) throw new Error("Session menu is missing its first separator");
+  expect(activity.compareDocumentPosition(verbosity) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+  expect(verbosity.compareDocumentPosition(firstSeparator) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+
+  await user.click(verbosity);
+  expect(onOpenVerbosity).toHaveBeenCalledOnce();
+});
+
+test("rail-style callers that omit the pane-only callback do not get Verbosity", async () => {
+  const user = userEvent.setup();
+  renderMenu({ triggerLabel: "Actions for My session" });
+  await user.click(screen.getByRole("button", { name: "Actions for My session" }));
+  expect(screen.queryByRole("menuitem", { name: "Verbosity…" })).toBeNull();
+});
+
 test("live labels replace the plain pane names", async () => {
   const user = userEvent.setup();
   renderMenu({ taskLabel: "Tasks 3/7", activityLabel: "Activity · 2" });

--- a/cmd/evener-hub/frontend/src/shell/sessionMenu/SessionMenu.tsx
+++ b/cmd/evener-hub/frontend/src/shell/sessionMenu/SessionMenu.tsx
@@ -52,6 +52,8 @@ export interface SessionMenuProps {
   panesOpen: { details: boolean; tasks: boolean; activity: boolean };
   taskLabel?: string; // e.g. "Tasks 3/7"; defaults to "Tasks"
   activityLabel?: string; // e.g. "Activity · 2"; defaults to "Activity"
+  /** Pane-only action. Rail/sidebar callers omit it. */
+  onOpenVerbosity?: () => void;
   actions: SessionMenuActions;
   triggerTabIndex?: number; // -1 inside rail rows (roving tabindex contract)
 }
@@ -77,6 +79,7 @@ export function SessionMenu({
   panesOpen,
   taskLabel,
   activityLabel,
+  onOpenVerbosity,
   actions,
   triggerTabIndex,
 }: SessionMenuProps) {
@@ -122,6 +125,9 @@ export function SessionMenu({
       onSelect: () => actions.onOpenPane("activity"),
     },
   ];
+  if (onOpenVerbosity) {
+    paneItems.push({ id: "verbosity", label: "Verbosity…", onSelect: onOpenVerbosity });
+  }
   const organizeItems: MenuEntry[] = [
     {
       id: "rename",

--- a/cmd/evener-hub/frontend/src/stores/transcriptDisplay.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/transcriptDisplay.test.ts
@@ -128,7 +128,6 @@ describe("effective transcript display state", () => {
         return leftSnapshot;
       }),
       restore: vi.fn(() => events.push("restore:left")),
-      focusDetailTrigger: vi.fn(),
       announce: vi.fn(() => events.push("announce:left")),
     };
     const right = {
@@ -138,7 +137,6 @@ describe("effective transcript display state", () => {
         return rightSnapshot;
       }),
       restore: vi.fn(() => events.push("restore:right")),
-      focusDetailTrigger: vi.fn(),
       announce: vi.fn(() => events.push("announce:right")),
     };
     const unregisterLeft = registerTranscriptView(left);
@@ -168,7 +166,6 @@ describe("effective transcript display state", () => {
       id: "pane",
       capture,
       restore: vi.fn(),
-      focusDetailTrigger: vi.fn(),
       announce,
     });
 
@@ -188,7 +185,6 @@ describe("effective transcript display state", () => {
       id: "announcement-pane",
       capture: vi.fn(() => viewSnapshot("announcement-pane")),
       restore: vi.fn(),
-      focusDetailTrigger: vi.fn(),
       announce,
     });
     const timings = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" }, { roundTimings: true });
@@ -210,7 +206,6 @@ describe("effective transcript display state", () => {
         return viewSnapshot("pane");
       }),
       restore: vi.fn(() => events.push("restore")),
-      focusDetailTrigger: vi.fn(),
       announce: vi.fn(() => events.push("announce")),
     });
     const sameConfig = preset("full");
@@ -733,7 +728,6 @@ test("routes a storage reset through capture/restore, while masking a non-curren
     id: "pane",
     capture,
     restore,
-    focusDetailTrigger: vi.fn(),
     announce,
   });
 

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/config.test.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/config.test.ts
@@ -25,9 +25,17 @@ import {
 describe("transcript display config", () => {
   const LEVELS = ["chat", "intent", "tools", "activity", "full"] as const;
 
+  test("Chat enables intent proxies without expanding them (catches toolIntent=false)", () => {
+    expect(presetContent("chat")).toMatchObject({ toolIntent: true, toolCalls: false, expandByDefault: false });
+  });
+
+  test("Intent keeps generic detail expansion disabled", () => {
+    expect(presetContent("intent")).toMatchObject({ toolIntent: true, toolCalls: false, expandByDefault: false });
+  });
+
   test("expands the five cumulative content presets", () => {
     expect(presetContent("chat")).toEqual({
-      toolIntent: false,
+      toolIntent: true,
       toolCalls: false,
       reasoning: false,
       expandByDefault: false,

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/config.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/config.ts
@@ -50,7 +50,7 @@ export const CONTENT_LEVELS = ["chat", "intent", "tools", "activity", "full"] as
 export const HOOK_EXIT_DETAILS = ["none", "successful", "all"] as const;
 
 const CONTENT_VECTORS: Readonly<Record<ContentLevel, ContentVector>> = {
-  chat: { toolIntent: false, toolCalls: false, reasoning: false, expandByDefault: false },
+  chat: { toolIntent: true, toolCalls: false, reasoning: false, expandByDefault: false },
   intent: { toolIntent: true, toolCalls: false, reasoning: false, expandByDefault: false },
   tools: { toolIntent: true, toolCalls: true, reasoning: false, expandByDefault: false },
   activity: { toolIntent: true, toolCalls: true, reasoning: true, expandByDefault: false },

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/designSystemContract.test.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/designSystemContract.test.ts
@@ -163,7 +163,7 @@ test("keeps transcript display surfaces on shared design-system primitives", () 
   expect(settingsCard).toMatch(/<Button(?:\s|>)/);
   expect(settingsCard).toMatch(/<Card(?:\s|>)/);
   expect(liveControl).toMatch(/<Button(?:\s|>)/);
-  expect(liveControl).toMatch(/<Popover(?:\s|>)/);
+  expect(liveControl).toMatch(/<Dialog(?:\s|>)/);
   expect(liveControl).toMatch(/<Sheet(?:\s|>)/);
   expect(editor).not.toMatch(/<(?:button|input|select|textarea)\b/);
   expect(settingsCard).not.toMatch(/<(?:button|input|select|textarea)\b/);
@@ -171,7 +171,7 @@ test("keeps transcript display surfaces on shared design-system primitives", () 
   expect(settingsCard).not.toMatch(/(?:style|width)\s*=\s*[{"]|style\s*:/i);
 });
 
-test("keeps feature rules from taking shared Card and Popover chrome", () => {
+test("keeps feature rules from taking shared Card and overlay chrome", () => {
   const cardPath = "src/panes/settings/sections/transcriptDisplayCard.module.css";
   const contentRule = expectExactlyOneRule(cardPath, ".content");
   expectDeclarations(contentRule, [
@@ -184,11 +184,7 @@ test("keeps feature rules from taking shared Card and Popover chrome", () => {
   const detailPath = "src/panes/session/transcript/transcriptDisplay.module.css";
   const detailRule = expectExactlyOneRule(detailPath, ".detailPanel");
   expectDeclarations(detailRule, [
-    ["box-sizing", "border-box"],
-    ["inline-size", "min(42rem, calc(100vw - var(--space-8)))"],
-    ["max-block-size", "calc(100dvh - var(--space-8))"],
-    ["padding", "var(--space-4)"],
-    ["overflow-y", "auto"],
+    ["min-width", "0"],
     ["container-type", "inline-size"],
     ["container-name", "transcript-detail-panel"],
   ]);
@@ -200,13 +196,12 @@ test("keeps feature rules from taking shared Card and Popover chrome", () => {
       [".detailStatus,\n.detailWarning", [["background", "var(--surface-inset)"]]],
     ]),
   );
-  expectOnlyAllowedOverflow(detailPath, new Map([[".detailPanel", [["overflow-y", "auto"]]]]));
+  expectOnlyAllowedOverflow(detailPath, new Map());
   expectOnlyAllowedPadding(
     detailPath,
     new Map([
       [".fieldset", [["padding", "0"]]],
       [".fieldset legend", [["padding", "0"]]],
-      [".detailPanel", [["padding", "var(--space-4)"]]],
       [".detailStatus,\n.detailWarning", [["padding", "var(--space-2) var(--space-3)"]]],
     ]),
   );

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts
@@ -52,10 +52,72 @@ function entriesFor(model: ThreadModel, config: TranscriptDisplayConfigV1) {
 }
 
 describe("transcript projector", () => {
+  test("Chat projects ordinary commands as intent proxies (catches toolIntent=false)", () => {
+    const model = threadWith(item("tool-1", "commandExecution", { description: "Inspect the tree" }));
+
+    expect(entriesFor(model, preset("chat"))).toEqual([
+      expect.objectContaining({
+        kind: "intent",
+        id: "intent:tool-1",
+        sourceItemId: "tool-1",
+        rationale: "Inspect the tree",
+        failed: false,
+      }),
+    ]);
+  });
+
+  test("intent-only vectors keep failed and active ordinary calls as proxies (catches critical escalation)", () => {
+    const model = threadWith(
+      item("failed-tool", "commandExecution", {
+        toolName: "shell",
+        description: "Run checks",
+        error: "denied",
+      }),
+      item("active-tool", "commandExecution", {
+        toolName: "shell",
+        description: "Keep checking",
+        status: "inProgress",
+      }),
+      item("blank-tool", "commandExecution", {
+        toolName: "shell",
+        description: "   ",
+        status: "failed",
+      }),
+    );
+    const intentOnly = custom({ toolIntent: true, toolCalls: false, reasoning: false, expandByDefault: false });
+
+    expect(entriesFor(model, intentOnly)).toEqual([
+      expect.objectContaining({ kind: "intent", id: "intent:failed-tool", rationale: "Run checks", failed: true }),
+      expect.objectContaining({ kind: "intent", id: "intent:active-tool", rationale: "Keep checking", failed: false }),
+      expect.objectContaining({
+        kind: "intent",
+        id: "intent:blank-tool",
+        rationale: "Action summary unavailable",
+        failed: true,
+      }),
+    ]);
+  });
+
+  test("Tools and above keep ordinary failed and active calls as full items", () => {
+    const model = threadWith(
+      item("failed-tool", "commandExecution", { description: "Run checks", status: "failed" }),
+      item("active-tool", "commandExecution", { description: "Keep checking", status: "inProgress" }),
+    );
+
+    for (const level of ["tools", "activity", "full"] as const) {
+      expect(entriesFor(model, preset(level))).toEqual([
+        expect.objectContaining({ kind: "item", id: "failed-tool" }),
+        expect.objectContaining({ kind: "item", id: "active-tool" }),
+      ]);
+    }
+  });
+
   test("uses an intent proxy until the real tool row supersedes it", () => {
     const model = threadWith(item("tool-1", "commandExecution", { description: "Inspect the tree" }));
 
-    expect(entriesFor(model, preset("chat"))).toEqual([]);
+    expect(entriesFor(model, preset("chat"))).toEqual([
+      expect.objectContaining({ kind: "intent", id: "intent:tool-1", rationale: "Inspect the tree" }),
+    ]);
     expect(entriesFor(model, preset("intent"))).toEqual([
       expect.objectContaining({ kind: "intent", id: "intent:tool-1", rationale: "Inspect the tree" }),
     ]);
@@ -63,7 +125,7 @@ describe("transcript projector", () => {
   });
 
   test.each([
-    ["chat", ["user", "agent"]],
+    ["chat", ["user", "intent:tool", "agent"]],
     ["intent", ["user", "intent:tool", "agent"]],
     ["tools", ["user", "tool", "agent"]],
     ["activity", ["user", "tool", "think", "agent"]],
@@ -112,7 +174,7 @@ describe("transcript projector", () => {
   });
 
   test.each(["chat", "intent", "tools", "activity", "full"] as const)(
-    "keeps critical interaction and failure rows at the %s level",
+    "keeps interactions and non-tool failures critical at the %s level",
     (level) => {
       const model = threadWith(
         item("ask", "commandExecution", { toolName: "ask_user", description: "Ask for a choice" }),
@@ -132,21 +194,19 @@ describe("transcript projector", () => {
         item("turn-error", "systemMessage", { eventKind: "error", text: "Failure" }),
       );
       const entries = entriesFor(model, preset(level));
-      expect(entries.map((entry) => entry.id)).toEqual([
-        "ask",
-        "failed-tool",
-        "active-tool",
-        "hook-failure",
-        "warning",
-        "steer",
-        "turn-error",
-      ]);
-      expect(entries.find((entry) => entry.id === "ask")?.kind).toBe("critical");
-      expect(entries.find((entry) => entry.id === "failed-tool")?.kind).toBe(
-        level === "chat" || level === "intent" ? "critical" : "item",
+      expect(entries.map((entry) => entry.id)).toEqual(
+        level === "chat" || level === "intent"
+          ? ["ask", "intent:failed-tool", "intent:active-tool", "hook-failure", "warning", "steer", "turn-error"]
+          : ["ask", "failed-tool", "active-tool", "hook-failure", "warning", "steer", "turn-error"],
       );
-      expect(entries.find((entry) => entry.id === "active-tool")?.kind).toBe(
-        level === "chat" || level === "intent" ? "critical" : "item",
+      expect(entries.find((entry) => entry.id === "ask")?.kind).toBe("critical");
+      const failedId = level === "chat" || level === "intent" ? "intent:failed-tool" : "failed-tool";
+      const activeId = level === "chat" || level === "intent" ? "intent:active-tool" : "active-tool";
+      expect(entries.find((entry) => entry.id === failedId)?.kind).toBe(
+        level === "chat" || level === "intent" ? "intent" : "item",
+      );
+      expect(entries.find((entry) => entry.id === activeId)?.kind).toBe(
+        level === "chat" || level === "intent" ? "intent" : "item",
       );
       expect(entries.find((entry) => entry.id === "hook-failure")?.kind).toBe("critical");
       for (const id of ["warning", "steer", "turn-error"]) {
@@ -167,7 +227,11 @@ describe("transcript projector", () => {
       }),
     ]);
     expect(entriesFor(model, preset("chat"))).toEqual([
-      expect.objectContaining({ kind: "critical", id: "blank-tool", summary: "Action summary unavailable" }),
+      expect.objectContaining({
+        kind: "intent",
+        id: "intent:blank-tool",
+        rationale: "Action summary unavailable",
+      }),
     ]);
     for (const level of ["tools", "activity", "full"] as const) {
       expect(entriesFor(model, preset(level))).toEqual([
@@ -282,7 +346,7 @@ describe("transcript projector", () => {
       turns: [turn([item("status-only-active", "commandExecution", { toolName: "shell" })], { status: "inProgress" })],
     } as ThreadModel;
     expect(entriesFor(turnStillOpening, preset("chat"))).toEqual([
-      expect.objectContaining({ kind: "critical", id: "status-only-active" }),
+      expect.objectContaining({ kind: "intent", id: "intent:status-only-active", failed: false }),
     ]);
   });
 
@@ -318,8 +382,11 @@ describe("transcript projector", () => {
     const model = { ...threadWith(), turns: [terminalTurn] } as ThreadModel;
 
     const projection = projectThread(model, preset("chat"));
-    expect(projection.turns[0]?.entries.map((entry) => entry.id)).toEqual(["failed-command", "failed-reasoning"]);
-    expect(projection.turns[0]?.entries.every((entry) => entry.kind === "critical")).toBe(true);
+    expect(projection.turns[0]?.entries.map((entry) => entry.id)).toEqual([
+      "intent:failed-command",
+      "failed-reasoning",
+    ]);
+    expect(projection.turns[0]?.entries.map((entry) => entry.kind)).toEqual(["intent", "critical"]);
     expect(projection.turns[0]?.source).toBe(terminalTurn);
     expect(projection.turns[0]?.source.status).toBe("failed");
     expect(projection.turns[0]?.source.error).toEqual({ message: "structured turn failure" });
@@ -406,8 +473,8 @@ describe("transcript projector", () => {
       "warning",
       "agent",
     ]);
-    expect(projected?.visibleItems.map((item) => item.id)).toEqual(["user", "warning", "agent"]);
-    expect(projected?.entries.map((entry) => entry.id)).toEqual(["user", "warning", "agent"]);
+    expect(projected?.visibleItems.map((item) => item.id)).toEqual(["user", "hidden-tool", "warning", "agent"]);
+    expect(projected?.entries.map((entry) => entry.id)).toEqual(["user", "intent:hidden-tool", "warning", "agent"]);
   });
 
   test("preserves source turns and does not mutate the input model or items", () => {

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
@@ -18,6 +18,7 @@ export type ProjectedEntry =
       sourceIndex: number;
       sourceItemId: string;
       rationale: string;
+      failed: boolean;
     }
   | {
       kind: "critical";
@@ -172,6 +173,7 @@ function intentEntry(item: ItemModel, turnId: string, sourceIndex: number): Proj
     sourceIndex,
     sourceItemId: item.id,
     rationale,
+    failed: hasItemFailure(item),
   };
 }
 
@@ -223,16 +225,17 @@ function decisionFor(
 
     // Questions and approvals are interaction rows at every regular level.
     if (interaction) return "critical";
-    // The ordinary item shape has no projected summary field. Keep a
-    // purpose-less call on the critical path at every level so its renderer
+    // The ordinary item shape has no projected summary field. At tool-call
+    // levels, keep a purpose-less call on the critical path so its renderer
     // receives the exact neutral summary instead of inventing one from the
-    // tool name.
+    // tool name. Intent-only levels use the proxy's rationale field instead.
     if (vector.toolCalls && missingPurpose) return "critical";
     if (vector.toolCalls) return "item";
-    if (failure || active || (isTerminalTurn(turn) && !vector.toolCalls)) return "critical";
     if (vector.toolIntent) return "intent";
-    // Chat omits routine action rows, but a call with no purpose is not
-    // routine-readable content: keep it as the neutral critical contract.
+    if (failure || active || (isTerminalTurn(turn) && !vector.toolCalls)) return "critical";
+    // A Custom vector may disable both calls and intent. Even there, a call
+    // with no purpose is not routine-readable content: keep its neutral
+    // critical contract rather than inventing a summary from the tool name.
     return missingPurpose ? "critical" : "hidden";
   }
 

--- a/cmd/evener-hub/frontend/src/widgets/disclosure/disclosure.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/disclosure/disclosure.module.css
@@ -27,6 +27,12 @@
   opacity: 0.5;
 }
 
+@media (max-width: 899px) {
+  .summary {
+    min-height: var(--tap-min);
+  }
+}
+
 /* The open disclosure's own persistent affordance - the same "which one is
  * currently active" wash Menu's quiet trigger keeps while its popup is open
  * (menu.module.css's .triggerQuiet[aria-expanded="true"]), so a reader

--- a/cmd/evener-hub/frontend/src/widgets/disclosure/disclosure.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/disclosure/disclosure.test.tsx
@@ -221,6 +221,12 @@ test("disabled styling attenuates only the summary and suppresses its hover wash
   expect(css).not.toMatch(/\.body[^}]*opacity\s*:/);
 });
 
+test("keeps the summary at the narrow-viewport tap floor", () => {
+  expect(motionCss()).toMatch(
+    /@media\s*\(max-width:\s*899px\)\s*\{[\s\S]*?\.summary\s*\{[^}]*min-height:\s*var\(--tap-min\)/,
+  );
+});
+
 // --- A6: opening animates, subtly, and honors prefers-reduced-motion -----
 
 test("the chevron rotation and the body fade are declared with real motion", () => {

--- a/cmd/evener-hub/frontend/src/widgets/menu/menu.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/menu/menu.module.css
@@ -56,6 +56,8 @@
   position: fixed;
   z-index: var(--z-menu);
   min-width: 180px;
+  max-block-size: calc(100dvh - (2 * var(--space-2)));
+  overflow-y: auto;
   margin: 0;
   padding: var(--space-1) 0;
   list-style: none;
@@ -74,6 +76,16 @@
   to {
     opacity: 1;
     transform: scale(1);
+  }
+}
+
+@keyframes menuFade {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
   }
 }
 
@@ -110,6 +122,23 @@
   outline: var(--focus-ring);
   outline-offset: -2px;
   background: var(--hover-1);
+}
+
+@media (max-width: 899px) {
+  .popup {
+    animation-name: menuFade;
+  }
+
+  .trigger {
+    min-height: var(--tap-min);
+  }
+
+  .item {
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    min-height: var(--tap-min);
+  }
 }
 
 .itemDisabled {

--- a/cmd/evener-hub/frontend/src/widgets/menu/menu.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/menu/menu.test.tsx
@@ -272,6 +272,13 @@ test("declares a :focus-visible rule in its CSS module, using only tokens", () =
   expect(css).toContain(":focus-visible");
 });
 
+test("keeps the menu trigger and items at the narrow-viewport tap floor", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const css = readFileSync(join(here, "menu.module.css"), "utf8");
+  expect(css).toMatch(/@media\s*\(max-width:\s*899px\)\s*\{[\s\S]*?\.trigger\s*\{[^}]*min-height:\s*var\(--tap-min\)/);
+  expect(css).toMatch(/@media\s*\(max-width:\s*899px\)\s*\{[\s\S]*?\.item\s*\{[^}]*min-height:\s*var\(--tap-min\)/);
+});
+
 // jsdom does not evaluate real CSS animations or media queries - see the
 // exemplar/dialog pattern this mirrors.
 test("the popup's open animation honors prefers-reduced-motion, using only tokens", () => {


### PR DESCRIPTION
## Summary

- move transcript verbosity controls into the open Session pane’s **Session actions** menu and remove live/read-only transcript toolbar buttons
- reuse the full editor in a desktop Dialog or mobile bottom Sheet while preserving local/hub defaults, projection, announcements, and focus behavior
- correct verbosity semantics: Chat shows closed action summaries, Intent opens those summaries by default, failed intents carry the accessible failure glyph, and streaming updates retain row/disclosure identity
- preserve failed-turn recovery chrome and harden responsive/browser guards, including short mobile menus, Tools→Chat focus, and Linux scrollbar-aware dialog centering

## Testing

- focused Chat/Intent/failure/focus suites (278 tests on the final integrated feature tree)
- `make test-web`
- `make test-web-browser`
- `make lint`
- `make vet`
- `make test`
- Linux Chromium `overflowguard` at 1024px and 1400px
