### PR TITLE
fix(plugins): remove legacy 'git' source-kind alias

### DIFF
--- a/appwire/cov_rhub_appwire_test.go
+++ b/appwire/cov_rhub_appwire_test.go
@@ -450,8 +450,8 @@ func TestClientRequestWrappersRoundTrip(t *testing.T) {
 		}},
 		{"CommandList", MethodEvenerCommandList, `{}`, map[string]any{}, func(ctx context.Context, c *Client) error { _, err := c.CommandList(ctx); return err }},
 		{"MarketplaceList", MethodEvenerMarketplaceList, `{}`, map[string]any{}, func(ctx context.Context, c *Client) error { _, err := c.MarketplaceList(ctx); return err }},
-		{"MarketplaceAdd", MethodEvenerMarketplaceAdd, `{"name":"acme","source":{"kind":"git","repo":"acme/plugins"}}`, map[string]any{}, func(ctx context.Context, c *Client) error {
-			_, err := c.MarketplaceAdd(ctx, MarketplaceAddParams{Name: "acme", Source: MarketplaceSourceInput{Kind: "git", Repo: "acme/plugins"}})
+		{"MarketplaceAdd", MethodEvenerMarketplaceAdd, `{"name":"acme","source":{"kind":"url","repo":"acme/plugins"}}`, map[string]any{}, func(ctx context.Context, c *Client) error {
+			_, err := c.MarketplaceAdd(ctx, MarketplaceAddParams{Name: "acme", Source: MarketplaceSourceInput{Kind: "url", Repo: "acme/plugins"}})
 			return err
 		}},
 		{"MarketplaceRemove", MethodEvenerMarketplaceRemove, `{"name":"acme"}`, map[string]any{}, func(ctx context.Context, c *Client) error {

--- a/internal/plugins/package_union_fuzz_test.go
+++ b/internal/plugins/package_union_fuzz_test.go
@@ -20,7 +20,7 @@ func FuzzPackageUnion(f *testing.F) {
 		t.Run("TestUpgrade_ManifestLessPlugin_FallbackAppliedToNewShaDir", TestUpgrade_ManifestLessPlugin_FallbackAppliedToNewShaDir)
 		t.Run("TestSource_UnmarshalObjectForms", TestSource_UnmarshalObjectForms)
 		t.Run("TestSource_UnmarshalStringForm", TestSource_UnmarshalStringForm)
-		t.Run("TestSource_MarshalNeverWritesGit", TestSource_MarshalNeverWritesGit)
+		t.Run("TestSource_MarshalWritesCanonicalKind", TestSource_MarshalWritesCanonicalKind)
 		t.Run("TestSource_UnmarshalRejectsUnknownKind", TestSource_UnmarshalRejectsUnknownKind)
 		t.Run("TestSource_RelSurvivesRoundTrip", TestSource_RelSurvivesRoundTrip)
 		t.Run("TestList_FlagsBroken", TestList_FlagsBroken)

--- a/internal/plugins/source.go
+++ b/internal/plugins/source.go
@@ -74,9 +74,6 @@ func (s *Source) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	kind := SourceKind(j.Source)
-	if kind == "git" { // read-only legacy alias
-		kind = SourceURL
-	}
 	switch kind {
 	case SourceDirectory, SourceGitHub, SourceURL, SourceGitSubdir:
 	default:

--- a/internal/plugins/source_fuzz_test.go
+++ b/internal/plugins/source_fuzz_test.go
@@ -11,8 +11,7 @@ import (
 // entry's custom source decoder (bare-string and object forms) — with
 // arbitrary bytes. Invariants: it never panics on any input, and every source
 // it accepts round-trips through MarshalJSON/UnmarshalJSON with a stable Kind
-// (the decode normalizes legacy aliases like "git" -> url, so re-decoding the
-// marshaled form must reproduce the same normalized Kind).
+// (re-decoding the marshaled form must reproduce the same Kind).
 func FuzzSourceUnmarshalJSON(f *testing.F) {
 	for _, s := range []string{
 		`"./subdir"`,
@@ -20,8 +19,7 @@ func FuzzSourceUnmarshalJSON(f *testing.F) {
 		`{"source":"url","url":"https://example.com/x.git"}`,
 		`{"source":"git-subdir","url":"https://example.com/x.git","path":"sub"}`,
 		`{"source":"directory","path":"./d","rel":true}`,
-		`{"source":"git","url":"https://example.com/x.git"}`, // legacy alias -> url
-		`{"source":"npm","package":"whatever"}`,              // unknown -> error
+		`{"source":"npm","package":"whatever"}`, // unknown -> error
 		`{}`,
 		``,
 		`null`,

--- a/internal/plugins/source_test.go
+++ b/internal/plugins/source_test.go
@@ -11,7 +11,6 @@ func TestSource_UnmarshalObjectForms(t *testing.T) {
 		`{"source":"url","url":"https://x/y.git"}`:                   {Kind: SourceURL, URL: "https://x/y.git"},
 		`{"source":"directory","path":"/abs"}`:                       {Kind: SourceDirectory, Path: "/abs"},
 		`{"source":"git-subdir","url":"https://x.git","path":"a/b"}`: {Kind: SourceGitSubdir, URL: "https://x.git", Path: "a/b"},
-		`{"source":"git","url":"https://x/y.git"}`:                   {Kind: SourceURL, URL: "https://x/y.git"}, // legacy alias
 	}
 	for in, want := range cases {
 		var s Source
@@ -34,7 +33,7 @@ func TestSource_UnmarshalStringForm(t *testing.T) {
 	}
 }
 
-func TestSource_MarshalNeverWritesGit(t *testing.T) {
+func TestSource_MarshalWritesCanonicalKind(t *testing.T) {
 	b, _ := json.Marshal(Source{Kind: SourceURL, URL: "https://x/y.git"})
 	if got := string(b); got == `{"source":"git","url":"https://x/y.git"}` || !json.Valid(b) {
 		t.Fatalf("marshalled = %s", got)
@@ -47,9 +46,11 @@ func TestSource_MarshalNeverWritesGit(t *testing.T) {
 }
 
 func TestSource_UnmarshalRejectsUnknownKind(t *testing.T) {
-	var s Source
-	if err := json.Unmarshal([]byte(`{"source":"bogus"}`), &s); err == nil {
-		t.Fatal("Unmarshal accepted unknown source kind; want error")
+	for _, in := range []string{`{"source":"bogus"}`, `{"source":"git"}`} {
+		var s Source
+		if err := json.Unmarshal([]byte(in), &s); err == nil {
+			t.Fatalf("Unmarshal(%s) accepted unknown source kind; want error", in)
+		}
 	}
 }
 


### PR DESCRIPTION
The 'git' source kind was a read-only legacy alias for 'url' (SourceURL),
kept for old plugin configs from the Serf era. In zero-back-compat land,
this should not exist; users should run 'evener-migrate' to update old
configs instead of silently absorbing the old kind at load time.

Removed the alias from Source.UnmarshalJSON and updated all tests:
- source_test.go: removed the 'git' success case, added 'git' to the
  rejects-unknown-kind test, renamed MarshalNeverWritesGit to
  MarshalWritesCanonicalKind
- source_fuzz_test.go: removed the 'git' legacy-alias seed, updated the
  doc comment
- package_union_fuzz_test.go: updated the renamed test reference
- cov_rhub_appwire_test.go: changed Kind 'git' to 'url' in coverage test