### PR TITLE
fix(launchconfig): remove deprecated singular Hash field from MetaTrust

### DIFF
--- a/cmd/evener-hub/internal/launchconfig/coverage_test.go
+++ b/cmd/evener-hub/internal/launchconfig/coverage_test.go
@@ -205,7 +205,7 @@ func (fs *statFailureFS) Stat(name string) (os.FileInfo, error) {
 }
 
 func checkComputeTrustStateUnknownDecision(t *testing.T) {
-	meta := Meta{Trust: MetaTrust{Hash: "hash", Decision: "pending"}}
+	meta := Meta{Trust: MetaTrust{Hashes: []string{"hash"}, Decision: "pending"}}
 	if got := ComputeTrustState("hash", meta); got != TrustUntrusted {
 		t.Fatalf("ComputeTrustState = %q, want %q", got, TrustUntrusted)
 	}

--- a/cmd/evener-hub/internal/launchconfig/io_fuzz_test.go
+++ b/cmd/evener-hub/internal/launchconfig/io_fuzz_test.go
@@ -102,7 +102,7 @@ func metaEqual(a, b Meta) bool {
 	if a.Schema != b.Schema || a.CWD != b.CWD || !a.CreatedAt.Equal(b.CreatedAt) {
 		return false
 	}
-	if a.Trust.Decision != b.Trust.Decision || a.Trust.Hash != b.Trust.Hash {
+	if a.Trust.Decision != b.Trust.Decision {
 		return false
 	}
 	if !a.Trust.DecidedAt.Equal(b.Trust.DecidedAt) {

--- a/cmd/evener-hub/internal/launchconfig/resolver_test.go
+++ b/cmd/evener-hub/internal/launchconfig/resolver_test.go
@@ -74,7 +74,7 @@ skills_dirs = ["/g"]
 	writeFile(t, filepath.Join(stateRoot, "projects", pid, "meta.toml"), `schema = 1
 cwd = "`+cwd+`"
 [trust]
-hash = "`+repoHash+`"
+hashes = ["`+repoHash+`"]
 decision = "trusted"
 `)
 	writeFile(t, filepath.Join(cwd, ".evener", "launch.local.toml"), `skills_dirs = ["/p"]`)
@@ -174,7 +174,7 @@ func checkResolve_RejectedRepoSkippedSilently(t *testing.T) {
 	writeFile(t, filepath.Join(stateRoot, "projects", pid, "meta.toml"), `schema = 1
 cwd = "`+cwd+`"
 [trust]
-hash = "`+hash+`"
+hashes = ["`+hash+`"]
 decision = "rejected"
 `)
 	got, _ := Resolve(stateRoot, cwd, Layer{})
@@ -200,7 +200,7 @@ func checkResolve_RepoPathsExpandedAndValidated(t *testing.T) {
 	writeFile(t, filepath.Join(stateRoot, "projects", pid, "meta.toml"), `schema = 1
 cwd = "`+cwd+`"
 [trust]
-hash = "`+hash+`"
+hashes = ["`+hash+`"]
 decision = "trusted"
 `)
 	got, _ := Resolve(stateRoot, cwd, Layer{})

--- a/cmd/evener-hub/internal/launchconfig/trust.go
+++ b/cmd/evener-hub/internal/launchconfig/trust.go
@@ -34,9 +34,8 @@ func canonicalHashTOML(data []byte, encode func(io.Writer, Layer) error) (string
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
-// trustHashes returns the effective set of recorded hashes from a MetaTrust.
-// It merges the deprecated singular Hash field into the Hashes slice so that
-// old single-hash entries are handled transparently.
+// trustHashes returns the deduplicated set of recorded hashes from a
+// MetaTrust.
 func trustHashes(t MetaTrust) []string {
 	seen := map[string]bool{}
 	var out []string
@@ -46,15 +45,10 @@ func trustHashes(t MetaTrust) []string {
 			out = append(out, h)
 		}
 	}
-	// Migrate the deprecated singular Hash field.
-	if t.Hash != "" && !seen[t.Hash] {
-		out = append(out, t.Hash)
-	}
 	return out
 }
 
-// TrustHashSet returns the deduplicated set of hashes from a MetaTrust,
-// including migration of the deprecated singular Hash field.
+// TrustHashSet returns the deduplicated set of hashes from a MetaTrust.
 // This is the canonical way for callers to read the hash set before appending.
 func TrustHashSet(t MetaTrust) []string {
 	return trustHashes(t)

--- a/cmd/evener-hub/internal/launchconfig/trust_test.go
+++ b/cmd/evener-hub/internal/launchconfig/trust_test.go
@@ -65,19 +65,19 @@ func checkComputeTrustState(t *testing.T) {
 	if got := ComputeTrustState("hash-1", Meta{}); got != TrustUntrusted {
 		t.Errorf("untrusted: got %q, want %q", got, TrustUntrusted)
 	}
-	// File present, hash matches trusted record (legacy singular Hash field).
-	meta := Meta{Trust: MetaTrust{Hash: "hash-1", Decision: "trusted"}}
+	// File present, hash matches trusted record.
+	meta := Meta{Trust: MetaTrust{Hashes: []string{"hash-1"}, Decision: "trusted"}}
 	if got := ComputeTrustState("hash-1", meta); got != TrustTrusted {
-		t.Errorf("trusted (legacy): got %q, want %q", got, TrustTrusted)
+		t.Errorf("trusted: got %q, want %q", got, TrustTrusted)
 	}
-	// File present, hash differs from legacy singular hash → changed.
+	// File present, hash differs from recorded hash → changed.
 	if got := ComputeTrustState("hash-2", meta); got != TrustChanged {
-		t.Errorf("changed (legacy): got %q, want %q", got, TrustChanged)
+		t.Errorf("changed: got %q, want %q", got, TrustChanged)
 	}
-	// File present, explicitly rejected (legacy).
-	rejected := Meta{Trust: MetaTrust{Hash: "hash-1", Decision: "rejected"}}
+	// File present, explicitly rejected.
+	rejected := Meta{Trust: MetaTrust{Hashes: []string{"hash-1"}, Decision: "rejected"}}
 	if got := ComputeTrustState("hash-1", rejected); got != TrustRejected {
-		t.Errorf("rejected (legacy): got %q, want %q", got, TrustRejected)
+		t.Errorf("rejected: got %q, want %q", got, TrustRejected)
 	}
 
 	// Multi-hash set: hash-1 and hash-2 both trusted.
@@ -93,23 +93,11 @@ func checkComputeTrustState(t *testing.T) {
 		t.Errorf("multi changed hash-3: got %q, want %q", got, TrustChanged)
 	}
 
-	// Migration: singular Hash is merged into the set.
-	migrated := Meta{Trust: MetaTrust{Hash: "hash-old", Hashes: []string{"hash-new"}, Decision: "trusted"}}
-	if got := ComputeTrustState("hash-old", migrated); got != TrustTrusted {
-		t.Errorf("migrated hash-old: got %q, want %q", got, TrustTrusted)
-	}
-	if got := ComputeTrustState("hash-new", migrated); got != TrustTrusted {
-		t.Errorf("migrated hash-new: got %q, want %q", got, TrustTrusted)
-	}
-
 	// TrustHashSet and HashInSet helpers.
-	trust := MetaTrust{Hash: "h-legacy", Hashes: []string{"h-1", "h-2"}, Decision: "trusted"}
+	trust := MetaTrust{Hashes: []string{"h-1", "h-2"}, Decision: "trusted"}
 	set := TrustHashSet(trust)
 	if !HashInSet("h-1", set) {
 		t.Error("HashInSet: h-1 should be in set")
-	}
-	if !HashInSet("h-legacy", set) {
-		t.Error("HashInSet: h-legacy should be in set (migrated from Hash)")
 	}
 	if HashInSet("h-unknown", set) {
 		t.Error("HashInSet: h-unknown should not be in set")

--- a/cmd/evener-hub/internal/launchconfig/types.go
+++ b/cmd/evener-hub/internal/launchconfig/types.go
@@ -121,12 +121,7 @@ type MetaTrust struct {
 	// Hashes is the set of content hashes that have been explicitly trusted or
 	// rejected. New trust decisions append to this set so that branch-switching
 	// with different .evener/launch.toml content does not require re-prompting.
-	Hashes []string `toml:"hashes,omitempty"`
-	// Hash is the singular trusted hash from the original TOFU implementation.
-	//
-	// Deprecated: new code reads Hashes; old single-hash entries are migrated
-	// to Hashes on first write.
-	Hash      string    `toml:"hash,omitempty"`
+	Hashes    []string  `toml:"hashes,omitempty"`
 	Decision  string    `toml:"decision,omitempty"` // "trusted" | "rejected"
 	DecidedAt time.Time `toml:"decided_at,omitempty"`
 }

--- a/cmd/evener-hub/internal/launchconfig/worktree_identity_test.go
+++ b/cmd/evener-hub/internal/launchconfig/worktree_identity_test.go
@@ -125,7 +125,7 @@ func checkResolve_TrustFromMainRootAppliesInLinkedWorktree(t *testing.T) {
 	writeFile(t, mainPaths.Meta, `schema = 1
 cwd = "`+main+`"
 [trust]
-hash = "`+hash+`"
+hashes = ["`+hash+`"]
 decision = "trusted"
 `)
 


### PR DESCRIPTION
The singular Hash field was the original TOFU implementation's trust hash.
It was deprecated in favor of the multi-hash Hashes slice, with a migration
branch in trustHashes that silently absorbed old single-hash entries. In
zero-back-compat land this migration shim should not exist.

Removed:
- MetaTrust.Hash field (types.go)
- Migration branch in trustHashes (trust.go)
- Legacy Hash comparison in metaEqual (io_fuzz_test.go)

Updated all tests to use Hashes instead of the singular Hash field:
- trust_test.go: converted legacy Hash test cases to Hashes, removed
  migration-specific test cases
- coverage_test.go: Hash -> Hashes
- resolver_test.go: 3 TOML fixtures hash -> hashes
- worktree_identity_test.go: TOML fixture hash -> hashes

Note: old meta.toml files with singular hash = "..." will now load with
an empty hash set (untrusted), forcing a re-prompt. This is safe in
zero-back-compat land. A future change should add schema-versioned loading
to LoadMeta (using Undecoded() like resolver.go:190 does for launch.toml)
to detect and reject or migrate legacy meta.toml files explicitly.

simplify-code: 4 reviewers (reuse/simplification/efficiency clean, altitude
noted the missing schema-versioned load mechanism as a separate concern).