### PR TITLE
fix(schema): remove SessionMeta original_task legacy fallback

### DIFF
--- a/agent/schema/snapshot.go
+++ b/agent/schema/snapshot.go
@@ -217,12 +217,11 @@ type SessionMeta struct {
 	// longer exists lands the session here instead, with a notice.
 	WorktreeRestoreRoot string `json:"worktree_restore_root,omitempty"`
 	// CumulativeUsage carries the session's running self-only token totals so
-	// they survive restart/resume. omitzero: legacy metas without it round-trip
-	// unchanged (WS2 working-state-metrics).
+	// they survive restart/resume.
 	CumulativeUsage CumulativeUsage `json:"cumulative_usage,omitzero"`
 	// WorkMillis is the accumulated wall-clock work time (sum of every turn's
 	// duration, interrupted and failed included), persisted so the total
-	// survives restart/resume. omitzero for legacy round-trip.
+	// survives restart/resume.
 	WorkMillis int64 `json:"work_millis,omitzero"`
 	// JobTreeRootSessionID identifies the root session whose shared job/activity
 	// lifecycle revision this session participates in. For standalone/root
@@ -240,7 +239,7 @@ type SessionMeta struct {
 // CumulativeUsage is a deliberately lossy snapshot of an llm.Usage kept in
 // SessionMeta so per-session token totals survive daemon restart and resume.
 // Conversion from llm.Usage drops Raw and the reasoning/cache-write pointers;
-// nil pointers map to 0. Tagged omitzero so legacy metas round-trip untouched.
+// nil pointers map to 0.
 type CumulativeUsage struct {
 	InputTokens     int64 `json:"input_tokens,omitzero"`
 	OutputTokens    int64 `json:"output_tokens,omitzero"`
@@ -263,28 +262,9 @@ type GoalSnapshot struct {
 	UpdatedAt        time.Time `json:"updated_at,omitzero"`
 }
 
-// UnmarshalJSON decodes a SessionMeta from JSON, falling back to the legacy
-// "original_task" field for OriginalPrompt when the current "original_prompt"
-// field is empty or absent.
-func (m *SessionMeta) UnmarshalJSON(data []byte) error {
-	type sessionMetaAlias SessionMeta
-	var aux struct {
-		sessionMetaAlias
-		LegacyOriginalPrompt string `json:"original_task,omitempty"`
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	*m = SessionMeta(aux.sessionMetaAlias)
-	if m.OriginalPrompt == "" {
-		m.OriginalPrompt = aux.LegacyOriginalPrompt
-	}
-	return nil
-}
-
 // SessionDisplayName returns the best available human-readable title for a
-// session. Generated names are preferred, with OriginalPrompt retained as the
-// backward-compatible fallback for sessions written before naming existed.
+// session: the generated name if set, otherwise the original prompt, falling
+// back to the session ID.
 func SessionDisplayName(meta SessionMeta) string {
 	if name := strings.TrimSpace(meta.Name); name != "" {
 		return name

--- a/agent/schema/snapshot_fuzz_test.go
+++ b/agent/schema/snapshot_fuzz_test.go
@@ -8,9 +8,8 @@ import (
 	"testing"
 )
 
-// mustMarshalMeta marshals m or fails the test. SessionMeta has a custom
-// UnmarshalJSON but default MarshalJSON; comparing marshaled bytes (not
-// reflect.DeepEqual) keeps time.Time and pointer fields comparable.
+// mustMarshalMeta marshals m or fails the test. Comparing marshaled bytes
+// (not reflect.DeepEqual) keeps time.Time and pointer fields comparable.
 func mustMarshalMeta(t *testing.T, m SessionMeta) []byte {
 	t.Helper()
 	b, err := json.Marshal(m)
@@ -27,9 +26,7 @@ func mustMarshalMeta(t *testing.T, m SessionMeta) []byte {
 //     must survive a second marshal/unmarshal unchanged. This proves
 //     MarshalJSON/UnmarshalJSON agree across the full nested graph
 //     (ConfigSnapshot + GoalSnapshot + maps/slices). The baseline is the
-//     canonical form, not the raw input, which sidesteps the legacy
-//     original_task→OriginalPrompt asymmetry (UnmarshalJSON reads it, MarshalJSON
-//     does not write it).
+//     canonical form, not the raw input.
 //   - Save/Load ROUND-TRIP. SaveSessionMeta + LoadSessionMeta over a t.TempDir
 //     must reproduce the canonical bytes. A dropped or mis-tagged field, or an
 //     atomic-write/read regression, diverges here immediately.
@@ -39,8 +36,6 @@ func FuzzSessionMetaRoundTrip(f *testing.F) {
 		`{"id":"01ABC","profile_id":"openai","model":"gpt-5.5","cheap_model":"gpt-5.4-mini","config":{"max_tool_rounds_per_input":40,"max_turns":0,"tool_output_limits":{"shell":{"ride_whole_bytes":8192}},"agent_name":"engineer","reasoning_effort":"high","skills_dirs":["/a","/b"],"model_fallbacks":["anthropic/claude"],"enable_loop_detection":false},"env_info":{"working_dir":"/home/u/p"},"created_at":"2026-06-01T10:00:00Z","updated_at":"2026-06-01T11:00:00Z","turn_count":7,"last_input_tokens":12000,"name":"Session title","name_source":"prompt","name_updated_at":"2026-06-01T10:05:00Z","original_prompt":"do the thing","goal":{"objective":"ship it","status":"active","iterations":3,"made_progress_once":true,"created_at":"2026-06-01T10:00:00Z","updated_at":"2026-06-01T10:30:00Z"},"pinned_note":"remember this","observed_by":["01OBS1","01OBS2"]}`,
 		// Fork lineage fields.
 		`{"id":"01FORK","profile_id":"anthropic","model":"claude","config":{},"env_info":{},"created_at":"2026-06-02T00:00:00Z","updated_at":"2026-06-02T00:00:00Z","turn_count":0,"parent_session_id":"01PARENT","divergence_turn":4,"fork_label":"main","is_subagent":true}`,
-		// Legacy-only doc: pins the original_task→OriginalPrompt fallback path.
-		`{"original_task":"legacy prompt only"}`,
 		// Minimal / degenerate inputs.
 		`{}`,
 		`null`,

--- a/agent/snapshot_test.go
+++ b/agent/snapshot_test.go
@@ -664,18 +664,6 @@ func TestSessionDisplayName(t *testing.T) {
 	}
 }
 
-func TestSessionMeta_OriginalPrompt_ReadsLegacyOriginalTask(t *testing.T) {
-	t.Parallel()
-	data := []byte(`{"id":"01TEST0001","original_task":"fix the bug in handler"}`)
-	var got schema.SessionMeta
-	if err := json.Unmarshal(data, &got); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if got.OriginalPrompt != "fix the bug in handler" {
-		t.Fatalf("OriginalPrompt: got %q, want %q", got.OriginalPrompt, "fix the bug in handler")
-	}
-}
-
 func TestSessionMeta_OriginalPrompt_OmitEmpty(t *testing.T) {
 	t.Parallel()
 	meta := schema.SessionMeta{ID: "01TEST0001"}


### PR DESCRIPTION
SessionMeta.UnmarshalJSON had a legacy fallback that read the old
'original_task' JSON field into OriginalPrompt when the current
'original_prompt' field was absent. This was back-compat for an old
on-disk format. In zero-back-compat land, old snapshots should use a
migration script, not a silent fallback in the hot path.

Removed:
- Custom SessionMeta.UnmarshalJSON (the default json.Unmarshal now
  handles decoding; old 'original_task' fields are silently ignored)
- LegacyOriginalPrompt alias struct field
- TestSessionMeta_OriginalPrompt_ReadsLegacyOriginalTask (asserted the
  removed fallback behavior)
- Legacy 'original_task' fuzz test seed

Updated comments to remove legacy justifications:
- omitzero tags on CumulativeUsage/WorkMillis (the tags are correct for
  zero-value omission; the 'legacy round-trip' rationale is removed)
- CumulativeUsage struct doc (removed 'Tagged omitzero so legacy metas
  round-trip untouched')
- SessionDisplayName doc (removed 'backward-compatible fallback' framing)
- mustMarshalMeta helper doc (removed 'custom UnmarshalJSON' reference)
- FuzzSessionMetaRoundTrip doc (removed original_task asymmetry note)

simplify-code: 4 reviewers (reuse/efficiency clean; simplification and
altitude both found the same 2 issues — stale comment + broken test —
both fixed before commit).