### PR TITLE
fix(schema): remove Deprecated marker from TurnTool constant

### DIFF
--- a/agent/schema/turn.go
+++ b/agent/schema/turn.go
@@ -18,8 +18,9 @@ const (
 	TurnSteering TurnKind = "STEERING"
 	// TurnAssistant is a turn carrying an assistant message.
 	TurnAssistant TurnKind = "ASSISTANT"
-	// TurnTool is a turn carrying tool output.
-	TurnTool TurnKind = "TOOL" // Deprecated: use TurnToolResults for new code.
+	// TurnTool is a turn carrying tool output. Old transcripts may use this
+	// kind (value "TOOL"); current code writes TurnToolResults instead.
+	TurnTool TurnKind = "TOOL"
 	// TurnToolResults is a turn carrying aggregated tool results from one round.
 	TurnToolResults TurnKind = "TOOL_RESULTS" // Aggregated tool results from one round.
 	// TurnSystem is a turn carrying a system message.

--- a/agent/transcript_render.go
+++ b/agent/transcript_render.go
@@ -824,7 +824,7 @@ func writeEntry(b *strings.Builder, seq int, e transcript.Entry, resultTool stri
 			b.WriteString("\n> [SYSTEM turn omitted]\n")
 		}
 
-	case schema.TurnTool: // deprecated
+	case schema.TurnTool: // old transcript format
 		b.WriteString("\n> [TOOL turn omitted]\n")
 
 	default:


### PR DESCRIPTION
TurnTool (value "TOOL") is a genuinely different wire kind from
TurnToolResults (value "TOOL_RESULTS"). Old transcripts on disk use
"TOOL" and the read-path switch cases must handle it. The constant is
not deprecated — it's a legitimate kind value for old-format data.

Removed the misleading "Deprecated: use TurnToolResults for new code"
comment and replaced it with an accurate description: old transcripts
may use this kind; current code writes TurnToolResults instead.

Updated the "// deprecated" comment in transcript_render.go to
"// old transcript format".