### PR TITLE
fix(llm): extract shared apiLogCredentialMaterial helper

### DIFF
--- a/llm/api_attempt_sanitize.go
+++ b/llm/api_attempt_sanitize.go
@@ -29,6 +29,35 @@ var commonCredentialQueryNames = map[string]struct{}{
 	"token":        {},
 }
 
+// BuildAPILogCredentialMaterial constructs an APILogCredentialMaterial from
+// the standard provider fields: a primary header name (e.g. "Authorization"
+// or "x-api-key"), query parameter names (e.g. []string{"key"} for Google),
+// the API key value, additional credential headers, and any user info
+// embedded in the request URL.
+//
+// This is the shared implementation used by all provider adapters. Each
+// adapter calls it with its primary header name and query param names:
+//
+//	llm.BuildAPILogCredentialMaterial("Authorization", nil, a.APIKey, a.CredentialHeaders, httpReq)
+func BuildAPILogCredentialMaterial(primaryHeader string, queryNames []string, apiKey string, credentialHeaders map[string]string, httpReq *http.Request) APILogCredentialMaterial {
+	var headerNames []string
+	if primaryHeader != "" {
+		headerNames = []string{primaryHeader}
+	}
+	values := []string{apiKey}
+	for name, value := range credentialHeaders {
+		headerNames = append(headerNames, name)
+		values = append(values, value)
+	}
+	if httpReq != nil && httpReq.URL != nil && httpReq.URL.User != nil {
+		values = append(values, httpReq.URL.User.Username())
+		if password, ok := httpReq.URL.User.Password(); ok {
+			values = append(values, password)
+		}
+	}
+	return NewAPILogCredentialMaterial(headerNames, queryNames, values...)
+}
+
 // NewAPILogCredentialMaterial records the provider/config-derived names and
 // values that must be removed before request metadata or errors are persisted.
 func NewAPILogCredentialMaterial(headerNames, queryNames []string, values ...string) APILogCredentialMaterial {

--- a/llm/providers/anthropic/adapter.go
+++ b/llm/providers/anthropic/adapter.go
@@ -222,19 +222,7 @@ func (a *Adapter) Complete(ctx context.Context, req llm.Request) (result llm.Res
 }
 
 func (a *Adapter) apiLogCredentialMaterial(httpReq *http.Request) llm.APILogCredentialMaterial {
-	headerNames := []string{"x-api-key"}
-	values := []string{a.APIKey}
-	for name, value := range a.CredentialHeaders {
-		headerNames = append(headerNames, name)
-		values = append(values, value)
-	}
-	if httpReq != nil && httpReq.URL != nil && httpReq.URL.User != nil {
-		values = append(values, httpReq.URL.User.Username())
-		if password, ok := httpReq.URL.User.Password(); ok {
-			values = append(values, password)
-		}
-	}
-	return llm.NewAPILogCredentialMaterial(headerNames, nil, values...)
+	return llm.BuildAPILogCredentialMaterial("x-api-key", nil, a.APIKey, a.CredentialHeaders, httpReq)
 }
 
 func (a *Adapter) CountInputTokens(ctx context.Context, req llm.Request) (llm.InputTokenCount, error) {

--- a/llm/providers/google/adapter.go
+++ b/llm/providers/google/adapter.go
@@ -230,19 +230,7 @@ func (a *Adapter) Complete(ctx context.Context, req llm.Request) (result llm.Res
 }
 
 func (a *Adapter) apiLogCredentialMaterial(httpReq *http.Request) llm.APILogCredentialMaterial {
-	headerNames := make([]string, 0, len(a.CredentialHeaders))
-	values := []string{a.APIKey}
-	for name, value := range a.CredentialHeaders {
-		headerNames = append(headerNames, name)
-		values = append(values, value)
-	}
-	if httpReq != nil && httpReq.URL != nil && httpReq.URL.User != nil {
-		values = append(values, httpReq.URL.User.Username())
-		if password, ok := httpReq.URL.User.Password(); ok {
-			values = append(values, password)
-		}
-	}
-	return llm.NewAPILogCredentialMaterial(headerNames, []string{"key"}, values...)
+	return llm.BuildAPILogCredentialMaterial("", []string{"key"}, a.APIKey, a.CredentialHeaders, httpReq)
 }
 
 func (a *Adapter) CountInputTokens(ctx context.Context, req llm.Request) (llm.InputTokenCount, error) {

--- a/llm/providers/kimi/adapter.go
+++ b/llm/providers/kimi/adapter.go
@@ -172,19 +172,7 @@ func (a *adapter) CountInputTokens(ctx context.Context, req llm.Request) (llm.In
 }
 
 func (a *adapter) apiLogCredentialMaterial(httpReq *http.Request) llm.APILogCredentialMaterial {
-	headerNames := []string{"Authorization"}
-	values := []string{a.APIKey}
-	for name, value := range a.CredentialHeaders {
-		headerNames = append(headerNames, name)
-		values = append(values, value)
-	}
-	if httpReq != nil && httpReq.URL != nil && httpReq.URL.User != nil {
-		values = append(values, httpReq.URL.User.Username())
-		if password, ok := httpReq.URL.User.Password(); ok {
-			values = append(values, password)
-		}
-	}
-	return llm.NewAPILogCredentialMaterial(headerNames, nil, values...)
+	return llm.BuildAPILogCredentialMaterial("Authorization", nil, a.APIKey, a.CredentialHeaders, httpReq)
 }
 
 func stripKimiTokenCountOutputFields(body map[string]any) {

--- a/llm/providers/openai/adapter.go
+++ b/llm/providers/openai/adapter.go
@@ -662,19 +662,7 @@ func (a *Adapter) responsesEndpointFamily() llm.ResponsesEndpointFamily {
 }
 
 func (a *Adapter) apiLogCredentialMaterial(httpReq *http.Request) llm.APILogCredentialMaterial {
-	headerNames := []string{"Authorization"}
-	values := []string{a.APIKey}
-	for name, value := range a.CredentialHeaders {
-		headerNames = append(headerNames, name)
-		values = append(values, value)
-	}
-	if httpReq != nil && httpReq.URL != nil && httpReq.URL.User != nil {
-		values = append(values, httpReq.URL.User.Username())
-		if password, ok := httpReq.URL.User.Password(); ok {
-			values = append(values, password)
-		}
-	}
-	return llm.NewAPILogCredentialMaterial(headerNames, nil, values...)
+	return llm.BuildAPILogCredentialMaterial("Authorization", nil, a.APIKey, a.CredentialHeaders, httpReq)
 }
 
 func (a *Adapter) stampResponseIDHash(resp *llm.Response) {

--- a/llm/providers/openaicompat/adapter.go
+++ b/llm/providers/openaicompat/adapter.go
@@ -796,17 +796,5 @@ func (a *Adapter) doHTTP(parentCtx, ctx context.Context, req llm.Request, body m
 }
 
 func (a *Adapter) apiLogCredentialMaterial(httpReq *http.Request) llm.APILogCredentialMaterial {
-	headerNames := []string{"Authorization"}
-	values := []string{a.APIKey}
-	for name, value := range a.CredentialHeaders {
-		headerNames = append(headerNames, name)
-		values = append(values, value)
-	}
-	if httpReq != nil && httpReq.URL != nil && httpReq.URL.User != nil {
-		values = append(values, httpReq.URL.User.Username())
-		if password, ok := httpReq.URL.User.Password(); ok {
-			values = append(values, password)
-		}
-	}
-	return llm.NewAPILogCredentialMaterial(headerNames, nil, values...)
+	return llm.BuildAPILogCredentialMaterial("Authorization", nil, a.APIKey, a.CredentialHeaders, httpReq)
 }


### PR DESCRIPTION
The apiLogCredentialMaterial method was byte-identical across 5 provider
adapters (anthropic, google, openaicompat, openai, kimi), each copy-pasting
the same 14-line body that iterates CredentialHeaders and extracts URL
user info. The only differences were the primary header name and query
param names passed to NewAPILogCredentialMaterial.

Added llm.BuildAPILogCredentialMaterial — a shared helper that takes the
primary header name, query param names, API key, credential headers, and
HTTP request, and builds the APILogCredentialMaterial. Each provider's
method now reduces to a one-line call:

  - anthropic: llm.BuildAPILogCredentialMaterial("x-api-key", nil, ...)
  - google:    llm.BuildAPILogCredentialMaterial("", []string{"key"}, ...)
  - openai:    llm.BuildAPILogCredentialMaterial("Authorization", nil, ...)
  - openaicompat: same as openai
  - kimi:      same as openai (receiver is *adapter not *Adapter)

6 files changed, net -31 lines.