### PR TITLE
ci: cut the PR snapshot artifact upload and shallow the build clones

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -22,7 +22,7 @@ jobs:
       # job keeps a full clone for its own template needs.
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup-toolchain
 

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -17,6 +17,9 @@ jobs:
     if: github.ref_type != 'tag'
     runs-on: ubuntu-latest
     steps:
+      # Depth 1 suffices: snapshot mode's version template reads the commit
+      # from HEAD (ShortCommit) and no changelog is generated. The tag release
+      # job keeps a full clone for its own template needs.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
@@ -32,7 +35,9 @@ jobs:
           BUILD_CHANNEL: snapshot
 
       - name: Inspect archives
-        run: for f in dist/*.tar.gz; do echo "== $f"; tar -tzf "$f"; done
+        run: |
+          for f in dist/*.tar.gz; do echo "== $f"; tar -tzf "$f"; done
+          test -s dist/checksums.txt
 
       - name: Upload archives
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,12 @@ jobs:
       - name: Fuzz seed-corpus replay (committed crashers — no search, deterministic)
         run: make fuzz
 
+  # Packaging proof, not artifact production: a PR that breaks the goreleaser
+  # config, archive layout, or SPA-embedding before-hook must fail before merge.
+  # The build plus this inspection is the whole proof, so the job deliberately
+  # uploads nothing — no automated consumer reads a PR-run artifact (the main
+  # snapshot channel is fed by the Build Binaries workflow), and the check name
+  # is pinned by branch protection.
   snapshot-artifacts:
     name: Build snapshot artifacts
     if: github.event_name == 'pull_request'
@@ -188,14 +194,10 @@ jobs:
         env:
           BUILD_CHANNEL: snapshot
 
+      # tar -tzf proves each archive's member list; the checksums assertion
+      # carries the existence coverage the dropped upload's if-no-files-found
+      # used to provide.
       - name: Inspect archives
-        run: for f in dist/*.tar.gz; do echo "== $f"; tar -tzf "$f"; done
-
-      - name: Upload archives
-        uses: actions/upload-artifact@v7
-        with:
-          name: evener-snapshot-artifacts
-          path: |
-            dist/*.tar.gz
-            dist/checksums.txt
-          if-no-files-found: error
+        run: |
+          for f in dist/*.tar.gz; do echo "== $f"; tar -tzf "$f"; done
+          test -s dist/checksums.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup-toolchain
 


### PR DESCRIPTION
## Why

The PR-run `snapshot-artifacts` job uploaded a ~71.5 MB `evener-snapshot-artifacts` archive on every green PR, and **nothing consumes it**:

- The artifact name is referenced only by the two workflow files themselves — no script, doc, or tooling reads it.
- The only automated consumer of that artifact name is the Build Binaries workflow's `snapshot` publisher, which downloads it from **main-push runs only** — a PR-run copy is never fetched.
- Each copy sat unread for its 90-day retention. (The repo is public, so no billing impact — the cost was noise plus a mild footgun: a PR build's artifact carried the same name and `BUILD_CHANNEL=snapshot` as the main snapshot channel, inviting someone to install an unmerged PR thinking it was main.)

## What changed

**Commit 1 — drop the PR upload (`ci.yml`).** The job was already a *packaging proof*, not artifact production: it exists so a PR that breaks the goreleaser config, archive layout, ldflags templates, or the SPA-embedding before-hook fails before merge. The build plus archive inspection is the whole proof. The upload step is removed; the inspect step gains `test -s dist/checksums.txt` so the existence coverage the upload's `if-no-files-found: error` used to provide is preserved. The job keeps its name `Build snapshot artifacts`, so **branch protection needs no update** — it remains a required check.

**Commit 2 — shallow clones (`ci.yml` + `binaries.yml`).** `fetch-depth: 0` predates the current version template, which reads only the HEAD commit (`ShortCommit`); no changelog or release notes are generated in snapshot mode, so history beyond HEAD is unused. Both snapshot build jobs now use `fetch-depth: 1`.

## Verification

- **Shallow-clone build verified locally:** a `file://` depth-1 clone ran the exact CI command (`BUILD_CHANNEL=snapshot goreleaser release --snapshot --clean`) to a successful release — both archives and checksums.txt produced, and the built binary reports the shallow HEAD's short SHA (`942b1e4`).
- `actionlint` passes on both workflow files.
- `go test -run TestBinariesWorkflow .` passes — the repo's workflow-pinning test still sees the `binaries.yml` snapshot publisher downloading the build job's artifacts, moving the snapshot tag, and uploading to the snapshot release.

## Deliberately kept

- The **PR packaging-proof job itself** (it's the only pre-merge guard on the release path) and its required-check name.
- The **main-run upload** in `binaries.yml` — the `snapshot` publisher job consumes it to refresh the mutable snapshot channel (default install path via `install.sh`).
- The **tag `release` job keeps `fetch-depth: 0`** — it serves a different mode (real release notes/templates), and this PR does not touch it.