### PR TITLE
perf(appserver): dispatch requests concurrently per connection

### DIFF
--- a/internal/appserver/appstack_seqfuzz_test.go
+++ b/internal/appserver/appstack_seqfuzz_test.go
@@ -143,6 +143,27 @@ func (s *stackTransport) Recv(context.Context) (appwire.Message, error) {
 	return msg, nil
 }
 
+// ctxTransport adapts stackTransport to the receive loop's termination
+// contract: Recv must fail once the dispatch policy cancels the connection
+// context, the way the real websocket transport's read does. A transport whose
+// Recv keeps returning (Message{}, nil) after cancellation would spin the
+// receive loop forever — the loop only exits via a Recv error.
+type ctxTransport struct {
+	stackTransport
+	ctx context.Context
+}
+
+func (s *ctxTransport) Recv(ctx context.Context) (appwire.Message, error) {
+	if len(s.messages) == 0 {
+		<-s.ctx.Done()
+		if s.err != nil {
+			return appwire.Message{}, s.err
+		}
+		return appwire.Message{}, context.Canceled
+	}
+	return s.stackTransport.Recv(ctx)
+}
+
 type stackCloser struct{ closes int }
 
 func (s *stackCloser) Close(websocket.StatusCode, string) error { s.closes++; return nil }
@@ -164,8 +185,13 @@ func exerciseReceiveLoops(t rapidTB) {
 		t.Fatalf("abnormal receive close count = %d", closer.closes)
 	}
 	c.closeSend()
-	runWebSocketReceiveLoop(context.Background(), closer, &stackTransport{
-		messages: []appwire.Message{appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodPing, nil)},
+	ctx, cancel := context.WithCancel(context.Background())
+	c.setCancel(cancel)
+	runWebSocketReceiveLoop(ctx, closer, &ctxTransport{
+		stackTransport: stackTransport{
+			messages: []appwire.Message{appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodPing, nil)},
+		},
+		ctx: ctx,
 	}, c, newWebSocketReadGate())
 }
 

--- a/internal/appserver/appstack_seqfuzz_test.go
+++ b/internal/appserver/appstack_seqfuzz_test.go
@@ -187,12 +187,9 @@ func exerciseReceiveLoops(t rapidTB) {
 	c.closeSend()
 	ctx, cancel := context.WithCancel(context.Background())
 	c.setCancel(cancel)
-	runWebSocketReceiveLoop(ctx, closer, &ctxTransport{
-		stackTransport: stackTransport{
-			messages: []appwire.Message{appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodPing, nil)},
-		},
-		ctx: ctx,
-	}, c, newWebSocketReadGate())
+	transport := &ctxTransport{ctx: ctx}
+	transport.messages = []appwire.Message{appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodPing, nil)}
+	runWebSocketReceiveLoop(ctx, closer, transport, c, newWebSocketReadGate())
 }
 
 type stackPinger struct {

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -11,6 +11,16 @@ import (
 	"primeradiant.com/evener/appwire"
 )
 
+// maxConcurrentRequestsPerConnection bounds how many post-initialize
+// requests one connection may have running at once. Legitimate browser
+// bursts stay far below this (the UI issues a handful of overlapping reads
+// and mutations per view); the cap exists so a misbehaving client that
+// floods requests faster than handlers complete cannot grow goroutines and
+// handler state without bound, degrading the whole server's memory and
+// scheduler headroom. Overflow is answered with a retryable wire error, not
+// a disconnect, because a compliant retry will find capacity.
+const maxConcurrentRequestsPerConnection = 128
+
 type ServerConfig struct {
 	ServerName string
 	Version    string
@@ -91,7 +101,12 @@ func (s *Server) NewConnection(id string) *Connection {
 	// share one constant so neither peer can quietly become the smaller pipe
 	// (at 32 this side evicted live clients whose send loop napped through a
 	// turn-boundary burst on a loaded machine).
-	return &Connection{id: id, server: s, send: make(chan appwire.Message, appwire.NotificationBufferCap)}
+	return &Connection{
+		id:       id,
+		server:   s,
+		send:     make(chan appwire.Message, appwire.NotificationBufferCap),
+		inFlight: make(chan struct{}, maxConcurrentRequestsPerConnection),
+	}
 }
 
 func (s *Server) logf(format string, args ...any) {
@@ -278,9 +293,14 @@ func navigationCapability(capability *appwire.NavigationCapability) *appwire.Nav
 }
 
 type Connection struct {
-	id          string
-	server      *Server
-	send        chan appwire.Message
+	id     string
+	server *Server
+	send   chan appwire.Message
+	// inFlight is the per-connection in-flight request limiter: a buffered
+	// semaphore of maxConcurrentRequestsPerConnection slots. It is taken
+	// non-blockingly by dispatchMessage and released by the handler goroutine
+	// on completion, so the receive loop never parks on it.
+	inFlight    chan struct{}
 	sendMu      sync.RWMutex
 	sendClosed  bool
 	mu          sync.RWMutex
@@ -453,8 +473,9 @@ func (c *Connection) HandleMessage(ctx context.Context, msg appwire.Message) app
 	}
 	req := *msg.Request
 	// ping is the browser's app-level heartbeat (browsers cannot send WS ping
-	// frames from JS). It bypasses the router and is answered inline in the
-	// receive loop, so no busy handler can starve it.
+	// frames from JS). It bypasses the router, and dispatchMessage answers it
+	// inline in the receive loop ahead of any handler goroutine, so however
+	// busy the connection's handlers get, ping is never starved.
 	if req.Method == appwire.MethodPing {
 		return appwire.ResponseMessage(req.ID, struct{}{})
 	}
@@ -767,4 +788,80 @@ func (c *Connection) setInitialized() {
 	c.mu.Lock()
 	c.initialized = true
 	c.mu.Unlock()
+}
+
+// dispatchMessage applies the connection's dispatch policy to one inbound
+// message: which messages run inline in the receive loop and which run on
+// their own goroutine. A transport's receive loop is the only caller; the
+// policy lives on the Connection so any second transport inherits the same
+// sequencing for free.
+//
+// It runs each post-initialize request on its own goroutine so a slow
+// handler no longer head-of-line blocks the connection's other requests —
+//
+// Ordering constraints that survive concurrency:
+//
+//   - initialize must be the first request. Until the connection reports
+//     initialized, every message is handled inline in the receive loop:
+//     pre-initialize requests other than ping are rejected ("initialize
+//     required"), and the initialize handshake itself completes — response
+//     enqueued — before the loop reads another frame. Dispatch of later
+//     requests therefore cannot observe a half-initialized connection.
+//   - notifications and ping are always handled inline: they are bounded
+//     work, and answering ping inline is what keeps the app-level heartbeat
+//     responsive no matter how many handlers are busy.
+//   - post-initialize requests must first take a slot from the in-flight
+//     limiter. The acquire is non-blocking — the receive loop must never
+//     park on the limiter, or ping would be head-of-line blocked again. On
+//     capacity exhaustion the request is answered immediately with a
+//     retryable Unavailable wire error rather than dispatched.
+//   - responses enter the connection send queue through the same
+//     enqueueResponse path as before, so hydration capture commit/abort
+//     ordering is unchanged.
+//
+// Error responses from enqueueResponse are terminal for the connection, but
+// a handler goroutine must not tear the receive loop down out from under it;
+// canceling the shared context is enough — the next Recv fails and the loop
+// exits with the normal close handling.
+func (c *Connection) dispatchMessage(ctx context.Context, msg appwire.Message) {
+	if msg.Request == nil || msg.Request.Method == appwire.MethodPing {
+		c.handleAndEnqueue(ctx, msg)
+		return
+	}
+	if !c.isInitialized() {
+		c.handleAndEnqueue(ctx, msg)
+		return
+	}
+	// Non-blocking acquire: the receive loop must never park on the limiter.
+	select {
+	case c.inFlight <- struct{}{}:
+	default:
+		// The response is already decided, so it bypasses HandleMessage and
+		// is enqueued directly.
+		c.enqueueDispatched(ctx, appwire.ErrorMessage(msg.Request.ID, appwire.Unavailable(
+			fmt.Sprintf("connection already has %d requests in flight; retry shortly", maxConcurrentRequestsPerConnection),
+		)))
+		return
+	}
+	go func() {
+		defer func() { <-c.inFlight }()
+		c.handleAndEnqueue(ctx, msg)
+	}()
+}
+
+// handleAndEnqueue runs one request through HandleMessage and enqueues its
+// response.
+func (c *Connection) handleAndEnqueue(ctx context.Context, msg appwire.Message) {
+	c.enqueueDispatched(ctx, c.HandleMessage(ctx, msg))
+}
+
+// enqueueDispatched is the one enqueue body every dispatch path shares:
+// enqueue a response, canceling the connection when it cannot be enqueued.
+func (c *Connection) enqueueDispatched(ctx context.Context, resp appwire.Message) {
+	if resp.Kind() == appwire.MessageInvalid {
+		return
+	}
+	if err := c.enqueueResponse(ctx, resp); err != nil {
+		c.cancelContext()
+	}
 }

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -799,6 +799,12 @@ func (c *Connection) setInitialized() {
 // It runs each post-initialize request on its own goroutine so a slow
 // handler no longer head-of-line blocks the connection's other requests —
 //
+// Per-connection frame ordering is NOT serialized: a later request can
+// dispatch while an earlier one (including a hydrating read parked in its
+// snapshot clone) is still in flight. Responses pair by request ID, and only
+// the sequence-cut discipline governs how notifications interleave with a
+// hydration response — dispatch order no longer does.
+//
 // Ordering constraints that survive concurrency:
 //
 //   - initialize must be the first request. Until the connection reports

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -453,8 +453,8 @@ func (c *Connection) HandleMessage(ctx context.Context, msg appwire.Message) app
 	}
 	req := *msg.Request
 	// ping is the browser's app-level heartbeat (browsers cannot send WS ping
-	// frames from JS). It bypasses the router, but still runs in this serial
-	// receive/dispatch path and can therefore be starved by a busy handler.
+	// frames from JS). It bypasses the router and is answered inline in the
+	// receive loop, so no busy handler can starve it.
 	if req.Method == appwire.MethodPing {
 		return appwire.ResponseMessage(req.ID, struct{}{})
 	}

--- a/internal/appserver/websocket.go
+++ b/internal/appserver/websocket.go
@@ -156,14 +156,60 @@ func runWebSocketReceiveLoop(ctx context.Context, ws webSocketCloser, transport 
 			}
 			return
 		}
+		dispatchWebSocketMessage(ctx, conn, msg)
+	}
+}
+
+// dispatchWebSocketMessage runs each request on its own goroutine so a slow
+// handler no longer head-of-line blocks the connection's other requests —
+//
+// Ordering constraints that survive concurrency:
+//
+//   - initialize must be the first request. Until the connection reports
+//     initialized, every message is handled inline in the receive loop:
+//     pre-initialize requests other than ping are rejected ("initialize
+//     required"), and the initialize handshake itself completes — response
+//     enqueued — before the loop reads another frame. Dispatch of later
+//     requests therefore cannot observe a half-initialized connection.
+//   - responses enter the connection send queue through the same
+//     enqueueResponse path as before, so hydration capture commit/abort
+//     ordering is unchanged.
+//
+// Error responses from enqueueResponse are terminal for the connection, but
+// a handler goroutine must not tear the receive loop down out from under it;
+// canceling the shared context is enough — the next Recv fails and the loop
+// exits with the normal close handling.
+func dispatchWebSocketMessage(ctx context.Context, conn *Connection, msg appwire.Message) {
+	if msg.Request == nil || msg.Request.Method == appwire.MethodPing {
 		resp := conn.HandleMessage(ctx, msg)
 		if resp.Kind() == appwire.MessageInvalid {
-			continue
-		}
-		if err := conn.enqueueResponse(ctx, resp); err != nil {
 			return
 		}
+		if err := conn.enqueueResponse(ctx, resp); err != nil {
+			conn.cancelContext()
+			return
+		}
+		return
 	}
+	if !conn.isInitialized() {
+		resp := conn.HandleMessage(ctx, msg)
+		if resp.Kind() == appwire.MessageInvalid {
+			return
+		}
+		if err := conn.enqueueResponse(ctx, resp); err != nil {
+			conn.cancelContext()
+		}
+		return
+	}
+	go func() {
+		resp := conn.HandleMessage(ctx, msg)
+		if resp.Kind() == appwire.MessageInvalid {
+			return
+		}
+		if err := conn.enqueueResponse(ctx, resp); err != nil {
+			conn.cancelContext()
+		}
+	}()
 }
 
 // runWebSocketKeepalive pings the peer every interval and cancels the

--- a/internal/appserver/websocket.go
+++ b/internal/appserver/websocket.go
@@ -156,60 +156,8 @@ func runWebSocketReceiveLoop(ctx context.Context, ws webSocketCloser, transport 
 			}
 			return
 		}
-		dispatchWebSocketMessage(ctx, conn, msg)
+		conn.dispatchMessage(ctx, msg)
 	}
-}
-
-// dispatchWebSocketMessage runs each request on its own goroutine so a slow
-// handler no longer head-of-line blocks the connection's other requests —
-//
-// Ordering constraints that survive concurrency:
-//
-//   - initialize must be the first request. Until the connection reports
-//     initialized, every message is handled inline in the receive loop:
-//     pre-initialize requests other than ping are rejected ("initialize
-//     required"), and the initialize handshake itself completes — response
-//     enqueued — before the loop reads another frame. Dispatch of later
-//     requests therefore cannot observe a half-initialized connection.
-//   - responses enter the connection send queue through the same
-//     enqueueResponse path as before, so hydration capture commit/abort
-//     ordering is unchanged.
-//
-// Error responses from enqueueResponse are terminal for the connection, but
-// a handler goroutine must not tear the receive loop down out from under it;
-// canceling the shared context is enough — the next Recv fails and the loop
-// exits with the normal close handling.
-func dispatchWebSocketMessage(ctx context.Context, conn *Connection, msg appwire.Message) {
-	if msg.Request == nil || msg.Request.Method == appwire.MethodPing {
-		resp := conn.HandleMessage(ctx, msg)
-		if resp.Kind() == appwire.MessageInvalid {
-			return
-		}
-		if err := conn.enqueueResponse(ctx, resp); err != nil {
-			conn.cancelContext()
-			return
-		}
-		return
-	}
-	if !conn.isInitialized() {
-		resp := conn.HandleMessage(ctx, msg)
-		if resp.Kind() == appwire.MessageInvalid {
-			return
-		}
-		if err := conn.enqueueResponse(ctx, resp); err != nil {
-			conn.cancelContext()
-		}
-		return
-	}
-	go func() {
-		resp := conn.HandleMessage(ctx, msg)
-		if resp.Kind() == appwire.MessageInvalid {
-			return
-		}
-		if err := conn.enqueueResponse(ctx, resp); err != nil {
-			conn.cancelContext()
-		}
-	}()
 }
 
 // runWebSocketKeepalive pings the peer every interval and cancels the

--- a/internal/appserver/websocket_dispatch_test.go
+++ b/internal/appserver/websocket_dispatch_test.go
@@ -2,14 +2,56 @@ package appserver
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
 
 	"primeradiant.com/evener/appwire"
 )
+
+// serveWebSocketHTTP spins up an httptest server speaking AppWire over
+// WebSocket for the given server and closes it at test cleanup.
+func serveWebSocketHTTP(t *testing.T, server *Server) *httptest.Server {
+	t.Helper()
+	httpServer := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
+	t.Cleanup(httpServer.Close)
+	return httpServer
+}
+
+// dialAppWireClient dials the ServeWebSocket endpoint and returns an
+// initialized client. The transport is closed at test cleanup.
+func dialAppWireClient(t *testing.T, httpServer *httptest.Server) *appwire.Client {
+	t.Helper()
+	ctx := context.Background()
+	transport, err := appwire.DialWebSocket(ctx, "ws"+httpServer.URL[len("http"):], httpServer.Client())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = transport.Close() })
+	client := appwire.NewClient(transport)
+	client.Start(ctx)
+	if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	return client
+}
+
+// waitFor is the one shared "block until this channel yields or the test
+// deadline passes" helper; what names the thing being waited for.
+func waitFor[T any](t *testing.T, what string, ch <-chan T) T {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", what)
+		return *new(T)
+	}
+}
 
 // dispatchSlowFastServer builds a server whose thread/list handler blocks
 // until released, plus an http server speaking AppWire over WebSocket. The
@@ -29,7 +71,7 @@ func dispatchSlowFastServer(t *testing.T) (*Server, *httptest.Server, chan struc
 		<-releaseHandler
 		return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_held"}}}, nil
 	})
-	httpServer := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
+	httpServer := serveWebSocketHTTP(t, server)
 	t.Cleanup(func() {
 		select {
 		case <-releaseHandler:
@@ -37,24 +79,7 @@ func dispatchSlowFastServer(t *testing.T) (*Server, *httptest.Server, chan struc
 			close(releaseHandler)
 		}
 	})
-	t.Cleanup(httpServer.Close)
 	return server, httpServer, handlerStarted
-}
-
-func dispatchDialClient(t *testing.T, httpServer *httptest.Server) *appwire.Client {
-	t.Helper()
-	ctx := context.Background()
-	transport, err := appwire.DialWebSocket(ctx, "ws"+httpServer.URL[len("http"):], httpServer.Client())
-	if err != nil {
-		t.Fatalf("dial: %v", err)
-	}
-	t.Cleanup(func() { _ = transport.Close() })
-	client := appwire.NewClient(transport)
-	client.Start(ctx)
-	if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
-		t.Fatalf("Initialize: %v", err)
-	}
-	return client
 }
 
 // TestServeWebSocketSlowHandlerDoesNotDelayPing pins the fix itself: with one
@@ -62,7 +87,7 @@ func dispatchDialClient(t *testing.T, httpServer *httptest.Server) *appwire.Clie
 // on the same connection while the slow handler is still running.
 func TestServeWebSocketSlowHandlerDoesNotDelayPing(t *testing.T) {
 	_, httpServer, handlerStarted := dispatchSlowFastServer(t)
-	client := dispatchDialClient(t, httpServer)
+	client := dialAppWireClient(t, httpServer)
 	ctx := context.Background()
 
 	slowDone := make(chan error, 1)
@@ -70,11 +95,7 @@ func TestServeWebSocketSlowHandlerDoesNotDelayPing(t *testing.T) {
 		_, err := client.ThreadList(ctx, appwire.ThreadListParams{})
 		slowDone <- err
 	}()
-	select {
-	case <-handlerStarted:
-	case <-time.After(time.Second):
-		t.Fatal("slow handler did not start")
-	}
+	waitFor(t, "slow handler to start", handlerStarted)
 
 	pingDone := make(chan error, 1)
 	go func() {
@@ -109,7 +130,7 @@ func TestServeWebSocketFastRequestCompletesWhileSlowHandlerRuns(t *testing.T) {
 		<-fastRelease
 		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: "th_fast"}}, nil
 	})
-	client := dispatchDialClient(t, httpServer)
+	client := dialAppWireClient(t, httpServer)
 	ctx := context.Background()
 
 	slowDone := make(chan error, 1)
@@ -117,22 +138,14 @@ func TestServeWebSocketFastRequestCompletesWhileSlowHandlerRuns(t *testing.T) {
 		_, err := client.ThreadList(ctx, appwire.ThreadListParams{})
 		slowDone <- err
 	}()
-	select {
-	case <-handlerStarted:
-	case <-time.After(time.Second):
-		t.Fatal("slow handler did not start")
-	}
+	waitFor(t, "slow handler to start", handlerStarted)
 
 	fastDone := make(chan error, 1)
 	go func() {
 		_, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:th_fast"})
 		fastDone <- err
 	}()
-	select {
-	case <-fastStarted:
-	case <-time.After(time.Second):
-		t.Fatal("fast handler did not start while the slow handler was busy")
-	}
+	waitFor(t, "fast handler to start while the slow handler was busy", fastStarted)
 
 	// Release only the fast handler; the slow one stays parked. If dispatch
 	// were still serial, the fast response could never arrive.
@@ -156,21 +169,21 @@ func TestServeWebSocketFastRequestCompletesWhileSlowHandlerRuns(t *testing.T) {
 // TestServeWebSocketRejectsRequestsBeforeInitialize pins the initialize
 // ordering invariant under concurrent dispatch over a real WebSocket: a
 // request that arrives before initialize completes is rejected ("initialize
-// required"), and once initialize lands the same request succeeds.
+// required"), and once initialize lands the same request succeeds. The
+// handshake cannot ride dialAppWireClient because that helper initializes.
 func TestServeWebSocketRejectsRequestsBeforeInitialize(t *testing.T) {
 	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
 	HandleTyped(server.Router(), appwire.MethodThreadList, func(_ context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
 		return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_1"}}}, nil
 	})
-	httpServer := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
-	defer httpServer.Close()
+	httpServer := serveWebSocketHTTP(t, server)
 
 	ctx := context.Background()
 	transport, err := appwire.DialWebSocket(ctx, "ws"+httpServer.URL[len("http"):], httpServer.Client())
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	defer transport.Close() //nolint:errcheck // test cleanup
+	t.Cleanup(func() { _ = transport.Close() })
 	client := appwire.NewClient(transport)
 	client.Start(ctx)
 
@@ -207,20 +220,9 @@ func TestServeWebSocketResponsesPairToIDsWhenHandlersCompleteOutOfOrder(t *testi
 		close(fastStarted)
 		return fastResult, nil
 	})
-	httpServer := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
-	defer httpServer.Close()
-
+	httpServer := serveWebSocketHTTP(t, server)
+	client := dialAppWireClient(t, httpServer)
 	ctx := context.Background()
-	transport, err := appwire.DialWebSocket(ctx, "ws"+httpServer.URL[len("http"):], httpServer.Client())
-	if err != nil {
-		t.Fatalf("dial: %v", err)
-	}
-	defer transport.Close() //nolint:errcheck // test cleanup
-	client := appwire.NewClient(transport)
-	client.Start(ctx)
-	if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
-		t.Fatalf("Initialize: %v", err)
-	}
 
 	slowDone := make(chan appwire.ThreadListResponse, 1)
 	slowErr := make(chan error, 1)
@@ -237,11 +239,7 @@ func TestServeWebSocketResponsesPairToIDsWhenHandlersCompleteOutOfOrder(t *testi
 		fastErr <- err
 	}()
 
-	select {
-	case <-fastStarted:
-	case <-time.After(time.Second):
-		t.Fatal("fast handler did not start while the slow handler was pending")
-	}
+	waitFor(t, "fast handler to start while the slow handler was pending", fastStarted)
 	select {
 	case err := <-fastErr:
 		if err != nil {
@@ -250,72 +248,49 @@ func TestServeWebSocketResponsesPairToIDsWhenHandlersCompleteOutOfOrder(t *testi
 	case <-time.After(time.Second):
 		t.Fatal("fast response was blocked behind the slow request")
 	}
-	select {
-	case resp := <-fastDone:
-		if resp.Thread.ID != "th_fast" {
-			t.Fatalf("fast response paired to wrong result: %+v", resp.Thread)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("fast response payload missing")
+	resp := waitFor(t, "fast response payload", fastDone)
+	if resp.Thread.ID != "th_fast" {
+		t.Fatalf("fast response paired to wrong result: %+v", resp.Thread)
 	}
 
 	close(releaseSlow)
-	select {
-	case err := <-slowErr:
-		if err != nil {
-			t.Fatalf("slow request failed after release: %v", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("slow request did not complete after release")
+	if err := waitFor(t, "slow request to complete after release", slowErr); err != nil {
+		t.Fatalf("slow request failed after release: %v", err)
 	}
-	select {
-	case resp := <-slowDone:
-		if len(resp.Data) != 1 || resp.Data[0].ID != "th_slow" {
-			t.Fatalf("slow response paired to wrong result: %+v", resp.Data)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("slow response payload missing")
+	slowResp := waitFor(t, "slow response payload", slowDone)
+	if len(slowResp.Data) != 1 || slowResp.Data[0].ID != "th_slow" {
+		t.Fatalf("slow response paired to wrong result: %+v", slowResp.Data)
 	}
 }
 
 // TestServeWebSocketBurstOfConcurrentRequestsAllPairCorrectly drives many
 // concurrent requests over one connection and checks every response pairs to
-// its own request id — a stress form of the correlation invariant above.
+// its own request — a stress form of the correlation invariant above. Each
+// request carries a distinct nonce the handler echoes back, so a response
+// paired to the wrong request cannot pass.
 func TestServeWebSocketBurstOfConcurrentRequestsAllPairCorrectly(t *testing.T) {
 	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
-	HandleTyped(server.Router(), appwire.MethodThreadList, func(_ context.Context, params appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
-		// Echo the raw params through the response so the test can tell each
-		// request's own answer apart.
-		return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_1"}}}, nil
+	HandleTyped(server.Router(), appwire.MethodThreadRead, func(_ context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: params.ThreadID}}, nil
 	})
-	httpServer := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
-	defer httpServer.Close()
-
+	httpServer := serveWebSocketHTTP(t, server)
+	client := dialAppWireClient(t, httpServer)
 	ctx := context.Background()
-	transport, err := appwire.DialWebSocket(ctx, "ws"+httpServer.URL[len("http"):], httpServer.Client())
-	if err != nil {
-		t.Fatalf("dial: %v", err)
-	}
-	defer transport.Close() //nolint:errcheck // test cleanup
-	client := appwire.NewClient(transport)
-	client.Start(ctx)
-	if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
-		t.Fatalf("Initialize: %v", err)
-	}
 
 	const requests = 30
 	var wg sync.WaitGroup
 	wg.Add(requests)
-	for range requests {
+	for i := range requests {
 		go func() {
 			defer wg.Done()
-			resp, err := client.ThreadList(ctx, appwire.ThreadListParams{})
+			nonce := "th_burst_" + strconv.Itoa(i)
+			resp, err := client.ThreadRead(ctx, appwire.ThreadReadParams{ThreadID: nonce})
 			if err != nil {
-				t.Errorf("concurrent request failed: %v", err)
+				t.Errorf("concurrent request %d failed: %v", i, err)
 				return
 			}
-			if len(resp.Data) != 1 || resp.Data[0].ID != "th_1" {
-				t.Errorf("concurrent response paired wrong: %+v", resp.Data)
+			if resp.Thread.ID != nonce {
+				t.Errorf("concurrent response %d paired wrong: got %q, want %q", i, resp.Thread.ID, nonce)
 			}
 		}()
 	}
@@ -328,5 +303,72 @@ func TestServeWebSocketBurstOfConcurrentRequestsAllPairCorrectly(t *testing.T) {
 	case <-wgDone:
 	case <-time.After(5 * time.Second):
 		t.Fatal("concurrent request burst did not all complete")
+	}
+}
+
+// TestServeWebSocketInFlightOverflowAnswersUnavailableAndPingStillAnswered
+// pins the in-flight limiter: with every slot held by a blocking handler, the
+// next request is answered promptly with a retryable Unavailable wire error —
+// not parked, not disconnected — and ping still answers on the same
+// connection, because the limiter never blocks the receive loop.
+func TestServeWebSocketInFlightOverflowAnswersUnavailableAndPingStillAnswered(t *testing.T) {
+	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
+	release := make(chan struct{})
+	var started sync.WaitGroup
+	started.Add(maxConcurrentRequestsPerConnection)
+	HandleTyped(server.Router(), appwire.MethodThreadRead, func(_ context.Context, _ appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		started.Done()
+		<-release
+		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: "th_held"}}, nil
+	})
+	HandleTyped(server.Router(), appwire.MethodThreadList, func(_ context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+		return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_list"}}}, nil
+	})
+	httpServer := serveWebSocketHTTP(t, server)
+	client := dialAppWireClient(t, httpServer)
+	ctx := context.Background()
+	t.Cleanup(func() { close(release) })
+
+	// Park one request per limiter slot; each takes its own dispatch
+	// goroutine and its own slot.
+	for range maxConcurrentRequestsPerConnection {
+		go func() {
+			_, _ = client.ThreadRead(ctx, appwire.ThreadReadParams{ThreadID: "th_held"})
+		}()
+	}
+	startedDone := make(chan struct{})
+	go func() {
+		started.Wait()
+		close(startedDone)
+	}()
+	waitFor(t, "all in-flight slots to be held", startedDone)
+
+	overflowDone := make(chan error, 1)
+	go func() {
+		_, err := client.ThreadList(ctx, appwire.ThreadListParams{})
+		overflowDone <- err
+	}()
+	select {
+	case err := <-overflowDone:
+		var wire appwire.WireError
+		if !errors.As(err, &wire) || wire.Code != appwire.CodeUnavailable {
+			t.Fatalf("overflow request error=%v, want Unavailable wire error", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("overflow request was parked instead of answered with Unavailable")
+	}
+
+	pingDone := make(chan error, 1)
+	go func() {
+		var out appwire.EmptyResponse
+		pingDone <- client.Request(ctx, appwire.MethodPing, appwire.EmptyParams{}, &out)
+	}()
+	select {
+	case err := <-pingDone:
+		if err != nil {
+			t.Fatalf("ping failed while all in-flight slots were held: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ping was starved while all in-flight slots were held")
 	}
 }

--- a/internal/appserver/websocket_dispatch_test.go
+++ b/internal/appserver/websocket_dispatch_test.go
@@ -1,0 +1,332 @@
+package appserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+)
+
+// dispatchSlowFastServer builds a server whose thread/list handler blocks
+// until released, plus an http server speaking AppWire over WebSocket. The
+// release channel is closed by test cleanup so a parked handler can never
+// outlive the test.
+func dispatchSlowFastServer(t *testing.T) (*Server, *httptest.Server, chan struct{}) {
+	t.Helper()
+	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
+	handlerStarted := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	HandleTyped(server.Router(), appwire.MethodThreadList, func(_ context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+		select {
+		case <-handlerStarted:
+		default:
+			close(handlerStarted)
+		}
+		<-releaseHandler
+		return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_held"}}}, nil
+	})
+	httpServer := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
+	t.Cleanup(func() {
+		select {
+		case <-releaseHandler:
+		default:
+			close(releaseHandler)
+		}
+	})
+	t.Cleanup(httpServer.Close)
+	return server, httpServer, handlerStarted
+}
+
+func dispatchDialClient(t *testing.T, httpServer *httptest.Server) *appwire.Client {
+	t.Helper()
+	ctx := context.Background()
+	transport, err := appwire.DialWebSocket(ctx, "ws"+httpServer.URL[len("http"):], httpServer.Client())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = transport.Close() })
+	client := appwire.NewClient(transport)
+	client.Start(ctx)
+	if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	return client
+}
+
+// TestServeWebSocketSlowHandlerDoesNotDelayPing pins the fix itself: with one
+// handler parked mid-turn, the browser's app-level ping heartbeat completes
+// on the same connection while the slow handler is still running.
+func TestServeWebSocketSlowHandlerDoesNotDelayPing(t *testing.T) {
+	_, httpServer, handlerStarted := dispatchSlowFastServer(t)
+	client := dispatchDialClient(t, httpServer)
+	ctx := context.Background()
+
+	slowDone := make(chan error, 1)
+	go func() {
+		_, err := client.ThreadList(ctx, appwire.ThreadListParams{})
+		slowDone <- err
+	}()
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("slow handler did not start")
+	}
+
+	pingDone := make(chan error, 1)
+	go func() {
+		var out appwire.EmptyResponse
+		pingDone <- client.Request(ctx, appwire.MethodPing, appwire.EmptyParams{}, &out)
+	}()
+	select {
+	case err := <-pingDone:
+		if err != nil {
+			t.Fatalf("ping failed while a slow handler was busy: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ping was starved by a busy handler")
+	}
+
+	select {
+	case err := <-slowDone:
+		t.Fatalf("slow handler completed before it was released: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// TestServeWebSocketFastRequestCompletesWhileSlowHandlerRuns pins the other
+// half of the fix: a fast request issued after a slow one returns its own
+// response, correctly paired to its id, without waiting for the slow one.
+func TestServeWebSocketFastRequestCompletesWhileSlowHandlerRuns(t *testing.T) {
+	server, httpServer, handlerStarted := dispatchSlowFastServer(t)
+	fastStarted := make(chan struct{})
+	fastRelease := make(chan struct{})
+	HandleTyped(server.Router(), appwire.MethodThreadRead, func(_ context.Context, _ appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		close(fastStarted)
+		<-fastRelease
+		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: "th_fast"}}, nil
+	})
+	client := dispatchDialClient(t, httpServer)
+	ctx := context.Background()
+
+	slowDone := make(chan error, 1)
+	go func() {
+		_, err := client.ThreadList(ctx, appwire.ThreadListParams{})
+		slowDone <- err
+	}()
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("slow handler did not start")
+	}
+
+	fastDone := make(chan error, 1)
+	go func() {
+		_, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:th_fast"})
+		fastDone <- err
+	}()
+	select {
+	case <-fastStarted:
+	case <-time.After(time.Second):
+		t.Fatal("fast handler did not start while the slow handler was busy")
+	}
+
+	// Release only the fast handler; the slow one stays parked. If dispatch
+	// were still serial, the fast response could never arrive.
+	close(fastRelease)
+	select {
+	case err := <-fastDone:
+		if err != nil {
+			t.Fatalf("fast request failed while slow handler was busy: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("fast request was head-of-line blocked behind a slow handler")
+	}
+
+	select {
+	case err := <-slowDone:
+		t.Fatalf("slow handler completed before it was released: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// TestServeWebSocketRejectsRequestsBeforeInitialize pins the initialize
+// ordering invariant under concurrent dispatch over a real WebSocket: a
+// request that arrives before initialize completes is rejected ("initialize
+// required"), and once initialize lands the same request succeeds.
+func TestServeWebSocketRejectsRequestsBeforeInitialize(t *testing.T) {
+	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
+	HandleTyped(server.Router(), appwire.MethodThreadList, func(_ context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+		return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_1"}}}, nil
+	})
+	httpServer := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
+	defer httpServer.Close()
+
+	ctx := context.Background()
+	transport, err := appwire.DialWebSocket(ctx, "ws"+httpServer.URL[len("http"):], httpServer.Client())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer transport.Close() //nolint:errcheck // test cleanup
+	client := appwire.NewClient(transport)
+	client.Start(ctx)
+
+	if _, err := client.ThreadList(ctx, appwire.ThreadListParams{}); err == nil {
+		t.Fatal("ThreadList before initialize succeeded")
+	}
+	if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	resp, err := client.ThreadList(ctx, appwire.ThreadListParams{})
+	if err != nil {
+		t.Fatalf("ThreadList after initialize: %v", err)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].ID != "th_1" {
+		t.Fatalf("resp=%+v", resp)
+	}
+}
+
+// TestServeWebSocketResponsesPairToIDsWhenHandlersCompleteOutOfOrder pins
+// response correlation: two concurrent requests whose handlers complete in
+// the opposite order they were issued both return their own result, not each
+// other's.
+func TestServeWebSocketResponsesPairToIDsWhenHandlersCompleteOutOfOrder(t *testing.T) {
+	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
+	releaseSlow := make(chan struct{})
+	slowResult := appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_slow"}}}
+	fastResult := appwire.ThreadReadResponse{Thread: appwire.Thread{ID: "th_fast"}}
+	HandleTyped(server.Router(), appwire.MethodThreadList, func(_ context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+		<-releaseSlow
+		return slowResult, nil
+	})
+	fastStarted := make(chan struct{})
+	HandleTyped(server.Router(), appwire.MethodThreadRead, func(_ context.Context, _ appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		close(fastStarted)
+		return fastResult, nil
+	})
+	httpServer := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
+	defer httpServer.Close()
+
+	ctx := context.Background()
+	transport, err := appwire.DialWebSocket(ctx, "ws"+httpServer.URL[len("http"):], httpServer.Client())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer transport.Close() //nolint:errcheck // test cleanup
+	client := appwire.NewClient(transport)
+	client.Start(ctx)
+	if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	slowDone := make(chan appwire.ThreadListResponse, 1)
+	slowErr := make(chan error, 1)
+	go func() {
+		resp, err := client.ThreadList(ctx, appwire.ThreadListParams{})
+		slowDone <- resp
+		slowErr <- err
+	}()
+	fastDone := make(chan appwire.ThreadReadResponse, 1)
+	fastErr := make(chan error, 1)
+	go func() {
+		resp, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:th_fast"})
+		fastDone <- resp
+		fastErr <- err
+	}()
+
+	select {
+	case <-fastStarted:
+	case <-time.After(time.Second):
+		t.Fatal("fast handler did not start while the slow handler was pending")
+	}
+	select {
+	case err := <-fastErr:
+		if err != nil {
+			t.Fatalf("fast request failed before the slow one completed: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("fast response was blocked behind the slow request")
+	}
+	select {
+	case resp := <-fastDone:
+		if resp.Thread.ID != "th_fast" {
+			t.Fatalf("fast response paired to wrong result: %+v", resp.Thread)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("fast response payload missing")
+	}
+
+	close(releaseSlow)
+	select {
+	case err := <-slowErr:
+		if err != nil {
+			t.Fatalf("slow request failed after release: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("slow request did not complete after release")
+	}
+	select {
+	case resp := <-slowDone:
+		if len(resp.Data) != 1 || resp.Data[0].ID != "th_slow" {
+			t.Fatalf("slow response paired to wrong result: %+v", resp.Data)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("slow response payload missing")
+	}
+}
+
+// TestServeWebSocketBurstOfConcurrentRequestsAllPairCorrectly drives many
+// concurrent requests over one connection and checks every response pairs to
+// its own request id — a stress form of the correlation invariant above.
+func TestServeWebSocketBurstOfConcurrentRequestsAllPairCorrectly(t *testing.T) {
+	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
+	HandleTyped(server.Router(), appwire.MethodThreadList, func(_ context.Context, params appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+		// Echo the raw params through the response so the test can tell each
+		// request's own answer apart.
+		return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_1"}}}, nil
+	})
+	httpServer := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
+	defer httpServer.Close()
+
+	ctx := context.Background()
+	transport, err := appwire.DialWebSocket(ctx, "ws"+httpServer.URL[len("http"):], httpServer.Client())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer transport.Close() //nolint:errcheck // test cleanup
+	client := appwire.NewClient(transport)
+	client.Start(ctx)
+	if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	const requests = 30
+	var wg sync.WaitGroup
+	wg.Add(requests)
+	for range requests {
+		go func() {
+			defer wg.Done()
+			resp, err := client.ThreadList(ctx, appwire.ThreadListParams{})
+			if err != nil {
+				t.Errorf("concurrent request failed: %v", err)
+				return
+			}
+			if len(resp.Data) != 1 || resp.Data[0].ID != "th_1" {
+				t.Errorf("concurrent response paired wrong: %+v", resp.Data)
+			}
+		}()
+	}
+	wgDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(wgDone)
+	}()
+	select {
+	case <-wgDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent request burst did not all complete")
+	}
+}

--- a/internal/appserver/websocket_dispatch_test.go
+++ b/internal/appserver/websocket_dispatch_test.go
@@ -2,9 +2,11 @@ package appserver
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strconv"
 	"sync"
 	"testing"
@@ -371,4 +373,160 @@ func TestServeWebSocketInFlightOverflowAnswersUnavailableAndPingStillAnswered(t 
 	case <-time.After(time.Second):
 		t.Fatal("ping was starved while all in-flight slots were held")
 	}
+}
+
+// hydrationMarkerParams is the notification payload the read-then-mutation
+// interleaving test commits: a thread-scoped marker identifying exactly which
+// mutation produced the record, so the test can assert every record arrived
+// exactly once across the buffered replay set and the live stream.
+type hydrationMarkerParams struct {
+	ThreadID string `json:"threadId"`
+	Marker   string `json:"marker"`
+}
+
+// TestServeWebSocketHydrationThenMutationDeliversEveryNotificationExactlyOnce
+// pins the record accounting when one connection issues a hydrating read
+// immediately followed by mutations: under concurrent dispatch the mutation
+// can run (and commit notifications) while the hydration read is still in
+// flight, so the sequence-cut discipline — not dispatch order — decides which
+// set each record lands in. Whatever the interleaving, every notification
+// must reach the client exactly once, in whichever set (the hydration's
+// buffered replay or the live stream), and none may be lost or duplicated.
+func TestServeWebSocketHydrationThenMutationDeliversEveryNotificationExactlyOnce(t *testing.T) {
+	const threadID = "th_hydration"
+	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
+	notifier := NewNotifier(64)
+
+	// releaseHydrationRead parks the hydrating read AFTER its buffering
+	// subscription is open (the capture has returned, locks released), which is
+	// exactly the in-flight window a follow-up request can now dispatch into:
+	// before concurrent dispatch it would have queued behind the read.
+	hydrationReadParked := make(chan struct{})
+	releaseHydrationRead := make(chan struct{})
+	HandleTyped(server.Router(), appwire.MethodThreadRead, func(ctx context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		var response appwire.ThreadReadResponse
+		response.Thread = appwire.Thread{ID: params.ThreadID}
+		if !CaptureSubscription(
+			ctx,
+			false,
+			func() string { return threadID },
+			notifier.CurrentSequence,
+			func() bool { return true },
+		) {
+			t.Error("hydration capture was rejected")
+		}
+		// Park with the buffering subscription open: the cut is already taken,
+		// so records committed from here on land in the buffered replay set.
+		close(hydrationReadParked)
+		<-releaseHydrationRead
+		return response, nil
+	})
+	// The mutation commits its notification through CommitProjection from the
+	// handler itself — the same path hub handlers use — so the commit runs
+	// while the hydration read is still parked in flight. Each mutation names
+	// itself through the Model field so its record is identifiable on arrival.
+	HandleTyped(server.Router(), appwire.MethodThreadModelSet, func(_ context.Context, params appwire.ThreadModelSetParams) (appwire.EmptyResponse, error) {
+		server.CommitProjection(func() []SequencedNotification {
+			record := notifier.Record(threadID, appwire.NotifyThreadStatusChanged, hydrationMarkerParams{
+				ThreadID: threadID,
+				Marker:   params.Model,
+			})
+			return []SequencedNotification{record}
+		})
+		return appwire.EmptyResponse{}, nil
+	})
+
+	httpServer := serveWebSocketHTTP(t, server)
+	client := dialAppWireClient(t, httpServer)
+	ctx := context.Background()
+	t.Cleanup(func() {
+		select {
+		case <-releaseHydrationRead:
+		default:
+			close(releaseHydrationRead)
+		}
+	})
+
+	// One connection issues the hydrating read, then — while that read is
+	// still in flight — two mutations. Both commits land above the open
+	// capture's cut, so both records must be buffered into the replay set.
+	hydrateDone := make(chan error, 1)
+	go func() {
+		_, err := client.ThreadRead(ctx, appwire.ThreadReadParams{ThreadID: threadID})
+		hydrateDone <- err
+	}()
+	waitFor(t, "hydrating read to park in flight", hydrationReadParked)
+
+	runMutation := func(marker string) chan error {
+		done := make(chan error, 1)
+		go func() {
+			done <- client.ThreadModelSet(ctx, appwire.ThreadModelSetParams{
+				Ref:           "local:" + threadID,
+				ModelProvider: "test-provider",
+				Model:         marker,
+			})
+		}()
+		return done
+	}
+	for i := range 2 {
+		if err := waitFor(t, "in-flight mutation to complete", runMutation("inflight-"+strconv.Itoa(i))); err != nil {
+			t.Fatalf("mutation during hydration failed: %v", err)
+		}
+	}
+
+	// Let the hydrating read finish. Its response enqueues, the capture
+	// commits, and the buffered records flush behind it — after this the
+	// subscription is live again.
+	close(releaseHydrationRead)
+	if err := waitFor(t, "hydrating read to complete", hydrateDone); err != nil {
+		t.Fatalf("hydrating read failed: %v", err)
+	}
+
+	// Two more mutations on the same connection, now against the live
+	// subscription: their records must stream directly. Together with the
+	// buffered pair above, both delivery sets are exercised.
+	for i := range 2 {
+		if err := waitFor(t, "live mutation to complete", runMutation("live-"+strconv.Itoa(i))); err != nil {
+			t.Fatalf("live mutation failed: %v", err)
+		}
+	}
+
+	// Every notification must arrive exactly once, in whichever set. The
+	// buffered pair rides the replay flush; the live pair streams; a record
+	// crossing both sets (or neither) fails by count or duplicate marker.
+	seen := make(map[string]bool)
+	deadline := time.Now().Add(5 * time.Second)
+	for len(seen) < 4 && time.Now().Before(deadline) {
+		select {
+		case notif := <-client.Notifications():
+			if notif.Method != appwire.NotifyThreadStatusChanged {
+				continue
+			}
+			var marker hydrationMarkerParams
+			if err := json.Unmarshal(notif.Params, &marker); err != nil {
+				t.Fatalf("decode notification params: %v", err)
+			}
+			if marker.ThreadID != threadID {
+				continue
+			}
+			if seen[marker.Marker] {
+				t.Fatalf("notification marker %q delivered twice", marker.Marker)
+			}
+			seen[marker.Marker] = true
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	if len(seen) != 4 {
+		t.Fatalf("distinct notifications received=%d of 4 (markers %v): records lost", len(seen), seenMarkers(seen))
+	}
+}
+
+// seenMarkers sorts the delivered markers for stable failure messages.
+func seenMarkers(seen map[string]bool) []string {
+	markers := make([]string, 0, len(seen))
+	for marker := range seen {
+		markers = append(markers, marker)
+	}
+	sort.Strings(markers)
+	return markers
 }

--- a/internal/appserver/websocket_test.go
+++ b/internal/appserver/websocket_test.go
@@ -45,7 +45,7 @@ func TestServeWebSocketHandlesAppWire(t *testing.T) {
 	}
 }
 
-func TestServeWebSocketKeepsBusyRPCAliveAndPingsWhenReaderIsIdle(t *testing.T) {
+func TestServeWebSocketPingsIdleReaderWhileBusyRPCHandlerRuns(t *testing.T) {
 	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
 	ticker := newControlledKeepaliveTicker()
 	decision := make(chan bool, 2)
@@ -101,17 +101,21 @@ func TestServeWebSocketKeepsBusyRPCAliveAndPingsWhenReaderIsIdle(t *testing.T) {
 	}
 
 	// Drive the actual ServeWebSocket keepalive goroutine while HandleMessage is
-	// held in the serial reader/dispatch path. The decision is emitted only
-	// after the gate has observed the busy reader, so release is not time-based.
+	// held busy in a handler goroutine. Concurrent dispatch keeps the receive
+	// loop reading, so the gate observes an available reader and the keepalive
+	// pings even while the RPC handler is still held. The decision is emitted
+	// only after the gate has been consulted, so release is not time-based.
 	ticker.Tick()
 	select {
 	case attempted := <-decision:
-		if attempted {
-			t.Fatal("keepalive attempted a ping while the serial RPC handler was busy")
+		if !attempted {
+			t.Fatal("keepalive did not attempt a ping while the receive loop was free and the RPC handler was busy")
 		}
 		release()
+	case <-idlePingSeen:
+		release()
 	case <-time.After(time.Second):
-		t.Fatal("keepalive did not report the busy-reader decision")
+		t.Fatal("keepalive did not report the available-reader decision")
 	}
 
 	select {
@@ -125,21 +129,24 @@ func TestServeWebSocketKeepsBusyRPCAliveAndPingsWhenReaderIsIdle(t *testing.T) {
 	// Receiving the RPC response does not order the send goroutine against the
 	// receive loop's next readerAvailable transition, so drive controlled ticks
 	// until the keepalive observes that transition and pings the idle peer.
+	//
+	// Under concurrent dispatch the ping is what proves the fix this test was
+	// renamed around: the heartbeat answers while the held handler is busy.
+	sawAvailablePing := false
 	availableDeadline := time.NewTimer(time.Second)
 	defer availableDeadline.Stop()
-	for {
+	for !sawAvailablePing {
 		ticker.Tick()
 		select {
 		case attempted := <-decision:
 			if attempted {
-				goto readerAvailable
+				sawAvailablePing = true
 			}
 		case <-availableDeadline.C:
 			t.Fatal("keepalive did not observe the available reader")
 		}
 	}
 
-readerAvailable:
 	select {
 	case <-idlePingSeen:
 	case <-time.After(time.Second):


### PR DESCRIPTION
## Summary

The hub's WebSocket receive loop handled every request synchronously, so one slow handler (e.g. a past-session thread/read doing full-transcript scans) head-of-line blocked ALL subsequent requests on that connection — including the browser heartbeat ping, which is the only way a browser (unable to send WS ping frames from JS) detects a half-open connection. A starved ping hung the whole UI for tens of seconds.

This dispatches each post-initialize request on its own goroutine, with:
- initialize (and all pre-initialize traffic) still handled inline — the handshake completes before the next frame is read, preserving the initialize-first contract
- ping and notifications always inline — the heartbeat is never behind a busy handler
- a per-connection 128-slot non-blocking in-flight limiter (overflow answered with a retryable Unavailable error rather than dispatched)
- responses through the existing enqueueResponse path (hydration capture commit/abort ordering unchanged)

Per-connection frame ordering is intentionally no longer serialized: responses pair by request ID, and only the sequence-cut discipline governs notification/response interleaving (documented in the dispatchMessage comment).

## Verification

- go build/vet, go test -race ./internal/appserver/, ./server/..., ./cmd/evener-hub/... all green
- New tests: slow handler doesn't delay ping or a fast request; pre-initialize requests still rejected; out-of-order response correlation; burst of 30 concurrent requests pair by per-request nonce; overflow returns Unavailable while ping still answers; hydration-then-mutation delivers every notification exactly once on one connection

Reviewed adversarially across two review rounds (ordering-contract documentation and interleaving test added from round-1 findings).