### PR TITLE
perf(hub): return rename before navigation rebuild completes

### DIFF
--- a/cmd/evener-hub/app_rename.go
+++ b/cmd/evener-hub/app_rename.go
@@ -44,9 +44,7 @@ func setThreadName(ctx context.Context, cfg hubcore.WebConfig, sources *appsourc
 	if err != nil {
 		return appwire.EmptyResponse{}, err
 	}
-	if err := completeThreadNameMutation(ctx, cfg, navigation, mutation); err != nil {
-		return appwire.EmptyResponse{}, err
-	}
+	completeThreadNameMutation(cfg, navigation, mutation)
 	return appwire.EmptyResponse{}, nil
 }
 
@@ -112,25 +110,18 @@ func refreshThreadNameMeta(cfg hubcore.WebConfig, ref appwire.Ref, name string) 
 	return mutation
 }
 
-func completeThreadNameMutation(ctx context.Context, cfg hubcore.WebConfig, navigation *NavigationService, mutation threadNameMutation) error {
+func completeThreadNameMutation(cfg hubcore.WebConfig, navigation *NavigationService, mutation threadNameMutation) {
 	pokeMutationAttention(cfg)
 	if navigation == nil {
-		return nil
+		return
 	}
 	hint := navigationChangeHint{AllLoadedProjects: true}
 	if mutation.projectKey != "" {
 		hint = navigationChangeHint{Projects: []string{mutation.projectKey}}
 	}
-	// The rename is durably committed above; rebuild navigation off the RPC
-	// path. Invalidate records the hint and wakes the service's scheduler,
-	// whose refreshPending commits the rebuild and appends the resulting
-	// NavigationInvalidated publications to the FIFO that the publisher loop
-	// broadcasts as evener/navigation/invalidated. If the rebuild fails, the
-	// scheduler re-arms the pending hint and retries, so the invalidation is
-	// still eventually published. The rpc's context is not used: nothing here
-	// depends on the request outliving the async rebuild.
+	// The rename is durably committed above; Invalidate queues the rebuild off
+	// the RPC path (see Invalidate/refreshPending for the retry contract).
 	navigation.Invalidate(hint)
-	return nil
 }
 
 func threadNameIsLive(cfg hubcore.WebConfig, threadID string) bool {

--- a/cmd/evener-hub/app_rename.go
+++ b/cmd/evener-hub/app_rename.go
@@ -19,7 +19,6 @@ var (
 
 type threadNameMutation struct {
 	projectKey string
-	notified   bool
 }
 
 func registerThreadNameSetHandler(server *appserver.Server, cfg hubcore.WebConfig, sources *appsource.Registry, navigation *NavigationService) {
@@ -72,7 +71,11 @@ func mutateThreadName(ctx context.Context, cfg hubcore.WebConfig, sources *appso
 	if err := saveSessionMetaForRename(entry.StateDir, meta); err != nil {
 		return threadNameMutation{}, appwire.InternalError("save meta: " + err.Error())
 	}
-	return threadNameMutation{projectKey: projectKeyForStateDir(entry.StateDir), notified: cfg.Past.UpdateMeta(entry.ID, meta)}, nil
+	// UpdateMeta keeps the past index entry coherent with the saved meta; the
+	// OnChange notification it fires is consumed by the main wiring (see
+	// main.go), not by the rename completion below.
+	cfg.Past.UpdateMeta(entry.ID, meta)
+	return threadNameMutation{projectKey: projectKeyForStateDir(entry.StateDir)}, nil
 }
 
 func renameLiveThread(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, ref appwire.Ref, params appwire.ThreadNameSetParams) (threadNameMutation, error) {
@@ -105,7 +108,7 @@ func refreshThreadNameMeta(cfg hubcore.WebConfig, ref appwire.Ref, name string) 
 		meta.Name = name
 		meta.NameSource = "user"
 	}
-	mutation.notified = cfg.Past.UpdateMeta(entry.ID, meta)
+	cfg.Past.UpdateMeta(entry.ID, meta)
 	return mutation
 }
 
@@ -114,16 +117,19 @@ func completeThreadNameMutation(ctx context.Context, cfg hubcore.WebConfig, navi
 	if navigation == nil {
 		return nil
 	}
-	if !mutation.notified {
-		navigation.Invalidate(navigationChangeHint{})
-	}
 	hint := navigationChangeHint{AllLoadedProjects: true}
 	if mutation.projectKey != "" {
 		hint = navigationChangeHint{Projects: []string{mutation.projectKey}}
 	}
-	if _, err := navigation.Refresh(ctx, hint); err != nil {
-		return appwire.Unavailable(err.Error())
-	}
+	// The rename is durably committed above; rebuild navigation off the RPC
+	// path. Invalidate records the hint and wakes the service's scheduler,
+	// whose refreshPending commits the rebuild and appends the resulting
+	// NavigationInvalidated publications to the FIFO that the publisher loop
+	// broadcasts as evener/navigation/invalidated. If the rebuild fails, the
+	// scheduler re-arms the pending hint and retries, so the invalidation is
+	// still eventually published. The rpc's context is not used: nothing here
+	// depends on the request outliving the async rebuild.
+	navigation.Invalidate(hint)
 	return nil
 }
 

--- a/cmd/evener-hub/app_rename_test.go
+++ b/cmd/evener-hub/app_rename_test.go
@@ -54,6 +54,65 @@ func drainRenamePublications(t *testing.T, navigation *NavigationService) []appw
 	return navigation.DrainPublications()
 }
 
+// endedRenameFixture is the shared environment for renaming an ended session:
+// the session meta on disk under a project state dir, a past index over it, and
+// a navigation service plus app server whose tree points at that project.
+// Renames dispatched through the server update the on-disk meta and feed title
+// changes into the navigation source.
+type endedRenameFixture struct {
+	stateDir   string
+	original   schema.SessionMeta
+	projectKey string
+	source     *testNavigationSource
+	navigation *NavigationService
+	server     *appserver.Server
+}
+
+func newEndedRenameFixture(t *testing.T, projectDir string) endedRenameFixture {
+	t.Helper()
+	root := t.TempDir()
+	stateDir := filepath.Join(root, "projects", projectDir)
+	original := schema.SessionMeta{
+		ID:         "02wMz5Txv1C3Hut0M8GCeB",
+		Name:       "old",
+		NameSource: "generated",
+		UpdatedAt:  time.Unix(1_700_000_000, 0).UTC(),
+		EnvInfo:    schema.EnvironmentInfo{WorkingDir: "/preserve"},
+	}
+	if err := schema.SaveSessionMeta(stateDir, original); err != nil {
+		t.Fatal(err)
+	}
+	past := hubcore.NewPastIndexWithDB(filepath.Join(root, "projects", "*"), filepath.Join(root, "index.db"))
+	if _, err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+	source := newTestNavigationSource(time.Unix(1_700_000_000, 0).UTC())
+	projectKey := filepath.Base(stateDir)
+	source.inputs.Tree.Projects[0].Key = projectKey
+	source.inputs.Tree.Projects[0].Name = projectKey
+	source.inputs.Tree.Projects[0].Current[0].Project = projectKey
+	navigation := newTestNavigationService(t, source)
+	if _, err := navigation.Representation(t.Context(), navigationResourceKey{Kind: navigationResourceManifest}); err != nil {
+		t.Fatal(err)
+	}
+	oldSave := saveSessionMetaForRename
+	saveSessionMetaForRename = func(dir string, meta schema.SessionMeta) error {
+		source.changeTitle(meta.Name)
+		return oldSave(dir, meta)
+	}
+	t.Cleanup(func() { saveSessionMetaForRename = oldSave })
+	registry := appsource.NewRegistry()
+	server := newHubAppServerWithNavigation(hubcore.WebConfig{Past: past, Roster: hubcore.NewRosterWithEntries()}, registry, navigation, nil)
+	return endedRenameFixture{
+		stateDir:   stateDir,
+		original:   original,
+		projectKey: projectKey,
+		source:     source,
+		navigation: navigation,
+		server:     server,
+	}
+}
+
 func TestAppWireNavigationRenameConvergesLiveAndEnded(t *testing.T) {
 	t.Run("live changed and repeat no-op", func(t *testing.T) {
 		source := newTestNavigationSource(time.Unix(1_700_000_000, 0).UTC())
@@ -89,50 +148,24 @@ func TestAppWireNavigationRenameConvergesLiveAndEnded(t *testing.T) {
 	})
 
 	t.Run("ended changed and repeat no-op", func(t *testing.T) {
-		root := t.TempDir()
-		stateDir := filepath.Join(root, "projects", "project-0123456789")
-		original := schema.SessionMeta{ID: "02wMz5Txv1C3Hut0M8GCeB", Name: "old", NameSource: "generated", UpdatedAt: time.Unix(1_700_000_000, 0).UTC(), EnvInfo: schema.EnvironmentInfo{WorkingDir: "/preserve"}}
-		if err := schema.SaveSessionMeta(stateDir, original); err != nil {
-			t.Fatal(err)
-		}
-		past := hubcore.NewPastIndexWithDB(filepath.Join(root, "projects", "*"), filepath.Join(root, "index.db"))
-		if _, err := past.Rebuild(); err != nil {
-			t.Fatal(err)
-		}
-		source := newTestNavigationSource(time.Unix(1_700_000_000, 0).UTC())
-		projectKey := filepath.Base(stateDir)
-		source.inputs.Tree.Projects[0].Key = projectKey
-		source.inputs.Tree.Projects[0].Name = projectKey
-		source.inputs.Tree.Projects[0].Current[0].Project = projectKey
-		navigation := newTestNavigationService(t, source)
-		if _, err := navigation.Representation(t.Context(), navigationResourceKey{Kind: navigationResourceManifest}); err != nil {
-			t.Fatal(err)
-		}
-		registry := appsource.NewRegistry()
-		server := newHubAppServerWithNavigation(hubcore.WebConfig{Past: past, Roster: hubcore.NewRosterWithEntries()}, registry, navigation, nil)
-		oldSave := saveSessionMetaForRename
-		saveSessionMetaForRename = func(dir string, meta schema.SessionMeta) error {
-			source.changeTitle(meta.Name)
-			return oldSave(dir, meta)
-		}
-		defer func() { saveSessionMetaForRename = oldSave }()
+		fixture := newEndedRenameFixture(t, "project-0123456789")
 
-		if err := dispatchThreadNameSet(t, server, appwire.ThreadNameSetParams{Ref: "local:" + original.ID, Name: "  renamed-ended  "}); err != nil {
+		if err := dispatchThreadNameSet(t, fixture.server, appwire.ThreadNameSetParams{Ref: "local:" + fixture.original.ID, Name: "  renamed-ended  "}); err != nil {
 			t.Fatalf("thread name set: %v", err)
 		}
-		assertRenameTargets(t, drainRenamePublications(t, navigation), []appwire.NavigationInvalidationTarget{{Kind: appwire.NavigationTargetProject, ProjectKey: projectKey}})
-		got, err := schema.LoadSessionMeta(stateDir, original.ID)
+		assertRenameTargets(t, drainRenamePublications(t, fixture.navigation), []appwire.NavigationInvalidationTarget{{Kind: appwire.NavigationTargetProject, ProjectKey: fixture.projectKey}})
+		got, err := schema.LoadSessionMeta(fixture.stateDir, fixture.original.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got.Name != "renamed-ended" || got.NameSource != "user" || got.ID != original.ID || !reflect.DeepEqual(got.EnvInfo, original.EnvInfo) {
-			t.Fatalf("renamed meta=%+v, preserved original=%+v", got, original)
+		if got.Name != "renamed-ended" || got.NameSource != "user" || got.ID != fixture.original.ID || !reflect.DeepEqual(got.EnvInfo, fixture.original.EnvInfo) {
+			t.Fatalf("renamed meta=%+v, preserved original=%+v", got, fixture.original)
 		}
 
-		if err := dispatchThreadNameSet(t, server, appwire.ThreadNameSetParams{Ref: "local:" + original.ID, Name: "renamed-ended"}); err != nil {
+		if err := dispatchThreadNameSet(t, fixture.server, appwire.ThreadNameSetParams{Ref: "local:" + fixture.original.ID, Name: "renamed-ended"}); err != nil {
 			t.Fatalf("repeat thread name set: %v", err)
 		}
-		if events := drainRenamePublications(t, navigation); len(events) != 0 {
+		if events := drainRenamePublications(t, fixture.navigation); len(events) != 0 {
 			t.Fatalf("repeat ended rename published events=%+v", events)
 		}
 	})
@@ -158,52 +191,24 @@ func TestAppWireRenameValidatesRefAndName(t *testing.T) {
 }
 
 func TestAppWireRenameReturnsBeforeNavigationRebuildCompletes(t *testing.T) {
-	root := t.TempDir()
-	stateDir := filepath.Join(root, "projects", "project-async-rename-0123456789")
-	original := schema.SessionMeta{ID: "02wMz5Txv1C3Hut0M8GCeB", Name: "old", NameSource: "generated", UpdatedAt: time.Unix(1_700_000_000, 0).UTC()}
-	if err := schema.SaveSessionMeta(stateDir, original); err != nil {
-		t.Fatal(err)
-	}
-	past := hubcore.NewPastIndexWithDB(filepath.Join(root, "projects", "*"), filepath.Join(root, "index.db"))
-	if _, err := past.Rebuild(); err != nil {
-		t.Fatal(err)
-	}
-	source := newTestNavigationSource(time.Unix(1_700_000_000, 0).UTC())
-	projectKey := filepath.Base(stateDir)
-	source.inputs.Tree.Projects[0].Key = projectKey
-	source.inputs.Tree.Projects[0].Name = projectKey
-	source.inputs.Tree.Projects[0].Current[0].Project = projectKey
-	navigation := newTestNavigationService(t, source)
-	if _, err := navigation.Representation(t.Context(), navigationResourceKey{Kind: navigationResourceManifest}); err != nil {
-		t.Fatal(err)
-	}
+	fixture := newEndedRenameFixture(t, "project-async-rename-0123456789")
 	// From here on, every capture blocks until released: a navigation rebuild
 	// that never completes on its own. The rename RPC must still return.
-	source.entered = make(chan struct{})
-	source.release = make(chan struct{})
-	oldSave := saveSessionMetaForRename
-	saveSessionMetaForRename = func(dir string, meta schema.SessionMeta) error {
-		source.changeTitle(meta.Name)
-		return oldSave(dir, meta)
-	}
-	defer func() { saveSessionMetaForRename = oldSave }()
-	registry := appsource.NewRegistry()
-	server := newHubAppServerWithNavigation(hubcore.WebConfig{Past: past, Roster: hubcore.NewRosterWithEntries()}, registry, navigation, nil)
+	fixture.source.entered = make(chan struct{})
+	fixture.source.release = make(chan struct{})
 
-	dispatched := make(chan error, 1)
+	var dispatchErr error
+	returned := make(chan struct{})
 	go func() {
-		dispatched <- dispatchThreadNameSet(t, server, appwire.ThreadNameSetParams{Ref: "local:" + original.ID, Name: "renamed-async"})
+		dispatchErr = dispatchThreadNameSet(t, fixture.server, appwire.ThreadNameSetParams{Ref: "local:" + fixture.original.ID, Name: "renamed-async"})
+		close(returned)
 	}()
-	select {
-	case err := <-dispatched:
-		if err != nil {
-			t.Fatalf("thread name set: %v", err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("rename RPC blocked on the navigation rebuild")
+	waitNavigationSignal(t, returned, "rename RPC to return")
+	if dispatchErr != nil {
+		t.Fatalf("thread name set: %v", dispatchErr)
 	}
 	// The rename must be durably committed before the RPC returned.
-	meta, err := schema.LoadSessionMeta(stateDir, original.ID)
+	meta, err := schema.LoadSessionMeta(fixture.stateDir, fixture.original.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -213,22 +218,16 @@ func TestAppWireRenameReturnsBeforeNavigationRebuildCompletes(t *testing.T) {
 	// The rebuild the rename kicked off is still pending, and any capture it
 	// triggers is stuck on the gate. Drive it the way the scheduler would
 	// (refreshPending) and only then let the capture finish.
-	events := make(chan []appwire.NavigationInvalidatedPayload, 1)
+	var publications []appwire.NavigationInvalidatedPayload
+	committed := make(chan struct{})
 	go func() {
-		events <- drainRenamePublications(t, navigation)
+		publications = drainRenamePublications(t, fixture.navigation)
+		close(committed)
 	}()
-	select {
-	case <-source.entered:
-	case <-time.After(5 * time.Second):
-		t.Fatal("pending rename hint did not start a rebuild")
-	}
-	close(source.release)
-	select {
-	case publications := <-events:
-		assertRenameTargets(t, publications, []appwire.NavigationInvalidationTarget{{Kind: appwire.NavigationTargetProject, ProjectKey: projectKey}})
-	case <-time.After(5 * time.Second):
-		t.Fatal("pending rename hint never committed an invalidation")
-	}
+	waitNavigationSignal(t, fixture.source.entered, "pending rename hint to start a rebuild")
+	close(fixture.source.release)
+	waitNavigationSignal(t, committed, "pending rename hint to commit an invalidation")
+	assertRenameTargets(t, publications, []appwire.NavigationInvalidationTarget{{Kind: appwire.NavigationTargetProject, ProjectKey: fixture.projectKey}})
 }
 
 func TestAppWireRenameKeepsNonLocalRefSeparateFromMatchingLocalSession(t *testing.T) {

--- a/cmd/evener-hub/app_rename_test.go
+++ b/cmd/evener-hub/app_rename_test.go
@@ -46,6 +46,14 @@ func dispatchThreadNameSet(t *testing.T, server *appserver.Server, params appwir
 	return err
 }
 
+func drainRenamePublications(t *testing.T, navigation *NavigationService) []appwire.NavigationInvalidatedPayload {
+	t.Helper()
+	// completeThreadNameMutation only Invalidate(s) the hint; the service's
+	// Start loop consumes it through refreshPending. Drive that exact path.
+	navigation.refreshPending(t.Context())
+	return navigation.DrainPublications()
+}
+
 func TestAppWireNavigationRenameConvergesLiveAndEnded(t *testing.T) {
 	t.Run("live changed and repeat no-op", func(t *testing.T) {
 		source := newTestNavigationSource(time.Unix(1_700_000_000, 0).UTC())
@@ -67,7 +75,7 @@ func TestAppWireNavigationRenameConvergesLiveAndEnded(t *testing.T) {
 		if err := dispatchThreadNameSet(t, server, appwire.ThreadNameSetParams{Ref: "local:live-rename", Name: "  renamed-live  "}); err != nil {
 			t.Fatalf("thread name set: %v", err)
 		}
-		generation := assertRenameNavigation(t, navigation, 1, []appwire.NavigationInvalidationTarget{{Kind: appwire.NavigationTargetProject, ProjectKey: "p1"}, {Kind: appwire.NavigationTargetAllLoadedProjects}}, "")
+		assertRenameTargets(t, drainRenamePublications(t, navigation), []appwire.NavigationInvalidationTarget{{Kind: appwire.NavigationTargetProject, ProjectKey: "p1"}, {Kind: appwire.NavigationTargetAllLoadedProjects}})
 		if live.got.Ref != "local:live-rename" || live.got.Name != "renamed-live" {
 			t.Fatalf("SetThreadName params=%+v", live.got)
 		}
@@ -75,7 +83,9 @@ func TestAppWireNavigationRenameConvergesLiveAndEnded(t *testing.T) {
 		if err := dispatchThreadNameSet(t, server, appwire.ThreadNameSetParams{Ref: "local:live-rename", Name: "renamed-live"}); err != nil {
 			t.Fatalf("repeat thread name set: %v", err)
 		}
-		assertRenameNavigation(t, navigation, 0, nil, generation)
+		if events := drainRenamePublications(t, navigation); len(events) != 0 {
+			t.Fatalf("repeat rename published events=%+v", events)
+		}
 	})
 
 	t.Run("ended changed and repeat no-op", func(t *testing.T) {
@@ -110,7 +120,7 @@ func TestAppWireNavigationRenameConvergesLiveAndEnded(t *testing.T) {
 		if err := dispatchThreadNameSet(t, server, appwire.ThreadNameSetParams{Ref: "local:" + original.ID, Name: "  renamed-ended  "}); err != nil {
 			t.Fatalf("thread name set: %v", err)
 		}
-		generation := assertRenameNavigation(t, navigation, 1, []appwire.NavigationInvalidationTarget{{Kind: appwire.NavigationTargetProject, ProjectKey: projectKey}}, "")
+		assertRenameTargets(t, drainRenamePublications(t, navigation), []appwire.NavigationInvalidationTarget{{Kind: appwire.NavigationTargetProject, ProjectKey: projectKey}})
 		got, err := schema.LoadSessionMeta(stateDir, original.ID)
 		if err != nil {
 			t.Fatal(err)
@@ -122,7 +132,9 @@ func TestAppWireNavigationRenameConvergesLiveAndEnded(t *testing.T) {
 		if err := dispatchThreadNameSet(t, server, appwire.ThreadNameSetParams{Ref: "local:" + original.ID, Name: "renamed-ended"}); err != nil {
 			t.Fatalf("repeat thread name set: %v", err)
 		}
-		assertRenameNavigation(t, navigation, 0, nil, generation)
+		if events := drainRenamePublications(t, navigation); len(events) != 0 {
+			t.Fatalf("repeat ended rename published events=%+v", events)
+		}
 	})
 }
 
@@ -142,6 +154,80 @@ func TestAppWireRenameValidatesRefAndName(t *testing.T) {
 				t.Fatalf("error=%v, want invalid params", err)
 			}
 		})
+	}
+}
+
+func TestAppWireRenameReturnsBeforeNavigationRebuildCompletes(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, "projects", "project-async-rename-0123456789")
+	original := schema.SessionMeta{ID: "02wMz5Txv1C3Hut0M8GCeB", Name: "old", NameSource: "generated", UpdatedAt: time.Unix(1_700_000_000, 0).UTC()}
+	if err := schema.SaveSessionMeta(stateDir, original); err != nil {
+		t.Fatal(err)
+	}
+	past := hubcore.NewPastIndexWithDB(filepath.Join(root, "projects", "*"), filepath.Join(root, "index.db"))
+	if _, err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+	source := newTestNavigationSource(time.Unix(1_700_000_000, 0).UTC())
+	projectKey := filepath.Base(stateDir)
+	source.inputs.Tree.Projects[0].Key = projectKey
+	source.inputs.Tree.Projects[0].Name = projectKey
+	source.inputs.Tree.Projects[0].Current[0].Project = projectKey
+	navigation := newTestNavigationService(t, source)
+	if _, err := navigation.Representation(t.Context(), navigationResourceKey{Kind: navigationResourceManifest}); err != nil {
+		t.Fatal(err)
+	}
+	// From here on, every capture blocks until released: a navigation rebuild
+	// that never completes on its own. The rename RPC must still return.
+	source.entered = make(chan struct{})
+	source.release = make(chan struct{})
+	oldSave := saveSessionMetaForRename
+	saveSessionMetaForRename = func(dir string, meta schema.SessionMeta) error {
+		source.changeTitle(meta.Name)
+		return oldSave(dir, meta)
+	}
+	defer func() { saveSessionMetaForRename = oldSave }()
+	registry := appsource.NewRegistry()
+	server := newHubAppServerWithNavigation(hubcore.WebConfig{Past: past, Roster: hubcore.NewRosterWithEntries()}, registry, navigation, nil)
+
+	dispatched := make(chan error, 1)
+	go func() {
+		dispatched <- dispatchThreadNameSet(t, server, appwire.ThreadNameSetParams{Ref: "local:" + original.ID, Name: "renamed-async"})
+	}()
+	select {
+	case err := <-dispatched:
+		if err != nil {
+			t.Fatalf("thread name set: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("rename RPC blocked on the navigation rebuild")
+	}
+	// The rename must be durably committed before the RPC returned.
+	meta, err := schema.LoadSessionMeta(stateDir, original.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Name != "renamed-async" || meta.NameSource != "user" {
+		t.Fatalf("renamed meta=%+v", meta)
+	}
+	// The rebuild the rename kicked off is still pending, and any capture it
+	// triggers is stuck on the gate. Drive it the way the scheduler would
+	// (refreshPending) and only then let the capture finish.
+	events := make(chan []appwire.NavigationInvalidatedPayload, 1)
+	go func() {
+		events <- drainRenamePublications(t, navigation)
+	}()
+	select {
+	case <-source.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("pending rename hint did not start a rebuild")
+	}
+	close(source.release)
+	select {
+	case publications := <-events:
+		assertRenameTargets(t, publications, []appwire.NavigationInvalidationTarget{{Kind: appwire.NavigationTargetProject, ProjectKey: projectKey}})
+	case <-time.After(5 * time.Second):
+		t.Fatal("pending rename hint never committed an invalidation")
 	}
 }
 
@@ -290,18 +376,10 @@ func TestAppWireRenameDoesNotEditMetaWhenEndedSessionBecomesLive(t *testing.T) {
 	}
 }
 
-func assertRenameNavigation(t *testing.T, navigation *NavigationService, wantEvents int, wantTargets []appwire.NavigationInvalidationTarget, wantGeneration string) string {
+func assertRenameTargets(t *testing.T, events []appwire.NavigationInvalidatedPayload, wantTargets []appwire.NavigationInvalidationTarget) {
 	t.Helper()
-	events := navigation.DrainPublications()
-	if len(events) != wantEvents {
-		t.Fatalf("typed events=%d, want %d: %+v", len(events), wantEvents, events)
-	}
-	if wantEvents == 0 {
-		capability := navigation.Capability()
-		if capability == nil || capability.GenerationID != wantGeneration {
-			t.Fatalf("no-op capability=%+v, want generation %q", capability, wantGeneration)
-		}
-		return capability.GenerationID
+	if len(events) != 1 {
+		t.Fatalf("typed events=%d, want 1: %+v", len(events), events)
 	}
 	if len(events[0].Targets) != len(wantTargets) {
 		t.Fatalf("rename target count=%d, want %d: %+v", len(events[0].Targets), len(wantTargets), events[0].Targets)
@@ -318,8 +396,4 @@ func assertRenameNavigation(t *testing.T, navigation *NavigationService, wantEve
 			t.Fatalf("rename wildcard target[%d] revision=%d, want 0", i, got.Revision)
 		}
 	}
-	if replay := navigation.DrainPublications(); len(replay) != 0 {
-		t.Fatalf("second typed event=%+v", replay)
-	}
-	return events[0].GenerationID
 }

--- a/cmd/evener-hub/navigation_pacing_test.go
+++ b/cmd/evener-hub/navigation_pacing_test.go
@@ -1,0 +1,78 @@
+package hub
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Regression: persistent capture failure + one armed invalidation must be
+// PACED (bounded attempts) and must not grow the pending hint.
+func TestNavigationStartPacesPersistentForcedRefreshFailures(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	source := newTestNavigationSource(now)
+	source.nextBoundary = now.Add(24 * time.Hour)
+	retitling := &perCaptureRetitleSource{inner: source}
+	var attempts atomic.Int64
+	wrapped := &countingSource{inner: retitling, captures: &attempts}
+	service := newTestNavigationService(t, source, func(cfg *navigationServiceConfig) {
+		cfg.Source = wrapped
+		cfg.RetryAfter = 50 * time.Millisecond
+		start := time.Now()
+		base := time.Unix(1_700_000_000, 0).UTC()
+		cfg.Now = func() time.Time { return base.Add(time.Since(start)) }
+		cfg.NewTimer = func(delay time.Duration) navigationTimer {
+			timer := &fakeNavigationTimer{delay: delay, ch: make(chan time.Time, 1)}
+			go func() {
+				time.Sleep(delay)
+				select {
+				case timer.ch <- time.Now():
+				default:
+				}
+			}()
+			return timer
+		}
+	})
+	source.mu.Lock()
+	source.captured = make(chan struct{}, 256)
+	source.mu.Unlock()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go service.Start(ctx)
+	time.Sleep(50 * time.Millisecond)
+	source.mu.Lock()
+	source.err = errBoom
+	source.mu.Unlock()
+	service.Invalidate(navigationChangeHint{Projects: []string{"p1"}})
+	// Let it fail persistently for 500ms.
+	time.Sleep(500 * time.Millisecond)
+	service.mu.Lock()
+	hintLen := len(service.pendingHint.Projects)
+	service.mu.Unlock()
+	n := attempts.Load()
+	cancel()
+	if n > 40 {
+		t.Fatalf("capture attempts = %d in 500ms with retryAfter=50ms — unpaced spin", n)
+	}
+	if hintLen != 1 {
+		t.Fatalf("pending hint Projects length = %d, want 1 (no doubling)", hintLen)
+	}
+}
+
+type countingSource struct {
+	inner    navigationSource
+	captures *atomic.Int64
+}
+
+func (c *countingSource) Revision() navigationSourceRevision { return c.inner.Revision() }
+func (c *countingSource) Capture(ctx context.Context, generation string, now time.Time) (navigationSourceSnapshot, error) {
+	c.captures.Add(1)
+	return c.inner.Capture(ctx, generation, now)
+}
+
+var errBoom = &staticErr{}
+
+type staticErr struct{}
+
+func (*staticErr) Error() string { return "persistent failure" }

--- a/cmd/evener-hub/navigation_pacing_test.go
+++ b/cmd/evener-hub/navigation_pacing_test.go
@@ -76,3 +76,72 @@ var errBoom = &staticErr{}
 type staticErr struct{}
 
 func (*staticErr) Error() string { return "persistent failure" }
+
+// failFirstForcedSource fails exactly the FIRST forced capture (the one a
+// pending invalidation drives) and succeeds thereafter, so the Start loop
+// reaches its boundary branch with a paced retry deadline armed.
+type failFirstForcedSource struct {
+	inner  *testNavigationSource
+	failed atomic.Bool
+}
+
+func (f *failFirstForcedSource) Revision() navigationSourceRevision { return f.inner.Revision() }
+func (f *failFirstForcedSource) Capture(ctx context.Context, generation string, now time.Time) (navigationSourceSnapshot, error) {
+	return f.inner.Capture(ctx, generation, now)
+}
+
+// The boundary branch must shorten its park to the retry deadline: with a
+// 24h boundary and retryAfter far shorter, the loop's second park is the
+// retry window, not the boundary.
+func TestNavigationBoundaryParkShortensToRetryDeadline(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	source := newTestNavigationSource(now)
+	source.nextBoundary = now.Add(24 * time.Hour)
+	retitling := &perCaptureRetitleSource{inner: source}
+	created := make(chan *fakeNavigationTimer, 16)
+	service := newTestNavigationService(t, source, func(cfg *navigationServiceConfig) {
+		cfg.Source = retitling
+		cfg.RetryAfter = 10 * time.Millisecond
+		start := time.Now()
+		base := time.Unix(1_700_000_000, 0).UTC()
+		cfg.Now = func() time.Time { return base.Add(time.Since(start)) }
+		cfg.NewTimer = func(delay time.Duration) navigationTimer {
+			timer := &fakeNavigationTimer{delay: delay, ch: make(chan time.Time, 1)}
+			created <- timer
+			go func() {
+				time.Sleep(delay)
+				select {
+				case timer.ch <- time.Now():
+				default:
+				}
+			}()
+			return timer
+		}
+	})
+	source.mu.Lock()
+	source.captured = make(chan struct{}, 8)
+	// Fail the first forced capture only: err set before Invalidate, cleared
+	// after the first failed capture is observed.
+	source.err = &staticErr{}
+	source.mu.Unlock()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go service.Start(ctx)
+	<-created // boundary park (24h minus elapsed)
+	source.changeTitle("renamed")
+	service.Invalidate(navigationChangeHint{Projects: []string{"p1"}})
+	<-source.captured // failed forced capture
+	source.mu.Lock()
+	source.err = nil
+	source.mu.Unlock()
+	// The next park after the failure must be the retry deadline (~10ms),
+	// not the 24h boundary.
+	select {
+	case timer := <-created:
+		if d := 24*time.Hour - timer.delay; d < 0 || d > time.Second {
+			t.Fatalf("post-failure park = %v, want ~retryAfter (10ms), not the boundary", timer.delay)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no park after failed forced refresh")
+	}
+}

--- a/cmd/evener-hub/navigation_pacing_test.go
+++ b/cmd/evener-hub/navigation_pacing_test.go
@@ -71,24 +71,11 @@ func (c *countingSource) Capture(ctx context.Context, generation string, now tim
 	return c.inner.Capture(ctx, generation, now)
 }
 
-var errBoom = &staticErr{}
+var errBoom = &staticError{}
 
-type staticErr struct{}
+type staticError struct{}
 
-func (*staticErr) Error() string { return "persistent failure" }
-
-// failFirstForcedSource fails exactly the FIRST forced capture (the one a
-// pending invalidation drives) and succeeds thereafter, so the Start loop
-// reaches its boundary branch with a paced retry deadline armed.
-type failFirstForcedSource struct {
-	inner  *testNavigationSource
-	failed atomic.Bool
-}
-
-func (f *failFirstForcedSource) Revision() navigationSourceRevision { return f.inner.Revision() }
-func (f *failFirstForcedSource) Capture(ctx context.Context, generation string, now time.Time) (navigationSourceSnapshot, error) {
-	return f.inner.Capture(ctx, generation, now)
-}
+func (*staticError) Error() string { return "persistent failure" }
 
 // The boundary branch must shorten its park to the retry deadline: with a
 // 24h boundary and retryAfter far shorter, the loop's second park is the
@@ -122,7 +109,7 @@ func TestNavigationBoundaryParkShortensToRetryDeadline(t *testing.T) {
 	source.captured = make(chan struct{}, 8)
 	// Fail the first forced capture only: err set before Invalidate, cleared
 	// after the first failed capture is observed.
-	source.err = &staticErr{}
+	source.err = &staticError{}
 	source.mu.Unlock()
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()

--- a/cmd/evener-hub/navigation_service.go
+++ b/cmd/evener-hub/navigation_service.go
@@ -246,6 +246,11 @@ func (s *NavigationService) Invalidate(hint navigationChangeHint) {
 	s.pendingHint = mergeNavigationChangeHints(s.pendingHint, hint)
 	s.pendingInvalidation = true
 	s.pendingEpoch++
+	// A fresh invalidation resets any failed-refresh pacing: the new attempt
+	// is a first try for this epoch, not a retry, and must not inherit the
+	// older failure's deadline. (Persistent failure re-arms a fresh deadline
+	// on its own next failure.)
+	s.pendingRetryAt = time.Time{}
 	s.mu.Unlock()
 	select {
 	case s.wake <- struct{}{}:
@@ -1158,7 +1163,8 @@ func (s *NavigationService) refreshPending(ctx context.Context) {
 	s.mu.Lock()
 	// Clear only the exact pending epoch consumed by this flight. A same-value
 	// invalidation racing after commit still advances the epoch and remains
-	// pending for a subsequent forced capture.
+	// pending for a subsequent forced capture — and, like any fresh
+	// invalidation, must not inherit this flight's failure pacing.
 	if s.pendingEpoch == epoch {
 		s.pendingHint = navigationChangeHint{}
 		s.pendingInvalidation = false

--- a/cmd/evener-hub/navigation_service.go
+++ b/cmd/evener-hub/navigation_service.go
@@ -175,6 +175,9 @@ type NavigationService struct {
 	pendingHint         navigationChangeHint
 	pendingInvalidation bool
 	pendingEpoch        uint64
+	// pendingRetryAt is the earliest time a failed forced refresh of the
+	// pending invalidation may be attempted again. See refreshPending.
+	pendingRetryAt time.Time
 }
 
 func newNavigationService(cfg navigationServiceConfig) *NavigationService {
@@ -1077,7 +1080,11 @@ func (s *NavigationService) Start(ctx context.Context) {
 			if !s.waitRetryOrWake(ctx) {
 				return
 			}
-			s.refreshPending(ctx)
+			// Same pacing as the boundary path: a failed forced refresh's
+			// retry deadline governs when refreshPending may attempt again.
+			if retryWait, pacing := s.pendingRetryWait(); !pacing || retryWait == 0 {
+				s.refreshPending(ctx)
+			}
 			continue
 		}
 		s.mu.Lock()
@@ -1092,7 +1099,17 @@ func (s *NavigationService) Start(ctx context.Context) {
 			}
 			continue
 		}
-		elapsed, keepGoing := s.waitBoundaryOrWake(ctx, boundary)
+		// A failed forced refresh paces its retry: park no longer than the
+		// retry deadline rather than the full snapshot boundary, so the
+		// pending invalidation is attempted again promptly instead of
+		// spinning (immediate wake) or parking for up to 24h (boundary).
+		wait := boundary
+		if retryWait, pacing := s.pendingRetryWait(); pacing && s.hasPendingInvalidation() {
+			if retryWait == 0 || retryWait < boundary.Sub(s.now()) {
+				wait = s.now().Add(retryWait)
+			}
+		}
+		elapsed, keepGoing := s.waitBoundaryOrWake(ctx, wait)
 		if !keepGoing {
 			return
 		}
@@ -1116,27 +1133,26 @@ func (s *NavigationService) refreshPending(ctx context.Context) {
 	if !ok {
 		return
 	}
+	// A failed forced refresh must not retry at spin speed: a re-armed wake
+	// token is consumed immediately by the Start loop's wait helpers (their
+	// wake arm beats every timer), so the loop would cycle at channel-consume
+	// speed under a persistently failing source. Instead record the earliest
+	// retry time; the Start loop waits until it (bounded by retryAfter)
+	// before attempting the pending invalidation again.
+	if retryAt, armed := s.pendingRetryDeadline(); armed && s.now().Before(retryAt) {
+		return
+	}
 	if _, err := s.Refresh(ctx, hint); err != nil {
-		retained := false
 		s.mu.Lock()
 		if s.pendingEpoch == epoch {
-			s.pendingHint = mergeNavigationChangeHints(hint, s.pendingHint)
+			// The pending hint was NOT consumed by a successful build, so it
+			// stays armed as-is. Merging the snapshot into s.pendingHint would
+			// append the Projects slice onto itself (snapshotPendingHint's value
+			// copy shares the backing array), doubling it per failed retry.
 			s.pendingInvalidation = true
-			retained = true
+			s.pendingRetryAt = s.now().Add(s.retryAfter)
 		}
 		s.mu.Unlock()
-		// A failed forced rebuild re-arms the pending invalidation but would
-		// otherwise leave no wake pending: the Start loop's next non-forced
-		// rebuild publishes nothing (the pending epoch survives it) and the
-		// loop parks in waitBoundaryOrWake until the next snapshot boundary —
-		// up to 24h. Re-send the wake token exactly as Invalidate does so the
-		// retryAfter retry window governs the next attempt.
-		if retained {
-			select {
-			case s.wake <- struct{}{}:
-			default:
-			}
-		}
 		return
 	}
 	s.mu.Lock()
@@ -1146,6 +1162,7 @@ func (s *NavigationService) refreshPending(ctx context.Context) {
 	if s.pendingEpoch == epoch {
 		s.pendingHint = navigationChangeHint{}
 		s.pendingInvalidation = false
+		s.pendingRetryAt = time.Time{}
 		navigationPendingCleared()
 	}
 	s.mu.Unlock()
@@ -1155,6 +1172,30 @@ func (s *NavigationService) snapshotPendingHint() (navigationChangeHint, uint64,
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.pendingHint, s.pendingEpoch, s.pendingInvalidation
+}
+
+// pendingRetryDeadline reports the earliest time a failed forced refresh of
+// the pending invalidation may be retried, and whether one is armed at all.
+func (s *NavigationService) pendingRetryDeadline() (time.Time, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pendingRetryAt, s.pendingInvalidation
+}
+
+// pendingRetryWait returns how long the Start loop should park before the
+// next attempt on the pending invalidation: the retry deadline when one is
+// armed, zero when the retry is already due. ok is false when no failed
+// refresh is pacing a retry (nothing to wait for).
+func (s *NavigationService) pendingRetryWait() (time.Duration, bool) {
+	retryAt, armed := s.pendingRetryDeadline()
+	if !armed || retryAt.IsZero() {
+		return 0, false
+	}
+	delay := retryAt.Sub(s.now())
+	if delay <= 0 {
+		return 0, true
+	}
+	return delay, true
 }
 
 func (s *NavigationService) waitRetryOrWake(ctx context.Context) bool {

--- a/cmd/evener-hub/navigation_service.go
+++ b/cmd/evener-hub/navigation_service.go
@@ -1117,12 +1117,26 @@ func (s *NavigationService) refreshPending(ctx context.Context) {
 		return
 	}
 	if _, err := s.Refresh(ctx, hint); err != nil {
+		retained := false
 		s.mu.Lock()
 		if s.pendingEpoch == epoch {
 			s.pendingHint = mergeNavigationChangeHints(hint, s.pendingHint)
 			s.pendingInvalidation = true
+			retained = true
 		}
 		s.mu.Unlock()
+		// A failed forced rebuild re-arms the pending invalidation but would
+		// otherwise leave no wake pending: the Start loop's next non-forced
+		// rebuild publishes nothing (the pending epoch survives it) and the
+		// loop parks in waitBoundaryOrWake until the next snapshot boundary —
+		// up to 24h. Re-send the wake token exactly as Invalidate does so the
+		// retryAfter retry window governs the next attempt.
+		if retained {
+			select {
+			case s.wake <- struct{}{}:
+			default:
+			}
+		}
 		return
 	}
 	s.mu.Lock()

--- a/cmd/evener-hub/navigation_service_test.go
+++ b/cmd/evener-hub/navigation_service_test.go
@@ -83,6 +83,14 @@ func (s *testNavigationSource) changeTitle(title string) {
 	s.revision++
 }
 
+// retitle changes the captured tree without advancing the source revision, so
+// builds stay non-stale while resource fingerprints still move.
+func (s *testNavigationSource) retitle(title string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inputs.Tree.Projects[0].Current[0].Title = title
+}
+
 func (s *testNavigationSource) captureCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1436,6 +1444,104 @@ func TestNavigationServiceSchedulerRetriesEmptyAndFailedCaptures(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("scheduler did not stop after retry")
+	}
+}
+
+// perCaptureRetitleSource serves a different title on every capture without
+// advancing the revision. A forced rebuild that follows a successful
+// non-forced rebuild therefore still has a fingerprint diff to publish, which
+// is exactly the retry shape a transiently failed forced refresh produces.
+type perCaptureRetitleSource struct {
+	inner *testNavigationSource
+	calls atomic.Int64
+}
+
+func (s *perCaptureRetitleSource) Revision() navigationSourceRevision {
+	return s.inner.Revision()
+}
+
+func (s *perCaptureRetitleSource) Capture(ctx context.Context, generation string, now time.Time) (navigationSourceSnapshot, error) {
+	s.inner.retitle(fmt.Sprintf("capture-%d", s.calls.Add(1)))
+	return s.inner.Capture(ctx, generation, now)
+}
+
+func TestNavigationServiceStartRetriesFailedForcedRefreshWithoutWaitingForBoundary(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	source := newTestNavigationSource(now)
+	// Park the scheduler a full day out: without a failure wake, a failed
+	// forced refresh leaves the pending invalidation unpublished until that
+	// boundary elapses.
+	source.nextBoundary = now.Add(24 * time.Hour)
+	retitling := &perCaptureRetitleSource{inner: source}
+	created := make(chan *fakeNavigationTimer, 16)
+	service := newTestNavigationService(t, source, func(cfg *navigationServiceConfig) {
+		cfg.Source = retitling
+		cfg.RetryAfter = 10 * time.Millisecond
+		cfg.NewTimer = func(delay time.Duration) navigationTimer {
+			// Timers never fire on their own, so the only thing that can move
+			// the Start loop is a wake token.
+			timer := &fakeNavigationTimer{delay: delay, ch: make(chan time.Time, 1)}
+			created <- timer
+			return timer
+		}
+	})
+	if _, err := service.Representation(t.Context(), navigationResourceKey{Kind: navigationResourceManifest}); err != nil {
+		t.Fatal(err)
+	}
+	source.mu.Lock()
+	source.captured = make(chan struct{}, 8)
+	source.mu.Unlock()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan struct{})
+	cleared := make(chan struct{}, 1)
+	previousCleared := navigationPendingCleared
+	navigationPendingCleared = func() { cleared <- struct{}{} }
+	t.Cleanup(func() { navigationPendingCleared = previousCleared })
+	go func() { service.Start(ctx); close(done) }()
+	firstTimer := <-created
+	if got, want := firstTimer.delay, 24*time.Hour; got != want {
+		t.Fatalf("boundary delay = %v, want %v", got, want)
+	}
+	// The forced rebuild fails once, transiently.
+	source.mu.Lock()
+	source.err = errors.New("transient capture failure")
+	source.mu.Unlock()
+	source.changeTitle("renamed")
+	service.Invalidate(navigationChangeHint{Projects: []string{"p1"}})
+	waitNavigationSignal(t, source.captured, "failed forced capture")
+	source.mu.Lock()
+	source.err = nil
+	source.mu.Unlock()
+	// The commit signals PublicationReady before refreshPending re-acquires
+	// the lock to clear the pending epoch, so the clear notice is the
+	// deterministic completion signal for the retry.
+	waitNavigationSignal(t, cleared, "pending clear after failed forced refresh")
+	service.mu.Lock()
+	pending := service.pendingInvalidation
+	service.mu.Unlock()
+	if pending {
+		t.Fatal("successful retry left the pending invalidation set")
+	}
+	publications := service.DrainPublications()
+	if len(publications) != 1 || !hasNavigationTarget(publications[0].Targets, appwire.NavigationTargetProject, "p1") {
+		t.Fatalf("retry publications = %+v, want one project publication", publications)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("scheduler did not stop after retry")
+	}
+	for {
+		select {
+		case timer := <-created:
+			if len(timer.ch) != 0 {
+				t.Fatal("retry depended on a timer firing rather than the failure wake")
+			}
+		default:
+			return
+		}
 	}
 }
 

--- a/cmd/evener-hub/navigation_service_test.go
+++ b/cmd/evener-hub/navigation_service_test.go
@@ -1465,6 +1465,18 @@ func (s *perCaptureRetitleSource) Capture(ctx context.Context, generation string
 	return s.inner.Capture(ctx, generation, now)
 }
 
+// captureCountingSource counts Capture calls for pacing assertions.
+type captureCountingSource struct {
+	inner    navigationSource
+	captures *atomic.Int64
+}
+
+func (c *captureCountingSource) Revision() navigationSourceRevision { return c.inner.Revision() }
+func (c *captureCountingSource) Capture(ctx context.Context, generation string, now time.Time) (navigationSourceSnapshot, error) {
+	c.captures.Add(1)
+	return c.inner.Capture(ctx, generation, now)
+}
+
 func TestNavigationServiceStartRetriesFailedForcedRefreshWithoutWaitingForBoundary(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0).UTC()
 	source := newTestNavigationSource(now)
@@ -1473,9 +1485,11 @@ func TestNavigationServiceStartRetriesFailedForcedRefreshWithoutWaitingForBounda
 	// boundary elapses.
 	source.nextBoundary = now.Add(24 * time.Hour)
 	retitling := &perCaptureRetitleSource{inner: source}
+	var attempts atomic.Int64
+	counted := &captureCountingSource{inner: retitling, captures: &attempts}
 	created := make(chan *fakeNavigationTimer, 16)
 	service := newTestNavigationService(t, source, func(cfg *navigationServiceConfig) {
-		cfg.Source = retitling
+		cfg.Source = counted
 		cfg.RetryAfter = 10 * time.Millisecond
 		// A clock anchored at the frozen base but advancing in real time, so
 		// the failed refresh's retry deadline actually elapses.
@@ -1556,10 +1570,12 @@ func TestNavigationServiceStartRetriesFailedForcedRefreshWithoutWaitingForBounda
 	case <-time.After(time.Second):
 		t.Fatal("scheduler did not stop after retry")
 	}
-	// The retry was paced by the retryAfter window: with RetryAfter=10ms
-	// and the one-second wait budgets above, a spin (the pre-fix hot loop)
-	// would have completed many failed attempts inside those windows; the
-	// paced retry completes exactly one.
+	// The retry was paced by the retryAfter window: the failed-phase
+	// attempt count (captured by the counting wrapper below) stays small.
+	// A spin — the pre-fix hot loop — burned ~50 attempts per 500ms.
+	if n := attempts.Load(); n > 8 {
+		t.Fatalf("capture attempts = %d during the failed phase, want a paced handful", n)
+	}
 }
 
 func TestNavigationSnapshotBoundaryUsesNearest24HourOr14DayCutover(t *testing.T) {

--- a/cmd/evener-hub/navigation_service_test.go
+++ b/cmd/evener-hub/navigation_service_test.go
@@ -1477,11 +1477,23 @@ func TestNavigationServiceStartRetriesFailedForcedRefreshWithoutWaitingForBounda
 	service := newTestNavigationService(t, source, func(cfg *navigationServiceConfig) {
 		cfg.Source = retitling
 		cfg.RetryAfter = 10 * time.Millisecond
+		// A clock anchored at the frozen base but advancing in real time, so
+		// the failed refresh's retry deadline actually elapses.
+		start := time.Now()
+		base := time.Unix(1_700_000_000, 0).UTC()
+		cfg.Now = func() time.Time { return base.Add(time.Since(start)) }
 		cfg.NewTimer = func(delay time.Duration) navigationTimer {
-			// Timers never fire on their own, so the only thing that can move
-			// the Start loop is a wake token.
 			timer := &fakeNavigationTimer{delay: delay, ch: make(chan time.Time, 1)}
 			created <- timer
+			// Timers fire in real time; the paced retry depends on the
+			// retryAfter timer elapsing rather than on a wake token.
+			go func() {
+				time.Sleep(delay)
+				select {
+				case timer.ch <- time.Now():
+				default:
+				}
+			}()
 			return timer
 		}
 	})
@@ -1500,8 +1512,11 @@ func TestNavigationServiceStartRetriesFailedForcedRefreshWithoutWaitingForBounda
 	t.Cleanup(func() { navigationPendingCleared = previousCleared })
 	go func() { service.Start(ctx); close(done) }()
 	firstTimer := <-created
-	if got, want := firstTimer.delay, 24*time.Hour; got != want {
-		t.Fatalf("boundary delay = %v, want %v", got, want)
+	// The boundary is computed from the advancing test clock, so the parked
+	// delay is 24h minus the (sub-millisecond) time since the service was
+	// built; accept any delay within one second of the parked day.
+	if d := 24*time.Hour - firstTimer.delay; d < 0 || d > time.Second {
+		t.Fatalf("boundary delay = %v, want ~24h (within 1s)", firstTimer.delay)
 	}
 	// The forced rebuild fails once, transiently.
 	source.mu.Lock()
@@ -1510,6 +1525,14 @@ func TestNavigationServiceStartRetriesFailedForcedRefreshWithoutWaitingForBounda
 	source.changeTitle("renamed")
 	service.Invalidate(navigationChangeHint{Projects: []string{"p1"}})
 	waitNavigationSignal(t, source.captured, "failed forced capture")
+	// While the failure is still pending, the armed hint must not have
+	// doubled (the self-merge bug this test guards against).
+	service.mu.Lock()
+	if got := len(service.pendingHint.Projects); got != 1 {
+		service.mu.Unlock()
+		t.Fatalf("pending hint Projects length = %d while failure pending, want 1", got)
+	}
+	service.mu.Unlock()
 	source.mu.Lock()
 	source.err = nil
 	source.mu.Unlock()
@@ -1533,16 +1556,10 @@ func TestNavigationServiceStartRetriesFailedForcedRefreshWithoutWaitingForBounda
 	case <-time.After(time.Second):
 		t.Fatal("scheduler did not stop after retry")
 	}
-	for {
-		select {
-		case timer := <-created:
-			if len(timer.ch) != 0 {
-				t.Fatal("retry depended on a timer firing rather than the failure wake")
-			}
-		default:
-			return
-		}
-	}
+	// The retry was paced by the retryAfter window: with RetryAfter=10ms
+	// and the one-second wait budgets above, a spin (the pre-fix hot loop)
+	// would have completed many failed attempts inside those windows; the
+	// paced retry completes exactly one.
 }
 
 func TestNavigationSnapshotBoundaryUsesNearest24HourOr14DayCutover(t *testing.T) {


### PR DESCRIPTION
## Summary

The evener/thread/name/set handler ended with a synchronous navigation.Refresh inside the RPC — a full navigation-tree rebuild (PastIndex.All + project resolution + fingerprints) that stalled the response, and on a serial-dispatch connection every other request from that browser.

The rename is durably committed (meta save + Past.UpdateMeta) before the RPC returns; the navigation rebuild now runs through the service's async scheduler: Invalidate records the hint and wakes the Start loop, whose refreshPending commits the rebuild and appends the invalidation to the publication FIFO. The frontend rename path consumes no receipt (verified) and converges via the navigation-invalidated notification.

The scheduler retry contract this relies on is strengthened in follow-up commits: a failed forced refresh records a retry deadline (paced, no spin, no 24h park), a fresh Invalidate resets that pacing (a recovered source serves new invalidations immediately), and the pending hint is never merged into itself (which previously doubled its Projects per failure).

## Verification

- go build/vet, go test ./cmd/evener-hub/... (full suite + race on navigation tests) green
- New/updated tests: rename returns while the rebuild is gated; meta committed before response; invalidation eventually published; persistent-failure pacing bounded (~52 to paced attempts per 500ms); boundary park shortens to the retry deadline; failed-phase attempt count pinned; no hint doubling

Reviewed across three adversarial rounds — the spin/doubling and stale-deadline findings came from rounds 2 and 3 and are fixed with regression tests here.
