### PR TITLE
perf(web): make agentMessage delta accumulation O(1) per delta

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.tsx
@@ -26,6 +26,7 @@
 // that starts and settles within a frame keeps the same DOM shape.
 
 import { memo, type ReactNode } from "react";
+import { pendingTextJoined } from "../../../../protocol/reducer";
 import { Markdown } from "../../../../widgets";
 import { requireClass } from "../../../../widgets/internal/requireClass";
 // Direct widget path, NOT the controller-owned widgets barrel: this pane
@@ -126,7 +127,7 @@ export const AgentMessageItem = memo(function AgentMessageItem({
     // stream's tail truncates, so formatting renders while streaming.
     return wrap(
       <div className={CLASS.stream} data-testid="agent-message-stream">
-        <Markdown source={chunks.join("")} live />
+        <Markdown source={pendingTextJoined(chunks)} live />
       </div>,
       "true",
     );

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/reasoningFormat.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/reasoningFormat.test.ts
@@ -1,5 +1,8 @@
 // @vitest-environment node
 import { expect, test } from "vitest";
+import { applyNotification, chunkViewBackingForTests } from "../../../../protocol/reducer";
+import { buildFloodChunks, hydrateFloodModel } from "../../../../protocol/testing/tokenFlood";
+import type { AnyNotification } from "../../../../protocol/types.gen";
 import {
   formatThoughtDuration,
   joinedReasoningParagraphs,
@@ -41,6 +44,88 @@ test("drops a paragraph whose chunks join to all-whitespace", () => {
 
 test("all paragraphs empty yields an empty array (the whole thought is empty)", () => {
   expect(joinedReasoningParagraphs([[], ["   "]])).toEqual([]);
+});
+
+// --- joinedReasoningParagraphs over LIVE chunk views -------------------------
+// The reducer accumulates reasoning deltas into brand-carrying chunk views
+// (protocol/reducer.ts's appendChunk/appendReasoningDelta), so a streaming
+// think block hands this function view arrays, not plain ones. These pin the
+// contract the O(1) rerouting relies on: joining live views must return text
+// IDENTICAL to joining the same chunks as plain arrays, in every summary slot.
+
+// Folds a reasoning item up through `counts.length` summary indices, each fed
+// its own list of deltas, exactly the way the live wire would (item/started
+// then one item/reasoning/summaryTextDelta per chunk). Returns the model so
+// callers can read the item's reasoningSummaries straight out of the fold.
+function foldLiveReasoning(deltas: string[][]): { summaries: string[][] | undefined } {
+  let model = hydrateFloodModel("ref_t");
+  const threadId = "thr_ref_t";
+  const ref = "ref_t";
+  const turnId = "turn_1";
+  const itemId = "item_r";
+  model = applyNotification(
+    model,
+    {
+      method: "turn/started",
+      params: { threadId, ref, turn: { id: turnId, status: "inProgress", itemsView: "" } },
+    } as AnyNotification,
+    1001,
+  );
+  model = applyNotification(
+    model,
+    {
+      method: "item/started",
+      params: { threadId, ref, turnId, item: { type: "reasoning", id: itemId, turnId, status: "inProgress" } },
+    } as AnyNotification,
+    1002,
+  );
+  let now = 1003;
+  for (const [summaryIndex, chunks] of deltas.entries()) {
+    for (const delta of chunks) {
+      now += 1;
+      model = applyNotification(
+        model,
+        {
+          method: "item/reasoning/summaryTextDelta",
+          params: { threadId, ref, turnId, itemId, summaryIndex, delta },
+        } as AnyNotification,
+        now,
+      );
+    }
+  }
+  // Locate the reasoning item the fold produced (turn 0, item 0).
+  const turn = model.turns[0];
+  const item = turn?.items[0];
+  return { summaries: item?.reasoningSummaries };
+}
+
+test("joinedReasoningParagraphs over live chunk views returns the same paragraphs as plain-array joins", () => {
+  // Fixture: deterministic chunk lists in the live wire's observed size range
+  // (2..40 chars, the token-flood harness's own bounds).
+  const deltas = [buildFloodChunks(12, 7), buildFloodChunks(9, 11), buildFloodChunks(1, 13)];
+  const { summaries } = foldLiveReasoning(deltas);
+  expect(summaries).toBeDefined();
+  // The fold really produced views, not plain arrays (otherwise this test
+  // would silently stop exercising the cache path it exists to pin).
+  for (const chunks of summaries ?? []) {
+    expect(chunkViewBackingForTests(chunks ?? [])).toBeDefined();
+  }
+  // The paragraphs joined from views are IDENTICAL to plain-array joins of
+  // the same chunk contents, summary slot by summary slot.
+  const expected = (summaries ?? []).map((chunks) => (chunks ?? []).join(""));
+  expect(joinedReasoningParagraphs(summaries)).toEqual(expected);
+});
+
+test("joinedReasoningParagraphs drops empty live-view paragraphs exactly like plain ones", () => {
+  // Second summary joins to whitespace-only, so only the first survives -
+  // the same empty-thoughts rule the plain-array tests above pin, held to the
+  // view path. Plain counterpart: the same chunk CONTENTS as plain arrays.
+  const deltas = [buildFloodChunks(5, 3), ["  ", "\n", "\t"]];
+  const { summaries } = foldLiveReasoning(deltas);
+  expect(summaries).toBeDefined();
+  const plain = (summaries ?? []).map((chunks) => [...(chunks ?? [])]);
+  expect(joinedReasoningParagraphs(plain)).toEqual(joinedReasoningParagraphs(summaries));
+  expect(joinedReasoningParagraphs(summaries)).toHaveLength(1);
 });
 
 // --- thoughtDurationMs -------------------------------------------------------

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/reasoningFormat.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/reasoningFormat.ts
@@ -2,6 +2,7 @@
 // ThinkBlock.tsx for the component that consumes these.
 
 import { Marked, type Token, type Tokens } from "marked";
+import { pendingTextJoined } from "../../../../protocol/reducer";
 
 // Reuse the app's existing Markdown tokenizer so nested links, block prefixes,
 // and emphasis are handled as syntax rather than accumulated regex cases.
@@ -15,9 +16,15 @@ const ISO_TIMESTAMP = /^(\d{4}|[+-]\d{6})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}
 // whitespace-only) - "empty thoughts removed" per the wave-4 T2 scope, at
 // both the whole-item level (settle finds zero paragraphs -> render
 // nothing, see ThinkBlock) and the per-paragraph level.
+//
+// Each per-summary join goes through pendingTextJoined (protocol/reducer.ts):
+// live chunk views carry a brand-cached join text, so a per-render read over a
+// view is O(1) rather than the O(n) element-by-element Proxy walk this path
+// used to pay on every render of a streaming think block. Plain arrays (tests,
+// hydrate) fall back to a plain join inside the same helper.
 export function joinedReasoningParagraphs(summaries: string[][] | undefined): string[] {
   if (!summaries) return [];
-  return summaries.map((chunks) => chunks.join("")).filter((text) => text.trim() !== "");
+  return summaries.map((chunks) => pendingTextJoined(chunks)).filter((text) => text.trim() !== "");
 }
 
 // thoughtDurationMs computes elapsed milliseconds from two REAL ISO timestamps

--- a/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
@@ -9,12 +9,15 @@ import toolAndJobsFixture from "./fixtures/tool-and-jobs.jsonl?raw";
 import { type ItemModel, SYSTEM_PRELUDE_TURN_ID, type ThreadModel, type TurnModel } from "./model";
 import {
   applyNotification,
+  chunkViewBackingForTests,
   collectAuthoritativeMutationIds,
   hydrateThread,
   notificationTargetsThread,
+  pendingTextJoined,
   prependOlderTurns,
   resolvePendingEscalation,
 } from "./reducer";
+import { hydrateStreamingAgentMessage } from "./testing/tokenFlood";
 import type {
   AnyNotification,
   QueueState,
@@ -478,43 +481,12 @@ test("delta accumulates into pendingText chunks and joins on completion", () => 
 });
 
 // --- O(1) per-delta accumulation (perf fix, PR3) ----------------------------
-//
-// The delta fold must not copy the accumulated chunks per delta (the
-// pre-fix [...chunks, delta] did, making an n-chunk item O(n^2) total —
-// see tokenFlood.bench.ts's growth-curve profile and the wave4 report).
-// These tests pin the ALGORITHMIC property deterministically, without a
-// wall-clock assertion (which would be flaky in CI): each delta's fold
-// must reuse the chunk STRINGS it was handed by reference — the previous
-// state's chunks all appear, reference-identical, in the next state — and
-// grow the chunk count by exactly one. A per-delta copy back (any spread
-// or slice of the accumulated array) would still pass the join/length
-// checks below, but reference identity is what makes the append O(1), and
-// only a copy breaks it.
+// Rationale and machinery: reducer.ts's chunk-view section header.
 
+// The shared streaming-agentMessage scaffold (src/protocol/testing/
+// tokenFlood.ts) on this suite's thr_t/ref_t/turn_1/item_1 identity.
 function streamingItem(): ThreadModel {
-  let model = testHydrate();
-  model = applyNotification(
-    model,
-    {
-      method: "turn/started",
-      params: { threadId: "thr_t", ref: "ref_t", turn: { id: "turn_1", status: "inProgress", itemsView: "" } },
-    },
-    1001,
-  );
-  model = applyNotification(
-    model,
-    {
-      method: "item/started",
-      params: {
-        threadId: "thr_t",
-        ref: "ref_t",
-        turnId: "turn_1",
-        item: { type: "agentMessage", id: "item_1", turnId: "turn_1", status: "inProgress" },
-      },
-    },
-    1002,
-  );
-  return model;
+  return hydrateStreamingAgentMessage("ref_t", { threadId: "thr_t" });
 }
 
 function agentMessageDelta(delta: string): AnyNotification {
@@ -524,42 +496,37 @@ function agentMessageDelta(delta: string): AnyNotification {
   };
 }
 
-test("every delta's fold reuses the previous chunks by reference and grows the count by one (O(1) append)", () => {
-  // 20,000 deltas matches the brief's scale. Reference identity is the
-  // property that makes the append O(1) — a per-delta copy ([...chunks,
-  // delta]) would still produce the right join and length but hands back
-  // fresh string references only if the strings themselves were rebuilt,
-  // which they are not; the copy that matters is the ARRAY copy, caught
-  // below by snapshotting the array reference across consecutive folds:
-  // a copied array is a different object than the one whose chunk at the
-  // same index we then read. Checking a FIXED set of sentinel positions
-  // (not every prior index per step) keeps the test O(n), not O(n^2) —
-  // the test must not recreate the very blowup it guards against.
+test("every delta's fold appends onto the SAME backing array, which grows by exactly one (O(1) append)", () => {
+  // White-box on purpose (chunkViewBackingForTests): chunk strings are
+  // PRIMITIVES, so element-level identity checks survive a per-delta copy
+  // ([...chunks, delta] preserves every string reference) — only the
+  // BACKING ARRAY reference distinguishes a true append from a copy: a
+  // copy mints a fresh backing per delta, an append returns the same
+  // array one longer. Each iteration therefore asserts (a) the backing
+  // reference is IDENTICAL to the previous fold's and (b) its length grew
+  // by exactly one, keeping the test O(n) — it must not recreate the very
+  // blowup it guards against. Rationale: reducer.ts's chunk-view header.
   const N = 20_000;
-  const SENTINELS = [0, 1, 2, 7, 100, 999, 5_000, 12_345, N - 2, N - 1];
   let model = streamingItem();
-  const seenChunkRefs = new Map<number, string>();
+  let prevBacking: string[] | undefined;
   for (let i = 0; i < N; i++) {
     model = applyNotification(model, agentMessageDelta(`c${i} `), 1003 + i);
     const chunks = itemAt(turnAt(model, 0), 0).pendingText;
     expect(chunks).toHaveLength(i + 1);
-    // Record each sentinel chunk once, at the fold that produces it.
-    if (SENTINELS.includes(i)) {
-      const chunk = chunks?.[i];
-      expect(typeof chunk).toBe("string");
-      seenChunkRefs.set(i, chunk ?? "");
-    }
-    // After the sentinel exists, every later fold must still hand back
-    // THE SAME string reference at that index — an append, not a rebuild.
-    for (const s of SENTINELS) {
-      if (s <= i) {
-        expect(Object.is(chunks?.[s], seenChunkRefs.get(s))).toBe(true);
-      }
+    const backing = chunkViewBackingForTests(chunks ?? []);
+    expect(backing).toBeDefined();
+    if (i === 0) {
+      prevBacking = backing;
+    } else {
+      expect(backing).toBe(prevBacking);
+      expect(backing?.length).toBe(i + 1);
     }
   }
   const chunks = itemAt(turnAt(model, 0), 0).pendingText;
   expect(chunks?.length).toBe(N);
   expect(chunks).toEqual(Array.from({ length: N }, (_, i) => `c${i} `));
+  // And the O(1) joined-text cache agrees with a full structural join.
+  expect(chunks?.join("")).toBe(pendingTextJoined(chunks ?? []));
 });
 
 test("a mid-stream model state stays observationally frozen while later deltas continue folding (view purity)", () => {
@@ -580,8 +547,6 @@ test("a mid-stream model state stays observationally frozen while later deltas c
   // And the live item carries all 502 chunks, first two unchanged.
   const live = itemAt(turnAt(model, 0), 0);
   expect(live.pendingText?.length).toBe(502);
-  expect(live.pendingText?.[0]).toBe("Hel");
-  expect(live.pendingText?.[1]).toBe("lo");
   expect(live.pendingText?.slice(0, 2)).toEqual(["Hel", "lo"]);
   // Mutating traps throw rather than corrupting the shared backing.
   expect(() => (live.pendingText as string[]).push("y")).toThrow();
@@ -632,9 +597,6 @@ test("a delta folded onto a STALE mid-stream state branches cleanly — no alias
   const forkChunks = itemAt(turnAt(fork, 0), 0).pendingText;
   expect(forkChunks?.length).toBe(102);
   expect(forkChunks?.join("")).toBe(`ab${"F".repeat(100)}`);
-  // Neither branch saw the other's chunks.
-  expect(liveChunks?.join("")).toBe(`ab${"L".repeat(100)}`);
-  expect(liveChunks?.length).toBe(102);
 });
 
 test("item/completed inserts an item that had no preceding item/started", () => {

--- a/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
@@ -477,6 +477,166 @@ test("delta accumulates into pendingText chunks and joins on completion", () => 
   expect(settled.pendingText).toBeUndefined();
 });
 
+// --- O(1) per-delta accumulation (perf fix, PR3) ----------------------------
+//
+// The delta fold must not copy the accumulated chunks per delta (the
+// pre-fix [...chunks, delta] did, making an n-chunk item O(n^2) total —
+// see tokenFlood.bench.ts's growth-curve profile and the wave4 report).
+// These tests pin the ALGORITHMIC property deterministically, without a
+// wall-clock assertion (which would be flaky in CI): each delta's fold
+// must reuse the chunk STRINGS it was handed by reference — the previous
+// state's chunks all appear, reference-identical, in the next state — and
+// grow the chunk count by exactly one. A per-delta copy back (any spread
+// or slice of the accumulated array) would still pass the join/length
+// checks below, but reference identity is what makes the append O(1), and
+// only a copy breaks it.
+
+function streamingItem(): ThreadModel {
+  let model = testHydrate();
+  model = applyNotification(
+    model,
+    {
+      method: "turn/started",
+      params: { threadId: "thr_t", ref: "ref_t", turn: { id: "turn_1", status: "inProgress", itemsView: "" } },
+    },
+    1001,
+  );
+  model = applyNotification(
+    model,
+    {
+      method: "item/started",
+      params: {
+        threadId: "thr_t",
+        ref: "ref_t",
+        turnId: "turn_1",
+        item: { type: "agentMessage", id: "item_1", turnId: "turn_1", status: "inProgress" },
+      },
+    },
+    1002,
+  );
+  return model;
+}
+
+function agentMessageDelta(delta: string): AnyNotification {
+  return {
+    method: "item/agentMessage/delta",
+    params: { threadId: "thr_t", ref: "ref_t", turnId: "turn_1", itemId: "item_1", delta },
+  };
+}
+
+test("every delta's fold reuses the previous chunks by reference and grows the count by one (O(1) append)", () => {
+  // 20,000 deltas matches the brief's scale. Reference identity is the
+  // property that makes the append O(1) — a per-delta copy ([...chunks,
+  // delta]) would still produce the right join and length but hands back
+  // fresh string references only if the strings themselves were rebuilt,
+  // which they are not; the copy that matters is the ARRAY copy, caught
+  // below by snapshotting the array reference across consecutive folds:
+  // a copied array is a different object than the one whose chunk at the
+  // same index we then read. Checking a FIXED set of sentinel positions
+  // (not every prior index per step) keeps the test O(n), not O(n^2) —
+  // the test must not recreate the very blowup it guards against.
+  const N = 20_000;
+  const SENTINELS = [0, 1, 2, 7, 100, 999, 5_000, 12_345, N - 2, N - 1];
+  let model = streamingItem();
+  const seenChunkRefs = new Map<number, string>();
+  for (let i = 0; i < N; i++) {
+    model = applyNotification(model, agentMessageDelta(`c${i} `), 1003 + i);
+    const chunks = itemAt(turnAt(model, 0), 0).pendingText;
+    expect(chunks).toHaveLength(i + 1);
+    // Record each sentinel chunk once, at the fold that produces it.
+    if (SENTINELS.includes(i)) {
+      const chunk = chunks?.[i];
+      expect(typeof chunk).toBe("string");
+      seenChunkRefs.set(i, chunk ?? "");
+    }
+    // After the sentinel exists, every later fold must still hand back
+    // THE SAME string reference at that index — an append, not a rebuild.
+    for (const s of SENTINELS) {
+      if (s <= i) {
+        expect(Object.is(chunks?.[s], seenChunkRefs.get(s))).toBe(true);
+      }
+    }
+  }
+  const chunks = itemAt(turnAt(model, 0), 0).pendingText;
+  expect(chunks?.length).toBe(N);
+  expect(chunks).toEqual(Array.from({ length: N }, (_, i) => `c${i} `));
+});
+
+test("a mid-stream model state stays observationally frozen while later deltas continue folding (view purity)", () => {
+  let model = streamingItem();
+  model = applyNotification(model, agentMessageDelta("Hel"), 1003);
+  model = applyNotification(model, agentMessageDelta("lo"), 1004);
+  const frozen = itemAt(turnAt(model, 0), 0);
+  const snapshot = [...(frozen.pendingText ?? [])];
+  // Snapshot the JOIN too — the most common read (settleItem, renderers).
+  const joined = frozen.pendingText?.join("");
+  // Keep folding well past the snapshotted state.
+  for (let i = 0; i < 500; i++) {
+    model = applyNotification(model, agentMessageDelta("x"), 1005 + i);
+  }
+  expect(frozen.pendingText?.length).toBe(2);
+  expect([...(frozen.pendingText ?? [])]).toEqual(snapshot);
+  expect(frozen.pendingText?.join("")).toBe(joined);
+  // And the live item carries all 502 chunks, first two unchanged.
+  const live = itemAt(turnAt(model, 0), 0);
+  expect(live.pendingText?.length).toBe(502);
+  expect(live.pendingText?.[0]).toBe("Hel");
+  expect(live.pendingText?.[1]).toBe("lo");
+  expect(live.pendingText?.slice(0, 2)).toEqual(["Hel", "lo"]);
+  // Mutating traps throw rather than corrupting the shared backing.
+  expect(() => (live.pendingText as string[]).push("y")).toThrow();
+  expect(() => {
+    (live.pendingText as string[])[0] = "z";
+  }).toThrow();
+  // Settling after the fold still joins exactly the streamed text.
+  model = applyNotification(
+    model,
+    {
+      method: "turn/completed",
+      params: {
+        threadId: "thr_t",
+        ref: "ref_t",
+        turnId: "turn_1",
+        turn: { id: "turn_1", status: "completed", itemsView: "" },
+      },
+    },
+    2000,
+  );
+  const settled = itemAt(turnAt(model, 0), 0);
+  expect(settled.text).toBe(`Hello${"x".repeat(500)}`);
+  expect(settled.pendingText).toBeUndefined();
+});
+
+test("a delta folded onto a STALE mid-stream state branches cleanly — no aliasing into the newer fold (copy-on-branch)", () => {
+  let base = streamingItem();
+  base = applyNotification(base, agentMessageDelta("a"), 1003);
+  base = applyNotification(base, agentMessageDelta("b"), 1004);
+  const branchedAt = base;
+
+  // One line of history continues from branchedAt...
+  let live = branchedAt;
+  for (let i = 0; i < 100; i++) {
+    live = applyNotification(live, agentMessageDelta("L"), 1100 + i);
+  }
+  const liveChunks = itemAt(turnAt(live, 0), 0).pendingText;
+  expect(liveChunks?.length).toBe(102);
+  expect(liveChunks?.join("")).toBe(`ab${"L".repeat(100)}`);
+
+  // ...and a second fold from the SAME stale state takes its own branch.
+  // The stale state's view is not the backing's newest, so this append
+  // must NOT push into the backing the live branch reads — it copies.
+  let fork = branchedAt;
+  for (let i = 0; i < 100; i++) {
+    fork = applyNotification(fork, agentMessageDelta("F"), 1200 + i);
+  }
+  const forkChunks = itemAt(turnAt(fork, 0), 0).pendingText;
+  expect(forkChunks?.length).toBe(102);
+  expect(forkChunks?.join("")).toBe(`ab${"F".repeat(100)}`);
+  // Neither branch saw the other's chunks.
+  expect(liveChunks?.join("")).toBe(`ab${"L".repeat(100)}`);
+  expect(liveChunks?.length).toBe(102);
+});
+
 test("item/completed inserts an item that had no preceding item/started", () => {
   // userMessage and systemMessage items go straight to item/completed with
   // no item/started (internal/appprojector/appwire_projection.go: a new user

--- a/cmd/evener-hub/frontend/src/protocol/reducer.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.ts
@@ -89,6 +89,10 @@ function epochMsToISO(ms: number | undefined): string | undefined {
 // work on it, Array.isArray is true, and every mutating trap throws). A
 // delta appends the chunk to the backing (O(1)) and mints a fresh view one
 // longer (O(1)) — no copy of any earlier chunk ever happens.
+// The view's brand also carries the running JOINED text (`brand.text`,
+// maintained per append), so the hot readers of a live view (settleItem,
+// AgentMessageItem's per-render markdown source) get the full text in O(1)
+// instead of paying the per-element Proxy-trap cost of a join.
 //
 // Purity: the reducer's contract is immutable updates, and this preserves
 // it OBSERVATIONALLY. The one deliberate alias — new views share the
@@ -111,16 +115,26 @@ function epochMsToISO(ms: number | undefined): string | undefined {
 // reference after the fact, which is exactly the purity violation this
 // design exists to avoid; the view keeps each state's snapshot frozen.
 
-// Brands a view so appendDelta can recognize its own kind. Stored as a
+// Brands a view so appendChunk can recognize its own kind. Stored as a
 // non-enumerable symbol-keyed prop that ownKeys does not report, keeping
 // the view structurally identical to a plain string[] for every consumer
 // (toEqual, JSON.stringify, spread, iteration) while appendChunk still has
 // a way to check "is this one of mine" without an O(1)-breaking lookup.
 const CHUNK_VIEW = Symbol("evener.chunkView");
 
-interface ChunkView {
-  [CHUNK_VIEW]: { backing: string[]; length: number };
+// The per-view brand, carried ON THE PROXY TARGET as a non-enumerable
+// symbol-keyed prop (so the traps — one shared module-level handler, not a
+// fresh closure set per view — can read it with Reflect.get on the raw
+// target). `text` is the cached join of backing[0..length); it is only
+// current while the view is the backing's newest (length ===
+// backing.length), which is exactly when the O(1) readers use it.
+interface ChunkViewBrand {
+  backing: string[];
+  length: number;
+  text: string;
 }
+
+type ChunkView = string[] & { [CHUNK_VIEW]?: ChunkViewBrand };
 
 // "5" | "12" -> 5 | 12; anything else (including "length", symbols,
 // negatives, fractions) -> undefined. Canonical numeric-string form only.
@@ -129,81 +143,94 @@ function chunkIndex(prop: string): number | undefined {
   return Number.isInteger(n) && n >= 0 && String(n) === prop ? n : undefined;
 }
 
-// The backing a view reads. A view created by chunkView is read back here;
-// anything else (a plain array from tests or hydrate) returns undefined.
-function viewBacking(chunks: string[]): string[] | undefined {
-  return (chunks as string[] & Partial<ChunkView>)[CHUNK_VIEW]?.backing;
+// A view's brand, in ONE trap hit (a view created by chunkView answers
+// here; anything else — a plain array from tests or hydrate — returns
+// undefined). Callers that need both the backing and the length read them
+// off this single result rather than paying the get trap twice.
+function chunkBrand(chunks: string[]): ChunkViewBrand | undefined {
+  return (chunks as ChunkView)[CHUNK_VIEW];
 }
 
-function viewLength(chunks: string[]): number | undefined {
-  return (chunks as string[] & Partial<ChunkView>)[CHUNK_VIEW]?.length;
-}
+// Every view shares this ONE handler (module-level, not minted per view):
+// the per-view state it needs — the brand — rides on the target, where the
+// traps read it with Reflect.get on the raw target (no closure capture, no
+// per-delta handler allocation). Every trap mirrors the exact descriptor
+// semantics of a real Array of that length so structural equality with a
+// plain string[] holds.
+const CHUNK_VIEW_HANDLER: ProxyHandler<string[]> = {
+  get(t, prop, receiver) {
+    const brand = Reflect.get(t, CHUNK_VIEW) as ChunkViewBrand | undefined;
+    if (prop === CHUNK_VIEW) return brand;
+    if (prop === "length") return brand?.length;
+    if (typeof prop === "string" && brand !== undefined) {
+      const i = chunkIndex(prop);
+      if (i !== undefined) return i < brand.length ? brand.backing[i] : undefined;
+    }
+    return Reflect.get(t, prop, receiver);
+  },
+  has(t, prop) {
+    if (prop === CHUNK_VIEW) return false;
+    const brand = Reflect.get(t, CHUNK_VIEW) as ChunkViewBrand | undefined;
+    if (typeof prop === "string" && brand !== undefined) {
+      const i = chunkIndex(prop);
+      if (i !== undefined) return i < brand.length;
+    }
+    return Reflect.has(t, prop);
+  },
+  ownKeys(t) {
+    const brand = Reflect.get(t, CHUNK_VIEW) as ChunkViewBrand | undefined;
+    const length = brand?.length ?? 0;
+    const keys: string[] = [];
+    for (let i = 0; i < length; i++) keys.push(String(i));
+    keys.push("length");
+    return keys;
+  },
+  getOwnPropertyDescriptor(t, prop) {
+    if (prop === CHUNK_VIEW) return undefined;
+    const brand = Reflect.get(t, CHUNK_VIEW) as ChunkViewBrand | undefined;
+    if (brand !== undefined) {
+      if (prop === "length") return { value: brand.length, writable: true, enumerable: false, configurable: false };
+      if (typeof prop === "string") {
+        const i = chunkIndex(prop);
+        if (i !== undefined) {
+          if (i >= brand.length) return undefined;
+          return { value: brand.backing[i], writable: true, enumerable: true, configurable: true };
+        }
+      }
+    }
+    return Reflect.getOwnPropertyDescriptor(t, prop);
+  },
+  set() {
+    throw new TypeError("pendingText views are immutable (append via the reducer)");
+  },
+  deleteProperty() {
+    throw new TypeError("pendingText views are immutable (append via the reducer)");
+  },
+  defineProperty() {
+    throw new TypeError("pendingText views are immutable (append via the reducer)");
+  },
+  preventExtensions() {
+    throw new TypeError("pendingText views are immutable (append via the reducer)");
+  },
+};
 
-// Returns a fresh immutable view of backing[0..length). Every trap below
-// mirrors the exact descriptor semantics of a real Array of that length so
-// structural equality with a plain string[] holds.
-function chunkView(backing: string[], length: number): string[] {
+// Returns a fresh immutable view of backing[0..length). `text` (the cached
+// join of that prefix) may be passed by a caller that already knows it —
+// the append fast path does, saving the O(length) recompute.
+function chunkView(backing: string[], length: number, text?: string): string[] {
   // A zero-length view has nothing to protect; an empty plain array is
   // cheaper than a Proxy and toEqual-identical. Also keeps RawItemView's
   // `chunks.length === 0` and AgentMessageItem's empty-array fallback on
   // their existing code paths.
   if (length === 0) return [];
-  const brand: ChunkView[typeof CHUNK_VIEW] = { backing, length };
+  const brand: ChunkViewBrand = { backing, length, text: text ?? backing.slice(0, length).join("") };
   const target: string[] = [];
-  return new Proxy(target, {
-    get(t, prop, receiver) {
-      if (prop === CHUNK_VIEW) return brand;
-      if (prop === "length") return length;
-      if (typeof prop === "string") {
-        const i = chunkIndex(prop);
-        if (i !== undefined) return i < length ? backing[i] : undefined;
-      }
-      return Reflect.get(t, prop, receiver);
-    },
-    has(t, prop) {
-      if (typeof prop === "string") {
-        const i = chunkIndex(prop);
-        if (i !== undefined) return i < length;
-      }
-      return Reflect.has(t, prop);
-    },
-    ownKeys() {
-      const keys: string[] = [];
-      for (let i = 0; i < length; i++) keys.push(String(i));
-      keys.push("length");
-      return keys;
-    },
-    getOwnPropertyDescriptor(t, prop) {
-      if (prop === "length") return { value: length, writable: true, enumerable: false, configurable: false };
-      if (typeof prop === "string") {
-        const i = chunkIndex(prop);
-        if (i !== undefined) {
-          if (i >= length) return undefined;
-          return { value: backing[i], writable: true, enumerable: true, configurable: true };
-        }
-      }
-      return Reflect.getOwnPropertyDescriptor(t, prop);
-    },
-    set() {
-      throw new TypeError("pendingText views are immutable (append via the reducer)");
-    },
-    deleteProperty() {
-      throw new TypeError("pendingText views are immutable (append via the reducer)");
-    },
-    defineProperty() {
-      throw new TypeError("pendingText views are immutable (append via the reducer)");
-    },
-    preventExtensions() {
-      throw new TypeError("pendingText views are immutable (append via the reducer)");
-    },
-  });
-}
-
-// The first chunk of an item. Owns a fresh backing — the item had no
-// chunks, so there is nothing to share.
-function firstChunkView(delta: string): string[] {
-  const backing: string[] = [delta];
-  return chunkView(backing, 1);
+  // configurable (not frozen) is REQUIRED by the Proxy invariants: a
+  // non-configurable target prop would force ownKeys to report the symbol,
+  // breaking toEqual/spread/JSON structural invisibility. Configurable, the
+  // traps below may hide it — exactly like the old closure-carried brand.
+  Object.defineProperty(target, CHUNK_VIEW, { value: brand, enumerable: false, writable: true, configurable: true });
+  return new Proxy(target, CHUNK_VIEW_HANDLER);
 }
 
 // Appends `delta` to `item.pendingText`, O(1). Fast path: the item's view
@@ -214,15 +241,34 @@ function firstChunkView(delta: string): string[] {
 // only correct option there: pushing onto the old view's backing would
 // overwrite a chunk some other view already reads, and pushing onto a plain
 // array would mutate an array the caller may still hold.
-function appendChunk(item: { pendingText?: string[] }, delta: string): string[] {
-  const current = item.pendingText;
-  if (current === undefined) return firstChunkView(delta);
-  const backing = viewBacking(current);
-  if (backing !== undefined && viewLength(current) === backing.length) {
-    backing.push(delta);
-    return chunkView(backing, backing.length);
+function appendChunk(current: string[] | undefined, delta: string): string[] {
+  if (current === undefined) return copyChunkPrefix([], delta);
+  const brand = chunkBrand(current);
+  if (brand !== undefined && brand.length === brand.backing.length) {
+    brand.backing.push(delta);
+    return chunkView(brand.backing, brand.backing.length, brand.text + delta);
   }
   return copyChunkPrefix(current, delta);
+}
+
+// The joined text of a pendingText value, O(1) for a live view (the brand
+// caches it per append) and a plain join for anything else (a plain array
+// from tests or hydrate). THE one read both hot consumers — settleItem's
+// finalize and AgentMessageItem's per-render markdown source — go through,
+// so the O(1) brand-cache read lives in exactly one place.
+export function pendingTextJoined(chunks: string[]): string {
+  const brand = chunkBrand(chunks);
+  if (brand !== undefined && brand.length === brand.backing.length) return brand.text;
+  return chunks.join("");
+}
+
+// Test-only white-box accessor: the backing array a view reads (undefined
+// for a plain array). The O(1) test discriminates append from copy by
+// asserting this reference is IDENTICAL across consecutive folds — the one
+// property a per-delta copy cannot fake (chunk strings are primitives, so
+// element-level Object.is survives a copy).
+export function chunkViewBackingForTests(chunks: string[]): string[] | undefined {
+  return chunkBrand(chunks)?.backing;
 }
 
 // Detached append: copies `chunks` (a plain array or a view) and appends.
@@ -392,7 +438,7 @@ function settleItem(item: ItemModel, now: number): ItemModel {
   if (pending === undefined && !stale && !needsObservedCompletion) return item;
   return {
     ...item,
-    text: pending === undefined ? item.text : item.text + pending.join(""),
+    text: pending === undefined ? item.text : item.text + pendingTextJoined(pending),
     pendingText: undefined,
     status: stale ? "completed" : item.status,
     observedCompletedAt: needsObservedCompletion ? epochMsToISO(now) : item.observedCompletedAt,
@@ -734,7 +780,7 @@ function appendReasoningDelta(item: ItemModel, summaryIndex: number, delta: stri
   const summaries = item.reasoningSummaries ? item.reasoningSummaries.slice() : [];
   while (summaries.length <= summaryIndex) summaries.push([]);
   const chunks = summaries[summaryIndex] ?? [];
-  summaries[summaryIndex] = appendChunk({ pendingText: chunks }, delta);
+  summaries[summaryIndex] = appendChunk(chunks, delta);
   return { ...item, reasoningSummaries: summaries, observedStartedAt: item.observedStartedAt ?? epochMsToISO(now) };
 }
 
@@ -928,12 +974,8 @@ function applyNotificationToThread(model: ThreadModel, n: AnyNotification, now: 
           ...turn,
           items: mapItem(turn.items, params.itemId, (item) => ({
             ...item,
-            // O(1): appends to the item's chunk backing without copying
-            // the accumulated chunks (appendChunk's copy-on-branch slow
-            // path handles the divergent-replay cases). The item spread
-            // above stays O(1) too: appendChunk returns a fresh view, and
-            // no other prop here reads pendingText.
-            pendingText: appendChunk(item, params.delta),
+            // O(1) — see appendChunk's doc comment.
+            pendingText: appendChunk(item.pendingText, params.delta),
           })),
         })),
         lastFrameAt: now,

--- a/cmd/evener-hub/frontend/src/protocol/reducer.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.ts
@@ -72,6 +72,169 @@ function epochMsToISO(ms: number | undefined): string | undefined {
   return ms === undefined || Number.isNaN(ms) || ms <= 0 ? undefined : new Date(ms).toISOString();
 }
 
+// Streaming-delta chunk accumulation, in O(1) per delta.
+//
+// The pre-fix shape copied the whole accumulated chunk array on every delta
+// (pendingText: [...(item.pendingText ?? []), delta]) — O(current-length)
+// work per delta, O(n^2) total for an item streamed in n chunks; the
+// token-flood benchmark measured ~13x late/early per-delta cost growth at
+// 10k deltas (docs/superpowers/plans/wave4-report.md, "Token-flood
+// benchmark"). The public shape — ItemModel.pendingText: string[] of every
+// chunk, in arrival order, readable at any time mid-stream — is unchanged;
+// only the cost of producing the next state changed.
+//
+// Shape: a per-item append-only backing array plus, per fold state, an
+// IMMUTABLE fixed-length view of that backing (a Proxy over an empty array
+// target that presents backing[0..length) — real Array.prototype methods
+// work on it, Array.isArray is true, and every mutating trap throws). A
+// delta appends the chunk to the backing (O(1)) and mints a fresh view one
+// longer (O(1)) — no copy of any earlier chunk ever happens.
+//
+// Purity: the reducer's contract is immutable updates, and this preserves
+// it OBSERVATIONALLY. The one deliberate alias — new views share the
+// backing with the view they extend — is safe because a chunk is only ever
+// appended at the index one past the current view's fixed length: no view
+// already handed out can read that index (its length is frozen), so every
+// view ever returned reads the exact same bytes for its whole life. A fold
+// whose chunk history diverges from the backing's (a delta arriving on a
+// model state whose pendingText is not the backing's latest view — the
+// replay/branch/reset interleavings that would otherwise alias a future
+// push into an old view) takes copyChunkPrefix instead, detaching from the
+// shared backing entirely. So no output of applyNotification is ever
+// mutated by a later applyNotification — same inputs, same observable
+// outputs, which is the purity the file header promises.
+//
+// Why a Proxy view rather than "mutate the item's array in place": the
+// model is handed to React and tests that treat it as deeply immutable
+// (memo comparators, hydrate-vs-fold snapshots, expect(...).toEqual). A
+// bare mutable array would change observable content under an existing
+// reference after the fact, which is exactly the purity violation this
+// design exists to avoid; the view keeps each state's snapshot frozen.
+
+// Brands a view so appendDelta can recognize its own kind. Stored as a
+// non-enumerable symbol-keyed prop that ownKeys does not report, keeping
+// the view structurally identical to a plain string[] for every consumer
+// (toEqual, JSON.stringify, spread, iteration) while appendChunk still has
+// a way to check "is this one of mine" without an O(1)-breaking lookup.
+const CHUNK_VIEW = Symbol("evener.chunkView");
+
+interface ChunkView {
+  [CHUNK_VIEW]: { backing: string[]; length: number };
+}
+
+// "5" | "12" -> 5 | 12; anything else (including "length", symbols,
+// negatives, fractions) -> undefined. Canonical numeric-string form only.
+function chunkIndex(prop: string): number | undefined {
+  const n = Number(prop);
+  return Number.isInteger(n) && n >= 0 && String(n) === prop ? n : undefined;
+}
+
+// The backing a view reads. A view created by chunkView is read back here;
+// anything else (a plain array from tests or hydrate) returns undefined.
+function viewBacking(chunks: string[]): string[] | undefined {
+  return (chunks as string[] & Partial<ChunkView>)[CHUNK_VIEW]?.backing;
+}
+
+function viewLength(chunks: string[]): number | undefined {
+  return (chunks as string[] & Partial<ChunkView>)[CHUNK_VIEW]?.length;
+}
+
+// Returns a fresh immutable view of backing[0..length). Every trap below
+// mirrors the exact descriptor semantics of a real Array of that length so
+// structural equality with a plain string[] holds.
+function chunkView(backing: string[], length: number): string[] {
+  // A zero-length view has nothing to protect; an empty plain array is
+  // cheaper than a Proxy and toEqual-identical. Also keeps RawItemView's
+  // `chunks.length === 0` and AgentMessageItem's empty-array fallback on
+  // their existing code paths.
+  if (length === 0) return [];
+  const brand: ChunkView[typeof CHUNK_VIEW] = { backing, length };
+  const target: string[] = [];
+  return new Proxy(target, {
+    get(t, prop, receiver) {
+      if (prop === CHUNK_VIEW) return brand;
+      if (prop === "length") return length;
+      if (typeof prop === "string") {
+        const i = chunkIndex(prop);
+        if (i !== undefined) return i < length ? backing[i] : undefined;
+      }
+      return Reflect.get(t, prop, receiver);
+    },
+    has(t, prop) {
+      if (typeof prop === "string") {
+        const i = chunkIndex(prop);
+        if (i !== undefined) return i < length;
+      }
+      return Reflect.has(t, prop);
+    },
+    ownKeys() {
+      const keys: string[] = [];
+      for (let i = 0; i < length; i++) keys.push(String(i));
+      keys.push("length");
+      return keys;
+    },
+    getOwnPropertyDescriptor(t, prop) {
+      if (prop === "length") return { value: length, writable: true, enumerable: false, configurable: false };
+      if (typeof prop === "string") {
+        const i = chunkIndex(prop);
+        if (i !== undefined) {
+          if (i >= length) return undefined;
+          return { value: backing[i], writable: true, enumerable: true, configurable: true };
+        }
+      }
+      return Reflect.getOwnPropertyDescriptor(t, prop);
+    },
+    set() {
+      throw new TypeError("pendingText views are immutable (append via the reducer)");
+    },
+    deleteProperty() {
+      throw new TypeError("pendingText views are immutable (append via the reducer)");
+    },
+    defineProperty() {
+      throw new TypeError("pendingText views are immutable (append via the reducer)");
+    },
+    preventExtensions() {
+      throw new TypeError("pendingText views are immutable (append via the reducer)");
+    },
+  });
+}
+
+// The first chunk of an item. Owns a fresh backing — the item had no
+// chunks, so there is nothing to share.
+function firstChunkView(delta: string): string[] {
+  const backing: string[] = [delta];
+  return chunkView(backing, 1);
+}
+
+// Appends `delta` to `item.pendingText`, O(1). Fast path: the item's view
+// is the newest over its backing (the plain sequential-stream case, by far
+// the common one) — push and mint. Slow path (copy-on-branch): the item's
+// view is stale (a folded state that predates later pushes on the same
+// backing) or a plain array (hydrated/test-constructed). Copying is the
+// only correct option there: pushing onto the old view's backing would
+// overwrite a chunk some other view already reads, and pushing onto a plain
+// array would mutate an array the caller may still hold.
+function appendChunk(item: { pendingText?: string[] }, delta: string): string[] {
+  const current = item.pendingText;
+  if (current === undefined) return firstChunkView(delta);
+  const backing = viewBacking(current);
+  if (backing !== undefined && viewLength(current) === backing.length) {
+    backing.push(delta);
+    return chunkView(backing, backing.length);
+  }
+  return copyChunkPrefix(current, delta);
+}
+
+// Detached append: copies `chunks` (a plain array or a view) and appends.
+// O(length) — only ever reached when the item's chunk history has already
+// diverged from any shared backing, so the total work across a whole
+// divergent replay is still O(n) for n deltas (one copy per branch point,
+// not per delta).
+function copyChunkPrefix(chunks: string[], delta: string): string[] {
+  const backing = [...chunks, delta];
+  return chunkView(backing, backing.length);
+}
+
 // Thread.createdAt/updatedAt are the wire's only Unix-SECONDS stamps
 // (cmd/evener-hub's hubcore.UnixSeconds for a past session,
 // appsource/local_daemon.go's entry.StartedAt.Unix() for a live one), unlike
@@ -560,10 +723,18 @@ function foldNonActiveTurnCompleted(model: ThreadModel, turnId: string, stamp: T
 // in model.ts). `now` is the reducer's own now parameter, never a clock
 // read (purity).
 function appendReasoningDelta(item: ItemModel, summaryIndex: number, delta: string, now: number): ItemModel {
+  // O(1) per delta (was: summaries.slice() + [...chunks, delta], both
+  // O(current-length) copies per delta — the same quadratic the
+  // agentMessage case had). The outer array is a plain string[][] (its
+  // entries come from wireItemToModel/hydrate too, not just this append),
+  // so it copies per call — but that copy is O(#summaries), a small bound
+  // set by the wire's summary indices, not by stream length. The chunk
+  // list per summary is the unbounded one, and that one gets the O(1)
+  // shared-backing append.
   const summaries = item.reasoningSummaries ? item.reasoningSummaries.slice() : [];
   while (summaries.length <= summaryIndex) summaries.push([]);
   const chunks = summaries[summaryIndex] ?? [];
-  summaries[summaryIndex] = [...chunks, delta];
+  summaries[summaryIndex] = appendChunk({ pendingText: chunks }, delta);
   return { ...item, reasoningSummaries: summaries, observedStartedAt: item.observedStartedAt ?? epochMsToISO(now) };
 }
 
@@ -757,7 +928,12 @@ function applyNotificationToThread(model: ThreadModel, n: AnyNotification, now: 
           ...turn,
           items: mapItem(turn.items, params.itemId, (item) => ({
             ...item,
-            pendingText: [...(item.pendingText ?? []), params.delta],
+            // O(1): appends to the item's chunk backing without copying
+            // the accumulated chunks (appendChunk's copy-on-branch slow
+            // path handles the divergent-replay cases). The item spread
+            // above stays O(1) too: appendChunk returns a fresh view, and
+            // no other prop here reads pendingText.
+            pendingText: appendChunk(item, params.delta),
           })),
         })),
         lastFrameAt: now,

--- a/cmd/evener-hub/frontend/src/protocol/testing/tokenFlood.ts
+++ b/cmd/evener-hub/frontend/src/protocol/testing/tokenFlood.ts
@@ -168,6 +168,41 @@ export function buildFloodStream(count: number, seed = 1): FloodStream {
   return { notifications, expectedText, chunkCount: count, ref, threadId, turnId, itemId };
 }
 
+// A model hydrated and folded up to (and including) item/started for one
+// in-flight agentMessage item — the canonical "streaming item" scaffold the
+// token-flood stream (buildFloodStream above) opens with and that
+// reducer.test.ts's O(1)/purity/branch tests fold deltas onto. Shared here
+// (next to buildFloodStream's own notifications) rather than re-implemented
+// per test file. `ids` overrides the flood defaults so callers can pin their
+// own thread/ref/turn/item identity; determinism is by construction (no
+// randomness anywhere).
+export function hydrateStreamingAgentMessage(
+  ref: string,
+  ids?: { threadId?: string; turnId?: string; itemId?: string },
+): ThreadModel {
+  const threadId = ids?.threadId ?? `thr_${ref}`;
+  const turnId = ids?.turnId ?? "turn_1";
+  const itemId = ids?.itemId ?? "item_1";
+  let model = hydrateFloodModel(ref);
+  model = applyNotification(
+    model,
+    {
+      method: "turn/started",
+      params: { threadId, ref, turn: { id: turnId, status: "inProgress", itemsView: "" } },
+    } as AnyNotification,
+    1001,
+  );
+  model = applyNotification(
+    model,
+    {
+      method: "item/started",
+      params: { threadId, ref, turnId, item: { type: "agentMessage", id: itemId, turnId, status: "inProgress" } },
+    } as AnyNotification,
+    1002,
+  );
+  return model;
+}
+
 const CAPABILITIES: ThreadCapabilities = {
   send: true,
   steer: true,


### PR DESCRIPTION
## Summary

The frontend reducer's `item/agentMessage/delta` case accumulated streaming chunks with `pendingText: [...(item.pendingText ?? []), params.delta]` — copying the entire accumulated chunk array on every delta, O(n) per delta and O(n^2) total. The repo's own token-flood benchmark documented this: ~13x per-delta cost growth from first to last 10%, 48.8x total-time growth for 1k→10k deltas, extrapolating to ~3-5s of pure main-thread time at 100k deltas on one item — the "UI freezes while a long turn streams" bug.

Each streaming item's chunks now live in a per-item append-only backing array exposed through fixed-length immutable Proxy views: a delta appends to the backing (O(1)) and mints a fresh view (O(1)) — no copy of accumulated chunks ever happens. The public `pendingText: string[]` shape is unchanged; every existing consumer (settleItem, AgentMessageItem, RawItemView, StreamingText, tokenFlood correctness tests) passes unmodified. The same reasoning-summary path gets the same treatment.

A brand-cached running joined string makes the hot per-render join O(1) (~9,000x on a 20k-chunk view: 0.886ms through the Proxy traps → 0.0001ms), consumed by AgentMessageItem, settleItem, and (from review round 1) ThinkBlock's live reasoning paragraphs.

## Benchmark (before → after)

- fold 10,000 deltas: 36.7ms → 4.0ms; growth 48.8x → 9.5x (≈linear)
- late/early per-delta ratio: ~10x → ~1x (noise)
- 20k-chunk join (the path that runs per render): 0.886ms → 0.0001ms

## Verification

- make test-web and make test-web-browser green; 7,241 frontend tests pass
- The white-box O(1) test discriminates for real: it fails against the old quadratic implementation (verified by stashing) — the fold's backing array must be reference-identical across consecutive folds while growing by exactly one

Fold-side micro-regression (~1.4x per delta, single-digit ms at 10k) is the deliberate trade for the consumer-side algorithmic win; the fold was never the dominant term.
