### PR TITLE
perf(hub): single-pass derived usage and failure scans for past thread reads

### DIFF
--- a/cmd/evener-hub/app_threadread.go
+++ b/cmd/evener-hub/app_threadread.go
@@ -32,8 +32,10 @@ func pastThreadForRead(cfg hubcore.WebConfig, params appwire.ThreadReadParams) (
 	}
 	thread = attachPastThreadSkillCatalog(entry, thread)
 	// One thread, one transcript: this path can afford the full-transcript
-	// scans the per-entry list sweeps cannot (see stampDerivedSessionUsage).
-	return stampDerivedFailureCount(entry, stampDerivedSessionUsage(entry, thread)), true, nil
+	// scans the per-entry list sweeps cannot (see stampDerivedTotals).
+	// One combined scan answers both figures; two separate ones would read and
+	// decode the same immutable bytes twice.
+	return stampDerivedTotals(entry, thread), true, nil
 }
 
 func pastThreadReadResponse(cfg hubcore.WebConfig, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, bool, error) {
@@ -61,7 +63,7 @@ func pastThreadReadResponse(cfg hubcore.WebConfig, params appwire.ThreadReadPara
 	if err != nil {
 		return appwire.ThreadReadResponse{}, true, err
 	}
-	thread = stampDerivedFailureCount(entry, stampDerivedSessionUsage(entry, reconcileAndEnrichPastThread(entry, thread)))
+	thread = stampDerivedTotals(entry, reconcileAndEnrichPastThread(entry, thread))
 	return appwire.ThreadReadResponse{Thread: thread, OlderCursor: olderCursor}, true, nil
 }
 
@@ -357,7 +359,7 @@ func pastEntryThread(cfg hubcore.WebConfig, entry hubcore.PastEntry, includeTurn
 	// A meta without it leaves both absent HERE, because this function also
 	// runs once per entry on the list and transcript-target sweeps. The
 	// single-thread read paths recover the figure from the transcript instead —
-	// see stampDerivedSessionUsage.
+	// see stampDerivedTotals.
 	cumulativeUsage := evenerUsageFromCumulative(entry.Meta.CumulativeUsage)
 	thread := appwire.Thread{
 		ID:            entry.Meta.ID,
@@ -520,52 +522,68 @@ func windowedReadResponse(thread appwire.Thread, turnLimit int) appwire.ThreadRe
 // the whole transcript each page.
 var pastTranscriptCache = apptranscript.NewTurnCache()
 
-// stampDerivedSessionUsage fills in a session token total the meta does not
-// carry, by summing the session's own span of its FULL transcript.
+// stampDerivedTotals fills in a session token total the meta does not carry,
+// and the session's failed-tool-call count, by scanning the session's own span
+// of its FULL transcript ONCE.
 //
-// The gap is the common case, not an edge: agent/fork.go's writeForkChild builds
-// the child SessionMeta field by field and stamps no CumulativeUsage at all, so
-// every fork child arrives with the field unset, and evener.usage and evener.cost
-// both empty. The client can then only sum the turns it happens to hold, which
-// it must honestly label "tokens (loaded turns)". The transcript records
-// per-turn usage regardless, so summing it recovers the full-session figure —
-// and because it reads the whole file rather than the loaded window, the total
-// does not shrink with thread/read's turnLimit.
+// The usage gap is the common case, not an edge: agent/fork.go's writeForkChild
+// builds the child SessionMeta field by field and stamps no CumulativeUsage at
+// all, so every fork child arrives with the field unset, and evener.usage and
+// evener.cost both empty. The client can then only sum the turns it happens to
+// hold, which it must honestly label "tokens (loaded turns)". The transcript
+// records per-turn usage regardless, so summing it recovers the full-session
+// figure — and because it reads the whole file rather than the loaded window,
+// the total does not shrink with thread/read's turnLimit.
+//
+// The failure count is derived server-side because the client cannot derive it
+// honestly. A windowed thread/read hands the client a suffix of the session —
+// measured at about 47% of a long real session's document at load (kata hw2n) —
+// and a count over that suffix is a partial figure wearing a full-session
+// label. For failures that is worse than saying nothing: the harm the count
+// exists to fix is a reader concluding a run was clean because they had not yet
+// scrolled to the failure, and a "0 failed" computed from the loaded window
+// states exactly that conclusion in the session's own chrome.
 //
 // A fork child's transcript OPENS with a verbatim copy of the parent's prefix,
-// whose tokens the PARENT spent. DivergenceTurn marks where the child's own
-// history begins, and only that span is counted: charging the parent's spend to
-// the child would be fabrication.
+// whose tokens the PARENT spent and whose failures the PARENT made.
+// DivergenceTurn marks where the child's own history begins, and only that span
+// counts toward either figure: charging the parent's spend or failures to the
+// child would be fabrication.
 //
-// A present total is left alone: it is the daemon's own running count, and
-// re-deriving would invite a second, disagreeing figure.
+// A present usage total is left alone: it is the daemon's own running count, and
+// re-deriving would invite a second, disagreeing figure (the failure count is
+// still owed, so that case scans for failures alone).
 //
 // Applied only on the single-thread read paths. pastEntryThread also runs once
 // per entry on the thread-list and transcript-target sweeps, where a scan per
 // session would cost a read of every transcript in the state dir.
 //
-// A read error (a legacy format_version 1 transcript, a missing file) leaves the
-// total absent. "Unknown" is the honest report, the client already renders an
-// absent total as nothing rather than "↑0 ↓0", and a missing token figure is no
-// reason to fail the whole thread projection.
-func stampDerivedSessionUsage(entry hubcore.PastEntry, thread appwire.Thread) appwire.Thread {
+// A read error (a legacy format_version 1 transcript, a missing file) leaves
+// both figures absent. "Unknown" is the honest report, the client already
+// renders an absent total as nothing rather than "↑0 ↓0" and an absent count as
+// nothing rather than "clean", and a missing figure is no reason to fail the
+// whole thread projection.
+func stampDerivedTotals(entry hubcore.PastEntry, thread appwire.Thread) appwire.Thread {
 	if thread.Evener.Usage != nil {
+		return stampDerivedFailureCount(entry, thread)
+	}
+	total, failures, err := pastTranscriptCache.DerivedTotalsFromFile(pastTranscriptPath(entry), transcriptJSONLMaxLineBytes, entry.Meta.DivergenceTurn)
+	if err != nil {
 		return thread
 	}
-	total := derivedSessionUsage(entry)
-	if total == nil {
-		return thread
+	if total != nil {
+		thread.Evener.Usage = total
+		thread.Evener.Cost = appwire.EstimateCost(entry.Meta.Model, total)
 	}
-	thread.Evener.Usage = total
-	thread.Evener.Cost = appwire.EstimateCost(entry.Meta.Model, total)
+	thread.Evener.FailedToolCalls = &failures
 	return thread
 }
 
-// derivedSessionUsage is stampDerivedSessionUsage's sum, for the legacy web
-// surface that assembles its own WorkspaceData rather than an appwire.Thread.
-// Returns nil for an absent total, on the same terms.
-func derivedSessionUsage(entry hubcore.PastEntry) *appwire.EvenerUsage {
-	total, err := pastTranscriptCache.UsageTotalFromFile(pastTranscriptPath(entry), transcriptJSONLMaxLineBytes, entry.Meta.DivergenceTurn)
+// derivedWorkspaceUsage is stampDerivedTotals's usage-only view, for the legacy
+// web surface that assembles its own WorkspaceData rather than an appwire.Thread
+// and owes no failure count. Returns nil for an absent total, on the same terms.
+func derivedWorkspaceUsage(entry hubcore.PastEntry) *appwire.EvenerUsage {
+	total, _, err := pastTranscriptCache.DerivedTotalsFromFile(pastTranscriptPath(entry), transcriptJSONLMaxLineBytes, entry.Meta.DivergenceTurn)
 	if err != nil {
 		return nil
 	}
@@ -587,10 +605,10 @@ func derivedSessionUsage(entry hubcore.PastEntry) *appwire.EvenerUsage {
 // A fork child's transcript OPENS with a verbatim copy of the parent's prefix,
 // whose failures the PARENT made. DivergenceTurn marks where the child's own
 // history begins, and only that span is counted — the same attribution rule
-// stampDerivedSessionUsage applies to tokens.
+// stampDerivedTotals applies to tokens.
 //
 // Applied only on the single-thread read paths, for the reason
-// stampDerivedSessionUsage states: pastEntryThread also runs once per entry on
+// stampDerivedTotals states: pastEntryThread also runs once per entry on
 // the thread-list and transcript-target sweeps, where a scan per session costs a
 // read of every transcript in the state dir.
 //

--- a/cmd/evener-hub/app_threadread.go
+++ b/cmd/evener-hub/app_threadread.go
@@ -590,31 +590,11 @@ func derivedWorkspaceUsage(entry hubcore.PastEntry) *appwire.EvenerUsage {
 	return total
 }
 
-// stampDerivedFailureCount reports how many of the session's tool calls failed,
-// by scanning its own span of the FULL transcript.
-//
-// It is derived server-side because the client cannot derive it honestly. A
-// windowed thread/read hands the client a suffix of the session — measured at
-// about 47% of a long real session's document at load (kata hw2n) — and a count
-// over that suffix is a partial figure wearing a full-session label. For
-// failures that is worse than saying nothing: the harm the count exists to fix
-// is a reader concluding a run was clean because they had not yet scrolled to
-// the failure, and a "0 failed" computed from the loaded window states exactly
-// that conclusion in the session's own chrome.
-//
-// A fork child's transcript OPENS with a verbatim copy of the parent's prefix,
-// whose failures the PARENT made. DivergenceTurn marks where the child's own
-// history begins, and only that span is counted — the same attribution rule
-// stampDerivedTotals applies to tokens.
-//
-// Applied only on the single-thread read paths, for the reason
-// stampDerivedTotals states: pastEntryThread also runs once per entry on
-// the thread-list and transcript-target sweeps, where a scan per session costs a
-// read of every transcript in the state dir.
-//
-// A read error (a legacy format_version 1 transcript, a missing file) leaves the
-// count ABSENT. Unknown is the honest report, the client renders an absent count
-// as nothing, and a session nobody can read must not be reported as clean.
+// stampDerivedFailureCount is stampDerivedTotals's failure-only half, for a
+// thread whose usage total the meta already carried: it scans the session's own
+// span for the failure count alone. The full rationale — why the count is
+// derived server-side, the divergence cut, error-means-absent — is stamped above
+// stampDerivedTotals.
 func stampDerivedFailureCount(entry hubcore.PastEntry, thread appwire.Thread) appwire.Thread {
 	count, err := pastTranscriptCache.FailedToolCallsFromFile(pastTranscriptPath(entry), transcriptJSONLMaxLineBytes, entry.Meta.DivergenceTurn)
 	if err != nil {

--- a/cmd/evener-hub/app_threadread_bench_test.go
+++ b/cmd/evener-hub/app_threadread_bench_test.go
@@ -17,11 +17,6 @@ import (
 	"primeradiant.com/evener/llm"
 )
 
-// apptranscriptNewTurnCacheForBench exists only to name the constructor this
-// benchmark needs without importing the package solely for that symbol in the
-// loop body; keep it trivial.
-var apptranscriptNewTurnCacheForBench = apptranscript.NewTurnCache
-
 // seedLargePastThread builds one past session with a large synthetic transcript
 // (thousands of user/assistant/tool turns carrying usage, tool calls, and failed
 // tool results — the shape the derived usage/failure scans walk) and returns the
@@ -44,74 +39,59 @@ func seedLargePastThread(tb testing.TB, rounds int) (hubcore.WebConfig, appwire.
 		tb.Fatal(err)
 	}
 	path := filepath.Join(sessions, sessionID+".transcript.jsonl")
-	file, err := os.Create(path)
+	writer, err := transcript.NewWriter(path, transcript.Header{
+		SessionID: sessionID, CreatedAt: now, ProfileID: "openai", Model: "gpt-5",
+	})
 	if err != nil {
 		tb.Fatal(err)
 	}
-	// Buffered writes: seeding is input fixture construction, not the measured
-	// read, and the transcript read back is byte-identical either way.
-	writer := newSynclessBufferedWriter(file)
-	writeLine := func(v any) {
-		line, err := json.Marshal(v)
-		if err != nil {
+	// Input fixture, not a durability test: batch the writes so seeding a large
+	// synthetic transcript does not pay one fsync per Append. Close still
+	// flushes, so the transcript read back is byte-identical.
+	writer.SyncInterval = time.Hour
+	// seq numbers the synthetic turns for call IDs and timestamps; the entry's
+	// own Seq is the writer's, incremented once per Append.
+	seq := 0
+	appendTurn := func(turn schema.Turn) {
+		seq++
+		turn.Timestamp = time.Unix(1_700_000_000+int64(seq), 0).UTC()
+		if err := writer.Append(turn); err != nil {
 			tb.Fatal(err)
 		}
-		writer.Write(append(line, '\n'))
 	}
-	writeLine(transcript.Header{Kind: "header", FormatVersion: transcript.FormatVersion, SessionID: sessionID, CreatedAt: now, ProfileID: "openai", Model: "gpt-5"})
-	seq := 0
 	assistantText := strings.Repeat("a long assistant answer line that mirrors real transcript density ", 8)
 	cacheRead := 800
 	for i := range rounds {
-		seq++
-		writeLine(transcript.Entry{Kind: "entry", Seq: seq, Turn: schema.Turn{
+		appendTurn(schema.Turn{
 			Kind: schema.TurnUserInput, Message: llm.User(fmt.Sprintf("round %d request", i)),
-			Timestamp: time.Unix(1_700_000_000+int64(seq), 0).UTC(),
-		}})
-		seq++
-		writeLine(transcript.Entry{Kind: "entry", Seq: seq, Turn: schema.Turn{
+		})
+		callID := fmt.Sprintf("call_%d", seq)
+		appendTurn(schema.Turn{
 			Kind: schema.TurnAssistant,
 			Message: llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{
 				{Kind: llm.ContentText, Text: assistantText},
-				{Kind: llm.ContentToolCall, ToolCall: &llm.ToolCallData{ID: fmt.Sprintf("call_%d", seq), Name: "shell", Arguments: json.RawMessage(`{"argv":["ls","-la"]}`)}},
+				{Kind: llm.ContentToolCall, ToolCall: &llm.ToolCallData{ID: callID, Name: "shell", Arguments: json.RawMessage(`{"argv":["ls","-la"]}`)}},
 			}},
-			Usage:     llm.Usage{InputTokens: 1200, OutputTokens: 340, CacheReadTokens: &cacheRead},
-			Timestamp: time.Unix(1_700_000_000+int64(seq), 0).UTC(),
-		}})
-		seq++
-		// Every eighth tool result fails (IsError), so the failure scan has real
-		// work; the rest carry a nonzero exit code every sixteenth call.
-		seq++
-		failed := i%8 == 0
+			Usage: llm.Usage{InputTokens: 1200, OutputTokens: 340, CacheReadTokens: &cacheRead},
+		})
+		// Every sixteenth tool result is a shell result whose command failed
+		// but whose result is not an error — the case the failure rule reads
+		// from opaque tool state. Every other eighth fails via IsError, so the
+		// failure scan has real work either way.
+		toolResult := &llm.ToolResultData{ToolCallID: callID, Name: "shell"}
 		if i%16 == 0 {
-			// A shell result whose command failed but whose result is not an
-			// error — the case the failure rule reads from opaque tool state.
-			writeLine(transcript.Entry{Kind: "entry", Seq: seq, Turn: schema.Turn{
-				Kind: schema.TurnToolResults,
-				Message: llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{{
-					Kind: llm.ContentToolResult,
-					ToolResult: &llm.ToolResultData{
-						ToolCallID: fmt.Sprintf("call_%d", seq-1), Name: "shell",
-						Content:   strings.Repeat("command failed output ", 2),
-						ToolState: json.RawMessage(`{"exit_code":1}`),
-					},
-				}}},
-				Timestamp: time.Unix(1_700_000_000+int64(seq), 0).UTC(),
-			}})
-			continue
+			toolResult.Content = strings.Repeat("command failed output ", 2)
+			toolResult.ToolState = json.RawMessage(`{"exit_code":1}`)
+		} else {
+			toolResult.Content = strings.Repeat("tool output text mirroring a real result body ", 6)
+			toolResult.IsError = i%8 == 0
 		}
-		writeLine(transcript.Entry{Kind: "entry", Seq: seq, Turn: schema.Turn{
+		appendTurn(schema.Turn{
 			Kind: schema.TurnToolResults,
 			Message: llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{{
-				Kind: llm.ContentToolResult,
-				ToolResult: &llm.ToolResultData{
-					ToolCallID: fmt.Sprintf("call_%d", seq-1), Name: "shell",
-					Content: strings.Repeat("tool output text mirroring a real result body ", 6),
-					IsError: failed,
-				},
+				Kind: llm.ContentToolResult, ToolResult: toolResult,
 			}}},
-			Timestamp: time.Unix(1_700_000_000+int64(seq), 0).UTC(),
-		}})
+		})
 	}
 	if err := writer.Close(); err != nil {
 		tb.Fatal(err)
@@ -123,39 +103,6 @@ func seedLargePastThread(tb testing.TB, rounds int) (hubcore.WebConfig, appwire.
 	return hubcore.WebConfig{Past: idx}, appwire.ThreadReadParams{
 		Ref: "local:" + sessionID, IncludeTurns: true, TurnLimit: 40,
 	}, path
-}
-
-// synclessBufferedWriter buffers transcript fixture writes so seeding a large
-// synthetic transcript does not pay one write syscall per entry.
-type synclessBufferedWriter struct {
-	file *os.File
-	buf  []byte
-}
-
-func newSynclessBufferedWriter(file *os.File) *synclessBufferedWriter {
-	return &synclessBufferedWriter{file: file}
-}
-
-func (w *synclessBufferedWriter) Write(p []byte) {
-	w.buf = append(w.buf, p...)
-	if len(w.buf) >= 1<<20 {
-		w.flush()
-	}
-}
-
-func (w *synclessBufferedWriter) flush() {
-	if len(w.buf) == 0 {
-		return
-	}
-	if _, err := w.file.Write(w.buf); err != nil {
-		panic(err)
-	}
-	w.buf = w.buf[:0]
-}
-
-func (w *synclessBufferedWriter) Close() error {
-	w.flush()
-	return w.file.Close()
 }
 
 // BenchmarkPastThreadReadResponseCold times a past session's initial
@@ -181,7 +128,7 @@ func BenchmarkPastThreadReadResponseCold(b *testing.B) {
 						b.Fatal(err)
 					}
 				}
-				pastTranscriptCache = apptranscriptNewTurnCacheForBench()
+				pastTranscriptCache = apptranscript.NewTurnCache()
 				b.StartTimer()
 				response, found, err := pastThreadReadResponse(cfg, params)
 				if err != nil || !found {

--- a/cmd/evener-hub/app_threadread_bench_test.go
+++ b/cmd/evener-hub/app_threadread_bench_test.go
@@ -1,0 +1,199 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/internal/apptranscript"
+	"primeradiant.com/evener/llm"
+)
+
+// apptranscriptNewTurnCacheForBench exists only to name the constructor this
+// benchmark needs without importing the package solely for that symbol in the
+// loop body; keep it trivial.
+var apptranscriptNewTurnCacheForBench = apptranscript.NewTurnCache
+
+// seedLargePastThread builds one past session with a large synthetic transcript
+// (thousands of user/assistant/tool turns carrying usage, tool calls, and failed
+// tool results — the shape the derived usage/failure scans walk) and returns the
+// WebConfig plus the thread/read params a client's initial past-session click
+// issues. It is the benchmark counterpart of seedBoundedPastThread.
+func seedLargePastThread(tb testing.TB, rounds int) (hubcore.WebConfig, appwire.ThreadReadParams, string) {
+	tb.Helper()
+	root := tb.TempDir()
+	stateDir := filepath.Join(root, "projects", "project-bench-0000000000")
+	sessionID := "02wMz5Txv47YP64RR3B9YJ"
+	sessions := filepath.Join(stateDir, "sessions")
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		tb.Fatal(err)
+	}
+	now := time.Unix(1700000000, 0).UTC()
+	if err := schema.SaveSessionMeta(stateDir, schema.SessionMeta{
+		ID: sessionID, ProfileID: "openai", Model: "gpt-5", TurnCount: rounds,
+		EnvInfo: schema.EnvironmentInfo{WorkingDir: "/tmp/project"}, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		tb.Fatal(err)
+	}
+	path := filepath.Join(sessions, sessionID+".transcript.jsonl")
+	file, err := os.Create(path)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	// Buffered writes: seeding is input fixture construction, not the measured
+	// read, and the transcript read back is byte-identical either way.
+	writer := newSynclessBufferedWriter(file)
+	writeLine := func(v any) {
+		line, err := json.Marshal(v)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		writer.Write(append(line, '\n'))
+	}
+	writeLine(transcript.Header{Kind: "header", FormatVersion: transcript.FormatVersion, SessionID: sessionID, CreatedAt: now, ProfileID: "openai", Model: "gpt-5"})
+	seq := 0
+	assistantText := strings.Repeat("a long assistant answer line that mirrors real transcript density ", 8)
+	cacheRead := 800
+	for i := range rounds {
+		seq++
+		writeLine(transcript.Entry{Kind: "entry", Seq: seq, Turn: schema.Turn{
+			Kind: schema.TurnUserInput, Message: llm.User(fmt.Sprintf("round %d request", i)),
+			Timestamp: time.Unix(1_700_000_000+int64(seq), 0).UTC(),
+		}})
+		seq++
+		writeLine(transcript.Entry{Kind: "entry", Seq: seq, Turn: schema.Turn{
+			Kind: schema.TurnAssistant,
+			Message: llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{
+				{Kind: llm.ContentText, Text: assistantText},
+				{Kind: llm.ContentToolCall, ToolCall: &llm.ToolCallData{ID: fmt.Sprintf("call_%d", seq), Name: "shell", Arguments: json.RawMessage(`{"argv":["ls","-la"]}`)}},
+			}},
+			Usage:     llm.Usage{InputTokens: 1200, OutputTokens: 340, CacheReadTokens: &cacheRead},
+			Timestamp: time.Unix(1_700_000_000+int64(seq), 0).UTC(),
+		}})
+		seq++
+		// Every eighth tool result fails (IsError), so the failure scan has real
+		// work; the rest carry a nonzero exit code every sixteenth call.
+		seq++
+		failed := i%8 == 0
+		if i%16 == 0 {
+			// A shell result whose command failed but whose result is not an
+			// error — the case the failure rule reads from opaque tool state.
+			writeLine(transcript.Entry{Kind: "entry", Seq: seq, Turn: schema.Turn{
+				Kind: schema.TurnToolResults,
+				Message: llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{{
+					Kind: llm.ContentToolResult,
+					ToolResult: &llm.ToolResultData{
+						ToolCallID: fmt.Sprintf("call_%d", seq-1), Name: "shell",
+						Content:   strings.Repeat("command failed output ", 2),
+						ToolState: json.RawMessage(`{"exit_code":1}`),
+					},
+				}}},
+				Timestamp: time.Unix(1_700_000_000+int64(seq), 0).UTC(),
+			}})
+			continue
+		}
+		writeLine(transcript.Entry{Kind: "entry", Seq: seq, Turn: schema.Turn{
+			Kind: schema.TurnToolResults,
+			Message: llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{{
+				Kind: llm.ContentToolResult,
+				ToolResult: &llm.ToolResultData{
+					ToolCallID: fmt.Sprintf("call_%d", seq-1), Name: "shell",
+					Content: strings.Repeat("tool output text mirroring a real result body ", 6),
+					IsError: failed,
+				},
+			}}},
+			Timestamp: time.Unix(1_700_000_000+int64(seq), 0).UTC(),
+		}})
+	}
+	if err := writer.Close(); err != nil {
+		tb.Fatal(err)
+	}
+	idx := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+	if _, err := idx.Rebuild(); err != nil {
+		tb.Fatal(err)
+	}
+	return hubcore.WebConfig{Past: idx}, appwire.ThreadReadParams{
+		Ref: "local:" + sessionID, IncludeTurns: true, TurnLimit: 40,
+	}, path
+}
+
+// synclessBufferedWriter buffers transcript fixture writes so seeding a large
+// synthetic transcript does not pay one write syscall per entry.
+type synclessBufferedWriter struct {
+	file *os.File
+	buf  []byte
+}
+
+func newSynclessBufferedWriter(file *os.File) *synclessBufferedWriter {
+	return &synclessBufferedWriter{file: file}
+}
+
+func (w *synclessBufferedWriter) Write(p []byte) {
+	w.buf = append(w.buf, p...)
+	if len(w.buf) >= 1<<20 {
+		w.flush()
+	}
+}
+
+func (w *synclessBufferedWriter) flush() {
+	if len(w.buf) == 0 {
+		return
+	}
+	if _, err := w.file.Write(w.buf); err != nil {
+		panic(err)
+	}
+	w.buf = w.buf[:0]
+}
+
+func (w *synclessBufferedWriter) Close() error {
+	w.flush()
+	return w.file.Close()
+}
+
+// BenchmarkPastThreadReadResponseCold times a past session's initial
+// thread/read with a cold transcript cache and no on-disk turn index — the
+// first read after hub start or LRU eviction. Each iteration re-creates the
+// in-memory cache and removes the sidecar files the bounded reader persists,
+// so every pass pays the full cold path: turn-index build, derived usage scan,
+// derived failure scan, and projection of the latest 40 turns.
+func BenchmarkPastThreadReadResponseCold(b *testing.B) {
+	for _, rounds := range []int{4_000, 25_000} {
+		b.Run(fmt.Sprintf("rounds=%d", rounds), func(b *testing.B) {
+			cfg, params, path := seedLargePastThread(b, rounds)
+			if info, err := os.Stat(path); err == nil {
+				b.Logf("transcript %s: %.1f MB", filepath.Base(path), float64(info.Size())/(1<<20))
+			}
+			sidecars := []string{path + ".appwire-index.json", path + ".appwire-index.json.journal"}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				for _, sidecar := range sidecars {
+					if err := os.Remove(sidecar); err != nil && !os.IsNotExist(err) {
+						b.Fatal(err)
+					}
+				}
+				pastTranscriptCache = apptranscriptNewTurnCacheForBench()
+				b.StartTimer()
+				response, found, err := pastThreadReadResponse(cfg, params)
+				if err != nil || !found {
+					b.Fatalf("pastThreadReadResponse = %v, %v", err, found)
+				}
+				if response.Thread.Evener.Usage == nil {
+					b.Fatal("bench response missing derived usage")
+				}
+				if response.Thread.Evener.FailedToolCalls == nil {
+					b.Fatal("bench response missing derived failure count")
+				}
+			}
+		})
+	}
+}

--- a/cmd/evener-hub/web_workspace.go
+++ b/cmd/evener-hub/web_workspace.go
@@ -157,9 +157,9 @@ func (s *WebServer) workspaceData(id string) WorkspaceData {
 			}
 			// One session's own workspace, so this path can afford the same
 			// full-transcript recovery the single-thread read does: a fork child's
-			// meta carries no CumulativeUsage at all (stampDerivedSessionUsage).
+			// meta carries no CumulativeUsage at all (stampDerivedTotals).
 			if data.Usage == nil {
-				data.Usage = derivedSessionUsage(pe)
+				data.Usage = derivedWorkspaceUsage(pe)
 			}
 			data.Cost = appwire.EstimateCost(data.Model, data.Usage)
 			s.fillForkLineage(&data, pe.Meta)

--- a/internal/apptranscript/derived_totals.go
+++ b/internal/apptranscript/derived_totals.go
@@ -10,9 +10,9 @@ import (
 )
 
 // derivedTotals is what DerivedTotalsFromFile computes in one pass: the
-// session's full-transcript token sum and failed-tool-call count, plus whether
-// the counted span carried any usage at all (absent and zero are different
-// claims — see UsageTotalFromFile).
+// session's full-transcript token sum and its failed-tool-call count. A nil
+// usage means the counted span carried no token data — the nil-usage semantics
+// DerivedTotalsFromFile documents below.
 type derivedTotals struct {
 	usage          *appwire.EvenerUsage
 	failedToolCall int

--- a/internal/apptranscript/derived_totals.go
+++ b/internal/apptranscript/derived_totals.go
@@ -1,0 +1,174 @@
+package apptranscript
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/llm"
+)
+
+// derivedTotals is what DerivedTotalsFromFile computes in one pass: the
+// session's full-transcript token sum and failed-tool-call count, plus whether
+// the counted span carried any usage at all (absent and zero are different
+// claims — see UsageTotalFromFile).
+type derivedTotals struct {
+	usage          *appwire.EvenerUsage
+	failedToolCall int
+}
+
+// DerivedTotalsFromFile computes BOTH derived figures — the full-transcript
+// token sum of UsageTotalFromFile and the failed-tool-call count of
+// FailedToolCallsFromFile — in a SINGLE scan of the transcript.
+//
+// It exists because the past-thread read path needs both on every read: two
+// separate scans read and strictly decode the same immutable bytes twice, and
+// on a tens-of-megabytes transcript that doubled cost dominated the read. One
+// pass over the same narrow field-for-field subsets (usage block, tool calls
+// and tool results) answers both for the price of one.
+//
+// Semantics are exactly the union of the two functions it replaces:
+//
+//   - fromEntryOrdinal is the 1-based entry ordinal at which the session's OWN
+//     history begins (a fork child's SessionMeta.DivergenceTurn); entries
+//     before it are the parent's verbatim prefix and contribute to neither
+//     figure. The failure rule still learns tool names from EVERY assistant
+//     entry, including inherited ones, because a fork child's own result can
+//     answer a call the inherited prefix announced.
+//   - usage is nil when the counted span carries no token data; the count is
+//     still a real measurement. Errors are surfaced rather than swallowed, so
+//     a caller reports "unknown" instead of a fabricated figure.
+//
+// The result is memoized on the same file-identity + divergence-ordinal gate
+// the two individual memos use, stored alongside them so all three evict
+// together. Callers that need only one figure should keep using the single
+// functions; this is for read paths that provably need both.
+func (c *TurnCache) DerivedTotalsFromFile(path string, maxLineBytes int, fromEntryOrdinal int) (*appwire.EvenerUsage, int, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, 0, fmt.Errorf("stat transcript: %w", err)
+	}
+	identity := derivedTotalsKey{
+		size:           info.Size(),
+		modUnixNano:    info.ModTime().UnixNano(),
+		fileIdentity:   fileIdentity(info),
+		changeIdentity: fileChangeIdentity(info),
+		fromOrdinal:    fromEntryOrdinal,
+	}
+
+	c.mu.Lock()
+	if entry, ok := c.entries[path]; ok && entry.derivedTotals != nil && entry.derivedTotals.key == identity {
+		totals := entry.derivedTotals.totals
+		c.touch(path)
+		c.mu.Unlock()
+		return cloneEvenerUsage(totals.usage), totals.failedToolCall, nil
+	}
+	c.mu.Unlock()
+
+	totals, err := scanDerivedTotals(path, maxLineBytes, fromEntryOrdinal)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	c.mu.Lock()
+	entry := c.entries[path]
+	entry.derivedTotals = &derivedTotalsMemo{key: identity, totals: totals}
+	c.entries[path] = entry
+	c.touch(path)
+	c.evictLocked()
+	c.mu.Unlock()
+	return cloneEvenerUsage(totals.usage), totals.failedToolCall, nil
+}
+
+// scanDerivedTotals reads the transcript once, computing both figures with the
+// same narrow decodes and attribution rules the two individual scans apply. It
+// reuses scanSemanticTranscript so the format gate (v1 rejection,
+// unknown-field strictness, header validation) is exactly the one every other
+// reader in this package applies.
+func scanDerivedTotals(path string, maxLineBytes int, fromEntryOrdinal int) (derivedTotals, error) {
+	var totals derivedTotals
+	var accumulated llm.Usage
+	counted := false
+	ordinal := 0
+	// toolNames resolves a result whose own record omits its name, mirroring
+	// ProjectTurn's map of the same name. It is filled from EVERY assistant
+	// entry, including ones before the divergence cut: a fork child's own
+	// result can answer a call the inherited prefix announced.
+	toolNames := map[string]string{}
+	if _, err := scanSemanticTranscript(path, maxLineBytes, func(raw json.RawMessage) error {
+		ordinal++
+		var record derivedTotalsEntry
+		if err := json.Unmarshal(raw, &record); err != nil {
+			// Unreachable for any line scanSemanticTranscript admits: it has
+			// already strictly decoded the whole entry into transcript.Entry,
+			// of which this is a field-for-field subset. A failure here means
+			// this struct has drifted from schema.Turn, and skipping the
+			// record would silently undercount — reporting a wrong figure is
+			// worse than reporting none, so surface it.
+			return fmt.Errorf("decode transcript entry derived totals: %w", err)
+		}
+		counting := ordinal >= fromEntryOrdinal
+		if counting && appwire.EvenerUsageFromLLM(record.Turn.Usage) != nil {
+			accumulated = accumulated.Add(record.Turn.Usage)
+			counted = true
+		}
+		for _, part := range record.Turn.Message.Content {
+			switch {
+			case part.ToolCall != nil && part.Kind == llm.ContentToolCall:
+				toolNames[part.ToolCall.ID] = part.ToolCall.Name
+			case part.ToolResult != nil && part.Kind == llm.ContentToolResult:
+				if counting && failedToolResult(part.ToolResult, toolNames) {
+					totals.failedToolCall++
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		return derivedTotals{}, err
+	}
+	observeIndexRead(ReadStats{derivedScans: 1})
+	if !counted {
+		return totals, nil
+	}
+	totals.usage = appwire.EvenerUsageFromLLM(accumulated)
+	return totals, nil
+}
+
+// derivedTotalsEntry decodes the few fields both figures need: the usage block
+// for the token sum, and the tool calls/results for the failure count.
+// scanSemanticTranscript has already validated the full record, so this
+// narrow view can ignore the rest rather than paying to decode whole message
+// bodies (including inline image bytes) per line.
+type derivedTotalsEntry struct {
+	Turn struct {
+		Usage   llm.Usage `json:"usage"`
+		Message struct {
+			Content []struct {
+				Kind     llm.ContentKind `json:"kind"`
+				ToolCall *struct {
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"tool_call"`
+				ToolResult *failedToolCallResult `json:"tool_result"`
+			} `json:"content"`
+		} `json:"message"`
+	} `json:"turn"`
+}
+
+// derivedTotalsKey is the file identity a memoized combined scan is valid for.
+// It mirrors usageTotalKey and failedToolCallsKey exactly (object identity,
+// size, mtime as nanos, platform change time, divergence ordinal) so the
+// combined memo can never outlive the two it consolidates.
+type derivedTotalsKey struct {
+	size           int64
+	modUnixNano    int64
+	fileIdentity   string
+	changeIdentity string
+	fromOrdinal    int
+}
+
+type derivedTotalsMemo struct {
+	key    derivedTotalsKey
+	totals derivedTotals
+}

--- a/internal/apptranscript/derived_totals_test.go
+++ b/internal/apptranscript/derived_totals_test.go
@@ -1,0 +1,209 @@
+package apptranscript
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/llm"
+)
+
+func filepathJoinDerivedTotals(t testing.TB, name string) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), name)
+}
+
+func writeDerivedTotalsLines(t testing.TB, path string, records []any) {
+	t.Helper()
+	var data []byte
+	for _, record := range records {
+		line, err := json.Marshal(record)
+		if err != nil {
+			t.Fatal(err)
+		}
+		data = append(data, line...)
+		data = append(data, '\n')
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func marshalDerivedTotalsToolState(t testing.TB, state map[string]any) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+// writeDerivedTotalsTranscript writes a transcript whose entries carry both
+// usage and tool calls/results, so a test can name the exact token sum and
+// failure count it expects the combined scan to produce.
+func writeDerivedTotalsTranscript(t testing.TB, entries []schema.Turn) string {
+	t.Helper()
+	path := filepathJoinDerivedTotals(t, "derived.transcript.jsonl")
+	records := []any{transcript.Header{Kind: "header", FormatVersion: transcript.FormatVersion, SessionID: "derived"}}
+	for i, turn := range entries {
+		turn.Timestamp = time.Unix(1_700_000_000+int64(i), 0).UTC()
+		records = append(records, transcript.Entry{Kind: "entry", Seq: i + 1, Turn: turn})
+	}
+	writeDerivedTotalsLines(t, path, records)
+	return path
+}
+
+// requireDerivedTotalsFromFile is DerivedTotalsFromFile's test helper.
+func requireDerivedTotalsFromFile(t testing.TB, cache *TurnCache, path string, maxLineBytes, fromEntryOrdinal int) (*appwire.EvenerUsage, int) {
+	t.Helper()
+	usage, failures, err := cache.DerivedTotalsFromFile(path, maxLineBytes, fromEntryOrdinal)
+	if err != nil {
+		t.Fatalf("DerivedTotalsFromFile: %v", err)
+	}
+	return usage, failures
+}
+
+// The combined scan answers exactly what the two individual scans answer:
+// one transcript, both figures, one pass.
+func TestDerivedTotalsFromFileMatchesIndividualScans(t *testing.T) {
+	zero := 0
+	one := 1
+	path := writeDerivedTotalsTranscript(t, []schema.Turn{
+		{Kind: schema.TurnAssistant, Message: llm.Assistant("first"), Usage: llm.Usage{InputTokens: 100, OutputTokens: 10, TotalTokens: 110}},
+		{Kind: schema.TurnAssistant, Message: llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{
+			{Kind: llm.ContentToolCall, ToolCall: &llm.ToolCallData{ID: "c1", Name: "shell"}},
+		}}},
+		{Kind: schema.TurnToolResults, Message: llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{
+			{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "c1", Name: "shell", IsError: true}},
+		}}},
+		{Kind: schema.TurnAssistant, Message: llm.Assistant("after failure"), Usage: llm.Usage{InputTokens: 200, OutputTokens: 20, TotalTokens: 220}},
+		{Kind: schema.TurnToolResults, Message: llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{
+			{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "c2", Name: "shell", ToolState: marshalDerivedTotalsToolState(t, map[string]any{"exit_code": one})}},
+		}}},
+		{Kind: schema.TurnAssistant, Message: llm.Assistant("clean"), Usage: llm.Usage{InputTokens: 50, OutputTokens: 5, TotalTokens: 55}},
+		{Kind: schema.TurnToolResults, Message: llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{
+			{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "c3", Name: "shell", ToolState: marshalDerivedTotalsToolState(t, map[string]any{"exit_code": zero})}},
+		}}},
+	})
+
+	cache := NewTurnCache()
+	usage, failures := requireDerivedTotalsFromFile(t, cache, path, testMaxLineBytes, 0)
+	wantUsage := &appwire.EvenerUsage{InputTokens: 350, OutputTokens: 35, TotalTokens: 385}
+	if usage == nil || *usage != *wantUsage {
+		t.Fatalf("combined usage = %+v, want %+v", usage, wantUsage)
+	}
+	if failures != 2 {
+		t.Fatalf("combined failures = %d, want 2 (IsError + nonzero exit)", failures)
+	}
+
+	// The individual scans over the same file must agree with the combined one.
+	individualUsage := requireUsageTotalFromFile(t, NewTurnCache(), path, testMaxLineBytes, 0)
+	if individualUsage == nil || *individualUsage != *wantUsage {
+		t.Fatalf("individual usage = %+v, want %+v", individualUsage, wantUsage)
+	}
+	individualFailures := requireFailedToolCalls(t, NewTurnCache(), path, 0)
+	if individualFailures != 2 {
+		t.Fatalf("individual failures = %d, want 2", individualFailures)
+	}
+}
+
+// A fork child's inherited prefix contributes to neither figure, and the
+// failure rule still resolves tool names from inherited calls.
+func TestDerivedTotalsFromFileSkipsInheritedForkPrefix(t *testing.T) {
+	one := 1
+	path := writeDerivedTotalsTranscript(t, []schema.Turn{
+		// Parent's prefix: entry 1 announces a call, entry 2 answers it
+		// with a failure, entry 3 spends tokens.
+		{Kind: schema.TurnAssistant, Message: llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{
+			{Kind: llm.ContentToolCall, ToolCall: &llm.ToolCallData{ID: "p1", Name: "shell"}},
+		}}},
+		{Kind: schema.TurnToolResults, Message: llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{
+			{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "p1", IsError: true}}, // nameless: resolved from p1's call
+		}}},
+		{Kind: schema.TurnAssistant, Message: llm.Assistant("parent spend"), Usage: llm.Usage{InputTokens: 999, OutputTokens: 99, TotalTokens: 1098}},
+		// Child's own history: entry 4 answers the inherited call with a
+		// failure, entry 5 spends its own tokens.
+		{Kind: schema.TurnToolResults, Message: llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{
+			{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "p1", IsError: true}},
+		}}},
+		{Kind: schema.TurnAssistant, Message: llm.Assistant("child spend"), Usage: llm.Usage{InputTokens: 100, OutputTokens: 10, TotalTokens: 110}},
+	})
+
+	usage, failures := requireDerivedTotalsFromFile(t, NewTurnCache(), path, testMaxLineBytes, 4)
+	wantUsage := &appwire.EvenerUsage{InputTokens: 100, OutputTokens: 10, TotalTokens: 110}
+	if usage == nil || *usage != *wantUsage {
+		t.Fatalf("post-divergence usage = %+v, want %+v (never the parent's prefix)", usage, wantUsage)
+	}
+	if failures != 1 {
+		t.Fatalf("post-divergence failures = %d, want 1 (the child's own; the parent's is excluded but its call still names the result)", failures)
+	}
+	_ = one
+}
+
+// An empty own span reports absent usage, not zero, and a zero failure count is
+// still a real measurement.
+func TestDerivedTotalsFromFileAbsentUsageForEmptySpan(t *testing.T) {
+	path := writeDerivedTotalsTranscript(t, []schema.Turn{
+		{Kind: schema.TurnAssistant, Message: llm.Assistant("parent only"), Usage: llm.Usage{InputTokens: 100, OutputTokens: 10, TotalTokens: 110}},
+	})
+
+	usage, failures := requireDerivedTotalsFromFile(t, NewTurnCache(), path, testMaxLineBytes, 3)
+	if usage != nil {
+		t.Fatalf("usage = %+v, want nil (an unopened fork has spent nothing)", usage)
+	}
+	if failures != 0 {
+		t.Fatalf("failures = %d, want 0", failures)
+	}
+}
+
+// The combined scan memoizes on the same file-identity gate the individual
+// memos use, so a repeat read does not rescan; a grown file does.
+func TestDerivedTotalsFromFileMemoizesByFileIdentity(t *testing.T) {
+	path := writeDerivedTotalsTranscript(t, []schema.Turn{
+		{Kind: schema.TurnAssistant, Message: llm.Assistant("one"), Usage: llm.Usage{InputTokens: 100, OutputTokens: 10, TotalTokens: 110}},
+		{Kind: schema.TurnToolResults, Message: llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{
+			{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "c1", Name: "shell", IsError: true}},
+		}}},
+	})
+	cache := NewTurnCache()
+
+	var scans int64
+	restore := InstallReadObserverForTesting(func(stats ReadStats) { scans += stats.derivedScans })
+	t.Cleanup(restore)
+
+	first, firstFailures := requireDerivedTotalsFromFile(t, cache, path, testMaxLineBytes, 0)
+	second, secondFailures := requireDerivedTotalsFromFile(t, cache, path, testMaxLineBytes, 0)
+	if first == nil || second == nil || *first != *second {
+		t.Fatalf("memoized usage differs: %+v vs %+v", first, second)
+	}
+	if firstFailures != secondFailures {
+		t.Fatalf("memoized failures differ: %d vs %d", firstFailures, secondFailures)
+	}
+	if scans != 1 {
+		t.Fatalf("transcript derived scans = %d, want 1 (second read served from the memo)", scans)
+	}
+}
+
+// A missing or legacy transcript is unknown, not a fabricated zero.
+func TestDerivedTotalsFromFilePropagatesErrors(t *testing.T) {
+	missing := filepathJoinDerivedTotals(t, "absent.transcript.jsonl")
+	if _, _, err := NewTurnCache().DerivedTotalsFromFile(missing, testMaxLineBytes, 0); err == nil {
+		t.Fatal("DerivedTotalsFromFile on a missing transcript returned no error")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("error = %v, want it to wrap os.ErrNotExist", err)
+	}
+
+	legacy := filepathJoinDerivedTotals(t, "legacy.transcript.jsonl")
+	if err := os.WriteFile(legacy, []byte(`{"kind":"header","format_version":1}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := NewTurnCache().DerivedTotalsFromFile(legacy, testMaxLineBytes, 0); err == nil {
+		t.Fatal("DerivedTotalsFromFile on a v1 transcript returned no error; want unknown, not a fabricated figure")
+	}
+}

--- a/internal/apptranscript/derived_totals_test.go
+++ b/internal/apptranscript/derived_totals_test.go
@@ -72,8 +72,6 @@ func requireDerivedTotalsFromFile(t testing.TB, cache *TurnCache, path string, m
 // The combined scan answers exactly what the two individual scans answer:
 // one transcript, both figures, one pass.
 func TestDerivedTotalsFromFileMatchesIndividualScans(t *testing.T) {
-	zero := 0
-	one := 1
 	path := writeDerivedTotalsTranscript(t, []schema.Turn{
 		{Kind: schema.TurnAssistant, Message: llm.Assistant("first"), Usage: llm.Usage{InputTokens: 100, OutputTokens: 10, TotalTokens: 110}},
 		{Kind: schema.TurnAssistant, Message: llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{
@@ -84,11 +82,11 @@ func TestDerivedTotalsFromFileMatchesIndividualScans(t *testing.T) {
 		}}},
 		{Kind: schema.TurnAssistant, Message: llm.Assistant("after failure"), Usage: llm.Usage{InputTokens: 200, OutputTokens: 20, TotalTokens: 220}},
 		{Kind: schema.TurnToolResults, Message: llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{
-			{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "c2", Name: "shell", ToolState: marshalDerivedTotalsToolState(t, map[string]any{"exit_code": one})}},
+			{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "c2", Name: "shell", ToolState: marshalDerivedTotalsToolState(t, map[string]any{"exit_code": 1})}},
 		}}},
 		{Kind: schema.TurnAssistant, Message: llm.Assistant("clean"), Usage: llm.Usage{InputTokens: 50, OutputTokens: 5, TotalTokens: 55}},
 		{Kind: schema.TurnToolResults, Message: llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{
-			{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "c3", Name: "shell", ToolState: marshalDerivedTotalsToolState(t, map[string]any{"exit_code": zero})}},
+			{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "c3", Name: "shell", ToolState: marshalDerivedTotalsToolState(t, map[string]any{"exit_code": 0})}},
 		}}},
 	})
 
@@ -116,7 +114,6 @@ func TestDerivedTotalsFromFileMatchesIndividualScans(t *testing.T) {
 // A fork child's inherited prefix contributes to neither figure, and the
 // failure rule still resolves tool names from inherited calls.
 func TestDerivedTotalsFromFileSkipsInheritedForkPrefix(t *testing.T) {
-	one := 1
 	path := writeDerivedTotalsTranscript(t, []schema.Turn{
 		// Parent's prefix: entry 1 announces a call, entry 2 answers it
 		// with a failure, entry 3 spends tokens.
@@ -143,7 +140,6 @@ func TestDerivedTotalsFromFileSkipsInheritedForkPrefix(t *testing.T) {
 	if failures != 1 {
 		t.Fatalf("post-divergence failures = %d, want 1 (the child's own; the parent's is excluded but its call still names the result)", failures)
 	}
-	_ = one
 }
 
 // An empty own span reports absent usage, not zero, and a zero failure count is

--- a/internal/apptranscript/turn_cache.go
+++ b/internal/apptranscript/turn_cache.go
@@ -45,6 +45,10 @@ type turnCacheEntry struct {
 	// failedToolCalls memoizes FailedToolCallsFromFile's full-transcript
 	// failure count, on the same terms as usageTotal above.
 	failedToolCalls *failedToolCallsMemo
+	// derivedTotals memoizes DerivedTotalsFromFile's combined single-pass scan
+	// (usage sum and failure count together), on the same terms as usageTotal
+	// and failedToolCalls above.
+	derivedTotals *derivedTotalsMemo
 }
 
 // NewTurnCache returns a TurnCache bounded to a default number of transcripts.

--- a/internal/apptranscript/turn_index.go
+++ b/internal/apptranscript/turn_index.go
@@ -62,6 +62,7 @@ type ReadStats struct {
 	rebuilt               bool
 	usageScans            int64
 	failureScans          int64
+	derivedScans          int64
 }
 
 var (


### PR DESCRIPTION
## Summary

A past-session `thread/read` did, per request: a full-transcript scan summing token usage (`UsageTotalFromFile`), a second full scan counting failed tool calls (`FailedToolCallsFromFile`), plus the turn parse — each reading and decoding the same immutable bytes. At 40 MB the two derived scans together were ~64% of a ~1.10s cold read.

`DerivedTotalsFromFile` computes BOTH figures in one scan: same narrow field-for-field decodes, same format gate, same divergence-ordinal attribution cut, same absent-vs-zero and error-surfacing semantics — the union of the two functions it replaces, on the same file-identity memo (evicted together with the parse memo). The hub read path stamps both figures through it; the legacy web workspace surface keeps its usage-only view; a present CumulativeUsage still wins (and that case scans for failures alone, preserving the present-total-wins rule).

## Benchmark (Apple M5 Max, -benchtime 5x -count 3)

- 40.3 MB (75k entries): ~1.10s/op → ~818-838ms/op
- allocations at 40 MB: 6.04M → 4.51M allocs/op (−25%); bytes 1.22 GB → ~875 MB
- 6.4 MB: ~179-203ms/op → ~141-147ms/op

## Verification

- go build/vet, go test ./internal/apptranscript/..., ./cmd/evener-hub/..., make lint all green
- Parity tests: combined scan equals the two individual scans over the same file; fork-prefix exclusion (parent's tokens/failures not charged to the child); absent usage for an empty own span; memoization (exactly 1 derived scan, counted via the read observer); error propagation
- Wire contract unchanged: response shape, windowing, OlderCursor, capabilities, absent-on-error behavior
