### PR TITLE
fix: anchor the mobile composer to the screen bottom

### DIFF
--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/mobile-shell-viewport-height/assert.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/mobile-shell-viewport-height/assert.mjs
@@ -112,6 +112,18 @@ export default async function assert(measurements) {
       }
     }
 
+    // The composer's dock fills the screen's bottom edge: the footer is the
+    // pane's last column item, so its bottom must REACH the visible viewport
+    // bottom, not float above a dead band. Catches a container lift (the old
+    // blanket host padding) in one direction and an overflow push in the
+    // other. Headless env() resolves to 0, so the inset-bearing variant of
+    // this contract is the CSS-source tests' job, not this measurement's.
+    if (measurement.footer && Math.abs(measurement.footer.bottom - visibleViewportHeight) > tolerance) {
+      failures.push(
+        `${fixtureName}: footer chrome ends ${(measurement.footer.bottom - visibleViewportHeight).toFixed(1)}px off the ${visibleViewportHeight}px screen bottom - the composer's dock must fill to the bottom edge`,
+      );
+    }
+
     if (!measurement.shell) failures.push(`${fixtureName}: missing [data-shell]`);
     if (!measurement.pane) failures.push(`${fixtureName}: missing [data-pane]`);
     if (!measurement.paneBody) failures.push(`${fixtureName}: missing [data-pane-body]`);

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/mobile-shell-viewport-height/case.json
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/mobile-shell-viewport-height/case.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-shell-viewport-height",
-  "description": "mobile shell height chain at an explicit 390x844 phone viewport: the shared shell, StackHost top bar/body, pane body, and optional session footer must stay inside the visible viewport for both session and non-session fixtures",
+  "description": "mobile shell height chain at an explicit 390x844 phone viewport: the shared shell, StackHost top bar/body, pane body, and optional session footer must stay inside the visible viewport for both session and non-session fixtures, and the session footer's chrome must reach the screen's bottom edge (the composer's dock fills the bottom; only its controls are inset)",
   "viewport": {
     "width": 390,
     "height": 844,

--- a/cmd/evener-hub/frontend/src/shell/mobile/StackHost.module.css
+++ b/cmd/evener-hub/frontend/src/shell/mobile/StackHost.module.css
@@ -3,13 +3,14 @@
   flex-direction: column;
   height: 100%;
   background: var(--surface-0);
-  /* Requirement 4 (wave-3 plan, Task 4): keeps the stack's own bottom edge
-   * clear of a device's home-indicator/gesture-bar cutout. The composer a
-   * session pane grows in wave 5 will need its OWN safe-area accommodation
-   * where it actually docks (typically as its own fixed/sticky bottom bar,
-   * not this container's padding) - noted here, not built, since no
-   * composer exists yet this wave. */
-  padding-bottom: env(safe-area-inset-bottom);
+  /* No bottom safe-area padding here (the requirement-4 note that used to
+   * live on this rule): a blanket container inset lifted the whole stack -
+   * the session pane's docked composer footer included - off the screen's
+   * bottom edge, leaving a dead surface-0 band under the input. The
+   * accommodation lives where content actually docks: PaneScaffold's footer
+   * (the composer's own bar, whose chrome fills the home-indicator band
+   * while its padding keeps the controls clear) and body (end-of-scroll
+   * content on footer-less panes). */
 }
 
 .topBar {

--- a/cmd/evener-hub/frontend/src/shell/mobile/StackHost.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/mobile/StackHost.test.tsx
@@ -706,16 +706,25 @@ test("mounting already at the focused pane's own URL does not dispatch a redunda
   expect(handler).not.toHaveBeenCalled();
 });
 
-// --- bottom safe-area padding (requirement 4) ------------------------
+// --- bottom safe-area accommodation (requirement 4) -------------------
 //
-// jsdom does not evaluate real CSS (env(), viewport units, etc.), so - same
-// idiom as sheet.test.tsx's own prefers-reduced-motion check - this reads
-// the CSS module's own source rather than asserting on computed style.
+// The blanket host padding that used to carry the bottom inset lifted the
+// whole stack - docked composer footer included - off the screen's bottom
+// edge, leaving a dead surface-0 band under the input. The accommodation
+// moved to where the composer docks (PaneScaffold's footer and body rules);
+// the host deliberately carries none of it so the pane chrome fills to the
+// bottom edge. jsdom does not evaluate real CSS (env(), viewport units,
+// etc.), so - same idiom as sheet.test.tsx's own prefers-reduced-motion
+// check - this reads the CSS module's own source rather than asserting on
+// computed style, comments stripped so the .host comment's own mention of
+// the inset cannot false-positive the match.
 
-test("the stack container reserves the device's bottom safe-area inset", () => {
+test("the host lifts nothing off the bottom edge - docked chrome owns the bottom inset", () => {
   const here = dirname(fileURLToPath(import.meta.url));
-  const css = readFileSync(join(here, "StackHost.module.css"), "utf8");
-  expect(css).toContain("env(safe-area-inset-bottom)");
+  const css = readFileSync(join(here, "StackHost.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+  expect(css).not.toContain("env(safe-area-inset-bottom)");
+  const hostRule = css.match(/\.host \{([^}]*)\}/)?.[1] ?? "";
+  expect(hostRule).not.toContain("padding-bottom");
 });
 
 test("the top bar reserves the device's top safe-area inset", () => {

--- a/cmd/evener-hub/frontend/src/widgets/panescaffold/panescaffold.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/panescaffold/panescaffold.module.css
@@ -80,11 +80,25 @@
    * a horizontal scrollbar. */
   overflow-x: clip;
   padding: var(--space-4);
+  /* End-of-scroll content stays clear of a phone's home-indicator band now
+   * that StackHost's blanket host padding is gone (see that rule's comment):
+   * footer-less panes (welcome, settings, spawn, doc) dock nothing of their
+   * own, so their scroll padding carries the inset. env() is 0 on desktop,
+   * where this resolves to plain --space-4. */
+  padding-bottom: calc(var(--space-4) + env(safe-area-inset-bottom));
 }
 
 .footer {
   flex: none;
   padding: var(--space-3) var(--space-4);
+  /* The composer docks here (Session.tsx): its safe-area accommodation
+   * belongs on this bar, not on a container (the old StackHost host padding
+   * lifted the whole pane off the screen's bottom edge, leaving a dead band
+   * under the input). The footer's own chrome fills the home-indicator band
+   * while this padding keeps the composer controls above it - the same
+   * recipe StackHost's top bar uses at the top edge. env() is 0 on desktop,
+   * where this resolves to plain --space-3. */
+  padding-bottom: calc(var(--space-3) + env(safe-area-inset-bottom));
   border-top: 1px solid var(--edge);
 }
 

--- a/cmd/evener-hub/frontend/src/widgets/panescaffold/panescaffold.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/panescaffold/panescaffold.test.tsx
@@ -174,6 +174,31 @@ test("the question footer fits short content and caps tall content", () => {
   expect(css).toContain("max-height: 70%");
 });
 
+// The composer's bottom safe-area accommodation lives where it docks - this
+// footer - not on StackHost's container (StackHost.module.css's .host
+// comment): the footer's own chrome fills the home-indicator band while its
+// padding keeps the composer controls above it. env() is 0 on desktop, so
+// the padding resolves to plain --space-3 there.
+test("the footer fills to the screen's bottom edge while keeping its content clear of the home indicator", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // Comments stripped: the rule's own comment names the inset (testing.md's
+  // "a stylesheet assertion that matches its own comment" trap).
+  const css = readFileSync(join(here, "panescaffold.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+  const footerRule = css.match(/\.footer \{([^}]*)\}/)?.[1] ?? "";
+  expect(footerRule).toContain("padding-bottom: calc(var(--space-3) + env(safe-area-inset-bottom))");
+});
+
+// Footer-less panes (welcome, settings, spawn, doc) had their end-of-scroll
+// content covered by StackHost's blanket host padding; with that gone (the
+// composer owns its own dock), the body's scroll padding carries the inset
+// so the last content still clears the home indicator.
+test("the body keeps end-of-scroll content clear of the home indicator", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const css = readFileSync(join(here, "panescaffold.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+  const bodyRule = css.match(/\.body \{([^}]*)\}/)?.[1] ?? "";
+  expect(bodyRule).toContain("padding-bottom: calc(var(--space-4) + env(safe-area-inset-bottom))");
+});
+
 // The chrome-store title channel (2026-07-30-mobile-session-layout-design.md,
 // decision 2): PaneScaffold always publishes its title, host-agnostically -
 // StackHost renders it in the mobile top bar, DockHost never reads it.


### PR DESCRIPTION
## Problem

On phones with a home indicator, the mobile session UI stopped short of the screen's bottom edge: a dead band of empty shell background sat below the composer, and the input floated above it. Measured on an iPhone 16 Pro screenshot: a ~137 device px band, exactly the 34pt safe-area inset (102px) plus the footer's 12px padding (36px) at 3x.

**Root cause:** `StackHost.module.css .host` carried a blanket `padding-bottom: env(safe-area-inset-bottom)`, which lifted the entire pane stack — including the session pane's docked composer footer — off the screen's bottom edge. The band below the pane rendered the host's `--surface-0` background. The rule's own comment had anticipated the fix: the composer's safe-area accommodation belongs "where it actually docks … not this container's padding."

## Fix

Move the bottom safe-area accommodation from the host container to where content docks (CSS only):

- **`StackHost.module.css .host`** — blanket padding removed; the pane now reaches the screen's bottom edge.
- **`panescaffold.module.css .footer`** — `padding-bottom: calc(var(--space-3) + env(safe-area-inset-bottom))`: the composer dock's own chrome fills the home-indicator band while its controls stay clear of it — the same recipe StackHost's top bar uses at the top edge.
- **`panescaffold.module.css .body`** — equivalent `calc(var(--space-4) + env(...))` scroll padding, so footer-less panes (welcome, settings, spawn, doc) keep end-of-scroll content clear of the home indicator, which the host padding used to do for them.

Desktop is unchanged: `env()` resolves to 0 there, so both paddings compute to their previous values.

## Verification

- **TDD, red-first:** 3 new/rewritten vitest contract tests failed pre-fix for the expected reason, now pass (63/63 in the touched files). CSS-source assertions strip comments before matching (testing.md's matching-your-own-comment trap).
- **New layoutguard assertion** — the session footer's chrome must reach the visible viewport bottom — can-fail proven against a simulated container lift ("footer chrome ends -24.0px off the 844px screen bottom"), probe then reverted.
- **`make test-web`** PASS (typecheck, vitest, biome) on the committed tree; **`make test-web-browser`** PASS (layoutguard, overflowguard, shellguard, spawnguard).
- **Real Chrome at 390×844** on the live dev server: shell/host/pane/body all reach exactly 844px, no document scroll, and the served CSS carries both new inset rules.

One limitation: desktop Chrome reports `env(safe-area-inset-bottom)` as 0 even in device emulation, so the actual 34px inset behavior wants a real-device eyeball (reload on a phone: the composer dock should sit flush at the bottom with the input clear of the home indicator). The inset contract is pinned by the CSS-source tests, and `viewport-fit=cover` (which makes the insets nonzero) was already pinned by `viewport-pin.test.ts`.