### PR TITLE
refactor(agent): unify delegate run-end classification

### DIFF
--- a/agent/delegate_tree_finish.go
+++ b/agent/delegate_tree_finish.go
@@ -47,7 +47,7 @@ func (c *delegateTreeController) SupervisionBoundary(lease delegateLease, mode d
 	if err != nil {
 		return delegateSupervisionSuppress, err
 	}
-	if c.closing || aggregate.Phase == delegatestore.PhaseStopping || aggregate.PendingStopSeq != 0 || live.recoveryRequired {
+	if c.supervisionSuppressedLocked(aggregate, live) {
 		return delegateSupervisionSuppress, nil
 	}
 	if aggregate.Phase != delegatestore.PhaseRunning || !aggregate.Resumable || live.binding == nil || !live.binding.ready {
@@ -57,6 +57,16 @@ func (c *delegateTreeController) SupervisionBoundary(lease delegateLease, mode d
 		return delegateSupervisionContinue, nil
 	}
 	return delegateSupervisionProceed, nil
+}
+
+// supervisionSuppressedLocked reports whether ordinary supervision must be
+// suppressed because the controller is closing, the generation is stopping or
+// stop-pending, or its live state needs recovery. It is the single
+// suppression predicate behind SupervisionBoundary's suppress-without-cause
+// branch; the not-running/not-ready path (errDelegateTargetBusy) is a
+// different case and deliberately not covered here. Caller holds c.mu.
+func (c *delegateTreeController) supervisionSuppressedLocked(aggregate *delegatestore.Aggregate, live *delegateLiveState) bool {
+	return c.closing || aggregate.Phase == delegatestore.PhaseStopping || aggregate.PendingStopSeq != 0 || live.recoveryRequired
 }
 
 // BeginSettlement makes the final pending-steer decision and fences new work

--- a/agent/delegate_tree_finish.go
+++ b/agent/delegate_tree_finish.go
@@ -59,12 +59,10 @@ func (c *delegateTreeController) SupervisionBoundary(lease delegateLease, mode d
 	return delegateSupervisionProceed, nil
 }
 
-// supervisionSuppressedLocked reports whether ordinary supervision must be
-// suppressed because the controller is closing, the generation is stopping or
-// stop-pending, or its live state needs recovery. It is the single
-// suppression predicate behind SupervisionBoundary's suppress-without-cause
-// branch; the not-running/not-ready path (errDelegateTargetBusy) is a
-// different case and deliberately not covered here. Caller holds c.mu.
+// supervisionSuppressedLocked reports whether ordinary supervision must be suppressed
+// (controller closing, generation stopping or stop-pending, or recovery required).
+// The not-running/not-ready path (errDelegateTargetBusy) is not part of this predicate.
+// Caller holds c.mu.
 func (c *delegateTreeController) supervisionSuppressedLocked(aggregate *delegatestore.Aggregate, live *delegateLiveState) bool {
 	return c.closing || aggregate.Phase == delegatestore.PhaseStopping || aggregate.PendingStopSeq != 0 || live.recoveryRequired
 }

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -1740,7 +1740,12 @@ func (a *subagent) run(ctx context.Context, input string, inputProvenance *prove
 	a.endedAt = &finalizeTime
 	runEnd := classifyRunEnd(err, a.cancelRequested)
 	a.status = runEnd.status
-	if runEnd.exhaustion != nil {
+	// The exhaustion payload replaces the run error only when the exhausted
+	// status branch actually matched: a cancelled run whose error is
+	// Join(context.Canceled, budgetExhaustionError) publishes Cancelled and
+	// keeps the joined error verbatim (the pre-classifier switch overwrote
+	// a.err only inside its budgetExhausted case).
+	if runEnd.status == SubagentExhausted {
 		a.err = runEnd.exhaustion
 	}
 	done := a.done

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -1718,8 +1718,6 @@ func (a *subagent) run(ctx context.Context, input string, inputProvenance *prove
 		}
 		break
 	}
-	exhaustion, budgetExhausted := budgetExhaustionFromError(err)
-
 	a.sess.mu.Lock()
 	turns := a.sess.turns
 	a.sess.mu.Unlock()
@@ -1740,16 +1738,10 @@ func (a *subagent) run(ctx context.Context, input string, inputProvenance *prove
 	a.running = false
 	a.turnsUsed = turns
 	a.endedAt = &finalizeTime
-	switch {
-	case a.cancelRequested && errors.Is(err, context.Canceled):
-		a.status = SubagentCancelled
-	case budgetExhausted:
-		a.status = SubagentExhausted
-		a.err = exhaustion
-	case err != nil:
-		a.status = SubagentFailed
-	default:
-		a.status = SubagentCompleted
+	runEnd := classifyRunEnd(err, a.cancelRequested)
+	a.status = runEnd.status
+	if runEnd.exhaustion != nil {
+		a.err = runEnd.exhaustion
 	}
 	done := a.done
 	a.endEmitted = true
@@ -1819,25 +1811,72 @@ func (a *subagent) drainForFinalization(ctx context.Context, result string) (str
 	return result, parentDriveNotify, nil
 }
 
-func delegateSettlementModeForRun(err error, cancelRequested bool) delegateSettlementMode {
+// runEndClass is the shared classification of a delegate run's terminal
+// error, with the three projections every consumer derives from the same
+// taxonomy: settlement mode (can the run still be nudged or steered),
+// fatality (should the error be gated as a fatal run), and the published
+// subagent status.
+type runEndClass struct {
+	mode       delegateSettlementMode
+	fatal      bool
+	status     SubagentStatus
+	exhaustion *budgetExhaustionError
+}
+
+// classifyRunEnd maps a run error plus the local cancel request onto the
+// settlement-mode, fatality, and status projections in one pattern-match over
+// the run-end taxonomy. It is pure: no locking, I/O, Session, or controller
+// access. Pins:
+//
+//   - Settlement mode is terminal when cancelRequested regardless of err,
+//     while SubagentCancelled additionally requires errors.Is(err,
+//     context.Canceled). The two are deliberately distinct; one is "this
+//     runtime can no longer settle ordinarily", the other is "the user
+//     stopped this run".
+//   - Budget exhaustion is terminal settlement, published as status
+//     Exhausted, never fatal, and its payload replaces the run error in the
+//     subagent's terminal state (the caller applies runEnd.exhaustion).
+//   - context.Canceled is never fatal even when cancelRequested is false —
+//     a host interrupt, not a user stop.
+//   - errors.Is/errors.As semantics are preserved for wrapped and joined
+//     (errors.Join) error values, matching the pre-refactor matching.
+func classifyRunEnd(err error, cancelRequested bool) runEndClass {
+	exhaustion, budgetExhausted := budgetExhaustionFromError(err)
+	// Order matters for joined errors: the pre-refactor settlement-mode
+	// logic tested budget exhaustion BEFORE the bare-text/empty-response
+	// sentinels, so Join(bareText, exhaustion) settles terminally.
+	ordinary := !budgetExhausted && (err == nil ||
+		errors.Is(err, errBareTextWithoutResultTool) || errors.Is(err, errEmptyResponseExhausted))
+	nonFatal := err == nil || errors.Is(err, context.Canceled) || ordinary || budgetExhausted
+	cls := runEndClass{exhaustion: exhaustion}
 	if cancelRequested {
-		return delegateSettlementTerminal
+		// Cancel-requested runs always settle terminally, regardless of err.
+		cls.mode = delegateSettlementTerminal
+	} else if ordinary {
+		cls.mode = delegateSettlementOrdinary
+	} else {
+		cls.mode = delegateSettlementTerminal
 	}
-	if _, exhausted := budgetExhaustionFromError(err); exhausted {
-		return delegateSettlementTerminal
+	cls.fatal = !nonFatal
+	switch {
+	case cancelRequested && errors.Is(err, context.Canceled):
+		cls.status = SubagentCancelled
+	case budgetExhausted:
+		cls.status = SubagentExhausted
+	case err != nil:
+		cls.status = SubagentFailed
+	default:
+		cls.status = SubagentCompleted
 	}
-	if err == nil || errors.Is(err, errBareTextWithoutResultTool) || errors.Is(err, errEmptyResponseExhausted) {
-		return delegateSettlementOrdinary
-	}
-	return delegateSettlementTerminal
+	return cls
+}
+
+func delegateSettlementModeForRun(err error, cancelRequested bool) delegateSettlementMode {
+	return classifyRunEnd(err, cancelRequested).mode
 }
 
 func stableDelegateFatalRun(err error) bool {
-	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, errBareTextWithoutResultTool) || errors.Is(err, errEmptyResponseExhausted) {
-		return false
-	}
-	_, exhausted := budgetExhaustionFromError(err)
-	return !exhausted
+	return classifyRunEnd(err, false).fatal
 }
 
 func stableDelegateFinish(sess *Session, result string, runErr error) delegateFinish {

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -1740,12 +1740,9 @@ func (a *subagent) run(ctx context.Context, input string, inputProvenance *prove
 	a.endedAt = &finalizeTime
 	runEnd := classifyRunEnd(err, a.cancelRequested)
 	a.status = runEnd.status
-	// The exhaustion payload replaces the run error only when the exhausted
-	// status branch actually matched: a cancelled run whose error is
-	// Join(context.Canceled, budgetExhaustionError) publishes Cancelled and
-	// keeps the joined error verbatim (the pre-classifier switch overwrote
-	// a.err only inside its budgetExhausted case).
-	if runEnd.status == SubagentExhausted {
+	// The payload is non-nil exactly when the run published Exhausted
+	// (classifier contract), so its presence alone is the overwrite decision.
+	if runEnd.exhaustion != nil {
 		a.err = runEnd.exhaustion
 	}
 	done := a.done
@@ -1816,48 +1813,41 @@ func (a *subagent) drainForFinalization(ctx context.Context, result string) (str
 	return result, parentDriveNotify, nil
 }
 
-// runEndClass is the shared classification of a delegate run's terminal
-// error, with the three projections every consumer derives from the same
-// taxonomy: settlement mode (can the run still be nudged or steered),
-// fatality (should the error be gated as a fatal run), and the published
-// subagent status.
+// runEndClass is the shared classification of a delegate run's terminal error.
 type runEndClass struct {
-	mode       delegateSettlementMode
-	fatal      bool
-	status     SubagentStatus
+	mode   delegateSettlementMode
+	fatal  bool
+	status SubagentStatus
+	// exhaustion is non-nil exactly when status == SubagentExhausted; its
+	// presence is the caller's decision to replace the run error, so a
+	// cancelled run whose error also carries a budget component never sees it.
 	exhaustion *budgetExhaustionError
 }
 
 // classifyRunEnd maps a run error plus the local cancel request onto the
 // settlement-mode, fatality, and status projections in one pattern-match over
 // the run-end taxonomy. It is pure: no locking, I/O, Session, or controller
-// access. Pins:
+// access. Load-bearing pins:
 //
 //   - Settlement mode is terminal when cancelRequested regardless of err,
 //     while SubagentCancelled additionally requires errors.Is(err,
-//     context.Canceled). The two are deliberately distinct; one is "this
-//     runtime can no longer settle ordinarily", the other is "the user
-//     stopped this run".
-//   - Budget exhaustion is terminal settlement, published as status
-//     Exhausted, never fatal, and its payload replaces the run error in the
-//     subagent's terminal state (the caller applies runEnd.exhaustion).
+//     context.Canceled): "this runtime can no longer settle ordinarily" vs
+//     "the user stopped this run".
+//   - Budget exhaustion is tested BEFORE the bare-text/empty-response
+//     sentinels (so Join(bareText, exhaustion) settles terminally), and a
+//     joined exhaustion+Canceled under cancel still publishes Cancelled with
+//     no exhaustion payload — the error is kept verbatim there.
 //   - context.Canceled is never fatal even when cancelRequested is false —
 //     a host interrupt, not a user stop.
 //   - errors.Is/errors.As semantics are preserved for wrapped and joined
-//     (errors.Join) error values, matching the pre-refactor matching.
+//     (errors.Join) error values.
 func classifyRunEnd(err error, cancelRequested bool) runEndClass {
 	exhaustion, budgetExhausted := budgetExhaustionFromError(err)
-	// Order matters for joined errors: the pre-refactor settlement-mode
-	// logic tested budget exhaustion BEFORE the bare-text/empty-response
-	// sentinels, so Join(bareText, exhaustion) settles terminally.
 	ordinary := !budgetExhausted && (err == nil ||
 		errors.Is(err, errBareTextWithoutResultTool) || errors.Is(err, errEmptyResponseExhausted))
-	nonFatal := err == nil || errors.Is(err, context.Canceled) || ordinary || budgetExhausted
-	cls := runEndClass{exhaustion: exhaustion}
-	if cancelRequested {
-		// Cancel-requested runs always settle terminally, regardless of err.
-		cls.mode = delegateSettlementTerminal
-	} else if ordinary {
+	nonFatal := ordinary || budgetExhausted || errors.Is(err, context.Canceled)
+	var cls runEndClass
+	if !cancelRequested && ordinary {
 		cls.mode = delegateSettlementOrdinary
 	} else {
 		cls.mode = delegateSettlementTerminal
@@ -1868,6 +1858,7 @@ func classifyRunEnd(err error, cancelRequested bool) runEndClass {
 		cls.status = SubagentCancelled
 	case budgetExhausted:
 		cls.status = SubagentExhausted
+		cls.exhaustion = exhaustion
 	case err != nil:
 		cls.status = SubagentFailed
 	default:

--- a/agent/subagents_classify_run_end_test.go
+++ b/agent/subagents_classify_run_end_test.go
@@ -71,12 +71,13 @@ func TestClassifyRunEnd(t *testing.T) {
 		{name: "cancel with empty response", err: errEmptyResponseExhausted, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentFailed},
 		// Budget exhaustion wins the status projection over the cancel
 		// branch ONLY when the error is not ctx.Canceled (the original
-		// switch ordered Cancelled first); its payload must be exposed for
-		// the a.err overwrite.
+		// switch ordered Cancelled first). A cancelled run carries NO
+		// exhaustion payload — the caller's a.err overwrite keys on payload
+		// presence, so the joined error must be kept verbatim.
 		{name: "cancel with turns exhaustion", err: turnsExhausted, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentExhausted, exhaustion: turnsExhausted},
 		{name: "cancel with tool-rounds exhaustion", err: toolRoundsExhausted, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentExhausted, exhaustion: toolRoundsExhausted},
 		{name: "cancel with generic err", err: errors.New("boom"), cancel: true, mode: delegateSettlementTerminal, fatal: true, status: SubagentFailed},
-		{name: "cancel with joined exhaustion+canceled", err: joinedExhaustionAndCanceled, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentCancelled, exhaustion: toolRoundsExhausted},
+		{name: "cancel with joined exhaustion+canceled", err: joinedExhaustionAndCanceled, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentCancelled},
 		{name: "cancel with joined generic+canceled", err: joinedGenericAndCanceled, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentCancelled},
 		{name: "cancel with joined generic+bare-text", err: joinedGenericAndBareText, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentFailed},
 		{name: "cancel with joined bare-text+exhaustion", err: joinedBareTextAndExhaustion, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentExhausted, exhaustion: turnsExhausted},
@@ -126,6 +127,14 @@ func TestClassifyRunEndProjectionsMatchLegacySites(t *testing.T) {
 					joined = errors.Join(base, extra)
 				}
 			}
+			// Loop-invariant precomputations for both cancelRequested values.
+			_, exhausted := budgetExhaustionFromError(joined)
+			wantFatal := joined != nil &&
+				!errors.Is(joined, context.Canceled) &&
+				!errors.Is(joined, errBareTextWithoutResultTool) &&
+				!errors.Is(joined, errEmptyResponseExhausted) &&
+				!exhausted
+			exhaustion, budgetExhausted := budgetExhaustionFromError(joined)
 			for _, cancelRequested := range []bool{false, true} {
 				cls := classifyRunEnd(joined, cancelRequested)
 
@@ -143,18 +152,11 @@ func TestClassifyRunEndProjectionsMatchLegacySites(t *testing.T) {
 				}
 
 				// Site 2: stableDelegateFatalRun (subagents.go).
-				_, exhausted := budgetExhaustionFromError(joined)
-				wantFatal := joined != nil &&
-					!errors.Is(joined, context.Canceled) &&
-					!errors.Is(joined, errBareTextWithoutResultTool) &&
-					!errors.Is(joined, errEmptyResponseExhausted) &&
-					!exhausted
 				if cls.fatal != wantFatal {
 					t.Errorf("err=%v cancel=%t: fatal=%v, want %v", joined, cancelRequested, cls.fatal, wantFatal)
 				}
 
 				// Site 3: the final-status switch in (*subagent).run.
-				exhaustion, budgetExhausted := budgetExhaustionFromError(joined)
 				var wantStatus SubagentStatus
 				switch {
 				case cancelRequested && errors.Is(joined, context.Canceled):
@@ -169,8 +171,12 @@ func TestClassifyRunEndProjectionsMatchLegacySites(t *testing.T) {
 				if cls.status != wantStatus {
 					t.Errorf("err=%v cancel=%t: status=%q, want %q", joined, cancelRequested, cls.status, wantStatus)
 				}
-				if cls.exhaustion != exhaustion {
-					t.Errorf("err=%v: exhaustion payload = %v, want %v", joined, cls.exhaustion, exhaustion)
+				wantExhaustion := exhaustion
+				if wantStatus != SubagentExhausted {
+					wantExhaustion = nil
+				}
+				if cls.exhaustion != wantExhaustion {
+					t.Errorf("err=%v cancel=%t: exhaustion payload = %v, want %v", joined, cancelRequested, cls.exhaustion, wantExhaustion)
 				}
 			}
 		}

--- a/agent/subagents_classify_run_end_test.go
+++ b/agent/subagents_classify_run_end_test.go
@@ -1,0 +1,178 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// TestClassifyRunEnd pins the shared run-end taxonomy table: for every input
+// class in the matrix (nil, canceled, wrapped canceled, bare-text,
+// empty-response, each budget type, generic error, joined combos) and both
+// cancelRequested values, the settlement-mode, fatality, status, and
+// exhaustion-payload projections must match the pre-refactor per-site logic:
+//
+//   - delegateSettlementModeForRun: terminal iff cancelRequested,
+//     budget-exhausted, or any error outside {nil, bare-text,
+//     empty-response}. Budget exhaustion is tested BEFORE the
+//     bare-text/empty-response sentinels, so Join(bareText, exhaustion)
+//     settles terminally.
+//   - stableDelegateFatalRun: fatal iff err non-nil AND NOT (canceled,
+//     bare-text, empty-response, budget-exhausted). cancelRequested is not an
+//     input — a cancellation without ctx.Canceled is NOT fatal.
+//   - (*subagent).run final-status switch: Cancelled iff cancelRequested AND
+//     errors.Is(err, context.Canceled); else Exhausted iff budget-exhausted
+//     (with the exhaustion payload exposed for the a.err overwrite); else
+//     Failed iff err non-nil; else Completed.
+func TestClassifyRunEnd(t *testing.T) {
+	turnsExhausted := &budgetExhaustionError{Budget: exhaustedBudgetTurns, Limit: 23, Resumable: false}
+	toolRoundsExhausted := &budgetExhaustionError{Budget: exhaustedBudgetToolRounds, Limit: 17, Resumable: true}
+	wrappedCanceled := fmt.Errorf("provider stream: %w", context.Canceled)
+	wrappedBareText := fmt.Errorf("round ended: %w", errBareTextWithoutResultTool)
+	joinedExhaustionAndCanceled := errors.Join(toolRoundsExhausted, context.Canceled)
+	joinedGenericAndCanceled := errors.Join(errors.New("boom"), context.Canceled)
+	joinedGenericAndBareText := errors.Join(errors.New("boom"), errBareTextWithoutResultTool)
+	joinedBareTextAndExhaustion := errors.Join(errBareTextWithoutResultTool, turnsExhausted)
+
+	cases := []struct {
+		name       string
+		err        error
+		cancel     bool
+		mode       delegateSettlementMode
+		fatal      bool
+		status     SubagentStatus
+		exhaustion *budgetExhaustionError
+	}{
+		// --- cancelRequested = false ---
+		{name: "nil", err: nil, cancel: false, mode: delegateSettlementOrdinary, fatal: false, status: SubagentCompleted},
+		{name: "canceled", err: context.Canceled, cancel: false, mode: delegateSettlementTerminal, fatal: false, status: SubagentFailed},
+		{name: "wrapped canceled", err: wrappedCanceled, cancel: false, mode: delegateSettlementTerminal, fatal: false, status: SubagentFailed},
+		{name: "bare text", err: errBareTextWithoutResultTool, cancel: false, mode: delegateSettlementOrdinary, fatal: false, status: SubagentFailed},
+		{name: "wrapped bare text", err: wrappedBareText, cancel: false, mode: delegateSettlementOrdinary, fatal: false, status: SubagentFailed},
+		{name: "empty response", err: errEmptyResponseExhausted, cancel: false, mode: delegateSettlementOrdinary, fatal: false, status: SubagentFailed},
+		{name: "turns exhaustion", err: turnsExhausted, cancel: false, mode: delegateSettlementTerminal, fatal: false, status: SubagentExhausted, exhaustion: turnsExhausted},
+		{name: "tool-rounds exhaustion", err: toolRoundsExhausted, cancel: false, mode: delegateSettlementTerminal, fatal: false, status: SubagentExhausted, exhaustion: toolRoundsExhausted},
+		{name: "generic error", err: errors.New("boom"), cancel: false, mode: delegateSettlementTerminal, fatal: true, status: SubagentFailed},
+		{name: "joined exhaustion+canceled", err: joinedExhaustionAndCanceled, cancel: false, mode: delegateSettlementTerminal, fatal: false, status: SubagentExhausted, exhaustion: toolRoundsExhausted},
+		{name: "joined generic+canceled", err: joinedGenericAndCanceled, cancel: false, mode: delegateSettlementTerminal, fatal: false, status: SubagentFailed},
+		{name: "joined generic+bare-text", err: joinedGenericAndBareText, cancel: false, mode: delegateSettlementOrdinary, fatal: false, status: SubagentFailed},
+		// Exhaustion precedence over the bare-text sentinel in settlement mode.
+		{name: "joined bare-text+exhaustion", err: joinedBareTextAndExhaustion, cancel: false, mode: delegateSettlementTerminal, fatal: false, status: SubagentExhausted, exhaustion: turnsExhausted},
+
+		// --- cancelRequested = true ---
+		// Mode is terminal regardless of err; status Cancelled additionally
+		// requires errors.Is(err, context.Canceled). Fatality never depends
+		// on cancelRequested (a cancel without ctx.Canceled is not fatal).
+		{name: "cancel with nil err", err: nil, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentCompleted},
+		{name: "cancel with canceled err", err: context.Canceled, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentCancelled},
+		{name: "cancel with wrapped canceled err", err: wrappedCanceled, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentCancelled},
+		{name: "cancel with bare text", err: errBareTextWithoutResultTool, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentFailed},
+		{name: "cancel with empty response", err: errEmptyResponseExhausted, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentFailed},
+		// Budget exhaustion wins the status projection over the cancel
+		// branch ONLY when the error is not ctx.Canceled (the original
+		// switch ordered Cancelled first); its payload must be exposed for
+		// the a.err overwrite.
+		{name: "cancel with turns exhaustion", err: turnsExhausted, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentExhausted, exhaustion: turnsExhausted},
+		{name: "cancel with tool-rounds exhaustion", err: toolRoundsExhausted, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentExhausted, exhaustion: toolRoundsExhausted},
+		{name: "cancel with generic err", err: errors.New("boom"), cancel: true, mode: delegateSettlementTerminal, fatal: true, status: SubagentFailed},
+		{name: "cancel with joined exhaustion+canceled", err: joinedExhaustionAndCanceled, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentCancelled, exhaustion: toolRoundsExhausted},
+		{name: "cancel with joined generic+canceled", err: joinedGenericAndCanceled, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentCancelled},
+		{name: "cancel with joined generic+bare-text", err: joinedGenericAndBareText, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentFailed},
+		{name: "cancel with joined bare-text+exhaustion", err: joinedBareTextAndExhaustion, cancel: true, mode: delegateSettlementTerminal, fatal: false, status: SubagentExhausted, exhaustion: turnsExhausted},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cls := classifyRunEnd(tc.err, tc.cancel)
+			if cls.mode != tc.mode {
+				t.Errorf("mode = %v, want %v", cls.mode, tc.mode)
+			}
+			if cls.fatal != tc.fatal {
+				t.Errorf("fatal = %v, want %v", cls.fatal, tc.fatal)
+			}
+			if cls.status != tc.status {
+				t.Errorf("status = %q, want %q", cls.status, tc.status)
+			}
+			if cls.exhaustion != tc.exhaustion {
+				t.Errorf("exhaustion = %v, want %v", cls.exhaustion, tc.exhaustion)
+			}
+		})
+	}
+}
+
+// TestClassifyRunEndProjectionsMatchLegacySites cross-checks the classifier
+// against the original per-site logic over an expanded join matrix, guarding
+// the behavior-preserving property directly rather than only the pinned
+// table above.
+func TestClassifyRunEndProjectionsMatchLegacySites(t *testing.T) {
+	baseErrs := []error{
+		nil,
+		context.Canceled,
+		errBareTextWithoutResultTool,
+		errEmptyResponseExhausted,
+		errors.New("generic"),
+		&budgetExhaustionError{Budget: exhaustedBudgetTurns, Limit: 23, Resumable: false},
+		&budgetExhaustionError{Budget: exhaustedBudgetToolRounds, Limit: 17, Resumable: true},
+	}
+	extras := []error{nil, context.Canceled, errBareTextWithoutResultTool, errors.New("other")}
+	for _, base := range baseErrs {
+		for _, extra := range extras {
+			joined := base
+			if extra != nil {
+				if base == nil {
+					joined = extra
+				} else {
+					joined = errors.Join(base, extra)
+				}
+			}
+			for _, cancelRequested := range []bool{false, true} {
+				cls := classifyRunEnd(joined, cancelRequested)
+
+				// Site 1: delegateSettlementModeForRun (subagents.go).
+				wantMode := delegateSettlementTerminal
+				if !cancelRequested {
+					_, exhausted := budgetExhaustionFromError(joined)
+					if !exhausted && (joined == nil ||
+						errors.Is(joined, errBareTextWithoutResultTool) || errors.Is(joined, errEmptyResponseExhausted)) {
+						wantMode = delegateSettlementOrdinary
+					}
+				}
+				if cls.mode != wantMode {
+					t.Errorf("err=%v cancel=%t: mode=%v, want %v", joined, cancelRequested, cls.mode, wantMode)
+				}
+
+				// Site 2: stableDelegateFatalRun (subagents.go).
+				_, exhausted := budgetExhaustionFromError(joined)
+				wantFatal := joined != nil &&
+					!errors.Is(joined, context.Canceled) &&
+					!errors.Is(joined, errBareTextWithoutResultTool) &&
+					!errors.Is(joined, errEmptyResponseExhausted) &&
+					!exhausted
+				if cls.fatal != wantFatal {
+					t.Errorf("err=%v cancel=%t: fatal=%v, want %v", joined, cancelRequested, cls.fatal, wantFatal)
+				}
+
+				// Site 3: the final-status switch in (*subagent).run.
+				exhaustion, budgetExhausted := budgetExhaustionFromError(joined)
+				var wantStatus SubagentStatus
+				switch {
+				case cancelRequested && errors.Is(joined, context.Canceled):
+					wantStatus = SubagentCancelled
+				case budgetExhausted:
+					wantStatus = SubagentExhausted
+				case joined != nil:
+					wantStatus = SubagentFailed
+				default:
+					wantStatus = SubagentCompleted
+				}
+				if cls.status != wantStatus {
+					t.Errorf("err=%v cancel=%t: status=%q, want %q", joined, cancelRequested, cls.status, wantStatus)
+				}
+				if cls.exhaustion != exhaustion {
+					t.Errorf("err=%v: exhaustion payload = %v, want %v", joined, cls.exhaustion, exhaustion)
+				}
+			}
+		}
+	}
+}

--- a/agent/subagents_test.go
+++ b/agent/subagents_test.go
@@ -451,6 +451,70 @@ func TestCancelAgent_GenuineFailureRacingCancelStaysFailed(t *testing.T) {
 	}
 }
 
+// TestCancelAgent_JoinedCanceledAndExhaustionStaysCancelledWithJoinedError pins
+// the interaction between the cancelled status and the budget-exhaustion payload
+// when both are present in one joined run error: cancelRequested with
+// errors.Join(context.Canceled, budgetExhaustionError) publishes SubagentCancelled
+// (the cancel branch wins the status) and must keep the joined error verbatim —
+// errors.Is(a.err, context.Canceled) stays true and the exhaustion component is
+// only inside its budgetExhausted case, which this branch never reached.
+func TestCancelAgent_JoinedCanceledAndExhaustionStaysCancelledWithJoinedError(t *testing.T) {
+	t.Parallel()
+	joined := errors.Join(context.Canceled, &budgetExhaustionError{Budget: exhaustedBudgetTurns, Limit: 23, Resumable: false})
+	dir := t.TempDir()
+	c := llm.NewClient()
+	c.Register(&fakeErrAdapter{
+		name: "openai",
+		steps: []func(req llm.Request) (llm.Response, error){
+			func(req llm.Request) (llm.Response, error) {
+				return llm.Response{}, joined
+			},
+		},
+	})
+	noRetry := llm.RetryPolicy{MaxRetries: 0}
+	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
+		MaxSubagentDepth: 1,
+		LLMRetryPolicy:   &noRetry,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sess.Close()
+
+	// The sub drives sub.run directly (not via the manager), so it is
+	// intentionally not tracked; see the note in
+	// TestCancelAgent_GenuineFailureRacingCancelStaysFailed.
+	sub := &subagent{
+		id:              sess.id,
+		sess:            sess,
+		emit:            sess.emit,
+		running:         true,
+		status:          SubagentRunning,
+		done:            make(chan struct{}),
+		cancelRequested: true, // a cancel is racing this joined cancel+exhaustion error
+	}
+
+	sub.run(context.Background(), "do work", nil)
+
+	sub.mu.Lock()
+	status := sub.status
+	runErr := sub.err
+	sub.mu.Unlock()
+	if status != SubagentCancelled {
+		t.Fatalf("status = %q, want %q (cancel plus context.Canceled must publish cancelled even with a joined exhaustion component)", status, SubagentCancelled)
+	}
+	if runErr == nil || !errors.Is(runErr, context.Canceled) {
+		t.Fatalf("sub.err = %v, want the joined error kept verbatim so errors.Is(sub.err, context.Canceled) holds", runErr)
+	}
+	if runErr.Error() != joined.Error() {
+		t.Fatalf("sub.err = %q, want the original joined error text %q", runErr.Error(), joined.Error())
+	}
+	var exhaustion *budgetExhaustionError
+	if !errors.As(runErr, &exhaustion) || exhaustion == nil {
+		t.Fatalf("sub.err = %v, want the joined error preserved (errors.As still finds its exhaustion component)", runErr)
+	}
+}
+
 // TestCancelAgent_NotRunning asserts cancelling an idle/terminal child returns the
 // "is not running" error rather than fabricating a cancelled outcome.
 func TestCancelAgent_NotRunning(t *testing.T) {

--- a/agent/subagents_test.go
+++ b/agent/subagents_test.go
@@ -457,30 +457,25 @@ func TestCancelAgent_GenuineFailureRacingCancelStaysFailed(t *testing.T) {
 // errors.Join(context.Canceled, budgetExhaustionError) publishes SubagentCancelled
 // (the cancel branch wins the status) and must keep the joined error verbatim —
 // errors.Is(a.err, context.Canceled) stays true and the exhaustion component is
+// not substituted for the whole error. The pre-classifier switch overwrote a.err
 // only inside its budgetExhausted case, which this branch never reached.
 func TestCancelAgent_JoinedCanceledAndExhaustionStaysCancelledWithJoinedError(t *testing.T) {
 	t.Parallel()
 	joined := errors.Join(context.Canceled, &budgetExhaustionError{Budget: exhaustedBudgetTurns, Limit: 23, Resumable: false})
-	dir := t.TempDir()
-	c := llm.NewClient()
-	c.Register(&fakeErrAdapter{
-		name: "openai",
-		steps: []func(req llm.Request) (llm.Response, error){
-			func(req llm.Request) (llm.Response, error) {
-				return llm.Response{}, joined
+	sess := newSession(t,
+		withAdapter(&fakeErrAdapter{
+			name: "openai",
+			steps: []func(req llm.Request) (llm.Response, error){
+				func(req llm.Request) (llm.Response, error) {
+					return llm.Response{}, joined
+				},
 			},
-		},
-	})
-	noRetry := llm.RetryPolicy{MaxRetries: 0}
-	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
-		MaxSubagentDepth: 1,
-		LLMRetryPolicy:   &noRetry,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer sess.Close()
-
+		}),
+		withConfig(SessionConfig{
+			MaxSubagentDepth: 1,
+			LLMRetryPolicy:   &llm.RetryPolicy{MaxRetries: 0},
+		}),
+	)
 	// The sub drives sub.run directly (not via the manager), so it is
 	// intentionally not tracked; see the note in
 	// TestCancelAgent_GenuineFailureRacingCancelStaysFailed.


### PR DESCRIPTION
## Summary

Follow-up to #580 (merged). Behavior-preserving deduplication of the residual lifecycle overlap identified in the post-merge simplify analysis (~2–3% of the lifecycle code):

- **`classifyRunEnd`** — one pure classification of a run's terminal error feeding all three projections (settlement mode, fatality, published status), replacing four independent pattern-matches over the same taxonomy.
- **`supervisionSuppressedLocked`** — one suppression predicate behind `SupervisionBoundary`'s suppress branch.
- Exhaustion payload contract: non-nil exactly when status is `SubagentExhausted`, making the one review-found divergence class unrepresentable.
- Attention-bookkeeping consolidation was investigated and rejected with evidence (`live.attentionIDs` has no production populate path — flagged for a future dead-state audit).

## Review process

- **Adversarial review** (two independent reviewers): converged on exactly one significant divergence — the `a.err` exhaustion overwrite fired under `SubagentCancelled`, where the pre-refactor switch only overwrote inside the budget branch. Fixed and pinned with a mutation-verified run-loop regression test (`TestCancelAgent_JoinedCanceledAndExhaustionStaysCancelledWithJoinedError`); scoped re-review approved.
- **Simplify pass** (four angles): 7 findings applied (including the payload-contract hardening), 2 rejected with reasons (would undo the consolidation or change race semantics).

## Verification

- `TestClassifyRunEnd` + `TestClassifyRunEndProjectionsMatchLegacySites`: full taxonomy matrix × cancelRequested, cross-checked against the pre-refactor per-site logic
- `go test ./agent -count=1` — PASS (122.026s)
- `make lint` — PASS (9/9)
- `make vet` — PASS
- `make test` — PASS (all modules + web)

No behavior change intended; all existing tests unchanged and green.
