### PR TITLE
feat(web): redesign Marketplaces & Plugins settings as segmented workspace

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/BrowseSection.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/BrowseSection.test.tsx
@@ -70,7 +70,7 @@ test("shows the no-marketplaces empty state", () => {
   connectFakeClient();
   extensionsStore.setState({ marketplaces: [], plugins: [] });
   render(<Harness />);
-  expect(screen.getByText("No marketplaces registered. Add one above to browse plugins.")).toBeTruthy();
+  expect(screen.getByText("No marketplaces registered. Add one from the Marketplaces tab.")).toBeTruthy();
 });
 
 test("expanding a node lazily fetches its catalog once; re-expanding does not refetch", async () => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/BrowseSection.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/BrowseSection.tsx
@@ -14,8 +14,6 @@ import { sourceLabel } from "./sourceLabel";
 
 const CLASS = {
   section: requireClass(styles.section, "marketplacesPlugins.module.css", "section"),
-  header: requireClass(styles.header, "marketplacesPlugins.module.css", "header"),
-  title: requireClass(styles.title, "marketplacesPlugins.module.css", "title"),
   filterRow: requireClass(styles.filterRow, "marketplacesPlugins.module.css", "filterRow"),
   tree: requireClass(styles.tree, "marketplacesPlugins.module.css", "tree"),
   treeNode: requireClass(styles.treeNode, "marketplacesPlugins.module.css", "treeNode"),
@@ -152,9 +150,6 @@ export function BrowseSection({ expandedMarketplaces, setExpandedMarketplaces }:
 
   return (
     <section className={CLASS.section}>
-      <header className={CLASS.header}>
-        <h3 className={CLASS.title}>Browse</h3>
-      </header>
       <div className={CLASS.filterRow}>
         <Input
           value={filterQuery}
@@ -164,7 +159,7 @@ export function BrowseSection({ expandedMarketplaces, setExpandedMarketplaces }:
       </div>
       <ul aria-label="Marketplace browse tree" className={CLASS.tree}>
         {marketplaces.length === 0 ? (
-          <li className={CLASS.empty}>No marketplaces registered. Add one above to browse plugins.</li>
+          <li className={CLASS.empty}>No marketplaces registered. Add one from the Marketplaces tab.</li>
         ) : trimmedQuery !== "" && filterLoading ? (
           <li className={CLASS.empty}>Loading marketplaces…</li>
         ) : trimmedQuery !== "" && visibleMarketplaces.length === 0 ? (

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/InstalledSection.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/InstalledSection.test.tsx
@@ -1,11 +1,11 @@
-import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { FakeClient } from "../../../../protocol/testing/fakeClient";
 import type { PluginEntry } from "../../../../protocol/types.gen";
 import { connectionStore } from "../../../../stores/connection";
 import { extensionsStore, resetExtensionsStoreForTests } from "../../../../stores/extensions";
-import { getToasts, resetToastStoreForTests } from "../../../../widgets/toast/store";
+import { resetToastStoreForTests } from "../../../../widgets/toast/store";
 import { InstalledSection } from "./InstalledSection";
 
 const LINTER: PluginEntry = {
@@ -18,6 +18,13 @@ const LINTER: PluginEntry = {
   installPath: "/x",
   installedAt: 1,
   lastUpdated: 1,
+};
+
+const FORMATTER: PluginEntry = {
+  ...LINTER,
+  plugin: "formatter",
+  marketplace: "other-market",
+  version: "0.3.1",
 };
 
 function connectFakeClient(): FakeClient {
@@ -37,30 +44,26 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-test("renders the heading, count, name, marketplace, and version", () => {
+test("renders a row per plugin with name, marketplace, and version", () => {
   connectFakeClient();
   extensionsStore.setState({ plugins: [LINTER] });
-  render(<InstalledSection />);
-  expect(screen.getByText("Installed")).toBeTruthy();
-  expect(screen.getByText("1 entry")).toBeTruthy();
+  render(<InstalledSection onSelect={() => {}} />);
   expect(screen.getByText("linter")).toBeTruthy();
-  expect(screen.getByText("@ acme-plugins")).toBeTruthy();
-  expect(screen.getByText("v1.2.0")).toBeTruthy();
+  expect(screen.getByText("@ acme-plugins · v1.2.0")).toBeTruthy();
 });
 
 test("shows v.unknown when version is empty", () => {
   connectFakeClient();
   extensionsStore.setState({ plugins: [{ ...LINTER, version: "" }] });
-  render(<InstalledSection />);
-  expect(screen.getByText("vunknown")).toBeTruthy();
+  render(<InstalledSection onSelect={() => {}} />);
+  expect(screen.getByText("@ acme-plugins · vunknown")).toBeTruthy();
 });
 
-test("shows the empty state and pluralizes the count", () => {
+test("shows the empty state when no plugins are installed", () => {
   connectFakeClient();
   extensionsStore.setState({ plugins: [] });
-  render(<InstalledSection />);
-  expect(screen.getByText("No plugins installed yet. Install one from Browse above.")).toBeTruthy();
-  expect(screen.getByText("0 entries")).toBeTruthy();
+  render(<InstalledSection onSelect={() => {}} />);
+  expect(screen.getByText("No plugins installed yet. Install one from Browse.")).toBeTruthy();
 });
 
 test("shows broken/disabled/auto-upgrade badges only when applicable", () => {
@@ -68,7 +71,7 @@ test("shows broken/disabled/auto-upgrade badges only when applicable", () => {
   extensionsStore.setState({
     plugins: [{ ...LINTER, broken: true, enabled: false, autoUpgrade: true }],
   });
-  render(<InstalledSection />);
+  render(<InstalledSection onSelect={() => {}} />);
   expect(screen.getByText("broken")).toBeTruthy();
   expect(screen.getByText("disabled")).toBeTruthy();
   expect(screen.getByText("auto-upgrade")).toBeTruthy();
@@ -77,7 +80,7 @@ test("shows broken/disabled/auto-upgrade badges only when applicable", () => {
 test("no badges render for a healthy, enabled, non-auto-upgrading plugin", () => {
   connectFakeClient();
   extensionsStore.setState({ plugins: [LINTER] });
-  render(<InstalledSection />);
+  render(<InstalledSection onSelect={() => {}} />);
   expect(screen.queryByText("broken")).toBeNull();
   expect(screen.queryByText("disabled")).toBeNull();
   expect(screen.queryByText("auto-upgrade")).toBeNull();
@@ -92,245 +95,62 @@ test("the status dot reads broken > disabled > idle, in that priority order", ()
       { ...LINTER, plugin: "healthy-one", broken: false, enabled: true },
     ],
   });
-  render(<InstalledSection />);
+  render(<InstalledSection onSelect={() => {}} />);
   expect(screen.getAllByRole("img", { name: "Failed" })).toHaveLength(1);
   expect(screen.getAllByRole("img", { name: "Ended" })).toHaveLength(1);
   expect(screen.getAllByRole("img", { name: "Idle" })).toHaveLength(1);
 });
 
-test("Disable calls pluginDisable (enabled plugin); no success toast", async () => {
+test("clicking a row calls onSelect with the plugin and marketplace", async () => {
   const user = userEvent.setup();
-  const fake = connectFakeClient();
+  connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER, FORMATTER] });
+  const onSelect = vi.fn();
+  render(<InstalledSection onSelect={onSelect} />);
+  await user.click(screen.getByRole("button", { name: /formatter/ }));
+  expect(onSelect).toHaveBeenCalledWith({ plugin: "formatter", marketplace: "other-market" });
+});
+
+test("rows carry no per-row action buttons - actions live in the detail sheet", () => {
+  connectFakeClient();
   extensionsStore.setState({ plugins: [LINTER] });
-  fake.on("evener/plugin/disable", (params) => {
-    expect(params).toEqual({ plugin: "linter", marketplace: "acme-plugins" });
-    return { plugins: [{ ...LINTER, enabled: false }] };
-  });
-  render(<InstalledSection />);
-  await user.click(screen.getByRole("button", { name: "Disable" }));
-  expect(await screen.findByRole("button", { name: "Enable" })).toBeTruthy();
-  expect(getToasts()).toEqual([]);
+  render(<InstalledSection onSelect={() => {}} />);
+  expect(screen.queryByRole("button", { name: "Disable" })).toBeNull();
+  expect(screen.queryByRole("button", { name: "Enable" })).toBeNull();
+  expect(screen.queryByRole("button", { name: "Upgrade" })).toBeNull();
+  expect(screen.queryByRole("button", { name: "Remove" })).toBeNull();
+  expect(screen.queryByRole("button", { name: /Auto-upgrade/ })).toBeNull();
 });
 
-test("Enable calls pluginEnable (disabled plugin)", async () => {
+test("the filter narrows rows by plugin name, case-insensitively", async () => {
   const user = userEvent.setup();
-  const fake = connectFakeClient();
-  extensionsStore.setState({ plugins: [{ ...LINTER, enabled: false }] });
-  fake.on("evener/plugin/enable", (params) => {
-    expect(params).toEqual({ plugin: "linter", marketplace: "acme-plugins" });
-    return { plugins: [{ ...LINTER, enabled: true }] };
-  });
-  render(<InstalledSection />);
-  await user.click(screen.getByRole("button", { name: "Enable" }));
-  expect(await screen.findByRole("button", { name: "Disable" })).toBeTruthy();
+  connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER, FORMATTER] });
+  render(<InstalledSection onSelect={() => {}} />);
+  await user.type(screen.getByRole("textbox", { name: "Filter installed" }), "FORM");
+  expect(screen.queryByText("linter")).toBeNull();
+  expect(screen.getByText("formatter")).toBeTruthy();
 });
 
-test("a failed enable/disable toggle toasts 'Toggle enable failed'", async () => {
+test("the filter also matches the marketplace name", async () => {
   const user = userEvent.setup();
-  const fake = connectFakeClient();
+  connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER, FORMATTER] });
+  render(<InstalledSection onSelect={() => {}} />);
+  await user.type(screen.getByRole("textbox", { name: "Filter installed" }), "other-mark");
+  expect(screen.queryByText("linter")).toBeNull();
+  expect(screen.getByText("formatter")).toBeTruthy();
+});
+
+test("a filter with no match says so, and clearing it restores the rows", async () => {
+  const user = userEvent.setup();
+  connectFakeClient();
   extensionsStore.setState({ plugins: [LINTER] });
-  fake.on("evener/plugin/disable", () => {
-    throw new Error("boom");
-  });
-  render(<InstalledSection />);
-  await user.click(screen.getByRole("button", { name: "Disable" }));
-  await waitFor(() =>
-    expect(getToasts().some((t) => t.kind === "error" && t.text === "Toggle enable failed: boom")).toBe(true),
-  );
-});
-
-test("the auto-upgrade toggle shows on/off and flips the current value; no success toast", async () => {
-  const user = userEvent.setup();
-  const fake = connectFakeClient();
-  extensionsStore.setState({ plugins: [LINTER] });
-  fake.on("evener/plugin/setAutoUpgrade", (params) => {
-    expect(params).toEqual({ plugin: "linter", marketplace: "acme-plugins", autoUpgrade: true });
-    return { plugins: [{ ...LINTER, autoUpgrade: true }] };
-  });
-  render(<InstalledSection />);
-  expect(screen.getByRole("button", { name: "Auto-upgrade: off" })).toBeTruthy();
-  await user.click(screen.getByRole("button", { name: "Auto-upgrade: off" }));
-  expect(await screen.findByRole("button", { name: "Auto-upgrade: on" })).toBeTruthy();
-  expect(getToasts()).toEqual([]);
-});
-
-test("a failed auto-upgrade toggle toasts 'Toggle auto-upgrade failed'", async () => {
-  const user = userEvent.setup();
-  const fake = connectFakeClient();
-  extensionsStore.setState({ plugins: [LINTER] });
-  fake.on("evener/plugin/setAutoUpgrade", () => {
-    throw new Error("boom");
-  });
-  render(<InstalledSection />);
-  await user.click(screen.getByRole("button", { name: "Auto-upgrade: off" }));
-  await waitFor(() =>
-    expect(getToasts().some((t) => t.kind === "error" && t.text === "Toggle auto-upgrade failed: boom")).toBe(true),
-  );
-});
-
-test("Upgrade calls pluginUpgrade and toasts a checked-for-upgrades success", async () => {
-  const user = userEvent.setup();
-  const fake = connectFakeClient();
-  extensionsStore.setState({ plugins: [LINTER] });
-  fake.on("evener/plugin/upgrade", (params) => {
-    expect(params).toEqual({ plugin: "linter", marketplace: "acme-plugins" });
-    return { plugins: [{ ...LINTER, version: "1.3.0" }] };
-  });
-  render(<InstalledSection />);
-  await user.click(screen.getByRole("button", { name: "Upgrade" }));
-  await waitFor(() =>
-    expect(getToasts().some((t) => t.kind === "success" && t.text === "Checked linter for upgrades")).toBe(true),
-  );
-});
-
-test("a failed upgrade toasts failure", async () => {
-  const user = userEvent.setup();
-  const fake = connectFakeClient();
-  extensionsStore.setState({ plugins: [LINTER] });
-  fake.on("evener/plugin/upgrade", () => {
-    throw new Error("boom");
-  });
-  render(<InstalledSection />);
-  await user.click(screen.getByRole("button", { name: "Upgrade" }));
-  await waitFor(() =>
-    expect(getToasts().some((t) => t.kind === "error" && t.text === "Upgrade failed: boom")).toBe(true),
-  );
-});
-
-test("Disable disables its own button while the RPC is in flight, and re-enables after", async () => {
-  const user = userEvent.setup();
-  const fake = connectFakeClient();
-  extensionsStore.setState({ plugins: [LINTER] });
-  let resolveDisable: (v: { plugins: PluginEntry[] }) => void = () => {};
-  fake.on(
-    "evener/plugin/disable",
-    () =>
-      new Promise((resolve) => {
-        resolveDisable = resolve;
-      }),
-  );
-  render(<InstalledSection />);
-  const disableButton = screen.getByRole("button", { name: "Disable" });
-  await user.click(disableButton);
-  expect((disableButton as HTMLButtonElement).disabled).toBe(true);
-
-  resolveDisable({ plugins: [{ ...LINTER, enabled: false }] });
-  await waitFor(() => expect(screen.getByRole("button", { name: "Enable" })).toBeTruthy());
-});
-
-test("a failed enable/disable toggle re-enables the button too", async () => {
-  const user = userEvent.setup();
-  const fake = connectFakeClient();
-  extensionsStore.setState({ plugins: [LINTER] });
-  fake.on("evener/plugin/disable", () => {
-    throw new Error("boom");
-  });
-  render(<InstalledSection />);
-  const disableButton = screen.getByRole("button", { name: "Disable" });
-  await user.click(disableButton);
-  await waitFor(() => expect((disableButton as HTMLButtonElement).disabled).toBe(false));
-});
-
-test("the auto-upgrade toggle disables its own button while in flight, without disabling this row's other actions", async () => {
-  const user = userEvent.setup();
-  const fake = connectFakeClient();
-  extensionsStore.setState({ plugins: [LINTER] });
-  fake.on("evener/plugin/setAutoUpgrade", () => new Promise(() => {})); // never resolves - observe mid-flight only
-  render(<InstalledSection />);
-  const autoUpgradeButton = screen.getByRole("button", { name: "Auto-upgrade: off" });
-  await user.click(autoUpgradeButton);
-  expect((autoUpgradeButton as HTMLButtonElement).disabled).toBe(true);
-  expect((screen.getByRole("button", { name: "Disable" }) as HTMLButtonElement).disabled).toBe(false);
-  expect((screen.getByRole("button", { name: "Upgrade" }) as HTMLButtonElement).disabled).toBe(false);
-});
-
-test("Upgrade disables its own button while in flight, and re-enables after", async () => {
-  const user = userEvent.setup();
-  const fake = connectFakeClient();
-  extensionsStore.setState({ plugins: [LINTER] });
-  let resolveUpgrade: (v: { plugins: PluginEntry[] }) => void = () => {};
-  fake.on(
-    "evener/plugin/upgrade",
-    () =>
-      new Promise((resolve) => {
-        resolveUpgrade = resolve;
-      }),
-  );
-  render(<InstalledSection />);
-  const upgradeButton = screen.getByRole("button", { name: "Upgrade" });
-  await user.click(upgradeButton);
-  expect((upgradeButton as HTMLButtonElement).disabled).toBe(true);
-
-  resolveUpgrade({ plugins: [LINTER] });
-  await waitFor(() => expect((upgradeButton as HTMLButtonElement).disabled).toBe(false));
-});
-
-test("a busy row action does not disable the same action on a different row", async () => {
-  const user = userEvent.setup();
-  const fake = connectFakeClient();
-  const OTHER: PluginEntry = { ...LINTER, plugin: "formatter" };
-  extensionsStore.setState({ plugins: [LINTER, OTHER] });
-  fake.on("evener/plugin/upgrade", () => new Promise(() => {})); // never resolves - observe mid-flight only
-  render(<InstalledSection />);
-  const upgradeButtons = screen.getAllByRole("button", { name: "Upgrade" });
-  await user.click(upgradeButtons[0]!);
-  expect((upgradeButtons[0] as HTMLButtonElement).disabled).toBe(true);
-  expect((upgradeButtons[1] as HTMLButtonElement).disabled).toBe(false);
-});
-
-test("Remove opens a destructive confirm; confirming removes and toasts success", async () => {
-  const user = userEvent.setup();
-  const fake = connectFakeClient();
-  extensionsStore.setState({ plugins: [LINTER] });
-  fake.on("evener/plugin/remove", (params) => {
-    expect(params).toEqual({ plugin: "linter", marketplace: "acme-plugins" });
-    return { plugins: [] };
-  });
-  render(<InstalledSection />);
-  await user.click(screen.getByRole("button", { name: "Remove" }));
-  const dialog = screen.getByRole("dialog", { name: "Remove plugin" });
-  expect(within(dialog).getByText('Remove plugin "linter"?')).toBeTruthy();
-  await user.click(within(dialog).getByRole("button", { name: "Remove" }));
-  await waitFor(() => expect(getToasts().some((t) => t.kind === "success" && t.text === "Removed linter")).toBe(true));
-});
-
-test("cancelling the remove confirm does not call pluginRemove", async () => {
-  const user = userEvent.setup();
-  const fake = connectFakeClient();
-  extensionsStore.setState({ plugins: [LINTER] });
-  const removeSpy = vi.fn();
-  fake.on("evener/plugin/remove", removeSpy);
-  render(<InstalledSection />);
-  await user.click(screen.getByRole("button", { name: "Remove" }));
-  await user.click(screen.getByRole("button", { name: "Cancel" }));
-  expect(removeSpy).not.toHaveBeenCalled();
-});
-
-test("a failed remove toasts failure", async () => {
-  const user = userEvent.setup();
-  const fake = connectFakeClient();
-  extensionsStore.setState({ plugins: [LINTER] });
-  fake.on("evener/plugin/remove", () => {
-    throw new Error("boom");
-  });
-  render(<InstalledSection />);
-  await user.click(screen.getByRole("button", { name: "Remove" }));
-  const dialog = screen.getByRole("dialog", { name: "Remove plugin" });
-  await user.click(within(dialog).getByRole("button", { name: "Remove" }));
-  await waitFor(() =>
-    expect(getToasts().some((t) => t.kind === "error" && t.text === "Remove failed: boom")).toBe(true),
-  );
-});
-
-test("the remove confirm's buttons disable while the removal is in flight", async () => {
-  const user = userEvent.setup();
-  const fake = connectFakeClient();
-  extensionsStore.setState({ plugins: [LINTER] });
-  fake.on("evener/plugin/remove", () => new Promise(() => {})); // never resolves - just observe the mid-flight state
-  render(<InstalledSection />);
-  await user.click(screen.getByRole("button", { name: "Remove" }));
-  const dialog = screen.getByRole("dialog", { name: "Remove plugin" });
-  await user.click(within(dialog).getByRole("button", { name: "Remove" }));
-  expect((within(dialog).getByRole("button", { name: "Remove" }) as HTMLButtonElement).disabled).toBe(true);
-  expect((within(dialog).getByRole("button", { name: "Cancel" }) as HTMLButtonElement).disabled).toBe(true);
+  render(<InstalledSection onSelect={() => {}} />);
+  const filter = screen.getByRole("textbox", { name: "Filter installed" });
+  await user.type(filter, "zzz");
+  expect(screen.getByText('No plugins match "zzz".')).toBeTruthy();
+  expect(screen.queryByText("linter")).toBeNull();
+  await user.clear(filter);
+  expect(screen.getByText("linter")).toBeTruthy();
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/InstalledSection.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/InstalledSection.tsx
@@ -1,190 +1,99 @@
-// InstalledSection: the installed-plugins list (parity-m7-settings.md
-// §12e) - enable/disable, auto-upgrade toggle, upgrade, and a
-// ConfirmDialog-gated remove (this wave's binding "every destructive
-// action confirms" constraint; the legacy had none for plugin removal
-// either - `confirm(...)` there, ConfirmDialog here).
-import { type Dispatch, type SetStateAction, useState } from "react";
-import { errorText } from "../../../../protocol/errors";
+// InstalledSection: the installed-plugins row list for the Segmented
+// Workspace redesign. Rows carry status (dot + chips) and identity only -
+// every ACTION (enable/disable, auto-upgrade, upgrade, remove) moved into
+// the PluginDetailSheet that opens when a row is selected, so the list
+// stays a single-tap-target-per-row on both desktop and mobile. The
+// client-side filter matches plugin name OR marketplace, case-insensitively.
+import { useId, useState } from "react";
 import type { PluginEntry } from "../../../../protocol/types.gen";
-import { extensionsStore, useExtensionsStore } from "../../../../stores/extensions";
-import { Button, type CadenceState, Chip, ConfirmDialog, StatusDot, useToasts } from "../../../../widgets";
+import { useExtensionsStore } from "../../../../stores/extensions";
+import { type CadenceState, Chevron, Chip, Input, StatusDot } from "../../../../widgets";
 import { requireClass } from "../../../../widgets/internal/requireClass";
+import { VisuallyHidden } from "../../../../widgets/internal/VisuallyHidden";
 import styles from "./marketplacesPlugins.module.css";
 
 const CLASS = {
   section: requireClass(styles.section, "marketplacesPlugins.module.css", "section"),
-  header: requireClass(styles.header, "marketplacesPlugins.module.css", "header"),
-  title: requireClass(styles.title, "marketplacesPlugins.module.css", "title"),
-  count: requireClass(styles.count, "marketplacesPlugins.module.css", "count"),
+  filterRow: requireClass(styles.filterRow, "marketplacesPlugins.module.css", "filterRow"),
   list: requireClass(styles.list, "marketplacesPlugins.module.css", "list"),
-  row: requireClass(styles.row, "marketplacesPlugins.module.css", "row"),
+  rowButton: requireClass(styles.rowButton, "marketplacesPlugins.module.css", "rowButton"),
   rowMain: requireClass(styles.rowMain, "marketplacesPlugins.module.css", "rowMain"),
   rowText: requireClass(styles.rowText, "marketplacesPlugins.module.css", "rowText"),
   rowMeta: requireClass(styles.rowMeta, "marketplacesPlugins.module.css", "rowMeta"),
-  rowActions: requireClass(styles.rowActions, "marketplacesPlugins.module.css", "rowActions"),
+  rowChevron: requireClass(styles.rowChevron, "marketplacesPlugins.module.css", "rowChevron"),
   empty: requireClass(styles.empty, "marketplacesPlugins.module.css", "empty"),
 };
 
-function pluginKey(plugin: string, marketplace: string): string {
-  return `${plugin}@${marketplace}`;
+export interface InstalledSectionProps {
+  onSelect: (target: { plugin: string; marketplace: string }) => void;
 }
 
-// §12e: "Status dot: warning if broken, else ended if !enabled, else idle".
-// StatusDot (widgets/statusdot) is built on the shared CadenceState enum,
-// which has no "warning" state - broken maps onto "failed" (the only
-// failure-family state, giving the danger/red treatment a broken plugin
-// warrants) rather than inventing a state the shared widget doesn't have.
+// See the pre-redesign comment that lived here: StatusDot's CadenceState has
+// no "warning" state, so broken maps onto "failed" (the only failure-family
+// state) rather than inventing a state the shared widget doesn't have.
 function pluginStatus(plugin: PluginEntry): CadenceState {
   if (plugin.broken) return "failed";
   if (!plugin.enabled) return "ended";
   return "idle";
 }
 
-// Runs fn() with `key` added to the given busy-key Set for its duration,
-// always removing it again in a finally - the "withBusy" shape (§12f:
-// "disables the triggering button... re-enabling in a finally") for a
-// per-row action, without a shared boolean that would also disable every
-// OTHER row's (or this row's OTHER action's) button.
-async function runBusy(setBusy: Dispatch<SetStateAction<Set<string>>>, key: string, fn: () => Promise<void>) {
-  setBusy((prev) => new Set(prev).add(key));
-  try {
-    await fn();
-  } finally {
-    setBusy((prev) => {
-      const next = new Set(prev);
-      next.delete(key);
-      return next;
-    });
-  }
-}
-
-export function InstalledSection() {
+export function InstalledSection({ onSelect }: InstalledSectionProps) {
   const plugins = useExtensionsStore((s) => s.plugins) ?? [];
-  const toasts = useToasts();
-  const [pendingRemove, setPendingRemove] = useState<{ plugin: string; marketplace: string } | null>(null);
-  const [removeBusy, setRemoveBusy] = useState(false);
-  const [toggleBusy, setToggleBusy] = useState<Set<string>>(new Set());
-  const [autoUpgradeBusy, setAutoUpgradeBusy] = useState<Set<string>>(new Set());
-  const [upgradeBusy, setUpgradeBusy] = useState<Set<string>>(new Set());
+  const [filterQuery, setFilterQuery] = useState("");
+  const filterId = useId();
 
-  async function handleToggleEnable(plugin: string, marketplace: string, currentlyEnabled: boolean) {
-    await runBusy(setToggleBusy, pluginKey(plugin, marketplace), async () => {
-      try {
-        if (currentlyEnabled) await extensionsStore.getState().disablePlugin(plugin, marketplace);
-        else await extensionsStore.getState().enablePlugin(plugin, marketplace);
-      } catch (err) {
-        toasts.push("error", `Toggle enable failed: ${errorText(err)}`);
-      }
-    });
-  }
-
-  async function handleToggleAutoUpgrade(plugin: string, marketplace: string, currentlyAutoUpgrade: boolean) {
-    await runBusy(setAutoUpgradeBusy, pluginKey(plugin, marketplace), async () => {
-      try {
-        await extensionsStore.getState().setPluginAutoUpgrade(plugin, marketplace, !currentlyAutoUpgrade);
-      } catch (err) {
-        toasts.push("error", `Toggle auto-upgrade failed: ${errorText(err)}`);
-      }
-    });
-  }
-
-  async function handleUpgrade(plugin: string, marketplace: string) {
-    await runBusy(setUpgradeBusy, pluginKey(plugin, marketplace), async () => {
-      try {
-        await extensionsStore.getState().upgradePlugin(plugin, marketplace);
-        toasts.push("success", `Checked ${plugin} for upgrades`);
-      } catch (err) {
-        toasts.push("error", `Upgrade failed: ${errorText(err)}`);
-      }
-    });
-  }
-
-  async function handleConfirmRemove() {
-    const target = pendingRemove;
-    if (target === null) return;
-    setRemoveBusy(true);
-    try {
-      await extensionsStore.getState().removePlugin(target.plugin, target.marketplace);
-      toasts.push("success", `Removed ${target.plugin}`);
-      setPendingRemove(null);
-    } catch (err) {
-      toasts.push("error", `Remove failed: ${errorText(err)}`);
-    } finally {
-      setRemoveBusy(false);
-    }
-  }
+  const trimmedQuery = filterQuery.trim().toLowerCase();
+  const visible =
+    trimmedQuery === ""
+      ? plugins
+      : plugins.filter(
+          (p) => p.plugin.toLowerCase().includes(trimmedQuery) || p.marketplace.toLowerCase().includes(trimmedQuery),
+        );
 
   return (
     <section className={CLASS.section}>
-      <header className={CLASS.header}>
-        <h3 className={CLASS.title}>Installed</h3>
-        <span className={CLASS.count}>
-          {plugins.length} {plugins.length === 1 ? "entry" : "entries"}
-        </span>
-      </header>
+      <div className={CLASS.filterRow}>
+        <VisuallyHidden>
+          <label htmlFor={filterId}>Filter installed</label>
+        </VisuallyHidden>
+        <Input
+          id={filterId}
+          value={filterQuery}
+          onChange={(event) => setFilterQuery(event.target.value)}
+          placeholder="Filter installed…"
+        />
+      </div>
       <ul aria-label="Installed plugins" className={CLASS.list}>
         {plugins.length === 0 ? (
-          <li className={CLASS.empty}>No plugins installed yet. Install one from Browse above.</li>
+          <li className={CLASS.empty}>No plugins installed yet. Install one from Browse.</li>
+        ) : visible.length === 0 ? (
+          <li className={CLASS.empty}>{`No plugins match "${filterQuery.trim()}".`}</li>
         ) : (
-          plugins.map((p) => (
-            <li key={`${p.plugin}@${p.marketplace}`} className={CLASS.row}>
-              <div className={CLASS.rowMain}>
-                <div className={CLASS.rowText}>
-                  <StatusDot state={pluginStatus(p)} />
-                  {p.plugin} <span className={CLASS.rowMeta}>@ {p.marketplace}</span>
-                  {p.broken && <Chip tone="danger">broken</Chip>}
-                  {!p.enabled && <Chip tone="neutral">disabled</Chip>}
-                  {p.autoUpgrade && <Chip tone="neutral">auto-upgrade</Chip>}
+          visible.map((p) => (
+            <li key={`${p.plugin}@${p.marketplace}`}>
+              <button
+                type="button"
+                className={CLASS.rowButton}
+                onClick={() => onSelect({ plugin: p.plugin, marketplace: p.marketplace })}
+              >
+                <div className={CLASS.rowMain}>
+                  <div className={CLASS.rowText}>
+                    <StatusDot state={pluginStatus(p)} />
+                    {p.plugin}
+                    {p.broken && <Chip tone="danger">broken</Chip>}
+                    {!p.enabled && <Chip tone="neutral">disabled</Chip>}
+                    {p.autoUpgrade && <Chip tone="neutral">auto-upgrade</Chip>}
+                  </div>
+                  <div className={CLASS.rowMeta}>{`@ ${p.marketplace} · v${p.version || "unknown"}`}</div>
                 </div>
-                <div className={CLASS.rowMeta}>v{p.version || "unknown"}</div>
-              </div>
-              <div className={CLASS.rowActions}>
-                <Button
-                  variant="quiet"
-                  size="sm"
-                  onClick={() => void handleToggleEnable(p.plugin, p.marketplace, p.enabled)}
-                  disabled={toggleBusy.has(pluginKey(p.plugin, p.marketplace))}
-                >
-                  {p.enabled ? "Disable" : "Enable"}
-                </Button>
-                <Button
-                  variant="quiet"
-                  size="sm"
-                  onClick={() => void handleToggleAutoUpgrade(p.plugin, p.marketplace, p.autoUpgrade)}
-                  disabled={autoUpgradeBusy.has(pluginKey(p.plugin, p.marketplace))}
-                >
-                  {p.autoUpgrade ? "Auto-upgrade: on" : "Auto-upgrade: off"}
-                </Button>
-                <Button
-                  variant="quiet"
-                  size="sm"
-                  onClick={() => void handleUpgrade(p.plugin, p.marketplace)}
-                  disabled={upgradeBusy.has(pluginKey(p.plugin, p.marketplace))}
-                >
-                  Upgrade
-                </Button>
-                <Button
-                  variant="danger"
-                  size="sm"
-                  onClick={() => setPendingRemove({ plugin: p.plugin, marketplace: p.marketplace })}
-                >
-                  Remove
-                </Button>
-              </div>
+                <span className={CLASS.rowChevron} aria-hidden="true">
+                  <Chevron direction="right" />
+                </span>
+              </button>
             </li>
           ))
         )}
       </ul>
-      <ConfirmDialog
-        open={pendingRemove !== null}
-        title="Remove plugin"
-        confirmLabel="Remove"
-        busy={removeBusy}
-        onConfirm={() => void handleConfirmRemove()}
-        onCancel={() => setPendingRemove(null)}
-      >
-        {pendingRemove !== null ? `Remove plugin "${pendingRemove.plugin}"?` : ""}
-      </ConfirmDialog>
     </section>
   );
 }

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/MarketplacesSection.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/MarketplacesSection.test.tsx
@@ -31,23 +31,24 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-test("renders the heading, count, and each marketplace's name/kind/sourceLabel", () => {
+test("renders each marketplace's name/kind/sourceLabel; the segment label owns the heading and count", () => {
   connectFakeClient();
   extensionsStore.setState({ marketplaces: [MARKETPLACE_A] });
   render(<MarketplacesSection expandedMarketplaces={new Set()} />);
-  expect(screen.getByText("Marketplaces")).toBeTruthy();
-  expect(screen.getByText("1 entry")).toBeTruthy();
   expect(screen.getByText("acme-plugins")).toBeTruthy();
   expect(screen.getByText("github")).toBeTruthy();
   expect(screen.getByText("github: acme/plugins")).toBeTruthy();
+  // No in-section heading or count: the page-level SegmentedControl carries
+  // "Marketplaces (n)" - asserted in index.test.tsx.
+  expect(screen.queryByRole("heading")).toBeNull();
+  expect(screen.queryByText("1 entry")).toBeNull();
 });
 
-test("shows the empty state and pluralizes the count when there are no marketplaces", () => {
+test("shows the empty state when there are no marketplaces", () => {
   connectFakeClient();
   extensionsStore.setState({ marketplaces: [] });
   render(<MarketplacesSection expandedMarketplaces={new Set()} />);
   expect(screen.getByText("No marketplaces registered. Add one below.")).toBeTruthy();
-  expect(screen.getByText("0 entries")).toBeTruthy();
 });
 
 test("the Add form and the + Add marketplace button are mutually exclusive", async () => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/MarketplacesSection.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/MarketplacesSection.tsx
@@ -15,9 +15,6 @@ import { sourceLabel } from "./sourceLabel";
 
 const CLASS = {
   section: requireClass(styles.section, "marketplacesPlugins.module.css", "section"),
-  header: requireClass(styles.header, "marketplacesPlugins.module.css", "header"),
-  title: requireClass(styles.title, "marketplacesPlugins.module.css", "title"),
-  count: requireClass(styles.count, "marketplacesPlugins.module.css", "count"),
   list: requireClass(styles.list, "marketplacesPlugins.module.css", "list"),
   row: requireClass(styles.row, "marketplacesPlugins.module.css", "row"),
   rowMain: requireClass(styles.rowMain, "marketplacesPlugins.module.css", "rowMain"),
@@ -142,12 +139,6 @@ export function MarketplacesSection({ expandedMarketplaces }: MarketplacesSectio
 
   return (
     <section className={CLASS.section}>
-      <header className={CLASS.header}>
-        <h3 className={CLASS.title}>Marketplaces</h3>
-        <span className={CLASS.count}>
-          {marketplaces.length} {marketplaces.length === 1 ? "entry" : "entries"}
-        </span>
-      </header>
       <ul aria-label="Marketplaces" className={CLASS.list}>
         {marketplaces.length === 0 ? (
           <li className={CLASS.empty}>No marketplaces registered. Add one below.</li>

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/PluginDetailSheet.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/PluginDetailSheet.test.tsx
@@ -1,0 +1,346 @@
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { FakeClient } from "../../../../protocol/testing/fakeClient";
+import type { MarketplaceEntry, PluginEntry } from "../../../../protocol/types.gen";
+import { connectionStore } from "../../../../stores/connection";
+import { extensionsStore, resetExtensionsStoreForTests } from "../../../../stores/extensions";
+import { getToasts, resetToastStoreForTests } from "../../../../widgets/toast/store";
+import { PluginDetailSheet } from "./PluginDetailSheet";
+
+const LINTER: PluginEntry = {
+  plugin: "linter",
+  marketplace: "acme-plugins",
+  version: "1.2.0",
+  enabled: true,
+  autoUpgrade: false,
+  broken: false,
+  installPath: "/x",
+  installedAt: 1,
+  lastUpdated: 1,
+};
+
+const ACME: MarketplaceEntry = {
+  name: "acme-plugins",
+  source: { kind: "github", repo: "acme/plugins" },
+  lastUpdated: 1,
+};
+
+const TARGET = { plugin: "linter", marketplace: "acme-plugins" };
+
+function connectFakeClient(): FakeClient {
+  const fake = new FakeClient("ready");
+  connectionStore.getState().connect(fake);
+  return fake;
+}
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
+  resetExtensionsStoreForTests();
+  resetToastStoreForTests();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+test("renders nothing when target is null", () => {
+  connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  render(<PluginDetailSheet target={null} onClose={() => {}} />);
+  expect(screen.queryByRole("dialog")).toBeNull();
+});
+
+test("renders name, state chips, version, marketplace, and source", () => {
+  connectFakeClient();
+  extensionsStore.setState({
+    plugins: [{ ...LINTER, broken: true, enabled: false, autoUpgrade: true }],
+    marketplaces: [ACME],
+  });
+  render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
+  expect(screen.getByRole("dialog", { name: "linter" })).toBeTruthy();
+  expect(screen.getByText("broken")).toBeTruthy();
+  expect(screen.getByText("disabled")).toBeTruthy();
+  expect(screen.getByText("auto-upgrade")).toBeTruthy();
+  expect(screen.getByText("v1.2.0")).toBeTruthy();
+  expect(screen.getByText("acme-plugins")).toBeTruthy();
+  expect(screen.getByText("github: acme/plugins")).toBeTruthy();
+});
+
+test("omits the source row when the marketplace is not registered", () => {
+  connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [] });
+  render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
+  expect(screen.getByRole("dialog", { name: "linter" })).toBeTruthy();
+  expect(screen.queryByText("github: acme/plugins")).toBeNull();
+});
+
+test("the Enabled and Auto-upgrade switches reflect the entry's state", () => {
+  connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
+  expect(screen.getByRole("switch", { name: "Enabled" }).getAttribute("aria-checked")).toBe("true");
+  expect(screen.getByRole("switch", { name: "Auto-upgrade" }).getAttribute("aria-checked")).toBe("false");
+});
+
+test("the Enabled switch calls pluginDisable on an enabled plugin, pluginEnable on a disabled one", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  fake.on("evener/plugin/disable", (params) => {
+    expect(params).toEqual(TARGET);
+    return { plugins: [{ ...LINTER, enabled: false }] };
+  });
+  render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
+  await user.click(screen.getByRole("switch", { name: "Enabled" }));
+  await waitFor(() =>
+    expect(screen.getByRole("switch", { name: "Enabled" }).getAttribute("aria-checked")).toBe("false"),
+  );
+  expect(getToasts()).toEqual([]);
+});
+
+test("the Enabled switch calls pluginEnable on a disabled plugin", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  extensionsStore.setState({ plugins: [{ ...LINTER, enabled: false }], marketplaces: [ACME] });
+  fake.on("evener/plugin/enable", (params) => {
+    expect(params).toEqual(TARGET);
+    return { plugins: [{ ...LINTER, enabled: true }] };
+  });
+  render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
+  await user.click(screen.getByRole("switch", { name: "Enabled" }));
+  await waitFor(() =>
+    expect(screen.getByRole("switch", { name: "Enabled" }).getAttribute("aria-checked")).toBe("true"),
+  );
+  expect(getToasts()).toEqual([]);
+});
+
+test("a failed enable toggle re-enables the switch too", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  fake.on("evener/plugin/disable", () => {
+    throw new Error("boom");
+  });
+  render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
+  const enabledSwitch = screen.getByRole("switch", { name: "Enabled" });
+  await user.click(enabledSwitch);
+  await waitFor(() => expect((enabledSwitch as HTMLButtonElement).disabled).toBe(false));
+});
+
+test("a failed enable toggle toasts 'Toggle enable failed'", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  fake.on("evener/plugin/disable", () => {
+    throw new Error("boom");
+  });
+  render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
+  await user.click(screen.getByRole("switch", { name: "Enabled" }));
+  await waitFor(() =>
+    expect(getToasts().some((t) => t.kind === "error" && t.text === "Toggle enable failed: boom")).toBe(true),
+  );
+});
+
+test("the Enabled switch is disabled while its RPC is in flight, and re-enables after", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  let resolveDisable: (v: { plugins: PluginEntry[] }) => void = () => {};
+  fake.on(
+    "evener/plugin/disable",
+    () =>
+      new Promise((resolve) => {
+        resolveDisable = resolve;
+      }),
+  );
+  render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
+  const enabledSwitch = screen.getByRole("switch", { name: "Enabled" });
+  await user.click(enabledSwitch);
+  expect((enabledSwitch as HTMLButtonElement).disabled).toBe(true);
+
+  resolveDisable({ plugins: [{ ...LINTER, enabled: false }] });
+  await waitFor(() =>
+    expect((screen.getByRole("switch", { name: "Enabled" }) as HTMLButtonElement).disabled).toBe(false),
+  );
+});
+
+test("the Auto-upgrade switch flips the current value; failure toasts", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  fake.on("evener/plugin/setAutoUpgrade", (params) => {
+    expect(params).toEqual({ ...TARGET, autoUpgrade: true });
+    return { plugins: [{ ...LINTER, autoUpgrade: true }] };
+  });
+  render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
+  await user.click(screen.getByRole("switch", { name: "Auto-upgrade" }));
+  await waitFor(() =>
+    expect(screen.getByRole("switch", { name: "Auto-upgrade" }).getAttribute("aria-checked")).toBe("true"),
+  );
+});
+
+test("a failed auto-upgrade toggle toasts 'Toggle auto-upgrade failed'", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  fake.on("evener/plugin/setAutoUpgrade", () => {
+    throw new Error("boom");
+  });
+  render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
+  await user.click(screen.getByRole("switch", { name: "Auto-upgrade" }));
+  await waitFor(() =>
+    expect(getToasts().some((t) => t.kind === "error" && t.text === "Toggle auto-upgrade failed: boom")).toBe(true),
+  );
+});
+
+test("Upgrade calls pluginUpgrade, toasts a checked-for-upgrades success, and is busy in flight", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  let resolveUpgrade: (v: { plugins: PluginEntry[] }) => void = () => {};
+  fake.on("evener/plugin/upgrade", (params) => {
+    expect(params).toEqual(TARGET);
+    return new Promise((resolve) => {
+      resolveUpgrade = resolve;
+    });
+  });
+  render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
+  const upgradeButton = screen.getByRole("button", { name: "Upgrade" });
+  await user.click(upgradeButton);
+  expect((upgradeButton as HTMLButtonElement).disabled).toBe(true);
+
+  resolveUpgrade({ plugins: [LINTER] });
+  await waitFor(() =>
+    expect(getToasts().some((t) => t.kind === "success" && t.text === "Checked linter for upgrades")).toBe(true),
+  );
+});
+
+test("a failed upgrade toasts failure", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  fake.on("evener/plugin/upgrade", () => {
+    throw new Error("boom");
+  });
+  render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
+  await user.click(screen.getByRole("button", { name: "Upgrade" }));
+  await waitFor(() =>
+    expect(getToasts().some((t) => t.kind === "error" && t.text === "Upgrade failed: boom")).toBe(true),
+  );
+});
+
+test("Remove opens a confirm; confirming removes, toasts, and closes the sheet", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  fake.on("evener/plugin/remove", (params) => {
+    expect(params).toEqual(TARGET);
+    return { plugins: [] };
+  });
+  const onClose = vi.fn();
+  render(<PluginDetailSheet target={TARGET} onClose={onClose} />);
+  await user.click(screen.getByRole("button", { name: "Remove" }));
+  const dialog = screen.getByRole("dialog", { name: "Remove plugin" });
+  expect(within(dialog).getByText('Remove plugin "linter"?')).toBeTruthy();
+  await user.click(within(dialog).getByRole("button", { name: "Remove" }));
+  await waitFor(() => expect(getToasts().some((t) => t.kind === "success" && t.text === "Removed linter")).toBe(true));
+  await waitFor(() => expect(onClose).toHaveBeenCalled());
+});
+
+test("cancelling the remove confirm does not call pluginRemove and keeps the sheet open", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  const removeSpy = vi.fn();
+  fake.on("evener/plugin/remove", removeSpy);
+  const onClose = vi.fn();
+  render(<PluginDetailSheet target={TARGET} onClose={onClose} />);
+  await user.click(screen.getByRole("button", { name: "Remove" }));
+  await user.click(screen.getByRole("button", { name: "Cancel" }));
+  expect(removeSpy).not.toHaveBeenCalled();
+  expect(onClose).not.toHaveBeenCalled();
+  expect(screen.getByRole("dialog", { name: "linter" })).toBeTruthy();
+});
+
+test("a failed remove toasts failure and keeps the sheet open", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  fake.on("evener/plugin/remove", () => {
+    throw new Error("boom");
+  });
+  const onClose = vi.fn();
+  render(<PluginDetailSheet target={TARGET} onClose={onClose} />);
+  await user.click(screen.getByRole("button", { name: "Remove" }));
+  const dialog = screen.getByRole("dialog", { name: "Remove plugin" });
+  await user.click(within(dialog).getByRole("button", { name: "Remove" }));
+  await waitFor(() =>
+    expect(getToasts().some((t) => t.kind === "error" && t.text === "Remove failed: boom")).toBe(true),
+  );
+  expect(onClose).not.toHaveBeenCalled();
+  expect(screen.getByRole("dialog", { name: "linter" })).toBeTruthy();
+});
+
+test("the remove confirm's buttons disable while the removal is in flight", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  fake.on("evener/plugin/remove", () => new Promise(() => {})); // never resolves - just observe the mid-flight state
+  render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
+  await user.click(screen.getByRole("button", { name: "Remove" }));
+  const dialog = screen.getByRole("dialog", { name: "Remove plugin" });
+  await user.click(within(dialog).getByRole("button", { name: "Remove" }));
+  expect((within(dialog).getByRole("button", { name: "Remove" }) as HTMLButtonElement).disabled).toBe(true);
+  expect((within(dialog).getByRole("button", { name: "Cancel" }) as HTMLButtonElement).disabled).toBe(true);
+});
+
+test("the close button calls onClose", async () => {
+  const user = userEvent.setup();
+  connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  const onClose = vi.fn();
+  render(<PluginDetailSheet target={TARGET} onClose={onClose} />);
+  await user.click(screen.getByRole("button", { name: "Close" }));
+  expect(onClose).toHaveBeenCalled();
+});
+
+test("lazily browses the marketplace and shows the catalog description when loaded", async () => {
+  const fake = connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  fake.on("evener/marketplace/browse", (params) => {
+    expect(params).toEqual({ name: "acme-plugins" });
+    return {
+      name: "acme-plugins",
+      plugins: [{ name: "linter", description: "Checks code style on every save." }],
+    };
+  });
+  render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
+  expect(fake.calls.some((c) => c.method === "evener/marketplace/browse")).toBe(true);
+  expect(await screen.findByText("Checks code style on every save.")).toBeTruthy();
+});
+
+test("does not re-browse a marketplace whose catalog is already cached", () => {
+  const fake = connectFakeClient();
+  extensionsStore.setState({
+    plugins: [LINTER],
+    marketplaces: [ACME],
+    browseCatalogs: new Map([
+      ["acme-plugins", { status: "loaded" as const, plugins: [{ name: "linter", description: "Checks code style." }] }],
+    ]),
+  });
+  render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
+  expect(fake.calls.some((c) => c.method === "evener/marketplace/browse")).toBe(false);
+  expect(screen.getByText("Checks code style.")).toBeTruthy();
+});
+
+test("closes itself when the entry disappears from the store (removed elsewhere)", async () => {
+  connectFakeClient();
+  extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  const onClose = vi.fn();
+  render(<PluginDetailSheet target={TARGET} onClose={onClose} />);
+  expect(screen.getByRole("dialog", { name: "linter" })).toBeTruthy();
+  extensionsStore.setState({ plugins: [] });
+  await waitFor(() => expect(onClose).toHaveBeenCalled());
+});

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/PluginDetailSheet.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/PluginDetailSheet.tsx
@@ -1,0 +1,208 @@
+// PluginDetailSheet: the plugin inspector for the Segmented Workspace
+// redesign. Opens from an InstalledSection row tap; owns every per-plugin
+// ACTION (enable/disable, auto-upgrade, upgrade, remove) so the list rows
+// stay single-target. A right side Sheet on desktop, a bottom Sheet on
+// mobile (same content, geometry follows useIsMobile). The catalog
+// description is lazily pulled from the browse cache (browseMarketplace
+// no-ops when the marketplace is already cached, so re-opens are free).
+import { useEffect, useState } from "react";
+import { errorText } from "../../../../protocol/errors";
+import { useIsMobile } from "../../../../shell/useIsMobile";
+import { extensionsStore, useExtensionsStore } from "../../../../stores/extensions";
+import { Button, Chip, ConfirmDialog, Sheet, Switch, useToasts } from "../../../../widgets";
+import { requireClass } from "../../../../widgets/internal/requireClass";
+import styles from "./marketplacesPlugins.module.css";
+import { sourceLabel } from "./sourceLabel";
+
+const CLASS = {
+  sheetDesc: requireClass(styles.sheetDesc, "marketplacesPlugins.module.css", "sheetDesc"),
+  chipRow: requireClass(styles.chipRow, "marketplacesPlugins.module.css", "chipRow"),
+  metaList: requireClass(styles.metaList, "marketplacesPlugins.module.css", "metaList"),
+  metaRow: requireClass(styles.metaRow, "marketplacesPlugins.module.css", "metaRow"),
+  metaLabel: requireClass(styles.metaLabel, "marketplacesPlugins.module.css", "metaLabel"),
+  metaValue: requireClass(styles.metaValue, "marketplacesPlugins.module.css", "metaValue"),
+  switchRows: requireClass(styles.switchRows, "marketplacesPlugins.module.css", "switchRows"),
+  rowMeta: requireClass(styles.rowMeta, "marketplacesPlugins.module.css", "rowMeta"),
+};
+
+export interface PluginDetailSheetProps {
+  target: { plugin: string; marketplace: string } | null;
+  onClose: () => void;
+}
+
+export function PluginDetailSheet({ target, onClose }: PluginDetailSheetProps) {
+  const plugins = useExtensionsStore((s) => s.plugins);
+  const marketplaces = useExtensionsStore((s) => s.marketplaces) ?? [];
+  const browseCatalogs = useExtensionsStore((s) => s.browseCatalogs);
+  const isMobile = useIsMobile();
+  const toasts = useToasts();
+
+  const [toggleBusy, setToggleBusy] = useState(false);
+  const [autoUpgradeBusy, setAutoUpgradeBusy] = useState(false);
+  const [upgradeBusy, setUpgradeBusy] = useState(false);
+  const [pendingRemove, setPendingRemove] = useState(false);
+  const [removeBusy, setRemoveBusy] = useState(false);
+
+  const entry =
+    target === null || plugins === null
+      ? undefined
+      : plugins.find((p) => p.plugin === target.plugin && p.marketplace === target.marketplace);
+
+  // The entry can vanish under an open sheet - a remove completing (this
+  // sheet's own or another client's), or a refetch after external change.
+  // An inspector for a thing that no longer exists closes itself rather
+  // than rendering stale actions.
+  useEffect(() => {
+    if (target !== null && plugins !== null && entry === undefined) onClose();
+  }, [target, plugins, entry, onClose]);
+
+  // Lazy catalog browse for the description. browseMarketplace no-ops when
+  // the marketplace already has a cache entry (loaded, errored, or in
+  // flight - see the store's own comment), so this fires once per
+  // marketplace, not once per open.
+  useEffect(() => {
+    if (target === null) return;
+    if (!extensionsStore.getState().browseCatalogs.has(target.marketplace)) {
+      void extensionsStore.getState().browseMarketplace(target.marketplace);
+    }
+  }, [target]);
+
+  async function handleToggleEnable(currentlyEnabled: boolean) {
+    if (target === null) return;
+    setToggleBusy(true);
+    try {
+      if (currentlyEnabled) await extensionsStore.getState().disablePlugin(target.plugin, target.marketplace);
+      else await extensionsStore.getState().enablePlugin(target.plugin, target.marketplace);
+    } catch (err) {
+      toasts.push("error", `Toggle enable failed: ${errorText(err)}`);
+    } finally {
+      setToggleBusy(false);
+    }
+  }
+
+  async function handleToggleAutoUpgrade(currentlyAutoUpgrade: boolean) {
+    if (target === null) return;
+    setAutoUpgradeBusy(true);
+    try {
+      await extensionsStore.getState().setPluginAutoUpgrade(target.plugin, target.marketplace, !currentlyAutoUpgrade);
+    } catch (err) {
+      toasts.push("error", `Toggle auto-upgrade failed: ${errorText(err)}`);
+    } finally {
+      setAutoUpgradeBusy(false);
+    }
+  }
+
+  async function handleUpgrade() {
+    if (target === null) return;
+    setUpgradeBusy(true);
+    try {
+      await extensionsStore.getState().upgradePlugin(target.plugin, target.marketplace);
+      toasts.push("success", `Checked ${target.plugin} for upgrades`);
+    } catch (err) {
+      toasts.push("error", `Upgrade failed: ${errorText(err)}`);
+    } finally {
+      setUpgradeBusy(false);
+    }
+  }
+
+  async function handleConfirmRemove() {
+    if (target === null) return;
+    setRemoveBusy(true);
+    try {
+      await extensionsStore.getState().removePlugin(target.plugin, target.marketplace);
+      toasts.push("success", `Removed ${target.plugin}`);
+      setPendingRemove(false);
+      // onClose fires via the entry-vanished effect above once the store's
+      // updated plugin list lands - no explicit close here.
+    } catch (err) {
+      toasts.push("error", `Remove failed: ${errorText(err)}`);
+    } finally {
+      setRemoveBusy(false);
+    }
+  }
+
+  const open = target !== null && entry !== undefined;
+
+  const cache = target === null ? undefined : browseCatalogs.get(target.marketplace);
+  const description =
+    cache?.status === "loaded" && entry !== undefined
+      ? cache.plugins.find((p) => p.name === entry.plugin)?.description
+      : undefined;
+  const marketplaceEntry = entry === undefined ? undefined : marketplaces.find((m) => m.name === entry.marketplace);
+
+  return (
+    <>
+      <Sheet
+        open={open}
+        onClose={onClose}
+        title={entry?.plugin ?? ""}
+        side={isMobile ? "bottom" : "right"}
+        footer={
+          entry !== undefined && (
+            <>
+              <Button variant="primary" onClick={() => void handleUpgrade()} disabled={upgradeBusy}>
+                Upgrade
+              </Button>
+              <Button variant="danger" onClick={() => setPendingRemove(true)}>
+                Remove
+              </Button>
+            </>
+          )
+        }
+      >
+        {entry !== undefined && (
+          <>
+            {(entry.broken || !entry.enabled || entry.autoUpgrade) && (
+              <div className={CLASS.chipRow}>
+                {entry.broken && <Chip tone="danger">broken</Chip>}
+                {!entry.enabled && <Chip tone="neutral">disabled</Chip>}
+                {entry.autoUpgrade && <Chip tone="neutral">auto-upgrade</Chip>}
+              </div>
+            )}
+            {description !== undefined && <p className={CLASS.sheetDesc}>{description}</p>}
+            <div className={CLASS.metaList}>
+              <div className={CLASS.metaRow}>
+                <span className={CLASS.metaLabel}>Version</span>
+                <span className={`${CLASS.metaValue} ${CLASS.rowMeta}`}>{`v${entry.version || "unknown"}`}</span>
+              </div>
+              <div className={CLASS.metaRow}>
+                <span className={CLASS.metaLabel}>Marketplace</span>
+                <span className={CLASS.metaValue}>{entry.marketplace}</span>
+              </div>
+              {marketplaceEntry !== undefined && (
+                <div className={CLASS.metaRow}>
+                  <span className={CLASS.metaLabel}>Source</span>
+                  <span className={`${CLASS.metaValue} ${CLASS.rowMeta}`}>{sourceLabel(marketplaceEntry.source)}</span>
+                </div>
+              )}
+            </div>
+            <div className={CLASS.switchRows}>
+              <Switch
+                checked={entry.enabled}
+                onChange={() => void handleToggleEnable(entry.enabled)}
+                disabled={toggleBusy}
+                label="Enabled"
+              />
+              <Switch
+                checked={entry.autoUpgrade}
+                onChange={() => void handleToggleAutoUpgrade(entry.autoUpgrade)}
+                disabled={autoUpgradeBusy}
+                label="Auto-upgrade"
+              />
+            </div>
+          </>
+        )}
+      </Sheet>
+      <ConfirmDialog
+        open={pendingRemove && target !== null}
+        title="Remove plugin"
+        confirmLabel="Remove"
+        busy={removeBusy}
+        onConfirm={() => void handleConfirmRemove()}
+        onCancel={() => setPendingRemove(false)}
+      >
+        {target !== null ? `Remove plugin "${target.plugin}"?` : ""}
+      </ConfirmDialog>
+    </>
+  );
+}

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/index.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/index.test.tsx
@@ -1,14 +1,44 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { FakeClient } from "../../../../protocol/testing/fakeClient";
+import type { MarketplaceEntry, PluginEntry } from "../../../../protocol/types.gen";
 import { connectionStore } from "../../../../stores/connection";
 import { resetExtensionsStoreForTests } from "../../../../stores/extensions";
 import { resetToastStoreForTests } from "../../../../widgets/toast/store";
 import { MarketplacesPluginsSection } from "./index";
 
+const LINTER: PluginEntry = {
+  plugin: "linter",
+  marketplace: "acme-plugins",
+  version: "1.2.0",
+  enabled: true,
+  autoUpgrade: false,
+  broken: false,
+  installPath: "/x",
+  installedAt: 1,
+  lastUpdated: 1,
+};
+
+const ACME: MarketplaceEntry = {
+  name: "acme-plugins",
+  source: { kind: "github", repo: "acme/plugins" },
+  lastUpdated: 1,
+};
+
 function connectFakeClient(): FakeClient {
   const fake = new FakeClient("ready");
   connectionStore.getState().connect(fake);
+  return fake;
+}
+
+// Registers list handlers returning one marketplace + one plugin, so the
+// section's own mount fetch populates the store (the same path production
+// takes) instead of the test forcing store state around it.
+function connectSeededClient(): FakeClient {
+  const fake = connectFakeClient();
+  fake.on("evener/marketplace/list", () => ({ marketplaces: [ACME] }));
+  fake.on("evener/plugin/list", () => ({ plugins: [LINTER] }));
   return fake;
 }
 
@@ -36,9 +66,7 @@ test("fetches both marketplaces and plugins in parallel on mount", async () => {
   fake.on("evener/marketplace/list", () => ({ marketplaces: [] }));
   fake.on("evener/plugin/list", () => ({ plugins: [] }));
   render(<MarketplacesPluginsSection />);
-  expect(await screen.findByText("Marketplaces")).toBeTruthy();
-  expect(screen.getByText("Browse")).toBeTruthy();
-  expect(screen.getByText("Installed")).toBeTruthy();
+  expect(await screen.findByRole("radiogroup", { name: "View" })).toBeTruthy();
   expect(fake.calls.some((c) => c.method === "evener/marketplace/list")).toBe(true);
   expect(fake.calls.some((c) => c.method === "evener/plugin/list")).toBe(true);
 });
@@ -55,9 +83,7 @@ test("shows one failed-to-load message replacing everything when the marketplace
   expect(screen.getByText("Something went wrong.")).toBeTruthy();
   // Assert the raw string no longer appears
   expect(screen.queryByText("network down")).toBeNull();
-  expect(screen.queryByText("Marketplaces")).toBeNull();
-  expect(screen.queryByText("Browse")).toBeNull();
-  expect(screen.queryByText("Installed")).toBeNull();
+  expect(screen.queryByRole("radiogroup", { name: "View" })).toBeNull();
 });
 
 test("shows one failed-to-load message when the plugin list fails to load", async () => {
@@ -72,4 +98,59 @@ test("shows one failed-to-load message when the plugin list fails to load", asyn
   expect(screen.getByText("Something went wrong.")).toBeTruthy();
   // Assert the raw string no longer appears
   expect(screen.queryByText("boom")).toBeNull();
+});
+
+test("the segment control carries the list counts and defaults to Installed", async () => {
+  connectSeededClient();
+  render(<MarketplacesPluginsSection />);
+  const installed = await screen.findByRole("radio", { name: "Installed (1)" });
+  expect(installed.getAttribute("aria-checked")).toBe("true");
+  expect(screen.getByRole("radio", { name: "Browse" }).getAttribute("aria-checked")).toBe("false");
+  expect(screen.getByRole("radio", { name: "Marketplaces (1)" }).getAttribute("aria-checked")).toBe("false");
+});
+
+test("the Installed segment is the default view; other segments' lists are hidden", async () => {
+  connectSeededClient();
+  render(<MarketplacesPluginsSection />);
+  expect(await screen.findByRole("list", { name: "Installed plugins" })).toBeTruthy();
+  expect(screen.queryByRole("list", { name: "Marketplace browse tree" })).toBeNull();
+  expect(screen.queryByRole("list", { name: "Marketplaces" })).toBeNull();
+});
+
+test("switching to the Browse segment shows the browse tree and hides installed rows", async () => {
+  const user = userEvent.setup();
+  connectSeededClient();
+  render(<MarketplacesPluginsSection />);
+  await user.click(await screen.findByRole("radio", { name: "Browse" }));
+  expect(screen.getByRole("list", { name: "Marketplace browse tree" })).toBeTruthy();
+  expect(screen.queryByRole("list", { name: "Installed plugins" })).toBeNull();
+});
+
+test("switching to the Marketplaces segment shows the marketplace list and hides installed rows", async () => {
+  const user = userEvent.setup();
+  connectSeededClient();
+  render(<MarketplacesPluginsSection />);
+  await user.click(await screen.findByRole("radio", { name: "Marketplaces (1)" }));
+  expect(screen.getByRole("list", { name: "Marketplaces" })).toBeTruthy();
+  expect(screen.queryByRole("list", { name: "Installed plugins" })).toBeNull();
+});
+
+test("clicking an installed row opens the detail sheet; its close button dismisses it", async () => {
+  const user = userEvent.setup();
+  connectSeededClient();
+  render(<MarketplacesPluginsSection />);
+  await user.click(await screen.findByRole("button", { name: /linter/ }));
+  expect(await screen.findByRole("dialog", { name: "linter" })).toBeTruthy();
+  await user.click(screen.getByRole("button", { name: "Close" }));
+  await waitFor(() => expect(screen.queryByRole("dialog", { name: "linter" })).toBeNull());
+});
+
+test("switching segments while the detail sheet is open closes it", async () => {
+  const user = userEvent.setup();
+  connectSeededClient();
+  render(<MarketplacesPluginsSection />);
+  await user.click(await screen.findByRole("button", { name: /linter/ }));
+  expect(await screen.findByRole("dialog", { name: "linter" })).toBeTruthy();
+  await user.click(screen.getByRole("radio", { name: "Browse" }));
+  await waitFor(() => expect(screen.queryByRole("dialog", { name: "linter" })).toBeNull());
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/index.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/index.tsx
@@ -1,37 +1,37 @@
 // marketplacesPlugins/index.tsx is the "Marketplaces & Plugins" settings
-// section (#12 - parity-m7-settings.md §12) - the wave's second-dominant
-// piece after Credentials. Orchestrates the 3 sub-sections
-// (Marketplaces/Browse/Installed): fetches both lists in parallel on mount
-// (mirroring the legacy's own `Promise.all([refreshMarketplaces(),
-// refreshInstalled()])`), and owns `expandedMarketplaces` - lifted here
-// rather than owned by BrowseSection alone, because MarketplacesSection's
-// Refresh action needs to read it too (see that component's own comment).
+// section (#12 - parity-m7-settings.md §12), Segmented Workspace redesign:
+// one list at a time behind a page-level SegmentedControl (Installed /
+// Browse / Marketplaces) instead of the three stacked sub-sections the
+// parity wave shipped. Per-plugin actions live in the PluginDetailSheet
+// opened from an Installed row, so each segment stays a single-purpose
+// list. The orchestrator's jobs are unchanged in kind: the initial parallel
+// fetch (mirroring the legacy's own Promise.all), the top-level
+// loading/error gate, and the lifted `expandedMarketplaces` (see
+// MarketplacesSection's own comment for why Refresh needs to read it); on
+// top of those it owns the two new page-level states, activeSegment and
+// selectedPlugin.
 import { useEffect, useState } from "react";
 import { friendlyErrorMessage } from "../../../../protocol/errors";
 import { connectionStore } from "../../../../stores/connection";
 import { extensionsStore, useExtensionsStore } from "../../../../stores/extensions";
-import { EmptyState, Skeleton } from "../../../../widgets";
+import { EmptyState, SegmentedControl, Skeleton } from "../../../../widgets";
 import { requireClass } from "../../../../widgets/internal/requireClass";
 import { BrowseSection } from "./BrowseSection";
 import { InstalledSection } from "./InstalledSection";
 import { MarketplacesSection } from "./MarketplacesSection";
 import styles from "./marketplacesPlugins.module.css";
+import { PluginDetailSheet } from "./PluginDetailSheet";
 
 const CLASS = {
   page: requireClass(styles.page, "marketplacesPlugins.module.css", "page"),
-  pageTitle: requireClass(styles.pageTitle, "marketplacesPlugins.module.css", "pageTitle"),
-  pageHelp: requireClass(styles.pageHelp, "marketplacesPlugins.module.css", "pageHelp"),
 };
 
+type SegmentId = "installed" | "browse" | "marketplaces";
+
 /**
- * The settings section for #12. Every mutation across the 3 sub-sections
- * goes straight through stores/extensions.ts (each RPC response already
- * carries the updated list - see that store's own doc comment), so this
- * orchestrator's only jobs are the initial parallel fetch, the top-level
- * loading/error gate (matching the legacy's own "initial load throws ->
- * replace the entire root with one message, no partial UI, no retry"
- * behavior - templates/partials/settings/plugins-manager.html:326-329),
- * and lifting `expandedMarketplaces`.
+ * The settings section for #12. Every mutation across the segments goes
+ * straight through stores/extensions.ts (each RPC response already carries
+ * the updated list - see that store's own doc comment).
  */
 export function MarketplacesPluginsSection() {
   const marketplaces = useExtensionsStore((s) => s.marketplaces);
@@ -41,6 +41,8 @@ export function MarketplacesPluginsSection() {
   const pluginsLoading = useExtensionsStore((s) => s.pluginsLoading);
   const pluginsError = useExtensionsStore((s) => s.pluginsError);
   const [expandedMarketplaces, setExpandedMarketplaces] = useState<Set<string>>(new Set());
+  const [activeSegment, setActiveSegment] = useState<SegmentId>("installed");
+  const [selectedPlugin, setSelectedPlugin] = useState<{ plugin: string; marketplace: string } | null>(null);
 
   // Mirrors DirListSetting's own mount-effect shape (see that component's
   // comment): waits for the shared client to actually be ready before
@@ -58,30 +60,54 @@ export function MarketplacesPluginsSection() {
     return connectionStore.subscribe(tryStart);
   }, []);
 
+  function handleSegmentChange(segment: SegmentId) {
+    setActiveSegment(segment);
+    // The detail sheet belongs to the Installed list; navigating away from
+    // the segment that opened it closes it rather than leaving an inspector
+    // floating over an unrelated list.
+    setSelectedPlugin(null);
+  }
+
   const loadError = marketplacesError ?? pluginsError;
   const stillLoading = (marketplacesLoading || marketplaces === null) && (pluginsLoading || plugins === null);
 
+  if (loadError !== null) {
+    return (
+      <section className={CLASS.page}>
+        <EmptyState title="Failed to load" hint={friendlyErrorMessage(loadError)} />
+      </section>
+    );
+  }
+  if (stillLoading) {
+    return (
+      <section className={CLASS.page}>
+        <Skeleton />
+      </section>
+    );
+  }
+
+  const pluginCount = plugins?.length ?? 0;
+  const marketplaceCount = marketplaces?.length ?? 0;
+
   return (
     <section className={CLASS.page}>
-      <h2 className={CLASS.pageTitle}>Marketplaces &amp; Plugins</h2>
-      <p className={CLASS.pageHelp}>
-        Marketplaces are catalogs of installable plugins. Register a marketplace, browse its catalog, and install what
-        you need — installed, enabled plugins load into every new evener session.
-      </p>
-      {loadError !== null ? (
-        <EmptyState title="Failed to load" hint={friendlyErrorMessage(loadError)} />
-      ) : stillLoading ? (
-        <Skeleton />
-      ) : (
-        <>
-          <MarketplacesSection expandedMarketplaces={expandedMarketplaces} />
-          <BrowseSection
-            expandedMarketplaces={expandedMarketplaces}
-            setExpandedMarketplaces={setExpandedMarketplaces}
-          />
-          <InstalledSection />
-        </>
+      <SegmentedControl
+        label="View"
+        value={activeSegment}
+        onChange={(value) => handleSegmentChange(value as SegmentId)}
+        options={[
+          { value: "installed", label: `Installed (${pluginCount})` },
+          { value: "browse", label: "Browse" },
+          { value: "marketplaces", label: `Marketplaces (${marketplaceCount})` },
+        ]}
+        fullWidth
+      />
+      {activeSegment === "installed" && <InstalledSection onSelect={setSelectedPlugin} />}
+      {activeSegment === "browse" && (
+        <BrowseSection expandedMarketplaces={expandedMarketplaces} setExpandedMarketplaces={setExpandedMarketplaces} />
       )}
+      {activeSegment === "marketplaces" && <MarketplacesSection expandedMarketplaces={expandedMarketplaces} />}
+      <PluginDetailSheet target={selectedPlugin} onClose={() => setSelectedPlugin(null)} />
     </section>
   );
 }

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/marketplacesPlugins.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/marketplacesPlugins.module.css
@@ -10,42 +10,10 @@
   gap: var(--space-5);
 }
 
-.pageTitle {
-  margin: 0;
-  color: var(--ink-hi);
-  font-size: var(--font-size-pane-title);
-  font-weight: var(--font-weight-semibold);
-}
-
-.pageHelp {
-  margin: 0;
-  color: var(--ink-mid);
-  font-size: var(--font-size-ui);
-}
-
 .section {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-}
-
-.header {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: var(--space-2);
-}
-
-.title {
-  margin: 0;
-  color: var(--ink-hi);
-  font-size: var(--font-size-body);
-  font-weight: var(--font-weight-semibold);
-}
-
-.count {
-  color: var(--ink-mid);
-  font-size: var(--font-size-caption);
 }
 
 .list {
@@ -205,4 +173,95 @@
 .installedBadge {
   color: var(--ink-mid);
   font-size: var(--font-size-caption);
+}
+
+/* Tappable installed-plugin row (Segmented Workspace redesign): one full-
+ * width button per row so the whole row is the select target on both desktop
+ * and mobile; actions live in the detail sheet, not the row. Shares .row's
+ * visual language (surface, edge, radius-control) but resets button chrome. */
+.rowButton {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-control);
+  background: var(--surface-1);
+  color: var(--ink-hi);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-ui);
+  text-align: left;
+  cursor: pointer;
+  transition: background-color var(--motion-duration-hover) var(--motion-easing-standard);
+}
+
+.rowButton:hover {
+  background: var(--hover-1);
+}
+
+.rowButton:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -2px;
+}
+
+@media (max-width: 900px) {
+  .rowButton {
+    min-height: var(--tap-min);
+  }
+}
+
+.rowChevron {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  color: var(--ink-low);
+}
+
+/* PluginDetailSheet body layout (Segmented Workspace redesign). */
+.sheetDesc {
+  margin: 0;
+  color: var(--ink-hi);
+  font-size: var(--font-size-ui);
+}
+
+.chipRow {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  margin-bottom: var(--space-3);
+}
+
+.metaList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: var(--space-4) 0;
+}
+
+.metaRow {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+}
+
+.metaLabel {
+  flex: none;
+  width: 96px;
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}
+
+.metaValue {
+  min-width: 0;
+  color: var(--ink-hi);
+  font-size: var(--font-size-ui);
+}
+
+.switchRows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
 }

--- a/docs/superpowers/specs/2026-08-28-provider-model-contract-program-design.md
+++ b/docs/superpowers/specs/2026-08-28-provider-model-contract-program-design.md
@@ -1,0 +1,441 @@
+# Provider and Model Contract Program Design
+
+Date: 2026-08-28
+Status: draft for review; implementation not started
+Decision: clean redesign; no backward-compatibility requirement
+
+## Purpose
+
+Evener needs more than a model list. It needs a trustworthy answer to four separate questions:
+
+1. Which model identity is being requested?
+2. Which provider serving surface will answer it?
+3. Which request and response contract is legal on that surface?
+4. What limits, capabilities, economics, and evidence describe that exact serving variant?
+
+The current system answers these questions with provider-name defaults, an instance-wide API style, and a broad LiteLLM snapshot. That arrangement permits a provider such as Groq to receive an OpenAI Responses request containing fields and server tools it does not accept.
+
+This design splits the work into independently shippable projects. The first project is the serving-contract core described in `docs/superpowers/specs/2026-08-28-serving-contract-core-design.md`. This document defines the program around it: trusted configuration, curated contracts, external metadata, inventory discovery, diagnostics, presentation, and any future fallback.
+
+## Product requirements
+
+### Hard requirements
+
+- Every model request resolves one explicit serving surface before network dispatch.
+- Request shaping is governed by an Evener-owned typed contract scoped to the provider instance, wire model, surface, API version, and deployment/entitlement scope.
+- Optional fields are emitted only when the selected contract permits them.
+- Unknown is distinct from unsupported, and neither enables optional behavior.
+- A caller-requested semantic feature that cannot be represented fails before dispatch instead of being silently dropped.
+- Provider destination, authentication, credential headers, and redirects are controlled only by trusted configuration and curated code.
+- Agent capability exposure and adapter request construction consume the same resolved serving variant.
+- Provider-native history and continuation state cannot cross surface boundaries without provenance validation.
+- Runtime correctness does not depend on an external catalog or live provider discovery.
+- Default tests are deterministic and offline.
+- Metadata claims retain source, revision, scope, retrieval time, and confidence.
+- Errors identify the provider instance, wire model, surface, contract, and failing phase without exposing credentials.
+
+### Secondary requirements
+
+- Support one wire model on multiple serving surfaces.
+- Enrich context limits, output limits, modalities, reasoning levels, tools, structured output, aliases, and pricing.
+- Show users why a model/surface was selected and which capabilities remain unknown.
+- Permit explicit diagnostic checks without making ordinary startup expensive or nondeterministic.
+- Provide a path to provider-specific fallback only when a provider proves that retrying another surface is safe.
+
+### Non-goals
+
+- Universal protocol introspection.
+- Automatic adapter generation from catalog data.
+- Treating model capability flags as proof of request-field compatibility.
+- Runtime catalog downloads as a correctness dependency.
+- Catalog-controlled URLs, authentication, headers, redirects, or arbitrary request bodies.
+- Price enforcement from third-party estimates.
+- Generic retry of LLM POSTs across protocols.
+- Silent semantic downgrade to make a request succeed.
+
+## Core model
+
+### Model identity
+
+A model identity is a name-resolution object:
+
+- provider instance;
+- canonical model ID, if known;
+- wire model ID;
+- aliases explicitly documented for that instance;
+- requested name and resolved name for diagnostics.
+
+Aliases are one-way mappings. Exact wire IDs beat aliases. Duplicate, cyclic, ambiguous, or cross-instance aliases fail closed. An accepted alias does not imply equivalent limits or capabilities.
+
+### Provider integration
+
+A provider integration identifies how a configured instance can be served:
+
+- curated adapter ID and implementation revision;
+- trusted origin and credential binding;
+- available serving surfaces;
+- provider-level defaults;
+- model inventory and model-ID translation rules.
+
+The integration is not the same thing as a model contract. A provider may serve one model through several APIs with different capabilities and fields.
+
+### Serving variant
+
+A serving variant is the executable identity:
+
+```
+provider instance + wire model ID + serving surface + API version
+```
+
+It contains:
+
+- model identity;
+- adapter ID and implementation revision;
+- surface/API family and version;
+- endpoint path selected by the adapter;
+- credential-scope reference;
+- immutable request/response contract;
+- exact limits and capabilities for that surface;
+- effective contract revision.
+
+The normalized base URL and authentication come from trusted instance configuration. External metadata may describe an integration, but it cannot change the destination that receives a prompt.
+
+### Contract
+
+The contract is typed and immutable. It has independent policy for:
+
+- optional request fields;
+- semantic feature requirements;
+- modalities and attachments;
+- tools and server tools;
+- tool choice and strict schemas;
+- reasoning controls and wire-level mapping;
+- roles, history replay, and continuation handles;
+- generation fields, output caps, stop sequences, and sampling;
+- streaming usage and event grammar;
+- response shape and finish reasons.
+
+Each capability and optional field has one of four states:
+
+- `supported` — use is permitted;
+- `unsupported` — use is forbidden;
+- `unknown` — no trusted claim exists, so optional use is forbidden;
+- `conflict` — equally authoritative claims disagree, so resolution fails.
+
+Each field also declares its semantic class:
+
+- `semantic` — omission changes caller intent and must fail before dispatch;
+- `optional` — omission preserves intent;
+- `required` — the adapter must emit it as part of the surface's core request.
+
+This prevents a generic “omit unsupported fields” rule from silently dropping a requested tool, schema, modality, output cap, or stop condition.
+
+### Evidence and claims
+
+A claim is a statement about one field of one serving variant. It carries:
+
+- field path;
+- value and state;
+- source class;
+- source revision or content hash;
+- retrieval/observation time;
+- scope, including instance, origin, model, surface, API version, region, deployment, and entitlement where relevant;
+- confidence and review/expiry metadata.
+
+Sources are not interchangeable. A catalog estimate, provider documentation claim, explicit user override, and successful probe have different authority and failure modes.
+
+## Source strategy
+
+### Curated typed Evener registry: executable authority
+
+Evener's typed registry is authoritative for:
+
+- adapter selection;
+- supported surface families;
+- request and response transformation;
+- credential policy;
+- safe endpoint paths;
+- field policies and semantic-loss behavior;
+- provider-specific server-tool and reasoning dialects.
+
+The registry is code-reviewed, allowlisted, and versioned with the adapter implementation. A catalog cannot instantiate a new adapter or apply an arbitrary body transform.
+
+### LiteLLM: broad enrichment source
+
+Keep the vendored LiteLLM snapshot as the broad enrichment source for:
+
+- model inventory breadth;
+- context and output limits;
+- pricing dimensions;
+- common capability flags;
+- aliases and provider-qualified model identifiers where present;
+- endpoint hints such as `mode` and `supported_endpoints`.
+
+LiteLLM's catalog is an advisory map, not a portable Evener wire contract. Its fields describe LiteLLM's model/provider knowledge, while important compatibility behavior also lives in LiteLLM provider transformation code. The snapshot is MIT-licensed under the repository's non-enterprise terms, but model and provider licenses remain separate.
+
+### Models.dev: provider/inventory enrichment source
+
+Use a pinned Models.dev snapshot as a supplemental source for:
+
+- normalized provider/model inventory;
+- provider API base metadata;
+- adapter/package integration hints such as `npm`;
+- modalities, reasoning options, limits, dates, and simple pricing.
+
+Models.dev's `npm` field names an AI SDK package, not an Evener adapter. Its provider/model shape is sparse and cannot authorize an Evener request field. Translate it through an allowlisted Evener mapping. Models.dev is MIT-licensed; model/provider licenses remain separate.
+
+Do not replace LiteLLM with Models.dev. LiteLLM is broader for the enrichment already used by Evener. Models.dev is cleaner for provider-oriented inventory and integration hints. Both are useful inputs to one normalized claim pipeline; neither is executable authority.
+
+### Provider documentation
+
+Official provider documentation informs curated registry entries. Documentation references are stored with the curated profile and reviewed when API versions or beta features change. “OpenAI-compatible” is not treated as “OpenAI-equivalent.”
+
+### Runtime sources
+
+A provider's `/models` response is an inventory source unless that provider explicitly documents richer fields. An ordinary model-list response does not establish protocol, tool, reasoning, cache, or request-field support.
+
+An opt-in diagnostic probe is runtime evidence for the exact request shape it exercised. A successful response proves acceptance of that request, not that every related field is semantically honored. Failed probes distinguish authentication, quota, outage, moderation, invalid model, and unsupported feature; only the last can affect a capability claim.
+
+## Authority and precedence
+
+There is no global source precedence. Resolution is field-specific.
+
+| Domain | Authority order | Rule |
+|---|---|---|
+| Origin, credentials, headers, redirects | trusted explicit config → curated registry | External sources cannot write executable routing or authentication. |
+| Adapter and serving surface | explicit trusted selection → curated registry | Catalog protocol hints are advisory only. |
+| Request transforms | typed adapter contract → curated provider/model/surface delta → explicit typed override | Arbitrary body passthrough is forbidden. |
+| Capabilities | trusted surface override → curated documentation/profile → exact positive runtime evidence → external claim | Preserve unknown, unsupported, and conflict. |
+| Limits | account/deployment config → curated serving value → exact provider field → external estimate | Context, input, and output are separate. |
+| Pricing | account contract/rate sheet → curated rate → external estimate | Preserve units, currency, region, tier, effective date, and unknown. |
+| Aliases | explicit alias → provider-documented alias → curated alias | Accepted IDs do not prove equivalence. |
+| Inventory | provider `/models` → pinned catalog | Inventory cannot alter executable contract. |
+
+Within a trusted layer, incompatible values are a configuration conflict. A higher-priority explicit value replaces a lower-priority default. External conflicts remain diagnostic and resolve to unknown for request construction. No source can silently turn unknown into supported.
+
+## Trust boundary
+
+Only user-global/state-root provider configuration is discovered implicitly. Project-local provider configuration is not discovered automatically.
+
+An explicitly selected configuration path must be:
+
+- owned by the current user;
+- a regular file, not a symlink;
+- not group/world writable;
+- located under a non-group/world-writable parent;
+- explicitly selected when outside the default state root.
+
+A credential reference is bound to its instance and normalized origin. First-party API keys and OAuth records are valid only for curated first-party origins. A custom origin requires an instance-scoped credential or explicit credential header. Missing or mismatched binding fails before transport. Redirects cannot forward credentials across origins.
+
+Project-local configuration may later be supported only through an explicit trust/consent mechanism. It must never become an ambient source of destinations or credentials merely because Evener entered a repository.
+
+## Project decomposition
+
+Each project below has one contract, one acceptance boundary, and an explicit non-scope. Projects can be reviewed and landed independently.
+
+### Project 0: incident mitigation
+
+**Contract:** Configure Groq to use the known-safe Chat Completions surface until the serving-contract core supports an explicit Groq Responses profile.
+
+**Acceptance:** The local Groq configuration no longer sends the rejected Responses request. No application code or catalog behavior changes.
+
+**Non-scope:** General metadata, config schema, discovery, diagnostics, and fallback.
+
+### Project 1: serving-contract core
+
+**Contract:** Resolve one immutable serving variant and use it for agent capability exposure, request validation, adapter shaping, history replay, and session identity.
+
+**Required behavior:**
+
+- clean model/surface configuration;
+- deterministic surface selection;
+- typed field and capability states;
+- semantic-loss errors before transport;
+- trusted credential/origin binding;
+- provenance-aware history replay;
+- exact contract revision persisted with session identity;
+- curated profiles for every retained adapter surface.
+
+**Acceptance:** Fake-transport request goldens prove legal OpenAI, compatible Chat, Groq, Anthropic, Google, Kimi, MiniMax, and OpenRouter surfaces. Unknown surfaces and adapters fail before dispatch. Unknown model metadata on a known surface emits only required core fields. The full first-slice acceptance suite is specified in `2026-08-28-serving-contract-core-design.md`.
+
+**Non-scope:** External catalog ingestion, `/models` enrichment, live probes, UI, and cross-protocol fallback.
+
+### Project 2: normalized metadata and offline catalog pipeline
+
+**Contract:** Import pinned LiteLLM and Models.dev snapshots into provenance-bearing Evener claims without changing executable routing or request behavior.
+
+**Pipeline:**
+
+1. Fetch exact upstream revisions in a maintainer-controlled refresh operation.
+2. Validate JSON/TOML shape, entry counts, license notices, and required fields.
+3. Parse each source into separate claims rather than merging source objects.
+4. Normalize identity, limits, modalities, capabilities, pricing, aliases, `mode`, endpoint hints, and provider integration hints.
+5. Apply field-specific conflict rules.
+6. Overlay reviewed Evener claims and materialize a generated artifact.
+7. Emit a human-readable drift/conflict report.
+
+**Acceptance:** Runtime uses only the pinned generated artifact. A source update is reproducible from its revision/hash. Removed or changed upstream entries produce a reviewable report. External data cannot alter adapter, URL, auth, or request-body behavior. Unknown fields survive normalization as unknown.
+
+**Non-scope:** Live fetching at startup, automatic protocol selection, arbitrary provider adapters, and direct catalog-to-body passthrough.
+
+### Project 3: provider inventory discovery
+
+**Contract:** Query a configured provider's documented inventory endpoint and publish available wire IDs and explicitly advertised metadata.
+
+**Behavior:**
+
+- inventory is keyed by instance and origin;
+- credentials use the instance binding from Project 1;
+- a failed refresh retains the last good inventory with stale status;
+- a successful inventory may add/remove selectable wire IDs;
+- absent capability fields remain unknown;
+- inventory cannot change protocol, request fields, auth, or destination.
+
+**Acceptance:** Fake providers cover authentication, pagination, malformed payloads, stale retention, explicit capability fields, duplicate IDs, and provider-specific endpoint paths. No inventory response changes a serving contract without a curated mapping.
+
+**Non-scope:** Inference calls, protocol probes, semantic capability inference, and fallback.
+
+### Project 4: opt-in diagnostics and evidence cache
+
+**Contract:** Let a user explicitly test a selected serving variant and record exact-scope evidence without changing runtime behavior implicitly.
+
+**Probe rules:**
+
+- explicit doctor/preflight command or UI action;
+- clear disclosure that the call may cost money, consume quota, be logged, or trigger moderation;
+- minimal non-sensitive input;
+- no tools, uploads, provider state, continuation handles, cache fields, or background mode;
+- smallest practical output cap;
+- one feature per probe where possible;
+- no probe on ordinary startup or default tests.
+
+**Evidence key:**
+
+```
+instance + normalized URL/path + wire model + surface/API version
++ adapter revision + deployment/region/entitlement
++ relevant headers/options + stream mode + exact feature/schema hash
++ non-secret credential-scope fingerprint
+```
+
+Positive evidence expires. Negative capability evidence expires separately. Authentication, quota, outage, moderation, timeout, and transport failures never become negative capability claims. Configuration, adapter, API-version, and credential-scope changes invalidate evidence.
+
+**Acceptance:** Probes require explicit consent, never persist secrets, retain exact scope and failure class, do not rewrite providers configuration, and never affect default runtime decisions without a reviewed override.
+
+**Non-scope:** Automatic probing, arbitrary prompts, continuation proof, and protocol fallback.
+
+### Project 5: metadata presentation
+
+**Contract:** Expose the resolved serving variant and its claims so users can understand why a request will or will not be sent.
+
+**Presentation:**
+
+- selected provider instance, model, surface, adapter, and contract revision;
+- supported, unsupported, unknown, and conflict states;
+- source and age of important claims;
+- stale inventory/evidence indicators;
+- semantic features that will fail before dispatch;
+- explicit overrides and their scope;
+- provider documentation links.
+
+**Acceptance:** CLI, hub, and web views render the same typed descriptor. Presentation never invents capabilities and never changes resolver output.
+
+**Non-scope:** Contract resolution, request shaping, catalog refresh, and live probes.
+
+### Project 6: provider-specific protocol fallback
+
+**Contract:** Permit one rebuilt alternate request only for a provider/surface transition whose error proves the first request was not applied or whose idempotency is documented.
+
+Fallback requires all of:
+
+- provider-specific structured evidence of wrong surface;
+- no response event or output byte;
+- provider guarantee of non-execution or valid cross-surface idempotency;
+- semantic intersection of both surfaces;
+- rebuilt request through the alternate adapter;
+- one alternate attempt maximum;
+- durable logging of both attempts and the reason.
+
+Generic 400/404/422, timeout, connection reset, auth, quota, moderation, model-not-found, partial stream, or empty answer never triggers fallback. Responses-only state, server tools, uploads, background work, and continuation never downgrade silently.
+
+**Acceptance:** Provider-specific fake tests prove allowed and disallowed transitions, exact one-attempt behavior, semantic-feature rejection, and API-log visibility.
+
+**Non-scope:** This project is not part of the initial serving-contract release.
+
+## Runtime data flow
+
+```text
+trusted config + curated registry
+        │
+        ├── instance/origin/credential validation
+        ├── model alias resolution
+        ├── explicit surface selection
+        └── serving-variant resolver
+                    │
+                    ├── agent capability/profile projection
+                    ├── adapter request contract
+                    ├── session variant identity
+                    └── API-log contract identity
+
+pinned LiteLLM/Models.dev claims ──> advisory enrichment only
+provider /models inventory       ──> selectable IDs + explicit fields only
+opt-in diagnostic evidence       ──> scoped claims + report only
+```
+
+The resolver has no network dependency. The adapter cannot replace the variant after resolution. The agent cannot expose a feature the adapter contract forbids. A provider-native history artifact cannot cross surfaces without a typed translation or a pre-dispatch error.
+
+## Persistence and invalidation
+
+Session metadata stores the selected instance, canonical/wire model IDs, surface, API version, effective-contract revision, credential-scope fingerprint, and continuation/state compatibility marker. Resume requires that exact variant and revision. A missing or incompatible revision produces a recovery/migration error.
+
+Catalog snapshots, inventory records, runtime evidence, and session identity have separate storage and invalidation policies:
+
+- catalog artifact: replaced only by a reviewed generated refresh;
+- inventory: per instance/origin, stale-retained on transient refresh failure;
+- evidence: exact scope, bounded TTL, invalidated by relevant revisions;
+- session identity: immutable for the session unless an explicit model/surface switch creates a new request identity.
+
+No credential, prompt, raw authorization header, or secret-bearing catalog field is stored in evidence or API-log identity.
+
+## Rollout and gates
+
+1. Apply incident mitigation for Groq.
+2. Land Project 1 with curated contracts and deterministic request goldens.
+3. Land Project 2 as an offline enrichment pipeline; keep its claims advisory.
+4. Land Project 3 for documented inventory only.
+5. Land Project 4 for explicit diagnostics and scoped evidence.
+6. Land Project 5 for explainability.
+7. Consider Project 6 only after a concrete provider supplies non-execution/idempotency evidence.
+
+Every project must pass the normal Go tests, vet, lint, generated-output checks, secret scan, and deterministic test policy. Live provider checks remain explicit opt-in and separate from default gates.
+
+## Program acceptance criteria
+
+The full program is complete only when:
+
+- every selectable model resolves to an explicit serving variant;
+- every retained adapter surface has a typed contract and baseline wire tests;
+- no unknown or external claim can enable an optional field or redirect traffic;
+- semantic request features fail clearly rather than disappearing;
+- credentials cannot cross their bound origin;
+- provider-native state cannot cross incompatible surfaces;
+- catalogs are pinned, reproducible, licensed, and advisory;
+- inventory does not masquerade as capability proof;
+- diagnostics are explicit, scoped, and non-authoritative by default;
+- fallback is absent unless a provider-specific proof justifies it;
+- session resume pins the serving variant and contract revision;
+- CLI/hub/web presentation agrees with the resolver;
+- default tests and startup require no provider credentials, network, quota, or current model behavior.
+
+## Decisions for implementation plans
+
+The following are architectural decisions, not implementation placeholders:
+
+- Do not replace LiteLLM with Models.dev. Use both as pinned enrichment sources with different roles.
+- Curated typed Evener profiles own executable behavior.
+- The serving variant, not the bare model or provider name, is the request identity.
+- Surface selection is deterministic: launch override, model default, instance default, exactly one defined surface, then failure.
+- Unknown surface/adapter fails before dispatch. Unknown model metadata may use a known surface's required core only.
+- No automatic protocol probing or cross-protocol fallback ships in the serving-contract core.
+- No backward-compatibility layer constrains the clean configuration redesign.
+- Any later change to these decisions requires a separate design review.

--- a/docs/superpowers/specs/2026-08-28-serving-contract-core-design.md
+++ b/docs/superpowers/specs/2026-08-28-serving-contract-core-design.md
@@ -1,39 +1,40 @@
 # Serving-Contract Core Design
 
 Date: 2026-08-28
-Status: approved for specification; implementation not started
+Status: revised after adversarial review; implementation not started
 Decision: clean redesign; no backward-compatibility requirement
 
 ## Summary
 
-Evener currently treats an OpenAI-shaped provider as if the provider name determined the complete wire contract. That failed for Groq: the configured `groq` instance used the OpenAI Responses adapter, which emitted OpenAI-only request fields and a server-tool shape Groq rejected with HTTP 400.
+Evener currently treats an OpenAI-shaped provider as if the provider name determined the complete wire contract. That failed for Groq: the configured instance used the OpenAI Responses adapter, which emitted OpenAI-only request fields and a server-tool shape Groq rejected with HTTP 400.
 
-This project introduces an Evener-owned serving-contract layer. It resolves a typed request contract before the first model call. The contract is scoped to the provider instance, wire model, and serving surface. It controls request construction; external model catalogs do not.
+This project introduces an Evener-owned serving-contract layer. It resolves a typed request contract before the first model call. The executable unit is a serving variant, scoped to a provider instance, wire model, and serving surface. The variant controls request construction; external model catalogs do not.
 
-The first release solves request-shape safety. It does not ingest external catalogs, probe providers, display metadata, or retry a request through another protocol.
+The first release solves request-shape safety for every retained adapter surface. It does not ingest external catalogs, probe providers, display metadata, or retry a request through another protocol.
 
 ## Requirements
 
 ### Functional requirements
 
-- Select a serving surface explicitly for every model: for example, OpenAI Chat Completions or OpenAI Responses.
-- Represent one model on multiple surfaces without sharing surface-specific fields.
-- Resolve provider, model, surface, adapter, and request contract before sending a request.
+- Resolve exactly one serving surface before every model request. A launch may name the surface explicitly; otherwise resolution must follow the deterministic default rule defined below.
+- Represent one wire model on multiple surfaces without sharing surface-specific fields or state.
+- Resolve provider, model, surface, adapter, endpoint path, authentication scope, and request contract before network dispatch.
 - Represent capability and field support as `supported`, `unsupported`, `unknown`, or `conflict`.
-- Omit optional fields when support is unknown or unsupported.
-- Keep request-field policy separate from capability claims. A capability claim never authorizes an adapter to emit an arbitrary field.
-- Support provider-, model-, and surface-specific reasoning, tool, role, history, output-limit, and streaming rules.
-- Make agent profile capabilities and adapter request shaping consume the same resolved contract.
-- Fail closed on invalid or conflicting configuration.
-- Keep provider destination and authentication under trusted user configuration and curated Evener code.
+- Omit optional fields only when omission preserves caller semantics. If a requested semantic feature cannot be represented, fail before dispatch.
+- Support provider-, model-, and surface-specific reasoning, tool, role, history, output-limit, modality, and streaming rules.
+- Make agent profile capabilities and adapter request shaping consume the same resolved variant.
+- Fail closed on invalid, ambiguous, or conflicting configuration.
+- Bind credentials to the selected trusted origin and instance. A custom origin must never inherit a first-party provider credential by adapter type alone.
+- Preserve provenance on provider-native history artifacts so a surface cannot replay another surface's raw state without validation.
 
 ### Operational requirements
 
 - Startup and default tests remain network-free.
 - External catalogs are not required for runtime correctness.
 - Request shaping is deterministic and testable with fake transports.
-- The API log identifies the resolved adapter, surface, model, and contract revision.
-- Unknown providers and models produce an actionable configuration error or a conservative contract; they never receive guessed optional fields.
+- API logs identify the resolved adapter, surface, wire model, and contract revision without recording secrets.
+- Unknown surface contracts fail before dispatch. Unknown model metadata may use a known surface's required core contract, but optional capabilities remain unknown.
+- A revised adapter or contract revision cannot silently reinterpret persisted continuation or provider-native state.
 
 ## Non-goals
 
@@ -44,6 +45,7 @@ The first release solves request-shape safety. It does not ingest external catal
 - Making external metadata control URLs, authentication, headers, redirects, or request bodies.
 - Pricing enforcement, UI presentation, or catalog freshness.
 - Continuation support for an arbitrary serving surface.
+- Silent dropping of caller-requested semantic features.
 
 Those concerns are separate follow-up projects.
 
@@ -58,7 +60,20 @@ A model identity contains:
 - wire model ID;
 - explicitly documented aliases.
 
-An alias is an accepted name mapping. It is not evidence that two model IDs have equivalent capabilities.
+An alias is a one-way accepted-name mapping to a canonical and wire ID. It is not evidence that two model IDs have equivalent capabilities.
+
+Exact wire IDs take precedence over aliases. Alias cycles, duplicate aliases within one instance, and aliases that resolve to different wire IDs fail configuration. An alias never crosses provider instances unless explicitly configured there.
+
+### Serving surface
+
+A serving surface is a named API contract such as:
+
+- `openai-completions`;
+- `openai-responses`;
+- `anthropic-messages`;
+- `google-generative-ai`.
+
+A surface identifies the adapter family and API version. It does not authorize a destination or credential. The instance owns the trusted base URL and authentication binding.
 
 ### Serving variant
 
@@ -70,19 +85,21 @@ provider instance + wire model ID + surface
 
 It contains:
 
-- a trusted adapter ID;
+- a curated adapter ID and implementation revision;
 - an API family and version;
 - an endpoint path selected by the adapter;
+- an authentication scope reference;
 - an immutable request contract;
-- the model limits and capabilities relevant to that surface.
+- the model limits and capabilities relevant to that surface;
+- a stable effective-contract revision.
 
-The base URL and authentication remain instance configuration. A catalog cannot replace them.
+The base URL and authentication remain trusted instance configuration. A catalog cannot replace them.
 
 ### Request contract
 
 A request contract is typed data, not `map[string]any`. It contains these groups:
 
-- **field policy:** optional request fields allowed, omitted, or unknown;
+- **field policy:** each optional field's state and omission behavior;
 - **capabilities:** tools, reasoning, vision, structured output, server tools, and modalities;
 - **reasoning:** supported effort levels, wire mapping, summary/replay behavior, and encrypted-content support;
 - **tools:** function-tool shape, strict-schema policy, tool choice, server-tool names, and parallel-call support;
@@ -90,14 +107,22 @@ A request contract is typed data, not `map[string]any`. It contains these groups
 - **generation:** output-token field, sampling fields, stop fields, and stream usage;
 - **response:** stream event family, finish reasons, and response-shape requirements.
 
-Each capability has four states:
+Every capability and optional field has four states:
 
-- `supported`: the contract permits the feature;
-- `unsupported`: the contract forbids the feature;
+- `supported`: the contract permits the feature or field;
+- `unsupported`: the contract forbids it;
 - `unknown`: no trusted claim exists, so optional use is forbidden;
-- `conflict`: trusted sources disagree, so resolution fails until curated.
+- `conflict`: equally authoritative claims disagree; resolution fails.
 
-Required fields belong to the adapter contract and are not controlled by these optional-field states.
+A higher-priority explicit value replaces a lower-priority default. Two incompatible values at the same trusted layer are a conflict. External-source conflicts remain diagnostic claims and never authorize a request.
+
+A field policy also declares whether a requested value is:
+
+- **semantic:** omission changes the requested operation and must fail before dispatch;
+- **optional:** omission preserves semantics and is allowed when unsupported or unknown;
+- **required-by-adapter:** the adapter always supplies it as part of its validated core shape.
+
+For example, dropping a prompt-cache optimization may be optional; dropping a requested structured-output schema, tool, modality, stop sequence, or output cap is semantic and must fail unless the contract explicitly defines an equivalent representation.
 
 ## Configuration model
 
@@ -112,34 +137,56 @@ default = "groq"
 [instances.groq]
 adapter = "openai"
 base_url = "https://api.groq.com/openai/v1"
+credential = "groq-api-key"
+default_surface = "openai-responses"
 
 [instances.groq.models."qwen/qwen3.8-27b"]
 canonical_id = "qwen/qwen3.8-27b"
-default_surface = "responses"
+default_surface = "openai-responses"
 
-[instances.groq.models."qwen/qwen3.8-27b".surfaces.responses]
-api = "openai-responses"
+[instances.groq.models."qwen/qwen3.8-27b".surfaces.openai-responses]
 contract = "groq-responses"
+
+[instances.groq.models."qwen/qwen3.8-27b".surfaces.openai-responses.compat]
+include = "unsupported"
+store = "unsupported"
+server_search = "unsupported"
 ```
 
-Surface-specific compatibility belongs under the surface. The user may override typed fields, but cannot provide arbitrary JSON body fragments:
+The exact TOML names are implementation detail; the schema must preserve these invariants:
 
-```toml
-[instances.groq.models."qwen/qwen3.8-27b".surfaces.responses.compat]
-supports_store = false
-supports_include = false
-server_search = "none"
-```
-
-The exact field names are implementation detail; the schema must preserve the following rules:
-
-- an instance may provide a default surface;
-- a model may select a different default surface;
+- every model resolves a surface through explicit launch selection or a deterministic authored default;
 - a model may define multiple named surfaces;
-- each surface has independent compatibility;
+- each surface has independent compatibility and state rules;
 - a surface cannot inherit fields from another surface;
 - only allowlisted contract fields are configurable;
-- base URL, authentication, and headers are never sourced from catalog claims.
+- base URL, authentication, and headers are never sourced from catalog claims;
+- arbitrary JSON body fragments and arbitrary adapter IDs are rejected;
+- alias mappings are scoped to an instance and resolve deterministically.
+
+### Surface selection
+
+The selection algorithm is fixed:
+
+1. explicit launch surface;
+2. model `default_surface`;
+3. instance `default_surface`;
+4. exactly one surface defined for the model;
+5. otherwise fail with an ambiguous-or-missing-surface error.
+
+Auxiliary calls, model switches, forks, and resume use the same algorithm only when they create a new request identity. A resumed session uses its persisted serving-variant identity and does not silently re-resolve a changed default.
+
+### Trust and credential binding
+
+Only user-global/state-root provider configuration is loaded implicitly. A project-local provider configuration is never discovered automatically. An explicitly supplied configuration path requires:
+
+- current-user ownership;
+- a regular file, not a symlink;
+- no group/world write permission;
+- a parent directory that is not group/world writable;
+- explicit user selection when the path is outside the default state root.
+
+The resolved credential reference is bound to the instance and normalized origin. First-party provider credentials and OAuth records are valid only for their curated first-party origins. A custom base URL requires an instance-scoped credential or explicit credential header. Missing or mismatched binding fails before transport. Redirects cannot carry credentials across origins.
 
 ## Authority and resolution
 
@@ -152,9 +199,9 @@ For adapter, protocol, endpoint path, request fields, and transforms:
 1. explicit trusted instance/model/surface configuration;
 2. exact curated Evener serving profile;
 3. curated adapter/surface default;
-4. conservative default.
+4. conservative default or pre-dispatch failure, according to field policy.
 
-External catalogs are advisory inputs for later enrichment. They cannot select executable behavior without an allowlisted curated mapping.
+External catalogs cannot select executable behavior without an allowlisted curated mapping.
 
 ### Capabilities and limits
 
@@ -164,15 +211,33 @@ For capabilities and limits:
 2. exact curated provider/model/surface profile;
 3. conservative unknown.
 
-The first project does not use LiteLLM or Models.dev in this resolution path. Later catalog ingestion may add claims, but claims must retain source, revision, and scope and cannot silently turn `unknown` into `supported`.
+A field marked `unknown` never emits an optional provider-specific request field. A field marked `unsupported` never emits it. A `conflict` fails resolution.
 
-### Conflicts
+The first project does not use LiteLLM or Models.dev in this execution path. Later catalog ingestion may add claims, but claims must retain source, revision, retrieval time, and scope and cannot silently turn `unknown` into `supported`.
 
-Contradictory trusted values are a configuration error. Contradictory external claims are retained as a conflict and resolve to unknown for request construction until a curated override settles them.
+### Pricing and aliases
+
+Pricing remains informational and is outside this project. Later pricing claims must preserve currency, units, region, service tier, effective date, and unknown state; missing price is not zero.
+
+Aliases are resolved before profile lookup. Exact IDs beat aliases. A duplicate or ambiguous alias fails closed. The resolved variant records both the requested alias and final wire ID for diagnostics.
 
 ## Curated profiles
 
-The first release ships typed profiles for the existing supported surfaces and the incident case:
+The first release must enumerate every retained adapter. Each row has one or more typed surfaces and baseline request/response/error/stream tests.
+
+| Adapter family | Surface(s) in v1 | Contract source |
+|---|---|---|
+| OpenAI | `openai-responses`, `openai-completions` | Curated Evener adapter contracts |
+| OpenAI-compatible | `openai-completions` | Curated compatible contract plus model/surface overrides |
+| Anthropic | `anthropic-messages` | Curated Anthropic contract |
+| Google/Gemini | `google-generative-ai` | Curated Gemini contract |
+| Kimi | Kimi's current chat surface | Curated Kimi contract |
+| Kimi Anthropic | `anthropic-messages` variant | Curated Kimi-Anthropic contract |
+| MiniMax | MiniMax's current chat surface | Curated MiniMax contract |
+| OpenRouter | OpenAI-compatible chat surface | Curated OpenRouter contract |
+| OpenRouter Anthropic | `anthropic-messages` variant | Curated OpenRouter-Anthropic contract |
+
+If an adapter cannot be given a v1 contract and tests, it is explicitly removed from the new configuration schema; it is not silently accepted outside the resolver.
 
 ### OpenAI public Responses
 
@@ -180,7 +245,7 @@ Implement the native OpenAI Responses contract, including supported Responses co
 
 ### OpenAI-compatible Chat Completions
 
-Implement the OpenAI-compatible Chat Completions contract: model-specific reasoning formats, output-token field, tool-result replay, strict-tool policy, stream usage, and cache controls are surface-scoped. The new contract defines the intended behavior; it does not preserve accidental legacy fields.
+Implement the OpenAI-compatible Chat Completions contract: model-specific reasoning formats, output-token field, tool-result replay, strict-tool policy, stream usage, and cache controls are surface-scoped. The new contract defines intended behavior; it does not preserve accidental legacy fields.
 
 ### Groq Responses
 
@@ -191,26 +256,59 @@ Use the Groq Responses API only when explicitly selected. The profile:
 - disables OpenAI `web_search` for Qwen;
 - permits only Groq-documented server-tool names on models that support them;
 - does not enable continuation merely because Responses is accepted;
-- retains Groq’s model-specific reasoning and tool capabilities as separate claims.
+- retains Groq's model-specific reasoning and tool capabilities as separate claims.
 
-### Unknown OpenAI-shaped surface
+### Unknown model on a known surface
 
-Use a conservative Responses or Chat contract selected by configuration. Emit required core fields only. Do not inherit OpenAI-only caching, server tools, encrypted reasoning, continuation, or provider options merely because a URL resembles an OpenAI endpoint.
+A model unknown to the curated catalog may use a configured known surface's required core contract. Its optional capabilities remain unknown. The agent must not expose optional server tools or semantic features without a positive claim. If the caller explicitly requests an unknown semantic feature, resolution fails before dispatch.
+
+### Unknown surface or adapter
+
+An unknown surface or adapter is never executable. Resolution fails before network dispatch with the instance, model, requested surface, and missing contract named.
 
 ## Runtime architecture
 
-The serving resolver is a pure, network-free package shared by configuration loading, agent profile construction, and adapter construction. It returns an immutable serving variant or a typed error.
+The serving resolver is a pure, network-free package shared by configuration loading, agent profile construction, session persistence, and adapter construction. It returns an immutable serving variant or a typed error.
 
-The client resolves the variant before dispatch. The adapter receives the variant’s contract and cannot silently substitute a different surface. The agent uses the same variant to decide whether to expose reasoning, tools, or provider-native web search.
+The client resolves the variant before dispatch. The adapter receives the variant and cannot silently substitute a different surface. The agent uses the same variant to decide whether to expose reasoning, tools, modalities, or provider-native web search.
 
-The existing semantic request model remains provider-agnostic. Provider-specific behavior is applied only by the selected adapter under the resolved contract. Arbitrary provider options are removed from the execution path unless they are defined by an allowlisted contract field.
+The semantic request remains separate from the serving variant. The adapter translates the semantic request under the contract. It validates semantic feature requirements before constructing bytes:
 
-A missing variant has two valid outcomes:
+- unsupported or unknown requested modalities fail before transport;
+- unsupported or unknown requested structured output fails before transport;
+- unsupported or unknown requested tools, stop sequences, output caps, or continuation state fail before transport unless the contract defines an equivalent;
+- optional optimizations may be omitted;
+- persisted provider-native artifacts are validated against their source and target surfaces before replay.
 
-- explicit configuration selects a known surface and its conservative contract can serve the request; or
-- resolution fails before network dispatch with the instance, model, and missing contract named.
+The first release removes the existing implicit Responses-to-Chat fallback path
+from the OpenAI adapter. An empty Responses stream, a generic provider error, or
+a transport failure produces one surfaced failure and exactly one recorded
+attempt. No alternate endpoint is tried.
 
-The runtime never sends a speculative first request to discover the answer.
+The API-attempt record includes the variant identity and effective-contract revision. Contract resolution, validation, and serialization are separate observable phases so a future failure identifies the boundary.
+
+### Session identity
+
+Session metadata persists:
+
+- instance name;
+- wire model ID and canonical model ID;
+- selected surface and API version;
+- effective-contract revision;
+- credential-scope fingerprint, never the credential;
+- continuation/state compatibility marker.
+
+Resume requires the exact variant and contract revision to remain available. If they do not, resume fails with an explicit migration/recovery error. A curated-code upgrade may invalidate a revision only through a declared revision transition; it cannot silently reinterpret old provider state.
+
+### History provenance
+
+Provider-native content parts that carry raw wire artifacts, including server-tool calls and encrypted reasoning, carry their source variant or an equivalent provenance marker. Before replay, the target contract either:
+
+- accepts the artifact's source and target shape;
+- applies a typed, documented translation; or
+- fails before transport.
+
+Raw provider artifacts are never passed through solely because they are valid JSON.
 
 ## Breaking changes
 
@@ -218,11 +316,12 @@ This project intentionally has no backward-compatibility requirement.
 
 - The provider configuration schema may move from instance-wide API style to model/surface variants.
 - Existing configuration files may require explicit reauthoring.
-- The internal adapter/profile interfaces may change to require a resolved serving variant.
+- Internal adapter/profile interfaces may require a resolved serving variant.
 - Duplicated provider-conditional decisions in agent and adapters are removed in favor of the shared resolver.
-- Existing tests and fixtures are rewritten to the new schema rather than preserving legacy parsing behavior.
+- Existing tests and fixtures are rewritten to the new schema.
+- Providers without a v1 serving contract are rejected rather than run through an implicit legacy path.
 
-A deliberate compatibility shim may be added later if migration cost warrants it, but it is not part of this project.
+A compatibility shim may be added later if migration cost warrants it, but it is not part of this project.
 
 ## Testing and acceptance
 
@@ -230,42 +329,49 @@ All tests use fake transports or pure functions. No provider credentials or netw
 
 ### Resolver tests
 
-- exact instance/model/surface selection;
-- provider default and model override selection;
-- multiple surfaces for one wire model;
-- surface isolation;
+- explicit launch, model-default, instance-default, single-surface, and missing/ambiguous surface selection;
+- exact instance/model/surface variant identity;
+- multiple surfaces for one wire model and surface isolation;
 - typed allowlist validation;
-- supported, unsupported, unknown, and conflict behavior;
-- trusted configuration precedence;
-- unknown model conservative resolution;
-- invalid configuration fails before adapter dispatch.
+- supported, unsupported, unknown, and conflict states for both capabilities and fields;
+- same-layer conflict versus higher-priority override;
+- unknown surface and unknown adapter fail before dispatch;
+- unknown model on a known surface uses only its defined core contract;
+- alias exact-match precedence, one-way mapping, duplicate/cycle rejection, and wire-ID recording;
+- custom-origin credential binding, credential mismatch, symlink/permission rejection, and cross-origin redirect rejection;
+- persisted variant identity and resume failure when the revision is unavailable.
 
 ### Request-shape tests
 
-Golden request tests must cover:
+Golden request tests cover every retained adapter/surface in the table above. The OpenAI-shaped set includes:
 
 - OpenAI public Responses baseline;
 - OpenAI-compatible Chat baseline;
 - Groq Responses with `store`, `include`, and OpenAI `web_search` absent;
 - Groq function tools and reasoning controls in their documented shape;
-- unknown Responses and Chat surfaces with optional fields omitted;
-- tool history and stream request behavior;
-- response and error parsing for each adapter.
+- unknown-model Requests on known surfaces with optional fields omitted;
+- no automatic Responses-to-Chat request after an empty Responses stream or provider error;
+- surface-switch history containing a prior server-tool artifact;
+- image, document, and audio requests on unsupported/unknown surfaces fail with zero transport dispatch;
+- explicit structured-output, tool, stop, output-cap, and continuation requests fail rather than being silently weakened when unavailable;
+- response and error parsing for each retained adapter.
 
 ### Cross-layer tests
 
 - agent capability exposure equals adapter contract capability;
-- a disabled server tool cannot enter the request through agent defaults;
+- a disabled server tool cannot enter a request through agent defaults or persisted history;
 - a surface switch cannot carry surface-specific continuation or reasoning state;
 - API attempt records include instance, wire model, surface, adapter, and contract revision;
-- existing provider behavior is tested under the new schema, not through legacy compatibility fixtures.
+- every registered adapter is either represented in the v1 table or rejected before dispatch.
 
 ### Fuzz/property tests
 
 - malformed configuration and contract values never panic;
 - unknown values never enable optional fields;
 - serialization is deterministic;
-- no contract field can inject an unallowlisted body key, URL, or credential header.
+- no contract field can inject an unallowlisted body key, URL, or credential header;
+- provider-native artifacts from one surface cannot serialize onto an incompatible surface;
+- semantic request features are never silently dropped.
 
 The project is accepted only when these tests pass and the normal offline gates remain deterministic.
 
@@ -273,7 +379,7 @@ The project is accepted only when these tests pass and the normal offline gates 
 
 ### External metadata ingestion
 
-Keep LiteLLM for broad limits, pricing, and capability enrichment. Add Models.dev as a supplemental provider/inventory source because it has useful provider/API-package mappings. Neither becomes protocol authority. Pin both snapshots, validate them, preserve license notices, and convert them into provenance-bearing claims.
+Keep LiteLLM for broad limits, pricing, and capability enrichment. Add Models.dev as a supplemental provider/inventory source because it has useful provider/API-package mappings. Neither becomes protocol authority. Pin both snapshots, validate them, preserve license notices, and convert them into provenance-bearing claims. Catalog claims remain advisory and cannot directly execute.
 
 ### Inventory discovery
 
@@ -291,12 +397,14 @@ Only add provider-specific fallback after a provider documents non-execution or 
 
 Expose selected surface, contract status, provenance, conflicts, and unknown capabilities in CLI/hub/web model views.
 
-## Open decisions for implementation planning
+## Implementation boundary
 
-1. Should a conservative unknown surface be selectable, or should unknown contracts always fail before dispatch?
-2. Which exact contract fields are needed in v1 beyond Groq’s `store`, `include`, and server-tool restrictions?
-3. Should surface selection be a model-level default plus named surfaces, or should every launch specify a surface explicitly?
-4. Which current provider adapters are in the first curated-profile set?
-5. What is the precise trusted boundary for project-local configuration versus user-global configuration?
+This spec defines a clean serving-contract core, not a catalog project. The first implementation plan should partition the work into these independently testable units:
 
-These decisions must be resolved in the implementation plan. They do not justify adding catalog ingestion or runtime probing to the first project.
+1. trusted config and serving-variant schema;
+2. pure resolution and field-state validation;
+3. adapter contract integration and semantic request validation;
+4. agent/session profile and persisted-variant wiring;
+5. curated adapter profiles and request-shape goldens.
+
+External catalog ingestion, `/models` enrichment, diagnostic probing, UI presentation, and protocol fallback require separate designs and approvals.

--- a/docs/superpowers/specs/2026-08-28-serving-contract-core-design.md
+++ b/docs/superpowers/specs/2026-08-28-serving-contract-core-design.md
@@ -27,6 +27,10 @@ The first release solves request-shape safety for every retained adapter surface
 - Bind credentials to the selected trusted origin and instance. A custom origin must never inherit a first-party provider credential by adapter type alone.
 - Preserve provenance on provider-native history artifacts so a surface cannot replay another surface's raw state without validation.
 - Reject untyped provider options and any attempt to overwrite core request fields.
+- Scope the variant to deployment, region, and entitlement when those dimensions
+  affect the provider contract.
+- Route every executable construction path, including environment/default-client
+  paths and credential refresh, through a typed, validated operation contract.
 
 ### Operational requirements
 
@@ -71,8 +75,8 @@ A serving surface is a named API contract such as:
 
 - `openai.responses.v1`;
 - `openai.chat.v1`;
-- `anthropic-messages`;
-- `google-generative-ai`.
+- `anthropic.messages.v1`;
+- `google.generate-content.v1`.
 
 A surface identifies the adapter family and API version. It does not authorize a destination or credential. The instance owns the trusted base URL and authentication binding.
 
@@ -82,6 +86,7 @@ A serving variant is the executable selection unit:
 
 ```
 provider instance + normalized origin + credential scope
+  + deployment/region/entitlement (when applicable)
   + wire model ID + surface + API version
 ```
 
@@ -91,25 +96,36 @@ It contains:
 - an API family and version;
 - an endpoint path selected by the adapter;
 - an authentication scope reference;
+- deployment, region, and entitlement scope when they affect behavior;
 - an immutable request contract;
 - the model limits and capabilities relevant to that surface;
 - a stable effective-contract revision.
 
-Each operation is a subidentity of the variant. A buffered generation,
-streaming generation, token-count, or model-list operation has its own
-operation contract and API-log identity.
+Each model-scoped operation is a subidentity of the variant. Buffered generation,
+streaming generation, and token counting have independent operation contracts and
+API-log identities. Instance-scoped discovery and credential refresh are separate
+operations described below.
 
 The base URL and authentication remain trusted instance configuration. A catalog cannot replace them.
 
-### Operation contract
+### Operation contracts
 
-A serving variant has a contract for every network operation it exposes. At
-minimum this covers buffered generation, streaming generation, provider-side
-input-token counting, and provider model listing when the adapter implements
-them. Each operation names its stable endpoint family and path, request shape,
-response or stream grammar, timeout policy, and API-log identity. A generation
-contract cannot be reused for token counting merely because both operations use
-the same provider or model.
+A serving variant has a contract for every model-scoped operation it exposes. At
+minimum this covers buffered generation, streaming generation, and provider-side
+input-token counting. Each operation names its stable endpoint family and path,
+request shape, response or stream grammar, timeout policy, and API-log identity.
+A generation contract cannot be reused for token counting merely because both
+operations use the same provider or model.
+
+Model listing is not model-scoped: it runs before a model is selected. It has an
+instance/integration-scoped discovery contract keyed by instance, normalized
+origin, credential scope, adapter revision, and inventory API version.
+
+Credential refresh is a separate instance-scoped operation. It has a curated
+issuer/token endpoint, method and body shape, timeout, redirect policy,
+redaction rule, and API-log identity. Resolver construction is network-free;
+refresh is lazy and must occur only after the credential-refresh operation has
+been validated.
 
 ### Request contract
 
@@ -215,10 +231,6 @@ Only user-global/state-root provider configuration is loaded implicitly. A proje
 - a parent directory that is not group/world writable;
 - explicit user selection when the path is outside the default state root.
 
-These checks apply to the implicit default path as well as explicitly supplied
-paths. The file and every parent in the resolved path are checked before the
-configuration becomes executable authority.
-
 The resolved credential reference is bound to the instance and normalized
 origin, including scheme, host, and effective port. First-party provider
 credentials and OAuth records are valid only for their curated first-party
@@ -226,6 +238,36 @@ origins. A custom base URL requires an instance-scoped credential or explicit
 credential header. Missing or mismatched binding fails before transport.
 The HTTP client rejects redirects in v1; it does not forward a prompt body or
 headers to either a same-origin alternate path or a cross-origin target.
+
+Environment construction is not a second runtime. The environment registry,
+`NewFromEnv`, and the lazy default client are removed from supported model-call
+entrypoints. An explicit environment bootstrap may materialize a schema-2
+instance with an instance-scoped credential, after which the normal resolver
+must validate the complete variant and operation contract before constructing an
+adapter. No environment path may create an unversioned adapter directly.
+
+OAuth refresh is not hidden inside adapter construction. It runs lazily through
+the credential-refresh operation contract, with its curated issuer, no redirects,
+bounded timeout, and redacted attempt record. An expired token cannot cause an
+unmodeled network request during resolver or startup construction.
+
+### URL canonicalization
+
+URL handling uses one canonical parser and joiner for allowlisting, transport,
+session identity, and API-log provenance. A configured base URL must have an
+explicit `https` scheme, or `http` only for an explicitly configured loopback
+development endpoint. It must not contain userinfo, query, fragment, opaque
+data, invalid or empty ports, encoded path separators, or dot-segment traversal.
+
+The canonical host is lower-case ASCII; non-ASCII/IDNA hostnames and trailing
+dots are rejected rather than converted. IPv4 and bracketed IPv6 are normalized
+by the URL parser. The effective port is inserted (`443` for HTTPS, `80` for
+permitted HTTP). The base path is normalized to a leading-slash prefix without
+a trailing slash. Each operation supplies a relative path, which is joined to
+that prefix without implicit `/v1` insertion or deduplication. The effective
+URL, including its path prefix but excluding credentials, is part of the
+configuration fingerprint. Credential binding uses the canonical scheme, host,
+and effective-port origin.
 
 ## Authority and resolution
 
@@ -290,6 +332,11 @@ auth-selected backend branch must map to exactly one row. If an adapter cannot
 be given a stable surface ID, operation contracts, and tests, it is removed
 from the new configuration schema rather than accepted outside the resolver.
 
+Every curated non-default capability or field claim carries an official
+documentation reference or explicit contract-test reference, source/API
+revision, exact scope, reviewed date, and review/expiry status. Registry
+validation rejects an executable `supported` claim without that evidence.
+
 ### OpenAI public Responses
 
 Implement the native OpenAI Responses contract, including supported Responses continuation and reasoning fields where the adapter requires them. This is the desired contract for the native surface, not a promise to preserve accidental behavior from the old implementation.
@@ -346,13 +393,24 @@ The first release also removes generic model fallback for model calls. A fallbac
 model cannot silently select another surface or contract. Any future fallback is
 the separate provider-specific project described below.
 
-The HTTP client rejects all redirects in v1. It does not follow 301, 302, 307,
-or 308 responses, even on the same origin. The selected endpoint, method, body,
-and headers therefore remain the ones validated by the contract.
+Every HTTP client used by the serving system rejects all redirects in v1. It
+does not follow 301, 302, 303, 307, or 308 responses, even on the same origin.
+The selected endpoint, method, body, and headers therefore remain the ones
+validated by the contract. This applies to generation, streaming, token count,
+model listing, and credential refresh.
 
-The API-attempt record includes the complete variant identity, operation, and
-effective-contract revision. Contract resolution, validation, and serialization
-are separate observable phases so a future failure identifies the boundary.
+The API-attempt record includes the complete variant identity for model-scoped
+operations, or the complete instance/integration identity for discovery and
+credential refresh, together with the operation and effective-contract revision.
+Contract resolution, validation, and serialization are separate observable
+phases so a future failure identifies the boundary.
+
+Every production model-call entry point uses the resolver: primary generation,
+cheap-model calls, vision-model calls, context compaction and summaries,
+fork summaries, hook/plugin model calls, evaluation/judge calls, web-fetch or
+web-search model calls, direct client calls, and provider token counting. Each
+entry point supplies its target instance/model and receives its own variant;
+none may copy only the parent's provider or model fields.
 
 ### Session identity
 
@@ -362,31 +420,41 @@ Session metadata persists:
 - wire model ID and canonical model ID;
 - selected surface and API version;
 - normalized origin/configuration fingerprint;
+- deployment, region, and entitlement scope when applicable;
 - adapter ID and implementation revision;
 - effective-contract revision;
 - credential-scope fingerprint, never the credential;
 - continuation/state compatibility marker.
 
+The session also stores an append-only variant-selection timeline keyed by the
+request/turn or transcript entry at which a model or surface was selected. A
+fork copies the timeline prefix through its divergence point; a model/surface
+switch appends a new selection instead of overwriting the history needed by an
+older fork.
+
 The effective-contract revision is the hash of a canonical serialization of the
 adapter implementation revision, surface/API version, curated profile revision,
-operation contracts, and every wire- or response-affecting resolved override.
-Behavior changes implemented in code require an adapter revision bump.
+operation contracts, deployment/region/entitlement scope when applicable, and
+every wire- or response-affecting resolved override. Behavior changes
+implemented in code require an adapter revision bump.
 
 Resume requires equality of the persisted variant, normalized origin/configuration
-fingerprint, credential-scope fingerprint, adapter revision, and effective
-contract revision. If any component differs or is unavailable, resume fails with
-an explicit migration/recovery error before dispatch. A curated-code upgrade may
-invalidate a revision only through a declared transition; it cannot silently
-reinterpret old provider state.
+fingerprint, deployment/region/entitlement scope when applicable,
+credential-scope fingerprint, adapter revision, and effective contract revision.
+If any component differs or is unavailable, resume fails with an explicit
+migration/recovery error before dispatch. A curated-code upgrade may invalidate
+a revision only through a declared transition; it cannot silently reinterpret old
+provider state.
 
 ### History provenance
 
 Provider-native content parts that carry raw wire artifacts, including server-tool
 calls, encrypted reasoning, response IDs, item IDs, and thought signatures, carry
 their complete source variant or an equivalent provenance marker. By default,
-replay requires equality of instance, normalized origin, credential scope, wire
-model, surface/API version, adapter revision, contract revision, and operation
-family. Before replay, the target contract either:
+replay requires equality of instance, normalized origin, credential scope,
+deployment/region/entitlement scope when applicable, wire model, surface/API
+version, adapter revision, contract revision, and operation family. Before
+replay, the target contract either:
 
 - accepts the artifact's source and target shape;
 - applies a typed, documented translation; or
@@ -423,7 +491,9 @@ All tests use fake transports or pure functions. No provider credentials or netw
 - typed allowlist validation;
 - supported, unsupported, unknown, and conflict states for both capabilities and fields;
 - same-layer conflict versus higher-priority override;
-- operation selection and distinct generation, streaming, token-count, and model-list contracts;
+- operation selection and distinct generation, streaming, token-count, model-list, and credential-refresh contracts;
+- model listing resolves as an instance-scoped discovery operation, not a
+  model-scoped variant;
 - unknown surface and unknown adapter fail before dispatch;
 - unknown model on a known surface uses only its defined core contract;
 - launch, hub, model-switch, fork, and resume boundaries carry the selected
@@ -431,7 +501,15 @@ All tests use fake transports or pure functions. No provider credentials or netw
 - alias exact-match precedence, one-way mapping, duplicate/cycle rejection, and wire-ID recording;
 - custom-origin credential binding, credential mismatch, symlink/permission rejection, and cross-origin redirect rejection;
 - default-path and explicit-path trust checks;
-- persisted variant identity, origin/auth/adapter comparison, and resume failure when any revision is unavailable.
+- environment/default-client paths remove the unsupported ambient path or
+  explicitly materialize through the resolver; neither may construct an adapter
+  directly;
+- lazy OAuth refresh uses its own operation contract and never runs during
+  resolver/startup construction;
+- URL canonicalization equivalence, lookalike rejection, path-prefix joining,
+  and invalid-component rejection;
+- persisted variant identity, origin/auth/adapter/deployment/region/entitlement
+  comparison, and resume failure when any revision is unavailable;
 - schema 1, missing schema, unsupported schema, and legacy session metadata are
   rejected before adapter construction.
 
@@ -447,12 +525,21 @@ Golden request tests cover every retained adapter/surface in the table above. Th
 - untyped provider options and core-field overrides are rejected with zero dispatch;
 - no automatic Responses-to-Chat request after an empty Responses stream or provider error;
 - no generic model fallback request after an ordinary model error;
+- every auxiliary model-call entry point resolves and records its target variant;
 - surface-switch history containing a prior server-tool artifact;
-- same-surface history from a different instance, model, credential scope, or contract revision is rejected;
+- same-surface history from a different instance, origin, model, API version,
+  adapter revision, deployment/region/entitlement, credential scope, operation
+  family, or contract revision is rejected;
 - image, document, and audio requests on unsupported/unknown surfaces fail with zero transport dispatch;
 - explicit structured-output, tool, stop, output-cap, and continuation requests fail rather than being silently weakened when unavailable;
-- token-count and model-list operations use their declared endpoints and contracts;
-- 301/302/307/308 redirects produce no request to the redirect target;
+- token-count uses its model-scoped contract; model-list and credential-refresh
+  use their instance-scoped contracts;
+- credential refresh, generation, stream, token-count, and model-list clients
+  all reject 301/302/303/307/308 redirects without forwarding a body or headers;
+- API logs and structured errors contain operation, API version, adapter
+  implementation revision, phase, and non-secret identity fields but
+  no credential values, credential headers, userinfo, query secrets, or prompt
+  data in identity fields;
 - response and error parsing for each retained adapter.
 
 ### Cross-layer tests

--- a/docs/superpowers/specs/2026-08-28-serving-contract-core-design.md
+++ b/docs/superpowers/specs/2026-08-28-serving-contract-core-design.md
@@ -69,8 +69,8 @@ Exact wire IDs take precedence over aliases. Alias cycles, duplicate aliases wit
 
 A serving surface is a named API contract such as:
 
-- `openai-completions`;
-- `openai-responses`;
+- `openai.responses.v1`;
+- `openai.chat.v1`;
 - `anthropic-messages`;
 - `google-generative-ai`.
 
@@ -81,7 +81,8 @@ A surface identifies the adapter family and API version. It does not authorize a
 A serving variant is the executable selection unit:
 
 ```
-provider instance + wire model ID + surface
+provider instance + normalized origin + credential scope
+  + wire model ID + surface + API version
 ```
 
 It contains:
@@ -94,7 +95,21 @@ It contains:
 - the model limits and capabilities relevant to that surface;
 - a stable effective-contract revision.
 
+Each operation is a subidentity of the variant. A buffered generation,
+streaming generation, token-count, or model-list operation has its own
+operation contract and API-log identity.
+
 The base URL and authentication remain trusted instance configuration. A catalog cannot replace them.
+
+### Operation contract
+
+A serving variant has a contract for every network operation it exposes. At
+minimum this covers buffered generation, streaming generation, provider-side
+input-token counting, and provider model listing when the adapter implements
+them. Each operation names its stable endpoint family and path, request shape,
+response or stream grammar, timeout policy, and API-log identity. A generation
+contract cannot be reused for token counting merely because both operations use
+the same provider or model.
 
 ### Request contract
 
@@ -125,6 +140,11 @@ A field policy also declares whether a requested value is:
 
 For example, dropping a prompt-cache optimization may be optional; dropping a requested structured-output schema, tool, modality, stop sequence, or output cap is semantic and must fail unless the contract explicitly defines an equivalent representation.
 
+The semantic request has no untyped provider-options escape hatch. Provider
+extensions are typed, surface-scoped contract fields. Core fields such as the
+wire model, input, tools, and operation cannot be overwritten by an extension.
+Unknown extension keys and values fail before dispatch.
+
 ## Configuration model
 
 The clean configuration schema is versioned independently of the current `providers.toml` shape. Old configuration is not migrated silently; it is rejected with an instruction to author the new form.
@@ -139,16 +159,16 @@ default = "groq"
 adapter = "openai"
 base_url = "https://api.groq.com/openai/v1"
 credential = "groq-api-key"
-default_surface = "openai-responses"
+default_surface = "openai.responses.v1"
 
 [instances.groq.models."qwen/qwen3.8-27b"]
 canonical_id = "qwen/qwen3.8-27b"
-default_surface = "openai-responses"
+default_surface = "openai.responses.v1"
 
-[instances.groq.models."qwen/qwen3.8-27b".surfaces.openai-responses]
+[instances.groq.models."qwen/qwen3.8-27b".surfaces."openai.responses.v1"]
 contract = "groq-responses"
 
-[instances.groq.models."qwen/qwen3.8-27b".surfaces.openai-responses.compat]
+[instances.groq.models."qwen/qwen3.8-27b".surfaces."openai.responses.v1".compat]
 include = "unsupported"
 store = "unsupported"
 server_search = "unsupported"
@@ -175,7 +195,15 @@ The selection algorithm is fixed:
 4. exactly one surface defined for the model;
 5. otherwise fail with an ambiguous-or-missing-surface error.
 
-Auxiliary calls, model switches, forks, and resume use the same algorithm only when they create a new request identity. A resumed session uses its persisted serving-variant identity and does not silently re-resolve a changed default.
+An explicit surface must be one of the surfaces configured for that exact
+instance/model. An instance default is eligible only when it is also present in
+the model's surface set or when the model has no model-local surface table and
+the instance explicitly allowlists it. A globally known surface is not enough.
+
+The selected surface is carried as a structured field through launch, hub
+materialization, model switching, auxiliary calls, forks, and resume. A resumed
+session uses its persisted serving-variant identity and does not silently
+re-resolve a changed default.
 
 ### Trust and credential binding
 
@@ -187,7 +215,17 @@ Only user-global/state-root provider configuration is loaded implicitly. A proje
 - a parent directory that is not group/world writable;
 - explicit user selection when the path is outside the default state root.
 
-The resolved credential reference is bound to the instance and normalized origin. First-party provider credentials and OAuth records are valid only for their curated first-party origins. A custom base URL requires an instance-scoped credential or explicit credential header. Missing or mismatched binding fails before transport. Redirects cannot carry credentials across origins.
+These checks apply to the implicit default path as well as explicitly supplied
+paths. The file and every parent in the resolved path are checked before the
+configuration becomes executable authority.
+
+The resolved credential reference is bound to the instance and normalized
+origin, including scheme, host, and effective port. First-party provider
+credentials and OAuth records are valid only for their curated first-party
+origins. A custom base URL requires an instance-scoped credential or explicit
+credential header. Missing or mismatched binding fails before transport.
+The HTTP client rejects redirects in v1; it does not forward a prompt body or
+headers to either a same-origin alternate path or a cross-origin target.
 
 ## Authority and resolution
 
@@ -195,7 +233,7 @@ There is no global source precedence. Resolution is domain-specific.
 
 ### Executable behavior
 
-For adapter, protocol, endpoint path, request fields, and transforms:
+For adapter, protocol, operation endpoint, request fields, and transforms:
 
 1. explicit trusted instance/model/surface configuration;
 2. exact curated Evener serving profile;
@@ -203,6 +241,10 @@ For adapter, protocol, endpoint path, request fields, and transforms:
 4. conservative default or pre-dispatch failure, according to field policy.
 
 External catalogs cannot select executable behavior without an allowlisted curated mapping.
+
+The operation contract is part of the selected variant. Buffered generation,
+streaming generation, provider-side token counting, and model listing cannot
+borrow one another's endpoint or body shape.
 
 ### Capabilities and limits
 
@@ -226,19 +268,27 @@ Aliases are resolved before profile lookup. Exact IDs beat aliases. A duplicate 
 
 The first release must enumerate every retained adapter. Each row has one or more typed surfaces and baseline request/response/error/stream tests.
 
-| Adapter family | Surface(s) in v1 | Contract source |
+| Adapter family | Stable v1 surface ID | Endpoint/API family |
 |---|---|---|
-| OpenAI | `openai-responses`, `openai-completions` | Curated Evener adapter contracts |
-| OpenAI-compatible | `openai-completions` | Curated compatible contract plus model/surface overrides |
-| Anthropic | `anthropic-messages` | Curated Anthropic contract |
-| Google/Gemini | `google-generative-ai` | Curated Gemini contract |
-| Kimi | Kimi's current chat surface | Curated Kimi contract |
-| Kimi Anthropic | `anthropic-messages` variant | Curated Kimi-Anthropic contract |
-| MiniMax | MiniMax's current chat surface | Curated MiniMax contract |
-| OpenRouter | OpenAI-compatible chat surface | Curated OpenRouter contract |
-| OpenRouter Anthropic | `anthropic-messages` variant | Curated OpenRouter-Anthropic contract |
+| OpenAI public API | `openai.responses.v1` | `/v1/responses` |
+| OpenAI public API | `openai.chat.v1` | `/v1/chat/completions` |
+| OpenAI ChatGPT/Codex | `openai.codex-responses.v1` | `/backend-api/codex/responses` |
+| OpenAI ChatGPT/Codex | `openai.codex-responses-lite.v1` | Codex Responses-lite request shape |
+| OpenAI-compatible | `openai-compatible.chat.v1` | configured `/chat/completions` |
+| Anthropic | `anthropic.messages.v1` | `/v1/messages` |
+| Google/Gemini | `google.generate-content.v1` | `generateContent` |
+| Kimi | `kimi.chat.v1` | Kimi OpenAI-compatible chat |
+| Kimi Anthropic | `kimi.anthropic-messages.v1` | Kimi Anthropic-compatible messages |
+| MiniMax | `minimax.chat.v1` | MiniMax OpenAI-compatible chat |
+| OpenRouter | `openrouter.chat.v1` | OpenRouter OpenAI-compatible chat |
+| OpenRouter Anthropic | `openrouter.anthropic-messages.v1` | OpenRouter Anthropic-compatible messages |
+| GLM | `glm.chat.v1` | z.ai OpenAI-compatible chat |
+| Ollama | `ollama.chat.v1` | Ollama OpenAI-compatible chat |
 
-If an adapter cannot be given a v1 contract and tests, it is explicitly removed from the new configuration schema; it is not silently accepted outside the resolver.
+This table is the registry oracle. Every production adapter factory and every
+auth-selected backend branch must map to exactly one row. If an adapter cannot
+be given a stable surface ID, operation contracts, and tests, it is removed
+from the new configuration schema rather than accepted outside the resolver.
 
 ### OpenAI public Responses
 
@@ -376,10 +426,14 @@ All tests use fake transports or pure functions. No provider credentials or netw
 - operation selection and distinct generation, streaming, token-count, and model-list contracts;
 - unknown surface and unknown adapter fail before dispatch;
 - unknown model on a known surface uses only its defined core contract;
+- launch, hub, model-switch, fork, and resume boundaries carry the selected
+  surface and reject a known-but-unconfigured surface;
 - alias exact-match precedence, one-way mapping, duplicate/cycle rejection, and wire-ID recording;
 - custom-origin credential binding, credential mismatch, symlink/permission rejection, and cross-origin redirect rejection;
 - default-path and explicit-path trust checks;
 - persisted variant identity, origin/auth/adapter comparison, and resume failure when any revision is unavailable.
+- schema 1, missing schema, unsupported schema, and legacy session metadata are
+  rejected before adapter construction.
 
 ### Request-shape tests
 

--- a/docs/superpowers/specs/2026-08-28-serving-contract-core-design.md
+++ b/docs/superpowers/specs/2026-08-28-serving-contract-core-design.md
@@ -18,7 +18,7 @@ The first release solves request-shape safety for every retained adapter surface
 
 - Resolve exactly one serving surface before every model request. A launch may name the surface explicitly; otherwise resolution must follow the deterministic default rule defined below.
 - Represent one wire model on multiple surfaces without sharing surface-specific fields or state.
-- Resolve provider, model, surface, adapter, endpoint path, authentication scope, and request contract before network dispatch.
+- Resolve provider, model, surface, adapter, operation endpoint, authentication scope, and request contract before network dispatch.
 - Represent capability and field support as `supported`, `unsupported`, `unknown`, or `conflict`.
 - Omit optional fields only when omission preserves caller semantics. If a requested semantic feature cannot be represented, fail before dispatch.
 - Support provider-, model-, and surface-specific reasoning, tool, role, history, output-limit, modality, and streaming rules.
@@ -26,6 +26,7 @@ The first release solves request-shape safety for every retained adapter surface
 - Fail closed on invalid, ambiguous, or conflicting configuration.
 - Bind credentials to the selected trusted origin and instance. A custom origin must never inherit a first-party provider credential by adapter type alone.
 - Preserve provenance on provider-native history artifacts so a surface cannot replay another surface's raw state without validation.
+- Reject untyped provider options and any attempt to overwrite core request fields.
 
 ### Operational requirements
 
@@ -278,14 +279,30 @@ The semantic request remains separate from the serving variant. The adapter tran
 - unsupported or unknown requested structured output fails before transport;
 - unsupported or unknown requested tools, stop sequences, output caps, or continuation state fail before transport unless the contract defines an equivalent;
 - optional optimizations may be omitted;
-- persisted provider-native artifacts are validated against their source and target surfaces before replay.
+- persisted provider-native artifacts are validated against their full source and target variants before replay;
+- provider-side token counting and model listing use their own operation contracts.
+
+The untyped `Request.ProviderOptions` escape hatch is removed. Provider-specific
+options are typed, surface-scoped contract fields. Core fields such as model,
+input, tools, operation, and endpoint cannot be overwritten by extensions.
+Unknown option keys or values fail before transport.
 
 The first release removes the existing implicit Responses-to-Chat fallback path
 from the OpenAI adapter. An empty Responses stream, a generic provider error, or
 a transport failure produces one surfaced failure and exactly one recorded
 attempt. No alternate endpoint is tried.
 
-The API-attempt record includes the variant identity and effective-contract revision. Contract resolution, validation, and serialization are separate observable phases so a future failure identifies the boundary.
+The first release also removes generic model fallback for model calls. A fallback
+model cannot silently select another surface or contract. Any future fallback is
+the separate provider-specific project described below.
+
+The HTTP client rejects all redirects in v1. It does not follow 301, 302, 307,
+or 308 responses, even on the same origin. The selected endpoint, method, body,
+and headers therefore remain the ones validated by the contract.
+
+The API-attempt record includes the complete variant identity, operation, and
+effective-contract revision. Contract resolution, validation, and serialization
+are separate observable phases so a future failure identifies the boundary.
 
 ### Session identity
 
@@ -294,15 +311,32 @@ Session metadata persists:
 - instance name;
 - wire model ID and canonical model ID;
 - selected surface and API version;
+- normalized origin/configuration fingerprint;
+- adapter ID and implementation revision;
 - effective-contract revision;
 - credential-scope fingerprint, never the credential;
 - continuation/state compatibility marker.
 
-Resume requires the exact variant and contract revision to remain available. If they do not, resume fails with an explicit migration/recovery error. A curated-code upgrade may invalidate a revision only through a declared revision transition; it cannot silently reinterpret old provider state.
+The effective-contract revision is the hash of a canonical serialization of the
+adapter implementation revision, surface/API version, curated profile revision,
+operation contracts, and every wire- or response-affecting resolved override.
+Behavior changes implemented in code require an adapter revision bump.
+
+Resume requires equality of the persisted variant, normalized origin/configuration
+fingerprint, credential-scope fingerprint, adapter revision, and effective
+contract revision. If any component differs or is unavailable, resume fails with
+an explicit migration/recovery error before dispatch. A curated-code upgrade may
+invalidate a revision only through a declared transition; it cannot silently
+reinterpret old provider state.
 
 ### History provenance
 
-Provider-native content parts that carry raw wire artifacts, including server-tool calls and encrypted reasoning, carry their source variant or an equivalent provenance marker. Before replay, the target contract either:
+Provider-native content parts that carry raw wire artifacts, including server-tool
+calls, encrypted reasoning, response IDs, item IDs, and thought signatures, carry
+their complete source variant or an equivalent provenance marker. By default,
+replay requires equality of instance, normalized origin, credential scope, wire
+model, surface/API version, adapter revision, contract revision, and operation
+family. Before replay, the target contract either:
 
 - accepts the artifact's source and target shape;
 - applies a typed, documented translation; or
@@ -316,9 +350,13 @@ This project intentionally has no backward-compatibility requirement.
 
 - The provider configuration schema may move from instance-wide API style to model/surface variants.
 - Existing configuration files may require explicit reauthoring.
+- Schema 1, a missing schema, or any unsupported schema version is rejected before
+  provider adapter construction with an explicit reauthoring error.
 - Internal adapter/profile interfaces may require a resolved serving variant.
 - Duplicated provider-conditional decisions in agent and adapters are removed in favor of the shared resolver.
 - Existing tests and fixtures are rewritten to the new schema.
+- Legacy session, fork, and resume metadata without a complete serving-variant
+  identity is rejected before adapter construction or transport.
 - Providers without a v1 serving contract are rejected rather than run through an implicit legacy path.
 
 A compatibility shim may be added later if migration cost warrants it, but it is not part of this project.
@@ -335,11 +373,13 @@ All tests use fake transports or pure functions. No provider credentials or netw
 - typed allowlist validation;
 - supported, unsupported, unknown, and conflict states for both capabilities and fields;
 - same-layer conflict versus higher-priority override;
+- operation selection and distinct generation, streaming, token-count, and model-list contracts;
 - unknown surface and unknown adapter fail before dispatch;
 - unknown model on a known surface uses only its defined core contract;
 - alias exact-match precedence, one-way mapping, duplicate/cycle rejection, and wire-ID recording;
 - custom-origin credential binding, credential mismatch, symlink/permission rejection, and cross-origin redirect rejection;
-- persisted variant identity and resume failure when the revision is unavailable.
+- default-path and explicit-path trust checks;
+- persisted variant identity, origin/auth/adapter comparison, and resume failure when any revision is unavailable.
 
 ### Request-shape tests
 
@@ -350,10 +390,15 @@ Golden request tests cover every retained adapter/surface in the table above. Th
 - Groq Responses with `store`, `include`, and OpenAI `web_search` absent;
 - Groq function tools and reasoning controls in their documented shape;
 - unknown-model Requests on known surfaces with optional fields omitted;
+- untyped provider options and core-field overrides are rejected with zero dispatch;
 - no automatic Responses-to-Chat request after an empty Responses stream or provider error;
+- no generic model fallback request after an ordinary model error;
 - surface-switch history containing a prior server-tool artifact;
+- same-surface history from a different instance, model, credential scope, or contract revision is rejected;
 - image, document, and audio requests on unsupported/unknown surfaces fail with zero transport dispatch;
 - explicit structured-output, tool, stop, output-cap, and continuation requests fail rather than being silently weakened when unavailable;
+- token-count and model-list operations use their declared endpoints and contracts;
+- 301/302/307/308 redirects produce no request to the redirect target;
 - response and error parsing for each retained adapter.
 
 ### Cross-layer tests

--- a/docs/superpowers/specs/2026-08-28-serving-contract-core-design.md
+++ b/docs/superpowers/specs/2026-08-28-serving-contract-core-design.md
@@ -1,0 +1,302 @@
+# Serving-Contract Core Design
+
+Date: 2026-08-28
+Status: approved for specification; implementation not started
+Decision: clean redesign; no backward-compatibility requirement
+
+## Summary
+
+Evener currently treats an OpenAI-shaped provider as if the provider name determined the complete wire contract. That failed for Groq: the configured `groq` instance used the OpenAI Responses adapter, which emitted OpenAI-only request fields and a server-tool shape Groq rejected with HTTP 400.
+
+This project introduces an Evener-owned serving-contract layer. It resolves a typed request contract before the first model call. The contract is scoped to the provider instance, wire model, and serving surface. It controls request construction; external model catalogs do not.
+
+The first release solves request-shape safety. It does not ingest external catalogs, probe providers, display metadata, or retry a request through another protocol.
+
+## Requirements
+
+### Functional requirements
+
+- Select a serving surface explicitly for every model: for example, OpenAI Chat Completions or OpenAI Responses.
+- Represent one model on multiple surfaces without sharing surface-specific fields.
+- Resolve provider, model, surface, adapter, and request contract before sending a request.
+- Represent capability and field support as `supported`, `unsupported`, `unknown`, or `conflict`.
+- Omit optional fields when support is unknown or unsupported.
+- Keep request-field policy separate from capability claims. A capability claim never authorizes an adapter to emit an arbitrary field.
+- Support provider-, model-, and surface-specific reasoning, tool, role, history, output-limit, and streaming rules.
+- Make agent profile capabilities and adapter request shaping consume the same resolved contract.
+- Fail closed on invalid or conflicting configuration.
+- Keep provider destination and authentication under trusted user configuration and curated Evener code.
+
+### Operational requirements
+
+- Startup and default tests remain network-free.
+- External catalogs are not required for runtime correctness.
+- Request shaping is deterministic and testable with fake transports.
+- The API log identifies the resolved adapter, surface, model, and contract revision.
+- Unknown providers and models produce an actionable configuration error or a conservative contract; they never receive guessed optional fields.
+
+## Non-goals
+
+- Automatic protocol detection.
+- Generic cross-protocol fallback or retry.
+- Runtime catalog downloads.
+- Generating an adapter from metadata.
+- Making external metadata control URLs, authentication, headers, redirects, or request bodies.
+- Pricing enforcement, UI presentation, or catalog freshness.
+- Continuation support for an arbitrary serving surface.
+
+Those concerns are separate follow-up projects.
+
+## Terminology
+
+### Model identity
+
+A model identity contains:
+
+- provider instance name;
+- canonical model ID, when known;
+- wire model ID;
+- explicitly documented aliases.
+
+An alias is an accepted name mapping. It is not evidence that two model IDs have equivalent capabilities.
+
+### Serving variant
+
+A serving variant is the executable selection unit:
+
+```
+provider instance + wire model ID + surface
+```
+
+It contains:
+
+- a trusted adapter ID;
+- an API family and version;
+- an endpoint path selected by the adapter;
+- an immutable request contract;
+- the model limits and capabilities relevant to that surface.
+
+The base URL and authentication remain instance configuration. A catalog cannot replace them.
+
+### Request contract
+
+A request contract is typed data, not `map[string]any`. It contains these groups:
+
+- **field policy:** optional request fields allowed, omitted, or unknown;
+- **capabilities:** tools, reasoning, vision, structured output, server tools, and modalities;
+- **reasoning:** supported effort levels, wire mapping, summary/replay behavior, and encrypted-content support;
+- **tools:** function-tool shape, strict-schema policy, tool choice, server-tool names, and parallel-call support;
+- **conversation:** system/developer role, tool-result replay, continuation handles, and stateful fields;
+- **generation:** output-token field, sampling fields, stop fields, and stream usage;
+- **response:** stream event family, finish reasons, and response-shape requirements.
+
+Each capability has four states:
+
+- `supported`: the contract permits the feature;
+- `unsupported`: the contract forbids the feature;
+- `unknown`: no trusted claim exists, so optional use is forbidden;
+- `conflict`: trusted sources disagree, so resolution fails until curated.
+
+Required fields belong to the adapter contract and are not controlled by these optional-field states.
+
+## Configuration model
+
+The clean configuration schema is versioned independently of the current `providers.toml` shape. Old configuration is not migrated silently; it is rejected with an instruction to author the new form.
+
+The conceptual shape is:
+
+```toml
+schema = 2
+default = "groq"
+
+[instances.groq]
+adapter = "openai"
+base_url = "https://api.groq.com/openai/v1"
+
+[instances.groq.models."qwen/qwen3.8-27b"]
+canonical_id = "qwen/qwen3.8-27b"
+default_surface = "responses"
+
+[instances.groq.models."qwen/qwen3.8-27b".surfaces.responses]
+api = "openai-responses"
+contract = "groq-responses"
+```
+
+Surface-specific compatibility belongs under the surface. The user may override typed fields, but cannot provide arbitrary JSON body fragments:
+
+```toml
+[instances.groq.models."qwen/qwen3.8-27b".surfaces.responses.compat]
+supports_store = false
+supports_include = false
+server_search = "none"
+```
+
+The exact field names are implementation detail; the schema must preserve the following rules:
+
+- an instance may provide a default surface;
+- a model may select a different default surface;
+- a model may define multiple named surfaces;
+- each surface has independent compatibility;
+- a surface cannot inherit fields from another surface;
+- only allowlisted contract fields are configurable;
+- base URL, authentication, and headers are never sourced from catalog claims.
+
+## Authority and resolution
+
+There is no global source precedence. Resolution is domain-specific.
+
+### Executable behavior
+
+For adapter, protocol, endpoint path, request fields, and transforms:
+
+1. explicit trusted instance/model/surface configuration;
+2. exact curated Evener serving profile;
+3. curated adapter/surface default;
+4. conservative default.
+
+External catalogs are advisory inputs for later enrichment. They cannot select executable behavior without an allowlisted curated mapping.
+
+### Capabilities and limits
+
+For capabilities and limits:
+
+1. explicit trusted surface override;
+2. exact curated provider/model/surface profile;
+3. conservative unknown.
+
+The first project does not use LiteLLM or Models.dev in this resolution path. Later catalog ingestion may add claims, but claims must retain source, revision, and scope and cannot silently turn `unknown` into `supported`.
+
+### Conflicts
+
+Contradictory trusted values are a configuration error. Contradictory external claims are retained as a conflict and resolve to unknown for request construction until a curated override settles them.
+
+## Curated profiles
+
+The first release ships typed profiles for the existing supported surfaces and the incident case:
+
+### OpenAI public Responses
+
+Implement the native OpenAI Responses contract, including supported Responses continuation and reasoning fields where the adapter requires them. This is the desired contract for the native surface, not a promise to preserve accidental behavior from the old implementation.
+
+### OpenAI-compatible Chat Completions
+
+Implement the OpenAI-compatible Chat Completions contract: model-specific reasoning formats, output-token field, tool-result replay, strict-tool policy, stream usage, and cache controls are surface-scoped. The new contract defines the intended behavior; it does not preserve accidental legacy fields.
+
+### Groq Responses
+
+Use the Groq Responses API only when explicitly selected. The profile:
+
+- omits `store`;
+- omits `include` and encrypted-reasoning request fields unless separately proven;
+- disables OpenAI `web_search` for Qwen;
+- permits only Groq-documented server-tool names on models that support them;
+- does not enable continuation merely because Responses is accepted;
+- retains Groq’s model-specific reasoning and tool capabilities as separate claims.
+
+### Unknown OpenAI-shaped surface
+
+Use a conservative Responses or Chat contract selected by configuration. Emit required core fields only. Do not inherit OpenAI-only caching, server tools, encrypted reasoning, continuation, or provider options merely because a URL resembles an OpenAI endpoint.
+
+## Runtime architecture
+
+The serving resolver is a pure, network-free package shared by configuration loading, agent profile construction, and adapter construction. It returns an immutable serving variant or a typed error.
+
+The client resolves the variant before dispatch. The adapter receives the variant’s contract and cannot silently substitute a different surface. The agent uses the same variant to decide whether to expose reasoning, tools, or provider-native web search.
+
+The existing semantic request model remains provider-agnostic. Provider-specific behavior is applied only by the selected adapter under the resolved contract. Arbitrary provider options are removed from the execution path unless they are defined by an allowlisted contract field.
+
+A missing variant has two valid outcomes:
+
+- explicit configuration selects a known surface and its conservative contract can serve the request; or
+- resolution fails before network dispatch with the instance, model, and missing contract named.
+
+The runtime never sends a speculative first request to discover the answer.
+
+## Breaking changes
+
+This project intentionally has no backward-compatibility requirement.
+
+- The provider configuration schema may move from instance-wide API style to model/surface variants.
+- Existing configuration files may require explicit reauthoring.
+- The internal adapter/profile interfaces may change to require a resolved serving variant.
+- Duplicated provider-conditional decisions in agent and adapters are removed in favor of the shared resolver.
+- Existing tests and fixtures are rewritten to the new schema rather than preserving legacy parsing behavior.
+
+A deliberate compatibility shim may be added later if migration cost warrants it, but it is not part of this project.
+
+## Testing and acceptance
+
+All tests use fake transports or pure functions. No provider credentials or network access are allowed.
+
+### Resolver tests
+
+- exact instance/model/surface selection;
+- provider default and model override selection;
+- multiple surfaces for one wire model;
+- surface isolation;
+- typed allowlist validation;
+- supported, unsupported, unknown, and conflict behavior;
+- trusted configuration precedence;
+- unknown model conservative resolution;
+- invalid configuration fails before adapter dispatch.
+
+### Request-shape tests
+
+Golden request tests must cover:
+
+- OpenAI public Responses baseline;
+- OpenAI-compatible Chat baseline;
+- Groq Responses with `store`, `include`, and OpenAI `web_search` absent;
+- Groq function tools and reasoning controls in their documented shape;
+- unknown Responses and Chat surfaces with optional fields omitted;
+- tool history and stream request behavior;
+- response and error parsing for each adapter.
+
+### Cross-layer tests
+
+- agent capability exposure equals adapter contract capability;
+- a disabled server tool cannot enter the request through agent defaults;
+- a surface switch cannot carry surface-specific continuation or reasoning state;
+- API attempt records include instance, wire model, surface, adapter, and contract revision;
+- existing provider behavior is tested under the new schema, not through legacy compatibility fixtures.
+
+### Fuzz/property tests
+
+- malformed configuration and contract values never panic;
+- unknown values never enable optional fields;
+- serialization is deterministic;
+- no contract field can inject an unallowlisted body key, URL, or credential header.
+
+The project is accepted only when these tests pass and the normal offline gates remain deterministic.
+
+## Follow-up projects
+
+### External metadata ingestion
+
+Keep LiteLLM for broad limits, pricing, and capability enrichment. Add Models.dev as a supplemental provider/inventory source because it has useful provider/API-package mappings. Neither becomes protocol authority. Pin both snapshots, validate them, preserve license notices, and convert them into provenance-bearing claims.
+
+### Inventory discovery
+
+Extend documented `/models` responses to inventory and explicitly advertised metadata. Do not infer protocol or request-field support from an ordinary model list.
+
+### Diagnostic probing
+
+Add an explicit, disclosed doctor operation for minimal no-state requests. Store exact-scope evidence with TTL and config/adapter invalidation. Never run it implicitly.
+
+### Protocol fallback
+
+Only add provider-specific fallback after a provider documents non-execution or provides a valid idempotency guarantee. Rebuild the alternate request, make one attempt, and log both. Generic 400/404/422 responses remain non-fallback errors.
+
+### Presentation
+
+Expose selected surface, contract status, provenance, conflicts, and unknown capabilities in CLI/hub/web model views.
+
+## Open decisions for implementation planning
+
+1. Should a conservative unknown surface be selectable, or should unknown contracts always fail before dispatch?
+2. Which exact contract fields are needed in v1 beyond Groq’s `store`, `include`, and server-tool restrictions?
+3. Should surface selection be a model-level default plus named surfaces, or should every launch specify a surface explicitly?
+4. Which current provider adapters are in the first curated-profile set?
+5. What is the precise trusted boundary for project-local configuration versus user-global configuration?
+
+These decisions must be resolved in the implementation plan. They do not justify adding catalog ingestion or runtime probing to the first project.


### PR DESCRIPTION
## What

Redesigns **Settings → Marketplaces & Plugins** as a *segmented workspace*, replacing the three stacked sub-sections (marketplaces, browse tree, installed) with one list at a time behind a page-level `SegmentedControl` — **Installed (n) / Browse / Marketplaces (n)**.

- Installed rows are now single tappable targets (status dot, state chips, mono meta, chevron) with a client-side filter. The per-row wall of four small buttons is gone.
- Every per-plugin action moved into a new `PluginDetailSheet`: a `Sheet` on the right on desktop, on the bottom on mobile. It carries state chips, the catalog description (lazily pulled through the browse cache), a Version/Marketplace/Source meta table, **Enabled** and **Auto-upgrade** switches (disabled while their RPC is in flight), **Upgrade**, and **Remove** behind a `ConfirmDialog` (safely nested over the sheet — each `OverlayPanel` traps/restores focus down the stack, and its `preventDefault` on Escape keeps the settings pane open).
- The sheet reads its entry from the store, so cross-client changes land live; it closes itself when the entry disappears or when the segment switches.
- Counts moved from per-section headers into the segment labels; the headers and their CSS are deleted.

## Why

The stacked layout's pain points: 4-button rows that cramped mobile, marketplace management competing with browsing for the same scroll, and no focused surface for per-plugin detail. This design was picked from a six-mockup exploration (all six, with desktop+mobile screenshots, are in `docs/web-ui/specs/assets/2026-08-29-plugins-segmented-workspace/`).

## Deliberate deviation from the approved mockup

The mockup's "Update available" chip / "Upgrade to vX.Y.Z" label implies an update-detection field the wire model does not have (`PluginEntry` has version, enabled, autoUpgrade, broken — nothing upstream). The sheet ships a plain **Upgrade** action (the RPC's real check-and-pull semantics) rather than faking the field. Real update detection is a backend feature.

## Design docs

The design language this PR ships is written up in **#584** (docs-only): `design-system.md` §10 — Collection pages: segmented workspaces and detail sheets — plus the `decisions.md` entry and all mockup/implementation screenshots.

## Screenshots

The approved mockup, and what actually shipped (real app, disposable hub, real marketplaces + installs):

| | Mockup B | Shipped |
|---|---|---|
| Desktop | ![mockup desktop](https://github.com/prime-radiant-inc/evener/raw/4200ed18c/docs/web-ui/specs/assets/2026-08-29-plugins-segmented-workspace/mockup-b-desktop.png) | ![installed desktop](https://github.com/prime-radiant-inc/evener/raw/4200ed18c/docs/web-ui/specs/assets/2026-08-29-plugins-segmented-workspace/impl-installed-desktop.png) |
| Mobile | ![mockup mobile](https://github.com/prime-radiant-inc/evener/raw/4200ed18c/docs/web-ui/specs/assets/2026-08-29-plugins-segmented-workspace/mockup-b-mobile.png) | ![installed mobile](https://github.com/prime-radiant-inc/evener/raw/4200ed18c/docs/web-ui/specs/assets/2026-08-29-plugins-segmented-workspace/impl-installed-mobile.png) |

Detail sheet — right sheet on desktop, bottom sheet on mobile:

| Desktop | Mobile |
|---|---|
| ![sheet desktop](https://github.com/prime-radiant-inc/evener/raw/4200ed18c/docs/web-ui/specs/assets/2026-08-29-plugins-segmented-workspace/impl-sheet-desktop.png) | ![sheet mobile](https://github.com/prime-radiant-inc/evener/raw/4200ed18c/docs/web-ui/specs/assets/2026-08-29-plugins-segmented-workspace/impl-sheet-mobile.png) |

Browse and Marketplaces segments: [browse desktop](https://github.com/prime-radiant-inc/evener/raw/4200ed18c/docs/web-ui/specs/assets/2026-08-29-plugins-segmented-workspace/impl-browse-desktop.png) · [browse mobile](https://github.com/prime-radiant-inc/evener/raw/4200ed18c/docs/web-ui/specs/assets/2026-08-29-plugins-segmented-workspace/impl-browse-mobile.png) · [marketplaces desktop](https://github.com/prime-radiant-inc/evener/raw/4200ed18c/docs/web-ui/specs/assets/2026-08-29-plugins-segmented-workspace/impl-marketplaces-desktop.png) · [marketplaces mobile](https://github.com/prime-radiant-inc/evener/raw/4200ed18c/docs/web-ui/specs/assets/2026-08-29-plugins-segmented-workspace/impl-marketplaces-mobile.png)

## Verification

- TDD throughout: red→green per component; the new tests were mutation-proven (watched fail with the mechanism broken, green when restored).
- **79/79** section tests; `make test-web` (typecheck + full frontend unit + Biome) ✓; `make test-web-browser` (all four real-Chrome guards) ✓; `make test` in the worktree ✓.
- Independent code review: *approve-with-nits*; all four actionable findings fixed (stale empty-state copy, enable-branch coverage, two busy-state coverage cases).
- Screenshots above were taken against this branch built and run, driving the real UI (browse → install → sheet) in Chrome at 1440×900 and 390×844.

