### PR TITLE
fix(fuzz): make oracle-audit string matching immune to SIGPIPE under pipefail (#277)

### DIFF
--- a/scripts/fuzz/fuzz-oracle-audit-selftest.sh
+++ b/scripts/fuzz/fuzz-oracle-audit-selftest.sh
@@ -19,7 +19,11 @@ scratch_dir work fuzz-oracle-audit-selftest
 # assert_str_has STRING NEEDLE DESC — DESC passes if STRING contains NEEDLE.
 # Distinct from the lib's file-based assert_has: every call site here already
 # has its candidate output in hand as a string, not as a file on disk.
-assert_str_has() { if printf '%s' "$1" | grep -qF -- "$2"; then ok "$3"; else bad "$3 (missing: $2)"; printf '%s\n' "$1" | sed 's/^/    | /'; fi; }
+# Pipe-free on purpose: `printf | grep -qF` exits grep at the first hit while
+# printf is still writing a >pipe-buffer string, so pipefail reported the
+# producer's SIGPIPE (141) and a true match read as "missing" (#277). A quoted
+# `[[ == *"$2"* ]]` is the same literal-substring test with no pipe to break.
+assert_str_has() { if [[ "$1" == *"$2"* ]]; then ok "$3"; else bad "$3 (missing: $2)"; printf '%s\n' "$1" | sed 's/^/    | /'; fi; }
 
 repo="$work/repo"
 mkdir -p "$repo/fuzz/mutations"
@@ -142,5 +146,13 @@ out2="$(run_audit --gap-only)"; rc2=$?
 set -e
 assert_str_has "$out2" "UNAUDITED: .:FuzzUnaudited" "gap-only: lists the unaudited target"
 assert_eq "$rc2" "0" "gap-only: exits zero (report, not a gate)"
+
+# --- SIGPIPE regression (#277) -----------------------------------------------
+# A needle in the FIRST line of a >pipe-buffer multi-line string must not read
+# as "missing" (mechanism documented on assert_str_has above). Multi-line is
+# load-bearing: grep buffers whole lines, so a single-line probe cannot fill
+# the pipe.
+big="NEEDLE-FIRST-LINE"$'\n'"$(printf 'filler line %d, long enough and repeated enough to overflow any pipe buffer\n' {1..20000})"
+assert_str_has "$big" "NEEDLE-FIRST-LINE" "containment holds on >pipe-buffer output (no SIGPIPE false negative)"
 
 selftest_summary

--- a/scripts/fuzz/fuzz-oracle-audit.sh
+++ b/scripts/fuzz/fuzz-oracle-audit.sh
@@ -44,13 +44,23 @@ done
 native_targets() { bash "$runner" --list | awk -F: '$1=="native"{print $2":"$4}'; }
 mutated_targets() { [ -f "$manifest" ] && awk -F'\t' '$1!~/^#/ && NF>=2{print $2}' "$manifest" | sort -u; }
 
+# in_list <needle> <newline-delimited-list> — whole-line membership, pipe-free
+# on purpose: `printf | grep -qxF` exits grep at the hit while printf is still
+# writing, and pipefail then reports the producer's SIGPIPE (141) — a covered
+# target read as UNAUDITED (#277). A quoted case pattern is the same literal
+# whole-line test with no pipe to break. (Twin copy: fuzz-triage.sh.)
+in_list() { case "$2" in *$'\n'"$1"$'\n'*) return 0 ;; *) return 1 ;; esac; }
+
 report_gaps() {
-	local t covered=0 gap=0 muts
-	muts="$(mutated_targets)"
+	local t covered=0 gap=0 muts_nl
+	# Frame the mutated-target list with \n (command substitution strips the
+	# trailing newline) so whole-line matching below sees the first and last
+	# lines too.
+	muts_nl=$'\n'"$(mutated_targets)"$'\n'
 	echo "fuzz-oracle-audit: oracle coverage"
 	while read -r t; do
 		[ -n "$t" ] || continue
-		if printf '%s\n' "$muts" | grep -qxF "$t"; then
+		if in_list "$t" "$muts_nl"; then
 			covered=$((covered + 1))
 		else
 			echo "    UNAUDITED: $t"; gap=$((gap + 1))
@@ -97,14 +107,21 @@ run_seeds() {
 	REPRO_OUT="$(cd "$wt/$1" && EVENER_FUZZ_TESTS=1 "$go_bin" test ${tags:+-tags "$tags"} -run "^$3\$" -count=1 "$2" 2>&1)"
 	REPRO_RC=$?
 }
-build_failed() { printf '%s' "$REPRO_OUT" | grep -qE '\[build failed\]|\[setup failed\]'; }
+# build_failed matches POSIX ERE, pipe-free on purpose: `printf | grep -qE`
+# exits grep at the hit while printf is still writing, and pipefail then reports
+# the producer's SIGPIPE (141) — a build failure could read as a clean build
+# (#277). `[[ =~ ]]` applies the same ERE with no pipe to break; the regex
+# rides in a variable because that is the one spelling every bash (3.2 on up,
+# the stock macOS shell included) treats literally instead of re-parsing.
+build_failed() {
+	local re='\[build failed\]|\[setup failed\]'
+	[[ "$REPRO_OUT" =~ $re ]]
+}
 
 # Per-target clean-tree memo as two newline-delimited lists (ok / bad):
 # bash 3.2 — the stock macOS bash — has no associative arrays.
 clean_ok_list=$'\n'
 clean_bad_list=$'\n'
-# in_list <needle> <newline-delimited-list>
-in_list() { case "$2" in *$'\n'"$1"$'\n'*) return 0 ;; *) return 1 ;; esac; }
 pass=0 blind=0 rot=0 err=0 audited=0
 
 while IFS=$'\t' read -r id target patchfile desc; do


### PR DESCRIPTION
Closes #277.

## Root cause
`set -uo pipefail` + `grep -q` short-circuit: when a producer (`printf '%s' ""`) writes a large string and `grep -qF` exits at the first match, the producer receives SIGPIPE; under pipefail the pipeline returns **141 even though the match succeeded**, turning a true match into a false "missing" failure. Output-size dependent — hence CI-only and transient (the issue's triage measured producer status 141 / grep 0 on a 440,006-byte probe). Sites: `fuzz-oracle-audit-selftest.sh` `assert_str_has` (`printf | grep -qF`), `fuzz-oracle-audit.sh` target-membership (`grep -qxF`) and `build_failed` (`grep -qE`).

## Fix
Replaced the three containment pipelines with pipe-free shell matching that preserves exact semantics per site:
- `assert_str_has`: `[[ "$1" == *"$2"* ]]` (quoted-variable glob is literal — same -qF substring semantics)
- target membership `in_list`: `case "$2" in *$'\n'"$1"$'\n'*`` newline-delimited exact-line membership (same -qxF)
- `build_failed`: ERE-equivalent pipe-free match (same -qE)

Plus a >pipe-buffer regression check in the selftest (multi-line probe — single-line probes cannot fill the pipe buffer — asserting containment holds on ~1MB output).

## Tests
- New regression check verified by an independent adversarial reviewer to fail **20/20 pre-fix** and pass post-fix.
- `make test-dev-tooling` — PASS (all suites)
- `bash -n` both scripts — PASS
- `make vet`, `make lint` — PASS

## Review
Two independent adversarial reviewers (competitive protocol with disqualification for false/inflated findings): both **approve**. Reviewer A: 3 nits, each verified unreachable at the actual call sites. Reviewer B: zero findings — confirmed all old-vs-new semantics differentials are unreachable, `in_list` framing correct at every caller, and the regression test exercises the real fixed construct. The one legitimate residual (an untriggerable `grep -q` at `selftest:137`) is filed separately as #586 rather than expanding this PR.

Simplify pass applied pre-commit; tests re-run green after.