### PR TITLE
fix(web): clean frontend/dist before the typecheck, not only inside vite

### DIFF
--- a/cmd/evener-hub/frontend/package.json
+++ b/cmd/evener-hub/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc --noEmit --incremental false && vite build",
+    "build": "node scripts/clean-dist.mjs && tsc --noEmit --incremental false && vite build",
     "typecheck": "tsc --noEmit --incremental false",
     "typecheck:fast": "tsc --noEmit",
     "test": "sh -c 'vitest run --maxWorkers=4 --exclude \"scripts/*.test.mjs\" \"$@\" && node --test scripts/*.test.mjs' --",

--- a/cmd/evener-hub/frontend/scripts/clean-dist.mjs
+++ b/cmd/evener-hub/frontend/scripts/clean-dist.mjs
@@ -1,0 +1,34 @@
+// clean-dist.mjs — reduce frontend/dist to the tracked PLACEHOLDER before the
+// build's fallible steps run.
+//
+// Why: `npm run build` is `tsc --noEmit && vite build`, and vite's
+// emptyOutDir only fires inside the second half. A failed typecheck leaves
+// the PREVIOUS build's dist fully in place, and any `go build` afterward
+// silently embeds that stale SPA — the hub serves an old UI with no signal
+// anything failed (the manual `rm -rf dist` workaround this script
+// replaces). Cleaning first means a failed build leaves dist holding only
+// the tracked PLACEHOLDER: go:embed still compiles and the hub serves its
+// documented 503 "web app not built" instead of a stale app.
+//
+// The content written here is byte-identical to the tracked
+// dist/PLACEHOLDER and to what vite.config.ts's restoreDistPlaceholder
+// plugin writes at closeBundle (kata 88nn), so `git status` stays clean
+// however the build ends.
+//
+// Safety: this script recursively deletes the contents of one directory.
+// That directory is derived from this file's own location — never from
+// arguments or the environment — so no caller can redirect the delete.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const frontendRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const distDir = path.join(frontendRoot, "dist");
+const placeholderPath = path.join(distDir, "PLACEHOLDER");
+const placeholderContent = "run make build-web\n";
+
+fs.mkdirSync(distDir, { recursive: true });
+for (const entry of fs.readdirSync(distDir)) {
+  fs.rmSync(path.join(distDir, entry), { recursive: true, force: true });
+}
+fs.writeFileSync(placeholderPath, placeholderContent);

--- a/cmd/evener-hub/frontend/scripts/clean-dist.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/clean-dist.test.mjs
@@ -1,0 +1,92 @@
+// Pins clean-dist.mjs's contract: the script npm run build invokes before its
+// fallible steps, so a failed typecheck cannot leave the previous build's
+// dist behind for go:embed to silently pick up (the stale-SPA failure mode
+// that previously required a manual `rm -rf dist`).
+//
+// The cases run the REAL script against a fixture frontend tree laid out
+// like the real one (scripts/ next to dist/), because the failure this pins
+// is about what actually lands on disk — a fake cleaner would only restate
+// the mock.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { fileURLToPath } from "node:url";
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const scriptPath = path.join(scriptsDir, "clean-dist.mjs");
+
+// newFixtureFrontend builds a throwaway tree shaped like the real frontend
+// (scripts/clean-dist.mjs with dist/ one level up), so the script under test
+// cleans ITS tree, never the real checkout's dist.
+function newFixtureFrontend() {
+  const root = mkdtempSync(path.join(tmpdir(), "evener-clean-dist-"));
+  const fixtureScripts = path.join(root, "scripts");
+  mkdirSync(fixtureScripts);
+  const realScript = readFileSync(scriptPath, "utf8");
+  writeFileSync(path.join(fixtureScripts, "clean-dist.mjs"), realScript);
+  return { root, script: path.join(fixtureScripts, "clean-dist.mjs") };
+}
+
+test("removes a previous build's dist down to the tracked PLACEHOLDER", () => {
+  const { root, script } = newFixtureFrontend();
+  try {
+    const dist = path.join(root, "dist");
+    mkdirSync(path.join(dist, "webassets"), { recursive: true });
+    writeFileSync(path.join(dist, "webassets", "index-STALE.js"), "stale bundle");
+    writeFileSync(path.join(dist, "webassets", "nested"), "nested dir entry");
+    mkdirSync(path.join(dist, "webassets", "deep"), { recursive: true });
+    writeFileSync(path.join(dist, "webassets", "deep", "chunk.js"), "stale chunk");
+    writeFileSync(path.join(dist, "index.html"), "stale shell");
+
+    execFileSync(process.execPath, [script], { cwd: root });
+
+    assert.equal(existsSync(path.join(dist, "webassets")), false, "stale webassets survived");
+    assert.equal(existsSync(path.join(dist, "index.html")), false, "stale index.html survived");
+    assert.equal(
+      readFileSync(path.join(dist, "PLACEHOLDER"), "utf8"),
+      "run make build-web\n",
+      "PLACEHOLDER content must stay byte-identical to the tracked file",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("creates the tracked PLACEHOLDER when dist is absent", () => {
+  const { root, script } = newFixtureFrontend();
+  try {
+    execFileSync(process.execPath, [script], { cwd: root });
+
+    assert.equal(
+      readFileSync(path.join(root, "dist", "PLACEHOLDER"), "utf8"),
+      "run make build-web\n",
+      "a missing dist must end with only the PLACEHOLDER so go:embed compiles",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("cleans only its own tree, ignoring the working directory", () => {
+  const { root, script } = newFixtureFrontend();
+  try {
+    const otherDist = path.join(root, "elsewhere", "dist");
+    mkdirSync(otherDist, { recursive: true });
+    writeFileSync(path.join(otherDist, "index.html"), "unrelated");
+
+    execFileSync(process.execPath, [script], { cwd: tmpdir() });
+
+    assert.equal(
+      readFileSync(path.join(otherDist, "index.html"), "utf8"),
+      "unrelated",
+      "cleaned a dist resolved from the working directory instead of the script location",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/make/building.mk
+++ b/make/building.mk
@@ -65,7 +65,13 @@ web-preflight:
 # point, the install step is the only cacheable part. vite's emptyOutDir wipes
 # the tracked dist/PLACEHOLDER on every build; vite.config.ts writes it back
 # at closeBundle, so no recipe here restores it and `git status` stays clean
-# after a build however vite was invoked (kata 88nn).
+# after a build however vite was invoked (kata 88nn). npm run build also
+# cleans dist down to that PLACEHOLDER BEFORE the fallible typecheck runs
+# (frontend scripts/clean-dist.mjs): emptyOutDir only fires inside
+# `vite build`, so a failed typecheck used to leave the previous build's dist
+# behind for go:embed to silently pick up — a failed build now leaves only
+# the PLACEHOLDER, which embeds and serves the documented 503 instead of a
+# stale SPA.
 ## Build the frontend (TypeScript typecheck + Vite production build) into
 ## frontend/dist for Go embedding.
 ## proves: TypeScript typecheck and the Vite production build complete and


### PR DESCRIPTION
## Root cause

`npm run build` (the recipe behind `make build-web`, `make build`, `make install`, and the e2e runbook's documented frontend path) was:

    tsc --noEmit --incremental false && vite build

Vite's `emptyOutDir` — the only thing that cleaned `frontend/dist` — runs **inside** `vite build`, i.e. only after the typecheck already passed. When `tsc` failed, the previous build's `dist/` survived untouched: a complete, valid-looking SPA. Any subsequent `go build` against that tree (`//go:embed all:frontend/dist` in `cmd/evener-hub/webnext.go`) then silently embedded the **stale** SPA, and the hub served the old UI with no signal that the build had failed. The only workaround was a manual `rm -rf cmd/evener-hub/frontend/dist` — the "cached build" that never got cleaned.

Verified before fixing (in a clean worktree): the pipeline is otherwise correct — `emptyOutDir` does remove leftovers on a successful build, the Go build cache correctly invalidates on embed-content changes (change/add/remove all propagate), and the hub serves straight from the embedded FS with no disk cache. The stale window is exactly and only the failed-build case.

## Fix

`cmd/evener-hub/frontend/scripts/clean-dist.mjs` reduces `dist/` to the tracked `PLACEHOLDER` **before** the fallible typecheck runs, and `npm run build` invokes it first:

    node scripts/clean-dist.mjs && tsc --noEmit --incremental false && vite build

A failed build now leaves `dist/` holding only `dist/PLACEHOLDER`, so:

- `go:embed` still compiles (the tracked placeholder exists precisely to keep dist non-empty),
- a hub built from that tree serves the documented `503 evener hub web app not built: run make build-web and rebuild` instead of a silently stale app,
- the placeholder content is byte-identical to the tracked file and to what `vite.config.ts` restores at `closeBundle` (kata 88nn), so `git status` stays clean however the build ends,
- the delete target is derived from the script's own location — never from arguments or the environment — so no caller can redirect it (per the repo's recursive-delete rules).

## Test

`cmd/evener-hub/frontend/scripts/clean-dist.test.mjs` (node --test, part of `npm test` / `make test-web`): a seeded stale dist is reduced to the PLACEHOLDER; a missing dist ends with only the PLACEHOLDER; and the clean never follows the working directory.

## Verification

- Reproduction (before fix): type error in `src/main.tsx` → `make build-web` exit 2 → `dist/webassets` still held the previous 35 files.
- After fix, same scenario: `make build-web` exit 2 → `dist/` contains only `PLACEHOLDER`.
- Clean rebuild after failure: 35 files restored, embedded frontend hash unchanged from a clean tree (`63962571a74c`), `git status` clean.
- `make build` end-to-end, `make test-web` (typecheck / vitest / lint PASS), `make lint-generated` PASS, `go build ./...` PASS, `go test -run 'TestRuntimePairBuild|TestMakeRuntime|TestMakeWeb|TestInstallHome' .` PASS, `scripts/web/web-preflight-selftest.sh` exit 0.
