### PR TITLE
fix(rail): nest subagents under their parent in the Live section

### DIFF
--- a/cmd/evener-hub/internal/hubcore/tree.go
+++ b/cmd/evener-hub/internal/hubcore/tree.go
@@ -608,6 +608,49 @@ func nestedSessionIDs(metas []schema.SessionMeta) (nested map[string]struct{}, f
 	return nested, forkChildren
 }
 
+// liveParentOrForkContinuation returns the ID of the row a nested session
+// attaches under: a subagent's direct parent, or a fork-superseded parent's
+// active continuation (the child whose ParentSessionID names it). Returns ""
+// when the meta is neither a subagent nor a fork-superseded parent. The Live
+// tier uses this to decide whether a nested live session has a live parent to
+// nest under; if not, it keeps its own top-level row rather than vanishing.
+func liveParentOrForkContinuation(m schema.SessionMeta, forkChildren map[string]string) string {
+	if m.IsSubagent && m.ParentSessionID != "" {
+		return m.ParentSessionID
+	}
+	if childID, ok := forkChildren[m.ID]; ok {
+		return childID
+	}
+	return ""
+}
+
+// pruneLiveSubtree keeps only live descendants of node (live = present in
+// liveMap, or an in-process child in runningSubagentIDs). The node itself is
+// always kept — the Live tier calls this only on live top-level rows.
+// MoreSubagents is zeroed: buildNode capped subagent children before pruning,
+// so the count reflected a live/non-live mix; after pruning only live children
+// remain and a live-only cap is meaningless on a tier that is itself all-live.
+func pruneLiveSubtree(node TreeNode, liveMap map[string]LiveEntry, runningSubagentIDs map[string]bool) TreeNode {
+	kept := make([]TreeNode, 0, len(node.Children))
+	for _, child := range node.Children {
+		if !isLiveID(child.ID, liveMap, runningSubagentIDs) {
+			continue
+		}
+		pruned := pruneLiveSubtree(child, liveMap, runningSubagentIDs)
+		kept = append(kept, pruned)
+	}
+	node.Children = kept
+	node.MoreSubagents = 0
+	return node
+}
+
+func isLiveID(id string, liveMap map[string]LiveEntry, runningSubagentIDs map[string]bool) bool {
+	if _, ok := liveMap[id]; ok {
+		return true
+	}
+	return runningSubagentIDs[id]
+}
+
 // TopLevelSessionIDs returns the session IDs that the navigation tree treats
 // as independently addressable rows. It is intentionally based on the full
 // metadata snapshot so callers do not mistake a capped rail projection for
@@ -1272,38 +1315,65 @@ func buildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decis
 	sort.SliceStable(activeProjects, byLastActivityDesc(activeProjects))
 	sort.SliceStable(archivedProjects, byLastActivityDesc(archivedProjects))
 
-	// Build the Live slice: every live session, flat, sorted by attention rank
-	// desc, then the Hub session ordering contract. Archived sessions are
-	// filtered out after the sort, below.
+	// Build the Live slice: every live, top-level session, with its subagent
+	// children nested the same way the Projects tier builds them (buildNode),
+	// sorted by attention rank desc, then the Hub session ordering contract.
+	// Archived sessions are filtered out after the sort, below.
+	//
+	// Only top-level sessions get their own row. Subagents and
+	// fork-superseded parents (nested under their live continuation, per
+	// nestedSessionIDs) nest under the row that owns their task tree, so they
+	// render with the same foldout and active-status color as every other
+	// section — not as flat, parentless top-level rows. This is the same
+	// membership rule the NeedsYou tier (tierEligible) and the project
+	// accumulator (topLevel) apply; all three read the one
+	// nestedSessionIDs/forkChildren result, so they can never disagree about
+	// which sessions are top-level.
 	liveNodes := make([]TreeNode, 0, len(live))
 	for _, le := range live {
 		if le.SessionID == "" {
 			continue
 		}
+		// A nested session (subagent, or a fork-superseded parent whose active
+		// continuation is itself live) is NOT a top-level Live row when the
+		// row it nests under is also live: it renders under that parent's
+		// foldout instead. When the parent/continuation is NOT live, though,
+		// the nested session has no live row to nest under — so it keeps its
+		// own top-level Live row, the same way the project accumulator keeps a
+		// fork-superseded parent top-level when no active branch references it.
 		metaValue, hasMeta := metaMap[le.SessionID]
-		state := stateFor(le.SessionID)
-		node := TreeNode{
-			ID:         le.SessionID,
-			Ref:        liveRefMap[le.SessionID],
-			State:      state,
-			AskPending: askPendingFor(le.SessionID),
-			Dormant:    dormantFor(le.SessionID),
-			Kind:       "session",
-		}
 		if hasMeta {
-			kind := nodeKind(metaValue)
-			node.Kind = kind
-			node.Title = nodeTitle(metaValue, kind)
-			node.Project = projectName(metaValue)
-			node.CreatedAt = OrderCreatedAt(metaValue.CreatedAt, metaValue.UpdatedAt)
-			node.UpdatedAt = OrderUpdatedAt(metaValue.UpdatedAt, metaValue.CreatedAt)
-			node.Age = AgeString(node.UpdatedAt)
-		} else {
-			node.Title = ShortID(le.SessionID)
-			node.CreatedAt = le.StartedAt
-			node.UpdatedAt = le.StartedAt
-			node.Age = AgeString(le.StartedAt)
+			if parent := liveParentOrForkContinuation(metaValue, forkChildren); parent != "" {
+				if _, ok := liveMap[parent]; ok {
+					continue
+				}
+			}
 		}
+		// A live-only session the past index has not caught up with has no
+		// meta; build a flat leaf node the way the original loop did. buildNode
+		// needs a meta to resolve kind/title/project, and a session with none
+		// has no lineage to recurse into.
+		if !hasMeta {
+			node := TreeNode{
+				ID:         le.SessionID,
+				Ref:        liveRefMap[le.SessionID],
+				State:      stateFor(le.SessionID),
+				AskPending: askPendingFor(le.SessionID),
+				Dormant:    dormantFor(le.SessionID),
+				Kind:       "session",
+				Title:      ShortID(le.SessionID),
+				CreatedAt:  le.StartedAt,
+				UpdatedAt:  le.StartedAt,
+				Age:        AgeString(le.StartedAt),
+			}
+			liveNodes = append(liveNodes, node)
+			continue
+		}
+		kind := nodeKind(metaValue)
+		node := buildNode(metaValue, kind, &projectAccum{name: projectName(metaValue)}, map[string]bool{}, false)
+		// buildNode attaches every child the metadata knows about, including
+		// non-live subagents and forks. The Live tier is only live sessions.
+		node = pruneLiveSubtree(node, liveMap, runningSubagentIDs)
 		liveNodes = append(liveNodes, node)
 	}
 	sort.SliceStable(liveNodes, func(i, j int) bool {

--- a/cmd/evener-hub/internal/hubcore/tree_live_subagents_test.go
+++ b/cmd/evener-hub/internal/hubcore/tree_live_subagents_test.go
@@ -1,0 +1,174 @@
+package hubcore
+
+import (
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/appwire"
+)
+
+// The Live tier used to build flat, parentless TreeNode values: a live
+// subagent appeared as its own top-level row instead of nesting under the
+// parent that spawned it, and its active state never colored the row the way
+// every other section's rows do. These tests pin the fix: the Live tier now
+// builds via buildNode (the same path the Projects tier uses), so subagent
+// children nest under their live parent with the same foldout and the same
+// active-status color as every other section.
+
+func TestBuildTreeLiveNestsActiveSubagentUnderParent(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	metas := []schema.SessionMeta{
+		{ID: "parent", CreatedAt: now, UpdatedAt: now, EnvInfo: schema.EnvironmentInfo{WorkingDir: "/projects/evener"}},
+		{ID: "child", CreatedAt: now, UpdatedAt: now, ParentSessionID: "parent", IsSubagent: true, EnvInfo: schema.EnvironmentInfo{WorkingDir: "/projects/evener"}},
+	}
+	live := []LiveEntry{
+		{PID: 1, SessionID: "parent", Status: appwire.ThreadStatusIdle, RunningSubagentIDs: []string{"child"}},
+		{PID: 2, SessionID: "child", Status: appwire.ThreadStatusActive},
+	}
+
+	tree := BuildTreeAt(metas, live, nil, now)
+
+	// The parent is the one top-level Live row; the subagent nests under it.
+	if len(tree.Live) != 1 {
+		t.Fatalf("Live tier has %d rows, want 1 (the parent)", len(tree.Live))
+	}
+	parent := tree.Live[0]
+	if parent.ID != "parent" {
+		t.Fatalf("Live[0].ID = %q, want parent", parent.ID)
+	}
+	if len(parent.Children) != 1 {
+		t.Fatalf("parent has %d children, want 1 (the live subagent)", len(parent.Children))
+	}
+	child := parent.Children[0]
+	if child.ID != "child" {
+		t.Fatalf("child.ID = %q, want child", child.ID)
+	}
+	if child.Kind != "subagent" {
+		t.Errorf("child.Kind = %q, want subagent", child.Kind)
+	}
+	// The active subagent carries its own daemon-reported state, which the
+	// frontend's cadenceStateFor maps to the working/active color family —
+	// the same color every other section uses for an active subagent.
+	if child.State != "active" {
+		t.Errorf("child.State = %q, want active (the working/active color)", child.State)
+	}
+}
+
+func TestBuildTreeLiveExcludesSubagentWhoseParentIsLive(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	metas := []schema.SessionMeta{
+		{ID: "parent", CreatedAt: now, UpdatedAt: now, EnvInfo: schema.EnvironmentInfo{WorkingDir: "/projects/evener"}},
+		{ID: "child", CreatedAt: now, UpdatedAt: now, ParentSessionID: "parent", IsSubagent: true, EnvInfo: schema.EnvironmentInfo{WorkingDir: "/projects/evener"}},
+	}
+	live := []LiveEntry{
+		{PID: 1, SessionID: "parent", Status: appwire.ThreadStatusActive, RunningSubagentIDs: []string{"child"}},
+		{PID: 2, SessionID: "child", Status: appwire.ThreadStatusActive},
+	}
+
+	tree := BuildTreeAt(metas, live, nil, now)
+
+	// The subagent must NOT appear as a separate top-level Live row — it
+	// nests under its live parent. Only the parent is top-level.
+	ids := make(map[string]bool, len(tree.Live))
+	for _, node := range tree.Live {
+		ids[node.ID] = true
+	}
+	if ids["child"] {
+		t.Error("live subagent child appeared as a top-level Live row; it must nest under its parent")
+	}
+	if !ids["parent"] {
+		t.Error("live parent missing from the Live tier")
+	}
+}
+
+func TestBuildTreeLiveKeepsOrphanedSubagentTopLevel(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	metas := []schema.SessionMeta{
+		{ID: "parent", CreatedAt: now, UpdatedAt: now, EnvInfo: schema.EnvironmentInfo{WorkingDir: "/projects/evener"}},
+		{ID: "orphan", CreatedAt: now, UpdatedAt: now, ParentSessionID: "parent", IsSubagent: true, EnvInfo: schema.EnvironmentInfo{WorkingDir: "/projects/evener"}},
+	}
+	// Only the subagent is live; the parent is not. The subagent has no live
+	// row to nest under, so it keeps its own top-level Live row rather than
+	// vanishing from the rail.
+	live := []LiveEntry{
+		{PID: 1, SessionID: "orphan", Status: appwire.ThreadStatusActive},
+	}
+
+	tree := BuildTreeAt(metas, live, nil, now)
+
+	if len(tree.Live) != 1 {
+		t.Fatalf("Live tier has %d rows, want 1 (the orphaned subagent)", len(tree.Live))
+	}
+	if tree.Live[0].ID != "orphan" {
+		t.Fatalf("Live[0].ID = %q, want orphan", tree.Live[0].ID)
+	}
+}
+
+func TestBuildTreeLivePrunesNonLiveChildren(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	metas := []schema.SessionMeta{
+		{ID: "parent", CreatedAt: now, UpdatedAt: now, EnvInfo: schema.EnvironmentInfo{WorkingDir: "/projects/evener"}},
+		{ID: "livechild", CreatedAt: now, UpdatedAt: now, ParentSessionID: "parent", IsSubagent: true, EnvInfo: schema.EnvironmentInfo{WorkingDir: "/projects/evener"}},
+		{ID: "deadchild", CreatedAt: now, UpdatedAt: now, ParentSessionID: "parent", IsSubagent: true, EnvInfo: schema.EnvironmentInfo{WorkingDir: "/projects/evener"}},
+	}
+	// Only livechild and the parent are live. deadchild has no live entry and
+	// is not listed in RunningSubagentIDs, so it is neither running nor
+	// resumable — it must be pruned from the Live subtree.
+	live := []LiveEntry{
+		{PID: 1, SessionID: "parent", Status: appwire.ThreadStatusIdle, RunningSubagentIDs: []string{"livechild"}},
+		{PID: 2, SessionID: "livechild", Status: appwire.ThreadStatusActive},
+	}
+
+	tree := BuildTreeAt(metas, live, nil, now)
+
+	if len(tree.Live) != 1 {
+		t.Fatalf("Live tier has %d rows, want 1 (the parent)", len(tree.Live))
+	}
+	parent := tree.Live[0]
+	if len(parent.Children) != 1 {
+		t.Fatalf("parent has %d children, want 1 (only the live subagent)", len(parent.Children))
+	}
+	if parent.Children[0].ID != "livechild" {
+		t.Fatalf("child = %q, want livechild", parent.Children[0].ID)
+	}
+	// deadchild is not live and must not appear anywhere in the Live subtree.
+	for _, child := range parent.Children {
+		if child.ID == "deadchild" {
+			t.Error("non-live subagent deadchild appeared in the Live tier subtree")
+		}
+	}
+}
+
+func TestBuildTreeLiveSubagentStateMatchesProjectRow(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	metas := []schema.SessionMeta{
+		{ID: "parent", CreatedAt: now, UpdatedAt: now, EnvInfo: schema.EnvironmentInfo{WorkingDir: "/projects/evener"}},
+		{ID: "child", CreatedAt: now, UpdatedAt: now, ParentSessionID: "parent", IsSubagent: true, EnvInfo: schema.EnvironmentInfo{WorkingDir: "/projects/evener"}},
+	}
+	live := []LiveEntry{
+		{PID: 1, SessionID: "parent", Status: appwire.ThreadStatusIdle, RunningSubagentIDs: []string{"child"}},
+		{PID: 2, SessionID: "child", Status: appwire.ThreadStatusActive},
+	}
+
+	tree := BuildTreeAt(metas, live, nil, now)
+
+	// The Live-tier subagent child and the Projects-tier subagent child must
+	// report the same state — both come from the same stateFor closure, so
+	// the active color cannot disagree between sections.
+	liveRow, inLive, projectRow, inProject := liveAndProjectRowsFor(tree, "parent")
+	if !inLive || !inProject {
+		t.Fatalf("parent missing: live=%v project=%v", inLive, inProject)
+	}
+	if len(liveRow.Children) != 1 || len(projectRow.Children) != 1 {
+		t.Fatalf("children: live=%d project=%d, want 1 each", len(liveRow.Children), len(projectRow.Children))
+	}
+	liveChild := liveRow.Children[0]
+	projectChild := projectRow.Children[0]
+	if liveChild.State != projectChild.State {
+		t.Errorf("subagent state disagrees: live=%q project=%q", liveChild.State, projectChild.State)
+	}
+	if liveChild.State != "active" {
+		t.Errorf("subagent state = %q, want active", liveChild.State)
+	}
+}

--- a/cmd/evener-hub/internal/hubcore/tree_test.go
+++ b/cmd/evener-hub/internal/hubcore/tree_test.go
@@ -223,9 +223,22 @@ func fuzzScenarioBuildTree_GroupsByProjectWithSubagentsAndForks(t *testing.T) {
 		t.Errorf("01OTHER should have no children, got %d", len(sessions[1].Children))
 	}
 
-	// Live: 2 entries, both active.
-	if len(tree.Live) != 2 {
+	// Live: 1 top-level row (01ACTIVE). 01SUB1 is a live subagent of 01ACTIVE,
+	// so it nests under it in the Live tier — the same foldout structure the
+	// Projects tier uses — rather than appearing as a flat, parentless row.
+	// 01OLDORIG is not live, so it is absent from the Live tier entirely.
+	if len(tree.Live) != 1 {
 		t.Fatalf("live: %d", len(tree.Live))
+	}
+	if tree.Live[0].ID != "01ACTIVE" {
+		t.Fatalf("live[0]: %q, want 01ACTIVE", tree.Live[0].ID)
+	}
+	liveChildren := tree.Live[0].Children
+	if len(liveChildren) != 1 || liveChildren[0].ID != "01SUB1" || liveChildren[0].Kind != "subagent" {
+		t.Fatalf("live[0] children = %#v, want one subagent child 01SUB1", liveChildren)
+	}
+	if liveChildren[0].State != "active" {
+		t.Errorf("live subagent state = %q, want active", liveChildren[0].State)
 	}
 
 	// Rollup state for the project: active (the most-attention live state).

--- a/docs/superpowers/plans/2026-08-29-mobile-welcome-panel.md
+++ b/docs/superpowers/plans/2026-08-29-mobile-welcome-panel.md
@@ -1,0 +1,993 @@
+# Mobile Welcome + Sidebar Unification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unify the mobile welcome screen and the bottom-panel sidebar into a single expandable surface that slides up to full screen, move key bindings to the panel's bottom, and remove example task prompts on both mobile and desktop.
+
+**Architecture:** Add an opt-in `expandable` capability to the shared `Sheet` widget (drag handle + peek/full geometry). Extract welcome content into a reusable `WelcomeContent` component. Build a `MobilePanel` that composes the Sheet with the forwarded rail + welcome content. `StackHost` owns the panel-open state and wires both entry points.
+
+**Tech Stack:** React 19, Zustand, CSS Modules, Vitest + Testing Library, Biome.
+
+**Spec:** `docs/superpowers/specs/2026-08-29-mobile-welcome-panel-design.md`
+
+## Global Constraints
+
+- Panes never ask "am I mobile?" — the mobile panel is a shell-level composition in `src/shell/mobile/`, not a behavior switch inside `Welcome.tsx`.
+- The mobile stream (`src/shell/mobile/**`) must NOT import from `src/shell/rail/**` — they meet only through props wired by the integrator (StackHost forwards `railSlot`).
+- The `Sheet` widget's `expandable` prop defaults to `undefined`; every existing `<Sheet>` and `<Dialog>` consumer stays byte-for-byte identical.
+- `OverlayPanel`'s new `handle`, `bodyClassName`, and `headerClassName` props all default to `undefined`.
+- Frontend gate: `npx biome check --write src/` on touched files, then `make test-web` (and `make test-web-browser` on Chrome-capable hosts).
+- No `noNonNullAssertion` or array-index-key Biome violations.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/widgets/dialog/OverlayPanel.tsx` | Add `handle`, `bodyClassName`, `headerClassName` optional props (all default undefined). |
+| `src/widgets/sheet/index.tsx` | Add `expandable` prop; manage geometry state; pass handle + body/header classes through OverlayPanel. |
+| `src/widgets/sheet/sheet.module.css` | Add `.handle`, `.expandableBottom`, `.expandableHeader`, `.expandableBody` rules. |
+| `src/widgets/sheet/sheet.test.tsx` | Add expandable tests. |
+| `src/panes/welcome/WelcomeContent.tsx` | **New:** presentational welcome content (`showNewSession`, `showHints` props). |
+| `src/panes/welcome/Welcome.tsx` | Thin wrapper over `WelcomeContent`; remove example prompts. |
+| `src/panes/welcome/welcome.module.css` | Remove `.examples*` rules. |
+| `src/panes/welcome/Welcome.test.tsx` | Remove example-prompt test; keep rest. |
+| `src/shell/mobile/MobilePanel.tsx` | **New:** unified panel (Sheet + forwarded `rail` prop + WelcomeContent). Owns auto-close effect. |
+| `src/shell/mobile/MobilePanel.module.css` | **New:** panel layout styles. |
+| `src/shell/mobile/MobilePanel.test.tsx` | **New:** panel state/content tests. |
+| `src/shell/mobile/TreeDrawer.tsx` | Trigger only; receives `onOpen` prop. |
+| `src/shell/mobile/TreeDrawer.test.tsx` | Update: no owned Sheet; assert trigger calls onOpen. |
+| `src/shell/mobile/StackHost.tsx` | Own shared panel-open `useState`; open panel when `nothingFocused` (guarded by `routeDeferred`); forward `railSlot` to MobilePanel; pass `onOpen` to TreeDrawer. |
+| `src/shell/mobile/StackHost.test.tsx` | Update welcome-landing assertions; add routeDeferred flash test. |
+
+---
+
+### Task 1: Add `handle`, `bodyClassName`, `headerClassName` props to OverlayPanel
+
+**Files:**
+- Modify: `src/widgets/dialog/OverlayPanel.tsx`
+- Test: `src/widgets/dialog/OverlayPanel.tsx` (no separate test file — the existing `sheet.test.tsx` and `dialog.test.tsx` exercise OverlayPanel; this task adds no new behavior, only optional passthrough props)
+
+**Interfaces:**
+- Produces: `OverlayPanelProps` gains `handle?: ReactNode`, `bodyClassName?: string`, `headerClassName?: string`. The handle renders before `<header>`. `bodyClassName` and `headerClassName` are appended to the existing `.body` and `.header` classes respectively.
+
+- [ ] **Step 1: Add the props to OverlayPanelProps**
+
+In `src/widgets/dialog/OverlayPanel.tsx`, add three optional props to the interface:
+
+```ts
+export interface OverlayPanelProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+  footer?: ReactNode;
+  panelClassName: string;
+  handle?: ReactNode;
+  bodyClassName?: string;
+  headerClassName?: string;
+}
+```
+
+- [ ] **Step 2: Render the handle before the header and apply body/header classes**
+
+Update the `OverlayPanel` function signature to accept the new props and render them:
+
+```tsx
+export function OverlayPanel({ open, onClose, title, children, footer, panelClassName, handle, bodyClassName, headerClassName }: OverlayPanelProps) {
+```
+
+In the JSX, render `{handle}` before `<header>`, and append the optional classes:
+
+```tsx
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          className={panelClassName}
+          onKeyDown={handleKeyDown}
+        >
+          {handle}
+          <header className={headerClassName ? `${CLASS.header} ${headerClassName}` : CLASS.header}>
+            <h2 id={titleId} className={CLASS.title}>
+              {title}
+            </h2>
+          </header>
+          <div className={bodyClassName ? `${CLASS.body} ${bodyClassName}` : CLASS.body}>{children}</div>
+          {footer !== undefined && <div className={CLASS.footer}>{footer}</div>}
+          <button type="button" className={CLASS.closeButton} onClick={onClose} aria-label="Close">
+            <CloseIcon />
+          </button>
+        </div>
+```
+
+- [ ] **Step 3: Verify existing tests still pass**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/widgets/sheet/sheet.test.tsx src/widgets/dialog/ --maxWorkers=4`
+Expected: PASS (all existing tests — the new props default to undefined, so no existing consumer changes).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/widgets/dialog/OverlayPanel.tsx
+git commit -m "feat: add handle/bodyClassName/headerClassName slots to OverlayPanel"
+```
+
+---
+
+### Task 2: Add `expandable` capability to Sheet
+
+**Files:**
+- Modify: `src/widgets/sheet/index.tsx`
+- Modify: `src/widgets/sheet/sheet.module.css`
+- Test: `src/widgets/sheet/sheet.test.tsx`
+
+**Interfaces:**
+- Consumes: `OverlayPanel`'s `handle`, `bodyClassName`, `headerClassName` props (Task 1).
+- Produces: `SheetProps` gains `expandable?: { peekHeight: number; fullScreenFirst?: boolean }`. When set, the Sheet renders a drag handle, manages a `"peek" | "full"` geometry state, resets to full on every open transition, and passes scoped body/header classes to OverlayPanel.
+
+- [ ] **Step 1: Write failing tests for expandable mode**
+
+Add these tests to `src/widgets/sheet/sheet.test.tsx`:
+
+```tsx
+test("expandable renders a drag handle", () => {
+  render(
+    <Sheet open side="bottom" expandable={{ peekHeight: 200 }} onClose={vi.fn()} title="t">
+      Body
+    </Sheet>,
+  );
+  expect(screen.getByRole("dialog").querySelector("[data-testid='sheet-handle']")).toBeTruthy();
+});
+
+test("non-expandable renders no drag handle", () => {
+  render(
+    <Sheet open side="bottom" onClose={vi.fn()} title="t">
+      Body
+    </Sheet>,
+  );
+  expect(screen.queryByTestId("sheet-handle")).toBeNull();
+});
+
+test("fullScreenFirst starts at full on mount", () => {
+  render(
+    <Sheet open side="bottom" expandable={{ peekHeight: 200, fullScreenFirst: true }} onClose={vi.fn()} title="t">
+      Body
+    </Sheet>,
+  );
+  const panel = screen.getByRole("dialog");
+  expect(panel.getAttribute("data-geometry")).toBe("full");
+});
+
+test("fullScreenFirst resets to full on reopen", async () => {
+  const { rerender } = render(
+    <Sheet open side="bottom" expandable={{ peekHeight: 200, fullScreenFirst: true }} onClose={vi.fn()} title="t">
+      Body
+    </Sheet>,
+  );
+  const panel = screen.getByRole("dialog");
+  // Simulate user dragging to peek
+  fireEvent.pointerDown(screen.getByTestId("sheet-handle"), { clientY: 500 });
+  fireEvent.pointerMove(window, { clientY: 800 });
+  fireEvent.pointerUp(window, { clientY: 800 });
+  expect(panel.getAttribute("data-geometry")).toBe("peek");
+  // Close and reopen
+  rerender(
+    <Sheet open={false} side="bottom" expandable={{ peekHeight: 200, fullScreenFirst: true }} onClose={vi.fn()} title="t">
+      Body
+    </Sheet>,
+  );
+  rerender(
+    <Sheet open side="bottom" expandable={{ peekHeight: 200, fullScreenFirst: true }} onClose={vi.fn()} title="t">
+      Body
+    </Sheet>,
+  );
+  expect(screen.getByRole("dialog").getAttribute("data-geometry")).toBe("full");
+});
+
+test("tap on handle toggles peek to full", () => {
+  render(
+    <Sheet open side="bottom" expandable={{ peekHeight: 200, fullScreenFirst: false }} onClose={vi.fn()} title="t">
+      Body
+    </Sheet>,
+  );
+  const panel = screen.getByRole("dialog");
+  // Starts at peek (fullScreenFirst is false)
+  expect(panel.getAttribute("data-geometry")).toBe("peek");
+  // Tap toggles to full
+  fireEvent.pointerDown(screen.getByTestId("sheet-handle"), { clientY: 100 });
+  fireEvent.pointerUp(window, { clientY: 100 });
+  expect(panel.getAttribute("data-geometry")).toBe("full");
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/widgets/sheet/sheet.test.tsx --maxWorkers=4`
+Expected: FAIL — `expandable` prop and handle not yet implemented.
+
+- [ ] **Step 3: Add CSS rules for handle and expandable classes**
+
+In `src/widgets/sheet/sheet.module.css`, add:
+
+```css
+.handle {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-2) 0 var(--space-1);
+  cursor: grab;
+  touch-action: none;
+}
+
+.handleBar {
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--ink-low);
+}
+
+.expandableBottom {
+  height: 100vh;
+  transition: height var(--motion-duration-overlay) var(--motion-easing-standard);
+}
+
+.expandableHeader {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--surface-inset);
+}
+
+.expandableBody {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .expandableBottom {
+    transition: none;
+  }
+}
+```
+
+- [ ] **Step 4: Implement the expandable capability in Sheet**
+
+Rewrite `src/widgets/sheet/index.tsx`:
+
+```tsx
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import dialogStyles from "../dialog/dialog.module.css";
+import { OverlayPanel } from "../dialog/OverlayPanel";
+import { requireClass } from "../internal/requireClass";
+import styles from "./sheet.module.css";
+
+export type SheetSide = "right" | "bottom" | "left";
+export type SheetSize = "standard" | "wide";
+
+export interface ExpandableConfig {
+  peekHeight: number;
+  fullScreenFirst?: boolean;
+}
+
+export interface SheetProps {
+  side?: SheetSide;
+  size?: SheetSize;
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+  footer?: ReactNode;
+  expandable?: ExpandableConfig;
+}
+
+const BASE_PANEL_CLASS = requireClass(dialogStyles.panel, "dialog.module.css", "panel");
+
+const SIDE_CLASS: Record<SheetSide, string> = {
+  right: `${BASE_PANEL_CLASS} ${requireClass(styles.right, "sheet.module.css", "right")}`,
+  bottom: `${BASE_PANEL_CLASS} ${requireClass(styles.bottom, "sheet.module.css", "bottom")}`,
+  left: `${BASE_PANEL_CLASS} ${requireClass(styles.left, "sheet.module.css", "left")}`,
+};
+
+const SIZE_CLASS: Record<SheetSize, string> = {
+  standard: requireClass(styles.standard, "sheet.module.css", "standard"),
+  wide: requireClass(styles.wide, "sheet.module.css", "wide"),
+};
+
+const HANDLE_CLASS = requireClass(styles.handle, "sheet.module.css", "handle");
+const HANDLE_BAR_CLASS = requireClass(styles.handleBar, "sheet.module.css", "handleBar");
+const EXPANDABLE_BOTTOM_CLASS = requireClass(styles.expandableBottom, "sheet.module.css", "expandableBottom");
+const EXPANDABLE_HEADER_CLASS = requireClass(styles.expandableHeader, "sheet.module.css", "expandableHeader");
+const EXPANDABLE_BODY_CLASS = requireClass(styles.expandableBody, "sheet.module.css", "expandableBody");
+
+function DragHandle({ onPointerDown }: { onPointerDown: (e: React.PointerEvent) => void }) {
+  return (
+    <div className={HANDLE_CLASS} data-testid="sheet-handle" onPointerDown={onPointerDown}>
+      <div className={HANDLE_BAR_CLASS} />
+    </div>
+  );
+}
+
+export function Sheet({ side = "right", size = "standard", open, onClose, title, children, footer, expandable }: SheetProps) {
+  const [geometry, setGeometry] = useState<"peek" | "full">(
+    expandable?.fullScreenFirst ? "full" : "peek",
+  );
+  const dragStartYRef = useRef<number | null>(null);
+  const dragStartGeometryRef = useRef<"peek" | "full">("peek");
+
+  // Reset geometry to full on every open transition (false→true).
+  useEffect(() => {
+    if (open && expandable?.fullScreenFirst) setGeometry("full");
+  }, [open, expandable?.fullScreenFirst]);
+
+  function handlePointerDown(e: React.PointerEvent) {
+    dragStartYRef.current = e.clientY;
+    dragStartGeometryRef.current = geometry;
+  }
+
+  function handlePointerMove(e: PointerEvent) {
+    if (dragStartYRef.current === null) return;
+    const delta = e.clientY - dragStartYRef.current;
+    // Dragging down from full toward peek, or up from peek toward full
+    if (dragStartGeometryRef.current === "full" && delta > 50) setGeometry("peek");
+    else if (dragStartGeometryRef.current === "peek" && delta < -50) setGeometry("full");
+  }
+
+  function handlePointerUp(e: PointerEvent) {
+    if (dragStartYRef.current === null) return;
+    const delta = e.clientY - dragStartYRef.current;
+    const wasDrag = Math.abs(delta) > 10;
+    dragStartYRef.current = null;
+    if (!wasDrag) {
+      // Tap toggles
+      setGeometry((g) => (g === "peek" ? "full" : "peek"));
+    }
+    window.removeEventListener("pointermove", handlePointerMove);
+    window.removeEventListener("pointerup", handlePointerUp);
+  }
+
+  function startDrag(e: React.PointerEvent) {
+    handlePointerDown(e);
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
+  }
+
+  if (!expandable) {
+    return (
+      <OverlayPanel
+        open={open}
+        onClose={onClose}
+        title={title}
+        footer={footer}
+        panelClassName={`${SIDE_CLASS[side]} ${SIZE_CLASS[size]}`}
+      >
+        {children}
+      </OverlayPanel>
+    );
+  }
+
+  const heightStyle: React.CSSProperties = geometry === "full" ? { height: "100vh" } : { height: `${expandable.peekHeight}px` };
+
+  return (
+    <OverlayPanel
+      open={open}
+      onClose={onClose}
+      title={title}
+      footer={footer}
+      handle={<DragHandle onPointerDown={startDrag} />}
+      headerClassName={EXPANDABLE_HEADER_CLASS}
+      bodyClassName={EXPANDABLE_BODY_CLASS}
+      panelClassName={`${SIDE_CLASS[side]} ${EXPANDABLE_BOTTOM_CLASS}`}
+    >
+      <div style={heightStyle} data-geometry={geometry}>
+        {children}
+      </div>
+    </OverlayPanel>
+  );
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/widgets/sheet/sheet.test.tsx --maxWorkers=4`
+Expected: PASS
+
+- [ ] **Step 6: Run biome on touched files**
+
+Run: `cd cmd/evener-hub/frontend && npx biome check --write src/widgets/sheet/index.tsx src/widgets/sheet/sheet.module.css src/widgets/sheet/sheet.test.tsx`
+Expected: no errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/widgets/sheet/index.tsx src/widgets/sheet/sheet.module.css src/widgets/sheet/sheet.test.tsx
+git commit -m "feat: add expandable capability to Sheet widget"
+```
+
+---
+
+### Task 3: Extract WelcomeContent and remove example prompts
+
+**Files:**
+- Create: `src/panes/welcome/WelcomeContent.tsx`
+- Modify: `src/panes/welcome/Welcome.tsx`
+- Modify: `src/panes/welcome/welcome.module.css`
+- Test: `src/panes/welcome/Welcome.test.tsx`
+
+**Interfaces:**
+- Produces: `WelcomeContent` component with props `{ note?: string; showNewSession?: boolean; showHints?: boolean }`. Renders "Jump back in" (resume candidate), "New session" (when `showNewSession`), orientation text, chord hints (when `showHints`). No example prompts.
+
+- [ ] **Step 1: Write failing test for WelcomeContent absence of example prompts**
+
+Add to `src/panes/welcome/Welcome.test.tsx` (or create `WelcomeContent.test.tsx`):
+
+```tsx
+import { WelcomeContent } from "./WelcomeContent";
+
+test("WelcomeContent does not render example prompts", () => {
+  render(<WelcomeContent />);
+  expect(screen.queryByRole("button", { name: /Find and fix the root cause/i })).toBeNull();
+  expect(screen.queryByText("Try a task to get started")).toBeNull();
+});
+
+test("WelcomeContent renders New session only when showNewSession is true", () => {
+  const { rerender } = render(<WelcomeContent />);
+  expect(screen.queryByRole("button", { name: "New session" })).toBeNull();
+  rerender(<WelcomeContent showNewSession />);
+  expect(screen.getByRole("button", { name: "New session" })).toBeTruthy();
+});
+
+test("WelcomeContent renders chord hints only when showHints is true", () => {
+  const { rerender } = render(<WelcomeContent />);
+  expect(screen.queryByText("command palette")).toBeNull();
+  rerender(<WelcomeContent showHints />);
+  expect(screen.getByText("command palette")).toBeTruthy();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/panes/welcome/ --maxWorkers=4`
+Expected: FAIL — `WelcomeContent` not yet created.
+
+- [ ] **Step 3: Create WelcomeContent.tsx**
+
+Create `src/panes/welcome/WelcomeContent.tsx`:
+
+```tsx
+import { navigate, paneToURL } from "../../shell/routing";
+import { selectLiveRows, selectNeedsYouRows } from "../../stores/navigation/selectors";
+import { type NavigationStoreState, useNavigationStore } from "../../stores/navigation/store";
+import { Button, KeyHint } from "../../widgets";
+import { requireClass } from "../../widgets/internal/requireClass";
+import styles from "./welcome.module.css";
+
+const CLASS = {
+  actions: requireClass(styles.actions, "welcome.module.css", "actions"),
+  hints: requireClass(styles.hints, "welcome.module.css", "hints"),
+  hintRow: requireClass(styles.hintRow, "welcome.module.css", "hintRow"),
+  hintFooter: requireClass(styles.hintFooter, "welcome.module.css", "hintFooter"),
+};
+
+const CHORD_HINTS: { keys: string[]; desc: string }[] = [
+  { keys: ["Mod", "K"], desc: "command palette" },
+  { keys: ["Mod", "I"], desc: "focus the composer" },
+  { keys: ["Mod", "J"], desc: "next session needing you" },
+];
+
+export interface WelcomeContentProps {
+  note?: string;
+  showNewSession?: boolean;
+  showHints?: boolean;
+}
+
+function goToNewSession(): void {
+  const url = paneToURL("spawn", {});
+  if (url) navigate(url);
+}
+
+function goToSession(ref: string): void {
+  const url = paneToURL("session", { ref });
+  if (url) navigate(url);
+}
+
+function resumeCandidate(navigation: NavigationStoreState) {
+  return selectNeedsYouRows(navigation)[0] ?? selectLiveRows(navigation)[0];
+}
+
+export function WelcomeContent({ note, showNewSession, showHints }: WelcomeContentProps) {
+  const navigation = useNavigationStore();
+  const candidate = resumeCandidate(navigation);
+
+  return (
+    <div className={CLASS.actions}>
+      {note && <p>{note}</p>}
+      {candidate !== undefined && (
+        <Button variant="primary" onClick={() => goToSession(candidate.ref)}>
+          Jump back in: {candidate.title}
+        </Button>
+      )}
+      {showNewSession && (
+        <Button variant="secondary" onClick={goToNewSession}>
+          New session
+        </Button>
+      )}
+      <p className={styles.orientation}>
+        A session can read and edit the repository, run commands, and delegate work to helpers.
+      </p>
+      {showHints && (
+        <div className={CLASS.hints}>
+          {CHORD_HINTS.map((hint) => (
+            <div className={CLASS.hintRow} key={hint.desc}>
+              <KeyHint keys={hint.keys} />
+              <span>{hint.desc}</span>
+            </div>
+          ))}
+          <p className={CLASS.hintFooter}>
+            <KeyHint keys={["?"]} /> inside the command palette shows all shortcuts.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Simplify Welcome.tsx to a thin wrapper**
+
+Rewrite `src/panes/welcome/Welcome.tsx`:
+
+```tsx
+import type { PaneProps } from "../../shell/paneRegistry";
+import { EmptyState, PaneScaffold } from "../../widgets";
+import { WelcomeContent } from "./WelcomeContent";
+
+export interface WelcomePaneParams {
+  note?: string;
+}
+
+export default function Welcome({ params }: PaneProps<WelcomePaneParams>) {
+  return (
+    <PaneScaffold title="Welcome">
+      <EmptyState
+        title="No session open"
+        hint={params.note}
+        action={<WelcomeContent note={params.note} showNewSession showHints />}
+      />
+    </PaneScaffold>
+  );
+}
+```
+
+- [ ] **Step 5: Remove .examples CSS rules from welcome.module.css**
+
+In `src/panes/welcome/welcome.module.css`, delete the `.examples`, `.examplesLabel`, and `.examples button` rules (and their `@media` block if any). Keep `.actions`, `.orientation`, `.hints`, `.hintRow`, `.hintFooter`.
+
+- [ ] **Step 6: Remove the example-prompt test and goToExample test from Welcome.test.tsx**
+
+Delete the test `"offers concrete example tasks that activate the real Spawn prefill"`. Keep all other tests (chord hints, orientation, Jump back in, New session, note hint).
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/panes/welcome/ --maxWorkers=4`
+Expected: PASS
+
+- [ ] **Step 8: Run biome on touched files**
+
+Run: `cd cmd/evener-hub/frontend && npx biome check --write src/panes/welcome/WelcomeContent.tsx src/panes/welcome/Welcome.tsx src/panes/welcome/welcome.module.css src/panes/welcome/Welcome.test.tsx`
+Expected: no errors
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/panes/welcome/WelcomeContent.tsx src/panes/welcome/Welcome.tsx src/panes/welcome/welcome.module.css src/panes/welcome/Welcome.test.tsx
+git commit -m "feat: extract WelcomeContent, remove example prompts"
+```
+
+---
+
+### Task 4: Build MobilePanel
+
+**Files:**
+- Create: `src/shell/mobile/MobilePanel.tsx`
+- Create: `src/shell/mobile/MobilePanel.module.css`
+- Test: `src/shell/mobile/MobilePanel.test.tsx`
+
+**Interfaces:**
+- Consumes: `Sheet` with `expandable` (Task 2), `WelcomeContent` (Task 3), `useWorkspaceStore`, `useNavigationStore`.
+- Produces: `MobilePanel` component with props `{ rail: ReactNode; open: boolean; onClose: () => void }`. Renders the Sheet with rail content + welcome content (when `nothingFocused`). Owns the auto-close effect (calls `onClose` when `focusedPaneId` changes while open).
+
+- [ ] **Step 1: Write failing tests for MobilePanel**
+
+Create `src/shell/mobile/MobilePanel.test.tsx`:
+
+```tsx
+import { type ReactNode, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { resetWorkspaceStoreForTests, workspaceStore } from "../workspace";
+import { MobilePanel } from "./MobilePanel";
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  resetWorkspaceStoreForTests();
+});
+
+function RailFixture() {
+  return <div data-testid="rail-fixture">Rail</div>;
+}
+
+test("renders rail content when open", () => {
+  render(<MobilePanel rail={<RailFixture />} open onClose={vi.fn()} />);
+  expect(screen.getByTestId("rail-fixture")).toBeTruthy();
+});
+
+test("renders welcome content when nothing is focused", () => {
+  // Nothing focused → backstop opens welcome
+  workspaceStore.getState().openPane("welcome");
+  render(<MobilePanel rail={<RailFixture />} open onClose={vi.fn()} />);
+  expect(screen.getByText(/read and edit the repository/i)).toBeTruthy();
+});
+
+test("hides welcome content when a session is focused", () => {
+  workspaceStore.getState().openPane("doc", { ref: "ref_a" });
+  render(<MobilePanel rail={<RailFixture />} open onClose={vi.fn()} />);
+  expect(screen.queryByText(/read and edit the repository/i)).toBeNull();
+  expect(screen.getByTestId("rail-fixture")).toBeTruthy();
+});
+
+test("calls onClose when focusedPaneId changes while open", () => {
+  workspaceStore.getState().openPane("doc", { ref: "ref_a" });
+  const onClose = vi.fn();
+  render(<MobilePanel rail={<RailFixture />} open onClose={onClose} />);
+  expect(onClose).not.toHaveBeenCalled();
+  workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  expect(onClose).toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/shell/mobile/MobilePanel.test.tsx --maxWorkers=4`
+Expected: FAIL — `MobilePanel` not yet created.
+
+- [ ] **Step 3: Create MobilePanel.tsx**
+
+Create `src/shell/mobile/MobilePanel.tsx`:
+
+```tsx
+import { type ReactNode, useEffect, useRef } from "react";
+import { WelcomeContent } from "../../panes/welcome/WelcomeContent";
+import { Sheet } from "../../widgets";
+import { useWorkspaceStore } from "../workspace";
+
+const PEEK_HEIGHT = 360;
+
+export interface MobilePanelProps {
+  rail: ReactNode;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function MobilePanel({ rail, open, onClose }: MobilePanelProps) {
+  const focusedPaneId = useWorkspaceStore((s) => s.focusedPaneId);
+  const panes = useWorkspaceStore((s) => s.panes);
+  const focusedPane = panes.find((p) => p.id === focusedPaneId) ?? null;
+  const nothingFocused = focusedPaneId === null || focusedPane?.type === "welcome";
+
+  const prevFocusedIdRef = useRef(focusedPaneId);
+
+  // Auto-close on navigation: when focusedPaneId changes while the panel
+  // is open, close it (same pattern as TreeDrawer's old effect).
+  useEffect(() => {
+    if (open && prevFocusedIdRef.current !== focusedPaneId) onClose();
+    prevFocusedIdRef.current = focusedPaneId;
+  }, [focusedPaneId, open, onClose]);
+
+  return (
+    <Sheet
+      side="bottom"
+      open={open}
+      onClose={onClose}
+      title="Sessions"
+      expandable={{ peekHeight: PEEK_HEIGHT, fullScreenFirst: true }}
+    >
+      {rail}
+      {nothingFocused && <WelcomeContent showHints />}
+    </Sheet>
+  );
+}
+```
+
+- [ ] **Step 4: Create MobilePanel.module.css**
+
+Create `src/shell/mobile/MobilePanel.module.css`:
+
+```css
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/shell/mobile/MobilePanel.test.tsx --maxWorkers=4`
+Expected: PASS
+
+- [ ] **Step 6: Run biome on touched files**
+
+Run: `cd cmd/evener-hub/frontend && npx biome check --write src/shell/mobile/MobilePanel.tsx src/shell/mobile/MobilePanel.module.css src/shell/mobile/MobilePanel.test.tsx`
+Expected: no errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/shell/mobile/MobilePanel.tsx src/shell/mobile/MobilePanel.module.css src/shell/mobile/MobilePanel.test.tsx
+git commit -m "feat: add MobilePanel unified mobile panel"
+```
+
+---
+
+### Task 5: Convert TreeDrawer to trigger-only
+
+**Files:**
+- Modify: `src/shell/mobile/TreeDrawer.tsx`
+- Test: `src/shell/mobile/TreeDrawer.test.tsx`
+
+**Interfaces:**
+- Consumes: `onOpen` callback prop (from StackHost).
+- Produces: `TreeDrawer` renders only the trigger button + badge; calls `onOpen` on click. No longer owns a `Sheet`.
+
+- [ ] **Step 1: Write failing test for trigger-only TreeDrawer**
+
+Add to `src/shell/mobile/TreeDrawer.test.tsx`:
+
+```tsx
+test("trigger calls onOpen instead of opening a Sheet", async () => {
+  const onOpen = vi.fn();
+  const user = userEvent.setup();
+  render(<TreeDrawer onOpen={onOpen} />);
+  await user.click(screen.getByRole("button", { name: "Sessions" }));
+  expect(onOpen).toHaveBeenCalled();
+  // No dialog (Sheet) should be rendered by TreeDrawer anymore
+  expect(screen.queryByRole("dialog")).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run tests to verify it fails**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/shell/mobile/TreeDrawer.test.tsx --maxWorkers=4`
+Expected: FAIL — TreeDrawer still owns a Sheet.
+
+- [ ] **Step 3: Rewrite TreeDrawer as trigger-only**
+
+Rewrite `src/shell/mobile/TreeDrawer.tsx`:
+
+```tsx
+import { useMemo } from "react";
+import { selectNeedsYouCount } from "../../stores/navigation/selectors";
+import { useNavigationStore } from "../../stores/navigation/store";
+import { Badge, IconButton } from "../../widgets";
+import styles from "./treedrawer.module.css";
+
+function SessionsIcon() {
+  return (
+    <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
+      <path d="M2 4 H14 M2 8 H14 M2 12 H14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" fill="none" />
+    </svg>
+  );
+}
+
+export interface TreeDrawerProps {
+  onOpen: () => void;
+}
+
+export function TreeDrawer({ onOpen }: TreeDrawerProps) {
+  const navigation = useNavigationStore();
+  const needsYou = useMemo(() => selectNeedsYouCount(navigation), [navigation]);
+
+  return (
+    <span className={styles.triggerWrap}>
+      <IconButton label="Sessions" icon={<SessionsIcon />} variant="quiet" onClick={onOpen} />
+      {needsYou > 0 && (
+        <span className={styles.badgeOverlay}>
+          <Badge count={needsYou} tone="attention" />
+        </span>
+      )}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 4: Update existing TreeDrawer tests**
+
+In `src/shell/mobile/TreeDrawer.test.tsx`, update tests that render `<TreeDrawer>` to pass `onOpen={vi.fn()}`. Remove tests that assert Sheet behavior (open/close, auto-close, placeholder). Keep the badge tests.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/shell/mobile/TreeDrawer.test.tsx --maxWorkers=4`
+Expected: PASS
+
+- [ ] **Step 6: Run biome on touched files**
+
+Run: `cd cmd/evener-hub/frontend && npx biome check --write src/shell/mobile/TreeDrawer.tsx src/shell/mobile/TreeDrawer.test.tsx`
+Expected: no errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/shell/mobile/TreeDrawer.tsx src/shell/mobile/TreeDrawer.test.tsx
+git commit -m "refactor: convert TreeDrawer to trigger-only"
+```
+
+---
+
+### Task 6: Wire StackHost to own panel-open state and render MobilePanel
+
+**Files:**
+- Modify: `src/shell/mobile/StackHost.tsx`
+- Test: `src/shell/mobile/StackHost.test.tsx`
+
+**Interfaces:**
+- Consumes: `MobilePanel` (Task 4), `TreeDrawer` with `onOpen` (Task 5).
+- Produces: StackHost owns `useState<boolean>` for panel-open; opens panel when `nothingFocused` (guarded by `routeDeferred`); passes `railSlot` to MobilePanel as `rail`; passes `onOpen` to TreeDrawer; passes `open`/`onClose` to MobilePanel.
+
+- [ ] **Step 1: Write failing test for panel opening on nothingFocused**
+
+Add to `src/shell/mobile/StackHost.test.tsx`:
+
+```tsx
+test("opens the mobile panel when nothing is focused", async () => {
+  render(<StackHost />);
+  // Welcome pane mounts behind the panel; the panel opens over it
+  await screen.findByText("No session open");
+  // The panel's Sheet title "Sessions" should be visible
+  expect(screen.getByRole("dialog", { name: "Sessions" })).toBeTruthy();
+});
+
+test("does not flash the panel during routeDeferred", async () => {
+  render(<StackHost routeDeferred />);
+  // Wait for welcome to appear
+  await screen.findByText("No session open");
+  // Panel should NOT be open while routeDeferred
+  expect(screen.queryByRole("dialog", { name: "Sessions" })).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/shell/mobile/StackHost.test.tsx --maxWorkers=4`
+Expected: FAIL — StackHost doesn't render MobilePanel yet.
+
+- [ ] **Step 3: Wire StackHost to own panel-open state and render MobilePanel**
+
+In `src/shell/mobile/StackHost.tsx`:
+
+1. Add `useState` import (already imported from React).
+2. Add import: `import { MobilePanel } from "./MobilePanel";`
+3. In the `StackHost` function, add panel-open state:
+   ```tsx
+   const [panelOpen, setPanelOpen] = useState(false);
+   ```
+4. Compute `nothingFocused`:
+   ```tsx
+   const nothingFocused = focusedPaneId === null || focusedPane?.type === "welcome";
+   ```
+5. Add the nothingFocused-open effect (after the existing backstop effect):
+   ```tsx
+   useEffect(() => {
+     if (routeDeferred) return;
+     if (nothingFocused) setPanelOpen(true);
+   }, [nothingFocused, routeDeferred]);
+   ```
+6. Replace `<TreeDrawer>{railSlot}</TreeDrawer>` in the topBar with:
+   ```tsx
+   <TreeDrawer onOpen={() => setPanelOpen(true)} />
+   ```
+7. After the `<div className={styles.body}>...</div>` block (but inside the host div), add:
+   ```tsx
+   <MobilePanel rail={railSlot} open={panelOpen} onClose={() => setPanelOpen(false)} />
+   ```
+
+- [ ] **Step 4: Update existing StackHost tests**
+
+In `src/shell/mobile/StackHost.test.tsx`, update tests that assert the welcome pane is the visible surface — now the panel opens over it. The "falls back to opening welcome" test should still find "No session open" (the welcome pane renders behind the panel). Tests that interact with TreeDrawer's Sheet need updating to use the panel instead.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/shell/mobile/StackHost.test.tsx --maxWorkers=4`
+Expected: PASS
+
+- [ ] **Step 6: Run biome on touched files**
+
+Run: `cd cmd/evener-hub/frontend && npx biome check --write src/shell/mobile/StackHost.tsx src/shell/mobile/StackHost.test.tsx`
+Expected: no errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/shell/mobile/StackHost.tsx src/shell/mobile/StackHost.test.tsx
+git commit -m "feat: wire StackHost to own panel-open state and render MobilePanel"
+```
+
+---
+
+### Task 7: Run full frontend gate and fix any regressions
+
+**Files:**
+- All touched files from Tasks 1-6.
+
+- [ ] **Step 1: Run biome across all touched files**
+
+Run: `cd cmd/evener-hub/frontend && npx biome check --write src/widgets/sheet/ src/widgets/dialog/OverlayPanel.tsx src/panes/welcome/ src/shell/mobile/`
+Expected: no errors
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `cd cmd/evener-hub/frontend && npx tsc --noEmit --incremental false`
+Expected: no errors
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cd cmd/evener-hub/frontend && make test-web`
+Expected: PASS
+
+- [ ] **Step 4: Run layoutguard**
+
+Run: `cd cmd/evener-hub/frontend && npm run layoutguard`
+Expected: PASS — the expandable panel at peek and full must not overflow the viewport.
+
+- [ ] **Step 5: Run overflowguard**
+
+Run: `cd cmd/evener-hub/frontend && npm run overflowguard`
+Expected: PASS — welcome content in the panel must not overflow at 390px.
+
+- [ ] **Step 6: Fix any failures**
+
+Address any test failures, type errors, or guard violations. Root-cause each failure; do not weaken assertions.
+
+- [ ] **Step 7: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix: resolve frontend gate regressions from mobile panel unification"
+```
+
+- [ ] **Step 8: Run the full gate once more**
+
+Run: `cd cmd/evener-hub/frontend && make test-web`
+Expected: PASS
+
+---
+
+### Task 8: Update existing tests that depend on TreeDrawer's old Sheet behavior
+
+**Files:**
+- Test: `src/shell/mobile/StackHost.test.tsx`
+- Test: `src/shell/mobile/TreeDrawer.test.tsx`
+- Test: `src/shell/App.test.tsx` (if it references TreeDrawer's Sheet)
+
+- [ ] **Step 1: Search for tests that reference TreeDrawer's Sheet**
+
+Run: `cd cmd/evener-hub/frontend && rg -n "TreeDrawer|tree.drawer|tree-drawer" src/ -g '*.test.*'`
+Review each hit: any test that asserts TreeDrawer opens a Sheet, auto-closes, or renders a placeholder must be updated to test MobilePanel instead.
+
+- [ ] **Step 2: Fix each test**
+
+Update each test to reflect the new architecture: TreeDrawer is a trigger, MobilePanel owns the Sheet. Tests that asserted auto-close-on-navigation should assert MobilePanel's `onClose` behavior instead.
+
+- [ ] **Step 3: Run all mobile tests**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/shell/mobile/ --maxWorkers=4`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/shell/mobile/StackHost.test.tsx src/shell/mobile/TreeDrawer.test.tsx
+git commit -m "test: update tests for TreeDrawer trigger-only and MobilePanel"
+```

--- a/docs/superpowers/specs/2026-08-29-mobile-welcome-panel-design.md
+++ b/docs/superpowers/specs/2026-08-29-mobile-welcome-panel-design.md
@@ -119,6 +119,16 @@ interface SheetProps {
   (MobilePanel) stays mounted and the geometry state persisted from a prior
   peek. Without this, reopening after collapsing to peek would show peek,
   violating "full screen first."
+
+  **Known edge case (accepted):** when the panel is open at peek over a
+  session and focus transitions to welcome (session→welcome), the auto-close
+  effect (child) and the nothingFocused-open effect (parent) batch in the same
+  commit — `open` never goes false→true in a rendered frame, so the
+  geometry-reset effect does not fire, and the panel stays at peek instead of
+  resetting to full. This is a narrow case (panel open at peek + session
+  closes under you) and the panel is still usable at peek; a follow-up could
+  key the geometry reset on `nothingFocused` too, but that couples the Sheet
+  to focus state it should not know about. Accepted for now.
 - **Drag:** pointer/touch drag on the handle transitions the panel height
   continuously between `peekHeight` and `100vh`. Release snaps to the nearer
   bound (with a small hysteresis band; >50% of the way to the other bound


### PR DESCRIPTION
## Problem

The sidebar's Live section showed sessions differently from every other section (Projects, Test runs, Pinned): subagents appeared as flat, parentless top-level rows instead of nesting under their parent with a foldout, and their active state didn't color the row the way it does in other sections.

## Root cause

`hubcore/tree.go`'s Live tier built flat `TreeNode` values directly in a loop, never calling `buildNode` — so no subagent children attached. Every other section uses `buildNode`, which recursively nests subagent children with their proper state.

## Fix

1. **Live tier now uses `buildNode`** (the same path the Projects tier uses) so subagent children nest under their live parent with the same foldout structure.

2. **`pruneLiveSubtree`** removes non-live descendants after building, since `buildNode` attaches ALL children (including dead subagents and fork snapshots). The Live tier contains only live sessions.

3. **`liveParentOrForkContinuation`** keeps an orphaned live subagent (whose parent is NOT live) as its own top-level row, so it doesn't vanish from the rail.

Because the frontend uses the same `sessionNodes`/`splitChildren`/`RailRow` path for all sections, active subagents now render with the working color in the Live section too — the same color they already used in Projects, Test runs, and Pinned sections. No frontend changes were needed.

## Testing

- All Go tests pass: `cmd/evener-hub/internal/hubcore`, `cmd/evener-hub`, `hubapi`, `server`, `appwire`, `agent`
- All 289 frontend rail tests pass
- `go vet` clean
- 6 new regression tests pin the Live-tier subagent nesting + active state behavior