### PR TITLE
fix(devtooling): scale FIFO read tripwire with the test deadline (#173)

### DIFF
--- a/agent/deadline_audit_test.go
+++ b/agent/deadline_audit_test.go
@@ -43,7 +43,7 @@ import (
 // real defect (kata ww3g bucket 3) instead of hacking around it here.
 //
 // Naming the bound -- a package- or file-level constant/variable with its own
-// doc comment, e.g. fifoReadTripwire in cmd/evener-test-dev-tooling/wave_test.go
+// doc comment, e.g. fifoReadTripwireFor in cmd/evener-test-dev-tooling/wave_test.go
 // -- also clears the audit: there is no bare literal left at the call site
 // once the duration is a named identifier. That is not a second sanctioned
 // mechanism, it is simply outside what "bare" means; the audit never inspects

--- a/cmd/evener-test-dev-tooling/wave_test.go
+++ b/cmd/evener-test-dev-tooling/wave_test.go
@@ -251,12 +251,6 @@ func mkFixtureFifos(t *testing.T, names ...string) string {
 	return dir
 }
 
-// fifoReadTripwire bounds a FIFO read that should complete in milliseconds. It
-// is a tripwire, never the synchronisation mechanism: the wave's exit is what
-// actually tells us a writer is never coming (see readFifoLineOrExit). Generous
-// on purpose, so a loaded machine never trips it before the real signal lands.
-const fifoReadTripwire = 60 * time.Second
-
 // postExitGrace is the minimum grace for descendants that outlived the wave.
 // An orphan already past its TERM trap writes within milliseconds, so this
 // only elapses when no writer exists at all. It is also the whole grace for a
@@ -290,6 +284,18 @@ func graceFor(deadline, now time.Time) time.Duration {
 	return min(max(deadline.Sub(now)-deadlineReportReserve, postExitGrace), postExitGraceMax)
 }
 
+// fifoReadTripwireFor scales the FIFO read tripwire from the same deadline
+// arithmetic graceFor uses (#173): a TERMed suite legitimately gets graceFor of
+// KillGrace before its group is KILLed, and a writer that outlives the wave
+// gets up to postExitGraceMax more after its exit, so the tripwire sits a full
+// post-exit ceiling beyond the grace the deadline still grants. The flat 60s
+// constant it replaces sat exactly on top of both ceilings and raced them
+// under load. graceFor's own postExitGrace floor keeps the no-deadline case at
+// 65s, the same generosity the old constant carried.
+func fifoReadTripwireFor(deadline, now time.Time) time.Duration {
+	return graceFor(deadline, now) + postExitGraceMax
+}
+
 // waveRun is a running wave whose exit any number of waiters can observe.
 // A plain exit-code channel could be received only once, which is why the FIFO
 // reads could not consult it and blocked forever instead.
@@ -314,17 +320,19 @@ func (w *waveRun) wait() int {
 // that is reported immediately with the exit code rather than as a timeout.
 //
 // deadline is the caller's own test deadline (t.Deadline(), zero if it has
-// none); graceFor turns it into how long the post-exit wait may run.
+// none); graceFor turns it into how long the post-exit wait may run, and
+// fifoReadTripwireFor into how long the still-running wait may run.
 //
 // The goroutine may outlive this call, blocked in open() on a FIFO nobody will
 // ever write to. That is deliberate: it holds only a file descriptor, the test
 // binary is about to exit, and the alternative (a non-blocking open plus a
 // readiness poll) would reintroduce polling where an awaitable event exists.
-func readFifoLineOrExit(path string, run *waveRun, tripwire time.Duration, deadline time.Time) (string, error) {
+func readFifoLineOrExit(path string, run *waveRun, deadline time.Time) (string, error) {
 	type result struct {
 		line string
 		err  error
 	}
+	tripwire := fifoReadTripwireFor(deadline, time.Now())
 	lines := make(chan result, 1)
 	go func() {
 		f, err := os.Open(path)
@@ -370,7 +378,7 @@ func readFifoLineOrExit(path string, run *waveRun, tripwire time.Duration, deadl
 func readFifoLine(t *testing.T, path string, run *waveRun) string {
 	t.Helper()
 	deadline, _ := t.Deadline()
-	line, err := readFifoLineOrExit(path, run, fifoReadTripwire, deadline)
+	line, err := readFifoLineOrExit(path, run, deadline)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -580,7 +588,7 @@ func TestReadFifoLineFailsWhenWaveExitsWithoutWriting(t *testing.T) {
 	close(dead.done) // the wave is already over; nobody will ever open for write
 
 	start := time.Now()
-	_, err := readFifoLineOrExit(filepath.Join(fx, "never-written"), dead, time.Minute, time.Time{})
+	_, err := readFifoLineOrExit(filepath.Join(fx, "never-written"), dead, time.Time{})
 	elapsed := time.Since(start)
 
 	if err == nil {
@@ -620,7 +628,7 @@ func TestReadFifoLineWaitsForWriterThatOutlivesTheWave(t *testing.T) {
 		_, _ = f.WriteString("late-descendant\n")
 	}()
 
-	line, err := readFifoLineOrExit(path, dead, time.Minute, time.Time{})
+	line, err := readFifoLineOrExit(path, dead, time.Time{})
 	if err != nil {
 		t.Fatalf("read failed on a writer that outlived the wave: %v", err)
 	}
@@ -655,6 +663,45 @@ func TestGraceFor(t *testing.T) {
 	}
 }
 
+// TestFifoReadTripwireOutlivesTheGraceWindow pins the #173 fix: the FIFO read
+// tripwire must be derived from the same deadline arithmetic that sizes the
+// post-exit grace and the wave's KillGrace (graceFor), so it can never fire
+// inside a window the grace logic still considers live. A wave whose suite was
+// TERMed right now can legitimately still deliver a writer up to a full grace
+// later (KillGrace while running, plus up to postExitGraceMax after the wave
+// exits); a tripwire that expires inside that span reports "no line ... and the
+// wave is still running" while the wave is behaving exactly as configured.
+//
+// This is the strongest deterministic pin available: the race it guards is
+// load-sensitivity in which select case wins, so it is pinned structurally
+// (tripwire > graceFor + postExitGraceMax for every deadline) rather than by
+// reproducing the timing, per docs/developing-evener/testing.md's no-sleeps rule.
+func TestFifoReadTripwireOutlivesTheGraceWindow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	for _, deadline := range []time.Time{
+		{},                        // no deadline (`go test` without -timeout)
+		now,                       // already expired
+		now.Add(time.Second),      // inside the report reserve
+		now.Add(30 * time.Second), // between floor and ceiling
+		now.Add(deadlineReportReserve + 30*time.Second),
+		now.Add(deadlineReportReserve + 9*time.Minute), // capped grace
+		now.Add(10 * time.Minute),                      // the 10m package gate
+	} {
+		grace := graceFor(deadline, now)
+		tripwire := fifoReadTripwireFor(deadline, now)
+		// A TERMed suite gets KillGrace = graceFor to exit before KILL, and a
+		// writer that outlives the wave gets up to postExitGraceMax more after
+		// its exit. The tripwire must sit beyond that whole live window.
+		liveWindow := grace + postExitGraceMax
+		if tripwire < liveWindow {
+			t.Errorf("deadline %v from now: tripwire %v expires inside the live grace window (grace %v + post-exit max %v = %v)",
+				deadline.Sub(now), tripwire, grace, postExitGraceMax, liveWindow)
+		}
+	}
+}
+
 // TestReadFifoLineGraceFollowsTheTestDeadline is the wiring half: TestGraceFor
 // proves the arithmetic, and this proves readFifoLineOrExit actually waits the
 // duration that arithmetic returns rather than the floor it used to.
@@ -673,7 +720,7 @@ func TestReadFifoLineGraceFollowsTheTestDeadline(t *testing.T) {
 
 	grace := postExitGrace + 2*time.Second
 	start := time.Now()
-	_, err := readFifoLineOrExit(filepath.Join(fx, "never-written"), dead, time.Minute,
+	_, err := readFifoLineOrExit(filepath.Join(fx, "never-written"), dead,
 		start.Add(deadlineReportReserve+grace))
 	elapsed := time.Since(start)
 

--- a/cmd/evener-test-dev-tooling/wave_test.go
+++ b/cmd/evener-test-dev-tooling/wave_test.go
@@ -285,15 +285,35 @@ func graceFor(deadline, now time.Time) time.Duration {
 }
 
 // fifoReadTripwireFor scales the FIFO read tripwire from the same deadline
-// arithmetic graceFor uses (#173): a TERMed suite legitimately gets graceFor of
-// KillGrace before its group is KILLed, and a writer that outlives the wave
-// gets up to postExitGraceMax more after its exit, so the tripwire sits a full
-// post-exit ceiling beyond the grace the deadline still grants. The flat 60s
-// constant it replaces sat exactly on top of both ceilings and raced them
-// under load. graceFor's own postExitGrace floor keeps the no-deadline case at
-// 65s, the same generosity the old constant carried.
+// arithmetic graceFor uses (#173). While the wave is still running it grants
+// TWO sequential KillGrace windows — the watcher's TERM-then-KILL escalation,
+// then the survivor sweep's own KillGrace for descendants still finishing
+// their TERM traps (see runSuite) — and waveKillGrace sizes KillGrace with
+// graceFor, so a writer can legitimately still arrive 2×graceFor after TERM.
+// A writer that outlives the wave gets up to postExitGraceMax more after its
+// exit, which is padding on top of the window the tripwire actually races.
+//
+// The flat 60s constant this replaces sat exactly on top of the capped
+// still-running window (120s) and raced it under load; counting only one
+// KillGrace (the first fix) sat exactly on top of it again.
+//
+// Two deliberate tradeoffs:
+//   - Wedge-diagnosis latency roughly triples at the cap (180s vs the old
+//     flat 60s), because the wave legitimately gets both windows. A read that
+//     should complete in milliseconds still does; only a genuinely wedged
+//     wave ever pays the ceiling.
+//   - deadlineReportReserve is respected by shaving only the post-exit
+//     padding, never the still-running window: a tripwire inside THAT window
+//     is the #173 race reborn. When the deadline cannot afford both, the
+//     still-running window wins and the runner's own deadline backstops.
 func fifoReadTripwireFor(deadline, now time.Time) time.Duration {
-	return graceFor(deadline, now) + postExitGraceMax
+	runningWindow := 2 * graceFor(deadline, now)
+	liveWindow := runningWindow + postExitGraceMax
+	if deadline.IsZero() {
+		return liveWindow
+	}
+	budget := deadline.Sub(now) - deadlineReportReserve
+	return max(min(liveWindow, budget), runningWindow)
 }
 
 // waveRun is a running wave whose exit any number of waiters can observe.
@@ -597,8 +617,9 @@ func TestReadFifoLineFailsWhenWaveExitsWithoutWriting(t *testing.T) {
 	if !strings.Contains(err.Error(), "7") {
 		t.Errorf("error should name the wave's exit code so the failure is diagnosable, got: %v", err)
 	}
-	// The tripwire is a minute; returning anywhere near it means the wave-exit
-	// path is not wired and we fell through to the ceiling instead.
+	// The tripwire is minutes (see fifoReadTripwireFor); returning anywhere
+	// near it means the wave-exit path is not wired and we fell through to
+	// the ceiling instead.
 	if elapsed > 10*time.Second {
 		t.Errorf("took %v: fell through to the tripwire instead of noticing the wave had exited", elapsed)
 	}
@@ -666,16 +687,29 @@ func TestGraceFor(t *testing.T) {
 // TestFifoReadTripwireOutlivesTheGraceWindow pins the #173 fix: the FIFO read
 // tripwire must be derived from the same deadline arithmetic that sizes the
 // post-exit grace and the wave's KillGrace (graceFor), so it can never fire
-// inside a window the grace logic still considers live. A wave whose suite was
-// TERMed right now can legitimately still deliver a writer up to a full grace
-// later (KillGrace while running, plus up to postExitGraceMax after the wave
-// exits); a tripwire that expires inside that span reports "no line ... and the
-// wave is still running" while the wave is behaving exactly as configured.
+// inside a window the grace logic still considers live. The live window is
+// counted from runSuite's actual TERM-then-KILL escalation, not from the
+// tripwire's own arithmetic: the watcher grants one KillGrace, the survivor
+// sweep grants a second one for descendants still finishing their TERM traps
+// (wave.go), and a writer that outlives the wave gets up to postExitGraceMax
+// more after its exit. waveKillGrace sizes KillGrace with graceFor, so that
+// window is 2×graceFor + postExitGraceMax; a tripwire that expires inside it
+// reports "no line ... and the wave is still running" while the wave is
+// behaving exactly as configured.
 //
 // This is the strongest deterministic pin available: the race it guards is
 // load-sensitivity in which select case wins, so it is pinned structurally
-// (tripwire > graceFor + postExitGraceMax for every deadline) rather than by
-// reproducing the timing, per docs/developing-evener/testing.md's no-sleeps rule.
+// (tripwire >= the counted live window for every deadline) rather than by
+// reproducing the timing, per docs/developing-evener/testing.md's no-sleeps
+// rule. The window count here is deliberately written from wave.go's
+// escalation, not mirrored from fifoReadTripwireFor, so the pin fails if
+// either side drifts.
+//
+// The reserve is a layered contract, not an absolute one: a deadline too
+// close to afford the full window cannot have the tripwire wait past it —
+// the runner would panic first. The still-running window (2×grace) is the
+// #173 race itself and is never given up; the post-exit padding is what gets
+// shed when the budget is tight.
 func TestFifoReadTripwireOutlivesTheGraceWindow(t *testing.T) {
 	t.Parallel()
 
@@ -691,13 +725,35 @@ func TestFifoReadTripwireOutlivesTheGraceWindow(t *testing.T) {
 	} {
 		grace := graceFor(deadline, now)
 		tripwire := fifoReadTripwireFor(deadline, now)
-		// A TERMed suite gets KillGrace = graceFor to exit before KILL, and a
-		// writer that outlives the wave gets up to postExitGraceMax more after
-		// its exit. The tripwire must sit beyond that whole live window.
-		liveWindow := grace + postExitGraceMax
-		if tripwire < liveWindow {
-			t.Errorf("deadline %v from now: tripwire %v expires inside the live grace window (grace %v + post-exit max %v = %v)",
-				deadline.Sub(now), tripwire, grace, postExitGraceMax, liveWindow)
+		// runSuite's escalation: watcher KillGrace, then the survivor sweep's
+		// second KillGrace, then post-exit grace for a writer that outlives
+		// the wave. The tripwire must never sit inside the still-running
+		// window — that is the #173 race itself.
+		liveWindow := 2*grace + postExitGraceMax
+		runningWindow := 2 * grace
+		if tripwire < runningWindow {
+			t.Errorf("deadline %v from now: tripwire %v expires inside the still-running grace window (2×grace %v) it must never race",
+				deadline.Sub(now), tripwire, runningWindow)
+		}
+		if deadline.IsZero() {
+			if tripwire < liveWindow {
+				t.Errorf("no deadline: tripwire %v is inside the full live window %v it should cover", tripwire, liveWindow)
+			}
+			continue
+		}
+		budget := deadline.Sub(now) - deadlineReportReserve
+		if budget >= liveWindow && tripwire < liveWindow {
+			t.Errorf("deadline %v from now: budget %v affords the full live window %v but tripwire is only %v",
+				deadline.Sub(now), budget, liveWindow, tripwire)
+		}
+		// deadlineReportReserve: when the budget cannot afford the full
+		// window, the post-exit padding is shed so a wedged read surfaces as
+		// this file's clean one-line error rather than the runner's panic —
+		// unless even the still-running window exceeds the budget, where that
+		// window wins and the runner's deadline backstops.
+		if tripwire > budget && tripwire > liveWindow {
+			t.Errorf("deadline %v from now: tripwire %v exceeds the reportable budget %v while also exceeding the live window %v: it should shed its post-exit padding instead",
+				deadline.Sub(now), tripwire, budget, liveWindow)
 		}
 	}
 }

--- a/cmd/evener-test-dev-tooling/wave_test.go
+++ b/cmd/evener-test-dev-tooling/wave_test.go
@@ -751,9 +751,9 @@ func TestFifoReadTripwireOutlivesTheGraceWindow(t *testing.T) {
 		// this file's clean one-line error rather than the runner's panic —
 		// unless even the still-running window exceeds the budget, where that
 		// window wins and the runner's deadline backstops.
-		if tripwire > budget && tripwire > liveWindow {
-			t.Errorf("deadline %v from now: tripwire %v exceeds the reportable budget %v while also exceeding the live window %v: it should shed its post-exit padding instead",
-				deadline.Sub(now), tripwire, budget, liveWindow)
+		if tripwire > budget && tripwire > runningWindow {
+			t.Errorf("deadline %v from now: tripwire %v exceeds the reportable budget %v while also beyond the still-running window %v: it should shed its post-exit padding instead",
+				deadline.Sub(now), tripwire, budget, runningWindow)
 		}
 	}
 }


### PR DESCRIPTION
Closes #173 (residual flake-hardening; the 10-minute hang itself was fixed earlier by 18b0a0b2f and the residual race was classified in the 2026-08-29 triage comment).

## Summary
The wave test's FIFO read tripwire was a flat 60s constant racing three coincidentally-equal 60-second ceilings (tripwire, post-exit grace max, test KillGrace) — under load it could fire inside a window the grace logic still considered live, producing intermittent FAILs that block merge gates.

- **Round 1**: scaled the tripwire to the deadline (`graceFor + postExitGraceMax`), computed inside `readFifoLineOrExit` so no caller can reintroduce an independent constant. Deterministic pin test (`TestFifoReadTripwireOutlivesTheGraceWindow`, 7 deadline shapes) — red-first demonstrated via a behavior-identical flat-60s intermediate, no sleeps, no timing races.
- **Round 2**: adversarial review found the derivation omitted the survivor-sweep's second full KillGrace (wave.go:223 — descendants "can legitimately still be writing its shutdown event here"), so at the CI-common capped case the tripwire *equaled* the live window. Now `2×graceFor + postExitGraceMax`, with the report reserve shaving only the post-exit padding (never the still-running window — the runner's own deadline backstops near-deadline shapes). The pin now counts the real window from wave.go's escalation rather than mirroring the implementation.
- **Round 3**: one-token pin fix — the reserve clause's second conjunct referenced the wrong bound, leaving the budget clamp unpinned; now pinned (mutation-verified: clamp removal fails 4/7 shapes).

## Verification highlights
- Pin red-first against all wrong shapes: flat-60s, round-1 formula, clamp removal — each demonstrated by mutation testing.
- Round-2 reviewer independently re-derived the window arithmetic with a Go program plus a 40-minute ms-granularity brute-force sweep: zero inside-running-window violations.
- Gates: full dev-tooling package, `make vet`, `make lint` (all 9 targets) PASS in the fix worktree; targeted interrupt/forked tests re-run by the orchestrator.

## Adversarial review
Two rounds, two competing reviewers each. Round 1: split verdict — one reviewer found the sweep-grace omission (verified by the orchestrator in wave.go directly), the other approved zero findings; the finding held. Round 2: both approve (one non-blocking pin conjunct fixed in round 3). The doubled wedge-failure latency at the cap (a genuinely hung wave now takes up to 3× longer to fail) is documented in the function's doc comment as a deliberate tradeoff.
