### PR TITLE
consolidate duplicated intent-reader selection loop into toolargs.FirstNonEmpty

### DIFF
--- a/agent/cov_s3_filetools_test.go
+++ b/agent/cov_s3_filetools_test.go
@@ -19,7 +19,7 @@ func TestS3Cov_FileTools_ReadWriteEdit(t *testing.T) {
 	}
 
 	// read_file returns content and tracks the read.
-	res = s3cov_exec(t, s, "read_file", `{"file_path":"note.txt","purpose":"inspect"}`)
+	res = s3cov_exec(t, s, "read_file", `{"file_path":"note.txt","intent":"inspect"}`)
 	if res.IsError || !strings.Contains(res.Output, "hello world") {
 		t.Fatalf("read_file: err=%v out=%s", res.IsError, res.Output)
 	}

--- a/agent/cov_s3_render_test.go
+++ b/agent/cov_s3_render_test.go
@@ -67,18 +67,22 @@ func TestS3Cov_ScalarStringAndFormatNumber(t *testing.T) {
 	}
 }
 
-func TestS3Cov_ToolPurpose(t *testing.T) {
+func TestS3Cov_ToolIntent(t *testing.T) {
 	t.Parallel()
-	if got := toolPurpose(json.RawMessage(`{"purpose":"explain"}`)); got != "explain" {
-		t.Fatalf("purpose = %q", got)
-	}
-	if got := toolPurpose(json.RawMessage(`{"intent":"find bug"}`)); got != "find bug" {
+	if got := toolIntent(json.RawMessage(`{"intent":"explain"}`)); got != "explain" {
 		t.Fatalf("intent = %q", got)
 	}
-	if got := toolPurpose(json.RawMessage(`{"other":"x"}`)); got != "" {
+	// "purpose" remains a supported fallback key (backward compatibility).
+	if got := toolIntent(json.RawMessage(`{"purpose":"explain"}`)); got != "explain" {
+		t.Fatalf("intent = %q", got)
+	}
+	if got := toolIntent(json.RawMessage(`{"intent":"find bug"}`)); got != "find bug" {
+		t.Fatalf("intent = %q", got)
+	}
+	if got := toolIntent(json.RawMessage(`{"other":"x"}`)); got != "" {
 		t.Fatalf("expected empty, got %q", got)
 	}
-	if got := toolPurpose(nil); got != "" {
+	if got := toolIntent(nil); got != "" {
 		t.Fatalf("nil args => %q", got)
 	}
 }

--- a/agent/cov_s3_renderoutline_test.go
+++ b/agent/cov_s3_renderoutline_test.go
@@ -24,7 +24,7 @@ func TestS3Cov_RenderOutline_ToolCallsAndStatus(t *testing.T) {
 	entries := s3cov_entries(
 		schema.NewTurn(schema.TurnUserInput, llm.User("do a thing")),
 		s3cov_assistantCall("reading files",
-			&llm.ToolCallData{ID: "c1", Name: "read_file", Arguments: json.RawMessage(`{"purpose":"inspect"}`)},
+			&llm.ToolCallData{ID: "c1", Name: "read_file", Arguments: json.RawMessage(`{"intent":"inspect"}`)},
 			&llm.ToolCallData{ID: "c2", Name: "grep"},
 		),
 		schema.NewTurn(schema.TurnToolResults, s3cov_twoResults("c1", "ok content", false, "c2", "match", false)),

--- a/agent/cov_s3_vision_test.go
+++ b/agent/cov_s3_vision_test.go
@@ -40,7 +40,7 @@ func TestVisionPromptContractIsUnconditional(t *testing.T) {
 	}
 	var suffix string
 	for _, purpose := range purposes {
-		if got := sess.describeImage(context.Background(), tool.ExecResult{ImageData: []byte("image"), ImagePurpose: purpose}); got != "vision" {
+		if got := sess.describeImage(context.Background(), tool.ExecResult{ImageData: []byte("image"), ImageIntent: purpose}); got != "vision" {
 			t.Fatalf("vision response = %q", got)
 		}
 		requests := adapter.Requests()

--- a/agent/cov_stweb_fuzz_test.go
+++ b/agent/cov_stweb_fuzz_test.go
@@ -344,7 +344,7 @@ func stweb_run(t *testing.T, data []byte) stweb_trace {
 	fetch := stweb_execute(t, reg, env, "stweb-fetch", "web_fetch", map[string]any{
 		"url":      fetchURL,
 		"question": question,
-		"purpose":  "inspect " + token,
+		"intent":   "inspect " + token,
 	})
 	stweb_assertResult(t, fetch, "web_fetch", "stweb-fetch", denied, "fetched:"+fetchURL+":"+question)
 	if got, want := fetchCalls, stweb_callCount(denied); got != want {
@@ -363,8 +363,8 @@ func stweb_run(t *testing.T, data []byte) stweb_trace {
 	}
 
 	search := stweb_execute(t, reg, env, "stweb-search", "web_search", map[string]any{
-		"query":   query,
-		"purpose": "search " + token,
+		"query":  query,
+		"intent": "search " + token,
 	})
 	stweb_assertResult(t, search, "web_search", "stweb-search", denied, "searched:"+query)
 	if got, want := searchCalls, stweb_callCount(denied); got != want {

--- a/agent/cov_w3sub_session_tools_file_test.go
+++ b/agent/cov_w3sub_session_tools_file_test.go
@@ -54,7 +54,7 @@ func w3sub_readFileResult(t *testing.T, env execenv.ExecutionEnvironment, path s
 	if err := registerFileTools(reg, deps); err != nil {
 		t.Fatalf("registerFileTools: %v", err)
 	}
-	args, _ := json.Marshal(map[string]any{"file_path": path, "purpose": "inspect"})
+	args, _ := json.Marshal(map[string]any{"file_path": path, "intent": "inspect"})
 	return reg.ExecuteCall(context.Background(), env, llm.ToolCallData{ID: "c1", Name: "read_file", Arguments: args})
 }
 
@@ -69,8 +69,8 @@ func TestW3Sub_RegisterFileTools_ImageResult(t *testing.T) {
 	if len(res.ImageData) == 0 || res.ImageMediaType != "image/png" {
 		t.Fatalf("expected an image side-channel result, got: %+v", res)
 	}
-	if res.ImagePurpose != "inspect" {
-		t.Fatalf("purpose not carried through: %q", res.ImagePurpose)
+	if res.ImageIntent != "inspect" {
+		t.Fatalf("intent not carried through: %q", res.ImageIntent)
 	}
 }
 

--- a/agent/env_local_image_test.go
+++ b/agent/env_local_image_test.go
@@ -180,7 +180,7 @@ func TestReadFile_RealPDF_DetectedByItsBytes(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(dir, name), content, 0o644); err != nil {
 			t.Fatalf("write %s: %v", name, err)
 		}
-		args, err := json.Marshal(map[string]any{"file_path": name, "purpose": "inspect"})
+		args, err := json.Marshal(map[string]any{"file_path": name, "intent": "inspect"})
 		if err != nil {
 			t.Fatalf("marshal args: %v", err)
 		}

--- a/agent/fuzz_fc2_dispatch_test.go
+++ b/agent/fuzz_fc2_dispatch_test.go
@@ -82,25 +82,34 @@ func FuzzFc2OutputWindowStatus(f *testing.F) {
 }
 
 // FuzzFc2ToolStartDescription drives toolStartDescription — the pure description
-// promotion lifted out of execTool: an explicit "purpose" wins over the legacy
-// "description", else empty. Oracles (beyond never-panic):
+// promotion lifted out of execTool: an explicit "intent" wins over the legacy
+// "purpose" (backward compat) and "description", else empty. Oracles (beyond
+// never-panic):
 //   - determinism;
-//   - a non-empty string "purpose" is always returned verbatim;
+//   - a non-empty string "intent" (or legacy "purpose") is always returned verbatim;
 //   - otherwise a non-empty string "description" is returned;
 //   - otherwise the result is empty.
 func FuzzFc2ToolStartDescription(f *testing.F) {
-	f.Add("do the thing", "shell desc", true, true)
-	f.Add("", "shell desc", false, true)
-	f.Add("", "", false, false)
-	f.Add("purpose only", "", true, false)
+	f.Add("do the thing", "shell desc", true, true, false)
+	f.Add("", "shell desc", false, true, false)
+	f.Add("", "", false, false, false)
+	f.Add("intent only", "", true, false, false)
+	// Backward-compat: a legacy "purpose" key is still honored as a fallback.
+	f.Add("legacy purpose", "", true, false, true)
 
-	f.Fuzz(func(t *testing.T, purpose, desc string, hasPurpose, hasDesc bool) {
+	f.Fuzz(func(t *testing.T, purpose, desc string, hasIntent, hasDesc, useLegacyPurpose bool) {
 		args := map[string]any{}
 		// Vary the value TYPES too: only a string value should be honored.
-		if hasPurpose {
-			args["purpose"] = purpose
+		// The value rides the primary "intent" key, or the legacy "purpose"
+		// fallback key when useLegacyPurpose is set, to exercise both paths.
+		key := "intent"
+		if useLegacyPurpose {
+			key = "purpose"
+		}
+		if hasIntent {
+			args[key] = purpose
 		} else {
-			args["purpose"] = 42 // non-string: ignored
+			args[key] = 42 // non-string: ignored
 		}
 		if hasDesc {
 			args["description"] = desc
@@ -113,12 +122,12 @@ func FuzzFc2ToolStartDescription(f *testing.F) {
 			t.Fatalf("non-deterministic: %q vs %q", got, got2)
 		}
 
-		wantPurpose := hasPurpose && purpose != ""
+		wantIntent := hasIntent && purpose != ""
 		wantDesc := hasDesc && desc != ""
 		switch {
-		case wantPurpose:
+		case wantIntent:
 			if got != purpose {
-				t.Fatalf("purpose set but got %q, want %q", got, purpose)
+				t.Fatalf("intent set but got %q, want %q", got, purpose)
 			}
 		case wantDesc:
 			if got != desc {

--- a/agent/internal/mcp/manager_program_fuzz_test.go
+++ b/agent/internal/mcp/manager_program_fuzz_test.go
@@ -366,7 +366,7 @@ func mcpProgramServerWithTools(t *testing.T, replies map[string]string) (*mcpsdk
 
 func mcpProgramExecute(ctx context.Context, t *testing.T, reg *tool.Registry, env *agenttest.DenyEnv, name, message string) tool.ExecResult {
 	t.Helper()
-	raw, err := json.Marshal(map[string]string{"message": message, "purpose": "fuzz manager routing"})
+	raw, err := json.Marshal(map[string]string{"message": message, "intent": "fuzz manager routing"})
 	if err != nil {
 		t.Fatalf("marshal MCP args: %v", err)
 	}

--- a/agent/internal/tool/cov_s4_tool_test.go
+++ b/agent/internal/tool/cov_s4_tool_test.go
@@ -183,23 +183,23 @@ func TestParseV4APatchErrorBranches(t *testing.T) {
 	}
 }
 
-func TestWithoutPurposeParameter_RemovesFromRequired(t *testing.T) {
+func TestWithoutIntentParameter_RemovesFromRequired(t *testing.T) {
 	// []any required branch.
 	tdAny := llm.ToolDefinition{
 		Name: "t",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
-				"purpose": map[string]any{"type": "string"},
-				"foo":     map[string]any{"type": "string"},
+				"intent": map[string]any{"type": "string"},
+				"foo":    map[string]any{"type": "string"},
 			},
-			"required": []any{"purpose", "foo"},
+			"required": []any{"intent", "foo"},
 		},
 	}
-	got := WithoutPurposeParameter(tdAny)
+	got := WithoutIntentParameter(tdAny)
 	props, _ := got.Parameters["properties"].(map[string]any)
-	if _, ok := props["purpose"]; ok {
-		t.Fatal("purpose should be removed from properties")
+	if _, ok := props["intent"]; ok {
+		t.Fatal("intent should be removed from properties")
 	}
 	reqAny, ok := got.Parameters["required"].([]any)
 	if !ok {
@@ -214,11 +214,11 @@ func TestWithoutPurposeParameter_RemovesFromRequired(t *testing.T) {
 		Name: "t",
 		Parameters: map[string]any{
 			"type":       "object",
-			"properties": map[string]any{"purpose": map[string]any{"type": "string"}},
-			"required":   []string{"purpose", "bar"},
+			"properties": map[string]any{"intent": map[string]any{"type": "string"}},
+			"required":   []string{"intent", "bar"},
 		},
 	}
-	got = WithoutPurposeParameter(tdStr)
+	got = WithoutIntentParameter(tdStr)
 	reqStr, ok := got.Parameters["required"].([]string)
 	if !ok {
 		t.Fatalf("required should stay []string, got %T", got.Parameters["required"])

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -17,7 +17,7 @@ func DefReadFile() llm.ToolDefinition {
 				"file_path": map[string]any{"type": "string"},
 				"offset":    map[string]any{"type": "integer", "description": "For large files read in slices: 1-based start line (default 1)."},
 				"limit":     map[string]any{"type": "integer", "description": "For large files read in slices: line count to return, default 2000."},
-				"purpose":   map[string]any{"type": "string", "description": "For image/PDF files: describe what factual data you need extracted. Vision is an OCR + description service, not an analyst. It will extract and describe what you ask for; interpretation and classification are your job. Concrete asks work best: transcribe, list, extract, locate."},
+				"intent":    map[string]any{"type": "string", "description": "For image/PDF files: describe what factual data you need extracted and why. Vision is an OCR + description service, not an analyst. It will extract and describe what you ask for; interpretation and classification are your job. Concrete asks work best: transcribe, list, extract, locate."},
 			},
 			"required": []string{"file_path"},
 		},

--- a/agent/internal/tool/definitions_program_fuzz_test.go
+++ b/agent/internal/tool/definitions_program_fuzz_test.go
@@ -79,8 +79,8 @@ func FuzzToolDefinitionsProgram(f *testing.F) {
 			}
 
 			if err := reg.Register(RegisteredTool{
-				Definition:  def,
-				OmitPurpose: i%2 == 0,
+				Definition: def,
+				OmitIntent: i%2 == 0,
 				Exec: func(_ context.Context, _ execenv.ExecutionEnvironment, _ map[string]any) (any, error) {
 					return "definition program", nil
 				},
@@ -150,15 +150,15 @@ func toolProgramDefinitionShape(t *testing.T, def llm.ToolDefinition) {
 	if typ, _ := def.Parameters["type"].(string); typ != "object" {
 		t.Fatalf("definition %q root type = %q, want object", def.Name, typ)
 	}
-	withPurpose := WithPurposeParameter(def)
-	props, _ := withPurpose.Parameters["properties"].(map[string]any)
-	if props == nil || props["purpose"] == nil {
-		t.Fatalf("definition %q did not gain purpose: %#v", def.Name, withPurpose.Parameters)
+	withIntent := WithIntentParameter(def)
+	props, _ := withIntent.Parameters["properties"].(map[string]any)
+	if props == nil || props["intent"] == nil {
+		t.Fatalf("definition %q did not gain intent: %#v", def.Name, withIntent.Parameters)
 	}
-	withoutPurpose := WithoutPurposeParameter(withPurpose)
-	withoutProps, _ := withoutPurpose.Parameters["properties"].(map[string]any)
-	if withoutProps != nil && withoutProps["purpose"] != nil {
-		t.Fatalf("definition %q retained purpose after removal: %#v", def.Name, withoutPurpose.Parameters)
+	withoutIntent := WithoutIntentParameter(withIntent)
+	withoutProps, _ := withoutIntent.Parameters["properties"].(map[string]any)
+	if withoutProps != nil && withoutProps["intent"] != nil {
+		t.Fatalf("definition %q retained intent after removal: %#v", def.Name, withoutIntent.Parameters)
 	}
 }
 

--- a/agent/internal/tool/registry.go
+++ b/agent/internal/tool/registry.go
@@ -23,7 +23,7 @@ import (
 	"primeradiant.com/evener/llm"
 )
 
-const toolPurposeDescription = "A short verb-first gerund phrase naming what this call is doing, e.g. \"Reading the config file\" or \"Searching for the handler\". Keep it to a few words so it renders nicely as an inline activity label."
+const toolIntentDescription = "A short verb-first gerund phrase naming what this call is doing and why, e.g. \"Reading the config file\" or \"Searching for the handler\". Keep it to a few words so it renders nicely as an inline activity label."
 
 // maxToolArgumentBytes caps the size of a tool call's raw argument payload
 // before it is parsed, so a runaway generation can't push a multi-hundred-KB
@@ -37,7 +37,7 @@ const toolPurposeDescription = "A short verb-first gerund phrase naming what thi
 // keep the two values in sync by comment.)
 const maxToolArgumentBytes = 2 * 1024 * 1024
 
-func WithPurposeParameter(td llm.ToolDefinition) llm.ToolDefinition {
+func WithIntentParameter(td llm.ToolDefinition) llm.ToolDefinition {
 	params := CloneSchemaMap(td.Parameters)
 	if params == nil {
 		params = map[string]any{"type": "object"}
@@ -52,27 +52,27 @@ func WithPurposeParameter(td llm.ToolDefinition) llm.ToolDefinition {
 		props = map[string]any{}
 		params["properties"] = props
 	}
-	if _, exists := props["purpose"]; !exists {
-		props["purpose"] = map[string]any{
+	if _, exists := props["intent"]; !exists {
+		props["intent"] = map[string]any{
 			"type":        "string",
-			"description": toolPurposeDescription,
+			"description": toolIntentDescription,
 		}
 	}
 	td.Parameters = params
 	return td
 }
 
-func WithoutPurposeParameter(td llm.ToolDefinition) llm.ToolDefinition {
+func WithoutIntentParameter(td llm.ToolDefinition) llm.ToolDefinition {
 	params := CloneSchemaMap(td.Parameters)
 	props, _ := params["properties"].(map[string]any)
 	if props != nil {
-		delete(props, "purpose")
+		delete(props, "intent")
 	}
 	switch required := params["required"].(type) {
 	case []string:
-		params["required"] = removeRequiredField(required, "purpose")
+		params["required"] = removeRequiredField(required, "intent")
 	case []any:
-		params["required"] = removeRequiredFieldAny(required, "purpose")
+		params["required"] = removeRequiredFieldAny(required, "intent")
 	}
 	td.Parameters = params
 	return td
@@ -243,7 +243,7 @@ type ExecResult struct {
 	// alongside the text output so the model can "see" the image.
 	ImageData      []byte
 	ImageMediaType string
-	ImagePurpose   string // from the caller: what they hope to learn
+	ImageIntent    string // from the caller: what they hope to learn
 
 	// ToolState is an optional JSON-encoded snapshot emitted alongside
 	// Output via the TOOL_CALL_END event. The LLM never sees this — it's a
@@ -282,7 +282,7 @@ type ImageResult struct {
 	Text      string
 	Data      []byte
 	MediaType string
-	Purpose   string // what the caller hopes to learn from this image
+	Intent    string // what the caller hopes to learn from this image
 }
 
 // ParseImageResult checks if ReadFile output is an image response (the [image: ...]
@@ -339,10 +339,10 @@ func ParseDocumentResult(_ string, readFileOutput string) *ImageResult {
 // Execute), its compiled validation schema, output limit, and the agent-layer
 // executor that receives the execenv.ExecutionEnvironment.
 type RegisteredTool struct {
-	llm.Tool    // embeds Definition + Execute
-	Schema      *jsonschema.Schema
-	Limit       schema.ToolOutputLimit
-	OmitPurpose bool
+	llm.Tool   // embeds Definition + Execute
+	Schema     *jsonschema.Schema
+	Limit      schema.ToolOutputLimit
+	OmitIntent bool
 	// Agent-layer executor with environment context.
 	Exec func(ctx context.Context, env execenv.ExecutionEnvironment, args map[string]any) (any, error)
 }
@@ -399,17 +399,17 @@ func (r *Registry) Use(mw toolMiddleware) {
 }
 
 // Register validates and stores a tool in the registry. It rejects an invalid
-// tool name or a missing executor, injects the purpose parameter into work-tool
+// tool name or a missing executor, injects the intent parameter into work-tool
 // definitions, applies a default output limit when none is set, compiles (or
 // reuses) the argument schema, and bridges llm.Tool.Execute from Exec when unset.
 func (r *Registry) Register(t RegisteredTool) error {
 	if err := llm.ValidateToolName(t.Definition.Name); err != nil {
 		return err
 	}
-	if t.OmitPurpose {
-		t.Definition = WithoutPurposeParameter(t.Definition)
+	if t.OmitIntent {
+		t.Definition = WithoutIntentParameter(t.Definition)
 	} else {
-		t.Definition = WithPurposeParameter(t.Definition)
+		t.Definition = WithIntentParameter(t.Definition)
 	}
 	if strings.TrimSpace(t.Definition.Description) == "" {
 		log.Printf("WARNING: tool %q registered with empty description", t.Definition.Name)
@@ -675,7 +675,7 @@ func (r *Registry) ExecuteCall(ctx context.Context, env execenv.ExecutionEnviron
 	}
 
 	if name != "read_file" {
-		delete(args, "purpose")
+		delete(args, "intent")
 	}
 	v, err := t.Exec(ctx, env, args)
 	res := dispatchedResult(name, callID, t.Limit, v, err)
@@ -734,7 +734,7 @@ func dispatchedResult(name, callID string, lim schema.ToolOutputLimit, v any, er
 		res := truncateResult(name, callID, img.Text, false, lim)
 		res.ImageData = img.Data
 		res.ImageMediaType = img.MediaType
-		res.ImagePurpose = img.Purpose
+		res.ImageIntent = img.Intent
 		return res
 	}
 

--- a/agent/internal/tool/registry_program_fuzz_test.go
+++ b/agent/internal/tool/registry_program_fuzz_test.go
@@ -45,7 +45,7 @@ func FuzzToolRegistryProgram(f *testing.F) {
 			return
 		}
 		payload := toolProgramPayload(raw)
-		reg, calls, readFileSawPurpose := toolProgramRegistry(t)
+		reg, calls, readFileSawIntent := toolProgramRegistry(t)
 		deny := &agenttest.DenyEnv{WorkDir: t.TempDir(), Seed: seed}
 
 		beforeCalls := *calls
@@ -105,8 +105,8 @@ func FuzzToolRegistryProgram(f *testing.F) {
 			t.Fatalf("executor calls = %d, want %d", *calls, beforeCalls+6)
 		}
 
-		if got := toolProgramCall(t, reg, deny, "read_file", payload, 0, false, "read-file"); got.IsError || !*readFileSawPurpose {
-			t.Fatalf("read_file purpose preservation = result=%+v saw=%v", got, *readFileSawPurpose)
+		if got := toolProgramCall(t, reg, deny, "read_file", payload, 0, false, "read-file"); got.IsError || !*readFileSawIntent {
+			t.Fatalf("read_file intent preservation = result=%+v saw=%v", got, *readFileSawIntent)
 		}
 
 		toolProgramPatchBoundary(t, reg, deny, payload)
@@ -121,7 +121,7 @@ func toolProgramRegistry(t *testing.T) (*Registry, *int, *bool) {
 	t.Helper()
 	reg := NewRegistry()
 	calls := new(int)
-	readFileSawPurpose := new(bool)
+	readFileSawIntent := new(bool)
 
 	if err := reg.Register(RegisteredTool{
 		Definition: llm.ToolDefinition{
@@ -140,8 +140,8 @@ func toolProgramRegistry(t *testing.T) (*Registry, *int, *bool) {
 		},
 		Exec: func(_ context.Context, _ execenv.ExecutionEnvironment, args map[string]any) (any, error) {
 			*calls++
-			if _, found := args["purpose"]; found {
-				return nil, errors.New("purpose leaked to non-read_file executor")
+			if _, found := args["intent"]; found {
+				return nil, errors.New("intent leaked to non-read_file executor")
 			}
 			value, _ := args["value"].(string)
 			mode, _ := args["mode"].(float64)
@@ -151,7 +151,7 @@ func toolProgramRegistry(t *testing.T) (*Registry, *int, *bool) {
 			case 2:
 				return TextResult{Output: "text:" + value, FullOutput: "full:" + value}, nil
 			case 3:
-				return ImageResult{Text: "image:" + value, Data: encodeRasterFixture(t, "png"), MediaType: "image/png", Purpose: "program"}, nil
+				return ImageResult{Text: "image:" + value, Data: encodeRasterFixture(t, "png"), MediaType: "image/png", Intent: "program"}, nil
 			case 4:
 				return "partial:" + value, errors.New("program executor error")
 			case 5:
@@ -167,7 +167,7 @@ func toolProgramRegistry(t *testing.T) (*Registry, *int, *bool) {
 	if err := reg.Register(RegisteredTool{
 		Definition: llm.ToolDefinition{
 			Name:        "read_file",
-			Description: "program read_file purpose witness",
+			Description: "program read_file intent witness",
 			Parameters: map[string]any{
 				"type":       "object",
 				"properties": map[string]any{"value": map[string]any{"type": "string"}, "mode": map[string]any{"type": "integer"}, "block": map[string]any{"type": "boolean"}},
@@ -175,7 +175,7 @@ func toolProgramRegistry(t *testing.T) (*Registry, *int, *bool) {
 			},
 		},
 		Exec: func(_ context.Context, _ execenv.ExecutionEnvironment, args map[string]any) (any, error) {
-			_, *readFileSawPurpose = args["purpose"]
+			_, *readFileSawIntent = args["intent"]
 			return "read:" + fmt.Sprint(args["value"]), nil
 		},
 	}); err != nil {
@@ -215,12 +215,12 @@ func toolProgramRegistry(t *testing.T) (*Registry, *int, *bool) {
 		}
 		return nil
 	})
-	return reg, calls, readFileSawPurpose
+	return reg, calls, readFileSawIntent
 }
 
 func toolProgramCall(t *testing.T, reg *Registry, env execenv.ExecutionEnvironment, name, value string, mode int, block bool, callID string) ExecResult {
 	t.Helper()
-	raw, err := json.Marshal(map[string]any{"value": value, "mode": mode, "block": block, "purpose": "fuzz registry program"})
+	raw, err := json.Marshal(map[string]any{"value": value, "mode": mode, "block": block, "intent": "fuzz registry program"})
 	if err != nil {
 		t.Fatalf("marshal %s args: %v", name, err)
 	}
@@ -230,7 +230,7 @@ func toolProgramCall(t *testing.T, reg *Registry, env execenv.ExecutionEnvironme
 func toolProgramPatchBoundary(t *testing.T, reg *Registry, deny *agenttest.DenyEnv, payload string) {
 	t.Helper()
 	patch := "*** Begin Patch\n*** Add File: program.txt\n+" + payload + "\n*** End Patch\n"
-	raw, err := json.Marshal(map[string]string{"patch": patch, "purpose": "exercise FileMutator"})
+	raw, err := json.Marshal(map[string]string{"patch": patch, "intent": "exercise FileMutator"})
 	if err != nil {
 		t.Fatalf("marshal patch args: %v", err)
 	}
@@ -329,21 +329,21 @@ func toolProgramHelpers(t *testing.T, payload string) {
 // schemas here: each case has one stable, independently checkable contract.
 func toolProgramRegistryEdges(t *testing.T) {
 	t.Helper()
-	if got := WithPurposeParameter(llm.ToolDefinition{}); got.Parameters["type"] != "object" {
+	if got := WithIntentParameter(llm.ToolDefinition{}); got.Parameters["type"] != "object" {
 		t.Fatalf("nil schema purpose injection = %#v", got.Parameters)
 	}
 	nonObject := llm.ToolDefinition{Parameters: map[string]any{"type": "string"}}
-	if got := WithPurposeParameter(nonObject); got.Parameters["type"] != "string" {
+	if got := WithIntentParameter(nonObject); got.Parameters["type"] != "string" {
 		t.Fatalf("non-object schema changed: %#v", got.Parameters)
 	}
 	withRequired := llm.ToolDefinition{Parameters: map[string]any{
 		"type":       "object",
-		"properties": map[string]any{"purpose": map[string]any{"type": "string"}},
-		"required":   []any{"purpose", 9, "value"},
+		"properties": map[string]any{"intent": map[string]any{"type": "string"}},
+		"required":   []any{"intent", 9, "value"},
 	}}
-	without := WithoutPurposeParameter(withRequired)
+	without := WithoutIntentParameter(withRequired)
 	if got := without.Parameters["required"].([]any); len(got) != 2 || got[0] != 9 || got[1] != "value" {
-		t.Fatalf("purpose removal retained wrong required list: %#v", got)
+		t.Fatalf("intent removal retained wrong required list: %#v", got)
 	}
 
 	cloneSource := map[string]any{

--- a/agent/internal/tool/registry_test.go
+++ b/agent/internal/tool/registry_test.go
@@ -17,21 +17,21 @@ import (
 	"primeradiant.com/evener/llm"
 )
 
-func TestWithPurposeParameter_DescriptionGuidesGerundForm(t *testing.T) {
-	td := WithPurposeParameter(llm.ToolDefinition{Name: "demo"})
+func TestWithIntentParameter_DescriptionGuidesGerundForm(t *testing.T) {
+	td := WithIntentParameter(llm.ToolDefinition{Name: "demo"})
 	props, _ := td.Parameters["properties"].(map[string]any)
 	if props == nil {
-		t.Fatalf("purpose injection produced no properties: %#v", td.Parameters)
+		t.Fatalf("intent injection produced no properties: %#v", td.Parameters)
 	}
-	purpose, _ := props["purpose"].(map[string]any)
-	if purpose == nil {
-		t.Fatalf("purpose property missing: %#v", props)
+	intent, _ := props["intent"].(map[string]any)
+	if intent == nil {
+		t.Fatalf("intent property missing: %#v", props)
 	}
-	desc, _ := purpose["description"].(string)
+	desc, _ := intent["description"].(string)
 	if desc == "" {
-		t.Fatalf("purpose property has no description: %#v", purpose)
+		t.Fatalf("intent property has no description: %#v", intent)
 	}
-	// The purpose string renders as an inline activity label in the UI, so the
+	// The intent string renders as an inline activity label in the UI, so the
 	// description must steer the model toward a verb-first gerund phrase with
 	// a concrete example rather than imperative or verbose prose.
 	if !strings.Contains(desc, "gerund") {
@@ -156,23 +156,23 @@ func TestToolRegistry_AddsAndStripsUniversalPurpose(t *testing.T) {
 	}
 	defs := r.Definitions()
 	props, _ := defs[0].Parameters["properties"].(map[string]any)
-	if _, ok := props["purpose"]; !ok {
-		t.Fatal("registered schema missing universal purpose")
+	if _, ok := props["intent"]; !ok {
+		t.Fatal("registered schema missing universal intent")
 	}
 	res := r.ExecuteCall(context.Background(), execenv.NewLocalExecutionEnvironment(t.TempDir()), llm.ToolCallData{
 		ID:        "c1",
 		Name:      "echo",
-		Arguments: json.RawMessage(`{"value":"x","purpose":"checking behavior"}`),
+		Arguments: json.RawMessage(`{"value":"x","intent":"checking behavior"}`),
 	})
 	if res.IsError {
 		t.Fatalf("unexpected error: %q", res.Output)
 	}
-	if _, ok := gotArgs["purpose"]; ok {
-		t.Fatalf("purpose should be stripped before non-read_file execution: %#v", gotArgs)
+	if _, ok := gotArgs["intent"]; ok {
+		t.Fatalf("intent should be stripped before non-read_file execution: %#v", gotArgs)
 	}
 }
 
-func TestToolRegistry_OmitPurposeLeavesSchemaStrict(t *testing.T) {
+func TestToolRegistry_OmitIntentLeavesSchemaStrict(t *testing.T) {
 	r := NewRegistry()
 	if err := r.Register(RegisteredTool{
 		Definition: llm.ToolDefinition{
@@ -187,7 +187,7 @@ func TestToolRegistry_OmitPurposeLeavesSchemaStrict(t *testing.T) {
 				"required": []string{"message"},
 			},
 		},
-		OmitPurpose: true,
+		OmitIntent: true,
 		Exec: func(ctx context.Context, env execenv.ExecutionEnvironment, args map[string]any) (any, error) {
 			_ = ctx
 			_ = env
@@ -199,19 +199,19 @@ func TestToolRegistry_OmitPurposeLeavesSchemaStrict(t *testing.T) {
 	}
 	defs := r.Definitions()
 	props, _ := defs[0].Parameters["properties"].(map[string]any)
-	if _, ok := props["purpose"]; ok {
-		t.Fatalf("schema should omit purpose: %#v", props["purpose"])
+	if _, ok := props["intent"]; ok {
+		t.Fatalf("schema should omit intent: %#v", props["intent"])
 	}
 	res := r.ExecuteCall(context.Background(), execenv.NewLocalExecutionEnvironment(t.TempDir()), llm.ToolCallData{
 		ID:        "c1",
 		Name:      "result",
-		Arguments: json.RawMessage(`{"message":"done","purpose":"final_result"}`),
+		Arguments: json.RawMessage(`{"message":"done","intent":"final_result"}`),
 	})
 	if !res.IsError {
-		t.Fatalf("purpose should be rejected by strict schema, got: %q", res.Output)
+		t.Fatalf("intent should be rejected by strict schema, got: %q", res.Output)
 	}
-	if !strings.Contains(res.Output, "additionalProperties") || !strings.Contains(res.Output, "purpose") {
-		t.Fatalf("expected purpose schema error, got: %s", res.Output)
+	if !strings.Contains(res.Output, "additionalProperties") || !strings.Contains(res.Output, "intent") {
+		t.Fatalf("expected intent schema error, got: %s", res.Output)
 	}
 }
 

--- a/agent/profile_test.go
+++ b/agent/profile_test.go
@@ -187,7 +187,7 @@ func TestProviderProfiles_AllIncludeUseSkill(t *testing.T) {
 	}
 }
 
-func TestProviderProfiles_AddPurposeToWorkToolSchemas(t *testing.T) {
+func TestProviderProfiles_AddIntentToWorkToolSchemas(t *testing.T) {
 	t.Parallel()
 	profiles := []*provider.Profile{
 		NewOpenAIProfile("gpt-5.2"),
@@ -204,15 +204,15 @@ func TestProviderProfiles_AddPurposeToWorkToolSchemas(t *testing.T) {
 			if props == nil {
 				t.Fatalf("%s/%s has no properties schema", p.ID(), td.Name)
 			}
-			_, hasPurpose := props["purpose"]
+			_, hasIntent := props["intent"]
 			if canonicalName == "communicate" {
-				if hasPurpose {
-					t.Fatalf("%s/%s should not advertise purpose", p.ID(), td.Name)
+				if hasIntent {
+					t.Fatalf("%s/%s should not advertise intent", p.ID(), td.Name)
 				}
 				continue
 			}
-			if !hasPurpose {
-				t.Fatalf("%s/%s missing purpose parameter", p.ID(), td.Name)
+			if !hasIntent {
+				t.Fatalf("%s/%s missing intent parameter", p.ID(), td.Name)
 			}
 		}
 	}

--- a/agent/session_communicate_test.go
+++ b/agent/session_communicate_test.go
@@ -960,7 +960,7 @@ func TestCommunicate_SchemaRejectsMalformedOutput(t *testing.T) {
 	}
 }
 
-func TestCommunicate_SchemaRejectsPurposeInsideOutput(t *testing.T) {
+func TestCommunicate_SchemaRejectsIntentInsideOutput(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	c := llm.NewClient()
@@ -979,7 +979,7 @@ func TestCommunicate_SchemaRejectsPurposeInsideOutput(t *testing.T) {
 			"message":   "RESULT_LIST_DIR visible-item.txt",
 			"data":      map[string]any{},
 			"artifacts": []any{},
-			"purpose":   "final_result",
+			"intent":    "final_result",
 		},
 	})
 	res := sess.reg.ExecuteCall(context.Background(), sess.env, llm.ToolCallData{
@@ -991,12 +991,12 @@ func TestCommunicate_SchemaRejectsPurposeInsideOutput(t *testing.T) {
 	if !res.IsError {
 		t.Fatalf("expected schema error, got success: %s", res.Output)
 	}
-	if !strings.Contains(res.Output, "additionalProperties") || !strings.Contains(res.Output, "purpose") {
-		t.Fatalf("expected output.purpose schema error, got: %s", res.Output)
+	if !strings.Contains(res.Output, "additionalProperties") || !strings.Contains(res.Output, "intent") {
+		t.Fatalf("expected output.intent schema error, got: %s", res.Output)
 	}
 }
 
-func TestCommunicate_SchemaRejectsTopLevelPurpose(t *testing.T) {
+func TestCommunicate_SchemaRejectsTopLevelIntent(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	c := llm.NewClient()
@@ -1011,7 +1011,7 @@ func TestCommunicate_SchemaRejectsTopLevelPurpose(t *testing.T) {
 	rawArgs, _ := json.Marshal(map[string]any{
 		"message":  "RESULT_LIST_DIR visible-item.txt",
 		"end_turn": true,
-		"purpose":  "final_result",
+		"intent":   "final_result",
 		"output": map[string]any{
 			"message":   "",
 			"data":      map[string]any{},
@@ -1027,12 +1027,12 @@ func TestCommunicate_SchemaRejectsTopLevelPurpose(t *testing.T) {
 	if !res.IsError {
 		t.Fatalf("expected schema error, got success: %s", res.Output)
 	}
-	if !strings.Contains(res.Output, "additionalProperties") || !strings.Contains(res.Output, "purpose") {
-		t.Fatalf("expected top-level purpose schema error, got: %s", res.Output)
+	if !strings.Contains(res.Output, "additionalProperties") || !strings.Contains(res.Output, "intent") {
+		t.Fatalf("expected top-level intent schema error, got: %s", res.Output)
 	}
 }
 
-func TestCommunicate_ModelFacingSchemaOmitsPurpose(t *testing.T) {
+func TestCommunicate_ModelFacingSchemaOmitsIntent(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	c := llm.NewClient()
@@ -1058,24 +1058,24 @@ func TestCommunicate_ModelFacingSchemaOmitsPurpose(t *testing.T) {
 		t.Fatal("communicate tool not advertised")
 	}
 	props, _ := communicate.Parameters["properties"].(map[string]any)
-	if _, ok := props["purpose"]; ok {
-		t.Fatalf("communicate should not advertise purpose: %#v", props["purpose"])
+	if _, ok := props["intent"]; ok {
+		t.Fatalf("communicate should not advertise intent: %#v", props["intent"])
 	}
 	output, _ := props["output"].(map[string]any)
 	outProps, _ := output["properties"].(map[string]any)
-	if _, ok := outProps["purpose"]; ok {
-		t.Fatalf("communicate.output should not advertise purpose: %#v", outProps["purpose"])
+	if _, ok := outProps["intent"]; ok {
+		t.Fatalf("communicate.output should not advertise intent: %#v", outProps["intent"])
 	}
 	if readFile == nil {
 		t.Fatal("read_file tool not advertised")
 	}
 	readProps, _ := readFile.Parameters["properties"].(map[string]any)
-	if _, ok := readProps["purpose"]; !ok {
-		t.Fatal("read_file should still advertise purpose")
+	if _, ok := readProps["intent"]; !ok {
+		t.Fatal("read_file should still advertise intent")
 	}
 }
 
-func TestCommunicate_ModelFacingSchemaOmitsPurposeForResultAlias(t *testing.T) {
+func TestCommunicate_ModelFacingSchemaOmitsIntentForResultAlias(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	c := llm.NewClient()
@@ -1100,8 +1100,8 @@ func TestCommunicate_ModelFacingSchemaOmitsPurposeForResultAlias(t *testing.T) {
 		t.Fatal("result alias not advertised")
 	}
 	props, _ := respond.Parameters["properties"].(map[string]any)
-	if _, ok := props["purpose"]; ok {
-		t.Fatalf("result alias should not advertise purpose: %#v", props["purpose"])
+	if _, ok := props["intent"]; ok {
+		t.Fatalf("result alias should not advertise intent: %#v", props["intent"])
 	}
 }
 

--- a/agent/session_dod_definition_test.go
+++ b/agent/session_dod_definition_test.go
@@ -2842,7 +2842,7 @@ func TestSession_ToolNameMapping_EventsUseCanonicalName(t *testing.T) {
 	}
 }
 
-func TestSession_ToolPurpose_IncludedInToolCallStartEvent(t *testing.T) {
+func TestSession_ToolIntent_IncludedInToolCallStartEvent(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	c := llm.NewClient()
@@ -2854,7 +2854,7 @@ func TestSession_ToolPurpose_IncludedInToolCallStartEvent(t *testing.T) {
 				call := llm.ToolCallData{
 					ID:        "call-sh",
 					Name:      "exec_command",
-					Arguments: json.RawMessage(`{"command":"ls","purpose":"List project files"}`),
+					Arguments: json.RawMessage(`{"command":"ls","intent":"List project files"}`),
 					Type:      "function",
 				}
 				return llm.Response{
@@ -2907,7 +2907,7 @@ func TestSession_ToolPurpose_IncludedInToolCallStartEvent(t *testing.T) {
 			}
 		}
 	}
-	t.Fatal("TOOL_CALL_START event should include description field from tool purpose")
+	t.Fatal("TOOL_CALL_START event should include description field from tool intent")
 }
 
 func TestSession_ReadBeforeWrite_WarnsOnUnreadFile(t *testing.T) {

--- a/agent/session_effort_clamp_test.go
+++ b/agent/session_effort_clamp_test.go
@@ -207,7 +207,7 @@ func TestDescribeImage_OmitsEffortWhenProfileDoesNotSupportReasoning(t *testing.
 	desc := sess.describeImage(context.Background(), tool.ExecResult{
 		ImageData:      []byte("fake-png-bytes"),
 		ImageMediaType: "image/png",
-		ImagePurpose:   "what is in this image",
+		ImageIntent:    "what is in this image",
 	})
 	if desc == "" {
 		t.Fatal("describeImage returned empty description")

--- a/agent/session_invalid_image_test.go
+++ b/agent/session_invalid_image_test.go
@@ -54,7 +54,7 @@ func testInvalidRasterToolResultRemainsRecoverable(t *testing.T, name string, da
 					ID:        "read_invalid_image",
 					Name:      "read_file",
 					Type:      "function",
-					Arguments: json.RawMessage(fmt.Sprintf(`{"file_path":%q,"purpose":"inspect it"}`, name)),
+					Arguments: json.RawMessage(fmt.Sprintf(`{"file_path":%q,"intent":"inspect it"}`, name)),
 				})
 			},
 			func(req llm.Request) llm.Response {

--- a/agent/session_skills_test.go
+++ b/agent/session_skills_test.go
@@ -499,7 +499,7 @@ func TestOpenAIUseSkillToolExecutes(t *testing.T) {
 	result := sess.reg.ExecuteCall(context.Background(), execenv.NewLocalExecutionEnvironment(root), llm.ToolCallData{
 		ID:        "call_use_skill",
 		Name:      "use_skill",
-		Arguments: json.RawMessage(`{"skill_name":"greet","purpose":"test skill loading"}`),
+		Arguments: json.RawMessage(`{"skill_name":"greet","intent":"test skill loading"}`),
 		Type:      "function",
 	})
 	if result.IsError {

--- a/agent/session_tool_registry.go
+++ b/agent/session_tool_registry.go
@@ -368,8 +368,8 @@ func buildProfileToolRegistry(defs []llm.ToolDefinition) *tool.Registry {
 	reg := tool.NewRegistry()
 	for _, td := range defs {
 		_ = reg.Register(tool.RegisteredTool{
-			Definition:  td,
-			OmitPurpose: td.Name == "communicate",
+			Definition: td,
+			OmitIntent: td.Name == "communicate",
 			Exec: func(ctx context.Context, env execenv.ExecutionEnvironment, args map[string]any) (any, error) {
 				return nil, errors.New("tool executor not wired")
 			},

--- a/agent/session_tool_round_tail_coverage_fuzz_test.go
+++ b/agent/session_tool_round_tail_coverage_fuzz_test.go
@@ -53,7 +53,7 @@ func registerToolRoundTailTool(t *testing.T, s *Session, name string, readOnly b
 			Name: name, Description: "deterministic coverage tool",
 			Parameters: map[string]any{"type": "object", "additionalProperties": false},
 		}, ReadOnly: readOnly},
-		OmitPurpose: true,
+		OmitIntent: true,
 		Exec: func(ctx context.Context, _ execenv.ExecutionEnvironment, _ map[string]any) (any, error) {
 			return exec(ctx)
 		},

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -21,6 +21,7 @@ import (
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/agent/task"
+	"primeradiant.com/evener/internal/toolargs"
 	"primeradiant.com/evener/llm"
 )
 
@@ -918,12 +919,10 @@ func (r toolCallRerunner) run(ctx context.Context) tool.ExecResult {
 // else empty. Pure over the args map, so the promotion order is fuzzable in
 // isolation.
 func toolStartDescription(args map[string]any) string {
-	for _, key := range []string{"intent", "purpose", "description"} {
-		if v, ok := args[key].(string); ok && v != "" {
-			return v
-		}
-	}
-	return ""
+	return toolargs.FirstNonEmpty(func(key string) string {
+		v, _ := args[key].(string)
+		return v
+	}, "intent", "purpose", "description")
 }
 
 func applyUpdatedToolInput(call *llm.ToolCallData, updated map[string]any) error {

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -449,10 +449,10 @@ func (s *Session) describeImageCall(ctx context.Context, r tool.ExecResult) visi
 		return visionSideChannelResult{outcome: visionSideChannelSuccess}
 	}
 
-	// Use the caller's stated purpose as the vision prompt. The calling LLM
+	// Use the caller's stated intent as the vision prompt. The calling LLM
 	// knows what it needs — we just ask the vision model to answer that question
 	// under one unconditional observation contract.
-	prompt := visionPrompt(r.ImagePurpose)
+	prompt := visionPrompt(r.ImageIntent)
 
 	mt := r.ImageMediaType
 	if mt == "" {
@@ -913,15 +913,15 @@ func (r toolCallRerunner) run(ctx context.Context) tool.ExecResult {
 }
 
 // toolStartDescription resolves the tool-call-start Description from a tool call's
-// decoded arguments: an explicit "purpose" wins, falling back to "description"
-// (backward compatibility for older shell calls and transcripts), else empty. Pure
-// over the args map, so the promotion order is fuzzable in isolation.
+// decoded arguments: an explicit "intent" wins, falling back to "purpose" then
+// "description" (backward compatibility for older shell calls and transcripts),
+// else empty. Pure over the args map, so the promotion order is fuzzable in
+// isolation.
 func toolStartDescription(args map[string]any) string {
-	if purpose, ok := args["purpose"].(string); ok && purpose != "" {
-		return purpose
-	}
-	if desc, ok := args["description"].(string); ok && desc != "" {
-		return desc
+	for _, key := range []string{"intent", "purpose", "description"} {
+		if v, ok := args[key].(string); ok && v != "" {
+			return v
+		}
 	}
 	return ""
 }
@@ -1308,8 +1308,8 @@ func (s *Session) delegateAgentTypeNames() []string {
 
 // wireToolDef renders a canonical tool definition in its provider-visible wire
 // form: it renames the tool to the provider-specific name (nameMap is
-// canonical→provider) and adds the shared "purpose" parameter to work tools.
-// communicate/result tools omit purpose because their user-facing message and
+// canonical→provider) and adds the shared "intent" parameter to work tools.
+// communicate/result tools omit intent because their user-facing message and
 // strict output envelope already carry the result intent.
 func wireToolDef(td llm.ToolDefinition, nameMap map[string]string, resultToolName string) llm.ToolDefinition {
 	canonicalName := td.Name
@@ -1317,9 +1317,9 @@ func wireToolDef(td llm.ToolDefinition, nameMap map[string]string, resultToolNam
 		td.Name = mapped
 	}
 	if isResultToolDefinition(canonicalName, td.Name, resultToolName) {
-		return tool.WithoutPurposeParameter(td)
+		return tool.WithoutIntentParameter(td)
 	}
-	return tool.WithPurposeParameter(td)
+	return tool.WithIntentParameter(td)
 }
 
 func isResultToolDefinition(canonicalName, wireName, resultToolName string) bool {
@@ -1402,9 +1402,9 @@ func (s *Session) rebuildToolDefsCache() {
 	}
 	for i := range defs {
 		if isResultToolDefinition(defs[i].Name, defs[i].Name, s.resultToolName()) {
-			defs[i] = tool.WithoutPurposeParameter(defs[i])
+			defs[i] = tool.WithoutIntentParameter(defs[i])
 		} else {
-			defs[i] = tool.WithPurposeParameter(defs[i])
+			defs[i] = tool.WithIntentParameter(defs[i])
 		}
 	}
 

--- a/agent/session_tools_communicate.go
+++ b/agent/session_tools_communicate.go
@@ -30,8 +30,8 @@ func registerCommunicateTool(reg *tool.Registry, deps *toolDeps) {
 		resultToolDef = existing.Definition
 	}
 	_ = reg.Register(tool.RegisteredTool{
-		Definition:  resultToolDef,
-		OmitPurpose: true,
+		Definition: resultToolDef,
+		OmitIntent: true,
 		Exec: func(ctx context.Context, env execenv.ExecutionEnvironment, args map[string]any) (any, error) {
 			_ = env
 			if err := deps.abort(ctx); err != nil {

--- a/agent/session_tools_core_exact_fuzz_test.go
+++ b/agent/session_tools_core_exact_fuzz_test.go
@@ -85,7 +85,7 @@ func stceFileTools(t *testing.T) {
 		{"doc.pdf", "[document: doc.pdf]\n" + base64.StdEncoding.EncodeToString(validPDFFixture(t))},
 		{"plain.txt", "plain"},
 	} {
-		res := exec(&stceFileEnv{DenyEnv: &agenttest.DenyEnv{WorkDir: root}, readOutput: tc.output}, "read", "read_file", map[string]any{"file_path": tc.path, "offset": 1.0, "limit": 2.0, "purpose": "inspect"})
+		res := exec(&stceFileEnv{DenyEnv: &agenttest.DenyEnv{WorkDir: root}, readOutput: tc.output}, "read", "read_file", map[string]any{"file_path": tc.path, "offset": 1.0, "limit": 2.0, "intent": "inspect"})
 		if res.IsError || tracked != tc.path {
 			t.Fatalf("read %s = %#v tracked=%q", tc.path, res, tracked)
 		}

--- a/agent/session_tools_dispatch_fuzz_test.go
+++ b/agent/session_tools_dispatch_fuzz_test.go
@@ -160,8 +160,8 @@ func FuzzStoolDispatch(f *testing.F) {
 			t.Fatalf("execTool under canceled context did not report an error: %#v", skipped)
 		}
 
-		// A call whose args carry a bare "description" (no "purpose") exercises the
-		// event-description fallback branch.
+		// A call whose args carry a bare "description" (no "intent"/"purpose")
+		// exercises the event-description fallback branch.
 		descArgs, _ := json.Marshal(map[string]any{"path": r.str(), "description": r.str()})
 		stool_execOne(ctx, t, sess, "list_dir", descArgs)
 
@@ -341,8 +341,12 @@ func stool_structuredArgs(r *jobtools_reader, name string) map[string]any {
 	default:
 		m["k"] = r.str()
 	}
-	// Occasionally attach a stray purpose (the wire param) to exercise its strip.
+	// Occasionally attach a stray intent (the wire param) to exercise its strip.
 	if r.booln() {
+		m["intent"] = r.str()
+	} else if r.booln() {
+		// Backward-compat: a legacy "purpose" key is no longer stripped by the
+		// registry, but must not break dispatch (it passes through to handlers).
 		m["purpose"] = r.str()
 	}
 	return m

--- a/agent/session_tools_file.go
+++ b/agent/session_tools_file.go
@@ -23,18 +23,18 @@ func registerFileTools(reg *tool.Registry, deps *toolDeps) error {
 			path := fmt.Sprint(args["file_path"])
 			offset := optionalIntArg(args, "offset")
 			limit := optionalIntArg(args, "limit")
-			purpose, _ := args["purpose"].(string)
+			intent, _ := args["intent"].(string)
 			result, err := env.ReadFile(path, offset, limit)
 			if err == nil {
 				deps.readGuard.TrackRead(path)
 				// If the file is an image or document (PDF), return an
 				// tool.ImageResult so the vision side-channel can process it.
 				if img := tool.ParseImageResult(path, result); img != nil {
-					img.Purpose = purpose
+					img.Intent = intent
 					return *img, nil
 				}
 				if doc := tool.ParseDocumentResult(path, result); doc != nil {
-					doc.Purpose = purpose
+					doc.Intent = intent
 					return *doc, nil
 				}
 			}

--- a/agent/session_tools_misc_contract_fuzz_test.go
+++ b/agent/session_tools_misc_contract_fuzz_test.go
@@ -170,7 +170,7 @@ func stmRunRoundContracts(t *testing.T, program []byte) {
 	}
 
 	calls := []llm.ToolCallData{
-		stmCall(t, "read", "read_file", map[string]any{"file_path": value + ".txt", "purpose": "inspect " + value}),
+		stmCall(t, "read", "read_file", map[string]any{"file_path": value + ".txt", "intent": "inspect " + value}),
 		stmCall(t, "list", "list_dir", map[string]any{"path": ".", "depth": float64(r.next()%3 + 1), "offset": float64(r.next() % 3), "limit": float64(r.next()%4 + 1)}),
 		stmCall(t, "grep", "grep", map[string]any{"pattern": value, "path": ".", "output_mode": []string{"content", "count", "files_with_matches"}[int(r.next())%3]}),
 		stmCall(t, "glob", "glob", map[string]any{"pattern": "*." + value, "path": "."}),
@@ -297,7 +297,7 @@ func stmRunRoundContracts(t *testing.T, program []byte) {
 		mediaType = "application/pdf"
 		wantKind = llm.ContentDocument
 	}
-	if description := s.describeImage(ctx, tool.ExecResult{ImageData: []byte("fixture-" + value), ImageMediaType: mediaType, ImagePurpose: "describe " + value}); description != "scripted vision" {
+	if description := s.describeImage(ctx, tool.ExecResult{ImageData: []byte("fixture-" + value), ImageMediaType: mediaType, ImageIntent: "describe " + value}); description != "scripted vision" {
 		t.Fatalf("scripted image description = %q", description)
 	}
 	requests := adapter.Requests()

--- a/agent/session_vision_effort_test.go
+++ b/agent/session_vision_effort_test.go
@@ -56,7 +56,7 @@ func TestDescribeImage_ClampsEffortToProfileLevels(t *testing.T) {
 	desc := sess.describeImage(context.Background(), tool.ExecResult{
 		ImageData:      []byte("fake-png-bytes"),
 		ImageMediaType: "image/png",
-		ImagePurpose:   "what is in this image",
+		ImageIntent:    "what is in this image",
 	})
 	if desc != visionOutputSentinel {
 		t.Fatalf("describeImage output sentinel = %q", desc)

--- a/agent/session_vision_model_test.go
+++ b/agent/session_vision_model_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func visionImageResult() tool.ExecResult {
-	return tool.ExecResult{ImageData: []byte("fake-png"), ImageMediaType: "image/png", ImagePurpose: "describe it"}
+	return tool.ExecResult{ImageData: []byte("fake-png"), ImageMediaType: "image/png", ImageIntent: "describe it"}
 }
 
 func TestDescribeImage_OffMakesNoCall(t *testing.T) {

--- a/agent/transcript_render.go
+++ b/agent/transcript_render.go
@@ -13,6 +13,7 @@ import (
 
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/internal/toolargs"
 	"primeradiant.com/evener/llm"
 )
 
@@ -1436,14 +1437,7 @@ func toolIntent(args json.RawMessage) string {
 	if m == nil {
 		return ""
 	}
-	for _, key := range []string{"intent", "purpose", "description"} {
-		if v, ok := m[key]; ok {
-			if s := scalarString(v); s != "" {
-				return s
-			}
-		}
-	}
-	return ""
+	return toolargs.FirstNonEmpty(func(key string) string { return scalarString(m[key]) }, "intent", "purpose", "description")
 }
 
 // parseArgs decodes tool-call arguments into a map, or nil on any error.

--- a/agent/transcript_render.go
+++ b/agent/transcript_render.go
@@ -954,8 +954,8 @@ func writeToolCard(b *strings.Builder, callOwnerSeq int, tc *llm.ToolCallData, i
 // header line for a tool card. The purpose segment is omitted when absent.
 func writeToolCardLine(b *strings.Builder, status, name string, args json.RawMessage) {
 	fmt.Fprintf(b, "- [%s] `%s`", status, name)
-	if purpose := toolPurpose(args); purpose != "" {
-		fmt.Fprintf(b, " — purpose: %s", purpose)
+	if intent := toolIntent(args); intent != "" {
+		fmt.Fprintf(b, " — intent: %s", intent)
 	}
 	fmt.Fprintf(b, " — input: %s\n", toolInputSummary(name, args))
 }
@@ -1428,15 +1428,15 @@ func indentLines(lines []string) string {
 	return b.String()
 }
 
-// toolPurpose returns the value of an explicit purpose/intent/description
-// argument, or "" if none is present. Purpose is never inferred from commands
+// toolIntent returns the value of an explicit intent/purpose/description
+// argument, or "" if none is present. Intent is never inferred from commands
 // or paths. Spec §Tool Call Condensation.
-func toolPurpose(args json.RawMessage) string {
+func toolIntent(args json.RawMessage) string {
 	m := parseArgs(args)
 	if m == nil {
 		return ""
 	}
-	for _, key := range []string{"purpose", "intent", "description"} {
+	for _, key := range []string{"intent", "purpose", "description"} {
 		if v, ok := m[key]; ok {
 			if s := scalarString(v); s != "" {
 				return s

--- a/agent/transcript_render_fuzz_test.go
+++ b/agent/transcript_render_fuzz_test.go
@@ -402,7 +402,7 @@ func FuzzToolInputSummary(f *testing.F) {
 		name string
 		args string
 	}{
-		{"shell", `{"command":"ls -la /tmp","purpose":"look"}`},
+		{"shell", `{"command":"ls -la /tmp","intent":"look"}`},
 		{"read_file", `{"file_path":"/a/b.go","offset":10,"limit":50}`},
 		{"write_file", `{"file_path":"/a/b.go","content":"package main"}`},
 		{"edit_file", `{"file_path":"/a","old_string":"x","new_string":"yy","replace_all":true}`},
@@ -716,7 +716,7 @@ func trender_program(program []byte, payload string) (transcript.Header, []trans
 				llm.ContentPart{Kind: llm.ContentThinking, Thinking: &llm.ThinkingData{Text: "think " + payload}},
 				llm.ContentPart{Kind: llm.ContentRedThinking},
 				part(llm.ContentText, "assistant "+payload),
-				call("call-shell", "shell", `{"command":"printf hi","purpose":"inspect"}`),
+				call("call-shell", "shell", `{"command":"printf hi","intent":"inspect"}`),
 				call("call-result", "communicate", `{"message":"done"}`),
 				llm.ContentPart{Kind: llm.ContentToolCall},
 			),

--- a/agent/transcript_render_lookup_exact_fuzz_test.go
+++ b/agent/transcript_render_lookup_exact_fuzz_test.go
@@ -84,7 +84,7 @@ func rleRenderEdges(t *testing.T, payload string) {
 	t.Helper()
 	rleAssertRenderScenarios(t, payload)
 	for _, tc := range []struct{ name, args, want string }{
-		{"shell", `{"command":"ls","purpose":"inspect"}`, "ls"},
+		{"shell", `{"command":"ls","intent":"inspect"}`, "ls"},
 		{"read_file", `{"file_path":"/tmp/a","offset":1,"limit":2}`, "/tmp/a (offset 1, limit 2)"},
 		{"write_file", `{"file_path":"/tmp/a","content":"x"}`, "/tmp/a (1 bytes)"},
 		{"edit_file", `{"file_path":"/tmp/a","old_string":"x","new_string":"y","replace_all":true}`, "/tmp/a (replace 1→1 chars, all)"},
@@ -312,17 +312,18 @@ func rleRenderContracts(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		raw         json.RawMessage
-		wantPurpose string
-		wantParsed  bool
+		raw        json.RawMessage
+		wantIntent string
+		wantParsed bool
 	}{
 		{nil, "", false}, {json.RawMessage("{"), "", false},
-		{json.RawMessage(`{"purpose":false}`), "false", true},
+		{json.RawMessage(`{"intent":false}`), "false", true},
+		{json.RawMessage(`{"purpose":"legacy"}`), "legacy", true},
 		{json.RawMessage(`{"intent":"why"}`), "why", true},
 		{json.RawMessage(`{"description":"what"}`), "what", true},
 	} {
-		if got := toolPurpose(tc.raw); got != tc.wantPurpose {
-			t.Fatalf("toolPurpose(%q) = %q, want %q", tc.raw, got, tc.wantPurpose)
+		if got := toolIntent(tc.raw); got != tc.wantIntent {
+			t.Fatalf("toolIntent(%q) = %q, want %q", tc.raw, got, tc.wantIntent)
 		}
 		if parsed := parseArgs(tc.raw); (parsed != nil) != tc.wantParsed {
 			t.Fatalf("parseArgs(%q) parsed=%v, wantParsed=%v", tc.raw, parsed, tc.wantParsed)

--- a/agent/transcript_render_test.go
+++ b/agent/transcript_render_test.go
@@ -999,29 +999,29 @@ func TestRenderMarkdown_ResultToolResultNotOrphaned(t *testing.T) {
 	}
 }
 
-// TestRenderMarkdown_PurposeField verifies purpose: appears only when an explicit
-// purpose/intent/description argument is present.
-func TestRenderMarkdown_PurposeField(t *testing.T) {
+// TestRenderMarkdown_IntentField verifies intent: appears only when an explicit
+// intent/purpose/description argument is present.
+func TestRenderMarkdown_IntentField(t *testing.T) {
 	t.Parallel()
-	t.Run("purpose present when explicit purpose arg given", func(t *testing.T) {
+	t.Run("intent present when explicit intent arg given", func(t *testing.T) {
 		entries := []transcript.Entry{
-			toolCallEntry(call("c1", "shell", `{"command":"ls","purpose":"list the directory"}`)),
+			toolCallEntry(call("c1", "shell", `{"command":"ls","intent":"list the directory"}`)),
 			toolResultEntry(result("c1", "shell", "file.go", false)),
 		}
 		out := renderMarkdown(transcript.Header{}, entries, 0, renderOpts{})
-		if !strings.Contains(out, "purpose: list the directory") {
-			t.Errorf("expected purpose segment from explicit purpose arg, got:\n%s", out)
+		if !strings.Contains(out, "intent: list the directory") {
+			t.Errorf("expected intent segment from explicit intent arg, got:\n%s", out)
 		}
 	})
 
-	t.Run("no purpose segment when absent", func(t *testing.T) {
+	t.Run("no intent segment when absent", func(t *testing.T) {
 		entries := []transcript.Entry{
 			toolCallEntry(call("c1", "shell", `{"command":"ls"}`)),
 			toolResultEntry(result("c1", "shell", "file.go", false)),
 		}
 		out := renderMarkdown(transcript.Header{}, entries, 0, renderOpts{})
-		if strings.Contains(out, "purpose:") {
-			t.Errorf("purpose segment must be omitted when no purpose/intent/description arg, got:\n%s", out)
+		if strings.Contains(out, "intent:") {
+			t.Errorf("intent segment must be omitted when no intent/purpose/description arg, got:\n%s", out)
 		}
 	})
 
@@ -1031,8 +1031,8 @@ func TestRenderMarkdown_PurposeField(t *testing.T) {
 			toolResultEntry(result("c1", "grep", "match", false)),
 		}
 		out := renderMarkdown(transcript.Header{}, entries, 0, renderOpts{})
-		if !strings.Contains(out, "purpose: find the symbol") {
-			t.Errorf("expected purpose from intent arg, got:\n%s", out)
+		if !strings.Contains(out, "intent: find the symbol") {
+			t.Errorf("expected intent from intent arg, got:\n%s", out)
 		}
 	})
 }

--- a/cmd/evener-doctor/study_runbooks_test.go
+++ b/cmd/evener-doctor/study_runbooks_test.go
@@ -213,7 +213,7 @@ func TestRun_AuditErrorLoopBundledRunbook_HealthyEmitsZero(t *testing.T) {
 // inBandMCPErrorLoopTurns reproduces the real-world session shape the
 // 2026-08-06 final review found the identical-run check blind to: a tool
 // call (like use_browser) whose arguments carry a free-text field the model
-// varies every call (here "purpose"), fragmenting longest_identical_run's
+// varies every call (here "intent"), fragmenting longest_identical_run's
 // signature well below the check's threshold even though the underlying
 // action repeats; and a failure reported in-band inside a successful result
 // (is_error=false, "Error: ..." text) rather than via the transport error
@@ -229,7 +229,7 @@ func inBandMCPErrorLoopTurns() []schema.Turn {
 	}
 	for i, purpose := range purposes {
 		id := fmt.Sprintf("mcp%d", i)
-		args := fmt.Sprintf(`{"action":"screenshot","purpose":%q}`, purpose)
+		args := fmt.Sprintf(`{"action":"screenshot","intent":%q}`, purpose)
 		turns = append(turns,
 			schema.NewTurn(schema.TurnAssistant, llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{
 				studyToolCall(id, "use_browser", args),

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -1046,7 +1046,7 @@ func TestAppItemsFromReplayTurnAcceptsCurrentToolCallKind(t *testing.T) {
 			ToolCall: &llm.ToolCallData{
 				ID:        "call_read",
 				Name:      "read_file",
-				Arguments: []byte(`{"file_path":"/tmp/example.txt","purpose":"Inspect example output."}`),
+				Arguments: []byte(`{"file_path":"/tmp/example.txt","intent":"Inspect example output."}`),
 			},
 		}}},
 	}, toolNames)

--- a/cmd/evener-tui/internal/msgrender/message.go
+++ b/cmd/evener-tui/internal/msgrender/message.go
@@ -292,9 +292,12 @@ func RenderToolCall(tc transcript.ToolCallInfo, width int, focused bool) string 
 	}
 
 	var bodyLines []string
-	if purpose := strings.TrimSpace(args.Str("purpose")); purpose != "" {
-		purposeLine := lipgloss.NewStyle().Italic(true).Render(purpose)
-		bodyLines = append(bodyLines, indentBlock(purposeLine, th.IndentToolBody))
+	for _, key := range []string{"intent", "purpose"} {
+		if v := strings.TrimSpace(args.Str(key)); v != "" {
+			line := lipgloss.NewStyle().Italic(true).Render(v)
+			bodyLines = append(bodyLines, indentBlock(line, th.IndentToolBody))
+			break
+		}
 	}
 
 	// Show expanded body: renderer Body func takes priority; fall back to

--- a/cmd/evener-tui/internal/msgrender/message.go
+++ b/cmd/evener-tui/internal/msgrender/message.go
@@ -15,6 +15,7 @@ import (
 	"primeradiant.com/evener/cmd/evener-tui/internal/transcript"
 	"primeradiant.com/evener/cmd/evener-tui/internal/tuiprim"
 	"primeradiant.com/evener/cmd/evener-tui/internal/tuitheme"
+	"primeradiant.com/evener/internal/toolargs"
 	"primeradiant.com/evener/llm"
 )
 
@@ -292,12 +293,9 @@ func RenderToolCall(tc transcript.ToolCallInfo, width int, focused bool) string 
 	}
 
 	var bodyLines []string
-	for _, key := range []string{"intent", "purpose"} {
-		if v := strings.TrimSpace(args.Str(key)); v != "" {
-			line := lipgloss.NewStyle().Italic(true).Render(v)
-			bodyLines = append(bodyLines, indentBlock(line, th.IndentToolBody))
-			break
-		}
+	if v := toolargs.FirstNonEmpty(func(key string) string { return strings.TrimSpace(args.Str(key)) }, "intent", "purpose"); v != "" {
+		line := lipgloss.NewStyle().Italic(true).Render(v)
+		bodyLines = append(bodyLines, indentBlock(line, th.IndentToolBody))
 	}
 
 	// Show expanded body: renderer Body func takes priority; fall back to

--- a/cmd/evener-tui/internal/msgrender/message_test.go
+++ b/cmd/evener-tui/internal/msgrender/message_test.go
@@ -244,7 +244,33 @@ func TestRenderToolCallUsesStructuredSubagentBody(t *testing.T) {
 	}
 }
 
-func TestRenderToolCallShowsPurposeAsFirstBodyLine(t *testing.T) {
+func TestRenderToolCallShowsIntentAsFirstBodyLine(t *testing.T) {
+	withTestColorProfile(t)
+	tc := transcript.ToolCallInfo{
+		Name:     "exec_command",
+		RawArgs:  `{"command":"go test ./cmd/evener-tui","intent":"Verify tool renderer intent display"}`,
+		Output:   "ok",
+		Duration: 50 * time.Millisecond,
+		Done:     true,
+		Expanded: true,
+	}
+
+	got := RenderToolCall(tc, 100, false)
+	lines := strings.Split(got, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected intent body line under header, got %q", got)
+	}
+	if !strings.Contains(lines[1], "Verify tool renderer intent display") {
+		t.Fatalf("first body line = %q, want intent text; full render:\n%q", lines[1], got)
+	}
+	if !strings.Contains(lines[1], "\x1b[3m") {
+		t.Fatalf("first body line should be italic-styled, got %q", lines[1])
+	}
+}
+
+// TestRenderToolCallShowsLegacyPurposeAsFirstBodyLine verifies the older
+// "purpose" wire key still renders as the body line (intent takes priority).
+func TestRenderToolCallShowsLegacyPurposeAsFirstBodyLine(t *testing.T) {
 	withTestColorProfile(t)
 	tc := transcript.ToolCallInfo{
 		Name:     "exec_command",

--- a/cmd/evener-tui/internal/msgrender/tool_renderers_fuzz_test.go
+++ b/cmd/evener-tui/internal/msgrender/tool_renderers_fuzz_test.go
@@ -30,7 +30,7 @@ func FuzzRenderToolCall(f *testing.F) {
 		name, args, output, errStr string
 	}{
 		{"read_file", `{"file_path":"/a/b.go","offset":1,"limit":5}`, "line\nline", ""},
-		{"shell", `{"command":"ls -la","purpose":"list"}`, "out", ""},
+		{"shell", `{"command":"ls -la","intent":"list"}`, "out", ""},
 		{"edit_file", `{"file_path":"/a.go","old_string":"x","new_string":"y"}`, "", ""},
 		{"grep", `{"pattern":"TODO"}`, "match", ""},
 		{"glob", `{"pattern":"**/*"}`, "", "boom"},
@@ -135,7 +135,7 @@ func replayRenderSurface() {
 	toolCases := []transcript.ToolCallInfo{
 		{Name: "unknown", RawArgs: `{"purpose":"why"}`, Expanded: false},
 		{Name: "read_file", Description: ` {"file_path":"x.go"}`, Done: true, Duration: 500 * time.Microsecond},
-		{Name: "read_file", RawArgs: `{"file_path":"x.go","purpose":"inspect"}`, Output: "a\nb\nc\nd\ne\nf\n", Done: true, Expanded: true, Duration: 250 * time.Millisecond},
+		{Name: "read_file", RawArgs: `{"file_path":"x.go","intent":"inspect"}`, Output: "a\nb\nc\nd\ne\nf\n", Done: true, Expanded: true, Duration: 250 * time.Millisecond},
 		{Name: "read_file", RawArgs: `{"file_path":"x.go"}`, Detail: "detail", Output: "output", Error: "boom", Expanded: true},
 		{Name: "read_file", RawArgs: `{"file_path":"x.go"}`, Detail: "detail", Error: "boom", Expanded: true},
 		{Name: "delegate", RawArgs: `{"task":"inspect"}`, Error: "boom", Expanded: true, Subagent: &transcript.SubagentRunInfo{Task: "inspect", Status: "done"}},
@@ -152,7 +152,7 @@ func replayRenderSurface() {
 
 	args := ToolArgs{
 		"command": "first line\nsecond line", "pattern": "TODO", "path": "/tmp", "file_path": "x.go",
-		"purpose": "why", "query": "find", "task": "task", "job_id": "123456789", "status": "done",
+		"intent": "why", "query": "find", "task": "task", "job_id": "123456789", "status": "done",
 		"patch": "*** Update File: x.go\n@@ -1 +1 @@\n-old\n+new", "content": "a\nb",
 	}
 	_ = args.Str("missing")

--- a/cmd/evener-tui/internal/msgrender/tool_renderers_test.go
+++ b/cmd/evener-tui/internal/msgrender/tool_renderers_test.go
@@ -91,7 +91,7 @@ func TestJobControlTargetsKeepSameOwnerJobSuffixesDistinct(t *testing.T) {
 
 func TestShellRenderer(t *testing.T) {
 	r, _ := lookupToolRenderer("shell")
-	args := toolArgsFromJSON(`{"command":"ls -la","purpose":"List home dir"}`)
+	args := toolArgsFromJSON(`{"command":"ls -la","intent":"List home dir"}`)
 	if r.Verb(args) != "shell" {
 		t.Errorf("shell verb = %q", r.Verb(args))
 	}

--- a/cmd/evener-tui/internal/toolsummary/tool_summary.go
+++ b/cmd/evener-tui/internal/toolsummary/tool_summary.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alecthomas/chroma/v2/formatters"
 	"github.com/alecthomas/chroma/v2/lexers"
 	"github.com/alecthomas/chroma/v2/styles"
+	"primeradiant.com/evener/internal/toolargs"
 )
 
 // SummarizeTool summarizes without a known session cwd: the redundant-cd
@@ -57,14 +58,6 @@ func SummarizeToolInDir(toolName, argsJSON, cwd string) (desc, detail string) {
 		v, _ := args[key].(string)
 		return v
 	}
-	firstNonEmpty := func(get func(string) string, keys ...string) string {
-		for _, k := range keys {
-			if v := get(k); v != "" {
-				return v
-			}
-		}
-		return ""
-	}
 	num := func(key string) (int, bool) {
 		v, ok := args[key].(float64)
 		return int(v), ok
@@ -81,7 +74,7 @@ func SummarizeToolInDir(toolName, argsJSON, cwd string) (desc, detail string) {
 	case "shell":
 		cmd := str("command")
 		cmd = stripRedundantCd(cmd, cwd)
-		if d := firstNonEmpty(str, "intent", "purpose", "description"); d != "" {
+		if d := toolargs.FirstNonEmpty(str, "intent", "purpose", "description"); d != "" {
 			desc = trunc(d, 80)
 		} else {
 			// Show first line as desc; full command as detail if multi-line.

--- a/cmd/evener-tui/internal/toolsummary/tool_summary.go
+++ b/cmd/evener-tui/internal/toolsummary/tool_summary.go
@@ -57,6 +57,14 @@ func SummarizeToolInDir(toolName, argsJSON, cwd string) (desc, detail string) {
 		v, _ := args[key].(string)
 		return v
 	}
+	firstNonEmpty := func(get func(string) string, keys ...string) string {
+		for _, k := range keys {
+			if v := get(k); v != "" {
+				return v
+			}
+		}
+		return ""
+	}
 	num := func(key string) (int, bool) {
 		v, ok := args[key].(float64)
 		return int(v), ok
@@ -73,10 +81,7 @@ func SummarizeToolInDir(toolName, argsJSON, cwd string) (desc, detail string) {
 	case "shell":
 		cmd := str("command")
 		cmd = stripRedundantCd(cmd, cwd)
-		if d := str("purpose"); d != "" {
-			desc = trunc(d, 80)
-		} else if d := str("description"); d != "" {
-			// Backward compatibility for older transcripts.
+		if d := firstNonEmpty(str, "intent", "purpose", "description"); d != "" {
 			desc = trunc(d, 80)
 		} else {
 			// Show first line as desc; full command as detail if multi-line.

--- a/cmd/evener-tui/internal/toolsummary/tool_summary_fuzz_test.go
+++ b/cmd/evener-tui/internal/toolsummary/tool_summary_fuzz_test.go
@@ -15,7 +15,7 @@ func FuzzSummarizeTool(f *testing.F) {
 		tool string
 		args string
 	}{
-		{"shell", `{"command":"ls -la","purpose":"list"}`},
+		{"shell", `{"command":"ls -la","intent":"list"}`},
 		{"read_file", `{"file_path":"/a/b/c.go","offset":10,"limit":20}`},
 		{"write_file", `{"file_path":"/a/b.go","content":"x\ny\nz"}`},
 		{"edit_file", `{"file_path":"/a.go","old_string":"foo","new_string":"bar"}`},

--- a/cmd/evener-tui/internal/toolsummary/tool_summary_test.go
+++ b/cmd/evener-tui/internal/toolsummary/tool_summary_test.go
@@ -6,7 +6,16 @@ import (
 	"testing"
 )
 
-func TestSummarizeTool_Shell_WithPurpose(t *testing.T) {
+func TestSummarizeTool_Shell_WithIntent(t *testing.T) {
+	desc, _ := SummarizeTool("shell", `{"command":"ls -la /tmp","intent":"list temp files"}`)
+	if desc != "list temp files" {
+		t.Errorf("got %q", desc)
+	}
+}
+
+// TestSummarizeTool_Shell_WithLegacyPurpose verifies the older "purpose" wire
+// key still works as a backward-compat fallback (intent takes priority).
+func TestSummarizeTool_Shell_WithLegacyPurpose(t *testing.T) {
 	desc, _ := SummarizeTool("shell", `{"command":"ls -la /tmp","purpose":"list temp files"}`)
 	if desc != "list temp files" {
 		t.Errorf("got %q", desc)

--- a/internal/appprojector/appwire_projection.go
+++ b/internal/appprojector/appwire_projection.go
@@ -684,9 +684,9 @@ func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification
 			OutputImages:  projectOutputImages(data.OutputImages),
 			Status:        apptranscript.SettledToolStatus(data.Error != ""),
 			Raw:           raw,
-			// Carry the call's purpose onto the completed item too (#26):
+			// Carry the call's intent onto the completed item too (#26):
 			// the started item already has it, and live consumers (the web
-			// subagent activity line) render the purpose from Description.
+			// subagent activity line) render the intent from Description.
 			Description: apptranscript.ToolIntentFromArguments(json.RawMessage(argsJSON)),
 			// ExitCode promotes the shell tool's exit code, already riding
 			// data.ToolState end to end (agent/session_tools_shell.go:483

--- a/internal/apptranscript/apptranscript.go
+++ b/internal/apptranscript/apptranscript.go
@@ -13,6 +13,7 @@ import (
 	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/envvars"
+	"primeradiant.com/evener/internal/toolargs"
 	"primeradiant.com/evener/invariant"
 	"primeradiant.com/evener/llm"
 )
@@ -158,14 +159,12 @@ func ToolIntentFromArguments(raw json.RawMessage) string {
 	if len(raw) == 0 || json.Unmarshal(raw, &args) != nil {
 		return ""
 	}
-	for _, key := range []string{"intent", "purpose", "description"} {
+	return toolargs.FirstNonEmpty(func(key string) string {
 		if value, ok := args[key].(string); ok {
-			if trimmed := strings.TrimSpace(value); trimmed != "" {
-				return trimmed
-			}
+			return strings.TrimSpace(value)
 		}
-	}
-	return ""
+		return ""
+	}, "intent", "purpose", "description")
 }
 
 // ExitCodeFromToolState extracts a shell tool call's process exit code from

--- a/internal/toolargs/toolargs.go
+++ b/internal/toolargs/toolargs.go
@@ -1,0 +1,28 @@
+// Package toolargs holds shared helpers for reading common tool-argument
+// fields from decoded JSON args.
+//
+// The intent reader family (toolStartDescription, toolIntent,
+// ToolIntentFromArguments, and the TUI toolsummary/msgrender renderers) all
+// resolve a tool call's short description the same way: walk a fixed list of
+// candidate keys in priority order and return the first one whose extracted
+// value is non-empty. The per-site behavior that differs — which keys to
+// consider, how a value is extracted from the decoded map, and whether
+// surrounding whitespace is trimmed — is captured entirely in each caller's
+// get closure and key list, so sharing the selection loop changes no
+// behavior. FirstNonEmpty is that loop.
+package toolargs
+
+// FirstNonEmpty returns the first non-empty result of get for the given keys,
+// in order. It is the shared key-selection loop duplicated by the intent
+// readers across agent/, internal/apptranscript, and cmd/evener-tui/internal.
+// get decides how a key maps to a string (string-only, scalar coercion, with
+// or without strings.TrimSpace); the caller passes the key set. An empty
+// string from get is treated as "absent" and the next key is tried.
+func FirstNonEmpty(get func(string) string, keys ...string) string {
+	for _, key := range keys {
+		if v := get(key); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/toolargs/toolargs_test.go
+++ b/internal/toolargs/toolargs_test.go
@@ -1,0 +1,48 @@
+package toolargs
+
+import "testing"
+
+func TestFirstNonEmpty(t *testing.T) {
+	get := func(m map[string]string) func(string) string {
+		return func(k string) string { return m[k] }
+	}
+	tests := []struct {
+		name string
+		m    map[string]string
+		keys []string
+		want string
+	}{
+		{"first wins", map[string]string{"intent": "a", "purpose": "b"}, []string{"intent", "purpose"}, "a"},
+		{"fallback to second", map[string]string{"purpose": "b"}, []string{"intent", "purpose"}, "b"},
+		{"empty first skipped", map[string]string{"intent": "", "purpose": "b"}, []string{"intent", "purpose"}, "b"},
+		{"all empty -> empty", map[string]string{"intent": "", "purpose": ""}, []string{"intent", "purpose"}, ""},
+		{"no keys -> empty", map[string]string{"intent": "a"}, nil, ""},
+		{"missing key skipped", map[string]string{"description": "d"}, []string{"intent", "purpose", "description"}, "d"},
+		{"single key", map[string]string{"intent": "x"}, []string{"intent"}, "x"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FirstNonEmpty(get(tc.m), tc.keys...); got != tc.want {
+				t.Fatalf("FirstNonEmpty(%v, %v) = %q, want %q", tc.m, tc.keys, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFirstNonEmptyDeterministic(t *testing.T) {
+	get := func(k string) string {
+		switch k {
+		case "intent":
+			return "why"
+		case "purpose":
+			return "fallback"
+		}
+		return ""
+	}
+	keys := []string{"intent", "purpose", "description"}
+	a := FirstNonEmpty(get, keys...)
+	b := FirstNonEmpty(get, keys...)
+	if a != b || a != "why" {
+		t.Fatalf("non-deterministic or wrong: %q vs %q", a, b)
+	}
+}


### PR DESCRIPTION
## Summary

The "read intent from tool args" logic was duplicated at **5 sites** across packages that cannot import each other. Each site walks a fixed list of candidate keys (`intent`/`purpose`/`description`) and returns the first non-empty value, but varies in how it extracts a string from the decoded map and whether it trims whitespace.

This PR extracts the shared key-selection loop into `internal/toolargs.FirstNonEmpty(get func(string) string, keys ...string) string`, consolidating the duplication **without changing any function signature**. Each call site keeps its exact extraction behavior inside its `get` closure.

## The 5 sites

| # | Site | Input | Keys | Extraction | TrimSpace |
|---|------|-------|------|------------|-----------|
| 1 | `toolStartDescription` (`agent/session_tools.go`) | `map[string]any` | intent, purpose, description | string-only | no |
| 2 | `toolIntent` (`agent/transcript_render.go`) | `json.RawMessage` | intent, purpose, description | `scalarString` (bool/num coercion) | no |
| 3 | `ToolIntentFromArguments` (`internal/apptranscript/apptranscript.go`) | `json.RawMessage` | intent, purpose, description | string-only | yes |
| 4 | `SummarizeToolInDir` (`cmd/evener-tui/internal/toolsummary/tool_summary.go`) | `map[string]any` | intent, purpose, description | string-only | no (downstream `trunc`) |
| 5 | `RenderToolCall` (`cmd/evener-tui/internal/msgrender/message.go`) | `ToolArgs` map | intent, purpose | string-only | yes |

## Why a shared helper is feasible

The **selection loop** ("iterate keys, return first non-empty") is genuinely duplicated. Site 4 already factored it into a *local* `firstNonEmpty` helper — this PR lifts that same helper to a module-root `internal/` package so all 5 sites share it.

The **per-site variation** (string-only vs scalar coercion, TrimSpace vs none, 2-key vs 3-key) is *not* duplicated — it's genuinely different behavior. The parameterized `FirstNonEmpty` preserves all of it via each caller's `get` closure and key list, so:

- No function signature changes (no behavior change)
- All test-pinned behaviors preserved, including `toolIntent`'s scalar coercion (`{"intent":false}` → `"false"`) and the TrimSpace / 2-key differences

## Changes

- **New**: `internal/toolargs/toolargs.go` + test — `FirstNonEmpty(get func(string) string, keys ...string) string`
- 5 call sites refactored to use `toolargs.FirstNonEmpty`
- Removed toolsummary's local `firstNonEmpty` helper (identical copy of the now-shared loop)
- Net: -17 lines (35 deletions, 18 insertions across modified files)

## Verification

- `gofmt -w` clean on all changed files
- `make vet` passes (go vet across every workspace module)
- `go test` passes for all changed packages: `agent`, `internal/apptranscript`, `internal/toolargs`, `cmd/evener-tui/internal/toolsummary`, `cmd/evener-tui/internal/msgrender`
- Targeted behavior-preservation tests pass:
  - `TestToolIntentFromArguments` (site 3)
  - `TestS3Cov_ToolIntent` / `TestS3Cov_ScalarStringAndFormatNumber` (site 2, incl. scalar coercion)
  - `TestSummarizeTool_Shell_WithIntent` / `_WithLegacyPurpose` (site 4)
  - `TestRenderToolCallShowsIntentAsFirstBodyLine` / `TestRenderToolCallShowsLegacyPurposeAsFirstBodyLine` (site 5)

## Note on `make test`

`make test` fails in this worktree due to an **environmental sandbox restriction**, not a code issue: `/bin/ps` is blocked (`Operation not permitted`), which breaks two pre-existing tests that inspect process state:
- `agent/execenv.TestStreamCommandSignalKillsWholeProcessGroup` (uses `/bin/ps` + `/proc/.../cmdline`)
- `cmd/evener-hub/frontend` `browserGuardProcessCrashpadLeak` (uses `/bin/ps`)

Neither test is related to this change (pure Go, no `execenv`/frontend files touched). The Go-only gate (`WEB=0`) and direct `go test` of all changed packages both pass.