### PR TITLE
feat: unify mobile welcome screen and sidebar into expandable bottom panel

### DIFF
--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/welcome-resume-candidate-overflow/assert.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/welcome-resume-candidate-overflow/assert.mjs
@@ -4,14 +4,10 @@
 //   column past the pane body. When it does, PaneScaffold's .body
 //   overflow-x:clip slices the centered button symmetrically into a
 //   marker-less mid-string fragment (leftClippedPx/rightClippedPx both
-//   positive), and .examples' width:min(100%,36rem) resolves its 100% against
-//   the inflated column, stretching every suggestion button past the viewport.
+//   positive), stretching the column past the viewport.
 // - The fix (white-space:normal on the resume button) must not reintroduce
 //   the bug button.module.css's nowrap exists to prevent: a wrapped label
 //   spilling out of a fixed-height box (scrollHeight > clientHeight).
-// - The .examples buttons keep their deliberate text-align:left
-//   (welcome.module.css's own .examples button rule) - an .actions-scoped
-//   override written after it, at equal specificity, silently recenters them.
 const TOLERANCE = 1;
 
 export default function assert(measurements) {
@@ -48,24 +44,14 @@ export default function assert(measurements) {
 
     contained("New session button", m.newSession);
 
-    if (m.examples.length !== 3) failures.push(`${tag}: expected 3 example buttons, found ${m.examples.length}`);
-    m.examples.forEach((box, i) => {
-      contained(`example button ${i + 1}`, box);
-      fitsVertically(`example button ${i + 1}`, box);
-      if (box.textAlign !== "left") {
-        failures.push(
-          `${tag}: example button ${i + 1} computed text-align is ${box.textAlign}, expected left (welcome.module.css's .examples button rule was overridden)`,
-        );
-      }
-    });
-
     for (const [name, rect] of [
       ["welcome .actions column", m.actions],
-      [".examples container", m.examplesDiv],
       [".hints container", m.hints],
     ]) {
       if (rect.width > bodyWidth + TOLERANCE) {
-        failures.push(`${tag}: ${name} is ${rect.width.toFixed(1)}px wide inside a ${bodyWidth.toFixed(1)}px pane body`);
+        failures.push(
+          `${tag}: ${name} is ${rect.width.toFixed(1)}px wide inside a ${bodyWidth.toFixed(1)}px pane body`,
+        );
       }
     }
   }
@@ -73,7 +59,10 @@ export default function assert(measurements) {
   return failures.length === 0
     ? {
         pass: true,
-        reason: `resume button, suggestions, and hints stay inside the pane body at ${measurements.map((m) => m.width).filter((w, i, a) => a.indexOf(w) === i).join("/")}px, the wrapped title fits its box, and the example buttons stay left-aligned`,
+        reason: `resume button and hints stay inside the pane body at ${measurements
+          .map((m) => m.width)
+          .filter((w, i, a) => a.indexOf(w) === i)
+          .join("/")}px and the wrapped title fits its box`,
       }
     : { pass: false, reason: failures.join("; ") };
 }

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/welcome-resume-candidate-overflow/case.json
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/welcome-resume-candidate-overflow/case.json
@@ -1,6 +1,6 @@
 {
   "name": "welcome-resume-candidate-overflow",
-  "description": "Welcome pane (issue #197): a 200-rune resume-candidate title, forced to white-space:nowrap by button.module.css, must not inflate the centered .actions column past the pane body - PaneScaffold's overflow-x:clip would slice it into a marker-less mid-string fragment and stretch the .examples buttons past the viewport. The wrapped title must also fit INSIDE the button box vertically (no fixed-height spill), and the example buttons keep their deliberate left alignment.",
+  "description": "Welcome pane (issue #197): a 200-rune resume-candidate title, forced to white-space:nowrap by button.module.css, must not inflate the centered .actions column past the pane body - PaneScaffold's overflow-x:clip would slice it into a marker-less mid-string fragment and stretch the column past the viewport. The wrapped title must also fit INSIDE the button box vertically (no fixed-height spill). The example prompt buttons were removed from the product; this probe now asserts only the resume button, the New session button, and the hints staying inside the pane body.",
   "viewport": {
     "width": 390,
     "height": 844,
@@ -17,7 +17,7 @@
   ],
   "widthMatrix": [{ "width": 320 }, { "width": 360 }, { "width": 390 }],
   "mutation": {
-    "declaration": "panes/welcome/welcome.module.css: .actions button { white-space: normal } (deleted - fails with the full #197 shape: resume button 1163px wide, symmetric double-ended clip, examples stretched to 576px); .actions button { height: auto } (deleted - fails with the wrapped label spilling 19-27px out of its fixed-height box)",
+    "declaration": "panes/welcome/welcome.module.css: .actions button { white-space: normal } (deleted - fails with the full #197 shape: resume button 1163px wide, symmetric double-ended clip, column stretched past viewport); .actions button { height: auto } (deleted - fails with the wrapped label spilling 19-27px out of its fixed-height box)",
     "verified": "2026-08-19",
     "expect": "fail"
   }

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/welcome-resume-candidate-overflow/harness.html
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/welcome-resume-candidate-overflow/harness.html
@@ -62,12 +62,6 @@
               <button class="button primary md" data-resume type="button"></button>
               <button class="button secondary md" data-new-session type="button">New session</button>
               <p class="orientation">A session can read and edit the repository, run commands, and delegate work to helpers.</p>
-              <div class="examples" data-examples>
-                <p class="examplesLabel">Try a task to get started</p>
-                <button class="button quiet sm" data-example type="button">Find and fix the root cause of a flaky test</button>
-                <button class="button quiet sm" data-example type="button">Audit error handling across the auth package</button>
-                <button class="button quiet sm" data-example type="button">Explain how requests flow from router to handler</button>
-              </div>
               <div class="hints" data-hints>
                 <div class="hintRow"><span class="kbdStandIn">Mod</span><span class="kbdStandIn">K</span><span>command palette</span></div>
                 <div class="hintRow"><span class="kbdStandIn">Mod</span><span class="kbdStandIn">I</span><span>focus the composer</span></div>
@@ -143,11 +137,9 @@ window.measure = () =>
       candidate,
       body: { rect: bodyRect, clientWidth: body.clientWidth },
       actions: rectOf(root.querySelector("[data-actions]")),
-      examplesDiv: rectOf(root.querySelector("[data-examples]")),
       hints: rectOf(root.querySelector("[data-hints]")),
       resume: resume ? buttonBox(resume, bodyRect) : null,
       newSession: buttonBox(root.querySelector("[data-new-session]"), bodyRect),
-      examples: [...root.querySelectorAll("[data-example]")].map((el) => buttonBox(el, bodyRect)),
     };
   });
 </script>

--- a/cmd/evener-hub/frontend/src/panes/welcome/Welcome.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/welcome/Welcome.test.tsx
@@ -6,6 +6,7 @@ import { navigationStore, resetNavigationStoreForTests } from "../../stores/navi
 import { keyID } from "../../stores/navigation/types";
 import buttonStyles from "../../widgets/button/button.module.css";
 import Welcome from "./Welcome";
+import { WelcomeContent } from "./WelcomeContent";
 
 afterEach(() => {
   cleanup();
@@ -80,17 +81,6 @@ test("orients a new person to what a session can do", () => {
   expect(screen.getByText(/delegate work to helpers/i)).toBeTruthy();
 });
 
-test("offers concrete example tasks that activate the real Spawn prefill", async () => {
-  const user = userEvent.setup();
-  render(<Welcome params={{}} paneId="welcome" focused={true} />);
-
-  const example = screen.getByRole("button", { name: /Find and fix the root cause of a flaky test/i });
-  await user.click(example);
-
-  expect(window.location.pathname).toBe("/new");
-  expect(new URLSearchParams(window.location.search).get("prompt")).toBe("Find and fix the root cause of a flaky test");
-});
-
 test('clicking "New session" navigates to /new', async () => {
   const user = userEvent.setup();
   render(<Welcome params={{}} paneId="welcome" focused={true} />);
@@ -106,6 +96,26 @@ test("shows params.note as a hint when provided", () => {
 test("shows no hint when params.note is absent", () => {
   const { container } = render(<Welcome params={{}} paneId="welcome" focused={true} />);
   expect(container.textContent).not.toMatch(/available yet/i);
+});
+
+test("WelcomeContent does not render example prompts", () => {
+  render(<WelcomeContent />);
+  expect(screen.queryByRole("button", { name: /Find and fix the root cause/i })).toBeNull();
+  expect(screen.queryByText("Try a task to get started")).toBeNull();
+});
+
+test("WelcomeContent renders New session only when showNewSession is true", () => {
+  const { rerender } = render(<WelcomeContent />);
+  expect(screen.queryByRole("button", { name: "New session" })).toBeNull();
+  rerender(<WelcomeContent showNewSession />);
+  expect(screen.getByRole("button", { name: "New session" })).toBeTruthy();
+});
+
+test("WelcomeContent renders chord hints only when showHints is true", () => {
+  const { rerender } = render(<WelcomeContent />);
+  expect(screen.queryByText("command palette")).toBeNull();
+  rerender(<WelcomeContent showHints />);
+  expect(screen.getByText("command palette")).toBeTruthy();
 });
 
 // tbk8: a cold "/" with no restored pane layout (a fresh browser, or

--- a/cmd/evener-hub/frontend/src/panes/welcome/Welcome.tsx
+++ b/cmd/evener-hub/frontend/src/panes/welcome/Welcome.tsx
@@ -1,32 +1,6 @@
 import type { PaneProps } from "../../shell/paneRegistry";
-import { navigate, paneToURL } from "../../shell/routing";
-import { selectLiveRows, selectNeedsYouRows } from "../../stores/navigation/selectors";
-import { type NavigationStoreState, useNavigationStore } from "../../stores/navigation/store";
-import { Button, EmptyState, KeyHint, PaneScaffold } from "../../widgets";
-import { requireClass } from "../../widgets/internal/requireClass";
-import styles from "./welcome.module.css";
-
-const CLASS = {
-  actions: requireClass(styles.actions, "welcome.module.css", "actions"),
-  hints: requireClass(styles.hints, "welcome.module.css", "hints"),
-  hintRow: requireClass(styles.hintRow, "welcome.module.css", "hintRow"),
-  hintFooter: requireClass(styles.hintFooter, "welcome.module.css", "hintFooter"),
-};
-
-// T6: the chords a new person has no other way to discover from this cold
-// pane - CommandPalette.tsx's own HELP_ROWS is the source of truth for all
-// three (Mod+K/Mod+I/Mod+J); order matches HELP_ROWS' own listing.
-const CHORD_HINTS: { keys: string[]; desc: string }[] = [
-  { keys: ["Mod", "K"], desc: "command palette" },
-  { keys: ["Mod", "I"], desc: "focus the composer" },
-  { keys: ["Mod", "J"], desc: "next session needing you" },
-];
-
-const EXAMPLE_PROMPTS = [
-  "Find and fix the root cause of a flaky test",
-  "Audit error handling across the auth package",
-  "Explain how requests flow from router to handler",
-] as const;
+import { EmptyState, PaneScaffold } from "../../widgets";
+import { WelcomeContent } from "./WelcomeContent";
 
 export interface WelcomePaneParams {
   // Shown as the empty state's hint - e.g. the note /new renders while the
@@ -34,81 +8,15 @@ export interface WelcomePaneParams {
   note?: string;
 }
 
-function goToNewSession(): void {
-  const url = paneToURL("spawn", {});
-  if (url) navigate(url);
-}
-
-function goToExample(prompt: string): void {
-  const url = paneToURL("spawn", {});
-  if (url) navigate(`${url}?prompt=${encodeURIComponent(prompt)}`);
-}
-
-function goToSession(ref: string): void {
-  const url = paneToURL("session", { ref });
-  if (url) navigate(url);
-}
-
-/** tbk8: the one session this cold pane offers to resume, when there is one.
- * A rail beside this pane may ALSO show the same session (it's always
- * docked on desktop as of the rail redesign) - that overlap is fine, and is
- * what keeps this pane itself correct on a narrow viewport, where there is
- * no rail to fall back on, and on a genuinely cold load with no restored
- * pane layout to have opened it already.
- *
- * needs-you outranks live, matching the rail's own attention ordering
- * (railNodes.ts's sessionWantsYou / hubapi.AttentionRank): a session
- * blocked on you is a stronger "come back" signal than one merely still
- * running. Only the first candidate in whichever tier is non-empty - this
- * is a single "jump back in" link, not a list; a list is the rail's job. */
-function resumeCandidate(navigation: NavigationStoreState) {
-  return selectNeedsYouRows(navigation)[0] ?? selectLiveRows(navigation)[0];
-}
-
 export default function Welcome({ params }: PaneProps<WelcomePaneParams>) {
-  const navigation = useNavigationStore();
-  const candidate = resumeCandidate(navigation);
-
+  // The note is rendered by EmptyState's hint (the original rendering path,
+  // so the existing "shows params.note as a hint" test stays green). It is
+  // NOT also passed to WelcomeContent here: WelcomeContent.note is the
+  // reusable slot for consumers that don't wrap it in EmptyState (the mobile
+  // welcome panel); passing it here too would render the note twice.
   return (
     <PaneScaffold title="Welcome">
-      <EmptyState
-        title="No session open"
-        hint={params.note}
-        action={
-          <div className={CLASS.actions}>
-            {candidate !== undefined && (
-              <Button variant="primary" onClick={() => goToSession(candidate.ref)}>
-                Jump back in: {candidate.title}
-              </Button>
-            )}
-            <Button variant="secondary" onClick={goToNewSession}>
-              New session
-            </Button>
-            <p className={styles.orientation}>
-              A session can read and edit the repository, run commands, and delegate work to helpers.
-            </p>
-            <div className={styles.examples}>
-              <p className={styles.examplesLabel}>Try a task to get started</p>
-              {EXAMPLE_PROMPTS.map((prompt) => (
-                <Button key={prompt} variant="quiet" size="sm" onClick={() => goToExample(prompt)}>
-                  {prompt}
-                </Button>
-              ))}
-            </div>
-            <div className={CLASS.hints}>
-              {CHORD_HINTS.map((hint) => (
-                <div className={CLASS.hintRow} key={hint.desc}>
-                  <KeyHint keys={hint.keys} />
-                  <span>{hint.desc}</span>
-                </div>
-              ))}
-              <p className={CLASS.hintFooter}>
-                <KeyHint keys={["?"]} /> inside the command palette shows all shortcuts.
-              </p>
-            </div>
-          </div>
-        }
-      />
+      <EmptyState title="No session open" hint={params.note} action={<WelcomeContent showNewSession showHints />} />
     </PaneScaffold>
   );
 }

--- a/cmd/evener-hub/frontend/src/panes/welcome/WelcomeContent.tsx
+++ b/cmd/evener-hub/frontend/src/panes/welcome/WelcomeContent.tsx
@@ -1,0 +1,99 @@
+import { navigate, paneToURL } from "../../shell/routing";
+import { selectLiveRows, selectNeedsYouRows } from "../../stores/navigation/selectors";
+import { type NavigationStoreState, useNavigationStore } from "../../stores/navigation/store";
+import { Button, KeyHint } from "../../widgets";
+import { requireClass } from "../../widgets/internal/requireClass";
+import styles from "./welcome.module.css";
+
+const CLASS = {
+  actions: requireClass(styles.actions, "welcome.module.css", "actions"),
+  hints: requireClass(styles.hints, "welcome.module.css", "hints"),
+  hintRow: requireClass(styles.hintRow, "welcome.module.css", "hintRow"),
+  hintFooter: requireClass(styles.hintFooter, "welcome.module.css", "hintFooter"),
+};
+
+// T6: the chords a new person has no other way to discover from this cold
+// pane - CommandPalette.tsx's own HELP_ROWS is the source of truth for all
+// three (Mod+K/Mod+I/Mod+J); order matches HELP_ROWS' own listing.
+const CHORD_HINTS: { keys: string[]; desc: string }[] = [
+  { keys: ["Mod", "K"], desc: "command palette" },
+  { keys: ["Mod", "I"], desc: "focus the composer" },
+  { keys: ["Mod", "J"], desc: "next session needing you" },
+];
+
+export interface WelcomeContentProps {
+  note?: string;
+  showNewSession?: boolean;
+  showHints?: boolean;
+}
+
+function goToNewSession(): void {
+  const url = paneToURL("spawn", {});
+  if (url) navigate(url);
+}
+
+function goToSession(ref: string): void {
+  const url = paneToURL("session", { ref });
+  if (url) navigate(url);
+}
+
+/** tbk8: the one session this cold pane offers to resume, when there is one.
+ * A rail beside this pane may ALSO show the same session (it's always
+ * docked on desktop as of the rail redesign) - that overlap is fine, and is
+ * what keeps this pane itself correct on a narrow viewport, where there is
+ * no rail to fall back on, and on a genuinely cold load with no restored
+ * pane layout to have opened it already.
+ *
+ * needs-you outranks live, matching the rail's own attention ordering
+ * (railNodes.ts's sessionWantsYou / hubapi.AttentionRank): a session
+ * blocked on you is a stronger "come back" signal than one merely still
+ * running. Only the first candidate in whichever tier is non-empty - this
+ * is a single "jump back in" link, not a list; a list is the rail's job. */
+function resumeCandidate(navigation: NavigationStoreState) {
+  return selectNeedsYouRows(navigation)[0] ?? selectLiveRows(navigation)[0];
+}
+
+/**
+ * Presentational body of the Welcome pane: the "Jump back in" resume
+ * candidate, an optional "New session" action, orientation text, and
+ * optional chord hints. No example prompts, and no host-conditional
+ * ("am I mobile?") behavior - this component renders exactly what its
+ * props ask for regardless of the viewport. The Welcome pane decides
+ * which of these to show.
+ */
+export function WelcomeContent({ note, showNewSession, showHints }: WelcomeContentProps) {
+  const navigation = useNavigationStore();
+  const candidate = resumeCandidate(navigation);
+
+  return (
+    <div className={CLASS.actions}>
+      {note && <p>{note}</p>}
+      {candidate !== undefined && (
+        <Button variant="primary" onClick={() => goToSession(candidate.ref)}>
+          Jump back in: {candidate.title}
+        </Button>
+      )}
+      {showNewSession && (
+        <Button variant="secondary" onClick={goToNewSession}>
+          New session
+        </Button>
+      )}
+      <p className={styles.orientation}>
+        A session can read and edit the repository, run commands, and delegate work to helpers.
+      </p>
+      {showHints && (
+        <div className={CLASS.hints}>
+          {CHORD_HINTS.map((hint) => (
+            <div className={CLASS.hintRow} key={hint.desc}>
+              <KeyHint keys={hint.keys} />
+              <span>{hint.desc}</span>
+            </div>
+          ))}
+          <p className={CLASS.hintFooter}>
+            <KeyHint keys={["?"]} /> inside the command palette shows all shortcuts.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/cmd/evener-hub/frontend/src/panes/welcome/welcome.module.css
+++ b/cmd/evener-hub/frontend/src/panes/welcome/welcome.module.css
@@ -10,11 +10,11 @@
   /* Issue #197: an unbreakable child (the resume-candidate button's
    * server-truncated-but-still-200-rune title, forced to white-space:nowrap
    * by button.module.css) sizes this flex column to its min-content width
-   * instead of the viewport's, which then propagates to .examples/.hints
-   * (their width:min(100%,36rem) resolves 100% against this inflated width)
-   * and is clipped mid-string by PaneScaffold's .body overflow-x:clip. Cap
-   * the column's width and let long words wrap so a wide child wraps instead
-   * of inflating the layout. */
+   * instead of the viewport's, which then propagates to .hints (its
+   * width:min(100%,36rem) resolves 100% against this inflated width) and is
+   * clipped mid-string by PaneScaffold's .body overflow-x:clip. Cap the
+   * column's width and let long words wrap so a wide child wraps instead of
+   * inflating the layout. */
   width: 100%;
   max-width: 36rem;
   overflow-wrap: break-word;
@@ -26,16 +26,13 @@
  * button.module.css (correct for most buttons - catastrophic here, where the
  * label is the widest thing in the column, not the narrowest). Override that
  * LOCALLY for buttons in this welcome .actions column so the long title wraps
- * instead of inflating the flex layout past the viewport - the same override
- * .examples button below applies for the identical reason. Wrapping reopens
- * the bug .button's nowrap exists to prevent (button.module.css pins
- * height: 32px on .md, so a wrapped label spills out of the box - 19px of
- * clipped text at 390px in the layoutguard probe), so the box also gets
- * height: auto with the desktop height kept as a floor. The phone tap floor
- * is re-declared in the media block because this rule's higher specificity
- * would otherwise beat button.module.css's own @media min-height. This rule
- * stays ABOVE .examples button so that rule's larger 44px floor still wins
- * for the suggestion buttons on desktop. */
+ * instead of inflating the flex layout past the viewport. Wrapping reopens
+ * the bug .button's nowrap exists to prevent (button.module.css pins height:
+ * 32px on .md, so a wrapped label spills out of the box - 19px of clipped
+ * text at 390px in the layoutguard probe), so the box also gets height: auto
+ * with the desktop height kept as a floor. The phone tap floor is re-declared
+ * in the media block because this rule's higher specificity would otherwise
+ * beat button.module.css's own @media min-height. */
 .actions button {
   white-space: normal;
   height: auto;
@@ -55,28 +52,6 @@
   font-family: var(--font-sans);
   font-size: var(--font-size-body);
   line-height: var(--line-height-body);
-}
-
-.examples {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  width: min(100%, 36rem);
-  gap: var(--space-2);
-  margin-top: var(--space-2);
-}
-
-.examplesLabel {
-  margin: 0;
-  color: var(--ink-mid);
-  font-family: var(--font-sans);
-  font-size: var(--font-size-ui);
-}
-
-.examples button {
-  min-height: 44px;
-  white-space: normal;
-  text-align: left;
 }
 
 /* T6: a quiet hint row teaching the chords, below the task suggestions -

--- a/cmd/evener-hub/frontend/src/panes/welcome/welcome.overflow.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/welcome/welcome.overflow.test.tsx
@@ -117,17 +117,17 @@ test("welcome.module.css overrides white-space: nowrap for the resume-candidate 
   expect(css).not.toMatch(/white-space:\s*nowrap/);
 });
 
-// Issue #197 symptom: the inflated resume button cascades into .examples and
-// .hints, whose `width: min(100%, 36rem)` resolves its 100% against the
-// now-inflated .actions. The fix must cap the .actions / title containers so
-// wide content wraps instead of inflating the flex layout. This asserts the
-// containers that hold the title and examples/hints carry a max-width (or
-// equivalent width cap) plus overflow-wrap so long unbroken text wraps.
-test("welcome.module.css caps width and wraps long text in the title/examples/hints containers", () => {
+// Issue #197 symptom: the inflated resume button cascades into .hints, whose
+// `width: min(100%, 36rem)` resolves its 100% against the now-inflated .actions.
+// The fix must cap the .actions / title containers so wide content wraps
+// instead of inflating the flex layout. This asserts the containers that hold
+// the title and hints carry a max-width (or equivalent width cap) plus
+// overflow-wrap so long unbroken text wraps.
+test("welcome.module.css caps width and wraps long text in the title/hints containers", () => {
   const css = welcomeCss();
   // .actions is the flex column holding the resume button, the orientation
-  // paragraph, .examples and .hints. It must cap its own width so an
-  // unbreakable child cannot inflate it past the viewport.
+  // paragraph and .hints. It must cap its own width so an unbreakable child
+  // cannot inflate it past the viewport.
   const actionsBlock = css.match(/\.actions\s*\{([^}]*)\}/);
   expect(actionsBlock, "welcome.module.css must define an .actions rule").toBeTruthy();
   const actionsRules = actionsBlock?.[1] ?? "";

--- a/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.module.css
+++ b/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.module.css
@@ -1,0 +1,5 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}

--- a/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.module.css
+++ b/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.module.css
@@ -1,5 +1,0 @@
-.panel {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-}

--- a/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.test.tsx
@@ -1,0 +1,75 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { lazy } from "react";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { registerPaneForTests } from "../paneRegistry";
+import { resetWorkspaceStoreForTests, workspaceStore } from "../workspace";
+import { MobilePanel } from "./MobilePanel";
+
+// The brief's tests call openPane("doc", ...) and openPane("welcome"). Both
+// require a registered pane type (openPane -> paneFor throws otherwise), so
+// this file registers "doc" as a fixture and imports the real welcome module
+// for its registerPane("welcome") side effect - the same setup every sibling
+// shell test (TreeDrawer.test.tsx, StackHost.test.tsx, DockHost.test.tsx)
+// uses for the same reason.
+function DocFixture() {
+  return <div>doc</div>;
+}
+
+let restoreDocPane: () => void;
+
+beforeAll(async () => {
+  restoreDocPane = registerPaneForTests<{ ref: string }>({
+    id: "doc",
+    title: () => "Doc",
+    component: lazy(() => Promise.resolve({ default: DocFixture })),
+  });
+  await import("../../panes/welcome/Welcome");
+  await import("../../panes/welcome");
+});
+
+afterAll(() => {
+  restoreDocPane();
+});
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  resetWorkspaceStoreForTests();
+});
+
+function RailFixture() {
+  return <div data-testid="rail-fixture">Rail</div>;
+}
+
+test("renders rail content when open", () => {
+  render(<MobilePanel rail={<RailFixture />} open onClose={vi.fn()} />);
+  expect(screen.getByTestId("rail-fixture")).toBeTruthy();
+});
+
+test("renders welcome content when nothing is focused", () => {
+  // Nothing focused → backstop opens welcome
+  workspaceStore.getState().openPane("welcome");
+  render(<MobilePanel rail={<RailFixture />} open onClose={vi.fn()} />);
+  expect(screen.getByText(/read and edit the repository/i)).toBeTruthy();
+});
+
+test("hides welcome content when a session is focused", () => {
+  workspaceStore.getState().openPane("doc", { ref: "ref_a" });
+  render(<MobilePanel rail={<RailFixture />} open onClose={vi.fn()} />);
+  expect(screen.queryByText(/read and edit the repository/i)).toBeNull();
+  expect(screen.getByTestId("rail-fixture")).toBeTruthy();
+});
+
+test("calls onClose when focusedPaneId changes while open", () => {
+  workspaceStore.getState().openPane("doc", { ref: "ref_a" });
+  const onClose = vi.fn();
+  render(<MobilePanel rail={<RailFixture />} open onClose={onClose} />);
+  expect(onClose).not.toHaveBeenCalled();
+  // act() flushes the focus-change effect synchronously, the same idiom
+  // TreeDrawer.test.tsx and StackHost.test.tsx use for a store mutation
+  // issued after the component is already mounted.
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  });
+  expect(onClose).toHaveBeenCalled();
+});

--- a/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.tsx
+++ b/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.tsx
@@ -1,0 +1,41 @@
+import { type ReactNode, useEffect, useRef } from "react";
+import { WelcomeContent } from "../../panes/welcome/WelcomeContent";
+import { Sheet } from "../../widgets";
+import { useWorkspaceStore } from "../workspace";
+
+const PEEK_HEIGHT = 360;
+
+export interface MobilePanelProps {
+  rail: ReactNode;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function MobilePanel({ rail, open, onClose }: MobilePanelProps) {
+  const focusedPaneId = useWorkspaceStore((s) => s.focusedPaneId);
+  const panes = useWorkspaceStore((s) => s.panes);
+  const focusedPane = panes.find((p) => p.id === focusedPaneId) ?? null;
+  const nothingFocused = focusedPaneId === null || focusedPane?.type === "welcome";
+
+  const prevFocusedIdRef = useRef(focusedPaneId);
+
+  // Auto-close on navigation: when focusedPaneId changes while the panel
+  // is open, close it (same pattern as TreeDrawer's old effect).
+  useEffect(() => {
+    if (open && prevFocusedIdRef.current !== focusedPaneId) onClose();
+    prevFocusedIdRef.current = focusedPaneId;
+  }, [focusedPaneId, open, onClose]);
+
+  return (
+    <Sheet
+      side="bottom"
+      open={open}
+      onClose={onClose}
+      title="Sessions"
+      expandable={{ peekHeight: PEEK_HEIGHT, fullScreenFirst: true }}
+    >
+      {rail}
+      {nothingFocused && <WelcomeContent showHints />}
+    </Sheet>
+  );
+}

--- a/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.tsx
+++ b/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.tsx
@@ -18,10 +18,26 @@ export function MobilePanel({ rail, open, onClose }: MobilePanelProps) {
   const nothingFocused = focusedPaneId === null || focusedPane?.type === "welcome";
 
   const prevFocusedIdRef = useRef(focusedPaneId);
+  // Tracks the previous `open` so the closed->open transition can re-baseline
+  // prevFocusedIdRef (see the effect below).
+  const prevOpenRef = useRef(open);
 
   // Auto-close on navigation: when focusedPaneId changes while the panel
-  // is open, close it (same pattern as TreeDrawer's old effect).
+  // is open, close it (same pattern as TreeDrawer's old effect). On a
+  // closed->open transition, re-baseline prevFocusedIdRef to the CURRENT
+  // focusedPaneId first: a focus change that happened while the panel was
+  // closed (or was batched into the same commit as the open, which React
+  // never exposes as an intermediate closed state) must NOT be misread as a
+  // navigation-while-open. The owner (StackHost) opens this panel over a
+  // welcome pane that its own backstop just focused in that exact batched
+  // beat; without the re-baseline, the panel opens already "stale" and
+  // closes itself one effect tick later. A navigation that genuinely
+  // happens AFTER the panel is already open still closes it (the task-4
+  // contract), because prevFocusedIdRef then names the pane that was
+  // focused at open time, not whatever landed batched with the open.
   useEffect(() => {
+    if (open && prevOpenRef.current !== open) prevFocusedIdRef.current = focusedPaneId;
+    prevOpenRef.current = open;
     if (open && prevFocusedIdRef.current !== focusedPaneId) onClose();
     prevFocusedIdRef.current = focusedPaneId;
   }, [focusedPaneId, open, onClose]);

--- a/cmd/evener-hub/frontend/src/shell/mobile/StackHost.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/mobile/StackHost.test.tsx
@@ -141,6 +141,22 @@ test("falls back to opening welcome when nothing is focused at mount", async () 
   expect(await screen.findByText("No session open")).toBeTruthy();
 });
 
+test("opens the mobile panel when nothing is focused", async () => {
+  render(<StackHost />);
+  // Welcome pane mounts behind the panel; the panel opens over it
+  await screen.findByText("No session open");
+  // The panel's Sheet title "Sessions" is the dialog's accessible name
+  expect(screen.getByRole("dialog", { name: "Sessions" })).toBeTruthy();
+});
+
+test("does not flash the panel during routeDeferred", async () => {
+  render(<StackHost routeDeferred />);
+  // Wait for welcome to appear behind the (closed) panel
+  await screen.findByText("No session open");
+  // Panel should NOT be open while routeDeferred
+  expect(screen.queryByRole("dialog", { name: "Sessions" })).toBeNull();
+});
+
 test("renders the focused pane's component full-screen, with focused=true", async () => {
   workspaceStore.getState().openPane("doc", { ref: "ref_a" });
   render(<StackHost />);

--- a/cmd/evener-hub/frontend/src/shell/mobile/StackHost.tsx
+++ b/cmd/evener-hub/frontend/src/shell/mobile/StackHost.tsx
@@ -37,13 +37,14 @@
 // restored anywhere. A reload lands wherever the URL says (see the URL-
 // sync effect below), the same as any other fresh navigation - there is no
 // separate "last mobile screen" memory to restore independently of that.
-import { type ReactNode, Suspense, useEffect, useRef } from "react";
+import { type ReactNode, Suspense, useEffect, useRef, useState } from "react";
 import { Chevron, IconButton } from "../../widgets";
 import { useChromeStore } from "../chromeStore";
 import { paneFor } from "../paneRegistry";
 import { navigate, paneToURL, urlToPane } from "../routing";
 import { isSinglePaneRoute } from "../singlePane";
 import { type OpenPaneRecord, useWorkspaceStore, workspaceStore } from "../workspace";
+import { MobilePanel } from "./MobilePanel";
 import styles from "./StackHost.module.css";
 import { TreeDrawer } from "./TreeDrawer";
 
@@ -143,10 +144,10 @@ export function setLastPopstateWasTrustedForTests(value: boolean): void {
 }
 
 export interface StackHostProps {
-  // The rail content for the tree drawer, threaded through to TreeDrawer's
-  // children slot (children ARE TreeDrawer's whole rail contract). AppShell
-  // — the integrator — passes <Rail/> here; StackHost itself stays
-  // rail-agnostic, exactly like TreeDrawer.
+  // The rail content, threaded through to MobilePanel's `rail` prop (the
+  // panel's whole rail contract). AppShell — the integrator — passes
+  // <Rail/> here; StackHost itself stays rail-agnostic, exactly like the
+  // panel and the trigger-only TreeDrawer.
   railSlot?: ReactNode;
   // True while the shell has parsed the address bar's route but cannot place
   // it yet — a /s/{ref} deep link waits for its navigation location resource before it can tell a
@@ -172,6 +173,13 @@ export function StackHost({ railSlot, routeDeferred = false }: StackHostProps = 
   // publishes one, the top-bar Back invokes IT instead of the stack walk.
   const paneBack = useChromeStore((s) => s.paneBack);
   const focusedPane = panes.find((p) => p.id === focusedPaneId) ?? null;
+  const [panelOpen, setPanelOpen] = useState(false);
+  // True when no real pane is focused: either nothing at all, or the
+  // welcome pane (the app's "nothing open" landing screen). The mobile
+  // panel auto-opens in this state (see the effect below) so the rail —
+  // the only way to open a pane on a phone — is one tap away, the same
+  // role the always-docked desktop rail plays without a panel.
+  const nothingFocused = focusedPaneId === null || focusedPane?.type === "welcome";
 
   // This component's OWN back-stack: ids previously focused, most-recent-
   // last. Not part of useWorkspaceStore (the store only ever tracks the
@@ -282,6 +290,20 @@ export function StackHost({ railSlot, routeDeferred = false }: StackHostProps = 
     if (!focusedPane) workspaceStore.getState().openPane("welcome");
   }, [focusedPane]);
 
+  // Opens the mobile panel whenever nothing real is focused — the rail
+  // (the only pane-opener on a phone) lives inside it, so a blank or
+  // welcome screen must not strand the user with no way forward. Guarded
+  // by routeDeferred: a deep-linked route spends a beat parsed-but-unplaced
+  // (AppShell's openRouteAsPane waiting on its navigation resource), which
+  // the backstop above fills with welcome — opening the panel over that
+  // would flash it for one frame before the real pane lands, so the panel
+  // stays closed until the route resolves (the same beat the URL-sync effect
+  // declines to publish over, see its own comment).
+  useEffect(() => {
+    if (routeDeferred) return;
+    if (nothingFocused) setPanelOpen(true);
+  }, [nothingFocused, routeDeferred]);
+
   function handleBack(): void {
     const target = popValidBackTarget(backStackRef.current, panes, focusedPaneId);
     wentBackRef.current = true;
@@ -333,7 +355,7 @@ export function StackHost({ railSlot, routeDeferred = false }: StackHostProps = 
         <span className={styles.title} data-testid="topbar-title">
           {paneTitle}
         </span>
-        <TreeDrawer>{railSlot}</TreeDrawer>
+        <TreeDrawer onOpen={() => setPanelOpen(true)} />
       </div>
       <div className={styles.body}>
         {focusedPane && (
@@ -349,6 +371,7 @@ export function StackHost({ railSlot, routeDeferred = false }: StackHostProps = 
           <StackedPane key={focusedPane.id} pane={focusedPane} />
         )}
       </div>
+      <MobilePanel rail={railSlot} open={panelOpen} onClose={() => setPanelOpen(false)} />
     </div>
   );
 }

--- a/cmd/evener-hub/frontend/src/shell/mobile/TreeDrawer.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/mobile/TreeDrawer.test.tsx
@@ -1,13 +1,11 @@
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { lazy } from "react";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, test } from "vitest";
-import { FakeClient } from "../../protocol/testing/fakeClient";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
 import { navigationStore, resetNavigationStoreForTests } from "../../stores/navigation/store";
 import { keyID } from "../../stores/navigation/types";
-import { ClientProvider } from "../clientContext";
 import { registerPaneForTests } from "../paneRegistry";
-import { resetWorkspaceStoreForTests, workspaceStore } from "../workspace";
+import { resetWorkspaceStoreForTests } from "../workspace";
 import { TreeDrawer } from "./TreeDrawer";
 
 function needsYouNode(n: number) {
@@ -83,7 +81,7 @@ afterEach(() => {
 });
 
 test("renders a trigger button labeled Sessions", () => {
-  render(<TreeDrawer />);
+  render(<TreeDrawer onOpen={vi.fn()} />);
   expect(screen.getByRole("button", { name: "Sessions" })).toBeTruthy();
 });
 
@@ -92,13 +90,13 @@ test("renders a trigger button labeled Sessions", () => {
 // is visible without opening the drawer first.
 test("the trigger carries the same needs-you Badge overlay the desktop chip has", () => {
   setNeedsYou(2);
-  render(<TreeDrawer />);
+  render(<TreeDrawer onOpen={vi.fn()} />);
   expect(screen.getByText("2")).toBeTruthy();
 });
 
 test("no Badge overlay when nothing needs attention", () => {
   setNeedsYou(0);
-  render(<TreeDrawer />);
+  render(<TreeDrawer onOpen={vi.fn()} />);
   expect(screen.queryByText("0")).toBeNull();
 });
 
@@ -116,115 +114,16 @@ test("no Badge overlay when nothing needs attention", () => {
 // with what the drawer's own rows show once opened.
 test("the trigger badge follows the bounded needs-you rows", () => {
   setNeedsYou(1);
-  render(<TreeDrawer />);
+  render(<TreeDrawer onOpen={vi.fn()} />);
   expect(screen.getByText("1")).toBeTruthy();
 });
 
-test("the drawer is closed until the trigger is clicked", () => {
-  render(<TreeDrawer />);
+test("trigger calls onOpen instead of opening a Sheet", async () => {
+  const onOpen = vi.fn();
+  const user = userEvent.setup();
+  render(<TreeDrawer onOpen={onOpen} />);
+  await user.click(screen.getByRole("button", { name: "Sessions" }));
+  expect(onOpen).toHaveBeenCalled();
+  // No dialog (Sheet) should be rendered by TreeDrawer anymore
   expect(screen.queryByRole("dialog")).toBeNull();
-});
-
-test("clicking the trigger opens the sheet, titled Sessions", async () => {
-  const user = userEvent.setup();
-  render(<TreeDrawer />);
-
-  await user.click(screen.getByRole("button", { name: "Sessions" }));
-
-  const dialog = screen.getByRole("dialog");
-  expect(dialog).toBeTruthy();
-  expect(screen.getByText("Sessions", { selector: "h2" })).toBeTruthy();
-});
-
-test("Escape closes the drawer (the open/onClose wiring into Sheet is correct)", async () => {
-  const user = userEvent.setup();
-  render(<TreeDrawer />);
-  await user.click(screen.getByRole("button", { name: "Sessions" }));
-  expect(screen.getByRole("dialog")).toBeTruthy();
-
-  await user.keyboard("{Escape}");
-
-  expect(screen.queryByRole("dialog")).toBeNull();
-});
-
-test("shows a clearly-marked placeholder for the rail when no children are given", async () => {
-  const user = userEvent.setup();
-  render(<TreeDrawer />);
-  await user.click(screen.getByRole("button", { name: "Sessions" }));
-
-  expect(screen.getByTestId("rail-slot")).toBeTruthy();
-});
-
-test("renders provided children instead of the placeholder", async () => {
-  const user = userEvent.setup();
-  render(
-    <TreeDrawer>
-      <div data-testid="real-rail">the real rail, once T3 lands</div>
-    </TreeDrawer>,
-  );
-  await user.click(screen.getByRole("button", { name: "Sessions" }));
-
-  expect(screen.getByTestId("real-rail")).toBeTruthy();
-  expect(screen.queryByTestId("rail-slot")).toBeNull();
-});
-
-// The drawer-hosted rail is the SAME full-chrome Rail as desktop (collapsed
-// mode + the hostedInSheet suppression were removed 2026-07-24): search,
-// + New session, and the settings footer all render inside the sheet.
-test("the drawer-hosted RailHost carries the full sidebar chrome", async () => {
-  const { RailHost } = await import("../rail");
-  const user = userEvent.setup();
-  render(
-    <TreeDrawer>
-      <ClientProvider client={new FakeClient()}>
-        <RailHost />
-      </ClientProvider>
-    </TreeDrawer>,
-  );
-  await user.click(screen.getByRole("button", { name: "Sessions" }));
-
-  expect(screen.getByTestId("rail-search")).toBeTruthy();
-  expect(screen.getByRole("button", { name: /new session/i })).toBeTruthy();
-  expect(screen.getByTestId("rail-settings")).toBeTruthy();
-});
-
-// --- auto-close on navigation -------------------------------------------
-
-test("closes automatically when the focused pane changes elsewhere while open", async () => {
-  const user = userEvent.setup();
-  render(<TreeDrawer />);
-  await user.click(screen.getByRole("button", { name: "Sessions" }));
-  expect(screen.getByRole("dialog")).toBeTruthy();
-
-  // Simulates the rail (a sibling stream, not built here) calling the same
-  // workspaceStore.openPane() every other pane-opening trigger in the app
-  // already calls - see this file's own header comment on the intended
-  // integration contract. act() flushes the resulting re-render
-  // synchronously, same idiom workspace.test.ts/DockHost.test.tsx use for
-  // a store mutation issued after the component is already mounted.
-  act(() => {
-    workspaceStore.getState().openPane("doc", { ref: "ref_a" });
-  });
-
-  expect(screen.queryByRole("dialog")).toBeNull();
-});
-
-test("does not close from a store update that leaves focusedPaneId unchanged", async () => {
-  workspaceStore.getState().openPane("welcome");
-  const user = userEvent.setup();
-  render(<TreeDrawer />);
-  await user.click(screen.getByRole("button", { name: "Sessions" }));
-  expect(screen.getByRole("dialog")).toBeTruthy();
-
-  // welcome is a singleton and already focused - reopening it with
-  // DIFFERENT params still updates the store (a real, observable change,
-  // unlike an identical no-op call) but focusedPaneId's own VALUE does not
-  // change, since the same pane stays focused throughout. Proves the
-  // auto-close effect keys specifically off focusedPaneId changing, not
-  // "the store emitted a change" more broadly.
-  act(() => {
-    workspaceStore.getState().openPane("welcome", { note: "a different note" });
-  });
-
-  expect(screen.getByRole("dialog")).toBeTruthy();
 });

--- a/cmd/evener-hub/frontend/src/shell/mobile/TreeDrawer.tsx
+++ b/cmd/evener-hub/frontend/src/shell/mobile/TreeDrawer.tsx
@@ -1,25 +1,7 @@
-// The mobile tree drawer: a trigger button in StackHost's top bar plus the
-// Sheet it opens. Slot contract for the sibling stream building the real
-// rail (src/shell/rail/**, owned by a different task - this stream may not
-// touch that directory, and that one may not touch this one, so the two
-// meet only through props, wired up by whoever merges both): pass the real
-// rail component as `children` -
-//
-//   <TreeDrawer><Rail /></TreeDrawer>
-//
-// - and it replaces the placeholder below outright, with no other change
-// needed here. `children` is deliberately the ENTIRE contract (no bespoke
-// "onSelect"/"close" callback prop): the rail only needs to call
-// workspaceStore's own openPane(), exactly like every other pane-opening
-// trigger in the app already does (Welcome's "New session" button,
-// AppShell's routing glue, DockHost's dockview interactions) - the
-// auto-close effect below already reacts to that, for free, with no
-// bespoke integration code required on the rail's side.
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 import { selectNeedsYouCount } from "../../stores/navigation/selectors";
 import { useNavigationStore } from "../../stores/navigation/store";
-import { Badge, EmptyState, IconButton, Sheet } from "../../widgets";
-import { useWorkspaceStore } from "../workspace";
+import { Badge, IconButton } from "../../widgets";
 import styles from "./treedrawer.module.css";
 
 function SessionsIcon() {
@@ -31,65 +13,21 @@ function SessionsIcon() {
 }
 
 export interface TreeDrawerProps {
-  children?: ReactNode;
+  onOpen: () => void;
 }
 
-export function TreeDrawer({ children }: TreeDrawerProps) {
-  const [open, setOpen] = useState(false);
-  const focusedPaneId = useWorkspaceStore((s) => s.focusedPaneId);
-  const prevFocusedIdRef = useRef(focusedPaneId);
-  // UX fix: parity with RailHost's own hidden-rail ☰ chip, which already
-  // shows Badge(needsYou) beside its glyph - this trigger carries the same
-  // Badge, overlaid on its corner since an icon-only button has no room for
-  // an inline second element.
-  //
-  // FIX 4: reads tree.needs_you (the server's own ordered needs-you list -
-  // needsYouCycle.ts's own "one source of truth" for every other needs-you
-  // surface in the app), NOT attentionSummary.needsYou - a separate,
-  // narrower aggregate (hubcore's DeriveAttention/tierEligible: top-level,
-  // non-subagent, non-archived sessions only) that can undercount relative
-  // to what the drawer's own rows show once opened, leaving the trigger
-  // unbadged for a session the rows plainly present as needing you
-  // (real-browser observation).
+export function TreeDrawer({ onOpen }: TreeDrawerProps) {
   const navigation = useNavigationStore();
   const needsYou = useMemo(() => selectNeedsYouCount(navigation), [navigation]);
 
-  // Auto-close on navigation: whatever eventually fills the slot above
-  // only ever needs to call openPane() for this to work - see the module
-  // comment. Keyed specifically on focusedPaneId's VALUE changing, not on
-  // "the store emitted some update" more broadly (e.g. re-opening the
-  // already-focused singleton with different params updates the store but
-  // leaves focusedPaneId itself unchanged - must not close the drawer).
-  useEffect(() => {
-    if (open && prevFocusedIdRef.current !== focusedPaneId) setOpen(false);
-    prevFocusedIdRef.current = focusedPaneId;
-  }, [focusedPaneId, open]);
-
   return (
-    <>
-      <span className={styles.triggerWrap}>
-        <IconButton label="Sessions" icon={<SessionsIcon />} variant="quiet" onClick={() => setOpen(true)} />
-        {needsYou > 0 && (
-          <span className={styles.badgeOverlay}>
-            <Badge count={needsYou} tone="attention" />
-          </span>
-        )}
-      </span>
-      {/* Bottom, not right: see this stream's own report for the
-          thumb-reach justification (a bottom sheet's header/close button
-          sits within one-handed reach; a full-height right-edge sheet's
-          header does not, on a tall phone). */}
-      <Sheet side="bottom" open={open} onClose={() => setOpen(false)} title="Sessions">
-        {children ?? (
-          // A single descriptive title, no separate hint - same "not built
-          // yet" placeholder convention as panes/session/Session.tsx's own
-          // EmptyState, and avoids repeating "Sessions" right under the
-          // Sheet's own title heading above.
-          <div data-testid="rail-slot">
-            <EmptyState title="Session tree arrives from a parallel wave-3 stream" />
-          </div>
-        )}
-      </Sheet>
-    </>
+    <span className={styles.triggerWrap}>
+      <IconButton label="Sessions" icon={<SessionsIcon />} variant="quiet" onClick={onOpen} />
+      {needsYou > 0 && (
+        <span className={styles.badgeOverlay}>
+          <Badge count={needsYou} tone="attention" />
+        </span>
+      )}
+    </span>
   );
 }

--- a/cmd/evener-hub/frontend/src/widgets/dialog/OverlayPanel.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/dialog/OverlayPanel.tsx
@@ -15,6 +15,14 @@ export interface OverlayPanelProps {
    * for Dialog, slide-in-from-an-edge for Sheet). OverlayPanel itself picks
    * the scrim, header, body, and footer classes - those never vary. */
   panelClassName: string;
+  /** Optional element rendered before the <header>, e.g. a drag handle for a
+   * Sheet on a touch viewport. Defaults to undefined; existing consumers
+   * that don't pass it are unchanged. */
+  handle?: ReactNode;
+  /** Optional extra class appended to the body div's base `.body` class. */
+  bodyClassName?: string;
+  /** Optional extra class appended to the header element's base `.header` class. */
+  headerClassName?: string;
 }
 
 const CLASS = {
@@ -36,7 +44,17 @@ const CLASS = {
  * this task's report - while CSS pins it to the header's top-right corner
  * regardless of DOM position.
  */
-export function OverlayPanel({ open, onClose, title, children, footer, panelClassName }: OverlayPanelProps) {
+export function OverlayPanel({
+  open,
+  onClose,
+  title,
+  children,
+  footer,
+  panelClassName,
+  handle,
+  bodyClassName,
+  headerClassName,
+}: OverlayPanelProps) {
   const titleId = useId();
   // Radix-style pointer-down-outside semantics: the gesture that decides
   // whether this counts as "outside the panel" is where the PRESS
@@ -104,12 +122,13 @@ export function OverlayPanel({ open, onClose, title, children, footer, panelClas
           className={panelClassName}
           onKeyDown={handleKeyDown}
         >
-          <header className={CLASS.header}>
+          {handle}
+          <header className={headerClassName ? `${CLASS.header} ${headerClassName}` : CLASS.header}>
             <h2 id={titleId} className={CLASS.title}>
               {title}
             </h2>
           </header>
-          <div className={CLASS.body}>{children}</div>
+          <div className={bodyClassName ? `${CLASS.body} ${bodyClassName}` : CLASS.body}>{children}</div>
           {footer !== undefined && <div className={CLASS.footer}>{footer}</div>}
           <button type="button" className={CLASS.closeButton} onClick={onClose} aria-label="Close">
             <CloseIcon />

--- a/cmd/evener-hub/frontend/src/widgets/dialog/OverlayPanel.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/dialog/OverlayPanel.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, type MouseEvent, type ReactNode, useId, useRef } from "react";
+import { type CSSProperties, type KeyboardEvent, type MouseEvent, type ReactNode, useId, useRef } from "react";
 import { FocusScope } from "../focusscope";
 import { requireClass } from "../internal/requireClass";
 import { CloseIcon } from "./CloseIcon";
@@ -23,6 +23,12 @@ export interface OverlayPanelProps {
   bodyClassName?: string;
   /** Optional extra class appended to the header element's base `.header` class. */
   headerClassName?: string;
+  /** Optional inline style applied to the panel element. Defaults to
+   * undefined; existing consumers that don't pass it are unchanged. Used by
+   * the expandable Sheet to drive a dynamic peek/full height on the panel
+   * itself (not a child wrapper) so a `.bottom` max-height cap can't clamp
+   * the full-screen geometry. */
+  style?: CSSProperties;
 }
 
 const CLASS = {
@@ -54,6 +60,7 @@ export function OverlayPanel({
   handle,
   bodyClassName,
   headerClassName,
+  style,
 }: OverlayPanelProps) {
   const titleId = useId();
   // Radix-style pointer-down-outside semantics: the gesture that decides
@@ -121,6 +128,7 @@ export function OverlayPanel({
           aria-labelledby={titleId}
           className={panelClassName}
           onKeyDown={handleKeyDown}
+          style={style}
         >
           {handle}
           <header className={headerClassName ? `${CLASS.header} ${headerClassName}` : CLASS.header}>

--- a/cmd/evener-hub/frontend/src/widgets/sheet/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/sheet/index.tsx
@@ -92,6 +92,13 @@ export function Sheet({
   const [geometry, setGeometry] = useState<"peek" | "full">(expandable?.fullScreenFirst ? "full" : "peek");
   const dragStartYRef = useRef<number | null>(null);
   const dragStartGeometryRef = useRef<"peek" | "full">("peek");
+  // The window pointermove/pointerup listeners added in startDrag are
+  // removed in handlePointerUp. If the component unmounts mid-drag (e.g.
+  // the panel closes), handlePointerUp never runs and the listeners leak
+  // on window. These refs hold the active listener functions so an unmount
+  // cleanup can remove them by the same reference that added them.
+  const pointerMoveRef = useRef<((e: PointerEvent) => void) | null>(null);
+  const pointerUpRef = useRef<((e: PointerEvent) => void) | null>(null);
 
   // Reset geometry to full on every open transition (false->true). An effect
   // keyed on `open` (and fullScreenFirst) is the only place that observes
@@ -102,6 +109,16 @@ export function Sheet({
     if (open && expandable?.fullScreenFirst) setGeometry("full");
   }, [open, expandable?.fullScreenFirst]);
 
+  // Remove any active drag listeners on unmount so a mid-drag close can't
+  // leak pointermove/pointerup handlers on window. The refs hold the exact
+  // functions that were added (stored in startDrag); if no drag is active
+  // they are null and removeEventListener is a no-op on a missing handler.
+  useEffect(() => {
+    return () => {
+      if (pointerMoveRef.current) window.removeEventListener("pointermove", pointerMoveRef.current);
+      if (pointerUpRef.current) window.removeEventListener("pointerup", pointerUpRef.current);
+    };
+  }, []);
   function handlePointerMove(e: PointerEvent) {
     if (dragStartYRef.current === null) return;
     const delta = e.clientY - dragStartYRef.current;
@@ -121,11 +138,17 @@ export function Sheet({
     }
     window.removeEventListener("pointermove", handlePointerMove);
     window.removeEventListener("pointerup", handlePointerUp);
+    pointerMoveRef.current = null;
+    pointerUpRef.current = null;
   }
 
   function startDrag(e: ReactPointerEvent) {
     dragStartYRef.current = e.clientY;
     dragStartGeometryRef.current = geometry;
+    // Store the listener functions in the refs BEFORE adding them so the
+    // unmount cleanup can remove these exact references.
+    pointerMoveRef.current = handlePointerMove;
+    pointerUpRef.current = handlePointerUp;
     window.addEventListener("pointermove", handlePointerMove);
     window.addEventListener("pointerup", handlePointerUp);
   }
@@ -157,10 +180,9 @@ export function Sheet({
       headerClassName={EXPANDABLE_HEADER_CLASS}
       bodyClassName={EXPANDABLE_BODY_CLASS}
       panelClassName={`${SIDE_CLASS[side]} ${EXPANDABLE_BOTTOM_CLASS}`}
+      style={heightStyle}
     >
-      <div style={heightStyle} data-geometry={geometry}>
-        {children}
-      </div>
+      <div data-geometry={geometry}>{children}</div>
     </OverlayPanel>
   );
 }

--- a/cmd/evener-hub/frontend/src/widgets/sheet/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/sheet/index.tsx
@@ -1,4 +1,11 @@
-import type { ReactNode } from "react";
+import {
+  type CSSProperties,
+  type ReactNode,
+  type PointerEvent as ReactPointerEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import dialogStyles from "../dialog/dialog.module.css";
 import { OverlayPanel } from "../dialog/OverlayPanel";
 import { requireClass } from "../internal/requireClass";
@@ -6,6 +13,11 @@ import styles from "./sheet.module.css";
 
 export type SheetSide = "right" | "bottom" | "left";
 export type SheetSize = "standard" | "wide";
+
+export interface ExpandableConfig {
+  peekHeight: number;
+  fullScreenFirst?: boolean;
+}
 
 export interface SheetProps {
   side?: SheetSide;
@@ -15,6 +27,12 @@ export interface SheetProps {
   title: string;
   children: ReactNode;
   footer?: ReactNode;
+  /** When set, the Sheet renders a drag handle and manages a "peek" | "full"
+   * geometry state (full on every open transition when fullScreenFirst). The
+   * handle both drags (pointermove threshold) and taps (toggles). Scoped
+   * header/body classes flow to OverlayPanel. Defaults to undefined; existing
+   * consumers that don't pass it render exactly as before. */
+  expandable?: ExpandableConfig;
 }
 
 const BASE_PANEL_CLASS = requireClass(dialogStyles.panel, "dialog.module.css", "panel");
@@ -30,23 +48,119 @@ const SIZE_CLASS: Record<SheetSize, string> = {
   wide: requireClass(styles.wide, "sheet.module.css", "wide"),
 };
 
+const HANDLE_CLASS = requireClass(styles.handle, "sheet.module.css", "handle");
+const HANDLE_BAR_CLASS = requireClass(styles.handleBar, "sheet.module.css", "handleBar");
+const EXPANDABLE_BOTTOM_CLASS = requireClass(styles.expandableBottom, "sheet.module.css", "expandableBottom");
+const EXPANDABLE_HEADER_CLASS = requireClass(styles.expandableHeader, "sheet.module.css", "expandableHeader");
+const EXPANDABLE_BODY_CLASS = requireClass(styles.expandableBody, "sheet.module.css", "expandableBody");
+
+function DragHandle({ onPointerDown }: { onPointerDown: (e: ReactPointerEvent) => void }) {
+  return (
+    <div className={HANDLE_CLASS} data-testid="sheet-handle" onPointerDown={onPointerDown}>
+      <div className={HANDLE_BAR_CLASS} />
+    </div>
+  );
+}
+
 /**
  * Slide-over panel anchored to the right edge, the left edge, or the
  * bottom edge - otherwise the exact Dialog contract (see ../dialog),
  * sharing its OverlayPanel: scrim, Escape/scrim-click to close, trapped
  * and restored focus, close button. Only the panel's own geometry and
  * slide-in animation differ (sheet.module.css).
+ *
+ * When `expandable` is set, the Sheet additionally renders a drag handle
+ * above the header and manages a "peek" | "full" geometry state, resetting
+ * to "full" on every open false->true transition (when fullScreenFirst).
+ * The handle drags between the two geometries (pointermove past a threshold
+ * on the window) and taps to toggle. The current geometry is surfaced on a
+ * wrapper div inside the body as a `data-geometry` attribute for tests and
+ * for CSS to key off. When `expandable` is not set, this is the plain
+ * Sheet - no handle, no extra classes, fixed geometry - byte-for-byte the
+ * pre-existing behavior.
  */
-export function Sheet({ side = "right", size = "standard", open, onClose, title, children, footer }: SheetProps) {
+export function Sheet({
+  side = "right",
+  size = "standard",
+  open,
+  onClose,
+  title,
+  children,
+  footer,
+  expandable,
+}: SheetProps) {
+  const [geometry, setGeometry] = useState<"peek" | "full">(expandable?.fullScreenFirst ? "full" : "peek");
+  const dragStartYRef = useRef<number | null>(null);
+  const dragStartGeometryRef = useRef<"peek" | "full">("peek");
+
+  // Reset geometry to full on every open transition (false->true). An effect
+  // keyed on `open` (and fullScreenFirst) is the only place that observes
+  // that transition; the render-time useState initializer only fires once,
+  // on mount, so without this a peek reached before close would survive a
+  // reopen.
+  useEffect(() => {
+    if (open && expandable?.fullScreenFirst) setGeometry("full");
+  }, [open, expandable?.fullScreenFirst]);
+
+  function handlePointerMove(e: PointerEvent) {
+    if (dragStartYRef.current === null) return;
+    const delta = e.clientY - dragStartYRef.current;
+    // Dragging down from full toward peek, or up from peek toward full.
+    if (dragStartGeometryRef.current === "full" && delta > 50) setGeometry("peek");
+    else if (dragStartGeometryRef.current === "peek" && delta < -50) setGeometry("full");
+  }
+
+  function handlePointerUp(e: PointerEvent) {
+    if (dragStartYRef.current === null) return;
+    const delta = e.clientY - dragStartYRef.current;
+    const wasDrag = Math.abs(delta) > 10;
+    dragStartYRef.current = null;
+    if (!wasDrag) {
+      // Tap toggles between the two geometries.
+      setGeometry((g) => (g === "peek" ? "full" : "peek"));
+    }
+    window.removeEventListener("pointermove", handlePointerMove);
+    window.removeEventListener("pointerup", handlePointerUp);
+  }
+
+  function startDrag(e: ReactPointerEvent) {
+    dragStartYRef.current = e.clientY;
+    dragStartGeometryRef.current = geometry;
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
+  }
+
+  if (!expandable) {
+    return (
+      <OverlayPanel
+        open={open}
+        onClose={onClose}
+        title={title}
+        footer={footer}
+        panelClassName={`${SIDE_CLASS[side]} ${SIZE_CLASS[size]}`}
+      >
+        {children}
+      </OverlayPanel>
+    );
+  }
+
+  const heightStyle: CSSProperties =
+    geometry === "full" ? { height: "100vh" } : { height: `${expandable.peekHeight}px` };
+
   return (
     <OverlayPanel
       open={open}
       onClose={onClose}
       title={title}
       footer={footer}
-      panelClassName={`${SIDE_CLASS[side]} ${SIZE_CLASS[size]}`}
+      handle={<DragHandle onPointerDown={startDrag} />}
+      headerClassName={EXPANDABLE_HEADER_CLASS}
+      bodyClassName={EXPANDABLE_BODY_CLASS}
+      panelClassName={`${SIDE_CLASS[side]} ${EXPANDABLE_BOTTOM_CLASS}`}
     >
-      {children}
+      <div style={heightStyle} data-geometry={geometry}>
+        {children}
+      </div>
     </OverlayPanel>
   );
 }

--- a/cmd/evener-hub/frontend/src/widgets/sheet/sheet.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/sheet/sheet.module.css
@@ -95,4 +95,53 @@
   .left {
     animation: none;
   }
+
+/* --- expandable bottom Sheet (Task 2) -------------------------------------
+ * A bottom-anchored Sheet can opt into a peek/full geometry: a drag handle
+ * at the top toggles or drags between a fixed peek height and full viewport
+ * height. .expandableBottom animates the height transition; .expandableHeader
+ * stays pinned so it survives the body's scroll; .expandableBody gives the
+ * inner scroll region a flex column that can actually shrink (min-height:
+ * 0) so the content clips instead of overflowing the panel.
+ */
+
+.handle {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-2) 0 var(--space-1);
+  cursor: grab;
+  touch-action: none;
+}
+
+.handleBar {
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--ink-low);
+}
+
+.expandableBottom {
+  height: 100vh;
+  transition: height var(--motion-duration-overlay) var(--motion-easing-standard);
+}
+
+.expandableHeader {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--surface-inset);
+}
+
+.expandableBody {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .expandableBottom {
+    transition: none;
+  }
+}
 }

--- a/cmd/evener-hub/frontend/src/widgets/sheet/sheet.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/sheet/sheet.module.css
@@ -123,6 +123,13 @@
 
 .expandableBottom {
   height: 100vh;
+  /* Override .bottom's max-height: min(480px, 100vh): when expandable, the
+   * panel owns the dynamic height (peek vs full) via an inline style, and
+   * the 480px cap would prevent the "full" (100vh) geometry from ever
+   * filling the screen. .expandableBottom appears after .bottom in the
+   * composed panelClassName and has equal (single-class) specificity, so
+   * this later declaration wins. */
+  max-height: 100vh;
   transition: height var(--motion-duration-overlay) var(--motion-easing-standard);
 }
 

--- a/cmd/evener-hub/frontend/src/widgets/sheet/sheet.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/sheet/sheet.module.css
@@ -95,6 +95,7 @@
   .left {
     animation: none;
   }
+}
 
 /* --- expandable bottom Sheet (Task 2) -------------------------------------
  * A bottom-anchored Sheet can opt into a peek/full geometry: a drag handle
@@ -128,7 +129,7 @@
 .expandableHeader {
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: var(--z-sticky-bar);
   background: var(--surface-inset);
 }
 
@@ -143,5 +144,4 @@
   .expandableBottom {
     transition: none;
   }
-}
 }

--- a/cmd/evener-hub/frontend/src/widgets/sheet/sheet.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/sheet/sheet.test.tsx
@@ -189,3 +189,85 @@ test("all side variants' slide-in animations honor prefers-reduced-motion, using
   expect(css).toContain("var(--motion-duration-overlay)");
   expect(css).toMatch(/@media \(prefers-reduced-motion: reduce\)/);
 });
+
+// --- expandable mode (Task 2) --------------------------------------------
+// The drag handle (data-testid="sheet-handle") is rendered only when
+// `expandable` is set; geometry state ("peek" | "full") is exposed via a
+// `data-geometry` attribute on a wrapper div inside the body (see
+// index.tsx), so these assertions query that wrapper rather than the dialog
+// panel itself.
+
+test("expandable renders a drag handle", () => {
+  render(
+    <Sheet open side="bottom" expandable={{ peekHeight: 200 }} onClose={vi.fn()} title="t">
+      Body
+    </Sheet>,
+  );
+  expect(screen.getByRole("dialog").querySelector("[data-testid='sheet-handle']")).toBeTruthy();
+});
+
+test("non-expandable renders no drag handle", () => {
+  render(
+    <Sheet open side="bottom" onClose={vi.fn()} title="t">
+      Body
+    </Sheet>,
+  );
+  expect(screen.queryByTestId("sheet-handle")).toBeNull();
+});
+
+test("fullScreenFirst starts at full on mount", () => {
+  render(
+    <Sheet open side="bottom" expandable={{ peekHeight: 200, fullScreenFirst: true }} onClose={vi.fn()} title="t">
+      Body
+    </Sheet>,
+  );
+  const panel = screen.getByRole("dialog");
+  expect(panel.querySelector("[data-geometry]")?.getAttribute("data-geometry")).toBe("full");
+});
+
+test("fullScreenFirst resets to full on reopen", async () => {
+  const { rerender } = render(
+    <Sheet open side="bottom" expandable={{ peekHeight: 200, fullScreenFirst: true }} onClose={vi.fn()} title="t">
+      Body
+    </Sheet>,
+  );
+  const panel = screen.getByRole("dialog");
+  // Simulate user dragging to peek
+  fireEvent.pointerDown(screen.getByTestId("sheet-handle"), { clientY: 500 });
+  fireEvent.pointerMove(window, { clientY: 800 });
+  fireEvent.pointerUp(window, { clientY: 800 });
+  expect(panel.querySelector("[data-geometry]")?.getAttribute("data-geometry")).toBe("peek");
+  // Close and reopen
+  rerender(
+    <Sheet
+      open={false}
+      side="bottom"
+      expandable={{ peekHeight: 200, fullScreenFirst: true }}
+      onClose={vi.fn()}
+      title="t"
+    >
+      Body
+    </Sheet>,
+  );
+  rerender(
+    <Sheet open side="bottom" expandable={{ peekHeight: 200, fullScreenFirst: true }} onClose={vi.fn()} title="t">
+      Body
+    </Sheet>,
+  );
+  expect(screen.getByRole("dialog").querySelector("[data-geometry]")?.getAttribute("data-geometry")).toBe("full");
+});
+
+test("tap on handle toggles peek to full", () => {
+  render(
+    <Sheet open side="bottom" expandable={{ peekHeight: 200, fullScreenFirst: false }} onClose={vi.fn()} title="t">
+      Body
+    </Sheet>,
+  );
+  const panel = screen.getByRole("dialog");
+  // Starts at peek (fullScreenFirst is false)
+  expect(panel.querySelector("[data-geometry]")?.getAttribute("data-geometry")).toBe("peek");
+  // Tap toggles to full
+  fireEvent.pointerDown(screen.getByTestId("sheet-handle"), { clientY: 100 });
+  fireEvent.pointerUp(window, { clientY: 100 });
+  expect(panel.querySelector("[data-geometry]")?.getAttribute("data-geometry")).toBe("full");
+});


### PR DESCRIPTION
## Summary

On mobile, unifies the welcome screen and the bottom-panel sidebar (TreeDrawer) into a single expandable surface that slides up to full screen. The unique key-binding content from the welcome screen moves to the bottom of the panel. The example task prompts are removed on both mobile and desktop.

## Changes

- **OverlayPanel** (`src/widgets/dialog/OverlayPanel.tsx`): Added optional `handle`, `bodyClassName`, `headerClassName`, and `style` props (all default undefined — existing Dialog/Sheet consumers unchanged).
- **Sheet** (`src/widgets/sheet/`): Added opt-in `expandable` capability — drag handle + peek/full geometry state + geometry reset on open + scoped sticky header/scroll body classes. Non-expandable path is byte-for-byte identical.
- **WelcomeContent** (`src/panes/welcome/WelcomeContent.tsx`): Extracted presentational welcome content (`showNewSession`, `showHints` props). No example prompts. Desktop `Welcome.tsx` is a thin wrapper.
- **MobilePanel** (`src/shell/mobile/MobilePanel.tsx`): New unified panel composing expandable Sheet + forwarded rail + WelcomeContent. Owns auto-close effect.
- **TreeDrawer** (`src/shell/mobile/TreeDrawer.tsx`): Converted to trigger-only (`onOpen` prop, no Sheet).
- **StackHost** (`src/shell/mobile/StackHost.tsx`): Owns shared panel-open `useState`; opens panel when `nothingFocused` (guarded by `routeDeferred`); forwards `railSlot` to MobilePanel.

## Design

- Spec: `docs/superpowers/specs/2026-08-29-mobile-welcome-panel-design.md`
- Plan: `docs/superpowers/plans/2026-08-29-mobile-welcome-panel.md`

Both were reviewed through 3 rounds of adversarial spec review (2 subagents per round) until zero serious findings remained.

## Verification

- `make test-web` PASS (typecheck, test, lint)
- `npm run layoutguard` — all 19 cases pass
- Full vitest suite: 7283/7283 pass
- Adversarial implementation review (2 subagents): 3 serious findings found and fixed (max-height cap, layoutguard red, listener leak); re-reviewed clean