### PR TITLE
docs+tests: close intent rename review findings

### DIFF
--- a/agent/fuzz_fc2_dispatch_test.go
+++ b/agent/fuzz_fc2_dispatch_test.go
@@ -81,10 +81,9 @@ func FuzzFc2OutputWindowStatus(f *testing.F) {
 	})
 }
 
-// FuzzFc2ToolStartDescription drives toolStartDescription — the pure description
-// promotion lifted out of execTool: an explicit "intent" wins over the legacy
-// promotion lifted out of execTool: an explicit "intent" is returned verbatim,
-// else empty. Oracles (beyond never-panic):
+// FuzzFc2ToolStartDescription drives toolStartDescription — the pure promotion
+// lifted out of execTool: an explicit "intent" is returned verbatim, else empty.
+// Oracles (beyond never-panic):
 //   - determinism;
 //   - a non-empty string "intent" is always returned verbatim;
 //   - otherwise the result is empty.

--- a/agent/transcript_render.go
+++ b/agent/transcript_render.go
@@ -950,8 +950,8 @@ func writeToolCard(b *strings.Builder, callOwnerSeq int, tc *llm.ToolCallData, i
 	}
 }
 
-// writeToolCardLine emits the "- [status] `name` — purpose: <X> — input: <summary>"
-// header line for a tool card. The purpose segment is omitted when absent.
+// writeToolCardLine emits the "- [status] `name` — intent: <X> — input: <summary>"
+// header line for a tool card. The intent segment is omitted when absent.
 func writeToolCardLine(b *strings.Builder, status, name string, args json.RawMessage) {
 	fmt.Fprintf(b, "- [%s] `%s`", status, name)
 	if intent := toolIntent(args); intent != "" {

--- a/agent/transcript_render_test.go
+++ b/agent/transcript_render_test.go
@@ -1000,7 +1000,7 @@ func TestRenderMarkdown_ResultToolResultNotOrphaned(t *testing.T) {
 }
 
 // TestRenderMarkdown_IntentField verifies intent: appears only when an explicit
-// intent/purpose/description argument is present.
+// intent argument is present.
 func TestRenderMarkdown_IntentField(t *testing.T) {
 	t.Parallel()
 	t.Run("intent present when explicit intent arg given", func(t *testing.T) {
@@ -1021,11 +1021,11 @@ func TestRenderMarkdown_IntentField(t *testing.T) {
 		}
 		out := renderMarkdown(transcript.Header{}, entries, 0, renderOpts{})
 		if strings.Contains(out, "intent:") {
-			t.Errorf("intent segment must be omitted when no intent/purpose/description arg, got:\n%s", out)
+			t.Errorf("intent segment must be omitted when no intent arg, got:\n%s", out)
 		}
 	})
 
-	t.Run("intent and description also recognized", func(t *testing.T) {
+	t.Run("intent from non-shell tool arg", func(t *testing.T) {
 		entries := []transcript.Entry{
 			toolCallEntry(call("c1", "grep", `{"pattern":"x","intent":"find the symbol"}`)),
 			toolResultEntry(result("c1", "grep", "match", false)),

--- a/cmd/evener-tui/internal/toolsummary/fuzz_coverage_test.go
+++ b/cmd/evener-tui/internal/toolsummary/fuzz_coverage_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestFuzzCoverageUnion(t *testing.T) {
 	cases := []struct{ tool, args string }{
-		{"shell", `{"command":"x","description":"legacy"}`},
+		{"shell", `{"command":"x","intent":"describe the change"}`},
 		{"shell", `{"command":"line one\nline two"}`},
 		{"read_file", `{"file_path":""}`},
 		{"read_file", `{"file_path":"a/b","offset":1}`},

--- a/docs/tools/transcripts.md
+++ b/docs/tools/transcripts.md
@@ -208,8 +208,8 @@ Rendering rules:
   omitted note; unknown kinds get a labeled note. Nothing is silently dropped.
 - **Reasoning shown** — assistant thinking and text render in full, in recorded order.
 - **Tool-call condensation** — calls render as condensed cards under a **Tools** block:
-  `- [status] \`name\` — purpose: <X> — input: <summary>`. Purpose comes only from an
-  explicit `purpose`/`intent`/`description` arg, never inferred. Input summaries are
+  `- [status] \`name\` — intent: <X> — input: <summary>`. Intent comes only from an
+  explicit `intent` arg, never inferred. Input summaries are
   per-tool and never dump file contents or full edit strings.
 - **Tool-result pairing** — results pair to calls by **call ID**, never by adjacency. A
   result whose call is not in the rendered slice collects under a **"Tool results without a

--- a/internal/appprojector/appwire_projection_test.go
+++ b/internal/appprojector/appwire_projection_test.go
@@ -2601,7 +2601,7 @@ func notificationTurnID(t *testing.T, items []AppNotification, method string) st
 // in Description; the completed item must carry it too (derived from the
 // call's arguments, mirroring apptranscript.ToolIntentFromArguments) so the
 // activity line stays on the intent when the tool finishes.
-func TestAppEventProjectorToolCallEndCarriesPurposeDescription(t *testing.T) {
+func TestAppEventProjectorToolCallEndCarriesIntentDescription(t *testing.T) {
 	projector := NewAppEventProjector("th_1", "local:th_1")
 	projector.Project(events.SessionEvent{Kind: events.EventUserInput, SessionID: "th_1", Data: events.UserInputData{Text: "hello"}})
 
@@ -2621,7 +2621,9 @@ func TestAppEventProjectorToolCallEndCarriesPurposeDescription(t *testing.T) {
 		t.Fatalf("completed tool item should carry the intent-derived Description, got %q", item.Description)
 	}
 
-	// The intent field is honored too, matching ToolIntentFromArguments.
+	// Description is derived from the arguments' intent field when the
+	// started event carries no explicit Description, matching
+	// ToolIntentFromArguments.
 	projector.Project(events.SessionEvent{Kind: events.EventToolCallStart, SessionID: "th_1", Data: events.ToolCallStartData{
 		ToolName:      "grep",
 		CallID:        "call_2",
@@ -2637,7 +2639,7 @@ func TestAppEventProjectorToolCallEndCarriesPurposeDescription(t *testing.T) {
 		t.Fatalf("completed tool item should derive Description from the intent field, got %q", item.Description)
 	}
 
-	// No purpose in the arguments: Description stays empty rather than
+	// No intent in the arguments: Description stays empty rather than
 	// falling back to a raw command dump.
 	projector.Project(events.SessionEvent{Kind: events.EventToolCallStart, SessionID: "th_1", Data: events.ToolCallStartData{
 		ToolName:      "shell",
@@ -2651,7 +2653,7 @@ func TestAppEventProjectorToolCallEndCarriesPurposeDescription(t *testing.T) {
 	}})
 	item = notificationThreadItem(t, out, appwire.NotifyItemCompleted)
 	if item.Description != "" {
-		t.Fatalf("purpose-less tool call should have empty Description, got %q", item.Description)
+		t.Fatalf("intent-less tool call should have empty Description, got %q", item.Description)
 	}
 }
 

--- a/internal/apptranscript/apptranscript_test.go
+++ b/internal/apptranscript/apptranscript_test.go
@@ -823,7 +823,7 @@ func TestToolIntentFromArguments(t *testing.T) {
 		want string
 	}{
 		{"intent", `{"intent":"do it"}`, "do it"},
-		{"intent priority", `{"intent":"a","purpose":"b"}`, "a"},
+		{"purpose ignored", `{"intent":"a","purpose":"b"}`, "a"},
 		{"non-string ignored", `{"intent":123}`, ""},
 		{"empty object", `{}`, ""},
 		{"invalid json", `not json`, ""},


### PR DESCRIPTION
## Summary

Follow-up to the purpose→intent rename (#600, merged as 7512a736e). Fixes the seven Minor findings from the adversarial review — all cosmetic staleness left behind by the rename and the subsequent backward-compat removal.

## Changes

| Finding | File | Fix |
|---|---|---|
| Garbled duplicated comment | `agent/fuzz_fc2_dispatch_test.go` | Collapsed to one coherent sentence |
| Stale `purpose:` doc comment | `agent/transcript_render.go` | `writeToolCardLine` comment now says `intent:` |
| Misleading subtest name | `agent/transcript_render_test.go` | "intent and description also recognized" → "intent from non-shell tool arg"; fixed doc comment + error message |
| Stale "intent priority" case | `internal/apptranscript/apptranscript_test.go` | Renamed to "purpose ignored" — with the multi-key chain gone, purpose is simply ignored, not prioritized over |
| Stale comments | `internal/appprojector/appwire_projection_test.go` | "No purpose"/"purpose-less" → intent wording; reworded misleading "intent field is honored too" comment; renamed `...CarriesPurposeDescription` test fn |
| Stale corpus entry | `cmd/evener-tui/internal/toolsummary/fuzz_coverage_test.go` | `{"description":"legacy"}` → `intent` arg exercising the current contract |
| Stale living spec | `docs/tools/transcripts.md` | Tool-card condensation rule now documents intent-only: `intent: <X>` from an explicit intent arg |

Dated plan/report/spec documents still mentioning `purpose` are historical artifacts and were deliberately left unchanged.

## Verification
- `go build ./...` — pass
- `go vet ./...` — pass
- `make vet` — pass
- Full test suites for all touched packages (agent, apptranscript, appprojector, toolsummary, msgrender) — pass
- `gofmt` — clean