### PR TITLE
fix(agent): reject stale turn interrupts via SinceTurnID click-time binding (#178)

### DIFF
--- a/agent/session_client_mutation.go
+++ b/agent/session_client_mutation.go
@@ -528,6 +528,20 @@ func (s *Session) InterruptClientMutation(
 			rejectClientMutation(record, appwire.Conflict("session is not processing"))
 			return nil
 		}
+		// The click-time binding (issue #178): a Stop carrying the turn that
+		// was active when it was clicked, delivered only after a DIFFERENT
+		// turn is already running, refers to a turn the user saw end. Applying
+		// it would cancel a later turn they never saw, so it is rejected as
+		// expired instead -- surfaced, not silent. Inequality with a non-empty
+		// current id is the whole test: every ActiveTurnID is minted from one
+		// monotonic counter and never reused, so a different id IS a later
+		// generation. An equal id (late delivery still inside the clicked
+		// turn, the #176 window) and an absent one (old client, old durable
+		// outbox record) both fall through to today's session-scoped rule.
+		if params.SinceTurnID != "" && snapshot.ActiveTurnID != "" && snapshot.ActiveTurnID != params.SinceTurnID {
+			rejectClientMutation(record, appwire.Conflict("stop expired: a later turn is already running"))
+			return nil
+		}
 		// The fence records the turn this interrupt is actually cancelling,
 		// which is the durable name of whatever was running -- and the empty
 		// name when that turn had none. An interrupt that matches no pending

--- a/agent/session_client_mutation.go
+++ b/agent/session_client_mutation.go
@@ -533,12 +533,28 @@ func (s *Session) InterruptClientMutation(
 		// turn is already running, refers to a turn the user saw end. Applying
 		// it would cancel a later turn they never saw, so it is rejected as
 		// expired instead -- surfaced, not silent. Inequality with a non-empty
-		// current id is the whole test: every ActiveTurnID is minted from one
-		// monotonic counter and never reused, so a different id IS a later
-		// generation. An equal id (late delivery still inside the clicked
-		// turn, the #176 window) and an absent one (old client, old durable
-		// outbox record) both fall through to today's session-scoped rule.
-		if params.SinceTurnID != "" && snapshot.ActiveTurnID != "" && snapshot.ActiveTurnID != params.SinceTurnID {
+		// current id is the whole test: every durable ActiveTurnID is minted
+		// from one monotonic counter and never reused, so a different id IS a
+		// later generation. An equal id (late delivery still inside the clicked
+		// turn, the #176 window), an absent one (old client, old durable
+		// outbox record), and an empty current one (the between-turn gap, or a
+		// daemon-started turn whose durable mint has not landed) all fall
+		// through to today's session-scoped rule.
+		//
+		// The namespace gate: only a durable turn_m<N> SinceTurnID can be
+		// ordered against the mutation counter. The wire also publishes
+		// PROJECTOR-namespace turn_N ids as the active turn (setProcessingLocked
+		// mints them for daemon-started kinds before the durable mint exists),
+		// so a client that read the thread in that window legitimately holds a
+		// turn_N naming the SAME logical turn the session's turn_mN names --
+		// two non-empty, unequal ids with no staleness between them, and
+		// comparing them would reject an on-time Stop as expired. A projector id
+		// has no durable alias to compare against, so it falls through to the
+		// session-scoped rule exactly as an absent field does -- and that costs
+		// nothing, because the projector namespace is only ever the click-time
+		// view of the CURRENT turn, never of a past one.
+		if strings.HasPrefix(params.SinceTurnID, "turn_m") &&
+			snapshot.ActiveTurnID != "" && snapshot.ActiveTurnID != params.SinceTurnID {
 			rejectClientMutation(record, appwire.Conflict("stop expired: a later turn is already running"))
 			return nil
 		}

--- a/agent/session_client_mutation.go
+++ b/agent/session_client_mutation.go
@@ -550,9 +550,10 @@ func (s *Session) InterruptClientMutation(
 		// two non-empty, unequal ids with no staleness between them, and
 		// comparing them would reject an on-time Stop as expired. A projector id
 		// has no durable alias to compare against, so it falls through to the
-		// session-scoped rule exactly as an absent field does -- and that costs
-		// nothing, because the projector namespace is only ever the click-time
-		// view of the CURRENT turn, never of a past one.
+		// session-scoped rule exactly as an absent field does -- staleness in
+		// that namespace cannot be detected (a projector id has no durable
+		// alias), so falling through restores the pre-#178 session-scoped
+		// behavior for projector-held ids rather than guessing.
 		if strings.HasPrefix(params.SinceTurnID, "turn_m") &&
 			snapshot.ActiveTurnID != "" && snapshot.ActiveTurnID != params.SinceTurnID {
 			rejectClientMutation(record, appwire.Conflict("stop expired: a later turn is already running"))

--- a/agent/session_interrupt_scope_test.go
+++ b/agent/session_interrupt_scope_test.go
@@ -37,6 +37,17 @@ func runningStartTurn(t *testing.T, sess *Session, clientMutationID, text string
 	return started.Turn.ID
 }
 
+// completedStartTurn runs a turn to completion and returns its id, leaving the
+// session settled after it: the state a stale Stop's SinceTurnID refers to.
+func completedStartTurn(t *testing.T, sess *Session, clientMutationID, text string) string {
+	t.Helper()
+	turnID := runningStartTurn(t, sess, clientMutationID, text)
+	if err := sess.completeClientMutationTurn(clientMutationID); err != nil {
+		t.Fatalf("completeClientMutationTurn(%q): %v", clientMutationID, err)
+	}
+	return turnID
+}
+
 // TestInterruptStopsATurnItCannotName is Task 1's between-turn gap: the drain
 // loop settled turn 1 (clearing the durable name) while a queued message keeps
 // the session running, so no id any client holds names the turn that is over.
@@ -256,5 +267,174 @@ func TestInterruptRetryStopsNothingTwice(t *testing.T) {
 	survivor := snapshot.Journal["start-idempotence-two"]
 	if survivor.OperationState == clientMutationOperationTerminal {
 		t.Fatalf("retry terminalized the second turn: %#v", survivor)
+	}
+}
+
+// TestInterruptSinceTurnID rejects a Stop whose delivery crossed a turn
+// boundary the user never saw. The click-time binding is SinceTurnID -- the
+// active turn id the client held when Stop was pressed -- and issue #178 is
+// the delayed dispatch that lands only after a LATER turn is already running.
+// The guard must reject that delivery outright (surfaced as a rejection, the
+// same shape as "session is not processing"), never cancel the later turn.
+//
+// The same-generation case is the #176 win preserved: a Stop pressed during
+// turn N's pre-turn work, delivered late but still inside turn N, must still
+// land. And the absent field is backward compatibility -- an old client (or an
+// old durable outbox record) that sends no sinceTurnId gets today's
+// session-scoped behavior, unchanged.
+func TestInterruptSinceTurnID(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(t *testing.T, sess *Session)
+	}{
+		{
+			// The issue #178 repro: turn 1 is clicked-then-missed, turn 2 is
+			// running at delivery. Modelled on TestInterruptRetryStopsNothingTwice
+			// but WITHOUT reusing the clientMutationId -- this is the FIRST
+			// delivery arriving late, not a replayed one.
+			name: "delayed stop must not cancel a later turn",
+			run: func(t *testing.T, sess *Session) {
+				firstTurn := completedStartTurn(t, sess, "start-since-one", "first message")
+				secondTurn := runningStartTurn(t, sess, "start-since-two", "second message")
+
+				cancels := 0
+				_, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+					ClientMutationID: "interrupt-since-stale",
+					SinceTurnID:      firstTurn,
+				}, func() { cancels++ })
+				if err == nil || !strings.Contains(err.Error(), "stop expired") {
+					t.Fatalf("stale-SinceTurnID interrupt = %v, want a stop expired rejection", err)
+				}
+				if cancels != 0 {
+					t.Fatalf("stale-SinceTurnID interrupt cancelled %d times, want 0", cancels)
+				}
+				snapshot := sess.clientMutations.snapshot()
+				if snapshot.ActiveTurnID != secondTurn {
+					t.Fatalf("ActiveTurnID after the stale interrupt = %q, want the untouched second turn %q", snapshot.ActiveTurnID, secondTurn)
+				}
+				if snapshot.InterruptFence != nil {
+					t.Fatalf("stale interrupt left a fence: %#v", snapshot.InterruptFence)
+				}
+				if snapshot.QueueHeld {
+					t.Fatal("stale interrupt held the queue")
+				}
+				survivor := snapshot.Journal["start-since-two"]
+				if survivor.OperationState == clientMutationOperationTerminal {
+					t.Fatalf("stale interrupt terminalized the second turn: %#v", survivor)
+				}
+				rejected := snapshot.Journal["interrupt-since-stale"]
+				if rejected.OperationState != clientMutationOperationRejected {
+					t.Fatalf("stale interrupt record = %#v, want rejected", rejected)
+				}
+			},
+		},
+		{
+			// A genuine retry of an expired Stop must replay the terminal
+			// rejection, not re-evaluate against a now-current ActiveTurnID --
+			// the property TestInterruptRetryStopsNothingTwice pins for the
+			// applied case, pinned here for the expired one.
+			name: "retry of an expired stop replays the rejection",
+			run: func(t *testing.T, sess *Session) {
+				firstTurn := completedStartTurn(t, sess, "start-retry-expired-one", "first message")
+				secondTurn := runningStartTurn(t, sess, "start-retry-expired-two", "second message")
+
+				interrupt := appwire.TurnInterruptParams{
+					ClientMutationID: "interrupt-retry-expired",
+					SinceTurnID:      firstTurn,
+				}
+				cancels := 0
+				_, firstErr := sess.InterruptClientMutation(context.Background(), interrupt, func() { cancels++ })
+				if firstErr == nil || !strings.Contains(firstErr.Error(), "stop expired") {
+					t.Fatalf("first expired interrupt = %v, want a stop expired rejection", firstErr)
+				}
+				_, retryErr := sess.InterruptClientMutation(context.Background(), interrupt, func() { cancels++ })
+				if retryErr == nil || !strings.Contains(retryErr.Error(), "stop expired") {
+					t.Fatalf("retried expired interrupt = %v, want the same stop expired rejection", retryErr)
+				}
+				if cancels != 0 {
+					t.Fatalf("retried expired interrupt cancelled %d times, want 0", cancels)
+				}
+				// The retry replays the durable rejection itself (a retry of
+				// a rejected mutation returns that rejection), so the journal
+				// record must still be the same terminal rejection and the
+				// second turn must remain untouched.
+				snapshot := sess.clientMutations.snapshot()
+				if snapshot.ActiveTurnID != secondTurn {
+					t.Fatalf("ActiveTurnID after the retry = %q, want the untouched second turn %q", snapshot.ActiveTurnID, secondTurn)
+				}
+				if rejected := snapshot.Journal["interrupt-retry-expired"]; rejected.OperationState != clientMutationOperationRejected {
+					t.Fatalf("retried expired interrupt record = %#v, want rejected", rejected)
+				}
+			},
+		},
+		{
+			// The #176 regression guard: SinceTurnID equal to the claimed turn's
+			// own id -- a same-generation Stop delivered during pre-turn work --
+			// must still apply.
+			name: "same-generation stop during pre-turn work still applies",
+			run: func(t *testing.T, sess *Session) {
+				if _, err := sess.AcceptClientMutationStart(appwire.TurnStartParams{
+					ClientMutationID: "start-since-claimed",
+					Input:            []appwire.InputItem{{Type: "text", Text: "/park"}},
+				}); err != nil {
+					t.Fatalf("AcceptClientMutationStart: %v", err)
+				}
+				claimed, ok, err := sess.claimClientMutationStart()
+				if err != nil || !ok {
+					t.Fatalf("claimClientMutationStart: claimed=%#v ok=%v err=%v", claimed, ok, err)
+				}
+				claimedTurn := sess.clientMutations.snapshot().ActiveTurnID
+				if claimedTurn == "" {
+					t.Fatal("no durable turn was claimed")
+				}
+
+				cancels := 0
+				response, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+					ClientMutationID: "interrupt-since-claimed",
+					SinceTurnID:      claimedTurn,
+				}, func() { cancels++ })
+				if err != nil {
+					t.Fatalf("same-generation Stop on claimed turn %s: %v", claimedTurn, err)
+				}
+				if cancels != 1 {
+					t.Fatalf("same-generation Stop cancelled %d times, want 1", cancels)
+				}
+				if response.Receipt.TurnID != claimedTurn {
+					t.Fatalf("Stop receipt turn = %q, want the claimed turn %q", response.Receipt.TurnID, claimedTurn)
+				}
+			},
+		},
+		{
+			// Backward compatibility: absent SinceTurnID is today's
+			// session-scoped behavior, deliberately -- an old client or an old
+			// durable outbox record without the field must never trip the new
+			// rejection branch.
+			name: "no sinceTurnId keeps session-scoped behavior",
+			run: func(t *testing.T, sess *Session) {
+				completedStartTurn(t, sess, "start-since-absent-one", "first message")
+				secondTurn := runningStartTurn(t, sess, "start-since-absent-two", "second message")
+
+				cancels := 0
+				response, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+					ClientMutationID: "interrupt-since-absent",
+				}, func() { cancels++ })
+				if err != nil {
+					t.Fatalf("absent-SinceTurnID interrupt across a turn boundary: %v", err)
+				}
+				if cancels != 1 {
+					t.Fatalf("absent-SinceTurnID interrupt cancelled %d times, want 1", cancels)
+				}
+				if response.Receipt.TurnID != secondTurn {
+					t.Fatalf("interrupt receipt turn = %q, want the second turn %q (session-scoped behavior is unchanged)", response.Receipt.TurnID, secondTurn)
+				}
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sess := newQueuePersistTestSession(t, t.TempDir())
+			defer sess.Close()
+			tc.run(t, sess)
+		})
 	}
 }

--- a/agent/session_interrupt_scope_test.go
+++ b/agent/session_interrupt_scope_test.go
@@ -429,6 +429,81 @@ func TestInterruptSinceTurnID(t *testing.T) {
 				}
 			},
 		},
+		{
+			// The namespace gate (round-1 review B-1): the wire publishes a
+			// PROJECTOR-namespace turn_N as the active turn id for
+			// daemon-started kinds (setProcessingLocked mints it for goal
+			// continuations, notification wakes, queued drains, steering
+			// claims -- before the durable turn_mN exists), so a client that
+			// reads the thread in that window legitimately holds turn_N for
+			// the SAME logical turn the session's turn_mN names. A
+			// cross-namespace comparison of those two ids is inequality
+			// without staleness -- a false "stop expired" for a Stop that is
+			// exactly on time. SinceTurnID a projector id cannot be ordered
+			// against the mutation counter, so the guard must fall through to
+			// session-scoped behavior, exactly as an absent field does.
+			name: "projector-namespace sinceTurnId falls through to session-scoped behavior",
+			run: func(t *testing.T, sess *Session) {
+				durableTurn := runningStartTurn(t, sess, "start-since-projector", "running message")
+
+				cancels := 0
+				response, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+					ClientMutationID: "interrupt-since-projector",
+					// What thread/read publishes in the window before the
+					// durable id exists: the projector's own turn_N.
+					SinceTurnID: "turn_1",
+				}, func() { cancels++ })
+				if err != nil {
+					t.Fatalf("projector-namespace SinceTurnID against durable turn %s: %v", durableTurn, err)
+				}
+				if cancels != 1 {
+					t.Fatalf("projector-namespace SinceTurnID cancelled %d times, want 1", cancels)
+				}
+				if response.Receipt.TurnID != durableTurn {
+					t.Fatalf("interrupt receipt turn = %q, want the running durable turn %q (a projector sinceTurnId is not comparable and must not reject)", response.Receipt.TurnID, durableTurn)
+				}
+			},
+		},
+		{
+			// The between-turn gap (round-1 review B-2): turn 1 settled, a
+			// queued message keeps the session running, so ActiveTurnID is
+			// empty while WireState reports processing -- the
+			// TestInterruptStopsATurnItCannotName fixture shape, now carrying
+			// a SinceTurnID for the turn that already ended. The guard is
+			// gated on a non-empty current id, so it must not fire: the Stop
+			// applies session-scoped, as it did before the field existed.
+			name: "sinceTurnId with an empty active turn applies session-scoped",
+			run: func(t *testing.T, sess *Session) {
+				firstTurn := completedStartTurn(t, sess, "start-since-gap-one", "first message")
+				if _, err := sess.AcceptClientMutationQueue(appwire.TurnQueueParams{
+					ClientMutationID: "queue-since-gap-follow-up",
+					Input:            []appwire.InputItem{{Type: "text", Text: "second message"}},
+				}); err != nil {
+					t.Fatalf("AcceptClientMutationQueue: %v", err)
+				}
+				if got := sess.clientMutations.snapshot().ActiveTurnID; got != "" {
+					t.Fatalf("durable ActiveTurnID after the first turn settled = %q, want empty", got)
+				}
+				if got := sess.WireState(); got != string(SessionProcessing) {
+					t.Fatalf("WireState in the gap = %q, want %q", got, SessionProcessing)
+				}
+
+				cancels := 0
+				response, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+					ClientMutationID: "interrupt-since-gap",
+					SinceTurnID:      firstTurn,
+				}, func() { cancels++ })
+				if err != nil {
+					t.Fatalf("SinceTurnID interrupt in the between-turn gap: %v", err)
+				}
+				if cancels != 1 {
+					t.Fatalf("SinceTurnID interrupt in the gap cancelled %d times, want 1", cancels)
+				}
+				if response.Receipt.Disposition != appwire.MutationDispositionApplied {
+					t.Fatalf("interrupt disposition = %q, want applied (session-scoped behavior in the gap)", response.Receipt.Disposition)
+				}
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -107,7 +107,7 @@ var Methods = []MethodSpec{
 	{MethodThreadShutdown, ThreadShutdownParams{}, EmptyResponse{}, ScopeBoth, "Shuts the session down (the daemon runs it asynchronously)."},
 	{MethodTurnStart, TurnStartParams{}, TurnStartResponse{}, ScopeBoth, "Starts a new user turn and reserves a turn ID."},
 	{MethodTurnSteer, TurnSteerParams{}, TurnSteerResponse{}, ScopeBoth, "Injects a steering message into the active turn."},
-	{MethodTurnInterrupt, TurnInterruptParams{}, TurnInterruptResponse{}, ScopeBoth, "Cancels whatever turn the session is running; the receipt names the turn actually cancelled."},
+	{MethodTurnInterrupt, TurnInterruptParams{}, TurnInterruptResponse{}, ScopeBoth, "Cancels whatever turn the session is running; the receipt names the turn actually cancelled. sinceTurnId is the click-time binding (issue #178): a stale Stop is rejected, never applied to a later turn."},
 	{MethodTurnQueue, TurnQueueParams{}, TurnQueueResponse{}, ScopeBoth, "Queues a user message for after the active turn completes."},
 	{MethodTurnDrainAsSteer, TurnDrainAsSteerParams{}, TurnDrainAsSteerResponse{}, ScopeBoth, "Drains the input queue and injects it as a single steering message."},
 	{MethodTurnPromoteQueuedAsSteer, TurnPromoteQueuedAsSteerParams{}, TurnPromoteQueuedAsSteerResponse{}, ScopeBoth, "Removes one queued message by index and injects it as user-sourced steering into the in-flight turn."},

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -1373,12 +1373,18 @@ type TurnSteerParams struct {
 // that was active when the user clicked Stop, captured client-side at click
 // time and carried in the durable outbox record, so a dispatch delayed across
 // a turn boundary can be recognized as stale (issue #178). At delivery, a
-// non-empty SinceTurnID that differs from the session's current active turn
-// means the Stop refers to a turn the user already saw end, and applying it
-// would cancel a later turn they never saw -- so it is rejected instead. An
-// equal (or empty) SinceTurnID never rejects: a same-generation Stop still
-// lands however late it arrives (the #176 window), and an old client or an
-// old durable outbox record without the field gets today's behavior unchanged.
+// SinceTurnID in the durable turn_m<N> namespace that differs from the
+// session's current active turn means the Stop refers to a turn the user
+// already saw end, and applying it would cancel a later turn they never saw
+// -- so it is rejected instead. Everything else falls through to today's
+// session-scoped behavior: an equal SinceTurnID (a same-generation Stop,
+// however late), an absent one (old client, old durable outbox record), an
+// empty current active turn (the between-turn gap), and a
+// projector-namespace turn_N one (the wire publishes those for
+// daemon-started turns before the durable mint exists; they name the same
+// logical turn a turn_mN names and cannot be ordered against the mutation
+// counter, so they are never treated as stale). Clients that hold an active
+// turn id SHOULD send it.
 type TurnInterruptParams struct {
 	Ref                string `json:"ref,omitempty"`
 	ThreadID           string `json:"threadId,omitempty"`

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -1368,11 +1368,23 @@ type TurnSteerParams struct {
 // TurnInterruptParams cancels whatever turn the session is running. The receipt
 // names the turn actually cancelled, which is how a client learns what it
 // stopped without having had to name it first.
+//
+// SinceTurnID is not a target. Stop stays session-scoped: this is the turn
+// that was active when the user clicked Stop, captured client-side at click
+// time and carried in the durable outbox record, so a dispatch delayed across
+// a turn boundary can be recognized as stale (issue #178). At delivery, a
+// non-empty SinceTurnID that differs from the session's current active turn
+// means the Stop refers to a turn the user already saw end, and applying it
+// would cancel a later turn they never saw -- so it is rejected instead. An
+// equal (or empty) SinceTurnID never rejects: a same-generation Stop still
+// lands however late it arrives (the #176 window), and an old client or an
+// old durable outbox record without the field gets today's behavior unchanged.
 type TurnInterruptParams struct {
 	Ref                string `json:"ref,omitempty"`
 	ThreadID           string `json:"threadId,omitempty"`
 	ClientMutationID   string `json:"clientMutationId"`
 	ExpectedInstanceID string `json:"expectedInstanceId"`
+	SinceTurnID        string `json:"sinceTurnId,omitempty"`
 }
 
 // TurnQueueParams queues a user message during a running turn for processing

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -1886,6 +1886,7 @@ export interface TurnInterruptParams {
   threadId?: string;
   clientMutationId: string;
   expectedInstanceId: string;
+  sinceTurnId?: string;
 }
 
 export interface TurnInterruptResponse {

--- a/cmd/evener-hub/frontend/src/stores/threads.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/threads.test.ts
@@ -3895,11 +3895,12 @@ describe("useThreadsStore.steer / queue / interrupt", () => {
     });
   });
 
-  // Stop never names a turn, even here, where this client is tracking one.
-  // Naming it could only ever make Stop fail -- the id goes stale when a turn
-  // rolls over between the click and the request -- and a refused Stop is the
-  // failure the button exists to prevent.
-  test("interrupt asks for whatever is running even when this client knows the turn id", async () => {
+  // Stop never TARGETS a turn, even here, where this client is tracking one:
+  // sinceTurnId is not a target but the click-time binding (issue #178). The
+  // daemon rejects a Stop only when a DIFFERENT, later turn is already running
+  // at delivery -- never for naming the "wrong" turn -- so carrying the id can
+  // never make Stop fail the way a target would.
+  test("interrupt carries the click-time turn id, without targeting", async () => {
     const fake = connectMutationClient();
     await ensureActiveTurn(fake, "ref_a");
     expect(threadsStore.getState().threads.get("ref_a")?.activeTurnId).toBe("turn_1");
@@ -3913,6 +3914,37 @@ describe("useThreadsStore.steer / queue / interrupt", () => {
       ref: "ref_a",
       clientMutationId: expect.any(String),
       expectedInstanceId: "thr_ref_a",
+      sinceTurnId: "turn_1",
+    });
+  });
+
+  // The frontend half of issue #178: the generation must be captured at
+  // ENQUEUE time (inside interrupt), not re-read when the dispatcher actually
+  // sends. A dispatch delayed behind an earlier outbox mutation for the same
+  // ref -- or until a reconnect -- is exactly the case where the two differ,
+  // and reading the id lazily at send time would silently defeat the daemon's
+  // stale-Stop rejection.
+  test("interrupt records the click-time sinceTurnId in the durable outbox payload", async () => {
+    const fake = connectMutationClient();
+    await ensureActiveTurn(fake, "ref_a");
+    // The queued mutation ahead of the Stop in the per-ref FIFO never gets an
+    // answer, so the interrupt is still sitting in the outbox when the active
+    // turn rolls over to a later one the user never saw. What matters is the
+    // durable record's own payload: it was written at enqueue (click) time and
+    // must carry the id the client held THEN, not whatever the model says now.
+    fake.on("turn/queue", () => new Promise<TurnQueueResponse>(() => {}));
+    await threadsStore.getState().queue("ref_a", "queued ahead of the stop");
+    await flushIndexedDBUntil(() => fake.calls.some((call) => call.method === "turn/queue"));
+    await threadsStore.getState().interrupt("ref_a");
+    const rolledOver = threadsStore.getState().threads.get("ref_a");
+    if (rolledOver) rolledOver.activeTurnId = "turn_2";
+
+    const persistence = await readMutationPersistence("ref_a");
+    const interrupt = persistence.outbox.find((record) => record.method === "turn/interrupt");
+    expect(interrupt?.payload).toMatchObject({
+      ref: "ref_a",
+      expectedInstanceId: "thr_ref_a",
+      sinceTurnId: "turn_1",
     });
   });
 

--- a/cmd/evener-hub/frontend/src/stores/threads.ts
+++ b/cmd/evener-hub/frontend/src/stores/threads.ts
@@ -2285,10 +2285,18 @@ export const threadsStore = createStore<ThreadsStoreState>(() => ({
     // drain, a cold client -- and stale in the race where a turn rolls over
     // between the click and the request. Neither refusal is what the button
     // means. "Stop" means stop what you are doing.
+    //
+    // sinceTurnId is not that naming (issue #178). It is the click-time
+    // binding: the turn that was active when Stop was pressed, captured HERE
+    // so the durable outbox record carries it verbatim and a dispatch delayed
+    // across a turn boundary can be recognized as stale by the daemon. It
+    // never targets -- the daemon rejects only a DIFFERENT non-empty active
+    // turn at delivery -- and it is omitted (today's behavior) whenever the
+    // client holds no turn id, e.g. a cold client that never saw one.
     await enqueueMutation(
       ref,
       "turn/interrupt",
-      { ref, expectedInstanceId: expectedInstanceID(ref) },
+      { ref, expectedInstanceId: expectedInstanceID(ref), sinceTurnId: trackedThreadModel(ref)?.activeTurnId },
       { method: "turn/interrupt" },
     );
   },

--- a/cmd/evener-tui/hub_command_registry.go
+++ b/cmd/evener-tui/hub_command_registry.go
@@ -210,19 +210,21 @@ var hubCommandRegistry = []hubCommandDefinition{
 		UnavailableAction:  "interrupt",
 		UnavailableSummary: "Interrupt is not available for this session.",
 		Available:          capabilityAvailable(func(c hubSessionCapabilities) bool { return c.Interrupt }, "source does not advertise interrupt"),
-		// No ActiveTurnID gate here. turn/interrupt is session-scoped -- it
-		// names no turn (appwire v3) and the daemon decides on the session's own
-		// quiescence. Gating on an id the request does not carry can only refuse
-		// a Stop the daemon would have taken, and active-with-no-id is a state
-		// the wire really reaches -- a session holding queued work reports
-		// active with no turn running (kata vewa).
+		// No ActiveTurnID GATE here. turn/interrupt is session-scoped -- it
+		// targets no turn (appwire v3) and the daemon decides on the session's
+		// own quiescence. Gating on an id can only refuse a Stop the daemon
+		// would have taken, and active-with-no-id is a state the wire really
+		// reaches -- a session holding queued work reports active with no turn
+		// running (kata vewa). The id still RIDES ALONG as sinceTurnId (issue
+		// #178): the click-time binding the daemon's stale-Stop guard reads,
+		// never a precondition of its own.
 		Run: func(m *hubModel, _ string) tea.Cmd {
 			ref, ok := m.currentRef()
 			if !ok {
 				m.addSessionSystem("Session ref is invalid.")
 				return nil
 			}
-			return sendHubAction(m.client, ref, "interrupt", m.detail.InstanceID)
+			return sendHubAction(m.client, ref, "interrupt", m.detail.ActiveTurnID, m.detail.InstanceID)
 		},
 	},
 	{
@@ -240,7 +242,7 @@ var hubCommandRegistry = []hubCommandDefinition{
 				m.addSessionSystem("Session ref is invalid.")
 				return nil
 			}
-			return sendHubAction(m.client, ref, "compact")
+			return sendHubAction(m.client, ref, "compact", "")
 		},
 	},
 	{
@@ -317,7 +319,7 @@ var hubCommandRegistry = []hubCommandDefinition{
 				m.addSessionSystem("Session ref is invalid.")
 				return nil
 			}
-			return sendHubAction(m.client, ref, "shutdown")
+			return sendHubAction(m.client, ref, "shutdown", "")
 		},
 	},
 	{
@@ -344,7 +346,7 @@ var hubCommandRegistry = []hubCommandDefinition{
 				m.addSessionSystem("Session ref is invalid.")
 				return nil
 			}
-			return sendHubAction(m.client, ref, model)
+			return sendHubAction(m.client, ref, model, "")
 		},
 	},
 	{

--- a/cmd/evener-tui/hub_commands.go
+++ b/cmd/evener-tui/hub_commands.go
@@ -641,7 +641,14 @@ func fetchHubTasksSync(ctx context.Context, client *appwire.Client, ref appwire.
 	return tasks, nil
 }
 
-func sendHubAction(client *appwire.Client, ref appwire.Ref, action string, expectedInstanceIDs ...string) tea.Cmd {
+// sendHubAction dispatches a hub session action. sinceTurnID is the
+// click-time binding for the interrupt branch (issue #178): the turn the wire
+// published as active when Stop was invoked, captured by the CALLER at
+// command-run time so a dispatch delayed across a turn boundary can be
+// recognized as stale by the daemon. It is never a target -- the daemon
+// rejects only a DIFFERENT durable id at delivery -- and empty when this TUI
+// holds no id, which the daemon treats as today's session-scoped behavior.
+func sendHubAction(client *appwire.Client, ref appwire.Ref, action, sinceTurnID string, expectedInstanceIDs ...string) tea.Cmd {
 	// Only the interrupt branch is a retry-safe turn mutation; the rest are
 	// thread-level calls the guard does not cover. Minted unconditionally so the
 	// identity is fixed to the action, not to the branch taken at run time.
@@ -658,6 +665,7 @@ func sendHubAction(client *appwire.Client, ref appwire.Ref, action string, expec
 				Ref:                ref.String(),
 				ClientMutationID:   mutationID,
 				ExpectedInstanceID: expectedInstanceID,
+				SinceTurnID:        strings.TrimSpace(sinceTurnID),
 			})
 		case "compact":
 			err = client.ThreadCompactStart(context.Background(), appwire.ThreadCompactStartParams{Ref: ref.String()})

--- a/cmd/evener-tui/hub_commands_covtest_test.go
+++ b/cmd/evener-tui/hub_commands_covtest_test.go
@@ -377,7 +377,7 @@ func TestCovSendHubAction(t *testing.T) {
 	defer cleanup()
 	ref := appwire.Ref{SourceID: "local", ThreadID: "01TEST"}
 	for _, action := range []string{"interrupt", "compact", "shutdown", "openai/gpt-5"} {
-		cmd := sendHubAction(client, ref, action)
+		cmd := sendHubAction(client, ref, action, "")
 		msg, ok := cmd().(hubActionMsg)
 		if !ok || msg.err != nil {
 			t.Fatalf("action %q result = %#v", action, msg)

--- a/cmd/evener-tui/hub_mutation_identity_test.go
+++ b/cmd/evener-tui/hub_mutation_identity_test.go
@@ -65,12 +65,15 @@ func TestSendHubActionInterruptSendsIdentityAndExpectedTurn(t *testing.T) {
 	client, cleanup := newTUIAppWireClient(t, app)
 	defer cleanup()
 
-	msg := sendHubAction(client, appwire.Ref{SourceID: "local", ThreadID: "th_1"}, "interrupt")()
+	msg := sendHubAction(client, appwire.Ref{SourceID: "local", ThreadID: "th_1"}, "interrupt", "turn_m2")()
 	if actionMsg, ok := msg.(hubActionMsg); !ok || actionMsg.err != nil {
 		t.Fatalf("msg=%T err=%v", msg, actionMsg.err)
 	}
 	if got.ClientMutationID == "" {
 		t.Error("ClientMutationID is empty")
+	}
+	if got.SinceTurnID != "turn_m2" {
+		t.Errorf("SinceTurnID = %q, want the click-time turn id carried through", got.SinceTurnID)
 	}
 }
 

--- a/cmd/evener-tui/hub_session_keys.go
+++ b/cmd/evener-tui/hub_session_keys.go
@@ -107,7 +107,7 @@ func (m hubModel) updateSessionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 				m.addSessionSystem(fmt.Sprintf("Switching to model %s...", selected))
-				return m, sendHubAction(m.client, ref, selected)
+				return m, sendHubAction(m.client, ref, selected, "")
 			}
 			m.session.refreshViewport()
 		}
@@ -349,7 +349,7 @@ func (m hubModel) updateSessionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if turnID := strings.TrimSpace(m.detail.ActiveTurnID); turnID != "" {
 				if ref, ok := m.currentRef(); ok {
 					m.addSessionSystem("Interrupting active turn. Press ctrl+c again to quit.")
-					return m, sendHubAction(m.client, ref, "interrupt", m.detail.InstanceID)
+					return m, sendHubAction(m.client, ref, "interrupt", m.detail.ActiveTurnID, m.detail.InstanceID)
 				}
 			}
 		}

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -1806,6 +1806,7 @@ _(no fields)_
 | `threadId` | `string` | yes |  |
 | `clientMutationId` | `string` |  |  |
 | `expectedInstanceId` | `string` |  |  |
+| `sinceTurnId` | `string` | yes |  |
 
 
 ### `TurnInterruptResponse`

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -103,7 +103,7 @@ no router (reserved).
 | `thread/shutdown` | both | `ThreadShutdownParams` | `EmptyResponse` | Shuts the session down (the daemon runs it asynchronously). |
 | `turn/start` | both | `TurnStartParams` | `TurnStartResponse` | Starts a new user turn and reserves a turn ID. |
 | `turn/steer` | both | `TurnSteerParams` | `TurnSteerResponse` | Injects a steering message into the active turn. |
-| `turn/interrupt` | both | `TurnInterruptParams` | `TurnInterruptResponse` | Cancels whatever turn the session is running; the receipt names the turn actually cancelled. |
+| `turn/interrupt` | both | `TurnInterruptParams` | `TurnInterruptResponse` | Cancels whatever turn the session is running; the receipt names the turn actually cancelled. sinceTurnId is the click-time binding (issue #178): a stale Stop is rejected, never applied to a later turn. |
 | `turn/queue` | both | `TurnQueueParams` | `TurnQueueResponse` | Queues a user message for after the active turn completes. |
 | `turn/drainAsSteer` | both | `TurnDrainAsSteerParams` | `TurnDrainAsSteerResponse` | Drains the input queue and injects it as a single steering message. |
 | `turn/promoteQueuedAsSteer` | both | `TurnPromoteQueuedAsSteerParams` | `TurnPromoteQueuedAsSteerResponse` | Removes one queued message by index and injects it as user-sourced steering into the in-flight turn. |
@@ -171,6 +171,34 @@ no router (reserved).
 | `evener/settings/transcriptDisplay/get` | hub | `EmptyParams` | `TranscriptDisplayDefaults` | Reads the canonical Desktop and Mobile transcript-display defaults. |
 | `evener/settings/transcriptDisplay/patch` | hub | `TranscriptDisplayDefaultsPatchParams` | `TranscriptDisplayPatchResponse` | Updates one transcript-display default using an expected revision and returns the canonical value. |
 | `evener/sandbox/escalation/resolve` | both | `SandboxEscalationResolveParams` | `EmptyResponse` | Delivers a human's approve/deny decision for a pending sandbox-exemption escalation (M7); the daemon unblocks the waiting tool-exec goroutine, the hub relays. |
+
+### `turn/interrupt` — the click-time binding
+
+Stop is session-scoped: it cancels whatever turn the session is running, and
+the receipt names the turn actually cancelled. `sinceTurnId` is not a target
+and never gates acceptance by itself — it is the turn that was active when
+the user pressed Stop, captured client-side at click time and carried in the
+durable outbox record, so a dispatch delayed across a turn boundary (behind an
+earlier mutation in the per-ref FIFO, or until a reconnect) can be recognized
+as stale. Clients SHOULD send it whenever they hold an active turn id.
+
+At delivery the daemon rejects the Stop with a `conflict` — "stop expired: a
+later turn is already running" — only when all of these hold:
+
+- `sinceTurnId` is a non-empty **durable-namespace** id (`turn_m<N>` — the id
+  family `thread.evener.activeTurnId` carries for client-authored and
+  daemon-autonomous turns once the durable mint has landed);
+- the session's current active turn id is also non-empty and **differs** from
+  it, meaning a later turn the user never saw is already running.
+
+Everything else falls through to the session-scoped rule (apply to whatever
+is running): an absent `sinceTurnId` (old client, old durable outbox record),
+an equal one (late delivery still inside the clicked turn), an empty current
+active id (the between-turn gap), and a projector-namespace `turn_N` one (the
+wire publishes those ids for daemon-started turns before the durable mint
+exists; they cannot be ordered against the mutation counter and are never
+treated as stale). A rejected Stop settles through the ordinary recovery
+pipeline — it is surfaced, never silently applied to the later turn.
 
 ## Notifications (server → client)
 

--- a/internal/appwiredoc/protocol.md.tmpl
+++ b/internal/appwiredoc/protocol.md.tmpl
@@ -89,6 +89,34 @@ no router (reserved).
 | `{{.Name}}` | {{.Scope}} | `{{.ParamsType}}` | `{{.ResultType}}` | {{.Summary}} |
 {{- end}}
 
+### `turn/interrupt` — the click-time binding
+
+Stop is session-scoped: it cancels whatever turn the session is running, and
+the receipt names the turn actually cancelled. `sinceTurnId` is not a target
+and never gates acceptance by itself — it is the turn that was active when
+the user pressed Stop, captured client-side at click time and carried in the
+durable outbox record, so a dispatch delayed across a turn boundary (behind an
+earlier mutation in the per-ref FIFO, or until a reconnect) can be recognized
+as stale. Clients SHOULD send it whenever they hold an active turn id.
+
+At delivery the daemon rejects the Stop with a `conflict` — "stop expired: a
+later turn is already running" — only when all of these hold:
+
+- `sinceTurnId` is a non-empty **durable-namespace** id (`turn_m<N>` — the id
+  family `thread.evener.activeTurnId` carries for client-authored and
+  daemon-autonomous turns once the durable mint has landed);
+- the session's current active turn id is also non-empty and **differs** from
+  it, meaning a later turn the user never saw is already running.
+
+Everything else falls through to the session-scoped rule (apply to whatever
+is running): an absent `sinceTurnId` (old client, old durable outbox record),
+an equal one (late delivery still inside the clicked turn), an empty current
+active id (the between-turn gap), and a projector-namespace `turn_N` one (the
+wire publishes those ids for daemon-started turns before the durable mint
+exists; they cannot be ordered against the mutation counter and are never
+treated as stale). A rejected Stop settles through the ordinary recovery
+pipeline — it is surfaced, never silently applied to the later turn.
+
 ## Notifications (server → client)
 
 Pushed to subscribed connections; no `id`. The web client maps these in

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -1198,6 +1198,7 @@ func (s *Server) handleAppSandboxEscalationResolve(_ context.Context, params app
 func (s *Server) handleAppTurnInterrupt(ctx context.Context, params appwire.TurnInterruptParams) (appwire.TurnInterruptResponse, error) {
 	params.ClientMutationID = strings.TrimSpace(params.ClientMutationID)
 	params.ExpectedInstanceID = strings.TrimSpace(params.ExpectedInstanceID)
+	params.SinceTurnID = strings.TrimSpace(params.SinceTurnID)
 	unlock, err := s.lockRetrySafeMutation(params.Ref, params.ThreadID, params.ExpectedInstanceID, params.ClientMutationID)
 	if err != nil {
 		return appwire.TurnInterruptResponse{}, err


### PR DESCRIPTION
Closes #178.

## Summary
A delayed Stop used to cancel whatever turn was running at delivery time — `turn/interrupt` acceptance was decided from session state ("is something running"), not from what the user actually saw when they clicked. This PR binds the interrupt to the turn that was active at click time and rejects it as stale if a different turn is already running:

- **Additive `sinceTurnId` on the interrupt params** (backward compatible: absent = current behavior; the web frontend, the TUI, and the protocol doc all updated, with the doc carrying full semantics via the appwiredoc template).
- **Click-time capture** in both producers: the hub frontend reads the tracked thread's active turn synchronously inside `interrupt()` (a 42-line test blocks the model's rollover behind a never-answered queued mutation and asserts the durable outbox payload still carries the click-time id), and the TUI captures `m.detail.ActiveTurnID` in the command's `Run` (both the registry command and ctrl-c paths).
- **Delivery-time guard** in `reservePrepared`'s prepare callback: a durable-namespace `turn_m<N>` SinceTurnID that differs from the session's current durable ActiveTurnID is rejected with `Conflict("stop expired: a later turn is already running")` — surfaced to the user as a recovery row with the reason, no dangling UI state, and durably terminal so retries replay the rejection rather than re-evaluating.
- **Namespace gate**: only durable `turn_m<N>` ids can be ordered against the mutation counter. The wire also publishes projector-namespace `turn_N` ids for daemon-started turns (goal continuations, notification wakes, queued drains) before the durable mint lands — a client holding such an id names the SAME logical turn the session tracks as `turn_mN`, so comparing them would falsely reject an on-time Stop. Projector-held ids fall through to session-scoped behavior exactly like an absent field; the honest tradeoff (staleness in that namespace is undetectable) is documented in the protocol doc and the code comment.

## Root cause
`sessionIsQuiesced` answered "is something running," not "is it the thing the user saw"; the interrupt carried no turn binding, so a delayed dispatch cancelled whatever was running then. Full analysis in the issue's triage comment.

## Verification highlights
- Table-driven tests drive the real `InterruptClientMutation` path deterministically: the #178 repro (stale different-id rejected), retry-of-expired (replays rejection), #176 same-generation window (applies), absent-id compat (applies), the projector-window cross-namespace case (applies), and the between-turn gap (applies session-scoped).
- Reviewers verified the durable id counter never reuses across restarts and restore (persisted `NextTurnSequence`; re-adoption of pending ids), and that no producer can mint a `turn_m`-shaped projector id (namespaces structurally disjoint).
- Gates: full agent suite, TUI/server/appwire/appprojector suites, `go vet`, gofmt, frontend vitest (threads 226/226), tsc, and byte-identical doc regeneration all PASS.

## Adversarial review
Two rounds, two competing reviewers each. Round 1: Reviewer B found a major — the guard compared the wire's projector-namespace id against the session's durable id, so the same logical turn could yield unequal ids and a false "stop expired" rejection (verified by the orchestrator in `setProcessingLocked`/`ReserveTurnID` directly). Round 2: both approve; B re-drove its exact scenario as a test (the Stop now applies and cancels the running turn) and confirmed the in-sync population keeps full protection. One comment-precision reword applied.
