### PR TITLE
feat(web): mobile model selector as a bottom sheet

### DIFF
--- a/cmd/evener-hub/frontend/src/dev/gallery-sections/modelCatalog.module.css
+++ b/cmd/evener-hub/frontend/src/dev/gallery-sections/modelCatalog.module.css
@@ -1,0 +1,15 @@
+/* Composed from sheet.module.css in this directory: Sheet's panel is
+ * position:fixed, scoped here to the demo frame instead of the viewport, with
+ * an explicit width because the frame's only in-flow child is entirely
+ * position:fixed. See sheet.module.css's own derivation for the full trick. */
+.demoFrame {
+  composes: demoFrame from "./sheet.module.css";
+}
+
+.reopen {
+  composes: reopen from "./sheet.module.css";
+}
+
+.sheetBody {
+  padding-bottom: env(safe-area-inset-bottom);
+}

--- a/cmd/evener-hub/frontend/src/dev/gallery-sections/modelCatalog.tsx
+++ b/cmd/evener-hub/frontend/src/dev/gallery-sections/modelCatalog.tsx
@@ -1,7 +1,10 @@
 // ModelCatalog is both the component (value) and the envelope interface (type);
 // one import brings in both meanings via declaration merging.
-import { ModelCatalog } from "../../widgets/modelCatalog";
+import { useState } from "react";
+import { ModelCatalog, type ModelCatalog as ModelCatalogEnvelope, ModelCatalogPanel } from "../../widgets/modelCatalog";
+import { Sheet } from "../../widgets/sheet";
 import { ThemeFlip } from "../ThemeFlip";
+import styles from "./modelCatalog.module.css";
 
 // The rich model catalog widget (wave-8 T2 filled it: provider grouping,
 // capability badges, cost, and a Recent section). The gallery drives it with a
@@ -9,7 +12,7 @@ import { ThemeFlip } from "../ThemeFlip";
 // the harness-default marker and a chosen qualified provider/model; it never
 // hits the wire, so the badges/cost/Recent affordances only light up against a
 // live model/list response.
-const CATALOG: ModelCatalog = {
+const CATALOG: ModelCatalogEnvelope = {
   models: [
     { provider: "anthropic", model: "claude-sonnet-4-5", displayName: "Claude Sonnet 4.5" },
     { provider: "openai", model: "gpt-5", displayName: "GPT-5" },
@@ -17,8 +20,37 @@ const CATALOG: ModelCatalog = {
   recent: [],
 };
 
-function loadCatalog(): Promise<ModelCatalog> {
+function loadCatalog(): Promise<ModelCatalogEnvelope> {
   return Promise.resolve(CATALOG);
+}
+
+// The mobile variant: the same catalog rows in a bottom Sheet with 48px tap
+// targets and no search input (docs/web-ui/design-system.md §11). Shown the
+// same open-by-default, contained-frame way the Sheet section itself is - see
+// sheet.module.css in this directory for the containing-block trick.
+function SheetDemo() {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className={styles.demoFrame}>
+      {!open && (
+        <button type="button" className={styles.reopen} onClick={() => setOpen(true)}>
+          Reopen sheet
+        </button>
+      )}
+      <Sheet open={open} side="bottom" onClose={() => setOpen(false)} title="Choose model">
+        <div className={styles.sheetBody}>
+          <ModelCatalogPanel
+            loading={false}
+            error={null}
+            catalog={CATALOG}
+            value="anthropic/claude-sonnet-4-5"
+            onPick={() => setOpen(false)}
+            variant="sheet"
+          />
+        </div>
+      </Sheet>
+    </div>
+  );
 }
 
 export default function ModelCatalogGallerySection() {
@@ -28,6 +60,10 @@ export default function ModelCatalogGallerySection() {
       <ThemeFlip>
         <ModelCatalog value="" onChange={() => {}} loadCatalog={loadCatalog} />
         <ModelCatalog value="anthropic/claude-sonnet-4-5" onChange={() => {}} loadCatalog={loadCatalog} />
+      </ThemeFlip>
+      <h3>Mobile sheet variant</h3>
+      <ThemeFlip>
+        <SheetDemo />
       </ThemeFlip>
     </section>
   );

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ModelSwitchTrigger.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ModelSwitchTrigger.test.tsx
@@ -1,8 +1,9 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, expect, test, vi } from "vitest";
 import { WireError } from "../../../protocol/errors";
 import type { ModelCatalog } from "../../../widgets";
+import { installMobileViewport } from "../testing/mobileViewport";
 import { ModelSwitchTrigger } from "./ModelSwitchTrigger";
 import rawStyles from "./modelswitch.module.css";
 
@@ -194,4 +195,63 @@ test("a scroll does not close the open picker", async () => {
   window.dispatchEvent(new Event("scroll"));
 
   expect(screen.getByRole("combobox")).toBeTruthy();
+});
+
+// --- mobile: the same trigger opens a bottom Sheet, not a Popover -------------
+// docs/web-ui/design-system.md §11: mobile choice controls use the bottom Sheet
+// pattern with >=48px options and no search input. Both surfaces that mount this
+// component (the spawn pane's prompt card, the session composer's status row)
+// get it from this one branch.
+
+test("on a mobile viewport the trigger opens a Choose-model bottom Sheet, not a Popover", async () => {
+  const restoreViewport = installMobileViewport();
+  const user = userEvent.setup();
+  try {
+    renderTrigger();
+
+    await user.click(screen.getByTestId("trigger"));
+
+    const sheet = await screen.findByRole("dialog", { name: "Choose model" });
+    expect(sheet.className).toContain("bottom");
+    expect(screen.queryByRole("combobox")).toBeNull();
+    expect(within(sheet).getAllByRole("option")).toHaveLength(2);
+  } finally {
+    restoreViewport();
+  }
+});
+
+test("picking from the mobile sheet reports the entry and closes it", async () => {
+  const restoreViewport = installMobileViewport();
+  const user = userEvent.setup();
+  const onPick = vi.fn();
+  try {
+    renderTrigger({ onPick });
+
+    await user.click(screen.getByTestId("trigger"));
+    const sheet = await screen.findByRole("dialog", { name: "Choose model" });
+    await user.click(within(sheet).getByRole("option", { name: /gpt-5\.5/i }));
+
+    expect(onPick).toHaveBeenCalledWith(expect.objectContaining({ provider: "openai", model: "gpt-5.5" }));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Choose model" })).toBeNull());
+  } finally {
+    restoreViewport();
+  }
+});
+
+test("Escape closes the mobile sheet and returns focus to the trigger", async () => {
+  const restoreViewport = installMobileViewport();
+  const user = userEvent.setup();
+  try {
+    renderTrigger();
+
+    const trigger = screen.getByTestId("trigger");
+    await user.click(trigger);
+    await screen.findByRole("dialog", { name: "Choose model" });
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Choose model" })).toBeNull());
+    expect(document.activeElement).toBe(trigger);
+  } finally {
+    restoreViewport();
+  }
 });

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ModelSwitchTrigger.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ModelSwitchTrigger.tsx
@@ -13,9 +13,24 @@
 // thread/model/set; the spawn pane records the choice for its next launch
 // (panes/spawn/Spawn.tsx). Both get the identical affordance because it is the
 // identical component, which is the whole point of issue #198.
+//
+// The picker's OVERLAY is viewport-selected (docs/web-ui/design-system.md §11):
+// a floating Popover with the search combobox on desktop, the same catalog
+// rows in a bottom Sheet with 48px tap targets and no search input on mobile.
+// Chrome, not a pane: the "panes never ask am I mobile?" rule doesn't reach
+// this component (SessionChrome's own openDetails already branches the same
+// way).
 import { useRef, useState } from "react";
 import { friendlyLaunchErrorMessage, sessionActionHeadline } from "../../../protocol/errors";
-import { Chevron, type ModelCatalog, type ModelCatalogEntry, ModelCatalogPanel, Popover } from "../../../widgets";
+import { useIsMobile } from "../../../shell/useIsMobile";
+import {
+  Chevron,
+  type ModelCatalog,
+  type ModelCatalogEntry,
+  ModelCatalogPanel,
+  Popover,
+  Sheet,
+} from "../../../widgets";
 import { requireClass } from "../../../widgets/internal/requireClass";
 import styles from "./modelswitch.module.css";
 
@@ -51,6 +66,8 @@ const CLASS = {
   chevron: requireClass(styles.chevron, "modelswitch.module.css", "chevron"),
   srOnly: requireClass(styles.srOnly, "modelswitch.module.css", "srOnly"),
   popoverPanel: requireClass(styles.popoverPanel, "modelswitch.module.css", "popoverPanel"),
+  sheetBody: requireClass(styles.sheetBody, "modelswitch.module.css", "sheetBody"),
+  triggerWrapper: requireClass(styles.triggerWrapper, "modelswitch.module.css", "triggerWrapper"),
 };
 
 export function ModelSwitchTrigger({
@@ -63,6 +80,7 @@ export function ModelSwitchTrigger({
   "data-testid": testId,
   valueTestId,
 }: ModelSwitchTriggerProps) {
+  const isMobile = useIsMobile();
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -92,12 +110,14 @@ export function ModelSwitchTrigger({
     }
   }
 
-  // Popover's FocusScope is opted out of focus management (autoFocus={false})
-  // so the panel's input can own focus and its selection - which makes
-  // restoring focus to the trigger on close this component's job.
+  // The Popover path's FocusScope is opted out of focus management
+  // (autoFocus={false}) so the panel's input can own focus and its selection -
+  // which makes restoring focus to the trigger on close this component's job.
+  // The Sheet path's FocusScope keeps its default focus management (first
+  // tabbable option in, restore on close), so only the Popover path needs this.
   function closePicker(): void {
     setOpen(false);
-    triggerRef.current?.focus();
+    if (!isMobile) triggerRef.current?.focus();
   }
 
   function handlePick(entry: ModelCatalogEntry): void {
@@ -107,6 +127,70 @@ export function ModelSwitchTrigger({
     // of the (already-closed) picker."
     setOpen(false);
     onPick(entry);
+  }
+
+  const panel = (
+    <ModelCatalogPanel
+      loading={loading}
+      error={error}
+      catalog={catalog}
+      value={value}
+      onPick={handlePick}
+      variant={isMobile ? "sheet" : "default"}
+    />
+  );
+
+  // One trigger button, whichever overlay sits behind it: the visible control
+  // must not change identity across the breakpoint, or the spawn pane's
+  // phone-only trigger slot and the status row's chip would both re-mount on
+  // a viewport crossing.
+  const triggerButton = (
+    <button
+      ref={triggerRef}
+      type="button"
+      className={CLASS.trigger}
+      data-testid={testId}
+      title={label}
+      onClick={() => (open ? closePicker() : void openPicker())}
+      disabled={disabled}
+    >
+      {/* Plain text, not a Chip: the trigger already draws the control's
+          own hover box, and a bordered chip inside it reads as a double
+          border - the same rule widgets/pathfield's and
+          widgets/modelCatalog's triggers follow. */}
+      <span className={CLASS.value} data-testid={valueTestId}>
+        {label}
+      </span>
+      <span className={CLASS.chevron} aria-hidden="true">
+        <Chevron direction="down" />
+      </span>{" "}
+      {/* That separating space is load-bearing: the accessible name is this
+          button's children concatenated, and each child's own text is
+          trimmed first, so a space INSIDE either span would be dropped and
+          the name would run together as "…sonnet-4-5— change model". A
+          whitespace-only text node between them survives that trim and
+          renders nothing of its own (an all-whitespace anonymous flex item
+          is not laid out). */}
+      <span className={CLASS.srOnly}>— {actionLabel}</span>
+    </button>
+  );
+
+  if (isMobile) {
+    return (
+      <>
+        {/* A span wrapper matching Popover's own trigger wrapper
+            (widgets/popover's .trigger: inline-flex, hugging): the status
+            row's container-query compression targets
+            `.identity > span:first-child > button`, so the trigger must stay
+            one span deep on both sides of the breakpoint or the phone-width
+            label floor (min-width: 1rem, padding-inline: 0) stops applying
+            and the fixed facts squeeze the model label to zero width. */}
+        <span className={CLASS.triggerWrapper}>{triggerButton}</span>
+        <Sheet open={open} side="bottom" onClose={closePicker} title="Choose model">
+          <div className={CLASS.sheetBody}>{panel}</div>
+        </Sheet>
+      </>
+    );
   }
 
   return (
@@ -119,40 +203,9 @@ export function ModelSwitchTrigger({
       // The panel's input owns focus and its own text selection - see
       // closePicker for why FocusScope must not manage focus here.
       autoFocus={false}
-      trigger={
-        <button
-          ref={triggerRef}
-          type="button"
-          className={CLASS.trigger}
-          data-testid={testId}
-          title={label}
-          onClick={() => (open ? closePicker() : void openPicker())}
-          disabled={disabled}
-        >
-          {/* Plain text, not a Chip: the trigger already draws the control's
-              own hover box, and a bordered chip inside it reads as a double
-              border - the same rule widgets/pathfield's and
-              widgets/modelCatalog's triggers follow. */}
-          <span className={CLASS.value} data-testid={valueTestId}>
-            {label}
-          </span>
-          <span className={CLASS.chevron} aria-hidden="true">
-            <Chevron direction="down" />
-          </span>{" "}
-          {/* That separating space is load-bearing: the accessible name is this
-              button's children concatenated, and each child's own text is
-              trimmed first, so a space INSIDE either span would be dropped and
-              the name would run together as "…sonnet-4-5— change model". A
-              whitespace-only text node between them survives that trim and
-              renders nothing of its own (an all-whitespace anonymous flex item
-              is not laid out). */}
-          <span className={CLASS.srOnly}>— {actionLabel}</span>
-        </button>
-      }
+      trigger={triggerButton}
     >
-      <div className={CLASS.popoverPanel}>
-        <ModelCatalogPanel loading={loading} error={error} catalog={catalog} value={value} onPick={handlePick} />
-      </div>
+      <div className={CLASS.popoverPanel}>{panel}</div>
     </Popover>
   );
 }

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/modelswitch.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/modelswitch.module.css
@@ -1,5 +1,9 @@
 /* Quiet trigger: no border/background until hover, so the model label itself
  * reads as the interactive element rather than a separate button beside it. */
+.triggerWrapper {
+  composes: trigger from "../../../widgets/popover/popover.module.css";
+}
+
 .trigger {
   display: inline-flex;
   align-items: center;
@@ -87,4 +91,12 @@
   width: 400px;
   /* Reserves both of computePosition's EDGE_MARGINs (8px a side). */
   max-width: calc(100dvw - var(--space-4));
+}
+
+/* The mobile bottom Sheet's body wrapper: same safe-area reservation as the
+ * spawn pane's own sheet bodies (MobileSettingRows.module.css .sheetBody), so
+ * a home-indicator never covers the last option. The Sheet's own .body
+ * padding carries the sides. */
+.sheetBody {
+  padding-bottom: env(safe-area-inset-bottom);
 }

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/index.tsx
@@ -41,6 +41,14 @@ const CLASS = {
   check: requireClass(styles.check, "modelCatalog.module.css", "check"),
   meta: requireClass(styles.meta, "modelCatalog.module.css", "meta"),
   unavailable: requireClass(styles.unavailable, "modelCatalog.module.css", "unavailable"),
+  panelSheet: requireClass(styles.panelSheet, "modelCatalog.module.css", "panelSheet"),
+  listSheet: requireClass(styles.listSheet, "modelCatalog.module.css", "listSheet"),
+  sheetRowItem: requireClass(styles.sheetRowItem, "modelCatalog.module.css", "sheetRowItem"),
+  sheetRow: requireClass(styles.sheetRow, "modelCatalog.module.css", "sheetRow"),
+  sheetRowSelected: requireClass(styles.sheetRowSelected, "modelCatalog.module.css", "sheetRowSelected"),
+  sheetRowMain: requireClass(styles.sheetRowMain, "modelCatalog.module.css", "sheetRowMain"),
+  sheetRowName: requireClass(styles.sheetRowName, "modelCatalog.module.css", "sheetRowName"),
+  sheetRowMeta: requireClass(styles.sheetRowMeta, "modelCatalog.module.css", "sheetRowMeta"),
 };
 
 const SKELETON_LINES = 4;
@@ -85,6 +93,12 @@ export interface ModelCatalogPanelProps {
    * pre-fills the input, marks the current row, and scrolls it into view. */
   value: string;
   onPick: (entry: ModelCatalogEntry) => void;
+  /** "sheet" renders the mobile variant used inside a bottom Sheet: no search
+   * input (a phone picker is scrolled, not autocompleted - the design system's
+   * mobile-forms rule that a feature reuses its existing catalog panel rather
+   * than a second picker implementation), rows sized to the 48px tap floor,
+   * and the same grouped list/roles as the default combobox variant. */
+  variant?: "default" | "sheet";
 }
 
 function rowDomId(listboxId: string, key: string): string {
@@ -110,7 +124,14 @@ function rowDomId(listboxId: string, key: string): string {
  * button, and no blur handler: focus staying in the input is the whole point
  * of the activedescendant pattern.
  */
-export function ModelCatalogPanel({ loading, error, catalog, value, onPick }: ModelCatalogPanelProps): JSX.Element {
+export function ModelCatalogPanel({
+  loading,
+  error,
+  catalog,
+  value,
+  onPick,
+  variant = "default",
+}: ModelCatalogPanelProps): JSX.Element {
   // null means "the user hasn't typed yet": the input SHOWS the current value
   // (selected, so the first keystroke replaces it) while the list stays
   // unfiltered. Once typing starts, the typed text is both the input's value
@@ -119,9 +140,12 @@ export function ModelCatalogPanel({ loading, error, catalog, value, onPick }: Mo
   const [activeIndex, setActiveIndex] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
   const listboxId = useId();
+  const isSheet = variant === "sheet";
 
-  const text = typed ?? value;
-  const query = typed ?? "";
+  // The sheet variant has no input to own focus or drive a query: the list is
+  // the whole unfiltered catalog, and focus stays with the enclosing Sheet's
+  // FocusScope (the first tabbable option).
+  const query = isSheet ? "" : (typed ?? "");
   const rows = useMemo(() => buildPickerRows(catalog, query), [catalog, query]);
   const picks = useMemo(() => pickableRows(rows), [rows]);
   const activeKey = activeIndex >= 0 && activeIndex < picks.length ? picks[activeIndex]?.key : undefined;
@@ -130,33 +154,50 @@ export function ModelCatalogPanel({ loading, error, catalog, value, onPick }: Mo
   // aria-selected option - so the marker goes on the first occurrence only.
   const currentKey = useMemo(() => picks.find((row) => row.option.qualified === value)?.key, [picks, value]);
   const listShown = !loading && error === null;
+  const text = typed ?? value;
+
+  // The sheet variant opens already scrolled to the current value, matching
+  // what the combobox variant's activedescendant effect does for its list.
+  // Mount-only: the panel stays mounted across loading -> loaded, and
+  // re-scrolling then would fight a user already scrolling.
+  useEffect(() => {
+    if (!isSheet || currentKey === undefined) return;
+    document.getElementById(rowDomId(listboxId, currentKey))?.scrollIntoView?.({ block: "center" });
+  }, [isSheet, currentKey, listboxId]);
 
   // Focus the input and select all of it, so the first keystroke replaces the
   // pre-filled value wholesale. Mount-only: the panel stays mounted across
   // loading -> loaded, and re-selecting then would fight a user already typing.
+  // Sheet variant: no input, so this is a no-op (guarded to avoid a null focus).
   useEffect(() => {
+    if (isSheet) return;
     const input = inputRef.current;
     if (!input) return;
     input.focus();
     input.select();
-  }, []);
+  }, [isSheet]);
 
   // Until the user types, the highlight follows the CURRENT value (so the
   // list opens showing where you already are, and ArrowDown continues from
   // there). This only re-runs when the rows or the value change - arrow keys
   // move the highlight without fighting it, since they change neither.
+  // Sheet variant: the activedescendant model is unused (rows are real focusable
+  // buttons, no input owns virtual focus), so this effect would do a redundant
+  // state update + re-render whose output the sheet markup never reads.
   useEffect(() => {
-    if (typed !== null) return;
+    if (isSheet || typed !== null) return;
     setActiveIndex(picks.findIndex((row) => row.option.qualified === value));
-  }, [picks, value, typed]);
+  }, [isSheet, picks, value, typed]);
 
   // Keep the highlighted row visible inside the list's own scroll container -
   // both for the current value on open and for keyboard walks past the fold.
   // scrollIntoView is called optionally: jsdom implements none at all.
+  // Sheet variant: the sheet's own mount-only effect above (block: "center")
+  // handles scroll-into-view, so this activedescendant-driven scroll is skipped.
   useEffect(() => {
-    if (activeKey === undefined) return;
+    if (isSheet || activeKey === undefined) return;
     document.getElementById(rowDomId(listboxId, activeKey))?.scrollIntoView?.({ block: "nearest" });
-  }, [activeKey, listboxId]);
+  }, [isSheet, activeKey, listboxId]);
 
   function pickAt(index: number): boolean {
     const row = picks[index];
@@ -208,25 +249,27 @@ export function ModelCatalogPanel({ loading, error, catalog, value, onPick }: Mo
   }
 
   return (
-    <div className={CLASS.panel}>
-      <input
-        ref={inputRef}
-        role="combobox"
-        className={CLASS.input}
-        value={text}
-        onChange={(event) => {
-          setTyped(event.target.value);
-          // The first match is the answer the user is narrowing toward, so
-          // Enter right after typing picks it.
-          setActiveIndex(0);
-        }}
-        onKeyDown={handleKeyDown}
-        aria-expanded={listShown}
-        aria-autocomplete="list"
-        aria-controls={listShown ? listboxId : undefined}
-        aria-activedescendant={activeKey !== undefined ? rowDomId(listboxId, activeKey) : undefined}
-        aria-label="Model"
-      />
+    <div className={`${CLASS.panel} ${isSheet ? CLASS.panelSheet : ""}`}>
+      {!isSheet && (
+        <input
+          ref={inputRef}
+          role="combobox"
+          className={CLASS.input}
+          value={text}
+          onChange={(event) => {
+            setTyped(event.target.value);
+            // The first match is the answer the user is narrowing toward, so
+            // Enter right after typing picks it.
+            setActiveIndex(0);
+          }}
+          onKeyDown={handleKeyDown}
+          aria-expanded={listShown}
+          aria-autocomplete="list"
+          aria-controls={listShown ? listboxId : undefined}
+          aria-activedescendant={activeKey !== undefined ? rowDomId(listboxId, activeKey) : undefined}
+          aria-label="Model"
+        />
+      )}
       {loading && <Skeleton lines={SKELETON_LINES} />}
       {error !== null && (
         <p className={CLASS.error} role="alert">
@@ -244,7 +287,7 @@ export function ModelCatalogPanel({ loading, error, catalog, value, onPick }: Mo
           role="listbox"
           id={listboxId}
           aria-label="Model"
-          className={CLASS.list}
+          className={`${CLASS.list} ${isSheet ? CLASS.listSheet : ""}`}
         >
           {rows.map((row) => {
             if (row.kind === "group") {
@@ -262,6 +305,34 @@ export function ModelCatalogPanel({ loading, error, catalog, value, onPick }: Mo
               );
             }
             const current = row.key === currentKey;
+            if (isSheet) {
+              // A real button per option: with no input to own focus, each
+              // row must be independently focusable for the Sheet's FocusScope
+              // trap and keyboard activation. Same listbox semantics
+              // (role=option, aria-selected) as the combobox variant.
+              return (
+                <li key={row.key} role="presentation" className={CLASS.sheetRowItem}>
+                  <button
+                    type="button"
+                    id={rowDomId(listboxId, row.key)}
+                    role="option"
+                    aria-selected={current}
+                    className={`${CLASS.sheetRow} ${current ? CLASS.sheetRowSelected : ""}`}
+                    onClick={() => onPick(row.option.entry)}
+                  >
+                    <span className={CLASS.sheetRowMain}>
+                      <span className={CLASS.sheetRowName}>{row.option.label}</span>
+                      {current && (
+                        <span className={CLASS.check} aria-hidden="true">
+                          ✓
+                        </span>
+                      )}
+                    </span>
+                    {row.meta !== "" && <span className={CLASS.sheetRowMeta}>{row.meta}</span>}
+                  </button>
+                </li>
+              );
+            }
             return (
               // Real focus never leaves the input (ARIA 1.2 activedescendant
               // pattern): aria-activedescendant above tracks the "virtual"

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/modelCatalog.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/modelCatalog.module.css
@@ -165,3 +165,82 @@
   color: var(--ink-low);
   font-size: var(--font-size-caption);
 }
+
+/* --- sheet variant (mobile bottom Sheet) ---------------------------------
+ * The design system's mobile-forms rule (docs/web-ui/design-system.md §11):
+ * sheet options are at least 48px tall, use the existing tokens, and reuse
+ * the shared catalog rows rather than a second picker implementation. Same
+ * recipe as the spawn pane's own option rows (MobileSettingRows.module.css
+ * .option), so the two mobile pickers read as one object. */
+
+.panelSheet {
+  gap: 0;
+}
+
+/* The list is the sheet's whole body: no internal max-height - the Sheet's
+ * own body already scrolls and caps the panel at min(480px, 100vh). */
+.listSheet {
+  max-height: none;
+  overflow-y: visible;
+}
+
+.sheetRowItem {
+  border-bottom: 1px solid var(--edge);
+}
+
+.sheetRowItem:last-child {
+  border-bottom: none;
+}
+
+.sheetRow {
+  display: flex;
+  min-height: 48px;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--space-1);
+  width: 100%;
+  padding: var(--space-3) 0;
+  border: 0;
+  background: transparent;
+  color: var(--ink-hi);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-body);
+  text-align: left;
+  cursor: pointer;
+  transition: background-color var(--motion-duration-hover) var(--motion-easing-standard);
+}
+
+.sheetRow:hover {
+  background: var(--hover-1);
+}
+
+.sheetRow:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.sheetRowSelected {
+  background: var(--hover-2);
+}
+
+.sheetRowMain {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.sheetRowName {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sheetRowMeta {
+  overflow: hidden;
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/modelCatalog.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/modelCatalog.test.tsx
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { WireError } from "../../protocol/errors";
 // ModelCatalog is both the component (value) and the envelope interface (type);
 // a single import brings in both meanings via declaration merging.
-import { ModelCatalog, type ModelCatalogEntry } from "./index";
+import { ModelCatalog, type ModelCatalogEntry, ModelCatalogPanel } from "./index";
 
 afterEach(() => cleanup());
 
@@ -519,4 +519,63 @@ test("the active (virtual-focus) row carries the selected wash", () => {
   const css = readFileSync(join(here, "modelCatalog.module.css"), "utf8");
   const rule = /\.rowActive\s*\{([^}]*)\}/.exec(css)?.[1] ?? "";
   expect(rule).toContain("background: var(--hover-2)");
+});
+
+// --- sheet variant (mobile bottom Sheet) -------------------------------------
+// The variant contract: same grouped list and option semantics as the default
+// combobox, but no search input and rows built for a 48px tap floor
+// (docs/web-ui/design-system.md §11).
+
+function renderSheetPanel(props: Partial<Parameters<typeof ModelCatalogPanel>[0]> = {}) {
+  render(
+    <ModelCatalogPanel
+      loading={false}
+      error={null}
+      catalog={CATALOG}
+      value={props.value ?? ""}
+      onPick={props.onPick ?? vi.fn()}
+      variant="sheet"
+      {...props}
+    />,
+  );
+}
+
+test("the sheet variant renders no search combobox - the list is the whole panel", () => {
+  renderSheetPanel();
+  expect(screen.queryByRole("combobox")).toBeNull();
+  expect(screen.getByRole("listbox", { name: "Model" })).toBeTruthy();
+  expect(screen.getAllByRole("option")).toHaveLength(3);
+});
+
+test("the sheet variant keeps provider group heads and the current-value marker", () => {
+  renderSheetPanel({ value: "openai/gpt-5" });
+  expect(screen.getByRole("listbox", { name: "Model" }).textContent).toContain("anthropic");
+  expect(screen.getByRole("listbox", { name: "Model" }).textContent).toContain("openai");
+  const current = screen.getAllByRole("option", { selected: true });
+  expect(current).toHaveLength(1);
+  expect(current[0]!.textContent).toContain("GPT-5");
+});
+
+test("the sheet variant's options are real buttons - each owns focus for the Sheet's trap", () => {
+  renderSheetPanel({ value: "anthropic/claude-sonnet-4-5" });
+  const option = screen.getByRole("option", { selected: true });
+  expect(option.tagName).toBe("BUTTON");
+  expect((option as HTMLButtonElement).type).toBe("button");
+});
+
+test("picking from the sheet variant reports the entry to the caller", async () => {
+  const user = userEvent.setup();
+  const onPick = vi.fn();
+  renderSheetPanel({ onPick });
+
+  await user.click(screen.getByRole("option", { name: /gpt-5/i }));
+
+  expect(onPick).toHaveBeenCalledWith(expect.objectContaining({ provider: "openai", model: "gpt-5" }));
+});
+
+test("the sheet variant's rows meet the 48px tap floor", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const css = readFileSync(join(here, "modelCatalog.module.css"), "utf8");
+  const rule = /\.sheetRow\s*\{([^}]*)\}/.exec(css)?.[1] ?? "";
+  expect(rule).toContain("min-height: 48px");
 });


### PR DESCRIPTION
## What

On mobile, the model selector opens as a bottom **Sheet** with 48px tap rows — matching the other mobile selectors on the session start page and the design system's mobile-forms rule (docs/web-ui/design-system.md §11) — instead of the desktop floating Popover with a search combobox. It works the same way on the session start page (spawn) and from the composer mid-session, because both surfaces render the same `ModelSwitchTrigger`.

No autocomplete on mobile, per the design intent: the picker is scrolled, not searched.

## Why

The model control is the one shared affordance for choosing a model (issue #198). On a phone it opened the desktop catalog in a floating Popover whose ~28px rows are too small to tap and whose search combobox is the wrong interaction for a scrollable list. The design system already says mobile choice controls use a bottom Sheet with ≥48px options and reuse the existing catalog panel rather than a second picker implementation.

## How

- **`ModelCatalogPanel`** gains a `variant="sheet"` mode: the existing grouped list and `role="option"` semantics, but with no search combobox and each option as a real focusable `<button>` sized to the 48px tap floor. The current value is marked and scrolled into view on open. `buildPickerRows`/`pickerRows.ts` are reused unchanged.
- **`ModelSwitchTrigger`** branches on `useIsMobile()`: desktop keeps the floating Popover/combobox; mobile renders the sheet variant in a bottom `Sheet` titled "Choose model" (focus trap, Escape, scrim, focus restore from the Sheet's `OverlayPanel`.
- A  span () keeps the status row's container-query compression () applying on both sides of the breakpoint — without it the phone-width label floor drops and the fixed footer facts squeeze the model label to zero width.
- The widget gallery's existing model-catalog section now shows the sheet variant in both themes (open by default, same contained-frame approach as the Sheet section).

## Verification

- PASS  web-typecheck
PASS  web-test
PASS  web-lint — typecheck, unit tests, lint all PASS
- PASS  web-layoutguard
PASS  web-overflowguard
PASS  web-shellguard
PASS  web-spawnguard — layoutguard, overflowguard, shellguard, spawnguard all PASS
- Live Chrome at 390px: bottom sheet, no combobox, 2 options at 48px each, selected value marked, provider group heads present

## Adversarial review

Ran the four-angle simplify review (reuse / simplification / efficiency / altitude). Applied three in-scope fixes:
1. Guarded the activedescendant effects with  — removes a redundant render + scrollIntoView per sheet open.
2.  now  popover's  instead of redeclaring .
3. Gallery / now  from  instead of byte-duplicating a 5th copy.

Three architectural findings were **skipped** as out-of-scope for this branch (they reach across multiple widget contracts and the spawn pane's existing code) and are better tracked as follow-ups:
- A viewport-responsive overlay (/ owning the breakpoint) so the trigger stays viewport-agnostic.
- / capability props on the panel instead of a host-named .
- Moving the  reservation into the Sheet widget itself (currently triplicated across consumers).
EOF
)