### PR TITLE
feat(web): redesign Providers & credentials settings with detail sheets

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.edge.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.edge.test.tsx
@@ -1,8 +1,8 @@
 // Edge cases for CredentialsSection.tsx uncovered lines:
-// - handleConfirmedAction clear failure error toast (lines 153-154)
-// - handleConfirmedAction remove failure error toast (lines 153-154)
-// - findInstance returns undefined for apiKey dialog when instance is gone (line 223)
-// - findInstance returns undefined for edit dialog when instance is gone (line 224)
+// - handleConfirmedAction clear failure error toast
+// - handleConfirmedAction remove failure error toast
+// - findInstance returns undefined for apiKey dialog when instance is gone
+// - findInstance returns undefined for edit dialog when instance is gone
 
 import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -44,6 +44,13 @@ const WORK = instance({
 const PERSONAL = instance({ name: "personal", type: "openai", authModes: ["apiKey", "oauth"] });
 const LIST: InstanceListResponse = { instances: [WORK, PERSONAL], availableTypes: ["anthropic", "openai"] };
 
+// Same detail-sheet navigation path as CredentialsSection.test.tsx: every
+// per-instance action is reached through the row's inspector.
+async function openSheet(user: ReturnType<typeof userEvent.setup>, name: string): Promise<HTMLElement> {
+  await user.click(screen.getByRole("button", { name: new RegExp(name) }));
+  return screen.findByRole("dialog", { name });
+}
+
 beforeEach(() => {
   connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
   resetCredentialsStoreForTests();
@@ -57,7 +64,6 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-// Lines 153-154: handleConfirmedAction clear failure error toast
 describe("CredentialsSection edge cases", () => {
   test("clear failure shows error toast", async () => {
     const fake = connectFakeClient();
@@ -73,10 +79,10 @@ describe("CredentialsSection edge cases", () => {
     );
     await screen.findByText("work");
     const user = userEvent.setup();
-    // Click Clear on the work instance (has stored file → Clear available)
-    const clearButtons = screen.getAllByRole("button", { name: "Clear" });
-    await user.click(clearButtons[0]!);
-    const dialog = screen.getByRole("dialog");
+    // WORK has stored file → its sheet offers Clear.
+    const inspector = await openSheet(user, "work");
+    await user.click(within(inspector).getByRole("button", { name: "Clear" }));
+    const dialog = screen.getByRole("dialog", { name: "Clear credentials" });
     await user.click(within(dialog).getByRole("button", { name: "Clear" }));
     await screen.findByText("Clear failed: Something went wrong.");
     expect(screen.getByRole("dialog", { name: "Clear credentials" })).toBeTruthy();
@@ -96,23 +102,23 @@ describe("CredentialsSection edge cases", () => {
     );
     await screen.findByText("personal");
     const user = userEvent.setup();
-    const removeButtons = screen.getAllByRole("button", { name: "Remove" });
-    await user.click(removeButtons[1]!);
-    const dialog = screen.getByRole("dialog");
+    const inspector = await openSheet(user, "personal");
+    await user.click(within(inspector).getByRole("button", { name: "Remove" }));
+    const dialog = screen.getByRole("dialog", { name: "Remove instance" });
     await user.click(within(dialog).getByRole("button", { name: "Remove" }));
     await screen.findByText("Remove failed: Something went wrong.");
     expect(screen.getByRole("dialog", { name: "Remove instance" })).toBeTruthy();
   });
 
-  // Lines 194, 223-224: an open API-key editor stops rendering if its instance disappears.
+  // An open API-key editor stops rendering if its instance disappears.
   test("an API key dialog closes when a refreshed list removes its instance", async () => {
     const fake = connectFakeClient();
     fake.on("evener/instance/list", () => LIST);
     render(<CredentialsSection sectionId="credentials" />);
     await screen.findByText("work");
     const user = userEvent.setup();
-    const setKeyButtons = screen.getAllByRole("button", { name: /replace key/i });
-    await user.click(setKeyButtons[0]!);
+    const inspector = await openSheet(user, "work");
+    await user.click(within(inspector).getByRole("button", { name: /replace key/i }));
     await screen.findByRole("dialog", { name: "Set API key for work" });
 
     act(() => credentialsStore.setState({ instances: [PERSONAL] }));
@@ -120,15 +126,15 @@ describe("CredentialsSection edge cases", () => {
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Set API key for work" })).toBeNull());
   });
 
-  // Lines 196, 228-229: an open edit dialog stops rendering if its instance disappears.
+  // An open edit dialog stops rendering if its instance disappears.
   test("an edit dialog closes when a refreshed list removes its instance", async () => {
     const fake = connectFakeClient();
     fake.on("evener/instance/list", () => LIST);
     render(<CredentialsSection sectionId="credentials" />);
     await screen.findByText("work");
     const user = userEvent.setup();
-    const editButtons = screen.getAllByRole("button", { name: "Edit" });
-    await user.click(editButtons[0]!);
+    const inspector = await openSheet(user, "work");
+    await user.click(within(inspector).getByRole("button", { name: "Edit" }));
     await screen.findByRole("dialog", { name: "Edit work" });
 
     act(() => credentialsStore.setState({ instances: [PERSONAL] }));

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.test.tsx
@@ -6,6 +6,7 @@ import type { AuthTestResponse, InstanceEntry, InstanceListResponse } from "../.
 import { connectionStore } from "../../../../stores/connection";
 import { credentialsStore, resetCredentialsStoreForTests } from "../../../../stores/credentials";
 import { Toast } from "../../../../widgets";
+import { resetToastStoreForTests } from "../../../../widgets/toast/store";
 import { CredentialsSection } from "./CredentialsSection";
 
 function connectFakeClient(): FakeClient {
@@ -51,9 +52,18 @@ async function advanceTime(milliseconds: number): Promise<void> {
   await act(() => vi.advanceTimersByTimeAsync(milliseconds));
 }
 
+// The detail-sheet navigation path: every per-instance action lives in the
+// inspector that opens from a row tap (design-system.md §10), so integration
+// tests reach them through it. Returns the inspector dialog for scoping.
+async function openSheet(user: ReturnType<typeof userEvent.setup>, name: string): Promise<HTMLElement> {
+  await user.click(await screen.findByRole("button", { name: new RegExp(name) }));
+  return screen.findByRole("dialog", { name });
+}
+
 beforeEach(() => {
   connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
   resetCredentialsStoreForTests();
+  resetToastStoreForTests();
 });
 
 afterEach(() => {
@@ -121,6 +131,55 @@ describe("initial load", () => {
   });
 });
 
+describe("the detail sheet", () => {
+  test("clicking a row opens the inspector; its close button dismisses it", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/instance/list", () => LIST);
+    render(<CredentialsSection sectionId="credentials" />);
+    await screen.findByText("work");
+    const user = userEvent.setup();
+    const inspector = await openSheet(user, "work");
+    expect(within(inspector).getByText(/Configured via stored API key/)).toBeTruthy();
+    await user.click(within(inspector).getByRole("button", { name: "Close" }));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "work" })).toBeNull());
+  });
+
+  test("opening the API-key editor from the sheet closes the sheet", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/instance/list", () => LIST);
+    render(<CredentialsSection sectionId="credentials" />);
+    await screen.findByText("work");
+    const user = userEvent.setup();
+    const inspector = await openSheet(user, "work");
+    await user.click(within(inspector).getByRole("button", { name: "Replace key" }));
+    expect(screen.getByRole("dialog", { name: "Set API key for work" })).toBeTruthy();
+    expect(screen.queryByRole("dialog", { name: "work" })).toBeNull();
+  });
+
+  test("a removed instance's inspector closes itself once the store updates", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/instance/list", () => LIST);
+    fake.on("evener/instance/remove", (params) => {
+      expect(params).toEqual({ name: "personal" });
+      return { instances: [WORK], availableTypes: ["anthropic"] };
+    });
+    render(
+      <>
+        <CredentialsSection sectionId="credentials" />
+        <Toast />
+      </>,
+    );
+    await screen.findByText("personal");
+    const user = userEvent.setup();
+    const inspector = await openSheet(user, "personal");
+    await user.click(within(inspector).getByRole("button", { name: "Remove" }));
+    const confirm = screen.getByRole("dialog", { name: "Remove instance" });
+    await user.click(within(confirm).getByRole("button", { name: "Remove" }));
+    await screen.findByText("Removed instance personal");
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "personal" })).toBeNull());
+  });
+});
+
 describe("credential verification", () => {
   test("sends the exact custom instance name and shows local pending state until the deferred response arrives", async () => {
     const fake = connectFakeClient();
@@ -135,20 +194,21 @@ describe("credential verification", () => {
     render(<CredentialsSection sectionId="credentials" />);
     await screen.findByText(customName);
 
-    const row = screen.getByText(customName).closest("li");
-    expect(row).not.toBeNull();
-    const testButton = within(row!).getByRole("button", { name: "Test credentials" });
+    const inspector = await openSheet(userEvent.setup(), customName);
+    const testButton = within(inspector).getByRole("button", { name: "Test credentials" });
     await userEvent.setup().click(testButton);
 
-    expect((within(row!).getByRole("button", { name: "Testing credentials…" }) as HTMLButtonElement).disabled).toBe(
-      true,
-    );
-    expect((within(row!).getByRole("button", { name: "Edit" }) as HTMLButtonElement).disabled).toBe(false);
+    expect(
+      (within(inspector).getByRole("button", { name: "Testing credentials…" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect((within(inspector).getByRole("button", { name: "Edit" }) as HTMLButtonElement).disabled).toBe(false);
     expect(fake.calls.filter((call) => call.method === "evener/auth/test")).toHaveLength(1);
 
     response.resolve({ provider: customName, status: "success", message: "Credentials verified." });
     expect((await screen.findByRole("status")).textContent).toContain("Credentials verified.");
-    expect((within(row!).getByRole("button", { name: "Test credentials" }) as HTMLButtonElement).disabled).toBe(false);
+    expect((within(inspector).getByRole("button", { name: "Test credentials" }) as HTMLButtonElement).disabled).toBe(
+      false,
+    );
   });
 
   test("suppresses duplicate clicks for one pending instance while another instance stays enabled", async () => {
@@ -164,35 +224,36 @@ describe("credential verification", () => {
     render(<CredentialsSection sectionId="credentials" />);
     await screen.findByText(WORK.name);
     const user = userEvent.setup();
-    const workRow = screen.getByText(WORK.name).closest("li");
-    const personalRow = screen.getByText(PERSONAL.name).closest("li");
-    expect(workRow).not.toBeNull();
-    expect(personalRow).not.toBeNull();
 
-    const workButton = within(workRow!).getByRole("button", { name: "Test credentials" });
+    const workInspector = await openSheet(user, WORK.name);
+    const workButton = within(workInspector).getByRole("button", { name: "Test credentials" });
     await user.click(workButton);
     await user.click(workButton);
     expect(fake.calls.filter((call) => call.method === "evener/auth/test")).toHaveLength(1);
-    expect((within(workRow!).getByRole("button", { name: "Testing credentials…" }) as HTMLButtonElement).disabled).toBe(
-      true,
-    );
-    expect((within(personalRow!).getByRole("button", { name: "Test credentials" }) as HTMLButtonElement).disabled).toBe(
-      false,
-    );
+    expect(
+      (within(workInspector).getByRole("button", { name: "Testing credentials…" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
 
-    await user.click(within(personalRow!).getByRole("button", { name: "Test credentials" }));
+    // The other instance's sheet is independent: its Test stays enabled.
+    await user.click(within(workInspector).getByRole("button", { name: "Close" }));
+    const personalInspector = await openSheet(user, PERSONAL.name);
+    const personalButton = within(personalInspector).getByRole("button", { name: "Test credentials" });
+    expect((personalButton as HTMLButtonElement).disabled).toBe(false);
+    await user.click(personalButton);
     expect(fake.calls.filter((call) => call.method === "evener/auth/test")).toHaveLength(2);
 
     workResponse.resolve({ provider: WORK.name, status: "success", message: "Credentials verified." });
     personalResponse.resolve({ provider: PERSONAL.name, status: "success", message: "Credentials verified." });
-    await waitFor(() => {
-      expect((within(workRow!).getByRole("button", { name: "Test credentials" }) as HTMLButtonElement).disabled).toBe(
-        false,
-      );
+    await waitFor(() =>
       expect(
-        (within(personalRow!).getByRole("button", { name: "Test credentials" }) as HTMLButtonElement).disabled,
-      ).toBe(false);
-    });
+        (within(personalInspector).getByRole("button", { name: "Test credentials" }) as HTMLButtonElement).disabled,
+      ).toBe(false),
+    );
+    await user.click(within(personalInspector).getByRole("button", { name: "Close" }));
+    const workAgain = await openSheet(user, WORK.name);
+    expect((within(workAgain).getByRole("button", { name: "Test credentials" }) as HTMLButtonElement).disabled).toBe(
+      false,
+    );
   });
 
   test.each([
@@ -209,7 +270,8 @@ describe("credential verification", () => {
     fake.on("evener/auth/test", () => response.promise);
     render(<CredentialsSection sectionId="credentials" />);
     await screen.findByText(WORK.name);
-    await userEvent.setup().click(screen.getByRole("button", { name: "Test credentials" }));
+    const inspector = await openSheet(userEvent.setup(), WORK.name);
+    await userEvent.setup().click(within(inspector).getByRole("button", { name: "Test credentials" }));
     response.resolve({ provider: WORK.name, status, message });
 
     const statusNode = await screen.findByRole("status");
@@ -223,7 +285,8 @@ describe("credential verification", () => {
     fake.on("evener/auth/test", async () => ({ provider: WORK.name, status: "auth_rejected", message: secret }));
     render(<CredentialsSection sectionId="credentials" />);
     await screen.findByText(WORK.name);
-    await userEvent.setup().click(screen.getByRole("button", { name: "Test credentials" }));
+    const inspector = await openSheet(userEvent.setup(), WORK.name);
+    await userEvent.setup().click(within(inspector).getByRole("button", { name: "Test credentials" }));
 
     const status = await screen.findByRole("status");
     expect(status.textContent).toContain("The provider rejected these credentials. Replace the key or sign in again.");
@@ -239,7 +302,8 @@ describe("credential verification", () => {
     });
     render(<CredentialsSection sectionId="credentials" />);
     await screen.findByText(WORK.name);
-    await userEvent.setup().click(screen.getByRole("button", { name: "Test credentials" }));
+    const inspector = await openSheet(userEvent.setup(), WORK.name);
+    await userEvent.setup().click(within(inspector).getByRole("button", { name: "Test credentials" }));
 
     const status = await screen.findByRole("status");
     expect(status.textContent).toContain(
@@ -262,15 +326,18 @@ describe("credential verification", () => {
     });
     fake.on("evener/auth/test", () => response.promise);
     render(<CredentialsSection sectionId="credentials" />);
-    await screen.findByText("base https://old.example/v1");
-    await userEvent.setup().click(screen.getByRole("button", { name: "Test credentials" }));
-    expect(screen.getByRole("button", { name: "Testing credentials…" })).toBeTruthy();
+    const inspector = await openSheet(userEvent.setup(), "work");
+    await within(inspector).findByText("base https://old.example/v1");
+    await userEvent.setup().click(within(inspector).getByRole("button", { name: "Test credentials" }));
+    expect(within(inspector).getByRole("button", { name: "Testing credentials…" })).toBeTruthy();
 
     await act(async () => {
       await credentialsStore.getState().fetch();
     });
-    await screen.findByText("base https://new.example/v1");
-    const refreshedButton = screen.getByRole("button", { name: /Test(?:ing credentials…)?/ });
+    // The sheet reads the instance from the store, so the refreshed base URL
+    // lands live; the stale pending state from the old configuration is gone.
+    await within(inspector).findByText("base https://new.example/v1");
+    const refreshedButton = within(inspector).getByRole("button", { name: /Test(?:ing credentials…)?/ });
     expect((refreshedButton as HTMLButtonElement).disabled).toBe(false);
     response.resolve({ provider: "work", status: "success", message: "Credentials verified." });
     await act(async () => {
@@ -281,7 +348,7 @@ describe("credential verification", () => {
 });
 
 describe("single-open-editor invariant", () => {
-  test("opening the Add form, then Edit on a row, replaces it (only one editor open at a time)", async () => {
+  test("opening the Add form, then Edit from a row's sheet, replaces it (only one editor open at a time)", async () => {
     const fake = connectFakeClient();
     fake.on("evener/instance/list", () => LIST);
     render(<CredentialsSection sectionId="credentials" />);
@@ -289,8 +356,10 @@ describe("single-open-editor invariant", () => {
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "+ Add provider instance" }));
     expect(screen.getByRole("dialog", { name: "Add provider instance" })).toBeTruthy();
-    await user.click(screen.getAllByRole("button", { name: "Edit" })[0]!);
+    const inspector = await openSheet(user, "work");
+    await user.click(within(inspector).getByRole("button", { name: "Edit" }));
     expect(screen.queryByRole("dialog", { name: "Add provider instance" })).toBeNull();
+    expect(screen.queryByRole("dialog", { name: "work" })).toBeNull();
     expect(screen.getByRole("dialog", { name: "Edit work" })).toBeTruthy();
   });
 });
@@ -316,8 +385,10 @@ describe("OAuth start branches", () => {
     render(<CredentialsSection sectionId="credentials" />);
     await screen.findByText("personal");
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: "Sign in…" }));
+    const inspector = await openSheet(user, "personal");
+    await user.click(within(inspector).getByRole("button", { name: "Sign in…" }));
     await screen.findByRole("dialog", { name: "Sign in to personal" });
+    expect(screen.queryByRole("dialog", { name: "personal" })).toBeNull();
     expect(openSpy).toHaveBeenCalledWith("https://auth/start", "_blank", "noopener");
     expect(screen.getByRole("link", { name: /re-open authorize url/i })).toBeTruthy();
   });
@@ -336,7 +407,8 @@ describe("OAuth start branches", () => {
     render(<CredentialsSection sectionId="credentials" />);
     await screen.findByText("personal");
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: "Sign in…" }));
+    const inspector = await openSheet(user, "personal");
+    await user.click(within(inspector).getByRole("button", { name: "Sign in…" }));
     await screen.findByText("ABCD-EFGH");
   });
 
@@ -354,11 +426,14 @@ describe("OAuth start branches", () => {
     );
     await screen.findByText("personal");
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: "Sign in…" }));
+    const inspector = await openSheet(user, "personal");
+    await user.click(within(inspector).getByRole("button", { name: "Sign in…" }));
     // error is converted via friendlyErrorMessage: raw JS errors become the generic message
     await screen.findByText("Sign-in failed: Something went wrong.");
     // Assert the raw string no longer appears
     expect(screen.queryByText(/provider unavailable/)).toBeNull();
+    // No dialog of any kind: the inspector closed on the click, and the
+    // failed start must not open (or reopen) anything.
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 
@@ -403,8 +478,10 @@ describe("OAuth start branches", () => {
     });
     render(<CredentialsSection sectionId="credentials" />);
     await screen.findByText("personal");
+    const user = userEvent.setup();
+    const inspector = await openSheet(user, "personal");
     vi.useFakeTimers();
-    fireEvent.click(screen.getByRole("button", { name: "Sign in…" }));
+    fireEvent.click(within(inspector).getByRole("button", { name: "Sign in…" }));
     await vi.waitFor(() => expect(screen.getByText("AAAA-1111")).toBeTruthy());
 
     // Flow A expires.
@@ -443,7 +520,8 @@ describe("set default", () => {
     );
     await screen.findByText("personal");
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: /make default/i }));
+    const inspector = await openSheet(user, "personal");
+    await user.click(within(inspector).getByRole("button", { name: /make default/i }));
     await waitFor(() => expect(fake.calls.some((c) => c.method === "evener/instance/setDefault")).toBe(true));
     expect(screen.queryByRole("alert")).toBeNull();
   });
@@ -462,7 +540,8 @@ describe("set default", () => {
     );
     await screen.findByText("personal");
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: /make default/i }));
+    const inspector = await openSheet(user, "personal");
+    await user.click(within(inspector).getByRole("button", { name: /make default/i }));
     // error is converted via friendlyErrorMessage: raw JS errors become the generic message
     await screen.findByText("Set default failed: Something went wrong.");
     // Assert the raw string no longer appears
@@ -490,11 +569,12 @@ describe("Clear / Remove confirm dialogs", () => {
     await screen.findByText("work");
     const user = userEvent.setup();
     // WORK carries hasStoredFile+activeSource:"file" in the shared fixture,
-    // so its row already offers Clear.
-    await user.click(screen.getByRole("button", { name: "Clear" }));
-    const dialog = screen.getByRole("dialog", { name: /clear/i });
+    // so its sheet already offers Clear.
+    const inspector = await openSheet(user, "work");
+    await user.click(within(inspector).getByRole("button", { name: "Clear" }));
+    const dialog = screen.getByRole("dialog", { name: "Clear credentials" });
     expect(dialog).toBeTruthy();
-    // The row's own Clear button is still present behind the dialog, so
+    // The sheet's own Clear button is still present behind the confirm, so
     // scope this second click to the dialog's own Clear/confirm button.
     await user.click(within(dialog).getByRole("button", { name: "Clear" }));
     await screen.findByText("Credentials cleared for work");
@@ -515,17 +595,17 @@ describe("Clear / Remove confirm dialogs", () => {
     );
     await screen.findByText("personal");
     const user = userEvent.setup();
-    const removeButtons = screen.getAllByRole("button", { name: "Remove" });
-    await user.click(removeButtons[1]!); // personal's row
-    const dialog = screen.getByRole("dialog", { name: /remove/i });
+    const inspector = await openSheet(user, "personal");
+    await user.click(within(inspector).getByRole("button", { name: "Remove" }));
+    const dialog = screen.getByRole("dialog", { name: "Remove instance" });
     expect(dialog).toBeTruthy();
-    // The row's own Remove button is still present behind the dialog, so
+    // The sheet's own Remove button is still present behind the confirm, so
     // scope this second click to the dialog's own Remove/confirm button.
     await user.click(within(dialog).getByRole("button", { name: "Remove" }));
     await screen.findByText("Removed instance personal");
   });
 
-  test("cancelling a confirm dialog makes no RPC call", async () => {
+  test("cancelling a confirm dialog makes no RPC call and keeps the sheet open", async () => {
     const fake = connectFakeClient();
     fake.on("evener/instance/list", () => LIST);
     const removeCalls: unknown[] = [];
@@ -536,10 +616,11 @@ describe("Clear / Remove confirm dialogs", () => {
     render(<CredentialsSection sectionId="credentials" />);
     await screen.findByText("personal");
     const user = userEvent.setup();
-    const removeButtons = screen.getAllByRole("button", { name: "Remove" });
-    await user.click(removeButtons[1]!);
+    const inspector = await openSheet(user, "personal");
+    await user.click(within(inspector).getByRole("button", { name: "Remove" }));
     await user.click(screen.getByRole("button", { name: "Cancel" }));
-    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(screen.queryByRole("dialog", { name: "Remove instance" })).toBeNull();
     expect(removeCalls).toEqual([]);
+    expect(screen.getByRole("dialog", { name: "personal" })).toBeTruthy();
   });
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.tsx
@@ -1,6 +1,13 @@
 // CredentialsSection (#7 - the dominant piece of the Agents & models
-// cluster): instance list/CRUD, API-key set, OAuth browser+device dual
-// flow, default-instance switch, remove - parity-m7-settings.md §7.
+// cluster), detail-sheet redesign: instance rows are single tappable
+// targets that open an InstanceDetailSheet inspector; every per-instance
+// action (test, set key, sign in, edit, make default, clear, remove)
+// lives in that sheet - the same row→detail-sheet collection-page idiom
+// the marketplacesPlugins redesign introduced (a sibling workstream; the
+// idiom's design-system writeup lands with it) - instead of a per-row
+// button cluster. The editors (add/apiKey/edit/OAuth flows) stay dialogs:
+// opening one from the sheet replaces it (single-mutable-editor invariant
+// below).
 //
 // Single-mutable-editor invariant: `openEditor` is ONE section-level state
 // value (a discriminated union), so opening a second editor always replaces
@@ -15,6 +22,7 @@ import { requireClass } from "../../../../widgets/internal/requireClass";
 import { useConnectedEffect } from "../useConnectedEffect";
 import styles from "./CredentialsSection.module.css";
 import { groupByType, safeCredentialTestResult } from "./credentialLabels";
+import { InstanceDetailSheet } from "./InstanceDetailSheet";
 import { InstanceRow } from "./InstanceRow";
 import { AddInstanceDialog, ApiKeyDialog, EditInstanceDialog } from "./instanceDialogs";
 import { DeviceCodeDialog, OAuthRedirectDialog } from "./oauthDialogs";
@@ -49,6 +57,7 @@ export interface CredentialsSectionProps {
 export function CredentialsSection(_props: CredentialsSectionProps) {
   const { instances, availableTypes, loading, error, fetch } = useCredentialsStore();
   const [openEditor, setOpenEditor] = useState<OpenEditor>(null);
+  const [selectedInstance, setSelectedInstance] = useState<string | null>(null);
   const [pendingConfirm, setPendingConfirm] = useState<PendingConfirm>(null);
   const [confirmBusy, setConfirmBusy] = useState(false);
   const [credentialTests, setCredentialTests] = useState<Record<string, CredentialTestState>>({});
@@ -71,8 +80,8 @@ export function CredentialsSection(_props: CredentialsSectionProps) {
   // client (throws otherwise) - see that hook's own doc comment.
   useConnectedEffect(fetch, [fetch]);
 
-  // handleOAuthStart is shared by a row's own "Sign in…"/"Refresh OAuth"
-  // button and the device editor's "Start again" - always begins with
+  // handleOAuthStart is shared by the sheet's "Sign in…"/"Refresh OAuth"
+  // action and the device editor's "Start again" - always begins with
   // authDeviceStart, then branches on `fallback` exactly like the legacy's
   // startDeviceLogin (templates/partials/credentials.html:58-75).
   async function handleOAuthStart(name: string): Promise<void> {
@@ -161,6 +170,16 @@ export function CredentialsSection(_props: CredentialsSectionProps) {
     return instances.find((i) => i.name === name);
   }
 
+  // Editor-opening sheet actions REPLACE the inspector with the flow's
+  // dialog (one overlay owns the screen during a flow); confirm-gated and
+  // self-contained actions (clear, remove, test, make default) leave it
+  // open - the confirm nests over it, and the store keeps it live.
+  function openEditorFromSheet(editor: (name: string) => void): void {
+    const name = selectedInstance;
+    setSelectedInstance(null);
+    if (name !== null) editor(name);
+  }
+
   const groups = groupByType(instances);
   // useCallback'd (not a plain inline arrow) so its identity stays stable
   // across CredentialsSection re-renders - DeviceCodeDialog's own poll
@@ -191,22 +210,7 @@ export function CredentialsSection(_props: CredentialsSectionProps) {
                     <InstanceRow
                       key={instance.name}
                       instance={instance}
-                      onSetApiKey={() => setOpenEditor({ kind: "apiKey", name: instance.name })}
-                      onOAuthStart={() => void handleOAuthStart(instance.name)}
-                      onEdit={() => setOpenEditor({ kind: "edit", name: instance.name })}
-                      onClear={() => setPendingConfirm({ kind: "clear", name: instance.name })}
-                      onRemove={() => setPendingConfirm({ kind: "remove", name: instance.name })}
-                      onSetDefault={() => void handleSetDefault(instance.name)}
-                      onTestCredentials={() => void handleTestCredentials(instance.name)}
-                      testCredentialsPending={
-                        credentialTests[instance.name]?.version === instanceVersion.current &&
-                        (credentialTests[instance.name]?.pending ?? false)
-                      }
-                      testCredentialsResult={
-                        credentialTests[instance.name]?.version === instanceVersion.current
-                          ? credentialTests[instance.name]?.result
-                          : undefined
-                      }
+                      onSelect={() => setSelectedInstance(instance.name)}
                     />
                   ))}
                 </ul>
@@ -214,6 +218,36 @@ export function CredentialsSection(_props: CredentialsSectionProps) {
             ))}
           </div>
         ))}
+
+      <InstanceDetailSheet
+        name={selectedInstance}
+        onClose={() => setSelectedInstance(null)}
+        onSetApiKey={() => openEditorFromSheet((name) => setOpenEditor({ kind: "apiKey", name }))}
+        onOAuthStart={() => openEditorFromSheet((name) => void handleOAuthStart(name))}
+        onEdit={() => openEditorFromSheet((name) => setOpenEditor({ kind: "edit", name }))}
+        onClear={() => {
+          if (selectedInstance !== null) setPendingConfirm({ kind: "clear", name: selectedInstance });
+        }}
+        onRemove={() => {
+          if (selectedInstance !== null) setPendingConfirm({ kind: "remove", name: selectedInstance });
+        }}
+        onSetDefault={() => {
+          if (selectedInstance !== null) void handleSetDefault(selectedInstance);
+        }}
+        onTestCredentials={() => {
+          if (selectedInstance !== null) void handleTestCredentials(selectedInstance);
+        }}
+        testCredentialsPending={
+          selectedInstance !== null &&
+          credentialTests[selectedInstance]?.version === instanceVersion.current &&
+          (credentialTests[selectedInstance]?.pending ?? false)
+        }
+        testCredentialsResult={
+          selectedInstance !== null && credentialTests[selectedInstance]?.version === instanceVersion.current
+            ? credentialTests[selectedInstance]?.result
+            : undefined
+        }
+      />
 
       {openEditor?.kind === "add" && (
         <AddInstanceDialog availableTypes={availableTypes} onCancel={closeEditor} onSuccess={closeEditor} />

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceDetailSheet.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceDetailSheet.module.css
@@ -1,0 +1,92 @@
+/* InstanceDetailSheet body layout (detail-sheet redesign). Same inspector
+ * vocabulary as marketplacesPlugins' PluginDetailSheet: chip row, layered
+ * status block, 96px-caption meta table, full-width action rows with a
+ * danger zone below a divider. */
+
+.headingRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.layers {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-bottom: var(--space-4);
+}
+
+.layer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}
+
+.unconfigured {
+  margin: 0 0 var(--space-4);
+  color: var(--ink-mid);
+  font-size: var(--font-size-ui);
+}
+
+.metaList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: 0 0 var(--space-4);
+}
+
+.metaRow {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+}
+
+.metaLabel {
+  flex: none;
+  width: 96px;
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}
+
+.metaValue {
+  min-width: 0;
+  color: var(--ink-hi);
+  font-size: var(--font-size-ui);
+}
+
+.metaMono {
+  overflow: hidden;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-caption);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.actionRows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+/* Full-width action row: the quiet Button stretches to the row and its
+ * label left-aligns, so stacked actions read as one list (the bottom-sheet
+ * idiom) rather than a button cluster. Layout only, not a widget reskin. */
+.fullRow > button {
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.divider {
+  margin: var(--space-3) 0;
+  border: none;
+  border-top: 1px solid var(--edge);
+}
+
+.testResult {
+  margin: 0 0 var(--space-1);
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceDetailSheet.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceDetailSheet.test.tsx
@@ -1,0 +1,257 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { FakeClient } from "../../../../protocol/testing/fakeClient";
+import type { InstanceEntry } from "../../../../protocol/types.gen";
+import { connectionStore } from "../../../../stores/connection";
+import { credentialsStore, resetCredentialsStoreForTests } from "../../../../stores/credentials";
+import { InstanceDetailSheet } from "./InstanceDetailSheet";
+
+function instance(overrides: Partial<InstanceEntry> & Pick<InstanceEntry, "name" | "type">): InstanceEntry {
+  return {
+    apiStyle: "",
+    baseUrl: "",
+    isDefault: false,
+    activeSource: "absent",
+    hasStoredOAuth: false,
+    credentialRequired: true,
+    ...overrides,
+  };
+}
+
+function noopHandlers() {
+  return {
+    onTestCredentials: vi.fn(),
+    onSetApiKey: vi.fn(),
+    onOAuthStart: vi.fn(),
+    onEdit: vi.fn(),
+    onClear: vi.fn(),
+    onRemove: vi.fn(),
+    onSetDefault: vi.fn(),
+  };
+}
+
+function renderSheet(inst: InstanceEntry | null, extra: Partial<Parameters<typeof InstanceDetailSheet>[0]> = {}) {
+  const handlers = noopHandlers();
+  const onClose = vi.fn();
+  credentialsStore.setState({ instances: inst === null ? [] : [inst] });
+  render(<InstanceDetailSheet name={inst?.name ?? null} onClose={onClose} {...handlers} {...extra} />);
+  return { handlers, onClose };
+}
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
+  resetCredentialsStoreForTests();
+  const fake = new FakeClient("ready");
+  connectionStore.getState().connect(fake);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("visibility", () => {
+  test("renders nothing when name is null", () => {
+    renderSheet(null);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  test("renders a dialog named after the instance, with the default chip when set", () => {
+    renderSheet(instance({ name: "openai-work", type: "openai", isDefault: true }));
+    expect(screen.getByRole("dialog", { name: "openai-work" })).toBeTruthy();
+    expect(screen.getByText(/default/i)).toBeTruthy();
+  });
+
+  test("the close button calls onClose", async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderSheet(instance({ name: "a", type: "x" }));
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("closes itself when the instance disappears from the store", async () => {
+    const { onClose } = renderSheet(instance({ name: "a", type: "x" }));
+    expect(screen.getByRole("dialog", { name: "a" })).toBeTruthy();
+    credentialsStore.setState({ instances: [] });
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  test("the heading dot reads idle for a configured instance", () => {
+    renderSheet(instance({ name: "a", type: "x", hasStoredFile: true, activeSource: "file" }));
+    expect(screen.getByRole("img", { name: "Idle" })).toBeTruthy();
+  });
+
+  test("the heading dot reads ended when a required key is missing", () => {
+    renderSheet(instance({ name: "a", type: "x", activeSource: "absent", credentialRequired: true }));
+    expect(screen.getByRole("img", { name: "Ended" })).toBeTruthy();
+  });
+});
+
+describe("credential display", () => {
+  test("multiple layers show effective + shadowed chips", () => {
+    renderSheet(
+      instance({ name: "a", type: "openai", hasStoredOAuth: true, hasStoredFile: true, activeSource: "oauth" }),
+    );
+    expect(screen.getByText("effective")).toBeTruthy();
+    expect(screen.getByText("shadowed")).toBeTruthy();
+    expect(screen.getByText(/Configured via stored API key/)).toBeTruthy();
+  });
+
+  test("an oauth layer carries the stored email", () => {
+    renderSheet(
+      instance({ name: "a", type: "openai", hasStoredOAuth: true, storedEmail: "me@x.com", activeSource: "oauth" }),
+    );
+    expect(screen.getByText(/Configured via OAuth \(me@x\.com\)/)).toBeTruthy();
+  });
+
+  test("an unconfigured instance shows its label instead of layers", () => {
+    renderSheet(instance({ name: "a", type: "x", activeSource: "absent" }));
+    expect(screen.getByText("Not configured")).toBeTruthy();
+    expect(screen.queryByText("effective")).toBeNull();
+  });
+});
+
+describe("the meta table", () => {
+  test("shows the instance type, and the API style/base row only when present", () => {
+    renderSheet(
+      instance({
+        name: "a",
+        type: "openai",
+        apiStyle: "responses",
+        baseUrl: "https://x",
+        hasStoredFile: true,
+        activeSource: "file",
+      }),
+    );
+    expect(screen.getByText("Type")).toBeTruthy();
+    expect(screen.getByText("openai")).toBeTruthy();
+    expect(screen.getByText("responses · base https://x")).toBeTruthy();
+  });
+
+  test("omits the API row when neither apiStyle nor baseUrl is set", () => {
+    renderSheet(instance({ name: "a", type: "x", hasStoredFile: true, activeSource: "file" }));
+    expect(screen.queryByText("API")).toBeNull();
+  });
+});
+
+describe("actions are conditionally rendered", () => {
+  test("Set key only when authModes includes apiKey", () => {
+    renderSheet(instance({ name: "a", type: "x", authModes: ["oauth"] }));
+    expect(screen.queryByRole("button", { name: /set key|replace key/i })).toBeNull();
+  });
+
+  test("Sign in… only when authModes includes oauth", () => {
+    renderSheet(instance({ name: "a", type: "x", authModes: ["apiKey"] }));
+    expect(screen.queryByRole("button", { name: /sign in|refresh oauth/i })).toBeNull();
+  });
+
+  test("Clear only when activeSource is file or oauth", () => {
+    renderSheet(instance({ name: "a", type: "x", activeSource: "env", envVar: "X_KEY" }));
+    expect(screen.queryByRole("button", { name: "Clear" })).toBeNull();
+  });
+
+  test("Edit and Remove are always present", () => {
+    renderSheet(instance({ name: "a", type: "x" }));
+    expect(screen.getByRole("button", { name: "Edit" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Remove" })).toBeTruthy();
+  });
+
+  test("make default only when not already default", () => {
+    renderSheet(instance({ name: "a", type: "x", isDefault: false }));
+    expect(screen.getByRole("button", { name: /make default/i })).toBeTruthy();
+  });
+
+  test("make default hidden when already default", () => {
+    renderSheet(instance({ name: "a", type: "x", isDefault: true }));
+    expect(screen.queryByRole("button", { name: /make default/i })).toBeNull();
+  });
+});
+
+describe("action labels follow stored state", () => {
+  test("'Set key' when no file-sourced key exists", () => {
+    renderSheet(instance({ name: "a", type: "x", authModes: ["apiKey"], hasStoredFile: false }));
+    expect(screen.getByRole("button", { name: "Set key" })).toBeTruthy();
+  });
+
+  test("'Replace key' whenever a file-sourced key exists, even if a different source is currently effective", () => {
+    renderSheet(
+      instance({
+        name: "a",
+        type: "x",
+        authModes: ["apiKey"],
+        hasStoredFile: true,
+        hasStoredOAuth: true,
+        activeSource: "oauth",
+      }),
+    );
+    expect(screen.getByRole("button", { name: "Replace key" })).toBeTruthy();
+  });
+
+  test("'Sign in…' when no OAuth is stored", () => {
+    renderSheet(instance({ name: "a", type: "x", authModes: ["oauth"], hasStoredOAuth: false }));
+    expect(screen.getByRole("button", { name: "Sign in…" })).toBeTruthy();
+  });
+
+  test("'Refresh OAuth' once signed in", () => {
+    renderSheet(instance({ name: "a", type: "x", authModes: ["oauth"], hasStoredOAuth: true }));
+    expect(screen.getByRole("button", { name: "Refresh OAuth" })).toBeTruthy();
+  });
+});
+
+describe("action callbacks fire", () => {
+  test("clicking each action calls its handler", async () => {
+    const user = userEvent.setup();
+    const { handlers } = renderSheet(
+      instance({
+        name: "a",
+        type: "openai",
+        authModes: ["apiKey", "oauth"],
+        hasStoredFile: true,
+        activeSource: "file",
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: "Replace key" }));
+    expect(handlers.onSetApiKey).toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Sign in…" }));
+    expect(handlers.onOAuthStart).toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+    expect(handlers.onClear).toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+    expect(handlers.onEdit).toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+    expect(handlers.onRemove).toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: /make default/i }));
+    expect(handlers.onSetDefault).toHaveBeenCalled();
+  });
+
+  test("clicking Test credentials calls its handler", async () => {
+    const user = userEvent.setup();
+    const { handlers } = renderSheet(instance({ name: "a", type: "x" }));
+    await user.click(screen.getByRole("button", { name: "Test credentials" }));
+    expect(handlers.onTestCredentials).toHaveBeenCalledTimes(1);
+  });
+
+  test("pending verification disables only the Test credentials action", () => {
+    renderSheet(instance({ name: "a", type: "x" }), { testCredentialsPending: true });
+    expect((screen.getByRole("button", { name: "Testing credentials…" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole("button", { name: "Edit" }) as HTMLButtonElement).disabled).toBe(false);
+    expect((screen.getByRole("button", { name: "Remove" }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  test("a credential test result renders as a status line", () => {
+    renderSheet(instance({ name: "a", type: "x" }), {
+      testCredentialsResult: { provider: "a", status: "success", message: "Credentials verified." },
+    });
+    expect(screen.getByRole("status").textContent).toContain("Credentials verified.");
+  });
+
+  test("an unknown test status is sanitized to the endpoint-failure message", () => {
+    renderSheet(instance({ name: "a", type: "x" }), {
+      testCredentialsResult: { provider: "a", status: "garbage", message: "raw provider prose" },
+    });
+    const line = screen.getByRole("status");
+    expect(line.textContent).toContain("The provider endpoint could not be reached.");
+    expect(line.textContent).not.toContain("raw provider prose");
+  });
+});

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceDetailSheet.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceDetailSheet.tsx
@@ -1,0 +1,193 @@
+// InstanceDetailSheet: the provider-instance inspector for the detail-sheet
+// redesign. Opens from an InstanceRow tap and owns everything the old row
+// carried: the layered credential display (oauth > file > env,
+// effective/shadowed), the meta table, and every per-instance ACTION (test,
+// set/replace key, sign in/refresh OAuth, edit, make default, clear,
+// remove). A right side Sheet on desktop, a bottom Sheet on mobile
+// (useIsMobile, the shell's own source). The instance is read from the
+// store by name so cross-client changes land live, and the sheet closes
+// itself when the instance disappears (its own Remove completing, or
+// another client's) - an inspector is only as alive as its subject.
+// Presentation only - the section owns what each action DOES (opening an
+// editor, a confirm dialog, or calling the store), same division of labor
+// as the old InstanceRow.
+import { useEffect } from "react";
+import type { AuthTestResponse, InstanceEntry } from "../../../../protocol/types.gen";
+import { useIsMobile } from "../../../../shell/useIsMobile";
+import { useCredentialsStore } from "../../../../stores/credentials";
+import { Button, Chip, Sheet, StatusDot } from "../../../../widgets";
+import { requireClass } from "../../../../widgets/internal/requireClass";
+import {
+  credentialLayers,
+  keylessByDesign,
+  safeCredentialTestMessage,
+  safeCredentialTestResult,
+  unconfiguredLabel,
+} from "./credentialLabels";
+import styles from "./InstanceDetailSheet.module.css";
+
+const CLASS = {
+  headingRow: requireClass(styles.headingRow, "InstanceDetailSheet.module.css", "headingRow"),
+  layers: requireClass(styles.layers, "InstanceDetailSheet.module.css", "layers"),
+  layer: requireClass(styles.layer, "InstanceDetailSheet.module.css", "layer"),
+  unconfigured: requireClass(styles.unconfigured, "InstanceDetailSheet.module.css", "unconfigured"),
+  metaList: requireClass(styles.metaList, "InstanceDetailSheet.module.css", "metaList"),
+  metaRow: requireClass(styles.metaRow, "InstanceDetailSheet.module.css", "metaRow"),
+  metaLabel: requireClass(styles.metaLabel, "InstanceDetailSheet.module.css", "metaLabel"),
+  metaValue: requireClass(styles.metaValue, "InstanceDetailSheet.module.css", "metaValue"),
+  metaMono: requireClass(styles.metaMono, "InstanceDetailSheet.module.css", "metaMono"),
+  actionRows: requireClass(styles.actionRows, "InstanceDetailSheet.module.css", "actionRows"),
+  fullRow: requireClass(styles.fullRow, "InstanceDetailSheet.module.css", "fullRow"),
+  divider: requireClass(styles.divider, "InstanceDetailSheet.module.css", "divider"),
+  testResult: requireClass(styles.testResult, "InstanceDetailSheet.module.css", "testResult"),
+};
+
+export interface InstanceDetailSheetProps {
+  name: string | null;
+  onClose: () => void;
+  onSetApiKey: () => void;
+  onOAuthStart: () => void;
+  onEdit: () => void;
+  onClear: () => void;
+  onRemove: () => void;
+  onSetDefault: () => void;
+  onTestCredentials: () => void;
+  testCredentialsPending?: boolean;
+  testCredentialsResult?: AuthTestResponse;
+}
+
+function styleInfoText(instance: InstanceEntry): string | null {
+  if (instance.apiStyle)
+    return instance.baseUrl ? `${instance.apiStyle} · base ${instance.baseUrl}` : instance.apiStyle;
+  if (instance.baseUrl) return `base ${instance.baseUrl}`;
+  return null;
+}
+
+export function InstanceDetailSheet({
+  name,
+  onClose,
+  onSetApiKey,
+  onOAuthStart,
+  onEdit,
+  onClear,
+  onRemove,
+  onSetDefault,
+  onTestCredentials,
+  testCredentialsPending = false,
+  testCredentialsResult,
+}: InstanceDetailSheetProps) {
+  const instances = useCredentialsStore((s) => s.instances);
+  const isMobile = useIsMobile();
+
+  const instance = name === null ? undefined : instances.find((i) => i.name === name);
+
+  // An inspector is only as alive as its subject: the instance can vanish
+  // under an open sheet (its own Remove completing, or another client's
+  // change), and an inspector for a thing that no longer exists closes
+  // itself rather than offering actions on a ghost.
+  useEffect(() => {
+    if (name !== null && instance === undefined) onClose();
+  }, [name, instance, onClose]);
+
+  const open = name !== null && instance !== undefined;
+
+  const supportsApiKey = instance !== undefined && (instance.authModes ?? []).includes("apiKey");
+  const supportsOAuth = instance !== undefined && (instance.authModes ?? []).includes("oauth");
+  const showClear = instance !== undefined && (instance.activeSource === "file" || instance.activeSource === "oauth");
+  const layers = instance === undefined ? [] : credentialLayers(instance);
+  const unconfigured = instance === undefined ? null : unconfiguredLabel(instance);
+  const styleInfo = instance === undefined ? null : styleInfoText(instance);
+  const safeTestResult = testCredentialsResult
+    ? safeCredentialTestResult(name ?? "", testCredentialsResult)
+    : undefined;
+
+  return (
+    <Sheet open={open} onClose={onClose} title={instance?.name ?? ""} side={isMobile ? "bottom" : "right"}>
+      {instance !== undefined && (
+        <>
+          <div className={CLASS.headingRow}>
+            <StatusDot state={layers.length > 0 || keylessByDesign(instance) ? "idle" : "ended"} />
+            {instance.isDefault && <Chip>★ default</Chip>}
+          </div>
+          {unconfigured !== null ? (
+            <p className={CLASS.unconfigured}>{unconfigured}</p>
+          ) : (
+            <div className={CLASS.layers}>
+              {layers.map((layer) => (
+                <div key={layer.source} className={CLASS.layer}>
+                  <span>↳ {layer.label}</span>
+                  <Chip tone={layer.effective ? "alive" : "neutral"}>{layer.effective ? "effective" : "shadowed"}</Chip>
+                </div>
+              ))}
+            </div>
+          )}
+          <div className={CLASS.metaList}>
+            <div className={CLASS.metaRow}>
+              <span className={CLASS.metaLabel}>Type</span>
+              <span className={CLASS.metaValue}>{instance.type}</span>
+            </div>
+            {styleInfo !== null && (
+              <div className={CLASS.metaRow}>
+                <span className={CLASS.metaLabel}>API</span>
+                <span className={`${CLASS.metaValue} ${CLASS.metaMono}`}>{styleInfo}</span>
+              </div>
+            )}
+          </div>
+          <div className={CLASS.actionRows}>
+            <div className={CLASS.fullRow}>
+              <Button variant="quiet" onClick={onTestCredentials} disabled={testCredentialsPending}>
+                {testCredentialsPending ? "Testing credentials…" : "Test credentials"}
+              </Button>
+            </div>
+            {safeTestResult && (
+              <p className={CLASS.testResult} role="status">
+                {safeTestResult.status}: {safeCredentialTestMessage(safeTestResult.status)}
+              </p>
+            )}
+            {supportsApiKey && (
+              <div className={CLASS.fullRow}>
+                <Button variant="quiet" onClick={onSetApiKey}>
+                  {instance.hasStoredFile ? "Replace key" : "Set key"}
+                </Button>
+              </div>
+            )}
+            {supportsOAuth && (
+              <div className={CLASS.fullRow}>
+                <Button variant="quiet" onClick={onOAuthStart}>
+                  {instance.hasStoredOAuth ? "Refresh OAuth" : "Sign in…"}
+                </Button>
+              </div>
+            )}
+            {!instance.isDefault && (
+              <div className={CLASS.fullRow}>
+                <Button variant="quiet" onClick={onSetDefault}>
+                  ★ make default
+                </Button>
+              </div>
+            )}
+            <div className={CLASS.fullRow}>
+              <Button variant="quiet" onClick={onEdit}>
+                Edit
+              </Button>
+            </div>
+          </div>
+          <hr className={CLASS.divider} />
+          <div className={CLASS.actionRows}>
+            {showClear && (
+              <div className={CLASS.fullRow}>
+                <Button variant="dangerQuiet" onClick={onClear}>
+                  Clear
+                </Button>
+              </div>
+            )}
+            <div className={CLASS.fullRow}>
+              <Button variant="danger" onClick={onRemove}>
+                Remove
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </Sheet>
+  );
+}

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceRow.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceRow.module.css
@@ -48,7 +48,6 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  flex-wrap: wrap;
   min-width: 0;
 }
 
@@ -56,6 +55,9 @@
   color: var(--ink-hi);
   font-size: var(--font-size-ui);
   font-weight: var(--font-weight-medium);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .meta {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceRow.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceRow.module.css
@@ -1,10 +1,47 @@
-.row {
+/* InstanceRow: the tappable provider-instance row (detail-sheet redesign).
+ * One full-width button per row — the whole row is the select target on both
+ * desktop and mobile; actions and the layered credential display live in
+ * InstanceDetailSheet. Shares the collection-row idiom: surface-1, edge,
+ * radius-control, hover wash, 44px floor on phones. */
+
+.rowButton {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
   gap: var(--space-2);
-  padding: var(--space-3);
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
   border: 1px solid var(--edge);
   border-radius: var(--radius-control);
+  background: var(--surface-1);
+  color: var(--ink-hi);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-ui);
+  text-align: left;
+  cursor: pointer;
+  transition: background-color var(--motion-duration-hover) var(--motion-easing-standard);
+}
+
+.rowButton:hover {
+  background: var(--hover-1);
+}
+
+.rowButton:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -2px;
+}
+
+@media (max-width: 900px) {
+  .rowButton {
+    min-height: var(--tap-min);
+  }
+}
+
+.rowMain {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
 }
 
 .heading {
@@ -12,6 +49,7 @@
   align-items: center;
   gap: var(--space-2);
   flex-wrap: wrap;
+  min-width: 0;
 }
 
 .name {
@@ -20,39 +58,18 @@
   font-weight: var(--font-weight-medium);
 }
 
-.styleInfo {
+.meta {
+  overflow: hidden;
   color: var(--ink-mid);
+  font-family: var(--font-mono);
   font-size: var(--font-size-caption);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.layers {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-}
-
-.layer {
-  display: flex;
+.chevron {
+  display: inline-flex;
+  flex: none;
   align-items: center;
-  gap: var(--space-2);
-  color: var(--ink-mid);
-  font-size: var(--font-size-caption);
-}
-
-.unconfigured {
-  margin: 0;
-  color: var(--ink-mid);
-  font-size: var(--font-size-caption);
-}
-
-.actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-}
-
-.testResult {
-  margin: 0;
-  color: var(--ink-mid);
-  font-size: var(--font-size-caption);
+  color: var(--ink-low);
 }

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceRow.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceRow.test.tsx
@@ -18,226 +18,19 @@ function instance(overrides: Partial<InstanceEntry> & Pick<InstanceEntry, "name"
   };
 }
 
-function noopHandlers() {
-  return {
-    onTestCredentials: vi.fn(),
-    onSetApiKey: vi.fn(),
-    onOAuthStart: vi.fn(),
-    onEdit: vi.fn(),
-    onClear: vi.fn(),
-    onRemove: vi.fn(),
-    onSetDefault: vi.fn(),
-  };
-}
-
-describe("row actions are conditionally rendered", () => {
-  test("Set key only when authModes includes apiKey", () => {
-    const handlers = noopHandlers();
-    render(<InstanceRow instance={instance({ name: "a", type: "x", authModes: ["oauth"] })} {...handlers} />);
-    expect(screen.queryByRole("button", { name: /set key|replace key/i })).toBeNull();
-  });
-
-  test("Sign in… only when authModes includes oauth", () => {
-    const handlers = noopHandlers();
-    render(<InstanceRow instance={instance({ name: "a", type: "x", authModes: ["apiKey"] })} {...handlers} />);
-    expect(screen.queryByRole("button", { name: /sign in|refresh oauth/i })).toBeNull();
-  });
-
-  test("Clear only when activeSource is file or oauth", () => {
-    const handlers = noopHandlers();
-    const { rerender } = render(
-      <InstanceRow instance={instance({ name: "a", type: "x", activeSource: "env" })} {...handlers} />,
-    );
-    expect(screen.queryByRole("button", { name: "Clear" })).toBeNull();
-    rerender(
-      <InstanceRow
-        instance={instance({ name: "a", type: "x", activeSource: "file", hasStoredFile: true })}
-        {...handlers}
-      />,
-    );
-    expect(screen.getByRole("button", { name: "Clear" })).toBeTruthy();
-  });
-
-  test("Edit and Remove are always present", () => {
-    const handlers = noopHandlers();
-    render(<InstanceRow instance={instance({ name: "a", type: "x" })} {...handlers} />);
-    expect(screen.getByRole("button", { name: "Edit" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Remove" })).toBeTruthy();
-  });
-
-  test("make default only when not already default", () => {
-    const handlers = noopHandlers();
-    const { rerender } = render(
-      <InstanceRow instance={instance({ name: "a", type: "x", isDefault: false })} {...handlers} />,
-    );
-    expect(screen.getByRole("button", { name: /make default/i })).toBeTruthy();
-    rerender(<InstanceRow instance={instance({ name: "a", type: "x", isDefault: true })} {...handlers} />);
-    expect(screen.queryByRole("button", { name: /make default/i })).toBeNull();
-  });
-});
-
-describe("Set/Replace key label", () => {
-  test("'Set key' when no file-sourced key exists", () => {
-    const handlers = noopHandlers();
+describe("the row carries identity and status only", () => {
+  test("the whole row is one button showing name, meta, and a chevron", () => {
     render(
       <InstanceRow
-        instance={instance({ name: "a", type: "x", authModes: ["apiKey"], hasStoredFile: false })}
-        {...handlers}
+        instance={instance({ name: "openai-work", type: "openai", hasStoredFile: true, activeSource: "file" })}
+        onSelect={() => {}}
       />,
     );
-    expect(screen.getByRole("button", { name: "Set key" })).toBeTruthy();
+    const row = screen.getByRole("button", { name: /openai-work/ });
+    expect(row).toBeTruthy();
   });
 
-  test("'Replace key' whenever a file-sourced key exists, even if a different source is currently effective", () => {
-    const handlers = noopHandlers();
-    render(
-      <InstanceRow
-        instance={instance({
-          name: "a",
-          type: "x",
-          authModes: ["apiKey"],
-          hasStoredFile: true,
-          hasStoredOAuth: true,
-          activeSource: "oauth",
-        })}
-        {...handlers}
-      />,
-    );
-    expect(screen.getByRole("button", { name: "Replace key" })).toBeTruthy();
-  });
-});
-
-describe("Sign in / Refresh OAuth label", () => {
-  test("'Sign in…' when no OAuth is stored", () => {
-    const handlers = noopHandlers();
-    render(
-      <InstanceRow
-        instance={instance({ name: "a", type: "x", authModes: ["oauth"], hasStoredOAuth: false })}
-        {...handlers}
-      />,
-    );
-    expect(screen.getByRole("button", { name: "Sign in…" })).toBeTruthy();
-  });
-
-  test("'Refresh OAuth' once signed in", () => {
-    const handlers = noopHandlers();
-    render(
-      <InstanceRow
-        instance={instance({ name: "a", type: "x", authModes: ["oauth"], hasStoredOAuth: true })}
-        {...handlers}
-      />,
-    );
-    expect(screen.getByRole("button", { name: "Refresh OAuth" })).toBeTruthy();
-  });
-});
-
-describe("layered credential display", () => {
-  test("an unconfigured instance shows 'Not configured' and no Clear button", () => {
-    const handlers = noopHandlers();
-    render(<InstanceRow instance={instance({ name: "a", type: "x", activeSource: "absent" })} {...handlers} />);
-    expect(screen.getByText("Not configured")).toBeTruthy();
-  });
-
-  test("multiple layers show effective + shadowed badges", () => {
-    const handlers = noopHandlers();
-    render(
-      <InstanceRow
-        instance={instance({
-          name: "a",
-          type: "openai",
-          hasStoredOAuth: true,
-          hasStoredFile: true,
-          activeSource: "oauth",
-        })}
-        {...handlers}
-      />,
-    );
-    expect(screen.getByText("effective")).toBeTruthy();
-    expect(screen.getByText("shadowed")).toBeTruthy();
-  });
-
-  test("apiStyle/baseUrl trailing text: apiStyle preferred, then base url", () => {
-    const handlers = noopHandlers();
-    render(
-      <InstanceRow
-        instance={instance({ name: "a", type: "openai", apiStyle: "responses", baseUrl: "https://x" })}
-        {...handlers}
-      />,
-    );
-    expect(screen.getByText("responses · base https://x")).toBeTruthy();
-  });
-
-  test("base url alone when apiStyle is empty", () => {
-    const handlers = noopHandlers();
-    render(<InstanceRow instance={instance({ name: "a", type: "openai", baseUrl: "https://x" })} {...handlers} />);
-    expect(screen.getByText("base https://x")).toBeTruthy();
-  });
-
-  test("the default badge shows when isDefault", () => {
-    const handlers = noopHandlers();
-    render(<InstanceRow instance={instance({ name: "a", type: "x", isDefault: true })} {...handlers} />);
-    expect(screen.getByText(/default/i)).toBeTruthy();
-  });
-});
-
-// The heading dot is the glyph half of what the unconfigured label says in
-// words, so the two have to agree about the same instance. StatusDot's only
-// observable difference between "idle" and "ended" is its accessible name
-// (both states share the neutral token family - src/widgets/statusdot), so
-// that name is what these assert on.
-describe("the heading dot agrees with the credential label", () => {
-  test("a keyless gateway - no key, none needed - is not announced as ended", () => {
-    const handlers = noopHandlers();
-    render(
-      <InstanceRow
-        instance={instance({
-          name: "llama",
-          type: "openai",
-          baseUrl: "http://127.0.0.1:8080/v1",
-          activeSource: "absent",
-          credentialRequired: false,
-        })}
-        {...handlers}
-      />,
-    );
-    expect(screen.getByText("No key set · optional")).toBeTruthy();
-    expect(screen.getByRole("img", { name: "Idle" })).toBeTruthy();
-  });
-
-  test("an auth-none provider - one that authenticates nothing - is not announced as ended", () => {
-    const handlers = noopHandlers();
-    render(
-      <InstanceRow
-        instance={instance({
-          name: "ollama",
-          type: "ollama",
-          activeSource: "none",
-          credentialRequired: false,
-        })}
-        {...handlers}
-      />,
-    );
-    expect(screen.getByText("No credentials required")).toBeTruthy();
-    expect(screen.getByRole("img", { name: "Idle" })).toBeTruthy();
-  });
-
-  test("a provider whose required key is missing keeps the ended dot", () => {
-    const handlers = noopHandlers();
-    render(
-      <InstanceRow
-        instance={instance({ name: "a", type: "anthropic", activeSource: "absent", credentialRequired: true })}
-        {...handlers}
-      />,
-    );
-    expect(screen.getByText("Not configured")).toBeTruthy();
-    expect(screen.getByRole("img", { name: "Ended" })).toBeTruthy();
-  });
-});
-
-describe("action callbacks fire", () => {
-  test("clicking each action calls its handler", async () => {
-    const handlers = noopHandlers();
-    const user = userEvent.setup();
+  test("rows carry no per-row action buttons - every action lives in the detail sheet", () => {
     render(
       <InstanceRow
         instance={instance({
@@ -247,39 +40,155 @@ describe("action callbacks fire", () => {
           hasStoredFile: true,
           activeSource: "file",
         })}
-        {...handlers}
+        onSelect={() => {}}
       />,
     );
-    await user.click(screen.getByRole("button", { name: "Replace key" }));
-    expect(handlers.onSetApiKey).toHaveBeenCalled();
-    await user.click(screen.getByRole("button", { name: "Sign in…" }));
-    expect(handlers.onOAuthStart).toHaveBeenCalled();
-    await user.click(screen.getByRole("button", { name: "Clear" }));
-    expect(handlers.onClear).toHaveBeenCalled();
-    await user.click(screen.getByRole("button", { name: "Edit" }));
-    expect(handlers.onEdit).toHaveBeenCalled();
-    await user.click(screen.getByRole("button", { name: "Remove" }));
-    expect(handlers.onRemove).toHaveBeenCalled();
-    await user.click(screen.getByRole("button", { name: /make default/i }));
-    expect(handlers.onSetDefault).toHaveBeenCalled();
+    for (const name of ["Edit", "Remove", "Clear", "Set key", "Sign in…", "Test credentials"]) {
+      expect(screen.queryByRole("button", { name })).toBeNull();
+    }
+    expect(screen.queryByRole("button", { name: /make default/i })).toBeNull();
   });
 
-  test("clicking Test credentials calls its handler", async () => {
-    const handlers = noopHandlers();
+  test("the layered credential chips and the test result line live in the sheet, not the row", () => {
+    render(
+      <InstanceRow
+        instance={instance({
+          name: "a",
+          type: "openai",
+          hasStoredOAuth: true,
+          hasStoredFile: true,
+          activeSource: "oauth",
+        })}
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.queryByText("effective")).toBeNull();
+    expect(screen.queryByText("shadowed")).toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  test("the default badge shows when isDefault", () => {
+    render(<InstanceRow instance={instance({ name: "a", type: "x", isDefault: true })} onSelect={() => {}} />);
+    expect(screen.getByText(/default/i)).toBeTruthy();
+  });
+});
+
+describe("the meta line", () => {
+  test("apiStyle/baseUrl trailing text: apiStyle preferred, then base url", () => {
+    render(
+      <InstanceRow
+        instance={instance({
+          name: "a",
+          type: "openai",
+          apiStyle: "responses",
+          baseUrl: "https://x",
+          hasStoredFile: true,
+          activeSource: "file",
+        })}
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.getByText("responses · base https://x")).toBeTruthy();
+  });
+
+  test("base url alone when apiStyle is empty", () => {
+    render(
+      <InstanceRow
+        instance={instance({
+          name: "a",
+          type: "openai",
+          baseUrl: "https://x",
+          hasStoredFile: true,
+          activeSource: "file",
+        })}
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.getByText("base https://x")).toBeTruthy();
+  });
+
+  test("the unconfigured label wins the meta line, with style info appended when present", () => {
+    render(
+      <InstanceRow
+        instance={instance({
+          name: "llama",
+          type: "openai",
+          baseUrl: "http://127.0.0.1:8080/v1",
+          activeSource: "absent",
+          credentialRequired: false,
+        })}
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.getByText("No key set · optional · base http://127.0.0.1:8080/v1")).toBeTruthy();
+  });
+
+  test("an unconfigured instance with no style info shows just the label", () => {
+    render(<InstanceRow instance={instance({ name: "a", type: "x", activeSource: "absent" })} onSelect={() => {}} />);
+    expect(screen.getByText("Not configured")).toBeTruthy();
+  });
+});
+
+// The heading dot is the glyph half of what the meta line says in words, so
+// the two have to agree about the same instance. StatusDot's only observable
+// difference between "idle" and "ended" is its accessible name (both states
+// share the neutral token family - src/widgets/statusdot), so that name is
+// what these assert on.
+describe("the heading dot agrees with the meta line", () => {
+  test("a keyless gateway - no key, none needed - is not announced as ended", () => {
+    render(
+      <InstanceRow
+        instance={instance({
+          name: "llama",
+          type: "openai",
+          baseUrl: "http://127.0.0.1:8080/v1",
+          activeSource: "absent",
+          credentialRequired: false,
+        })}
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.getByRole("img", { name: "Idle" })).toBeTruthy();
+  });
+
+  test("an auth-none provider - one that authenticates nothing - is not announced as ended", () => {
+    render(
+      <InstanceRow
+        instance={instance({ name: "ollama", type: "ollama", activeSource: "none", credentialRequired: false })}
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.getByText("No credentials required")).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Idle" })).toBeTruthy();
+  });
+
+  test("a provider whose required key is missing keeps the ended dot", () => {
+    render(
+      <InstanceRow
+        instance={instance({ name: "a", type: "anthropic", activeSource: "absent", credentialRequired: true })}
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.getByRole("img", { name: "Ended" })).toBeTruthy();
+  });
+
+  test("a configured instance shows the idle dot", () => {
+    render(
+      <InstanceRow
+        instance={instance({ name: "a", type: "x", hasStoredFile: true, activeSource: "file" })}
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.getByRole("img", { name: "Idle" })).toBeTruthy();
+  });
+});
+
+describe("selection", () => {
+  test("clicking the row calls onSelect", async () => {
     const user = userEvent.setup();
-    render(<InstanceRow instance={instance({ name: "a", type: "x" })} {...handlers} />);
-
-    await user.click(screen.getByRole("button", { name: "Test credentials" }));
-
-    expect(handlers.onTestCredentials).toHaveBeenCalledTimes(1);
-  });
-
-  test("pending verification disables only the Test credentials action", () => {
-    const handlers = noopHandlers();
-    render(<InstanceRow instance={instance({ name: "a", type: "x" })} {...handlers} testCredentialsPending />);
-
-    expect((screen.getByRole("button", { name: "Testing credentials…" }) as HTMLButtonElement).disabled).toBe(true);
-    expect((screen.getByRole("button", { name: "Edit" }) as HTMLButtonElement).disabled).toBe(false);
-    expect((screen.getByRole("button", { name: "Remove" }) as HTMLButtonElement).disabled).toBe(false);
+    const onSelect = vi.fn();
+    render(<InstanceRow instance={instance({ name: "openai-work", type: "openai" })} onSelect={onSelect} />);
+    await user.click(screen.getByRole("button", { name: /openai-work/ }));
+    expect(onSelect).toHaveBeenCalledTimes(1);
   });
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceRow.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceRow.tsx
@@ -1,30 +1,23 @@
-// InstanceRow.tsx: one provider instance's display + row actions
-// (parity-m7-settings.md §7c) - pure presentational component, no store
-// access of its own. CredentialsSection supplies every action as a plain
-// callback and owns what happens next (opening an editor, a confirm
-// dialog, or calling the store directly).
-import type { AuthTestResponse, InstanceEntry } from "../../../../protocol/types.gen";
-import { Button, Chip, StatusDot } from "../../../../widgets";
+// InstanceRow.tsx: one provider instance's tappable list row for the
+// detail-sheet redesign - a single full-width button carrying identity and
+// status only (heading dot, name, ★ default chip, one meta line, chevron).
+// Every per-instance ACTION (test, set key, sign in, edit, clear, remove,
+// make default) and the layered credential display moved into
+// InstanceDetailSheet, so the list stays one-target-per-row on desktop and
+// touch alike. Pure presentational: the section owns selection.
+import type { InstanceEntry } from "../../../../protocol/types.gen";
+import { Chevron, Chip, StatusDot } from "../../../../widgets";
 import { requireClass } from "../../../../widgets/internal/requireClass";
-import {
-  credentialLayers,
-  keylessByDesign,
-  safeCredentialTestMessage,
-  safeCredentialTestResult,
-  unconfiguredLabel,
-} from "./credentialLabels";
+import { credentialLayers, keylessByDesign, unconfiguredLabel } from "./credentialLabels";
 import styles from "./InstanceRow.module.css";
 
 const CLASS = {
-  row: requireClass(styles.row, "InstanceRow.module.css", "row"),
+  rowButton: requireClass(styles.rowButton, "InstanceRow.module.css", "rowButton"),
+  rowMain: requireClass(styles.rowMain, "InstanceRow.module.css", "rowMain"),
   heading: requireClass(styles.heading, "InstanceRow.module.css", "heading"),
   name: requireClass(styles.name, "InstanceRow.module.css", "name"),
-  styleInfo: requireClass(styles.styleInfo, "InstanceRow.module.css", "styleInfo"),
-  layers: requireClass(styles.layers, "InstanceRow.module.css", "layers"),
-  layer: requireClass(styles.layer, "InstanceRow.module.css", "layer"),
-  unconfigured: requireClass(styles.unconfigured, "InstanceRow.module.css", "unconfigured"),
-  actions: requireClass(styles.actions, "InstanceRow.module.css", "actions"),
-  testResult: requireClass(styles.testResult, "InstanceRow.module.css", "testResult"),
+  meta: requireClass(styles.meta, "InstanceRow.module.css", "meta"),
+  chevron: requireClass(styles.chevron, "InstanceRow.module.css", "chevron"),
 };
 
 function styleInfoText(instance: InstanceEntry): string | null {
@@ -34,97 +27,38 @@ function styleInfoText(instance: InstanceEntry): string | null {
   return null;
 }
 
-export interface InstanceRowProps {
-  instance: InstanceEntry;
-  onSetApiKey: () => void;
-  onOAuthStart: () => void;
-  onEdit: () => void;
-  onClear: () => void;
-  onRemove: () => void;
-  onSetDefault: () => void;
-  onTestCredentials: () => void;
-  testCredentialsPending?: boolean;
-  testCredentialsResult?: AuthTestResponse;
-}
-
-export function InstanceRow({
-  instance,
-  onSetApiKey,
-  onOAuthStart,
-  onEdit,
-  onClear,
-  onRemove,
-  onSetDefault,
-  onTestCredentials,
-  testCredentialsPending = false,
-  testCredentialsResult,
-}: InstanceRowProps) {
-  const supportsApiKey = (instance.authModes ?? []).includes("apiKey");
-  const supportsOAuth = (instance.authModes ?? []).includes("oauth");
-  const showClear = instance.activeSource === "file" || instance.activeSource === "oauth";
-  const layers = credentialLayers(instance);
+// The one meta line: the unconfigured label is the more important signal and
+// wins; style info (a gateway's base URL is the interesting part of "No key
+// set · optional") appends after it when both exist.
+function metaText(instance: InstanceEntry): string | null {
   const unconfigured = unconfiguredLabel(instance);
   const styleInfo = styleInfoText(instance);
-  const safeTestResult = testCredentialsResult
-    ? safeCredentialTestResult(instance.name, testCredentialsResult)
-    : undefined;
+  if (unconfigured !== null && styleInfo !== null) return `${unconfigured} · ${styleInfo}`;
+  return unconfigured ?? styleInfo;
+}
 
+export interface InstanceRowProps {
+  instance: InstanceEntry;
+  onSelect: () => void;
+}
+
+export function InstanceRow({ instance, onSelect }: InstanceRowProps) {
+  const meta = metaText(instance);
   return (
-    <li className={CLASS.row}>
-      <div className={CLASS.heading}>
-        <StatusDot state={layers.length > 0 || keylessByDesign(instance) ? "idle" : "ended"} />
-        <span className={CLASS.name}>{instance.name}</span>
-        {instance.isDefault && <Chip>★ default</Chip>}
-        {styleInfo && <span className={CLASS.styleInfo}>{styleInfo}</span>}
-      </div>
-      {unconfigured ? (
-        <p className={CLASS.unconfigured}>{unconfigured}</p>
-      ) : (
-        <div className={CLASS.layers}>
-          {layers.map((layer) => (
-            <div key={layer.source} className={CLASS.layer}>
-              <span>↳ {layer.label}</span>
-              <Chip tone={layer.effective ? "alive" : "neutral"}>{layer.effective ? "effective" : "shadowed"}</Chip>
-            </div>
-          ))}
+    <li>
+      <button type="button" className={CLASS.rowButton} onClick={onSelect}>
+        <div className={CLASS.rowMain}>
+          <div className={CLASS.heading}>
+            <StatusDot state={credentialLayers(instance).length > 0 || keylessByDesign(instance) ? "idle" : "ended"} />
+            <span className={CLASS.name}>{instance.name}</span>
+            {instance.isDefault && <Chip>★ default</Chip>}
+          </div>
+          {meta !== null && <div className={CLASS.meta}>{meta}</div>}
         </div>
-      )}
-      <div className={CLASS.actions}>
-        <Button variant="quiet" size="sm" onClick={onTestCredentials} disabled={testCredentialsPending}>
-          {testCredentialsPending ? "Testing credentials…" : "Test credentials"}
-        </Button>
-        {supportsApiKey && (
-          <Button variant="quiet" size="sm" onClick={onSetApiKey}>
-            {instance.hasStoredFile ? "Replace key" : "Set key"}
-          </Button>
-        )}
-        {supportsOAuth && (
-          <Button variant="quiet" size="sm" onClick={onOAuthStart}>
-            {instance.hasStoredOAuth ? "Refresh OAuth" : "Sign in…"}
-          </Button>
-        )}
-        {showClear && (
-          <Button variant="danger" size="sm" onClick={onClear}>
-            Clear
-          </Button>
-        )}
-        <Button variant="quiet" size="sm" onClick={onEdit}>
-          Edit
-        </Button>
-        <Button variant="danger" size="sm" onClick={onRemove}>
-          Remove
-        </Button>
-        {!instance.isDefault && (
-          <Button variant="quiet" size="sm" onClick={onSetDefault}>
-            ★ make default
-          </Button>
-        )}
-      </div>
-      {safeTestResult && (
-        <p className={CLASS.testResult} role="status">
-          {safeTestResult.status}: {safeCredentialTestMessage(safeTestResult.status)}
-        </p>
-      )}
+        <span className={CLASS.chevron} aria-hidden="true">
+          <Chevron direction="right" />
+        </span>
+      </button>
     </li>
   );
 }

--- a/cmd/evener-hub/frontend/src/widgets/dialog/dialog.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/dialog/dialog.module.css
@@ -24,6 +24,7 @@
   padding: var(--space-4) var(--space-7) var(--space-3) var(--space-4);
   background: var(--surface-inset);
   border-bottom: 1px solid var(--edge);
+  min-width: 0;
 }
 
 .title {
@@ -34,6 +35,9 @@
   letter-spacing: var(--tracking-display);
   line-height: var(--line-height-title);
   color: var(--ink-hi);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .body {


### PR DESCRIPTION
## What

Redesigns **Settings → Providers & credentials** with the same row→detail-sheet collection-page idiom as the Marketplaces & Plugins redesign (#583):

- Instance rows are now single tappable targets (status dot, ★ default chip, one mono meta line, chevron) grouped by provider type. The per-row wall of seven buttons is gone.
- Every per-instance action moved into a new `InstanceDetailSheet`: a `Sheet` on the right on desktop, on the bottom on mobile. It carries the layered credential display (oauth > file > env, effective vs. shadowed), a Type/API meta table, and all seven conditional actions (Set/Replace key, Sign in…/Refresh OAuth, Clear, Edit, Remove, ★ make default, Test credentials) with their exact old conditional rules.
- Editor flows (add, set key, edit, OAuth) replace the sheet; Clear and Remove keep their `ConfirmDialog` nested over it.
- The sheet reads its instance from the store live, so cross-client changes land while it is open, and it closes itself when the instance disappears.

## Behavior preservation

Every toast string, RPC param, test-invalidation rule, and secret-sanitization behavior is preserved verbatim — the handlers are byte-identical to HEAD (verified by diff). The `danger`→`dangerQuiet` variant change on Clear is deliberate: `dangerQuiet` is the documented variant for a destructive action that is not the primary one on its surface.

## Adversarial QA

Two independent subagents tested this redesign against a real hub in Chrome at desktop and mobile. One real fix resulted (long instance names clipping in the sheet header without ellipsis — `fbb24420d`); the rest were pre-existing UX questions or tooling artifacts. No console errors at any step; keyboard a11y and focus management verified solid (focus trap, restore, Tab order, Escape nesting).

## Design docs

The design language is written up in **#584**: `design-system.md` §10 — Collection pages: segmented workspaces and detail sheets.

## Verification

- TDD throughout: red→green per component; new tests mutation-proven.
- **114/114** section tests; `make test-web` (typecheck + full frontend unit + Biome) ✓; `make test-web-browser` (all four real-Chrome guards) ✓.
- Independent code review: *approve-with-nits*; all findings fixed (weakened assertion restored, stale comment, dead CSS, sheet-dot coverage + mutation proof).
