### PR TITLE
fix(web): preserve Browse tree expansion across segment round trips

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/BrowseSection.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/BrowseSection.tsx
@@ -3,7 +3,7 @@
 // (marketplacesPlugins/index.tsx) - see MarketplacesSection's own comment
 // for why (its Refresh action needs to read this component's expansion
 // state).
-import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
+import { type Dispatch, type SetStateAction, useEffect, useRef, useState } from "react";
 import { errorText } from "../../../../protocol/errors";
 import type { MarketplaceCatalogPlugin, MarketplaceEntry } from "../../../../protocol/types.gen";
 import { extensionsStore, type MarketplaceCatalogEntry, useExtensionsStore } from "../../../../stores/extensions";
@@ -60,12 +60,16 @@ export function BrowseSection({ expandedMarketplaces, setExpandedMarketplaces }:
   // last keystroke, first lazily loads every not-yet-cached marketplace's
   // catalog (filterLoading shows "Loading marketplaces…" tree-wide meanwhile
   // - see the render below), then auto-expands every marketplace with a
-  // match and collapses the rest.
+  // match and collapses the rest. The empty-query collapse is skipped on
+  // the initial mount so lifted expansion state (from a prior Browse visit)
+  // survives the segment round trip instead of being clobbered.
+  const filterTouched = useRef(false);
   useEffect(() => {
     if (trimmedQuery === "") {
-      setExpandedMarketplaces(new Set());
+      if (filterTouched.current) setExpandedMarketplaces(new Set());
       return;
     }
+    filterTouched.current = true;
     let cancelled = false;
     const timer = setTimeout(() => {
       void (async () => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/index.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/index.test.tsx
@@ -154,3 +154,28 @@ test("switching segments while the detail sheet is open closes it", async () => 
   await user.click(screen.getByRole("radio", { name: "Browse" }));
   await waitFor(() => expect(screen.queryByRole("dialog", { name: "linter" })).toBeNull());
 });
+
+test("Browse tree expansion survives a segment round trip (Installed → Browse → Installed → Browse)", async () => {
+  const user = userEvent.setup();
+  const fake = connectSeededClient();
+  fake.on("evener/marketplace/browse", () => ({
+    name: "acme-plugins",
+    description: "Acme plugins catalog",
+    plugins: [{ name: "formatter", description: "A formatter" }],
+  }));
+  render(<MarketplacesPluginsSection />);
+  await screen.findByText("linter");
+
+  // Switch to Browse and expand the marketplace tree
+  await user.click(screen.getByRole("radio", { name: "Browse" }));
+  await user.click(await screen.findByRole("button", { name: /acme-plugins/ }));
+  await waitFor(() => expect(screen.getByText("formatter")).toBeTruthy());
+
+  // Switch to Installed and back to Browse
+  await user.click(screen.getByRole("radio", { name: /Installed/ }));
+  await screen.findByText("linter");
+  await user.click(screen.getByRole("radio", { name: "Browse" }));
+
+  // The tree should still be expanded — formatter should be visible without re-expanding
+  await waitFor(() => expect(screen.getByText("formatter")).toBeTruthy());
+});


### PR DESCRIPTION
## What

Fixes a regression in the Marketplaces & Plugins segmented workspace (#583, merged): expanding a marketplace in Browse, switching to another segment, and switching back collapsed the tree — requiring re-expansion to see the plugins again.

## Root cause

`BrowseSection`'s debounced filter effect has an empty-query branch that calls `setExpandedMarketplaces(new Set())`. On segment round trips, `BrowseSection` unmounts and remounts — its `filterQuery` state resets to `""`, the effect fires, and the empty-query collapse clobbers the lifted `expandedMarketplaces` set that was supposed to survive the round trip.

## Fix

A `filterTouched` ref skips the empty-query collapse on initial mount, so lifted expansion state survives the remount. The active-clear-collapses-everything behavior is preserved: once the user types in the filter, `filterTouched.current` is set to `true`, and subsequent clearing of the query collapses as before.

## Verification

- TDD: RED→GREEN (test reproduces the round-trip collapse, passes with the fix).
- **80/80** section tests; `make test-web` (typecheck + full frontend unit + Biome) ✓.
- Adversarial QA found this bug during a real-Chrome test of the merged redesign.
