### PR TITLE
fix(repair): explain oneOf constraint failures instead of misreporting present args as missing

### DIFF
--- a/agent/internal/tool/repair/explain.go
+++ b/agent/internal/tool/repair/explain.go
@@ -74,6 +74,16 @@ func ExplainSchemaError(toolName string, params, args map[string]any, instanceLo
 		return fmt.Sprintf("%s: argument %q has the wrong type or value.\nExample: %s", toolName, fullPath, minimalExample(params))
 	}
 
+	// A branch-combinator failure names no property: the deepest cause is the
+	// combinator (e.g. #/oneOf/0/not), so there is no field to walk and the
+	// missing-field fallback below would misreport a present, valid argument
+	// as missing (issue #618). Explain the constraint itself instead.
+	if isBranchKeyword(constraintKeyword) {
+		if msg := oneOfConstraintMessage(toolName, params, constraintKeyword); msg != "" {
+			return msg
+		}
+	}
+
 	switch {
 	case !haveField:
 		fmt.Fprintf(&b, "%s: arguments did not match the schema.", toolName)
@@ -322,6 +332,109 @@ func formatPath(segs []string) string {
 		b.WriteString(seg)
 	}
 	return b.String()
+}
+
+// isBranchKeyword reports whether a failing JSON-Schema keyword is one of the
+// combinators whose branches oneOfConstraintMessage can describe ("oneOf",
+// and the "not" that lives inside a oneOf branch — the delegate shape). A
+// keyword outside this set has no describable branch list; widening to
+// anyOf/allOf needs per-keyword branch phrasing (issues #621-625).
+func isBranchKeyword(keyword string) bool {
+	switch keyword {
+	case "oneOf", "not":
+		return true
+	}
+	return false
+}
+
+// oneOfConstraintMessage renders an honest explanation for a validation
+// failure caused by a branch-combinator constraint (today: the delegate
+// schema's oneOf sandbox/sandbox_net pairing rule) rather than by any single
+// argument's type or value. It describes each branch's requirements in terms
+// of the properties it constrains, so the model can see which argument
+// combination to change or omit. Returns "" when params carries no usable
+// branch list for the failing keyword or no branch can be described, letting
+// the caller fall back to the generic message.
+func oneOfConstraintMessage(toolName string, params map[string]any, keyword string) string {
+	branches, source := branchList(params, keyword)
+	if len(branches) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s: arguments violate a conditional rule on the combination of arguments (the schema's %s constraint), not any single argument's type or value.", toolName, source)
+	rendered := false
+	for i, br := range branches {
+		desc := branchRequirement(br)
+		if desc == "" {
+			continue
+		}
+		rendered = true
+		fmt.Fprintf(&b, "\nBranch %d requires: %s.", i, desc)
+	}
+	if !rendered {
+		return ""
+	}
+	fmt.Fprintf(&b, "\nExample: %s", minimalExample(params))
+	return b.String()
+}
+
+// branchList returns the schema's branch list for the failing combinator
+// keyword and the keyword that names it in the message. A "not" failure
+// inside a oneOf branch (the delegate shape) has no top-level "not" list —
+// the failing not's KeywordLocation path was reduced to its last segment by
+// offendingKeyword — so it falls back to the enclosing oneOf and reports
+// that as the source keyword (keyword-path walking is issues #621-625).
+func branchList(params map[string]any, keyword string) (branches []any, source string) {
+	list, _ := params[keyword].([]any)
+	if list != nil {
+		return list, keyword
+	}
+	list, _ = params["oneOf"].([]any)
+	return list, "oneOf"
+}
+
+// branchRequirement renders one branch's requirement in prose: the
+// properties it requires, and for a "not" branch, the properties it forbids
+// being present.
+func branchRequirement(branch any) string {
+	schema, _ := branch.(map[string]any)
+	if schema == nil {
+		return ""
+	}
+	if forbidden := schemaMap(schema, "not"); forbidden != nil {
+		names := requiredNames(forbidden)
+		if len(names) == 0 {
+			return ""
+		}
+		return "do not send " + joinQuoted(names)
+	}
+	req := requiredNames(schema)
+	if len(req) == 0 {
+		return ""
+	}
+	parts := []string{"send all of " + joinQuoted(req)}
+	props := schemaProps(schema)
+	for _, name := range req {
+		prop := schemaMap(props, name)
+		if allowed := asStringSlice(prop["enum"]); len(allowed) > 0 {
+			parts = append(parts, fmt.Sprintf("%q must be one of %s", name, joinQuoted(allowed)))
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func joinQuoted(names []string) string {
+	quoted := make([]string, 0, len(names))
+	for _, n := range names {
+		quoted = append(quoted, strconv.Quote(n))
+	}
+	return strings.Join(quoted, ", ")
+}
+
+// schemaMap returns the named key's value as a non-nil object schema, or nil.
+func schemaMap(schema map[string]any, key string) map[string]any {
+	m, _ := schema[key].(map[string]any)
+	return m
 }
 
 // ExplainJSONError renders coaching for arguments still unparseable after

--- a/agent/internal/tool/repair/explain_oneof_test.go
+++ b/agent/internal/tool/repair/explain_oneof_test.go
@@ -1,0 +1,63 @@
+package repair
+
+import (
+	"strings"
+	"testing"
+)
+
+// delegateOneOfParams mirrors the delegate tool schema built by
+// DefDelegateWithSandbox on a host with a sandbox backend when the parent
+// session runs sandbox mode off (RequireNonOffModeForNetwork): the oneOf
+// constraint forbids pairing sandbox "off" with sandbox_net.
+func delegateOneOfParams() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"task":        map[string]any{"type": "string"},
+			"sandbox":     map[string]any{"type": "string", "enum": []string{"off", "read-only", "workspace-write", "restricted"}},
+			"sandbox_net": map[string]any{"type": "boolean"},
+		},
+		"required": []any{"task"},
+		"oneOf": []any{
+			map[string]any{"not": map[string]any{"required": []string{"sandbox_net"}}},
+			map[string]any{
+				"required": []string{"sandbox", "sandbox_net"},
+				"properties": map[string]any{
+					"sandbox": map[string]any{"enum": []string{"read-only", "workspace-write", "restricted"}},
+				},
+			},
+		},
+	}
+}
+
+func delegateOneOfArgs() map[string]any {
+	return map[string]any{
+		"task":        "ping",
+		"sandbox":     "off",
+		"sandbox_net": true,
+	}
+}
+
+// Issue #618: a oneOf-branch failure carries no property in its instance
+// location (the deepest cause is #/oneOf/0/not), so the explained message must
+// not attribute the failure to a missing required argument. The task field is
+// present and valid.
+func TestExplainSchemaError_OneOfConstraintDoesNotReportMissingArgument(t *testing.T) {
+	msg := ExplainSchemaError("delegate", delegateOneOfParams(), delegateOneOfArgs(), "", "not")
+	if strings.Contains(msg, "arguments did not match the schema") {
+		t.Fatalf("oneOf failure explained as generic schema mismatch: %q", msg)
+	}
+	if strings.Contains(msg, "Required arguments: task") {
+		t.Fatalf("oneOf failure misattributed to missing 'task' (issue #618): %q", msg)
+	}
+	if !strings.Contains(msg, "oneOf constraint") {
+		t.Fatalf("message must name the oneOf constraint, not the leaf 'not' keyword: %q", msg)
+	}
+	if !strings.Contains(msg, `"read-only"`) {
+		t.Fatalf("message must render the branch-1 enum token: %q", msg)
+	}
+	if !strings.Contains(msg, "sandbox_net") {
+		t.Fatalf("message must name the constrained field sandbox_net: %q", msg)
+	}
+}

--- a/agent/session_tool_repair_oneof_test.go
+++ b/agent/session_tool_repair_oneof_test.go
@@ -1,0 +1,81 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"primeradiant.com/evener/agent/internal/tool"
+	"primeradiant.com/evener/agent/sandbox"
+	"primeradiant.com/evener/llm"
+)
+
+// Issue #618 regression: a delegate call that trips the oneOf
+// sandbox/sandbox_net pairing constraint (parent sandbox mode off, sandbox
+// backend available) must be rejected with an error naming that constraint —
+// not "Required arguments: task (string)", which sends the model resending a
+// task it already sent. This exercises the real prevalidation seam
+// (prepareToolCall → Schema.Validate → repair → ExplainSchemaError) with the
+// exact argument shape observed in session 034FsgXdyimiBvbubPlB4w.
+func TestPrepareToolCall_DelegateOneOfConstraintExplainedHonestly(t *testing.T) {
+	def := tool.DefDelegateWithSandbox([]string{"subagent"}, tool.DelegateSandboxSchema{
+		Available:                   true,
+		Modes:                       []string{"off", "read-only", "workspace-write", "restricted"},
+		RequireNonOffModeForNetwork: true,
+	})
+	reg := tool.NewRegistry()
+	if err := reg.Register(regTool(def)); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	rt := reg.Get("delegate")
+
+	call := llm.ToolCallData{
+		ID:   "issue618",
+		Name: "delegate",
+		Arguments: json.RawMessage(`{"task":"ping","agent_type":"subagent","isolation":"worktree",` +
+			`"sandbox":"off","sandbox_net":true,"reasoning_effort":"low","delegation_allowance":0}`),
+	}
+	res := prepareToolCall(call, rt, []string{"delegate"}, "delegate", "")
+	if res.PrevalErr == "" {
+		t.Fatalf("expected prevalidation failure for oneOf-violating delegate args, got none (changes: %v)", res.Changes)
+	}
+	if strings.Contains(res.PrevalErr, "Required arguments: task") {
+		t.Fatalf("oneOf failure misattributed to missing 'task' (issue #618): %q", res.PrevalErr)
+	}
+	if !strings.Contains(res.PrevalErr, "sandbox") {
+		t.Fatalf("error does not name the constrained fields: %q", res.PrevalErr)
+	}
+}
+
+// The same call through execTool must surface the honest error to the model.
+// Host facts are injected (backend-capable, parent mode off) so the delegate
+// schema carries the oneOf constraint on every host — without this the test
+// passes vacuously on backend-less hosts where the schema drops the sandbox
+// fields and the runtime's "controls unavailable" error satisfies the
+// assertions without exercising the oneOf path.
+func TestExecTool_DelegateOneOfConstraintErrorNamed(t *testing.T) {
+	s := sbxDelegateSession(t, sandbox.HostFacts{OS: "linux", Home: t.TempDir(), BwrapPath: "/usr/bin/bwrap", BwrapCapable: true})
+	if err := registerStableDelegateTool(s.reg, s); err != nil {
+		t.Fatalf("register delegate tool: %v", err)
+	}
+	res := s.execTool(context.Background(), llm.ToolCallData{
+		ID:        "issue618-exec",
+		Name:      "delegate",
+		Arguments: json.RawMessage(`{"task":"ping","sandbox":"off","sandbox_net":true}`),
+	}, "")
+	if !res.IsError {
+		t.Fatalf("expected error for oneOf-violating delegate args, got: %s", res.FullOutput)
+	}
+	if strings.Contains(res.FullOutput, "Required arguments: task") {
+		t.Fatalf("model-visible error misattributes failure to missing 'task' (issue #618): %s", res.FullOutput)
+	}
+	// A vacuous pass on a backend-less host produces the controls-unavailable
+	// refusal instead of a oneOf explanation; fail loudly on that shape.
+	if strings.Contains(res.FullOutput, "sandbox controls unavailable") {
+		t.Fatalf("test passed vacuously: delegate schema lacks the oneOf constraint on this host: %s", res.FullOutput)
+	}
+	if !strings.Contains(res.FullOutput, "sandbox") {
+		t.Fatalf("error does not name the constrained fields: %s", res.FullOutput)
+	}
+}


### PR DESCRIPTION
## Summary

`delegate` calls that violate the sandbox/sandbox_net `oneOf` pairing rule (e.g. `sandbox: "off"` + `sandbox_net: true` under a parent sandbox mode `off`) failed schema validation **correctly**, but the error surfaced to the model was a confidently wrong diagnosis:

```
delegate: arguments did not match the schema.
Required arguments: task (string).
Example: {"task": "..."}
```

`task` was present and valid the whole time. The natural recovery (resending `task`) fails identically, which produced a five-attempt hard retry loop in a live session.

Root cause: after raw validation fails, `offendingField` walks the deepest **first** cause of the jsonschema error tree. For a oneOf failure that cause is the combinator itself (`#/oneOf/0/not`, no property in its instance location), so `repair.ExplainSchemaError` received no field and fell through to its missing-field fallback — which reports the first entry of the schema's `required` list.

## The fix

`ExplainSchemaError` now explains branch-combinator failures honestly before the missing-field fallback. When the failing keyword is a describable branch combinator (`oneOf`, or the `not` that lives inside a oneOf branch — the delegate shape), it renders each branch's requirements and labels the constraint by the keyword that actually yielded the branch list:

```
delegate: arguments violate a conditional rule on the combination of arguments (the schema's oneOf constraint), not any single argument's type or value.
Branch 0 requires: do not send "sandbox_net".
Branch 1 requires: send all of "sandbox", "sandbox_net", "sandbox" must be one of "read-only", "workspace-write", "restricted".
Example: {"task": "..."}
```

Returns `""` (falling back to the generic message) when no branch can be described, so it never degrades below the previous behavior.

## Verification

- **TDD:** three tests written red-first, all failing on `main` with the exact issue-618 message; revert-verified (a `go test -overlay` run against pre-fix `explain.go` fails all three).
- **Seam coverage:** unit test at the repair layer + `prepareToolCall` test with the real `DefDelegateWithSandbox(RequireNonOffModeForNetwork)` schema + `execTool` test with injected sandbox host facts (backend-capable, so the schema carries the oneOf on every host — without injection the exec test passes vacuously on backend-less hosts like CI's ubuntu runners).
- **Adversarial review:** three independent reviewers (correctness, edge cases/regressions, test quality). Zero blockers; every warranted finding applied — including the vacuous-pass must-fix above.
- **Simplify pass:** four reviewers (reuse, simplification, efficiency, altitude); findings applied (guard reduced to `isBranchKeyword(constraintKeyword)`, unused `args` param dropped, dead `params["not"].([]any)` lookup removed — JSON Schema `not` is always an object — header labels `oneOf` rather than the leaf `not` keyword, `isBranchKeyword` narrowed to the describable set `{oneOf, not}`, header-only messages return `""` honoring the fall-back contract, existing helpers `requiredNames`/`schemaProps` reused).
- **Gates:** `go test ./agent` (110s), `go test ./agent/internal/tool/...`, `go vet ./agent/...`, `gofmt`, `golangci-lint` on the touched package — all clean.

## Out of scope (filed separately)

- #621 oneOf attribution is arm-order fragile (positive-arm-first schemas get a wrong allowed-values message)
- #622 constraintMessage reads top-level enum for branch-level (oneOf arm) enums
- #623 multiple-match oneOf failures render satisfied requirements with no recovery hint
- #624 oneOf nested inside a property schema gets no constraint explanation
- #625 integer enums silently dropped by `asStringSlice`

Fixes #618
