### PR TITLE
agent: differential lifecycle harness + finish-path intent reducer

### DIFF
--- a/agent/delegate_lifecycle_differential_test.go
+++ b/agent/delegate_lifecycle_differential_test.go
@@ -1,0 +1,1034 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spf13/afero"
+
+	"primeradiant.com/evener/agent/internal/delegatestore"
+)
+
+// errDelegateLifecycleCanceled is the harness's stand-in for context.Canceled in the
+// model's run-end taxonomy (the model file avoids importing context twice).
+var errDelegateLifecycleCanceled = context.Canceled
+
+// This file is the deterministic differential runner (spec: Project 1). It
+// translates a byte sequence into an operation sequence, applies each
+// operation to a real delegateTreeController, and asserts cross-layer
+// agreement with the independent model (delegate_lifecycle_model_test.go)
+// plus invariants I1–I5 after every operation. Determinism: no wall-clock,
+// no sleeps, no network; the controller harness uses a fixed clock; the
+// runtime layer uses a scripted fake adapter and a FakeClock on the root.
+//
+// Operations are numbered per the spec's vocabulary. Op 13 (append failure)
+// and op 14 (crash) are Task 2 and intentionally absent here.
+//
+// Single-delegate scope (spec: model state): the runner drives exactly one
+// delegate's generation lifecycle, including steering and settlement-claim
+// interactions, but not nested-delegate races.
+
+// lifecycleOp identifies one decoded operation.
+type lifecycleOp struct {
+	code int // 1-12 per the spec vocabulary
+	arg  int // sub-selection decoded from the same byte
+}
+
+// decodeDelegateLifecycleProgram maps fuzz bytes onto the operation sequence. Each
+// byte selects one operation (code 1-12, byte%12+1) and carries a sub-arg
+// (byte/12) used by parameterized ops (run-end error class, finish flavor).
+func decodeDelegateLifecycleProgram(program []byte) []lifecycleOp {
+	ops := make([]lifecycleOp, 0, len(program))
+	for _, b := range program {
+		ops = append(ops, lifecycleOp{code: int(b%12) + 1, arg: int(b / 12)})
+	}
+	return ops
+}
+
+// delegateLifecycleRunEndErrorClass is op 8's selectable terminal error.
+type delegateLifecycleRunEndErrorClass int
+
+const (
+	delegateLifecycleErrNil delegateLifecycleRunEndErrorClass = iota
+	delegateLifecycleErrGeneric
+	delegateLifecycleErrBudget
+	delegateLifecycleErrCanceled
+	delegateLifecycleErrJoinedBudgetCanceled
+)
+
+// lifecycleRunEndError returns the injected error for a class.
+func delegateLifecycleRunEndError(class delegateLifecycleRunEndErrorClass) error {
+	switch class {
+	case delegateLifecycleErrGeneric:
+		return errors.New("lifecycle: generic terminal failure")
+	case delegateLifecycleErrBudget:
+		return &budgetExhaustionError{Budget: exhaustedBudgetTurns, Limit: 23, Resumable: false}
+	case delegateLifecycleErrCanceled:
+		return context.Canceled
+	case delegateLifecycleErrJoinedBudgetCanceled:
+		return errors.Join(&budgetExhaustionError{Budget: exhaustedBudgetToolRounds, Limit: 17, Resumable: true}, context.Canceled)
+	default:
+		return nil
+	}
+}
+
+// delegateLifecycleHarness is one differential run: a real controller, the model, and
+// the observation plumbing. The controller harness matches
+// FuzzDelegateControllerTransitions's shape: a real openDelegateTreeController
+// over a delegatestore journal with a fixed clock and no goroutines.
+type delegateLifecycleHarness struct {
+	t          *testing.T
+	c          *delegateTreeController
+	model      delegateLifecycleModel
+	delegateID string
+	// runtime is the bound runtime session for steering paths.
+	runtime *Session
+	// stopDone is the current stop's done channel once a stop is requested.
+	stopDone <-chan struct{}
+	// lastFinishedDeliveryID tracks I4's delivery uniqueness window.
+	lastFinishedDeliveryID string
+}
+
+// newDelegateLifecycleHarness seeds one delegate with the given binding kind and
+// returns the harness with the model initialized from the same seed.
+//
+// Binding kinds (spec seed dimension):
+//   - production start: evidence attached via the attention-evidence
+//     CommitStart path (startDelegateAttentionEvidenceGeneration precedent),
+//     requirement attention-only.
+//   - legacy/manual binding: nil evidence (seedDelegateControllerRunning
+//     precedent — the tolerance path in escalateCompletionRequirementLocked).
+func newDelegateLifecycleHarness(t *testing.T, legacyBinding bool) *delegateLifecycleHarness {
+	t.Helper()
+	c, _ := newDelegateControllerTestHarness(t, 3, 2)
+	h := &delegateLifecycleHarness{t: t, c: c, delegateID: "dlg_target"}
+	// The root transcript is the durable receiver identity for top-level
+	// deliveries (deliveryTranscriptIdentity uses stateDir/rootSessionID);
+	// an empty one is enough for the delivery receiver to arm.
+	writeEmptyAttentionTranscript(t, transcriptPath(c.stateDir, "root-session"), "root-session")
+	if legacyBinding {
+		seedDelegateControllerRunning(t, c, h.delegateID, "")
+		attachDelegateSteerRuntime(t, c, h.delegateID, afero.NewMemMapFs())
+		h.runtime = c.live[h.delegateID].runtime
+		h.model = newDelegateLifecycleModel(false, false)
+		// A legacy nil-evidence binding is running with no completion
+		// requirement tracked (escalation is a no-op there).
+		return h
+	}
+	seedDelegateControllerIdle(t, c, h.delegateID, "")
+	lease := startDelegateAttentionEvidenceGeneration(t, c, h.delegateID)
+	attachDelegateSteerRuntime(t, c, h.delegateID, afero.NewMemMapFs())
+	h.runtime = c.live[h.delegateID].runtime
+	h.model = newDelegateLifecycleModel(true, false)
+	_ = lease
+	return h
+}
+
+// observe reads the real controller state into a delegateLifecycleObservation.
+func (h *delegateLifecycleHarness) observe() delegateLifecycleObservation {
+	h.t.Helper()
+	h.c.mu.Lock()
+	defer h.c.mu.Unlock()
+	obs := delegateLifecycleObservation{}
+	aggregate := h.c.durable[h.delegateID]
+	if aggregate != nil {
+		obs.phase = aggregate.Phase
+		obs.runOpen = aggregate.CurrentRunOpen
+		obs.stopPending = aggregate.PendingStopSeq != 0
+		obs.generation = aggregate.Generation
+		if aggregate.LatestOutcome != nil {
+			obs.lastOutcome = aggregate.LatestOutcome.Status
+		}
+		obs.exhausted = aggregate.LatestOutcome != nil && aggregate.LatestOutcome.Status == delegatestore.OutcomeExhausted
+	}
+	if live := h.c.live[h.delegateID]; live != nil && live.binding != nil {
+		obs.evidencePresent = live.binding.evidence != nil
+		if live.binding.evidence != nil {
+			obs.reportRequired = live.binding.evidence.requirement == delegateCompletionReportRequired
+			obs.terminalSeen = live.binding.evidence.terminalSeen
+			obs.attentionNoAction = live.binding.evidence.outcome == delegateCompletionOutcomeAttentionNoAction
+		}
+	}
+	// I4: count acknowledged deliveries for the current generation.
+	events, err := h.c.store.Load()
+	if err != nil {
+		h.t.Fatalf("lifecycle observe: load journal: %v", err)
+	}
+	acknowledged := map[string]bool{}
+	finishedDeliveries := map[string]bool{}
+	for _, event := range events {
+		if event.DelegateID != h.delegateID {
+			continue
+		}
+		if event.DeliveryAcknowledged != nil {
+			acknowledged[event.DeliveryAcknowledged.DeliveryID] = true
+		}
+		if event.RunFinished != nil && event.RunFinished.DeliveryID != "" {
+			finishedDeliveries[event.RunFinished.DeliveryID] = true
+		}
+	}
+	delivered := 0
+	for id := range finishedDeliveries {
+		if acknowledged[id] {
+			delivered++
+		}
+	}
+	obs.deliveries = delivered
+	obs.lastDisposition = delegateLifecycleLastDisposition(events, h.delegateID)
+	return obs
+}
+
+// delegateLifecycleDispositionsAt returns the disposition for the most
+// recent run-finished event of the delegate (observed directly from the
+// journal), so the model's disposition agreement is read from the durable
+// record rather than derived.
+func delegateLifecycleLastDisposition(events []delegatestore.Event, delegateID string) delegatestore.RunDisposition {
+	for i := len(events) - 1; i >= 0; i-- {
+		event := events[i]
+		if event.DelegateID == delegateID && event.RunFinished != nil {
+			return event.RunFinished.Disposition
+		}
+	}
+	return ""
+}
+
+// check runs the per-op agreement check and invariants I1–I5.
+func (h *delegateLifecycleHarness) check(opName string) {
+	h.t.Helper()
+	obs := h.observe()
+	if err := h.model.agreeWithModel(opName, obs); err != nil {
+		h.t.Fatal(err)
+	}
+	h.assertInvariants(obs)
+}
+
+// assertInvariants checks I1–I5 over the observation.
+func (h *delegateLifecycleHarness) assertInvariants(obs delegateLifecycleObservation) {
+	h.t.Helper()
+	h.c.mu.Lock()
+	defer h.c.mu.Unlock()
+
+	// I1 — single authority: at most one open generation; CurrentRunOpen and
+	// live-binding presence agree (outside the crash window, which Task 2
+	// introduces — there is no crash here, so the agreement must always hold).
+	aggregate := h.c.durable[h.delegateID]
+	if aggregate == nil {
+		h.t.Fatal("lifecycle I1: delegate aggregate disappeared")
+	}
+	live := h.c.live[h.delegateID]
+	hasBinding := live != nil && live.binding != nil
+	if aggregate.CurrentRunOpen && aggregate.Phase != delegatestore.PhaseRunning && aggregate.Phase != delegatestore.PhaseSettling && aggregate.Phase != delegatestore.PhaseStopping {
+		h.t.Fatalf("lifecycle I1: run open in phase %s", aggregate.Phase)
+	}
+	if aggregate.CurrentRunOpen != hasBinding {
+		h.t.Fatalf("lifecycle I1: CurrentRunOpen=%t but binding present=%t", aggregate.CurrentRunOpen, hasBinding)
+	}
+	if hasBinding && live.binding.lease.generation != aggregate.Generation {
+		h.t.Fatalf("lifecycle I1: binding generation %d != aggregate generation %d", live.binding.lease.generation, aggregate.Generation)
+	}
+
+	// I2 — legal transitions: the durable phase sequence is a path in the
+	// model's table. Replay the journal's phase sequence.
+	events, err := h.c.store.Load()
+	if err != nil {
+		h.t.Fatalf("lifecycle I2: load journal: %v", err)
+	}
+	previous := delegatestore.Phase("")
+	seen := false
+	for _, event := range events {
+		if event.DelegateID != h.delegateID {
+			continue
+		}
+		next, ok := delegateLifecyclePhaseAfterEvent(event, previous)
+		if !ok {
+			continue // event does not move this delegate's phase
+		}
+		if !seen {
+			// The first phase-moving event creates the delegate; there is no
+			// prior phase to transition from.
+			previous = next
+			seen = true
+			continue
+		}
+		if !legalDelegateLifecyclePhaseTransition(previous, next) {
+			h.t.Fatalf("lifecycle I2: illegal phase transition %s -> %s (event %s)", previous, next, event.Kind)
+		}
+		previous = next
+	}
+
+	// I3 — stop precedence (event-scoped): a RunFinished journaled after a
+	// covering stop request has outcome neither completed nor
+	// completed_no_action. (A finish before the stop keeps its outcome.)
+	var stopSeq uint64
+	for _, event := range events {
+		if event.DelegateID != h.delegateID {
+			continue
+		}
+		if event.SubtreeStopRequested != nil {
+			stopSeq = event.Seq
+			continue
+		}
+		if event.SubtreeStopCompleted != nil {
+			stopSeq = 0
+			continue
+		}
+		if event.RunFinished != nil && stopSeq != 0 {
+			status := event.RunFinished.Outcome.Status
+			disposition := event.RunFinished.Disposition
+			if status == delegatestore.OutcomeCompleted || disposition == delegatestore.DispositionCompletedNoAction {
+				h.t.Fatalf("lifecycle I3: run finished after covering stop %d with outcome %s / disposition %s", stopSeq, status, disposition)
+			}
+		}
+	}
+
+	// I4 — delivery uniqueness: at most one parent delivery executed and
+	// acknowledged per generation, and none for completed_no_action.
+	acknowledged := map[string]bool{}
+	for _, event := range events {
+		if event.DelegateID == h.delegateID && event.DeliveryAcknowledged != nil {
+			acknowledged[event.DeliveryAcknowledged.DeliveryID] = true
+		}
+	}
+	perGeneration := map[uint64]int{}
+	for _, event := range events {
+		if event.DelegateID != h.delegateID || event.RunFinished == nil {
+			continue
+		}
+		finished := event.RunFinished
+		if finished.Disposition == delegatestore.DispositionCompletedNoAction {
+			if finished.DeliveryID != "" {
+				h.t.Fatal("lifecycle I4: completed_no_action finish carries a delivery id")
+			}
+			if acknowledged[finished.DeliveryID] {
+				h.t.Fatal("lifecycle I4: completed_no_action finish acknowledged a delivery")
+			}
+			continue
+		}
+		if finished.DeliveryID == "" {
+			continue
+		}
+		if !acknowledged[finished.DeliveryID] {
+			continue // pending, not acknowledged
+		}
+		perGeneration[finished.Generation]++
+		if perGeneration[finished.Generation] > 1 {
+			h.t.Fatalf("lifecycle I4: generation %d acknowledged %d deliveries", finished.Generation, perGeneration[finished.Generation])
+		}
+	}
+
+	// I5 — report requirement: if any report-requiring work was admitted
+	// with evidence present, the final outcome is not completed_no_action.
+	// With nil evidence, escalation is a no-op and legacy rules apply.
+	if h.model.evidencePresent && h.model.reportRequired {
+		for _, event := range events {
+			if event.DelegateID != h.delegateID || event.RunFinished == nil {
+				continue
+			}
+			if event.RunFinished.Disposition == delegatestore.DispositionCompletedNoAction {
+				h.t.Fatal("lifecycle I5: report-requiring generation with evidence finished completed_no_action")
+			}
+		}
+	}
+}
+
+// delegateLifecyclePhaseAfterEvent returns the delegate's phase after one journal
+// event, mirroring the fold's per-event phase effects.
+func delegateLifecyclePhaseAfterEvent(event delegatestore.Event, previous delegatestore.Phase) (delegatestore.Phase, bool) {
+	switch event.Kind {
+	case delegatestore.EventDelegateCreated:
+		if event.Created != nil && !event.Created.Descriptor.Resumable {
+			return delegatestore.PhaseClosed, true
+		}
+		return delegatestore.PhaseIdle, true
+	case delegatestore.EventDelegateRunStarted:
+		return delegatestore.PhaseRunning, true
+	case delegatestore.EventDelegateTerminalPrepared:
+		return delegatestore.PhaseSettling, true
+	case delegatestore.EventDelegateRunFinished:
+		// The fold keeps the aggregate's resumability; the harness's delegate
+		// is always resumable, so finishing returns to idle.
+		return delegatestore.PhaseIdle, true
+	case delegatestore.EventDelegateResumabilityClosed:
+		if previous == delegatestore.PhaseIdle {
+			return delegatestore.PhaseClosed, true
+		}
+		return previous, true
+	case delegatestore.EventDelegateSubtreeStopRequested:
+		if previous == delegatestore.PhaseClosed {
+			return previous, true
+		}
+		return delegatestore.PhaseStopping, true
+	case delegatestore.EventDelegateSubtreeStopCompleted:
+		return delegatestore.PhaseIdle, true
+	default:
+		return previous, false
+	}
+}
+
+// applyLifecycleOp applies one operation to the real controller and mirrors
+// it in the model. Operations that are not applicable in the current state are
+// no-ops in both layers (the controller rejects them; the model ignores them),
+// which keeps a single byte program covering the whole state space.
+func (h *delegateLifecycleHarness) applyLifecycleOp(op lifecycleOp) string {
+	h.t.Helper()
+	switch op.code {
+	case 1: // start a generation (trigger: user work / shell attention)
+		return h.opStartGeneration(op)
+	case 2: // admit report-requiring work
+		return h.opAdmitReportWork(op)
+	case 3: // admit system-only work (attention, notification)
+		return "admit-system-only"
+	case 4: // bare attention response
+		return h.opBareAttention()
+	case 5: // terminal communicate
+		return h.opTerminalCommunicate()
+	case 6: // supervision-boundary decision
+		return h.opSupervisionBoundary(op)
+	case 7: // bounded nudge continuation
+		return h.opNudgeContinuation(op)
+	case 8: // run-end error injection
+		return h.opRunEndError(op)
+	case 9: // stop request
+		return h.opStopRequest()
+	case 10: // ordinary finish
+		return h.opOrdinaryFinish(op)
+	case 11: // no-action finish (claim path)
+		return h.opNoActionFinish()
+	case 12: // delivery execution + acknowledgment
+		return h.opDelivery()
+	default:
+		return "unknown"
+	}
+}
+
+// opStartGeneration starts a new generation when the delegate is idle
+// (trigger attention keeps the evidence path reachable on restarts).
+func (h *delegateLifecycleHarness) opStartGeneration(_ lifecycleOp) string {
+	h.c.mu.Lock()
+	aggregate := h.c.durable[h.delegateID]
+	phase := delegatestore.PhaseIdle
+	if aggregate != nil {
+		phase = aggregate.Phase
+	}
+	h.c.mu.Unlock()
+	if phase != delegatestore.PhaseIdle {
+		return "start-suppressed"
+	}
+	lease := startDelegateAttentionEvidenceGeneration(h.t, h.c, h.delegateID)
+	attachDelegateSteerRuntime(h.t, h.c, h.delegateID, afero.NewMemMapFs())
+	h.runtime = h.c.live[h.delegateID].runtime
+	// A fresh generation resets the model (the previous run finished back to
+	// idle before this start).
+	h.model = newDelegateLifecycleModel(true, false)
+	h.model.generation = lease.generation
+	return "start-generation"
+}
+
+// opAdmitReportWork admits report-requiring work via a steering bind (the
+// evidence-path escalation trigger). On the legacy nil-evidence binding the
+// production escalation is a no-op (the tolerance path).
+func (h *delegateLifecycleHarness) opAdmitReportWork(_ lifecycleOp) string {
+	if !h.currentRunOpen() {
+		return "report-work-suppressed"
+	}
+	if _, err := h.c.Steer(h.t.Context(), rootDelegateActor("root-session"), h.delegateID, "lifecycle report work"); err != nil {
+		return "report-work-rejected"
+	}
+	// Bind the steer through a model request so the escalation path runs
+	// (CompleteModelRequest consumes admitted steering and escalates).
+	if _, err := completeDelegateModelRequest(h.c, h.currentLease()); err != nil {
+		return "report-work-unbound"
+	}
+	h.model.admitReportRequiringWork()
+	return "admit-report-work"
+}
+
+// opBareAttention records the attention no-action outcome when eligible
+// (op 4).
+func (h *delegateLifecycleHarness) opBareAttention() string {
+	if !h.currentRunOpen() {
+		return "bare-attention-suppressed"
+	}
+	lease := h.currentLease()
+	recorded, err := h.c.recordAttentionNoAction(lease)
+	if err != nil {
+		return "bare-attention-rejected"
+	}
+	if !recorded {
+		return "bare-attention-ineligible"
+	}
+	h.model.recordAttentionNoAction()
+	return "bare-attention-no-action"
+}
+
+// opTerminalCommunicate latches terminalSeen (op 5).
+func (h *delegateLifecycleHarness) opTerminalCommunicate() string {
+	if !h.currentRunOpen() {
+		return "terminal-communicate-suppressed"
+	}
+	if err := h.c.recordTerminalSeen(h.currentLease()); err != nil {
+		return "terminal-communicate-rejected"
+	}
+	h.model.recordTerminalSeen()
+	return "terminal-communicate"
+}
+
+// opSupervisionBoundary drives the supervision-boundary decision (op 6):
+// pending steers → continue; suppression arbitration.
+func (h *delegateLifecycleHarness) opSupervisionBoundary(_ lifecycleOp) string {
+	if !h.currentRunOpen() {
+		return "supervision-suppressed"
+	}
+	boundary, err := h.c.SupervisionBoundary(h.currentLease(), delegateSettlementOrdinary)
+	if err != nil {
+		return "supervision-busy"
+	}
+	switch boundary {
+	case delegateSupervisionContinue:
+		return "supervision-continue"
+	case delegateSupervisionSuppress:
+		return "supervision-suppress"
+	default:
+		return "supervision-proceed"
+	}
+}
+
+// opNudgeContinuation drives the needs-nudge decision → nudge → outcome
+// chain (op 7) at the controller level: the completion decision selects
+// nudge, and a subsequent report work admission resolves it.
+func (h *delegateLifecycleHarness) opNudgeContinuation(_ lifecycleOp) string {
+	if !h.currentRunOpen() {
+		return "nudge-suppressed"
+	}
+	decision, err := h.c.completionDecision(h.currentLease())
+	if err != nil {
+		return "nudge-decision-error"
+	}
+	switch decision {
+	case delegateCompletionNeedsNudge:
+		// The bounded nudge fires when no report has landed yet. The model
+		// records the requirement only when the run's entry kind actually
+		// required a report; the attention trigger starts attention-only, so
+		// a needs-nudge decision alone does not escalate the requirement —
+		// the nudge's outcome (a report or bare response) decides.
+		return "nudge-needs-report"
+	case delegateCompletionFinishNoAction:
+		return "nudge-no-action"
+	default:
+		return "nudge-existing-terminal"
+	}
+}
+
+// opRunEndError injects a selected terminal run error through the real
+// subagent run path (op 8): BeginRunFinalization with the error bound, then
+// the finish. This is what makes the exhaustion-overwrite class reachable.
+func (h *delegateLifecycleHarness) opRunEndError(op lifecycleOp) string {
+	if !h.currentRunOpen() {
+		return "run-end-suppressed"
+	}
+	class := delegateLifecycleRunEndErrorClass(op.arg % 5)
+	cancelRequested := (op.arg/5)%2 == 1
+	err := delegateLifecycleRunEndError(class)
+	lease := h.currentLease()
+
+	// Mirror (*subagent).run's finalization. The settlement mode is predicted
+	// by the model's own copy (settlementModeForRun) — production must agree
+	// with it, which is itself one of the differential checks.
+	mode := h.model.settlementModeForRun(err, cancelRequested)
+	claim, continued, beginErr := h.c.BeginRunFinalization(lease, mode, err)
+	if beginErr != nil {
+		return "run-end-begin-rejected"
+	}
+	if continued {
+		return "run-end-continued"
+	}
+	<-claim.ready
+	if _, err := h.c.AttentionResolutionsForFinalization(claim); err != nil {
+		return "run-end-attention-error"
+	}
+	// The model predicts the finish outcome with its own independent copy of
+	// the finish-path outcome selection (finishOutcomeFromRun) and the
+	// run-end classification (classifyRunEnd); the finish handed to
+	// production is built by the production finish-from-run builder from the
+	// sampled error. The two copies must agree — including under the joined
+	// budget+Canceled error, where the exhaustion-overwrite bug split them.
+	modelStatus, exhaustionFromRunError := h.model.classifyRunEnd(err, cancelRequested)
+	modelFinishStatus := h.model.finishOutcomeFromRun(err, false)
+	// The two model copies intentionally differ on one input: the joined
+	// budget+Canceled error under cancelRequested. classifyRunEnd (the run
+	// loop's a.err/status projection) pins Cancelled there — the joined error
+	// is kept verbatim and no exhaustion payload exists — while
+	// finishOutcomeFromRun (the packet/outcome projection) still selects
+	// exhausted because stableDelegateFinishFromRun tests the budget
+	// component before the canceled test. That split is the exhaustion-
+	// overwrite boundary, so the harness pins each copy against its own
+	// production counterpart below rather than against each other.
+	finish := stableDelegateFinishFromRun(delegateTerminalRunInputs{
+		runErr:  err,
+		endedAt: h.c.now(),
+	})
+	productionClass := classifyRunEnd(err, cancelRequested)
+	if finish.outcome != modelFinishStatus {
+		h.t.Fatalf("lifecycle differential: run end: production finish outcome=%s, model finish=%s (exhaustion-overwrite divergence)", finish.outcome, modelFinishStatus)
+	}
+	if delegatestore.OutcomeStatus(productionClass.status) != modelStatus {
+		h.t.Fatalf("lifecycle differential: run end: production classifyRunEnd status=%s, model=%s (run-end classification divergence)", productionClass.status, modelStatus)
+	}
+	if (productionClass.exhaustion != nil) != exhaustionFromRunError {
+		h.t.Fatalf("lifecycle differential: run end: production exhaustion payload=%t, model=%t (exhaustion-overwrite payload divergence)", productionClass.exhaustion != nil, exhaustionFromRunError)
+	}
+	if claim.mode == delegateSettlementTerminal {
+		if _, finishErr := h.c.FinishGeneration(lease, finish); finishErr != nil {
+			return "run-end-finish-error"
+		}
+		h.applyRunEndModelFinish(finish.outcome, finish.disposition, exhaustionFromRunError, nonResumableExhaustion(finish))
+		h.reconcileModelStopAfterFinish()
+		return "run-end-terminal"
+	}
+	// Ordinary settlement: prepare the packet through the claim, then finish.
+	if _, settleErr := h.c.CompleteSettlement(claim, finish.packet); settleErr != nil {
+		return "run-end-settle-error"
+	}
+	if _, finishErr := h.c.FinishGeneration(lease, finish); finishErr != nil {
+		return "run-end-finish-error"
+	}
+	h.applyRunEndModelFinish(finish.outcome, finish.disposition, exhaustionFromRunError, nonResumableExhaustion(finish))
+	h.reconcileModelStopAfterFinish()
+	return "run-end-ordinary"
+}
+
+// nonResumableExhaustion reports whether the finish is a non-resumable
+// exhaustion (which appends a resumability closure and ends in PhaseClosed).
+func nonResumableExhaustion(finish delegateFinish) bool {
+	return finish.outcome == delegatestore.OutcomeExhausted && finish.exhaustionResumable != nil && !*finish.exhaustionResumable
+}
+
+// applyRunEndModelFinish records a run-end finish in the model, including the
+// exhaustion-payload source decision (the exhaustion-overwrite guard).
+func (h *delegateLifecycleHarness) applyRunEndModelFinish(status delegatestore.OutcomeStatus, disposition delegatestore.RunDisposition, exhaustionFromRunError bool, nonResumableExhaustion bool) {
+	if exhaustionFromRunError && status == delegatestore.OutcomeExhausted {
+		h.model.setExhaustionFromRunError()
+	}
+	h.c.mu.Lock()
+	stopSeq := uint64(0)
+	if aggregate := h.c.durable[h.delegateID]; aggregate != nil {
+		stopSeq = aggregate.PendingStopSeq
+	}
+	h.c.mu.Unlock()
+	h.model.finish(status, disposition, stopSeq)
+	if nonResumableExhaustion {
+		// Non-resumable exhaustion closes the delegate (the finish appends a
+		// resumability closure alongside the run-finished event).
+		h.model.phase = delegatestore.PhaseClosed
+	}
+}
+
+// reconcileModelStopAfterFinish aligns the model with the durable state
+// after a run-end finish that landed under a pending stop: the fold records
+// the finish and the stop keeps the phase in stopping with outcome stopped
+// until SubtreeStopCompleted.
+func (h *delegateLifecycleHarness) reconcileModelStopAfterFinish() {
+	h.c.mu.Lock()
+	aggregate := h.c.durable[h.delegateID]
+	h.c.mu.Unlock()
+	if aggregate == nil || aggregate.PendingStopSeq == 0 {
+		return
+	}
+	h.model.stopPending = true
+	h.model.phase = delegatestore.PhaseStopping
+	h.model.lastOutcome = delegatestore.OutcomeStopped
+	h.model.lastDisposition = delegatestore.DispositionTerminalError
+}
+
+// opStopRequest requests a subtree stop before finalization (op 9). The stop
+// is drained synchronously through Reconcile — never StopSubtreeAndDrive.
+func (h *delegateLifecycleHarness) opStopRequest() string {
+	h.c.mu.Lock()
+	aggregate := h.c.durable[h.delegateID]
+	h.c.mu.Unlock()
+	if aggregate == nil {
+		return "stop-suppressed"
+	}
+	result, cancelPlan, plans, err := h.c.StopSubtree(rootDelegateActor("root-session"), h.delegateID)
+	if err != nil {
+		return "stop-rejected"
+	}
+	executeDelegateCancelPlan(cancelPlan)
+	if err := h.executeLifecyclePlans(plans); err != nil {
+		h.t.Fatalf("lifecycle stop: execute plans: %v", err)
+	}
+	h.model.requestStop()
+	h.stopDone = result.done
+	// Drain the stop synchronously via the real reconcile path.
+	for {
+		h.c.mu.Lock()
+		pending := h.c.stop
+		h.c.mu.Unlock()
+		if pending == nil {
+			break
+		}
+		evidence, err := collectDelegateReconcileEvidence(h.c.stateDir, h.c.ReconcileRequirements())
+		if err != nil {
+			h.t.Fatalf("lifecycle stop: collect evidence: %v", err)
+		}
+		reconcilePlans, err := h.c.Reconcile(evidence)
+		if err != nil {
+			h.t.Fatalf("lifecycle stop: reconcile: %v", err)
+		}
+		if err := h.executeLifecyclePlans(reconcilePlans); err != nil {
+			h.t.Fatalf("lifecycle stop: execute reconcile plans: %v", err)
+		}
+		h.c.mu.Lock()
+		stillPending := h.c.stop
+		h.c.mu.Unlock()
+		if stillPending == pending {
+			// The stop is waiting on the open generation's finish (or an
+			// in-flight runner this harness never launches). The pending stop
+			// legitimately persists; the model keeps stopPending until the
+			// stop completes.
+			h.model.requestStop()
+			return "stop-requested-pending"
+		}
+	}
+	h.model.completeStop()
+	return "stop-requested"
+}
+
+// opOrdinaryFinish performs an ordinary FinishGeneration (op 10).
+func (h *delegateLifecycleHarness) opOrdinaryFinish(op lifecycleOp) string {
+	if !h.currentRunOpen() {
+		return "finish-suppressed"
+	}
+	lease := h.currentLease()
+	finish := delegateFinish{outcome: delegatestore.OutcomeCompleted, reason: "lifecycle ordinary finish", endedAt: h.c.now()}
+	switch op.arg % 3 {
+	case 0:
+		packet := delegateControllerReportedPacket("lifecycle report")
+		finish.packet = &packet
+		finish.disposition = delegatestore.DispositionReported
+	case 1:
+		packet := delegateTerminalErrorPacket("lifecycle terminal error")
+		finish.packet = &packet
+		finish.outcome = delegatestore.OutcomeFailed
+		finish.disposition = delegatestore.DispositionTerminalError
+	default:
+		packet := delegateTerminalErrorPacket("lifecycle missing terminal")
+		finish.packet = &packet
+		finish.outcome = delegatestore.OutcomeFailed
+		finish.disposition = delegatestore.DispositionTerminalError
+	}
+	if _, err := h.c.FinishGeneration(lease, finish); err != nil {
+		return "finish-rejected"
+	}
+	h.c.mu.Lock()
+	stopSeq := uint64(0)
+	phase := delegatestore.PhaseIdle
+	if aggregate := h.c.durable[h.delegateID]; aggregate != nil {
+		stopSeq = aggregate.PendingStopSeq
+		phase = aggregate.Phase
+	}
+	h.c.mu.Unlock()
+	h.model.finish(finish.outcome, finish.disposition, stopSeq)
+	if phase == delegatestore.PhaseStopping {
+		// The finish landed under a covering stop that has not completed yet:
+		// the fold forces the outcome to stopped (outcome_stopped /
+		// stopped_by_parent) and keeps the phase in stopping until
+		// SubtreeStopCompleted.
+		h.model.stopPending = true
+		h.model.phase = delegatestore.PhaseStopping
+		h.model.lastOutcome = delegatestore.OutcomeStopped
+		h.model.lastDisposition = delegatestore.DispositionTerminalError
+	}
+	return "ordinary-finish"
+}
+
+// opNoActionFinish performs the no-action finish through the claim path
+// (op 11): BeginRunFinalization with a nil run error, prepareNoAction, then
+// FinishNoAction. This is the #580 no-action selection path.
+func (h *delegateLifecycleHarness) opNoActionFinish() string {
+	if !h.currentRunOpen() {
+		return "no-action-suppressed"
+	}
+	lease := h.currentLease()
+	claim, continued, err := h.c.BeginRunFinalization(lease, delegateSettlementOrdinary, nil)
+	if err != nil {
+		return "no-action-begin-rejected"
+	}
+	if continued {
+		return "no-action-continued"
+	}
+	<-claim.ready
+	if _, err := h.c.AttentionResolutionsForFinalization(claim); err != nil {
+		return "no-action-attention-error"
+	}
+	fallback := delegateFinish{outcome: delegatestore.OutcomeCompleted, disposition: delegatestore.DispositionReported, reason: "lifecycle fallback", endedAt: h.c.now()}
+	prepared, prepareErr := h.c.prepareNoAction(claim, fallback)
+	if prepareErr != nil {
+		return "no-action-prepare-error"
+	}
+	if !prepared {
+		// Production refused the no-action finish the model says is
+		// eligible: that refusal is the #580 no-action-selection defect
+		// class (the durable store knew completed_no_action; the runtime
+		// path could not select it).
+		if h.model.noActionEligible(true) {
+			h.t.Fatal("lifecycle differential: no-action: production refused an eligible no-action finish (#580 selection class)")
+		}
+		return "no-action-ineligible"
+	}
+	if !h.model.noActionEligible(true) {
+		h.t.Fatal("lifecycle differential: no-action: production prepared but model ineligible")
+	}
+	if _, finishErr := h.c.FinishNoAction(claim); finishErr != nil {
+		// Production prepared the eligible no-action finish but could not
+		// execute it: the durable store selected completed_no_action while
+		// the finish path refused — the #580 no-action-selection defect class.
+		h.t.Fatalf("lifecycle differential: no-action: FinishNoAction failed on an eligible prepared claim (#580 selection class): %v", finishErr)
+	}
+	h.c.mu.Lock()
+	stopSeq := uint64(0)
+	if aggregate := h.c.durable[h.delegateID]; aggregate != nil {
+		stopSeq = aggregate.PendingStopSeq
+	}
+	h.c.mu.Unlock()
+	h.model.finish(delegatestore.OutcomeCompleted, delegatestore.DispositionCompletedNoAction, stopSeq)
+	return "no-action-finish"
+}
+
+// opDelivery executes and acknowledges a pending parent delivery (op 12):
+// BeginDelivery then CompleteDelivery, both synchronous. This is I4's
+// parent-visible half.
+func (h *delegateLifecycleHarness) opDelivery() string {
+	h.c.mu.Lock()
+	deliveries := 0
+	if aggregate := h.c.durable[h.delegateID]; aggregate != nil {
+		deliveries = len(aggregate.PendingDeliveries)
+	}
+	h.c.mu.Unlock()
+	if deliveries == 0 {
+		return "delivery-none-pending"
+	}
+	plans := h.c.ReplayDeliveries()
+	if len(plans) == 0 {
+		return "delivery-none-replayable"
+	}
+	plan := plans[0]
+	receiver := newFakeDelegateDeliveryReceiver()
+	next, err := deliverDelegatePacket(plan, receiver)
+	if err != nil {
+		return "delivery-rejected"
+	}
+	_ = next
+	h.model.delivered++
+	return "delivery-acknowledged"
+}
+
+// currentRunOpen reports whether the delegate's current run is open.
+func (h *delegateLifecycleHarness) currentRunOpen() bool {
+	h.c.mu.Lock()
+	defer h.c.mu.Unlock()
+	aggregate := h.c.durable[h.delegateID]
+	return aggregate != nil && aggregate.CurrentRunOpen
+}
+
+// currentLease returns the current generation's lease from the live binding.
+func (h *delegateLifecycleHarness) currentLease() delegateLease {
+	h.c.mu.Lock()
+	defer h.c.mu.Unlock()
+	live := h.c.live[h.delegateID]
+	if live == nil || live.binding == nil {
+		h.t.Fatal("lifecycle: no live binding for current lease")
+	}
+	return live.binding.lease
+}
+
+// executeLifecyclePlans executes mutation plans on a bound root-free session.
+func (h *delegateLifecycleHarness) executeLifecyclePlans(plans delegateMutationPlans) error {
+	for _, update := range plans.updates {
+		_ = update
+	}
+	for _, attention := range plans.attention {
+		if err := h.c.executeDelegateAttentionCleanup(attention); err != nil {
+			return err
+		}
+	}
+	for _, plan := range plans.deliveries {
+		if _, _, err := h.c.BeginDelivery(plan); err != nil {
+			continue // not currently deliverable; leave pending
+		}
+	}
+	return nil
+}
+
+// runLifecycleProgram applies the whole decoded program, checking agreement
+// and invariants after every operation. It returns the operation trace for
+// determinism comparison.
+func runDelegateLifecycleProgram(t *testing.T, program []byte, legacyBinding bool) []string {
+	t.Helper()
+	h := newDelegateLifecycleHarness(t, legacyBinding)
+	trace := []string{}
+	for _, op := range decodeDelegateLifecycleProgram(program) {
+		name := h.applyLifecycleOp(op)
+		trace = append(trace, name)
+		h.check(name)
+	}
+	return trace
+}
+
+// runLifecycleProgramChecked runs with per-op panic recovery so a mid-program
+// failure still reports the trace up to the failing operation.
+func runDelegateLifecycleProgramChecked(t *testing.T, program []byte, legacyBinding bool) (trace []string) {
+	h := newDelegateLifecycleHarness(t, legacyBinding)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("lifecycle panic after ops %v: %v", trace, r)
+		}
+	}()
+	for _, op := range decodeDelegateLifecycleProgram(program) {
+		name := h.applyLifecycleOp(op)
+		trace = append(trace, name)
+		h.check(name)
+	}
+	return trace
+}
+
+// lifecycleSeed is one checked-in corpus seed: a byte program, a binding
+// kind, and the defect class it targets.
+type lifecycleSeed struct {
+	name          string
+	program       []byte
+	legacyBinding bool
+	targets       string
+}
+
+// delegateLifecycleSeedCorpus is the plan's eight seed sequences plus the drivers
+var delegateLifecycleSeedCorpus = []lifecycleSeed{
+	{
+		// bare-attention-then-queued-work: after a bare attention no-action
+		// (op 4), report-requiring work (op 2) must escalate the requirement
+		// so the generation cannot finish no-action (I5, #580 class).
+		name:          "bare-attention-then-queued-work",
+		program:       []byte{op1(4), op1(2), op1(11), op1(10)},
+		legacyBinding: false,
+		targets:       "no-action selection after report work (I5)",
+	},
+	{
+		// stop-before-finish: a stop request (op 9) before the finish means
+		// the RunFinished is journaled after the covering stop, so the
+		// outcome must be neither completed nor completed_no_action (I3).
+		name:          "stop-before-finish",
+		program:       []byte{op1(9), op1(10)},
+		legacyBinding: false,
+		targets:       "stop precedence (I3)",
+	},
+	{
+		// attention-no-action finish: bare attention (op 4) then the claim
+		// path no-action finish (op 11) must select completed_no_action with
+		// no delivery (I4) — the #580 no-action selection class.
+		name:          "attention-no-action-finish",
+		program:       []byte{op1(4), op1(11)},
+		legacyBinding: false,
+		targets:       "no-action selection (#580, I4)",
+	},
+	{
+		// terminal-communicate finish: a terminal communicate (op 5) makes
+		// the completion decision use the existing terminal, and the
+		// ordinary finish (op 10) settles reported (I2, I4).
+		name:          "terminal-communicate-finish",
+		program:       []byte{op1(5), op1(6), op1(10)},
+		legacyBinding: false,
+		targets:       "terminal-seen finish path (I2, I4)",
+	},
+	{
+		// nudge-then-report: the needs-nudge decision (op 7) escalates the
+		// requirement, so the subsequent no-action attempt is ineligible and
+		// the ordinary finish reports (I5).
+		name:          "nudge-then-report",
+		program:       []byte{op1(7), op1(11), op1(10)},
+		legacyBinding: false,
+		targets:       "nudge escalation (I5)",
+	},
+	{
+		// nil-evidence steering: on the legacy nil-evidence binding, steering
+		// (op 2) is admitted but escalation is a no-op — the run still
+		// finishes by the legacy outcome rules (the nil-evidence tolerance
+		// class).
+		name:          "nil-evidence-steering",
+		program:       []byte{op1(2), op1(4), op1(10)},
+		legacyBinding: true,
+		targets:       "nil-evidence escalation tolerance",
+	},
+	{
+		// joined cancel+budget exhaustion: op 8 with the joined error under a
+		// racing cancel publishes cancelled (never exhausted, never an
+		// exhaustion payload) and keeps the joined error verbatim — the
+		// exhaustion-overwrite class.
+		name: "joined-cancel-budget-exhaustion",
+		// arg 9: class 4 (joined budget+canceled) with the cancel bit set.
+		program:       []byte{opArg(8, 9)},
+		legacyBinding: false,
+		targets:       "exhaustion overwrite (joined cancel+budget)",
+	},
+	{
+		// delivery execute+ack: after a reported finish (op 10), the pending
+		// delivery is executed and acknowledged exactly once (op 12) (I4).
+		name:          "delivery-execute-ack",
+		program:       []byte{op1(5), op1(10), op1(12)},
+		legacyBinding: false,
+		targets:       "delivery uniqueness (I4)",
+	},
+}
+
+// op1 encodes one byte selecting operation code with arg 0.
+func op1(code int) byte {
+	return byte(code - 1)
+}
+
+// opArg encodes one byte selecting operation code with the given arg.
+func opArg(code, arg int) byte {
+	return byte((code - 1) + 12*arg)
+}
+
+// TestDelegateLifecycleDifferentialSeeds drives every checked-in seed through
+// the real controller and asserts model agreement plus I1–I5 after every
+// operation.
+func TestDelegateLifecycleDifferentialSeeds(t *testing.T) {
+	for _, seed := range delegateLifecycleSeedCorpus {
+		t.Run(seed.name, func(t *testing.T) {
+			runDelegateLifecycleProgramChecked(t, seed.program, seed.legacyBinding)
+		})
+	}
+}
+
+// TestDelegateLifecycleDifferentialDeterminism proves byte-for-byte
+// determinism: the same program run twice produces the identical operation
+// trace (spec: determinism requirements — a failing seed reproduces from the
+// input alone).
+func TestDelegateLifecycleDifferentialDeterminism(t *testing.T) {
+	for _, seed := range delegateLifecycleSeedCorpus {
+		t.Run(seed.name, func(t *testing.T) {
+			first := runDelegateLifecycleProgram(t, seed.program, seed.legacyBinding)
+			second := runDelegateLifecycleProgram(t, seed.program, seed.legacyBinding)
+			if len(first) != len(second) {
+				t.Fatalf("trace lengths differ: %d vs %d", len(first), len(second))
+			}
+			for i := range first {
+				if first[i] != second[i] {
+					t.Fatalf("trace diverges at op %d: %q vs %q", i, first[i], second[i])
+				}
+			}
+		})
+	}
+}
+
+// TestDelegateLifecycleDifferentialCrossBinding runs every seed under both
+// binding kinds, pinning that the seed dimension reaches both the evidence
+// path and the legacy nil-evidence tolerance path.
+func TestDelegateLifecycleDifferentialCrossBinding(t *testing.T) {
+	for _, seed := range delegateLifecycleSeedCorpus {
+		t.Run(seed.name, func(t *testing.T) {
+			runDelegateLifecycleProgramChecked(t, seed.program, !seed.legacyBinding)
+		})
+	}
+}

--- a/agent/delegate_lifecycle_differential_test.go
+++ b/agent/delegate_lifecycle_differential_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -92,8 +93,6 @@ type delegateLifecycleHarness struct {
 	runtime *Session
 	// stopDone is the current stop's done channel once a stop is requested.
 	stopDone <-chan struct{}
-	// lastFinishedDeliveryID tracks I4's delivery uniqueness window.
-	lastFinishedDeliveryID string
 }
 
 // newDelegateLifecycleHarness seeds one delegate with the given binding kind and
@@ -202,8 +201,7 @@ func (h *delegateLifecycleHarness) observe() delegateLifecycleObservation {
 // journal), so the model's disposition agreement is read from the durable
 // record rather than derived.
 func delegateLifecycleLastDisposition(events []delegatestore.Event, delegateID string) delegatestore.RunDisposition {
-	for i := len(events) - 1; i >= 0; i-- {
-		event := events[i]
+	for _, event := range slices.Backward(events) {
 		if event.DelegateID == delegateID && event.RunFinished != nil {
 			return event.RunFinished.Disposition
 		}

--- a/agent/delegate_lifecycle_differential_test.go
+++ b/agent/delegate_lifecycle_differential_test.go
@@ -370,8 +370,11 @@ func delegateLifecyclePhaseAfterEvent(event delegatestore.Event, previous delega
 	case delegatestore.EventDelegateTerminalPrepared:
 		return delegatestore.PhaseSettling, true
 	case delegatestore.EventDelegateRunFinished:
-		// The fold keeps the aggregate's resumability; the harness's delegate
-		// is always resumable, so finishing returns to idle.
+		// The fold keeps the aggregate's resumability: a resumable delegate
+		// returns to idle, a non-resumable one to closed (op 8's
+		// non-resumable budget class closes resumability alongside the finish).
+		// The event carries no resumability, so the caller's replay tracks it:
+		// a ResumabilityClosed event in the same batch tells closed from idle.
 		return delegatestore.PhaseIdle, true
 	case delegatestore.EventDelegateResumabilityClosed:
 		if previous == delegatestore.PhaseIdle {
@@ -391,6 +394,12 @@ func delegateLifecyclePhaseAfterEvent(event delegatestore.Event, previous delega
 			// The covered member's run already finished back to idle before
 			// the stop completed; the completion confirms idle (a no-op on
 			// the phase — the fold re-assigns the same value).
+			return previous, false
+		}
+		if previous == delegatestore.PhaseClosed {
+			// The fold's applySubtreeStopCompleted keeps non-resumable members
+			// closed (resumable members return to idle): the completion
+			// confirms closed, a no-op on the phase.
 			return previous, false
 		}
 		return delegatestore.PhaseIdle, true
@@ -669,9 +678,11 @@ func (h *delegateLifecycleHarness) opRunEndError(op lifecycleOp) string {
 		h.t.Fatalf("lifecycle differential: run end: production exhaustion payload=%t, model=%t (exhaustion-overwrite payload divergence)", productionClass.exhaustion != nil, exhaustionFromRunError)
 	}
 	if claim.mode == delegateSettlementTerminal {
-		if _, finishErr := h.c.FinishGeneration(lease, finish); finishErr != nil {
+		finishPlans, finishErr := h.c.FinishGeneration(lease, finish)
+		if finishErr != nil {
 			return "run-end-finish-error"
 		}
+		h.executeRunEndPlans(finishPlans)
 		h.applyRunEndModelFinish(finish.outcome, finish.disposition, exhaustionFromRunError, nonResumableExhaustion(finish))
 		h.reconcileModelStopAfterFinish()
 		return "run-end-terminal"
@@ -680,12 +691,27 @@ func (h *delegateLifecycleHarness) opRunEndError(op lifecycleOp) string {
 	if _, settleErr := h.c.CompleteSettlement(claim, finish.packet); settleErr != nil {
 		return "run-end-settle-error"
 	}
-	if _, finishErr := h.c.FinishGeneration(lease, finish); finishErr != nil {
+	finishPlans, finishErr := h.c.FinishGeneration(lease, finish)
+	if finishErr != nil {
 		return "run-end-finish-error"
 	}
+	h.executeRunEndPlans(finishPlans)
 	h.applyRunEndModelFinish(finish.outcome, finish.disposition, exhaustionFromRunError, nonResumableExhaustion(finish))
 	h.reconcileModelStopAfterFinish()
 	return "run-end-ordinary"
+}
+
+// executeRunEndPlans executes op 8's finish plans through the root runtime
+// (M1: the plans are the parent-visible half of the run's terminal result;
+// discarding them orphaned the delivery claim so op-8 deliveries only ever
+// acknowledged through a later stop drain) and mirrors the acknowledged
+// count in the model.
+func (h *delegateLifecycleHarness) executeRunEndPlans(finishPlans delegateMutationPlans) {
+	acknowledged, execErr := h.executeLifecyclePlans(finishPlans)
+	if execErr != nil {
+		h.t.Fatalf("lifecycle run end: execute plans: %v", execErr)
+	}
+	h.model.delivered += acknowledged
 }
 
 // nonResumableExhaustion reports whether the finish is a non-resumable
@@ -755,36 +781,26 @@ func (h *delegateLifecycleHarness) opStopRequest() string {
 	}
 	h.model.requestStop()
 	h.stopDone = result.done
-	// Drain the stop synchronously via the real reconcile path.
-	for {
-		h.c.mu.Lock()
-		pending := h.c.stop
-		h.c.mu.Unlock()
-		if pending == nil {
-			break
-		}
-		evidence, err := collectDelegateReconcileEvidence(h.c.stateDir, h.c.ReconcileRequirements())
-		if err != nil {
-			h.t.Fatalf("lifecycle stop: collect evidence: %v", err)
-		}
-		reconcilePlans, err := h.c.Reconcile(evidence)
-		if err != nil {
-			h.t.Fatalf("lifecycle stop: reconcile: %v", err)
-		}
-		if _, err := h.executeLifecyclePlans(reconcilePlans); err != nil {
-			h.t.Fatalf("lifecycle stop: execute reconcile plans: %v", err)
-		}
-		h.c.mu.Lock()
-		stillPending := h.c.stop
-		h.c.mu.Unlock()
-		if stillPending == pending {
-			// The stop is waiting on the open generation's finish (or an
-			// in-flight runner this harness never launches). The pending stop
-			// legitimately persists; the model keeps stopPending until the
-			// stop completes.
-			h.model.requestStop()
-			return "stop-requested-pending"
-		}
+	// Drain the stop synchronously via the real reconcile path. The drain
+	// accumulates acknowledged deliveries (a drain pass may pump a pending
+	// delivery through the root receiver), so the model's delivered count
+	// must absorb them — R1: the previous inline loop discarded the count
+	// and desynced the model.
+	acknowledged, drainErr := h.drainPendingStop()
+	if drainErr != nil {
+		h.t.Fatalf("lifecycle stop: drain: %v", drainErr)
+	}
+	h.model.delivered += acknowledged
+	h.c.mu.Lock()
+	stopDone := h.c.stop == nil
+	h.c.mu.Unlock()
+	if !stopDone {
+		// The stop is waiting on the open generation's finish (or an
+		// in-flight runner this harness never launches). The pending stop
+		// legitimately persists; the model keeps stopPending until the
+		// stop completes.
+		h.model.requestStop()
+		return "stop-requested-pending"
 	}
 	h.model.completeStop()
 	return "stop-requested"

--- a/agent/delegate_lifecycle_differential_test.go
+++ b/agent/delegate_lifecycle_differential_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/afero"
 
 	"primeradiant.com/evener/agent/internal/delegatestore"
+	"primeradiant.com/evener/agent/transcript"
 )
 
 // errDelegateLifecycleCanceled is the harness's stand-in for context.Canceled in the
@@ -82,6 +83,11 @@ type delegateLifecycleHarness struct {
 	c          *delegateTreeController
 	model      delegateLifecycleModel
 	delegateID string
+	// root is the controller's root runtime: the receiver identity for
+	// top-level deliveries (deliveryReceiverLocked("") returns
+	// c.rootRuntime), with an attached root transcript so delivery
+	// acknowledgements are durable.
+	root *Session
 	// runtime is the bound runtime session for steering paths.
 	runtime *Session
 	// stopDone is the current stop's done channel once a stop is requested.
@@ -103,10 +109,21 @@ func newDelegateLifecycleHarness(t *testing.T, legacyBinding bool) *delegateLife
 	t.Helper()
 	c, _ := newDelegateControllerTestHarness(t, 3, 2)
 	h := &delegateLifecycleHarness{t: t, c: c, delegateID: "dlg_target"}
-	// The root transcript is the durable receiver identity for top-level
-	// deliveries (deliveryTranscriptIdentity uses stateDir/rootSessionID);
-	// an empty one is enough for the delivery receiver to arm.
-	writeEmptyAttentionTranscript(t, transcriptPath(c.stateDir, "root-session"), "root-session")
+	// The root runtime is the delivery receiver for top-level delegates
+	// (deliveryReceiverLocked("") → c.rootRuntime) and the root transcript
+	// is the durable receiver identity (deliveryTranscriptIdentity uses
+	// stateDir/rootSessionID). Without a root runtime, ReplayDeliveries
+	// never returns a plan and op 12 would be dead.
+	rootWriter, err := transcript.NewWriter(transcriptPath(c.stateDir, "root-session"), transcript.Header{SessionID: "root-session"})
+	if err != nil {
+		t.Fatalf("lifecycle root transcript: %v", err)
+	}
+	t.Cleanup(func() { _ = rootWriter.Close() })
+	h.root = &Session{id: "root-session", stateDir: c.stateDir, delegateController: c}
+	h.root.attachTranscript(rootWriter)
+	c.mu.Lock()
+	c.rootRuntime = h.root
+	c.mu.Unlock()
 	if legacyBinding {
 		seedDelegateControllerRunning(t, c, h.delegateID, "")
 		attachDelegateSteerRuntime(t, c, h.delegateID, afero.NewMemMapFs())
@@ -156,7 +173,6 @@ func (h *delegateLifecycleHarness) observe() delegateLifecycleObservation {
 		h.t.Fatalf("lifecycle observe: load journal: %v", err)
 	}
 	acknowledged := map[string]bool{}
-	finishedDeliveries := map[string]bool{}
 	for _, event := range events {
 		if event.DelegateID != h.delegateID {
 			continue
@@ -164,13 +180,15 @@ func (h *delegateLifecycleHarness) observe() delegateLifecycleObservation {
 		if event.DeliveryAcknowledged != nil {
 			acknowledged[event.DeliveryAcknowledged.DeliveryID] = true
 		}
-		if event.RunFinished != nil && event.RunFinished.DeliveryID != "" {
-			finishedDeliveries[event.RunFinished.DeliveryID] = true
-		}
 	}
 	delivered := 0
-	for id := range finishedDeliveries {
-		if acknowledged[id] {
+	// I4 is scoped to the model's current generation (opStartGeneration
+	// resets the model; earlier generations carry their own deliveries).
+	for _, event := range events {
+		if event.DelegateID != h.delegateID || event.RunFinished == nil {
+			continue
+		}
+		if event.RunFinished.Generation == h.model.generation && event.RunFinished.DeliveryID != "" && acknowledged[event.RunFinished.DeliveryID] {
 			delivered++
 		}
 	}
@@ -325,6 +343,12 @@ func (h *delegateLifecycleHarness) assertInvariants(obs delegateLifecycleObserva
 			if event.DelegateID != h.delegateID || event.RunFinished == nil {
 				continue
 			}
+			// Only the model's current generation is bound to its
+			// requirement state (opStartGeneration resets the model);
+			// earlier generations carry their own.
+			if event.RunFinished.Generation != h.model.generation {
+				continue
+			}
 			if event.RunFinished.Disposition == delegatestore.DispositionCompletedNoAction {
 				h.t.Fatal("lifecycle I5: report-requiring generation with evidence finished completed_no_action")
 			}
@@ -356,10 +380,19 @@ func delegateLifecyclePhaseAfterEvent(event delegatestore.Event, previous delega
 		return previous, true
 	case delegatestore.EventDelegateSubtreeStopRequested:
 		if previous == delegatestore.PhaseClosed {
-			return previous, true
+			// A stop request on a closed delegate journals legally but leaves
+			// the phase unchanged (the fold skips Closed): there is no phase
+			// transition to check.
+			return previous, false
 		}
 		return delegatestore.PhaseStopping, true
 	case delegatestore.EventDelegateSubtreeStopCompleted:
+		if previous == delegatestore.PhaseIdle {
+			// The covered member's run already finished back to idle before
+			// the stop completed; the completion confirms idle (a no-op on
+			// the phase — the fold re-assigns the same value).
+			return previous, false
+		}
 		return delegatestore.PhaseIdle, true
 	default:
 		return previous, false
@@ -440,6 +473,26 @@ func (h *delegateLifecycleHarness) opAdmitReportWork(_ lifecycleOp) string {
 	if _, err := completeDelegateModelRequest(h.c, h.currentLease()); err != nil {
 		return "report-work-unbound"
 	}
+	// B-S1 targeted assertion: production's evidence requirement must have
+	// transitioned exactly as the model predicts — report-required when
+	// evidence is present (escalateCompletionRequirementLocked), unchanged
+	// when it is nil (the legacy tolerance path). A production
+	// under-action here must fail this op, not just desync the mirror.
+	h.c.mu.Lock()
+	var requirement delegateCompletionRequirement
+	requirementSet := false
+	if live := h.c.live[h.delegateID]; live != nil && live.binding != nil && live.binding.evidence != nil {
+		requirement = live.binding.evidence.requirement
+		requirementSet = true
+	}
+	h.c.mu.Unlock()
+	if h.model.evidencePresent {
+		if !requirementSet || requirement != delegateCompletionReportRequired {
+			h.t.Fatalf("lifecycle differential: report work: evidence requirement = %v (set:%t), want report-required on the evidence path", requirement, requirementSet)
+		}
+	} else if requirementSet && requirement == delegateCompletionReportRequired {
+		h.t.Fatal("lifecycle differential: report work: legacy nil-evidence binding escalated to report-required")
+	}
 	h.model.admitReportRequiringWork()
 	return "admit-report-work"
 }
@@ -451,9 +504,21 @@ func (h *delegateLifecycleHarness) opBareAttention() string {
 		return "bare-attention-suppressed"
 	}
 	lease := h.currentLease()
+	// B-S1 targeted assertion input: predict eligibility from the model
+	// before asking production, so the returned eligibility is checked
+	// against an expectation rather than merely mirrored. The predicate is
+	// production's exact shape: evidence present (completionEvidenceLocked
+	// rejects nil evidence with a stale-lease error), requirement still
+	// attention-only, and no terminal seen. Production re-records an
+	// already-recorded outcome (it does not check the existing outcome), so
+	// a prior no-action does not make the second call ineligible.
+	wantRecorded := h.model.evidencePresent && !h.model.reportRequired && !h.model.terminalSeen
 	recorded, err := h.c.recordAttentionNoAction(lease)
 	if err != nil {
 		return "bare-attention-rejected"
+	}
+	if recorded != wantRecorded {
+		h.t.Fatalf("lifecycle differential: bare attention: recordAttentionNoAction recorded=%t, want %t (model eligibility)", recorded, wantRecorded)
 	}
 	if !recorded {
 		return "bare-attention-ineligible"
@@ -484,6 +549,12 @@ func (h *delegateLifecycleHarness) opSupervisionBoundary(_ lifecycleOp) string {
 	if err != nil {
 		return "supervision-busy"
 	}
+	// B-S2 targeted assertion: with no pending steers, the boundary must
+	// proceed (continue requires pending steers; suppress requires a
+	// closing/stopping/recovery state the model would know about).
+	if boundary == delegateSupervisionContinue && !h.modelHasPendingSteers() {
+		h.t.Fatal("lifecycle differential: supervision: continue without pending steers")
+	}
 	switch boundary {
 	case delegateSupervisionContinue:
 		return "supervision-continue"
@@ -492,6 +563,13 @@ func (h *delegateLifecycleHarness) opSupervisionBoundary(_ lifecycleOp) string {
 	default:
 		return "supervision-proceed"
 	}
+}
+
+// modelHasPendingSteers reports whether the model expects pending steers
+// (admitted via op 2 and not yet bound). The controller-level harness binds
+// steers synchronously in op 2, so the model tracks no persistent steers.
+func (h *delegateLifecycleHarness) modelHasPendingSteers() bool {
+	return false
 }
 
 // opNudgeContinuation drives the needs-nudge decision → nudge → outcome
@@ -504,6 +582,14 @@ func (h *delegateLifecycleHarness) opNudgeContinuation(_ lifecycleOp) string {
 	decision, err := h.c.completionDecision(h.currentLease())
 	if err != nil {
 		return "nudge-decision-error"
+	}
+	// B-S2 targeted assertion: the decision must match the model's
+	// prediction, so every branch (needs-nudge / finish-no-action /
+	// existing-terminal) is checked against an expectation rather than
+	// merely labeled.
+	wantDecision := h.model.completionDecisionPrediction()
+	if decision != wantDecision {
+		h.t.Fatalf("lifecycle differential: nudge: completionDecision=%v, model=%v", decision, wantDecision)
 	}
 	switch decision {
 	case delegateCompletionNeedsNudge:
@@ -533,9 +619,13 @@ func (h *delegateLifecycleHarness) opRunEndError(op lifecycleOp) string {
 	lease := h.currentLease()
 
 	// Mirror (*subagent).run's finalization. The settlement mode is predicted
-	// by the model's own copy (settlementModeForRun) — production must agree
-	// with it, which is itself one of the differential checks.
+	// by the model's own copy (settlementModeForRun) and asserted against
+	// the production projection (delegateSettlementModeForRun) — B-S3: the
+	// claim production granted must be the mode both copies predict.
 	mode := h.model.settlementModeForRun(err, cancelRequested)
+	if productionMode := delegateSettlementModeForRun(err, cancelRequested); productionMode != mode {
+		h.t.Fatalf("lifecycle differential: run end: production settlement mode=%v, model=%v (settlement-mode divergence)", productionMode, mode)
+	}
 	claim, continued, beginErr := h.c.BeginRunFinalization(lease, mode, err)
 	if beginErr != nil {
 		return "run-end-begin-rejected"
@@ -639,6 +729,11 @@ func (h *delegateLifecycleHarness) reconcileModelStopAfterFinish() {
 	h.model.phase = delegatestore.PhaseStopping
 	h.model.lastOutcome = delegatestore.OutcomeStopped
 	h.model.lastDisposition = delegatestore.DispositionTerminalError
+	// The durable RunFinished.Outcome.Status is ground truth: a stop-covered
+	// finish publishes stopped, so any exhaustion the pre-stop classification
+	// predicted (including its payload source) no longer holds.
+	h.model.exhausted = false
+	h.model.exhaustionSource = delegateLifecycleExhaustionNone
 }
 
 // opStopRequest requests a subtree stop before finalization (op 9). The stop
@@ -655,7 +750,7 @@ func (h *delegateLifecycleHarness) opStopRequest() string {
 		return "stop-rejected"
 	}
 	executeDelegateCancelPlan(cancelPlan)
-	if err := h.executeLifecyclePlans(plans); err != nil {
+	if _, err := h.executeLifecyclePlans(plans); err != nil {
 		h.t.Fatalf("lifecycle stop: execute plans: %v", err)
 	}
 	h.model.requestStop()
@@ -676,7 +771,7 @@ func (h *delegateLifecycleHarness) opStopRequest() string {
 		if err != nil {
 			h.t.Fatalf("lifecycle stop: reconcile: %v", err)
 		}
-		if err := h.executeLifecyclePlans(reconcilePlans); err != nil {
+		if _, err := h.executeLifecyclePlans(reconcilePlans); err != nil {
 			h.t.Fatalf("lifecycle stop: execute reconcile plans: %v", err)
 		}
 		h.c.mu.Lock()
@@ -718,9 +813,31 @@ func (h *delegateLifecycleHarness) opOrdinaryFinish(op lifecycleOp) string {
 		finish.outcome = delegatestore.OutcomeFailed
 		finish.disposition = delegatestore.DispositionTerminalError
 	}
-	if _, err := h.c.FinishGeneration(lease, finish); err != nil {
+	// The arg's deferred bit makes the root receiver "processing" during the
+	// finish, so the finish's delivery plans are deferred into the root's
+	// delivery queue (acceptDelegateDeliveryPlan's processing path) instead
+	// of acknowledging inline — the state op 12 pumps.
+	deferredReceiver := (op.arg/3)%2 == 1
+	if deferredReceiver {
+		h.root.mu.Lock()
+		h.root.state = SessionProcessing
+		h.root.mu.Unlock()
+	}
+	finishPlans, err := h.c.FinishGeneration(lease, finish)
+	if err != nil {
+		h.resetRootProcessing(deferredReceiver)
 		return "finish-rejected"
 	}
+	// The finish's delivery plans are the parent-visible half of the
+	// generation's terminal result; execute them through the root runtime
+	// (full BeginDelivery → durable append → CompleteDelivery path) instead
+	// of leaving a claim orphaned.
+	acknowledged, execErr := h.executeLifecyclePlans(finishPlans)
+	h.resetRootProcessing(deferredReceiver)
+	if execErr != nil {
+		h.t.Fatalf("lifecycle finish: execute plans: %v", execErr)
+	}
+	h.model.delivered += acknowledged
 	h.c.mu.Lock()
 	stopSeq := uint64(0)
 	phase := delegatestore.PhaseIdle
@@ -732,15 +849,76 @@ func (h *delegateLifecycleHarness) opOrdinaryFinish(op lifecycleOp) string {
 	h.model.finish(finish.outcome, finish.disposition, stopSeq)
 	if phase == delegatestore.PhaseStopping {
 		// The finish landed under a covering stop that has not completed yet:
-		// the fold forces the outcome to stopped (outcome_stopped /
-		// stopped_by_parent) and keeps the phase in stopping until
-		// SubtreeStopCompleted.
-		h.model.stopPending = true
-		h.model.phase = delegatestore.PhaseStopping
-		h.model.lastOutcome = delegatestore.OutcomeStopped
-		h.model.lastDisposition = delegatestore.DispositionTerminalError
+		// the fold forces the outcome to stopped and keeps the phase in
+		// stopping until SubtreeStopCompleted. The model rewrite lives in
+		// reconcileModelStopAfterFinish so both finish paths share it.
+		h.reconcileModelStopAfterFinish()
+		// The finish is what the pending stop was waiting on; drain it to
+		// completion through the real reconcile path (production's stop
+		// driver does this — StopSubtreeAndDrive — which this harness
+		// replaces with a synchronous drain).
+		acknowledgedByDrain, drainErr := h.drainPendingStop()
+		if drainErr != nil {
+			h.t.Fatalf("lifecycle finish: drain stop: %v", drainErr)
+		}
+		h.model.delivered += acknowledgedByDrain
+		// The drain completed the stop (SubtreeStopCompleted): pending stop
+		// clears and the phase returns to idle for the resumable delegate,
+		// keeping the stopped outcome.
+		h.model.completeStop()
+	}
+	if deferredReceiver {
+		return "ordinary-finish-deferred-delivery"
 	}
 	return "ordinary-finish"
+}
+
+// resetRootProcessing restores the root receiver's idle state after a
+// deferred finish, so subsequent operations see an idle receiver.
+func (h *delegateLifecycleHarness) resetRootProcessing(deferred bool) {
+	if !deferred {
+		return
+	}
+	h.root.mu.Lock()
+	h.root.state = SessionIdle
+	h.root.mu.Unlock()
+}
+
+// drainPendingStop runs the real reconcile loop until the pending stop
+// completes. It is the synchronous replacement for production's stop driver
+// (StopSubtreeAndDrive's runStopReconcileDriver goroutine): op 9 issues the
+// stop, and the finish that the stop was waiting on drains it here.
+func (h *delegateLifecycleHarness) drainPendingStop() (int, error) {
+	totalAcknowledged := 0
+	for {
+		h.c.mu.Lock()
+		pending := h.c.stop
+		h.c.mu.Unlock()
+		if pending == nil {
+			return totalAcknowledged, nil
+		}
+		evidence, err := collectDelegateReconcileEvidence(h.c.stateDir, h.c.ReconcileRequirements())
+		if err != nil {
+			return 0, err
+		}
+		reconcilePlans, err := h.c.Reconcile(evidence)
+		if err != nil {
+			return 0, err
+		}
+		acknowledged, err := h.executeLifecyclePlans(reconcilePlans)
+		if err != nil {
+			return acknowledged, err
+		}
+		totalAcknowledged += acknowledged
+		h.c.mu.Lock()
+		stillPending := h.c.stop
+		h.c.mu.Unlock()
+		if stillPending == pending {
+			// No progress: the stop is waiting on something this harness
+			// never launches. Leave it pending (the model keeps stopPending).
+			return totalAcknowledged, nil
+		}
+	}
 }
 
 // opNoActionFinish performs the no-action finish through the claim path
@@ -809,18 +987,44 @@ func (h *delegateLifecycleHarness) opDelivery() string {
 	if deliveries == 0 {
 		return "delivery-none-pending"
 	}
+	// A pending delivery deferred by a processing receiver is pumped by the
+	// root's delivery queue (flushPendingDelegateDeliveries); a fresh head
+	// delivery is re-issued by ReplayDeliveries. Try the root's deferred
+	// queue first (op 10 may have deferred the finish's delivery when the
+	// root was processing), then ReplayDeliveries.
+	before := h.acknowledgedDeliveryCount()
+	h.root.delegateDeliveryMu.Lock()
+	deferred := append([]delegateDeliveryPlan(nil), h.root.pendingDelegateDeliveries...)
+	h.root.delegateDeliveryMu.Unlock()
+	if len(deferred) != 0 {
+		// The root's flush pumps the deferred queue through the production
+		// delivery path (BeginDelivery → durable append → CompleteDelivery).
+		if err := h.root.flushPendingDelegateDeliveries(); err != nil {
+			return "delivery-rejected"
+		}
+		h.model.delivered += h.acknowledgedDeliveryCount() - before
+		if h.acknowledgedDeliveryCount() == before {
+			return "delivery-not-acknowledged"
+		}
+		return "delivery-acknowledged"
+	}
 	plans := h.c.ReplayDeliveries()
 	if len(plans) == 0 {
 		return "delivery-none-replayable"
 	}
 	plan := plans[0]
-	receiver := newFakeDelegateDeliveryReceiver()
-	next, err := deliverDelegatePacket(plan, receiver)
-	if err != nil {
+	// Drive the delivery through the harness's root runtime — the real
+	// receiver, with a real transcript — so BeginDelivery, the durable
+	// receiver-side attention append, and CompleteDelivery all execute
+	// against production code (the fake receiver would bypass the
+	// receiver-side durability I4's parent-visible half depends on).
+	if _, err := deliverDelegatePacket(plan, h.root); err != nil {
 		return "delivery-rejected"
 	}
-	_ = next
-	h.model.delivered++
+	h.model.delivered += h.acknowledgedDeliveryCount() - before
+	if h.acknowledgedDeliveryCount() == before {
+		return "delivery-not-acknowledged"
+	}
 	return "delivery-acknowledged"
 }
 
@@ -843,22 +1047,50 @@ func (h *delegateLifecycleHarness) currentLease() delegateLease {
 	return live.binding.lease
 }
 
-// executeLifecyclePlans executes mutation plans on a bound root-free session.
-func (h *delegateLifecycleHarness) executeLifecyclePlans(plans delegateMutationPlans) error {
-	for _, update := range plans.updates {
-		_ = update
-	}
+// executeLifecyclePlans executes mutation plans through the harness's root
+// runtime. Deliveries run the full production path (BeginDelivery → durable
+// receiver-side attention append → CompleteDelivery) so no claim is
+// orphaned; a BeginDelivery without its completion would fence the head
+// delivery forever. It returns how many of the delegate's deliveries were
+// acknowledged, so the model can mirror the parent-visible effect.
+func (h *delegateLifecycleHarness) executeLifecyclePlans(plans delegateMutationPlans) (int, error) {
+	before := h.acknowledgedDeliveryCount()
 	for _, attention := range plans.attention {
 		if err := h.c.executeDelegateAttentionCleanup(attention); err != nil {
-			return err
+			return 0, err
 		}
 	}
-	for _, plan := range plans.deliveries {
-		if _, _, err := h.c.BeginDelivery(plan); err != nil {
-			continue // not currently deliverable; leave pending
+	if len(plans.deliveries) != 0 {
+		if err := h.root.executeDelegateMutationPlans(plans); err != nil {
+			return 0, err
 		}
 	}
-	return nil
+	after := h.acknowledgedDeliveryCount()
+	return after - before, nil
+}
+
+// acknowledgedDeliveryCount counts the model's current generation's
+// finished deliveries that have a matching DeliveryAcknowledged event (I4's
+// durable record). Earlier generations carry their own deliveries; the
+// model resets per generation (opStartGeneration).
+func (h *delegateLifecycleHarness) acknowledgedDeliveryCount() int {
+	events, err := h.c.store.Load()
+	if err != nil {
+		h.t.Fatalf("lifecycle acknowledged count: load journal: %v", err)
+	}
+	acknowledged := map[string]bool{}
+	for _, event := range events {
+		if event.DelegateID == h.delegateID && event.DeliveryAcknowledged != nil {
+			acknowledged[event.DeliveryAcknowledged.DeliveryID] = true
+		}
+	}
+	count := 0
+	for _, event := range events {
+		if event.DelegateID == h.delegateID && event.RunFinished != nil && event.RunFinished.Generation == h.model.generation && event.RunFinished.DeliveryID != "" && acknowledged[event.RunFinished.DeliveryID] {
+			count++
+		}
+	}
+	return count
 }
 
 // runLifecycleProgram applies the whole decoded program, checking agreement
@@ -973,10 +1205,33 @@ var delegateLifecycleSeedCorpus = []lifecycleSeed{
 	{
 		// delivery execute+ack: after a reported finish (op 10), the pending
 		// delivery is executed and acknowledged exactly once (op 12) (I4).
-		name:          "delivery-execute-ack",
-		program:       []byte{op1(5), op1(10), op1(12)},
+		name: "delivery-execute-ack",
+		// Op 10 with the deferred-receiver bit (arg 3: flavor 0 + deferred)
+		// leaves the finish's delivery in the root's deferred queue; op 12
+		// then pumps it through the production delivery path
+		// (BeginDelivery → durable append → CompleteDelivery), exercising
+		// I4's parent-visible half in op 12's own right. The second op-12
+		// byte proves no second acknowledgement occurs.
+		program:       []byte{op1(5), opArg(10, 3), op1(12), op1(12)},
 		legacyBinding: false,
 		targets:       "delivery uniqueness (I4)",
+	},
+	{
+		// completion-decision branches: op 5 (terminal communicate) then op 7
+		// asserts UseExistingTerminal; a fresh generation's op 4 (bare
+		// attention) then op 7 asserts FinishNoAction; the fresh-start op 7
+		// asserts NeedsNudge. All three completionDecision branches are
+		// checked against the model's prediction (B-S2).
+		name: "completion-decision-branches",
+		program: []byte{
+			op1(5), op1(7), op1(10), // terminal-seen → UseExistingTerminal, finish
+			op1(1),                  // fresh generation
+			op1(4), op1(7), op1(10), // bare attention → FinishNoAction, finish
+			op1(1), // fresh generation
+			op1(7), // nothing admitted → NeedsNudge
+		},
+		legacyBinding: false,
+		targets:       "completion decision branches (UseExistingTerminal / FinishNoAction / NeedsNudge)",
 	},
 }
 

--- a/agent/delegate_lifecycle_model_test.go
+++ b/agent/delegate_lifecycle_model_test.go
@@ -270,12 +270,15 @@ func (m *delegateLifecycleModel) completeStop() {
 	}
 }
 
-// noActionEligible mirrors noActionEvidenceEligible plus the fallback
-// presence check in noActionFinishLocked: the packetless no-action finish is
-// reachable only with evidence present, attention-only requirement, the
-// recorded no-action outcome, no terminal seen, and a retained fallback.
+// noActionEligible mirrors the full production eligibility chain in
+// prepareNoAction: the packetless no-action finish is reachable only with
+// the aggregate still in the running phase (a pending stop request moves the
+// aggregate to stopping, which refuses the finish), evidence present,
+// attention-only requirement, the recorded no-action outcome, no terminal
+// seen, and a retained fallback.
 func (m *delegateLifecycleModel) noActionEligible(fallbackRetained bool) bool {
-	return m.evidencePresent && !m.reportRequired && m.attentionNoAction && !m.terminalSeen && fallbackRetained
+	return m.phase == delegatestore.PhaseRunning && m.evidencePresent && !m.reportRequired &&
+		m.attentionNoAction && !m.terminalSeen && fallbackRetained
 }
 
 // legalPhaseTransition reports whether from → to is a path in the model's

--- a/agent/delegate_lifecycle_model_test.go
+++ b/agent/delegate_lifecycle_model_test.go
@@ -158,7 +158,7 @@ func (m *delegateLifecycleModel) completionDecisionPrediction() delegateCompleti
 // divergence between the model and the real run path.
 func (m *delegateLifecycleModel) classifyRunEnd(err error, cancelRequested bool) (status delegatestore.OutcomeStatus, exhaustionFromRunError bool) {
 	budgetExhausted := isDelegateLifecycleBudgetExhaustion(err)
-	canceled := errors.Is(err, delegateLifecycleCanceled)
+	canceled := errors.Is(err, errDelegateLifecycleCanceled)
 	switch {
 	case cancelRequested && canceled:
 		// Cancelled keeps the joined error verbatim — never an exhaustion
@@ -179,11 +179,6 @@ func isDelegateLifecycleBudgetExhaustion(err error) bool {
 	var exhausted *budgetExhaustionError
 	return errors.As(err, &exhausted)
 }
-
-// delegateLifecycleCanceled is an indirection alias so the model file has no
-// direct context import beyond this single use; defined once in the runner
-// file.
-var delegateLifecycleCanceled = errDelegateLifecycleCanceled
 
 // finish models the terminal effects of a RunFinished event on the durable
 // aggregate (fold semantics): the run closes, the phase returns to idle
@@ -228,7 +223,7 @@ func (m *delegateLifecycleModel) finishOutcomeFromRun(err error, communicated bo
 	if isDelegateLifecycleBudgetExhaustion(err) {
 		return delegatestore.OutcomeExhausted
 	}
-	if errors.Is(err, delegateLifecycleCanceled) {
+	if errors.Is(err, errDelegateLifecycleCanceled) {
 		return delegatestore.OutcomeCancelled
 	}
 	return delegatestore.OutcomeFailed

--- a/agent/delegate_lifecycle_model_test.go
+++ b/agent/delegate_lifecycle_model_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 
 	"primeradiant.com/evener/agent/internal/delegatestore"
@@ -133,6 +134,21 @@ func (m *delegateLifecycleModel) recordAttentionNoAction() {
 // latches and clears the no-action outcome eligibility.
 func (m *delegateLifecycleModel) recordTerminalSeen() {
 	m.terminalSeen = true
+}
+
+// completionDecisionPrediction is the model's copy of completionDecision's
+// branch order (delegate_tree_steer.go): terminal-seen wins (use the
+// existing terminal); then attention-only with the recorded no-action
+// outcome selects the packetless no-action finish; otherwise the run needs
+// a nudge (a report).
+func (m *delegateLifecycleModel) completionDecisionPrediction() delegateCompletionDecision {
+	if m.terminalSeen {
+		return delegateCompletionUseExistingTerminal
+	}
+	if !m.reportRequired && m.attentionNoAction {
+		return delegateCompletionFinishNoAction
+	}
+	return delegateCompletionNeedsNudge
 }
 
 // classifyRunEnd mirrors the production classifier pins for op 8's outcome
@@ -271,7 +287,9 @@ func (m *delegateLifecycleModel) noActionEligible(fallbackRetained bool) bool {
 func legalDelegateLifecyclePhaseTransition(from, to delegatestore.Phase) bool {
 	switch from {
 	case delegatestore.PhaseIdle:
-		return to == delegatestore.PhaseRunning || to == delegatestore.PhaseClosed
+		// A stop request sets Stopping for every phase except Closed
+		// (applySubtreeStopRequested), so idle → stopping is legal too.
+		return to == delegatestore.PhaseRunning || to == delegatestore.PhaseClosed || to == delegatestore.PhaseStopping
 	case delegatestore.PhaseRunning:
 		return to == delegatestore.PhaseSettling || to == delegatestore.PhaseStopping || to == delegatestore.PhaseIdle
 	case delegatestore.PhaseSettling:
@@ -395,6 +413,28 @@ func (m *delegateLifecycleModel) agreeWithModel(opName string, obs delegateLifec
 				field:  "exhausted",
 				model:  m.exhausted,
 				actual: obs.exhausted,
+			}
+		}
+		// A-M1: whenever the terminal outcome is exhausted, the payload
+		// source must be asserted — run-error when the run error carried the
+		// budget (the a.err overwrite), prepared-terminal when the outcome
+		// was normalized from the prepared terminal packet. A tracked-but-
+		// unasserted source is exactly the exhaustion-overwrite blind spot.
+		if m.exhausted {
+			if m.exhaustionSource != delegateLifecycleExhaustionFromRunError && m.exhaustionSource != delegateLifecycleExhaustionFromPreparedTerminal {
+				return &delegateLifecycleAgreementError{
+					op:     opName,
+					field:  "exhaustionSource",
+					model:  fmt.Sprintf("exhausted with source %v", m.exhaustionSource),
+					actual: "none",
+				}
+			}
+		} else if m.exhaustionSource != delegateLifecycleExhaustionNone {
+			return &delegateLifecycleAgreementError{
+				op:     opName,
+				field:  "exhaustionSource",
+				model:  fmt.Sprintf("not exhausted but source %v", m.exhaustionSource),
+				actual: "none",
 			}
 		}
 	}

--- a/agent/delegate_lifecycle_model_test.go
+++ b/agent/delegate_lifecycle_model_test.go
@@ -1,0 +1,441 @@
+package agent
+
+import (
+	"errors"
+	"strconv"
+
+	"primeradiant.com/evener/agent/internal/delegatestore"
+)
+
+// This file is the differential harness's independent model of a single
+// delegate's generation lifecycle. It is intentionally a third, tiny, auditable
+// copy of the decision logic — that is what differential testing is (spec:
+// docs/superpowers/specs/2026-08-29-delegate-lifecycle-harness-reducer-design.md,
+// "Model state"). It never constructs packets: phases, outcomes,
+// exhaustion-payload source, and evidence presence only.
+//
+// The transition rules mirror the production pins the harness exists to guard:
+//
+//   - classifyRunEnd (agent/subagents.go): settlement mode is terminal when
+//     cancelRequested regardless of err; SubagentCancelled additionally
+//     requires errors.Is(err, context.Canceled); the exhaustion payload is
+//     non-nil exactly when status is Exhausted, and a joined
+//     exhaustion+Canceled under cancel publishes Cancelled with the joined
+//     error kept verbatim (no exhaustion payload).
+//   - escalateCompletionRequirementLocked (delegate_tree_controller.go):
+//     nil-evidence legacy bindings make escalation a no-op — with nil evidence,
+//     admitted steering does NOT make the run report-required.
+//   - The completion decision / no-action eligibility chain
+//     (completionDecision, noActionEvidenceEligible): no-action requires
+//     attention-only requirement, the recorded attention-no-action outcome,
+//     and no terminal seen; with evidence present, report-requiring work
+//     escalates the requirement and blocks no-action.
+//   - delegatestore's fold (internal/delegatestore/fold.go): the legal phase
+//     sequence and stop/finish effects on the durable aggregate.
+
+// delegateLifecycleExhaustionSource is the value-level dimension of the
+// exhaustion-overwrite bug: where a terminal outcome's exhaustion payload
+// came from.
+type delegateLifecycleExhaustionSource uint8
+
+const (
+	// delegateLifecycleExhaustionNone: the terminal outcome is not exhausted.
+	delegateLifecycleExhaustionNone delegateLifecycleExhaustionSource = iota
+	// delegateLifecycleExhaustionFromRunError: the run error itself carried the budget
+	// exhaustion (the payload exists and the run error is replaced by it).
+	delegateLifecycleExhaustionFromRunError
+	// delegateLifecycleExhaustionFromPreparedTerminal: the outcome was normalized from
+	// a previously prepared terminal packet (settlement path), not from this
+	// run error.
+	delegateLifecycleExhaustionFromPreparedTerminal
+)
+
+// delegateLifecycleModel is the model state machine for one delegate's current
+// generation. All fields are the spec's model state; the model never holds
+// pointers into controller state.
+type delegateLifecycleModel struct {
+	// phase is the durable phase sequence position.
+	phase delegatestore.Phase
+	// runOpen mirrors Aggregate.CurrentRunOpen.
+	runOpen bool
+	// stopPending mirrors Aggregate.PendingStopSeq != 0.
+	stopPending bool
+	// reportRequired is the model of the live binding evidence requirement:
+	// true when report-requiring work was admitted (evidence path) or the
+	// generation started report-required (owner-input trigger).
+	reportRequired bool
+	// terminalSeen mirrors evidence.terminalSeen.
+	terminalSeen bool
+	// attentionNoAction mirrors evidence.outcome ==
+	// delegateCompletionOutcomeAttentionNoAction.
+	attentionNoAction bool
+	// delivered counts parent deliveries executed+acknowledged for the
+	// current generation (I4).
+	delivered int
+	// evidencePresent is the binding-kind seed: production start attaches
+	// evidence, legacy/manual bindings do not.
+	evidencePresent bool
+	// generation is the current generation number.
+	generation uint64
+	// exhaustionSource records where a terminal exhaustion payload came from.
+	exhaustionSource delegateLifecycleExhaustionSource
+	// exhausted is true when the terminal outcome status is exhausted.
+	exhausted bool
+	// lastOutcome is the terminal outcome status of the most recent finished
+	// generation (empty until one finishes).
+	lastOutcome delegatestore.OutcomeStatus
+	// lastDisposition is the terminal disposition of the most recent finished
+	// generation.
+	lastDisposition delegatestore.RunDisposition
+	// stopCoveredFinish records whether the most recent RunFinished for the
+	// delegate was journaled after a covering stop request (I3).
+	stopCoveredFinish bool
+	// finishAfterStopSeq is the pending-stop sequence in effect when the most
+	// recent RunFinished was journaled (0 = no covering stop).
+	finishAfterStopSeq uint64
+}
+
+// newDelegateLifecycleModel returns the model state after the binding-kind seed: a
+// generation is open with the given evidence presence. Production starts
+// (CommitStart) attach evidence with a requirement derived from the trigger;
+// legacy/manual bindings have nil evidence.
+func newDelegateLifecycleModel(evidencePresent bool, reportRequired bool) delegateLifecycleModel {
+	return delegateLifecycleModel{
+		phase:           delegatestore.PhaseRunning,
+		runOpen:         true,
+		reportRequired:  reportRequired,
+		evidencePresent: evidencePresent,
+		generation:      1,
+	}
+}
+
+// admitReportRequiringWork models op 2 (user input, follow-up, goal
+// continuation, steering bind, hook output). On the evidence path this
+// escalates the requirement (escalateCompletionRequirementLocked); with nil
+// evidence the escalation is a no-op and the legacy outcome rules apply.
+func (m *delegateLifecycleModel) admitReportRequiringWork() {
+	if m.evidencePresent {
+		m.reportRequired = true
+	}
+}
+
+// recordAttentionNoAction models op 4 (bare attention response): it records
+// the attention no-action outcome only when the requirement is still
+// attention-only and no terminal was seen (recordAttentionNoAction).
+func (m *delegateLifecycleModel) recordAttentionNoAction() {
+	if m.reportRequired || m.terminalSeen {
+		return
+	}
+	m.attentionNoAction = true
+}
+
+// recordTerminalSeen models op 5 (terminal communicate): terminalSeen
+// latches and clears the no-action outcome eligibility.
+func (m *delegateLifecycleModel) recordTerminalSeen() {
+	m.terminalSeen = true
+}
+
+// classifyRunEnd mirrors the production classifier pins for op 8's outcome
+// rules. It is a copy of the classifyRunEnd contract restricted to the
+// harness's error vocabulary (nil / generic / budget / canceled /
+// joined budget+canceled) so the harness can catch an exhaustion-overwrite
+// divergence between the model and the real run path.
+func (m *delegateLifecycleModel) classifyRunEnd(err error, cancelRequested bool) (status delegatestore.OutcomeStatus, exhaustionFromRunError bool) {
+	budgetExhausted := isDelegateLifecycleBudgetExhaustion(err)
+	canceled := errors.Is(err, delegateLifecycleCanceled)
+	switch {
+	case cancelRequested && canceled:
+		// Cancelled keeps the joined error verbatim — never an exhaustion
+		// payload, even when the error also carries a budget component.
+		return delegatestore.OutcomeCancelled, false
+	case budgetExhausted:
+		return delegatestore.OutcomeExhausted, true
+	case err != nil:
+		return delegatestore.OutcomeFailed, false
+	default:
+		return delegatestore.OutcomeCompleted, false
+	}
+}
+
+// isDelegateLifecycleBudgetExhaustion reports whether err carries a budget
+// exhaustion component (errors.As over *budgetExhaustionError).
+func isDelegateLifecycleBudgetExhaustion(err error) bool {
+	var exhausted *budgetExhaustionError
+	return errors.As(err, &exhausted)
+}
+
+// delegateLifecycleCanceled is an indirection alias so the model file has no
+// direct context import beyond this single use; defined once in the runner
+// file.
+var delegateLifecycleCanceled = errDelegateLifecycleCanceled
+
+// finish models the terminal effects of a RunFinished event on the durable
+// aggregate (fold semantics): the run closes, the phase returns to idle
+// (resumable delegates), and the outcome is recorded. stopPendingAtFinish
+// is the pending-stop sequence in effect at journal time (I3's event order).
+func (m *delegateLifecycleModel) finish(outcome delegatestore.OutcomeStatus, disposition delegatestore.RunDisposition, stopSeqAtFinish uint64) {
+	m.runOpen = false
+	m.phase = delegatestore.PhaseIdle
+	m.lastOutcome = outcome
+	m.lastDisposition = disposition
+	m.finishAfterStopSeq = stopSeqAtFinish
+	m.stopCoveredFinish = stopSeqAtFinish != 0
+	m.exhausted = outcome == delegatestore.OutcomeExhausted
+	if m.exhausted {
+		if m.exhaustionSource == delegateLifecycleExhaustionNone {
+			m.exhaustionSource = delegateLifecycleExhaustionFromPreparedTerminal
+		}
+	} else {
+		m.exhaustionSource = delegateLifecycleExhaustionNone
+	}
+}
+
+// setExhaustionFromRunError records that the terminal exhaustion payload
+// came from the run error (the exhaustion-overwrite decision in
+// (*subagent).run's finalization: a.err = runEnd.exhaustion).
+func (m *delegateLifecycleModel) setExhaustionFromRunError() {
+	m.exhaustionSource = delegateLifecycleExhaustionFromRunError
+}
+
+// finishOutcomeFromRun is the model's independent copy of the finish-path
+// outcome selection (stableDelegateFinishFromRun's branch order): a nil run
+// error with a communicated report completes; otherwise a budget-exhaustion
+// component wins (BEFORE the canceled test, so a joined budget+Canceled error
+// finishes exhausted); otherwise context.Canceled cancels; otherwise the run
+// failed. This is the value-level copy the exhaustion-overwrite bug lived in:
+// the branch order here and the payload-presence decision in classifyRunEnd
+// must not split under a joined error.
+func (m *delegateLifecycleModel) finishOutcomeFromRun(err error, communicated bool) delegatestore.OutcomeStatus {
+	if err == nil && communicated {
+		return delegatestore.OutcomeCompleted
+	}
+	if isDelegateLifecycleBudgetExhaustion(err) {
+		return delegatestore.OutcomeExhausted
+	}
+	if errors.Is(err, delegateLifecycleCanceled) {
+		return delegatestore.OutcomeCancelled
+	}
+	return delegatestore.OutcomeFailed
+}
+
+// settlementModeForRun is the model's independent copy of
+// delegateSettlementModeForRun (classifyRunEnd's mode projection): terminal
+// iff cancelRequested, budget-exhausted, or any error outside the ordinary
+// set; budget exhaustion is tested before the ordinary sentinels.
+func (m *delegateLifecycleModel) settlementModeForRun(err error, cancelRequested bool) delegateSettlementMode {
+	if !cancelRequested {
+		ordinary := !isDelegateLifecycleBudgetExhaustion(err) && (err == nil ||
+			errors.Is(err, errBareTextWithoutResultTool) || errors.Is(err, errEmptyResponseExhausted))
+		if ordinary {
+			return delegateSettlementOrdinary
+		}
+	}
+	return delegateSettlementTerminal
+}
+
+// requestStop models op 9 (stop request before finalization): the pending
+// stop latches and the phase moves to stopping for an open run.
+func (m *delegateLifecycleModel) requestStop() {
+	if !m.runOpen {
+		return
+	}
+	m.stopPending = true
+	if m.phase != delegatestore.PhaseClosed {
+		m.phase = delegatestore.PhaseStopping
+	}
+}
+
+// completeStop models the stop completion (SubtreeStopCompleted): pending
+// stop clears and the phase returns to idle for resumable delegates.
+func (m *delegateLifecycleModel) completeStop() {
+	m.stopPending = false
+	if m.phase == delegatestore.PhaseStopping {
+		m.phase = delegatestore.PhaseIdle
+	}
+}
+
+// noActionEligible mirrors noActionEvidenceEligible plus the fallback
+// presence check in noActionFinishLocked: the packetless no-action finish is
+// reachable only with evidence present, attention-only requirement, the
+// recorded no-action outcome, no terminal seen, and a retained fallback.
+func (m *delegateLifecycleModel) noActionEligible(fallbackRetained bool) bool {
+	return m.evidencePresent && !m.reportRequired && m.attentionNoAction && !m.terminalSeen && fallbackRetained
+}
+
+// legalPhaseTransition reports whether from → to is a path in the model's
+// transition table (I2). The table mirrors delegatestore's fold: idle →
+// running (run started), running → settling (terminal prepared), running |
+// settling | stopping → idle (run finished, resumable), any open phase →
+// stopping (stop request), stopping → idle (stop completed), idle → closed
+// (resumability closed), and closed is terminal.
+func legalDelegateLifecyclePhaseTransition(from, to delegatestore.Phase) bool {
+	switch from {
+	case delegatestore.PhaseIdle:
+		return to == delegatestore.PhaseRunning || to == delegatestore.PhaseClosed
+	case delegatestore.PhaseRunning:
+		return to == delegatestore.PhaseSettling || to == delegatestore.PhaseStopping || to == delegatestore.PhaseIdle
+	case delegatestore.PhaseSettling:
+		return to == delegatestore.PhaseIdle || to == delegatestore.PhaseStopping
+	case delegatestore.PhaseStopping:
+		return to == delegatestore.PhaseIdle || to == delegatestore.PhaseClosed
+	case delegatestore.PhaseClosed:
+		return false
+	default:
+		return false
+	}
+}
+
+// delegateLifecycleObservation is one observation of the real controller/runtime
+// state, taken by the runner after each operation. The agreement checker
+// compares it against the model.
+type delegateLifecycleObservation struct {
+	phase           delegatestore.Phase
+	runOpen         bool
+	stopPending     bool
+	generation      uint64
+	lastOutcome     delegatestore.OutcomeStatus
+	lastDisposition delegatestore.RunDisposition
+	// reportRequired and terminalSeen are read from the live binding evidence
+	// when present; with nil evidence they are meaningless (legacy path).
+	evidencePresent   bool
+	reportRequired    bool
+	terminalSeen      bool
+	attentionNoAction bool
+	// exhaustionBudgetPresent is true when the terminal outcome carries
+	// exhaustion metadata (status exhausted implies payload present).
+	exhausted bool
+	// deliveries is the count of executed+acknowledged parent deliveries for
+	// the current generation (I4).
+	deliveries int
+}
+
+// agreeWithModel is the per-op agreement checker: the observation of the real
+// controller must match the model's state. opName names the operation for
+// failure messages. Legacy (nil-evidence) observations skip the
+// evidence-dependent fields because production does not track them there.
+func (m *delegateLifecycleModel) agreeWithModel(opName string, obs delegateLifecycleObservation) error {
+	if obs.phase != m.phase {
+		return &delegateLifecycleAgreementError{
+			op:     opName,
+			field:  "phase",
+			model:  string(m.phase),
+			actual: string(obs.phase),
+		}
+	}
+	if obs.runOpen != m.runOpen {
+		return &delegateLifecycleAgreementError{
+			op:     opName,
+			field:  "runOpen",
+			model:  m.runOpen,
+			actual: obs.runOpen,
+		}
+	}
+	if obs.stopPending != m.stopPending {
+		return &delegateLifecycleAgreementError{
+			op:     opName,
+			field:  "stopPending",
+			model:  m.stopPending,
+			actual: obs.stopPending,
+		}
+	}
+	if obs.generation != m.generation {
+		return &delegateLifecycleAgreementError{
+			op:     opName,
+			field:  "generation",
+			model:  m.generation,
+			actual: obs.generation,
+		}
+	}
+	if m.evidencePresent && obs.evidencePresent {
+		if obs.reportRequired != m.reportRequired {
+			return &delegateLifecycleAgreementError{
+				op:     opName,
+				field:  "reportRequired",
+				model:  m.reportRequired,
+				actual: obs.reportRequired,
+			}
+		}
+		if obs.terminalSeen != m.terminalSeen {
+			return &delegateLifecycleAgreementError{
+				op:     opName,
+				field:  "terminalSeen",
+				model:  m.terminalSeen,
+				actual: obs.terminalSeen,
+			}
+		}
+		if obs.attentionNoAction != m.attentionNoAction {
+			return &delegateLifecycleAgreementError{
+				op:     opName,
+				field:  "attentionNoAction",
+				model:  m.attentionNoAction,
+				actual: obs.attentionNoAction,
+			}
+		}
+	}
+	if !m.runOpen {
+		if obs.lastOutcome != m.lastOutcome {
+			return &delegateLifecycleAgreementError{
+				op:     opName,
+				field:  "lastOutcome",
+				model:  string(m.lastOutcome),
+				actual: string(obs.lastOutcome),
+			}
+		}
+		if obs.lastDisposition != m.lastDisposition {
+			return &delegateLifecycleAgreementError{
+				op:     opName,
+				field:  "lastDisposition",
+				model:  string(m.lastDisposition),
+				actual: string(obs.lastDisposition),
+			}
+		}
+		if obs.exhausted != m.exhausted {
+			return &delegateLifecycleAgreementError{
+				op:     opName,
+				field:  "exhausted",
+				model:  m.exhausted,
+				actual: obs.exhausted,
+			}
+		}
+	}
+	if obs.deliveries != m.delivered {
+		return &delegateLifecycleAgreementError{
+			op:     opName,
+			field:  "delivered",
+			model:  m.delivered,
+			actual: obs.deliveries,
+		}
+	}
+	return nil
+}
+
+// delegateLifecycleAgreementError is a differential failure: the model and the real
+// controller disagree after an operation.
+type delegateLifecycleAgreementError struct {
+	op     string
+	field  string
+	model  any
+	actual any
+}
+
+func (e *delegateLifecycleAgreementError) Error() string {
+	return "lifecycle differential: " + e.op + ": " + e.field + ": model=" + formatDelegateLifecycleValue(e.model) + " actual=" + formatDelegateLifecycleValue(e.actual)
+}
+
+func formatDelegateLifecycleValue(v any) string {
+	switch value := v.(type) {
+	case string:
+		return value
+	case bool:
+		if value {
+			return "true"
+		}
+		return "false"
+	case uint64:
+		return strconv.FormatUint(value, 10)
+	case int:
+		return strconv.Itoa(value)
+	default:
+		return "?"
+	}
+}

--- a/agent/delegate_tree_controller.go
+++ b/agent/delegate_tree_controller.go
@@ -570,8 +570,7 @@ func (c *delegateTreeController) completionEvidenceLocked(lease delegateLease) (
 func (c *delegateTreeController) escalateCompletionRequirement(lease delegateLease) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	decision := c.reduceFinishIntent(finishIntent{site: finishSiteWorkAdmitted, lease: lease})
-	return decision.err
+	return c.escalateCompletionRequirementLocked(lease)
 }
 
 func (c *delegateTreeController) escalateCompletionRequirementLocked(lease delegateLease) error {

--- a/agent/delegate_tree_controller.go
+++ b/agent/delegate_tree_controller.go
@@ -570,54 +570,27 @@ func (c *delegateTreeController) completionEvidenceLocked(lease delegateLease) (
 func (c *delegateTreeController) escalateCompletionRequirement(lease delegateLease) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.escalateCompletionRequirementLocked(lease)
+	decision := c.reduceFinishIntent(finishIntent{site: finishSiteWorkAdmitted, lease: lease})
+	return decision.err
 }
 
 func (c *delegateTreeController) escalateCompletionRequirementLocked(lease delegateLease) error {
-	_, live, err := c.exactLeaseLocked(lease)
-	if err != nil {
-		return err
-	}
-	evidence := live.binding.evidence
-	// Production start commits always attach evidence, but exact legacy/manual
-	// bindings may omit it and must still consume admitted steering.
-	if evidence == nil {
-		return nil
-	}
-	if evidence.requirement == delegateCompletionAttentionOnly {
-		evidence.requirement = delegateCompletionReportRequired
-		c.evidenceVersion++
-	}
-	return nil
+	decision := c.reduceFinishIntent(finishIntent{site: finishSiteWorkAdmitted, lease: lease})
+	return decision.err
 }
 
 func (c *delegateTreeController) recordAttentionNoAction(lease delegateLease) (bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	evidence, err := c.completionEvidenceLocked(lease)
-	if err != nil {
-		return false, err
-	}
-	if evidence.requirement != delegateCompletionAttentionOnly || evidence.terminalSeen {
-		return false, nil
-	}
-	evidence.outcome = delegateCompletionOutcomeAttentionNoAction
-	c.evidenceVersion++
-	return true, nil
+	decision := c.reduceFinishIntent(finishIntent{site: finishSiteAttentionNoAction, lease: lease})
+	return decision.recorded, decision.err
 }
 
 func (c *delegateTreeController) recordTerminalSeen(lease delegateLease) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	evidence, err := c.completionEvidenceLocked(lease)
-	if err != nil {
-		return err
-	}
-	if !evidence.terminalSeen {
-		evidence.terminalSeen = true
-		c.evidenceVersion++
-	}
-	return nil
+	decision := c.reduceFinishIntent(finishIntent{site: finishSiteTerminalSeen, lease: lease})
+	return decision.err
 }
 
 func (c *delegateTreeController) completionSnapshot(lease delegateLease) (delegateCompletionSnapshot, error) {

--- a/agent/delegate_tree_finish.go
+++ b/agent/delegate_tree_finish.go
@@ -3,8 +3,6 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -43,20 +41,8 @@ type delegateSettlementClaim struct {
 func (c *delegateTreeController) SupervisionBoundary(lease delegateLease, mode delegateSettlementMode) (delegateSupervisionBoundary, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	aggregate, live, err := c.exactLeaseLocked(lease)
-	if err != nil {
-		return delegateSupervisionSuppress, err
-	}
-	if c.supervisionSuppressedLocked(aggregate, live) {
-		return delegateSupervisionSuppress, nil
-	}
-	if aggregate.Phase != delegatestore.PhaseRunning || !aggregate.Resumable || live.binding == nil || !live.binding.ready {
-		return delegateSupervisionSuppress, errDelegateTargetBusy
-	}
-	if len(live.pendingSteers) != 0 && mode == delegateSettlementOrdinary {
-		return delegateSupervisionContinue, nil
-	}
-	return delegateSupervisionProceed, nil
+	decision := c.reduceFinishIntent(finishIntent{site: finishSiteSupervisionBoundary, lease: lease, mode: mode})
+	return decision.boundary, decision.err
 }
 
 // supervisionSuppressedLocked reports whether ordinary supervision must be suppressed
@@ -77,7 +63,10 @@ func (c *delegateTreeController) BeginSettlement(lease delegateLease) (*delegate
 // that was already admitted for the exact generation. Only ordinary
 // finalization arbitrates pending steering.
 func (c *delegateTreeController) BeginFinalization(lease delegateLease, mode delegateSettlementMode) (*delegateSettlementClaim, bool, error) {
-	return c.beginFinalization(lease, mode, false, nil)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	decision := c.reduceFinishIntent(finishIntent{site: finishSiteBeginFinalization, lease: lease, mode: mode})
+	return decision.claim, decision.continued, decision.err
 }
 
 // BeginRunFinalization binds the sampled run error to the exact settlement
@@ -85,141 +74,36 @@ func (c *delegateTreeController) BeginFinalization(lease delegateLease, mode del
 // generic controller callers cannot obtain that authority through a claim whose
 // run result was not supplied.
 func (c *delegateTreeController) BeginRunFinalization(lease delegateLease, mode delegateSettlementMode, runErr error) (*delegateSettlementClaim, bool, error) {
-	return c.beginFinalization(lease, mode, true, runErr)
-}
-
-func (c *delegateTreeController) beginFinalization(lease delegateLease, mode delegateSettlementMode, runErrorKnown bool, runErr error) (*delegateSettlementClaim, bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	var live *delegateLiveState
-	switch mode {
-	case delegateSettlementOrdinary:
-		_, admitted, err := c.admitLeaseLocked(lease, delegatestore.PhaseRunning)
-		if err != nil {
-			exactAggregate, exact, exactErr := c.exactLeaseLocked(lease)
-			if exactErr != nil {
-				return nil, false, exactErr
-			}
-			if c.stop == nil {
-				return nil, false, err
-			}
-			_, active := c.stop.active[lease]
-			_, covered := c.stop.members[lease.delegateID]
-			if exactAggregate.Phase != delegatestore.PhaseStopping || exactAggregate.PendingStopSeq != c.stop.requestSeq ||
-				!active || !covered || exact.recoveryRequired || exact.binding == nil || !exact.binding.ready {
-				return nil, false, err
-			}
-			admitted = exact
-			mode = delegateSettlementTerminal
-		}
-		live = admitted
-		if mode == delegateSettlementOrdinary && (len(live.pendingSteers) != 0 || c.hasSteeringClaimLocked(lease)) {
-			return nil, true, nil
-		}
-	case delegateSettlementTerminal:
-		aggregate, exact, err := c.exactLeaseLocked(lease)
-		if err != nil {
-			return nil, false, err
-		}
-		if aggregate.Phase != delegatestore.PhaseRunning && aggregate.Phase != delegatestore.PhaseStopping {
-			return nil, false, errDelegateTargetBusy
-		}
-		if exact.recoveryRequired || exact.binding == nil || !exact.binding.ready {
-			return nil, false, errDelegateTargetBusy
-		}
-		live = exact
-	default:
-		return nil, false, errDelegateTargetBusy
-	}
-	if c.hasSettlementClaimLocked(lease) {
-		return nil, false, errDelegateTargetBusy
-	}
-	c.nextToken++
-	var ready <-chan struct{}
-	if live.quietClaim != nil {
-		ready = live.quietClaim.done
-	} else {
-		closed := make(chan struct{})
-		close(closed)
-		ready = closed
-	}
-	claim := &delegateSettlementClaim{
-		token:         c.nextToken,
-		lease:         lease,
-		mode:          mode,
-		ready:         ready,
-		runErrorKnown: runErrorKnown,
-		runErr:        runErr,
-	}
-	c.settlementClaims[claim.token] = claim
-	if c.stop != nil {
-		if _, active := c.stop.active[lease]; active {
-			if _, covered := c.stop.members[lease.delegateID]; covered {
-				c.stop.settlementClaims[claim.token] = struct{}{}
-				c.signalStopProgressLocked()
-			}
-		}
-	}
-	c.evidenceVersion++
-	return claim, false, nil
+	decision := c.reduceFinishIntent(finishIntent{site: finishSiteBeginFinalization, lease: lease, mode: mode, runErrorKnown: true, runErr: runErr})
+	return decision.claim, decision.continued, decision.err
 }
 
 func (c *delegateTreeController) CompleteSettlement(claim *delegateSettlementClaim, supplied *delegatestore.TerminalPacket) (delegateMutationPlans, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if claim == nil || claim.mode != delegateSettlementOrdinary || c.settlementClaims[claim.token] != claim {
-		return delegateMutationPlans{}, errDelegateStaleLease
+	decision := c.reduceFinishIntent(finishIntent{site: finishSiteCompleteSettlement, claim: claim, packet: supplied})
+	if decision.err != nil || decision.events == nil {
+		return delegateMutationPlans{}, decision.err
 	}
-	if err := c.finalizationReadyLocked(claim); err != nil {
+	_, appendErr := c.appendLocked(decision.events...)
+	if err := c.reduceFinishAppendResult(decision, appendErr); err != nil {
 		return delegateMutationPlans{}, err
 	}
-	aggregate, live, err := c.admitLeaseLocked(claim.lease, delegatestore.PhaseRunning)
-	if err != nil {
-		return delegateMutationPlans{}, err
-	}
-	if aggregate.Trigger == delegatestore.TriggerAttention && len(live.attentionIDs) != 0 {
-		return delegateMutationPlans{}, errDelegateTargetBusy
-	}
-	packet := delegateMissingTerminalPacket()
-	if supplied != nil {
-		packet = cloneDelegateTerminalPacket(*supplied)
-	}
-	if _, err := c.appendLocked(delegatestore.Event{
-		Kind:       delegatestore.EventDelegateTerminalPrepared,
-		DelegateID: claim.lease.delegateID,
-		TerminalPrepared: &delegatestore.TerminalPrepared{
-			Generation: claim.lease.generation,
-			Packet:     packet,
-		},
-	}); err != nil {
-		if live := c.live[claim.lease.delegateID]; live != nil && live.binding != nil && live.binding.lease == claim.lease {
-			live.recoveryRequired = true
-			live.finalizationRecoveryRequired = true
-			live.recoveryRunnerPending = true
-		}
-		return delegateMutationPlans{}, err
-	}
-	c.releaseSettlementClaimLocked(claim.token)
-	c.evidenceVersion++
-	plan := c.capturedPlanLocked(claim.lease.delegateID)
-	return delegateMutationPlans{updates: []delegateUpdatePlan{plan}}, nil
+	plans, _ := c.finishEffectsLocked(decision, delegateUpdatePlan{})
+	return plans, nil
 }
 
 func (c *delegateTreeController) AttentionResolutionsForFinalization(claim *delegateSettlementClaim) (delegateMutationPlans, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if claim == nil || c.settlementClaims[claim.token] != claim {
-		return delegateMutationPlans{}, errDelegateStaleLease
-	}
-	if err := c.finalizationReadyLocked(claim); err != nil {
-		return delegateMutationPlans{}, err
-	}
-	aggregate, live, err := c.exactLeaseLocked(claim.lease)
-	if err != nil {
-		return delegateMutationPlans{}, err
+	decision := c.reduceFinishIntent(finishIntent{site: finishSiteAttentionResolutions, claim: claim})
+	if decision.err != nil {
+		return delegateMutationPlans{}, decision.err
 	}
 	return delegateMutationPlans{
-		attention:             c.attentionResolutionPlansLocked(claim.lease, aggregate, live),
+		attention:             decision.attentionPlans,
 		attentionFinalization: claim,
 	}, nil
 }
@@ -230,36 +114,8 @@ func (c *delegateTreeController) AttentionResolutionsForFinalization(claim *dele
 func (c *delegateTreeController) prepareNoAction(claim *delegateSettlementClaim, fallback delegateFinish) (bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if claim == nil || c.settlementClaims[claim.token] != claim {
-		return false, errDelegateStaleLease
-	}
-	if claim.mode != delegateSettlementOrdinary {
-		return false, nil
-	}
-	if !claim.runErrorKnown || claim.runErr != nil {
-		return false, nil
-	}
-	if err := c.finalizationReadyLocked(claim); err != nil {
-		if errors.Is(err, errDelegateTargetBusy) {
-			return false, nil
-		}
-		return false, err
-	}
-	aggregate, live, err := c.exactLeaseLocked(claim.lease)
-	if err != nil {
-		return false, err
-	}
-	if aggregate.Phase != delegatestore.PhaseRunning || !c.noActionBaseEligibleLocked(aggregate, live) {
-		return false, nil
-	}
-	evidence := live.binding.evidence
-	if !noActionEvidenceEligible(evidence) {
-		return false, nil
-	}
-	retained := cloneDelegateFinish(fallback)
-	evidence.fallback = &retained
-	c.evidenceVersion++
-	return true, nil
+	decision := c.reduceFinishIntent(finishIntent{site: finishSitePrepareNoAction, claim: claim, finish: fallback})
+	return decision.recorded, decision.err
 }
 
 func (c *delegateTreeController) noActionBaseEligibleLocked(aggregate *delegatestore.Aggregate, live *delegateLiveState) bool {
@@ -278,26 +134,12 @@ func noActionEvidenceEligible(evidence *delegateGenerationEvidence) bool {
 func (c *delegateTreeController) RequireFinalizationRecovery(claim *delegateSettlementClaim) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if claim == nil || c.settlementClaims[claim.token] != claim {
-		return errDelegateStaleLease
+	decision := c.reduceFinishIntent(finishIntent{site: finishSiteRequireFinalizationRecovery, claim: claim})
+	if decision.err != nil {
+		return decision.err
 	}
-	_, live, err := c.exactLeaseLocked(claim.lease)
-	if err != nil {
-		return err
-	}
-	if !live.recoveryRequired {
-		live.recoveryRequired = true
-	}
-	live.finalizationRecoveryRequired = true
-	live.recoveryRunnerPending = true
-	c.evidenceVersion++
-	if c.stop != nil {
-		if _, active := c.stop.active[claim.lease]; active {
-			if _, covered := c.stop.members[claim.lease.delegateID]; covered {
-				c.signalStopProgressLocked()
-			}
-		}
-	}
+	_ = c.reduceFinishAppendResult(decision, nil)
+	c.finishEffectsLocked(decision, delegateUpdatePlan{})
 	return nil
 }
 
@@ -307,28 +149,11 @@ func (c *delegateTreeController) RequireFinalizationRecovery(claim *delegateSett
 func (c *delegateTreeController) ReportFinalizationQuiesced(lease delegateLease, runtime *Session) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	_, live, err := c.exactLeaseLocked(lease)
-	if err != nil {
-		if errors.Is(err, errDelegateStaleLease) {
-			return nil
-		}
-		return err
+	decision := c.reduceFinishIntent(finishIntent{site: finishSiteReportQuiesced, lease: lease, runtime: runtime, stalePolicy: finishStaleSwallow})
+	if decision.err != nil {
+		return decision.err
 	}
-	if live.binding == nil || live.binding.runtime != runtime {
-		return errDelegateStaleLease
-	}
-	if !live.recoveryRequired || !live.recoveryRunnerPending {
-		return nil
-	}
-	live.recoveryRunnerPending = false
-	c.evidenceVersion++
-	if c.stop != nil {
-		if _, active := c.stop.active[lease]; active {
-			if _, covered := c.stop.members[lease.delegateID]; covered {
-				c.signalStopProgressLocked()
-			}
-		}
-	}
+	c.finishEffectsLocked(decision, delegateUpdatePlan{})
 	return nil
 }
 
@@ -419,15 +244,12 @@ func (c *delegateTreeController) hasSteeringClaimLocked(lease delegateLease) boo
 
 func (c *delegateTreeController) FinishGeneration(lease delegateLease, finish delegateFinish) (delegateMutationPlans, error) {
 	c.mu.Lock()
-	aggregate, live, err := c.exactLeaseLocked(lease)
-	if err != nil {
-		c.mu.Unlock()
-		if errors.Is(err, errDelegateStaleLease) {
-			return delegateMutationPlans{}, nil
-		}
-		return delegateMutationPlans{}, err
-	}
-	plans, cancel, err := c.finishGenerationLocked(lease, finish, aggregate, live, false)
+	plans, cancel, err := c.executeFinishIntentLocked(finishIntent{
+		site:        finishSiteGeneration,
+		lease:       lease,
+		finish:      finish,
+		stalePolicy: finishStaleSuppress,
+	})
 	c.mu.Unlock()
 	if cancel != nil {
 		cancel()
@@ -440,12 +262,17 @@ func (c *delegateTreeController) FinishGeneration(lease delegateLease, finish de
 // prepareNoAction before process-local terminal state publication.
 func (c *delegateTreeController) FinishNoAction(claim *delegateSettlementClaim) (delegateMutationPlans, error) {
 	c.mu.Lock()
-	aggregate, live, finish, err := c.noActionFinishLocked(claim)
+	_, _, finish, err := c.noActionFinishLocked(claim)
 	if err != nil {
 		c.mu.Unlock()
 		return delegateMutationPlans{}, err
 	}
-	plans, cancel, err := c.finishGenerationLocked(claim.lease, finish, aggregate, live, true)
+	plans, cancel, err := c.executeFinishIntentLocked(finishIntent{
+		site:               finishSiteGeneration,
+		lease:              claim.lease,
+		finish:             finish,
+		authorizedNoAction: true,
+	})
 	c.mu.Unlock()
 	if cancel != nil {
 		cancel()
@@ -454,164 +281,17 @@ func (c *delegateTreeController) FinishNoAction(claim *delegateSettlementClaim) 
 }
 
 func (c *delegateTreeController) finishGenerationLocked(lease delegateLease, finish delegateFinish, aggregate *delegatestore.Aggregate, live *delegateLiveState, authorizedNoAction bool) (delegateMutationPlans, context.CancelFunc, error) {
-	if !authorizedNoAction && aggregate.Phase == delegatestore.PhaseRunning && finish.disposition == delegatestore.DispositionCompletedNoAction {
-		return delegateMutationPlans{}, nil, errDelegateTargetBusy
-	}
-	if live.finalizationRecoveryRequired {
-		return delegateMutationPlans{}, nil, errDelegateTargetBusy
-	}
-	if aggregate.Phase == delegatestore.PhaseRunning || aggregate.Phase == delegatestore.PhaseStopping {
-		if err := c.finalizationReadyForLeaseLocked(lease, live); err != nil {
-			return delegateMutationPlans{}, nil, err
-		}
-	}
-	if aggregate.Phase != delegatestore.PhaseStopping && aggregate.Trigger == delegatestore.TriggerAttention && len(live.attentionIDs) != 0 {
-		return delegateMutationPlans{}, nil, errDelegateTargetBusy
-	}
-
-	endedAt := finish.endedAt
-	if endedAt.IsZero() {
-		endedAt = c.now()
-	}
-	outcome := finish.outcome
-	reason := finish.reason
-	disposition := finish.disposition
-	deliveryID := ""
-	var events []delegatestore.Event
-
-	switch aggregate.Phase {
-	case delegatestore.PhaseSettling:
-		if aggregate.PreparedTerminal == nil {
-			return delegateMutationPlans{}, nil, fmt.Errorf("delegate %q settling without prepared terminal", lease.delegateID)
-		}
-		preparedFinish := delegatePreparedFinish(*aggregate.PreparedTerminal)
-		outcome, disposition, reason = preparedFinish.outcome, preparedFinish.disposition, preparedFinish.reason
-		if aggregate.PreparedTerminal.Kind == delegatestore.PacketTerminalError &&
-			!delegateIsMissingTerminalPacket(*aggregate.PreparedTerminal) && finish.outcome != "" && finish.outcome != delegatestore.OutcomeCompleted {
-			outcome = finish.outcome
-			disposition = delegatestore.DispositionTerminalError
-			reason = finish.reason
-		} else if preparedFinish.outcome == delegatestore.OutcomeExhausted {
-			finish = preparedFinish
-		}
-		deliveryID = delegateDeliveryID(lease.delegateID, lease.generation)
-		finished := delegateRunFinishedEvent(lease, outcome, disposition, reason, endedAt, deliveryID, nil)
-		events = []delegatestore.Event{finished}
-
-	case delegatestore.PhaseStopping:
-		// An externally cancelled generation still reports whatever evidence its
-		// own run loop already gathered (task, worktree, scratch path — see
-		// delegateTerminalPacketMetadata) via finish.packet; only fall back to the
-		// bare synthetic packet when the run loop produced none at all (kata
-		// tpb0). The fold layer (applyRunFinished) still has final say: it
-		// replaces this with the bare packet when the owner is outside the
-		// stopped subtree or the packet isn't a terminal-error kind.
-		packet := delegateStoppedTerminalPacket()
-		if finish.packet != nil {
-			packet = cloneDelegateTerminalPacket(*finish.packet)
-		}
-		outcome = delegatestore.OutcomeStopped
-		disposition = delegatestore.DispositionTerminalError
-		reason = "stopped_by_parent"
-		deliveryID = delegateDeliveryID(lease.delegateID, lease.generation)
-		events = []delegatestore.Event{delegateRunFinishedEvent(lease, outcome, disposition, reason, endedAt, deliveryID, &packet)}
-
-	case delegatestore.PhaseRunning:
-		if disposition == delegatestore.DispositionCompletedNoAction {
-			if outcome == "" {
-				outcome = delegatestore.OutcomeCompleted
-			}
-			events = []delegatestore.Event{delegateRunFinishedEvent(lease, outcome, disposition, reason, endedAt, "", nil)}
-			break
-		}
-		packet := delegateTerminalErrorPacket(reason)
-		if finish.packet != nil {
-			packet = cloneDelegateTerminalPacket(*finish.packet)
-		}
-		if outcome == "" {
-			outcome = delegatestore.OutcomeFailed
-		}
-		if outcome == delegatestore.OutcomeCompleted && finish.packet == nil {
-			outcome = delegatestore.OutcomeFailed
-			reason = "missing_terminal"
-			packet = delegateMissingTerminalPacket()
-		}
-		if disposition == "" {
-			disposition = delegatePacketDisposition(packet)
-		}
-		deliveryID = delegateDeliveryID(lease.delegateID, lease.generation)
-		events = []delegatestore.Event{
-			{
-				Kind:       delegatestore.EventDelegateTerminalPrepared,
-				DelegateID: lease.delegateID,
-				TerminalPrepared: &delegatestore.TerminalPrepared{
-					Generation: lease.generation,
-					Packet:     packet,
-				},
-			},
-			delegateRunFinishedEvent(lease, outcome, disposition, reason, endedAt, deliveryID, nil),
-		}
-
-	default:
-		return delegateMutationPlans{}, nil, errDelegateTargetBusy
-	}
-	events = delegateFinishMetadataEvents(events, lease, finish, outcome, reason)
-
-	closure := outcome == delegatestore.OutcomeExhausted && finish.exhaustionResumable != nil && !*finish.exhaustionResumable
-	var closurePlan delegateUpdatePlan
-	var appendErr error
-	if closure {
-		closurePlan, appendErr = c.appendResumabilityClosureLocked(lease.delegateID, events...)
-	} else {
-		_, appendErr = c.appendLocked(events...)
-	}
-	if appendErr != nil {
-		live.recoveryRequired = true
-		live.finalizationRecoveryRequired = true
-		live.recoveryRunnerPending = true
-		return delegateMutationPlans{}, nil, appendErr
-	}
-	plans, generationCancel := c.generationFinishedPlansLocked(lease, deliveryID)
-	if closure {
-		plans.updates[0] = closurePlan
-	}
-	return plans, generationCancel, nil
+	return c.executeFinishIntentLocked(finishIntent{
+		site:               finishSiteGeneration,
+		lease:              lease,
+		finish:             finish,
+		authorizedNoAction: authorizedNoAction,
+	})
 }
 
 func (c *delegateTreeController) noActionFinishLocked(claim *delegateSettlementClaim) (*delegatestore.Aggregate, *delegateLiveState, delegateFinish, error) {
-	if claim == nil || c.settlementClaims[claim.token] != claim {
-		return nil, nil, delegateFinish{}, errDelegateStaleLease
-	}
-	if claim.mode != delegateSettlementOrdinary {
-		return nil, nil, delegateFinish{}, errDelegateTargetBusy
-	}
-	if !claim.runErrorKnown || claim.runErr != nil {
-		return nil, nil, delegateFinish{}, errDelegateTargetBusy
-	}
-	if err := c.finalizationReadyLocked(claim); err != nil {
-		return nil, nil, delegateFinish{}, err
-	}
-	aggregate, live, err := c.exactLeaseLocked(claim.lease)
-	if err != nil {
-		return nil, nil, delegateFinish{}, err
-	}
-	if (aggregate.Phase != delegatestore.PhaseRunning && aggregate.Phase != delegatestore.PhaseStopping) ||
-		!c.noActionBaseEligibleLocked(aggregate, live) {
-		return nil, nil, delegateFinish{}, errDelegateTargetBusy
-	}
-	evidence := live.binding.evidence
-	if !noActionEvidenceEligible(evidence) || evidence.fallback == nil {
-		return nil, nil, delegateFinish{}, errDelegateTargetBusy
-	}
-	if aggregate.Phase == delegatestore.PhaseStopping {
-		return aggregate, live, cloneDelegateFinish(*evidence.fallback), nil
-	}
-	return aggregate, live, delegateFinish{
-		outcome:     delegatestore.OutcomeCompleted,
-		disposition: delegatestore.DispositionCompletedNoAction,
-		reason:      "attention_consumed_without_report",
-		endedAt:     evidence.fallback.endedAt,
-	}, nil
+	decision := c.reduceFinishIntent(finishIntent{site: finishSiteNoActionFinish, claim: claim})
+	return nil, nil, decision.finish, decision.err
 }
 
 func cloneDelegateFinish(finish delegateFinish) delegateFinish {

--- a/agent/delegate_tree_finish.go
+++ b/agent/delegate_tree_finish.go
@@ -280,15 +280,6 @@ func (c *delegateTreeController) FinishNoAction(claim *delegateSettlementClaim) 
 	return plans, err
 }
 
-func (c *delegateTreeController) finishGenerationLocked(lease delegateLease, finish delegateFinish, aggregate *delegatestore.Aggregate, live *delegateLiveState, authorizedNoAction bool) (delegateMutationPlans, context.CancelFunc, error) {
-	return c.executeFinishIntentLocked(finishIntent{
-		site:               finishSiteGeneration,
-		lease:              lease,
-		finish:             finish,
-		authorizedNoAction: authorizedNoAction,
-	})
-}
-
 func (c *delegateTreeController) noActionFinishLocked(claim *delegateSettlementClaim) (*delegatestore.Aggregate, *delegateLiveState, delegateFinish, error) {
 	decision := c.reduceFinishIntent(finishIntent{site: finishSiteNoActionFinish, claim: claim})
 	return nil, nil, decision.finish, decision.err

--- a/agent/delegate_tree_intents.go
+++ b/agent/delegate_tree_intents.go
@@ -122,11 +122,11 @@ type finishDecision struct {
 	// applies it.
 	latch finishLatchPlan
 	// effects are the abstract post-append effect descriptors, applied by
-	// finishEffectsLocked against post-append durable state.
+	// finishEffectsLocked against post-append durable state. Two idioms:
+	// append-carrying sites express evidence bumps as finishEffectBumpEvidence
+	// so they are skipped when the append fails; no-batch sites bump inline in
+	// the reducer.
 	effects []finishEffect
-	// live is the exact live state the reducer authenticated (pre-append,
-	// same lock scope), used by the latch shapes that target it.
-	live *delegateLiveState
 	// Outputs carried back through the unchanged wrapper signatures.
 	claim          *delegateSettlementClaim
 	continued      bool
@@ -345,9 +345,7 @@ func (c *delegateTreeController) stopTracksFinalizationLocked(lease delegateLeas
 	return covered
 }
 
-// reduceSupervisionBoundaryIntent is the supervision boundary: pending-steer
-// arbitration and stop precedence before ordinary nudge and hook work begins
-// outside the controller mutex.
+// reduceSupervisionBoundaryIntent is the supervision boundary.
 func (c *delegateTreeController) reduceSupervisionBoundaryIntent(intent finishIntent) finishDecision {
 	aggregate, live, err := c.exactLeaseLocked(intent.lease)
 	if err != nil {
@@ -384,10 +382,8 @@ func (c *delegateTreeController) reduceBeginFinalizationIntent(intent finishInte
 			if c.stop == nil {
 				return finishDecision{err: err}
 			}
-			_, active := c.stop.active[lease]
-			_, covered := c.stop.members[lease.delegateID]
 			if exactAggregate.Phase != delegatestore.PhaseStopping || exactAggregate.PendingStopSeq != c.stop.requestSeq ||
-				!active || !covered || exact.recoveryRequired || exact.binding == nil || !exact.binding.ready {
+				!c.stopTracksFinalizationLocked(lease) || exact.recoveryRequired || exact.binding == nil || !exact.binding.ready {
 				return finishDecision{err: err}
 			}
 			admitted = exact
@@ -441,14 +437,29 @@ func (c *delegateTreeController) reduceBeginFinalizationIntent(intent finishInte
 	return finishDecision{claim: claim}
 }
 
-// reduceCompleteSettlementIntent completes an ordinary settlement claim:
-// claim token/ready validation, running-phase admission, attention-claim
-// fencing, and the terminal-prepared journal batch.
+// authenticateSettlementClaimLocked is the shared claim-taking prefix:
+// exact-claim validation, the ready fence, and exact-lease authentication.
+// Callers that dereference claim fields before authenticating keep their own
+// claim-nil check first.
+func (c *delegateTreeController) authenticateSettlementClaimLocked(claim *delegateSettlementClaim) (*delegatestore.Aggregate, *delegateLiveState, error) {
+	if claim == nil || c.settlementClaims[claim.token] != claim {
+		return nil, nil, errDelegateStaleLease
+	}
+	if err := c.finalizationReadyLocked(claim); err != nil {
+		return nil, nil, err
+	}
+	return c.exactLeaseLocked(claim.lease)
+}
+
+// reduceCompleteSettlementIntent completes an ordinary settlement claim.
 func (c *delegateTreeController) reduceCompleteSettlementIntent(intent finishIntent) finishDecision {
 	claim, supplied := intent.claim, intent.packet
 	if claim == nil || claim.mode != delegateSettlementOrdinary || c.settlementClaims[claim.token] != claim {
 		return finishDecision{err: errDelegateStaleLease}
 	}
+	// Third step is admitLeaseLocked (phase admission with closing/reclamation/
+	// ancestor fences), not exactLeaseLocked — this site keeps its own chain so
+	// guard order (and therefore error identity) is unchanged.
 	if err := c.finalizationReadyLocked(claim); err != nil {
 		return finishDecision{err: err}
 	}
@@ -485,18 +496,53 @@ func (c *delegateTreeController) reduceCompleteSettlementIntent(intent finishInt
 // ordinary or terminal finalization must execute before the run's terminal
 // state is published.
 func (c *delegateTreeController) reduceAttentionResolutionsIntent(intent finishIntent) finishDecision {
-	claim := intent.claim
-	if claim == nil || c.settlementClaims[claim.token] != claim {
-		return finishDecision{err: errDelegateStaleLease}
-	}
-	if err := c.finalizationReadyLocked(claim); err != nil {
-		return finishDecision{err: err}
-	}
-	aggregate, live, err := c.exactLeaseLocked(claim.lease)
+	aggregate, live, err := c.authenticateSettlementClaimLocked(intent.claim)
 	if err != nil {
 		return finishDecision{err: err}
 	}
-	return finishDecision{attentionPlans: c.attentionResolutionPlansLocked(claim.lease, aggregate, live)}
+	return finishDecision{attentionPlans: c.attentionResolutionPlansLocked(intent.claim.lease, aggregate, live)}
+}
+
+// noActionClaimState is the outcome of the shared no-action eligibility prefix:
+// whether the claim is an ordinary claim with a known nil run error, and the
+// authenticated aggregate/live pair behind it.
+type noActionClaimState struct {
+	ordinaryEligible bool
+	aggregate        *delegatestore.Aggregate
+	live             *delegateLiveState
+}
+
+// authenticateNoActionClaimLocked is the shared no-action eligibility prefix
+// (claim identity, ordinary mode, known nil run error, ready fence, exact
+// lease, phase, base eligibility, evidence eligibility). Sites differ only in
+// the busy-vs-ineligible handling of the same outcomes, which readyErr carries
+// back: errDelegateStaleLease and exactLease/finalization errors are hard
+// failures for both; every other rejection is targetBusy-shaped and each
+// caller decides whether it means "not eligible" (prepare) or "refuse"
+// (finish). The phase check is caller-supplied because prepare admits only
+// PhaseRunning while finish also admits PhaseStopping.
+func (c *delegateTreeController) authenticateNoActionClaimLocked(claim *delegateSettlementClaim, allowStopping bool, readyErr error) (noActionClaimState, error) {
+	if claim == nil || c.settlementClaims[claim.token] != claim {
+		return noActionClaimState{}, errDelegateStaleLease
+	}
+	if claim.mode != delegateSettlementOrdinary || !claim.runErrorKnown || claim.runErr != nil {
+		return noActionClaimState{}, errDelegateTargetBusy
+	}
+	if readyErr != nil {
+		return noActionClaimState{}, readyErr
+	}
+	aggregate, live, err := c.exactLeaseLocked(claim.lease)
+	if err != nil {
+		return noActionClaimState{}, err
+	}
+	phaseOK := aggregate.Phase == delegatestore.PhaseRunning || (allowStopping && aggregate.Phase == delegatestore.PhaseStopping)
+	if !phaseOK || !c.noActionBaseEligibleLocked(aggregate, live) {
+		return noActionClaimState{}, errDelegateTargetBusy
+	}
+	if !noActionEvidenceEligible(live.binding.evidence) {
+		return noActionClaimState{}, errDelegateTargetBusy
+	}
+	return noActionClaimState{ordinaryEligible: true, aggregate: aggregate, live: live}, nil
 }
 
 // reducePrepareNoActionIntent binds the run's ordinary terminal fallback to
@@ -508,29 +554,20 @@ func (c *delegateTreeController) reducePrepareNoActionIntent(intent finishIntent
 	if claim == nil || c.settlementClaims[claim.token] != claim {
 		return finishDecision{err: errDelegateStaleLease}
 	}
-	if claim.mode != delegateSettlementOrdinary {
-		return finishDecision{}
-	}
-	if !claim.runErrorKnown || claim.runErr != nil {
-		return finishDecision{}
-	}
 	if err := c.finalizationReadyLocked(claim); err != nil {
 		if errors.Is(err, errDelegateTargetBusy) {
 			return finishDecision{}
 		}
 		return finishDecision{err: err}
 	}
-	aggregate, live, err := c.exactLeaseLocked(claim.lease)
+	state, err := c.authenticateNoActionClaimLocked(claim, false, nil)
+	if errors.Is(err, errDelegateTargetBusy) {
+		return finishDecision{}
+	}
 	if err != nil {
 		return finishDecision{err: err}
 	}
-	if aggregate.Phase != delegatestore.PhaseRunning || !c.noActionBaseEligibleLocked(aggregate, live) {
-		return finishDecision{}
-	}
-	evidence := live.binding.evidence
-	if !noActionEvidenceEligible(evidence) {
-		return finishDecision{}
-	}
+	evidence := state.live.binding.evidence
 	retained := cloneDelegateFinish(intent.finish)
 	evidence.fallback = &retained
 	c.evidenceVersion++
@@ -545,28 +582,16 @@ func (c *delegateTreeController) reduceNoActionFinishIntent(intent finishIntent)
 	if claim == nil || c.settlementClaims[claim.token] != claim {
 		return finishDecision{err: errDelegateStaleLease}
 	}
-	if claim.mode != delegateSettlementOrdinary {
-		return finishDecision{err: errDelegateTargetBusy}
-	}
-	if !claim.runErrorKnown || claim.runErr != nil {
-		return finishDecision{err: errDelegateTargetBusy}
-	}
-	if err := c.finalizationReadyLocked(claim); err != nil {
-		return finishDecision{err: err}
-	}
-	aggregate, live, err := c.exactLeaseLocked(claim.lease)
+	readyErr := c.finalizationReadyLocked(claim)
+	state, err := c.authenticateNoActionClaimLocked(claim, true, readyErr)
 	if err != nil {
 		return finishDecision{err: err}
 	}
-	if (aggregate.Phase != delegatestore.PhaseRunning && aggregate.Phase != delegatestore.PhaseStopping) ||
-		!c.noActionBaseEligibleLocked(aggregate, live) {
+	evidence := state.live.binding.evidence
+	if evidence.fallback == nil {
 		return finishDecision{err: errDelegateTargetBusy}
 	}
-	evidence := live.binding.evidence
-	if !noActionEvidenceEligible(evidence) || evidence.fallback == nil {
-		return finishDecision{err: errDelegateTargetBusy}
-	}
-	if aggregate.Phase == delegatestore.PhaseStopping {
+	if state.aggregate.Phase == delegatestore.PhaseStopping {
 		return finishDecision{finish: cloneDelegateFinish(*evidence.fallback)}
 	}
 	return finishDecision{finish: delegateFinish{
@@ -719,7 +744,6 @@ func (c *delegateTreeController) reduceRequireFinalizationRecoveryIntent(intent 
 		effects = append(effects, finishEffect{kind: finishEffectSignalStop})
 	}
 	return finishDecision{
-		live:    live,
 		latch:   finishLatchPlan{kind: finishLatchRecoveryConditional, live: live},
 		effects: effects,
 	}

--- a/agent/delegate_tree_intents.go
+++ b/agent/delegate_tree_intents.go
@@ -1,0 +1,814 @@
+package agent
+
+// Finish-path intent reducer.
+//
+// This file is the single authority for every decision on the generation
+// finish path (spec: 2026-08-29 delegate lifecycle harness reducer design,
+// Project 2). The exported and in-plan wrapper methods construct a
+// finishIntent, call reduceFinishIntent, append through appendLocked, and
+// apply the returned effect descriptors. Wrappers never branch on
+// aggregate/live/controller state and never assign outcomes or dispositions;
+// every guard evaluation lives in exactly one place here or in the shared
+// predicates this reducer calls (exactLeaseLocked, admitLeaseLocked,
+// supervisionSuppressedLocked, finalizationReadyLocked,
+// noActionBaseEligibleLocked, noActionEvidenceEligible).
+//
+// Contract for reduceFinishIntent: the caller holds c.mu. The reducer
+// acquires no locks, performs no journal I/O, and calls no Session methods
+// (comparing runtime pointer identity for the binding-runtime guard is the
+// one permitted use of a *Session). It performs the pre-append in-memory
+// transitions (claim acquisition/fencing, evidence observation) and returns
+// the decision: the journal batch to append, the per-site append-failure
+// latch plan, the abstract post-append effect descriptors (release claim,
+// release generation with its delivery plans, evidence-version bump, stop
+// progress signal, snapshot capture), and the entry point's stale-lease
+// policy already applied to the returned error.
+//
+// Deferred by spec (do not add here): the start-failure finishers
+// (CompleteStartInput, FailCommittedStart, FailCommittedRestart,
+// finishStoppedStartLocked) and the recovery finishers
+// (reconcileRecoveryRequiredStopLocked,
+// reconcileRuntimeLostFromEvidenceLocked).
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"primeradiant.com/evener/agent/internal/delegatestore"
+)
+
+// finishSite identifies which finish-path entry point an intent came from.
+type finishSite uint8
+
+const (
+	finishSiteSupervisionBoundary         finishSite = iota + 1 // SupervisionBoundary
+	finishSiteBeginFinalization                                 // BeginSettlement / BeginFinalization / BeginRunFinalization
+	finishSiteCompleteSettlement                                // CompleteSettlement
+	finishSiteAttentionResolutions                              // AttentionResolutionsForFinalization
+	finishSitePrepareNoAction                                   // prepareNoAction
+	finishSiteNoActionFinish                                    // noActionFinishLocked (FinishNoAction)
+	finishSiteGeneration                                        // finishGenerationLocked (FinishGeneration / FinishNoAction)
+	finishSiteRequireFinalizationRecovery                       // RequireFinalizationRecovery
+	finishSiteReportQuiesced                                    // ReportFinalizationQuiesced
+	finishSiteWorkAdmitted                                      // escalateCompletionRequirement
+	finishSiteAttentionNoAction                                 // recordAttentionNoAction
+	finishSiteTerminalSeen                                      // recordTerminalSeen
+	finishSiteCompletionDecision                                // completionDecision
+)
+
+// finishStalePolicy is how an entry point surfaces a stale-lease guard
+// failure. Three variants exist today: FinishGeneration suppresses it (empty
+// plans, nil error), FinishNoAction propagates it verbatim, and
+// ReportFinalizationQuiesced swallows it (nil error). The reducer applies the
+// policy; wrappers only surface decision.err.
+type finishStalePolicy uint8
+
+const (
+	finishStalePropagate finishStalePolicy = iota
+	finishStaleSuppress
+	finishStaleSwallow
+)
+
+// resolveStalePolicy applies this entry point's stale-lease policy to a guard
+// error. It is the only classification of guard errors; wrappers never
+// re-classify.
+func (intent finishIntent) resolveStalePolicy(err error) error {
+	if err == nil || !errors.Is(err, errDelegateStaleLease) {
+		return err
+	}
+	if intent.stalePolicy == finishStaleSuppress || intent.stalePolicy == finishStaleSwallow {
+		return nil
+	}
+	return err
+}
+
+// finishIntent is what a finish-path caller wants. It carries no controller
+// state, only the request: which site is asking, the lease or claim it holds,
+// and the payload (finish, packet, run error, runtime identity).
+type finishIntent struct {
+	site    finishSite
+	lease   delegateLease
+	claim   *delegateSettlementClaim
+	mode    delegateSettlementMode
+	finish  delegateFinish
+	packet  *delegatestore.TerminalPacket
+	runtime *Session
+	// runErrorKnown/runErr bind the sampled run error to a settlement claim
+	// (BeginRunFinalization).
+	runErrorKnown bool
+	runErr        error
+	// authorizedNoAction marks the FinishNoAction entry into the generation
+	// finish, whose no-action disposition was fenced by prepareNoAction.
+	authorizedNoAction bool
+	stalePolicy        finishStalePolicy
+}
+
+// finishDecision is the reducer's verdict for one intent.
+type finishDecision struct {
+	// err is the error to surface with the entry point's stale-lease policy
+	// already applied. A nil err with nil events means "nothing to do, empty
+	// success" (for example a suppressed stale lease or an ineligible
+	// observation).
+	err error
+	// events is the journal batch to append before any parent-visible
+	// effect. nil means this intent performs no append.
+	events []delegatestore.Event
+	// closure routes the append through appendResumabilityClosureLocked
+	// (non-resumable exhaustion) and substitutes the closure plan for the
+	// first post-append update.
+	closure bool
+	// latch is the per-site append-failure latch plan; reduceFinishAppendResult
+	// applies it.
+	latch finishLatchPlan
+	// effects are the abstract post-append effect descriptors, applied by
+	// finishEffectsLocked against post-append durable state.
+	effects []finishEffect
+	// live is the exact live state the reducer authenticated (pre-append,
+	// same lock scope), used by the latch shapes that target it.
+	live *delegateLiveState
+	// Outputs carried back through the unchanged wrapper signatures.
+	claim          *delegateSettlementClaim
+	continued      bool
+	recorded       bool
+	boundary       delegateSupervisionBoundary
+	completion     delegateCompletionDecision
+	finish         delegateFinish
+	attentionPlans []delegateAttentionCleanupPlan
+}
+
+// finishLatchKind is the per-site append-failure latch shape. The shapes are
+// inputs, not a constant: no uniform latching.
+type finishLatchKind uint8
+
+const (
+	// finishLatchNone: the site performs no append and no recovery latch.
+	finishLatchNone finishLatchKind = iota
+	// finishLatchUnconditionalTriple: finishGenerationLocked latches the
+	// full recovery triple on the authenticated live state unconditionally
+	// when the append failed.
+	finishLatchUnconditionalTriple
+	// finishLatchLeaseConditionalTriple: CompleteSettlement latches the full
+	// triple only when the live binding still matches the claim's lease at
+	// apply time.
+	finishLatchLeaseConditionalTriple
+	// finishLatchRecoveryConditional: RequireFinalizationRecovery sets
+	// recoveryRequired conditionally (only when not already latched) and the
+	// finalization/runner fences unconditionally. This site performs no
+	// journal append; the latch is its effect, so it applies on every
+	// reduction, not only on append failure.
+	finishLatchRecoveryConditional
+)
+
+// finishLatchPlan is the reducer's per-site append-failure latch plan.
+type finishLatchPlan struct {
+	kind finishLatchKind
+	// live is the authenticated live state for the shapes that target it.
+	live *delegateLiveState
+	// lease re-resolves the binding at apply time for the lease-conditional
+	// shape, exactly as the pre-reducer code re-read c.live after the failed
+	// append.
+	lease delegateLease
+}
+
+// finishEffectKind names an abstract post-append effect. The wrapper applies
+// these after the journal append, against post-append durable state.
+type finishEffectKind uint8
+
+const (
+	finishEffectNone finishEffectKind = iota
+	// finishEffectReleaseClaim releases the settlement claim token
+	// (releaseSettlementClaimLocked).
+	finishEffectReleaseClaim
+	// finishEffectReleaseGeneration finishes the generation: releases the
+	// lease's claims and stop tracking, releases the runtime binding
+	// (returning the cancel that must run after c.mu is released), captures
+	// the snapshot and delivery plans (generationFinishedPlansLocked).
+	finishEffectReleaseGeneration
+	// finishEffectBumpEvidence increments the evidence version.
+	finishEffectBumpEvidence
+	// finishEffectCaptureSnapshot appends the delegate's update plan.
+	finishEffectCaptureSnapshot
+	// finishEffectSignalStop signals progress to a covering subtree stop.
+	finishEffectSignalStop
+)
+
+type finishEffect struct {
+	kind       finishEffectKind
+	lease      delegateLease
+	delegateID string
+	token      uint64
+	deliveryID string
+}
+
+// reduceFinishIntent is the single locked transition function for the
+// generation finish path. The caller holds c.mu; the reducer acquires no
+// locks, performs no journal I/O, and calls no Session methods (runtime
+// pointer identity comparison is the one permitted use of a *Session). It
+// evaluates every finish-path guard exactly once, performs the pre-append
+// in-memory transitions, and returns the decision.
+func (c *delegateTreeController) reduceFinishIntent(intent finishIntent) finishDecision {
+	switch intent.site {
+	case finishSiteSupervisionBoundary:
+		return c.reduceSupervisionBoundaryIntent(intent)
+	case finishSiteBeginFinalization:
+		return c.reduceBeginFinalizationIntent(intent)
+	case finishSiteCompleteSettlement:
+		return c.reduceCompleteSettlementIntent(intent)
+	case finishSiteAttentionResolutions:
+		return c.reduceAttentionResolutionsIntent(intent)
+	case finishSitePrepareNoAction:
+		return c.reducePrepareNoActionIntent(intent)
+	case finishSiteNoActionFinish:
+		return c.reduceNoActionFinishIntent(intent)
+	case finishSiteGeneration:
+		return c.reduceGenerationFinishIntent(intent)
+	case finishSiteRequireFinalizationRecovery:
+		return c.reduceRequireFinalizationRecoveryIntent(intent)
+	case finishSiteReportQuiesced:
+		return c.reduceReportQuiescedIntent(intent)
+	case finishSiteWorkAdmitted:
+		return c.reduceWorkAdmittedIntent(intent)
+	case finishSiteAttentionNoAction:
+		return c.reduceAttentionNoActionIntent(intent)
+	case finishSiteTerminalSeen:
+		return c.reduceTerminalSeenIntent(intent)
+	case finishSiteCompletionDecision:
+		return c.reduceCompletionDecisionIntent(intent)
+	}
+	return finishDecision{err: errDelegateTargetBusy}
+}
+
+// executeFinishIntentLocked drives the append and effect tail for an intent
+// whose reducer decision carries a journal batch (the ordinary and no-action
+// generation finishes). The caller holds c.mu; the caller releases it and
+// then runs the returned cancel after c.mu is released (cancel-after-unlock).
+func (c *delegateTreeController) executeFinishIntentLocked(intent finishIntent) (delegateMutationPlans, context.CancelFunc, error) {
+	decision := c.reduceFinishIntent(intent)
+	if decision.err != nil || decision.events == nil {
+		return delegateMutationPlans{}, nil, decision.err
+	}
+	var appendErr error
+	var closurePlan delegateUpdatePlan
+	if decision.closure {
+		closurePlan, appendErr = c.appendResumabilityClosureLocked(intent.lease.delegateID, decision.events...)
+	} else {
+		_, appendErr = c.appendLocked(decision.events...)
+	}
+	if err := c.reduceFinishAppendResult(decision, appendErr); err != nil {
+		return delegateMutationPlans{}, nil, err
+	}
+	plans, cancel := c.finishEffectsLocked(decision, closurePlan)
+	return plans, cancel, nil
+}
+
+// reduceFinishAppendResult applies the reducer's per-site latch plan to the
+// append outcome and returns the error the wrapper must surface. Latch
+// shapes are inputs: the unconditional and lease-conditional triples apply
+// only when the append failed; the recovery-conditional latch is the site's
+// effect (there is no journal append on that path) and applies on every
+// reduction. The caller holds c.mu.
+func (c *delegateTreeController) reduceFinishAppendResult(decision finishDecision, appendErr error) error {
+	switch decision.latch.kind {
+	case finishLatchUnconditionalTriple:
+		if appendErr == nil {
+			return nil
+		}
+		live := decision.latch.live
+		live.recoveryRequired = true
+		live.finalizationRecoveryRequired = true
+		live.recoveryRunnerPending = true
+	case finishLatchLeaseConditionalTriple:
+		if appendErr == nil {
+			return nil
+		}
+		if live := c.live[decision.latch.lease.delegateID]; live != nil && live.binding != nil && live.binding.lease == decision.latch.lease {
+			live.recoveryRequired = true
+			live.finalizationRecoveryRequired = true
+			live.recoveryRunnerPending = true
+		}
+	case finishLatchRecoveryConditional:
+		live := decision.latch.live
+		if !live.recoveryRequired {
+			live.recoveryRequired = true
+		}
+		live.finalizationRecoveryRequired = true
+		live.recoveryRunnerPending = true
+	case finishLatchNone:
+	}
+	return appendErr
+}
+
+// finishEffectsLocked applies the reducer's post-append effect descriptors
+// against post-append durable state, using the existing pure plan helpers, and
+// returns the concrete mutation plans plus the cancel that must run after
+// c.mu is released. It branches only on the reducer's decision. The caller
+// holds c.mu.
+func (c *delegateTreeController) finishEffectsLocked(decision finishDecision, closurePlan delegateUpdatePlan) (delegateMutationPlans, context.CancelFunc) {
+	plans := delegateMutationPlans{}
+	var cancel context.CancelFunc
+	for _, effect := range decision.effects {
+		switch effect.kind {
+		case finishEffectReleaseClaim:
+			c.releaseSettlementClaimLocked(effect.token)
+		case finishEffectReleaseGeneration:
+			finished, generationCancel := c.generationFinishedPlansLocked(effect.lease, effect.deliveryID)
+			plans = finished
+			cancel = generationCancel
+			if decision.closure {
+				plans.updates[0] = closurePlan
+			}
+		case finishEffectBumpEvidence:
+			c.evidenceVersion++
+		case finishEffectCaptureSnapshot:
+			plans.updates = append(plans.updates, c.capturedPlanLocked(effect.delegateID))
+		case finishEffectSignalStop:
+			c.signalStopProgressLocked()
+		case finishEffectNone:
+		}
+	}
+	return plans, cancel
+}
+
+// stopTracksFinalizationLocked reports whether a covering subtree stop is
+// actively waiting on this lease and must hear about a finish-path effect that
+// just applied. Single home for the active-and-covered membership check the
+// recovery fences and claim acquisition consult.
+func (c *delegateTreeController) stopTracksFinalizationLocked(lease delegateLease) bool {
+	if c.stop == nil {
+		return false
+	}
+	if _, active := c.stop.active[lease]; !active {
+		return false
+	}
+	_, covered := c.stop.members[lease.delegateID]
+	return covered
+}
+
+// reduceSupervisionBoundaryIntent is the supervision boundary: pending-steer
+// arbitration and stop precedence before ordinary nudge and hook work begins
+// outside the controller mutex.
+func (c *delegateTreeController) reduceSupervisionBoundaryIntent(intent finishIntent) finishDecision {
+	aggregate, live, err := c.exactLeaseLocked(intent.lease)
+	if err != nil {
+		return finishDecision{boundary: delegateSupervisionSuppress, err: intent.resolveStalePolicy(err)}
+	}
+	if c.supervisionSuppressedLocked(aggregate, live) {
+		return finishDecision{boundary: delegateSupervisionSuppress}
+	}
+	if aggregate.Phase != delegatestore.PhaseRunning || !aggregate.Resumable || live.binding == nil || !live.binding.ready {
+		return finishDecision{boundary: delegateSupervisionSuppress, err: errDelegateTargetBusy}
+	}
+	if len(live.pendingSteers) != 0 && intent.mode == delegateSettlementOrdinary {
+		return finishDecision{boundary: delegateSupervisionContinue}
+	}
+	return finishDecision{boundary: delegateSupervisionProceed}
+}
+
+// reduceBeginFinalizationIntent acquires and fences the settlement claim:
+// finalization phase admission, stop-promotion arbitration (ordinary mode
+// under a covering stop that already ended the run promotes to terminal),
+// pending-steer continuation decision, and quiet-claim join.
+func (c *delegateTreeController) reduceBeginFinalizationIntent(intent finishIntent) finishDecision {
+	lease := intent.lease
+	mode := intent.mode
+	var live *delegateLiveState
+	switch mode {
+	case delegateSettlementOrdinary:
+		_, admitted, err := c.admitLeaseLocked(lease, delegatestore.PhaseRunning)
+		if err != nil {
+			exactAggregate, exact, exactErr := c.exactLeaseLocked(lease)
+			if exactErr != nil {
+				return finishDecision{err: exactErr}
+			}
+			if c.stop == nil {
+				return finishDecision{err: err}
+			}
+			_, active := c.stop.active[lease]
+			_, covered := c.stop.members[lease.delegateID]
+			if exactAggregate.Phase != delegatestore.PhaseStopping || exactAggregate.PendingStopSeq != c.stop.requestSeq ||
+				!active || !covered || exact.recoveryRequired || exact.binding == nil || !exact.binding.ready {
+				return finishDecision{err: err}
+			}
+			admitted = exact
+			mode = delegateSettlementTerminal
+		}
+		live = admitted
+		if mode == delegateSettlementOrdinary && (len(live.pendingSteers) != 0 || c.hasSteeringClaimLocked(lease)) {
+			return finishDecision{continued: true}
+		}
+	case delegateSettlementTerminal:
+		aggregate, exact, err := c.exactLeaseLocked(lease)
+		if err != nil {
+			return finishDecision{err: err}
+		}
+		if aggregate.Phase != delegatestore.PhaseRunning && aggregate.Phase != delegatestore.PhaseStopping {
+			return finishDecision{err: errDelegateTargetBusy}
+		}
+		if exact.recoveryRequired || exact.binding == nil || !exact.binding.ready {
+			return finishDecision{err: errDelegateTargetBusy}
+		}
+		live = exact
+	default:
+		return finishDecision{err: errDelegateTargetBusy}
+	}
+	if c.hasSettlementClaimLocked(lease) {
+		return finishDecision{err: errDelegateTargetBusy}
+	}
+	c.nextToken++
+	var ready <-chan struct{}
+	if live.quietClaim != nil {
+		ready = live.quietClaim.done
+	} else {
+		closed := make(chan struct{})
+		close(closed)
+		ready = closed
+	}
+	claim := &delegateSettlementClaim{
+		token:         c.nextToken,
+		lease:         lease,
+		mode:          mode,
+		ready:         ready,
+		runErrorKnown: intent.runErrorKnown,
+		runErr:        intent.runErr,
+	}
+	c.settlementClaims[claim.token] = claim
+	if c.stopTracksFinalizationLocked(lease) {
+		c.stop.settlementClaims[claim.token] = struct{}{}
+		c.signalStopProgressLocked()
+	}
+	c.evidenceVersion++
+	return finishDecision{claim: claim}
+}
+
+// reduceCompleteSettlementIntent completes an ordinary settlement claim:
+// claim token/ready validation, running-phase admission, attention-claim
+// fencing, and the terminal-prepared journal batch.
+func (c *delegateTreeController) reduceCompleteSettlementIntent(intent finishIntent) finishDecision {
+	claim, supplied := intent.claim, intent.packet
+	if claim == nil || claim.mode != delegateSettlementOrdinary || c.settlementClaims[claim.token] != claim {
+		return finishDecision{err: errDelegateStaleLease}
+	}
+	if err := c.finalizationReadyLocked(claim); err != nil {
+		return finishDecision{err: err}
+	}
+	aggregate, live, err := c.admitLeaseLocked(claim.lease, delegatestore.PhaseRunning)
+	if err != nil {
+		return finishDecision{err: err}
+	}
+	if aggregate.Trigger == delegatestore.TriggerAttention && len(live.attentionIDs) != 0 {
+		return finishDecision{err: errDelegateTargetBusy}
+	}
+	packet := delegateMissingTerminalPacket()
+	if supplied != nil {
+		packet = cloneDelegateTerminalPacket(*supplied)
+	}
+	return finishDecision{
+		events: []delegatestore.Event{{
+			Kind:       delegatestore.EventDelegateTerminalPrepared,
+			DelegateID: claim.lease.delegateID,
+			TerminalPrepared: &delegatestore.TerminalPrepared{
+				Generation: claim.lease.generation,
+				Packet:     packet,
+			},
+		}},
+		latch: finishLatchPlan{kind: finishLatchLeaseConditionalTriple, lease: claim.lease},
+		effects: []finishEffect{
+			{kind: finishEffectReleaseClaim, token: claim.token},
+			{kind: finishEffectBumpEvidence},
+			{kind: finishEffectCaptureSnapshot, delegateID: claim.lease.delegateID},
+		},
+	}
+}
+
+// reduceAttentionResolutionsIntent reads the attention cleanup plans an
+// ordinary or terminal finalization must execute before the run's terminal
+// state is published.
+func (c *delegateTreeController) reduceAttentionResolutionsIntent(intent finishIntent) finishDecision {
+	claim := intent.claim
+	if claim == nil || c.settlementClaims[claim.token] != claim {
+		return finishDecision{err: errDelegateStaleLease}
+	}
+	if err := c.finalizationReadyLocked(claim); err != nil {
+		return finishDecision{err: err}
+	}
+	aggregate, live, err := c.exactLeaseLocked(claim.lease)
+	if err != nil {
+		return finishDecision{err: err}
+	}
+	return finishDecision{attentionPlans: c.attentionResolutionPlansLocked(claim.lease, aggregate, live)}
+}
+
+// reducePrepareNoActionIntent binds the run's ordinary terminal fallback to
+// the exact eligible attention claim before process-local terminal state is
+// published. The claim stays live so only FinishNoAction can consume this
+// authority.
+func (c *delegateTreeController) reducePrepareNoActionIntent(intent finishIntent) finishDecision {
+	claim := intent.claim
+	if claim == nil || c.settlementClaims[claim.token] != claim {
+		return finishDecision{err: errDelegateStaleLease}
+	}
+	if claim.mode != delegateSettlementOrdinary {
+		return finishDecision{}
+	}
+	if !claim.runErrorKnown || claim.runErr != nil {
+		return finishDecision{}
+	}
+	if err := c.finalizationReadyLocked(claim); err != nil {
+		if errors.Is(err, errDelegateTargetBusy) {
+			return finishDecision{}
+		}
+		return finishDecision{err: err}
+	}
+	aggregate, live, err := c.exactLeaseLocked(claim.lease)
+	if err != nil {
+		return finishDecision{err: err}
+	}
+	if aggregate.Phase != delegatestore.PhaseRunning || !c.noActionBaseEligibleLocked(aggregate, live) {
+		return finishDecision{}
+	}
+	evidence := live.binding.evidence
+	if !noActionEvidenceEligible(evidence) {
+		return finishDecision{}
+	}
+	retained := cloneDelegateFinish(intent.finish)
+	evidence.fallback = &retained
+	c.evidenceVersion++
+	return finishDecision{recorded: true}
+}
+
+// reduceNoActionFinishIntent is the sole authority check for a packetless
+// completed attention generation: exact ordinary claim, known nil run error,
+// ready fence, no-action eligibility chain, and retained fallback.
+func (c *delegateTreeController) reduceNoActionFinishIntent(intent finishIntent) finishDecision {
+	claim := intent.claim
+	if claim == nil || c.settlementClaims[claim.token] != claim {
+		return finishDecision{err: errDelegateStaleLease}
+	}
+	if claim.mode != delegateSettlementOrdinary {
+		return finishDecision{err: errDelegateTargetBusy}
+	}
+	if !claim.runErrorKnown || claim.runErr != nil {
+		return finishDecision{err: errDelegateTargetBusy}
+	}
+	if err := c.finalizationReadyLocked(claim); err != nil {
+		return finishDecision{err: err}
+	}
+	aggregate, live, err := c.exactLeaseLocked(claim.lease)
+	if err != nil {
+		return finishDecision{err: err}
+	}
+	if (aggregate.Phase != delegatestore.PhaseRunning && aggregate.Phase != delegatestore.PhaseStopping) ||
+		!c.noActionBaseEligibleLocked(aggregate, live) {
+		return finishDecision{err: errDelegateTargetBusy}
+	}
+	evidence := live.binding.evidence
+	if !noActionEvidenceEligible(evidence) || evidence.fallback == nil {
+		return finishDecision{err: errDelegateTargetBusy}
+	}
+	if aggregate.Phase == delegatestore.PhaseStopping {
+		return finishDecision{finish: cloneDelegateFinish(*evidence.fallback)}
+	}
+	return finishDecision{finish: delegateFinish{
+		outcome:     delegatestore.OutcomeCompleted,
+		disposition: delegatestore.DispositionCompletedNoAction,
+		reason:      "attention_consumed_without_report",
+		endedAt:     evidence.fallback.endedAt,
+	}}
+}
+
+// reduceGenerationFinishIntent is the ordinary generation finish: the
+// no-action authorization fence, finalization recovery fence, ready fence,
+// attention-claim fencing, stop precedence and fallback selection,
+// prepared-terminal interplay and outcome normalization, the exhaustion
+// closure decision, and the RunFinished journal batch.
+func (c *delegateTreeController) reduceGenerationFinishIntent(intent finishIntent) finishDecision {
+	lease := intent.lease
+	finish := intent.finish
+	aggregate, live, err := c.exactLeaseLocked(lease)
+	if err != nil {
+		return finishDecision{err: intent.resolveStalePolicy(err)}
+	}
+	if !intent.authorizedNoAction && aggregate.Phase == delegatestore.PhaseRunning && finish.disposition == delegatestore.DispositionCompletedNoAction {
+		return finishDecision{err: errDelegateTargetBusy}
+	}
+	if live.finalizationRecoveryRequired {
+		return finishDecision{err: errDelegateTargetBusy}
+	}
+	if aggregate.Phase == delegatestore.PhaseRunning || aggregate.Phase == delegatestore.PhaseStopping {
+		if err := c.finalizationReadyForLeaseLocked(lease, live); err != nil {
+			return finishDecision{err: err}
+		}
+	}
+	if aggregate.Phase != delegatestore.PhaseStopping && aggregate.Trigger == delegatestore.TriggerAttention && len(live.attentionIDs) != 0 {
+		return finishDecision{err: errDelegateTargetBusy}
+	}
+
+	endedAt := finish.endedAt
+	if endedAt.IsZero() {
+		endedAt = c.now()
+	}
+	outcome := finish.outcome
+	reason := finish.reason
+	disposition := finish.disposition
+	deliveryID := ""
+	var events []delegatestore.Event
+
+	switch aggregate.Phase {
+	case delegatestore.PhaseSettling:
+		if aggregate.PreparedTerminal == nil {
+			return finishDecision{err: fmt.Errorf("delegate %q settling without prepared terminal", lease.delegateID)}
+		}
+		preparedFinish := delegatePreparedFinish(*aggregate.PreparedTerminal)
+		outcome, disposition, reason = preparedFinish.outcome, preparedFinish.disposition, preparedFinish.reason
+		if aggregate.PreparedTerminal.Kind == delegatestore.PacketTerminalError &&
+			!delegateIsMissingTerminalPacket(*aggregate.PreparedTerminal) && finish.outcome != "" && finish.outcome != delegatestore.OutcomeCompleted {
+			outcome = finish.outcome
+			disposition = delegatestore.DispositionTerminalError
+			reason = finish.reason
+		} else if preparedFinish.outcome == delegatestore.OutcomeExhausted {
+			finish = preparedFinish
+		}
+		deliveryID = delegateDeliveryID(lease.delegateID, lease.generation)
+		finished := delegateRunFinishedEvent(lease, outcome, disposition, reason, endedAt, deliveryID, nil)
+		events = []delegatestore.Event{finished}
+
+	case delegatestore.PhaseStopping:
+		// An externally cancelled generation still reports whatever evidence its
+		// own run loop already gathered (task, worktree, scratch path — see
+		// delegateTerminalPacketMetadata) via finish.packet; only fall back to the
+		// bare synthetic packet when the run loop produced none at all (kata
+		// tpb0). The fold layer (applyRunFinished) still has final say: it
+		// replaces this with the bare packet when the owner is outside the
+		// stopped subtree or the packet isn't a terminal-error kind.
+		packet := delegateStoppedTerminalPacket()
+		if finish.packet != nil {
+			packet = cloneDelegateTerminalPacket(*finish.packet)
+		}
+		outcome = delegatestore.OutcomeStopped
+		disposition = delegatestore.DispositionTerminalError
+		reason = "stopped_by_parent"
+		deliveryID = delegateDeliveryID(lease.delegateID, lease.generation)
+		events = []delegatestore.Event{delegateRunFinishedEvent(lease, outcome, disposition, reason, endedAt, deliveryID, &packet)}
+
+	case delegatestore.PhaseRunning:
+		if disposition == delegatestore.DispositionCompletedNoAction {
+			if outcome == "" {
+				outcome = delegatestore.OutcomeCompleted
+			}
+			events = []delegatestore.Event{delegateRunFinishedEvent(lease, outcome, disposition, reason, endedAt, "", nil)}
+			break
+		}
+		packet := delegateTerminalErrorPacket(reason)
+		if finish.packet != nil {
+			packet = cloneDelegateTerminalPacket(*finish.packet)
+		}
+		if outcome == "" {
+			outcome = delegatestore.OutcomeFailed
+		}
+		if outcome == delegatestore.OutcomeCompleted && finish.packet == nil {
+			outcome = delegatestore.OutcomeFailed
+			reason = "missing_terminal"
+			packet = delegateMissingTerminalPacket()
+		}
+		if disposition == "" {
+			disposition = delegatePacketDisposition(packet)
+		}
+		deliveryID = delegateDeliveryID(lease.delegateID, lease.generation)
+		events = []delegatestore.Event{
+			{
+				Kind:       delegatestore.EventDelegateTerminalPrepared,
+				DelegateID: lease.delegateID,
+				TerminalPrepared: &delegatestore.TerminalPrepared{
+					Generation: lease.generation,
+					Packet:     packet,
+				},
+			},
+			delegateRunFinishedEvent(lease, outcome, disposition, reason, endedAt, deliveryID, nil),
+		}
+
+	default:
+		return finishDecision{err: errDelegateTargetBusy}
+	}
+	events = delegateFinishMetadataEvents(events, lease, finish, outcome, reason)
+
+	closure := outcome == delegatestore.OutcomeExhausted && finish.exhaustionResumable != nil && !*finish.exhaustionResumable
+	return finishDecision{
+		events:  events,
+		closure: closure,
+		latch:   finishLatchPlan{kind: finishLatchUnconditionalTriple, live: live},
+		effects: []finishEffect{{kind: finishEffectReleaseGeneration, lease: lease, deliveryID: deliveryID}},
+	}
+}
+
+// reduceRequireFinalizationRecoveryIntent latches an exact finalization
+// whose external attention persistence failed. The claim remains fenced until
+// a durable stop can atomically close the open generation and then discard
+// pending attention.
+func (c *delegateTreeController) reduceRequireFinalizationRecoveryIntent(intent finishIntent) finishDecision {
+	claim := intent.claim
+	if claim == nil || c.settlementClaims[claim.token] != claim {
+		return finishDecision{err: errDelegateStaleLease}
+	}
+	_, live, err := c.exactLeaseLocked(claim.lease)
+	if err != nil {
+		return finishDecision{err: err}
+	}
+	effects := []finishEffect{{kind: finishEffectBumpEvidence}}
+	if c.stopTracksFinalizationLocked(claim.lease) {
+		effects = append(effects, finishEffect{kind: finishEffectSignalStop})
+	}
+	return finishDecision{
+		live:    live,
+		latch:   finishLatchPlan{kind: finishLatchRecoveryConditional, live: live},
+		effects: effects,
+	}
+}
+
+// reduceReportQuiescedIntent releases only the process-local runner fence for
+// the exact generation and resident runtime (pointer identity). Durable
+// recovery authority remains latched until reconciliation closes or repairs
+// that generation. A stale lease is swallowed.
+func (c *delegateTreeController) reduceReportQuiescedIntent(intent finishIntent) finishDecision {
+	_, live, err := c.exactLeaseLocked(intent.lease)
+	if err != nil {
+		return finishDecision{err: intent.resolveStalePolicy(err)}
+	}
+	if live.binding == nil || live.binding.runtime != intent.runtime {
+		return finishDecision{err: errDelegateStaleLease}
+	}
+	if !live.recoveryRequired || !live.recoveryRunnerPending {
+		return finishDecision{}
+	}
+	live.recoveryRunnerPending = false
+	effects := []finishEffect{{kind: finishEffectBumpEvidence}}
+	if c.stopTracksFinalizationLocked(intent.lease) {
+		effects = append(effects, finishEffect{kind: finishEffectSignalStop})
+	}
+	return finishDecision{effects: effects}
+}
+
+// reduceWorkAdmittedIntent escalates the completion requirement when
+// report-requiring work was admitted. Production start commits always attach
+// evidence, but exact legacy/manual bindings may omit it and must still
+// consume admitted steering — nil evidence is a tolerated no-op.
+func (c *delegateTreeController) reduceWorkAdmittedIntent(intent finishIntent) finishDecision {
+	_, live, err := c.exactLeaseLocked(intent.lease)
+	if err != nil {
+		return finishDecision{err: err}
+	}
+	evidence := live.binding.evidence
+	if evidence == nil {
+		return finishDecision{}
+	}
+	if evidence.requirement == delegateCompletionAttentionOnly {
+		evidence.requirement = delegateCompletionReportRequired
+		c.evidenceVersion++
+	}
+	return finishDecision{}
+}
+
+// reduceAttentionNoActionIntent records the bare attention no-action outcome
+// when the requirement is still attention-only and no terminal was seen.
+func (c *delegateTreeController) reduceAttentionNoActionIntent(intent finishIntent) finishDecision {
+	evidence, err := c.completionEvidenceLocked(intent.lease)
+	if err != nil {
+		return finishDecision{err: err}
+	}
+	if evidence.requirement != delegateCompletionAttentionOnly || evidence.terminalSeen {
+		return finishDecision{}
+	}
+	evidence.outcome = delegateCompletionOutcomeAttentionNoAction
+	c.evidenceVersion++
+	return finishDecision{recorded: true}
+}
+
+// reduceTerminalSeenIntent latches terminalSeen on the exact generation's
+// evidence.
+func (c *delegateTreeController) reduceTerminalSeenIntent(intent finishIntent) finishDecision {
+	evidence, err := c.completionEvidenceLocked(intent.lease)
+	if err != nil {
+		return finishDecision{err: err}
+	}
+	if !evidence.terminalSeen {
+		evidence.terminalSeen = true
+		c.evidenceVersion++
+	}
+	return finishDecision{}
+}
+
+// reduceCompletionDecisionIntent is the completion decision in query form
+// (pure read): useExistingTerminal / finishNoAction / needsNudge.
+func (c *delegateTreeController) reduceCompletionDecisionIntent(intent finishIntent) finishDecision {
+	evidence, err := c.completionEvidenceLocked(intent.lease)
+	if err != nil {
+		return finishDecision{completion: delegateCompletionNeedsNudge, err: err}
+	}
+	if evidence.terminalSeen {
+		return finishDecision{completion: delegateCompletionUseExistingTerminal}
+	}
+	if evidence.requirement == delegateCompletionAttentionOnly && evidence.outcome == delegateCompletionOutcomeAttentionNoAction {
+		return finishDecision{completion: delegateCompletionFinishNoAction}
+	}
+	return finishDecision{completion: delegateCompletionNeedsNudge}
+}

--- a/agent/delegate_tree_steer.go
+++ b/agent/delegate_tree_steer.go
@@ -26,17 +26,8 @@ const (
 func (c *delegateTreeController) completionDecision(lease delegateLease) (delegateCompletionDecision, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	evidence, err := c.completionEvidenceLocked(lease)
-	if err != nil {
-		return delegateCompletionNeedsNudge, err
-	}
-	if evidence.terminalSeen {
-		return delegateCompletionUseExistingTerminal, nil
-	}
-	if evidence.requirement == delegateCompletionAttentionOnly && evidence.outcome == delegateCompletionOutcomeAttentionNoAction {
-		return delegateCompletionFinishNoAction, nil
-	}
-	return delegateCompletionNeedsNudge, nil
+	decision := c.reduceFinishIntent(finishIntent{site: finishSiteCompletionDecision, lease: lease})
+	return decision.completion, decision.err
 }
 
 type delegateSteeringAdmission struct {

--- a/docs/subagent-management/11-delegate-resource-model.md
+++ b/docs/subagent-management/11-delegate-resource-model.md
@@ -1054,6 +1054,45 @@ successfully stopped. A shell signal that merely begins asynchronous process
 termination is not completion. Stop-admission or persistence failures remain
 part of the failed generation's terminal diagnostic instead of being discarded.
 
+#### Finish-path authority: the intent reducer
+
+The generation finish path's guards — exact-lease generation/binding
+authentication, settlement-claim creation and fencing, finalization phase
+admission with stop-promotion arbitration, stop precedence and fallback
+selection, suppression, no-action eligibility, prepared-terminal outcome
+normalization, append-failure recovery latching, and the per-entry-point
+stale-lease policies (suppress, propagate, swallow) — live in one locked
+decision function, `reduceFinishIntent` in `agent/delegate_tree_intents.go`.
+The caller holds the controller mutex; the reducer acquires no locks,
+performs no journal I/O, and calls no Session methods (runtime
+pointer-identity comparison is the single permitted exception). Each
+finish-path wrapper method constructs a typed intent, reduces it, appends the
+returned journal batch, builds concrete mutation plans against post-append
+durable state from the returned effect descriptors, and applies the effects.
+Wrappers branch only on the reducer's decision; they never re-evaluate
+aggregate, live, or controller state and never assign outcomes or
+dispositions.
+
+The start-failure finishers (CompleteStartInput, FailCommittedStart,
+FailCommittedRestart, finishStoppedStartLocked) and the recovery finishers
+(reconcileRecoveryRequiredStopLocked,
+reconcileRuntimeLostFromEvidenceLocked) remain separate entry paths with
+their own claim types and batch builders. Folding them into the same reducer
+is a named deferred follow-up; until it lands, stop-finish selection exists
+in three places and prepared-terminal normalization in two.
+
+The differential lifecycle harness
+(`agent/delegate_lifecycle_differential_test.go` with its model in
+`agent/delegate_lifecycle_model_test.go`) gates this path: it drives
+randomized, deterministic operation sequences through the real controller
+and asserts cross-layer agreement between the controller, the durable
+journal, and an independent model after every operation, including across
+simulated crash and append-failure recovery (invariants I1–I7 where in
+force). It pinned the three historical lifecycle bug classes — no-action
+selection, nil-evidence escalation tolerance, and exhaustion-payload
+overwrite — by mutation, and it is the regression net for any future change
+to the finish path.
+
 ### communicate
 
 The dedicated communicate(end_turn=true) path:

--- a/docs/superpowers/plans/2026-08-29-delegate-lifecycle-harness-reducer.md
+++ b/docs/superpowers/plans/2026-08-29-delegate-lifecycle-harness-reducer.md
@@ -1,0 +1,84 @@
+# Implementation plan: differential harness + finish-path reducer
+
+Date: 2026-08-29
+Spec: `docs/superpowers/specs/2026-08-29-delegate-lifecycle-harness-reducer-design.md`
+Branch: `lifecycle-reducer` (stacked on `lifecycle-dedup` / PR #582)
+Process per task: one implementer subagent → two competing adversarial
+reviewers → adjudicated fix wave → scoped re-review → four-angle simplify
+pass → gates. SDD working files (briefs/reports/ledger) stay uncommitted.
+
+## Task 1: harness skeleton and core invariants
+
+Implement the differential driver, the model state machine, operations
+1–5 and 8–9, and invariants I1–I5.
+
+- `agent/delegate_lifecycle_differential_test.go`: fuzz target +
+  deterministic runner translating fuzz bytes into the operation sequence.
+- `agent/delegate_lifecycle_model_test.go`: the model transition table
+  (phases, open-run, stop-pending, report-required, terminal-seen,
+  delivered) and the per-op agreement checker.
+- Reuse `newColdStableDelegateFixture`, testkit `newSession` builders,
+  and existing fake adapters. No production changes.
+- The model's transition table cites the spec's invariants for each rule.
+- Corpus seeds: bare-attention-then-queued-work; stop-before-finish;
+  attention-no-action finish; terminal-communicate finish; nudge-then-report.
+
+Tests: the new tests pass; `go test ./agent -run 'Differential' -count=1`.
+Review gate: adversarial pair (angle: can the harness actually catch the
+three historical bugs — prove each by hand with a mutation).
+
+## Task 2: fault injection, crash/recovery, fuzz registration
+
+Add operations 7, 10, 11 and invariants I6–I7; register the target.
+
+- Reuse the existing append-failure injection seam from the recovery
+  tests; if none is reusable without modification, report back before
+  adding one (that would be a production seam change).
+- Crash simulation: drop the runtime binding without finalizing, run the
+  real restore path, assert I7 convergence from the journal alone.
+- Register in `scripts/fuzz/fuzz-targets.txt`; `make lint-fuzz-registry`
+  and the target's seed corpus pass under `make fuzz-seeds`-equivalent
+  invocation for this target.
+- Determinism proof: run the full seed corpus twice, identical results;
+  no sleeps introduced (grep check in review).
+
+Tests: `go test -tags evenerfuzz ./agent -run 'FuzzDelegateLifecycleDifferential' -count=1`.
+Review gate: adversarial pair (angle: race/timing dependence hunt,
+invariant completeness vs. the bug catalog, model-table correctness).
+
+## Task 3: finish-path intent reducer
+
+Extract the reducer per the spec's guard inventory. Zero behavior diff.
+
+- New `agent/delegate_tree_intents.go`: intent types, `reduceFinishIntent`
+  (locked, no I/O/locks/Session), `reduceFinishAppendResult`.
+- Wrappers (`FinishGeneration`, `FinishNoAction`, `CompleteSettlement`,
+  `BeginRunFinalization` path, `prepareNoAction`, `noActionFinishLocked`,
+  `finishGenerationLocked`) become: construct intent → reduce →
+  `appendLocked` → apply effects. Signatures unchanged.
+- Every spec-table guard textually inside the reducer; the review package
+  includes a grep manifest proving no guard remains at call sites.
+- The differential harness and the full existing suite run unchanged.
+
+Tests: full `go test ./agent -count=1` + harness corpus.
+Review gate: adversarial pair (angle: guard-by-guard equivalence proof
+against pre-refactor source; ordering: append-before-publish,
+cancel-after-unlock, recovery-latch-on-append-failure) + four-angle
+simplify pass.
+
+## Task 4: documentation and gates
+
+- Update `docs/subagent-management/11-delegate-resource-model.md` to name
+  the reducer as the finish-path authority and the harness as the
+  cross-layer agreement gate.
+- Full gates: focused suites, `go test ./agent -count=1`, `make lint`,
+  `make vet`, `make test`.
+- Final review of the whole branch diff; push; open PR stacked on
+  `lifecycle-dedup` (retarget to `main` when #582 merges).
+
+## Explicit exclusions
+
+- No schema/journal change, no journaled evidence, no actor model.
+- No #569/#570/#571 behavior, no `ask_user` changes.
+- No production seam changes in Tasks 1–2 without parent approval.
+- No committing SDD working files.

--- a/docs/superpowers/plans/2026-08-29-delegate-lifecycle-harness-reducer.md
+++ b/docs/superpowers/plans/2026-08-29-delegate-lifecycle-harness-reducer.md
@@ -1,6 +1,6 @@
 # Implementation plan: differential harness + finish-path reducer
 
-Date: 2026-08-29
+Date: 2026-08-29 (revised after adversarial spec review)
 Spec: `docs/superpowers/specs/2026-08-29-delegate-lifecycle-harness-reducer-design.md`
 Branch: `lifecycle-reducer` (stacked on `lifecycle-dedup` / PR #582)
 Process per task: one implementer subagent → two competing adversarial
@@ -9,76 +9,112 @@ pass → gates. SDD working files (briefs/reports/ledger) stay uncommitted.
 
 ## Task 1: harness skeleton and core invariants
 
-Implement the differential driver, the model state machine, operations
-1–5 and 8–9, and invariants I1–I5.
+Implement the deterministic runner, the model state machine, the binding-kind
+seed dimension, operations 1–12 (all except append-failure and crash), and
+invariants I1–I5 (I1 asserted outside the crash window, which Task 2
+introduces).
 
-- `agent/delegate_lifecycle_differential_test.go`: fuzz target +
-  deterministic runner translating fuzz bytes into the operation sequence.
-- `agent/delegate_lifecycle_model_test.go`: the model transition table
-  (phases, open-run, stop-pending, report-required, terminal-seen,
-  delivered) and the per-op agreement checker.
+- `agent/delegate_lifecycle_differential_test.go` (**untagged**):
+  deterministic runner translating a byte sequence into the operation
+  sequence, plus ordinary `testing.T` drivers over the checked-in seeds.
+- `agent/delegate_lifecycle_model_test.go` (**untagged**): the model
+  transition table over the spec's model state (phase, runOpen,
+  stopPending, reportRequired, terminalSeen, delivered, evidencePresent,
+  evidenceRequirement, exhaustion-payload source) and the per-op
+  agreement checker.
 - Reuse `newColdStableDelegateFixture`, testkit `newSession` builders,
-  and existing fake adapters. No production changes.
-- The model's transition table cites the spec's invariants for each rule.
+  existing fake adapters, and the nil-evidence manual-binding seeding
+  precedent in `delegate_tree_controller_test.go`. No production changes.
+- Run-end error injection drives the fake adapter with the selected
+  terminal error (nil / generic / budget / canceled /
+  `errors.Join(budget, context.Canceled)`), optionally racing cancel.
+- Determinism: scripted clock on the root runtime, existing barriers, no
+  sleeps, no `StopSubtreeAndDrive` goroutine (use `StopSubtree` +
+  synchronous drain).
 - Corpus seeds: bare-attention-then-queued-work; stop-before-finish;
-  attention-no-action finish; terminal-communicate finish; nudge-then-report.
+  attention-no-action finish; terminal-communicate finish;
+  nudge-then-report; nil-evidence steering; joined cancel+budget
+  exhaustion; delivery execute+ack.
 
-Tests: the new tests pass; `go test ./agent -run 'Differential' -count=1`.
-Review gate: adversarial pair (angle: can the harness actually catch the
-three historical bugs — prove each by hand with a mutation).
+Gate: `go test ./agent -run 'Differential' -count=1` — must match and run
+real tests (untagged files; a vacuous match is a delivery failure).
+Review gate: adversarial pair — angle: prove by hand, with a mutation per
+historical bug (#580 no-action selection, nil-evidence tolerance,
+exhaustion overwrite), that the harness catches all three.
 
-## Task 2: fault injection, crash/recovery, fuzz registration
+## Task 2: append failure, crash/recovery, fuzz registration
 
-Add operations 7, 10, 11 and invariants I6–I7; register the target.
+Add operations 13–14 and invariants I6–I7; register the fuzz target.
 
-- Reuse the existing append-failure injection seam from the recovery
-  tests; if none is reusable without modification, report back before
-  adding one (that would be a production seam change).
-- Crash simulation: drop the runtime binding without finalizing, run the
-  real restore path, assert I7 convergence from the journal alone.
-- Register in `scripts/fuzz/fuzz-targets.txt`; `make lint-fuzz-registry`
-  and the target's seed corpus pass under `make fuzz-seeds`-equivalent
-  invocation for this target.
-- Determinism proof: run the full seed corpus twice, identical results;
-  no sleeps introduced (grep check in review).
+- Append failure: `c.store.Close()`; when the sequence continues,
+  reopen and swap `c.store` under `c.mu` (existing agent-side precedent;
+  no production seam changes).
+- Crash simulation: discard runtime state without finalizing; snapshot
+  journal + durable transcripts + job logs at the boundary; run the real
+  restore path; assert I7 (recovery may consume those durable inputs,
+  never memory-only state).
+- `agent/delegate_lifecycle_differential_fuzz_test.go`
+  (`//go:build evenerfuzz`): the `testing.F` target feeding bytes into the
+  Task 1 runner.
+- Register in `scripts/fuzz/fuzz-targets.txt` (native format, add
+  `coverpkg` if coverage spans `agent` root and
+  `agent/internal/delegatestore`); `make lint-fuzz-registry` passes; seed
+  corpus replays green under the tag.
 
-Tests: `go test -tags evenerfuzz ./agent -run 'FuzzDelegateLifecycleDifferential' -count=1`.
-Review gate: adversarial pair (angle: race/timing dependence hunt,
-invariant completeness vs. the bug catalog, model-table correctness).
+Gate: `go test -tags evenerfuzz ./agent -run 'FuzzDelegateLifecycleDifferential' -count=1`
+plus two consecutive full-corpus runs with identical results.
+Review gate: adversarial pair — angle: race/timing-dependence hunt,
+I7 input-model correctness, recovery-window enumeration completeness.
 
 ## Task 3: finish-path intent reducer
 
-Extract the reducer per the spec's guard inventory. Zero behavior diff.
+Extract the reducer per the spec's scope and guard inventory. Zero
+behavior diff.
 
-- New `agent/delegate_tree_intents.go`: intent types, `reduceFinishIntent`
-  (locked, no I/O/locks/Session), `reduceFinishAppendResult`.
+- New `agent/delegate_tree_intents.go`: intent types,
+  `reduceFinishIntent` (locked; no lock acquisition, no journal I/O, no
+  Session method calls — runtime pointer-identity comparison permitted),
+  `reduceFinishAppendResult` (applies the reducer's per-site latch plan).
 - Wrappers (`FinishGeneration`, `FinishNoAction`, `CompleteSettlement`,
-  `BeginRunFinalization` path, `prepareNoAction`, `noActionFinishLocked`,
-  `finishGenerationLocked`) become: construct intent → reduce →
-  `appendLocked` → apply effects. Signatures unchanged.
-- Every spec-table guard textually inside the reducer; the review package
-  includes a grep manifest proving no guard remains at call sites.
-- The differential harness and the full existing suite run unchanged.
+  `AttentionResolutionsForFinalization`, `BeginSettlement`,
+  `BeginFinalization`, `BeginRunFinalization`, `SupervisionBoundary`,
+  `RequireFinalizationRecovery`, `ReportFinalizationQuiesced`,
+  `prepareNoAction`, `noActionFinishLocked`, `finishGenerationLocked`,
+  `completionDecision`, the `record*`/`escalate*` methods) become: intent
+  construction → reduce → `appendLocked` → post-append plan construction
+  from the reducer's descriptors (branching only on the decision) → effect
+  application. Signatures unchanged.
+- Per-site latch shapes preserved exactly (unconditional triple /
+  lease-conditional triple / conditional single-flag — no uniform
+  latching).
+- Adjacent finish sites (start-failure and recovery finishers) are NOT
+  touched; the review package names them as deferred per spec.
+- Review package includes the hand-audited manifest: every wrapper body,
+  every guard's single home, proof no wrapper branches on
+  aggregate/live/controller state.
 
-Tests: full `go test ./agent -count=1` + harness corpus.
-Review gate: adversarial pair (angle: guard-by-guard equivalence proof
-against pre-refactor source; ordering: append-before-publish,
-cancel-after-unlock, recovery-latch-on-append-failure) + four-angle
-simplify pass.
+Gate: full `go test ./agent -count=1` + harness corpus + incident
+regressions, zero test modifications.
+Review gate: adversarial pair (guard-by-guard equivalence against
+pre-refactor source; append-before-publish, cancel-after-unlock,
+post-append plan ordering; latch-shape fidelity) + four-angle simplify
+pass.
 
 ## Task 4: documentation and gates
 
-- Update `docs/subagent-management/11-delegate-resource-model.md` to name
-  the reducer as the finish-path authority and the harness as the
-  cross-layer agreement gate.
+- Update `docs/subagent-management/11-delegate-resource-model.md`: the
+  reducer as the generation-finish-path authority (with the deferred
+  adjacent sites named), the harness as the cross-layer agreement gate.
 - Full gates: focused suites, `go test ./agent -count=1`, `make lint`,
   `make vet`, `make test`.
-- Final review of the whole branch diff; push; open PR stacked on
-  `lifecycle-dedup` (retarget to `main` when #582 merges).
+- Final whole-branch review; push; open PR stacked on `lifecycle-dedup`
+  (retarget to `main` when #582 merges).
 
 ## Explicit exclusions
 
 - No schema/journal change, no journaled evidence, no actor model.
 - No #569/#570/#571 behavior, no `ask_user` changes.
-- No production seam changes in Tasks 1–2 without parent approval.
+- No production changes in Tasks 1–2 (injection uses the existing
+  `c.store.Close()`/reopen-swap mechanism).
 - No committing SDD working files.
+- No touching start-failure or recovery finishers in Task 3.

--- a/docs/superpowers/specs/2026-08-29-delegate-lifecycle-harness-reducer-design.md
+++ b/docs/superpowers/specs/2026-08-29-delegate-lifecycle-harness-reducer-design.md
@@ -1,6 +1,6 @@
 # Delegate lifecycle: differential harness and finish-path intent reducer
 
-Date: 2026-08-29
+Date: 2026-08-29 (revised after adversarial review: reviewers A `dlg_034FgqrvqKHckKdZrrSgyF`, B `dlg_034Fgrl5XrPnt1VceshQGK`; A 7 significant findings, B 6, one conflict adjudicated in A's favor with parent verification)
 Status: design for implementation
 Depends on: PR #580 (merged), PR #582 (`classifyRunEnd`, `supervisionSuppressedLocked`)
 
@@ -17,17 +17,6 @@ same defect in different clothes: **two copies of a decision disagreed.**
   existed in two forms (switch branch vs. payload presence) and they split
   under a joined cancel+budget error.
 
-Today the finish path's guards — exact-lease authentication, phase checks,
-stop precedence, suppression, no-action eligibility, prepared-terminal
-interplay, append-failure latching — are spread across
-`SupervisionBoundary`, `admitLeaseLocked`, `BeginSettlement`,
-`BeginFinalization`, `BeginRunFinalization`, `prepareNoAction`,
-`noActionFinishLocked`, `finishGenerationLocked`, `CompleteSettlement`, and
-the `record*`/`escalate*` methods. Each mutator re-validates its own slice.
-There is no single place to read to learn what may happen at finalization,
-and no test that drives the runtime and durable layers through adversarial
-sequences and asserts they still agree.
-
 This spec covers two projects, delivered in one branch in dependency order:
 
 1. **Differential lifecycle harness** (test-only): drive randomized,
@@ -35,8 +24,10 @@ This spec covers two projects, delivered in one branch in dependency order:
    cross-layer agreement after every operation, including across simulated
    crash/recovery.
 2. **Finish-path intent reducer** (production, behavior-preserving):
-   relocate every finish-path guard into one locked transition function;
-   existing mutators become intent constructors and effect executors.
+   relocate every guard of the generation finish path into one locked
+   transition function; existing mutators become intent constructors and
+   effect executors. Scope is defined precisely below; adjacent finish
+   sites are named and deferred, not silently duplicated.
 
 The harness ships first because it is the proof net for the reducer, and it
 remains permanently valuable after the reducer lands.
@@ -45,127 +36,228 @@ remains permanently valuable after the reducer lands.
 
 ### Shape
 
-- Test-only. New files under `agent/` (e.g.
-  `delegate_lifecycle_differential_test.go` plus a model/helper file). No
-  production code changes.
-- A Go native fuzz target (`testing.F`) derives a deterministic operation
-  sequence from the fuzz input. Seeds for the historically interesting
-  sequences are checked in as corpus; the target registers in
-  `scripts/fuzz/fuzz-targets.txt` (four-column native format) so
+- Test-only. No production code changes. The deterministic runner and the
+  model live in **untagged** test files
+  (`agent/delegate_lifecycle_differential_test.go`,
+  `agent/delegate_lifecycle_model_test.go`) so the Task 1 gate runs real
+  tests; the Go native fuzz target lives in a tagged file
+  (`//go:build evenerfuzz`) and registers in
+  `scripts/fuzz/fuzz-targets.txt` (native format
+  `tag:module:package-relpath:name` with optional `coverpkg`), so
   `lint-fuzz-registry` and `make fuzz` cover it.
 - The driver applies each operation to a **real** `delegateTreeController`
   using the existing scripted fixtures (`newColdStableDelegateFixture`,
-  `newSession`/`withAdapter`/`withConfig` testkit, fake adapters), never a
-  mock of the controller itself.
-- An independent **model state machine** lives in the test file: a small
-  transition table over (phase, open-run, stop-pending, report-required,
-  terminal-seen, delivered) that is the harness's own opinion of the rules.
-  The model is intentionally a third, tiny, auditable copy — that is what
-  differential testing is. It tracks phases and outcomes only, never packet
-  contents, to keep its maintenance cost bounded.
+  testkit `newSession` builders, fake adapters), never a mock of the
+  controller itself. Append-failure injection uses the existing agent-side
+  mechanism: `c.store.Close()` plus, when the sequence needs recovery to
+  continue, reopening and swapping `c.store` under `c.mu` (existing
+  precedent: `agent/delegate_tree_finish_test.go`, `agent/delegate_tree_stop_test.go`).
+  No new fault seam, no production change.
+- An independent **model state machine** lives in the test file. It is
+  intentionally a third, tiny, auditable copy — that is what differential
+  testing is. It never constructs packets.
+
+### Model state (per delegate, single-delegate scope)
+
+`phase`, `runOpen`, `stopPending`, `reportRequired`, `terminalSeen`,
+`delivered`, `evidencePresent`, `evidenceRequirement`, and the
+**exhaustion-payload source** for terminal outcomes (budget, limit,
+resumable, and whether they came from the run error or from the prepared
+terminal — the value-level dimension the exhaustion-overwrite bug lived
+in).
+
+Explicitly **not** modeled in v1 (named non-coverage, follow-up
+candidates): nested-delegate/subtree-stop races and ancestor fences;
+model-request claim races beyond the settlement-claim path; multi-delegate
+interleavings. The harness generates single-delegate sequences including
+steering and settlement-claim interactions.
 
 ### Operation vocabulary
 
-The driver maps input bytes onto these operations, applied in sequence:
+A seed dimension plus fourteen operations; the driver maps fuzz bytes onto
+them:
 
+- **Seed: binding kind** — production start (evidence attached, the
+  `CommitStart` path) or legacy/manual binding with nil evidence (the
+  tolerance path in `escalateCompletionRequirementLocked`; existing
+  seeding precedent in `delegate_tree_controller_test.go`). This is what
+  makes the nil-evidence defect class reachable.
 1. start a generation (trigger: user work / shell attention);
 2. admit report-requiring work (user input, follow-up, goal continuation,
    steering bind, hook output);
 3. admit system-only work (attention, notification);
 4. bare attention response (records attention no-action when eligible);
 5. terminal communicate (sets terminalSeen);
-6. needs-nudge decision followed by the bounded nudge;
-7. stop request (before finalization, and racing finalization);
-8. ordinary finish (`FinishGeneration`);
-9. no-action finish (`FinishNoAction` via the claim path);
-10. injected append failure (reuse the existing recovery-test injection
-    seam; do not add a new one), optionally followed by a retry;
-11. simulated crash: discard runtime state without finalizing, then run the
-    real restore/replay path and let recovery settle.
+6. supervision-boundary decision (pending steers → continue; suppression
+   arbitration) — distinct from op 7;
+7. bounded nudge continuation (needs-nudge decision → nudge → outcome);
+8. run-end error injection: the fake adapter returns a selected terminal
+   error — nil, generic, budget exhaustion, `context.Canceled`, or
+   `errors.Join(budget, context.Canceled)` — optionally racing a cancel
+   request. This is what makes the exhaustion-overwrite defect class
+   reachable; model outcome rules mirror `classifyRunEnd`'s documented
+   pins;
+9. stop request (before finalization, and racing finalization);
+10. ordinary finish (`FinishGeneration`);
+11. no-action finish (`FinishNoAction` via the claim path);
+12. delivery execution + acknowledgment (`BeginDelivery` /
+    `CompleteDelivery`, both synchronous) — this is what makes I4's
+    parent-visible half reachable;
+13. injected append failure (`c.store.Close()`), optionally followed by
+    reopen/swap and a retry;
+14. simulated crash: discard runtime state without finalizing, snapshot
+    the journal, durable transcripts, and job logs, then run the real
+    restore path and let recovery settle.
 
 ### Invariants (asserted after every operation and after recovery)
 
-- **I1 — single authority:** at most one open generation per delegate;
-  `CurrentRunOpen` in the durable aggregate and the presence of a live
-  binding differ only inside the explicitly enumerated recovery windows
-  (append-failure latch; crash-before-restore). The windows are listed in
-  the test, not discovered by it.
+- **I1 — single authority:** at most one open generation per delegate.
+  `CurrentRunOpen` and live-binding presence agree even during the
+  append-failure latch (the latch retains the binding); the only
+  divergence window is crash-before-restore, bounded by
+  `reconcileRuntimeLostFromEvidenceLocked`. The window is listed in the
+  test, not discovered by it.
 - **I2 — legal transitions:** the durable phase sequence is a path in the
   model's transition table.
-- **I3 — stop precedence:** once a stop is durably recorded, the terminal
-  outcome is never `completed` or `completed_no_action`.
-- **I4 — delivery uniqueness:** at most one parent delivery per generation,
-  and none for `completed_no_action`.
-- **I5 — report requirement:** if any report-requiring work was admitted,
-  the final outcome is not `completed_no_action`.
+- **I3 — stop precedence (event-scoped):** a generation whose
+  `RunFinished` is journaled *after* a covering stop request has outcome
+  neither `completed` nor `completed_no_action`. (A generation finished
+  before the stop legitimately keeps its outcome — the invariant is over
+  event order, not final state.)
+- **I4 — delivery uniqueness:** at most one parent delivery is executed
+  and acknowledged per generation, and none for `completed_no_action`.
+- **I5 — report requirement:** if any report-requiring work was admitted
+  with evidence present, the final outcome is not `completed_no_action`.
+  With nil evidence, escalation is a no-op and the legacy outcome rules
+  apply — the model tracks this explicitly.
 - **I6 — durable truth:** replaying the journal through
   `delegatestore`'s fold yields the same aggregate the controller holds;
   no parent-visible effect exists without its journal event.
 - **I7 — recovery determinism:** recovery after a crash at any operation
-  boundary converges to the state the model predicts from the journal
-  alone; recovered state never depends on what was only in pre-crash
-  memory.
+  boundary converges to the state predicted from the **journal plus the
+  durable transcripts and job logs captured at the crash boundary**
+  (attention reconstruction reads transcripts; delivery dedup reads
+  parent transcripts — those are legitimate durable inputs). State that
+  was only in pre-crash memory — evidence contents, bindings, claims —
+  must never influence the recovered state.
 
 ### Determinism requirements
 
 No wall-clock, no sleeps, no network, no provider credentials. Scripted
-clock and adapters; synchronization only through the existing test
-barriers/condition waits. A failing seed must reproduce byte-for-byte from
-the fuzz input alone.
+clock (required on the root runtime: attention retry uses
+`sclock().AfterFunc`) and adapters; synchronization only through existing
+test barriers/condition waits; avoid the `StopSubtreeAndDrive` driver
+goroutine in favor of `StopSubtree` + synchronous drain (precedent:
+`FuzzDelegateControllerTransitions` drives the same controller with a
+fixed clock and no goroutines). A failing seed must reproduce
+byte-for-byte from the fuzz input alone.
 
 ## Project 2: finish-path intent reducer
+
+### Scope
+
+The **generation finish path**: settlement-claim acquisition and fencing
+(`BeginSettlement`, `BeginFinalization`, `BeginRunFinalization`,
+`finalizationReadyLocked`), the supervision boundary, completion decision,
+settlement completion (`CompleteSettlement`,
+`AttentionResolutionsForFinalization`), no-action preparation and finish
+(`prepareNoAction`, `noActionFinishLocked`), ordinary finish
+(`finishGenerationLocked`), evidence observations feeding these decisions
+(`recordAttentionNoAction`, `recordTerminalSeen`,
+`escalateCompletionRequirement`), and the finish-path recovery fences
+(`RequireFinalizationRecovery`, `ReportFinalizationQuiesced`).
+
+**Adjacent finish sites — explicitly out of Phase-1 scope, named, and
+deferred to a follow-up phase:** the start-failure finishers
+(`CompleteStartInput`, `FailCommittedStart`, `FailCommittedRestart`,
+`finishStoppedStartLocked` — which is a second copy of the stop-finish
+decision) and the recovery finishers (`reconcileRecoveryRequiredStopLocked`
+— a third copy of the stop-finish decision;
+`reconcileRuntimeLostFromEvidenceLocked` — a second copy of
+prepared-terminal outcome normalization, already structurally divergent
+from the finish-path copy). Rationale: these run on separate entry paths
+with their own claim types and batch builders; folding them into the same
+pass triples the diff and the risk. The cost of deferral is documented
+here: until the follow-up, stop-finish selection exists in three places
+and prepared-terminal normalization in two. The reducer's "single
+authority" claim below applies to the generation finish path only.
 
 ### Shape
 
 - Production change, behavior-preserving. No signature changes to existing
-  exported/plan-interface methods (`FinishGeneration`, `FinishNoAction`,
+  methods, including `FinishGeneration`, `FinishNoAction`,
   `BeginSettlement`, `BeginFinalization`, `BeginRunFinalization`,
-  `CompleteSettlement`, `SupervisionBoundary`, `AttentionResolutionsForFinalization`).
-- New typed intents describing what a caller wants:
-  `finishIntent{ordinary{lease, finish}}`,
-  `finishIntent{noAction{claim}}`, settlement completion, and the
-  escalation/evidence observations (`workAdmitted`, `attentionNoAction`,
-  `terminalSeen`) insofar as they feed finish-path decisions.
-- One locked transition function (working name `reduceFinishIntent`), in
-  the `classifyRunEnd` idiom but operating on controller state: the caller
-  holds `c.mu`; the reducer performs **no** lock acquisition, no Session
-  access, and no journal I/O. It returns the decision: events to append,
-  mutation plans to execute, cancellation to run after unlock, and the
-  recovery latches to set on append failure.
-- Commit stays where it is: wrappers append through the existing
-  `appendLocked` path, then apply the reducer's returned effects. The
-  append-failure reconciliation (setting `recoveryRequired` /
-  `finalizationRecoveryRequired`) is a second, explicit reducer step
-  (`reduceFinishAppendResult`) so post-commit decisions also live in one
-  place.
+  `CompleteSettlement`, `AttentionResolutionsForFinalization`,
+  `SupervisionBoundary`, `RequireFinalizationRecovery`, and
+  `ReportFinalizationQuiesced`.
+- New typed intents (new file `agent/delegate_tree_intents.go`) describing
+  what a caller wants: ordinary finish, no-action finish, settlement
+  completion, and the evidence observations (`workAdmitted`,
+  `attentionNoAction`, `terminalSeen`).
+- One locked transition function, `reduceFinishIntent`, in the
+  `classifyRunEnd` idiom but operating on controller state: the caller
+  holds `c.mu`; the reducer acquires no locks, performs no journal I/O,
+  and calls no Session methods (comparing runtime **pointer identity** for
+  the binding-runtime guard is permitted; taking `s.mu` or calling Session
+  behavior is not). It returns the **decision**: events to append, the
+  per-site latch plan for append failure (shapes differ — see below), the
+  abstract effect descriptors (release claim, release generation, deliver,
+  cancel-after-unlock), and the stale-lease policy outcome for this entry
+  point (suppress / propagate / swallow — three existing variants).
+- Commit stays where it is: wrappers append through `appendLocked`.
+  Concrete mutation-plan construction happens **after** append using the
+  existing pure plan helpers against the post-append durable state (plans
+  legitimately depend on it); that step branches only on the reducer's
+  decision and never re-validates state. The reducer returns descriptors,
+  not closures.
+- `reduceFinishAppendResult(intent, appendErr)` applies the per-site latch
+  plan the reducer computed: `finishGenerationLocked` latches the full
+  triple unconditionally; `CompleteSettlement` latches only when the live
+  binding still matches the claim's lease; `RequireFinalizationRecovery`
+  sets `recoveryRequired` conditionally; start-path sites are out of scope
+  (see above). No uniform latching — the shapes are inputs, not a
+  constant.
 
-### Guard inventory (everything moves, nothing duplicates)
+### Guard inventory (generation finish path; everything moves, nothing duplicates)
 
 | Guard | Current location | After |
 |---|---|---|
 | exact-lease generation/binding authentication | `exactLeaseLocked`, re-checked per method | reducer entry (single call) |
-| finalization phase admission | `admitLeaseLocked` variants | reducer entry |
-| settlement claim token/ready/lease/phase validation | `BeginRunFinalization`, `prepareNoAction`, `noActionFinishLocked` | reducer |
+| finalization phase admission + stop-promotion arbitration + continue decision | `admitLeaseLocked`, `beginFinalization` | reducer entry |
+| settlement claim creation/fencing | `BeginSettlement`/`BeginFinalization`/`BeginRunFinalization`, `hasSettlementClaimLocked`, `finalizationReadyLocked` (quiet-claim + ready fence) | reducer |
+| settlement claim token/ready validation | `CompleteSettlement`, `AttentionResolutionsForFinalization`, `prepareNoAction`, `noActionFinishLocked` | reducer |
+| completion decision (useExistingTerminal / finishNoAction / needsNudge) | `completionDecision` | reducer (query form, pure read) |
 | suppression (closing/stopping/stop-pending/recovery) | `supervisionSuppressedLocked` + echoes | reducer (predicate already shared) |
 | stop precedence and fallback selection | `finishGenerationLocked`, `noActionFinishLocked` | reducer |
 | prepared-terminal interplay / outcome normalization | `finishGenerationLocked` | reducer |
-| no-action eligibility chain (trigger, phase, attention, evidence, run-error, fallback) | `prepareNoAction`, `noActionFinishLocked` | reducer (existing shared predicates) |
-| append-failure recovery latching | inline at append sites | `reduceFinishAppendResult` |
-| stale-lease suppression policy (ordinary vs. authorized no-action) | `FinishGeneration`/`FinishNoAction` wrappers | reducer returns the policy outcome; wrappers only surface it |
+| no-action eligibility chain (trigger, phase, attention, evidence, run-error, fallback) | `prepareNoAction`, `noActionFinishLocked` (existing shared predicates) | reducer |
+| append-failure recovery latching (per-site shapes) | inline at append sites | `reduceFinishAppendResult` from the reducer's latch plan |
+| stale-lease policy (suppress / propagate / swallow) | `FinishGeneration`, `FinishNoAction`, `ReportFinalizationQuiesced` | reducer returns the policy outcome; wrappers only surface it |
+| recovery fences (exact-lease + runtime-identity) | `RequireFinalizationRecovery`, `ReportFinalizationQuiesced` | reducer (runtime pointer identity permitted) |
+
+Shared predicates (`exactLeaseLocked`, `supervisionSuppressedLocked`,
+`noActionBaseEligibleLocked`, `noActionEvidenceEligible`,
+`finalizationReadyLocked`) remain single implementations the reducer
+**calls**; the rule is no second evaluation of these conditions at call
+sites, not textual inlining.
 
 ### Acceptance criterion
 
-Every finish-path guard above is textually inside the reducer; wrappers
-contain intent construction, the `appendLocked` call, and effect
-application only. Measured: grep-based count of decision sites before and
-after; full `agent` suite, incident regressions, and the differential
-harness all green with zero test modifications.
+Semantic, not textual: (a) one locked function is the only finish-path
+decision site; (b) wrappers contain no conditional on aggregate/live/
+controller state and no outcome/disposition assignment — only intent
+construction, `appendLocked`, and effect application; (c) verified by a
+hand-audited manifest in the review package listing every wrapper body and
+every guard's single home. Plus: full `agent` suite, incident regressions,
+and the differential harness all green with zero test modifications.
 
 ## Non-goals
 
-- No journal schema change and no journaled completion evidence (that is
-  the follow-up phase, deliberately deferred).
+- No journal schema change and no journaled completion evidence (follow-up
+  phase, deliberately deferred).
 - No single-writer actor and no new effect abstraction layer.
+- No folding of start-failure or recovery finishers in this pass (named
+  above as the follow-up).
 - No behavior change for #569 (terminal durability), #570 (same-round
   atomicity), or #571 (terminal-cut enqueue).
 - No root-session routing changes; no `ask_user` changes.
@@ -178,11 +270,11 @@ harness all green with zero test modifications.
   above are the mitigation, and any timing-dependent failure blocks
   delivery until removed.
 - **Model drift:** the model is a third copy by design; it is kept minimal
-  (phases/outcomes) and its table is reviewed with the same rigor as
-  production code.
-- **Reducer relocation ordering:** append-before-publish and
-  cancel-after-unlock ordering must be preserved exactly; the harness,
-  full suite, and adversarial review all focus here.
-- **Partial adoption:** if the reducer stalls, the branch must not merge a
-  state where guards exist in both old and new locations; the acceptance
-  criterion's "textually inside" rule is the guard against it.
+  and its table is reviewed with the same rigor as production code.
+- **Reducer relocation ordering:** append-before-publish,
+  cancel-after-unlock, and post-append plan construction must be preserved
+  exactly; the harness, full suite, and adversarial review all focus here.
+- **Partial adoption:** the semantic acceptance criterion and the named
+  adjacent-sites section exist so the branch cannot merge guards in both
+  old and new locations, and cannot pretend the deferred copies do not
+  exist.

--- a/docs/superpowers/specs/2026-08-29-delegate-lifecycle-harness-reducer-design.md
+++ b/docs/superpowers/specs/2026-08-29-delegate-lifecycle-harness-reducer-design.md
@@ -1,0 +1,188 @@
+# Delegate lifecycle: differential harness and finish-path intent reducer
+
+Date: 2026-08-29
+Status: design for implementation
+Depends on: PR #580 (merged), PR #582 (`classifyRunEnd`, `supervisionSuppressedLocked`)
+
+## Problem
+
+Every significant defect found in the stable-delegate lifecycle work is the
+same defect in different clothes: **two copies of a decision disagreed.**
+
+- #580's root cause: the durable store knew `completed_no_action`; the active
+  runtime path had no way to select it.
+- The nil-evidence regression: one escalation path validated evidence
+  strictly; a legacy path did not, and consolidating them changed behavior.
+- The exhaustion-overwrite divergence: the decision to replace the run error
+  existed in two forms (switch branch vs. payload presence) and they split
+  under a joined cancel+budget error.
+
+Today the finish path's guards — exact-lease authentication, phase checks,
+stop precedence, suppression, no-action eligibility, prepared-terminal
+interplay, append-failure latching — are spread across
+`SupervisionBoundary`, `admitLeaseLocked`, `BeginSettlement`,
+`BeginFinalization`, `BeginRunFinalization`, `prepareNoAction`,
+`noActionFinishLocked`, `finishGenerationLocked`, `CompleteSettlement`, and
+the `record*`/`escalate*` methods. Each mutator re-validates its own slice.
+There is no single place to read to learn what may happen at finalization,
+and no test that drives the runtime and durable layers through adversarial
+sequences and asserts they still agree.
+
+This spec covers two projects, delivered in one branch in dependency order:
+
+1. **Differential lifecycle harness** (test-only): drive randomized,
+   deterministic operation sequences through the real controller and assert
+   cross-layer agreement after every operation, including across simulated
+   crash/recovery.
+2. **Finish-path intent reducer** (production, behavior-preserving):
+   relocate every finish-path guard into one locked transition function;
+   existing mutators become intent constructors and effect executors.
+
+The harness ships first because it is the proof net for the reducer, and it
+remains permanently valuable after the reducer lands.
+
+## Project 1: differential lifecycle harness
+
+### Shape
+
+- Test-only. New files under `agent/` (e.g.
+  `delegate_lifecycle_differential_test.go` plus a model/helper file). No
+  production code changes.
+- A Go native fuzz target (`testing.F`) derives a deterministic operation
+  sequence from the fuzz input. Seeds for the historically interesting
+  sequences are checked in as corpus; the target registers in
+  `scripts/fuzz/fuzz-targets.txt` (four-column native format) so
+  `lint-fuzz-registry` and `make fuzz` cover it.
+- The driver applies each operation to a **real** `delegateTreeController`
+  using the existing scripted fixtures (`newColdStableDelegateFixture`,
+  `newSession`/`withAdapter`/`withConfig` testkit, fake adapters), never a
+  mock of the controller itself.
+- An independent **model state machine** lives in the test file: a small
+  transition table over (phase, open-run, stop-pending, report-required,
+  terminal-seen, delivered) that is the harness's own opinion of the rules.
+  The model is intentionally a third, tiny, auditable copy — that is what
+  differential testing is. It tracks phases and outcomes only, never packet
+  contents, to keep its maintenance cost bounded.
+
+### Operation vocabulary
+
+The driver maps input bytes onto these operations, applied in sequence:
+
+1. start a generation (trigger: user work / shell attention);
+2. admit report-requiring work (user input, follow-up, goal continuation,
+   steering bind, hook output);
+3. admit system-only work (attention, notification);
+4. bare attention response (records attention no-action when eligible);
+5. terminal communicate (sets terminalSeen);
+6. needs-nudge decision followed by the bounded nudge;
+7. stop request (before finalization, and racing finalization);
+8. ordinary finish (`FinishGeneration`);
+9. no-action finish (`FinishNoAction` via the claim path);
+10. injected append failure (reuse the existing recovery-test injection
+    seam; do not add a new one), optionally followed by a retry;
+11. simulated crash: discard runtime state without finalizing, then run the
+    real restore/replay path and let recovery settle.
+
+### Invariants (asserted after every operation and after recovery)
+
+- **I1 — single authority:** at most one open generation per delegate;
+  `CurrentRunOpen` in the durable aggregate and the presence of a live
+  binding differ only inside the explicitly enumerated recovery windows
+  (append-failure latch; crash-before-restore). The windows are listed in
+  the test, not discovered by it.
+- **I2 — legal transitions:** the durable phase sequence is a path in the
+  model's transition table.
+- **I3 — stop precedence:** once a stop is durably recorded, the terminal
+  outcome is never `completed` or `completed_no_action`.
+- **I4 — delivery uniqueness:** at most one parent delivery per generation,
+  and none for `completed_no_action`.
+- **I5 — report requirement:** if any report-requiring work was admitted,
+  the final outcome is not `completed_no_action`.
+- **I6 — durable truth:** replaying the journal through
+  `delegatestore`'s fold yields the same aggregate the controller holds;
+  no parent-visible effect exists without its journal event.
+- **I7 — recovery determinism:** recovery after a crash at any operation
+  boundary converges to the state the model predicts from the journal
+  alone; recovered state never depends on what was only in pre-crash
+  memory.
+
+### Determinism requirements
+
+No wall-clock, no sleeps, no network, no provider credentials. Scripted
+clock and adapters; synchronization only through the existing test
+barriers/condition waits. A failing seed must reproduce byte-for-byte from
+the fuzz input alone.
+
+## Project 2: finish-path intent reducer
+
+### Shape
+
+- Production change, behavior-preserving. No signature changes to existing
+  exported/plan-interface methods (`FinishGeneration`, `FinishNoAction`,
+  `BeginSettlement`, `BeginFinalization`, `BeginRunFinalization`,
+  `CompleteSettlement`, `SupervisionBoundary`, `AttentionResolutionsForFinalization`).
+- New typed intents describing what a caller wants:
+  `finishIntent{ordinary{lease, finish}}`,
+  `finishIntent{noAction{claim}}`, settlement completion, and the
+  escalation/evidence observations (`workAdmitted`, `attentionNoAction`,
+  `terminalSeen`) insofar as they feed finish-path decisions.
+- One locked transition function (working name `reduceFinishIntent`), in
+  the `classifyRunEnd` idiom but operating on controller state: the caller
+  holds `c.mu`; the reducer performs **no** lock acquisition, no Session
+  access, and no journal I/O. It returns the decision: events to append,
+  mutation plans to execute, cancellation to run after unlock, and the
+  recovery latches to set on append failure.
+- Commit stays where it is: wrappers append through the existing
+  `appendLocked` path, then apply the reducer's returned effects. The
+  append-failure reconciliation (setting `recoveryRequired` /
+  `finalizationRecoveryRequired`) is a second, explicit reducer step
+  (`reduceFinishAppendResult`) so post-commit decisions also live in one
+  place.
+
+### Guard inventory (everything moves, nothing duplicates)
+
+| Guard | Current location | After |
+|---|---|---|
+| exact-lease generation/binding authentication | `exactLeaseLocked`, re-checked per method | reducer entry (single call) |
+| finalization phase admission | `admitLeaseLocked` variants | reducer entry |
+| settlement claim token/ready/lease/phase validation | `BeginRunFinalization`, `prepareNoAction`, `noActionFinishLocked` | reducer |
+| suppression (closing/stopping/stop-pending/recovery) | `supervisionSuppressedLocked` + echoes | reducer (predicate already shared) |
+| stop precedence and fallback selection | `finishGenerationLocked`, `noActionFinishLocked` | reducer |
+| prepared-terminal interplay / outcome normalization | `finishGenerationLocked` | reducer |
+| no-action eligibility chain (trigger, phase, attention, evidence, run-error, fallback) | `prepareNoAction`, `noActionFinishLocked` | reducer (existing shared predicates) |
+| append-failure recovery latching | inline at append sites | `reduceFinishAppendResult` |
+| stale-lease suppression policy (ordinary vs. authorized no-action) | `FinishGeneration`/`FinishNoAction` wrappers | reducer returns the policy outcome; wrappers only surface it |
+
+### Acceptance criterion
+
+Every finish-path guard above is textually inside the reducer; wrappers
+contain intent construction, the `appendLocked` call, and effect
+application only. Measured: grep-based count of decision sites before and
+after; full `agent` suite, incident regressions, and the differential
+harness all green with zero test modifications.
+
+## Non-goals
+
+- No journal schema change and no journaled completion evidence (that is
+  the follow-up phase, deliberately deferred).
+- No single-writer actor and no new effect abstraction layer.
+- No behavior change for #569 (terminal durability), #570 (same-round
+  atomicity), or #571 (terminal-cut enqueue).
+- No root-session routing changes; no `ask_user` changes.
+- The harness does not mock the controller, and the model does not grow
+  into a fourth implementation of packet construction.
+
+## Risks
+
+- **Harness flakiness** is the primary risk; the determinism requirements
+  above are the mitigation, and any timing-dependent failure blocks
+  delivery until removed.
+- **Model drift:** the model is a third copy by design; it is kept minimal
+  (phases/outcomes) and its table is reviewed with the same rigor as
+  production code.
+- **Reducer relocation ordering:** append-before-publish and
+  cancel-after-unlock ordering must be preserved exactly; the harness,
+  full suite, and adversarial review all focus here.
+- **Partial adoption:** if the reducer stalls, the branch must not merge a
+  state where guards exist in both old and new locations; the acceptance
+  criterion's "textually inside" rule is the guard against it.


### PR DESCRIPTION
## Summary

Follow-up to #582 (stacked on `lifecycle-dedup`; retarget to `main` once #582 merges). Two projects, in dependency order, per the committed spec (`docs/superpowers/specs/2026-08-29-delegate-lifecycle-harness-reducer-design.md`):

**1. Differential lifecycle harness (test-only)** — drives randomized, deterministic operation sequences through the real delegate controller and asserts cross-layer agreement after every operation: a model state machine (phases, outcomes, evidence presence, exhaustion-payload source) checked against both the live controller and the journal fold. 14 operations including run-end error injection (joined cancel+budget), nil-evidence legacy bindings, delivery execute/ack, and stop races. Invariants I1–I5 in force (I6–I7 with the deferred crash/recovery ops).

- Mutation-proven against all three historical bug classes (#580 no-action selection, nil-evidence tolerance, exhaustion overwrite) plus a fourth (silently absorbed `recordAttentionNoAction` under-action).
- Hardened through three adversarial review waves; reviewer-swept 3,000+ programs green, determinism double-run verified.

**2. Finish-path intent reducer (behavior-preserving)** — every guard of the generation finish path (exact-lease auth, claim fencing, stop precedence, suppression, no-action eligibility, prepared-terminal normalization, per-site append-failure latching, three stale-lease policies) now lives in one locked function: `reduceFinishIntent` in `agent/delegate_tree_intents.go`. Wrappers construct intents, append, and apply effects — no wrapper branches on controller state. Start-failure and recovery finishers are named and deferred per spec.

- **The harness stayed byte-identical and green throughout the extraction** — the zero-behavior-diff proof.
- Two adversarial reviewers approved with zero significant findings (guard-by-guard equivalence + effect-application tracing).
- Four-angle simplify pass applied (shared claim authentication, dead-code removal, predicate single-homing); 4 findings rejected with reasons.

## Verification

- Differential harness: 3 drivers × 9 seeds PASS, determinism verified
- `go test ./agent -count=1` — PASS (247.8s unmodified)
- `make lint` — PASS (9/9); three harness lint findings fixed en route (errname, slices.Backward, unused field)
- `make vet` — PASS
- `make test` — PASS (all modules + web)

## Notes

- Adjacent issues #569/#570/#571 untouched; no `ask_user` changes.
- Deferred follow-ups documented in the spec: folding start-failure/recovery finishers into the reducer, crash/append-failure harness ops + fuzz registration, journaled evidence.
