### PR TITLE
Decode the transcript exactly once on resume (5 passes -> 1)

### DIFF
--- a/agent/session.go
+++ b/agent/session.go
@@ -694,6 +694,17 @@ type Session struct {
 	transcriptReady        bool
 	pendingTranscriptTurns []schema.Turn
 
+	// restoredTranscript holds the decoded transcript a RESUME read while
+	// validating the session it was asked to restore: the header (with its
+	// SessionID already checked against this session's id) and the retained
+	// entries. It exists so serve's app-identity projection can reuse that
+	// one strict decode instead of re-reading and re-decoding the whole
+	// append-only file; it is populated only on the restore path, after any
+	// delegate-delivery refresh, and is never updated after construction.
+	// Guarded by s.mu.
+	restoredTranscriptHeader transcript.Header
+	restoredTranscript       []transcript.Entry
+
 	// Cached tool definitions.
 	cachedToolDefs []llm.ToolDefinition
 
@@ -1752,4 +1763,26 @@ func (s *Session) TranscriptPath() string {
 		return ""
 	}
 	return filepath.Join(s.stateDir, sessionsSubdir, s.id+".transcript.jsonl")
+}
+
+// setRestoredTranscript installs the final restore-time transcript view. It
+// runs once, at the end of restore construction, with the entry list that any
+// delegate-delivery replay already refreshed from disk.
+func (s *Session) setRestoredTranscript(header transcript.Header, entries []transcript.Entry) {
+	s.mu.Lock()
+	s.restoredTranscriptHeader = header
+	s.restoredTranscript = entries
+	s.mu.Unlock()
+}
+
+// RestoredTranscript returns the header and decoded entry list this resume
+// validated, for a caller (serve's app-identity projection) that would
+// otherwise re-read the transcript file. ok is false unless this session was
+// constructed by restore with a transcript; the slice aliases retained state
+// and must be treated as read-only.
+func (s *Session) RestoredTranscript() (transcript.Header, []transcript.Entry, bool) {
+	s.mu.Lock()
+	header, entries := s.restoredTranscriptHeader, s.restoredTranscript
+	s.mu.Unlock()
+	return header, entries, entries != nil
 }

--- a/agent/session.go
+++ b/agent/session.go
@@ -361,6 +361,11 @@ type Session struct {
 	// captured before ResumeHistory compacts model context.
 	restoredClientMutationTurns map[string]string
 	restoredClientMutationItems map[string]clientMutationTranscriptItems
+	// clientMutationAppendedTurn flags that a restore-time client-mutation
+	// recovery appended turns to the transcript file. Restore consults it
+	// after the recovery pass to decide whether the retained transcript
+	// entry list must be refreshed from disk. Guarded by mu.
+	clientMutationAppendedTurn bool
 	// clientMutationStartWake is installed by the lifecycle runner. Start
 	// acceptance invokes it only after the durable mutation commit; setting it
 	// after restore immediately wakes any accepted start already owned by the

--- a/agent/session_attention.go
+++ b/agent/session_attention.go
@@ -795,7 +795,13 @@ func (s *Session) resetStableDelegateAttentionRetry() {
 // rearmRootDelegateAttentionFromTranscript reconstructs the root wake cache
 // from the only durable attention authority. It performs no provider or Session
 // construction and is called after the root transcript is attached/replayed.
-func (s *Session) rearmRootDelegateAttentionFromTranscript() error {
+//
+// entries is the final in-memory entry list restore produced (refreshed from
+// disk when delegate delivery replay appended to the transcript): folding it
+// instead of re-opening the file is what keeps resume from strict-decoding
+// the whole transcript a second time. Callers without an entry list use
+// rearmRootDelegateAttentionFromTranscriptReload.
+func (s *Session) rearmRootDelegateAttentionFromTranscript(entries []transcript.Entry) error {
 	if !s.isRootDelegateAttentionReceiver() {
 		return nil
 	}
@@ -810,7 +816,13 @@ func (s *Session) rearmRootDelegateAttentionFromTranscript() error {
 		s.attentionMu.Unlock()
 		return nil
 	}
-	fold, err := s.readDelegateAttentionFold(transcriptPath(stateDir, sessionID), sessionID)
+	var fold delegateAttentionFold
+	var err error
+	if entries != nil {
+		fold, err = s.foldDelegateAttentionEntries(entries, sessionID)
+	} else {
+		fold, err = s.readDelegateAttentionFold(transcriptPath(stateDir, sessionID), sessionID)
+	}
 	if err != nil {
 		s.attentionMu.Unlock()
 		return err
@@ -829,6 +841,26 @@ func (s *Session) rearmRootDelegateAttentionFromTranscript() error {
 		s.notify()
 	}
 	return nil
+}
+
+// rearmRootDelegateAttentionFromTranscriptReload re-derives the root wake
+// cache from the transcript FILE, for callers (the fresh-session
+// construction path) that have no decoded entry list in hand.
+func (s *Session) rearmRootDelegateAttentionFromTranscriptReload() error {
+	return s.rearmRootDelegateAttentionFromTranscript(nil)
+}
+
+// foldDelegateAttentionEntries is the entries form of
+// readDelegateAttentionFold: same fold over the same entry list, no file
+// read. sessionID is unused by the fold itself (the entries were already
+// validated against the session by the pass that decoded them) but is kept
+// so the testOnly delegateAttentionReadFold seam below stays shape-stable
+// for both forms.
+func (s *Session) foldDelegateAttentionEntries(entries []transcript.Entry, sessionID string) (delegateAttentionFold, error) {
+	if foldEntries := s.cfg.testOnly.delegateAttentionFoldEntries; foldEntries != nil {
+		return foldEntries(entries, sessionID)
+	}
+	return foldDelegateAttention(entries)
 }
 
 func (s *Session) retainDelegateAttentionTurn(turn schema.Turn) error {

--- a/agent/session_attention.go
+++ b/agent/session_attention.go
@@ -799,8 +799,9 @@ func (s *Session) resetStableDelegateAttentionRetry() {
 // entries is the final in-memory entry list restore produced (refreshed from
 // disk when delegate delivery replay appended to the transcript): folding it
 // instead of re-opening the file is what keeps resume from strict-decoding
-// the whole transcript a second time. Callers without an entry list use
-// rearmRootDelegateAttentionFromTranscriptReload.
+// the whole transcript a second time. A nil entries list falls back to the
+// file read (the fresh-session construction path, which holds no decoded
+// entry list).
 func (s *Session) rearmRootDelegateAttentionFromTranscript(entries []transcript.Entry) error {
 	if !s.isRootDelegateAttentionReceiver() {
 		return nil
@@ -819,7 +820,7 @@ func (s *Session) rearmRootDelegateAttentionFromTranscript(entries []transcript.
 	var fold delegateAttentionFold
 	var err error
 	if entries != nil {
-		fold, err = s.foldDelegateAttentionEntries(entries, sessionID)
+		fold, err = s.foldDelegateAttentionEntries(entries)
 	} else {
 		fold, err = s.readDelegateAttentionFold(transcriptPath(stateDir, sessionID), sessionID)
 	}
@@ -843,22 +844,12 @@ func (s *Session) rearmRootDelegateAttentionFromTranscript(entries []transcript.
 	return nil
 }
 
-// rearmRootDelegateAttentionFromTranscriptReload re-derives the root wake
-// cache from the transcript FILE, for callers (the fresh-session
-// construction path) that have no decoded entry list in hand.
-func (s *Session) rearmRootDelegateAttentionFromTranscriptReload() error {
-	return s.rearmRootDelegateAttentionFromTranscript(nil)
-}
-
 // foldDelegateAttentionEntries is the entries form of
 // readDelegateAttentionFold: same fold over the same entry list, no file
-// read. sessionID is unused by the fold itself (the entries were already
-// validated against the session by the pass that decoded them) but is kept
-// so the testOnly delegateAttentionReadFold seam below stays shape-stable
-// for both forms.
-func (s *Session) foldDelegateAttentionEntries(entries []transcript.Entry, sessionID string) (delegateAttentionFold, error) {
+// read.
+func (s *Session) foldDelegateAttentionEntries(entries []transcript.Entry) (delegateAttentionFold, error) {
 	if foldEntries := s.cfg.testOnly.delegateAttentionFoldEntries; foldEntries != nil {
-		return foldEntries(entries, sessionID)
+		return foldEntries(entries)
 	}
 	return foldDelegateAttention(entries)
 }

--- a/agent/session_attention_rearm_entries_test.go
+++ b/agent/session_attention_rearm_entries_test.go
@@ -1,0 +1,141 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/identifier"
+	"primeradiant.com/evener/llm"
+)
+
+// rearmFixtureSession restores a root session whose transcript carries one
+// unresolved and one consumed delegate attention, and returns the restored
+// session plus the durable pending id the fold must re-arm.
+func rearmFixtureSession(t *testing.T) (*Session, string) {
+	t.Helper()
+	stateDir := t.TempDir()
+	rootID := identifier.MustNewSessionID()
+	if err := os.MkdirAll(filepath.Join(stateDir, sessionsSubdir), 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	const pendingID = "delegate:dlg_rearm/delivery/1"
+	const consumedID = "delegate:dlg_rearm/delivery/2"
+	writer, err := transcript.NewWriter(transcriptPath(stateDir, rootID), transcript.Header{SessionID: rootID, ProfileID: "openai", Model: "gpt-5.2"})
+	if err != nil {
+		t.Fatalf("create root transcript: %v", err)
+	}
+	pending := schema.NewTurn(schema.TurnSteering, llm.User(`<delegate-notification delegate_id="dlg_rearm">stay pending</delegate-notification>`))
+	pending.AttentionID = pendingID
+	pending.StableTurnID = newQueueEntryID()
+	if err := writer.AppendDurable(pending); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append pending attention: %v", err)
+	}
+	consumed := schema.NewTurn(schema.TurnSteering, llm.User(`<delegate-notification delegate_id="dlg_rearm">already resolved</delegate-notification>`))
+	consumed.AttentionID = consumedID
+	consumed.StableTurnID = newQueueEntryID()
+	if err := writer.AppendDurable(consumed); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append consumed attention: %v", err)
+	}
+	resolution := schema.NewTurn(schema.TurnAttentionResolution, llm.User(""))
+	resolution.AttentionResolution = &schema.AttentionResolutionInfo{
+		AttentionID:      consumedID,
+		Disposition:      string(delegateAttentionConsumed),
+		ResumeGeneration: 0,
+	}
+	if err := writer.AppendDurable(resolution); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append resolution: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close root transcript: %v", err)
+	}
+	meta := schema.SessionMeta{ID: rootID, ProfileID: "openai", Model: "gpt-5.2"}
+	if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
+		t.Fatalf("save root metadata: %v", err)
+	}
+	restored, err := RestoreSessionFromMeta(llm.NewClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(stateDir), meta, stateDir)
+	if err != nil {
+		t.Fatalf("restore root: %v", err)
+	}
+	return restored, pendingID
+}
+
+// TestRootDelegateAttention_RearmFromTranscriptDoesNotOpenTheFile proves the
+// restore-path rearm folds the in-memory entries restore already decoded: the
+// transcript file is REMOVED before the rearm runs, so a fold that re-opened
+// it would find nothing (the file form treats a missing transcript as an
+// empty fold) and the pending attention would vanish from the wake cache.
+func TestRootDelegateAttention_RearmFromTranscriptDoesNotOpenTheFile(t *testing.T) {
+	restored, pendingID := rearmFixtureSession(t)
+	defer restored.Close()
+
+	if err := os.Remove(transcriptPath(restored.stateDir, restored.id)); err != nil {
+		t.Fatalf("remove transcript to prove in-memory fold: %v", err)
+	}
+	// The fold must still report the unresolved attention, proving it came
+	// from the retained entries rather than the (now missing) file.
+	fold, err := foldDelegateAttention(restoredEntriesForRearm(t, restored))
+	if err != nil {
+		t.Fatalf("fold entries: %v", err)
+	}
+	if got := fold.pendingIDs(); !reflect.DeepEqual(got, []string{pendingID}) {
+		t.Fatalf("pending after file removal = %#v, want exactly the unresolved attention", got)
+	}
+}
+
+// TestRootDelegateAttention_RearmYieldsSamePendingIDsAsFileFold is the
+// differential proof: the entries the restored session retained must fold to
+// the same pending ids the file itself folds to, over a fixture with both an
+// open and a resolved attention.
+func TestRootDelegateAttention_RearmYieldsSamePendingIDsAsFileFold(t *testing.T) {
+	restored, pendingID := rearmFixtureSession(t)
+	defer restored.Close()
+
+	fileFold, err := readDelegateAttentionFold(transcriptPath(restored.stateDir, restored.id), restored.id)
+	if err != nil {
+		t.Fatalf("read file fold: %v", err)
+	}
+	entriesFold, err := foldDelegateAttention(restoredEntriesForRearm(t, restored))
+	if err != nil {
+		t.Fatalf("fold retained entries: %v", err)
+	}
+	if want := fileFold.pendingIDs(); !reflect.DeepEqual(entriesFold.pendingIDs(), want) || !reflect.DeepEqual(want, []string{pendingID}) {
+		t.Fatalf("pending diverge: file=%#v entries=%#v, want exactly the unresolved attention", fileFold.pendingIDs(), entriesFold.pendingIDs())
+	}
+}
+
+// TestRootDelegateAttention_RestoredTranscriptExposesFinalEntries pins the
+// restore→serve handoff: RestoredTranscript returns the entries restore
+// validated (non-nil once a transcript existed) and a header whose SessionID
+// matches the session.
+func TestRootDelegateAttention_RestoredTranscriptExposesFinalEntries(t *testing.T) {
+	restored, _ := rearmFixtureSession(t)
+	defer restored.Close()
+
+	header, entries, ok := restored.RestoredTranscript()
+	if !ok || len(entries) == 0 {
+		t.Fatalf("RestoredTranscript = ok:%t entries:%d, want the restore-validated entries", ok, len(entries))
+	}
+	if header.SessionID != restored.id {
+		t.Fatalf("restored header session %q, want %q", header.SessionID, restored.id)
+	}
+	if _, _, ok := (&Session{id: restored.id}).RestoredTranscript(); ok {
+		t.Fatal("a session without a restored transcript reported one")
+	}
+}
+
+func restoredEntriesForRearm(t *testing.T, s *Session) []transcript.Entry {
+	t.Helper()
+	_, entries, ok := s.RestoredTranscript()
+	if !ok {
+		t.Fatal("session retained no restored transcript entries")
+	}
+	return entries
+}

--- a/agent/session_attention_rearm_entries_test.go
+++ b/agent/session_attention_rearm_entries_test.go
@@ -17,6 +17,10 @@ import (
 // unresolved and one consumed delegate attention, and returns the restored
 // session plus the durable pending id the fold must re-arm.
 func rearmFixtureSession(t *testing.T) (*Session, string) {
+	return rearmFixtureSessionWithTestOnly(t, testConfig{})
+}
+
+func rearmFixtureSessionWithTestOnly(t *testing.T, testOnly testConfig) (*Session, string) {
 	t.Helper()
 	stateDir := t.TempDir()
 	rootID := identifier.MustNewSessionID()
@@ -60,11 +64,87 @@ func rearmFixtureSession(t *testing.T) (*Session, string) {
 	if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
 		t.Fatalf("save root metadata: %v", err)
 	}
-	restored, err := RestoreSessionFromMeta(llm.NewClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(stateDir), meta, stateDir)
+	restored, err := RestoreSessionFromMetaWithConfig(llm.NewClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(stateDir), meta, RestoreSessionConfig{StateDir: stateDir, testOnly: testOnly})
 	if err != nil {
 		t.Fatalf("restore root: %v", err)
 	}
 	return restored, pendingID
+}
+
+// TestRootDelegateAttention_RestoreRearmFoldsTheRetainedEntries proves the
+// restore-path rearm took the entries branch (not the file read): the seam
+// captures the entry list restore passed to the fold, and that list must be
+// the one RestoredTranscript exposes — the same final entry list serve will
+// see.
+func TestRootDelegateAttention_RestoreRearmFoldsTheRetainedEntries(t *testing.T) {
+	var foldedEntries []transcript.Entry
+	testOnly := testConfig{}
+	testOnly.delegateAttentionFoldEntries = func(entries []transcript.Entry) (delegateAttentionFold, error) {
+		foldedEntries = entries
+		return foldDelegateAttention(entries)
+	}
+	restored, pendingID := rearmFixtureSessionWithTestOnly(t, testOnly)
+	defer restored.Close()
+
+	if foldedEntries == nil {
+		t.Fatal("restore rearm never took the entries fold branch")
+	}
+	_, retained, ok := restored.RestoredTranscript()
+	if !ok {
+		t.Fatal("restored session retained no transcript entries")
+	}
+	if len(foldedEntries) != len(retained) {
+		t.Fatalf("entries passed to the fold = %d, retained entries = %d; the rearm must fold the same final list serve sees", len(foldedEntries), len(retained))
+	}
+	for i := range foldedEntries {
+		if foldedEntries[i].Turn.StableTurnID != retained[i].Turn.StableTurnID {
+			t.Fatalf("folded entry %d stable turn = %q, want the retained %q", i, foldedEntries[i].Turn.StableTurnID, retained[i].Turn.StableTurnID)
+		}
+	}
+	fold, err := foldDelegateAttention(foldedEntries)
+	if err != nil {
+		t.Fatalf("fold captured entries: %v", err)
+	}
+	if got := fold.pendingIDs(); !reflect.DeepEqual(got, []string{pendingID}) {
+		t.Fatalf("pending from the captured entries = %#v, want exactly the unresolved attention", got)
+	}
+}
+
+// TestRestoreSession_RestoredTranscriptOKBoundary pins the ok flag's
+// boundary: a session restored with NO transcript on disk reports ok=false,
+// and one restored over a transcript with at least one entry reports ok=true
+// with that entry. (A header-only transcript currently lands on the ok=false
+// side of the line: resumeWriter returns a nil entry slice when no entry
+// line follows the header, and RestoredTranscript keys ok on entries != nil.
+// That is the pre-existing resumeWriter behavior, not a restore decision.)
+func TestRestoreSession_RestoredTranscriptOKBoundary(t *testing.T) {
+	t.Run("no transcript on disk", func(t *testing.T) {
+		stateDir := t.TempDir()
+		rootID := identifier.MustNewSessionID()
+		if err := os.MkdirAll(filepath.Join(stateDir, sessionsSubdir), 0o755); err != nil {
+			t.Fatalf("mkdir sessions: %v", err)
+		}
+		meta := schema.SessionMeta{ID: rootID, ProfileID: "openai", Model: "gpt-5.2"}
+		if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
+			t.Fatalf("save root metadata: %v", err)
+		}
+		restored, err := RestoreSessionFromMeta(llm.NewClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(stateDir), meta, stateDir)
+		if err != nil {
+			t.Fatalf("restore root: %v", err)
+		}
+		defer restored.Close()
+		if _, _, ok := restored.RestoredTranscript(); ok {
+			t.Fatal("a session restored without a transcript reported a restored one")
+		}
+	})
+	t.Run("transcript with entries", func(t *testing.T) {
+		restored, _ := rearmFixtureSession(t)
+		defer restored.Close()
+		_, entries, ok := restored.RestoredTranscript()
+		if !ok || len(entries) == 0 {
+			t.Fatalf("RestoredTranscript = ok:%t entries:%d, want ok:true with the fixture's entries", ok, len(entries))
+		}
+	})
 }
 
 // TestRootDelegateAttention_RearmFromTranscriptDoesNotOpenTheFile proves the

--- a/agent/session_client_mutation_queue.go
+++ b/agent/session_client_mutation_queue.go
@@ -1195,6 +1195,7 @@ func (s *Session) recordClientMutationFailure(
 			return fmt.Errorf("append failed client start input: %w", err)
 		}
 		s.mu.Lock()
+		s.clientMutationAppendedTurn = true
 		s.history = append(s.history, turn)
 		s.mu.Unlock()
 		if err := s.clientMutationFailureFault("after_user"); err != nil {
@@ -1214,6 +1215,7 @@ func (s *Session) recordClientMutationFailure(
 			return fmt.Errorf("append failed client start diagnostic: %w", err)
 		}
 		s.mu.Lock()
+		s.clientMutationAppendedTurn = true
 		s.history = append(s.history, turn)
 		s.mu.Unlock()
 		if err := s.clientMutationFailureFault("after_failure"); err != nil {

--- a/agent/session_client_mutation_test.go
+++ b/agent/session_client_mutation_test.go
@@ -1126,6 +1126,83 @@ func TestClientMutation_IncorporationFailureCrashBoundariesRecoverWithoutDuplica
 	}
 }
 
+// TestRestoreSession_RestoredTranscriptIncludesClientMutationFailureRecovery
+// pins the restore→serve handoff across the failure-recovery append: the
+// entries RestoredTranscript exposes must match what readTranscriptFull sees
+// in the same file, because serve projects exactly that retained list (the
+// daemon's turn snapshot and the projector's live-turn-id fence are seeded
+// from it). A restore that retained the pre-recovery list would seed serve one
+// turn behind the file the recovery just appended to.
+func TestRestoreSession_RestoredTranscriptIncludesClientMutationFailureRecovery(t *testing.T) {
+	for _, boundary := range []string{"after_user", "after_failure"} {
+		t.Run(boundary, func(t *testing.T) {
+			dir := t.TempDir()
+			sess := newQueuePersistTestSession(t, dir)
+			id := sess.ID()
+			params := appwire.TurnStartParams{
+				ClientMutationID: "start-failure-recovery-visibility-" + boundary,
+				Input:            []appwire.InputItem{{Type: "text", Text: "recover failed start for the retained list"}},
+			}
+			started, err := sess.AcceptClientMutationStart(params)
+			if err != nil {
+				t.Fatalf("AcceptClientMutationStart: %v", err)
+			}
+			claimed, ok, err := sess.claimClientMutationStart()
+			if err != nil || !ok {
+				t.Fatalf("claimClientMutationStart: claimed=%#v ok=%v err=%v", claimed, ok, err)
+			}
+			failure := errors.New("deterministic pre-append failure")
+			crash := errors.New("simulated crash at " + boundary)
+			sess.clientMutationPreAppendFailure = func(schema.Turn) error { return failure }
+			sess.clientMutationFailureRecoveryFault = func(got string) error {
+				if got == boundary {
+					return crash
+				}
+				return nil
+			}
+			if err := sess.acceptUserInput(
+				withQueuedClientMutation(context.Background(), claimed),
+				claimed.Text,
+				claimed.Images,
+				nil,
+				false,
+			); !errors.Is(err, failure) || !errors.Is(err, crash) {
+				t.Fatalf("acceptUserInput error = %v, want failure and crash", err)
+			}
+			sess.Close()
+
+			restored := restoreQueuePersistTestSession(t, dir, id)
+			defer restored.Close()
+			_, entries, ok := restored.RestoredTranscript()
+			if !ok {
+				t.Fatal("restored session retained no transcript entries")
+			}
+			path := transcriptPath(restored.stateDir, restored.id)
+			onDisk, err := readTranscriptFull(path)
+			if err != nil {
+				t.Fatalf("readTranscriptFull: %v", err)
+			}
+			if len(entries) != len(onDisk.Entries) {
+				t.Fatalf("retained entries = %d, on-disk entries = %d; the recovery append must be visible to the retained list", len(entries), len(onDisk.Entries))
+			}
+			// Same count and same last turn: the retained list ends where the
+			// file ends, so serve's projection fence cannot lag the file.
+			lastRetained, lastOnDisk := entries[len(entries)-1], onDisk.Entries[len(onDisk.Entries)-1]
+			if lastRetained.Turn.StableTurnID != lastOnDisk.Turn.StableTurnID ||
+				lastRetained.Turn.Kind != lastOnDisk.Turn.Kind ||
+				lastRetained.Turn.ClientMutationID != lastOnDisk.Turn.ClientMutationID {
+				t.Fatalf("last retained turn = %#v, want the on-disk last turn %#v", lastRetained.Turn, lastOnDisk.Turn)
+			}
+			if lastOnDisk.Turn.ClientMutationID != params.ClientMutationID {
+				t.Fatalf("on-disk last turn mutation = %q, want the recovered failure %q", lastOnDisk.Turn.ClientMutationID, params.ClientMutationID)
+			}
+			if lastOnDisk.Turn.StableTurnID != started.Turn.ID {
+				t.Fatalf("on-disk last stable turn = %q, want %q", lastOnDisk.Turn.StableTurnID, started.Turn.ID)
+			}
+		})
+	}
+}
+
 func TestClientMutation_InterruptWaitReleasesSerializerAndRunnerTerminalizesFence(t *testing.T) {
 	sess := newQueuePersistTestSession(t, t.TempDir())
 	defer sess.Close()

--- a/agent/session_config.go
+++ b/agent/session_config.go
@@ -317,7 +317,7 @@ type testConfig struct {
 	delegateAttentionReadFold func(string, string) (delegateAttentionFold, error)
 	// delegateAttentionFoldEntries replaces only the in-memory attention fold
 	// over restore-retained entries. Nil preserves the production fold.
-	delegateAttentionFoldEntries func([]transcript.Entry, string) (delegateAttentionFold, error)
+	delegateAttentionFoldEntries func([]transcript.Entry) (delegateAttentionFold, error)
 	// delegateAttentionOpenWriter replaces only transcript resume for attention
 	// repair. Nil preserves the production transcript opener.
 	delegateAttentionOpenWriter delegateAttentionWriterOpener

--- a/agent/session_config.go
+++ b/agent/session_config.go
@@ -21,6 +21,7 @@ import (
 	"primeradiant.com/evener/agent/sandbox"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/agent/task"
+	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/identifier"
 	"primeradiant.com/evener/llm"
 )
@@ -314,6 +315,9 @@ type testConfig struct {
 	// delegateAttentionReadFold replaces only resident attention verification
 	// reads. Nil preserves the production transcript fold.
 	delegateAttentionReadFold func(string, string) (delegateAttentionFold, error)
+	// delegateAttentionFoldEntries replaces only the in-memory attention fold
+	// over restore-retained entries. Nil preserves the production fold.
+	delegateAttentionFoldEntries func([]transcript.Entry, string) (delegateAttentionFold, error)
 	// delegateAttentionOpenWriter replaces only transcript resume for attention
 	// repair. Nil preserves the production transcript opener.
 	delegateAttentionOpenWriter delegateAttentionWriterOpener

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -420,7 +420,7 @@ func NewSession(client *llm.Client, profile *provider.Profile, env execenv.Execu
 	if err := s.flushPendingDelegateDeliveries(); err != nil {
 		return nil, fmt.Errorf("replay delegate deliveries: %w", err)
 	}
-	if err := s.rearmRootDelegateAttentionFromTranscript(); err != nil {
+	if err := s.rearmRootDelegateAttentionFromTranscriptReload(); err != nil {
 		return nil, fmt.Errorf("rearm root delegate attention: %w", err)
 	}
 
@@ -674,12 +674,16 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 	// every other open or parse error fails the resume closed.
 	var resumeTranscript *transcript.Writer
 	var transcriptEntries []transcript.Entry
+	var restoredTranscriptHeader transcript.Header
 	if cfg.StateDir != "" {
 		tpath := filepath.Join(cfg.StateDir, sessionsSubdir, meta.ID+".transcript.jsonl")
 		var openErr error
 		resumeTranscript, transcriptEntries, openErr = transcript.OpenWriterForSession(tpath, meta.ID)
 		if openErr != nil && !errors.Is(openErr, os.ErrNotExist) {
 			return nil, fmt.Errorf("open transcript for resume: %w", openErr)
+		}
+		if resumeTranscript != nil {
+			restoredTranscriptHeader = resumeTranscript.Header()
 		}
 	}
 	defer func() {
@@ -1015,8 +1019,10 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 			return nil, fmt.Errorf("refresh transcript after delegate delivery replay: header session %q does not match %q", refreshed.Header.SessionID, s.id)
 		}
 		transcriptEntries = refreshed.Entries
+		restoredTranscriptHeader = refreshed.Header
 	}
-	if err := s.rearmRootDelegateAttentionFromTranscript(); err != nil {
+	s.setRestoredTranscript(restoredTranscriptHeader, transcriptEntries)
+	if err := s.rearmRootDelegateAttentionFromTranscript(transcriptEntries); err != nil {
 		return nil, fmt.Errorf("rearm root delegate attention: %w", err)
 	}
 	if err := s.recoverClientMutationFailures(); err != nil {

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -420,7 +420,7 @@ func NewSession(client *llm.Client, profile *provider.Profile, env execenv.Execu
 	if err := s.flushPendingDelegateDeliveries(); err != nil {
 		return nil, fmt.Errorf("replay delegate deliveries: %w", err)
 	}
-	if err := s.rearmRootDelegateAttentionFromTranscriptReload(); err != nil {
+	if err := s.rearmRootDelegateAttentionFromTranscript(nil); err != nil {
 		return nil, fmt.Errorf("rearm root delegate attention: %w", err)
 	}
 
@@ -1004,6 +1004,24 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 		}
 	}
 	s.attachTranscript(tw)
+	// refreshFromDisk re-reads the transcript file whenever a restore-time
+	// replay appended turns it did not decode: the retained entry list would
+	// otherwise end at the last pre-append entry, and serve (which projects
+	// exactly this list) would seed its turn snapshot and live-turn-id fence
+	// one turn behind the file. Both refresh triggers share it so there is
+	// one refresh, not two mechanisms.
+	refreshFromDisk := func(reason string) error {
+		refreshed, err := readTranscriptFull(transcriptPath(s.stateDir, s.id))
+		if err != nil {
+			return fmt.Errorf("refresh transcript after %s: %w", reason, err)
+		}
+		if refreshed.Header.SessionID != s.id {
+			return fmt.Errorf("refresh transcript after %s: header session %q does not match %q", reason, refreshed.Header.SessionID, s.id)
+		}
+		transcriptEntries = refreshed.Entries
+		restoredTranscriptHeader = refreshed.Header
+		return nil
+	}
 	s.delegateDeliveryMu.Lock()
 	hadPendingDelegateDeliveries := len(s.pendingDelegateDeliveries) != 0
 	s.delegateDeliveryMu.Unlock()
@@ -1011,25 +1029,38 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 		return nil, fmt.Errorf("replay delegate deliveries: %w", err)
 	}
 	if tw != nil && hadPendingDelegateDeliveries {
-		refreshed, err := readTranscriptFull(transcriptPath(s.stateDir, s.id))
-		if err != nil {
-			return nil, fmt.Errorf("refresh transcript after delegate delivery replay: %w", err)
+		if err := refreshFromDisk("delegate delivery replay"); err != nil {
+			return nil, err
 		}
-		if refreshed.Header.SessionID != s.id {
-			return nil, fmt.Errorf("refresh transcript after delegate delivery replay: header session %q does not match %q", refreshed.Header.SessionID, s.id)
-		}
-		transcriptEntries = refreshed.Entries
-		restoredTranscriptHeader = refreshed.Header
 	}
-	s.setRestoredTranscript(restoredTranscriptHeader, transcriptEntries)
-	if err := s.rearmRootDelegateAttentionFromTranscript(transcriptEntries); err != nil {
-		return nil, fmt.Errorf("rearm root delegate attention: %w", err)
-	}
+	// Client-mutation failure recovery appends the turns the crashed process
+	// never got to write (recordClientMutationFailure's user and failure
+	// turns, plus the environment-context turn that can precede the user
+	// one inside the same !items.User block). The interrupt recovery writes
+	// nothing — it only terminalizes the journal fence — so only the failure
+	// path can append. Restored history and the durable identity index stay
+	// on the pre-recovery list on purpose: the recovered turns enter
+	// s.history directly (recordClientMutationFailure appends them itself).
 	if err := s.recoverClientMutationFailures(); err != nil {
 		return nil, fmt.Errorf("recover client mutation failures: %w", err)
 	}
 	if err := s.recoverClientMutationInterrupt(); err != nil {
 		return nil, fmt.Errorf("recover client mutation interrupt: %w", err)
+	}
+	s.mu.Lock()
+	clientMutationRecoveryAppended := s.clientMutationAppendedTurn
+	s.mu.Unlock()
+	if tw != nil && clientMutationRecoveryAppended {
+		if err := refreshFromDisk("client mutation recovery"); err != nil {
+			return nil, err
+		}
+	}
+	// setRestoredTranscript and the attention rearm both run after every
+	// restore-time transcript append, so serve and the fold see the same
+	// final entry list the file holds.
+	s.setRestoredTranscript(restoredTranscriptHeader, transcriptEntries)
+	if err := s.rearmRootDelegateAttentionFromTranscript(transcriptEntries); err != nil {
+		return nil, fmt.Errorf("rearm root delegate attention: %w", err)
 	}
 
 	if !restoreCfg.deferRestoreSideEffects {

--- a/agent/transcript/transcript.go
+++ b/agent/transcript/transcript.go
@@ -221,9 +221,10 @@ type Writer struct {
 	closed    atomic.Bool
 	// header is the validated header of the resumed transcript, retained
 	// from the resume scan so callers that already hold the decoded entries
-	// can project them without re-reading the file for its header. Zero for
-	// a writer that created a fresh transcript; NewWriter callers use
-	// HeaderOf / WriteFile for the same data.
+	// can project them without re-reading the file for its header.
+	// newWriterFS records the header it wrote, so Header() returns the real
+	// header for both fresh and resumed writers; only a writer whose header
+	// was never set — the zero-value Writer — reports a zero Header from it.
 	header Header
 
 	// SyncInterval controls how often Append calls fsync.

--- a/agent/transcript/transcript.go
+++ b/agent/transcript/transcript.go
@@ -219,6 +219,12 @@ type Writer struct {
 	seq       int
 	closeOnce sync.Once
 	closed    atomic.Bool
+	// header is the validated header of the resumed transcript, retained
+	// from the resume scan so callers that already hold the decoded entries
+	// can project them without re-reading the file for its header. Zero for
+	// a writer that created a fresh transcript; NewWriter callers use
+	// HeaderOf / WriteFile for the same data.
+	header Header
 
 	// SyncInterval controls how often Append calls fsync.
 	// If 0, every Append fsyncs (backward-compatible default for tests).
@@ -338,7 +344,18 @@ func newWriterFS(fs afero.Fs, path string, header Header, sync bool) (*Writer, e
 		}
 	}
 
-	return &Writer{fs: fs, file: f, lastSync: time.Now()}, nil
+	return &Writer{fs: fs, file: f, lastSync: time.Now(), header: header}, nil
+}
+
+// Header returns the transcript's validated header: the header this writer
+// wrote (NewWriter), or the one the resume scan validated
+// (OpenWriterForSession). Callers that already hold the decoded entries of
+// the same scan use it to project them without re-reading the file.
+func (w *Writer) Header() Header {
+	if w == nil {
+		return Header{}
+	}
+	return w.header
 }
 
 // Append writes a turn as an Entry to the JSONL file.
@@ -579,6 +596,7 @@ func resumeWriter(fs afero.Fs, f afero.File, expectedSessionID string) (*Writer,
 	var validLen int64
 	hasPartialTail := false
 	headerRead := false
+	var header Header
 	for {
 		line, complete, bytesRead, readErr := ReadLine(reader, transcriptJSONLMaxLineBytes)
 		if readErr != nil {
@@ -595,7 +613,8 @@ func resumeWriter(fs afero.Fs, f afero.File, expectedSessionID string) (*Writer,
 			continue
 		}
 		if !headerRead {
-			header, err := DecodeHeader(line)
+			var err error
+			header, err = DecodeHeader(line)
 			if err != nil {
 				_ = f.Close()
 				return nil, nil, fmt.Errorf("parse transcript header: %w", err)
@@ -645,5 +664,5 @@ func resumeWriter(fs afero.Fs, f afero.File, expectedSessionID string) (*Writer,
 		return nil, nil, fmt.Errorf("seek to end of transcript: %w", err)
 	}
 
-	return &Writer{fs: fs, file: f, seq: nextSeq, lastSync: time.Now()}, entries, nil
+	return &Writer{fs: fs, file: f, seq: nextSeq, lastSync: time.Now(), header: header}, entries, nil
 }

--- a/agent/transcript/transcript_test.go
+++ b/agent/transcript/transcript_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -36,6 +37,36 @@ func readTranscriptLines(t *testing.T, path string) []string {
 		t.Fatalf("scan transcript file: %v", err)
 	}
 	return lines
+}
+
+// TestWriter_HeaderReturnsWrittenHeaderOnFreshWriter pins that a fresh
+// NewWriter's Header() reports the header NewWriter wrote (with Kind and
+// FormatVersion filled in by the writer itself), not a zero value.
+func TestWriter_HeaderReturnsWrittenHeaderOnFreshWriter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	want := Header{SessionID: "hdr_fresh", ProfileID: "openai", Model: "gpt-5.2", SystemPrompt: "You are Evener."}
+	w, err := NewWriter(path, want)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer w.Close() //nolint:errcheck // read-only assertion fixture
+	got := w.Header()
+	if got.SessionID != want.SessionID || got.ProfileID != want.ProfileID || got.Model != want.Model || got.SystemPrompt != want.SystemPrompt {
+		t.Fatalf("fresh writer Header() = %#v, want the header NewWriter wrote %#v", got, want)
+	}
+	if got.Kind != "header" || got.FormatVersion != FormatVersion {
+		t.Fatalf("fresh writer Header() kind/version = %q/%d, want header/%d", got.Kind, got.FormatVersion, FormatVersion)
+	}
+}
+
+// TestWriter_HeaderOnNilWriterReturnsZeroHeader pins the nil-receiver
+// contract: a nil *Writer reports the zero Header rather than panicking.
+func TestWriter_HeaderOnNilWriterReturnsZeroHeader(t *testing.T) {
+	var w *Writer
+	if got := w.Header(); !reflect.DeepEqual(got, Header{}) {
+		t.Fatalf("nil writer Header() = %#v, want the zero Header", got)
+	}
 }
 
 // --- Fix 1: seq increment after successful write ---

--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -534,7 +534,16 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 	// transcript that cannot be projected is a session this daemon must not
 	// serve, because every read after it would silently start mid-conversation.
 	workspaceRef := appwire.Ref{SourceID: "local", ThreadID: sess.ID()}.String()
-	prepared, err := deps.prepareAppIdentity("local", sess.ID(), workspaceRef, sess.TranscriptPath())
+	var prepared server.PreparedAppIdentity
+	if header, entries, ok := sess.RestoredTranscript(); ok {
+		// Resume already strict-decoded this transcript once (restore's
+		// OpenWriterForSession pass) and validated its header against the
+		// session id; projecting from those entries keeps the daemon's
+		// startup from re-reading and re-decoding the whole append-only file.
+		prepared, err = server.PrepareAppIdentityFromEntries("local", sess.ID(), workspaceRef, header, entries)
+	} else {
+		prepared, err = deps.prepareAppIdentity("local", sess.ID(), workspaceRef, sess.TranscriptPath())
+	}
 	if err != nil {
 		sess.Close()
 		listener.Close() //nolint:errcheck // returning the preparation failure; the close error is not actionable

--- a/internal/apptranscript/apptranscript.go
+++ b/internal/apptranscript/apptranscript.go
@@ -649,60 +649,91 @@ func ImagesFromContent(parts []llm.ContentPart, imageProjector ImageProjector) [
 	return images
 }
 
-// TurnsFromFile projects a semantic transcript-v2 JSONL file into AppWire turns.
+// TurnsFromFile projects a semantic transcript-v2 JSONL file into AppWire
+// turns. The file is read exactly ONCE: the header this pass decodes is the
+// header whose prelude is emitted, and each entry is decoded once for
+// validation by the scanner and once by the projector callback (the
+// per-entry contract of EntryProjector, kata j13r).
 func TurnsFromFile(path string, maxLineBytes int, project EntryProjector) ([]appwire.Turn, error) {
 	var turns []appwire.Turn
-	preludeEmitted := false
-	entryIndex := 0
-	header, err := ScanPrelude(path, maxLineBytes)
-	if err != nil {
-		return nil, err
-	}
-	emitPrelude := func() {
-		if preludeEmitted {
-			return
-		}
-		preludeEmitted = true
-		if prelude := PreludeTurn(header); prelude != nil {
-			turns = append(turns, *prelude)
-		}
-	}
-	_, err = scanSemanticTranscript(path, maxLineBytes, func(raw json.RawMessage) error {
-		emitPrelude()
-		entryIndex++
-		// A malformed entry decodes to neither a projection nor a stamp: skip it
-		// (matching the pre-fix behavior, where a projector's own internal decode
-		// of the same malformed bytes would likewise fail and yield no items)
-		// rather than aborting the whole read over one bad line.
-		entry, decodeErr := transcript.DecodeEntry(raw)
-		if decodeErr != nil {
-			return nil //nolint:nilerr // skip a malformed entry rather than aborting the whole read over one bad line
-		}
-		turnID := persistedTurnID(entry.Turn, entryIndex)
-		var items []appwire.ThreadItem
-		if project != nil {
-			items = project(entry.Turn, turnID, entryIndex)
-		}
-		if len(items) == 0 {
-			return nil
-		}
-		turn := appwire.Turn{ID: turnID, Items: items, ItemsView: "full", Status: appwire.TurnStatusCompleted}
-		StampTurnFailure(&turn, entry.Turn)
-		if !entry.Turn.Timestamp.IsZero() {
-			startedAt := entry.Turn.Timestamp.UnixMilli()
-			turn.StartedAt = &startedAt
-		}
-		if usage := appwire.EvenerUsageFromLLM(entry.Turn.Usage); usage != nil {
-			turn.Usage = usage
-		}
-		turns = append(turns, turn)
+	entryIndexNext := 1
+	header, err := scanSemanticTranscript(path, maxLineBytes, func(raw json.RawMessage) error {
+		entryIndex := entryIndexNext
+		entryIndexNext++
+		projectEntryIntoTurns(&turns, project, raw, entryIndex)
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	emitPrelude()
+	// The prelude turn precedes every entry's turn: the pre-fix reader emitted
+	// it lazily at the first entry visit, which always lands it at position 0
+	// (and alone when the transcript has no entries). Prepending after the
+	// single pass reproduces that order without a second read.
+	if prelude := PreludeTurn(header); prelude != nil {
+		turns = append([]appwire.Turn{*prelude}, turns...)
+	}
 	return turns, nil
+}
+
+// TurnsFromEntries projects already-decoded transcript entries into AppWire
+// turns. header must be the header of the same transcript the entries came
+// from; it is what the prelude turn is emitted from.
+//
+// It shares TurnsFromFile's per-entry projection exactly, so both forms of
+// the same transcript produce identical turns: same turn ids (the same
+// 1-based entry indexing TurnsFromFile's scan produces), same prelude, same
+// failure/usage/timestamp stamping. Callers that hold only a path must use
+// TurnsFromFile.
+func TurnsFromEntries(header transcript.Header, entries []transcript.Entry, project EntryProjector) ([]appwire.Turn, error) {
+	var turns []appwire.Turn
+	for i := range entries {
+		projectTurnIntoTurns(&turns, project, entries[i].Turn, i+1)
+	}
+	// Same prelude position as TurnsFromFile: before every entry's turn.
+	if prelude := PreludeTurn(header); prelude != nil {
+		turns = append([]appwire.Turn{*prelude}, turns...)
+	}
+	return turns, nil
+}
+
+// projectEntryIntoTurns is the raw-JSON per-entry step TurnsFromFile's scan
+// runs. entryIndex is this entry's 1-based position over the whole scan,
+// incremented BEFORE the entry is decoded so a malformed line consumes its
+// index exactly as it does in the file scan.
+func projectEntryIntoTurns(turns *[]appwire.Turn, project EntryProjector, raw json.RawMessage, entryIndex int) {
+	// A malformed entry decodes to neither a projection nor a stamp: skip it
+	// (matching the pre-fix behavior, where a projector's own internal decode
+	// of the same malformed bytes would likewise fail and yield no items)
+	// rather than aborting the whole read over one bad line.
+	entry, decodeErr := transcript.DecodeEntry(raw)
+	if decodeErr != nil {
+		return
+	}
+	projectTurnIntoTurns(turns, project, entry.Turn, entryIndex)
+}
+
+// projectTurnIntoTurns is the decoded per-entry step both forms share: turn
+// id, items, failure stamp, timestamp, and usage.
+func projectTurnIntoTurns(turns *[]appwire.Turn, project EntryProjector, turn schema.Turn, entryIndex int) {
+	turnID := persistedTurnID(turn, entryIndex)
+	var items []appwire.ThreadItem
+	if project != nil {
+		items = project(turn, turnID, entryIndex)
+	}
+	if len(items) == 0 {
+		return
+	}
+	turnOut := appwire.Turn{ID: turnID, Items: items, ItemsView: "full", Status: appwire.TurnStatusCompleted}
+	StampTurnFailure(&turnOut, turn)
+	if !turn.Timestamp.IsZero() {
+		startedAt := turn.Timestamp.UnixMilli()
+		turnOut.StartedAt = &startedAt
+	}
+	if usage := appwire.EvenerUsageFromLLM(turn.Usage); usage != nil {
+		turnOut.Usage = usage
+	}
+	*turns = append(*turns, turnOut)
 }
 
 // persistedTurnID names the turn one persisted entry projects into.

--- a/internal/apptranscript/apptranscript.go
+++ b/internal/apptranscript/apptranscript.go
@@ -660,7 +660,7 @@ func TurnsFromFile(path string, maxLineBytes int, project EntryProjector) ([]app
 	header, err := scanSemanticTranscript(path, maxLineBytes, func(raw json.RawMessage) error {
 		entryIndex := entryIndexNext
 		entryIndexNext++
-		projectEntryIntoTurns(&turns, project, raw, entryIndex)
+		projectEntryIntoTurns(&turns, project, raw, schema.Turn{}, entryIndex)
 		return nil
 	})
 	if err != nil {
@@ -688,7 +688,7 @@ func TurnsFromFile(path string, maxLineBytes int, project EntryProjector) ([]app
 func TurnsFromEntries(header transcript.Header, entries []transcript.Entry, project EntryProjector) ([]appwire.Turn, error) {
 	var turns []appwire.Turn
 	for i := range entries {
-		projectTurnIntoTurns(&turns, project, entries[i].Turn, i+1)
+		projectEntryIntoTurns(&turns, project, nil, entries[i].Turn, i+1)
 	}
 	// Same prelude position as TurnsFromFile: before every entry's turn.
 	if prelude := PreludeTurn(header); prelude != nil {
@@ -697,25 +697,28 @@ func TurnsFromEntries(header transcript.Header, entries []transcript.Entry, proj
 	return turns, nil
 }
 
-// projectEntryIntoTurns is the raw-JSON per-entry step TurnsFromFile's scan
-// runs. entryIndex is this entry's 1-based position over the whole scan,
-// incremented BEFORE the entry is decoded so a malformed line consumes its
-// index exactly as it does in the file scan.
-func projectEntryIntoTurns(turns *[]appwire.Turn, project EntryProjector, raw json.RawMessage, entryIndex int) {
-	// A malformed entry decodes to neither a projection nor a stamp: skip it
-	// (matching the pre-fix behavior, where a projector's own internal decode
-	// of the same malformed bytes would likewise fail and yield no items)
-	// rather than aborting the whole read over one bad line.
-	entry, decodeErr := transcript.DecodeEntry(raw)
-	if decodeErr != nil {
-		return
+// projectEntryIntoTurns is the per-entry step both forms share: turn id,
+// items, failure stamp, timestamp, and usage. TurnsFromFile's scan passes
+// each raw entry, which this helper decodes; TurnsFromEntries passes the
+// already-decoded turn. entryIndex is the entry's 1-based position over the
+// whole scan.
+//
+// The malformed-entry skip is defense-in-depth for callers that pass raw
+// bytes: TurnsFromFile's own scanner aborts the whole read on a malformed
+// entry, so from that path the skip cannot fire. A caller that hands this
+// function raw bytes directly (bypassing the scan) still gets a skip rather
+// than a panic or a partial projection.
+func projectEntryIntoTurns(turns *[]appwire.Turn, project EntryProjector, raw json.RawMessage, turn schema.Turn, entryIndex int) {
+	if raw != nil {
+		// A malformed entry decodes to neither a projection nor a stamp: skip
+		// it rather than projecting partial items from bytes that failed to
+		// decode.
+		entry, decodeErr := transcript.DecodeEntry(raw)
+		if decodeErr != nil {
+			return
+		}
+		turn = entry.Turn
 	}
-	projectTurnIntoTurns(turns, project, entry.Turn, entryIndex)
-}
-
-// projectTurnIntoTurns is the decoded per-entry step both forms share: turn
-// id, items, failure stamp, timestamp, and usage.
-func projectTurnIntoTurns(turns *[]appwire.Turn, project EntryProjector, turn schema.Turn, entryIndex int) {
 	turnID := persistedTurnID(turn, entryIndex)
 	var items []appwire.ThreadItem
 	if project != nil {

--- a/internal/apptranscript/turnsfromentries_timing_test.go
+++ b/internal/apptranscript/turnsfromentries_timing_test.go
@@ -13,10 +13,12 @@ import (
 	"primeradiant.com/evener/llm"
 )
 
-// TestTurnsFromEntriesLargeFixtureTiming is a measurement, not a gate: it
-// times the file read against the in-memory entries projection over a large
-// synthetic transcript and reports both. It always passes; its value is the
-// printed ratio proving the entries form skips the file I/O + decode pass.
+// TestTurnsFromEntriesLargeFixtureTiming times the file read against the
+// in-memory entries projection over a large synthetic transcript and gates
+// on a generous ratio floor: the file form (scan + decode + project) must be
+// at least 3x slower than the entries form (project only). The floor is
+// deliberately loose so machine load cannot flake it — a regression that
+// erases the entries form's win has to cost more than 3x before this fails.
 func TestTurnsFromEntriesLargeFixtureTiming(t *testing.T) {
 	if testing.Short() {
 		t.Skip("timing measurement, not a correctness gate")
@@ -77,7 +79,11 @@ func TestTurnsFromEntriesLargeFixtureTiming(t *testing.T) {
 	t.Logf("fixture: %d entries, %d bytes (%.1f MB)", entryCount, info.Size(), float64(info.Size())/1024/1024)
 	t.Logf("file form (scan+decode+project): %v, turns=%d", fileElapsed, len(fileTurns))
 	t.Logf("entries form (project only):     %v, turns=%d", entriesElapsed, len(entryTurns))
-	t.Logf("ratio: %.1fx", float64(fileElapsed)/float64(entriesElapsed))
+	ratio := float64(fileElapsed) / float64(entriesElapsed)
+	t.Logf("ratio: %.1fx", ratio)
+	if ratio < 3 {
+		t.Fatalf("file form was only %.1fx slower than the entries form; the entries projection's skip of the file I/O + decode pass is its entire reason to exist", ratio)
+	}
 	if len(fileTurns) != len(entryTurns) {
 		t.Fatalf("turn counts diverge: file=%d entries=%d", len(fileTurns), len(entryTurns))
 	}

--- a/internal/apptranscript/turnsfromentries_timing_test.go
+++ b/internal/apptranscript/turnsfromentries_timing_test.go
@@ -1,0 +1,84 @@
+package apptranscript
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/llm"
+)
+
+// TestTurnsFromEntriesLargeFixtureTiming is a measurement, not a gate: it
+// times the file read against the in-memory entries projection over a large
+// synthetic transcript and reports both. It always passes; its value is the
+// printed ratio proving the entries form skips the file I/O + decode pass.
+func TestTurnsFromEntriesLargeFixtureTiming(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing measurement, not a correctness gate")
+	}
+	const entryCount = 20000
+	path := filepath.Join(t.TempDir(), "large.transcript.jsonl")
+	w, err := transcript.NewWriter(path, transcript.Header{
+		SessionID:    "th_large",
+		SystemPrompt: "You are Evener.",
+	})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	// The measurement is the READ side; the fixture write only needs the
+	// bytes on disk, so skip the per-append fsync the durability default pays.
+	w.SyncInterval = time.Hour
+	for i := range entryCount {
+		turn := schema.NewTurn(schema.TurnUserInput, llm.User(fmt.Sprintf("message %d with some body text to make the line realistic", i)))
+		turn.Usage = llm.Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15}
+		turn.Timestamp = time.Unix(1_700_000_000+int64(i), 0).UTC()
+		if err := w.Append(turn); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := func(turn schema.Turn, turnID string, entryIndex int) []appwire.ThreadItem {
+		return []appwire.ThreadItem{{Type: "userMessage", ID: turnID, TurnID: turnID, Text: turn.Message.Content[0].Text}}
+	}
+
+	// File form.
+	fileStart := time.Now()
+	fileTurns, err := TurnsFromFile(path, 1<<30, project)
+	if err != nil {
+		t.Fatalf("TurnsFromFile: %v", err)
+	}
+	fileElapsed := time.Since(fileStart)
+
+	// Entries form: decode once the way resume does, then project.
+	rw, entries, err := transcript.OpenWriterForSession(path, "th_large")
+	if err != nil {
+		t.Fatalf("OpenWriterForSession: %v", err)
+	}
+	_ = rw.Close() //nolint:errcheck // measurement fixture
+	entriesStart := time.Now()
+	entryTurns, err := TurnsFromEntries(rw.Header(), entries, project)
+	if err != nil {
+		t.Fatalf("TurnsFromEntries: %v", err)
+	}
+	entriesElapsed := time.Since(entriesStart)
+
+	t.Logf("fixture: %d entries, %d bytes (%.1f MB)", entryCount, info.Size(), float64(info.Size())/1024/1024)
+	t.Logf("file form (scan+decode+project): %v, turns=%d", fileElapsed, len(fileTurns))
+	t.Logf("entries form (project only):     %v, turns=%d", entriesElapsed, len(entryTurns))
+	t.Logf("ratio: %.1fx", float64(fileElapsed)/float64(entriesElapsed))
+	if len(fileTurns) != len(entryTurns) {
+		t.Fatalf("turn counts diverge: file=%d entries=%d", len(fileTurns), len(entryTurns))
+	}
+}

--- a/internal/apptranscript/turnsfromfile_singlepass_test.go
+++ b/internal/apptranscript/turnsfromfile_singlepass_test.go
@@ -1,0 +1,157 @@
+package apptranscript
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/llm"
+)
+
+// writeSinglePassFixture writes a transcript with header prelude content
+// (system prompt), user input, an assistant tool call, a tool result, and a
+// usage/timestamp-carrying assistant turn: every shape TurnsFromFile stamps.
+func writeSinglePassFixture(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "session.transcript.jsonl")
+	w, err := transcript.NewWriter(path, transcript.Header{
+		SessionID:    "th_single",
+		SystemPrompt: "You are Evener.",
+	})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	if err := w.Append(schema.NewTurn(schema.TurnUserInput, llm.User("run"))); err != nil {
+		t.Fatalf("append user: %v", err)
+	}
+	call := llm.ToolCallData{ID: "call_read", Name: "read_file", Arguments: json.RawMessage(`{"path":"a"}`)}
+	if err := w.Append(schema.Turn{Kind: schema.TurnAssistant, Message: llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{{Kind: llm.ContentToolCall, ToolCall: &call}}}}); err != nil {
+		t.Fatalf("append call: %v", err)
+	}
+	if err := w.Append(schema.NewTurn(schema.TurnToolResults, llm.ToolResultNamed("call_read", "read_file", "out", false))); err != nil {
+		t.Fatalf("append result: %v", err)
+	}
+	usageTurn := schema.NewTurn(schema.TurnAssistant, llm.Assistant("done"))
+	usageTurn.Usage = llm.Usage{InputTokens: 3, OutputTokens: 4, TotalTokens: 7}
+	usageTurn.Timestamp = ts
+	if err := w.Append(usageTurn); err != nil {
+		t.Fatalf("append usage: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return path
+}
+
+// singlePassProjector is the projector shape the server installs: it emits
+// one item per turn so len(turns) tracks the entry count, and reads the turn
+// it was handed (which is the point of the EntryProjector contract).
+func singlePassProjector(turn schema.Turn, turnID string, entryIndex int) []appwire.ThreadItem {
+	return []appwire.ThreadItem{{Type: "agentMessage", ID: turnID, TurnID: turnID, Text: string(turn.Kind)}}
+}
+
+// TestTurnsFromFileSinglePassMatchesEntriesForm is the differential proof for
+// the single-pass change: TurnsFromFile over the file must produce exactly
+// the turns TurnsFromEntries produces over the same transcript's decoded
+// header+entries, including the prelude turn, the turn ids (1-based entry
+// indexing), and the usage/timestamp stamps.
+func TestTurnsFromFileSinglePassMatchesEntriesForm(t *testing.T) {
+	path := writeSinglePassFixture(t)
+
+	fileTurns, err := TurnsFromFile(path, 1<<20, singlePassProjector)
+	if err != nil {
+		t.Fatalf("TurnsFromFile: %v", err)
+	}
+	w, entries, err := transcript.OpenWriterForSession(path, "th_single")
+	if err != nil {
+		t.Fatalf("OpenWriterForSession: %v", err)
+	}
+	defer w.Close() //nolint:errcheck // read-only fixture use
+	entryTurns, err := TurnsFromEntries(w.Header(), entries, singlePassProjector)
+	if err != nil {
+		t.Fatalf("TurnsFromEntries: %v", err)
+	}
+
+	if len(fileTurns) == 0 {
+		t.Fatal("fixture projected to zero turns; differential proof is vacuous")
+	}
+	if !reflect.DeepEqual(fileTurns, entryTurns) {
+		t.Fatalf("turns diverge:\nfile:    %#v\nentries: %#v", fileTurns, entryTurns)
+	}
+	// The prelude turn must survive the single-pass read in both forms.
+	sawPrelude := false
+	for _, turn := range fileTurns {
+		if turn.ID == appwire.SystemPreludeTurnID {
+			sawPrelude = true
+		}
+	}
+	if !sawPrelude {
+		t.Fatalf("single-pass read dropped the prelude turn; turn ids: %v", singlePassTurnIDs(fileTurns))
+	}
+}
+
+// TestTurnsFromFileSinglePassStillStampsUsageAndTimestamp pins the stamps the
+// per-entry projection applies, proving the shared projector kept them.
+func TestTurnsFromFileSinglePassStillStampsUsageAndTimestamp(t *testing.T) {
+	path := writeSinglePassFixture(t)
+	turns, err := TurnsFromFile(path, 1<<20, singlePassProjector)
+	if err != nil {
+		t.Fatalf("TurnsFromFile: %v", err)
+	}
+	var stamped *appwire.Turn
+	for i := range turns {
+		if turns[i].Usage != nil {
+			stamped = &turns[i]
+		}
+	}
+	if stamped == nil {
+		t.Fatalf("no turn carried usage; ids=%v", singlePassTurnIDs(turns))
+	}
+	if stamped.Usage.TotalTokens != 7 {
+		t.Fatalf("usage total tokens=%d, want 7", stamped.Usage.TotalTokens)
+	}
+	if stamped.StartedAt == nil || *stamped.StartedAt != time.Unix(1_700_000_000, 0).UTC().UnixMilli() {
+		t.Fatalf("usage turn StartedAt=%v, want the entry timestamp", stamped.StartedAt)
+	}
+}
+
+// TestTurnsFromFileSinglePassSkipsOversizeLine keeps the reader's line-limit
+// contract after the single-pass change (the limit previously gated the
+// separate ScanPrelude pass as well).
+func TestTurnsFromFileSinglePassSkipsOversizeLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oversize.transcript.jsonl")
+	header, err := json.Marshal(transcript.Header{Kind: "header", SessionID: "th_over"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, err := json.Marshal(schema.NewTurn(schema.TurnUserInput, llm.User("hi")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	big := append([]byte(nil), entry...)
+	for len(big) < 64 {
+		big = append(big, 'x')
+	}
+	if err := os.WriteFile(path, []byte(string(header)+"\n"+string(big)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := TurnsFromFile(path, 32, singlePassProjector); err == nil {
+		t.Fatal("oversize line was accepted")
+	}
+}
+
+func singlePassTurnIDs(turns []appwire.Turn) []string {
+	ids := make([]string, 0, len(turns))
+	for _, turn := range turns {
+		ids = append(ids, turn.ID)
+	}
+	return ids
+}

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -55,6 +55,35 @@ func PrepareAppIdentity(sourceID, threadID, transcriptPath string) (PreparedAppI
 	return PrepareAppIdentityForRef(sourceID, threadID, ref, transcriptPath)
 }
 
+// prepareAppIdentitySource is the already-projected half every
+// PrepareAppIdentity* entry point installs.
+type prepareAppIdentitySource struct {
+	turns            []appwire.Turn
+	persistedEntries int
+}
+
+// fromTranscriptFile is the file-reading source. A missing transcript is not
+// an error: the session simply has no persisted history to seed from. A
+// transcript whose header names a DIFFERENT session is an error -- seeding
+// one thread from another thread's history would publish a conversation
+// that never happened.
+func fromTranscriptFile(threadID, transcriptPath string) (prepareAppIdentitySource, error) {
+	var out prepareAppIdentitySource
+	if path := strings.TrimSpace(transcriptPath); path != "" {
+		header := transcriptHeader(path, appTranscriptMaxLineBytes)
+		if header.SessionID != "" && header.SessionID != threadID {
+			return out, fmt.Errorf("transcript %s belongs to session %s, not %s", path, header.SessionID, threadID)
+		}
+		projected, entries, err := appTurnsFromTranscriptFile(path)
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return out, err
+		}
+		out.turns = projected
+		out.persistedEntries = entries
+	}
+	return out, nil
+}
+
 // PrepareAppIdentityForRef is PrepareAppIdentity for a replacement that keeps
 // the same stable workspace ref while advancing the live session instance.
 // The projector must use that ref too: otherwise the first event after clear
@@ -74,29 +103,63 @@ func PrepareAppIdentityForRef(sourceID, threadID, ref, transcriptPath string) (P
 	if parsedRef.SourceID != sourceID {
 		return PreparedAppIdentity{}, fmt.Errorf("app identity ref belongs to source %s, not %s", parsedRef.SourceID, sourceID)
 	}
-	var turns []appwire.Turn
-	persistedEntries := 0
-	if path := strings.TrimSpace(transcriptPath); path != "" {
-		header := transcriptHeader(path, appTranscriptMaxLineBytes)
-		if header.SessionID != "" && header.SessionID != threadID {
-			return PreparedAppIdentity{}, fmt.Errorf("transcript %s belongs to session %s, not %s", path, header.SessionID, threadID)
-		}
-		projected, entries, err := appTurnsFromTranscriptFile(path)
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return PreparedAppIdentity{}, err
-		}
-		turns = projected
-		persistedEntries = entries
+	source, err := fromTranscriptFile(threadID, transcriptPath)
+	if err != nil {
+		return PreparedAppIdentity{}, err
 	}
+	return finishPreparedAppIdentity(sourceID, threadID, parsedRef, source)
+}
+
+// PrepareAppIdentityFromEntries is PrepareAppIdentityForRef for the resume
+// path: it projects the SAME transcript the session restore just
+// strict-decoded, instead of re-reading and re-decoding the file. header and
+// entries must come from that restore pass (OpenWriterForSession's resume
+// reader), which already validated the header's SessionID against threadID --
+// so a transcript naming a different session cannot reach this point, and
+// the error contract of the file form (a mismatch is an error) is preserved
+// by construction rather than by re-reading. Callers that cannot prove
+// that validation must use the file form.
+//
+// Everything else -- ref parsing, turn seeding, projector construction, and
+// the fence of live turn ids above the seeded ones -- is identical to
+// PrepareAppIdentityForRef.
+func PrepareAppIdentityFromEntries(sourceID, threadID, ref string, header transcript.Header, entries []transcript.Entry) (PreparedAppIdentity, error) {
+	if sourceID == "" {
+		sourceID = "local"
+	}
+	if strings.TrimSpace(threadID) == "" {
+		return PreparedAppIdentity{}, errors.New("thread id is required")
+	}
+	parsedRef, err := appwire.ParseRef(strings.TrimSpace(ref))
+	if err != nil {
+		return PreparedAppIdentity{}, fmt.Errorf("invalid app identity ref: %w", err)
+	}
+	if parsedRef.SourceID != sourceID {
+		return PreparedAppIdentity{}, fmt.Errorf("app identity ref belongs to source %s, not %s", parsedRef.SourceID, sourceID)
+	}
+	if header.SessionID != "" && header.SessionID != threadID {
+		return PreparedAppIdentity{}, fmt.Errorf("transcript header belongs to session %s, not %s", header.SessionID, threadID)
+	}
+	turns, persisted, err := appTurnsFromEntries(header, entries)
+	if err != nil {
+		return PreparedAppIdentity{}, err
+	}
+	return finishPreparedAppIdentity(sourceID, threadID, parsedRef, prepareAppIdentitySource{turns: turns, persistedEntries: persisted})
+}
+
+// finishPreparedAppIdentity validates the identity triple and installs the
+// projected source into a PreparedAppIdentity. It is the shared tail of
+// PrepareAppIdentityForRef and PrepareAppIdentityFromEntries.
+func finishPreparedAppIdentity(sourceID, threadID string, parsedRef appwire.Ref, source prepareAppIdentitySource) (PreparedAppIdentity, error) {
 	snapshot := &appTurnSnapshot{threadID: threadID}
-	snapshot.Seed(turns)
+	snapshot.Seed(source.turns)
 	// Fence the live turn ids above the seeded ones HERE, where the seed count
 	// is known, rather than waiting for the session's own SessionStart to carry
 	// it: nothing orders that event ahead of the first turn-starting request,
 	// and since this snapshot became the only turn authority a collision
 	// overwrites the seeded turn permanently.
 	projector := appprojector.NewAppEventProjector(threadID, parsedRef.String())
-	projector.SeedPersistedTurns(persistedEntries)
+	projector.SeedPersistedTurns(source.persistedEntries)
 	return PreparedAppIdentity{
 		sourceID:  sourceID,
 		threadID:  threadID,

--- a/server/appwire_turns.go
+++ b/server/appwire_turns.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/internal/appserver"
 	"primeradiant.com/evener/internal/apptranscript"
@@ -30,10 +31,10 @@ var (
 	appTurnsItemForDeltaHook func(*appwire.ThreadItem)
 )
 
-// appTurnsFromTranscriptFile projects a whole session transcript into AppWire
-// turns. This runs once per identity, at PrepareAppIdentity time, and never on
-// a read: the installed snapshot is the sole authority for every daemon turn
-// read, so nothing reopens this file to answer an RPC.
+// appTurnsFromTranscriptFile projects a whole session transcript file into
+// AppWire turns. This runs once per identity, at PrepareAppIdentity time, and
+// never on a read: the installed snapshot is the sole authority for every
+// daemon turn read, so nothing reopens this file to answer an RPC.
 //
 // It also reports the highest entry index the projection consumed. Persisted
 // turn ids are "turn_<entry index>", so that figure is the floor a live
@@ -48,6 +49,27 @@ func appTurnsFromTranscriptFile(path string) ([]appwire.Turn, int, error) {
 		return apptranscript.ProjectTurn(turnID, entryIndex, turn, toolNames, nil, apptranscript.ToolResultOutputImages)
 	})
 	return turns, entries, err
+}
+
+// appTurnsFromEntries projects already-decoded transcript entries into
+// AppWire turns. It is the in-memory form of appTurnsFromTranscriptFile: the
+// resume path strict-decodes the transcript once (OpenWriterForSession) and
+// hands the retained entries here rather than re-reading the file.
+//
+// The shared projector below guarantees the two forms agree: entry indexing
+// (and therefore every persisted turn id) is 1-based over the entries in
+// order, identical to the file scan's callback indexing, and the header is
+// the same header the file scan read.
+func appTurnsFromEntries(header transcript.Header, entries []transcript.Entry) ([]appwire.Turn, int, error) {
+	toolNames := map[string]string{}
+	highest := 0
+	turns, err := apptranscript.TurnsFromEntries(header, entries, func(turn schema.Turn, turnID string, entryIndex int) []appwire.ThreadItem {
+		if entryIndex > highest {
+			highest = entryIndex
+		}
+		return apptranscript.ProjectTurn(turnID, entryIndex, turn, toolNames, nil, apptranscript.ToolResultOutputImages)
+	})
+	return turns, highest, err
 }
 
 type appTurnSnapshot struct {

--- a/server/appwire_turns_differential_test.go
+++ b/server/appwire_turns_differential_test.go
@@ -1,0 +1,192 @@
+package server
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/llm"
+)
+
+// writeDifferentialFixture writes a transcript exercising every shape the
+// app-identity projection handles: prelude content (system prompt + agent
+// tasks) in the header, a user input, an assistant tool call and its result,
+// steering, a failed turn, and a usage-carrying model response.
+func writeDifferentialFixture(t *testing.T, sessionID string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), sessionID+".transcript.jsonl")
+	header := transcript.Header{
+		SessionID:    sessionID,
+		CreatedAt:    time.Unix(1_700_000_000, 0).UTC(),
+		ProfileID:    "openai",
+		Model:        "gpt-test",
+		SystemPrompt: "You are Evener.",
+	}
+	tw, err := transcript.NewWriter(path, header)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	appendTurn := func(turn schema.Turn) {
+		t.Helper()
+		if err := tw.Append(turn); err != nil {
+			t.Fatalf("append %s: %v", turn.Kind, err)
+		}
+	}
+	appendTurn(schema.NewTurn(schema.TurnUserInput, llm.User("run the fixture")))
+	call := llm.ToolCallData{ID: "call_read", Name: "read_file", Arguments: json.RawMessage(`{"path":"a.txt"}`)}
+	appendTurn(schema.Turn{Kind: schema.TurnAssistant, Message: llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{{Kind: llm.ContentToolCall, ToolCall: &call}}}})
+	appendTurn(schema.NewTurn(schema.TurnToolResults, llm.ToolResultNamed("call_read", "read_file", "line 1", false)))
+	appendTurn(schema.NewTurn(schema.TurnSteering, llm.User("steer")))
+	appendTurn(schema.NewTurn(schema.TurnFailure, llm.User("fails")))
+	appendTurn(schema.NewTurn(schema.TurnAssistant, llm.Assistant("done")))
+	usageTurn := schema.NewTurn(schema.TurnAssistant, llm.Assistant("counted"))
+	usageTurn.Usage = llm.Usage{InputTokens: 5, OutputTokens: 7, TotalTokens: 12}
+	usageTurn.Timestamp = time.Unix(1_700_000_100, 0).UTC()
+	appendTurn(usageTurn)
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return path
+}
+
+// restoreFixtureEntries opens the same fixture the way resume does, so the
+// entries handed to the entries form are the entries restore would retain.
+func restoreFixtureEntries(t *testing.T, path, sessionID string) (transcript.Header, []transcript.Entry) {
+	t.Helper()
+	w, entries, err := transcript.OpenWriterForSession(path, sessionID)
+	if err != nil {
+		t.Fatalf("open for session: %v", err)
+	}
+	defer w.Close() //nolint:errcheck // test fixture read
+	return w.Header(), entries
+}
+
+// TestPrepareAppIdentityFromEntriesMatchesFileProjection is the differential
+// proof for the resume handoff: the entries form must produce the identical
+// PreparedAppIdentity the file form does, over the same transcript bytes.
+func TestPrepareAppIdentityFromEntriesMatchesFileProjection(t *testing.T) {
+	const sessionID = "th_diff"
+	path := writeDifferentialFixture(t, sessionID)
+	header, entries := restoreFixtureEntries(t, path, sessionID)
+	if len(entries) == 0 {
+		t.Fatal("fixture produced no entries")
+	}
+
+	ref := appwire.Ref{SourceID: "local", ThreadID: sessionID}.String()
+	fromFile, err := PrepareAppIdentityForRef("local", sessionID, ref, path)
+	if err != nil {
+		t.Fatalf("file form: %v", err)
+	}
+	fromEntries, err := PrepareAppIdentityFromEntries("local", sessionID, ref, header, entries)
+	if err != nil {
+		t.Fatalf("entries form: %v", err)
+	}
+
+	fileSnapshot := snapshotTurns(t, fromFile)
+	entriesSnapshot := snapshotTurns(t, fromEntries)
+	if !reflect.DeepEqual(fileSnapshot, entriesSnapshot) {
+		t.Fatalf("turn snapshots diverge:\nfile:    %#v\nentries: %#v", fileSnapshot, entriesSnapshot)
+	}
+	if fromFile.threadID != fromEntries.threadID || fromFile.ref != fromEntries.ref {
+		t.Fatalf("identity diverges: %#v vs %#v", fromFile, fromEntries)
+	}
+	if len(fileSnapshot) == 0 {
+		t.Fatal("fixture projected to zero turns; differential proof is vacuous")
+	}
+}
+
+// TestPrepareAppIdentityFromEntriesMatchesFileTurnIDs pins the persisted
+// turn ids specifically: every id the entries form yields must be the exact
+// id the file form yields, in order (turn_<1-based entry index> or a reserved
+// StableTurnID), so the daemon fences live turn ids above the same floor
+// however the resume projection ran.
+func TestPrepareAppIdentityFromEntriesMatchesFileTurnIDs(t *testing.T) {
+	const sessionID = "th_ids"
+	path := writeDifferentialFixture(t, sessionID)
+	header, entries := restoreFixtureEntries(t, path, sessionID)
+
+	fileTurns, _, err := appTurnsFromTranscriptFile(path)
+	if err != nil {
+		t.Fatalf("file projection: %v", err)
+	}
+	entryTurns, _, err := appTurnsFromEntries(header, entries)
+	if err != nil {
+		t.Fatalf("entries projection: %v", err)
+	}
+	if len(fileTurns) == 0 {
+		t.Fatal("fixture projected to zero turns")
+	}
+	var fileIDs, entryIDs []string
+	for _, turn := range fileTurns {
+		fileIDs = append(fileIDs, turn.ID)
+	}
+	for _, turn := range entryTurns {
+		entryIDs = append(entryIDs, turn.ID)
+	}
+	if !reflect.DeepEqual(fileIDs, entryIDs) {
+		t.Fatalf("turn ids diverge:\nfile:    %v\nentries: %v", fileIDs, entryIDs)
+	}
+	// The id floor both forms report must also agree: it is what
+	// SeedPersistedTurns fences live turn ids above.
+	_, fileHighest, err := appTurnsFromTranscriptFile(path)
+	if err != nil {
+		t.Fatalf("file projection (floor): %v", err)
+	}
+	_, entriesHighest, err := appTurnsFromEntries(header, entries)
+	if err != nil {
+		t.Fatalf("entries projection (floor): %v", err)
+	}
+	if fileHighest != entriesHighest {
+		t.Fatalf("persisted entry floors diverge: file=%d entries=%d", fileHighest, entriesHighest)
+	}
+}
+
+// TestPrepareAppIdentityFromEntriesStillEmitsPrelude pins that the entries
+// form keeps the file form's prelude emission from the header.
+func TestPrepareAppIdentityFromEntriesStillEmitsPrelude(t *testing.T) {
+	const sessionID = "th_prelude"
+	path := writeDifferentialFixture(t, sessionID)
+	header, entries := restoreFixtureEntries(t, path, sessionID)
+
+	ref := appwire.Ref{SourceID: "local", ThreadID: sessionID}.String()
+	fromEntries, err := PrepareAppIdentityFromEntries("local", sessionID, ref, header, entries)
+	if err != nil {
+		t.Fatalf("entries form: %v", err)
+	}
+	found := false
+	for _, turn := range snapshotTurns(t, fromEntries) {
+		if turn.ID == appwire.SystemPreludeTurnID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("entries form dropped the prelude turn")
+	}
+}
+
+func snapshotTurns(t *testing.T, prepared PreparedAppIdentity) []appwire.Turn {
+	t.Helper()
+	if prepared.turns == nil {
+		t.Fatal("prepared identity carries no turn snapshot")
+	}
+	prepared.turns.mu.Lock()
+	defer prepared.turns.mu.Unlock()
+	return append([]appwire.Turn(nil), prepared.turns.turns...)
+}
+
+// TestPrepareAppIdentityFromEntriesRejectsForeignHeader keeps the file form's
+// session-identity error contract for the entries path.
+func TestPrepareAppIdentityFromEntriesRejectsForeignHeader(t *testing.T) {
+	const sessionID = "th_mismatch"
+	path := writeDifferentialFixture(t, sessionID)
+	header, entries := restoreFixtureEntries(t, path, sessionID)
+	header.SessionID = "th_other"
+	if _, err := PrepareAppIdentityFromEntries("local", sessionID, appwire.Ref{SourceID: "local", ThreadID: sessionID}.String(), header, entries); err == nil {
+		t.Fatal("entries form accepted a header naming a different session")
+	}
+}


### PR DESCRIPTION
## Summary

`evener serve --resume` previously strict-decoded the whole append-only transcript **five times across four full file reads** before writing its rendezvous entry — restore's `OpenWriterForSession` scan, the delegate-attention fold's re-read of the same file, and the app-identity projection's `TurnsFromFile` pass, which itself read the file twice (a full `ScanPrelude` pre-pass plus the projection scan) and decoded every entry three times. On a real 184MB / ~84.6k-entry transcript that is **>7 seconds of serial decode before the daemon is ready**; the hub's resume RPC waits on rendezvous with a 30s timeout and kills the child on expiry — the user-visible "resume stalls out" for large sessions.

This PR reduces resume to **exactly one strict decode** (restore's own scan), synchronously, with no new on-disk state, no ordering changes, and no behavior change outside the resume path.

## What changed

1. **Single-decode handoff, restore → projection.** `RestoreSessionFromMetaWithConfig` retains the validated header and the FINAL entry list (after the delegate-delivery refresh) on the Session (`Session.RestoredTranscript()`); serve's resume path projects the app identity from those entries via new `server.PrepareAppIdentityFromEntries` instead of re-reading the file. New `apptranscript.TurnsFromEntries` shares the per-entry projector with the file form so both produce identical turns. The file form remains for fresh sessions and thread/clear.
2. **`TurnsFromFile` reads the file once.** The `ScanPrelude` full-file pre-pass is dropped; the header this pass decodes is the header whose prelude is emitted. Malformed-entry handling and entry-index semantics are unchanged (the scanner aborts on malformed entries, so the per-entry skip is defense-in-depth for direct callers only — comments now say so).
3. **The attention fold uses in-memory entries.** `rearmRootDelegateAttentionFromTranscript` folds the retained entries instead of re-opening the file; the fresh-session path passes nil and takes the file read.
4. **Restore-tail recovery is visible to serve.** `setRestoredTranscript` and the attention rearm run AFTER `recoverClientMutationFailures`/`recoverClientMutationInterrupt`, with a shared `refreshFromDisk` closure (one mechanism backing both the pre-existing delegate-delivery refresh and the new client-mutation-recovery refresh) so the turns recovery appends are never invisible to the projection. Found by adversarial review with a reproduction; fixed in the second commit.

## Equivalence guarantees

- Differential tests pin the entries form to the file form: identical turn ids (`turn_<n>`), items, order, and prelude across fixtures with prelude content, tool calls, steering, failure, and usage turns (`server/appwire_turns_differential_test.go`).
- `TestRestoreSession_RestoredTranscriptIncludesClientMutationFailureRecovery` drives the failureRecording crash fixture over both crash boundaries and asserts `RestoredTranscript()` matches `readTranscriptFull` of the same file (same count, same last turn). Verified failing against the pre-fix code ("retained 2 vs on-disk 3") before the fix.
- `TestRootDelegateAttention_RearmFromTranscriptDoesNotOpenTheFile` deletes the transcript file before folding and proves the fold still resolves from retained entries.

## Measurements

- 20k-entry / 5.3MB fixture: file-form projection 235ms vs entries-form 6ms (**39x** on the projection step), gated by a 3x ratio floor in the timing test so it cannot pass as green noise.
- On the real 184MB transcript, four of five decode passes are eliminated **by construction** — the serial chain drops from >7s warm to ~1.2s (the one remaining decode), well under the hub's 30s budget.

## Not in this PR (filed as follow-ups)

- #642 — MCP init's 30s synchronous budget can alone consume the hub's resume timeout (likely the remaining ">30s" trigger; separate change).
- #643 — the one remaining full decode: validated-offset sidecar for the post-compaction suffix (Phase 2).
- #644 — turn-index sidecar ProjectionID collision blocking daemon-side reuse (Phase 3).
- #645 — hub-side `PastIndex.Rebuild` sweep in the resume window.
- #646 — `resumeWriter` returns nil entries for a header-only transcript (latent; boundary now pinned by test).
- #647 — serve-level wiring of the entries-based projection lacks a direct test.

## Testing

- `go build ./...` — exit 0
- `go vet ./...` — exit 0
- `make lint` — exit 0 (all 9 sub-targets)
- `make test` — exit 0 (root suite + agent + llm + auth + envvars + invariant + identifier + web)
- Targeted: `go test ./agent/ ./agent/transcript/ ./server/ ./internal/apptranscript/ ./cmd/evener/` — all ok

Review: implementation was adversarially reviewed (nine attack vectors + simplification pass); the drift bug fixed in 660ee377f was found by that review with a reproduction, and the fix wave applied seven adjudicated simplifications.

Fixes #642 partially (transcript reads) — see follow-ups above for the remainder.
