### PR TITLE
fix(agent): make tool schemas more robust across 5 tools

### DIFF
--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -1163,8 +1163,8 @@ func (runtime delegateRuntime) create(ctx context.Context, args delegateArgs) de
 	explicitSandbox := strings.TrimSpace(args.Sandbox) != "" || args.SandboxNet != nil
 	if explicitSandbox && args.SandboxNet != nil && strings.TrimSpace(args.Sandbox) == "" && !delegateSandboxBackendAvailable(s.sandboxHostFacts()) {
 		return delegateStartFailed(newDelegateSandboxRequestError(
-			errors.New("invalid_request: sandbox_net cannot be enforced on this host because no sandbox backend is available; omit sandbox_net"),
-			"sandbox_net",
+			errors.New("invalid_request: sandbox cannot be enforced on this host because no sandbox backend is available; omit the sandbox parameter"),
+			"sandbox",
 		))
 	}
 	if readOnlyScope {

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -97,24 +97,20 @@ func DefShell() llm.ToolDefinition {
 	}
 }
 
-// DelegateSandboxSchema describes the sandbox controls that the current
-// session can actually enforce. Available=false removes both sandbox knobs;
-// explicit values are still rejected by the handler rather than ignored.
-// Modes and NetworkValues are copied into the returned definition. An empty
-// NetworkValues leaves sandbox_net as an unconstrained boolean, which is the
-// portable full-capability schema used by DefDelegate.
+// DelegateSandboxSchema describes the sandbox control that the current
+// session can actually enforce. Available=false removes the sandbox knob;
+// an explicit value is still rejected by the handler rather than ignored.
+// Modes lists the mode names the parent floor permits (informational);
+// SandboxEnum (or, when empty, DelegateSandboxEnumFromModes over Modes)
+// becomes the sandbox property's enum: combined mode+network values such
+// as "read-only+nonet" and "nonet".
 type DelegateSandboxSchema struct {
-	Available                   bool
-	Modes                       []string
-	NetworkValues               []bool
-	RequireNonOffModeForNetwork bool
-	SandboxDescription          string
-	SandboxNetDescription       string
+	Available          bool
+	Modes              []string
+	SandboxDescription string
 	// SandboxEnum carries the precomputed combined sandbox+sandbox_net enum
-	// values (e.g. "off", "read-only", "read-only+nonet", "nonet"). When
-	// non-empty it replaces the separate sandbox and sandbox_net fields with
-	// a single sandbox field whose enum lists every valid combination, so the
-	// model can never send an invalid combo.
+	// values (e.g. "off", "read-only", "read-only+nonet", "nonet"). Empty
+	// derives the enum from Modes via DelegateSandboxEnumFromModes.
 	SandboxEnum []string
 	// ModelDescription is appended to the model override description when a
 	// caller has captured a bounded, startup-frozen availability snapshot.
@@ -215,10 +211,8 @@ func DefDelegateWithSandbox(agentTypes []string, sandboxSchema DelegateSandboxSc
 	}
 	if len(sandboxSchema.SandboxEnum) > 0 {
 		props["sandbox"].(map[string]any)["enum"] = append([]string(nil), sandboxSchema.SandboxEnum...)
-	} else if len(sandboxSchema.Modes) > 0 {
-		// Fallback: build enum from Modes (without +nonet variants) for
-		// callers that have not precomputed the combined enum.
-		props["sandbox"].(map[string]any)["enum"] = append([]string(nil), sandboxSchema.Modes...)
+	} else if enum := DelegateSandboxEnumFromModes(sandboxSchema.Modes, true, false); len(enum) > 0 {
+		props["sandbox"].(map[string]any)["enum"] = enum
 	} else {
 		// No usable sandbox mode; remove the control entirely.
 		delete(props, "sandbox")
@@ -229,6 +223,34 @@ func DefDelegateWithSandbox(agentTypes []string, sandboxSchema DelegateSandboxSc
 		}
 	}
 	return def
+}
+
+// DelegateSandboxEnumFromModes expands sandbox mode names into the combined
+// sandbox+sandbox_net enum values: each non-off mode produces a base value
+// (inherit parent network) and a +nonet variant (disable network). When the
+// parent network is off, only +nonet variants are emitted. Bare "nonet"
+// (inherit the parent's mode, disable network) is available under any non-off
+// parent with network on; when parentModeOff it is omitted, since network
+// confinement is meaningless without a sandbox.
+func DelegateSandboxEnumFromModes(modes []string, parentNetwork, parentModeOff bool) []string {
+	var values []string
+	for _, mode := range modes {
+		if mode == "off" {
+			values = append(values, "off")
+			continue
+		}
+		if parentNetwork {
+			// Parent has network: base value inherits network, +nonet disables it.
+			values = append(values, mode, mode+"+nonet")
+		} else {
+			// Parent network is off: only +nonet is enforceable.
+			values = append(values, mode+"+nonet")
+		}
+	}
+	if parentNetwork && !parentModeOff {
+		values = append(values, "nonet")
+	}
+	return values
 }
 
 // DefDelegateSend defines the delegate_send tool, the single follow-up surface

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -110,6 +110,12 @@ type DelegateSandboxSchema struct {
 	RequireNonOffModeForNetwork bool
 	SandboxDescription          string
 	SandboxNetDescription       string
+	// SandboxEnum carries the precomputed combined sandbox+sandbox_net enum
+	// values (e.g. "off", "read-only", "read-only+nonet", "nonet"). When
+	// non-empty it replaces the separate sandbox and sandbox_net fields with
+	// a single sandbox field whose enum lists every valid combination, so the
+	// model can never send an invalid combo.
+	SandboxEnum []string
 	// ModelDescription is appended to the model override description when a
 	// caller has captured a bounded, startup-frozen availability snapshot.
 	// Empty preserves the generic string contract.
@@ -187,11 +193,7 @@ func DefDelegateWithSandbox(agentTypes []string, sandboxSchema DelegateSandboxSc
 				"sandbox": map[string]any{
 					"type":        "string",
 					"enum":        []string{"off", "read-only", "workspace-write", "restricted"},
-					"description": "Run this delegate under its own sandbox, independent of your session. Modes: off = no confinement; read-only = reads anywhere but secret paths, no writes (a private temp dir only); workspace-write = reads anywhere but secret paths, writes the working tree; restricted = reads and writes only the working tree. All sandboxed modes mask credential/secret paths, give a private temp dir, and confine spawned shell commands too; network is a separate toggle (sandbox_net). Most useful with isolation=\"worktree\". The modes are a partial order: you may only pick a box at least as confining as your own on BOTH reads and writes — you cannot grant a delegate more access than you have. Omit to inherit your session's sandbox.",
-				},
-				"sandbox_net": map[string]any{
-					"type":        "boolean",
-					"description": "Whether the sandboxed delegate may use the network. Setting this to false disables all IP networking, including TCP, UDP, DNS, and loopback, and may break tests that start or connect to a local network server. Omit to inherit your session's setting. You cannot enable network for a delegate if your own session has it off.",
+					"description": "Run this delegate under its own sandbox, independent of your session. Each value encodes a sandbox mode and an optional network override: the base mode (e.g. \"read-only\") inherits your session's network; appending \"+nonet\" (e.g. \"read-only+nonet\") disables all IP networking. \"off\" = no confinement; \"read-only\" = reads anywhere but secret paths, no writes (a private temp dir only); \"workspace-write\" = reads anywhere but secret paths, writes the working tree; \"restricted\" = reads and writes only the working tree. All sandboxed modes mask credential/secret paths, give a private temp dir, and confine spawned shell commands too. \"nonet\" alone inherits your session's sandbox mode and disables network. Most useful with isolation=\"worktree\". The modes are a partial order: you may only pick a box at least as confining as your own on BOTH reads and writes — you cannot grant a delegate more access than you have. Omit to inherit your session's sandbox.",
 				},
 				"result_schema": map[string]any{
 					"type":                 "object",
@@ -208,46 +210,23 @@ func DefDelegateWithSandbox(agentTypes []string, sandboxSchema DelegateSandboxSc
 	}
 	if !sandboxSchema.Available {
 		delete(props, "sandbox")
-		delete(props, "sandbox_net")
-		def.Description += " This session's host cannot enforce per-delegate sandboxing, so `sandbox` and `sandbox_net` are unavailable; do not send them."
+		def.Description += " This session's host cannot enforce per-delegate sandboxing, so `sandbox` is unavailable; do not send it."
 		return def
 	}
-	if len(sandboxSchema.Modes) > 0 {
+	if len(sandboxSchema.SandboxEnum) > 0 {
+		props["sandbox"].(map[string]any)["enum"] = append([]string(nil), sandboxSchema.SandboxEnum...)
+	} else if len(sandboxSchema.Modes) > 0 {
+		// Fallback: build enum from Modes (without +nonet variants) for
+		// callers that have not precomputed the combined enum.
 		props["sandbox"].(map[string]any)["enum"] = append([]string(nil), sandboxSchema.Modes...)
 	} else {
-		// An available backend may still have no explicit mode that satisfies the
-		// parent's effective floor (for example, restricted plus WriteBlocked).
-		// Omit only the unusable mode control; sandbox_net remains available for
-		// the valid net-only tightening/inheritance path.
+		// No usable sandbox mode; remove the control entirely.
 		delete(props, "sandbox")
-	}
-	if len(sandboxSchema.NetworkValues) > 0 {
-		props["sandbox_net"].(map[string]any)["enum"] = append([]bool(nil), sandboxSchema.NetworkValues...)
-	}
-	if sandboxSchema.RequireNonOffModeForNetwork {
-		nonOffModes := make([]string, 0, len(sandboxSchema.Modes))
-		for _, mode := range sandboxSchema.Modes {
-			if mode != "off" {
-				nonOffModes = append(nonOffModes, mode)
-			}
-		}
-		def.Parameters["oneOf"] = []any{
-			map[string]any{"not": map[string]any{"required": []string{"sandbox_net"}}},
-			map[string]any{
-				"required": []string{"sandbox", "sandbox_net"},
-				"properties": map[string]any{
-					"sandbox": map[string]any{"enum": nonOffModes},
-				},
-			},
-		}
 	}
 	if sandboxSchema.SandboxDescription != "" {
 		if sandbox, ok := props["sandbox"].(map[string]any); ok {
 			sandbox["description"] = strings.TrimSpace(sandbox["description"].(string) + " " + sandboxSchema.SandboxDescription)
 		}
-	}
-	if sandboxSchema.SandboxNetDescription != "" {
-		props["sandbox_net"].(map[string]any)["description"] = strings.TrimSpace(props["sandbox_net"].(map[string]any)["description"].(string) + " " + sandboxSchema.SandboxNetDescription)
 	}
 	return def
 }
@@ -654,7 +633,7 @@ func DefTaskList(effortLevels []string) llm.ToolDefinition {
 				},
 				"updates": map[string]any{
 					"type":        "array",
-					"description": "For update: list of {id, status} pairs with optional notes.",
+					"description": "For update: list of {id} entries with optional status, notes, depends_on, or reasoning_effort.",
 					"items": map[string]any{
 						"type": "object",
 						"properties": map[string]any{
@@ -668,7 +647,7 @@ func DefTaskList(effortLevels []string) llm.ToolDefinition {
 							},
 							"reasoning_effort": reasoningSchema,
 						},
-						"required": []string{"id", "status"},
+						"required": []string{"id"},
 					},
 				},
 			},

--- a/agent/internal/tool/definitions_test.go
+++ b/agent/internal/tool/definitions_test.go
@@ -278,7 +278,15 @@ func TestDefDelegateHasSandboxParams(t *testing.T) {
 	if !ok {
 		t.Fatalf("sandbox enum = %T, want []string", sb["enum"])
 	}
-	wantEnum := []string{"off", "read-only", "workspace-write", "restricted"}
+	// DefDelegate is the portable full-capability surface: every mode plus
+	// its +nonet variant, plus bare "nonet" (net-only tightening).
+	wantEnum := []string{
+		"off",
+		"read-only", "read-only+nonet",
+		"workspace-write", "workspace-write+nonet",
+		"restricted", "restricted+nonet",
+		"nonet",
+	}
 	if !reflect.DeepEqual(enum, wantEnum) {
 		t.Errorf("sandbox enum = %v, want %v", enum, wantEnum)
 	}
@@ -287,32 +295,19 @@ func TestDefDelegateHasSandboxParams(t *testing.T) {
 		t.Errorf("sandbox description must explain the no-escalation floor, got %q", sbDesc)
 	}
 	// The modes must be glossed, not merely enumerated.
-	for _, want := range []string{"read-only", "workspace-write", "restricted", "no writes", "working tree", "network is a separate toggle"} {
+	for _, want := range []string{"read-only", "workspace-write", "restricted", "no writes", "working tree", "+nonet"} {
 		if !strings.Contains(sbDesc, want) {
 			t.Errorf("sandbox description must define the modes (missing %q), got %q", want, sbDesc)
 		}
 	}
 
-	sn, ok := props["sandbox_net"].(map[string]any)
-	if !ok {
-		t.Fatal("DefDelegate missing sandbox_net param")
+	// The combined-enum surface has no separate sandbox_net property and no
+	// oneOf pairing constraint: an invalid combo is unrepresentable.
+	if _, hasNet := props["sandbox_net"]; hasNet {
+		t.Fatal("DefDelegate must not expose a separate sandbox_net param")
 	}
-	if typ, _ := sn["type"].(string); typ != "boolean" {
-		t.Errorf("sandbox_net type = %q, want boolean", sn["type"])
-	}
-	// Pin the load-bearing semantics (matching the sandbox param's pinning strength):
-	// network-off consequences, inherit-on-omit behavior, and the no-escalation floor.
-	snDesc, _ := sn["description"].(string)
-	for _, want := range []string{"disables all IP networking", "local network server"} {
-		if !strings.Contains(snDesc, want) {
-			t.Errorf("sandbox_net must warn that network-off can break local-server tests (missing %q), got %q", want, snDesc)
-		}
-	}
-	if !strings.Contains(snDesc, "Omit to inherit") {
-		t.Errorf("sandbox_net must document inherit-on-omit with the exact contract phrase, got %q", snDesc)
-	}
-	if !strings.Contains(snDesc, "cannot enable network") {
-		t.Errorf("sandbox_net must document the network no-escalation floor, got %q", snDesc)
+	if _, hasOneOf := DefDelegate(nil).Parameters["oneOf"]; hasOneOf {
+		t.Fatal("DefDelegate must not carry a oneOf constraint")
 	}
 }
 

--- a/agent/internal/tool/repair/explain_covtest_test.go
+++ b/agent/internal/tool/repair/explain_covtest_test.go
@@ -514,7 +514,7 @@ func TestExplainSchemaError_ContainerPathMissingField(t *testing.T) {
 	params := taskListParamsForExplain()
 	args := map[string]any{
 		"action":  "update",
-		"updates": []any{map[string]any{"id": float64(1)}},
+		"updates": []any{map[string]any{"status": "done"}},
 	}
 	got := ExplainSchemaError("task_list", params, args, "updates/0", "")
 	if !strings.Contains(got, "missing required argument") || !strings.Contains(got, "updates[0]") {

--- a/agent/internal/tool/repair/explain_test.go
+++ b/agent/internal/tool/repair/explain_test.go
@@ -153,7 +153,7 @@ func taskListParamsForExplain() map[string]any {
 						"status": map[string]any{"type": "string", "enum": []string{"open", "in_progress", "done", "cancelled"}},
 						"notes":  map[string]any{"type": "string"},
 					},
-					"required": []string{"id", "status"},
+					"required": []string{"id"},
 				},
 			},
 		},
@@ -207,11 +207,11 @@ func TestExplainSchemaError_ArrayItemMissingRequiredField(t *testing.T) {
 	params := taskListParamsForExplain()
 	args := map[string]any{
 		"action":  "update",
-		"updates": []any{map[string]any{"id": float64(1), "notes": "x"}},
+		"updates": []any{map[string]any{"status": "done", "notes": "x"}},
 	}
 	got := ExplainSchemaError("task_list", params, args, "updates/0", "")
-	want := "task_list: missing required argument \"status\" in updates[0].\n" +
-		"Required arguments in updates[0]: id (integer), status (string).\n" +
+	want := "task_list: missing required argument \"id\" in updates[0].\n" +
+		"Required arguments in updates[0]: id (integer).\n" +
 		"Example: {\"action\": \"...\"}"
 	if got != want {
 		t.Fatalf("got:\n%s\nwant:\n%s", got, want)

--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -254,6 +254,10 @@ func normalizeWatchSource(source string) (watchSource, error) {
 	case "parent":
 		return watchSource{Kind: watchSourceParentSession, Public: "parent", Internal: runtimeMessageAliasCaller}, nil
 	default:
+		// Accept an optional "job:" prefix so both "job:job_123" and "job_123"
+		// resolve to the same concrete job. The transcript_ref convention uses
+		// the "job:" prefix; job_watch source should tolerate it for ergonomics.
+		source = strings.TrimPrefix(source, "job:")
 		if strings.HasPrefix(source, "job_") {
 			return watchSource{Kind: watchSourceConcreteJob, Public: source, Internal: source}, nil
 		}

--- a/agent/job_watch_branches_test.go
+++ b/agent/job_watch_branches_test.go
@@ -192,6 +192,18 @@ func TestNormalizeWatchSource(t *testing.T) {
 			t.Fatalf("Public = %q", src.Public)
 		}
 	})
+	t.Run("job id with job: prefix", func(t *testing.T) {
+		src, err := normalizeWatchSource("job:job_abc123")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if src.Kind != watchSourceConcreteJob {
+			t.Fatalf("Kind = %v", src.Kind)
+		}
+		if src.Public != "job_abc123" {
+			t.Fatalf("Public = %q, want job_abc123 (prefix stripped)", src.Public)
+		}
+	})
 	t.Run("delegate id", func(t *testing.T) {
 		src, err := normalizeWatchSource("dlg_abc123")
 		if err != nil {

--- a/agent/registry_schema_projection_test.go
+++ b/agent/registry_schema_projection_test.go
@@ -44,29 +44,28 @@ func TestProjectToolSchemaBehaviorMatrix(t *testing.T) {
 	}
 }
 
+// The real registry schemas must be projection-free: no core tool ships a
+// oneOf disjunction, so every schema goes through the plain generator path.
+// (The delegate tool's former sandbox/sandbox_net oneOf was replaced by a
+// single combined enum — an invalid combo is now unrepresentable rather than
+// excluded by a conditional.) projectToolSchema itself stays covered by
+// TestProjectToolSchemaBehaviorMatrix with synthetic fixtures.
 func TestProjectToolSchemaUsesRealCapableToolShape(t *testing.T) {
 	defs := coreToolSchemaDefs(t)
-	found := false
-	for _, td := range defs {
-		projection, err := projectToolSchema(td.params)
-		if err != nil {
-			continue
-		}
-		found = true
-		if projection.absent == nil || projection.present == nil {
-			t.Fatalf("tool %q projection arms = %#v", td.name, projection)
-		}
-		for _, arm := range []map[string]any{projection.absent, projection.present} {
-			for i := range 300 {
-				value := schemagen.Value(schemagen.NewByteSource([]byte{byte(i), byte(i >> 8), 0xa5}), arm, schemagen.Valid)
-				if err := td.schema.Validate(value); err != nil {
-					t.Fatalf("tool %q byte value %d rejected: %v; value=%#v", td.name, i, err, value)
-				}
-			}
-		}
+	if len(defs) == 0 {
+		t.Fatal("capable fixture exposed no tool schemas")
 	}
-	if !found {
-		t.Fatal("capable fixture exposed no projectable tool schema")
+	for _, td := range defs {
+		if _, err := projectToolSchema(td.params); !errors.Is(err, errProjectionNotNeeded) {
+			t.Fatalf("tool %q schema must not need projection, got %v", td.name, err)
+		}
+		generator, err := projectedToolGenerator(td.params)
+		if err != nil {
+			t.Fatalf("tool %q generator: %v", td.name, err)
+		}
+		if generator == nil {
+			t.Fatalf("tool %q produced no generator", td.name)
+		}
 	}
 }
 

--- a/agent/sandbox_delegate.go
+++ b/agent/sandbox_delegate.go
@@ -57,7 +57,7 @@ func rejectUnavailableDelegateSandboxControls(toolName string, parameters, args 
 	}
 	properties, _ := parameters["properties"].(map[string]any)
 	invalid := make([]string, 0, 2)
-	for _, field := range []string{"sandbox", "sandbox_net"} {
+	for _, field := range []string{"sandbox"} {
 		if _, supplied := args[field]; !supplied {
 			continue
 		}
@@ -95,15 +95,16 @@ func (s *Session) delegateSandboxSchemaForEnv(env execenv.ExecutionEnvironment) 
 	result := tool.DelegateSandboxSchema{
 		Available:          true,
 		Modes:              modes,
+		SandboxEnum:        buildDelegateSandboxEnum(modes, parentNetwork, parentMode == sandbox.ModeOff),
 		SandboxDescription: fmt.Sprintf("The current parent floor permits only these explicit modes: %s.", strings.Join(modes, ", ")),
 	}
 	if !parentNetwork {
-		result.NetworkValues = []bool{false}
-		result.SandboxNetDescription = "Your session has network disabled, so only sandbox_net=false is enforceable."
+		// Parent network is off: +nonet variants are the only network option
+		// and "nonet" alone is available. SandboxEnum already reflects this.
 	}
 	if parentMode == sandbox.ModeOff {
-		result.RequireNonOffModeForNetwork = true
-		result.SandboxNetDescription += " When sandbox is omitted or set to off, omit sandbox_net; a network setting requires a non-off sandbox mode."
+		// Parent mode is off: the combined enum already excludes invalid
+		// combos (off+nonet is meaningless since off applies no confinement).
 	}
 	return result
 }
@@ -117,6 +118,37 @@ func delegateSandboxBackendAvailable(host sandbox.HostFacts) bool {
 	default:
 		return false
 	}
+}
+// buildDelegateSandboxEnum computes the combined sandbox+sandbox_net enum
+// values for the delegate schema. Each non-off mode produces a base value
+// (inherit parent network) and a +nonet variant (disable network). When
+// the parent network is off, only +nonet variants are emitted. "off" is
+// alone inherits the parent's mode and disables network — it is available
+// under any non-off parent. When parentMode is off, "nonet" is omitted
+// (network confinement is meaningless without a sandbox, and the handler
+// rejects sandbox_net without a non-off mode under an off parent).
+func buildDelegateSandboxEnum(modes []string, parentNetwork, parentModeOff bool) []string {
+	var values []string
+	for _, mode := range modes {
+		if mode == "off" {
+			values = append(values, "off")
+			continue
+		}
+		if parentNetwork {
+			// Parent has network: base value inherits network, +nonet disables it.
+			values = append(values, mode)
+			values = append(values, mode+"+nonet")
+		} else {
+			// Parent network is off: only +nonet is enforceable.
+			values = append(values, mode+"+nonet")
+		}
+	}
+	// "nonet" alone (inherit parent mode, disable network) is available
+	// under a non-off parent with network on (it tightens the parent).
+	if parentNetwork && !parentModeOff {
+		values = append(values, "nonet")
+	}
+	return values
 }
 
 func (s *Session) prepareSubagentEnvironment(workingDir string, requested *sandbox.SandboxPolicy) (execenv.ExecutionEnvironment, bool, error) {

--- a/agent/sandbox_delegate.go
+++ b/agent/sandbox_delegate.go
@@ -95,16 +95,8 @@ func (s *Session) delegateSandboxSchemaForEnv(env execenv.ExecutionEnvironment) 
 	result := tool.DelegateSandboxSchema{
 		Available:          true,
 		Modes:              modes,
-		SandboxEnum:        buildDelegateSandboxEnum(modes, parentNetwork, parentMode == sandbox.ModeOff),
+		SandboxEnum:        tool.DelegateSandboxEnumFromModes(modes, parentNetwork, parentMode == sandbox.ModeOff),
 		SandboxDescription: fmt.Sprintf("The current parent floor permits only these explicit modes: %s.", strings.Join(modes, ", ")),
-	}
-	if !parentNetwork {
-		// Parent network is off: +nonet variants are the only network option
-		// and "nonet" alone is available. SandboxEnum already reflects this.
-	}
-	if parentMode == sandbox.ModeOff {
-		// Parent mode is off: the combined enum already excludes invalid
-		// combos (off+nonet is meaningless since off applies no confinement).
 	}
 	return result
 }
@@ -118,37 +110,6 @@ func delegateSandboxBackendAvailable(host sandbox.HostFacts) bool {
 	default:
 		return false
 	}
-}
-// buildDelegateSandboxEnum computes the combined sandbox+sandbox_net enum
-// values for the delegate schema. Each non-off mode produces a base value
-// (inherit parent network) and a +nonet variant (disable network). When
-// the parent network is off, only +nonet variants are emitted. "off" is
-// alone inherits the parent's mode and disables network — it is available
-// under any non-off parent. When parentMode is off, "nonet" is omitted
-// (network confinement is meaningless without a sandbox, and the handler
-// rejects sandbox_net without a non-off mode under an off parent).
-func buildDelegateSandboxEnum(modes []string, parentNetwork, parentModeOff bool) []string {
-	var values []string
-	for _, mode := range modes {
-		if mode == "off" {
-			values = append(values, "off")
-			continue
-		}
-		if parentNetwork {
-			// Parent has network: base value inherits network, +nonet disables it.
-			values = append(values, mode)
-			values = append(values, mode+"+nonet")
-		} else {
-			// Parent network is off: only +nonet is enforceable.
-			values = append(values, mode+"+nonet")
-		}
-	}
-	// "nonet" alone (inherit parent mode, disable network) is available
-	// under a non-off parent with network on (it tightens the parent).
-	if parentNetwork && !parentModeOff {
-		values = append(values, "nonet")
-	}
-	return values
 }
 
 func (s *Session) prepareSubagentEnvironment(workingDir string, requested *sandbox.SandboxPolicy) (execenv.ExecutionEnvironment, bool, error) {

--- a/agent/sandbox_delegate_contract_test.go
+++ b/agent/sandbox_delegate_contract_test.go
@@ -8,7 +8,6 @@ import (
 	"maps"
 	"os"
 	"reflect"
-	"slices"
 	"testing"
 
 	"github.com/santhosh-tekuri/jsonschema/v5"
@@ -119,14 +118,9 @@ func TestExecTool_UnsupportedHostRejectsExplicitSandboxControlsBeforeRepair(t *t
 			invalidParameters: []string{"sandbox"},
 		},
 		{
-			name:              "sandbox_net",
-			args:              map[string]any{"sandbox_net": true},
-			invalidParameters: []string{"sandbox_net"},
-		},
-		{
-			name:              "sandbox and sandbox_net",
-			args:              map[string]any{"sandbox": "read-only", "sandbox_net": true},
-			invalidParameters: []string{"sandbox", "sandbox_net"},
+			name:              "sandbox with nonet suffix",
+			args:              map[string]any{"sandbox": "read-only+nonet"},
+			invalidParameters: []string{"sandbox"},
 		},
 	}
 	for _, tc := range tests {
@@ -175,7 +169,7 @@ func TestExecTool_SupportedHostPreservesExplicitSandboxControls(t *testing.T) {
 		wantNetwork bool
 	}{
 		{
-			name:        "sandbox",
+			name:        "sandbox base mode",
 			parentMode:  sandbox.ModeOff,
 			parentNet:   true,
 			args:        map[string]any{"sandbox": "read-only"},
@@ -183,18 +177,18 @@ func TestExecTool_SupportedHostPreservesExplicitSandboxControls(t *testing.T) {
 			wantNetwork: true,
 		},
 		{
-			name:        "sandbox_net",
+			name:        "nonet suffix disables network",
 			parentMode:  sandbox.ModeReadOnly,
 			parentNet:   true,
-			args:        map[string]any{"sandbox_net": false},
+			args:        map[string]any{"sandbox": "read-only+nonet"},
 			wantMode:    sandbox.ModeReadOnly,
 			wantNetwork: false,
 		},
 		{
-			name:        "sandbox and sandbox_net",
+			name:        "nonet suffix on write-capable mode",
 			parentMode:  sandbox.ModeOff,
 			parentNet:   true,
-			args:        map[string]any{"sandbox": "workspace-write", "sandbox_net": false},
+			args:        map[string]any{"sandbox": "workspace-write+nonet"},
 			wantMode:    sandbox.ModeWorkspaceWrite,
 			wantNetwork: false,
 		},
@@ -332,10 +326,8 @@ func TestDelegateSchemaOmitsUnsupportedSandboxControls(t *testing.T) {
 	s := sbxDelegateSession(t, sandbox.HostFacts{OS: "linux", Home: home})
 	params := delegateDefinitionParameters(t, s)
 	props := delegateDefinitionProperties(t, s)
-	for _, name := range []string{"sandbox", "sandbox_net"} {
-		if _, ok := props[name]; ok {
-			t.Errorf("unsupported-host schema exposes %q", name)
-		}
+	if _, ok := props["sandbox"]; ok {
+		t.Errorf("unsupported-host schema exposes %q", "sandbox")
 	}
 	compiled := compileDelegateParameters(t, params)
 	requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work"}, true)
@@ -349,17 +341,16 @@ func TestDelegateSchemaHonorsParentConfinementAndNetwork(t *testing.T) {
 		parentMode         sandbox.Mode
 		parentNetwork      bool
 		parentWriteBlocked bool
-		wantModes          []string
-		wantNetworks       []bool
+		wantSandboxEnum    []string
 	}{
-		{name: "off parent", parentMode: sandbox.ModeOff, parentNetwork: true, wantModes: []string{"off", "read-only", "workspace-write", "restricted"}},
-		{name: "read-only parent", parentMode: sandbox.ModeReadOnly, parentNetwork: true, wantModes: []string{"read-only"}},
-		{name: "workspace-write parent", parentMode: sandbox.ModeWorkspaceWrite, parentNetwork: true, wantModes: []string{"read-only", "workspace-write", "restricted"}},
-		{name: "restricted parent", parentMode: sandbox.ModeRestricted, parentNetwork: true, wantModes: []string{"restricted"}},
-		{name: "write-blocked read-only parent", parentMode: sandbox.ModeReadOnly, parentNetwork: true, parentWriteBlocked: true, wantModes: []string{"read-only"}},
-		{name: "write-blocked restricted parent", parentMode: sandbox.ModeRestricted, parentNetwork: true, parentWriteBlocked: true},
-		{name: "write-blocked workspace-write parent", parentMode: sandbox.ModeWorkspaceWrite, parentNetwork: true, parentWriteBlocked: true, wantModes: []string{"read-only"}},
-		{name: "network-off parent", parentMode: sandbox.ModeWorkspaceWrite, parentNetwork: false, wantModes: []string{"read-only", "workspace-write", "restricted"}, wantNetworks: []bool{false}},
+		{name: "off parent", parentMode: sandbox.ModeOff, parentNetwork: true, wantSandboxEnum: []string{"off", "read-only", "read-only+nonet", "workspace-write", "workspace-write+nonet", "restricted", "restricted+nonet"}},
+		{name: "read-only parent", parentMode: sandbox.ModeReadOnly, parentNetwork: true, wantSandboxEnum: []string{"read-only", "read-only+nonet", "nonet"}},
+		{name: "workspace-write parent", parentMode: sandbox.ModeWorkspaceWrite, parentNetwork: true, wantSandboxEnum: []string{"read-only", "read-only+nonet", "workspace-write", "workspace-write+nonet", "restricted", "restricted+nonet", "nonet"}},
+		{name: "restricted parent", parentMode: sandbox.ModeRestricted, parentNetwork: true, wantSandboxEnum: []string{"restricted", "restricted+nonet", "nonet"}},
+		{name: "write-blocked read-only parent", parentMode: sandbox.ModeReadOnly, parentNetwork: true, parentWriteBlocked: true, wantSandboxEnum: []string{"read-only", "read-only+nonet", "nonet"}},
+		{name: "write-blocked restricted parent", parentMode: sandbox.ModeRestricted, parentNetwork: true, parentWriteBlocked: true, wantSandboxEnum: []string{"nonet"}},
+		{name: "write-blocked workspace-write parent", parentMode: sandbox.ModeWorkspaceWrite, parentNetwork: true, parentWriteBlocked: true, wantSandboxEnum: []string{"read-only", "read-only+nonet", "nonet"}},
+		{name: "network-off parent", parentMode: sandbox.ModeWorkspaceWrite, parentNetwork: false, wantSandboxEnum: []string{"read-only+nonet", "workspace-write+nonet", "restricted+nonet"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -368,45 +359,35 @@ func TestDelegateSchemaHonorsParentConfinementAndNetwork(t *testing.T) {
 			setParentSandboxForContractWithWriteBlocked(t, s, sbxBwrapFacts(home), lane, tc.parentMode, tc.parentNetwork, tc.parentWriteBlocked)
 			params := delegateDefinitionParameters(t, s)
 			props := delegateDefinitionProperties(t, s)
-			if len(tc.wantModes) == 0 {
+			if len(tc.wantSandboxEnum) == 0 {
 				if _, ok := props["sandbox"]; ok {
 					t.Fatalf("sandbox property exposed for parent with no accepted explicit modes: %#v", props["sandbox"])
 				}
 				compiled := compileDelegateParameters(t, params)
 				requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox": "restricted"}, false)
-				requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox_net": false}, true)
+				requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox_net": false}, false)
 				return
 			}
+			if _, ok := props["sandbox_net"]; ok {
+				t.Fatalf("schema exposes a sandbox_net property; the combined enum replaced it: %#v", props["sandbox_net"])
+			}
+			if _, hasOneOf := params["oneOf"]; hasOneOf {
+				t.Fatalf("schema carries a oneOf constraint; the combined enum replaced it: %#v", params["oneOf"])
+			}
 			sandboxSchema := props["sandbox"].(map[string]any)
-			if got := sandboxSchema["enum"]; !reflect.DeepEqual(got, tc.wantModes) {
-				t.Fatalf("sandbox enum = %#v, want %#v", got, tc.wantModes)
-			}
-			netSchema := props["sandbox_net"].(map[string]any)
-			if len(tc.wantNetworks) == 0 {
-				if _, ok := netSchema["enum"]; ok {
-					t.Fatalf("sandbox_net unexpectedly constrained: %#v", netSchema["enum"])
-				}
-			} else if got := netSchema["enum"]; !reflect.DeepEqual(got, tc.wantNetworks) {
-				t.Fatalf("sandbox_net enum = %#v, want %#v", got, tc.wantNetworks)
-			}
-			_, hasConditionalNetworkRule := params["oneOf"]
-			if got, want := hasConditionalNetworkRule, tc.parentMode == sandbox.ModeOff; got != want {
-				t.Fatalf("off-parent network condition present = %v, want %v", got, want)
+			if got := sandboxSchema["enum"]; !reflect.DeepEqual(got, tc.wantSandboxEnum) {
+				t.Fatalf("sandbox enum = %#v, want %#v", got, tc.wantSandboxEnum)
 			}
 
 			compiled := compileDelegateParameters(t, params)
-			for _, mode := range []string{"off", "read-only", "workspace-write", "restricted"} {
-				requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox": mode}, slices.Contains(tc.wantModes, mode))
+			// Every advertised combined value is schema-valid; an off+nonet combo
+			// (which the combined enum never lists) is schema-invalid, and a legacy
+			// sandbox_net property is rejected by additionalProperties:false.
+			for _, value := range tc.wantSandboxEnum {
+				requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox": value}, true)
 			}
-			nonOffMode := tc.wantModes[len(tc.wantModes)-1]
-			for _, network := range []bool{false, true} {
-				wantValid := len(tc.wantNetworks) == 0 || slices.Contains(tc.wantNetworks, network)
-				requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox": nonOffMode, "sandbox_net": network}, wantValid)
-			}
-			if tc.parentMode == sandbox.ModeOff {
-				requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox": "off", "sandbox_net": false}, false)
-				requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox_net": false}, false)
-			}
+			requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox": "off+nonet"}, false)
+			requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox_net": false}, false)
 		})
 	}
 }
@@ -422,11 +403,15 @@ func TestExecTool_WriteBlockedParentSchemaAndRuntimeContract(t *testing.T) {
 
 	params := delegateDefinitionParameters(t, s)
 	props := delegateDefinitionProperties(t, s)
-	if _, ok := props["sandbox"]; ok {
-		t.Fatal("write-blocked restricted parent schema advertises an unusable sandbox mode control")
+	sandboxSchema, ok := props["sandbox"].(map[string]any)
+	if !ok {
+		t.Fatal("write-blocked restricted parent schema omitted the sandbox property that carries the net-only control")
 	}
-	if _, ok := props["sandbox_net"]; !ok {
-		t.Fatal("write-blocked restricted parent schema removed the valid sandbox_net control")
+	if got := sandboxSchema["enum"]; !reflect.DeepEqual(got, []string{"nonet"}) {
+		t.Fatalf("write-blocked restricted parent sandbox enum = %#v, want [\"nonet\"] (net-only tightening only)", got)
+	}
+	if _, ok := props["sandbox_net"]; ok {
+		t.Fatal("write-blocked restricted parent schema exposes a sandbox_net property; the combined enum replaced it")
 	}
 	var wiredProps map[string]any
 	for _, def := range s.profileWireToolDefs() {
@@ -439,21 +424,26 @@ func TestExecTool_WriteBlockedParentSchemaAndRuntimeContract(t *testing.T) {
 	if wiredProps == nil {
 		t.Fatal("provider wire definitions omitted delegate")
 	}
-	if _, ok := wiredProps["sandbox"]; ok {
-		t.Fatal("provider wire schema advertises an unusable sandbox mode control")
+	if _, ok := wiredProps["sandbox"]; !ok {
+		t.Fatal("provider wire schema omitted the sandbox property that carries the net-only control")
 	}
-	if _, ok := wiredProps["sandbox_net"]; !ok {
-		t.Fatal("provider wire schema removed the valid sandbox_net control")
+	if _, ok := wiredProps["sandbox_net"]; ok {
+		t.Fatal("provider wire schema exposes a sandbox_net property; the combined enum replaced it")
 	}
 	compiled := compileDelegateParameters(t, params)
 	requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox": "restricted"}, false)
-	requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox_net": false}, true)
+	requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox_net": false}, false)
+	requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox": "nonet"}, true)
 
+	// "restricted" is not in the advertised enum, so schema prevalidation rejects
+	// it before the handler ever sees it: a PrevalOnly error with no delegate launch.
 	restricted := execDelegateForContract(t, s, map[string]any{"task": "do work", "sandbox": "restricted"})
-	requireDelegateSandboxExecError(t, restricted, []string{"sandbox"})
+	if !restricted.IsError || !restricted.PrevalOnly {
+		t.Fatalf("restricted exec result = %#v, want a prevalidation rejection (IsError=true, PrevalOnly=true)", restricted)
+	}
 	requireNoDelegatePreRepairState(t, s)
 
-	netOnly := execDelegateForContract(t, s, map[string]any{"task": "do work", "sandbox_net": false})
+	netOnly := execDelegateForContract(t, s, map[string]any{"task": "do work", "sandbox": "nonet"})
 	if netOnly.IsError {
 		t.Fatalf("write-blocked parent net-only tightening failed: %#v", netOnly)
 	}
@@ -543,9 +533,9 @@ func TestStableDelegateCreateTool_UnsupportedHostRejectsNetworkOnly(t *testing.T
 	_, home := sbxLane(t)
 	s := sbxDelegateSession(t, sandbox.HostFacts{OS: "linux", Home: home})
 	_, err := stableDelegateCreateTool(context.Background(), s, map[string]any{
-		"task":        "do work",
-		"sandbox_net": false,
+		"task":    "do work",
+		"sandbox": "nonet",
 	}, 8192)
-	requireDelegateSandboxRequestError(t, err, []string{"sandbox_net"})
+	requireDelegateSandboxRequestError(t, err, []string{"sandbox"})
 	requireNoDelegateLaunch(t, s)
 }

--- a/agent/session_tool_repair_oneof_test.go
+++ b/agent/session_tool_repair_oneof_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 
@@ -83,14 +84,7 @@ func TestDelegateSandboxSchemaNoOneOfOrSandboxNet(t *testing.T) {
 	}
 	// Verify combined enum values are present.
 	for _, want := range []string{"off", "read-only", "read-only+nonet", "nonet"} {
-		found := false
-		for _, v := range enum {
-			if v == want {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(enum, want) {
 			t.Fatalf("sandbox enum missing %q: %v", want, enum)
 		}
 	}

--- a/agent/session_tool_repair_oneof_test.go
+++ b/agent/session_tool_repair_oneof_test.go
@@ -11,18 +11,22 @@ import (
 	"primeradiant.com/evener/llm"
 )
 
-// Issue #618 regression: a delegate call that trips the oneOf
-// sandbox/sandbox_net pairing constraint (parent sandbox mode off, sandbox
-// backend available) must be rejected with an error naming that constraint —
-// not "Required arguments: task (string)", which sends the model resending a
-// task it already sent. This exercises the real prevalidation seam
-// (prepareToolCall → Schema.Validate → repair → ExplainSchemaError) with the
-// exact argument shape observed in session 034FsgXdyimiBvbubPlB4w.
-func TestPrepareToolCall_DelegateOneOfConstraintExplainedHonestly(t *testing.T) {
+// The delegate sandbox schema now uses a single `sandbox` enum encoding both
+// mode and network (e.g. "read-only+nonet") instead of separate `sandbox` +
+// `sandbox_net` fields with a oneOf constraint. These tests verify the new
+// behavior: a legacy `sandbox_net` field is dropped as unknown by repair (it
+// is no longer in the schema), and the handler rejects invalid combos like
+// "off+nonet" (off applies no network confinement) with a clear error naming
+// the `sandbox` field.
+
+// Test: a delegate call with a legacy `sandbox_net` field should have that
+// field dropped by repair (additionalProperties: false), and the call should
+// NOT be rejected at prevalidation — the oneOf constraint no longer exists.
+func TestPrepareToolCall_DelegateLegacySandboxNetDropped(t *testing.T) {
 	def := tool.DefDelegateWithSandbox([]string{"subagent"}, tool.DelegateSandboxSchema{
-		Available:                   true,
-		Modes:                       []string{"off", "read-only", "workspace-write", "restricted"},
-		RequireNonOffModeForNetwork: true,
+		Available:   true,
+		Modes:       []string{"off", "read-only", "workspace-write", "restricted"},
+		SandboxEnum: []string{"off", "read-only", "read-only+nonet", "workspace-write", "workspace-write+nonet", "restricted", "restricted+nonet", "nonet"},
 	})
 	reg := tool.NewRegistry()
 	if err := reg.Register(regTool(def)); err != nil {
@@ -31,51 +35,86 @@ func TestPrepareToolCall_DelegateOneOfConstraintExplainedHonestly(t *testing.T) 
 	rt := reg.Get("delegate")
 
 	call := llm.ToolCallData{
-		ID:   "issue618",
+		ID:   "legacy-net",
 		Name: "delegate",
 		Arguments: json.RawMessage(`{"task":"ping","agent_type":"subagent","isolation":"worktree",` +
 			`"sandbox":"off","sandbox_net":true,"reasoning_effort":"low","delegation_allowance":0}`),
 	}
 	res := prepareToolCall(call, rt, []string{"delegate"}, "delegate", "")
-	if res.PrevalErr == "" {
-		t.Fatalf("expected prevalidation failure for oneOf-violating delegate args, got none (changes: %v)", res.Changes)
+	// sandbox_net is no longer in the schema, so it must be dropped — not
+	// cause a prevalidation error. The oneOf constraint is gone.
+	if res.PrevalErr != "" {
+		t.Fatalf("expected no prevalidation failure (oneOf removed), got: %q (changes: %v)", res.PrevalErr, res.Changes)
 	}
-	if strings.Contains(res.PrevalErr, "Required arguments: task") {
-		t.Fatalf("oneOf failure misattributed to missing 'task' (issue #618): %q", res.PrevalErr)
+	// Verify sandbox_net was dropped.
+	foundDrop := false
+	for _, ch := range res.Changes {
+		if strings.Contains(ch.Detail, "sandbox_net") && strings.Contains(ch.Detail, "dropped") {
+			foundDrop = true
+		}
 	}
-	if !strings.Contains(res.PrevalErr, "sandbox") {
-		t.Fatalf("error does not name the constrained fields: %q", res.PrevalErr)
+	if !foundDrop {
+		t.Fatalf("expected sandbox_net to be dropped as unknown, changes: %v", res.Changes)
 	}
 }
 
-// The same call through execTool must surface the honest error to the model.
-// Host facts are injected (backend-capable, parent mode off) so the delegate
-// schema carries the oneOf constraint on every host — without this the test
-// passes vacuously on backend-less hosts where the schema drops the sandbox
-// fields and the runtime's "controls unavailable" error satisfies the
-// assertions without exercising the oneOf path.
-func TestExecTool_DelegateOneOfConstraintErrorNamed(t *testing.T) {
+// Test: the schema has no oneOf constraint — sandbox_net is not a property.
+func TestDelegateSandboxSchemaNoOneOfOrSandboxNet(t *testing.T) {
+	def := tool.DefDelegateWithSandbox([]string{"subagent"}, tool.DelegateSandboxSchema{
+		Available:   true,
+		Modes:       []string{"off", "read-only", "workspace-write", "restricted"},
+		SandboxEnum: []string{"off", "read-only", "read-only+nonet", "workspace-write", "workspace-write+nonet", "restricted", "restricted+nonet", "nonet"},
+	})
+	params := def.Parameters
+	if _, hasOneOf := params["oneOf"]; hasOneOf {
+		t.Fatal("schema still has a oneOf constraint")
+	}
+	props := params["properties"].(map[string]any)
+	if _, hasNet := props["sandbox_net"]; hasNet {
+		t.Fatal("schema still has sandbox_net property")
+	}
+	sandboxProp, ok := props["sandbox"].(map[string]any)
+	if !ok {
+		t.Fatal("schema missing sandbox property")
+	}
+	enum, ok := sandboxProp["enum"].([]string)
+	if !ok {
+		t.Fatal("sandbox property missing enum")
+	}
+	// Verify combined enum values are present.
+	for _, want := range []string{"off", "read-only", "read-only+nonet", "nonet"} {
+		found := false
+		for _, v := range enum {
+			if v == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("sandbox enum missing %q: %v", want, enum)
+		}
+	}
+}
+
+// Test: the handler rejects sandbox="off+nonet" (off has no network
+// confinement) with a clear error naming the sandbox field.
+func TestExecTool_DelegateOffPlusNonetRejectedByHandler(t *testing.T) {
 	s := sbxDelegateSession(t, sandbox.HostFacts{OS: "linux", Home: t.TempDir(), BwrapPath: "/usr/bin/bwrap", BwrapCapable: true})
 	if err := registerStableDelegateTool(s.reg, s); err != nil {
 		t.Fatalf("register delegate tool: %v", err)
 	}
 	res := s.execTool(context.Background(), llm.ToolCallData{
-		ID:        "issue618-exec",
+		ID:        "off-nonet",
 		Name:      "delegate",
-		Arguments: json.RawMessage(`{"task":"ping","sandbox":"off","sandbox_net":true}`),
+		Arguments: json.RawMessage(`{"task":"ping","sandbox":"off+nonet"}`),
 	}, "")
 	if !res.IsError {
-		t.Fatalf("expected error for oneOf-violating delegate args, got: %s", res.FullOutput)
+		t.Fatalf("expected error for off+nonet (off has no network confinement), got: %s", res.FullOutput)
 	}
 	if strings.Contains(res.FullOutput, "Required arguments: task") {
-		t.Fatalf("model-visible error misattributes failure to missing 'task' (issue #618): %s", res.FullOutput)
-	}
-	// A vacuous pass on a backend-less host produces the controls-unavailable
-	// refusal instead of a oneOf explanation; fail loudly on that shape.
-	if strings.Contains(res.FullOutput, "sandbox controls unavailable") {
-		t.Fatalf("test passed vacuously: delegate schema lacks the oneOf constraint on this host: %s", res.FullOutput)
+		t.Fatalf("error misattributes failure to missing 'task': %s", res.FullOutput)
 	}
 	if !strings.Contains(res.FullOutput, "sandbox") {
-		t.Fatalf("error does not name the constrained fields: %s", res.FullOutput)
+		t.Fatalf("error does not name the sandbox field: %s", res.FullOutput)
 	}
 }

--- a/agent/session_tool_repair_test.go
+++ b/agent/session_tool_repair_test.go
@@ -197,12 +197,12 @@ func TestPrepareToolCall_NestedSchemaErrors_NameRealFieldAndContainer(t *testing
 		t.Fatalf("register ask_user: %v", err)
 	}
 
-	t.Run("task_list update missing status", func(t *testing.T) {
+	t.Run("task_list update missing id", func(t *testing.T) {
 		call := llm.ToolCallData{ID: "c1", Name: "task_list",
-			Arguments: json.RawMessage(`{"action":"update","updates":[{"id":1,"notes":"x"}]}`)}
+			Arguments: json.RawMessage(`{"action":"update","updates":[{"status":"done","notes":"x"}]}`)}
 		res := prepareToolCall(call, reg.Get("task_list"), []string{"task_list"}, "task_list", "")
-		want := "task_list: missing required argument \"status\" in updates[0].\n" +
-			"Required arguments in updates[0]: id (integer), status (string).\n" +
+		want := "task_list: missing required argument \"id\" in updates[0].\n" +
+			"Required arguments in updates[0]: id (integer).\n" +
 			"Example: {\"action\": \"...\"}"
 		if res.PrevalErr != want {
 			t.Fatalf("PrevalErr =\n%s\nwant:\n%s", res.PrevalErr, want)

--- a/agent/session_tools_jobs.go
+++ b/agent/session_tools_jobs.go
@@ -350,21 +350,36 @@ func decodeDelegateArgs(args map[string]any) (delegateArgs, error) {
 		ReasoningEffort: stringArg(args, "reasoning_effort"),
 		WatchParent:     shellBoolArg(args, "watch_parent"),
 		Isolation:       stringArg(args, "isolation"),
-		Sandbox:         stringArg(args, "sandbox"),
+		Sandbox:         stringArg(args, "sandbox"), // may carry "+nonet" suffix or be "nonet" alone
 	}
-	// sandbox_net is a tri-state: absent stays nil so the delegate INHERITS the
-	// parent's network; present carries the explicit choice. A missing key must not
-	// read as false — that would silently force network off. A present-but-non-boolean
-	// value (e.g. the string "false" from a non-strict provider) is refused rather
-	// than silently decoded as inherit — the same silent no-op this surface refuses
-	// elsewhere (net-without-mode, net-with-off).
-	switch v := args["sandbox_net"].(type) {
-	case nil:
-		// omitted → inherit
-	case bool:
-		a.SandboxNet = &v
-	default:
-		return delegateArgs{}, errors.New("invalid_request: sandbox_net must be a JSON boolean (true or false, not a quoted string)")
+	// The sandbox field now encodes both mode and an optional network override
+	// in a single enum value. Values like "read-only+nonet" split into mode=
+	// "read-only" and sandbox_net=false. "nonet" alone means inherit the
+	// parent's mode and disable network. The legacy separate sandbox_net
+	// boolean field is no longer part of the schema, but we still accept it
+	// from in-process callers that build args directly (tests, scripted
+	// providers) so existing test fixtures don't break.
+	sandboxVal := strings.TrimSpace(a.Sandbox)
+	if sandboxVal == "nonet" || strings.HasSuffix(sandboxVal, "+nonet") {
+		// "nonet" alone (inherit parent mode, disable network) and any
+		// "<mode>+nonet" suffix both decode to a net-off request. The bare
+		// "nonet" value is advertised by the combined enum for non-off
+		// parents, so it must split here exactly like "+nonet".
+		mode := strings.TrimSuffix(sandboxVal, "+nonet")
+		if mode == "nonet" {
+			mode = ""
+		}
+		a.Sandbox = mode
+		netFalse := false
+		a.SandboxNet = &netFalse
+	}
+	if rawNet, exists := args["sandbox_net"]; exists {
+		switch v := rawNet.(type) {
+		case bool:
+			a.SandboxNet = &v
+		default:
+			return delegateArgs{}, errors.New("invalid_request: sandbox_net must be a JSON boolean (true or false, not a quoted string)")
+		}
 	}
 	// delegation_allowance: 0/absent = leaf delegate (cannot delegate); positive
 	// = grant; negative = invalid_request. Zero reads as unset (strict-zero rule).

--- a/agent/session_tools_test.go
+++ b/agent/session_tools_test.go
@@ -198,14 +198,17 @@ func TestDelegateSurfaceUsesAgentRegistryCapabilities(t *testing.T) {
 	wantSandboxEnum := []string{
 		sandbox.ModeOff.String(),
 		sandbox.ModeReadOnly.String(),
+		sandbox.ModeReadOnly.String() + "+nonet",
 		sandbox.ModeWorkspaceWrite.String(),
+		sandbox.ModeWorkspaceWrite.String() + "+nonet",
 		sandbox.ModeRestricted.String(),
+		sandbox.ModeRestricted.String() + "+nonet",
 	}
 	if !slices.Equal(sandboxEnum, wantSandboxEnum) {
 		t.Fatalf("sandbox enum = %v, want %v", sandboxEnum, wantSandboxEnum)
 	}
-	if got := props["sandbox_net"].(map[string]any)["type"]; got != "boolean" {
-		t.Fatalf("sandbox_net type = %v, want boolean", got)
+	if _, hasNet := props["sandbox_net"]; hasNet {
+		t.Fatal("sandbox_net property should not exist in the combined-enum schema")
 	}
 
 	data := sess.buildPromptData(sess.currentEnv())

--- a/agent/session_tools_transcript.go
+++ b/agent/session_tools_transcript.go
@@ -381,13 +381,15 @@ func validateJobReadArgs(args map[string]any, operation retainedReadOperation) e
 	if !formatSet {
 		return nil
 	}
+	if strings.TrimSpace(fmt.Sprint(format)) == formatMarkdown {
+		// markdown is the default view; it is always compatible with offset_bytes
+		// and output_match on job: refs, so accept it as a no-op format hint.
+		return nil
+	}
 	if operation != retainedReadDefault {
 		return errors.New("invalid_request: format cannot be combined with offset_bytes or output_match on job: refs")
 	}
-	if strings.TrimSpace(fmt.Sprint(format)) != formatMarkdown {
-		return errors.New("invalid_request: job: refs support only format=markdown")
-	}
-	return nil
+	return errors.New("invalid_request: job: refs support only format=markdown")
 }
 
 func compileOutputMatch(expression string) (*regexp.Regexp, error) {

--- a/agent/session_tools_transcript_branches_test.go
+++ b/agent/session_tools_transcript_branches_test.go
@@ -2459,7 +2459,7 @@ func TestExecReadTranscriptJobPageFormatRejected(t *testing.T) {
 	_, err := execReadTranscript(deps, map[string]any{
 		"transcript_ref": "job:abc",
 		"offset_bytes":   float64(0),
-		"format":         "markdown",
+		"format":         "outline",
 	})
 	if err == nil || !strings.Contains(err.Error(), "format cannot be combined") {
 		t.Fatalf("expected format+offset error, got %v", err)
@@ -2471,7 +2471,7 @@ func TestExecReadTranscriptJobSearchFormatRejected(t *testing.T) {
 	_, err := execReadTranscript(deps, map[string]any{
 		"transcript_ref": "job:abc",
 		"output_match":   "x",
-		"format":         "markdown",
+		"format":         "outline",
 	})
 	if err == nil || !strings.Contains(err.Error(), "format cannot be combined") {
 		t.Fatalf("expected format+search error, got %v", err)

--- a/agent/session_tools_transcript_branches_test.go
+++ b/agent/session_tools_transcript_branches_test.go
@@ -181,9 +181,21 @@ func TestValidateJobReadArgs(t *testing.T) {
 		}
 	})
 	t.Run("format with offset rejected", func(t *testing.T) {
-		err := validateJobReadArgs(map[string]any{"format": "markdown", "offset_bytes": float64(1)}, retainedReadPage)
+		err := validateJobReadArgs(map[string]any{"format": "jsonl", "offset_bytes": float64(1)}, retainedReadPage)
 		if err == nil || !strings.Contains(err.Error(), "format cannot be combined") {
 			t.Fatalf("expected format+offset error, got %v", err)
+		}
+	})
+	t.Run("format markdown with offset accepted", func(t *testing.T) {
+		err := validateJobReadArgs(map[string]any{"format": "markdown", "offset_bytes": float64(1)}, retainedReadPage)
+		if err != nil {
+			t.Fatalf("expected markdown+offset to be accepted, got %v", err)
+		}
+	})
+	t.Run("format markdown with output_match accepted", func(t *testing.T) {
+		err := validateJobReadArgs(map[string]any{"format": "markdown", "output_match": "READY"}, retainedReadSearch)
+		if err != nil {
+			t.Fatalf("expected markdown+output_match to be accepted, got %v", err)
 		}
 	})
 	t.Run("format non-markdown", func(t *testing.T) {

--- a/agent/session_tools_transcript_job_read_test.go
+++ b/agent/session_tools_transcript_job_read_test.go
@@ -542,8 +542,9 @@ func TestReadTranscriptJobPageAndSearchValidation(t *testing.T) {
 		want []string
 	}{
 		{name: "outline format", args: map[string]any{"transcript_ref": "job:" + jobID, "format": "outline"}, want: []string{"invalid_request", "format"}},
-		{name: "markdown plus page", args: map[string]any{"transcript_ref": "job:" + jobID, "format": "markdown", "offset_bytes": float64(0)}, want: []string{"invalid_request", "format", "offset_bytes"}},
-		{name: "markdown plus search", args: map[string]any{"transcript_ref": "job:" + jobID, "format": "markdown", "output_match": "line"}, want: []string{"invalid_request", "format", "output_match"}},
+		{name: "outline format plus page", args: map[string]any{"transcript_ref": "job:" + jobID, "format": "outline", "offset_bytes": float64(0)}, want: []string{"invalid_request", "format", "offset_bytes"}},
+		{name: "outline format plus search", args: map[string]any{"transcript_ref": "job:" + jobID, "format": "outline", "output_match": "line"}, want: []string{"invalid_request", "format", "output_match"}},
+		{name: "jsonl format plus search", args: map[string]any{"transcript_ref": "job:" + jobID, "format": "jsonl", "output_match": "line"}, want: []string{"invalid_request", "format", "output_match"}},
 		{name: "range", args: map[string]any{"transcript_ref": "job:" + jobID, "range": "1-2"}, want: []string{"invalid_request", "range", "session"}},
 		{name: "expand turn", args: map[string]any{"transcript_ref": "job:" + jobID, "expand_turn": float64(0)}, want: []string{"invalid_request", "expand_turn", "session"}},
 		{name: "invalid re2", args: map[string]any{"transcript_ref": "job:" + jobID, "output_match": "["}, want: []string{"invalid_request", "output_match"}},
@@ -562,6 +563,25 @@ func TestReadTranscriptJobPageAndSearchValidation(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// markdown is the default view, so an explicit format=markdown must be
+// accepted alongside offset_bytes and output_match on job: refs.
+func TestReadTranscriptJobMarkdownWithPageAndSearchAccepted(t *testing.T) {
+	stateDir := t.TempDir()
+	owner := identifier.MustNewSessionID()
+	jobID := identifier.MustNewJobID(owner)
+	const output = "line\n"
+	seedLocalJobRecord(t, stateDir, owner, jobID, "/decoy", output, maxJobOutputRetentionBytes, false, 0, nil)
+	deps := &toolDeps{stateDir: stateDir, sessionID: owner}
+
+	page := execRead(t, deps, map[string]any{"transcript_ref": "job:" + jobID, "format": "markdown", "offset_bytes": float64(0)})
+	requirePage(t, page, 0, "line\n")
+
+	search := execRead(t, deps, map[string]any{"transcript_ref": "job:" + jobID, "format": "markdown", "output_match": "line"})
+	if search["job_status"] == "" {
+		t.Fatalf("search result missing job_status: %#v", search)
 	}
 }
 

--- a/agent/session_tools_worktree.go
+++ b/agent/session_tools_worktree.go
@@ -2506,10 +2506,18 @@ func (s *Session) worktreeList(ctx context.Context) ([]WorktreeListEntry, error)
 				// inviting its removal, so it needs no unknown marker.
 				if tipOut, tErr := run("-C", e.Path, "rev-parse", "HEAD"); tErr == nil {
 					tip := strings.TrimSpace(tipOut)
-					if mr, mErr := worktree.Merged(run, tip, entry.MergeTarget, entry.BaseSHA); mErr == nil {
-						entry.Merged = mr.Merged
-						entry.MergedArm = mr.Arm
-						entry.MergeTargetUnknown = mr.TargetUnknown
+					// A 0-commit lane (tip == baseSHA) is "unchanged", not
+					// "merged": isAncestor(base, main) is trivially true since
+					// the branch was cut from main, but that is not evidence of
+					// a merge — it is the absence of any work to merge. Skip
+					// the Merged check so the lane reads as "0 ahead" rather
+					// than the misleading "merged".
+					if tip != entry.BaseSHA {
+						if mr, mErr := worktree.Merged(run, tip, entry.MergeTarget, entry.BaseSHA); mErr == nil {
+							entry.Merged = mr.Merged
+							entry.MergedArm = mr.Arm
+							entry.MergeTargetUnknown = mr.TargetUnknown
+						}
 					}
 				}
 			}

--- a/agent/session_tools_worktree_branches_test.go
+++ b/agent/session_tools_worktree_branches_test.go
@@ -632,6 +632,34 @@ func TestWorktreeListSummaryWithUnmanaged(t *testing.T) {
 	}
 }
 
+// TestWorktreeListSummaryZeroAheadNotMerged verifies a 0-commit lane (0 ahead,
+// not merged) renders as "0 ahead" without the misleading "merged" label.
+// The list operation skips the Merged check when tip == baseSHA (0 commits)
+// because isAncestor(base, main) is trivially true but is not evidence of a
+// merge.
+func TestWorktreeListSummaryZeroAheadNotMerged(t *testing.T) {
+	entries := []WorktreeListEntry{
+		{Name: "fresh-lane", AheadCommits: 0, Dirty: false, Merged: false},
+	}
+	result := worktreeListSummary(entries, nil)
+	if !strings.Contains(result, "0 ahead") {
+		t.Fatalf("expected '0 ahead' in summary: %q", result)
+	}
+	if !strings.Contains(result, "unmerged") {
+		t.Fatalf("0-commit lane should show as unmerged: %q", result)
+	}
+	// Ensure it does NOT show as "merged" (the misleading label for 0-commit
+	// lanes). Check that "merged" only appears as part of "unmerged", not as
+	// the standalone "merged" label.
+	for _, line := range strings.Split(result, "\n") {
+		if strings.Contains(line, " fresh-lane ") {
+			if strings.Contains(line, " merged") && !strings.Contains(line, "unmerged") {
+				t.Fatalf("0-commit lane should not show as merged: %q", result)
+			}
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // worktreeListEntryToMap
 // ---------------------------------------------------------------------------

--- a/agent/session_tools_worktree_branches_test.go
+++ b/agent/session_tools_worktree_branches_test.go
@@ -651,7 +651,7 @@ func TestWorktreeListSummaryZeroAheadNotMerged(t *testing.T) {
 	// Ensure it does NOT show as "merged" (the misleading label for 0-commit
 	// lanes). Check that "merged" only appears as part of "unmerged", not as
 	// the standalone "merged" label.
-	for _, line := range strings.Split(result, "\n") {
+	for line := range strings.SplitSeq(result, "\n") {
 		if strings.Contains(line, " fresh-lane ") {
 			if strings.Contains(line, " merged") && !strings.Contains(line, "unmerged") {
 				t.Fatalf("0-commit lane should not show as merged: %q", result)


### PR DESCRIPTION
## Summary

Five robustness improvements to tool schemas and handlers, making the model-facing surface less error-prone.

## Changes

### 1. delegate sandbox: oneOf → combined enum
Replaced the two-field `sandbox` (string enum) + `sandbox_net` (boolean) with a `oneOf` constraint with a **single combined `sandbox` enum** encoding both mode and network:
- `"read-only"` — inherit parent network
- `"read-only+nonet"` — disable network
- `"nonet"` — inherit parent mode, disable network (non-off parents only)
- `"off"` — no confinement

The model can now express any valid combo without hitting a `oneOf` violation. `decodeDelegateArgs` splits the `+nonet` suffix into mode + `sandbox_net=false` for the handler.

**Files:** `definitions.go`, `sandbox_delegate.go`, `session_tools_jobs.go`, `delegate_runtime.go`

### 2. task_list update: status optional
Schema `required` changed from `["id", "status"]` to `["id"]`. The handler already accepted id+notes without status; the schema now matches.

**Files:** `definitions.go`, `explain_test.go`

### 3. job_watch: accept `job:` prefix
`normalizeWatchSource` strips an optional `job:` prefix so both `job:job_123` and `job_123` resolve to the same concrete job.

**Files:** `job_watch.go`

### 4. read_transcript: accept format=markdown + offset_bytes
`validateJobReadArgs` now accepts `format=markdown` (the default view) alongside `offset_bytes`/`output_match` on `job:` refs. Only non-markdown formats are still rejected with paging/search.

**Files:** `session_tools_transcript.go`

### 5. manage_worktree list: 0-commit lane not labeled "merged"
The list operation now skips the `Merged` check when `tip == baseSHA` (0-commit lane). `isAncestor(base, main)` is trivially true since the branch was cut from main, but that is the absence of work, not evidence of a merge. The lane now correctly reads "0 ahead" instead of the misleading "merged".

**Files:** `session_tools_worktree.go`

## Related Issue

#655 — Stopping an observer sidecar delegate does not clear its `job_watch` on the parent session, causing the stopped delegate to fire indefinitely on every parent `communicate` event. Observed live while developing these changes.

## Test Plan

- [x] All new/updated tests pass: `TestNormalizeWatchSource`, `TestValidateJobReadArgs`, `TestWorktreeListSummaryZeroAheadNotMerged`, `TestDelegateSchema*`, `TestExecTool_*Delegate*`, `TestPrepareToolCall_Delegate*`, `TestDelegateSurfaceUsesAgentRegistryCapabilities`
- [x] `go build ./...` clean
- [x] Full delegate/sandbox test suite passes
- [x] golangci-lint 0 issues; `make vet`, `lint-gofmt`, `lint-naming`, `lint-generated` pass; race detector clean