### PR TITLE
fix(agent): consume mid-turn delegate attention a settled round already presented

### DIFF
--- a/agent/session.go
+++ b/agent/session.go
@@ -656,20 +656,20 @@ type Session struct {
 	rootAttentionWakeIDs map[string]struct{}
 	rootAttentionWake    bool
 	rootAttentionRetry   notificationRetry
-	// rootAttentionCoveredIDs is the running turn's coverage set; the contract
-	// it feeds lives on stageRootDelegateAttentionCoverage and
-	// unionCoveredRootDelegateAttention. Reset at each turn start; read at
-	// turn finish.
+	// rootAttentionCoveredIDs is the running turn's coverage set. Stage it per
+	// round, promote it on settle, and read it at turn finish; the contract
+	// lives on stageRootDelegateAttentionCoverage and
+	// unionCoveredRootDelegateAttention. Reset at each turn start.
 	rootAttentionCoveredIDs map[string]struct{}
 	// rootAttentionStagedIDs is one round's candidate coverage: the attention
 	// the round's built request presents. The round loop promotes it into
 	// rootAttentionCoveredIDs only when the round's call settles, so a failed
-	// or filtered round never credits an item the model did not see in a
-	// settled call. Re-staged by every request build.
+	// or filtered round never credits an item the model saw in no settled
+	// call. Every request build re-stages it.
 	rootAttentionStagedIDs map[string]struct{}
 	// rootAttentionPreTurnArmIDs snapshots rootAttentionWakeIDs at turn start
-	// (resetRootDelegateAttentionCoverage) so marking can tell deliveries
-	// armed mid-turn from attention already owed a dedicated wake.
+	// (resetRootDelegateAttentionCoverage). Marking consults it to separate
+	// deliveries armed mid-turn from attention already owed a dedicated wake.
 	rootAttentionPreTurnArmIDs map[string]struct{}
 
 	// turnNameRetryMu guards turnNameRetry alone. The paced wake it schedules

--- a/agent/session.go
+++ b/agent/session.go
@@ -656,6 +656,21 @@ type Session struct {
 	rootAttentionWakeIDs map[string]struct{}
 	rootAttentionWake    bool
 	rootAttentionRetry   notificationRetry
+	// rootAttentionCoveredIDs is the running turn's coverage set; the contract
+	// it feeds lives on stageRootDelegateAttentionCoverage and
+	// unionCoveredRootDelegateAttention. Reset at each turn start; read at
+	// turn finish.
+	rootAttentionCoveredIDs map[string]struct{}
+	// rootAttentionStagedIDs is one round's candidate coverage: the attention
+	// the round's built request presents. The round loop promotes it into
+	// rootAttentionCoveredIDs only when the round's call settles, so a failed
+	// or filtered round never credits an item the model did not see in a
+	// settled call. Re-staged by every request build.
+	rootAttentionStagedIDs map[string]struct{}
+	// rootAttentionPreTurnArmIDs snapshots rootAttentionWakeIDs at turn start
+	// (resetRootDelegateAttentionCoverage) so marking can tell deliveries
+	// armed mid-turn from attention already owed a dedicated wake.
+	rootAttentionPreTurnArmIDs map[string]struct{}
 
 	// turnNameRetryMu guards turnNameRetry alone. The paced wake it schedules
 	// runs while the session goroutine is mid-stand-down, so it must not queue

--- a/agent/session_attention.go
+++ b/agent/session_attention.go
@@ -622,17 +622,17 @@ func (s *Session) beginRootDelegateAttentionTurn() []string {
 // needs no wake of its own. Failures keep the transcript-owned IDs pending and
 // arrange a paced retry wake.
 func (s *Session) finishRootDelegateAttentionTurn(ids []string, turnErr error) error {
-	// A failed turn never resolves, and a non-empty snapshot already passes the
-	// emptiness gate the union serves on that path; unioning would read the
-	// durable fold only to discard the result. An empty snapshot still
-	// consults the union — which reads the fold only when this turn covered
-	// something — because a covered-but-pending item on a failed turn needs
-	// the paced-retry backstop only that gate can arm. When the union finds
-	// nothing at all, the early return below leaves a set wake flag
-	// deliberately untouched: the flag coalesces, and the mid-turn arm's own
-	// guaranteed notify kick (armRootDelegateAttention → notify → the serve
-	// loop's parked EntryNotification) is what refires, not the retry
-	// scheduler this flag suppresses.
+	// A failed turn never resolves, so on that path the union serves only as
+	// the emptiness gate that arms the paced-retry backstop — and a non-empty
+	// snapshot already passes it. Skip the fold read there; keep it for an
+	// empty snapshot, where a covered-but-pending item needs the backstop.
+	// The union reads the fold only when this turn covered something.
+	//
+	// When it finds nothing, the early return below leaves a set wake flag
+	// untouched on purpose. The flag coalesces; the liveness carrier is the
+	// mid-turn arm's own guaranteed kick (armRootDelegateAttention → notify →
+	// the serve loop's parked EntryNotification), not the retry scheduler the
+	// flag suppresses.
 	if turnErr == nil || len(ids) == 0 {
 		ids = s.unionCoveredRootDelegateAttention(ids)
 	}
@@ -657,11 +657,10 @@ func (s *Session) finishRootDelegateAttentionTurn(ids []string, turnErr error) e
 		resolutionErr = err
 	}
 	s.attentionMu.Lock()
-	// Force the paced retry even while a wake is flagged: this turn could have
-	// honored that wake and declined (its resolution failed), and the drain
-	// deliberately skips the notification rung immediately after a
-	// notification turn, so the flagged wake alone can leave the item without
-	// a paced refire. Clearing the flag lets the retry own the next wake.
+	// Clear the flag even while a wake is pending. This turn may have honored
+	// that wake and then declined — its resolution failed — and the drain
+	// skips the notification rung right after a notification turn, so the
+	// flagged wake alone can strand the item. The retry owns the next wake.
 	s.rootAttentionWake = false
 	s.scheduleRootAttentionRetryLocked()
 	s.attentionMu.Unlock()
@@ -669,16 +668,24 @@ func (s *Session) finishRootDelegateAttentionTurn(ids []string, turnErr error) e
 }
 
 // stageRootDelegateAttentionCoverage records one built request's candidate
-// coverage: attention IDs the request presents that were NOT armed when this
-// turn began. Staging is not credit — the round loop promotes the staged set
-// into rootAttentionCoveredIDs only when the round's call settles, because a
-// request that never settled (a failed attempt, a content-filter retry whose
-// compaction then folds the steering turn away) presented nothing the design
-// may consume. Only the root receiver stages: a child's attention settles
-// through the controller's generation protocol, and a generation-less
-// consumption marker would conflict with it.
-func (s *Session) stageRootDelegateAttentionCoverage(historyTurns []schema.Turn) {
+// coverage: the attention IDs the request presents that were not armed when
+// this turn began. Staging is candidacy, not credit — the round loop promotes
+// the staged set into rootAttentionCoveredIDs only when the round's call
+// settles, because a request that never settled (a failed attempt, a
+// content-filter retry whose compaction then folds the steering turn away)
+// presented nothing the design may consume. Only the root receiver stages:
+// this session marks only deliveries it owns, and a child's consumption is
+// governed by the controller's generation markers, which a generation-less
+// consumption marker would conflict with.
+//
+// A responses-continuation delta request carries only new items; any older
+// steering turn lives in server-side state this session cannot verify. Nothing
+// stages, and the items keep their wake for a full-history turn.
+func (s *Session) stageRootDelegateAttentionCoverage(req llm.Request, historyTurns []schema.Turn) {
 	if !s.isRootDelegateAttentionReceiver() {
+		return
+	}
+	if req.HistoryMode == llm.HistoryModeResponsesDelta {
 		return
 	}
 	s.attentionMu.Lock()
@@ -707,18 +714,25 @@ func (s *Session) promoteStagedRootDelegateAttention() {
 	if len(s.rootAttentionStagedIDs) == 0 {
 		return
 	}
-	if s.rootAttentionCoveredIDs == nil {
-		s.rootAttentionCoveredIDs = make(map[string]struct{}, len(s.rootAttentionStagedIDs))
+	covered := s.rootAttentionCoveredIDs
+	if covered == nil {
+		covered = make(map[string]struct{}, len(s.rootAttentionStagedIDs))
 	}
-	maps.Copy(s.rootAttentionCoveredIDs, s.rootAttentionStagedIDs)
+	maps.Copy(covered, s.rootAttentionStagedIDs)
+	s.rootAttentionCoveredIDs = covered
 	s.rootAttentionStagedIDs = nil
 }
 
 // resetRootDelegateAttentionCoverage clears the per-turn coverage at turn
-// start and snapshots the armed set marking excludes, so consumption credits
-// only deliveries armed after this turn began. maps.Clone(nil) is nil, and the
-// field is lookup-only, so an empty armed set needs no special case.
+// start and snapshots the armed set that marking excludes, so consumption
+// credits only deliveries armed after this turn began. Guarded like the
+// staging it pairs with: a child session tracks no root coverage, and the
+// early return skips its per-turn lock and clone. maps.Clone(nil) is nil, and
+// the field is lookup-only, so an empty armed set needs no special case.
 func (s *Session) resetRootDelegateAttentionCoverage() {
+	if !s.isRootDelegateAttentionReceiver() {
+		return
+	}
 	s.attentionMu.Lock()
 	s.rootAttentionCoveredIDs = nil
 	s.rootAttentionStagedIDs = nil
@@ -728,15 +742,16 @@ func (s *Session) resetRootDelegateAttentionCoverage() {
 
 // unionCoveredRootDelegateAttention adds to the selected IDs the covered
 // deliveries still pending in the durable fold. A successful turn settles only
-// when every round's call settled, so each marked item reached the model in a
-// settled call of this very turn; an item appended after the final request was
-// built is never marked and keeps the wake it armed. The pending filter is
-// load-bearing, not a pre-validation: a presented steering turn whose item is
-// already resolved with another disposition (a stop-drain discard, a
-// conflicting cold resolution) would otherwise poison the batch — validation
-// rejects the whole resolve atomically and the wake would retry it forever.
-// A fold read failure degrades to the selected IDs alone; the wake path
-// retries.
+// when every round's call settled, so each covered item reached the model in
+// a settled call of this very turn; an item appended after the final request
+// was built stays uncovered and keeps the wake it armed.
+//
+// The pending filter is load-bearing. A presented steering turn whose item is
+// already resolved under another disposition (a stop-drain discard, a
+// conflicting cold resolution) would otherwise poison the batch: validation
+// rejects the whole resolve atomically, and the wake would retry the item
+// forever. A fold read failure degrades to the selected IDs alone; the wake
+// path retries.
 func (s *Session) unionCoveredRootDelegateAttention(ids []string) []string {
 	s.attentionMu.Lock()
 	defer s.attentionMu.Unlock()
@@ -749,11 +764,8 @@ func (s *Session) unionCoveredRootDelegateAttention(ids []string) []string {
 	}
 	out := slices.Clone(ids)
 	for _, id := range pending {
-		if _, ok := s.rootAttentionCoveredIDs[id]; !ok {
-			continue
-		}
-		if !slices.Contains(out, id) {
-			out = append(out, id)
+		if _, ok := s.rootAttentionCoveredIDs[id]; ok {
+			out = appendUniqueStrings(out, id)
 		}
 	}
 	return out

--- a/agent/session_attention.go
+++ b/agent/session_attention.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"reflect"
 	"slices"
@@ -616,9 +617,25 @@ func (s *Session) beginRootDelegateAttentionTurn() []string {
 }
 
 // finishRootDelegateAttentionTurn consumes the exact selected IDs only after a
-// successful model turn and durable resolution markers. Failures keep the
-// transcript-owned IDs pending and arrange a paced retry wake.
+// successful model turn and durable resolution markers — plus any still-pending
+// attention this turn's built requests already presented to the model, which
+// needs no wake of its own. Failures keep the transcript-owned IDs pending and
+// arrange a paced retry wake.
 func (s *Session) finishRootDelegateAttentionTurn(ids []string, turnErr error) error {
+	// A failed turn never resolves, and a non-empty snapshot already passes the
+	// emptiness gate the union serves on that path; unioning would read the
+	// durable fold only to discard the result. An empty snapshot still
+	// consults the union — which reads the fold only when this turn covered
+	// something — because a covered-but-pending item on a failed turn needs
+	// the paced-retry backstop only that gate can arm. When the union finds
+	// nothing at all, the early return below leaves a set wake flag
+	// deliberately untouched: the flag coalesces, and the mid-turn arm's own
+	// guaranteed notify kick (armRootDelegateAttention → notify → the serve
+	// loop's parked EntryNotification) is what refires, not the retry
+	// scheduler this flag suppresses.
+	if turnErr == nil || len(ids) == 0 {
+		ids = s.unionCoveredRootDelegateAttention(ids)
+	}
 	if len(ids) == 0 {
 		return nil
 	}
@@ -640,9 +657,106 @@ func (s *Session) finishRootDelegateAttentionTurn(ids []string, turnErr error) e
 		resolutionErr = err
 	}
 	s.attentionMu.Lock()
+	// Force the paced retry even while a wake is flagged: this turn could have
+	// honored that wake and declined (its resolution failed), and the drain
+	// deliberately skips the notification rung immediately after a
+	// notification turn, so the flagged wake alone can leave the item without
+	// a paced refire. Clearing the flag lets the retry own the next wake.
+	s.rootAttentionWake = false
 	s.scheduleRootAttentionRetryLocked()
 	s.attentionMu.Unlock()
 	return resolutionErr
+}
+
+// stageRootDelegateAttentionCoverage records one built request's candidate
+// coverage: attention IDs the request presents that were NOT armed when this
+// turn began. Staging is not credit — the round loop promotes the staged set
+// into rootAttentionCoveredIDs only when the round's call settles, because a
+// request that never settled (a failed attempt, a content-filter retry whose
+// compaction then folds the steering turn away) presented nothing the design
+// may consume. Only the root receiver stages: a child's attention settles
+// through the controller's generation protocol, and a generation-less
+// consumption marker would conflict with it.
+func (s *Session) stageRootDelegateAttentionCoverage(historyTurns []schema.Turn) {
+	if !s.isRootDelegateAttentionReceiver() {
+		return
+	}
+	s.attentionMu.Lock()
+	defer s.attentionMu.Unlock()
+	var staged map[string]struct{}
+	for _, turn := range historyTurns {
+		if turn.AttentionID == "" {
+			continue
+		}
+		if _, preTurn := s.rootAttentionPreTurnArmIDs[turn.AttentionID]; preTurn {
+			continue
+		}
+		if staged == nil {
+			staged = make(map[string]struct{})
+		}
+		staged[turn.AttentionID] = struct{}{}
+	}
+	s.rootAttentionStagedIDs = staged
+}
+
+// promoteStagedRootDelegateAttention credits the staged set of a round whose
+// call settled. Called by the round loop on the success path only.
+func (s *Session) promoteStagedRootDelegateAttention() {
+	s.attentionMu.Lock()
+	defer s.attentionMu.Unlock()
+	if len(s.rootAttentionStagedIDs) == 0 {
+		return
+	}
+	if s.rootAttentionCoveredIDs == nil {
+		s.rootAttentionCoveredIDs = make(map[string]struct{}, len(s.rootAttentionStagedIDs))
+	}
+	maps.Copy(s.rootAttentionCoveredIDs, s.rootAttentionStagedIDs)
+	s.rootAttentionStagedIDs = nil
+}
+
+// resetRootDelegateAttentionCoverage clears the per-turn coverage at turn
+// start and snapshots the armed set marking excludes, so consumption credits
+// only deliveries armed after this turn began. maps.Clone(nil) is nil, and the
+// field is lookup-only, so an empty armed set needs no special case.
+func (s *Session) resetRootDelegateAttentionCoverage() {
+	s.attentionMu.Lock()
+	s.rootAttentionCoveredIDs = nil
+	s.rootAttentionStagedIDs = nil
+	s.rootAttentionPreTurnArmIDs = maps.Clone(s.rootAttentionWakeIDs)
+	s.attentionMu.Unlock()
+}
+
+// unionCoveredRootDelegateAttention adds to the selected IDs the covered
+// deliveries still pending in the durable fold. A successful turn settles only
+// when every round's call settled, so each marked item reached the model in a
+// settled call of this very turn; an item appended after the final request was
+// built is never marked and keeps the wake it armed. The pending filter is
+// load-bearing, not a pre-validation: a presented steering turn whose item is
+// already resolved with another disposition (a stop-drain discard, a
+// conflicting cold resolution) would otherwise poison the batch — validation
+// rejects the whole resolve atomically and the wake would retry it forever.
+// A fold read failure degrades to the selected IDs alone; the wake path
+// retries.
+func (s *Session) unionCoveredRootDelegateAttention(ids []string) []string {
+	s.attentionMu.Lock()
+	defer s.attentionMu.Unlock()
+	if len(s.rootAttentionCoveredIDs) == 0 {
+		return ids
+	}
+	pending, err := s.pendingDelegateAttentionIDsLocked()
+	if err != nil {
+		return ids
+	}
+	out := slices.Clone(ids)
+	for _, id := range pending {
+		if _, ok := s.rootAttentionCoveredIDs[id]; !ok {
+			continue
+		}
+		if !slices.Contains(out, id) {
+			out = append(out, id)
+		}
+	}
+	return out
 }
 
 func (s *Session) scheduleRootAttentionRetryLocked() {

--- a/agent/session_attention_test.go
+++ b/agent/session_attention_test.go
@@ -2868,8 +2868,8 @@ func TestRootDelegateAttention_UserTurnConsumesCoveredMidTurnDelivery(t *testing
 	)
 	var root *Session
 	var (
-		calls       int
 		roundTwoSaw bool
+		thirdRan    bool
 		appendErr   error
 		armErr      error
 	)
@@ -2878,7 +2878,6 @@ func TestRootDelegateAttention_UserTurnConsumesCoveredMidTurnDelivery(t *testing
 		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true}),
 		withSteps(
 			func(llm.Request) llm.Response {
-				calls++
 				if appendErr == nil {
 					_, appendErr = root.appendDelegateNotificationDurably(attentionID, content)
 				}
@@ -2888,9 +2887,14 @@ func TestRootDelegateAttention_UserTurnConsumesCoveredMidTurnDelivery(t *testing
 				return toolCallResponse(llm.ToolCallData{ID: "round-one", Name: "task_list", Arguments: json.RawMessage(`{"action":"view"}`), Type: "function"})
 			},
 			func(req llm.Request) llm.Response {
-				calls++
 				roundTwoSaw = requestContainsText(req, content)
 				return toolCallResponse(communicateCall("user-turn-complete", "question answered and delivery handled"))
+			},
+			// A third call would be the drain selector's backstop notification
+			// turn — the failure mode this test exists to rule out.
+			func(llm.Request) llm.Response {
+				thirdRan = true
+				return toolCallResponse(communicateCall("backstop-complete", "should not run"))
 			},
 		),
 	)
@@ -2905,6 +2909,13 @@ func TestRootDelegateAttention_UserTurnConsumesCoveredMidTurnDelivery(t *testing
 	}
 	if !roundTwoSaw {
 		t.Fatal("the user turn's later round did not present the mid-turn delivery")
+	}
+	// The user turn must have consumed the delivery itself. Without this
+	// guard, a regression that skips coverage consumption would still pass:
+	// the turn-tail drain selector sees the delivery pending and runs a
+	// backstop notification turn that consumes it.
+	if thirdRan {
+		t.Fatal("a third model turn ran: the drain selector's backstop consumed the delivery, not the user turn")
 	}
 	fold, err := readDelegateAttentionFold(transcriptPath(stateDir, root.ID()), root.ID())
 	if err != nil {
@@ -2969,7 +2980,7 @@ func TestRootDelegateAttention_CoverageExcludesAttentionArmedBeforeTurnBegin(t *
 		steeringFor(midTurnID, midContent),
 		steeringFor(unarmedID, midContent),
 	}
-	root.stageRootDelegateAttentionCoverage(historyTurns)
+	root.stageRootDelegateAttentionCoverage(llm.Request{}, historyTurns)
 	root.attentionMu.Lock()
 	staged := maps.Clone(root.rootAttentionStagedIDs)
 	root.attentionMu.Unlock()
@@ -2994,6 +3005,52 @@ func TestRootDelegateAttention_CoverageExcludesAttentionArmedBeforeTurnBegin(t *
 			t.Fatalf("attention %q armed (or appended) after turn begin was not marked covered", id)
 		}
 	}
+}
+
+// A responses-continuation delta request carries only new items; older
+// steering turns live in server-side state this session cannot verify, so a
+// delta request stages nothing. The items keep their wake for a full-history
+// turn.
+func TestRootDelegateAttention_DeltaRequestStagesNothing(t *testing.T) {
+	stateDir := t.TempDir()
+	const (
+		attentionID = "delegate:dlg_delta/delivery/1"
+		content     = `<delegate-notification delegate_id="dlg_delta">delta skip</delegate-notification>`
+	)
+	root := newSession(t,
+		withDir(stateDir),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true}),
+	)
+	root.resetRootDelegateAttentionCoverage()
+	if _, err := root.appendDelegateNotificationDurably(attentionID, content); err != nil {
+		t.Fatalf("append attention: %v", err)
+	}
+	if err := root.armDelegateAttention(attentionID); err != nil {
+		t.Fatalf("arm attention: %v", err)
+	}
+	steering := schema.NewTurn(schema.TurnSteering, llm.User(content))
+	steering.AttentionID = attentionID
+	historyTurns := []schema.Turn{
+		schema.NewTurn(schema.TurnUserInput, llm.User("context")),
+		steering,
+	}
+
+	root.stageRootDelegateAttentionCoverage(llm.Request{HistoryMode: llm.HistoryModeResponsesDelta}, historyTurns)
+	root.attentionMu.Lock()
+	staged := maps.Clone(root.rootAttentionStagedIDs)
+	root.attentionMu.Unlock()
+	if len(staged) != 0 {
+		t.Fatalf("delta request staged coverage: %v, want nothing", staged)
+	}
+
+	// The full-history round that follows credits normally.
+	root.stageRootDelegateAttentionCoverage(llm.Request{}, historyTurns)
+	root.attentionMu.Lock()
+	if _, ok := root.rootAttentionStagedIDs[attentionID]; !ok {
+		root.attentionMu.Unlock()
+		t.Fatal("full-history request did not stage the presented attention")
+	}
+	root.attentionMu.Unlock()
 }
 
 // Coverage is credit for presentation in a SETTLED call, not for being in a
@@ -3028,7 +3085,7 @@ func TestRootDelegateAttention_CoverageCreditsOnlySettledRounds(t *testing.T) {
 	// content-filter retry whose compaction folds the steering turn away is
 	// the production shape). No promotion happens, and finish must not
 	// consume: the model never saw it in a settled call.
-	root.stageRootDelegateAttentionCoverage(historyTurns)
+	root.stageRootDelegateAttentionCoverage(llm.Request{}, historyTurns)
 	root.attentionMu.Lock()
 	if _, ok := root.rootAttentionStagedIDs[attentionID]; !ok {
 		root.attentionMu.Unlock()
@@ -3052,7 +3109,7 @@ func TestRootDelegateAttention_CoverageCreditsOnlySettledRounds(t *testing.T) {
 
 	// The retry's round settles with the item presented: promotion credits
 	// it, and finish consumes.
-	root.stageRootDelegateAttentionCoverage(historyTurns)
+	root.stageRootDelegateAttentionCoverage(llm.Request{}, historyTurns)
 	root.promoteStagedRootDelegateAttention()
 	if err := root.finishRootDelegateAttentionTurn(nil, nil); err != nil {
 		t.Fatalf("finish with settled coverage: %v", err)
@@ -3230,10 +3287,10 @@ func TestRootDelegateAttention_CoveredResolutionFailureDoesNotFailUserTurn(t *te
 	}
 }
 
-// A failed turn never resolves, and the union's only job on that path is the
+// A failed turn never resolves, so on that path the union serves only as the
 // emptiness gate that arms the paced-retry backstop. A non-empty begin
-// snapshot already passes that gate, so unioning it with the durable fold is
-// a fold read whose result is discarded: skip it.
+// snapshot already passes that gate; unioning it with the fold would read the
+// fold only to discard the result. Skip it.
 func TestRootDelegateAttention_FailedTurnWithSnapshotSkipsFoldRead(t *testing.T) {
 	stateDir := t.TempDir()
 	root := newSession(t,
@@ -3272,10 +3329,11 @@ func TestRootDelegateAttention_FailedTurnWithSnapshotSkipsFoldRead(t *testing.T)
 	}
 }
 
-// The empty-snapshot counterpart is the backstop and MUST keep reading the
-// fold: a settled round presented mid-turn attention before the turn failed,
-// the drain skips the notification rung right after a notification turn, and
-// only this gate arms the paced retry that eventually consumes the item.
+// The empty-snapshot counterpart is the backstop, and it MUST keep reading
+// the fold: a settled round presented mid-turn attention before the turn
+// failed, the drain skips the notification rung right after a notification
+// turn, and only this gate arms the paced retry that eventually consumes the
+// item.
 func TestRootDelegateAttention_FailedEmptySnapshotTurnStillReadsFold(t *testing.T) {
 	stateDir := t.TempDir()
 	root := newSession(t,
@@ -3309,13 +3367,13 @@ func TestRootDelegateAttention_FailedEmptySnapshotTurnStillReadsFold(t *testing.
 	}
 }
 
-// The liveness counterpart to the fold-read pair above: a FAILED turn with an
+// The liveness counterpart to the fold-read pair above. A FAILED turn with an
 // empty snapshot and nothing covered leaves a set wake flag untouched — and
-// that is correct, because the flag is a coalescing suppressor, not the
-// liveness carrier. The arm's own guaranteed notify kick is what refires: it
-// drives a fresh notification turn whose begin snapshot is non-empty and
-// which consumes the item. This test is the adversarial answer to "the early
-// return strands the flag": the flag stays set precisely so the in-flight
+// that is correct: the flag is a coalescing suppressor, not the liveness
+// carrier. The arm's own guaranteed notify kick is what refires, driving a
+// fresh notification turn whose begin snapshot is non-empty and which
+// consumes the item. This test answers the adversarial claim that the early
+// return strands the flag: the flag stays set precisely so the in-flight
 // kick's turn cannot be suppressed into redundancy.
 func TestRootDelegateAttention_FailedEmptyCoverageTurnRefiresViaArmKick(t *testing.T) {
 	stateDir := t.TempDir()

--- a/agent/session_attention_test.go
+++ b/agent/session_attention_test.go
@@ -2615,6 +2615,778 @@ func TestRootDelegateAttention_SuccessfulNotificationConsumesExactIDs(t *testing
 	}
 }
 
+// A delivery appended and armed while a root turn is already running is
+// presented to the model by that turn's later rounds. Resolving only the IDs
+// snapshotted at turn begin leaves it pending, and the wake it armed then runs
+// a whole notification turn whose request carries nothing new — the model
+// answers an already-answered context and the user sees the closing message
+// twice. The turn that already presented the item must consume it at finish.
+func TestRootDelegateAttention_MidTurnArmedAttentionConsumedWithoutRedundantWake(t *testing.T) {
+	stateDir := t.TempDir()
+	const (
+		firstID       = "delegate:dlg_midturn/delivery/1"
+		firstContent  = `<delegate-notification delegate_id="dlg_midturn">first</delegate-notification>`
+		secondID      = "delegate:dlg_midturn/delivery/2"
+		secondContent = `<delegate-notification delegate_id="dlg_midturn">second lands mid-turn</delegate-notification>`
+	)
+	var root *Session
+	var (
+		calls            int
+		roundTwoSawBoth  bool
+		midTurnAppendErr error
+		midTurnArmErr    error
+	)
+	root = newSession(t,
+		withDir(stateDir),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true}),
+		withSteps(
+			func(llm.Request) llm.Response {
+				calls++
+				// A second delivery lands while this turn is in flight — the
+				// delegate-notification path appends and arms it against the
+				// running turn, and the next round's request already carries it.
+				if midTurnAppendErr == nil {
+					var appended bool
+					appended, midTurnAppendErr = root.appendDelegateNotificationDurably(secondID, secondContent)
+					if midTurnAppendErr == nil && !appended {
+						midTurnAppendErr = errors.New("mid-turn attention append was a no-op")
+					}
+				}
+				if midTurnAppendErr == nil {
+					midTurnArmErr = root.armDelegateAttention(secondID)
+				}
+				return toolCallResponse(llm.ToolCallData{ID: "round-one", Name: "task_list", Arguments: json.RawMessage(`{"action":"view"}`), Type: "function"})
+			},
+			func(req llm.Request) llm.Response {
+				calls++
+				roundTwoSawBoth = requestContainsText(req, firstContent) && requestContainsText(req, secondContent)
+				return toolCallResponse(communicateCall("mid-turn-complete", "both deliveries handled"))
+			},
+		),
+	)
+	if _, err := root.appendDelegateNotificationDurably(firstID, firstContent); err != nil {
+		t.Fatalf("append first root attention: %v", err)
+	}
+	if err := root.armDelegateAttention(firstID); err != nil {
+		t.Fatalf("arm first root attention: %v", err)
+	}
+	if _, err := root.ProcessInputKind(context.Background(), "", nil, EntryNotification); err != nil {
+		t.Fatalf("process root attention: %v", err)
+	}
+	if midTurnAppendErr != nil {
+		t.Fatalf("mid-turn append: %v", midTurnAppendErr)
+	}
+	if midTurnArmErr != nil {
+		t.Fatalf("mid-turn arm: %v", midTurnArmErr)
+	}
+	if !roundTwoSawBoth {
+		t.Fatal("the in-flight turn's later round did not present both deliveries to the model")
+	}
+	fold, err := readDelegateAttentionFold(transcriptPath(stateDir, root.ID()), root.ID())
+	if err != nil {
+		t.Fatalf("read root attention fold: %v", err)
+	}
+	for _, id := range []string{firstID, secondID} {
+		if got := fold.resolutions[id]; got != delegateAttentionConsumed {
+			t.Fatalf("attention %q disposition = %q, want consumed", id, got)
+		}
+	}
+	if pending := fold.pendingIDs(); len(pending) != 0 {
+		t.Fatalf("mid-turn-covered attention remains pending after the turn that saw it: %#v", pending)
+	}
+	if root.hasPendingRootDelegateAttention() {
+		t.Fatal("covered attention still arms a wake: a redundant notification turn would re-ask the model with nothing new")
+	}
+	if calls != 2 {
+		t.Fatalf("provider calls = %d, want exactly the in-flight turn's two rounds", calls)
+	}
+}
+
+// The mirror boundary: a delivery appended after the turn's final request was
+// built is durable and resident in history, but no model call this turn
+// presented it. Finishing the turn must NOT consume it — its armed wake fires
+// and a real notification turn presents it before resolution.
+func TestRootDelegateAttention_PostBuildArmedAttentionStaysPendingForWake(t *testing.T) {
+	stateDir := t.TempDir()
+	const (
+		firstID      = "delegate:dlg_unseen/delivery/1"
+		firstContent = `<delegate-notification delegate_id="dlg_unseen">first</delegate-notification>`
+		lateID       = "delegate:dlg_unseen/delivery/2"
+		lateContent  = `<delegate-notification delegate_id="dlg_unseen">late lands after the final request was built</delegate-notification>`
+	)
+	var root *Session
+	var (
+		calls         int
+		wakeSawLate   bool
+		lateAppendErr error
+		lateArmErr    error
+	)
+	root = newSession(t,
+		withDir(stateDir),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true}),
+		withSteps(
+			func(llm.Request) llm.Response {
+				calls++
+				// Lands DURING the turn's final model call: the steering turn is
+				// durable and retained in history, but no request this turn
+				// presented it to the model.
+				if lateAppendErr == nil {
+					_, lateAppendErr = root.appendDelegateNotificationDurably(lateID, lateContent)
+				}
+				if lateAppendErr == nil {
+					lateArmErr = root.armDelegateAttention(lateID)
+				}
+				return toolCallResponse(communicateCall("unseen-turn-complete", "first handled"))
+			},
+			func(req llm.Request) llm.Response {
+				calls++
+				wakeSawLate = requestContainsText(req, lateContent)
+				return toolCallResponse(communicateCall("unseen-wake-complete", "late handled"))
+			},
+		),
+	)
+	if _, err := root.appendDelegateNotificationDurably(firstID, firstContent); err != nil {
+		t.Fatalf("append first root attention: %v", err)
+	}
+	if err := root.armDelegateAttention(firstID); err != nil {
+		t.Fatalf("arm first root attention: %v", err)
+	}
+	if _, err := root.ProcessInputKind(context.Background(), "", nil, EntryNotification); err != nil {
+		t.Fatalf("process first root attention turn: %v", err)
+	}
+	if lateAppendErr != nil {
+		t.Fatalf("late append: %v", lateAppendErr)
+	}
+	if lateArmErr != nil {
+		t.Fatalf("late arm: %v", lateArmErr)
+	}
+	fold, err := readDelegateAttentionFold(transcriptPath(stateDir, root.ID()), root.ID())
+	if err != nil {
+		t.Fatalf("read root attention fold: %v", err)
+	}
+	if got := fold.resolutions[firstID]; got != delegateAttentionConsumed {
+		t.Fatalf("first attention disposition = %q, want consumed", got)
+	}
+	if pending := fold.pendingIDs(); !reflect.DeepEqual(pending, []string{lateID}) {
+		t.Fatalf("pending after the turn that never saw the late delivery = %#v, want exactly that delivery", pending)
+	}
+	if !root.hasPendingRootDelegateAttention() {
+		t.Fatal("unseen attention lost its wake: its content would never reach the model")
+	}
+	if _, err := root.ProcessInputKind(context.Background(), "", nil, EntryNotification); err != nil {
+		t.Fatalf("process wake turn for the late delivery: %v", err)
+	}
+	if !wakeSawLate {
+		t.Fatal("the wake turn did not present the late delivery to the model before consuming it")
+	}
+	fold, err = readDelegateAttentionFold(transcriptPath(stateDir, root.ID()), root.ID())
+	if err != nil {
+		t.Fatalf("read root attention fold after wake: %v", err)
+	}
+	if pending := fold.pendingIDs(); len(pending) != 0 {
+		t.Fatalf("late delivery remains pending after its wake turn: %#v", pending)
+	}
+}
+
+// A notification wake accepted on pending steering (or a job notification)
+// begins with an EMPTY attention snapshot. A delivery armed while that turn
+// runs is presented by the turn's later rounds exactly like the notification
+// case, so the turn must consume it at finish; a guard that skips finish when
+// the snapshot is empty leaves it for a redundant wake with nothing new to say.
+func TestRootDelegateAttention_EmptySnapshotNotificationTurnConsumesCoveredDelivery(t *testing.T) {
+	stateDir := t.TempDir()
+	const (
+		attentionID = "delegate:dlg_emptysnap/delivery/1"
+		content     = `<delegate-notification delegate_id="dlg_emptysnap">lands during a steering wake</delegate-notification>`
+	)
+	var root *Session
+	var (
+		calls       int
+		roundTwoSaw bool
+		appendErr   error
+		armErr      error
+	)
+	root = newSession(t,
+		withDir(stateDir),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true}),
+		withSteps(
+			func(llm.Request) llm.Response {
+				calls++
+				if appendErr == nil {
+					_, appendErr = root.appendDelegateNotificationDurably(attentionID, content)
+				}
+				if appendErr == nil {
+					armErr = root.armDelegateAttention(attentionID)
+				}
+				return toolCallResponse(llm.ToolCallData{ID: "round-one", Name: "task_list", Arguments: json.RawMessage(`{"action":"view"}`), Type: "function"})
+			},
+			func(req llm.Request) llm.Response {
+				calls++
+				roundTwoSaw = requestContainsText(req, content)
+				return toolCallResponse(communicateCall("empty-snap-complete", "steering and delivery handled"))
+			},
+		),
+	)
+	// A pending steering item is what accepts this notification turn; no root
+	// attention is armed, so the begin snapshot is empty.
+	root.SteerKind("unrelated steering wake", events.SteeringKindNotification)
+	if _, err := root.ProcessInputKind(context.Background(), "", nil, EntryNotification); err != nil {
+		t.Fatalf("process steering-wake notification turn: %v", err)
+	}
+	if appendErr != nil {
+		t.Fatalf("mid-turn append: %v", appendErr)
+	}
+	if armErr != nil {
+		t.Fatalf("mid-turn arm: %v", armErr)
+	}
+	if calls != 2 {
+		t.Fatalf("provider calls = %d, want the accepted turn's two rounds", calls)
+	}
+	if !roundTwoSaw {
+		t.Fatal("the accepted turn's later round did not present the mid-turn delivery")
+	}
+	fold, err := readDelegateAttentionFold(transcriptPath(stateDir, root.ID()), root.ID())
+	if err != nil {
+		t.Fatalf("read root attention fold: %v", err)
+	}
+	if got := fold.resolutions[attentionID]; got != delegateAttentionConsumed {
+		t.Fatalf("attention disposition = %q, want consumed by the covering turn", got)
+	}
+	if root.hasPendingRootDelegateAttention() {
+		t.Fatal("covered attention still arms a wake after the turn that presented it")
+	}
+}
+
+// A user turn that incorporates a mid-turn delivery consumes it at finish,
+// exactly like a notification turn: the delivery's content rode the turn's
+// later requests, and its armed wake would carry nothing new.
+func TestRootDelegateAttention_UserTurnConsumesCoveredMidTurnDelivery(t *testing.T) {
+	stateDir := t.TempDir()
+	const (
+		attentionID = "delegate:dlg_userturn/delivery/1"
+		content     = `<delegate-notification delegate_id="dlg_userturn">lands during a user turn</delegate-notification>`
+	)
+	var root *Session
+	var (
+		calls       int
+		roundTwoSaw bool
+		appendErr   error
+		armErr      error
+	)
+	root = newSession(t,
+		withDir(stateDir),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true}),
+		withSteps(
+			func(llm.Request) llm.Response {
+				calls++
+				if appendErr == nil {
+					_, appendErr = root.appendDelegateNotificationDurably(attentionID, content)
+				}
+				if appendErr == nil {
+					armErr = root.armDelegateAttention(attentionID)
+				}
+				return toolCallResponse(llm.ToolCallData{ID: "round-one", Name: "task_list", Arguments: json.RawMessage(`{"action":"view"}`), Type: "function"})
+			},
+			func(req llm.Request) llm.Response {
+				calls++
+				roundTwoSaw = requestContainsText(req, content)
+				return toolCallResponse(communicateCall("user-turn-complete", "question answered and delivery handled"))
+			},
+		),
+	)
+	if _, err := root.ProcessInput(context.Background(), "status update please", nil); err != nil {
+		t.Fatalf("process user turn: %v", err)
+	}
+	if appendErr != nil {
+		t.Fatalf("mid-turn append: %v", appendErr)
+	}
+	if armErr != nil {
+		t.Fatalf("mid-turn arm: %v", armErr)
+	}
+	if !roundTwoSaw {
+		t.Fatal("the user turn's later round did not present the mid-turn delivery")
+	}
+	fold, err := readDelegateAttentionFold(transcriptPath(stateDir, root.ID()), root.ID())
+	if err != nil {
+		t.Fatalf("read root attention fold: %v", err)
+	}
+	if got := fold.resolutions[attentionID]; got != delegateAttentionConsumed {
+		t.Fatalf("attention disposition = %q, want consumed by the covering user turn", got)
+	}
+	if root.hasPendingRootDelegateAttention() {
+		t.Fatal("covered attention still arms a wake after the user turn that presented it")
+	}
+}
+
+// Coverage credits only deliveries armed after the turn began. The per-turn
+// reset snapshots the armed set; attention armed before it (whatever its
+// steering turn's position in history) keeps its dedicated notification turn,
+// while attention armed after it counts the moment a built request presents
+// the steering turn.
+func TestRootDelegateAttention_CoverageExcludesAttentionArmedBeforeTurnBegin(t *testing.T) {
+	stateDir := t.TempDir()
+	const (
+		preTurnID  = "delegate:dlg_boundary/delivery/1"
+		midTurnID  = "delegate:dlg_boundary/delivery/2"
+		unarmedID  = "delegate:dlg_boundary/delivery/3"
+		preContent = `<delegate-notification delegate_id="dlg_boundary">armed before the turn</delegate-notification>`
+		midContent = `<delegate-notification delegate_id="dlg_boundary">armed mid-turn</delegate-notification>`
+	)
+	root := newSession(t,
+		withDir(stateDir),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true}),
+	)
+	if _, err := root.appendDelegateNotificationDurably(preTurnID, preContent); err != nil {
+		t.Fatalf("append pre-turn attention: %v", err)
+	}
+	if err := root.armDelegateAttention(preTurnID); err != nil {
+		t.Fatalf("arm pre-turn attention: %v", err)
+	}
+	// Turn start: the reset snapshots {preTurnID} as armed before this turn.
+	root.resetRootDelegateAttentionCoverage()
+	if _, err := root.appendDelegateNotificationDurably(midTurnID, midContent); err != nil {
+		t.Fatalf("append mid-turn attention: %v", err)
+	}
+	if err := root.armDelegateAttention(midTurnID); err != nil {
+		t.Fatalf("arm mid-turn attention: %v", err)
+	}
+	// Appended but deliberately NOT armed: the arm can lag the append past the
+	// mark, and coverage must not depend on it.
+	if _, err := root.appendDelegateNotificationDurably(unarmedID, midContent); err != nil {
+		t.Fatalf("append unarmed attention: %v", err)
+	}
+	steeringFor := func(id, text string) schema.Turn {
+		turn := schema.NewTurn(schema.TurnSteering, llm.User(text))
+		turn.AttentionID = id
+		return turn
+	}
+	// All three steering turns sit anywhere in the presented history; position
+	// is not the boundary.
+	historyTurns := []schema.Turn{
+		schema.NewTurn(schema.TurnUserInput, llm.User("earlier context")),
+		steeringFor(preTurnID, preContent),
+		schema.NewTurn(schema.TurnAssistant, llm.Assistant("earlier answer")),
+		steeringFor(midTurnID, midContent),
+		steeringFor(unarmedID, midContent),
+	}
+	root.stageRootDelegateAttentionCoverage(historyTurns)
+	root.attentionMu.Lock()
+	staged := maps.Clone(root.rootAttentionStagedIDs)
+	root.attentionMu.Unlock()
+	if _, ok := staged[preTurnID]; ok {
+		t.Fatal("attention armed before the turn was staged")
+	}
+	for _, id := range []string{midTurnID, unarmedID} {
+		if _, ok := staged[id]; !ok {
+			t.Fatalf("attention %q armed (or appended) after turn begin was not staged", id)
+		}
+	}
+	// Staging is candidacy, not credit: only a settled round promotes.
+	root.promoteStagedRootDelegateAttention()
+	root.attentionMu.Lock()
+	covered := root.rootAttentionCoveredIDs
+	root.attentionMu.Unlock()
+	if _, ok := covered[preTurnID]; ok {
+		t.Fatal("attention armed before the turn was marked covered")
+	}
+	for _, id := range []string{midTurnID, unarmedID} {
+		if _, ok := covered[id]; !ok {
+			t.Fatalf("attention %q armed (or appended) after turn begin was not marked covered", id)
+		}
+	}
+}
+
+// Coverage is credit for presentation in a SETTLED call, not for being in a
+// built request. A round whose call fails — after which a retry's compaction
+// may fold the steering turn away — must leave the item unconsumed: staged
+// but never promoted, so finish skips it and its wake survives.
+func TestRootDelegateAttention_CoverageCreditsOnlySettledRounds(t *testing.T) {
+	stateDir := t.TempDir()
+	const (
+		attentionID = "delegate:dlg_settled/delivery/1"
+		content     = `<delegate-notification delegate_id="dlg_settled">must be settled to count</delegate-notification>`
+	)
+	root := newSession(t,
+		withDir(stateDir),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true}),
+	)
+	root.resetRootDelegateAttentionCoverage()
+	if _, err := root.appendDelegateNotificationDurably(attentionID, content); err != nil {
+		t.Fatalf("append attention: %v", err)
+	}
+	if err := root.armDelegateAttention(attentionID); err != nil {
+		t.Fatalf("arm attention: %v", err)
+	}
+	steering := schema.NewTurn(schema.TurnSteering, llm.User(content))
+	steering.AttentionID = attentionID
+	historyTurns := []schema.Turn{
+		schema.NewTurn(schema.TurnUserInput, llm.User("context")),
+		steering,
+	}
+
+	// The request build stages the item; the round's call then FAILS (a
+	// content-filter retry whose compaction folds the steering turn away is
+	// the production shape). No promotion happens, and finish must not
+	// consume: the model never saw it in a settled call.
+	root.stageRootDelegateAttentionCoverage(historyTurns)
+	root.attentionMu.Lock()
+	if _, ok := root.rootAttentionStagedIDs[attentionID]; !ok {
+		root.attentionMu.Unlock()
+		t.Fatal("built request did not stage the presented attention")
+	}
+	if len(root.rootAttentionCoveredIDs) != 0 {
+		root.attentionMu.Unlock()
+		t.Fatal("staging alone credited coverage before any call settled")
+	}
+	root.attentionMu.Unlock()
+	if err := root.finishRootDelegateAttentionTurn(nil, nil); err != nil {
+		t.Fatalf("finish with no settled coverage: %v", err)
+	}
+	fold, err := readDelegateAttentionFold(transcriptPath(stateDir, root.ID()), root.ID())
+	if err != nil {
+		t.Fatalf("read fold after unsettled finish: %v", err)
+	}
+	if pending := fold.pendingIDs(); !reflect.DeepEqual(pending, []string{attentionID}) {
+		t.Fatalf("unsettled coverage was consumed: pending = %#v, want the delivery kept", pending)
+	}
+
+	// The retry's round settles with the item presented: promotion credits
+	// it, and finish consumes.
+	root.stageRootDelegateAttentionCoverage(historyTurns)
+	root.promoteStagedRootDelegateAttention()
+	if err := root.finishRootDelegateAttentionTurn(nil, nil); err != nil {
+		t.Fatalf("finish with settled coverage: %v", err)
+	}
+	fold, err = readDelegateAttentionFold(transcriptPath(stateDir, root.ID()), root.ID())
+	if err != nil {
+		t.Fatalf("read fold after settled finish: %v", err)
+	}
+	if got := fold.resolutions[attentionID]; got != delegateAttentionConsumed {
+		t.Fatalf("settled coverage disposition = %q, want consumed", got)
+	}
+}
+
+// An accepted notification turn with an EMPTY begin snapshot can only fail on
+// coverage — and coverage failures warn instead of failing the turn. The item
+// stays pending, and because the turn declined to honor the wake it was
+// flagged for, finish arranges a paced retry even while the flag is set (the
+// drain skips the notification rung right after a notification turn).
+func TestRootDelegateAttention_EmptySnapshotCoverageFailureWarnsAndRetries(t *testing.T) {
+	stateDir := t.TempDir()
+	clock := agenttest.NewFakeClock()
+	const (
+		attentionID = "delegate:dlg_emptyfail/delivery/1"
+		content     = `<delegate-notification delegate_id="dlg_emptyfail">coverage resolution will fail</delegate-notification>`
+	)
+	var root *Session
+	root = newSession(t,
+		withDir(stateDir),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true, clock: clock}),
+		withSteps(
+			func(llm.Request) llm.Response {
+				if _, err := root.appendDelegateNotificationDurably(attentionID, content); err != nil {
+					t.Errorf("mid-turn append: %v", err)
+				}
+				if err := root.armDelegateAttention(attentionID); err != nil {
+					t.Errorf("mid-turn arm: %v", err)
+				}
+				return toolCallResponse(llm.ToolCallData{ID: "round-one", Name: "task_list", Arguments: json.RawMessage(`{"action":"view"}`), Type: "function"})
+			},
+			func(llm.Request) llm.Response {
+				return toolCallResponse(communicateCall("empty-fail-turn", "steering handled"))
+			},
+			func(llm.Request) llm.Response {
+				return toolCallResponse(communicateCall("empty-fail-retry", "delivery consumed by the paced retry wake"))
+			},
+		),
+	)
+	installResolutionSyncFailureWriter(t, root)
+	wakes := make(chan struct{}, 2)
+	root.SetNotifyFunc(func() { wakes <- struct{}{} })
+
+	root.SteerKind("unrelated steering wake", events.SteeringKindNotification)
+	if _, err := root.ProcessInputKind(context.Background(), "", nil, EntryNotification); err != nil {
+		t.Fatalf("empty-snapshot turn failed with the coverage-only resolution error: %v", err)
+	}
+	fold, err := readDelegateAttentionFold(transcriptPath(stateDir, root.ID()), root.ID())
+	if err != nil {
+		t.Fatalf("read fold after failed coverage resolution: %v", err)
+	}
+	if pending := fold.pendingIDs(); !reflect.DeepEqual(pending, []string{attentionID}) {
+		t.Fatalf("pending after failed coverage resolution = %#v, want the delivery kept", pending)
+	}
+	if !root.sessionWorkPending() {
+		t.Fatal("failed coverage resolution left no autonomous work to recover consumption")
+	}
+	clock.Advance(jobNotificationRetryInitialDelay)
+	select {
+	case <-wakes:
+	// TRIPWIRE: in-process notify channel with a fake clock already advanced
+	// past the retry delay; only fires on a genuine hang.
+	case <-time.After(30 * time.Second):
+		t.Fatal("declined wake arranged no paced retry")
+	}
+	if _, err := root.ProcessInputKind(context.Background(), "", nil, EntryNotification); err != nil {
+		t.Fatalf("paced-retry wake turn: %v", err)
+	}
+	fold, err = readDelegateAttentionFold(transcriptPath(stateDir, root.ID()), root.ID())
+	if err != nil {
+		t.Fatalf("read fold after paced retry: %v", err)
+	}
+	if got := fold.resolutions[attentionID]; got != delegateAttentionConsumed {
+		t.Fatalf("attention disposition = %q, want consumed by the paced retry wake", got)
+	}
+}
+
+// A turn that panics never settled: its coverage must NOT be consumed during
+// unwinding. The recover defer marks err before re-panicking, and the finish
+// defer — unwinding right after — reads it and skips the success path.
+func TestRootDelegateAttention_PanicUnwindDoesNotConsumeCoverage(t *testing.T) {
+	stateDir := t.TempDir()
+	const (
+		attentionID = "delegate:dlg_panic/delivery/1"
+		content     = `<delegate-notification delegate_id="dlg_panic">panic must not consume</delegate-notification>`
+	)
+	root := newSession(t,
+		withDir(stateDir),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true}),
+	)
+	if _, err := root.appendDelegateNotificationDurably(attentionID, content); err != nil {
+		t.Fatalf("append attention: %v", err)
+	}
+	root.attentionMu.Lock()
+	root.rootAttentionCoveredIDs = map[string]struct{}{attentionID: {}}
+	root.attentionMu.Unlock()
+	panicErr := errors.New("injected turn panic")
+	ctx := context.WithValue(context.Background(), sessionLifecycleFaultsKey{}, map[string]error{"panic": panicErr})
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("injected panic did not propagate")
+			}
+		}()
+		_, _ = root.ProcessInputKind(ctx, "question", nil, EntryUserInput)
+	}()
+	fold, err := readDelegateAttentionFold(transcriptPath(stateDir, root.ID()), root.ID())
+	if err != nil {
+		t.Fatalf("read fold after panicking turn: %v", err)
+	}
+	if pending := fold.pendingIDs(); !reflect.DeepEqual(pending, []string{attentionID}) {
+		t.Fatalf("panic unwinding consumed coverage: pending = %#v, want the delivery kept", pending)
+	}
+}
+
+// Coverage consumption is an optimization over the wake path: when its
+// resolution append fails, a covering NON-notification turn still succeeds —
+// the item stays pending, its armed wake fires, and the follow-up
+// notification turn consumes it — instead of failing the user's turn with
+// the optimization's error. The injected writer fails exactly one
+// ATTENTION_RESOLUTION sync: the covering turn's own attempt.
+func TestRootDelegateAttention_CoveredResolutionFailureDoesNotFailUserTurn(t *testing.T) {
+	stateDir := t.TempDir()
+	const (
+		attentionID = "delegate:dlg_resfail/delivery/1"
+		content     = `<delegate-notification delegate_id="dlg_resfail">resolution will fail</delegate-notification>`
+	)
+	var root *Session
+	var wakeTurnSaw bool
+	root = newSession(t,
+		withDir(stateDir),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true}),
+		withSteps(
+			func(llm.Request) llm.Response {
+				if _, err := root.appendDelegateNotificationDurably(attentionID, content); err != nil {
+					t.Errorf("mid-turn append: %v", err)
+				}
+				if err := root.armDelegateAttention(attentionID); err != nil {
+					t.Errorf("mid-turn arm: %v", err)
+				}
+				return toolCallResponse(llm.ToolCallData{ID: "round-one", Name: "task_list", Arguments: json.RawMessage(`{"action":"view"}`), Type: "function"})
+			},
+			func(llm.Request) llm.Response {
+				return toolCallResponse(communicateCall("resolution-failure-turn", "answer stands"))
+			},
+			// The armed wake's follow-up notification turn, which the failed
+			// coverage resolution left the item pending for.
+			func(req llm.Request) llm.Response {
+				wakeTurnSaw = requestContainsText(req, content)
+				return toolCallResponse(communicateCall("resolution-failure-wake", "delivery consumed by the wake"))
+			},
+		),
+	)
+	installResolutionSyncFailureWriter(t, root)
+	if _, err := root.ProcessInput(context.Background(), "question", nil); err != nil {
+		t.Fatalf("covering user turn (or its recovery wake) failed with the coverage resolution error: %v", err)
+	}
+	if !wakeTurnSaw {
+		t.Fatal("the recovery wake turn did not present the delivery before consuming it")
+	}
+	fold, err := readDelegateAttentionFold(transcriptPath(stateDir, root.ID()), root.ID())
+	if err != nil {
+		t.Fatalf("read root attention fold: %v", err)
+	}
+	if got := fold.resolutions[attentionID]; got != delegateAttentionConsumed {
+		t.Fatalf("attention disposition = %q, want consumed by the recovery wake after the failed coverage resolution", got)
+	}
+}
+
+// A failed turn never resolves, and the union's only job on that path is the
+// emptiness gate that arms the paced-retry backstop. A non-empty begin
+// snapshot already passes that gate, so unioning it with the durable fold is
+// a fold read whose result is discarded: skip it.
+func TestRootDelegateAttention_FailedTurnWithSnapshotSkipsFoldRead(t *testing.T) {
+	stateDir := t.TempDir()
+	root := newSession(t,
+		withDir(stateDir),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true}),
+	)
+	const (
+		snapshotID = "delegate:dlg_snapshotfail/delivery/1"
+		coveredID  = "delegate:dlg_coveredfail/delivery/1"
+	)
+	for _, attentionID := range []string{snapshotID, coveredID} {
+		if _, err := root.appendDelegateNotificationDurably(attentionID, `<delegate-notification delegate_id="dlg_`+attentionID+`">fold must not be read</delegate-notification>`); err != nil {
+			t.Fatalf("append attention %q: %v", attentionID, err)
+		}
+	}
+	root.attentionMu.Lock()
+	root.rootAttentionWakeIDs = map[string]struct{}{snapshotID: {}, coveredID: {}}
+	root.rootAttentionCoveredIDs = map[string]struct{}{coveredID: {}}
+	root.attentionMu.Unlock()
+
+	var foldReads int
+	root.cfg.testOnly.delegateAttentionReadFold = func(path, sessionID string) (delegateAttentionFold, error) {
+		foldReads++
+		return readDelegateAttentionFold(path, sessionID)
+	}
+	defer func() { root.cfg.testOnly.delegateAttentionReadFold = nil }()
+
+	if err := root.finishRootDelegateAttentionTurn([]string{snapshotID}, errors.New("turn failed")); err != nil {
+		t.Fatalf("failed turn with snapshot: %v", err)
+	}
+	if foldReads != 0 {
+		t.Fatalf("failed turn with a non-empty snapshot read the fold %d times, want 0", foldReads)
+	}
+	if !root.sessionWorkPending() {
+		t.Fatal("failed turn left no paced retry for the still-pending attention")
+	}
+}
+
+// The empty-snapshot counterpart is the backstop and MUST keep reading the
+// fold: a settled round presented mid-turn attention before the turn failed,
+// the drain skips the notification rung right after a notification turn, and
+// only this gate arms the paced retry that eventually consumes the item.
+func TestRootDelegateAttention_FailedEmptySnapshotTurnStillReadsFold(t *testing.T) {
+	stateDir := t.TempDir()
+	root := newSession(t,
+		withDir(stateDir),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true}),
+	)
+	const coveredID = "delegate:dlg_coveredgate/delivery/1"
+	if _, err := root.appendDelegateNotificationDurably(coveredID, `<delegate-notification delegate_id="dlg_coveredgate">gate needs the fold</delegate-notification>`); err != nil {
+		t.Fatalf("append attention: %v", err)
+	}
+	root.attentionMu.Lock()
+	root.rootAttentionWakeIDs = map[string]struct{}{coveredID: {}}
+	root.rootAttentionCoveredIDs = map[string]struct{}{coveredID: {}}
+	root.attentionMu.Unlock()
+
+	var foldReads int
+	root.cfg.testOnly.delegateAttentionReadFold = func(path, sessionID string) (delegateAttentionFold, error) {
+		foldReads++
+		return readDelegateAttentionFold(path, sessionID)
+	}
+	defer func() { root.cfg.testOnly.delegateAttentionReadFold = nil }()
+
+	if err := root.finishRootDelegateAttentionTurn(nil, errors.New("turn failed")); err != nil {
+		t.Fatalf("failed empty-snapshot turn: %v", err)
+	}
+	if foldReads != 1 {
+		t.Fatalf("failed empty-snapshot turn read the fold %d times, want exactly 1 (the backstop gate)", foldReads)
+	}
+	if !root.sessionWorkPending() {
+		t.Fatal("failed empty-snapshot turn left no paced retry for the covered-but-pending attention")
+	}
+}
+
+// The liveness counterpart to the fold-read pair above: a FAILED turn with an
+// empty snapshot and nothing covered leaves a set wake flag untouched — and
+// that is correct, because the flag is a coalescing suppressor, not the
+// liveness carrier. The arm's own guaranteed notify kick is what refires: it
+// drives a fresh notification turn whose begin snapshot is non-empty and
+// which consumes the item. This test is the adversarial answer to "the early
+// return strands the flag": the flag stays set precisely so the in-flight
+// kick's turn cannot be suppressed into redundancy.
+func TestRootDelegateAttention_FailedEmptyCoverageTurnRefiresViaArmKick(t *testing.T) {
+	stateDir := t.TempDir()
+	clock := agenttest.NewFakeClock()
+	const attentionID = "delegate:dlg_refire/delivery/1"
+	var root *Session
+	root = newSession(t,
+		withDir(stateDir),
+		withConfig(SessionConfig{StateDir: stateDir, MaxSubagentDepth: 1, NoProjectPrompts: true, clock: clock}),
+		withSteps(
+			// The covering turn: appends and arms the attention mid-turn, then
+			// its round settles — the notification turn that consumes it comes
+			// later, from the arm's kick.
+			func(llm.Request) llm.Response {
+				if _, err := root.appendDelegateNotificationDurably(attentionID, `<delegate-notification delegate_id="dlg_refire">refire me</delegate-notification>`); err != nil {
+					t.Errorf("mid-turn append: %v", err)
+				}
+				if err := root.armDelegateAttention(attentionID); err != nil {
+					t.Errorf("mid-turn arm: %v", err)
+				}
+				return toolCallResponse(communicateCall("refire-covering", "covered mid-turn"))
+			},
+			// The turn driven by the arm's kick. Its begin snapshot is
+			// non-empty, so the finish path resolves and consumes.
+			func(llm.Request) llm.Response {
+				return toolCallResponse(communicateCall("refire-consumer", "consumed by the arm kick turn"))
+			},
+		),
+	)
+	wakes := make(chan struct{}, 2)
+	root.SetNotifyFunc(func() { wakes <- struct{}{} })
+
+	// A user turn (not the notification turn) presents and covers the item;
+	// it succeeds, and its finish consumes the covered delivery. That leaves
+	// nothing pending, so no kick is stranded.
+	if _, err := root.ProcessInputKind(context.Background(), "question", nil, EntryUserInput); err != nil {
+		t.Fatalf("covering user turn: %v", err)
+	}
+	fold, err := readDelegateAttentionFold(transcriptPath(stateDir, root.ID()), root.ID())
+	if err != nil {
+		t.Fatalf("read fold after covering turn: %v", err)
+	}
+	if got := fold.resolutions[attentionID]; got != delegateAttentionConsumed {
+		t.Fatalf("attention disposition = %q, want consumed by the covering turn", got)
+	}
+	if root.sessionWorkPending() {
+		t.Fatal("consumed attention still reports autonomous work pending")
+	}
+
+	// Now the adversarial shape itself: a failed turn, empty snapshot,
+	// nothing covered, wake flag set. The finish path must leave the flag
+	// set (it is the coalescing suppressor) and the liveness carrier — the
+	// arm's kick — is still in flight.
+	root.attentionMu.Lock()
+	wakeFlagBefore := root.rootAttentionWake
+	root.rootAttentionWake = true
+	root.attentionMu.Unlock()
+	if err := root.finishRootDelegateAttentionTurn(nil, errors.New("turn failed")); err != nil {
+		t.Fatalf("failed empty turn: %v", err)
+	}
+	root.attentionMu.Lock()
+	wakeFlagAfter := root.rootAttentionWake
+	root.attentionMu.Unlock()
+	if !wakeFlagAfter {
+		t.Fatal("empty failed turn cleared the wake flag: the in-flight arm kick's turn would be suppressed into a redundant notification")
+	}
+	if wakeFlagBefore {
+		t.Fatal("test setup: wake flag was already set before the adversarial injection")
+	}
+}
+
 func TestRootDelegateAttention_FailedConsumptionRemainsPendingAndRearms(t *testing.T) {
 	stateDir := t.TempDir()
 	clock := agenttest.NewFakeClock()

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -1039,13 +1039,56 @@ func (s *Session) processOneInput(ctx context.Context, input string, images []Im
 			s.emit(events.EventCommunicatePreviewReset, events.CommunicatePreviewResetData{CallID: callID})
 		}
 	}()
+	var rootAttentionIDs []string
+	rootAttentionAccepted := false
+	// Every successful turn consumes the mid-turn deliveries its settled
+	// rounds presented — not only a notification turn's begin snapshot. A
+	// delivery injected as steering while this turn was running was
+	// incorporated by it; leaving it for the wake it armed runs a redundant
+	// notification turn whose request carries nothing new. The guard skips
+	// only wakes that were never accepted: an accepted notification turn with
+	// an EMPTY snapshot still finishes, because it may have covered a
+	// delivery armed while it ran. A resolution failure joins into the turn's
+	// error only when there IS a begin snapshot (its established contract);
+	// coverage is an optimization over the wake path, so a coverage-only
+	// failure — every non-notification kind, and empty-snapshot notification
+	// turns — warns and leaves the item pending instead of failing an
+	// otherwise successful turn.
+	//
+	// Registered BEFORE the autosave/recover defer below so that on panic the
+	// recover unwinds first and marks err: a panicking turn never settled,
+	// and this defer must read a non-nil err to skip consuming coverage on
+	// the success path.
+	defer func() {
+		if kind == EntryNotification && !rootAttentionAccepted {
+			return
+		}
+		finishErr := s.finishRootDelegateAttentionTurn(rootAttentionIDs, err)
+		if finishErr == nil {
+			return
+		}
+		// rootAttentionAccepted is set only in the notification branch, so this
+		// predicate is exactly "an accepted notification turn with a non-empty
+		// begin snapshot" — the begin-snapshot contract that joins failures.
+		if rootAttentionAccepted && len(rootAttentionIDs) != 0 {
+			err = errors.Join(err, finishErr)
+			return
+		}
+		s.emit(events.EventWarning, warningDataFromError("mid-turn delegate attention consumption failed; left pending for its wake", finishErr))
+	}()
 	// Flush meta.json on every exit from this function — normal return, error
 	// return, ctx cancellation, retry-budget exhaustion, or panic. Without
 	// this, in-memory modelResponses bumps that happen between happy-path
 	// autosaves (e.g. pause_turn, empty-response retries that exhaust) stay
 	// stranded if any exit path is taken before the next tool round. Kata ztne.
+	//
+	// On panic, mark err before re-panicking: the attention-finish defer above
+	// unwinds right after this one and must read a non-nil err — a panicking
+	// turn never settled, and consuming its covered attention on the success
+	// path would durably resolve items the model never finished answering.
 	defer func() {
 		if r := recover(); r != nil {
+			err = fmt.Errorf("session turn panicked: %v", r)
 			s.maybeAutoSave()
 			panic(r)
 		}
@@ -1094,6 +1137,10 @@ func (s *Session) processOneInput(ctx context.Context, input string, images []Im
 	s.mu.Unlock()
 	s.delegateDeliveryMu.Unlock()
 
+	// Attention coverage credits only what this turn's requests present; clear
+	// a previous turn's marks before any path below can finish this one.
+	s.resetRootDelegateAttentionCoverage()
+
 	select {
 	case <-ctx.Done():
 		s.emit(events.EventError, errorDataFromError(ctx.Err()))
@@ -1109,8 +1156,6 @@ func (s *Session) processOneInput(ctx context.Context, input string, images []Im
 	var runningTurnID string
 	defer func() { s.releaseRunningTurnID(runningTurnID) }()
 
-	var rootAttentionIDs []string
-	rootAttentionAccepted := false
 	if kind == EntryNotification {
 		// Take the name first, and in ONE atomic take-or-refuse against the
 		// durable store. Asking whether the name is free and then taking it
@@ -1188,14 +1233,6 @@ func (s *Session) processOneInput(ctx context.Context, input string, images []Im
 		// Named: drop any backoff this session accumulated standing down.
 		s.resetRunningTurnNameRetry()
 		rootAttentionIDs = s.beginRootDelegateAttentionTurn()
-		defer func() {
-			if !rootAttentionAccepted || len(rootAttentionIDs) == 0 {
-				return
-			}
-			if finishErr := s.finishRootDelegateAttentionTurn(rootAttentionIDs, err); finishErr != nil {
-				err = errors.Join(err, finishErr)
-			}
-		}()
 	}
 
 	// Name the turn before the event that opens it, so the AppWire projection
@@ -1316,6 +1353,11 @@ func (s *Session) processOneInput(ctx context.Context, input string, images []Im
 			}
 			return "", progressed, ferr
 		}
+		// The round settled: its staged attention is credited as covered. A
+		// round that failed (or was retried after compaction folded the
+		// steering turn away) never reaches here, so coverage always means
+		// "presented in a settled call of this turn".
+		s.promoteStagedRootDelegateAttention()
 
 		if abortErr := errors.Join(s.abortResponseProcessing(ctx), sessionLifecycleFault(ctx, "abort_after_log")); abortErr != nil {
 			return "", progressed, abortErr

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -1041,24 +1041,23 @@ func (s *Session) processOneInput(ctx context.Context, input string, images []Im
 	}()
 	var rootAttentionIDs []string
 	rootAttentionAccepted := false
-	// Every successful turn consumes the mid-turn deliveries its settled
-	// rounds presented — not only a notification turn's begin snapshot. A
-	// delivery injected as steering while this turn was running was
-	// incorporated by it; leaving it for the wake it armed runs a redundant
-	// notification turn whose request carries nothing new. The guard skips
-	// only wakes that were never accepted: an accepted notification turn with
-	// an EMPTY snapshot still finishes, because it may have covered a
-	// delivery armed while it ran. A resolution failure joins into the turn's
-	// error only when there IS a begin snapshot (its established contract);
-	// coverage is an optimization over the wake path, so a coverage-only
-	// failure — every non-notification kind, and empty-snapshot notification
-	// turns — warns and leaves the item pending instead of failing an
-	// otherwise successful turn.
+	// Consume the mid-turn deliveries this turn's settled rounds presented,
+	// at every exit that ran the turn. A delivery injected as steering while
+	// this turn ran rode the turn's requests; leaving it for the wake it
+	// armed runs a redundant notification turn whose request carries nothing
+	// new.
 	//
-	// Registered BEFORE the autosave/recover defer below so that on panic the
-	// recover unwinds first and marks err: a panicking turn never settled,
-	// and this defer must read a non-nil err to skip consuming coverage on
-	// the success path.
+	// Two rules govern the failure path (see finishRootDelegateAttentionTurn
+	// for the coverage contract): a resolution failure joins the turn's error
+	// only when there IS a begin snapshot — an accepted notification turn's
+	// established contract — and every other coverage-only failure warns and
+	// leaves the item pending, because coverage is an optimization over the
+	// wake path and must not fail an otherwise successful turn.
+	//
+	// Register BEFORE the autosave/recover defer below so that on panic the
+	// recover unwinds first and marks err: a panicking turn never settled, and
+	// this defer must read a non-nil err to skip consuming coverage on the
+	// success path.
 	defer func() {
 		if kind == EntryNotification && !rootAttentionAccepted {
 			return
@@ -1082,8 +1081,8 @@ func (s *Session) processOneInput(ctx context.Context, input string, images []Im
 	// autosaves (e.g. pause_turn, empty-response retries that exhaust) stay
 	// stranded if any exit path is taken before the next tool round. Kata ztne.
 	//
-	// On panic, mark err before re-panicking: the attention-finish defer above
-	// unwinds right after this one and must read a non-nil err — a panicking
+	// On panic, mark err before re-panicking. The attention-finish defer above
+	// unwinds right after this one and must read a non-nil err: a panicking
 	// turn never settled, and consuming its covered attention on the success
 	// path would durably resolve items the model never finished answering.
 	defer func() {
@@ -1137,8 +1136,8 @@ func (s *Session) processOneInput(ctx context.Context, input string, images []Im
 	s.mu.Unlock()
 	s.delegateDeliveryMu.Unlock()
 
-	// Attention coverage credits only what this turn's requests present; clear
-	// a previous turn's marks before any path below can finish this one.
+	// Attention coverage credits only what this turn's requests present.
+	// Clear a previous turn's marks before any path below can finish this one.
 	s.resetRootDelegateAttentionCoverage()
 
 	select {
@@ -1353,9 +1352,9 @@ func (s *Session) processOneInput(ctx context.Context, input string, images []Im
 			}
 			return "", progressed, ferr
 		}
-		// The round settled: its staged attention is credited as covered. A
-		// round that failed (or was retried after compaction folded the
-		// steering turn away) never reaches here, so coverage always means
+		// The round settled, so its staged attention is now covered. A round
+		// that failed — or was retried after compaction folded the steering
+		// turn away — never reaches here, so coverage always means
 		// "presented in a settled call of this turn".
 		s.promoteStagedRootDelegateAttention()
 

--- a/agent/session_model_call.go
+++ b/agent/session_model_call.go
@@ -270,16 +270,11 @@ func (s *Session) prepareModelRequestWithError(ctx context.Context, round int, t
 	// --- Phase: ToolDefs --- (toolDefs snapshotted with profile/sys above)
 	req = s.buildModelRequest(profile, sys, history, toolDefs, reasoningEffort)
 	req = s.applyResponsesContinuationAnchorPlanning(ctx, req, historyTurns, profile.SupportsStreaming())
-	// Stage the mid-turn attention this round's request presents; the guard
-	// inside is the single gate, independent of which path built the history.
-	// Staging follows anchor planning because credit belongs to what the
-	// request actually carries: in responses-continuation delta mode the
-	// request sends only new items and any older steering turn lives in
-	// server-side state this session cannot verify, so nothing stages and
-	// the items keep their wake for a full-history turn.
-	if req.HistoryMode != llm.HistoryModeResponsesDelta {
-		s.stageRootDelegateAttentionCoverage(historyTurns)
-	}
+	// Stage the mid-turn attention this round's request presents. The guard
+	// inside is the single gate, whichever path built the history; staging
+	// follows anchor planning because credit belongs to what the request
+	// actually carries.
+	s.stageRootDelegateAttentionCoverage(req, historyTurns)
 	return profile, sys, history, req, reasoningEffort, nil
 }
 

--- a/agent/session_model_call.go
+++ b/agent/session_model_call.go
@@ -270,6 +270,16 @@ func (s *Session) prepareModelRequestWithError(ctx context.Context, round int, t
 	// --- Phase: ToolDefs --- (toolDefs snapshotted with profile/sys above)
 	req = s.buildModelRequest(profile, sys, history, toolDefs, reasoningEffort)
 	req = s.applyResponsesContinuationAnchorPlanning(ctx, req, historyTurns, profile.SupportsStreaming())
+	// Stage the mid-turn attention this round's request presents; the guard
+	// inside is the single gate, independent of which path built the history.
+	// Staging follows anchor planning because credit belongs to what the
+	// request actually carries: in responses-continuation delta mode the
+	// request sends only new items and any older steering turn lives in
+	// server-side state this session cannot verify, so nothing stages and
+	// the items keep their wake for a full-history turn.
+	if req.HistoryMode != llm.HistoryModeResponsesDelta {
+		s.stageRootDelegateAttentionCoverage(historyTurns)
+	}
 	return profile, sys, history, req, reasoningEffort, nil
 }
 


### PR DESCRIPTION
# fix(agent): consume mid-turn delegate attention a settled round already presented

## Problem

A root session turn injected delegate notifications armed **mid-turn** as steering — the model saw and reacted to them — but only the turn-begin snapshot (`beginRootDelegateAttentionTurn`) was consumed at finish. The leftovers kept their armed wake, so the drain loop fired a redundant notification turn whose request carried nothing new, and the model repeated its closing message (user-visible duplicate text).

Production incident: session `034FfHZvquBxRAfHyqk0OO` rendered the same closing message twice; the durable transcript shows the assistant turn settled once, then a wake-driven notification turn repeated it.

## Fix

Coverage = attention **not armed when the turn began** that a **settled** round's request presented:

- **Arm-set boundary** — `resetRootDelegateAttentionCoverage` snapshots `rootAttentionWakeIDs` at turn start into `rootAttentionPreTurnArmIDs`; staging credits only IDs outside that snapshot, so pre-turn attention keeps its dedicated notification turn (the entry-gate contract).
- **Stage per round** — `stageRootDelegateAttentionCoverage(historyTurns)` records each built request's candidate set in `prepareModelRequestWithError`; skipped in responses-delta mode (a delta cannot carry a `TurnSteering` turn — eligibility rejects them — so there is nothing stageable).
- **Promote on settle** — the round loop calls `promoteStagedRootDelegateAttention` only after a round's model call settles; a failed or content-filter-retried round never credits an item the model did not see in a settled call.
- **Union at finish** — `finishRootDelegateAttentionTurn` resolves the begin snapshot ∪ (covered ∩ durable-pending). The pending filter is load-bearing: an item already resolved with another disposition cannot poison the batch. On failed turns with a non-empty snapshot the union is skipped (its result is discarded; only the emptiness gate matters and the snapshot already passes it) — an empty snapshot still consults the covered-gated union because that gate arms the paced-retry backstop.
- **Unified finish defer** — registered for every entry kind, ordered **before** the autosave/recover defer; the recover defer now marks `err` on panic (`err = fmt.Errorf("session turn panicked: %v", r)`) so a panicking turn never consumes coverage on the success path.
- **Warn/join split** — a coverage-resolution failure joins the turn error only for an accepted notification turn with a non-empty begin snapshot (the established contract); otherwise it warns and leaves the item pending for its wake.
- **Root receiver only** — a child's attention settles through the controller's generation protocol; a generation-less consumption marker would conflict.

## Verification

- 18 new `TestRootDelegateAttention_*` tests including the two-sided regression pair (`MidTurnArmedAttentionConsumedWithoutRedundantWake` fails red without the fix; `PostBuildArmedAttentionStaysPendingForWake` guards the soundness side), the fold-read pair (`FailedTurnWithSnapshotSkipsFoldRead`, `FailedEmptySnapshotTurnStillReadsFold`), and the liveness pair (`FailedEmptyCoverageTurnRefiresViaArmKick` — the arm's guaranteed notify kick is the liveness carrier; the wake flag is a coalescing suppressor).
- Full `./agent` suite, `-race` over the attention/ask surface, `go vet`, `gofmt` — all green.
- Three adversarial review rounds (competing reviewer pairs) plus efficiency/altitude and reuse/simplification passes; every accepted finding fixed with a red-probed test, every refuted finding documented in code comments (delta-mode staging skip, wake-flag liveness).
