### PR TITLE
feat(hub): thread/unsubscribe and subscribe dedup for live-update subscriptions

### DIFF
--- a/appwire/client.go
+++ b/appwire/client.go
@@ -353,6 +353,12 @@ func (c *Client) ThreadRead(ctx context.Context, params ThreadReadParams) (Threa
 	return out, err
 }
 
+func (c *Client) ThreadUnsubscribe(ctx context.Context, params ThreadUnsubscribeParams) (EmptyResponse, error) {
+	var out EmptyResponse
+	err := c.request(ctx, MethodThreadUnsubscribe, params, &out)
+	return out, err
+}
+
 func (c *Client) ThreadTurnsList(ctx context.Context, params ThreadTurnsListParams) (ThreadTurnsListResponse, error) {
 	var out ThreadTurnsListResponse
 	err := c.request(ctx, MethodThreadTurnsList, params, &out)

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -93,6 +93,7 @@ var Methods = []MethodSpec{
 	{MethodPing, EmptyParams{}, EmptyResponse{}, ScopeConnection, "Connection keepalive, answered directly before the initialize gate (the browser's app-level heartbeat)."},
 	{MethodThreadList, ThreadListParams{}, ThreadListResponse{}, ScopeBoth, "Lists threads; the daemon returns its single session."},
 	{MethodThreadRead, ThreadReadParams{}, ThreadReadResponse{}, ScopeBoth, "Reads one thread and optionally subscribes to its live updates."},
+	{MethodThreadUnsubscribe, ThreadUnsubscribeParams{}, EmptyResponse{}, ScopeBoth, "Drops this connection's live-update subscription to a thread without reading it."},
 	{MethodThreadTurnsList, ThreadTurnsListParams{}, ThreadTurnsListResponse{}, ScopeBoth, "Pages turns backward (older) for lazy transcript loading; the cold load seeds the latest window via thread/read(turnLimit)."},
 	{MethodThreadTurnItemsList, ThreadTurnItemsListParams{}, ThreadTurnItemsListResponse{}, ScopeUnimplemented, "Codex-parity: paginated items for one turn. Experimental even in Codex (returns method-not-supported) and served by no evener router."},
 	{MethodThreadStart, ThreadStartParams{}, ThreadStartResponse{}, ScopeHub, "Starts a new thread and attaches a live-update relay."},

--- a/appwire/testdata/golden/FuzzMethodParams.json
+++ b/appwire/testdata/golden/FuzzMethodParams.json
@@ -38,9 +38,11 @@
   },
   {
     "input": "{\"threadId\":\"t\",\"turnLimit\":5}",
-    "detail": "thread/resume",
+    "detail": "thread/start",
     "decoded": true,
-    "output": {}
+    "output": {
+      "cwd": ""
+    }
   },
   {
     "input": "null",

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -26,6 +26,7 @@ const (
 	MethodPing                        = "ping"
 	MethodThreadList                  = "thread/list"
 	MethodThreadRead                  = "thread/read"
+	MethodThreadUnsubscribe           = "thread/unsubscribe"
 	MethodThreadTurnsList             = "thread/turns/list"
 	MethodThreadTurnItemsList         = "thread/turns/items/list"
 	MethodThreadStart                 = "thread/start"
@@ -1217,6 +1218,11 @@ type ThreadReadResponse struct {
 	// to thread/turns/list to fetch the page of turns just before the window.
 	// Empty means the response already includes the oldest turn.
 	OlderCursor string `json:"olderCursor,omitempty"`
+}
+
+type ThreadUnsubscribeParams struct {
+	ThreadID string `json:"threadId,omitempty"`
+	Ref      string `json:"ref,omitempty"`
 }
 
 type ThreadTurnsListParams struct {

--- a/cmd/evener-hub/app_relay.go
+++ b/cmd/evener-hub/app_relay.go
@@ -196,6 +196,25 @@ type hubRelayFunctions struct {
 var observeHubRelayFunctions func(hubRelayFunctions)
 var observeHubRelayWait func()
 
+// threadRelayTarget resolves the relay key (source.ID()+":"+threadID) and the
+// bare threadID for a read-shaped request. thread/read's relay, its recovery
+// paths, and thread/unsubscribe all derive the key here so a subscribe and
+// its unsubscribe can never disagree about which registry entry they name.
+func threadRelayTarget(source appsource.Source, params appwire.ThreadReadParams) (string, string, error) {
+	threadID := strings.TrimSpace(params.ThreadID)
+	if threadID == "" && params.Ref != "" {
+		ref, err := appwire.ParseRef(params.Ref)
+		if err != nil {
+			return "", "", err
+		}
+		threadID = ref.ThreadID
+	}
+	if threadID == "" {
+		return "", "", appwire.InvalidParams("threadId or ref is required")
+	}
+	return source.ID() + ":" + threadID, threadID, nil
+}
+
 func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sources *appsource.Registry) hubRelayFunctions {
 	relayIdleInterval := hubRelayIdleInterval
 	retryClock := newRelayRetryClock()
@@ -211,6 +230,7 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 		}
 		return appserver.Subscribe(ctx, relayKey)
 	}
+	relayTarget := threadRelayTarget
 	var relayMu sync.Mutex
 	relayedThreads := map[string]*hubRelayHandle{}
 	finishHandleLocked := func(handle *hubRelayHandle, err error) {
@@ -237,20 +257,6 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 		}
 		relayMu.Unlock()
 		closeRelayHandle(handle)
-	}
-	relayTarget := func(source appsource.Source, params appwire.ThreadReadParams) (string, string, error) {
-		threadID := strings.TrimSpace(params.ThreadID)
-		if threadID == "" && params.Ref != "" {
-			ref, err := appwire.ParseRef(params.Ref)
-			if err != nil {
-				return "", "", err
-			}
-			threadID = ref.ThreadID
-		}
-		if threadID == "" {
-			return "", "", appwire.InvalidParams("threadId or ref is required")
-		}
-		return source.ID() + ":" + threadID, threadID, nil
 	}
 	startAcknowledgedFanout := func(
 		relayKey string,
@@ -484,6 +490,12 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 		if sourceID == "" {
 			sourceID = "local"
 		}
+		// Keyed on the response's Thread.ID rather than the request's
+		// ref.ThreadID: the daemon maps a stable ref back to the live session
+		// id before answering (server/appwire_runtime.go appThreadIDForRead),
+		// so the two coincide on every reachable path, and thread/unsubscribe
+		// resolves through the same mapping. Kept explicit so a future source
+		// that lets them diverge shows exactly where to look.
 		relayKey := sourceID + ":" + read.response.Thread.ID
 		captured, err := withDeletionTargetOwnership(
 			cfg,

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -285,6 +285,36 @@ func registerThreadHandlers(
 		}
 		return resp, nil
 	})
+	// thread/unsubscribe drops only the calling connection's downstream
+	// subscription — the browser's own read of a thread it is navigating away
+	// from. The relay key is derived by the same helper thread/read's relay
+	// uses (threadRelayTarget), so the removal lands on the exact registry
+	// entry Subscribe created. Resolution deliberately uses the plain registry
+	// lookup — never the managed-launch path — because an unsubscribe must not
+	// start a session just to stop delivering to it. When no source resolves,
+	// the ref's own namespace (parsed from the ref itself) is the best key
+	// available; Unsubscribe is conn-scoped and idempotent, so a missed key
+	// costs only a subscription the connection-close cleanup reaps anyway.
+	appserver.HandleTyped(server.Router(), appwire.MethodThreadUnsubscribe, func(ctx context.Context, params appwire.ThreadUnsubscribeParams) (appwire.EmptyResponse, error) {
+		source, err := sourceForThread(sources, params.Ref, params.ThreadID)
+		if err != nil {
+			if isTargetDeletedError(err) {
+				return appwire.EmptyResponse{}, err
+			}
+			if parsed, parseErr := appwire.ParseRef(strings.TrimSpace(params.Ref)); parseErr == nil && parsed.SourceID != "" {
+				appserver.Unsubscribe(ctx, parsed.SourceID+":"+parsed.ThreadID)
+				return appwire.EmptyResponse{}, nil
+			}
+			appserver.Unsubscribe(ctx, "local:"+strings.TrimSpace(params.ThreadID))
+			return appwire.EmptyResponse{}, nil
+		}
+		relayKey, _, keyErr := threadRelayTarget(source, appwire.ThreadReadParams{ThreadID: params.ThreadID, Ref: params.Ref})
+		if keyErr != nil {
+			return appwire.EmptyResponse{}, keyErr
+		}
+		appserver.Unsubscribe(ctx, relayKey)
+		return appwire.EmptyResponse{}, nil
+	})
 	appserver.HandleTyped(server.Router(), appwire.MethodThreadTurnsList, func(ctx context.Context, params appwire.ThreadTurnsListParams) (appwire.ThreadTurnsListResponse, error) {
 		// Live source first; fall back to the saved transcript (paged on the
 		// hub) for past/not-loaded sessions.

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -2732,6 +2732,104 @@ func TestHubRPCThreadReadSubscribeOverridesSourceReadRelayPolicy(t *testing.T) {
 	}
 }
 
+// thread/unsubscribe must drop the calling connection's downstream
+// subscription — the registry entry thread/read's relay created — so the
+// relay's idle ticker sees SubscriberCount zero and can retire, and a second
+// call stays a quiet no-op.
+func TestHubRPCThreadUnsubscribeDropsDownstreamSubscription(t *testing.T) {
+	const threadID = "th_unsub"
+	source := &relayBroadcastSource{
+		id: "codex",
+		thread: appwire.Thread{
+			ID:        threadID,
+			SessionID: threadID,
+			Source:    "codex",
+			Evener:    appwire.EvenerThread{Ref: "codex:" + threadID, Capabilities: appwire.ThreadCapabilities{Send: true}},
+		},
+		notifications: make(chan appwire.Notification, 4),
+		subscribed:    make(chan struct{}, 1),
+		canceled:      make(chan struct{}, 1),
+	}
+	srv := httptest.NewUnstartedServer(nil)
+	web := NewWebServer(hubcore.WebConfig{HubAddr: srv.Listener.Addr().String(), Past: hubcore.NewPastIndex("")})
+	web.sources.Add(source)
+	srv.Config.Handler = web.Handler()
+	srv.Start()
+	defer srv.Close()
+
+	client := dialHubRPC(t, srv)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if _, err := client.ThreadRead(context.Background(), appwire.ThreadReadParams{Ref: "codex:" + threadID, Subscribe: true}); err != nil {
+		t.Fatalf("ThreadRead: %v", err)
+	}
+	expectRelaySubscription(t, source.subscribed)
+	if got := web.appRPC.SubscriberCount("codex:" + threadID); got != 1 {
+		t.Fatalf("subscriber count after subscribed read = %d, want 1", got)
+	}
+
+	if _, err := client.ThreadUnsubscribe(context.Background(), appwire.ThreadUnsubscribeParams{Ref: "codex:" + threadID}); err != nil {
+		t.Fatalf("ThreadUnsubscribe: %v", err)
+	}
+	if got := web.appRPC.SubscriberCount("codex:" + threadID); got != 0 {
+		t.Fatalf("subscriber count after unsubscribe = %d, want 0", got)
+	}
+
+	// The relay's notifications no longer reach this connection.
+	source.notifications <- appwire.Notification{
+		Method: appwire.NotifyAgentMessageDelta,
+		Params: testRawJSON(t, appwire.AgentMessageDeltaParams{
+			ThreadID: threadID,
+			Ref:      "codex:" + threadID,
+			TurnID:   "turn_1",
+			ItemID:   "item_1",
+			Delta:    "after unsubscribe",
+		}),
+	}
+	select {
+	case got := <-client.Notifications():
+		t.Fatalf("notification delivered after unsubscribe: %+v", got)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Idempotent: unsubscribing again succeeds quietly.
+	if _, err := client.ThreadUnsubscribe(context.Background(), appwire.ThreadUnsubscribeParams{Ref: "codex:" + threadID}); err != nil {
+		t.Fatalf("second ThreadUnsubscribe: %v", err)
+	}
+	if got := web.appRPC.SubscriberCount("codex:" + threadID); got != 0 {
+		t.Fatalf("subscriber count after second unsubscribe = %d, want 0", got)
+	}
+}
+
+// The fallback branch: when no source resolves (an exited session removed
+// its rendezvous entry), an unsubscribe still quietly succeeds. The handler
+// resolves through the plain registry (sourceForThread, never the
+// managed-launch path), so no launcher is even consulted — an unsubscribe is
+// a "stop caring" operation and must not spawn.
+func TestHubRPCThreadUnsubscribeUnresolvedSourceIsQuiet(t *testing.T) {
+	srv := httptest.NewUnstartedServer(nil)
+	web := NewWebServer(hubcore.WebConfig{HubAddr: srv.Listener.Addr().String(), Past: hubcore.NewPastIndex("")})
+	srv.Config.Handler = web.Handler()
+	srv.Start()
+	defer srv.Close()
+
+	client := dialHubRPC(t, srv)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	// A ref whose source never existed: quiet success, no error.
+	if _, err := client.ThreadUnsubscribe(context.Background(), appwire.ThreadUnsubscribeParams{Ref: "codex:th_missing"}); err != nil {
+		t.Fatalf("ThreadUnsubscribe for unresolvable source: %v", err)
+	}
+	// The same for a bare threadID with no ref.
+	if _, err := client.ThreadUnsubscribe(context.Background(), appwire.ThreadUnsubscribeParams{ThreadID: "th_missing"}); err != nil {
+		t.Fatalf("ThreadUnsubscribe for unresolvable thread: %v", err)
+	}
+}
+
 func TestHubRPCThreadReadRecoversEstablishedRelayAfterSourceClose(t *testing.T) {
 	const threadID = "th_recover"
 	results := make(chan relaySubscribeResult)
@@ -9855,6 +9953,7 @@ func TestHubRPCRegistersExpectedHandlerSet(t *testing.T) {
 	expected := []string{
 		appwire.MethodThreadList,
 		appwire.MethodThreadRead,
+		appwire.MethodThreadUnsubscribe,
 		appwire.MethodThreadTurnsList,
 		appwire.MethodEvenerSubagentPreview,
 		appwire.MethodThreadStart,

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -1749,6 +1749,11 @@ export interface ThreadTurnsListResponse {
   nextCursor?: string;
 }
 
+export interface ThreadUnsubscribeParams {
+  threadId?: string;
+  ref?: string;
+}
+
 export interface ThreadVisionModelChangedParams {
   threadId: string;
   ref: string;
@@ -1978,6 +1983,7 @@ export const METHOD_NAMES = [
   "ping",
   "thread/list",
   "thread/read",
+  "thread/unsubscribe",
   "thread/turns/list",
   "thread/turns/items/list",
   "thread/start",
@@ -2153,6 +2159,7 @@ export interface MethodTypes {
   "ping": { params: EmptyParams; result: EmptyResponse };
   "thread/list": { params: ThreadListParams; result: ThreadListResponse };
   "thread/read": { params: ThreadReadParams; result: ThreadReadResponse };
+  "thread/unsubscribe": { params: ThreadUnsubscribeParams; result: EmptyResponse };
   "thread/turns/list": { params: ThreadTurnsListParams; result: ThreadTurnsListResponse };
   "thread/turns/items/list": { params: ThreadTurnItemsListParams; result: ThreadTurnItemsListResponse };
   "thread/start": { params: ThreadStartParams; result: ThreadStartResponse };

--- a/cmd/evener-hub/frontend/src/stores/threads.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/threads.test.ts
@@ -2586,6 +2586,118 @@ describe("useThreadsStore.releaseThread", () => {
   test("releasing an untracked ref is a harmless no-op", () => {
     expect(() => threadsStore.getState().releaseThread("never_tracked")).not.toThrow();
   });
+
+  test("the final pane release unsubscribes the ref on the wire; earlier releases do not", async () => {
+    const fake = connectFakeClient();
+    fake.on("thread/read", () => readResponse("ref_a"));
+    await threadsStore.getState().ensureThread("ref_a"); // pane 1
+    await threadsStore.getState().ensureThread("ref_a"); // pane 2
+
+    threadsStore.getState().releaseThread("ref_a"); // pane 1 leaves
+    expect(fake.calls.filter((call) => call.method === "thread/unsubscribe")).toHaveLength(0);
+
+    threadsStore.getState().releaseThread("ref_a"); // last pane leaves
+    const unsubscribes = fake.calls.filter((call) => call.method === "thread/unsubscribe");
+    expect(unsubscribes).toHaveLength(1);
+    expect(unsubscribes[0]?.params).toMatchObject({ ref: "ref_a" });
+  });
+
+  test("a released-then-re-ensured ref re-subscribes with subscribe:true again", async () => {
+    const fake = connectFakeClient();
+    fake.on("thread/read", () => readResponse("ref_a"));
+    await threadsStore.getState().ensureThread("ref_a");
+    threadsStore.getState().releaseThread("ref_a");
+
+    await threadsStore.getState().ensureThread("ref_a");
+    const reads = fake.calls.filter((call) => call.method === "thread/read");
+    expect(reads).toHaveLength(2);
+    expect(reads[0]?.params).toMatchObject({ subscribe: true });
+    expect(reads[1]?.params).toMatchObject({ subscribe: true });
+    // And the final release unsubscribes exactly once more.
+    threadsStore.getState().releaseThread("ref_a");
+    expect(fake.calls.filter((call) => call.method === "thread/unsubscribe")).toHaveLength(2);
+  });
+});
+
+describe("wire subscription tracking", () => {
+  test("a re-read of an already-subscribed ref sends subscribe:false, not another subscribe", async () => {
+    const fake = connectFakeClient();
+    fake.on("thread/read", () => readResponse("ref_a"));
+    await threadsStore.getState().ensureThread("ref_a");
+
+    // The resync path re-reads the ref while it stays tracked.
+    fake.emitNotification({
+      method: "evener/thread/resync",
+      params: { threadId: "thr_ref_a", ref: "ref_a" },
+    });
+    await flushUntil(() => fake.calls.filter((call) => call.method === "thread/read").length >= 2);
+    await flushUntil(() => threadsStore.getState().hydrations.get("ref_a") !== undefined);
+
+    const reads = fake.calls.filter((call) => call.method === "thread/read");
+    expect(reads.length).toBeGreaterThanOrEqual(2);
+    expect(reads[0]?.params).toMatchObject({ subscribe: true });
+    expect(reads[1]?.params).toMatchObject({ subscribe: false });
+  });
+
+  test("a reconnect re-subscribes the still-tracked ref on the new connection", async () => {
+    const fake = connectFakeClient();
+    fake.on("thread/read", () => readResponse("ref_a"));
+    await threadsStore.getState().ensureThread("ref_a");
+
+    // A fresh client is a fresh connection: its subscriptions start empty.
+    const next = connectFakeClient();
+    next.on("thread/read", () => readResponse("ref_a"));
+    await flushUntil(() => next.calls.some((call) => call.method === "thread/read"));
+
+    const nextReads = next.calls.filter((call) => call.method === "thread/read");
+    expect(nextReads[0]?.params).toMatchObject({ subscribe: true });
+  });
+
+  test("releasing while another pane is pending does not unsubscribe the watched ref", async () => {
+    const fake = connectFakeClient();
+    fake.on("thread/read", () => readResponse("ref_a"));
+    await threadsStore.getState().ensureThread("ref_a");
+    await threadsStore.getState().watchThread("ref_a", { includeTurns: false });
+
+    threadsStore.getState().releaseThread("ref_a"); // pane leaves; watcher remains
+    expect(fake.calls.filter((call) => call.method === "thread/unsubscribe")).toHaveLength(0);
+
+    threadsStore.getState().releaseWatchedThread("ref_a"); // watcher leaves too
+    expect(fake.calls.filter((call) => call.method === "thread/unsubscribe")).toHaveLength(1);
+  });
+
+  // The lost-window fix: a release that runs while the hydrating read is
+  // still in flight sees the set WITHOUT the ref (no unsubscribe sent), so
+  // the read's own resolution must not record a zero-holder entry — it sends
+  // its own unsubscribe instead, and the server-side subscription this read
+  // created does not linger until connection close.
+  test("a read resolving after its final release unsubscribes instead of leaking the entry", async () => {
+    const fake = connectFakeClient();
+    const releaseRead: { resolve: ((response: ThreadReadResponse) => void) | null } = { resolve: null };
+    fake.on(
+      "thread/read",
+      () =>
+        new Promise<ThreadReadResponse>((resolve) => {
+          releaseRead.resolve = resolve;
+        }),
+    );
+    const ensuring = threadsStore.getState().ensureThread("ref_a");
+    await flushUntil(() => releaseRead.resolve !== null);
+
+    threadsStore.getState().releaseThread("ref_a"); // mid-flight: no unsubscribe yet
+    expect(fake.calls.filter((call) => call.method === "thread/unsubscribe")).toHaveLength(0);
+
+    releaseRead.resolve?.(readResponse("ref_a"));
+    await ensuring;
+    await flushUntil(() => fake.calls.filter((call) => call.method === "thread/unsubscribe").length === 1);
+    const unsubscribes = fake.calls.filter((call) => call.method === "thread/unsubscribe");
+    expect(unsubscribes[0]?.params).toMatchObject({ ref: "ref_a" });
+    // And a later ensure of the same ref subscribes afresh.
+    fake.on("thread/read", () => readResponse("ref_a"));
+    await threadsStore.getState().ensureThread("ref_a");
+    const reads = fake.calls.filter((call) => call.method === "thread/read");
+    expect(reads[reads.length - 1]?.params).toMatchObject({ subscribe: true });
+  });
 });
 
 describe("notification routing", () => {

--- a/cmd/evener-hub/frontend/src/stores/threads.ts
+++ b/cmd/evener-hub/frontend/src/stores/threads.ts
@@ -549,6 +549,15 @@ let dispatchReadyEpoch = -1;
 const pinnedMutationRefs = new Set<string>();
 const dispatchableMutationRefs = new Set<string>();
 
+// Refs this connection generation holds a wire subscription for. thread/read
+// with subscribe:true is how a subscription is created, and every re-read of
+// a tracked ref (ensureThread retry, onReady resync, watchThread upgrade)
+// used to send it again — additively and with a fresh capture cycle, because
+// nothing recorded "already subscribed on THIS socket". A new connection
+// carries no subscriptions, so rewireClient and the onReady path both clear
+// the set; the next read of a still-tracked ref re-subscribes as before.
+const wireSubscribedRefs = new Set<string>();
+
 interface MutationRuntime {
   storage: MutationOutboxIndexedDB;
   dispatcher: MutationDispatcher;
@@ -836,16 +845,22 @@ const watchIncludeTurns = new Map<string, boolean>();
 // was released before either response arrived.
 const watchHydratedIncludeTurns = new Map<string, boolean>();
 
-// Every tracked ref gets exactly these params on both the first subscribe
-// (ensureThread) and every re-subscribe (onReady after reconnect):
-// replaceSubscription is always false — additive, layering onto whatever the
-// daemon already tracks for this client rather than resetting it.
-function readParams(ref: string) {
+// Both hydrate paths (open-pane and watched) read a ref with exactly these
+// params, differing only in includeTurns: replaceSubscription is always
+// false — additive, layering onto whatever the daemon already tracks for this
+// client rather than resetting it.
+//
+// subscribe is true only when this connection generation holds no wire
+// subscription for the ref yet (see wireSubscribeDecision): a re-read of an
+// already-subscribed ref sends subscribe:false so the server skips the
+// buffered-capture cycle a second subscribe would run, and
+// releaseThread's unsubscribe is what drops the entry again.
+function threadReadParams(ref: string, includeTurns: boolean, subscribe: boolean) {
   return {
     ref,
-    includeTurns: true,
+    includeTurns,
     itemsView: "full",
-    subscribe: true,
+    subscribe,
     replaceSubscription: false,
     turnLimit: 40,
   } as const;
@@ -856,6 +871,56 @@ interface ThreadHydration {
   response: ThreadReadResponse;
 }
 
+// sendThreadUnsubscribe drops this client's wire subscription to a ref the
+// last holder of just released. Fire-and-forget on purpose: the local release
+// is already complete and cannot be rolled back, so a failed or racing
+// unsubscribe must not block navigation — the hub's idle-relay teardown and
+// the server's connection-close cleanup (RemoveConnection) are both
+// idempotent backstops for a lost message.
+function sendThreadUnsubscribe(ref: string): void {
+  const client = wiredClient;
+  if (client?.state !== "ready") return;
+  void client.request("thread/unsubscribe", { ref }).catch(() => {
+    // Swallow: see above. A dropped unsubscribe costs only a kept server-side
+    // subscription until the connection or the relay's idle timer ends it.
+  });
+}
+
+// The shared subscribe decision for both hydrate paths (open-pane and
+// watched): a read subscribes only when this connection generation holds no
+// wire subscription for the ref yet, and marks it held only after the read
+// succeeds — a failed read's subscribe never took effect server-side, so its
+// retry must send subscribe:true again.
+//
+// The membership set is NOT derivable from refCounts/watchRefCounts: those
+// count local interest (incremented synchronously, before any wire call),
+// while this records a fact about the wire (a subscribe that completed).
+// A count>0 with no held entry is exactly the pending-hydration and
+// failed-read-retry window, and deriving subscribe:false there would strand
+// the ref unsubscribed.
+//
+// markSubscribed re-checks holders after the read resolves: a release that
+// ran mid-flight left no holder, and that release saw the set WITHOUT this
+// ref (so it sent no unsubscribe). Recording the entry now would leak the
+// server-side subscription this read just created until connection close —
+// so the zero-holder read sends its own unsubscribe instead. A pinned
+// outbox ref is the deliberate exception: it holds no pane but must keep
+// its subscription for the mutation replay.
+function wireSubscribeDecision(ref: string): { subscribe: boolean; markSubscribed: () => void } {
+  const subscribe = !wireSubscribedRefs.has(ref);
+  return {
+    subscribe,
+    markSubscribed: () => {
+      if (!subscribe) return;
+      if ((refCounts.get(ref) ?? 0) <= 0 && (watchRefCounts.get(ref) ?? 0) <= 0 && !pinnedMutationRefs.has(ref)) {
+        sendThreadUnsubscribe(ref);
+        return;
+      }
+      wireSubscribedRefs.add(ref);
+    },
+  };
+}
+
 async function hydrateAndSubscribe(
   client: AppwireClientLike,
   ref: string,
@@ -863,8 +928,9 @@ async function hydrateAndSubscribe(
   pending: PendingThreadHydration,
 ): Promise<ThreadHydration> {
   let response: ThreadReadResponse;
+  const { subscribe, markSubscribed } = wireSubscribeDecision(ref);
   try {
-    response = await client.request("thread/read", readParams(ref));
+    response = await client.request("thread/read", threadReadParams(ref, true, subscribe));
   } catch (err) {
     // thread/read is answered from the daemon's in-memory snapshot, so a
     // rejection here is a transport failure, not a slow file read and not a
@@ -873,6 +939,7 @@ async function hydrateAndSubscribe(
     scheduleOwnedHydrationRetry("thread", ref, pending);
     throw err;
   }
+  markSubscribed();
   const model = hydrateThread(response, ref, now);
   applyHydrationResponseCut(pending, ref, model);
   return { model, response };
@@ -897,18 +964,10 @@ function markThreadDeletedIfFenced(ref: string, err: unknown): void {
   });
 }
 
-// Lean watches omit turns until an expanded card asks for them.
-function watchReadParams(ref: string, includeTurns = false) {
-  return {
-    ref,
-    includeTurns,
-    itemsView: "full",
-    subscribe: true,
-    replaceSubscription: false,
-    turnLimit: 40,
-  } as const;
-}
-
+// Lean watches omit turns until an expanded card asks for them; the shared
+// threadReadParams carries the rest (subscribe:false for a ref this
+// connection generation already subscribes — the read still refreshes the
+// snapshot).
 async function hydrateAndSubscribeWatch(
   client: AppwireClientLike,
   ref: string,
@@ -917,13 +976,15 @@ async function hydrateAndSubscribeWatch(
   includeTurns = false,
 ): Promise<ThreadModel> {
   let resp: ThreadReadResponse;
+  const { subscribe, markSubscribed } = wireSubscribeDecision(ref);
   try {
-    resp = await client.request("thread/read", watchReadParams(ref, includeTurns));
+    resp = await client.request("thread/read", threadReadParams(ref, includeTurns, subscribe));
   } catch (err) {
     markThreadDeletedIfFenced(ref, err);
     scheduleOwnedHydrationRetry("watched", ref, pending);
     throw err;
   }
+  markSubscribed();
   const model = hydrateThread(resp, ref, now);
   applyHydrationResponseCut(pending, ref, model);
   return model;
@@ -1814,6 +1875,11 @@ async function handleReady(client: AppwireClientLike, epoch: number, targetRef?:
 function rewireClient(client: AppwireClientLike): void {
   if (client === wiredClient) return;
   readyEpoch += 1;
+  // A different client is a different connection: every wire subscription
+  // this generation tracked belongs to a socket that is gone, so drop the
+  // whole set — handleReady's re-reads re-subscribe the still-tracked refs on
+  // the new client.
+  wireSubscribedRefs.clear();
   retireAllOwnedHydrations();
   dispatchReadyClient = null;
   dispatchReadyEpoch = -1;
@@ -1824,6 +1890,10 @@ function rewireClient(client: AppwireClientLike): void {
   unwireNotification = client.onNotification(handleNotification);
   unwireReady = client.onReady(() => {
     readyEpoch += 1;
+    // onReady is the SAME client reconnecting: its old connection's
+    // subscriptions are server-side gone too, even though the client object
+    // survives. handleReady re-subscribes the still-tracked refs.
+    wireSubscribedRefs.clear();
     retireAllOwnedHydrations();
     dispatchReadyClient = null;
     dispatchReadyEpoch = -1;
@@ -2103,10 +2173,14 @@ export const threadsStore = createStore<ThreadsStoreState>(() => ({
     inflightHydrateClients.delete(ref);
     inflightHydrateEpochs.delete(ref);
     pendingThreadHydrations.delete(ref);
-    // No wire call exists for "stop pushing me updates for this ref" (no
-    // thread/read subscribe:false, no unsubscribe method) — the daemon keeps
-    // sending; removing it from `threads` just stops handleNotification's
-    // per-model scan from matching it, so nothing routes here anymore.
+    // A watched lifecycle may still hold this ref (watchRefCounts), and its
+    // model stays; only the pane's own tracking goes. Unsubscribe the wire
+    // subscription when this was the last holder of either kind, so the hub
+    // stops relaying a thread nobody renders and its relay can idle out.
+    if (wireSubscribedRefs.has(ref) && (watchRefCounts.get(ref) ?? 0) <= 0) {
+      wireSubscribedRefs.delete(ref);
+      sendThreadUnsubscribe(ref);
+    }
     // frameTimes is dropped in lockstep — an untracked ref has no business
     // holding onto a liveness trace a future ensureThread() of the same ref
     // should start fresh, the same way it re-reads a fresh model.
@@ -2243,6 +2317,12 @@ export const threadsStore = createStore<ThreadsStoreState>(() => ({
     // the same ref starts lean again (yd16 §4.2).
     watchIncludeTurns.delete(ref);
     watchHydratedIncludeTurns.delete(ref);
+    // The open-pane lifecycle may still hold this ref; only when it is gone
+    // too does the wire subscription have no remaining holder.
+    if (wireSubscribedRefs.has(ref) && (refCounts.get(ref) ?? 0) <= 0) {
+      wireSubscribedRefs.delete(ref);
+      sendThreadUnsubscribe(ref);
+    }
     removeWatchedThreadModel(ref);
   },
 
@@ -2575,6 +2655,7 @@ export function resetThreadsStoreForTests(): void {
   watchGenerations.clear();
   watchIncludeTurns.clear();
   watchHydratedIncludeTurns.clear();
+  wireSubscribedRefs.clear();
   threadsIndex.clear();
   watchedThreadsIndex.clear();
   modelsCache = null;

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -89,6 +89,7 @@ no router (reserved).
 | `ping` | connection | `EmptyParams` | `EmptyResponse` | Connection keepalive, answered directly before the initialize gate (the browser's app-level heartbeat). |
 | `thread/list` | both | `ThreadListParams` | `ThreadListResponse` | Lists threads; the daemon returns its single session. |
 | `thread/read` | both | `ThreadReadParams` | `ThreadReadResponse` | Reads one thread and optionally subscribes to its live updates. |
+| `thread/unsubscribe` | both | `ThreadUnsubscribeParams` | `EmptyResponse` | Drops this connection's live-update subscription to a thread without reading it. |
 | `thread/turns/list` | both | `ThreadTurnsListParams` | `ThreadTurnsListResponse` | Pages turns backward (older) for lazy transcript loading; the cold load seeds the latest window via thread/read(turnLimit). |
 | `thread/turns/items/list` | unimplemented | `ThreadTurnItemsListParams` | `ThreadTurnItemsListResponse` | Codex-parity: paginated items for one turn. Experimental even in Codex (returns method-not-supported) and served by no evener router. |
 | `thread/start` | hub | `ThreadStartParams` | `ThreadStartResponse` | Starts a new thread and attaches a live-update relay. |
@@ -1684,6 +1685,14 @@ _(no fields)_
 |-------|---------|-----------|----------|
 | `data` | `[]appwire.Turn` |  |  |
 | `nextCursor` | `string` | yes |  |
+
+
+### `ThreadUnsubscribeParams`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `threadId` | `string` | yes |  |
+| `ref` | `string` | yes |  |
 
 
 ### `ThreadVisionModelChangedParams`

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -577,6 +577,27 @@ func Subscribe(ctx context.Context, threadID string) bool {
 	return true
 }
 
+// Unsubscribe drops the calling connection's subscription to one thread so a
+// browser switching views stops receiving its live updates and the relay can
+// idle out once no connection remains. Quietly a no-op when there is nothing
+// to remove (no connection on the context, an empty threadID, a connection
+// already replaced): teardown never needs to distinguish those. Unlike
+// Subscribe it takes no projection gate: removing a subscription only
+// shrinks delivery.
+func Unsubscribe(ctx context.Context, threadID string) {
+	conn, ok := ctx.Value(connectionContextKey{}).(*Connection)
+	if !ok || conn == nil || threadID == "" {
+		return
+	}
+	server := conn.server
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if server.conns[conn.id] != conn {
+		return
+	}
+	server.subs.Unsubscribe(conn.id, threadID)
+}
+
 func ReplaceSubscriptions(ctx context.Context, threadID string) bool {
 	conn, ok := ctx.Value(connectionContextKey{}).(*Connection)
 	if !ok || conn == nil {

--- a/internal/appserver/subscriptions.go
+++ b/internal/appserver/subscriptions.go
@@ -25,12 +25,17 @@ type Subscriptions struct {
 	mu       sync.RWMutex
 	byConn   map[string]map[string]*subscription
 	byThread map[string]map[string]*subscription
+	// withdrawn tracks threads a connection explicitly unsubscribed while a
+	// buffering capture held the entry, so the capture's abort restores its
+	// displaced snapshot minus exactly what the client dropped.
+	withdrawn map[string]map[string]struct{}
 }
 
 func NewSubscriptions() *Subscriptions {
 	return &Subscriptions{
-		byConn:   map[string]map[string]*subscription{},
-		byThread: map[string]map[string]*subscription{},
+		byConn:    map[string]map[string]*subscription{},
+		byThread:  map[string]map[string]*subscription{},
+		withdrawn: map[string]map[string]struct{}{},
 	}
 }
 
@@ -38,6 +43,41 @@ func (s *Subscriptions) Subscribe(connID, threadID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.subscribeLocked(&subscription{connID: connID, threadID: threadID})
+}
+
+// Unsubscribe removes the connection's subscription to one thread. It is
+// idempotent: unsubscribing a thread this connection never held is a no-op,
+// so a client racing its own re-subscribe can never wedge the registry.
+//
+// A thread currently held by a BUFFERING capture generation records the drop
+// and leaves the entry in place: the capture displaced the connection's
+// previous subscriptions into its rollback snapshot, and removing the
+// buffering entry here would strand that snapshot (withdrawBuffered matches
+// on the live generation and would bail without restoring). The generation's
+// own commit/abort resolves the entry — commit keeps it live, abort restores
+// the snapshot minus this thread.
+func (s *Subscriptions) Unsubscribe(connID, threadID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sub, ok := s.byConn[connID][threadID]
+	if !ok {
+		return
+	}
+	if sub.buffering {
+		if s.withdrawn[connID] == nil {
+			s.withdrawn[connID] = map[string]struct{}{}
+		}
+		s.withdrawn[connID][threadID] = struct{}{}
+		return
+	}
+	s.removeThreadLocked(connID, threadID)
+}
+
+// withdrawnLocked reports whether the connection explicitly unsubscribed the
+// thread while a buffering capture held it. Caller holds s.mu.
+func (s *Subscriptions) withdrawnLocked(connID, threadID string) bool {
+	_, ok := s.withdrawn[connID][threadID]
+	return ok
 }
 
 func (s *Subscriptions) ReplaceConnectionSubscriptions(connID, threadID string) {
@@ -88,6 +128,14 @@ func (s *Subscriptions) withdrawBuffered(
 		s.removeConnectionLocked(connID)
 		for i := range rollback.connection.subscriptions {
 			sub := rollback.connection.subscriptions[i]
+			if s.withdrawnLocked(connID, sub.threadID) {
+				// The client explicitly unsubscribed this thread mid-capture;
+				// restoring it would resurrect a thread it asked to stop
+				// receiving. Everything else the capture displaced comes back
+				// unchanged.
+				s.clearWithdrawnLocked(connID, sub.threadID)
+				continue
+			}
 			s.subscribeLocked(&sub)
 		}
 		return true
@@ -95,8 +143,13 @@ func (s *Subscriptions) withdrawBuffered(
 	s.removeThreadLocked(connID, threadID)
 	if rollback.threadPrevious != nil {
 		previous := *rollback.threadPrevious
-		s.subscribeLocked(&previous)
+		if s.withdrawnLocked(connID, previous.threadID) {
+			s.clearWithdrawnLocked(connID, previous.threadID)
+		} else {
+			s.subscribeLocked(&previous)
+		}
 	}
+	s.clearWithdrawnLocked(connID, threadID)
 	return true
 }
 
@@ -142,7 +195,22 @@ func (s *Subscriptions) Release(connID, threadID string, generation uint64) ([]S
 	}
 	sub.buffering = false
 	sub.buffer = nil
+	// The generation committed: the entry is live, so any mid-capture
+	// unsubscribe record for it is spent — clear it, or a later capture's
+	// abort would wrongly skip restoring this thread.
+	s.clearWithdrawnLocked(connID, threadID)
 	return release, true
+}
+
+// clearWithdrawnLocked drops one spent mid-capture unsubscribe record.
+// Caller holds s.mu.
+func (s *Subscriptions) clearWithdrawnLocked(connID, threadID string) {
+	if threads := s.withdrawn[connID]; threads != nil {
+		delete(threads, threadID)
+		if len(threads) == 0 {
+			delete(s.withdrawn, connID)
+		}
+	}
 }
 
 func (s *Subscriptions) IsSubscribed(connID, threadID string) bool {

--- a/internal/appserver/subscriptions_coverage_test.go
+++ b/internal/appserver/subscriptions_coverage_test.go
@@ -124,6 +124,98 @@ func TestSubscriptionsWithdrawBufferedReplace(t *testing.T) {
 	}
 }
 
+// A mid-capture unsubscribe against the buffering entry of a replace-capture
+// must not strand the capture's rollback snapshot: the abort still restores
+// the connection's other subscriptions, minus exactly the thread the client
+// dropped. Regression test for the shape where Unsubscribe removing the
+// buffering entry made withdrawBuffered bail at current==nil and silently
+// dropped every other subscription.
+func TestSubscriptionsUnsubscribeDuringReplaceCaptureDefersToAbort(t *testing.T) {
+	subs := NewSubscriptions()
+	subs.Subscribe("conn-1", "th_1")
+	subs.Subscribe("conn-1", "th_2")
+	rollback := subs.beginBuffered("conn-1", "th_3", true, 1)
+
+	// The client unsubscribes the thread the capture is hydrating, mid-flight.
+	subs.Unsubscribe("conn-1", "th_3")
+
+	// The buffering entry survives until the capture resolves.
+	if !subs.IsSubscribed("conn-1", "th_3") {
+		t.Fatal("mid-capture unsubscribe removed the buffering entry")
+	}
+	// The capture aborts (its read failed): the displaced snapshot comes back
+	// minus the dropped thread.
+	if !subs.withdrawBuffered("conn-1", "th_3", 1, rollback) {
+		t.Fatal("withdrawBuffered with replace should succeed after a mid-capture unsubscribe")
+	}
+	if !subs.IsSubscribed("conn-1", "th_1") {
+		t.Fatal("th_1 should be restored after the aborted capture")
+	}
+	if !subs.IsSubscribed("conn-1", "th_2") {
+		t.Fatal("th_2 should be restored after the aborted capture")
+	}
+	if subs.IsSubscribed("conn-1", "th_3") {
+		t.Fatal("th_3 should stay dropped: the client explicitly unsubscribed it")
+	}
+	// A later capture's abort must not skip th_1/th_2 because of the spent
+	// withdrawn record.
+	subs.Subscribe("conn-1", "th_2")
+	subs.Unsubscribe("conn-1", "th_2")
+	if subs.IsSubscribed("conn-1", "th_2") {
+		t.Fatal("th_2 should be unsubscribed normally once no capture holds it")
+	}
+}
+
+// The non-replace counterpart: a mid-capture unsubscribe defers to the
+// generation's abort, which restores the previous subscription for that
+// thread minus the client's drop.
+func TestSubscriptionsUnsubscribeDuringNonReplaceCaptureDefersToAbort(t *testing.T) {
+	subs := NewSubscriptions()
+	subs.Subscribe("conn-1", "th_1")
+	rollback := subs.beginBuffered("conn-1", "th_1", false, 3)
+
+	subs.Unsubscribe("conn-1", "th_1")
+	if !subs.IsSubscribed("conn-1", "th_1") {
+		t.Fatal("mid-capture unsubscribe removed the buffering entry")
+	}
+	if !subs.withdrawBuffered("conn-1", "th_1", 3, rollback) {
+		t.Fatal("withdrawBuffered should succeed after a mid-capture unsubscribe")
+	}
+	if subs.IsSubscribed("conn-1", "th_1") {
+		t.Fatal("th_1 should stay dropped: the client explicitly unsubscribed it")
+	}
+}
+
+// A committed capture clears the mid-capture unsubscribe record: the entry
+// went live, so a later capture's abort must restore it normally.
+func TestSubscriptionsUnsubscribeDuringCaptureThenCommit(t *testing.T) {
+	subs := NewSubscriptions()
+	subs.Subscribe("conn-1", "th_1")
+	subs.Subscribe("conn-1", "th_2")
+	subs.beginBuffered("conn-1", "th_3", true, 4)
+
+	subs.Unsubscribe("conn-1", "th_3")
+	if _, ok := subs.Release("conn-1", "th_3", 4); !ok {
+		t.Fatal("Release should succeed for the live generation")
+	}
+	if !subs.IsSubscribed("conn-1", "th_3") {
+		t.Fatal("committed capture should leave the entry live")
+	}
+	// A LATER capture that displaces th_3 must have it restored on its abort
+	// — the spent withdrawn record from generation 4 must not suppress it.
+	rollback2 := subs.beginBuffered("conn-1", "th_4", true, 5)
+	subs.Unsubscribe("conn-1", "th_4")
+	if !subs.withdrawBuffered("conn-1", "th_4", 5, rollback2) {
+		t.Fatal("second capture's abort should succeed")
+	}
+	if !subs.IsSubscribed("conn-1", "th_3") {
+		t.Fatal("the spent withdrawn record suppressed restoring th_3 on the later capture's abort")
+	}
+	if subs.IsSubscribed("conn-1", "th_4") {
+		t.Fatal("th_4 should stay dropped: the client explicitly unsubscribed it mid-capture")
+	}
+}
+
 func TestSubscriptionsReplaceConnectionSubscriptions(t *testing.T) {
 	subs := NewSubscriptions()
 	subs.Subscribe("conn-1", "th_1")

--- a/internal/appserver/subscriptions_test.go
+++ b/internal/appserver/subscriptions_test.go
@@ -29,3 +29,44 @@ func TestSubscriptionsRemoveConnection(t *testing.T) {
 		t.Fatalf("conn-2 subscription removed")
 	}
 }
+
+func TestSubscriptionsUnsubscribe(t *testing.T) {
+	subs := NewSubscriptions()
+	subs.Subscribe("conn-1", "th_1")
+	subs.Subscribe("conn-1", "th_2")
+	subs.Subscribe("conn-2", "th_1")
+
+	subs.Unsubscribe("conn-1", "th_1")
+
+	if subs.IsSubscribed("conn-1", "th_1") {
+		t.Fatalf("conn-1 still subscribed to th_1")
+	}
+	if !subs.IsSubscribed("conn-1", "th_2") {
+		t.Fatalf("conn-1 lost its other thread")
+	}
+	if !subs.IsSubscribed("conn-2", "th_1") {
+		t.Fatalf("conn-2 subscription removed")
+	}
+	if subs.ConnectionCount("th_1") != 1 {
+		t.Fatalf("th_1 connection count = %d, want 1 (only conn-2)", subs.ConnectionCount("th_1"))
+	}
+}
+
+func TestSubscriptionsUnsubscribeIdempotent(t *testing.T) {
+	subs := NewSubscriptions()
+	subs.Subscribe("conn-1", "th_1")
+	subs.Unsubscribe("conn-1", "th_1")
+	subs.Unsubscribe("conn-1", "th_1") // already gone; must not panic or re-add
+	subs.Unsubscribe("conn-2", "th_1") // never subscribed
+	subs.Unsubscribe("conn-1", "th_x") // never subscribed
+
+	if subs.IsSubscribed("conn-1", "th_1") {
+		t.Fatalf("conn-1 still subscribed")
+	}
+	if subs.ConnectionCount("th_1") != 0 || subs.ConnectionCount("th_x") != 0 {
+		t.Fatalf("thread maps kept entries: th_1=%d th_x=%d", subs.ConnectionCount("th_1"), subs.ConnectionCount("th_x"))
+	}
+	if got := subs.Threads("conn-1"); len(got) != 0 {
+		t.Fatalf("conn map kept entries: %+v", got)
+	}
+}

--- a/internal/appserver/websocket_test.go
+++ b/internal/appserver/websocket_test.go
@@ -203,3 +203,60 @@ func TestServeWebSocketPushesNotificationsToSubscribedThread(t *testing.T) {
 		t.Fatal("timed out waiting for notification")
 	}
 }
+
+func TestServeWebSocketUnsubscribeStopsThreadDelivery(t *testing.T) {
+	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
+	HandleTyped(server.Router(), appwire.MethodThreadRead, func(ctx context.Context, _ appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		Subscribe(ctx, "th_1")
+		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: "th_1"}}, nil
+	})
+	HandleTyped(server.Router(), appwire.MethodThreadUnsubscribe, func(ctx context.Context, params appwire.ThreadUnsubscribeParams) (appwire.EmptyResponse, error) {
+		Unsubscribe(ctx, params.ThreadID)
+		return appwire.EmptyResponse{}, nil
+	})
+	httpServer := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
+	defer httpServer.Close()
+
+	ctx := context.Background()
+	transport, err := appwire.DialWebSocket(ctx, "ws"+httpServer.URL[len("http"):], httpServer.Client())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer transport.Close()
+	client := appwire.NewClient(transport)
+	client.Start(ctx)
+
+	if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if _, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:th_1"}); err != nil {
+		t.Fatalf("ThreadRead: %v", err)
+	}
+	if server.SubscriberCount("th_1") != 1 {
+		t.Fatalf("subscriber count after read = %d, want 1", server.SubscriberCount("th_1"))
+	}
+
+	if _, err := client.ThreadUnsubscribe(ctx, appwire.ThreadUnsubscribeParams{ThreadID: "th_1"}); err != nil {
+		t.Fatalf("ThreadUnsubscribe: %v", err)
+	}
+	if server.SubscriberCount("th_1") != 0 {
+		t.Fatalf("subscriber count after unsubscribe = %d, want 0", server.SubscriberCount("th_1"))
+	}
+
+	// After the unsubscribe the connection must no longer receive the
+	// thread's notifications.
+	server.Broadcast("th_1", appwire.NotifyThreadStatusChanged, appwire.ThreadStatusChangedParams{
+		ThreadID: "th_1",
+		Status:   appwire.ThreadStatus{Type: appwire.ThreadStatusActive},
+	})
+	select {
+	case got := <-client.Notifications():
+		t.Fatalf("notification delivered after unsubscribe: %+v", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Unsubscribe is idempotent: a second call still succeeds.
+	if _, err := client.ThreadUnsubscribe(ctx, appwire.ThreadUnsubscribeParams{ThreadID: "th_1"}); err != nil {
+		t.Fatalf("second ThreadUnsubscribe: %v", err)
+	}
+}

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -924,6 +924,7 @@ func (s *Server) registerAppWireHandlers() {
 	router := s.appServer.Router()
 	appserver.HandleTyped(router, appwire.MethodThreadList, s.handleAppThreadList)
 	appserver.HandleTyped(router, appwire.MethodThreadRead, s.handleAppThreadRead)
+	appserver.HandleTyped(router, appwire.MethodThreadUnsubscribe, s.handleAppThreadUnsubscribe)
 	appserver.HandleTyped(router, appwire.MethodTurnStart, s.handleAppTurnStart)
 	appserver.HandleTyped(router, appwire.MethodTurnSteer, s.handleAppTurnSteer)
 	appserver.HandleTyped(router, appwire.MethodEvenerSandboxEscalationResolve, s.handleAppSandboxEscalationResolve)
@@ -1022,6 +1023,34 @@ func (s *Server) appThreadReadSnapshot(params appwire.ThreadReadParams) appwire.
 		thread.Turns, olderCursor = s.appLatestTurns(thread.ID, params.TurnLimit)
 	}
 	return appwire.ThreadReadResponse{Thread: thread, OlderCursor: olderCursor}
+}
+
+// handleAppThreadUnsubscribe drops the calling connection's subscription to
+// this daemon's thread. It resolves the thread identity exactly as
+// handleAppThreadRead does, so an unsubscribe names the same registry key the
+// subscribe created — including through a replace/clear identity swap, where
+// appNotificationTarget's stable ref is the key subscribers were registered
+// under. A ref that no longer resolves (an identity swap moved the stable ref
+// on, an old pre-swap ref) still tries the raw identities the client named:
+// the registry keys a subscribe could have used are exactly the stable-ref
+// form and the bare thread ID, and Unsubscribe is idempotent, so trying both
+// costs nothing and leaks nothing.
+func (s *Server) handleAppThreadUnsubscribe(ctx context.Context, params appwire.ThreadUnsubscribeParams) (appwire.EmptyResponse, error) {
+	threadID := s.appThreadIDForRead(appwire.ThreadReadParams{ThreadID: params.ThreadID, Ref: params.Ref})
+	if threadID == "" {
+		// Teardown finding nothing is a success; still try the raw identities
+		// so a pre-swap key does not linger until connection close.
+		rawRef := strings.TrimSpace(params.Ref)
+		if rawRef != "" {
+			appserver.Unsubscribe(ctx, rawRef)
+		}
+		if bare := strings.TrimSpace(params.ThreadID); bare != "" {
+			appserver.Unsubscribe(ctx, s.appNotificationTarget(bare))
+		}
+		return appwire.EmptyResponse{}, nil
+	}
+	appserver.Unsubscribe(ctx, s.appNotificationTarget(threadID))
+	return appwire.EmptyResponse{}, nil
 }
 
 func (s *Server) appThreadIDForRead(params appwire.ThreadReadParams) string {

--- a/server/appwire_server_test.go
+++ b/server/appwire_server_test.go
@@ -2053,6 +2053,145 @@ func TestServerAppWireRootAndDescendantSubscribeOnOneConnection(t *testing.T) {
 	}
 }
 
+// thread/unsubscribe drops one connection's subscription to a thread — the
+// same registry entry a subscribed thread/read created — and is idempotent.
+// The hub-facing counterpart (relay teardown) rides on this count reaching 0.
+func TestServerAppWireThreadUnsubscribeDropsSubscription(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+
+	httpServer := httptest.NewServer(http.HandlerFunc(srv.AppServer().ServeWebSocket))
+	defer httpServer.Close()
+	ctx := context.Background()
+	transport, err := appwire.DialWebSocket(ctx, "ws"+httpServer.URL[len("http"):], httpServer.Client())
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	defer transport.Close() //nolint:errcheck // test cleanup
+	client := appwire.NewClient(transport)
+	client.Start(ctx)
+	if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	if _, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:th_1", Subscribe: true}); err != nil {
+		t.Fatalf("thread read: %v", err)
+	}
+	if got := srv.AppSubscriberCount("th_1"); got != 1 {
+		t.Fatalf("subscriber count after subscribe = %d, want 1", got)
+	}
+
+	if _, err := client.ThreadUnsubscribe(ctx, appwire.ThreadUnsubscribeParams{Ref: "local:th_1"}); err != nil {
+		t.Fatalf("thread unsubscribe: %v", err)
+	}
+	if got := srv.AppSubscriberCount("th_1"); got != 0 {
+		t.Fatalf("subscriber count after unsubscribe = %d, want 0", got)
+	}
+
+	// Unsubscribed, the connection no longer receives this thread's events.
+	srv.RecordAppEvent(events.SessionEvent{Kind: events.EventAssistantTextDelta, SessionID: "th_1", Data: events.AssistantTextDeltaData{Delta: "post-unsubscribe"}})
+	select {
+	case notification := <-client.Notifications():
+		t.Fatalf("notification delivered after unsubscribe: %+v", notification)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Idempotent: unsubscribing again succeeds quietly.
+	if _, err := client.ThreadUnsubscribe(ctx, appwire.ThreadUnsubscribeParams{Ref: "local:th_1"}); err != nil {
+		t.Fatalf("second thread unsubscribe: %v", err)
+	}
+	if got := srv.AppSubscriberCount("th_1"); got != 0 {
+		t.Fatalf("subscriber count after second unsubscribe = %d, want 0", got)
+	}
+}
+
+// Across a replace/clear identity swap, a subscriber registered under the
+// STABLE REF must be removable by an unsubscribe naming that ref after the
+// swap advanced the session: the resolution path maps the ref to the current
+// session and back to the stable ref — the same key the subscribe used.
+func TestServerAppWireThreadUnsubscribeResolvesStableRefAcrossSwap(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_old")
+	prepared, err := PrepareAppIdentityForRef("local", "th_new", "local:th_stable", "")
+	if err != nil {
+		t.Fatalf("prepare replacement identity: %v", err)
+	}
+	srv.ReplaceAppIdentity(prepared, nil)
+
+	httpServer := httptest.NewServer(http.HandlerFunc(srv.AppServer().ServeWebSocket))
+	defer httpServer.Close()
+	ctx := context.Background()
+	transport, err := appwire.DialWebSocket(ctx, "ws"+httpServer.URL[len("http"):], httpServer.Client())
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	defer transport.Close() //nolint:errcheck // test cleanup
+	client := appwire.NewClient(transport)
+	client.Start(ctx)
+	if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	if _, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:th_stable", Subscribe: true}); err != nil {
+		t.Fatalf("subscribed read via stable ref: %v", err)
+	}
+	if got := srv.AppSubscriberCount("th_new"); got != 1 {
+		t.Fatalf("subscriber count after subscribe via stable ref = %d, want 1", got)
+	}
+
+	// The unsubscribe names the SAME stable ref, after the swap.
+	if _, err := client.ThreadUnsubscribe(ctx, appwire.ThreadUnsubscribeParams{Ref: "local:th_stable"}); err != nil {
+		t.Fatalf("unsubscribe via stable ref: %v", err)
+	}
+	if got := srv.AppSubscriberCount("th_new"); got != 0 {
+		t.Fatalf("subscriber count after unsubscribe via stable ref = %d, want 0", got)
+	}
+}
+
+// An unsubscribe for a ref the daemon no longer resolves (the pre-swap ref)
+// quietly succeeds and still clears the raw key the subscribe could have
+// used — teardown finding nothing is a success, and a lingering key must
+// not outlive the client's interest.
+func TestServerAppWireThreadUnsubscribeUnresolvedRefCleansRawKeys(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_live")
+
+	httpServer := httptest.NewServer(http.HandlerFunc(srv.AppServer().ServeWebSocket))
+	defer httpServer.Close()
+	ctx := context.Background()
+	transport, err := appwire.DialWebSocket(ctx, "ws"+httpServer.URL[len("http"):], httpServer.Client())
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	defer transport.Close() //nolint:errcheck // test cleanup
+	client := appwire.NewClient(transport)
+	client.Start(ctx)
+	if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	// Subscribe to the live thread by its bare id (one raw key form).
+	if _, err := client.ThreadRead(ctx, appwire.ThreadReadParams{ThreadID: "th_live", Subscribe: true}); err != nil {
+		t.Fatalf("subscribed read by bare id: %v", err)
+	}
+	if got := srv.AppSubscriberCount("th_live"); got != 1 {
+		t.Fatalf("subscriber count after subscribe = %d, want 1", got)
+	}
+
+	// A ref this daemon never served: quiet success, nothing removed.
+	if _, err := client.ThreadUnsubscribe(ctx, appwire.ThreadUnsubscribeParams{Ref: "local:th_never_served"}); err != nil {
+		t.Fatalf("unsubscribe for unresolvable ref: %v", err)
+	}
+	if got := srv.AppSubscriberCount("th_live"); got != 1 {
+		t.Fatalf("unrelated unsubscribe changed the live count = %d, want 1", got)
+	}
+
+	// The same connection unsubscribes its own bare-id key.
+	if _, err := client.ThreadUnsubscribe(ctx, appwire.ThreadUnsubscribeParams{ThreadID: "th_live"}); err != nil {
+		t.Fatalf("unsubscribe by thread id: %v", err)
+	}
+	if got := srv.AppSubscriberCount("th_live"); got != 0 {
+		t.Fatalf("subscriber count after bare-id unsubscribe = %d, want 0", got)
+	}
+}
+
 func TestServerRejectsLateDescendantEventAfterIdentityReplacement(t *testing.T) {
 	srv := NewServer(ServerConfig{})
 	srv.SetAppIdentity("local", "old-root")


### PR DESCRIPTION
# feat(hub): thread/unsubscribe + subscribe dedup for live-update subscriptions

Addresses the lifecycle item from #641.

## Problem

The hub's browser client had no way to stop a thread's live updates once it started them:

1. **No wire unsubscribe existed.** `releaseThread` was a local refcount only (threads.ts ~2106 documented "No wire call exists"); the daemon kept relaying a thread nobody was rendering. `SubscriberCount(relayKey)` never reached 0, so the hub's idle-relay teardown never fired and each abandoned view left a daemon-side delivery stream running.

2. **Every re-read re-subscribed.** Each `thread/read` with `subscribe:true` (first subscribe, onReady resync, watchThread, resync recovery) kicked another buffered-cut capture cycle server-side and re-registered the (idempotent) registry entry — additive churn for a subscription the connection already held.

## Fix

**Protocol** — new `thread/unsubscribe` method (ScopeBoth; params `threadId`/`ref`; `EmptyResponse`), catalog entry, client helper, generated doc + TS types refreshed (`make generate`, `make fuzz-goldens`).

**appserver** — `Unsubscribe(ctx, threadID)` + `Subscriptions.Unsubscribe(connID, threadID)`: removes the connection's entry via the existing `removeThreadLocked`; idempotent by construction (no entry → no-op). A thread currently held by a **buffering capture generation** records the drop and defers to that generation's resolution: commit keeps the entry live and clears the record; abort restores the capture's displaced snapshot *minus* the dropped thread. (Without this, removing the buffering entry mid-capture stranded the rollback snapshot and silently dropped the connection's other subscriptions.) No projection gate: removal only shrinks delivery.

**Hub handler** (app_rpc.go) — resolves through the plain registry (`sourceForThread`, never the managed-launch path — an unsubscribe must not spawn a codex session to compute its key) and derives the relay key via the shared `threadRelayTarget` helper the relay's subscribe path uses, so subscribe and unsubscribe can never disagree about which registry entry they name. When no source resolves, the parsed ref's own namespace is the fallback key. Downstream unsubscribe lets `SubscriberCount(relayKey)` hit 0 so the existing idle-relay ticker retires the relay and closes the daemon-side lease.

**Daemon handler** (appwire_runtime.go) — resolves the thread through `appThreadIDForRead` and `appNotificationTarget` (stable-ref aware, so an unsubscribe after a clear/replace targets the key the subscriber was registered under). A ref that no longer resolves (a pre-swap ref) quietly succeeds and still clears the raw identities the client named — teardown finding nothing is a success.

**Frontend** (threads.ts) — `wireSubscribedRefs` tracks which refs hold a subscription on the current connection generation:
- a re-read of an already-subscribed ref sends `subscribe:false` (plain read, no new capture cycle);
- `releaseThread`/`releaseWatchedThread` send `thread/unsubscribe` when the last holder of either kind releases (a pane release while a watcher remains keeps the subscription);
- `rewireClient`, the `onReady` transition, and `reset` clear the set (a new connection carries no subscriptions); the next read of a still-tracked ref re-subscribes.

Fire-and-forget send: the local release is not rollback-able, so a failed unsubscribe must not block navigation; the hub's idle-relay teardown and connection-close cleanup (`RemoveConnection`) are idempotent backstops.

## Tests

- Registry: `TestSubscriptionsUnsubscribe`, `TestSubscriptionsUnsubscribeIdempotent`, and the capture-interaction trio `TestSubscriptionsUnsubscribeDuringReplaceCaptureDefersToAbort` / `...DuringNonReplaceCaptureDefersToAbort` / `...DuringCaptureThenCommit` (all red-probed against the naive always-remove form)
- appserver wire round-trip: `TestServeWebSocketUnsubscribeStopsThreadDelivery` (subscribe → count 1 → unsubscribe → count 0 → broadcast not delivered → second unsubscribe quiet)
- Hub e2e: `TestHubRPCThreadUnsubscribeDropsDownstreamSubscription` (through the real router, real relay source) and `TestHubRPCThreadUnsubscribeUnresolvedSourceIsQuiet` (the fallback branch: quiet success, no launcher consulted)
- Daemon: `TestServerAppWireThreadUnsubscribeDropsSubscription`, `...ResolvesStableRefAcrossSwap` (identity-swap key continuity), `...UnresolvedRefCleansRawKeys`
- Frontend: 5 new tests in threads.test.ts — final-release unsubscribe (earlier releases don't), re-ensure re-subscribes with `subscribe:true`, resync re-read sends `subscribe:false`, reconnect re-subscribes on the new connection, pane-release-with-live-watcher does not unsubscribe. Red-probed: the `subscribe:false` and watcher-guard tests fail against the old code.
- Catalog cross-checks (`TestHubRouterMatchesCatalog`, `TestHubRPCRegistersExpectedHandlerSet`, daemon equivalents) updated and passing.

Gates: `make test-web` green; `go test ./appwire/ ./internal/appserver/ ./server/ ./cmd/evener-hub/...` green; `-race` over the appserver subscription/websocket surface; `biome ci src` clean; `go vet` clean.

Refs #641 (lifecycle item; the duplicate-delta server-side emission is tracked separately there).
