### PR TITLE
fix(tui-test): pin spawn-form model default race in APIErrorsRenderInPlace e2e

### DIFF
--- a/cmd/evener-tui/tmux_e2e_test.go
+++ b/cmd/evener-tui/tmux_e2e_test.go
@@ -1005,7 +1005,13 @@ func TestTUITmuxE2E_APIErrorsRenderInPlace(t *testing.T) {
 	app.WaitFor("EVENER LIVE", "live task")
 	hub.SetFailSpawn(true)
 	app.SendKeys("n")
-	app.WaitFor("evener / new session", "Prompt (optional):")
+	// The form's model default arrives asynchronously (fetchHubSpawnOptions
+	// round-trips to the hub); submitting before hubSpawnOptionsMsg lands sees
+	// an empty spawnModel and renders "choose a model before starting" instead
+	// of the scripted spawn failure — a startup race a loaded CI runner loses.
+	// Waiting for the populated Model field pins the happens-before edge the
+	// same way the harness-cycling spawn test does.
+	app.WaitFor("evener / new session", "Prompt (optional):", "Model:    openai/gpt-5")
 	app.TypeLine("spawn should fail")
 	app.WaitFor("Hub session start failed.", "cause appwire thread/start: spawn failed", "> spawn should fail")
 }


### PR DESCRIPTION
## Summary

Follow-up to #633. PR #633 merged (squash, e892c8eeb) at 11:46 PDT, but the flake fix for `TestTUITmuxE2E_APIErrorsRenderInPlace` was committed 12 minutes later — it landed on the orphaned `doctor-tool-build` branch and never reached main. This PR carries that fix onto main.

## Root cause

A startup race in the test, not ambient config. Pressing `n` clears the spawn form's model field (`resetSpawnForm`), and the default model only repopulates when `hubSpawnOptionsMsg` arrives — an async WebSocket round-trip to the hub's `ModelList`. The test submitted the form after waiting only for `"Prompt (optional):"`. On a loaded Linux CI runner, Enter could be consumed before the model default landed, so `spawnModel` was empty and the TUI rendered `"choose a model before starting"` instead of the scripted spawn failure (CI run 33304123980 on the #633 head). Local macOS wins the race in milliseconds, which is why it passed locally.

Proven both directions with a temporary 1.5s `ModelList` delay on the fake hub: the unfixed test failed with CI's exact output; the fixed test passes under the same delay. All instrumentation removed; no production code changed.

## Fix

One line + comment: the test's `WaitFor` now also requires `"Model:    openai/gpt-5"` before submitting, pinning the same happens-before edge the sibling harness-cycling spawn test already pins (tmux_e2e_test.go:375). No timeout bumps, retries, or skips.

## Verification

- `-count=20`: 20/20 pass; `-count=5` re-verified on this branch (5/5)
- Scrubbed env (`env -i`, clean HOME/XDG): pass
- Whole package `go test ./cmd/evener-tui/ -count=1`: green
- `go vet ./cmd/evener-tui/...`, `golangci-lint run ./cmd/evener-tui/...`: clean

## Known follow-up (out of scope)

The dashboard/project spawn test (tmux_e2e_test.go:121) has the same latent race — waits for `Dir:`/`Prompt:` but not `Model:`. A one-line `WaitFor` addition would pin it too.
