### PR TITLE
fix(tui-test): pin spawn-form model default race in DashboardProjectAndSpawn e2e

### DIFF
--- a/cmd/evener-tui/tmux_e2e_test.go
+++ b/cmd/evener-tui/tmux_e2e_test.go
@@ -118,7 +118,14 @@ func TestTUITmuxE2E_DashboardProjectAndSpawn(t *testing.T) {
 	app.WaitFor("EVENER LIVE", "live task", "ended maintenance")
 
 	app.SendKeys("n")
-	app.WaitFor("evener / new session", "Dir:      "+tuiE2EProjectDir, "Prompt (optional):")
+	// The form's model default arrives asynchronously (fetchHubSpawnOptions
+	// round-trips to the hub); submitting before hubSpawnOptionsMsg lands sees
+	// an empty spawnModel and renders "choose a model before starting" — the
+	// startup race that flaked TestTUITmuxE2E_APIErrorsRenderInPlace in CI
+	// (issue #656). Waiting for the populated Model field pins the
+	// happens-before edge the way that test and the harness-cycling spawn
+	// test do.
+	app.WaitFor("evener / new session", "Dir:      "+tuiE2EProjectDir, "Prompt (optional):", "Model:    openai/gpt-5")
 	app.SendKeys("Tab", "Tab", "Tab", "C-u")
 	app.TypeText("/tmp/evener-e2e/custom")
 	app.WaitFor("Dir:      /tmp/evener-e2e/custom")


### PR DESCRIPTION
## Summary

Fixes #656.

The first spawn segment of `TestTUITmuxE2E_DashboardProjectAndSpawn` had the same latent startup race that flaked `TestTUITmuxE2E_APIErrorsRenderInPlace` in CI (fixed in #654): it waited for `Dir:`/`Prompt:` but not the populated `Model:` field. Pressing `n` clears `spawnModel`, and the default only repopulates when `hubSpawnOptionsMsg` arrives — an async WebSocket round-trip to the hub's `ModelList`. Submitting before that lands renders "choose a model before starting" instead of proceeding. The test's keystroke sequence only lowered the race's probability on a loaded runner.

## Fix

One line + comment: the first segment's `WaitFor` now also requires `"Model:    openai/gpt-5"`, pinning the same happens-before edge as `TestTUITmuxE2E_APIErrorsRenderInPlace` and `TestTUITmuxE2E_HarnessModelPicker` (line ~375). The second spawn segment is implicitly synchronized via `"Plugins: 2/2 enabled"` and is unchanged.

No timeout bumps, retries, or skips. Test-only change; no production code touched.

## Verification

- `-count=10`: 10/10 pass; `-count=5` re-verified (5/5)
- `go vet ./cmd/evener-tui/...`: clean
- `golangci-lint run ./cmd/evener-tui/...`: 0 issues
- `gofmt -l`: clean

Reproduction method (from the #654 investigation): a temporary 1.5s delay on the fake hub's `handleModelList` makes the unfixed test fail with the same "choose a model before starting" output. No instrumentation remains in the tree.
