### PR TITLE
fix(appserver-test): condition-wait for busy-handler keepalive ping decision (was flaky under -race)

### DIFF
--- a/internal/appserver/websocket_test.go
+++ b/internal/appserver/websocket_test.go
@@ -103,19 +103,33 @@ func TestServeWebSocketPingsIdleReaderWhileBusyRPCHandlerRuns(t *testing.T) {
 	// Drive the actual ServeWebSocket keepalive goroutine while HandleMessage is
 	// held busy in a handler goroutine. Concurrent dispatch keeps the receive
 	// loop reading, so the gate observes an available reader and the keepalive
-	// pings even while the RPC handler is still held. The decision is emitted
-	// only after the gate has been consulted, so release is not time-based.
-	ticker.Tick()
-	select {
-	case attempted := <-decision:
-		if !attempted {
-			t.Fatal("keepalive did not attempt a ping while the receive loop was free and the RPC handler was busy")
+	// pings even while the RPC handler is still held.
+	//
+	// The receive loop's transition back to an available reader is not ordered
+	// against the handler goroutine reaching handlerStarted: dispatchMessage
+	// runs the handler on its own goroutine, so a tick can land while the loop
+	// is still between readerUnavailable() and its next readerAvailable(). Each
+	// tick reports one gate decision, so the condition under test is the first
+	// attempted decision, not the decision from the first tick. The receive
+	// loop deterministically parks in Recv with the reader available while the
+	// handler is held, so this wait terminates rather than polling a window.
+	busyPingDeadline := time.NewTimer(time.Minute)
+	defer busyPingDeadline.Stop()
+	released := false
+	for !released {
+		ticker.Tick()
+		select {
+		case attempted := <-decision:
+			if attempted {
+				release()
+				released = true
+			}
+		case <-idlePingSeen:
+			release()
+			released = true
+		case <-busyPingDeadline.C:
+			t.Fatal("keepalive never attempted a ping while the receive loop was free and the RPC handler was busy")
 		}
-		release()
-	case <-idlePingSeen:
-		release()
-	case <-time.After(time.Second):
-		t.Fatal("keepalive did not report the available-reader decision")
 	}
 
 	select {


### PR DESCRIPTION
## Summary

Fixes #640.

`TestServeWebSocketPingsIdleReaderWhileBusyRPCHandlerRuns` asserted that the **first** controlled tick after `handlerStarted` yields an `attempted=true` keepalive decision. That is not an invariant: `dispatchMessage` runs the RPC handler on its own goroutine, so `handlerStarted` can be observed while the receive loop is still between `readerUnavailable()` and its next `readerAvailable()`. A tick landing in that window consults the reader-availability gate as unavailable and reports `decision=false`, firing the line-112 assertion even though the keepalive logic is correct. `-race` widens this scheduling window, which is when the flake fires.

**Correction to the issue's analysis:** the failure is not a missed 1-second deadline (that would be the line-118 "did not report the available-reader decision" message). Both CI failures on record — PR #582 (run 33298875440) and PR #654 (run 33330196547) — show the line-112 message, i.e. a `false` decision, not a late one.

## Fix

Replace the single-tick wall-clock assertion with a condition wait, mirroring the test's existing phase-2 loop (which already uses tick-until-condition): keep driving `ticker.Tick()` until the first `attempted=true` decision (or `idlePingSeen`), then release. The wait terminates deterministically — while the handler is held, the receive loop has no further frames to read and parks in `Recv` with the reader available. A generous 1-minute `t.Fatal` safety net catches genuine regressions without ever firing under scheduling pressure.

No production code changed. Coverage intent preserved: keepalive must still ping while the RPC handler is busy and the receive loop is free — now asserted on the accumulated condition instead of one tick's window.

## Reproduction (honest)

Not reproducible on the dev machine used for the fix: `-race -count=200` (200/200 ok) and ~760 further executions under CPU saturation (32 `yes` processes, parallel test runs), zero failures pre-fix. The flake needs CI's scheduling shape. The fix is grounded in the static ordering argument above — the assertion demanded an ordering the code never guaranteed — plus the matching CI failure messages.

## Verification

- Targeted `-race -count=100`: 100/100 (subagent); `-count=30` re-verified independently (30/30)
- Loaded-machine parallel runs: 7/7 ok (4× targeted + 3× whole-package concurrent)
- `go test -race ./internal/appserver/ -count=2`: ok
- `go vet ./internal/appserver/...`: clean
- `golangci-lint run ./internal/appserver/...`: 0 issues
- `gofmt -l`: clean

## Sibling exposure

`TestWebSocketKeepaliveSkipsPingsWhileReaderIsUnavailable` (websocket_keepalive_test.go) shares the controlled-ticker/decision-channel pattern, but its gate state is set directly by the test goroutine before ticking — ordering is deterministic, no exposure. No other test uses `keepaliveDecision`.

This should also unblock the red `tests` job on #654, which failed on this exact test.
