### PR TITLE
fix(appserver): narrow concurrent dispatch to slow reads and restore the panic barrier

### DIFF
--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -106,6 +106,18 @@ func (s *Server) logf(format string, args ...any) {
 	}
 }
 
+// panicLogf reports a handler panic. It prefers the embedder's configured
+// sink so panic lines ride the same channel as every other server-initiated
+// event, but unlike logf it never drops the line: a panic must stay visible
+// even when the embedder configured no logger.
+func (s *Server) panicLogf(format string, args ...any) {
+	if s.cfg.Logf != nil {
+		s.cfg.Logf(format, args...)
+		return
+	}
+	log.Printf(format, args...)
+}
+
 // evictSlowConsumer unregisters a connection whose outbound buffer is full.
 // The buffer holds appwire.NotificationBufferCap frames — any legitimate
 // burst fits — so a full one means the peer stopped draining, not that its
@@ -459,11 +471,9 @@ func (c *Connection) HandleMessage(ctx context.Context, msg appwire.Message) app
 	}
 	req := *msg.Request
 	// ping is the browser's app-level heartbeat (browsers cannot send WS ping
-	// frames from JS). It bypasses the router, and dispatchMessage answers it
-	// inline in the receive loop, so however busy the slow-read handler
-	// goroutines get, ping is never starved. (Inline handlers do occupy the
-	// receive loop ahead of a queued ping, which is why they must stay
-	// bounded.)
+	// frames from JS). It bypasses the router and is answered here, before
+	// the initialize gate; dispatchMessage owns the inline-vs-concurrent
+	// policy that keeps it responsive.
 	if req.Method == appwire.MethodPing {
 		return appwire.ResponseMessage(req.ID, struct{}{})
 	}
@@ -822,14 +832,16 @@ func concurrentDispatchMethod(method string) bool {
 // policy lives on the Connection so any second transport inherits the same
 // sequencing for free.
 //
-// The contract: requests are serial per connection — a later request does
-// not begin until an earlier one completes — EXCEPT the slow-read methods
+// Requests are serial per connection — a later request does not begin until
+// an earlier one completes — EXCEPT the slow-read methods
 // concurrentDispatchMethod names, which run on their own goroutine so a
 // full-transcript read cannot head-of-line block the connection. A later
 // request can therefore dispatch while a slow read (including a hydrating
 // read parked in its snapshot clone) is still in flight; responses pair by
 // request ID, and only the sequence-cut discipline governs how notifications
-// interleave with a hydration response.
+// interleave with a hydration response. An inline handler occupies the
+// receive loop — ping included, since ping is answered inline — so every
+// method outside the concurrent set must stay bounded.
 //
 // Ordering constraints in detail:
 //
@@ -839,10 +851,6 @@ func concurrentDispatchMethod(method string) bool {
 //     required"), and the initialize handshake itself completes — response
 //     enqueued — before the loop reads another frame. Dispatch of later
 //     requests therefore cannot observe a half-initialized connection.
-//   - notifications and ping are always handled inline: they are bounded
-//     work, and answering ping inline is what keeps the app-level heartbeat
-//     responsive while a slow read is busy. (An inline handler does occupy
-//     the receive loop, so every non-slow-read handler must stay bounded.)
 //   - responses enter the connection send queue through the same
 //     enqueueResponse path on both dispatch modes, so hydration capture
 //     commit/abort ordering is unchanged.
@@ -852,11 +860,13 @@ func concurrentDispatchMethod(method string) bool {
 // canceling the shared context is enough — the next Recv fails and the loop
 // exits with the normal close handling.
 func (c *Connection) dispatchMessage(ctx context.Context, msg appwire.Message) {
-	if msg.Request == nil || !c.isInitialized() || !concurrentDispatchMethod(msg.Request.Method) {
-		c.handleAndEnqueue(ctx, msg)
+	// concurrentDispatchMethod is checked before isInitialized so the common
+	// inline path never takes the connection mutex.
+	if msg.Request != nil && concurrentDispatchMethod(msg.Request.Method) && c.isInitialized() {
+		go c.handleAndEnqueue(ctx, msg)
 		return
 	}
-	go c.handleAndEnqueue(ctx, msg)
+	c.handleAndEnqueue(ctx, msg)
 }
 
 // handleAndEnqueue runs one request through HandleMessage and enqueues its
@@ -869,7 +879,7 @@ func (c *Connection) dispatchMessage(ctx context.Context, msg appwire.Message) {
 func (c *Connection) handleAndEnqueue(ctx context.Context, msg appwire.Message) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("appserver: panic handling %s: %v\n%s", methodOf(msg), r, debug.Stack())
+			c.server.panicLogf("appserver: panic handling %s: %v\n%s", methodOf(msg), r, debug.Stack())
 			if msg.Request != nil {
 				c.enqueueDispatched(ctx, appwire.ErrorMessage(msg.Request.ID, appwire.InternalError("internal error handling request")))
 			}

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
+	"runtime/debug"
 	"sort"
 	"sync"
 	"time"
@@ -877,9 +879,35 @@ func (c *Connection) dispatchMessage(ctx context.Context, msg appwire.Message) {
 }
 
 // handleAndEnqueue runs one request through HandleMessage and enqueues its
-// response.
+// response. It is the panic barrier for handler code: a panicking handler is
+// logged with its stack and answered with an InternalError response, and the
+// connection lives on. Handlers dispatched on their own goroutine have no
+// other recover between them and the runtime (the net/http barrier only
+// covers the receive loop's goroutine), and the inline path shares the
+// barrier so both dispatch modes contain a panic identically.
 func (c *Connection) handleAndEnqueue(ctx context.Context, msg appwire.Message) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("appserver: panic handling %s: %v\n%s", methodOf(msg), r, debug.Stack())
+			if msg.Request != nil {
+				c.enqueueDispatched(ctx, appwire.ErrorMessage(msg.Request.ID, appwire.InternalError("internal error handling request")))
+			}
+		}
+	}()
 	c.enqueueDispatched(ctx, c.HandleMessage(ctx, msg))
+}
+
+// methodOf names a message's method for the panic log; a frame that is
+// neither request nor notification cannot reach a handler, but the barrier
+// covers it anyway.
+func methodOf(msg appwire.Message) string {
+	switch {
+	case msg.Request != nil:
+		return msg.Request.Method
+	case msg.Notification != nil:
+		return msg.Notification.Method
+	}
+	return "invalid frame"
 }
 
 // enqueueDispatched is the one enqueue body every dispatch path shares:

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -13,16 +13,6 @@ import (
 	"primeradiant.com/evener/appwire"
 )
 
-// maxConcurrentRequestsPerConnection bounds how many post-initialize
-// requests one connection may have running at once. Legitimate browser
-// bursts stay far below this (the UI issues a handful of overlapping reads
-// and mutations per view); the cap exists so a misbehaving client that
-// floods requests faster than handlers complete cannot grow goroutines and
-// handler state without bound, degrading the whole server's memory and
-// scheduler headroom. Overflow is answered with a retryable wire error, not
-// a disconnect, because a compliant retry will find capacity.
-const maxConcurrentRequestsPerConnection = 128
-
 type ServerConfig struct {
 	ServerName string
 	Version    string
@@ -104,10 +94,9 @@ func (s *Server) NewConnection(id string) *Connection {
 	// (at 32 this side evicted live clients whose send loop napped through a
 	// turn-boundary burst on a loaded machine).
 	return &Connection{
-		id:       id,
-		server:   s,
-		send:     make(chan appwire.Message, appwire.NotificationBufferCap),
-		inFlight: make(chan struct{}, maxConcurrentRequestsPerConnection),
+		id:     id,
+		server: s,
+		send:   make(chan appwire.Message, appwire.NotificationBufferCap),
 	}
 }
 
@@ -295,14 +284,9 @@ func navigationCapability(capability *appwire.NavigationCapability) *appwire.Nav
 }
 
 type Connection struct {
-	id     string
-	server *Server
-	send   chan appwire.Message
-	// inFlight is the per-connection in-flight request limiter: a buffered
-	// semaphore of maxConcurrentRequestsPerConnection slots. It is taken
-	// non-blockingly by dispatchMessage and released by the handler goroutine
-	// on completion, so the receive loop never parks on it.
-	inFlight    chan struct{}
+	id          string
+	server      *Server
+	send        chan appwire.Message
 	sendMu      sync.RWMutex
 	sendClosed  bool
 	mu          sync.RWMutex
@@ -476,8 +460,10 @@ func (c *Connection) HandleMessage(ctx context.Context, msg appwire.Message) app
 	req := *msg.Request
 	// ping is the browser's app-level heartbeat (browsers cannot send WS ping
 	// frames from JS). It bypasses the router, and dispatchMessage answers it
-	// inline in the receive loop ahead of any handler goroutine, so however
-	// busy the connection's handlers get, ping is never starved.
+	// inline in the receive loop, so however busy the slow-read handler
+	// goroutines get, ping is never starved. (Inline handlers do occupy the
+	// receive loop ahead of a queued ping, which is why they must stay
+	// bounded.)
 	if req.Method == appwire.MethodPing {
 		return appwire.ResponseMessage(req.ID, struct{}{})
 	}
@@ -813,22 +799,39 @@ func (c *Connection) setInitialized() {
 	c.mu.Unlock()
 }
 
+// concurrentDispatchMethod reports whether a request method leaves the
+// receive loop for its own goroutine. The set is exactly the known-slow read
+// methods — the ones that scan a full transcript and can park for a while
+// (thread/read is the handler the original ping-starvation bug named;
+// thread/turns/list and evener/subagentPreview walk the same saved
+// transcripts). Everything else — every mutation and every other read — is
+// bounded work and runs inline, keeping the per-connection ordering those
+// handlers were written against. A method added here must be safe to run
+// out of order against every other request on the connection.
+func concurrentDispatchMethod(method string) bool {
+	switch method {
+	case appwire.MethodThreadRead, appwire.MethodThreadTurnsList, appwire.MethodEvenerSubagentPreview:
+		return true
+	}
+	return false
+}
+
 // dispatchMessage applies the connection's dispatch policy to one inbound
 // message: which messages run inline in the receive loop and which run on
 // their own goroutine. A transport's receive loop is the only caller; the
 // policy lives on the Connection so any second transport inherits the same
 // sequencing for free.
 //
-// It runs each post-initialize request on its own goroutine so a slow
-// handler no longer head-of-line blocks the connection's other requests —
+// The contract: requests are serial per connection — a later request does
+// not begin until an earlier one completes — EXCEPT the slow-read methods
+// concurrentDispatchMethod names, which run on their own goroutine so a
+// full-transcript read cannot head-of-line block the connection. A later
+// request can therefore dispatch while a slow read (including a hydrating
+// read parked in its snapshot clone) is still in flight; responses pair by
+// request ID, and only the sequence-cut discipline governs how notifications
+// interleave with a hydration response.
 //
-// Per-connection frame ordering is NOT serialized: a later request can
-// dispatch while an earlier one (including a hydrating read parked in its
-// snapshot clone) is still in flight. Responses pair by request ID, and only
-// the sequence-cut discipline governs how notifications interleave with a
-// hydration response — dispatch order no longer does.
-//
-// Ordering constraints that survive concurrency:
+// Ordering constraints in detail:
 //
 //   - initialize must be the first request. Until the connection reports
 //     initialized, every message is handled inline in the receive loop:
@@ -838,44 +841,22 @@ func (c *Connection) setInitialized() {
 //     requests therefore cannot observe a half-initialized connection.
 //   - notifications and ping are always handled inline: they are bounded
 //     work, and answering ping inline is what keeps the app-level heartbeat
-//     responsive no matter how many handlers are busy.
-//   - post-initialize requests must first take a slot from the in-flight
-//     limiter. The acquire is non-blocking — the receive loop must never
-//     park on the limiter, or ping would be head-of-line blocked again. On
-//     capacity exhaustion the request is answered immediately with a
-//     retryable Unavailable wire error rather than dispatched.
+//     responsive while a slow read is busy. (An inline handler does occupy
+//     the receive loop, so every non-slow-read handler must stay bounded.)
 //   - responses enter the connection send queue through the same
-//     enqueueResponse path as before, so hydration capture commit/abort
-//     ordering is unchanged.
+//     enqueueResponse path on both dispatch modes, so hydration capture
+//     commit/abort ordering is unchanged.
 //
 // Error responses from enqueueResponse are terminal for the connection, but
 // a handler goroutine must not tear the receive loop down out from under it;
 // canceling the shared context is enough — the next Recv fails and the loop
 // exits with the normal close handling.
 func (c *Connection) dispatchMessage(ctx context.Context, msg appwire.Message) {
-	if msg.Request == nil || msg.Request.Method == appwire.MethodPing {
+	if msg.Request == nil || !c.isInitialized() || !concurrentDispatchMethod(msg.Request.Method) {
 		c.handleAndEnqueue(ctx, msg)
 		return
 	}
-	if !c.isInitialized() {
-		c.handleAndEnqueue(ctx, msg)
-		return
-	}
-	// Non-blocking acquire: the receive loop must never park on the limiter.
-	select {
-	case c.inFlight <- struct{}{}:
-	default:
-		// The response is already decided, so it bypasses HandleMessage and
-		// is enqueued directly.
-		c.enqueueDispatched(ctx, appwire.ErrorMessage(msg.Request.ID, appwire.Unavailable(
-			fmt.Sprintf("connection already has %d requests in flight; retry shortly", maxConcurrentRequestsPerConnection),
-		)))
-		return
-	}
-	go func() {
-		defer func() { <-c.inFlight }()
-		c.handleAndEnqueue(ctx, msg)
-	}()
+	go c.handleAndEnqueue(ctx, msg)
 }
 
 // handleAndEnqueue runs one request through HandleMessage and enqueues its

--- a/internal/appserver/websocket_dispatch_test.go
+++ b/internal/appserver/websocket_dispatch_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -529,4 +531,91 @@ func seenMarkers(seen map[string]bool) []string {
 	}
 	sort.Strings(markers)
 	return markers
+}
+
+// panicLogCapture redirects the standard logger to a buffer for the duration
+// of the test, so an intentionally provoked panic keeps the test output
+// pristine and the log line itself can be asserted on.
+func panicLogCapture(t *testing.T) func() string {
+	t.Helper()
+	var mu sync.Mutex
+	var buf strings.Builder
+	prev := log.Writer()
+	log.SetOutput(writerFunc(func(p []byte) (int, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		return buf.Write(p)
+	}))
+	t.Cleanup(func() { log.SetOutput(prev) })
+	return func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return buf.String()
+	}
+}
+
+type writerFunc func(p []byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }
+
+// requireInternalError asserts one request error is the panic barrier's
+// InternalError wire error.
+func requireInternalError(t *testing.T, what string, err error) {
+	t.Helper()
+	var wire appwire.WireError
+	if !errors.As(err, &wire) || wire.Code != appwire.CodeInternalError {
+		t.Fatalf("%s error = %v, want InternalError wire error", what, err)
+	}
+}
+
+// TestServeWebSocketPanickingHandlerAnswersInternalErrorAndConnectionSurvives
+// pins the panic barrier on both dispatch paths: a panic in an
+// inline-dispatched handler (thread/list) and in a concurrently dispatched
+// slow read (thread/read) each answer an InternalError response, are logged
+// with a stack, and leave the connection — and the process — alive for
+// subsequent requests.
+func TestServeWebSocketPanickingHandlerAnswersInternalErrorAndConnectionSurvives(t *testing.T) {
+	logged := panicLogCapture(t)
+	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
+	HandleTyped(server.Router(), appwire.MethodThreadList, func(_ context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+		panic("inline handler blew up")
+	})
+	HandleTyped(server.Router(), appwire.MethodThreadRead, func(_ context.Context, _ appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		panic("slow-read handler blew up")
+	})
+	HandleTyped(server.Router(), appwire.MethodThreadModelSet, func(_ context.Context, _ appwire.ThreadModelSetParams) (appwire.EmptyResponse, error) {
+		return appwire.EmptyResponse{}, nil
+	})
+	httpServer := serveWebSocketHTTP(t, server)
+	client := dialAppWireClient(t, httpServer)
+	ctx := context.Background()
+
+	_, err := client.ThreadList(ctx, appwire.ThreadListParams{})
+	requireInternalError(t, "inline panicking request", err)
+
+	_, err = client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:th_1"})
+	requireInternalError(t, "concurrent panicking request", err)
+
+	// The same connection keeps serving: a routed request and the app-level
+	// ping both still answer.
+	if err := client.ThreadModelSet(ctx, appwire.ThreadModelSetParams{Ref: "local:th_1", ModelProvider: "p", Model: "m"}); err != nil {
+		t.Fatalf("routed request after panics failed: %v", err)
+	}
+	var out appwire.EmptyResponse
+	if err := client.Request(ctx, appwire.MethodPing, appwire.EmptyParams{}, &out); err != nil {
+		t.Fatalf("ping after panics failed: %v", err)
+	}
+
+	output := logged()
+	for _, want := range []string{
+		"panic handling " + appwire.MethodThreadList,
+		"inline handler blew up",
+		"panic handling " + appwire.MethodThreadRead,
+		"slow-read handler blew up",
+		"goroutine", // the stack trace made it into the log
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("panic log missing %q in:\n%s", want, output)
+		}
+	}
 }

--- a/internal/appserver/websocket_dispatch_test.go
+++ b/internal/appserver/websocket_dispatch_test.go
@@ -57,23 +57,23 @@ func waitFor[T any](t *testing.T, what string, ch <-chan T) T {
 	}
 }
 
-// dispatchSlowFastServer builds a server whose thread/list handler blocks
-// until released, plus an http server speaking AppWire over WebSocket. The
-// release channel is closed by test cleanup so a parked handler can never
-// outlive the test.
+// dispatchSlowFastServer builds a server whose thread/read handler — a
+// slow-read method that dispatches concurrently — blocks until released, plus
+// an http server speaking AppWire over WebSocket. The release channel is
+// closed by test cleanup so a parked handler can never outlive the test.
 func dispatchSlowFastServer(t *testing.T) (*Server, *httptest.Server, chan struct{}) {
 	t.Helper()
 	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
 	handlerStarted := make(chan struct{})
 	releaseHandler := make(chan struct{})
-	HandleTyped(server.Router(), appwire.MethodThreadList, func(_ context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+	HandleTyped(server.Router(), appwire.MethodThreadRead, func(_ context.Context, _ appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
 		select {
 		case <-handlerStarted:
 		default:
 			close(handlerStarted)
 		}
 		<-releaseHandler
-		return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_held"}}}, nil
+		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: "th_held"}}, nil
 	})
 	httpServer := serveWebSocketHTTP(t, server)
 	t.Cleanup(func() {
@@ -87,8 +87,8 @@ func dispatchSlowFastServer(t *testing.T) (*Server, *httptest.Server, chan struc
 }
 
 // TestServeWebSocketSlowHandlerDoesNotDelayPing pins the fix itself: with one
-// handler parked mid-turn, the browser's app-level ping heartbeat completes
-// on the same connection while the slow handler is still running.
+// slow-read handler parked mid-turn, the browser's app-level ping heartbeat
+// completes on the same connection while the slow handler is still running.
 func TestServeWebSocketSlowHandlerDoesNotDelayPing(t *testing.T) {
 	_, httpServer, handlerStarted := dispatchSlowFastServer(t)
 	client := dialAppWireClient(t, httpServer)
@@ -96,7 +96,7 @@ func TestServeWebSocketSlowHandlerDoesNotDelayPing(t *testing.T) {
 
 	slowDone := make(chan error, 1)
 	go func() {
-		_, err := client.ThreadList(ctx, appwire.ThreadListParams{})
+		_, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:th_held"})
 		slowDone <- err
 	}()
 	waitFor(t, "slow handler to start", handlerStarted)
@@ -123,44 +123,37 @@ func TestServeWebSocketSlowHandlerDoesNotDelayPing(t *testing.T) {
 }
 
 // TestServeWebSocketFastRequestCompletesWhileSlowHandlerRuns pins the other
-// half of the fix: a fast request issued after a slow one returns its own
-// response, correctly paired to its id, without waiting for the slow one.
+// half of the fix: a request issued after a parked slow read returns its own
+// response, correctly paired to its id, without waiting for the slow one —
+// the slow read dispatched on its own goroutine, so the receive loop stayed
+// free to handle the later request inline.
 func TestServeWebSocketFastRequestCompletesWhileSlowHandlerRuns(t *testing.T) {
 	server, httpServer, handlerStarted := dispatchSlowFastServer(t)
-	fastStarted := make(chan struct{})
-	fastRelease := make(chan struct{})
-	HandleTyped(server.Router(), appwire.MethodThreadRead, func(_ context.Context, _ appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
-		close(fastStarted)
-		<-fastRelease
-		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: "th_fast"}}, nil
+	HandleTyped(server.Router(), appwire.MethodThreadList, func(_ context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+		return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_fast"}}}, nil
 	})
 	client := dialAppWireClient(t, httpServer)
 	ctx := context.Background()
 
 	slowDone := make(chan error, 1)
 	go func() {
-		_, err := client.ThreadList(ctx, appwire.ThreadListParams{})
+		_, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:th_held"})
 		slowDone <- err
 	}()
 	waitFor(t, "slow handler to start", handlerStarted)
 
 	fastDone := make(chan error, 1)
 	go func() {
-		_, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:th_fast"})
+		_, err := client.ThreadList(ctx, appwire.ThreadListParams{})
 		fastDone <- err
 	}()
-	waitFor(t, "fast handler to start while the slow handler was busy", fastStarted)
-
-	// Release only the fast handler; the slow one stays parked. If dispatch
-	// were still serial, the fast response could never arrive.
-	close(fastRelease)
 	select {
 	case err := <-fastDone:
 		if err != nil {
 			t.Fatalf("fast request failed while slow handler was busy: %v", err)
 		}
 	case <-time.After(time.Second):
-		t.Fatal("fast request was head-of-line blocked behind a slow handler")
+		t.Fatal("fast request was head-of-line blocked behind a slow read")
 	}
 
 	select {
@@ -212,38 +205,38 @@ func TestServeWebSocketRejectsRequestsBeforeInitialize(t *testing.T) {
 // other's.
 func TestServeWebSocketResponsesPairToIDsWhenHandlersCompleteOutOfOrder(t *testing.T) {
 	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
+	slowStarted := make(chan struct{})
 	releaseSlow := make(chan struct{})
-	slowResult := appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_slow"}}}
-	fastResult := appwire.ThreadReadResponse{Thread: appwire.Thread{ID: "th_fast"}}
-	HandleTyped(server.Router(), appwire.MethodThreadList, func(_ context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+	slowResult := appwire.ThreadReadResponse{Thread: appwire.Thread{ID: "th_slow"}}
+	fastResult := appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_fast"}}}
+	HandleTyped(server.Router(), appwire.MethodThreadRead, func(_ context.Context, _ appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		close(slowStarted)
 		<-releaseSlow
 		return slowResult, nil
 	})
-	fastStarted := make(chan struct{})
-	HandleTyped(server.Router(), appwire.MethodThreadRead, func(_ context.Context, _ appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
-		close(fastStarted)
+	HandleTyped(server.Router(), appwire.MethodThreadList, func(_ context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
 		return fastResult, nil
 	})
 	httpServer := serveWebSocketHTTP(t, server)
 	client := dialAppWireClient(t, httpServer)
 	ctx := context.Background()
 
-	slowDone := make(chan appwire.ThreadListResponse, 1)
+	slowDone := make(chan appwire.ThreadReadResponse, 1)
 	slowErr := make(chan error, 1)
 	go func() {
-		resp, err := client.ThreadList(ctx, appwire.ThreadListParams{})
+		resp, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:th_slow"})
 		slowDone <- resp
 		slowErr <- err
 	}()
-	fastDone := make(chan appwire.ThreadReadResponse, 1)
+	waitFor(t, "slow handler to start", slowStarted)
+	fastDone := make(chan appwire.ThreadListResponse, 1)
 	fastErr := make(chan error, 1)
 	go func() {
-		resp, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:th_fast"})
+		resp, err := client.ThreadList(ctx, appwire.ThreadListParams{})
 		fastDone <- resp
 		fastErr <- err
 	}()
 
-	waitFor(t, "fast handler to start while the slow handler was pending", fastStarted)
 	select {
 	case err := <-fastErr:
 		if err != nil {
@@ -253,8 +246,8 @@ func TestServeWebSocketResponsesPairToIDsWhenHandlersCompleteOutOfOrder(t *testi
 		t.Fatal("fast response was blocked behind the slow request")
 	}
 	resp := waitFor(t, "fast response payload", fastDone)
-	if resp.Thread.ID != "th_fast" {
-		t.Fatalf("fast response paired to wrong result: %+v", resp.Thread)
+	if len(resp.Data) != 1 || resp.Data[0].ID != "th_fast" {
+		t.Fatalf("fast response paired to wrong result: %+v", resp.Data)
 	}
 
 	close(releaseSlow)
@@ -262,8 +255,8 @@ func TestServeWebSocketResponsesPairToIDsWhenHandlersCompleteOutOfOrder(t *testi
 		t.Fatalf("slow request failed after release: %v", err)
 	}
 	slowResp := waitFor(t, "slow response payload", slowDone)
-	if len(slowResp.Data) != 1 || slowResp.Data[0].ID != "th_slow" {
-		t.Fatalf("slow response paired to wrong result: %+v", slowResp.Data)
+	if slowResp.Thread.ID != "th_slow" {
+		t.Fatalf("slow response paired to wrong result: %+v", slowResp.Thread)
 	}
 }
 
@@ -310,70 +303,88 @@ func TestServeWebSocketBurstOfConcurrentRequestsAllPairCorrectly(t *testing.T) {
 	}
 }
 
-// TestServeWebSocketInFlightOverflowAnswersUnavailableAndPingStillAnswered
-// pins the in-flight limiter: with every slot held by a blocking handler, the
-// next request is answered promptly with a retryable Unavailable wire error —
-// not parked, not disconnected — and ping still answers on the same
-// connection, because the limiter never blocks the receive loop.
-func TestServeWebSocketInFlightOverflowAnswersUnavailableAndPingStillAnswered(t *testing.T) {
+// TestConcurrentDispatchMethodsAreExactlyTheSlowReads pins the dispatch
+// policy's method set: only the known-slow read methods leave the receive
+// loop; every mutation — and every other read — stays serial per connection.
+func TestConcurrentDispatchMethodsAreExactlyTheSlowReads(t *testing.T) {
+	for _, method := range []string{
+		appwire.MethodThreadRead,
+		appwire.MethodThreadTurnsList,
+		appwire.MethodEvenerSubagentPreview,
+	} {
+		if !concurrentDispatchMethod(method) {
+			t.Errorf("%s should dispatch concurrently", method)
+		}
+	}
+	for _, method := range []string{
+		appwire.MethodThreadList,
+		appwire.MethodTurnStart,
+		appwire.MethodTurnSteer,
+		appwire.MethodThreadClear,
+		appwire.MethodThreadModelSet,
+		appwire.MethodPing,
+		appwire.MethodInitialize,
+	} {
+		if concurrentDispatchMethod(method) {
+			t.Errorf("%s should dispatch inline", method)
+		}
+	}
+}
+
+// TestServeWebSocketMutationsDispatchSeriallyPerConnection pins the serial
+// half of the dispatch contract: a later request on the same connection does
+// not begin until an earlier non-slow-read request completes, so handlers
+// outside the slow-read set keep the per-connection ordering they were
+// written against.
+func TestServeWebSocketMutationsDispatchSeriallyPerConnection(t *testing.T) {
 	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
-	release := make(chan struct{})
-	var started sync.WaitGroup
-	started.Add(maxConcurrentRequestsPerConnection)
-	HandleTyped(server.Router(), appwire.MethodThreadRead, func(_ context.Context, _ appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
-		started.Done()
-		<-release
-		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: "th_held"}}, nil
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	HandleTyped(server.Router(), appwire.MethodThreadModelSet, func(_ context.Context, _ appwire.ThreadModelSetParams) (appwire.EmptyResponse, error) {
+		close(firstStarted)
+		<-releaseFirst
+		return appwire.EmptyResponse{}, nil
 	})
+	secondStarted := make(chan struct{})
 	HandleTyped(server.Router(), appwire.MethodThreadList, func(_ context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
-		return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_list"}}}, nil
+		close(secondStarted)
+		return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_1"}}}, nil
 	})
 	httpServer := serveWebSocketHTTP(t, server)
 	client := dialAppWireClient(t, httpServer)
 	ctx := context.Background()
-	t.Cleanup(func() { close(release) })
+	t.Cleanup(func() {
+		select {
+		case <-releaseFirst:
+		default:
+			close(releaseFirst)
+		}
+	})
 
-	// Park one request per limiter slot; each takes its own dispatch
-	// goroutine and its own slot.
-	for range maxConcurrentRequestsPerConnection {
-		go func() {
-			_, _ = client.ThreadRead(ctx, appwire.ThreadReadParams{ThreadID: "th_held"})
-		}()
-	}
-	startedDone := make(chan struct{})
+	firstDone := make(chan error, 1)
 	go func() {
-		started.Wait()
-		close(startedDone)
+		firstDone <- client.ThreadModelSet(ctx, appwire.ThreadModelSetParams{Ref: "local:th_1", ModelProvider: "p", Model: "m"})
 	}()
-	waitFor(t, "all in-flight slots to be held", startedDone)
+	waitFor(t, "first request to start", firstStarted)
 
-	overflowDone := make(chan error, 1)
+	secondDone := make(chan error, 1)
 	go func() {
 		_, err := client.ThreadList(ctx, appwire.ThreadListParams{})
-		overflowDone <- err
+		secondDone <- err
 	}()
 	select {
-	case err := <-overflowDone:
-		var wire appwire.WireError
-		if !errors.As(err, &wire) || wire.Code != appwire.CodeUnavailable {
-			t.Fatalf("overflow request error=%v, want Unavailable wire error", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("overflow request was parked instead of answered with Unavailable")
+	case <-secondStarted:
+		t.Fatal("a later request began while an earlier one was still in flight on the same connection")
+	case <-time.After(100 * time.Millisecond):
 	}
 
-	pingDone := make(chan error, 1)
-	go func() {
-		var out appwire.EmptyResponse
-		pingDone <- client.Request(ctx, appwire.MethodPing, appwire.EmptyParams{}, &out)
-	}()
-	select {
-	case err := <-pingDone:
-		if err != nil {
-			t.Fatalf("ping failed while all in-flight slots were held: %v", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("ping was starved while all in-flight slots were held")
+	close(releaseFirst)
+	if err := waitFor(t, "first request to complete", firstDone); err != nil {
+		t.Fatalf("first request failed: %v", err)
+	}
+	waitFor(t, "second handler to start after the first completed", secondStarted)
+	if err := waitFor(t, "second request to complete", secondDone); err != nil {
+		t.Fatalf("second request failed: %v", err)
 	}
 }
 
@@ -388,9 +399,10 @@ type hydrationMarkerParams struct {
 
 // TestServeWebSocketHydrationThenMutationDeliversEveryNotificationExactlyOnce
 // pins the record accounting when one connection issues a hydrating read
-// immediately followed by mutations: under concurrent dispatch the mutation
-// can run (and commit notifications) while the hydration read is still in
-// flight, so the sequence-cut discipline — not dispatch order — decides which
+// immediately followed by mutations: the read dispatches on its own
+// goroutine, so the mutation can run (and commit notifications) while the
+// hydration read is still in flight, and only the sequence-cut discipline
+// — not dispatch order — decides which
 // set each record lands in. Whatever the interleaving, every notification
 // must reach the client exactly once, in whichever set (the hydration's
 // buffered replay or the live stream), and none may be lost or duplicated.

--- a/internal/appserver/websocket_dispatch_test.go
+++ b/internal/appserver/websocket_dispatch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -59,9 +60,10 @@ func waitFor[T any](t *testing.T, what string, ch <-chan T) T {
 
 // dispatchSlowFastServer builds a server whose thread/read handler — a
 // slow-read method that dispatches concurrently — blocks until released, plus
-// an http server speaking AppWire over WebSocket. The release channel is
-// closed by test cleanup so a parked handler can never outlive the test.
-func dispatchSlowFastServer(t *testing.T) (*Server, *httptest.Server, chan struct{}) {
+// an http server speaking AppWire over WebSocket. The returned release is
+// idempotent and also runs at test cleanup, so a parked handler can never
+// outlive the test.
+func dispatchSlowFastServer(t *testing.T) (*Server, *httptest.Server, chan struct{}, func()) {
 	t.Helper()
 	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
 	handlerStarted := make(chan struct{})
@@ -76,21 +78,16 @@ func dispatchSlowFastServer(t *testing.T) (*Server, *httptest.Server, chan struc
 		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: "th_held"}}, nil
 	})
 	httpServer := serveWebSocketHTTP(t, server)
-	t.Cleanup(func() {
-		select {
-		case <-releaseHandler:
-		default:
-			close(releaseHandler)
-		}
-	})
-	return server, httpServer, handlerStarted
+	release := sync.OnceFunc(func() { close(releaseHandler) })
+	t.Cleanup(release)
+	return server, httpServer, handlerStarted, release
 }
 
 // TestServeWebSocketSlowHandlerDoesNotDelayPing pins the fix itself: with one
 // slow-read handler parked mid-turn, the browser's app-level ping heartbeat
 // completes on the same connection while the slow handler is still running.
 func TestServeWebSocketSlowHandlerDoesNotDelayPing(t *testing.T) {
-	_, httpServer, handlerStarted := dispatchSlowFastServer(t)
+	_, httpServer, handlerStarted, _ := dispatchSlowFastServer(t)
 	client := dialAppWireClient(t, httpServer)
 	ctx := context.Background()
 
@@ -128,7 +125,7 @@ func TestServeWebSocketSlowHandlerDoesNotDelayPing(t *testing.T) {
 // the slow read dispatched on its own goroutine, so the receive loop stayed
 // free to handle the later request inline.
 func TestServeWebSocketFastRequestCompletesWhileSlowHandlerRuns(t *testing.T) {
-	server, httpServer, handlerStarted := dispatchSlowFastServer(t)
+	server, httpServer, handlerStarted, _ := dispatchSlowFastServer(t)
 	HandleTyped(server.Router(), appwire.MethodThreadList, func(_ context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
 		return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_fast"}}}, nil
 	})
@@ -204,27 +201,17 @@ func TestServeWebSocketRejectsRequestsBeforeInitialize(t *testing.T) {
 // the opposite order they were issued both return their own result, not each
 // other's.
 func TestServeWebSocketResponsesPairToIDsWhenHandlersCompleteOutOfOrder(t *testing.T) {
-	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
-	slowStarted := make(chan struct{})
-	releaseSlow := make(chan struct{})
-	slowResult := appwire.ThreadReadResponse{Thread: appwire.Thread{ID: "th_slow"}}
-	fastResult := appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_fast"}}}
-	HandleTyped(server.Router(), appwire.MethodThreadRead, func(_ context.Context, _ appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
-		close(slowStarted)
-		<-releaseSlow
-		return slowResult, nil
-	})
+	server, httpServer, slowStarted, releaseSlow := dispatchSlowFastServer(t)
 	HandleTyped(server.Router(), appwire.MethodThreadList, func(_ context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
-		return fastResult, nil
+		return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_fast"}}}, nil
 	})
-	httpServer := serveWebSocketHTTP(t, server)
 	client := dialAppWireClient(t, httpServer)
 	ctx := context.Background()
 
 	slowDone := make(chan appwire.ThreadReadResponse, 1)
 	slowErr := make(chan error, 1)
 	go func() {
-		resp, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:th_slow"})
+		resp, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:th_held"})
 		slowDone <- resp
 		slowErr <- err
 	}()
@@ -250,12 +237,12 @@ func TestServeWebSocketResponsesPairToIDsWhenHandlersCompleteOutOfOrder(t *testi
 		t.Fatalf("fast response paired to wrong result: %+v", resp.Data)
 	}
 
-	close(releaseSlow)
+	releaseSlow()
 	if err := waitFor(t, "slow request to complete after release", slowErr); err != nil {
 		t.Fatalf("slow request failed after release: %v", err)
 	}
 	slowResp := waitFor(t, "slow response payload", slowDone)
-	if slowResp.Thread.ID != "th_slow" {
+	if slowResp.Thread.ID != "th_held" {
 		t.Fatalf("slow response paired to wrong result: %+v", slowResp.Thread)
 	}
 }
@@ -304,29 +291,25 @@ func TestServeWebSocketBurstOfConcurrentRequestsAllPairCorrectly(t *testing.T) {
 }
 
 // TestConcurrentDispatchMethodsAreExactlyTheSlowReads pins the dispatch
-// policy's method set: only the known-slow read methods leave the receive
-// loop; every mutation — and every other read — stays serial per connection.
+// policy's method set against the full appwire catalog: only the known-slow
+// read methods leave the receive loop; every mutation — and every other
+// read, present or future — stays serial per connection. A method added to
+// the catalog is classified here automatically, so the concurrent set cannot
+// silently acquire (or lose) a member.
 func TestConcurrentDispatchMethodsAreExactlyTheSlowReads(t *testing.T) {
-	for _, method := range []string{
-		appwire.MethodThreadRead,
-		appwire.MethodThreadTurnsList,
-		appwire.MethodEvenerSubagentPreview,
-	} {
-		if !concurrentDispatchMethod(method) {
-			t.Errorf("%s should dispatch concurrently", method)
+	slowReads := map[string]bool{
+		appwire.MethodThreadRead:            true,
+		appwire.MethodThreadTurnsList:       true,
+		appwire.MethodEvenerSubagentPreview: true,
+	}
+	for _, spec := range appwire.Methods {
+		if got, want := concurrentDispatchMethod(spec.Name), slowReads[spec.Name]; got != want {
+			t.Errorf("concurrentDispatchMethod(%s) = %v, want %v", spec.Name, got, want)
 		}
 	}
-	for _, method := range []string{
-		appwire.MethodThreadList,
-		appwire.MethodTurnStart,
-		appwire.MethodTurnSteer,
-		appwire.MethodThreadClear,
-		appwire.MethodThreadModelSet,
-		appwire.MethodPing,
-		appwire.MethodInitialize,
-	} {
-		if concurrentDispatchMethod(method) {
-			t.Errorf("%s should dispatch inline", method)
+	for method := range slowReads {
+		if !concurrentDispatchMethod(method) {
+			t.Errorf("%s should dispatch concurrently", method)
 		}
 	}
 }
@@ -353,13 +336,8 @@ func TestServeWebSocketMutationsDispatchSeriallyPerConnection(t *testing.T) {
 	httpServer := serveWebSocketHTTP(t, server)
 	client := dialAppWireClient(t, httpServer)
 	ctx := context.Background()
-	t.Cleanup(func() {
-		select {
-		case <-releaseFirst:
-		default:
-			close(releaseFirst)
-		}
-	})
+	release := sync.OnceFunc(func() { close(releaseFirst) })
+	t.Cleanup(release)
 
 	firstDone := make(chan error, 1)
 	go func() {
@@ -378,7 +356,7 @@ func TestServeWebSocketMutationsDispatchSeriallyPerConnection(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 	}
 
-	close(releaseFirst)
+	release()
 	if err := waitFor(t, "first request to complete", firstDone); err != nil {
 		t.Fatalf("first request failed: %v", err)
 	}
@@ -545,31 +523,6 @@ func seenMarkers(seen map[string]bool) []string {
 	return markers
 }
 
-// panicLogCapture redirects the standard logger to a buffer for the duration
-// of the test, so an intentionally provoked panic keeps the test output
-// pristine and the log line itself can be asserted on.
-func panicLogCapture(t *testing.T) func() string {
-	t.Helper()
-	var mu sync.Mutex
-	var buf strings.Builder
-	prev := log.Writer()
-	log.SetOutput(writerFunc(func(p []byte) (int, error) {
-		mu.Lock()
-		defer mu.Unlock()
-		return buf.Write(p)
-	}))
-	t.Cleanup(func() { log.SetOutput(prev) })
-	return func() string {
-		mu.Lock()
-		defer mu.Unlock()
-		return buf.String()
-	}
-}
-
-type writerFunc func(p []byte) (int, error)
-
-func (f writerFunc) Write(p []byte) (int, error) { return f(p) }
-
 // requireInternalError asserts one request error is the panic barrier's
 // InternalError wire error.
 func requireInternalError(t *testing.T, what string, err error) {
@@ -587,8 +540,21 @@ func requireInternalError(t *testing.T, what string, err error) {
 // with a stack, and leave the connection — and the process — alive for
 // subsequent requests.
 func TestServeWebSocketPanickingHandlerAnswersInternalErrorAndConnectionSurvives(t *testing.T) {
-	logged := panicLogCapture(t)
-	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
+	var logMu sync.Mutex
+	var logBuf strings.Builder
+	server := NewServer(ServerConfig{
+		ServerName: "test-server", Version: "test", SourceID: "local",
+		Logf: func(format string, args ...any) {
+			logMu.Lock()
+			fmt.Fprintf(&logBuf, format+"\n", args...)
+			logMu.Unlock()
+		},
+	})
+	logged := func() string {
+		logMu.Lock()
+		defer logMu.Unlock()
+		return logBuf.String()
+	}
 	HandleTyped(server.Router(), appwire.MethodThreadList, func(_ context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
 		panic("inline handler blew up")
 	})
@@ -629,5 +595,21 @@ func TestServeWebSocketPanickingHandlerAnswersInternalErrorAndConnectionSurvives
 		if !strings.Contains(output, want) {
 			t.Fatalf("panic log missing %q in:\n%s", want, output)
 		}
+	}
+}
+
+// TestPanicLogfFallsBackToStandardLoggerWhenNoSinkIsConfigured pins the
+// never-silent guarantee: with no ServerConfig.Logf, a panic report goes to
+// the standard logger instead of being dropped the way logf drops advisory
+// lines.
+func TestPanicLogfFallsBackToStandardLoggerWhenNoSinkIsConfigured(t *testing.T) {
+	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local"})
+	var buf strings.Builder
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(prev) })
+	server.panicLogf("appserver: panic handling %s: %v", appwire.MethodThreadList, "boom")
+	if !strings.Contains(buf.String(), "panic handling thread/list: boom") {
+		t.Fatalf("standard logger output = %q, want the panic line", buf.String())
 	}
 }

--- a/internal/appserver/websocket_test.go
+++ b/internal/appserver/websocket_test.go
@@ -57,10 +57,10 @@ func TestServeWebSocketPingsIdleReaderWhileBusyRPCHandlerRuns(t *testing.T) {
 	var releaseOnce sync.Once
 	release := func() { releaseOnce.Do(func() { close(releaseHandler) }) }
 	defer release()
-	HandleTyped(server.Router(), appwire.MethodThreadList, func(ctx context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+	HandleTyped(server.Router(), appwire.MethodThreadRead, func(ctx context.Context, _ appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
 		close(handlerStarted)
 		<-releaseHandler
-		return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: "th_held"}}}, nil
+		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: "th_held"}}, nil
 	})
 	httpServer := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
 	defer httpServer.Close()
@@ -91,7 +91,7 @@ func TestServeWebSocketPingsIdleReaderWhileBusyRPCHandlerRuns(t *testing.T) {
 
 	result := make(chan error, 1)
 	go func() {
-		_, err := client.ThreadList(ctx, appwire.ThreadListParams{})
+		_, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:th_held"})
 		result <- err
 	}()
 	select {
@@ -101,18 +101,20 @@ func TestServeWebSocketPingsIdleReaderWhileBusyRPCHandlerRuns(t *testing.T) {
 	}
 
 	// Drive the actual ServeWebSocket keepalive goroutine while HandleMessage is
-	// held busy in a handler goroutine. Concurrent dispatch keeps the receive
-	// loop reading, so the gate observes an available reader and the keepalive
-	// pings even while the RPC handler is still held.
+	// held busy in a handler goroutine. A slow read dispatches on its own
+	// goroutine, which keeps the receive loop reading, so the gate observes an
+	// available reader and the keepalive pings even while the RPC handler is
+	// still held.
 	//
 	// The receive loop's transition back to an available reader is not ordered
 	// against the handler goroutine reaching handlerStarted: dispatchMessage
-	// runs the handler on its own goroutine, so a tick can land while the loop
-	// is still between readerUnavailable() and its next readerAvailable(). Each
-	// tick reports one gate decision, so the condition under test is the first
-	// attempted decision, not the decision from the first tick. The receive
-	// loop deterministically parks in Recv with the reader available while the
-	// handler is held, so this wait terminates rather than polling a window.
+	// runs a slow-read handler on its own goroutine, so a tick can land while
+	// the loop is still between readerUnavailable() and its next
+	// readerAvailable(). Each tick reports one gate decision, so the condition
+	// under test is the first attempted decision, not the decision from the
+	// first tick. The receive loop deterministically parks in Recv with the
+	// reader available while the handler is held, so this wait terminates
+	// rather than polling a window.
 	busyPingDeadline := time.NewTimer(time.Minute)
 	defer busyPingDeadline.Stop()
 	released := false


### PR DESCRIPTION
Resolves three findings from the 2026-08-30 code-quality audit of `eed02042f..origin/main`:

- **C1 (critical)** — a panicking AppWire handler killed the whole process: concurrent per-request dispatch (`0291be074`) moved handlers onto bare goroutines with no `recover()`, removing the net/http panic barrier that had contained a panic to one WebSocket connection.
- **I3 (important)** — the same commit silently retired per-connection request ordering for every handler (~163 registrations) with no handler-side audit.
- **Over-engineering row 1** — the goroutine-per-request fan-out, the 128-slot in-flight limiter, and the `Unavailable` overflow error existed only to unblock slow reads; the inline ping answer in the receive loop was the real fix for the original ping-starvation bug.

## Design decision

Narrow concurrent dispatch to only the known-slow read methods — `thread/read` (the handler the original bug named), `thread/turns/list`, and `evener/subagentPreview`, which walk the same saved transcripts — and return every other method, all mutations included, to serial inline handling per connection. Ping stays answered inline in the receive loop. With no unbounded fan-out, the 128-slot limiter and its `Unavailable` overflow response are removed entirely (`appwire.Unavailable` itself stays; other handlers return it).

A `recover()` panic barrier now sits in `handleAndEnqueue`, covering both dispatch modes identically: a panic is logged with its stack (through `ServerConfig.Logf` when configured, falling back to the standard logger so it can never be silent), answered with an `InternalError` response, and the connection lives on.

## Tests

- Panicking handlers on both the inline and the goroutine path yield an error response with the connection, and the process, surviving (before the barrier, the goroutine-path panic killed the test process — reproducing the audit's proof).
- Serial ordering pinned: a later request on one connection does not begin until an earlier non-slow-read request completes.
- Slow reads pinned concurrent: a parked `thread/read` blocks neither ping nor a subsequent request.
- The concurrent method set is pinned against the full `appwire.Methods` catalog, so a future method is classified automatically.
- The limiter-overflow test was removed with the limiter; the slow/fast, out-of-order-pairing, keepalive, and hydration-interleaving tests were reworked to park a slow-read handler now that `thread/list` is inline.

## Residual considerations

- Serial inline handling means a slow non-slow-read handler once again occupies the receive loop (and thereby delays ping) for its duration — the pre-`0291be074` behavior for those methods. A handful of read handlers do real I/O (`evener/auth/device/poll` makes outbound HTTPS, `evener/git/head` forks git, `evener/paths/complete` walks the filesystem). The audit named only the transcript readers as the observed slow set; if any of these proves slow in practice, adding it to `concurrentDispatchMethod` is a one-line, individually-reviewed change with the catalog test forcing the classification.
- Roborev (per-commit and branch reviews) repeatedly proposed re-adding a bounded semaphore for the three concurrent slow reads. Rejected per the audit's direction to remove the limiter entirely: the exposure shrank from every post-initialize method to three read-only methods, slow consumers are already evicted via the bounded outbound buffer, and the limiter never bounded a client that opens more connections.

## Gates

`go test ./...` (root module), `go test -race ./internal/appserver/... ./appwire/...`, and `make lint` (9/9) all pass; `server/` and `cmd/evener-hub/...` pass against the new dispatch policy.
