### PR TITLE
Finish the purpose->intent rename: document the accepted transcript loss (I4) and clean the residue (M9)

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,15 @@
 
 Breaking changes and migration notes for evener.
 
+## Unreleased — Tool `purpose` param renamed to `intent`
+
+The shared tool parameter that carries the agent's stated reason for a call
+was renamed from `purpose` to `intent`. Readers read only `intent` — there is
+deliberately no backward-compat fallback. Transcripts recorded before
+2026-08-29 render tool calls without an intent line in the hub, the TUI, and
+`evener doctor`; the data is not lost — it remains in the transcript under
+`purpose`.
+
 ## Unreleased — Binary consolidation
 
 ### Summary

--- a/agent/cov_s3_vision_test.go
+++ b/agent/cov_s3_vision_test.go
@@ -34,13 +34,13 @@ func TestVisionPromptContractIsUnconditional(t *testing.T) {
 		}
 	}()
 
-	purposes := []string{
+	intents := []string{
 		"Describe the layout and visible controls.",
 		"Transcribe the rendered text exactly, including punctuation.",
 	}
 	var suffix string
-	for _, purpose := range purposes {
-		if got := sess.describeImage(context.Background(), tool.ExecResult{ImageData: []byte("image"), ImageIntent: purpose}); got != "vision" {
+	for _, intent := range intents {
+		if got := sess.describeImage(context.Background(), tool.ExecResult{ImageData: []byte("image"), ImageIntent: intent}); got != "vision" {
 			t.Fatalf("vision response = %q", got)
 		}
 		requests := adapter.Requests()
@@ -49,9 +49,9 @@ func TestVisionPromptContractIsUnconditional(t *testing.T) {
 			t.Fatalf("vision request content shape = %#v", request.Messages)
 		}
 		prompt := request.Messages[0].Content[0].Text
-		wantPrefix := strings.TrimSpace(purpose) + "\n\n"
+		wantPrefix := strings.TrimSpace(intent) + "\n\n"
 		if !strings.HasPrefix(prompt, wantPrefix) {
-			t.Fatalf("prompt does not preserve purpose: %q", prompt)
+			t.Fatalf("prompt does not preserve intent: %q", prompt)
 		}
 		gotSuffix := strings.TrimPrefix(prompt, wantPrefix)
 		if gotSuffix != visionRequestContract {
@@ -63,7 +63,7 @@ func TestVisionPromptContractIsUnconditional(t *testing.T) {
 		if suffix == "" {
 			suffix = gotSuffix
 		} else if gotSuffix != suffix {
-			t.Fatal("description and transcription purposes received different contracts")
+			t.Fatal("description and transcription intents received different contracts")
 		}
 	}
 }

--- a/agent/internal/tool/definitions_program_fuzz_test.go
+++ b/agent/internal/tool/definitions_program_fuzz_test.go
@@ -12,7 +12,7 @@ import (
 
 // FuzzToolDefinitionsProgram builds every shipped tool definition, registers it
 // in the real Registry, and verifies that construction is deterministic and
-// does not share schema maps with registration-time purpose normalization. The
+// does not share schema maps with registration-time intent normalization. The
 // fuzz input varies the enum-bearing definitions (delegate, job_watch, and
 // task_list) and the custom communicate name; every generated value is encoded
 // into a valid tool identifier, so invalid-name rejection is not mistaken for a

--- a/agent/internal/tool/registry_program_fuzz_test.go
+++ b/agent/internal/tool/registry_program_fuzz_test.go
@@ -24,7 +24,7 @@ import (
 // intentional FileMutator path and receives a fresh LocalExecutionEnvironment
 // rooted in t.TempDir, so its mutation is confined to the test's own root.
 //
-// Its semantic checks cover registration/clone/restrict isolation, purpose
+// Its semantic checks cover registration/clone/restrict isolation, intent
 // handling, schema and JSON rejection, middleware, typed execution results,
 // error propagation, output limits, and FileMutator capability handling.
 func FuzzToolRegistryProgram(f *testing.F) {
@@ -330,7 +330,7 @@ func toolProgramHelpers(t *testing.T, payload string) {
 func toolProgramRegistryEdges(t *testing.T) {
 	t.Helper()
 	if got := WithIntentParameter(llm.ToolDefinition{}); got.Parameters["type"] != "object" {
-		t.Fatalf("nil schema purpose injection = %#v", got.Parameters)
+		t.Fatalf("nil schema intent injection = %#v", got.Parameters)
 	}
 	nonObject := llm.ToolDefinition{Parameters: map[string]any{"type": "string"}}
 	if got := WithIntentParameter(nonObject); got.Parameters["type"] != "string" {

--- a/agent/internal/tool/registry_test.go
+++ b/agent/internal/tool/registry_test.go
@@ -129,7 +129,7 @@ func TestToolRegistry_ToolStateResult_CarriesStateAsSideChannel(t *testing.T) {
 	}
 }
 
-func TestToolRegistry_AddsAndStripsUniversalPurpose(t *testing.T) {
+func TestToolRegistry_AddsAndStripsUniversalIntent(t *testing.T) {
 	r := NewRegistry()
 	var gotArgs map[string]any
 	if err := r.Register(RegisteredTool{

--- a/agent/provider/profile.go
+++ b/agent/provider/profile.go
@@ -299,7 +299,7 @@ func (p *Profile) BehaviorTag() string { return p.behaviorTag }
 func (p *Profile) Model() string { return p.model }
 
 // ToolDefinitions returns the profile's tool schemas by their canonical names.
-// Provider-specific renaming (via ToolNameMap) and the shared purpose parameter
+// Provider-specific renaming (via ToolNameMap) and the shared intent parameter
 // are applied by the agent when advertising tools to the model, not here.
 func (p *Profile) ToolDefinitions() []llm.ToolDefinition {
 	return append([]llm.ToolDefinition{}, p.toolDefs...)

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -550,12 +550,12 @@ func (s *Session) describeImageCall(ctx context.Context, r tool.ExecResult) visi
 	}
 }
 
-func visionPrompt(purpose string) string {
-	purpose = strings.TrimSpace(purpose)
-	if purpose == "" {
-		purpose = "Describe what you see in this image in thorough detail."
+func visionPrompt(intent string) string {
+	intent = strings.TrimSpace(intent)
+	if intent == "" {
+		intent = "Describe what you see in this image in thorough detail."
 	}
-	return purpose + "\n\n" + visionRequestContract
+	return intent + "\n\n" + visionRequestContract
 }
 
 func (s *Session) canonicalToolName(name string) string {
@@ -733,7 +733,7 @@ func (s *Session) execTool(ctx context.Context, call llm.ToolCallData, finishRea
 		CallID:        call.ID,
 		ArgumentsJSON: string(argsJSON),
 	}
-	// Promote purpose to the top-level event field for observability.
+	// Promote intent to the top-level event field for observability.
 	var args map[string]any
 	if len(call.Arguments) > 0 {
 		_ = json.Unmarshal(call.Arguments, &args)
@@ -1349,7 +1349,7 @@ func (s *Session) rebuildToolDefsCache() {
 
 	// Profile tool definitions are canonical (e.g. "shell"); the registry is also
 	// keyed by canonical names. Each registered profile tool is advertised in its
-	// provider-visible wire form (provider-specific rename + purpose param).
+	// provider-visible wire form (provider-specific rename + intent param).
 	nameMap := s.profile.ToolNameMap() // canonical → provider, may be nil
 
 	var defs []llm.ToolDefinition

--- a/cmd/evener-doctor/study_runbooks_test.go
+++ b/cmd/evener-doctor/study_runbooks_test.go
@@ -223,13 +223,13 @@ func TestRun_AuditErrorLoopBundledRunbook_HealthyEmitsZero(t *testing.T) {
 // derived from either of the above.
 func inBandMCPErrorLoopTurns() []schema.Turn {
 	var turns []schema.Turn
-	purposes := []string{
+	intents := []string{
 		"checking initial page state", "confirming the viewport resized",
 		"verifying the element is visible", "re-checking after the click",
 	}
-	for i, purpose := range purposes {
+	for i, intent := range intents {
 		id := fmt.Sprintf("mcp%d", i)
-		args := fmt.Sprintf(`{"action":"screenshot","intent":%q}`, purpose)
+		args := fmt.Sprintf(`{"action":"screenshot","intent":%q}`, intent)
 		turns = append(turns,
 			schema.NewTurn(schema.TurnAssistant, llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{
 				studyToolCall(id, "use_browser", args),

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/rdry-toolrow-contrast/assert.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/rdry-toolrow-contrast/assert.mjs
@@ -25,11 +25,11 @@ export default function assert(measurement) {
   if (!geometry.triggerContainsSummary || !geometry.summaryHitTrigger || !geometry.actionHitAction) {
     return {
       pass: false,
-      reason: `purpose-less disclosure geometry is invalid: ${JSON.stringify(geometry)}`,
+      reason: `intent-less disclosure geometry is invalid: ${JSON.stringify(geometry)}`,
     };
   }
   return {
     pass: true,
-    reason: `demoted line clears AA and purpose-less disclosure hit area is intact (dark ${darkRatio.toFixed(2)}:1, light ${lightRatio.toFixed(2)}:1)`,
+    reason: `demoted line clears AA and intent-less disclosure hit area is intact (dark ${darkRatio.toFixed(2)}:1, light ${lightRatio.toFixed(2)}:1)`,
   };
 }

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/rdry-toolrow-contrast/case.json
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/rdry-toolrow-contrast/case.json
@@ -1,6 +1,6 @@
 {
   "name": "rdry-toolrow-contrast",
-  "description": "a purpose-bearing tool row's demoted result line (e.g. \"Wrote fizzbuzz.py\") must clear WCAG AA (4.5:1) against its pane background, in both themes (kata rdry)",
+  "description": "an intent-bearing tool row's demoted result line (e.g. \"Wrote fizzbuzz.py\") must clear WCAG AA (4.5:1) against its pane background, in both themes (kata rdry)",
   "cssFiles": [
     "styles/global.css",
     "styles/tokens.css",

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/rdry-toolrow-contrast/case.json
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/rdry-toolrow-contrast/case.json
@@ -8,8 +8,8 @@
   ],
   "mutation": {
     "declaration": "toolcallitem.module.css: .demoted { color: var(--ink-mid) } (reverted to var(--ink-low))",
-    "verified": "2026-08-17",
+    "verified": "2026-08-30",
     "expect": "fail",
-    "note": "Re-verified after the case picked up styles/global.css (kata e4sh) - its measurement came back byte-identical, but the field attests to a rendering configuration, and that configuration changed. Still fails: dark 3.08:1 and light 3.51:1, both below the 4.5:1 AA floor."
+    "note": "Re-verified after the purpose->intent vocabulary rename touched the harness markup and toolcallitem.module.css class names (the measured .demoted line itself is untouched). Still fails: dark 3.08:1 and light 3.51:1, both below the 4.5:1 AA floor."
   }
 }

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/rdry-toolrow-contrast/harness.html
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/rdry-toolrow-contrast/harness.html
@@ -16,13 +16,13 @@
 </style>
 </head>
 <body>
-<!-- The purpose-bearing row keeps the original contrast fixture. -->
+<!-- The intent-bearing row keeps the original contrast fixture. -->
 <div class="row" data-testid="tool-row">
-  <span class="purpose" data-testid="tool-row-purpose">Write fizzbuzz.py to disk</span>
+  <span class="intent" data-testid="tool-row-intent">Write fizzbuzz.py to disk</span>
   <span class="summary demoted" data-testid="tool-row-summary" id="demoted-line">Wrote fizzbuzz.py</span>
   <span class="chevron" aria-hidden="true">&#9656;</span>
 </div>
-<!-- The existing case also exercises the ordinary purpose-less disclosure
+<!-- The existing case also exercises the ordinary intent-less disclosure
      geometry: the native trigger is a sibling of the visible summary and
      inline action controls, while its rectangle covers the whole row. -->
 <div class="row" data-testid="geometry-row">

--- a/cmd/evener-hub/frontend/src/dev/overflowharness-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/overflowharness-entry.tsx
@@ -157,7 +157,7 @@ const snapshot: ThreadReadResponse = {
             output: JSON.stringify({ delegate_id: "dlg_1", status: "running", reason: CARD_LONG_TOKEN }),
           },
           {
-            // A purpose-bearing shell row: the two-line composition (italic
+            // An intent-bearing shell row: the two-line composition (italic
             // rationale over the demoted verb/target line) is the transcript's
             // most common tool-row shape, and this guard is the only thing
             // that measures IT for horizontal escape at every width.

--- a/cmd/evener-hub/frontend/src/panes/session/session.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/session.module.css
@@ -19,7 +19,7 @@
   min-width: 0;
 }
 
-/* Projected purpose-only actions use the same quiet disclosure treatment on
+/* Projected intent-only actions use the same quiet disclosure treatment on
  * every TranscriptBody surface, including read-only and preview. */
 .intentGroup {
   width: 100%;

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallCluster.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallCluster.tsx
@@ -44,7 +44,7 @@ function leadItem(items: ItemModel[]): ItemModel {
 // web_fetch-led run's URL is a real link here too rather than dead text the
 // reader has to unfold the run to click (kata 79cs). Text and link come from
 // ONE descriptor lookup of ONE item, because they must always describe the
-// same call. This row never passes a `intent`, so ToolRow always renders the
+// same call. This row never passes an `intent`, so ToolRow always renders the
 // summary in full - the clamped head/tail split that keeps xw3t's per-call
 // row plain text while collapsed cannot arise here.
 function clusterHeader(

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallCluster.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallCluster.tsx
@@ -44,7 +44,7 @@ function leadItem(items: ItemModel[]): ItemModel {
 // web_fetch-led run's URL is a real link here too rather than dead text the
 // reader has to unfold the run to click (kata 79cs). Text and link come from
 // ONE descriptor lookup of ONE item, because they must always describe the
-// same call. This row never passes a `purpose`, so ToolRow always renders the
+// same call. This row never passes a `intent`, so ToolRow always renders the
 // summary in full - the clamped head/tail split that keeps xw3t's per-call
 // row plain text while collapsed cannot arise here.
 function clusterHeader(

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
@@ -50,7 +50,7 @@ test("renders the resolved descriptor's summary", () => {
   expect(screen.getByText("did a thing")).toBeTruthy();
 });
 
-test("settled purpose-bearing commandExecution rows stack purpose over the demoted summary", () => {
+test("settled intent-bearing commandExecution rows stack intent over the demoted summary", () => {
   registerToolRenderer({ match: "tci_one_line", summary: () => "Ran npm test -- src/foo" });
   render(
     <ToolCallItem
@@ -63,11 +63,11 @@ test("settled purpose-bearing commandExecution rows stack purpose over the demot
       live={false}
     />,
   );
-  // Two lines through the real consumer: no composed "purpose — summary"
+  // Two lines through the real consumer: no composed "intent — summary"
   // single line (tried in tiered density, reverted on review).
-  expect(screen.getByTestId("tool-row-purpose").textContent).toBe("Running the foo tests");
+  expect(screen.getByTestId("tool-row-intent").textContent).toBe("Running the foo tests");
   expect(screen.getByTestId("tool-row-summary").textContent).toBe("Ran npm test -- src/foo");
-  expect(screen.getByTestId("tool-row-purpose").textContent).not.toContain(" — ");
+  expect(screen.getByTestId("tool-row-intent").textContent).not.toContain(" — ");
 });
 
 // The expanded content mounts only while the row is open (the same shape
@@ -552,7 +552,7 @@ test("an expanded shell row drops the one-line summary - the body's pretty-print
   expect(screen.queryByTestId("tool-row-summary")).toBeNull();
   // The command still appears exactly once: the body's pretty-printed block.
   expect(screen.getByTestId("tool-call-body").textContent).toContain("echo hi");
-  // The row stays toggleable: with no purpose and no summary, the chevron
+  // The row stays toggleable: with no intent and no summary, the chevron
   // still renders.
   expect(screen.getByTestId("tool-row-chevron")).toBeTruthy();
 });
@@ -979,7 +979,7 @@ test("summarySuffix is omitted (bare summary) when the descriptor doesn't define
   expect(screen.getByTestId("tool-row-summary").textContent).toBe("plain summary");
 });
 
-test("delegate tool rows keep the human description as purpose and suppress the technical delegate summary", () => {
+test("delegate tool rows keep the human description as intent and suppress the technical delegate summary", () => {
   render(
     <ToolCallItem
       item={item({
@@ -991,11 +991,11 @@ test("delegate tool rows keep the human description as purpose and suppress the 
       live={false}
     />,
   );
-  expect(screen.getByTestId("tool-row-purpose").textContent).toBe("Testing delegation");
+  expect(screen.getByTestId("tool-row-intent").textContent).toBe("Testing delegation");
   expect(screen.queryByTestId("tool-row-summary")).toBeNull();
 });
 
-test("task-only delegate purpose previews preserve an emoji at the Unicode clipping boundary", () => {
+test("task-only delegate intent previews preserve an emoji at the Unicode clipping boundary", () => {
   const emojiTask = `${"a".repeat(119)}😀 suffix`;
   const exactAsciiTask = "b".repeat(120);
   render(
@@ -1024,8 +1024,8 @@ test("task-only delegate purpose previews preserve an emoji at the Unicode clipp
   );
 
   const [unicodeTool, asciiTool] = screen.getAllByTestId("tool-call-item");
-  expect(within(unicodeTool!).getByTestId("tool-row-purpose").textContent).toBe(`${"a".repeat(119)}😀…`);
-  expect(within(asciiTool!).getByTestId("tool-row-purpose").textContent).toBe(exactAsciiTask);
+  expect(within(unicodeTool!).getByTestId("tool-row-intent").textContent).toBe(`${"a".repeat(119)}😀…`);
+  expect(within(asciiTool!).getByTestId("tool-row-intent").textContent).toBe(exactAsciiTask);
 });
 
 test("delegate controls require stable delegate_id and reject activation-only job_id", () => {
@@ -1069,7 +1069,7 @@ test("delegate controls require stable delegate_id and reject activation-only jo
   expect(screen.getAllByRole("button", { name: "Open transcript" })).toHaveLength(1);
 });
 
-test("malformed delegate arguments keep status without inventing a purpose", () => {
+test("malformed delegate arguments keep status without inventing an intent", () => {
   render(
     <ToolCallItem
       item={item({
@@ -1083,13 +1083,13 @@ test("malformed delegate arguments keep status without inventing a purpose", () 
     />,
   );
 
-  expect(screen.queryByTestId("tool-row-purpose")).toBeNull();
+  expect(screen.queryByTestId("tool-row-intent")).toBeNull();
   expect(screen.queryByTestId("tool-row-summary")).toBeNull();
   expect(screen.getByTestId("tool-row-status")).toBeTruthy();
   expect(screen.queryByText("delegate")).toBeNull();
 });
 
-test("blank and non-string delegate tasks keep status without inventing a purpose", () => {
+test("blank and non-string delegate tasks keep status without inventing an intent", () => {
   const blank = item({
     id: "blank_delegate",
     toolName: "delegate",
@@ -1109,7 +1109,7 @@ test("blank and non-string delegate tasks keep status without inventing a purpos
     </>,
   );
 
-  expect(screen.queryAllByTestId("tool-row-purpose")).toHaveLength(0);
+  expect(screen.queryAllByTestId("tool-row-intent")).toHaveLength(0);
   expect(screen.queryAllByTestId("tool-row-summary")).toHaveLength(0);
   expect(screen.getAllByTestId("tool-row-status")).toHaveLength(2);
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
@@ -26,7 +26,7 @@ import { requireClass } from "../../../widgets/internal/requireClass";
 import { FileOpenBesideButton, fileDocParams } from "./fileOpenBeside";
 import { ImageGallery } from "./flow/ImageGallery";
 import { OpenTranscriptButton } from "./openTranscript";
-import { statedPurposeOf, ToolRow } from "./ToolRow";
+import { statedIntentOf, ToolRow } from "./ToolRow";
 import styles from "./toolcallitem.module.css";
 import { toolCallFailed, toolRendererFor } from "./toolRenderers";
 import { supersededBySuccess } from "./toolSupersession";
@@ -60,19 +60,19 @@ const DELEGATE_INDICATOR_STATE: Record<DelegateStatusKey, CadenceState> = {
   unknown: "needs-you",
 };
 
-const DELEGATE_PURPOSE_PREVIEW_MAX = 120;
+const DELEGATE_INTENT_PREVIEW_MAX = 120;
 
-function clipDelegatePurpose(text: string, max: number): string {
+function clipDelegateIntent(text: string, max: number): string {
   const codePoints = Array.from(text);
   return codePoints.length <= max ? text : `${codePoints.slice(0, max).join("")}…`;
 }
 
-function delegatePurposeOf(item: ItemModel): string | undefined {
-  const statedPurpose = statedPurposeOf(item);
-  if (statedPurpose !== undefined) return statedPurpose;
+function delegateIntentOf(item: ItemModel): string | undefined {
+  const statedIntent = statedIntentOf(item);
+  if (statedIntent !== undefined) return statedIntent;
 
   const task = str(parseArgs(item.argumentsJSON), "task")?.replace(/\s+/g, " ").trim();
-  return task === undefined || task === "" ? undefined : clipDelegatePurpose(task, DELEGATE_PURPOSE_PREVIEW_MAX);
+  return task === undefined || task === "" ? undefined : clipDelegateIntent(task, DELEGATE_INTENT_PREVIEW_MAX);
 }
 
 // Both status readers take the delegate call's ALREADY-PARSED output envelope
@@ -212,14 +212,14 @@ function ToolCallItemBody({ item, live, sessionRef, projectedSummary, renderCont
   // cwd (subscribed once above) is threaded into summary() as
   // ToolSummaryContext so shell's own descriptor can strip a redundant
   // "cd <cwd> && " prefix from its summary.
-  const statedPurpose = statedPurposeOf(item);
-  const useProjectedSummary = projectedSummary !== undefined && statedPurpose === undefined;
+  const statedIntent = statedIntentOf(item);
+  const useProjectedSummary = projectedSummary !== undefined && statedIntent === undefined;
   const summary = useProjectedSummary ? projectedSummary : descriptor.summary(item, { cwd }) + (summarySuffix ?? "");
-  let purpose = item.description;
+  let intent = item.description;
   if (isDelegate) {
-    purpose = delegatePurposeOf(item);
-  } else if (projectedSummary !== undefined && statedPurpose !== undefined) {
-    purpose = projectedSummary;
+    intent = delegateIntentOf(item);
+  } else if (projectedSummary !== undefined && statedIntent !== undefined) {
+    intent = projectedSummary;
   }
   // kata xw3t: the URL, if any, embedded in this row's own summary text -
   // web_fetch's only descriptor with one today. Read directly off the item
@@ -292,7 +292,7 @@ function ToolCallItemBody({ item, live, sessionRef, projectedSummary, renderCont
         <ToolRow
           summary={isDelegate ? "" : summary}
           summaryLink={summaryLink}
-          purpose={purpose}
+          intent={intent}
           icon={descriptor.icon}
           monoSummary={descriptor.monoSummary}
           failed={false}
@@ -334,7 +334,7 @@ function ToolCallItemBody({ item, live, sessionRef, projectedSummary, renderCont
         // representation. Collapsed, the summary stays: it is the only glance.
         summary={isDelegate || (expanded && descriptor.summaryHiddenWhenExpanded) ? "" : summary}
         summaryLink={summaryLink}
-        purpose={purpose}
+        intent={intent}
         icon={descriptor.icon}
         monoSummary={descriptor.monoSummary}
         failed={failed}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolRow.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolRow.tsx
@@ -444,7 +444,7 @@ export function ToolRow({
           ) : null}
         </span>
       )}
-      {/* Rows with no intent trail the control at the summary line's end. A
+      {/* Rows with no intent trail the control at the summary line's end. An
           intent-only row never reaches this fallback: its control rides the
           disclosure line via intentLineTrailing (the summaryLine div below
           only mounts when there is no such slot). */}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolRow.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolRow.tsx
@@ -3,10 +3,10 @@
 // only its own CONTENT (what the verb/target is, what meta it shows, what its
 // expanded body looks like), never how the row is arranged.
 //
-// THE ROW GRAMMAR, two lines when a purpose exists (one otherwise):
+// THE ROW GRAMMAR, two lines when an intent exists (one otherwise):
 //
 //     rail:   [kind icon, 50%]            (in the gutter, beside line 1)
-//     line 1: [✗ failure glyph?] [status?] purpose[chevron inline]
+//     line 1: [✗ failure glyph?] [status?] intent[chevron inline]
 //     line 2: verb target [· meta] [affordances]
 //
 //   Line 2's truncation: COLLAPSED it middle-truncates (head … tail, the
@@ -23,21 +23,21 @@
 //     runContent wrapper reserves, at 50% opacity - the kind is ambient
 //     context, not content. Below the breakpoint (no gutter) it leads the
 //     rationale line inline, same 50%;
-//   - a COLLAPSED row with both a purpose and a summary STACKS them: the
-//     purpose (the agent's stated rationale, italic) on the first line, the
+//   - a COLLAPSED row with both an intent and a summary STACKS them: the
+//     intent (the agent's stated rationale, italic) on the first line, the
 //     verb/target summary demoted to a quiet second line (truncation
 //     per above). Composing both onto one line was tried (tiered density)
 //     and reverted on review: two clamped, truncated fragments read worse
 //     than one full line plus one clamped one.
 //   - the chevron rides INLINE at the end of the headline text - inside the
-//     purpose when there is one, otherwise inside the summary - wrapping with
+//     intent when there is one, otherwise inside the summary - wrapping with
 //     the words it opens. It is never a flex item of the row: right-justified
 //     at the end of the line it sat a column of whitespace away from its own
 //     rationale (Jesse's review call), the very defect the trailing placement
 //     was supposed to fix;
 //   - the failure glyph appears ONLY on a failed call and reserves no space
 //     otherwise (A2 — see the deliberate-inconsistency note below);
-//   - the purpose is the agent's own stated reason for the call
+//   - the intent is the agent's own stated reason for the call
 //     (ItemModel.description) and LEADS the text, because it is the one part
 //     written for a human; verb/target recede to a quiet line under it, in
 //     the same sans face - fixed-width is reserved for shell, whose summary
@@ -45,9 +45,9 @@
 //   - verb/target/meta are one string the descriptor's summary() produced;
 //   - affordances are trailing controls (e.g. "Open beside") and they ride the
 //     TOOL-CALL line: inline at the end of the summary when there is one,
-//     which - with a purpose present - is the demoted second line, not the
-//     rationale line. A purpose-only row (no summary) trails them on the
-//     purpose line instead, the one line it has: a sibling flex item AFTER
+//     which - with an intent present - is the demoted second line, not the
+//     rationale line. An intent-only row (no summary) trails them on the
+//     intent line instead, the one line it has: a sibling flex item AFTER
 //     the trigger button (never nested inside it - a button inside a button
 //     is not valid), sprung to the line's end by the trigger's own flex-grow,
 //     the same placement the notification card's head gives "Open subagent"
@@ -56,7 +56,7 @@
 //     openBesideInline) anchors the control mid-summary via trailingAfter -
 //     between the file name and the line range it opens.
 //
-// A row with no purpose is a single line: summary, then affordances, then
+// A row with no intent is a single line: summary, then affordances, then
 // the chevron if there is something to expand.
 import { type ReactNode, useId } from "react";
 import { Chevron, FailureGlyph, ToolIcon, type ToolIconKind } from "../../../widgets";
@@ -67,7 +67,7 @@ const CLASS = {
   row: requireClass(styles.row, "toolcallitem.module.css", "row"),
   trigger: requireClass(styles.trigger, "toolcallitem.module.css", "trigger"),
   summaryLine: requireClass(styles.summaryLine, "toolcallitem.module.css", "summaryLine"),
-  purpose: requireClass(styles.purpose, "toolcallitem.module.css", "purpose"),
+  intent: requireClass(styles.intent, "toolcallitem.module.css", "intent"),
   summary: requireClass(styles.summary, "toolcallitem.module.css", "summary"),
   mono: requireClass(styles.mono, "toolcallitem.module.css", "mono"),
   status: requireClass(styles.status, "toolcallitem.module.css", "status"),
@@ -77,7 +77,7 @@ const CLASS = {
   clampedHead: requireClass(styles.clampedHead, "toolcallitem.module.css", "clampedHead"),
   clampedTail: requireClass(styles.clampedTail, "toolcallitem.module.css", "clampedTail"),
   summaryTrailing: requireClass(styles.summaryTrailing, "toolcallitem.module.css", "summaryTrailing"),
-  purposeTrailing: requireClass(styles.purposeTrailing, "toolcallitem.module.css", "purposeTrailing"),
+  intentTrailing: requireClass(styles.intentTrailing, "toolcallitem.module.css", "intentTrailing"),
   summaryMeta: requireClass(styles.summaryMeta, "toolcallitem.module.css", "summaryMeta"),
   chevron: requireClass(styles.chevron, "toolcallitem.module.css", "chevron"),
 };
@@ -97,10 +97,10 @@ export interface ToolRowProps {
   summaryLink?: string;
   /** The agent's stated reason for the call (ItemModel.description). Blank or
    * absent renders nothing at all — no placeholder, no empty separator. */
-  purpose?: string;
+  intent?: string;
   /** The tool-FAMILY glyph, riding inline at the start of the tool-use line
    * (the descriptor's `icon` field); a summary-less row rides it on the
-   * purpose line instead. Absent renders no icon. */
+   * intent line instead. Absent renders no icon. */
   icon?: ToolIconKind;
   /** Fixed-width summary text (shell, whose summary IS a command). Default
    * is the sans face - Jesse's review call: fixed-width everywhere made
@@ -126,7 +126,7 @@ export interface ToolRowProps {
    * anchor" contract as summaryLink). */
   trailingAfter?: string;
   /** Optional status rail content for tools that need a one-glance
-   * progression/health signal before human-facing purpose text. */
+   * progression/health signal before human-facing intent text. */
   status?: ReactNode;
   /** Hover text for details that are real but must not be the headline — the
    * shell exit code, per A2. */
@@ -135,13 +135,13 @@ export interface ToolRowProps {
   bodyId?: string;
 }
 
-/** The one rule for reading a tool call's stated purpose (ItemModel.description):
+/** The one rule for reading a tool call's stated intent (ItemModel.description):
  * trimmed, and blank means ABSENT. Shared with the subagent activity feed
  * (tools/subagentModule.tsx), which presents the same field very differently
  * (a numbered feed of a child's steps) but must agree on when it exists at all -
  * otherwise a whitespace-only description is a line in one surface and nothing
  * in the other. */
-export function statedPurposeOf(item: { description?: string }): string | undefined {
+export function statedIntentOf(item: { description?: string }): string | undefined {
   const trimmed = item.description?.trim();
   return trimmed === undefined || trimmed === "" ? undefined : trimmed;
 }
@@ -210,7 +210,7 @@ function linkifySummary(text: string, href: string | undefined): ReactNode {
 export function ToolRow({
   summary,
   summaryLink,
-  purpose,
+  intent,
   icon,
   monoSummary,
   failed,
@@ -225,8 +225,8 @@ export function ToolRow({
 }: ToolRowProps) {
   const generatedBodyId = useId();
   const disclosureBodyId = bodyId ?? generatedBodyId;
-  const statedPurpose = statedPurposeOf({ description: purpose });
-  const hasPurpose = statedPurpose !== undefined;
+  const statedIntent = statedIntentOf({ description: intent });
+  const hasIntent = statedIntent !== undefined;
   const hasSummary = summary.trim() !== "";
   // `status` is typed ReactNode, so it admits values that render nothing and
   // carry no accessible name - null, undefined, false (the common
@@ -255,7 +255,7 @@ export function ToolRow({
     return [trailingAfter, summary.slice(trailingAfter.length)];
   })();
   // The chevron rides INLINE at the end of the headline text (see the grammar
-  // above): inside the purpose when there is one, otherwise inside the
+  // above): inside the intent when there is one, otherwise inside the
   // summary - never a flex item of the row, so nothing can justify it away
   // from the words it opens.
   const chevron = expandable ? (
@@ -287,19 +287,19 @@ export function ToolRow({
         <ToolIcon kind={icon} />
       </span>
     ) : null;
-  // A purpose-only row has no tool-call line for affordances to ride, so they
+  // An intent-only row has no tool-call line for affordances to ride, so they
   // ride the DISCLOSURE line - the one line it has (see the grammar above).
   // The disclosure trigger is a <button>, so the control cannot nest inside
   // it: the slot follows the trigger as a sibling flex item of the row, and
-  // data-purpose-trailing on the row is the stylesheet's hook for letting the
+  // data-intent-trailing on the row is the stylesheet's hook for letting the
   // two share line 1.
-  const purposeLineTrailing =
-    hasPurpose && !hasSummary && anchorSplit === undefined && trailing !== undefined && trailing !== null ? (
-      <span className={CLASS.purposeTrailing} data-testid="tool-row-purpose-trailing">
+  const intentLineTrailing =
+    hasIntent && !hasSummary && anchorSplit === undefined && trailing !== undefined && trailing !== null ? (
+      <span className={CLASS.intentTrailing} data-testid="tool-row-intent-trailing">
         {trailing}
       </span>
     ) : null;
-  const showPurposeTrailing = purposeLineTrailing !== null;
+  const showIntentTrailing = intentLineTrailing !== null;
   // The collapsed second line's middle-truncation, WITH the inline-affordance
   // variant: when anchorSplit places the trailing control mid-summary, the
   // control becomes a flex item of the clamped line between the anchor's end
@@ -366,21 +366,21 @@ export function ToolRow({
           indent. Different context, different answer. */}
       {failureNode}
       {statusNode}
-      {hasPurpose && (
-        <span className={CLASS.purpose} data-testid="tool-row-purpose">
-          {statedPurpose}
+      {hasIntent && (
+        <span className={CLASS.intent} data-testid="tool-row-intent">
+          {statedIntent}
           {chevron}
         </span>
       )}
       {hasSummary && (
         <span
           className={`${CLASS.summary}${monoSummary ? ` ${CLASS.mono}` : ""}${
-            hasPurpose ? ` ${CLASS.demoted}${expanded ? "" : ` ${CLASS.clamped}`}` : ""
+            hasIntent ? ` ${CLASS.demoted}${expanded ? "" : ` ${CLASS.clamped}`}` : ""
           }`}
           data-testid="tool-row-summary"
-          title={hasPurpose ? summary : undefined}
+          title={hasIntent ? summary : undefined}
         >
-          {hasPurpose && !expanded ? (
+          {hasIntent && !expanded ? (
             clampedSummary
           ) : anchorSplit !== undefined ? (
             <>
@@ -393,24 +393,24 @@ export function ToolRow({
           ) : (
             linkifySummary(summary, summaryLink)
           )}
-          {!hasPurpose && chevron}
+          {!hasIntent && chevron}
           {/* Affordances ride the TOOL-CALL line (see the grammar above):
-              inline at the end of the summary text, so with a purpose present
+              inline at the end of the summary text, so with an intent present
               they sit on the demoted second line - not the rationale line.
               Skipped when anchorSplit already placed the control mid-summary. */}
-          {hasPurpose && trailing && anchorSplit === undefined ? (
+          {hasIntent && trailing && anchorSplit === undefined ? (
             <span className={CLASS.summaryTrailing}>{trailing}</span>
           ) : null}
         </span>
       )}
-      {!hasPurpose && !hasSummary && chevron}
-      {(!hasPurpose || !hasSummary) && anchorSplit === undefined ? trailing : null}
+      {!hasIntent && !hasSummary && chevron}
+      {(!hasIntent || !hasSummary) && anchorSplit === undefined ? trailing : null}
     </>
   );
 
   if (!expandable) {
     return (
-      <div className={CLASS.row} data-testid="tool-row" data-purpose={hasPurpose ? "true" : undefined} title={title}>
+      <div className={CLASS.row} data-testid="tool-row" data-intent={hasIntent ? "true" : undefined} title={title}>
         {content}
       </div>
     );
@@ -421,12 +421,12 @@ export function ToolRow({
       {hasSummary && (
         <span
           className={`${CLASS.summary}${monoSummary ? ` ${CLASS.mono}` : ""}${
-            hasPurpose ? ` ${CLASS.demoted}${expanded ? "" : ` ${CLASS.clamped}`}` : ""
+            hasIntent ? ` ${CLASS.demoted}${expanded ? "" : ` ${CLASS.clamped}`}` : ""
           }`}
           data-testid="tool-row-summary"
-          title={hasPurpose ? summary : undefined}
+          title={hasIntent ? summary : undefined}
         >
-          {hasPurpose && !expanded ? (
+          {hasIntent && !expanded ? (
             clampedSummary
           ) : anchorSplit !== undefined ? (
             <>
@@ -439,19 +439,19 @@ export function ToolRow({
           ) : (
             linkifySummary(summary, summaryLink)
           )}
-          {hasPurpose && trailing && anchorSplit === undefined ? (
+          {hasIntent && trailing && anchorSplit === undefined ? (
             <span className={CLASS.summaryTrailing}>{trailing}</span>
           ) : null}
         </span>
       )}
-      {/* Rows with no purpose trail the control at the summary line's end. A
-          purpose-only row never reaches this fallback: its control rides the
-          disclosure line via purposeLineTrailing (the summaryLine div below
+      {/* Rows with no intent trail the control at the summary line's end. A
+          intent-only row never reaches this fallback: its control rides the
+          disclosure line via intentLineTrailing (the summaryLine div below
           only mounts when there is no such slot). */}
-      {!hasPurpose && anchorSplit === undefined ? trailing : null}
+      {!hasIntent && anchorSplit === undefined ? trailing : null}
     </>
   );
-  const triggerLabel = !hasPurpose
+  const triggerLabel = !hasIntent
     ? [
         failed ? "Failed" : undefined,
         hasSummary ? summary : undefined,
@@ -465,11 +465,11 @@ export function ToolRow({
     <div
       className={CLASS.row}
       data-testid="tool-row"
-      data-purpose={hasPurpose ? "true" : undefined}
-      data-purpose-trailing={showPurposeTrailing ? "true" : undefined}
+      data-intent={hasIntent ? "true" : undefined}
+      data-intent-trailing={showIntentTrailing ? "true" : undefined}
       title={title}
     >
-      {hasPurpose ? (
+      {hasIntent ? (
         <button
           type="button"
           className={CLASS.trigger}
@@ -481,8 +481,8 @@ export function ToolRow({
           {iconNode}
           {failureNode}
           {statusNode}
-          <span className={CLASS.purpose} data-testid="tool-row-purpose">
-            {statedPurpose}
+          <span className={CLASS.intent} data-testid="tool-row-intent">
+            {statedIntent}
             {chevron}
           </span>
         </button>
@@ -493,9 +493,9 @@ export function ToolRow({
           {statusNode}
         </>
       )}
-      {purposeLineTrailing}
-      {!hasPurpose && <div className={CLASS.summaryLine}>{summaryContent}</div>}
-      {!hasPurpose && (
+      {intentLineTrailing}
+      {!hasIntent && <div className={CLASS.summaryLine}>{summaryContent}</div>}
+      {!hasIntent && (
         <button
           type="button"
           className={CLASS.trigger}
@@ -508,7 +508,7 @@ export function ToolRow({
           {chevron}
         </button>
       )}
-      {hasPurpose && !showPurposeTrailing && <div className={CLASS.summaryLine}>{summaryContent}</div>}
+      {hasIntent && !showIntentTrailing && <div className={CLASS.summaryLine}>{summaryContent}</div>}
     </div>
   );
 }

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.test.tsx
@@ -747,7 +747,7 @@ describe("TranscriptBody", () => {
     expect(single.hasAttribute("open")).toBe(true);
   });
 
-  test("coalesces purpose-only intents across adjacent turns into one stable virtual row", () => {
+  test("coalesces intent-only actions across adjacent turns into one stable virtual row", () => {
     const { rerender } = render(
       <TranscriptBody
         model={crossTurnFixture}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
@@ -324,24 +324,24 @@ test("with both hook toggles off, only a non-zero hook survives as a compact cri
   expect(screen.getByTestId("system-notice-failure")).toBeTruthy();
 });
 
-test("a blank-purpose tool uses the projected neutral summary without a raw command summary", () => {
+test("a blank-intent tool uses the projected neutral summary without a raw command summary", () => {
   const config = makeTranscriptDisplayConfig({ kind: "preset", level: "chat" });
-  const blankPurpose = item({
-    id: "critical-blank-purpose",
+  const blankIntent = item({
+    id: "critical-blank-intent",
     type: "commandExecution",
     toolName: "shell",
     argumentsJSON: JSON.stringify({ command: "echo should-not-be-recomputed" }),
     description: "  ",
     status: "completed",
   });
-  const { rerender } = render(withConfig(config, <TurnBlock turn={turn([blankPurpose], {}, config)} />));
+  const { rerender } = render(withConfig(config, <TurnBlock turn={turn([blankIntent], {}, config)} />));
 
   expect(screen.queryAllByTestId("tool-call-item")).toHaveLength(0);
   expect(screen.getByText("Action summary unavailable")).toBeTruthy();
   expect(screen.queryByText("Ran echo should-not-be-recomputed")).toBeNull();
 
   const tools = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
-  rerender(withConfig(tools, <TurnBlock turn={turn([blankPurpose], {}, tools)} />));
+  rerender(withConfig(tools, <TurnBlock turn={turn([blankIntent], {}, tools)} />));
   expect(screen.getAllByTestId("tool-call-item")).toHaveLength(1);
   expect(screen.getByTestId("tool-row-summary").textContent).toBe("Action summary unavailable");
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolRenderers.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolRenderers.ts
@@ -37,7 +37,7 @@ export interface ToolSummaryContext {
 
 export interface ToolRendererDescriptor {
   match: string | ((toolName: string) => boolean); // exact name or predicate (job_* family)
-  summary(item: ItemModel, ctx?: ToolSummaryContext): string; // one-line purpose-first summary
+  summary(item: ItemModel, ctx?: ToolSummaryContext): string; // one-line intent-first summary
   // The tool-FAMILY glyph riding inline at the start of the row's tool-use
   // line (widgets/toolicon), so the kind of work - shell vs file read vs
   // edit vs web - is scannable down a run of calls without reading the

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolRowGrammar.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolRowGrammar.test.tsx
@@ -12,7 +12,7 @@ import type { ItemModel, TurnModel } from "../../../protocol/model";
 import { resetWorkspaceStoreForTests, workspaceStore } from "../../../shell/workspace";
 import { resetDisclosureStoreForTests } from "../../../widgets/disclosure/disclosureStore";
 import { ToolCallItem } from "./ToolCallItem";
-import { statedPurposeOf, ToolRow } from "./ToolRow";
+import { statedIntentOf, ToolRow } from "./ToolRow";
 import { registerToolRenderer, toolRendererFor } from "./toolRenderers";
 // The failure-glyph and exit-code tests below drive the REAL shell descriptor
 // (its failed()/detail() hooks are the whole point of A2), so this file has to
@@ -49,11 +49,11 @@ test("a non-expandable row renders the summary in the shared row element", () =>
   expect(screen.getByTestId("tool-row-summary").textContent).toBe("Ran ls");
 });
 
-test("a purpose-bearing row stacks: purpose on line 1, demoted summary on line 2 - never one composed line", () => {
+test("an intent-bearing row stacks: intent on line 1, demoted summary on line 2 - never one composed line", () => {
   render(
     <ToolRow
       summary="npm test -- src/foo"
-      purpose="Running the foo tests"
+      intent="Running the foo tests"
       failed={false}
       expandable
       expanded={false}
@@ -65,16 +65,16 @@ test("a purpose-bearing row stacks: purpose on line 1, demoted summary on line 2
   // one-line compose was tried in tiered density and reverted on review).
   expect(row.textContent).toBe("Running the foo testsnpm test -- src/foo");
   // The demoted second line ellipsis-clamps, so the full summary rides the
-  // hover title; the unclamped purpose needs none.
+  // hover title; the unclamped intent needs none.
   expect(screen.getByTestId("tool-row-summary").getAttribute("title")).toBe("npm test -- src/foo");
-  expect(screen.getByTestId("tool-row-purpose").getAttribute("title")).toBe(null);
+  expect(screen.getByTestId("tool-row-intent").getAttribute("title")).toBe(null);
 });
 
 test("an expanded row has the same stacked grammar - open vs collapsed differs only in the body below", () => {
   render(
     <ToolRow
       summary="npm test -- src/foo"
-      purpose="Running the foo tests"
+      intent="Running the foo tests"
       failed={false}
       expandable
       expanded
@@ -94,7 +94,7 @@ test("a collapsed row splits the summary into a clampable head and an always-ful
   render(
     <ToolRow
       summary={summary}
-      purpose="Merging the redesign"
+      intent="Merging the redesign"
       failed={false}
       expandable
       expanded={false}
@@ -116,7 +116,7 @@ test("a collapsed row splits the summary into a clampable head and an always-ful
 test("an expanded row drops the clamp entirely - the full call wraps, no head/tail split", () => {
   const summary = "Ran cd ~/prime-radiant/toil-suite/evener && git merge --no-ff transcript-view-design";
   render(
-    <ToolRow summary={summary} purpose="Merging the redesign" failed={false} expandable expanded onToggle={() => {}} />,
+    <ToolRow summary={summary} intent="Merging the redesign" failed={false} expandable expanded onToggle={() => {}} />,
   );
   expect(screen.queryByTestId("tool-row-summary-head")).toBe(null);
   expect(screen.getByTestId("tool-row-summary").textContent).toBe(summary);
@@ -134,7 +134,7 @@ test("the collapsed head/tail split never leaves whitespace at a span boundary -
   render(
     <ToolRow
       summary={summary}
-      purpose="Running the tests"
+      intent="Running the tests"
       failed={false}
       expandable
       expanded={false}
@@ -170,7 +170,7 @@ test("the clamp mechanics: head ellipsis-clamps, tail never shrinks, and the cla
   expect(demoted![1]).not.toContain("nowrap");
 });
 
-test("a purpose-less row is a single line: summary text followed by its disclosure button", () => {
+test("an intent-less row is a single line: summary text followed by its disclosure button", () => {
   render(<ToolRow summary="npm test" failed={false} expandable expanded={false} onToggle={() => {}} />);
   const row = screen.getByTestId("tool-row");
   expect(row.textContent).toBe("npm test");
@@ -191,7 +191,7 @@ test("an expandable row renders as a real button with no interactive descendants
   );
 });
 
-test("a purpose-less disclosure button covers the visible summary while sibling controls stay outside it", () => {
+test("an intent-less disclosure button covers the visible summary while sibling controls stay outside it", () => {
   const css = rowCss();
   render(
     <ToolRow
@@ -209,9 +209,9 @@ test("a purpose-less disclosure button covers the visible summary while sibling 
   expect(trigger.parentElement).toBe(row);
   expect(trigger.contains(screen.getByRole("link"))).toBe(false);
   expect(trigger.contains(screen.getByRole("button", { name: "Open beside" }))).toBe(false);
-  expect(css).toMatch(/\.row:not\(\[data-purpose="true"\]\) \.trigger\s*\{[^}]*position:\s*absolute[^}]*inset:\s*0/);
-  expect(css).toMatch(/\.row:not\(\[data-purpose="true"\]\) \.summaryLine\s*\{[^}]*pointer-events:\s*none/);
-  expect(css).toMatch(/\.row:not\(\[data-purpose="true"\]\) \.summaryLine a,[\s\S]*pointer-events:\s*auto/);
+  expect(css).toMatch(/\.row:not\(\[data-intent="true"\]\) \.trigger\s*\{[^}]*position:\s*absolute[^}]*inset:\s*0/);
+  expect(css).toMatch(/\.row:not\(\[data-intent="true"\]\) \.summaryLine\s*\{[^}]*pointer-events:\s*none/);
+  expect(css).toMatch(/\.row:not\(\[data-intent="true"\]\) \.summaryLine a,[\s\S]*pointer-events:\s*auto/);
 });
 
 test("native Enter and Space activation toggle disclosure exactly once", async () => {
@@ -305,56 +305,56 @@ test("every tool renderer's row comes from ToolRow - ToolCallItem renders exactl
   expect(screen.getAllByTestId("tool-row")).toHaveLength(1);
 });
 
-// --- A1b: the agent's stated purpose comes back ---------------------------
+// --- A1b: the agent's stated intent comes back ---------------------------
 
-test("the row renders item.description as the call's stated purpose", () => {
-  registerToolRenderer({ match: "trg_purpose", summary: () => "Ran ls -la" });
+test("the row renders item.description as the call's stated intent", () => {
+  registerToolRenderer({ match: "trg_intent", summary: () => "Ran ls -la" });
   render(
     <ToolCallItem
-      item={item({ toolName: "trg_purpose", description: "Check the working directory." })}
+      item={item({ toolName: "trg_intent", description: "Check the working directory." })}
       turn={turn}
       live={false}
     />,
   );
-  expect(screen.getByTestId("tool-row-purpose").textContent).toBe("Check the working directory.");
+  expect(screen.getByTestId("tool-row-intent").textContent).toBe("Check the working directory.");
 });
 
-test("the purpose LEADS the verb/target summary in document order", () => {
-  registerToolRenderer({ match: "trg_purpose_order", summary: () => "Ran ls -la" });
+test("the intent LEADS the verb/target summary in document order", () => {
+  registerToolRenderer({ match: "trg_intent_order", summary: () => "Ran ls -la" });
   render(
     <ToolCallItem
-      item={item({ toolName: "trg_purpose_order", description: "Check the working directory." })}
+      item={item({ toolName: "trg_intent_order", description: "Check the working directory." })}
       turn={turn}
       live={false}
     />,
   );
   const row = screen.getByTestId("tool-row");
-  const purpose = screen.getByTestId("tool-row-purpose");
+  const intent = screen.getByTestId("tool-row-intent");
   const summary = screen.getByTestId("tool-row-summary");
   const children = Array.from(row.querySelectorAll("[data-testid]"));
-  expect(children.indexOf(purpose)).toBeLessThan(children.indexOf(summary));
+  expect(children.indexOf(intent)).toBeLessThan(children.indexOf(summary));
 });
 
-test("no description means no purpose element at all - no placeholder, no empty separator", () => {
-  registerToolRenderer({ match: "trg_no_purpose", summary: () => "Ran ls" });
-  render(<ToolCallItem item={item({ toolName: "trg_no_purpose" })} turn={turn} live={false} />);
-  expect(screen.queryByTestId("tool-row-purpose")).toBe(null);
+test("no description means no intent element at all - no placeholder, no empty separator", () => {
+  registerToolRenderer({ match: "trg_no_intent", summary: () => "Ran ls" });
+  render(<ToolCallItem item={item({ toolName: "trg_no_intent" })} turn={turn} live={false} />);
+  expect(screen.queryByTestId("tool-row-intent")).toBe(null);
 });
 
-test("a whitespace-only description is absence, not a purpose", () => {
-  registerToolRenderer({ match: "trg_blank_purpose", summary: () => "Ran ls" });
-  render(<ToolCallItem item={item({ toolName: "trg_blank_purpose", description: "   " })} turn={turn} live={false} />);
-  expect(screen.queryByTestId("tool-row-purpose")).toBe(null);
+test("a whitespace-only description is absence, not an intent", () => {
+  registerToolRenderer({ match: "trg_blank_intent", summary: () => "Ran ls" });
+  render(<ToolCallItem item={item({ toolName: "trg_blank_intent", description: "   " })} turn={turn} live={false} />);
+  expect(screen.queryByTestId("tool-row-intent")).toBe(null);
 });
 
 // The subagent activity feed reads the SAME field with a very different
 // presentation; the two must at least agree on when it exists, which is what
 // this shared helper is for (see its doc comment).
-test("statedPurposeOf is the one absent-vs-present rule both surfaces share", () => {
-  expect(statedPurposeOf({ description: "  Check the tree.  " })).toBe("Check the tree.");
-  expect(statedPurposeOf({ description: "   " })).toBeUndefined();
-  expect(statedPurposeOf({ description: "" })).toBeUndefined();
-  expect(statedPurposeOf({})).toBeUndefined();
+test("statedIntentOf is the one absent-vs-present rule both surfaces share", () => {
+  expect(statedIntentOf({ description: "  Check the tree.  " })).toBe("Check the tree.");
+  expect(statedIntentOf({ description: "   " })).toBeUndefined();
+  expect(statedIntentOf({ description: "" })).toBeUndefined();
+  expect(statedIntentOf({})).toBeUndefined();
 });
 
 // --- A2: failure is a glyph on the left; success costs no space -----------
@@ -382,10 +382,10 @@ test("a clean call with nothing to open leads with its summary - no chevron, no 
 });
 
 // The chevron rides INLINE at the end of the headline text (see ToolRow.tsx's
-// grammar): inside the purpose when there is one, otherwise inside the
+// grammar): inside the intent when there is one, otherwise inside the
 // summary. It is never a flex item of the row, so nothing can justify it a
 // column of whitespace away from the words it opens.
-test("the chevron rides inline at the end of the purpose text when a purpose exists", () => {
+test("the chevron rides inline at the end of the intent text when an intent exists", () => {
   registerToolRenderer({ match: "trg_chev_inline", summary: () => "Ran ls", body: () => <div>more</div> });
   render(
     <ToolCallItem
@@ -394,10 +394,10 @@ test("the chevron rides inline at the end of the purpose text when a purpose exi
       live={false}
     />,
   );
-  expect(screen.getByTestId("tool-row-purpose").lastElementChild).toBe(screen.getByTestId("tool-row-chevron"));
+  expect(screen.getByTestId("tool-row-intent").lastElementChild).toBe(screen.getByTestId("tool-row-chevron"));
 });
 
-test("the chevron rides inline at the end of the summary when there is no purpose", () => {
+test("the chevron rides inline at the end of the summary when there is no intent", () => {
   registerToolRenderer({ match: "trg_chev_trail", summary: () => "Ran ls", body: () => <div>more</div> });
   render(<ToolCallItem item={item({ toolName: "trg_chev_trail" })} turn={turn} live={false} />);
   expect(screen.getByTestId("tool-row-trigger").lastElementChild).toBe(screen.getByTestId("tool-row-chevron"));
@@ -493,22 +493,22 @@ test("a descriptor with an icon puts it in the RAIL as the row's first flex item
     />,
   );
   const row = screen.getByTestId("tool-row");
-  const purpose = screen.getByTestId("tool-row-purpose");
+  const intent = screen.getByTestId("tool-row-intent");
   const summary = screen.getByTestId("tool-row-summary");
   const icon = screen.getByTestId("tool-row-icon");
   expect(row.firstElementChild).toBe(icon);
-  expect(purpose.contains(icon)).toBe(false);
+  expect(intent.contains(icon)).toBe(false);
   expect(summary.contains(icon)).toBe(false);
 });
 
-test("a summary-less row (a delegate's purpose-only row) also rails the icon beside its rationale line", () => {
+test("a summary-less row (a delegate's intent-only row) also rails the icon beside its rationale line", () => {
   render(
-    <ToolRow summary="" purpose="Scout the repo" icon="delegate" failed={false} expandable={false} expanded={false} />,
+    <ToolRow summary="" intent="Scout the repo" icon="delegate" failed={false} expandable={false} expanded={false} />,
   );
   const row = screen.getByTestId("tool-row");
   const icon = screen.getByTestId("tool-row-icon");
   expect(row.firstElementChild).toBe(icon);
-  expect(screen.getByTestId("tool-row-purpose").contains(icon)).toBe(false);
+  expect(screen.getByTestId("tool-row-intent").contains(icon)).toBe(false);
 });
 
 test("a descriptor WITHOUT an icon renders no icon element - the icon-less grammar is unchanged", () => {
@@ -624,15 +624,15 @@ test("the row hover is an ink wash, not a surface token that can match the pane"
   expect(hover![1]).not.toMatch(/var\(--surface-/);
 });
 
-// A1: with a purpose present the summary demotes onto its own line, and the
+// A1: with an intent present the summary demotes onto its own line, and the
 // affordances ride THAT line - the tool call they act on - not the rationale
 // line. Rendered inline at the end of the summary text (same idiom as the
 // chevron on the headline line), so the row still never wraps to three.
-test("with a purpose, a trailing affordance rides the tool-call line, not the rationale line", () => {
+test("with an intent, a trailing affordance rides the tool-call line, not the rationale line", () => {
   render(
     <ToolRow
       summary="Read a.ts"
-      purpose="Check the source."
+      intent="Check the source."
       failed={false}
       expandable={false}
       expanded={false}
@@ -641,17 +641,17 @@ test("with a purpose, a trailing affordance rides the tool-call line, not the ra
   );
   const button = screen.getByRole("button", { name: "Open beside" });
   expect(screen.getByTestId("tool-row-summary").contains(button)).toBe(true);
-  expect(screen.getByTestId("tool-row-purpose").contains(button)).toBe(false);
+  expect(screen.getByTestId("tool-row-intent").contains(button)).toBe(false);
 });
 
-// A purpose-only row (the delegate card: purpose, no summary) has no
+// An intent-only row (the delegate card: intent, no summary) has no
 // tool-call line, so its affordance rides the disclosure line (ToolRow's
 // grammar). Regression guard: it used to drop onto a second line of its own.
-test("a purpose-only row trails its affordance on the disclosure line, not a line of its own", () => {
+test("an intent-only row trails its affordance on the disclosure line, not a line of its own", () => {
   render(
     <ToolRow
       summary=""
-      purpose="Proving family scheduler quiescence"
+      intent="Proving family scheduler quiescence"
       failed={false}
       expandable
       expanded={false}
@@ -661,27 +661,27 @@ test("a purpose-only row trails its affordance on the disclosure line, not a lin
   );
   const row = screen.getByTestId("tool-row");
   const button = screen.getByRole("button", { name: "Open transcript" });
-  // Exactly one rendering, in the purpose-line slot, outside the trigger.
+  // Exactly one rendering, in the intent-line slot, outside the trigger.
   expect(screen.getAllByRole("button", { name: "Open transcript" })).toHaveLength(1);
-  expect(screen.getByTestId("tool-row-purpose-trailing").contains(button)).toBe(true);
+  expect(screen.getByTestId("tool-row-intent-trailing").contains(button)).toBe(true);
   expect(screen.getByTestId("tool-row-trigger").contains(button)).toBe(false);
   // No second line at all: nothing renders a summary element or summaryLine.
   expect(screen.queryByTestId("tool-row-summary")).toBeNull();
-  expect(row.getAttribute("data-purpose-trailing")).toBe("true");
+  expect(row.getAttribute("data-intent-trailing")).toBe("true");
   // The stylesheet keeps trigger and control on one line: the trigger gives
-  // up the full-width flex basis a purpose-bearing row otherwise assigns.
+  // up the full-width flex basis an intent-bearing row otherwise assigns.
   const css = rowCss();
-  expect(css).toMatch(/\.row\[data-purpose-trailing="true"\] \.trigger\s*\{[^}]*flex:\s*1 1 auto/);
+  expect(css).toMatch(/\.row\[data-intent-trailing="true"\] \.trigger\s*\{[^}]*flex:\s*1 1 auto/);
 });
 
-// Without an affordance a purpose-only row changes shape not at all: no
+// Without an affordance an intent-only row changes shape not at all: no
 // slot, no data attribute, and the (empty) summaryLine stays as it was.
-test("a purpose-only row with no affordance renders no purpose-line trailing slot", () => {
+test("an intent-only row with no affordance renders no intent-line trailing slot", () => {
   render(
-    <ToolRow summary="" purpose="Just a rationale." failed={false} expandable expanded={false} onToggle={() => {}} />,
+    <ToolRow summary="" intent="Just a rationale." failed={false} expandable expanded={false} onToggle={() => {}} />,
   );
-  expect(screen.queryByTestId("tool-row-purpose-trailing")).toBeNull();
-  expect(screen.getByTestId("tool-row").getAttribute("data-purpose-trailing")).toBe(null);
+  expect(screen.queryByTestId("tool-row-intent-trailing")).toBeNull();
+  expect(screen.getByTestId("tool-row").getAttribute("data-intent-trailing")).toBe(null);
 });
 
 // --- trailingAfter: the affordance rides INLINE mid-summary (read_file's
@@ -695,12 +695,12 @@ test("a purpose-only row with no affordance renders no purpose-line trailing slo
 // literal prefix of `summary` keeps the default end-of-line placement (same
 // "never a dead anchor" contract as summaryLink). ---------------------------------------
 
-test("trailingAfter places the control between the anchor text and the meta on a collapsed purpose-bearing row", () => {
+test("trailingAfter places the control between the anchor text and the meta on a collapsed intent-bearing row", () => {
   const summary = "Read cmd/evener-hub/frontend/src/widgets/sheet/sheet.test.tsx · lines 1-260";
   render(
     <ToolRow
       summary={summary}
-      purpose="Reviewing Sheet tests before adding size coverage"
+      intent="Reviewing Sheet tests before adding size coverage"
       failed={false}
       expandable
       expanded={false}
@@ -733,7 +733,7 @@ test("trailingAfter with a short path (anchor inside the clamped head) keeps the
   render(
     <ToolRow
       summary={summary}
-      purpose="Check the source"
+      intent="Check the source"
       failed={false}
       expandable
       expanded={false}
@@ -760,7 +760,7 @@ test("trailingAfter on an expanded row splits the full summary around the contro
   render(
     <ToolRow
       summary={summary}
-      purpose="Check the source"
+      intent="Check the source"
       failed={false}
       expandable
       expanded
@@ -782,7 +782,7 @@ test("a trailingAfter anchor NOT present at all in the summary falls back to the
   render(
     <ToolRow
       summary="Read a.ts · lines 1-3"
-      purpose="Check the source"
+      intent="Check the source"
       failed={false}
       expandable
       expanded={false}
@@ -808,7 +808,7 @@ test("a trailingAfter anchor that is present but NOT a prefix of the summary als
   render(
     <ToolRow
       summary="Read a.ts · lines 1-3"
-      purpose="Check the source"
+      intent="Check the source"
       failed={false}
       expandable
       expanded={false}
@@ -841,7 +841,7 @@ test("an ambiguous bare anchor that also recurs LATER in the summary (the meta-s
   render(
     <ToolRow
       summary={summary}
-      purpose="Check the source"
+      intent="Check the source"
       failed={false}
       expandable
       expanded={false}
@@ -867,7 +867,7 @@ test("an ambiguous bare anchor whose real target is the EARLIER occurrence does 
   render(
     <ToolRow
       summary={summary}
-      purpose="Check the source"
+      intent="Check the source"
       failed={false}
       expandable
       expanded={false}
@@ -892,7 +892,7 @@ test("the complete prefix anchors correctly even when the bare target text recur
   render(
     <ToolRow
       summary={summary}
-      purpose="Check the source"
+      intent="Check the source"
       failed={false}
       expandable
       expanded
@@ -915,18 +915,18 @@ test("the complete prefix anchors correctly even when the bare target text recur
 test("the rationale-to-call gap is tightened to line-leading only, still tighter than the gap between calls", () => {
   const css = rowCss();
   expect(css).toMatch(/\.row\s*\{[^}]*row-gap:\s*0/);
-  expect(css).toMatch(/\.purpose\s*\{[^}]*line-height:\s*var\(--line-height-title\)/);
+  expect(css).toMatch(/\.intent\s*\{[^}]*line-height:\s*var\(--line-height-title\)/);
   expect(css).toMatch(/\.demoted\s*\{[^}]*line-height:\s*var\(--line-height-title\)/);
   const call = /\.call\s*\{([^}]*)\}/.exec(css);
   expect(call).not.toBeNull();
   expect(call![1]).toContain("padding: var(--space-2) 0");
 });
 
-// The purpose is the agent's stated rationale for the call - commentary on
+// The intent is the agent's stated rationale for the call - commentary on
 // the machine text, set off in italics rather than a colour or size of its
 // own (Jesse's review call on the tiered-density follow-up).
-test("the stated purpose renders in italics", () => {
-  expect(rowCss()).toMatch(/\.purpose\s*\{[^}]*font-style:\s*italic/);
+test("the stated intent renders in italics", () => {
+  expect(rowCss()).toMatch(/\.intent\s*\{[^}]*font-style:\s*italic/);
 });
 
 // kata rdry: the demoted line is a tool-RESULT ("Wrote fizzbuzz.py"), not a
@@ -1023,15 +1023,15 @@ test("no summaryLink means the summary renders exactly as before - every descrip
 // The clamped state middle-truncates on raw character position (ToolRow's
 // own middleSplit) and can cut a URL mid-way, or split it across the two
 // independently-ellipsis-clamped head/tail spans - there is no sound "which
-// half is clickable" answer there, so the collapsed+purpose state stays
+// half is clickable" answer there, so the collapsed+intent state stays
 // plain text; opening the row (one click, the same chevron already on the
 // row) shows the summary in full, with the link.
-test("a collapsed row WITH a purpose keeps the clamped plain-text split - no link inside the ellipsis-truncated head/tail", () => {
+test("a collapsed row WITH an intent keeps the clamped plain-text split - no link inside the ellipsis-truncated head/tail", () => {
   render(
     <ToolRow
       summary="Fetched https://example.com/page · 4096 bytes"
       summaryLink="https://example.com/page"
-      purpose="Read the docs"
+      intent="Read the docs"
       failed={false}
       expandable
       expanded={false}
@@ -1042,12 +1042,12 @@ test("a collapsed row WITH a purpose keeps the clamped plain-text split - no lin
   expect(screen.getByTestId("tool-row-summary-head")).toBeTruthy();
 });
 
-test("the SAME purpose-bearing row, expanded, drops the clamp and shows the real link", () => {
+test("the SAME intent-bearing row, expanded, drops the clamp and shows the real link", () => {
   render(
     <ToolRow
       summary="Fetched https://example.com/page · 4096 bytes"
       summaryLink="https://example.com/page"
-      purpose="Read the docs"
+      intent="Read the docs"
       failed={false}
       expandable
       expanded
@@ -1102,12 +1102,12 @@ test("clicking the linkified URL does not toggle the sibling disclosure trigger"
 });
 
 // #93: an expanded row whose descriptor hides the summary while open (shell's
-// summaryHiddenWhenExpanded) and carries no purpose either renders NOTHING but
+// summaryHiddenWhenExpanded) and carries no intent either renders NOTHING but
 // the aria-hidden chevron inside the disclosure trigger - the disclosure has
 // no accessible name at all. The fix must not resurrect the hidden summary text
 // (that suppression is deliberate, ToolCallItem.tsx:259); it needs a stable
 // label of its own.
-test("an expanded summary-less, purpose-less row's disclosure trigger still has a nonempty accessible name", () => {
+test("an expanded summary-less, intent-less row's disclosure trigger still has a nonempty accessible name", () => {
   render(<ToolRow summary="" failed={false} expandable expanded onToggle={() => {}} />);
   const trigger = screen.getByTestId("tool-row-trigger");
   expect(trigger.tagName).toBe("BUTTON");

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolcallitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolcallitem.module.css
@@ -10,9 +10,9 @@
 }
 
 /* The shared row (ToolRow.tsx) - see that file for the row grammar it
- * implements. A purpose-bearing row wraps onto two lines (italic purpose
+ * implements. An intent-bearing row wraps onto two lines (italic intent
  * above, quiet verb/target below) via the demoted line's flex-basis rule
- * further down; without a purpose it stays on one.
+ * further down; without an intent it stays on one.
  *
  * row-gap vs column-gap, split deliberately: the column gap separates the
  * glyph/status/text on one line; the row gap is the rationale-to-call
@@ -25,7 +25,7 @@
   align-items: baseline;
   column-gap: var(--space-2);
   /* No row gap at all: the rationale-to-call coupling comes from the two
-   * lines' own tightened line-height (see .purpose/.demoted) alone, so the
+   * lines' own tightened line-height (see .intent/.demoted) alone, so the
    * gap between a description and its call reads clearly tighter than the
    * 2x8px .call padding between separate calls. */
   row-gap: 0;
@@ -60,15 +60,15 @@
   cursor: pointer;
 }
 
-.row[data-purpose="true"] .trigger {
+.row[data-intent="true"] .trigger {
   flex: 1 1 100%;
 }
 
-/* data-purpose-trailing marks a purpose-only row whose trailing affordance
+/* data-intent-trailing marks an intent-only row whose trailing affordance
  * rides the disclosure line (ToolRow.tsx's grammar): the trigger gives up
  * the full-width basis the rule above assigns, so trigger and control share
  * line 1, the trigger's own grow springing the control to the line's end. */
-.row[data-purpose-trailing="true"] .trigger {
+.row[data-intent-trailing="true"] .trigger {
   flex: 1 1 auto;
 }
 
@@ -79,16 +79,16 @@
   min-width: 0;
 }
 
-.row[data-purpose="true"] .summaryLine {
+.row[data-intent="true"] .summaryLine {
   flex: 1 1 100%;
 }
 
-/* A purpose-less row keeps its visible summary and inline actions as siblings
+/* An intent-less row keeps its visible summary and inline actions as siblings
  * of the disclosure button. The button still owns the whole visual row: its
  * transparent box sits under the summary line, while real links/buttons opt
  * back into pointer hit testing. This restores the old full-row disclosure
  * target without nesting interactive controls. */
-.row:not([data-purpose="true"]) .trigger {
+.row:not([data-intent="true"]) .trigger {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -96,17 +96,17 @@
   justify-content: flex-end;
 }
 
-.row:not([data-purpose="true"]) .summaryLine {
+.row:not([data-intent="true"]) .summaryLine {
   position: relative;
   z-index: var(--z-raised);
   pointer-events: none;
 }
 
-.row:not([data-purpose="true"]) .summaryLine a,
-.row:not([data-purpose="true"]) .summaryLine button,
-.row:not([data-purpose="true"]) .summaryLine input,
-.row:not([data-purpose="true"]) .summaryLine select,
-.row:not([data-purpose="true"]) .summaryLine textarea {
+.row:not([data-intent="true"]) .summaryLine a,
+.row:not([data-intent="true"]) .summaryLine button,
+.row:not([data-intent="true"]) .summaryLine input,
+.row:not([data-intent="true"]) .summaryLine select,
+.row:not([data-intent="true"]) .summaryLine textarea {
   pointer-events: auto;
 }
 
@@ -132,8 +132,8 @@
  * from the machine text below it without a colour or size of its own.
  *
  * overflow-wrap:anywhere so long machine text can still break when the
- * purpose itself is the long part. */
-.purpose {
+ * intent itself is the long part. */
+.intent {
   flex: 1 1 0;
   min-width: 0;
   font-family: var(--font-sans);
@@ -150,9 +150,9 @@
 /* verb + target + meta, the descriptor's own summary() string: the sans
  * face (Jesse's review call - fixed-width everywhere made every tool read
  * like a terminal; mono is now reserved for shell, whose summary IS a
- * command - see .mono). flex-basis 0 for the same reason .purpose has it -
- * see there. overflow-wrap:anywhere serves the purpose-less one-line case;
- * with a purpose present the .demoted override below replaces it with
+ * command - see .mono). flex-basis 0 for the same reason .intent has it -
+ * see there. overflow-wrap:anywhere serves the intent-less one-line case;
+ * with an intent present the .demoted override below replaces it with
  * nowrap + the middle-truncation split on the second line. */
 .summary {
   flex: 1 1 0;
@@ -214,14 +214,14 @@
   }
 }
 
-/* With a purpose above it the summary is a glanceable detail, not the story:
+/* With an intent above it the summary is a glanceable detail, not the story:
  * it takes the whole next line, dimmer. flex-basis 100% is what forces the
  * line break inside the wrapping row. The row's affordances (e.g. "Open
  * beside") ride THIS line now - rendered inline at the end of the summary
  * text by ToolRow, not as flex items of the row - so no order trick is
  * needed to keep the row at two lines. */
 /* kata rdry: this line is a tool RESULT ("Wrote fizzbuzz.py"), shown on every
- * purpose-bearing row in every transcript - not a placeholder/disabled/
+ * intent-bearing row in every transcript - not a placeholder/disabled/
  * timestamp, --ink-low's documented job (design-system.md). --ink-low measured
  * 2.97:1 dark / 3.64:1 light against --surface-1, under the 4.5:1 AA floor for
  * body text; --ink-mid clears it at 6.86/6.56. Same fix as usermessageitem's
@@ -230,7 +230,7 @@
 .demoted {
   flex: 0 0 100%;
   color: var(--ink-mid);
-  /* Same tightened line box as the rationale above it - see .purpose. */
+  /* Same tightened line box as the rationale above it - see .intent. */
   line-height: var(--line-height-title);
 }
 
@@ -291,11 +291,11 @@
   margin-left: var(--space-2);
 }
 
-/* The disclosure-line trailing slot (a purpose-only row's affordance - see
- * the [data-purpose-trailing] rule above): a plain flex-none item of the row,
+/* The disclosure-line trailing slot (an intent-only row's affordance - see
+ * the [data-intent-trailing] rule above): a plain flex-none item of the row,
  * baseline-aligned with the rationale like every other line-mate; the row's
  * own column-gap separates it from the trigger. */
-.purposeTrailing {
+.intentTrailing {
   display: inline-flex;
   flex: none;
 }

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/fsTools.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/fsTools.tsx
@@ -1,7 +1,7 @@
 // Descriptors for the four read-only filesystem tools (parity checklist §2):
 // read_file, grep (+ its grep_files/grep_search aliases), list_dir (+
 // list_directory), glob. Each is "cheap" mode in the legacy sense (a short,
-// bounded row) - target/result folded into one purpose-first summary string
+// bounded row) - target/result folded into one intent-first summary string
 // per this file's own ToolRendererDescriptor contract (there is no separate
 // target/result slot on the wire like the legacy DOM had).
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentModule.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentModule.test.tsx
@@ -366,7 +366,7 @@ test("a still-running row (with a transcriptRef) offers Open transcript, not gat
 // --- expanded card: disclosure + Mandate / Activity / Summary (qb8e, tv5k) -
 
 // A child thread/read that carries a real Activity feed (two tool-call items
-// with a `description` purpose) plus a final agentMessage summary - but ONLY
+// with a `description` intent) plus a final agentMessage summary - but ONLY
 // when the caller asked for turns. A lean (includeTurns:false) read returns
 // none, so a passing Activity/Summary assertion proves the expanded card's
 // watch upgraded to { includeTurns: true } (Task 9's Option B), not that the
@@ -415,7 +415,7 @@ function childThreadRead(params: unknown, childStatus: string) {
                 {
                   // A whitespace-only description is ABSENCE, not a step - the
                   // same rule the main transcript's tool row applies
-                  // (ToolRow.tsx's statedPurposeOf, shared by both surfaces).
+                  // (ToolRow.tsx's statedIntentOf, shared by both surfaces).
                   // A truthiness filter here would count it and the two
                   // surfaces would disagree about whether it exists.
                   id: "item_act_blank",
@@ -458,7 +458,7 @@ test("a folded card quotes the child's newest own words from the full event stre
   expect(quote.tagName).toBe("EM");
 });
 
-test("expanding a card lists recent quotes - purposes plain, messages italic - each with its runtime and timestamp", async () => {
+test("expanding a card lists recent quotes - intents plain, messages italic - each with its runtime and timestamp", async () => {
   const fake = new FakeClient("ready");
   fake.on("thread/read", (params) => {
     const base = childThreadRead(params, "active");
@@ -487,7 +487,7 @@ test("expanding a card lists recent quotes - purposes plain, messages italic - e
   const quotes = await within(row).findByTestId("subagent-quotes");
   const items = within(quotes).getAllByRole("listitem") as HTMLLIElement[];
   // Two real steps plus the final message; the whitespace-only description
-  // contributed no quote (the same statedPurposeOf rule the old feed used).
+  // contributed no quote (the same statedIntentOf rule the old feed used).
   expect(items).toHaveLength(3);
   expect(items.map((li) => li.value)).toEqual([1, 2, 3]);
 
@@ -525,7 +525,7 @@ test("an expanded card with no child activity yet says so instead of rendering a
   expect(within(quotes).queryAllByRole("listitem")).toHaveLength(0);
 });
 
-// mhcf: a child thread/read fixture with MANY purpose-bearing steps.
+// mhcf: a child thread/read fixture with MANY intent-bearing steps.
 // childThreadRead above hard-codes exactly two real steps - useful for the
 // Mandate/Activity/Summary shape, but far too few to exercise a cap. `status`
 // is fixed "active" (childRunning: true) so the same fixture also exercises
@@ -587,7 +587,7 @@ test("mhcf: the Activity feed caps to the 5 most recent steps, not the first 5",
   for (const n of [1, 2, 14, 15]) expect(within(activity).queryByText(`step ${n}`)).toBeNull();
 });
 
-// A timing annotation is not an action: round_timings items carry a purpose-
+// A timing annotation is not an action: round_timings items carry an intent-
 // like description ("Round timings") that would otherwise flood the feed -
 // one per round - and crowd real steps out of the five-slot window. They are
 // elided by eventKind, and the remaining steps keep contiguous true ordinals
@@ -702,7 +702,7 @@ test("the stats line counts the child's turns and tool calls from the full-turns
   const row = screen.getByTestId("subagent-row");
   const stats = await within(row).findByTestId("subagent-stats");
   // 1 real turn (the prelude excluded), 3 tool calls (the final agent message
-  // is not a call; the blank-purpose commandExecution still is).
+  // is not a call; the blank-intent commandExecution still is).
   await waitFor(() => {
     expect(stats.textContent).toContain("1 turn");
     expect(stats.textContent).toContain("3 calls");

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentModule.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentModule.tsx
@@ -12,7 +12,7 @@ import { requireClass } from "../../../../widgets/internal/requireClass";
 import { formatUsagePair } from "../../chrome/activityFormat";
 import { cadenceStateForStatus, useSessionNow } from "../../liveness";
 import { formatClockTimeSeconds, formatElapsed, plainQuoteLine } from "../messages/format";
-import { statedPurposeOf } from "../ToolRow";
+import { statedIntentOf } from "../ToolRow";
 import type { ToolRenderProps } from "../toolRenderers";
 import { registerToolRenderer } from "../toolRenderers";
 import { parseJSONObject, str } from "./helpers";
@@ -92,8 +92,8 @@ const STATUS_GLYPH: Record<SubagentRowKind | "attention", string> = {
 //   child's feed otherwise drowns real steps in them (every round produces
 //   one). Excluded by eventKind - the stable typed discriminator, not by
 //   matching the "Round timings" description text.
-// - purpose-less tool calls: a whitespace-only description is ABSENCE, not a
-//   step - the same statedPurposeOf rule the main transcript's tool row
+// - intent-less tool calls: a whitespace-only description is ABSENCE, not a
+//   step - the same statedIntentOf rule the main transcript's tool row
 //   applies, so a line is a quote on one surface iff it is on the other.
 function deriveQuotes(items: ItemModel[]): Quote[] {
   const out: Quote[] = [];
@@ -106,9 +106,9 @@ function deriveQuotes(items: ItemModel[]): Quote[] {
       if (text !== "") out.push({ id: it.id, text, msg: true, startedAt: it.startedAt, completedAt: it.completedAt });
       continue;
     }
-    const purpose = statedPurposeOf(it);
-    if (purpose !== undefined) {
-      out.push({ id: it.id, text: purpose, msg: false, startedAt: it.startedAt, completedAt: it.completedAt });
+    const intent = statedIntentOf(it);
+    if (intent !== undefined) {
+      out.push({ id: it.id, text: intent, msg: false, startedAt: it.startedAt, completedAt: it.completedAt });
     }
   }
   return out;

--- a/cmd/evener-hub/frontend/src/protocol/model.ts
+++ b/cmd/evener-hub/frontend/src/protocol/model.ts
@@ -56,7 +56,7 @@ export interface ItemModel {
   toolName?: string;
   callId?: string;
   argumentsJSON?: string;
-  // Tool-call purpose — the wire ThreadItem.description, surfaced for the
+  // Tool-call intent — the wire ThreadItem.description, surfaced for the
   // subagent Activity feed. Dropped historically by wireItemToModel; now carried.
   description?: string;
   // The wire ThreadItem.eventKind: a stable typed discriminator naming what a

--- a/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
@@ -2120,12 +2120,12 @@ test("hydrateThread maps a settled item's exitCode onto the model (snapshot path
   expect(itemAt(turnAt(model, 0), 0).exitCode).toBe(0);
 });
 
-// A tool-call's purpose crosses the wire as ThreadItem.description (set
+// A tool-call's intent crosses the wire as ThreadItem.description (set
 // server-side, e.g. delegate's mandate); wireItemToModel historically dropped
 // it. The model must carry it so the subagent Activity feed can render each
-// child tool-call's purpose (§4.2). Both hydrate and live paths fold through
+// child tool-call's intent (§4.2). Both hydrate and live paths fold through
 // wireItemToModel, so the snapshot path proves the carry.
-test("wireItemToModel carries the wire description (tool-call purpose) onto the item", () => {
+test("wireItemToModel carries the wire description (tool-call intent) onto the item", () => {
   const thread = testThread({
     turns: [
       {

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts
@@ -215,7 +215,7 @@ describe("transcript projector", () => {
     },
   );
 
-  test("uses the neutral action summary for a blank tool purpose without dropping the action", () => {
+  test("uses the neutral action summary for a blank tool intent without dropping the action", () => {
     const model = threadWith(item("blank-tool", "commandExecution", { toolName: "shell", description: "   " }));
 
     expect(entriesFor(model, preset("intent"))).toEqual([

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
@@ -226,7 +226,7 @@ function decisionFor(
     // Questions and approvals are interaction rows at every regular level.
     if (interaction) return "critical";
     // The ordinary item shape has no projected summary field. At tool-call
-    // levels, keep a purpose-less call on the critical path so its renderer
+    // levels, keep an intent-less call on the critical path so its renderer
     // receives the exact neutral summary instead of inventing one from the
     // tool name. Intent-only levels use the proxy's rationale field instead.
     if (vector.toolCalls && missingPurpose) return "critical";
@@ -234,7 +234,7 @@ function decisionFor(
     if (vector.toolIntent) return "intent";
     if (failure || active || (isTerminalTurn(turn) && !vector.toolCalls)) return "critical";
     // A Custom vector may disable both calls and intent. Even there, a call
-    // with no purpose is not routine-readable content: keep its neutral
+    // with no intent is not routine-readable content: keep its neutral
     // critical contract rather than inventing a summary from the tool name.
     return missingPurpose ? "critical" : "hidden";
   }

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
@@ -219,7 +219,7 @@ function decisionFor(
 
   if (item.type === "commandExecution") {
     const interaction = INTERACTION_TOOL_NAMES.has(item.toolName ?? "");
-    const missingPurpose = !item.description?.trim();
+    const missingIntent = !item.description?.trim();
     const failure = hasItemFailure(item);
     const active = isActiveItem(item, turn);
 
@@ -229,14 +229,14 @@ function decisionFor(
     // levels, keep an intent-less call on the critical path so its renderer
     // receives the exact neutral summary instead of inventing one from the
     // tool name. Intent-only levels use the proxy's rationale field instead.
-    if (vector.toolCalls && missingPurpose) return "critical";
+    if (vector.toolCalls && missingIntent) return "critical";
     if (vector.toolCalls) return "item";
     if (vector.toolIntent) return "intent";
     if (failure || active || (isTerminalTurn(turn) && !vector.toolCalls)) return "critical";
     // A Custom vector may disable both calls and intent. Even there, a call
     // with no intent is not routine-readable content: keep its neutral
     // critical contract rather than inventing a summary from the tool name.
-    return missingPurpose ? "critical" : "hidden";
+    return missingIntent ? "critical" : "hidden";
   }
 
   if (item.type === "reasoning") {

--- a/internal/bundled/skills/doctoring-evener/runbooks/error-loop.md
+++ b/internal/bundled/skills/doctoring-evener/runbooks/error-loop.md
@@ -63,7 +63,7 @@ check exists to cover them:**
   signature hashes a call's whole arguments payload
   (`toolCallSignature`/`shortHash`), so a tool whose arguments carry a
   free-text field the model varies each call (e.g. a browser tool's
-  `purpose` rationale string) never repeats the same hash twice, even when
+  `intent` rationale string) never repeats the same hash twice, even when
   every other argument and the underlying action are identical. A ~300-call
   MCP tool loop measured `longest_identical_run.length` at 10, not 300,
   purely from this fragmentation — the run was real, the metric just


### PR DESCRIPTION
Resolves audit findings **I4 (decision/documentation portion)** and **Minor 9** from the 2026-08-30 audit of the `purpose` -> `intent` tool-param rename (`7512a736e`).

## I4 — accepted loss, documented (no fallback)

Jesse's decision: **accept the loss — no backward-compat fallback anywhere.** Readers read only `intent`; transcripts recorded before 2026-08-29 render tool calls without an intent line in the hub, the TUI, and `evener doctor`. The data is not lost — it remains in the transcript under `purpose`. This PR adds no `purpose`-reading code; it records the decision in `UPGRADING.md` (the repo's breaking-changes/migration file) under Unreleased.

## M9 — rename residue cleaned

The rename commit skipped the hub frontend entirely; the transcript pane was still written in `purpose` vocabulary end to end. Renamed to match:

- **ToolRow and consumers**: the `purpose` prop, `statedPurposeOf`/`delegatePurposeOf`/`clipDelegatePurpose`/`DELEGATE_PURPOSE_PREVIEW_MAX`, the `.purpose`/`.purposeTrailing` CSS classes (the flagged ToolRow.tsx:70), `data-purpose*` attributes, `tool-row-purpose*` test ids, and the comments/tests describing them
- **layoutguard `rdry-toolrow-contrast`**: harness markup follows the renamed classes; mutation attestation re-verified by hand under the new configuration (still fails as expected: dark 3.08:1, light 3.51:1) and re-dated
- **projector/model/reducer**: stale "tool-call purpose" comments, test names, and the `missingPurpose` local
- **Go side**: `visionPrompt`'s parameter, comments in `session_tools.go`/`provider/profile.go`, test identifiers in `agent/internal/tool`, `cov_s3_vision_test.go`, `cmd/evener-doctor/study_runbooks_test.go`
- **Bundled doctoring skill**: `error-loop.md`'s free-text-argument example named the old field

**Deliberately untouched:**
- `tools/tool-fluency/variants/remaining-failures-2026-06-20/` (incl. the flagged `16-communicate-combined.md:7`): judged **historical-by-design**. The dated variant corpus is the recorded input of the 2026-06-20 experiment campaign; the committed reports cite these files by name and describe their `purpose`-era content verbatim. A mechanical `purpose`->`intent` edit would also be wrong against today's schema — `communicate` registers with `OmitIntent` and carries no such param at all.
- Generic English uses ("on purpose", "general-purpose") and historical records (`docs/superpowers/plans`, `docs/web-ui/history` mockups, `docs/web-ui/decisions.md` ledger prose).
- `apptranscript_test.go:826`'s "purpose ignored" case — it is the test pinning the no-fallback decision.

## Gates

- `make test-web` PASS (typecheck/test/lint); layoutguard suite PASS
- `go test ./...` green in the agent and root modules
- `make lint`: all targets PASS except `lint-gofmt`, which is **red on main itself** (three pre-existing unformatted files, none touched here) — filed as #666
- roborev: per-commit and branch-level reviews all clean ("No issues found")