### PR TITLE
fix(transcript): keep the delegate row's "open" control inline on the disclosure line

### DIFF
--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/delegate-open-widget-inline/assert.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/delegate-open-widget-inline/assert.mjs
@@ -1,0 +1,38 @@
+// The delegate / subagent card is an intent-only tool row (a stated intent,
+// no separate verb/target summary) whose trailing "open" control opens the
+// child transcript. ToolRow.tsx's grammar says the control rides the
+// DISCLOSURE line as a sibling flex item of the trigger (data-intent-trailing
+// =true), sprung to the line's end by the trigger's own flex-grow. The control
+// must share the trigger's FIRST line - not drop to its own line below the
+// intent.
+//
+// What this guards: a flex-basis:auto on the data-intent-trailing trigger
+// resolves to the intent text's max-content (one long unwrapped line).
+// Because .row is flex-wrap:wrap, line-breaking is decided on flex BASE SIZES
+// before shrink is considered, so an intent wider than (column - control)
+// claims its full width and the .intentTrailing control wraps to a second
+// line - the regression. flex-basis:0 lets the trigger's content wrap WITHIN
+// a zero basis (grow absorbing the rest), so the control stays on line 1.
+//
+// Font- and platform-independent: "same line" is the control's top edge
+// falling within the intent's first line box (a Range rect), never a pixel
+// snapshot.
+
+export default function assert(measurement) {
+  const failures = [];
+  for (const f of measurement) {
+    if (!f.sameLine) {
+      failures.push(
+        `#${f.id} (${f.label}): the 'open' control's top sits ${f.dropBelowLine1.toFixed(1)}px below the intent's first line - it wrapped to its own line; the trailing control must ride inline on the disclosure line, not on its own`,
+      );
+    }
+  }
+  if (failures.length > 0) {
+    return { pass: false, reason: failures.join("; ") };
+  }
+  const drops = measurement.map((f) => f.dropBelowLine1.toFixed(1)).join(", ");
+  return {
+    pass: true,
+    reason: `trigger and 'open' control share line 1 in all ${measurement.length} fixtures (dropBelowLine1: ${drops}; <=0 = inline)`,
+  };
+}

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/delegate-open-widget-inline/case.json
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/delegate-open-widget-inline/case.json
@@ -1,0 +1,22 @@
+{
+  "name": "delegate-open-widget-inline",
+  "description": "An intent-only tool row (the delegate/subagent card: a stated intent, no separate verb/target summary, with an 'open' trailing control that opens the child transcript) must keep its disclosure trigger and the 'open' control on the SAME line. The trigger gives up the full-width flex basis an intent-bearing row otherwise assigns (data-intent-trailing=true), so the control rides the disclosure line as a sibling flex item. A flex-basis:auto on that trigger resolves to the intent text's max-content (one long unwrapped line) BEFORE flex-wrap decides to break, so a long intent pushes the 'open' control onto its own second line - the regression this case pins. The control must share the trigger's first line at the pane's narrow (transcript-column) width and at a comfortable desktop width, for both a short intent (fits beside the control) and a long one (must wrap INSIDE the trigger, not push the control down).",
+  "cssFiles": [
+    "styles/global.css",
+    "styles/tokens.css",
+    "panes/session/transcript/toolcallitem.module.css",
+    "widgets/button/button.module.css"
+  ],
+  "viewport": {
+    "width": 1200,
+    "height": 900,
+    "deviceScaleFactor": 1,
+    "mobile": false
+  },
+  "mutation": {
+    "declaration": "toolcallitem.module.css: .row[data-intent-trailing=\"true\"] .trigger reverted from flex:1 1 0 to the pre-fix flex:1 1 auto",
+    "verified": "2026-08-30",
+    "expect": "fail",
+    "note": "With flex-basis:auto the trigger's base size resolves to the long intent's max-content (one unwrapped line). Because .row is flex-wrap:wrap, line-breaking is decided on flex base sizes BEFORE shrink, so an intent longer than (container - control) claims its full width and the .intentTrailing control wraps to a second line. The long-intent fixtures fail sameLine (the control's top drops below the intent's first line box). Restoring flex:1 1 0 lets the trigger's content wrap within a zero basis (grow absorbing the remaining space) so the control stays on line 1; short-intent fixtures stay inline either way (the basis is never the binding constraint when the text already fits)."
+  }
+}

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/delegate-open-widget-inline/harness.html
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/delegate-open-widget-inline/harness.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<title>delegate-open-widget-inline layoutguard harness</title>
+<link rel="stylesheet" href="tokens.css">
+<link rel="stylesheet" href="resolved.css">
+<style>
+  /* Transitions OFF (docs/testing.md): the assertion reads line placement via
+     top-edge equality, which a chevron rotation transition does not move - but
+     a hover fade on the trigger's ink wash could repaint mid-measure. Settled
+     is what we want. */
+  *, *::before, *::after { transition: none !important; }
+  body {
+    margin: 0;
+    background: var(--surface-1);
+    font-family: var(--font-sans);
+    color: var(--ink-hi);
+  }
+  .fixtures { display: flex; flex-direction: column; align-items: flex-start; gap: 12px; padding: 12px; }
+  .fixtureLabel { color: var(--ink-low); font: var(--font-size-caption) var(--font-mono); margin-bottom: 2px; }
+  /* The row sits inside runContent's --speaker-gutter padding in production;
+     a transcript column is what bounds it. Reproduce both a narrow
+     transcript column (420px) and a comfortable desktop width (880px) by
+     wrapping .row in a box of that width. The row's own .rowIcon negative
+     margin (pulling into the gutter) is irrelevant to whether the trigger
+     and the trailing control share a line, so the icon is omitted for
+     clarity - its slot is not a flex item that affects the wrap decision. */
+  .railBox { box-sizing: border-box; padding-left: var(--speaker-gutter); }
+</style>
+</head>
+<body data-font-size="m">
+<!-- Reproduces ToolRow.tsx's intent-only expandable branch (the delegate /
+     subagent card) against the REAL classes from
+     panes/session/transcript/toolcallitem.module.css and
+     widgets/button/button.module.css:
+
+       <div class="row" data-intent="true" data-intent-trailing="true">
+         <button class="trigger">
+           <span class="intent">{statedIntent}<span class="chevron"><Chevron/></span></span>
+         </button>
+         <span class="intentTrailing">{trailing open control}</span>
+       </div>
+
+     The trailing control is the word-form OpenButton the delegate row renders
+     (OpenTranscriptButton -> Button variant="quiet" size="sm" with the word
+     "open" + the box-arrow OpenIcon), reproduced with Button's real classes.
+
+     Two intent lengths x two column widths:
+       short intent - already fits beside the control, so it is inline
+         regardless of the trigger's flex-basis (it is not the binding case,
+         but it must not regress either);
+       long intent  - the binding case: with flex-basis:auto it claims its
+         max-content width and pushes the control to line 2; with flex-basis:0
+         it wraps INSIDE the trigger and the control stays on line 1.
+
+     The measure reports each fixture's trigger and control top edges (and
+     whether they share a line) so the assert is font- and platform-independent:
+     line membership is decided against the trigger's first line box (a Range
+     over the intent text), not a pixel-position snapshot. -->
+<div class="fixtures"></div>
+<script>
+// The real Chevron widget's "right" path (widgets/chevron/index.tsx), 14px box.
+const CHEVRON_SVG = '<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true" focusable="false" style="display:block"><path d="M6 3.5 L10.5 8 L6 12.5" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" fill="none"></path></svg>';
+
+// The real OpenIcon (widgets/openbutton/index.tsx), 14px box, currentColor so
+// the quiet Button's ink is what it inherits in production.
+const OPEN_SVG = '<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true" focusable="false" style="display:block"><path d="M12.5 8.5V12.5H3.5V3.5H7.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"></path><path d="M8 8L13 3M9.5 3H13V6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"></path></svg>';
+
+// ToolRow.tsx's intent-only expandable branch: the trigger holds the intent
+// + inline chevron; the trailing control follows as a sibling flex item in
+// the .intentTrailing slot (data-intent-trailing="true" on the row).
+function delegateRowHtml(id, intent) {
+  return `
+    <div class="row" id="row-${id}" data-intent="true" data-intent-trailing="true">
+      <button type="button" class="trigger" id="trigger-${id}" aria-expanded="false">
+        <span class="intent" id="intent-${id}">
+          ${intent}
+          <span class="chevron" aria-hidden="true" data-open="false">${CHEVRON_SVG}</span>
+        </span>
+      </button>
+      <span class="intentTrailing" id="trailing-${id}">
+        <button type="button" class="button quiet sm" id="open-${id}" aria-label="Open transcript" title="Open transcript">
+          open
+          <span class="icon" aria-hidden="true">${OPEN_SVG}</span>
+        </button>
+      </span>
+    </div>`;
+}
+
+const SHORT_INTENT = "Scout the frontend for the open-widget renderer.";
+// Long enough that at a 420px transcript column the intent alone is wider
+// than (column - control): the binding case where flex-basis decides the wrap.
+const LONG_INTENT = "Locate the delegate row renderer in the transcript pane, trace how its trailing open-transcript control is composed against the disclosure trigger, and confirm the inline placement holds when the stated intent wraps across more than one line inside the row.";
+
+const CONFIGS = [
+  { key: "narrow-short",  width: 420, intent: SHORT_INTENT, label: "420px column, short intent (fits beside the control)" },
+  { key: "narrow-long",  width: 420, intent: LONG_INTENT,  label: "420px column, long intent (binding: must wrap inside the trigger)" },
+  { key: "wide-short",   width: 880, intent: SHORT_INTENT, label: "880px column, short intent" },
+  { key: "wide-long",    width: 880, intent: LONG_INTENT,  label: "880px column, long intent (binding)" },
+];
+
+const root = document.querySelector(".fixtures");
+for (const c of CONFIGS) {
+  const section = document.createElement("div");
+  section.className = "fixture";
+  const label = document.createElement("div");
+  label.className = "fixtureLabel";
+  label.textContent = `${c.label} (#${c.key})`;
+  const box = document.createElement("div");
+  box.className = "railBox";
+  box.style.width = `${c.width}px`;
+  box.innerHTML = delegateRowHtml(c.key, c.intent);
+  section.append(label, box);
+  root.append(section);
+}
+
+function box(el) {
+  const r = el.getBoundingClientRect();
+  return { left: r.left, right: r.right, top: r.top, bottom: r.bottom, width: r.width, height: r.height };
+}
+
+// The trigger's FIRST line box. The row uses align-items:baseline, so two
+// siblings on the SAME flex line have different top edges (a 28px-tall
+// button baseline-aligns above an italic text line -> its top is HIGHER,
+// not lower). A naive top-equality test misreads that baseline offset as a
+// wrap. Line membership is decided instead against the trigger's own first
+// line: a Range over the intent text yields one rect per wrapped line, and
+// rects[0] is line 1. The control shares line 1 iff it starts WITHIN or ABOVE
+// that line (its top is below the line-1 bottom by only sub-pixel noise);
+// once it wraps to line 2 its top sits at the line-1 bottom (the row's
+// row-gap is 0, so flex line 2 begins exactly where line 1 ends). Font- and
+// platform-independent: no line-height constant, no pixel snapshot.
+function firstLineBox(intentEl) {
+  const range = document.createRange();
+  range.selectNodeContents(intentEl);
+  const rects = range.getClientRects();
+  // An intent with no text would return nothing; the harness always has one.
+  return rects[0];
+}
+
+window.measure = () => {
+  return CONFIGS.map((c) => {
+    const trigger  = box(document.getElementById(`trigger-${c.key}`));
+    const trailing = box(document.getElementById(`trailing-${c.key}`));
+    const open     = box(document.getElementById(`open-${c.key}`));
+    const intentEl = document.getElementById(`intent-${c.key}`);
+    const intent   = box(intentEl);
+    const line1    = firstLineBox(intentEl);
+    // Same line: the control's top is within line 1 (allowing baseline
+    // alignment to pull it ABOVE line1.top, and sub-pixel noise). Wrapped:
+    // the control's top reaches line 1's bottom (it starts on line 2). The
+    // 1px tolerance absorbs rounding where line 2 meets line 1's bottom.
+    const sameLine = open.top < line1.bottom - 1;
+    return {
+      id: c.key,
+      label: c.label,
+      width: c.width,
+      trigger,
+      trailing,
+      open,
+      intent,
+      line1,
+      sameLine,
+      // How far the control's top sits below line 1's bottom, for the assert's
+      // reason: 0 (or negative) = inline; >0 = dropped to a later line.
+      dropBelowLine1: open.top - line1.bottom,
+    };
+  });
+};
+</script>
+</body>
+</html>

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolRowGrammar.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolRowGrammar.test.tsx
@@ -669,9 +669,13 @@ test("an intent-only row trails its affordance on the disclosure line, not a lin
   expect(screen.queryByTestId("tool-row-summary")).toBeNull();
   expect(row.getAttribute("data-intent-trailing")).toBe("true");
   // The stylesheet keeps trigger and control on one line: the trigger gives
-  // up the full-width flex basis an intent-bearing row otherwise assigns.
+  // up the full-width flex basis an intent-bearing row otherwise assigns, and
+  // uses a ZERO basis (not auto) so the intent wraps inside the trigger
+  // instead of the control wrapping to its own line - the regression a
+  // layoutguard geometry case (delegate-open-widget-inline) pins, since
+  // jsdom computes no cascade and can't see the wrap.
   const css = rowCss();
-  expect(css).toMatch(/\.row\[data-intent-trailing="true"\] \.trigger\s*\{[^}]*flex:\s*1 1 auto/);
+  expect(css).toMatch(/\.row\[data-intent-trailing="true"\] \.trigger\s*\{[^}]*flex:\s*1 1 0/);
 });
 
 // Without an affordance an intent-only row changes shape not at all: no

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolcallitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolcallitem.module.css
@@ -65,11 +65,22 @@
 }
 
 /* data-intent-trailing marks an intent-only row whose trailing affordance
- * rides the disclosure line (ToolRow.tsx's grammar): the trigger gives up
- * the full-width basis the rule above assigns, so trigger and control share
- * line 1, the trigger's own grow springing the control to the line's end. */
+ * rides the disclosure line (ToolRow.tsx's grammar): the trigger gives up the
+ * full-width basis the rule above assigns, so trigger and control share line
+ * 1, the trigger's own grow springing the control to the line's end.
+ *
+ * flex-basis 0, NOT auto: .row is flex-wrap:wrap, so line-breaking is decided
+ * on flex BASE SIZES before shrink is considered. With basis auto the trigger's
+ * base size resolves to the intent text's max-content (one long unwrapped
+ * line), and an intent wider than (column - control) claims that full
+ * width - pushing the trailing control (the delegate row's "open" widget)
+ * onto its own second line (the regression a layoutguard case pins). Basis 0
+ * starts the trigger at zero width: the intent wraps INSIDE it as the
+ * trigger's grow absorbs the remaining space, and the control stays on line
+ * 1. The trigger still grows to fill (flex-grow 1), so a short intent's
+ * control still springs to the line's end unchanged. */
 .row[data-intent-trailing="true"] .trigger {
-  flex: 1 1 auto;
+  flex: 1 1 0;
 }
 
 .summaryLine {


### PR DESCRIPTION
## Problem

On subagent (delegate) rows, the "open" control (opens the child transcript) dropped onto its own line below the disclosure chevron instead of riding inline to the right of it.

## Root cause

A delegate/subagent row is a **purpose-only tool row** (a stated rationale, no separate verb/target summary) whose trailing "open" control rides the disclosure line as a sibling flex item of the trigger (`data-purpose-trailing="true"`). The trigger rule was `flex: 1 1 auto`, whose flex-basis resolves to the rationale text's **max-content** (one long unwrapped line). Because `.row` is `flex-wrap: wrap`, line-breaking is decided on flex **base sizes before shrink** — so any rationale wider than (column − control) claimed its full width and pushed the "open" control onto its own second line.

## Fix

Change the trigger flex-basis from `auto` to `0`:

```css
.row[data-purpose-trailing="true"] .trigger {
  flex: 1 1 0;
}
```

Basis `0` starts the trigger at zero width: the rationale wraps **inside** the trigger (its grow absorbing the remaining space), so the control stays on line 1. `flex-grow 1` is unchanged, so a short rationale's control still springs to the line's end. Because this is the shared `ToolRow` CSS, the fix covers every purpose-only row with a trailing open control (delegate and `delegate_send`).

## Tests

- Added a real-browser geometry guard: `scripts/layoutguard/cases/delegate-open-widget-inline/` — reproduces the delegate row anatomy at narrow (420px) and wide (880px) columns with short and long rationales. Line membership is asserted via a `Range.getClientRects()` first-line box (not top-edge equality, which `align-items: baseline` would fool), so it is font- and platform-independent. Includes mutation evidence in `case.json`. jsdom computes no cascade and could not see the wrap.
- Updated the `toolRowGrammar.test.tsx` assertion that pinned the old `flex: 1 1 auto` to the corrected `flex: 1 1 0`.

## Verification

All gates green:
- `npx biome check --write` on touched src files — no fixes
- `make test-web` — PASS (web-typecheck, web-test, web-lint)
- `make test-web-browser` — PASS (web-layoutguard, web-overflowguard, web-shellguard, web-spawnguard)
- `toolRowGrammar.test.tsx` — 78 tests pass
- Full layoutguard suite — all 19 cases pass, including the new `delegate-open-widget-inline`

## Files changed

- `src/panes/session/transcript/toolcallitem.module.css` — the fix (flex-basis auto → 0)
- `src/panes/session/transcript/toolRowGrammar.test.tsx` — assertion update
- `scripts/layoutguard/cases/delegate-open-widget-inline/{case.json,harness.html,assert.mjs}` — geometry guard