### PR TITLE
Thread-clear hardening: re-pin the failure path, bound the journal (audit I1/I2/M4/M6)

### DIFF
--- a/server/appwire_clear_test.go
+++ b/server/appwire_clear_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -339,5 +340,123 @@ func TestServerRejectsOldInstanceTurnMutationsAfterClear(t *testing.T) {
 				t.Fatalf("old-generation mutation callback calls = %d, want 0", calls)
 			}
 		})
+	}
+}
+
+// TestServerAppWireThreadClearFailureReleasesGateAndReservation covers the half
+// of the clear fence a success path cannot: a clear whose replacement callback
+// fails must hand back both the mutation gate and its journal reservation, or
+// one transient failure turns into a clear that is refused forever.
+func TestServerAppWireThreadClearFailureReleasesGateAndReservation(t *testing.T) {
+	stateDir := t.TempDir()
+	srv := NewServer(ServerConfig{StateDir: stateDir})
+	srv.SetAppIdentity("local", "old")
+	srv.SetClearFunc(func(context.Context, appwire.ThreadClearParams) error {
+		return errors.New("replacement provisioning failed")
+	})
+
+	_, err := srv.handleAppThreadClear(context.Background(), appwire.ThreadClearParams{
+		Ref: "local:old", ClientMutationID: "clear-fails", ExpectedInstanceID: "old",
+	})
+	if err == nil {
+		t.Fatal("failed clear reported success")
+	}
+	var wire appwire.WireError
+	if !errors.As(err, &wire) {
+		t.Fatalf("failed clear error = %T %v, want WireError", err, err)
+	}
+	data, ok := wire.Data.(appwire.ErrorData)
+	if !ok || data.ClientMutationID != "clear-fails" || data.MutationOutcome != appwire.MutationOutcomeNotAccepted {
+		t.Fatalf("failed clear error data = %#v, want named notAccepted mutation", wire.Data)
+	}
+
+	srv.mu.RLock()
+	_, held := srv.clearRecords["clear-fails"]
+	srv.mu.RUnlock()
+	if held {
+		t.Fatal("failed clear left its reservation in clearRecords")
+	}
+
+	srv.SetClearFunc(func(_ context.Context, params appwire.ThreadClearParams) error {
+		prepared, err := PrepareAppIdentityForRef("local", "new", params.Ref, "")
+		if err != nil {
+			return err
+		}
+		srv.ReplaceAppIdentity(prepared, nil)
+		return nil
+	})
+	response, err := srv.handleAppThreadClear(context.Background(), appwire.ThreadClearParams{
+		Ref: "local:old", ClientMutationID: "clear-retry", ExpectedInstanceID: "old",
+	})
+	if err != nil {
+		t.Fatalf("clear after a failed clear: %v", err)
+	}
+	if response.Thread.ID != "new" || response.Receipt.Disposition != appwire.MutationDispositionApplied {
+		t.Fatalf("clear after a failed clear = (%q, %q), want (new, applied)", response.Thread.ID, response.Receipt.Disposition)
+	}
+}
+
+// TestServerAppWireThreadClearRestoresReservationWhenRollbackPersistFails pins
+// the failure path's failure path: when the callback fails AND the journal
+// write that would remove the reservation also fails, the reservation must stay
+// in memory (matching the journal on disk) and the client must hear
+// mutationOutcomeUnknown -- then the SAME mutation id must be able to retry to
+// completion once persistence recovers.
+func TestServerAppWireThreadClearRestoresReservationWhenRollbackPersistFails(t *testing.T) {
+	stateDir := t.TempDir()
+	srv := NewServer(ServerConfig{StateDir: stateDir})
+	srv.SetAppIdentity("local", "old")
+	// Occupying the journal's temp path with a directory makes the rollback
+	// persist fail without any production fault seam. The callback installs
+	// the fault after the reservation has already been persisted.
+	journalTmp := threadClearJournalPath(stateDir) + ".tmp"
+	srv.SetClearFunc(func(context.Context, appwire.ThreadClearParams) error {
+		if err := os.Mkdir(journalTmp, 0o700); err != nil {
+			t.Fatalf("install journal write fault: %v", err)
+		}
+		return errors.New("replacement provisioning failed")
+	})
+
+	_, err := srv.handleAppThreadClear(context.Background(), appwire.ThreadClearParams{
+		Ref: "local:old", ClientMutationID: "clear-wedged", ExpectedInstanceID: "old",
+	})
+	if err == nil {
+		t.Fatal("clear with an unpersistable rollback reported success")
+	}
+	var wire appwire.WireError
+	if !errors.As(err, &wire) {
+		t.Fatalf("wedged clear error = %T %v, want WireError", err, err)
+	}
+	data, ok := wire.Data.(appwire.ErrorData)
+	if !ok || data.ClientMutationID != "clear-wedged" || data.MutationOutcome != appwire.MutationOutcomeUnknown {
+		t.Fatalf("wedged clear error data = %#v, want named unknown-outcome mutation", wire.Data)
+	}
+
+	srv.mu.RLock()
+	record, held := srv.clearRecords["clear-wedged"]
+	srv.mu.RUnlock()
+	if !held || record.State != threadClearReserved {
+		t.Fatalf("clearRecords after unpersistable rollback = (%#v, %t), want the reserved record restored", record, held)
+	}
+
+	if err := os.Remove(journalTmp); err != nil {
+		t.Fatalf("clear journal write fault: %v", err)
+	}
+	srv.SetClearFunc(func(_ context.Context, params appwire.ThreadClearParams) error {
+		prepared, err := PrepareAppIdentityForRef("local", "new", params.Ref, "")
+		if err != nil {
+			return err
+		}
+		srv.ReplaceAppIdentity(prepared, nil)
+		return nil
+	})
+	response, err := srv.handleAppThreadClear(context.Background(), appwire.ThreadClearParams{
+		Ref: "local:old", ClientMutationID: "clear-wedged", ExpectedInstanceID: "old",
+	})
+	if err != nil {
+		t.Fatalf("retry after persistence recovered: %v", err)
+	}
+	if response.Thread.ID != "new" || response.Receipt.Disposition != appwire.MutationDispositionApplied {
+		t.Fatalf("recovered retry = (%q, %q), want (new, applied)", response.Thread.ID, response.Receipt.Disposition)
 	}
 }

--- a/server/appwire_clear_test.go
+++ b/server/appwire_clear_test.go
@@ -432,6 +432,59 @@ func TestServerAppWireThreadClearJournalKeepsOneRecordPerRef(t *testing.T) {
 	}
 }
 
+// TestServerAppWireThreadClearFailedClearRestoresSupersededReceipt pins that
+// superseding is tied to actually replacing the instance: a newer clear's
+// reservation evicts the older receipt, but when its callback fails and
+// installs nothing, the older receipt is live again and must still replay.
+func TestServerAppWireThreadClearFailedClearRestoresSupersededReceipt(t *testing.T) {
+	stateDir := t.TempDir()
+	srv := NewServer(ServerConfig{StateDir: stateDir})
+	srv.SetAppIdentity("local", "gen-0")
+	srv.SetClearFunc(func(_ context.Context, params appwire.ThreadClearParams) error {
+		prepared, err := PrepareAppIdentityForRef("local", "gen-1", params.Ref, "")
+		if err != nil {
+			return err
+		}
+		srv.ReplaceAppIdentity(prepared, nil)
+		return nil
+	})
+	if _, err := srv.handleAppThreadClear(context.Background(), appwire.ThreadClearParams{
+		Ref: "local:gen-0", ClientMutationID: "clear-1", ExpectedInstanceID: "gen-0",
+	}); err != nil {
+		t.Fatalf("first clear: %v", err)
+	}
+
+	srv.SetClearFunc(func(context.Context, appwire.ThreadClearParams) error {
+		return errors.New("replacement provisioning failed")
+	})
+	if _, err := srv.handleAppThreadClear(context.Background(), appwire.ThreadClearParams{
+		Ref: "local:gen-0", ClientMutationID: "clear-2", ExpectedInstanceID: "gen-1",
+	}); err == nil {
+		t.Fatal("failed newer clear reported success")
+	}
+
+	replayed, err := srv.handleAppThreadClear(context.Background(), appwire.ThreadClearParams{
+		Ref: "local:gen-0", ClientMutationID: "clear-1", ExpectedInstanceID: "gen-0",
+	})
+	if err != nil {
+		t.Fatalf("replay of the older clear after a failed newer clear: %v", err)
+	}
+	if replayed.Thread.ID != "gen-1" || replayed.Receipt.Disposition != appwire.MutationDispositionReplayed {
+		t.Fatalf("older clear replay = (%q, %q), want (gen-1, replayed)", replayed.Thread.ID, replayed.Receipt.Disposition)
+	}
+
+	loaded, err := loadThreadClearJournal(threadClearJournalPath(stateDir))
+	if err != nil {
+		t.Fatalf("reload journal: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("journal records on disk = %d, want 1", len(loaded))
+	}
+	if _, ok := loaded["clear-1"]; !ok {
+		t.Fatal("journal on disk lost the restored receipt")
+	}
+}
+
 // TestServerAppWireThreadClearFailureReleasesGateAndReservation covers the half
 // of the clear fence a success path cannot: a clear whose replacement callback
 // fails must hand back both the mutation gate and its journal reservation, or

--- a/server/appwire_clear_test.go
+++ b/server/appwire_clear_test.go
@@ -343,6 +343,95 @@ func TestServerRejectsOldInstanceTurnMutationsAfterClear(t *testing.T) {
 	}
 }
 
+// TestServerAppWireThreadClearJournalKeepsOneRecordPerRef pins the journal's
+// size bound: a clear installs a new live instance under the stable ref, so an
+// older clear's record can no longer be a live client's retry (its expected
+// instance is gone) and a new reservation supersedes it. Without this the
+// journal grows by one full ThreadClearResponse per clear, forever.
+func TestServerAppWireThreadClearJournalKeepsOneRecordPerRef(t *testing.T) {
+	stateDir := t.TempDir()
+	srv := NewServer(ServerConfig{StateDir: stateDir})
+	srv.SetAppIdentity("local", "gen-0")
+	generations := []string{"gen-1", "gen-2"}
+	calls := 0
+	srv.SetClearFunc(func(_ context.Context, params appwire.ThreadClearParams) error {
+		if calls >= len(generations) {
+			return errors.New("unexpected extra clear callback")
+		}
+		next := generations[calls]
+		calls++
+		prepared, err := PrepareAppIdentityForRef("local", next, params.Ref, "")
+		if err != nil {
+			return err
+		}
+		srv.ReplaceAppIdentity(prepared, nil)
+		return nil
+	})
+
+	if _, err := srv.handleAppThreadClear(context.Background(), appwire.ThreadClearParams{
+		Ref: "local:gen-0", ClientMutationID: "clear-1", ExpectedInstanceID: "gen-0",
+	}); err != nil {
+		t.Fatalf("first clear: %v", err)
+	}
+	if _, err := srv.handleAppThreadClear(context.Background(), appwire.ThreadClearParams{
+		Ref: "local:gen-0", ClientMutationID: "clear-2", ExpectedInstanceID: "gen-1",
+	}); err != nil {
+		t.Fatalf("second clear: %v", err)
+	}
+
+	srv.mu.RLock()
+	_, oldHeld := srv.clearRecords["clear-1"]
+	newRecord, newHeld := srv.clearRecords["clear-2"]
+	total := len(srv.clearRecords)
+	srv.mu.RUnlock()
+	if oldHeld {
+		t.Fatal("superseded clear record survived a newer clear of the same ref")
+	}
+	if !newHeld || newRecord.State != threadClearApplied || total != 1 {
+		t.Fatalf("clearRecords after two clears = (held=%t state=%q total=%d), want only clear-2, applied", newHeld, newRecord.State, total)
+	}
+
+	loaded, err := loadThreadClearJournal(threadClearJournalPath(stateDir))
+	if err != nil {
+		t.Fatalf("reload journal: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("journal records on disk = %d, want 1", len(loaded))
+	}
+	if _, ok := loaded["clear-2"]; !ok {
+		t.Fatal("journal on disk lost the newest clear record")
+	}
+
+	// The newest clear still replays its durable receipt; the superseded one
+	// is refused as stale without running the callback again.
+	replayed, err := srv.handleAppThreadClear(context.Background(), appwire.ThreadClearParams{
+		Ref: "local:gen-0", ClientMutationID: "clear-2", ExpectedInstanceID: "gen-1",
+	})
+	if err != nil {
+		t.Fatalf("replay newest clear: %v", err)
+	}
+	if replayed.Receipt.Disposition != appwire.MutationDispositionReplayed {
+		t.Fatalf("newest clear replay disposition = %q, want replayed", replayed.Receipt.Disposition)
+	}
+	_, err = srv.handleAppThreadClear(context.Background(), appwire.ThreadClearParams{
+		Ref: "local:gen-0", ClientMutationID: "clear-1", ExpectedInstanceID: "gen-0",
+	})
+	if err == nil {
+		t.Fatal("superseded clear replayed after its record was evicted")
+	}
+	var wire appwire.WireError
+	if !errors.As(err, &wire) {
+		t.Fatalf("superseded clear error = %T %v, want WireError", err, err)
+	}
+	data, ok := wire.Data.(appwire.ErrorData)
+	if !ok || data.MutationOutcome != appwire.MutationOutcomeNotAccepted {
+		t.Fatalf("superseded clear error data = %#v, want notAccepted", wire.Data)
+	}
+	if calls != 2 {
+		t.Fatalf("clear callback calls = %d, want 2", calls)
+	}
+}
+
 // TestServerAppWireThreadClearFailureReleasesGateAndReservation covers the half
 // of the clear fence a success path cannot: a clear whose replacement callback
 // fails must hand back both the mutation gate and its journal reservation, or

--- a/server/appwire_clear_test.go
+++ b/server/appwire_clear_test.go
@@ -11,6 +11,37 @@ import (
 	"primeradiant.com/evener/appwire"
 )
 
+// setReplacingClearFunc installs the standard successful clear callback: swap
+// a replacement instance in under the request's stable ref, the way the
+// daemon's real clear does.
+func setReplacingClearFunc(srv *Server, nextID string) {
+	srv.SetClearFunc(func(_ context.Context, params appwire.ThreadClearParams) error {
+		prepared, err := PrepareAppIdentityForRef("local", nextID, params.Ref, "")
+		if err != nil {
+			return err
+		}
+		srv.ReplaceAppIdentity(prepared, nil)
+		return nil
+	})
+}
+
+// requireMutationErrorData asserts err is a WireError whose ErrorData names
+// the given mutation and outcome.
+func requireMutationErrorData(t *testing.T, err error, wantID string, wantOutcome appwire.MutationOutcome) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("mutation %q succeeded, want a %s error", wantID, wantOutcome)
+	}
+	var wire appwire.WireError
+	if !errors.As(err, &wire) {
+		t.Fatalf("mutation error = %T %v, want WireError", err, err)
+	}
+	data, ok := wire.Data.(appwire.ErrorData)
+	if !ok || data.ClientMutationID != wantID || data.MutationOutcome != wantOutcome {
+		t.Fatalf("mutation error data = %#v, want clientMutationID %q outcome %q", wire.Data, wantID, wantOutcome)
+	}
+}
+
 func TestServerAppWireThreadClearInvokesConfiguredClear(t *testing.T) {
 	srv := NewServer(ServerConfig{})
 	srv.SetAppIdentity("local", "old")
@@ -416,17 +447,7 @@ func TestServerAppWireThreadClearJournalKeepsOneRecordPerRef(t *testing.T) {
 	_, err = srv.handleAppThreadClear(context.Background(), appwire.ThreadClearParams{
 		Ref: "local:gen-0", ClientMutationID: "clear-1", ExpectedInstanceID: "gen-0",
 	})
-	if err == nil {
-		t.Fatal("superseded clear replayed after its record was evicted")
-	}
-	var wire appwire.WireError
-	if !errors.As(err, &wire) {
-		t.Fatalf("superseded clear error = %T %v, want WireError", err, err)
-	}
-	data, ok := wire.Data.(appwire.ErrorData)
-	if !ok || data.MutationOutcome != appwire.MutationOutcomeNotAccepted {
-		t.Fatalf("superseded clear error data = %#v, want notAccepted", wire.Data)
-	}
+	requireMutationErrorData(t, err, "clear-1", appwire.MutationOutcomeNotAccepted)
 	if calls != 2 {
 		t.Fatalf("clear callback calls = %d, want 2", calls)
 	}
@@ -440,14 +461,7 @@ func TestServerAppWireThreadClearFailedClearRestoresSupersededReceipt(t *testing
 	stateDir := t.TempDir()
 	srv := NewServer(ServerConfig{StateDir: stateDir})
 	srv.SetAppIdentity("local", "gen-0")
-	srv.SetClearFunc(func(_ context.Context, params appwire.ThreadClearParams) error {
-		prepared, err := PrepareAppIdentityForRef("local", "gen-1", params.Ref, "")
-		if err != nil {
-			return err
-		}
-		srv.ReplaceAppIdentity(prepared, nil)
-		return nil
-	})
+	setReplacingClearFunc(srv, "gen-1")
 	if _, err := srv.handleAppThreadClear(context.Background(), appwire.ThreadClearParams{
 		Ref: "local:gen-0", ClientMutationID: "clear-1", ExpectedInstanceID: "gen-0",
 	}); err != nil {
@@ -500,17 +514,7 @@ func TestServerAppWireThreadClearFailureReleasesGateAndReservation(t *testing.T)
 	_, err := srv.handleAppThreadClear(context.Background(), appwire.ThreadClearParams{
 		Ref: "local:old", ClientMutationID: "clear-fails", ExpectedInstanceID: "old",
 	})
-	if err == nil {
-		t.Fatal("failed clear reported success")
-	}
-	var wire appwire.WireError
-	if !errors.As(err, &wire) {
-		t.Fatalf("failed clear error = %T %v, want WireError", err, err)
-	}
-	data, ok := wire.Data.(appwire.ErrorData)
-	if !ok || data.ClientMutationID != "clear-fails" || data.MutationOutcome != appwire.MutationOutcomeNotAccepted {
-		t.Fatalf("failed clear error data = %#v, want named notAccepted mutation", wire.Data)
-	}
+	requireMutationErrorData(t, err, "clear-fails", appwire.MutationOutcomeNotAccepted)
 
 	srv.mu.RLock()
 	_, held := srv.clearRecords["clear-fails"]
@@ -519,14 +523,7 @@ func TestServerAppWireThreadClearFailureReleasesGateAndReservation(t *testing.T)
 		t.Fatal("failed clear left its reservation in clearRecords")
 	}
 
-	srv.SetClearFunc(func(_ context.Context, params appwire.ThreadClearParams) error {
-		prepared, err := PrepareAppIdentityForRef("local", "new", params.Ref, "")
-		if err != nil {
-			return err
-		}
-		srv.ReplaceAppIdentity(prepared, nil)
-		return nil
-	})
+	setReplacingClearFunc(srv, "new")
 	response, err := srv.handleAppThreadClear(context.Background(), appwire.ThreadClearParams{
 		Ref: "local:old", ClientMutationID: "clear-retry", ExpectedInstanceID: "old",
 	})
@@ -562,17 +559,7 @@ func TestServerAppWireThreadClearRestoresReservationWhenRollbackPersistFails(t *
 	_, err := srv.handleAppThreadClear(context.Background(), appwire.ThreadClearParams{
 		Ref: "local:old", ClientMutationID: "clear-wedged", ExpectedInstanceID: "old",
 	})
-	if err == nil {
-		t.Fatal("clear with an unpersistable rollback reported success")
-	}
-	var wire appwire.WireError
-	if !errors.As(err, &wire) {
-		t.Fatalf("wedged clear error = %T %v, want WireError", err, err)
-	}
-	data, ok := wire.Data.(appwire.ErrorData)
-	if !ok || data.ClientMutationID != "clear-wedged" || data.MutationOutcome != appwire.MutationOutcomeUnknown {
-		t.Fatalf("wedged clear error data = %#v, want named unknown-outcome mutation", wire.Data)
-	}
+	requireMutationErrorData(t, err, "clear-wedged", appwire.MutationOutcomeUnknown)
 
 	srv.mu.RLock()
 	record, held := srv.clearRecords["clear-wedged"]
@@ -584,14 +571,7 @@ func TestServerAppWireThreadClearRestoresReservationWhenRollbackPersistFails(t *
 	if err := os.Remove(journalTmp); err != nil {
 		t.Fatalf("clear journal write fault: %v", err)
 	}
-	srv.SetClearFunc(func(_ context.Context, params appwire.ThreadClearParams) error {
-		prepared, err := PrepareAppIdentityForRef("local", "new", params.Ref, "")
-		if err != nil {
-			return err
-		}
-		srv.ReplaceAppIdentity(prepared, nil)
-		return nil
-	})
+	setReplacingClearFunc(srv, "new")
 	response, err := srv.handleAppThreadClear(context.Background(), appwire.ThreadClearParams{
 		Ref: "local:old", ClientMutationID: "clear-wedged", ExpectedInstanceID: "old",
 	})

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -1595,11 +1595,19 @@ func (s *Server) handleAppThreadClear(ctx context.Context, params appwire.Thread
 		s.mu.Lock()
 		reservedRecord := s.clearRecords[params.ClientMutationID]
 		delete(s.clearRecords, params.ClientMutationID)
+		// The failed clear installed nothing, so the records its reservation
+		// superseded describe the still-current instance: restore them so an
+		// older receipt's replay survives a failed newer clear.
+		maps.Copy(s.clearRecords, superseded)
 		persistErr := persistThreadClearJournal(s.clearJournalPath, s.clearRecords)
 		if persistErr != nil {
-			// Keep the reservation in memory when its removal could not be
-			// persisted. A retry must not invoke the replacement callback a
-			// second time while the journal still records this request.
+			// Keep memory matching the journal on disk, which still holds the
+			// reservation and not the superseded records. A retry must not
+			// invoke the replacement callback a second time while the journal
+			// still records this request.
+			for id := range superseded {
+				delete(s.clearRecords, id)
+			}
 			s.clearRecords[params.ClientMutationID] = reservedRecord
 		}
 		s.mu.Unlock()

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -1567,9 +1567,23 @@ func (s *Server) handleAppThreadClear(ctx context.Context, params appwire.Thread
 		ExpectedInstanceID: params.ExpectedInstanceID,
 		State:              threadClearReserved,
 	}
+	// A new reservation supersedes every older record for the same stable ref:
+	// the instance those records expected (or installed) is being replaced, so
+	// none of them can be a live client's retry anymore. This bounds the
+	// journal at one record per ref instead of one per clear, forever.
+	superseded := make(map[string]threadClearRecord)
+	for id, existing := range s.clearRecords {
+		if existing.Ref == params.Ref {
+			superseded[id] = existing
+			delete(s.clearRecords, id)
+		}
+	}
 	s.clearRecords[params.ClientMutationID] = record
 	if err := persistThreadClearJournal(s.clearJournalPath, s.clearRecords); err != nil {
 		delete(s.clearRecords, params.ClientMutationID)
+		for id, existing := range superseded {
+			s.clearRecords[id] = existing
+		}
 		s.mu.Unlock()
 		return appwire.ThreadClearResponse{}, appwire.MutationUnknown(params.ClientMutationID, "thread clear reservation could not be persisted")
 	}

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -1584,9 +1585,7 @@ func (s *Server) handleAppThreadClear(ctx context.Context, params appwire.Thread
 	s.clearRecords[params.ClientMutationID] = record
 	if err := persistThreadClearJournal(s.clearJournalPath, s.clearRecords); err != nil {
 		delete(s.clearRecords, params.ClientMutationID)
-		for id, existing := range superseded {
-			s.clearRecords[id] = existing
-		}
+		maps.Copy(s.clearRecords, superseded)
 		s.mu.Unlock()
 		return appwire.ThreadClearResponse{}, appwire.MutationUnknown(params.ClientMutationID, "thread clear reservation could not be persisted")
 	}

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -1574,31 +1574,31 @@ func (s *Server) handleAppThreadClear(ctx context.Context, params appwire.Thread
 	// A new reservation supersedes every older record for the same stable ref:
 	// the instance those records expected (or installed) is being replaced, so
 	// none of them can be a live client's retry anymore. This bounds the
-	// journal at one record per ref instead of one per clear, forever.
-	superseded := make(map[string]threadClearRecord)
+	// journal at one record per ref instead of one per clear, forever. The two
+	// snapshots make each rollback below a wholesale restore; only this
+	// handler mutates clearRecords, and appMutationGate serializes it.
+	beforeReservation := maps.Clone(s.clearRecords)
 	for id, existing := range s.clearRecords {
 		if existing.Ref == params.Ref {
-			superseded[id] = existing
 			delete(s.clearRecords, id)
 		}
 	}
 	s.clearRecords[params.ClientMutationID] = record
 	if err := persistThreadClearJournal(s.clearJournalPath, s.clearRecords); err != nil {
-		delete(s.clearRecords, params.ClientMutationID)
-		maps.Copy(s.clearRecords, superseded)
+		s.clearRecords = beforeReservation
 		s.mu.Unlock()
 		return appwire.ThreadClearResponse{}, appwire.MutationUnknown(params.ClientMutationID, "thread clear reservation could not be persisted")
 	}
+	reserved := maps.Clone(s.clearRecords)
 	s.mu.Unlock()
 
 	if err := fn(ctx, params); err != nil {
 		s.mu.Lock()
-		reservedRecord := s.clearRecords[params.ClientMutationID]
-		delete(s.clearRecords, params.ClientMutationID)
 		// The failed clear installed nothing, so the records its reservation
-		// superseded describe the still-current instance: restore them so an
-		// older receipt's replay survives a failed newer clear.
-		maps.Copy(s.clearRecords, superseded)
+		// superseded describe the still-current instance: restoring the
+		// pre-reservation journal keeps an older receipt's replay alive after
+		// a failed newer clear.
+		s.clearRecords = beforeReservation
 		persistErr := persistThreadClearJournal(s.clearJournalPath, s.clearRecords)
 		if persistErr != nil {
 			// Roll memory back to the journal the reservation persisted. Disk
@@ -1607,10 +1607,7 @@ func (s *Server) handleAppThreadClear(ctx context.Context, params appwire.Thread
 			// the whole file from memory, so the next successful one resyncs
 			// disk, and a retry that re-invokes the callback re-runs work that
 			// failed without installing anything.
-			for id := range superseded {
-				delete(s.clearRecords, id)
-			}
-			s.clearRecords[params.ClientMutationID] = reservedRecord
+			s.clearRecords = reserved
 		}
 		s.mu.Unlock()
 		if persistErr != nil {

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -1601,10 +1601,12 @@ func (s *Server) handleAppThreadClear(ctx context.Context, params appwire.Thread
 		maps.Copy(s.clearRecords, superseded)
 		persistErr := persistThreadClearJournal(s.clearJournalPath, s.clearRecords)
 		if persistErr != nil {
-			// Keep memory matching the journal on disk, which still holds the
-			// reservation and not the superseded records. A retry must not
-			// invoke the replacement callback a second time while the journal
-			// still records this request.
+			// Roll memory back to the journal the reservation persisted. Disk
+			// may already hold the rollback if only the post-rename directory
+			// sync failed, but either state is safe: every persist rewrites
+			// the whole file from memory, so the next successful one resyncs
+			// disk, and a retry that re-invokes the callback re-runs work that
+			// failed without installing anything.
 			for id := range superseded {
 				delete(s.clearRecords, id)
 			}

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -1487,7 +1487,10 @@ func (s *Server) handleAppThreadClear(ctx context.Context, params appwire.Thread
 	if parsedRef.SourceID != "local" {
 		return appwire.ThreadClearResponse{}, appwire.SessionUnavailable("thread is unavailable")
 	}
-	requestHash := threadClearRequestHash(params)
+	requestHash, err := threadClearRequestHash(params)
+	if err != nil {
+		return appwire.ThreadClearResponse{}, appwire.InternalError(err.Error())
+	}
 	if !s.appMutationGate.TryLock() {
 		return appwire.ThreadClearResponse{}, appwire.MutationNotAccepted(params.ClientMutationID, "a retry-safe mutation is already in progress")
 	}

--- a/server/server_surface_fuzz_test.go
+++ b/server/server_surface_fuzz_test.go
@@ -212,15 +212,25 @@ func exerciseAppWireResiduals() {
 	s.SetCompactFunc(func(context.Context) error { return nil })
 	_, _ = s.handleAppThreadCompactStart(ctx, appwire.ThreadCompactStartParams{})
 	_, _ = s.handleAppThreadShutdown(ctx, appwire.ThreadShutdownParams{})
-	s.SetProcessing(true)
-	_, _ = s.handleAppThreadClear(ctx, appwire.ThreadClearParams{})
-	s.SetProcessing(false)
-	s.SetClearFunc(nil)
-	_, _ = s.handleAppThreadClear(ctx, appwire.ThreadClearParams{})
-	s.SetClearFunc(func(context.Context, appwire.ThreadClearParams) error { return errors.New("clear") })
-	_, _ = s.handleAppThreadClear(ctx, appwire.ThreadClearParams{})
-	s.SetClearFunc(func(context.Context, appwire.ThreadClearParams) error { return nil })
-	_, _ = s.handleAppThreadClear(ctx, appwire.ThreadClearParams{})
+	// The clear arms run on a dedicated server with a known identity: the
+	// handler's mandatory Ref/ClientMutationID/ExpectedInstanceID checks
+	// reject empty params before the gate, the journal, or clearFunc, and the
+	// turn state earlier residuals left on s would block the clear anyway.
+	clearSrv := NewServer(ServerConfig{})
+	clearSrv.SetAppIdentity("local", "thread")
+	clearParams := func(id string) appwire.ThreadClearParams {
+		return appwire.ThreadClearParams{Ref: "local:thread", ClientMutationID: id, ExpectedInstanceID: "thread"}
+	}
+	_, _ = clearSrv.handleAppThreadClear(ctx, appwire.ThreadClearParams{})
+	clearSrv.SetProcessing(true)
+	_, _ = clearSrv.handleAppThreadClear(ctx, clearParams("clear-busy"))
+	clearSrv.SetProcessing(false)
+	_, _ = clearSrv.handleAppThreadClear(ctx, clearParams("clear-unwired"))
+	clearSrv.SetClearFunc(func(context.Context, appwire.ThreadClearParams) error { return errors.New("clear") })
+	_, _ = clearSrv.handleAppThreadClear(ctx, clearParams("clear-failed"))
+	clearSrv.SetClearFunc(func(context.Context, appwire.ThreadClearParams) error { return nil })
+	_, _ = clearSrv.handleAppThreadClear(ctx, clearParams("clear-applied"))
+	_, _ = clearSrv.handleAppThreadClear(ctx, clearParams("clear-applied"))
 	_, _ = s.handleAppThreadModelSet(ctx, appwire.ThreadModelSetParams{})
 	s.SetModelFunc(nil)
 	_, _ = s.handleAppThreadModelSet(ctx, appwire.ThreadModelSetParams{Model: "m"})

--- a/server/thread_clear_journal.go
+++ b/server/thread_clear_journal.go
@@ -26,7 +26,9 @@ const (
 // threadClearRecord is the durable identity fence for one clear request. A
 // reserved record survives a daemon restart so the same request can resume (or
 // recover the already-installed replacement) without accepting a second clear
-// against the same stable workspace ref.
+// against the same stable workspace ref. The journal holds at most one record
+// per stable ref: a newer clear's reservation supersedes any older record for
+// the same ref, whose expected instance no such retry can name anymore.
 type threadClearRecord struct {
 	ClientMutationID   string                       `json:"client_mutation_id"`
 	RequestHash        string                       `json:"request_hash"`

--- a/server/thread_clear_journal.go
+++ b/server/thread_clear_journal.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 
 	"primeradiant.com/evener/appwire"
 )
@@ -131,12 +132,14 @@ func persistThreadClearJournal(path string, records map[string]threadClearRecord
 		return fmt.Errorf("replace thread clear journal: %w", err)
 	}
 	// The rename is only durable once the directory entry itself is synced; a
-	// crash right after the rename could otherwise lose the replacement.
+	// crash right after the rename could otherwise lose the replacement. Some
+	// filesystems cannot sync a directory at all; tolerating that keeps clear
+	// usable there instead of turning a durability nicety into a hard failure.
 	dir, err := os.Open(filepath.Dir(path))
 	if err != nil {
 		return fmt.Errorf("open thread clear journal directory: %w", err)
 	}
-	if err := dir.Sync(); err != nil {
+	if err := dir.Sync(); err != nil && !journalSyncUnsupported(err) {
 		_ = dir.Close()
 		return fmt.Errorf("sync thread clear journal directory: %w", err)
 	}
@@ -144,6 +147,15 @@ func persistThreadClearJournal(path string, records map[string]threadClearRecord
 		return fmt.Errorf("close thread clear journal directory: %w", err)
 	}
 	return nil
+}
+
+// journalSyncUnsupported reports whether a sync failed because the filesystem
+// does not support syncing that file, mirroring the tolerance the hub's
+// deletion and transcript-display stores apply to the same rename idiom.
+func journalSyncUnsupported(err error) bool {
+	return errors.Is(err, syscall.ENOSYS) ||
+		errors.Is(err, syscall.ENOTSUP) ||
+		errors.Is(err, syscall.EINVAL)
 }
 
 func threadClearRequestHash(params appwire.ThreadClearParams) (string, error) {

--- a/server/thread_clear_journal.go
+++ b/server/thread_clear_journal.go
@@ -133,8 +133,11 @@ func persistThreadClearJournal(path string, records map[string]threadClearRecord
 	return nil
 }
 
-func threadClearRequestHash(params appwire.ThreadClearParams) string {
-	data, _ := json.Marshal(params)
+func threadClearRequestHash(params appwire.ThreadClearParams) (string, error) {
+	data, err := json.Marshal(params)
+	if err != nil {
+		return "", fmt.Errorf("encode thread clear request for hashing: %w", err)
+	}
 	hash := sha256.Sum256(data)
-	return hex.EncodeToString(hash[:])
+	return hex.EncodeToString(hash[:]), nil
 }

--- a/server/thread_clear_journal.go
+++ b/server/thread_clear_journal.go
@@ -130,6 +130,19 @@ func persistThreadClearJournal(path string, records map[string]threadClearRecord
 		_ = os.Remove(tmp)
 		return fmt.Errorf("replace thread clear journal: %w", err)
 	}
+	// The rename is only durable once the directory entry itself is synced; a
+	// crash right after the rename could otherwise lose the replacement.
+	dir, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		return fmt.Errorf("open thread clear journal directory: %w", err)
+	}
+	if err := dir.Sync(); err != nil {
+		_ = dir.Close()
+		return fmt.Errorf("sync thread clear journal directory: %w", err)
+	}
+	if err := dir.Close(); err != nil {
+		return fmt.Errorf("close thread clear journal directory: %w", err)
+	}
 	return nil
 }
 

--- a/server/thread_clear_journal_test.go
+++ b/server/thread_clear_journal_test.go
@@ -7,9 +7,11 @@ import (
 )
 
 // TestThreadClearRequestHash pins the property the "client mutation ID reused
-// with a different clear request" guard is built on: equal params hash equal,
-// different params hash different, and an encoding failure is reported rather
-// than collapsing every request onto the hash of nil.
+// with a different clear request" guard is built on: equal params hash equal
+// and different params hash different. The error return is unreachable for
+// the current all-strings params struct, so only the nil-error path runs here;
+// it exists so an encoding failure surfaces instead of collapsing every
+// request onto the hash of nil.
 func TestThreadClearRequestHash(t *testing.T) {
 	base := appwire.ThreadClearParams{Ref: "local:a", ClientMutationID: "clear-1", ExpectedInstanceID: "old"}
 	first, err := threadClearRequestHash(base)

--- a/server/thread_clear_journal_test.go
+++ b/server/thread_clear_journal_test.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+)
+
+// TestThreadClearRequestHash pins the property the "client mutation ID reused
+// with a different clear request" guard is built on: equal params hash equal,
+// different params hash different, and an encoding failure is reported rather
+// than collapsing every request onto the hash of nil.
+func TestThreadClearRequestHash(t *testing.T) {
+	base := appwire.ThreadClearParams{Ref: "local:a", ClientMutationID: "clear-1", ExpectedInstanceID: "old"}
+	first, err := threadClearRequestHash(base)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	if first == "" {
+		t.Fatal("hash is empty")
+	}
+	same, err := threadClearRequestHash(base)
+	if err != nil {
+		t.Fatalf("hash of equal params: %v", err)
+	}
+	if same != first {
+		t.Fatalf("equal params hashed differently: %q vs %q", first, same)
+	}
+	changed := base
+	changed.ExpectedInstanceID = "new"
+	different, err := threadClearRequestHash(changed)
+	if err != nil {
+		t.Fatalf("hash of different params: %v", err)
+	}
+	if different == first {
+		t.Fatal("different params hashed identically, so the reuse guard cannot fire")
+	}
+}


### PR DESCRIPTION
Resolves audit findings I1, I2, Minor 4, and Minor 6 from the code-quality audit of the fenced thread-clear work (`7c5dd61f6`).

## I1 — clear failure path re-pinned; surface fuzz clear arm restored

- `test(server)`: `TestServerAppWireThreadClearFailureReleasesGateAndReservation` pins that a failing `SetClearFunc` surfaces as a named `notAccepted` mutation, releases its journal reservation, and a fresh `ClientMutationID` clears afterwards — the property the deleted `server_clear_concurrency_test.go` covered, restated against the new journal-fenced path.
- `TestServerAppWireThreadClearRestoresReservationWhenRollbackPersistFails` covers the restore-on-persist-failure branch. The fault is injected by occupying the journal's temp path with a directory inside the clear callback — no production fault seam added (per the audit's criticism of nil-checked hot-path test seams). It also pins that the same mutation id retries to completion once persistence recovers.
- The surface fuzz's four `ThreadClearParams{}` calls died at `InvalidParams("ref is required")` and never reached the handler interior. The clear arms now run on a dedicated server with valid identity fields; a coverage profile of the fuzz seeds confirms the gate, reservation, busy-block, unwired, failing, applied, and replay branches are exercised again (one empty-params call kept for the validation branch).

## I2 — journal bounded at one record per stable ref

A clear installs a new live instance under the stable ref, so an older clear's record can no longer be a live client's retry — its expected instance is gone. A new reservation now evicts every older record for the same ref, bounding `thread-clear-journal.json` at one record per ref (O(1) for this single-thread daemon) and removing the O(n) rewrite growth. Crash-recovery replay of the newest clear is preserved; pre-existing oversized journals self-heal on the next clear. A roborev finding sharpened this: when the newer clear's callback **fails** it installed nothing, so the superseded records are restored (pinned by `TestServerAppWireThreadClearFailedClearRestoresSupersededReceipt`). Rollbacks are wholesale `maps.Clone` snapshot restores rather than hand-maintained incremental surgery.

## Minor 4 — journal rename made durable

`persistThreadClearJournal` now opens and fsyncs the containing directory after `os.Rename`. `ENOSYS`/`ENOTSUP`/`EINVAL` from the directory sync are tolerated (mirroring the hub's deletion and transcript-display stores) so filesystems that cannot sync a directory keep `thread/clear` usable instead of failing every persist.

## Minor 6 — request hash no longer swallows its marshal error

`threadClearRequestHash` returns the `json.Marshal` error instead of discarding it; `handleAppThreadClear` refuses the request with `InternalError` rather than comparing hashes of `nil`. Unreachable for the current all-strings params struct, but the "client mutation ID reused with a different clear request" guard is a correctness fence and is no longer built on a discarded error.

## Review process

- Per-commit roborev reviews: one finding (superseded receipts lost on a failed newer clear) fixed; one finding (memory/disk divergence when the persist fails after its rename) analyzed, judged safe under both disk states, documented at the rollback site, and closed with reasoning; all other commits clean.
- Simplify pass applied: snapshot rollbacks, dir-sync tolerance, extracted `setReplacingClearFunc` / `requireMutationErrorData` test helpers.
- Branch-level `roborev review --branch --base main`: no issues found.
- Gates: `go test ./...`, `go test -race ./server/...`, `make lint` 9/9 — all green after rebase onto current main.
