### PR TITLE
docs(skill): sweep doctoring-evener corpus to doctor_evener tool dialect

### DIFF
--- a/internal/bundled/agents/doctor.md
+++ b/internal/bundled/agents/doctor.md
@@ -81,9 +81,11 @@ it is surfaced. Do not use shell for inspection.
 thresholds). 3. CLASSIFY each result PASS-with-a-note or confirmed problem.
 4. Emit a Finding per confirmed problem. 5. Report back in plain language: what
 you checked, what you found (or that it was healthy), and the exact
-`doctor_evener` calls (command + selector + flags) you made so a human can
-reproduce them via the CLI.
+`doctor_evener` calls (command + selector + arguments) you made — for a human's
+reproduction, give the equivalent `evener doctor <cmd>` line.
 
-Your runtime context — the target selector(s), the state dir in effect, and
-today's date — is provided when you are invoked. If no selector is given, ask for
-one (a standalone forensic tool has no "current" session).
+Your runtime context — the target selector(s) and today's date — is provided
+when you are invoked. State root: `doctor_evener` targets this session's own
+state root by default; pass `state_dir` only when a caller names a different
+root. If no selector is given, ask for one (a standalone forensic tool has no
+"current" session).

--- a/internal/bundled/skills/doctoring-evener/SKILL.md
+++ b/internal/bundled/skills/doctoring-evener/SKILL.md
@@ -60,7 +60,7 @@ Results are the CLI's `--json` struct shapes. The same commands also run as
 |---|---|---|
 | `locate <sel>` | where are this session's transcript / private API log / meta / jobs / client-mutation files? | — |
 | `sessions` | enumerate sessions for a batch study — id, bucket, timestamps, model(s), turn count, transcript bytes, subagent/parent linkage, outcome hint | `since DUR`, `bucket B` |
-| `transcript <sel>` | render the turns; **how many real `X` calls?** | `count`, `format`, `range`, `text_max`, `full_text` |
+| `transcript <sel>` | render the turns; **how many real `X` calls?** | `count`, `range`, `text_max`, `full_text` |
 | `transcript <sel>` + `full_text` | **is one response repeating itself?** Turn text and tool-result previews both render capped at 200 bytes by default; a salvaged partial response carries its repeated tool calls as *text*, so no tool-call metric counts them and the cap hides the whole loop. Narrow with `range` first — one turn can run to tens of kilobytes. | `range`, `text_max` for a middle ground |
 | `transcript <sel>` + `health` | one session's mechanical metrics in one shot — tool calls/errors by class, longest identical-call run (+ whether it's all errors), truncation warnings, steering counts, jobs by terminal reason, stale notifications, user corrections (proxy) | — |
 | `apilog <sel>` | summarize canonical `sessions/<sid>.api.jsonl` attempt identity/grouping/finality, tokens/latency, **empty responses, errors, cache spikes**; `validate` strictly decodes offset zero..EOF and reports every corrupt/malformed/oversized/unsupported record with its offset (whole-file scan, explicit diagnostics only) | `empty`, `errors`, `cache_spikes` + `threshold`, `summary`, `validate`, `recompute` |

--- a/internal/bundled/skills/doctoring-evener/references/data-model.md
+++ b/internal/bundled/skills/doctoring-evener/references/data-model.md
@@ -68,7 +68,8 @@ it was never read). Under an XDG home the layout is:
 - **the client-mutation store is a third shape again**: a flat `<SID>.json` in a
   bucket-level `mutations/` dir that is a **sibling** of `sessions/`, not a file
   under it (`clientMutationFilePath`).
-- When `EVENER_STATE_DIR` / `--state-dir` is set, that path **is** the bucket
+- When `EVENER_STATE_DIR` / the tool's `state_dir` argument is set, that path
+  **is** the bucket
   (sessions sit directly under it — no `evener/projects/<hash>` layer). This is the
   E2E / scratch-root shape.
 
@@ -191,8 +192,8 @@ the target shell's folded state before diagnosing a missing match.
 
 **Read it via:** `doctor_evener` `watches <selector>` (distinct deliveries vs pending
 lines, per-delivery terminal + reason + provenance, self-influence/breaker
-telemetry, and the joined `target job:` state — `target_job` / `target_job_missing`
-under `--json`).
+telemetry, and the joined `target job:` state — the `target_job` /
+`target_job_missing` fields).
 
 ### delegates.jsonl → the stable session tree
 

--- a/internal/bundled/skills/doctoring-evener/references/failure-modes.md
+++ b/internal/bundled/skills/doctoring-evener/references/failure-modes.md
@@ -74,8 +74,8 @@ gotchas" are seeded from this. Cite Go **symbols**, never `file:line`.
 - **What it is:** the parser guessed the JSONL shape (looked for top-level keys; a
   tool call is nested at `entry.Turn.Message.Content[].ToolCall.Name`; a steering
   turn is `schema.TurnSteering`).
-- **Confirm:** `doctor_evener` `transcript <sel>` with `format: outline` (turn map) and
-  `--count <tool>`. The result tool resolves via `effectiveResultToolName`
+- **Confirm:** `doctor_evener` `transcript <sel>` (turn map) and
+  `count: <tool>`. The result tool resolves via `effectiveResultToolName`
   (`meta.Config.ResultToolName` else `communicate`).
 - **Mechanics:** `transcript.Entry{Kind, Seq, Turn}` wraps a `schema.Turn`; the
   turn kinds are `USER_INPUT`/`STEERING`/`ASSISTANT`/`TOOL_RESULTS` (current,

--- a/internal/bundled/skills/doctoring-evener/references/finding-contract.md
+++ b/internal/bundled/skills/doctoring-evener/references/finding-contract.md
@@ -25,8 +25,9 @@ missed note costs nothing; a spurious finding makes a human triage noise.
 | `suggestedFix` | object | yes | the **routing** directive (below). |
 
 `evidence` sub-fields: `sessionRefs[]`, `watchIds[]`, `deliveryIds[]`,
-`transcriptTurns[]`, `doctorCommand` (the reproduction command — an `evener doctor <cmd> …` line that
-surfaces it — so a human can reproduce), `logSnippets[]`. Redact secrets from
+`transcriptTurns[]`, `doctorCommand` (the reproduction command — an
+`evener doctor <cmd> …` line a human can run to reproduce what the
+`doctor_evener` call surfaced), `logSnippets[]`. Redact secrets from
 evidence.
 
 ### Category
@@ -37,7 +38,7 @@ Adopt the diagnostic categories from Contract 3 where they apply — `validation
 shapes this skill adds: `watch_runaway`, `dropped_delivery`, `provenance_gap`,
 `stuck_processing`, `orphaned_runtime`, `legacy_state`. Use `legacy_state` only
 for the exact fail-closed `legacy_delegate_state` or
-`legacy_delegate_watch_state` codes reported by `evener doctor`; do not infer it
+`legacy_delegate_watch_state` codes reported by `doctor_evener` `jobs`; do not infer it
 from prose or historical transcript rendering. The category routes and groups.
 
 ### Signature formats

--- a/internal/bundled/skills/doctoring-evener/references/writing-runbooks.md
+++ b/internal/bundled/skills/doctoring-evener/references/writing-runbooks.md
@@ -16,12 +16,11 @@ HEALTHY/INSPECT/CLASSIFY), each a heading:
    delivery — normal, not a runaway). A reader must be able to tell PASS from FAIL
    without guessing.
 2. **INSPECT** — the exact `doctor_evener` calls (command + selector +
-flags). **Pull live
+   arguments). **Pull live
    state first; never hardcode a session id, a watch id, or a threshold** — take
-   them from the target selector the runbook is invoked with. `doctor_evener` always
-returns the structured result, so no flag is needed; the CLI equivalent is
-`--json` so
-   CLASSIFY keys on fields, not on parsing prose.
+   them from the target selector the runbook is invoked with. `doctor_evener`
+   always returns the structured result (the CLI equivalent needs `--json`),
+   so CLASSIFY keys on fields, not on parsing prose.
 3. **CLASSIFY** — which results are PASS-with-a-note and which **emit a Finding**.
    Name the exact `category`, `severity`, `signature` format, and
    `suggestedFix.type` for each emit (see `finding-contract.md`). State plainly:
@@ -63,7 +62,7 @@ returns the structured result, so no flag is needed; the CLI equivalent is
 ## INSPECT
 Take the target session id from the runbook invocation — never hardcode one.
 \`\`\`
-doctor_evener {command, selector, ...flags}   (CLI: evener doctor <cmd> <selector> [--flag] --json)
+doctor_evener {command, selector, ...args}   (human reproduction: evener doctor <cmd> <selector> [--flag] --json)
 \`\`\`
 
 ## CLASSIFY
@@ -76,15 +75,16 @@ A run that finds nothing is the expected, correct outcome.
 ## Worked sketch
 
 The seed `observer-self-loop.md` is the canonical example: HEALTHY = no watch has
-a `runaway` drop (bounded self-influence is normal); INSPECT = `evener doctor
-watches` with `self_loops: true`; CLASSIFY = each watch with
+a `runaway` drop (bounded self-influence is normal); INSPECT = `doctor_evener`
+`watches` with `self_loops: true`; CLASSIFY = each watch with
 `runaway_drops > 0` → one `watch_runaway` Finding, empty output → PASS. Read it
 before authoring a new one.
 
 ## The `audit:` block — mechanical checks the audit command drives
 
 CLASSIFY's INSPECT/prose form is written for an LLM operator's judgment.
-`doctor_evener` audit with `runbook: NAME` and (`sessions` | `since`) — CLI: `evener doctor audit --runbook NAME (--sessions ... | --since DUR)`
+`doctor_evener` audit with `runbook: NAME` and (`sessions` | `since`) — human
+reproduction: `evener doctor audit --runbook NAME (--sessions ... | --since DUR)`
 is the **batch** driver: it runs a runbook's threshold checks over a whole
 session set mechanically, dedups the results into Findings by signature
 (one Finding, every affected session listed in its evidence), and prints a

--- a/internal/bundled/skills/doctoring-evener/runbooks/error-loop.md
+++ b/internal/bundled/skills/doctoring-evener/runbooks/error-loop.md
@@ -6,8 +6,8 @@ instead of recognizing the failure and changing approach?
 ## HEALTHY
 
 - `longest_identical_run` is either short, or wasn't all errors —
-  `evener doctor transcript --health` reports a run below the threshold, or one
-  whose results weren't all failures.
+  `doctor_evener` `transcript` with `health: true` reports a run below the
+  threshold, or one whose results weren't all failures.
 - Note: a repeated call that keeps SUCCEEDING (e.g. two identical greps that
   both return the same empty match) is not a problem — length alone never
   trips this runbook, only length **and** all-errors together.
@@ -17,7 +17,8 @@ instead of recognizing the failure and changing approach?
 Take the target session id from the runbook invocation — never hardcode one.
 
 ```
-evener doctor transcript <selector> --health --json
+doctor_evener transcript, selector: <selector>, health: true
+# (human reproduction: evener doctor transcript <selector> --health --json)
 ```
 
 ## CLASSIFY
@@ -43,11 +44,11 @@ audit:
 ```
 
 - Read the flagged session's transcript around the identical run
-  (`evener doctor transcript <sel> --format outline` or `--range last:N`) to
+  (`doctor_evener` `transcript` with `range: last:N`) to
   confirm the calls really are identical retries of a failing operation, not
   a legitimate scripted retry with backoff — and check whether the runtime's
   own loop-detector steering (`steering.loop-detected` in the same
-  `--health` output) already fired, and whether the session heeded it. The
+  health output) already fired, and whether the session heeded it. The
   2026-08-05 session study found this pattern reach ~300 consecutive
   failures in one session (`034163AU8MmLapfXKT7nMu`, a `set_viewport` loop
   that survived two loop-warnings and three user interventions), so absence
@@ -80,10 +81,10 @@ check exists to cover them:**
   detector operates on live signatures as calls happen, independent of
   argument-field content or which channel a tool used to report failure.
   Treat an identical-run miss as inconclusive, not as evidence of health;
-  use `evener doctor transcript <sid> --count <tool>` to get the tool's real
-  call count and `evener doctor transcript <sid> --format outline` to read
-  the run and judge it manually when the mechanical checks disagree or
-  both stay silent.
+  use `doctor_evener` `transcript` with `count: <tool>` to get the tool's
+  real call count and `doctor_evener` `transcript` with `range` narrowed to
+  the run to read it and judge it manually when the mechanical checks
+  disagree or both stay silent.
 
 A healthy run emits zero findings.
 

--- a/internal/bundled/skills/doctoring-evener/runbooks/observer-self-loop.md
+++ b/internal/bundled/skills/doctoring-evener/runbooks/observer-self-loop.md
@@ -7,7 +7,8 @@ the Finding is a loop that climbed until the machinery had to cut it.
 
 ## HEALTHY
 
-- No watch has a `runaway` drop. `evener doctor watches --self-loops` reports
+- No watch has a `runaway` drop. `doctor_evener` `watches` with `self_loops:
+  true` reports
   **no watches** (it surfaces only watches whose fuse FIRED).
 - Self-influenced deliveries with a **bounded** `self_influence_depth` are fine —
   the sidecar saw its own echo, was informed by the depth-gradient line, and
@@ -20,18 +21,20 @@ Take the target session id from the runbook invocation — never hardcode one.
 
 ```
 # Watches whose runaway fuse FIRED on the session (empty output ⇒ healthy):
-evener doctor watches <selector> --self-loops --json
+doctor_evener watches, selector: <selector>, self_loops: true
+# (human reproduction: evener doctor watches <selector> --self-loops --json)
 
 # Optional: enumerate observer sessions feeding this worker, to widen the sweep:
-evener doctor tree <selector> --observers
+doctor_evener tree, selector: <selector>, observers: true
+# (human reproduction: evener doctor tree <selector> --observers)
 ```
 
-For a fleet sweep, run the `--self-loops` check for each session the tree
+For a fleet sweep, run the `self_loops` check for each session the tree
 surfaces.
 
 ## CLASSIFY
 
-- For each watch in the `--self-loops` output, `runaway_drops > 0` is the
+- For each watch in the `self_loops` output, `runaway_drops > 0` is the
   **Finding** — the fuse fired, so a real runaway loop was bounded by the
   machinery (sends at `self_influence_depth >= 8` were dropped with
   `diagnostic_reason: "runaway"`). Emit one Finding:
@@ -39,14 +42,15 @@ surfaces.
   - `severity`: `high`
   - `signature`: `watch_runaway:<sessionID>:<watchID>`
   - `evidence`: `watchIds` = the watch, `deliveryIds` = the dropped-send delivery
-    ids, `doctorCommand` = the `evener doctor watches … --self-loops` invocation.
+    ids, `doctorCommand` = the `evener doctor watches … --self-loops` line that
+    reproduces the same check for a human.
     Put `max_self_influence_depth` and `runaway_drops` in the `description`.
   - `suggestedFix.type`: `diagnosis` (a runaway that the fuse had to cut is a
     sidecar/watch-topology problem in evener, not in the doctor's machinery —
     report it).
 - A watch that is self-influenced but **bounded** (`runaway_drops == 0`, any
   `max_self_influence_depth`) is **not** a Finding — the inform+breaker design
-  expects it. `--self-loops` will not list it.
-- Empty `--self-loops` output (no watches) ⇒ **PASS, emit nothing.**
+  expects it. The `self_loops` filter will not list it.
+- Empty `self_loops` output (no watches) ⇒ **PASS, emit nothing.**
 
 A run where no fuse fired is the expected, correct outcome.

--- a/internal/bundled/skills/doctoring-evener/runbooks/run-timeout-waste.md
+++ b/internal/bundled/skills/doctoring-evener/runbooks/run-timeout-waste.md
@@ -5,8 +5,9 @@ over, discarding the run's output each time, instead of adapting?
 
 ## HEALTHY
 
-- Few or no terminal jobs ended by `run_timeout`. `evener doctor transcript
-  --health` reports `jobs.run_timeout` below the threshold.
+- Few or no terminal jobs ended by `run_timeout`. `doctor_evener`
+  `transcript` with `health: true` reports `jobs.run_timeout` below the
+  threshold.
 - Note: a single `run_timeout` is not itself a Finding — it becomes a
   wasted-budget pattern only once the session keeps re-running a doomed
   command instead of adapting (raising the tool's own timeout, running in
@@ -17,9 +18,11 @@ over, discarding the run's output each time, instead of adapting?
 Take the target session id from the runbook invocation — never hardcode one.
 
 ```
-evener doctor transcript <selector> --health --json
+doctor_evener transcript, selector: <selector>, health: true
+# (human reproduction: evener doctor transcript <selector> --health --json)
 # per-job command/output_bytes detail, if the summary count needs unpacking:
-evener doctor jobs <selector> --json
+doctor_evener jobs, selector: <selector>
+# (human reproduction: evener doctor jobs <selector> --json)
 ```
 
 ## CLASSIFY
@@ -34,13 +37,13 @@ audit:
     value: 5
 ```
 
-- Cross-check `jobs.zero_output_terminal` in the same `--health` result — the
+- Cross-check `jobs.zero_output_terminal` in the same health result — the
   2026-08-05 session study's worst cases combined `run_timeout` with zero
   recorded output (everything the killed process printed was thrown away),
   which is what turns the retries into blind repeats instead of informed
   ones (`0341CrVzn6z2CM0sgd87F2`: 90 of 145 jobs ended `run_timeout`, 89 with
   zero output, ~90 minutes lost; `0340xUxn3kwKp6BNy6J7Tj`: 15 timeouts then
-  committed without ever seeing a pass). `evener doctor jobs <sel>` shows each
+  committed without ever seeing a pass). `doctor_evener` `jobs` shows each
   job's own command, so confirm the flagged session was actually re-running
   the *same* command rather than five distinct long-but-legitimate jobs.
 - Fewer than the threshold's `run_timeout` jobs is not a Finding — a session

--- a/internal/bundled/skills/doctoring-evener/runbooks/stale-notification.md
+++ b/internal/bundled/skills/doctoring-evener/runbooks/stale-notification.md
@@ -6,7 +6,8 @@ after it had already declared itself done (`end_turn=true`)?
 ## HEALTHY
 
 - Few or no notification-kind steering turns arrive after the session's
-  final `end_turn=true` result-tool call. `evener doctor transcript --health`
+  final `end_turn=true` result-tool call. `doctor_evener` `transcript` with
+  `health: true`
   reports `stale_notifications` below the threshold.
 - Note: a notification delivered BEFORE the session's final `end_turn` is
   normal — the session is still working and can act on it. Only post-done
@@ -17,7 +18,8 @@ after it had already declared itself done (`end_turn=true`)?
 Take the target session id from the runbook invocation — never hardcode one.
 
 ```
-evener doctor transcript <selector> --health --json
+doctor_evener transcript, selector: <selector>, health: true
+# (human reproduction: evener doctor transcript <selector> --health --json)
 ```
 
 ## CLASSIFY
@@ -33,12 +35,12 @@ audit:
 ```
 
 - Read the flagged session's transcript around each stale notification
-  (`evener doctor transcript <sel> --format outline`) to see how late it
+  (`doctor_evener` `transcript` with `range` narrowed to the affected turns) to see how late it
   arrived relative to the final `end_turn` call, and whether it forced a
   wasted acknowledgment turn — the 2026-08-05 session study found completion
   events arriving up to 54 minutes after the final answer, ~14 sessions
   affected. If the notification's source watch itself looks suspect, widen
-  the sweep with `evener doctor tree <sel> --observers` and pair this with the
+  the sweep with `doctor_evener` `tree` with `observers: true` and pair this with the
   `observer-self-loop` runbook.
 - A single stale notification is not a Finding — the machinery notifying a
   session that has just finished is expected under normal timing; the

--- a/internal/bundled/skills/doctoring-evener/runbooks/truncation-waste.md
+++ b/internal/bundled/skills/doctoring-evener/runbooks/truncation-waste.md
@@ -6,8 +6,9 @@ truncated result?
 
 ## HEALTHY
 
-- Few or no tool results carry the truncation banner. `evener doctor
-  transcript --health` reports `truncation_warnings` below the threshold.
+- Few or no tool results carry the truncation banner. `doctor_evener`
+  `transcript` with `health: true` reports `truncation_warnings` below the
+  threshold.
 - Note: one truncated result is not a Finding by itself — the pattern is
   *repeated* truncation without narrowing (a smaller glob, a bounded
   read/paging affordance, an excluded worktree) after the first warning.
@@ -17,7 +18,8 @@ truncated result?
 Take the target session id from the runbook invocation — never hardcode one.
 
 ```
-evener doctor transcript <selector> --health --json
+doctor_evener transcript, selector: <selector>, health: true
+# (human reproduction: evener doctor transcript <selector> --health --json)
 ```
 
 ## CLASSIFY
@@ -32,8 +34,8 @@ audit:
     value: 3
 ```
 
-- Read the flagged session's transcript (`evener doctor transcript <sel>
-  --format outline`) around each truncated result to see whether the session
+- Read the flagged session's transcript (`doctor_evener` `transcript` with
+  `range` narrowed to the affected turns) around each truncated result to see whether the session
   narrowed its request afterward, or repeated the same unscoped call. The
   2026-08-05 session study found this truncation happens **from the front**
   (dropping the top-level, usually most-relevant entries) with only a prose

--- a/internal/bundled/skills/doctoring-evener/runbooks/watch-delivery-health.md
+++ b/internal/bundled/skills/doctoring-evener/runbooks/watch-delivery-health.md
@@ -18,7 +18,8 @@ settling as expected, with coalescing recognised as normal and drops explained?
 Take the target session id from the runbook invocation.
 
 ```
-evener doctor watches <selector> --json
+doctor_evener watches, selector: <selector>
+# (human reproduction: evener doctor watches <selector> --json)
 ```
 
 Per watch, read: `distinct_deliveries`, `delivered` / `dropped` / `evicted`,


### PR DESCRIPTION
## Summary

Completes the doctoring-evener skill seam update that #633 started. The #633 round-2 review (finding 5) flagged that the update stopped at SKILL.md's command table: the rest of the corpus still instructed in CLI-flag dialect, re-creating the three-synchronized-edits drift class the original proposal condemned. An agent following a runbook literally would construct `evener doctor transcript <sel> --health --json` — a shell-out the `doctor_evener` tool replaced.

## Convention

One dialect, applied corpus-wide: **`doctor_evener` tool dialect is canonical** (command + arguments); the CLI line survives only as an explicit, labeled human-reproduction hint.

## Changes (12 files, +73/−56)

- **All 6 runbooks** — INSPECT fences now show the `doctor_evener` call shape (`doctor_evener transcript, selector: <selector>, health: true`) with a `# (human reproduction: evener doctor …)` line; prose follows (`--self-loops output` → `self_loops output`). YAML `audit:` blocks untouched — still parse-validated by the tests.
- **writing-runbooks.md** — skeleton and worked sketch in tool dialect; `--json` advice corrected (the tool *always* returns structured results; it's the CLI that needs `--json`).
- **data-model.md** — `--json` field mention → plain field names; `--state-dir is set` → the tool's `state_dir` argument.
- **finding-contract.md** — `doctorCommand` defined as the human reproduction of what the `doctor_evener` call surfaced; `legacy_state` codes read via `doctor_evener` `jobs`.
- **failure-modes.md** — `--count <tool>` → `count: <tool>`.
- **doctor.md persona** — the report step asks for `doctor_evener` calls with the CLI line only as the reproduction equivalent; the state-root paragraph now describes the tool's actual `state_dir` default.
- **SKILL.md** — dropped the inert `format` argument from the transcript row (removed from the tool surface in #633's round-2 fixes; the doc had drifted the other way).

**Left intentionally CLI-mentioning:** the CLI described as a surface that exists (SKILL.md's "the same commands also run as `evener doctor <cmd>`"), the `cmd/evener-doctor` Go binary in repair-guardrails, and `doctorCommand` examples in finding-contract.md — those are reproduction lines by definition.

## Verification

- `go test ./internal/bundled/ ./cmd/evener-doctor/ ./cmd/evener-hub/` — green (runbook YAML `audit:` blocks parse-validated end-to-end by `study_runbooks_test.go` / `audit_test.go`)
- `go build ./...`, `go vet ./internal/bundled/... ./cmd/evener-doctor/...` — clean
- `golangci-lint run ./internal/bundled/...` — 0 issues
- Post-sweep grep audit: every remaining `evener doctor` / `--json` / flag mention in the corpus is an intentional reproduction hint, a description of the CLI/Go binary as a thing, or a `doctorCommand` example
