### PR TITLE
Five audit-recommended cleanups: dead Secret field, test seams, notification stamping, navigation retry pacing, derived-totals dedup

### DIFF
--- a/agent/task/task_mutation_publication_test.go
+++ b/agent/task/task_mutation_publication_test.go
@@ -24,9 +24,10 @@ func TestTaskStoreMutationPublicationSerializesSharedProducers(t *testing.T) {
 	emitted := make(chan publication, 2)
 
 	var waitingOnce sync.Once
-	store.beforeMutationPublicationWait = func() {
+	beforeMutationPublicationWaitHook = func() {
 		waitingOnce.Do(func() { close(childWaiting) })
 	}
+	t.Cleanup(func() { beforeMutationPublicationWaitHook = nil })
 
 	rootDone := make(chan error, 1)
 	go func() {

--- a/agent/task/task_store.go
+++ b/agent/task/task_store.go
@@ -175,10 +175,13 @@ type TaskStore struct {
 	path                  string
 	now                   func() time.Time
 	fs                    afero.Fs
-	// beforeMutationPublicationWait is a deterministic contention seam for the
-	// shared-producer ordering test. Production leaves it nil.
-	beforeMutationPublicationWait func()
 }
+
+// beforeMutationPublicationWaitHook, when non-nil, runs when MutateAndPublish
+// finds the publication serializer contended, before blocking on it. It is a
+// deterministic contention seam for the shared-producer ordering test;
+// production never assigns it.
+var beforeMutationPublicationWaitHook func()
 
 // NewTaskStore creates a TaskStore that persists to <stateDir>/tasks/<sessionID>.json.
 // Each session (parent or subagent) gets its own task file, ensuring isolation.
@@ -201,8 +204,8 @@ func NewTaskStore(stateDir, sessionID string) *TaskStore {
 // is never held by this method.
 func (s *TaskStore) MutateAndPublish(fn func(epoch, revision uint64) error) error {
 	if !s.mutationPublicationMu.TryLock() {
-		if s.beforeMutationPublicationWait != nil {
-			s.beforeMutationPublicationWait()
+		if beforeMutationPublicationWaitHook != nil {
+			beforeMutationPublicationWaitHook()
 		}
 		s.mutationPublicationMu.Lock()
 	}

--- a/agent/task/task_store.go
+++ b/agent/task/task_store.go
@@ -180,7 +180,9 @@ type TaskStore struct {
 // beforeMutationPublicationWaitHook, when non-nil, runs when MutateAndPublish
 // finds the publication serializer contended, before blocking on it. It is a
 // deterministic contention seam for the shared-producer ordering test;
-// production never assigns it.
+// production never assigns it. It is one unsynchronized package variable, so
+// a test that installs it must not run in parallel and must join its
+// goroutines before its cleanup resets the hook.
 var beforeMutationPublicationWaitHook func()
 
 // NewTaskStore creates a TaskStore that persists to <stateDir>/tasks/<sessionID>.json.

--- a/appwire/notification_target.go
+++ b/appwire/notification_target.go
@@ -5,7 +5,7 @@ package appwire
 // round trip. Every params struct the app-event projector emits implements it;
 // the value receiver mutates a copy and returns it, so callers holding the
 // params as `any` get the restamped value back. Params the projector builds as
-// map[string]any carry threadId/ref keys instead and are restamped directly.
+// map[string]any carry threadId/ref keys instead and are restamped on a copy.
 type NotificationTargeted interface {
 	WithNotificationTarget(threadID, ref string) NotificationTargeted
 }

--- a/appwire/notification_target.go
+++ b/appwire/notification_target.go
@@ -1,0 +1,116 @@
+package appwire
+
+// NotificationTargeted lets the daemon re-address a notification's params to
+// the fanout target it is committing them under (threadId/ref) without a JSON
+// round trip. Every params struct the app-event projector emits implements it;
+// the value receiver mutates a copy and returns it, so callers holding the
+// params as `any` get the restamped value back. Params the projector builds as
+// map[string]any carry threadId/ref keys instead and are restamped directly.
+type NotificationTargeted interface {
+	WithNotificationTarget(threadID, ref string) NotificationTargeted
+}
+
+func (p ThreadStartedParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p TurnStartedParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p ItemLifecycleParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p AgentMessageDeltaParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p AgentMessageResetParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p ReasoningSummaryDeltaParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p ToolOutputDeltaParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p ThreadStatusChangedParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p ThreadQueueChangedParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p ThreadNameChangedParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p ThreadModelChangedParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p ThreadModelRetryParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p ThreadReasoningEffortChangedParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p ThreadVisionModelChangedParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p TaskUpdatedParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p GoalUpdatedParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p SandboxEscalationRequested) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p SandboxEscalationResolved) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p EvenerJobParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p JobsTreeUpdatedParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p EvenerDelegateParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}

--- a/appwire/notification_target.go
+++ b/appwire/notification_target.go
@@ -2,9 +2,11 @@ package appwire
 
 // NotificationTargeted lets the daemon re-address a notification's params to
 // the fanout target it is committing them under (threadId/ref) without a JSON
-// round trip. Every params struct the app-event projector emits implements it;
-// the value receiver mutates a copy and returns it, so callers holding the
-// params as `any` get the restamped value back. Params the projector builds as
+// round trip. Every thread-scoped params struct in the Notifications catalog
+// implements it (TestThreadNotificationsRequireAuthoritativeRoutingIdentity
+// pins that, so a new payload type cannot land without the method); the value
+// receiver mutates a copy and returns it, so callers holding the params as
+// `any` get the restamped value back. Params the projector builds as
 // map[string]any carry threadId/ref keys instead and are restamped on a copy.
 type NotificationTargeted interface {
 	WithNotificationTarget(threadID, ref string) NotificationTargeted
@@ -111,6 +113,31 @@ func (p JobsTreeUpdatedParams) WithNotificationTarget(threadID, ref string) Noti
 }
 
 func (p EvenerDelegateParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p ThreadClosedParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p TurnCompletedParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p WarningParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p EvenerSteeringInjectedParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
+	p.ThreadID, p.Ref = threadID, ref
+	return p
+}
+
+func (p ThreadResyncParams) WithNotificationTarget(threadID, ref string) NotificationTargeted {
 	p.ThreadID, p.Ref = threadID, ref
 	return p
 }

--- a/appwire/protocol_test.go
+++ b/appwire/protocol_test.go
@@ -413,6 +413,12 @@ func TestThreadNotificationsRequireAuthoritativeRoutingIdentity(t *testing.T) {
 				t.Errorf("%s payload %s.%s json tag = %q, want %q", notification.Name, payloadType.Name(), fieldName, got, want)
 			}
 		}
+		// The daemon restamps threadId/ref at its notification egress
+		// (stampAppNotificationTarget); a payload without the method would
+		// silently ship the projector's own view of the target instead.
+		if _, ok := notification.Payload.(NotificationTargeted); !ok {
+			t.Errorf("%s payload %s does not implement NotificationTargeted", notification.Name, payloadType.Name())
+		}
 	}
 }
 

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -2445,8 +2445,7 @@ type LaunchOptionChoice struct {
 }
 
 type LaunchOptionEnvFallback struct {
-	Name   string `json:"name"`
-	Secret bool   `json:"secret,omitempty"`
+	Name string `json:"name"`
 }
 
 type LaunchOption struct {

--- a/cmd/evener-hub/app_launch.go
+++ b/cmd/evener-hub/app_launch.go
@@ -66,7 +66,7 @@ func (c *hubLaunchController) Schema(ctx context.Context, params appwire.EmptyPa
 			wire.DefaultableLayers = append(wire.DefaultableLayers, string(layer))
 		}
 		if opt.EnvFallback != nil {
-			wire.EnvFallback = &appwire.LaunchOptionEnvFallback{Name: opt.EnvFallback.Name, Secret: opt.EnvFallback.Secret}
+			wire.EnvFallback = &appwire.LaunchOptionEnvFallback{Name: opt.EnvFallback.Name}
 		}
 		for _, choice := range opt.Choices {
 			wire.Choices = append(wire.Choices, appwire.LaunchOptionChoice{Value: choice.Value, Label: choice.Label, Disabled: choice.Disabled, Hint: choice.Hint})

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -794,7 +794,6 @@ export interface LaunchOptionChoice {
 
 export interface LaunchOptionEnvFallback {
   name: string;
-  secret?: boolean;
 }
 
 export interface LaunchOptionSchemaResponse {

--- a/cmd/evener-hub/internal/launchconfig/runtime_defaults.go
+++ b/cmd/evener-hub/internal/launchconfig/runtime_defaults.go
@@ -17,7 +17,7 @@ const (
 
 // ApplyEnvDefaults returns resolved with the effective layer's
 // still-unset fields filled from the environment floor only: the schema's
-// non-secret EnvFallback set (EVENER_MODEL, EVENER_REASONING_EFFORT,
+// EnvFallback set (EVENER_MODEL, EVENER_REASONING_EFFORT,
 // EVENER_OPENAI_RESPONSES_CONTINUATION). A field any file layer already set
 // is left untouched; provenance records "env" for the fields filled.
 //
@@ -49,7 +49,7 @@ func ApplyEnvDefaults(resolved Resolved, getenv func(string) string, schema []La
 	}
 
 	for _, opt := range schema {
-		if opt.EnvFallback == nil || opt.EnvFallback.Secret {
+		if opt.EnvFallback == nil {
 			continue
 		}
 		// All env-fallback fields are string scalars, so a single read of the
@@ -81,7 +81,7 @@ func ApplyEnvDefaults(resolved Resolved, getenv func(string) string, schema []La
 // ApplyRuntimeDefaults returns a copy of resolved with the effective layer's
 // still-unset fields filled from two floors of the fallback chain, in order:
 //
-//  1. env: the schema's non-secret EnvFallback set, and
+//  1. env: the schema's EnvFallback set, and
 //  2. builtin: the agent's own defaults declared on each LaunchOption
 //     (BuiltinDefault / BuiltinDefaultInt / BuiltinDefaultBool) — the floor
 //     the agent itself applies when flag, env, and layer are all absent.

--- a/cmd/evener-hub/internal/launchconfig/schema.go
+++ b/cmd/evener-hub/internal/launchconfig/schema.go
@@ -61,8 +61,7 @@ type LaunchOptionChoice struct {
 }
 
 type LaunchOptionEnvFallback struct {
-	Name   string `json:"name"`
-	Secret bool   `json:"secret,omitempty"`
+	Name string `json:"name"`
 }
 
 type LaunchOption struct {

--- a/cmd/evener-hub/internal/launchconfig/schema_test.go
+++ b/cmd/evener-hub/internal/launchconfig/schema_test.go
@@ -88,8 +88,8 @@ func checkLaunchOptionSchema_OpenAIResponsesContinuation(t *testing.T) {
 			t.Fatalf("Choices = %+v, want values %v", opt.Choices, wantChoices)
 		}
 	}
-	if opt.EnvFallback == nil || opt.EnvFallback.Name != envvars.EVENEROpenAIResponsesContinuation.Name || opt.EnvFallback.Secret {
-		t.Fatalf("EnvFallback = %+v, want public %s", opt.EnvFallback, envvars.EVENEROpenAIResponsesContinuation.Name)
+	if opt.EnvFallback == nil || opt.EnvFallback.Name != envvars.EVENEROpenAIResponsesContinuation.Name {
+		t.Fatalf("EnvFallback = %+v, want %s", opt.EnvFallback, envvars.EVENEROpenAIResponsesContinuation.Name)
 	}
 }
 

--- a/cmd/evener-hub/navigation_pacing_test.go
+++ b/cmd/evener-hub/navigation_pacing_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -130,5 +131,107 @@ func TestNavigationBoundaryParkShortensToRetryDeadline(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("no park after failed forced refresh")
+	}
+}
+
+// scriptedFailureSource fails exactly the capture calls its script names,
+// making multi-step retry interleavings deterministic without racing on a
+// shared err field.
+type scriptedFailureSource struct {
+	inner navigationSource
+	calls atomic.Int64
+	fail  func(call int64) bool
+}
+
+func (s *scriptedFailureSource) Revision() navigationSourceRevision { return s.inner.Revision() }
+
+func (s *scriptedFailureSource) Capture(ctx context.Context, generation string, now time.Time) (navigationSourceSnapshot, error) {
+	call := s.calls.Add(1)
+	snapshot, err := s.inner.Capture(ctx, generation, now)
+	if err == nil && s.fail(call) {
+		return navigationSourceSnapshot{}, errBoom
+	}
+	return snapshot, err
+}
+
+// A retry-deadline wake is NOT a time-boundary crossing. When the boundary
+// park ends early because a failed forced refresh's retry came due, the loop
+// must retry the pending invalidation as-is — not stamp a spurious
+// navigationChangeHint{Time: true} (and bump the pending epoch) as if the
+// snapshot's time boundary had elapsed.
+func TestNavigationRetryDeadlineWakeDoesNotStampTimeHint(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	source := newTestNavigationSource(base)
+	source.nextBoundary = base.Add(24 * time.Hour)
+	source.captured = make(chan struct{}, 16)
+	// Capture 1 (initial build) succeeds; capture 2 (the forced refresh for
+	// the invalidation) fails and arms the retry deadline; capture 3 (the
+	// scheduler's own rebuild) succeeds so the loop reaches the boundary
+	// park; every later capture (the paced retries) fails.
+	scripted := &scriptedFailureSource{inner: source, fail: func(call int64) bool {
+		return call == 2 || call >= 4
+	}}
+	created := make(chan *fakeNavigationTimer, 16)
+	var clockMu sync.Mutex
+	now := base
+	service := newTestNavigationService(t, source, func(cfg *navigationServiceConfig) {
+		cfg.Source = scripted
+		cfg.RetryAfter = time.Minute
+		cfg.Now = func() time.Time {
+			clockMu.Lock()
+			defer clockMu.Unlock()
+			return now
+		}
+		cfg.NewTimer = func(delay time.Duration) navigationTimer {
+			timer := &fakeNavigationTimer{delay: delay, ch: make(chan time.Time, 1)}
+			created <- timer
+			return timer
+		}
+	})
+	waitCapture := func(label string) {
+		t.Helper()
+		select {
+		case <-source.captured:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for capture: %s", label)
+		}
+	}
+	waitTimer := func(label string) *fakeNavigationTimer {
+		t.Helper()
+		select {
+		case timer := <-created:
+			return timer
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for park: %s", label)
+			return nil
+		}
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go service.Start(ctx)
+	waitCapture("initial build")
+	waitTimer("boundary park")
+	service.Invalidate(navigationChangeHint{Projects: []string{"p1"}})
+	waitCapture("failed forced refresh")
+	waitCapture("scheduler rebuild")
+	retryPark := waitTimer("retry-deadline park")
+	if retryPark.delay != time.Minute {
+		t.Fatalf("retry park delay = %v, want retryAfter (1m)", retryPark.delay)
+	}
+	// The retry deadline comes due — a minute passed, nowhere near the 24h
+	// snapshot boundary — and the park's timer fires.
+	clockMu.Lock()
+	now = base.Add(time.Minute + time.Second)
+	clockMu.Unlock()
+	retryPark.ch <- now
+	waitCapture("paced retry")
+	service.mu.Lock()
+	hint := service.pendingHint
+	service.mu.Unlock()
+	if hint.Time {
+		t.Fatal("retry-deadline wake stamped navigationChangeHint{Time: true}: a failed retry is not a time-boundary crossing")
+	}
+	if len(hint.Projects) != 1 || hint.Projects[0] != "p1" {
+		t.Fatalf("pending hint Projects = %v, want the armed invalidation preserved as [p1]", hint.Projects)
 	}
 }

--- a/cmd/evener-hub/navigation_service.go
+++ b/cmd/evener-hub/navigation_service.go
@@ -1086,11 +1086,7 @@ func (s *NavigationService) Start(ctx context.Context) {
 			if _, keepGoing := s.waitUntil(ctx, s.now().Add(s.retryAfter)); !keepGoing {
 				return
 			}
-			// Same pacing as the boundary path: a failed forced refresh's
-			// next-attempt time governs when refreshPending may try again.
-			if at, _ := s.pendingAttemptAt(); !s.now().Before(at) {
-				s.refreshPending(ctx)
-			}
+			s.refreshPending(ctx)
 			continue
 		}
 		s.mu.Lock()
@@ -1109,32 +1105,24 @@ func (s *NavigationService) Start(ctx context.Context) {
 		// next-attempt time rather than the full snapshot boundary, so the
 		// pending invalidation is attempted again promptly instead of
 		// spinning (immediate wake) or parking for up to 24h (boundary).
-		wait := boundary
+		wait, retryPark := boundary, false
 		if at, pending := s.pendingAttemptAt(); pending && !at.IsZero() && at.Before(wait) {
-			wait = at
+			wait, retryPark = at, true
 		}
 		elapsed, keepGoing := s.waitUntil(ctx, wait)
 		if !keepGoing {
 			return
 		}
-		// elapsed only says the park's own deadline passed, and that deadline
-		// is the EARLIER of the snapshot boundary and the next-attempt time.
-		// Only a genuine boundary crossing is a time invalidation; a
-		// retry-deadline wake retries the already-pending invalidation as-is,
-		// stamping no hint and consuming no epoch.
-		if elapsed && !s.now().Before(boundary) {
+		// Only a park on the snapshot boundary that ran its deadline out is a
+		// time invalidation. A retry-deadline park elapsing retries the
+		// already-pending invalidation as-is, stamping no hint and consuming
+		// no epoch; refreshPending itself declines when nothing is pending or
+		// the next attempt is still paced into the future.
+		if elapsed && !retryPark {
 			s.Invalidate(navigationChangeHint{Time: true})
-			s.refreshPending(ctx)
-		} else if s.hasPendingInvalidation() {
-			s.refreshPending(ctx)
 		}
+		s.refreshPending(ctx)
 	}
-}
-
-func (s *NavigationService) hasPendingInvalidation() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.pendingInvalidation
 }
 
 func (s *NavigationService) refreshPending(ctx context.Context) {

--- a/cmd/evener-hub/navigation_service.go
+++ b/cmd/evener-hub/navigation_service.go
@@ -175,9 +175,10 @@ type NavigationService struct {
 	pendingHint         navigationChangeHint
 	pendingInvalidation bool
 	pendingEpoch        uint64
-	// pendingRetryAt is the earliest time a failed forced refresh of the
-	// pending invalidation may be attempted again. See refreshPending.
-	pendingRetryAt time.Time
+	// nextAttemptAt is the earliest time a failed forced refresh of the
+	// pending invalidation may be attempted again; zero means the next
+	// attempt is not paced. See refreshPending.
+	nextAttemptAt time.Time
 }
 
 func newNavigationService(cfg navigationServiceConfig) *NavigationService {
@@ -250,7 +251,7 @@ func (s *NavigationService) Invalidate(hint navigationChangeHint) {
 	// is a first try for this epoch, not a retry, and must not inherit the
 	// older failure's deadline. (Persistent failure re-arms a fresh deadline
 	// on its own next failure.)
-	s.pendingRetryAt = time.Time{}
+	s.nextAttemptAt = time.Time{}
 	s.mu.Unlock()
 	select {
 	case s.wake <- struct{}{}:
@@ -1082,12 +1083,12 @@ func (s *NavigationService) Start(ctx context.Context) {
 			return
 		}
 		if err != nil {
-			if !s.waitRetryOrWake(ctx) {
+			if _, keepGoing := s.waitUntil(ctx, s.now().Add(s.retryAfter)); !keepGoing {
 				return
 			}
 			// Same pacing as the boundary path: a failed forced refresh's
-			// retry deadline governs when refreshPending may attempt again.
-			if retryWait, pacing := s.pendingRetryWait(); !pacing || retryWait == 0 {
+			// next-attempt time governs when refreshPending may try again.
+			if at, _ := s.pendingAttemptAt(); !s.now().Before(at) {
 				s.refreshPending(ctx)
 			}
 			continue
@@ -1099,26 +1100,29 @@ func (s *NavigationService) Start(ctx context.Context) {
 		}
 		s.mu.Unlock()
 		if boundary.IsZero() {
-			if !s.waitRetryOrWake(ctx) {
+			if _, keepGoing := s.waitUntil(ctx, s.now().Add(s.retryAfter)); !keepGoing {
 				return
 			}
 			continue
 		}
 		// A failed forced refresh paces its retry: park no longer than the
-		// retry deadline rather than the full snapshot boundary, so the
+		// next-attempt time rather than the full snapshot boundary, so the
 		// pending invalidation is attempted again promptly instead of
 		// spinning (immediate wake) or parking for up to 24h (boundary).
 		wait := boundary
-		if retryWait, pacing := s.pendingRetryWait(); pacing && s.hasPendingInvalidation() {
-			if retryWait == 0 || retryWait < boundary.Sub(s.now()) {
-				wait = s.now().Add(retryWait)
-			}
+		if at, pending := s.pendingAttemptAt(); pending && !at.IsZero() && at.Before(wait) {
+			wait = at
 		}
-		elapsed, keepGoing := s.waitBoundaryOrWake(ctx, wait)
+		elapsed, keepGoing := s.waitUntil(ctx, wait)
 		if !keepGoing {
 			return
 		}
-		if elapsed {
+		// elapsed only says the park's own deadline passed, and that deadline
+		// is the EARLIER of the snapshot boundary and the next-attempt time.
+		// Only a genuine boundary crossing is a time invalidation; a
+		// retry-deadline wake retries the already-pending invalidation as-is,
+		// stamping no hint and consuming no epoch.
+		if elapsed && !s.now().Before(boundary) {
 			s.Invalidate(navigationChangeHint{Time: true})
 			s.refreshPending(ctx)
 		} else if s.hasPendingInvalidation() {
@@ -1144,7 +1148,7 @@ func (s *NavigationService) refreshPending(ctx context.Context) {
 	// speed under a persistently failing source. Instead record the earliest
 	// retry time; the Start loop waits until it (bounded by retryAfter)
 	// before attempting the pending invalidation again.
-	if retryAt, armed := s.pendingRetryDeadline(); armed && s.now().Before(retryAt) {
+	if at, pending := s.pendingAttemptAt(); pending && s.now().Before(at) {
 		return
 	}
 	if _, err := s.Refresh(ctx, hint); err != nil {
@@ -1155,7 +1159,7 @@ func (s *NavigationService) refreshPending(ctx context.Context) {
 			// append the Projects slice onto itself (snapshotPendingHint's value
 			// copy shares the backing array), doubling it per failed retry.
 			s.pendingInvalidation = true
-			s.pendingRetryAt = s.now().Add(s.retryAfter)
+			s.nextAttemptAt = s.now().Add(s.retryAfter)
 		}
 		s.mu.Unlock()
 		return
@@ -1168,7 +1172,7 @@ func (s *NavigationService) refreshPending(ctx context.Context) {
 	if s.pendingEpoch == epoch {
 		s.pendingHint = navigationChangeHint{}
 		s.pendingInvalidation = false
-		s.pendingRetryAt = time.Time{}
+		s.nextAttemptAt = time.Time{}
 		navigationPendingCleared()
 	}
 	s.mu.Unlock()
@@ -1180,47 +1184,20 @@ func (s *NavigationService) snapshotPendingHint() (navigationChangeHint, uint64,
 	return s.pendingHint, s.pendingEpoch, s.pendingInvalidation
 }
 
-// pendingRetryDeadline reports the earliest time a failed forced refresh of
-// the pending invalidation may be retried, and whether one is armed at all.
-func (s *NavigationService) pendingRetryDeadline() (time.Time, bool) {
+// pendingAttemptAt reports the earliest time the pending invalidation may be
+// attempted again (zero when the next attempt is not paced) and whether an
+// invalidation is pending at all.
+func (s *NavigationService) pendingAttemptAt() (time.Time, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.pendingRetryAt, s.pendingInvalidation
+	return s.nextAttemptAt, s.pendingInvalidation
 }
 
-// pendingRetryWait returns how long the Start loop should park before the
-// next attempt on the pending invalidation: the retry deadline when one is
-// armed, zero when the retry is already due. ok is false when no failed
-// refresh is pacing a retry (nothing to wait for).
-func (s *NavigationService) pendingRetryWait() (time.Duration, bool) {
-	retryAt, armed := s.pendingRetryDeadline()
-	if !armed || retryAt.IsZero() {
-		return 0, false
-	}
-	delay := retryAt.Sub(s.now())
-	if delay <= 0 {
-		return 0, true
-	}
-	return delay, true
-}
-
-func (s *NavigationService) waitRetryOrWake(ctx context.Context) bool {
-	timer := s.newTimer(s.retryAfter)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return false
-	case <-s.wake:
-		return true
-	case <-timer.C():
-		return true
-	}
-}
-
-func (s *NavigationService) waitBoundaryOrWake(ctx context.Context, boundary time.Time) (elapsed, keepGoing bool) {
-	delay := boundary.Sub(s.now())
-	delay = max(delay, 0)
-	timer := s.newTimer(delay)
+// waitUntil parks until deadline, an invalidation wake, or cancellation.
+// elapsed reports that the deadline itself passed (a wake reports false);
+// keepGoing is false only on cancellation.
+func (s *NavigationService) waitUntil(ctx context.Context, deadline time.Time) (elapsed, keepGoing bool) {
+	timer := s.newTimer(max(deadline.Sub(s.now()), 0))
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():

--- a/internal/appprojector/appwire_projection.go
+++ b/internal/appprojector/appwire_projection.go
@@ -1377,6 +1377,17 @@ func (p *AppEventProjector) notification(method string, params any) AppNotificat
 	// callers all pass a non-empty appwire.Notify* constant; an empty method
 	// would produce an unroutable wire frame.
 	invariant.Hold(method != "", "appprojector: notification with empty method (threadID=%q)", p.threadID)
+	if invariant.Enabled {
+		// The daemon restamps every notification's threadId/ref with its
+		// authoritative fanout target (server.stampAppNotificationTarget), so
+		// params must be either a struct implementing NotificationTargeted or
+		// a map carrying the keys — anything else would ship untargeted.
+		switch params.(type) {
+		case appwire.NotificationTargeted, map[string]any:
+		default:
+			invariant.Hold(false, "appprojector: %s params %T cannot carry a notification target", method, params)
+		}
+	}
 	return AppNotification{ThreadID: p.threadID, Method: method, Params: params}
 }
 

--- a/internal/apptranscript/derived_totals.go
+++ b/internal/apptranscript/derived_totals.go
@@ -49,13 +49,7 @@ func (c *TurnCache) DerivedTotalsFromFile(path string, maxLineBytes int, fromEnt
 	if err != nil {
 		return nil, 0, fmt.Errorf("stat transcript: %w", err)
 	}
-	identity := derivedTotalsKey{
-		size:           info.Size(),
-		modUnixNano:    info.ModTime().UnixNano(),
-		fileIdentity:   fileIdentity(info),
-		changeIdentity: fileChangeIdentity(info),
-		fromOrdinal:    fromEntryOrdinal,
-	}
+	identity := scanMemoIdentity(info, fromEntryOrdinal)
 
 	c.mu.Lock()
 	if entry, ok := c.entries[path]; ok && entry.derivedTotals != nil && entry.derivedTotals.key == identity {
@@ -113,16 +107,7 @@ func scanDerivedTotals(path string, maxLineBytes int, fromEntryOrdinal int) (der
 			accumulated = accumulated.Add(record.Turn.Usage)
 			counted = true
 		}
-		for _, part := range record.Turn.Message.Content {
-			switch {
-			case part.ToolCall != nil && part.Kind == llm.ContentToolCall:
-				toolNames[part.ToolCall.ID] = part.ToolCall.Name
-			case part.ToolResult != nil && part.Kind == llm.ContentToolResult:
-				if counting && failedToolResult(part.ToolResult, toolNames) {
-					totals.failedToolCall++
-				}
-			}
-		}
+		totals.failedToolCall += tallyFailedToolCalls(record.Turn.Message.Content, counting, toolNames)
 		return nil
 	}); err != nil {
 		return derivedTotals{}, err
@@ -136,39 +121,19 @@ func scanDerivedTotals(path string, maxLineBytes int, fromEntryOrdinal int) (der
 }
 
 // derivedTotalsEntry decodes the few fields both figures need: the usage block
-// for the token sum, and the tool calls/results for the failure count.
+// for the token sum (usageOnlyEntry's field), and the tool calls/results for
+// the failure count (failedToolCallEntry's shared toolScanMessage).
 // scanSemanticTranscript has already validated the full record, so this
 // narrow view can ignore the rest rather than paying to decode whole message
 // bodies (including inline image bytes) per line.
 type derivedTotalsEntry struct {
 	Turn struct {
-		Usage   llm.Usage `json:"usage"`
-		Message struct {
-			Content []struct {
-				Kind     llm.ContentKind `json:"kind"`
-				ToolCall *struct {
-					ID   string `json:"id"`
-					Name string `json:"name"`
-				} `json:"tool_call"`
-				ToolResult *failedToolCallResult `json:"tool_result"`
-			} `json:"content"`
-		} `json:"message"`
+		Usage   llm.Usage       `json:"usage"`
+		Message toolScanMessage `json:"message"`
 	} `json:"turn"`
 }
 
-// derivedTotalsKey is the file identity a memoized combined scan is valid for.
-// It mirrors usageTotalKey and failedToolCallsKey exactly (object identity,
-// size, mtime as nanos, platform change time, divergence ordinal) so the
-// combined memo can never outlive the two it consolidates.
-type derivedTotalsKey struct {
-	size           int64
-	modUnixNano    int64
-	fileIdentity   string
-	changeIdentity string
-	fromOrdinal    int
-}
-
 type derivedTotalsMemo struct {
-	key    derivedTotalsKey
+	key    scanMemoKey
 	totals derivedTotals
 }

--- a/internal/apptranscript/derived_totals.go
+++ b/internal/apptranscript/derived_totals.go
@@ -82,8 +82,7 @@ func (c *TurnCache) DerivedTotalsFromFile(path string, maxLineBytes int, fromEnt
 // reader in this package applies.
 func scanDerivedTotals(path string, maxLineBytes int, fromEntryOrdinal int) (derivedTotals, error) {
 	var totals derivedTotals
-	var accumulated llm.Usage
-	counted := false
+	var accumulated usageAccumulator
 	ordinal := 0
 	// toolNames resolves a result whose own record omits its name, mirroring
 	// ProjectTurn's map of the same name. It is filled from EVERY assistant
@@ -103,9 +102,8 @@ func scanDerivedTotals(path string, maxLineBytes int, fromEntryOrdinal int) (der
 			return fmt.Errorf("decode transcript entry derived totals: %w", err)
 		}
 		counting := ordinal >= fromEntryOrdinal
-		if counting && appwire.EvenerUsageFromLLM(record.Turn.Usage) != nil {
-			accumulated = accumulated.Add(record.Turn.Usage)
-			counted = true
+		if counting {
+			accumulated.add(record.Turn.Usage)
 		}
 		totals.failedToolCall += tallyFailedToolCalls(record.Turn.Message.Content, counting, toolNames)
 		return nil
@@ -113,10 +111,7 @@ func scanDerivedTotals(path string, maxLineBytes int, fromEntryOrdinal int) (der
 		return derivedTotals{}, err
 	}
 	observeIndexRead(ReadStats{derivedScans: 1})
-	if !counted {
-		return totals, nil
-	}
-	totals.usage = appwire.EvenerUsageFromLLM(accumulated)
+	totals.usage = accumulated.total()
 	return totals, nil
 }
 

--- a/internal/apptranscript/derived_totals_fuzz_test.go
+++ b/internal/apptranscript/derived_totals_fuzz_test.go
@@ -1,0 +1,103 @@
+package apptranscript
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/llm"
+)
+
+// derivedTotalsSeedTranscript renders a header plus entries into the on-disk
+// transcript shape, for seeding the differential fuzz below with realistic
+// files.
+func derivedTotalsSeedTranscript(f *testing.F, entries []schema.Turn) []byte {
+	f.Helper()
+	records := []any{transcript.Header{Kind: "header", FormatVersion: transcript.FormatVersion, SessionID: "derived"}}
+	for i, turn := range entries {
+		turn.Timestamp = time.Unix(1_700_000_000+int64(i), 0).UTC()
+		records = append(records, transcript.Entry{Kind: "entry", Seq: i + 1, Turn: turn})
+	}
+	var data []byte
+	for _, record := range records {
+		line, err := json.Marshal(record)
+		if err != nil {
+			f.Fatal(err)
+		}
+		data = append(data, line...)
+		data = append(data, '\n')
+	}
+	return data
+}
+
+// FuzzDerivedTotalsMatchesIndividualScans pins DerivedTotalsFromFile to the
+// two scans it consolidates: for ANY file content and any divergence ordinal,
+// the combined single-pass scan must agree with UsageTotalFromFile and
+// FailedToolCallsFromFile — the same usage sum, the same failure count, and
+// an error on exactly the same inputs. This is the drift alarm for
+// derivedTotalsEntry's narrow decode: a field dropped or mistyped there would
+// silently undercount relative to the individual scans, which is precisely
+// the divergence this differential detects.
+func FuzzDerivedTotalsMatchesIndividualScans(f *testing.F) {
+	toolState := func(state map[string]any) json.RawMessage {
+		raw, err := json.Marshal(state)
+		if err != nil {
+			f.Fatal(err)
+		}
+		return raw
+	}
+	full := derivedTotalsSeedTranscript(f, []schema.Turn{
+		{Kind: schema.TurnAssistant, Message: llm.Assistant("first"), Usage: llm.Usage{InputTokens: 100, OutputTokens: 10, TotalTokens: 110}},
+		{Kind: schema.TurnAssistant, Message: llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{
+			{Kind: llm.ContentToolCall, ToolCall: &llm.ToolCallData{ID: "c1", Name: "shell"}},
+		}}},
+		{Kind: schema.TurnToolResults, Message: llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{
+			{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "c1", IsError: true}}, // nameless: resolved from c1's call
+		}}},
+		{Kind: schema.TurnAssistant, Message: llm.Assistant("after failure"), Usage: llm.Usage{InputTokens: 200, OutputTokens: 20, TotalTokens: 220}},
+		{Kind: schema.TurnToolResults, Message: llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{
+			{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "c2", Name: "shell", ToolState: toolState(map[string]any{"exit_code": 1})}},
+		}}},
+		{Kind: schema.TurnToolResults, Message: llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{
+			{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "c3", Name: "shell", ToolState: toolState(map[string]any{"exit_code": 0})}},
+		}}},
+	})
+	f.Add(full, 0)
+	f.Add(full, 3) // a fork child's divergence cut mid-file
+	f.Add(full, 100)
+	f.Add(full, -1)
+	f.Add(derivedTotalsSeedTranscript(f, nil), 0) // header only
+	f.Add(derivedTotalsSeedTranscript(f, []schema.Turn{{Kind: schema.TurnAssistant, Message: llm.Assistant("no usage")}}), 0)
+	f.Add([]byte(nil), 0)          // empty file
+	f.Add([]byte("not json\n"), 0) // rejected by the format gate
+	f.Add([]byte(`{"kind":"header","format_version":1}`+"\n"), 0)
+
+	f.Fuzz(func(t *testing.T, content []byte, fromEntryOrdinal int) {
+		path := filepath.Join(t.TempDir(), "derived.jsonl")
+		if err := os.WriteFile(path, content, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		usage, failures, combinedErr := NewTurnCache().DerivedTotalsFromFile(path, testMaxLineBytes, fromEntryOrdinal)
+		wantUsage, usageErr := NewTurnCache().UsageTotalFromFile(path, testMaxLineBytes, fromEntryOrdinal)
+		wantFailures, failuresErr := NewTurnCache().FailedToolCallsFromFile(path, testMaxLineBytes, fromEntryOrdinal)
+		if (combinedErr != nil) != (usageErr != nil) || (combinedErr != nil) != (failuresErr != nil) {
+			t.Fatalf("error disagreement: combined=%v usage=%v failures=%v", combinedErr, usageErr, failuresErr)
+		}
+		if combinedErr != nil {
+			return
+		}
+		switch {
+		case (usage == nil) != (wantUsage == nil):
+			t.Fatalf("usage presence disagreement: combined=%+v individual=%+v", usage, wantUsage)
+		case usage != nil && *usage != *wantUsage:
+			t.Fatalf("usage disagreement: combined=%+v individual=%+v", *usage, *wantUsage)
+		}
+		if failures != wantFailures {
+			t.Fatalf("failure count disagreement: combined=%d individual=%d", failures, wantFailures)
+		}
+	})
+}

--- a/internal/apptranscript/derived_totals_fuzz_test.go
+++ b/internal/apptranscript/derived_totals_fuzz_test.go
@@ -1,38 +1,13 @@
 package apptranscript
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"primeradiant.com/evener/agent/schema"
-	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/llm"
 )
-
-// derivedTotalsSeedTranscript renders a header plus entries into the on-disk
-// transcript shape, for seeding the differential fuzz below with realistic
-// files.
-func derivedTotalsSeedTranscript(f *testing.F, entries []schema.Turn) []byte {
-	f.Helper()
-	records := []any{transcript.Header{Kind: "header", FormatVersion: transcript.FormatVersion, SessionID: "derived"}}
-	for i, turn := range entries {
-		turn.Timestamp = time.Unix(1_700_000_000+int64(i), 0).UTC()
-		records = append(records, transcript.Entry{Kind: "entry", Seq: i + 1, Turn: turn})
-	}
-	var data []byte
-	for _, record := range records {
-		line, err := json.Marshal(record)
-		if err != nil {
-			f.Fatal(err)
-		}
-		data = append(data, line...)
-		data = append(data, '\n')
-	}
-	return data
-}
 
 // FuzzDerivedTotalsMatchesIndividualScans pins DerivedTotalsFromFile to the
 // two scans it consolidates: for ANY file content and any divergence ordinal,
@@ -43,14 +18,7 @@ func derivedTotalsSeedTranscript(f *testing.F, entries []schema.Turn) []byte {
 // silently undercount relative to the individual scans, which is precisely
 // the divergence this differential detects.
 func FuzzDerivedTotalsMatchesIndividualScans(f *testing.F) {
-	toolState := func(state map[string]any) json.RawMessage {
-		raw, err := json.Marshal(state)
-		if err != nil {
-			f.Fatal(err)
-		}
-		return raw
-	}
-	full := derivedTotalsSeedTranscript(f, []schema.Turn{
+	full := renderDerivedTotalsTranscript(f, []schema.Turn{
 		{Kind: schema.TurnAssistant, Message: llm.Assistant("first"), Usage: llm.Usage{InputTokens: 100, OutputTokens: 10, TotalTokens: 110}},
 		{Kind: schema.TurnAssistant, Message: llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{
 			{Kind: llm.ContentToolCall, ToolCall: &llm.ToolCallData{ID: "c1", Name: "shell"}},
@@ -60,24 +28,28 @@ func FuzzDerivedTotalsMatchesIndividualScans(f *testing.F) {
 		}}},
 		{Kind: schema.TurnAssistant, Message: llm.Assistant("after failure"), Usage: llm.Usage{InputTokens: 200, OutputTokens: 20, TotalTokens: 220}},
 		{Kind: schema.TurnToolResults, Message: llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{
-			{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "c2", Name: "shell", ToolState: toolState(map[string]any{"exit_code": 1})}},
+			{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "c2", Name: "shell", ToolState: marshalDerivedTotalsToolState(f, map[string]any{"exit_code": 1})}},
 		}}},
 		{Kind: schema.TurnToolResults, Message: llm.Message{Role: llm.RoleTool, Content: []llm.ContentPart{
-			{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "c3", Name: "shell", ToolState: toolState(map[string]any{"exit_code": 0})}},
+			{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "c3", Name: "shell", ToolState: marshalDerivedTotalsToolState(f, map[string]any{"exit_code": 0})}},
 		}}},
 	})
 	f.Add(full, 0)
 	f.Add(full, 3) // a fork child's divergence cut mid-file
 	f.Add(full, 100)
 	f.Add(full, -1)
-	f.Add(derivedTotalsSeedTranscript(f, nil), 0) // header only
-	f.Add(derivedTotalsSeedTranscript(f, []schema.Turn{{Kind: schema.TurnAssistant, Message: llm.Assistant("no usage")}}), 0)
+	f.Add(renderDerivedTotalsTranscript(f, nil), 0) // header only
+	f.Add(renderDerivedTotalsTranscript(f, []schema.Turn{{Kind: schema.TurnAssistant, Message: llm.Assistant("no usage")}}), 0)
 	f.Add([]byte(nil), 0)          // empty file
 	f.Add([]byte("not json\n"), 0) // rejected by the format gate
 	f.Add([]byte(`{"kind":"header","format_version":1}`+"\n"), 0)
 
+	// One directory and one path for the whole campaign: os.WriteFile
+	// truncates, execs within a worker are sequential, and every scan below
+	// uses a fresh TurnCache, so nothing can memo-hit across iterations. A
+	// per-exec t.TempDir would spend a mkdir+RemoveAll per input for nothing.
+	path := filepath.Join(f.TempDir(), "derived.jsonl")
 	f.Fuzz(func(t *testing.T, content []byte, fromEntryOrdinal int) {
-		path := filepath.Join(t.TempDir(), "derived.jsonl")
 		if err := os.WriteFile(path, content, 0o600); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/apptranscript/derived_totals_test.go
+++ b/internal/apptranscript/derived_totals_test.go
@@ -19,8 +19,16 @@ func filepathJoinDerivedTotals(t testing.TB, name string) string {
 	return filepath.Join(t.TempDir(), name)
 }
 
-func writeDerivedTotalsLines(t testing.TB, path string, records []any) {
+// renderDerivedTotalsTranscript renders a header plus entries into the
+// on-disk transcript bytes. writeDerivedTotalsTranscript writes them to a
+// file; the differential fuzz seeds them directly.
+func renderDerivedTotalsTranscript(t testing.TB, entries []schema.Turn) []byte {
 	t.Helper()
+	records := []any{transcript.Header{Kind: "header", FormatVersion: transcript.FormatVersion, SessionID: "derived"}}
+	for i, turn := range entries {
+		turn.Timestamp = time.Unix(1_700_000_000+int64(i), 0).UTC()
+		records = append(records, transcript.Entry{Kind: "entry", Seq: i + 1, Turn: turn})
+	}
 	var data []byte
 	for _, record := range records {
 		line, err := json.Marshal(record)
@@ -30,9 +38,7 @@ func writeDerivedTotalsLines(t testing.TB, path string, records []any) {
 		data = append(data, line...)
 		data = append(data, '\n')
 	}
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		t.Fatal(err)
-	}
+	return data
 }
 
 func marshalDerivedTotalsToolState(t testing.TB, state map[string]any) json.RawMessage {
@@ -50,12 +56,9 @@ func marshalDerivedTotalsToolState(t testing.TB, state map[string]any) json.RawM
 func writeDerivedTotalsTranscript(t testing.TB, entries []schema.Turn) string {
 	t.Helper()
 	path := filepathJoinDerivedTotals(t, "derived.transcript.jsonl")
-	records := []any{transcript.Header{Kind: "header", FormatVersion: transcript.FormatVersion, SessionID: "derived"}}
-	for i, turn := range entries {
-		turn.Timestamp = time.Unix(1_700_000_000+int64(i), 0).UTC()
-		records = append(records, transcript.Entry{Kind: "entry", Seq: i + 1, Turn: turn})
+	if err := os.WriteFile(path, renderDerivedTotalsTranscript(t, entries), 0o600); err != nil {
+		t.Fatal(err)
 	}
-	writeDerivedTotalsLines(t, path, records)
 	return path
 }
 

--- a/internal/apptranscript/failed_tool_calls.go
+++ b/internal/apptranscript/failed_tool_calls.go
@@ -57,13 +57,7 @@ func (c *TurnCache) FailedToolCallsFromFile(path string, maxLineBytes int, fromE
 	if err != nil {
 		return 0, fmt.Errorf("stat transcript: %w", err)
 	}
-	identity := failedToolCallsKey{
-		size:           info.Size(),
-		modUnixNano:    info.ModTime().UnixNano(),
-		fileIdentity:   fileIdentity(info),
-		changeIdentity: fileChangeIdentity(info),
-		fromOrdinal:    fromEntryOrdinal,
-	}
+	identity := scanMemoIdentity(info, fromEntryOrdinal)
 
 	c.mu.Lock()
 	if entry, ok := c.entries[path]; ok && entry.failedToolCalls != nil && entry.failedToolCalls.key == identity {
@@ -113,17 +107,7 @@ func scanFailedToolCalls(path string, maxLineBytes int, fromEntryOrdinal int) (i
 			// reporting none, so surface it.
 			return fmt.Errorf("decode transcript entry tool calls: %w", err)
 		}
-		counting := ordinal >= fromEntryOrdinal
-		for _, part := range record.Turn.Message.Content {
-			switch {
-			case part.ToolCall != nil && part.Kind == llm.ContentToolCall:
-				toolNames[part.ToolCall.ID] = part.ToolCall.Name
-			case part.ToolResult != nil && part.Kind == llm.ContentToolResult:
-				if counting && failedToolResult(part.ToolResult, toolNames) {
-					count++
-				}
-			}
-		}
+		count += tallyFailedToolCalls(record.Turn.Message.Content, ordinal >= fromEntryOrdinal, toolNames)
 		return nil
 	}); err != nil {
 		return 0, err
@@ -145,6 +129,26 @@ func failedToolResult(result *failedToolCallResult, toolNames map[string]string)
 	return transcript.FailedToolResult(name, result.IsError, result.ToolState)
 }
 
+// tallyFailedToolCalls applies the failure rule to one entry's narrow content
+// decode: it learns tool names from EVERY call — a fork child's own result can
+// answer a call the inherited prefix announced — and, when counting, counts
+// the failing results. Shared by scanFailedToolCalls and scanDerivedTotals so
+// the two scans apply one rule.
+func tallyFailedToolCalls(parts []toolScanPart, counting bool, toolNames map[string]string) int {
+	count := 0
+	for _, part := range parts {
+		switch {
+		case part.ToolCall != nil && part.Kind == llm.ContentToolCall:
+			toolNames[part.ToolCall.ID] = part.ToolCall.Name
+		case part.ToolResult != nil && part.Kind == llm.ContentToolResult:
+			if counting && failedToolResult(part.ToolResult, toolNames) {
+				count++
+			}
+		}
+	}
+	return count
+}
+
 // failedToolCallEntry decodes the few fields the count needs.
 // scanSemanticTranscript has already validated the full record, so this narrow
 // view can ignore the rest rather than paying to decode whole message bodies
@@ -155,17 +159,25 @@ type failedToolCallEntry struct {
 		// Tool calls and tool results only ever appear on the assistant and
 		// tool-result kinds, so matching on the part itself is both narrower
 		// and immune to a new turn kind that carries them.
-		Message struct {
-			Content []struct {
-				Kind     llm.ContentKind `json:"kind"`
-				ToolCall *struct {
-					ID   string `json:"id"`
-					Name string `json:"name"`
-				} `json:"tool_call"`
-				ToolResult *failedToolCallResult `json:"tool_result"`
-			} `json:"content"`
-		} `json:"message"`
+		Message toolScanMessage `json:"message"`
 	} `json:"turn"`
+}
+
+// toolScanMessage is the narrow message decode the failure rule needs: only
+// the content parts that carry tool calls and tool results. It is shared by
+// failedToolCallEntry and derivedTotalsEntry so the two scans decode the same
+// field-for-field subset of schema.Turn and cannot drift apart.
+type toolScanMessage struct {
+	Content []toolScanPart `json:"content"`
+}
+
+type toolScanPart struct {
+	Kind     llm.ContentKind `json:"kind"`
+	ToolCall *struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"tool_call"`
+	ToolResult *failedToolCallResult `json:"tool_result"`
 }
 
 type failedToolCallResult struct {
@@ -175,20 +187,7 @@ type failedToolCallResult struct {
 	ToolState  json.RawMessage `json:"tool_state"`
 }
 
-// failedToolCallsKey is the file identity a memoized count is valid for. It
-// mirrors usageTotalKey exactly, for the same reasons: object identity, size,
-// mtime (as nanos, so the key stays comparable with ==) and platform change
-// time, plus the divergence ordinal, since two ordinals over one file are two
-// different answers.
-type failedToolCallsKey struct {
-	size           int64
-	modUnixNano    int64
-	fileIdentity   string
-	changeIdentity string
-	fromOrdinal    int
-}
-
 type failedToolCallsMemo struct {
-	key   failedToolCallsKey
+	key   scanMemoKey
 	count int
 }

--- a/internal/apptranscript/turn_cache.go
+++ b/internal/apptranscript/turn_cache.go
@@ -56,6 +56,34 @@ func NewTurnCache() *TurnCache {
 	return &TurnCache{entries: map[string]turnCacheEntry{}, max: defaultTurnCacheSize}
 }
 
+// scanMemoKey is the file identity a memoized full-transcript scan (the usage
+// total, the failed-tool-call count, or the combined derived totals) is valid
+// for. It mirrors the turn cache's own parse-validity gate (object identity,
+// size, mtime, platform change time) and adds the divergence ordinal, since
+// two ordinals over one file are two different answers. mtime is held as nanos
+// so the key stays comparable with == (a time.Time compares its
+// monotonic/location fields too, which would spuriously miss).
+type scanMemoKey struct {
+	size           int64
+	modUnixNano    int64
+	fileIdentity   string
+	changeIdentity string
+	fromOrdinal    int
+}
+
+// scanMemoIdentity builds the scanMemoKey for one stat result and divergence
+// ordinal. All three full-transcript scan memos key on exactly this, so the
+// combined memo can never outlive the two it consolidates.
+func scanMemoIdentity(info os.FileInfo, fromEntryOrdinal int) scanMemoKey {
+	return scanMemoKey{
+		size:           info.Size(),
+		modUnixNano:    info.ModTime().UnixNano(),
+		fileIdentity:   fileIdentity(info),
+		changeIdentity: fileChangeIdentity(info),
+		fromOrdinal:    fromEntryOrdinal,
+	}
+}
+
 // TurnsFromFile returns the cached turns for path when its size and modtime
 // match the cached entry, otherwise parses via the package TurnsFromFile and
 // caches the result.

--- a/internal/apptranscript/usage_total.go
+++ b/internal/apptranscript/usage_total.go
@@ -70,8 +70,7 @@ func (c *TurnCache) UsageTotalFromFile(path string, maxLineBytes int, fromEntryO
 // unknown-field strictness, header validation) is exactly the one every other
 // reader in this package applies.
 func scanUsageTotal(path string, maxLineBytes int, fromEntryOrdinal int) (*appwire.EvenerUsage, error) {
-	var accumulated llm.Usage
-	counted := false
+	var accumulated usageAccumulator
 	ordinal := 0
 	if _, err := scanSemanticTranscript(path, maxLineBytes, func(raw json.RawMessage) error {
 		ordinal++
@@ -88,20 +87,37 @@ func scanUsageTotal(path string, maxLineBytes int, fromEntryOrdinal int) (*appwi
 			// worse than reporting none, so surface it.
 			return fmt.Errorf("decode transcript entry usage: %w", err)
 		}
-		if appwire.EvenerUsageFromLLM(record.Turn.Usage) == nil {
-			return nil
-		}
-		accumulated = accumulated.Add(record.Turn.Usage)
-		counted = true
+		accumulated.add(record.Turn.Usage)
 		return nil
 	}); err != nil {
 		return nil, err
 	}
 	observeIndexRead(ReadStats{usageScans: 1})
-	if !counted {
-		return nil, nil
+	return accumulated.total(), nil
+}
+
+// usageAccumulator applies the token-sum rule shared by scanUsageTotal and
+// scanDerivedTotals: only entries carrying real token data count, and a span
+// that carried none totals to nil rather than a fabricated zero (absent and
+// zero are different claims — see UsageTotalFromFile).
+type usageAccumulator struct {
+	sum     llm.Usage
+	counted bool
+}
+
+func (a *usageAccumulator) add(usage llm.Usage) {
+	if appwire.EvenerUsageFromLLM(usage) == nil {
+		return
 	}
-	return appwire.EvenerUsageFromLLM(accumulated), nil
+	a.sum = a.sum.Add(usage)
+	a.counted = true
+}
+
+func (a *usageAccumulator) total() *appwire.EvenerUsage {
+	if !a.counted {
+		return nil
+	}
+	return appwire.EvenerUsageFromLLM(a.sum)
 }
 
 // usageOnlyEntry decodes the one field the sum needs. scanSemanticTranscript has

--- a/internal/apptranscript/usage_total.go
+++ b/internal/apptranscript/usage_total.go
@@ -39,13 +39,7 @@ func (c *TurnCache) UsageTotalFromFile(path string, maxLineBytes int, fromEntryO
 	if err != nil {
 		return nil, fmt.Errorf("stat transcript: %w", err)
 	}
-	identity := usageTotalKey{
-		size:           info.Size(),
-		modUnixNano:    info.ModTime().UnixNano(),
-		fileIdentity:   fileIdentity(info),
-		changeIdentity: fileChangeIdentity(info),
-		fromOrdinal:    fromEntryOrdinal,
-	}
+	identity := scanMemoIdentity(info, fromEntryOrdinal)
 
 	c.mu.Lock()
 	if entry, ok := c.entries[path]; ok && entry.usageTotal != nil && entry.usageTotal.key == identity {
@@ -119,22 +113,8 @@ type usageOnlyEntry struct {
 	} `json:"turn"`
 }
 
-// usageTotalKey is the file identity a memoized sum is valid for. It mirrors
-// the turn cache's own parse-validity gate (object identity, size, mtime,
-// platform change time) and adds the divergence ordinal, since two ordinals
-// over one file are two different answers. mtime is held as nanos so the key
-// stays comparable with == (a time.Time compares its monotonic/location fields
-// too, which would spuriously miss).
-type usageTotalKey struct {
-	size           int64
-	modUnixNano    int64
-	fileIdentity   string
-	changeIdentity string
-	fromOrdinal    int
-}
-
 type usageTotalMemo struct {
-	key   usageTotalKey
+	key   scanMemoKey
 	total *appwire.EvenerUsage
 }
 

--- a/scripts/fuzz/fuzz-targets.txt
+++ b/scripts/fuzz/fuzz-targets.txt
@@ -188,6 +188,7 @@ native:.:./server:FuzzAppTurnsFromNotifications
 native:.:./internal/appserver:FuzzHandleMessage
 native:.:./internal/appprojector:FuzzProject
 native:.:./internal/apptranscript:FuzzProjectTurn
+native:.:./internal/apptranscript:FuzzDerivedTotalsMatchesIndividualScans
 native:.:./cmd/evener-hub/internal/appsource:FuzzMapCodexTurn
 native:.:./cmd/evener-hub/internal/appsource:FuzzAppSourceProgram
 native:.:./cmd/evener-hub/internal/codexlaunch:FuzzParseCodexEndpoint

--- a/server/appwire_rejoin_test.go
+++ b/server/appwire_rejoin_test.go
@@ -40,14 +40,12 @@ func TestAtomicProjectionCommitPreservesProducerOrderAcrossSequenceAllocation(t 
 	release := make(chan struct{})
 	var once sync.Once
 	setEnvelope(srv, func(e *stubThreadEnvelopeSource) { e.failuresMeasured = true })
-	srv.mu.Lock()
-	srv.insideAppProjectionCommit = func() {
+	setInsideAppProjectionCommitHook(t, func() {
 		once.Do(func() {
 			close(projected)
 			<-release
 		})
-	}
-	srv.mu.Unlock()
+	})
 
 	completed := make(chan struct{})
 	go func() {

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -745,7 +745,7 @@ func stampAppNotificationTarget(params any, threadID, ref string) any {
 		// Copy rather than mutate: the caller's map must stay untouched so a
 		// future multi-target fanout of one params value cannot make every
 		// notification share the last target stamped.
-		out := make(map[string]any, len(p)+2)
+		out := make(map[string]any, len(p))
 		maps.Copy(out, p)
 		out["threadId"] = threadID
 		out["ref"] = ref

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -741,9 +742,14 @@ func stampAppNotificationTarget(params any, threadID, ref string) any {
 	case appwire.NotificationTargeted:
 		return p.WithNotificationTarget(threadID, ref)
 	case map[string]any:
-		p["threadId"] = threadID
-		p["ref"] = ref
-		return p
+		// Copy rather than mutate: the caller's map must stay untouched so a
+		// future multi-target fanout of one params value cannot make every
+		// notification share the last target stamped.
+		out := make(map[string]any, len(p)+2)
+		maps.Copy(out, p)
+		out["threadId"] = threadID
+		out["ref"] = ref
+		return out
 	default:
 		return params
 	}

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -302,6 +302,13 @@ func (s *Server) appNotificationTarget(threadID string) string {
 	return threadID
 }
 
+// insideAppProjectionCommitHook, when non-nil, runs inside RecordAppEvent's
+// commit callback, i.e. while the projection gate is held. It is a test seam:
+// production never assigns it, so the commit path pays one nil check on a
+// package-level word instead of the s.mu.RLock a per-server field would need
+// on every projected event.
+var insideAppProjectionCommitHook func()
+
 func (s *Server) RecordAppEvent(event events.SessionEvent) {
 	s.mu.RLock()
 	beforeCommit := s.beforeAppProjectionCommit
@@ -314,13 +321,10 @@ func (s *Server) RecordAppEvent(event events.SessionEvent) {
 		// held. beforeAppProjectionCommit above cannot serve that purpose: it
 		// runs before CommitProjection takes the gate, so a goroutine parked
 		// there holds nothing and any ordering it appears to establish is a
-		// coin toss. Deliberately called without s.mu, so a parked commit
+		// coin toss. Deliberately consulted without s.mu, so a parked commit
 		// blocks a concurrent one on the projection gate rather than on s.mu.
-		s.mu.RLock()
-		insideCommit := s.insideAppProjectionCommit
-		s.mu.RUnlock()
-		if insideCommit != nil {
-			insideCommit()
+		if insideAppProjectionCommitHook != nil {
+			insideAppProjectionCommitHook()
 		}
 		s.mu.Lock()
 		if !s.acceptsSessionEventLocked(event.SessionID) {

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -730,24 +730,23 @@ func (s *Server) applyTaskCarrierLocked(threadID string, params appwire.TaskUpda
 	}
 }
 
+// stampAppNotificationTarget re-addresses params to the fanout target the
+// server is committing them under. The projector already stamps its own view
+// of threadId/ref; the server overwrites both with the authoritative target
+// (ref remapping, descendant fanout). Params are either structs implementing
+// appwire.NotificationTargeted or map[string]any carrying threadId/ref keys;
+// anything else passes through untouched.
 func stampAppNotificationTarget(params any, threadID, ref string) any {
-	data, err := json.Marshal(params)
-	if err != nil {
+	switch p := params.(type) {
+	case appwire.NotificationTargeted:
+		return p.WithNotificationTarget(threadID, ref)
+	case map[string]any:
+		p["threadId"] = threadID
+		p["ref"] = ref
+		return p
+	default:
 		return params
 	}
-	fields := map[string]json.RawMessage{}
-	if len(data) > 0 && string(data) != "null" {
-		if err := json.Unmarshal(data, &fields); err != nil {
-			return params
-		}
-	}
-	fields["threadId"], _ = json.Marshal(threadID)
-	fields["ref"], _ = json.Marshal(ref)
-	qualified, err := json.Marshal(fields)
-	if err != nil {
-		return params
-	}
-	return json.RawMessage(qualified)
 }
 
 // stampFailureCountOnStatusChange rides the session's running failure count

--- a/server/appwire_runtime_gaps_test.go
+++ b/server/appwire_runtime_gaps_test.go
@@ -43,6 +43,9 @@ func TestStampAppNotificationTargetWithMap(t *testing.T) {
 	if stamped["message"] != "boom" {
 		t.Fatalf("message = %v, want the original payload preserved", stamped["message"])
 	}
+	if params["threadId"] != "old-id" || params["ref"] != "old-ref" {
+		t.Fatalf("caller's map = (%v, %v), want it left unmutated", params["threadId"], params["ref"])
+	}
 }
 
 // TestStampAppNotificationTargetPassesThroughUnknownParams pins the fallback:

--- a/server/appwire_runtime_gaps_test.go
+++ b/server/appwire_runtime_gaps_test.go
@@ -1,77 +1,59 @@
 package server
 
 import (
-	"encoding/json"
 	"testing"
 
 	"primeradiant.com/evener/appwire"
 )
 
-// TestStampAppNotificationTargetWithStruct covers the happy path where params
-// is a struct that can be marshaled and have fields added.
+// TestStampAppNotificationTargetWithStruct covers the happy path: a
+// projector-produced params struct is restamped in place of its own view of
+// the target, and the concrete type survives the trip (no JSON round trip).
 func TestStampAppNotificationTargetWithStruct(t *testing.T) {
-	params := appwire.ThreadStatusChangedParams{ThreadID: "old-id"}
+	params := appwire.ThreadStatusChangedParams{ThreadID: "old-id", Ref: "old-ref", Status: appwire.ThreadStatus{Type: appwire.ThreadStatusActive}}
 	got := stampAppNotificationTarget(params, "thread-1", "local:thread-1")
-	raw, ok := got.(json.RawMessage)
+	stamped, ok := got.(appwire.ThreadStatusChangedParams)
 	if !ok {
-		t.Fatalf("got type = %T, want json.RawMessage", got)
+		t.Fatalf("got type = %T, want appwire.ThreadStatusChangedParams", got)
 	}
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &fields); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+	if stamped.ThreadID != "thread-1" || stamped.Ref != "local:thread-1" {
+		t.Fatalf("target = (%q, %q), want (thread-1, local:thread-1)", stamped.ThreadID, stamped.Ref)
 	}
-	if tid, _ := json.Marshal("thread-1"); string(fields["threadId"]) != string(tid) {
-		t.Fatalf("threadId = %q, want %q", fields["threadId"], tid)
+	if stamped.Status.Type != appwire.ThreadStatusActive {
+		t.Fatalf("status = %q, want the original payload preserved", stamped.Status.Type)
 	}
-	if ref, _ := json.Marshal("local:thread-1"); string(fields["ref"]) != string(ref) {
-		t.Fatalf("ref = %q, want %q", fields["ref"], ref)
+	if params.ThreadID != "old-id" {
+		t.Fatal("the caller's params value must not be mutated")
 	}
 }
 
-// TestStampAppNotificationTargetWithNil covers the nil-params path.
-func TestStampAppNotificationTargetWithNil(t *testing.T) {
-	got := stampAppNotificationTarget(nil, "thread-1", "ref-1")
-	// nil marshals to "null", which is not "null" string check — it's the
-	// bytes "null". The function checks `string(data) != "null"`, so nil
-	// params skip the Unmarshal but still add threadId and ref fields.
-	raw, ok := got.(json.RawMessage)
+// TestStampAppNotificationTargetWithMap covers the projector's map-shaped
+// params (warning, turn/completed, thread/closed, steering): the server's
+// target overwrites the projector's own threadId/ref keys.
+func TestStampAppNotificationTargetWithMap(t *testing.T) {
+	params := map[string]any{"threadId": "old-id", "ref": "old-ref", "message": "boom"}
+	got := stampAppNotificationTarget(params, "thread-1", "local:thread-1")
+	stamped, ok := got.(map[string]any)
 	if !ok {
-		t.Fatalf("got type = %T, want json.RawMessage", got)
+		t.Fatalf("got type = %T, want map[string]any", got)
 	}
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &fields); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+	if stamped["threadId"] != "thread-1" || stamped["ref"] != "local:thread-1" {
+		t.Fatalf("target = (%v, %v), want (thread-1, local:thread-1)", stamped["threadId"], stamped["ref"])
 	}
-	if _, ok := fields["threadId"]; !ok {
-		t.Fatal("threadId should be present")
+	if stamped["message"] != "boom" {
+		t.Fatalf("message = %v, want the original payload preserved", stamped["message"])
 	}
 }
 
-// TestStampAppNotificationTargetWithEmptyParams covers the path where params
-// is an empty struct (marshals to "{}").
-func TestStampAppNotificationTargetWithEmptyParams(t *testing.T) {
-	got := stampAppNotificationTarget(struct{}{}, "thread-1", "ref-1")
-	raw, ok := got.(json.RawMessage)
-	if !ok {
-		t.Fatalf("got type = %T, want json.RawMessage", got)
+// TestStampAppNotificationTargetPassesThroughUnknownParams pins the fallback:
+// params that neither implement appwire.NotificationTargeted nor are maps
+// (nil included) pass through untouched rather than being force-stamped.
+func TestStampAppNotificationTargetPassesThroughUnknownParams(t *testing.T) {
+	if got := stampAppNotificationTarget(nil, "thread-1", "ref-1"); got != nil {
+		t.Fatalf("nil params = %v, want nil pass-through", got)
 	}
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &fields); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if _, ok := fields["threadId"]; !ok {
-		t.Fatal("threadId should be present")
-	}
-}
-
-// TestStampAppNotificationTargetMarshalError covers the marshal-error path by
-// passing a channel (which cannot be marshaled to JSON).
-func TestStampAppNotificationTargetMarshalError(t *testing.T) {
-	ch := make(chan int)
-	got := stampAppNotificationTarget(ch, "thread-1", "ref-1")
-	// Should return the original value since Marshal fails.
-	if got == nil {
-		t.Fatal("should return original value, not nil")
+	if got := stampAppNotificationTarget(struct{}{}, "thread-1", "ref-1"); got != struct{}{} {
+		t.Fatalf("unknown params = %v, want unchanged pass-through", got)
 	}
 }
 

--- a/server/appwire_runtime_hooks_test.go
+++ b/server/appwire_runtime_hooks_test.go
@@ -1,0 +1,13 @@
+package server
+
+import "testing"
+
+// setInsideAppProjectionCommitHook installs fn as the package-wide
+// inside-commit hook (see insideAppProjectionCommitHook) for the duration of
+// the test. Callers must join every goroutine that can commit before the test
+// returns, so the cleanup's reset cannot race a live commit.
+func setInsideAppProjectionCommitHook(t *testing.T, fn func()) {
+	t.Helper()
+	insideAppProjectionCommitHook = fn
+	t.Cleanup(func() { insideAppProjectionCommitHook = nil })
+}

--- a/server/appwire_runtime_hooks_test.go
+++ b/server/appwire_runtime_hooks_test.go
@@ -4,8 +4,10 @@ import "testing"
 
 // setInsideAppProjectionCommitHook installs fn as the package-wide
 // inside-commit hook (see insideAppProjectionCommitHook) for the duration of
-// the test. Callers must join every goroutine that can commit before the test
-// returns, so the cleanup's reset cannot race a live commit.
+// the test. The hook is one unsynchronized package variable, so a caller MUST
+// NOT be a parallel test (two parallel installers would race each other and
+// every committing goroutine), and it must join every goroutine that can
+// commit before returning, so the cleanup's reset cannot race a live commit.
 func setInsideAppProjectionCommitHook(t *testing.T, fn func()) {
 	t.Helper()
 	insideAppProjectionCommitHook = fn

--- a/server/appwire_server_test.go
+++ b/server/appwire_server_test.go
@@ -1179,14 +1179,12 @@ func TestServerAppWireTaskAndGoalUpdatesHaveOneOrderForEveryClient(t *testing.T)
 	insideCommit := make(chan struct{})
 	release := make(chan struct{})
 	var parked sync.Once
-	srv.mu.Lock()
-	srv.insideAppProjectionCommit = func() {
+	setInsideAppProjectionCommitHook(t, func() {
 		parked.Do(func() {
 			close(insideCommit)
 			<-release
 		})
-	}
-	srv.mu.Unlock()
+	})
 
 	taskDone := make(chan struct{})
 	go func() {

--- a/server/appwire_turns_paging_test.go
+++ b/server/appwire_turns_paging_test.go
@@ -691,14 +691,12 @@ func TestAppTurnSnapshotReducesInProducerOrderUnderConcurrentEvents(t *testing.T
 	release := make(chan struct{})
 	var stamped sync.Once
 	setEnvelope(srv, func(e *stubThreadEnvelopeSource) { e.failuresMeasured = true })
-	srv.mu.Lock()
-	srv.insideAppProjectionCommit = func() {
+	setInsideAppProjectionCommitHook(t, func() {
 		stamped.Do(func() {
 			close(insideCommit)
 			<-release
 		})
-	}
-	srv.mu.Unlock()
+	})
 
 	firstDone := make(chan struct{})
 	go func() {

--- a/server/server.go
+++ b/server/server.go
@@ -331,10 +331,6 @@ type Server struct {
 	appEnvelopeSource         ThreadEnvelopeSource
 	appReservedTurnID         string
 	beforeAppProjectionCommit func()
-	// insideAppProjectionCommit is a test seam invoked from within
-	// RecordAppEvent's commit callback, i.e. while the projection gate is held.
-	// Production leaves it nil.
-	insideAppProjectionCommit func()
 	// appLastStampedFailedToolCalls is the failure count most recently
 	// stamped onto an item/completed notification (kata 895d) — nil means
 	// nothing has been stamped yet for the current identity. It exists so

--- a/server/thread_envelope_test.go
+++ b/server/thread_envelope_test.go
@@ -643,7 +643,7 @@ func TestEnvelopeCommittedBeforeTheCutIsInTheResponse(t *testing.T) {
 // TestEnvelopeCommittedBeforeTheCutIsInTheResponse looks like this pin and is
 // not: feedBridge returns only after the whole bridge pass, so it pins "refresh
 // before the reader's gate", which the inverted order still satisfies. This one
-// observes from INSIDE the commit, through the insideAppProjectionCommit seam,
+// observes from INSIDE the commit, through the insideAppProjectionCommitHook,
 // where the difference is the whole question. No parking and no second
 // goroutine: the commit runs on feedBridge's own.
 //
@@ -655,8 +655,7 @@ func TestEnvelopeLeadsTheCommitThatAnnouncesIt(t *testing.T) {
 
 	var atCommit *int
 	var sawCommit bool
-	srv.mu.Lock()
-	srv.insideAppProjectionCommit = func() {
+	setInsideAppProjectionCommitHook(t, func() {
 		sawCommit = true
 		srv.mu.RLock()
 		if srv.appEnvelope.FailedToolCalls != nil {
@@ -664,8 +663,7 @@ func TestEnvelopeLeadsTheCommitThatAnnouncesIt(t *testing.T) {
 			atCommit = &v
 		}
 		srv.mu.RUnlock()
-	}
-	srv.mu.Unlock()
+	})
 
 	// A tool call fails: the session writes its count, then emits the event
 	// announcing it. That is the production ordering the bridge samples under.


### PR DESCRIPTION
Five independent cleanups from the 2026-08-30 audit (over-engineering table + Minors 5 and 7). Each item is its own commit, with small follow-up commits from the post-commit reviews and a /simplify pass, so the items can be reviewed independently.

## Checklist: audit items → commits

- [x] **1. Delete dead `LaunchOptionEnvFallback.Secret`** — `3a038fa2e`
  Nothing in the tree ever set it to `true`; the guard skipping secret env fallbacks in `ApplyEnvDefaults` was dead. Removes the field from the launchconfig schema, the appwire wire type, and the generated frontend types (`make generate` re-run).
- [x] **2. Test seams off the hot path** — `89c3bc9a8` (+ docs follow-up `14c75b362`)
  `Server.insideAppProjectionCommit` cost an `s.mu.RLock/RUnlock` on every projected session event to read a hook that is nil in production; `TaskStore.beforeMutationPublicationWait` was a per-instance func field with one test caller. Both are now package-level test hooks (stdlib `testHookServerServe` pattern): production never assigns them, the commit path pays one nil check on an immutable word, and neither production struct carries a test seam. The follow-up documents the no-parallel/join-your-goroutines contract the hooks require.
- [x] **3. `stampAppNotificationTarget` double JSON round trip** — `52520736a` (+ follow-ups `298425684`, `1b88d17a3`)
  Was `json.Marshal` → `map[string]json.RawMessage` → `json.Marshal` per notification per fanout target. Every params struct the projector emits now implements `appwire.NotificationTargeted` (value-receiver `WithNotificationTarget`); the projector's map-shaped params get their `threadId`/`ref` keys stamped onto a copy. An `evenerfuzz`-build invariant in `appprojector.notification()` pins that every emitted params shape can carry a target, and `TestThreadNotificationsRequireAuthoritativeRoutingIdentity` now requires every thread-scoped catalog payload to implement the interface, so a new payload type cannot land without the method.
- [x] **4. Navigation retry pacing consolidation + Minor 5 fix** — `fb6b59b39` (+ simplify follow-up `7febd3a3e`)
  TDD: `TestNavigationRetryDeadlineWakeDoesNotStampTimeHint` written first (fails on main — every paced retry stamped a spurious `navigationChangeHint{Time: true}` and bumped `pendingEpoch`). The Start loop now invalidates for time only when the snapshot boundary itself has passed. Pacing state consolidated per the audit: one `nextAttemptAt time.Time` + one `pendingAttemptAt()` accessor + one `waitUntil` park helper replace `pendingRetryAt`/`pendingRetryDeadline()`/`pendingRetryWait()`/`waitRetryOrWake`/`waitBoundaryOrWake`; the follow-up lets `refreshPending` own the whole admission policy and carries the boundary-vs-retry decision on the branch that chose the park deadline.
- [x] **5. Minor 7 — `scanDerivedTotals` duplication + fuzzed differential** — `e2bc8fd8d` (+ simplify follow-up `6dc7e137d`)
  The failure tally now runs through one shared `tallyFailedToolCalls` over one shared `toolScanMessage` narrow decode (used by both `scanFailedToolCalls` and `scanDerivedTotals`), and the three identical memo-key structs collapse into one `scanMemoKey`; the follow-up gives the usage half the same treatment (`usageAccumulator`) and has the fuzz reuse the package's test renderers. The single-fixture differential is strengthened with `FuzzDerivedTotalsMatchesIndividualScans` (combined scan vs `UsageTotalFromFile` + `FailedToolCallsFromFile` over arbitrary content and ordinals), registered in `scripts/fuzz/fuzz-targets.txt`.

## Gates

- `go test ./...` green in the root and agent modules; `go test -race` green for `server`, `appwire`, `internal/apptranscript`, `internal/appprojector`, `cmd/evener-hub` (full package), `cmd/evener-hub/internal/launchconfig`, `agent/task`.
- `-tags evenerfuzz` builds/tests green for `server`, `internal/appprojector`, `internal/apptranscript`; 20s fuzz run of the new target clean; `fuzz-registry-check` clean.
- `make lint`: all targets pass except **`lint-gofmt`, which is red on `origin/main` itself** (three untouched `agent/` files; pre-existing, tracked as #666 — every file this PR touches is gofmt-clean).

## Roborev

Per-commit reviews: 5 clean; 2 findings (parallel-test hazard on the package hooks, in-place map mutation) fixed in the two follow-up commits, commented and closed. Branch review clean (see PR discussion).
