### PR TITLE
refactor(agent): simplify the finish-path intent reducer vocabulary

### DIFF
--- a/agent/delegate_tree_controller.go
+++ b/agent/delegate_tree_controller.go
@@ -574,21 +574,21 @@ func (c *delegateTreeController) escalateCompletionRequirement(lease delegateLea
 }
 
 func (c *delegateTreeController) escalateCompletionRequirementLocked(lease delegateLease) error {
-	decision := c.reduceFinishIntent(finishIntent{site: finishSiteWorkAdmitted, lease: lease})
+	decision := c.reduceWorkAdmittedIntent(finishIntent{lease: lease})
 	return decision.err
 }
 
 func (c *delegateTreeController) recordAttentionNoAction(lease delegateLease) (bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	decision := c.reduceFinishIntent(finishIntent{site: finishSiteAttentionNoAction, lease: lease})
+	decision := c.reduceAttentionNoActionIntent(finishIntent{lease: lease})
 	return decision.recorded, decision.err
 }
 
 func (c *delegateTreeController) recordTerminalSeen(lease delegateLease) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	decision := c.reduceFinishIntent(finishIntent{site: finishSiteTerminalSeen, lease: lease})
+	decision := c.reduceTerminalSeenIntent(finishIntent{lease: lease})
 	return decision.err
 }
 

--- a/agent/delegate_tree_finish.go
+++ b/agent/delegate_tree_finish.go
@@ -82,10 +82,11 @@ func (c *delegateTreeController) BeginRunFinalization(lease delegateLease, mode 
 
 func (c *delegateTreeController) CompleteSettlement(claim *delegateSettlementClaim, supplied *delegatestore.TerminalPacket) (delegateMutationPlans, error) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	// This site never releases a generation, so there is no cancel to run
-	// after c.mu is released.
-	plans, _, err := c.executeFinishDecisionLocked(c.reduceCompleteSettlementIntent(finishIntent{claim: claim, packet: supplied}))
+	plans, cancel, err := c.executeFinishDecisionLocked(c.reduceCompleteSettlementIntent(finishIntent{claim: claim, packet: supplied}))
+	c.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 	return plans, err
 }
 
@@ -246,14 +247,14 @@ func (c *delegateTreeController) FinishGeneration(lease delegateLease, finish de
 // prepareNoAction before process-local terminal state publication.
 func (c *delegateTreeController) FinishNoAction(claim *delegateSettlementClaim) (delegateMutationPlans, error) {
 	c.mu.Lock()
-	_, _, finish, err := c.noActionFinishLocked(claim)
-	if err != nil {
+	noAction := c.reduceNoActionFinishIntent(finishIntent{claim: claim})
+	if noAction.err != nil {
 		c.mu.Unlock()
-		return delegateMutationPlans{}, err
+		return delegateMutationPlans{}, noAction.err
 	}
 	plans, cancel, err := c.executeFinishDecisionLocked(c.reduceGenerationFinishIntent(finishIntent{
 		lease:              claim.lease,
-		finish:             finish,
+		finish:             noAction.finish,
 		authorizedNoAction: true,
 	}))
 	c.mu.Unlock()
@@ -261,11 +262,6 @@ func (c *delegateTreeController) FinishNoAction(claim *delegateSettlementClaim) 
 		cancel()
 	}
 	return plans, err
-}
-
-func (c *delegateTreeController) noActionFinishLocked(claim *delegateSettlementClaim) (*delegatestore.Aggregate, *delegateLiveState, delegateFinish, error) {
-	decision := c.reduceNoActionFinishIntent(finishIntent{claim: claim})
-	return nil, nil, decision.finish, decision.err
 }
 
 func cloneDelegateFinish(finish delegateFinish) delegateFinish {

--- a/agent/delegate_tree_finish.go
+++ b/agent/delegate_tree_finish.go
@@ -83,16 +83,10 @@ func (c *delegateTreeController) BeginRunFinalization(lease delegateLease, mode 
 func (c *delegateTreeController) CompleteSettlement(claim *delegateSettlementClaim, supplied *delegatestore.TerminalPacket) (delegateMutationPlans, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	decision := c.reduceFinishIntent(finishIntent{site: finishSiteCompleteSettlement, claim: claim, packet: supplied})
-	if decision.err != nil || decision.events == nil {
-		return delegateMutationPlans{}, decision.err
-	}
-	_, appendErr := c.appendLocked(decision.events...)
-	if err := c.reduceFinishAppendResult(decision, appendErr); err != nil {
-		return delegateMutationPlans{}, err
-	}
-	plans, _ := c.finishEffectsLocked(decision, delegateUpdatePlan{})
-	return plans, nil
+	// This site never releases a generation, so there is no cancel to run
+	// after c.mu is released.
+	plans, _, err := c.executeFinishIntentLocked(finishIntent{site: finishSiteCompleteSettlement, claim: claim, packet: supplied})
+	return plans, err
 }
 
 func (c *delegateTreeController) AttentionResolutionsForFinalization(claim *delegateSettlementClaim) (delegateMutationPlans, error) {

--- a/agent/delegate_tree_finish.go
+++ b/agent/delegate_tree_finish.go
@@ -41,7 +41,7 @@ type delegateSettlementClaim struct {
 func (c *delegateTreeController) SupervisionBoundary(lease delegateLease, mode delegateSettlementMode) (delegateSupervisionBoundary, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	decision := c.reduceFinishIntent(finishIntent{site: finishSiteSupervisionBoundary, lease: lease, mode: mode})
+	decision := c.reduceSupervisionBoundaryIntent(finishIntent{lease: lease, mode: mode})
 	return decision.boundary, decision.err
 }
 
@@ -65,7 +65,7 @@ func (c *delegateTreeController) BeginSettlement(lease delegateLease) (*delegate
 func (c *delegateTreeController) BeginFinalization(lease delegateLease, mode delegateSettlementMode) (*delegateSettlementClaim, bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	decision := c.reduceFinishIntent(finishIntent{site: finishSiteBeginFinalization, lease: lease, mode: mode})
+	decision := c.reduceBeginFinalizationIntent(finishIntent{lease: lease, mode: mode})
 	return decision.claim, decision.continued, decision.err
 }
 
@@ -76,7 +76,7 @@ func (c *delegateTreeController) BeginFinalization(lease delegateLease, mode del
 func (c *delegateTreeController) BeginRunFinalization(lease delegateLease, mode delegateSettlementMode, runErr error) (*delegateSettlementClaim, bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	decision := c.reduceFinishIntent(finishIntent{site: finishSiteBeginFinalization, lease: lease, mode: mode, runErrorKnown: true, runErr: runErr})
+	decision := c.reduceBeginFinalizationIntent(finishIntent{lease: lease, mode: mode, runErrorKnown: true, runErr: runErr})
 	return decision.claim, decision.continued, decision.err
 }
 
@@ -85,14 +85,14 @@ func (c *delegateTreeController) CompleteSettlement(claim *delegateSettlementCla
 	defer c.mu.Unlock()
 	// This site never releases a generation, so there is no cancel to run
 	// after c.mu is released.
-	plans, _, err := c.executeFinishIntentLocked(finishIntent{site: finishSiteCompleteSettlement, claim: claim, packet: supplied})
+	plans, _, err := c.executeFinishDecisionLocked(c.reduceCompleteSettlementIntent(finishIntent{claim: claim, packet: supplied}))
 	return plans, err
 }
 
 func (c *delegateTreeController) AttentionResolutionsForFinalization(claim *delegateSettlementClaim) (delegateMutationPlans, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	decision := c.reduceFinishIntent(finishIntent{site: finishSiteAttentionResolutions, claim: claim})
+	decision := c.reduceAttentionResolutionsIntent(finishIntent{claim: claim})
 	if decision.err != nil {
 		return delegateMutationPlans{}, decision.err
 	}
@@ -108,7 +108,7 @@ func (c *delegateTreeController) AttentionResolutionsForFinalization(claim *dele
 func (c *delegateTreeController) prepareNoAction(claim *delegateSettlementClaim, fallback delegateFinish) (bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	decision := c.reduceFinishIntent(finishIntent{site: finishSitePrepareNoAction, claim: claim, finish: fallback})
+	decision := c.reducePrepareNoActionIntent(finishIntent{claim: claim, finish: fallback})
 	return decision.recorded, decision.err
 }
 
@@ -128,7 +128,7 @@ func noActionEvidenceEligible(evidence *delegateGenerationEvidence) bool {
 func (c *delegateTreeController) RequireFinalizationRecovery(claim *delegateSettlementClaim) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	decision := c.reduceFinishIntent(finishIntent{site: finishSiteRequireFinalizationRecovery, claim: claim})
+	decision := c.reduceRequireFinalizationRecoveryIntent(finishIntent{claim: claim})
 	return decision.err
 }
 
@@ -138,7 +138,7 @@ func (c *delegateTreeController) RequireFinalizationRecovery(claim *delegateSett
 func (c *delegateTreeController) ReportFinalizationQuiesced(lease delegateLease, runtime *Session) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	decision := c.reduceFinishIntent(finishIntent{site: finishSiteReportQuiesced, lease: lease, runtime: runtime, stalePolicy: finishStaleSwallow})
+	decision := c.reduceReportQuiescedIntent(finishIntent{lease: lease, runtime: runtime, stalePolicy: finishStaleSwallow})
 	return decision.err
 }
 
@@ -229,12 +229,11 @@ func (c *delegateTreeController) hasSteeringClaimLocked(lease delegateLease) boo
 
 func (c *delegateTreeController) FinishGeneration(lease delegateLease, finish delegateFinish) (delegateMutationPlans, error) {
 	c.mu.Lock()
-	plans, cancel, err := c.executeFinishIntentLocked(finishIntent{
-		site:        finishSiteGeneration,
+	plans, cancel, err := c.executeFinishDecisionLocked(c.reduceGenerationFinishIntent(finishIntent{
 		lease:       lease,
 		finish:      finish,
 		stalePolicy: finishStaleSuppress,
-	})
+	}))
 	c.mu.Unlock()
 	if cancel != nil {
 		cancel()
@@ -252,12 +251,11 @@ func (c *delegateTreeController) FinishNoAction(claim *delegateSettlementClaim) 
 		c.mu.Unlock()
 		return delegateMutationPlans{}, err
 	}
-	plans, cancel, err := c.executeFinishIntentLocked(finishIntent{
-		site:               finishSiteGeneration,
+	plans, cancel, err := c.executeFinishDecisionLocked(c.reduceGenerationFinishIntent(finishIntent{
 		lease:              claim.lease,
 		finish:             finish,
 		authorizedNoAction: true,
-	})
+	}))
 	c.mu.Unlock()
 	if cancel != nil {
 		cancel()
@@ -266,7 +264,7 @@ func (c *delegateTreeController) FinishNoAction(claim *delegateSettlementClaim) 
 }
 
 func (c *delegateTreeController) noActionFinishLocked(claim *delegateSettlementClaim) (*delegatestore.Aggregate, *delegateLiveState, delegateFinish, error) {
-	decision := c.reduceFinishIntent(finishIntent{site: finishSiteNoActionFinish, claim: claim})
+	decision := c.reduceNoActionFinishIntent(finishIntent{claim: claim})
 	return nil, nil, decision.finish, decision.err
 }
 

--- a/agent/delegate_tree_finish.go
+++ b/agent/delegate_tree_finish.go
@@ -135,12 +135,7 @@ func (c *delegateTreeController) RequireFinalizationRecovery(claim *delegateSett
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	decision := c.reduceFinishIntent(finishIntent{site: finishSiteRequireFinalizationRecovery, claim: claim})
-	if decision.err != nil {
-		return decision.err
-	}
-	_ = c.reduceFinishAppendResult(decision, nil)
-	c.finishEffectsLocked(decision, delegateUpdatePlan{})
-	return nil
+	return decision.err
 }
 
 // ReportFinalizationQuiesced releases only the process-local runner fence for
@@ -150,11 +145,7 @@ func (c *delegateTreeController) ReportFinalizationQuiesced(lease delegateLease,
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	decision := c.reduceFinishIntent(finishIntent{site: finishSiteReportQuiesced, lease: lease, runtime: runtime, stalePolicy: finishStaleSwallow})
-	if decision.err != nil {
-		return decision.err
-	}
-	c.finishEffectsLocked(decision, delegateUpdatePlan{})
-	return nil
+	return decision.err
 }
 
 func (c *delegateTreeController) attentionResolutionPlansLocked(lease delegateLease, aggregate *delegatestore.Aggregate, live *delegateLiveState) []delegateAttentionCleanupPlan {

--- a/agent/delegate_tree_intents.go
+++ b/agent/delegate_tree_intents.go
@@ -18,11 +18,10 @@ package agent
 // (comparing runtime pointer identity for the binding-runtime guard is the
 // one permitted use of a *Session). It performs the pre-append in-memory
 // transitions (claim acquisition/fencing, evidence observation) and returns
-// the decision: the journal batch to append, the per-site append-failure
-// latch plan, the abstract post-append effect descriptors (release claim,
-// release generation with its delivery plans, evidence-version bump, stop
-// progress signal, snapshot capture), and the entry point's stale-lease
-// policy already applied to the returned error.
+// the decision: the journal batch to append, the append-failure latch
+// target, the post-append effects (release claim, release generation with
+// its delivery plans, evidence-version bump, snapshot capture), and the
+// entry point's stale-lease policy already applied to the returned error.
 //
 // Deferred by spec (do not add here): the start-failure finishers
 // (CompleteStartInput, FailCommittedStart, FailCommittedRestart,
@@ -118,15 +117,33 @@ type finishDecision struct {
 	// (non-resumable exhaustion) and substitutes the closure plan for the
 	// first post-append update.
 	closure bool
-	// latch is the per-site append-failure latch plan; reduceFinishAppendResult
-	// applies it.
-	latch finishLatchPlan
-	// effects are the abstract post-append effect descriptors, applied by
-	// finishEffectsLocked against post-append durable state. Two idioms:
-	// append-carrying sites express evidence bumps as finishEffectBumpEvidence
-	// so they are skipped when the append fails; no-batch sites bump inline in
-	// the reducer.
-	effects []finishEffect
+	// Append-failure latch targets: when the append fails, the recovery
+	// triple (recoveryRequired, finalizationRecoveryRequired,
+	// recoveryRunnerPending) is latched on latchLive when set (the generation
+	// finish latches its authenticated live state unconditionally); otherwise
+	// latchLease re-resolves the binding at apply time and latches only when
+	// it still matches (CompleteSettlement).
+	latchLive  *delegateLiveState
+	latchLease delegateLease
+	// Post-append effects, applied by finishEffectsLocked against post-append
+	// durable state only when the append succeeded. Sites without a journal
+	// batch apply their effects inline in the reducer instead.
+	//
+	// releaseClaim releases the settlement claim token
+	// (releaseSettlementClaimLocked).
+	releaseClaim *delegateSettlementClaim
+	// releaseGeneration finishes the generation identified by lease: releases
+	// its claims and stop tracking, releases the runtime binding (returning
+	// the cancel that must run after c.mu is released), and captures the
+	// snapshot and delivery plans (generationFinishedPlansLocked with
+	// deliveryID).
+	releaseGeneration bool
+	lease             delegateLease
+	deliveryID        string
+	// bumpEvidence increments the evidence version.
+	bumpEvidence bool
+	// snapshotDelegateID, when non-empty, appends the delegate's update plan.
+	snapshotDelegateID string
 	// Outputs carried back through the unchanged wrapper signatures.
 	claim          *delegateSettlementClaim
 	continued      bool
@@ -135,62 +152,6 @@ type finishDecision struct {
 	completion     delegateCompletionDecision
 	finish         delegateFinish
 	attentionPlans []delegateAttentionCleanupPlan
-}
-
-// finishLatchKind is the per-site append-failure latch shape. The shapes are
-// inputs, not a constant: no uniform latching.
-type finishLatchKind uint8
-
-const (
-	// finishLatchNone: the site performs no append and no recovery latch.
-	finishLatchNone finishLatchKind = iota
-	// finishLatchUnconditionalTriple: finishGenerationLocked latches the
-	// full recovery triple on the authenticated live state unconditionally
-	// when the append failed.
-	finishLatchUnconditionalTriple
-	// finishLatchLeaseConditionalTriple: CompleteSettlement latches the full
-	// triple only when the live binding still matches the claim's lease at
-	// apply time.
-	finishLatchLeaseConditionalTriple
-)
-
-// finishLatchPlan is the reducer's per-site append-failure latch plan.
-type finishLatchPlan struct {
-	kind finishLatchKind
-	// live is the authenticated live state for the shapes that target it.
-	live *delegateLiveState
-	// lease re-resolves the binding at apply time for the lease-conditional
-	// shape, exactly as the pre-reducer code re-read c.live after the failed
-	// append.
-	lease delegateLease
-}
-
-// finishEffectKind names an abstract post-append effect. The wrapper applies
-// these after the journal append, against post-append durable state.
-type finishEffectKind uint8
-
-const (
-	finishEffectNone finishEffectKind = iota
-	// finishEffectReleaseClaim releases the settlement claim token
-	// (releaseSettlementClaimLocked).
-	finishEffectReleaseClaim
-	// finishEffectReleaseGeneration finishes the generation: releases the
-	// lease's claims and stop tracking, releases the runtime binding
-	// (returning the cancel that must run after c.mu is released), captures
-	// the snapshot and delivery plans (generationFinishedPlansLocked).
-	finishEffectReleaseGeneration
-	// finishEffectBumpEvidence increments the evidence version.
-	finishEffectBumpEvidence
-	// finishEffectCaptureSnapshot appends the delegate's update plan.
-	finishEffectCaptureSnapshot
-)
-
-type finishEffect struct {
-	kind       finishEffectKind
-	lease      delegateLease
-	delegateID string
-	token      uint64
-	deliveryID string
 }
 
 // reduceFinishIntent is the single locked transition function for the
@@ -231,10 +192,12 @@ func (c *delegateTreeController) reduceFinishIntent(intent finishIntent) finishD
 	return finishDecision{err: errDelegateTargetBusy}
 }
 
-// executeFinishIntentLocked drives the append and effect tail for an intent
-// whose reducer decision carries a journal batch (the ordinary and no-action
-// generation finishes). The caller holds c.mu; the caller releases it and
-// then runs the returned cancel after c.mu is released (cancel-after-unlock).
+// executeFinishIntentLocked drives the append, the append-failure recovery
+// latch, and the post-append effects for an intent whose reducer decision
+// carries a journal batch (settlement completion and the ordinary and
+// no-action generation finishes). The caller holds c.mu; the caller releases
+// it and then runs the returned cancel after c.mu is released
+// (cancel-after-unlock).
 func (c *delegateTreeController) executeFinishIntentLocked(intent finishIntent) (delegateMutationPlans, context.CancelFunc, error) {
 	decision := c.reduceFinishIntent(intent)
 	if decision.err != nil || decision.events == nil {
@@ -247,66 +210,56 @@ func (c *delegateTreeController) executeFinishIntentLocked(intent finishIntent) 
 	} else {
 		_, appendErr = c.appendLocked(decision.events...)
 	}
-	if err := c.reduceFinishAppendResult(decision, appendErr); err != nil {
-		return delegateMutationPlans{}, nil, err
+	if appendErr != nil {
+		if live := c.latchTargetLocked(decision); live != nil {
+			live.recoveryRequired = true
+			live.finalizationRecoveryRequired = true
+			live.recoveryRunnerPending = true
+		}
+		return delegateMutationPlans{}, nil, appendErr
 	}
 	plans, cancel := c.finishEffectsLocked(decision, closurePlan)
 	return plans, cancel, nil
 }
 
-// reduceFinishAppendResult applies the reducer's per-site latch plan to the
-// append outcome and returns the error the wrapper must surface. Latch
-// shapes are inputs: the unconditional and lease-conditional triples apply
-// only when the append failed. The caller holds c.mu.
-func (c *delegateTreeController) reduceFinishAppendResult(decision finishDecision, appendErr error) error {
-	switch decision.latch.kind {
-	case finishLatchUnconditionalTriple:
-		if appendErr == nil {
-			return nil
-		}
-		live := decision.latch.live
-		live.recoveryRequired = true
-		live.finalizationRecoveryRequired = true
-		live.recoveryRunnerPending = true
-	case finishLatchLeaseConditionalTriple:
-		if appendErr == nil {
-			return nil
-		}
-		if live := c.live[decision.latch.lease.delegateID]; live != nil && live.binding != nil && live.binding.lease == decision.latch.lease {
-			live.recoveryRequired = true
-			live.finalizationRecoveryRequired = true
-			live.recoveryRunnerPending = true
-		}
-	case finishLatchNone:
+// latchTargetLocked resolves the live state the recovery triple must be
+// latched on after a failed finish append. The generation finish targets its
+// authenticated live state unconditionally; CompleteSettlement re-resolves
+// the binding at apply time (exactly as the pre-reducer code re-read c.live
+// after the failed append) and latches only when it still matches the claim's
+// lease. The caller holds c.mu.
+func (c *delegateTreeController) latchTargetLocked(decision finishDecision) *delegateLiveState {
+	if decision.latchLive != nil {
+		return decision.latchLive
 	}
-	return appendErr
+	if live := c.live[decision.latchLease.delegateID]; live != nil && live.binding != nil && live.binding.lease == decision.latchLease {
+		return live
+	}
+	return nil
 }
 
-// finishEffectsLocked applies the reducer's post-append effect descriptors
-// against post-append durable state, using the existing pure plan helpers, and
+// finishEffectsLocked applies the reducer's post-append effects against
+// post-append durable state, using the existing pure plan helpers, and
 // returns the concrete mutation plans plus the cancel that must run after
 // c.mu is released. It branches only on the reducer's decision. The caller
 // holds c.mu.
 func (c *delegateTreeController) finishEffectsLocked(decision finishDecision, closurePlan delegateUpdatePlan) (delegateMutationPlans, context.CancelFunc) {
 	plans := delegateMutationPlans{}
 	var cancel context.CancelFunc
-	for _, effect := range decision.effects {
-		switch effect.kind {
-		case finishEffectReleaseClaim:
-			c.releaseSettlementClaimLocked(effect.token)
-		case finishEffectReleaseGeneration:
-			finished, generationCancel := c.generationFinishedPlansLocked(effect.lease, effect.deliveryID)
-			plans = finished
-			cancel = generationCancel
-			if decision.closure {
-				plans.updates[0] = closurePlan
-			}
-		case finishEffectBumpEvidence:
-			c.evidenceVersion++
-		case finishEffectCaptureSnapshot:
-			plans.updates = append(plans.updates, c.capturedPlanLocked(effect.delegateID))
-		case finishEffectNone:
+	if decision.releaseClaim != nil {
+		c.releaseSettlementClaimLocked(decision.releaseClaim.token)
+	}
+	if decision.releaseGeneration {
+		plans, cancel = c.generationFinishedPlansLocked(decision.lease, decision.deliveryID)
+		if decision.closure {
+			plans.updates[0] = closurePlan
 		}
+	}
+	if decision.bumpEvidence {
+		c.evidenceVersion++
+	}
+	if decision.snapshotDelegateID != "" {
+		plans.updates = append(plans.updates, c.capturedPlanLocked(decision.snapshotDelegateID))
 	}
 	return plans, cancel
 }
@@ -464,12 +417,10 @@ func (c *delegateTreeController) reduceCompleteSettlementIntent(intent finishInt
 				Packet:     packet,
 			},
 		}},
-		latch: finishLatchPlan{kind: finishLatchLeaseConditionalTriple, lease: claim.lease},
-		effects: []finishEffect{
-			{kind: finishEffectReleaseClaim, token: claim.token},
-			{kind: finishEffectBumpEvidence},
-			{kind: finishEffectCaptureSnapshot, delegateID: claim.lease.delegateID},
-		},
+		latchLease:         claim.lease,
+		releaseClaim:       claim,
+		bumpEvidence:       true,
+		snapshotDelegateID: claim.lease.delegateID,
 	}
 }
 
@@ -700,10 +651,12 @@ func (c *delegateTreeController) reduceGenerationFinishIntent(intent finishInten
 
 	closure := outcome == delegatestore.OutcomeExhausted && finish.exhaustionResumable != nil && !*finish.exhaustionResumable
 	return finishDecision{
-		events:  events,
-		closure: closure,
-		latch:   finishLatchPlan{kind: finishLatchUnconditionalTriple, live: live},
-		effects: []finishEffect{{kind: finishEffectReleaseGeneration, lease: lease, deliveryID: deliveryID}},
+		events:            events,
+		closure:           closure,
+		latchLive:         live,
+		releaseGeneration: true,
+		lease:             lease,
+		deliveryID:        deliveryID,
 	}
 }
 

--- a/agent/delegate_tree_intents.go
+++ b/agent/delegate_tree_intents.go
@@ -99,14 +99,17 @@ type finishDecision struct {
 	// (non-resumable exhaustion) and substitutes the closure plan for the
 	// first post-append update.
 	closure bool
-	// Append-failure latch targets: when the append fails, the recovery
-	// triple (recoveryRequired, finalizationRecoveryRequired,
+	// lease is the generation the batch-carrying decision is about: the
+	// closure append, the append-failure latch, the generation release, and
+	// the snapshot capture all key off it.
+	lease delegateLease
+	// latchLive is the append-failure latch target: when the append fails,
+	// the recovery triple (recoveryRequired, finalizationRecoveryRequired,
 	// recoveryRunnerPending) is latched on latchLive when set (the generation
 	// finish latches its authenticated live state unconditionally); otherwise
-	// latchLease re-resolves the binding at apply time and latches only when
-	// it still matches (CompleteSettlement).
-	latchLive  *delegateLiveState
-	latchLease delegateLease
+	// lease re-resolves the binding at apply time and latches only when it
+	// still matches (CompleteSettlement).
+	latchLive *delegateLiveState
 	// Post-append effects, applied by finishEffectsLocked against post-append
 	// durable state only when the append succeeded. Sites without a journal
 	// batch apply their effects inline in the reducer instead.
@@ -120,12 +123,11 @@ type finishDecision struct {
 	// snapshot and delivery plans (generationFinishedPlansLocked with
 	// deliveryID).
 	releaseGeneration bool
-	lease             delegateLease
 	deliveryID        string
 	// bumpEvidence increments the evidence version.
 	bumpEvidence bool
-	// snapshotDelegateID, when non-empty, appends the delegate's update plan.
-	snapshotDelegateID string
+	// captureSnapshot appends the lease's delegate update plan.
+	captureSnapshot bool
 	// Outputs carried back through the unchanged wrapper signatures.
 	claim          *delegateSettlementClaim
 	continued      bool
@@ -175,7 +177,7 @@ func (c *delegateTreeController) latchTargetLocked(decision finishDecision) *del
 	if decision.latchLive != nil {
 		return decision.latchLive
 	}
-	if live := c.live[decision.latchLease.delegateID]; live != nil && live.binding != nil && live.binding.lease == decision.latchLease {
+	if live := c.live[decision.lease.delegateID]; live != nil && live.binding != nil && live.binding.lease == decision.lease {
 		return live
 	}
 	return nil
@@ -201,8 +203,8 @@ func (c *delegateTreeController) finishEffectsLocked(decision finishDecision, cl
 	if decision.bumpEvidence {
 		c.evidenceVersion++
 	}
-	if decision.snapshotDelegateID != "" {
-		plans.updates = append(plans.updates, c.capturedPlanLocked(decision.snapshotDelegateID))
+	if decision.captureSnapshot {
+		plans.updates = append(plans.updates, c.capturedPlanLocked(decision.lease.delegateID))
 	}
 	return plans, cancel
 }
@@ -360,10 +362,10 @@ func (c *delegateTreeController) reduceCompleteSettlementIntent(intent finishInt
 				Packet:     packet,
 			},
 		}},
-		latchLease:         claim.lease,
-		releaseClaim:       claim,
-		bumpEvidence:       true,
-		snapshotDelegateID: claim.lease.delegateID,
+		lease:           claim.lease,
+		releaseClaim:    claim,
+		bumpEvidence:    true,
+		captureSnapshot: true,
 	}
 }
 

--- a/agent/delegate_tree_intents.go
+++ b/agent/delegate_tree_intents.go
@@ -152,12 +152,6 @@ const (
 	// triple only when the live binding still matches the claim's lease at
 	// apply time.
 	finishLatchLeaseConditionalTriple
-	// finishLatchRecoveryConditional: RequireFinalizationRecovery sets
-	// recoveryRequired conditionally (only when not already latched) and the
-	// finalization/runner fences unconditionally. This site performs no
-	// journal append; the latch is its effect, so it applies on every
-	// reduction, not only on append failure.
-	finishLatchRecoveryConditional
 )
 
 // finishLatchPlan is the reducer's per-site append-failure latch plan.
@@ -189,8 +183,6 @@ const (
 	finishEffectBumpEvidence
 	// finishEffectCaptureSnapshot appends the delegate's update plan.
 	finishEffectCaptureSnapshot
-	// finishEffectSignalStop signals progress to a covering subtree stop.
-	finishEffectSignalStop
 )
 
 type finishEffect struct {
@@ -265,9 +257,7 @@ func (c *delegateTreeController) executeFinishIntentLocked(intent finishIntent) 
 // reduceFinishAppendResult applies the reducer's per-site latch plan to the
 // append outcome and returns the error the wrapper must surface. Latch
 // shapes are inputs: the unconditional and lease-conditional triples apply
-// only when the append failed; the recovery-conditional latch is the site's
-// effect (there is no journal append on that path) and applies on every
-// reduction. The caller holds c.mu.
+// only when the append failed. The caller holds c.mu.
 func (c *delegateTreeController) reduceFinishAppendResult(decision finishDecision, appendErr error) error {
 	switch decision.latch.kind {
 	case finishLatchUnconditionalTriple:
@@ -287,13 +277,6 @@ func (c *delegateTreeController) reduceFinishAppendResult(decision finishDecisio
 			live.finalizationRecoveryRequired = true
 			live.recoveryRunnerPending = true
 		}
-	case finishLatchRecoveryConditional:
-		live := decision.latch.live
-		if !live.recoveryRequired {
-			live.recoveryRequired = true
-		}
-		live.finalizationRecoveryRequired = true
-		live.recoveryRunnerPending = true
 	case finishLatchNone:
 	}
 	return appendErr
@@ -322,8 +305,6 @@ func (c *delegateTreeController) finishEffectsLocked(decision finishDecision, cl
 			c.evidenceVersion++
 		case finishEffectCaptureSnapshot:
 			plans.updates = append(plans.updates, c.capturedPlanLocked(effect.delegateID))
-		case finishEffectSignalStop:
-			c.signalStopProgressLocked()
 		case finishEffectNone:
 		}
 	}
@@ -729,7 +710,8 @@ func (c *delegateTreeController) reduceGenerationFinishIntent(intent finishInten
 // reduceRequireFinalizationRecoveryIntent latches an exact finalization
 // whose external attention persistence failed. The claim remains fenced until
 // a durable stop can atomically close the open generation and then discard
-// pending attention.
+// pending attention. This site performs no journal append; the latch is its
+// effect, so it applies in-place on every successful reduction.
 func (c *delegateTreeController) reduceRequireFinalizationRecoveryIntent(intent finishIntent) finishDecision {
 	claim := intent.claim
 	if claim == nil || c.settlementClaims[claim.token] != claim {
@@ -739,14 +721,14 @@ func (c *delegateTreeController) reduceRequireFinalizationRecoveryIntent(intent 
 	if err != nil {
 		return finishDecision{err: err}
 	}
-	effects := []finishEffect{{kind: finishEffectBumpEvidence}}
+	live.recoveryRequired = true
+	live.finalizationRecoveryRequired = true
+	live.recoveryRunnerPending = true
+	c.evidenceVersion++
 	if c.stopTracksFinalizationLocked(claim.lease) {
-		effects = append(effects, finishEffect{kind: finishEffectSignalStop})
+		c.signalStopProgressLocked()
 	}
-	return finishDecision{
-		latch:   finishLatchPlan{kind: finishLatchRecoveryConditional, live: live},
-		effects: effects,
-	}
+	return finishDecision{}
 }
 
 // reduceReportQuiescedIntent releases only the process-local runner fence for
@@ -765,11 +747,11 @@ func (c *delegateTreeController) reduceReportQuiescedIntent(intent finishIntent)
 		return finishDecision{}
 	}
 	live.recoveryRunnerPending = false
-	effects := []finishEffect{{kind: finishEffectBumpEvidence}}
+	c.evidenceVersion++
 	if c.stopTracksFinalizationLocked(intent.lease) {
-		effects = append(effects, finishEffect{kind: finishEffectSignalStop})
+		c.signalStopProgressLocked()
 	}
-	return finishDecision{effects: effects}
+	return finishDecision{}
 }
 
 // reduceWorkAdmittedIntent escalates the completion requirement when

--- a/agent/delegate_tree_intents.go
+++ b/agent/delegate_tree_intents.go
@@ -5,15 +5,16 @@ package agent
 // This file is the single authority for every decision on the generation
 // finish path (spec: 2026-08-29 delegate lifecycle harness reducer design,
 // Project 2). The exported and in-plan wrapper methods construct a
-// finishIntent, call reduceFinishIntent, append through appendLocked, and
-// apply the returned effect descriptors. Wrappers never branch on
+// finishIntent, call their site's reduce*Intent method, and — for the sites
+// that carry a journal batch — drive the append and post-append effects
+// through executeFinishDecisionLocked. Wrappers never branch on
 // aggregate/live/controller state and never assign outcomes or dispositions;
 // every guard evaluation lives in exactly one place here or in the shared
-// predicates this reducer calls (exactLeaseLocked, admitLeaseLocked,
+// predicates the reducers call (exactLeaseLocked, admitLeaseLocked,
 // supervisionSuppressedLocked, finalizationReadyLocked,
 // noActionBaseEligibleLocked, noActionEvidenceEligible).
 //
-// Contract for reduceFinishIntent: the caller holds c.mu. The reducer
+// Contract for the reduce*Intent methods: the caller holds c.mu. The reducer
 // acquires no locks, performs no journal I/O, and calls no Session methods
 // (comparing runtime pointer identity for the binding-runtime guard is the
 // one permitted use of a *Session). It performs the pre-append in-memory
@@ -35,25 +36,6 @@ import (
 	"fmt"
 
 	"primeradiant.com/evener/agent/internal/delegatestore"
-)
-
-// finishSite identifies which finish-path entry point an intent came from.
-type finishSite uint8
-
-const (
-	finishSiteSupervisionBoundary         finishSite = iota + 1 // SupervisionBoundary
-	finishSiteBeginFinalization                                 // BeginSettlement / BeginFinalization / BeginRunFinalization
-	finishSiteCompleteSettlement                                // CompleteSettlement
-	finishSiteAttentionResolutions                              // AttentionResolutionsForFinalization
-	finishSitePrepareNoAction                                   // prepareNoAction
-	finishSiteNoActionFinish                                    // noActionFinishLocked (FinishNoAction)
-	finishSiteGeneration                                        // finishGenerationLocked (FinishGeneration / FinishNoAction)
-	finishSiteRequireFinalizationRecovery                       // RequireFinalizationRecovery
-	finishSiteReportQuiesced                                    // ReportFinalizationQuiesced
-	finishSiteWorkAdmitted                                      // escalateCompletionRequirement
-	finishSiteAttentionNoAction                                 // recordAttentionNoAction
-	finishSiteTerminalSeen                                      // recordTerminalSeen
-	finishSiteCompletionDecision                                // completionDecision
 )
 
 // finishStalePolicy is how an entry point surfaces a stale-lease guard
@@ -83,10 +65,10 @@ func (intent finishIntent) resolveStalePolicy(err error) error {
 }
 
 // finishIntent is what a finish-path caller wants. It carries no controller
-// state, only the request: which site is asking, the lease or claim it holds,
-// and the payload (finish, packet, run error, runtime identity).
+// state, only the request: the lease or claim the caller holds and the
+// payload (finish, packet, run error, runtime identity). Each entry point
+// passes its intent to its site's reduce*Intent method.
 type finishIntent struct {
-	site    finishSite
 	lease   delegateLease
 	claim   *delegateSettlementClaim
 	mode    delegateSettlementMode
@@ -154,59 +136,20 @@ type finishDecision struct {
 	attentionPlans []delegateAttentionCleanupPlan
 }
 
-// reduceFinishIntent is the single locked transition function for the
-// generation finish path. The caller holds c.mu; the reducer acquires no
-// locks, performs no journal I/O, and calls no Session methods (runtime
-// pointer identity comparison is the one permitted use of a *Session). It
-// evaluates every finish-path guard exactly once, performs the pre-append
-// in-memory transitions, and returns the decision.
-func (c *delegateTreeController) reduceFinishIntent(intent finishIntent) finishDecision {
-	switch intent.site {
-	case finishSiteSupervisionBoundary:
-		return c.reduceSupervisionBoundaryIntent(intent)
-	case finishSiteBeginFinalization:
-		return c.reduceBeginFinalizationIntent(intent)
-	case finishSiteCompleteSettlement:
-		return c.reduceCompleteSettlementIntent(intent)
-	case finishSiteAttentionResolutions:
-		return c.reduceAttentionResolutionsIntent(intent)
-	case finishSitePrepareNoAction:
-		return c.reducePrepareNoActionIntent(intent)
-	case finishSiteNoActionFinish:
-		return c.reduceNoActionFinishIntent(intent)
-	case finishSiteGeneration:
-		return c.reduceGenerationFinishIntent(intent)
-	case finishSiteRequireFinalizationRecovery:
-		return c.reduceRequireFinalizationRecoveryIntent(intent)
-	case finishSiteReportQuiesced:
-		return c.reduceReportQuiescedIntent(intent)
-	case finishSiteWorkAdmitted:
-		return c.reduceWorkAdmittedIntent(intent)
-	case finishSiteAttentionNoAction:
-		return c.reduceAttentionNoActionIntent(intent)
-	case finishSiteTerminalSeen:
-		return c.reduceTerminalSeenIntent(intent)
-	case finishSiteCompletionDecision:
-		return c.reduceCompletionDecisionIntent(intent)
-	}
-	return finishDecision{err: errDelegateTargetBusy}
-}
-
-// executeFinishIntentLocked drives the append, the append-failure recovery
-// latch, and the post-append effects for an intent whose reducer decision
-// carries a journal batch (settlement completion and the ordinary and
-// no-action generation finishes). The caller holds c.mu; the caller releases
-// it and then runs the returned cancel after c.mu is released
+// executeFinishDecisionLocked drives the append, the append-failure recovery
+// latch, and the post-append effects for a reducer decision that carries a
+// journal batch (settlement completion and the ordinary and no-action
+// generation finishes). The caller holds c.mu; the caller releases it and
+// then runs the returned cancel after c.mu is released
 // (cancel-after-unlock).
-func (c *delegateTreeController) executeFinishIntentLocked(intent finishIntent) (delegateMutationPlans, context.CancelFunc, error) {
-	decision := c.reduceFinishIntent(intent)
+func (c *delegateTreeController) executeFinishDecisionLocked(decision finishDecision) (delegateMutationPlans, context.CancelFunc, error) {
 	if decision.err != nil || decision.events == nil {
 		return delegateMutationPlans{}, nil, decision.err
 	}
 	var appendErr error
 	var closurePlan delegateUpdatePlan
 	if decision.closure {
-		closurePlan, appendErr = c.appendResumabilityClosureLocked(intent.lease.delegateID, decision.events...)
+		closurePlan, appendErr = c.appendResumabilityClosureLocked(decision.lease.delegateID, decision.events...)
 	} else {
 		_, appendErr = c.appendLocked(decision.events...)
 	}

--- a/agent/delegate_tree_steer.go
+++ b/agent/delegate_tree_steer.go
@@ -26,7 +26,7 @@ const (
 func (c *delegateTreeController) completionDecision(lease delegateLease) (delegateCompletionDecision, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	decision := c.reduceFinishIntent(finishIntent{site: finishSiteCompletionDecision, lease: lease})
+	decision := c.reduceCompletionDecisionIntent(finishIntent{lease: lease})
 	return decision.completion, decision.err
 }
 


### PR DESCRIPTION
## What

Implements the audit's over-engineering finding for the finish-path intent reducer (commits `6564dd7d3`, `a99863e7e`, `fe43ad825`, `7b41b8948`; `agent/delegate_tree_intents.go` + `agent/delegate_tree_finish.go`). Jesse pre-approved rewriting this freshly-landed code.

The reducer had built a formal vocabulary — `finishSite` (13 variants), `finishLatchKind` (3 shapes), `finishEffect`/`finishEffectKind` (5 kinds), plus the `reduceFinishAppendResult` interpreter — where every variant appeared only 4-5 times in one file (definition, doc, one switch case, one producer). The real win (one place evaluates the guards) came from the extracted shared predicates, which stay.

## Changes (4 commits)

1. **Inline the no-append sites' latch and effects** — `RequireFinalizationRecovery` and `ReportFinalizationQuiesced` perform no journal append, so their recovery latch and evidence/stop-signal effects apply directly in the reducers; the wrappers shrink to surfacing `decision.err`.
2. **Replace the effect-descriptor IR and latch plan with concrete `finishDecision` fields** (`releaseClaim`, `releaseGeneration` + `deliveryID`, `bumpEvidence`, `captureSnapshot`, `latchLive`/`lease`) that `finishEffectsLocked` and the append-failure latch read directly. `CompleteSettlement` now routes through the shared execution path instead of duplicating the append/latch/effects sequence.
3. **Delete `finishSite` and the `reduceFinishIntent` dispatch switch** — the enum's only job was routing to the per-site reducer (the stale-lease policy already rides on the intent as `finishStalePolicy`, which is kept per the audit). Entry points call their site's `reduce*Intent` method directly.
4. **Simplify-pass cleanups** — merge the two mutually-exclusive lease fields on `finishDecision`, handle the shared path's cancel uniformly in `CompleteSettlement`, inline the fossil `noActionFinishLocked` wrapper.

## Behavior

Identical by construction and by pin: the delegate-lifecycle differential model harness (~1782 test lines) is untouched and green, along with the full `agent` module (`go test`, `go test -race`) and `make lint` (9/9). Per-commit and branch-level roborev reviews: no issues found.

## Net delta

**-141 lines** (130 insertions, 271 deletions across 4 files); `delegate_tree_intents.go` shrinks 838 → 718 lines.