### PR TITLE
fix(appserver): honor a mid-capture thread/unsubscribe when the capture commits

### DIFF
--- a/internal/appserver/server_test.go
+++ b/internal/appserver/server_test.go
@@ -1470,6 +1470,60 @@ func TestAtomicReplaceSubscriptionOwnsSnapshotAndPostCutStream(t *testing.T) {
 	}
 }
 
+// A serial unsubscribe that lands between a subscribed read's capture and
+// that capture's release-commit must win. The read's response enters the send
+// queue BEFORE the commit runs (enqueueResponse commits the finalizer after
+// `c.send <- msg`), so a client can observe the response, send
+// thread/unsubscribe, and have it processed while the entry is still
+// buffering. The commit must then honor the drop rather than resurrect the
+// subscription. Deterministic regression test for the CI flake in
+// TestServerAppWireThreadUnsubscribeResolvesStableRefAcrossSwap.
+func TestUnsubscribeBetweenCaptureAndCommitEndsUnsubscribed(t *testing.T) {
+	server := NewServer(ServerConfig{ServerName: "test", SourceID: "local"})
+	conn := server.NewConnection("conn-unsub-commit")
+	server.registerConnection(conn)
+	conn.setInitialized()
+
+	notifier := NewNotifier(10)
+	HandleTyped(server.Router(), "test/subscribe-snapshot", func(ctx context.Context, _ struct{}) (struct{}, error) {
+		if !CaptureSubscription(
+			ctx,
+			false,
+			func() string { return "th_live" },
+			notifier.CurrentSequence,
+			func() bool { return true },
+		) {
+			t.Error("subscription capture was rejected")
+		}
+		return struct{}{}, nil
+	})
+
+	// HandleMessage returns the response without enqueueing it: the capture
+	// is registered but its finalizer has not committed yet.
+	response := conn.HandleMessage(
+		context.Background(),
+		appwire.RequestMessage(appwire.NewIntID(1), "test/subscribe-snapshot", struct{}{}),
+	)
+
+	// The unsubscribe lands in exactly the wire race's window: after the
+	// capture registered, before the response enqueue commits it.
+	ctx := context.WithValue(context.Background(), connectionContextKey{}, conn)
+	Unsubscribe(ctx, "th_live")
+
+	// The unsubscribe succeeded, so the count reflects it immediately — even
+	// though the capture's commit has not resolved the entry yet.
+	if got := server.SubscriberCount("th_live"); got != 0 {
+		t.Fatalf("subscriber count before commit = %d, want 0", got)
+	}
+
+	if err := conn.enqueueResponse(context.Background(), response); err != nil {
+		t.Fatalf("enqueue response: %v", err)
+	}
+	if got := server.SubscriberCount("th_live"); got != 0 {
+		t.Fatalf("subscriber count after unsubscribe-then-commit = %d, want 0", got)
+	}
+}
+
 func TestContextSubscriptionRegistrationRejectsRemovedConnection(t *testing.T) {
 	for _, tc := range []struct {
 		name     string

--- a/internal/appserver/server_test.go
+++ b/internal/appserver/server_test.go
@@ -1521,7 +1521,10 @@ func TestUnsubscribeBetweenCaptureAndCommitEndsUnsubscribed(t *testing.T) {
 	}
 	// The commit resolved the withdrawn entry by removing it — not by
 	// leaving it behind, filtered out of the count.
-	if server.subs.IsSubscribed(conn.ID(), "th_live") {
+	server.subs.mu.RLock()
+	_, present := server.subs.byConn[conn.id]["th_live"]
+	server.subs.mu.RUnlock()
+	if present {
 		t.Fatal("committed capture left the withdrawn entry in the registry")
 	}
 	if got := server.SubscriberCount("th_live"); got != 0 {

--- a/internal/appserver/server_test.go
+++ b/internal/appserver/server_test.go
@@ -1519,6 +1519,11 @@ func TestUnsubscribeBetweenCaptureAndCommitEndsUnsubscribed(t *testing.T) {
 	if err := conn.enqueueResponse(context.Background(), response); err != nil {
 		t.Fatalf("enqueue response: %v", err)
 	}
+	// The commit resolved the withdrawn entry by removing it — not by
+	// leaving it behind, filtered out of the count.
+	if server.subs.IsSubscribed(conn.ID(), "th_live") {
+		t.Fatal("committed capture left the withdrawn entry in the registry")
+	}
 	if got := server.SubscriberCount("th_live"); got != 0 {
 		t.Fatalf("subscriber count after unsubscribe-then-commit = %d, want 0", got)
 	}

--- a/internal/appserver/subscriptions.go
+++ b/internal/appserver/subscriptions.go
@@ -54,8 +54,9 @@ func (s *Subscriptions) Subscribe(connID, threadID string) {
 // previous subscriptions into its rollback snapshot, and removing the
 // buffering entry here would strand that snapshot (withdrawBuffered matches
 // on the live generation and would bail without restoring). The generation's
-// own commit/abort resolves the entry — commit keeps it live, abort restores
-// the snapshot minus this thread.
+// own commit/abort resolves the entry, either way honoring the drop: commit
+// (Release) removes the entry, abort restores the snapshot minus this
+// thread.
 func (s *Subscriptions) Unsubscribe(connID, threadID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -187,6 +188,16 @@ func (s *Subscriptions) Release(connID, threadID string, generation uint64) ([]S
 	if sub == nil || !sub.buffering || sub.generation != generation {
 		return nil, false
 	}
+	if s.withdrawnLocked(connID, threadID) {
+		// The client unsubscribed this thread while the capture buffered it.
+		// Its unsubscribe already succeeded on the wire, so committing the
+		// entry live would resurrect a subscription the client dropped:
+		// honor the drop instead — remove the entry, release none of the
+		// buffered records, and consume the withdrawal record.
+		s.removeThreadLocked(connID, threadID)
+		s.clearWithdrawnLocked(connID, threadID)
+		return nil, true
+	}
 	release := make([]SequencedNotification, 0, len(sub.buffer))
 	for _, record := range sub.buffer {
 		if record.Seq > sub.cut {
@@ -195,10 +206,6 @@ func (s *Subscriptions) Release(connID, threadID string, generation uint64) ([]S
 	}
 	sub.buffering = false
 	sub.buffer = nil
-	// The generation committed: the entry is live, so any mid-capture
-	// unsubscribe record for it is spent — clear it, or a later capture's
-	// abort would wrongly skip restoring this thread.
-	s.clearWithdrawnLocked(connID, threadID)
 	return release, true
 }
 
@@ -240,10 +247,22 @@ func (s *Subscriptions) Connections(threadID string) []string {
 	return conns
 }
 
+// ConnectionCount reports how many connections hold a live interest in the
+// thread. An entry whose connection unsubscribed mid-capture does not count:
+// that client's unsubscribe already succeeded, and the entry only lingers as
+// bookkeeping until the capture's commit/abort resolves it — counting it
+// would let a subscription the client dropped hold the relay open.
 func (s *Subscriptions) ConnectionCount(threadID string) int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return len(s.byThread[threadID])
+	count := 0
+	for connID := range s.byThread[threadID] {
+		if s.withdrawnLocked(connID, threadID) {
+			continue
+		}
+		count++
+	}
+	return count
 }
 
 func (s *Subscriptions) RemoveConnection(connID string) {

--- a/internal/appserver/subscriptions.go
+++ b/internal/appserver/subscriptions.go
@@ -9,6 +9,15 @@ type subscription struct {
 	generation uint64
 	cut        uint64
 	buffer     []SequencedNotification
+	// withdrawn marks a buffering entry whose connection unsubscribed the
+	// thread mid-capture. The client's unsubscribe already succeeded on the
+	// wire, so the entry is capture bookkeeping, not a live interest:
+	// queries skip it, no records buffer into it, and the capture's
+	// commit/abort resolves it by dropping the thread rather than
+	// resurrecting a subscription the client no longer holds. Living on the
+	// entry, the mark shares its lifetime: removal and replacement dispose
+	// of it for free.
+	withdrawn bool
 }
 
 type connectionSubscriptionSnapshot struct {
@@ -25,17 +34,12 @@ type Subscriptions struct {
 	mu       sync.RWMutex
 	byConn   map[string]map[string]*subscription
 	byThread map[string]map[string]*subscription
-	// withdrawn tracks threads a connection explicitly unsubscribed while a
-	// buffering capture held the entry, so the capture's abort restores its
-	// displaced snapshot minus exactly what the client dropped.
-	withdrawn map[string]map[string]struct{}
 }
 
 func NewSubscriptions() *Subscriptions {
 	return &Subscriptions{
-		byConn:    map[string]map[string]*subscription{},
-		byThread:  map[string]map[string]*subscription{},
-		withdrawn: map[string]map[string]struct{}{},
+		byConn:   map[string]map[string]*subscription{},
+		byThread: map[string]map[string]*subscription{},
 	}
 }
 
@@ -49,14 +53,13 @@ func (s *Subscriptions) Subscribe(connID, threadID string) {
 // idempotent: unsubscribing a thread this connection never held is a no-op,
 // so a client racing its own re-subscribe can never wedge the registry.
 //
-// A thread currently held by a BUFFERING capture generation records the drop
-// and leaves the entry in place: the capture displaced the connection's
+// A thread currently held by a BUFFERING capture generation marks the entry
+// withdrawn and leaves it in place: the capture displaced the connection's
 // previous subscriptions into its rollback snapshot, and removing the
 // buffering entry here would strand that snapshot (withdrawBuffered matches
 // on the live generation and would bail without restoring). The generation's
-// own commit/abort resolves the entry, either way honoring the drop: commit
-// (Release) removes the entry, abort restores the snapshot minus this
-// thread.
+// own commit/abort resolves the entry, either way honoring the drop (see
+// subscription.withdrawn).
 func (s *Subscriptions) Unsubscribe(connID, threadID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -65,20 +68,10 @@ func (s *Subscriptions) Unsubscribe(connID, threadID string) {
 		return
 	}
 	if sub.buffering {
-		if s.withdrawn[connID] == nil {
-			s.withdrawn[connID] = map[string]struct{}{}
-		}
-		s.withdrawn[connID][threadID] = struct{}{}
+		sub.withdrawn = true
 		return
 	}
 	s.removeThreadLocked(connID, threadID)
-}
-
-// withdrawnLocked reports whether the connection explicitly unsubscribed the
-// thread while a buffering capture held it. Caller holds s.mu.
-func (s *Subscriptions) withdrawnLocked(connID, threadID string) bool {
-	_, ok := s.withdrawn[connID][threadID]
-	return ok
 }
 
 func (s *Subscriptions) ReplaceConnectionSubscriptions(connID, threadID string) {
@@ -129,12 +122,11 @@ func (s *Subscriptions) withdrawBuffered(
 		s.removeConnectionLocked(connID)
 		for i := range rollback.connection.subscriptions {
 			sub := rollback.connection.subscriptions[i]
-			if s.withdrawnLocked(connID, sub.threadID) {
+			if sub.withdrawn || (current.withdrawn && sub.threadID == threadID) {
 				// The client explicitly unsubscribed this thread mid-capture;
 				// restoring it would resurrect a thread it asked to stop
 				// receiving. Everything else the capture displaced comes back
 				// unchanged.
-				s.clearWithdrawnLocked(connID, sub.threadID)
 				continue
 			}
 			s.subscribeLocked(&sub)
@@ -142,15 +134,10 @@ func (s *Subscriptions) withdrawBuffered(
 		return true
 	}
 	s.removeThreadLocked(connID, threadID)
-	if rollback.threadPrevious != nil {
+	if rollback.threadPrevious != nil && !current.withdrawn && !rollback.threadPrevious.withdrawn {
 		previous := *rollback.threadPrevious
-		if s.withdrawnLocked(connID, previous.threadID) {
-			s.clearWithdrawnLocked(connID, previous.threadID)
-		} else {
-			s.subscribeLocked(&previous)
-		}
+		s.subscribeLocked(&previous)
 	}
-	s.clearWithdrawnLocked(connID, threadID)
 	return true
 }
 
@@ -173,7 +160,9 @@ func (s *Subscriptions) Route(record SequencedNotification) []string {
 	var live []string
 	for connID, sub := range s.byThread[record.ThreadID] {
 		if sub.buffering {
-			sub.buffer = append(sub.buffer, record)
+			if !sub.withdrawn {
+				sub.buffer = append(sub.buffer, record)
+			}
 			continue
 		}
 		live = append(live, connID)
@@ -188,14 +177,10 @@ func (s *Subscriptions) Release(connID, threadID string, generation uint64) ([]S
 	if sub == nil || !sub.buffering || sub.generation != generation {
 		return nil, false
 	}
-	if s.withdrawnLocked(connID, threadID) {
-		// The client unsubscribed this thread while the capture buffered it.
-		// Its unsubscribe already succeeded on the wire, so committing the
-		// entry live would resurrect a subscription the client dropped:
-		// honor the drop instead — remove the entry, release none of the
-		// buffered records, and consume the withdrawal record.
+	if sub.withdrawn {
+		// The client unsubscribed mid-capture (see subscription.withdrawn):
+		// drop the entry instead of committing it live.
 		s.removeThreadLocked(connID, threadID)
-		s.clearWithdrawnLocked(connID, threadID)
 		return nil, true
 	}
 	release := make([]SequencedNotification, 0, len(sub.buffer))
@@ -207,17 +192,6 @@ func (s *Subscriptions) Release(connID, threadID string, generation uint64) ([]S
 	sub.buffering = false
 	sub.buffer = nil
 	return release, true
-}
-
-// clearWithdrawnLocked drops one spent mid-capture unsubscribe record.
-// Caller holds s.mu.
-func (s *Subscriptions) clearWithdrawnLocked(connID, threadID string) {
-	if threads := s.withdrawn[connID]; threads != nil {
-		delete(threads, threadID)
-		if len(threads) == 0 {
-			delete(s.withdrawn, connID)
-		}
-	}
 }
 
 func (s *Subscriptions) IsSubscribed(connID, threadID string) bool {
@@ -241,23 +215,24 @@ func (s *Subscriptions) Connections(threadID string) []string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	conns := make([]string, 0, len(s.byThread[threadID]))
-	for connID := range s.byThread[threadID] {
+	for connID, sub := range s.byThread[threadID] {
+		if sub.withdrawn {
+			continue
+		}
 		conns = append(conns, connID)
 	}
 	return conns
 }
 
 // ConnectionCount reports how many connections hold a live interest in the
-// thread. An entry whose connection unsubscribed mid-capture does not count:
-// that client's unsubscribe already succeeded, and the entry only lingers as
-// bookkeeping until the capture's commit/abort resolves it — counting it
-// would let a subscription the client dropped hold the relay open.
+// thread, skipping withdrawn entries (see subscription.withdrawn) — counting
+// one would let a subscription the client dropped hold the relay open.
 func (s *Subscriptions) ConnectionCount(threadID string) int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	count := 0
-	for connID := range s.byThread[threadID] {
-		if s.withdrawnLocked(connID, threadID) {
+	for _, sub := range s.byThread[threadID] {
+		if sub.withdrawn {
 			continue
 		}
 		count++

--- a/internal/appserver/subscriptions.go
+++ b/internal/appserver/subscriptions.go
@@ -194,11 +194,14 @@ func (s *Subscriptions) Release(connID, threadID string, generation uint64) ([]S
 	return release, true
 }
 
+// IsSubscribed reports whether the connection holds a live interest in the
+// thread; a withdrawn mid-capture entry does not count (see
+// subscription.withdrawn).
 func (s *Subscriptions) IsSubscribed(connID, threadID string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	_, ok := s.byConn[connID][threadID]
-	return ok
+	sub, ok := s.byConn[connID][threadID]
+	return ok && !sub.withdrawn
 }
 
 func (s *Subscriptions) Threads(connID string) []string {

--- a/internal/appserver/subscriptions.go
+++ b/internal/appserver/subscriptions.go
@@ -204,11 +204,16 @@ func (s *Subscriptions) IsSubscribed(connID, threadID string) bool {
 	return ok && !sub.withdrawn
 }
 
+// Threads lists the threads the connection holds a live interest in; a
+// withdrawn mid-capture entry does not count (see subscription.withdrawn).
 func (s *Subscriptions) Threads(connID string) []string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	threads := make([]string, 0, len(s.byConn[connID]))
-	for threadID := range s.byConn[connID] {
+	for threadID, sub := range s.byConn[connID] {
+		if sub.withdrawn {
+			continue
+		}
 		threads = append(threads, threadID)
 	}
 	return threads

--- a/internal/appserver/subscriptions_coverage_test.go
+++ b/internal/appserver/subscriptions_coverage_test.go
@@ -186,8 +186,14 @@ func TestSubscriptionsUnsubscribeDuringNonReplaceCaptureDefersToAbort(t *testing
 	}
 }
 
-// A committed capture clears the mid-capture unsubscribe record: the entry
-// went live, so a later capture's abort must restore it normally.
+// A committed capture honors the mid-capture unsubscribe: the client dropped
+// the thread after the capture began, so the commit removes the entry instead
+// of resurrecting a subscription the client no longer holds, releases none of
+// the buffered records, and consumes the withdrawal so later captures behave
+// normally. Regression test for the wire-level flake where a serial
+// unsubscribe landing between a subscribed read's capture and its
+// release-commit was silently discarded
+// (TestServerAppWireThreadUnsubscribeResolvesStableRefAcrossSwap).
 func TestSubscriptionsUnsubscribeDuringCaptureThenCommit(t *testing.T) {
 	subs := NewSubscriptions()
 	subs.Subscribe("conn-1", "th_1")
@@ -195,14 +201,26 @@ func TestSubscriptionsUnsubscribeDuringCaptureThenCommit(t *testing.T) {
 	subs.beginBuffered("conn-1", "th_3", true, 4)
 
 	subs.Unsubscribe("conn-1", "th_3")
-	if _, ok := subs.Release("conn-1", "th_3", 4); !ok {
+	// The drop is visible immediately: the lingering buffering entry is
+	// capture bookkeeping, not a live interest, so it must not hold the
+	// relay open while the commit is still pending.
+	if got := subs.ConnectionCount("th_3"); got != 0 {
+		t.Fatalf("connection count after mid-capture unsubscribe = %d, want 0", got)
+	}
+	subs.Route(SequencedNotification{Seq: 9, ThreadID: "th_3"})
+	records, ok := subs.Release("conn-1", "th_3", 4)
+	if !ok {
 		t.Fatal("Release should succeed for the live generation")
 	}
-	if !subs.IsSubscribed("conn-1", "th_3") {
-		t.Fatal("committed capture should leave the entry live")
+	if len(records) != 0 {
+		t.Fatalf("released records = %#v, want none: the client unsubscribed mid-capture", records)
 	}
-	// A LATER capture that displaces th_3 must have it restored on its abort
-	// — the spent withdrawn record from generation 4 must not suppress it.
+	if subs.IsSubscribed("conn-1", "th_3") {
+		t.Fatal("committed capture resurrected a subscription the client dropped mid-capture")
+	}
+	// The withdrawal is consumed: a re-subscribe works, and a LATER capture
+	// that displaces th_3 must have it restored on its abort.
+	subs.Subscribe("conn-1", "th_3")
 	rollback2 := subs.beginBuffered("conn-1", "th_4", true, 5)
 	subs.Unsubscribe("conn-1", "th_4")
 	if !subs.withdrawBuffered("conn-1", "th_4", 5, rollback2) {

--- a/internal/appserver/subscriptions_coverage_test.go
+++ b/internal/appserver/subscriptions_coverage_test.go
@@ -139,8 +139,9 @@ func TestSubscriptionsUnsubscribeDuringReplaceCaptureDefersToAbort(t *testing.T)
 	// The client unsubscribes the thread the capture is hydrating, mid-flight.
 	subs.Unsubscribe("conn-1", "th_3")
 
-	// The buffering entry survives until the capture resolves.
-	if !subs.IsSubscribed("conn-1", "th_3") {
+	// The raw buffering entry survives until the capture resolves (IsSubscribed
+	// already reports the withdrawal).
+	if subs.byConn["conn-1"]["th_3"] == nil {
 		t.Fatal("mid-capture unsubscribe removed the buffering entry")
 	}
 	// The capture aborts (its read failed): the displaced snapshot comes back
@@ -175,7 +176,7 @@ func TestSubscriptionsUnsubscribeDuringNonReplaceCaptureDefersToAbort(t *testing
 	rollback := subs.beginBuffered("conn-1", "th_1", false, 3)
 
 	subs.Unsubscribe("conn-1", "th_1")
-	if !subs.IsSubscribed("conn-1", "th_1") {
+	if subs.byConn["conn-1"]["th_1"] == nil {
 		t.Fatal("mid-capture unsubscribe removed the buffering entry")
 	}
 	if !subs.withdrawBuffered("conn-1", "th_1", 3, rollback) {

--- a/internal/appserver/subscriptions_coverage_test.go
+++ b/internal/appserver/subscriptions_coverage_test.go
@@ -179,6 +179,15 @@ func TestSubscriptionsUnsubscribeDuringNonReplaceCaptureDefersToAbort(t *testing
 	if subs.byConn["conn-1"]["th_1"] == nil {
 		t.Fatal("mid-capture unsubscribe removed the buffering entry")
 	}
+	// Every live-interest query agrees the drop already happened.
+	if subs.IsSubscribed("conn-1", "th_1") {
+		t.Fatal("IsSubscribed still reports a thread the client unsubscribed mid-capture")
+	}
+	for _, thread := range subs.Threads("conn-1") {
+		if thread == "th_1" {
+			t.Fatal("Threads still enumerates a thread the client unsubscribed mid-capture")
+		}
+	}
 	if !subs.withdrawBuffered("conn-1", "th_1", 3, rollback) {
 		t.Fatal("withdrawBuffered should succeed after a mid-capture unsubscribe")
 	}


### PR DESCRIPTION
Fixes #663

## Root cause (production bug, shipped in 86354f683)

`TestServerAppWireThreadUnsubscribeResolvesStableRefAcrossSwap` flaked in the race-root CI job because a serial client's unsubscribe could be silently discarded. The sequence:

1. A subscribed `thread/read` registers a **buffering** capture entry (`beginBuffered`) and enqueues its response. The hydration finalizer commits (`Release`) only *after* the response enters the connection's send queue.
2. The client receives the response and sends `thread/unsubscribe`. Requests dispatch concurrently, so the unsubscribe handler can run while the entry is still buffering — `Subscriptions.Unsubscribe` records the drop as a *withdrawal* and defers to the capture's resolution.
3. `Release` (the commit path) then **discarded the withdrawal and committed the entry live** — deliberately, per the code comment "commit keeps it live" — resurrecting a subscription whose unsubscribe had already succeeded on the wire. Subscriber count stays 1; the relay idle-teardown that rides on the count reaching 0 never fires.

The non-race job passed on the same commit because the commit usually wins the race; a loaded CI runner descheduling the handler goroutine between the response enqueue and `finalizer.commit()` loses it.

## Fix

- `Release` now honors a mid-capture withdrawal: it drops the entry instead of committing it live, and releases none of the buffered records.
- The withdrawal mark moved from a side-table onto the `subscription` entry itself (`withdrawn bool`), so its lifetime is tied to the entry by construction — a stale record can no longer outlive its entry and skew the count.
- All registry queries agree on "live interest": `ConnectionCount`, `Connections`, `IsSubscribed`, and `Threads` skip withdrawn entries, and `Route` stops buffering records into them. A successful unsubscribe stops counting immediately, even while the capture's commit is still pending.

## Reproduction

Could not trigger the flake locally (400+ runs under `-race` with varied `GOMAXPROCS`) — the window is one goroutine descheduling wide. Made it reproducible two ways:

- **Deterministic tests** pin the interleaving at both layers: `TestSubscriptionsUnsubscribeDuringCaptureThenCommit` (registry level: `Unsubscribe` between `beginBuffered` and `Release`) and `TestUnsubscribeBetweenCaptureAndCommitEndsUnsubscribed` (server level: `Unsubscribe` between `HandleMessage` and `enqueueResponse` — exactly the wire race's window). Both failed with the CI symptom (count 1, want 0) before the fix.
- **Widened window**: a temporary 50ms sleep before `finalizer.commit()` made all three wire `ThreadUnsubscribe` tests fail exactly like the CI run (including the `appwire_server_test.go:2145` line from #663); with the fix they pass under the same widened window.

## Verification

- `go test ./...` clean, `go test -race` for `internal/appserver` and `server`, full `make lint` pass.
- Roborev: per-commit reviews clean; branch-level review iterated 3 rounds (round 1 flagged `IsSubscribed` inconsistency, round 2 flagged `Threads` — both fixed), round 3: no issues found.