### PR TITLE
fix(appserver): honor a mid-capture unsubscribe when the hydration commits

### DIFF
--- a/internal/appserver/subscriptions.go
+++ b/internal/appserver/subscriptions.go
@@ -50,12 +50,12 @@ func (s *Subscriptions) Subscribe(connID, threadID string) {
 // so a client racing its own re-subscribe can never wedge the registry.
 //
 // A thread currently held by a BUFFERING capture generation records the drop
-// and leaves the entry in place: the capture displaced the connection's
-// previous subscriptions into its rollback snapshot, and removing the
-// buffering entry here would strand that snapshot (withdrawBuffered matches
-// on the live generation and would bail without restoring). The generation's
-// own commit/abort resolves the entry — commit keeps it live, abort restores
-// the snapshot minus this thread.
+// and leaves the entry in place until the generation resolves: removing the
+// buffering entry here would strand the capture's rollback snapshot
+// (withdrawBuffered matches on the live generation and would bail without
+// restoring). The resolution then honors the drop — abort restores the
+// snapshot minus this thread, and commit removes the entry instead of
+// reviving it.
 func (s *Subscriptions) Unsubscribe(connID, threadID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -195,10 +195,14 @@ func (s *Subscriptions) Release(connID, threadID string, generation uint64) ([]S
 	}
 	sub.buffering = false
 	sub.buffer = nil
-	// The generation committed: the entry is live, so any mid-capture
-	// unsubscribe record for it is spent — clear it, or a later capture's
-	// abort would wrongly skip restoring this thread.
-	s.clearWithdrawnLocked(connID, threadID)
+	if s.withdrawnLocked(connID, threadID) {
+		// The client unsubscribed while this generation buffered. Commit
+		// honors that will instead of reviving the thread it dropped: remove
+		// the entry and report no records, so nothing it buffered is delivered.
+		s.clearWithdrawnLocked(connID, threadID)
+		s.removeThreadLocked(connID, threadID)
+		return nil, true
+	}
 	return release, true
 }
 

--- a/internal/appserver/subscriptions_coverage_test.go
+++ b/internal/appserver/subscriptions_coverage_test.go
@@ -186,6 +186,36 @@ func TestSubscriptionsUnsubscribeDuringNonReplaceCaptureDefersToAbort(t *testing
 	}
 }
 
+// The commit counterpart of the two abort tests above, and the registry-level
+// regression for a CI flake in the daemon tests: an unsubscribe can arrive
+// while the hydration generation is still buffering — the client received
+// the read response and sent its unsubscribe before the handler goroutine
+// reached finalizer.commit(). The commit must honor the drop, not revive the
+// thread: the client asked to stop receiving it, and a revived entry both
+// counts as a subscriber and delivers its buffered records.
+func TestSubscriptionsUnsubscribeDuringCaptureThenCommitDropsEntry(t *testing.T) {
+	subs := NewSubscriptions()
+	subs.Subscribe("conn-1", "th_1")
+	// The non-replace shape: the generation buffers a thread the connection
+	// already held, buffering records past its cut.
+	subs.beginBuffered("conn-1", "th_1", false, 7)
+
+	subs.Unsubscribe("conn-1", "th_1")
+	records, ok := subs.Release("conn-1", "th_1", 7)
+	if !ok {
+		t.Fatal("Release should succeed for the live generation")
+	}
+	if subs.IsSubscribed("conn-1", "th_1") {
+		t.Fatal("commit must honor the unsubscribe recorded while the generation buffered")
+	}
+	if len(records) != 0 {
+		t.Fatalf("commit delivered buffered records for a withdrawn thread: %d", len(records))
+	}
+	if got := subs.ConnectionCount("th_1"); got != 0 {
+		t.Fatalf("subscriber count after commit = %d, want 0", got)
+	}
+}
+
 // A committed capture clears the mid-capture unsubscribe record: the entry
 // went live, so a later capture's abort must restore it normally.
 func TestSubscriptionsUnsubscribeDuringCaptureThenCommit(t *testing.T) {
@@ -195,21 +225,23 @@ func TestSubscriptionsUnsubscribeDuringCaptureThenCommit(t *testing.T) {
 	subs.beginBuffered("conn-1", "th_3", true, 4)
 
 	subs.Unsubscribe("conn-1", "th_3")
-	if _, ok := subs.Release("conn-1", "th_3", 4); !ok {
+	records, ok := subs.Release("conn-1", "th_3", 4)
+	if !ok {
 		t.Fatal("Release should succeed for the live generation")
 	}
-	if !subs.IsSubscribed("conn-1", "th_3") {
-		t.Fatal("committed capture should leave the entry live")
+	if subs.IsSubscribed("conn-1", "th_3") {
+		t.Fatal("commit must honor the unsubscribe recorded while the generation buffered")
 	}
-	// A LATER capture that displaces th_3 must have it restored on its abort
-	// — the spent withdrawn record from generation 4 must not suppress it.
+	if len(records) != 0 {
+		t.Fatalf("commit delivered buffered records for a withdrawn thread: %d", len(records))
+	}
+	// A LATER capture still resolves cleanly on top of the committed one. Its
+	// rollback is empty — gen 4's commit already consumed the displacement —
+	// so its abort restores nothing and honors its own withdrawn thread.
 	rollback2 := subs.beginBuffered("conn-1", "th_4", true, 5)
 	subs.Unsubscribe("conn-1", "th_4")
 	if !subs.withdrawBuffered("conn-1", "th_4", 5, rollback2) {
 		t.Fatal("second capture's abort should succeed")
-	}
-	if !subs.IsSubscribed("conn-1", "th_3") {
-		t.Fatal("the spent withdrawn record suppressed restoring th_3 on the later capture's abort")
 	}
 	if subs.IsSubscribed("conn-1", "th_4") {
 		t.Fatal("th_4 should stay dropped: the client explicitly unsubscribed it mid-capture")


### PR DESCRIPTION
Fixes the unsubscribe flake failing PR #649's `race-root` CI check.

## What failed

```
--- FAIL: TestServerAppWireThreadUnsubscribeDropsSubscription (0.01s)
    appwire_server_test.go:2087: subscriber count after unsubscribe = 1, want 0
```

## Whose change it was

This test and the bug beneath it came from #651 (merged), not from #649's
changes — #649 branched from main after #651 landed and inherited the test.
The flake is timing-dependent, which is why #649's two earlier CI runs passed
and the race-detector build (`race-root`, different scheduling) caught it.

## Root cause

A subscribed `thread/read` registers a **buffering** capture generation; the
entry goes live only when the response's finalizer commits (after the response
enters the connection's send queue). An unsubscribe arriving inside that
window — the client got the read response and sent its unsubscribe before the
handler goroutine reached `commit()` — was recorded as withdrawn but left the
buffering entry in place, and `Release` then **cleared the withdrawn record and
kept the entry live**. The unsubscribe was silently dropped:

- `SubscriberCount` stays 1 (what the flaky test caught), so the hub relay's
  idle teardown never fires;
- the connection keeps receiving that thread's notifications after a
  *successful* unsubscribe.

Reproduced deterministically at the registry level: `beginBuffered` →
`Unsubscribe` → `Release` leaves the entry subscribed.

## Fix

`Subscriptions.Release` now honors a recorded drop at commit: it removes the
entry and returns no buffered records. Abort already honored drops (restore
the displaced snapshot minus the thread); commit now matches. The
`Unsubscribe` doc said "commit keeps it live" — the abort half was right, the
commit half was the bug.

Also corrects one existing test that had pinned the wrong behavior ("committed
capture should leave the entry live" — that assertion *was* the dropped
unsubscribe) and adds a red-probed regression test,
`TestSubscriptionsUnsubscribeDuringCaptureThenCommitDropsEntry`.

## Verification

- Registry-level repro: fails pre-fix, passes post-fix.
- `TestServerAppWireThreadUnsubscribe*` ×30 under `-race`: green.
- `go test -race` on `internal/appserver`, `server`, `cmd/evener-hub`: green.
- The originally-flaky websocket test is unchanged — with the semantics
  fixed, both orderings of the race are now correct.

After this merges, #649 can rebase (or simply re-run CI once main picks this
up) and `race-root` should go back to green.
