### PR TITLE
test(serve): prove resume seeds its app identity from the restored entries (#647)

### DIFF
--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -25,6 +25,7 @@ import (
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
 	taskpkg "primeradiant.com/evener/agent/task"
+	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener/internal/rvreg"
 	"primeradiant.com/evener/cmdutil"
@@ -149,8 +150,14 @@ type serveDeps struct {
 	// is injectable: a test needs a deterministic preparation failure to prove
 	// thread/clear abandons a half-built session instead of publishing it.
 	prepareAppIdentity func(sourceID, threadID, ref, transcriptPath string) (server.PreparedAppIdentity, error)
-	updateSessionID    func(*rvreg.Registration, string) error
-	observeCallbacks   func(serveCallbackObserver)
+	// prepareAppIdentityFromEntries is the resume-path form of
+	// prepareAppIdentity: same projection from the entries restore already
+	// decoded instead of a second file read. Injectable for the same reason —
+	// the resume branch below bypasses prepareAppIdentity, so without this
+	// seam no test can observe which form ran.
+	prepareAppIdentityFromEntries func(sourceID, threadID, ref string, header transcript.Header, entries []transcript.Entry) (server.PreparedAppIdentity, error)
+	updateSessionID               func(*rvreg.Registration, string) error
+	observeCallbacks              func(serveCallbackObserver)
 }
 
 type serveCallbackObserver struct {
@@ -188,12 +195,13 @@ func defaultServeDeps() serveDeps {
 		drainWaitExpiry: func() <-chan time.Time { return time.After(shutdownDrainWaitBudget) },
 		subscriberCount: func(s serveServer, id string) int { return s.(*server.Server).AppSubscriberCount(id) },
 		notifyContext:   signal.NotifyContext, startCPUProfile: cmdutil.StartCPUProfile, startTrace: cmdutil.StartTrace,
-		register:           func(r *rvreg.Registration, dir string, entry rendezvous.Entry) error { return r.Register(dir, entry) },
-		serveHTTP:          func(s *http.Server, l net.Listener) error { return s.Serve(l) },
-		provisionSandbox:   provisionSandbox,
-		newClearSession:    agent.NewSession,
-		prepareAppIdentity: server.PrepareAppIdentityForRef,
-		updateSessionID:    func(r *rvreg.Registration, id string) error { return r.UpdateSessionID(id) },
+		register:                      func(r *rvreg.Registration, dir string, entry rendezvous.Entry) error { return r.Register(dir, entry) },
+		serveHTTP:                     func(s *http.Server, l net.Listener) error { return s.Serve(l) },
+		provisionSandbox:              provisionSandbox,
+		newClearSession:               agent.NewSession,
+		prepareAppIdentity:            server.PrepareAppIdentityForRef,
+		prepareAppIdentityFromEntries: server.PrepareAppIdentityFromEntries,
+		updateSessionID:               func(r *rvreg.Registration, id string) error { return r.UpdateSessionID(id) },
 	}
 }
 
@@ -540,7 +548,7 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 		// OpenWriterForSession pass) and validated its header against the
 		// session id; projecting from those entries keeps the daemon's
 		// startup from re-reading and re-decoding the whole append-only file.
-		prepared, err = server.PrepareAppIdentityFromEntries("local", sess.ID(), workspaceRef, header, entries)
+		prepared, err = deps.prepareAppIdentityFromEntries("local", sess.ID(), workspaceRef, header, entries)
 	} else {
 		prepared, err = deps.prepareAppIdentity("local", sess.ID(), workspaceRef, sess.TranscriptPath())
 	}

--- a/cmd/evener/serve_resume_identity_test.go
+++ b/cmd/evener/serve_resume_identity_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 
 	"primeradiant.com/evener/agent/schema"
@@ -20,7 +19,7 @@ import (
 // a real --resume can restore: OpenWriterForSession will strict-decode the
 // entries and RestoredTranscript will report them, so serve's identity
 // preparation has a choice of forms to make.
-func seedResumableSession(t *testing.T, stateDir, sessionID string, headerSessionID string) string {
+func seedResumableSession(t *testing.T, stateDir, sessionID string, headerSessionID string) {
 	t.Helper()
 	if err := schema.SaveSessionMeta(stateDir, schema.SessionMeta{
 		ID: sessionID, ProfileID: "openai", Model: "gpt-test",
@@ -46,14 +45,14 @@ func seedResumableSession(t *testing.T, stateDir, sessionID string, headerSessio
 	if err := writer.Close(); err != nil {
 		t.Fatalf("Close writer: %v", err)
 	}
-	return path
 }
 
 // serveResumeIdentityProbe records which app-identity preparation form a
-// --resume run used. Plain fields suffice: identity preparation and the
-// serveHTTP override both run on the goroutine that called
-// runServeWithDeps, before any serve goroutine exists, and the test reads
-// the probe only after runServeWithDeps returns.
+// --resume run used. Plain fields suffice: every write happens on the
+// goroutine that called runServeWithDeps (identity preparation at
+// serve.go:551 and the serveHTTP override at serve.go:1181), before it
+// returns, and the test reads the probe only after that return. The serve
+// goroutines spawned along the way never touch the probe.
 type serveResumeIdentityProbe struct {
 	entriesFormUsed bool
 	fileFormUsed    bool
@@ -69,13 +68,10 @@ func runServeResumeWithProbe(t *testing.T, stateDir, sessionID string) (*serveRe
 	deps := defaultServeDeps()
 	deps.ensureConfigDirs = func() error { return nil }
 	deps.seedMarketplaces = func() error { return nil }
-	var cancelMu sync.Mutex
 	var cancel context.CancelFunc
 	deps.notifyContext = func(ctx context.Context, _ ...os.Signal) (context.Context, context.CancelFunc) {
 		next, stop := context.WithCancel(ctx)
-		cancelMu.Lock()
 		cancel = stop
-		cancelMu.Unlock()
 		return next, stop
 	}
 	entriesForm := deps.prepareAppIdentityFromEntries
@@ -95,10 +91,7 @@ func runServeResumeWithProbe(t *testing.T, stateDir, sessionID string) (*serveRe
 		// even after serveHTTP returns, so returning without canceling would
 		// deadlock the test (same pattern as
 		// TestRunResumeWithFailedReservationPreservesForeignOwnedChild).
-		cancelMu.Lock()
-		stop := cancel
-		cancelMu.Unlock()
-		stop()
+		cancel()
 		return http.ErrServerClosed
 	}
 	args := []string{

--- a/cmd/evener/serve_resume_identity_test.go
+++ b/cmd/evener/serve_resume_identity_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/llm"
+	"primeradiant.com/evener/server")
+
+// seedResumableSession writes a session meta and a two-entry transcript that
+// a real --resume can restore: OpenWriterForSession will strict-decode the
+// entries and RestoredTranscript will report them, so serve's identity
+// preparation has a choice of forms to make.
+func seedResumableSession(t *testing.T, stateDir, sessionID string, headerSessionID string) string {
+	t.Helper()
+	if err := schema.SaveSessionMeta(stateDir, schema.SessionMeta{
+		ID: sessionID, ProfileID: "openai", Model: "gpt-test",
+	}); err != nil {
+		t.Fatalf("SaveSessionMeta: %v", err)
+	}
+	sessionsDir := filepath.Join(stateDir, "sessions")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := filepath.Join(sessionsDir, sessionID+".transcript.jsonl")
+	writer, err := transcript.NewWriter(path, transcript.Header{
+		SessionID:  headerSessionID,
+		ProfileID:  "openai",
+		Model:      "gpt-test",
+		WorkingDir: stateDir,
+	})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	for _, text := range []string{"first turn", "second turn"} {
+		if err := writer.Append(schema.NewTurn(schema.TurnUserInput, llm.User(text))); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+	return path
+}
+
+// serveResumeIdentityProbe records which app-identity preparation form a
+// --resume run used. The serveHTTP override samples inside the live loop
+// (same pattern as runClearAttempt) and ends it by returning
+// http.ErrServerClosed, which runServeWithDeps treats as a clean stop.
+type serveResumeIdentityProbe struct {
+	mu sync.Mutex
+
+	entriesFormUsed bool
+	fileFormUsed     bool
+	gotThreadID      string
+	gotEntryCount    int
+}
+
+func (p *serveResumeIdentityProbe) recordEntries(threadID string, entryCount int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.entriesFormUsed = true
+	p.gotThreadID = threadID
+	p.gotEntryCount = entryCount
+}
+
+func (p *serveResumeIdentityProbe) recordFile() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.fileFormUsed = true
+}
+
+// runServeResumeWithProbe drives one --resume through runServeWithDeps and
+// returns the probe's observations plus the serve error.
+func runServeResumeWithProbe(t *testing.T, stateDir, sessionID string) (*serveResumeIdentityProbe, error) {
+	t.Helper()
+	probe := &serveResumeIdentityProbe{}
+	deps := defaultServeDeps()
+	deps.ensureConfigDirs = func() error { return nil }
+	deps.seedMarketplaces = func() error { return nil }
+	// Capture the serve context's cancel the way the existing tests do (see
+	// TestRunResumeWithFailedReservationPreservesForeignOwnedChild): the
+	// shutdown goroutine waits on ctx.Done() even after serveHTTP returns,
+	// so the override below must cancel before returning.
+	var cancelMu sync.Mutex
+	var cancel context.CancelFunc
+	deps.notifyContext = func(ctx context.Context, _ ...os.Signal) (context.Context, context.CancelFunc) {
+		next, stop := context.WithCancel(ctx)
+		cancelMu.Lock()
+		cancel = stop
+		cancelMu.Unlock()
+		return next, stop
+	}
+	entriesForm := deps.prepareAppIdentityFromEntries
+	deps.prepareAppIdentityFromEntries = func(sourceID, threadID, ref string, header transcript.Header, entries []transcript.Entry) (server.PreparedAppIdentity, error) {
+		probe.recordEntries(threadID, len(entries))
+		return entriesForm(sourceID, threadID, ref, header, entries)
+	}
+	fileForm := deps.prepareAppIdentity
+	deps.prepareAppIdentity = func(sourceID, threadID, ref, transcriptPath string) (server.PreparedAppIdentity, error) {
+		probe.recordFile()
+		return fileForm(sourceID, threadID, ref, transcriptPath)
+	}
+	deps.serveHTTP = func(*http.Server, net.Listener) error {
+		// The identity is installed by the time HTTP serves; observe, cancel
+		// the serve context (the shutdown goroutine waits on ctx.Done()), and
+		// stop the loop with the clean-shutdown sentinel.
+		cancelMu.Lock()
+		stop := cancel
+		cancelMu.Unlock()
+		stop()
+		return http.ErrServerClosed
+	}
+	args := []string{
+		"--model", "openai/gpt-test",
+		"--addr", "127.0.0.1:0",
+		"--resume", sessionID,
+		"--dir", t.TempDir(),
+		"--state-dir", stateDir,
+		"--run-dir", t.TempDir(),
+		"--no-project-prompts",
+	}
+	serveErr := runServeWithDeps(args, deps)
+	return probe, serveErr
+}
+
+// TestServeResumeSeedsIdentityFromRestoredEntries pins the serve-level
+// wiring issue #647: a --resume whose restore decoded the transcript must
+// seed its prepared app identity from those entries (the entries form),
+// NOT from a second file read. The differential facts asserted:
+//   - the entries form ran and the file form did not;
+//   - it ran for the resumed session id with the restored entry count;
+//   - the run completed cleanly.
+func TestServeResumeSeedsIdentityFromRestoredEntries(t *testing.T) {
+	installServeScriptedProvider(t, &scriptedProvider{name: "openai"})
+	stateDir := t.TempDir()
+	const sessionID = "02wMz5Txv1C3Hut0M8GCeB"
+	seedResumableSession(t, stateDir, sessionID, sessionID)
+
+	probe, serveErr := runServeResumeWithProbe(t, stateDir, sessionID)
+	if serveErr != nil {
+		t.Fatalf("runServeWithDeps(resume): %v", serveErr)
+	}
+	probe.mu.Lock()
+	defer probe.mu.Unlock()
+	if !probe.entriesFormUsed {
+		t.Fatal("resume did not seed its app identity from the restored entries (entries form unused)")
+	}
+	if probe.fileFormUsed {
+		t.Fatal("resume re-read the transcript file for its app identity (file form used)")
+	}
+	if probe.gotThreadID != sessionID {
+		t.Fatalf("entries form thread id = %q, want %q", probe.gotThreadID, sessionID)
+	}
+	if probe.gotEntryCount != 2 {
+		t.Fatalf("entries form entry count = %d, want 2 (the restored two-entry transcript)", probe.gotEntryCount)
+	}
+}
+
+// TestServeResumeForeignHeaderEntryListFailsStartup pins the error contract
+// at the same serve-level boundary: an entries list whose header names
+// another session fails daemon startup with the same error the file form
+// produces for a foreign-header transcript, rather than serving a
+// conversation that never happened.
+func TestServeResumeForeignHeaderEntryListFailsStartup(t *testing.T) {
+	installServeScriptedProvider(t, &scriptedProvider{name: "openai"})
+	stateDir := t.TempDir()
+	const sessionID = "02wMz5Txv1C3Hut0M8GCeB"
+	const foreignSessionID = "02wMz5Txv2enqVTitaig6F"
+	// The transcript's header names a DIFFERENT session than the one being
+	// resumed: restore's OpenWriterForSession must reject it before serve.
+	seedResumableSession(t, stateDir, sessionID, foreignSessionID)
+
+	probe, serveErr := runServeResumeWithProbe(t, stateDir, sessionID)
+	if serveErr == nil {
+		t.Fatal("serve accepted a resume over a transcript whose header names another session")
+	}
+	probe.mu.Lock()
+	defer probe.mu.Unlock()
+	if probe.entriesFormUsed || probe.fileFormUsed {
+		t.Fatal("identity preparation ran over a foreign-header transcript; restore should have failed first")
+	}
+	if !strings.Contains(serveErr.Error(), "restore session") {
+		t.Fatalf("serve error = %v, want the restore-stage failure naming the mismatch", serveErr)
+	}
+}

--- a/cmd/evener/serve_resume_identity_test.go
+++ b/cmd/evener/serve_resume_identity_test.go
@@ -13,7 +13,8 @@ import (
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/llm"
-	"primeradiant.com/evener/server")
+	"primeradiant.com/evener/server"
+)
 
 // seedResumableSession writes a session meta and a two-entry transcript that
 // a real --resume can restore: OpenWriterForSession will strict-decode the
@@ -26,11 +27,8 @@ func seedResumableSession(t *testing.T, stateDir, sessionID string, headerSessio
 	}); err != nil {
 		t.Fatalf("SaveSessionMeta: %v", err)
 	}
-	sessionsDir := filepath.Join(stateDir, "sessions")
-	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
-		t.Fatalf("mkdir sessions: %v", err)
-	}
-	path := filepath.Join(sessionsDir, sessionID+".transcript.jsonl")
+	// SaveSessionMeta creates <stateDir>/sessions.
+	path := filepath.Join(stateDir, "sessions", sessionID+".transcript.jsonl")
 	writer, err := transcript.NewWriter(path, transcript.Header{
 		SessionID:  headerSessionID,
 		ProfileID:  "openai",
@@ -52,30 +50,15 @@ func seedResumableSession(t *testing.T, stateDir, sessionID string, headerSessio
 }
 
 // serveResumeIdentityProbe records which app-identity preparation form a
-// --resume run used. The serveHTTP override samples inside the live loop
-// (same pattern as runClearAttempt) and ends it by returning
-// http.ErrServerClosed, which runServeWithDeps treats as a clean stop.
+// --resume run used. Plain fields suffice: identity preparation and the
+// serveHTTP override both run on the goroutine that called
+// runServeWithDeps, before any serve goroutine exists, and the test reads
+// the probe only after runServeWithDeps returns.
 type serveResumeIdentityProbe struct {
-	mu sync.Mutex
-
 	entriesFormUsed bool
-	fileFormUsed     bool
-	gotThreadID      string
-	gotEntryCount    int
-}
-
-func (p *serveResumeIdentityProbe) recordEntries(threadID string, entryCount int) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.entriesFormUsed = true
-	p.gotThreadID = threadID
-	p.gotEntryCount = entryCount
-}
-
-func (p *serveResumeIdentityProbe) recordFile() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.fileFormUsed = true
+	fileFormUsed    bool
+	gotThreadID     string
+	gotEntryCount   int
 }
 
 // runServeResumeWithProbe drives one --resume through runServeWithDeps and
@@ -86,10 +69,6 @@ func runServeResumeWithProbe(t *testing.T, stateDir, sessionID string) (*serveRe
 	deps := defaultServeDeps()
 	deps.ensureConfigDirs = func() error { return nil }
 	deps.seedMarketplaces = func() error { return nil }
-	// Capture the serve context's cancel the way the existing tests do (see
-	// TestRunResumeWithFailedReservationPreservesForeignOwnedChild): the
-	// shutdown goroutine waits on ctx.Done() even after serveHTTP returns,
-	// so the override below must cancel before returning.
 	var cancelMu sync.Mutex
 	var cancel context.CancelFunc
 	deps.notifyContext = func(ctx context.Context, _ ...os.Signal) (context.Context, context.CancelFunc) {
@@ -101,18 +80,21 @@ func runServeResumeWithProbe(t *testing.T, stateDir, sessionID string) (*serveRe
 	}
 	entriesForm := deps.prepareAppIdentityFromEntries
 	deps.prepareAppIdentityFromEntries = func(sourceID, threadID, ref string, header transcript.Header, entries []transcript.Entry) (server.PreparedAppIdentity, error) {
-		probe.recordEntries(threadID, len(entries))
+		probe.entriesFormUsed = true
+		probe.gotThreadID = threadID
+		probe.gotEntryCount = len(entries)
 		return entriesForm(sourceID, threadID, ref, header, entries)
 	}
 	fileForm := deps.prepareAppIdentity
 	deps.prepareAppIdentity = func(sourceID, threadID, ref, transcriptPath string) (server.PreparedAppIdentity, error) {
-		probe.recordFile()
+		probe.fileFormUsed = true
 		return fileForm(sourceID, threadID, ref, transcriptPath)
 	}
 	deps.serveHTTP = func(*http.Server, net.Listener) error {
-		// The identity is installed by the time HTTP serves; observe, cancel
-		// the serve context (the shutdown goroutine waits on ctx.Done()), and
-		// stop the loop with the clean-shutdown sentinel.
+		// Cancel before returning: the shutdown goroutine waits on ctx.Done()
+		// even after serveHTTP returns, so returning without canceling would
+		// deadlock the test (same pattern as
+		// TestRunResumeWithFailedReservationPreservesForeignOwnedChild).
 		cancelMu.Lock()
 		stop := cancel
 		cancelMu.Unlock()
@@ -149,8 +131,6 @@ func TestServeResumeSeedsIdentityFromRestoredEntries(t *testing.T) {
 	if serveErr != nil {
 		t.Fatalf("runServeWithDeps(resume): %v", serveErr)
 	}
-	probe.mu.Lock()
-	defer probe.mu.Unlock()
 	if !probe.entriesFormUsed {
 		t.Fatal("resume did not seed its app identity from the restored entries (entries form unused)")
 	}
@@ -183,8 +163,6 @@ func TestServeResumeForeignHeaderEntryListFailsStartup(t *testing.T) {
 	if serveErr == nil {
 		t.Fatal("serve accepted a resume over a transcript whose header names another session")
 	}
-	probe.mu.Lock()
-	defer probe.mu.Unlock()
 	if probe.entriesFormUsed || probe.fileFormUsed {
 		t.Fatal("identity preparation ran over a foreign-header transcript; restore should have failed first")
 	}


### PR DESCRIPTION
## Summary

Closes #647. The resume path's app-identity preparation bypassed the injectable `prepareAppIdentity` seam (it called the entries form directly), so no test could observe **which form** ran at the serve level — the exact wiring gap issue #647 names.

## What changed

- **`cmd/evener/serve.go`**: new `prepareAppIdentityFromEntries` field in `serveDeps`, mirroring the existing `prepareAppIdentity` seam (and the `newClearSession` dual-form precedent): defaulting to `server.PrepareAppIdentityFromEntries`, and the resume branch now routes through `deps.prepareAppIdentityFromEntries(...)`. The file form remains for fresh sessions and thread/clear.
- **`cmd/evener/serve_resume_identity_test.go`** (new): two serve-level tests driving a real `--resume` through `runServeWithDeps`:
  - `TestServeResumeSeedsIdentityFromRestoredEntries` — the entries form ran (right thread id, right restored entry count) and the file form did not: the resume must not re-read the transcript for its identity.
  - `TestServeResumeForeignHeaderEntryListFailsStartup` — a transcript whose header names a different session fails at the restore stage, with neither form running (the stricter guarantee: the mismatch is rejected before any entry list exists).

Both use the repo's existing shutdown pattern (notifyContext cancel captured and invoked inside the serveHTTP override — returning `http.ErrServerClosed` without canceling would deadlock, since the shutdown goroutine waits on `ctx.Done()`).

## Verification

- `go vet ./cmd/evener/` — exit 0
- `go test ./cmd/evener/ -run 'TestServeResume...' -race -count=5` — ok
- Full `go test ./cmd/evener/` — ok (21s)
- `make lint-golangci` — PASS

## Review process

Simplify-code pass (4 parallel reviewers) found and fixed: a redundant `MkdirAll`, a provably-unnecessary probe mutex, triple-stated comments, and a gofmt violation. Adversarial contest (two competing reviewers, disqualification for inflated findings): both reported **zero significant findings**; four minor findings each, all addressed or consciously dispositioned:

- Probe doc comment claimed "before any serve goroutine exists" — factually wrong (input loop at serve.go:1054 and shutdown watcher at :1173 predate serveHTTP at :1181); restated the true invariant (every write on the calling goroutine before return).
- `seedResumableSession`'s unused return value — dropped.
- Leftover `cancelMu` guarding the captured cancel — dropped (same single-goroutine sequencing; `notifyContext` is called at serve.go:523 before `listen`, and `serveHTTP` reads it later on the same goroutine).
- Hard-coded session-ID literals — kept: they mirror `fresh_session_ownership_test.go`'s fixtures, pass `ValidateSessionID`, and no fresh session is minted here.
- Listener held for the test's lifetime — kept: the established pattern in this package (serve_state_test.go:755, serve_shutdown_budget_test.go:45, serve_verbose_e2e_test.go:248); a shared-fixture refactor is out of scope for this issue.
