### PR TITLE
fix(appprojector): reset the in-progress reasoning item on stream retry

### DIFF
--- a/agent/events/events.go
+++ b/agent/events/events.go
@@ -29,9 +29,11 @@ const (
 	EventAssistantTextDelta EventKind = "ASSISTANT_TEXT_DELTA"
 	// EventAssistantTextEnd marks the end of an assistant text response.
 	EventAssistantTextEnd EventKind = "ASSISTANT_TEXT_END"
-	// EventAssistantTextReset discards the in-progress assistant message: a model
-	// call retried after streaming partial output emits this so the retry's
+	// EventAssistantTextReset discards the in-progress output a retried model
+	// call streamed: a retry after partial output emits this so the retry's
 	// output replaces, rather than appends to, the partial that was shown.
+	// It covers both streamed item kinds — assistant text and reasoning —
+	// because a failed attempt typically streamed both.
 	EventAssistantTextReset EventKind = "ASSISTANT_TEXT_RESET"
 	// EventCommunicatePreviewStart opens a call-scoped provisional communicate item.
 	EventCommunicatePreviewStart EventKind = "COMMUNICATE_PREVIEW_START"

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -245,7 +245,7 @@ var Notifications = []NotificationSpec{
 	{NotifyItemStarted, ItemLifecycleParams{}, "A thread item began streaming."},
 	{NotifyItemCompleted, ItemLifecycleParams{}, "A thread item finished."},
 	{NotifyAgentMessageDelta, AgentMessageDeltaParams{}, "Incremental assistant-message text chunk for an item."},
-	{NotifyAgentMessageReset, AgentMessageResetParams{}, "Discard the in-progress assistant item (a retry replaces it)."},
+	{NotifyAgentMessageReset, AgentMessageResetParams{}, "Discard the in-progress streamed item (assistant or reasoning — a retry replaces it)."},
 	{NotifyReasoningSummaryDelta, ReasoningSummaryDeltaParams{}, "Incremental reasoning-summary text chunk for a reasoning item."},
 	{NotifyToolOutputDelta, ToolOutputDeltaParams{}, "Incremental tool-output chunk for a tool-call item."},
 	{NotifyWarning, WarningParams{}, "Non-fatal diagnostic. Also used for cancelled turns and relay-attach failures."},

--- a/cmd/evener-hub/app_relay_view_switch_test.go
+++ b/cmd/evener-hub/app_relay_view_switch_test.go
@@ -1,0 +1,177 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+// TestHubRelayViewSwitchDeliversEachDeltaOnce probes the delivery layer for
+// the #641 duplicate-delta signature: while the relay streams one block of
+// deltas, connections subscribe, unsubscribe, and re-subscribe (the view
+// switching the issue's repro describes), and every delta must reach each
+// subscribed connection exactly once. The relay and appserver layers pass
+// this — the #641 root cause was the projector's retry reset (see
+// appprojector's reasoning-reset regression test) — and this test pins the
+// delivery-once contract the fix must not regress.
+func TestHubRelayViewSwitchDeliversEachDeltaOnce(t *testing.T) {
+	const deltaCount = 12
+	thread := appwire.Thread{
+		ID:        "thread-view-switch",
+		SessionID: "thread-view-switch",
+		Source:    "local",
+		Evener:    appwire.EvenerThread{Ref: "local:thread-view-switch"},
+	}
+	deliveries := make(chan appsource.RelayDelivery, deltaCount*4)
+	handoff := &recordingRelayHandoff{
+		committed: make(chan struct{}),
+		aborted:   make(chan struct{}),
+	}
+	lease := &scriptedRelaySessionLease{
+		readResult: appsource.RelayReadResult{
+			Response: appwire.ThreadReadResponse{Thread: thread},
+			Handoff:  handoff,
+		},
+		deliveries: deliveries,
+	}
+	source := &relaySessionTestSource{thread: thread, lease: lease}
+	sources := appsource.NewRegistry()
+	sources.Add(source)
+	appServer := newHubAppServer(hubcore.WebConfig{
+		HubStateRoot: t.TempDir(),
+		Past:         hubcore.NewPastIndex(""),
+	}, sources)
+	hub := httptest.NewServer(http.HandlerFunc(appServer.ServeWebSocket))
+	defer hub.Close()
+
+	clientA := dialHubRPC(t, hub)
+	defer clientA.Close()
+	if _, err := clientA.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("initialize A: %v", err)
+	}
+	if _, err := clientA.ThreadRead(context.Background(), appwire.ThreadReadParams{Ref: thread.Evener.Ref, Subscribe: true}); err != nil {
+		t.Fatalf("thread read A: %v", err)
+	}
+
+	clientB := dialHubRPC(t, hub)
+	defer clientB.Close()
+	if _, err := clientB.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("initialize B: %v", err)
+	}
+	if _, err := clientB.ThreadRead(context.Background(), appwire.ThreadReadParams{Ref: thread.Evener.Ref, Subscribe: true}); err != nil {
+		t.Fatalf("thread read B: %v", err)
+	}
+
+	// streamDeltas streams one block, waiting for each frame's acknowledgement
+	// so the block is fully delivered before the next phase begins.
+	streamDeltas := func(from, to int) {
+		for i := from; i < to; i++ {
+			payload, _ := json.Marshal(appwire.AgentMessageDeltaParams{
+				ThreadID: thread.ID,
+				Ref:      thread.Evener.Ref,
+				TurnID:   "turn-view-switch",
+				ItemID:   "item-view-switch",
+				Delta:    fmt.Sprintf("delta-%d ", i),
+			})
+			ack := make(chan struct{})
+			var once sync.Once
+			deliveries <- appsource.RelayDelivery{
+				Notification: appwire.Notification{
+					Method: appwire.NotifyAgentMessageDelta,
+					Params: payload,
+				},
+				Acknowledge: func() { once.Do(func() { close(ack) }) },
+			}
+			select {
+			case <-ack:
+			case <-time.After(2 * time.Second):
+				t.Errorf("delta %d was not acknowledged", i)
+				return
+			}
+		}
+	}
+
+	counts := func(c *appwire.Client) map[string]int {
+		result := map[string]int{}
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			select {
+			case notification := <-c.Notifications():
+				var params appwire.AgentMessageDeltaParams
+				if notification.Method == appwire.NotifyAgentMessageDelta && json.Unmarshal(notification.Params, &params) == nil {
+					result[params.Delta]++
+				}
+			case <-time.After(500 * time.Millisecond):
+				return result
+			}
+		}
+		return result
+	}
+
+	// Phase 1: both views live, one block streams. Each delta exactly once
+	// per subscribed connection.
+	streamDeltas(0, deltaCount)
+	for label, client := range map[string]*appwire.Client{"A": clientA, "B": clientB} {
+		received := counts(client)
+		for i := 0; i < deltaCount; i++ {
+			key := fmt.Sprintf("delta-%d ", i)
+			switch got := received[key]; got {
+			case 1:
+			default:
+				t.Errorf("client %s received delta %d %d times, want exactly 1 — duplicate delta delivery (the #641 signature)", label, i, got)
+			}
+		}
+	}
+
+	// Phase 2: A leaves the view, a new block streams. A gets nothing from
+	// this block; B keeps the once-each contract.
+	if _, err := clientA.ThreadUnsubscribe(context.Background(), appwire.ThreadUnsubscribeParams{Ref: thread.Evener.Ref}); err != nil {
+		t.Fatalf("thread unsubscribe A: %v", err)
+	}
+	streamDeltas(deltaCount, deltaCount*2)
+	receivedA := counts(clientA)
+	for key, got := range receivedA {
+		if got > 0 && key >= fmt.Sprintf("delta-%d ", deltaCount) {
+			t.Errorf("client A received %q %d times after unsubscribing, want 0 — unsubscribed connection still receiving", key, got)
+		}
+	}
+	receivedB := counts(clientB)
+	for i := deltaCount; i < deltaCount*2; i++ {
+		key := fmt.Sprintf("delta-%d ", i)
+		switch got := receivedB[key]; got {
+		case 1:
+		default:
+			t.Errorf("client B received delta %d %d times, want exactly 1 — duplicate delta delivery", i, got)
+		}
+	}
+
+	// Phase 3: a new view of the same thread subscribes (the reconnect /
+	// view-re-entry shape) and a third block streams.
+	clientC := dialHubRPC(t, hub)
+	defer clientC.Close()
+	if _, err := clientC.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("initialize C: %v", err)
+	}
+	if _, err := clientC.ThreadRead(context.Background(), appwire.ThreadReadParams{Ref: thread.Evener.Ref, Subscribe: true}); err != nil {
+		t.Fatalf("thread read C: %v", err)
+	}
+	streamDeltas(deltaCount*2, deltaCount*3)
+	receivedC := counts(clientC)
+	for i := deltaCount * 2; i < deltaCount*3; i++ {
+		key := fmt.Sprintf("delta-%d ", i)
+		switch got := receivedC[key]; got {
+		case 1:
+		default:
+			t.Errorf("client C received delta %d %d times, want exactly 1 — duplicate delta delivery", i, got)
+		}
+	}
+}

--- a/cmd/evener-hub/app_relay_view_switch_test.go
+++ b/cmd/evener-hub/app_relay_view_switch_test.go
@@ -122,7 +122,7 @@ func TestHubRelayViewSwitchDeliversEachDeltaOnce(t *testing.T) {
 	streamDeltas(0, deltaCount)
 	for label, client := range map[string]*appwire.Client{"A": clientA, "B": clientB} {
 		received := counts(client)
-		for i := 0; i < deltaCount; i++ {
+		for i := range deltaCount {
 			key := fmt.Sprintf("delta-%d ", i)
 			switch got := received[key]; got {
 			case 1:

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -193,7 +193,7 @@ Pushed to subscribed connections; no `id`. The web client maps these in
 | `item/started` | `ItemLifecycleParams` | A thread item began streaming. |
 | `item/completed` | `ItemLifecycleParams` | A thread item finished. |
 | `item/agentMessage/delta` | `AgentMessageDeltaParams` | Incremental assistant-message text chunk for an item. |
-| `item/agentMessage/reset` | `AgentMessageResetParams` | Discard the in-progress assistant item (a retry replaces it). |
+| `item/agentMessage/reset` | `AgentMessageResetParams` | Discard the in-progress streamed item (assistant or reasoning — a retry replaces it). |
 | `item/reasoning/summaryTextDelta` | `ReasoningSummaryDeltaParams` | Incremental reasoning-summary text chunk for a reasoning item. |
 | `item/toolOutput/delta` | `ToolOutputDeltaParams` | Incremental tool-output chunk for a tool-call item. |
 | `warning` | `WarningParams` | Non-fatal diagnostic. Also used for cancelled turns and relay-attach failures. |

--- a/internal/appprojector/appwire_projection.go
+++ b/internal/appprojector/appwire_projection.go
@@ -454,22 +454,35 @@ func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification
 			Item:     item,
 		}))
 	case events.EventAssistantTextReset:
-		// A retry after partial output: discard the in-progress assistant item
-		// so the retry's stream replaces it rather than appending. No-op when
-		// nothing was streamed yet (no item to reset).
-		if p.assistantItem == "" {
-			return nil
+		// A retry after partial output: discard the in-progress items so the
+		// retry's stream replaces them rather than appending. The retry loop
+		// emits this one reset for BOTH item kinds — a failed attempt's
+		// reasoning and assistant text both streamed, and both must be
+		// discarded; resetting only the assistant item left the reasoning
+		// item open, so the retry's reasoning deltas appended onto the failed
+		// attempt's (the #641 repeated-word live view). No-op when nothing
+		// was streamed yet (no items to reset).
+		out := []AppNotification{}
+		if p.assistantItem != "" {
+			out = append(out, p.notification(appwire.NotifyAgentMessageReset, appwire.AgentMessageResetParams{
+				ThreadID: p.threadID,
+				Ref:      p.ref,
+				TurnID:   p.activeTurnID,
+				ItemID:   p.assistantItem,
+			}))
+			p.assistantItem = ""
+			p.assistantText = ""
 		}
-		itemID := p.assistantItem
-		turnID := p.activeTurnID
-		p.assistantItem = ""
-		p.assistantText = ""
-		return []AppNotification{p.notification(appwire.NotifyAgentMessageReset, appwire.AgentMessageResetParams{
-			ThreadID: p.threadID,
-			Ref:      p.ref,
-			TurnID:   turnID,
-			ItemID:   itemID,
-		})}
+		if p.reasoningItem != "" {
+			out = append(out, p.notification(appwire.NotifyAgentMessageReset, appwire.AgentMessageResetParams{
+				ThreadID: p.threadID,
+				Ref:      p.ref,
+				TurnID:   p.activeTurnID,
+				ItemID:   p.reasoningItem,
+			}))
+			p.reasoningItem = ""
+		}
+		return out
 	case events.EventModelRetry:
 		// Thread-scoped, item-less: the retry is state about the wait in
 		// progress, not a fact worth a transcript row (see

--- a/internal/appprojector/reasoning_reset_repro_test.go
+++ b/internal/appprojector/reasoning_reset_repro_test.go
@@ -1,0 +1,119 @@
+package appprojector
+
+import (
+	"testing"
+
+	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/appwire"
+)
+
+// TestProjector_ReasoningResetDiscardsInProgressItem pins the #641 fix: a
+// stream retry after partial output emits EventAssistantTextReset, and the
+// projector must discard the in-progress REASONING item too — not only the
+// assistant item. Without it, the reset left the reasoning item open, so the
+// retry's reasoning deltas carried the SAME item id as the failed attempt's:
+// the live view kept the old text and appended the retry's onto it, and N
+// retries rendered the same words N+1 times — the "what what what… the the
+// the…" mangled live view the issue reports. The durable transcript never
+// applied the failed attempts' deltas, which is why reload rendered correctly.
+func TestProjector_ReasoningResetDiscardsInProgressItem(t *testing.T) {
+	p := NewAppEventProjector("th_1", "local:th_1")
+	p.Project(events.SessionEvent{Kind: events.EventUserInput, SessionID: "th_1", Data: events.UserInputData{Text: "hi"}})
+	p.Project(events.SessionEvent{Kind: events.EventAssistantTextStart, SessionID: "th_1", Data: events.AssistantTextStartData{Model: "gpt-5"}})
+
+	// Attempt 1 streams reasoning, then the stream fails mid-flight. Capture
+	// the item id the live view is accumulating text under.
+	attemptOneItem := reasoningDeltaItem(t, p.Project(events.SessionEvent{
+		Kind: events.EventReasoningSummaryDelta, SessionID: "th_1",
+		Data: events.ReasoningSummaryDeltaData{SummaryIndex: 0, Delta: "what "},
+	}))
+	p.Project(events.SessionEvent{
+		Kind: events.EventReasoningSummaryDelta, SessionID: "th_1",
+		Data: events.ReasoningSummaryDeltaData{SummaryIndex: 0, Delta: "the "},
+	})
+
+	// The retry loop's OnReset fires before attempt 2. The reset must name
+	// the in-progress reasoning item so the live view discards it.
+	resetOut := p.Project(events.SessionEvent{Kind: events.EventAssistantTextReset, SessionID: "th_1", Data: events.AssistantTextResetData{}})
+	resetNamed := map[string]bool{}
+	for _, n := range resetOut {
+		if n.Method != appwire.NotifyAgentMessageReset {
+			continue
+		}
+		params, ok := n.Params.(appwire.AgentMessageResetParams)
+		if !ok {
+			continue
+		}
+		resetNamed[params.ItemID] = true
+	}
+	if !resetNamed[attemptOneItem] {
+		t.Fatalf("EventAssistantTextReset did not reset the in-progress reasoning item %q: %+v", attemptOneItem, resetOut)
+	}
+	if p.reasoningItem != "" {
+		t.Fatalf("reasoning item survived the reset: %q", p.reasoningItem)
+	}
+
+	// Attempt 2 re-streams the same words. Its deltas must open a FRESH
+	// item — a new id the live view has no text under — so nothing the
+	// failed attempt streamed survives into the retry's rendering.
+	attemptTwoItem := reasoningDeltaItem(t, p.Project(events.SessionEvent{
+		Kind: events.EventReasoningSummaryDelta, SessionID: "th_1",
+		Data: events.ReasoningSummaryDeltaData{SummaryIndex: 0, Delta: "what "},
+	}))
+	if attemptTwoItem == attemptOneItem {
+		t.Fatalf("retry's reasoning delta reused the discarded item id %q — the live view would append the retry's text onto the failed attempt's", attemptOneItem)
+	}
+}
+
+// TestProjector_ResetStillDiscardsAssistantItem pins the assistant half of
+// the same reset: the retry replacement contract that existed before this fix
+// must hold unchanged for assistant text.
+func TestProjector_ResetStillDiscardsAssistantItem(t *testing.T) {
+	p := NewAppEventProjector("th_1", "local:th_1")
+	p.Project(events.SessionEvent{Kind: events.EventUserInput, SessionID: "th_1", Data: events.UserInputData{Text: "hi"}})
+	p.Project(events.SessionEvent{Kind: events.EventAssistantTextStart, SessionID: "th_1", Data: events.AssistantTextStartData{Model: "gpt-5"}})
+
+	// An assistant item opens on the first delta.
+	var assistantItem string
+	for _, n := range p.Project(events.SessionEvent{Kind: events.EventAssistantTextDelta, SessionID: "th_1", Data: events.AssistantTextDeltaData{Delta: "partial"}}) {
+		if n.Method == appwire.NotifyAgentMessageDelta {
+			assistantItem = n.Params.(appwire.AgentMessageDeltaParams).ItemID
+		}
+	}
+	if assistantItem == "" {
+		t.Fatal("no assistant item was opened by the first delta")
+	}
+
+	resetOut := p.Project(events.SessionEvent{Kind: events.EventAssistantTextReset, SessionID: "th_1", Data: events.AssistantTextResetData{}})
+	if len(resetOut) != 1 {
+		t.Fatalf("assistant-only reset emitted %d notifications, want 1: %+v", len(resetOut), resetOut)
+	}
+	params, ok := resetOut[0].Params.(appwire.AgentMessageResetParams)
+	if !ok || params.ItemID != assistantItem {
+		t.Fatalf("reset did not name the assistant item %q: %+v", assistantItem, resetOut)
+	}
+	if p.assistantItem != "" {
+		t.Fatalf("assistant item survived the reset: %q", p.assistantItem)
+	}
+}
+
+// reasoningDeltaItem returns the item id the next reasoning delta carries —
+// the id the live view is accumulating text under.
+func reasoningDeltaItem(t *testing.T, out []AppNotification) string {
+	t.Helper()
+	for _, n := range out {
+		if n.Method != appwire.NotifyReasoningSummaryDelta {
+			continue
+		}
+		params, ok := n.Params.(appwire.ReasoningSummaryDeltaParams)
+		if !ok {
+			continue
+		}
+		if params.ItemID == "" {
+			t.Fatalf("reasoning delta carried no item id: %+v", n)
+		}
+		return params.ItemID
+	}
+	t.Fatalf("no reasoning delta in %+v", out)
+	return ""
+}


### PR DESCRIPTION
Fixes the root cause of #641 (the live view mangling streamed thinking blocks into repeated-word garbage). The lifecycle direction from the issue — wire unsubscribe on view switch — was already landed in #651; this is the missing server-side half.

## Root cause

The retry loop (`agent/session_stream.go`, `RetryStream`'s `OnReset`) emits `EventAssistantTextReset` before retrying an attempt that streamed partial output, "so the retry's output replaces rather than appends". But the projector applied that reset to the **assistant item only** — the in-progress **reasoning item** survived it, and a failed attempt typically streamed both kinds.

The failure sequence, matching the issue's report exactly (a ~8.9k-char thinking block, words repeated ~8–17×, *growing* across the block, durable transcript correct, reload renders correctly):

1. Attempt 1 streams reasoning deltas into the live reasoning item.
2. The stream fails mid-flight (truncation, SSE read timeout — what `RetryAfterPartial` exists to retry).
3. `OnReset` fires — but only the assistant item is discarded. The reasoning item stays open holding attempt 1's text.
4. Attempt 2 re-streams the same words onto that still-open item.
5. N retries → each word appears N+1 times, growing across the block: `what what what… the the the…`.
6. The durable transcript never applied the failed attempts' deltas, so reload rebuilds from clean state and renders correctly.

## Fix

`EventAssistantTextReset` now discards **both** in-progress items, emitting a reset notification for each (`internal/appprojector/appwire_projection.go`).

No wire change: `NotifyAgentMessageReset` is already the generic "discard the in-progress item by id" across item kinds (the communicate-preview reset uses it), and the frontend reducer filters by `itemId`, so the reasoning item's reset clears the live view through the existing path. Docs updated to say so (`agent/events/events.go`, `appwire/protocol.go`, regenerated `docs/appwire-protocol.md`).

## What I ruled out along the way

The issue's first suggested direction — find the duplicate emission in the relay (`app_relay.go`, `relay_session.go`) — is clean. A new hub-level test (`TestHubRelayViewSwitchDeliversEachDeltaOnce`) streams one delta block through subscribe, unsubscribe, and re-subscribe (the exact view-switching the issue's repro described) and pins that each delta reaches each subscribed connection **exactly once**, in ack-synchronized phases. The duplication needed the retry interleaving, not connection churn. That test stays as the delivery-layer contract.

## Tests

- `TestProjector_ReasoningResetDiscardsInProgressItem` — red on pre-fix code (verified by revert), green after. Asserts the reset names the in-progress reasoning item and the retry's deltas carry a **fresh item id** — the client-visible contract, since the frontend keys accumulated text by itemId.
- `TestProjector_ResetStillDiscardsAssistantItem` — pins the assistant half's pre-existing contract unchanged.
- Full suites green: appwire, appprojector, appserver, server, evener-hub; gofmt and vet clean.

## Deliberately not done

The issue's client-side suggestion (seq/id dedup in `reducer.ts`) — per discussion, that's a diaper over this class of bug. The duplicate emission itself is now gone; whether to also harden the client is a separate decision.

Refs #641
