### PR TITLE
fix(web): render GFM tables instead of collapsing to unwrapped text

### DIFF
--- a/cmd/evener-hub/frontend/src/dev/gallery-sections/markdown.tsx
+++ b/cmd/evener-hub/frontend/src/dev/gallery-sections/markdown.tsx
@@ -16,6 +16,12 @@ full change.
 
 > One test still flakes under load; tracked separately.
 
+| Step | Command | Result |
+| :--- | :--- | :---: |
+| build | \`make build\` | ok |
+| test | \`make test\` | ok |
+| lint | \`make lint\` | ok |
+
 \`\`\`go
 func main() {
 	fmt.Println("hello, evener")

--- a/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
@@ -95,17 +95,20 @@ const md = new Marked({ gfm: true, renderer });
 
 // Sanitizes the OUTPUT html, not the markdown source - this is DOMPurify's
 // documented pairing with marked (marked itself performs no sanitization).
-// The allowlist is deliberately small: every tag/attribute marked's
-// defaults or the overrides above can produce, and nothing else. Notably
-// absent: img/table and friends - GFM tables and images tokenize fine but
-// aren't allowlisted yet (no consumer needs them this wave). Disallowed
-// elements don't uniformly "degrade to their text content" though -
-// verified directly against this exact config: a <thead>'s content
-// (including its <th> cells) is dropped entirely, while a <tbody>'s
-// <td> content survives as unwrapped text; a bare <img> has no text
-// content to keep in the first place, so it just vanishes. Whichever way
-// a given element behaves, nothing dangerous survives - they fail safe,
-// just not via one single mechanism.
+// The allowlist is every tag/attribute marked's defaults or the overrides
+// above can produce, and nothing else. GFM pipe tables are supported: marked
+// tokenizes them (gfm: true) into <table>/<thead>/<tbody>/<tr>/<th>/<td> with
+// an align="left|center|right" attribute per aligned column, so all six
+// table tags plus `align` are allowlisted. The only path to a real <table>
+// is that tokenizer: the html() override below escapes all authored raw
+// HTML to text before DOMPurify ever sees it, so no markdown-typed <table>
+// can sneak through. Still absent: img - images tokenize fine but aren't
+// allowlisted yet (no consumer needs them this wave). Disallowed elements
+// don't uniformly "degrade to their text content" though - verified
+// directly against this exact config: a bare <img> has no text content to
+// keep, so it just vanishes. Whichever way a given element behaves,
+// nothing dangerous survives - they fail safe, just not via one single
+// mechanism.
 const SANITIZE_CONFIG = {
   ALLOWED_TAGS: [
     "p",
@@ -129,6 +132,12 @@ const SANITIZE_CONFIG = {
     "blockquote",
     "div",
     "span",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
   ],
   // "class" is allowlisted globally (not scoped to specific tags) but is
   // currently inert against anything a markdown AUTHOR controls: the only
@@ -136,10 +145,13 @@ const SANITIZE_CONFIG = {
   // above writes itself (CODEBLOCK_CLASS/CLASS.inlineCode) - html() above
   // escapes all raw source HTML to text before DOMPurify ever sees it, so
   // there's no path today for a class value to originate from user input.
-  // If a future change widens ALLOWED_TAGS to let raw source HTML through
-  // in some form, that safety stops being automatic - re-check whether
-  // "class" should stay this permissive at that point.
-  ALLOWED_ATTR: ["href", "title", "target", "rel", "class"],
+  // `align` is the legacy HTML attribute marked emits for GFM column
+  // alignment (:---/:---:/---:); it carries no script surface and is
+  // harmless on table cells. If a future change widens ALLOWED_TAGS to let
+  // raw source HTML through in some form, that safety stops being
+  // automatic - re-check whether "class"/"align" should stay this
+  // permissive at that point.
+  ALLOWED_ATTR: ["href", "title", "target", "rel", "class", "align"],
 };
 
 /**

--- a/cmd/evener-hub/frontend/src/widgets/markdown/markdown.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/markdown.module.css
@@ -121,3 +121,71 @@
   color: var(--ink-hi);
   border-bottom: 1px solid var(--edge);
 }
+
+/* GFM pipe tables. marked (gfm: true) tokenizes them into a bare
+ * <table>/<thead>/<tbody>/<tr>/<th>/<td> with no class attributes, so - like
+ * the headings/paragraphs above - these are styled by plain-tag descendant
+ * selectors scoped under .root (CSS Modules only renames `.class`/`#id`
+ * selectors, leaving a bare `table`/`th` inside `.root table { }` untouched).
+ * The chrome reuses the same tokens the standalone Table/DiffTable widgets
+ * use (border-collapse, --edge hairlines, --surface-inset header band,
+ * --hover-1 row hover) but at PROSE scale: font-size inherits from .root
+ * (so a table inside agent prose at --font-size-pane-title sizes with it),
+ * and padding is tight so a dense table reads as a paragraph of cells, not a
+ * chrome-heavy data grid. Overflow-wrap on .root already lets long cell
+ * tokens wrap; a wide table itself is contained by the host bubble/pane, and
+ * overflow-x here lets it scroll horizontally rather than forcing the pane
+ * wider. */
+.root :where(table) {
+  margin: 0 0 var(--space-3);
+  border-collapse: collapse;
+  width: 100%;
+  font-size: inherit;
+}
+
+.root :where(thead th) {
+  padding: var(--space-1) var(--space-2);
+  background: var(--surface-inset);
+  border-bottom: 1px solid var(--edge);
+  color: var(--ink-low);
+  font-weight: var(--font-weight-semibold);
+  text-align: left;
+  white-space: nowrap;
+}
+
+.root :where(tbody td) {
+  padding: var(--space-1) var(--space-2);
+  color: var(--ink-hi);
+  text-align: left;
+  vertical-align: top;
+}
+
+.root :where(tbody tr) {
+  border-bottom: 1px solid var(--edge);
+}
+
+.root :where(tbody tr:last-child) {
+  border-bottom: none;
+}
+
+.root :where(tbody tr:hover) {
+  background: var(--hover-1);
+}
+
+/* GFM column alignment: marked emits the legacy align="left|center|right"
+ * attribute on each <th>/<td> for the :---/:---:/---: delimiter syntax. It's
+ * allowlisted through DOMPurify (not a style attribute) and carries no script
+ * surface, so these attribute selectors honor author alignment without
+ * widening the allowlist to `style`. The bare th/td text-align above is the
+ * default; an explicit align attribute wins by specificity. */
+.root :where(th[align="center"], td[align="center"]) {
+  text-align: center;
+}
+
+.root :where(th[align="right"], td[align="right"]) {
+  text-align: right;
+}
+
+.root :where(th[align="left"], td[align="left"]) {
+  text-align: left;
+}

--- a/cmd/evener-hub/frontend/src/widgets/markdown/markdown.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/markdown.test.tsx
@@ -211,3 +211,46 @@ test("the root rule wraps long unbreakable tokens anywhere", () => {
   expect(root).not.toBeNull();
   expect(root![1]).toContain("overflow-wrap: anywhere");
 });
+
+// --- GFM tables -------------------------------------------------------------
+// marked tokenizes GFM pipe tables (gfm: true) into <table> markup; the
+// DOMPurify allowlist must keep every table tag so the structure survives
+// sanitization instead of collapsing to unwrapped cell text (headers dropped
+// entirely). These guard against re-removing the tags from the allowlist.
+
+test("renders a GFM table with header and body rows", () => {
+  const { container } = render(
+    <Markdown source={"| Name | Value |\n| ---- | ----- |\n| foo | 123 |\n| bar | 456 |"} />,
+  );
+  expect(container.querySelector("table")).not.toBeNull();
+  expect(container.querySelectorAll("thead tr th")).toHaveLength(2);
+  expect(container.querySelectorAll("thead tr th")[0]?.textContent).toBe("Name");
+  expect(container.querySelectorAll("tbody tr")).toHaveLength(2);
+  expect(container.querySelectorAll("tbody tr")[0]?.querySelectorAll("td")).toHaveLength(2);
+  expect(container.querySelectorAll("tbody tr")[0]?.querySelectorAll("td")[0]?.textContent).toBe("foo");
+});
+
+test("renders GFM column alignment via the align attribute", () => {
+  const { container } = render(<Markdown source={"| L | C | R |\n| :--- | :---: | ---: |\n| a | b | c |"} />);
+  const ths = Array.from(container.querySelectorAll("thead th"));
+  expect(ths.map((th) => th.getAttribute("align"))).toEqual(["left", "center", "right"]);
+  const tds = Array.from(container.querySelectorAll("tbody tr:first-child td"));
+  expect(tds.map((td) => td.getAttribute("align"))).toEqual(["left", "center", "right"]);
+});
+
+// The table chrome lives in the stylesheet, not on a class the component
+// writes, so - like the ink/font-size assertions above - this reads the
+// stylesheet's own source. Guards the table styling contract: a header band
+// on --surface-inset, --edge hairlines, and the legacy align attribute
+// honored via attribute selectors (so GFM column alignment works without
+// allowing the style attribute through DOMPurify).
+test("the stylesheet styles GFM tables: header band, edge borders, align selectors", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const css = readFileSync(join(here, "markdown.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+  expect(css).toContain(".root :where(table)");
+  expect(css).toContain("border-collapse: collapse");
+  expect(css).toMatch(/thead th[^{]*\{[^}]*--surface-inset/);
+  expect(css).toMatch(/--edge/);
+  expect(css).toContain('th[align="center"]');
+  expect(css).toContain('td[align="right"]');
+});


### PR DESCRIPTION
## Problem

The web transcript renderer's Markdown widget rendered GFM pipe tables as an inline `<p>` with no tabular markup: the header row vanished entirely and body cells survived as unwrapped text.

## Root cause

**Not** the markdown→table converter. `marked` is configured with `gfm: true` and tokenizes GFM pipe tables correctly into proper `<table>` markup.

The bug was the **second** stage — DOMPurify sanitization. `SANITIZE_CONFIG.ALLOWED_TAGS` in `src/widgets/markdown/index.tsx` allowlisted no table tags, so DOMPurify stripped every `<table>/<thead>/<tbody>/<tr>/<th>/<td>` from marked's output. The code's own comment documented this as a deliberate "not this wave" scope cut and described the exact symptom: a `<thead>`'s content (including `<th>` cells) dropped entirely, a `<tbody>`'s `<td>` content survived as unwrapped text.

Confirmed empirically: a `| Name | Value |` table rendered as bare `\nfoo\n123\nbar\n456\n` with zero table elements.

## Fix (4 files, +144/-15)

**`src/widgets/markdown/index.tsx`** — Widened `ALLOWED_TAGS` to add `table, thead, tbody, tr, th, td`, and added `align` to `ALLOWED_ATTR`. Updated the stale "scope cut" comments to document the new reality and security rationale. The only path to a real `<table>` is marked's GFM tokenizer: the `html()` renderer override escapes all *authored* raw HTML to text before DOMPurify sees it, so no markdown-typed table can sneak through. The `align` attribute carries no script surface.

**`src/widgets/markdown/markdown.module.css`** — Added GFM table styling scoped under `.root`, reusing established table conventions from the standalone Table/DiffTable widgets (`border-collapse`, `--edge` hairlines, `--surface-inset` header band, `--hover-1` row hover) at **prose scale** (`font-size: inherit`, tight padding). GFM column alignment works via `[align="left|center|right"]` **attribute selectors** — so `:---:` syntax is honored **without** widening the allowlist to the `style` attribute.

**`src/widgets/markdown/markdown.test.tsx`** — 3 regression tests: table header/body structure, column alignment via the `align` attribute, and a CSS-source contract test guarding the styling.

**`src/dev/gallery-sections/markdown.tsx`** — Added a GFM table (with a centered column) to the widget gallery sample.

## Verification

- `make test-web` → **PASS** (web-typecheck, web-test, web-lint), exit 0
- 28/28 markdown widget tests pass; no regressions
- Failing-test-first: the 2 structure tests failed before the allowlist change, passed after

## Security note

Chose the `align` HTML attribute path (what marked emits) over allowing `style`. DOMPurify does sanitize `style` values, but `align` is narrower and carries no script surface, keeping the allowlist minimal. The file comments now flag both `class` and `align` for re-review if a future change ever lets authored raw HTML through.