### PR TITLE
Fix header-only transcript resumes reporting no restored transcript

### DIFF
--- a/agent/session.go
+++ b/agent/session.go
@@ -716,14 +716,18 @@ type Session struct {
 
 	// restoredTranscript holds the decoded transcript a RESUME read while
 	// validating the session it was asked to restore: the header (with its
-	// SessionID already checked against this session's id) and the retained
-	// entries. It exists so serve's app-identity projection can reuse that
-	// one strict decode instead of re-reading and re-decoding the whole
-	// append-only file; it is populated only on the restore path, after any
-	// delegate-delivery refresh, and is never updated after construction.
-	// Guarded by s.mu.
+	// SessionID already checked against this session's id), the retained
+	// entries, and whether a transcript was opened at all — the ok flag, kept
+	// as an explicit bool rather than inferred from the entries slice, so a
+	// header-only refresh (whose entry list is empty) cannot silently flip
+	// ok back to false. It exists so serve's app-identity projection can
+	// reuse that one strict decode instead of re-reading and re-decoding the
+	// whole append-only file; it is populated only on the restore path,
+	// after any delegate-delivery refresh, and is never updated after
+	// construction. Guarded by s.mu.
 	restoredTranscriptHeader transcript.Header
 	restoredTranscript       []transcript.Entry
+	restoredTranscriptOpened bool
 
 	// Cached tool definitions.
 	cachedToolDefs []llm.ToolDefinition
@@ -1787,22 +1791,26 @@ func (s *Session) TranscriptPath() string {
 
 // setRestoredTranscript installs the final restore-time transcript view. It
 // runs once, at the end of restore construction, with the entry list that any
-// delegate-delivery replay already refreshed from disk.
-func (s *Session) setRestoredTranscript(header transcript.Header, entries []transcript.Entry) {
+// delegate-delivery replay already refreshed from disk. opened reports
+// whether restore opened a transcript at all, independent of the entry
+// slice's emptiness.
+func (s *Session) setRestoredTranscript(header transcript.Header, entries []transcript.Entry, opened bool) {
 	s.mu.Lock()
 	s.restoredTranscriptHeader = header
 	s.restoredTranscript = entries
+	s.restoredTranscriptOpened = opened
 	s.mu.Unlock()
 }
 
 // RestoredTranscript returns the header and decoded entry list this resume
 // validated, for a caller (serve's app-identity projection) that would
-// otherwise re-read the transcript file. ok is false unless this session was
-// constructed by restore with a transcript; the slice aliases retained state
-// and must be treated as read-only.
+// otherwise re-read the transcript file. ok is true exactly when restore
+// opened a transcript, including a header-only one; the slice aliases
+// retained state and must be treated as read-only.
 func (s *Session) RestoredTranscript() (transcript.Header, []transcript.Entry, bool) {
 	s.mu.Lock()
 	header, entries := s.restoredTranscriptHeader, s.restoredTranscript
+	opened := s.restoredTranscriptOpened
 	s.mu.Unlock()
-	return header, entries, entries != nil
+	return header, entries, opened
 }

--- a/agent/session.go
+++ b/agent/session.go
@@ -716,17 +716,18 @@ type Session struct {
 
 	// restoredTranscript holds the decoded transcript a RESUME read while
 	// validating the session it was asked to restore: the header (with its
-	// SessionID already checked against this session's id), the retained
-	// entries, and whether a transcript was opened at all — the ok flag, kept
-	// as an explicit bool rather than inferred from the entries slice, so a
-	// header-only refresh (whose entry list is empty) cannot silently flip
-	// ok back to false. It exists so serve's app-identity projection can
-	// reuse that one strict decode instead of re-reading and re-decoding the
-	// whole append-only file; it is populated only on the restore path,
-	// after any delegate-delivery refresh, and is never updated after
-	// construction. Guarded by s.mu.
+	// SessionID already checked against this session's id) and the retained
+	// entries. It exists so serve's app-identity projection can reuse that
+	// one strict decode instead of re-reading and re-decoding the whole
+	// append-only file; it is populated only on the restore path, after any
+	// delegate-delivery refresh, and is never updated after construction.
+	// Guarded by s.mu.
 	restoredTranscriptHeader transcript.Header
 	restoredTranscript       []transcript.Entry
+
+	// restoredTranscriptOpened is the ok flag RestoredTranscript reports:
+	// whether restore opened a transcript, captured at the open so a later
+	// refresh cannot flip it. Guarded by s.mu.
 	restoredTranscriptOpened bool
 
 	// Cached tool definitions.

--- a/agent/session_attention.go
+++ b/agent/session_attention.go
@@ -925,9 +925,11 @@ func (s *Session) resetStableDelegateAttentionRetry() {
 // entries is the final in-memory entry list restore produced (refreshed from
 // disk when delegate delivery replay appended to the transcript): folding it
 // instead of re-opening the file is what keeps resume from strict-decoding
-// the whole transcript a second time. A nil entries list falls back to the
-// file read (the fresh-session construction path, which holds no decoded
-// entry list).
+// the whole transcript a second time. The list is non-nil whenever a
+// transcript was opened — including a header-only one, where folding zero
+// entries matches reading that file — so a nil list means the caller holds no
+// decoded list at all (the fresh-session construction path) and the fold
+// re-reads the file.
 func (s *Session) rearmRootDelegateAttentionFromTranscript(entries []transcript.Entry) error {
 	if !s.isRootDelegateAttentionReceiver() {
 		return nil

--- a/agent/session_attention.go
+++ b/agent/session_attention.go
@@ -925,11 +925,9 @@ func (s *Session) resetStableDelegateAttentionRetry() {
 // entries is the final in-memory entry list restore produced (refreshed from
 // disk when delegate delivery replay appended to the transcript): folding it
 // instead of re-opening the file is what keeps resume from strict-decoding
-// the whole transcript a second time. The list is non-nil whenever a
-// transcript was opened — including a header-only one, where folding zero
-// entries matches reading that file — so a nil list means the caller holds no
-// decoded list at all (the fresh-session construction path) and the fold
-// re-reads the file.
+// the whole transcript a second time. A nil list means the caller has no
+// decoded list to fold (a fresh session, or a refresh that produced none);
+// the fold then re-reads the file.
 func (s *Session) rearmRootDelegateAttentionFromTranscript(entries []transcript.Entry) error {
 	if !s.isRootDelegateAttentionReceiver() {
 		return nil

--- a/agent/session_attention_rearm_entries_test.go
+++ b/agent/session_attention_rearm_entries_test.go
@@ -113,9 +113,9 @@ func TestRootDelegateAttention_RestoreRearmFoldsTheRetainedEntries(t *testing.T)
 // TestRestoreSession_RestoredTranscriptOKBoundary pins the ok flag's
 // boundary: a session restored with NO transcript on disk reports ok=false,
 // one restored over a transcript with at least one entry reports ok=true
-// with that entry, and — since the header-only fix — one restored over a
-// header-only transcript reports ok=true with a non-nil empty slice: ok
-// means "a transcript was opened and validated," not "entries exist."
+// with that entry, and one restored over a header-only transcript reports
+// ok=true with a non-nil empty slice: ok means "a transcript was opened and
+// validated," not "entries exist."
 func TestRestoreSession_RestoredTranscriptOKBoundary(t *testing.T) {
 	t.Run("no transcript on disk", func(t *testing.T) {
 		stateDir := t.TempDir()
@@ -147,9 +147,6 @@ func TestRestoreSession_RestoredTranscriptOKBoundary(t *testing.T) {
 	t.Run("header-only transcript", func(t *testing.T) {
 		stateDir := t.TempDir()
 		rootID := identifier.MustNewSessionID()
-		if err := os.MkdirAll(filepath.Join(stateDir, sessionsSubdir), 0o755); err != nil {
-			t.Fatalf("mkdir sessions: %v", err)
-		}
 		meta := schema.SessionMeta{ID: rootID, ProfileID: "openai", Model: "gpt-5.2"}
 		if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
 			t.Fatalf("save root metadata: %v", err)

--- a/agent/session_attention_rearm_entries_test.go
+++ b/agent/session_attention_rearm_entries_test.go
@@ -112,11 +112,10 @@ func TestRootDelegateAttention_RestoreRearmFoldsTheRetainedEntries(t *testing.T)
 
 // TestRestoreSession_RestoredTranscriptOKBoundary pins the ok flag's
 // boundary: a session restored with NO transcript on disk reports ok=false,
-// and one restored over a transcript with at least one entry reports ok=true
-// with that entry. (A header-only transcript currently lands on the ok=false
-// side of the line: resumeWriter returns a nil entry slice when no entry
-// line follows the header, and RestoredTranscript keys ok on entries != nil.
-// That is the pre-existing resumeWriter behavior, not a restore decision.)
+// one restored over a transcript with at least one entry reports ok=true
+// with that entry, and — since the header-only fix — one restored over a
+// header-only transcript reports ok=true with a non-nil empty slice: ok
+// means "a transcript was opened and validated," not "entries exist."
 func TestRestoreSession_RestoredTranscriptOKBoundary(t *testing.T) {
 	t.Run("no transcript on disk", func(t *testing.T) {
 		stateDir := t.TempDir()
@@ -143,6 +142,36 @@ func TestRestoreSession_RestoredTranscriptOKBoundary(t *testing.T) {
 		_, entries, ok := restored.RestoredTranscript()
 		if !ok || len(entries) == 0 {
 			t.Fatalf("RestoredTranscript = ok:%t entries:%d, want ok:true with the fixture's entries", ok, len(entries))
+		}
+	})
+	t.Run("header-only transcript", func(t *testing.T) {
+		stateDir := t.TempDir()
+		rootID := identifier.MustNewSessionID()
+		if err := os.MkdirAll(filepath.Join(stateDir, sessionsSubdir), 0o755); err != nil {
+			t.Fatalf("mkdir sessions: %v", err)
+		}
+		meta := schema.SessionMeta{ID: rootID, ProfileID: "openai", Model: "gpt-5.2"}
+		if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
+			t.Fatalf("save root metadata: %v", err)
+		}
+		writer, err := transcript.NewWriter(transcriptPath(stateDir, rootID), transcript.Header{SessionID: rootID, ProfileID: "openai", Model: "gpt-5.2"})
+		if err != nil {
+			t.Fatalf("write header-only transcript: %v", err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("close writer: %v", err)
+		}
+		restored, err := RestoreSessionFromMeta(llm.NewClient(), NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(stateDir), meta, stateDir)
+		if err != nil {
+			t.Fatalf("restore over header-only transcript: %v", err)
+		}
+		defer restored.Close()
+		_, entries, ok := restored.RestoredTranscript()
+		if !ok {
+			t.Fatal("a session restored over a header-only transcript reported no restored transcript; ok must mean 'a transcript was opened'")
+		}
+		if entries == nil || len(entries) != 0 {
+			t.Fatalf("entries = %#v, want a non-nil empty slice over a header-only transcript", entries)
 		}
 	})
 }

--- a/agent/session_header_only_refresh_test.go
+++ b/agent/session_header_only_refresh_test.go
@@ -1,0 +1,76 @@
+package agent
+
+import (
+	"testing"
+
+	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/identifier"
+	"primeradiant.com/evener/llm"
+)
+
+// TestRestoredTranscriptOpenFlagSurvivesEmptyRefresh pins the property the
+// explicit opened flag exists for, at the seam where it is decided.
+//
+// Before the flag, ok was inferred from entries != nil — and the restore
+// path's refreshFromDisk re-reads the transcript after delegate-delivery
+// replay via readTranscriptFull, whose entry list is append-built and
+// therefore NIL for a header-only file. A header-only session that replayed
+// a delivery would silently flip ok back to false, sending serve to the
+// file form after all. The flag is captured at the open (openErr == nil)
+// and survives every refresh.
+//
+// The two subtests exercise both refresh shapes against a session whose
+// restore opened a header-only transcript: setRestoredTranscript receives
+// whatever the refresh produced (nil or empty), and ok must hold.
+func TestRestoredTranscriptOpenFlagSurvivesEmptyRefresh(t *testing.T) {
+	for name, refreshEntries := range map[string][]transcript.Entry{
+		"refresh over header-only file (nil entries from append-built read)": nil,
+		"refresh over header-only file (empty non-nil entries)":              {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := &Session{}
+			s.setRestoredTranscript(transcript.Header{SessionID: "sid"}, refreshEntries, true)
+			_, entries, ok := s.RestoredTranscript()
+			if !ok {
+				t.Fatal("ok flipped to false when the refresh produced an empty entry list; ok must mean 'a transcript was opened'")
+			}
+			if len(entries) != 0 {
+				t.Fatalf("entries = %d, want 0", len(entries))
+			}
+		})
+	}
+}
+
+// TestRestoreSession_HeaderOnlyOpenCapturesOKFlag pins the capture itself:
+// restoring over a header-only transcript sets the opened flag even though
+// the entry list is empty, so the very first RestoredTranscript call after
+// restore reports ok=true.
+func TestRestoreSession_HeaderOnlyOpenCapturesOKFlag(t *testing.T) {
+	stateDir := t.TempDir()
+	rootID := identifier.MustNewSessionID()
+	meta := schema.SessionMeta{ID: rootID, ProfileID: "openai", Model: "gpt-5.2"}
+	if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+	writer, err := transcript.NewWriter(transcriptPath(stateDir, rootID), transcript.Header{SessionID: rootID, ProfileID: "openai", Model: "gpt-5.2"})
+	if err != nil {
+		t.Fatalf("create header-only transcript: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	restored, err := RestoreSessionFromMetaWithConfig(
+		llm.NewClient(), NewOpenAIProfile("gpt-5.2"),
+		execenv.NewLocalExecutionEnvironment(stateDir),
+		meta, RestoreSessionConfig{StateDir: stateDir},
+	)
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	defer restored.Close()
+	if _, _, ok := restored.RestoredTranscript(); !ok {
+		t.Fatal("restore over a header-only transcript did not capture the opened flag")
+	}
+}

--- a/agent/session_header_only_refresh_test.go
+++ b/agent/session_header_only_refresh_test.go
@@ -3,31 +3,19 @@ package agent
 import (
 	"testing"
 
-	"primeradiant.com/evener/agent/execenv"
-	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/agent/transcript"
-	"primeradiant.com/evener/identifier"
-	"primeradiant.com/evener/llm"
 )
 
 // TestRestoredTranscriptOpenFlagSurvivesEmptyRefresh pins the property the
 // explicit opened flag exists for, at the seam where it is decided.
 //
-// Before the flag, ok was inferred from entries != nil — and the restore
-// path's refreshFromDisk re-reads the transcript after delegate-delivery
-// replay via readTranscriptFull, whose entry list is append-built and
-// therefore NIL for a header-only file. A header-only session that replayed
-// a delivery would silently flip ok back to false, sending serve to the
-// file form after all. The flag is captured at the open (openErr == nil)
-// and survives every refresh.
-//
-// The two subtests exercise both refresh shapes against a session whose
-// restore opened a header-only transcript: setRestoredTranscript receives
-// whatever the refresh produced (nil or empty), and ok must hold.
+// A restore-time refresh re-reads the transcript and can produce an empty
+// or nil entry list (a header-only file re-reads as nil); ok must not flip
+// to false when that happens.
 func TestRestoredTranscriptOpenFlagSurvivesEmptyRefresh(t *testing.T) {
 	for name, refreshEntries := range map[string][]transcript.Entry{
-		"refresh over header-only file (nil entries from append-built read)": nil,
-		"refresh over header-only file (empty non-nil entries)":              {},
+		"nil entries":   nil,
+		"empty entries": {},
 	} {
 		t.Run(name, func(t *testing.T) {
 			s := &Session{}
@@ -40,37 +28,5 @@ func TestRestoredTranscriptOpenFlagSurvivesEmptyRefresh(t *testing.T) {
 				t.Fatalf("entries = %d, want 0", len(entries))
 			}
 		})
-	}
-}
-
-// TestRestoreSession_HeaderOnlyOpenCapturesOKFlag pins the capture itself:
-// restoring over a header-only transcript sets the opened flag even though
-// the entry list is empty, so the very first RestoredTranscript call after
-// restore reports ok=true.
-func TestRestoreSession_HeaderOnlyOpenCapturesOKFlag(t *testing.T) {
-	stateDir := t.TempDir()
-	rootID := identifier.MustNewSessionID()
-	meta := schema.SessionMeta{ID: rootID, ProfileID: "openai", Model: "gpt-5.2"}
-	if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
-		t.Fatalf("save metadata: %v", err)
-	}
-	writer, err := transcript.NewWriter(transcriptPath(stateDir, rootID), transcript.Header{SessionID: rootID, ProfileID: "openai", Model: "gpt-5.2"})
-	if err != nil {
-		t.Fatalf("create header-only transcript: %v", err)
-	}
-	if err := writer.Close(); err != nil {
-		t.Fatalf("close writer: %v", err)
-	}
-	restored, err := RestoreSessionFromMetaWithConfig(
-		llm.NewClient(), NewOpenAIProfile("gpt-5.2"),
-		execenv.NewLocalExecutionEnvironment(stateDir),
-		meta, RestoreSessionConfig{StateDir: stateDir},
-	)
-	if err != nil {
-		t.Fatalf("restore: %v", err)
-	}
-	defer restored.Close()
-	if _, _, ok := restored.RestoredTranscript(); !ok {
-		t.Fatal("restore over a header-only transcript did not capture the opened flag")
 	}
 }

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -675,6 +675,11 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 	var resumeTranscript *transcript.Writer
 	var transcriptEntries []transcript.Entry
 	var restoredTranscriptHeader transcript.Header
+	// restoredTranscriptOpened is the ok flag RestoredTranscript reports:
+	// captured at the open, not inferred from the entry slice, so the
+	// delegate-delivery refresh below (whose re-read of a header-only file
+	// produces an empty entry list) cannot silently flip it back to false.
+	restoredTranscriptOpened := false
 	if cfg.StateDir != "" {
 		tpath := filepath.Join(cfg.StateDir, sessionsSubdir, meta.ID+".transcript.jsonl")
 		var openErr error
@@ -685,6 +690,7 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 		if resumeTranscript != nil {
 			restoredTranscriptHeader = resumeTranscript.Header()
 		}
+		restoredTranscriptOpened = openErr == nil
 	}
 	defer func() {
 		if !restoreComplete && resumeTranscript != nil {
@@ -1058,7 +1064,7 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 	// setRestoredTranscript and the attention rearm both run after every
 	// restore-time transcript append, so serve and the fold see the same
 	// final entry list the file holds.
-	s.setRestoredTranscript(restoredTranscriptHeader, transcriptEntries)
+	s.setRestoredTranscript(restoredTranscriptHeader, transcriptEntries, restoredTranscriptOpened)
 	if err := s.rearmRootDelegateAttentionFromTranscript(transcriptEntries); err != nil {
 		return nil, fmt.Errorf("rearm root delegate attention: %w", err)
 	}

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -675,10 +675,8 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 	var resumeTranscript *transcript.Writer
 	var transcriptEntries []transcript.Entry
 	var restoredTranscriptHeader transcript.Header
-	// restoredTranscriptOpened is the ok flag RestoredTranscript reports:
-	// captured at the open, not inferred from the entry slice, so the
-	// delegate-delivery refresh below (whose re-read of a header-only file
-	// produces an empty entry list) cannot silently flip it back to false.
+	// ok flag for RestoredTranscript; captured at the open so the refresh
+	// below can't flip it.
 	restoredTranscriptOpened := false
 	if cfg.StateDir != "" {
 		tpath := filepath.Join(cfg.StateDir, sessionsSubdir, meta.ID+".transcript.jsonl")

--- a/agent/transcript/header_only_reopen_test.go
+++ b/agent/transcript/header_only_reopen_test.go
@@ -7,12 +7,9 @@ import (
 
 // TestOpenWriterForSessionHeaderOnlyReturnsNonNilEntries pins the resume
 // contract at the transcript layer: a successful open over a header-only
-// file returns a NON-NIL empty entry slice. Session.RestoredTranscript
-// (whose ok flag means "a transcript was opened") and the delegate
-// attention fold (whose nil gate means "caller holds no decoded list")
-// both key on the slice's nilness, so this must not regress to var-style
-// nil initialization even though the two are equivalent to range and
-// append.
+// file returns a NON-NIL empty entry slice: the delegate-attention fold
+// keys on that nilness to skip re-reading the file, so this must not
+// regress to var-style nil initialization.
 func TestOpenWriterForSessionHeaderOnlyReturnsNonNilEntries(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "header-only.transcript.jsonl")

--- a/agent/transcript/header_only_reopen_test.go
+++ b/agent/transcript/header_only_reopen_test.go
@@ -1,0 +1,38 @@
+package transcript
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestOpenWriterForSessionHeaderOnlyReturnsNonNilEntries pins the resume
+// contract at the transcript layer: a successful open over a header-only
+// file returns a NON-NIL empty entry slice. Session.RestoredTranscript
+// (whose ok flag means "a transcript was opened") and the delegate
+// attention fold (whose nil gate means "caller holds no decoded list")
+// both key on the slice's nilness, so this must not regress to var-style
+// nil initialization even though the two are equivalent to range and
+// append.
+func TestOpenWriterForSessionHeaderOnlyReturnsNonNilEntries(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "header-only.transcript.jsonl")
+	const sessionID = "034FwfafTaAYeTEUVT9lSR"
+	writer, err := NewWriter(path, Header{SessionID: sessionID, ProfileID: "openai", Model: "gpt-test"})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	resumed, entries, err := OpenWriterForSession(path, sessionID)
+	if err != nil {
+		t.Fatalf("OpenWriterForSession: %v", err)
+	}
+	defer func() { _ = resumed.Close() }()
+	if entries == nil {
+		t.Fatal("entries = nil over a header-only transcript, want non-nil empty: ok sentinels key on nilness")
+	}
+	if len(entries) != 0 {
+		t.Fatalf("entries = %d, want 0 over a header-only transcript", len(entries))
+	}
+}

--- a/agent/transcript/transcript.go
+++ b/agent/transcript/transcript.go
@@ -592,9 +592,9 @@ func resumeWriter(fs afero.Fs, f afero.File, expectedSessionID string) (*Writer,
 	// boundary before any crash tail. The shared framer drains an arbitrarily
 	// large unterminated tail without retaining the file in memory.
 	maxSeq := -1
-	// entries is non-nil even for a header-only transcript: a successful open
-	// means "this transcript exists and was validated," and callers (notably
-	// Session.RestoredTranscript's ok flag) use non-nil as exactly that.
+	// entries is non-nil even for a header-only transcript: the
+	// delegate-attention fold keys on nilness to decide whether it can fold
+	// in memory or must re-read the file.
 	entries := make([]Entry, 0)
 	reader := bufio.NewReaderSize(f, 64*1024)
 	var validLen int64

--- a/agent/transcript/transcript.go
+++ b/agent/transcript/transcript.go
@@ -592,7 +592,10 @@ func resumeWriter(fs afero.Fs, f afero.File, expectedSessionID string) (*Writer,
 	// boundary before any crash tail. The shared framer drains an arbitrarily
 	// large unterminated tail without retaining the file in memory.
 	maxSeq := -1
-	var entries []Entry
+	// entries is non-nil even for a header-only transcript: a successful open
+	// means "this transcript exists and was validated," and callers (notably
+	// Session.RestoredTranscript's ok flag) use non-nil as exactly that.
+	entries := make([]Entry, 0)
 	reader := bufio.NewReaderSize(f, 64*1024)
 	var validLen int64
 	hasPartialTail := false


### PR DESCRIPTION
Fixes #646.

## Summary

`transcript.resumeWriter` returned a nil entry slice for a header-only transcript (a session whose transcript was created but never appended to). Because `Session.RestoredTranscript` inferred its ok flag from `entries != nil`, a resume over such a transcript reported ok=false — serve then fell back to re-reading the file it had already decoded, and the delegate-attention fold re-read it too.

Two fixes:

1. `resumeWriter` now initializes `entries := make([]Entry, 0)`, so a successful open over a header-only file returns a **non-nil empty slice**. A successful open already means "this transcript exists and was validated"; the entry list now says so too. This also removes a redundant file re-read in the delegate-attention fold, whose nil gate (`session_attention.go`) previously sent a header-only resume back to disk.

2. The ok flag is now an explicit `restoredTranscriptOpened` bool, captured once at the open (`openErr == nil`) and returned by `RestoredTranscript` — no longer inferred from slice nilness. This makes ok structural ("a transcript was opened"), so no later restore-time refresh can flip it regardless of how the refreshed slice is built. A prior revision inferred ok from nilness, and the restore path's `refreshFromDisk` re-read builds its list with `append` over a nil slice — a header-only file re-reads as nil, which would have silently flipped ok back to false on the refresh path.

## What changed

- `agent/transcript/transcript.go` — `make([]Entry, 0)` in `resumeWriter`; comment names the real nilness consumer (the fold's in-memory-vs-file-read gate).
- `agent/session.go` — new `restoredTranscriptOpened` field (guarded by `s.mu`, like its neighbors); `setRestoredTranscript` takes the flag; `RestoredTranscript` returns it.
- `agent/session_init.go` — flag captured at the open site, before the fresh-writer reassignment and both `refreshFromDisk` triggers, and threaded to `setRestoredTranscript`.
- Tests: the transcript-layer nilness contract (`TestOpenWriterForSessionHeaderOnlyReturnsNonNilEntries`), the ok-flag boundary across no-file / entries / header-only shapes (`TestRestoreSession_RestoredTranscriptOKBoundary`), and the flag-survives-empty-refresh seam property (`TestRestoredTranscriptOpenFlagSurvivesEmptyRefresh`).

Consumers audited: every `OpenWriterForSession`/`OpenWriterForSessionWithFS` call site is nil/empty-agnostic (range, len, or discard) except the fold's nil gate, which is exactly the improvement above.

## Verification

- `go test ./agent/ ./agent/transcript/` — ok (agent ~112-161s across runs, transcript <1s)
- `go build ./...`, `go vet`, `gofmt -l` — clean
- `-race` on the new tests — pass
- Full gates independently re-run by an adversarial reviewer: build/vet/gofmt clean; `agent` 160.5s ok; `agent/transcript`, `server`, `internal/apptranscript`, `cmd/evener` all ok; `-race` on new tests pass.

## Review process

Simplify pass (4 angles: Reuse / Simplification / Efficiency / Altitude) applied: dropped a duplicate fixture (a standalone test that was a strict subset of the boundary subtest), gave the flag its own doc, and fixed three comments that still cited nilness consumers the explicit flag replaced — one of which described the refresh path inaccurately (nil entries were claimed to be fresh-session-only).

Adversarial contest (two independent reviewers, competing to find legitimate significant findings): **both returned zero significant findings, verdict ship.** Each verified the flag capture site on every restore path (including the fresh-writer and both refresh triggers), the lock guarding, every consumer of the changed return shape repo-wide, and the error paths. One reviewer traced that the exact hazard the flag guards (a nil-producing refresh over an opened file) is currently unreachable — both refresh triggers require restore-time appends that un-empty the file — so the flag is defensive hardening on top of the semantic fix.
