### PR TITLE
fix(hub): route shared relay notifications once

### DIFF
--- a/cmd/evener-hub/app_relay.go
+++ b/cmd/evener-hub/app_relay.go
@@ -215,6 +215,33 @@ func threadRelayTarget(source appsource.Source, params appwire.ThreadReadParams)
 	return source.ID() + ":" + threadID, threadID, nil
 }
 
+// relayNotificationTargets reports whether one notification from a shared
+// local-daemon relay session belongs to this hub relay handle. Root sessions
+// and their in-process descendants share one upstream RelaySession, so every
+// handle's listener observes every subscribed alias unless the hub filters at
+// this boundary. Ref has the same precedence the browser reducer uses.
+func relayNotificationTargets(notification appwire.Notification, threadID, ref string) bool {
+	var params map[string]json.RawMessage
+	if len(notification.Params) == 0 || json.Unmarshal(notification.Params, &params) != nil {
+		return true
+	}
+	var targetRef string
+	if raw := params["ref"]; len(raw) > 0 && json.Unmarshal(raw, &targetRef) != nil {
+		return true
+	}
+	if targetRef != "" {
+		return targetRef == ref
+	}
+	var targetThreadID string
+	if raw := params["threadId"]; len(raw) > 0 && json.Unmarshal(raw, &targetThreadID) != nil {
+		return true
+	}
+	if targetThreadID != "" {
+		return targetThreadID == threadID
+	}
+	return true
+}
+
 func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sources *appsource.Registry) hubRelayFunctions {
 	relayIdleInterval := hubRelayIdleInterval
 	retryClock := newRelayRetryClock()
@@ -311,7 +338,7 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 					active := relayedThreads[relayKey] == handle
 					thread := handle.thread
 					relayMu.Unlock()
-					if active {
+					if active && relayNotificationTargets(delivery.Notification, threadID, ref) {
 						notification := delivery.Notification
 						// The edits only this hub can make to a local daemon's
 						// notification on its way to a browser: the images it can
@@ -428,7 +455,11 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 			handle.established = true
 			finishHandleLocked(handle, nil)
 			relayMu.Unlock()
-			startAcknowledgedFanout(relayKey, threadID, params.Ref, handle, deliveries)
+			fanoutRef := strings.TrimSpace(params.Ref)
+			if fanoutRef == "" {
+				fanoutRef = relayKey
+			}
+			startAcknowledgedFanout(relayKey, threadID, fanoutRef, handle, deliveries)
 			return handle, func() {
 				relayMu.Lock()
 				if handle.commands > 0 {

--- a/cmd/evener-hub/app_relay.go
+++ b/cmd/evener-hub/app_relay.go
@@ -337,8 +337,16 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 					relayMu.Lock()
 					active := relayedThreads[relayKey] == handle
 					thread := handle.thread
+					targetThreadID := threadID
+					if thread.ID != "" {
+						targetThreadID = thread.ID
+					}
+					targetRef := ref
+					if thread.Evener.Ref != "" {
+						targetRef = thread.Evener.Ref
+					}
 					relayMu.Unlock()
-					if active && relayNotificationTargets(delivery.Notification, threadID, ref) {
+					if active && relayNotificationTargets(delivery.Notification, targetThreadID, targetRef) {
 						notification := delivery.Notification
 						// The edits only this hub can make to a local daemon's
 						// notification on its way to a browser: the images it can

--- a/cmd/evener-hub/app_relay_alias_test.go
+++ b/cmd/evener-hub/app_relay_alias_test.go
@@ -1,0 +1,205 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+func TestHubRelaySharedSessionAliasesDeliverEachNotificationOnce(t *testing.T) {
+	const (
+		rootRef  = "local:root-thread"
+		childRef = "local:child-thread"
+	)
+	pool := &aliasRelayPool{}
+	source := &aliasRelaySource{pool: pool}
+	sources := appsource.NewRegistry()
+	sources.Add(source)
+	appServer := newHubAppServer(hubcore.WebConfig{
+		HubStateRoot: t.TempDir(),
+		Past:         hubcore.NewPastIndex(""),
+	}, sources)
+	hub := httptest.NewServer(http.HandlerFunc(appServer.ServeWebSocket))
+	defer hub.Close()
+
+	longLived := dialHubRPC(t, hub)
+	defer longLived.Close()
+	if _, err := longLived.Initialize(t.Context(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("initialize long-lived client: %v", err)
+	}
+	for _, ref := range []string{rootRef, childRef} {
+		if _, err := longLived.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: ref, Subscribe: true}); err != nil {
+			t.Fatalf("subscribe long-lived client to %s: %v", ref, err)
+		}
+	}
+	if got := pool.listenerCount(); got != 2 {
+		t.Fatalf("relay listeners = %d, want two alias handles sharing one session", got)
+	}
+
+	fresh := dialHubRPC(t, hub)
+	defer fresh.Close()
+	if _, err := fresh.Initialize(t.Context(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("initialize fresh client: %v", err)
+	}
+	if _, err := fresh.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: rootRef, Subscribe: true}); err != nil {
+		t.Fatalf("subscribe fresh client: %v", err)
+	}
+
+	params, err := json.Marshal(appwire.ReasoningSummaryDeltaParams{
+		ThreadID:     "root-thread",
+		Ref:          rootRef,
+		TurnID:       "turn-alias",
+		ItemID:       "item-alias",
+		SummaryIndex: 0,
+		Delta:        "one logical delta",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool.emit(t, appwire.Notification{Method: appwire.NotifyReasoningSummaryDelta, Params: params})
+	// Every alias fanout has acknowledged and enqueued the delta before emit
+	// returns. This connection-wide marker is therefore an ordered drain barrier.
+	appServer.BroadcastAll("test/alias-barrier", map[string]any{})
+
+	if got := aliasDeltaCountUntilBarrier(t, longLived, "one logical delta"); got != 1 {
+		t.Fatalf("long-lived root+child client received delta %d times, want once", got)
+	}
+	if got := aliasDeltaCountUntilBarrier(t, fresh, "one logical delta"); got != 1 {
+		t.Fatalf("fresh root-only client received delta %d times, want once", got)
+	}
+
+	params, err = json.Marshal(appwire.ReasoningSummaryDeltaParams{
+		ThreadID:     "child-thread",
+		Ref:          childRef,
+		TurnID:       "turn-alias",
+		ItemID:       "item-alias-child",
+		SummaryIndex: 0,
+		Delta:        "one child delta",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool.emit(t, appwire.Notification{Method: appwire.NotifyReasoningSummaryDelta, Params: params})
+	appServer.BroadcastAll("test/alias-barrier", map[string]any{})
+	if got := aliasDeltaCountUntilBarrier(t, longLived, "one child delta"); got != 1 {
+		t.Fatalf("long-lived root+child client received child delta %d times, want once", got)
+	}
+	if got := aliasDeltaCountUntilBarrier(t, fresh, "one child delta"); got != 0 {
+		t.Fatalf("fresh root-only client received child delta %d times, want none", got)
+	}
+}
+
+type aliasRelaySource struct {
+	relayLifecycleSource
+	pool *aliasRelayPool
+}
+
+func (*aliasRelaySource) ID() string { return "local" }
+
+func (s *aliasRelaySource) AcquireRelaySession(appwire.ThreadReadParams) (appsource.RelaySessionLease, error) {
+	return &aliasRelayLease{pool: s.pool}, nil
+}
+
+type aliasRelayLease struct {
+	pool *aliasRelayPool
+}
+
+func (l *aliasRelayLease) Read(_ context.Context, params appwire.ThreadReadParams) (appsource.RelayReadResult, error) {
+	ref, err := appwire.ParseRef(params.Ref)
+	if err != nil {
+		return appsource.RelayReadResult{}, err
+	}
+	return appsource.RelayReadResult{
+		Response: appwire.ThreadReadResponse{Thread: appwire.Thread{
+			ID:        ref.ThreadID,
+			SessionID: ref.ThreadID,
+			Source:    ref.SourceID,
+			Evener:    appwire.EvenerThread{Ref: params.Ref},
+		}},
+		Handoff: &recordingRelayHandoff{committed: make(chan struct{}), aborted: make(chan struct{})},
+	}, nil
+}
+
+func (l *aliasRelayLease) Listen(context.Context) (<-chan appsource.RelayDelivery, error) {
+	return l.pool.listen(), nil
+}
+
+func (*aliasRelayLease) Close() {}
+
+type aliasRelayPool struct {
+	mu        sync.Mutex
+	listeners []chan appsource.RelayDelivery
+}
+
+func (p *aliasRelayPool) listen() <-chan appsource.RelayDelivery {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	listener := make(chan appsource.RelayDelivery)
+	p.listeners = append(p.listeners, listener)
+	return listener
+}
+
+func (p *aliasRelayPool) listenerCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.listeners)
+}
+
+func (p *aliasRelayPool) emit(t *testing.T, notification appwire.Notification) {
+	t.Helper()
+	p.mu.Lock()
+	listeners := append([]chan appsource.RelayDelivery(nil), p.listeners...)
+	p.mu.Unlock()
+	for _, listener := range listeners {
+		ack := make(chan struct{})
+		var once sync.Once
+		delivery := appsource.RelayDelivery{
+			Notification: notification,
+			Acknowledge:  func() { once.Do(func() { close(ack) }) },
+		}
+		select {
+		case listener <- delivery:
+		case <-time.After(2 * time.Second):
+			t.Fatal("relay listener did not accept notification")
+		}
+		select {
+		case <-ack:
+		case <-time.After(2 * time.Second):
+			t.Fatal("relay listener did not acknowledge notification")
+		}
+	}
+}
+
+func aliasDeltaCountUntilBarrier(t *testing.T, client *appwire.Client, delta string) int {
+	t.Helper()
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	count := 0
+	for {
+		select {
+		case notification, ok := <-client.Notifications():
+			if !ok {
+				t.Fatal("client notification stream closed before barrier")
+			}
+			if notification.Method == "test/alias-barrier" {
+				return count
+			}
+			if notification.Method == appwire.NotifyReasoningSummaryDelta {
+				var params appwire.ReasoningSummaryDeltaParams
+				if json.Unmarshal(notification.Params, &params) == nil && params.Delta == delta {
+					count++
+				}
+			}
+		case <-timer.C:
+			t.Fatal("timed out waiting for alias delivery barrier")
+		}
+	}
+}

--- a/cmd/evener-hub/app_relay_alias_test.go
+++ b/cmd/evener-hub/app_relay_alias_test.go
@@ -97,39 +97,117 @@ func TestHubRelaySharedSessionAliasesDeliverEachNotificationOnce(t *testing.T) {
 	}
 }
 
+func TestHubRelayThreadIDReadUsesAuthoritativeResponseRef(t *testing.T) {
+	pool := &aliasRelayPool{}
+	source := &aliasRelaySource{
+		pool:              pool,
+		authoritativeRefs: map[string]string{"lookup-thread": "local:workspace-thread"},
+	}
+	sources := appsource.NewRegistry()
+	sources.Add(source)
+	appServer := newHubAppServer(hubcore.WebConfig{
+		HubStateRoot: t.TempDir(),
+		Past:         hubcore.NewPastIndex(""),
+	}, sources)
+	hub := httptest.NewServer(http.HandlerFunc(appServer.ServeWebSocket))
+	defer hub.Close()
+
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("initialize client: %v", err)
+	}
+	if _, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{ThreadID: "lookup-thread", Subscribe: true}); err != nil {
+		t.Fatalf("subscribe by thread id: %v", err)
+	}
+	params, err := json.Marshal(appwire.ReasoningSummaryDeltaParams{
+		ThreadID:     "lookup-thread",
+		Ref:          "local:workspace-thread",
+		TurnID:       "turn-workspace",
+		ItemID:       "item-workspace",
+		SummaryIndex: 0,
+		Delta:        "authoritative workspace delta",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool.emit(t, appwire.Notification{Method: appwire.NotifyReasoningSummaryDelta, Params: params})
+	appServer.BroadcastAll("test/alias-barrier", map[string]any{})
+	if got := aliasDeltaCountUntilBarrier(t, client, "authoritative workspace delta"); got != 1 {
+		t.Fatalf("thread-id subscriber received authoritative-ref delta %d times, want once", got)
+	}
+}
+
+func TestRelayNotificationTargetsPreservesRoutingPrecedenceAndUnknownPayloads(t *testing.T) {
+	tests := []struct {
+		name         string
+		params       string
+		threadID     string
+		ref          string
+		wantTargeted bool
+	}{
+		{name: "matching ref wins over conflicting thread", params: `{"ref":"local:target","threadId":"other"}`, threadID: "target", ref: "local:target", wantTargeted: true},
+		{name: "mismatched ref wins over matching thread", params: `{"ref":"local:other","threadId":"target"}`, threadID: "target", ref: "local:target", wantTargeted: false},
+		{name: "thread fallback matches", params: `{"threadId":"target"}`, threadID: "target", ref: "local:target", wantTargeted: true},
+		{name: "thread fallback rejects mismatch", params: `{"threadId":"other"}`, threadID: "target", ref: "local:target", wantTargeted: false},
+		{name: "untargeted payload preserves delivery", params: `{}`, threadID: "target", ref: "local:target", wantTargeted: true},
+		{name: "malformed payload preserves delivery", params: `{`, threadID: "target", ref: "local:target", wantTargeted: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := relayNotificationTargets(appwire.Notification{Params: json.RawMessage(tc.params)}, tc.threadID, tc.ref)
+			if got != tc.wantTargeted {
+				t.Fatalf("relayNotificationTargets() = %v, want %v", got, tc.wantTargeted)
+			}
+		})
+	}
+}
+
 type aliasRelaySource struct {
 	relayLifecycleSource
-	pool *aliasRelayPool
+	pool              *aliasRelayPool
+	authoritativeRefs map[string]string
 }
 
 func (*aliasRelaySource) ID() string { return "local" }
 
 func (s *aliasRelaySource) AcquireRelaySession(appwire.ThreadReadParams) (appsource.RelaySessionLease, error) {
-	return &aliasRelayLease{pool: s.pool}, nil
+	return &aliasRelayLease{source: s}, nil
 }
 
 type aliasRelayLease struct {
-	pool *aliasRelayPool
+	source *aliasRelaySource
 }
 
 func (l *aliasRelayLease) Read(_ context.Context, params appwire.ThreadReadParams) (appsource.RelayReadResult, error) {
-	ref, err := appwire.ParseRef(params.Ref)
-	if err != nil {
-		return appsource.RelayReadResult{}, err
+	threadID := params.ThreadID
+	authoritativeRef := params.Ref
+	if params.Ref != "" {
+		ref, err := appwire.ParseRef(params.Ref)
+		if err != nil {
+			return appsource.RelayReadResult{}, err
+		}
+		threadID = ref.ThreadID
+	}
+	if mapped := l.source.authoritativeRefs[threadID]; mapped != "" {
+		authoritativeRef = mapped
+	}
+	if authoritativeRef == "" {
+		authoritativeRef = appwire.Ref{SourceID: "local", ThreadID: threadID}.String()
 	}
 	return appsource.RelayReadResult{
 		Response: appwire.ThreadReadResponse{Thread: appwire.Thread{
-			ID:        ref.ThreadID,
-			SessionID: ref.ThreadID,
-			Source:    ref.SourceID,
-			Evener:    appwire.EvenerThread{Ref: params.Ref},
+			ID:        threadID,
+			SessionID: threadID,
+			Source:    "local",
+			Evener:    appwire.EvenerThread{Ref: authoritativeRef},
 		}},
 		Handoff: &recordingRelayHandoff{committed: make(chan struct{}), aborted: make(chan struct{})},
 	}, nil
 }
 
 func (l *aliasRelayLease) Listen(context.Context) (<-chan appsource.RelayDelivery, error) {
-	return l.pool.listen(), nil
+	return l.source.pool.listen(), nil
 }
 
 func (*aliasRelayLease) Close() {}

--- a/cmd/evener-hub/internal/appsource/local_daemon_test.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon_test.go
@@ -910,3 +910,48 @@ func TestThreadFromEntryReadOnlyAliasCarriesKindAndParentRef(t *testing.T) {
 		t.Fatal("Evener.ParentRef is empty, want a non-empty parent reference")
 	}
 }
+
+func TestLocalDaemonRootAndReadOnlyAliasShareRelaySession(t *testing.T) {
+	entry := rendezvous.Entry{
+		Protocol:     appwire.ProtocolVersion,
+		Endpoint:     "ws://127.0.0.1/rpc",
+		SourceID:     "local",
+		ThreadID:     "sess_root",
+		SessionID:    "sess_root",
+		WorkspaceRef: "local:sess_root",
+	}
+	source := NewLocalDaemonSourceWithEntries("local", func() []LocalDaemonEntry {
+		return []LocalDaemonEntry{
+			{Entry: entry, SessionID: "sess_root"},
+			{Entry: entry, SessionID: "sess_child", OwnerSessionID: "sess_root", ReadOnlyAlias: true},
+		}
+	}, nil)
+	rootValue, err := source.AcquireRelaySession(appwire.ThreadReadParams{Ref: "local:sess_root"})
+	if err != nil {
+		t.Fatalf("acquire root relay: %v", err)
+	}
+	defer rootValue.Close()
+	childValue, err := source.AcquireRelaySession(appwire.ThreadReadParams{Ref: "local:sess_child"})
+	if err != nil {
+		t.Fatalf("acquire child relay: %v", err)
+	}
+	defer childValue.Close()
+
+	root, ok := rootValue.(*relaySessionLease)
+	if !ok {
+		t.Fatalf("root lease type = %T, want *relaySessionLease", rootValue)
+	}
+	child, ok := childValue.(*relaySessionLease)
+	if !ok {
+		t.Fatalf("child lease type = %T, want *relaySessionLease", childValue)
+	}
+	if root.session != child.session {
+		t.Fatal("root and read-only child aliases acquired different relay sessions")
+	}
+	source.relayMu.Lock()
+	actors := len(source.relaySessions)
+	source.relayMu.Unlock()
+	if actors != 1 {
+		t.Fatalf("relay session actors = %d, want 1", actors)
+	}
+}

--- a/cmd/evener-hub/web.go
+++ b/cmd/evener-hub/web.go
@@ -173,6 +173,7 @@ func (s *WebServer) Handler() http.Handler {
 
 	// API
 	mux.HandleFunc("/api/health", s.handleAPIHealth)
+	mux.HandleFunc("/api/debug/subscriptions", s.handleAPIDebugSubscriptions)
 
 	mux.HandleFunc("/auth", hubedge.HandleAuth(s.cfg.AuthToken))
 

--- a/cmd/evener-hub/web_api.go
+++ b/cmd/evener-hub/web_api.go
@@ -93,6 +93,15 @@ func (s *WebServer) handleAPIHealth(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (s *WebServer) handleAPIDebugSubscriptions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeAPIError(w, http.StatusMethodNotAllowed, "GET required")
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	writeAPIJSON(w, http.StatusOK, s.appRPC.DebugSubscriptions())
+}
+
 func (s *WebServer) apiStateGlob() string {
 	if s.cfg.Past == nil {
 		return ""

--- a/cmd/evener-hub/web_debug_subscriptions_test.go
+++ b/cmd/evener-hub/web_debug_subscriptions_test.go
@@ -1,0 +1,45 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/internal/appserver"
+)
+
+func TestWebDebugSubscriptionsRequiresAuthentication(t *testing.T) {
+	web := NewWebServer(hubcore.WebConfig{AuthToken: "debug-secret"})
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/subscriptions", nil)
+	rec := httptest.NewRecorder()
+	web.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("anonymous status = %d, want 401", rec.Code)
+	}
+}
+
+func TestWebDebugSubscriptionsReturnsLiveRegistrySnapshot(t *testing.T) {
+	web := NewWebServer(hubcore.WebConfig{AuthToken: "debug-secret"})
+	conn := web.appRPC.NewConnection("conn-http-debug")
+	conn.Subscribe("local:thread-http")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/debug/subscriptions", nil)
+	req.Header.Set("Authorization", "Bearer debug-secret")
+	rec := httptest.NewRecorder()
+	web.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %q, want 200", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+	var got appserver.SubscriptionDebugSnapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode snapshot: %v (body %q)", err, rec.Body.String())
+	}
+	if len(got.Subscriptions) != 1 || got.Subscriptions[0].ConnectionID != "conn-http-debug" || got.Subscriptions[0].ThreadID != "local:thread-http" || got.Subscriptions[0].Buffering {
+		t.Fatalf("subscriptions = %+v", got.Subscriptions)
+	}
+}

--- a/internal/appserver/subscriptions_debug.go
+++ b/internal/appserver/subscriptions_debug.go
@@ -1,0 +1,131 @@
+package appserver
+
+import "sort"
+
+// SubscriptionDebugSnapshot is a point-in-time view of the live AppWire
+// connection, subscription, and hydration-capture registry. It deliberately
+// contains no notification payloads or authentication material.
+type SubscriptionDebugSnapshot struct {
+	RoutedSequence          uint64                         `json:"routedSequence"`
+	NextHydrationGeneration uint64                         `json:"nextHydrationGeneration"`
+	Connections             []ConnectionDebugSnapshot      `json:"connections"`
+	Subscriptions           []SubscriptionDebugSnapshotRow `json:"subscriptions"`
+}
+
+// ConnectionDebugSnapshot describes one registered AppWire connection and
+// the response-bound hydration captures it still owns.
+type ConnectionDebugSnapshot struct {
+	ConnectionID      string                   `json:"connectionId"`
+	SendQueueDepth    int                      `json:"sendQueueDepth"`
+	SendQueueCapacity int                      `json:"sendQueueCapacity"`
+	PendingHydrations []HydrationDebugSnapshot `json:"pendingHydrations"`
+}
+
+// HydrationDebugSnapshot describes one capture waiting for its matching
+// response to enter the connection's send queue.
+type HydrationDebugSnapshot struct {
+	ResponseID             string `json:"responseId"`
+	ThreadID               string `json:"threadId"`
+	Generation             uint64 `json:"generation"`
+	Replace                bool   `json:"replace"`
+	ReleaseOnErrorResponse bool   `json:"releaseOnErrorResponse"`
+}
+
+// SubscriptionDebugSnapshotRow describes the current registry entry for one
+// connection and thread.
+type SubscriptionDebugSnapshotRow struct {
+	ConnectionID   string `json:"connectionId"`
+	ThreadID       string `json:"threadId"`
+	Buffering      bool   `json:"buffering"`
+	Generation     uint64 `json:"generation"`
+	Cut            uint64 `json:"cut"`
+	BufferedFrames int    `json:"bufferedFrames"`
+	Withdrawn      bool   `json:"withdrawn"`
+}
+
+// DebugSubscriptions snapshots the live registry without exposing frame
+// contents. It is safe to call while broadcasts and capture responses race;
+// each component is sampled under the lock that owns it.
+func (s *Server) DebugSubscriptions() SubscriptionDebugSnapshot {
+	s.projectionMu.Lock()
+	defer s.projectionMu.Unlock()
+
+	s.mu.RLock()
+	connections := make([]*Connection, 0, len(s.conns))
+	for _, conn := range s.conns {
+		connections = append(connections, conn)
+	}
+	s.mu.RUnlock()
+
+	out := SubscriptionDebugSnapshot{
+		RoutedSequence:          s.routedSeq,
+		NextHydrationGeneration: s.nextHydrationGeneration,
+		Connections:             make([]ConnectionDebugSnapshot, 0, len(connections)),
+		Subscriptions:           s.subs.debugSnapshot(),
+	}
+	for _, conn := range connections {
+		out.Connections = append(out.Connections, conn.debugSnapshot())
+	}
+	sort.Slice(out.Connections, func(i, j int) bool {
+		return out.Connections[i].ConnectionID < out.Connections[j].ConnectionID
+	})
+	return out
+}
+
+func (s *Subscriptions) debugSnapshot() []SubscriptionDebugSnapshotRow {
+	s.mu.RLock()
+	rows := make([]SubscriptionDebugSnapshotRow, 0)
+	for connectionID, subscriptions := range s.byConn {
+		for threadID, subscription := range subscriptions {
+			rows = append(rows, SubscriptionDebugSnapshotRow{
+				ConnectionID:   connectionID,
+				ThreadID:       threadID,
+				Buffering:      subscription.buffering,
+				Generation:     subscription.generation,
+				Cut:            subscription.cut,
+				BufferedFrames: len(subscription.buffer),
+				Withdrawn:      subscription.withdrawn,
+			})
+		}
+	}
+	s.mu.RUnlock()
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].ConnectionID != rows[j].ConnectionID {
+			return rows[i].ConnectionID < rows[j].ConnectionID
+		}
+		return rows[i].ThreadID < rows[j].ThreadID
+	})
+	return rows
+}
+
+func (c *Connection) debugSnapshot() ConnectionDebugSnapshot {
+	c.sendMu.RLock()
+	queueDepth := len(c.send)
+	queueCapacity := cap(c.send)
+	c.sendMu.RUnlock()
+
+	c.responseMu.Lock()
+	pending := make([]HydrationDebugSnapshot, 0, len(c.hydrations))
+	for _, finalizer := range c.hydrations {
+		pending = append(pending, HydrationDebugSnapshot{
+			ResponseID:             finalizer.responseID,
+			ThreadID:               finalizer.threadID,
+			Generation:             finalizer.generation,
+			Replace:                finalizer.replace,
+			ReleaseOnErrorResponse: finalizer.releaseOnErrorResponse,
+		})
+	}
+	c.responseMu.Unlock()
+	sort.Slice(pending, func(i, j int) bool {
+		if pending[i].Generation != pending[j].Generation {
+			return pending[i].Generation < pending[j].Generation
+		}
+		return pending[i].ResponseID < pending[j].ResponseID
+	})
+	return ConnectionDebugSnapshot{
+		ConnectionID:      c.id,
+		SendQueueDepth:    queueDepth,
+		SendQueueCapacity: queueCapacity,
+		PendingHydrations: pending,
+	}
+}

--- a/internal/appserver/subscriptions_debug_test.go
+++ b/internal/appserver/subscriptions_debug_test.go
@@ -1,0 +1,97 @@
+package appserver
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+)
+
+func TestServerSubscriptionDebugSnapshotShowsCaptureState(t *testing.T) {
+	server := NewServer(ServerConfig{ServerName: "debug-test"})
+	conn := server.NewConnection("conn-debug")
+	server.registerConnection(conn)
+	t.Cleanup(func() { server.unregisterConnection(conn) })
+
+	ctx := context.WithValue(context.Background(), connectionContextKey{}, conn)
+	ctx = context.WithValue(ctx, requestIDContextKey{}, requestIDKey(appwire.NewIntID(7)))
+	if !CaptureSubscription(
+		ctx,
+		false,
+		func() string { return "local:thread-1" },
+		func() uint64 { return 0 },
+		func() bool { return true },
+	) {
+		t.Fatal("capture subscription failed")
+	}
+	server.Broadcast("local:thread-1", "debug/notice", map[string]any{"value": 1})
+	if !conn.enqueue(appwire.NotificationMessage("debug/queued", map[string]any{"value": 2})) {
+		t.Fatal("queue diagnostic notification")
+	}
+
+	method := reflect.ValueOf(server).MethodByName("DebugSubscriptions")
+	if !method.IsValid() {
+		t.Fatal("Server.DebugSubscriptions is missing")
+	}
+	values := method.Call(nil)
+	if len(values) != 1 {
+		t.Fatalf("DebugSubscriptions returned %d values, want 1", len(values))
+	}
+	raw, err := json.Marshal(values[0].Interface())
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	var got struct {
+		RoutedSequence uint64 `json:"routedSequence"`
+		Connections    []struct {
+			ConnectionID      string `json:"connectionId"`
+			SendQueueDepth    int    `json:"sendQueueDepth"`
+			SendQueueCapacity int    `json:"sendQueueCapacity"`
+			PendingHydrations []struct {
+				ResponseID             string `json:"responseId"`
+				ThreadID               string `json:"threadId"`
+				Generation             uint64 `json:"generation"`
+				Replace                bool   `json:"replace"`
+				ReleaseOnErrorResponse bool   `json:"releaseOnErrorResponse"`
+			} `json:"pendingHydrations"`
+		} `json:"connections"`
+		Subscriptions []struct {
+			ConnectionID string `json:"connectionId"`
+			ThreadID     string `json:"threadId"`
+			Buffering    bool   `json:"buffering"`
+			Generation   uint64 `json:"generation"`
+			Cut          uint64 `json:"cut"`
+			Buffered     int    `json:"bufferedFrames"`
+			Withdrawn    bool   `json:"withdrawn"`
+		} `json:"subscriptions"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	if got.RoutedSequence != 1 {
+		t.Fatalf("routedSequence = %d, want 1", got.RoutedSequence)
+	}
+	if len(got.Connections) != 1 {
+		t.Fatalf("connections = %+v, want one", got.Connections)
+	}
+	connection := got.Connections[0]
+	if connection.ConnectionID != "conn-debug" || connection.SendQueueDepth != 1 || connection.SendQueueCapacity != appwire.NotificationBufferCap {
+		t.Fatalf("connection = %+v", connection)
+	}
+	if len(connection.PendingHydrations) != 1 {
+		t.Fatalf("pending hydrations = %+v, want one", connection.PendingHydrations)
+	}
+	pending := connection.PendingHydrations[0]
+	if pending.ResponseID != "7" || pending.ThreadID != "local:thread-1" || pending.Generation != 1 || pending.Replace || !pending.ReleaseOnErrorResponse {
+		t.Fatalf("pending hydration = %+v", pending)
+	}
+	if len(got.Subscriptions) != 1 {
+		t.Fatalf("subscriptions = %+v, want one", got.Subscriptions)
+	}
+	subscription := got.Subscriptions[0]
+	if subscription.ConnectionID != "conn-debug" || subscription.ThreadID != "local:thread-1" || !subscription.Buffering || subscription.Generation != 1 || subscription.Cut != 0 || subscription.Buffered != 1 || subscription.Withdrawn {
+		t.Fatalf("subscription = %+v", subscription)
+	}
+}

--- a/internal/appserver/subscriptions_debug_test.go
+++ b/internal/appserver/subscriptions_debug_test.go
@@ -1,6 +1,7 @@
 package appserver
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"reflect"
@@ -42,6 +43,11 @@ func TestServerSubscriptionDebugSnapshotShowsCaptureState(t *testing.T) {
 	raw, err := json.Marshal(values[0].Interface())
 	if err != nil {
 		t.Fatalf("marshal snapshot: %v", err)
+	}
+	for _, forbidden := range [][]byte{[]byte(`"value"`), []byte("debug/notice"), []byte("debug/queued")} {
+		if bytes.Contains(raw, forbidden) {
+			t.Fatalf("snapshot leaked notification payload marker %q: %s", forbidden, raw)
+		}
 	}
 	var got struct {
 		RoutedSequence uint64 `json:"routedSequence"`


### PR DESCRIPTION
## Summary

- filter shared local-daemon relay deliveries by each hub handle's authoritative `ref` / `threadId`
- prevent a browser subscribed to both a root session and an in-process child from receiving the same upstream frame twice
- add an authenticated, no-store `/api/debug/subscriptions` snapshot for live connection, subscription-capture, and hydration-finalizer state

## Root cause

Root sessions and in-process descendants share one upstream `RelaySession`, but the hub created one listener/fanout handle per downstream alias. Every listener observed every upstream frame and broadcast it under its own alias key, so a long-lived client subscribed to root and child keys received identical frames twice. A fresh root-only client received one.

## Verification

- deterministic regression: red before fix (`got 2, want 1`), green after
- targeted Go tests and targeted `-race`
- `go test ./internal/appserver ./cmd/evener-hub/... -count=1`
- `go vet ./internal/appserver ./cmd/evener-hub/...`
- `make test-web`
- `make test-web-browser`
- `make build`
- `make lint`
