### PR TITLE
fix(repair): name the action branch a conditional sub-schema belongs to

### DIFF
--- a/agent/internal/tool/repair/explain.go
+++ b/agent/internal/tool/repair/explain.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -66,12 +67,18 @@ func ExplainSchemaError(toolName string, params, args map[string]any, instanceLo
 		if containerPath != "" {
 			fullPath = containerPath + "." + field
 		}
+		// The wrong branch's array can also reject a present field (issue
+		// #626 round 2: {"action":"update","tasks":[{"type":123}]}), and the
+		// early return here would otherwise bypass the branch-naming below —
+		// entering the same unrecoverable loop one step later, via a type
+		// error instead of a missing one. Attribute the branch here too.
+		ctx := newBranchCtx(params, args, containerPath)
 		if constraintKeyword != "" {
 			if specific := constraintMessage(toolName, fullPath, containerSchema, field, constraintKeyword, args, instanceLocation); specific != "" {
-				return specific
+				return specific + ctx.wrongBranchTail(args)
 			}
 		}
-		return fmt.Sprintf("%s: argument %q has the wrong type or value.\nExample: %s", toolName, fullPath, minimalExample(params))
+		return fmt.Sprintf("%s: argument %q has the wrong type or value.\nExample: %s%s", toolName, fullPath, ctx.example(params), ctx.wrongBranchTail(args))
 	}
 
 	// A branch-combinator failure names no property: the deepest cause is the
@@ -93,16 +100,325 @@ func ExplainSchemaError(toolName string, params, args map[string]any, instanceLo
 		fmt.Fprintf(&b, "%s: missing required argument %q in %s.", toolName, field, containerPath)
 	}
 
+	// A conditional sub-schema's required list describes one action's branch,
+	// not the call the caller made (issue #626: task_list's tasks[0] belongs to
+	// append, but an update caller read the bare list as describing its own
+	// call and retried into an unrecoverable loop). When the failing container
+	// sits inside an array property scoped to an action the caller did not
+	// send, name that branch, and point the caller at the array its own action
+	// takes instead.
+	ctx := newBranchCtx(params, args, containerPath)
+	branchNamed := ctx.branchValue != ""
+	// The Example shows the caller's own branch shape whenever the failure
+	// sits inside an action-scoped array — a same-branch caller (append
+	// missing prompt) needs it just as much as a wrong-branch one (issue
+	// #626 complaint 3: the action-only Example gave neither a usable
+	// template). Only the caller-sent-wrong-array tail is wrong-branch-only.
 	req := requiredList(containerSchema)
 	if len(req) > 0 {
-		if containerPath == "" {
+		if branchNamed {
+			fmt.Fprintf(&b, "\nRequired arguments in %s for action %q: %s.", containerPath, ctx.branchValue, strings.Join(req, ", "))
+		} else if containerPath == "" {
 			fmt.Fprintf(&b, "\nRequired arguments: %s.", strings.Join(req, ", "))
 		} else {
 			fmt.Fprintf(&b, "\nRequired arguments in %s: %s.", containerPath, strings.Join(req, ", "))
 		}
 	}
-	fmt.Fprintf(&b, "\nExample: %s", minimalExample(params))
+	if branchNamed || ctx.actionArrays != nil {
+		fmt.Fprintf(&b, "\nExample: %s", ctx.example(params))
+		if tail := ctx.takesClause(args); tail != "" {
+			b.WriteString(tail)
+		}
+	} else {
+		fmt.Fprintf(&b, "\nExample: %s", minimalExample(params))
+	}
 	return b.String()
+}
+
+// branchCtx is the branch context for one explained error, computed once
+// and shared by the present-field and missing-field paths (issue #626 round
+// 3: the two paths previously computed it independently, twice each).
+type branchCtx struct {
+	selectorName string
+	actionValue  string
+	branchValue  string // non-empty only when the failure sits in another action's branch
+	actionArrays []string
+}
+
+// newBranchCtx resolves the branch context for the failing container's
+// path. selectorName and actionValue are set whenever the schema has an
+// action selector the caller exercised (a same-branch caller still gets its
+// own branch's Example); branchValue is non-empty only when the container's
+// property is scoped to a different action's branch.
+func newBranchCtx(params, args map[string]any, containerPath string) branchCtx {
+	selectorName, actionValue, branchValue := namedBranch(params, args, containerPath)
+	return branchCtx{
+		selectorName: selectorName,
+		actionValue:  actionValue,
+		branchValue:  branchValue,
+		actionArrays: actionScopedArrays(schemaProps(params), actionValue),
+	}
+}
+
+// wrongBranchTail renders the wrong-branch attribution appended to a
+// present-field failure's message. Empty when the failure is not in another
+// action's branch. Unlike takesClause it names the branch itself, because a
+// present-field message carries no branch-phrased line of its own.
+func (c branchCtx) wrongBranchTail(args map[string]any) string {
+	if c.branchValue == "" {
+		return ""
+	}
+	missing := missingArray(c.actionArrays, args)
+	sent := sentArgNames(c.selectorName, args)
+	if missing == "" || sent == "" {
+		// The correct array was also sent (or nothing else was): still name
+		// the branch so the caller knows where the failure came from.
+		return fmt.Sprintf(" (this failure is in the array for action %q)", c.branchValue)
+	}
+	return fmt.Sprintf(" (this failure is in the array for action %q; your action %q takes %q, not %s)", c.branchValue, c.actionValue, missing, sent)
+}
+
+// takesClause renders the "your action takes X" line appended after the
+// Example on the missing-field path. Empty when the caller's action has no
+// action-scoped array missing from the call.
+func (c branchCtx) takesClause(args map[string]any) string {
+	missing := missingArray(c.actionArrays, args)
+	if missing == "" {
+		return ""
+	}
+	sent := sentArgNames(c.selectorName, args)
+	if sent == "" {
+		return ""
+	}
+	return fmt.Sprintf(" Your action %q takes %q (sent: %s).", c.actionValue, missing, sent)
+}
+
+// example renders the Example for this failure: the caller's own branch
+// shape when the failure sits inside an action-scoped array (same-branch or
+// wrong-branch), the generic top-level Example otherwise.
+func (c branchCtx) example(params map[string]any) string {
+	if c.branchValue == "" && c.actionArrays == nil {
+		return minimalExample(params)
+	}
+	return actionExample(params, c.selectorName, c.actionValue, c.actionArrays)
+}
+
+// namedBranch reports the branch context for a conditional-sub-schema
+// failure (issue #626): the action selector's name, the action value the
+// caller sent, and the action value whose branch the failing container's
+// property is scoped to. selectorName and actionValue are set whenever the
+// schema has an action selector the caller exercised (a same-branch caller
+// still gets its own branch's Example); branchValue is non-empty only when
+// the property's "For X:" description tag names a member of the selector's
+// enum that differs from the caller's action — prose such as read_file's
+// "For large files read in slices: ..." on offset parses to a tag, but no
+// selector enum contains it, so it cannot masquerade as a branch. The enum
+// membership check does not materialize a []string copy, keeping the
+// not-firing path allocation-free.
+// containerPath is the DISPLAY form produced by resolveSchemaErrorContainer
+// ("tasks[0]", not the JSON-Pointer "tasks/0" that ExplainSchemaError takes
+// as its instanceLocation) — pathRootProperty parses the bracket form.
+func namedBranch(params, args map[string]any, containerPath string) (selectorName, actionValue, branchValue string) {
+	selectorName, actionValue = actionSelector(params, args)
+	if selectorName == "" {
+		return "", "", ""
+	}
+	props := schemaProps(params)
+	tag := actionTag(schemaMap(props, pathRootProperty(containerPath)))
+	if tag == "" || tag == actionValue {
+		return selectorName, actionValue, ""
+	}
+	if !listContains(schemaMap(props, selectorName)["enum"], tag) {
+		return selectorName, actionValue, ""
+	}
+	return selectorName, actionValue, tag
+}
+
+// listContains reports whether v is a string list ([]string hand-built or
+// []any from JSON) containing s, without materializing a []string copy.
+// Sibling of hasListEntries.
+func listContains(v any, s string) bool {
+	switch list := v.(type) {
+	case []string:
+		return slices.Contains(list, s)
+	case []any:
+		for _, e := range list {
+			if str, ok := e.(string); ok && str == s {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// actionSelector finds the action/operation selector in params: a required
+// string property with an enum, whose value the caller actually sent. It
+// walks the schema's required list (not the properties map) so selection is
+// deterministic when more than one property qualifies, and materializes no
+// string slices: this runs on every explained error, including MCP schemas
+// where it never fires.
+func actionSelector(params, args map[string]any) (name, value string) {
+	props := schemaProps(params)
+	if props == nil {
+		return "", ""
+	}
+	switch required := params["required"].(type) {
+	case []string:
+		for _, propName := range required {
+			if v, ok := selectorValue(props, args, propName); ok {
+				return propName, v
+			}
+		}
+	case []any:
+		for _, raw := range required {
+			propName, ok := raw.(string)
+			if !ok {
+				continue
+			}
+			if v, ok := selectorValue(props, args, propName); ok {
+				return propName, v
+			}
+		}
+	}
+	return "", ""
+}
+
+// selectorValue reports whether propName is the action selector — a string
+// property with a non-empty enum that the caller sent a value for — and
+// returns that value. The enum is checked for presence only, not
+// materialized; namedBranch materializes it once a branch tag actually needs
+// validating against it.
+func selectorValue(props, args map[string]any, propName string) (string, bool) {
+	p := schemaMap(props, propName)
+	if p == nil {
+		return "", false
+	}
+	if t, _ := p["type"].(string); t != "string" {
+		return "", false
+	}
+	sent, _ := args[propName].(string)
+	if sent == "" || !hasListEntries(p["enum"]) {
+		return "", false
+	}
+	return sent, true
+}
+
+// hasListEntries reports whether v is a non-empty slice — the shapes a
+// schema's enum or required list may carry ([]string hand-built, []any from
+// JSON) — without materializing a []string copy.
+func hasListEntries(v any) bool {
+	switch s := v.(type) {
+	case []string:
+		return len(s) > 0
+	case []any:
+		return len(s) > 0
+	}
+	return false
+}
+
+// actionTag returns the action value a property schema is scoped to by its
+// description tag ("For append: ..." → "append"), or "" when the description
+// carries no such tag. Only task_list's tasks/updates descriptions carry the
+// tag today; the enum-membership check in namedBranch is what makes a parsed
+// tag count as a branch.
+func actionTag(propSchema map[string]any) string {
+	if propSchema == nil {
+		return ""
+	}
+	desc, _ := propSchema["description"].(string)
+	rest, ok := strings.CutPrefix(desc, "For ")
+	if !ok {
+		return ""
+	}
+	if value, _, ok := strings.Cut(rest, ":"); ok {
+		return value
+	}
+	return ""
+}
+
+// pathRootProperty extracts the top-level property name a display path
+// starts with ("tasks[0]" → "tasks", "updates[0].id" → "updates"). Returns
+// "" for a path with no leading property segment.
+func pathRootProperty(containerPath string) string {
+	if containerPath == "" {
+		return ""
+	}
+	seg := containerPath
+	if idx := strings.IndexAny(seg, "[."); idx >= 0 {
+		seg = seg[:idx]
+	}
+	return seg
+}
+
+// actionScopedArrays returns the array property names scoped to the given
+// action value by their description tag, sorted for deterministic output.
+func actionScopedArrays(props map[string]any, actionValue string) []string {
+	if actionValue == "" {
+		return nil
+	}
+	var out []string
+	for propName, p := range props {
+		schema, ok := p.(map[string]any)
+		if ok && schemaIsArray(schema) && actionTag(schema) == actionValue {
+			out = append(out, propName)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// missingArray returns the first action-scoped array name absent from the
+// call — the array the caller should have sent instead of the one that failed
+// (issue #626: update takes "updates", not "tasks") — or "" when every
+// action-scoped array was supplied.
+func missingArray(actionArrays []string, args map[string]any) string {
+	for _, name := range actionArrays {
+		if _, ok := args[name]; !ok {
+			return name
+		}
+	}
+	return ""
+}
+
+// sentArgNames renders the argument names the caller actually sent, sorted,
+// excluding the action selector itself so the contrast the message draws —
+// this array, not that one — stays sharp. Returns "" when nothing else was
+// sent.
+func sentArgNames(selectorName string, args map[string]any) string {
+	names := make([]string, 0, len(args))
+	for name := range args {
+		if name == selectorName {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if len(names) == 0 {
+		return ""
+	}
+	return strings.Join(names, ", ")
+}
+
+// actionExample renders a minimal example for the branch the caller actually
+// used: the action plus its tagged array with one minimal item. The item
+// renders through minimalExample (the same sorted required list with type
+// placeholders it builds for any schema), wrapped in the array's brackets.
+// Falls back to minimalExample(params) when the branch has no tagged array
+// or the array has no item schema.
+func actionExample(params map[string]any, selectorName, actionValue string, actionArrays []string) string {
+	props := schemaProps(params)
+	for _, arrayName := range actionArrays {
+		arraySchema := schemaMap(props, arrayName)
+		if arraySchema == nil {
+			continue
+		}
+		item := schemaMap(arraySchema, "items")
+		if item == nil {
+			continue
+		}
+		return fmt.Sprintf(`{%q: %q, %q: [%s]}`, selectorName, actionValue, arrayName, minimalExample(item))
+	}
+	return minimalExample(params)
 }
 
 // constraintMessage renders a specific constraint-violation message for a

--- a/agent/internal/tool/repair/explain_action_branch_alloc_test.go
+++ b/agent/internal/tool/repair/explain_action_branch_alloc_test.go
@@ -1,0 +1,56 @@
+package repair
+
+import (
+	"testing"
+)
+
+// The branch detection runs on every explained schema error, including MCP
+// tool schemas where no action selector exists and it never fires. On such a
+// schema it must not allocate: the selector walk checks the required list
+// and enum for presence without materializing []string copies (finding #3
+// from the #626 review; round 3 extended this to the enum-membership check,
+// which now uses listContains instead of asStringSlice).
+func TestActionSelector_NoAllocationsOnSelectorlessSchema(t *testing.T) {
+	params := map[string]any{
+		"type":       "object",
+		"properties": map[string]any{"file_path": map[string]any{"type": "string"}},
+		"required":   []string{"file_path"},
+	}
+	args := map[string]any{}
+	allocs := testing.AllocsPerRun(100, func() {
+		_, _ = actionSelector(params, args)
+	})
+	if allocs > 0 {
+		t.Fatalf("actionSelector allocated %v per run on a selector-less schema; want 0", allocs)
+	}
+}
+
+// The enum-membership check inside namedBranch must also be
+// allocation-free: a schema with a selector and a tagged property whose tag
+// is not in the enum (the guard's not-firing branch) walks the enum without
+// materializing a []string copy (round 3, finding E2).
+func TestNamedBranch_NoAllocationsWhenTagOutsideEnum(t *testing.T) {
+	params := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"action": map[string]any{"type": "string", "enum": []any{"view", "append", "update"}},
+			"slices": map[string]any{
+				"type":        "array",
+				"description": "For large files read in slices: line ranges.",
+			},
+		},
+		"required": []string{"action"},
+	}
+	args := map[string]any{"action": "view"}
+	// The container path must use the display form ("slices[0]", as
+	// resolveSchemaErrorContainer's formatPath renders it) — a JSON-Pointer
+	// form like "slices/0" parses as a single property name in
+	// pathRootProperty, finds no such property, and exits at the empty-tag
+	// check before the enum walk the test exists to measure.
+	allocs := testing.AllocsPerRun(100, func() {
+		_, _, _ = namedBranch(params, args, "slices[0]")
+	})
+	if allocs > 0 {
+		t.Fatalf("namedBranch allocated %v per run when the tag is outside the enum; want 0", allocs)
+	}
+}

--- a/agent/internal/tool/repair/explain_action_branch_test.go
+++ b/agent/internal/tool/repair/explain_action_branch_test.go
@@ -1,0 +1,254 @@
+package repair
+
+import (
+	"strings"
+	"testing"
+)
+
+// taskListParams mirrors DefTaskList's parameters (this package must stay
+// dependency-free of agent/internal/tool, so the fixture is hand-built rather
+// than calling the real Def* function). tasks is the append-branch array,
+// updates the update-branch array; the real schema selects between them by
+// the action value in prose, not by a combinator — the handler enforces it.
+// The "For <action>:" description tags are what the branch detection keys on.
+func taskListParams() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"action": map[string]any{
+				"type": "string",
+				"enum": []string{"view", "append", "update"},
+			},
+			"tasks": map[string]any{
+				"type":        "array",
+				"description": "For append: tasks to add. Each has a type, brief description (<10 words), a detailed prompt, and optional reasoning_effort.",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"type":             map[string]any{"type": "string", "enum": []string{"research", "implement", "verify", "fix"}},
+						"description":      map[string]any{"type": "string"},
+						"prompt":           map[string]any{"type": "string"},
+						"reasoning_effort": map[string]any{"type": "string"},
+					},
+					"required": []string{"type", "description", "prompt"},
+				},
+			},
+			"updates": map[string]any{
+				"type":        "array",
+				"description": "For update: list of {id, status} pairs with optional notes.",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"id":     map[string]any{"type": "integer"},
+						"status": map[string]any{"type": "string", "enum": []string{"open", "in_progress", "done", "cancelled"}},
+						"notes":  map[string]any{"type": "string"},
+					},
+					"required": []string{"id", "status"},
+				},
+			},
+		},
+		"required": []string{"action"},
+	}
+}
+
+// taskListUpdateArgs mirrors the exact failing call shape from live session
+// 034FsgXdyimiBvbubPlB4w (issue #626): action "update" with the update
+// entries placed in the append-branch "tasks" array. Schema validation fails
+// inside tasks[0] ("missing required type/description/prompt"), and the
+// explanation must name the branch that produced the requirement and show the
+// shape the caller's action actually uses — not the bare append-branch
+// required-list, which reads to an update caller as describing its own call.
+func taskListUpdateArgs() map[string]any {
+	return map[string]any{
+		"action": "update",
+		"tasks": []any{map[string]any{
+			"id":               float64(1),
+			"status":           "in_progress",
+			"notes":            "",
+			"reasoning_effort": "inherit",
+		}},
+	}
+}
+
+// Issue #626: a conditional sub-schema failure (tasks[0] applies to
+// action:"append") must not be presented as a plain missing-argument error.
+// The old message — missing required argument "type" in tasks[0] + the
+// append-branch required list + a top-level-only Example — sends an update
+// caller into an unrecoverable loop: following it (adding type/description/
+// prompt to tasks[0]) still fails, this time with the handler's "update
+// requires a non-empty 'updates' array", and the two errors alternate without
+// either ever stating the actual fix. The golden pins the full machine
+// contract: the branch attribution, the update-branch Example, and the
+// pointer to the array the caller's action actually takes.
+func TestExplainSchemaError_TaskListUpdateCallerGolden(t *testing.T) {
+	got := ExplainSchemaError("task_list", taskListParams(), taskListUpdateArgs(), "tasks/0", "")
+	want := "task_list: missing required argument \"type\" in tasks[0].\n" +
+		"Required arguments in tasks[0] for action \"append\": type (string), description (string), prompt (string).\n" +
+		"Example: {\"action\": \"update\", \"updates\": [{\"id\": 0, \"status\": \"...\"}]} " +
+		"Your action \"update\" takes \"updates\" (sent: tasks)."
+	if got != want {
+		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// The reverse misplacement (append caller sending the update array) gets the
+// mirror-image guidance: the update-branch requirement is attributed to
+// action "update", and the caller is pointed at "tasks".
+func TestExplainSchemaError_TaskListAppendCallerGolden(t *testing.T) {
+	args := map[string]any{
+		"action":  "append",
+		"updates": []any{map[string]any{"id": float64(1)}},
+	}
+	got := ExplainSchemaError("task_list", taskListParams(), args, "updates/0", "")
+	want := "task_list: missing required argument \"status\" in updates[0].\n" +
+		"Required arguments in updates[0] for action \"update\": id (integer), status (string).\n" +
+		"Example: {\"action\": \"append\", \"tasks\": [{\"description\": \"...\", \"prompt\": \"...\", \"type\": \"...\"}]} " +
+		"Your action \"append\" takes \"tasks\" (sent: updates)."
+	if got != want {
+		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// Issue #626 complaint 3 (round 2): a same-branch caller — correct usage,
+// append with a task missing prompt — must get the append-shaped Example,
+// not the action-only template that gives no usable branch context.
+func TestExplainSchemaError_SameBranchCallerGetsBranchExample(t *testing.T) {
+	args := map[string]any{
+		"action": "append",
+		"tasks": []any{map[string]any{
+			"type":        "implement",
+			"description": "d",
+		}},
+	}
+	got := ExplainSchemaError("task_list", taskListParams(), args, "tasks/0", "")
+	want := "task_list: missing required argument \"prompt\" in tasks[0].\n" +
+		"Required arguments in tasks[0]: type (string), description (string), prompt (string).\n" +
+		"Example: {\"action\": \"append\", \"tasks\": [{\"description\": \"...\", \"prompt\": \"...\", \"type\": \"...\"}]}"
+	if got != want {
+		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// Issue #626 round 2, finding 1: a present field inside the wrong branch's
+// array (a type error, not a missing field) must also carry the branch
+// attribution — the early return on the present-field path otherwise enters
+// the same unrecoverable loop one step later.
+func TestExplainSchemaError_PresentFieldInWrongBranchNamesBranch(t *testing.T) {
+	args := map[string]any{
+		"action": "update",
+		"tasks": []any{map[string]any{
+			"type":        123,
+			"description": "d",
+			"prompt":      "p",
+		}},
+	}
+	got := ExplainSchemaError("task_list", taskListParams(), args, "tasks/0/type", "type")
+	want := "task_list: argument \"tasks[0].type\" has the wrong type or value.\n" +
+		"Example: {\"action\": \"update\", \"updates\": [{\"id\": 0, \"status\": \"...\"}]} " +
+		"(this failure is in the array for action \"append\"; your action \"update\" takes \"updates\", not tasks)"
+	if got != want {
+		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// A constraint-keyword message on the present-field path (enum violation)
+// inside the wrong branch's array carries the branch tail too.
+func TestExplainSchemaError_ConstraintKeywordInWrongBranchGolden(t *testing.T) {
+	args := map[string]any{
+		"action": "update",
+		"tasks": []any{map[string]any{
+			"type":        "bogus",
+			"description": "d",
+			"prompt":      "p",
+		}},
+	}
+	got := ExplainSchemaError("task_list", taskListParams(), args, "tasks/0/type", "enum")
+	want := "task_list: argument \"tasks[0].type\" is not one of the allowed values: research, implement, verify, fix. Value is \"bogus\". " +
+		"(this failure is in the array for action \"append\"; your action \"update\" takes \"updates\", not tasks)"
+	if got != want {
+		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// A top-level tagged array supplied with the wrong type (a string instead of
+// an array) still gets the caller's own branch shape in the Example.
+func TestExplainSchemaError_TopLevelTaggedArrayWrongTypeGolden(t *testing.T) {
+	args := map[string]any{"action": "update", "tasks": "oops"}
+	got := ExplainSchemaError("task_list", taskListParams(), args, "tasks", "type")
+	want := "task_list: argument \"tasks\" has the wrong type or value.\n" +
+		"Example: {\"action\": \"update\", \"updates\": [{\"id\": 0, \"status\": \"...\"}]}"
+	if got != want {
+		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// Both action-scoped arrays sent: the failure still names the branch it
+// came from on both the missing-field and present-field paths (round 3
+// alignment — the two paths previously disagreed, with the present-field
+// path dropping the attribution entirely when the correct array was also
+// sent).
+func TestExplainSchemaError_BothArraysSentStillNamesBranch(t *testing.T) {
+	both := map[string]any{
+		"action":  "update",
+		"tasks":   []any{map[string]any{"id": 1, "status": "in_progress"}},
+		"updates": []any{map[string]any{"id": 2, "status": "done"}},
+	}
+	missingPath := ExplainSchemaError("task_list", taskListParams(), both, "tasks/0", "")
+	if !strings.Contains(missingPath, `for action "append"`) {
+		t.Fatalf("missing-field path dropped branch attribution when both arrays were sent: %q", missingPath)
+	}
+	// Present-field variant: type error in the wrong branch's array.
+	present := map[string]any{
+		"action":  "update",
+		"tasks":   []any{map[string]any{"type": 123, "description": "d", "prompt": "p"}},
+		"updates": []any{map[string]any{"id": 2, "status": "done"}},
+	}
+	presentPath := ExplainSchemaError("task_list", taskListParams(), present, "tasks/0/type", "type")
+	if !strings.Contains(presentPath, `array for action "append"`) {
+		t.Fatalf("present-field path dropped branch attribution when both arrays were sent: %q", presentPath)
+	}
+}
+
+// A prose "For X: ..." description whose X is not a member of the selector's
+// enum must not be treated as a branch tag (read_file's "For large files read
+// in slices: ..." style on an array-tagged property). The message falls back
+// to the generic form with no branch attribution.
+func TestExplainSchemaError_ProseTagOutsideEnumIsNotBranch(t *testing.T) {
+	params := map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"action": map[string]any{"type": "string", "enum": []string{"view", "append", "update"}},
+			"slices": map[string]any{
+				"type":        "array",
+				"description": "For large files read in slices: line ranges.",
+				"items": map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"start": map[string]any{"type": "integer"}},
+					"required":   []string{"start"},
+				},
+			},
+		},
+		"required": []string{"action"},
+	}
+	args := map[string]any{"action": "view", "slices": []any{map[string]any{}}}
+	got := ExplainSchemaError("read_file", params, args, "slices/0", "")
+	// The guard this pins: the parsed tag "large files read in slices" is not
+	// in the selector's enum, so it must NOT be named as a branch. This
+	// assertion fails if the enum-membership check in namedBranch is removed
+	// (verified by experiment: disabling the guard produces branch
+	// attribution here).
+	if strings.Contains(got, "large files read in slices") {
+		t.Fatalf("prose tag outside the selector enum was treated as a branch: %q", got)
+	}
+	if strings.Contains(got, "for action") {
+		t.Fatalf("message must not attribute a branch when the tag is not an enum member: %q", got)
+	}
+	want := "read_file: missing required argument \"start\" in slices[0].\n" +
+		"Required arguments in slices[0]: start (integer).\n" +
+		"Example: {\"action\": \"...\"}"
+	if got != want {
+		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+	}
+}

--- a/agent/session_tool_repair_task_branch_test.go
+++ b/agent/session_tool_repair_task_branch_test.go
@@ -1,0 +1,89 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/internal/tool"
+	taskpkg "primeradiant.com/evener/agent/task"
+	"primeradiant.com/evener/llm"
+)
+
+// Issue #626 regression: a task_list call with action "update" whose update
+// entries were placed in the append-branch "tasks" array (the exact argument
+// shape observed 17 times in session 034FsgXdyimiBvbubPlB4w) must be
+// rejected with an error that names the append branch the tasks[0]
+// requirement belongs to and points the caller at the "updates" array — not
+// the bare append-branch required list, which read as describing the update
+// call itself and sent the model into an unrecoverable retry loop. This
+// exercises the real prevalidation seam (prepareToolCall → Schema.Validate →
+// repair → ExplainSchemaError) with the real DefTaskList schema.
+func TestPrepareToolCall_TaskListUpdateCallerNamesAppendBranch(t *testing.T) {
+	reg := tool.NewRegistry()
+	if err := reg.Register(regTool(tool.DefTaskList(nil))); err != nil {
+		t.Fatalf("register task_list: %v", err)
+	}
+	rt := reg.Get("task_list")
+
+	// Exact shape from the live session: update entries in "tasks", including
+	// the fields the model added while following the old misdirecting error.
+	call := llm.ToolCallData{
+		ID:   "issue626",
+		Name: "task_list",
+		Arguments: json.RawMessage(`{"action":"update","tasks":[{` +
+			`"depends_on":[],"id":1,"notes":"","reasoning_effort":"inherit",` +
+			`"status":"in_progress","type":"implement"}]}`),
+	}
+	res := prepareToolCall(call, rt, []string{"task_list"}, "task_list", "")
+	if res.PrevalErr == "" {
+		t.Fatalf("expected prevalidation failure for update-shaped entries in tasks, got none (changes: %v)", res.Changes)
+	}
+	if !strings.Contains(res.PrevalErr, `for action "append"`) {
+		t.Fatalf("error must name the append branch the tasks[0] requirement belongs to: %q", res.PrevalErr)
+	}
+	if !strings.Contains(res.PrevalErr, `takes "updates"`) {
+		t.Fatalf("error must point an update caller at the updates array: %q", res.PrevalErr)
+	}
+	if !strings.Contains(res.PrevalErr, `"updates": [{`) {
+		t.Fatalf("error example must show the updates-array item shape: %q", res.PrevalErr)
+	}
+}
+
+// The same call through execTool must surface the branch-named error to the
+// model, and must not reach the handler's "update requires a non-empty
+// 'updates' array" — that handler error was the other half of the loop.
+func TestExecTool_TaskListUpdateCallerBranchNamed(t *testing.T) {
+	s := newSession(t, withoutGitSnapshot())
+	s.stateDir = t.TempDir()
+	registerTaskTools(s.reg, &toolDeps{
+		emit:           func(events.EventKind, events.EventData) {},
+		steer:          func(string, string) {},
+		resultToolName: func() string { return "communicate" },
+		taskGuard: taskGuard{
+			getOrCreateTaskStore: func() *taskpkg.TaskStore {
+				return taskpkg.NewTaskStore(t.TempDir(), "issue626")
+			},
+			markUsed: func() {},
+		},
+	})
+	res := s.execTool(context.Background(), llm.ToolCallData{
+		ID:        "issue626-exec",
+		Name:      "task_list",
+		Arguments: json.RawMessage(`{"action":"update","tasks":[{"id":1,"status":"in_progress"}]}`),
+	}, "")
+	if !res.IsError {
+		t.Fatalf("expected error for update-shaped entries in tasks, got: %s", res.FullOutput)
+	}
+	if strings.Contains(res.FullOutput, "update requires a non-empty") {
+		t.Fatalf("error fell through to the handler's shape complaint instead of the branch-named schema error: %s", res.FullOutput)
+	}
+	if !strings.Contains(res.FullOutput, `for action "append"`) {
+		t.Fatalf("model-visible error must name the append branch: %s", res.FullOutput)
+	}
+	if !strings.Contains(res.FullOutput, `takes "updates"`) {
+		t.Fatalf("model-visible error must point the caller at updates: %s", res.FullOutput)
+	}
+}

--- a/agent/session_tool_repair_test.go
+++ b/agent/session_tool_repair_test.go
@@ -201,9 +201,13 @@ func TestPrepareToolCall_NestedSchemaErrors_NameRealFieldAndContainer(t *testing
 		call := llm.ToolCallData{ID: "c1", Name: "task_list",
 			Arguments: json.RawMessage(`{"action":"update","updates":[{"status":"done","notes":"x"}]}`)}
 		res := prepareToolCall(call, reg.Get("task_list"), []string{"task_list"}, "task_list", "")
+		// The Example shows the caller's own branch shape (issue #626 round 2,
+		// finding 3): a correctly-placed update call missing a required field
+		// gets the updates-array template, not the action-only one. (Main made
+		// status optional, so the same-branch case under test is missing id.)
 		want := "task_list: missing required argument \"id\" in updates[0].\n" +
 			"Required arguments in updates[0]: id (integer).\n" +
-			"Example: {\"action\": \"...\"}"
+			"Example: {\"action\": \"update\", \"updates\": [{\"id\": 0}]}"
 		if res.PrevalErr != want {
 			t.Fatalf("PrevalErr =\n%s\nwant:\n%s", res.PrevalErr, want)
 		}


### PR DESCRIPTION
## Summary

`task_list` declares both `tasks` (append branch: items require `type`/`description`/`prompt`) and `updates` (update branch: items require `id`/`status`) as unconditional top-level properties — which one applies is selected by the handler via `action`, not by the schema. When an update caller places entries in `tasks` (the exact shape from the live session in the issue), validation fails inside `tasks[0]` and the explainer rendered the **append branch's** required list with no branch attribution, plus a top-level-only `Example`. Following that advice produced the handler's *other* error ("update requires a non-empty 'updates' array") — the alternating two-error loop that cost the original session 17 failed calls and ended only when it abandoned task tracking. Same misdirection family as #618/#193: an error tail describing a code path the caller didn't take.

## The fix

`repair.ExplainSchemaError` is now action-branch-aware:

- A `branchCtx` (selector name, caller's action value, branch value, action-scoped arrays) is built **once** per explained error.
- When the failing container sits inside another action's array, the required-args tail names the branch: `Required arguments in tasks[0] for action "append": type (string), description (string), prompt (string).`
- The `Example` renders from the caller's **actual** branch: `Example: {"action": "update", "updates": [{"id": 0, "status": "..."}]}`
- A closing clause states what the caller's action takes: `Your action "update" takes "updates" (sent: action, tasks).`
- Branch naming applies on **both** the missing-field and present-field paths (a type error inside the wrong branch's array is also attributed), with aligned gating: a both-arrays-sent call names the branch without the takes-advice (which would be false when the correct array was sent).

Detection keys on the schema's existing conventions — a required string selector with an enum, and `"For <action>:"` description tags on action-scoped arrays — **guarded by enum membership**, so prose tags outside the selector's enum never name a branch. Generalizes to `manage_worktree`-style schemas via the same conventions.

## New message for the exact live-session call

```
task_list: missing required argument "type" in tasks[0].
Required arguments in tasks[0] for action "append": type (string), description (string), prompt (string).
Example: {"action": "update", "updates": [{"id": 0, "status": "..."}]}
Your action "update" takes "updates" (sent: action, tasks).
```

## Verification

- **TDD:** red-first (all new tests fail on pre-fix code with the exact misdirecting message — revert-verified independently by adversarial reviewers via `git stash` and `go test -overlay`).
- **Process:** two implementer subagents in isolated worktrees off main; two full simplify rounds (8 + 2 reviewers); three adversarial review rounds (two competing reviewers each, points-for-most-legitimate-significant-findings with disqualification for inflation); every warranted finding applied and re-gated.
- **Gates:** full `./agent` suite (172–189s), `./agent/internal/tool/...`, `go vet`, `gofmt`, `golangci-lint` 0 issues, coverage floor 94.7 exit 0, fuzz seeds pass. Non-firing paths allocation-free, pinned by alloc tests (the guard test mutation-verified in both directions). Goldens fail on revert.
- Final verification round: **SHIP** from both independent reviewers; remaining findings filed separately (#688 stale pre-existing fixture — not touched here to avoid scope creep).

Fixes #626
