### PR TITLE
fix(communicate): zero-fill the default output envelope and name real constraint violations

### DIFF
--- a/agent/cov_s3_communicate_test.go
+++ b/agent/cov_s3_communicate_test.go
@@ -113,13 +113,25 @@ func TestS3Cov_CommunicateSchemaStringSlice(t *testing.T) {
 	}
 }
 
-func TestS3Cov_CommunicateSchemaContains(t *testing.T) {
+func TestS3Cov_StringSetsEqual(t *testing.T) {
 	t.Parallel()
-	if !communicateSchemaContains([]string{"x", "y"}, "y") {
-		t.Fatal("expected contains")
+	props := func(names ...string) map[string]any {
+		m := map[string]any{}
+		for _, n := range names {
+			m[n] = map[string]any{}
+		}
+		return m
 	}
-	if communicateSchemaContains([]string{"x"}, "z") {
-		t.Fatal("expected not contains")
+	if !stringSetsEqual(props("x", "y"), []string{"y", "x"}, "x", "y") {
+		t.Fatal("expected equal")
+	}
+	// Missing member.
+	if stringSetsEqual(props("x"), []string{"x", "y"}, "x", "y") {
+		t.Fatal("expected not equal: required missing y")
+	}
+	// Extra member.
+	if stringSetsEqual(props("x", "y", "z"), []string{"x", "y"}, "x", "y") {
+		t.Fatal("expected not equal: extra property z")
 	}
 }
 

--- a/agent/cov_stweb_fuzz_test.go
+++ b/agent/cov_stweb_fuzz_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 
@@ -202,7 +203,7 @@ func stoolCommunicateRun(t *testing.T, data []byte) stoolCommunicateTrace {
 			t.Fatalf("custom schema recognized as default: %#v", def)
 		}
 	}
-	if got := communicateSchemaStringSlice([]any{"message", 1, "data"}); len(got) != 2 || !communicateSchemaContains(got, "data") {
+	if got := communicateSchemaStringSlice([]any{"message", 1, "data"}); len(got) != 2 || !slices.Contains(got, "data") {
 		t.Fatalf("schema string normalization = %#v", got)
 	}
 	if got := communicateSchemaStringSlice(42); got != nil {

--- a/agent/internal/tool/repair/explain.go
+++ b/agent/internal/tool/repair/explain.go
@@ -74,7 +74,7 @@ func ExplainSchemaError(toolName string, params, args map[string]any, instanceLo
 		// error instead of a missing one. Attribute the branch here too.
 		ctx := newBranchCtx(params, args, containerPath)
 		if constraintKeyword != "" {
-			if specific := constraintMessage(toolName, fullPath, containerSchema, field, constraintKeyword, args, instanceLocation); specific != "" {
+			if specific := constraintMessage(toolName, containerSchema, fullPath, field, constraintKeyword, args, instanceLocation); specific != "" {
 				return specific + ctx.wrongBranchTail(args)
 			}
 		}
@@ -425,10 +425,10 @@ func actionExample(params map[string]any, selectorName, actionValue string, acti
 // present field whose schema rejected it: the field's display path, the
 // constraint name, its limit, and the actual value/length. Returns "" when
 // the keyword is not one of the recognized constraints (maxLength,
-// minLength, minItems, maxItems, enum) or when the schema/value shape
-// doesn't match the keyword, so the caller falls back to the generic
+// minLength, minItems, maxItems, enum, required) or when the schema/value
+// shape doesn't match the keyword, so the caller falls back to the generic
 // "wrong type or value" message.
-func constraintMessage(toolName, displayPath string, containerSchema map[string]any, field, keyword string, args map[string]any, instanceLocation string) string {
+func constraintMessage(toolName string, containerSchema map[string]any, displayPath string, field, keyword string, args map[string]any, instanceLocation string) string {
 	fieldSchema, _ := schemaProps(containerSchema)[field].(map[string]any)
 	if fieldSchema == nil {
 		return ""
@@ -471,8 +471,42 @@ func constraintMessage(toolName, displayPath string, containerSchema map[string]
 			return ""
 		}
 		return fmt.Sprintf("%s: argument %q is not one of the allowed values: %s. Value is %q.", toolName, displayPath, strings.Join(allowed, ", "), fmt.Sprint(value))
+	case "required":
+		// The field itself is present but its object value is missing required
+		// properties (the issue #627 shape: communicate's output object without
+		// its nested message/data/artifacts). Name them rather than reporting
+		// the whole object as a wrong type or value, and show the accepted
+		// shape, resolved from the field's own schema (the container it lives
+		// in), never from a same-named top-level property.
+		inst, ok := value.(map[string]any)
+		if !ok {
+			return ""
+		}
+		missing := missingRequired(fieldSchema, inst)
+		if len(missing) == 0 {
+			return ""
+		}
+		for i, name := range missing {
+			missing[i] = fmt.Sprintf("%s.%s", displayPath, name)
+		}
+		return fmt.Sprintf("%s: argument %q is missing required properties: %s.\nExample: %s",
+			toolName, displayPath, strings.Join(missing, ", "), exampleForField(containerSchema, field))
 	}
 	return ""
+}
+
+// exampleForField renders a minimal example naming just the failing field,
+// with its nested required shape expanded (issue #627: the example must show
+// the accepted output envelope, not a bare {}). containerSchema is the schema
+// of the object holding field — the example resolves field's shape there, so
+// a nested field never picks up a same-named top-level property's schema.
+func exampleForField(containerSchema map[string]any, field string) string {
+	props := schemaProps(containerSchema)
+	if prop, ok := props[field].(map[string]any); ok {
+		typ, _ := prop["type"].(string)
+		return fmt.Sprintf("{%q: %s}", field, exampleValue(prop, typ))
+	}
+	return exampleObject(containerSchema, true)
 }
 
 // resolveInstanceValue walks a JSON-Pointer-style path (e.g.
@@ -583,10 +617,8 @@ func resolveSchemaErrorContainer(params, args map[string]any, instanceLocation s
 		// container — find its first missing required property.
 		item := schemas[n]
 		itemInst, _ := insts[n].(map[string]any)
-		for _, r := range requiredNames(item) {
-			if _, present := itemInst[r]; !present {
-				return item, formatPath(segs), r, false, true
-			}
+		if missing := missingRequired(item, itemInst); len(missing) > 0 {
+			return item, formatPath(segs), missing[0], false, true
 		}
 		return nil, "", "", false, false
 	}
@@ -851,18 +883,55 @@ func requiredList(params map[string]any) []string {
 }
 
 func minimalExample(params map[string]any) string {
-	props := schemaProps(params)
-	req := append([]string(nil), asStringSlice(params["required"])...)
+	return exampleObject(params, true)
+}
+
+// exampleObject renders an object schema's required properties as
+// "name: placeholder" pairs, sorted alphabetically. expandNested also
+// expands an object property that itself declares required keys one level
+// deep (issue #627: communicate's output example must show the accepted
+// envelope, not a bare {}).
+//
+// The required list is copied before sorting — a schema's "required" value
+// may be a []string held by reference (DefCommunicateNamed builds it that
+// way, and asStringSlice returns such a slice as-is), so sorting in place
+// would corrupt the shared schema for every later message and every
+// registry clone that shares it.
+func exampleObject(schema map[string]any, expandNested bool) string {
+	props := schemaProps(schema)
+	req := append([]string(nil), asStringSlice(schema["required"])...)
 	sort.Strings(req)
 	parts := make([]string, 0, len(req))
-	for _, r := range req {
+	for _, name := range req {
 		typ := ""
-		if p, ok := props[r].(map[string]any); ok {
+		if p, ok := props[name].(map[string]any); ok {
 			typ, _ = p["type"].(string)
 		}
-		parts = append(parts, fmt.Sprintf("%q: %s", r, examplePlaceholder(typ)))
+		placeholder := examplePlaceholder(typ)
+		if expandNested {
+			placeholder = exampleValue(props[name], typ)
+		}
+		parts = append(parts, fmt.Sprintf("%q: %s", name, placeholder))
 	}
 	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+// exampleValue renders a property's placeholder: examplePlaceholder for
+// scalars, or (for an object property that declares its own required list)
+// the nested shape via exampleObject, one level deep.
+func exampleValue(prop any, typ string) string {
+	placeholder := examplePlaceholder(typ)
+	if typ != "object" {
+		return placeholder
+	}
+	p, ok := prop.(map[string]any)
+	if !ok {
+		return placeholder
+	}
+	if len(asStringSlice(p["required"])) == 0 {
+		return placeholder
+	}
+	return exampleObject(p, false)
 }
 
 func examplePlaceholder(typ string) string {

--- a/agent/internal/tool/repair/explain_covtest_test.go
+++ b/agent/internal/tool/repair/explain_covtest_test.go
@@ -123,7 +123,7 @@ func TestConstraintMessage_FieldSchemaNil(t *testing.T) {
 		"required":   []string{"missing"},
 	}
 	args := map[string]any{"missing": "value"}
-	got := constraintMessage("my_tool", "missing", params, "missing", "maxLength", args, "missing")
+	got := constraintMessage("my_tool", params, "missing", "missing", "maxLength", args, "missing")
 	if got != "" {
 		t.Fatalf("constraintMessage = %q, want empty", got)
 	}
@@ -140,7 +140,7 @@ func TestConstraintMessage_UnrecognizedKeyword(t *testing.T) {
 		"required": []string{"val"},
 	}
 	args := map[string]any{"val": float64(5)}
-	got := constraintMessage("my_tool", "val", params, "val", "minimum", args, "val")
+	got := constraintMessage("my_tool", params, "val", "val", "minimum", args, "val")
 	if got != "" {
 		t.Fatalf("constraintMessage = %q, want empty for unrecognized keyword", got)
 	}

--- a/agent/internal/tool/repair/repair.go
+++ b/agent/internal/tool/repair/repair.go
@@ -18,6 +18,7 @@ const (
 	ChangeCoerceType    ChangeKind = "coerce_type"
 	ChangeDropUnknown   ChangeKind = "drop_unknown"
 	ChangeUnicodeRepair ChangeKind = "unicode_repair"
+	ChangeFillRequired  ChangeKind = "fill_required"
 )
 
 // Change records one repair for telemetry. Field is the affected key ("" for a
@@ -158,4 +159,16 @@ func dropUnknown(params, args map[string]any) []Change {
 		changes = append(changes, Change{Kind: ChangeDropUnknown, Field: key, Detail: "dropped " + key})
 	}
 	return changes
+}
+
+// missingRequired lists the container schema's required property names that
+// are absent from the instance object, in schema order.
+func missingRequired(container map[string]any, inst map[string]any) []string {
+	var missing []string
+	for _, r := range asStringSlice(container["required"]) {
+		if _, present := inst[r]; !present {
+			missing = append(missing, r)
+		}
+	}
+	return missing
 }

--- a/agent/session_communicate_issue627_test.go
+++ b/agent/session_communicate_issue627_test.go
@@ -1,0 +1,323 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"primeradiant.com/evener/agent/internal/tool"
+	"primeradiant.com/evener/agent/internal/tool/repair"
+	"primeradiant.com/evener/llm"
+)
+
+// issue627OutputArgs is the exact communicate argument shape recorded in
+// session 034FxZS24JiHCpndeJz7Xr turn 91 (and retried identically at turns
+// 93/95/97): output carries data and artifacts but no nested `message` key.
+// The schema's output.required rejected it with the generic
+// `argument "output" has the wrong type or value` — even though the call
+// followed the documented envelope and the executor treats a missing
+// output.message as an empty string.
+const issue627OutputArgs = `{"end_turn":true,"message":"ADVERSARIAL TEST-QUALITY REVIEW — final report","output":{"artifacts":[],"data":{"command":"go test ./agent","must_fix":["inject testOnly.sandboxProber"]}}}`
+
+// issue627ArgsMap is the same shape as a parsed argument map, for tests that
+// call repair.ExplainSchemaError directly.
+func issue627ArgsMap() map[string]any {
+	return map[string]any{
+		"end_turn": true,
+		"message":  "final report",
+		"output": map[string]any{
+			"artifacts": []any{},
+			"data":      map[string]any{"command": "go test"},
+		},
+	}
+}
+
+// registerCommunicateForIssue627 registers the default communicate tool the
+// way a real session does, returning the registry and the resolved tool.
+func registerCommunicateForIssue627(t *testing.T) (*tool.Registry, *tool.RegisteredTool) {
+	t.Helper()
+	reg := tool.NewRegistry()
+	if err := reg.Register(regTool(tool.DefCommunicate())); err != nil {
+		t.Fatalf("register communicate: %v", err)
+	}
+	rt := reg.Get("communicate")
+	return reg, rt
+}
+
+// TestPrepareToolCall_CommunicateOutputEnvelopeHealed is the red test for
+// issue #627: an output object that follows the documented envelope but omits
+// a nested default-envelope key (here `message`) must be healed before schema
+// validation — the runtime treats those keys as optional with defaults, so
+// the schema's required list must not strand a call whose visible text rides
+// in the top-level message.
+func TestPrepareToolCall_CommunicateOutputEnvelopeHealed(t *testing.T) {
+	_, rt := registerCommunicateForIssue627(t)
+
+	call := llm.ToolCallData{ID: "issue627", Name: "communicate", Arguments: json.RawMessage(issue627OutputArgs)}
+	res := prepareToolCall(call, rt, []string{"communicate"}, "communicate", "communicate", "")
+	if res.PrevalErr != "" {
+		t.Fatalf("documented-shape communicate call rejected (issue #627): %s", res.PrevalErr)
+	}
+	if len(res.Changes) == 0 {
+		t.Fatal("expected the missing envelope keys to be recorded as repairs")
+	}
+	var got map[string]any
+	if err := json.Unmarshal(res.Call.Arguments, &got); err != nil {
+		t.Fatalf("unmarshal healed args: %v", err)
+	}
+	out, ok := got["output"].(map[string]any)
+	if !ok {
+		t.Fatalf("healed args lost the output object: %v", got)
+	}
+	for _, key := range []string{"message", "data", "artifacts"} {
+		if _, ok := out[key]; !ok {
+			t.Fatalf("healed output missing %q key: %v", key, out)
+		}
+	}
+}
+
+// TestExecTool_CommunicateIssue627ShapeSucceeds drives the same call through
+// the full execTool path (prevalidation, hooks, dispatch) to prove the
+// delegate-report scenario from the issue — an agent delivering its final
+// report with structured data — no longer fails four times in a row.
+func TestExecTool_CommunicateIssue627ShapeSucceeds(t *testing.T) {
+	s := newSession(t, withoutGitSnapshot())
+	s.stateDir = t.TempDir()
+
+	res := s.execTool(context.Background(), llm.ToolCallData{
+		ID:        "issue627-exec",
+		Name:      "communicate",
+		Arguments: json.RawMessage(issue627OutputArgs),
+	}, "")
+	if res.IsError {
+		t.Fatalf("communicate with issue-627 output shape failed: %s", res.FullOutput)
+	}
+	if !strings.Contains(res.FullOutput, `"accepted":true`) {
+		t.Fatalf("communicate result not accepted: %s", res.FullOutput)
+	}
+}
+
+// TestPrepareToolCall_CommunicateOutputExampleShowsFullShape: when a
+// communicate call still fails validation (a custom output schema that
+// genuinely requires a key the model omitted), the model-facing error must
+// state the actual violated constraint — which nested key is missing — and
+// show the full accepted output shape, not the generic `wrong type or value`
+// with an example that renders `output` as a bare `{}`.
+func TestPrepareToolCall_CommunicateOutputExampleShowsFullShape(t *testing.T) {
+	reg := tool.NewRegistry()
+	def := tool.DefCommunicateNamed("communicate")
+	params := tool.CloneSchemaMap(def.Parameters)
+	props := params["properties"].(map[string]any)
+	outputSchema := props["output"].(map[string]any)
+	outProps := outputSchema["properties"].(map[string]any)
+	// `decision` is enum-constrained, so the fill must not invent a value for
+	// it; the call must be rejected with the missing key named.
+	outProps["decision"] = map[string]any{"type": "string", "enum": []string{"approved", "rejected"}}
+	outputSchema["required"] = append(outputSchema["required"].([]string), "decision")
+	if err := reg.Register(regTool(llm.ToolDefinition{Name: "communicate", Description: "d", Parameters: params})); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	rt := reg.Get("communicate")
+
+	call := llm.ToolCallData{ID: "issue627-custom", Name: "communicate",
+		Arguments: json.RawMessage(issue627OutputArgs)}
+	res := prepareToolCall(call, rt, []string{"communicate"}, "communicate", "communicate", "")
+	if res.PrevalErr == "" {
+		t.Fatal("expected prevalidation failure for enum-constrained missing decision")
+	}
+	if strings.Contains(res.PrevalErr, "wrong type or value") {
+		t.Fatalf("generic wrong-type-or-value message hides the actual constraint (issue #627): %s", res.PrevalErr)
+	}
+	if !strings.Contains(res.PrevalErr, "output.decision") {
+		t.Fatalf("error does not name the missing nested key output.decision: %s", res.PrevalErr)
+	}
+}
+
+// TestPrepareToolCall_CustomOutputSchemaNotSilentlyFilled pins the fill's
+// blast radius: only the default communicate envelope (whose missing keys the
+// executor documents as empty defaults) may be zero-filled. A custom output
+// schema — the shape a delegate's result_schema takes via
+// WithCommunicateOutputSchema — that requires a key the model omitted must
+// fail loudly, never be healed into validity with invented content.
+func TestPrepareToolCall_CustomOutputSchemaNotSilentlyFilled(t *testing.T) {
+	reg := tool.NewRegistry()
+	def := tool.DefCommunicateNamed("communicate")
+	params := tool.CloneSchemaMap(def.Parameters)
+	props := params["properties"].(map[string]any)
+	props["output"] = map[string]any{
+		"type":       "object",
+		"properties": map[string]any{"summary": map[string]any{"type": "string"}},
+		"required":   []string{"summary"},
+	}
+	if err := reg.Register(regTool(llm.ToolDefinition{Name: "communicate", Description: "d", Parameters: params})); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	rt := reg.Get("communicate")
+
+	call := llm.ToolCallData{ID: "issue627-custom-plain", Name: "communicate",
+		Arguments: json.RawMessage(`{"end_turn":true,"message":"report","output":{"detail":"x"}}`)}
+	res := prepareToolCall(call, rt, []string{"communicate"}, "communicate", "communicate", "")
+	if res.PrevalErr == "" {
+		t.Fatalf("custom output schema was silently healed (missing required summary): changes %+v", res.Changes)
+	}
+	if !strings.Contains(res.PrevalErr, "output.summary") {
+		t.Fatalf("error does not name the missing custom key: %s", res.PrevalErr)
+	}
+}
+
+// TestExplainSchemaError_CommunicateOutputNamesMissingNestedKey pins the
+// model-facing message for the issue #627 failure shape: a present `output`
+// object that omits a nested required property must be explained as exactly
+// that — never as a wrong type or value on `output` itself. Uses the real
+// DefCommunicateNamed parameters (not a hand-mirrored schema) so drift in
+// definitions.go fails here.
+func TestExplainSchemaError_CommunicateOutputNamesMissingNestedKey(t *testing.T) {
+	params := tool.DefCommunicateNamed("communicate").Parameters
+	msg := repair.ExplainSchemaError("communicate", params, issue627ArgsMap(), "output", "required")
+	if strings.Contains(msg, "wrong type or value") {
+		t.Fatalf("present output object misreported as wrong type or value (issue #627): %q", msg)
+	}
+	if !strings.Contains(msg, "output.message") {
+		t.Fatalf("message does not name the missing nested key: %q", msg)
+	}
+	if !strings.Contains(msg, "Example:") {
+		t.Fatalf("message lost the example tail: %q", msg)
+	}
+}
+
+// TestExplainSchemaError_ExampleShowsNestedOutputShape pins the Example tail:
+// for a schema whose required `output` property is itself an object with
+// required keys, the example must show that nested shape rather than a bare
+// `{}` — the recovery hint the issue reports as incomplete. It also guards
+// the shared schema against mutation: DefCommunicateNamed stores the nested
+// required list as a []string, which asStringSlice returns by reference, so
+// an example renderer that sorts it in place would corrupt
+// t.Definition.Parameters for every later message (and across registry
+// clones that share it).
+func TestExplainSchemaError_ExampleShowsNestedOutputShape(t *testing.T) {
+	params := tool.DefCommunicateNamed("communicate").Parameters
+	outputSchema := params["properties"].(map[string]any)["output"].(map[string]any)
+	required, _ := outputSchema["required"].([]string)
+	before := strings.Join(required, ",")
+
+	msg := repair.ExplainSchemaError("communicate", params, issue627ArgsMap(), "output", "required")
+	if !strings.Contains(msg, `"output": {"artifacts": [], "data": {}, "message": "..."}`) {
+		t.Fatalf("example does not show the accepted output shape: %q", msg)
+	}
+	if after := strings.Join(required, ","); after != before {
+		t.Fatalf("schema's required list mutated by example rendering: %s -> %s", before, after)
+	}
+}
+
+// TestPrepareToolCall_SameShapeNonResultToolNotFilled pins the identity half
+// of the fill gate: a tool that is NOT the session's result tool keeps its
+// envelope-shaped required output failing loudly, even when its schema is
+// byte-identical to the default communicate envelope. The fill is a property
+// of the result tool's documented contract, not of any schema that happens to
+// share its shape (an MCP or plugin tool could plausibly look like this).
+func TestPrepareToolCall_SameShapeNonResultToolNotFilled(t *testing.T) {
+	reg := tool.NewRegistry()
+	// submit_report: envelope-shaped schema on a differently-named tool.
+	if err := reg.Register(regTool(tool.DefCommunicateNamed("submit_report"))); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	rt := reg.Get("submit_report")
+
+	call := llm.ToolCallData{ID: "r2-identity", Name: "submit_report",
+		Arguments: json.RawMessage(`{"end_turn":true,"message":"m","output":{"data":{"a":1}}}`)}
+	// The session's result tool is communicate, not submit_report.
+	res := prepareToolCall(call, rt, []string{"submit_report"}, "submit_report", "communicate", "")
+	if res.PrevalErr == "" {
+		t.Fatalf("envelope-shaped schema on a non-result tool was silently filled: changes %+v args %s", res.Changes, res.Call.Arguments)
+	}
+	if !strings.Contains(res.PrevalErr, "output.message") {
+		t.Fatalf("error does not name the missing envelope key: %s", res.PrevalErr)
+	}
+}
+
+// TestPrepareToolCall_SupersetEnvelopeNotFilled pins the exact-match half of
+// the fill gate: usesDefaultCommunicateOutputEnvelope must reject a superset
+// envelope (the WithAllowedDecisions shape — message/data/artifacts plus an
+// enum-constrained decision), so those calls keep failing loudly on the key
+// the model was required to choose.
+func TestPrepareToolCall_SupersetEnvelopeNotFilled(t *testing.T) {
+	def := tool.DefCommunicateNamed("communicate")
+	params := tool.CloneSchemaMap(def.Parameters)
+	props := params["properties"].(map[string]any)
+	outputSchema := props["output"].(map[string]any)
+	outProps := outputSchema["properties"].(map[string]any)
+	outProps["decision"] = map[string]any{"type": "string", "enum": []string{"approved", "rejected"}}
+	outputSchema["required"] = append(outputSchema["required"].([]string), "decision")
+
+	if usesDefaultCommunicateOutputEnvelope(llm.ToolDefinition{Parameters: params}) {
+		t.Fatal("superset envelope must not match the default envelope predicate")
+	}
+
+	reg := tool.NewRegistry()
+	if err := reg.Register(regTool(llm.ToolDefinition{Name: "communicate", Description: "d", Parameters: params})); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	rt := reg.Get("communicate")
+
+	call := llm.ToolCallData{ID: "r2-superset", Name: "communicate",
+		Arguments: json.RawMessage(`{"end_turn":true,"message":"m","output":{"data":{"a":1}}}`)}
+	res := prepareToolCall(call, rt, []string{"communicate"}, "communicate", "communicate", "")
+	if res.PrevalErr == "" {
+		t.Fatalf("superset envelope was silently filled: changes %+v args %s", res.Changes, res.Call.Arguments)
+	}
+	if !strings.Contains(res.PrevalErr, "decision") {
+		t.Fatalf("error does not name the enum-constrained key: %s", res.PrevalErr)
+	}
+}
+
+// TestPrepareToolCall_FillNotRecordedWhenValidationStillFails pins the
+// telemetry contract: the fill is committed only when validation passes. A
+// call that still fails after filling (here: end_turn missing) must report
+// zero changes, so no ToolCallRepaired event claims arguments bytes that were
+// never applied.
+func TestPrepareToolCall_FillNotRecordedWhenValidationStillFails(t *testing.T) {
+	_, rt := registerCommunicateForIssue627(t)
+
+	call := llm.ToolCallData{ID: "r2-phantom", Name: "communicate",
+		Arguments: json.RawMessage(`{"message":"m","output":{"data":{"a":1}}}`)}
+	res := prepareToolCall(call, rt, []string{"communicate"}, "communicate", "communicate", "")
+	if res.PrevalErr == "" {
+		t.Fatal("expected validation failure (end_turn missing)")
+	}
+	if len(res.Changes) != 0 {
+		t.Fatalf("phantom ToolCallRepaired changes recorded for a call that failed validation: %+v", res.Changes)
+	}
+}
+
+// TestExplainSchemaError_NestedFieldExampleUsesContainerSchema pins the
+// container-collision fix: when a nested object property (tasks[0].meta) is
+// missing required keys, the Example must render that nested field's own
+// shape — never a same-named top-level property's.
+func TestExplainSchemaError_NestedFieldExampleUsesContainerSchema(t *testing.T) {
+	params := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"meta": map[string]any{"type": "object", "required": []string{"top_level_marker"}, "properties": map[string]any{"top_level_marker": map[string]any{"type": "string"}}},
+			"tasks": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"meta": map[string]any{"type": "object", "required": []string{"nested_marker"}, "properties": map[string]any{"nested_marker": map[string]any{"type": "string"}}},
+					},
+					"required": []string{"meta"},
+				},
+			},
+		},
+		"required": []string{"tasks"},
+	}
+	args := map[string]any{"tasks": []any{map[string]any{"meta": map[string]any{}}}}
+	msg := repair.ExplainSchemaError("probe_tool", params, args, "tasks/0/meta", "required")
+	if strings.Contains(msg, "top_level_marker") {
+		t.Fatalf("example rendered the top-level meta's shape for a nested field: %q", msg)
+	}
+	if !strings.Contains(msg, `"meta": {"nested_marker": "..."}`) {
+		t.Fatalf("example does not show the nested field's own shape: %q", msg)
+	}
+}

--- a/agent/session_tool_repair.go
+++ b/agent/session_tool_repair.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 
 	jsonschema "github.com/santhosh-tekuri/jsonschema/v5"
@@ -26,10 +27,12 @@ type prepareResult struct {
 // prepareToolCall heals a tool call before dispatch. t is the resolved tool
 // (nil if the name is unknown). visibleNames and requestedVisible are already
 // provider-visible names (the caller snapshots the name-map outside s.mu).
+// resultToolName is the session's result tool (communicate) — the only tool
+// whose default output envelope is eligible for the documented-defaults fill.
 // finishReason is the round's stop reason ("" when no model response is in
 // play); llm.FinishReasonLength disables JSON repair, since closing a
 // truncated string would execute a silently truncated call.
-func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames []string, requestedVisible, finishReason string) prepareResult {
+func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames []string, requestedVisible, resultToolName, finishReason string) prepareResult {
 	res := prepareResult{Call: call}
 	if strings.TrimSpace(res.Call.ID) == "" {
 		res.Call.ID = "call_" + shortHash(res.Call.Arguments)
@@ -80,6 +83,24 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 		args = normalized
 	}
 
+	// The default communicate envelope documents message/data/artifacts as
+	// always-present with empty defaults (issue #627), but the schema demands
+	// them as required — reconcile by filling the documented defaults before
+	// validation. communicateEnvelopeFor owns both gates (identity: the
+	// session's result tool only; exact shape: precisely the default
+	// envelope), and returns the envelope it validated so the fill cannot
+	// diverge from what was checked. The fill runs on a working copy and is
+	// committed (args + recorded changes) only if validation passes, so a
+	// call that still fails never emits a ToolCallRepaired event whose
+	// Arguments bytes were never applied.
+	var fillChanges []repair.Change
+	if envelope, ok := communicateEnvelopeFor(t, resultToolName); ok {
+		filled := make(map[string]any, len(args))
+		maps.Copy(filled, args)
+		fillChanges = fillCommunicateEnvelope(envelope, filled)
+		args = filled
+	}
+
 	if err := t.Schema.Validate(args); err != nil {
 		// A length stop that cut the stream before any argument byte leaves
 		// empty args; on a tool with required parameters that reads as a
@@ -95,7 +116,12 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 			return res
 		}
 		args = healed
+		// The healed form carries the fill (it was validated above), so the
+		// fill's changes belong in the record alongside the healing changes.
+		res.Changes = append(res.Changes, fillChanges...)
 		res.Changes = append(res.Changes, c...)
+	} else if len(fillChanges) > 0 {
+		res.Changes = append(res.Changes, fillChanges...)
 	}
 
 	if len(res.Changes) > 0 {

--- a/agent/session_tool_repair_oneof_test.go
+++ b/agent/session_tool_repair_oneof_test.go
@@ -41,7 +41,7 @@ func TestPrepareToolCall_DelegateLegacySandboxNetDropped(t *testing.T) {
 		Arguments: json.RawMessage(`{"task":"ping","agent_type":"subagent","isolation":"worktree",` +
 			`"sandbox":"off","sandbox_net":true,"reasoning_effort":"low","delegation_allowance":0}`),
 	}
-	res := prepareToolCall(call, rt, []string{"delegate"}, "delegate", "")
+	res := prepareToolCall(call, rt, []string{"delegate"}, "delegate", "communicate", "")
 	// sandbox_net is no longer in the schema, so it must be dropped — not
 	// cause a prevalidation error. The oneOf constraint is gone.
 	if res.PrevalErr != "" {

--- a/agent/session_tool_repair_task_branch_test.go
+++ b/agent/session_tool_repair_task_branch_test.go
@@ -37,7 +37,7 @@ func TestPrepareToolCall_TaskListUpdateCallerNamesAppendBranch(t *testing.T) {
 			`"depends_on":[],"id":1,"notes":"","reasoning_effort":"inherit",` +
 			`"status":"in_progress","type":"implement"}]}`),
 	}
-	res := prepareToolCall(call, rt, []string{"task_list"}, "task_list", "")
+	res := prepareToolCall(call, rt, []string{"task_list"}, "task_list", "communicate", "")
 	if res.PrevalErr == "" {
 		t.Fatalf("expected prevalidation failure for update-shaped entries in tasks, got none (changes: %v)", res.Changes)
 	}

--- a/agent/session_tool_repair_test.go
+++ b/agent/session_tool_repair_test.go
@@ -67,7 +67,7 @@ func TestPrepareToolCall_AliasesArgs(t *testing.T) {
 	et := editTool(t)
 	call := llm.ToolCallData{ID: "c1", Name: "edit_file",
 		Arguments: json.RawMessage(`{"file_path":"/x","old_str":"a","new_string":"b"}`)}
-	res := prepareToolCall(call, et, []string{"edit_file"}, "edit_file", "")
+	res := prepareToolCall(call, et, []string{"edit_file"}, "edit_file", "communicate", "")
 	if res.PrevalErr != "" {
 		t.Fatalf("unexpected prevalErr: %s", res.PrevalErr)
 	}
@@ -85,7 +85,7 @@ func TestPrepareToolCall_AliasesArgs(t *testing.T) {
 
 func TestPrepareToolCall_UnknownTool(t *testing.T) {
 	call := llm.ToolCallData{ID: "c1", Name: "reed_file", Arguments: json.RawMessage(`{}`)}
-	res := prepareToolCall(call, nil, []string{"read_file", "edit_file"}, "reed_file", "")
+	res := prepareToolCall(call, nil, []string{"read_file", "edit_file"}, "reed_file", "communicate", "")
 	if res.PrevalErr == "" {
 		t.Fatal("expected prevalErr for unknown tool")
 	}
@@ -97,7 +97,7 @@ func TestPrepareToolCall_EmptyArgsValidForNoRequiredTool(t *testing.T) {
 	_ = reg.Register(regTool(def)) // regTool: helper building a RegisteredTool with a no-op Exec (see below)
 	res := prepareToolCall(
 		llm.ToolCallData{ID: "c1", Name: "list_dir", Arguments: json.RawMessage(``)},
-		reg.Get("list_dir"), []string{"list_dir"}, "list_dir", "")
+		reg.Get("list_dir"), []string{"list_dir"}, "list_dir", "communicate", "")
 	if res.PrevalErr != "" {
 		t.Fatalf("empty args rejected: %s", res.PrevalErr)
 	}
@@ -107,7 +107,7 @@ func TestPrepareToolCall_SynthesizesStableIDWhenEmpty(t *testing.T) {
 	et := editTool(t)
 	call := llm.ToolCallData{Name: "edit_file",
 		Arguments: json.RawMessage(`{"file_path":"/x","old_string":"a","new_string":"b"}`)}
-	res := prepareToolCall(call, et, []string{"edit_file"}, "edit_file", "")
+	res := prepareToolCall(call, et, []string{"edit_file"}, "edit_file", "communicate", "")
 	if res.Call.ID == "" {
 		t.Fatal("expected synthesized ID")
 	}
@@ -120,7 +120,7 @@ func TestPrepareToolCall_TruncatedByLength(t *testing.T) {
 	et := editTool(t)
 	truncated := json.RawMessage(`{"file_path":"/x","old_string":"a","new_string":"unterminat`)
 	res := prepareToolCall(llm.ToolCallData{ID: "c1", Name: "edit_file", Arguments: truncated},
-		et, []string{"edit_file"}, "edit_file", llm.FinishReasonLength)
+		et, []string{"edit_file"}, "edit_file", "communicate", llm.FinishReasonLength)
 	if res.PrevalErr == "" || !strings.Contains(res.PrevalErr, "truncated") {
 		t.Fatalf("want truncation error, got: %q", res.PrevalErr)
 	}
@@ -137,7 +137,7 @@ func TestPrepareToolCall_TruncatedBeforeAnyArgs(t *testing.T) {
 	et := editTool(t)
 	res := prepareToolCall(llm.ToolCallData{ID: "c1", Name: "edit_file",
 		Arguments: json.RawMessage(``)},
-		et, []string{"edit_file"}, "edit_file", llm.FinishReasonLength)
+		et, []string{"edit_file"}, "edit_file", "communicate", llm.FinishReasonLength)
 	if res.PrevalErr == "" || !strings.Contains(res.PrevalErr, "truncated") {
 		t.Fatalf("want truncation error, got: %q", res.PrevalErr)
 	}
@@ -150,7 +150,7 @@ func TestPrepareToolCall_LengthStopEmptyArgsNoRequired(t *testing.T) {
 	_ = reg.Register(regTool(tool.DefListDir()))
 	res := prepareToolCall(
 		llm.ToolCallData{ID: "c1", Name: "list_dir", Arguments: json.RawMessage(``)},
-		reg.Get("list_dir"), []string{"list_dir"}, "list_dir", llm.FinishReasonLength)
+		reg.Get("list_dir"), []string{"list_dir"}, "list_dir", "communicate", llm.FinishReasonLength)
 	if res.PrevalErr != "" {
 		t.Fatalf("empty args rejected: %s", res.PrevalErr)
 	}
@@ -162,7 +162,7 @@ func TestPrepareToolCall_LengthStopWithValidArgs(t *testing.T) {
 	et := editTool(t)
 	res := prepareToolCall(llm.ToolCallData{ID: "c1", Name: "edit_file",
 		Arguments: json.RawMessage(`{"file_path":"/x","old_string":"a","new_string":"b"}`)},
-		et, []string{"edit_file"}, "edit_file", llm.FinishReasonLength)
+		et, []string{"edit_file"}, "edit_file", "communicate", llm.FinishReasonLength)
 	if res.PrevalErr != "" {
 		t.Fatalf("valid args must execute: %q", res.PrevalErr)
 	}
@@ -175,7 +175,7 @@ func TestPrepareToolCall_TaskListInheritEffortIsValid(t *testing.T) {
 	}
 	call := llm.ToolCallData{ID: "inherit", Name: "task_list",
 		Arguments: json.RawMessage(`{"action":"append","tasks":[{"type":"implement","description":"step","prompt":"do it","reasoning_effort":"inherit"}]}`)}
-	res := prepareToolCall(call, reg.Get("task_list"), []string{"task_list"}, "task_list", "")
+	res := prepareToolCall(call, reg.Get("task_list"), []string{"task_list"}, "task_list", "communicate", "")
 	if res.PrevalErr != "" {
 		t.Fatalf("inherit effort rejected: %s", res.PrevalErr)
 	}
@@ -200,7 +200,7 @@ func TestPrepareToolCall_NestedSchemaErrors_NameRealFieldAndContainer(t *testing
 	t.Run("task_list update missing id", func(t *testing.T) {
 		call := llm.ToolCallData{ID: "c1", Name: "task_list",
 			Arguments: json.RawMessage(`{"action":"update","updates":[{"status":"done","notes":"x"}]}`)}
-		res := prepareToolCall(call, reg.Get("task_list"), []string{"task_list"}, "task_list", "")
+		res := prepareToolCall(call, reg.Get("task_list"), []string{"task_list"}, "task_list", "communicate", "")
 		// The Example shows the caller's own branch shape (issue #626 round 2,
 		// finding 3): a correctly-placed update call missing a required field
 		// gets the updates-array template, not the action-only one. (Main made
@@ -216,7 +216,7 @@ func TestPrepareToolCall_NestedSchemaErrors_NameRealFieldAndContainer(t *testing
 	t.Run("ask_user accepts a long question header", func(t *testing.T) {
 		call := llm.ToolCallData{ID: "c2", Name: "ask_user",
 			Arguments: json.RawMessage(`{"questions":[{"header":"way too long for a chip label","question":"q","options":[{"label":"a","detail":"a"},{"label":"b","detail":"b"}]}]}`)}
-		res := prepareToolCall(call, reg.Get("ask_user"), []string{"ask_user"}, "ask_user", "")
+		res := prepareToolCall(call, reg.Get("ask_user"), []string{"ask_user"}, "ask_user", "communicate", "")
 		if res.PrevalErr != "" {
 			t.Fatalf("long header was rejected: %s", res.PrevalErr)
 		}
@@ -230,7 +230,7 @@ func TestPrepareToolCall_NestedSchemaErrors_NameRealFieldAndContainer(t *testing
 	t.Run("task_list action bogus enum value", func(t *testing.T) {
 		call := llm.ToolCallData{ID: "c4", Name: "task_list",
 			Arguments: json.RawMessage(`{"action":"bogus"}`)}
-		res := prepareToolCall(call, reg.Get("task_list"), []string{"task_list"}, "task_list", "")
+		res := prepareToolCall(call, reg.Get("task_list"), []string{"task_list"}, "task_list", "communicate", "")
 		want := "task_list: argument \"action\" is not one of the allowed values: view, append, update. Value is \"bogus\"."
 		if res.PrevalErr != want {
 			t.Fatalf("PrevalErr =\n%s\nwant:\n%s", res.PrevalErr, want)
@@ -246,7 +246,7 @@ func TestPrepareToolCall_BrokenJSONNonLengthStop(t *testing.T) {
 	et := editTool(t)
 	res := prepareToolCall(llm.ToolCallData{ID: "c1", Name: "edit_file",
 		Arguments: json.RawMessage(`{"file_path": nope}`)},
-		et, []string{"edit_file"}, "edit_file", llm.FinishReasonStop)
+		et, []string{"edit_file"}, "edit_file", "communicate", llm.FinishReasonStop)
 	if res.PrevalErr == "" || !strings.Contains(res.PrevalErr, "not valid JSON") {
 		t.Fatalf("want invalid-JSON error, got: %q", res.PrevalErr)
 	}

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -670,7 +670,7 @@ func (s *Session) execTool(ctx context.Context, call llm.ToolCallData, finishRea
 	nameMap := s.currentProfile().ToolNameMap()
 	visibleNames := providerVisibleToolNames(s.reg.Names(), nameMap)
 	requestedVisible := providerToolName(call.Name, nameMap)
-	prep := prepareToolCall(call, s.reg.Get(call.Name), visibleNames, requestedVisible, finishReason)
+	prep := prepareToolCall(call, s.reg.Get(call.Name), visibleNames, requestedVisible, s.resultToolName(), finishReason)
 	call = prep.Call
 	if len(prep.Changes) > 0 {
 		s.emit(events.EventToolCallRepaired, events.ToolCallRepairedData{

--- a/agent/session_tools_aux_exact_fuzz_test.go
+++ b/agent/session_tools_aux_exact_fuzz_test.go
@@ -97,7 +97,7 @@ func auxWebFetchExact(t *testing.T) {
 
 func auxRepairExact(t *testing.T) {
 	call := llm.ToolCallData{Arguments: json.RawMessage(`{"x":1}`)}
-	if got := prepareToolCall(call, nil, []string{"known"}, "missing", ""); got.Call.ID == "" || got.PrevalErr == "" {
+	if got := prepareToolCall(call, nil, []string{"known"}, "missing", "communicate", ""); got.Call.ID == "" || got.PrevalErr == "" {
 		t.Fatalf("unknown repair = %#v", got)
 	}
 	if got := offendingField(errors.New("plain")); got != "" {
@@ -154,7 +154,7 @@ func auxCommunicateExact(t *testing.T) {
 	}}}) {
 		t.Fatal("incomplete communicate requirements accepted")
 	}
-	if communicateSchemaContains([]string{"x"}, "y") {
+	if stringSetsEqual(map[string]any{"x": map[string]any{}}, []string{"y"}, defaultEnvelopeKeys...) {
 		t.Fatal("schema contains absent value")
 	}
 	if got := canonicalNodeOutputTextWithMarshal(nil, func(any) ([]byte, error) { return nil, errors.New("marshal") }); got != "{}" {

--- a/agent/session_tools_communicate.go
+++ b/agent/session_tools_communicate.go
@@ -11,6 +11,7 @@ import (
 	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/internal/tool"
+	"primeradiant.com/evener/agent/internal/tool/repair"
 	"primeradiant.com/evener/agent/skill"
 	"primeradiant.com/evener/llm"
 )
@@ -259,6 +260,47 @@ func hasMeaningfulNodeOutput(out nodeOutput) bool {
 		len(out.Artifacts) > 0
 }
 
+// defaultEnvelopeKeys are the output-envelope keys the default communicate
+// schema declares — and the only keys the documented-defaults fill may add.
+// Kept as one constant so the shape predicate and the fill cannot drift apart.
+var defaultEnvelopeKeys = []string{"message", "data", "artifacts"}
+
+// communicateEnvelopeFor reports whether t is the session's result tool with
+// its default output envelope, returning that envelope schema when it is.
+// This is the single owner of the fill's two gates (issue #627):
+//   - identity: only the result tool gets the fill. A same-shaped schema on
+//     any other registered tool (an MCP or plugin tool) must keep failing
+//     loudly on keys the model was required to choose.
+//   - exact shape: properties and required must each be precisely
+//     defaultEnvelopeKeys — a custom output schema (a delegate result_schema
+//     installed via WithCommunicateOutputSchema, or a WithAllowedDecisions
+//     superset) keeps failing loudly.
+//
+// Returning the envelope it validated (rather than a bool the caller
+// re-derives) is what keeps the check and the fill from diverging.
+func communicateEnvelopeFor(t *tool.RegisteredTool, resultToolName string) (map[string]any, bool) {
+	if t == nil || t.Definition.Name != resultToolName {
+		return nil, false
+	}
+	props, _ := t.Definition.Parameters["properties"].(map[string]any)
+	envelope, _ := props["output"].(map[string]any)
+	outProps, _ := envelope["properties"].(map[string]any)
+	if outProps == nil {
+		return nil, false
+	}
+	required := communicateSchemaStringSlice(envelope["required"])
+	if !stringSetsEqual(outProps, required, defaultEnvelopeKeys...) {
+		return nil, false
+	}
+	return envelope, true
+}
+
+// usesDefaultCommunicateOutputEnvelope reports whether def's `output` property
+// is exactly the default envelope DefCommunicateNamed builds: properties and
+// required are each precisely {message, data, artifacts} — no more, no fewer.
+// A superset (WithAllowedDecisions adds an enum-constrained `decision`) or a
+// differently-shaped schema is a custom envelope, whose required keys the
+// model was expected to choose.
 func usesDefaultCommunicateOutputEnvelope(def llm.ToolDefinition) bool {
 	props, _ := def.Parameters["properties"].(map[string]any)
 	output, _ := props["output"].(map[string]any)
@@ -266,14 +308,21 @@ func usesDefaultCommunicateOutputEnvelope(def llm.ToolDefinition) bool {
 	if outProps == nil {
 		return false
 	}
-	for _, name := range []string{"message", "data", "artifacts"} {
-		if _, ok := outProps[name]; !ok {
+	required := communicateSchemaStringSlice(output["required"])
+	return stringSetsEqual(outProps, required, defaultEnvelopeKeys...)
+}
+
+// stringSetsEqual reports whether the schema's property names and required
+// names are each exactly the wanted set (as sets: same members, same count).
+func stringSetsEqual(props map[string]any, required []string, want ...string) bool {
+	if len(props) != len(want) || len(required) != len(want) {
+		return false
+	}
+	for _, name := range want {
+		if _, ok := props[name]; !ok {
 			return false
 		}
-	}
-	required := communicateSchemaStringSlice(output["required"])
-	for _, name := range []string{"message", "data", "artifacts"} {
-		if !communicateSchemaContains(required, name) {
+		if !slices.Contains(required, name) {
 			return false
 		}
 	}
@@ -297,8 +346,61 @@ func communicateSchemaStringSlice(v any) []string {
 	}
 }
 
-func communicateSchemaContains(values []string, want string) bool {
-	return slices.Contains(values, want)
+// fillCommunicateEnvelope fills a present default-envelope `output` object's
+// missing message/data/artifacts keys with their documented empty defaults
+// ("" / {} / []). It mutates args in place on the working copy the caller
+// owns, and never overwrites an existing key. Only communicateEnvelopeFor's
+// envelope — the default one — may be passed here; a custom output schema
+// must keep failing loudly on keys the model was required to choose.
+func fillCommunicateEnvelope(envelope, args map[string]any) []repair.Change {
+	raw, isMap := args["output"].(map[string]any)
+	if !isMap {
+		return nil
+	}
+	props, _ := envelope["properties"].(map[string]any)
+	var changes []repair.Change
+	for _, key := range defaultEnvelopeKeys {
+		if _, present := raw[key]; present {
+			continue
+		}
+		prop, ok := props[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		v, ok := envelopeZeroValue(prop)
+		if !ok {
+			continue
+		}
+		raw[key] = v
+		changes = append(changes, repair.Change{Kind: repair.ChangeFillRequired, Field: "output", Detail: "filled " + key})
+	}
+	return changes
+}
+
+// envelopeZeroValue returns the zero-value instance of an envelope property's
+// declared type — the value a missing key is filled with. It returns ok=false
+// for anything that is not a plain scalar, object, or array, and for
+// enum-constrained properties: a zero value is never a value the model chose,
+// so an enum field must stay absent and be reported as missing rather than
+// silently sent as an invalid choice.
+func envelopeZeroValue(prop map[string]any) (any, bool) {
+	if _, hasEnum := prop["enum"]; hasEnum {
+		return nil, false
+	}
+	typ, _ := prop["type"].(string)
+	switch typ {
+	case "string":
+		return "", true
+	case "boolean":
+		return false, true
+	case "integer", "number":
+		return float64(0), true
+	case "object":
+		return map[string]any{}, true
+	case "array":
+		return []any{}, true
+	}
+	return nil, false
 }
 
 func hasMeaningfulRawOutput(raw any) bool {


### PR DESCRIPTION
## Summary

The `communicate` schema declared nested `required: [message, data, artifacts]` on `output`, but the runtime (`normalizeNodeOutput`) treats missing envelope keys as empty defaults. A call sending `output` with `data`/`artifacts` but no `message` key — the exact rejected shape from a live delegate whose finished report could not be delivered — failed schema validation **before** the lenient runtime ever saw it, with the generic `argument "output" has the wrong type or value` and an incomplete `Example`. No recovery path.

Root cause inverted the issue's hypothesis: the runtime is **more lenient** than the schema, not stricter. The schema demanding what the runtime treats as defaults was the defect.

## The fix

- **One agent-side helper owns both gates.** `communicateEnvelopeFor(t, resultToolName)` checks tool identity AND exact envelope shape (exactly `message`/`data`/`artifacts`, exactly those required, nothing else). The fill is unexported and lives in the agent package — no other tool's schema (MCP/plugin tools with envelope-shaped `output` included), and no communicate call carrying a custom result schema, can be silently zero-filled. `WithAllowedDecisions`-style extended envelopes fail the exact-shape gate and still fail loudly, with the enum-constrained `decision` key named (the enum guard refuses to invent enum values).
- **Zero-fill with commit-on-validation.** Missing envelope keys are filled on a working copy that commits only when `Schema.Validate` passes — no phantom `ToolCallRepaired` telemetry for still-failing calls; fill changes are recorded on healing success too.
- **Honest rejections.** Remaining violations name the actual missing nested keys and show the full accepted shape in the `Example`, resolving from the containing schema (no top-level name-collision rendering).
- **Shared-state safety pinned.** `exampleObject` copies before sorting (the #618-era in-place-sort mutation hazard on shared `required` slices — guard test included).

## Verification

- **TDD:** 4 red tests from the exact transcript-evidence argument shapes; red-on-revert verified independently by adversarial reviewers.
- **Process:** isolated worktree off main; two full simplify rounds; three adversarial rounds (competing reviewers, points-for-most-legitimate-significant-findings); every warranted finding applied — including two majors the reviewers caught (the fill-gate tool-identity hole, demonstrated with a synthetic tool; and the in-place-sort shared-state mutation) and the round's only blocker (a stranded fuzz-tagged reference caught by `make lint-evenerfuzz`, a gate invisible to plain `go test`/`make lint`).
- **Gates:** full `./agent` suite, `go vet`, `gofmt`, `golangci-lint` 0 issues, coverage floor 94.6 exit 0, fuzz seeds, and the `evenerfuzz`-tagged compile+test gate (242s) — all green. Final verification round: **SHIP** from both independent reviewers; the one cosmetic follow-up (projector phrase for `fill_required`) filed separately as #689.

## Note for the merger

This PR and #690 (the #626 fix) both modify `agent/internal/tool/repair/explain.go`'s present-field block and `agent/session_tool_repair_test.go`, and this PR changes `prepareToolCall`'s signature (one new arg), which #690's new tests call with the old form. Whichever merges second rebases and keeps **both** changes (the reordered `constraintMessage` arguments and #690's `wrongBranchTail` suffix).

Fixes #627
