### PR TITLE
fix: use primary model when fast cheap model is unset

### DIFF
--- a/agent/fork.go
+++ b/agent/fork.go
@@ -327,6 +327,7 @@ func writeForkChildWithConfig(fs afero.Fs, stateDir, parentID string, parentHead
 		ID:                 childID,
 		ProfileID:          parentMeta.ProfileID,
 		Model:              parentMeta.Model,
+		CheapModel:         parentMeta.CheapModel,
 		Config:             childConfig,
 		EnvInfo:            parentMeta.EnvInfo,
 		CreatedAt:          now,

--- a/agent/fork_test.go
+++ b/agent/fork_test.go
@@ -193,6 +193,77 @@ func TestForkSession_CopiesPrefixAndAppliesEdit(t *testing.T) {
 	}
 }
 
+func TestForkAndAsidePreserveCheapModel(t *testing.T) {
+	operations := []struct {
+		name   string
+		create func(string, string) (string, error)
+	}{
+		{
+			name: "fork",
+			create: func(stateDir, parentID string) (string, error) {
+				return ForkSession(stateDir, parentID, 3, "edited", "")
+			},
+		},
+		{name: "aside", create: AsideSession},
+	}
+	routes := []struct {
+		name         string
+		ref          string
+		wantProvider string
+		wantModel    string
+	}{
+		{name: "relative", ref: "gpt-5-mini", wantProvider: "openai", wantModel: "gpt-5-mini"},
+		{name: "qualified", ref: "anthropic/claude-haiku-4-5-20251001", wantProvider: "anthropic", wantModel: "claude-haiku-4-5-20251001"},
+	}
+	for _, operation := range operations {
+		for _, route := range routes {
+			t.Run(operation.name+"/"+route.name, func(t *testing.T) {
+				stateDir, parentID := buildParentSession(t)
+				parentMeta, err := schema.LoadSessionMeta(stateDir, parentID)
+				if err != nil {
+					t.Fatalf("LoadSessionMeta(parent): %v", err)
+				}
+				parentMeta.CheapModel = route.ref
+				if err := schema.SaveSessionMeta(stateDir, parentMeta); err != nil {
+					t.Fatalf("SaveSessionMeta(parent): %v", err)
+				}
+
+				childID, err := operation.create(stateDir, parentID)
+				if err != nil {
+					t.Fatalf("%s: %v", operation.name, err)
+				}
+				childMeta, err := schema.LoadSessionMeta(stateDir, childID)
+				if err != nil {
+					t.Fatalf("LoadSessionMeta(child): %v", err)
+				}
+				if childMeta.CheapModel != route.ref {
+					t.Fatalf("child CheapModel = %q, want %q", childMeta.CheapModel, route.ref)
+				}
+
+				client := llm.NewClient()
+				client.Register(&fakeAdapter{name: "openai"})
+				client.Register(&fakeAdapter{name: "anthropic"})
+				restored, err := RestoreSessionFromMetaWithConfig(
+					client,
+					NewOpenAIProfile(childMeta.Model),
+					execenv.NewLocalExecutionEnvironment(t.TempDir()),
+					childMeta,
+					RestoreSessionConfig{StateDir: stateDir},
+				)
+				if err != nil {
+					t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
+				}
+				defer restored.Close()
+				providerName, model := restored.profile.CheapModelRef()
+				if providerName != route.wantProvider || model != route.wantModel {
+					t.Fatalf("restored CheapModelRef() = (%q, %q), want (%q, %q)",
+						providerName, model, route.wantProvider, route.wantModel)
+				}
+			})
+		}
+	}
+}
+
 func TestForkSession_RejectsMixedAPICallWithoutCreatingChild(t *testing.T) {
 	t.Parallel()
 	stateDir, parentID := buildParentSession(t)

--- a/agent/internal/cheapmodel/caller.go
+++ b/agent/internal/cheapmodel/caller.go
@@ -51,8 +51,8 @@ func New(client *llm.Client) *Caller {
 
 // Complete resolves and executes a cheap-model request, falling back once to
 // the session model when the provider refuses the resolved model. It resolves
-// through the profile's cheap-model ref, which falls through to the provider's
-// default cheap model when the session configured none.
+// through the profile's cheap-model ref, which uses the session model when no
+// cheap model is configured.
 func (c *Caller) Complete(ctx context.Context, profile *provider.Profile, req llm.Request) (llm.Response, error) {
 	cheapProvider, cheapModel := profile.CheapModelRef()
 	return c.CompleteRouted(ctx, profile, cheapProvider, cheapModel, req)
@@ -68,19 +68,11 @@ func (c *Caller) CompleteRouted(ctx context.Context, profile *provider.Profile, 
 	return resp, err
 }
 
-// CompleteConfigured is Complete for work too costly to hand to a model nobody
-// chose: it uses only an explicitly configured cheap model and runs on the
-// session's own model when none is configured, where Complete would fall
-// through to the provider's default cheap model.
-//
-// It reports whether it ran the session model, so a caller that layers routes
-// of its own on top of this one does not re-run a route already tried here.
+// CompleteConfigured resolves the same route as Complete and reports whether it
+// ran the session model, so a caller that layers routes does not repeat it.
 func (c *Caller) CompleteConfigured(ctx context.Context, profile *provider.Profile, req llm.Request) (resp llm.Response, ranSessionModel bool, err error) {
-	cheap := route{provider: profile.CheapProvider(), model: profile.ConfiguredCheapModel()}
-	if cheap.model == "" {
-		cheap = sessionModel(profile)
-	}
-	return c.run(ctx, profile, cheap, req)
+	providerName, modelID := profile.CheapModelRef()
+	return c.run(ctx, profile, route{provider: providerName, model: modelID}, req)
 }
 
 // run executes one resolution. Both the cheap and the fallback attempt share

--- a/agent/internal/cheapmodel/caller_test.go
+++ b/agent/internal/cheapmodel/caller_test.go
@@ -54,6 +54,23 @@ func complete(t *testing.T, caller *cheapmodel.Caller, profile *provider.Profile
 	})
 }
 
+func profileWithCheap(main string) *provider.Profile {
+	return provider.WithCheapModel(provider.NewOpenAIProfile(main), "gpt-4.1-nano")
+}
+
+func TestCallerUsesSessionModelWhenCheapUnconfigured(t *testing.T) {
+	adapter := servesOnly("openai", "main", refusal(400, "unexpected model"))
+	caller := cheapmodel.New(clientWith(adapter))
+
+	resp, err := complete(t, caller, provider.NewOpenAIProfile("main"))
+	if err != nil || strings.TrimSpace(resp.Text()) != "answered" {
+		t.Fatalf("Complete = (%q, %v), want answered", resp.Text(), err)
+	}
+	if got, want := adapter.Models(), []string{"main"}; !slices.Equal(got, want) {
+		t.Fatalf("models = %v, want %v", got, want)
+	}
+}
+
 func TestCallerFallsBackAndRemembersObservedRefusals(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -66,7 +83,7 @@ func TestCallerFallsBackAndRemembersObservedRefusals(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			adapter := servesOnly("openai", "main", refusal(400, test.message))
 			caller := cheapmodel.New(clientWith(adapter))
-			profile := provider.NewOpenAIProfile("main")
+			profile := profileWithCheap("main")
 
 			for range 2 {
 				resp, err := complete(t, caller, profile)
@@ -94,7 +111,7 @@ func TestCallerDeduplicatesConcurrentCheapRefusalProbes(t *testing.T) {
 		return llm.Response{Message: llm.Assistant("answered")}, nil
 	}
 	caller := cheapmodel.New(clientWith(adapter))
-	profile := provider.NewOpenAIProfile("main")
+	profile := profileWithCheap("main")
 	start := make(chan struct{})
 	var wg sync.WaitGroup
 	errs := make(chan error, callers)
@@ -174,7 +191,7 @@ func TestCallerRunsConcurrentSuccessfulCheapRequestsIndependently(t *testing.T) 
 	}
 
 	caller := cheapmodel.New(clientWith(adapter))
-	profile := provider.NewOpenAIProfile("main")
+	profile := profileWithCheap("main")
 	start := make(chan struct{})
 	ready := make(chan struct{}, callers)
 	responses := make(chan string, callers)
@@ -251,7 +268,7 @@ func TestCallerDoesNotGeneralizeRequestErrorsIntoModelRefusals(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			adapter := servesOnly("openai", "main", refusal(test.status, test.message))
 			caller := cheapmodel.New(clientWith(adapter))
-			profile := provider.NewOpenAIProfile("main")
+			profile := profileWithCheap("main")
 
 			for range 2 {
 				if _, err := complete(t, caller, profile); err == nil {
@@ -274,7 +291,7 @@ func TestCallerDoesNotGeneralizeRequestErrorsIntoModelRefusals(t *testing.T) {
 func TestCallerIgnoresRefusalWordingOnARetryableError(t *testing.T) {
 	adapter := servesOnly("openai", "main", refusal(429, "The provided model identifier is invalid."))
 	caller := cheapmodel.New(clientWith(adapter))
-	profile := provider.NewOpenAIProfile("main")
+	profile := profileWithCheap("main")
 
 	for range 2 {
 		_, err := complete(t, caller, profile)
@@ -314,7 +331,7 @@ func TestCallerUsesStaticCompatibilityWithoutAProbe(t *testing.T) {
 	adapter := &declaredModelAdapter{ModelTrackingAdapter: tracker, served: "main"}
 	caller := cheapmodel.New(clientWith(adapter))
 
-	if _, err := complete(t, caller, provider.NewOpenAIProfile("main")); err != nil {
+	if _, err := complete(t, caller, profileWithCheap("main")); err != nil {
 		t.Fatalf("Complete: %v", err)
 	}
 	if got, want := tracker.Models(), []string{"main"}; !slices.Equal(got, want) {
@@ -333,7 +350,7 @@ func TestCallerReturnsBothErrorsWhenFallbackFails(t *testing.T) {
 	}
 	caller := cheapmodel.New(clientWith(adapter))
 
-	_, err := complete(t, caller, provider.NewOpenAIProfile("main"))
+	_, err := complete(t, caller, profileWithCheap("main"))
 	if !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "model identifier") {
 		t.Fatalf("Complete error = %v, want refusal and deadline", err)
 	}
@@ -342,11 +359,10 @@ func TestCallerReturnsBothErrorsWhenFallbackFails(t *testing.T) {
 	}
 }
 
-// TestCompleteConfiguredPrefersTheSessionModelOverAProviderDefault covers the
-// entry point summarization uses: with no cheap model configured it runs the
-// session's own model rather than the provider's default cheap one, and it says
-// so, so a caller layering its own routes does not repeat the session model.
-func TestCompleteConfiguredPrefersTheSessionModelOverAProviderDefault(t *testing.T) {
+// TestCompleteConfiguredReportsSessionModelWhenCheapUnset covers the entry
+// point summarization uses: with no cheap model configured it runs the session
+// model and reports that route so callers do not repeat it.
+func TestCompleteConfiguredReportsSessionModelWhenCheapUnset(t *testing.T) {
 	adapter := servesOnly("openai", "main", refusal(400, "unexpected model"))
 	caller := cheapmodel.New(clientWith(adapter))
 
@@ -411,16 +427,19 @@ func TestCallerKeepsRefusalsAcrossModelSwitchButNotProviderSwitch(t *testing.T) 
 	bedrock := servesOnly("bedrock", "bedrock-main", refusal(400, "The provided model identifier is invalid."))
 	caller := cheapmodel.New(clientWith(openAI, bedrock))
 
-	if _, err := complete(t, caller, provider.NewOpenAIProfile("main")); err != nil {
+	if _, err := complete(t, caller, profileWithCheap("main")); err != nil {
 		t.Fatalf("openai Complete: %v", err)
 	}
-	if _, err := complete(t, caller, provider.NewOpenAIProfile("main-2")); err != nil {
+	if _, err := complete(t, caller, profileWithCheap("main-2")); err != nil {
 		t.Fatalf("switched Complete: %v", err)
 	}
 	if got, want := openAI.Models(), []string{"gpt-4.1-nano", "main", "main-2"}; !slices.Equal(got, want) {
 		t.Fatalf("openai models = %v, want %v", got, want)
 	}
-	bedrockProfile := provider.WithProviderID(provider.NewOpenAIProfile("bedrock-main"), "bedrock")
+	bedrockProfile := provider.WithCheapModel(
+		provider.WithProviderID(provider.NewOpenAIProfile("bedrock-main"), "bedrock"),
+		"gpt-4.1-nano",
+	)
 	if _, err := complete(t, caller, bedrockProfile); err != nil {
 		t.Fatalf("bedrock Complete: %v", err)
 	}
@@ -502,7 +521,7 @@ func TestCallerWaiterHonorsItsOwnContext(t *testing.T) {
 		return llm.Response{Message: llm.Assistant("answered")}, nil
 	}
 	caller := cheapmodel.New(clientWith(adapter))
-	profile := provider.NewOpenAIProfile("main")
+	profile := profileWithCheap("main")
 	leaderDone := make(chan error, 1)
 	go func() {
 		_, err := caller.Complete(context.Background(), profile, llm.Request{Messages: []llm.Message{llm.User("leader")}})
@@ -547,7 +566,7 @@ func TestCallerRetriesAfterCanceledProbe(t *testing.T) {
 		return llm.Response{Message: llm.Assistant("answered")}, nil
 	}
 	caller := cheapmodel.New(clientWith(adapter))
-	profile := provider.NewOpenAIProfile("main")
+	profile := profileWithCheap("main")
 	leaderCtx, cancelLeader := context.WithCancel(context.Background())
 	leaderDone := make(chan error, 1)
 	go func() {
@@ -611,7 +630,7 @@ func TestCallerKeepsRefusalFlightUntilAllFallbacksSettle(t *testing.T) {
 		}
 	}
 	caller := cheapmodel.New(clientWith(adapter))
-	profile := provider.NewOpenAIProfile("main")
+	profile := profileWithCheap("main")
 
 	leaderCtx, cancelLeader := context.WithCancel(context.Background())
 	leaderDone := make(chan error, 1)
@@ -670,7 +689,7 @@ func TestCallerRetriesAfterFallbackFailure(t *testing.T) {
 		return llm.Response{Message: llm.Assistant("answered")}, nil
 	}
 	caller := cheapmodel.New(clientWith(adapter))
-	profile := provider.NewOpenAIProfile("main")
+	profile := profileWithCheap("main")
 	if _, err := complete(t, caller, profile); err == nil || !strings.Contains(err.Error(), "fallback unavailable") {
 		t.Fatalf("first Complete error = %v, want fallback failure", err)
 	}
@@ -796,7 +815,7 @@ func TestCallerEmitsOneAttemptGroupForCheapAndFallback(t *testing.T) {
 	client.Use(sink)
 	caller := cheapmodel.New(client)
 
-	resp, err := complete(t, caller, provider.NewOpenAIProfile("main"))
+	resp, err := complete(t, caller, profileWithCheap("main"))
 	if err != nil || strings.TrimSpace(resp.Text()) != "answered" {
 		t.Fatalf("Complete = (%q, %v), want answered", resp.Text(), err)
 	}

--- a/agent/profile_test.go
+++ b/agent/profile_test.go
@@ -385,20 +385,18 @@ func TestBuildSystemPrompt_DoesNotDuplicateMCPOrCustomToolDescriptions(t *testin
 	}
 }
 
-func TestProviderProfile_CheapModel(t *testing.T) {
+func TestProviderProfile_CheapModelRefDefaultsToPrimary(t *testing.T) {
 	t.Parallel()
-	cases := []struct {
-		profile *provider.Profile
-		want    string
-	}{
-		{NewOpenAIProfile("gpt-5.2"), "gpt-4.1-nano"},
-		{newAnthropicProfile("claude-opus-4-6"), "claude-haiku-4-5-20251001"},
-		{newGeminiProfile("gemini-3-pro"), "gemini-2.5-flash-lite"},
+	profiles := []*provider.Profile{
+		NewOpenAIProfile("gpt-5.2"),
+		newAnthropicProfile("claude-opus-4-6"),
+		newGeminiProfile("gemini-3-pro"),
 	}
-	for _, tc := range cases {
-		got := tc.profile.CheapModel()
-		if got != tc.want {
-			t.Fatalf("profile %q CheapModel: got %q want %q", tc.profile.ID(), got, tc.want)
+	for _, profile := range profiles {
+		providerName, model := profile.CheapModelRef()
+		if providerName != profile.ID() || model != profile.Model() {
+			t.Fatalf("profile %q CheapModelRef = (%q, %q), want (%q, %q)",
+				profile.ID(), providerName, model, profile.ID(), profile.Model())
 		}
 	}
 }
@@ -2081,30 +2079,20 @@ func TestWithProviderID(t *testing.T) {
 	}
 }
 
-// TestRenamedInstance_CheapModel verifies that CheapModel uses behaviorTag (not
-// id) so a renamed instance keeps the right cheap model.
-func TestRenamedInstance_CheapModel(t *testing.T) {
+// TestRenamedInstance_CheapModelRefUsesPrimary verifies that an unconfigured
+// auxiliary route uses the renamed provider instance and its active model.
+func TestRenamedInstance_CheapModelRefUsesPrimary(t *testing.T) {
 	t.Parallel()
-	// kimi renamed to "work" → cheap model should be the kimi default (p.model).
-	kimiWork := WithProviderID(newOpenAICompatProfile("kimi", "kimi-k2", 0), "work")
-	// CheapModel for kimi falls through to p.model (no explicit case for kimi in
-	// the switch), so the expected value is the model itself.
-	if got := kimiWork.CheapModel(); got == "" {
-		t.Fatalf("CheapModel() is empty for renamed kimi instance")
+	profiles := []*provider.Profile{
+		WithProviderID(newOpenAICompatProfile("kimi", "kimi-k2", 0), "work"),
+		WithProviderID(newGeminiProfile("gemini-2.5-pro"), "work"),
+		WithProviderID(newAnthropicProfile("claude-opus-4-6"), "work"),
 	}
-
-	// google/gemini renamed to "work" → cheap model should be gemini-2.5-flash-lite
-	googleWork := WithProviderID(newGeminiProfile("gemini-2.5-pro"), "work")
-	const wantGeminiCheap = "gemini-2.5-flash-lite"
-	if got := googleWork.CheapModel(); got != wantGeminiCheap {
-		t.Fatalf("CheapModel() = %q, want %q for renamed google (gemini) instance", got, wantGeminiCheap)
-	}
-
-	// anthropic renamed to "work" → cheap model should be claude-haiku-4-5-20251001
-	anthropicWork := WithProviderID(newAnthropicProfile("claude-opus-4-6"), "work")
-	const wantAnthropicCheap = "claude-haiku-4-5-20251001"
-	if got := anthropicWork.CheapModel(); got != wantAnthropicCheap {
-		t.Fatalf("CheapModel() = %q, want %q for renamed anthropic instance", got, wantAnthropicCheap)
+	for _, profile := range profiles {
+		providerName, model := profile.CheapModelRef()
+		if providerName != "work" || model != profile.Model() {
+			t.Fatalf("CheapModelRef() = (%q, %q), want (work, %q)", providerName, model, profile.Model())
+		}
 	}
 }
 

--- a/agent/provider/cheap_model_ref_test.go
+++ b/agent/provider/cheap_model_ref_test.go
@@ -10,8 +10,8 @@ func TestWithCheapModel_QualifiedRefSetsCheapProvider(t *testing.T) {
 	p := provider.NewOpenAIProfile("gpt-5.2")
 	got := provider.WithCheapModel(p, "anthropic/claude-haiku-4-5-20251001")
 
-	if got.CheapModel() != "claude-haiku-4-5-20251001" {
-		t.Errorf("CheapModel() = %q, want claude-haiku-4-5-20251001", got.CheapModel())
+	if got.ConfiguredCheapModel() != "claude-haiku-4-5-20251001" {
+		t.Errorf("ConfiguredCheapModel() = %q, want claude-haiku-4-5-20251001", got.ConfiguredCheapModel())
 	}
 	if got.CheapProvider() != "anthropic" {
 		t.Errorf("CheapProvider() = %q, want anthropic", got.CheapProvider())
@@ -30,8 +30,8 @@ func TestWithCheapModel_BareRefKeepsSameProvider(t *testing.T) {
 	p := provider.NewOpenAIProfile("gpt-5.2")
 	got := provider.WithCheapModel(p, "gpt-4.1-mini")
 
-	if got.CheapModel() != "gpt-4.1-mini" {
-		t.Errorf("CheapModel() = %q, want gpt-4.1-mini", got.CheapModel())
+	if got.ConfiguredCheapModel() != "gpt-4.1-mini" {
+		t.Errorf("ConfiguredCheapModel() = %q, want gpt-4.1-mini", got.ConfiguredCheapModel())
 	}
 	// A bare model keeps the active provider.
 	if got.CheapProvider() != "openai" {
@@ -60,9 +60,11 @@ func TestCheapModelRefString_RoundTrips(t *testing.T) {
 		}
 		// Re-applying the persisted string reproduces the routing.
 		rt := provider.WithCheapModel(provider.NewOpenAIProfile("gpt-5.2"), p.CheapModelRefString())
-		if rt.CheapProvider() != p.CheapProvider() || rt.CheapModel() != p.CheapModel() {
+		rtProvider, rtModel := rt.CheapModelRef()
+		providerName, model := p.CheapModelRef()
+		if rtProvider != providerName || rtModel != model {
 			t.Errorf("round-trip mismatch for %q: got (%q,%q), want (%q,%q)",
-				tc.ref, rt.CheapProvider(), rt.CheapModel(), p.CheapProvider(), p.CheapModel())
+				tc.ref, rtProvider, rtModel, providerName, model)
 		}
 	}
 
@@ -72,10 +74,10 @@ func TestCheapModelRefString_RoundTrips(t *testing.T) {
 	}
 }
 
-func TestCheapModelRef_DefaultsToActiveProviderAndDefaultCheapModel(t *testing.T) {
+func TestCheapModelRef_DefaultsToActiveProviderAndModel(t *testing.T) {
 	p := provider.NewOpenAIProfile("gpt-5.2")
 	// No cheap model configured: ConfiguredCheapModel stays empty (the namer's
-	// enable gate), but CheapModelRef falls through to the provider default.
+	// enable gate), and auxiliary work uses the active model.
 	if p.ConfiguredCheapModel() != "" {
 		t.Errorf("ConfiguredCheapModel() = %q, want empty", p.ConfiguredCheapModel())
 	}
@@ -83,7 +85,7 @@ func TestCheapModelRef_DefaultsToActiveProviderAndDefaultCheapModel(t *testing.T
 		t.Errorf("CheapProvider() = %q, want openai", p.CheapProvider())
 	}
 	prov, model := p.CheapModelRef()
-	if prov != "openai" || model != p.CheapModel() {
-		t.Errorf("CheapModelRef() = (%q, %q), want (openai, %q)", prov, model, p.CheapModel())
+	if prov != "openai" || model != "gpt-5.2" {
+		t.Errorf("CheapModelRef() = (%q, %q), want (openai, gpt-5.2)", prov, model)
 	}
 }

--- a/agent/provider/cov_w2tail_profile_test.go
+++ b/agent/provider/cov_w2tail_profile_test.go
@@ -53,17 +53,16 @@ func TestW2Tail_cloneStringSlice_Nil(t *testing.T) {
 	}
 }
 
-// CheapModel falls through to the main model when no cheap model is configured
-// and the provider has no default (openai-compat "kimi").
-func TestW2Tail_CheapModel_DefaultFallthrough(t *testing.T) {
-	p := newOpenAICompatProfile("kimi", "kimi-k2", 0, nil)
-	if got := p.CheapModel(); got != p.Model() {
-		t.Errorf("CheapModel default fallthrough = %q, want main model %q", got, p.Model())
+func TestW2Tail_CheapModelRef_DefaultFallthrough(t *testing.T) {
+	profiles := []*Profile{
+		newOpenAICompatProfile("kimi", "kimi-k2", 0, nil),
+		newAnthropicProfile("claude-opus-4-6"),
 	}
-	// Anthropic has an explicit default.
-	a := newAnthropicProfile("claude-opus-4-6")
-	if got := a.CheapModel(); got != "claude-haiku-4-5-20251001" {
-		t.Errorf("anthropic CheapModel = %q", got)
+	for _, profile := range profiles {
+		providerName, model := profile.CheapModelRef()
+		if providerName != profile.ID() || model != profile.Model() {
+			t.Errorf("CheapModelRef = (%q, %q), want (%q, %q)", providerName, model, profile.ID(), profile.Model())
+		}
 	}
 }
 

--- a/agent/provider/profile.go
+++ b/agent/provider/profile.go
@@ -137,7 +137,6 @@ type profileSpec struct {
 	providerOpts    map[string]any
 	toolNameMap     map[string]string
 	capabilities    []toolCapability
-	cheapModel      string
 	// catalogModel is the catalog entry for spec.model, nil when the model is
 	// unknown or the constructor suppresses catalog lookups. It is the source
 	// of the model-level reasoning facts (support, levels, default effort); a
@@ -328,7 +327,6 @@ func buildBaseProfile(spec profileSpec) Profile {
 		providerOpts:    cloneAnyMap(spec.providerOpts),
 		toolNameMap:     cloneStringMap(spec.toolNameMap),
 		toolDefs:        toolDefinitionsForCapabilities(spec.capabilities, enumEfforts),
-		cheapModel:      spec.cheapModel,
 	}
 }
 
@@ -428,30 +426,9 @@ func (p *Profile) DefaultCommandTimeoutMS() int { return p.defaultTimeout }
 // KnowledgeCutoff returns the model's training knowledge-cutoff date (YYYY-MM-DD).
 func (p *Profile) KnowledgeCutoff() string { return p.knowledgeCutoff }
 
-// CheapModel returns a cheaper model from the same provider for auxiliary
-// work such as session naming and summarization.
-func (p *Profile) CheapModel() string {
-	if strings.TrimSpace(p.cheapModel) != "" {
-		return strings.TrimSpace(p.cheapModel)
-	}
-	switch p.behaviorTag {
-	case "openai":
-		return "gpt-4.1-nano"
-	case "anthropic":
-		return "claude-haiku-4-5-20251001"
-	case "google":
-		return "gemini-2.5-flash-lite"
-	case "glm":
-		return "glm-4.7-flash"
-	default:
-		return p.model
-	}
-}
-
 // ConfiguredCheapModel returns the auxiliary model explicitly set via
-// WithCheapModel, or "" if none was configured. Unlike CheapModel it does not
-// fall back to a provider default, so callers can detect whether a cheap model
-// was configured at all (e.g. to decide whether to run session naming).
+// WithCheapModel, or "" if none was configured. Callers can use the empty
+// result to detect whether to run optional work such as session naming.
 func (p *Profile) ConfiguredCheapModel() string {
 	if p == nil {
 		return ""
@@ -472,20 +449,24 @@ func (p *Profile) CheapProvider() string {
 	return p.ID()
 }
 
-// CheapModelRef returns the (provider, model) pair for auxiliary side calls,
-// resolving the provider via CheapProvider and the model via CheapModel. Sites
-// that issue a cheap completion route on this pair so the cheap model can live
-// on a different provider than the main model.
+// CheapModelRef returns the (provider, model) pair for auxiliary side calls.
+// An explicit cheap-model route wins; otherwise auxiliary work uses the active
+// provider and model.
 func (p *Profile) CheapModelRef() (provider, model string) {
-	return p.CheapProvider(), p.CheapModel()
+	if p == nil {
+		return "", ""
+	}
+	if model := p.ConfiguredCheapModel(); model != "" {
+		return p.CheapProvider(), model
+	}
+	return p.ID(), p.Model()
 }
 
 // CheapModelRefString returns the configured cheap model as a WithCheapModel ref
 // ("provider/model" when cross-provider, else the bare model), or "" when no
 // cheap model is configured. It is the persistable form: feeding the result back
-// to WithCheapModel reproduces the routing, so it survives evener resume. Unlike
-// CheapModelRef it does NOT fall back to a provider default — an empty result
-// means "not configured", matching ConfiguredCheapModel.
+// to WithCheapModel reproduces the routing, so it survives evener resume. An
+// empty result means "not configured", matching ConfiguredCheapModel.
 func (p *Profile) CheapModelRefString() string {
 	if p == nil {
 		return ""

--- a/agent/provider/profile_overrides_test.go
+++ b/agent/provider/profile_overrides_test.go
@@ -288,9 +288,9 @@ func TestProfileGetters(t *testing.T) {
 		t.Errorf("KnowledgeCutoff = %q", p.KnowledgeCutoff())
 	}
 
-	// CheapModel fallback for openai behaviorTag
-	if got := p.CheapModel(); got != "gpt-4.1-nano" {
-		t.Errorf("CheapModel fallback = %q, want gpt-4.1-nano", got)
+	// Unconfigured auxiliary work uses the active provider and model.
+	if providerName, model := p.CheapModelRef(); providerName != p.ID() || model != p.Model() {
+		t.Errorf("CheapModelRef = (%q, %q), want (%q, %q)", providerName, model, p.ID(), p.Model())
 	}
 
 	// ConfiguredCheapModel with empty cheapModel
@@ -364,7 +364,7 @@ func TestWithCheapModel(t *testing.T) {
 		p := NewOpenAIProfile("gpt-4")
 		q := WithCheapModel(p, "  model  ")
 		if q.ConfiguredCheapModel() != "model" {
-			t.Errorf("CheapModel = %q, want model", q.ConfiguredCheapModel())
+			t.Errorf("ConfiguredCheapModel = %q, want model", q.ConfiguredCheapModel())
 		}
 	})
 }

--- a/agent/provider/profile_program_fuzz_test.go
+++ b/agent/provider/profile_program_fuzz_test.go
@@ -136,7 +136,7 @@ func assertProviderProfileCopies(t *testing.T, profile *Profile) {
 	_ = profile.SupportsStreaming()
 	_ = profile.DefaultCommandTimeoutMS()
 	_ = profile.KnowledgeCutoff()
-	_ = profile.CheapModel()
+	_, _ = profile.CheapModelRef()
 	if profile.ConfiguredCheapModel() != "" {
 		t.Fatalf("new %s profile unexpectedly has configured cheap model", profile.ID())
 	}
@@ -192,8 +192,8 @@ func assertProviderProfileDecorators(t *testing.T, profile *Profile, next string
 		t.Fatalf("WithProviderID identity = %q/%q (base %q)", renamed.ID(), renamed.BehaviorTag(), profile.ID())
 	}
 	bareCheap := WithCheapModel(profile, "  cheap-model  ")
-	if bareCheap.CheapProvider() != profile.ID() || bareCheap.CheapModel() != "cheap-model" || bareCheap.CheapModelRefString() != "cheap-model" {
-		t.Fatalf("bare WithCheapModel = %q/%q/%q", bareCheap.CheapProvider(), bareCheap.CheapModel(), bareCheap.CheapModelRefString())
+	if bareCheap.CheapProvider() != profile.ID() || bareCheap.ConfiguredCheapModel() != "cheap-model" || bareCheap.CheapModelRefString() != "cheap-model" {
+		t.Fatalf("bare WithCheapModel = %q/%q/%q", bareCheap.CheapProvider(), bareCheap.ConfiguredCheapModel(), bareCheap.CheapModelRefString())
 	}
 	qualifiedCheap := WithCheapModel(profile, "other/"+next)
 	if provider, model := qualifiedCheap.CheapModelRef(); provider != "other" || model != next || qualifiedCheap.CheapModelRefString() != "other/"+next {

--- a/agent/session.go
+++ b/agent/session.go
@@ -1093,6 +1093,9 @@ func (s *Session) resolveProfileForRef(base *provider.Profile, ref string) (*pro
 			return nil, false, err
 		}
 		if resolved != nil {
+			if cheapModelRef := base.CheapModelRefString(); cheapModelRef != "" {
+				resolved = provider.WithCheapModel(resolved, cheapModelRef)
+			}
 			return resolved, true, nil
 		}
 	}

--- a/agent/session_cheap_model_test.go
+++ b/agent/session_cheap_model_test.go
@@ -48,7 +48,8 @@ func TestCheapModelRefusalIsLearnedOnceForTheWholeSession(t *testing.T) {
 
 	c := llm.NewClient()
 	c.Register(fa)
-	sess, err := NewSession(c, NewOpenAIProfile("test-model"), execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{
+	profile := WithCheapModel(NewOpenAIProfile("test-model"), "gpt-4.1-nano")
+	sess, err := NewSession(c, profile, execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{
 		ContextStrategy: "session-log",
 		StateDir:        t.TempDir(),
 	})

--- a/agent/session_init_error_restore_program_fuzz_test.go
+++ b/agent/session_init_error_restore_program_fuzz_test.go
@@ -214,7 +214,7 @@ func sierRestoreProjection(t *testing.T, r *sierReader, client *llm.Client, prof
 	if len(sess.cfg.ModelFallbacks) != 1 || sess.cfg.ModelFallbacks[0] != "openai/gpt-4.1-mini" {
 		t.Fatalf("fallbacks = %v", sess.cfg.ModelFallbacks)
 	}
-	if got := sess.profile.CheapModel(); got != "gpt-4.1-mini" {
+	if got := sess.profile.ConfiguredCheapModel(); got != "gpt-4.1-mini" {
 		t.Fatalf("cheap model = %q, want gpt-4.1-mini", got)
 	}
 }

--- a/agent/session_resolve_profile_test.go
+++ b/agent/session_resolve_profile_test.go
@@ -5,6 +5,7 @@ package agent
 // which no longer work after the prefixActionSwitch arms are removed.
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -101,6 +102,119 @@ func TestSetModel_CrossProvider_SwapsProfileAndPreservesOverride(t *testing.T) {
 	outProps, _ := output["properties"].(map[string]any)
 	if _, ok := outProps["my_field"]; !ok {
 		t.Errorf("after cross-provider SetModel, communicate.output.properties is missing my_field — custom schema was not preserved")
+	}
+}
+
+func TestSetModel_CrossProvider_PreservesConfiguredCheapRoute(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		cheapRef     string
+		wantProvider string
+		wantModel    string
+	}{
+		{name: "relative route", cheapRef: "gpt-5-mini", wantProvider: "anthropic", wantModel: "gpt-5-mini"},
+		{name: "qualified route", cheapRef: "openai/gpt-5-mini", wantProvider: "openai", wantModel: "gpt-5-mini"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			stateDir := t.TempDir()
+			client := llm.NewClient()
+			client.Register(&fakeAdapter{name: "openai"})
+			client.Register(&fakeAdapter{name: "anthropic"})
+			startProfile := WithCheapModel(NewOpenAIProfile("gpt-5.4"), tc.cheapRef)
+			sess, err := NewSession(client, startProfile, execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{
+				NoProjectPrompts: true,
+				ResolveProfile:   testResolver,
+				StateDir:         stateDir,
+				testOnly:         testConfig{skipGitSnapshot: true},
+			})
+			if err != nil {
+				t.Fatalf("NewSession: %v", err)
+			}
+			defer sess.Close()
+
+			if err := sess.SetModel("anthropic/claude-opus-4-6"); err != nil {
+				t.Fatalf("SetModel: %v", err)
+			}
+			if got := sess.profile.CheapModelRefString(); got != tc.cheapRef {
+				t.Fatalf("CheapModelRefString() = %q, want %q", got, tc.cheapRef)
+			}
+			providerName, model := sess.profile.CheapModelRef()
+			if providerName != tc.wantProvider || model != tc.wantModel {
+				t.Fatalf("CheapModelRef() = (%q, %q), want (%q, %q)", providerName, model, tc.wantProvider, tc.wantModel)
+			}
+			persisted, err := schema.LoadSessionMeta(stateDir, sess.ID())
+			if err != nil {
+				t.Fatalf("LoadSessionMeta: %v", err)
+			}
+			if persisted.CheapModel != tc.cheapRef {
+				t.Fatalf("persisted CheapModel = %q, want %q", persisted.CheapModel, tc.cheapRef)
+			}
+			sess.Close()
+
+			restored, err := RestoreSessionFromMetaWithConfig(
+				client,
+				newAnthropicProfile(persisted.Model),
+				execenv.NewLocalExecutionEnvironment(t.TempDir()),
+				persisted,
+				RestoreSessionConfig{StateDir: stateDir, ResolveProfile: testResolver},
+			)
+			if err != nil {
+				t.Fatalf("RestoreSessionFromMetaWithConfig: %v", err)
+			}
+			defer restored.Close()
+			restoredProvider, restoredModel := restored.profile.CheapModelRef()
+			if restoredProvider != tc.wantProvider || restoredModel != tc.wantModel {
+				t.Fatalf("restored CheapModelRef() = (%q, %q), want (%q, %q)",
+					restoredProvider, restoredModel, tc.wantProvider, tc.wantModel)
+			}
+		})
+	}
+}
+
+func TestSelectSubagentModel_CrossProviderPreservesConfiguredCheapRoute(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		cheapRef     string
+		wantProvider string
+		wantModel    string
+	}{
+		{name: "relative route", cheapRef: "gpt-5-mini", wantProvider: "anthropic", wantModel: "gpt-5-mini"},
+		{name: "qualified route", cheapRef: "openai/gpt-5-mini", wantProvider: "openai", wantModel: "gpt-5-mini"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			client := llm.NewClient()
+			client.Register(&fakeAdapter{name: "openai"})
+			client.Register(&fakeAdapter{name: "anthropic"})
+			startProfile := WithCheapModel(NewOpenAIProfile("gpt-5.4"), tc.cheapRef)
+			sess, err := NewSession(client, startProfile, execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{
+				MaxSubagentDepth: 1,
+				NoProjectPrompts: true,
+				ResolveProfile:   testResolver,
+				testOnly:         testConfig{skipGitSnapshot: true},
+			})
+			if err != nil {
+				t.Fatalf("NewSession: %v", err)
+			}
+			defer sess.Close()
+
+			selected, err := sess.selectSubagentModel(context.Background(), "anthropic/claude-opus-4-6", "")
+			if err != nil {
+				t.Fatalf("selectSubagentModel: %v", err)
+			}
+			if got := selected.profile.CheapModelRefString(); got != tc.cheapRef {
+				t.Fatalf("CheapModelRefString() = %q, want %q", got, tc.cheapRef)
+			}
+			providerName, model := selected.profile.CheapModelRef()
+			if providerName != tc.wantProvider || model != tc.wantModel {
+				t.Fatalf("CheapModelRef() = (%q, %q), want (%q, %q)", providerName, model, tc.wantProvider, tc.wantModel)
+			}
+		})
 	}
 }
 

--- a/agent/tool_web_fetch_test.go
+++ b/agent/tool_web_fetch_test.go
@@ -139,7 +139,7 @@ func TestWebFetchTool_Integration(t *testing.T) {
 					Arguments: json.RawMessage(fmt.Sprintf(`{"url": %q, "question": "What is this page about?"}`, srv.URL)),
 				})
 			},
-			// Step 1: the cheap model Complete() call from web_fetch.
+			// Step 1: the auxiliary model Complete() call from web_fetch.
 			func(req llm.Request) llm.Response {
 				capturedReqs = append(capturedReqs, req)
 				return finalResponse("This page is about Go programming.")
@@ -171,13 +171,13 @@ func TestWebFetchTool_Integration(t *testing.T) {
 		t.Fatalf("unexpected output: %s", out)
 	}
 
-	// Verify the cheap model call used CheapModel().
+	// With no cheap model configured, web_fetch uses the primary model.
 	if len(capturedReqs) == 0 {
-		t.Fatalf("expected at least one cheap model request")
+		t.Fatalf("expected at least one auxiliary model request")
 	}
 	cheapReq := capturedReqs[0]
-	if cheapReq.Model != "gpt-4.1-nano" {
-		t.Fatalf("cheap model request used model %q, want %q", cheapReq.Model, "gpt-4.1-nano")
+	if cheapReq.Model != "test-model" {
+		t.Fatalf("auxiliary model request used model %q, want %q", cheapReq.Model, "test-model")
 	}
 	// Verify the cheap model request includes the question and content.
 	var sysTextSb171 strings.Builder
@@ -559,8 +559,8 @@ func TestWebFetch_Retries403WithAlternateUserAgentAndClosesBodies(t *testing.T) 
 	if answer, ok := result["answer"].(string); !ok || answer == "" {
 		t.Fatalf("answer field = %#v, want non-empty string", result["answer"])
 	}
-	if got, want := adapter.Models(), []string{"gpt-4.1-nano"}; !slices.Equal(got, want) {
-		t.Fatalf("models addressed = %v, want successful cheap-model route %v", got, want)
+	if got, want := adapter.Models(), []string{"test-model"}; !slices.Equal(got, want) {
+		t.Fatalf("models addressed = %v, want primary-model route %v", got, want)
 	}
 	if requestCount != 2 || len(transport.requests) != 2 {
 		t.Fatalf("HTTP requests = %d, transport requests = %d, want exactly one retry", requestCount, len(transport.requests))
@@ -645,7 +645,8 @@ func TestWebFetch_RawFallbackWhenBothModelsRefuse(t *testing.T) {
 	}
 	client := llm.NewClient()
 	client.Register(adapter)
-	sess, err := NewSession(client, NewOpenAIProfile("test-model"),
+	profile := WithCheapModel(NewOpenAIProfile("test-model"), "gpt-4.1-nano")
+	sess, err := NewSession(client, profile,
 		execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
@@ -720,7 +721,7 @@ func TestWebFetch_NonRefusalModelErrorRemainsError(t *testing.T) {
 	if _, err := sess.webFetch(context.Background(), page.URL, "WFNONREFUSALQUESTION3C67A9"); err == nil {
 		t.Fatal("webFetch succeeded, want non-refusal model error")
 	}
-	if got, want := adapter.Models(), []string{"gpt-4.1-nano"}; !slices.Equal(got, want) {
+	if got, want := adapter.Models(), []string{"test-model"}; !slices.Equal(got, want) {
 		t.Fatalf("models addressed = %v, want no fallback %v", got, want)
 	}
 }

--- a/cmd/evener/seed_coverage_fuzz_test.go
+++ b/cmd/evener/seed_coverage_fuzz_test.go
@@ -63,7 +63,7 @@ func FuzzRootCommandSeedCoverage(f *testing.F) {
 			{"cheap cross provider", TestApplyFastCheapModel_CrossProviderWhenRegistered},
 			{"cheap missing provider", TestApplyFastCheapModel_CrossProviderRejectedWhenNotRegistered},
 			{"cheap bare", TestApplyFastCheapModel_BareModelKeepsActiveProvider},
-			{"cheap blank", TestApplyFastCheapModel_BlankKeepsDefault},
+			{"cheap blank", TestApplyFastCheapModel_BlankUsesPrimaryModel},
 			{"session env", TestNewSessionFromEnv},
 			{"simple prompt", TestProcessInputSimplePrompt},
 			{"tool prompt", TestProcessInputWithToolUse},

--- a/cmd/evener/serve_coverage_fuzz_test.go
+++ b/cmd/evener/serve_coverage_fuzz_test.go
@@ -62,7 +62,7 @@ func FuzzServeSeedCoverage(f *testing.F) {
 			{"cheap cross", TestApplyFastCheapModel_CrossProviderWhenRegistered},
 			{"cheap rejected", TestApplyFastCheapModel_CrossProviderRejectedWhenNotRegistered},
 			{"cheap bare", TestApplyFastCheapModel_BareModelKeepsActiveProvider},
-			{"cheap blank", TestApplyFastCheapModel_BlankKeepsDefault},
+			{"cheap blank", TestApplyFastCheapModel_BlankUsesPrimaryModel},
 			{"client providers", TestClientHasProvider},
 			{"noninteractive", TestRunServeNonInteractiveFlagControlsPromptAddendum},
 			{"shutdown waits", TestRunServeShutdownWaitsForInFlightInput},

--- a/cmd/evener/serve_fast_cheap_model_test.go
+++ b/cmd/evener/serve_fast_cheap_model_test.go
@@ -38,8 +38,8 @@ func TestApplyFastCheapModel_SameProviderOverridesCheapModel(t *testing.T) {
 	if got.ID() != "openai" || got.Model() != "gpt-5.2" {
 		t.Fatalf("active profile changed: id=%q model=%q", got.ID(), got.Model())
 	}
-	if got.CheapModel() != "gpt-4.1-mini" {
-		t.Fatalf("CheapModel() = %q, want gpt-4.1-mini", got.CheapModel())
+	if got.ConfiguredCheapModel() != "gpt-4.1-mini" {
+		t.Fatalf("ConfiguredCheapModel() = %q, want gpt-4.1-mini", got.ConfiguredCheapModel())
 	}
 	if got.CheapProvider() != "openai" {
 		t.Fatalf("CheapProvider() = %q, want openai", got.CheapProvider())
@@ -79,19 +79,20 @@ func TestApplyFastCheapModel_BareModelKeepsActiveProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("applyFastCheapModel: %v", err)
 	}
-	if got.CheapModel() != "gpt-4.1-mini" || got.CheapProvider() != "openai" {
-		t.Fatalf("cheap = (%q, %q), want (gpt-4.1-mini, openai)", got.CheapProvider(), got.CheapModel())
+	if got.ConfiguredCheapModel() != "gpt-4.1-mini" || got.CheapProvider() != "openai" {
+		t.Fatalf("cheap = (%q, %q), want (gpt-4.1-mini, openai)", got.CheapProvider(), got.ConfiguredCheapModel())
 	}
 }
 
-func TestApplyFastCheapModel_BlankKeepsDefault(t *testing.T) {
+func TestApplyFastCheapModel_BlankUsesPrimaryModel(t *testing.T) {
 	profile := provider.NewOpenAIProfile("gpt-5.2")
 	got, err := applyFastCheapModel(profile, "", clientWithProviders("openai"))
 	if err != nil {
 		t.Fatalf("applyFastCheapModel: %v", err)
 	}
-	if got.CheapModel() != "gpt-4.1-nano" {
-		t.Fatalf("CheapModel() = %q, want gpt-4.1-nano", got.CheapModel())
+	providerName, model := got.CheapModelRef()
+	if providerName != "openai" || model != "gpt-5.2" {
+		t.Fatalf("CheapModelRef() = (%q, %q), want (openai, gpt-5.2)", providerName, model)
 	}
 }
 

--- a/docs/design/context.md
+++ b/docs/design/context.md
@@ -263,9 +263,11 @@ The checkpoint turn uses `TurnCheckpoint` kind and `llm.RoleUser` role.
 
 ### LLM Summarize (Layer 2)
 
-Calls the provider's cheap model to generate a narrative summary. Only fires when
-checkpoint alone doesn't free enough space (>= 95% after checkpoint). The prompt is
-capped at ~80K chars to fit within cheap model context windows.
+Uses the configured fast/cheap model when present; otherwise it uses the active
+provider and model. Eligible failures on a configured auxiliary route fall back
+to the active model. Summarization runs only when the checkpoint does not free
+enough space (>= 95% after checkpoint). The prompt is capped at ~80K chars to
+bound summarization input across model context windows.
 
 The summary turn uses `TurnSummary` kind and `llm.RoleUser` role.
 

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -51,10 +51,11 @@ cmdutil.SelectProfile(provider, model)            (wraps agent profile construct
   ▼
 ProviderProfile  (agent/profile.go)   profile.ID()=="openai"  profile.BehaviorTag()=="openai"
   │  carries: instance name (id), behavior tag, context window, tool surface,
-  │           quirks, ProviderOptions key, CheapModel
+  │           quirks, ProviderOptions key, configured auxiliary route
   ▼
-agent.Session   sets req.Provider = s.profile.ID()   (the NAME)
+agent.Session   sets primary req.Provider = s.profile.ID()   (the NAME)
   │  provider-conditional behavior branches on s.profile.BehaviorTag()  (the TAG)
+  │  auxiliary calls resolve an explicit route or the active provider/model
   ▼
 llm.Client.Complete / Stream            llm/client.go
   │  prov = normalizeProviderName(req.Provider)   (now just lower/trim)
@@ -578,7 +579,6 @@ the catalog **ingest** normalization (`model_catalog.go normalizeCatalogProvider
 
 Profile methods that branch on provider behavior now switch on **`p.behaviorTag`**
 (not `p.id`):
-- `CheapModel()` (`:355`).
 - `decidePrefixAction(behaviorTag, instanceName, prefix)` (`:411`) — the
   **meta-provider** logic: a self-prefix (`prefix == instanceName`) is stripped;
   meta-provider upstream namespaces (openrouter/openrouter-anthropic/minimax, by
@@ -590,6 +590,10 @@ Profile methods that branch on provider behavior now switch on **`p.behaviorTag`
 - `WithModel(model)` (`:506`, anthropic variant) re-targets the model **within
   the current instance only** — it strips/keeps prefixes and rebuilds for the
   catalog, but **no longer switches providers** (the switch arm was removed).
+
+Auxiliary routing does not branch on provider behavior. `CheapModelRef()` uses
+the explicitly configured fast/cheap route when present and otherwise returns
+the active provider and model.
 
 `ProviderOptions` is a `map[string]any` keyed by the behavior tag's contract
 string; each profile writes its options under that key and the matching adapter
@@ -788,10 +792,10 @@ provider/model>`, surviving reload and daemon restart.
 ## What keys on what (the map to consult before touching identity)
 
 **Routing + identity (the NAME — `req.Provider`/`profile.ID()`):**
-- `req.Provider = s.profile.ID()` at every LLM call site (main loop, vision,
-  fallbacks, and the side-channel calls in `session_namer.go`,
-  `fork_summarize.go`, `context_manager.go`, `tool_web_*`, `strategy_*`,
-  `eval_probes.go`, `ListModels`), all resolving through `client.providers[...]`.
+- Primary requests use `req.Provider = s.profile.ID()`. Auxiliary requests use
+  their resolved route: `CheapModelRef()` through `cheapmodel.Caller`,
+  `CheapProvider()` for the session namer, or the configured vision route. Every
+  route resolves through `client.providers[...]`.
 - `cmdutil.SelectProfile` — rejects unknown names; the hub's launch gate runs it
   in a subprocess (companion doc).
 - `resp.Provider` + error labels — stamped centrally to the instance name.
@@ -804,9 +808,10 @@ provider/model>`, surviving reload and daemon restart.
 - Gemini native web_search registration: `session.go:4881` `BehaviorTag() ==
   "google"` (and re-applied on switch by `reapplyProviderSpecificTools`).
 - Cross-provider fallback guard: compares `BehaviorTag()`.
-- Profile model-handling: `CheapModel`, `decidePrefixAction`,
-  `rebuildOnSameProviderChange`, catalog lookups, the openrouter gate — all on
-  the tag.
+- Profile model-handling: `decidePrefixAction`,
+  `rebuildOnSameProviderChange`, catalog lookups, and the openrouter gate all key
+  on the tag. Auxiliary routing does not; `CheapModelRef()` uses explicit config
+  or the active provider/model.
 - Prompt sections: `SectionResolver.provider = s.profile.BehaviorTag()`
   (`session.go`) → filenames like `tools.provider-openai_append.md`.
 - OpenAI Responses→chat endpoint-fallback signal: `classify.go:118` on the

--- a/docs/superpowers/plans/2026-05-29-provider-behavior-tag-phase-1a.md
+++ b/docs/superpowers/plans/2026-05-29-provider-behavior-tag-phase-1a.md
@@ -24,7 +24,7 @@
 ## File Structure
 
 - **Create** `internal/providerconfig/providerconfig.go` — leaf package: `Type`, `APIStyle`, `InstanceConfig`, `Config`, `BehaviorTag(type, apiStyle) string`, `NameToTag(Config) map[string]string`, `DefaultStateRoot() string` (relocated `hubStateRoot` resolver). No imports of `llm`/`agent`/`cmdutil`.
-- **Modify** `agent/profile.go` — add `behaviorTag` field + `BehaviorTag()` to `baseProfile`/`anthropicProfile`; recipes stamp it; re-key `CheapModel`, `decidePrefixAction`, `rebuildOnSameProviderChange`, `WithModel` (×2), the `:930`/`:1007` helpers, the catalog lookup; remove the cross-provider switch arm.
+- **Modify** `agent/profile.go` — add `behaviorTag` field + `BehaviorTag()` to `baseProfile`/`anthropicProfile`; recipes stamp it; re-key `decidePrefixAction`, `rebuildOnSameProviderChange`, `WithModel` (×2), the `:930`/`:1007` helpers, and the catalog lookup; remove the cross-provider switch arm.
 - **Create** `agent/resolve.go` — `ResolveProfileFromConfig(cfg, ref) (ProviderProfile, error)` and the behavior-preserving re-application of session overrides.
 - **Modify** `agent/session.go` — re-key prompt-cache/gemini/prompt-section/fallback sites onto `BehaviorTag()`; `SetModel`/subagent/fallback switch via the resolver + preserve overrides + re-run provider-conditional tools; `resp.Provider` identity.
 - **Modify** `agent/subagents.go` — model override via the resolver.
@@ -184,9 +184,10 @@ func TestRenamedInstance_BehaviorByTag_IdentityByName(t *testing.T) {
 	if !openAIBehavior(p) { // helper asserting the §4.2 :1382 path treats p as openai
 		t.Fatalf("renamed openai instance lost prompt-cache eligibility")
 	}
-	// CheapModel keys on the tag:
-	if p.CheapModel() != "gpt-4.1-nano" {
-		t.Fatalf("CheapModel()=%q want gpt-4.1-nano (tag-keyed)", p.CheapModel())
+	// An unset auxiliary route uses the renamed active instance, not its tag:
+	providerName, model := p.CheapModelRef()
+	if providerName != "work" || model != p.Model() {
+		t.Fatalf("CheapModelRef()=(%q, %q) want (work, %q)", providerName, model, p.Model())
 	}
 }
 ```
@@ -208,7 +209,7 @@ func TestRenamedInstance_BehaviorByTag_IdentityByName(t *testing.T) {
 - [ ] **Step 1: Write failing tests** asserting each constructor stamps the right tag: `NewOpenAIProfile(...).BehaviorTag()=="openai"`, `NewAnthropicProfile`→`anthropic`, `NewGeminiProfile`→`google`, `NewOpenAICompatProfile("openrouter",...)`→`openrouter`, etc. Include a `WithProviderID`/named variant returning `ID()=="work"`, `BehaviorTag()=="openai"`.
 - [ ] **Step 2: Run, verify fail** (`BehaviorTag` undefined).
 - [ ] **Step 3: Implement.** Add `behaviorTag string` to `baseProfile` and `anthropicProfile`; add `func (p *baseProfile) BehaviorTag() string { return p.behaviorTag }` (and anthropic). Add `behaviorTag` to `profileSpec`; `buildBaseProfile` copies it. Each constructor sets it via `providerconfig.BehaviorTag(type, style)`. Add a `WithProviderID(p, name)` wrapper (mirroring `WithCommunicateOutputSchema`) that overrides `id` while keeping the tag. Add `BehaviorTag()` to the `ProviderProfile` interface (`profile.go:40`).
-- [ ] **Step 4: Run profile tests + the Task 2 backstop.** Run: `go test ./agent/ -run 'Profile|RenamedInstance' -v`. Task 2's `BehaviorTag()`/`CheapModel` assertions should now compile; `CheapModel` still keyed on `id` so it may fail — that's Task 4.
+- [ ] **Step 4: Run profile tests + the Task 2 backstop.** Run: `go test ./agent/ -run 'Profile|RenamedInstance' -v`. Task 2's `BehaviorTag()` and active-route assertions should now compile.
 - [ ] **Step 5: Commit.** `git add agent/profile.go agent/profile_test.go && git commit -m "feat(agent): BehaviorTag on profiles, recipes stamp it (PRI-1880)"`
 
 ---
@@ -218,12 +219,12 @@ func TestRenamedInstance_BehaviorByTag_IdentityByName(t *testing.T) {
 Per spec §4.2 rows for `profile.go`. Each is `switch p.id`→`switch p.behaviorTag` (and the `case "gemini"`→`case "google"`), plus the catalog lookup and the prefix helpers.
 
 **Files:**
-- Modify: `agent/profile.go` (`:344 CheapModel`, `:396 decidePrefixAction`, `:498 rebuildOnSameProviderChange`, `:519/533/562 WithModel`, `:649 anthropic WithModel`, `:930`, `:955/964 catalog`, `:1007`)
+- Modify: `agent/profile.go` (`:396 decidePrefixAction`, `:498 rebuildOnSameProviderChange`, `:519/533/562 WithModel`, `:649 anthropic WithModel`, `:930`, `:955/964 catalog`, `:1007`)
 - Test: `agent/profile_test.go`
 
-- [ ] **Step 1: Write failing tests** with *renamed* instances: a `kimi`-behavior profile named `work` whose `CheapModel`, catalog context-window lookup, and `rebuildOnSameProviderChange` all behave as `kimi`; a `google`-named instance whose `CheapModel` returns `gemini-2.5-flash-lite`; an `openrouter`-named-`work` instance whose Codex/minimax gate (`:1007`) and meta-namespace keep (`:405`) fire by tag.
+- [ ] **Step 1: Write failing tests** with *renamed* instances: a `kimi`-behavior profile named `work` whose catalog context-window lookup and `rebuildOnSameProviderChange` behave as `kimi`; a `google`-named instance whose catalog lookup uses the Google tag; an `openrouter`-named-`work` instance whose Codex/minimax gate (`:1007`) and meta-namespace keep (`:405`) fire by tag. Assert separately that an unset `CheapModelRef()` returns the renamed active provider/model rather than a tag-derived default.
 - [ ] **Step 2: Run, verify fail** (still keyed on `id`).
-- [ ] **Step 3: Implement.** Mechanically apply each §4.2 row: `CheapModel` `switch p.behaviorTag` with `case "google"`; `decidePrefixAction(behaviorTag, instanceName, prefix)` — **keep** uses `behaviorTag` (meta-providers), self-prefix **strip** compares `prefix == instanceName`; `rebuildOnSameProviderChange(behaviorTag)`; `WithModel` passes `p.behaviorTag` + `p.id` and the rebuild constructor (`NewOpenAICompatProfile`) takes both name and tag (extend its signature or add a named variant); `:930` `behaviorTag == "ollama"`; catalog lookup uses `behaviorTag + "/" + model`; `:1007` `behaviorTag == "openrouter"`. **Remove the cross-provider switch arm** from both `WithModel`s (the `prefixActionSwitch` outcome) — switching now lives in the session (Task 8). `WithModel` returns within-instance results only.
+- [ ] **Step 3: Implement.** Mechanically apply each §4.2 row: `decidePrefixAction(behaviorTag, instanceName, prefix)` — **keep** uses `behaviorTag` (meta-providers), self-prefix **strip** compares `prefix == instanceName`; `rebuildOnSameProviderChange(behaviorTag)`; `WithModel` passes `p.behaviorTag` + `p.id` and the rebuild constructor (`NewOpenAICompatProfile`) takes both name and tag (extend its signature or add a named variant); `:930` `behaviorTag == "ollama"`; catalog lookup uses `behaviorTag + "/" + model`; `:1007` `behaviorTag == "openrouter"`. **Remove the cross-provider switch arm** from both `WithModel`s (the `prefixActionSwitch` outcome) — switching now lives in the session (Task 8). `WithModel` returns within-instance results only. Auxiliary routing is not tag-keyed.
 - [ ] **Step 4: Run** `go test ./agent/ -run 'Profile|RenamedInstance|WithModel' -v`. Rewrite the now-obsolete cross-provider `WithModel` unit tests (`TestProviderProfile_WithModel_CrossProvider` `:366`, `:379`, `TestBaseProfile_WithModel_PreservesSlashOnMetaProviders` `:658`) — the meta-namespace *keep* test stays (assert verbatim within instance); the cross-provider *switch* tests move to Task 8 (session-level). Confirm the catalog rebuild still recomputes the context window for a same-instance model change.
 - [ ] **Step 5: Commit.** `git add agent/profile.go agent/profile_test.go && git commit -m "refactor(agent): key profile.go behaviors on behaviorTag, drop WithModel switch (PRI-1880)"`
 

--- a/docs/superpowers/plans/2026-08-27-vision-model-config.md
+++ b/docs/superpowers/plans/2026-08-27-vision-model-config.md
@@ -72,8 +72,8 @@ In `agent/internal/cheapmodel/caller.go`, replace `Complete` (lines 52-60) with:
 ```go
 // Complete resolves and executes a cheap-model request, falling back once to
 // the session model when the provider refuses the resolved model. It resolves
-// through the profile's cheap-model ref, which falls through to the provider's
-// default cheap model when the session configured none.
+// through the profile's cheap-model ref, which uses the session model when no
+// cheap model is configured.
 func (c *Caller) Complete(ctx context.Context, profile *provider.Profile, req llm.Request) (llm.Response, error) {
 	cheapProvider, cheapModel := profile.CheapModelRef()
 	return c.CompleteRouted(ctx, profile, cheapProvider, cheapModel, req)

--- a/docs/superpowers/specs/2026-05-20-session-auto-naming-plan.md
+++ b/docs/superpowers/specs/2026-05-20-session-auto-naming-plan.md
@@ -112,7 +112,7 @@ Spec: `docs/specs/2026-05-20-session-auto-naming.md`
   go test ./cmd/evener-hub -run 'Spawn|FastCheapModel' -count=1
   ```
 
-## Task 4: Add serve flag and same-provider cheap model override
+## Task 4: Add serve flag and cheap model override
 
 **Files:**
 - Test: `agent/profile_test.go`
@@ -120,13 +120,14 @@ Spec: `docs/specs/2026-05-20-session-auto-naming.md`
 - Modify: `agent/profile.go`
 - Modify: `cmd/evener/serve.go`
 
-Smallest YAGNI decision: support same-provider overrides first. If `--fast-cheap-model` names a different provider than `--model`, return a clear error. Do not build a cross-provider cheap client yet.
+Support bare same-provider model names and qualified cross-provider refs. A
+qualified ref must name a provider registered in the active client.
 
 - [ ] **Red:** add profile test for a cheap model override helper.
   - Preferred minimal API:
     ```go
-    profile = agent.WithFastCheapModel(profile, "gpt-5-mini")
-    if profile.CheapModel() != "gpt-5-mini" { ... }
+    profile = agent.WithCheapModel(profile, "gpt-5-mini")
+    if profile.ConfiguredCheapModel() != "gpt-5-mini" { ... }
     ```
   - If an existing profile option pattern is better, use that instead.
 
@@ -138,10 +139,11 @@ Smallest YAGNI decision: support same-provider overrides first. If `--fast-cheap
 
 - [ ] **Green:** add `fs.String("fast-cheap-model", "", ...)` in `cmd/evener/serve.go`, resolve it, and apply the override before session creation/restore.
 
-- [ ] **Red:** add mismatch test.
-  - `--model openai/gpt-5.5 --fast-cheap-model anthropic/claude-haiku...` returns a clear error.
+- [ ] **Red:** add unavailable-provider test.
+  - `--model openai/gpt-5.5 --fast-cheap-model anthropic/claude-haiku...`
+    returns a clear error when the Anthropic provider is not registered.
 
-- [ ] **Green:** validate provider match for now. Document in error that cross-provider fast cheap model calls are not supported yet.
+- [ ] **Green:** validate that a qualified cheap-model provider is registered.
 
 - [ ] Run:
   ```sh
@@ -360,7 +362,6 @@ YAGNI approach: add a small method that can be called synchronously in tests, th
 
 Explicitly do not implement in this feature unless later requested:
 
-- cross-provider cheap side-call client if same-provider validation is acceptable
 - manual rename UI/API
 - bulk backfill of old session names
 - user-configurable naming prompt

--- a/docs/superpowers/specs/2026-05-20-session-auto-naming.md
+++ b/docs/superpowers/specs/2026-05-20-session-auto-naming.md
@@ -103,25 +103,31 @@ The flag should accept the same provider-qualified format as launch `model`, e.g
 
 Expected behavior:
 
-- If omitted, current provider default `CheapModel()` behavior remains unchanged.
+- If omitted, auxiliary calls use the active provider and model; automatic
+  naming remains disabled because no fast/cheap model was explicitly chosen.
 - If present and same provider as the active profile, use the specified model as the cheap model.
-- If present and provider-qualified for another provider, the cheap side call should use that provider if the existing client/profile architecture supports it.
-- If cross-provider cheap calls are not currently supported cleanly, initial implementation may validate that the provider matches the active session provider and return a clear launch/config error otherwise. Do not silently ignore the provider.
+- If present and provider-qualified for another registered provider, route the
+  auxiliary call to that provider. Reject an unavailable provider at launch;
+  never ignore the qualifier.
 
 ### Profile/API shape
 
 Preferred approach:
 
-- Add an override field to profile/session config so `profile.CheapModel()` returns the resolved `fast_cheap_model` model name.
-- Keep existing callers unchanged:
+- Store the explicit route in profile/session config. `ConfiguredCheapModel()`
+  exposes the enable-state model, while `CheapModelRef()` resolves the complete
+  provider/model pair.
+- Route completion-based callers through the shared auxiliary caller:
   - compaction
   - web fetch
   - checkpoint prediction
   - memory crystals
   - recursive distill
-  - session namer
+- Keep the session namer as the direct `GenerateObject` exception. Its explicit
+  configuration gate remains separate from completion routing.
 
-If provider switching for cheap calls requires broader architecture, represent the desired cheap model as a structured resolved model ref instead of squeezing provider into `CheapModel() string`.
+Provider switching requires preserving the qualified model ref so the provider
+and model cannot drift apart.
 
 ## Session metadata
 
@@ -168,16 +174,17 @@ Existing sessions display by `OriginalPrompt` until renamed by future compaction
 
 ### Shape
 
-The session namer is a single side LLM call:
+The session namer is a single structured-output side call:
 
 ```go
-resp, err := client.Complete(ctx, llm.Request{
-    Model: profile.CheapModel(),
-    Messages: []llm.Message{
-        llm.System(sessionNamingSystemPrompt),
-        llm.User(input),
-    },
-    MaxOutputTokens: 32,
+model := profile.ConfiguredCheapModel()
+res, err := llm.GenerateObject(ctx, llm.GenerateObjectOptions{
+    Client:   client,
+    Provider: profile.CheapProvider(),
+    Model:    model,
+    System:   new(sessionNamingSystemPrompt),
+    Prompt:   new(input),
+    Schema:   sessionNameSchema(),
 })
 ```
 
@@ -390,9 +397,9 @@ FTS should include a `name` column. Existing FTS index can be rebuilt. If schema
 
 Naming failure must be non-fatal.
 
-On any of these, keep fallback behavior and log advisory failure:
+If no fast/cheap model is configured, skip naming without logging a failure. For
+attempted naming, keep fallback behavior and log advisory failure on:
 
-- no fast cheap model available
 - model validation error
 - LLM call timeout
 - LLM provider error

--- a/docs/superpowers/specs/2026-05-29-provider-type-instance-model-design.md
+++ b/docs/superpowers/specs/2026-05-29-provider-type-instance-model-design.md
@@ -481,22 +481,25 @@ not just display, so it lands with the picker work.
   (and a second openai-type instance `work2`), runs a live session through it
   (prompt assembly, a streamed call, an error, a `/model` switch to `work2`, a
   resume), and asserts: the `openai` behavior fires by **tag** (prompt-cache,
-  the `tools.provider-openai_append.md` section, cheap model, Codex gate); the
+  the `tools.provider-openai_append.md` section, Codex gate); the
   response/error/diagnostic report the instance name `work`; the model picker and
   launch-check accept `work`; switching `work → work2` preserves the
-  output-schema/decisions overrides. Any site still keyed on the literal `"openai"`
-  fails here. **This test — not the §4.2 list — is what proves completeness**, and
-  it is the gate every 1a task closes against.
+  output-schema/decisions overrides; and an unset auxiliary route uses the active
+  `work` instance/model independently of the tag. Any site still keyed on the
+  literal `"openai"` fails here. **This test — not the §4.2 list — is what proves
+  completeness**, and it is the gate every 1a task closes against.
 - **Behavior-tag + switching (1a):** for an `openai`-type instance named `work`,
-  assert prompt-cache, the `tools.provider-openai_append.md` section, cheap model,
-  fallback guard, Codex gate, **and the compat catalog context-window lookup** key
-  on the tag; a `chat-completions` instance gets none of the `openai`-tag
-  behavior. `SetModel("other-instance/model")` switches via the session;
-  `WithModel` never changes the instance; a bare `/model` rebuilds the catalog
-  window; cross-tag `model_fallbacks` errors, same-tag cross-instance is allowed.
+  assert prompt-cache, the `tools.provider-openai_append.md` section, fallback
+  guard, Codex gate, **and the compat catalog context-window lookup** key on the
+  tag; a `chat-completions` instance gets none of the `openai`-tag behavior.
+  Auxiliary routing is separate: an unset route uses the active instance/model,
+  while explicit config supplies the provider/model pair.
+  `SetModel("other-instance/model")` switches via the session; `WithModel` never
+  changes the instance; a bare `/model` rebuilds the catalog window; cross-tag
+  `model_fallbacks` errors, same-tag cross-instance is allowed.
 - **Gemini:** `google`-named instance routes (adapter under `google`); sections/
-  cheap-model on tag `google`; `ListModels("google")` still returns Gemini data
-  (ingest normalization kept).
+  behavior key on tag `google`; `ListModels("google")` still returns Gemini data
+  (ingest normalization kept). Auxiliary routing remains independent of the tag.
 - **Identity:** a streamed **and** non-streamed error from instance `work`
   reports `work`; `context.Canceled` stays unlabeled.
 - **Selection/resume:** resolver builds a custom instance, rejects unknowns;

--- a/docs/superpowers/specs/2026-06-14-cross-provider-cheap-model.md
+++ b/docs/superpowers/specs/2026-06-14-cross-provider-cheap-model.md
@@ -7,26 +7,24 @@ is accepted as graceful-skip, not enforced.
 
 ## Problem
 
-The fast/cheap model evener uses for auxiliary "side calls" is locked to the
-**same provider** as the main model. Two enforcement points:
+At design time, the fast/cheap model evener used for auxiliary "side calls" was
+locked to the **same provider** as the main model. Two enforcement points:
 
-1. `applyFastCheapModel` (`cmd/evener/serve.go:492`) rejects a cheap model whose
-   provider differs from the active provider (error at `:501`). Today it also
-   requires a fully-qualified `provider/model` — `cmdutil.ParseModelRef`
-   (`cmdutil/cmdutil.go:113`) rejects a bare model name. So the current contract
-   is: "`provider/model`, and the provider must equal the active provider."
-2. The cheap model is only a *model name* swapped within the **same profile**:
-   `CheapModel()` returns a bare string (`agent/provider/profile.go:337`),
-   `WithCheapModel` stores a name on a clone of the main profile
-   (`agent/provider/profile_overrides.go`), and side-call sites issue requests
-   with `Provider: <mainProfile>.ID()`.
+1. `applyFastCheapModel` (`cmd/evener/serve.go:492`) rejected a cheap model
+   whose provider differed from the active provider (error at `:501`). It also
+   required a fully-qualified `provider/model`: `cmdutil.ParseModelRef`
+   (`cmdutil/cmdutil.go:113`) rejected a bare model name. The contract was
+   "`provider/model`, and the provider must equal the active provider."
+2. The cheap setting stored only a *model name* within the **same profile**.
+   `WithCheapModel` cloned the main profile, and side-call sites paired that
+   model with `Provider: <mainProfile>.ID()`.
 
 ## Motivation
 
 Acute for the **Kimi coding plan**: it exposes one model (`kimi-for-coding`), so
-`CheapModel()` falls through to `default: p.model` (`profile.go:351`) and every
-side call runs on the full, expensive coding model. A user on
-main=`kimi-anthropic` wants cheap calls on a cheap Anthropic/OpenAI/Google model.
+an unset fast/cheap route uses the full coding model. A user on
+main=`kimi-anthropic` may instead want auxiliary calls on an inexpensive
+Anthropic/OpenAI/Google model.
 
 ## Non-goal / do not conflate
 
@@ -37,44 +35,24 @@ self-contained (own short system prompt, no main tool surface — verified: none
 set `Tools`/`ProviderOptions`/`ReasoningEffort`), so cross-provider is safe for
 them in a way it is not for fallbacks. Keep the fallback guard as-is.
 
-## Side-call inventory (verified — 9 request constructions)
+## Side-call inventory
 
-Two **distinct families** with different semantics — this distinction drove the
-review and the design:
+Most auxiliary consumers—including web fetch, fork summaries, memory crystals,
+recursive distillation, checkpoint prediction, and eval probes—route through the
+session-scoped `cheapmodel.Caller`. `Caller.Complete` resolves
+`Profile.CheapModelRef()`: an explicit fast/cheap route wins, while an unset
+route uses the active provider and model. The caller also learns model refusals
+and can retry an explicit cheap route on the active model.
 
-**A. `CheapModel()` sites (6) — provider-default fallback, always non-empty.**
-Each builds `llm.Request{Provider: p.ID(), Model: p.CheapModel()}` + `Complete`:
+Two consumers retain additional policy:
 
-| Site | file:line |
-|---|---|
-| web_fetch Q&A | `agent/tool_web_fetch.go:124-125` |
-| fork summarize | `agent/internal/contextmgr/fork_summarize.go:23-24` |
-| memory crystals | `agent/internal/contextmgr/strategy_memory_crystals.go:148-149` |
-| recursive distill (×2) | `agent/internal/contextmgr/strategy_recursive_distill.go:163-164, 193-194` |
-| checkpoint prediction | `agent/internal/contextmgr/strategy_checkpoint_pred.go:220-221` |
-
-In each, the profile (`cp`/`p`) is already in hand, so adding a routing helper is
-a local change.
-
-**B. `ConfiguredCheapModel()` sites (2) — empty when unset; gate behavior.** These
-do **not** use `CheapModel()` and must not be folded into a blanket swap:
-- **Session namer** (`agent/session_namer.go`): the ONLY `GenerateObject`
-  side call (`:62`, strict JSON-schema validation via `generate_object.go:55`).
-  `sessionNamerEnabled` gates the namer on `ConfiguredCheapModel() != ""`
-  (`:87-92`); `sessionNamerModel` falls back to `profile.Model()` (the MAIN
-  model). Provider is `profile.ID()` (`:65`).
-- **Summarizer** (`agent/internal/contextmgr/context_manager.go:1125-1145`):
-  does NOT call `CheapModel()`. It calls `summarizationModels(sumProfile)`
-  (`:961-977`), which keys on `ConfiguredCheapModel()` and returns a **fallback
-  chain** `[configuredCheap, activeMain]`, then loops issuing
-  `llm.Request{Model: model, Provider: sumProfile.ID()}` (`:1135`) — both models
-  to the **same (main) provider**.
-
-**Not a side call** (correctly excluded): eval probes
-(`agent/eval_probes.go:81-92`) use a plain `Complete` + `parseBinaryJudge` text
-parse — **no `GenerateObject`, no schema**. They are still a `CheapModel()` site
-(`:82-83`) and route like family A, but carry no structured-output requirement.
-`tool_web_search.go` and `session_tools.go` use `p.Model()` (main), excluded.
+- **Session namer** (`agent/session_namer.go`) is the only `GenerateObject` side
+  call. `sessionNamerEnabled` uses `ConfiguredCheapModel() != ""` as its enable
+  gate, so naming remains disabled when no fast/cheap model was chosen.
+- **Summarizer** (`agent/internal/contextmgr/context_manager.go`) uses
+  `CompleteConfigured`, which reports whether the shared caller reached the
+  active model. It may retry a broader class of eligible configured-route
+  failures on that active model without repeating a route already attempted.
 
 ## What a side call actually needs — and the two real caveats
 
@@ -96,32 +74,34 @@ provider-specific behaviors do matter and the original spec missed both:
 2. **Context window.** Side-call inputs are clamped to FIXED char budgets tuned
    for large windows (`maxHistoryChars = 80_000`, `webFetchMaxContent =
    100_000` ≈ 25-33K tokens; checkpoint pred 30_000), independent of the cheap
-   model's window. With the default cheap models (≥128K) this is fine; a
-   pathologically small cross-provider cheap model could overflow. Document a
+   model's window. Common configured cheap models have large windows, but a
+   pathologically small cross-provider model could overflow. Document a
    minimum-window expectation; do not size dynamically (YAGNI).
 
 ## Design
 
-Profile carries an optional cheap **provider** alongside the cheap model. Keep
-`CheapModel()` / `ConfiguredCheapModel()` semantics **unchanged**; add provider
-routing on top so default behavior is preserved exactly.
+Profile carries an optional cheap **provider** alongside the explicitly
+configured cheap model. `ConfiguredCheapModel()` returns only that explicit
+model; `CheapModelRef()` returns the configured route or the active
+provider/model when no route was configured.
 
 - New field `cheapProvider string` on `Profile` (empty ⇒ same as main).
 - `WithCheapModel(p, ref)`:
   - `ref` = `provider/model` ⇒ set `cheapProvider` + `cheapModel`.
   - `ref` = bare `model` ⇒ set `cheapModel`, leave `cheapProvider` empty
-    (same-provider — newly accepted; today bare is rejected at the flag layer).
+    (same-provider; the flag layer accepts bare refs).
 - `CheapProvider() string` ⇒ `cheapProvider` if set, else `p.ID()`.
-- `CheapModelRef() (provider, model string)` ⇒ `(CheapProvider(), CheapModel())`
-  — used by the **6 family-A sites** (one-line swap each).
+- `CheapModelRef() (provider, model string)` returns
+  `(CheapProvider(), ConfiguredCheapModel())` when configured and
+  `(p.ID(), p.Model())` otherwise.
 - **Namer**: keep the `ConfiguredCheapModel() != ""` enable gate and
   `sessionNamerModel` unchanged; only change the request's `Provider` to
   `CheapProvider()`. Behavior preserved when no cheap is configured (namer still
   disabled).
-- **Summarizer**: change `summarizationModels` to return `(provider, model)`
-  pairs — `[(CheapProvider(), configuredCheap), (p.ID(), activeMain)]` — and have
-  the loop route each pair to its own provider. The cheap entry goes to the cheap
-  provider; the main-model fallback stays on the main provider.
+- **Summarizer**: call `cheapmodel.Caller.CompleteConfigured`, which resolves the
+  configured route and reports whether it reached the active model. For a
+  broader eligible configured-route failure, call the distinct active route
+  once when the shared caller has not already done so.
 
 Rejected: Option B (resolve a full second profile). Heavier; buys quirks/options
 the side calls don't use. Only revisit if a side call later needs the cheap
@@ -144,36 +124,29 @@ providers**, not `ResolveProfileFromConfig`:
 - If `ref` is cross-provider, require `client.ProviderNames()` to contain the
   cheap provider; else error early with a clear message naming it.
 - Same-provider/bare refs need no provider check.
-- Call-time defense: if a side call's cheap provider is somehow unroutable, fall
-  back to the main provider's `CheapModel()` rather than failing a summarization
-  mid-session (cheap calls are advisory).
+- Call-time defense: when an explicit cheap route is refused, the shared caller
+  can retry on the active provider/model rather than failing an advisory side
+  call immediately.
 
-## Resume / persistence (must-have — feature evaporates without it)
+## Resume / persistence
 
-Today the cheap setting is lost on hub resume: `cmd/evener-hub/spawn.go:256-258`
-sets `resumeResolved.Effective.FastCheapModel = ""`, and `SessionMeta`
-(`agent/schema/snapshot.go`) persists only `ProfileID`/`Model`. A resumed Kimi
-session silently reverts side calls to the expensive main model.
-
-Fix: persist the cheap ref and rebuild it on restore.
-- Add a `CheapModel` (and provider) field to `SessionMeta`; write it at snapshot
-  time; on `RestoreSessionFromMetaWithConfig` (`serve.go:219`) re-apply via
-  `WithCheapModel`.
-- Stop clearing `FastCheapModel` in `spawn.go` resume args (or re-pass it from
-  the persisted launch config) so the relaunched `evener serve` re-applies it.
-- Verify which mechanism is authoritative (launch-config replay vs. SessionMeta)
-  and use one; do not double-apply.
+`SessionMeta.CheapModel` is the authoritative persisted ref. Session snapshots
+write `CheapModelRefString()`, and `RestoreSessionFromMetaWithConfig` reapplies a
+non-empty value with `WithCheapModel`. Hub resume clears the launch-time
+`FastCheapModel` override so restore does not apply the route twice.
 
 ## Touch points
 
 - `agent/provider/profile.go`: `cheapProvider` field, `CheapProvider()`,
   `CheapModelRef()`.
 - `agent/provider/profile_overrides.go`: `WithCheapModel` parses `provider/model`.
-- 6 family-A sites: route via `CheapModelRef()`.
+- Shared side-call consumers: route through `cheapmodel.Caller`, which resolves
+  `CheapModelRef()`.
 - `agent/session_namer.go`: request `Provider` ⇒ `CheapProvider()` (gate
   unchanged).
-- `agent/internal/contextmgr/context_manager.go`: `summarizationModels` ⇒
-  `(provider, model)` pairs + loop routing.
+- `agent/internal/contextmgr/context_manager.go`: use `CompleteConfigured` for
+  the first route and retain one active-model retry for the summarizer's broader
+  eligible failure classes.
 - `cmd/evener/serve.go:492` `applyFastCheapModel`: new signature + client-registered
   validation + relaxed provider-match; **parse** bare vs `provider/model`.
 - Resume: `SessionMeta` field + restore re-apply + `spawn.go:256-258`.


### PR DESCRIPTION
## Summary

- remove provider-family fast/cheap model defaults; when unset, auxiliary calls use the active primary provider/model
- preserve explicit relative and qualified auxiliary routes across model switches, subagent selection, forks/asides, metadata persistence, and restore
- centralize auxiliary route resolution, add causal regression coverage, and update provider/design documentation

## Verification

- `make lint`
- `make vet`
- `make test`
- four-angle simplify review completed
- two independent adversarial reviewers converged after five rounds
