### PR TITLE
test(llm): make openaicompat cancel classification deterministic (#696)

### DIFF
--- a/llm/providers/openaicompat/adapter_test.go
+++ b/llm/providers/openaicompat/adapter_test.go
@@ -988,10 +988,20 @@ func TestComplete_NoCachedTokensField_LeavesNil(t *testing.T) {
 }
 
 func TestComplete_WrapsContextCanceled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
-	a := &Adapter{BaseURL: "http://127.0.0.1:1", Client: &http.Client{Timeout: time.Millisecond}}
+	// srv.Client() carries no http.Client.Timeout: a client timeout racing the
+	// cancellation would let net/http's timeoutError wrapper (which reports
+	// only context.DeadlineExceeded and unwraps to nothing) win the
+	// classification, turning the expected AbortError into a retryable
+	// requestTimeoutError on a slow runner (#696).
+	a := &Adapter{BaseURL: srv.URL, Client: srv.Client()}
 	_, err := a.Complete(ctx, llm.Request{Model: "test", Messages: []llm.Message{llm.User("hi")}})
 	if err == nil {
 		t.Fatal("expected error")


### PR DESCRIPTION
## Summary

`TestComplete_WrapsContextCanceled` raced a 1ms `http.Client.Timeout` against a pre-canceled context dialing `127.0.0.1:1`. When the client timeout won that race, net/http's `timeoutError` wrapper — which has no `Unwrap()` and whose `Is()` only reports `context.DeadlineExceeded` — severed the error chain, so `WrapContextError` classified the user cancellation as a retryable `requestTimeoutError` instead of `AbortError`. That is the exact CI failure in #696: load-sensitive by construction (on a slow runner the 1ms timer fires while the canceled dial is still pending).

This adopts the deterministic construction the sibling adapters (**openai**, **anthropic**, **google**) already use for the same test: an `httptest` server whose handler blocks on `r.Context().Done()`, `srv.Client()` (no client timeout), and a pre-canceled context. The cancellation is then always classified as `AbortError`.

## Verification

- `go test ./llm/providers/openaicompat/ -run TestComplete_WrapsContextCanceled -count=30 -race` — 30/30 pass
- 6 consecutive `-count=20` plain runs (120 executions) — all pass
- `go test ./llm/providers/openaicompat/ -count=5 -race` (full package) — pass
- `go vet ./llm/providers/openaicompat/` — clean
- A code-simplifier pass over the change confirmed the final form needs no further refinement

Fixes #696