### PR TITLE
test(tui): await recent-only dashboard absences on one frame (#694)

### DIFF
--- a/cmd/evener-tui/tmux_e2e_test.go
+++ b/cmd/evener-tui/tmux_e2e_test.go
@@ -316,13 +316,11 @@ func TestTUITmuxE2E_DashboardRecentOnlyState(t *testing.T) {
 	app := startTUITmux(t, bin, hub)
 	defer app.Close()
 
-	screen := app.WaitFor("EVENER LIVE", "0 live", "2 recent", "1 recent", "filter")
-	if strings.Contains(screen, "ended maintenance") || strings.Contains(screen, "ops task") {
-		t.Fatalf("recent-only dashboard should fold ended sessions by default:\n%s", screen)
-	}
-	if strings.Contains(screen, "Prompt (optional):") || strings.Contains(screen, "enter: send") {
-		t.Fatalf("recent-only dashboard rendered session composer content:\n%s", screen)
-	}
+	// Ended sessions fold by default and composer content belongs to session
+	// view, so both are awaited as absences on the same frame as the positives
+	// (WaitForWithout; mid-repaint shape from #694).
+	screen := app.WaitForWithout([]string{"ended maintenance", "ops task", "Prompt (optional):", "enter: send"},
+		"EVENER LIVE", "0 live", "2 recent", "1 recent", "filter")
 	t.Logf("recent-only dashboard capture:\n%s", screen)
 
 	app.SendKeys("Down", "Enter")


### PR DESCRIPTION
## Summary

`TestTUITmuxE2E_DashboardRecentOnlyState` (#694 part b) checked its absence invariants — ended sessions folded by default, no composer content — as one-shot `strings.Contains` checks on whichever frame first satisfied the positive matches (`0 live`, `2 recent`, `1 recent`). A capture that lands mid-repaint can satisfy the positives while stale rows are still on screen: exactly the anti-pattern `WaitForWithout` was created to eliminate (see its doc comment), and the fix shape used for the same flake family in #540/#656.

This converts both absence checks into the awaited condition — the positives and the absences must hold on the **same** captured frame.

## Investigation honesty

I could **not** reproduce the CI failure locally despite faithful replication attempts:
- CPU starvation at load 36 (16 busy-loop hogs): test passes 8/8
- Two concurrent full `go test ./...` suites (the issue's stated trigger): both green
- Delayed `ThreadList` responses (delay-injection into the fake hub): passes
- Coalesced `Down`+`Enter` pty delivery: verified via a bubbletea `tea.WithInput` harness that a single coalesced `\x1b[B\r` read parses as `[down enter]` — keys are not lost

So this PR closes the one demonstrable race class in the test (the documented mid-repaint capture race on one-shot absence assertions) rather than a confirmed reproduction. The issue's part (a) — the unidentified `cmd/evener-hub` failure — now has a concrete data point from this branch's CI run: `TestHubRelaySharedSessionAliasesDeliverEachNotificationOnce` failing with "fresh root-only client received delta 0 times" under CI load, passing 8/8 locally under `-race`; that one is a hub relay-logic investigation, out of scope for this test-only PR.

## Verification

- `go test ./cmd/evener-tui/ -run TestTUITmuxE2E_DashboardRecentOnlyState -count=6` — pass
- Full tmux e2e suite plain (14.3s) and under `-race` (5.7s) — pass
- `go vet ./cmd/evener-tui/` — clean
- code-simplifier pass applied (comment tightened to house style)

Fixes #694