### PR TITLE
feat(web): show active jobs in session sidebar

### DIFF
--- a/agent/status.go
+++ b/agent/status.go
@@ -44,6 +44,8 @@ type JobStatusInfo struct {
 	TranscriptRef    string `json:"transcript_ref,omitempty"`
 	OutputBytes      int64  `json:"output_bytes"`
 	ExitCode         *int   `json:"exit_code,omitempty"`
+	Command          string `json:"command,omitempty"`
+	Task             string `json:"task,omitempty"`
 }
 
 // DelegateStatusInfo is the stable delegate read model exposed by
@@ -403,6 +405,8 @@ func projectJobStatusInfos(records []*jobstore.JobRecord) []JobStatusInfo {
 			TranscriptRef:    jobTranscriptRef(rec),
 			OutputBytes:      rec.OutputBytes,
 			ExitCode:         rec.ExitCode,
+			Command:          rec.Command,
+			Task:             rec.Task,
 		})
 	}
 	return jobs

--- a/cmd/evener-hub/app_relay.go
+++ b/cmd/evener-hub/app_relay.go
@@ -385,6 +385,10 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 		if err != nil {
 			return nil, nil, err
 		}
+		canonicalRef, err := source.ResolveRelaySession(params)
+		if err != nil {
+			return nil, nil, err
+		}
 		for {
 			relayMu.Lock()
 			existing := relayedThreads[relayKey]
@@ -425,7 +429,7 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 			relayedThreads[relayKey] = handle
 			relayMu.Unlock()
 
-			lease, acquireErr := source.AcquireRelaySession(params)
+			lease, acquireErr := source.AcquireRelaySession(canonicalRef)
 			var deliveries <-chan appsource.RelayDelivery
 			if acquireErr == nil && lease == nil {
 				acquireErr = appwire.SessionUnavailable("source returned no RelaySession lease")

--- a/cmd/evener-hub/app_relay_alias_test.go
+++ b/cmd/evener-hub/app_relay_alias_test.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -171,7 +172,17 @@ type aliasRelaySource struct {
 
 func (*aliasRelaySource) ID() string { return "local" }
 
-func (s *aliasRelaySource) AcquireRelaySession(appwire.ThreadReadParams) (appsource.RelaySessionLease, error) {
+func (s *aliasRelaySource) ResolveRelaySession(params appwire.ThreadReadParams) (appwire.Ref, error) {
+	if params.Ref != "" {
+		return appwire.ParseRef(params.Ref)
+	}
+	if params.ThreadID == "" {
+		return appwire.Ref{}, errors.New("missing relay target")
+	}
+	return appwire.Ref{SourceID: s.ID(), ThreadID: params.ThreadID}, nil
+}
+
+func (s *aliasRelaySource) AcquireRelaySession(appwire.Ref) (appsource.RelaySessionLease, error) {
 	return &aliasRelayLease{source: s}, nil
 }
 

--- a/cmd/evener-hub/app_relay_test.go
+++ b/cmd/evener-hub/app_relay_test.go
@@ -935,7 +935,17 @@ func (s *relaySessionTestSource) StartTurn(context.Context, appwire.TurnStartPar
 	return appwire.TurnStartResponse{Turn: appwire.Turn{ID: "turn-started"}}, nil
 }
 
-func (s *relaySessionTestSource) AcquireRelaySession(appwire.ThreadReadParams) (appsource.RelaySessionLease, error) {
+func (s *relaySessionTestSource) ResolveRelaySession(params appwire.ThreadReadParams) (appwire.Ref, error) {
+	if params.Ref != "" {
+		return appwire.ParseRef(params.Ref)
+	}
+	if params.ThreadID == "" {
+		return appwire.Ref{}, errors.New("missing relay target")
+	}
+	return appwire.Ref{SourceID: s.ID(), ThreadID: params.ThreadID}, nil
+}
+
+func (s *relaySessionTestSource) AcquireRelaySession(appwire.Ref) (appsource.RelaySessionLease, error) {
 	s.mu.Lock()
 	s.acquireCalls++
 	s.mu.Unlock()

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -30,11 +30,12 @@ func newHubSourceRegistry(cfg hubcore.WebConfig) *appsource.Registry {
 					continue
 				}
 				entry := appsource.LocalDaemonEntry{
-					Entry:       item.Entry,
-					SessionID:   item.SessionID,
-					Status:      item.Status,
-					PendingAsk:  item.PendingAsk,
-					RunningJobs: item.RunningJobs,
+					Entry:         item.Entry,
+					SessionID:     item.SessionID,
+					Status:        item.Status,
+					PendingAsk:    item.PendingAsk,
+					RunningJobs:   item.RunningJobs,
+					CompletedJobs: item.CompletedJobs,
 				}
 				entries = append(entries, entry)
 				// In-process descendants are addressed as their own AppWire

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -933,6 +933,15 @@ export interface NavigationInvalidationTarget {
   revision?: number;
 }
 
+export interface NavigationJobSummary {
+  job_id: string;
+  job_type: string;
+  status: string;
+  command?: string;
+  task?: string;
+  reason?: string;
+}
+
 export interface NavigationManifest {
   generation_id: string;
   revision: number;
@@ -1074,6 +1083,8 @@ export interface NavigationSessionSummary {
   updated_at?: string;
   more_subagents?: number;
   omitted_descendants?: number;
+  running_jobs?: NavigationJobSummary[];
+  completed_jobs?: NavigationJobSummary[];
   children: NavigationSessionSummary[];
 }
 

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
@@ -107,6 +107,9 @@ interface RailSectionProps {
 function renderRailRow(actions: RailRowActions) {
   return (node: RailNode, info: TreeRowInfo) => <RailRow node={node} info={info} actions={actions} />;
 }
+function isPassiveRailNode(node: RailNode): boolean {
+  return node.kind === "loading" || node.kind === "job";
+}
 function RailSection({ title, nodes, onToggle, onActivate, actions }: RailSectionProps) {
   if (nodes.length === 0) return null;
   return (
@@ -673,7 +676,7 @@ function NavigationRail({ onHide, width, onWidthChange, revealTarget, onRevealCo
   }, [revealTarget, resources, expandedOverrides, consumeReveal, setExpanded, requestRevealResource]);
 
   function handleToggle(node: RailNode) {
-    if (node.kind === "loading") return;
+    if (isPassiveRailNode(node)) return;
     const value = !node.expanded;
     setExpanded(node.id, value);
     if (!value && node.kind === "project") rootLoadsInFlight.current.delete(node.project.key);
@@ -691,7 +694,7 @@ function NavigationRail({ onHide, width, onWidthChange, revealTarget, onRevealCo
     if (url) navigate(url);
   }
   function handleActivate(node: RailNode) {
-    if (node.kind === "loading") return;
+    if (isPassiveRailNode(node)) return;
     if (node.kind === "overflow") {
       void revealOverflow(node);
       return;

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
@@ -14,7 +14,9 @@ import { resetWorkspaceStoreForTests, workspaceStore } from "../workspace";
 import { activityGloss, cadenceStateFor, RailRow, type RailRowActions } from "./RailRow";
 import railStyles from "./RailRow.module.css";
 import type {
+  CompletedJobsFoldRailNode,
   InactiveFoldRailNode,
+  JobRailNode,
   LoadingRailNode,
   OverflowRailNode,
   ProjectRailNode,
@@ -151,6 +153,20 @@ function overflowRailNode(count: number): OverflowRailNode {
 
 function inactiveFoldRailNode(count: number): InactiveFoldRailNode {
   return { id: "inactive:parent", kind: "inactiveFold", count, expanded: false, children: [] };
+}
+
+function jobRailNode(overrides: Partial<JobRailNode["job"]> = {}): JobRailNode {
+  return {
+    id: "job:parent:job-1",
+    kind: "job",
+    job: { job_id: "job-1", job_type: "shell", status: "running", row_id: "job:parent:job-1", ...overrides },
+    active: true,
+    children: [],
+  };
+}
+
+function completedJobsFoldRailNode(count: number): CompletedJobsFoldRailNode {
+  return { id: "completed-jobs:parent", kind: "completedJobsFold", count, expanded: false, children: [] };
 }
 
 function info(overrides: Partial<TreeRowInfo> = {}): TreeRowInfo {
@@ -321,6 +337,14 @@ describe("activityGloss", () => {
       ),
     ).toBe("2 subagents working · fix/thing");
   });
+
+  test("reports active jobs alongside active subagents", () => {
+    const session = apiNode({ children: [apiNode({ state: "active" })] });
+    Object.assign(session, {
+      running_jobs: [{ job_id: "job-1", job_type: "shell", status: "running" }],
+    });
+    expect(activityGloss(session)).toBe("1 subagent working · 1 job running");
+  });
 });
 
 describe("loading row", () => {
@@ -411,6 +435,24 @@ describe("inactive-subagent fold row", () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const css = readFileSync(join(here, "RailRow.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
     expect(css).toMatch(/\.signal\s*\{[^}]*width:\s*6px;[^}]*margin-left:\s*-10px;/);
+  });
+});
+
+describe("job rows", () => {
+  test("renders an active job label and green status", () => {
+    render(<RailRow node={jobRailNode({ command: "go test ./..." })} info={info()} actions={actions()} />);
+    expect(screen.getByText("go test ./...")).toBeTruthy();
+    expect(screen.getByTestId("rail-row-job-status").className.split(" ")).toContain(railStyles.activityAlive);
+  });
+
+  test("renders a separate completed-jobs disclosure", () => {
+    const toggle = vi.fn();
+    render(
+      <RailRow node={completedJobsFoldRailNode(3)} info={info({ hasChildren: true, toggle })} actions={actions()} />,
+    );
+    expect(screen.getByText("Completed jobs (3)")).toBeTruthy();
+    fireEvent.click(screen.getByText("Completed jobs (3)"));
+    expect(toggle).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -572,6 +614,16 @@ describe("session row", () => {
     });
     render(<RailRow node={sessionRailNode(session)} info={info({ depth: 1 })} actions={actions()} />);
     expect(screen.getByTestId("rail-row-activity").textContent).toBe("2 subagents working · fix/thing");
+  });
+
+  test("shows an active job on a quiet session as green working activity", () => {
+    const session = apiNode({ state: "idle" });
+    Object.assign(session, {
+      running_jobs: [{ job_id: "job-1", job_type: "shell", status: "running" }],
+    });
+    render(<RailRow node={sessionRailNode(session)} info={info({ depth: 1 })} actions={actions()} />);
+    expect(screen.getByTestId("rail-row-signal")).toBeTruthy();
+    expect(screen.getByTestId("rail-row-activity").className.split(" ")).toContain(railStyles.activityAlive);
   });
 
   test("keeps a quiet row without active descendants one line", () => {

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
@@ -53,8 +53,11 @@ import { type PinTarget, SessionMenu } from "../sessionMenu/SessionMenu";
 import { isPaneOpen, useWorkspaceStore } from "../workspace";
 import styles from "./RailRow.module.css";
 import {
+  activeWorkSummary,
+  type CompletedJobsFoldRailNode,
   displayState,
   type InactiveFoldRailNode,
+  type JobRailNode,
   needsYouDescendantCount,
   type OverflowRailNode,
   type ProjectRailNode,
@@ -62,7 +65,6 @@ import {
   type RailProject,
   type RailSession,
   type SessionRailNode,
-  workingDescendantCount,
 } from "./railNodes";
 import { isTopLevelSession } from "./sessionKind";
 
@@ -242,13 +244,16 @@ function Signal({ wireState }: { wireState: string }) {
 // on the main line it charged its width to the title at the rail's default
 // 280px. Exported for direct testing of the join, which the rendered line can
 // only assert on as one flat string.
-export function activityGloss(session: RailSession): string {
-  const workingCount = workingDescendantCount(session);
-  const parts = [
-    workingCount === 0
-      ? humanizeState(session.state, session.ask_pending === true)
-      : `${workingCount} subagent${workingCount === 1 ? "" : "s"} working`,
-  ];
+export function activityGloss(session: RailSession, activity = activeWorkSummary(session)): string {
+  const workingCount = activity.workingSubagents;
+  const jobCount = activity.runningJobs;
+  const parts: string[] = [];
+  if (workingCount > 0) {
+    parts.push(`${workingCount} subagent${workingCount === 1 ? "" : "s"} working`);
+  } else if (jobCount === 0 || session.state === "active") {
+    parts.push(humanizeState(session.state, session.ask_pending === true));
+  }
+  if (jobCount > 0) parts.push(`${jobCount} job${jobCount === 1 ? "" : "s"} running`);
   if (session.branch !== undefined && session.branch !== "") parts.push(session.branch);
   return parts.join(" · ");
 }
@@ -262,12 +267,17 @@ export function activityGloss(session: RailSession): string {
 // the project it belongs to is the row it is indented under. Project leads
 // the line (state is what's happening, project is where) the same way
 // activityGloss already leads with state before branch.
-function secondLine(session: RailSession, showsGloss: boolean, showsProject: boolean): string {
+function secondLine(
+  session: RailSession,
+  showsGloss: boolean,
+  showsProject: boolean,
+  activity?: ReturnType<typeof activeWorkSummary>,
+): string {
   const parts: string[] = [];
   // An empty project name has nothing to join, so it must not contribute a
   // leading " · " separator with no text before it (UX fix).
   if (showsProject && session.project !== "") parts.push(session.project);
-  if (showsGloss) parts.push(activityGloss(session));
+  if (showsGloss) parts.push(activityGloss(session, activity));
   return parts.join(" · ");
 }
 
@@ -508,8 +518,16 @@ function SessionRow({ node, info, actions }: { node: SessionRailNode; info: Tree
   // gloss, and with it its second line - which makes signal rows physically
   // taller than quiet ones. That is the point: the rows worth finding are bigger
   // than the rows that aren't, and the list's evenness is worth less than that.
-  const showsGloss = SIGNAL_STATES.has(cadenceStateFor(presented));
-  const hasWorkingDescendants = workingDescendantCount(session) > 0;
+  const activity = activeWorkSummary(session);
+  const hasWorkingDescendants = activity.workingSubagents > 0;
+  const hasRunningJobs = activity.runningJobs > 0;
+  const hasActiveWork = session.state === "active" || hasWorkingDescendants || hasRunningJobs;
+  // Descendant/job activity is a working signal for the owning session. A
+  // failed session still wins over that rollup so an error cannot disappear
+  // behind a green child.
+  let effectiveState = presented;
+  if (effectiveState !== "errored" && hasActiveWork) effectiveState = "active";
+  const showsGloss = SIGNAL_STATES.has(cadenceStateFor(effectiveState));
   // kata hxjn: a row at depth 0 is a top-level entry in a flat, cross-project
   // tier (Live/Pinned - see toSessionNode/sessionNodes; a Projects/Test-runs/
   // Archived session is always nested under its own ProjectRow, never a depth-0
@@ -519,14 +537,14 @@ function SessionRow({ node, info, actions }: { node: SessionRailNode; info: Tree
   // above, made for exactly the fact that rule can't otherwise carry.
   const showsProject = info.depth === 0;
   const notStarted = saysNotStarted(session, showsGloss);
-  const showsActivity = showsGloss || hasWorkingDescendants;
-  const gloss = secondLine(session, showsActivity, showsProject);
+  const showsActivity = showsGloss || hasWorkingDescendants || hasRunningJobs;
+  const gloss = secondLine(session, showsActivity, showsProject, activity);
   const showsSecondLine = showsActivity || showsProject;
   // Only a genuine signal row (showsGloss) carries a state to tint - the
   // depth-0-only "just the project name" line (showsProject with no signal)
   // has no state family to color, so it stays the plain --ink-low default.
   const activityClass = showsGloss
-    ? `${CLASS.activity} ${ACTIVITY_FAMILY_CLASS[cadenceStateFor(presented)] ?? ""}`.trim()
+    ? `${CLASS.activity} ${ACTIVITY_FAMILY_CLASS[cadenceStateFor(effectiveState)] ?? ""}`.trim()
     : CLASS.activity;
   return (
     // data-session-ref is the scroll target Rail's reveal effect (the palette's
@@ -550,7 +568,7 @@ function SessionRow({ node, info, actions }: { node: SessionRailNode; info: Tree
             unreachable. The title's tooltip also carries what the visible row
             drops (rowTooltip). */}
         <span className={CLASS.titleLine}>
-          <Signal wireState={presented} />
+          <Signal wireState={effectiveState} />
           <span className={CLASS.label} title={rowTooltip(session, showsGloss, notStarted)}>
             {session.title}
           </span>
@@ -684,17 +702,15 @@ function ProjectRow({ node, info, actions }: { node: ProjectRailNode; info: Tree
 // hides carry their own. Its label sits at the same x as every other row at
 // its nesting depth - the trailing chevron after the label is its toggle,
 // the same inline affordance session and project rows use.
-function InactiveFoldRow({ node, info }: { node: InactiveFoldRailNode; info: TreeRowInfo }) {
-  const label = `${node.count === 1 ? "Inactive subagent" : "Inactive subagents"} (${node.count})`;
+function DisclosureFoldRow({ label, testId, info }: { label: string; testId: string; info: TreeRowInfo }) {
   return (
-    <span className={CLASS.railRow} data-testid="rail-row-inactive-fold">
+    <span className={CLASS.railRow} data-testid={testId}>
       <span className={CLASS.textCol}>
         <span className={CLASS.titleLine}>
-          {/* Same mouse-only shortcut for the toggle the chevron already offers,
-              and the same a11y reasoning as SessionRow's own label: this text is
-              the treeitem's accessible name, so it can't be aria-hidden. */}
-          {/* biome-ignore lint/a11y/noStaticElementInteractions: redundant with the row's own Enter handling, see SessionRow */}
-          {/* biome-ignore lint/a11y/useKeyWithClickEvents: redundant with the row's own Enter handling, see SessionRow */}
+          {/* The label is the accessible activation target; the chevron is a
+              decorative shortcut for the same treeitem toggle. */}
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: redundant with the row's own Enter handling */}
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: redundant with the row's own Enter handling */}
           <span className={CLASS.label} onClick={info.toggle}>
             {label}
           </span>
@@ -702,6 +718,44 @@ function InactiveFoldRow({ node, info }: { node: InactiveFoldRailNode; info: Tre
         </span>
       </span>
     </span>
+  );
+}
+
+function InactiveFoldRow({ node, info }: { node: InactiveFoldRailNode; info: TreeRowInfo }) {
+  const label = `${node.count === 1 ? "Inactive subagent" : "Inactive subagents"} (${node.count})`;
+  return <DisclosureFoldRow label={label} testId="rail-row-inactive-fold" info={info} />;
+}
+
+function jobLabel(job: JobRailNode["job"]): string {
+  return job.command?.trim() || job.task?.trim() || job.job_type?.trim() || job.job_id;
+}
+
+function JobRow({ node }: { node: JobRailNode }) {
+  const active = node.active;
+  const status = node.job.status.trim() || (active ? "running" : "completed");
+  return (
+    <span className={CLASS.railRow} data-testid="rail-row-job" data-job-id={node.job.job_id}>
+      <span className={CLASS.textCol}>
+        <span className={CLASS.titleLine}>
+          <Signal wireState={active ? "active" : status === "failed" ? "errored" : "ended"} />
+          <span className={CLASS.label} title={`${jobLabel(node.job)} · ${status}`}>
+            {jobLabel(node.job)}
+          </span>
+        </span>
+        <span
+          data-testid="rail-row-job-status"
+          className={active ? `${CLASS.activity} ${CLASS.activityAlive}` : CLASS.activity}
+        >
+          {status}
+        </span>
+      </span>
+    </span>
+  );
+}
+
+function CompletedJobsFoldRow({ node, info }: { node: CompletedJobsFoldRailNode; info: TreeRowInfo }) {
+  return (
+    <DisclosureFoldRow label={`Completed jobs (${node.count})`} testId="rail-row-completed-jobs-fold" info={info} />
   );
 }
 
@@ -741,8 +795,12 @@ export function RailRow({ node, info, actions }: RailRowProps) {
   switch (node.kind) {
     case "loading":
       return LoadingRow();
+    case "job":
+      return <JobRow node={node} />;
     case "inactiveFold":
       return <InactiveFoldRow node={node} info={info} />;
+    case "completedJobsFold":
+      return <CompletedJobsFoldRow node={node} info={info} />;
     case "overflow":
       return <OverflowRow node={node} info={info} />;
     case "project":

--- a/cmd/evener-hub/frontend/src/shell/rail/railNodes.test.ts
+++ b/cmd/evener-hub/frontend/src/shell/rail/railNodes.test.ts
@@ -68,6 +68,35 @@ describe("resource projection semantics", () => {
     expect(node?.children.map((child) => child.kind)).toEqual(["session", "inactiveFold"]);
     expect(node?.children[1]).toMatchObject({ count: 1, expanded: false });
   });
+
+  test("keeps active jobs inline and puts idle subagents and completed jobs in separate folds", () => {
+    const root = session({
+      ref: "root",
+      row_id: "root",
+      state: "idle",
+      children: [
+        session({ ref: "idle-child", row_id: "idle-child", kind: "subagent", state: "idle" }),
+        session({ ref: "active-child", row_id: "active-child", kind: "subagent", state: "active" }),
+      ],
+    });
+    Object.assign(root, {
+      running_jobs: [{ job_id: "job-running", job_type: "shell", status: "running" }],
+      completed_jobs: [{ job_id: "job-completed", job_type: "shell", status: "completed" }],
+    });
+    const [node] = sessionNodes([root], closed);
+    expect(node?.children.map((child) => child.kind)).toEqual(["session", "job", "inactiveFold", "completedJobsFold"]);
+    expect(node?.children[1]).toMatchObject({ kind: "job", job: { job_id: "job-running" } });
+    expect(node?.children[2]).toMatchObject({ kind: "inactiveFold", count: 1 });
+    expect(node?.children[3]).toMatchObject({ kind: "completedJobsFold", count: 1 });
+  });
+
+  test("keeps an idle subagent with active work in the inline list", () => {
+    const child = session({ ref: "child", row_id: "child", kind: "subagent", state: "idle" });
+    Object.assign(child, { running_jobs: [{ job_id: "job-child", job_type: "shell", status: "running" }] });
+    const [node] = sessionNodes([session({ ref: "root", row_id: "root", children: [child] })], closed);
+    expect(node?.children.map((entry) => entry.kind)).toEqual(["session"]);
+    expect(node?.children[0]).toMatchObject({ children: [{ kind: "job", job: { job_id: "job-child" } }] });
+  });
   test("handles cluster disclosure without a second inactive fold", () => {
     const cluster = session({
       kind: "cluster",

--- a/cmd/evener-hub/frontend/src/shell/rail/railNodes.ts
+++ b/cmd/evener-hub/frontend/src/shell/rail/railNodes.ts
@@ -5,7 +5,7 @@
 // pure functions OF (the expand-override map, the lazily-loaded archived
 // project detail map) and wires the results into <Tree>.
 
-import type { NavigationSessionSummary } from "../../protocol/types.gen";
+import type { NavigationJobSummary, NavigationSessionSummary } from "../../protocol/types.gen";
 
 export type TreeTier = "current" | "recent" | "archived";
 
@@ -18,6 +18,10 @@ export interface RailSession extends NavigationSessionSummary {
   model?: string;
   children: RailSession[];
   project_key?: string;
+}
+
+export interface RailJob extends NavigationJobSummary {
+  row_id: string;
 }
 
 export interface RailProject {
@@ -61,9 +65,15 @@ export interface SessionRailNode extends WidgetTreeNode {
   // hasChildrenOf), so there's no reason to carry two representations of
   // the same "nothing to expand" case.
   //
-  // Its current subagents, followed by at most one InactiveFoldRailNode
-  // holding the finished ones (see splitChildren).
-  children: (SessionRailNode | InactiveFoldRailNode)[];
+  // Its current subagents and jobs, followed by independent inactive-subagent
+  // and completed-job folds when either has rows (see splitChildren).
+  children: (SessionRailNode | JobRailNode | InactiveFoldRailNode | CompletedJobsFoldRailNode)[];
+}
+
+export interface JobRailNode extends WidgetTreeNode {
+  kind: "job";
+  job: RailJob;
+  active: boolean;
 }
 
 export interface ProjectRailNode extends WidgetTreeNode {
@@ -95,6 +105,12 @@ export interface InactiveFoldRailNode extends WidgetTreeNode {
   kind: "inactiveFold";
   count: number;
   children: (SessionRailNode | OverflowRailNode)[];
+}
+
+export interface CompletedJobsFoldRailNode extends WidgetTreeNode {
+  kind: "completedJobsFold";
+  count: number;
+  children: JobRailNode[];
 }
 
 export interface OverflowPage {
@@ -147,7 +163,14 @@ export function catalogOverflowNode(
   return overflowNode(id, remaining, [{ catalog, offset, limit }]);
 }
 
-export type RailNode = SessionRailNode | ProjectRailNode | LoadingRailNode | InactiveFoldRailNode | OverflowRailNode;
+export type RailNode =
+  | SessionRailNode
+  | JobRailNode
+  | ProjectRailNode
+  | LoadingRailNode
+  | InactiveFoldRailNode
+  | CompletedJobsFoldRailNode
+  | OverflowRailNode;
 
 // The rows a given list has hidden. Each caller passes the tiers it actually
 // renders: an active project's inline list shows Current+Recent (the archived
@@ -223,6 +246,30 @@ function inactiveFoldId(parentRowID: string): string {
   return `inactive:${parentRowID}`;
 }
 
+function completedJobsFoldId(parentRowID: string): string {
+  return `completed-jobs:${parentRowID}`;
+}
+
+function toJobNode(parent: RailSession, job: NavigationJobSummary): JobRailNode {
+  const rowID = `job:${parent.row_id}:${job.job_id}`;
+  return {
+    id: rowID,
+    kind: "job",
+    job: { ...job, row_id: rowID },
+    active: false,
+    children: [],
+  };
+}
+
+function activeJobNode(parent: RailSession, job: NavigationJobSummary): JobRailNode {
+  return { ...toJobNode(parent, job), active: true };
+}
+
+function subagentIsCurrent(child: RailSession): boolean {
+  const activity = activeWorkSummary(child);
+  return CURRENT_SUBAGENT_STATES.has(child.state) || activity.workingSubagents > 0 || activity.runningJobs > 0;
+}
+
 // Splits one parent's children into the rows that render inline and the
 // single fold node carrying the rest. Both sides keep their incoming order,
 // and the fold always lands last, so a parent's live work stays at the top of
@@ -235,27 +282,44 @@ function inactiveFoldId(parentRowID: string): string {
 // "Inactive subagents" for rows that are neither inactive-in-that-sense nor
 // subagents. A cluster is already a disclosure; its members are ordinary
 // top-level sessions (parity-m3-sidebar-tree.md §3).
-function splitChildren(parent: RailSession, isExpanded: IsExpanded): (SessionRailNode | InactiveFoldRailNode)[] {
+function splitChildren(
+  parent: RailSession,
+  isExpanded: IsExpanded,
+): (SessionRailNode | JobRailNode | InactiveFoldRailNode | CompletedJobsFoldRailNode)[] {
   const current: SessionRailNode[] = [];
   const inactive: SessionRailNode[] = [];
   if (parent.kind === "cluster") return parent.children.map((c) => toSessionNode(c, isExpanded));
   for (const child of parent.children) {
-    (CURRENT_SUBAGENT_STATES.has(child.state) ? current : inactive).push(toSessionNode(child, isExpanded));
+    (subagentIsCurrent(child) ? current : inactive).push(toSessionNode(child, isExpanded));
   }
   const inactiveCount = inactive.length + (parent.more_subagents ?? 0);
-  if (inactiveCount === 0) return current;
-  const id = inactiveFoldId(parent.row_id);
-  const omitted = overflowNode(id, parent.more_subagents ?? 0);
-  return [
+  const children: (SessionRailNode | JobRailNode | InactiveFoldRailNode | CompletedJobsFoldRailNode)[] = [
     ...current,
-    {
+    ...(parent.running_jobs ?? []).map((job) => activeJobNode(parent, job)),
+  ];
+  if (inactiveCount > 0) {
+    const id = inactiveFoldId(parent.row_id);
+    const omitted = overflowNode(id, parent.more_subagents ?? 0);
+    children.push({
       id,
       kind: "inactiveFold",
       count: inactiveCount,
       expanded: isExpanded(id, false),
       children: [...inactive, ...omitted],
-    },
-  ];
+    });
+  }
+  const completedJobs = parent.completed_jobs ?? [];
+  if (completedJobs.length > 0) {
+    const id = completedJobsFoldId(parent.row_id);
+    children.push({
+      id,
+      kind: "completedJobsFold",
+      count: completedJobs.length,
+      expanded: isExpanded(id, false),
+      children: completedJobs.map((job) => toJobNode(parent, job)),
+    });
+  }
+  return children;
 }
 
 function toSessionNode(n: RailSession, isExpanded: IsExpanded): SessionRailNode {
@@ -319,11 +383,28 @@ export function needsYouDescendantCount(node: RailSession): number {
   );
 }
 
+export interface ActiveWorkSummary {
+  workingSubagents: number;
+  runningJobs: number;
+}
+
+export function activeWorkSummary(node: RailSession): ActiveWorkSummary {
+  let workingSubagents = 0;
+  let runningJobs = (node.running_jobs ?? []).length;
+  for (const child of node.children) {
+    const childActivity = activeWorkSummary(child);
+    workingSubagents += (child.state === "active" ? 1 : 0) + childActivity.workingSubagents;
+    runningJobs += childActivity.runningJobs;
+  }
+  return { workingSubagents, runningJobs };
+}
+
+export function runningJobCount(node: RailSession): number {
+  return activeWorkSummary(node).runningJobs;
+}
+
 export function workingDescendantCount(node: RailSession): number {
-  return node.children.reduce(
-    (count, child) => count + (child.state === "active" ? 1 : 0) + workingDescendantCount(child),
-    0,
-  );
+  return activeWorkSummary(node).workingSubagents;
 }
 
 // A session "wants you" either directly (its own state) or transitively (a

--- a/cmd/evener-hub/frontend/src/stores/navigation/store.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/navigation/store.test.ts
@@ -506,6 +506,16 @@ test("invalid AppWire envelopes and resource bodies become resource errors", asy
   expect(client.calls.every(({ method }) => method === "evener/navigation/read")).toBe(true);
 });
 
+test("rejects malformed job collections in navigation session summaries", async () => {
+  await init((params) =>
+    params.resource === "manifest"
+      ? wire(emptyManifest())
+      : wire({ sessions: [{ ref: "local:bad", running_jobs: {} }], remaining: 0, truncated: false }),
+  );
+  const resource = await navigationStore.getState().loadSection("live");
+  expect(resource.error).toBeTruthy();
+});
+
 test("stale client completion cannot overwrite newer client", async () => {
   const old = deferred<NavigationReadResponse>();
   const first = new FakeClient("ready");

--- a/cmd/evener-hub/frontend/src/stores/navigation/store.ts
+++ b/cmd/evener-hub/frontend/src/stores/navigation/store.ts
@@ -194,12 +194,30 @@ function sessions(value: unknown): boolean {
       !optional(candidate.dormant, bool) ||
       !optional(candidate.updated_at, string) ||
       !optional(candidate.more_subagents, count) ||
-      !optional(candidate.omitted_descendants, count)
+      !optional(candidate.omitted_descendants, count) ||
+      !optional(candidate.running_jobs, jobs) ||
+      !optional(candidate.completed_jobs, jobs)
     )
       return false;
     pending.push(...candidate.children);
   }
   return true;
+}
+
+function jobs(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (candidate) =>
+        record(candidate) &&
+        string(candidate.job_id) &&
+        string(candidate.job_type) &&
+        string(candidate.status) &&
+        optional(candidate.command, string) &&
+        optional(candidate.task, string) &&
+        optional(candidate.reason, string),
+    )
+  );
 }
 function tier(value: unknown): boolean {
   return record(value) && sessions(value.sessions) && count(value.remaining);

--- a/cmd/evener-hub/internal/appsource/local_daemon.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon.go
@@ -56,6 +56,9 @@ type LocalDaemonEntry struct {
 	// RunningJobs carries the roster's non-terminal, non-agent work into the
 	// typed thread diagnostics consumed by hub and TUI status views.
 	RunningJobs []appwire.EvenerJobInfo
+	// CompletedJobs carries the recent terminal non-agent jobs into the same
+	// typed diagnostics snapshot for local compatibility consumers.
+	CompletedJobs []appwire.EvenerJobInfo
 }
 
 func NewLocalDaemonSource(sourceID string, entries func() []rendezvous.Entry, client *http.Client) *LocalDaemonSource {
@@ -874,8 +877,11 @@ func (s *LocalDaemonSource) threadFromEntry(item LocalDaemonEntry) appwire.Threa
 		},
 		Status: appwire.ThreadStatus{Type: status},
 	}
-	if !item.ReadOnlyAlias && len(item.RunningJobs) > 0 {
-		thread.Evener.Diagnostics = &appwire.EvenerDiagnostics{Jobs: cloneLocalDaemonJobs(item.RunningJobs)}
+	if !item.ReadOnlyAlias && (len(item.RunningJobs) > 0 || len(item.CompletedJobs) > 0) {
+		jobs := make([]appwire.EvenerJobInfo, 0, len(item.RunningJobs)+len(item.CompletedJobs))
+		jobs = append(jobs, item.RunningJobs...)
+		jobs = append(jobs, item.CompletedJobs...)
+		thread.Evener.Diagnostics = &appwire.EvenerDiagnostics{Jobs: cloneLocalDaemonJobs(jobs)}
 	}
 	if item.ReadOnlyAlias {
 		thread.Evener.Capabilities = appwire.ThreadCapabilities{}

--- a/cmd/evener-hub/internal/appsource/local_daemon.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon.go
@@ -90,16 +90,31 @@ func (s *LocalDaemonSource) ID() string {
 	return s.sourceID
 }
 
-func (s *LocalDaemonSource) AcquireRelaySession(params appwire.ThreadReadParams) (RelaySessionLease, error) {
+func (s *LocalDaemonSource) ResolveRelaySession(params appwire.ThreadReadParams) (appwire.Ref, error) {
 	entry, err := s.entryForReadRef(params.Ref, params.ThreadID)
 	if err != nil {
-		return nil, err
+		return appwire.Ref{}, err
 	}
 	threadID := entry.ThreadID
 	if entry.SessionID != "" {
 		threadID = entry.SessionID
 	}
-	key := localDaemonWorkspaceRef(s.sourceID, entry, threadID)
+	ref, err := appwire.ParseRef(localDaemonWorkspaceRef(s.sourceID, entry, threadID))
+	if err != nil {
+		return appwire.Ref{}, appwire.SessionUnavailable("local daemon returned an empty workspace ref")
+	}
+	return ref, nil
+}
+
+func (s *LocalDaemonSource) AcquireRelaySession(ref appwire.Ref) (RelaySessionLease, error) {
+	if ref.SourceID != s.sourceID || ref.String() == "" {
+		return nil, appwire.SessionUnavailable("invalid relay session ref")
+	}
+	_, err := s.entryForReadRef(ref.String(), "")
+	if err != nil {
+		return nil, err
+	}
+	key := ref.String()
 
 	s.relayMu.Lock()
 	session := s.relaySessions[key]
@@ -158,6 +173,16 @@ func (s *LocalDaemonSource) AcquireRelaySession(params appwire.ThreadReadParams)
 	return lease, nil
 }
 
+// acquireRelaySession preserves the old parameter-based source call sites while
+// keeping canonical resolution separate from relay session acquisition.
+func (s *LocalDaemonSource) acquireRelaySession(params appwire.ThreadReadParams) (RelaySessionLease, error) {
+	ref, err := s.ResolveRelaySession(params)
+	if err != nil {
+		return nil, err
+	}
+	return s.AcquireRelaySession(ref)
+}
+
 func (s *LocalDaemonSource) ListThreads(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
 	out := appwire.ThreadListResponse{}
 	for _, entry := range s.liveEntries() {
@@ -171,7 +196,7 @@ func (s *LocalDaemonSource) ListThreads(context.Context, appwire.ThreadListParam
 
 func (s *LocalDaemonSource) ReadThread(ctx context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
 	if params.Subscribe {
-		lease, err := s.AcquireRelaySession(params)
+		lease, err := s.acquireRelaySession(params)
 		if err != nil {
 			return appwire.ThreadReadResponse{}, err
 		}
@@ -508,7 +533,7 @@ func (s *LocalDaemonSource) SubscribeThread(ctx context.Context, params appwire.
 	handoff := pending.handoff
 	var err error
 	if lease == nil {
-		lease, err = s.AcquireRelaySession(params)
+		lease, err = s.acquireRelaySession(params)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/evener-hub/internal/appsource/local_daemon_test.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon_test.go
@@ -630,6 +630,9 @@ func TestLocalDaemonSourceListCarriesRunningNonAgentJobs(t *testing.T) {
 			RunningJobs: []appwire.EvenerJobInfo{{
 				JobID: "job_shell", JobType: "shell", Status: "running",
 			}},
+			CompletedJobs: []appwire.EvenerJobInfo{{
+				JobID: "job_done", JobType: "shell", Status: "completed",
+			}},
 		}}
 	}, nil)
 
@@ -637,8 +640,8 @@ func TestLocalDaemonSourceListCarriesRunningNonAgentJobs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListThreads: %v", err)
 	}
-	if len(resp.Data) != 1 || resp.Data[0].Evener.Diagnostics == nil || len(resp.Data[0].Evener.Diagnostics.Jobs) != 1 {
-		t.Fatalf("thread list diagnostics = %+v, want one running shell job", resp.Data)
+	if len(resp.Data) != 1 || resp.Data[0].Evener.Diagnostics == nil || len(resp.Data[0].Evener.Diagnostics.Jobs) != 2 {
+		t.Fatalf("thread list diagnostics = %+v, want active and completed shell jobs", resp.Data)
 	}
 	job := resp.Data[0].Evener.Diagnostics.Jobs[0]
 	if job.JobID != "job_shell" || job.JobType != "shell" || job.Status != "running" {

--- a/cmd/evener-hub/internal/appsource/local_daemon_test.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon_test.go
@@ -56,7 +56,7 @@ func TestRelaySessionHealthyRejoinUsesCanonicalConnection(t *testing.T) {
 	}
 
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	lease, err := source.AcquireRelaySession(params)
+	lease, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatalf("AcquireRelaySession: %v", err)
 	}
@@ -926,12 +926,20 @@ func TestLocalDaemonRootAndReadOnlyAliasShareRelaySession(t *testing.T) {
 			{Entry: entry, SessionID: "sess_child", OwnerSessionID: "sess_root", ReadOnlyAlias: true},
 		}
 	}, nil)
-	rootValue, err := source.AcquireRelaySession(appwire.ThreadReadParams{Ref: "local:sess_root"})
+	rootRef, err := source.ResolveRelaySession(appwire.ThreadReadParams{Ref: "local:sess_root"})
+	if err != nil {
+		t.Fatalf("resolve root relay: %v", err)
+	}
+	rootValue, err := source.AcquireRelaySession(rootRef)
 	if err != nil {
 		t.Fatalf("acquire root relay: %v", err)
 	}
 	defer rootValue.Close()
-	childValue, err := source.AcquireRelaySession(appwire.ThreadReadParams{Ref: "local:sess_child"})
+	childRef, err := source.ResolveRelaySession(appwire.ThreadReadParams{Ref: "local:sess_child"})
+	if err != nil {
+		t.Fatalf("resolve child relay: %v", err)
+	}
+	childValue, err := source.AcquireRelaySession(childRef)
 	if err != nil {
 		t.Fatalf("acquire child relay: %v", err)
 	}
@@ -953,5 +961,61 @@ func TestLocalDaemonRootAndReadOnlyAliasShareRelaySession(t *testing.T) {
 	source.relayMu.Unlock()
 	if actors != 1 {
 		t.Fatalf("relay session actors = %d, want 1", actors)
+	}
+}
+
+func TestLocalDaemonResolveRelaySessionCanonicalizesAliasesWithoutAcquiring(t *testing.T) {
+	entry := rendezvous.Entry{
+		Protocol:     appwire.ProtocolVersion,
+		Endpoint:     "ws://127.0.0.1/rpc",
+		SourceID:     "local",
+		ThreadID:     "sess_root",
+		SessionID:    "sess_root",
+		WorkspaceRef: "local:sess_root",
+	}
+	source := NewLocalDaemonSourceWithEntries("local", func() []LocalDaemonEntry {
+		return []LocalDaemonEntry{
+			{Entry: entry, SessionID: "sess_root"},
+			{Entry: entry, SessionID: "sess_child", OwnerSessionID: "sess_root", ReadOnlyAlias: true},
+		}
+	}, nil)
+
+	root, err := source.ResolveRelaySession(appwire.ThreadReadParams{Ref: "local:sess_root"})
+	if err != nil {
+		t.Fatalf("resolve root relay: %v", err)
+	}
+	child, err := source.ResolveRelaySession(appwire.ThreadReadParams{Ref: "local:sess_child"})
+	if err != nil {
+		t.Fatalf("resolve child relay: %v", err)
+	}
+	byThreadID, err := source.ResolveRelaySession(appwire.ThreadReadParams{ThreadID: "sess_child"})
+	if err != nil {
+		t.Fatalf("resolve thread-ID-only relay: %v", err)
+	}
+	want := appwire.Ref{SourceID: "local", ThreadID: "sess_root"}
+	for name, got := range map[string]appwire.Ref{"root": root, "child": child, "thread-ID-only": byThreadID} {
+		if got != want {
+			t.Errorf("%s canonical ref = %#v, want %#v", name, got, want)
+		}
+		if got.String() == "" {
+			t.Errorf("%s canonical ref is empty", name)
+		}
+	}
+
+	for _, params := range []appwire.ThreadReadParams{
+		{Ref: "not-a-ref"},
+		{Ref: "other:sess_root"},
+		{Ref: "local:missing"},
+		{ThreadID: "missing"},
+	} {
+		if _, err := source.ResolveRelaySession(params); err == nil {
+			t.Errorf("ResolveRelaySession(%+v) succeeded for invalid target", params)
+		}
+	}
+	source.relayMu.Lock()
+	acquired := len(source.relaySessions)
+	source.relayMu.Unlock()
+	if acquired != 0 {
+		t.Fatalf("resolution acquired %d relay sessions, want none", acquired)
 	}
 }

--- a/cmd/evener-hub/internal/appsource/relay_session_test.go
+++ b/cmd/evener-hub/internal/appsource/relay_session_test.go
@@ -234,7 +234,7 @@ func queueRelayNotificationAtEpoch(session *relaySession, epoch uint64, notifica
 func TestRelaySessionSnapshotCutFlushesPreCutAndHoldsPostCut(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	lease, err := source.AcquireRelaySession(params)
+	lease, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatalf("AcquireRelaySession: %v", err)
 	}
@@ -288,7 +288,7 @@ func TestRelaySessionSnapshotCutFlushesPreCutAndHoldsPostCut(t *testing.T) {
 func TestRelaySessionSnapshotCutWaitsForQueuedPreCaptureNotification(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	leaseValue, err := source.AcquireRelaySession(params)
+	leaseValue, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatalf("AcquireRelaySession: %v", err)
 	}
@@ -387,7 +387,7 @@ func TestRelaySessionSnapshotCutWaitsForQueuedPreCaptureNotification(t *testing.
 func TestRelaySessionRacingReadsDoNotOverlap(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	lease, err := source.AcquireRelaySession(params)
+	lease, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -429,7 +429,7 @@ func TestRelaySessionRacingReadsDoNotOverlap(t *testing.T) {
 func TestRelaySessionCanceledListenerCannotStrandPreCutFlush(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	lease, err := source.AcquireRelaySession(params)
+	lease, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -457,7 +457,7 @@ func TestRelaySessionCanceledListenerCannotStrandPreCutFlush(t *testing.T) {
 func TestRelaySessionCanceledListenerIsSafeAfterPublisherSnapshotsIt(t *testing.T) {
 	source, _ := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	leaseValue, err := source.AcquireRelaySession(params)
+	leaseValue, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -487,7 +487,7 @@ func TestRelaySessionCanceledListenerIsSafeAfterPublisherSnapshotsIt(t *testing.
 func TestRelaySessionCancellationBeforeCutResumesFeedAndFencesLateResponse(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	lease, err := source.AcquireRelaySession(params)
+	lease, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -542,7 +542,7 @@ func TestRelaySessionCancellationBeforeCutResumesFeedAndFencesLateResponse(t *te
 func TestRelaySessionAbortAfterCutReleasesPostCutFeedOnce(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	lease, err := source.AcquireRelaySession(params)
+	lease, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -577,7 +577,7 @@ func TestRelaySessionAbortAfterCutReleasesPostCutFeedOnce(t *testing.T) {
 func TestRelaySessionDisconnectDuringReadCannotReturnSnapshot(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	lease, err := source.AcquireRelaySession(params)
+	lease, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -708,7 +708,7 @@ func TestRelaySessionEOFBeforeConnectionInstallForcesNextReadToRedial(t *testing
 func TestRelaySessionCommitAbortRaceHasOneWinner(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	lease, err := source.AcquireRelaySession(params)
+	lease, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -749,7 +749,7 @@ func TestRelaySessionCommitAbortRaceHasOneWinner(t *testing.T) {
 func TestRelaySessionPreparedHandoffPinsEpochUntilResponseOutcome(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	leaseValue, err := source.AcquireRelaySession(params)
+	leaseValue, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -783,7 +783,7 @@ func TestRelaySessionPreparedHandoffPinsEpochUntilResponseOutcome(t *testing.T) 
 func TestRelaySessionPreparedHandoffAbortAppliesDeferredDisconnectAndRecoversListener(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	leaseValue, err := source.AcquireRelaySession(params)
+	leaseValue, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -829,7 +829,7 @@ func TestRelaySessionPreparedHandoffAbortAppliesDeferredDisconnectAndRecoversLis
 func TestRelaySessionHandoffCannotPrepareAfterEpochDisconnect(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	leaseValue, err := source.AcquireRelaySession(params)
+	leaseValue, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -859,7 +859,7 @@ func TestRelaySessionHandoffCannotPrepareAfterEpochDisconnect(t *testing.T) {
 func TestRelaySessionStaleEpochNotificationCannotPublish(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	leaseValue, err := source.AcquireRelaySession(params)
+	leaseValue, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -912,7 +912,7 @@ func TestRelaySessionStaleEpochNotificationCannotPublish(t *testing.T) {
 func TestRelaySessionDisconnectRevokesBlockedPublicationBeforeRecovery(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	leaseValue, err := source.AcquireRelaySession(params)
+	leaseValue, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -981,7 +981,7 @@ func TestRelaySessionDisconnectRevokesBlockedPublicationBeforeRecovery(t *testin
 func TestRelaySessionPreparedHandoffDisconnectRevokesBlockedPublicationBeforeRecovery(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	leaseValue, err := source.AcquireRelaySession(params)
+	leaseValue, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1050,7 +1050,7 @@ func TestRelaySessionPreparedHandoffDisconnectRevokesBlockedPublicationBeforeRec
 func TestRelaySessionIdleClosesCanonicalConnectionAfterLastOwner(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	lease, err := source.AcquireRelaySession(params)
+	lease, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1077,7 +1077,7 @@ func TestRelaySessionIdleClosesCanonicalConnectionAfterLastOwner(t *testing.T) {
 func TestRelaySessionPreparedHandoffDefersIdleUntilResponseOutcome(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	lease, err := source.AcquireRelaySession(params)
+	lease, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1113,7 +1113,7 @@ func TestRelaySessionPreparedHandoffDefersIdleUntilResponseOutcome(t *testing.T)
 func TestRelaySessionAcquireReplacesClosedActorBeforeIdleMapRemoval(t *testing.T) {
 	source, _ := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	firstValue, err := source.AcquireRelaySession(params)
+	firstValue, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1131,7 +1131,7 @@ func TestRelaySessionAcquireReplacesClosedActorBeforeIdleMapRemoval(t *testing.T
 	}()
 	<-idleEntered
 
-	secondValue, err := source.AcquireRelaySession(params)
+	secondValue, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatalf("AcquireRelaySession while closed actor awaited map removal: %v", err)
 	}
@@ -1151,12 +1151,12 @@ func TestRelaySessionUnrelatedActorProgressesWhileSnapshotBlocked(t *testing.T) 
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1"), relayEntry("thread-2")})
 	firstParams := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
 	secondParams := appwire.ThreadReadParams{Ref: "local:thread-2", Subscribe: true}
-	firstLease, err := source.AcquireRelaySession(firstParams)
+	firstLease, err := source.acquireRelaySession(firstParams)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer firstLease.Close()
-	secondLease, err := source.AcquireRelaySession(secondParams)
+	secondLease, err := source.acquireRelaySession(secondParams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1188,12 +1188,12 @@ func TestRelaySessionPreparedHandoffDoesNotBlockUnrelatedActor(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1"), relayEntry("thread-2")})
 	firstParams := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
 	secondParams := appwire.ThreadReadParams{Ref: "local:thread-2", Subscribe: true}
-	firstLease, err := source.AcquireRelaySession(firstParams)
+	firstLease, err := source.acquireRelaySession(firstParams)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer firstLease.Close()
-	secondLease, err := source.AcquireRelaySession(secondParams)
+	secondLease, err := source.acquireRelaySession(secondParams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1228,7 +1228,7 @@ func TestRelaySessionPreparedHandoffDoesNotBlockUnrelatedActor(t *testing.T) {
 func TestRelaySessionCanonicalFeedDoesNotOverflowUnusedClientNotificationBuffer(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	lease, err := source.AcquireRelaySession(params)
+	lease, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1277,7 +1277,7 @@ func TestRelaySessionCanonicalFeedDoesNotOverflowUnusedClientNotificationBuffer(
 func TestRelaySessionRecoversCanonicalFeedAndEmitsResyncWithoutAnotherRead(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	lease, err := source.AcquireRelaySession(params)
+	lease, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1322,7 +1322,7 @@ func TestRelaySessionRecoversCanonicalFeedAndEmitsResyncWithoutAnotherRead(t *te
 func TestRelaySessionRecoveryDisconnectBeforeHandoffResolutionStartsSuccessor(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	leaseValue, err := source.AcquireRelaySession(params)
+	leaseValue, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1426,7 +1426,7 @@ func decodeRelayDelta(t *testing.T, notification appwire.Notification) string {
 func TestRelaySessionCommandReadResyncsListenersOnReplacementConnection(t *testing.T) {
 	source, daemon := newRelayTestSource(t, []rendezvous.Entry{relayEntry("thread-1")})
 	params := appwire.ThreadReadParams{Ref: "local:thread-1", Subscribe: true}
-	lease, err := source.AcquireRelaySession(params)
+	lease, err := source.acquireRelaySession(params)
 	if err != nil {
 		t.Fatalf("AcquireRelaySession: %v", err)
 	}

--- a/cmd/evener-hub/internal/appsource/source.go
+++ b/cmd/evener-hub/internal/appsource/source.go
@@ -41,7 +41,8 @@ type Source interface {
 // upstream snapshot-to-live stream. Codex deliberately does not implement this
 // interface because it converges through authoritative full-state replacement.
 type RelaySessionSource interface {
-	AcquireRelaySession(appwire.ThreadReadParams) (RelaySessionLease, error)
+	ResolveRelaySession(appwire.ThreadReadParams) (appwire.Ref, error)
+	AcquireRelaySession(appwire.Ref) (RelaySessionLease, error)
 }
 
 type RelaySessionLease interface {

--- a/cmd/evener-hub/internal/hubcore/prober.go
+++ b/cmd/evener-hub/internal/hubcore/prober.go
@@ -86,6 +86,7 @@ func (p *StatusProber) Probe(entry rendezvous.Entry) ProbeResult {
 	}
 	sort.Strings(runningSubagentIDs)
 
+	runningJobs, completedJobs := splitNonAgentJobs(root.Evener.Diagnostics)
 	return ProbeResult{
 		SessionID:             rootID,
 		Status:                root.Status.Type,
@@ -93,7 +94,8 @@ func (p *StatusProber) Probe(entry rendezvous.Entry) ProbeResult {
 		PendingEscalation:     len(root.Evener.PendingEscalations) > 0,
 		RunningSubagentIDs:    runningSubagentIDs,
 		RunningSubagentStates: runningSubagentStates,
-		RunningJobs:           runningNonAgentJobs(root.Evener.Diagnostics),
+		RunningJobs:           runningJobs,
+		CompletedJobs:         completedJobs,
 		OK:                    true,
 	}
 }
@@ -105,18 +107,29 @@ func statusThreadID(thread appwire.Thread) string {
 	return strings.TrimSpace(thread.ID)
 }
 
-func runningNonAgentJobs(diagnostics *appwire.EvenerDiagnostics) []appwire.EvenerJobInfo {
+func splitNonAgentJobs(diagnostics *appwire.EvenerDiagnostics) ([]appwire.EvenerJobInfo, []appwire.EvenerJobInfo) {
 	if diagnostics == nil {
-		return nil
+		return nil, nil
 	}
-	var jobs []appwire.EvenerJobInfo
-	for _, job := range diagnostics.Jobs {
-		if strings.TrimSpace(job.JobType) == "delegate" || terminalJobStatus(job.Status) {
+	return SplitNonAgentJobs(diagnostics.Jobs)
+}
+
+// SplitNonAgentJobs separates non-delegate jobs into active and terminal
+// groups for navigation consumers. The input is already the daemon's bounded
+// diagnostic inventory, so the function preserves its order within each group.
+func SplitNonAgentJobs(jobs []appwire.EvenerJobInfo) ([]appwire.EvenerJobInfo, []appwire.EvenerJobInfo) {
+	var running, completed []appwire.EvenerJobInfo
+	for _, job := range jobs {
+		if strings.TrimSpace(job.JobType) == "delegate" {
 			continue
 		}
-		jobs = append(jobs, job)
+		if terminalJobStatus(job.Status) {
+			completed = append(completed, job)
+		} else {
+			running = append(running, job)
+		}
 	}
-	return jobs
+	return running, completed
 }
 
 func terminalJobStatus(status string) bool {

--- a/cmd/evener-hub/internal/hubcore/prober_test.go
+++ b/cmd/evener-hub/internal/hubcore/prober_test.go
@@ -232,3 +232,24 @@ func TestProbeIgnoresRetiredDetailedJobType(t *testing.T) {
 		t.Fatalf("delegate job inferred consumer status: %+v", result)
 	}
 }
+
+func TestProbeSeparatesActiveAndCompletedNonAgentJobs(t *testing.T) {
+	prober, entry := startProbeDaemon(t, probeDaemonConfig{
+		sessionID: "parent", state: appwire.ThreadStatusIdle,
+		source: wireProbeEnvelopeSource{detailed: server.DetailedStatus{Jobs: []server.JobStatusInfo{
+			{JobID: "job-running", JobType: "shell", Status: "running"},
+			{JobID: "job-completed", JobType: "shell", Status: "completed"},
+			{JobID: "job-delegate", JobType: "delegate", Status: "completed"},
+		}}},
+	})
+	result := prober.Probe(entry)
+	if !result.OK {
+		t.Fatal("expected successful status probe")
+	}
+	if len(result.RunningJobs) != 1 || result.RunningJobs[0].JobID != "job-running" {
+		t.Fatalf("running jobs = %+v, want only active non-agent job", result.RunningJobs)
+	}
+	if len(result.CompletedJobs) != 1 || result.CompletedJobs[0].JobID != "job-completed" {
+		t.Fatalf("completed jobs = %+v, want only terminal non-agent job", result.CompletedJobs)
+	}
+}

--- a/cmd/evener-hub/internal/hubcore/roster.go
+++ b/cmd/evener-hub/internal/hubcore/roster.go
@@ -40,7 +40,10 @@ type LiveEntry struct {
 	// such as shell and watch jobs. Delegate jobs stay represented by the
 	// descendant fields above so consumers do not render duplicate agent rows.
 	RunningJobs []appwire.EvenerJobInfo
-	Project     identifier.Project // canonical identity resolved at hub ingestion, when available
+	// CompletedJobs contains recent terminal non-agent jobs. Delegate jobs stay
+	// represented by descendant sessions for the same reason as RunningJobs.
+	CompletedJobs []appwire.EvenerJobInfo
+	Project       identifier.Project // canonical identity resolved at hub ingestion, when available
 }
 
 // ProbeResult is the dynamic session state returned by a daemon liveness probe.
@@ -52,6 +55,7 @@ type ProbeResult struct {
 	RunningSubagentIDs    []string
 	RunningSubagentStates map[string]string
 	RunningJobs           []appwire.EvenerJobInfo
+	CompletedJobs         []appwire.EvenerJobInfo
 	OK                    bool
 }
 
@@ -77,6 +81,15 @@ func cloneSubagentStates(in map[string]string) map[string]string {
 
 func cloneRunningJobs(in []appwire.EvenerJobInfo) []appwire.EvenerJobInfo {
 	return appwire.CloneEvenerJobs(in)
+}
+
+func cloneLiveEntry(in LiveEntry) LiveEntry {
+	out := in
+	out.RunningSubagentIDs = append([]string(nil), in.RunningSubagentIDs...)
+	out.RunningSubagentStates = cloneSubagentStates(in.RunningSubagentStates)
+	out.RunningJobs = cloneRunningJobs(in.RunningJobs)
+	out.CompletedJobs = cloneRunningJobs(in.CompletedJobs)
+	return out
 }
 
 // crashedFileRetention is how long Refresh keeps a dead PID's rendezvous file
@@ -189,9 +202,7 @@ func (r *Roster) SetFs(fs afero.Fs) *Roster {
 func NewRosterWithEntries(entries ...LiveEntry) *Roster {
 	r := NewRoster("", nil)
 	for _, e := range entries {
-		e.RunningSubagentIDs = append([]string(nil), e.RunningSubagentIDs...)
-		e.RunningSubagentStates = cloneSubagentStates(e.RunningSubagentStates)
-		e.RunningJobs = cloneRunningJobs(e.RunningJobs)
+		e = cloneLiveEntry(e)
 		r.byPID[e.PID] = e
 		if e.SessionID != "" {
 			r.bySess[e.SessionID] = e
@@ -241,24 +252,36 @@ func rosterFingerprint(bySess map[string]LiveEntry) uint64 {
 			_, _ = h.Write([]byte(bySess[id].RunningSubagentStates[childID]))
 			_, _ = h.Write([]byte{0})
 		}
-		runningJobs := append([]appwire.EvenerJobInfo(nil), bySess[id].RunningJobs...)
-		sort.Slice(runningJobs, func(i, j int) bool {
-			if runningJobs[i].JobID != runningJobs[j].JobID {
-				return runningJobs[i].JobID < runningJobs[j].JobID
+		writeJobs := func(jobs []appwire.EvenerJobInfo) {
+			sort.SliceStable(jobs, func(i, j int) bool {
+				if jobs[i].JobID != jobs[j].JobID {
+					return jobs[i].JobID < jobs[j].JobID
+				}
+				if jobs[i].JobType != jobs[j].JobType {
+					return jobs[i].JobType < jobs[j].JobType
+				}
+				return jobs[i].Status < jobs[j].Status
+			})
+			for _, job := range jobs {
+				_, _ = h.Write([]byte(job.JobID))
+				_, _ = h.Write([]byte{0})
+				_, _ = h.Write([]byte(job.JobType))
+				_, _ = h.Write([]byte{0})
+				_, _ = h.Write([]byte(job.Status))
+				_, _ = h.Write([]byte{0})
+				_, _ = h.Write([]byte(job.Command))
+				_, _ = h.Write([]byte{0})
+				_, _ = h.Write([]byte(job.Task))
+				_, _ = h.Write([]byte{0})
+				_, _ = h.Write([]byte(job.Reason))
+				_, _ = h.Write([]byte{0})
 			}
-			if runningJobs[i].JobType != runningJobs[j].JobType {
-				return runningJobs[i].JobType < runningJobs[j].JobType
-			}
-			return runningJobs[i].Status < runningJobs[j].Status
-		})
-		for _, job := range runningJobs {
-			_, _ = h.Write([]byte(job.JobID))
-			_, _ = h.Write([]byte{0})
-			_, _ = h.Write([]byte(job.JobType))
-			_, _ = h.Write([]byte{0})
-			_, _ = h.Write([]byte(job.Status))
-			_, _ = h.Write([]byte{0})
 		}
+		runningJobs := append([]appwire.EvenerJobInfo(nil), bySess[id].RunningJobs...)
+		writeJobs(runningJobs)
+		_, _ = h.Write([]byte{0})
+		completedJobs := append([]appwire.EvenerJobInfo(nil), bySess[id].CompletedJobs...)
+		writeJobs(completedJobs)
 		_, _ = h.Write([]byte{0})
 	}
 	return h.Sum64()
@@ -380,6 +403,7 @@ func (r *Roster) Refresh() {
 			RunningSubagentIDs:    append([]string(nil), res.RunningSubagentIDs...),
 			RunningSubagentStates: cloneSubagentStates(res.RunningSubagentStates),
 			RunningJobs:           cloneRunningJobs(res.RunningJobs),
+			CompletedJobs:         cloneRunningJobs(res.CompletedJobs),
 		}
 		if res.SessionID != "" {
 			if prev, ok := bySess[res.SessionID]; !ok || preferLiveEntry(live, prev) {
@@ -427,9 +451,7 @@ func (r *Roster) List() []LiveEntry {
 	bySession := make(map[string]LiveEntry, len(r.byPID))
 	out := make([]LiveEntry, 0, len(r.byPID))
 	for _, e := range r.byPID {
-		e.RunningSubagentIDs = append([]string(nil), e.RunningSubagentIDs...)
-		e.RunningSubagentStates = cloneSubagentStates(e.RunningSubagentStates)
-		e.RunningJobs = cloneRunningJobs(e.RunningJobs)
+		e = cloneLiveEntry(e)
 		sessionID := envvars.FirstNonEmpty(e.SessionID, e.Entry.SessionID, e.ThreadID)
 		if sessionID == "" {
 			out = append(out, e)
@@ -493,9 +515,7 @@ func (r *Roster) Find(sessionID string) (LiveEntry, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	e, ok := r.bySess[sessionID]
-	e.RunningSubagentIDs = append([]string(nil), e.RunningSubagentIDs...)
-	e.RunningSubagentStates = cloneSubagentStates(e.RunningSubagentStates)
-	e.RunningJobs = cloneRunningJobs(e.RunningJobs)
+	e = cloneLiveEntry(e)
 	return e, ok
 }
 

--- a/cmd/evener-hub/internal/hubcore/tree.go
+++ b/cmd/evener-hub/internal/hubcore/tree.go
@@ -113,6 +113,8 @@ func cloneTreeNodesContext(ctx context.Context, nodes []TreeNode) ([]TreeNode, e
 			return nil, err
 		}
 		out[index] = node
+		out[index].RunningJobs = appwire.CloneEvenerJobs(node.RunningJobs)
+		out[index].CompletedJobs = appwire.CloneEvenerJobs(node.CompletedJobs)
 		children, err := cloneTreeNodesContext(ctx, node.Children)
 		if err != nil {
 			return nil, err
@@ -428,6 +430,10 @@ type TreeNode struct {
 	// cap. The client folds this into the parent's inactive-child disclosure so
 	// capped children are counted rather than silently disappearing.
 	MoreSubagents int
+	// RunningJobs and CompletedJobs are the non-delegate jobs owned by this
+	// session. Delegate jobs remain represented by Children as subagents.
+	RunningJobs   []appwire.EvenerJobInfo
+	CompletedJobs []appwire.EvenerJobInfo
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 	Age           string // pre-formatted "now", "2m", "3h", "5d"
@@ -1125,18 +1131,20 @@ func buildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decis
 		// for children WITH one (it overwrote the child's own daemon-reported
 		// status with the parent's projection).
 		node := TreeNode{
-			ID:         m.ID,
-			Ref:        liveRefMap[m.ID],
-			Title:      nodeTitle(m, kind),
-			Project:    acc.name,
-			Branch:     m.EnvInfo.GitBranch,
-			State:      state,
-			AskPending: askPending,
-			Dormant:    dormantFor(m.ID),
-			Kind:       kind,
-			CreatedAt:  OrderCreatedAt(m.CreatedAt, m.UpdatedAt),
-			UpdatedAt:  OrderUpdatedAt(m.UpdatedAt, m.CreatedAt),
-			Age:        AgeString(OrderUpdatedAt(m.UpdatedAt, m.CreatedAt)),
+			ID:            m.ID,
+			Ref:           liveRefMap[m.ID],
+			Title:         nodeTitle(m, kind),
+			Project:       acc.name,
+			Branch:        m.EnvInfo.GitBranch,
+			State:         state,
+			AskPending:    askPending,
+			Dormant:       dormantFor(m.ID),
+			Kind:          kind,
+			CreatedAt:     OrderCreatedAt(m.CreatedAt, m.UpdatedAt),
+			UpdatedAt:     OrderUpdatedAt(m.UpdatedAt, m.CreatedAt),
+			Age:           AgeString(OrderUpdatedAt(m.UpdatedAt, m.CreatedAt)),
+			RunningJobs:   appwire.CloneEvenerJobs(liveMap[m.ID].RunningJobs),
+			CompletedJobs: appwire.CloneEvenerJobs(liveMap[m.ID].CompletedJobs),
 		}
 
 		childMetas := childrenByParent[m.ID]
@@ -1206,6 +1214,9 @@ func buildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decis
 			taskState := s.State
 			var includeDescendants func(TreeNode)
 			includeDescendants = func(node TreeNode) {
+				if len(node.RunningJobs) > 0 && hubapi.RollupRank("active") > hubapi.RollupRank(taskState) {
+					taskState = "active"
+				}
 				for _, child := range node.Children {
 					if hubapi.RollupRank(child.State) > hubapi.RollupRank(taskState) {
 						taskState = child.State
@@ -1355,16 +1366,18 @@ func buildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decis
 		// has no lineage to recurse into.
 		if !hasMeta {
 			node := TreeNode{
-				ID:         le.SessionID,
-				Ref:        liveRefMap[le.SessionID],
-				State:      stateFor(le.SessionID),
-				AskPending: askPendingFor(le.SessionID),
-				Dormant:    dormantFor(le.SessionID),
-				Kind:       "session",
-				Title:      ShortID(le.SessionID),
-				CreatedAt:  le.StartedAt,
-				UpdatedAt:  le.StartedAt,
-				Age:        AgeString(le.StartedAt),
+				ID:            le.SessionID,
+				Ref:           liveRefMap[le.SessionID],
+				State:         stateFor(le.SessionID),
+				AskPending:    askPendingFor(le.SessionID),
+				Dormant:       dormantFor(le.SessionID),
+				Kind:          "session",
+				Title:         ShortID(le.SessionID),
+				CreatedAt:     le.StartedAt,
+				UpdatedAt:     le.StartedAt,
+				Age:           AgeString(le.StartedAt),
+				RunningJobs:   appwire.CloneEvenerJobs(le.RunningJobs),
+				CompletedJobs: appwire.CloneEvenerJobs(le.CompletedJobs),
 			}
 			liveNodes = append(liveNodes, node)
 			continue
@@ -1449,11 +1462,13 @@ func buildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decis
 			continue
 		}
 		node := TreeNode{
-			ID:         le.SessionID,
-			State:      st,
-			Kind:       "session",
-			AskPending: le.PendingAsk,
-			Dormant:    dormantFor(le.SessionID),
+			ID:            le.SessionID,
+			State:         st,
+			Kind:          "session",
+			AskPending:    le.PendingAsk,
+			Dormant:       dormantFor(le.SessionID),
+			RunningJobs:   appwire.CloneEvenerJobs(le.RunningJobs),
+			CompletedJobs: appwire.CloneEvenerJobs(le.CompletedJobs),
 		}
 		if meta != nil {
 			node.Title = nodeTitle(*meta, nodeKind(*meta))
@@ -1650,7 +1665,7 @@ func clusterable(n TreeNode) bool {
 	if n.Kind != "session" {
 		return false
 	}
-	if len(n.Children) > 0 {
+	if len(n.Children) > 0 || len(n.RunningJobs) > 0 || len(n.CompletedJobs) > 0 {
 		return false
 	}
 	return n.State == "idle" || n.State == "ended"

--- a/cmd/evener-hub/internal/hubcore/tree_live_subagents_test.go
+++ b/cmd/evener-hub/internal/hubcore/tree_live_subagents_test.go
@@ -55,6 +55,43 @@ func TestBuildTreeLiveNestsActiveSubagentUnderParent(t *testing.T) {
 	}
 }
 
+func TestBuildTreeCarriesSessionJobsForNavigation(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	metas := []schema.SessionMeta{{ID: "parent", CreatedAt: now, UpdatedAt: now, EnvInfo: schema.EnvironmentInfo{WorkingDir: "/projects/evener"}}}
+	live := []LiveEntry{{
+		PID: 1, SessionID: "parent", Status: appwire.ThreadStatusIdle,
+		RunningJobs:   []appwire.EvenerJobInfo{{JobID: "job-running", JobType: "shell", Status: "running"}},
+		CompletedJobs: []appwire.EvenerJobInfo{{JobID: "job-completed", JobType: "shell", Status: "completed"}},
+	}}
+
+	tree := BuildTreeAt(metas, live, nil, now)
+	if len(tree.Live) != 1 {
+		t.Fatalf("Live tier has %d rows, want one parent", len(tree.Live))
+	}
+	parent := tree.Live[0]
+	if len(parent.RunningJobs) != 1 || parent.RunningJobs[0].JobID != "job-running" {
+		t.Fatalf("running jobs = %+v", parent.RunningJobs)
+	}
+	if len(parent.CompletedJobs) != 1 || parent.CompletedJobs[0].JobID != "job-completed" {
+		t.Fatalf("completed jobs = %+v", parent.CompletedJobs)
+	}
+	if len(tree.Projects) != 1 || !tree.Projects[0].Expanded || tree.Projects[0].RollupLive != 1 {
+		t.Fatalf("project job rollup = %+v, want expanded with one live task", tree.Projects)
+	}
+}
+
+func TestBuildTreeNeedsYouCarriesSessionJobs(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	metas := []schema.SessionMeta{{ID: "parent", CreatedAt: now, UpdatedAt: now, EnvInfo: schema.EnvironmentInfo{WorkingDir: "/projects/evener"}}}
+	tree := BuildTreeAt(metas, []LiveEntry{{
+		PID: 1, SessionID: "parent", Status: appwire.ThreadStatusAwaiting,
+		RunningJobs: []appwire.EvenerJobInfo{{JobID: "job-running", JobType: "shell", Status: "running"}},
+	}}, nil, now)
+	if len(tree.NeedsYou) != 1 || len(tree.NeedsYou[0].RunningJobs) != 1 || tree.NeedsYou[0].RunningJobs[0].JobID != "job-running" {
+		t.Fatalf("needs-you job projection = %+v, want active job", tree.NeedsYou)
+	}
+}
+
 func TestBuildTreeLiveExcludesSubagentWhoseParentIsLive(t *testing.T) {
 	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
 	metas := []schema.SessionMeta{

--- a/cmd/evener-hub/internal/hubcore/tree_test.go
+++ b/cmd/evener-hub/internal/hubcore/tree_test.go
@@ -944,6 +944,33 @@ func fuzzScenarioBuildTree_ClustersRepeatedIdleTitles(t *testing.T) {
 	}
 }
 
+func TestBuildTreeDoesNotClusterSessionWithJobs(t *testing.T) {
+	now := time.Now()
+	metas := make([]schema.SessionMeta, 0, 4)
+	for i := range 4 {
+		metas = append(metas, schema.SessionMeta{
+			ID:        "01JOB" + string(rune('A'+i)),
+			Name:      "repeatable work",
+			UpdatedAt: now.Add(-time.Duration(i) * time.Hour),
+			EnvInfo:   schema.EnvironmentInfo{WorkingDir: "/projects/evener-jobs"},
+		})
+	}
+	tree := buildTree(metas, []LiveEntry{{
+		PID: 1, SessionID: metas[0].ID, Status: appwire.ThreadStatusIdle,
+		RunningJobs: []appwire.EvenerJobInfo{{JobID: "job-running", JobType: "shell", Status: "running"}},
+	}})
+	project := projectByName(t, tree, "evener-jobs")
+	sessions := allSessions(project)
+	if len(sessions) != 4 {
+		t.Fatalf("sessions = %d, want four unclustered rows", len(sessions))
+	}
+	for _, session := range sessions {
+		if session.Kind == "cluster" {
+			t.Fatalf("session with active job was hidden in cluster %q", session.Title)
+		}
+	}
+}
+
 func fuzzScenarioBuildTree_DoesNotClusterLiveRepeatedTitles(t *testing.T) {
 	// A live/needs-you member must keep all repeated-title sessions un-clustered
 	// so live signal is never hidden behind a fold.

--- a/cmd/evener-hub/navigation_projection.go
+++ b/cmd/evener-hub/navigation_projection.go
@@ -11,6 +11,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
 	"primeradiant.com/evener/hubapi"
 )
@@ -261,6 +262,8 @@ func cloneNavigationLiveEntries(in []hubcore.LiveEntry) []hubcore.LiveEntry {
 	for i, entry := range in {
 		out[i] = entry
 		out[i].RunningSubagentIDs = append([]string(nil), entry.RunningSubagentIDs...)
+		out[i].RunningJobs = appwire.CloneEvenerJobs(entry.RunningJobs)
+		out[i].CompletedJobs = appwire.CloneEvenerJobs(entry.CompletedJobs)
 		if entry.RunningSubagentStates != nil {
 			out[i].RunningSubagentStates = make(map[string]string, len(entry.RunningSubagentStates))
 			maps.Copy(out[i].RunningSubagentStates, entry.RunningSubagentStates)
@@ -418,6 +421,13 @@ func validateNavigationNodesContext(ctx context.Context, rows []hubcore.TreeNode
 		}
 		if _, err := navigationNodeRef(node); err != nil {
 			return err
+		}
+		for _, jobs := range [2][]appwire.EvenerJobInfo{node.RunningJobs, node.CompletedJobs} {
+			for _, job := range jobs {
+				if err := validateNavigationIdentity("job ID", job.JobID, false); err != nil {
+					return err
+				}
+			}
 		}
 		if err := validateNavigationNodesContext(ctx, node.Children); err != nil {
 			return err
@@ -1037,7 +1047,42 @@ func (p navigationProjector) projectShallow(node hubcore.TreeNode) hubapi.Naviga
 		updatedAt = &updated
 	}
 	pinned := p.projection.pinSectionFor(node.ID, ref.String()) != ""
-	return hubapi.NavigationSessionSummary{Ref: ref.String(), HostID: ref.HostID, SessionID: ref.SessionID, Title: truncateNavigationRunes(node.Title, maxNavigationTitleRunes), Project: truncateNavigationRunes(node.Project, maxNavigationLabelRunes), State: node.State, Kind: node.Kind, Branch: truncateNavigationRunes(node.Branch, maxNavigationLabelRunes), ClusterCount: node.ClusterCount, Favorite: !pinned && p.projection.sessionFavorite(node.ID, ref.String()), Rename: p.projection.renameable(node.ID, ref.String()), Live: p.projection.isLive(node.ID, ref.String()) && hubcore.NormalizeState(node.State) != "ended", AskPending: node.AskPending, Dormant: node.Dormant, UpdatedAt: updatedAt, MoreSubagents: node.MoreSubagents, Children: hubapi.NavigationArray[hubapi.NavigationSessionSummary]{}}
+	return hubapi.NavigationSessionSummary{
+		Ref:           ref.String(),
+		HostID:        ref.HostID,
+		SessionID:     ref.SessionID,
+		Title:         truncateNavigationRunes(node.Title, maxNavigationTitleRunes),
+		Project:       truncateNavigationRunes(node.Project, maxNavigationLabelRunes),
+		State:         node.State,
+		Kind:          node.Kind,
+		Branch:        truncateNavigationRunes(node.Branch, maxNavigationLabelRunes),
+		ClusterCount:  node.ClusterCount,
+		Favorite:      !pinned && p.projection.sessionFavorite(node.ID, ref.String()),
+		Rename:        p.projection.renameable(node.ID, ref.String()),
+		Live:          p.projection.isLive(node.ID, ref.String()) && hubcore.NormalizeState(node.State) != "ended",
+		AskPending:    node.AskPending,
+		Dormant:       node.Dormant,
+		UpdatedAt:     updatedAt,
+		MoreSubagents: node.MoreSubagents,
+		RunningJobs:   navigationJobs(node.RunningJobs),
+		CompletedJobs: navigationJobs(node.CompletedJobs),
+		Children:      hubapi.NavigationArray[hubapi.NavigationSessionSummary]{},
+	}
+}
+
+func navigationJobs(jobs []appwire.EvenerJobInfo) hubapi.NavigationArray[hubapi.NavigationJobSummary] {
+	out := make(hubapi.NavigationArray[hubapi.NavigationJobSummary], 0, len(jobs))
+	for _, job := range jobs {
+		out = append(out, hubapi.NavigationJobSummary{
+			JobID:   job.JobID,
+			JobType: job.JobType,
+			Status:  job.Status,
+			Command: truncateNavigationRunes(job.Command, maxNavigationLabelRunes),
+			Task:    truncateNavigationRunes(job.Task, maxNavigationLabelRunes),
+			Reason:  truncateNavigationRunes(job.Reason, maxNavigationLabelRunes),
+		})
+	}
+	return out
 }
 
 func (p navigationProjection) isLive(id, ref string) bool {
@@ -1079,6 +1124,8 @@ func cloneNavigationSummary(summary hubapi.NavigationSessionSummary) hubapi.Navi
 		updated := *summary.UpdatedAt
 		clone.UpdatedAt = &updated
 	}
+	clone.RunningJobs = append(hubapi.NavigationArray[hubapi.NavigationJobSummary](nil), summary.RunningJobs...)
+	clone.CompletedJobs = append(hubapi.NavigationArray[hubapi.NavigationJobSummary](nil), summary.CompletedJobs...)
 	clone.Children = make(hubapi.NavigationArray[hubapi.NavigationSessionSummary], len(summary.Children))
 	for index, child := range summary.Children {
 		clone.Children[index] = cloneNavigationSummary(child)

--- a/cmd/evener-hub/navigation_projection_test.go
+++ b/cmd/evener-hub/navigation_projection_test.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
 	"primeradiant.com/evener/hubapi"
 )
@@ -81,6 +82,40 @@ func TestNavigationManifestHasNoRowsAndLocationHasSummary(t *testing.T) {
 	}
 	if _, ok := any(manifest).(hubapi.NavigationSessionSummary); ok {
 		t.Fatal("manifest must not contain navigation rows")
+	}
+}
+
+func TestNavigationProjectionCarriesActiveAndCompletedJobs(t *testing.T) {
+	project := hubcore.TreeProject{
+		Key:  "project",
+		Name: "project",
+		Current: []hubcore.TreeNode{{
+			ID:    "session-parent",
+			Title: "parent",
+			Kind:  "session",
+			State: "idle",
+			RunningJobs: []appwire.EvenerJobInfo{{
+				JobID: "job-running", JobType: "shell", Status: "running", Command: "go test ./...",
+			}},
+			CompletedJobs: []appwire.EvenerJobInfo{{
+				JobID: "job-completed", JobType: "shell", Status: "completed", Command: "go fmt ./...",
+			}},
+		}},
+	}
+	projection, err := buildNavigationProjection(navigationBuildInputs{GenerationID: "generation", Tree: hubcore.Tree{Projects: []hubcore.TreeProject{project}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource, ok := projection.Project("project")
+	if !ok {
+		t.Fatal("project missing")
+	}
+	row := resource.Current.Sessions[0]
+	if len(row.RunningJobs) != 1 || row.RunningJobs[0].JobID != "job-running" || row.RunningJobs[0].Command != "go test ./..." {
+		t.Fatalf("running jobs = %+v", row.RunningJobs)
+	}
+	if len(row.CompletedJobs) != 1 || row.CompletedJobs[0].JobID != "job-completed" || row.CompletedJobs[0].Status != "completed" {
+		t.Fatalf("completed jobs = %+v", row.CompletedJobs)
 	}
 }
 

--- a/cmd/evener-hub/web_api_tree.go
+++ b/cmd/evener-hub/web_api_tree.go
@@ -606,7 +606,15 @@ func appThreadTreeEntries(thread appwire.Thread) (schema.SessionMeta, hubcore.Li
 		Status:    thread.Status.Type,
 		Project:   project,
 	}
+	entry.RunningJobs, entry.CompletedJobs = hubcore.SplitNonAgentJobs(diagnosticsJobs(thread.Evener.Diagnostics))
 	return meta, entry, true
+}
+
+func diagnosticsJobs(diagnostics *appwire.EvenerDiagnostics) []appwire.EvenerJobInfo {
+	if diagnostics == nil {
+		return nil
+	}
+	return diagnostics.Jobs
 }
 
 // appThreadTreeParentSessionID translates the remote thread lineage into the

--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -1409,6 +1409,8 @@ func agentToServerDetailedStatus(ds agent.DetailedStatus) server.DetailedStatus 
 			ExitCode:         job.ExitCode,
 			OutputBytes:      job.OutputBytes,
 			TranscriptRef:    job.TranscriptRef,
+			Command:          job.Command,
+			Task:             job.Task,
 		})
 	}
 	for _, delegate := range ds.Delegates {

--- a/docs/superpowers/plans/2026-08-30-canonical-relay-demux.md
+++ b/docs/superpowers/plans/2026-08-30-canonical-relay-demux.md
@@ -1,0 +1,174 @@
+# Canonical Relay Demultiplexing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` or `superpowers:executing-plans`. Follow every red/green checkpoint.
+
+**Goal:** Replace per-relay-key upstream listeners with one listener per owner workspace and route each notification once to its authoritative downstream key.
+
+**Architecture:** `RelaySessionSource` resolves a mandatory canonical `appwire.Ref` before acquisition. The existing `relayedThreads` map continues to resolve downstream keys; a second canonical map deduplicates acquisition. One handle owns per-key generation state and one listener. A routing-key normalizer feeds one downstream demultiplexer.
+
+**Spec:** `docs/superpowers/specs/2026-08-30-canonical-relay-demux-design.md`
+
+## Constraints
+
+- Do not change the public AppWire protocol or Codex relay behavior.
+- Preserve the existing `RelayHandoff`/`CaptureSubscriptionWithHandoff` lifecycle, reconnect/resync, unsubscribe, identity replacement, deletion fencing, and malformed/untargeted visibility.
+- Keep PR #686's authenticated subscription-debug endpoint and tests.
+- Do not call source or appserver methods while holding hub locks.
+
+---
+
+### Task 1: Resolve canonical refs before acquisition
+
+**Files:**
+- Modify: `cmd/evener-hub/internal/appsource/source.go`
+- Modify: `cmd/evener-hub/internal/appsource/local_daemon.go`
+- Modify: `cmd/evener-hub/internal/appsource/local_daemon_test.go`
+- Modify: `cmd/evener-hub/internal/appsource/relay_session_test.go`
+- Modify test sources in `cmd/evener-hub/app_relay_test.go` and `app_relay_alias_test.go`
+
+- [ ] Write failing tests: root and read-only child resolve the same nonempty `appwire.Ref`; thread-ID-only resolution returns the owner ref; invalid targets fail; resolution alone does not acquire a lease.
+- [ ] Run red:
+
+```bash
+go test ./cmd/evener-hub/internal/appsource -run 'TestLocalDaemon.*RelaySession' -count=1
+go test ./cmd/evener-hub -run 'TestHubRelay' -count=1
+```
+
+- [ ] Add the source contract:
+
+```go
+type RelaySessionSource interface {
+    ResolveRelaySession(appwire.ThreadReadParams) (appwire.Ref, error)
+    AcquireRelaySession(appwire.Ref) (RelaySessionLease, error)
+}
+```
+
+`ResolveRelaySession` reuses `localDaemonWorkspaceRef`. `AcquireRelaySession` reuses/creates by that ref. Add one private resolve-and-acquire helper for legacy `LocalDaemonSource` call sites.
+
+- [ ] Run green:
+
+```bash
+go test ./cmd/evener-hub/internal/appsource -count=1
+go test ./cmd/evener-hub -run 'TestHubRelay' -count=1
+```
+
+- [ ] Commit named files only: `refactor(hub): resolve canonical relay sessions`
+
+---
+
+### Task 2: Share one handle while preserving relay-key lookup
+
+**Files:**
+- Modify: `cmd/evener-hub/app_relay.go`
+- Modify: `cmd/evener-hub/app_relay_alias_test.go`
+- Modify: `cmd/evener-hub/app_relay_test.go`
+
+- [ ] Tighten the root/child regression to require one acquisition and listener. Add a gate-controlled concurrent root/child read test.
+- [ ] Add a stale-state test: remap a relay key while an earlier read is held; releasing that read must not affect the replacement state.
+- [ ] Run red:
+
+```bash
+go test ./cmd/evener-hub -run '^TestHubRelay(SharedSessionAliases|ConcurrentAliases|StaleRelayKey)' -count=1
+```
+
+- [ ] Keep `relayedThreads map[string]*hubRelayHandle`. Add `canonicalRelays map[appwire.Ref]*hubRelayHandle` and per-handle state:
+
+```go
+type relayKeyState struct {
+    commands int
+    thread   appwire.Thread
+}
+```
+
+The handle owns `map[string]*relayKeyState`; state pointer identity is the generation token.
+
+- [ ] Resolve outside locks; install/join a canonical placeholder under `relayMu`; only the winner calls `AcquireRelaySession` and `Listen`. On failure, remove the exact placeholder, wake waiters, and permit retry.
+- [ ] Bind each read's relay key directly in `relayedThreads`, increment its state count, and return a release closure tied to that state pointer. Record response metadata only if the state remains current. Do not change `RelayHandoff` or `CaptureSubscriptionWithHandoff`.
+- [ ] Run green and race:
+
+```bash
+go test ./cmd/evener-hub -run 'TestHubRelay' -count=1
+go test -race ./cmd/evener-hub -run '^TestHubRelay(SharedSessionAliases|ConcurrentAliases|StaleRelayKey)' -count=1
+```
+
+- [ ] Commit named files only: `refactor(hub): share canonical relay handles`
+
+---
+
+### Task 3: Normalize routing keys and demultiplex once
+
+**Files:**
+- Modify: `cmd/evener-hub/app_relay.go`
+- Modify: `cmd/evener-hub/app_relay_alias_test.go`
+- Modify: `cmd/evener-hub/app_relay_closed_capabilities_test.go`
+
+- [ ] Add a backend behavior table mirroring frontend `notificationRoutingKey`: string `ref` precedence, string `threadId` fallback, untargeted params, malformed JSON, and wrong-typed fields.
+- [ ] Extend fanout regressions: root/child exact-once routing; malformed/untargeted visibility under each current key; unknown/foreign valid keys dropped; distinct root/child image metadata; missing metadata does not borrow another key.
+- [ ] Run red:
+
+```bash
+go test ./cmd/evener-hub -run '^(TestRelayNotificationRoutingKey|TestHubRelaySharedSessionAliases|TestHubRelayRelayKeyImageMetadata)' -count=1
+```
+
+- [ ] Replace `relayNotificationTargets` with `relayNotificationRoutingKey`. For a target, verify `relayedThreads[relayKey]` still names the handle, copy only that key's metadata, enrich, and broadcast once. For compatibility classifications, snapshot current relay keys and broadcast once under each.
+- [ ] Keep deletion-target ownership and acknowledgement behavior unchanged.
+- [ ] Run green and race:
+
+```bash
+go test ./cmd/evener-hub -run 'TestHubRelay|TestRelayNotificationRoutingKey' -count=1
+go test -race ./cmd/evener-hub -run 'TestHubRelay|TestRelayNotificationRoutingKey' -count=1
+```
+
+- [ ] Commit named files only: `refactor(hub): demultiplex relay notifications`
+
+---
+
+### Task 4: Retire relay keys and canonical handles safely
+
+**Files:**
+- Modify: `cmd/evener-hub/app_relay.go`
+- Modify: `cmd/evener-hub/app_relay_test.go`
+- Modify: `cmd/evener-hub/app_rpc_test.go`
+- Modify: `cmd/evener-hub/internal/appsource/relay_session_test.go`
+
+- [ ] Add deterministic lifecycle tests: inactive child state retires while subscribed root keeps the listener; final unsubscribe closes one lease; subscribe at the idle boundary prevents teardown; one reconnect produces one resync/listener; remap moves ownership; relay-key and canonical stop paths retire only the intended handle.
+- [ ] Run red:
+
+```bash
+go test ./cmd/evener-hub -run 'TestHubRelay.*(RelayKey|Idle|Reconnect|Remap|Stop)' -count=1
+```
+
+- [ ] Idle checks snapshot state pointers/counts, unlock, query subscribers, then revalidate `relayedThreads` ownership, state identity, counts, and subscribers before removal. Retire the canonical handle only after its final state disappears.
+- [ ] Keep `stopRelay(relayKey string)` for current call sites. Add a separate canonical teardown helper; neither accepts both namespaces. Clear only relay keys still pointing to the retiring handle.
+- [ ] Preserve the relay-recovery contract from `docs/superpowers/specs/2026-07-27-relay-recovery-thread-resync-design.md`; route its existing `ThreadResyncParams` once through the normal routing-key path.
+- [ ] Run green and race:
+
+```bash
+go test ./cmd/evener-hub ./cmd/evener-hub/internal/appsource -count=1
+go test -race ./cmd/evener-hub -run 'TestHubRelay' -count=1
+go test -race ./cmd/evener-hub/internal/appsource -run 'TestRelaySession' -count=1
+```
+
+- [ ] Commit named files only: `refactor(hub): make relay lifecycle key-aware`
+
+---
+
+### Task 5: Review, verify, and open the stacked PR
+
+- [ ] Run `gofmt` on touched Go files and `git diff --check`.
+- [ ] Run affected and repository gates:
+
+```bash
+go test ./cmd/evener-hub ./cmd/evener-hub/internal/appsource ./internal/appserver -count=1
+go test -race ./cmd/evener-hub -run 'TestHubRelay' -count=1
+go test -race ./cmd/evener-hub/internal/appsource -run 'TestRelaySession' -count=1
+go vet ./cmd/evener-hub/... ./internal/appserver
+make test-web
+make test-web-browser
+make build
+make lint
+```
+
+- [ ] Request independent review of canonical ownership, routing, lock order, reconnect, remap generations, idle races, and test fidelity. Fix every Critical/Important finding and rerun affected gates.
+- [ ] Verify `git status --short --branch`, `git log --oneline fix/hub-relay-alias-dedup..HEAD`, and `git diff --stat fix/hub-relay-alias-dedup...HEAD`.
+- [ ] Push `refactor/hub-canonical-relay-demux` and open a PR against `fix/hub-relay-alias-dedup`. Report URL, commits, tests, and retarget-to-`main` requirement after PR #686 merges.

--- a/docs/superpowers/specs/2026-08-30-canonical-relay-demux-design.md
+++ b/docs/superpowers/specs/2026-08-30-canonical-relay-demux-design.md
@@ -2,136 +2,128 @@
 
 ## Status
 
-Approved direction. This design follows the immediate root/child alias fanout fix in PR #686.
+Approved direction. This design follows the immediate root/child fanout fix in PR #686.
 
 ## Problem
 
-The hub currently keys `hubRelayHandle` by a downstream thread alias. A root session and its in-process descendants use different aliases, but `LocalDaemonSource` maps them to one owner-daemon `RelaySession`. The hub therefore creates several listeners over one upstream stream. Each listener sees every notification, and each handle must filter the stream before broadcasting.
-
-PR #686 stops duplicate delivery by filtering each handle. That repair is intentionally narrow. It leaves redundant listeners, acknowledgements, goroutines, and per-frame target decoding in place.
+The hub currently keys `hubRelayHandle` by the downstream `relayKey`. Root sessions and in-process read-only children have different relay keys, but `LocalDaemonSource` maps them to one owner-workspace relay session. The hub therefore creates several listeners over one upstream stream. PR #686 prevents duplicate delivery by filtering each handle, but redundant listeners, acknowledgements, goroutines, and target decoding remain.
 
 ## Goals
 
 1. Maintain one upstream listener per canonical relay session.
-2. Route each targeted notification once, using its authoritative `ref` first and `threadId` second.
-3. Preserve independent downstream subscriptions for root and child aliases.
-4. Preserve atomic snapshot-to-live handoff semantics for every alias read.
-5. Preserve reconnect, identity replacement, unsubscribe, and idle teardown behavior.
-6. Preserve local output-image enrichment with the target thread's metadata.
-7. Keep malformed or untargeted notifications observable without weakening targeted routing.
+2. Route each targeted notification once, using authoritative `ref` first and `threadId` second.
+3. Preserve independent downstream subscriptions and atomic snapshot-to-live handoffs for every relay key.
+4. Preserve reconnect, identity replacement, unsubscribe, and idle teardown behavior.
+5. Preserve local output-image enrichment with the target relay key's metadata.
+6. Preserve the visibility of malformed or untargeted notifications.
 
 ## Non-goals
 
-- Change the public AppWire protocol.
-- Merge root and child thread models.
+- Change the public AppWire protocol or merge root and child thread models.
 - Change Codex relay behavior. Codex does not implement `RelaySessionSource`.
 - Add payload-based client deduplication.
 
-## Current data flow
-
-For each alias read, `threadRelayTarget` derives a downstream key such as `local:root` or `local:child`. `newHubRelayFunctions` stores a handle under that key. Each handle acquires a lease and calls `Listen`.
-
-`LocalDaemonSource.AcquireRelaySession` instead keys the upstream actor by `WorkspaceRef`, so root and child leases share one `relaySession`. `relaySession.publishNotification` sends each notification to every listener. The hub then broadcasts once per alias handle.
-
-The immediate fix filters those per-handle deliveries. The canonical design removes the redundant handles and listeners.
-
 ## Design
 
-### 1. Give each lease a canonical key
+### 1. Resolve canonical identity before acquisition
 
-Extend `appsource.RelaySessionLease` with:
+Canonical identity belongs to the source. Reuse the existing comparable `appwire.Ref` instead of adding another string-key concept:
 
 ```go
-RelaySessionKey() string
+type RelaySessionSource interface {
+    ResolveRelaySession(appwire.ThreadReadParams) (appwire.Ref, error)
+    AcquireRelaySession(appwire.Ref) (RelaySessionLease, error)
+}
 ```
 
-`LocalDaemonSource` returns the canonical workspace ref already used by its `relaySessions` map. Test leases return an explicit key. An empty key falls back to the downstream relay key for defensive compatibility.
+`LocalDaemonSource.ResolveRelaySession` returns the owner workspace ref already produced by `localDaemonWorkspaceRef`. It rejects an empty ref. `AcquireRelaySession` accepts that resolved ref, so identity cannot change between hub installation and source acquisition.
 
-The hub may need to acquire a short-lived candidate lease before it knows the canonical key. If a handle already owns that key, the hub closes the candidate without calling `Listen` and uses the existing handle. Acquiring a lease is in-memory; connection establishment still happens only for the winning handle.
+The hub resolves without `relayMu`, installs or joins a canonical placeholder under `relayMu`, and only the winner acquires a lease and calls `Listen`. Concurrent root/child reads perform one acquisition and start one listener. Non-atomic sources keep their existing per-relay-key path.
 
-### 2. Key atomic handles canonically
+### 2. Reuse the relay-key registry
 
-For `RelaySessionSource` sources, `relayedThreads` uses the lease's canonical key. Non-atomic sources keep their current downstream key.
+Keep `relayedThreads` in its current role: downstream `relayKey` to `*hubRelayHandle`. Add only `canonicalRelays map[appwire.Ref]*hubRelayHandle` for acquisition deduplication. Several relay keys may point directly to one canonical handle.
 
-Each canonical handle owns:
+Each handle owns one lease/listener and current per-key state:
 
-- one lease and one upstream listener;
-- the source ID;
-- a set of downstream alias keys;
-- per-alias `appwire.Thread` metadata;
-- command ownership and readiness state.
+```go
+type relayKeyState struct {
+    commands int
+    thread   appwire.Thread
+}
+```
 
-A read still calls `handle.lease.Read` with the requested alias. The relay session's command gate serializes reads and preserves each read's snapshot/handoff cut. After the read, the handle records the authoritative response metadata under the downstream alias.
+A handle's `map[string]*relayKeyState` records the keys it currently owns. State pointer identity is the generation token: stale command releases and idle checks cannot modify a replacement state.
 
-### 3. Demultiplex once at fanout
+A read resolves its canonical ref, binds the requested relay key to the handle, and increments that key's command count. It calls the shared lease's `Read` with the original parameters. The existing `RelayHandoff` and `appserver.CaptureSubscriptionWithHandoff` `Prepare`/`Commit`/`Abort` lifecycle remains unchanged; canonicalization changes listener ownership, not the snapshot cut. A successful read records the authoritative response thread only if the key state is still current.
 
-The single fanout loop extracts the notification target:
+Identity remap atomically repoints `relayedThreads[relayKey]`, removes the old handle's state, and creates state on the new handle.
 
-1. valid `ref` wins;
-2. otherwise, nonempty `threadId` is combined with the source ID;
-3. malformed or untargeted payloads use the compatibility fallback below.
+### 3. Normalize routing keys, then demultiplex
 
-For a known target, the hub calls `server.Broadcast` exactly once under that downstream key. A client subscribed to root and child receives a root frame once and a child frame once.
+Replace the current boolean `relayNotificationTargets` predicate with `relayNotificationRoutingKey`, a key-returning Go counterpart to frontend `notificationRoutingKey`. Both use the same behavior table: a string `ref` has precedence; otherwise a string `threadId` is combined with the source ID; otherwise the frame is untargeted. Invalid JSON or wrong-typed routing fields are malformed.
 
-For malformed or untargeted payloads, the hub broadcasts once under every registered alias. This preserves the old visibility behavior for protocol-invalid frames while keeping the valid, cataloged path single-delivery.
+For a targeted frame, fanout converts the returned `appwire.Ref` to its relay key, verifies that `relayedThreads[relayKey]` still names this handle, copies that key's metadata, and calls `server.Broadcast` exactly once. A valid key unknown to this handle is not published by this listener.
 
-### 4. Keep alias metadata on the canonical handle
+For malformed or untargeted frames, fanout snapshots the handle's current relay keys and broadcasts once under each. This retains pre-refactor compatibility for subscribers that rely on protocol-invalid frames. The targeted path never scans all keys.
 
-The handle stores the latest `appwire.Thread` response per alias. Fanout uses the targeted alias's metadata for local output-image enrichment. If metadata is absent, it falls back to the canonical handle's last known thread, matching today's best-effort behavior.
+### 4. Enrich only from the routed key
 
-An identity remap moves the alias from its old canonical handle to the new one. The old handle no longer counts that alias during idle checks.
+Local output-image enrichment uses only the routed key state's `SessionID` and `CWD`. Missing metadata means best-effort enrichment is skipped; metadata from another key is never borrowed. Retiring inactive key state prevents a long-lived root from retaining historical children.
 
-### 5. Idle teardown spans aliases
+### 5. Retire inactive keys and handles
 
-A canonical handle remains live while either condition holds:
+A relay-key state remains live while either condition holds:
 
-- a command owns it;
-- any registered alias has downstream subscribers.
+- one of its reads owns a command reference;
+- `server.SubscriberCount(relayKey) > 0`.
 
-The idle check snapshots the alias set and sums `server.SubscriberCount(alias)`. When all counts reach zero, it removes the canonical handle, removes alias-to-canonical mappings, and closes the lease once.
+An idle check snapshots state pointers and command counts, releases hub locks, and queries subscriber counts. It removes each still-current state with neither owner nor subscriber. It short-circuits once an active key proves the handle cannot retire. The canonical handle retires only after no states remain; retirement deletes the exact canonical placeholder and closes the lease once.
 
-Unsubscribing one child cannot retire a root relay that still has subscribers. Removing the last alias subscriber allows the existing idle timer to retire the handle.
+Final removal revalidates `relayedThreads` ownership, state pointer identity, command counts, and subscriber counts. This preserves the existing subscribe-versus-idle race protection. Unsubscribing one child cannot retire a root relay that remains subscribed.
 
-### 6. Stop and recovery lookup
+### 6. Keep stop and recovery roles explicit
 
-Maintain `aliasToCanonical map[string]string`. `stopRelay` accepts either a canonical key or a downstream alias, preserving current test and recovery call sites.
+Existing alias-facing and test call sites continue to use `stopRelay(relayKey string)`, which resolves through `relayedThreads`. Internal canonical teardown is a separate helper accepting an `appwire.Ref` or handle. Neither function accepts both namespaces. Removal clears only relay keys still pointing to the retired handle.
 
-Reconnect remains owned by `relaySession`. A recovered canonical listener emits one resync notification through the demultiplexer. The notification's authoritative target selects the downstream alias; aliases that need snapshot replacement still follow their existing `evener/thread/resync` read path.
+Reconnect remains owned by `relaySession` under `2026-07-27-relay-recovery-thread-resync-design.md`. The only delta here is that one recovered canonical listener routes the existing typed `ThreadResyncParams` notification exactly once through `relayNotificationRoutingKey`; snapshot replacement continues through the established `evener/thread/resync` read path.
 
 ## Concurrency and lock order
 
-- Resolve/acquire the candidate lease without `relayMu`.
-- Hold `relayMu` only to install/find handles, update alias maps and metadata, and count command owners.
-- Never call `Listen`, `Read`, `Close`, `server.Broadcast`, or `server.SubscriberCount` while holding `relayMu`.
-- Snapshot aliases/metadata under `relayMu`, then perform routing and subscriber-count calls after unlocking.
-- Close losing candidate leases after unlocking.
-
-This keeps external callbacks outside the hub registry lock and preserves the existing appserver lock order.
+- Resolve source identity and call `AcquireRelaySession`, `Listen`, `Read`, and `Close` without hub locks.
+- `relayMu` protects canonical placeholder installation and `relayedThreads` ownership changes.
+- A handle mutex protects its key states, metadata, readiness, and command counts.
+- When both are required, acquire `relayMu` before a handle mutex; never hold two handle mutexes simultaneously.
+- Never call `server.Broadcast` or `server.SubscriberCount` while holding a hub lock.
+- Targeted routing copies one key's metadata. Only compatibility fanout and idle checks snapshot all keys.
 
 ## Failure handling
 
-- If candidate acquisition fails, no registry state changes.
-- If the winning handle fails before readiness, waiters may install their still-open candidate under the same canonical key.
-- If a target cannot be parsed, compatibility fanout keeps the frame visible.
-- If an alias remaps while an old handle is draining, handle identity checks prevent stale fanout from publishing as the new owner.
+- Resolution or winning acquisition failure leaves no relay-key state behind and wakes placeholder waiters with the error.
+- A later caller may replace a failed placeholder and retry acquisition.
+- Missing canonical refs are errors; there is no downstream-key fallback.
+- Malformed and untargeted frames retain compatibility fanout.
+- State identity checks prevent stale reads, idle checks, or draining handles from acting on a remapped relay key.
 
 ## Verification
 
-### Required deterministic tests
+Required deterministic tests:
 
-1. Root and child aliases acquire one canonical handle and one listener.
-2. A root+child client receives one root delta; a root-only client receives one.
-3. A root+child client receives one child delta; a root-only client receives none.
-4. Thread-ID-only reads route notifications by the authoritative response ref.
-5. Malformed and untargeted notifications retain compatibility fanout.
-6. Concurrent root/child reads install one canonical handle.
-7. Unsubscribing one alias keeps the handle alive while another alias is subscribed.
-8. Removing the final alias subscriber retires the handle and closes one lease.
-9. Reconnect emits one resync and resumes one upstream listener.
-10. Alias identity remap moves subscriber accounting to the new canonical handle.
-11. Target-specific image enrichment uses the correct alias metadata.
+1. Root and child relay keys resolve one canonical ref, acquire one lease, and start one listener.
+2. Root+child and root-only clients receive each root notification once.
+3. A root+child client receives each child notification once; a root-only client receives none.
+4. Thread-ID-only reads route by the authoritative response ref.
+5. Malformed and untargeted notifications remain visible under every current relay key.
+6. Routing-key behavior matches the frontend table; unknown/foreign valid keys are not published.
+7. Concurrent root/child reads install one handle and listener.
+8. Target-specific image enrichment uses only that relay key's metadata.
+9. An inactive child key retires while another key keeps the handle alive.
+10. Removing the final subscriber retires the handle and closes one lease.
+11. Reconnect emits one resync and resumes one upstream listener.
+12. Identity remap moves ownership and subscriber accounting; stale releases cannot affect the replacement.
+13. Relay-key and canonical stop paths retire the intended handle only.
 
-Run targeted tests red before implementation, then the hub/appsource race tests, full affected packages, vet, frontend gates, build, and lint.
+Run each new regression red before implementation, then the hub/appsource race tests, full affected packages, vet, frontend gates, build, and lint.
 
 ## Delivery
 

--- a/docs/superpowers/specs/2026-08-30-canonical-relay-demux-design.md
+++ b/docs/superpowers/specs/2026-08-30-canonical-relay-demux-design.md
@@ -1,0 +1,138 @@
+# Canonical Relay and Downstream Demultiplexing
+
+## Status
+
+Approved direction. This design follows the immediate root/child alias fanout fix in PR #686.
+
+## Problem
+
+The hub currently keys `hubRelayHandle` by a downstream thread alias. A root session and its in-process descendants use different aliases, but `LocalDaemonSource` maps them to one owner-daemon `RelaySession`. The hub therefore creates several listeners over one upstream stream. Each listener sees every notification, and each handle must filter the stream before broadcasting.
+
+PR #686 stops duplicate delivery by filtering each handle. That repair is intentionally narrow. It leaves redundant listeners, acknowledgements, goroutines, and per-frame target decoding in place.
+
+## Goals
+
+1. Maintain one upstream listener per canonical relay session.
+2. Route each targeted notification once, using its authoritative `ref` first and `threadId` second.
+3. Preserve independent downstream subscriptions for root and child aliases.
+4. Preserve atomic snapshot-to-live handoff semantics for every alias read.
+5. Preserve reconnect, identity replacement, unsubscribe, and idle teardown behavior.
+6. Preserve local output-image enrichment with the target thread's metadata.
+7. Keep malformed or untargeted notifications observable without weakening targeted routing.
+
+## Non-goals
+
+- Change the public AppWire protocol.
+- Merge root and child thread models.
+- Change Codex relay behavior. Codex does not implement `RelaySessionSource`.
+- Add payload-based client deduplication.
+
+## Current data flow
+
+For each alias read, `threadRelayTarget` derives a downstream key such as `local:root` or `local:child`. `newHubRelayFunctions` stores a handle under that key. Each handle acquires a lease and calls `Listen`.
+
+`LocalDaemonSource.AcquireRelaySession` instead keys the upstream actor by `WorkspaceRef`, so root and child leases share one `relaySession`. `relaySession.publishNotification` sends each notification to every listener. The hub then broadcasts once per alias handle.
+
+The immediate fix filters those per-handle deliveries. The canonical design removes the redundant handles and listeners.
+
+## Design
+
+### 1. Give each lease a canonical key
+
+Extend `appsource.RelaySessionLease` with:
+
+```go
+RelaySessionKey() string
+```
+
+`LocalDaemonSource` returns the canonical workspace ref already used by its `relaySessions` map. Test leases return an explicit key. An empty key falls back to the downstream relay key for defensive compatibility.
+
+The hub may need to acquire a short-lived candidate lease before it knows the canonical key. If a handle already owns that key, the hub closes the candidate without calling `Listen` and uses the existing handle. Acquiring a lease is in-memory; connection establishment still happens only for the winning handle.
+
+### 2. Key atomic handles canonically
+
+For `RelaySessionSource` sources, `relayedThreads` uses the lease's canonical key. Non-atomic sources keep their current downstream key.
+
+Each canonical handle owns:
+
+- one lease and one upstream listener;
+- the source ID;
+- a set of downstream alias keys;
+- per-alias `appwire.Thread` metadata;
+- command ownership and readiness state.
+
+A read still calls `handle.lease.Read` with the requested alias. The relay session's command gate serializes reads and preserves each read's snapshot/handoff cut. After the read, the handle records the authoritative response metadata under the downstream alias.
+
+### 3. Demultiplex once at fanout
+
+The single fanout loop extracts the notification target:
+
+1. valid `ref` wins;
+2. otherwise, nonempty `threadId` is combined with the source ID;
+3. malformed or untargeted payloads use the compatibility fallback below.
+
+For a known target, the hub calls `server.Broadcast` exactly once under that downstream key. A client subscribed to root and child receives a root frame once and a child frame once.
+
+For malformed or untargeted payloads, the hub broadcasts once under every registered alias. This preserves the old visibility behavior for protocol-invalid frames while keeping the valid, cataloged path single-delivery.
+
+### 4. Keep alias metadata on the canonical handle
+
+The handle stores the latest `appwire.Thread` response per alias. Fanout uses the targeted alias's metadata for local output-image enrichment. If metadata is absent, it falls back to the canonical handle's last known thread, matching today's best-effort behavior.
+
+An identity remap moves the alias from its old canonical handle to the new one. The old handle no longer counts that alias during idle checks.
+
+### 5. Idle teardown spans aliases
+
+A canonical handle remains live while either condition holds:
+
+- a command owns it;
+- any registered alias has downstream subscribers.
+
+The idle check snapshots the alias set and sums `server.SubscriberCount(alias)`. When all counts reach zero, it removes the canonical handle, removes alias-to-canonical mappings, and closes the lease once.
+
+Unsubscribing one child cannot retire a root relay that still has subscribers. Removing the last alias subscriber allows the existing idle timer to retire the handle.
+
+### 6. Stop and recovery lookup
+
+Maintain `aliasToCanonical map[string]string`. `stopRelay` accepts either a canonical key or a downstream alias, preserving current test and recovery call sites.
+
+Reconnect remains owned by `relaySession`. A recovered canonical listener emits one resync notification through the demultiplexer. The notification's authoritative target selects the downstream alias; aliases that need snapshot replacement still follow their existing `evener/thread/resync` read path.
+
+## Concurrency and lock order
+
+- Resolve/acquire the candidate lease without `relayMu`.
+- Hold `relayMu` only to install/find handles, update alias maps and metadata, and count command owners.
+- Never call `Listen`, `Read`, `Close`, `server.Broadcast`, or `server.SubscriberCount` while holding `relayMu`.
+- Snapshot aliases/metadata under `relayMu`, then perform routing and subscriber-count calls after unlocking.
+- Close losing candidate leases after unlocking.
+
+This keeps external callbacks outside the hub registry lock and preserves the existing appserver lock order.
+
+## Failure handling
+
+- If candidate acquisition fails, no registry state changes.
+- If the winning handle fails before readiness, waiters may install their still-open candidate under the same canonical key.
+- If a target cannot be parsed, compatibility fanout keeps the frame visible.
+- If an alias remaps while an old handle is draining, handle identity checks prevent stale fanout from publishing as the new owner.
+
+## Verification
+
+### Required deterministic tests
+
+1. Root and child aliases acquire one canonical handle and one listener.
+2. A root+child client receives one root delta; a root-only client receives one.
+3. A root+child client receives one child delta; a root-only client receives none.
+4. Thread-ID-only reads route notifications by the authoritative response ref.
+5. Malformed and untargeted notifications retain compatibility fanout.
+6. Concurrent root/child reads install one canonical handle.
+7. Unsubscribing one alias keeps the handle alive while another alias is subscribed.
+8. Removing the final alias subscriber retires the handle and closes one lease.
+9. Reconnect emits one resync and resumes one upstream listener.
+10. Alias identity remap moves subscriber accounting to the new canonical handle.
+11. Target-specific image enrichment uses the correct alias metadata.
+
+Run targeted tests red before implementation, then the hub/appsource race tests, full affected packages, vet, frontend gates, build, and lint.
+
+## Delivery
+
+Implement on `refactor/hub-canonical-relay-demux`, stacked on PR #686. Open the second PR against `fix/hub-relay-alias-dedup` until #686 merges; then retarget it to `main`.

--- a/hubapi/navigation.go
+++ b/hubapi/navigation.go
@@ -143,6 +143,17 @@ type NavigationSessionLocation struct {
 	Session      *NavigationSessionSummary `json:"session,omitempty"`
 }
 
+// NavigationJobSummary is the compact non-delegate job row shown beneath its
+// owning session. Delegate jobs remain represented as session children.
+type NavigationJobSummary struct {
+	JobID   string `json:"job_id"`
+	JobType string `json:"job_type"`
+	Status  string `json:"status"`
+	Command string `json:"command,omitempty"`
+	Task    string `json:"task,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+}
+
 // NavigationSessionSummary is the bounded recursive navigation row shape.
 type NavigationSessionSummary struct {
 	Ref                string                                    `json:"ref"`
@@ -162,6 +173,8 @@ type NavigationSessionSummary struct {
 	UpdatedAt          *time.Time                                `json:"updated_at,omitempty"`
 	MoreSubagents      int                                       `json:"more_subagents,omitempty"`
 	OmittedDescendants int                                       `json:"omitted_descendants,omitempty"`
+	RunningJobs        NavigationArray[NavigationJobSummary]     `json:"running_jobs,omitempty"`
+	CompletedJobs      NavigationArray[NavigationJobSummary]     `json:"completed_jobs,omitempty"`
 	Children           NavigationArray[NavigationSessionSummary] `json:"children"`
 }
 

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -2044,6 +2044,8 @@ func appDiagnosticsFromDetailedStatus(ds DetailedStatus) *appwire.EvenerDiagnost
 			ExitCode:         job.ExitCode,
 			OutputBytes:      job.OutputBytes,
 			TranscriptRef:    job.TranscriptRef,
+			Command:          job.Command,
+			Task:             job.Task,
 		})
 	}
 	for _, delegate := range ds.Delegates {

--- a/server/server.go
+++ b/server/server.go
@@ -88,6 +88,8 @@ type JobStatusInfo struct {
 	ExitCode         *int   `json:"exit_code,omitempty"`
 	OutputBytes      int64  `json:"output_bytes"`
 	TranscriptRef    string `json:"transcript_ref,omitempty"`
+	Command          string `json:"command,omitempty"`
+	Task             string `json:"task,omitempty"`
 }
 
 type DelegateStatusInfo struct {


### PR DESCRIPTION
## Summary
- show running non-delegate job counts beside running subagent counts
- show green activity when the session, subagents, or jobs are active
- render active jobs with active subagents and separate inactive/completed disclosures
- preserve delegate jobs as subagent rows without duplication

## Verification
- make test
- make test-web
- make test-web-browser
- make vet
- make lint
- make build