### PR TITLE
test(web): size the O(1)-append tripwire for gate load (#672)

### DIFF
--- a/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
@@ -524,7 +524,19 @@ function agentMessageDelta(delta: string): AnyNotification {
   };
 }
 
-test("every delta's fold appends onto the SAME backing array, which grows by exactly one (O(1) append)", () => {
+// The O(1)-append test's ceiling is a tripwire for a hang, not a
+// responsiveness bar: its 20,000-delta fold measures ~0.4s in isolation and
+// in-suite, so the 5s default holds ~12x headroom — until the whole gate's
+// concurrent Go and vitest streams saturate the runner and a single worker
+// loses more than that (the #672 CI failure: 5,000ms exceeded, same tree
+// green on rerun). Sized like hookTimeout/WARM_ROUTE_TRIPWIRE_MS: well above
+// the work, still bounded, and a regression to O(n^2) blows through it
+// regardless (a copy per delta is ~200M string copies at N=20,000).
+const O1_APPEND_TRIPWIRE_MS = 30_000;
+
+test("every delta's fold appends onto the SAME backing array, which grows by exactly one (O(1) append)", {
+  timeout: O1_APPEND_TRIPWIRE_MS,
+}, () => {
   // White-box on purpose (chunkViewBackingForTests): chunk strings are
   // PRIMITIVES, so element-level identity checks survive a per-delta copy
   // ([...chunks, delta] preserves every string reference) — only the


### PR DESCRIPTION
## Summary

`every delta's fold appends onto the SAME backing array` (#672) measures **~0.4s** both isolated and in-suite — ~12x headroom under vitest's default 5s `testTimeout`. Under full-gate CI load (concurrent Go + vitest streams saturating the runner), a single worker occasionally loses more than that: the #672 failure, `Test timed out in 5000ms` on a tree green on rerun.

This gives the test its own ceiling: a named `O1_APPEND_TRIPWIRE_MS = 30_000` via vitest's per-test `{ timeout }` options — sized the way this codebase already sizes `hookTimeout: 60_000` (vite.config.ts: "The work is real and awaitable, so the ceiling is the wrong lever to leave at its default; it stays a tripwire for a genuine hang, just one sized for the work it has to cover") and `WARM_ROUTE_TRIPWIRE_MS = 10_000` (App.test.tsx).

The perf guard is **not** weakened: a regression to O(n²) is ~200M string copies at N=20,000 and blows through 30s as easily as 5s. Reducing N would weaken it and was deliberately not taken.

## Verification

- Full frontend suite: **390 files / 7,404 tests pass**
- `npm run typecheck` — clean
- `npx biome check src` — clean
- Confirmed vitest applies the per-test options timeout (a probe test with `{ timeout: 50 }` failed at exactly 50ms)
- code-simplifier pass: no change warranted (comment length, constant name `<cause>_TRIPWIRE_MS` convention, options-object form, and scoping all reviewed against house precedent)

Fixes #672