### PR TITLE
fix(fuzz): drop the last grep -q pipeline in the oracle-audit selftest (#586)

### DIFF
--- a/scripts/fuzz/fuzz-oracle-audit-selftest.sh
+++ b/scripts/fuzz/fuzz-oracle-audit-selftest.sh
@@ -133,8 +133,15 @@ assert_str_has "$out" "does not compile" "non-compiling mutation: diagnosed as a
 assert_str_has "$out" "UNAUDITED: .:FuzzUnaudited" "gap report flags the unaudited target"
 assert_eq "$rc" "1" "audit exits non-zero when an oracle is blind or a patch rotted"
 # The disposable worktree (mktemp'd as fuzz-oracle-audit.XXXX) is gone; only the
-# throwaway repo's own main worktree should remain registered.
-if git -C "$repo" worktree list | grep -q 'fuzz-oracle-audit\.'; then
+# throwaway repo's own main worktree should remain registered. Pipe-free on
+# purpose (#586), same producer-SIGPIPE shape as assert_str_has above (#277):
+# `grep -q` exits at the first hit while git is still writing, so a >pipe-buffer
+# listing would make a true match read as "no worktree left behind" under
+# pipefail (141). Untriggerable today (the listing is short), but one
+# output-size change away. A quoted [[ == *...* ]] is the same
+# literal-substring test with no pipe to break.
+worktrees_left="$(git -C "$repo" worktree list)"
+if [[ "$worktrees_left" == *'fuzz-oracle-audit.'* ]]; then
 	bad "audit left a worktree behind"
 else
 	ok "audit cleaned up its worktree"


### PR DESCRIPTION
## Summary

`fuzz-oracle-audit-selftest.sh:137` piped `git worktree list` into `grep -q` under `set -uo pipefail` — the one remaining producer-into-`grep -q` construct after the #277 fix eliminated the other three sites (#586).

The mechanism (documented on `assert_str_has` in the same file): `grep -q` exits at its first hit while the producer is still writing; once the output exceeds the pipe buffer, the producer takes SIGPIPE, pipefail reports 141, and the `if` reads a **true** match as false — the selftest would report "audit cleaned up its worktree" with a worktree still behind. Untriggerable today (the listing is short), but one output-size change away from reintroducing the exact false-failure mode #277 fixed.

Converted to the pipe-free idiom the fixed sites use: capture the listing with command substitution, then a quoted `[[ == *...* ]]` literal-substring test (the quoted dot preserves the old regex `fuzz-oracle-audit\.` semantics — `fuzz-oracle-auditfoo` still does not match).

## Verification

- `bash -n` clean
- Full selftest: **11 checks, 0 failed**, including the changed site's "audit cleaned up its worktree"
- `make fuzz-oracle-audit-selftest` — green
- `make lint-naming`, `make secret-scan`, `make test-dev-tooling` — green
- shellcheck findings are all pre-existing lines (14/28/99/127), none in the changed region
- code-simplifier pass applied (comment cross-references `assert_str_has` instead of restating the #277 mechanism; glob fidelity, variable name, and construct choice confirmed)

Fixes #586