### PR TITLE
feat(appwire): log the client keepalive's connection teardown (#154)

### DIFF
--- a/appwire/client.go
+++ b/appwire/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -159,7 +160,12 @@ func requestIDObserverFrom(ctx context.Context) func(ID) {
 // runClientKeepalive pings the peer every interval and closes the transport if
 // a ping goes unanswered within timeout. Closing unblocks the read loop's Recv,
 // which fails pending requests and closes the notifications channel — so a
-// silently-dead daemon surfaces as a normal subscription end.
+// silently-dead daemon surfaces as a normal subscription end. The teardown
+// logs one line first: the closed connection then fails every later write
+// with an ordinary transport error, so without the log a pong-timeout
+// teardown under load — e.g. the hub subprocess starved past
+// interval+timeout by concurrent CI gates (#154) — is indistinguishable
+// from a dead hub.
 func runClientKeepalive(ctx context.Context, pinger Pinger, closeFn func() error, interval, timeout time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -172,6 +178,7 @@ func runClientKeepalive(ctx context.Context, pinger Pinger, closeFn func() error
 			err := pinger.Ping(pingCtx)
 			cancel()
 			if err != nil {
+				log.Printf("appwire: keepalive ping failed (ping interval %s, pong timeout %s): %v; closing connection", interval, timeout, err)
 				_ = closeFn()
 				return
 			}

--- a/appwire/client_keepalive_log_test.go
+++ b/appwire/client_keepalive_log_test.go
@@ -1,0 +1,57 @@
+package appwire
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"testing"
+	"time"
+)
+
+// silentPingerTransport is a pingingTransport whose Ping blocks until its
+// context is cancelled and then reports the context error — the shape a hub
+// subprocess starved past the pong deadline presents (issue #154): the ping
+// fails with no transport-level error to distinguish it from a dead socket.
+type silentPingerTransport struct {
+	*pingingTransport
+}
+
+func (s *silentPingerTransport) Ping(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// TestClientKeepaliveLogsTearDown pins the #154 diagnostic: when the client
+// keepalive closes the connection it must emit one self-describing log line
+// naming the keepalive and the ping error. The socket then presents a
+// normal-looking failure ("use of closed network connection" on every later
+// write), so this line is the only artifact that separates a pong-timeout
+// teardown under load from a genuinely dead hub.
+func TestClientKeepaliveLogsTearDown(t *testing.T) {
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(prev) })
+
+	base := newPingingTransport()
+	transport := &silentPingerTransport{base}
+	client := NewClient(transport)
+
+	ctx := t.Context()
+	client.startWithKeepalive(ctx, time.Millisecond, 5*time.Millisecond)
+
+	select {
+	case _, ok := <-client.Notifications():
+		if ok {
+			t.Fatal("expected notifications channel to close, got a value")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("keepalive did not tear down the client")
+	}
+
+	// The log line is written before closeFn runs, and the teardown observed
+	// above is what closeFn caused, so the line is already in the buffer.
+	if !bytes.Contains(buf.Bytes(), []byte("keepalive")) || !bytes.Contains(buf.Bytes(), []byte("ping")) {
+		t.Fatalf("keepalive teardown logged no self-describing line; got:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary

Implements **Option 1** of the #154 ruling: a zero-behavior diagnostic log.

The #154 investigation proved the mechanism but deliberately changed no code: under multi-gate CI load the hub subprocess can be starved past the keepalive window (15s ping / 10s pong); the keepalive fires and closes the connection, after which every later operation fails with an ordinary transport error — `"use of closed network connection"`, the exact strings at #154's Stop and thread/shutdown failure lines, indistinguishable in the logs from a genuinely dead hub. (SIGSTOP for 30s reproduces the string deterministically; 11s does not. 17 bounded-load runs never reproduced it — it needs genuine multi-full-gate starvation.)

This PR adds exactly one `log.Printf` in `runClientKeepalive` before the close fires, naming the keepalive, the configured ping interval and pong timeout, and the ping error — so the next CI occurrence names its cause from the log alone. No teardown decision or timing changes.

Adds `TestClientKeepaliveLogsTearDown` (TDD: written first, red, then green) covering the silent pong-timeout shape — `Ping` blocks until its context expires, no transport-level error — and asserting the self-describing line lands. Server-side mirror deliberately out of scope: the appserver keepalive's teardown already surfaces its error text through the recv loop, and #154's failure was client-side.

## Verification

- New test: red pre-fix, green post-fix (6/6 runs; 18 total keepalive-test passes across those runs)
- Full `appwire` suite — green (`-count=2` and single)
- `appwire/...` + `cmd/evener-hub/...` — all green
- `go vet ./appwire/`, `go build ./...` — clean
- code-simplifier pass applied: restore the captured `log.Writer()` (not a hardcoded `os.Stderr`), replace a redundant polling loop with a direct assertion (the log line provably precedes the observed teardown — happens-before via the channel close `closeFn` causes), and tighten the doc comment

Refs #154