### PR TITLE
feat(web): show jobs and clean up mobile sidebar

### DIFF
--- a/agent/status.go
+++ b/agent/status.go
@@ -44,6 +44,8 @@ type JobStatusInfo struct {
 	TranscriptRef    string `json:"transcript_ref,omitempty"`
 	OutputBytes      int64  `json:"output_bytes"`
 	ExitCode         *int   `json:"exit_code,omitempty"`
+	Command          string `json:"command,omitempty"`
+	Task             string `json:"task,omitempty"`
 }
 
 // DelegateStatusInfo is the stable delegate read model exposed by
@@ -403,6 +405,8 @@ func projectJobStatusInfos(records []*jobstore.JobRecord) []JobStatusInfo {
 			TranscriptRef:    jobTranscriptRef(rec),
 			OutputBytes:      rec.OutputBytes,
 			ExitCode:         rec.ExitCode,
+			Command:          rec.Command,
+			Task:             rec.Task,
 		})
 	}
 	return jobs

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -30,11 +30,12 @@ func newHubSourceRegistry(cfg hubcore.WebConfig) *appsource.Registry {
 					continue
 				}
 				entry := appsource.LocalDaemonEntry{
-					Entry:       item.Entry,
-					SessionID:   item.SessionID,
-					Status:      item.Status,
-					PendingAsk:  item.PendingAsk,
-					RunningJobs: item.RunningJobs,
+					Entry:         item.Entry,
+					SessionID:     item.SessionID,
+					Status:        item.Status,
+					PendingAsk:    item.PendingAsk,
+					RunningJobs:   item.RunningJobs,
+					CompletedJobs: item.CompletedJobs,
 				}
 				entries = append(entries, entry)
 				// In-process descendants are addressed as their own AppWire

--- a/cmd/evener-hub/frontend/scripts/shellguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/shellguard/run.mjs
@@ -31,6 +31,7 @@ const FRONTEND = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 // the scripted tree (12 projects x 10 sessions) overflows it several times
 // over - the exact condition the bug needed.
 const VIEWPORT = { width: 1400, height: 900 };
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
 
 async function measure(cdpEndpoint, vitePort) {
   const page = await connectPage(cdpEndpoint);
@@ -41,6 +42,21 @@ async function measure(cdpEndpoint, vitePort) {
     await evaluate(send, "window.settledShell");
     await waitForFonts(send);
     return JSON.parse(await evaluate(send, "JSON.stringify(window.measureShell())"));
+  } finally {
+    await clearViewportOverride(send);
+    page.close();
+  }
+}
+
+async function measureMobileSidebar(cdpEndpoint, vitePort) {
+  const page = await connectPage(cdpEndpoint);
+  const { send } = page;
+  try {
+    await applyViewport(send, MOBILE_VIEWPORT);
+    await navigateTo(page, `http://127.0.0.1:${vitePort}/shellguard.html`);
+    await evaluate(send, "window.settledShell");
+    await waitForFonts(send);
+    return JSON.parse(await evaluate(send, "JSON.stringify(window.measureMobileSidebar())"));
   } finally {
     await clearViewportOverride(send);
     page.close();
@@ -83,6 +99,54 @@ function assertResult(result) {
       `elements escape the viewport's bottom edge: ${result.leaks.map((l) => `${l.selector} bottom=${l.bottom.toFixed(1)}`).join("; ")}`,
     );
   }
+  return failures;
+}
+
+function assertMobileResult(result) {
+  const failures = [];
+  if (result.errors.length > 0) failures.push(`page errors: ${result.errors.join("; ")}`);
+  if (result.viewport.width !== MOBILE_VIEWPORT.width || result.viewport.height !== MOBILE_VIEWPORT.height) {
+    failures.push(
+      `mobile viewport is ${result.viewport.width}x${result.viewport.height}, expected ${MOBILE_VIEWPORT.width}x${MOBILE_VIEWPORT.height}`,
+    );
+  }
+  if (result.panel === null) {
+    failures.push("mobile Sheet panel is not rendered");
+  } else if (result.panel.overflowY !== "hidden") {
+    failures.push(`mobile Sheet panel overflow-y is ${result.panel.overflowY}, expected hidden`);
+  }
+  if (result.panelBody === null) {
+    failures.push("mobile Sheet body is not rendered");
+  } else {
+    if (result.panelBody.overflowY !== "auto") {
+      failures.push(`mobile Sheet body overflow-y is ${result.panelBody.overflowY}, expected auto`);
+    }
+    if (result.panelBody.scrollHeight <= result.panelBody.clientHeight + 1) {
+      failures.push(
+        `mobile Sheet body is not scrolling its content (scrollHeight ${result.panelBody.scrollHeight}, clientHeight ${result.panelBody.clientHeight})`,
+      );
+    }
+  }
+  if (result.panel !== null && result.panel.scrollHeight > result.panel.clientHeight + 1) {
+    failures.push(
+      `mobile Sheet panel itself scrolls (scrollHeight ${result.panel.scrollHeight}, clientHeight ${result.panel.clientHeight})`,
+    );
+  }
+  if (result.rail === null) failures.push("mobile rail is not rendered inside the Sheet");
+  else if (result.rail.overflowY !== "visible") failures.push(`mobile rail overflow-y is ${result.rail.overflowY}, expected visible`);
+  if (result.railBody === null) failures.push("mobile rail body is not rendered");
+  else if (result.railBody.overflowY !== "visible") {
+    failures.push(`mobile rail body overflow-y is ${result.railBody.overflowY}, expected visible`);
+  }
+  if (result.document.scrollHeight > MOBILE_VIEWPORT.height + 1) {
+    failures.push(
+      `mobile document is ${result.document.scrollHeight}px tall in a ${MOBILE_VIEWPORT.height}px viewport`,
+    );
+  }
+  if (result.searchBox) failures.push("mobile inline search box is still rendered");
+  if (result.resume) failures.push("mobile Jump back in action is still rendered");
+  if (result.hints) failures.push("mobile key-binding hints are still rendered");
+  if (!result.orientation) failures.push("mobile orientation text is missing");
   return failures;
 }
 
@@ -131,12 +195,13 @@ async function main() {
       startupDeadline.clear();
     }
     const result = await measure(cdpEndpoint, vitePort);
-    const failures = assertResult(result);
+    const mobileResult = await measureMobileSidebar(cdpEndpoint, vitePort);
+    const failures = [...assertResult(result), ...assertMobileResult(mobileResult)];
     if (failures.length === 0) {
       console.log(
         `shellguard ok: document ${result.document.scrollHeight}px in a ${result.viewport.height}px viewport, ` +
           `rail body scrolls (${result.railBody.scrollHeight}px in ${result.railBody.clientHeight}px), ` +
-          `${result.treeRows} tree rows`,
+          `${result.treeRows} tree rows; mobile Sheet body scrolls (${mobileResult.panelBody.scrollHeight}px in ${mobileResult.panelBody.clientHeight}px)`,
       );
     } else {
       for (const failure of failures) console.error(`shellguard FAIL: ${failure}`);
@@ -147,6 +212,7 @@ async function main() {
         console.error(`  ${link.selector} height=${link.height.toFixed(1)} ${JSON.stringify(link.computed)}`);
       }
       console.error(`railBody: ${JSON.stringify(result.railBody)}`);
+      console.error(`mobile sidebar: ${JSON.stringify(mobileResult)}`);
       console.error(`experiments: ${JSON.stringify(result.experiments)}`);
       console.error("positioned elements under the rail:");
       for (const el of result.positioned ?? []) {

--- a/cmd/evener-hub/frontend/src/dev/shellguard-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/shellguard-entry.tsx
@@ -342,13 +342,60 @@ function measureShell() {
   };
 }
 
+function scrollMetrics(el: Element | null) {
+  if (el === null) return null;
+  const htmlEl = el as HTMLElement;
+  const computed = getComputedStyle(el);
+  return {
+    clientHeight: htmlEl.clientHeight,
+    scrollHeight: htmlEl.scrollHeight,
+    overflowX: computed.overflowX,
+    overflowY: computed.overflowY,
+    box: rect(el),
+  };
+}
+
+function measureMobileSidebar() {
+  const settings = document.querySelector("[data-testid='rail-settings']");
+  const footer = settings?.parentElement ?? null;
+  const rail = footer?.parentElement ?? null;
+  const railBody = footer?.previousElementSibling ?? null;
+  const panelBody = rail?.parentElement ?? null;
+  const panel = panelBody?.parentElement ?? null;
+  const panelText = panel?.textContent ?? "";
+  const errors = (window as typeof window & { __shellGuardErrors?: string[] }).__shellGuardErrors ?? [];
+
+  return {
+    viewport: { width: window.innerWidth, height: window.innerHeight },
+    document: {
+      scrollWidth: document.documentElement.scrollWidth,
+      scrollHeight: document.documentElement.scrollHeight,
+    },
+    panel: scrollMetrics(panel),
+    panelBody: scrollMetrics(panelBody),
+    rail: scrollMetrics(rail),
+    railBody: scrollMetrics(railBody),
+    searchBox: panel?.querySelector('input[type="search"]') !== null,
+    resume: panelText.includes("Jump back in"),
+    hints:
+      panelText.includes("command palette") ||
+      panelText.includes("focus the composer") ||
+      panelText.includes("next session needing you") ||
+      panelText.includes("shows all shortcuts"),
+    orientation: panelText.includes("read and edit the repository"),
+    errors,
+  };
+}
+
 const booted = boot();
 
 const target = window as typeof window & {
   settledShell: Promise<unknown>;
   measureShell: typeof measureShell;
+  measureMobileSidebar: typeof measureMobileSidebar;
 };
 target.measureShell = measureShell;
+target.measureMobileSidebar = measureMobileSidebar;
 target.settledShell = (async () => {
   await booted;
   const deadline = performance.now() + 15_000;

--- a/cmd/evener-hub/frontend/src/panes/welcome/Welcome.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/welcome/Welcome.test.tsx
@@ -129,6 +129,14 @@ test('offers "Jump back in" to the first needs-you session when one exists', () 
   expect(screen.getByRole("button", { name: /Jump back in.*Fix the thing/s })).toBeTruthy();
 });
 
+test('can hide "Jump back in" while retaining orientation text', () => {
+  setRows([], [node({ ref: "local:live1", title: "Refactor auth", project: "myrepo" })]);
+  render(<WelcomeContent showResume={false} />);
+
+  expect(screen.queryByRole("button", { name: /Jump back in/ })).toBeNull();
+  expect(screen.getByText(/read and edit the repository/i)).toBeTruthy();
+});
+
 test("falls back to the first live session when nothing needs you", () => {
   setRows([], [node({ ref: "local:live1", title: "Refactor auth", project: "myrepo" })]);
   render(<Welcome params={{}} paneId="welcome" focused={true} />);

--- a/cmd/evener-hub/frontend/src/panes/welcome/WelcomeContent.tsx
+++ b/cmd/evener-hub/frontend/src/panes/welcome/WelcomeContent.tsx
@@ -24,6 +24,7 @@ const CHORD_HINTS: { keys: string[]; desc: string }[] = [
 export interface WelcomeContentProps {
   note?: string;
   showNewSession?: boolean;
+  showResume?: boolean;
   showHints?: boolean;
 }
 
@@ -54,21 +55,21 @@ function resumeCandidate(navigation: NavigationStoreState) {
 }
 
 /**
- * Presentational body of the Welcome pane: the "Jump back in" resume
- * candidate, an optional "New session" action, orientation text, and
+ * Presentational body of the Welcome pane: the optional "Jump back in"
+ * resume candidate, an optional "New session" action, orientation text, and
  * optional chord hints. No example prompts, and no host-conditional
  * ("am I mobile?") behavior - this component renders exactly what its
- * props ask for regardless of the viewport. The Welcome pane decides
- * which of these to show.
+ * props ask for regardless of the viewport. The host decides which of these
+ * to show.
  */
-export function WelcomeContent({ note, showNewSession, showHints }: WelcomeContentProps) {
+export function WelcomeContent({ note, showNewSession, showResume = true, showHints }: WelcomeContentProps) {
   const navigation = useNavigationStore();
   const candidate = resumeCandidate(navigation);
 
   return (
     <div className={CLASS.actions}>
       {note && <p>{note}</p>}
-      {candidate !== undefined && (
+      {showResume && candidate !== undefined && (
         <Button variant="primary" onClick={() => goToSession(candidate.ref)}>
           Jump back in: {candidate.title}
         </Button>

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -933,6 +933,15 @@ export interface NavigationInvalidationTarget {
   revision?: number;
 }
 
+export interface NavigationJobSummary {
+  job_id: string;
+  job_type: string;
+  status: string;
+  command?: string;
+  task?: string;
+  reason?: string;
+}
+
 export interface NavigationManifest {
   generation_id: string;
   revision: number;
@@ -1074,6 +1083,8 @@ export interface NavigationSessionSummary {
   updated_at?: string;
   more_subagents?: number;
   omitted_descendants?: number;
+  running_jobs?: NavigationJobSummary[];
+  completed_jobs?: NavigationJobSummary[];
   children: NavigationSessionSummary[];
 }
 

--- a/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.module.css
+++ b/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.module.css
@@ -1,3 +1,3 @@
-.searchWrap {
-  padding: 0 var(--space-2) var(--space-2);
+.singleScrollPanel {
+  overflow: hidden;
 }

--- a/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.test.tsx
@@ -4,6 +4,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from "vi
 import { registerPaneForTests } from "../paneRegistry";
 import { resetWorkspaceStoreForTests, workspaceStore } from "../workspace";
 import { MobilePanel } from "./MobilePanel";
+import styles from "./MobilePanel.module.css";
 
 // The brief's tests call openPane("doc", ...) and openPane("welcome"). Both
 // require a registered pane type (openPane -> paneFor throws otherwise), so
@@ -46,10 +47,9 @@ test("renders rail content when open", () => {
   expect(screen.getByTestId("rail-fixture")).toBeTruthy();
 });
 
-test("renders a search box at the top", () => {
+test("does not render an inline search box", () => {
   render(<MobilePanel rail={<RailFixture />} open onClose={vi.fn()} />);
-  expect(screen.getByRole("searchbox")).toBeTruthy();
-  expect(screen.getByRole("searchbox").getAttribute("placeholder")).toBe("Search sessions");
+  expect(screen.queryByRole("searchbox")).toBeNull();
 });
 
 test("renders welcome content when nothing is focused", () => {
@@ -57,6 +57,26 @@ test("renders welcome content when nothing is focused", () => {
   workspaceStore.getState().openPane("welcome");
   render(<MobilePanel rail={<RailFixture />} open onClose={vi.fn()} />);
   expect(screen.getByText(/read and edit the repository/i)).toBeTruthy();
+});
+
+test("keeps mobile orientation text but hides resume and shortcut hints", () => {
+  workspaceStore.getState().openPane("welcome");
+  render(<MobilePanel rail={<RailFixture />} open onClose={vi.fn()} />);
+
+  expect(screen.getByText(/read and edit the repository/i)).toBeTruthy();
+  expect(screen.queryByRole("button", { name: /Jump back in/i })).toBeNull();
+  expect(screen.queryByText("command palette")).toBeNull();
+  expect(screen.queryByText("focus the composer")).toBeNull();
+  expect(screen.queryByText("next session needing you")).toBeNull();
+  expect(screen.queryByText(/shows all shortcuts/i)).toBeNull();
+});
+
+test("makes the Sheet panel the mobile scroll owner", () => {
+  render(<MobilePanel rail={<RailFixture />} open onClose={vi.fn()} />);
+  const panel = screen.getByRole("dialog");
+
+  expect(styles.singleScrollPanel).toBeTruthy();
+  expect(panel.className.split(/\s+/)).toContain(styles.singleScrollPanel);
 });
 
 test("hides welcome content when a session is focused", () => {

--- a/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.tsx
+++ b/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.tsx
@@ -1,6 +1,6 @@
-import { type ChangeEvent, type ReactNode, useEffect, useRef, useState } from "react";
+import { type ReactNode, useEffect, useRef } from "react";
 import { WelcomeContent } from "../../panes/welcome/WelcomeContent";
-import { Input, Sheet } from "../../widgets";
+import { Sheet } from "../../widgets";
 import { useWorkspaceStore } from "../workspace";
 import styles from "./MobilePanel.module.css";
 
@@ -18,8 +18,6 @@ export function MobilePanel({ rail, open, onClose }: MobilePanelProps) {
 
   const prevFocusedIdRef = useRef(focusedPaneId);
   const prevOpenRef = useRef(open);
-  const [search, setSearch] = useState("");
-
   useEffect(() => {
     if (open && prevOpenRef.current !== open) prevFocusedIdRef.current = focusedPaneId;
     prevOpenRef.current = open;
@@ -27,22 +25,16 @@ export function MobilePanel({ rail, open, onClose }: MobilePanelProps) {
     prevFocusedIdRef.current = focusedPaneId;
   }, [focusedPaneId, open, onClose]);
 
-  function handleSearchChange(e: ChangeEvent<HTMLInputElement>) {
-    setSearch(e.target.value);
-  }
-
   return (
-    <Sheet side="left" open={open} onClose={onClose} title="Sessions" size="wide">
-      {nothingFocused && <WelcomeContent showHints />}
-      <div className={styles.searchWrap}>
-        <Input
-          type="search"
-          value={search}
-          onChange={handleSearchChange}
-          placeholder="Search sessions"
-          aria-label="Search sessions"
-        />
-      </div>
+    <Sheet
+      side="left"
+      open={open}
+      onClose={onClose}
+      title="Sessions"
+      size="wide"
+      panelClassName={styles.singleScrollPanel}
+    >
+      {nothingFocused && <WelcomeContent showResume={false} showHints={false} />}
       {rail}
     </Sheet>
   );

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.module.css
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.module.css
@@ -130,6 +130,17 @@
   padding: var(--space-2) 0;
 }
 
+/* Mobile's Sheet body is the single scroll owner for the drawer. In that
+ * mode the rail must grow with its list instead of creating a nested scroll
+ * region; the default desktop rail keeps the rules above unchanged. */
+.parentScrollRail {
+  height: auto;
+}
+
+.parentScrollBody {
+  overflow: visible;
+}
+
 .section {
   padding: var(--space-2) 0;
 }

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.test.tsx
@@ -16,6 +16,7 @@ import { getToasts, resetToastStoreForTests } from "../../widgets/toast/store";
 import { ClientProvider } from "../clientContext";
 import { resetWorkspaceStoreForTests } from "../workspace";
 import { adaptNavigationResources, Rail } from "./Rail";
+import railStyles from "./Rail.module.css";
 import { EXPANSION_STORAGE_KEY } from "./railExpansion";
 
 function summary(overrides: Partial<NavigationSessionSummary> = {}): NavigationSessionSummary {
@@ -148,6 +149,16 @@ describe("resource-backed Rail", () => {
     render(<Rail />);
     expect(screen.getByText("Live resource")).toBeTruthy();
     expect(screen.getAllByText("Proj").length).toBeGreaterThan(0);
+  });
+
+  test("can delegate scrolling to its parent container", () => {
+    installState([sectionResource("live", [summary({ title: "Live resource" })])]);
+    const { container } = render(<Rail scrollOwner="parent" />);
+    const body = container.querySelector(`.${railStyles.body}`);
+
+    expect(body).toBeTruthy();
+    expect(railStyles.parentScrollBody).toBeTruthy();
+    expect(body?.className.split(/\s+/)).toContain(railStyles.parentScrollBody);
   });
   test("shows bounded loading and empty states from manifest/resource state", () => {
     installState(

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
@@ -109,6 +109,9 @@ interface RailSectionProps {
 function renderRailRow(actions: RailRowActions) {
   return (node: RailNode, info: TreeRowInfo) => <RailRow node={node} info={info} actions={actions} />;
 }
+function isPassiveRailNode(node: RailNode): boolean {
+  return node.kind === "loading" || node.kind === "job";
+}
 function RailSection({ title, nodes, onToggle, onActivate, actions }: RailSectionProps) {
   if (nodes.length === 0) return null;
   return (
@@ -685,7 +688,7 @@ function NavigationRail({
   }, [revealTarget, resources, expandedOverrides, consumeReveal, setExpanded, requestRevealResource]);
 
   function handleToggle(node: RailNode) {
-    if (node.kind === "loading") return;
+    if (isPassiveRailNode(node)) return;
     const value = !node.expanded;
     setExpanded(node.id, value);
     if (!value && node.kind === "project") rootLoadsInFlight.current.delete(node.project.key);
@@ -703,7 +706,7 @@ function NavigationRail({
     if (url) navigate(url);
   }
   function handleActivate(node: RailNode) {
-    if (node.kind === "loading") return;
+    if (isPassiveRailNode(node)) return;
     if (node.kind === "overflow") {
       void revealOverflow(node);
       return;

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
@@ -83,6 +83,8 @@ const CLASS = {
   footer: requireClass(styles.footer, "Rail.module.css", "footer"),
   footerIdentity: requireClass(styles.footerIdentity, "Rail.module.css", "footerIdentity"),
   body: requireClass(styles.body, "Rail.module.css", "body"),
+  parentScrollRail: requireClass(styles.parentScrollRail, "Rail.module.css", "parentScrollRail"),
+  parentScrollBody: requireClass(styles.parentScrollBody, "Rail.module.css", "parentScrollBody"),
   section: requireClass(styles.section, "Rail.module.css", "section"),
   sectionTitle: requireClass(styles.sectionTitle, "Rail.module.css", "sectionTitle"),
   sectionDisclosure: requireClass(styles.sectionDisclosure, "Rail.module.css", "sectionDisclosure"),
@@ -201,6 +203,9 @@ export interface RailProps {
   onWidthChange?: (width: number) => void;
   revealTarget?: string | null;
   onRevealConsumed?: () => void;
+  /** The normal rail owns its list scrolling. Mobile's Sheet can opt to own
+   * the whole rail instead, so the rail grows with its content. */
+  scrollOwner?: "rail" | "parent";
 }
 interface RevealRequestGuard {
   target: string;
@@ -465,7 +470,14 @@ function isNavigationMutationReceipt(result: unknown): result is NavigationMutat
   );
 }
 
-function NavigationRail({ onHide, width, onWidthChange, revealTarget, onRevealConsumed }: RailProps = {}) {
+function NavigationRail({
+  onHide,
+  width,
+  onWidthChange,
+  revealTarget,
+  onRevealConsumed,
+  scrollOwner = "rail",
+}: RailProps = {}) {
   const client = useClient();
   const navigationMode = useNavigationStore((state) => state.mode);
   const manifest = useNavigationStore((state) => state.manifest);
@@ -1050,9 +1062,10 @@ function NavigationRail({ onHide, width, onWidthChange, revealTarget, onRevealCo
     (navigationMode === "error" ? "Navigation resources are unavailable" : null);
   const displayed = nonEmpty(resources);
   const needsYou = attention?.needsYou ?? manifest?.data?.attentionSummary.needsYou ?? 0;
+  const parentOwnsScroll = scrollOwner === "parent";
   return (
     <div
-      className={CLASS.rail}
+      className={parentOwnsScroll ? `${CLASS.rail} ${CLASS.parentScrollRail}` : CLASS.rail}
       ref={railRef}
       style={width === undefined ? undefined : ({ [RAIL_WIDTH_PROPERTY]: `${width}px` } as CSSProperties)}
     >
@@ -1089,7 +1102,7 @@ function NavigationRail({ onHide, width, onWidthChange, revealTarget, onRevealCo
           </Button>
         </div>
       </div>
-      <div className={CLASS.body} ref={bodyRef}>
+      <div className={parentOwnsScroll ? `${CLASS.body} ${CLASS.parentScrollBody}` : CLASS.body} ref={bodyRef}>
         {loading && !displayed && <Skeleton lines={6} />}
         {!loading && !displayed && loadError && (
           <EmptyState

--- a/cmd/evener-hub/frontend/src/shell/rail/RailHost.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailHost.test.tsx
@@ -8,6 +8,7 @@ import { manifest as navigationManifest } from "../../stores/navigation/testing"
 import { prefsStore, resetPrefsStoreForTests, SIDEBAR_WIDTH_MAX } from "../../stores/prefs";
 import { ClientProvider } from "../clientContext";
 import { resetWorkspaceStoreForTests } from "../workspace";
+import railStyles from "./Rail.module.css";
 import { RailHost } from "./RailHost";
 import { revealSessionInRail, setRailRevealHandler } from "./railController";
 
@@ -86,6 +87,9 @@ describe("docked by default", () => {
     expect(screen.getByRole("button", { name: /new session/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /hide sidebar/i })).toBeTruthy();
     expect(screen.queryByRole("button", { name: /show sidebar/i })).toBeNull();
+    const body = document.querySelector(`.${railStyles.body}`);
+    expect(body?.className.split(/\s+/)).not.toContain(railStyles.parentScrollBody);
+    expect(body?.parentElement?.className.split(/\s+/)).not.toContain(railStyles.parentScrollRail);
   });
 });
 
@@ -256,6 +260,9 @@ describe("resizable width", () => {
     render(<RailHost />);
     expect(screen.getByTestId("rail-search")).toBeTruthy(); // the rail itself is there
     expect(screen.queryByTestId("rail-resize-handle")).toBeNull();
+    const body = document.querySelector(`.${railStyles.body}`);
+    expect(railStyles.parentScrollBody).toBeTruthy();
+    expect(body?.className.split(/\s+/)).toContain(railStyles.parentScrollBody);
   });
 });
 

--- a/cmd/evener-hub/frontend/src/shell/rail/RailHost.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailHost.tsx
@@ -108,6 +108,7 @@ export function RailHost(_props: { railSlot?: never } = {}): JSX.Element {
       onWidthChange={isMobile ? undefined : (width) => prefsStore.getState().setSidebarWidth(width)}
       revealTarget={revealTarget}
       onRevealConsumed={clearReveal}
+      scrollOwner={isMobile ? "parent" : "rail"}
     />
   );
 }

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
@@ -14,7 +14,9 @@ import { resetWorkspaceStoreForTests, workspaceStore } from "../workspace";
 import { activityGloss, cadenceStateFor, RailRow, type RailRowActions } from "./RailRow";
 import railStyles from "./RailRow.module.css";
 import type {
+  CompletedJobsFoldRailNode,
   InactiveFoldRailNode,
+  JobRailNode,
   LoadingRailNode,
   OverflowRailNode,
   ProjectRailNode,
@@ -151,6 +153,20 @@ function overflowRailNode(count: number): OverflowRailNode {
 
 function inactiveFoldRailNode(count: number): InactiveFoldRailNode {
   return { id: "inactive:parent", kind: "inactiveFold", count, expanded: false, children: [] };
+}
+
+function jobRailNode(overrides: Partial<JobRailNode["job"]> = {}): JobRailNode {
+  return {
+    id: "job:parent:job-1",
+    kind: "job",
+    job: { job_id: "job-1", job_type: "shell", status: "running", row_id: "job:parent:job-1", ...overrides },
+    active: true,
+    children: [],
+  };
+}
+
+function completedJobsFoldRailNode(count: number): CompletedJobsFoldRailNode {
+  return { id: "completed-jobs:parent", kind: "completedJobsFold", count, expanded: false, children: [] };
 }
 
 function info(overrides: Partial<TreeRowInfo> = {}): TreeRowInfo {
@@ -321,6 +337,14 @@ describe("activityGloss", () => {
       ),
     ).toBe("2 subagents working · fix/thing");
   });
+
+  test("reports active jobs alongside active subagents", () => {
+    const session = apiNode({ children: [apiNode({ state: "active" })] });
+    Object.assign(session, {
+      running_jobs: [{ job_id: "job-1", job_type: "shell", status: "running" }],
+    });
+    expect(activityGloss(session)).toBe("1 subagent working · 1 job running");
+  });
 });
 
 describe("loading row", () => {
@@ -411,6 +435,24 @@ describe("inactive-subagent fold row", () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const css = readFileSync(join(here, "RailRow.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
     expect(css).toMatch(/\.signal\s*\{[^}]*width:\s*6px;[^}]*margin-left:\s*-10px;/);
+  });
+});
+
+describe("job rows", () => {
+  test("renders an active job label and green status", () => {
+    render(<RailRow node={jobRailNode({ command: "go test ./..." })} info={info()} actions={actions()} />);
+    expect(screen.getByText("go test ./...")).toBeTruthy();
+    expect(screen.getByTestId("rail-row-job-status").className.split(" ")).toContain(railStyles.activityAlive);
+  });
+
+  test("renders a separate completed-jobs disclosure", () => {
+    const toggle = vi.fn();
+    render(
+      <RailRow node={completedJobsFoldRailNode(3)} info={info({ hasChildren: true, toggle })} actions={actions()} />,
+    );
+    expect(screen.getByText("Completed jobs (3)")).toBeTruthy();
+    fireEvent.click(screen.getByText("Completed jobs (3)"));
+    expect(toggle).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -572,6 +614,16 @@ describe("session row", () => {
     });
     render(<RailRow node={sessionRailNode(session)} info={info({ depth: 1 })} actions={actions()} />);
     expect(screen.getByTestId("rail-row-activity").textContent).toBe("2 subagents working · fix/thing");
+  });
+
+  test("shows an active job on a quiet session as green working activity", () => {
+    const session = apiNode({ state: "idle" });
+    Object.assign(session, {
+      running_jobs: [{ job_id: "job-1", job_type: "shell", status: "running" }],
+    });
+    render(<RailRow node={sessionRailNode(session)} info={info({ depth: 1 })} actions={actions()} />);
+    expect(screen.getByTestId("rail-row-signal")).toBeTruthy();
+    expect(screen.getByTestId("rail-row-activity").className.split(" ")).toContain(railStyles.activityAlive);
   });
 
   test("keeps a quiet row without active descendants one line", () => {

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
@@ -53,8 +53,11 @@ import { type PinTarget, SessionMenu } from "../sessionMenu/SessionMenu";
 import { isPaneOpen, useWorkspaceStore } from "../workspace";
 import styles from "./RailRow.module.css";
 import {
+  activeWorkSummary,
+  type CompletedJobsFoldRailNode,
   displayState,
   type InactiveFoldRailNode,
+  type JobRailNode,
   needsYouDescendantCount,
   type OverflowRailNode,
   type ProjectRailNode,
@@ -62,7 +65,6 @@ import {
   type RailProject,
   type RailSession,
   type SessionRailNode,
-  workingDescendantCount,
 } from "./railNodes";
 import { isTopLevelSession } from "./sessionKind";
 
@@ -242,13 +244,16 @@ function Signal({ wireState }: { wireState: string }) {
 // on the main line it charged its width to the title at the rail's default
 // 280px. Exported for direct testing of the join, which the rendered line can
 // only assert on as one flat string.
-export function activityGloss(session: RailSession): string {
-  const workingCount = workingDescendantCount(session);
-  const parts = [
-    workingCount === 0
-      ? humanizeState(session.state, session.ask_pending === true)
-      : `${workingCount} subagent${workingCount === 1 ? "" : "s"} working`,
-  ];
+export function activityGloss(session: RailSession, activity = activeWorkSummary(session)): string {
+  const workingCount = activity.workingSubagents;
+  const jobCount = activity.runningJobs;
+  const parts: string[] = [];
+  if (workingCount > 0) {
+    parts.push(`${workingCount} subagent${workingCount === 1 ? "" : "s"} working`);
+  } else if (jobCount === 0 || session.state === "active") {
+    parts.push(humanizeState(session.state, session.ask_pending === true));
+  }
+  if (jobCount > 0) parts.push(`${jobCount} job${jobCount === 1 ? "" : "s"} running`);
   if (session.branch !== undefined && session.branch !== "") parts.push(session.branch);
   return parts.join(" · ");
 }
@@ -262,12 +267,17 @@ export function activityGloss(session: RailSession): string {
 // the project it belongs to is the row it is indented under. Project leads
 // the line (state is what's happening, project is where) the same way
 // activityGloss already leads with state before branch.
-function secondLine(session: RailSession, showsGloss: boolean, showsProject: boolean): string {
+function secondLine(
+  session: RailSession,
+  showsGloss: boolean,
+  showsProject: boolean,
+  activity?: ReturnType<typeof activeWorkSummary>,
+): string {
   const parts: string[] = [];
   // An empty project name has nothing to join, so it must not contribute a
   // leading " · " separator with no text before it (UX fix).
   if (showsProject && session.project !== "") parts.push(session.project);
-  if (showsGloss) parts.push(activityGloss(session));
+  if (showsGloss) parts.push(activityGloss(session, activity));
   return parts.join(" · ");
 }
 
@@ -508,8 +518,16 @@ function SessionRow({ node, info, actions }: { node: SessionRailNode; info: Tree
   // gloss, and with it its second line - which makes signal rows physically
   // taller than quiet ones. That is the point: the rows worth finding are bigger
   // than the rows that aren't, and the list's evenness is worth less than that.
-  const showsGloss = SIGNAL_STATES.has(cadenceStateFor(presented));
-  const hasWorkingDescendants = workingDescendantCount(session) > 0;
+  const activity = activeWorkSummary(session);
+  const hasWorkingDescendants = activity.workingSubagents > 0;
+  const hasRunningJobs = activity.runningJobs > 0;
+  const hasActiveWork = session.state === "active" || hasWorkingDescendants || hasRunningJobs;
+  // Descendant/job activity is a working signal for the owning session. A
+  // failed session still wins over that rollup so an error cannot disappear
+  // behind a green child.
+  let effectiveState = presented;
+  if (effectiveState !== "errored" && hasActiveWork) effectiveState = "active";
+  const showsGloss = SIGNAL_STATES.has(cadenceStateFor(effectiveState));
   // kata hxjn: a row at depth 0 is a top-level entry in a flat, cross-project
   // tier (Live/Pinned - see toSessionNode/sessionNodes; a Projects/Test-runs/
   // Archived session is always nested under its own ProjectRow, never a depth-0
@@ -519,14 +537,14 @@ function SessionRow({ node, info, actions }: { node: SessionRailNode; info: Tree
   // above, made for exactly the fact that rule can't otherwise carry.
   const showsProject = info.depth === 0;
   const notStarted = saysNotStarted(session, showsGloss);
-  const showsActivity = showsGloss || hasWorkingDescendants;
-  const gloss = secondLine(session, showsActivity, showsProject);
+  const showsActivity = showsGloss || hasWorkingDescendants || hasRunningJobs;
+  const gloss = secondLine(session, showsActivity, showsProject, activity);
   const showsSecondLine = showsActivity || showsProject;
   // Only a genuine signal row (showsGloss) carries a state to tint - the
   // depth-0-only "just the project name" line (showsProject with no signal)
   // has no state family to color, so it stays the plain --ink-low default.
   const activityClass = showsGloss
-    ? `${CLASS.activity} ${ACTIVITY_FAMILY_CLASS[cadenceStateFor(presented)] ?? ""}`.trim()
+    ? `${CLASS.activity} ${ACTIVITY_FAMILY_CLASS[cadenceStateFor(effectiveState)] ?? ""}`.trim()
     : CLASS.activity;
   return (
     // data-session-ref is the scroll target Rail's reveal effect (the palette's
@@ -550,7 +568,7 @@ function SessionRow({ node, info, actions }: { node: SessionRailNode; info: Tree
             unreachable. The title's tooltip also carries what the visible row
             drops (rowTooltip). */}
         <span className={CLASS.titleLine}>
-          <Signal wireState={presented} />
+          <Signal wireState={effectiveState} />
           <span className={CLASS.label} title={rowTooltip(session, showsGloss, notStarted)}>
             {session.title}
           </span>
@@ -684,17 +702,15 @@ function ProjectRow({ node, info, actions }: { node: ProjectRailNode; info: Tree
 // hides carry their own. Its label sits at the same x as every other row at
 // its nesting depth - the trailing chevron after the label is its toggle,
 // the same inline affordance session and project rows use.
-function InactiveFoldRow({ node, info }: { node: InactiveFoldRailNode; info: TreeRowInfo }) {
-  const label = `${node.count === 1 ? "Inactive subagent" : "Inactive subagents"} (${node.count})`;
+function DisclosureFoldRow({ label, testId, info }: { label: string; testId: string; info: TreeRowInfo }) {
   return (
-    <span className={CLASS.railRow} data-testid="rail-row-inactive-fold">
+    <span className={CLASS.railRow} data-testid={testId}>
       <span className={CLASS.textCol}>
         <span className={CLASS.titleLine}>
-          {/* Same mouse-only shortcut for the toggle the chevron already offers,
-              and the same a11y reasoning as SessionRow's own label: this text is
-              the treeitem's accessible name, so it can't be aria-hidden. */}
-          {/* biome-ignore lint/a11y/noStaticElementInteractions: redundant with the row's own Enter handling, see SessionRow */}
-          {/* biome-ignore lint/a11y/useKeyWithClickEvents: redundant with the row's own Enter handling, see SessionRow */}
+          {/* The label is the accessible activation target; the chevron is a
+              decorative shortcut for the same treeitem toggle. */}
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: redundant with the row's own Enter handling */}
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: redundant with the row's own Enter handling */}
           <span className={CLASS.label} onClick={info.toggle}>
             {label}
           </span>
@@ -702,6 +718,44 @@ function InactiveFoldRow({ node, info }: { node: InactiveFoldRailNode; info: Tre
         </span>
       </span>
     </span>
+  );
+}
+
+function InactiveFoldRow({ node, info }: { node: InactiveFoldRailNode; info: TreeRowInfo }) {
+  const label = `${node.count === 1 ? "Inactive subagent" : "Inactive subagents"} (${node.count})`;
+  return <DisclosureFoldRow label={label} testId="rail-row-inactive-fold" info={info} />;
+}
+
+function jobLabel(job: JobRailNode["job"]): string {
+  return job.command?.trim() || job.task?.trim() || job.job_type?.trim() || job.job_id;
+}
+
+function JobRow({ node }: { node: JobRailNode }) {
+  const active = node.active;
+  const status = node.job.status.trim() || (active ? "running" : "completed");
+  return (
+    <span className={CLASS.railRow} data-testid="rail-row-job" data-job-id={node.job.job_id}>
+      <span className={CLASS.textCol}>
+        <span className={CLASS.titleLine}>
+          <Signal wireState={active ? "active" : status === "failed" ? "errored" : "ended"} />
+          <span className={CLASS.label} title={`${jobLabel(node.job)} · ${status}`}>
+            {jobLabel(node.job)}
+          </span>
+        </span>
+        <span
+          data-testid="rail-row-job-status"
+          className={active ? `${CLASS.activity} ${CLASS.activityAlive}` : CLASS.activity}
+        >
+          {status}
+        </span>
+      </span>
+    </span>
+  );
+}
+
+function CompletedJobsFoldRow({ node, info }: { node: CompletedJobsFoldRailNode; info: TreeRowInfo }) {
+  return (
+    <DisclosureFoldRow label={`Completed jobs (${node.count})`} testId="rail-row-completed-jobs-fold" info={info} />
   );
 }
 
@@ -741,8 +795,12 @@ export function RailRow({ node, info, actions }: RailRowProps) {
   switch (node.kind) {
     case "loading":
       return LoadingRow();
+    case "job":
+      return <JobRow node={node} />;
     case "inactiveFold":
       return <InactiveFoldRow node={node} info={info} />;
+    case "completedJobsFold":
+      return <CompletedJobsFoldRow node={node} info={info} />;
     case "overflow":
       return <OverflowRow node={node} info={info} />;
     case "project":

--- a/cmd/evener-hub/frontend/src/shell/rail/railNodes.test.ts
+++ b/cmd/evener-hub/frontend/src/shell/rail/railNodes.test.ts
@@ -68,6 +68,35 @@ describe("resource projection semantics", () => {
     expect(node?.children.map((child) => child.kind)).toEqual(["session", "inactiveFold"]);
     expect(node?.children[1]).toMatchObject({ count: 1, expanded: false });
   });
+
+  test("keeps active jobs inline and puts idle subagents and completed jobs in separate folds", () => {
+    const root = session({
+      ref: "root",
+      row_id: "root",
+      state: "idle",
+      children: [
+        session({ ref: "idle-child", row_id: "idle-child", kind: "subagent", state: "idle" }),
+        session({ ref: "active-child", row_id: "active-child", kind: "subagent", state: "active" }),
+      ],
+    });
+    Object.assign(root, {
+      running_jobs: [{ job_id: "job-running", job_type: "shell", status: "running" }],
+      completed_jobs: [{ job_id: "job-completed", job_type: "shell", status: "completed" }],
+    });
+    const [node] = sessionNodes([root], closed);
+    expect(node?.children.map((child) => child.kind)).toEqual(["session", "job", "inactiveFold", "completedJobsFold"]);
+    expect(node?.children[1]).toMatchObject({ kind: "job", job: { job_id: "job-running" } });
+    expect(node?.children[2]).toMatchObject({ kind: "inactiveFold", count: 1 });
+    expect(node?.children[3]).toMatchObject({ kind: "completedJobsFold", count: 1 });
+  });
+
+  test("keeps an idle subagent with active work in the inline list", () => {
+    const child = session({ ref: "child", row_id: "child", kind: "subagent", state: "idle" });
+    Object.assign(child, { running_jobs: [{ job_id: "job-child", job_type: "shell", status: "running" }] });
+    const [node] = sessionNodes([session({ ref: "root", row_id: "root", children: [child] })], closed);
+    expect(node?.children.map((entry) => entry.kind)).toEqual(["session"]);
+    expect(node?.children[0]).toMatchObject({ children: [{ kind: "job", job: { job_id: "job-child" } }] });
+  });
   test("handles cluster disclosure without a second inactive fold", () => {
     const cluster = session({
       kind: "cluster",

--- a/cmd/evener-hub/frontend/src/shell/rail/railNodes.ts
+++ b/cmd/evener-hub/frontend/src/shell/rail/railNodes.ts
@@ -5,7 +5,7 @@
 // pure functions OF (the expand-override map, the lazily-loaded archived
 // project detail map) and wires the results into <Tree>.
 
-import type { NavigationSessionSummary } from "../../protocol/types.gen";
+import type { NavigationJobSummary, NavigationSessionSummary } from "../../protocol/types.gen";
 
 export type TreeTier = "current" | "recent" | "archived";
 
@@ -18,6 +18,10 @@ export interface RailSession extends NavigationSessionSummary {
   model?: string;
   children: RailSession[];
   project_key?: string;
+}
+
+export interface RailJob extends NavigationJobSummary {
+  row_id: string;
 }
 
 export interface RailProject {
@@ -61,9 +65,15 @@ export interface SessionRailNode extends WidgetTreeNode {
   // hasChildrenOf), so there's no reason to carry two representations of
   // the same "nothing to expand" case.
   //
-  // Its current subagents, followed by at most one InactiveFoldRailNode
-  // holding the finished ones (see splitChildren).
-  children: (SessionRailNode | InactiveFoldRailNode)[];
+  // Its current subagents and jobs, followed by independent inactive-subagent
+  // and completed-job folds when either has rows (see splitChildren).
+  children: (SessionRailNode | JobRailNode | InactiveFoldRailNode | CompletedJobsFoldRailNode)[];
+}
+
+export interface JobRailNode extends WidgetTreeNode {
+  kind: "job";
+  job: RailJob;
+  active: boolean;
 }
 
 export interface ProjectRailNode extends WidgetTreeNode {
@@ -95,6 +105,12 @@ export interface InactiveFoldRailNode extends WidgetTreeNode {
   kind: "inactiveFold";
   count: number;
   children: (SessionRailNode | OverflowRailNode)[];
+}
+
+export interface CompletedJobsFoldRailNode extends WidgetTreeNode {
+  kind: "completedJobsFold";
+  count: number;
+  children: JobRailNode[];
 }
 
 export interface OverflowPage {
@@ -147,7 +163,14 @@ export function catalogOverflowNode(
   return overflowNode(id, remaining, [{ catalog, offset, limit }]);
 }
 
-export type RailNode = SessionRailNode | ProjectRailNode | LoadingRailNode | InactiveFoldRailNode | OverflowRailNode;
+export type RailNode =
+  | SessionRailNode
+  | JobRailNode
+  | ProjectRailNode
+  | LoadingRailNode
+  | InactiveFoldRailNode
+  | CompletedJobsFoldRailNode
+  | OverflowRailNode;
 
 // The rows a given list has hidden. Each caller passes the tiers it actually
 // renders: an active project's inline list shows Current+Recent (the archived
@@ -223,6 +246,30 @@ function inactiveFoldId(parentRowID: string): string {
   return `inactive:${parentRowID}`;
 }
 
+function completedJobsFoldId(parentRowID: string): string {
+  return `completed-jobs:${parentRowID}`;
+}
+
+function toJobNode(parent: RailSession, job: NavigationJobSummary): JobRailNode {
+  const rowID = `job:${parent.row_id}:${job.job_id}`;
+  return {
+    id: rowID,
+    kind: "job",
+    job: { ...job, row_id: rowID },
+    active: false,
+    children: [],
+  };
+}
+
+function activeJobNode(parent: RailSession, job: NavigationJobSummary): JobRailNode {
+  return { ...toJobNode(parent, job), active: true };
+}
+
+function subagentIsCurrent(child: RailSession): boolean {
+  const activity = activeWorkSummary(child);
+  return CURRENT_SUBAGENT_STATES.has(child.state) || activity.workingSubagents > 0 || activity.runningJobs > 0;
+}
+
 // Splits one parent's children into the rows that render inline and the
 // single fold node carrying the rest. Both sides keep their incoming order,
 // and the fold always lands last, so a parent's live work stays at the top of
@@ -235,27 +282,44 @@ function inactiveFoldId(parentRowID: string): string {
 // "Inactive subagents" for rows that are neither inactive-in-that-sense nor
 // subagents. A cluster is already a disclosure; its members are ordinary
 // top-level sessions (parity-m3-sidebar-tree.md §3).
-function splitChildren(parent: RailSession, isExpanded: IsExpanded): (SessionRailNode | InactiveFoldRailNode)[] {
+function splitChildren(
+  parent: RailSession,
+  isExpanded: IsExpanded,
+): (SessionRailNode | JobRailNode | InactiveFoldRailNode | CompletedJobsFoldRailNode)[] {
   const current: SessionRailNode[] = [];
   const inactive: SessionRailNode[] = [];
   if (parent.kind === "cluster") return parent.children.map((c) => toSessionNode(c, isExpanded));
   for (const child of parent.children) {
-    (CURRENT_SUBAGENT_STATES.has(child.state) ? current : inactive).push(toSessionNode(child, isExpanded));
+    (subagentIsCurrent(child) ? current : inactive).push(toSessionNode(child, isExpanded));
   }
   const inactiveCount = inactive.length + (parent.more_subagents ?? 0);
-  if (inactiveCount === 0) return current;
-  const id = inactiveFoldId(parent.row_id);
-  const omitted = overflowNode(id, parent.more_subagents ?? 0);
-  return [
+  const children: (SessionRailNode | JobRailNode | InactiveFoldRailNode | CompletedJobsFoldRailNode)[] = [
     ...current,
-    {
+    ...(parent.running_jobs ?? []).map((job) => activeJobNode(parent, job)),
+  ];
+  if (inactiveCount > 0) {
+    const id = inactiveFoldId(parent.row_id);
+    const omitted = overflowNode(id, parent.more_subagents ?? 0);
+    children.push({
       id,
       kind: "inactiveFold",
       count: inactiveCount,
       expanded: isExpanded(id, false),
       children: [...inactive, ...omitted],
-    },
-  ];
+    });
+  }
+  const completedJobs = parent.completed_jobs ?? [];
+  if (completedJobs.length > 0) {
+    const id = completedJobsFoldId(parent.row_id);
+    children.push({
+      id,
+      kind: "completedJobsFold",
+      count: completedJobs.length,
+      expanded: isExpanded(id, false),
+      children: completedJobs.map((job) => toJobNode(parent, job)),
+    });
+  }
+  return children;
 }
 
 function toSessionNode(n: RailSession, isExpanded: IsExpanded): SessionRailNode {
@@ -319,11 +383,28 @@ export function needsYouDescendantCount(node: RailSession): number {
   );
 }
 
+export interface ActiveWorkSummary {
+  workingSubagents: number;
+  runningJobs: number;
+}
+
+export function activeWorkSummary(node: RailSession): ActiveWorkSummary {
+  let workingSubagents = 0;
+  let runningJobs = (node.running_jobs ?? []).length;
+  for (const child of node.children) {
+    const childActivity = activeWorkSummary(child);
+    workingSubagents += (child.state === "active" ? 1 : 0) + childActivity.workingSubagents;
+    runningJobs += childActivity.runningJobs;
+  }
+  return { workingSubagents, runningJobs };
+}
+
+export function runningJobCount(node: RailSession): number {
+  return activeWorkSummary(node).runningJobs;
+}
+
 export function workingDescendantCount(node: RailSession): number {
-  return node.children.reduce(
-    (count, child) => count + (child.state === "active" ? 1 : 0) + workingDescendantCount(child),
-    0,
-  );
+  return activeWorkSummary(node).workingSubagents;
 }
 
 // A session "wants you" either directly (its own state) or transitively (a

--- a/cmd/evener-hub/frontend/src/stores/navigation/store.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/navigation/store.test.ts
@@ -506,6 +506,16 @@ test("invalid AppWire envelopes and resource bodies become resource errors", asy
   expect(client.calls.every(({ method }) => method === "evener/navigation/read")).toBe(true);
 });
 
+test("rejects malformed job collections in navigation session summaries", async () => {
+  await init((params) =>
+    params.resource === "manifest"
+      ? wire(emptyManifest())
+      : wire({ sessions: [{ ref: "local:bad", running_jobs: {} }], remaining: 0, truncated: false }),
+  );
+  const resource = await navigationStore.getState().loadSection("live");
+  expect(resource.error).toBeTruthy();
+});
+
 test("stale client completion cannot overwrite newer client", async () => {
   const old = deferred<NavigationReadResponse>();
   const first = new FakeClient("ready");

--- a/cmd/evener-hub/frontend/src/stores/navigation/store.ts
+++ b/cmd/evener-hub/frontend/src/stores/navigation/store.ts
@@ -194,12 +194,30 @@ function sessions(value: unknown): boolean {
       !optional(candidate.dormant, bool) ||
       !optional(candidate.updated_at, string) ||
       !optional(candidate.more_subagents, count) ||
-      !optional(candidate.omitted_descendants, count)
+      !optional(candidate.omitted_descendants, count) ||
+      !optional(candidate.running_jobs, jobs) ||
+      !optional(candidate.completed_jobs, jobs)
     )
       return false;
     pending.push(...candidate.children);
   }
   return true;
+}
+
+function jobs(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (candidate) =>
+        record(candidate) &&
+        string(candidate.job_id) &&
+        string(candidate.job_type) &&
+        string(candidate.status) &&
+        optional(candidate.command, string) &&
+        optional(candidate.task, string) &&
+        optional(candidate.reason, string),
+    )
+  );
 }
 function tier(value: unknown): boolean {
   return record(value) && sessions(value.sessions) && count(value.remaining);

--- a/cmd/evener-hub/frontend/src/widgets/sheet/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/sheet/index.tsx
@@ -33,6 +33,9 @@ export interface SheetProps {
    * header/body classes flow to OverlayPanel. Defaults to undefined; existing
    * consumers that don't pass it render exactly as before. */
   expandable?: ExpandableConfig;
+  /** Optional extra class appended to the panel element after the side and
+   * size classes. */
+  panelClassName?: string;
 }
 
 const BASE_PANEL_CLASS = requireClass(dialogStyles.panel, "dialog.module.css", "panel");
@@ -88,6 +91,7 @@ export function Sheet({
   children,
   footer,
   expandable,
+  panelClassName,
 }: SheetProps) {
   const [geometry, setGeometry] = useState<"peek" | "full">(expandable?.fullScreenFirst ? "full" : "peek");
   const dragStartYRef = useRef<number | null>(null);
@@ -153,15 +157,14 @@ export function Sheet({
     window.addEventListener("pointerup", handlePointerUp);
   }
 
+  const composedPanelClassName = panelClassName
+    ? `${SIDE_CLASS[side]} ${SIZE_CLASS[size]} ${panelClassName}`
+    : `${SIDE_CLASS[side]} ${SIZE_CLASS[size]}`;
+  const composedExpandablePanelClassName = panelClassName ? `${SIDE_CLASS[side]} ${panelClassName}` : SIDE_CLASS[side];
+
   if (!expandable) {
     return (
-      <OverlayPanel
-        open={open}
-        onClose={onClose}
-        title={title}
-        footer={footer}
-        panelClassName={`${SIDE_CLASS[side]} ${SIZE_CLASS[size]}`}
-      >
+      <OverlayPanel open={open} onClose={onClose} title={title} footer={footer} panelClassName={composedPanelClassName}>
         {children}
       </OverlayPanel>
     );
@@ -179,7 +182,7 @@ export function Sheet({
       handle={<DragHandle onPointerDown={startDrag} />}
       headerClassName={EXPANDABLE_HEADER_CLASS}
       bodyClassName={EXPANDABLE_BODY_CLASS}
-      panelClassName={`${SIDE_CLASS[side]} ${EXPANDABLE_BOTTOM_CLASS}`}
+      panelClassName={`${composedExpandablePanelClassName} ${EXPANDABLE_BOTTOM_CLASS}`}
       style={heightStyle}
     >
       <div data-geometry={geometry}>{children}</div>

--- a/cmd/evener-hub/frontend/src/widgets/sheet/sheet.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/sheet/sheet.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, expect, test, vi } from "vitest";
 import { Sheet } from "./index";
+import sheetStyles from "./sheet.module.css";
 
 afterEach(cleanup);
 
@@ -49,6 +50,38 @@ test("defaults to size=standard and wide adds a distinct sizing class while pres
   expect(standardClass).not.toBe("");
   expect(wideClass).not.toBe("");
   expect(wideClass).not.toBe(standardClass);
+});
+
+test("appends an optional panel class without replacing sheet geometry classes", () => {
+  render(
+    <Sheet open onClose={vi.fn()} title="t" panelClassName="single-scroll-panel">
+      Body
+    </Sheet>,
+  );
+
+  const panel = screen.getByRole("dialog");
+  expect(panel.className).toContain("single-scroll-panel");
+  expect(panel.className.split(/\s+/).length).toBeGreaterThan(1);
+});
+
+test("optional panel styling does not change expandable geometry classes", () => {
+  render(
+    <Sheet
+      open
+      side="bottom"
+      size="wide"
+      expandable={{ peekHeight: 200 }}
+      onClose={vi.fn()}
+      title="t"
+      panelClassName="single-scroll-panel"
+    >
+      Body
+    </Sheet>,
+  );
+
+  const panel = screen.getByRole("dialog");
+  expect(panel.className).toContain("single-scroll-panel");
+  expect(panel.className).not.toContain(sheetStyles.wide);
 });
 
 test("renders as a modal dialog when open, labelled by its title, same contract as Dialog", () => {

--- a/cmd/evener-hub/internal/appsource/local_daemon.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon.go
@@ -56,6 +56,9 @@ type LocalDaemonEntry struct {
 	// RunningJobs carries the roster's non-terminal, non-agent work into the
 	// typed thread diagnostics consumed by hub and TUI status views.
 	RunningJobs []appwire.EvenerJobInfo
+	// CompletedJobs carries the recent terminal non-agent jobs into the same
+	// typed diagnostics snapshot for local compatibility consumers.
+	CompletedJobs []appwire.EvenerJobInfo
 }
 
 func NewLocalDaemonSource(sourceID string, entries func() []rendezvous.Entry, client *http.Client) *LocalDaemonSource {
@@ -849,8 +852,11 @@ func (s *LocalDaemonSource) threadFromEntry(item LocalDaemonEntry) appwire.Threa
 		},
 		Status: appwire.ThreadStatus{Type: status},
 	}
-	if !item.ReadOnlyAlias && len(item.RunningJobs) > 0 {
-		thread.Evener.Diagnostics = &appwire.EvenerDiagnostics{Jobs: cloneLocalDaemonJobs(item.RunningJobs)}
+	if !item.ReadOnlyAlias && (len(item.RunningJobs) > 0 || len(item.CompletedJobs) > 0) {
+		jobs := make([]appwire.EvenerJobInfo, 0, len(item.RunningJobs)+len(item.CompletedJobs))
+		jobs = append(jobs, item.RunningJobs...)
+		jobs = append(jobs, item.CompletedJobs...)
+		thread.Evener.Diagnostics = &appwire.EvenerDiagnostics{Jobs: cloneLocalDaemonJobs(jobs)}
 	}
 	if item.ReadOnlyAlias {
 		thread.Evener.Capabilities = appwire.ThreadCapabilities{}

--- a/cmd/evener-hub/internal/appsource/local_daemon_test.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon_test.go
@@ -630,6 +630,9 @@ func TestLocalDaemonSourceListCarriesRunningNonAgentJobs(t *testing.T) {
 			RunningJobs: []appwire.EvenerJobInfo{{
 				JobID: "job_shell", JobType: "shell", Status: "running",
 			}},
+			CompletedJobs: []appwire.EvenerJobInfo{{
+				JobID: "job_done", JobType: "shell", Status: "completed",
+			}},
 		}}
 	}, nil)
 
@@ -637,8 +640,8 @@ func TestLocalDaemonSourceListCarriesRunningNonAgentJobs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListThreads: %v", err)
 	}
-	if len(resp.Data) != 1 || resp.Data[0].Evener.Diagnostics == nil || len(resp.Data[0].Evener.Diagnostics.Jobs) != 1 {
-		t.Fatalf("thread list diagnostics = %+v, want one running shell job", resp.Data)
+	if len(resp.Data) != 1 || resp.Data[0].Evener.Diagnostics == nil || len(resp.Data[0].Evener.Diagnostics.Jobs) != 2 {
+		t.Fatalf("thread list diagnostics = %+v, want active and completed shell jobs", resp.Data)
 	}
 	job := resp.Data[0].Evener.Diagnostics.Jobs[0]
 	if job.JobID != "job_shell" || job.JobType != "shell" || job.Status != "running" {

--- a/cmd/evener-hub/internal/hubcore/prober.go
+++ b/cmd/evener-hub/internal/hubcore/prober.go
@@ -86,6 +86,7 @@ func (p *StatusProber) Probe(entry rendezvous.Entry) ProbeResult {
 	}
 	sort.Strings(runningSubagentIDs)
 
+	runningJobs, completedJobs := splitNonAgentJobs(root.Evener.Diagnostics)
 	return ProbeResult{
 		SessionID:             rootID,
 		Status:                root.Status.Type,
@@ -93,7 +94,8 @@ func (p *StatusProber) Probe(entry rendezvous.Entry) ProbeResult {
 		PendingEscalation:     len(root.Evener.PendingEscalations) > 0,
 		RunningSubagentIDs:    runningSubagentIDs,
 		RunningSubagentStates: runningSubagentStates,
-		RunningJobs:           runningNonAgentJobs(root.Evener.Diagnostics),
+		RunningJobs:           runningJobs,
+		CompletedJobs:         completedJobs,
 		OK:                    true,
 	}
 }
@@ -105,18 +107,29 @@ func statusThreadID(thread appwire.Thread) string {
 	return strings.TrimSpace(thread.ID)
 }
 
-func runningNonAgentJobs(diagnostics *appwire.EvenerDiagnostics) []appwire.EvenerJobInfo {
+func splitNonAgentJobs(diagnostics *appwire.EvenerDiagnostics) ([]appwire.EvenerJobInfo, []appwire.EvenerJobInfo) {
 	if diagnostics == nil {
-		return nil
+		return nil, nil
 	}
-	var jobs []appwire.EvenerJobInfo
-	for _, job := range diagnostics.Jobs {
-		if strings.TrimSpace(job.JobType) == "delegate" || terminalJobStatus(job.Status) {
+	return SplitNonAgentJobs(diagnostics.Jobs)
+}
+
+// SplitNonAgentJobs separates non-delegate jobs into active and terminal
+// groups for navigation consumers. The input is already the daemon's bounded
+// diagnostic inventory, so the function preserves its order within each group.
+func SplitNonAgentJobs(jobs []appwire.EvenerJobInfo) ([]appwire.EvenerJobInfo, []appwire.EvenerJobInfo) {
+	var running, completed []appwire.EvenerJobInfo
+	for _, job := range jobs {
+		if strings.TrimSpace(job.JobType) == "delegate" {
 			continue
 		}
-		jobs = append(jobs, job)
+		if terminalJobStatus(job.Status) {
+			completed = append(completed, job)
+		} else {
+			running = append(running, job)
+		}
 	}
-	return jobs
+	return running, completed
 }
 
 func terminalJobStatus(status string) bool {

--- a/cmd/evener-hub/internal/hubcore/prober_test.go
+++ b/cmd/evener-hub/internal/hubcore/prober_test.go
@@ -232,3 +232,24 @@ func TestProbeIgnoresRetiredDetailedJobType(t *testing.T) {
 		t.Fatalf("delegate job inferred consumer status: %+v", result)
 	}
 }
+
+func TestProbeSeparatesActiveAndCompletedNonAgentJobs(t *testing.T) {
+	prober, entry := startProbeDaemon(t, probeDaemonConfig{
+		sessionID: "parent", state: appwire.ThreadStatusIdle,
+		source: wireProbeEnvelopeSource{detailed: server.DetailedStatus{Jobs: []server.JobStatusInfo{
+			{JobID: "job-running", JobType: "shell", Status: "running"},
+			{JobID: "job-completed", JobType: "shell", Status: "completed"},
+			{JobID: "job-delegate", JobType: "delegate", Status: "completed"},
+		}}},
+	})
+	result := prober.Probe(entry)
+	if !result.OK {
+		t.Fatal("expected successful status probe")
+	}
+	if len(result.RunningJobs) != 1 || result.RunningJobs[0].JobID != "job-running" {
+		t.Fatalf("running jobs = %+v, want only active non-agent job", result.RunningJobs)
+	}
+	if len(result.CompletedJobs) != 1 || result.CompletedJobs[0].JobID != "job-completed" {
+		t.Fatalf("completed jobs = %+v, want only terminal non-agent job", result.CompletedJobs)
+	}
+}

--- a/cmd/evener-hub/internal/hubcore/roster.go
+++ b/cmd/evener-hub/internal/hubcore/roster.go
@@ -40,7 +40,10 @@ type LiveEntry struct {
 	// such as shell and watch jobs. Delegate jobs stay represented by the
 	// descendant fields above so consumers do not render duplicate agent rows.
 	RunningJobs []appwire.EvenerJobInfo
-	Project     identifier.Project // canonical identity resolved at hub ingestion, when available
+	// CompletedJobs contains recent terminal non-agent jobs. Delegate jobs stay
+	// represented by descendant sessions for the same reason as RunningJobs.
+	CompletedJobs []appwire.EvenerJobInfo
+	Project       identifier.Project // canonical identity resolved at hub ingestion, when available
 }
 
 // ProbeResult is the dynamic session state returned by a daemon liveness probe.
@@ -52,6 +55,7 @@ type ProbeResult struct {
 	RunningSubagentIDs    []string
 	RunningSubagentStates map[string]string
 	RunningJobs           []appwire.EvenerJobInfo
+	CompletedJobs         []appwire.EvenerJobInfo
 	OK                    bool
 }
 
@@ -77,6 +81,15 @@ func cloneSubagentStates(in map[string]string) map[string]string {
 
 func cloneRunningJobs(in []appwire.EvenerJobInfo) []appwire.EvenerJobInfo {
 	return appwire.CloneEvenerJobs(in)
+}
+
+func cloneLiveEntry(in LiveEntry) LiveEntry {
+	out := in
+	out.RunningSubagentIDs = append([]string(nil), in.RunningSubagentIDs...)
+	out.RunningSubagentStates = cloneSubagentStates(in.RunningSubagentStates)
+	out.RunningJobs = cloneRunningJobs(in.RunningJobs)
+	out.CompletedJobs = cloneRunningJobs(in.CompletedJobs)
+	return out
 }
 
 // crashedFileRetention is how long Refresh keeps a dead PID's rendezvous file
@@ -189,9 +202,7 @@ func (r *Roster) SetFs(fs afero.Fs) *Roster {
 func NewRosterWithEntries(entries ...LiveEntry) *Roster {
 	r := NewRoster("", nil)
 	for _, e := range entries {
-		e.RunningSubagentIDs = append([]string(nil), e.RunningSubagentIDs...)
-		e.RunningSubagentStates = cloneSubagentStates(e.RunningSubagentStates)
-		e.RunningJobs = cloneRunningJobs(e.RunningJobs)
+		e = cloneLiveEntry(e)
 		r.byPID[e.PID] = e
 		if e.SessionID != "" {
 			r.bySess[e.SessionID] = e
@@ -241,24 +252,36 @@ func rosterFingerprint(bySess map[string]LiveEntry) uint64 {
 			_, _ = h.Write([]byte(bySess[id].RunningSubagentStates[childID]))
 			_, _ = h.Write([]byte{0})
 		}
-		runningJobs := append([]appwire.EvenerJobInfo(nil), bySess[id].RunningJobs...)
-		sort.Slice(runningJobs, func(i, j int) bool {
-			if runningJobs[i].JobID != runningJobs[j].JobID {
-				return runningJobs[i].JobID < runningJobs[j].JobID
+		writeJobs := func(jobs []appwire.EvenerJobInfo) {
+			sort.SliceStable(jobs, func(i, j int) bool {
+				if jobs[i].JobID != jobs[j].JobID {
+					return jobs[i].JobID < jobs[j].JobID
+				}
+				if jobs[i].JobType != jobs[j].JobType {
+					return jobs[i].JobType < jobs[j].JobType
+				}
+				return jobs[i].Status < jobs[j].Status
+			})
+			for _, job := range jobs {
+				_, _ = h.Write([]byte(job.JobID))
+				_, _ = h.Write([]byte{0})
+				_, _ = h.Write([]byte(job.JobType))
+				_, _ = h.Write([]byte{0})
+				_, _ = h.Write([]byte(job.Status))
+				_, _ = h.Write([]byte{0})
+				_, _ = h.Write([]byte(job.Command))
+				_, _ = h.Write([]byte{0})
+				_, _ = h.Write([]byte(job.Task))
+				_, _ = h.Write([]byte{0})
+				_, _ = h.Write([]byte(job.Reason))
+				_, _ = h.Write([]byte{0})
 			}
-			if runningJobs[i].JobType != runningJobs[j].JobType {
-				return runningJobs[i].JobType < runningJobs[j].JobType
-			}
-			return runningJobs[i].Status < runningJobs[j].Status
-		})
-		for _, job := range runningJobs {
-			_, _ = h.Write([]byte(job.JobID))
-			_, _ = h.Write([]byte{0})
-			_, _ = h.Write([]byte(job.JobType))
-			_, _ = h.Write([]byte{0})
-			_, _ = h.Write([]byte(job.Status))
-			_, _ = h.Write([]byte{0})
 		}
+		runningJobs := append([]appwire.EvenerJobInfo(nil), bySess[id].RunningJobs...)
+		writeJobs(runningJobs)
+		_, _ = h.Write([]byte{0})
+		completedJobs := append([]appwire.EvenerJobInfo(nil), bySess[id].CompletedJobs...)
+		writeJobs(completedJobs)
 		_, _ = h.Write([]byte{0})
 	}
 	return h.Sum64()
@@ -380,6 +403,7 @@ func (r *Roster) Refresh() {
 			RunningSubagentIDs:    append([]string(nil), res.RunningSubagentIDs...),
 			RunningSubagentStates: cloneSubagentStates(res.RunningSubagentStates),
 			RunningJobs:           cloneRunningJobs(res.RunningJobs),
+			CompletedJobs:         cloneRunningJobs(res.CompletedJobs),
 		}
 		if res.SessionID != "" {
 			if prev, ok := bySess[res.SessionID]; !ok || preferLiveEntry(live, prev) {
@@ -427,9 +451,7 @@ func (r *Roster) List() []LiveEntry {
 	bySession := make(map[string]LiveEntry, len(r.byPID))
 	out := make([]LiveEntry, 0, len(r.byPID))
 	for _, e := range r.byPID {
-		e.RunningSubagentIDs = append([]string(nil), e.RunningSubagentIDs...)
-		e.RunningSubagentStates = cloneSubagentStates(e.RunningSubagentStates)
-		e.RunningJobs = cloneRunningJobs(e.RunningJobs)
+		e = cloneLiveEntry(e)
 		sessionID := envvars.FirstNonEmpty(e.SessionID, e.Entry.SessionID, e.ThreadID)
 		if sessionID == "" {
 			out = append(out, e)
@@ -493,9 +515,7 @@ func (r *Roster) Find(sessionID string) (LiveEntry, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	e, ok := r.bySess[sessionID]
-	e.RunningSubagentIDs = append([]string(nil), e.RunningSubagentIDs...)
-	e.RunningSubagentStates = cloneSubagentStates(e.RunningSubagentStates)
-	e.RunningJobs = cloneRunningJobs(e.RunningJobs)
+	e = cloneLiveEntry(e)
 	return e, ok
 }
 

--- a/cmd/evener-hub/internal/hubcore/tree.go
+++ b/cmd/evener-hub/internal/hubcore/tree.go
@@ -113,6 +113,8 @@ func cloneTreeNodesContext(ctx context.Context, nodes []TreeNode) ([]TreeNode, e
 			return nil, err
 		}
 		out[index] = node
+		out[index].RunningJobs = appwire.CloneEvenerJobs(node.RunningJobs)
+		out[index].CompletedJobs = appwire.CloneEvenerJobs(node.CompletedJobs)
 		children, err := cloneTreeNodesContext(ctx, node.Children)
 		if err != nil {
 			return nil, err
@@ -428,6 +430,10 @@ type TreeNode struct {
 	// cap. The client folds this into the parent's inactive-child disclosure so
 	// capped children are counted rather than silently disappearing.
 	MoreSubagents int
+	// RunningJobs and CompletedJobs are the non-delegate jobs owned by this
+	// session. Delegate jobs remain represented by Children as subagents.
+	RunningJobs   []appwire.EvenerJobInfo
+	CompletedJobs []appwire.EvenerJobInfo
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 	Age           string // pre-formatted "now", "2m", "3h", "5d"
@@ -1125,18 +1131,20 @@ func buildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decis
 		// for children WITH one (it overwrote the child's own daemon-reported
 		// status with the parent's projection).
 		node := TreeNode{
-			ID:         m.ID,
-			Ref:        liveRefMap[m.ID],
-			Title:      nodeTitle(m, kind),
-			Project:    acc.name,
-			Branch:     m.EnvInfo.GitBranch,
-			State:      state,
-			AskPending: askPending,
-			Dormant:    dormantFor(m.ID),
-			Kind:       kind,
-			CreatedAt:  OrderCreatedAt(m.CreatedAt, m.UpdatedAt),
-			UpdatedAt:  OrderUpdatedAt(m.UpdatedAt, m.CreatedAt),
-			Age:        AgeString(OrderUpdatedAt(m.UpdatedAt, m.CreatedAt)),
+			ID:            m.ID,
+			Ref:           liveRefMap[m.ID],
+			Title:         nodeTitle(m, kind),
+			Project:       acc.name,
+			Branch:        m.EnvInfo.GitBranch,
+			State:         state,
+			AskPending:    askPending,
+			Dormant:       dormantFor(m.ID),
+			Kind:          kind,
+			CreatedAt:     OrderCreatedAt(m.CreatedAt, m.UpdatedAt),
+			UpdatedAt:     OrderUpdatedAt(m.UpdatedAt, m.CreatedAt),
+			Age:           AgeString(OrderUpdatedAt(m.UpdatedAt, m.CreatedAt)),
+			RunningJobs:   appwire.CloneEvenerJobs(liveMap[m.ID].RunningJobs),
+			CompletedJobs: appwire.CloneEvenerJobs(liveMap[m.ID].CompletedJobs),
 		}
 
 		childMetas := childrenByParent[m.ID]
@@ -1206,6 +1214,9 @@ func buildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decis
 			taskState := s.State
 			var includeDescendants func(TreeNode)
 			includeDescendants = func(node TreeNode) {
+				if len(node.RunningJobs) > 0 && hubapi.RollupRank("active") > hubapi.RollupRank(taskState) {
+					taskState = "active"
+				}
 				for _, child := range node.Children {
 					if hubapi.RollupRank(child.State) > hubapi.RollupRank(taskState) {
 						taskState = child.State
@@ -1355,16 +1366,18 @@ func buildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decis
 		// has no lineage to recurse into.
 		if !hasMeta {
 			node := TreeNode{
-				ID:         le.SessionID,
-				Ref:        liveRefMap[le.SessionID],
-				State:      stateFor(le.SessionID),
-				AskPending: askPendingFor(le.SessionID),
-				Dormant:    dormantFor(le.SessionID),
-				Kind:       "session",
-				Title:      ShortID(le.SessionID),
-				CreatedAt:  le.StartedAt,
-				UpdatedAt:  le.StartedAt,
-				Age:        AgeString(le.StartedAt),
+				ID:            le.SessionID,
+				Ref:           liveRefMap[le.SessionID],
+				State:         stateFor(le.SessionID),
+				AskPending:    askPendingFor(le.SessionID),
+				Dormant:       dormantFor(le.SessionID),
+				Kind:          "session",
+				Title:         ShortID(le.SessionID),
+				CreatedAt:     le.StartedAt,
+				UpdatedAt:     le.StartedAt,
+				Age:           AgeString(le.StartedAt),
+				RunningJobs:   appwire.CloneEvenerJobs(le.RunningJobs),
+				CompletedJobs: appwire.CloneEvenerJobs(le.CompletedJobs),
 			}
 			liveNodes = append(liveNodes, node)
 			continue
@@ -1449,11 +1462,13 @@ func buildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decis
 			continue
 		}
 		node := TreeNode{
-			ID:         le.SessionID,
-			State:      st,
-			Kind:       "session",
-			AskPending: le.PendingAsk,
-			Dormant:    dormantFor(le.SessionID),
+			ID:            le.SessionID,
+			State:         st,
+			Kind:          "session",
+			AskPending:    le.PendingAsk,
+			Dormant:       dormantFor(le.SessionID),
+			RunningJobs:   appwire.CloneEvenerJobs(le.RunningJobs),
+			CompletedJobs: appwire.CloneEvenerJobs(le.CompletedJobs),
 		}
 		if meta != nil {
 			node.Title = nodeTitle(*meta, nodeKind(*meta))
@@ -1650,7 +1665,7 @@ func clusterable(n TreeNode) bool {
 	if n.Kind != "session" {
 		return false
 	}
-	if len(n.Children) > 0 {
+	if len(n.Children) > 0 || len(n.RunningJobs) > 0 || len(n.CompletedJobs) > 0 {
 		return false
 	}
 	return n.State == "idle" || n.State == "ended"

--- a/cmd/evener-hub/internal/hubcore/tree_live_subagents_test.go
+++ b/cmd/evener-hub/internal/hubcore/tree_live_subagents_test.go
@@ -55,6 +55,43 @@ func TestBuildTreeLiveNestsActiveSubagentUnderParent(t *testing.T) {
 	}
 }
 
+func TestBuildTreeCarriesSessionJobsForNavigation(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	metas := []schema.SessionMeta{{ID: "parent", CreatedAt: now, UpdatedAt: now, EnvInfo: schema.EnvironmentInfo{WorkingDir: "/projects/evener"}}}
+	live := []LiveEntry{{
+		PID: 1, SessionID: "parent", Status: appwire.ThreadStatusIdle,
+		RunningJobs:   []appwire.EvenerJobInfo{{JobID: "job-running", JobType: "shell", Status: "running"}},
+		CompletedJobs: []appwire.EvenerJobInfo{{JobID: "job-completed", JobType: "shell", Status: "completed"}},
+	}}
+
+	tree := BuildTreeAt(metas, live, nil, now)
+	if len(tree.Live) != 1 {
+		t.Fatalf("Live tier has %d rows, want one parent", len(tree.Live))
+	}
+	parent := tree.Live[0]
+	if len(parent.RunningJobs) != 1 || parent.RunningJobs[0].JobID != "job-running" {
+		t.Fatalf("running jobs = %+v", parent.RunningJobs)
+	}
+	if len(parent.CompletedJobs) != 1 || parent.CompletedJobs[0].JobID != "job-completed" {
+		t.Fatalf("completed jobs = %+v", parent.CompletedJobs)
+	}
+	if len(tree.Projects) != 1 || !tree.Projects[0].Expanded || tree.Projects[0].RollupLive != 1 {
+		t.Fatalf("project job rollup = %+v, want expanded with one live task", tree.Projects)
+	}
+}
+
+func TestBuildTreeNeedsYouCarriesSessionJobs(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	metas := []schema.SessionMeta{{ID: "parent", CreatedAt: now, UpdatedAt: now, EnvInfo: schema.EnvironmentInfo{WorkingDir: "/projects/evener"}}}
+	tree := BuildTreeAt(metas, []LiveEntry{{
+		PID: 1, SessionID: "parent", Status: appwire.ThreadStatusAwaiting,
+		RunningJobs: []appwire.EvenerJobInfo{{JobID: "job-running", JobType: "shell", Status: "running"}},
+	}}, nil, now)
+	if len(tree.NeedsYou) != 1 || len(tree.NeedsYou[0].RunningJobs) != 1 || tree.NeedsYou[0].RunningJobs[0].JobID != "job-running" {
+		t.Fatalf("needs-you job projection = %+v, want active job", tree.NeedsYou)
+	}
+}
+
 func TestBuildTreeLiveExcludesSubagentWhoseParentIsLive(t *testing.T) {
 	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
 	metas := []schema.SessionMeta{

--- a/cmd/evener-hub/internal/hubcore/tree_test.go
+++ b/cmd/evener-hub/internal/hubcore/tree_test.go
@@ -944,6 +944,33 @@ func fuzzScenarioBuildTree_ClustersRepeatedIdleTitles(t *testing.T) {
 	}
 }
 
+func TestBuildTreeDoesNotClusterSessionWithJobs(t *testing.T) {
+	now := time.Now()
+	metas := make([]schema.SessionMeta, 0, 4)
+	for i := range 4 {
+		metas = append(metas, schema.SessionMeta{
+			ID:        "01JOB" + string(rune('A'+i)),
+			Name:      "repeatable work",
+			UpdatedAt: now.Add(-time.Duration(i) * time.Hour),
+			EnvInfo:   schema.EnvironmentInfo{WorkingDir: "/projects/evener-jobs"},
+		})
+	}
+	tree := buildTree(metas, []LiveEntry{{
+		PID: 1, SessionID: metas[0].ID, Status: appwire.ThreadStatusIdle,
+		RunningJobs: []appwire.EvenerJobInfo{{JobID: "job-running", JobType: "shell", Status: "running"}},
+	}})
+	project := projectByName(t, tree, "evener-jobs")
+	sessions := allSessions(project)
+	if len(sessions) != 4 {
+		t.Fatalf("sessions = %d, want four unclustered rows", len(sessions))
+	}
+	for _, session := range sessions {
+		if session.Kind == "cluster" {
+			t.Fatalf("session with active job was hidden in cluster %q", session.Title)
+		}
+	}
+}
+
 func fuzzScenarioBuildTree_DoesNotClusterLiveRepeatedTitles(t *testing.T) {
 	// A live/needs-you member must keep all repeated-title sessions un-clustered
 	// so live signal is never hidden behind a fold.

--- a/cmd/evener-hub/navigation_projection.go
+++ b/cmd/evener-hub/navigation_projection.go
@@ -11,6 +11,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
 	"primeradiant.com/evener/hubapi"
 )
@@ -261,6 +262,8 @@ func cloneNavigationLiveEntries(in []hubcore.LiveEntry) []hubcore.LiveEntry {
 	for i, entry := range in {
 		out[i] = entry
 		out[i].RunningSubagentIDs = append([]string(nil), entry.RunningSubagentIDs...)
+		out[i].RunningJobs = appwire.CloneEvenerJobs(entry.RunningJobs)
+		out[i].CompletedJobs = appwire.CloneEvenerJobs(entry.CompletedJobs)
 		if entry.RunningSubagentStates != nil {
 			out[i].RunningSubagentStates = make(map[string]string, len(entry.RunningSubagentStates))
 			maps.Copy(out[i].RunningSubagentStates, entry.RunningSubagentStates)
@@ -418,6 +421,13 @@ func validateNavigationNodesContext(ctx context.Context, rows []hubcore.TreeNode
 		}
 		if _, err := navigationNodeRef(node); err != nil {
 			return err
+		}
+		for _, jobs := range [2][]appwire.EvenerJobInfo{node.RunningJobs, node.CompletedJobs} {
+			for _, job := range jobs {
+				if err := validateNavigationIdentity("job ID", job.JobID, false); err != nil {
+					return err
+				}
+			}
 		}
 		if err := validateNavigationNodesContext(ctx, node.Children); err != nil {
 			return err
@@ -1037,7 +1047,42 @@ func (p navigationProjector) projectShallow(node hubcore.TreeNode) hubapi.Naviga
 		updatedAt = &updated
 	}
 	pinned := p.projection.pinSectionFor(node.ID, ref.String()) != ""
-	return hubapi.NavigationSessionSummary{Ref: ref.String(), HostID: ref.HostID, SessionID: ref.SessionID, Title: truncateNavigationRunes(node.Title, maxNavigationTitleRunes), Project: truncateNavigationRunes(node.Project, maxNavigationLabelRunes), State: node.State, Kind: node.Kind, Branch: truncateNavigationRunes(node.Branch, maxNavigationLabelRunes), ClusterCount: node.ClusterCount, Favorite: !pinned && p.projection.sessionFavorite(node.ID, ref.String()), Rename: p.projection.renameable(node.ID, ref.String()), Live: p.projection.isLive(node.ID, ref.String()) && hubcore.NormalizeState(node.State) != "ended", AskPending: node.AskPending, Dormant: node.Dormant, UpdatedAt: updatedAt, MoreSubagents: node.MoreSubagents, Children: hubapi.NavigationArray[hubapi.NavigationSessionSummary]{}}
+	return hubapi.NavigationSessionSummary{
+		Ref:           ref.String(),
+		HostID:        ref.HostID,
+		SessionID:     ref.SessionID,
+		Title:         truncateNavigationRunes(node.Title, maxNavigationTitleRunes),
+		Project:       truncateNavigationRunes(node.Project, maxNavigationLabelRunes),
+		State:         node.State,
+		Kind:          node.Kind,
+		Branch:        truncateNavigationRunes(node.Branch, maxNavigationLabelRunes),
+		ClusterCount:  node.ClusterCount,
+		Favorite:      !pinned && p.projection.sessionFavorite(node.ID, ref.String()),
+		Rename:        p.projection.renameable(node.ID, ref.String()),
+		Live:          p.projection.isLive(node.ID, ref.String()) && hubcore.NormalizeState(node.State) != "ended",
+		AskPending:    node.AskPending,
+		Dormant:       node.Dormant,
+		UpdatedAt:     updatedAt,
+		MoreSubagents: node.MoreSubagents,
+		RunningJobs:   navigationJobs(node.RunningJobs),
+		CompletedJobs: navigationJobs(node.CompletedJobs),
+		Children:      hubapi.NavigationArray[hubapi.NavigationSessionSummary]{},
+	}
+}
+
+func navigationJobs(jobs []appwire.EvenerJobInfo) hubapi.NavigationArray[hubapi.NavigationJobSummary] {
+	out := make(hubapi.NavigationArray[hubapi.NavigationJobSummary], 0, len(jobs))
+	for _, job := range jobs {
+		out = append(out, hubapi.NavigationJobSummary{
+			JobID:   job.JobID,
+			JobType: job.JobType,
+			Status:  job.Status,
+			Command: truncateNavigationRunes(job.Command, maxNavigationLabelRunes),
+			Task:    truncateNavigationRunes(job.Task, maxNavigationLabelRunes),
+			Reason:  truncateNavigationRunes(job.Reason, maxNavigationLabelRunes),
+		})
+	}
+	return out
 }
 
 func (p navigationProjection) isLive(id, ref string) bool {
@@ -1079,6 +1124,8 @@ func cloneNavigationSummary(summary hubapi.NavigationSessionSummary) hubapi.Navi
 		updated := *summary.UpdatedAt
 		clone.UpdatedAt = &updated
 	}
+	clone.RunningJobs = append(hubapi.NavigationArray[hubapi.NavigationJobSummary](nil), summary.RunningJobs...)
+	clone.CompletedJobs = append(hubapi.NavigationArray[hubapi.NavigationJobSummary](nil), summary.CompletedJobs...)
 	clone.Children = make(hubapi.NavigationArray[hubapi.NavigationSessionSummary], len(summary.Children))
 	for index, child := range summary.Children {
 		clone.Children[index] = cloneNavigationSummary(child)

--- a/cmd/evener-hub/navigation_projection_test.go
+++ b/cmd/evener-hub/navigation_projection_test.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
 	"primeradiant.com/evener/hubapi"
 )
@@ -81,6 +82,40 @@ func TestNavigationManifestHasNoRowsAndLocationHasSummary(t *testing.T) {
 	}
 	if _, ok := any(manifest).(hubapi.NavigationSessionSummary); ok {
 		t.Fatal("manifest must not contain navigation rows")
+	}
+}
+
+func TestNavigationProjectionCarriesActiveAndCompletedJobs(t *testing.T) {
+	project := hubcore.TreeProject{
+		Key:  "project",
+		Name: "project",
+		Current: []hubcore.TreeNode{{
+			ID:    "session-parent",
+			Title: "parent",
+			Kind:  "session",
+			State: "idle",
+			RunningJobs: []appwire.EvenerJobInfo{{
+				JobID: "job-running", JobType: "shell", Status: "running", Command: "go test ./...",
+			}},
+			CompletedJobs: []appwire.EvenerJobInfo{{
+				JobID: "job-completed", JobType: "shell", Status: "completed", Command: "go fmt ./...",
+			}},
+		}},
+	}
+	projection, err := buildNavigationProjection(navigationBuildInputs{GenerationID: "generation", Tree: hubcore.Tree{Projects: []hubcore.TreeProject{project}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource, ok := projection.Project("project")
+	if !ok {
+		t.Fatal("project missing")
+	}
+	row := resource.Current.Sessions[0]
+	if len(row.RunningJobs) != 1 || row.RunningJobs[0].JobID != "job-running" || row.RunningJobs[0].Command != "go test ./..." {
+		t.Fatalf("running jobs = %+v", row.RunningJobs)
+	}
+	if len(row.CompletedJobs) != 1 || row.CompletedJobs[0].JobID != "job-completed" || row.CompletedJobs[0].Status != "completed" {
+		t.Fatalf("completed jobs = %+v", row.CompletedJobs)
 	}
 }
 

--- a/cmd/evener-hub/web_api_tree.go
+++ b/cmd/evener-hub/web_api_tree.go
@@ -606,7 +606,15 @@ func appThreadTreeEntries(thread appwire.Thread) (schema.SessionMeta, hubcore.Li
 		Status:    thread.Status.Type,
 		Project:   project,
 	}
+	entry.RunningJobs, entry.CompletedJobs = hubcore.SplitNonAgentJobs(diagnosticsJobs(thread.Evener.Diagnostics))
 	return meta, entry, true
+}
+
+func diagnosticsJobs(diagnostics *appwire.EvenerDiagnostics) []appwire.EvenerJobInfo {
+	if diagnostics == nil {
+		return nil
+	}
+	return diagnostics.Jobs
 }
 
 // appThreadTreeParentSessionID translates the remote thread lineage into the

--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -1409,6 +1409,8 @@ func agentToServerDetailedStatus(ds agent.DetailedStatus) server.DetailedStatus 
 			ExitCode:         job.ExitCode,
 			OutputBytes:      job.OutputBytes,
 			TranscriptRef:    job.TranscriptRef,
+			Command:          job.Command,
+			Task:             job.Task,
 		})
 	}
 	for _, delegate := range ds.Delegates {

--- a/hubapi/navigation.go
+++ b/hubapi/navigation.go
@@ -143,6 +143,17 @@ type NavigationSessionLocation struct {
 	Session      *NavigationSessionSummary `json:"session,omitempty"`
 }
 
+// NavigationJobSummary is the compact non-delegate job row shown beneath its
+// owning session. Delegate jobs remain represented as session children.
+type NavigationJobSummary struct {
+	JobID   string `json:"job_id"`
+	JobType string `json:"job_type"`
+	Status  string `json:"status"`
+	Command string `json:"command,omitempty"`
+	Task    string `json:"task,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+}
+
 // NavigationSessionSummary is the bounded recursive navigation row shape.
 type NavigationSessionSummary struct {
 	Ref                string                                    `json:"ref"`
@@ -162,6 +173,8 @@ type NavigationSessionSummary struct {
 	UpdatedAt          *time.Time                                `json:"updated_at,omitempty"`
 	MoreSubagents      int                                       `json:"more_subagents,omitempty"`
 	OmittedDescendants int                                       `json:"omitted_descendants,omitempty"`
+	RunningJobs        NavigationArray[NavigationJobSummary]     `json:"running_jobs,omitempty"`
+	CompletedJobs      NavigationArray[NavigationJobSummary]     `json:"completed_jobs,omitempty"`
 	Children           NavigationArray[NavigationSessionSummary] `json:"children"`
 }
 

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -2044,6 +2044,8 @@ func appDiagnosticsFromDetailedStatus(ds DetailedStatus) *appwire.EvenerDiagnost
 			ExitCode:         job.ExitCode,
 			OutputBytes:      job.OutputBytes,
 			TranscriptRef:    job.TranscriptRef,
+			Command:          job.Command,
+			Task:             job.Task,
 		})
 	}
 	for _, delegate := range ds.Delegates {

--- a/server/server.go
+++ b/server/server.go
@@ -88,6 +88,8 @@ type JobStatusInfo struct {
 	ExitCode         *int   `json:"exit_code,omitempty"`
 	OutputBytes      int64  `json:"output_bytes"`
 	TranscriptRef    string `json:"transcript_ref,omitempty"`
+	Command          string `json:"command,omitempty"`
+	Task             string `json:"task,omitempty"`
 }
 
 type DelegateStatusInfo struct {


### PR DESCRIPTION
## Summary
- show running non-delegate jobs alongside active subagents, with counts and green active-work state
- move idle subagents and completed jobs into separate disclosures
- remove the redundant mobile inline search field while keeping the rail search button
- keep mobile orientation text while hiding resume and keyboard-hint content
- make the mobile Sheet body the sole scroll container

## Validation
- make test
- make test-web
- make test-web-browser
- make vet
- make lint
- make test-race RACE_SCOPE=nonroot