### PR TITLE
Clarify tool intent guidance

### DIFF
--- a/agent/internal/tool/registry.go
+++ b/agent/internal/tool/registry.go
@@ -23,7 +23,7 @@ import (
 	"primeradiant.com/evener/llm"
 )
 
-const toolIntentDescription = "A short verb-first gerund phrase naming what this call is doing and why, e.g. \"Reading the config file\" or \"Searching for the handler\". Keep it to a few words so it renders nicely as an inline activity label."
+const toolIntentDescription = "Describe what you expect to learn or accomplish from this tool call, using a verb-first gerund. Make the expected outcome clear to the user and your future self; e.g. \"Reading config to identify the active profile\" or \"Searching handlers to locate request routing.\""
 
 // maxToolArgumentBytes caps the size of a tool call's raw argument payload
 // before it is parsed, so a runaway generation can't push a multi-hundred-KB

--- a/agent/internal/tool/registry_test.go
+++ b/agent/internal/tool/registry_test.go
@@ -17,7 +17,7 @@ import (
 	"primeradiant.com/evener/llm"
 )
 
-func TestWithIntentParameter_DescriptionGuidesGerundForm(t *testing.T) {
+func TestWithIntentParameter_DescriptionGuidesExpectedOutcome(t *testing.T) {
 	td := WithIntentParameter(llm.ToolDefinition{Name: "demo"})
 	props, _ := td.Parameters["properties"].(map[string]any)
 	if props == nil {
@@ -31,17 +31,16 @@ func TestWithIntentParameter_DescriptionGuidesGerundForm(t *testing.T) {
 	if desc == "" {
 		t.Fatalf("intent property has no description: %#v", intent)
 	}
-	// The intent string renders as an inline activity label in the UI, so the
-	// description must steer the model toward a verb-first gerund phrase with
-	// a concrete example rather than imperative or verbose prose.
+	// The description should steer the model toward a verb-first gerund phrase
+	// that states the expected outcome, not merely the action being taken.
 	if !strings.Contains(desc, "gerund") {
 		t.Errorf("description lacks gerund-form guidance: %q", desc)
 	}
-	if !strings.Contains(desc, "Reading the config file") {
-		t.Errorf("description lacks a concrete gerund example: %q", desc)
+	if !strings.Contains(desc, "expected outcome") {
+		t.Errorf("description lacks expected-outcome guidance: %q", desc)
 	}
-	if utf8.RuneCountInString(desc) > 240 {
-		t.Errorf("description should stay concise, got %d runes: %q", utf8.RuneCountInString(desc), desc)
+	if !strings.Contains(desc, "Reading config to identify the active profile") {
+		t.Errorf("description lacks an example with an explicit outcome: %q", desc)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Explain that `intent` should describe what the tool call is expected to teach or accomplish.
- Add outcome-oriented examples and update the schema test.

## Testing
- `go test ./...`