### PR TITLE
fix(hub): classify quiesced delegates as idle

### DIFF
--- a/cmd/evener-hub/internal/hubcore/prober.go
+++ b/cmd/evener-hub/internal/hubcore/prober.go
@@ -42,11 +42,15 @@ func (p *StatusProber) Probe(entry rendezvous.Entry) ProbeResult {
 	if _, err := appClient.Initialize(ctx, appwire.InitializeParams{ClientInfo: appwire.ClientInfo{Name: "evener-hub"}}); err != nil {
 		return ProbeResult{}
 	}
-	rootResponse, err := appClient.ThreadRead(ctx, appwire.ThreadReadParams{})
+	// Read descendants before the root diagnostics. A retained delegate can be
+	// resumed between these calls; taking the child projection first means a
+	// later running lifecycle cannot be mistaken for stale active work and then
+	// overwritten as idle by an older root snapshot.
+	listResponse, err := appClient.ThreadList(ctx, appwire.ThreadListParams{IncludeSubagents: true})
 	if err != nil {
 		return ProbeResult{}
 	}
-	listResponse, err := appClient.ThreadList(ctx, appwire.ThreadListParams{IncludeSubagents: true})
+	rootResponse, err := appClient.ThreadRead(ctx, appwire.ThreadReadParams{})
 	if err != nil {
 		return ProbeResult{}
 	}
@@ -56,13 +60,20 @@ func (p *StatusProber) Probe(entry rendezvous.Entry) ProbeResult {
 		return ProbeResult{}
 	}
 
+	// ThreadList carries the root and descendants from one projection cut. Keep
+	// the ThreadRead result only for identity validation, and use the matching
+	// listed root so its diagnostics and child projections cannot come from
+	// different snapshots.
+	var listedRoot *appwire.Thread
 	seen := make(map[string]bool)
-	rootListed := false
 	var runningSubagentIDs []string
 	var runningSubagentStates map[string]string
-	for _, thread := range listResponse.Data {
-		if thread.ID == root.ID && statusThreadID(thread) == rootID {
-			rootListed = true
+	for i := range listResponse.Data {
+		thread := listResponse.Data[i]
+		if isRootThread(thread, root) {
+			if listedRoot == nil {
+				listedRoot = &listResponse.Data[i]
+			}
 			continue
 		}
 		if thread.Status.Type == appwire.ThreadStatusClosed {
@@ -81,8 +92,19 @@ func (p *StatusProber) Probe(entry rendezvous.Entry) ProbeResult {
 			runningSubagentStates[id] = state
 		}
 	}
-	if !rootListed {
+	if listedRoot == nil {
 		return ProbeResult{}
+	}
+	root = *listedRoot
+
+	idleStableDelegateChildren := idleStableDelegateChildIDs(root.Evener.Diagnostics)
+	for _, id := range runningSubagentIDs {
+		if _, quiesced := idleStableDelegateChildren[id]; quiesced {
+			if runningSubagentStates == nil {
+				runningSubagentStates = make(map[string]string)
+			}
+			runningSubagentStates[id] = appwire.ThreadStatusIdle
+		}
 	}
 	sort.Strings(runningSubagentIDs)
 
@@ -105,6 +127,32 @@ func statusThreadID(thread appwire.Thread) string {
 		return sessionID
 	}
 	return strings.TrimSpace(thread.ID)
+}
+
+func isRootThread(thread, root appwire.Thread) bool {
+	return thread.ID == root.ID && statusThreadID(thread) == statusThreadID(root)
+}
+
+// idleStableDelegateChildIDs identifies retained stable delegates with no
+// current run. Their child thread can retain an older active projection while
+// the runtime is kept for a later resume, so the durable delegate lifecycle is
+// authoritative for the parent-side navigation state.
+func idleStableDelegateChildIDs(diagnostics *appwire.EvenerDiagnostics) map[string]struct{} {
+	if diagnostics == nil {
+		return nil
+	}
+	var ids map[string]struct{}
+	for _, delegate := range diagnostics.Delegates {
+		childID := strings.TrimSpace(delegate.ChildSessionID)
+		if childID == "" || strings.TrimSpace(delegate.Lifecycle) != "idle" {
+			continue
+		}
+		if ids == nil {
+			ids = make(map[string]struct{})
+		}
+		ids[childID] = struct{}{}
+	}
+	return ids
 }
 
 func splitNonAgentJobs(diagnostics *appwire.EvenerDiagnostics) ([]appwire.EvenerJobInfo, []appwire.EvenerJobInfo) {

--- a/cmd/evener-hub/internal/hubcore/prober_wire_test.go
+++ b/cmd/evener-hub/internal/hubcore/prober_wire_test.go
@@ -160,3 +160,78 @@ func TestStatusProberReadsAppWireStatusIncludingNonAgentJobs(t *testing.T) {
 		t.Fatalf("running job = %+v, want shell identity and status from Evener.Diagnostics.Jobs", job)
 	}
 }
+
+func TestStatusProberProjectsQuiescedStableDelegateAsIdle(t *testing.T) {
+	// A retained child can still have an active descendant projection even after
+	// its stable delegate run has settled. The stable delegate lifecycle is the
+	// authoritative no-current-run signal for the parent-side projection.
+	prober, entry := startProbeDaemon(t, probeDaemonConfig{
+		sessionID: "th_wire_quiesced",
+		descendants: map[string]string{
+			"child-quiesced": appwire.ThreadStatusActive,
+		},
+		source: wireProbeEnvelopeSource{detailed: server.DetailedStatus{Delegates: []server.DelegateStatusInfo{{
+			DelegateID: "dlg_quiesced", ChildSessionID: "child-quiesced",
+			Lifecycle: "idle", Phase: "idle", Status: "idle", Resumable: true,
+		}}}},
+	})
+	got := prober.Probe(entry)
+	if !got.OK {
+		t.Fatal("expected ok=true probing a real server")
+	}
+	if want := []string{"child-quiesced"}; !reflect.DeepEqual(got.RunningSubagentIDs, want) {
+		t.Fatalf("running subagent ids = %v, want %v so the retained child remains visible", got.RunningSubagentIDs, want)
+	}
+	if got.RunningSubagentStates["child-quiesced"] != appwire.ThreadStatusIdle {
+		t.Fatalf("quiesced child state = %q, want idle from stable delegate diagnostics", got.RunningSubagentStates["child-quiesced"])
+	}
+}
+
+func TestStatusProberDoesNotMaskChildResumeBetweenSnapshots(t *testing.T) {
+	rpc := appserver.NewServer(appserver.ServerConfig{ServerName: "status-test", SourceID: "local"})
+	var calls []string
+	record := func(name string) {
+		calls = append(calls, name)
+	}
+	root := func(lifecycle string) appwire.Thread {
+		return appwire.Thread{
+			ID: "root", SessionID: "root", Status: appwire.ThreadStatus{Type: appwire.ThreadStatusIdle},
+			Evener: appwire.EvenerThread{Diagnostics: &appwire.EvenerDiagnostics{
+				Delegates: []appwire.EvenerDelegateInfo{{
+					ChildSessionID: "child-resumed", Lifecycle: lifecycle, Phase: lifecycle, Status: lifecycle,
+				}},
+			}},
+		}
+	}
+	appserver.HandleTyped(rpc.Router(), appwire.MethodThreadList, func(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+		record("list")
+		return appwire.ThreadListResponse{Data: []appwire.Thread{
+			root(""),
+			{ID: "child-resumed", SessionID: "child-resumed", Status: appwire.ThreadStatus{Type: appwire.ThreadStatusActive}},
+		}}, nil
+	})
+	appserver.HandleTyped(rpc.Router(), appwire.MethodThreadRead, func(context.Context, appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		record("read")
+		listWasFirst := len(calls) > 0 && calls[0] == "list"
+		lifecycle := "idle"
+		if listWasFirst {
+			lifecycle = "running"
+		}
+		return appwire.ThreadReadResponse{Thread: root(lifecycle)}, nil
+	})
+	httpSrv := httptest.NewServer(http.HandlerFunc(rpc.ServeWebSocket))
+	defer httpSrv.Close()
+
+	got := (&StatusProber{client: httpSrv.Client()}).Probe(rendezvous.Entry{
+		Endpoint: "ws" + strings.TrimPrefix(httpSrv.URL, "http"),
+	})
+	if !got.OK {
+		t.Fatal("expected ok=true probing a real server")
+	}
+	if got.RunningSubagentStates["child-resumed"] != appwire.ThreadStatusActive {
+		t.Fatalf("resumed child state = %q, want active from the newer lifecycle snapshot", got.RunningSubagentStates["child-resumed"])
+	}
+	if !reflect.DeepEqual(calls, []string{"list", "read"}) {
+		t.Fatalf("probe snapshot calls = %v, want list before read to avoid masking a resume", calls)
+	}
+}

--- a/cmd/evener-hub/internal/hubcore/roster.go
+++ b/cmd/evener-hub/internal/hubcore/roster.go
@@ -29,12 +29,13 @@ type LiveEntry struct {
 	PendingAsk         bool     // true while the daemon reports an unanswered ask_user question
 	PendingEscalation  bool     // true while the daemon reports a blocked sandbox-exemption escalation (M7)
 	RunningSubagentIDs []string // in-process children reported by this daemon; not independently routable
-	// RunningSubagentStates carries each running child's own projected status
-	// ("active", "idle", ...) when the daemon reports it. A listed child with
-	// no entry has an unknown state (old daemon) — callers must NOT treat
-	// liveness as activity, and fold a no-state child to idle rather than
-	// active. Keyed by child session ID; a defensive copy rides every
-	// List/Find like the IDs slice.
+	// RunningSubagentStates carries each listed child's projected status
+	// ("active", "idle", ...) when the daemon reports it. Retained stable
+	// delegates with no current run are projected as idle even if their child
+	// thread has a stale active status. A listed child with no entry has an
+	// unknown state (old daemon) — callers must NOT treat liveness as activity,
+	// and fold a no-state child to idle rather than active. Keyed by child
+	// session ID; a defensive copy rides every List/Find like the IDs slice.
 	RunningSubagentStates map[string]string
 	// RunningJobs contains non-terminal, non-agent work reported by the daemon,
 	// such as shell and watch jobs. Delegate jobs stay represented by the

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -958,8 +958,8 @@ func (s *Server) registerAppWireHandlers() {
 }
 
 func (s *Server) handleAppThreadList(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
-	data := []appwire.Thread{s.appThread()}
 	s.mu.RLock()
+	data := []appwire.Thread{s.appThreadLocked()}
 	ids := make([]string, 0, len(s.appDescendants))
 	for id := range s.appDescendants {
 		ids = append(ids, id)
@@ -1912,6 +1912,11 @@ func (s *Server) handleAppModelList(ctx context.Context, _ appwire.ModelListPara
 // jobs.jsonl read, or the session's own mutex.
 func (s *Server) appThread() appwire.Thread {
 	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.appThreadLocked()
+}
+
+func (s *Server) appThreadLocked() appwire.Thread {
 	status := s.status
 	sourceID := s.appSourceID
 	threadID := s.appThreadID
@@ -1920,7 +1925,6 @@ func (s *Server) appThread() appwire.Thread {
 	turnReserved := strings.TrimSpace(s.appReservedTurnID) != ""
 	envelope := s.appEnvelope
 	activeTurnID := s.appActiveTurnID
-	s.mu.RUnlock()
 
 	if sourceID == "" {
 		sourceID = "local"
@@ -1976,7 +1980,7 @@ func (s *Server) appThread() appwire.Thread {
 			ContextUsed:           metrics.Used,
 			ContextWindow:         metrics.Window,
 			ContextRemaining:      metrics.Remaining,
-			Capabilities:          s.appCapabilities(status.State, processing),
+			Capabilities:          s.appCapabilitiesLocked(status.State, processing),
 			Diagnostics:           diagnostics,
 			Queue:                 queue,
 			PendingMutations:      pendingMutations,
@@ -2110,6 +2114,10 @@ func cloneServerInt64(value *int64) *int64 {
 func (s *Server) appCapabilities(state string, processing bool) appwire.ThreadCapabilities {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	return s.appCapabilitiesLocked(state, processing)
+}
+
+func (s *Server) appCapabilitiesLocked(state string, processing bool) appwire.ThreadCapabilities {
 	// Status-dependent capabilities derive from the status this thread PUBLISHES,
 	// not assembled again from the fields behind it. Clear additionally requires
 	// its handler and state gate to report that the action is currently safe.


### PR DESCRIPTION
## Summary
- use the existing stable delegate lifecycle to project retained/quiesced children as idle
- take root diagnostics and descendants from one atomic thread/list snapshot
- add deterministic AppWire regressions for quiesced children and resume ordering

## Verification
- make test
- make vet
- make lint
- go test -race ./server ./cmd/evener-hub/internal/hubcore -count=1