### PR TITLE
fix(web): keep the mobile composer above the on-screen keyboard

### DIFF
--- a/cmd/evener-hub/frontend/index.html
+++ b/cmd/evener-hub/frontend/index.html
@@ -5,8 +5,13 @@
     <!-- Pinned like an installed app: maximum-scale=1/user-scalable=no stop
          iOS Safari's auto-zoom when a sub-16px field (the composer textarea)
          gains focus; viewport-fit=cover makes the env(safe-area-inset-*)
-         paddings in the mobile shell nonzero. -->
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
+         paddings in the mobile shell nonzero. interactive-widget=resizes-content
+         makes Chromium/Android shrink the layout viewport when the on-screen
+         keyboard opens, so the fixed mobile shell (and the composer docked in
+         its footer) rides up instead of sliding under the keyboard; browsers
+         that don't know the key (Safari) ignore it — Safari gets the same
+         result from useKeyboardInset's visualViewport-driven --keyboard-inset. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content" />
     <!-- Mirrors tokens.css's dark --surface-0 and the PWA manifest's
          background_color/theme_color; src/styles/pwa-manifest-colors.test.ts
          locks all three together. -->

--- a/cmd/evener-hub/frontend/src/shell/AppShell.module.css
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.module.css
@@ -51,13 +51,8 @@
     position: fixed;
     inset: 0;
     width: 100%;
-    /* iOS Safari shrinks only the visual viewport when the on-screen keyboard
-     * opens, leaving this fixed shell at full height with the composer under
-     * the keyboard. useKeyboardInset mirrors the occluded strip into
-     * --keyboard-inset; spending it as padding (border-box is global) pulls
-     * the footer's composer up above the keyboard. 0px everywhere else:
-     * Chromium/Android resizes the layout viewport itself via the viewport
-     * meta's interactive-widget=resizes-content. */
+    /* Rides the composer up with iOS's on-screen keyboard: useKeyboardInset
+     * (see its header) feeds --keyboard-inset; 0px elsewhere. */
     padding-bottom: var(--keyboard-inset, 0px);
   }
 

--- a/cmd/evener-hub/frontend/src/shell/AppShell.module.css
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.module.css
@@ -51,6 +51,14 @@
     position: fixed;
     inset: 0;
     width: 100%;
+    /* iOS Safari shrinks only the visual viewport when the on-screen keyboard
+     * opens, leaving this fixed shell at full height with the composer under
+     * the keyboard. useKeyboardInset mirrors the occluded strip into
+     * --keyboard-inset; spending it as padding (border-box is global) pulls
+     * the footer's composer up above the keyboard. 0px everywhere else:
+     * Chromium/Android resizes the layout viewport itself via the viewport
+     * meta's interactive-widget=resizes-content. */
+    padding-bottom: var(--keyboard-inset, 0px);
   }
 
   .content {

--- a/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
@@ -2038,10 +2038,9 @@ test("mobile: the shell content frame drops its padding so the workspace is full
 });
 
 test("mobile: the shell spends --keyboard-inset as bottom padding so the composer clears the on-screen keyboard", () => {
-  // iOS Safari shrinks only the visual viewport when the keyboard opens, so
-  // the fixed shell would keep the composer under it; useKeyboardInset feeds
-  // this variable. Comments are stripped before matching (testing.md: a
-  // comment quoting the declaration must not satisfy the assertion).
+  // See useKeyboardInset.ts's header for the mechanism. Comments are stripped
+  // before matching (testing.md: a comment quoting the declaration must not
+  // satisfy the assertion).
   const here = dirname(fileURLToPath(import.meta.url));
   const css = readFileSync(join(here, "AppShell.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
   const mobile = css.match(/@media \(max-width: 899px\) \{([\s\S]*?)\n\}/);

--- a/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
@@ -2068,7 +2068,34 @@ test("mobile: the shared shell follows the visible viewport while retaining a vh
   expect(supportsShellRule![0]).not.toContain("height: 100vh");
 });
 
-// --- kata bbsv: a mobile deep link outlives the wait for the tree --------
+// --- useKeyboardInset wiring (pins the AppShell -> hook call) --------------
+// The hook's own tests pin that it sets --keyboard-inset given a visualViewport,
+// and the CSS test above pins that the mobile .shell rule consumes it, but
+// nothing connects the two through the real component: jsdom has no
+// visualViewport, so every AppShell render in this file never exercises it.
+// This test stubs one and renders the real AppShell to close that gap.
+
+test("AppShell mounts useKeyboardInset, so a visualViewport resize sets --keyboard-inset on the root", async () => {
+  // A real EventTarget so the hook's add/removeEventListener round-trips; the
+  // hook reads height/offsetTop/scale off the same object.
+  class FakeVisualViewport extends EventTarget {
+    height = 768;
+    offsetTop = 0;
+    scale = 1;
+  }
+  const fake = new FakeVisualViewport();
+  vi.stubGlobal("visualViewport", fake);
+  Object.defineProperty(window, "innerHeight", { value: 768, configurable: true, writable: true });
+  const { unmount } = render(<AppShell client={new FakeClient("ready")} />);
+  // Mount sets the initial value (0px: the fake viewport covers the layout).
+  expect(document.documentElement.style.getPropertyValue("--keyboard-inset")).toBe("0px");
+  // Keyboard opens: visualViewport shrinks; the hook writes the occluded strip.
+  fake.height = 400;
+  fake.dispatchEvent(new Event("resize"));
+  expect(document.documentElement.style.getPropertyValue("--keyboard-inset")).toBe("368px");
+  unmount();
+  vi.unstubAllGlobals();
+});
 
 // jsdom implements no matchMedia at all (useIsMobile.test.ts's own header
 // comment documents the probe), so a mobile-layout test installs one: the

--- a/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
@@ -2037,6 +2037,20 @@ test("mobile: the shell content frame drops its padding so the workspace is full
   expect(contentRule![1]).not.toContain("gap:");
 });
 
+test("mobile: the shell spends --keyboard-inset as bottom padding so the composer clears the on-screen keyboard", () => {
+  // iOS Safari shrinks only the visual viewport when the keyboard opens, so
+  // the fixed shell would keep the composer under it; useKeyboardInset feeds
+  // this variable. Comments are stripped before matching (testing.md: a
+  // comment quoting the declaration must not satisfy the assertion).
+  const here = dirname(fileURLToPath(import.meta.url));
+  const css = readFileSync(join(here, "AppShell.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+  const mobile = css.match(/@media \(max-width: 899px\) \{([\s\S]*?)\n\}/);
+  expect(mobile).not.toBeNull();
+  const shellRule = mobile![1]!.match(/\.shell \{([\s\S]*?)\n[ ]{2}\}/);
+  expect(shellRule).not.toBeNull();
+  expect(shellRule![0]).toContain("padding-bottom: var(--keyboard-inset, 0px)");
+});
+
 test("mobile: the shared shell follows the visible viewport while retaining a vh fallback", () => {
   const here = dirname(fileURLToPath(import.meta.url));
   const css = readFileSync(join(here, "AppShell.module.css"), "utf8");

--- a/cmd/evener-hub/frontend/src/shell/AppShell.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.tsx
@@ -491,9 +491,8 @@ export function AppShell({ client: injectedClient, bannerDelayMs }: AppShellProp
       .catch(() => undefined);
   }, [locationFailed, locationRef, locationResource]);
   const isMobile = useIsMobile();
-  // iOS Safari half of the keyboard fix: keeps --keyboard-inset current so the
-  // mobile .shell padding-bottom (AppShell.module.css) rides the composer up
-  // with the on-screen keyboard. Harmless on desktop, where the inset stays 0.
+  // Keeps --keyboard-inset current for the mobile .shell rule; see
+  // useKeyboardInset.ts's header for the why.
   useKeyboardInset();
   const pendingSessionRef = useRef<string | null>(null);
   // Single-pane mode (the /thread/{ref} share link): the shell strips its own

--- a/cmd/evener-hub/frontend/src/shell/AppShell.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.tsx
@@ -33,6 +33,7 @@ import { urlToPane } from "./routing";
 import { openNestedSessionWithOwner, openTopLevelSession } from "./sessionPlacement";
 import { isSinglePaneRoute } from "./singlePane";
 import { useIsMobile } from "./useIsMobile";
+import { useKeyboardInset } from "./useKeyboardInset";
 import { type OpenPaneRecord, workspaceStore } from "./workspace";
 import "../panes/welcome"; // registers the "welcome" pane type
 import "../panes/session"; // registers the "session" pane type
@@ -490,6 +491,10 @@ export function AppShell({ client: injectedClient, bannerDelayMs }: AppShellProp
       .catch(() => undefined);
   }, [locationFailed, locationRef, locationResource]);
   const isMobile = useIsMobile();
+  // iOS Safari half of the keyboard fix: keeps --keyboard-inset current so the
+  // mobile .shell padding-bottom (AppShell.module.css) rides the composer up
+  // with the on-screen keyboard. Harmless on desktop, where the inset stays 0.
+  useKeyboardInset();
   const pendingSessionRef = useRef<string | null>(null);
   // Single-pane mode (the /thread/{ref} share link): the shell strips its own
   // chrome - the rail (which carries the search/settings entry points, floor

--- a/cmd/evener-hub/frontend/src/shell/useKeyboardInset.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/useKeyboardInset.test.tsx
@@ -1,41 +1,20 @@
 // @vitest-environment jsdom
 
-// Pins the iOS half of the on-screen-keyboard fix: the hook mirrors the
-// visual viewport's occluded bottom strip into --keyboard-inset, which the
-// mobile .shell rule (AppShell.module.css) spends as padding-bottom. The fake
-// visualViewport below is the external boundary (the browser's own object);
-// everything under test is the real hook.
+// Pins the hook half of the keyboard fix (see useKeyboardInset.ts's header
+// for the full rationale): --keyboard-inset tracks the visual viewport's
+// occluded bottom strip. The fake visualViewport below is the external
+// boundary (the browser's own object); everything under test is the real hook.
 import { renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { keyboardInset, useKeyboardInset } from "./useKeyboardInset";
 
-type Listener = () => void;
-
-class FakeVisualViewport {
+class FakeVisualViewport extends EventTarget {
   height = 700;
   offsetTop = 0;
   scale = 1;
-  private listeners = new Map<string, Set<Listener>>();
-
-  addEventListener(type: string, listener: Listener): void {
-    let set = this.listeners.get(type);
-    if (!set) {
-      set = new Set();
-      this.listeners.set(type, set);
-    }
-    set.add(listener);
-  }
-
-  removeEventListener(type: string, listener: Listener): void {
-    this.listeners.get(type)?.delete(listener);
-  }
-
-  listenerCount(type: string): number {
-    return this.listeners.get(type)?.size ?? 0;
-  }
 
   fire(type: "resize" | "scroll"): void {
-    for (const listener of this.listeners.get(type) ?? []) listener();
+    this.dispatchEvent(new Event(type));
   }
 }
 
@@ -91,16 +70,19 @@ describe("useKeyboardInset", () => {
     unmount();
   });
 
-  test("unmount removes the variable and every listener", () => {
+  test("unmount removes the variable and every listener it added", () => {
     const vv = installVisualViewport();
     setInnerHeight(768);
+    const addSpy = vi.spyOn(vv, "addEventListener");
+    const removeSpy = vi.spyOn(vv, "removeEventListener");
     const { unmount } = renderHook(() => useKeyboardInset());
-    expect(vv.listenerCount("resize")).toBe(1);
-    expect(vv.listenerCount("scroll")).toBe(1);
+    const added = addSpy.mock.calls.map(([type, listener]) => ({ type, listener }));
+    expect(added.map(({ type }) => type).sort()).toEqual(["resize", "scroll"]);
 
     unmount();
-    expect(vv.listenerCount("resize")).toBe(0);
-    expect(vv.listenerCount("scroll")).toBe(0);
+    for (const { type, listener } of added) {
+      expect(removeSpy).toHaveBeenCalledWith(type, listener);
+    }
     expect(document.documentElement.style.getPropertyValue("--keyboard-inset")).toBe("");
   });
 

--- a/cmd/evener-hub/frontend/src/shell/useKeyboardInset.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/useKeyboardInset.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+
+// Pins the iOS half of the on-screen-keyboard fix: the hook mirrors the
+// visual viewport's occluded bottom strip into --keyboard-inset, which the
+// mobile .shell rule (AppShell.module.css) spends as padding-bottom. The fake
+// visualViewport below is the external boundary (the browser's own object);
+// everything under test is the real hook.
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { keyboardInset, useKeyboardInset } from "./useKeyboardInset";
+
+type Listener = () => void;
+
+class FakeVisualViewport {
+  height = 700;
+  offsetTop = 0;
+  scale = 1;
+  private listeners = new Map<string, Set<Listener>>();
+
+  addEventListener(type: string, listener: Listener): void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(listener);
+  }
+
+  removeEventListener(type: string, listener: Listener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  listenerCount(type: string): number {
+    return this.listeners.get(type)?.size ?? 0;
+  }
+
+  fire(type: "resize" | "scroll"): void {
+    for (const listener of this.listeners.get(type) ?? []) listener();
+  }
+}
+
+function installVisualViewport(): FakeVisualViewport {
+  const fake = new FakeVisualViewport();
+  vi.stubGlobal("visualViewport", fake);
+  return fake;
+}
+
+function setInnerHeight(px: number): void {
+  Object.defineProperty(window, "innerHeight", { value: px, configurable: true, writable: true });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.documentElement.style.removeProperty("--keyboard-inset");
+});
+
+describe("keyboardInset", () => {
+  test("is the layout-viewport strip hanging below the visual viewport", () => {
+    expect(keyboardInset({ height: 400, offsetTop: 0, scale: 1 }, 768)).toBe(368);
+  });
+
+  test("subtracts the visual viewport's scroll offset", () => {
+    expect(keyboardInset({ height: 400, offsetTop: 100, scale: 1 }, 768)).toBe(268);
+  });
+
+  test("never goes negative when the visual viewport covers the layout viewport", () => {
+    expect(keyboardInset({ height: 800, offsetTop: 0, scale: 1 }, 768)).toBe(0);
+  });
+
+  test("reports 0 under pinch zoom, which occludes nothing", () => {
+    expect(keyboardInset({ height: 400, offsetTop: 0, scale: 2 }, 768)).toBe(0);
+  });
+});
+
+describe("useKeyboardInset", () => {
+  test("sets --keyboard-inset on mount and tracks resize and scroll events", () => {
+    const vv = installVisualViewport();
+    setInnerHeight(768);
+    vv.height = 768;
+    const { unmount } = renderHook(() => useKeyboardInset());
+    expect(document.documentElement.style.getPropertyValue("--keyboard-inset")).toBe("0px");
+
+    vv.height = 400; // keyboard opened
+    vv.fire("resize");
+    expect(document.documentElement.style.getPropertyValue("--keyboard-inset")).toBe("368px");
+
+    vv.offsetTop = 100; // Safari scrolled the visual viewport down
+    vv.fire("scroll");
+    expect(document.documentElement.style.getPropertyValue("--keyboard-inset")).toBe("268px");
+
+    unmount();
+  });
+
+  test("unmount removes the variable and every listener", () => {
+    const vv = installVisualViewport();
+    setInnerHeight(768);
+    const { unmount } = renderHook(() => useKeyboardInset());
+    expect(vv.listenerCount("resize")).toBe(1);
+    expect(vv.listenerCount("scroll")).toBe(1);
+
+    unmount();
+    expect(vv.listenerCount("resize")).toBe(0);
+    expect(vv.listenerCount("scroll")).toBe(0);
+    expect(document.documentElement.style.getPropertyValue("--keyboard-inset")).toBe("");
+  });
+
+  test("is a no-op when the browser has no visualViewport", () => {
+    vi.stubGlobal("visualViewport", null);
+    const { unmount } = renderHook(() => useKeyboardInset());
+    expect(document.documentElement.style.getPropertyValue("--keyboard-inset")).toBe("");
+    unmount();
+  });
+});

--- a/cmd/evener-hub/frontend/src/shell/useKeyboardInset.ts
+++ b/cmd/evener-hub/frontend/src/shell/useKeyboardInset.ts
@@ -31,8 +31,14 @@ export function useKeyboardInset(): void {
     // Guard covers both null (stubbed) and undefined (jsdom, old browsers).
     if (!vv) return undefined;
     const root = document.documentElement;
+    let lastValue: string | null = null;
     const apply = (): void => {
-      root.style.setProperty(VAR_NAME, `${keyboardInset(vv, window.innerHeight)}px`);
+      // Scroll events fire per-frame with an almost-always-unchanged value;
+      // only a real change earns the style recalc.
+      const next = `${keyboardInset(vv, window.innerHeight)}px`;
+      if (next === lastValue) return;
+      lastValue = next;
+      root.style.setProperty(VAR_NAME, next);
     };
     apply();
     vv.addEventListener("resize", apply);

--- a/cmd/evener-hub/frontend/src/shell/useKeyboardInset.ts
+++ b/cmd/evener-hub/frontend/src/shell/useKeyboardInset.ts
@@ -1,0 +1,46 @@
+// iOS Safari's half of the on-screen-keyboard fix (the viewport meta's
+// interactive-widget=resizes-content covers Chromium/Android; Safari ignores
+// that key). When the keyboard opens, Safari shrinks only the VISUAL viewport
+// — the layout viewport the fixed mobile shell (AppShell.module.css's
+// position:fixed; inset:0) is sized against stays full height, so the composer
+// docked in the shell's footer ends up underneath the keyboard. This hook
+// mirrors the occluded bottom strip into a --keyboard-inset CSS variable that
+// the mobile .shell rule spends as padding-bottom, riding the composer up
+// exactly with the keyboard and back down when it closes.
+import { useEffect } from "react";
+
+const VAR_NAME = "--keyboard-inset";
+
+/**
+ * Bottom pixels of the layout viewport occluded by the on-screen keyboard (or
+ * any other visual-viewport shrink, e.g. Safari's collapsing toolbars).
+ * offsetTop is subtracted because the visual viewport may also be scrolled
+ * away from the layout viewport's top edge; only the remainder hangs past its
+ * bottom. Pinch zoom (scale > 1) shrinks the visual viewport without occluding
+ * anything, so it reports 0 — and the pinned viewport meta keeps scale at 1 in
+ * practice, so this is a guard, not the mechanism.
+ */
+export function keyboardInset(vv: Pick<VisualViewport, "height" | "offsetTop" | "scale">, innerHeight: number): number {
+  if (Math.abs(vv.scale - 1) > 0.01) return 0;
+  return Math.max(0, innerHeight - vv.height - vv.offsetTop);
+}
+
+export function useKeyboardInset(): void {
+  useEffect(() => {
+    const vv = window.visualViewport;
+    // Guard covers both null (stubbed) and undefined (jsdom, old browsers).
+    if (!vv) return undefined;
+    const root = document.documentElement;
+    const apply = (): void => {
+      root.style.setProperty(VAR_NAME, `${keyboardInset(vv, window.innerHeight)}px`);
+    };
+    apply();
+    vv.addEventListener("resize", apply);
+    vv.addEventListener("scroll", apply);
+    return () => {
+      vv.removeEventListener("resize", apply);
+      vv.removeEventListener("scroll", apply);
+      root.style.removeProperty(VAR_NAME);
+    };
+  }, []);
+}

--- a/cmd/evener-hub/frontend/src/styles/viewport-pin.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/viewport-pin.test.ts
@@ -36,3 +36,12 @@ test("the viewport meta uses viewport-fit=cover so safe-area insets are nonzero"
   // values resolve to 0 and the insets are dead code.
   expect(viewportContent()).toContain("viewport-fit=cover");
 });
+
+test("the viewport meta resizes content around the on-screen keyboard", () => {
+  // Without interactive-widget=resizes-content, Chromium/Android keeps the
+  // layout viewport at full height when the keyboard opens (resizes-visual is
+  // the default), so the fixed mobile shell and the composer docked in its
+  // footer slide under the keyboard. Safari ignores the unknown key and is
+  // covered by useKeyboardInset instead.
+  expect(viewportContent()).toContain("interactive-widget=resizes-content");
+});

--- a/cmd/evener-hub/frontend/src/styles/viewport-pin.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/viewport-pin.test.ts
@@ -38,10 +38,7 @@ test("the viewport meta uses viewport-fit=cover so safe-area insets are nonzero"
 });
 
 test("the viewport meta resizes content around the on-screen keyboard", () => {
-  // Without interactive-widget=resizes-content, Chromium/Android keeps the
-  // layout viewport at full height when the keyboard opens (resizes-visual is
-  // the default), so the fixed mobile shell and the composer docked in its
-  // footer slide under the keyboard. Safari ignores the unknown key and is
-  // covered by useKeyboardInset instead.
+  // Chromium/Android's half of the keyboard fix; Safari ignores the unknown
+  // key and is covered by useKeyboardInset (see its header).
   expect(viewportContent()).toContain("interactive-widget=resizes-content");
 });

--- a/cmd/evener-hub/frontend/src/widgets/panescaffold/panescaffold.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/panescaffold/panescaffold.module.css
@@ -84,8 +84,11 @@
    * that StackHost's blanket host padding is gone (see that rule's comment):
    * footer-less panes (welcome, settings, spawn, doc) dock nothing of their
    * own, so their scroll padding carries the inset. env() is 0 on desktop,
-   * where this resolves to plain --space-4. */
-  padding-bottom: calc(var(--space-4) + env(safe-area-inset-bottom));
+   * where this resolves to plain --space-4. The inset yields when the on-screen
+   * keyboard covers the home-indicator band (useKeyboardInset's
+   * --keyboard-inset, 0px everywhere else): max(0, inset - keyboard) keeps
+   * full inset when the keyboard is closed and plain --space-4 when open. */
+  padding-bottom: calc(var(--space-4) + max(0px, env(safe-area-inset-bottom) - var(--keyboard-inset, 0px)));
 }
 
 .footer {
@@ -97,8 +100,11 @@
    * under the input). The footer's own chrome fills the home-indicator band
    * while this padding keeps the composer controls above it - the same
    * recipe StackHost's top bar uses at the top edge. env() is 0 on desktop,
-   * where this resolves to plain --space-3. */
-  padding-bottom: calc(var(--space-3) + env(safe-area-inset-bottom));
+   * where this resolves to plain --space-3. The inset yields when the on-screen
+   * keyboard covers the home-indicator band (useKeyboardInset's
+   * --keyboard-inset, 0px everywhere else): max(0, inset - keyboard) keeps
+   * full inset when the keyboard is closed and plain --space-3 when open. */
+  padding-bottom: calc(var(--space-3) + max(0px, env(safe-area-inset-bottom) - var(--keyboard-inset, 0px)));
   border-top: 1px solid var(--edge);
 }
 

--- a/cmd/evener-hub/frontend/src/widgets/panescaffold/panescaffold.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/panescaffold/panescaffold.test.tsx
@@ -185,7 +185,9 @@ test("the footer fills to the screen's bottom edge while keeping its content cle
   // "a stylesheet assertion that matches its own comment" trap).
   const css = readFileSync(join(here, "panescaffold.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
   const footerRule = css.match(/\.footer \{([^}]*)\}/)?.[1] ?? "";
-  expect(footerRule).toContain("padding-bottom: calc(var(--space-3) + env(safe-area-inset-bottom))");
+  expect(footerRule).toContain(
+    "padding-bottom: calc(var(--space-3) + max(0px, env(safe-area-inset-bottom) - var(--keyboard-inset, 0px)))",
+  );
 });
 
 // Footer-less panes (welcome, settings, spawn, doc) had their end-of-scroll
@@ -196,7 +198,9 @@ test("the body keeps end-of-scroll content clear of the home indicator", () => {
   const here = dirname(fileURLToPath(import.meta.url));
   const css = readFileSync(join(here, "panescaffold.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
   const bodyRule = css.match(/\.body \{([^}]*)\}/)?.[1] ?? "";
-  expect(bodyRule).toContain("padding-bottom: calc(var(--space-4) + env(safe-area-inset-bottom))");
+  expect(bodyRule).toContain(
+    "padding-bottom: calc(var(--space-4) + max(0px, env(safe-area-inset-bottom) - var(--keyboard-inset, 0px)))",
+  );
 });
 
 // The chrome-store title channel (2026-07-30-mobile-session-layout-design.md,


### PR DESCRIPTION
## Problem

On mobile, focusing the composer mid-session opens the on-screen keyboard *over* the composer. The mobile shell is `position: fixed; inset: 0; height: 100dvh` — sized against the layout viewport, which neither Chromium/Android (default `interactive-widget=resizes-visual`) nor iOS Safari shrinks when the keyboard opens. The footer-docked composer slides underneath.

## Fix (one half per platform)

- **Chromium/Android** — `interactive-widget=resizes-content` in the viewport meta (`index.html`). The layout viewport now shrinks with the keyboard, the shell's `100dvh` follows, and the composer rides up. Browsers that don't know the key ignore it.
- **iOS Safari** — ignores that key and shrinks only the visual viewport. New `useKeyboardInset` hook (mounted once in `AppShell`) mirrors the occluded bottom strip (`innerHeight − vv.height − vv.offsetTop`, clamped ≥ 0, 0 under pinch-zoom) into a `--keyboard-inset` CSS variable; the mobile `.shell` rule spends it as `padding-bottom`. Writes only on change (scroll events fire per-frame). Listeners and the variable are removed on unmount.

## Verification

- New tests: 7 for the hook (inset math incl. offset/scale guards, event tracking, cleanup), 1 viewport-meta assertion, 1 CSS contract assertion.
- Each new assertion mutation-proven red (meta key removed, CSS padding removed, scroll listener removed → each goes red, then restored).
- `make test-web`: PASS web-typecheck, web-test, web-lint.
- Simplify pass (4-angle review) applied: change-only writes, EventTarget-based test fake, canonical comments.

Caveat: jsdom can't evaluate real keyboard geometry; the iOS path is verified at the unit/CSS level — worth one on-device spot-check.