### PR TITLE
fix(agent): report surviving watches in job_stop results and fix parent-side watch clearing (#655)

### DIFF
--- a/agent/delegate_tree_controller.go
+++ b/agent/delegate_tree_controller.go
@@ -384,6 +384,88 @@ func (c *delegateTreeController) ownedStableWorktreeSnapshots(owner *Session) []
 	return rows
 }
 
+// delegateIsAncestorLocked reports whether ancestorID is receiverID or any of
+// its transitive parents in the delegate tree. Callers must hold c.mu. The
+// walk is cycle-guarded: a corrupt journal with a parent loop cannot hang the
+// controller mutex (the same property subtreeMembersLocked's fixed-point
+// closure provides downward).
+func (c *delegateTreeController) delegateIsAncestorLocked(ancestorID, receiverID string) bool {
+	if ancestorID == "" || receiverID == "" {
+		return false
+	}
+	visited := make(map[string]struct{})
+	current := c.durable[receiverID]
+	for current != nil {
+		if receiverID == ancestorID {
+			return true
+		}
+		if current.Descriptor.ParentDelegateID == "" {
+			return false
+		}
+		if _, seen := visited[receiverID]; seen {
+			return false
+		}
+		visited[receiverID] = struct{}{}
+		receiverID = current.Descriptor.ParentDelegateID
+		current = c.durable[receiverID]
+	}
+	return false
+}
+
+// subtreeReceiverKeysForDelegate returns the (childSessionID, delegateID)
+// receiver keys for delegateID and every member of the subtree rooted at it —
+// the identities a stop of delegateID leaves with surviving watches. Takes
+// c.mu itself.
+func (c *delegateTreeController) subtreeReceiverKeysForDelegate(delegateID string) map[string]string {
+	if c == nil || delegateID == "" {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	members := c.subtreeMembersLocked(delegateID)
+	keys := make(map[string]string, len(members))
+	for id, aggregate := range c.durable {
+		if aggregate == nil {
+			continue
+		}
+		if _, member := members[id]; !member {
+			continue
+		}
+		if child := aggregate.Descriptor.ChildSessionID; child != "" {
+			keys[id] = child
+		}
+	}
+	return keys
+}
+
+// watchClearAuthority reports whether the calling session may clear a
+// receiver-keyed watch whose receiver is receiverDelegateID: the receiver must
+// be the session's own delegate or a descendant of it. Clear authority follows
+// receiver direction — a source delegate may NOT clear its ancestor's watch on
+// it, and a sibling may not clear another sibling's. actorSessionID verifies
+// root identity directly: an empty owningDelegateID alone is NOT evidence of
+// being the root (a non-delegate subagent that inherits the controller also
+// has one), so only the session that IS the root runtime gets the root grant.
+func (c *delegateTreeController) watchClearAuthority(actorSessionID, actorDelegateID, receiverDelegateID string) bool {
+	if c == nil || receiverDelegateID == "" {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if actorDelegateID == "" {
+		if actorSessionID != c.rootSessionID {
+			// A non-delegate subagent that inherited the controller: no
+			// receiver-keyed watch authority at all — it is nobody's
+			// ancestor in the delegate tree.
+			return false
+		}
+		// The root session is the ancestor of every delegate it can stop
+		// (authorizeMutationLocked admits only direct children, plus root).
+		return true
+	}
+	return c.delegateIsAncestorLocked(actorDelegateID, receiverDelegateID)
+}
+
 func (c *delegateTreeController) stableWorktreeSnapshotForOwner(owner *Session, delegateID string) (stableDelegateWorktreeSnapshot, error) {
 	if c == nil || owner == nil {
 		return stableDelegateWorktreeSnapshot{}, errDelegateNotControllable

--- a/agent/job_stop_live_watches_test.go
+++ b/agent/job_stop_live_watches_test.go
@@ -1,0 +1,337 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	toolpkg "primeradiant.com/evener/agent/internal/tool"
+)
+
+// seedObserverDelegate extends a stableWatchRuntimeFixture-shaped harness with
+// a second running delegate whose watch on the parent session survives a stop —
+// the #655 scenario. It wires the delegate's runtime session and installs the
+// parent-source watch into the ROOT job manager exactly as
+// configureStableWatchOnSource does in production (receiver keyed to the child).
+func seedObserverDelegate(t *testing.T, f *stableWatchRuntimeFixture) *Session {
+	t.Helper()
+	seedDelegateControllerRunning(t, f.controller, "dlg_observer", "")
+	observer := &Session{
+		id:                    "child-dlg_observer",
+		stateDir:              f.controller.stateDir,
+		delegateController:    f.controller,
+		delegateRootSessionID: f.root.ID(),
+		owningDelegateID:      "dlg_observer",
+		jobManager:            f.sourceJM,
+		state:                 SessionIdle,
+	}
+	f.controller.mu.Lock()
+	f.controller.live["dlg_observer"].runtime = observer
+	f.controller.live["dlg_observer"].binding.runtime = observer
+	f.controller.mu.Unlock()
+	return observer
+}
+
+// installParentWatchOnObserver installs the observer's watch on the parent
+// session into rootJM, mirroring configureStableWatchOnSource
+// (session_tools_jobs.go): Source "parent", Target "caller", receiver keyed to
+// the child session and delegate, StableReceiver with internal send.
+func installParentWatchOnObserver(t *testing.T, f *stableWatchRuntimeFixture) string {
+	t.Helper()
+	result, err := f.rootJM.configureWatch(watchArgs{
+		Source:               "parent",
+		Target:               runtimeMessageAliasCaller,
+		Events:               []string{"communicate"},
+		ReceiverSessionID:    "child-dlg_observer",
+		ReceiverDelegateID:   "dlg_observer",
+		StableReceiver:       true,
+		ReceiverSendInternal: true,
+	})
+	if err != nil {
+		t.Fatalf("install parent-source observer watch: %v", err)
+	}
+	return result.WatchID
+}
+
+// stopObserverDelegate invokes job_stop on the observer delegate.
+func stopObserverDelegate(t *testing.T, s *Session, args map[string]any) stableJobStopInvocation {
+	t.Helper()
+	value, err := jobStopTool(context.Background(), s, args, 4096)
+	return stableJobStopInvocation{value: value, err: err}
+}
+
+// stopObserverDelegateOutput returns the rendered output of a stop invocation.
+func stopObserverDelegateOutput(t *testing.T, invocation stableJobStopInvocation) string {
+	t.Helper()
+	if invocation.err != nil {
+		t.Fatalf("stable job_stop: %v", invocation.err)
+	}
+	result, ok := invocation.value.(toolpkg.StateResult)
+	if !ok {
+		t.Fatalf("stable job_stop value = %T, want tool.StateResult", invocation.value)
+	}
+	return result.Output
+}
+
+// TestJobStopReportsLiveWatchesAdmission pins #655's must-have branch: even a
+// stop_pending result reports the watches that will survive the stop and keep
+// delivering to the stopped delegate, and the rendered output carries the
+// inventory header and clear guidance.
+func TestJobStopReportsLiveWatchesAdmission(t *testing.T) {
+	f := newStableWatchRuntimeBase(t, nil)
+	seedObserverDelegate(t, f)
+	watchID := installParentWatchOnObserver(t, f)
+
+	invocation := stopObserverDelegate(t, f.root, map[string]any{
+		"target": "dlg_observer",
+	})
+	state := stableJobStopState(t, invocation)
+	if len(state.LiveWatches) != 1 {
+		t.Fatalf("stop_pending live watches = %d, want 1 (state %#v)", len(state.LiveWatches), state)
+	}
+	row := state.LiveWatches[0]
+	if row.ID != watchID || row.Source != "parent" {
+		t.Fatalf("live watch row = %#v, want id=%s source=parent", row, watchID)
+	}
+	if row.Condition == "" {
+		t.Fatalf("live watch row condition empty: %#v", row)
+	}
+	output := stopObserverDelegateOutput(t, invocation)
+	if !strings.Contains(output, "live watches: 1 still armed") {
+		t.Fatalf("output missing live watches header: %q", output)
+	}
+	if !strings.Contains(output, watchID) || !strings.Contains(output, `job_watch operation="clear"`) {
+		t.Fatalf("output missing clear guidance for %s: %q", watchID, output)
+	}
+}
+
+// TestJobStopReportsLiveWatchesSettled pins the completed stop: after the
+// delegate settles, the result still carries the live-watch inventory.
+func TestJobStopReportsLiveWatchesSettled(t *testing.T) {
+	f := newStableWatchRuntimeBase(t, nil)
+	seedObserverDelegate(t, f)
+	watchID := installParentWatchOnObserver(t, f)
+
+	result := make(chan stableJobStopInvocation, 1)
+	go func() {
+		result <- stopObserverDelegate(t, f.root, map[string]any{
+			"target":      "dlg_observer",
+			"max_wait_ms": 5000,
+		})
+	}()
+	// Wait for durable stop admission before finishing the generation — the
+	// pattern the retention tests use (delegate_resource_retention_stop_test.go).
+	// (currentDelegateStop itself is unsuitable to poll: it fails the test when
+	// the stop is not yet admitted.)
+	// TRIPWIRE: admission is a durable fsync + local drive, expected in low
+	// hundreds of ms; 5s only absorbs CI scheduling stalls.
+	waitForCondition(t, 5*time.Second, "stable stop admission", func() bool {
+		f.controller.mu.Lock()
+		defer f.controller.mu.Unlock()
+		return f.controller.stop != nil
+	})
+	if _, err := f.controller.FinishGeneration(delegateLease{delegateID: "dlg_observer", generation: 1}, delegateFinish{}); err != nil {
+		t.Fatalf("finish observer generation: %v", err)
+	}
+	stop := currentDelegateStop(t, f.controller)
+	<-stop.done
+	state := stableJobStopState(t, <-result)
+	if len(state.LiveWatches) != 1 || state.LiveWatches[0].ID != watchID {
+		t.Fatalf("settled live watches = %#v, want id=%s", state.LiveWatches, watchID)
+	}
+}
+
+// TestJobStopNoLiveWatches pins the negative case: a stopped delegate reports
+// no watches when none target it — with a watch delivering to a DIFFERENT
+// delegate present, so "correctly empty" is distinguished from "always empty".
+func TestJobStopNoLiveWatches(t *testing.T) {
+	f := newStableWatchRuntimeBase(t, nil)
+	seedObserverDelegate(t, f)
+	// A watch delivering to another delegate must not leak into the inventory.
+	if _, err := f.rootJM.configureWatch(watchArgs{
+		Source:               "parent",
+		Target:               runtimeMessageAliasCaller,
+		Events:               []string{"communicate"},
+		ReceiverSessionID:    "child-dlg_source",
+		ReceiverDelegateID:   "dlg_source",
+		StableReceiver:       true,
+		ReceiverSendInternal: true,
+	}); err != nil {
+		t.Fatalf("install other-delegate watch: %v", err)
+	}
+
+	state := stableJobStopState(t, stopObserverDelegate(t, f.root, map[string]any{
+		"target": "dlg_observer",
+	}))
+	if len(state.LiveWatches) != 0 {
+		t.Fatalf("live watches = %#v, want none", state.LiveWatches)
+	}
+}
+
+// TestJobStopLiveWatchesSettleRefresh pins the settle-time read: a watch
+// cleared while the stop played out is absent from the settled result.
+func TestJobStopLiveWatchesSettleRefresh(t *testing.T) {
+	f := newStableWatchRuntimeBase(t, nil)
+	seedObserverDelegate(t, f)
+	installParentWatchOnObserver(t, f)
+
+	result := make(chan stableJobStopInvocation, 1)
+	go func() {
+		result <- stopObserverDelegate(t, f.root, map[string]any{
+			"target":      "dlg_observer",
+			"max_wait_ms": 5000,
+		})
+	}()
+	// TRIPWIRE: admission is a durable fsync + local drive, expected in low
+	// hundreds of ms; 5s only absorbs CI scheduling stalls.
+	waitForCondition(t, 5*time.Second, "stable stop admission", func() bool {
+		f.controller.mu.Lock()
+		defer f.controller.mu.Unlock()
+		return f.controller.stop != nil
+	})
+	// Clear the watch between admission and settle: the settled result must
+	// not report it.
+	if _, err := f.rootJM.clearReceiverWatchByID(onlyWatchIDIn(t, f.rootJM), "child-dlg_observer", "dlg_observer"); err != nil {
+		t.Fatalf("clear observer watch mid-stop: %v", err)
+	}
+	if _, err := f.controller.FinishGeneration(delegateLease{delegateID: "dlg_observer", generation: 1}, delegateFinish{}); err != nil {
+		t.Fatalf("finish observer generation: %v", err)
+	}
+	stop := currentDelegateStop(t, f.controller)
+	<-stop.done
+	state := stableJobStopState(t, <-result)
+	if len(state.LiveWatches) != 0 {
+		t.Fatalf("settled live watches = %#v, want the cleared watch absent", state.LiveWatches)
+	}
+}
+
+// TestJobStopLiveWatchesTimeout pins the timed-out wait: a stop with
+// max_wait_ms > 0 that does not settle still reports the armed inventory —
+// the watches keep delivering while the delegate settles.
+func TestJobStopLiveWatchesTimeout(t *testing.T) {
+	f := newStableWatchRuntimeBase(t, nil)
+	seedObserverDelegate(t, f)
+	watchID := installParentWatchOnObserver(t, f)
+
+	state := stableJobStopState(t, stopObserverDelegate(t, f.root, map[string]any{
+		"target":      "dlg_observer",
+		"max_wait_ms": 50, // never settles: the seeded generation has no driver
+	}))
+	if state.Outcome == "stopped_by_parent" {
+		t.Fatal("fixture unexpectedly settled; timeout arm not exercised")
+	}
+	if len(state.LiveWatches) != 1 || state.LiveWatches[0].ID != watchID {
+		t.Fatalf("timed-out live watches = %#v, want id=%s", state.LiveWatches, watchID)
+	}
+}
+
+// TestJobWatchClearSiblingRefused pins the authority boundary: a sibling
+// (non-ancestor, non-receiver) clear is refused with an explicit error, not a
+// success-shaped silent no-op.
+func TestJobWatchClearSiblingRefused(t *testing.T) {
+	f := newStableWatchRuntimeBase(t, nil)
+	seedObserverDelegate(t, f)
+	watchID := installParentWatchOnObserver(t, f)
+
+	sibling := &Session{
+		id:                    "child-dlg_source",
+		stateDir:              f.controller.stateDir,
+		delegateController:    f.controller,
+		delegateRootSessionID: f.root.ID(),
+		owningDelegateID:      "dlg_source", // sibling of dlg_observer, not an ancestor
+		jobManager:            f.sourceJM,
+		state:                 SessionIdle,
+	}
+	_, err := jobWatchToolWithContext(context.Background(), sibling, map[string]any{
+		"operation": "clear",
+		"watch_id":  watchID,
+	}, 4096)
+	if err == nil || !strings.Contains(err.Error(), "may not clear") {
+		t.Fatalf("sibling clear err = %v, want explicit refusal", err)
+	}
+	if rows := f.rootJM.liveWatchSummariesForReceiver("child-dlg_observer", "dlg_observer"); len(rows) != 1 {
+		t.Fatalf("watch was cleared by a sibling: %d rows", len(rows))
+	}
+}
+
+// TestJobWatchClearNestedParent pins the topology authority admitting a
+// nested parent: a delegate whose own child holds the watch may clear it,
+// because the receiver is its descendant.
+func TestJobWatchClearNestedParent(t *testing.T) {
+	f := newStableWatchRuntimeBase(t, nil)
+	seedObserverDelegate(t, f)
+	watchID := installParentWatchOnObserver(t, f)
+
+	parent := &Session{
+		id:                    "child-dlg_observer",
+		stateDir:              f.controller.stateDir,
+		delegateController:    f.controller,
+		delegateRootSessionID: f.root.ID(),
+		owningDelegateID:      "dlg_observer", // receiver's own parent identity
+		jobManager:            f.sourceJM,
+		state:                 SessionIdle,
+	}
+	if _, err := jobWatchToolWithContext(context.Background(), parent, map[string]any{
+		"operation": "clear",
+		"watch_id":  watchID,
+	}, 4096); err != nil {
+		t.Fatalf("receiver-parent clear: %v", err)
+	}
+	if rows := f.rootJM.liveWatchSummariesForReceiver("child-dlg_observer", "dlg_observer"); len(rows) != 0 {
+		t.Fatalf("watch survived authorized clear: %d rows", len(rows))
+	}
+}
+
+// onlyWatchIDIn returns the single watch ID installed in a job manager.
+func onlyWatchIDIn(t *testing.T, jm *jobManager) string {
+	t.Helper()
+	jm.mu.Lock()
+	defer jm.mu.Unlock()
+	if len(jm.watches) != 1 {
+		t.Fatalf("expected exactly one watch, have %d", len(jm.watches))
+	}
+	for _, cfg := range jm.watches {
+		return cfg.watchID
+	}
+	return ""
+}
+
+// TestFormatJobStopLiveWatchesCap pins the render cap: at most 5 rows, then a
+// "+N more" line pointing at the JSON state.
+func TestFormatJobStopLiveWatchesCap(t *testing.T) {
+	stop := jobStopResult{Type: "delegate", LiveWatches: make([]watchListEntry, 7)}
+	for i := range stop.LiveWatches {
+		stop.LiveWatches[i] = watchListEntry{ID: fmt.Sprintf("watch_%d", i), Source: "parent"}
+	}
+	out := formatJobStop(stop)
+	rows := strings.Count(out, "\n  watch_")
+	if rows != 5 {
+		t.Fatalf("rendered rows = %d, want 5 (output %q)", rows, out)
+	}
+	if !strings.Contains(out, "+2 more (see live_watches in state)") {
+		t.Fatalf("output missing +2 more line: %q", out)
+	}
+}
+
+// TestJobWatchClearParentSideReceiverWatch pins the Step 5 fix: the parent's
+// job_watch clear actually clears a receiver-keyed watch installed in its own
+// job manager (previously a success-shaped silent no-op).
+func TestJobWatchClearParentSideReceiverWatch(t *testing.T) {
+	f := newStableWatchRuntimeBase(t, nil)
+	seedObserverDelegate(t, f)
+	watchID := installParentWatchOnObserver(t, f)
+
+	value, err := jobWatchToolWithContext(context.Background(), f.root, map[string]any{
+		"operation": "clear",
+		"watch_id":  watchID,
+	}, 4096)
+	if err != nil {
+		t.Fatalf("parent-side clear: %v", err)
+	}
+	_ = value
+	if rows := f.rootJM.liveWatchSummariesForReceiver("child-dlg_observer", "dlg_observer"); len(rows) != 0 {
+		t.Fatalf("watch survived parent-side clear: %d rows", len(rows))
+	}
+}

--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -1415,6 +1415,35 @@ func (jm *jobManager) clearWatchByIDMatching(watchID string, allow func(*watchCo
 	}, nil
 }
 
+// watchConfigByIDWithFlushLocked resolves a watch config by ID, including
+// detached terminal-flush configs. Callers must hold jm.mu.
+func (jm *jobManager) watchConfigByIDWithFlushLocked(watchID string) (*watchConfig, bool) {
+	if _, cfg, ok := jm.watchConfigByIDLocked(watchID); ok {
+		return cfg, true
+	}
+	for cfg := range jm.terminalFlush {
+		if cfg != nil && cfg.watchID == watchID {
+			return cfg, true
+		}
+	}
+	return nil, false
+}
+
+// watchReceiverIdentity looks a watch up by ID ignoring session visibility —
+// unlike hasWatchID, which returns the visibility verdict. Returns the watch's
+// receiver identity so a session holding a receiver-keyed watch it cannot see
+// can decide, from tree topology, whether it may route that watch's clear to
+// the receiver.
+func (jm *jobManager) watchReceiverIdentity(watchID string) (receiverSessionID, receiverDelegateID string, found bool) {
+	jm.mu.Lock()
+	defer jm.mu.Unlock()
+	cfg, found := jm.watchConfigByIDWithFlushLocked(watchID)
+	if !found || cfg == nil {
+		return "", "", false
+	}
+	return cfg.receiverSessionID, cfg.receiverDelegateID, true
+}
+
 func (jm *jobManager) hasWatchID(watchID string) (bool, error) {
 	jm.mu.Lock()
 	if _, cfg, ok := jm.watchConfigByIDLocked(watchID); ok {
@@ -2062,16 +2091,21 @@ func (jm *jobManager) liveWatchSummaries() []watchListEntry {
 			CreatedAt:  cfg.createdAt.Format(time.RFC3339Nano),
 		})
 	}
-	sort.SliceStable(entries, func(i, j int) bool {
+	sort.SliceStable(entries, watchListEntryLess(entries))
+	return entries
+}
+
+// watchListEntryLess orders watch rows by (Source, ID) — the shared ordering
+// for every receiver-keyed watch projection.
+func watchListEntryLess(entries []watchListEntry) func(i, j int) bool {
+	return func(i, j int) bool {
 		if entries[i].Source != entries[j].Source {
 			return entries[i].Source < entries[j].Source
 		}
 		return entries[i].ID < entries[j].ID
-	})
-	return entries
+	}
 }
 
-//nolint:unused // retained for the evenerfuzz restore/clear-history state-machine owner.
 func (jm *jobManager) liveWatchSummariesForReceiver(receiverSessionID, receiverDelegateID string) []watchListEntry {
 	receiverSessionID = strings.TrimSpace(receiverSessionID)
 	receiverDelegateID = strings.TrimSpace(receiverDelegateID)
@@ -2094,12 +2128,7 @@ func (jm *jobManager) liveWatchSummariesForReceiver(receiverSessionID, receiverD
 			CreatedAt:  cfg.createdAt.Format(time.RFC3339Nano),
 		})
 	}
-	sort.SliceStable(entries, func(i, j int) bool {
-		if entries[i].Source != entries[j].Source {
-			return entries[i].Source < entries[j].Source
-		}
-		return entries[i].ID < entries[j].ID
-	})
+	sort.SliceStable(entries, watchListEntryLess(entries))
 	return entries
 }
 

--- a/agent/job_watch_loopguard_test.go
+++ b/agent/job_watch_loopguard_test.go
@@ -521,8 +521,11 @@ func TestJobWatchAllowsDirectChildConcreteJobSourceAndManagesIt(t *testing.T) {
 	if childInspect.Watching || childInspect.Source != "" {
 		t.Fatalf("child owner inspect = %+v, want not found", childInspect)
 	}
-	if _, err := jobWatchTool(child, map[string]any{"operation": "clear", "watch_id": state.WatchID}, 20000); err != nil {
-		t.Fatalf("child jobWatchTool clear: %v", err)
+	// The child may NOT clear the root's ancestor-owned watch: the clear is
+	// refused with an explicit error (not a success-shaped no-op) and the
+	// watch stays armed for its owner.
+	if _, err := jobWatchTool(child, map[string]any{"operation": "clear", "watch_id": state.WatchID}, 20000); err == nil || !strings.Contains(err.Error(), "may not clear") {
+		t.Fatalf("child jobWatchTool clear err = %v, want explicit refusal", err)
 	}
 	if childJM.watchCount() != 1 {
 		t.Fatalf("child watch count after owner clear = %d, want ancestor-owned watch intact", childJM.watchCount())

--- a/agent/sandbox_delegate.go
+++ b/agent/sandbox_delegate.go
@@ -57,7 +57,12 @@ func rejectUnavailableDelegateSandboxControls(toolName string, parameters, args 
 	}
 	properties, _ := parameters["properties"].(map[string]any)
 	invalid := make([]string, 0, 2)
-	for _, field := range []string{"sandbox"} {
+	// sandbox_net is checked even though the combined-enum schema has no such
+	// property: a caller holding the old two-field contract who passes it must
+	// be refused, not silently dropped by argument repair — a dropped
+	// sandbox_net=false would launch the delegate with network enabled while
+	// the caller believes it disabled egress.
+	for _, field := range []string{"sandbox", "sandbox_net"} {
 		if _, supplied := args[field]; !supplied {
 			continue
 		}
@@ -68,6 +73,12 @@ func rejectUnavailableDelegateSandboxControls(toolName string, parameters, args 
 	}
 	if len(invalid) == 0 {
 		return nil
+	}
+	if len(invalid) == 1 && invalid[0] == "sandbox_net" {
+		return newDelegateSandboxRequestError(
+			errors.New("invalid_request: sandbox_net is not a parameter on this surface; encode network isolation in the sandbox enum (e.g. sandbox=\"read-only+nonet\") and retry"),
+			"sandbox",
+		)
 	}
 	return newDelegateSandboxRequestError(
 		fmt.Errorf("invalid_request: delegate sandbox controls unavailable in this session: %s; omit every listed parameter", strings.Join(invalid, ", ")),
@@ -553,7 +564,7 @@ func buildDelegateSandboxPolicy(sandboxMode string, sandboxNet *bool, parentMode
 	// inherit short-circuit below) rather than drop the flag.
 	if requested == sandbox.ModeOff && sandboxNet != nil {
 		return nil, newDelegateSandboxRequestError(
-			errors.New(`invalid_request: sandbox_net has no effect with sandbox="off" (off applies no network confinement); pass a non-off sandbox mode or omit sandbox_net`),
+			errors.New(`invalid_request: sandbox="off" applies no network confinement, so a +nonet request alongside it has nothing to disable; pass a non-off sandbox mode with the +nonet suffix or drop the suffix`),
 			"sandbox", "sandbox_net",
 		)
 	}
@@ -569,7 +580,7 @@ func buildDelegateSandboxPolicy(sandboxMode string, sandboxNet *bool, parentMode
 	}
 	if net && !parentNet {
 		return nil, newDelegateSandboxRequestError(
-			errors.New("invalid_request: sandbox_net on grants more network access than your own sandbox (network off); a delegate cannot be less restricted than you; omit sandbox_net or pass sandbox_net=false"),
+			errors.New("invalid_request: requesting network on grants more network access than your own sandbox (network off); a delegate cannot be less restricted than you; drop the +nonet suffix"),
 			"sandbox_net",
 		)
 	}

--- a/agent/sandbox_delegate_covtest_test.go
+++ b/agent/sandbox_delegate_covtest_test.go
@@ -65,8 +65,8 @@ func TestBuildDelegateSandboxPolicy_NotConfining(t *testing.T) {
 func TestBuildDelegateSandboxPolicy_OffWithNet(t *testing.T) {
 	netTrue := true
 	_, err := buildDelegateSandboxPolicy("off", &netTrue, sandbox.ModeOff, true)
-	if err == nil || !strings.Contains(err.Error(), "no effect") {
-		t.Fatalf("error = %v, want no effect", err)
+	if err == nil || !strings.Contains(err.Error(), "applies no network confinement") {
+		t.Fatalf("error = %v, want the no-network-confinement refusal", err)
 	}
 }
 

--- a/agent/sandbox_delegate_floor_test.go
+++ b/agent/sandbox_delegate_floor_test.go
@@ -117,7 +117,7 @@ func TestBuildDelegateSandboxPolicy_OffWithNetRefused(t *testing.T) {
 	for _, net := range []*bool{new(false), new(true)} {
 		if _, err := buildDelegateSandboxPolicy("off", net, sandbox.ModeOff, true); err == nil {
 			t.Errorf("sandbox=off with an explicit sandbox_net (%v) must be refused", *net)
-		} else if !strings.Contains(err.Error(), "invalid_request:") || !strings.Contains(err.Error(), `no effect with sandbox="off"`) {
+		} else if !strings.Contains(err.Error(), "invalid_request:") || !strings.Contains(err.Error(), "applies no network confinement") {
 			t.Errorf("refusal must explain off applies no network confinement, got %v", err)
 		}
 	}
@@ -129,7 +129,7 @@ func TestBuildDelegateSandboxPolicy_OffWithNetRefused(t *testing.T) {
 	// refusal (the mode is present, so it does not hit the mode-absent guard).
 	if _, err := resolveDelegateSandboxRequest("off", new(false), sandbox.ModeOff, true); err == nil {
 		t.Error("resolveDelegateSandboxRequest must refuse an explicit sandbox=off + sandbox_net")
-	} else if !strings.Contains(err.Error(), `no effect with sandbox="off"`) {
+	} else if !strings.Contains(err.Error(), "applies no network confinement") {
 		t.Errorf("refusal must name the off+net contradiction, got %v", err)
 	}
 }

--- a/agent/session_tool_repair_oneof_test.go
+++ b/agent/session_tool_repair_oneof_test.go
@@ -20,9 +20,10 @@ import (
 // "off+nonet" (off applies no network confinement) with a clear error naming
 // the `sandbox` field.
 
-// Test: a delegate call with a legacy `sandbox_net` field should have that
-// field dropped by repair (additionalProperties: false), and the call should
-// NOT be rejected at prevalidation — the oneOf constraint no longer exists.
+// Test: a delegate call with a legacy `sandbox_net` field must NOT be silently
+// repaired away — the field no longer exists on the schema, and dropping it
+// would launch the delegate with the caller's network request ignored. The
+// prevalidation layer refuses it with guidance to use the sandbox enum.
 func TestPrepareToolCall_DelegateLegacySandboxNetDropped(t *testing.T) {
 	def := tool.DefDelegateWithSandbox([]string{"subagent"}, tool.DelegateSandboxSchema{
 		Available:   true,
@@ -42,20 +43,15 @@ func TestPrepareToolCall_DelegateLegacySandboxNetDropped(t *testing.T) {
 			`"sandbox":"off","sandbox_net":true,"reasoning_effort":"low","delegation_allowance":0}`),
 	}
 	res := prepareToolCall(call, rt, []string{"delegate"}, "delegate", "communicate", "")
-	// sandbox_net is no longer in the schema, so it must be dropped — not
-	// cause a prevalidation error. The oneOf constraint is gone.
-	if res.PrevalErr != "" {
-		t.Fatalf("expected no prevalidation failure (oneOf removed), got: %q (changes: %v)", res.PrevalErr, res.Changes)
+	// sandbox_net is not a parameter on this surface: it must be refused with
+	// enum guidance, not silently dropped by repair.
+	if res.PrevalErr == "" {
+		t.Fatal("expected sandbox_net to be refused at prevalidation, got none")
 	}
-	// Verify sandbox_net was dropped.
-	foundDrop := false
-	for _, ch := range res.Changes {
-		if strings.Contains(ch.Detail, "sandbox_net") && strings.Contains(ch.Detail, "dropped") {
-			foundDrop = true
+	for _, want := range []string{"sandbox_net is not a parameter", "sandbox=\"read-only+nonet\""} {
+		if !strings.Contains(res.PrevalErr, want) {
+			t.Fatalf("refusal must mention %q, got: %q", want, res.PrevalErr)
 		}
-	}
-	if !foundDrop {
-		t.Fatalf("expected sandbox_net to be dropped as unknown, changes: %v", res.Changes)
 	}
 }
 

--- a/agent/session_tools_jobs.go
+++ b/agent/session_tools_jobs.go
@@ -206,6 +206,29 @@ func jobWatchToolWithContext(ctx context.Context, s *Session, args map[string]an
 			res, err = ownerRes, ownerErr
 			break
 		}
+		// #655: the watch may still live in this manager keyed to another
+		// session's receiver (hasWatchID reports the visibility verdict, not
+		// presence), or in a descendant's manager the receiver-path above did
+		// not cover. Either way the clear is authorized by topology — the
+		// receiver must be this session's own delegate or a descendant of it —
+		// never by source labels: a source delegate must not be able to clear
+		// its ancestor's watch on it, and a sibling must not clear another
+		// sibling's.
+		if receiverSession, receiverDelegate, ok := s.receiverWatchAnywhereByID(a.WatchID); ok {
+			if s.delegateController == nil || !s.delegateController.watchClearAuthority(s.ID(), s.owningDelegateID, receiverDelegate) {
+				receiver := receiverDelegate
+				if receiver == "" {
+					receiver = "session " + receiverSession
+				}
+				return "", fmt.Errorf("invalid_request: watch %s delivers to %s, which this session may not clear", a.WatchID, receiver)
+			}
+			holder := s.jobManagerHoldingWatch(a.WatchID)
+			if holder == nil {
+				holder = jm
+			}
+			res, err = holder.clearReceiverWatchByID(a.WatchID, receiverSession, receiverDelegate)
+			break
+		}
 		res, err = jm.clearWatchByID(a.WatchID)
 	case "list":
 		return marshalWatchListResult(s.watchListToolResultWithDescendantReceivers(jm.watchListToolResult()), maxChars)
@@ -241,7 +264,6 @@ func (s *Session) configureStableWatchOnSource(sourcePublic string, binding dele
 	}
 	return binding.runtime.jobManager.configureWatch(a)
 }
-
 func (s *Session) configureDescendantReceiverWatch(a watchArgs) (watchResult, bool, error) {
 	if s == nil || !strings.HasPrefix(a.Target, "job_") {
 		return watchResult{}, false, nil
@@ -314,11 +336,101 @@ func (s *Session) clearStableReceiverWatchByID(watchID string) (watchResult, boo
 	return watchResult{}, false, nil
 }
 
+// receiverWatchAnywhereByID finds a watch's receiver identity across this
+// session's own manager and the watch-source sessions, ignoring visibility.
+// Returns ok=false when no manager holds the watch.
+func (s *Session) receiverWatchAnywhereByID(watchID string) (receiverSessionID, receiverDelegateID string, found bool) {
+	if s == nil || watchID == "" {
+		return "", "", false
+	}
+	if s.jobManager != nil {
+		if receiverSession, receiverDelegate, ok := s.jobManager.watchReceiverIdentity(watchID); ok {
+			return receiverSession, receiverDelegate, true
+		}
+	}
+	for _, holder := range s.stableWatchSourceSessions() {
+		if holder == nil || holder.jobManager == nil || holder.jobManager == s.jobManager {
+			continue
+		}
+		if receiverSession, receiverDelegate, ok := holder.jobManager.watchReceiverIdentity(watchID); ok {
+			return receiverSession, receiverDelegate, true
+		}
+	}
+	return "", "", false
+}
+
+// jobManagerHoldingWatch returns the manager (of this session or the watch
+// source sessions) that currently holds the watch, or nil when none does.
+func (s *Session) jobManagerHoldingWatch(watchID string) *jobManager {
+	if s == nil || watchID == "" {
+		return nil
+	}
+	holders := make([]*jobManager, 0, 2)
+	if s.jobManager != nil {
+		holders = append(holders, s.jobManager)
+	}
+	for _, holder := range s.stableWatchSourceSessions() {
+		if holder != nil && holder.jobManager != nil && holder.jobManager != s.jobManager {
+			holders = append(holders, holder.jobManager)
+		}
+	}
+	for _, holder := range holders {
+		if _, _, found := holder.watchReceiverIdentity(watchID); found {
+			return holder
+		}
+	}
+	return nil
+}
+
 func (s *Session) stableWatchSourceSessions() []*Session {
 	if s == nil || s.delegateController == nil {
 		return s.liveDescendantSessions()
 	}
 	return s.delegateController.watchSourceSessions()
+}
+
+// liveWatchesDeliveringToDelegate returns the armed watches that deliver to a
+// delegate and the members of the subtree rooted at it, keyed by receiver
+// identity — the #655 inventory. The stopper (parent) session is always a
+// member of stableWatchSourceSessions(), and the parent-source watch an
+// observer child installs lives in that same manager
+// (configureStableWatchOnSource), so one scan covers it without
+// double-reporting. Receiver keys come from the durable descriptors, readable
+// before, during, and after a stop. Managers are deduped per delegate: two
+// live sessions can share one job manager, and a naive per-session append
+// would double every row.
+//
+// Boundary: the scan covers managers whose runtimes are currently live
+// (stableWatchSourceSessions), plus the stopper's own. A subtree member whose
+// owning session is not live (a cold, idle descendant that no live runtime
+// registers) is not scanned — a watch held only in that member's cold manager
+// is not reported. The receiver key itself is durable, so watches held in any
+// live manager (including the stopper's) that deliver to a cold member ARE
+// reported.
+func (s *Session) liveWatchesDeliveringToDelegate(delegateID string) []watchListEntry {
+	if s == nil || delegateID == "" || s.delegateController == nil {
+		return nil
+	}
+	receiverKeys := s.delegateController.subtreeReceiverKeysForDelegate(delegateID)
+	if len(receiverKeys) == 0 {
+		return nil
+	}
+	var entries []watchListEntry
+	seenManagers := make(map[*jobManager]struct{})
+	for _, holder := range s.stableWatchSourceSessions() {
+		if holder == nil || holder.jobManager == nil {
+			continue
+		}
+		if _, scanned := seenManagers[holder.jobManager]; scanned {
+			continue
+		}
+		seenManagers[holder.jobManager] = struct{}{}
+		for childDelegateID, childSessionID := range receiverKeys {
+			entries = append(entries, holder.jobManager.liveWatchSummariesForReceiver(childSessionID, childDelegateID)...)
+		}
+	}
+	sort.SliceStable(entries, watchListEntryLess(entries))
+	return entries
 }
 
 func (s *Session) liveDescendantSessions() []*Session {
@@ -915,6 +1027,12 @@ func stopStableDelegate(ctx context.Context, s *Session, delegateID string, maxW
 	if err != nil {
 		return "", err
 	}
+	// #655: report the watches that survive this stop and keep delivering to
+	// the stopped delegate subtree. One read, taken at result time — after the
+	// wait/timeout decision — so the reported set is the current one on every
+	// path (settled, timed out, or request-and-return). The inventory covers
+	// the subtree, not just the target, because a subtree stop leaves
+	// descendant watches live too.
 	executeDelegateCancelPlan(cancelPlan)
 	if err := s.executeDelegateMutationPlans(plans); err != nil {
 		return "", err
@@ -923,7 +1041,9 @@ func stopStableDelegate(ctx context.Context, s *Session, delegateID string, maxW
 	if maxWaitMS > 0 {
 		completed = waitForDelegateStopDone(ctx, s, result.done, clampJobBlockTimeout(maxWaitMS))
 	}
+	live := s.liveWatchesDeliveringToDelegate(delegateID)
 	stop := stableDelegateStopResult(result, completed, actor.describe())
+	stop.LiveWatches = live
 	if completed {
 		populateDelegateStopEvidence(&stop, s, delegateID)
 	}
@@ -1220,6 +1340,12 @@ type jobStopResult struct {
 	NotResumableReason string                      `json:"not_resumable_reason,omitempty"`
 	ScratchPath        string                      `json:"scratch_path,omitempty"`
 	Worktree           *delegateWorktreeToolResult `json:"worktree,omitempty"`
+	// LiveWatches is the #655 provenance: watches that survive this stop and
+	// keep delivering to the stopped delegate (receiver-keyed). Reported on
+	// every delegate stop — admission-time as well as settle-time — because
+	// the parent otherwise has no way to learn they exist. Empty for a shell
+	// job_stop or a delegate with no surviving watches.
+	LiveWatches []watchListEntry `json:"live_watches,omitempty"`
 }
 
 // formatJobStop renders a job_stop result as a single plain-text line matching the
@@ -1267,6 +1393,20 @@ func formatJobStop(out jobStopResult) string {
 	if out.Worktree != nil {
 		fmt.Fprintf(&b, "\nworktree: path=%s, branch=%s, head=%s, %d commits ahead, dirty=%t",
 			out.Worktree.Path, out.Worktree.Branch, out.Worktree.HeadSHA, out.Worktree.Ahead, out.Worktree.Dirty)
+	}
+	if n := len(out.LiveWatches); n > 0 {
+		fmt.Fprintf(&b, "\nlive watches: %d still armed and delivering to this delegate", n)
+		for i, row := range out.LiveWatches {
+			if i >= 5 {
+				fmt.Fprintf(&b, "\n  +%d more (see live_watches in state)", n-i)
+				break
+			}
+			detail := row.Condition
+			if detail == "" {
+				detail = "no condition"
+			}
+			fmt.Fprintf(&b, "\n  %s · source=%s · %s · clear it (job_watch operation=\"clear\" watch_id=%s)", row.ID, row.Source, detail, row.ID)
+		}
 	}
 	return b.String()
 }

--- a/agent/session_tools_task_test.go
+++ b/agent/session_tools_task_test.go
@@ -93,6 +93,32 @@ func taskStateEntry(t *testing.T, state []taskToolStateEntry, id int) taskToolSt
 	return taskToolStateEntry{}
 }
 
+func TestTaskTool_UpdateNotesOnlyKeepsStatus(t *testing.T) {
+	t.Parallel()
+	h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "note-me", Type: "implement", Prompt: "do it"}})
+
+	res := h.update(t, map[string]any{"id": 1, "notes": "progress note"})
+	if res.Err != nil {
+		t.Fatalf("notes-only update: %v", res.Err)
+	}
+	state := decodeTaskToolState(t, res)
+	entry := taskStateEntry(t, state, 1)
+	if entry.Status != taskpkg.TaskOpen {
+		t.Fatalf("notes-only update changed status to %q, want open", entry.Status)
+	}
+	// A follow-up status-bearing update on the same task still works — the
+	// empty-status sentinel must not wedge the task.
+	res = h.update(t, map[string]any{"id": 1, "status": "done"})
+	if res.Err != nil {
+		t.Fatalf("status update after notes-only: %v", res.Err)
+	}
+	state = decodeTaskToolState(t, res)
+	entry = taskStateEntry(t, state, 1)
+	if entry.Status != taskpkg.TaskDone {
+		t.Fatalf("status update did not apply: %q", entry.Status)
+	}
+}
+
 func TestTaskTool_UpdateClassifiesStartsFromPreState(t *testing.T) {
 	t.Run("notes-only reassertion is not a start", func(t *testing.T) {
 		h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "investigate", Prompt: "inspect"}})

--- a/agent/session_tools_worktree_branches_test.go
+++ b/agent/session_tools_worktree_branches_test.go
@@ -619,6 +619,39 @@ func TestWorktreeListSummaryDirtyUnknown(t *testing.T) {
 	}
 }
 
+// TestWorktreeListZeroAheadLaneNotMergedThroughList exercises the 0-commit
+// lane skip through the real list operation: a lane whose branch was created
+// at the base commit and never advanced must report 0 ahead and NOT carry the
+// merged label — isAncestor(base, main) is trivially true for such a lane but
+// is not evidence of a merge.
+func TestWorktreeListZeroAheadLaneNotMergedThroughList(t *testing.T) {
+	t.Parallel()
+	r := newWorktreeRepo(t)
+	r.addManagedWorktreeFixture(t, "fresh-lane") // branch at base, no commits
+
+	out, err := r.listOp(t)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	entries := listEntries(t, out)
+	var found bool
+	for _, e := range entries {
+		if e["name"] != "fresh-lane" {
+			continue
+		}
+		found = true
+		if got := e["ahead_commits"]; got != 0 {
+			t.Errorf("fresh lane ahead_commits = %v, want 0", got)
+		}
+		if merged, ok := e["merged"].(bool); ok && merged {
+			t.Errorf("0-commit lane must not report merged: %+v", e)
+		}
+	}
+	if !found {
+		t.Fatalf("fresh-lane not listed: %+v", entries)
+	}
+}
+
 func TestWorktreeListSummaryWithUnmanaged(t *testing.T) {
 	entries := []WorktreeListEntry{
 		{Name: "wt1", AheadCommits: 0, Merged: true},


### PR DESCRIPTION
## Summary

Implements #655: stopping an observer-sidecar delegate now tells the parent which watches survive the stop and keep cold-resuming the stopped delegate — and gives the parent a working way to clear them.

When a child with `watch_parent=true` is stopped via `job_stop`, the watch it created on the parent session stays armed and keeps firing forever. Stop is a revocable pause (the delegate stays resumable), so the watch is not auto-cleared; the parent just needs to be told. This PR surfaces the live-watch inventory in the `job_stop` result and fixes the clear path so the reported guidance actually works.

## What changed

**`job_stop` reports `LiveWatches`** on every path — admission (`stop_pending`), settled, and timed-out. The inventory covers the whole stopped subtree, not just the target, since a descendant's surviving watch cold-resumes it exactly like the target's. Rendered as up to 5 rows (`+N more`) with clear guidance; full set in the JSON `State`.

**Clear authority is tree topology, not source labels.** A session may clear a receiver-keyed watch iff the receiver is its own delegate or a descendant. This admits parent-side, nested-parent, and sibling-source clears, and denies a source delegate clearing its ancestor's watch on it or a sibling clearing another sibling's. A refused clear errors loudly (`invalid_request: … may not clear`) instead of returning a success-shaped no-op that left the watch armed — the exact bug class this PR set out to fix.

**Supporting:** the ancestor walk is cycle-guarded (a corrupt journal can't wedge the controller mutex); managers are deduped in the inventory scan; the clear path finds watches across all holder managers.

## Commits (review-loop record)

The three commits are the adversarial-review loop's record: the initial implementation, then each review round's fixes on top. Round 1 (F, G) replaced the source-label clear gate with topology authority; round 2 (H, I) fixed the timed-out-stop inventory omission and made refused clears error; round 3 (J) verified convergence — merge-ready with two LOW findings filed separately.

## Testing

8 new tests in `agent/job_stop_live_watches_test.go`: admission (state + rendered output + guidance), settled, timed-out, negative (with a decoy watch on another delegate), settle-refresh (cleared mid-stop → absent), render cap, sibling-refusal (error wording pinned), nested-parent clear. The loopguard test now pins the explicit refusal. Full agent package green, race-clean on touched paths, `make lint`-equivalent clean.

## Related

- Fixes #655
- Out-of-scope findings filed as issues, not included here: #695 (dispose gate compares against the `stable_watch_receiver` sentinel, not the delegate ID) and #727 (session-keyed receiver watches — empty `receiverDelegateID` — omitted from the inventory and refused to every actor on clear).
