### PR TITLE
task_list: presence-based dispatch (combined add/update tool)

### DIFF
--- a/agent/cov_task_updated_test.go
+++ b/agent/cov_task_updated_test.go
@@ -39,8 +39,7 @@ func TestTaskTool_AppendEmitsTaskUpdated(t *testing.T) {
 	registerTaskTools(reg, deps)
 
 	args, _ := json.Marshal(map[string]any{
-		"action": "append",
-		"tasks": []map[string]any{
+		"add": []map[string]any{
 			{"type": "implement", "description": "a", "prompt": "p"},
 		},
 	})
@@ -84,8 +83,7 @@ func TestTaskTool_UpdateToDoneEmitsTaskUpdated(t *testing.T) {
 	registerTaskTools(reg, deps)
 
 	args, _ := json.Marshal(map[string]any{
-		"action":  "update",
-		"updates": []map[string]any{{"id": 1, "status": "done"}},
+		"update": []map[string]any{{"id": 1, "status": "done"}},
 	})
 	res := reg.ExecuteCall(context.Background(), nil, llm.ToolCallData{ID: "c1", Name: "task_list", Arguments: args})
 	if res.IsError {
@@ -130,8 +128,7 @@ func TestTaskTool_UpdateToInProgressEmitsTaskUpdated(t *testing.T) {
 	registerTaskTools(reg, deps)
 
 	args, _ := json.Marshal(map[string]any{
-		"action":  "update",
-		"updates": []map[string]any{{"id": 2, "status": "in_progress"}},
+		"update": []map[string]any{{"id": 2, "status": "in_progress"}},
 	})
 	res := reg.ExecuteCall(context.Background(), nil, llm.ToolCallData{ID: "c1", Name: "task_list", Arguments: args})
 	if res.IsError {

--- a/agent/internal/contextmgr/context_manager.go
+++ b/agent/internal/contextmgr/context_manager.go
@@ -676,9 +676,21 @@ func summarizeToolResult(toolName string, content any, args json.RawMessage) str
 		return fmt.Sprintf("[delegate: %d chars]", len(contentStr))
 
 	case "task_list":
-		action := getArg("action")
+		// Presence-based dispatch: derive the verb from whichever array the
+		// call carried (add/update, either or both; none = view).
+		verb := "view"
+		if a := getArg("add"); a != "" {
+			verb = "add"
+		}
+		if u := getArg("update"); u != "" {
+			if verb == "add" {
+				verb = "add+update"
+			} else {
+				verb = "update"
+			}
+		}
 		tasks := countJSONArrayElements(contentStr)
-		return fmt.Sprintf("[task_list: %s → %d tasks]", action, tasks)
+		return fmt.Sprintf("[task_list: %s → %d tasks]", verb, tasks)
 
 	case "use_skill":
 		name := getArg("skill_name")

--- a/agent/internal/contextmgr/context_manager.go
+++ b/agent/internal/contextmgr/context_manager.go
@@ -677,17 +677,26 @@ func summarizeToolResult(toolName string, content any, args json.RawMessage) str
 
 	case "task_list":
 		// Presence-based dispatch: derive the verb from whichever array the
-		// call carried (add/update, either or both; none = view).
+		// call carried with at least one entry (add/update, either or both;
+		// none = view). getArg stringifies, so an empty array would read as
+		// present — inspect argsMap directly instead.
 		verb := "view"
-		if a := getArg("add"); a != "" {
-			verb = "add"
-		}
-		if u := getArg("update"); u != "" {
-			if verb == "add" {
-				verb = "add+update"
-			} else {
-				verb = "update"
+		hasAdd, hasUpdate := false, false
+		if argsMap != nil {
+			if arr, ok := argsMap["add"].([]any); ok && len(arr) > 0 {
+				hasAdd = true
 			}
+			if arr, ok := argsMap["update"].([]any); ok && len(arr) > 0 {
+				hasUpdate = true
+			}
+		}
+		switch {
+		case hasAdd && hasUpdate:
+			verb = "add+update"
+		case hasAdd:
+			verb = "add"
+		case hasUpdate:
+			verb = "update"
 		}
 		tasks := countJSONArrayElements(contentStr)
 		return fmt.Sprintf("[task_list: %s → %d tasks]", verb, tasks)

--- a/agent/internal/contextmgr/context_manager_test.go
+++ b/agent/internal/contextmgr/context_manager_test.go
@@ -256,7 +256,7 @@ func TestSummarizeToolResult_Delegate(t *testing.T) {
 }
 
 func TestSummarizeToolResult_TaskList(t *testing.T) {
-	got := summarizeToolResult("task_list", `[{"id":1},{"id":2},{"id":3}]`, json.RawMessage(`{"action":"view"}`))
+	got := summarizeToolResult("task_list", `[{"id":1},{"id":2},{"id":3}]`, json.RawMessage(`{}`))
 	want := "[task_list: view → 3 tasks]"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -649,7 +649,7 @@ func DefTaskList(effortLevels []string) llm.ToolDefinition {
 							"depends_on": map[string]any{
 								"type":        "array",
 								"items":       map[string]any{"type": "integer"},
-									"description": "IDs of existing tasks (or earlier tasks in this same add array, which get sequential IDs) this one depends on. Optional.",
+								"description": "IDs of existing tasks (or earlier tasks in this same add array, which get sequential IDs) this one depends on. Optional.",
 							},
 							"reasoning_effort": reasoningSchema,
 						},

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -619,20 +619,23 @@ func DefTaskList(effortLevels []string) llm.ToolDefinition {
 		// every property) still lets the model decline to override.
 		reasoningSchema["enum"] = append(append([]string(nil), effortLevels...), "inherit")
 	}
+	strictFalse := false
 	return llm.ToolDefinition{
 		Name:        "task_list",
-		Description: "Manage your task list. Use view to inspect tasks and reasoning effort levels, append to add new tasks, and update to change status, notes, dependencies, or reasoning_effort. When you mark a task done, the next eligible task auto-starts and its prompt is injected. Use depends_on to express ordering and notes to record what happened. Only one task may be in_progress at a time; to start a new one, complete or defer the current one in the same updates array.",
+		Description: "Manage your task list. A bare call (or empty add/update) returns the current list. Use add to append new tasks (type, brief description <10 words, detailed prompt, optional depends_on/reasoning_effort) and update to change existing tasks (id plus optional status, notes, depends_on, reasoning_effort) — both in the same call when useful. When you mark a task done, the next eligible task auto-starts and its prompt is injected. Use depends_on to express ordering and notes to record what happened. Only one task may be in_progress at a time; to start a new one, complete or defer the current one in the same update array.",
+		// Strict is explicitly false: the OpenAI Responses adapter defaults
+		// strict=true when unset and force-requires every nested property,
+		// which would force strict-mode models to emit "status": "" (enum
+		// violation) or "depends_on": [] (which clears deps) on every update
+		// item. Opting out keeps optional fields genuinely omittable.
+		Strict: &strictFalse,
 		Parameters: map[string]any{
 			"type":                 "object",
 			"additionalProperties": false,
 			"properties": map[string]any{
-				"action": map[string]any{
-					"type": "string",
-					"enum": []string{"view", "append", "update"},
-				},
-				"tasks": map[string]any{
+				"add": map[string]any{
 					"type":        "array",
-					"description": "For append: tasks to add. Each has a type, brief description (<10 words), a detailed prompt, and optional reasoning_effort.",
+					"description": "Tasks to add. Omit or [] for none. Each: type, brief description (<10 words), a detailed prompt, optional depends_on (IDs of existing tasks, or of earlier tasks in this same add array which get sequential IDs), and optional reasoning_effort.",
 					"items": map[string]any{
 						"type": "object",
 						"properties": map[string]any{
@@ -646,16 +649,16 @@ func DefTaskList(effortLevels []string) llm.ToolDefinition {
 							"depends_on": map[string]any{
 								"type":        "array",
 								"items":       map[string]any{"type": "integer"},
-								"description": "IDs of tasks this one depends on. Optional.",
+									"description": "IDs of existing tasks (or earlier tasks in this same add array, which get sequential IDs) this one depends on. Optional.",
 							},
 							"reasoning_effort": reasoningSchema,
 						},
 						"required": []string{"type", "description", "prompt"},
 					},
 				},
-				"updates": map[string]any{
+				"update": map[string]any{
 					"type":        "array",
-					"description": "For update: list of {id} entries with optional status, notes, depends_on, or reasoning_effort.",
+					"description": "Changes to existing tasks. Omit or [] for none. Each: id plus optional status, notes, depends_on, or reasoning_effort. Omit status to leave it unchanged.",
 					"items": map[string]any{
 						"type": "object",
 						"properties": map[string]any{
@@ -673,7 +676,6 @@ func DefTaskList(effortLevels []string) llm.ToolDefinition {
 					},
 				},
 			},
-			"required": []string{"action"},
 		},
 	}
 }

--- a/agent/internal/tool/definitions_test.go
+++ b/agent/internal/tool/definitions_test.go
@@ -376,7 +376,7 @@ func TestDefDelegateSendDescriptionDistinguishesCallerFromFinalReport(t *testing
 
 func TestDefTaskListDescriptionStatesInProgressInvariant(t *testing.T) {
 	def := DefTaskList(nil)
-	want := "Only one task may be in_progress at a time; to start a new one, complete or defer the current one in the same updates array."
+	want := "Only one task may be in_progress at a time; to start a new one, complete or defer the current one in the same update array."
 	if !strings.Contains(def.Description, want) {
 		t.Fatalf("DefTaskList description = %q, want to contain %q", def.Description, want)
 	}
@@ -384,16 +384,19 @@ func TestDefTaskListDescriptionStatesInProgressInvariant(t *testing.T) {
 
 func TestDefTaskListEffortEnumIncludesInherit(t *testing.T) {
 	def := DefTaskList([]string{"low", "medium", "high"})
-	tasks := def.Parameters["properties"].(map[string]any)["tasks"].(map[string]any)
-	item := tasks["items"].(map[string]any)
-	schema := item["properties"].(map[string]any)["reasoning_effort"].(map[string]any)
-	enum, ok := schema["enum"].([]string)
-	if !ok {
-		t.Fatalf("reasoning_effort enum missing: %#v", schema)
-	}
 	want := []string{"low", "medium", "high", "inherit"}
-	if !reflect.DeepEqual(enum, want) {
-		t.Fatalf("reasoning_effort enum = %v, want %v", enum, want)
+	props := def.Parameters["properties"].(map[string]any)
+	for _, arrayName := range []string{"add", "update"} {
+		arraySchema := props[arrayName].(map[string]any)
+		item := arraySchema["items"].(map[string]any)
+		schema := item["properties"].(map[string]any)["reasoning_effort"].(map[string]any)
+		enum, ok := schema["enum"].([]string)
+		if !ok {
+			t.Fatalf("%s reasoning_effort enum missing: %#v", arrayName, schema)
+		}
+		if !reflect.DeepEqual(enum, want) {
+			t.Fatalf("%s reasoning_effort enum = %v, want %v", arrayName, enum, want)
+		}
 	}
 }
 
@@ -844,5 +847,43 @@ func TestDefModelListIsBoundedReadOnlyContract(t *testing.T) {
 	def := DefModelList()
 	if def.Name != "model_list" || def.Parameters["additionalProperties"] != false {
 		t.Fatalf("definition = %#v", def)
+	}
+}
+
+// TestDefTaskList_PresenceBased pins the combined-tool schema: no action
+// property, add/update arrays optional, update items require only id, no
+// top-level required list (a bare call is a view), and Strict explicitly
+// false (strict-mode normalization would force-requires nested update
+// fields, reintroducing forced status/depends_on values).
+func TestDefTaskList_PresenceBased(t *testing.T) {
+	def := DefTaskList([]string{"low", "high"})
+	params := def.Parameters
+	props := params["properties"].(map[string]any)
+	if _, has := props["action"]; has {
+		t.Fatal("schema must not have an action property")
+	}
+	if def.Strict == nil || *def.Strict {
+		t.Fatal("DefTaskList must set Strict: false explicitly")
+	}
+	add, has := props["add"]
+	if !has {
+		t.Fatal("schema must have an add property")
+	}
+	addItems := add.(map[string]any)["items"].(map[string]any)
+	addReq, ok := addItems["required"].([]string)
+	if !ok || len(addReq) != 3 || addReq[0] != "type" || addReq[1] != "description" || addReq[2] != "prompt" {
+		t.Fatalf("add item required = %v, want [type description prompt]", addItems["required"])
+	}
+	update, has := props["update"]
+	if !has {
+		t.Fatal("schema must have an update property")
+	}
+	updateItems := update.(map[string]any)["items"].(map[string]any)
+	updateReq, ok := updateItems["required"].([]string)
+	if !ok || len(updateReq) != 1 || updateReq[0] != "id" {
+		t.Fatalf("update item required = %v, want [id]", updateItems["required"])
+	}
+	if top, has := params["required"]; has {
+		t.Fatalf("schema must not force-require add/update at top level: %v", top)
 	}
 }

--- a/agent/internal/tool/repair/explain.go
+++ b/agent/internal/tool/repair/explain.go
@@ -130,9 +130,36 @@ func ExplainSchemaError(toolName string, params, args map[string]any, instanceLo
 			b.WriteString(tail)
 		}
 	} else {
-		fmt.Fprintf(&b, "\nExample: %s", minimalExample(params))
+		fmt.Fprintf(&b, "\nExample: %s", sentArrayExample(params, args, containerPath))
 	}
 	return b.String()
+}
+
+// sentArrayExample renders an example for a failure inside an array item the
+// caller actually sent: the array property with one minimal item template
+// ({"update": [{"id": 0}]}). A schema with no top-level required (presence-
+// based tools like task_list) otherwise renders a bare {}, which gives a
+// caller that just mis-shaped an array item no usable template. Falls back
+// to minimalExample when the failure is not in a sent array property or the
+// array has no item schema.
+func sentArrayExample(params, args map[string]any, containerPath string) string {
+	root := pathRootProperty(containerPath)
+	if root == "" {
+		return minimalExample(params)
+	}
+	if _, sent := args[root]; !sent {
+		return minimalExample(params)
+	}
+	props := schemaProps(params)
+	arraySchema := schemaMap(props, root)
+	if arraySchema == nil || !schemaIsArray(arraySchema) {
+		return minimalExample(params)
+	}
+	item := schemaMap(arraySchema, "items")
+	if item == nil {
+		return minimalExample(params)
+	}
+	return fmt.Sprintf(`{%q: [%s]}`, root, minimalExample(item))
 }
 
 // branchCtx is the branch context for one explained error, computed once

--- a/agent/internal/tool/repair/explain.go
+++ b/agent/internal/tool/repair/explain.go
@@ -150,16 +150,24 @@ func sentArrayExample(params, args map[string]any, containerPath string) string 
 	if _, sent := args[root]; !sent {
 		return minimalExample(params)
 	}
-	props := schemaProps(params)
-	arraySchema := schemaMap(props, root)
-	if arraySchema == nil || !schemaIsArray(arraySchema) {
-		return minimalExample(params)
-	}
-	item := schemaMap(arraySchema, "items")
+	item := arrayItemSchema(params, root)
 	if item == nil {
 		return minimalExample(params)
 	}
 	return fmt.Sprintf(`{%q: [%s]}`, root, minimalExample(item))
+}
+
+// arrayItemSchema returns the item schema of a declared array property, or
+// nil when the property is not a declared array or has no item schema.
+// Shared descent for the example renderers (sentArrayExample,
+// actionExample).
+func arrayItemSchema(params map[string]any, arrayName string) map[string]any {
+	props := schemaProps(params)
+	arraySchema := schemaMap(props, arrayName)
+	if arraySchema == nil || !schemaIsArray(arraySchema) {
+		return nil
+	}
+	return schemaMap(arraySchema, "items")
 }
 
 // branchCtx is the branch context for one explained error, computed once
@@ -433,13 +441,8 @@ func sentArgNames(selectorName string, args map[string]any) string {
 // Falls back to minimalExample(params) when the branch has no tagged array
 // or the array has no item schema.
 func actionExample(params map[string]any, selectorName, actionValue string, actionArrays []string) string {
-	props := schemaProps(params)
 	for _, arrayName := range actionArrays {
-		arraySchema := schemaMap(props, arrayName)
-		if arraySchema == nil {
-			continue
-		}
-		item := schemaMap(arraySchema, "items")
+		item := arrayItemSchema(params, arrayName)
 		if item == nil {
 			continue
 		}

--- a/agent/internal/tool/repair/explain_action_branch_alloc_test.go
+++ b/agent/internal/tool/repair/explain_action_branch_alloc_test.go
@@ -41,7 +41,7 @@ func TestNamedBranch_NoAllocationsWhenTagOutsideEnum(t *testing.T) {
 		},
 		"required": []string{"action"},
 	}
-	args := map[string]any{"action": "view"}
+	args := map[string]any{}
 	// The container path must use the display form ("slices[0]", as
 	// resolveSchemaErrorContainer's formatPath renders it) — a JSON-Pointer
 	// form like "slices/0" parses as a single property name in

--- a/agent/internal/tool/repair/explain_action_branch_test.go
+++ b/agent/internal/tool/repair/explain_action_branch_test.go
@@ -247,7 +247,7 @@ func TestExplainSchemaError_ProseTagOutsideEnumIsNotBranch(t *testing.T) {
 	}
 	want := "read_file: missing required argument \"start\" in slices[0].\n" +
 		"Required arguments in slices[0]: start (integer).\n" +
-		"Example: {\"action\": \"...\"}"
+		"Example: {\"slices\": [{\"start\": 0}]}"
 	if got != want {
 		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
 	}

--- a/agent/internal/tool/repair/explain_action_branch_test.go
+++ b/agent/internal/tool/repair/explain_action_branch_test.go
@@ -11,6 +11,11 @@ import (
 // updates the update-branch array; the real schema selects between them by
 // the action value in prose, not by a combinator — the handler enforces it.
 // The "For <action>:" description tags are what the branch detection keys on.
+// taskListParams is a SYNTHETIC action-enum schema shaped like the pre-rework
+// DefTaskList, kept because the branch machinery it exercises (actionTag
+// parsing, namedBranch enum membership, action-scoped arrays) still serves
+// manage_worktree and any MCP tool carrying a selector; task_list itself is
+// presence-based now and cannot produce these failures.
 func taskListParams() map[string]any {
 	return map[string]any{
 		"type":                 "object",

--- a/agent/internal/tool/repair/explain_test.go
+++ b/agent/internal/tool/repair/explain_test.go
@@ -212,7 +212,7 @@ func TestExplainSchemaError_ArrayItemMissingRequiredField(t *testing.T) {
 	got := ExplainSchemaError("task_list", params, args, "updates/0", "")
 	want := "task_list: missing required argument \"id\" in updates[0].\n" +
 		"Required arguments in updates[0]: id (integer).\n" +
-		"Example: {\"action\": \"...\"}"
+		"Example: {\"updates\": [{\"id\": 0}]}"
 	if got != want {
 		t.Fatalf("got:\n%s\nwant:\n%s", got, want)
 	}

--- a/agent/internal/tool/repair/explain_test.go
+++ b/agent/internal/tool/repair/explain_test.go
@@ -135,6 +135,11 @@ func TestExplainTruncatedCall(t *testing.T) {
 // taskListParamsForExplain mirrors DefTaskList's updates-item schema (this
 // package must stay dependency-free of agent/internal/tool, so the fixture is
 // hand-built rather than calling the real Def* function).
+// taskListParamsForExplain is a SYNTHETIC action-enum schema shaped like the
+// pre-rework DefTaskList. It exercises the generic branch machinery
+// (actionTag/namedBranch) in isolation; it deliberately does not mirror the
+// current DefTaskList (presence-based add/update arrays, no action), which
+// has no selector for the branch machinery to key on.
 func taskListParamsForExplain() map[string]any {
 	return map[string]any{
 		"type":                 "object",

--- a/agent/profile_test.go
+++ b/agent/profile_test.go
@@ -1997,11 +1997,29 @@ func extractTaskListEffortEnum(t *testing.T, p *provider.Profile) []string {
 		t.Fatalf("task_list tool not found in profile %s", p.ID())
 	}
 
-	// Navigate: parameters -> properties -> updates -> items -> properties -> reasoning_effort -> enum
+	// Navigate: parameters -> properties -> update -> items -> properties -> reasoning_effort -> enum
+	// (check both add and update; both item schemas carry the enum)
 	params, _ := taskListTool.Parameters["properties"].(map[string]any)
-	updates, _ := params["updates"].(map[string]any)
-	items, _ := updates["items"].(map[string]any)
-	itemProps, _ := items["properties"].(map[string]any)
+	var itemProps map[string]any
+	for _, arrayName := range []string{"update", "add"} {
+		arraySchema, _ := params[arrayName].(map[string]any)
+		if arraySchema == nil {
+			continue
+		}
+		items, _ := arraySchema["items"].(map[string]any)
+		if items == nil {
+			continue
+		}
+		itemProps, _ = items["properties"].(map[string]any)
+		if itemProps != nil {
+			if _, has := itemProps["reasoning_effort"]; has {
+				break
+			}
+		}
+	}
+	if itemProps == nil {
+		t.Fatalf("no task_list item schema with reasoning_effort in profile %s", p.ID())
+	}
 	reasoningEffort, _ := itemProps["reasoning_effort"].(map[string]any)
 	enumAny, _ := reasoningEffort["enum"].([]string)
 	if enumAny == nil {

--- a/agent/provider/profile_program_fuzz_test.go
+++ b/agent/provider/profile_program_fuzz_test.go
@@ -255,11 +255,18 @@ func providerProgramTaskListEfforts(defs []llm.ToolDefinition) []string {
 			continue
 		}
 		properties, _ := def.Parameters["properties"].(map[string]any)
-		tasks, _ := properties["tasks"].(map[string]any)
-		items, _ := tasks["items"].(map[string]any)
-		taskProperties, _ := items["properties"].(map[string]any)
-		reasoning, _ := taskProperties["reasoning_effort"].(map[string]any)
-		return append([]string(nil), toStringSlice(reasoning["enum"])...)
+		// Both add and update item schemas carry the reasoning_effort enum;
+		// read whichever is present (either satisfies the sync check).
+		for _, arrayName := range []string{"add", "update"} {
+			arraySchema, _ := properties[arrayName].(map[string]any)
+			if arraySchema == nil {
+				continue
+			}
+			items, _ := arraySchema["items"].(map[string]any)
+			taskProperties, _ := items["properties"].(map[string]any)
+			reasoning, _ := taskProperties["reasoning_effort"].(map[string]any)
+			return append([]string(nil), toStringSlice(reasoning["enum"])...)
+		}
 	}
 	return nil
 }

--- a/agent/session_attention_test.go
+++ b/agent/session_attention_test.go
@@ -2659,7 +2659,7 @@ func TestRootDelegateAttention_MidTurnArmedAttentionConsumedWithoutRedundantWake
 				if midTurnAppendErr == nil {
 					midTurnArmErr = root.armDelegateAttention(secondID)
 				}
-				return toolCallResponse(llm.ToolCallData{ID: "round-one", Name: "task_list", Arguments: json.RawMessage(`{"action":"view"}`), Type: "function"})
+				return toolCallResponse(llm.ToolCallData{ID: "round-one", Name: "task_list", Arguments: json.RawMessage(`{}`), Type: "function"})
 			},
 			func(req llm.Request) llm.Response {
 				calls++
@@ -2822,7 +2822,7 @@ func TestRootDelegateAttention_EmptySnapshotNotificationTurnConsumesCoveredDeliv
 				if appendErr == nil {
 					armErr = root.armDelegateAttention(attentionID)
 				}
-				return toolCallResponse(llm.ToolCallData{ID: "round-one", Name: "task_list", Arguments: json.RawMessage(`{"action":"view"}`), Type: "function"})
+				return toolCallResponse(llm.ToolCallData{ID: "round-one", Name: "task_list", Arguments: json.RawMessage(`{}`), Type: "function"})
 			},
 			func(req llm.Request) llm.Response {
 				calls++
@@ -2888,7 +2888,7 @@ func TestRootDelegateAttention_UserTurnConsumesCoveredMidTurnDelivery(t *testing
 				if appendErr == nil {
 					armErr = root.armDelegateAttention(attentionID)
 				}
-				return toolCallResponse(llm.ToolCallData{ID: "round-one", Name: "task_list", Arguments: json.RawMessage(`{"action":"view"}`), Type: "function"})
+				return toolCallResponse(llm.ToolCallData{ID: "round-one", Name: "task_list", Arguments: json.RawMessage(`{}`), Type: "function"})
 			},
 			func(req llm.Request) llm.Response {
 				roundTwoSaw = requestContainsText(req, content)
@@ -3151,7 +3151,7 @@ func TestRootDelegateAttention_EmptySnapshotCoverageFailureWarnsAndRetries(t *te
 				if err := root.armDelegateAttention(attentionID); err != nil {
 					t.Errorf("mid-turn arm: %v", err)
 				}
-				return toolCallResponse(llm.ToolCallData{ID: "round-one", Name: "task_list", Arguments: json.RawMessage(`{"action":"view"}`), Type: "function"})
+				return toolCallResponse(llm.ToolCallData{ID: "round-one", Name: "task_list", Arguments: json.RawMessage(`{}`), Type: "function"})
 			},
 			func(llm.Request) llm.Response {
 				return toolCallResponse(communicateCall("empty-fail-turn", "steering handled"))
@@ -3262,7 +3262,7 @@ func TestRootDelegateAttention_CoveredResolutionFailureDoesNotFailUserTurn(t *te
 				if err := root.armDelegateAttention(attentionID); err != nil {
 					t.Errorf("mid-turn arm: %v", err)
 				}
-				return toolCallResponse(llm.ToolCallData{ID: "round-one", Name: "task_list", Arguments: json.RawMessage(`{"action":"view"}`), Type: "function"})
+				return toolCallResponse(llm.ToolCallData{ID: "round-one", Name: "task_list", Arguments: json.RawMessage(`{}`), Type: "function"})
 			},
 			func(llm.Request) llm.Response {
 				return toolCallResponse(communicateCall("resolution-failure-turn", "answer stands"))

--- a/agent/session_current_work_seed_test.go
+++ b/agent/session_current_work_seed_test.go
@@ -199,8 +199,7 @@ func TestSharedChildStartAndTaskUpdateNameRootOwner(t *testing.T) {
 
 	beforeMutation := len(recorder.snapshot())
 	arguments, _ := json.Marshal(map[string]any{
-		"action": "append",
-		"tasks": []map[string]any{{
+		"add": []map[string]any{{
 			"type": "implement", "description": "Shared follow-up", "prompt": "Do it.",
 		}},
 	})

--- a/agent/session_dod_definition_test.go
+++ b/agent/session_dod_definition_test.go
@@ -3196,15 +3196,15 @@ func TestSession_TaskListUpdateEscalatesReasoningEffort(t *testing.T) {
 		steps: []func(req llm.Request) llm.Response{
 			// Step 1: create a task.
 			func(req llm.Request) llm.Response {
-				return taskListCall("c1", `{"action":"append","tasks":[{"type":"implement","description":"work","prompt":"do stuff"}]}`)
+				return taskListCall("c1", `{"add":[{"type":"implement","description":"work","prompt":"do stuff"}]}`)
 			},
 			// Step 2: start it (in_progress, no effort override yet).
 			func(req llm.Request) llm.Response {
-				return taskListCall("c2", `{"action":"update","updates":[{"id":1,"status":"in_progress"}]}`)
+				return taskListCall("c2", `{"update":[{"id":1,"status":"in_progress"}]}`)
 			},
 			// Step 3: escalate reasoning_effort to high.
 			func(req llm.Request) llm.Response {
-				return taskListCall("c3", `{"action":"update","updates":[{"id":1,"status":"in_progress","reasoning_effort":"high"}]}`)
+				return taskListCall("c3", `{"update":[{"id":1,"status":"in_progress","reasoning_effort":"high"}]}`)
 			},
 			// Step 4: done — this request should carry effort=high.
 			func(req llm.Request) llm.Response {
@@ -3265,10 +3265,10 @@ func TestSession_TaskList_AppendAndUpdate_EmitToolStateSnapshots(t *testing.T) {
 		name: "openai",
 		steps: []func(req llm.Request) llm.Response{
 			func(req llm.Request) llm.Response {
-				return taskListCall("c1", `{"action":"append","tasks":[{"type":"research","description":"Map criteria","prompt":"look at specs"},{"type":"implement","description":"Write tests","prompt":"add cases"}]}`)
+				return taskListCall("c1", `{"add":[{"type":"research","description":"Map criteria","prompt":"look at specs"},{"type":"implement","description":"Write tests","prompt":"add cases"}]}`)
 			},
 			func(req llm.Request) llm.Response {
-				return taskListCall("c2", `{"action":"update","updates":[{"id":1,"status":"done","notes":"reviewed specs"}]}`)
+				return taskListCall("c2", `{"update":[{"id":1,"status":"done","notes":"reviewed specs"}]}`)
 			},
 			func(req llm.Request) llm.Response { return finalResponse("done") },
 		},

--- a/agent/session_lifecycle_tail_coverage_fuzz_test.go
+++ b/agent/session_lifecycle_tail_coverage_fuzz_test.go
@@ -275,7 +275,7 @@ func FuzzSessionLifecyclePromptHookCoverage(f *testing.F) {
 func sltcNewToolSession(t *testing.T) *Session {
 	t.Helper()
 	root := t.TempDir()
-	args, err := json.Marshal(map[string]any{"action": "view"})
+	args, err := json.Marshal(map[string]any{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/agent/session_task_effort_test.go
+++ b/agent/session_task_effort_test.go
@@ -138,19 +138,19 @@ func TestSession_TaskEffortOverride_AppliesPerRoundOnly(t *testing.T) {
 		steps: []func(req llm.Request) llm.Response{
 			// req0 (expect max): create both tasks.
 			func(req llm.Request) llm.Response {
-				return taskEffortToolCall("c1", `{"action":"append","tasks":[{"type":"implement","description":"cheap step","prompt":"do cheap thing","reasoning_effort":"low"},{"type":"implement","description":"hard step","prompt":"do hard thing","reasoning_effort":"high"}]}`)
+				return taskEffortToolCall("c1", `{"add":[{"type":"implement","description":"cheap step","prompt":"do cheap thing","reasoning_effort":"low"},{"type":"implement","description":"hard step","prompt":"do hard thing","reasoning_effort":"high"}]}`)
 			},
 			// req1 (expect max, nothing in progress yet): start task 1.
 			func(req llm.Request) llm.Response {
-				return taskEffortToolCall("c2", `{"action":"update","updates":[{"id":1,"status":"in_progress"}]}`)
+				return taskEffortToolCall("c2", `{"update":[{"id":1,"status":"in_progress"}]}`)
 			},
 			// req2 (expect low, task 1 in progress): finish task 1 -> auto-advance starts task 2.
 			func(req llm.Request) llm.Response {
-				return taskEffortToolCall("c3", `{"action":"update","updates":[{"id":1,"status":"done"}]}`)
+				return taskEffortToolCall("c3", `{"update":[{"id":1,"status":"done"}]}`)
 			},
 			// req3 (expect high, task 2 in progress): finish task 2.
 			func(req llm.Request) llm.Response {
-				return taskEffortToolCall("c4", `{"action":"update","updates":[{"id":2,"status":"done"}]}`)
+				return taskEffortToolCall("c4", `{"update":[{"id":2,"status":"done"}]}`)
 			},
 			// req4 (expect max again: no task in progress).
 			func(req llm.Request) llm.Response { return finalResponse("done") },
@@ -304,11 +304,11 @@ func TestSession_TaskListRejectsInvalidEffortBeforeActivatingTask(t *testing.T) 
 		name: "openai",
 		steps: []func(req llm.Request) llm.Response{
 			func(req llm.Request) llm.Response {
-				requireTaskEffortSchemaLevel(t, req, "updates", "ultra")
-				return taskEffortToolCall("c1", `{"action":"append","tasks":[{"type":"implement","description":"first guard","prompt":"keep the first request valid","reasoning_effort":"high"},{"type":"implement","description":"second guard","prompt":"keep the second request valid","reasoning_effort":"low"}]}`)
+				requireTaskEffortSchemaLevel(t, req, "update", "ultra")
+				return taskEffortToolCall("c1", `{"add":[{"type":"implement","description":"first guard","prompt":"keep the first request valid","reasoning_effort":"high"},{"type":"implement","description":"second guard","prompt":"keep the second request valid","reasoning_effort":"low"}]}`)
 			},
 			func(req llm.Request) llm.Response {
-				return taskEffortToolCall("c2", `{"action":"update","updates":[{"id":1,"status":"done","reasoning_effort":"max"},{"id":2,"status":"in_progress","reasoning_effort":"ultra"}]}`)
+				return taskEffortToolCall("c2", `{"update":[{"id":1,"status":"done","reasoning_effort":"max"},{"id":2,"status":"in_progress","reasoning_effort":"ultra"}]}`)
 			},
 			func(req llm.Request) llm.Response {
 				requireTaskHandlerError(t, req, "c2")
@@ -358,8 +358,8 @@ func TestSession_TaskListRejectsInvalidEffortBeforeAppendingTask(t *testing.T) {
 		name: "openai",
 		steps: []func(req llm.Request) llm.Response{
 			func(req llm.Request) llm.Response {
-				requireTaskEffortSchemaLevel(t, req, "tasks", "ultra")
-				return taskEffortToolCall("c1", `{"action":"append","tasks":[{"type":"implement","description":"valid step","prompt":"must roll back with the batch","reasoning_effort":"high"},{"type":"implement","description":"poisoned step","prompt":"must not persist","reasoning_effort":"ultra"}]}`)
+				requireTaskEffortSchemaLevel(t, req, "add", "ultra")
+				return taskEffortToolCall("c1", `{"add":[{"type":"implement","description":"valid step","prompt":"must roll back with the batch","reasoning_effort":"high"},{"type":"implement","description":"poisoned step","prompt":"must not persist","reasoning_effort":"ultra"}]}`)
 			},
 			func(req llm.Request) llm.Response {
 				requireTaskHandlerError(t, req, "c1")
@@ -400,10 +400,10 @@ func TestSession_TaskEffortInherit_KeepsSessionEffort(t *testing.T) {
 		name: "openai",
 		steps: []func(req llm.Request) llm.Response{
 			func(req llm.Request) llm.Response {
-				return taskEffortToolCall("c1", `{"action":"append","tasks":[{"type":"implement","description":"a step","prompt":"do the thing","reasoning_effort":"inherit"}]}`)
+				return taskEffortToolCall("c1", `{"add":[{"type":"implement","description":"a step","prompt":"do the thing","reasoning_effort":"inherit"}]}`)
 			},
 			func(req llm.Request) llm.Response {
-				return taskEffortToolCall("c2", `{"action":"update","updates":[{"id":1,"status":"in_progress"}]}`)
+				return taskEffortToolCall("c2", `{"update":[{"id":1,"status":"in_progress"}]}`)
 			},
 			// req2: task 1 in progress with effort "inherit" -> session effort.
 			func(req llm.Request) llm.Response { return finalResponse("done") },
@@ -456,10 +456,10 @@ func TestSession_LoopDetectEscalation_WinsOverLowerTaskEffort(t *testing.T) {
 		name: "openai",
 		steps: []func(req llm.Request) llm.Response{
 			func(req llm.Request) llm.Response {
-				return taskEffortToolCall("c1", `{"action":"append","tasks":[{"type":"implement","description":"cheap step","prompt":"do cheap thing","reasoning_effort":"low"}]}`)
+				return taskEffortToolCall("c1", `{"add":[{"type":"implement","description":"cheap step","prompt":"do cheap thing","reasoning_effort":"low"}]}`)
 			},
 			func(req llm.Request) llm.Response {
-				return taskEffortToolCall("c2", `{"action":"update","updates":[{"id":1,"status":"in_progress"}]}`)
+				return taskEffortToolCall("c2", `{"update":[{"id":1,"status":"in_progress"}]}`)
 			},
 			// req2: task low in progress, no escalation yet -> low.
 			func(req llm.Request) llm.Response { return finalResponse("still working") },

--- a/agent/session_tool_repair.go
+++ b/agent/session_tool_repair.go
@@ -68,6 +68,10 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 		res.PrevalErr = errText
 		return res
 	}
+	if errText := retiredTaskListShapeError(call.Name, args); errText != "" {
+		res.PrevalErr = errText
+		return res
+	}
 
 	if err := rejectUnavailableDelegateSandboxControls(t.Definition.Name, t.Definition.Parameters, args); err != nil {
 		res.PrevalErr = err.Error()
@@ -146,6 +150,29 @@ func unsupportedDelegateWaitOption(toolName string, args map[string]any) string 
 		}
 	}
 	return ""
+}
+
+// retiredTaskListShapeError prevents argument repair from silently turning
+// an old action-shaped task_list call into a bare view. Repair would
+// otherwise drop the retired action/tasks/updates keys, validate the empty
+// remainder, and return the list — while the model believes its mutations
+// were applied. Naming the retired shape gets the model to the new contract
+// in one retry instead.
+func retiredTaskListShapeError(toolName string, args map[string]any) string {
+	if toolName != "task_list" {
+		return ""
+	}
+	var retired []string
+	for _, key := range []string{"action", "tasks", "updates"} {
+		if _, supplied := args[key]; supplied {
+			retired = append(retired, key)
+		}
+	}
+	if len(retired) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("invalid_request: task_list no longer takes %s; the call was not applied. Use {\"add\": [...]} to add tasks, {\"update\": [{\"id\": N, ...}]} to change them (omit status to leave it unchanged), or {} to view the list — all in one call.",
+		strings.Join(retired, ", "))
 }
 
 // changeStrings encodes changes as "kind:field:detail" for the telemetry event.

--- a/agent/session_tool_repair_task_branch_test.go
+++ b/agent/session_tool_repair_task_branch_test.go
@@ -12,50 +12,66 @@ import (
 	"primeradiant.com/evener/llm"
 )
 
-// Issue #626 regression: a task_list call with action "update" whose update
-// entries were placed in the append-branch "tasks" array (the exact argument
-// shape observed 17 times in session 034FsgXdyimiBvbubPlB4w) must be
-// rejected with an error that names the append branch the tasks[0]
-// requirement belongs to and points the caller at the "updates" array — not
-// the bare append-branch required list, which read as describing the update
-// call itself and sent the model into an unrecoverable retry loop. This
-// exercises the real prevalidation seam (prepareToolCall → Schema.Validate →
-// repair → ExplainSchemaError) with the real DefTaskList schema.
-func TestPrepareToolCall_TaskListUpdateCallerNamesAppendBranch(t *testing.T) {
+// The issue #626 failure family (update entries sent under the append
+// branch's "tasks" array, observed 17 times in a live session) is now
+// structurally unrepresentable: task_list has no action enum and no
+// tasks/updates arrays, so the old malformed shape cannot be formed. These
+// tests replace the #626 regression tests: they pin that the REMAINING
+// wrong-shape failure modes — old action-shaped calls and update entries in
+// the add array — fail with errors the repair layer can explain against the
+// new schema, through the real prevalidation seam.
+func TestPrepareToolCall_OldTaskListActionShapeRejected(t *testing.T) {
 	reg := tool.NewRegistry()
 	if err := reg.Register(regTool(tool.DefTaskList(nil))); err != nil {
 		t.Fatalf("register task_list: %v", err)
 	}
 	rt := reg.Get("task_list")
 
-	// Exact shape from the live session: update entries in "tasks", including
-	// the fields the model added while following the old misdirecting error.
 	call := llm.ToolCallData{
-		ID:   "issue626",
+		ID:   "old-shape",
 		Name: "task_list",
-		Arguments: json.RawMessage(`{"action":"update","tasks":[{` +
-			`"depends_on":[],"id":1,"notes":"","reasoning_effort":"inherit",` +
-			`"status":"in_progress","type":"implement"}]}`),
+		// The retired action key, exactly as an old session (or a model that
+		// learned the pre-rework contract) would send it.
+		Arguments: json.RawMessage(`{"action":"update","updates":[{"id":1,"status":"done"}]}`),
 	}
 	res := prepareToolCall(call, rt, []string{"task_list"}, "task_list", "communicate", "")
 	if res.PrevalErr == "" {
-		t.Fatalf("expected prevalidation failure for update-shaped entries in tasks, got none (changes: %v)", res.Changes)
+		t.Fatalf("expected prevalidation failure for action-shaped call, got none (changes: %v)", res.Changes)
 	}
-	if !strings.Contains(res.PrevalErr, `for action "append"`) {
-		t.Fatalf("error must name the append branch the tasks[0] requirement belongs to: %q", res.PrevalErr)
-	}
-	if !strings.Contains(res.PrevalErr, `takes "updates"`) {
-		t.Fatalf("error must point an update caller at the updates array: %q", res.PrevalErr)
-	}
-	if !strings.Contains(res.PrevalErr, `"updates": [{`) {
-		t.Fatalf("error example must show the updates-array item shape: %q", res.PrevalErr)
+	if !strings.Contains(res.PrevalErr, "action") {
+		t.Fatalf("error must name the retired action argument: %q", res.PrevalErr)
 	}
 }
 
-// The same call through execTool must surface the branch-named error to the
-// model, and must not reach the handler's "update requires a non-empty
-// 'updates' array" — that handler error was the other half of the loop.
-func TestExecTool_TaskListUpdateCallerBranchNamed(t *testing.T) {
+// An update entry misfiled into the add array must fail validation with an
+// error that names the add item's requirements — the same explainability the
+// #626 fix established, carried to the new schema.
+func TestPrepareToolCall_UpdateEntryInAddArrayExplains(t *testing.T) {
+	reg := tool.NewRegistry()
+	if err := reg.Register(regTool(tool.DefTaskList(nil))); err != nil {
+		t.Fatalf("register task_list: %v", err)
+	}
+	rt := reg.Get("task_list")
+
+	call := llm.ToolCallData{
+		ID:   "misfiled",
+		Name: "task_list",
+		// An update-shaped entry (id + status) inside add, where the schema
+		// demands type/description/prompt.
+		Arguments: json.RawMessage(`{"add":[{"id":1,"status":"in_progress"}]}`),
+	}
+	res := prepareToolCall(call, rt, []string{"task_list"}, "task_list", "communicate", "")
+	if res.PrevalErr == "" {
+		t.Fatalf("expected prevalidation failure for update entry in add, got none (changes: %v)", res.Changes)
+	}
+	if !strings.Contains(res.PrevalErr, "add") || !strings.Contains(res.PrevalErr, "description") {
+		t.Fatalf("error must name the add item requirements: %q", res.PrevalErr)
+	}
+}
+
+// The same misfiled-entry call through execTool must surface the
+// schema-explained error to the model.
+func TestExecTool_TaskListMisfiledEntrySurfacesSchemaError(t *testing.T) {
 	s := newSession(t, withoutGitSnapshot())
 	s.stateDir = t.TempDir()
 	registerTaskTools(s.reg, &toolDeps{
@@ -64,26 +80,20 @@ func TestExecTool_TaskListUpdateCallerBranchNamed(t *testing.T) {
 		resultToolName: func() string { return "communicate" },
 		taskGuard: taskGuard{
 			getOrCreateTaskStore: func() *taskpkg.TaskStore {
-				return taskpkg.NewTaskStore(t.TempDir(), "issue626")
+				return taskpkg.NewTaskStore(t.TempDir(), "misfiled")
 			},
 			markUsed: func() {},
 		},
 	})
 	res := s.execTool(context.Background(), llm.ToolCallData{
-		ID:        "issue626-exec",
+		ID:        "misfiled-exec",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action":"update","tasks":[{"id":1,"status":"in_progress"}]}`),
+		Arguments: json.RawMessage(`{"add":[{"id":1,"status":"in_progress"}]}`),
 	}, "")
 	if !res.IsError {
-		t.Fatalf("expected error for update-shaped entries in tasks, got: %s", res.FullOutput)
+		t.Fatalf("expected error for update-shaped entry in add, got: %s", res.FullOutput)
 	}
-	if strings.Contains(res.FullOutput, "update requires a non-empty") {
-		t.Fatalf("error fell through to the handler's shape complaint instead of the branch-named schema error: %s", res.FullOutput)
-	}
-	if !strings.Contains(res.FullOutput, `for action "append"`) {
-		t.Fatalf("model-visible error must name the append branch: %s", res.FullOutput)
-	}
-	if !strings.Contains(res.FullOutput, `takes "updates"`) {
-		t.Fatalf("model-visible error must point the caller at updates: %s", res.FullOutput)
+	if !strings.Contains(res.FullOutput, "add[0]") || !strings.Contains(res.FullOutput, "description") {
+		t.Fatalf("model-visible error must name the add item requirements: %s", res.FullOutput)
 	}
 }

--- a/agent/session_tool_repair_test.go
+++ b/agent/session_tool_repair_test.go
@@ -174,7 +174,7 @@ func TestPrepareToolCall_TaskListInheritEffortIsValid(t *testing.T) {
 		t.Fatalf("register task_list: %v", err)
 	}
 	call := llm.ToolCallData{ID: "inherit", Name: "task_list",
-		Arguments: json.RawMessage(`{"action":"append","tasks":[{"type":"implement","description":"step","prompt":"do it","reasoning_effort":"inherit"}]}`)}
+		Arguments: json.RawMessage(`{"add":[{"type":"implement","description":"step","prompt":"do it","reasoning_effort":"inherit"}]}`)}
 	res := prepareToolCall(call, reg.Get("task_list"), []string{"task_list"}, "task_list", "communicate", "")
 	if res.PrevalErr != "" {
 		t.Fatalf("inherit effort rejected: %s", res.PrevalErr)
@@ -199,15 +199,14 @@ func TestPrepareToolCall_NestedSchemaErrors_NameRealFieldAndContainer(t *testing
 
 	t.Run("task_list update missing id", func(t *testing.T) {
 		call := llm.ToolCallData{ID: "c1", Name: "task_list",
-			Arguments: json.RawMessage(`{"action":"update","updates":[{"status":"done","notes":"x"}]}`)}
+			Arguments: json.RawMessage(`{"update":[{"status":"done","notes":"x"}]}`)}
 		res := prepareToolCall(call, reg.Get("task_list"), []string{"task_list"}, "task_list", "communicate", "")
-		// The Example shows the caller's own branch shape (issue #626 round 2,
-		// finding 3): a correctly-placed update call missing a required field
-		// gets the updates-array template, not the action-only one. (Main made
-		// status optional, so the same-branch case under test is missing id.)
-		want := "task_list: missing required argument \"id\" in updates[0].\n" +
-			"Required arguments in updates[0]: id (integer).\n" +
-			"Example: {\"action\": \"update\", \"updates\": [{\"id\": 0}]}"
+		// Same-branch case (issue #626 round 2, finding 3): a correctly-shaped
+		// update call missing the required id names the update[0] container and
+		// shows the update-array template.
+		want := "task_list: missing required argument \"id\" in update[0].\n" +
+			"Required arguments in update[0]: id (integer).\n" +
+			"Example: {\"update\": [{\"id\": 0}]}"
 		if res.PrevalErr != want {
 			t.Fatalf("PrevalErr =\n%s\nwant:\n%s", res.PrevalErr, want)
 		}
@@ -222,16 +221,15 @@ func TestPrepareToolCall_NestedSchemaErrors_NameRealFieldAndContainer(t *testing
 		}
 	})
 
-	// The RCA for issue #193 confirmed enum is a second, independently
-	// affected constraint class: an invalid task_list action produced the
-	// same misleading "has the wrong type or value" + "Required arguments:
-	// action (string)." pair, even though action was present. Verify it
-	// through the real DefTaskList schema, not a hand-built fixture.
-	t.Run("task_list action bogus enum value", func(t *testing.T) {
+	// A bogus status value inside a correctly-shaped update entry is the
+	// enum-constraint case (issue #193's RCA class): the error names the
+	// enum and the offending value, never a misleading required-arguments
+	// line. Verified through the real DefTaskList schema.
+	t.Run("task_list update bogus status enum value", func(t *testing.T) {
 		call := llm.ToolCallData{ID: "c4", Name: "task_list",
-			Arguments: json.RawMessage(`{"action":"bogus"}`)}
+			Arguments: json.RawMessage(`{"update":[{"id":1,"status":"bogus"}]}`)}
 		res := prepareToolCall(call, reg.Get("task_list"), []string{"task_list"}, "task_list", "communicate", "")
-		want := "task_list: argument \"action\" is not one of the allowed values: view, append, update. Value is \"bogus\"."
+		want := "task_list: argument \"update[0].status\" is not one of the allowed values: open, in_progress, done, cancelled. Value is \"bogus\"."
 		if res.PrevalErr != want {
 			t.Fatalf("PrevalErr =\n%s\nwant:\n%s", res.PrevalErr, want)
 		}

--- a/agent/session_tools_aux_exact_fuzz_test.go
+++ b/agent/session_tools_aux_exact_fuzz_test.go
@@ -193,8 +193,8 @@ func auxGoalTaskExact(t *testing.T) {
 	registerTaskTools(reg, newToolDeps(s))
 	h := reg.Get("task_list").Exec
 	for _, args := range []map[string]any{
-		{"add":[]any{"bad"}},
-		{"update":[]any{"bad"}},
+		{"add": []any{"bad"}},
+		{"update": []any{"bad"}},
 		{"action": "unknown"},
 	} {
 		if _, err := h(context.Background(), nil, args); err == nil {

--- a/agent/session_tools_aux_exact_fuzz_test.go
+++ b/agent/session_tools_aux_exact_fuzz_test.go
@@ -193,8 +193,8 @@ func auxGoalTaskExact(t *testing.T) {
 	registerTaskTools(reg, newToolDeps(s))
 	h := reg.Get("task_list").Exec
 	for _, args := range []map[string]any{
-		{"action": "append", "tasks": []any{"bad"}},
-		{"action": "update", "updates": []any{"bad"}},
+		{"add":[]any{"bad"}},
+		{"update":[]any{"bad"}},
 		{"action": "unknown"},
 	} {
 		if _, err := h(context.Background(), nil, args); err == nil {

--- a/agent/session_tools_dispatch_fuzz_test.go
+++ b/agent/session_tools_dispatch_fuzz_test.go
@@ -148,10 +148,10 @@ func FuzzStoolDispatch(f *testing.F) {
 		stool_execOne(ctx, t, sess, "task_list", []byte(`{"update":[{"id":1,"status":"in_progress"}]}`))
 		stool_execOne(ctx, t, sess, "task_list", []byte(`{"update":[{"id":1,"status":"done"}]}`))
 		stool_execOne(ctx, t, sess, "task_list", []byte(`{"update":[{"id":2,"status":"done"}]}`))
-			stool_execOne(ctx, t, sess, "task_list", stool_taskListArgs(r, "add"))
+		stool_execOne(ctx, t, sess, "task_list", stool_taskListArgs(r, "add"))
 		stool_execOne(ctx, t, sess, "task_list", stool_taskListArgs(r, "update"))
 		stool_execOne(ctx, t, sess, "task_list", stool_taskListArgs(r, "view"))
-			stool_execOne(ctx, t, sess, "task_list", stool_taskListArgs(r, "both"))
+		stool_execOne(ctx, t, sess, "task_list", stool_taskListArgs(r, "both"))
 
 		// Entry-cancellation path: execTool must short-circuit to a skipped result
 		// (never a panic) when handed an already-canceled context.

--- a/agent/session_tools_dispatch_fuzz_test.go
+++ b/agent/session_tools_dispatch_fuzz_test.go
@@ -89,9 +89,9 @@ var stool_unknownNames = []string{
 	"../escape",
 }
 
-// stool_taskActions draws the task_list action across valid + invalid values so
+// stool_taskModes draws the task_list operation across valid + invalid values so
 // both the accept and the reject arms of registerTaskTools run.
-var stool_taskActions = []string{"view", "append", "update", "", "bogus"}
+var stool_taskModes = []string{"add", "update", "view", "both", "", "bogus"}
 
 // FuzzStoolDispatch fuzzes execTool / execToolBatch / the task_list handler.
 func FuzzStoolDispatch(f *testing.F) {
@@ -148,9 +148,10 @@ func FuzzStoolDispatch(f *testing.F) {
 		stool_execOne(ctx, t, sess, "task_list", []byte(`{"update":[{"id":1,"status":"in_progress"}]}`))
 		stool_execOne(ctx, t, sess, "task_list", []byte(`{"update":[{"id":1,"status":"done"}]}`))
 		stool_execOne(ctx, t, sess, "task_list", []byte(`{"update":[{"id":2,"status":"done"}]}`))
-		stool_execOne(ctx, t, sess, "task_list", stool_taskListArgs(r, "append"))
+			stool_execOne(ctx, t, sess, "task_list", stool_taskListArgs(r, "add"))
 		stool_execOne(ctx, t, sess, "task_list", stool_taskListArgs(r, "update"))
 		stool_execOne(ctx, t, sess, "task_list", stool_taskListArgs(r, "view"))
+			stool_execOne(ctx, t, sess, "task_list", stool_taskListArgs(r, "both"))
 
 		// Entry-cancellation path: execTool must short-circuit to a skipped result
 		// (never a panic) when handed an already-canceled context.
@@ -247,16 +248,24 @@ func stool_execOne(ctx context.Context, t *testing.T, sess *Session, name string
 	}
 }
 
-// stool_taskListArgs marshals a fuzzed task_list argument blob for a specific
-// action, driving the malformed/reject arms (empty batches, non-object entries,
-// bad dependency refs, invalid statuses) that the fixed happy-path calls skip.
-func stool_taskListArgs(r *jobtools_reader, action string) []byte {
-	m := map[string]any{"action": action}
-	switch action {
-	case "append":
-		m["tasks"] = stool_taskItems(r)
+// stool_taskListArgs marshals a fuzzed presence-based task_list argument blob
+// for a specific mode, driving the malformed/reject arms (empty batches,
+// non-object entries, bad dependency refs, invalid statuses) that the fixed
+// happy-path calls skip. Mode "both" sends add and update in one call; "view"
+// sends a bare object; "" and "bogus" drive the unknown-key reject arm via the
+// structured-args path below.
+func stool_taskListArgs(r *jobtools_reader, mode string) []byte {
+	m := map[string]any{}
+	switch mode {
+	case "add":
+		m["add"] = stool_taskItems(r)
 	case "update":
-		m["updates"] = stool_updateItems(r)
+		m["update"] = stool_updateItems(r)
+	case "both":
+		m["add"] = stool_taskItems(r)
+		m["update"] = stool_updateItems(r)
+	case "", "bogus":
+		m[mode] = r.str()
 	}
 	b, err := json.Marshal(m)
 	if err != nil {
@@ -296,12 +305,17 @@ func stool_structuredArgs(r *jobtools_reader, name string) map[string]any {
 	m := map[string]any{}
 	switch name {
 	case "task_list":
-		m["action"] = stool_taskActions[r.intn(len(stool_taskActions))]
-		switch m["action"] {
-		case "append":
-			m["tasks"] = stool_taskItems(r)
+		mode := stool_taskModes[r.intn(len(stool_taskModes))]
+		switch mode {
+		case "add":
+			m["add"] = stool_taskItems(r)
 		case "update":
-			m["updates"] = stool_updateItems(r)
+			m["update"] = stool_updateItems(r)
+		case "both":
+			m["add"] = stool_taskItems(r)
+			m["update"] = stool_updateItems(r)
+		case "", "bogus":
+			m[mode] = r.str()
 		}
 	case "read_file":
 		m["file_path"] = r.str()

--- a/agent/session_tools_dispatch_fuzz_test.go
+++ b/agent/session_tools_dispatch_fuzz_test.go
@@ -144,10 +144,10 @@ func FuzzStoolDispatch(f *testing.F) {
 		// one, complete it to trigger auto-advance, complete the rest to hit the
 		// all-done steer), then the fuzzed append/update calls exercise the reject
 		// and view arms.
-		stool_execOne(ctx, t, sess, "task_list", []byte(`{"action":"append","tasks":[{"type":"implement","description":"a","prompt":"do a"},{"type":"verify","description":"b","prompt":"do b"}]}`))
-		stool_execOne(ctx, t, sess, "task_list", []byte(`{"action":"update","updates":[{"id":1,"status":"in_progress"}]}`))
-		stool_execOne(ctx, t, sess, "task_list", []byte(`{"action":"update","updates":[{"id":1,"status":"done"}]}`))
-		stool_execOne(ctx, t, sess, "task_list", []byte(`{"action":"update","updates":[{"id":2,"status":"done"}]}`))
+		stool_execOne(ctx, t, sess, "task_list", []byte(`{"add":[{"type":"implement","description":"a","prompt":"do a"},{"type":"verify","description":"b","prompt":"do b"}]}`))
+		stool_execOne(ctx, t, sess, "task_list", []byte(`{"update":[{"id":1,"status":"in_progress"}]}`))
+		stool_execOne(ctx, t, sess, "task_list", []byte(`{"update":[{"id":1,"status":"done"}]}`))
+		stool_execOne(ctx, t, sess, "task_list", []byte(`{"update":[{"id":2,"status":"done"}]}`))
 		stool_execOne(ctx, t, sess, "task_list", stool_taskListArgs(r, "append"))
 		stool_execOne(ctx, t, sess, "task_list", stool_taskListArgs(r, "update"))
 		stool_execOne(ctx, t, sess, "task_list", stool_taskListArgs(r, "view"))
@@ -260,7 +260,7 @@ func stool_taskListArgs(r *jobtools_reader, action string) []byte {
 	}
 	b, err := json.Marshal(m)
 	if err != nil {
-		return []byte(`{"action":"view"}`)
+		return []byte(`{}`)
 	}
 	return b
 }

--- a/agent/session_tools_misc_contract_fuzz_test.go
+++ b/agent/session_tools_misc_contract_fuzz_test.go
@@ -174,7 +174,7 @@ func stmRunRoundContracts(t *testing.T, program []byte) {
 		stmCall(t, "list", "list_dir", map[string]any{"path": ".", "depth": float64(r.next()%3 + 1), "offset": float64(r.next() % 3), "limit": float64(r.next()%4 + 1)}),
 		stmCall(t, "grep", "grep", map[string]any{"pattern": value, "path": ".", "output_mode": []string{"content", "count", "files_with_matches"}[int(r.next())%3]}),
 		stmCall(t, "glob", "glob", map[string]any{"pattern": "*." + value, "path": "."}),
-		stmCall(t, "task", "task_list", map[string]any{"action": "append", "tasks": []any{map[string]any{"type": "implement", "description": value, "prompt": "do " + value}}}),
+		stmCall(t, "task", "task_list", map[string]any{"add":[]any{map[string]any{"type": "implement", "description": value, "prompt": "do " + value}}}),
 	}
 	results, err := s.execToolBatch(ctx, calls, s.currentProfile(), "")
 	if err != nil {

--- a/agent/session_tools_misc_contract_fuzz_test.go
+++ b/agent/session_tools_misc_contract_fuzz_test.go
@@ -174,7 +174,7 @@ func stmRunRoundContracts(t *testing.T, program []byte) {
 		stmCall(t, "list", "list_dir", map[string]any{"path": ".", "depth": float64(r.next()%3 + 1), "offset": float64(r.next() % 3), "limit": float64(r.next()%4 + 1)}),
 		stmCall(t, "grep", "grep", map[string]any{"pattern": value, "path": ".", "output_mode": []string{"content", "count", "files_with_matches"}[int(r.next())%3]}),
 		stmCall(t, "glob", "glob", map[string]any{"pattern": "*." + value, "path": "."}),
-		stmCall(t, "task", "task_list", map[string]any{"add":[]any{map[string]any{"type": "implement", "description": value, "prompt": "do " + value}}}),
+		stmCall(t, "task", "task_list", map[string]any{"add": []any{map[string]any{"type": "implement", "description": value, "prompt": "do " + value}}}),
 	}
 	results, err := s.execToolBatch(ctx, calls, s.currentProfile(), "")
 	if err != nil {

--- a/agent/session_tools_task.go
+++ b/agent/session_tools_task.go
@@ -81,6 +81,17 @@ func formatTaskUpdates(updates []taskpkg.TaskUpdate) string {
 	return strings.Join(parts, ", ")
 }
 
+// formatMutationAck renders the terse acknowledgement prefix for a call that
+// applied adds and/or updates: "Added N task(s); updated 1→done" (or either
+// half alone). formatTaskUpdates carries the id→status detail.
+func formatMutationAck(added int, updates []taskpkg.TaskUpdate) string {
+	detail := formatTaskUpdates(updates)
+	if added > 0 {
+		return fmt.Sprintf("Added %d task(s); updated %s.", added, detail)
+	}
+	return "Updated " + detail + "."
+}
+
 // taskToolState is the task-list mutation snapshot carried to human clients.
 // Started is present only for explicit updates whose final status is
 // in_progress, so the frontend can distinguish a real transition from a
@@ -123,6 +134,7 @@ func mutateAndPublishTaskStore(store *taskpkg.TaskStore, mutation func(epoch, re
 // literal string "<nil>" and broke the schema-documented optional status.
 func decodeTaskArgs(args map[string]any) (adds []taskpkg.TaskInput, updates []taskpkg.TaskUpdate, err error) {
 	rawAdds, _ := args["add"].([]any)
+	adds = make([]taskpkg.TaskInput, 0, len(rawAdds))
 	for i, r := range rawAdds {
 		m, ok := r.(map[string]any)
 		if !ok {
@@ -142,8 +154,12 @@ func decodeTaskArgs(args map[string]any) (adds []taskpkg.TaskInput, updates []ta
 			return nil, nil, fmt.Errorf("add entry %d requires a string prompt", i)
 		}
 		input.Prompt = prompt
-		if depsRaw, ok := m["depends_on"].([]any); ok {
-			depIDs, err := decodeIDList(depsRaw)
+		if depsRaw, has := m["depends_on"]; has {
+			arr, ok := depsRaw.([]any)
+			if !ok {
+				return nil, nil, fmt.Errorf("add entry %d depends_on must be an array of task IDs", i)
+			}
+			depIDs, err := decodeIDList(arr)
 			if err != nil {
 				return nil, nil, fmt.Errorf("add entry %d depends_on: %w", i, err)
 			}
@@ -158,6 +174,7 @@ func decodeTaskArgs(args map[string]any) (adds []taskpkg.TaskInput, updates []ta
 		adds = append(adds, input)
 	}
 	rawUpdates, _ := args["update"].([]any)
+	updates = make([]taskpkg.TaskUpdate, 0, len(rawUpdates))
 	for i, r := range rawUpdates {
 		m, ok := r.(map[string]any)
 		if !ok {
@@ -201,9 +218,6 @@ func decodeTaskArgs(args map[string]any) (adds []taskpkg.TaskInput, updates []ta
 
 // decodeIDList converts a JSON array of numbers into []int.
 func decodeIDList(raw []any) ([]int, error) {
-	if len(raw) == 0 {
-		return nil, nil
-	}
 	ids := make([]int, 0, len(raw))
 	for _, d := range raw {
 		v, ok := d.(float64)
@@ -223,12 +237,25 @@ func decodeIDList(raw []any) ([]int, error) {
 // shouldn't need to). Without the depends_on check the store would validate
 // post-add and accept a guessed new ID — exactly the ID-guessing the
 // pre-add target rule exists to prevent.
+//
+// This is handler-side policy over a store API that cannot express the
+// pre-add transaction: the semantic rule (the model cannot know new IDs)
+// belongs here, not in the store. If a second mutation caller appears, hoist
+// the whole combined batch into a store-level ApplyBatch(adds, updates) that
+// validates updates against the pre-add state under one lock and returns one
+// snapshot — until then the double validation (updateLocked re-rejects the
+// same unknown IDs) is the price of exactly one caller.
+//
+// Only load-bearing when the call also adds: updateLocked enforces the same
+// rejections (identical errors, nothing applied) when there are no adds, so
+// callers gate on len(adds) > 0 and skip the duplicated pass.
 func validateUpdateIDs(store *taskpkg.TaskStore, updates []taskpkg.TaskUpdate) error {
 	if len(updates) == 0 {
 		return nil
 	}
-	known := make(map[int]struct{}, 8)
-	for _, t := range store.View() {
+	tasks := store.View()
+	known := make(map[int]struct{}, len(tasks))
+	for _, t := range tasks {
 		known[t.ID] = struct{}{}
 	}
 	for _, u := range updates {
@@ -262,15 +289,20 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 			if len(adds) == 0 && len(updates) == 0 {
 				// Bare or all-empty call: view. (Empty arrays decode to nil
 				// slices; a mutation with nothing to mutate is the view.)
-				return tool.StateResult{Output: formatTaskList(store.View()), State: store.View()}, nil
+				tasks := store.View()
+				return tool.StateResult{Output: formatTaskList(tasks), State: tasks}, nil
 			}
 
 			return mutateAndPublishTaskStore(store, func(epoch, revision uint64) (any, error) {
-				// Validate update IDs against the PRE-ADD state: the model
-				// composed this call before any new IDs existed, so an update
-				// can never legitimately target this call's adds.
-				if err := validateUpdateIDs(store, updates); err != nil {
-					return nil, err
+				// Validate update IDs against the PRE-ADD state when this
+				// call also adds: the model composed the call before any new
+				// IDs existed, so an update can never legitimately target or
+				// depend on this call's adds. (Without adds, updateLocked
+				// enforces the same rejections itself.)
+				if len(adds) > 0 {
+					if err := validateUpdateIDs(store, updates); err != nil {
+						return nil, err
+					}
 				}
 				var added []taskpkg.Task
 				if len(adds) > 0 {
@@ -308,12 +340,14 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 				for _, task := range mutation.Before {
 					previous[task.ID] = task.Status
 				}
-				// Final statuses come from the snapshot, not the raw
+				// afterByID serves the classification below and the steering
+				// lookup: one pass over the snapshot instead of a scan per
+				// purpose. Final statuses come from the snapshot, not the raw
 				// entries: an empty-status entry (no change) must classify
 				// by the task's resulting status.
-				finalStatus := make(map[int]taskpkg.TaskStatus, len(mutation.After))
+				afterByID := make(map[int]taskpkg.Task, len(mutation.After))
 				for _, t := range mutation.After {
-					finalStatus[t.ID] = t.Status
+					afterByID[t.ID] = t
 				}
 				inProgressUpdates := make(map[int]struct{}, len(updates))
 				started := make(map[int]bool)
@@ -325,7 +359,7 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 						continue
 					}
 					seenIDs[u.ID] = struct{}{}
-					status := finalStatus[u.ID]
+					status := afterByID[u.ID].Status
 					if status == taskpkg.TaskDone || status == taskpkg.TaskCancelled {
 						completedAny = true
 					}
@@ -342,36 +376,22 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 				// steering so the SYSTEM-REMINDER for the new task shows up on
 				// the next turn.
 				if manuallyStartedID != 0 {
-					for _, t := range mutation.After {
-						if t.ID == manuallyStartedID {
-							// Inside the task_list handler: the tool is registered by
-							// construction, so the steering may name it.
-							deps.steer(formatCurrentTaskSteering(t, true), events.SteeringKindCurrentTask)
-							break
-						}
-					}
+					// Inside the task_list handler: the tool is registered by
+					// construction, so the steering may name it.
+					deps.steer(formatCurrentTaskSteering(afterByID[manuallyStartedID], true), events.SteeringKindCurrentTask)
 				}
 
 				if !completedAny && manuallyStartedID == 0 {
 					deps.emit(events.EventTaskUpdated, taskUpdatedData(taskpkg.Summarize(mutation.After), "", epoch, revision))
-					output := "Updated " + formatTaskUpdates(updates) + "."
-					if len(added) > 0 {
-						output = fmt.Sprintf("Added %d task(s); updated %s.", len(added), formatTaskUpdates(updates))
-					}
 					return tool.StateResult{
-						Output: output,
+						Output: formatMutationAck(len(added), updates),
 						State:  taskToolStateSnapshot(mutation.After, inProgressUpdates, started),
 					}, nil
 				}
 
 				var msg strings.Builder
-				if len(added) > 0 {
-					fmt.Fprintf(&msg, "Added %d task(s); updated ", len(added))
-				} else {
-					msg.WriteString("Updated ")
-				}
-				msg.WriteString(formatTaskUpdates(updates))
-				msg.WriteString(". ")
+				msg.WriteString(formatMutationAck(len(added), updates))
+				msg.WriteString(" ")
 				finalTasks := mutation.After
 
 				if completedAny {

--- a/agent/session_tools_task.go
+++ b/agent/session_tools_task.go
@@ -132,7 +132,17 @@ func mutateAndPublishTaskStore(store *taskpkg.TaskStore, mutation func(epoch, re
 // is rejected rather than silently no-opping. No fmt.Sprint coercion: the
 // old handler's fmt.Sprint(m["status"]) turned a missing status into the
 // literal string "<nil>" and broke the schema-documented optional status.
+//
+// Retired keys (action/tasks/updates) are rejected here too, not only in
+// prepareToolCall's guard: a direct handler caller (tests, internal callers)
+// bypasses prevalidation, and silently treating an action-shaped call as a
+// view would let the caller believe its mutations applied.
 func decodeTaskArgs(args map[string]any) (adds []taskpkg.TaskInput, updates []taskpkg.TaskUpdate, err error) {
+	for _, retired := range []string{"action", "tasks", "updates"} {
+		if _, supplied := args[retired]; supplied {
+			return nil, nil, fmt.Errorf("task_list no longer takes %s; use add and/or update, or a bare call to view", retired)
+		}
+	}
 	rawAdds, _ := args["add"].([]any)
 	adds = make([]taskpkg.TaskInput, 0, len(rawAdds))
 	for i, r := range rawAdds {

--- a/agent/session_tools_task.go
+++ b/agent/session_tools_task.go
@@ -114,6 +114,128 @@ func mutateAndPublishTaskStore(store *taskpkg.TaskStore, mutation func(epoch, re
 	return result, err
 }
 
+// decodeTaskArgs converts a presence-based task_list call into typed inputs:
+// whichever array is present is the operation, both can appear in one call.
+// Decoding is strict — a wrong-typed field is an error naming the entry, and
+// an update entry that sets none of status/notes/depends_on/reasoning_effort
+// is rejected rather than silently no-opping. No fmt.Sprint coercion: the
+// old handler's fmt.Sprint(m["status"]) turned a missing status into the
+// literal string "<nil>" and broke the schema-documented optional status.
+func decodeTaskArgs(args map[string]any) (adds []taskpkg.TaskInput, updates []taskpkg.TaskUpdate, err error) {
+	rawAdds, _ := args["add"].([]any)
+	for i, r := range rawAdds {
+		m, ok := r.(map[string]any)
+		if !ok {
+			return nil, nil, fmt.Errorf("add entry %d must be an object with type, description, and prompt", i)
+		}
+		var input taskpkg.TaskInput
+		if t, ok := m["type"].(string); ok {
+			input.Type = taskpkg.TaskType(t)
+		}
+		description, ok := m["description"].(string)
+		if !ok {
+			return nil, nil, fmt.Errorf("add entry %d requires a string description", i)
+		}
+		input.Description = description
+		prompt, ok := m["prompt"].(string)
+		if !ok {
+			return nil, nil, fmt.Errorf("add entry %d requires a string prompt", i)
+		}
+		input.Prompt = prompt
+		if depsRaw, ok := m["depends_on"].([]any); ok {
+			depIDs, err := decodeIDList(depsRaw)
+			if err != nil {
+				return nil, nil, fmt.Errorf("add entry %d depends_on: %w", i, err)
+			}
+			input.DependsOn = depIDs
+		}
+		if re, ok := m["reasoning_effort"].(string); ok {
+			input.ReasoningEffort, err = validateTaskEffort(re)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+		adds = append(adds, input)
+	}
+	rawUpdates, _ := args["update"].([]any)
+	for i, r := range rawUpdates {
+		m, ok := r.(map[string]any)
+		if !ok {
+			return nil, nil, fmt.Errorf("update entry %d must be an object with id", i)
+		}
+		idFloat, ok := m["id"].(float64)
+		if !ok {
+			return nil, nil, fmt.Errorf("update entry %d requires an integer id", i)
+		}
+		u := taskpkg.TaskUpdate{ID: int(idFloat)}
+		if s, ok := m["status"].(string); ok {
+			u.Status = taskpkg.TaskStatus(s)
+		}
+		if n, ok := m["notes"].(string); ok {
+			u.Notes = n
+		}
+		if depsRaw, has := m["depends_on"]; has {
+			arr, ok := depsRaw.([]any)
+			if !ok {
+				return nil, nil, fmt.Errorf("update entry %d depends_on must be an array of task IDs", i)
+			}
+			depIDs, err := decodeIDList(arr)
+			if err != nil {
+				return nil, nil, fmt.Errorf("update entry %d depends_on: %w", i, err)
+			}
+			u.DependsOn = &depIDs
+		}
+		if re, ok := m["reasoning_effort"].(string); ok {
+			u.ReasoningEffort, err = validateTaskEffort(re)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+		if u.Status == "" && u.Notes == "" && u.DependsOn == nil && u.ReasoningEffort == "" {
+			return nil, nil, fmt.Errorf("update entry for task %d changes nothing; include status, notes, depends_on, or reasoning_effort", u.ID)
+		}
+		updates = append(updates, u)
+	}
+	return adds, updates, nil
+}
+
+// decodeIDList converts a JSON array of numbers into []int.
+func decodeIDList(raw []any) ([]int, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	ids := make([]int, 0, len(raw))
+	for _, d := range raw {
+		v, ok := d.(float64)
+		if !ok {
+			return nil, errors.New("each element must be an integer task ID")
+		}
+		ids = append(ids, int(v))
+	}
+	return ids, nil
+}
+
+// validateUpdateIDs rejects update entries whose target does not exist in
+// the pre-add store state. The model composed the call before any new IDs
+// existed, so an update can never legitimately target this call's adds; the
+// same error covers both "never existed" and "not yet created" (the model
+// cannot distinguish them and shouldn't need to).
+func validateUpdateIDs(store *taskpkg.TaskStore, updates []taskpkg.TaskUpdate) error {
+	if len(updates) == 0 {
+		return nil
+	}
+	known := make(map[int]struct{}, 8)
+	for _, t := range store.View() {
+		known[t.ID] = struct{}{}
+	}
+	for _, u := range updates {
+		if _, ok := known[u.ID]; !ok {
+			return fmt.Errorf("unknown task ID %d", u.ID)
+		}
+	}
+	return nil
+}
+
 func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 	// Task management.
 	_ = reg.Register(tool.RegisteredTool{
@@ -122,59 +244,35 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 			_ = ctx
 			deps.taskGuard.MarkUsed()
 			store := deps.taskGuard.Store()
-			action := fmt.Sprint(args["action"])
-			switch action {
-			case "view":
+			adds, updates, err := decodeTaskArgs(args)
+			if err != nil {
+				return nil, err
+			}
+			if len(adds) == 0 && len(updates) == 0 {
+				// Bare or all-empty call: view. (Empty arrays decode to nil
+				// slices; a mutation with nothing to mutate is the view.)
 				return tool.StateResult{Output: formatTaskList(store.View()), State: store.View()}, nil
-			case "append":
-				raw, ok := args["tasks"].([]any)
-				if !ok || len(raw) == 0 {
-					return nil, errors.New("append requires a non-empty 'tasks' array")
+			}
+
+			return mutateAndPublishTaskStore(store, func(epoch, revision uint64) (any, error) {
+				// Validate update IDs against the PRE-ADD state: the model
+				// composed this call before any new IDs existed, so an update
+				// can never legitimately target this call's adds.
+				if err := validateUpdateIDs(store, updates); err != nil {
+					return nil, err
 				}
-				var items []taskpkg.TaskInput
-				for _, r := range raw {
-					m, ok := r.(map[string]any)
-					if !ok {
-						return nil, errors.New("each task must be an object with description and prompt")
-					}
-					var depIDs []int
-					if depsRaw, ok := m["depends_on"].([]any); ok {
-						for _, d := range depsRaw {
-							if v, ok := d.(float64); ok {
-								depIDs = append(depIDs, int(v))
-							}
-						}
-					}
-					var taskType taskpkg.TaskType
-					if t, ok := m["type"].(string); ok {
-						taskType = taskpkg.TaskType(t)
-					}
-					reasoningEffort := ""
-					if re, ok := m["reasoning_effort"].(string); ok {
-						var err error
-						reasoningEffort, err = validateTaskEffort(re)
-						if err != nil {
-							return nil, err
-						}
-					}
-					items = append(items, taskpkg.TaskInput{
-						Type:            taskType,
-						Description:     fmt.Sprint(m["description"]),
-						Prompt:          fmt.Sprint(m["prompt"]),
-						DependsOn:       depIDs,
-						ReasoningEffort: reasoningEffort,
-					})
-				}
-				return mutateAndPublishTaskStore(store, func(epoch, revision uint64) (any, error) {
-					added, err := store.Append(items)
+				var added []taskpkg.Task
+				if len(adds) > 0 {
+					added, err = store.Append(adds)
 					if err != nil {
 						return nil, err
 					}
-
-					// The tool response is a terse acknowledgement. The current
-					// task is announced via a separate SYSTEM-REMINDER steering
-					// message when the agent actually transitions one to
-					// in_progress, either manually or via auto-advance.
+				}
+				if len(updates) == 0 {
+					// Adds only: terse acknowledgement. The current task is
+					// announced via a separate SYSTEM-REMINDER steering message
+					// when the agent actually transitions one to in_progress,
+					// either manually or via auto-advance.
 					tasks := store.View()
 					taskUpdate := taskUpdatedData(taskpkg.Summarize(tasks), "", epoch, revision)
 					deps.emit(events.EventTaskUpdated, taskUpdate)
@@ -182,157 +280,122 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 						Output: fmt.Sprintf("Added %d task(s). Progress: %d/%d tasks complete.", len(added), taskUpdate.Done, taskUpdate.Total),
 						State:  tasks,
 					}, nil
-				})
-			case "update":
-				raw, ok := args["updates"].([]any)
-				if !ok || len(raw) == 0 {
-					return nil, errors.New("update requires a non-empty 'updates' array")
 				}
-				var updates []taskpkg.TaskUpdate
-				for _, r := range raw {
-					m, ok := r.(map[string]any)
-					if !ok {
-						return nil, errors.New("each update must be an object with id and status")
-					}
-					id := 0
-					if v, ok := m["id"].(float64); ok {
-						id = int(v)
-					}
-					u := taskpkg.TaskUpdate{
-						ID:     id,
-						Status: taskpkg.TaskStatus(fmt.Sprint(m["status"])),
-					}
-					if n, ok := m["notes"].(string); ok {
-						u.Notes = n
-					}
-					if depsRaw, ok := m["depends_on"]; ok {
-						var depIDs []int
-						if arr, ok := depsRaw.([]any); ok {
-							for _, d := range arr {
-								if v, ok := d.(float64); ok {
-									depIDs = append(depIDs, int(v))
-								}
-							}
-						}
-						u.DependsOn = &depIDs
-					}
-					if re, ok := m["reasoning_effort"].(string); ok {
-						var err error
-						u.ReasoningEffort, err = validateTaskEffort(re)
-						if err != nil {
-							return nil, err
-						}
-					}
-					updates = append(updates, u)
+				mutation, err := store.UpdateWithSnapshot(updates)
+				if err != nil {
+					return nil, err
 				}
-				return mutateAndPublishTaskStore(store, func(epoch, revision uint64) (any, error) {
-					mutation, err := store.UpdateWithSnapshot(updates)
-					if err != nil {
-						return nil, err
-					}
 
-					// Classify each ID from the final status the store applied, so
-					// duplicate entries cannot steer a task that ended completed or
-					// suppress auto-advance after the final state is known.
-					previous := make(map[int]taskpkg.TaskStatus, len(mutation.Before))
-					for _, task := range mutation.Before {
-						previous[task.ID] = task.Status
+				// Classify each ID from the final status the store applied, so
+				// duplicate entries cannot steer a task that ended completed or
+				// suppress auto-advance after the final state is known.
+				previous := make(map[int]taskpkg.TaskStatus, len(mutation.Before))
+				for _, task := range mutation.Before {
+					previous[task.ID] = task.Status
+				}
+				// Final statuses come from the snapshot, not the raw
+				// entries: an empty-status entry (no change) must classify
+				// by the task's resulting status.
+				finalStatus := make(map[int]taskpkg.TaskStatus, len(mutation.After))
+				for _, t := range mutation.After {
+					finalStatus[t.ID] = t.Status
+				}
+				inProgressUpdates := make(map[int]struct{}, len(updates))
+				started := make(map[int]bool)
+				var completedAny bool
+				var manuallyStartedID int
+				seenIDs := make(map[int]struct{}, len(updates))
+				for _, u := range updates {
+					if _, seen := seenIDs[u.ID]; seen {
+						continue
 					}
-					finalStatus := make(map[int]taskpkg.TaskStatus, len(updates))
-					for _, u := range updates {
-						finalStatus[u.ID] = u.Status
+					seenIDs[u.ID] = struct{}{}
+					status := finalStatus[u.ID]
+					if status == taskpkg.TaskDone || status == taskpkg.TaskCancelled {
+						completedAny = true
 					}
-					inProgressUpdates := make(map[int]struct{}, len(updates))
-					started := make(map[int]bool)
-					var completedAny bool
-					var manuallyStartedID int
-					seenIDs := make(map[int]struct{}, len(updates))
-					for _, u := range updates {
-						if _, seen := seenIDs[u.ID]; seen {
-							continue
-						}
-						seenIDs[u.ID] = struct{}{}
-						status := finalStatus[u.ID]
-						if status == taskpkg.TaskDone || status == taskpkg.TaskCancelled {
-							completedAny = true
-						}
-						if status == taskpkg.TaskInProgress {
-							inProgressUpdates[u.ID] = struct{}{}
-							if previous[u.ID] != taskpkg.TaskInProgress {
-								started[u.ID] = true
-								manuallyStartedID = u.ID
-							}
+					if status == taskpkg.TaskInProgress {
+						inProgressUpdates[u.ID] = struct{}{}
+						if previous[u.ID] != taskpkg.TaskInProgress {
+							started[u.ID] = true
+							manuallyStartedID = u.ID
 						}
 					}
+				}
 
-					// If the agent explicitly started a task, fire its current-task
-					// steering so the SYSTEM-REMINDER for the new task shows up on
-					// the next turn.
-					if manuallyStartedID != 0 {
-						for _, t := range mutation.After {
-							if t.ID == manuallyStartedID {
-								// Inside the task_list handler: the tool is registered by
-								// construction, so the steering may name it.
-								deps.steer(formatCurrentTaskSteering(t, true), events.SteeringKindCurrentTask)
-								break
-							}
+				// If the agent explicitly started a task, fire its current-task
+				// steering so the SYSTEM-REMINDER for the new task shows up on
+				// the next turn.
+				if manuallyStartedID != 0 {
+					for _, t := range mutation.After {
+						if t.ID == manuallyStartedID {
+							// Inside the task_list handler: the tool is registered by
+							// construction, so the steering may name it.
+							deps.steer(formatCurrentTaskSteering(t, true), events.SteeringKindCurrentTask)
+							break
 						}
 					}
+				}
 
-					if !completedAny && manuallyStartedID == 0 {
-						deps.emit(events.EventTaskUpdated, taskUpdatedData(taskpkg.Summarize(mutation.After), "", epoch, revision))
-						return tool.StateResult{
-							Output: "Updated " + formatTaskUpdates(updates) + ".",
-							State:  taskToolStateSnapshot(mutation.After, inProgressUpdates, started),
-						}, nil
+				if !completedAny && manuallyStartedID == 0 {
+					deps.emit(events.EventTaskUpdated, taskUpdatedData(taskpkg.Summarize(mutation.After), "", epoch, revision))
+					output := "Updated " + formatTaskUpdates(updates) + "."
+					if len(added) > 0 {
+						output = fmt.Sprintf("Added %d task(s); updated %s.", len(added), formatTaskUpdates(updates))
 					}
+					return tool.StateResult{
+						Output: output,
+						State:  taskToolStateSnapshot(mutation.After, inProgressUpdates, started),
+					}, nil
+				}
 
-					var msg strings.Builder
+				var msg strings.Builder
+				if len(added) > 0 {
+					fmt.Fprintf(&msg, "Added %d task(s); updated ", len(added))
+				} else {
 					msg.WriteString("Updated ")
-					msg.WriteString(formatTaskUpdates(updates))
-					msg.WriteString(". ")
-					finalTasks := mutation.After
+				}
+				msg.WriteString(formatTaskUpdates(updates))
+				msg.WriteString(". ")
+				finalTasks := mutation.After
 
-					if completedAny {
-						// Auto-advance unless the agent already picked what to do next.
-						if manuallyStartedID == 0 {
-							eligible := store.NextEligible()
-							if len(eligible) > 0 {
-								next := eligible[0]
-								if auto, err := store.UpdateWithSnapshot([]taskpkg.TaskUpdate{{ID: next.ID, Status: taskpkg.TaskInProgress}}); err == nil {
-									finalTasks = auto.After
-									deps.steer(formatCurrentTaskSteering(next, true), events.SteeringKindCurrentTask)
+				if completedAny {
+					// Auto-advance unless the agent already picked what to do next.
+					if manuallyStartedID == 0 {
+						eligible := store.NextEligible()
+						if len(eligible) > 0 {
+							next := eligible[0]
+							if auto, err := store.UpdateWithSnapshot([]taskpkg.TaskUpdate{{ID: next.ID, Status: taskpkg.TaskInProgress}}); err == nil {
+								finalTasks = auto.After
+								deps.steer(formatCurrentTaskSteering(next, true), events.SteeringKindCurrentTask)
+							}
+						} else {
+							// No eligible task. If nothing remains open or in_progress,
+							// signal the agent that the list is exhausted.
+							allDone := taskListAllDone(finalTasks)
+							if allDone && len(finalTasks) > 0 {
+								var blockingDelegateIDs []string
+								if deps.blockingDelegateIDs != nil {
+									blockingDelegateIDs = deps.blockingDelegateIDs()
 								}
-							} else {
-								// No eligible task. If nothing remains open or in_progress,
-								// signal the agent that the list is exhausted.
-								allDone := taskListAllDone(finalTasks)
-								if allDone && len(finalTasks) > 0 {
-									var blockingDelegateIDs []string
-									if deps.blockingDelegateIDs != nil {
-										blockingDelegateIDs = deps.blockingDelegateIDs()
-									}
-									deps.sendTaskCompletionSteering(taskReminderAllDoneWhileDelegatesRun(deps.resultToolName(), blockingDelegateIDs), blockingDelegateIDs)
-									if len(blockingDelegateIDs) == 0 {
-										msg.WriteString("All tasks complete. ")
-									} else {
-										msg.WriteString("All tasks complete; waiting for delegate(s) ")
-										msg.WriteString(strings.Join(blockingDelegateIDs, ", "))
-										msg.WriteString(". ")
-									}
+								deps.sendTaskCompletionSteering(taskReminderAllDoneWhileDelegatesRun(deps.resultToolName(), blockingDelegateIDs), blockingDelegateIDs)
+								if len(blockingDelegateIDs) == 0 {
+									msg.WriteString("All tasks complete. ")
+								} else {
+									msg.WriteString("All tasks complete; waiting for delegate(s) ")
+									msg.WriteString(strings.Join(blockingDelegateIDs, ", "))
+									msg.WriteString(". ")
 								}
 							}
 						}
 					}
+				}
 
-					taskUpdate := taskUpdatedData(taskpkg.Summarize(finalTasks), "", epoch, revision)
-					deps.emit(events.EventTaskUpdated, taskUpdate)
-					fmt.Fprintf(&msg, "Progress: %d/%d tasks complete.", taskUpdate.Done, taskUpdate.Total)
-					return tool.StateResult{Output: msg.String(), State: taskToolStateSnapshot(finalTasks, inProgressUpdates, started)}, nil
-				})
-			default:
-				return nil, fmt.Errorf("unknown task_list action %q: use view, append, or update", action)
-			}
+				taskUpdate := taskUpdatedData(taskpkg.Summarize(finalTasks), "", epoch, revision)
+				deps.emit(events.EventTaskUpdated, taskUpdate)
+				fmt.Fprintf(&msg, "Progress: %d/%d tasks complete.", taskUpdate.Done, taskUpdate.Total)
+				return tool.StateResult{Output: msg.String(), State: taskToolStateSnapshot(finalTasks, inProgressUpdates, started)}, nil
+			})
 		},
 	})
 }

--- a/agent/session_tools_task.go
+++ b/agent/session_tools_task.go
@@ -215,11 +215,14 @@ func decodeIDList(raw []any) ([]int, error) {
 	return ids, nil
 }
 
-// validateUpdateIDs rejects update entries whose target does not exist in
-// the pre-add store state. The model composed the call before any new IDs
-// existed, so an update can never legitimately target this call's adds; the
-// same error covers both "never existed" and "not yet created" (the model
-// cannot distinguish them and shouldn't need to).
+// validateUpdateIDs rejects update entries whose target — or any task their
+// depends_on names — does not exist in the pre-add store state. The model
+// composed the call before any new IDs existed, so an update can neither
+// target nor depend on this call's adds; the same error covers "never
+// existed" and "not yet created" (the model cannot distinguish them and
+// shouldn't need to). Without the depends_on check the store would validate
+// post-add and accept a guessed new ID — exactly the ID-guessing the
+// pre-add target rule exists to prevent.
 func validateUpdateIDs(store *taskpkg.TaskStore, updates []taskpkg.TaskUpdate) error {
 	if len(updates) == 0 {
 		return nil
@@ -231,6 +234,14 @@ func validateUpdateIDs(store *taskpkg.TaskStore, updates []taskpkg.TaskUpdate) e
 	for _, u := range updates {
 		if _, ok := known[u.ID]; !ok {
 			return fmt.Errorf("unknown task ID %d", u.ID)
+		}
+		if u.DependsOn == nil {
+			continue
+		}
+		for _, dep := range *u.DependsOn {
+			if _, ok := known[dep]; !ok {
+				return fmt.Errorf("task %d depends on unknown task %d", u.ID, dep)
+			}
 		}
 	}
 	return nil
@@ -288,7 +299,11 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 
 				// Classify each ID from the final status the store applied, so
 				// duplicate entries cannot steer a task that ended completed or
-				// suppress auto-advance after the final state is known.
+				// suppress auto-advance after the final state is known. Note:
+				// mutation.Before is the POST-ADD pre-update state, but every
+				// update target pre-existed the call (validateUpdateIDs), so its
+				// Before status equals its pre-call status — adds never touch
+				// existing tasks' statuses.
 				previous := make(map[int]taskpkg.TaskStatus, len(mutation.Before))
 				for _, task := range mutation.Before {
 					previous[task.ID] = task.Status

--- a/agent/session_tools_task_invariants_test.go
+++ b/agent/session_tools_task_invariants_test.go
@@ -1,0 +1,99 @@
+package agent
+
+import (
+	"testing"
+
+	"primeradiant.com/evener/agent/events"
+	taskpkg "primeradiant.com/evener/agent/task"
+)
+
+// Invariant battery for the presence-based task_list handler: one test per
+// contract invariant, each seeded to expose exactly that invariant.
+func TestTaskTool_SingleInProgressUnderCombinedBatch(t *testing.T) {
+	// Two pre-existing tasks; try to start both in one combined call.
+	h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "a", Prompt: "p"}, {Description: "b", Prompt: "p"}})
+	res := h.call(t, map[string]any{
+		"update": []any{
+			map[string]any{"id": 1, "status": "in_progress"},
+			map[string]any{"id": 2, "status": "in_progress"},
+		},
+	})
+	if !res.IsError {
+		t.Fatal("two in_progress in one batch must be rejected")
+	}
+}
+
+func TestTaskTool_AutoAdvanceFiresOnceWithSteering(t *testing.T) {
+	h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "a", Prompt: "p"}, {Description: "b", Prompt: "p"}})
+	if err := h.store.Update([]taskpkg.TaskUpdate{{ID: 1, Status: taskpkg.TaskInProgress}}); err != nil {
+		t.Fatal(err)
+	}
+	steersBefore := len(h.steers)
+	res := h.call(t, map[string]any{
+		"update": []any{map[string]any{"id": 1, "status": "done"}},
+	})
+	if res.IsError {
+		t.Fatalf("completion failed: %s", res.FullOutput)
+	}
+	// Auto-advance starts task 2: exactly one current-task steer.
+	if got := len(h.steers) - steersBefore; got != 1 {
+		t.Fatalf("auto-advance steering fired %d times, want 1", got)
+	}
+	if h.store.View()[1].Status != taskpkg.TaskInProgress {
+		t.Fatal("auto-advance did not start task 2")
+	}
+}
+
+func TestTaskTool_EventsPayloadShapeUnchanged(t *testing.T) {
+	h := newTaskToolHarness(t, nil)
+	h.call(t, map[string]any{
+		"add": []any{map[string]any{"type": "implement", "description": "x", "prompt": "p"}},
+	})
+	var found *events.TaskUpdatedData
+	for _, d := range h.emitted {
+		if td, ok := d.(events.TaskUpdatedData); ok {
+			found = &td
+		}
+	}
+	if found == nil {
+		t.Fatal("add did not emit EventTaskUpdated")
+	}
+	if found.Total != 1 || found.Done != 0 {
+		t.Fatalf("payload summary = %d/%d, want 1/0", found.Done, found.Total)
+	}
+	if found.TaskPublicationRevision == 0 {
+		t.Fatal("payload missing publication revision")
+	}
+}
+
+func TestTaskTool_AddDepOnUnknownRejected(t *testing.T) {
+	h := newTaskToolHarness(t, nil)
+	res := h.call(t, map[string]any{
+		"add": []any{map[string]any{"type": "implement", "description": "x", "prompt": "p", "depends_on": []any{99}}},
+	})
+	if !res.IsError {
+		t.Fatal("add depending on unknown ID must be rejected")
+	}
+	if len(h.store.View()) != 0 {
+		t.Fatal("rejected add must not apply")
+	}
+}
+
+func TestTaskTool_SameBatchAddDepsAllowed(t *testing.T) {
+	// Intra-batch: second add may depend on the first add in the same call
+	// (store validates against existing + pending).
+	h := newTaskToolHarness(t, nil)
+	res := h.call(t, map[string]any{
+		"add": []any{
+			map[string]any{"type": "implement", "description": "first", "prompt": "p"},
+			map[string]any{"type": "verify", "description": "second", "prompt": "p", "depends_on": []any{1}},
+		},
+	})
+	if res.IsError {
+		t.Fatalf("same-batch dep must be allowed: %s", res.FullOutput)
+	}
+	view := h.store.View()
+	if len(view) != 2 || len(view[1].DependsOn) != 1 || view[1].DependsOn[0] != 1 {
+		t.Fatalf("same-batch dep not applied: %+v", view)
+	}
+}

--- a/agent/session_tools_task_test.go
+++ b/agent/session_tools_task_test.go
@@ -50,15 +50,24 @@ func newTaskToolHarness(t *testing.T, inputs []taskpkg.TaskInput) *taskToolHarne
 	return h
 }
 
-func (h *taskToolHarness) update(t *testing.T, updates ...map[string]any) tool.ExecResult {
+// call executes a task_list call with the given raw arguments (nil = bare
+// view call). It replaces the old action-shaped update helper: presence of
+// the add/update arrays is the whole dispatch.
+func (h *taskToolHarness) call(t *testing.T, args map[string]any) tool.ExecResult {
 	t.Helper()
-	args, err := json.Marshal(map[string]any{"action": "update", "updates": updates})
+	raw, err := json.Marshal(args)
 	if err != nil {
-		t.Fatalf("marshal update: %v", err)
+		t.Fatalf("marshal task_list args: %v", err)
 	}
 	return h.reg.ExecuteCall(context.Background(), nil, llm.ToolCallData{
-		ID: "task-update", Name: "task_list", Arguments: args,
+		ID: "task-call", Name: "task_list", Arguments: raw,
 	})
+}
+
+// update is a convenience for update-only calls.
+func (h *taskToolHarness) update(t *testing.T, updates ...map[string]any) tool.ExecResult {
+	t.Helper()
+	return h.call(t, map[string]any{"update": updates})
 }
 
 func decodeTaskToolState(t *testing.T, result tool.ExecResult) []taskToolStateEntry {
@@ -243,5 +252,146 @@ func TestTaskTool_UpdateCompletionUsesLegacySteerFallback(t *testing.T) {
 	payload := parseTaskCompletionLLMPayload(t, llm.User(h.steers[0]))
 	if payload.CompletionState != "ready_for_final_output" || len(payload.BlockingDelegateIDs) != 0 {
 		t.Fatalf("legacy completion payload = %+v, want ready with no blocking delegates", payload)
+	}
+}
+
+// TestTaskTool_CombinedAddUpdate: both arrays in one call apply atomically
+// with one publication revision and one EventTaskUpdated.
+func TestTaskTool_CombinedAddUpdate(t *testing.T) {
+	h := newTaskToolHarness(t, nil)
+	res := h.call(t, map[string]any{
+		"add": []any{map[string]any{
+			"type": "implement", "description": "first", "prompt": "do one",
+		}},
+		"update": []any{map[string]any{
+			"id": 1, "status": "in_progress",
+		}},
+	})
+	if res.IsError {
+		t.Fatalf("combined call: %s", res.FullOutput)
+	}
+	if !strings.Contains(res.FullOutput, "Added 1 task(s); updated 1→in_progress") {
+		t.Fatalf("output should combine add+update ack: %q", res.FullOutput)
+	}
+	view := h.store.View()
+	if len(view) != 1 || view[0].Status != taskpkg.TaskInProgress {
+		t.Fatalf("combined call should add and start: %+v", view)
+	}
+}
+
+// TestTaskTool_UpdateReferencesThisCallAddsRejected: the model cannot know
+// IDs this call's add would assign, so updates must validate against the
+// pre-add store state, and a failed combined call must apply nothing.
+func TestTaskTool_UpdateReferencesThisCallAddsRejected(t *testing.T) {
+	h := newTaskToolHarness(t, nil)
+	res := h.call(t, map[string]any{
+		"add": []any{map[string]any{
+			"type": "implement", "description": "first", "prompt": "do one",
+		}},
+		"update": []any{map[string]any{
+			"id": 5, "status": "in_progress",
+		}},
+	})
+	if !res.IsError {
+		t.Fatal("update targeting an ID this call's add would create must be rejected")
+	}
+	if !strings.Contains(res.FullOutput, "unknown task ID 5") {
+		t.Fatalf("error should name the unknown ID: %s", res.FullOutput)
+	}
+	if len(h.store.View()) != 0 {
+		t.Fatal("failed combined call must not apply its adds either (atomicity)")
+	}
+}
+
+// TestTaskTool_EmptyArraysAreNoOps: strict-mode models force-send both
+// arrays; empty ones must be no-ops. With no mutation, the response is
+// the view output (the list), same as a bare call.
+func TestTaskTool_EmptyArraysAreNoOps(t *testing.T) {
+	h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "d", Prompt: "p"}})
+	res := h.call(t, map[string]any{"add": []any{}, "update": []any{}})
+	if res.IsError {
+		t.Fatalf("empty arrays must be no-ops: %s", res.FullOutput)
+	}
+	if !strings.Contains(res.FullOutput, "1. [open]") {
+		t.Fatalf("response must still return the list: %q", res.FullOutput)
+	}
+}
+
+// TestTaskTool_ViewIsBareCall: no arrays = view, returns the list.
+func TestTaskTool_ViewIsBareCall(t *testing.T) {
+	h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "d", Prompt: "p"}})
+	res := h.call(t, map[string]any{})
+	if res.IsError {
+		t.Fatalf("bare call must be a view: %s", res.FullOutput)
+	}
+	if !strings.Contains(res.FullOutput, "1. [open]") {
+		t.Fatalf("bare call must return the list: %q", res.FullOutput)
+	}
+}
+
+// TestTaskTool_OldActionShapeRejectedHelpfully: back-compat — old
+// action-shaped calls fail at validation.
+func TestTaskTool_OldActionShapeRejectedHelpfully(t *testing.T) {
+	h := newTaskToolHarness(t, nil)
+	res := h.call(t, map[string]any{"action": "view"})
+	if !res.IsError {
+		t.Fatal("old action-shaped call must be rejected")
+	}
+}
+
+// TestTaskTool_NoOpUpdateEntryRejected: an update entry that changes
+// nothing is a model mistake, not a no-op.
+func TestTaskTool_NoOpUpdateEntryRejected(t *testing.T) {
+	h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "d", Prompt: "p"}})
+	res := h.call(t, map[string]any{
+		"update": []any{map[string]any{"id": 1}},
+	})
+	if !res.IsError {
+		t.Fatal("empty update entry must be rejected")
+	}
+	if !strings.Contains(res.FullOutput, "changes nothing") {
+		t.Fatalf("error should say the entry changes nothing: %s", res.FullOutput)
+	}
+}
+
+// TestTaskTool_AutoAdvanceCanPickSameCallAdd: completing a task in a call
+// that also adds an eligible replacement auto-starts the new task in the
+// same publication — "when you mark a task done, the next eligible task
+// auto-starts" applies to same-call adds too.
+func TestTaskTool_AutoAdvanceCanPickSameCallAdd(t *testing.T) {
+	h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "first", Prompt: "p1"}})
+	if err := h.store.Update([]taskpkg.TaskUpdate{{ID: 1, Status: taskpkg.TaskInProgress}}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	res := h.call(t, map[string]any{
+		"update": []any{map[string]any{"id": 1, "status": "done"}},
+		"add":    []any{map[string]any{"type": "implement", "description": "second", "prompt": "p2"}},
+	})
+	if res.IsError {
+		t.Fatalf("combined completion+add: %s", res.FullOutput)
+	}
+	view := h.store.View()
+	if len(view) != 2 || view[1].Status != taskpkg.TaskInProgress {
+		t.Fatalf("auto-advance should start the same-call add: %+v", view)
+	}
+	if len(h.steers) == 0 {
+		t.Fatal("auto-advance steering should fire for the new task")
+	}
+}
+
+// TestTaskTool_NotesOnlyUpdateWorks: the end-to-end bug fix from the review.
+func TestTaskTool_NotesOnlyUpdateWorks(t *testing.T) {
+	h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "d", Prompt: "p"}})
+	if err := h.store.Update([]taskpkg.TaskUpdate{{ID: 1, Status: taskpkg.TaskInProgress}}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	res := h.call(t, map[string]any{
+		"update": []any{map[string]any{"id": 1, "notes": "found the root cause"}},
+	})
+	if res.IsError {
+		t.Fatalf("notes-only update must succeed (was: invalid status \"<nil>\"): %s", res.FullOutput)
+	}
+	if !strings.Contains(res.FullOutput, "Updated 1.") {
+		t.Fatalf("ack: %q", res.FullOutput)
 	}
 }

--- a/agent/session_tools_task_test.go
+++ b/agent/session_tools_task_test.go
@@ -256,9 +256,11 @@ func TestTaskTool_UpdateCompletionUsesLegacySteerFallback(t *testing.T) {
 }
 
 // TestTaskTool_CombinedAddUpdate: both arrays in one call apply atomically
-// with one publication revision and one EventTaskUpdated.
+// with one publication revision and one EventTaskUpdated. The update must
+// target a PRE-EXISTING task — updates validate against the pre-add state
+// (the model cannot know IDs this call's add would assign).
 func TestTaskTool_CombinedAddUpdate(t *testing.T) {
-	h := newTaskToolHarness(t, nil)
+	h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "existing", Prompt: "p0"}})
 	res := h.call(t, map[string]any{
 		"add": []any{map[string]any{
 			"type": "implement", "description": "first", "prompt": "do one",
@@ -274,8 +276,8 @@ func TestTaskTool_CombinedAddUpdate(t *testing.T) {
 		t.Fatalf("output should combine add+update ack: %q", res.FullOutput)
 	}
 	view := h.store.View()
-	if len(view) != 1 || view[0].Status != taskpkg.TaskInProgress {
-		t.Fatalf("combined call should add and start: %+v", view)
+	if len(view) != 2 || view[0].Status != taskpkg.TaskInProgress || view[1].Status != taskpkg.TaskOpen {
+		t.Fatalf("combined call should update existing and add new: %+v", view)
 	}
 }
 
@@ -330,7 +332,8 @@ func TestTaskTool_ViewIsBareCall(t *testing.T) {
 }
 
 // TestTaskTool_OldActionShapeRejectedHelpfully: back-compat — old
-// action-shaped calls fail at validation.
+// action-shaped calls fail at validation. The call below deliberately
+// sends the retired action key; do not "migrate" it.
 func TestTaskTool_OldActionShapeRejectedHelpfully(t *testing.T) {
 	h := newTaskToolHarness(t, nil)
 	res := h.call(t, map[string]any{"action": "view"})

--- a/agent/session_tools_task_test.go
+++ b/agent/session_tools_task_test.go
@@ -398,3 +398,28 @@ func TestTaskTool_NotesOnlyUpdateWorks(t *testing.T) {
 		t.Fatalf("ack: %q", res.FullOutput)
 	}
 }
+
+// TestTaskTool_UpdateDependsOnSameCallAddRejected: an update's depends_on
+// may not reference an ID this call's add would assign — the model cannot
+// know it, and allowing it invites ID-guessing (the same reason update
+// targets validate against the pre-add state).
+func TestTaskTool_UpdateDependsOnSameCallAddRejected(t *testing.T) {
+	h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "existing", Prompt: "p"}})
+	res := h.call(t, map[string]any{
+		"add": []any{map[string]any{
+			"type": "implement", "description": "new", "prompt": "p",
+		}},
+		"update": []any{map[string]any{
+			"id": 1, "depends_on": []any{2},
+		}},
+	})
+	if !res.IsError {
+		t.Fatalf("update depending on same-call add must be rejected, got: %s", res.FullOutput)
+	}
+	if !strings.Contains(res.FullOutput, "depends on unknown task 2") {
+		t.Fatalf("error should name the unknown dep: %s", res.FullOutput)
+	}
+	if len(h.store.View()) != 1 {
+		t.Fatal("rejected combined call must apply nothing (atomicity)")
+	}
+}

--- a/agent/steering_tool_gate_test.go
+++ b/agent/steering_tool_gate_test.go
@@ -262,7 +262,7 @@ func TestTasksDoneReminderUsesTheRenamedResultToolAtTheCallSite(t *testing.T) {
 	env := s.currentEnv()
 
 	appendArgs, _ := json.Marshal(map[string]any{
-		"add":  []map[string]any{{"type": "implement", "description": "only task", "prompt": "p"}},
+		"add": []map[string]any{{"type": "implement", "description": "only task", "prompt": "p"}},
 	})
 	if res := s.reg.ExecuteCall(ctx, env, llm.ToolCallData{ID: "t1", Name: "task_list", Arguments: appendArgs}); res.IsError {
 		t.Fatalf("append: %s", res.Output)

--- a/agent/steering_tool_gate_test.go
+++ b/agent/steering_tool_gate_test.go
@@ -262,15 +262,13 @@ func TestTasksDoneReminderUsesTheRenamedResultToolAtTheCallSite(t *testing.T) {
 	env := s.currentEnv()
 
 	appendArgs, _ := json.Marshal(map[string]any{
-		"action": "append",
-		"tasks":  []map[string]any{{"type": "implement", "description": "only task", "prompt": "p"}},
+		"add":  []map[string]any{{"type": "implement", "description": "only task", "prompt": "p"}},
 	})
 	if res := s.reg.ExecuteCall(ctx, env, llm.ToolCallData{ID: "t1", Name: "task_list", Arguments: appendArgs}); res.IsError {
 		t.Fatalf("append: %s", res.Output)
 	}
 	done, _ := json.Marshal(map[string]any{
-		"action":  "update",
-		"updates": []map[string]any{{"id": 1, "status": "done"}},
+		"update": []map[string]any{{"id": 1, "status": "done"}},
 	})
 	if res := s.reg.ExecuteCall(ctx, env, llm.ToolCallData{ID: "t2", Name: "task_list", Arguments: done}); res.IsError {
 		t.Fatalf("update: %s", res.Output)

--- a/agent/task/task_store.go
+++ b/agent/task/task_store.go
@@ -590,9 +590,8 @@ func (s *TaskStore) UpdateWithSnapshot(updates []TaskUpdate) (TaskUpdateSnapshot
 }
 
 func (s *TaskStore) updateLocked(updates []TaskUpdate) error {
-	// Validate status values up front so a bad status doesn't half-apply.
-	// An empty status means "no change": the tool schema documents status
-	// as optional, so notes/deps/effort-only updates are legal.
+	// Validate status values up front so a bad status doesn't half-apply;
+	// empty status means "no change" (see TaskUpdate).
 	for _, u := range updates {
 		if u.Status == "" {
 			continue

--- a/agent/task/task_store.go
+++ b/agent/task/task_store.go
@@ -93,7 +93,10 @@ type TaskInput struct {
 	Insert          string   `json:"insert,omitempty"`           // template-expansion marker (see Task.Insert)
 }
 
-// TaskUpdate is a status change for an existing task.
+// TaskUpdate is a change for an existing task.
+// Status empty means no status change; a non-empty value must be one of the
+// four statuses. The tool schema has always documented status as optional,
+// so notes/deps/effort-only updates are legal.
 // DependsOn nil means no change; &[]int{} clears the dependency list.
 // ReasoningEffort empty means no change; a non-empty value replaces it.
 type TaskUpdate struct {
@@ -588,7 +591,12 @@ func (s *TaskStore) UpdateWithSnapshot(updates []TaskUpdate) (TaskUpdateSnapshot
 
 func (s *TaskStore) updateLocked(updates []TaskUpdate) error {
 	// Validate status values up front so a bad status doesn't half-apply.
+	// An empty status means "no change": the tool schema documents status
+	// as optional, so notes/deps/effort-only updates are legal.
 	for _, u := range updates {
+		if u.Status == "" {
+			continue
+		}
 		switch u.Status {
 		case TaskOpen, TaskInProgress, TaskDone, TaskCancelled:
 			// valid
@@ -607,7 +615,9 @@ func (s *TaskStore) updateLocked(updates []TaskUpdate) error {
 		if _, exists := projected[u.ID]; !exists {
 			return fmt.Errorf("unknown task ID %d", u.ID)
 		}
-		projected[u.ID] = u.Status
+		if u.Status != "" {
+			projected[u.ID] = u.Status
+		}
 	}
 	inProgressCount := 0
 	for _, status := range projected {
@@ -675,7 +685,9 @@ func (s *TaskStore) updateLocked(updates []TaskUpdate) error {
 		found := false
 		for i := range s.tasks {
 			if s.tasks[i].ID == u.ID {
-				s.tasks[i].Status = u.Status
+				if u.Status != "" {
+					s.tasks[i].Status = u.Status
+				}
 				if u.Notes != "" {
 					s.tasks[i].Notes = append(s.tasks[i].Notes, u.Notes)
 				}
@@ -691,7 +703,7 @@ func (s *TaskStore) updateLocked(updates []TaskUpdate) error {
 				s.tasks[i].UpdatedAt = ts
 				if u.Status == TaskDone {
 					s.tasks[i].CompletedAt = ts
-				} else {
+				} else if u.Status != "" {
 					s.tasks[i].CompletedAt = nil
 				}
 				found = true

--- a/agent/task/task_store_test.go
+++ b/agent/task/task_store_test.go
@@ -537,3 +537,59 @@ func TestView_ReturnsCopy(t *testing.T) {
 		t.Error("View did not return a copy; mutation leaked into the store")
 	}
 }
+
+// TestTaskUpdate_EmptyStatusMeansNoChange pins the combined-tool contract:
+// an update entry with an empty status leaves the task's status unchanged
+// while still applying notes, deps, and effort — the tool schema has always
+// documented status as optional, so the store must honor that.
+func TestTaskUpdate_EmptyStatusMeansNoChange(t *testing.T) {
+	s := newTestStore(t)
+	added, err := s.Append([]TaskInput{{Description: "d", Prompt: "p"}})
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if err := s.Update([]TaskUpdate{{ID: added[0].ID, Notes: "note one"}}); err != nil {
+		t.Fatalf("notes-only update: %v", err)
+	}
+	got := s.View()
+	if got[0].Status != TaskOpen {
+		t.Fatalf("status changed by notes-only update: %v", got[0].Status)
+	}
+	if len(got[0].Notes) != 1 || got[0].Notes[0] != "note one" {
+		t.Fatalf("notes not applied: %v", got[0].Notes)
+	}
+
+	if err := s.Update([]TaskUpdate{{ID: added[0].ID, Status: TaskInProgress}}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if err := s.Update([]TaskUpdate{{ID: added[0].ID, Notes: "note two"}}); err != nil {
+		t.Fatalf("notes-only during progress: %v", err)
+	}
+	got = s.View()
+	if got[0].Status != TaskInProgress {
+		t.Fatalf("notes-only update clobbered in_progress: %v", got[0].Status)
+	}
+	if len(got[0].Notes) != 2 {
+		t.Fatalf("second note not appended: %v", got[0].Notes)
+	}
+}
+
+// TestTaskUpdate_EmptyStatusStillValidates pins that empty status does not
+// weaken the other validations: unknown IDs, unknown deps, and invalid
+// non-empty statuses still fail.
+func TestTaskUpdate_EmptyStatusStillValidates(t *testing.T) {
+	s := newTestStore(t)
+	added, err := s.Append([]TaskInput{{Description: "d", Prompt: "p"}})
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if err := s.Update([]TaskUpdate{{ID: 999, Notes: "x"}}); err == nil {
+		t.Fatal("unknown ID with empty status must still be rejected")
+	}
+	if err := s.Update([]TaskUpdate{{ID: added[0].ID, DependsOn: &[]int{999}}}); err == nil {
+		t.Fatal("unknown dep must still be rejected")
+	}
+	if err := s.Update([]TaskUpdate{{ID: added[0].ID, Status: "bogus"}}); err == nil {
+		t.Fatal("bogus status must still be rejected")
+	}
+}

--- a/agent/task_store_test.go
+++ b/agent/task_store_test.go
@@ -546,7 +546,7 @@ func TestTaskListSchema_ReasoningEffortEnumPerProvider(t *testing.T) {
 			}
 			props := td.Parameters["properties"].(map[string]any)
 
-			tasks := props["tasks"].(map[string]any)
+			tasks := props["add"].(map[string]any)
 			taskItems := tasks["items"].(map[string]any)
 			taskProps := taskItems["properties"].(map[string]any)
 			appendEffort := taskProps["reasoning_effort"].(map[string]any)
@@ -565,7 +565,7 @@ func TestTaskListSchema_ReasoningEffortEnumPerProvider(t *testing.T) {
 				t.Fatalf("append task type enum: got %v", gotTypes)
 			}
 
-			updates := props["updates"].(map[string]any)
+			updates := props["update"].(map[string]any)
 			items := updates["items"].(map[string]any)
 			updProps := items["properties"].(map[string]any)
 			effort := updProps["reasoning_effort"].(map[string]any)
@@ -790,8 +790,7 @@ func TestTaskListTool_UpdateWithNotes(t *testing.T) {
 		ID:   "c1",
 		Name: "task_list",
 		Arguments: json.RawMessage(`{
-			"action": "append",
-			"tasks": [{"type": "research", "description": "Build project", "prompt": "Run make"}]
+			"add": [{"type": "research", "description": "Build project", "prompt": "Run make"}]
 		}`),
 	})
 
@@ -799,7 +798,7 @@ func TestTaskListTool_UpdateWithNotes(t *testing.T) {
 	updateRes := sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
 		ID:        "c2",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action": "update", "updates": [{"id": 1, "status": "in_progress", "notes": "make failed with missing libfoo"}]}`),
+		Arguments: json.RawMessage(`{"update":[{"id": 1, "status": "in_progress", "notes": "make failed with missing libfoo"}]}`),
 	})
 	if updateRes.IsError {
 		t.Fatalf("update with notes error: %s", updateRes.Output)
@@ -809,7 +808,7 @@ func TestTaskListTool_UpdateWithNotes(t *testing.T) {
 	viewRes := sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
 		ID:        "c3",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action": "view"}`),
+		Arguments: json.RawMessage(`{}`),
 	})
 	if !strings.Contains(viewRes.Output, "make failed with missing libfoo") {
 		t.Fatalf("view should contain notes: %s", viewRes.Output)
@@ -835,8 +834,7 @@ func TestTaskListTool_UpdateReasoningEffort(t *testing.T) {
 		ID:   "c1",
 		Name: "task_list",
 		Arguments: json.RawMessage(`{
-			"action": "append",
-			"tasks": [{"type": "implement", "description": "Do the work", "prompt": "Build it"}]
+			"add": [{"type": "implement", "description": "Do the work", "prompt": "Build it"}]
 		}`),
 	})
 
@@ -844,7 +842,7 @@ func TestTaskListTool_UpdateReasoningEffort(t *testing.T) {
 	updateRes := sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
 		ID:        "c2",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action": "update", "updates": [{"id": 1, "status": "in_progress", "reasoning_effort": "high"}]}`),
+		Arguments: json.RawMessage(`{"update":[{"id": 1, "status": "in_progress", "reasoning_effort": "high"}]}`),
 	})
 	if updateRes.IsError {
 		t.Fatalf("update with reasoning_effort error: %s", updateRes.Output)
@@ -853,7 +851,7 @@ func TestTaskListTool_UpdateReasoningEffort(t *testing.T) {
 	viewRes := sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
 		ID:        "c3",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action": "view"}`),
+		Arguments: json.RawMessage(`{}`),
 	})
 	if !strings.Contains(viewRes.Output, "high") {
 		t.Fatalf("view should report reasoning_effort high: %s", viewRes.Output)
@@ -863,7 +861,7 @@ func TestTaskListTool_UpdateReasoningEffort(t *testing.T) {
 	xhigh := sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
 		ID:        "c4",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action": "update", "updates": [{"id": 1, "status": "in_progress", "reasoning_effort": "xhigh"}]}`),
+		Arguments: json.RawMessage(`{"update":[{"id": 1, "status": "in_progress", "reasoning_effort": "xhigh"}]}`),
 	})
 	if xhigh.IsError {
 		t.Fatalf("xhigh should be accepted by OpenAI profile: %s", xhigh.Output)
@@ -886,8 +884,7 @@ func TestTaskListTool_AppendPreservesReasoningEffortAndType(t *testing.T) {
 		ID:   "c1",
 		Name: "task_list",
 		Arguments: json.RawMessage(`{
-			"action": "append",
-			"tasks": [{"type": "fix", "description": "Repair flaky test", "prompt": "Stabilize the test after the regression", "reasoning_effort": "xhigh"}]
+			"add": [{"type": "fix", "description": "Repair flaky test", "prompt": "Stabilize the test after the regression", "reasoning_effort": "xhigh"}]
 		}`),
 	})
 	if appendRes.IsError {
@@ -926,8 +923,7 @@ func TestTaskListTool_AppendViewUpdate(t *testing.T) {
 		ID:   "c1",
 		Name: "task_list",
 		Arguments: json.RawMessage(`{
-			"action": "append",
-			"tasks": [
+			"add": [
 				{"type": "research", "description": "Read auth code", "prompt": "Read the auth module"},
 				{"type": "research", "description": "Write tests", "prompt": "Write tests for auth"}
 			]
@@ -949,7 +945,7 @@ func TestTaskListTool_AppendViewUpdate(t *testing.T) {
 	viewRes := sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
 		ID:        "c2",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action": "view"}`),
+		Arguments: json.RawMessage(`{}`),
 	})
 	if viewRes.IsError {
 		t.Fatalf("view error: %s", viewRes.Output)
@@ -962,7 +958,7 @@ func TestTaskListTool_AppendViewUpdate(t *testing.T) {
 	updateRes := sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
 		ID:        "c3",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action": "update", "updates": [{"id": 1, "status": "done"}]}`),
+		Arguments: json.RawMessage(`{"update":[{"id": 1, "status": "done"}]}`),
 	})
 	if updateRes.IsError {
 		t.Fatalf("update error: %s", updateRes.Output)
@@ -972,7 +968,7 @@ func TestTaskListTool_AppendViewUpdate(t *testing.T) {
 	viewRes2 := sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
 		ID:        "c4",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action": "view"}`),
+		Arguments: json.RawMessage(`{}`),
 	})
 	if !strings.Contains(viewRes2.Output, "[done]") {
 		t.Fatalf("view after update missing done status: %s", viewRes2.Output)
@@ -1401,8 +1397,7 @@ func TestTaskListTool_AppendWithDependsOn(t *testing.T) {
 		ID:   "c1",
 		Name: "task_list",
 		Arguments: json.RawMessage(`{
-			"action": "append",
-			"tasks": [
+			"add": [
 				{"type": "research", "description": "Task A", "prompt": "Do A"},
 				{"type": "research", "description": "Task B", "prompt": "Do B", "depends_on": [1]}
 			]
@@ -1416,7 +1411,7 @@ func TestTaskListTool_AppendWithDependsOn(t *testing.T) {
 	viewRes := sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
 		ID:        "c2",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action": "view"}`),
+		Arguments: json.RawMessage(`{}`),
 	})
 	if viewRes.IsError {
 		t.Fatalf("view error: %s", viewRes.Output)
@@ -1460,8 +1455,7 @@ func TestTaskListTool_UpdateAutoAdvanceFiresSteeringNotOutput(t *testing.T) {
 		ID:   "c1",
 		Name: "task_list",
 		Arguments: json.RawMessage(`{
-			"action": "append",
-			"tasks": [
+			"add": [
 				{"type": "research", "description": "Task A", "prompt": "Do A"},
 				{"type": "research", "description": "Task B", "prompt": "Do B", "depends_on": [1]}
 			]
@@ -1477,7 +1471,7 @@ func TestTaskListTool_UpdateAutoAdvanceFiresSteeringNotOutput(t *testing.T) {
 	updateRes := sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
 		ID:        "c2",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action": "update", "updates": [{"id": 1, "status": "done"}]}`),
+		Arguments: json.RawMessage(`{"update":[{"id": 1, "status": "done"}]}`),
 	})
 	if updateRes.IsError {
 		t.Fatalf("update error: %s", updateRes.Output)
@@ -1537,8 +1531,7 @@ func TestTaskListTool_ManualInProgressFiresSteering(t *testing.T) {
 		ID:   "c1",
 		Name: "task_list",
 		Arguments: json.RawMessage(`{
-			"action": "append",
-			"tasks": [
+			"add": [
 				{"type": "research", "description": "Task A", "prompt": "Do A"},
 				{"type": "research", "description": "Task B", "prompt": "Do B"}
 			]
@@ -1553,7 +1546,7 @@ func TestTaskListTool_ManualInProgressFiresSteering(t *testing.T) {
 	updateRes := sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
 		ID:        "c2",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action": "update", "updates": [{"id": 2, "status": "in_progress"}]}`),
+		Arguments: json.RawMessage(`{"update":[{"id": 2, "status": "in_progress"}]}`),
 	})
 	if updateRes.IsError {
 		t.Fatalf("update error: %s", updateRes.Output)
@@ -1601,8 +1594,7 @@ func TestTaskListTool_UpdateRejectsMultipleInProgress(t *testing.T) {
 		ID:   "c1",
 		Name: "task_list",
 		Arguments: json.RawMessage(`{
-			"action": "append",
-			"tasks": [
+			"add": [
 				{"type": "research", "description": "Task A", "prompt": "Do A"},
 				{"type": "research", "description": "Task B", "prompt": "Do B"}
 			]
@@ -1612,7 +1604,7 @@ func TestTaskListTool_UpdateRejectsMultipleInProgress(t *testing.T) {
 	updateRes := sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
 		ID:        "c2",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action": "update", "updates": [{"id": 1, "status": "in_progress"}, {"id": 2, "status": "in_progress"}]}`),
+		Arguments: json.RawMessage(`{"update":[{"id": 1, "status": "in_progress"}, {"id": 2, "status": "in_progress"}]}`),
 	})
 	if !updateRes.IsError {
 		t.Fatalf("expected tool error for two in_progress in one update; got output: %s", updateRes.Output)
@@ -1642,8 +1634,7 @@ func TestTaskListTool_UpdateShowsAllComplete(t *testing.T) {
 		ID:   "c1",
 		Name: "task_list",
 		Arguments: json.RawMessage(`{
-			"action": "append",
-			"tasks": [{"type": "research", "description": "Only task", "prompt": "Do it"}]
+			"add": [{"type": "research", "description": "Only task", "prompt": "Do it"}]
 		}`),
 	})
 
@@ -1651,7 +1642,7 @@ func TestTaskListTool_UpdateShowsAllComplete(t *testing.T) {
 	updateRes := sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
 		ID:        "c2",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action": "update", "updates": [{"id": 1, "status": "done"}]}`),
+		Arguments: json.RawMessage(`{"update":[{"id": 1, "status": "done"}]}`),
 	})
 	if updateRes.IsError {
 		t.Fatalf("update error: %s", updateRes.Output)
@@ -1680,14 +1671,13 @@ func TestTaskListTool_UpdateNamesBlockingDelegateDependency(t *testing.T) {
 		ID:   "task-append",
 		Name: "task_list",
 		Arguments: json.RawMessage(`{
-			"action": "append",
-			"tasks": [{"type": "research", "description": "Finish the answer", "prompt": "Finish it"}]
+			"add": [{"type": "research", "description": "Finish the answer", "prompt": "Finish it"}]
 		}`),
 	})
 	updateRes := root.reg.ExecuteCall(ctx, root.env, llm.ToolCallData{
 		ID:        "task-done",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action": "update", "updates": [{"id": 1, "status": "done"}]}`),
+		Arguments: json.RawMessage(`{"update":[{"id": 1, "status": "done"}]}`),
 	})
 	if updateRes.IsError {
 		t.Fatalf("update error: %s", updateRes.Output)
@@ -1726,14 +1716,13 @@ func TestTaskListTool_UpdateLeavesBackgroundDelegateOutOfDependencyReminder(t *t
 		ID:   "task-append",
 		Name: "task_list",
 		Arguments: json.RawMessage(`{
-			"action": "append",
-			"tasks": [{"type": "research", "description": "Finish the answer", "prompt": "Finish it"}]
+			"add": [{"type": "research", "description": "Finish the answer", "prompt": "Finish it"}]
 		}`),
 	})
 	updateRes := root.reg.ExecuteCall(ctx, root.env, llm.ToolCallData{
 		ID:        "task-done",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action": "update", "updates": [{"id": 1, "status": "done"}]}`),
+		Arguments: json.RawMessage(`{"update":[{"id": 1, "status": "done"}]}`),
 	})
 	if updateRes.IsError {
 		t.Fatalf("update error: %s", updateRes.Output)
@@ -1802,14 +1791,13 @@ func TestTaskListTool_UpdateIgnoresTerminalDelegates(t *testing.T) {
 				ID:   "task-append",
 				Name: "task_list",
 				Arguments: json.RawMessage(`{
-					"action": "append",
-					"tasks": [{"type": "research", "description": "Finish the answer", "prompt": "Finish it"}]
+					"add": [{"type": "research", "description": "Finish the answer", "prompt": "Finish it"}]
 				}`),
 			})
 			updateRes := root.reg.ExecuteCall(ctx, root.env, llm.ToolCallData{
 				ID:        "task-done",
 				Name:      "task_list",
-				Arguments: json.RawMessage(`{"action": "update", "updates": [{"id": 1, "status": "done"}]}`),
+				Arguments: json.RawMessage(`{"update":[{"id": 1, "status": "done"}]}`),
 			})
 			if updateRes.IsError {
 				t.Fatalf("update error: %s", updateRes.Output)
@@ -1907,8 +1895,7 @@ func TestTaskListTool_UpdateStaysMinimalWhenBlocked(t *testing.T) {
 		ID:   "c1",
 		Name: "task_list",
 		Arguments: json.RawMessage(`{
-			"action": "append",
-			"tasks": [
+			"add": [
 				{"type": "research", "description": "Task A", "prompt": "Do A"},
 				{"type": "research", "description": "Task B", "prompt": "Do B", "depends_on": [1]},
 				{"type": "research", "description": "Task C", "prompt": "Do C", "depends_on": [2]}
@@ -1920,13 +1907,13 @@ func TestTaskListTool_UpdateStaysMinimalWhenBlocked(t *testing.T) {
 	sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
 		ID:        "c2",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action": "update", "updates": [{"id": 1, "status": "in_progress"}]}`),
+		Arguments: json.RawMessage(`{"update":[{"id": 1, "status": "in_progress"}]}`),
 	})
 
 	updateRes := sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
 		ID:        "c3",
 		Name:      "task_list",
-		Arguments: json.RawMessage(`{"action": "update", "updates": [{"id": 3, "status": "cancelled"}]}`),
+		Arguments: json.RawMessage(`{"update":[{"id": 3, "status": "cancelled"}]}`),
 	})
 	if updateRes.IsError {
 		t.Fatalf("update error: %s", updateRes.Output)
@@ -2086,8 +2073,7 @@ func TestTaskListTool_AppendResponseIsMinimal(t *testing.T) {
 		ID:   "c1",
 		Name: "task_list",
 		Arguments: json.RawMessage(`{
-			"action": "append",
-			"tasks": [
+			"add": [
 				{"type": "research", "description": "Task A", "prompt": "Do A"},
 				{"type": "research", "description": "Task B", "prompt": "Do B", "depends_on": [1]}
 			]

--- a/cmd/evener-tui/internal/toolsummary/tool_summary.go
+++ b/cmd/evener-tui/internal/toolsummary/tool_summary.go
@@ -142,18 +142,21 @@ func SummarizeToolInDir(toolName, argsJSON, cwd string) (desc, detail string) {
 		return desc, detail
 
 	case "task_list":
-		action := str("action")
-		switch action {
-		case "append":
-			tasks, _ := args["tasks"].([]any)
-			desc = fmt.Sprintf("append %d tasks", len(tasks))
-			detail = renderTaskAppend(tasks)
-		case "update":
-			updates, _ := args["updates"].([]any)
+		// Presence-based dispatch: add and/or update arrays, either or both.
+		adds, _ := args["add"].([]any)
+		updates, _ := args["update"].([]any)
+		switch {
+		case len(adds) > 0 && len(updates) > 0:
+			desc = fmt.Sprintf("add %d, update %d tasks", len(adds), len(updates))
+			detail = renderTaskAppend(adds) + renderTaskUpdate(updates)
+		case len(adds) > 0:
+			desc = fmt.Sprintf("add %d tasks", len(adds))
+			detail = renderTaskAppend(adds)
+		case len(updates) > 0:
 			desc = fmt.Sprintf("update %d tasks", len(updates))
 			detail = renderTaskUpdate(updates)
 		default:
-			desc = action
+			desc = "view tasks"
 		}
 		return desc, detail
 

--- a/cmd/evener-tui/internal/toolsummary/tool_summary.go
+++ b/cmd/evener-tui/internal/toolsummary/tool_summary.go
@@ -145,18 +145,17 @@ func SummarizeToolInDir(toolName, argsJSON, cwd string) (desc, detail string) {
 		// Presence-based dispatch: add and/or update arrays, either or both.
 		adds, _ := args["add"].([]any)
 		updates, _ := args["update"].([]any)
+		detail = renderTaskAppend(adds) + renderTaskUpdate(updates)
 		switch {
 		case len(adds) > 0 && len(updates) > 0:
 			desc = fmt.Sprintf("add %d, update %d tasks", len(adds), len(updates))
-			detail = renderTaskAppend(adds) + renderTaskUpdate(updates)
 		case len(adds) > 0:
 			desc = fmt.Sprintf("add %d tasks", len(adds))
-			detail = renderTaskAppend(adds)
 		case len(updates) > 0:
 			desc = fmt.Sprintf("update %d tasks", len(updates))
-			detail = renderTaskUpdate(updates)
 		default:
 			desc = "view tasks"
+			detail = ""
 		}
 		return desc, detail
 

--- a/cmd/evener-tui/internal/toolsummary/tool_summary_test.go
+++ b/cmd/evener-tui/internal/toolsummary/tool_summary_test.go
@@ -113,8 +113,8 @@ func TestSummarizeTool_Grep(t *testing.T) {
 }
 
 func TestSummarizeTool_TaskList_View(t *testing.T) {
-	desc, detail := SummarizeTool("task_list", `{"action":"view"}`)
-	if desc != "view" {
+	desc, detail := SummarizeTool("task_list", `{}`)
+	if desc != "view tasks" {
 		t.Errorf("got %q", desc)
 	}
 	if detail != "" {
@@ -123,8 +123,8 @@ func TestSummarizeTool_TaskList_View(t *testing.T) {
 }
 
 func TestSummarizeTool_TaskList_Append(t *testing.T) {
-	desc, detail := SummarizeTool("task_list", `{"action":"append","tasks":[{"description":"do thing A","prompt":"do A fully"},{"description":"do thing B","prompt":"do B fully"}]}`)
-	if desc != "append 2 tasks" {
+	desc, detail := SummarizeTool("task_list", `{"add":[{"description":"do thing A","prompt":"do A fully"},{"description":"do thing B","prompt":"do B fully"}]}`)
+	if desc != "add 2 tasks" {
 		t.Errorf("desc: got %q", desc)
 	}
 	if !strings.Contains(detail, "do thing A") {
@@ -137,7 +137,7 @@ func TestSummarizeTool_TaskList_Append(t *testing.T) {
 
 func TestSummarizeTool_TaskList_Update(t *testing.T) {
 	// Status keys must be snake_case to match the statusIcon map.
-	desc, detail := SummarizeTool("task_list", `{"action":"update","updates":[{"id":1,"status":"done"},{"id":2,"status":"in_progress"}]}`)
+	desc, detail := SummarizeTool("task_list", `{"update":[{"id":1,"status":"done"},{"id":2,"status":"in_progress"}]}`)
 	if desc != "update 2 tasks" {
 		t.Errorf("desc: got %q", desc)
 	}
@@ -261,10 +261,10 @@ func TestSummarizeToolEmptyCwdNeverStrips(t *testing.T) {
 // Surfaced by FuzzSummarizeTool.
 func TestSummarizeTool_TaskUpdate_MissingID(t *testing.T) {
 	cases := []string{
-		`{"action":"update","updates":[{}]}`,
-		`{"action":"update","updates":[{"status":"completed"}]}`,
-		`{"action":"update","updates":[{"id":"not-a-number"}]}`,
-		`{"action":"update","updates":[{"id":3,"status":"completed"}]}`,
+		`{"update":[{}]}`,
+		`{"update":[{"status":"completed"}]}`,
+		`{"update":[{"id":"not-a-number"}]}`,
+		`{"update":[{"id":3,"status":"completed"}]}`,
 	}
 	for _, args := range cases {
 		// Must not panic; we only assert it returns.

--- a/docs/superpowers/plans/2026-08-31-task-tool-combined.md
+++ b/docs/superpowers/plans/2026-08-31-task-tool-combined.md
@@ -1,0 +1,639 @@
+# Combined Task Tool (presence-based dispatch) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace task_list's action-enum branching with presence-based dispatch — optional `add` and `update` arrays, no `action` parameter, every response returns the full task list — and fix the status-optional bug it exposed.
+
+**Architecture:** One tool, one `MutateAndPublish` closure per call. Update entries are validated against pre-existing IDs (before adds apply), adds apply, then updates. Empty status means "no change." The tool name `task_list`, the store, the events payloads, the steering machinery, and the repair branch heuristics all stay; only the wire schema and handler dispatch change.
+
+**Tech Stack:** Go (module `primeradiant.com/evener`), JSON Schema validation via the existing `tool.Registry` prevalidation, no new dependencies.
+
+**Spec:** This document is the spec (design + plan). Companion evidence: the review delivered in this session (issue #626 failure family, the `"<nil>"` status bug, strict-mode force-requiring).
+
+## Global Constraints
+
+- Gates: `make lint`, `make vet`, `make test` must pass. Default tests must be deterministic (no network, no credentials, no ambient state).
+- Keep the tool name `task_list` — it is load-bearing: registry output limits (`agent/internal/tool/registry.go:923`), subagent allowlists (`agent/subagents.go:258`), reminders (`agent/task_reminders.go`), profile effort-enum sync (`agent/provider/profile.go:542` — `setEffortLevels` regenerates `DefTaskList` by name), transcript conventions (`agent/transcript/transcript.go:65`), session round tracking (`agent/session.go:630-632`).
+- Preserve the events payload shapes: `events.EventTaskUpdated` (`TaskStateData`/`TaskUpdatedData`) and `tool.StateResult.State` (the taskToolState snapshot). The hub UI renders these.
+- Preserve all steering behavior: current-task steering on manual start, auto-advance steering when a completion leaves nothing in progress, all-done/delegates steering, reminders (nudge/inactivity/all-done).
+- Do not modify the repair machinery's generic branch heuristics in `agent/internal/tool/repair/explain.go` — `manage_worktree` still uses the pattern and old persisted calls still reference action-shaped schemas. Deleting it is a separate follow-up once the corpus ages out.
+- Set `Strict: false` explicitly on DefTaskList (six precedents in definitions.go). The OpenAI Responses adapter defaults strict=true when unset and force-requires every nested property — which would force `"status": ""` (enum violation) or `"depends_on": []` (silent dep clearing) on strict-mode models. With Strict:false, empty arrays are simply never-required no-op channels.
+- Old persisted action-shaped calls (e.g. `{"action":"view"}`) must fail with a helpful error, not crash.
+- reasoning_effort keeps the `"inherit"` sentinel semantics (`normalizeTaskEffort`).
+- Staged commits use explicit file paths only — never `git add -A` or `git add .`.
+
+## Design
+
+### New wire schema (DefTaskList)
+
+```jsonc
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "add": {
+      "type": "array",
+      "description": "Tasks to add. Omit or [] for none. Each: type, brief description (<10 words), detailed prompt, optional depends_on (IDs of existing tasks), optional reasoning_effort.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type":            { "type": "string", "enum": ["research","implement","verify","fix"], "description": "Task type. Use 'fix' for targeted remediation after a specific failure or review finding." },
+          "description":     { "type": "string" },
+          "prompt":          { "type": "string" },
+          "depends_on":      { "type": "array", "items": { "type": "integer" }, "description": "IDs of existing tasks (or earlier tasks in this same add array, which get sequential IDs) this one depends on. Optional." },
+          "reasoning_effort": reasoningSchema
+        },
+        "required": ["type", "description", "prompt"]
+      }
+    },
+    "update": {
+      "type": "array",
+      "description": "Changes to existing tasks. Omit or [] for none. Each: id plus optional status, notes, depends_on, or reasoning_effort.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id":              { "type": "integer" },
+          "status":          { "type": "string", "enum": ["open","in_progress","done","cancelled"] },
+          "notes":           { "type": "string", "description": "Document what you tried and why it failed or succeeded. Appended to the task's notes log." },
+          "depends_on":      { "type": "array", "items": { "type": "integer" }, "description": "Set dependencies. [] clears them. Omit to leave unchanged." },
+          "reasoning_effort": reasoningSchema
+        },
+        "required": ["id"]
+      }
+    }
+  }
+  // no top-level "required" — a bare {} is a valid view
+}
+```
+
+`reasoningSchema` construction is unchanged from today (string, description, effortLevels enum + "inherit" sentinel when levels are known). Top-level `required` is deliberately absent: a bare call (or empty arrays) is the view/search operation, answered by the always-returned list. `additionalProperties: false` at top level means an `action` key is rejected at schema validation with an error the repair layer can explain — that is the back-compat failure mode for old-shaped calls.
+
+### Tool description (new)
+
+```
+Manage your task list. A bare call (or empty add/update) returns the current list. Use add to append new tasks (type, brief description <10 words, detailed prompt, optional depends_on/reasoning_effort) and update to change existing tasks (id plus optional status, notes, depends_on, reasoning_effort) — both in the same call when useful. When you mark a task done, the next eligible task auto-starts and its prompt is injected. Use depends_on to express ordering and notes to record what happened. Only one task may be in_progress at a time; to start a new one, complete or defer the current one in the same update array.
+```
+
+### Handler semantics (agent/session_tools_task.go)
+
+Single `mutateAndPublishTaskStore` closure per call:
+
+1. **Decode** `add` and `update` arrays via Go type assertions into `[]taskpkg.TaskInput` / `[]taskpkg.TaskUpdate`, strictly — wrong types produce clear errors; no `fmt.Sprint` coercion. Missing arrays → nil slices. An `update` item that sets none of status/notes/depends_on/reasoning_effort → error: `update entry for task %d changes nothing; include status, notes, depends_on, or reasoning_effort`. An `add` item missing type/description/prompt fails schema validation (they're required in the item schema).
+2. **Validate update IDs against the pre-add store state** (inside the mutation closure, before `store.Append`): any `update` id not in the current store → `unknown task ID %d`, nothing applies. Rationale: the model composed the call before any new IDs existed, so updates can never legitimately target this call's adds. (The store's own `updateLocked` re-validates IDs after the adds apply; the pre-check gives the error before any mutation, keeping the whole call atomic on failure.)
+3. **Apply** inside the same closure: `store.Append(adds)` then `store.UpdateWithSnapshot(updates)`. If either errors, the publication is abandoned — one revision, one `EventTaskUpdated`. Add `depends_on` semantics are the store's existing ones, unchanged: an add's deps may reference existing tasks and same-batch adds (the store assigns sequential IDs and validates against existing+pending; the model sees the current list with IDs, so same-batch references remain possible exactly as they are today via `append`). Update `depends_on` may only reference pre-existing tasks (an update entry validated against the pre-add state cannot name this call's adds).
+4. **Response output contract** (preserves the existing token-economy decision — session_tools_task.go's "terse acknowledgement" comment): mutations return terse acks + `State`; a bare call (or the no-array view) returns `formatTaskList`. The list is NOT appended to mutation acks — the current-task is announced via steering, exactly as today, and `State` carries the snapshot for the hub UI. Search is free because a bare call is the view.
+   - Only adds: `Added N task(s). Progress: d/t tasks complete.` + `State: store.View()`
+   - Only updates: `Updated <formatTaskUpdates>. Progress: d/t tasks complete.` + `State: taskToolStateSnapshot(...)` — plus auto-advance/all-done text per current rules
+   - Both: `Added N task(s); updated <formatTaskUpdates>. Progress: d/t tasks complete.` + snapshot State
+   - Neither (bare view): `formatTaskList(store.View())` + `State: store.View()` — same as today's view action.
+
+### Classification from final state (not raw entries)
+
+Because empty status now means "no change," the handler's classification (`completedAny`, `inProgressUpdates`, `started`, `manuallyStartedID`) must derive statuses from the snapshot (`mutation.After` / final view), not from the raw update entries. An update entry with empty status whose task ends in_progress counts for `inProgressUpdates` bookkeeping; `started[id]` is true only when the pre-state wasn't in_progress (the existing `Started *bool` frontend contract).
+
+### Status-optional fix (agent/task/task_store.go)
+
+`TaskUpdate.Status` semantics change: empty string = leave status unchanged; non-empty must be one of the four statuses. In `updateLocked`:
+
+- Status validation skips empty statuses (non-empty invalid values still error with today's message).
+- The single-in_progress projection carries the task's current status forward for empty-status entries (only `u.Status != ""` overwrites `projected[u.ID]`).
+- The apply loop assigns status only when non-empty.
+- Everything else (unknown-ID rejection, dependency validation against the projected graph, cycle detection, single-in_progress blocker messaging, timestamps) is unchanged.
+
+### Strict mode
+
+DefTaskList sets `Strict: false` explicitly (following `DefFindSessionTranscripts`, `DefDoctorEvener`, `DefCommunicate`, `DefDelegate`, and the read/transcript tools — six precedents in definitions.go). Rationale: the OpenAI Responses adapter defaults `strict = true` when `Strict` is nil (`toResponsesTools`, llm/providers/openai/responses.go:875-886) and `strictifyJSONSchema` force-requires every property including nested ones. Under that normalization, a strict model would be forced to emit `"status": ""` (violates the enum) or `"depends_on": []` (which CLEARS dependencies — a silent data mutation) on every update item. Explicit `Strict: false` opts out; the schema is then sent as-is with optional fields genuinely omittable. Non-strict providers (Anthropic path, openaicompat with `strict:false` in the function object) are unaffected. The reasoning_effort "inherit" sentinel keeps working (enum includes it) — and with `Strict: false` the sentinel becomes belt-and-suspenders rather than load-bearing for task_list, though it must stay for any other strict-mode surface that reuses `normalizeTaskEffort` (e.g. future delegate schemas).
+
+### Backward compatibility
+
+Old persisted/queued action-shaped calls fail schema validation (`additionalProperties: false` rejects `action`). The repair layer's `ExplainSchemaError` reports the unknown property with the correct container path and an example built from the NEW schema — the model sees "unknown argument action" plus the new shape and self-corrects in one retry. Sessions renegotiate the tool contract every request (schemas ride along), so exposure is limited to in-flight sessions across a rollout.
+
+### Known limitation (documented, pinned by test)
+
+In one combined call you can complete a task and add new tasks, but you cannot start a task created by the same call's `add`: the update would have to name an ID the model cannot know before publication. The response returns the list with the new IDs, so a follow-up call to start it is natural — and when a completion leaves nothing in progress, auto-advance usually starts the next eligible task anyway. Rejected updates of this shape get `unknown task ID %d`, the same error as any unknown ID (the model cannot distinguish "not yet created" from "never existed," and shouldn't need to).
+
+### Test migration inventory
+
+Production code changes: `agent/internal/tool/definitions.go` (DefTaskList), `agent/session_tools_task.go` (handler + decode), `agent/task/task_store.go` (status semantics). Everything else is tests:
+
+| File | Change |
+|---|---|
+| `agent/session_tools_task_test.go` | Rewrite handler tests to new call shape; add combined add+update, empty-array, notes-only tests |
+| `agent/task_store_test.go` | Add empty-status tests; existing TaskUpdate-level tests unaffected (they use the store API) |
+| `agent/session_task_effort_test.go` | Update call shapes (11 refs) |
+| `agent/task_workflow_test.go` | Update call shapes |
+| `agent/cov_task_updated_test.go` | Update call shapes (3 refs) |
+| `agent/session_tools_dispatch_fuzz_test.go` | Update fixtures (22 refs) |
+| `agent/session_tool_repair_task_branch_test.go` | DELETE both issue #626 tests (failure shape unrepresentable); replace with old-shape rejection tests |
+| `agent/internal/tool/repair/explain_covtest_test.go` | Update task_list fixtures (params builder reflects new schema) |
+| `agent/internal/tool/repair/explain_action_branch_test.go` | Update taskListParams builder; keep generic branch machinery tests (they test the machinery, not task_list) |
+| `agent/session_attention_test.go` | Update call shapes (5 refs) |
+| `agent/session_dod_definition_test.go` | Update call shapes (5 refs) |
+| `agent/steering_tool_gate_test.go` | Update call shapes (2 refs) |
+| `agent/session_tool_repair_test.go` | Update call shapes (3 refs) |
+| `agent/internal/sessionlog/load_fuzz_test.go`, `cov_s5_sessionlog_test.go` | Update fixture JSON |
+| `agent/transcript_render_job_test.go` | Update fixture JSON (3 refs) |
+| `agent/session_tools_misc_contract_fuzz_test.go`, `session_tools_aux_exact_fuzz_test.go`, `session_lifecycle_tail_coverage_fuzz_test.go` | Update fixtures |
+| `agent/provider/profile_test.go` | Verify effort-enum sync passes (setEffortLevels rebuilds DefTaskList by name) |
+| `cmd/evener-tui/internal/toolsummary/tool_summary.go:144-158` | PRODUCTION: rewrite the `task_list` case — no `action`; render from `add`/`update` arrays (both may be present; e.g. `add 2, update 1`); keep `renderTaskAppend`/`renderTaskUpdate` helpers, call both when both arrays present |
+| `cmd/evener-tui/internal/toolsummary/*_test.go`, `fuzz_coverage_test.go` | Update fixtures to new call shape |
+| `cmd/evener-tui/internal/msgrender/*_test.go` | Verify: `taskListBody` renders tool OUTPUT (not args), so unaffected; check fixtures that pass task_list args to renderers expecting `action` |
+
+Frontend tests use `"ln"` as a renamed generic tool in fixtures — verify none assert `action` specifically for task_list (spot-check; no changes expected).
+
+---
+
+### Task 1: Store — empty status means no change
+
+**Files:**
+- Modify: `agent/task/task_store.go` (TaskUpdate doc comment, `updateLocked`)
+- Test: `agent/task/task_store_test.go`
+
+**Interfaces:**
+- Consumes: none.
+- Produces: `TaskUpdate.Status == ""` = no status change; all other validations unchanged. Used by the handler (Task 3).
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+// TestTaskUpdate_EmptyStatusMeansNoChange pins the contract: an update
+// entry with an empty status leaves the task's status unchanged while still
+// applying notes, deps, and effort — the tool schema has always documented
+// status as optional, so the store must honor that.
+func TestTaskUpdate_EmptyStatusMeansNoChange(t *testing.T) {
+	s := NewTaskStore(t.TempDir(), "t")
+	added, err := s.Append([]TaskInput{{Description: "d", Prompt: "p"}})
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if err := s.Update([]TaskUpdate{{ID: added[0].ID, Notes: "note one"}}); err != nil {
+		t.Fatalf("notes-only update: %v", err)
+	}
+	got := s.View()
+	if got[0].Status != TaskOpen {
+		t.Fatalf("status changed by notes-only update: %v", got[0].Status)
+	}
+	if len(got[0].Notes) != 1 || got[0].Notes[0] != "note one" {
+		t.Fatalf("notes not applied: %v", got[0].Notes)
+	}
+
+	if err := s.Update([]TaskUpdate{{ID: added[0].ID, Status: TaskInProgress}}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if err := s.Update([]TaskUpdate{{ID: added[0].ID, Notes: "note two"}}); err != nil {
+		t.Fatalf("notes-only during progress: %v", err)
+	}
+	got = s.View()
+	if got[0].Status != TaskInProgress {
+		t.Fatalf("notes-only update clobbered in_progress: %v", got[0].Status)
+	}
+	if len(got[0].Notes) != 2 {
+		t.Fatalf("second note not appended: %v", got[0].Notes)
+	}
+}
+
+// TestTaskUpdate_EmptyStatusStillValidates pins that empty status does not
+// weaken the other validations: unknown IDs, unknown deps, and invalid
+// non-empty statuses still fail.
+func TestTaskUpdate_EmptyStatusStillValidates(t *testing.T) {
+	s := NewTaskStore(t.TempDir(), "t")
+	added, err := s.Append([]TaskInput{{Description: "d", Prompt: "p"}})
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if err := s.Update([]TaskUpdate{{ID: 999, Notes: "x"}}); err == nil {
+		t.Fatal("unknown ID with empty status must still be rejected")
+	}
+	if err := s.Update([]TaskUpdate{{ID: added[0].ID, DependsOn: &[]int{999}}}); err == nil {
+		t.Fatal("unknown dep must still be rejected")
+	}
+	if err := s.Update([]TaskUpdate{{ID: added[0].ID, Status: "bogus"}}); err == nil {
+		t.Fatal("bogus status must still be rejected")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./agent/task/ -run 'TestTaskUpdate_EmptyStatus' -v`
+Expected: FAIL — `invalid status "" for task 1`.
+
+- [ ] **Step 3: Implement**
+
+Update the `TaskUpdate` doc comment:
+
+```go
+// TaskUpdate is a change for an existing task.
+// Status empty means no status change; non-empty must be one of the four.
+// DependsOn nil means no change; &[]int{} clears the dependency list.
+// ReasoningEffort empty means no change; a non-empty value replaces it.
+```
+
+In `updateLocked`, change the status validation to skip empties:
+
+```go
+	// Validate status values up front so a bad status doesn't half-apply.
+	// An empty status means "no change": the tool schema documents status
+	// as optional, so notes/deps/effort-only updates are legal.
+	for _, u := range updates {
+		if u.Status == "" {
+			continue
+		}
+		switch u.Status {
+		case TaskOpen, TaskInProgress, TaskDone, TaskCancelled:
+			// valid
+		default:
+			return fmt.Errorf("invalid status %q for task %d: must be open, in_progress, done, or cancelled", u.Status, u.ID)
+		}
+	}
+```
+
+In the projection loop, only overwrite when non-empty:
+
+```go
+	for _, u := range updates {
+		if _, exists := projected[u.ID]; !exists {
+			return fmt.Errorf("unknown task ID %d", u.ID)
+		}
+		if u.Status != "" {
+			projected[u.ID] = u.Status
+		}
+	}
+```
+
+In the apply loop, guard the assignment:
+
+```go
+			if s.tasks[i].ID == u.ID {
+				if u.Status != "" {
+					s.tasks[i].Status = u.Status
+				}
+				if u.Notes != "" {
+					s.tasks[i].Notes = append(s.tasks[i].Notes, u.Notes)
+				}
+				// ... unchanged: DependsOn, ReasoningEffort, timestamps
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test ./agent/task/ -run 'TestTaskUpdate_EmptyStatus' -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the store suite and audit the old contract**
+
+Run: `go test ./agent/task/`
+Expected: PASS. Then `rg -n 'invalid status' agent/task/` and update any test that relied on empty status being rejected (none expected — existing bogus-status tests use non-empty values).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/task/task_store.go agent/task/task_store_test.go
+git commit -m "fix(task): empty status in update means no change
+
+The tool schema has always documented status as optional, but the store
+validated every update's status against the four-value enum, rejecting
+notes-only updates the schema promised were legal. An empty status now
+carries the current status forward; validation, the single-in_progress
+projection, and the apply loop all treat empty as no-change. Non-empty
+status behavior is unchanged."
+```
+
+### Task 2: Schema — presence-based DefTaskList
+
+**Files:**
+- Modify: `agent/internal/tool/definitions.go` (DefTaskList, ~line 611)
+- Test: `agent/internal/tool/definitions_test.go`
+
+**Interfaces:**
+- Consumes: none.
+- Produces: new DefTaskList shape (consumed by `profile.setEffortLevels` and the registry).
+
+- [ ] **Step 1: Write the failing schema test**
+
+```go
+// TestDefTaskList_PresenceBased pins the combined-tool schema: no action
+// property, add/update arrays optional, update items require only id, and
+// no top-level required list (a bare call is a view).
+func TestDefTaskList_PresenceBased(t *testing.T) {
+	def := DefTaskList([]string{"low", "high"})
+	params := def.Parameters.(map[string]any)
+	props := params["properties"].(map[string]any)
+	if _, has := props["action"]; has {
+		t.Fatal("schema must not have an action property")
+	}
+	if def.Strict == nil || *def.Strict {
+		t.Fatal("DefTaskList must set Strict: false explicitly (strict-mode normalization would force-requires nested update fields)")
+	}
+	add, has := props["add"]
+	if !has {
+		t.Fatal("schema must have an add property")
+	}
+	addItems := add.(map[string]any)["items"].(map[string]any)
+	addReq, ok := addItems["required"].([]string)
+	if !ok || len(addReq) != 3 || addReq[0] != "type" || addReq[1] != "description" || addReq[2] != "prompt" {
+		t.Fatalf("add item required = %v, want [type description prompt]", addItems["required"])
+	}
+	update, has := props["update"]
+	if !has {
+		t.Fatal("schema must have an update property")
+	}
+	updateItems := update.(map[string]any)["items"].(map[string]any)
+	updateReq, ok := updateItems["required"].([]string)
+	if !ok || len(updateReq) != 1 || updateReq[0] != "id" {
+		t.Fatalf("update item required = %v, want [id]", updateItems["required"])
+	}
+	if top, has := params["required"]; has {
+		t.Fatalf("schema must not force-require add/update at top level: %v", top)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./agent/internal/tool/ -run TestDefTaskList_PresenceBased -v`
+Expected: FAIL — "schema must not have an action property".
+
+- [ ] **Step 3: Implement DefTaskList**
+
+Replace DefTaskList's body with the Design-section schema: keep the `reasoningSchema` construction exactly as today (shared by both item types), new tool description text (Design section), top level without `required`. Delete the old `action`/`tasks`/`updates` properties.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test ./agent/internal/tool/ -run TestDefTaskList_PresenceBased -v`
+Expected: PASS
+
+- [ ] **Step 5: Verify effort-enum sync still passes**
+
+Run: `go test ./agent/provider/`
+Expected: PASS (`setEffortLevels` rebuilds DefTaskList by name; the new schema keeps reasoning_effort enums in both item types). Update any profile test asserting on old property names if needed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/internal/tool/definitions.go agent/internal/tool/definitions_test.go
+git commit -m "feat(tool): task_list schema uses presence-based dispatch
+
+Replace the action enum and the tasks/updates arrays with optional add
+and update arrays: whichever array is present is the operation, both can
+appear in one call, and every response returns the full list. A bare
+call is the view. additionalProperties:false rejects old action-shaped
+calls at validation with an explainable error."
+```
+
+### Task 3: Handler — combined add/update in one publication
+
+**Files:**
+- Rewrite: `agent/session_tools_task.go` (registerTaskTools, decode helper, classification)
+- Test: `agent/session_tools_task_test.go`
+
+**Interfaces:**
+- Consumes: Task 1 store semantics (empty status = no change), Task 2 schema.
+- Produces: same tool name, same events payloads, same steering calls, plus a `decodeTaskArgs(args map[string]any) (adds []taskpkg.TaskInput, updates []taskpkg.TaskUpdate, err error)` helper.
+
+- [ ] **Step 1: Rewrite the harness invoke helper first** — `newTaskToolHarness.update` hardcodes `{"action":"update","updates":...}` (session_tools_task_test.go:53-62). Replace with `call(t *testing.T, args map[string]any) tool.ExecResult` taking raw args (nil-safe), update `h.update` callers in the same commit, and add a `h.view(t)` convenience for bare calls.
+
+- [ ] **Step 2: Write failing handler tests** (using the new `h.call` helper)
+
+```go
+// TestTaskTool_CombinedAddUpdate: both arrays in one call apply atomically
+// with one publication revision and one EventTaskUpdated.
+func TestTaskTool_CombinedAddUpdate(t *testing.T) {
+	h := newTaskToolHarness(t, nil)
+	res := h.update(t, map[string]any{
+		"add": []any{map[string]any{
+			"type": "implement", "description": "first", "prompt": "do one",
+		}},
+		"update": []any{map[string]any{
+			"id": 1, "status": "in_progress",
+		}},
+	})
+	if res.IsError {
+		t.Fatalf("combined call: %s", res.FullOutput)
+	}
+	if !strings.Contains(res.FullOutput, "Added 1 task(s); updated 1→in_progress") {
+		t.Fatalf("output should combine add+update ack: %q", res.FullOutput)
+	}
+}
+
+// TestTaskTool_UpdateReferencesThisCallAddsRejected: the model cannot know
+// IDs this call's add would assign, so updates must validate against the
+// pre-add store state.
+func TestTaskTool_UpdateReferencesThisCallAddsRejected(t *testing.T) {
+	h := newTaskToolHarness(t, nil)
+	res := h.update(t, map[string]any{
+		"add": []any{map[string]any{
+			"type": "implement", "description": "first", "prompt": "do one",
+		}},
+		"update": []any{map[string]any{
+			"id": 5, "status": "in_progress",
+		}},
+	})
+	if !res.IsError {
+		t.Fatal("update targeting an ID this call's add would create must be rejected")
+	}
+	if !strings.Contains(res.FullOutput, "unknown task ID 5") {
+		t.Fatalf("error should name the unknown ID: %s", res.FullOutput)
+	}
+	if len(h.store.View()) != 0 {
+		t.Fatal("failed combined call must not apply its adds either (atomicity)")
+	}
+}
+
+// TestTaskTool_EmptyArraysAreNoOps: strict-mode models force-send both
+// arrays; empty ones must be no-ops. With no mutation, the response is
+// the view output (the list), same as a bare call.
+func TestTaskTool_EmptyArraysAreNoOps(t *testing.T) {
+	h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "d", Prompt: "p"}})
+	res := h.update(t, map[string]any{"add": []any{}, "update": []any{}})
+	if res.IsError {
+		t.Fatalf("empty arrays must be no-ops: %s", res.FullOutput)
+	}
+	if !strings.Contains(res.FullOutput, "1. [open]") {
+		t.Fatalf("response must still return the list: %q", res.FullOutput)
+	}
+}
+
+// TestTaskTool_NotesOnlyUpdateWorks: the end-to-end bug fix from the review.
+func TestTaskTool_NotesOnlyUpdateWorks(t *testing.T) {
+	h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "d", Prompt: "p"}})
+	if err := h.store.Update([]taskpkg.TaskUpdate{{ID: 1, Status: taskpkg.TaskInProgress}}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	res := h.update(t, map[string]any{
+		"update": []any{map[string]any{"id": 1, "notes": "found the root cause"}},
+	})
+	if res.IsError {
+		t.Fatalf("notes-only update must succeed (was: invalid status \"<nil>\"): %s", res.FullOutput)
+	}
+	if !strings.Contains(res.FullOutput, "Updated 1.") {
+		t.Fatalf("ack: %q", res.FullOutput)
+	}
+}
+
+// TestTaskTool_ViewIsBareCall: no arrays = view, returns the list.
+func TestTaskTool_ViewIsBareCall(t *testing.T) {
+	h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "d", Prompt: "p"}})
+	res := h.update(t, map[string]any{})
+	if res.IsError {
+		t.Fatalf("bare call must be a view: %s", res.FullOutput)
+	}
+	if !strings.Contains(res.FullOutput, "1. [open]") {
+		t.Fatalf("bare call must return the list: %q", res.FullOutput)
+	}
+}
+
+// TestTaskTool_OldActionShapeRejectedHelpfully: back-compat — old
+// action-shaped calls fail at validation with an error the repair layer
+// explains against the new schema.
+func TestTaskTool_OldActionShapeRejectedHelpfully(t *testing.T) {
+	h := newTaskToolHarness(t, nil)
+	res := h.update(t, map[string]any{"action": "view"})
+	if !res.IsError {
+		t.Fatal("old action-shaped call must be rejected")
+	}
+}
+
+// TestTaskTool_NoOpUpdateEntryRejected: an update entry that changes
+// nothing is a model mistake, not a no-op.
+func TestTaskTool_NoOpUpdateEntryRejected(t *testing.T) {
+	h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "d", Prompt: "p"}})
+	res := h.update(t, map[string]any{
+		"update": []any{map[string]any{"id": 1}},
+	})
+	if !res.IsError {
+		t.Fatal("empty update entry must be rejected")
+	}
+// TestTaskTool_AutoAdvanceCanPickSameCallAdd: completing a task in a call
+// that also adds an eligible replacement auto-starts the new task in the
+// same publication — "when you mark a task done, the next eligible task
+// auto-starts" applies to same-call adds too.
+func TestTaskTool_AutoAdvanceCanPickSameCallAdd(t *testing.T) {
+	h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "first", Prompt: "p1"}})
+	if err := h.store.Update([]taskpkg.TaskUpdate{{ID: 1, Status: taskpkg.TaskInProgress}}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	res := h.call(t, map[string]any{
+		"update": []any{map[string]any{"id": 1, "status": "done"}},
+		"add":    []any{map[string]any{"type": "implement", "description": "second", "prompt": "p2"}},
+	})
+	if res.IsError {
+		t.Fatalf("combined completion+add: %s", res.FullOutput)
+	}
+	view := h.store.View()
+	if len(view) != 2 || view[1].Status != taskpkg.TaskInProgress {
+		t.Fatalf("auto-advance should start the same-call add: %+v", view)
+	}
+	if len(h.steers) == 0 {
+		t.Fatal("auto-advance steering should fire for the new task")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./agent/ -run 'TestTaskTool_' -v`
+Expected: FAIL — handler still requires `action`.
+
+- [ ] **Step 3: Implement the handler**
+
+Rewrite `registerTaskTools`. Structure:
+
+```go
+func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
+	_ = reg.Register(tool.RegisteredTool{
+		Definition: tool.DefTaskList(deps.reasoningEffortLevels),
+		Exec: func(ctx context.Context, env execenv.ExecutionEnvironment, args map[string]any) (any, error) {
+			_ = ctx
+			deps.taskGuard.MarkUsed()
+			store := deps.taskGuard.Store()
+
+			adds, updates, err := decodeTaskArgs(args)
+			if err != nil {
+				return nil, err
+			}
+
+			return mutateAndPublishTaskStore(store, func(epoch, revision uint64) (any, error) {
+				// Validate update IDs against the PRE-ADD state: the model
+				// composed this call before any new IDs existed.
+				if err := validateUpdateIDs(store, updates); err != nil {
+					return nil, err
+				}
+				var added []taskpkg.Task
+				if len(adds) > 0 {
+					added, err = store.Append(adds)
+					if err != nil {
+						return nil, err
+					}
+				}
+				// ... updates path (UpdateWithSnapshot + classification from
+				// mutation.After), steering/auto-advance blocks ported verbatim
+				// from the current update branch, response assembly per Design.
+			})
+		},
+	})
+}
+```
+
+`decodeTaskArgs` decodes strictly with typed assertions (no `fmt.Sprint`): `add` items → `taskpkg.TaskInput` (type, description, prompt, depends_on ints, reasoning_effort via `validateTaskEffort`); `update` items → `taskpkg.TaskUpdate` (id, status string, notes, depends_on `*[]int` present/absent distinction, reasoning_effort). Update entries with no change field error ("changes nothing"). Missing/wrong-typed arrays → nil / clear errors.
+
+Classification port (from the current update branch), with statuses read from `mutation.After` instead of raw entries: `previous` map from `mutation.Before`, `finalStatus` derived from `mutation.After` keyed by ID, `inProgressUpdates`/`started`/`completedAny`/`manuallyStartedID` logic unchanged in structure. Manual-start steering, auto-advance, all-done + delegates steering, single `deps.emit(events.EventTaskUpdated, ...)`, and the `taskToolStateSnapshot` call all port verbatim.
+
+- [ ] **Step 4: Run handler tests**
+
+Run: `go test ./agent/ -run 'TestTaskTool_' -v`
+Expected: PASS. Then rewrite the existing per-action handler tests (view/append/update) into presence-based equivalents, keeping every steering/auto-advance/all-done/events/classification assertion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/session_tools_task.go agent/session_tools_task_test.go
+git commit -m "feat(task): combined add/update handler with presence-based dispatch
+
+One MutateAndPublish per call: adds and updates decode into typed inputs
+with strict errors (no fmt.Sprint coercion), update IDs validate against
+the pre-add store state (the model composed the call before new IDs
+existed), adds apply first, then updates. Every response returns the
+full list; empty arrays are no-ops. Classification derives statuses from
+the mutation snapshot so empty-status entries classify correctly.
+Auto-advance, steering, and events payloads are unchanged."
+```
+
+### Task 4: Test migration sweep
+
+**Files:** the inventory table above.
+
+- [ ] **Step 1:** For each file in the inventory, convert `{"action":"view"}` → `{}`, `{"action":"append","tasks":X}` → `{"add":X}`, `{"action":"update","updates":Y}` → `{"update":Y}`. Where tests assert old error strings (`unknown task_list action`, `requires a non-empty 'tasks' array`), re-assert on the new ones. File-by-file with rg + edits — no sed scripting over 20 files.
+- [ ] **Step 2:** Delete the two issue #626 tests in `agent/session_tool_repair_task_branch_test.go` and replace them with old-shape rejection tests (the model-visible error names `action` as unknown and shows the new example shape).
+- [ ] **Step 3:** Run `go test ./agent/...` — fix fallout until green.
+- [ ] **Step 4:** Run `go test ./agent/internal/tool/...` — task_list fixtures updated; generic branch-machinery tests stay.
+- [ ] **Step 5:** Commit with explicit paths (only files actually changed):
+
+```bash
+git add <explicitly-changed-files>
+git commit -m "test(task): migrate fixtures to presence-based task_list calls"
+```
+
+### Task 5: Full gate
+
+- [ ] **Step 1:** `make lint` — expect naming/generated-output gates to pass.
+- [ ] **Step 2:** `make vet`.
+- [ ] **Step 3:** `make test` (or at minimum `go test ./agent/... ./agent/internal/...`).
+- [ ] **Step 4:** Fix any fallout, commit.
+
+---
+
+## Self-Review
+
+1. **Spec coverage:** schema (Task 2), handler + atomicity (Task 3), status fix (Task 1), back-compat (Task 3 + Task 4 rejection tests), test migration (Task 4), gates (Task 5), repair machinery untouched (constraint honored — only test fixtures change).
+2. **Placeholder scan:** clean — every step carries complete code or an exact contract.
+3. **Type consistency:** `decodeTaskArgs` signature matches its Task 3 use; `validateUpdateIDs(store, updates)` is defined in Task 3 Step 3's structure and named identically; store changes (Task 1) match what Task 3's classification port relies on (empty status, snapshot-derived statuses).
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-08-31-task-tool-combined.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks
+
+**2. Inline Execution** — execute tasks in this session with checkpoints
+
+Which approach?


### PR DESCRIPTION
## Summary

Reworks the `task_list` tool from action-enum branching to **presence-based dispatch**: no `action` parameter, optional `add` and `update` arrays (either or both in one call), and a bare call (or empty arrays) as the view. Also fixes the store bug where a schema-legal notes-only update failed with `invalid status "<nil>"`.

**Why:** the old shape had a redundant intent channel — the call said `action: "update"` and then had to pick the matching array — which models misfiled repeatedly (issue #626: update entries in `tasks`, observed 17× in one session, with misdirecting errors causing unrecoverable retry loops). Presence-based dispatch deletes the first channel; the array name is the whole intent.

## Key decisions

- **`Strict: false` explicitly** — the OpenAI Responses adapter defaults strict=true when unset and force-requires every nested property, which would force strict models to emit `"status": ""` (enum violation) or `"depends_on": []` (silently clears deps) on every update item. Six existing definitions already use this opt-out.
- **Updates validate against the pre-add state** — the model cannot know IDs its own call's `add` would assign, so an update can never target or depend on this call's adds. Same error for "never existed" and "not yet created".
- **One publication per call** — add+update apply atomically in one `MutateAndPublish`, one revision, one `EventTaskUpdated`.
- **Mutations stay terse acks** — the list comes back from a bare call; auto-advance/current-task steering unchanged.
- **Old action-shaped calls get a named error** (`retiredTaskListShapeError`, the `unsupportedDelegateWaitOption` pattern) instead of being silently repaired into a view.
- **Empty status = no change** in the store, matching what the schema always documented; also stops spuriously clearing `CompletedAt`.

## Known limitation (documented + pinned)

A combined call cannot *start* a task its own `add` creates (the model can't know the ID). The response returns the new IDs; auto-advance usually handles it. See the design doc.

## Verification

- `make lint` — all 9 sub-gates PASS
- `make vet` — pass
- `go test ./...` (full repo) — zero failures
- New invariant battery (`session_tools_task_invariants_test.go`): single-in_progress under combined batches, auto-advance exactly-once with steering, events payload shape, add-dep-on-unknown rejection, same-batch add deps
- Fuzz generators rewritten to presence-based modes (the old generator had silently stopped exercising the malformed-entry arms)

## Reviews this survived

- **Design:** 5 adversarial iterations (caught the strict-mode hole, missed TUI/contextmgr surfaces, a wrong plan test, and an incorrect every-call-returns-list claim)
- **Implementation:** 3 findings fixed (update-dep-on-same-call-add hole, fuzz coverage loss, undocumented synthetic fixtures)
- **Simplify:** 4 reviewer angles, 17 findings — 12 applied including one real bug (contextmgr mislabeled `{"add": []}` as "add"); 2 skipped with reasons documented in the code

Design doc: `docs/superpowers/plans/2026-08-31-task-tool-combined.md`