### PR TITLE
Consolidate the non-chat model filter into the registry's one list

### DIFF
--- a/llm/providers/responses/models.go
+++ b/llm/providers/responses/models.go
@@ -116,23 +116,6 @@ func codexReasoningEfforts(levels []codexReasoningLevel) []string {
 	return out
 }
 
-// skipOpenAIModel reports whether id names a non-text model (embeddings,
-// audio, image, moderation, ...) that this listing should not advertise.
-func skipOpenAIModel(id string) bool {
-	lower := strings.ToLower(id)
-	skip := []string{
-		"embedding", "dall-e", "whisper", "davinci", "babbage",
-		"tts", "audio", "realtime", "transcribe", "image",
-		"moderation", "sora",
-	}
-	for _, s := range skip {
-		if strings.Contains(lower, s) {
-			return true
-		}
-	}
-	return false
-}
-
 // firstPositiveInt returns the first positive argument, or 0 if none is
 // positive.
 func firstPositiveInt(values ...int) int {
@@ -162,12 +145,12 @@ func (p *Protocol) ListModels(ctx context.Context, res registry.Resolved) ([]reg
 			return nil, fmt.Errorf("models.list: %w", err)
 		}
 		for _, e := range payload.Data {
-			if e.ID != "" && !skipOpenAIModel(e.ID) {
+			if registry.IsChatModelID(e.ID) {
 				rows = append(rows, e.row())
 			}
 		}
 		for _, e := range payload.Models {
-			if id := e.id(); id != "" && !skipOpenAIModel(id) {
+			if id := e.id(); registry.IsChatModelID(id) {
 				rows = append(rows, e.row())
 			}
 		}

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -19,7 +19,7 @@ var protocolDefaults = map[string]Transport{
 }
 
 // nonChatPatterns identifies live listing ids that are not text models
-// (spec §5); one list, replacing nonChatModelSubstrings and skipOpenAIModel.
+// (spec §5); the one list every listing filter reads, via IsChatModelID.
 var nonChatPatterns = []string{"embedding", "whisper", "tts", "dall-e", "moderation", "audio", "transcribe", "image", "realtime", "davinci", "babbage", "sora"}
 
 // IsChatModelID reports whether a live listing id names a text model.


### PR DESCRIPTION
Fixes the post-merge review finding on #704 (Low): `skipOpenAIModel` in `llm/providers/responses/models.go` survived as a byte-identical twelve-substring copy of the registry's `nonChatPatterns`, on the same listing path — so a future edit to one list and not the other would silently make the registry's visibility rule disagree with what the listing advertises, and `resolve.go`'s "one list" comment was false.

- Delete `skipOpenAIModel`; both `ListModels` payload loops now filter through `registry.IsChatModelID` (already imported), which also covers the empty-id guard.
- Trim `resolve.go`'s comment so it no longer names the deleted helpers.

Behavior is identical (same substrings, same lowercase-contains semantics); `TestListModelsPlatformAndCodexShapes` keeps covering the filtering through the real path (`text-embedding-3-large` dropped). `llm` responses + registry tests and all 9 lint targets green.