### PR TITLE
Provider registry step 4: cloud live verification

### DIFF
--- a/agent/profile_test.go
+++ b/agent/profile_test.go
@@ -1215,14 +1215,19 @@ func TestGeminiProfile_ProviderOptions_HasSafetySettings(t *testing.T) {
 	}
 }
 
-func TestAnthropicProfile_ContextWindow_Default200K(t *testing.T) {
+// Sonnet 4.5's window is 1M on the base row itself (GA, verified live
+// 2026-08-31), dated spelling included — no [1m] suffix needed to get it.
+func TestAnthropicProfile_ContextWindow_Sonnet45Is1M(t *testing.T) {
 	t.Parallel()
 	p := newAnthropicProfile("claude-sonnet-4-5-20250929")
-	if p.ContextWindowSize() != 200_000 {
-		t.Errorf("expected 200000, got %d", p.ContextWindowSize())
+	if p.ContextWindowSize() != 1_000_000 {
+		t.Errorf("expected 1000000, got %d", p.ContextWindowSize())
 	}
 }
 
+// On Sonnet 4.5 the [1m] row is a pure alias now, so this pins what the alias
+// still buys: the ref resolves (1M, reaching it through the alias fold from
+// the base row) and the model string keeps the suffix for canonicalModelID.
 func TestAnthropicProfile_ContextWindow_1MSuffix(t *testing.T) {
 	t.Parallel()
 	p := newAnthropicProfile("claude-sonnet-4-5[1m]")
@@ -1237,22 +1242,24 @@ func TestAnthropicProfile_ContextWindow_1MSuffix(t *testing.T) {
 
 func TestAnthropicProfile_WithModel_RoundTrip(t *testing.T) {
 	t.Parallel()
-	// Start at 200K, switch to 1M model.
-	orig := newAnthropicProfile("claude-sonnet-4-5")
+	// Start at 200K, switch to 1M model. Opus 4.5 is the pair whose [1m] alias
+	// still moves the window; Sonnet 4.5 is 1M on its base row, so it no longer
+	// exercises the switch.
+	orig := newAnthropicProfile("claude-opus-4-5")
 	if orig.ContextWindowSize() != 200_000 {
 		t.Fatalf("orig context: got %d, want 200000", orig.ContextWindowSize())
 	}
 
-	upgraded := orig.WithModel("claude-sonnet-4-5[1m]")
+	upgraded := orig.WithModel("claude-opus-4-5[1m]")
 	if upgraded.ContextWindowSize() != 1_000_000 {
 		t.Fatalf("upgraded context: got %d, want 1000000", upgraded.ContextWindowSize())
 	}
-	if upgraded.Model() != "claude-sonnet-4-5[1m]" {
+	if upgraded.Model() != "claude-opus-4-5[1m]" {
 		t.Fatalf("upgraded model: got %q", upgraded.Model())
 	}
 
 	// Switch back to 200K.
-	downgraded := upgraded.WithModel("claude-sonnet-4-5")
+	downgraded := upgraded.WithModel("claude-opus-4-5")
 	if downgraded.ContextWindowSize() != 200_000 {
 		t.Fatalf("downgraded context: got %d, want 200000", downgraded.ContextWindowSize())
 	}

--- a/agent/profile_test.go
+++ b/agent/profile_test.go
@@ -1233,10 +1233,6 @@ func TestAnthropicProfile_ContextWindow_1MSuffix(t *testing.T) {
 	if p.Model() != "claude-sonnet-4-5[1m]" {
 		t.Errorf("model: got %q, want %q", p.Model(), "claude-sonnet-4-5[1m]")
 	}
-	// The alias row is what makes the 1M window legal on the wire.
-	if bh := p.Resolved().Headers["anthropic-beta"]; bh != "context-1m-2025-08-07" {
-		t.Errorf("anthropic-beta = %q, want context-1m-2025-08-07", bh)
-	}
 }
 
 func TestAnthropicProfile_WithModel_RoundTrip(t *testing.T) {
@@ -1285,16 +1281,15 @@ func TestProfile_ProviderOptionsAreNotAliased(t *testing.T) {
 	}
 }
 
-func TestAnthropicProfile_1M_BetaHeader(t *testing.T) {
+// Sonnet 4.5's 1M window is GA (verified live 2026-08-31), and so is prompt
+// caching, so the [1m] profile opts into neither: it sends no anthropic-beta
+// header at all. Any value here means a retired beta crept back onto every
+// [1m] request.
+func TestAnthropicProfile_1M_NoBetaHeader(t *testing.T) {
 	t.Parallel()
 	p := newAnthropicProfile("claude-sonnet-4-5[1m]")
-	bh := p.Resolved().Headers["anthropic-beta"]
-	if !strings.Contains(bh, "context-1m-2025-08-07") {
-		t.Fatalf("expected 1M beta header, got %q", bh)
-	}
-	// Should NOT have prompt-caching — caching is GA.
-	if strings.Contains(bh, "prompt-caching-2024-07-31") {
-		t.Fatalf("prompt-caching beta header should not be present (GA), got %q", bh)
+	if bh := p.Resolved().Headers["anthropic-beta"]; bh != "" {
+		t.Fatalf("anthropic-beta = %q, want no header: the 1M window and prompt caching are both GA", bh)
 	}
 }
 

--- a/agent/session_config_test.go
+++ b/agent/session_config_test.go
@@ -1886,7 +1886,10 @@ func TestSession_SetModel_UpdatesContextManager(t *testing.T) {
 		},
 	})
 
-	sess, err := NewSession(c, newAnthropicProfile("claude-sonnet-4-5"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{})
+	// Opus 4.5 is the 200K/1M pair: its [1m] alias still moves the window, so a
+	// stale profile after SetModel shows up as an unchanged pressure. Sonnet 4.5
+	// is 1M on its base row now and would make both readings identical.
+	sess, err := NewSession(c, newAnthropicProfile("claude-opus-4-5"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
@@ -1905,7 +1908,7 @@ func TestSession_SetModel_UpdatesContextManager(t *testing.T) {
 	}
 
 	// Switch to 1M context model. Context manager should see the new window.
-	sess.SetModel("claude-sonnet-4-5[1m]")
+	sess.SetModel("claude-opus-4-5[1m]")
 
 	// Pressure with 1M window: 100K/1M = 0.10
 	p2 := sess.ContextPressure()

--- a/cmd/evener/models_live_test.go
+++ b/cmd/evener/models_live_test.go
@@ -462,10 +462,11 @@ const (
 // get-foundation-model-availability reports it AUTHORIZED and AVAILABLE. The
 // two namespaces are simply different — inference-profile ids address
 // bedrock-runtime's InvokeModel/Converse path, which spec §1 puts out of
-// scope, while bedrock-mantle serves the flat catalog above. Spec §9.3's
-// global-routing paragraph is what needs re-deciding; until it is, the global
-// leg is pinned offline only, and sending it would only burn a request on a
-// 404 every run.
+// scope, while bedrock-mantle serves the flat catalog above. Spec §9.3 now
+// records that, and the §6.1 converter marks the region-prefixed rows Hidden,
+// so the global leg is pinned offline only: it still resolves, keeps its
+// prefix verbatim, and sending it would only burn a request on a 404 every
+// run.
 //
 // Gated like TestLiveSmoke, plus the two AWS variables the row is built from,
 // without which no request can be assembled at all. Run with:

--- a/cmd/evener/models_live_test.go
+++ b/cmd/evener/models_live_test.go
@@ -16,18 +16,28 @@ import (
 	"time"
 
 	"primeradiant.com/evener/cmdutil"
+	"primeradiant.com/evener/envvars"
 	"primeradiant.com/evener/internal/credentials"
+	"primeradiant.com/evener/llm"
+	"primeradiant.com/evener/llm/providers/anthropic"
 	"primeradiant.com/evener/llm/registry"
 )
 
 // liveSmokeModels names cheap models to exercise per instance. An instance
 // with a credential that is not listed here uses the first ids its models
-// endpoint returns.
+// endpoint returns, so naming one model is also what keeps a row to a single
+// request instead of the four an auto-picked listing costs.
+//
+// The `anthropic` row deliberately stops at the cheap model: the
+// claude-sonnet-4-5[1m] row has its own pin below, which asserts the resolved
+// window as well as acceptance, so listing it here too would only buy a second
+// request against a row already covered.
 var liveSmokeModels = map[string][]string{
 	"openrouter":      {"google/gemini-2.5-flash-lite", "anthropic/claude-haiku-4.5", "deepseek/deepseek-v4-flash", "minimax/minimax-m2.7", "openai/gpt-4.1-nano"},
 	"orclaude":        {"minimax/minimax-m2.7", "anthropic/claude-haiku-4.5"},
 	"kimi-for-coding": {"kimi-for-coding", "k3"},
-	"anthropic":       {"claude-haiku-4-5", "claude-sonnet-4-5[1m]"},
+	"kimi":            {"kimi-for-coding"},
+	"anthropic":       {"claude-haiku-4-5"},
 	"openai":          {"gpt-4.1-nano"},
 	"groq":            {"openai/gpt-oss-120b"},
 	"google":          {"gemini-2.5-flash-lite"},
@@ -41,12 +51,73 @@ var liveSmokeModels = map[string][]string{
 	"minimax":         {"MiniMax-M2.7"},
 }
 
+// liveSmokeEndpoints pins the endpoint an instance's completions must be
+// dispatched to, for the rows where the endpoint is itself the property under
+// test (spec §13). `openai` is one: its surface selects the Responses API, so
+// a row that quietly fell back to Chat Completions would still answer "pong"
+// and hide the regression.
+var liveSmokeEndpoints = map[string]string{"openai": "/responses"}
+
 const liveSmokePrompt = "Reply with the single word: pong"
 
 // liveConfig names the providers.toml the smoke loads (its credentials.toml
 // sibling supplies the keys). A flag rather than EVENER_PROVIDERS_CONFIG
-// because TestMain scrubs every EVENER_* variable and redirects HOME.
-var liveConfig = flag.String("live-config", "", "providers.toml for TestLiveSmoke (credentials.toml is its sibling)")
+// because TestMain scrubs every EVENER_* variable and redirects HOME. It is
+// also the whole gate on the live tests running at all, so it stays a flag
+// nothing can supply by accident.
+var liveConfig = flag.String("live-config", "", "providers.toml for the live tests (credentials.toml is its sibling)")
+
+// liveCredentialsConfig is EVENER_CREDENTIALS_CONFIG as this process was
+// started. TestMain clears every EVENER_* variable before the first test runs,
+// so the value has to be captured at package initialization — which Go
+// performs before it calls TestMain. scripts/live/with-live-env --store sets
+// the variable to the developer's real store while --config copies the
+// providers.toml into the run's fake home; without this capture those two
+// flags could not be used together.
+var liveCredentialsConfig = envvars.EVENERCredentialsConfig.Trimmed()
+
+// liveStorePath is credentials.toml's location for a live run:
+// EVENER_CREDENTIALS_CONFIG when one was set, else the sibling of the
+// -live-config providers.toml. Same rule as cmdutil.CredentialsPath, which
+// this package cannot call because TestMain has already cleared the variable.
+func liveStorePath() string {
+	if liveCredentialsConfig != "" {
+		return liveCredentialsConfig
+	}
+	return filepath.Join(filepath.Dir(*liveConfig), "credentials.toml")
+}
+
+// requireLiveGate skips unless both halves of the gate are present: the
+// EVENER_LIVE_TESTS environment gate and the -live-config flag. what names
+// the test in the skip message.
+func requireLiveGate(t *testing.T, what string) {
+	t.Helper()
+	if os.Getenv("EVENER_LIVE_TESTS") != "1" {
+		t.Skipf("set EVENER_LIVE_TESTS=1 to run %s", what)
+	}
+	if *liveConfig == "" {
+		t.Skipf("pass -args -live-config=<providers.toml> to run %s", what)
+	}
+}
+
+// loadLiveRegistry loads the registry a live test resolves against: the user
+// layer -live-config names, the credential store liveStorePath names, and a
+// throwaway state root. Offline, so no live run can start a catalog refresh.
+// The log line carries paths and warnings, never a credential value.
+func loadLiveRegistry(t *testing.T) *registry.Registry {
+	t.Helper()
+	store, err := credentials.LoadStore(liveStorePath())
+	if err != nil {
+		t.Fatalf("credentials: %v", err)
+	}
+	r, err := registry.Load(registry.WithConfigPath(*liveConfig), registry.WithCredentials(cmdutil.StoreCredentialSource{Store: store}),
+		registry.WithStateRoot(t.TempDir()), registry.WithOffline(true))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	t.Logf("%s; credential store: %s; warnings=%v", r.UserLayerNote(), store.Path(), r.Warnings())
+	return r
+}
 
 // TestLiveSmoke sends one minimal request per (instance, model) built from
 // the registry's Resolved record — the resolved base URL, endpoint, auth
@@ -59,22 +130,8 @@ var liveConfig = flag.String("live-config", "", "providers.toml for TestLiveSmok
 // It never prints a credential value: only URLs, header names, statuses,
 // and short response excerpts.
 func TestLiveSmoke(t *testing.T) {
-	if os.Getenv("EVENER_LIVE_TESTS") != "1" {
-		t.Skip("set EVENER_LIVE_TESTS=1 to run the live provider smoke")
-	}
-	if *liveConfig == "" {
-		t.Skip("pass -args -live-config=<providers.toml> to run the live provider smoke")
-	}
-	store, err := credentials.LoadStore(filepath.Join(filepath.Dir(*liveConfig), "credentials.toml"))
-	if err != nil {
-		t.Fatalf("credentials: %v", err)
-	}
-	r, err := registry.Load(registry.WithConfigPath(*liveConfig), registry.WithCredentials(cmdutil.StoreCredentialSource{Store: store}),
-		registry.WithStateRoot(t.TempDir()), registry.WithOffline(true))
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
-	t.Logf("%s; warnings=%v", r.UserLayerNote(), r.Warnings())
+	requireLiveGate(t, "the live provider smoke")
+	r := loadLiveRegistry(t)
 	client := &http.Client{Timeout: 90 * time.Second}
 	ran := 0
 	for _, inst := range r.Instances() {
@@ -156,6 +213,11 @@ func liveSmokeInstance(t *testing.T, r *registry.Registry, client *http.Client, 
 			t.Errorf("resolve %s: %v", ref, err)
 			continue
 		}
+		// Asserted here rather than off the probe above so it pins the
+		// endpoint of the request actually sent below.
+		if want, pinned := liveSmokeEndpoints[inst.Name]; pinned && res.Transport.Endpoint != want {
+			t.Errorf("%s: dispatches to %q, want %q", ref, res.Transport.Endpoint, want)
+		}
 		url, body, ok := liveBody(res)
 		if !ok {
 			t.Logf("%s: protocol %s not covered by the smoke", ref, res.Protocol)
@@ -197,22 +259,8 @@ const oneMegaContextRef = "anthropic/claude-sonnet-4-5[1m]"
 // no Anthropic key. It never prints a credential value — only header names, the
 // status, and the reply's length.
 func TestLiveOneMegaContextRowAccepted(t *testing.T) {
-	if os.Getenv("EVENER_LIVE_TESTS") != "1" {
-		t.Skip("set EVENER_LIVE_TESTS=1 to run the live [1m] pin")
-	}
-	if *liveConfig == "" {
-		t.Skip("pass -args -live-config=<providers.toml> to run the live [1m] pin")
-	}
-	store, err := credentials.LoadStore(filepath.Join(filepath.Dir(*liveConfig), "credentials.toml"))
-	if err != nil {
-		t.Fatalf("credentials: %v", err)
-	}
-	r, err := registry.Load(registry.WithConfigPath(*liveConfig), registry.WithCredentials(cmdutil.StoreCredentialSource{Store: store}),
-		registry.WithStateRoot(t.TempDir()), registry.WithOffline(true))
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
-	t.Logf("%s; warnings=%v", r.UserLayerNote(), r.Warnings())
+	requireLiveGate(t, "the live [1m] pin")
+	r := loadLiveRegistry(t)
 	res, err := r.Resolve(oneMegaContextRef)
 	if err != nil {
 		t.Fatalf("resolve %s: %v", oneMegaContextRef, err)
@@ -224,7 +272,7 @@ func TestLiveOneMegaContextRowAccepted(t *testing.T) {
 		t.Fatalf("%s: context window %d, want at least 1000000", oneMegaContextRef, *res.Caps.ContextWindow)
 	}
 	t.Logf("%s: wire=%s window=%d headers=%v provenance=%s", oneMegaContextRef, res.WireID,
-		*res.Caps.ContextWindow, headerNames(res.Headers), res.Provenance["model"])
+		*res.Caps.ContextWindow, sortedNames(res.Headers), res.Provenance["model"])
 	if res.Credential.Value == "" {
 		t.Skipf("%s: no credential in this environment (source %s)", oneMegaContextRef, res.Credential.Source)
 	}
@@ -244,11 +292,166 @@ func TestLiveOneMegaContextRowAccepted(t *testing.T) {
 	t.Logf("%s: POST %s (wire %s) → %d, %d chars of reply text", oneMegaContextRef, res.Transport.Endpoint, res.WireID, status, len(text))
 }
 
-// headerNames lists a header map's names, sorted. Only names: a resolved
-// header map can carry a credential-bearing value, which is never logged.
-func headerNames(h map[string]string) []string {
-	names := make([]string, 0, len(h))
-	for k := range h {
+// kimiK3Ref is the row whose thinking shape spec §13 pins. The curated
+// kimi-for-coding rows give k3* thinking_shape = "budget+effort", so a request
+// carrying an effort must send both halves of the Anthropic thinking body —
+// the budget object and output_config.effort — and the reply must come back
+// with thinking content. The instance half is the name the coding endpoint has
+// in the live smoke's providers.toml (`base = "kimi-for-coding"`); a config
+// that names no such instance skips.
+const kimiK3Ref = "kimi/k3"
+
+// kimiK3Effort is the effort the pin sets: the cheapest level that still turns
+// thinking on, so the property is proven with the smallest budget
+// llm.ReasoningBudget hands out.
+const kimiK3Effort = "low"
+
+// liveThinkingPrompt wants one number back but a step of arithmetic to get
+// there, so a thinking-enabled row has something to think about while still
+// answering in a handful of tokens.
+const liveThinkingPrompt = "What is 17 times 23? Reply with the number only."
+
+// TestLiveKimiK3ThinkingShape pins Kimi K3's thinking shape end to end (spec
+// §13): the registry resolves budget+effort for the row, the anthropic
+// protocol turns that into the budget object plus output_config.effort, the
+// wire body that leaves the process still carries both, and the endpoint
+// answers with thinking content. It builds and sends through the shipping
+// protocol, not a hand-rolled body, so it is the real request shape that is
+// under test. Gated like TestLiveSmoke. Run with:
+//
+//	EVENER_LIVE_TESTS=1 go test ./cmd/evener/ -run TestLiveKimiK3ThinkingShape -v -count=1 -args -live-config=/path/to/providers.toml
+//
+// Everything down to the credential check is offline, so the shape half is
+// exercisable with no key present and costs no request. It logs shape field
+// names and lengths only: never the prompt, the thinking text, or a header
+// value.
+func TestLiveKimiK3ThinkingShape(t *testing.T) {
+	requireLiveGate(t, "the Kimi K3 thinking-shape pin")
+	r := loadLiveRegistry(t)
+	instance, _, _ := strings.Cut(kimiK3Ref, "/")
+	if _, ok := r.Instance(instance); !ok {
+		t.Skipf("%s: this config has no %q instance", kimiK3Ref, instance)
+	}
+	res, err := r.Resolve(kimiK3Ref)
+	if err != nil {
+		t.Fatalf("resolve %s: %v", kimiK3Ref, err)
+	}
+	if got := registry.StringValue(res.Caps.ThinkingShape); got != "budget+effort" {
+		t.Fatalf("%s: resolved thinking_shape %q, want %q", kimiK3Ref, got, "budget+effort")
+	}
+	effort := kimiK3Effort
+	maxTokens := 64
+	req := llm.Request{
+		Model:           kimiK3Ref,
+		Messages:        []llm.Message{llm.User(liveThinkingPrompt)},
+		MaxTokens:       &maxTokens,
+		ReasoningEffort: &effort,
+	}
+	body, err := anthropic.DefaultProtocol.BuildBody(req, res)
+	if err != nil {
+		t.Fatalf("%s: build body: %v", kimiK3Ref, err)
+	}
+	budget := assertThinkingShape(t, kimiK3Ref+" built body", body)
+	t.Logf("%s: protocol=%s wire=%s shape=%s effort=%q budget_tokens=%d headers=%v provenance=%s", kimiK3Ref,
+		res.Protocol, res.WireID, registry.StringValue(res.Caps.ThinkingShape), effort, budget, sortedNames(res.Headers), res.Provenance["model"])
+	if res.Credential.Value == "" {
+		t.Skipf("%s: no credential in this environment (source %s)", kimiK3Ref, res.Credential.Source)
+	}
+
+	// One request, through the shipping protocol so the prune, the body
+	// constants, and the authenticator all run exactly as they do in
+	// production. The recorder captures what actually went on the wire.
+	rec := &liveWireRecorder{next: http.DefaultTransport}
+	protocol := &anthropic.Protocol{Client: &http.Client{Timeout: 90 * time.Second, Transport: rec}}
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	resp, err := protocol.Complete(ctx, req, res)
+	if err != nil {
+		t.Fatalf("%s: POST %s (wire %s): %v", kimiK3Ref, res.Transport.Endpoint, res.WireID, err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(rec.body, &wire); err != nil {
+		t.Fatalf("%s: the recorded request body is not JSON: %v", kimiK3Ref, err)
+	}
+	assertThinkingShape(t, kimiK3Ref+" wire body", wire)
+
+	parts, chars := 0, 0
+	for _, p := range resp.Message.Content {
+		if p.Kind == llm.ContentThinking && p.Thinking != nil {
+			parts++
+			chars += len(p.Thinking.Text)
+		}
+	}
+	if parts == 0 || chars == 0 {
+		t.Fatalf("%s: reply carried no thinking content: %d content part(s), finish=%s", kimiK3Ref, len(resp.Message.Content), resp.Finish.Reason)
+	}
+	t.Logf("%s: POST %s (wire %s) → %d thinking part(s), %d chars of thinking, %d chars of reply text, finish=%s",
+		kimiK3Ref, res.Transport.Endpoint, res.WireID, parts, chars, len(strings.TrimSpace(resp.Text())), resp.Finish.Reason)
+}
+
+// assertThinkingShape checks that body carries the whole budget+effort
+// Anthropic thinking shape and returns the budget it committed to. what names
+// which body is under test (the builder's or the wire's). It logs field names
+// and the numeric budget, never a field carrying prompt or reply text.
+func assertThinkingShape(t *testing.T, what string, body map[string]any) int {
+	t.Helper()
+	thinking, ok := body["thinking"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s: no thinking object; fields=%v", what, sortedNames(body))
+	}
+	if typ, _ := thinking["type"].(string); typ != "enabled" {
+		t.Fatalf("%s: thinking.type = %q, want %q", what, typ, "enabled")
+	}
+	budget := 0
+	switch v := thinking["budget_tokens"].(type) {
+	case int:
+		budget = v
+	case float64: // the recorded wire body round-trips through JSON
+		budget = int(v)
+	}
+	if budget <= 0 {
+		t.Fatalf("%s: thinking.budget_tokens = %v, want a positive budget", what, thinking["budget_tokens"])
+	}
+	output, ok := body["output_config"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s: no output_config object; fields=%v", what, sortedNames(body))
+	}
+	if got, _ := output["effort"].(string); got != kimiK3Effort {
+		t.Fatalf("%s: output_config.effort = %q, want %q", what, got, kimiK3Effort)
+	}
+	t.Logf("%s: thinking fields=%v output_config fields=%v budget_tokens=%d", what, sortedNames(thinking), sortedNames(output), budget)
+	return budget
+}
+
+// liveWireRecorder keeps the request body of the call it forwards so a
+// property test can assert what actually went on the wire rather than what the
+// builder returned. The bytes it holds carry the prompt and the request it
+// forwards carries the credential, so nothing here is ever logged; only the
+// recorded body's field names leave this file.
+type liveWireRecorder struct {
+	next http.RoundTripper
+	body []byte
+}
+
+func (rec *liveWireRecorder) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.GetBody != nil {
+		if rc, err := req.GetBody(); err == nil {
+			raw, err := io.ReadAll(rc)
+			_ = rc.Close()
+			if err == nil {
+				rec.body = raw
+			}
+		}
+	}
+	return rec.next.RoundTrip(req)
+}
+
+// sortedNames lists a map's keys, sorted. Names only, for every map a live
+// test logs: a resolved header map can carry a credential-bearing value and a
+// request body carries the prompt, so no value from either is ever printed.
+func sortedNames[V any](m map[string]V) []string {
+	names := make([]string, 0, len(m))
+	for k := range m {
 		names = append(names, k)
 	}
 	sort.Strings(names)

--- a/cmd/evener/models_live_test.go
+++ b/cmd/evener/models_live_test.go
@@ -178,6 +178,82 @@ func liveSmokeInstance(t *testing.T, r *registry.Registry, client *http.Client, 
 	}
 }
 
+// oneMegaContextRef is the [1m] row the live pin below exercises.
+const oneMegaContextRef = "anthropic/claude-sonnet-4-5[1m]"
+
+// TestLiveOneMegaContextRowAccepted pins both halves of what the
+// anthropic/claude-sonnet-4-5[1m] row promises: it resolves to the 1M context
+// window, and a real /messages request assembled from that row is accepted.
+// The request carries exactly the headers the row resolves to, so this test is
+// what tells us the day the row's header set stops being the one Anthropic
+// wants — whether that set is a beta opt-in or empty. Gated like TestLiveSmoke.
+// Run with:
+//
+//	EVENER_LIVE_TESTS=1 go test ./cmd/evener/ -run TestLiveOneMegaContextRowAccepted -v -count=1 -args -live-config=/path/to/providers.toml
+//
+// The resolution and window assertions run before the credential check on
+// purpose: they need no network and no credential, so the offline half of this
+// pin is exercisable by running it with the gate set in an environment that has
+// no Anthropic key. It never prints a credential value — only header names, the
+// status, and the reply's length.
+func TestLiveOneMegaContextRowAccepted(t *testing.T) {
+	if os.Getenv("EVENER_LIVE_TESTS") != "1" {
+		t.Skip("set EVENER_LIVE_TESTS=1 to run the live [1m] pin")
+	}
+	if *liveConfig == "" {
+		t.Skip("pass -args -live-config=<providers.toml> to run the live [1m] pin")
+	}
+	store, err := credentials.LoadStore(filepath.Join(filepath.Dir(*liveConfig), "credentials.toml"))
+	if err != nil {
+		t.Fatalf("credentials: %v", err)
+	}
+	r, err := registry.Load(registry.WithConfigPath(*liveConfig), registry.WithCredentials(cmdutil.StoreCredentialSource{Store: store}),
+		registry.WithStateRoot(t.TempDir()), registry.WithOffline(true))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	res, err := r.Resolve(oneMegaContextRef)
+	if err != nil {
+		t.Fatalf("resolve %s: %v", oneMegaContextRef, err)
+	}
+	if res.Caps.ContextWindow == nil {
+		t.Fatalf("%s: no resolved context window, want at least 1000000", oneMegaContextRef)
+	}
+	if *res.Caps.ContextWindow < 1_000_000 {
+		t.Fatalf("%s: context window %d, want at least 1000000", oneMegaContextRef, *res.Caps.ContextWindow)
+	}
+	t.Logf("%s: wire=%s window=%d headers=%v provenance=%s", oneMegaContextRef, res.WireID,
+		*res.Caps.ContextWindow, headerNames(res.Headers), res.Provenance["model"])
+	if res.Credential.Value == "" {
+		t.Skipf("%s: no credential in this environment (source %s)", oneMegaContextRef, res.Credential.Source)
+	}
+	url, body, ok := liveBody(res)
+	if !ok {
+		t.Fatalf("%s: protocol %s builds no request body", oneMegaContextRef, res.Protocol)
+	}
+	client := &http.Client{Timeout: 90 * time.Second}
+	status, resp := liveRequest(t, client, http.MethodPost, url, body, res)
+	if status != http.StatusOK {
+		t.Fatalf("%s: POST %s (wire %s) → %d: %s", oneMegaContextRef, res.Transport.Endpoint, res.WireID, status, excerpt(resp, 300))
+	}
+	text := strings.TrimSpace(string(liveText(res.Protocol, resp)))
+	if text == "" {
+		t.Fatalf("%s: POST %s → %d with no reply text: %s", oneMegaContextRef, res.Transport.Endpoint, status, excerpt(resp, 300))
+	}
+	t.Logf("%s: POST %s (wire %s) → %d, %d chars of reply text", oneMegaContextRef, res.Transport.Endpoint, res.WireID, status, len(text))
+}
+
+// headerNames lists a header map's names, sorted. Only names: a resolved
+// header map can carry a credential-bearing value, which is never logged.
+func headerNames(h map[string]string) []string {
+	names := make([]string, 0, len(h))
+	for k := range h {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
 // liveBody builds the smallest legal request per protocol from Resolved.
 func liveBody(res registry.Resolved) (string, map[string]any, bool) {
 	body := map[string]any{}

--- a/cmd/evener/models_live_test.go
+++ b/cmd/evener/models_live_test.go
@@ -423,6 +423,117 @@ func assertThinkingShape(t *testing.T, what string, body map[string]any) int {
 	return budget
 }
 
+// bedrockInstance is the implicit instance the amazon-bedrock rows activate
+// as: a curated implicit provider takes its own id as its instance name, and
+// the provider's credential (auth = header) has to resolve before the instance
+// exists at all, so the pin below both needs and asserts a bearer.
+const bedrockInstance = "amazon-bedrock"
+
+// bedrockGlobalWire and bedrockRegionalWire spell the same Sonnet 5 row two
+// ways: through the `global.` cross-region inference profile and through the
+// in-region id. Naming one base id leaves the routing prefix as the only
+// difference between the two legs below. Sonnet 5 is the cheapest catalog row
+// that carries a `global.` prefix and is also served on the Mantle Anthropic
+// endpoint (input 2 / output 10).
+const (
+	bedrockGlobalWire   = "global.anthropic.claude-sonnet-5"
+	bedrockRegionalWire = "anthropic.claude-sonnet-5"
+)
+
+// TestLiveBedrockGlobalRouting pins how the amazon-bedrock rows reach Bedrock
+// (spec §9.3, §15): the base URL is the regional Mantle host built from
+// AWS_REGION, the credential travels as a bearer in x-api-key with no request
+// signing anywhere in the path, and the model id reaches the wire verbatim —
+// prefix included, since the routing prefix is the whole of what would select
+// a cross-region profile. A normalizer that trimmed the prefix would leave a
+// request that still answered 200 from the in-region id, so nothing short of a
+// verbatim wire id catches that.
+//
+// Only the in-region leg sends a request, because on 2026-08-31 the Mantle
+// Anthropic endpoint does not serve the prefixed ids at all. Its own catalog
+// (GET https://bedrock-mantle.{region}.api.aws/v1/models, 200) lists six
+// unprefixed Claude ids — anthropic.claude-{fable-5,haiku-4-5,opus-4-7,
+// opus-4-8,opus-5,sonnet-5} — and asking /anthropic/v1/messages for
+// global.anthropic.claude-sonnet-5 answers 404 not_found_error, "The model
+// 'global.anthropic.claude-sonnet-5' does not exist". That is not an
+// entitlement problem and not stale registry data: `aws bedrock
+// list-inference-profiles` shows global.anthropic.claude-sonnet-5 ACTIVE and
+// SYSTEM_DEFINED in the same account and region, and
+// get-foundation-model-availability reports it AUTHORIZED and AVAILABLE. The
+// two namespaces are simply different — inference-profile ids address
+// bedrock-runtime's InvokeModel/Converse path, which spec §1 puts out of
+// scope, while bedrock-mantle serves the flat catalog above. Spec §9.3's
+// global-routing paragraph is what needs re-deciding; until it is, the global
+// leg is pinned offline only, and sending it would only burn a request on a
+// 404 every run.
+//
+// Gated like TestLiveSmoke, plus the two AWS variables the row is built from,
+// without which no request can be assembled at all. Run with:
+//
+//	EVENER_LIVE_TESTS=1 go test ./cmd/evener/ -run TestLiveBedrockGlobalRouting -v -count=1 -args -live-config=/path/to/providers.toml
+//
+// It never prints a credential value: only the base URL, the wire id, header
+// names, statuses, and the reply's length.
+func TestLiveBedrockGlobalRouting(t *testing.T) {
+	requireLiveGate(t, "the Bedrock global-routing pin")
+	region := os.Getenv(envvars.AWSRegion.Name)
+	if os.Getenv(envvars.AWSBearerTokenBedrock.Name) == "" || region == "" {
+		t.Skipf("set %s and %s to run the Bedrock global-routing pin",
+			envvars.AWSBearerTokenBedrock.Name, envvars.AWSRegion.Name)
+	}
+	r := loadLiveRegistry(t)
+	wantBase := "https://bedrock-mantle." + region + ".api.aws/anthropic/v1"
+	assertBedrockRouting(t, r, bedrockGlobalWire, wantBase)
+	res := assertBedrockRouting(t, r, bedrockRegionalWire, wantBase)
+
+	url, body, ok := liveBody(res)
+	if !ok {
+		t.Fatalf("%s: protocol %s builds no request body", res.ModelID, res.Protocol)
+	}
+	client := &http.Client{Timeout: 90 * time.Second}
+	status, resp := liveRequest(t, client, http.MethodPost, url, body, res)
+	if status != http.StatusOK {
+		t.Fatalf("%s: POST %s (wire %s) → %d: %s", res.ModelID, res.Transport.Endpoint, res.WireID, status, excerpt(resp, 300))
+	}
+	text := strings.TrimSpace(string(liveText(res.Protocol, resp)))
+	if text == "" {
+		t.Fatalf("%s: POST %s → %d with no reply text: %s", res.ModelID, res.Transport.Endpoint, status, excerpt(resp, 300))
+	}
+	t.Logf("%s: POST %s (wire %s) → %d, %d chars of reply text", res.ModelID, res.Transport.Endpoint, res.WireID, status, len(text))
+}
+
+// assertBedrockRouting checks everything the amazon-bedrock row promises about
+// reaching the endpoint for the model id wire, which is both the model half of
+// the reference it resolves and the id the request must carry unchanged. All
+// of it is offline, so it costs no request on either leg.
+func assertBedrockRouting(t *testing.T, r *registry.Registry, wire, wantBase string) registry.Resolved {
+	t.Helper()
+	ref := bedrockInstance + "/" + wire
+	res, err := r.Resolve(ref)
+	if err != nil {
+		t.Fatalf("resolve %s: %v", ref, err)
+	}
+	if res.Synthesized {
+		t.Fatalf("%s: the catalog lists no such row, so the reference was synthesized", ref)
+	}
+	if res.Transport.BaseURL != wantBase {
+		t.Fatalf("%s: base URL %q, want %q", ref, res.Transport.BaseURL, wantBase)
+	}
+	if res.WireID != wire {
+		t.Fatalf("%s: wire id %q, want %q verbatim — the routing prefix must survive resolution", ref, res.WireID, wire)
+	}
+	if res.Transport.Auth != registry.AuthHeader || res.Transport.AuthHeader != "x-api-key" {
+		t.Fatalf("%s: auth %q in header %q, want %q in %q (spec §15: bearer only, never SigV4)",
+			ref, res.Transport.Auth, res.Transport.AuthHeader, registry.AuthHeader, "x-api-key")
+	}
+	if res.Credential.Value == "" {
+		t.Fatalf("%s: no credential resolved (source %s) though %s is set", ref, res.Credential.Source, envvars.AWSBearerTokenBedrock.Name)
+	}
+	t.Logf("%s: base=%s wire=%s protocol=%s auth=%s/%s headers=%v provenance=%s", ref, res.Transport.BaseURL,
+		res.WireID, res.Protocol, res.Transport.Auth, res.Transport.AuthHeader, sortedNames(res.Headers), res.Provenance["model"])
+	return res
+}
+
 // liveWireRecorder keeps the request body of the call it forwards so a
 // property test can assert what actually went on the wire rather than what the
 // builder returned. The bytes it holds carry the prompt and the request it

--- a/cmd/evener/models_live_test.go
+++ b/cmd/evener/models_live_test.go
@@ -355,22 +355,35 @@ func liveRequest(t *testing.T, client *http.Client, method, url string, body map
 	return resp.StatusCode, raw
 }
 
-// liveModelIDs reads the OpenAI-shaped {"data":[{"id":…}]} listing every
-// protocol here uses (Anthropic's /models has the same shape).
+// liveModelIDs reads a models listing in either shape the protocols here
+// answer with: the OpenAI-shaped {"data":[{"id":…}]} (Anthropic's /models
+// matches it) and Gemini's {"models":[{"name":"models/…"}]}, whose ids carry
+// a "models/" prefix no reference outside that listing uses. Reading only the
+// first shape made every Gemini listing look empty, which quietly skipped
+// both the live-layer enrichment and the id-resolves check for the row.
 func liveModelIDs(body []byte) []string {
 	var listing struct {
 		Data []struct {
 			ID string `json:"id"`
 		} `json:"data"`
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
 	}
 	if err := json.Unmarshal(body, &listing); err != nil {
 		return nil
 	}
-	ids := make([]string, 0, len(listing.Data))
-	for _, m := range listing.Data {
-		if m.ID != "" && registry.IsChatModelID(m.ID) {
-			ids = append(ids, m.ID)
+	ids := make([]string, 0, len(listing.Data)+len(listing.Models))
+	add := func(id string) {
+		if id != "" && registry.IsChatModelID(id) {
+			ids = append(ids, id)
 		}
+	}
+	for _, m := range listing.Data {
+		add(m.ID)
+	}
+	for _, m := range listing.Models {
+		add(strings.TrimPrefix(m.Name, "models/"))
 	}
 	sort.Strings(ids)
 	return ids

--- a/cmd/evener/models_live_test.go
+++ b/cmd/evener/models_live_test.go
@@ -212,6 +212,7 @@ func TestLiveOneMegaContextRowAccepted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
+	t.Logf("%s; warnings=%v", r.UserLayerNote(), r.Warnings())
 	res, err := r.Resolve(oneMegaContextRef)
 	if err != nil {
 		t.Fatalf("resolve %s: %v", oneMegaContextRef, err)

--- a/cmd/evener/models_live_test.go
+++ b/cmd/evener/models_live_test.go
@@ -20,6 +20,7 @@ import (
 	"primeradiant.com/evener/internal/credentials"
 	"primeradiant.com/evener/llm"
 	"primeradiant.com/evener/llm/providers/anthropic"
+	"primeradiant.com/evener/llm/providers/tokenauth"
 	"primeradiant.com/evener/llm/registry"
 )
 
@@ -535,6 +536,159 @@ func assertBedrockRouting(t *testing.T, r *registry.Registry, wire, wantBase str
 	return res
 }
 
+// vertexAnthropicInstance is the curated implicit provider both Vertex pins
+// below resolve: google-vertex-anthropic serves Claude on Vertex AI through
+// the vertex-anthropic transport preset (spec §9.4). Resolving it directly
+// by this id works whether or not GOOGLE_VERTEX_PROJECT/LOCATION or ADC let
+// it become a listed instance (spec §5.2), so neither pin needs a
+// -live-config entry naming it.
+const vertexAnthropicInstance = "google-vertex-anthropic"
+
+// vertexClaudeModel is the row both Vertex pins resolve: the provider's own
+// cheap_model (providers_overlay.toml), so the live half below spends the
+// smallest request the row supports.
+const vertexClaudeModel = "claude-haiku-4-5@20251001"
+
+// vertexOfflineProject and vertexOfflineLocation are synthetic
+// GOOGLE_VERTEX_PROJECT/LOCATION values for TestVertexAnthropicRequestShape:
+// a location outside "global"/"us"/"eu" so the assertion exercises the
+// per-region branch of the vertex-location host rule (spec §9.4). vertexHost's
+// own table (llm/registry/hostrules_test.go, TestVertexHost) already covers
+// every branch exhaustively; this pin only needs one location to prove the
+// row's Transport wires that rule end to end.
+const (
+	vertexOfflineProject  = "test-project"
+	vertexOfflineLocation = "us-central1"
+)
+
+// TestVertexAnthropicRequestShape pins what the google-vertex-anthropic row
+// promises about a request before any network is involved (spec §9.4): the
+// resolved base URL follows the vertex-location host rule, both endpoints are
+// path-addressed (:rawPredict, and its streaming twin :streamRawPredict), and
+// the anthropic protocol's real body builder omits "model" from the JSON
+// body since the wire id already lives in the URL path
+// (protocolhttp.ModelInBody). It runs in the ordinary offline suite — no
+// EVENER_LIVE_TESTS, no -live-config, no credential — against the registry's
+// embedded snapshot and overlay, so `go test ./cmd/evener/` alone exercises
+// it. TestLiveVertexOneRequest below sends this exact shape over the wire
+// once ADC is configured.
+func TestVertexAnthropicRequestShape(t *testing.T) {
+	env := map[string]string{
+		envvars.GoogleVertexProject.Name:  vertexOfflineProject,
+		envvars.GoogleVertexLocation.Name: vertexOfflineLocation,
+	}
+	r, err := registry.Load(
+		registry.WithOffline(true),
+		registry.WithoutCache(),
+		registry.WithNoUserLayer(),
+		registry.WithEnv(func(name string) (string, bool) { v, ok := env[name]; return v, ok }),
+	)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	ref := vertexAnthropicInstance + "/" + vertexClaudeModel
+	res, err := r.Resolve(ref)
+	if err != nil {
+		t.Fatalf("resolve %s: %v", ref, err)
+	}
+	if res.Synthesized {
+		t.Fatalf("%s: the catalog lists no such row, so the reference was synthesized", ref)
+	}
+	if res.Transport.Auth != registry.AuthGCPADC {
+		t.Fatalf("%s: auth %q, want %q", ref, res.Transport.Auth, registry.AuthGCPADC)
+	}
+	if res.Transport.HostRule != registry.HostRuleVertexLocation {
+		t.Fatalf("%s: host_rule %q, want %q", ref, res.Transport.HostRule, registry.HostRuleVertexLocation)
+	}
+	wantBase := "https://" + vertexOfflineLocation + "-aiplatform.googleapis.com/v1/projects/" + vertexOfflineProject + "/locations/" + vertexOfflineLocation
+	if res.Transport.BaseURL != wantBase {
+		t.Fatalf("%s: base URL %q, want %q (spec §9.4 host-by-location rule)", ref, res.Transport.BaseURL, wantBase)
+	}
+	if !strings.Contains(res.Transport.Endpoint, "{model}") || !strings.HasSuffix(res.Transport.Endpoint, ":rawPredict") {
+		t.Fatalf("%s: endpoint %q, want a path-addressed :rawPredict endpoint", ref, res.Transport.Endpoint)
+	}
+	if !strings.Contains(res.Transport.StreamEndpoint, "{model}") || !strings.HasSuffix(res.Transport.StreamEndpoint, ":streamRawPredict") {
+		t.Fatalf("%s: stream endpoint %q, want a path-addressed :streamRawPredict endpoint", ref, res.Transport.StreamEndpoint)
+	}
+
+	maxTokens := 64
+	req := llm.Request{
+		Model:     ref,
+		Messages:  []llm.Message{llm.User(liveSmokePrompt)},
+		MaxTokens: &maxTokens,
+	}
+	body, err := anthropic.DefaultProtocol.BuildBody(req, res)
+	if err != nil {
+		t.Fatalf("%s: build body: %v", ref, err)
+	}
+	if _, ok := body["model"]; ok {
+		t.Fatalf("%s: built body carries \"model\"; want it omitted — the wire id (%q) is path-addressed", ref, res.WireID)
+	}
+	t.Logf("%s: base=%s endpoint=%s wire=%s body fields=%v", ref, res.Transport.BaseURL, res.Transport.Endpoint, res.WireID, sortedNames(body))
+}
+
+// requireGCPADC skips the calling test unless application-default
+// credentials resolve through evener's own gcp-adc authenticator
+// (llm/providers/tokenauth.DefaultGCPADC) — the exact seam the live request
+// below authenticates through; gcloud is never shelled out to. The
+// authenticator's own error already names the remedy (`gcloud auth
+// application-default login`, or GOOGLE_APPLICATION_CREDENTIALS), so the skip
+// message only needs to repeat it.
+func requireGCPADC(t *testing.T) {
+	t.Helper()
+	probe, err := http.NewRequest(http.MethodPost, "https://vertex-adc-probe.invalid/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tokenauth.DefaultGCPADC.Apply(context.Background(), probe, registry.Resolved{Instance: vertexAnthropicInstance}); err != nil {
+		t.Skipf("application-default credentials: %v", err)
+	}
+}
+
+// TestLiveVertexOneRequest sends the shape TestVertexAnthropicRequestShape
+// proved offline through a real Vertex endpoint: one pong via :rawPredict,
+// authenticated by the tokenauth gcp-adc source. It skips, cleanly, unless
+// EVENER_LIVE_TESTS + -live-config (requireLiveGate), application-default
+// credentials resolve through evener's own authenticator (requireGCPADC), and
+// GOOGLE_VERTEX_PROJECT/GOOGLE_VERTEX_LOCATION are both set. Run with:
+//
+//	EVENER_LIVE_TESTS=1 go test ./cmd/evener/ -run TestLiveVertexOneRequest -v -count=1 -args -live-config=/path/to/providers.toml
+//
+// It never prints a credential value: only the base URL, the wire id, the
+// status, and the reply's length.
+func TestLiveVertexOneRequest(t *testing.T) {
+	requireLiveGate(t, "the Vertex live pin")
+	requireGCPADC(t)
+	project := os.Getenv(envvars.GoogleVertexProject.Name)
+	location := os.Getenv(envvars.GoogleVertexLocation.Name)
+	if project == "" || location == "" {
+		t.Skipf("set %s and %s to run the Vertex live pin", envvars.GoogleVertexProject.Name, envvars.GoogleVertexLocation.Name)
+	}
+	r := loadLiveRegistry(t)
+	ref := vertexAnthropicInstance + "/" + vertexClaudeModel
+	res, err := r.Resolve(ref)
+	if err != nil {
+		t.Fatalf("resolve %s: %v", ref, err)
+	}
+	url, body, ok := liveBody(res)
+	if !ok {
+		t.Fatalf("%s: protocol %s builds no request body", ref, res.Protocol)
+	}
+	if _, ok := body["model"]; ok {
+		t.Fatalf("%s: request body carries \"model\"; want it omitted — the wire id (%q) is path-addressed", ref, res.WireID)
+	}
+	client := &http.Client{Timeout: 90 * time.Second}
+	status, resp := liveRequest(t, client, http.MethodPost, url, body, res)
+	if status != http.StatusOK {
+		t.Fatalf("%s: POST %s (wire %s) → %d: %s", ref, res.Transport.Endpoint, res.WireID, status, excerpt(resp, 300))
+	}
+	text := strings.TrimSpace(string(liveText(res.Protocol, resp)))
+	if text == "" {
+		t.Fatalf("%s: POST %s → %d with no reply text: %s", ref, res.Transport.Endpoint, status, excerpt(resp, 300))
+	}
+	t.Logf("%s: POST %s (wire %s) → %d, %d chars of reply text", ref, res.Transport.Endpoint, res.WireID, status, len(text))
+}
+
 // liveWireRecorder keeps the request body of the call it forwards so a
 // property test can assert what actually went on the wire rather than what the
 // builder returned. The bytes it holds carry the prompt and the request it
@@ -621,7 +775,10 @@ func liveSetPath(body map[string]any, path string, v any) {
 }
 
 // liveRequest performs one request with the resolved auth and headers and
-// returns the status and body. It never logs a credential value.
+// returns the status and body. gcp-adc mints its bearer through
+// tokenauth.DefaultGCPADC — the same production seam TestLiveVertexOneRequest
+// gates on — rather than a value already sitting in res.Credential.Value.
+// It never logs a credential value.
 func liveRequest(t *testing.T, client *http.Client, method, url string, body map[string]any, res registry.Resolved) (int, []byte) {
 	t.Helper()
 	var payload io.Reader
@@ -645,6 +802,10 @@ func liveRequest(t *testing.T, client *http.Client, method, url string, body map
 		}
 	case registry.AuthHeader:
 		req.Header.Set(res.Transport.AuthHeader, res.Credential.Value)
+	case registry.AuthGCPADC:
+		if err := tokenauth.DefaultGCPADC.Apply(ctx, req, res); err != nil {
+			t.Fatalf("%s %s: application-default credentials: %v", method, url, err)
+		}
 	}
 	for k, v := range res.Headers {
 		req.Header.Set(k, v)

--- a/cmd/evener/models_live_test.go
+++ b/cmd/evener/models_live_test.go
@@ -724,6 +724,41 @@ func sortedNames[V any](m map[string]V) []string {
 	return names
 }
 
+// TestLiveTextReasoningOnly runs offline. It pins what liveText reports for
+// the Chat Completions shape both openrouter/minimax/minimax-m2.7 and
+// lunaroute/glm-5.2-vision answered with on 2026-08-31 (issue #715): a null
+// content, the reasoning in its own field, and finish_reason "length" because
+// the model spent the whole output cap thinking. The log line has to name the
+// truncation, since that — not a lost reply — is why there is no text.
+func TestLiveTextReasoningOnly(t *testing.T) {
+	body := []byte(`{"choices":[{"finish_reason":"length","message":{"role":"assistant","content":null,` +
+		`"refusal":null,"reasoning":"still deciding","reasoning_details":[{"type":"reasoning.text","text":"still deciding"}]}}]}`)
+	got := string(liveText(registry.ProtocolOpenAIChat, body))
+	want := "<no content; finish=length, message carried [reasoning reasoning_details role]>"
+	if got != want {
+		t.Fatalf("liveText = %q, want %q", got, want)
+	}
+
+	answered := []byte(`{"choices":[{"finish_reason":"stop","message":{"role":"assistant","content":"pong"}}]}`)
+	if got := string(liveText(registry.ProtocolOpenAIChat, answered)); got != "pong" {
+		t.Fatalf("liveText = %q, want %q for a message that did carry content", got, "pong")
+	}
+}
+
+// liveValuedNames lists the keys of a wire object whose value is not JSON
+// null, sorted. Names only, under the same rule as sortedNames: it reports
+// what a message carried without printing any of it.
+func liveValuedNames(m map[string]any) []string {
+	names := make([]string, 0, len(m))
+	for k, v := range m {
+		if v != nil {
+			names = append(names, k)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
 // liveBody builds the smallest legal request per protocol from Resolved.
 func liveBody(res registry.Resolved) (string, map[string]any, bool) {
 	body := map[string]any{}
@@ -866,6 +901,12 @@ func liveModelIDs(body []byte) []string {
 }
 
 // liveText extracts the reply text per protocol for the log line.
+//
+// A reasoning model that spends this smoke's whole 64-token output cap
+// thinking answers 200 with a null content and its reasoning in a separate
+// field. Printing what the message did carry, plus the finish reason, is what
+// tells that apart from an extraction that lost the reply — a bare "<nil>"
+// reads as the latter and was filed as issue #715 when it was the former.
 func liveText(protocol string, body []byte) []byte {
 	var doc map[string]any
 	if err := json.Unmarshal(body, &doc); err != nil {
@@ -874,8 +915,13 @@ func liveText(protocol string, body []byte) []byte {
 	switch protocol {
 	case registry.ProtocolOpenAIChat:
 		if choices, ok := doc["choices"].([]any); ok && len(choices) > 0 {
-			if msg, ok := choices[0].(map[string]any)["message"].(map[string]any); ok {
-				return []byte(fmt.Sprint(msg["content"]))
+			choice, _ := choices[0].(map[string]any)
+			if msg, ok := choice["message"].(map[string]any); ok {
+				if content, ok := msg["content"].(string); ok && content != "" {
+					return []byte(content)
+				}
+				return fmt.Appendf(nil, "<no content; finish=%v, message carried %v>",
+					choice["finish_reason"], liveValuedNames(msg))
 			}
 		}
 	case registry.ProtocolOpenAIResponses:

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -228,7 +228,7 @@ openai/gpt-5.6` work on a machine with no key set.
 | `zai-coding-plan` | `ZHIPU_API_KEY` (the same key as `zai`) | `ZAI_CODING_PLAN_BASE_URL` (`https://api.z.ai/api/coding/paas/v4`) | `thinking_format = zai`; `default_model = glm-5.3`, `cheap_model = glm-5.3-flash` |
 | `google-vertex-anthropic` | none — `gcp-adc` (`GOOGLE_APPLICATION_CREDENTIALS` or the well-known ADC file) | n/a — host derived from `GOOGLE_VERTEX_LOCATION` | also needs `GOOGLE_VERTEX_PROJECT` to exist at all; surface `anthropic`, family `claude`; `default_model = claude-opus-5`, `cheap_model = claude-haiku-4-5@20251001` |
 | `google-vertex` | none — `gcp-adc` | n/a — same host derivation | also needs `GOOGLE_VERTEX_PROJECT`; surface `google`; `default_model = gemini-3.7-flash`, `cheap_model = gemini-2.5-flash-lite` |
-| `amazon-bedrock` | `AWS_BEARER_TOKEN_BEDROCK` | n/a — host built from `AWS_REGION` | surface `anthropic`, family `claude`; `default_model = global.anthropic.claude-opus-5`, `cheap_model = global.anthropic.claude-haiku-4-5-20251001-v1:0` |
+| `amazon-bedrock` | `AWS_BEARER_TOKEN_BEDROCK` | n/a — host built from `AWS_REGION` | surface `anthropic`, family `claude`; `default_model = anthropic.claude-opus-5`, `cheap_model = anthropic.claude-haiku-4-5` (unprefixed — see [Cloud transports](#cloud-transports-azure-bedrock-vertex) below) |
 | `azure` | `AZURE_API_KEY` | n/a — needs `AZURE_RESOURCE_NAME` | no curated `default_model` (deployment names are per-tenant) — a bare `azure` reference can't resolve without one, and a real deployment needs its own `providers.toml` row (`alias_of`; see [Cloud transports](#cloud-transports-azure-bedrock-vertex) below). With just the key and resource name set, `azure` still exists as an instance, addressable as `azure/<deployment>` |
 | `ollama` | none required; `auth = optional-bearer`, `OLLAMA_API_KEY` optional | `OLLAMA_HOST` (default `localhost`, normalized by the `ollama-host` rule) or `OLLAMA_BASE_URL` (wins when set) | no curated `default_model` — see [`ollama.md`](ollama.md) for the "never the default" rule; provider-level `context_window = 131072` |
 
@@ -474,11 +474,15 @@ alias_of = "claude-opus-4-5"  # facts, the anthropic protocol, the Foundry /anth
 
 **Bedrock.** `amazon-bedrock` uses Anthropic's Messages API on
 `bedrock-mantle` (`https://bedrock-mantle.{AWS_REGION}.api.aws/anthropic/v1`),
-bearer token via `x-api-key`. Global/regional routing is expressed in the
-model id (`global.`, `us.`, `eu.`, `jp.`, `au.` inference-profile ids), not
-the host. Nine Mantle OpenAI-shaped rows (gpt-oss, gpt-5.x, grok) also exist,
-via a separate bearer-auth preset. Token counting is estimate-only — exact
-counting is tracked as
+bearer token via `x-api-key`. Mantle serves exactly the six unprefixed Claude
+ids its own `/v1/models` catalog lists; `global.`/`us.`/`eu.`/`jp.`/`au.`
+inference-profile ids resolve for metadata and stay usable by explicit
+reference, but are hidden from `evener models list` and 404 on this endpoint
+(verified live 2026-08-31 — see spec §9.3) because they address
+`bedrock-runtime`'s `InvokeModel`/`Converse` path, not Mantle. Nine Mantle
+OpenAI-shaped rows (gpt-oss, gpt-5.x, grok) also exist, via a separate
+bearer-auth preset. Token counting is estimate-only — exact counting is
+tracked as
 [issue #565](https://github.com/prime-radiant-inc/evener/issues/565).
 
 **Vertex.** Host is derived from location: `global` →

--- a/docs/superpowers/plans/2026-08-31-provider-registry-step4.md
+++ b/docs/superpowers/plans/2026-08-31-provider-registry-step4.md
@@ -37,7 +37,7 @@
 - Test: a dry run of the wrapper proving isolation
 
 **Interfaces:**
-- Produces: `scripts/live/with-live-env [--config <providers.toml>] -- <command…>` — builds a fake `HOME` (mktemp), exports `EVENER_STATE_DIR=$HOME/state`, `EVENER_PROVIDERS_CONFIG` (default: a copy of the repo-root live config written by this script from a committed template with NO secrets), `EVENER_CREDENTIALS_CONFIG` pointing at the DEVELOPER's real store only when `--store` is passed, sources `~/git/prime-radiant/serf/.env` into the process env when present (never echoing values), then execs the command.
+- Produces: `scripts/live/with-live-env [--config <providers.toml>] -- <command…>` — builds a fake `HOME` (mktemp), exports `EVENER_STATE_DIR=$HOME/state`, `EVENER_PROVIDERS_CONFIG` (default: an absent path inside the fake home — the registry treats it as "user layer: none" and implicit instances come from the sourced env; `--config` copies a given providers.toml into the fake home instead), `EVENER_CREDENTIALS_CONFIG` pointing at the DEVELOPER's real store only when `--store` is passed, sources `~/git/prime-radiant/serf/.env` into the process env when present (never echoing values), then execs the command.
 
 - [ ] **Step 1: Write the wrapper** with `set -euo pipefail`, a `--help`, and a comment block naming every variable it exports. It must `chmod 700` the fake home and delete it on exit unless `--keep`.
 - [ ] **Step 2: Prove isolation**: `scripts/live/with-live-env -- sh -c 'echo $HOME'` prints a temp path; run it again with `EVENER_LIVE_TESTS=1 go test ./cmd/evener/ -run TestLiveSmoke -count=1` WITHOUT `-args -live-config` and confirm the suite skips cleanly (no config → skip), touching nothing under the real `~/.config/evener` (assert by mtime).

--- a/docs/superpowers/plans/2026-08-31-provider-registry-step4.md
+++ b/docs/superpowers/plans/2026-08-31-provider-registry-step4.md
@@ -1,0 +1,143 @@
+# Provider Registry Step 4: Cloud Live Verification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove the registry's cloud rows against real endpoints (spec §13 "Live"), update the `[1m]` rows to GA, and close the two live-found issues (#714 minimal-budget floor, #715 empty-text extractions) — using only the credentials actually available on this machine, lightly, under an isolated fake homedir.
+
+**Architecture:** No new subsystems. Live tests extend the existing `EVENER_LIVE_TESTS=1`-gated files (`cmd/evener/models_live_test.go`, `llm/integration_smoke_test.go`); every run uses a scoped fake `HOME` with explicit `EVENER_PROVIDERS_CONFIG`/`EVENER_CREDENTIALS_CONFIG`/`EVENER_STATE_DIR`; credentials come from `~/git/prime-radiant/serf/.env` (Anthropic, OpenAI, Gemini, OpenRouter, Moonshot) plus the store (kimi, lunaroute, openrouter) and the local AWS CLI. Code changes are data (overlay rows), one effort-floor fix, and whatever #715's diagnosis demands.
+
+**Tech Stack:** Go 1.27 go.work workspace; `llm/registry` overlay + models.dev snapshot; the four protocol packages.
+
+**Spec:** docs/superpowers/specs/2026-08-28-provider-registry-design.md — §9.2–9.4 (cloud transports), §13 "Live" (`[1m]`, Groq Responses, Bedrock `global.` routing, Kimi K3 thinking shape, MiniMax M3 budget object, one request per cloud transport), §15 (Bedrock bearer-only; Vertex/Bedrock counting estimate-only).
+
+## Global Constraints
+
+- **Light use**: one request per (instance, model, property) — smoke-sized prompts ("Reply with the single word: pong"); never loops of live calls; every live test skips (never fails) when its credential is absent.
+- **Credentials never printed, logged, committed, or placed in argv**: keys load from `~/git/prime-radiant/serf/.env` / the store / `aws` into process env only; test output shows sources and header NAMES only (the existing `models_live_test.go` discipline).
+- **Isolated fake homedir for every live run**: `HOME=$(mktemp -d)` with explicit `EVENER_PROVIDERS_CONFIG`, `EVENER_CREDENTIALS_CONFIG`, `EVENER_STATE_DIR`; the developer's real `~/.config/evener` and `~/.local/state/evener` are never read or written by live tests.
+- Offline suites stay offline: nothing gated on `EVENER_LIVE_TESTS` may run in the normal gate; `make lint` 9/9; the full gate green apart from the accepted roster (agent/sandbox bwrap 2/7; root-fuzz appwire fixture test).
+- Flag day (spec §14.1) still binds: no compat shims in any code change.
+- Unavailable credentials (Azure, Groq, MiniMax-direct, Vertex-without-ADC) produce a SKIPPED row in the report naming exactly what is missing — never a silent gap.
+
+## File Structure
+
+- `cmd/evener/models_live_test.go` — extend `liveSmokeModels` + add per-property live tests ([1m], thinking shapes, budget objects, Bedrock global routing).
+- `llm/registry/data/providers_overlay.toml` — `[1m]` GA rows; any Bedrock/vertex row corrections live testing exposes.
+- `llm/types.go` (or wherever `ReasoningBudget` lives) + tests — #714 floor.
+- `#715`: diagnosis decides (likely `llm/providers/chatcompletions` response folding); tests beside it.
+- `docs/llm-providers.md`, the spec — [1m] GA language; anything live testing corrects.
+- `.superpowers/sdd/<this plan>/live-report.md` — the per-row verification report (gitignored).
+
+---
+
+### Task 1: The live-run harness recipe and credential inventory
+
+**Files:**
+- Create: `scripts/live/with-live-env` (small sourcing wrapper, documented)
+- Test: a dry run of the wrapper proving isolation
+
+**Interfaces:**
+- Produces: `scripts/live/with-live-env [--config <providers.toml>] -- <command…>` — builds a fake `HOME` (mktemp), exports `EVENER_STATE_DIR=$HOME/state`, `EVENER_PROVIDERS_CONFIG` (default: a copy of the repo-root live config written by this script from a committed template with NO secrets), `EVENER_CREDENTIALS_CONFIG` pointing at the DEVELOPER's real store only when `--store` is passed, sources `~/git/prime-radiant/serf/.env` into the process env when present (never echoing values), then execs the command.
+
+- [ ] **Step 1: Write the wrapper** with `set -euo pipefail`, a `--help`, and a comment block naming every variable it exports. It must `chmod 700` the fake home and delete it on exit unless `--keep`.
+- [ ] **Step 2: Prove isolation**: `scripts/live/with-live-env -- sh -c 'echo $HOME'` prints a temp path; run it again with `EVENER_LIVE_TESTS=1 go test ./cmd/evener/ -run TestLiveSmoke -count=1` WITHOUT `-args -live-config` and confirm the suite skips cleanly (no config → skip), touching nothing under the real `~/.config/evener` (assert by mtime).
+- [ ] **Step 3: Commit** (`git add scripts/live/with-live-env && git commit -m "test(live): scoped fake-home wrapper for live verification runs"`).
+
+### Task 2: `[1m]` is GA — rows, docs, and the live pin
+
+**Files:**
+- Modify: `llm/registry/data/providers_overlay.toml` (the two `[1m]` rows at ~:107-117), `docs/llm-providers.md`, the spec's §13 live row (one clause)
+- Test: `cmd/evener/models_live_test.go` (a `[1m]` property test), `llm/registry` goldens
+
+**Interfaces:**
+- Consumes: `ANTHROPIC_API_KEY` from the .env; the anthropic protocol.
+
+- [ ] **Step 1 (investigate before editing):** with the Task-1 wrapper, send ONE live `/messages` request on `anthropic/claude-sonnet-4-5[1m]` as the rows stand (beta header on) and ONE with the header stripped (a local overlay override in the fake home's config), each asking for the single word pong with a `context_window`-sized prompt NOT sent (small prompt; the property under test is acceptance, not the window). Record both statuses.
+- [ ] **Step 2:** if the headerless request is accepted (GA confirmed): update the overlay comment ("[1m] rows exist only where the 1M window is a beta" → GA wording), drop the `anthropic-beta` headers, keep the rows (the id spelling and 1M window facts remain useful), regenerate any goldens (`make fuzz-goldens` if a corpus seed covers the rows), and update `docs/llm-providers.md` + the spec §13 clause. If the header is still REQUIRED, keep it, correct nothing, and record the finding — the human partner's belief is then out of date and the report says so with the status line.
+- [ ] **Step 3:** add `TestLiveOneMegaContextRowAccepted` beside `TestLiveSmoke` (gated the same way): resolve `anthropic/claude-sonnet-4-5[1m]`, assert the resolved window is 1_000_000+, send the one pong request, assert 200 and non-empty text.
+- [ ] **Step 4:** offline gate for the touched packages + commit.
+
+### Task 3: The direct-provider live matrix
+
+**Files:**
+- Modify: `cmd/evener/models_live_test.go` (`liveSmokeModels` additions + two property tests)
+
+**Interfaces:**
+- Consumes: ANTHROPIC/OPENAI/GEMINI/OPENROUTER/MOONSHOT keys from the .env; the store's kimi/lunaroute keys via `--store`.
+
+- [ ] **Step 1:** extend `liveSmokeModels` so the smoke covers, one model each: `anthropic` (claude-haiku-4-5), `openai` (gpt-4.1-nano over Responses — assert the request went to `/responses`), `google` (gemini-2.5-flash-lite), `moonshotai` (kimi-k2.5), plus the already-proven openrouter/kimi/lunaroute rows.
+- [ ] **Step 2:** add `TestLiveKimiK3ThinkingShape` (spec §13): one k3 request with a reasoning effort set; assert the response carries thinking content and the request body used the anthropic thinking shape the registry resolved (log the shape fields, not the payload).
+- [ ] **Step 3:** run the matrix once under the wrapper with the .env + `--store`; every available row green; capture the per-row log into the live report.
+- [ ] **Step 4:** commit.
+
+### Task 4: Bedrock — token acquisition and `global.` routing
+
+**Files:**
+- Create: nothing new unless the investigation demands a row fix
+- Test: `cmd/evener/models_live_test.go` (`TestLiveBedrockGlobalRouting`)
+
+**Interfaces:**
+- Consumes: the local AWS CLI (account verified reachable); `amazon-bedrock` rows (bearer via `AWS_BEARER_TOKEN_BEDROCK`, spec §9.3/§15 — bearer only, no SigV4).
+
+- [ ] **Step 1 (investigate):** determine how to obtain a Bedrock bearer token from the local CLI credentials: check `aws bedrock` / `aws bedrock-runtime` CLI surface and AWS's documented bearer-token path for `bedrock-mantle` (the `aws-bedrock-token-generator` mechanism or a console-issued API key). Document the working command in the report. If NO bearer token is obtainable without console action, stop this task with a one-line ask for the human partner (a console-issued key pasted into the .env) and mark the row BLOCKED-ON-CREDENTIAL in the report — do not implement SigV4 (spec §15 forbids it).
+- [ ] **Step 2 (with a token):** `TestLiveBedrockGlobalRouting`: resolve `bedrock/global.anthropic.claude-haiku-4-5` (or the cheapest global profile the catalog lists), assert the resolved base URL is the regional mantle host and the wire id keeps the `global.` prefix verbatim, send one pong request, assert 200. One more request on the in-region id (`anthropic.…`) for the non-global leg.
+- [ ] **Step 3:** offline gate + commit.
+
+### Task 5: Vertex, and the unavailable rows
+
+**Files:**
+- Test: `cmd/evener/models_live_test.go` (`TestLiveVertexOneRequest`, skip-gated on ADC)
+
+**Interfaces:**
+- Consumes: `gcp-adc` (gcloud present; ADC currently unconfigured — the test SKIPS with the exact remedy `gcloud auth application-default login`).
+
+- [ ] **Step 1:** `TestLiveVertexOneRequest`: skip unless ADC resolves (probe via the tokenauth gcp-adc source, not gcloud exec); with ADC: resolve a `google-vertex-anthropic` claude row for the project/location taken from `GOOGLE_VERTEX_PROJECT`/`GOOGLE_VERTEX_LOCATION` env (skip naming them when unset), send one pong via `:rawPredict`, assert 200 and that `model` was omitted from the body (path-addressed).
+- [ ] **Step 2:** the report's skip rows: `azure` (no `AZURE_API_KEY` anywhere on this machine), `groq` (no `GROQ_API_KEY` — spec §13's Groq-Responses row stays open), `minimax` direct (no `MINIMAX_API_KEY`; M3's budget object gets a partial check via `openrouter/minimax/minimax-m3` IF openrouter lists it — one attempted request, recorded either way), `vertex` when ADC is unconfigured. Each row names the exact missing credential.
+- [ ] **Step 3:** commit.
+
+### Task 6: #714 — the minimal-effort thinking budget floor
+
+**Files:**
+- Modify: the `ReasoningBudget` mapping in `llm` (locate via `grep -rn 'ReasoningBudget' llm/`), its unit tests
+- Test: one live pin on `anthropic` (budget-shaped row)
+
+- [ ] **Step 1 (RED):** unit test: `minimal` on a budget-shaped row yields a budget ≥ 1024 (Anthropic's floor); today it yields 512 — watch it fail.
+- [ ] **Step 2:** clamp budget-shaped `minimal` to 1024 (the plainest fix; keep effort-shaped `minimal` untouched); doc comment cites Anthropic's minimum and #714.
+- [ ] **Step 3 (live):** one request on `anthropic/claude-haiku-4-5` with `--reasoning-effort minimal` equivalents through the session path (`evener run` under the wrapper) — assert 200, no wire rejection.
+- [ ] **Step 4:** offline gate + commit; note the fix on #714.
+
+### Task 7: #715 — the empty-text 200s
+
+**Files:**
+- Diagnosis decides; likely `llm/providers/chatcompletions` response folding + a fixture from the captured live body
+
+- [ ] **Step 1 (capture):** re-run the smoke rows that returned empty (`openrouter/minimax/minimax-m2.7`, `lunaroute/glm-5.2-vision`) once each with the raw body logged to the live report (bodies are provider OUTPUT — safe to capture; still grep them for header echoes before committing any excerpt).
+- [ ] **Step 2 (classify):** if the text lives in a reasoning-only field the production `Response.Text()` also misses, that is a real folding gap: write the failing fixture test from the captured body (offline), fix the folding, re-run the live row (text non-empty). If production folds it fine and only the smoke's extractor was thin, fix the smoke's extractor and say so on #715.
+- [ ] **Step 3:** commit; note findings on #715.
+
+### Task 8: Report, docs sync, and issue closures
+
+**Files:**
+- Create: `.superpowers/sdd/2026-08-31-provider-registry-step4/live-report.md` (gitignored path)
+- Modify: `docs/llm-providers.md` / the spec only where live results contradicted them
+
+- [ ] **Step 1:** assemble the per-row report: every §13 live row → VERIFIED (with the one-line evidence) | SKIPPED (missing credential, named) | BLOCKED (Task 4's ask) | CORRECTED (what changed).
+- [ ] **Step 2:** update #716 with the report summary; close/comment #714 and #715 per their outcomes.
+- [ ] **Step 3:** full offline gate; commit anything outstanding.
+
+## Spec coverage
+
+| Spec §13 live row | Task |
+|---|---|
+| `[1m]` on Sonnet 4.5 / Opus 4.5 | 2 |
+| Kimi K3 thinking shape | 3 |
+| Bedrock `global.` routing | 4 |
+| One request per cloud transport | 4 (bedrock), 5 (vertex; azure skipped-with-note) |
+| Groq Responses | 5 (skip row — no credential) |
+| MiniMax M3 budget object | 5 (partial via openrouter; direct key absent) |
+
+## Rulings
+
+- `[1m]` GA is the human partner's statement (2026-08-31); Task 2 verifies live before editing rows — evidence beats belief in both directions.
+- Bedrock stays bearer-only (spec §15); a missing bearer is a credential ask, never a SigV4 implementation.
+- Light use is a hard rule: a task that wants a second request per property must justify it in its report.

--- a/docs/superpowers/specs/2026-08-28-provider-registry-design.md
+++ b/docs/superpowers/specs/2026-08-28-provider-registry-design.md
@@ -2265,8 +2265,10 @@ files are renamed or deleted.
   survive as a feature with models.dev's URL convention.
 - Bedrock via Anthropic's Messages endpoint on `bedrock-mantle`, bearer
   token only. No SigV4, no event-stream framing, no AWS SDK dependency.
-  Global routing ships now, as `global.` inference-profile model ids on the
-  regional host (Jesse verified live, 2026-08-28).
+  Inference-profile ids (`global.`/`us.`/…) resolve for metadata but are
+  hidden from listings — the Mantle endpoint serves only unprefixed Claude ids
+  (§9.3, verified live 2026-08-31; the 2026-08-28 global verification predates
+  this and its path is an open question).
 - Surface is a model attribute derived from models.dev `family`; the
   provider fallback applies only to family-less and synthesized rows.
 - 413 stays a context-length error; the classifier's new work is the

--- a/docs/superpowers/specs/2026-08-28-provider-registry-design.md
+++ b/docs/superpowers/specs/2026-08-28-provider-registry-design.md
@@ -752,22 +752,24 @@ the merge order of §4.1 applies to them.
   transport's own behaviors are enumerated in §9.5.
 - **Anthropic**: `CacheTTL`, `WebSearch = true`, and the corrections to
   upstream: `claude-sonnet-4-5` and `claude-sonnet-4-5-20250929` pinned to
-  `context_window = 200000` (models.dev says 1000000; Anthropic's
-  context-window page, fetched 2026-08-28, lists 1M only for Opus 4.6+,
-  Sonnet 4.6+, Sonnet 5, Fable 5, Mythos, says Sonnet 4.5 is 200k, and says
-  "no beta header" for the 1M models; models.dev already has Opus 4.5 and
-  Haiku 4.5 at 200000; the same Sonnet 4.5 rows on gateways are left to
-  those gateways' live listings). **`[1m]` rows** where the base row's window
-  is not the 1M one: `claude-sonnet-4-5[1m]`, `claude-sonnet-4-5-20250929[1m]`,
-  `claude-opus-4-5[1m]`, and `claude-opus-4-5-20251101[1m]`, each `alias_of`
-  and `wire_id` naming the base row and `context_window = 1000000`. Only the
-  Opus 4.5 pair carries `headers = { anthropic-beta =
-  "context-1m-2025-08-07" }`: Sonnet 4.5's 1M window went GA (verified live
-  2026-08-31 — `/v1/models` reports `max_input_tokens = 1000000` with and
-  without the beta, and `/messages` accepts a headerless request), so its
-  rows send no header and the live test in §13 pins that. The 4.6+ rows are 1M
-  natively, so `claude-opus-4-6[1m]` is not a row and a saved ref spelled
-  that way fails to resolve (flag day, §14.1).
+  `context_window = 1000000`, agreeing with models.dev. Anthropic's
+  context-window page, fetched 2026-08-28, said Sonnet 4.5 was 200k and the
+  rows were pinned down to match; live verification on 2026-08-31 overrode
+  that — `/v1/models` reports `max_input_tokens = 1000000` for both spellings
+  with and without the `context-1m-2025-08-07` beta, so the 1M window is GA
+  and the pin now records it. models.dev already has Opus 4.5 and Haiku 4.5
+  at 200000; the same Sonnet 4.5 rows on gateways are left to those gateways'
+  live listings. **`[1m]` rows** where the base row's window is not the 1M
+  one: `claude-opus-4-5[1m]` and `claude-opus-4-5-20251101[1m]`, each
+  `alias_of` and `wire_id` naming the base row, `context_window = 1000000`,
+  and `headers = { anthropic-beta = "context-1m-2025-08-07" }` — Opus 4.5's
+  1M is still a beta opt-in (`/v1/models` reports 200000 for it either way).
+  `claude-sonnet-4-5[1m]` and `claude-sonnet-4-5-20250929[1m]` survive as
+  **pure alias rows** — no window, no header — solely to keep the `[1m]`
+  spelling resolvable and fold it onto the base row (§7, `canonicalModelID`);
+  the live test in §13 pins that they still resolve and are accepted. The
+  4.6+ rows are 1M natively, so `claude-opus-4-6[1m]` is not a row and a
+  saved ref spelled that way fails to resolve (flag day, §14.1).
   Two Mythos rows models.dev lacks under `anthropic`: `claude-mythos-5` with
   `alias_of = "azure/claude-mythos-5"` (facts only; the transport stays
   `anthropic`'s, §4.2), and `claude-mythos-preview` with `context_window`,
@@ -1969,7 +1971,8 @@ error types is removed; `Provider()` returns the instance name and a new
   and the exact header set without org/project),
   `anthropic/claude-sonnet-4-5` and `anthropic/claude-sonnet-4-5[1m]`
   (asserting `budget` shape, no always-on; the `[1m]` row also `WireID`,
-  window 1000000, and beta header), `anthropic/claude-opus-4-6[1m]`
+  window 1000000 reached through the alias fold, and no beta header),
+  `anthropic/claude-opus-4-6[1m]`
   (asserting it is unknown: synthesized row, wire id verbatim, `model not
   in catalog`), `anthropic/claude-haiku-4-5` (`budget`),
   `anthropic/claude-opus-4-6` with

--- a/docs/superpowers/specs/2026-08-28-provider-registry-design.md
+++ b/docs/superpowers/specs/2026-08-28-provider-registry-design.md
@@ -757,12 +757,15 @@ the merge order of §4.1 applies to them.
   Sonnet 4.6+, Sonnet 5, Fable 5, Mythos, says Sonnet 4.5 is 200k, and says
   "no beta header" for the 1M models; models.dev already has Opus 4.5 and
   Haiku 4.5 at 200000; the same Sonnet 4.5 rows on gateways are left to
-  those gateways' live listings). **`[1m]` rows** only where the 1M window
-  is a beta: `claude-sonnet-4-5[1m]`, `claude-sonnet-4-5-20250929[1m]`,
+  those gateways' live listings). **`[1m]` rows** where the base row's window
+  is not the 1M one: `claude-sonnet-4-5[1m]`, `claude-sonnet-4-5-20250929[1m]`,
   `claude-opus-4-5[1m]`, and `claude-opus-4-5-20251101[1m]`, each `alias_of`
-  and `wire_id` naming the base row, `context_window = 1000000`, and
-  `headers = { anthropic-beta = "context-1m-2025-08-07" }` (the live test in
-  §13 verifies the beta still works before they ship). The 4.6+ rows are 1M
+  and `wire_id` naming the base row and `context_window = 1000000`. Only the
+  Opus 4.5 pair carries `headers = { anthropic-beta =
+  "context-1m-2025-08-07" }`: Sonnet 4.5's 1M window went GA (verified live
+  2026-08-31 — `/v1/models` reports `max_input_tokens = 1000000` with and
+  without the beta, and `/messages` accepts a headerless request), so its
+  rows send no header and the live test in §13 pins that. The 4.6+ rows are 1M
   natively, so `claude-opus-4-6[1m]` is not a row and a saved ref spelled
   that way fails to resolve (flag day, §14.1).
   Two Mythos rows models.dev lacks under `anthropic`: `claude-mythos-5` with
@@ -2052,7 +2055,9 @@ error types is removed; `Provider()` returns the instance name and a new
   constructs adapters by struct literal and calls the two-argument interface
   today (`differential_fuzz_test.go:89-92`), so it moves to `Resolved`
   inputs; the openai-compat leg becomes the `chatcompletions` leg.
-- **Live** (`EVENER_LIVE_TESTS=1`): the `[1m]` beta on Sonnet 4.5 and Opus
+- **Live** (`EVENER_LIVE_TESTS=1`): the Sonnet 4.5 `[1m]` row, whose 1M
+  window is GA and whose request therefore carries no beta header
+  (`TestLiveOneMegaContextRowAccepted`); the `[1m]` beta on Opus
   4.5, Groq Responses, Bedrock `global.` routing, Kimi K3's thinking shape,
   MiniMax M3's budget object, and one request per cloud transport once
   step 4 lands.

--- a/docs/superpowers/specs/2026-08-28-provider-registry-design.md
+++ b/docs/superpowers/specs/2026-08-28-provider-registry-design.md
@@ -587,16 +587,18 @@ https://${AZURE_RESOURCE_NAME}.services.ai.azure.com/anthropic/v1`), and
 Vertex's Claude rows under `google-vertex` (`npm:
 @ai-sdk/google-vertex/anthropic`, no `api`) resolve without curated rows.
 
-Row-level hiding (`Model.Hidden`, recomputed after merge and cleared when
-any layer or a same-provider alias import supplies a `protocol` or
-`transport` for the row): an `amazon-bedrock` row with no per-model
-override whose id, after the region prefix, does not start with
-`anthropic.` (the Messages endpoint serves Claude only, and the seven OpenAI
-rows without a Mantle override, such as `global.openai.gpt-5.6-sol`, would
-otherwise resolve to it); a `google-vertex` row whose id contains `/` and
-carries no per-model `api` (models.dev lists `openai/gpt-oss-*-maas` without
-the MaaS template); and every row of a `Hidden` provider. Rows whose
-`modalities.output` lacks `text` are dropped outright, not hidden.
+Row-level hiding (`Model.Hidden`, recomputed after merge and cleared when any
+layer or a same-provider alias import supplies a `protocol` or `transport`
+for the row): an `amazon-bedrock` row with no per-model override that
+carries a region prefix (hidden regardless of what follows it, such as
+`global.openai.gpt-5.6-sol` or even `global.anthropic.claude-sonnet-5`,
+since the Mantle endpoint serves only the six unprefixed Claude ids) or,
+unprefixed, does not start with `anthropic.` (the seven OpenAI rows without
+a Mantle override would otherwise resolve to the Messages endpoint); a
+`google-vertex` row whose id contains `/` and carries no per-model `api`
+(models.dev lists `openai/gpt-oss-*-maas` without the MaaS template);
+and every row of a `Hidden` provider. Rows whose `modalities.output` lacks
+`text` are dropped outright, not hidden.
 
 **Base URL convention.** models.dev base URLs include the version segment
 (`…/v1`, `…/anthropic/v1`, `…/paas/v4`; DeepSeek's `https://api.deepseek.com`

--- a/docs/superpowers/specs/2026-08-28-provider-registry-design.md
+++ b/docs/superpowers/specs/2026-08-28-provider-registry-design.md
@@ -1509,17 +1509,33 @@ dedicated client and is not supported here. So:
   marks the Sonnet 5, Haiku 4.5, Sonnet 4.6, Opus 4.5, and Opus 4.6 rows
   `structured_output: true` at the row level, which the layer-3 glob beats
   under §4.1's merge order; the Mantle OpenAI rows keep their own values).
-- **Global vs regional routing** is expressed in the model id, not the
-  host: `bedrock-mantle` hosts are regional (AWS lists fourteen,
-  `bedrock-mantle.<region>.api.aws`), and AWS's cross-Region inference
-  routes a request whose model is a `global.`, `us.`, `eu.`, `jp.`, or
-  `au.` inference-profile id across the profile's regions. models.dev lists
-  those rows (`global.anthropic.claude-opus-5`, `us.anthropic.claude-fable-5`,
-  …) alongside the in-region ids (`anthropic.claude-opus-5`), so
-  `bedrock/global.anthropic.claude-opus-5` resolves to its own row and sends
-  that id verbatim; §7.2's prefix strip only serves ids the catalog lacks.
-  Jesse verified the global profile live on 2026-08-28; no `Warnings` entry
-  is attached to profile ids.
+- **Inference-profile ids are not served on this endpoint** (corrected
+  2026-08-31 from live evidence). `bedrock-mantle` hosts are regional
+  (`bedrock-mantle.<region>.api.aws`), and the endpoint serves exactly the
+  ids its own catalog lists: `GET
+  https://bedrock-mantle.{region}.api.aws/v1/models` answers 200 with six
+  Claude ids, all unprefixed —
+  `anthropic.claude-{fable-5,haiku-4-5,opus-4-7,opus-4-8,opus-5,sonnet-5}`.
+  A request naming a `global.`, `us.`, `eu.`, `jp.`, `au.`, or `apac.`
+  inference-profile id answers `404 not_found_error` ("The model
+  'global.anthropic.claude-sonnet-5' does not exist"), even though `aws
+  bedrock list-inference-profiles` reports that same profile ACTIVE and
+  SYSTEM_DEFINED in the account and region the request was made from, and
+  `get-foundation-model-availability` reports it AUTHORIZED and AVAILABLE.
+  The namespaces are simply different: inference-profile ids address
+  bedrock-runtime's `InvokeModel`/`Converse` path, which §1 puts out of
+  scope. models.dev lists the profile rows regardless, so the §6.1 converter
+  marks every region-prefixed `amazon-bedrock` row `Hidden`: the row stays in
+  the catalog for metadata and still resolves when a reference names one
+  explicitly — carrying a `hidden: this provider does not serve this row`
+  warning, so the endpoint's own 404 remains the truth — but it is out of
+  `evener models list`. The provider's `default_model` and `cheap_model` are
+  unprefixed for the same reason. §7.2's prefix strip only serves ids the
+  catalog lacks.
+  *Historical note:* Jesse verified the global profile live on 2026-08-28,
+  three days before the readings above, and that note predates this finding.
+  Which path that verification took is an open question flagged for the human
+  partner; nothing in this design now depends on the answer.
 - **OpenAI-shaped models**: models.dev marks nine rows
   `@ai-sdk/amazon-bedrock/mantle` with `api:
   https://bedrock-mantle.${AWS_REGION}.api.aws/v1` (gpt-oss) or `…/openai/v1`

--- a/llm/cov_tt_llm_test.go
+++ b/llm/cov_tt_llm_test.go
@@ -110,7 +110,7 @@ func TestIntFromAny(t *testing.T) {
 // TestReasoningBudget covers every recognized effort level and the default.
 func TestReasoningBudget(t *testing.T) {
 	tests := map[string]int{
-		"minimal": 512, "low": 1024, "medium": 8192, "high": 32768,
+		"minimal": 1024, "low": 1024, "medium": 8192, "high": 32768,
 		"xhigh": 131072, "max": 131072, "unknown": 0, "": 0,
 	}
 	for effort, want := range tests {

--- a/llm/providers/chatcompletions/reasoning_only_truncated_test.go
+++ b/llm/providers/chatcompletions/reasoning_only_truncated_test.go
@@ -1,0 +1,155 @@
+package chatcompletions
+
+import (
+	"encoding/json"
+	"testing"
+
+	"primeradiant.com/evener/llm"
+)
+
+// The two bodies below are the verbatim wire shapes captured on 2026-08-31
+// from live completions that answered 200 with no reply text (issue #715):
+// openrouter/minimax/minimax-m2.7 and lunaroute/glm-5.2-vision. Every key the
+// provider sent is kept — that is the point of the fixture, since it shows
+// there is no further text-bearing field the decoder could be missing — and
+// only the chain-of-thought prose is shortened, to a string that still breaks
+// off mid-sentence exactly as the captured one did.
+//
+// Both requests capped output at 64 tokens. Both models spent all 64 on
+// reasoning and were cut off (`finish_reason: "length"`) before emitting a
+// single visible token, so `content` came back null. An empty Text() is the
+// correct reading of these bodies, not a folding gap: nothing in them is
+// dropped, as the thinking assertions below show.
+
+const truncatedReasoningOnlyMiniMax = `{
+  "id": "gen-fixture",
+  "object": "chat.completion",
+  "created": 0,
+  "model": "minimax/minimax-m2.7",
+  "provider": "Minimax",
+  "system_fingerprint": null,
+  "service_tier": null,
+  "choices": [
+    {
+      "index": 0,
+      "finish_reason": "length",
+      "native_finish_reason": "length",
+      "logprobs": null,
+      "message": {
+        "role": "assistant",
+        "content": null,
+        "refusal": null,
+        "reasoning": "The user wants one word. Should I add punctuation? I will stick to just \"pong",
+        "reasoning_details": [
+          {
+            "type": "reasoning.text",
+            "text": "The user wants one word. Should I add punctuation? I will stick to just \"pong",
+            "format": "unknown",
+            "index": 0
+          }
+        ]
+      }
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 48,
+    "completion_tokens": 64,
+    "total_tokens": 112,
+    "completion_tokens_details": {"reasoning_tokens": 64, "image_tokens": 0, "audio_tokens": 0},
+    "prompt_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 0, "audio_tokens": 0, "video_tokens": 0}
+  }
+}`
+
+const truncatedReasoningOnlyGLM = `{
+  "id": "chatcmpl-fixture",
+  "object": "chat.completion",
+  "created": 0,
+  "model": "glm-5.2-vision",
+  "service_tier": null,
+  "prompt_logprobs": null,
+  "prompt_token_ids": null,
+  "prompt_text": null,
+  "kv_transfer_params": null,
+  "ec_transfer_params": null,
+  "metrics": null,
+  "choices": [
+    {
+      "index": 0,
+      "finish_reason": "length",
+      "stop_reason": null,
+      "logprobs": null,
+      "token_ids": null,
+      "routed_experts": null,
+      "message": {
+        "role": "assistant",
+        "content": null,
+        "refusal": null,
+        "annotations": null,
+        "audio": null,
+        "function_call": null,
+        "reasoning": "The user wants one word. Should I add punctuation? I will stick to just \"pong"
+      }
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 19,
+    "completion_tokens": 64,
+    "total_tokens": 83,
+    "prompt_tokens_details": {"cached_tokens": 0, "created_cache_tokens": 0, "multimodal_tokens": null}
+  }
+}`
+
+// TestTruncatedReasoningOnlyResponse pins the reading of a 200 whose message
+// carries reasoning and a null content because the output cap cut the model
+// off mid-thought. Text() is empty and that is correct; what must never
+// regress is that the reasoning still arrives as a thinking part and the
+// truncation is still legible as finish_reason "length", so a caller can tell
+// "the model was cut off" from "we dropped the reply".
+func TestTruncatedReasoningOnlyResponse(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		// field is the wire field the reasoning arrived on, as reported on
+		// ThinkingData.Signature. reasoning_details reports none, because
+		// it replays through the reasoning_details path instead.
+		field string
+	}{
+		{name: "openrouter/minimax/minimax-m2.7", body: truncatedReasoningOnlyMiniMax, field: ""},
+		{name: "lunaroute/glm-5.2-vision", body: truncatedReasoningOnlyGLM, field: "reasoning"},
+	}
+	const wantReasoning = `The user wants one word. Should I add punctuation? I will stick to just "pong`
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var raw map[string]any
+			if err := json.Unmarshal([]byte(tt.body), &raw); err != nil {
+				t.Fatalf("fixture is not JSON: %v", err)
+			}
+			resp, err := fromChatCompletionResponse(raw, nil)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+
+			if resp.Text() != "" {
+				t.Fatalf("Text() = %q, want empty: the body's content is null", resp.Text())
+			}
+			if len(resp.Message.Content) != 1 {
+				t.Fatalf("Content = %+v, want exactly the thinking part", resp.Message.Content)
+			}
+			part := resp.Message.Content[0]
+			if part.Kind != llm.ContentThinking || part.Thinking == nil {
+				t.Fatalf("part 0 = %+v, want a thinking part", part)
+			}
+			if part.Thinking.Text != wantReasoning {
+				t.Fatalf("thinking text = %q, want the whole reasoning field", part.Thinking.Text)
+			}
+			if part.Thinking.Signature != tt.field {
+				t.Fatalf("thinking arrived on field %q, want %q", part.Thinking.Signature, tt.field)
+			}
+			if resp.Finish.Reason != "length" {
+				t.Fatalf("Finish.Reason = %q, want %q — the truncation is the whole explanation for the empty text",
+					resp.Finish.Reason, "length")
+			}
+		})
+	}
+}

--- a/llm/providers/chatcompletions/reasoning_only_truncated_test.go
+++ b/llm/providers/chatcompletions/reasoning_only_truncated_test.go
@@ -9,11 +9,11 @@ import (
 
 // The two bodies below are the verbatim wire shapes captured on 2026-08-31
 // from live completions that answered 200 with no reply text (issue #715):
-// openrouter/minimax/minimax-m2.7 and lunaroute/glm-5.2-vision. Every key the
-// provider sent is kept — that is the point of the fixture, since it shows
-// there is no further text-bearing field the decoder could be missing — and
-// only the chain-of-thought prose is shortened, to a string that still breaks
-// off mid-sentence exactly as the captured one did.
+// openrouter/minimax/minimax-m2.7 and lunaroute/glm-5.2-vision. Every message
+// and choice key the provider sent is kept verbatim — that is the point of the
+// fixture, since it shows there is no further text-bearing field the decoder
+// could be missing. Usage/billing side fields (cost, system_fingerprint) are
+// dropped, and the chain-of-thought prose is shortened to a stand-in string.
 //
 // Both requests capped output at 64 tokens. Both models spent all 64 on
 // reasoning and were cut off (`finish_reason: "length"`) before emitting a

--- a/llm/providers/wirecapture/testdata/golden/anthropic-sonnet-4-5-1m-stream.json
+++ b/llm/providers/wirecapture/testdata/golden/anthropic-sonnet-4-5-1m-stream.json
@@ -5,7 +5,6 @@
   "method": "POST",
   "url": "https://api.anthropic.com/v1/messages",
   "headers": {
-    "Anthropic-Beta": "context-1m-2025-08-07",
     "Anthropic-Version": "2023-06-01",
     "Content-Type": "application/json",
     "X-Api-Key": "\u003ccredential\u003e"

--- a/llm/providers/wirecapture/wirecapture_test.go
+++ b/llm/providers/wirecapture/wirecapture_test.go
@@ -469,7 +469,9 @@ func TestWireCaptureAssertions(t *testing.T) {
 	check(groqChat["max_tokens"] != nil && groqChat["max_completion_tokens"] == nil && groqChat["stream_options"] != nil, "groq chat spelling/stream_options: %s", byName["groq-chat-stream"].Body)
 
 	sonnet1m := byName["anthropic-sonnet-4-5-1m-stream"]
-	check(strings.Contains(sonnet1m.Headers["Anthropic-Beta"], "context-1m-2025-08-07") && sonnet1m.Headers["X-Api-Key"] == "<credential>" && sonnet1m.Headers["Anthropic-Version"] != "", "sonnet [1m] headers: %v", sonnet1m.Headers)
+	// Sonnet 4.5's 1M window is GA (verified live 2026-08-31), so the [1m] row
+	// puts no anthropic-beta on the wire — only the standing auth/version pair.
+	check(sonnet1m.Headers["Anthropic-Beta"] == "" && sonnet1m.Headers["X-Api-Key"] == "<credential>" && sonnet1m.Headers["Anthropic-Version"] != "", "sonnet [1m] headers: %v", sonnet1m.Headers)
 	check(bodyOf(t, sonnet1m)["model"] == "claude-sonnet-4-5", "sonnet [1m] wire id: %v", bodyOf(t, sonnet1m)["model"])
 	opus46 := bodyOf(t, byName["anthropic-opus-4-6-no-effort"])
 	check(opus46["thinking"].(map[string]any)["type"] == "adaptive" && opus46["thinking"].(map[string]any)["display"] == nil && opus46["output_config"] == nil, "opus 4.6 adaptive without display: %s", byName["anthropic-opus-4-6-no-effort"].Body)

--- a/llm/registry/data/providers_overlay.toml
+++ b/llm/registry/data/providers_overlay.toml
@@ -97,25 +97,25 @@ default_model = "claude-opus-5"
 cheap_model = "claude-haiku-4-5"
 web_search = true
 
-# Sonnet 4.5 is 200k; models.dev says 1M (Anthropic's context-window page,
-# 2026-08-28, lists 1M only for Opus 4.6+, Sonnet 4.6+, and Claude 5).
+# Sonnet 4.5 is 1M, and its 1M is GA. Verified live 2026-08-31: /v1/models
+# reports max_input_tokens = 1000000 for both spellings with and without the
+# retired context-1m beta, and /messages accepts a headerless request.
 [providers.anthropic.models."claude-sonnet-4-5"]
-context_window = 200000
+context_window = 1000000
 [providers.anthropic.models."claude-sonnet-4-5-20250929"]
-context_window = 200000
+context_window = 1000000
 
-# [1m] rows give a 1M window the base row does not. Sonnet 4.5's is GA
-# (verified live 2026-08-31: /v1/models reports max_input_tokens = 1000000
-# with and without the beta, and /messages accepts a headerless request), so
-# its rows carry no header; Opus 4.5 still opts in with anthropic-beta.
+# [1m] rows give a 1M window the base row does not. Sonnet 4.5's base rows now
+# carry it themselves, so its two [1m] rows are pure aliases: they stay only to
+# keep the [1m] spelling resolvable and fold it onto the base row
+# (canonicalModelID, agent/session_model_call.go). Opus 4.5's 1M is still a
+# beta opt-in, so those rows keep both the window and the header.
 [providers.anthropic.models."claude-sonnet-4-5[1m]"]
 alias_of = "claude-sonnet-4-5"
 wire_id = "claude-sonnet-4-5"
-context_window = 1000000
 [providers.anthropic.models."claude-sonnet-4-5-20250929[1m]"]
 alias_of = "claude-sonnet-4-5-20250929"
 wire_id = "claude-sonnet-4-5-20250929"
-context_window = 1000000
 [providers.anthropic.models."claude-opus-4-5[1m]"]
 alias_of = "claude-opus-4-5"
 wire_id = "claude-opus-4-5"

--- a/llm/registry/data/providers_overlay.toml
+++ b/llm/registry/data/providers_overlay.toml
@@ -317,8 +317,10 @@ auth = "header"
 auth_header = "x-api-key"
 models_endpoint = "-"
 count_tokens_endpoint = "-"
-default_model = "global.anthropic.claude-opus-5"
-cheap_model = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+# Unprefixed on purpose (spec §9.3): bedrock-mantle serves only the ids its own
+# /v1/models catalog lists, so a `global.`-prefixed default would 404.
+default_model = "anthropic.claude-opus-5"
+cheap_model = "anthropic.claude-haiku-4-5"
 
 # The Messages endpoint lacks structured outputs and web search; the Mantle
 # OpenAI rows keep their own values.

--- a/llm/registry/data/providers_overlay.toml
+++ b/llm/registry/data/providers_overlay.toml
@@ -104,17 +104,18 @@ context_window = 200000
 [providers.anthropic.models."claude-sonnet-4-5-20250929"]
 context_window = 200000
 
-# [1m] rows exist only where the 1M window is a beta.
+# [1m] rows give a 1M window the base row does not. Sonnet 4.5's is GA
+# (verified live 2026-08-31: /v1/models reports max_input_tokens = 1000000
+# with and without the beta, and /messages accepts a headerless request), so
+# its rows carry no header; Opus 4.5 still opts in with anthropic-beta.
 [providers.anthropic.models."claude-sonnet-4-5[1m]"]
 alias_of = "claude-sonnet-4-5"
 wire_id = "claude-sonnet-4-5"
 context_window = 1000000
-headers = { "anthropic-beta" = "context-1m-2025-08-07" }
 [providers.anthropic.models."claude-sonnet-4-5-20250929[1m]"]
 alias_of = "claude-sonnet-4-5-20250929"
 wire_id = "claude-sonnet-4-5-20250929"
 context_window = 1000000
-headers = { "anthropic-beta" = "context-1m-2025-08-07" }
 [providers.anthropic.models."claude-opus-4-5[1m]"]
 alias_of = "claude-opus-4-5"
 wire_id = "claude-opus-4-5"

--- a/llm/registry/golden_test.go
+++ b/llm/registry/golden_test.go
@@ -194,7 +194,8 @@ func TestGoldenResolved(t *testing.T) {
 			}
 		}},
 		{"anthropic-sonnet-4-5-1m", "anthropic/claude-sonnet-4-5[1m]", nil, func(t *testing.T, res Resolved) {
-			if res.WireID != "claude-sonnet-4-5" || ip(res.Caps.ContextWindow) != 1000000 || res.Headers["anthropic-beta"] != "context-1m-2025-08-07" || sp(res.Caps.ThinkingShape) != "budget" {
+			// GA 1M window: the row sends no beta header (see the overlay).
+			if res.WireID != "claude-sonnet-4-5" || ip(res.Caps.ContextWindow) != 1000000 || res.Headers["anthropic-beta"] != "" || sp(res.Caps.ThinkingShape) != "budget" {
 				t.Errorf("%+v", res)
 			}
 		}},

--- a/llm/registry/golden_test.go
+++ b/llm/registry/golden_test.go
@@ -189,7 +189,7 @@ func TestGoldenResolved(t *testing.T) {
 			}
 		}},
 		{"anthropic-sonnet-4-5", "anthropic/claude-sonnet-4-5", nil, func(t *testing.T, res Resolved) {
-			if sp(res.Caps.ThinkingShape) != "budget" || res.Caps.ThinkingAlwaysOn != nil || ip(res.Caps.ContextWindow) != 200000 {
+			if sp(res.Caps.ThinkingShape) != "budget" || res.Caps.ThinkingAlwaysOn != nil || ip(res.Caps.ContextWindow) != 1000000 {
 				t.Errorf("%+v", res.Caps)
 			}
 		}},

--- a/llm/registry/load_test.go
+++ b/llm/registry/load_test.go
@@ -323,6 +323,82 @@ func TestLoad_RowHidden(t *testing.T) {
 	}
 }
 
+// TestLoad_BedrockProfileRowsHiddenButResolvable pins spec §9.3's ruling on
+// Bedrock's inference-profile ids. bedrock-mantle serves the six unprefixed
+// Claude ids its own /v1/models catalog lists; the `global.`/`us.`/`eu.`/
+// `jp.`/`au.`/`apac.` spellings address bedrock-runtime, which §1 puts out of
+// scope, so a request for one 404s at the endpoint. They stay in the catalog
+// for metadata and still resolve when a reference names one explicitly —
+// resolution is strict but honest, and the endpoint's 404 tells the truth —
+// but they are hidden, which is what keeps them out of `evener models list`
+// (which filters on the resolved row's Hidden).
+func TestLoad_BedrockProfileRowsHiddenButResolvable(t *testing.T) {
+	r := fixtureLoad(t, map[string]string{"AWS_REGION": "us-east-1", "AWS_BEARER_TOKEN_BEDROCK": "bt"}, "")
+
+	for _, id := range []string{"global.anthropic.claude-sonnet-5", "us.anthropic.claude-fable-5", "eu.anthropic.claude-opus-5", "jp.anthropic.claude-sonnet-5", "au.anthropic.claude-sonnet-5"} {
+		res, err := r.Resolve("amazon-bedrock/" + id)
+		if err != nil {
+			t.Fatalf("%s: a hidden row must still resolve when named: %v", id, err)
+		}
+		if !res.Model.Hidden {
+			t.Fatalf("%s: profile rows must be hidden from listings", id)
+		}
+		if res.WireID != id {
+			t.Fatalf("%s: wire id %q, want the id verbatim", id, res.WireID)
+		}
+		if res.Transport.BaseURL != "https://bedrock-mantle.us-east-1.api.aws/anthropic/v1" {
+			t.Fatalf("%s: base URL %q", id, res.Transport.BaseURL)
+		}
+	}
+
+	// The ids Mantle actually serves stay visible.
+	for _, id := range []string{"anthropic.claude-sonnet-5", "anthropic.claude-opus-5", "anthropic.claude-fable-5"} {
+		res, err := r.Resolve("amazon-bedrock/" + id)
+		if err != nil {
+			t.Fatalf("%s: %v", id, err)
+		}
+		if res.Model.Hidden {
+			t.Fatalf("%s: the unprefixed ids Mantle serves must stay listed", id)
+		}
+	}
+
+	// The rows stay in the catalog: hiding is a listing filter, not a delete.
+	ids, err := r.CatalogModelIDs("amazon-bedrock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(ids, "global.anthropic.claude-sonnet-5") {
+		t.Fatal("a hidden row must stay in the catalog for metadata")
+	}
+}
+
+// TestLoad_CuratedDefaultsAreNotHidden pins the invariant the Bedrock profile
+// ruling exposed: a provider's curated default_model / cheap_model is what a
+// profile picks when nothing is configured, so naming a hidden row there
+// hands every such session a reference the provider does not serve. Rows the
+// catalog lacks are left alone — those synthesize by design (spec §7.3).
+func TestLoad_CuratedDefaultsAreNotHidden(t *testing.T) {
+	r := fixtureLoad(t, nil, "")
+	for _, id := range sortedKeys(r.curated) {
+		rec := r.curated[id]
+		for _, pick := range []struct{ what, model string }{
+			{"default_model", rec.head.DefaultModel},
+			{"cheap_model", rec.head.CheapModel},
+		} {
+			if pick.model == "" {
+				continue
+			}
+			row, ok := rec.head.Models[pick.model]
+			if !ok {
+				continue
+			}
+			if row.Hidden {
+				t.Errorf("providers.%s: %s = %q names a hidden row", id, pick.what, pick.model)
+			}
+		}
+	}
+}
+
 func TestLoad_UserLayerTriState(t *testing.T) {
 	data, _ := os.ReadFile("testdata/models.dev.sample.json")
 	dir := t.TempDir()

--- a/llm/registry/modelsdev.go
+++ b/llm/registry/modelsdev.go
@@ -337,7 +337,16 @@ func convertModel(providerID, key string, mm mdModel) (Model, bool) {
 	// Row-level hiding rules (spec §6.1).
 	switch providerID {
 	case "amazon-bedrock":
-		if !hasOverride && !strings.HasPrefix(stripRegionPrefix(m.ID), "anthropic.") {
+		// bedrock-mantle serves the unprefixed Claude ids its own /v1/models
+		// catalog lists (spec §9.3). Everything else here is hidden: a
+		// non-Claude row without a Mantle override has no transport evener
+		// can reach it through, and a `global.`/`us.`/`eu.`/`jp.`/`au.`/
+		// `apac.` inference-profile id addresses bedrock-runtime, which §1
+		// puts out of scope, so the Mantle endpoint answers not_found_error
+		// for it. Hidden keeps both kinds out of listings while leaving them
+		// in the catalog for metadata and resolvable when named.
+		stripped := stripRegionPrefix(m.ID)
+		if !hasOverride && (stripped != m.ID || !strings.HasPrefix(stripped, "anthropic.")) {
 			m.Hidden = true
 		}
 	case "google-vertex":

--- a/llm/registry/modelsdev_test.go
+++ b/llm/registry/modelsdev_test.go
@@ -175,8 +175,13 @@ func TestFromModelsDev_ModelLevel(t *testing.T) {
 	if p["amazon-bedrock"].Models["anthropic.claude-opus-5"].Hidden {
 		t.Fatalf("Claude bedrock rows must not be hidden")
 	}
-	if p["amazon-bedrock"].Models["us.anthropic.claude-fable-5"].Hidden {
-		t.Fatalf("region-prefixed Claude rows must not be hidden")
+	// spec §9.3: bedrock-mantle serves unprefixed ids only, so the
+	// inference-profile spellings are hidden from listings even though they
+	// are Claude rows and still resolve when named.
+	for _, id := range []string{"us.anthropic.claude-fable-5", "global.anthropic.claude-sonnet-5", "eu.anthropic.claude-opus-5", "jp.anthropic.claude-sonnet-5", "au.anthropic.claude-sonnet-5"} {
+		if !p["amazon-bedrock"].Models[id].Hidden {
+			t.Fatalf("%s: region-prefixed Claude rows must be hidden", id)
+		}
 	}
 
 	vc := p["google-vertex"].Models["claude-opus-5"]

--- a/llm/registry/overlay_test.go
+++ b/llm/registry/overlay_test.go
@@ -98,11 +98,23 @@ func TestCuratedOverlay_Transports(t *testing.T) {
 func TestCuratedOverlay_AnthropicRows(t *testing.T) {
 	l := loadOverlay(t)
 	a := l.Providers["anthropic"]
+	// Every [1m] row aliases its base row and pins the 1M window. Only the
+	// Opus 4.5 pair still opts in with the beta header; Sonnet 4.5's 1M window
+	// is GA (verified live 2026-08-31), so its rows must send no beta header —
+	// a stale opt-in reintroduced here would ride every [1m] request.
 	for _, id := range []string{"claude-sonnet-4-5[1m]", "claude-sonnet-4-5-20250929[1m]", "claude-opus-4-5[1m]", "claude-opus-4-5-20251101[1m]"} {
 		row, ok := a.Models[id]
 		base := strings.TrimSuffix(id, "[1m]")
-		if !ok || row.AliasOf != base || row.WireID != base || row.Caps.ContextWindow == nil || *row.Caps.ContextWindow != 1000000 || row.Headers["anthropic-beta"] != "context-1m-2025-08-07" {
+		if !ok || row.AliasOf != base || row.WireID != base || row.Caps.ContextWindow == nil || *row.Caps.ContextWindow != 1000000 {
 			t.Errorf("%s: %+v", id, row)
+			continue
+		}
+		want := "context-1m-2025-08-07"
+		if strings.HasPrefix(id, "claude-sonnet-4-5") {
+			want = ""
+		}
+		if got := row.Headers["anthropic-beta"]; got != want {
+			t.Errorf("%s: anthropic-beta = %q, want %q", id, got, want)
 		}
 	}
 	for _, id := range []string{"claude-sonnet-4-5", "claude-sonnet-4-5-20250929"} {

--- a/llm/registry/overlay_test.go
+++ b/llm/registry/overlay_test.go
@@ -98,28 +98,34 @@ func TestCuratedOverlay_Transports(t *testing.T) {
 func TestCuratedOverlay_AnthropicRows(t *testing.T) {
 	l := loadOverlay(t)
 	a := l.Providers["anthropic"]
-	// Every [1m] row aliases its base row and pins the 1M window. Only the
-	// Opus 4.5 pair still opts in with the beta header; Sonnet 4.5's 1M window
-	// is GA (verified live 2026-08-31), so its rows must send no beta header —
-	// a stale opt-in reintroduced here would ride every [1m] request.
+	// Every [1m] row aliases its base row; what each carries beyond that
+	// differs. Opus 4.5's 1M is still a beta opt-in, so those rows pin the
+	// window and the header themselves. Sonnet 4.5's 1M is GA and lives on the
+	// base row, so its [1m] rows are pure aliases — a window or a header
+	// reappearing on them means the GA fold silently regressed.
 	for _, id := range []string{"claude-sonnet-4-5[1m]", "claude-sonnet-4-5-20250929[1m]", "claude-opus-4-5[1m]", "claude-opus-4-5-20251101[1m]"} {
 		row, ok := a.Models[id]
 		base := strings.TrimSuffix(id, "[1m]")
-		if !ok || row.AliasOf != base || row.WireID != base || row.Caps.ContextWindow == nil || *row.Caps.ContextWindow != 1000000 {
+		if !ok || row.AliasOf != base || row.WireID != base {
 			t.Errorf("%s: %+v", id, row)
 			continue
 		}
-		want := "context-1m-2025-08-07"
 		if strings.HasPrefix(id, "claude-sonnet-4-5") {
-			want = ""
+			if row.Caps.ContextWindow != nil || row.Headers["anthropic-beta"] != "" {
+				t.Errorf("%s must be a pure alias, got window %d and anthropic-beta %q",
+					id, ip(row.Caps.ContextWindow), row.Headers["anthropic-beta"])
+			}
+			continue
 		}
-		if got := row.Headers["anthropic-beta"]; got != want {
-			t.Errorf("%s: anthropic-beta = %q, want %q", id, got, want)
+		if row.Caps.ContextWindow == nil || *row.Caps.ContextWindow != 1000000 || row.Headers["anthropic-beta"] != "context-1m-2025-08-07" {
+			t.Errorf("%s: %+v", id, row)
 		}
 	}
+	// Both Sonnet 4.5 spellings are 1M (GA, verified live 2026-08-31). The
+	// [1m] aliases above inherit the window from here.
 	for _, id := range []string{"claude-sonnet-4-5", "claude-sonnet-4-5-20250929"} {
-		if cw := a.Models[id].Caps.ContextWindow; cw == nil || *cw != 200000 {
-			t.Errorf("%s must be pinned to 200000", id)
+		if cw := a.Models[id].Caps.ContextWindow; cw == nil || *cw != 1000000 {
+			t.Errorf("%s must be pinned to 1000000, got %d", id, ip(a.Models[id].Caps.ContextWindow))
 		}
 	}
 	if a.Models["claude-mythos-5"].AliasOf != "azure/claude-mythos-5" {

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -362,7 +362,7 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 		warnings = append(warnings, "model not in catalog")
 	}
 	if row.Hidden {
-		warnings = append(warnings, "hidden: row has no transport on this provider")
+		warnings = append(warnings, "hidden: this provider does not serve this row")
 	}
 	if rec.head.Hidden {
 		warnings = append(warnings, "hidden: provider has no resolvable base URL or protocol")

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -150,7 +150,8 @@ func TestResolve_AliasSeeding(t *testing.T) {
 	if *res.Caps.ContextWindow != 1000000 || res.Provenance["ContextWindow"] != "overlay/row" || *res.Caps.MaxOutputTokens != 64000 || res.Provenance["MaxOutputTokens"] != "alias" {
 		t.Fatalf("[1m]: %v %v", res.Caps.ContextWindow, res.Provenance)
 	}
-	if res.WireID != "claude-sonnet-4-5" || res.Surface != SurfaceAnthropic || res.Model.Family != "claude-sonnet" || res.Headers["anthropic-beta"] != "context-1m-2025-08-07" || *res.Caps.ThinkingShape != "budget" || res.Caps.ThinkingAlwaysOn != nil || res.Caps.Sampling != nil {
+	// Sonnet 4.5's 1M window is GA, so the [1m] row resolves with no beta header.
+	if res.WireID != "claude-sonnet-4-5" || res.Surface != SurfaceAnthropic || res.Model.Family != "claude-sonnet" || res.Headers["anthropic-beta"] != "" || *res.Caps.ThinkingShape != "budget" || res.Caps.ThinkingAlwaysOn != nil || res.Caps.Sampling != nil {
 		t.Fatalf("[1m] row: %+v", res)
 	}
 	res = mustResolve(t, r, "openai-codex/gpt-5.6")

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -185,6 +185,39 @@ func TestResolve_AliasSeeding(t *testing.T) {
 	}
 }
 
+// TestResolve_Opus45OneMStillBeta pins Opus 4.5's [1m] rows as beta-gated,
+// unlike Sonnet 4.5's [1m] rows above (TestResolve_AliasSeeding), which
+// became plain GA aliases. Live evidence against api.anthropic.com on
+// 2026-08-31 showed GET /v1/models still reporting a 200k context window
+// for Opus 4.5 both with and without the context-1m beta header (unlike
+// Sonnet 4.5, which flipped to 1M both ways), so the overlay
+// (data/providers_overlay.toml) deliberately keeps both Opus [1m] rows'
+// own context_window = 1000000 override and their anthropic-beta header,
+// rather than folding the window onto the base row as a pure alias. A
+// future edit that flips Opus 4.5 to GA must fail this test until someone
+// deliberately updates it.
+func TestResolve_Opus45OneMStillBeta(t *testing.T) {
+	r := fixtureLoad(t, nil, "")
+	for _, tc := range []struct{ ref, wantWireID string }{
+		{"anthropic/claude-opus-4-5[1m]", "claude-opus-4-5"},
+		{"anthropic/claude-opus-4-5-20251101[1m]", "claude-opus-4-5-20251101"},
+	} {
+		res := mustResolve(t, r, tc.ref)
+		if res.WireID != tc.wantWireID {
+			t.Fatalf("%s: WireID = %q, want %q", tc.ref, res.WireID, tc.wantWireID)
+		}
+		// The window is the row's own curated override, not an alias fold
+		// (contrast Sonnet's now-GA rows, whose ContextWindow provenance is
+		// "alias" per TestResolve_AliasSeeding).
+		if res.Caps.ContextWindow == nil || *res.Caps.ContextWindow != 1000000 || res.Provenance["ContextWindow"] != "overlay/row" {
+			t.Fatalf("%s: ContextWindow = %v, provenance %q", tc.ref, res.Caps.ContextWindow, res.Provenance["ContextWindow"])
+		}
+		if res.Headers["anthropic-beta"] != "context-1m-2025-08-07" {
+			t.Fatalf("%s: anthropic-beta header = %q, want the beta still gating this window", tc.ref, res.Headers["anthropic-beta"])
+		}
+	}
+}
+
 func TestResolve_TransportAssembly(t *testing.T) {
 	r := fixtureLoad(t, map[string]string{"GOOGLE_VERTEX_PROJECT": "p", "GOOGLE_VERTEX_LOCATION": "global", "AWS_REGION": "us-east-1"}, "")
 	res := mustResolve(t, r, "google-vertex-anthropic/claude-opus-5")

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -147,7 +147,9 @@ func TestResolve_LiveSitsBetweenOverlayAndConfig(t *testing.T) {
 func TestResolve_AliasSeeding(t *testing.T) {
 	r := fixtureLoad(t, map[string]string{"AZURE_RESOURCE_NAME": "contoso"}, "[providers.azure.models.\"claude-prod\"]\nalias_of = \"claude-opus-4-5\"\n")
 	res := mustResolve(t, r, "anthropic/claude-sonnet-4-5[1m]")
-	if *res.Caps.ContextWindow != 1000000 || res.Provenance["ContextWindow"] != "overlay/row" || *res.Caps.MaxOutputTokens != 64000 || res.Provenance["MaxOutputTokens"] != "alias" {
+	// The [1m] row is a pure alias: its 1M window arrives through the alias
+	// fold from the base row, not from an override on the row itself.
+	if *res.Caps.ContextWindow != 1000000 || res.Provenance["ContextWindow"] != "alias" || *res.Caps.MaxOutputTokens != 64000 || res.Provenance["MaxOutputTokens"] != "alias" {
 		t.Fatalf("[1m]: %v %v", res.Caps.ContextWindow, res.Provenance)
 	}
 	// Sonnet 4.5's 1M window is GA, so the [1m] row resolves with no beta header.

--- a/llm/registry/testdata/golden/anthropic-sonnet-4-5-1m.json
+++ b/llm/registry/testdata/golden/anthropic-sonnet-4-5-1m.json
@@ -25,9 +25,6 @@
     "wire_id": "claude-sonnet-4-5",
     "alias_of": "claude-sonnet-4-5",
     "family": "claude-sonnet",
-    "headers": {
-      "anthropic-beta": "context-1m-2025-08-07"
-    },
     "surface": "anthropic",
     "caps": {}
   },
@@ -64,9 +61,6 @@
     },
     "thinking_shape": "budget",
     "web_search": true
-  },
-  "headers": {
-    "anthropic-beta": "context-1m-2025-08-07"
   },
   "provenance": {
     "ContextWindow": "overlay/row",

--- a/llm/registry/testdata/golden/anthropic-sonnet-4-5-1m.json
+++ b/llm/registry/testdata/golden/anthropic-sonnet-4-5-1m.json
@@ -63,7 +63,7 @@
     "web_search": true
   },
   "provenance": {
-    "ContextWindow": "overlay/row",
+    "ContextWindow": "alias",
     "Cost": "alias",
     "Family": "alias",
     "InputModalities": "alias",

--- a/llm/registry/testdata/golden/anthropic-sonnet-4-5.json
+++ b/llm/registry/testdata/golden/anthropic-sonnet-4-5.json
@@ -28,7 +28,7 @@
     "caps": {}
   },
   "caps": {
-    "context_window": 200000,
+    "context_window": 1000000,
     "max_output_tokens": 64000,
     "tools": true,
     "structured_output": true,

--- a/llm/registry/testdata/golden/bedrock-global-opus-5.json
+++ b/llm/registry/testdata/golden/bedrock-global-opus-5.json
@@ -25,7 +25,8 @@
     "wire_id": "global.anthropic.claude-opus-5",
     "family": "claude-opus",
     "surface": "anthropic",
-    "caps": {}
+    "caps": {},
+    "hidden": true
   },
   "caps": {
     "context_window": 1000000,
@@ -93,8 +94,11 @@
     "WebSearch": "overlay/glob:*anthropic.*",
     "model": "row:global.anthropic.claude-opus-5"
   },
-  "default_model": "global.anthropic.claude-opus-5",
-  "cheap_model": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "warnings": [
+    "hidden: this provider does not serve this row"
+  ],
+  "default_model": "anthropic.claude-opus-5",
+  "cheap_model": "anthropic.claude-haiku-4-5",
   "credential_source": "env:AWS_BEARER_TOKEN_BEDROCK",
   "pruned_fields": [
     "container",

--- a/llm/registry/testdata/golden/bedrock-gpt-5.5.json
+++ b/llm/registry/testdata/golden/bedrock-gpt-5.5.json
@@ -104,8 +104,8 @@
     "Tools": "snapshot/row",
     "model": "row:openai.gpt-5.5"
   },
-  "default_model": "global.anthropic.claude-opus-5",
-  "cheap_model": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "default_model": "anthropic.claude-opus-5",
+  "cheap_model": "anthropic.claude-haiku-4-5",
   "credential_source": "env:AWS_BEARER_TOKEN_BEDROCK",
   "pruned_fields": [
     "background",

--- a/llm/registry/testdata/golden/bedrock-new-model.json
+++ b/llm/registry/testdata/golden/bedrock-new-model.json
@@ -59,8 +59,8 @@
   "warnings": [
     "model not in catalog"
   ],
-  "default_model": "global.anthropic.claude-opus-5",
-  "cheap_model": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "default_model": "anthropic.claude-opus-5",
+  "cheap_model": "anthropic.claude-haiku-4-5",
   "synthesized": true,
   "credential_source": "env:AWS_BEARER_TOKEN_BEDROCK",
   "pruned_fields": [

--- a/llm/registry/testdata/golden/bedrock-sonnet-5.json
+++ b/llm/registry/testdata/golden/bedrock-sonnet-5.json
@@ -94,8 +94,8 @@
     "WebSearch": "overlay/glob:*anthropic.*",
     "model": "row:anthropic.claude-sonnet-5"
   },
-  "default_model": "global.anthropic.claude-opus-5",
-  "cheap_model": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "default_model": "anthropic.claude-opus-5",
+  "cheap_model": "anthropic.claude-haiku-4-5",
   "credential_source": "env:AWS_BEARER_TOKEN_BEDROCK",
   "pruned_fields": [
     "container",

--- a/llm/types.go
+++ b/llm/types.go
@@ -604,7 +604,9 @@ func (req Request) Validate() error {
 func ReasoningBudget(effort string) int {
 	switch strings.ToLower(strings.TrimSpace(effort)) {
 	case "minimal":
-		return 512
+		// Anthropic documents 1024 as the minimum for thinking.budget_tokens;
+		// a lower value is wire-rejectable on budget-shaped rows (#714).
+		return 1024
 	case "low":
 		return 1024
 	case "medium":

--- a/scripts/live/with-live-env
+++ b/scripts/live/with-live-env
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# with-live-env — run a command under an isolated fake HOME for evener's live
+# cloud-provider verification (provider-registry step 4, spec §13 "Live").
+#
+# WHY THIS EXISTS: live verification sends real requests, with real
+# credentials, to real provider endpoints. Every one of those runs must be
+# unable to read or write the developer's actual ~/.config/evener or
+# ~/.local/state/evener — an isolated fake homedir for every live run is
+# Jesse's explicit requirement, not a nicety. This script builds that
+# isolation once so every later live-testing task runs its commands through
+# it instead of re-deriving isolation by hand.
+#
+# It exports the following, then runs <command...> with them in its
+# environment:
+#
+#   HOME                   a fresh directory made by mktemp, chmod 700,
+#                          deleted on exit unless --keep.
+#   XDG_CONFIG_HOME
+#   XDG_CACHE_HOME
+#   XDG_STATE_HOME         redirected under the same fake home (via
+#                          scripts/lib/private-go-home.sh), so anything that
+#                          resolves paths from these instead of the EVENER_*
+#                          variables below still cannot see the real ones.
+#   GOENV                  a private copy of the ambient `go env -w` file (or
+#                          an empty one) — `go env -w` run under the wrapper
+#                          can never touch the developer's real Go config.
+#   GOPATH, GOCACHE        preserved at their ambient (real) values when not
+#                          already set in the environment. Without this,
+#                          redirecting HOME makes every `go build`/`go test`
+#                          run under the wrapper recompile from a cold cache —
+#                          measured ~22s and ~1GB of re-downloaded modules per
+#                          invocation — which this harness cannot afford to
+#                          pay on every one of plan 4's remaining tasks.
+#   EVENER_STATE_DIR       $HOME/state — evener's per-invocation state root.
+#   EVENER_PROVIDERS_CONFIG
+#                          with --config FILE: a copy of FILE at
+#                          $HOME/providers.toml. Without --config: a path
+#                          under $HOME that does not exist. Either way the
+#                          variable is always present: the registry's
+#                          tri-state rule (llm/registry/load.go) treats a
+#                          named-but-missing path the same as "no user
+#                          layer", so curated providers still activate
+#                          implicitly from the credential env vars sourced
+#                          below — no providers.toml is required to exercise
+#                          them.
+#   EVENER_CREDENTIALS_CONFIG
+#                          only with --store: the DEVELOPER's real credential
+#                          store, ~/.config/evener/credentials.toml, used
+#                          read-only. Never set otherwise.
+#
+# It also sources ~/git/prime-radiant/serf/.env into the process environment
+# when that file exists (ANTHROPIC_API_KEY, OPENROUTER_API_KEY,
+# OPENAI_API_KEY, GEMINI_API_KEY, OLLAMA_HOST, MOONSHOT_API_KEY) so curated
+# providers can pick them up implicitly. A credential value is never echoed,
+# logged, or placed in argv — not even on an error path.
+#
+# Usage:
+#   scripts/live/with-live-env [--config providers.toml] [--store] [--keep] -- <command...>
+#
+#   --config FILE  copy FILE into the fake home as the providers.toml the
+#                  command sees. Omitted: the command sees no providers.toml
+#                  at all, only the implicit/curated providers the sourced
+#                  credential env vars activate.
+#   --store        point EVENER_CREDENTIALS_CONFIG at the developer's real
+#                  ~/.config/evener/credentials.toml (read-only use).
+#   --keep         do not delete the fake home on exit; print its path to
+#                  stderr instead.
+#
+# Examples:
+#   scripts/live/with-live-env -- sh -c 'echo $HOME'
+#   scripts/live/with-live-env --store --config /tmp/providers.toml -- \
+#       env EVENER_LIVE_TESTS=1 go test ./cmd/evener/ -run TestLiveSmoke -count=1
+set -euo pipefail
+
+die() { printf 'with-live-env: %s\n' "$1" >&2; exit 2; }
+note() { printf 'with-live-env: %s\n' "$1" >&2; }
+
+usage() {
+	awk 'NR>1 && /^#/ {sub(/^# ?/, ""); print; next} NR>1 {exit}' "$0"
+}
+
+config_path=""
+use_store=0
+keep=0
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--help | -h)
+		usage
+		exit 0
+		;;
+	--config)
+		[ $# -ge 2 ] || die "--config requires a path (see --help)"
+		config_path="$2"
+		shift 2
+		;;
+	--store)
+		use_store=1
+		shift
+		;;
+	--keep)
+		keep=1
+		shift
+		;;
+	--)
+		shift
+		break
+		;;
+	*)
+		die "unknown argument: $1 (the command to run must follow --; see --help)"
+		;;
+	esac
+done
+
+[ $# -gt 0 ] || die "no command given (pass it after --; see --help)"
+
+if [ -n "$config_path" ]; then
+	[ -f "$config_path" ] || die "--config: no such file: $config_path"
+fi
+
+ambient_home=${HOME:-}
+[ -n "$ambient_home" ] || die "HOME is not set in the ambient environment"
+
+credentials_store="$ambient_home/.config/evener/credentials.toml"
+if [ "$use_store" -eq 1 ]; then
+	[ -f "$credentials_store" ] || die "--store: no such file: $credentials_store"
+fi
+
+credential_env_file="$ambient_home/git/prime-radiant/serf/.env"
+
+script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+. "$script_dir/../lib/private-go-home.sh"
+
+# An explicit template, never `mktemp -t`: macOS's mktemp ignores TMPDIR for
+# -t (scripts/lib/live-eval-isolation.sh made the same call).
+fake_home_root=$(mktemp -d "${TMPDIR:-/tmp}/evener-live-env.XXXXXX")
+chmod 700 "$fake_home_root"
+
+cleanup() {
+	if [ "$keep" -eq 1 ]; then
+		note "kept fake home: $fake_home_root"
+	else
+		rm -rf "$fake_home_root"
+	fi
+}
+trap cleanup EXIT
+
+# Redirects HOME (and XDG_CONFIG_HOME/XDG_CACHE_HOME/XDG_STATE_HOME) under
+# fake_home_root while preserving the ambient GOPATH/GOCACHE, per the header
+# comment above.
+evener_prepare_private_go_home "$fake_home_root"
+note "fake home: $HOME"
+
+state_dir="$HOME/state"
+mkdir -p "$state_dir"
+export EVENER_STATE_DIR="$state_dir"
+
+providers_config="$HOME/providers.toml"
+if [ -n "$config_path" ]; then
+	cp -- "$config_path" "$providers_config"
+fi
+export EVENER_PROVIDERS_CONFIG="$providers_config"
+
+if [ "$use_store" -eq 1 ]; then
+	export EVENER_CREDENTIALS_CONFIG="$credentials_store"
+fi
+
+if [ -f "$credential_env_file" ]; then
+	set -a
+	# shellcheck disable=SC1090  # dynamic path to a private, uncommitted secrets file
+	. "$credential_env_file"
+	set +a
+	note "sourced credentials from $credential_env_file"
+else
+	note "no credential file at $credential_env_file; continuing without it"
+fi
+
+# A plain foreground run, not `exec`: replacing this process would replace
+# away the cleanup trap above too, so the fake home would never be removed
+# (and --keep's notice would never print). Capturing the status this way,
+# rather than letting a failure trip `set -e`, is deliberate: the wrapped
+# command's real exit code is what a caller (a shell script, a CI job) needs
+# back.
+status=0
+"$@" || status=$?
+exit "$status"

--- a/scripts/live/with-live-env
+++ b/scripts/live/with-live-env
@@ -13,17 +13,26 @@
 # It exports the following, then runs <command...> with them in its
 # environment:
 #
-#   HOME                   a fresh directory made by mktemp, chmod 700,
-#                          deleted on exit unless --keep.
+#   HOME                   a subdirectory of a fresh mktemp root. The root
+#                          itself (not every directory nested under it) is
+#                          chmod 700, which is sufficient: Unix directory
+#                          traversal means the root alone blocks other
+#                          users from reaching anything inside it,
+#                          regardless of the nested entries' own bits. The
+#                          whole root is deleted on exit unless --keep.
 #   XDG_CONFIG_HOME
 #   XDG_CACHE_HOME
 #   XDG_STATE_HOME         redirected under the same fake home (via
 #                          scripts/lib/private-go-home.sh), so anything that
 #                          resolves paths from these instead of the EVENER_*
 #                          variables below still cannot see the real ones.
-#   GOENV                  a private copy of the ambient `go env -w` file (or
-#                          an empty one) — `go env -w` run under the wrapper
-#                          can never touch the developer's real Go config.
+#   GOENV                  a private, verbatim copy of the ambient `go env
+#                          -w` file (or an empty one) — `go env -w` run
+#                          under the wrapper can never touch the
+#                          developer's real Go config. That file ordinarily
+#                          holds only settings like GOPROXY/GOSUMDB, never
+#                          secrets, so the verbatim copy is not a
+#                          credential-handling concern in practice.
 #   GOPATH, GOCACHE        preserved at their ambient (real) values when not
 #                          already set in the environment. Without this,
 #                          redirecting HOME makes every `go build`/`go test`
@@ -51,8 +60,9 @@
 # It also sources ~/git/prime-radiant/serf/.env into the process environment
 # when that file exists (ANTHROPIC_API_KEY, OPENROUTER_API_KEY,
 # OPENAI_API_KEY, GEMINI_API_KEY, OLLAMA_HOST, MOONSHOT_API_KEY) so curated
-# providers can pick them up implicitly. A credential value is never echoed,
-# logged, or placed in argv — not even on an error path.
+# providers can pick them up implicitly. A credential value is never
+# echoed, logged, or placed in argv — not even on an error path, and not
+# even under xtrace (the sourcing block explicitly guards against `set -x`).
 #
 # Usage:
 #   scripts/live/with-live-env [--config providers.toml] [--store] [--keep] -- <command...>
@@ -166,10 +176,20 @@ if [ "$use_store" -eq 1 ]; then
 fi
 
 if [ -f "$credential_env_file" ]; then
+	# Credential VALUES pass through this exact statement (`. file` executes
+	# each KEY=value assignment). xtrace instruments every command it runs,
+	# so sourcing this under `bash -x` (or any caller that already has -x
+	# on) would print every credential verbatim. Disable xtrace for this
+	# block only and restore whatever the caller had — never assume it was
+	# off, and never leave it off for the rest of the run.
+	xtrace_was_on=0
+	[[ $- == *x* ]] && xtrace_was_on=1
+	set +x
 	set -a
 	# shellcheck disable=SC1090  # dynamic path to a private, uncommitted secrets file
 	. "$credential_env_file"
 	set +a
+	[ "$xtrace_was_on" -eq 1 ] && set -x
 	note "sourced credentials from $credential_env_file"
 else
 	note "no credential file at $credential_env_file; continuing without it"


### PR DESCRIPTION
Executes docs/superpowers/plans/2026-08-31-provider-registry-step4.md (tracking: #716) on top of the merged cut-over (#704). 21 commits: the isolated live-test harness (`scripts/live/with-live-env`), the spec-§13 live verification suite, and the fixes the campaign surfaced.

Live findings folded in:
- Sonnet 4.5 `[1m]` is GA: rows are plain aliases, 1M base window, beta header dropped. Opus 4.5 `[1m]` is still beta (200k both ways on the models endpoint) and now pinned offline by `TestResolve_Opus45OneMStillBeta`.
- Bedrock Mantle serves only the six unprefixed Claude ids; region-prefixed inference-profile rows are hidden from listings but stay resolvable (spec §6.1 rule, now stated consistently in §6.1/§9.3/§15), and the curated bedrock defaults were fixed off unservable prefixed ids.
- #714 fixed: `minimal` reasoning budget raised to Anthropic's 1024 floor.
- #715 root-caused: the smoke's 64-token cap produced reasoning-only truncated 200s; decoder was correct, the smoke's diagnostic was fixed and the shape pinned offline.
- Kimi K3 thinking shape verified on the wire; skips (azure/groq/minimax-direct/vertex) documented with remedies in the plan workspace.

Full gate green against the accepted roster; branch went through per-task review, a whole-branch review, and a byte-identical rebase check onto main.