### PR TITLE
providers.toml schema 2 and evener migrate auto-conversion

### DIFF
--- a/cmd/evener-migrate/convert.go
+++ b/cmd/evener-migrate/convert.go
@@ -164,7 +164,7 @@ func convertProvidersConfig(src []byte) ([]byte, []string, error) {
 				// "openai-compatible" family: it never inherited a vendor
 				// key, so none is invented for it here.
 				if inst.Type == "openai" && inst.APIStyle == "chat-completions" {
-					notes = append(notes, fmt.Sprintf("%s: no key carried over (the old schema inherited none here); set api_key_env or credential_headers if the gateway needs one", name))
+					notes = append(notes, name+": no key carried over (the old schema inherited none here); set api_key_env or credential_headers if the gateway needs one")
 				} else if env, ok := vendorKeyEnv[target.base]; ok {
 					// See vendorKeyEnv: base_url instances no longer inherit.
 					fmt.Fprintf(&b, "api_key_env = [%q]\n", env)
@@ -176,7 +176,7 @@ func convertProvidersConfig(src []byte) ([]byte, []string, error) {
 		case !strings.Contains(inst.APIKey, "$"):
 			fmt.Fprintf(&b, "api_key = %q\n", inst.APIKey)
 		default:
-			notes = append(notes, fmt.Sprintf("%s: api_key used $-expansion the new schema does not spell; set it with `evener providers add`", name))
+			notes = append(notes, name+": api_key used $-expansion the new schema does not spell; set it with `evener providers add`")
 			b.WriteString("# migrate: the old api_key mixed literal text with $VAR expansion; re-create the credential by hand\n")
 		}
 		writeStringTable(&b, name, "headers", inst.Headers)

--- a/cmd/evener-migrate/convert.go
+++ b/cmd/evener-migrate/convert.go
@@ -1,0 +1,190 @@
+package migrate
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+
+	"primeradiant.com/evener/llm/registry"
+)
+
+// oldInstance is the pre-registry [instances.NAME] shape, re-declared here
+// because the cut-over deleted its parser; evener migrate is the one place
+// that still reads it (spec §14.1).
+type oldInstance struct {
+	Type              string            `toml:"type"`
+	APIStyle          string            `toml:"api_style"`
+	BaseURL           string            `toml:"base_url"`
+	APIKey            string            `toml:"api_key"`
+	Quirks            string            `toml:"quirks"`
+	Headers           map[string]string `toml:"headers"`
+	CredentialHeaders map[string]string `toml:"credential_headers"`
+	Compat            map[string]any    `toml:"compat"`
+	Models            map[string]any    `toml:"models"`
+}
+
+type oldFileShape struct {
+	Schema    int                    `toml:"schema"`
+	Default   string                 `toml:"default"`
+	Instances map[string]oldInstance `toml:"instances"`
+}
+
+// oldTypeTarget maps each pre-registry type (and, for openai, api_style) to
+// the registry provider it addressed, grounded in the deleted adapters'
+// default endpoints: old bare kimi hit api.moonshot.ai (the platform), old
+// kimi-anthropic hit api.kimi.com/coding, old glm hit api.z.ai.
+var oldTypeTarget = map[string]struct{ base, protocol string }{
+	"openai":               {base: "openai"},
+	"anthropic":            {base: "anthropic"},
+	"google":               {base: "google"},
+	"openrouter":           {base: "openrouter"},
+	"openrouter-anthropic": {base: "openrouter", protocol: "anthropic"},
+	"kimi":                 {base: "moonshotai"},
+	"kimi-anthropic":       {base: "kimi-for-coding"},
+	"glm":                  {base: "zai"},
+	"minimax":              {base: "minimax"},
+	"ollama":               {base: "ollama"},
+}
+
+// vendorKeyEnv names each target provider's standard key variable (from the
+// registry's models.dev data). The old schema let a vendor instance with a
+// base_url inherit the vendor key; the registry deliberately does not, so
+// the converter writes the variable explicitly.
+var vendorKeyEnv = map[string]string{
+	"anthropic":       "ANTHROPIC_API_KEY",
+	"openai":          "OPENAI_API_KEY",
+	"google":          "GEMINI_API_KEY",
+	"openrouter":      "OPENROUTER_API_KEY",
+	"moonshotai":      "MOONSHOT_API_KEY",
+	"kimi-for-coding": "KIMI_API_KEY",
+	"zai":             "ZHIPU_API_KEY",
+	"minimax":         "MINIMAX_API_KEY",
+}
+
+var pureEnvRefRe = regexp.MustCompile(`^\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?$`)
+
+// isOldProvidersSchema reports whether src is a pre-registry providers.toml —
+// exactly the files the registry's own parser refuses with ErrOldSchema.
+func isOldProvidersSchema(src []byte) bool {
+	_, err := registry.ParseConfig(src)
+	return errors.Is(err, registry.ErrOldSchema)
+}
+
+// convertProvidersConfig rewrites a pre-registry providers.toml into the
+// schema-2 shape, recording every dropped field as a "# migrate:" comment in
+// the output and as a note for the report. The result is dry-parsed through
+// the registry's own reader before being returned, so a file this produces
+// is always one the registry can load.
+func convertProvidersConfig(src []byte) ([]byte, []string, error) {
+	var old oldFileShape
+	if _, err := toml.Decode(string(src), &old); err != nil {
+		return nil, nil, fmt.Errorf("parse old providers.toml: %w", err)
+	}
+	names := make([]string, 0, len(old.Instances))
+	for name := range old.Instances {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	defaultName := old.Default
+	if defaultName == "" && len(names) > 0 {
+		// The old loader's no-default rule picked the first sorted instance
+		// name; the registry ranks differently (§5.1), so pin the old pick.
+		defaultName = names[0]
+	}
+
+	var b strings.Builder
+	var notes []string
+	b.WriteString("# Converted from the pre-registry providers.toml schema by `evener migrate`.\n")
+	b.WriteString("schema = 2\n")
+	if defaultName != "" {
+		fmt.Fprintf(&b, "default = %q\n", defaultName)
+	}
+	for _, name := range names {
+		inst := old.Instances[name]
+		b.WriteString("\n")
+		target, known := oldTypeTarget[inst.Type]
+		if !known {
+			notes = append(notes, fmt.Sprintf("%s: unknown old type %q; instance commented out", name, inst.Type))
+			fmt.Fprintf(&b, "# migrate: instance %q had unknown type %q; re-create it with `evener providers add`\n", name, inst.Type)
+			fmt.Fprintf(&b, "# [providers.%s]\n", name)
+			continue
+		}
+		protocol := target.protocol
+		if inst.Type == "openai" && inst.APIStyle == "chat-completions" {
+			protocol = "openai-chat"
+		}
+		for dropped, present := range map[string]bool{
+			"quirks": inst.Quirks != "",
+			"compat": len(inst.Compat) > 0,
+			"models": len(inst.Models) > 0,
+		} {
+			if !present {
+				continue
+			}
+			notes = append(notes, fmt.Sprintf("%s: dropped %s (the registry derives this now)", name, dropped))
+		}
+		if inst.Quirks != "" {
+			fmt.Fprintf(&b, "# migrate: dropped quirks = %q — the registry derives protocol behavior now\n", inst.Quirks)
+		}
+		if len(inst.Compat) > 0 {
+			b.WriteString("# migrate: dropped the compat table — the registry derives wire behavior from provider data\n")
+		}
+		if len(inst.Models) > 0 {
+			b.WriteString("# migrate: dropped per-model overrides (models tables) — re-add with [providers.NAME.models] if still needed\n")
+		}
+		fmt.Fprintf(&b, "[providers.%s]\n", name)
+		if target.base != name {
+			fmt.Fprintf(&b, "base = %q\n", target.base)
+		}
+		if protocol != "" {
+			fmt.Fprintf(&b, "protocol = %q\n", protocol)
+		}
+		if inst.BaseURL != "" {
+			fmt.Fprintf(&b, "base_url = %q\n", inst.BaseURL)
+		}
+		switch {
+		case inst.APIKey == "":
+			if inst.BaseURL != "" {
+				if env, ok := vendorKeyEnv[target.base]; ok {
+					// See vendorKeyEnv: base_url instances no longer inherit.
+					fmt.Fprintf(&b, "api_key_env = [%q]\n", env)
+					notes = append(notes, fmt.Sprintf("%s: wrote api_key_env = [%q] — base_url instances no longer inherit the vendor key", name, env))
+				}
+			}
+		case pureEnvRefRe.MatchString(inst.APIKey):
+			fmt.Fprintf(&b, "api_key_env = [%q]\n", pureEnvRefRe.FindStringSubmatch(inst.APIKey)[1])
+		case !strings.Contains(inst.APIKey, "$"):
+			fmt.Fprintf(&b, "api_key = %q\n", inst.APIKey)
+		default:
+			notes = append(notes, fmt.Sprintf("%s: api_key used $-expansion the new schema does not spell; set it with `evener providers add`", name))
+			b.WriteString("# migrate: the old api_key mixed literal text with $VAR expansion; re-create the credential by hand\n")
+		}
+		writeStringTable(&b, name, "headers", inst.Headers)
+		writeStringTable(&b, name, "credential_headers", inst.CredentialHeaders)
+	}
+	out := []byte(b.String())
+	if _, err := registry.ParseConfig(out); err != nil {
+		return nil, notes, fmt.Errorf("converted providers.toml does not load: %w", err)
+	}
+	return out, notes, nil
+}
+
+func writeStringTable(b *strings.Builder, provider, key string, m map[string]string) {
+	if len(m) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "[providers.%s.%s]\n", provider, key)
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Fprintf(b, "%q = %q\n", k, m[k])
+	}
+}

--- a/cmd/evener-migrate/convert.go
+++ b/cmd/evener-migrate/convert.go
@@ -121,6 +121,13 @@ func convertProvidersConfig(src []byte) ([]byte, []string, error) {
 		if inst.Type == "openai" && inst.APIStyle == "chat-completions" {
 			protocol = "openai-chat"
 		}
+		// An old kimi-family instance pointed at the coding endpoint is the
+		// coding plan whatever its type said (§14.1: KIMI_API_KEY's meaning
+		// moved there at the flag day).
+		if (inst.Type == "kimi" || inst.Type == "kimi-anthropic") && strings.Contains(inst.BaseURL, "api.kimi.com/coding") {
+			target = oldTypeTarget["kimi-anthropic"]
+			protocol = target.protocol
+		}
 		for dropped, present := range map[string]bool{
 			"quirks": inst.Quirks != "",
 			"compat": len(inst.Compat) > 0,
@@ -153,7 +160,12 @@ func convertProvidersConfig(src []byte) ([]byte, []string, error) {
 		switch {
 		case inst.APIKey == "":
 			if inst.BaseURL != "" {
-				if env, ok := vendorKeyEnv[target.base]; ok {
+				// Old openai + chat-completions + base_url was the
+				// "openai-compatible" family: it never inherited a vendor
+				// key, so none is invented for it here.
+				if inst.Type == "openai" && inst.APIStyle == "chat-completions" {
+					notes = append(notes, fmt.Sprintf("%s: no key carried over (the old schema inherited none here); set api_key_env or credential_headers if the gateway needs one", name))
+				} else if env, ok := vendorKeyEnv[target.base]; ok {
 					// See vendorKeyEnv: base_url instances no longer inherit.
 					fmt.Fprintf(&b, "api_key_env = [%q]\n", env)
 					notes = append(notes, fmt.Sprintf("%s: wrote api_key_env = [%q] — base_url instances no longer inherit the vendor key", name, env))

--- a/cmd/evener-migrate/convert.go
+++ b/cmd/evener-migrate/convert.go
@@ -3,6 +3,9 @@ package migrate
 import (
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -187,4 +190,58 @@ func writeStringTable(b *strings.Builder, provider, key string, m map[string]str
 	for _, k := range keys {
 		fmt.Fprintf(b, "%q = %q\n", k, m[k])
 	}
+}
+
+// convertProvidersFile upgrades a pre-registry providers.toml sitting at the
+// final config location, keeping the original beside it as
+// providers.toml.pre-registry. It runs after the layout moves so a file
+// arriving from ~/.serf or ~/.evener is converted in the same invocation.
+func convertProvidersFile(opts options, rep *report, stdout, stderr io.Writer) {
+	path := filepath.Join(opts.configBase, "evener", "providers.toml")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return // no file, nothing to convert
+	}
+	if !isOldProvidersSchema(src) {
+		return
+	}
+	converted, notes, err := convertProvidersConfig(src)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "providers.toml: cannot convert: %v\n", err)
+		rep.failed++
+		return
+	}
+	if opts.dryRun {
+		_, _ = fmt.Fprintf(stdout, "providers.toml: would convert to schema 2 (backup: providers.toml.pre-registry)\n")
+		rep.moved++
+		return
+	}
+	backup := path + ".pre-registry"
+	if _, err := os.Stat(backup); err == nil {
+		_, _ = fmt.Fprintf(stderr, "providers.toml: refusing to convert: %s already exists\n", backup)
+		rep.failed++
+		return
+	}
+	if err := os.WriteFile(backup, src, 0o644); err != nil {
+		_, _ = fmt.Fprintf(stderr, "providers.toml: write backup: %v\n", err)
+		rep.failed++
+		return
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, converted, 0o644); err != nil {
+		_, _ = fmt.Fprintf(stderr, "providers.toml: write converted: %v\n", err)
+		rep.failed++
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		_, _ = fmt.Fprintf(stderr, "providers.toml: replace: %v\n", err)
+		rep.failed++
+		return
+	}
+	_, _ = fmt.Fprintf(stdout, "providers.toml: converted to schema 2 (backup: providers.toml.pre-registry)\n")
+	for _, n := range notes {
+		_, _ = fmt.Fprintf(stdout, "  note: %s\n", n)
+	}
+	rep.moved++
 }

--- a/cmd/evener-migrate/convert_fuzz_test.go
+++ b/cmd/evener-migrate/convert_fuzz_test.go
@@ -1,0 +1,34 @@
+package migrate
+
+import (
+	"bytes"
+	"testing"
+
+	"primeradiant.com/evener/llm/registry"
+)
+
+// FuzzConvertProvidersConfig drives the old-schema converter over arbitrary
+// bytes. Oracles: never panics; conversion is deterministic; and whenever it
+// reports success, the produced file loads through the registry's own parser
+// — the dry-parse guarantee convertProvidersConfig promises its callers.
+func FuzzConvertProvidersConfig(f *testing.F) {
+	f.Add([]byte("default = \"kimi\"\n\n[instances.kimi]\ntype = \"kimi\"\nbase_url = \"https://api.kimi.com/coding/v1\"\n"))
+	f.Add([]byte("[instances.gw]\ntype = \"openai\"\napi_style = \"chat-completions\"\nbase_url = \"http://localhost:1\"\napi_key = \"$VAR\"\n"))
+	f.Add([]byte("[instances.x]\ntype = \"glm\"\nquirks = \"glm\"\n[instances.x.compat]\nthinking_format = \"zai\"\n"))
+	f.Add([]byte("[instances.weird]\ntype = \"no-such-type\"\n"))
+	f.Add([]byte("schema = 1\n"))
+	f.Add([]byte(""))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		outA, notesA, errA := convertProvidersConfig(data)
+		outB, notesB, errB := convertProvidersConfig(data)
+		if (errA == nil) != (errB == nil) || !bytes.Equal(outA, outB) || len(notesA) != len(notesB) {
+			t.Fatal("nondeterministic conversion")
+		}
+		if errA != nil {
+			return
+		}
+		if _, err := registry.ParseConfig(outA); err != nil {
+			t.Fatalf("converted output must load through the registry parser: %v\n%s", err, outA)
+		}
+	})
+}

--- a/cmd/evener-migrate/convert_test.go
+++ b/cmd/evener-migrate/convert_test.go
@@ -1,6 +1,9 @@
 package migrate
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -171,5 +174,102 @@ func TestConvertOldConfig_OutputDeclaresSchemaTwo(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "schema = 2") {
 		t.Fatalf("converted file must declare schema = 2:\n%s", out)
+	}
+}
+
+func TestExecuteConvertsOldProvidersConfig(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".config", "evener")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "providers.toml")
+	src := []byte("default = \"kimi\"\n\n[instances.kimi]\ntype = \"kimi\"\n")
+	if err := os.WriteFile(path, src, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := execute(baseOpts(home, t.TempDir()), &stdout, &stderr); code != 0 {
+		t.Fatalf("code = %d; stderr = %q", code, stderr.String())
+	}
+	converted, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l, err := registry.ParseConfig(converted)
+	if err != nil {
+		t.Fatalf("providers.toml must be converted in place: %v\n%s", err, converted)
+	}
+	if l.Providers["kimi"].Base != "moonshotai" {
+		t.Fatalf("converted kimi base = %q", l.Providers["kimi"].Base)
+	}
+	backup, err := os.ReadFile(path + ".pre-registry")
+	if err != nil {
+		t.Fatalf("original must be backed up beside the file: %v", err)
+	}
+	if string(backup) != string(src) {
+		t.Fatalf("backup must hold the original bytes")
+	}
+	if !strings.Contains(stdout.String(), "providers.toml") {
+		t.Fatalf("report must mention the conversion:\n%s", stdout.String())
+	}
+}
+
+func TestExecuteDryRunLeavesOldProvidersConfig(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".config", "evener")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "providers.toml")
+	src := []byte("[instances.kimi]\ntype = \"kimi\"\n")
+	if err := os.WriteFile(path, src, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := baseOpts(home, t.TempDir())
+	opts.dryRun = true
+	var stdout, stderr bytes.Buffer
+	if code := execute(opts, &stdout, &stderr); code != 0 {
+		t.Fatalf("code = %d; stderr = %q", code, stderr.String())
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(src) {
+		t.Fatal("dry-run must not touch the file")
+	}
+	if !strings.Contains(stdout.String(), "providers.toml") {
+		t.Fatalf("dry-run must announce the pending conversion:\n%s", stdout.String())
+	}
+}
+
+func TestExecuteSkipsNewSchemaProvidersConfig(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".config", "evener")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "providers.toml")
+	src := []byte("schema = 2\n\n[providers.openai]\n")
+	if err := os.WriteFile(path, src, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := execute(baseOpts(home, t.TempDir()), &stdout, &stderr); code != 0 {
+		t.Fatalf("code = %d; stderr = %q", code, stderr.String())
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(src) {
+		t.Fatal("a new-schema file is not to be rewritten")
+	}
+	if _, err := os.Stat(path + ".pre-registry"); !os.IsNotExist(err) {
+		t.Fatal("no backup may appear for a new-schema file")
 	}
 }

--- a/cmd/evener-migrate/convert_test.go
+++ b/cmd/evener-migrate/convert_test.go
@@ -208,7 +208,7 @@ func TestExecuteConvertsOldProvidersConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("original must be backed up beside the file: %v", err)
 	}
-	if string(backup) != string(src) {
+	if !bytes.Equal(backup, src) {
 		t.Fatalf("backup must hold the original bytes")
 	}
 	if !strings.Contains(stdout.String(), "providers.toml") {
@@ -238,7 +238,7 @@ func TestExecuteDryRunLeavesOldProvidersConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(after) != string(src) {
+	if !bytes.Equal(after, src) {
 		t.Fatal("dry-run must not touch the file")
 	}
 	if !strings.Contains(stdout.String(), "providers.toml") {
@@ -266,7 +266,7 @@ func TestExecuteSkipsNewSchemaProvidersConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(after) != string(src) {
+	if !bytes.Equal(after, src) {
 		t.Fatal("a new-schema file is not to be rewritten")
 	}
 	if _, err := os.Stat(path + ".pre-registry"); !os.IsNotExist(err) {

--- a/cmd/evener-migrate/convert_test.go
+++ b/cmd/evener-migrate/convert_test.go
@@ -1,0 +1,175 @@
+package migrate
+
+import (
+	"strings"
+	"testing"
+
+	"primeradiant.com/evener/llm/registry"
+)
+
+func TestIsOldProvidersSchema(t *testing.T) {
+	if !isOldProvidersSchema([]byte("[instances.kimi]\ntype = \"kimi\"\n")) {
+		t.Fatal("old-schema file must be detected")
+	}
+	if isOldProvidersSchema([]byte("schema = 2\n\n[providers.openai]\n")) {
+		t.Fatal("new-schema file must not be detected as old")
+	}
+	if isOldProvidersSchema([]byte("not toml at all = = =")) {
+		t.Fatal("unparseable file is not convertible")
+	}
+}
+
+func TestConvertOldConfig_MapsTypesAndDefault(t *testing.T) {
+	src := []byte(`default = "kimi"
+
+[instances.kimi]
+type = "kimi"
+
+[instances.glm]
+type = "glm"
+
+[instances.km]
+type = "kimi-anthropic"
+
+[instances.ora]
+type = "openrouter-anthropic"
+
+[instances.lunaroute]
+type = "openai"
+api_style = "chat-completions"
+base_url = "http://localhost:8892/v1"
+
+[instances.openrouter]
+type = "openrouter"
+`)
+	out, _, err := convertProvidersConfig(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l, err := registry.ParseConfig(out)
+	if err != nil {
+		t.Fatalf("converted file must load through the real parser: %v\n%s", err, out)
+	}
+	if l.Default != "kimi" {
+		t.Fatalf("default = %q, want kimi", l.Default)
+	}
+	want := map[string]struct{ base, protocol, baseURL string }{
+		"kimi":       {base: "moonshotai"},
+		"glm":        {base: "zai"},
+		"km":         {base: "kimi-for-coding"},
+		"ora":        {base: "openrouter", protocol: "anthropic"},
+		"lunaroute":  {base: "openai", protocol: "openai-chat", baseURL: "http://localhost:8892/v1"},
+		"openrouter": {}, // name is already the registry id: no base needed
+	}
+	for name, w := range want {
+		p, ok := l.Providers[name]
+		if !ok {
+			t.Fatalf("instance %q missing from converted config", name)
+		}
+		if p.Base != w.base || p.Protocol != w.protocol || p.Transport.BaseURL != w.baseURL {
+			t.Fatalf("%s: base=%q protocol=%q base_url=%q, want %+v", name, p.Base, p.Protocol, p.Transport.BaseURL, w)
+		}
+	}
+}
+
+func TestConvertOldConfig_CredentialForms(t *testing.T) {
+	src := []byte(`[instances.gw]
+type = "openrouter"
+api_key = "$MY_GATEWAY_KEY"
+
+[instances.lit]
+type = "openrouter"
+api_key = "sk-or-literal"
+
+[instances.anthropic]
+type = "anthropic"
+base_url = "https://gw.example.com/anthropic"
+
+[instances.hdr]
+type = "openrouter"
+headers = { "X-Route" = "a" }
+credential_headers = { "X-Secret" = "$SECRET_VAR" }
+`)
+	out, _, err := convertProvidersConfig(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l, err := registry.ParseConfig(out)
+	if err != nil {
+		t.Fatalf("converted file must load: %v\n%s", err, out)
+	}
+	if got := l.Providers["gw"].APIKeyEnv; len(got) != 1 || got[0] != "MY_GATEWAY_KEY" {
+		t.Fatalf("gw api_key_env = %v, want [MY_GATEWAY_KEY]", got)
+	}
+	if got := l.Providers["lit"].APIKey; got != "sk-or-literal" {
+		t.Fatalf("lit api_key = %q, want the literal carried", got)
+	}
+	// The old schema let a vendor instance with base_url inherit the vendor
+	// key; the registry deliberately does not, so the converter writes the
+	// standard variable explicitly.
+	if got := l.Providers["anthropic"].APIKeyEnv; len(got) != 1 || got[0] != "ANTHROPIC_API_KEY" {
+		t.Fatalf("anthropic api_key_env = %v, want [ANTHROPIC_API_KEY]", got)
+	}
+	if got := l.Providers["hdr"].Headers["X-Route"]; got != "a" {
+		t.Fatalf("headers must carry: %v", l.Providers["hdr"].Headers)
+	}
+	if got := l.Providers["hdr"].CredentialHeaders["X-Secret"]; got != "$SECRET_VAR" {
+		t.Fatalf("credential_headers must carry: %v", l.Providers["hdr"].CredentialHeaders)
+	}
+}
+
+func TestConvertOldConfig_DropsCompatQuirksModelsWithNote(t *testing.T) {
+	src := []byte(`[instances.kimi]
+type = "kimi"
+quirks = "kimi"
+
+[instances.kimi.compat]
+thinking_format = "openrouter"
+
+[instances.kimi.models."kimi-k3"]
+context_window = 262144
+`)
+	out, notes, err := convertProvidersConfig(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.ParseConfig(out); err != nil {
+		t.Fatalf("converted file must load: %v\n%s", err, out)
+	}
+	text := string(out)
+	for _, dropped := range []string{"quirks", "compat", "models"} {
+		if !strings.Contains(text, "# migrate: ") || !strings.Contains(text, dropped) {
+			t.Fatalf("dropped %q must be recorded as a comment:\n%s", dropped, text)
+		}
+	}
+	if len(notes) == 0 {
+		t.Fatal("dropping fields must surface notes for the report")
+	}
+}
+
+func TestConvertOldConfig_WritesExplicitDefault(t *testing.T) {
+	src := []byte("[instances.zeta]\ntype = \"openrouter\"\n\n[instances.alpha]\ntype = \"ollama\"\n")
+	out, _, err := convertProvidersConfig(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l, err := registry.ParseConfig(out)
+	if err != nil {
+		t.Fatalf("converted file must load: %v\n%s", err, out)
+	}
+	// The old loader picked the first sorted instance name when the file set
+	// no default; the ranking rule changed, so the converter pins the old pick.
+	if l.Default != "alpha" {
+		t.Fatalf("default = %q, want alpha (old sorted-name pick made explicit)", l.Default)
+	}
+}
+
+func TestConvertOldConfig_OutputDeclaresSchemaTwo(t *testing.T) {
+	out, _, err := convertProvidersConfig([]byte("[instances.ollama]\ntype = \"ollama\"\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "schema = 2") {
+		t.Fatalf("converted file must declare schema = 2:\n%s", out)
+	}
+}

--- a/cmd/evener-migrate/convert_test.go
+++ b/cmd/evener-migrate/convert_test.go
@@ -273,3 +273,50 @@ func TestExecuteSkipsNewSchemaProvidersConfig(t *testing.T) {
 		t.Fatal("no backup may appear for a new-schema file")
 	}
 }
+
+func TestConvertOldConfig_KimiCodingEndpointMapsToKimiForCoding(t *testing.T) {
+	// An old type = "kimi" instance pointed at the coding endpoint is the
+	// coding plan, whatever its type said: kimi-for-coding, KIMI_API_KEY.
+	src := []byte("[instances.kimi]\ntype = \"kimi\"\nbase_url = \"https://api.kimi.com/coding/v1\"\n")
+	out, _, err := convertProvidersConfig(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l, err := registry.ParseConfig(out)
+	if err != nil {
+		t.Fatalf("converted file must load: %v\n%s", err, out)
+	}
+	p := l.Providers["kimi"]
+	if p.Base != "kimi-for-coding" {
+		t.Fatalf("base = %q, want kimi-for-coding", p.Base)
+	}
+	if len(p.APIKeyEnv) != 1 || p.APIKeyEnv[0] != "KIMI_API_KEY" {
+		t.Fatalf("api_key_env = %v, want [KIMI_API_KEY]", p.APIKeyEnv)
+	}
+}
+
+func TestConvertOldConfig_OpenAICompatGatewayGetsNoInjectedKey(t *testing.T) {
+	// Old openai + chat-completions + base_url was the "openai-compatible"
+	// family: it inherited no vendor key, so the converter must not invent one.
+	src := []byte("[instances.gw]\ntype = \"openai\"\napi_style = \"chat-completions\"\nbase_url = \"http://localhost:8892/v1\"\n")
+	out, notes, err := convertProvidersConfig(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l, err := registry.ParseConfig(out)
+	if err != nil {
+		t.Fatalf("converted file must load: %v\n%s", err, out)
+	}
+	if got := l.Providers["gw"].APIKeyEnv; len(got) != 0 {
+		t.Fatalf("api_key_env = %v, want none injected", got)
+	}
+	found := false
+	for _, n := range notes {
+		if strings.Contains(n, "gw") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("the credential question must surface as a note: %v", notes)
+	}
+}

--- a/cmd/evener-migrate/main.go
+++ b/cmd/evener-migrate/main.go
@@ -1,5 +1,7 @@
 // Command evener-migrate migrates user data to the final evener layout. It is
 // invoked as `evener migrate` (see cmd/evener); this package holds its logic.
+// Besides moving files, it converts a pre-registry providers.toml found at
+// the final config location to the current schema (convert.go).
 //
 // It handles three source generations:
 //

--- a/cmd/evener-migrate/main.go
+++ b/cmd/evener-migrate/main.go
@@ -176,6 +176,8 @@ func execute(opts options, stdout, stderr io.Writer) int {
 		}
 	}
 
+	convertProvidersFile(opts, &rep, stdout, stderr)
+
 	if !opts.dryRun {
 		// The retired home roots hold nothing evener-migrate doesn't already
 		// know how to place elsewhere — once every known file is out, the

--- a/docs/llm-provider-config-and-launch.md
+++ b/docs/llm-provider-config-and-launch.md
@@ -260,8 +260,12 @@ equivalent allowlist function to describe here.
 
 ## Upgrading from the old schema
 
-There's no migration code. After upgrading, do the following once — the
-release notes and the load-error message both point here.
+Run `evener migrate` once after upgrading: it converts an old-schema
+`providers.toml` in place, keeps the original beside it as
+`providers.toml.pre-registry`, and records every dropped field as a
+`# migrate:` comment. The rest of this section is the by-hand story, for
+when you'd rather rewrite the file yourself — the release notes and the
+load-error message both point here.
 
 **`providers.toml` fails to load.** An old-schema file (`[instances.*]`,
 `type`, `api_style`, `quirks`, `compat`) fails to load. The CLI exits with a
@@ -269,8 +273,8 @@ pointer to
 [`docs/superpowers/specs/2026-08-28-provider-registry-design.md`](superpowers/specs/2026-08-28-provider-registry-design.md);
 the hub starts with implicit instances only, shows the error as a
 diagnostic, launches sessions against the implicit set, and refuses
-instance writes until the file is fixed. Fix it by hand — edit, delete, or
-move the file aside; nothing does this automatically. Most users need no
+instance writes until the file is fixed. Fix it with `evener migrate`, or by
+hand — edit, delete, or move the file aside. Most users need no
 file at all afterward: every implicit provider (see the table in
 [`llm-providers.md`](llm-providers.md#the-implicit-provider-list)) exists
 from its key alone, and `*_BASE_URL` variables cover proxies. Re-create a

--- a/docs/superpowers/specs/2026-08-28-provider-registry-design.md
+++ b/docs/superpowers/specs/2026-08-28-provider-registry-design.md
@@ -1641,9 +1641,14 @@ in `llm/providers/openai/adapter.go` and `responses.go` that moves behind the
 ## 10. `providers.toml`
 
 Same schema as the registry. Every key is optional except that an instance
-must end up with a protocol and a base URL after layering.
+must end up with a protocol and a base URL after layering. The file may
+declare `schema = 2` — the format version, stamped on everything the
+registry writes. Absent means 2 (files predate the field); `schema = 1` is
+refused as the pre-registry schema; any other value is refused as
+unsupported (amended 2026-08-31).
 
 ```toml
+schema  = 2
 default = "groq"
 
 [providers.groq]                        # name matches a registry id → inherits it
@@ -2152,15 +2157,20 @@ building the new packages beside the old ones and cutting over last.
 
 ### 14.1 Flag day
 
-There is no migration code. After upgrading, a user does the following
-once, and the release notes and the load-error pointer say so:
+Migration is one command: `evener migrate` converts an old-schema
+`providers.toml` in place, keeping the original beside it as
+`providers.toml.pre-registry`, mapping each instance to its registry
+provider, and recording every dropped field as a `# migrate:` comment
+(amended 2026-08-31; the decision as first taken shipped no migration
+code). A user who prefers to rewrite by hand does the following once, and
+the release notes and the load-error pointer say so:
 
 - **`providers.toml`**: an old-schema file (`[instances.*]`, `type`,
   `api_style`, `quirks`, `compat`) fails to load. The CLI exits with the
   pointer; the hub starts with implicit instances only, shows the error as
   a diagnostic, launches sessions against the implicit set, and refuses
-  instance writes until the file is fixed (§10, §11.3). The user edits,
-  deletes, or moves the file aside by hand. Most users need no file at all
+  instance writes until the file is fixed (§10, §11.3). The user runs
+  `evener migrate`, or edits, deletes, or moves the file aside by hand. Most users need no file at all
   afterwards: every provider on the implicit list (§6.2) exists from its
   key, and `*_BASE_URL` variables cover proxies. A gateway or a custom-named
   instance is re-created with `evener providers add … --api-key-env NAME`

--- a/llm/registry/schema.go
+++ b/llm/registry/schema.go
@@ -79,6 +79,7 @@ var oldSchemaKeys = []string{"type", "api_style", "quirks", "compat"}
 // (spec §10). Caps embeds directly so every cap is a key by its snake_case
 // name; transportSchema adds the transport keys at the same level.
 type fileSchema struct {
+	Schema       int                        `toml:"schema"`
 	Default      string                     `toml:"default"`
 	DefaultOrder []string                   `toml:"default_order"`
 	Transports   map[string]transportSchema `toml:"transports"`
@@ -160,6 +161,13 @@ func parseLayer(data []byte, tag string, curated bool) (*Layer, error) {
 		return nil, fmt.Errorf("%s: %w", tag, err)
 	}
 	if !curated {
+		switch fs.Schema {
+		case 0, 2: // absent means current (schema 2); every earlier file omitted it
+		case 1:
+			return nil, fmt.Errorf("%w (schema = 1)", ErrOldSchema)
+		default:
+			return nil, fmt.Errorf("%s: unsupported schema %d (this evener reads schema 2)", tag, fs.Schema)
+		}
 		if md.IsDefined("instances") {
 			return nil, fmt.Errorf("%w ([instances.*])", ErrOldSchema)
 		}

--- a/llm/registry/schema.go
+++ b/llm/registry/schema.go
@@ -39,7 +39,7 @@ type Layer struct {
 
 // ErrOldSchema marks a providers.toml written for the pre-registry schema
 // (spec §14.1). Callers match it with errors.Is.
-var ErrOldSchema = errors.New("providers.toml uses the pre-registry schema ([instances.*], type, api_style, quirks, compat); rewrite it per docs/superpowers/specs/2026-08-28-provider-registry-design.md §14.1")
+var ErrOldSchema = errors.New("providers.toml uses the pre-registry schema ([instances.*], type, api_style, quirks, compat); run `evener migrate` to convert it, or rewrite it per docs/superpowers/specs/2026-08-28-provider-registry-design.md §14.1")
 
 // Vocabularies validated at load (spec §10).
 var (

--- a/llm/registry/schema_test.go
+++ b/llm/registry/schema_test.go
@@ -381,3 +381,26 @@ func TestParseConfig_DefaultEffortVocabulary(t *testing.T) {
 		t.Fatalf("a typo must be refused by name and list the vocabulary: %v", err)
 	}
 }
+
+func TestParseConfig_SchemaTwoAccepted(t *testing.T) {
+	if _, err := ParseConfig([]byte("schema = 2\n\n[providers.openai]\n")); err != nil {
+		t.Fatalf("schema = 2 must parse: %v", err)
+	}
+}
+
+func TestParseConfig_SchemaOneIsOldSchema(t *testing.T) {
+	_, err := ParseConfig([]byte("schema = 1\n\n[providers.openai]\n"))
+	if !errors.Is(err, ErrOldSchema) {
+		t.Fatalf("schema = 1: want ErrOldSchema, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "§14.1") {
+		t.Fatalf("old-schema error must point at the spec: %v", err)
+	}
+}
+
+func TestParseConfig_UnsupportedSchemaNamesIt(t *testing.T) {
+	_, err := ParseConfig([]byte("schema = 3\n"))
+	if err == nil || !strings.Contains(err.Error(), "unsupported schema 3") || !strings.Contains(err.Error(), "2") {
+		t.Fatalf("schema = 3 must name the unsupported version and the supported one: %v", err)
+	}
+}

--- a/llm/registry/schema_test.go
+++ b/llm/registry/schema_test.go
@@ -404,3 +404,13 @@ func TestParseConfig_UnsupportedSchemaNamesIt(t *testing.T) {
 		t.Fatalf("schema = 3 must name the unsupported version and the supported one: %v", err)
 	}
 }
+
+func TestParseConfig_OldSchemaErrorNamesMigrate(t *testing.T) {
+	_, err := ParseConfig([]byte("[instances.kimi]\ntype = \"kimi\"\n"))
+	if !errors.Is(err, ErrOldSchema) {
+		t.Fatalf("want ErrOldSchema, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "evener migrate") {
+		t.Fatalf("old-schema error must point at evener migrate: %v", err)
+	}
+}

--- a/llm/registry/write.go
+++ b/llm/registry/write.go
@@ -27,7 +27,7 @@ var ErrConfigUnloadable = errors.New("providers.toml would not load back")
 // empty api_key_env list is kept: `api_key_env = []` is how a Codex-style
 // entry says "no key variable" (spec §6.2).
 func MarshalConfig(l *Layer) ([]byte, error) {
-	doc := map[string]any{}
+	doc := map[string]any{"schema": 2}
 	if l.Default != "" {
 		doc["default"] = l.Default
 	}

--- a/llm/registry/write_test.go
+++ b/llm/registry/write_test.go
@@ -182,3 +182,16 @@ func TestReadConfigFileReportsOldSchema(t *testing.T) {
 		t.Fatalf("want ErrOldSchema, got %v", err)
 	}
 }
+
+func TestMarshalConfig_StampsSchemaTwo(t *testing.T) {
+	data, err := MarshalConfig(&Layer{Default: "openai"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "schema = 2") {
+		t.Fatalf("marshalled config must declare schema = 2:\n%s", data)
+	}
+	if _, err := ParseConfig(data); err != nil {
+		t.Fatalf("stamped config must round-trip: %v", err)
+	}
+}

--- a/scripts/fuzz/fuzz-targets.txt
+++ b/scripts/fuzz/fuzz-targets.txt
@@ -27,6 +27,7 @@ native:.:./appwire:FuzzMessageDecodeStructured
 native:.:./appwire:FuzzTurnPagingEquivalence
 native:.:./appwire:FuzzMethodParams
 native:.:./appwire:FuzzWireTypes
+native:.:./cmd/evener-migrate:FuzzConvertProvidersConfig
 native:agent:.:FuzzToolArgsValidate:./internal/tool,.
 native:agent:./schema:FuzzSessionMetaRoundTrip
 native:agent:./schema:FuzzSessionDisplayName


### PR DESCRIPTION
Approved follow-up to the registry flag-day: old configs now auto-upgrade, and the file format carries a version number for the next time.

**`schema = 2`** — providers.toml declares its format version. Absent reads as 2 (every existing new-schema file stays valid), `schema = 1` gets the old-schema error, any other value is refused as unsupported. `WriteConfigFile` stamps it on everything it writes.

**`evener migrate` converts pre-registry configs** — a fourth generation for the existing migration command: an old-schema (`[instances.*]`) providers.toml at the final config location is converted in place, original kept as `providers.toml.pre-registry`, every dropped field recorded as a `# migrate:` comment plus a report note, and the result dry-parsed through the registry's own reader before anything lands. The flag-day error now names `evener migrate`.

Mapping is grounded in the deleted adapters' actual defaults and old credential-inheritance rules (`CredentialTag`): bare `kimi`→`moonshotai`, `glm`→`zai`, `kimi`-family on the coding endpoint→`kimi-for-coding`+`KIMI_API_KEY`, old openai+chat gateways get **no** invented key (they never inherited one), other vendor types with `base_url` get their standard var written explicitly since inheritance is gone, and the old sorted-name default pick is pinned as an explicit `default`.

Spec §10/§14.1 and the user upgrade guide amended. TDD throughout; smoke-tested end-to-end against a copy of a real pre-registry config in a fake home (dry-run, real run, backup byte-compare). Full gate green against the accepted roster.