### PR TITLE
job_list typed-decode filters; job_watch trigger-field errors

### DIFF
--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -770,7 +770,10 @@ func validateWatchEventArgs(a watchArgs) error {
 	}
 	if a.Every > 0 {
 		if len(a.Events) != 1 {
-			return errors.New("invalid_request: every requires exactly one watched event kind")
+			if len(a.Events) == 0 {
+				return errors.New(`invalid_request: every requires events naming exactly one kind (e.g. events ["communicate"], every 3); every with no events has nothing to fire on`)
+			}
+			return errors.New(`invalid_request: every requires events naming exactly one kind, not several (e.g. events ["communicate"], every 3)`)
 		}
 		if a.Events[0] == "*" {
 			return errors.New(`invalid_request: every requires a single concrete event kind, not "*"`)
@@ -778,7 +781,7 @@ func validateWatchEventArgs(a watchArgs) error {
 	}
 	if a.EventFilter != nil {
 		if len(a.Events) == 0 {
-			return errors.New("invalid_request: event_filter requires events")
+			return errors.New(`invalid_request: event_filter requires events naming assistant.tool (e.g. events ["assistant.tool"], event_filter {"tool_name":"read_file","status":"ok"}); event_filter with no events has nothing to filter`)
 		}
 		if len(a.Events) != 1 || a.Events[0] != "assistant.tool" {
 			if len(a.Events) == 1 && a.Events[0] == "communicate" {

--- a/agent/job_watch_branches_test.go
+++ b/agent/job_watch_branches_test.go
@@ -380,13 +380,13 @@ func TestValidateWatchEventArgs(t *testing.T) {
 	})
 	t.Run("every with zero events", func(t *testing.T) {
 		err := validateWatchEventArgs(watchArgs{Every: 3})
-		if err == nil || !strings.Contains(err.Error(), "every requires exactly one") {
+		if err == nil || !strings.Contains(err.Error(), "every requires events naming exactly one kind") {
 			t.Fatalf("expected error, got %v", err)
 		}
 	})
 	t.Run("every with multiple events", func(t *testing.T) {
 		err := validateWatchEventArgs(watchArgs{Every: 3, Events: []string{"job.notification", "communicate"}})
-		if err == nil || !strings.Contains(err.Error(), "every requires exactly one") {
+		if err == nil || !strings.Contains(err.Error(), "every requires events naming exactly one kind") {
 			t.Fatalf("expected error, got %v", err)
 		}
 	})
@@ -398,7 +398,7 @@ func TestValidateWatchEventArgs(t *testing.T) {
 	})
 	t.Run("event_filter without events", func(t *testing.T) {
 		err := validateWatchEventArgs(watchArgs{EventFilter: &watchEventFilter{}})
-		if err == nil || !strings.Contains(err.Error(), "event_filter requires events") {
+		if err == nil || !strings.Contains(err.Error(), "event_filter requires events naming assistant.tool") {
 			t.Fatalf("expected error, got %v", err)
 		}
 	})

--- a/agent/job_watch_config_test.go
+++ b/agent/job_watch_config_test.go
@@ -385,7 +385,7 @@ func TestConfigureWatchRejectsUnsupportedEventFilterShapes(t *testing.T) {
 		{
 			name: "without_events",
 			args: watchArgs{Target: runtimeMessageAliasCaller, EventFilter: &watchEventFilter{ToolName: "read_file"}},
-			want: "event_filter requires events",
+			want: "event_filter requires events naming assistant.tool",
 		},
 		{
 			name: "wrong_event",
@@ -450,8 +450,8 @@ func TestConfigureWatchRejectsEveryWithMultipleEvents(t *testing.T) {
 		Events: []string{"communicate", "job.notification"},
 		Every:  2,
 	})
-	if err == nil || !strings.Contains(err.Error(), "every requires exactly one watched event kind") {
-		t.Fatalf("error = %v, want every requires exactly one watched event kind", err)
+	if err == nil || !strings.Contains(err.Error(), "every requires events naming exactly one kind") {
+		t.Fatalf("error = %v, want every requires events naming exactly one kind", err)
 	}
 	if jm.watchCount() != 0 {
 		t.Fatalf("watch count = %d, want 0", jm.watchCount())
@@ -459,8 +459,8 @@ func TestConfigureWatchRejectsEveryWithMultipleEvents(t *testing.T) {
 
 	// every>1 with zero events should also fail (no event to throttle).
 	_, err = jm.configureWatch(watchArgs{Target: "caller", Every: 2})
-	if err == nil || !strings.Contains(err.Error(), "every requires exactly one watched event kind") {
-		t.Fatalf("bare every with no events: error = %v, want every requires exactly one watched event kind", err)
+	if err == nil || !strings.Contains(err.Error(), "every with no events has nothing to fire on") {
+		t.Fatalf("bare every with no events: error = %v, want every with no events has nothing to fire on", err)
 	}
 
 	// every:1 reads as unset, so bare every:1 is a watch with no condition.

--- a/agent/session_tools_jobs.go
+++ b/agent/session_tools_jobs.go
@@ -1872,15 +1872,21 @@ var watchTriggerFieldNames = []string{"output_match", "progress_interval_ms", "e
 // trigger field the call actually supplied alongside a non-create operation.
 // Omitting all of them stays valid: create on a granted cross-session source
 // (parent) watches all bounded public events, and list/inspect/clear need none.
+// Nullable trigger fields (progress_interval_ms, every — schema type
+// ["integer","null"]) with a null value count as omitted, matching how
+// shellIntArg decodes them everywhere else: a client serializing optional
+// fields as null is not arming a trigger.
 func rejectWatchTriggerFieldsOnNonCreate(args map[string]any, a watchArgs) error {
 	if a.Operation == "create" {
 		return nil
 	}
 	var supplied []string
 	for _, name := range watchTriggerFieldNames {
-		if _, ok := args[name]; ok {
-			supplied = append(supplied, name)
+		value, ok := args[name]
+		if !ok || value == nil {
+			continue
 		}
+		supplied = append(supplied, name)
 	}
 	if len(supplied) == 0 {
 		return nil

--- a/agent/session_tools_jobs.go
+++ b/agent/session_tools_jobs.go
@@ -1853,10 +1853,42 @@ func watchArgsFromToolArgs(args map[string]any) (watchArgs, error) {
 	default:
 		return watchArgs{}, fmt.Errorf("invalid_request: unsupported operation %q", a.Operation)
 	}
+	if err := rejectWatchTriggerFieldsOnNonCreate(args, a); err != nil {
+		return watchArgs{}, err
+	}
 	if a.Source == "*" {
 		return watchArgs{}, errors.New("invalid_request: wildcard watch target is not supported in v1")
 	}
 	return a, nil
+}
+
+// watchTriggerFieldNames lists the arguments that select what a created watch
+// fires on, in the DefJobWatch property order. They are meaningful only for
+// operation="create"; list/inspect/clear take only watch_id, so a trigger field
+// beside them was previously parsed and then silently ignored.
+var watchTriggerFieldNames = []string{"output_match", "progress_interval_ms", "events", "every", "event_filter"}
+
+// rejectWatchTriggerFieldsOnNonCreate returns an invalid_request naming every
+// trigger field the call actually supplied alongside a non-create operation.
+// Omitting all of them stays valid: create on a granted cross-session source
+// (parent) watches all bounded public events, and list/inspect/clear need none.
+func rejectWatchTriggerFieldsOnNonCreate(args map[string]any, a watchArgs) error {
+	if a.Operation == "create" {
+		return nil
+	}
+	var supplied []string
+	for _, name := range watchTriggerFieldNames {
+		if _, ok := args[name]; ok {
+			supplied = append(supplied, name)
+		}
+	}
+	if len(supplied) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"invalid_request: trigger fields apply only to operation=\"create\"; %s supplied with operation=%q — set operation=\"create\" to arm a watch, or drop %s to %s",
+		strings.Join(supplied, ", "), a.Operation, strings.Join(supplied, ", "), a.Operation,
+	)
 }
 
 func watchEventFilterArg(args map[string]any) (*watchEventFilter, error) {

--- a/agent/session_tools_jobs.go
+++ b/agent/session_tools_jobs.go
@@ -1781,7 +1781,11 @@ func jobStatusArrayArg(args map[string]any, key string) ([]jobstore.Status, erro
 	}
 	statuses := make([]jobstore.Status, 0, len(values))
 	for _, value := range values {
-		status := jobstore.Status(fmt.Sprint(value))
+		s, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s values must be strings", key)
+		}
+		status := jobstore.Status(s)
 		switch status {
 		case jobstore.StatusRunning,
 			jobstore.Status("idle"), jobstore.Status("settling"), jobstore.Status("stopping"), jobstore.Status("closed"),
@@ -1947,7 +1951,11 @@ func jobTypeArrayArg(args map[string]any, key string) ([]jobstore.JobType, error
 	}
 	types := make([]jobstore.JobType, 0, len(values))
 	for _, value := range values {
-		jobType := jobstore.JobType(fmt.Sprint(value))
+		s, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s values must be strings", key)
+		}
+		jobType := jobstore.JobType(s)
 		switch jobType {
 		case jobstore.JobShell, jobstore.JobType(delegateResourceType):
 			types = append(types, jobType)

--- a/agent/session_tools_jobs_covtest2_test.go
+++ b/agent/session_tools_jobs_covtest2_test.go
@@ -254,6 +254,14 @@ func TestCovJobStatusArrayArg2(t *testing.T) {
 	if !reflect.DeepEqual(statuses, wantStatuses) {
 		t.Fatalf("all statuses = %v, want %v", statuses, wantStatuses)
 	}
+
+	// Wrong-typed element — named error, not fmt.Sprint noise.
+	for _, bad := range []any{float64(1), true, nil, map[string]any{"status": "running"}} {
+		_, err = jobStatusArrayArg(map[string]any{"status": []any{bad}}, "status")
+		if err == nil || !strings.Contains(err.Error(), "status values must be strings") {
+			t.Fatalf("wrong-typed element %#v: err = %v", bad, err)
+		}
+	}
 }
 
 // TestCovJobTypeArrayArg covers jobTypeArrayArg
@@ -284,6 +292,14 @@ func TestCovJobTypeArrayArg2(t *testing.T) {
 	_, err = jobTypeArrayArg(map[string]any{"type": []any{"invalid_type"}}, "type")
 	if err == nil || !strings.Contains(err.Error(), "invalid job type") {
 		t.Fatalf("invalid type: %v", err)
+	}
+
+	// Wrong-typed element — named error, not fmt.Sprint noise.
+	for _, bad := range []any{float64(1), true, nil, map[string]any{"type": "shell"}} {
+		_, err = jobTypeArrayArg(map[string]any{"type": []any{bad}}, "type")
+		if err == nil || !strings.Contains(err.Error(), "type values must be strings") {
+			t.Fatalf("wrong-typed element %#v: err = %v", bad, err)
+		}
 	}
 }
 

--- a/agent/session_tools_jobs_watch_test.go
+++ b/agent/session_tools_jobs_watch_test.go
@@ -224,6 +224,164 @@ func TestJobWatchCreateReturnsIDAndClearUsesIDOnly(t *testing.T) {
 	}
 }
 
+// TestWatchArgsFromToolArgsRejectsTriggerFieldsOnNonCreateOperations covers the
+// one-trigger-mode-per-create contract from the other side: trigger fields
+// (output_match, events, event_filter, every, progress_interval_ms) select what a
+// NEW watch fires on, so supplying them with list/inspect/clear is a misuse the
+// parse used to swallow — those operations take only watch_id, and the trigger
+// fields silently did nothing.
+func TestWatchArgsFromToolArgsRejectsTriggerFieldsOnNonCreateOperations(t *testing.T) {
+	t.Parallel()
+	for name, args := range map[string]map[string]any{
+		"list with events": {
+			"operation": "list",
+			"events":    []any{"communicate"},
+		},
+		"list with output_match": {
+			"operation":    "list",
+			"output_match": "ready",
+		},
+		"list with progress_interval_ms": {
+			"operation":            "list",
+			"progress_interval_ms": 5000,
+		},
+		"list with every": {
+			"operation": "list",
+			"every":     2,
+		},
+		"inspect with events": {
+			"operation": "inspect",
+			"watch_id":  "watch_x",
+			"events":    []any{"communicate"},
+		},
+		"clear with event_filter": {
+			"operation":    "clear",
+			"watch_id":     "watch_x",
+			"event_filter": map[string]any{"tool_name": "read_file"},
+		},
+		"clear with output_match": {
+			"operation":    "clear",
+			"watch_id":     "watch_x",
+			"output_match": "ready",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := watchArgsFromToolArgs(args)
+			if err == nil {
+				t.Fatal("watchArgsFromToolArgs succeeded, want invalid_request")
+			}
+			if !strings.Contains(err.Error(), "invalid_request") {
+				t.Fatalf("error = %v, want invalid_request", err)
+			}
+			for _, field := range []string{"events", "output_match", "progress_interval_ms", "every", "event_filter"} {
+				if _, ok := args[field]; ok {
+					if !strings.Contains(err.Error(), field) {
+						t.Fatalf("error = %v, want it to name the supplied trigger field %q", err, field)
+					}
+				}
+			}
+			if !strings.Contains(err.Error(), "operation=\"create\"") {
+				t.Fatalf("error = %v, want it to name operation=\"create\" as the valid alternative", err)
+			}
+		})
+	}
+}
+
+// TestWatchArgsFromToolArgsAcceptsTriggerFieldsOnCreate pins the flip side of the
+// rejection above: every trigger field stays valid on create, so the new guard
+// cannot start rejecting legitimate installs.
+func TestWatchArgsFromToolArgsAcceptsTriggerFieldsOnCreate(t *testing.T) {
+	t.Parallel()
+	for name, args := range map[string]map[string]any{
+		"events": {
+			"operation": "create",
+			"source":    "self",
+			"events":    []any{"communicate"},
+		},
+		"output_match": {
+			"operation":    "create",
+			"source":       "job_x",
+			"output_match": "ready",
+		},
+		"progress_interval_ms": {
+			"operation":            "create",
+			"source":               "job_x",
+			"progress_interval_ms": 5000,
+		},
+		"every": {
+			"operation": "create",
+			"source":    "self",
+			"events":    []any{"communicate"},
+			"every":     2,
+		},
+		"event_filter": {
+			"operation":    "create",
+			"source":       "self",
+			"events":       []any{"assistant.tool"},
+			"event_filter": map[string]any{"tool_name": "read_file"},
+		},
+		"none (watch-all)": {
+			"operation": "create",
+			"source":    "parent",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := watchArgsFromToolArgs(args); err != nil {
+				t.Fatalf("watchArgsFromToolArgs returned error: %v", err)
+			}
+		})
+	}
+}
+
+// TestJobWatchValidationNamesRuleAndFixForBareEventModifiers covers the two
+// "modifier without events" errors the model actually hits: `every` with no
+// events names the supplied field, the rule (events must name exactly one
+// concrete kind), and the fix; `event_filter` with no events does the same with
+// the concrete assistant.tool shape.
+func TestJobWatchValidationNamesRuleAndFixForBareEventModifiers(t *testing.T) {
+	t.Parallel()
+	s := newTestSession(t)
+
+	for _, tc := range []struct {
+		name string
+		args string
+		want []string
+	}{
+		{
+			name: "every without events",
+			args: `{"operation":"create","source":"self","every":3}`,
+			want: []string{"every", "events", "exactly one", "communicate"},
+		},
+		{
+			name: "event_filter without events",
+			args: `{"operation":"create","source":"self","event_filter":{"tool_name":"read_file","status":"ok"}}`,
+			want: []string{"event_filter", "events", "assistant.tool", "tool_name"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res := s.reg.ExecuteCall(context.Background(), s.env, llm.ToolCallData{
+				ID:        "watch",
+				Name:      "job_watch",
+				Arguments: json.RawMessage(tc.args),
+			})
+			if !res.IsError {
+				t.Fatalf("job_watch succeeded, want validation error: %s", res.Output)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(res.Output, want) {
+					t.Fatalf("job_watch error = %q, want it to contain %q", res.Output, want)
+				}
+			}
+			if s.jobManager.watchCount() != 0 {
+				t.Fatalf("watch count = %d, want 0", s.jobManager.watchCount())
+			}
+		})
+	}
+}
+
 func TestJobWatchRejectsRemovedPublicShapes(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
@@ -239,6 +397,8 @@ func TestJobWatchRejectsRemovedPublicShapes(t *testing.T) {
 		{name: "source wildcard", args: `{"operation":"create","source":"*","events":["job.notification"]}`, want: "wildcard watch target is not supported"},
 		{name: "legacy target rejected", args: `{"operation":"create","target":"caller","events":["job.notification"]}`, want: "additionalProperties 'target' not allowed"},
 		{name: "legacy send rejected", args: `{"operation":"create","source":"self","events":["job.notification"],"send":{"to":"job_observer","message":"observe"}}`, want: "additionalProperties 'send' not allowed"},
+		{name: "list with trigger field", args: `{"operation":"list","events":["job.notification"]}`, want: "trigger fields apply only to operation=\"create\""},
+		{name: "clear with trigger field", args: `{"operation":"clear","watch_id":"watch_x","progress_interval_ms":120000}`, want: "operation=\"create\""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/agent/session_tools_jobs_watch_test.go
+++ b/agent/session_tools_jobs_watch_test.go
@@ -288,6 +288,42 @@ func TestWatchArgsFromToolArgsRejectsTriggerFieldsOnNonCreateOperations(t *testi
 	}
 }
 
+// TestWatchArgsFromToolArgsTreatsNullTriggerFieldsAsOmitted pins the nullable-
+// trigger-field contract (roborev review on PR #736): progress_interval_ms and
+// every are schema-typed ["integer","null"], and shellIntArg decodes null as
+// omitted everywhere else — a non-create call serializing optional fields as
+// null is not arming a trigger and must not be rejected.
+func TestWatchArgsFromToolArgsTreatsNullTriggerFieldsAsOmitted(t *testing.T) {
+	t.Parallel()
+	for name, args := range map[string]map[string]any{
+		"list with null progress_interval_ms": {
+			"operation":            "list",
+			"progress_interval_ms": nil,
+		},
+		"list with null every": {
+			"operation": "list",
+			"every":     nil,
+		},
+		"inspect with both null": {
+			"operation":            "inspect",
+			"watch_id":             "watch_x",
+			"progress_interval_ms": nil,
+			"every":                nil,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			a, err := watchArgsFromToolArgs(args)
+			if err != nil {
+				t.Fatalf("watchArgsFromToolArgs rejected null trigger field: %v", err)
+			}
+			if a.ProgressIntervalMS != 0 || a.Every != 0 {
+				t.Fatalf("null trigger field decoded nonzero: %+v", a)
+			}
+		})
+	}
+}
+
 // TestWatchArgsFromToolArgsAcceptsTriggerFieldsOnCreate pins the flip side of the
 // rejection above: every trigger field stays valid on create, so the new guard
 // cannot start rejecting legitimate installs.

--- a/agent/watch_config_validation_program_fuzz_test.go
+++ b/agent/watch_config_validation_program_fuzz_test.go
@@ -169,9 +169,9 @@ func wcvpAssertPureContracts(t *testing.T, r *wcvpReader) {
 	}{
 		{watchArgs{Events: []string{"assistant.message"}}, "invalid_request: assistant.message"},
 		{watchArgs{Events: []string{"not-real"}}, "invalid_request: unknown event"},
-		{watchArgs{Every: 2}, "invalid_request: every requires exactly"},
+		{watchArgs{Every: 2}, "invalid_request: every requires events naming exactly one kind"},
 		{watchArgs{Events: []string{"*"}, Every: 2}, "invalid_request: every requires a single concrete"},
-		{watchArgs{EventFilter: &watchEventFilter{}}, "invalid_request: event_filter requires events"},
+		{watchArgs{EventFilter: &watchEventFilter{}}, "invalid_request: event_filter requires events naming assistant.tool"},
 		{watchArgs{Events: []string{"communicate"}, EventFilter: &watchEventFilter{}}, "invalid_request: event_filter matches assistant.tool events; parent"},
 		{watchArgs{Events: []string{"job.notification"}, EventFilter: &watchEventFilter{}}, "invalid_request: event_filter matches assistant.tool events; use"},
 		{watchArgs{Events: []string{"assistant.tool"}, EventFilter: &watchEventFilter{Status: "bad"}}, "invalid_request: event_filter.status"},

--- a/agent/watch_pure_covtest_test.go
+++ b/agent/watch_pure_covtest_test.go
@@ -153,7 +153,7 @@ func TestCovValidateWatchEventArgs(t *testing.T) {
 
 	// Every with multiple events → error.
 	err = validateWatchEventArgs(watchArgs{Events: []string{"assistant.tool", "communicate"}, Every: 2})
-	if err == nil || !strings.Contains(err.Error(), "every requires exactly one") {
+	if err == nil || !strings.Contains(err.Error(), "every requires events naming exactly one kind") {
 		t.Fatalf("every multi: %v", err)
 	}
 
@@ -165,7 +165,7 @@ func TestCovValidateWatchEventArgs(t *testing.T) {
 
 	// Event filter without events → error.
 	err = validateWatchEventArgs(watchArgs{EventFilter: &watchEventFilter{}})
-	if err == nil || !strings.Contains(err.Error(), "event_filter requires events") {
+	if err == nil || !strings.Contains(err.Error(), "event_filter requires events naming assistant.tool") {
 		t.Fatalf("event_filter no events: %v", err)
 	}
 


### PR DESCRIPTION
Follow-up to #731 (two fixes developed in parallel with its merge; rebased onto main).

## 1. Typed-decode fixes for job_list filters (6d39d8c22)

Same bug class as the task_list "<nil>" status fix in #731: jobStatusArrayArg and jobTypeArrayArg coerced each array element with fmt.Sprint before the enum switch, so a wrong-typed element (number, bool, null, object) surfaced as enum noise like 'invalid job status "<nil>"'. Both now assert value.(string) and return '<key> values must be strings', matching the file's existing stringArrayArg pattern. Wrong-typed elements pinned by tests for both parsers.

## 2. job_watch trigger-mode error messages (dbe5f8ab0)

Investigation findings (each confirmed empirically):
- Two trigger modes on create: rejected with good messages on session sources; intentionally accepted as composition on concrete job sources (pinned by TestTerminalCatchupRejectsEventsCondition, documented as a separate progress trigger) — deliberately unchanged.
- Trigger fields on list/inspect/clear: were silently ignored (parsed, then discarded) — a real silent-ignore bug. Now rejected naming the supplied fields, the rule, and both fixes; watch-all on create is preserved.
- every/event_filter without events: were rejected with terse messages; now actionable with examples.

Tool schema untouched — error-message work only.

## Verification

- go test ./agent/ -count=1 — ok
- go test -tags evenerfuzz -run '^Fuzz' -count=1 . ./agent/... — all 41 packages ok
- make vet, make lint (9/9 sub-gates), gofmt -l agent/ empty

Both fixes were built TDD by subagents, reviewed and independently re-verified here before merge.