### PR TITLE
feat(rail): show shell-job command and intent in the sidebar

### DIFF
--- a/agent/internal/jobstore/event.go
+++ b/agent/internal/jobstore/event.go
@@ -36,8 +36,10 @@ type Event struct {
 	WatchID string `json:"watch_id,omitempty"`
 
 	// job_started payload
-	Type             JobType    `json:"type,omitempty"`
-	Command          string     `json:"command,omitempty"`
+	Type    JobType `json:"type,omitempty"`
+	Command string  `json:"command,omitempty"`
+	// Intent carries JobRecord.Intent for job_started (see its doc comment).
+	Intent           string     `json:"intent,omitempty"`
 	Task             string     `json:"task,omitempty"`
 	Description      string     `json:"description,omitempty"`
 	ParentSessionID  string     `json:"parent_session_id,omitempty"`

--- a/agent/internal/jobstore/fold.go
+++ b/agent/internal/jobstore/fold.go
@@ -182,6 +182,7 @@ func applyEvent(r *JobRecord, e Event) {
 	case EventJobStarted:
 		r.Type = e.Type
 		r.Command = e.Command
+		r.Intent = e.Intent
 		r.WorkingDir = e.WorkingDir
 		r.Task = e.Task
 		r.Description = e.Description

--- a/agent/internal/jobstore/record.go
+++ b/agent/internal/jobstore/record.go
@@ -160,6 +160,13 @@ type JobRecord struct {
 	ExhaustionLimit  int     `json:"exhaustion_limit,omitempty"`
 	Description      string  `json:"description,omitempty"`
 	Command          string  `json:"command,omitempty"`
+	// Intent is the tool call's `intent` argument (the model's own one-line
+	// statement of why this command is being run), captured at launch.
+	// Distinct from Description (the shell tool's separate `description`
+	// arg): Description is a human gloss for the command; Intent is the
+	// purpose the caller stated. Both may be present, and either may be
+	// empty when the model omitted it.
+	Intent string `json:"intent,omitempty"`
 	// Background reports that a shell job is running in the background rather
 	// than being waited on inline: stamped at launch for mode:"background", and
 	// at promotion when a foreground command outlives its block timeout. No

--- a/agent/internal/tool/registry.go
+++ b/agent/internal/tool/registry.go
@@ -696,9 +696,10 @@ func (r *Registry) ExecuteCall(ctx context.Context, env execenv.ExecutionEnviron
 		// The handler can no longer see intent in args — but the shell tool
 		// stamps it onto the job record (so job surfaces can show why the
 		// model said it is running the command), so keep it reachable on ctx.
-		if strings.TrimSpace(intent) != "" {
-			ctx = context.WithValue(ctx, ctxIntentKey{}, intent)
-		}
+		// Set unconditionally: a nested call reusing a context that already
+		// carries a stale intent would otherwise inherit it when this call
+		// omits intent.
+		ctx = context.WithValue(ctx, ctxIntentKey{}, strings.TrimSpace(intent))
 	}
 	v, err := t.Exec(ctx, env, args)
 	res := dispatchedResult(name, callID, t.Limit, v, err)

--- a/agent/internal/tool/registry.go
+++ b/agent/internal/tool/registry.go
@@ -37,6 +37,22 @@ const toolIntentDescription = "Describe what you expect to learn or accomplish f
 // keep the two values in sync by comment.)
 const maxToolArgumentBytes = 2 * 1024 * 1024
 
+// ctxIntentKey is the context key carrying a tool call's `intent` argument
+// past the registry's strip point (see ExecuteCall): handlers that want it —
+// the shell tool, stamping it onto the job record — read it with IntentFromContext.
+type ctxIntentKey struct{}
+
+// IntentFromContext returns the tool call's `intent` argument threaded onto
+// ctx by the registry, or "" when the call carried none. It exists so a
+// handler can still see intent after the registry removed it from args.
+func IntentFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	intent, _ := ctx.Value(ctxIntentKey{}).(string)
+	return intent
+}
+
 func WithIntentParameter(td llm.ToolDefinition) llm.ToolDefinition {
 	params := CloneSchemaMap(td.Parameters)
 	if params == nil {
@@ -675,7 +691,14 @@ func (r *Registry) ExecuteCall(ctx context.Context, env execenv.ExecutionEnviron
 	}
 
 	if name != "read_file" {
+		intent, _ := args["intent"].(string)
 		delete(args, "intent")
+		// The handler can no longer see intent in args — but the shell tool
+		// stamps it onto the job record (so job surfaces can show why the
+		// model said it is running the command), so keep it reachable on ctx.
+		if strings.TrimSpace(intent) != "" {
+			ctx = context.WithValue(ctx, ctxIntentKey{}, intent)
+		}
 	}
 	v, err := t.Exec(ctx, env, args)
 	res := dispatchedResult(name, callID, t.Limit, v, err)

--- a/agent/job_shell.go
+++ b/agent/job_shell.go
@@ -46,8 +46,12 @@ const (
 )
 
 type shellArgs struct {
-	Command        string
-	Description    string
+	Command     string
+	Description string
+	// Intent is the tool call's `intent` argument (see ctxToolCallIntent):
+	// why the model says it is running the command. Stamped onto the job
+	// record so job surfaces can show it with the command.
+	Intent         string
 	Mode           shellMode
 	Background     bool
 	BlockTimeoutMS int
@@ -516,6 +520,7 @@ func (jm *jobManager) newDelayedShell(args shellArgs) (*runningJob, error) {
 			Type:             jobstore.JobShell,
 			Status:           jobstore.StatusRunning,
 			Command:          args.Command,
+			Intent:           args.Intent,
 			WorkingDir:       args.WorkingDir,
 			Background:       args.Background,
 			Description:      args.Description,
@@ -605,6 +610,7 @@ func (jm *jobManager) commitDelayedShell(run *runningJob) error {
 		JobID:            rec.JobID,
 		Type:             rec.Type,
 		Command:          rec.Command,
+		Intent:           rec.Intent,
 		Description:      rec.Description,
 		OwnerSessionID:   rec.OwnerSessionID,
 		VisibleToSession: rec.VisibleToSession,

--- a/agent/job_shell.go
+++ b/agent/job_shell.go
@@ -49,6 +49,7 @@ type shellArgs struct {
 	Command     string
 	Description string
 	// Intent is the tool call's `intent` argument (see ctxToolCallIntent):
+	// Intent is the tool call's `intent` argument (see tool.IntentFromContext):
 	// why the model says it is running the command. Stamped onto the job
 	// record so job surfaces can show it with the command.
 	Intent         string

--- a/agent/jobs.go
+++ b/agent/jobs.go
@@ -558,6 +558,7 @@ func (n jobNotification) isWatch() bool {
 
 type createShellOpts struct {
 	Command     string
+	Intent      string
 	Description string
 }
 
@@ -895,6 +896,7 @@ func (jm *jobManager) createShell(opts createShellOpts) (*jobstore.JobRecord, er
 		Type:             jobstore.JobShell,
 		Status:           jobstore.StatusRunning,
 		Command:          opts.Command,
+		Intent:           opts.Intent,
 		Description:      opts.Description,
 		OwnerSessionID:   jm.sessionID,
 		VisibleToSession: jm.sessionID,
@@ -927,6 +929,7 @@ func (jm *jobManager) createShell(opts createShellOpts) (*jobstore.JobRecord, er
 		JobID:            rec.JobID,
 		Type:             rec.Type,
 		Command:          rec.Command,
+		Intent:           rec.Intent,
 		Description:      rec.Description,
 		OwnerSessionID:   rec.OwnerSessionID,
 		VisibleToSession: rec.VisibleToSession,

--- a/agent/jobs_nested.go
+++ b/agent/jobs_nested.go
@@ -541,6 +541,7 @@ func (jm *jobManager) recoverForwardedTerminalEvents() error {
 			JobID:            rec.JobID,
 			Type:             rec.Type,
 			Command:          rec.Command,
+			Intent:           rec.Intent,
 			Task:             rec.Task,
 			Description:      rec.Description,
 			ParentSessionID:  rec.ParentSessionID,

--- a/agent/session_tools_shell.go
+++ b/agent/session_tools_shell.go
@@ -141,7 +141,7 @@ func registerShellTools(reg *tool.Registry, s *Session, deps *toolDeps) error {
 	if err := register(tool.RegisteredTool{
 		Definition: tool.DefShell(),
 		Exec: func(ctx context.Context, env execenv.ExecutionEnvironment, args map[string]any) (any, error) {
-			shellArgs, err := parseShellToolArgs(args)
+			shellArgs, err := parseShellToolArgs(ctx, args)
 			if err != nil {
 				return "", err
 			}
@@ -276,7 +276,7 @@ func registerShellTools(reg *tool.Registry, s *Session, deps *toolDeps) error {
 	return nil
 }
 
-func parseShellToolArgs(args map[string]any) (shellArgs, error) {
+func parseShellToolArgs(ctx context.Context, args map[string]any) (shellArgs, error) {
 	mode, err := parseShellMode(args)
 	if err != nil {
 		return shellArgs{}, err
@@ -284,8 +284,11 @@ func parseShellToolArgs(args map[string]any) (shellArgs, error) {
 	parsed := shellArgs{
 		Command:     fmt.Sprint(args["command"]),
 		Description: stringArg(args, "description"),
-		Mode:        mode,
-		Background:  mode == shellModeBackground,
+		// The registry stripped intent from args before dispatch; recover it
+		// from the exec context (see tool.IntentFromContext).
+		Intent:     tool.IntentFromContext(ctx),
+		Mode:       mode,
+		Background: mode == shellModeBackground,
 		// WorkingDir is the raw model-supplied cwd, if any; "" means omitted. It is
 		// resolved (relative paths joined against env.WorkingDirectory(), validated
 		// against the sandbox root) by resolveShellWorkingDir before dispatch, which

--- a/agent/session_tools_shell_test.go
+++ b/agent/session_tools_shell_test.go
@@ -334,8 +334,9 @@ func TestShellDetachedRejectsInvalidCwdBeforeDetach(t *testing.T) {
 // TestShellToolIntentLandsOnJobRecord: the tool call's `intent` argument is
 // captured on the shell job record, so job surfaces (the sidebar rail, the
 // activity panel) can show why the model said it is running the command. The
-// registry strips intent from args before handlers run; execTool re-threads it
-// on ctx (ctxToolCallIntent) and parseShellToolArgs reads it back.
+// registry strips intent from args before handlers run and threads it onto
+// ctx (tool.IntentFromContext) at the strip point, so parseShellToolArgs can
+// read it back.
 func TestShellToolIntentLandsOnJobRecord(t *testing.T) {
 	t.Parallel()
 	s := newTestSession(t)

--- a/agent/session_tools_shell_test.go
+++ b/agent/session_tools_shell_test.go
@@ -331,6 +331,50 @@ func TestShellDetachedRejectsInvalidCwdBeforeDetach(t *testing.T) {
 	}
 }
 
+// TestShellToolIntentLandsOnJobRecord: the tool call's `intent` argument is
+// captured on the shell job record, so job surfaces (the sidebar rail, the
+// activity panel) can show why the model said it is running the command. The
+// registry strips intent from args before handlers run; execTool re-threads it
+// on ctx (ctxToolCallIntent) and parseShellToolArgs reads it back.
+func TestShellToolIntentLandsOnJobRecord(t *testing.T) {
+	t.Parallel()
+	s := newTestSession(t)
+
+	// TRIPWIRE: starting a background shell job returns as soon as the job
+	// is recorded (see TestShellToolBackgroundReturnsJobID); this normally
+	// returns in well under a second, so 30s only fires on a genuine hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	res := s.reg.ExecuteCall(ctx, s.env, llm.ToolCallData{
+		ID:   "c-intent",
+		Name: "shell",
+		Arguments: json.RawMessage(
+			`{"command":"sleep 30","mode":"background","intent":"Running the suite to find the failure"}`),
+	})
+	if res.IsError {
+		t.Fatalf("shell returned error: %s", res.Output)
+	}
+	var out struct {
+		JobID string `json:"job_id"`
+	}
+	if err := json.Unmarshal(toolResultJSON(res), &out); err != nil {
+		t.Fatalf("unmarshal shell output: %v (output: %s)", err, res.Output)
+	}
+	t.Cleanup(func() {
+		_, _ = s.jobManager.stop(out.JobID)
+		waitForShellDone(t, s.jobManager, out.JobID)
+	})
+
+	jobs := s.jobManager.list(listFilter{})
+	if len(jobs) != 1 {
+		t.Fatalf("jobs = %d, want 1", len(jobs))
+	}
+	if got := jobs[0].Intent; got != "Running the suite to find the failure" {
+		t.Fatalf("job record Intent = %q, want the tool call's intent", got)
+	}
+}
+
 func TestShellToolBackgroundReturnsJobID(t *testing.T) {
 	t.Parallel()
 	s := newTestSession(t)
@@ -462,7 +506,7 @@ func TestShellBackgroundCompletionRetainsUnterminatedOutput(t *testing.T) {
 
 func TestParseShellToolArgsClampsSmallMaxRuntime(t *testing.T) {
 	t.Parallel()
-	args, err := parseShellToolArgs(map[string]any{
+	args, err := parseShellToolArgs(context.Background(), map[string]any{
 		"command":        "sleep 30",
 		"max_runtime_ms": float64(1),
 	})
@@ -972,7 +1016,7 @@ func TestParseShellToolArgsMode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseShellToolArgs(tt.args)
+			got, err := parseShellToolArgs(context.Background(), tt.args)
 			if tt.wantErr != "" {
 				if err == nil || err.Error() != tt.wantErr {
 					t.Fatalf("error = %v, want %q", err, tt.wantErr)
@@ -988,7 +1032,7 @@ func TestParseShellToolArgsMode(t *testing.T) {
 
 func TestParseShellToolArgsRejectsNegativeMaxRuntime(t *testing.T) {
 	t.Parallel()
-	if _, err := parseShellToolArgs(map[string]any{
+	if _, err := parseShellToolArgs(context.Background(), map[string]any{
 		"command":        "echo hi",
 		"max_runtime_ms": -1,
 	}); err == nil {

--- a/agent/status.go
+++ b/agent/status.go
@@ -45,6 +45,7 @@ type JobStatusInfo struct {
 	OutputBytes      int64  `json:"output_bytes"`
 	ExitCode         *int   `json:"exit_code,omitempty"`
 	Command          string `json:"command,omitempty"`
+	Intent           string `json:"intent,omitempty"`
 	Task             string `json:"task,omitempty"`
 }
 
@@ -406,6 +407,7 @@ func projectJobStatusInfos(records []*jobstore.JobRecord) []JobStatusInfo {
 			OutputBytes:      rec.OutputBytes,
 			ExitCode:         rec.ExitCode,
 			Command:          rec.Command,
+			Intent:           rec.Intent,
 			Task:             rec.Task,
 		})
 	}

--- a/agent/status_test.go
+++ b/agent/status_test.go
@@ -528,11 +528,14 @@ func TestSession_DetailedStatus_Jobs(t *testing.T) {
 	startedAt := time.Now().UTC()
 	endedAt := startedAt.Add(time.Second)
 	const jobID = "job_status_projection"
+	const intent = "Running the test suite to find the failure"
 	if err := sess.jobManager.store.Append(jobstore.Event{
 		Kind:             jobstore.EventJobStarted,
 		TS:               startedAt,
 		JobID:            jobID,
 		Type:             jobstore.JobShell,
+		Command:          "go test ./...",
+		Intent:           intent,
 		OwnerSessionID:   sess.ID(),
 		VisibleToSession: sess.ID(),
 		StartedAt:        &startedAt,
@@ -562,6 +565,9 @@ func TestSession_DetailedStatus_Jobs(t *testing.T) {
 		job.Reason != "exit_nonzero" || job.TranscriptRef != shellTranscriptRef(jobID) ||
 		job.OutputBytes != 128 || job.ExitCode == nil || *job.ExitCode != exitCode {
 		t.Fatalf("job status = %+v", job)
+	}
+	if job.Intent != intent {
+		t.Fatalf("job intent = %q, want %q", job.Intent, intent)
 	}
 }
 

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -884,6 +884,11 @@ type EvenerJobInfo struct {
 	FromWatch        bool   `json:"fromWatch,omitempty"`
 	Background       bool   `json:"background,omitempty"`
 	Command          string `json:"command,omitempty"`
+	// Intent is the tool call's `intent` argument (see WithIntentParameter):
+	// the model's own one-line statement of why the command is being run.
+	// Captured on the job record at launch so job surfaces (the sidebar rail,
+	// the activity panel) can show it alongside the command.
+	Intent           string `json:"intent,omitempty"`
 	ParentDelegateID string `json:"parentDelegateId,omitempty"`
 	DelegateID       string `json:"delegateId,omitempty"`
 	Task             string `json:"task,omitempty"`

--- a/cmd/evener-hub/frontend/src/dev/surface-sections/rail.tsx
+++ b/cmd/evener-hub/frontend/src/dev/surface-sections/rail.tsx
@@ -84,7 +84,22 @@ const PROJECT_RESOURCE: NavigationProjectResource = {
   revision: 1,
   key: "proj_evener",
   current: {
-    sessions: [session({ ref: "ref_proj_1", title: "Add the surfaces gallery", state: "active" })],
+    sessions: [
+      session({
+        ref: "ref_proj_1",
+        title: "Add the surfaces gallery",
+        state: "active",
+        running_jobs: [
+          {
+            job_id: "job_running_1",
+            job_type: "shell",
+            status: "running",
+            command: "go build ./... && go test ./internal/migrate/...",
+            intent: "Building the tree before running the migration tests",
+          },
+        ],
+      }),
+    ],
     remaining: 0,
   },
   recent: { sessions: [], remaining: 0 },

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -284,6 +284,7 @@ export interface EvenerJobInfo {
   fromWatch?: boolean;
   background?: boolean;
   command?: string;
+  intent?: string;
   parentDelegateId?: string;
   delegateId?: string;
   task?: string;
@@ -956,6 +957,8 @@ export interface NavigationJobSummary {
   command?: string;
   task?: string;
   reason?: string;
+  intent?: string;
+  full_command?: string;
 }
 
 export interface NavigationManifest {

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
@@ -471,6 +471,35 @@ describe("job rows", () => {
     expect(screen.getByTestId("rail-row-job-status").className.split(" ")).toContain(railStyles.activityAlive);
   });
 
+  test("the tooltip shows the command and the tool call's intent", () => {
+    render(
+      <RailRow
+        node={jobRailNode({
+          command: "go test ./...",
+          intent: "Running the package tests to find the failure",
+        })}
+        info={info()}
+        actions={actions()}
+      />,
+    );
+    expect(screen.getByTitle("go test ./... · Running the package tests to find the failure · running")).toBeTruthy();
+  });
+
+  test("the tooltip prefers the full command when the label was truncated", () => {
+    const long = "echo a".repeat(200);
+    render(
+      <RailRow
+        node={jobRailNode({
+          command: "echo a…",
+          full_command: long,
+        })}
+        info={info()}
+        actions={actions()}
+      />,
+    );
+    expect(screen.getByTitle(`${long} · running`)).toBeTruthy();
+  });
+
   test("renders a separate completed-jobs disclosure", () => {
     const toggle = vi.fn();
     render(

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
@@ -730,6 +730,21 @@ function jobLabel(job: JobRailNode["job"]): string {
   return job.command?.trim() || job.task?.trim() || job.job_type?.trim() || job.job_id;
 }
 
+// jobTitle is the job row's hover tooltip: the full command that actually ran
+// (full_command, untruncated, when the label's command was cut by the wire's
+// label bound) plus the tool call's `intent` — why the model said it is
+// running the command. Status rides along the same way the old single-line
+// title carried it, so a hover still answers "what is this doing" end to end.
+function jobTitle(job: JobRailNode["job"], status: string): string {
+  const command =
+    job.full_command?.trim() || job.command?.trim() || job.task?.trim() || job.job_type?.trim() || job.job_id;
+  const intent = job.intent?.trim();
+  if (intent) {
+    return `${command} · ${intent} · ${status}`;
+  }
+  return `${command} · ${status}`;
+}
+
 function JobRow({ node }: { node: JobRailNode }) {
   const active = node.active;
   const status = node.job.status.trim() || (active ? "running" : "completed");
@@ -738,7 +753,7 @@ function JobRow({ node }: { node: JobRailNode }) {
       <span className={CLASS.textCol}>
         <span className={CLASS.titleLine}>
           <Signal wireState={active ? "active" : status === "failed" ? "errored" : "ended"} />
-          <span className={CLASS.label} title={`${jobLabel(node.job)} · ${status}`}>
+          <span className={CLASS.label} title={jobTitle(node.job, status)}>
             {jobLabel(node.job)}
           </span>
         </span>

--- a/cmd/evener-hub/frontend/src/stores/navigation/store.ts
+++ b/cmd/evener-hub/frontend/src/stores/navigation/store.ts
@@ -215,7 +215,9 @@ function jobs(value: unknown): boolean {
         string(candidate.status) &&
         optional(candidate.command, string) &&
         optional(candidate.task, string) &&
-        optional(candidate.reason, string),
+        optional(candidate.reason, string) &&
+        optional(candidate.intent, string) &&
+        optional(candidate.full_command, string),
     )
   );
 }

--- a/cmd/evener-hub/navigation_projection.go
+++ b/cmd/evener-hub/navigation_projection.go
@@ -28,10 +28,16 @@ const (
 	maxNavigationManifestBytes = 256 * 1024
 	maxNavigationCatalogBytes  = 512 * 1024
 
-	maxNavigationTitleRunes      = 200
-	maxNavigationLabelRunes      = 512
-	maxNavigationIdentityBytes   = 1_024
-	maxNavigationWorkingDirBytes = 4_096
+	maxNavigationTitleRunes = 200
+	maxNavigationLabelRunes = 512
+	// maxNavigationFullCommandRunes bounds FullCommand, the tooltip-sized
+	// untruncated command. Generous rather than label-tight: a tooltip can
+	// wrap, but it must not lie — a cut-off "full" command is worse than a
+	// long one. Still bounded so one pathological command cannot dominate
+	// the response's byte budget (navigationJSONFits).
+	maxNavigationFullCommandRunes = 4_096
+	maxNavigationIdentityBytes    = 1_024
+	maxNavigationWorkingDirBytes  = 4_096
 )
 
 type navigationResourceKind string
@@ -1074,12 +1080,14 @@ func navigationJobs(jobs []appwire.EvenerJobInfo) hubapi.NavigationArray[hubapi.
 	out := make(hubapi.NavigationArray[hubapi.NavigationJobSummary], 0, len(jobs))
 	for _, job := range jobs {
 		out = append(out, hubapi.NavigationJobSummary{
-			JobID:   job.JobID,
-			JobType: job.JobType,
-			Status:  job.Status,
-			Command: truncateNavigationRunes(job.Command, maxNavigationLabelRunes),
-			Task:    truncateNavigationRunes(job.Task, maxNavigationLabelRunes),
-			Reason:  truncateNavigationRunes(job.Reason, maxNavigationLabelRunes),
+			JobID:       job.JobID,
+			JobType:     job.JobType,
+			Status:      job.Status,
+			Command:     truncateNavigationRunes(job.Command, maxNavigationLabelRunes),
+			FullCommand: truncateNavigationRunes(job.Command, maxNavigationFullCommandRunes),
+			Task:        truncateNavigationRunes(job.Task, maxNavigationLabelRunes),
+			Reason:      truncateNavigationRunes(job.Reason, maxNavigationLabelRunes),
+			Intent:      truncateNavigationRunes(job.Intent, maxNavigationLabelRunes),
 		})
 	}
 	return out

--- a/cmd/evener-hub/navigation_projection.go
+++ b/cmd/evener-hub/navigation_projection.go
@@ -1079,16 +1079,22 @@ func (p navigationProjector) projectShallow(node hubcore.TreeNode) hubapi.Naviga
 func navigationJobs(jobs []appwire.EvenerJobInfo) hubapi.NavigationArray[hubapi.NavigationJobSummary] {
 	out := make(hubapi.NavigationArray[hubapi.NavigationJobSummary], 0, len(jobs))
 	for _, job := range jobs {
-		out = append(out, hubapi.NavigationJobSummary{
-			JobID:       job.JobID,
-			JobType:     job.JobType,
-			Status:      job.Status,
-			Command:     truncateNavigationRunes(job.Command, maxNavigationLabelRunes),
-			FullCommand: truncateNavigationRunes(job.Command, maxNavigationFullCommandRunes),
-			Task:        truncateNavigationRunes(job.Task, maxNavigationLabelRunes),
-			Reason:      truncateNavigationRunes(job.Reason, maxNavigationLabelRunes),
-			Intent:      truncateNavigationRunes(job.Intent, maxNavigationLabelRunes),
-		})
+		summary := hubapi.NavigationJobSummary{
+			JobID:   job.JobID,
+			JobType: job.JobType,
+			Status:  job.Status,
+			Command: truncateNavigationRunes(job.Command, maxNavigationLabelRunes),
+			Task:    truncateNavigationRunes(job.Task, maxNavigationLabelRunes),
+			Reason:  truncateNavigationRunes(job.Reason, maxNavigationLabelRunes),
+			Intent:  truncateNavigationRunes(job.Intent, maxNavigationLabelRunes),
+		}
+		// Emit FullCommand only when the label bound actually cut the
+		// command, so a short command isn't duplicated and a tooltip never
+		// shows less than the label.
+		if summary.Command != job.Command {
+			summary.FullCommand = truncateNavigationRunes(job.Command, maxNavigationFullCommandRunes)
+		}
+		out = append(out, summary)
 	}
 	return out
 }

--- a/cmd/evener-hub/navigation_projection_test.go
+++ b/cmd/evener-hub/navigation_projection_test.go
@@ -157,6 +157,34 @@ func TestNavigationJobSummaryKeepsFullCommandForTooltip(t *testing.T) {
 	}
 }
 
+func TestNavigationJobSummaryOmitsFullCommandWhenLabelFits(t *testing.T) {
+	project := hubcore.TreeProject{
+		Key:  "project",
+		Name: "project",
+		Current: []hubcore.TreeNode{{
+			ID:    "session-parent",
+			Title: "parent",
+			Kind:  "session",
+			State: "idle",
+			RunningJobs: []appwire.EvenerJobInfo{{
+				JobID: "job-running", JobType: "shell", Status: "running", Command: "go test ./...",
+			}},
+		}},
+	}
+	projection, err := buildNavigationProjection(navigationBuildInputs{GenerationID: "generation", Tree: hubcore.Tree{Projects: []hubcore.TreeProject{project}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource, ok := projection.Project("project")
+	if !ok {
+		t.Fatal("project missing")
+	}
+	job := resource.Current.Sessions[0].RunningJobs[0]
+	if job.FullCommand != "" {
+		t.Fatalf("full_command = %q, want empty when the command fits the label bound", job.FullCommand)
+	}
+}
+
 func TestNavigationProjectionRejectsMalformedIdentity(t *testing.T) {
 	_, err := buildNavigationProjection(navigationBuildInputs{GenerationID: "generation", Tree: hubcore.Tree{Live: []hubcore.TreeNode{{ID: "bad ref", Title: "bad", Kind: "session", State: "idle"}}}})
 	if err == nil {

--- a/cmd/evener-hub/navigation_projection_test.go
+++ b/cmd/evener-hub/navigation_projection_test.go
@@ -95,7 +95,7 @@ func TestNavigationProjectionCarriesActiveAndCompletedJobs(t *testing.T) {
 			Kind:  "session",
 			State: "idle",
 			RunningJobs: []appwire.EvenerJobInfo{{
-				JobID: "job-running", JobType: "shell", Status: "running", Command: "go test ./...",
+				JobID: "job-running", JobType: "shell", Status: "running", Command: "go test ./...", Intent: "Running the package tests to find the failure",
 			}},
 			CompletedJobs: []appwire.EvenerJobInfo{{
 				JobID: "job-completed", JobType: "shell", Status: "completed", Command: "go fmt ./...",
@@ -114,8 +114,46 @@ func TestNavigationProjectionCarriesActiveAndCompletedJobs(t *testing.T) {
 	if len(row.RunningJobs) != 1 || row.RunningJobs[0].JobID != "job-running" || row.RunningJobs[0].Command != "go test ./..." {
 		t.Fatalf("running jobs = %+v", row.RunningJobs)
 	}
+	if got := row.RunningJobs[0].Intent; got != "Running the package tests to find the failure" {
+		t.Fatalf("running job intent = %q", got)
+	}
 	if len(row.CompletedJobs) != 1 || row.CompletedJobs[0].JobID != "job-completed" || row.CompletedJobs[0].Status != "completed" {
 		t.Fatalf("completed jobs = %+v", row.CompletedJobs)
+	}
+}
+
+func TestNavigationJobSummaryKeepsFullCommandForTooltip(t *testing.T) {
+	long := strings.Repeat("a", 600)
+	project := hubcore.TreeProject{
+		Key:  "project",
+		Name: "project",
+		Current: []hubcore.TreeNode{{
+			ID:    "session-parent",
+			Title: "parent",
+			Kind:  "session",
+			State: "idle",
+			RunningJobs: []appwire.EvenerJobInfo{{
+				JobID: "job-running", JobType: "shell", Status: "running", Command: long, Intent: "intent text",
+			}},
+		}},
+	}
+	projection, err := buildNavigationProjection(navigationBuildInputs{GenerationID: "generation", Tree: hubcore.Tree{Projects: []hubcore.TreeProject{project}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource, ok := projection.Project("project")
+	if !ok {
+		t.Fatal("project missing")
+	}
+	job := resource.Current.Sessions[0].RunningJobs[0]
+	if job.Command == long {
+		t.Fatal("command must be truncated for the row label")
+	}
+	if got, want := len([]rune(job.Command)), maxNavigationLabelRunes; got != want {
+		t.Fatalf("truncated command runes=%d, want %d", got, want)
+	}
+	if job.FullCommand != long {
+		t.Fatalf("full_command = %q, want the untruncated command", job.FullCommand)
 	}
 }
 

--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -1428,6 +1428,7 @@ func agentToServerDetailedStatus(ds agent.DetailedStatus) server.DetailedStatus 
 			OutputBytes:      job.OutputBytes,
 			TranscriptRef:    job.TranscriptRef,
 			Command:          job.Command,
+			Intent:           job.Intent,
 			Task:             job.Task,
 		})
 	}

--- a/hubapi/navigation.go
+++ b/hubapi/navigation.go
@@ -152,6 +152,13 @@ type NavigationJobSummary struct {
 	Command string `json:"command,omitempty"`
 	Task    string `json:"task,omitempty"`
 	Reason  string `json:"reason,omitempty"`
+	// Intent is the tool call's `intent` argument: why the command is being
+	// run, in the model's own words. Surfaces in the rail row's tooltip.
+	Intent string `json:"intent,omitempty"`
+	// FullCommand is the complete, untruncated command. Command is bounded
+	// by maxNavigationLabelRunes for the row label; FullCommand exists so a
+	// tooltip can show what was actually executed when Command was cut.
+	FullCommand string `json:"full_command,omitempty"`
 }
 
 // NavigationSessionSummary is the bounded recursive navigation row shape.

--- a/hubapi/navigation.go
+++ b/hubapi/navigation.go
@@ -155,9 +155,11 @@ type NavigationJobSummary struct {
 	// Intent is the tool call's `intent` argument: why the command is being
 	// run, in the model's own words. Surfaces in the rail row's tooltip.
 	Intent string `json:"intent,omitempty"`
-	// FullCommand is the complete, untruncated command. Command is bounded
-	// by maxNavigationLabelRunes for the row label; FullCommand exists so a
-	// tooltip can show what was actually executed when Command was cut.
+	// FullCommand carries the command when it exceeds the label bound
+	// (maxNavigationLabelRunes), so a tooltip can show more of what was
+	// actually executed. Still bounded by maxNavigationFullCommandRunes:
+	// a pathological command cannot dominate the response's byte budget.
+	// Absent when the command fits the label bound (no truncation).
 	FullCommand string `json:"full_command,omitempty"`
 }
 

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -2052,6 +2052,7 @@ func appDiagnosticsFromDetailedStatus(ds DetailedStatus) *appwire.EvenerDiagnost
 			OutputBytes:      job.OutputBytes,
 			TranscriptRef:    job.TranscriptRef,
 			Command:          job.Command,
+			Intent:           job.Intent,
 			Task:             job.Task,
 		})
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -90,6 +90,7 @@ type JobStatusInfo struct {
 	OutputBytes      int64  `json:"output_bytes"`
 	TranscriptRef    string `json:"transcript_ref,omitempty"`
 	Command          string `json:"command,omitempty"`
+	Intent           string `json:"intent,omitempty"`
 	Task             string `json:"task,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

The sidebar rail's shell-job row now shows the command being run, and its tooltip shows the full command plus the tool call's `intent` (why the model said it is running the command).

## How it works

The tool call's `intent` argument is injected into work-tool schemas (`WithIntentParameter`) and stripped before handlers run (only `read_file` consumes it in-args). To keep it reachable, the registry now threads it onto the exec context (`tool.IntentFromContext`) at the strip point — the single chokepoint covering every dispatch path (execTool, approval re-dispatch, direct calls). `parseShellToolArgs` reads it into `shellArgs.Intent`, and the job record (`JobRecord`/`Event`), fold, job status projections (agent `JobStatusInfo`, server, appwire `EvenerJobInfo`), and the navigation wire (`hubapi NavigationJobSummary`) carry it through to the frontend.

`NavigationJobSummary` gained `intent` and `full_command` (the untruncated command for the tooltip; the label command is still bounded at 512 runes). `types.gen.ts` regenerated.

`RailRow.JobRow`'s tooltip shows `full_command · intent · status`, falling back to `command · status` when intent or full_command are absent. The navigation store wire validator accepts both new optional fields.

The dev gallery rail fixture seeds a running shell job with command + intent under a project session (visible at `/dev/surfaces` by expanding the project → expanding the session).

## Verification

- `make test-web`: PASS (web-typecheck, web-test, web-lint all green)
- `go vet`: clean
- `go test ./agent/ ./server/ ./cmd/evener-hub/... ./cmd/evener/ ./hubapi/ ./appwire/ ./agent/internal/tool/ ./agent/internal/jobstore/`: all pass
- `gofmt`: clean (after fixing struct field alignment on touched files)
- `gh`: authenticated (obra)