### PR TITLE
feat(webui): make verbosity levels control expansion, not visibility

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/session.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/session.module.css
@@ -57,17 +57,17 @@
   padding-bottom: var(--space-2);
 }
 
-.intent {
+/* IntentToolCallRow: a drill-down row inside the intent group. Collapsed it
+ * shows ToolRow (intent + icon + chevron); expanded it reveals the real
+ * ToolCallItem. The row itself is just a plain wrapper — ToolRow owns its own
+ * layout, and the body below indents under the headline. */
+.intentRow {
   display: flex;
-  align-items: baseline;
-  gap: var(--space-2);
-  padding: 0 var(--space-3);
-  color: var(--ink-mid);
-  font-family: var(--font-sans);
-  font-size: var(--font-size-ui);
-  font-style: italic;
-  line-height: var(--line-height-title);
-  overflow-wrap: anywhere;
+  flex-direction: column;
+}
+
+.intentRowBody {
+  padding-left: var(--space-3);
 }
 
 .coldStart {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
@@ -107,7 +107,15 @@ interface ToolCallItemBodyProps extends ItemRenderProps {
   thread?: ThreadModel;
 }
 
-function ToolCallItemBody({ item, live, sessionRef, projectedSummary, renderContext, thread }: ToolCallItemBodyProps) {
+function ToolCallItemBody({
+  item,
+  live,
+  sessionRef,
+  projectedSummary,
+  hideIntent,
+  renderContext,
+  thread,
+}: ToolCallItemBodyProps) {
   const context = renderContext;
   const { config } = context;
   const disclosureScope = disclosureScopeForSession(context, sessionRef);
@@ -221,6 +229,10 @@ function ToolCallItemBody({ item, live, sessionRef, projectedSummary, renderCont
   } else if (projectedSummary !== undefined && statedIntent !== undefined) {
     intent = projectedSummary;
   }
+  // hideIntent suppresses the intent line so the expanded disclosure body of an
+  // IntentToolCallRow renders only the tool-call summary (the intent already
+  // served as the collapsed headline above it).
+  if (hideIntent) intent = undefined;
   // kata xw3t: the URL, if any, embedded in this row's own summary text -
   // web_fetch's only descriptor with one today. Read directly off the item
   // (not the thread model): unlike summarySuffix, nothing about which URL a

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx
@@ -324,6 +324,9 @@ export function TranscriptBody({
             separatorTurn={row.separatorTurn}
             viewAnchorIndex={index}
             showSeenDivider={showSeenDivider && row.sourceTurnIds.includes(seenTurnId ?? "")}
+            sessionRef={sessionRef}
+            renderContext={itemRenderContext}
+            thread={model}
           />
         </div>
       );

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
@@ -421,7 +421,13 @@ test("named Intent opens only its action group while generic interaction and sys
   );
 
   expect(screen.getByTestId("intent-group").hasAttribute("open")).toBe(true);
-  expect(screen.getByTestId("tool-row-trigger").getAttribute("aria-expanded")).toBe("false");
+  // The intent group's IntentToolCallRow renders its own ToolRow trigger; the
+  // interaction's tool-row trigger is a separate one. Both should be collapsed
+  // (the drill-down has not been opened).
+  const triggers = screen.getAllByTestId("tool-row-trigger");
+  for (const trigger of triggers) {
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  }
   expect(screen.getByTestId("system-notice-scaffold").hasAttribute("open")).toBe(false);
 });
 
@@ -443,6 +449,39 @@ test("failed intent proxy renders the accessible FailureGlyph and neutral missin
   expect(screen.getByRole("img", { name: "Failed" })).toBeTruthy();
   expect(screen.queryByTestId("tool-call-item")).toBeNull();
   expect(screen.queryByText("sensitive failure output")).toBeNull();
+});
+
+test("intent row shows a tool icon and drills down to a tool-call row on click", () => {
+  const config = makeTranscriptDisplayConfig({ kind: "preset", level: "intent" });
+  const action = item({
+    id: "intent-drill-action",
+    type: "commandExecution",
+    toolName: "read_file",
+    description: "Read the configuration",
+    output: "private file output",
+    status: "completed",
+  });
+  render(withConfig(config, <TurnBlock turn={turn([action], { status: "completed" }, config)} />));
+
+  // The intent group is open at intent level, showing intent rows with icons.
+  expect(screen.getByTestId("intent-group").hasAttribute("open")).toBe(true);
+  const intentRow = screen.getByTestId("intent-tool-call-row");
+  expect(intentRow.getAttribute("data-open")).toBe("false");
+  // Tool icon is rendered (read_file uses the file icon kind).
+  expect(screen.getByTestId("tool-row-icon")).toBeTruthy();
+  // Intent text is visible.
+  expect(screen.getByText("Read the configuration")).toBeTruthy();
+  // No tool-call-item until the intent row is expanded.
+  expect(screen.queryByTestId("tool-call-item")).toBeNull();
+
+  // Click the intent row's trigger to expand it.
+  const trigger = screen.getByTestId("tool-row-trigger");
+  fireEvent.click(trigger);
+  expect(screen.getByTestId("intent-tool-call-row").getAttribute("data-open")).toBe("true");
+  // The ToolCallItem is now rendered (with hideIntent, so no duplicated intent).
+  expect(screen.getByTestId("tool-call-item")).toBeTruthy();
+  // The private output is still hidden (the tool-call body is not yet expanded).
+  expect(screen.queryByText("private file output")).toBeNull();
 });
 
 test("a growing Chat group keeps its first-action identity and manually opened state (catches last-id key)", () => {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx
@@ -6,8 +6,6 @@
 // ever imported, regardless of what else the app happens to have loaded -
 // the real SessionPane composition must never depend on import ORDER to
 // get tool calls rendered correctly.
-import "./ToolCallItem";
-import "./tools";
 import type { ReactNode } from "react";
 import type { ItemModel, ThreadModel, TurnModel } from "../../../protocol/model";
 import type { ProjectedEntry, ProjectedTurn } from "../../../transcriptDisplay/projector";
@@ -17,7 +15,7 @@ import {
   type TranscriptRenderContextValue,
   useTranscriptRenderContext,
 } from "../../../transcriptDisplay/renderContext";
-import { FailureGlyph } from "../../../widgets";
+import "./tools";
 import {
   disclosureDefault,
   isDisclosureOpen,
@@ -30,6 +28,8 @@ import { SeenDivider } from "./flow/SeenDivider";
 import { rowRoleFor } from "./layoutRoles";
 import { TurnSeparator } from "./messages";
 import { ToolCallCluster } from "./ToolCallCluster";
+import { ToolCallItem } from "./ToolCallItem";
+import { ToolRow } from "./ToolRow";
 import { TurnFailureEndCap } from "./TurnFailureEndCap";
 import { shouldGroup, toolRunFor } from "./toolGrouping";
 import { toolRendererFor } from "./toolRenderers";
@@ -104,6 +104,77 @@ export interface ProjectedIntentGroupProps {
   separatorTurn?: TurnModel;
   viewAnchorIndex?: number;
   showSeenDivider?: boolean;
+  sessionRef?: string;
+  renderContext?: TranscriptRenderContextValue;
+  thread?: ThreadModel;
+}
+
+// IntentToolCallRow is the drill-down row inside a ProjectedIntentGroup at
+// verbosity levels below "tools". Collapsed, it shows the agent's stated
+// intent plus the tool-family icon and a chevron — the same ToolRow headline a
+// full tool-call row uses, but with no summary line. Expanded, it reveals the
+// real ToolCallItem with hideIntent so the intent does not appear twice: it
+// was already the collapsed headline, and the expanded body shows the
+// tool-call summary + body instead. This is the "verbosity = expansion"
+// contract: each click peels one more layer (intent → tool summary → body).
+function IntentToolCallRow({
+  entry,
+  sessionRef,
+  renderContext,
+  thread,
+  viewAnchorIndex,
+}: {
+  entry: Extract<ProjectedEntry, { kind: "intent" }>;
+  sessionRef?: string;
+  renderContext?: TranscriptRenderContextValue;
+  thread?: ThreadModel;
+  viewAnchorIndex?: number;
+}) {
+  const context = useTranscriptRenderContext();
+  const item = entry.item;
+  const descriptor = toolRendererFor(item.toolName ?? "");
+  const disclosureScope = disclosureScopeForSession(context, sessionRef);
+  const disclosureKey = scopedDisclosureId(disclosureScope, `intent-row:${item.id}`);
+  const fallback =
+    expandDetailsByDefault(context.config) || disclosureDefault(disclosureScope, `intent-row:${item.id}`, false);
+  const open = isDisclosureOpen(disclosureKey, fallback);
+  // A minimal turn carrying only this item: ToolCallItem is memoized with
+  // ignoringTurn and never reads the turn itself; the descriptor body receives
+  // item/live/sessionRef/cwd, not turn.
+  const miniTurn: TurnModel = { id: entry.turnId, status: "completed", items: [item] };
+  const live = item.status === "inProgress";
+  return (
+    <div
+      className={transcriptStyles.intentRow}
+      data-testid="intent-tool-call-row"
+      data-open={open ? "true" : "false"}
+      {...projectedEntryAnchor(entry, viewAnchorIndex)}
+    >
+      <ToolRow
+        summary=""
+        intent={entry.rationale}
+        icon={descriptor.icon}
+        failed={entry.failed}
+        expandable
+        expanded={open}
+        onToggle={() => toggleDisclosure(disclosureKey, fallback)}
+      />
+      {open && (
+        <div className={transcriptStyles.intentRowBody}>
+          <ToolCallItem
+            item={item}
+            turn={miniTurn}
+            live={live}
+            sessionRef={sessionRef}
+            hideIntent
+            renderContext={renderContext ?? context}
+            thread={thread}
+            threadFingerprint={threadFingerprintForItem(item, thread, descriptor.summarySuffix?.(item, thread))}
+          />
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function ProjectedIntentGroup({
@@ -113,6 +184,9 @@ export function ProjectedIntentGroup({
   separatorTurn,
   viewAnchorIndex,
   showSeenDivider = false,
+  sessionRef,
+  renderContext,
+  thread,
 }: ProjectedIntentGroupProps) {
   const context = useTranscriptRenderContext();
   const { config } = context;
@@ -144,10 +218,14 @@ export function ProjectedIntentGroup({
         </summary>
         <div className={transcriptStyles.intentGroupItems}>
           {entries.map((entry) => (
-            <div key={entry.id} className={transcriptStyles.intent} {...projectedEntryAnchor(entry, viewAnchorIndex)}>
-              {entry.failed && <FailureGlyph />}
-              {entry.rationale}
-            </div>
+            <IntentToolCallRow
+              key={entry.id}
+              entry={entry}
+              sessionRef={sessionRef}
+              renderContext={renderContext}
+              thread={thread}
+              viewAnchorIndex={viewAnchorIndex}
+            />
           ))}
         </div>
       </details>
@@ -210,7 +288,14 @@ export function TurnBlock({
         if (next?.kind === "intent") group.push(next);
       }
       renderedEntries.push(
-        <ProjectedIntentGroup key={`intent-group:${group[0]?.id}`} entries={group} viewAnchorIndex={viewAnchorIndex} />,
+        <ProjectedIntentGroup
+          key={`intent-group:${group[0]?.id}`}
+          entries={group}
+          viewAnchorIndex={viewAnchorIndex}
+          sessionRef={sessionRef}
+          renderContext={itemRenderContext}
+          thread={thread}
+        />,
       );
       continue;
     }

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/types.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/types.ts
@@ -28,6 +28,10 @@ export interface ItemRenderProps {
   // A projector-owned compact summary for a critical entry. When present,
   // renderers must not reconstruct a routine summary from raw tool fields.
   projectedSummary?: string;
+  /** When true, suppress the intent/description line and render only the
+   * tool-call summary — used by IntentToolCallRow's expanded disclosure, which
+   * already showed the intent as the collapsed headline. */
+  hideIntent?: boolean;
   /** Snapshot inputs relevant to this item; stable when an unrelated delta lands. */
   threadFingerprint?: string;
   thread?: ThreadModel;
@@ -76,6 +80,7 @@ export function ignoringTurn(prev: ItemRenderProps, next: ItemRenderProps): bool
     prev.opensExchange === next.opensExchange &&
     prev.agentLabel === next.agentLabel &&
     prev.projectedSummary === next.projectedSummary &&
+    prev.hideIntent === next.hideIntent &&
     prev.renderContext === next.renderContext &&
     prev.threadFingerprint === next.threadFingerprint
   );

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
@@ -19,6 +19,9 @@ export type ProjectedEntry =
       sourceItemId: string;
       rationale: string;
       failed: boolean;
+      /** The source item, so a renderer can drill from an intent row into a full
+       * tool-call row (verbosity = expansion). */
+      item: ItemModel;
     }
   | {
       kind: "critical";
@@ -174,6 +177,7 @@ function intentEntry(item: ItemModel, turnId: string, sourceIndex: number): Proj
     sourceItemId: item.id,
     rationale,
     failed: hasItemFailure(item),
+    item,
   };
 }
 


### PR DESCRIPTION
## Summary

Tool calls at chat and intent levels used to collapse into plain text intent rows with no icons and no drill-down — the same projected shape at both levels. Now each verbosity level reveals more depth instead of hiding content:

- **chat**: the "N actions" group header shows but is closed
- **intent**: the group is open, showing intent rows with tool icons and a chevron; clicking an intent row drills down to the tool-call summary row, and clicking that expands the tool-call body
- **tools**: full tool-call rows (unchanged)
- **activity/full**: expanded by default (unchanged)

## Changes

- `projector.ts`: Added `item: ItemModel` to the intent `ProjectedEntry` type so intent rows can drill down to full tool-call rows
- `types.ts`: Added `hideIntent?: boolean` to `ItemRenderProps` (suppresses the intent line in the expanded body to avoid duplication)
- `ToolCallItem.tsx`: Wired `hideIntent` through `ToolCallItemBody`
- `TurnBlock.tsx`: Created `IntentToolCallRow` (disclosure: collapsed shows ToolRow with intent + icon + chevron, expanded reveals ToolCallItem with hideIntent). Updated `ProjectedIntentGroup` to render `IntentToolCallRow` rows instead of plain text
- `session.module.css`: Replaced the old `.intent` text class with `.intentRow` and `.intentRowBody` for the new disclosure structure
- `TranscriptBody.tsx`: Threaded new props to `ProjectedIntentGroup`

## Testing

- `make test-web` (web-typecheck, web-test, web-lint) ✅
- `make test-web-browser` (layoutguard, overflowguard, shellguard, spawnguard) ✅
- Full frontend suite: 7489 tests across 393 files ✅
- New test verifying drill-down: icon visible, clicking intent row expands to ToolCallItem, clicking again expands the body