### PR TITLE
providers add: name the resolved protocol and its override

### DIFF
--- a/cmd/evener/providers.go
+++ b/cmd/evener/providers.go
@@ -473,6 +473,16 @@ func runProvidersAdd(args []string, stdout, stderr io.Writer) error {
 	for _, w := range res.Warnings {
 		_, _ = fmt.Fprintf(stdout, "%s: %s\n", name, w)
 	}
+	// Name the protocol the instance landed on. A defaulted protocol is a
+	// silent choice, so it also names the override (the groq case: base =
+	// "groq" lands on openai-chat with openai-responses equally valid).
+	if strings.TrimSpace(*protocol) == "" {
+		_, _ = fmt.Fprintf(stdout, "%s: protocol %s (%s's default; --protocol %s overrides)\n",
+			name, res.Protocol, entry.Base,
+			strings.Join([]string{registry.ProtocolOpenAIChat, registry.ProtocolOpenAIResponses, registry.ProtocolAnthropic, registry.ProtocolGoogle}, "|"))
+	} else {
+		_, _ = fmt.Fprintf(stdout, "%s: protocol %s\n", name, res.Protocol)
+	}
 	if res.Credential.Source == "none" && res.Transport.Auth != registry.AuthNone && res.Transport.Auth != registry.AuthOptionalBearer {
 		if credentialPointerHelps(entry, res.Transport.Auth) {
 			_, _ = fmt.Fprintf(stdout, "no credential resolves for %s: set %s, add --api-key-env, or enter a key with the hub's credentials pane (credentials.toml [providers.%s]); not probing\n",

--- a/cmd/evener/providers_test.go
+++ b/cmd/evener/providers_test.go
@@ -667,3 +667,35 @@ func TestProvidersListAndModelsInspectRedactBaseURLUserinfo(t *testing.T) {
 		t.Fatalf("models inspect dropped the endpoint host entirely:\n%s", stdout.String())
 	}
 }
+
+// Adding an instance without --protocol resolves the base's default silently;
+// the report must say which protocol the instance ended up on and that
+// --protocol can pick another, so the choice is visible at the moment it is
+// made (the groq3 case: base = "groq" landed on openai-chat with nothing
+// saying openai-responses existed).
+func TestProvidersAddNamesTheDefaultedProtocol(t *testing.T) {
+	providersTestEnv(t, nil)
+	var stdout, stderr bytes.Buffer
+	if err := runProviders([]string{"add", "g3", "--base", "groq"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("add: %v\n%s", err, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"g3: protocol openai-chat", "--protocol", "openai-responses"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("defaulted add must name the protocol and the override:\nmissing %q in\n%s", want, out)
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if err := runProviders([]string{"add", "g4", "--base", "groq", "--protocol", "openai-responses"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("add with protocol: %v\n%s", err, stderr.String())
+	}
+	out = stdout.String()
+	if !strings.Contains(out, "g4: protocol openai-responses") {
+		t.Fatalf("chosen protocol must still be confirmed:\n%s", out)
+	}
+	if strings.Contains(out, "--protocol") {
+		t.Fatalf("no override hint when the user already chose:\n%s", out)
+	}
+}


### PR DESCRIPTION
UX gap from live groq debugging: `evener providers add groq3 --base groq` silently landed on `openai-chat` — nothing surfaced that `openai-responses` (which Groq serves, live-verified today) was one `--protocol` flag away.

The add report now always confirms the protocol the instance resolved to, and when the user didn't pass `--protocol`, names the base's default and the override vocabulary:

```
g3: protocol openai-chat (groq's default; --protocol openai-chat|openai-responses|anthropic|google overrides)
```

TDD; `cmd/evener` suite and all 9 lint targets green.