### PR TITLE
fix(llm): retry API log open after a transient lock clears

### DIFF
--- a/llm/apilog.go
+++ b/llm/apilog.go
@@ -123,7 +123,20 @@ func (l *APILogger) sessionFileWithError(sessionID string) (*os.File, error) {
 	}
 	f, err := apiLogOpenFile(filepath.Join(l.sessionsDir, base+".api.jsonl"))
 	if err != nil {
-		l.sessionFiles[base] = nil
+		if !errors.Is(err, ErrAPILogTargetLocked) {
+			// Cache the failure so repeated appends to the same base don't
+			// keep retrying a failure that won't clear itself on its own,
+			// e.g. a permissions error or a corrupt target (see
+			// TestSessionFileWithErrorNilCache). A locked target is
+			// different: the contender holding the flock can release it at
+			// any moment (issue #744 — a hub-spawned daemon or another
+			// evener process against the same project state dir), so don't
+			// latch that failure. Leave the cache miss in place and let the
+			// next append retry the open — deliberately, since a retry
+			// costs one flock syscall and this is best-effort forensic
+			// logging, not a hot path.
+			l.sessionFiles[base] = nil
+		}
 		return nil, err
 	}
 	l.sessionFiles[base] = f

--- a/llm/apilog_coverage_test.go
+++ b/llm/apilog_coverage_test.go
@@ -90,6 +90,50 @@ func TestSessionFileWithErrorNilCache(t *testing.T) {
 	}
 }
 
+// TestSessionFileWithErrorRecoversAfterTransientLockReleases covers issue #744:
+// a transient flock collision (ErrAPILogTargetLocked) must not latch a session
+// out of canonical logging the way a permanent failure does (contrast with
+// TestSessionFileWithErrorNilCache above). Once the contending holder releases
+// the lock, the next call must retry the open instead of replaying a cached
+// failure.
+func TestSessionFileWithErrorRecoversAfterTransientLockReleases(t *testing.T) {
+	stateDir := t.TempDir()
+	logger, err := NewSessionAPILogger(stateDir)
+	if err != nil {
+		t.Fatalf("NewSessionAPILogger: %v", err)
+	}
+	defer logger.Close()
+
+	// Hold the flock on "unattributed"'s target file the way another evener
+	// process would (e.g. a hub-spawned serve daemon that reached this
+	// project's session log first) — same mechanism as
+	// TestCovOpenPrivateAPILogFileTargetLocked, aimed at the session route.
+	target := filepath.Join(stateDir, "sessions", "unattributed.api.jsonl")
+	contender, err := openPrivateAPILogFile(target)
+	if err != nil {
+		t.Fatalf("open contender lock: %v", err)
+	}
+
+	// First call collides with the contender's flock and fails.
+	if _, err := logger.sessionFileWithError(""); !errors.Is(err, ErrAPILogTargetLocked) {
+		t.Fatalf("first sessionFileWithError = %v, want ErrAPILogTargetLocked", err)
+	}
+
+	// The contender releases the lock — e.g. the other process exits.
+	if err := contender.Close(); err != nil {
+		t.Fatalf("close contender: %v", err)
+	}
+
+	// A later call must retry the open, not replay the cached failure.
+	f, err := logger.sessionFileWithError("")
+	if err != nil {
+		t.Fatalf("sessionFileWithError after lock release = %v, want success", err)
+	}
+	if f == nil {
+		t.Fatal("sessionFileWithError after lock release returned a nil file")
+	}
+}
+
 // TestReserveSessionNoSessionsDir covers the empty sessionsDir path (lines 147-148).
 func TestReserveSessionNoSessionsDir(t *testing.T) {
 	logger, err := NewAPILogger(filepath.Join(t.TempDir(), "api.jsonl"))

--- a/llm/apilog_coverage_test.go
+++ b/llm/apilog_coverage_test.go
@@ -90,50 +90,6 @@ func TestSessionFileWithErrorNilCache(t *testing.T) {
 	}
 }
 
-// TestSessionFileWithErrorRecoversAfterTransientLockReleases covers issue #744:
-// a transient flock collision (ErrAPILogTargetLocked) must not latch a session
-// out of canonical logging the way a permanent failure does (contrast with
-// TestSessionFileWithErrorNilCache above). Once the contending holder releases
-// the lock, the next call must retry the open instead of replaying a cached
-// failure.
-func TestSessionFileWithErrorRecoversAfterTransientLockReleases(t *testing.T) {
-	stateDir := t.TempDir()
-	logger, err := NewSessionAPILogger(stateDir)
-	if err != nil {
-		t.Fatalf("NewSessionAPILogger: %v", err)
-	}
-	defer logger.Close()
-
-	// Hold the flock on "unattributed"'s target file the way another evener
-	// process would (e.g. a hub-spawned serve daemon that reached this
-	// project's session log first) — same mechanism as
-	// TestCovOpenPrivateAPILogFileTargetLocked, aimed at the session route.
-	target := filepath.Join(stateDir, "sessions", "unattributed.api.jsonl")
-	contender, err := openPrivateAPILogFile(target)
-	if err != nil {
-		t.Fatalf("open contender lock: %v", err)
-	}
-
-	// First call collides with the contender's flock and fails.
-	if _, err := logger.sessionFileWithError(""); !errors.Is(err, ErrAPILogTargetLocked) {
-		t.Fatalf("first sessionFileWithError = %v, want ErrAPILogTargetLocked", err)
-	}
-
-	// The contender releases the lock — e.g. the other process exits.
-	if err := contender.Close(); err != nil {
-		t.Fatalf("close contender: %v", err)
-	}
-
-	// A later call must retry the open, not replay the cached failure.
-	f, err := logger.sessionFileWithError("")
-	if err != nil {
-		t.Fatalf("sessionFileWithError after lock release = %v, want success", err)
-	}
-	if f == nil {
-		t.Fatal("sessionFileWithError after lock release returned a nil file")
-	}
-}
-
 // TestReserveSessionNoSessionsDir covers the empty sessionsDir path (lines 147-148).
 func TestReserveSessionNoSessionsDir(t *testing.T) {
 	logger, err := NewAPILogger(filepath.Join(t.TempDir(), "api.jsonl"))

--- a/llm/apilog_open_covtest_test.go
+++ b/llm/apilog_open_covtest_test.go
@@ -45,6 +45,57 @@ func TestCovOpenPrivateAPILogFileTargetLocked(t *testing.T) {
 	}
 }
 
+// TestSessionFileWithErrorRecoversAfterTransientLockReleases covers issue #744:
+// a transient flock collision (ErrAPILogTargetLocked) must not latch a session
+// out of canonical logging the way a permanent failure does (contrast with
+// TestSessionFileWithErrorNilCache in apilog_coverage_test.go). Once the
+// contending holder releases the lock, the next call must retry the open
+// instead of replaying a cached failure.
+//
+// This lives here, not next to TestSessionFileWithErrorNilCache, because it
+// depends on the real flock semantics openPrivateAPILogFile only implements
+// on darwin/linux (see apilog_open_other.go): on other platforms
+// openPrivateAPILogFile never contends, so the ErrAPILogTargetLocked
+// assertion below would fail.
+func TestSessionFileWithErrorRecoversAfterTransientLockReleases(t *testing.T) {
+	stateDir := t.TempDir()
+	logger, err := NewSessionAPILogger(stateDir)
+	if err != nil {
+		t.Fatalf("NewSessionAPILogger: %v", err)
+	}
+	defer logger.Close()
+
+	// Hold the flock on "unattributed"'s target file the way another evener
+	// process would (e.g. a hub-spawned serve daemon that reached this
+	// project's session log first) — same mechanism as
+	// TestCovOpenPrivateAPILogFileTargetLocked above, aimed at the session
+	// route.
+	target := filepath.Join(stateDir, "sessions", "unattributed.api.jsonl")
+	contender, err := openPrivateAPILogFile(target)
+	if err != nil {
+		t.Fatalf("open contender lock: %v", err)
+	}
+
+	// First call collides with the contender's flock and fails.
+	if _, err := logger.sessionFileWithError(""); !errors.Is(err, ErrAPILogTargetLocked) {
+		t.Fatalf("first sessionFileWithError = %v, want ErrAPILogTargetLocked", err)
+	}
+
+	// The contender releases the lock — e.g. the other process exits.
+	if err := contender.Close(); err != nil {
+		t.Fatalf("close contender: %v", err)
+	}
+
+	// A later call must retry the open, not replay the cached failure.
+	f, err := logger.sessionFileWithError("")
+	if err != nil {
+		t.Fatalf("sessionFileWithError after lock release = %v, want success", err)
+	}
+	if f == nil {
+		t.Fatal("sessionFileWithError after lock release returned a nil file")
+	}
+}
+
 func TestCovOpenPrivateAPILogFileOpenError(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "nonexistent-dir", "api.jsonl")
 	file, err := openPrivateAPILogFile(path)


### PR DESCRIPTION
Fixes #744

## Summary
- `sessionFileWithError` latched a nil ("unavailable") result forever on
  any open failure, including the purely transient `ErrAPILogTargetLocked`
  flock collision on the shared "unattributed" bucket. One collision with
  another evener process (e.g. a hub-spawned serve daemon) against the
  same project's `sessions/unattributed.api.jsonl` permanently disabled
  canonical logging for every later delegate spawn in the process.
- Skip caching the negative result specifically when the failure is
  `ErrAPILogTargetLocked`, so the next append retries the open once the
  contender releases the lock. Non-transient failures (permission errors,
  corrupt targets) still cache as before, avoiding a retry storm on a
  failure that won't clear itself.
- Named-session `ReserveSession` failures are unaffected: that failure
  already aborts session construction, so the latch there was never
  reachable a second time (unchanged, per the issue's direction).

## Test plan
- [x] New test `TestSessionFileWithErrorRecoversAfterTransientLockReleases`
      (`llm/apilog_coverage_test.go`) fails against the pre-fix latch and
      passes with the fix.
- [x] `cd llm && go test ./... -run APILog -count=1`
- [x] `cd llm && go test ./... -count=1` (full package)
- [x] `gofmt -l .` (repo-wide, clean)
- [x] `make lint` (full gate: naming, gofmt, evenerfuzz, eval, internal,
      golangci, generated, fuzz-registry, secret-scan) — all PASS