### PR TITLE
fix(hub): classify every bad-input refusal in instance Create as a wire error

### DIFF
--- a/cmd/evener-hub/app_instances.go
+++ b/cmd/evener-hub/app_instances.go
@@ -203,24 +203,32 @@ func (c *hubInstancesController) refuseWhenBroken() error {
 // Create authors a new instance entry. APIKeyEnv is a variable name and
 // CredentialHeader must reference a $VAR: a literal secret never crosses this
 // boundary, and none is ever written to the file (spec §11.2).
+//
+// Every refusal that blames the fields the caller sent comes back as a wire
+// error naming its class — InvalidParams for a field that is malformed or
+// names something that does not exist, Conflict for a name already taken —
+// matching how hubDirsCreate and the pin-section store classify the same
+// shapes. A refusal about the hub's own state (the registry not loaded, a
+// read or write failure) stays a plain error: that is not the caller's to
+// fix.
 func (c *hubInstancesController) Create(params appwire.InstanceCreateParams) error {
 	if err := c.refuseWhenBroken(); err != nil {
 		return err
 	}
 	name := strings.TrimSpace(params.Name)
 	if !registry.ValidInstanceName(name) {
-		return fmt.Errorf("invalid instance name %q (lowercase, no slash)", params.Name)
+		return appwire.InvalidParams(fmt.Sprintf("invalid instance name %q (lowercase, no slash)", params.Name))
 	}
 	base := strings.TrimSpace(params.Base)
 	if _, ok := c.reg.Get().Provider(base); !ok {
-		return fmt.Errorf("unknown base provider %q", params.Base)
+		return appwire.InvalidParams(fmt.Sprintf("unknown base provider %q", params.Base))
 	}
 	credentialHeaders, err := credentialHeaderFrom(params.CredentialHeader)
 	if err != nil {
 		return err
 	}
 	if err := validVarNames(params.Vars); err != nil {
-		return err
+		return appwire.InvalidParams(err.Error())
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -229,7 +237,7 @@ func (c *hubInstancesController) Create(params appwire.InstanceCreateParams) err
 		return err
 	}
 	if _, exists := l.Providers[name]; exists {
-		return fmt.Errorf("instance %q already exists", name)
+		return appwire.Conflict(fmt.Sprintf("instance %q already exists", name))
 	}
 	p := registry.Provider{
 		ID:       name,

--- a/cmd/evener-hub/app_instances_test.go
+++ b/cmd/evener-hub/app_instances_test.go
@@ -217,14 +217,22 @@ func TestInstances_CreateRejectsBadInput(t *testing.T) {
 		wire   bool
 	}{
 		{
+			wire:   true,
 			name:   "invalid instance name",
 			params: appwire.InstanceCreateParams{Name: "Work/Two", Base: "openai"},
 			want:   "invalid instance name",
 		},
 		{
+			wire:   true,
 			name:   "unknown base provider",
 			params: appwire.InstanceCreateParams{Name: "work", Base: "not-a-provider"},
 			want:   "unknown base provider",
+		},
+		{
+			wire:   true,
+			name:   "invalid variable name",
+			params: appwire.InstanceCreateParams{Name: "work", Base: "openai", Vars: map[string]string{"region": "value"}},
+			want:   "invalid variable name",
 		},
 		{
 			wire:   true,
@@ -296,6 +304,12 @@ func TestInstances_CreateRejectsDuplicateName(t *testing.T) {
 	err := f.ctl.Create(params)
 	if err == nil || !strings.Contains(err.Error(), "already exists") {
 		t.Fatalf("second Create = %v, want an already-exists error", err)
+	}
+	// The name collides with an existing entry, matching the Conflict class
+	// hubDirsCreate and the pin-section store use for the same "taken" shape.
+	var wire appwire.WireError
+	if !errors.As(err, &wire) || wire.Code != appwire.CodeConflict {
+		t.Fatalf("second Create = %v, want a Conflict wire error", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #717

## Summary

- `hubInstancesController.Create` (`cmd/evener-hub/app_instances.go`) mixed wire-classed and plain errors across its bad-input refusals: the credential-header and dry-parse refusals already returned `appwire.InvalidParams`, but the invalid-name, unknown-base-provider, invalid-vars-key, and duplicate-name refusals returned plain `fmt.Errorf` values. A plain error crosses the JSON-RPC boundary as `InternalError` (`appserver.WireError`'s fallback for anything that isn't already an `appwire.WireError`), so a client could not distinguish its own bad input from a genuine hub-side fault.
- Classified every one of Create's caller-blaming refusals by the convention already used by neighboring handlers in the same package (`hubDirsCreate` in `app_dirs.go`, and `pinSectionAppWireError` in `app_pin_section.go`): `InvalidParams` for a field that's malformed or names something that doesn't exist (bad instance name shape, unknown base provider, a vars key the placeholder grammar can't name), `Conflict` for a name that's already taken.
- Refusals about the hub's own state — the registry not loaded (`refuseWhenBroken`), a failed read of `providers.toml`, or a failed write that isn't the caller's dry-parse-caught fault — are unchanged; those are genuinely the hub's problem, not the caller's.
- No message text changed, only how each refusal is wrapped, so this is invisible to today's pane (which only renders `err.Error()`) and only changes what a future wire-code-aware client sees.

## Test plan

- [x] Extended the existing table-driven `TestInstances_CreateRejectsBadInput` (`cmd/evener-hub/app_instances_test.go`): added `wire: true` to the previously-plain "invalid instance name" and "unknown base provider" cases, and added a new "invalid variable name" case — all now assert an `appwire.WireError` with `Code == appwire.CodeInvalidParams`.
- [x] Extended `TestInstances_CreateRejectsDuplicateName` to assert the already-exists refusal is an `appwire.WireError` with `Code == appwire.CodeConflict`.
- [x] Confirmed RED: all four new/modified assertions failed against the pre-fix code (plain errors, not `appwire.WireError`) before the implementation change.
- [x] `go test ./cmd/evener-hub/...` — PASS (all subpackages).
- [x] `go test ./appwire/...` — PASS.
- [x] `gofmt -l` on the touched files — clean.
- [x] `go vet ./cmd/evener-hub/...` — clean.
- [x] `make lint` (full repo: naming, gofmt, evenerfuzz, eval, internal, golangci, generated, fuzz-registry, secret-scan) — all 9 targets PASS.