### PR TITLE
fix(registry): stop echoing pasted secrets from malformed ${...} refs

### DIFF
--- a/llm/registry/env.go
+++ b/llm/registry/env.go
@@ -48,7 +48,12 @@ func scanEnvRefs(value string, lit func(string), ref func(string)) error {
 			}
 			name := value[i+2 : i+2+end]
 			if !envNameRe.MatchString(name) {
-				return fmt.Errorf("invalid environment variable name %q", name)
+				// name is whatever the author put between the braces: exactly
+				// the content a misplaced secret would occupy, e.g.
+				// "${sk-live-...}" pasted where "${VAR}" belonged. Unlike
+				// every other error in this file, it must not be
+				// interpolated into the message.
+				return errors.New("invalid environment variable name in ${...} reference: must start with a letter or underscore, then only letters, digits, or underscores")
 			}
 			ref(name)
 			i += 2 + end + 1

--- a/llm/registry/env_test.go
+++ b/llm/registry/env_test.go
@@ -90,6 +90,11 @@ func TestCheckCredentialHeaderValue(t *testing.T) {
 		{"a literal that is not a scheme word", "key=$K", "$VARIABLE", "key="},
 		{"an unterminated reference", "Bearer ${TOKEN", "unterminated", ""},
 		{"an invalid variable name", "Bearer ${1BAD}", "invalid environment variable name", ""},
+		// A user who means to type "Bearer $API_KEY" but pastes the key
+		// itself inside the braces (issue #718) still gets a malformed
+		// name, but the content inside ${...} may be the very secret
+		// being protected -- it must never reach the refusal text.
+		{"an invalid name that is itself a secret", "Bearer ${sk-test-PLANTEDSECRET1234}", "invalid environment variable name", "sk-test-PLANTEDSECRET1234"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			err := CheckCredentialHeaderValue(tt.value)
@@ -116,5 +121,19 @@ func TestCheckEnvRefs(t *testing.T) {
 	}
 	if err := checkEnvRefs("${9BAD}", "api_key"); err == nil {
 		t.Fatal("invalid name must error")
+	}
+	// checkEnvRefs is what config load time uses to tell the user which
+	// field is broken (issue #718). The braces may hold a pasted secret
+	// instead of a variable name: the refusal must still name the field
+	// so the user can find it, but never echo what they pasted.
+	err := checkEnvRefs("${sk-test-PLANTEDSECRET1234}", "providers.foo.api_key")
+	if err == nil {
+		t.Fatal("invalid name must error")
+	}
+	if !strings.Contains(err.Error(), "providers.foo.api_key") {
+		t.Fatalf("checkEnvRefs error must name the field: %v", err)
+	}
+	if strings.Contains(err.Error(), "sk-test-PLANTEDSECRET1234") {
+		t.Fatalf("checkEnvRefs error echoed the value: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes #718

## Bug

A malformed `${...}` env-var reference (spec §10) echoed the raw brace
content into its refusal text:

```go
return fmt.Errorf("invalid environment variable name %q", name)
```

`name` is whatever the author put between the braces. If a user pastes a
literal secret where a variable name belonged — `${sk-live-...}` instead
of `${API_KEY}` — that secret rode straight into the error, which reaches
hub dialogs, CLI output, and logs on both authoring surfaces (`evener
providers add --credential-header` and the hub's credential-header field),
plus `providers.toml` load-time field validation (`api_key`,
`credential_headers`, `headers`, `vars`). This broke `scanEnvRefs`'s own
documented contract: "It never echoes the value (it may hold a secret)."

## Fix

`scanEnvRefs`'s invalid-name error now names the malformation instead of
the content:

```go
return errors.New("invalid environment variable name in ${...} reference: must start with a letter or underscore, then only letters, digits, or underscores")
```

Callers already wrap this with the location — `checkEnvRefs` prepends the
config field path (e.g. `providers.foo.api_key: ...`), and both CLI/hub
credential-header callers prepend the header name — so the refusal still
says where to look. This is the single low-level scan every caller goes
through, so one change covers config-load validation and both authoring
surfaces.

## Tests (TDD)

Added a sentinel-secret case to each of the two tests that exercise this
path in `llm/registry/env_test.go`:

- `TestCheckCredentialHeaderValue`: `Bearer ${sk-test-PLANTEDSECRET1234}`
  must be refused, the refusal must mention "invalid environment variable
  name", and must NOT contain the sentinel.
- `TestCheckEnvRefs`: `checkEnvRefs("${sk-test-PLANTEDSECRET1234}",
  "providers.foo.api_key")` must be refused, must name the field
  (`providers.foo.api_key`), and must NOT contain the sentinel.

Both failed before the fix (confirmed red) and pass after (confirmed
green).

## Verification

- `go test ./llm/registry/...` — PASS
- `go test ./cmd/evener/...` — PASS (CLI credential-header authoring surface)
- `go test ./cmd/evener-hub/...` — PASS (hub credential-header authoring surface)
- `go build ./...` — clean
- `go vet ./llm/registry/...` — clean
- `gofmt -l` on both changed files — clean
- `make lint` (full repo: naming, gofmt, evenerfuzz, eval, internal,
  golangci, generated, fuzz-registry, secret-scan) — all PASS

Smallest-change diff: 2 files, 25 insertions, 1 deletion.