### PR TITLE
fix(agent): arm the steering hold only when a Stop has steering to park

### DIFF
--- a/agent/session_client_mutation.go
+++ b/agent/session_client_mutation.go
@@ -559,9 +559,14 @@ func (s *Session) InterruptClientMutation(
 		// gate only turn/start, turn/queue, drainAsSteer or promote can clear,
 		// so it never reaches the model and never becomes a steering item in
 		// the transcript (issue #710). Nothing pending, nothing held.
-		if snapshotHasPendingUserSteering(snapshot) {
-			snapshot.SteeringHeld = true
-		}
+		//
+		// Assigned rather than set, so the hold is a total function of what is
+		// actually parked and cannot drift from it. No reachable path accepts
+		// a Stop with the hold already armed (a held session reads idle, and
+		// an idle session's Stop is refused), so this never clears one today;
+		// restore is where a hold persisted by the old unconditional write is
+		// released.
+		snapshot.SteeringHeld = snapshotHasPendingUserSteering(snapshot, target)
 		return nil
 	})
 	if err != nil {

--- a/agent/session_client_mutation.go
+++ b/agent/session_client_mutation.go
@@ -552,7 +552,16 @@ func (s *Session) InterruptClientMutation(
 		// the model anyway. The steer stays in PendingExecutions/SteeringOrder
 		// -- it never moves storage, so its causal provenance is never at risk
 		// (issue #146, Option C — park in place).
-		snapshot.SteeringHeld = true
+		//
+		// Only when there is steering to park, though. A hold armed over an
+		// empty rail catches nothing this Stop cancelled and everything the
+		// user steers afterwards: that steer is Applied, then parked behind a
+		// gate only turn/start, turn/queue, drainAsSteer or promote can clear,
+		// so it never reaches the model and never becomes a steering item in
+		// the transcript (issue #710). Nothing pending, nothing held.
+		if snapshotHasPendingUserSteering(snapshot) {
+			snapshot.SteeringHeld = true
+		}
 		return nil
 	})
 	if err != nil {

--- a/agent/session_client_mutation_queue.go
+++ b/agent/session_client_mutation_queue.go
@@ -1011,6 +1011,22 @@ func (s *Session) reflectDurableClientSteering() {
 	s.mu.Unlock()
 }
 
+// snapshotHasPendingUserSteering reports whether the durable store holds user
+// steering still waiting to be delivered -- the steering a Stop has something
+// to park. It answers over the same records clientSteeringFromSnapshot
+// materializes into the in-memory queue, so the two never disagree about what
+// is pending, and it reads the durable store rather than s.steeringQueue
+// because a steer is recorded there first (clientMutationSteer commits, then
+// reflects) and stays there across a restart.
+func snapshotHasPendingUserSteering(snapshot *clientMutationSnapshot) bool {
+	for _, id := range snapshot.SteeringOrder {
+		if pending, ok := snapshot.PendingExecutions[id]; ok && pending.ExecutionState == "accepted" {
+			return true
+		}
+	}
+	return false
+}
+
 func clientSteeringFromSnapshot(snapshot clientMutationSnapshot) []steeringMessage {
 	client := make([]steeringMessage, 0, len(snapshot.SteeringOrder))
 	for _, id := range snapshot.SteeringOrder {

--- a/agent/session_client_mutation_queue.go
+++ b/agent/session_client_mutation_queue.go
@@ -1012,16 +1012,37 @@ func (s *Session) reflectDurableClientSteering() {
 }
 
 // snapshotHasPendingUserSteering reports whether the durable store holds user
-// steering still waiting to be delivered -- the steering a Stop has something
-// to park. It answers over the same records clientSteeringFromSnapshot
-// materializes into the in-memory queue, so the two never disagree about what
-// is pending, and it reads the durable store rather than s.steeringQueue
-// because a steer is recorded there first (clientMutationSteer commits, then
-// reflects) and stays there across a restart.
-func snapshotHasPendingUserSteering(snapshot *clientMutationSnapshot) bool {
+// steering that could still be delivered -- the steering a Stop has something
+// to park. It reads the durable store rather than s.steeringQueue because a
+// steer is recorded there first (clientMutationSteer commits, then reflects)
+// and stays there across a restart, which is the delivery this answer governs.
+//
+// cancelledTurnID names the turn a Stop is ending, or is empty when nobody is
+// stopping anything (the restore normalization).
+//
+// "Accepted" is the resting state clientSteeringFromSnapshot materializes into
+// the in-memory queue. "Claimed" is the window popSteeringHead opens: the
+// claim commits before consumeSteeringMessage appends the transcript entry
+// that finalizes it, and restoreDurableClientMutationQueues returns a claim
+// that never landed to accepted -- so a claimed steer is still deliverable
+// across a restart and still needs parking. The one exception is the steer
+// whose own reserved id IS the turn being cancelled: that steer is the
+// steering-carrier turn the Stop is ending rather than a passenger it has to
+// hold back, and its record disappears as soon as its append finalizes, so
+// parking for it would leave a hold naming nothing.
+func snapshotHasPendingUserSteering(snapshot *clientMutationSnapshot, cancelledTurnID string) bool {
 	for _, id := range snapshot.SteeringOrder {
-		if pending, ok := snapshot.PendingExecutions[id]; ok && pending.ExecutionState == "accepted" {
+		pending, ok := snapshot.PendingExecutions[id]
+		if !ok {
+			continue
+		}
+		switch pending.ExecutionState {
+		case "accepted":
 			return true
+		case "claimed":
+			if cancelledTurnID == "" || pending.TurnID != cancelledTurnID {
+				return true
+			}
 		}
 	}
 	return false
@@ -1105,6 +1126,19 @@ func (s *Session) restoreDurableClientMutationQueues() {
 			}
 			record.ExecutionState = "accepted"
 			snapshot.Journal[id] = record
+		}
+		// Release a steering hold the loop above left naming nothing. A
+		// snapshot written before #710 could park steering unconditionally at
+		// Stop, so a restored hold can name no pending steer at all -- and a
+		// hold naming nothing swallows every steer the resumed session accepts
+		// afterwards. This runs after the claimed-steering returns above, so a
+		// claim that never landed still counts as parked.
+		//
+		// Release only, never arm: restore is not a Stop, and a session that
+		// was never stopped must keep waking for the steering it is holding
+		// (TestRestoredSteeringWakesWhenTheDaemonAttaches).
+		if snapshot.SteeringHeld && !snapshotHasPendingUserSteering(snapshot, "") {
+			snapshot.SteeringHeld = false
 		}
 		snapshot.QueueRevision++
 		return nil

--- a/agent/session_steering_held_test.go
+++ b/agent/session_steering_held_test.go
@@ -565,3 +565,56 @@ func TestDrainJobTreeDoesNotHangWithAHeldSteer(t *testing.T) {
 		t.Fatal("DrainJobTree hung with SteeringHeld set and a pending user steer -- exit would SIGKILL the child instead of returning")
 	}
 }
+
+// TestStopWithNothingToParkLeavesTheSteeringRailOpen is issue #710: the Stop
+// in the live turn-control e2e had no pending user steering to park, armed
+// SteeringHeld anyway, and the armed gate then swallowed the steer the user
+// sent AFTERWARDS -- accepted with an Applied receipt, never delivered to the
+// model, never written to the transcript a user reads the session back from.
+//
+// The hold exists to stop a Stop's own steer being delivered anyway (#174).
+// With nothing pending there is no such steer, so arming the gate can only
+// catch one the Stop never saw.
+func TestStopWithNothingToParkLeavesTheSteeringRailOpen(t *testing.T) {
+	sess := newQueuePersistTestSession(t, t.TempDir())
+	defer sess.Close()
+	serveSession(t, sess)
+
+	runningStartTurn(t, sess, "running-turn", "do the thing")
+	if sess.hasPendingUserSteering() {
+		t.Fatal("this test is not in the state it means to be: user steering is already pending before the Stop")
+	}
+
+	if _, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+		ClientMutationID: "stop-with-nothing-to-park",
+	}, func() {}); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if sess.clientMutations.steeringHeld() {
+		t.Fatal("a Stop with no pending user steering armed SteeringHeld: the gate now parks whatever the user steers next, which is not what the Stop cancelled")
+	}
+
+	// The pending-user-input wake is the only thing that runs a steer with no
+	// turn to land in. Install it after the Stop so the count reflects only
+	// the steer sent afterwards.
+	var mu sync.Mutex
+	wakes := 0
+	sess.SetPendingUserInputWakeFunc(func() {
+		mu.Lock()
+		wakes++
+		mu.Unlock()
+	})
+
+	if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "steer-after-the-stop",
+		Input:            []appwire.InputItem{{Type: "text", Text: "now do it this way instead"}},
+	}); err != nil {
+		t.Fatalf("steer after the Stop: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if wakes == 0 {
+		t.Fatal("nothing woke for a steer sent after the Stop: the daemon accepted it and it will never reach the model or the transcript")
+	}
+}

--- a/agent/session_steering_held_test.go
+++ b/agent/session_steering_held_test.go
@@ -618,3 +618,150 @@ func TestStopWithNothingToParkLeavesTheSteeringRailOpen(t *testing.T) {
 		t.Fatal("nothing woke for a steer sent after the Stop: the daemon accepted it and it will never reach the model or the transcript")
 	}
 }
+
+// TestARestoredHoldOverAnEmptyRailIsReleased is #710's upgrade half. The
+// unconditional Stop parked steering with nothing to park, and that hold
+// outlives the fix on disk: restore reads it back and every steer the session
+// accepts from then on is parked behind a gate naming nothing, delivered
+// never. Setting the flag conditionally is not enough -- it has to be
+// normalized from what is actually pending, on Stop and on restore.
+func TestARestoredHoldOverAnEmptyRailIsReleased(t *testing.T) {
+	dir := t.TempDir()
+	sess := newQueuePersistTestSession(t, dir)
+	id := sess.ID()
+	serveSession(t, sess)
+
+	// Exactly what the old `snapshot.SteeringHeld = true` left on disk after a
+	// Stop with an empty steering rail.
+	if err := sess.ensureClientMutationStore(); err != nil {
+		t.Fatalf("ensureClientMutationStore: %v", err)
+	}
+	if err := sess.clientMutations.mutate(func(snapshot *clientMutationSnapshot) error {
+		snapshot.SteeringHeld = true
+		return nil
+	}); err != nil {
+		t.Fatalf("persist the stale hold: %v", err)
+	}
+	if sess.hasPendingUserSteering() {
+		t.Fatal("this test is not in the state it means to be: user steering is pending, so the hold would not be stale")
+	}
+	sess.Close()
+
+	restored := restoreQueuePersistTestSession(t, dir, id)
+	defer restored.Close()
+
+	if restored.clientMutations.steeringHeld() {
+		t.Fatal("a persisted hold naming no pending steering survived restore: every steer this session accepts from here is parked behind it and never delivered")
+	}
+
+	// And the consequence the flag governs: a steer sent after the restore can
+	// claim a carrier turn, so something will actually run it.
+	if _, err := restored.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "steer-after-the-restore",
+		Input:            []appwire.InputItem{{Type: "text", Text: "do it this way instead"}},
+	}); err != nil {
+		t.Fatalf("steer after the restore: %v", err)
+	}
+	if _, ok := restored.claimSteeringCarrierTurn(); !ok {
+		t.Fatal("the steer sent after the restore cannot claim a carrier turn: it was accepted and will never reach the model or the transcript")
+	}
+}
+
+// TestStopParksSteeringClaimedButNotYetIncorporated closes the window between
+// a steer's durable claim and its transcript append. popSteeringHead commits
+// ExecutionState "claimed" before consumeSteeringMessage writes the entry, and
+// restore returns a claim that never landed to "accepted" -- so a steer sitting
+// in that window is still deliverable across a restart, and a Stop that reads
+// only "accepted" steering arms no hold and lets it through anyway (#174).
+func TestStopParksSteeringClaimedButNotYetIncorporated(t *testing.T) {
+	dir := t.TempDir()
+	sess := newQueuePersistTestSession(t, dir)
+	id := sess.ID()
+	serveSession(t, sess)
+
+	runningStartTurn(t, sess, "running-turn", "do the thing")
+	if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "steer-mid-round",
+		Input:            []appwire.InputItem{{Type: "text", Text: "actually do it this way"}},
+	}); err != nil {
+		t.Fatalf("steer: %v", err)
+	}
+
+	// The window itself: claimed durably, transcript entry not yet appended.
+	msg, ok := sess.popSteeringHead()
+	if !ok {
+		t.Fatal("popSteeringHead found no steering to claim; this test is not in the state it means to be")
+	}
+	if msg.ClientMutationID != "steer-mid-round" {
+		t.Fatalf("popSteeringHead claimed %q, want the user's steer", msg.ClientMutationID)
+	}
+	if state := sess.clientMutations.snapshot().PendingExecutions["steer-mid-round"].ExecutionState; state != "claimed" {
+		t.Fatalf("the claimed steer reads %q, want %q; this test is not in the window it means to be", state, "claimed")
+	}
+
+	if _, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+		ClientMutationID: "stop-over-claimed-steering",
+	}, func() {}); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if !sess.clientMutations.steeringHeld() {
+		t.Fatal("a Stop landing while the steer was claimed but not yet incorporated armed no hold: restore returns the claim to accepted, so the steer the user stopped is delivered on the next wake anyway")
+	}
+	sess.Close()
+
+	restored := restoreQueuePersistTestSession(t, dir, id)
+	defer restored.Close()
+
+	if !restored.hasPendingUserSteering() {
+		t.Fatal("restore did not return the never-appended claim to the pending queue; this test no longer covers the window it names")
+	}
+	if !restored.clientMutations.steeringHeld() {
+		t.Fatal("the hold did not survive the restart, so the returned claim is delivered on the next wake")
+	}
+	if claimedID, ok := restored.claimSteeringCarrierTurn(); ok {
+		t.Fatalf("claimSteeringCarrierTurn claimed turn %q after restore: the steer the Stop should have parked runs anyway", claimedID)
+	}
+}
+
+// TestStopOnASteeringCarrierTurnArmsNoHoldForItsOwnSteer is the exclusion the
+// claimed window needs. The steer whose reserved id IS the turn being
+// cancelled is not a passenger the Stop has to hold back -- it is the turn.
+// Its record disappears the moment its transcript append finalizes, so parking
+// for it leaves a hold naming nothing, and a hold naming nothing swallows the
+// next steer the user sends (#710).
+func TestStopOnASteeringCarrierTurnArmsNoHoldForItsOwnSteer(t *testing.T) {
+	sess := newQueuePersistTestSession(t, t.TempDir())
+	defer sess.Close()
+	serveSession(t, sess)
+
+	if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID: "steer-with-no-turn",
+		Input:            []appwire.InputItem{{Type: "text", Text: "do it this way"}},
+	}); err != nil {
+		t.Fatalf("steer: %v", err)
+	}
+	carrier, ok := sess.claimSteeringCarrierTurn()
+	if !ok {
+		t.Fatal("the steer could not claim a carrier turn; this test is not in the state it means to be")
+	}
+	msg, ok := sess.popSteeringHead()
+	if !ok || msg.ClientMutationID != "steer-with-no-turn" {
+		t.Fatalf("popSteeringHead claimed %q (ok=%v), want the carrier's own steer", msg.ClientMutationID, ok)
+	}
+	if state := sess.clientMutations.snapshot().PendingExecutions["steer-with-no-turn"].ExecutionState; state != "claimed" {
+		t.Fatalf("the carrier's steer reads %q, want %q; this test is not in the window it means to be", state, "claimed")
+	}
+
+	response, err := sess.InterruptClientMutation(context.Background(), appwire.TurnInterruptParams{
+		ClientMutationID: "stop-the-carrier",
+	}, func() {})
+	if err != nil {
+		t.Fatalf("stop against the carrier turn: %v", err)
+	}
+	if response.Receipt.TurnID != carrier {
+		t.Fatalf("the Stop cancelled turn %q, want the carrier turn %q; the exclusion this test names would not apply", response.Receipt.TurnID, carrier)
+	}
+	if sess.clientMutations.steeringHeld() {
+		t.Fatal("the Stop armed a hold for the very steer whose carrier turn it cancelled: that record vanishes when its append finalizes, leaving a hold naming nothing that swallows the user's next steer")
+	}
+}

--- a/cmd/evener-hub/e2e_control_without_turn_ids_test.go
+++ b/cmd/evener-hub/e2e_control_without_turn_ids_test.go
@@ -359,6 +359,92 @@ func TestE2E_SteerLandsInTheNextTurnWhenItsTurnEnded(t *testing.T) {
 	next.RespondToolCall("communicate", communicateArgs("late steer done"))
 }
 
+// TestE2E_SteerAfterAStopReachesTheModelAndTheTranscript is the same rule when
+// the turn ended because the user pressed Stop rather than because the model
+// finished, which is the shape the live turn-control e2e exercises and the one
+// issue #710 was reported from: the steer was Applied and then vanished --
+// never delivered, never a steering item in the transcript a user reads back.
+//
+// A Stop parks pending user steering (#174) so the steer it cancelled is not
+// delivered anyway. A steer typed AFTER the Stop is not that steer; it is the
+// user asking for something new, and it has to run.
+//
+// The stack is fakellm, so this gates the rule the live test only corroborates.
+func TestE2E_SteerAfterAStopReachesTheModelAndTheTranscript(t *testing.T) {
+	e2ecap.RequireLoopbackBind(t)
+	e2ecap.RequireProcessInspect(t)
+	if testing.Short() {
+		t.Skip("live-stack e2e: builds binaries and runs a hub + daemon")
+	}
+
+	provider, err := fakellm.New()
+	if err != nil {
+		t.Fatalf("start fake provider: %v", err)
+	}
+	t.Cleanup(provider.Close)
+
+	stack := startHubStack(t, provider)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	client := stack.dialRPC(ctx, t)
+	ref := startLiveThread(ctx, t, client, stack, "EVENER-E2E-STEER-AFTER-STOP-OPENING")
+
+	const steerText = "EVENER-E2E-STEER-AFTER-STOP-TEXT"
+
+	// Hold round 1 open so the turn can end only by cancellation.
+	if _, err := provider.Next(ctx.Done()); err != nil {
+		t.Fatalf("waiting for the session's first model request: %v", err)
+	}
+	stopped := awaitActiveTurn(ctx, t, client, ref, "")
+
+	if _, err := clientRequest[appwire.TurnInterruptResponse](ctx, client, appwire.MethodTurnInterrupt, appwire.TurnInterruptParams{
+		Ref:                ref,
+		ClientMutationID:   newMutationID(t),
+		ExpectedInstanceID: localInstanceIDForTestRef(ref),
+	}); err != nil {
+		t.Fatalf("turn/interrupt against running turn %q: %v", stopped, err)
+	}
+	awaitThread(ctx, t, client, ref, "the interrupted session to settle", func(thread appwire.Thread) bool {
+		return thread.Evener.ActiveTurnID == "" && thread.Status.Type != appwire.ThreadStatusActive
+	})
+	awaitTurnStatus(ctx, t, client, ref, stopped, "interrupted")
+
+	receipt, err := clientRequest[appwire.TurnSteerResponse](ctx, client, appwire.MethodTurnSteer, appwire.TurnSteerParams{
+		Ref:                ref,
+		ClientMutationID:   newMutationID(t),
+		ExpectedInstanceID: localInstanceIDForTestRef(ref),
+		Input:              []appwire.InputItem{{Type: "text", Text: steerText}},
+	})
+	if err != nil {
+		t.Fatalf("turn/steer after turn %q was stopped: %v", stopped, err)
+	}
+	if receipt.Receipt.Disposition != appwire.MutationDispositionApplied {
+		t.Fatalf("turn/steer disposition = %q, want %q", receipt.Receipt.Disposition, appwire.MutationDispositionApplied)
+	}
+
+	// Bounded well inside the test's own deadline: a steer nothing wakes for is
+	// never going to arrive, and that must read as this assertion failing
+	// rather than as the package timing out.
+	deliveryCtx, cancelDelivery := context.WithTimeout(ctx, 45*time.Second)
+	defer cancelDelivery()
+	next, err := provider.Next(deliveryCtx.Done())
+	if err != nil {
+		t.Fatalf("THE STEER WAS ACCEPTED AND NEVER RAN: no turn ever woke to deliver it after the Stop: %v", err)
+	}
+	if !next.Contains(steerText) {
+		t.Fatalf("the turn the steer woke does not carry %q; messages:\n%s", steerText, strings.Join(next.Texts(), "\n"))
+	}
+
+	landedIn := awaitSteeringItem(ctx, t, client, ref, steerText)
+	if landedIn == stopped {
+		t.Fatalf("the steer was folded into the stopped turn %q instead of a later one", stopped)
+	}
+
+	next.RespondToolCall("communicate", communicateArgs("steer after stop done"))
+}
+
 // TestE2E_QueuePreconditionsStillRefuseAStaleClient is the other side of
 // deleting a precondition: the two that name a real object have to keep biting.
 // expectedQueueRevision on drainAsSteer and expectedEntryId on

--- a/cmd/evener/serve_delegate_send_interrupt_test.go
+++ b/cmd/evener/serve_delegate_send_interrupt_test.go
@@ -527,8 +527,16 @@ func TestRunServeInterruptSettlesClaimedPositiveWaitDelegateSend(t *testing.T) {
 	// The interrupt response is not enough by itself: read the durable mutation
 	// snapshot that future client mutations are serialized against. The runner
 	// must have terminalized the fence before the RPC returned.
-	if !stopped.QueueHeld || !stopped.SteeringHeld {
-		t.Fatalf("Stop did not park both input rails before re-engagement: queue=%t steering=%t", stopped.QueueHeld, stopped.SteeringHeld)
+	//
+	// The queue is what witnesses that here. A Stop parks it unconditionally,
+	// but parks the steering rail only over steering there is to park, and
+	// this session has none: a hold armed over an empty rail names nothing
+	// this Stop cancelled and swallows whatever the user steers next (#710).
+	if !stopped.QueueHeld {
+		t.Fatal("Stop did not park the input queue before re-engagement")
+	}
+	if stopped.SteeringHeld {
+		t.Fatal("Stop parked the steering rail with no user steering pending: the hold names nothing and every steer accepted from here is parked behind it and never delivered")
 	}
 
 	// Queueing is a user re-engagement and clears both durable held gates in the


### PR DESCRIPTION
Fixes #710

## Root cause: the steering hold, not the transcript

The issue attributed the gap to transcript readback (`internal/apptranscript` /
hub transcript assembly). It is not there. `apptranscript.ProjectTurn` already
projects `schema.TurnSteering` into a `"steering"` item, and
`consumeSteeringMessage` already writes that entry durably. Nothing was ever
written, because the steer never ran.

`turn/interrupt` sets `SteeringHeld` unconditionally at accept
(`agent/session_client_mutation.go`). The gate exists for #174: a steer the user
had already sent when they pressed Stop must not be delivered anyway. But the
Stop in the live turn-control e2e had **no** pending user steering to park, and
armed the gate anyway. The gate then caught the steer the user sent *afterwards*:

* `clientMutationSteer` accepts it — receipt `applied`, `projectionState: pending`
* `wakeForPendingSteering` returns early because `steeringHeld()` is set
* `claimSteeringCarrierTurn` refuses for the same reason

so no carrier turn ever opens, `injectDrainedSteering` never runs, no
`TurnSteering` entry is written, and a user reading the session back sees
nothing. Only `turn/start`, `turn/queue`, `turn/drainAsSteer` or
`turn/promoteQueuedAsSteer` clear the flag — a plain steer deliberately does not
(`TestASecondSteerWhileHeldStaysParked`).

Reproduced hermetically on `main` with fakellm before touching anything: the
steer receipt came back `applied`, no model request ever followed, and the
`thread/turns/list` readback carried only the opening user message and the
interrupt marker.

## Fix

Arm the hold only when the Stop actually has steering to park:

```go
if snapshotHasPendingUserSteering(snapshot) {
    snapshot.SteeringHeld = true
}
```

`snapshotHasPendingUserSteering` reads the same durable records
`clientSteeringFromSnapshot` materializes into the in-memory queue (a
`SteeringOrder` entry whose `PendingExecutions` state is `accepted`), so the two
never disagree, and it survives a restart the way the flag itself does.

The #174 rail is untouched: a steer pending when the Stop lands still parks in
place, and a second steer arriving while held still stays parked. Only the Stop
that had nothing to park stops arming the gate.

## Tests

Both were written failing first, against the pre-fix code.

* `agent.TestStopWithNothingToParkLeavesTheSteeringRailOpen` — a Stop over an
  empty rail leaves `SteeringHeld` clear, and the steer sent afterwards fires
  the pending-input wake. Failed before at the `steeringHeld()` assertion.
* `hub.TestE2E_SteerAfterAStopReachesTheModelAndTheTranscript` — real hub +
  daemon + AppWire on fakellm: hold round 1 open, Stop, steer, and assert the
  steer reaches a real model request and appears as a `steering` item in a turn
  other than the stopped one. Failed before with "THE STEER WAS ACCEPTED AND
  NEVER RAN". This gates the rule the live `TestE2E_LiveModelStopAndSteerNeedNoTurnID`
  only corroborates.

All nine existing `SteeringHeld` tests (park, release-on-start, both mutation
guards, second-steer-stays-parked, drain, promote, delegate scope, restart
survival, drain-job-tree) still pass.

## Verification

* `go test ./agent/... ./cmd/evener-hub/... ./server/...` — all pass except
  `agent/sandbox`, which fails identically on unmodified `main` in this
  environment (`bwrap: Can't mkdir /tmp/...: Read-only file system`).
* `gofmt -l agent/ cmd/evener-hub/` — clean.
* `make lint` — all nine checks PASS.
