### PR TITLE
fix(hub): add clear-stored-key action for keys shadowed behind oauth/adc

### DIFF
--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -165,6 +165,7 @@ var Methods = []MethodSpec{
 	{MethodEvenerAuthLogout, AuthLogoutParams{}, AuthLogoutResponse{}, ScopeHub, "Logs out a provider; broadcasts evener/auth/updated."},
 	{MethodEvenerAuthList, EmptyParams{}, AuthListResponse{}, ScopeHub, "Lists auth status for all providers."},
 	{MethodEvenerAuthApiKeySet, AuthApiKeySetParams{}, AuthStatusResponse{}, ScopeHub, "Stores a provider API key; broadcasts evener/auth/updated."},
+	{MethodEvenerAuthApiKeyClear, AuthApiKeyClearParams{}, AuthStatusResponse{}, ScopeHub, "Clears a provider's stored file-layer key only, leaving any OAuth/ADC/env credential untouched; broadcasts evener/auth/updated."},
 	{MethodEvenerAuthDeviceStart, AuthDeviceStartParams{}, AuthDeviceStartResponse{}, ScopeHub, "Begins a device-code auth flow (or signals fallback)."},
 	{MethodEvenerAuthDevicePoll, AuthDevicePollParams{}, AuthDevicePollResponse{}, ScopeHub, "Polls a device-code flow; broadcasts evener/auth/updated when authorized."},
 	{MethodEvenerLaunchResolve, LaunchConfigResolveParams{}, LaunchConfigResolved{}, ScopeHub, "Resolves the effective launch config for a cwd."},

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -77,6 +77,7 @@ const (
 	MethodEvenerAuthLogout            = "evener/auth/logout"
 	MethodEvenerAuthList              = "evener/auth/list"
 	MethodEvenerAuthApiKeySet         = "evener/auth/apiKey/set"
+	MethodEvenerAuthApiKeyClear       = "evener/auth/apiKey/clear"
 	MethodEvenerAuthDeviceStart       = "evener/auth/device/start"
 	MethodEvenerAuthDevicePoll        = "evener/auth/device/poll"
 	MethodEvenerLaunchResolve         = "evener/launch/resolve"
@@ -2488,6 +2489,11 @@ type AuthListResponse struct {
 type AuthApiKeySetParams struct {
 	Provider string `json:"provider"`
 	Value    string `json:"value"`
+}
+
+// AuthApiKeyClearParams is the params for evener/auth/apiKey/clear.
+type AuthApiKeyClearParams struct {
+	Provider string `json:"provider"`
 }
 
 // AuthDeviceStartParams is the params for evener/auth/device/start.

--- a/cmd/evener-hub/app_auth.go
+++ b/cmd/evener-hub/app_auth.go
@@ -413,6 +413,27 @@ func (c *hubAuthController) ApiKeySet(params appwire.AuthApiKeySetParams) (appwi
 	return c.Status(appwire.AuthStatusParams{Provider: name})
 }
 
+// ApiKeyClear removes a stored file-layer key without touching any other
+// credential layer - the counterpart to ApiKeySet, and the instance sheet's
+// affordance for a stray stored key sitting shadowed behind an active
+// oauth/adc source (issue #713). Unlike Logout, it never refuses or
+// branches on the Codex transport: Logout's Codex path removes whichever
+// layer is currently active, which for a signed-in row means the OAuth
+// record, not the stray key, so it cannot express "clear the stray key but
+// keep the login." ApiKeyClear always targets the store entry alone,
+// leaving any OAuth record, ADC resolution, or environment credential
+// exactly as it was.
+func (c *hubAuthController) ApiKeyClear(params appwire.AuthApiKeyClearParams) (appwire.AuthStatusResponse, error) {
+	name := normalizeAuthProvider(params.Provider)
+	if err := c.clearCredential(name); err != nil {
+		return appwire.AuthStatusResponse{}, err
+	}
+	if err := c.reloadRegistry(); err != nil {
+		return appwire.AuthStatusResponse{}, err
+	}
+	return c.Status(appwire.AuthStatusParams{Provider: name})
+}
+
 func effectiveHubAuthEnv(launchEnv map[string]string) map[string]string {
 	out := envToMap(os.Environ())
 	maps.Copy(out, launchEnv)

--- a/cmd/evener-hub/app_auth_clear_stored_key_test.go
+++ b/cmd/evener-hub/app_auth_clear_stored_key_test.go
@@ -1,0 +1,166 @@
+package hub
+
+// ApiKeyClear is the instance sheet's narrow counterpart to Logout (issue
+// #713): a stray stored key can sit shadowed behind an active oauth/adc
+// credential - a Codex instance signed in via OAuth, or an ADC-resolved
+// instance, that also carries a leftover credentials.toml entry from before
+// that login/ADC took over (TestAuth_OpenAI_Status_OAuthShadowsStoredFileKey
+// renders exactly this state). Logout's Codex branch removes whichever
+// layer IS active, which for a signed-in row means the OAuth record, not
+// the stray key (TestAuth_Codex_Logout_OAuthRemovalLeavesNoCredential).
+// ApiKeyClear always clears the store layer only, regardless of what is
+// active, so it can never take down a live sign-in.
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	authopenai "primeradiant.com/evener/auth/openai"
+	"primeradiant.com/evener/auth/openai/oaitest"
+	"primeradiant.com/evener/internal/credentials"
+)
+
+// TestAuth_ApiKeyClear_LeavesActiveOAuthRecordIntact is the exact shape #713
+// reported: a Codex instance signed in via OAuth with a stray stored key
+// shadowed behind it. Clearing the stored key must drop the file entry
+// without touching the live OAuth record.
+func TestAuth_ApiKeyClear_LeavesActiveOAuthRecordIntact(t *testing.T) {
+	oaitest.IsolateOpenAIAuth(t)
+	dir := t.TempDir()
+	store, _ := credentials.LoadStore(filepath.Join(dir, "credentials.toml"))
+	c := newHubAuthControllerWithStore(dir, store)
+	c.stateDir = t.TempDir()
+	attachTestRegistry(t, c)
+	if err := store.Set("openai-codex", "sk-test-123"); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+	if err := authopenai.SaveAuth(c.stateDir, "openai-codex", authopenai.AuthRecord{
+		Version: 1, Provider: "openai", Source: authopenai.AuthSourceOAuth,
+		ObtainedAt: time.Now().Add(-time.Hour), TokenType: "Bearer",
+		AccessToken: "acc", RefreshToken: "ref",
+		Expiry: time.Now().Add(time.Hour), Email: "o@example.com",
+	}); err != nil {
+		t.Fatalf("SaveAuth: %v", err)
+	}
+
+	got, err := c.ApiKeyClear(appwire.AuthApiKeyClearParams{Provider: "openai-codex"})
+	if err != nil {
+		t.Fatalf("ApiKeyClear: %v", err)
+	}
+	if got.ActiveSource != authopenai.AuthSourceOAuth || !got.SignedIn {
+		t.Fatalf("status=%+v, want the OAuth login to stay active", got)
+	}
+	if !got.HasStoredOAuth {
+		t.Errorf("status=%+v, want the OAuth record still present", got)
+	}
+	if got.HasStoredFile {
+		t.Errorf("status=%+v, want the stored key gone", got)
+	}
+	if v, ok := store.Get("openai-codex"); ok {
+		t.Errorf("store still has a key: %q", v)
+	}
+}
+
+// TestAuth_ApiKeyClear_NonCodexMatchesLogout: on a plain apiKey-mode row
+// (no OAuth record ever exists to protect), clearing the stored key is the
+// same operation Logout already performs - ApiKeyClear must agree.
+func TestAuth_ApiKeyClear_NonCodexMatchesLogout(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := credentials.LoadStore(filepath.Join(dir, "credentials.toml"))
+	if err := store.Set("anthropic", "sk-ant-test"); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+	c := newHubAuthControllerWithStore(dir, store)
+	attachTestRegistry(t, c)
+
+	got, err := c.ApiKeyClear(appwire.AuthApiKeyClearParams{Provider: "anthropic"})
+	if err != nil {
+		t.Fatalf("ApiKeyClear: %v", err)
+	}
+	if got.SignedIn || got.ActiveSource != "none" {
+		t.Fatalf("status=%+v, want signed out after clearing the only credential", got)
+	}
+	if got.HasStoredFile {
+		t.Errorf("status=%+v, want the stored key gone", got)
+	}
+	if v, ok := store.Get("anthropic"); ok {
+		t.Errorf("store still has a key: %q", v)
+	}
+}
+
+// TestAuth_ApiKeyClear_PreservesADC is #713's other reported shape: an
+// instance resolved via Application Default Credentials with a stray stored
+// key shadowed behind it. adcCredentialsFile and the gcp-adc providers.toml
+// shape are shared with the status/adc wire fixture scenario
+// (app_auth_wire_fixture_test.go), which exercises the same registry path.
+func TestAuth_ApiKeyClear_PreservesADC(t *testing.T) {
+	credsDir := t.TempDir()
+	preStore, err := credentials.LoadStore(filepath.Join(credsDir, "credentials.toml"))
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	if err := preStore.Set("vertexish", "sk-stray"); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+	providersPath := writeProvidersToml(t, credsDir,
+		"[providers.vertexish]\nbase = \"openai-compatible\"\nbase_url = \"http://127.0.0.1:9/v1\"\nauth = \"gcp-adc\"\n")
+	c := newTestAuthController(t, credsDir, t.TempDir(), providersPath,
+		map[string]string{"GOOGLE_APPLICATION_CREDENTIALS": adcCredentialsFile(t)})
+
+	got, err := c.ApiKeyClear(appwire.AuthApiKeyClearParams{Provider: "vertexish"})
+	if err != nil {
+		t.Fatalf("ApiKeyClear: %v", err)
+	}
+	if got.ActiveSource != "adc" || !got.SignedIn {
+		t.Fatalf("status=%+v, want ADC to stay active", got)
+	}
+	if got.HasStoredFile {
+		t.Errorf("status=%+v, want the stray key gone", got)
+	}
+	if v, ok := c.creds.Get("vertexish"); ok {
+		t.Errorf("store still has a key: %q", v)
+	}
+}
+
+// TestAuth_ApiKeyClear_NoStoredKeyIsNoop: clearing an instance with nothing
+// stored is a no-op, not an error - Store.Clear is documented to accept an
+// absent entry, and the sheet's action must be safe to offer even when the
+// wire momentarily disagrees about hasStoredFile.
+func TestAuth_ApiKeyClear_NoStoredKeyIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := credentials.LoadStore(filepath.Join(dir, "credentials.toml"))
+	c := newHubAuthControllerWithStore(dir, store)
+	attachTestRegistry(t, c)
+
+	got, err := c.ApiKeyClear(appwire.AuthApiKeyClearParams{Provider: "anthropic"})
+	if err != nil {
+		t.Fatalf("ApiKeyClear: %v", err)
+	}
+	if got.HasStoredFile {
+		t.Errorf("status=%+v, want no stored file", got)
+	}
+}
+
+// TestAuth_ApiKeyClear_EmptyProviderMeansCodex mirrors
+// TestAuth_EmptyProviderMeansCodex: every evener/auth/* method treats a
+// blank provider as the default Codex instance name.
+func TestAuth_ApiKeyClear_EmptyProviderMeansCodex(t *testing.T) {
+	oaitest.IsolateOpenAIAuth(t)
+	dir := t.TempDir()
+	store, _ := credentials.LoadStore(filepath.Join(dir, "credentials.toml"))
+	c := newHubAuthControllerWithStore(dir, store)
+	c.stateDir = t.TempDir()
+	attachTestRegistry(t, c)
+	if err := store.Set("openai-codex", "sk-test-123"); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	if _, err := c.ApiKeyClear(appwire.AuthApiKeyClearParams{Provider: ""}); err != nil {
+		t.Fatalf("ApiKeyClear: %v", err)
+	}
+	if v, ok := store.Get("openai-codex"); ok {
+		t.Errorf("store still has a key: %q", v)
+	}
+}

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -644,6 +644,13 @@ func registerAuthHandlers(server *appserver.Server, authController *hubAuthContr
 		}
 		return resp, err
 	})
+	appserver.HandleTyped(server.Router(), appwire.MethodEvenerAuthApiKeyClear, func(ctx context.Context, params appwire.AuthApiKeyClearParams) (appwire.AuthStatusResponse, error) {
+		resp, err := authController.ApiKeyClear(params)
+		if err == nil {
+			notifyAuthUpdated(server, resp.Provider, resp.ActiveSource)
+		}
+		return resp, err
+	})
 	appserver.HandleTyped(server.Router(), appwire.MethodEvenerAuthDeviceStart, func(ctx context.Context, params appwire.AuthDeviceStartParams) (appwire.AuthDeviceStartResponse, error) {
 		return authController.DeviceStart(ctx, params)
 	})

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -11013,11 +11013,23 @@ func TestHubRPCRegistersExpectedHandlerSet(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	tomlPath := writeProvidersToml(t, dir, "[providers.my-openai]\nbase = \"openai\"\napi_key = \"sk-inline\"\n")
+	// A temp-dir-backed credentials store, shared with the registry below:
+	// the dispatch loop further down calls every expected method with empty
+	// params, including the credential-mutating evener/auth/* handlers
+	// (apiKey/set, logout, apiKey/clear). A nil CredsStore makes
+	// newHubAuthControllerWithStore fall back to the real on-disk default
+	// (~/.config/evener/credentials.toml via the ambient HOME/XDG env) -
+	// this test must never read or write a developer's actual store.
+	credsStore, loadErr := credentials.LoadStore(filepath.Join(t.TempDir(), "credentials.toml"))
+	if loadErr != nil {
+		t.Fatalf("LoadStore: %v", loadErr)
+	}
 	hub, web := newHubRPCTestServerWithWeb(t, hubcore.WebConfig{
 		Past:                hubcore.NewPastIndex(""),
-		Registry:            newTestRegistry(t, t.TempDir(), tomlPath, nil, nil),
+		Registry:            newTestRegistry(t, t.TempDir(), tomlPath, credsStore, nil),
 		ProvidersConfigPath: tomlPath,
 		HubStateRoot:        dir,
+		CredsStore:          credsStore,
 	})
 	defer hub.Close()
 	client := dialHubRPC(t, hub)

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -11059,6 +11059,7 @@ func TestHubRPCRegistersExpectedHandlerSet(t *testing.T) {
 		appwire.MethodEvenerAuthLogout,
 		appwire.MethodEvenerAuthList,
 		appwire.MethodEvenerAuthApiKeySet,
+		appwire.MethodEvenerAuthApiKeyClear,
 		appwire.MethodEvenerAuthDeviceStart,
 		appwire.MethodEvenerAuthDevicePoll,
 		appwire.MethodEvenerNavigationRead,

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.edge.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.edge.test.tsx
@@ -1,5 +1,6 @@
 // Edge cases for CredentialsSection.tsx uncovered lines:
 // - handleConfirmedAction clear failure error toast
+// - handleConfirmedAction clear stored key failure error toast
 // - handleConfirmedAction remove failure error toast
 // - findInstance returns undefined for apiKey dialog when instance is gone
 // - findInstance returns undefined for edit dialog when instance is gone
@@ -92,6 +93,37 @@ describe("CredentialsSection edge cases", () => {
     await user.click(within(dialog).getByRole("button", { name: "Clear" }));
     await screen.findByText("Clear failed: Something went wrong.");
     expect(screen.getByRole("dialog", { name: "Clear credentials" })).toBeTruthy();
+  });
+
+  test("clear stored key failure shows error toast", async () => {
+    const fake = connectFakeClient();
+    const SHADOWED = instance({
+      name: "shadowed",
+      providerId: "openai-codex",
+      auth: "oauth-openai-codex",
+      authModes: ["oauth"],
+      activeSource: "oauth",
+      hasStoredOAuth: true,
+      hasStoredFile: true,
+    });
+    fake.on("evener/instance/list", () => ({ instances: [SHADOWED], availableProviders: [] }));
+    fake.on("evener/auth/apiKey/clear", () => {
+      throw new Error("clear denied");
+    });
+    render(
+      <>
+        <Toast />
+        <CredentialsSection sectionId="credentials" />
+      </>,
+    );
+    await screen.findByText("shadowed");
+    const user = userEvent.setup();
+    const inspector = await openSheet(user, "shadowed");
+    await user.click(within(inspector).getByRole("button", { name: "Clear stored key" }));
+    const dialog = screen.getByRole("dialog", { name: "Clear stored key" });
+    await user.click(within(dialog).getByRole("button", { name: "Clear" }));
+    await screen.findByText("Clear stored key failed: Something went wrong.");
+    expect(screen.getByRole("dialog", { name: "Clear stored key" })).toBeTruthy();
   });
 
   test("remove failure shows error toast", async () => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.test.tsx
@@ -579,7 +579,7 @@ describe("set default", () => {
   });
 });
 
-describe("Clear / Remove confirm dialogs", () => {
+describe("Clear / Clear stored key / Remove confirm dialogs", () => {
   test("Clear opens a ConfirmDialog naming the instance; confirming calls authLogout then refreshes", async () => {
     const fake = connectFakeClient();
     fake.on("evener/instance/list", () => LIST);
@@ -608,6 +608,45 @@ describe("Clear / Remove confirm dialogs", () => {
     // scope this second click to the dialog's own Clear/confirm button.
     await user.click(within(dialog).getByRole("button", { name: "Clear" }));
     await screen.findByText("Credentials cleared for work");
+  });
+
+  // #713: a stray stored key shadowed behind an active OAuth login needs an
+  // affordance that clears the key without dropping the login - distinct
+  // from Clear (authLogout), which for a signed-in Codex row would remove
+  // the OAuth record instead.
+  test("Clear stored key opens a ConfirmDialog naming the instance; confirming calls clearStoredKey then refreshes", async () => {
+    const fake = connectFakeClient();
+    const SHADOWED = instance({
+      name: "shadowed",
+      providerId: "openai-codex",
+      auth: "oauth-openai-codex",
+      authModes: ["oauth"],
+      activeSource: "oauth",
+      hasStoredOAuth: true,
+      hasStoredFile: true,
+    });
+    fake.on("evener/instance/list", () => ({ instances: [SHADOWED], availableProviders: [] }));
+    fake.on("evener/auth/apiKey/clear", (params) => {
+      expect(params).toEqual({ provider: "shadowed" });
+      return { provider: "shadowed", supported: true, signedIn: true, activeSource: "oauth", hasStoredOAuth: true };
+    });
+    render(
+      <>
+        <CredentialsSection sectionId="credentials" />
+        <Toast />
+      </>,
+    );
+    await screen.findByText("shadowed");
+    const user = userEvent.setup();
+    const inspector = await openSheet(user, "shadowed");
+    // This row is signed in via OAuth (showClear also true), so both Clear
+    // and Clear stored key render - assert the narrower action reaches the
+    // narrower RPC, leaving the login alone.
+    await user.click(within(inspector).getByRole("button", { name: "Clear stored key" }));
+    const dialog = screen.getByRole("dialog", { name: "Clear stored key" });
+    expect(dialog).toBeTruthy();
+    await user.click(within(dialog).getByRole("button", { name: "Clear" }));
+    await screen.findByText("Stored key cleared for shadowed");
   });
 
   test("Remove opens a ConfirmDialog; confirming calls instanceRemove", async () => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.tsx
@@ -1,20 +1,20 @@
 // CredentialsSection (#7 - the dominant piece of the Agents & models
 // cluster), detail-sheet redesign: instance rows are single tappable
 // targets that open an InstanceDetailSheet inspector; every per-instance
-// action (test, set key, sign in, edit, make default, clear, remove)
-// lives in that sheet - the same row→detail-sheet collection-page idiom
-// the marketplacesPlugins redesign introduced (a sibling workstream; the
-// idiom's design-system writeup lands with it) - instead of a per-row
-// button cluster. The editors (add/apiKey/edit/OAuth flows) stay dialogs:
-// opening one from the sheet replaces it (single-mutable-editor invariant
-// below).
+// action (test, set key, sign in, edit, make default, clear, clear stored
+// key, remove) lives in that sheet - the same row→detail-sheet
+// collection-page idiom the marketplacesPlugins redesign introduced (a
+// sibling workstream; the idiom's design-system writeup lands with it) -
+// instead of a per-row button cluster. The editors (add/apiKey/edit/OAuth
+// flows) stay dialogs: opening one from the sheet replaces it
+// (single-mutable-editor invariant below).
 //
 // Updated for the provider registry's instance wire shape (spec §11.3):
 // instances group by providerId, the add form is fed availableProviders, and
 // a providers.toml load error surfaces as a diagnostics banner that disables
 // every instance-CRUD action until it clears (writesRefused) - Set key/Sign
-// in/Clear/Test credentials are unaffected, since none of them write
-// providers.toml.
+// in/Clear/Clear stored key/Test credentials are unaffected, since none of
+// them write providers.toml.
 //
 // Single-mutable-editor invariant: `openEditor` is ONE section-level state
 // value (a discriminated union), so opening a second editor always replaces
@@ -55,7 +55,7 @@ type OpenEditor =
   | { kind: "device"; name: string; flowId: string; userCode: string; verificationUrl: string; intervalSeconds: number }
   | null;
 
-type PendingConfirm = { kind: "clear" | "remove"; name: string } | null;
+type PendingConfirm = { kind: "clear" | "clearStoredKey" | "remove"; name: string } | null;
 type CredentialTestState = { version: number; pending: boolean; result?: AuthTestResponse };
 
 // Diagnostics: the providers.toml load-error pointer, the user-layer note,
@@ -177,13 +177,17 @@ export function CredentialsSection(_props: CredentialsSectionProps) {
         await credentialsStore.getState().logout(name);
         await credentialsStore.getState().fetch();
         toast.push("success", `Credentials cleared for ${name}`);
+      } else if (kind === "clearStoredKey") {
+        await credentialsStore.getState().clearStoredKey(name);
+        await credentialsStore.getState().fetch();
+        toast.push("success", `Stored key cleared for ${name}`);
       } else {
         await credentialsStore.getState().remove(name);
         toast.push("success", `Removed instance ${name}`);
       }
       setPendingConfirm(null);
     } catch (err) {
-      const verb = kind === "clear" ? "Clear" : "Remove";
+      const verb = kind === "clear" ? "Clear" : kind === "clearStoredKey" ? "Clear stored key" : "Remove";
       toast.push("error", `${verb} failed: ${friendlyErrorMessage(err)}`);
     } finally {
       setConfirmBusy(false);
@@ -261,6 +265,9 @@ export function CredentialsSection(_props: CredentialsSectionProps) {
         onClear={() => {
           if (selectedInstance !== null) setPendingConfirm({ kind: "clear", name: selectedInstance });
         }}
+        onClearStoredKey={() => {
+          if (selectedInstance !== null) setPendingConfirm({ kind: "clearStoredKey", name: selectedInstance });
+        }}
         onRemove={() => {
           if (selectedInstance !== null) setPendingConfirm({ kind: "remove", name: selectedInstance });
         }}
@@ -322,15 +329,23 @@ export function CredentialsSection(_props: CredentialsSectionProps) {
 
       <ConfirmDialog
         open={pendingConfirm !== null}
-        title={pendingConfirm?.kind === "clear" ? "Clear credentials" : "Remove instance"}
-        confirmLabel={pendingConfirm?.kind === "clear" ? "Clear" : "Remove"}
+        title={
+          pendingConfirm?.kind === "clear"
+            ? "Clear credentials"
+            : pendingConfirm?.kind === "clearStoredKey"
+              ? "Clear stored key"
+              : "Remove instance"
+        }
+        confirmLabel={pendingConfirm?.kind === "remove" ? "Remove" : "Clear"}
         busy={confirmBusy}
         onConfirm={() => void handleConfirmedAction()}
         onCancel={() => setPendingConfirm(null)}
       >
         {pendingConfirm?.kind === "clear"
           ? `Clear stored credentials for "${pendingConfirm.name}"?`
-          : `Remove instance "${pendingConfirm?.name}"? This will also clear its stored credentials.`}
+          : pendingConfirm?.kind === "clearStoredKey"
+            ? `Clear the stored API key for "${pendingConfirm.name}"? Its active sign-in is not affected.`
+            : `Remove instance "${pendingConfirm?.name}"? This will also clear its stored credentials.`}
       </ConfirmDialog>
     </div>
   );

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceDetailSheet.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceDetailSheet.test.tsx
@@ -27,6 +27,7 @@ function noopHandlers() {
     onOAuthStart: vi.fn(),
     onEdit: vi.fn(),
     onClear: vi.fn(),
+    onClearStoredKey: vi.fn(),
     onRemove: vi.fn(),
     onSetDefault: vi.fn(),
   };
@@ -187,6 +188,32 @@ describe("actions are conditionally rendered", () => {
     expect(screen.getByRole("button", { name: "Clear" })).toBeTruthy();
   });
 
+  // #713: a stray stored key can sit shadowed behind an active oauth/adc
+  // login - Clear stored key is the sheet's narrow affordance for exactly
+  // that state, distinct from Clear (which for a signed-in Codex row would
+  // drop the login instead of the stray key).
+  test("Clear stored key when a stored key is shadowed behind an active OAuth login", () => {
+    renderSheet(
+      instance({ name: "a", providerId: "openai-codex", activeSource: "oauth", hasStoredFile: true, hasStoredOAuth: true }),
+    );
+    expect(screen.getByRole("button", { name: "Clear stored key" })).toBeTruthy();
+  });
+
+  test("Clear stored key when a stored key is shadowed behind ADC", () => {
+    renderSheet(instance({ name: "a", providerId: "x", activeSource: "adc", hasStoredFile: true }));
+    expect(screen.getByRole("button", { name: "Clear stored key" })).toBeTruthy();
+  });
+
+  test("no Clear stored key when the stored key IS the active source", () => {
+    renderSheet(instance({ name: "a", providerId: "x", activeSource: "store", hasStoredFile: true }));
+    expect(screen.queryByRole("button", { name: "Clear stored key" })).toBeNull();
+  });
+
+  test("no Clear stored key when nothing is stored", () => {
+    renderSheet(instance({ name: "a", providerId: "x", activeSource: "oauth", hasStoredFile: false }));
+    expect(screen.queryByRole("button", { name: "Clear stored key" })).toBeNull();
+  });
+
   test("Edit and Remove are both offered for a non-implicit instance", () => {
     renderSheet(instance({ name: "a", providerId: "x" }));
     expect(screen.getByRole("button", { name: "Edit" })).toBeTruthy();
@@ -215,6 +242,15 @@ describe("actions are conditionally rendered", () => {
       instance({ name: "groq", providerId: "groq", implicit: true, activeSource: "store", hasStoredFile: true }),
     );
     expect(document.querySelectorAll("hr").length).toBe(1);
+  });
+
+  test("the danger-zone divider stays when Clear stored key alone is offered", () => {
+    renderSheet(
+      instance({ name: "groq", providerId: "groq", implicit: true, activeSource: "adc", hasStoredFile: true }),
+    );
+    expect(document.querySelectorAll("hr").length).toBe(1);
+    expect(screen.getByRole("button", { name: "Clear stored key" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Clear" })).toBeNull();
   });
 
   test("make default only when not already default", () => {
@@ -319,6 +355,15 @@ describe("action callbacks fire", () => {
     expect(handlers.onSetDefault).toHaveBeenCalled();
   });
 
+  test("clicking Clear stored key calls its handler", async () => {
+    const user = userEvent.setup();
+    const { handlers } = renderSheet(
+      instance({ name: "a", providerId: "openai-codex", activeSource: "oauth", hasStoredFile: true, hasStoredOAuth: true }),
+    );
+    await user.click(screen.getByRole("button", { name: "Clear stored key" }));
+    expect(handlers.onClearStoredKey).toHaveBeenCalled();
+  });
+
   test("clicking Sign in calls its handler", async () => {
     const user = userEvent.setup();
     const { handlers } = renderSheet(
@@ -361,8 +406,9 @@ describe("action callbacks fire", () => {
 
 // writesRefused is the wire's "providers.toml cannot be written" flag
 // (InstanceListResponse, spec §11.3): it gates the evener/instance/* writes
-// only. Set key/Sign in/Clear/Test credentials write the credentials store
-// or an OAuth record, never providers.toml, so they stay live.
+// only. Set key/Sign in/Clear/Clear stored key/Test credentials write the
+// credentials store or an OAuth record, never providers.toml, so they stay
+// live.
 describe("writesRefused disables instance-CRUD actions only", () => {
   test("disables Edit, Remove, and make default", () => {
     renderSheet(instance({ name: "a", providerId: "x", isDefault: false }), { writesRefused: true });
@@ -385,6 +431,13 @@ describe("writesRefused disables instance-CRUD actions only", () => {
     expect((screen.getByRole("button", { name: "Test credentials" }) as HTMLButtonElement).disabled).toBe(false);
     expect((screen.getByRole("button", { name: "Replace key" }) as HTMLButtonElement).disabled).toBe(false);
     expect((screen.getByRole("button", { name: "Clear" }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  test("leaves Clear stored key enabled", () => {
+    renderSheet(instance({ name: "a", providerId: "x", activeSource: "adc", hasStoredFile: true }), {
+      writesRefused: true,
+    });
+    expect((screen.getByRole("button", { name: "Clear stored key" }) as HTMLButtonElement).disabled).toBe(false);
   });
 
   test("an implicit instance under writesRefused still has no Remove button at all", () => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceDetailSheet.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceDetailSheet.test.tsx
@@ -194,7 +194,13 @@ describe("actions are conditionally rendered", () => {
   // drop the login instead of the stray key).
   test("Clear stored key when a stored key is shadowed behind an active OAuth login", () => {
     renderSheet(
-      instance({ name: "a", providerId: "openai-codex", activeSource: "oauth", hasStoredFile: true, hasStoredOAuth: true }),
+      instance({
+        name: "a",
+        providerId: "openai-codex",
+        activeSource: "oauth",
+        hasStoredFile: true,
+        hasStoredOAuth: true,
+      }),
     );
     expect(screen.getByRole("button", { name: "Clear stored key" })).toBeTruthy();
   });
@@ -358,7 +364,13 @@ describe("action callbacks fire", () => {
   test("clicking Clear stored key calls its handler", async () => {
     const user = userEvent.setup();
     const { handlers } = renderSheet(
-      instance({ name: "a", providerId: "openai-codex", activeSource: "oauth", hasStoredFile: true, hasStoredOAuth: true }),
+      instance({
+        name: "a",
+        providerId: "openai-codex",
+        activeSource: "oauth",
+        hasStoredFile: true,
+        hasStoredOAuth: true,
+      }),
     );
     await user.click(screen.getByRole("button", { name: "Clear stored key" }));
     expect(handlers.onClearStoredKey).toHaveBeenCalled();

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceDetailSheet.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceDetailSheet.tsx
@@ -107,7 +107,7 @@ export function InstanceDetailSheet({
   // instead of the stray key, and on an adc/api_key/env row it never shows
   // at all. This action always targets the store layer only, so it is safe
   // to offer regardless of what is effective.
-  const showClearStoredKey = instance !== undefined && instance.hasStoredFile && instance.activeSource !== "store";
+  const showClearStoredKey = instance?.hasStoredFile && instance.activeSource !== "store";
   // The danger zone is Clear + Clear stored key + Remove under a divider; an
   // implicit instance with nothing stored offers none of them, and a divider
   // over nothing reads as a rendering bug.

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceDetailSheet.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceDetailSheet.tsx
@@ -3,12 +3,12 @@
 // carried: the layered credential display (the effective source, plus an
 // environment variable shadowed behind it), the meta table, and every
 // per-instance ACTION (test, set/replace key, sign in/refresh OAuth, edit,
-// make default, clear, remove). A right side Sheet on desktop, a bottom
-// Sheet on mobile (useIsMobile, the shell's own source). The instance is
-// read from the store by name so cross-client changes land live, and the
-// sheet closes itself when the instance disappears (its own Remove
-// completing, or another client's) - an inspector is only as alive as its
-// subject.
+// make default, clear, clear stored key, remove). A right side Sheet on
+// desktop, a bottom Sheet on mobile (useIsMobile, the shell's own source).
+// The instance is read from the store by name so cross-client changes land
+// live, and the sheet closes itself when the instance disappears (its own
+// Remove completing, or another client's) - an inspector is only as alive
+// as its subject.
 // Presentation only - the section owns what each action DOES (opening an
 // editor, a confirm dialog, or calling the store), same division of labor
 // as the old InstanceRow.
@@ -51,6 +51,7 @@ export interface InstanceDetailSheetProps {
   onOAuthStart: () => void;
   onEdit: () => void;
   onClear: () => void;
+  onClearStoredKey: () => void;
   onRemove: () => void;
   onSetDefault: () => void;
   onTestCredentials: () => void;
@@ -58,8 +59,8 @@ export interface InstanceDetailSheetProps {
   testCredentialsResult?: AuthTestResponse;
   /** Disables Edit/Remove/make default while providers.toml cannot be
    * written (InstanceListResponse.writesRefused, spec §11.3) - Set key/Sign
-   * in/Clear/Test credentials are unaffected: they write the credentials
-   * store or an OAuth record, never providers.toml. */
+   * in/Clear/Clear stored key/Test credentials are unaffected: they write
+   * the credentials store or an OAuth record, never providers.toml. */
   writesRefused?: boolean;
 }
 
@@ -70,6 +71,7 @@ export function InstanceDetailSheet({
   onOAuthStart,
   onEdit,
   onClear,
+  onClearStoredKey,
   onRemove,
   onSetDefault,
   onTestCredentials,
@@ -95,10 +97,21 @@ export function InstanceDetailSheet({
   const supportsApiKey = instance !== undefined && (instance.authModes ?? []).includes("apiKey");
   const supportsOAuth = instance !== undefined && (instance.authModes ?? []).includes("oauth");
   const showClear = instance !== undefined && (instance.activeSource === "store" || instance.activeSource === "oauth");
-  // The danger zone is Clear + Remove under a divider; an implicit instance
-  // with nothing stored offers neither, and a divider over nothing reads as
-  // a rendering bug.
-  const showDangerZone = instance !== undefined && (showClear || !instance.implicit);
+  // showClearStoredKey: a stray stored key sits shadowed behind whatever IS
+  // active (the same condition credentialLayers uses to render that second,
+  // non-effective layer above) - true for an oauth/adc login with a leftover
+  // credentials.toml entry, and just as much for a signed-out Codex row a
+  // previous Clear left stranded (Clear's Codex branch removes the OAuth
+  // record, not the file, when one is active; issue #713). Clear alone
+  // cannot reach this state: on a Codex row it would drop the active login
+  // instead of the stray key, and on an adc/api_key/env row it never shows
+  // at all. This action always targets the store layer only, so it is safe
+  // to offer regardless of what is effective.
+  const showClearStoredKey = instance !== undefined && instance.hasStoredFile && instance.activeSource !== "store";
+  // The danger zone is Clear + Clear stored key + Remove under a divider; an
+  // implicit instance with nothing stored offers none of them, and a divider
+  // over nothing reads as a rendering bug.
+  const showDangerZone = instance !== undefined && (showClear || showClearStoredKey || !instance.implicit);
   const layers = instance === undefined ? [] : credentialLayers(instance);
   const unconfigured = instance === undefined ? null : unconfiguredLabel(instance);
   const safeTestResult = testCredentialsResult
@@ -178,6 +191,13 @@ export function InstanceDetailSheet({
             <>
               <hr className={CLASS.divider} />
               <div className={CLASS.actionRows}>
+                {showClearStoredKey && (
+                  <div className={CLASS.fullRow}>
+                    <Button variant="dangerQuiet" onClick={onClearStoredKey}>
+                      Clear stored key
+                    </Button>
+                  </div>
+                )}
                 {showClear && (
                   <div className={CLASS.fullRow}>
                     <Button variant="dangerQuiet" onClick={onClear}>

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceDetailSheet.wire.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceDetailSheet.wire.test.tsx
@@ -23,6 +23,7 @@ function renderHubInstance(name: string) {
       onOAuthStart={vi.fn()}
       onEdit={vi.fn()}
       onClear={vi.fn()}
+      onClearStoredKey={vi.fn()}
       onRemove={vi.fn()}
       onSetDefault={vi.fn()}
     />,

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -47,6 +47,10 @@ export interface AttentionSummary {
   working: number;
 }
 
+export interface AuthApiKeyClearParams {
+  provider: string;
+}
+
 export interface AuthApiKeySetParams {
   provider: string;
   value: string;
@@ -2074,6 +2078,7 @@ export const METHOD_NAMES = [
   "evener/auth/logout",
   "evener/auth/list",
   "evener/auth/apiKey/set",
+  "evener/auth/apiKey/clear",
   "evener/auth/device/start",
   "evener/auth/device/poll",
   "evener/launch/resolve",
@@ -2250,6 +2255,7 @@ export interface MethodTypes {
   "evener/auth/logout": { params: AuthLogoutParams; result: AuthLogoutResponse };
   "evener/auth/list": { params: EmptyParams; result: AuthListResponse };
   "evener/auth/apiKey/set": { params: AuthApiKeySetParams; result: AuthStatusResponse };
+  "evener/auth/apiKey/clear": { params: AuthApiKeyClearParams; result: AuthStatusResponse };
   "evener/auth/device/start": { params: AuthDeviceStartParams; result: AuthDeviceStartResponse };
   "evener/auth/device/poll": { params: AuthDevicePollParams; result: AuthDevicePollResponse };
   "evener/launch/resolve": { params: LaunchConfigResolveParams; result: LaunchConfigResolved };

--- a/cmd/evener-hub/frontend/src/stores/credentials.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/credentials.test.ts
@@ -196,6 +196,17 @@ describe("auth RPCs: thin proxies, no local state mutation", () => {
     expect(JSON.stringify(credentialsStore.getState())).not.toContain("sk-secret");
   });
 
+  test("clearStoredKey() calls evener/auth/apiKey/clear and returns its response", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/auth/apiKey/clear", (params) => {
+      expect(params).toEqual({ provider: "work" });
+      return { provider: "work", supported: true, signedIn: true, activeSource: "oauth", hasStoredOAuth: true };
+    });
+    const result = await credentialsStore.getState().clearStoredKey("work");
+    expect(result.activeSource).toBe("oauth");
+    expect(result.hasStoredOAuth).toBe(true);
+  });
+
   test("logout() calls evener/auth/logout", async () => {
     const fake = connectFakeClient();
     fake.on("evener/auth/logout", (params) => {

--- a/cmd/evener-hub/frontend/src/stores/credentials.ts
+++ b/cmd/evener-hub/frontend/src/stores/credentials.ts
@@ -69,6 +69,11 @@ export interface CredentialsStoreState {
   // refresh()" sequencing, and surfaces failures as inline errors/toasts
   // itself rather than this store swallowing them into an `error` field.
   setApiKey(provider: string, value: string): Promise<AuthStatusResponse>;
+  // clearStoredKey removes only the credentials.toml entry, leaving any
+  // OAuth/ADC/env credential untouched - the counterpart to setApiKey, and
+  // the narrow alternative to logout() for a stray stored key shadowed
+  // behind an active oauth/adc sign-in (issue #713).
+  clearStoredKey(provider: string): Promise<AuthStatusResponse>;
   logout(provider: string): Promise<AuthLogoutResponse>;
   loginStart(provider: string): Promise<AuthLoginStartResponse>;
   loginComplete(provider: string, flowId: string, redirectUrl: string): Promise<AuthLoginCompleteResponse>;
@@ -145,6 +150,11 @@ export const credentialsStore = createStore<CredentialsStoreState>((set) => ({
   async setApiKey(provider, value) {
     const client = requireClient();
     return client.request("evener/auth/apiKey/set", { provider, value });
+  },
+
+  async clearStoredKey(provider) {
+    const client = requireClient();
+    return client.request("evener/auth/apiKey/clear", { provider });
   },
 
   async logout(provider) {

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -140,6 +140,7 @@ no router (reserved).
 | `evener/auth/logout` | hub | `AuthLogoutParams` | `AuthLogoutResponse` | Logs out a provider; broadcasts evener/auth/updated. |
 | `evener/auth/list` | hub | `EmptyParams` | `AuthListResponse` | Lists auth status for all providers. |
 | `evener/auth/apiKey/set` | hub | `AuthApiKeySetParams` | `AuthStatusResponse` | Stores a provider API key; broadcasts evener/auth/updated. |
+| `evener/auth/apiKey/clear` | hub | `AuthApiKeyClearParams` | `AuthStatusResponse` | Clears a provider's stored file-layer key only, leaving any OAuth/ADC/env credential untouched; broadcasts evener/auth/updated. |
 | `evener/auth/device/start` | hub | `AuthDeviceStartParams` | `AuthDeviceStartResponse` | Begins a device-code auth flow (or signals fallback). |
 | `evener/auth/device/poll` | hub | `AuthDevicePollParams` | `AuthDevicePollResponse` | Polls a device-code flow; broadcasts evener/auth/updated when authorized. |
 | `evener/launch/resolve` | hub | `LaunchConfigResolveParams` | `LaunchConfigResolved` | Resolves the effective launch config for a cwd. |
@@ -267,6 +268,13 @@ An embedded type contributes its own fields inline.
 |-------|---------|-----------|----------|
 | `changed` | `[]appwire.AttentionChanged` |  |  |
 | `summary` | `appwire.AttentionSummary` |  |  |
+
+
+### `AuthApiKeyClearParams`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `provider` | `string` |  |  |
 
 
 ### `AuthApiKeySetParams`

--- a/internal/credentials/store.go
+++ b/internal/credentials/store.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/BurntSushi/toml"
 	"github.com/spf13/afero"
@@ -26,11 +27,21 @@ type providerSection struct {
 	APIKey string `toml:"api_key,omitempty"`
 }
 
-// Store is the in-memory + on-disk credentials.toml.
+// Store is the in-memory + on-disk credentials.toml. One Store is shared by
+// every evener/auth/* RPC handler plus evener/instance/remove on the hub's
+// single hubAuthController, and AppWire serializes requests only within a
+// single connection - two browser tabs, or a browser and the TUI, can call
+// Set/Clear/Get concurrently. mu guards data (a plain map, unsafe for
+// concurrent read+write) and serializes save()'s temp-file-then-rename pair,
+// so two racing writers can't interleave on the same .tmp path and corrupt
+// or drop each other's update. path and fs are set once at construction
+// (loadStoreFS) and never mutated again, so reading them needs no lock.
 type Store struct {
 	path string
-	data fileShape
 	fs   afero.Fs
+
+	mu   sync.RWMutex
+	data fileShape
 }
 
 // LoadStore reads path. Missing returns an empty Store. Non-missing files
@@ -73,6 +84,8 @@ func loadStoreFS(fs afero.Fs, path string) (*Store, error) {
 // Get returns the file-layer key stored under name (an instance name, spec
 // §10). The environment is the registry's business, not the store's.
 func (s *Store) Get(name string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	p, ok := s.data.Providers[strings.ToLower(name)]
 	if !ok || strings.TrimSpace(p.APIKey) == "" {
 		return "", false
@@ -83,6 +96,8 @@ func (s *Store) Get(name string) (string, bool) {
 // Names lists every entry, sorted, so a caller can report entries that
 // name no instance (spec §14.1).
 func (s *Store) Names() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	out := make([]string, 0, len(s.data.Providers))
 	for name := range s.data.Providers {
 		out = append(out, name)
@@ -96,6 +111,8 @@ func (s *Store) Path() string { return s.path }
 
 // Set writes an instance's API key into the in-memory store and persists.
 func (s *Store) Set(name, value string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	name = strings.ToLower(name)
 	if s.data.Providers == nil {
 		s.data.Providers = map[string]providerSection{}
@@ -106,11 +123,16 @@ func (s *Store) Set(name, value string) error {
 
 // Clear removes the entry. No error if absent.
 func (s *Store) Clear(name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	name = strings.ToLower(name)
 	delete(s.data.Providers, name)
 	return s.save()
 }
 
+// save persists s.data. Callers must hold mu (Lock, not RLock): it both
+// reads data for encoding and is the only place two concurrent writers could
+// otherwise interleave on the same .tmp path.
 func (s *Store) save() error {
 	if s.path == "" {
 		return nil

--- a/internal/credentials/store_test.go
+++ b/internal/credentials/store_test.go
@@ -1,9 +1,11 @@
 package credentials
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 )
 
@@ -137,6 +139,58 @@ func TestStore_PathIsTheFileItReadsAndWrites(t *testing.T) {
 	}
 	if got := s.Path(); got != path {
 		t.Errorf("Path = %q, want %q", got, path)
+	}
+}
+
+// TestStore_ConcurrentAccessIsRaceFree drives Set/Get/Clear/Names from many
+// goroutines against one Store: the hub's auth controller shares exactly one
+// Store across every evener/auth/* RPC plus evener/instance/remove, and
+// AppWire serializes requests only within a single connection - two browser
+// tabs (or a browser and the TUI) calling ApiKeySet/Logout/ApiKeyClear/
+// Remove/Status concurrently must not race the underlying map or corrupt
+// the on-disk file via colliding .tmp writes. `go test -race` is what makes
+// this test meaningful; without it, a torn map access can pass silently.
+func TestStore_ConcurrentAccessIsRaceFree(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "credentials.toml")
+	s, err := LoadStore(path)
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+
+	const goroutines = 8
+	const iterations = 50
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		name := fmt.Sprintf("provider-%d", g)
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			for range iterations {
+				if err := s.Set(name, "sk-test"); err != nil {
+					t.Errorf("Set(%s): %v", name, err)
+				}
+				// Get/Names only need to not race or panic here - a
+				// concurrent Clear from another goroutine legitimately owns
+				// whether this particular read observes the key.
+				s.Get(name)
+				s.Names()
+				if err := s.Clear(name); err != nil {
+					t.Errorf("Clear(%s): %v", name, err)
+				}
+			}
+		}(name)
+	}
+	wg.Wait()
+
+	// The store must still be in a coherent, reloadable state: every
+	// goroutine's last op was Clear, so nothing should remain, and the file
+	// itself must parse (not a half-written .tmp left over from a collision).
+	reloaded, err := LoadStore(path)
+	if err != nil {
+		t.Fatalf("LoadStore after concurrent access: %v", err)
+	}
+	if names := reloaded.Names(); len(names) != 0 {
+		t.Errorf("Names after concurrent access = %v, want none", names)
 	}
 }
 


### PR DESCRIPTION
Fixes #713

## Summary

An instance authenticating via OAuth (Codex) or Application Default
Credentials can also carry a leftover `credentials.toml` entry from
before that login/ADC took over. The instance sheet already rendered
this honestly as a shadowed layer, but offered no action to clear just
the stray key:

- **Clear** (`evener/auth/logout`) targets whichever credential layer is
  currently *active*. On a signed-in Codex row that means the OAuth
  record, not the stray stored key — clicking it would drop the login
  instead of removing the leftover key.
- `authModes` withholds key actions on a Codex row entirely.
- `adc` rows never showed a Clear affordance at all, even though the
  underlying `Logout` RPC would have handled that case safely (it only
  ever touches the store for a non-Codex instance).

The only way to remove such a stray key was hand-editing
`credentials.toml`.

## Fix

- New RPC `evener/auth/apiKey/clear` (`AuthApiKeyClearParams` ->
  `AuthStatusResponse`), the narrow counterpart to `apiKey/set`. Its
  handler (`hubAuthController.ApiKeyClear`) always clears just the
  credentials-store entry (`credentials.Store.Clear`) and never branches
  on the Codex transport the way `Logout` does, so it can never take
  down a live sign-in.
- New sheet action **"Clear stored key"**, shown whenever a stored key is
  shadowed by another active source — the same `hasStoredFile &&
  activeSource !== "store"` condition the sheet already uses to render
  the shadowed layer — alongside the existing Clear/Remove actions
  rather than replacing them.
- Additive wire change only: new method, new param type, existing types
  unchanged.

## Test plan

- New Go tests in `cmd/evener-hub/app_auth_clear_stored_key_test.go`:
  clearing a stray key leaves an active Codex OAuth record and an active
  ADC resolution intact; parity with `Logout` on a plain apiKey-mode row;
  no-op when nothing is stored; blank-provider-means-Codex convention.
- New frontend tests (`InstanceDetailSheet.test.tsx`,
  `CredentialsSection.test.tsx`, `CredentialsSection.edge.test.tsx`,
  `stores/credentials.test.ts`) covering visibility, the confirm-dialog
  flow, and error handling for the new action. These could not be
  executed in this offline sandbox (no `node_modules`, npm install
  requires network) — see PR conversation for details.
- `go test ./appwire/... ./cmd/evener-hub/... ./cmd/evener-tui/... ./internal/appserver/... ./internal/appwirets/... ./internal/appwiredoc/... ./cmd/evener-fuzz-harvest/...` all pass.
- `gofmt -l` clean on touched files.
- `make lint` passes in full (naming, gofmt, evenerfuzz, eval, internal, golangci, generated, fuzz-registry, secret-scan).