### PR TITLE
Resume sidecar: window transcript resume to the last checkpoint (validated offset)

### DIFF
--- a/agent/delegate_tree_restore.go
+++ b/agent/delegate_tree_restore.go
@@ -12,14 +12,15 @@ import (
 	"strings"
 
 	"primeradiant.com/evener/agent/internal/delegatestore"
+	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/agent/transcript"
 )
 
 type delegateAttentionResolution string
 
 const (
-	delegateAttentionConsumed  delegateAttentionResolution = "consumed"
-	delegateAttentionDiscarded delegateAttentionResolution = "discarded"
+	delegateAttentionConsumed  delegateAttentionResolution = schema.AttentionDispositionConsumed
+	delegateAttentionDiscarded delegateAttentionResolution = schema.AttentionDispositionDiscarded
 )
 
 type shellNotificationIdentity struct {

--- a/agent/schema/turn.go
+++ b/agent/schema/turn.go
@@ -63,6 +63,14 @@ const (
 	TurnAttentionResolution TurnKind = "ATTENTION_RESOLUTION"
 )
 
+// Attention resolution dispositions: the terminal states an attention can
+// resolve to. Exported because two packages judge them — the agent's fold
+// and the transcript package's restatement of it — and must not drift.
+const (
+	AttentionDispositionConsumed  = "consumed"
+	AttentionDispositionDiscarded = "discarded"
+)
+
 // AttentionResolutionInfo identifies one durable attention item and its
 // terminal disposition. The resolution is append-only so cold reconciliation
 // can repeat safely after a crash.

--- a/agent/session.go
+++ b/agent/session.go
@@ -734,6 +734,14 @@ type Session struct {
 	// refresh cannot flip it. Guarded by s.mu.
 	restoredTranscriptOpened bool
 
+	// restoredTranscriptWindowed and restoredTranscriptPrefixEntries carry
+	// the windowed-resume facts to RestoredTranscriptWindowed: whether a
+	// validated sidecar let restore decode only a suffix, and how many
+	// prefix entries that read skipped. A refresh from disk (which re-reads
+	// the whole file) resets windowed to false. Guarded by s.mu.
+	restoredTranscriptWindowed      bool
+	restoredTranscriptPrefixEntries int
+
 	// Cached tool definitions.
 	cachedToolDefs []llm.ToolDefinition
 
@@ -1656,6 +1664,12 @@ func (s *Session) attachedTranscript() *transcript.Writer {
 }
 
 func (s *Session) closeAttachedTranscript() error {
+	// No sidecar anchor here: shutdown cannot know where the last checkpoint
+	// sits without re-reading the transcript, and an end-of-file offset would
+	// skip live history on the next resume (the failure the restore tests
+	// caught in the first draft of this feature). The opportunistic
+	// post-full-scan anchor — written by the resume that just decoded the
+	// whole file — is what covers the shutdown case.
 	s.attentionMu.Lock()
 	defer s.attentionMu.Unlock()
 	return s.attachedTranscript().Close()
@@ -1805,10 +1819,19 @@ func (s *Session) TranscriptPath() string {
 // whether restore opened a transcript at all, independent of the entry
 // slice's emptiness.
 func (s *Session) setRestoredTranscript(header transcript.Header, entries []transcript.Entry, opened bool) {
+	s.setRestoredTranscriptWindowed(header, entries, opened, false, 0)
+}
+
+// setRestoredTranscriptWindowed is setRestoredTranscript with the windowed
+// facts: windowed reports a sidecar-validated suffix read, prefixEntryCount
+// the entries it skipped.
+func (s *Session) setRestoredTranscriptWindowed(header transcript.Header, entries []transcript.Entry, opened bool, windowed bool, prefixEntryCount int) {
 	s.mu.Lock()
 	s.restoredTranscriptHeader = header
 	s.restoredTranscript = entries
 	s.restoredTranscriptOpened = opened
+	s.restoredTranscriptWindowed = windowed
+	s.restoredTranscriptPrefixEntries = prefixEntryCount
 	s.mu.Unlock()
 }
 
@@ -1823,4 +1846,18 @@ func (s *Session) RestoredTranscript() (transcript.Header, []transcript.Entry, b
 	opened := s.restoredTranscriptOpened
 	s.mu.Unlock()
 	return header, entries, opened
+}
+
+// RestoredTranscriptWindowed reports whether the resume read was windowed
+// (a validated sidecar let restore decode only a suffix) and, when it was,
+// the prefix entry count below the entries RestoredTranscript returns.
+// ok mirrors RestoredTranscript's: true exactly when a transcript was
+// opened. A full-scan resume reports ok with windowed=false.
+func (s *Session) RestoredTranscriptWindowed() (windowed bool, prefixEntryCount int, ok bool) {
+	s.mu.Lock()
+	windowed = s.restoredTranscriptWindowed
+	prefixEntryCount = s.restoredTranscriptPrefixEntries
+	ok = s.restoredTranscriptOpened
+	s.mu.Unlock()
+	return windowed, prefixEntryCount, ok
 }

--- a/agent/session.go
+++ b/agent/session.go
@@ -741,6 +741,11 @@ type Session struct {
 	// the whole file) resets windowed to false. Guarded by s.mu.
 	restoredTranscriptWindowed      bool
 	restoredTranscriptPrefixEntries int
+	// restoredTranscriptPrefixTurns is the sidecar's count of turn positions
+	// the full AppWire projection holds below the windowed suffix (-1 when
+	// the anchor could not compute it): what serve needs to arm windowed turn
+	// paging. Guarded by s.mu.
+	restoredTranscriptPrefixTurns int
 
 	// Cached tool definitions.
 	cachedToolDefs []llm.ToolDefinition
@@ -1819,19 +1824,20 @@ func (s *Session) TranscriptPath() string {
 // whether restore opened a transcript at all, independent of the entry
 // slice's emptiness.
 func (s *Session) setRestoredTranscript(header transcript.Header, entries []transcript.Entry, opened bool) {
-	s.setRestoredTranscriptWindowed(header, entries, opened, false, 0)
+	s.setRestoredTranscriptWindowed(header, entries, opened, false, 0, -1)
 }
 
 // setRestoredTranscriptWindowed is setRestoredTranscript with the windowed
 // facts: windowed reports a sidecar-validated suffix read, prefixEntryCount
 // the entries it skipped.
-func (s *Session) setRestoredTranscriptWindowed(header transcript.Header, entries []transcript.Entry, opened bool, windowed bool, prefixEntryCount int) {
+func (s *Session) setRestoredTranscriptWindowed(header transcript.Header, entries []transcript.Entry, opened bool, windowed bool, prefixEntryCount, prefixTurnCount int) {
 	s.mu.Lock()
 	s.restoredTranscriptHeader = header
 	s.restoredTranscript = entries
 	s.restoredTranscriptOpened = opened
 	s.restoredTranscriptWindowed = windowed
 	s.restoredTranscriptPrefixEntries = prefixEntryCount
+	s.restoredTranscriptPrefixTurns = prefixTurnCount
 	s.mu.Unlock()
 }
 
@@ -1850,14 +1856,17 @@ func (s *Session) RestoredTranscript() (transcript.Header, []transcript.Entry, b
 
 // RestoredTranscriptWindowed reports whether the resume read was windowed
 // (a validated sidecar let restore decode only a suffix) and, when it was,
-// the prefix entry count below the entries RestoredTranscript returns.
+// the prefix entry count below the entries RestoredTranscript returns plus
+// the sidecar's count of turn positions the full AppWire projection holds
+// below them (-1 when the anchor could not compute it).
 // ok mirrors RestoredTranscript's: true exactly when a transcript was
 // opened. A full-scan resume reports ok with windowed=false.
-func (s *Session) RestoredTranscriptWindowed() (windowed bool, prefixEntryCount int, ok bool) {
+func (s *Session) RestoredTranscriptWindowed() (windowed bool, prefixEntryCount, prefixTurnCount int, ok bool) {
 	s.mu.Lock()
 	windowed = s.restoredTranscriptWindowed
 	prefixEntryCount = s.restoredTranscriptPrefixEntries
+	prefixTurnCount = s.restoredTranscriptPrefixTurns
 	ok = s.restoredTranscriptOpened
 	s.mu.Unlock()
-	return windowed, prefixEntryCount, ok
+	return windowed, prefixEntryCount, prefixTurnCount, ok
 }

--- a/agent/session_attention.go
+++ b/agent/session_attention.go
@@ -96,63 +96,7 @@ type delegateAttentionFold struct {
 }
 
 func foldDelegateAttention(entries []transcript.Entry) (delegateAttentionFold, error) {
-	fold := newDelegateAttentionFold()
-	for _, entry := range entries {
-		turn := entry.Turn
-		if err := foldDelegateDeliveryCommits(&fold, turn); err != nil {
-			return delegateAttentionFold{}, err
-		}
-		if turn.AttentionID != "" {
-			if turn.Kind != schema.TurnSteering || turn.AttentionResolution != nil {
-				return delegateAttentionFold{}, fmt.Errorf("attention %q is not a steering turn", turn.AttentionID)
-			}
-			if previous, exists := fold.content[turn.AttentionID]; exists {
-				if !reflect.DeepEqual(previous, turn.Message) {
-					return delegateAttentionFold{}, fmt.Errorf("attention %q has conflicting content", turn.AttentionID)
-				}
-			} else {
-				fold.content[turn.AttentionID] = turn.Message
-				fold.turns[turn.AttentionID] = turn
-				fold.order = append(fold.order, turn.AttentionID)
-			}
-		}
-		resolution := turn.AttentionResolution
-		if resolution == nil {
-			if turn.Kind == schema.TurnAttentionResolution {
-				return delegateAttentionFold{}, errors.New("attention resolution turn has no resolution")
-			}
-			continue
-		}
-		if turn.Kind != schema.TurnAttentionResolution || turn.AttentionID != "" || resolution.AttentionID == "" {
-			return delegateAttentionFold{}, errors.New("invalid attention resolution turn")
-		}
-		disposition := delegateAttentionResolution(resolution.Disposition)
-		if disposition != delegateAttentionConsumed && disposition != delegateAttentionDiscarded {
-			return delegateAttentionFold{}, fmt.Errorf("attention %q has invalid resolution %q", resolution.AttentionID, resolution.Disposition)
-		}
-		if disposition == delegateAttentionDiscarded && resolution.ResumeGeneration != 0 {
-			return delegateAttentionFold{}, fmt.Errorf("discarded attention %q has resume generation %d", resolution.AttentionID, resolution.ResumeGeneration)
-		}
-		if _, exists := fold.content[resolution.AttentionID]; !exists {
-			return delegateAttentionFold{}, fmt.Errorf("attention %q resolved before it was appended", resolution.AttentionID)
-		}
-		if previous, exists := fold.resolutions[resolution.AttentionID]; exists {
-			if previous != disposition || fold.resumeGenerations[resolution.AttentionID] != resolution.ResumeGeneration {
-				return delegateAttentionFold{}, fmt.Errorf("attention %q has conflicting resolutions", resolution.AttentionID)
-			}
-			continue
-		}
-		if resolution.ResumeGeneration != 0 {
-			for previousID, generation := range fold.resumeGenerations {
-				if generation == resolution.ResumeGeneration && previousID != resolution.AttentionID {
-					return delegateAttentionFold{}, fmt.Errorf("resume generation %d claims attention %q and %q", resolution.ResumeGeneration, previousID, resolution.AttentionID)
-				}
-			}
-		}
-		fold.resolutions[resolution.AttentionID] = disposition
-		fold.resumeGenerations[resolution.AttentionID] = resolution.ResumeGeneration
-	}
-	return fold, nil
+	return foldDelegateAttentionSuffix(newDelegateAttentionFold(), entries)
 }
 
 func foldDelegateDeliveryCommits(fold *delegateAttentionFold, turn schema.Turn) error {

--- a/agent/session_attention.go
+++ b/agent/session_attention.go
@@ -980,6 +980,47 @@ func (s *Session) foldDelegateAttentionEntries(entries []transcript.Entry) (dele
 	return foldDelegateAttention(entries)
 }
 
+// rearmRootDelegateAttentionSeeded is rearmRootDelegateAttentionFromTranscript
+// for a windowed resume: the suffix entries fold over the sidecar's prefix
+// snapshot, so an attention opened before the validated offset still rearms
+// the wake cache. The pre-seeded fold's per-entry rules are identical to the
+// file fold's; an unseedable snapshot falls back to the full file read.
+func (s *Session) rearmRootDelegateAttentionSeeded(view transcript.ResumeView) error {
+	if !s.isRootDelegateAttentionReceiver() {
+		return nil
+	}
+	fold, err := s.foldDelegateAttentionSeeded(view)
+	if err != nil {
+		// Incomplete snapshot: the full file read is the only state that
+		// can answer the rearm correctly.
+		return s.rearmRootDelegateAttentionFromTranscript(nil)
+	}
+	s.attentionMu.Lock()
+	s.rootAttentionWakeIDs = make(map[string]struct{}, len(fold.order))
+	for _, id := range fold.pendingIDs() {
+		s.rootAttentionWakeIDs[id] = struct{}{}
+	}
+	shouldWake := len(fold.order) != 0 && !s.rootAttentionWake
+	if shouldWake {
+		s.rootAttentionWake = true
+	}
+	s.attentionMu.Unlock()
+	if shouldWake {
+		s.notify()
+	}
+	return nil
+}
+
+// foldDelegateAttentionSeeded folds a windowed resume's suffix over its
+// sidecar snapshot, with the full-file-read fallback when the snapshot
+// cannot seed the fold.
+func (s *Session) foldDelegateAttentionSeeded(view transcript.ResumeView) (delegateAttentionFold, error) {
+	if foldEntries := s.cfg.testOnly.delegateAttentionFoldEntries; foldEntries != nil {
+		return foldEntries(view.Entries)
+	}
+	return foldDelegateAttentionSeeded(view.Sidecar, view.Entries)
+}
+
 func (s *Session) retainDelegateAttentionTurn(turn schema.Turn) error {
 	if turn.Kind != schema.TurnSteering || turn.AttentionID == "" {
 		return errors.New("durable delegate attention turn is invalid")

--- a/agent/session_attention_fuzz_test.go
+++ b/agent/session_attention_fuzz_test.go
@@ -281,16 +281,18 @@ func delegateAttentionFuzzEntries(program []byte) []transcript.Entry {
 		case 3:
 			turn = delegateAttentionResolutionTurn(attentionID, delegateAttentionDiscarded)
 		case 4:
-			turn = schema.NewTurn(schema.TurnToolResults, llm.ToolResultNamed(callID, "delegate_send", "done", false))
-			turn.DelegateDeliveryCommits = []schema.DelegateDeliveryCommit{{ToolCallID: callID, DeliveryID: deliveryID}}
+			// An invalid disposition: both folds must refuse it.
+			turn = delegateAttentionResolutionTurn(attentionID, "archived")
 		case 5:
-			turn = schema.NewTurn(schema.TurnToolResults, llm.ToolResultNamed(callID, "delegate_send", "done", false))
-			turn.DelegateDeliveryCommits = []schema.DelegateDeliveryCommit{{ToolCallID: callID + "-wrong", DeliveryID: deliveryID}}
+			// A resolution-kind turn with a nil pointer: both folds must
+			// refuse it ("attention resolution turn has no resolution").
+			turn = schema.NewTurn(schema.TurnAttentionResolution, llm.User(""))
 		case 6:
-			turn = schema.NewTurn(schema.TurnUserInput, llm.User("wrong-kind"))
+			turn = schema.NewTurn(schema.TurnToolResults, llm.ToolResultNamed(callID, "delegate_send", "done", false))
 			turn.DelegateDeliveryCommits = []schema.DelegateDeliveryCommit{{ToolCallID: callID, DeliveryID: deliveryID}}
 		case 7:
-			turn = schema.NewTurn(schema.TurnHookCompleted, llm.System("presentational"))
+			turn = schema.NewTurn(schema.TurnToolResults, llm.ToolResultNamed(callID, "delegate_send", "done", false))
+			turn.DelegateDeliveryCommits = []schema.DelegateDeliveryCommit{{ToolCallID: callID + "-wrong", DeliveryID: deliveryID}}
 		}
 		entries = append(entries, transcript.Entry{Seq: index, Turn: turn})
 	}

--- a/agent/session_attention_fuzz_test.go
+++ b/agent/session_attention_fuzz_test.go
@@ -83,7 +83,52 @@ func FuzzDelegateAttentionFold(f *testing.F) {
 		if !bytes.Equal(before, after) || beforeInfo.Size() != afterInfo.Size() || !beforeInfo.ModTime().Equal(afterInfo.ModTime()) {
 			t.Fatalf("cold fold mutated transcript: before=%d/%s after=%d/%s", beforeInfo.Size(), beforeInfo.ModTime(), afterInfo.Size(), afterInfo.ModTime())
 		}
+
+		// The sidecar snapshot's parity with the fold, over the SAME
+		// generated entries: the restatement in the transcript package cannot
+		// import this fold, so this differential is what bounds its drift.
+		// The snapshot's verdict is observable through the sidecar the
+		// refresh leaves behind — a refused fold writes none.
+		if len(entries) > 0 {
+			seedWriter, err := transcript.OpenWriter(path)
+			if err != nil {
+				t.Fatalf("OpenWriter for checkpoint: %v", err)
+			}
+			if err := seedWriter.AppendDurable(schema.NewTurn(schema.TurnCheckpoint, llm.User("compaction summary"))); err != nil {
+				_ = seedWriter.Close()
+				t.Fatalf("append checkpoint: %v", err)
+			}
+			if err := seedWriter.Close(); err != nil {
+				t.Fatalf("close checkpoint writer: %v", err)
+			}
+			if err := transcript.RefreshSidecarFromFullScan(path, sessionID); err != nil {
+				t.Fatalf("refresh: %v", err)
+			}
+			_, sidecarOK := transcript.ReadSidecar(path)
+			if sidecarOK != (wantErr == nil) {
+				t.Fatalf("snapshot verdict = %v, fold verdict = %v — the restatement and the fold disagree over the same entries", sidecarOK, wantErr == nil)
+			}
+			if sidecarOK {
+				// A written snapshot must seed a fold that agrees with the model.
+				seeded, err := foldDelegateAttentionSeeded(sidecarForFuzz(t, path), nil)
+				if err != nil {
+					t.Fatalf("seeded fold: %v", err)
+				}
+				assertDelegateAttentionFuzzFold(t, seeded, want)
+			}
+		}
 	})
+}
+
+// sidecarForFuzz reads the sidecar the refresh wrote, failing the test when
+// it is absent — the caller only invokes it after asserting sidecarOK.
+func sidecarForFuzz(t *testing.T, path string) transcript.ResumeSidecar {
+	t.Helper()
+	sidecar, ok := transcript.ReadSidecar(path)
+	if !ok {
+		t.Fatalf("sidecar missing after refresh over an accepted fold")
+	}
+	return sidecar
 }
 
 func FuzzStableDelegateWatchDelivery(f *testing.F) {

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -1116,7 +1116,7 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 	// over the sidecar's prefix snapshot; if the snapshot cannot seed the
 	// fold (incomplete, or the refresh above replaced it) the rearm falls
 	// back to its own full file read.
-	s.setRestoredTranscriptWindowed(restoredTranscriptHeader, transcriptEntries, restoredTranscriptOpened, resumeView.SidecarUsed, resumeView.PrefixEntryCount)
+	s.setRestoredTranscriptWindowed(restoredTranscriptHeader, transcriptEntries, restoredTranscriptOpened, resumeView.SidecarUsed, resumeView.PrefixEntryCount, resumeView.PrefixTurnCount)
 	if resumeView.SidecarUsed && resumeView.Entries != nil {
 		if err := s.rearmRootDelegateAttentionSeeded(resumeView); err != nil {
 			return nil, fmt.Errorf("rearm root delegate attention: %w", err)

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -1115,7 +1115,11 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 	// final entry list the file holds. A windowed resume folds the suffix
 	// over the sidecar's prefix snapshot; if the snapshot cannot seed the
 	// fold (incomplete, or the refresh above replaced it) the rearm falls
-	// back to its own full file read.
+	// back to its own full file read. The windowed facts are installed BEFORE
+	// the rearm because they describe the read that produced the entry list,
+	// not the rearm: the rearm's fallback re-reads the file only to rebuild
+	// the wake cache and deliberately does not rewrite them — the fallback
+	// is a rearm detail, not a new restored view.
 	s.setRestoredTranscriptWindowed(restoredTranscriptHeader, transcriptEntries, restoredTranscriptOpened, resumeView.SidecarUsed, resumeView.PrefixEntryCount, resumeView.PrefixTurnCount)
 	if resumeView.SidecarUsed && resumeView.Entries != nil {
 		if err := s.rearmRootDelegateAttentionSeeded(resumeView); err != nil {

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -687,6 +687,11 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 	// every other open or parse error fails the resume closed.
 	var resumeTranscript *transcript.Writer
 	var transcriptEntries []transcript.Entry
+	// resumeView carries what a windowed resume learned about the prefix it
+	// did not decode (entry count, fold snapshot, failure floor). It is the
+	// zero value whenever the full scan ran — which keeps every consumer
+	// below on one code path regardless of which read happened.
+	var resumeView transcript.ResumeView
 	var restoredTranscriptHeader transcript.Header
 	// ok flag for RestoredTranscript; captured at the open so the refresh
 	// below can't flip it.
@@ -694,10 +699,11 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 	if cfg.StateDir != "" {
 		tpath := filepath.Join(cfg.StateDir, sessionsSubdir, meta.ID+".transcript.jsonl")
 		var openErr error
-		resumeTranscript, transcriptEntries, openErr = transcript.OpenWriterForSession(tpath, meta.ID)
+		resumeTranscript, resumeView, openErr = transcript.OpenWriterForResume(tpath, meta.ID)
 		if openErr != nil && !errors.Is(openErr, os.ErrNotExist) {
 			return nil, fmt.Errorf("open transcript for resume: %w", openErr)
 		}
+		transcriptEntries = resumeView.Entries
 		if resumeTranscript != nil {
 			restoredTranscriptHeader = resumeTranscript.Header()
 		}
@@ -755,6 +761,20 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 				items.Failure = true
 			}
 			restoredClientMutationItems[entry.Turn.ClientMutationID] = items
+		}
+	}
+	// A windowed resume skipped the prefix entries; the sidecar's
+	// client-mutation map covers them, so a pending mutation whose turns
+	// predate the offset still reads as incorporated instead of being
+	// re-executed. The map's values are identity-only (no User/Failure
+	// items): the durable queue's own records carry the execution state, and
+	// the items flags only matter for mutations whose turns the suffix (and
+	// therefore the fold above) actually saw.
+	if resumeView.SidecarUsed && resumeView.Sidecar.SnapshotsComplete {
+		for mutationID, stableTurnID := range resumeView.Sidecar.ClientMutationTurns {
+			if _, inSuffix := restoredClientMutationTurns[mutationID]; !inSuffix {
+				restoredClientMutationTurns[mutationID] = stableTurnID
+			}
 		}
 	}
 
@@ -1013,11 +1033,25 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 		if tw != nil {
 			tw.SyncInterval = 1 * time.Second
 			// Seed the running failure count from the transcript this resume
-			// just read, bounded to the session's OWN span (a fork child's
+			// read, bounded to the session's OWN span (a fork child's
 			// inherited prefix carries the parent's failures). Without the seed
 			// the live figure would restart at zero every daemon restart and
 			// report a session-scale "clean" for a run that was not.
-			tw.TrackFailures(transcriptEntries, meta.DivergenceTurn)
+			if resumeView.SidecarUsed {
+				// Windowed read: the sidecar's floor carries the prefix
+				// failures the scan did not decode. An absent floor means
+				// the anchor could not vouch for it — re-derive from the
+				// full file rather than silently counting from zero.
+				if err := tw.TrackFailuresSeeded(transcriptEntries, resumeView.Sidecar.FailureFloor, resumeView.PrefixEntryCount, meta.DivergenceTurn); err != nil {
+					if refreshed, refreshErr := readTranscriptFull(transcriptPath(s.stateDir, s.id)); refreshErr == nil {
+						tw.TrackFailures(refreshed.Entries, meta.DivergenceTurn)
+					} else {
+						return nil, fmt.Errorf("seed failure count after windowed resume: %w", err)
+					}
+				}
+			} else {
+				tw.TrackFailures(transcriptEntries, meta.DivergenceTurn)
+			}
 		}
 	}
 	s.attachTranscript(tw)
@@ -1037,6 +1071,10 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 		}
 		transcriptEntries = refreshed.Entries
 		restoredTranscriptHeader = refreshed.Header
+		// The refresh re-reads the WHOLE file; the windowed prefix view is
+		// superseded (its snapshots described a prefix the full read has
+		// already folded into the fresh entry list).
+		resumeView = transcript.ResumeView{Entries: refreshed.Entries}
 		return nil
 	}
 	s.delegateDeliveryMu.Lock()
@@ -1074,9 +1112,16 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 	}
 	// setRestoredTranscript and the attention rearm both run after every
 	// restore-time transcript append, so serve and the fold see the same
-	// final entry list the file holds.
-	s.setRestoredTranscript(restoredTranscriptHeader, transcriptEntries, restoredTranscriptOpened)
-	if err := s.rearmRootDelegateAttentionFromTranscript(transcriptEntries); err != nil {
+	// final entry list the file holds. A windowed resume folds the suffix
+	// over the sidecar's prefix snapshot; if the snapshot cannot seed the
+	// fold (incomplete, or the refresh above replaced it) the rearm falls
+	// back to its own full file read.
+	s.setRestoredTranscriptWindowed(restoredTranscriptHeader, transcriptEntries, restoredTranscriptOpened, resumeView.SidecarUsed, resumeView.PrefixEntryCount)
+	if resumeView.SidecarUsed && resumeView.Entries != nil {
+		if err := s.rearmRootDelegateAttentionSeeded(resumeView); err != nil {
+			return nil, fmt.Errorf("rearm root delegate attention: %w", err)
+		}
+	} else if err := s.rearmRootDelegateAttentionFromTranscript(transcriptEntries); err != nil {
 		return nil, fmt.Errorf("rearm root delegate attention: %w", err)
 	}
 

--- a/agent/session_namer.go
+++ b/agent/session_namer.go
@@ -336,6 +336,14 @@ func isSessionNameCompactionTurn(turn schema.Turn) bool {
 func (s *Session) handleCompactionTurn(t schema.Turn) {
 	s.reportCompactionTranscriptAppend(s.writeTranscript(t))
 	if isSessionNameCompactionTurn(t) {
+		// Compaction anchor: the checkpoint just appended is the natural
+		// boundary — the next resume's live history starts at this entry, so
+		// a sidecar anchored here makes that resume O(suffix). The anchor is
+		// written AFTER the append so its offset covers the checkpoint; a
+		// failure is reported but never fails compaction.
+		if err := s.writeCompactionSidecarAnchor(); err != nil {
+			s.emit(events.EventWarning, events.WarningData{Message: fmt.Sprintf("resume sidecar anchor after compaction: %v", err)})
+		}
 		// A CHECKPOINT/SUMMARY turn replaces history: any ENVIRONMENT turns
 		// folded away with it are gone from what the model sees, so the
 		// environment-context tracker must forget what it last reported (see

--- a/agent/session_sidecar.go
+++ b/agent/session_sidecar.go
@@ -114,19 +114,21 @@ func foldDelegateAttentionSuffix(fold delegateAttentionFold, entries []transcrip
 
 // writeCompactionSidecarAnchor writes the resume sidecar from the session's
 // attached writer at the boundary the just-appended compaction turn defines.
-// It is one of the two anchors: compaction knows the exact byte offset where
-// live history now begins (the checkpoint entry it just appended), so its
-// sidecar windows the next resume to exactly ResumeHistory's window.
+// It is one of the two anchors: the writer recorded the byte offset where
+// the checkpoint entry it just appended BEGINS, so the sidecar windows the
+// next resume to exactly ResumeHistory's window — [checkpoint, ...rest],
+// the checkpoint entry included.
 //
-// The offset here is the CURRENT append position — the writer has just
-// appended the checkpoint and nothing else — so the suffix a windowed resume
-// decodes is [checkpoint, ...subsequent], matching ResumeHistory over the
-// same file.
+// The fold snapshots are NOT complete for this anchor and it says so: the
+// session's live attention state is process-local and cannot vouch for the
+// whole prefix the way a full decode can, and the prefix-turn count is not
+// computable without the prefix entries. A resume that needs either falls
+// back honestly (the rearm re-reads the file; serve's identity projection
+// takes the file form) rather than trusting a snapshot this anchor never
+// computed. The post-full-scan anchor is the one that computes them.
 //
 // Best-effort by contract: the error is reported to the caller, which must
-// not fail compaction on it. The caller must NOT hold attentionMu (the wake
-// count read below takes it; the lock order matches every other transcript
-// operation in the package).
+// not fail compaction on it.
 //
 // The clean-shutdown path deliberately writes NO anchor: shutdown cannot know
 // where the last checkpoint sits without re-reading the transcript, and a
@@ -135,9 +137,6 @@ func foldDelegateAttentionSuffix(fold delegateAttentionFold, entries []transcrip
 // the shutdown case instead — the resume itself just decoded the whole file
 // and knows the true boundary.
 func (s *Session) writeCompactionSidecarAnchor() error {
-	s.attentionMu.Lock()
-	wakeCount := len(s.rootAttentionWakeIDs)
-	s.attentionMu.Unlock()
 	s.mu.Lock()
 	writer := s.transcript
 	ready := s.transcriptReady
@@ -145,20 +144,5 @@ func (s *Session) writeCompactionSidecarAnchor() error {
 	if !ready || writer == nil {
 		return nil
 	}
-	pending, commits, mutations, complete := liveDelegateAttentionSnapshot(wakeCount)
-	return writer.WriteSidecarFromWriter(s.TranscriptPath(), pending, commits, mutations, complete)
-}
-
-// liveDelegateAttentionSnapshot derives the fold-snapshot completeness from
-// the session's live wake count. The wake cache holds pending IDs but not
-// content, so the snapshot is complete only when the session holds no live
-// attention state at all (the common case): an empty live state is
-// trivially complete, and any live attention forces the conservative
-// incomplete marker — the resume that needs the fold then falls back to its
-// own full read.
-func liveDelegateAttentionSnapshot(wakeCount int) (pending []transcript.SidecarPendingAttention, commits []transcript.SidecarDeliveryCommit, mutations map[string]string, complete bool) {
-	if wakeCount != 0 {
-		return nil, nil, nil, false
-	}
-	return nil, nil, nil, true
+	return writer.WriteSidecarFromWriter(s.TranscriptPath(), nil, nil, nil, false)
 }

--- a/agent/session_sidecar.go
+++ b/agent/session_sidecar.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -49,8 +50,9 @@ func foldDelegateAttentionSeeded(sidecar transcript.ResumeSidecar, suffix []tran
 }
 
 // foldDelegateAttentionSuffix folds suffix entries onto an existing fold
-// state. It shares foldDelegateAttention's per-entry rules by construction:
-// the loop body is the same sequence, applied to the pre-seeded state.
+// state. It is the general per-entry fold: foldDelegateAttention is this
+// function over a fresh fold, and the seeded form is this function over the
+// sidecar's pre-seeded state — one set of rules, three entry points.
 func foldDelegateAttentionSuffix(fold delegateAttentionFold, entries []transcript.Entry) (delegateAttentionFold, error) {
 	for _, entry := range entries {
 		turn := entry.Turn
@@ -62,7 +64,7 @@ func foldDelegateAttentionSuffix(fold delegateAttentionFold, entries []transcrip
 				return delegateAttentionFold{}, fmt.Errorf("attention %q is not a steering turn", turn.AttentionID)
 			}
 			if previous, exists := fold.content[turn.AttentionID]; exists {
-				if !deepEqualMessages(previous, turn.Message) {
+				if !reflect.DeepEqual(previous, turn.Message) {
 					return delegateAttentionFold{}, fmt.Errorf("attention %q has conflicting content", turn.AttentionID)
 				}
 			} else {
@@ -74,12 +76,12 @@ func foldDelegateAttentionSuffix(fold delegateAttentionFold, entries []transcrip
 		resolution := turn.AttentionResolution
 		if resolution == nil {
 			if turn.Kind == schema.TurnAttentionResolution {
-				return delegateAttentionFold{}, fmt.Errorf("attention resolution turn has no resolution")
+				return delegateAttentionFold{}, errors.New("attention resolution turn has no resolution")
 			}
 			continue
 		}
 		if turn.Kind != schema.TurnAttentionResolution || turn.AttentionID != "" || resolution.AttentionID == "" {
-			return delegateAttentionFold{}, fmt.Errorf("invalid attention resolution turn")
+			return delegateAttentionFold{}, errors.New("invalid attention resolution turn")
 		}
 		disposition := delegateAttentionResolution(resolution.Disposition)
 		if disposition != delegateAttentionConsumed && disposition != delegateAttentionDiscarded {
@@ -108,12 +110,6 @@ func foldDelegateAttentionSuffix(fold delegateAttentionFold, entries []transcrip
 		fold.resumeGenerations[resolution.AttentionID] = resolution.ResumeGeneration
 	}
 	return fold, nil
-}
-
-// deepEqualMessages is reflect.DeepEqual specialized to the fold's one use,
-// kept so the seeded fold and the file fold compare identically.
-func deepEqualMessages(a, b llm.Message) bool {
-	return reflect.DeepEqual(a, b)
 }
 
 // writeCompactionSidecarAnchor writes the resume sidecar from the session's

--- a/agent/session_sidecar.go
+++ b/agent/session_sidecar.go
@@ -1,0 +1,168 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/llm"
+)
+
+// foldDelegateAttentionSeeded folds a resume's suffix entries over the
+// prefix snapshot a validated sidecar carried. It reconstructs exactly the
+// state foldDelegateAttention would have produced over the full entry list:
+// the seed installs each pending attention's content and resolution before
+// the suffix entries fold over them, so an attention opened before the
+// boundary and resolved after it resolves correctly instead of tripping the
+// fold's "resolved before appended" guard.
+func foldDelegateAttentionSeeded(sidecar transcript.ResumeSidecar, suffix []transcript.Entry) (delegateAttentionFold, error) {
+	if !sidecar.SnapshotsComplete {
+		// An incomplete snapshot cannot seed the fold; the caller must fall
+		// back to the full file read.
+		return delegateAttentionFold{}, fmt.Errorf("resume sidecar fold snapshot is incomplete")
+	}
+	fold := newDelegateAttentionFold()
+	for _, pending := range sidecar.PendingAttention {
+		var message llm.Message
+		if err := json.Unmarshal(pending.Message, &message); err != nil {
+			return delegateAttentionFold{}, fmt.Errorf("sidecar attention %q message: %w", pending.AttentionID, err)
+		}
+		if message.Role == "" {
+			return delegateAttentionFold{}, fmt.Errorf("sidecar attention %q message is empty", pending.AttentionID)
+		}
+		fold.content[pending.AttentionID] = message
+		turn := schema.NewTurn(schema.TurnSteering, message)
+		turn.AttentionID = pending.AttentionID
+		fold.turns[pending.AttentionID] = turn
+		fold.order = append(fold.order, pending.AttentionID)
+		if resolution := pending.Resolution; resolution != "" {
+			fold.resolutions[pending.AttentionID] = delegateAttentionResolution(resolution)
+			fold.resumeGenerations[pending.AttentionID] = pending.ResumeGeneration
+		}
+	}
+	for _, commit := range sidecar.DeliveryCommits {
+		fold.deliveryCommits[commit.DeliveryID] = commit.ToolCallID
+	}
+	return foldDelegateAttentionSuffix(fold, suffix)
+}
+
+// foldDelegateAttentionSuffix folds suffix entries onto an existing fold
+// state. It shares foldDelegateAttention's per-entry rules by construction:
+// the loop body is the same sequence, applied to the pre-seeded state.
+func foldDelegateAttentionSuffix(fold delegateAttentionFold, entries []transcript.Entry) (delegateAttentionFold, error) {
+	for _, entry := range entries {
+		turn := entry.Turn
+		if err := foldDelegateDeliveryCommits(&fold, turn); err != nil {
+			return delegateAttentionFold{}, err
+		}
+		if turn.AttentionID != "" {
+			if turn.Kind != schema.TurnSteering || turn.AttentionResolution != nil {
+				return delegateAttentionFold{}, fmt.Errorf("attention %q is not a steering turn", turn.AttentionID)
+			}
+			if previous, exists := fold.content[turn.AttentionID]; exists {
+				if !deepEqualMessages(previous, turn.Message) {
+					return delegateAttentionFold{}, fmt.Errorf("attention %q has conflicting content", turn.AttentionID)
+				}
+			} else {
+				fold.content[turn.AttentionID] = turn.Message
+				fold.turns[turn.AttentionID] = turn
+				fold.order = append(fold.order, turn.AttentionID)
+			}
+		}
+		resolution := turn.AttentionResolution
+		if resolution == nil {
+			if turn.Kind == schema.TurnAttentionResolution {
+				return delegateAttentionFold{}, fmt.Errorf("attention resolution turn has no resolution")
+			}
+			continue
+		}
+		if turn.Kind != schema.TurnAttentionResolution || turn.AttentionID != "" || resolution.AttentionID == "" {
+			return delegateAttentionFold{}, fmt.Errorf("invalid attention resolution turn")
+		}
+		disposition := delegateAttentionResolution(resolution.Disposition)
+		if disposition != delegateAttentionConsumed && disposition != delegateAttentionDiscarded {
+			return delegateAttentionFold{}, fmt.Errorf("attention %q has invalid resolution %q", resolution.AttentionID, resolution.Disposition)
+		}
+		if disposition == delegateAttentionDiscarded && resolution.ResumeGeneration != 0 {
+			return delegateAttentionFold{}, fmt.Errorf("discarded attention %q has resume generation %d", resolution.AttentionID, resolution.ResumeGeneration)
+		}
+		if _, exists := fold.content[resolution.AttentionID]; !exists {
+			return delegateAttentionFold{}, fmt.Errorf("attention %q resolved before it was appended", resolution.AttentionID)
+		}
+		if previous, exists := fold.resolutions[resolution.AttentionID]; exists {
+			if previous != disposition || fold.resumeGenerations[resolution.AttentionID] != resolution.ResumeGeneration {
+				return delegateAttentionFold{}, fmt.Errorf("attention %q has conflicting resolutions", resolution.AttentionID)
+			}
+			continue
+		}
+		if resolution.ResumeGeneration != 0 {
+			for previousID, generation := range fold.resumeGenerations {
+				if generation == resolution.ResumeGeneration && previousID != resolution.AttentionID {
+					return delegateAttentionFold{}, fmt.Errorf("resume generation %d claims attention %q and %q", resolution.ResumeGeneration, previousID, resolution.AttentionID)
+				}
+			}
+		}
+		fold.resolutions[resolution.AttentionID] = disposition
+		fold.resumeGenerations[resolution.AttentionID] = resolution.ResumeGeneration
+	}
+	return fold, nil
+}
+
+// deepEqualMessages is reflect.DeepEqual specialized to the fold's one use,
+// kept so the seeded fold and the file fold compare identically.
+func deepEqualMessages(a, b llm.Message) bool {
+	return reflect.DeepEqual(a, b)
+}
+
+// writeCompactionSidecarAnchor writes the resume sidecar from the session's
+// attached writer at the boundary the just-appended compaction turn defines.
+// It is one of the two anchors: compaction knows the exact byte offset where
+// live history now begins (the checkpoint entry it just appended), so its
+// sidecar windows the next resume to exactly ResumeHistory's window.
+//
+// The offset here is the CURRENT append position — the writer has just
+// appended the checkpoint and nothing else — so the suffix a windowed resume
+// decodes is [checkpoint, ...subsequent], matching ResumeHistory over the
+// same file.
+//
+// Best-effort by contract: the error is reported to the caller, which must
+// not fail compaction on it. The caller must NOT hold attentionMu (the wake
+// count read below takes it; the lock order matches every other transcript
+// operation in the package).
+//
+// The clean-shutdown path deliberately writes NO anchor: shutdown cannot know
+// where the last checkpoint sits without re-reading the transcript, and a
+// wrong offset would skip live history (the exact failure the restore tests
+// caught in the first draft). The opportunistic post-full-scan anchor covers
+// the shutdown case instead — the resume itself just decoded the whole file
+// and knows the true boundary.
+func (s *Session) writeCompactionSidecarAnchor() error {
+	s.attentionMu.Lock()
+	wakeCount := len(s.rootAttentionWakeIDs)
+	s.attentionMu.Unlock()
+	s.mu.Lock()
+	writer := s.transcript
+	ready := s.transcriptReady
+	s.mu.Unlock()
+	if !ready || writer == nil {
+		return nil
+	}
+	pending, commits, mutations, complete := liveDelegateAttentionSnapshot(wakeCount)
+	return writer.WriteSidecarFromWriter(s.TranscriptPath(), pending, commits, mutations, complete)
+}
+
+// liveDelegateAttentionSnapshot derives the fold-snapshot completeness from
+// the session's live wake count. The wake cache holds pending IDs but not
+// content, so the snapshot is complete only when the session holds no live
+// attention state at all (the common case): an empty live state is
+// trivially complete, and any live attention forces the conservative
+// incomplete marker — the resume that needs the fold then falls back to its
+// own full read.
+func liveDelegateAttentionSnapshot(wakeCount int) (pending []transcript.SidecarPendingAttention, commits []transcript.SidecarDeliveryCommit, mutations map[string]string, complete bool) {
+	if wakeCount != 0 {
+		return nil, nil, nil, false
+	}
+	return nil, nil, nil, true
+}

--- a/agent/session_sidecar_test.go
+++ b/agent/session_sidecar_test.go
@@ -239,6 +239,123 @@ func TestForkChildResumeFallsBackToFullScanWithoutSidecar(t *testing.T) {
 	}
 }
 
+// TestFullScanSnapshotDedupesReSentAttentionAndCarriesResolutions pins the
+// opportunistic anchor's fold snapshot over the two attention shapes the
+// reviewer's probe showed it mishandling: a steering turn re-sent with
+// identical content (a legal transcript the file fold tolerates) must appear
+// ONCE, and an attention resolved before the boundary must carry its
+// resolution — so the seeded fold reports it resolved exactly as the file
+// fold over the same file does, instead of resurrecting it as pending.
+func TestFullScanSnapshotDedupesReSentAttentionAndCarriesResolutions(t *testing.T) {
+	const sessionID = "sidecar_dedupe"
+	dir := t.TempDir()
+	path := filepath.Join(dir, sessionID+".transcript.jsonl")
+	w, err := transcript.NewWriter(path, transcript.Header{SessionID: sessionID})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	steering := func(id string) schema.Turn {
+		turn := schema.NewTurn(schema.TurnSteering, llm.User("steer "+id))
+		turn.AttentionID = id
+		return turn
+	}
+	// att_dup: opened, then RE-SENT with identical content — one row.
+	if err := w.Append(steering("att_dup")); err != nil {
+		t.Fatalf("append att_dup: %v", err)
+	}
+	if err := w.Append(steering("att_dup")); err != nil {
+		t.Fatalf("append att_dup again: %v", err)
+	}
+	// att_resolved: opened and resolved BEFORE the boundary.
+	if err := w.Append(steering("att_resolved")); err != nil {
+		t.Fatalf("append att_resolved: %v", err)
+	}
+	resolution := schema.NewTurn(schema.TurnAttentionResolution, llm.User(""))
+	resolution.AttentionResolution = &schema.AttentionResolutionInfo{
+		AttentionID: "att_resolved",
+		Disposition: "consumed",
+	}
+	if err := w.Append(resolution); err != nil {
+		t.Fatalf("append resolution: %v", err)
+	}
+	// att_pending: opened, never resolved — pending.
+	if err := w.Append(steering("att_pending")); err != nil {
+		t.Fatalf("append att_pending: %v", err)
+	}
+	// The checkpoint anchors the sidecar's offset after all of the above.
+	if err := w.Append(schema.NewTurn(schema.TurnCheckpoint, llm.User("compaction summary"))); err != nil {
+		t.Fatalf("append checkpoint: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	// Full-scan resume writes the opportunistic sidecar; read the snapshot
+	// back the way the next, windowed resume will.
+	first, _, err := transcript.OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("full-scan resume: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first: %v", err)
+	}
+	sidecar, ok := transcript.ReadSidecar(path)
+	if !ok {
+		t.Fatalf("sidecar missing after full-scan resume")
+	}
+	if !sidecar.SnapshotsComplete {
+		t.Fatalf("full-scan sidecar must claim complete snapshots")
+	}
+	rows := map[string]transcript.SidecarPendingAttention{}
+	for _, row := range sidecar.PendingAttention {
+		rows[row.AttentionID] = row
+	}
+	if want := []string{"att_dup", "att_resolved", "att_pending"}; len(sidecar.PendingAttention) != len(want) {
+		t.Fatalf("snapshot rows: got %d (%v), want %d — a re-sent attention must not add a row", len(sidecar.PendingAttention), sidecar.PendingAttention, len(want))
+	}
+	for _, id := range []string{"att_dup", "att_resolved", "att_pending"} {
+		if _, present := rows[id]; !present {
+			t.Fatalf("snapshot is missing attention %q: %+v", id, sidecar.PendingAttention)
+		}
+	}
+	if rows["att_resolved"].Resolution != "consumed" {
+		t.Fatalf("prefix-resolved attention lost its resolution: %+v", rows["att_resolved"])
+	}
+	if rows["att_pending"].Resolution != "" {
+		t.Fatalf("pending attention gained a resolution: %+v", rows["att_pending"])
+	}
+
+	// The whole point: the seeded fold over this snapshot must agree with
+	// the file fold over the same file — same pending set, same resolutions.
+	_, view, err := transcript.OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("windowed resume: %v", err)
+	}
+	if !view.SidecarUsed {
+		t.Fatalf("second resume fell back to full scan — the snapshot the anchor wrote must validate")
+	}
+	seeded, err := foldDelegateAttentionSeeded(view.Sidecar, view.Entries)
+	if err != nil {
+		t.Fatalf("seeded fold: %v", err)
+	}
+	file, err := readDelegateAttentionFold(path, sessionID)
+	if err != nil {
+		t.Fatalf("file fold: %v", err)
+	}
+	seededPending, filePending := seeded.pendingIDs(), file.pendingIDs()
+	if len(seededPending) != 2 || seededPending[0] != "att_dup" || seededPending[1] != "att_pending" {
+		t.Fatalf("seeded fold pending: %v, want [att_dup att_pending] — the re-sent and pending attentions, not the resolved one", seededPending)
+	}
+	if len(filePending) != 2 || filePending[0] != "att_dup" || filePending[1] != "att_pending" {
+		t.Fatalf("file fold pending: %v, want [att_dup att_pending]", filePending)
+	}
+	if disposition, resolved := seeded.resolutions["att_resolved"]; !resolved || disposition != delegateAttentionConsumed {
+		t.Fatalf("seeded fold resolutions[att_resolved]: %v %v, want consumed true", disposition, resolved)
+	}
+	if len(seeded.order) != len(file.order) {
+		t.Fatalf("fold order lengths: seeded=%d file=%d — the re-sent attention must not duplicate an order entry", len(seeded.order), len(file.order))
+	}
+}
+
 // TestRestoreSessionAcceptsCorruptPrefixLineWithSidecarAndFullReaderStillFails
 // pins the deliberate wf7e posture change: the windowed reader ACCEPTS a
 // prefix it did not decode (that is its purpose — the sidecar's anchors

--- a/agent/session_sidecar_test.go
+++ b/agent/session_sidecar_test.go
@@ -1,0 +1,340 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/llm"
+)
+
+// seedSidecarSession writes a transcript with n entries, resumes it once
+// (full scan — writes the opportunistic sidecar), and returns the path.
+func seedSidecarSession(t *testing.T, sessionID string, n int) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, sessionID+".transcript.jsonl")
+	w, err := transcript.NewWriter(path, transcript.Header{SessionID: sessionID})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	for i := 0; i < n; i++ {
+		if err := w.Append(schema.NewTurn(schema.TurnUserInput, llm.User("turn"))); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+	// The checkpoint entry is what the opportunistic anchor keys its offset
+	// AT (ResumeHistory's window), so the fixture needs one.
+	if err := w.Append(schema.NewTurn(schema.TurnCheckpoint, llm.User("compaction summary"))); err != nil {
+		t.Fatalf("append checkpoint: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	first, _, err := transcript.OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("first resume: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first: %v", err)
+	}
+	return path
+}
+
+// TestTrackFailuresSeedWithSidecarIncludesPreCheckpointFailures: the failure
+// floor carried by the sidecar must survive a windowed resume — a session
+// with failures before the anchor reports them after resume, not a false
+// clean.
+func TestTrackFailuresSeedWithSidecarIncludesPreCheckpointFailures(t *testing.T) {
+	const sessionID = "sidecar_failures"
+	dir := t.TempDir()
+	path := filepath.Join(dir, sessionID+".transcript.jsonl")
+	w, err := transcript.NewWriter(path, transcript.Header{SessionID: sessionID})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	// A failing tool result: error=true counts via FailedToolResult.
+	failed := schema.NewTurn(schema.TurnToolResults, llm.User("results"))
+	failed.Message.Content = []llm.ContentPart{{
+		Kind: llm.ContentToolResult,
+		ToolResult: &llm.ToolResultData{
+			ToolCallID: "call_1",
+			Name:       "shell",
+			IsError:    true,
+		},
+	}}
+	if err := w.Append(failed); err != nil {
+		t.Fatalf("append failed turn: %v", err)
+	}
+	if err := w.Append(schema.NewTurn(schema.TurnUserInput, llm.User("ok"))); err != nil {
+		t.Fatalf("append ok turn: %v", err)
+	}
+	// The checkpoint entry anchors the sidecar's offset; the failing turn
+	// lives in the PREFIX (before it), which is what the floor must carry.
+	if err := w.Append(schema.NewTurn(schema.TurnCheckpoint, llm.User("compaction summary"))); err != nil {
+		t.Fatalf("append checkpoint: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	// Full-scan resume writes the opportunistic sidecar with the floor. The
+	// full-scan view itself does not carry the sidecar (it IS the full
+	// scan); read it back the way the next, windowed resume will.
+	first, _, err := transcript.OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("first resume: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first: %v", err)
+	}
+	written, ok := transcript.ReadSidecar(path)
+	if !ok {
+		t.Fatalf("sidecar missing after full-scan resume")
+	}
+	if written.FailureFloor != 1 {
+		t.Fatalf("opportunistic sidecar failure floor: got %d, want 1", written.FailureFloor)
+	}
+	// Windowed resume: the floor must come through.
+	second, view, err := transcript.OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("second resume: %v", err)
+	}
+	defer second.Close() //nolint:errcheck
+	if !view.SidecarUsed {
+		t.Fatalf("second resume fell back to full scan")
+	}
+	if err := second.TrackFailuresSeeded(view.Entries, view.Sidecar.FailureFloor, view.PrefixEntryCount, 0); err != nil {
+		t.Fatalf("seeded track failures: %v", err)
+	}
+	count, counted := second.FailedToolCalls()
+	if !counted || count != 1 {
+		t.Fatalf("windowed failure count: got (%d, %v), want (1, true)", count, counted)
+	}
+}
+
+// TestPendingDelegateAttentionOpenedBeforeBoundarySurvivesResume: an
+// attention opened before the sidecar's offset and still pending must
+// survive a windowed resume's fold — the seeded fold reconstructs it from
+// the snapshot instead of dropping it.
+func TestPendingDelegateAttentionOpenedBeforeBoundarySurvivesResume(t *testing.T) {
+	const sessionID = "sidecar_attention"
+	path := seedSidecarSession(t, sessionID, 3)
+
+	// Build a fold snapshot as the opportunistic anchor would: a pending
+	// attention with content.
+	sidecar, ok := transcript.ReadSidecar(path)
+	if !ok {
+		t.Fatalf("sidecar missing after full-scan resume")
+	}
+	encoded := []byte(`{"role":"user","content":[{"kind":"text","text":"pending attention content"}]}`)
+	sidecar.PendingAttention = []transcript.SidecarPendingAttention{
+		{AttentionID: "att_pending", Message: transcript.JSONMessage(encoded)},
+	}
+	sidecar.SnapshotsComplete = true
+	if err := transcript.WriteSidecar(path, sidecar); err != nil {
+		t.Fatalf("rewrite sidecar: %v", err)
+	}
+
+	_, view, err := transcript.OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("windowed resume: %v", err)
+	}
+	if !view.SidecarUsed {
+		t.Fatalf("resume did not use sidecar")
+	}
+	fold, err := foldDelegateAttentionSeeded(view.Sidecar, view.Entries)
+	if err != nil {
+		t.Fatalf("seeded fold: %v", err)
+	}
+	pending := fold.pendingIDs()
+	if len(pending) != 1 || pending[0] != "att_pending" {
+		t.Fatalf("pending attention after windowed resume: %v, want [att_pending]", pending)
+	}
+}
+
+// TestDelegateAttentionFoldResolutionAfterBoundaryDoesNotError: an
+// attention opened pre-boundary and RESOLVED in the suffix must fold
+// cleanly — the seed's content is what lets the resolution resolve instead
+// of tripping "resolved before it was appended".
+func TestDelegateAttentionFoldResolutionAfterBoundaryDoesNotError(t *testing.T) {
+	const sessionID = "sidecar_straddle"
+	path := seedSidecarSession(t, sessionID, 2)
+
+	sidecar, ok := transcript.ReadSidecar(path)
+	if !ok {
+		t.Fatalf("sidecar missing")
+	}
+	encoded := []byte(`{"role":"user","content":[{"kind":"text","text":"straddling attention"}]}`)
+	sidecar.PendingAttention = []transcript.SidecarPendingAttention{
+		{AttentionID: "att_straddle", Message: transcript.JSONMessage(encoded)},
+	}
+	sidecar.SnapshotsComplete = true
+	if err := transcript.WriteSidecar(path, sidecar); err != nil {
+		t.Fatalf("rewrite sidecar: %v", err)
+	}
+
+	// Append a resolution turn AFTER the boundary.
+	w, err := transcript.OpenWriter(path)
+	if err != nil {
+		t.Fatalf("open writer: %v", err)
+	}
+	resolution := schema.NewTurn(schema.TurnAttentionResolution, llm.User(""))
+	resolution.AttentionResolution = &schema.AttentionResolutionInfo{
+		AttentionID: "att_straddle",
+		Disposition: "consumed",
+	}
+	if err := w.Append(resolution); err != nil {
+		t.Fatalf("append resolution: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	_, view, err := transcript.OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("windowed resume: %v", err)
+	}
+	if !view.SidecarUsed {
+		t.Fatalf("resume did not use sidecar")
+	}
+	if len(view.Entries) != 2 {
+		t.Fatalf("suffix entries: got %d, want 2 (the checkpoint the sidecar anchors at, plus the resolution)", len(view.Entries))
+	}
+	fold, err := foldDelegateAttentionSeeded(view.Sidecar, view.Entries)
+	if err != nil {
+		t.Fatalf("seeded fold tripped on a boundary-straddling resolution: %v", err)
+	}
+	if disposition, resolved := fold.resolutions["att_straddle"]; !resolved || disposition != delegateAttentionConsumed {
+		t.Fatalf("resolution after fold: %v %v, want consumed true", disposition, resolved)
+	}
+}
+
+// TestForkChildResumeFallsBackToFullScanWithoutSidecar: a fork child's file
+// (replayed prefix, fresh incarnation) must not validate the parent's
+// sidecar — and its own first resume has no sidecar at all.
+func TestForkChildResumeFallsBackToFullScanWithoutSidecar(t *testing.T) {
+	const sessionID = "sidecar_forkchild"
+	path := seedSidecarSession(t, sessionID, 4)
+	// The fork child gets a COPY of the file — same bytes, new incarnation.
+	child := path + ".fork"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read parent: %v", err)
+	}
+	if err := os.WriteFile(child, data, 0o644); err != nil {
+		t.Fatalf("write child: %v", err)
+	}
+	w, view, err := transcript.OpenWriterForResume(child, sessionID)
+	if err != nil {
+		t.Fatalf("child resume: %v", err)
+	}
+	defer w.Close() //nolint:errcheck
+	if view.SidecarUsed {
+		t.Fatalf("fork child used a sidecar")
+	}
+	if len(view.Entries) != 5 {
+		t.Fatalf("child entries: got %d, want 5 (4 user turns + the checkpoint)", len(view.Entries))
+	}
+}
+
+// TestRestoreSessionAcceptsCorruptPrefixLineWithSidecarAndFullReaderStillFails
+// pins the deliberate wf7e posture change: the windowed reader ACCEPTS a
+// prefix it did not decode (that is its purpose — the sidecar's anchors
+// vouch for those bytes), while the FULL reader (readTranscriptFull) still
+// fails the whole file on a corrupt line anywhere. Both behaviors are
+// decisions: the comment at agent/transcript/transcript.go decodeStrictJSON
+// documents the one-way door; this test pins that the windowed path does
+// not widen the full reader's strictness and the full reader's failure is
+// what a windowed resume with a BAD sidecar falls back to.
+func TestRestoreSessionAcceptsCorruptPrefixLineWithSidecarAndFullReaderStillFails(t *testing.T) {
+	const sessionID = "sidecar_wf7e"
+	dir := t.TempDir()
+	path := filepath.Join(dir, sessionID+".transcript.jsonl")
+	w, err := transcript.NewWriter(path, transcript.Header{SessionID: sessionID})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if err := w.Append(schema.NewTurn(schema.TurnUserInput, llm.User("turn"))); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	// First resume writes the opportunistic sidecar.
+	first, _, err := transcript.OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("first resume: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first: %v", err)
+	}
+	// Corrupt a PREFIX line: not the first (header), and inside the
+	// sidecar's prefix. The sidecar's anchors were computed BEFORE the
+	// corruption — so anchor validation must REJECT the mutated prefix and
+	// fall back to the full scan, which then fails on the corrupt line.
+	// That is the intended composition: the sidecar never vouches for bytes
+	// it did not stamp.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	lines := splitTranscriptLines(data)
+	if len(lines) < 4 {
+		t.Fatalf("fixture too small: %d lines", len(lines))
+	}
+	lines[1] = []byte(`{"kind":"entry","seq":1,"turn":{"kind":"user_input","message":{"role":"user","content":[{"type":"text","text":"ok"}]},"unknown_field":true}}`)
+	corrupt := joinTranscriptLines(lines)
+	if err := os.WriteFile(path, corrupt, 0o644); err != nil {
+		t.Fatalf("write corrupt: %v", err)
+	}
+	w2, view, err := transcript.OpenWriterForResume(path, sessionID)
+	if err != nil {
+		// A full-scan failure on the corrupt line is the correct outcome:
+		// the sidecar's anchors reject the mutated prefix, the fallback
+		// full scan hits the unknown field, and wf7e's posture says the
+		// whole file fails. This branch PINS that the failure is the
+		// full reader's, not a windowed acceptance.
+		if w2 != nil {
+			t.Fatalf("writer returned alongside error")
+		}
+		if view.SidecarUsed {
+			t.Fatalf("windowed read accepted a mutated prefix")
+		}
+		return
+	}
+	defer w2.Close() //nolint:errcheck
+	if view.SidecarUsed {
+		t.Fatalf("windowed read accepted a mutated prefix")
+	}
+	// If the corrupt line still parses (a field the schema knows), the
+	// full scan simply ran — also correct. The invariant is only that the
+	// sidecar was not used over mutated prefix bytes.
+}
+
+func splitTranscriptLines(data []byte) [][]byte {
+	var lines [][]byte
+	start := 0
+	for i, b := range data {
+		if b == '\n' {
+			lines = append(lines, data[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(data) {
+		lines = append(lines, data[start:])
+	}
+	return lines
+}
+
+func joinTranscriptLines(lines [][]byte) []byte {
+	var out []byte
+	for _, line := range lines {
+		out = append(out, line...)
+		out = append(out, '\n')
+	}
+	return out
+}

--- a/agent/session_sidecar_test.go
+++ b/agent/session_sidecar_test.go
@@ -239,6 +239,126 @@ func TestForkChildResumeFallsBackToFullScanWithoutSidecar(t *testing.T) {
 	}
 }
 
+// TestFoldSnapshotRefusalsMatchTheFileFold pins the parity contract the
+// snapshot's doc states: every entry shape the agent's file fold rejects
+// must also be refused by the transcript package's restatement, and every
+// shape the fold accepts must produce a snapshot. The snapshot cannot
+// import the fold (agent imports transcript), so this differential — the
+// same turns fed to both, accept/reject agreement asserted — is what keeps
+// the restatement from drifting.
+func TestFoldSnapshotRefusalsMatchTheFileFold(t *testing.T) {
+	steering := func(id, text string) schema.Turn {
+		turn := schema.NewTurn(schema.TurnSteering, llm.User(text))
+		turn.AttentionID = id
+		return turn
+	}
+	resolution := func(id, disposition string, generation uint64) schema.Turn {
+		turn := schema.NewTurn(schema.TurnAttentionResolution, llm.User(""))
+		turn.AttentionResolution = &schema.AttentionResolutionInfo{
+			AttentionID:      id,
+			Disposition:      disposition,
+			ResumeGeneration: generation,
+		}
+		return turn
+	}
+	toolResults := func(callID string, commits ...schema.DelegateDeliveryCommit) schema.Turn {
+		turn := schema.NewTurn(schema.TurnToolResults, llm.User("results"))
+		turn.Message.Content = []llm.ContentPart{{
+			Kind:       llm.ContentToolResult,
+			ToolResult: &llm.ToolResultData{ToolCallID: callID, Name: "shell"},
+		}}
+		turn.DelegateDeliveryCommits = commits
+		return turn
+	}
+	cases := []struct {
+		name     string
+		turns    []schema.Turn
+		accepted bool
+	}{
+		{"plain steering accepted", []schema.Turn{steering("a1", "one")}, true},
+		{"re-sent identical steering accepted", []schema.Turn{steering("a1", "one"), steering("a1", "one")}, true},
+		{"re-sent conflicting content refused", []schema.Turn{steering("a1", "one"), steering("a1", "two")}, false},
+		{"resolved attention accepted", []schema.Turn{steering("a1", "one"), resolution("a1", "consumed", 0)}, true},
+		{"identical re-resolution accepted", []schema.Turn{steering("a1", "one"), resolution("a1", "consumed", 0), resolution("a1", "consumed", 0)}, true},
+		{"conflicting re-resolution refused", []schema.Turn{steering("a1", "one"), resolution("a1", "consumed", 0), resolution("a1", "discarded", 0)}, false},
+		{"resolution before append refused", []schema.Turn{resolution("a1", "consumed", 0), steering("a1", "one")}, false},
+		{"unknown disposition refused", []schema.Turn{steering("a1", "one"), resolution("a1", "archived", 0)}, false},
+		{"discarded with generation refused", []schema.Turn{steering("a1", "one"), resolution("a1", "discarded", 3)}, false},
+		{"generation claimed twice refused", []schema.Turn{steering("a1", "one"), steering("a2", "two"), resolution("a1", "consumed", 7), resolution("a2", "consumed", 7)}, false},
+		{"resolution turn with nil pointer refused", []schema.Turn{steering("a1", "one"), func() schema.Turn {
+			turn := schema.NewTurn(schema.TurnAttentionResolution, llm.User(""))
+			turn.AttentionResolution = nil
+			return turn
+		}()}, false},
+		{"non-steering attention turn refused", []schema.Turn{func() schema.Turn {
+			turn := schema.NewTurn(schema.TurnUserInput, llm.User("not steering"))
+			turn.AttentionID = "a1"
+			return turn
+		}()}, false},
+		{"valid delivery commit accepted", []schema.Turn{toolResults("tc1", schema.DelegateDeliveryCommit{DeliveryID: "d1", ToolCallID: "tc1"})}, true},
+		{"commit off tool-results turn refused", []schema.Turn{func() schema.Turn {
+			turn := schema.NewTurn(schema.TurnUserInput, llm.User("wrong kind"))
+			turn.DelegateDeliveryCommits = []schema.DelegateDeliveryCommit{{DeliveryID: "d1", ToolCallID: "tc1"}}
+			return turn
+		}()}, false},
+		{"commit referencing absent tool call refused", []schema.Turn{toolResults("tc1", schema.DelegateDeliveryCommit{DeliveryID: "d1", ToolCallID: "tcX"})}, false},
+		{"commit with incomplete identity refused", []schema.Turn{toolResults("tc1", schema.DelegateDeliveryCommit{DeliveryID: "", ToolCallID: "tc1"})}, false},
+		{"conflicting tool call per delivery refused", []schema.Turn{
+			toolResults("tc1", schema.DelegateDeliveryCommit{DeliveryID: "d1", ToolCallID: "tc1"}),
+			toolResults("tc2", schema.DelegateDeliveryCommit{DeliveryID: "d1", ToolCallID: "tc2"}),
+		}, false},
+		{"conflicting delivery per tool call refused", []schema.Turn{
+			toolResults("tc1", schema.DelegateDeliveryCommit{DeliveryID: "d1", ToolCallID: "tc1"}),
+			toolResults("tc1", schema.DelegateDeliveryCommit{DeliveryID: "d2", ToolCallID: "tc1"}),
+		}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "diff.transcript.jsonl")
+			writer, err := transcript.NewWriter(path, transcript.Header{SessionID: "diff"})
+			if err != nil {
+				t.Fatalf("new writer: %v", err)
+			}
+			// A checkpoint after the turns so the full-scan anchor has a
+			// boundary to anchor at; the refusals fire before it is consulted.
+			for _, turn := range tc.turns {
+				if err := writer.Append(turn); err != nil {
+					t.Fatalf("append turn: %v", err)
+				}
+			}
+			if err := writer.Append(schema.NewTurn(schema.TurnCheckpoint, llm.User("compaction summary"))); err != nil {
+				t.Fatalf("append checkpoint: %v", err)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatalf("close writer: %v", err)
+			}
+			// The snapshot's verdict is observable through the sidecar it
+			// leaves behind: a refused fold writes no sidecar at all.
+			refreshErr := transcript.RefreshSidecarFromFullScan(path, "diff")
+			if refreshErr != nil {
+				t.Fatalf("refresh: %v", refreshErr)
+			}
+			_, snapshotOK := transcript.ReadSidecar(path)
+			entries := make([]transcript.Entry, 0, len(tc.turns))
+			for i, turn := range tc.turns {
+				entries = append(entries, transcript.Entry{Seq: i, Turn: turn})
+			}
+			_, fileErr := foldDelegateAttention(entries)
+			fileOK := fileErr == nil
+			if snapshotOK != fileOK {
+				t.Fatalf("snapshot and file fold disagree: snapshot ok=%v, file fold ok=%v (file fold error: %v)", snapshotOK, fileOK, fileErr)
+			}
+			if !tc.accepted && snapshotOK {
+				t.Fatalf("case must be refused but the snapshot accepted it")
+			}
+			if tc.accepted && !snapshotOK {
+				t.Fatalf("case must be accepted but the snapshot refused it")
+			}
+		})
+	}
+}
+
 // TestFullScanSnapshotDedupesReSentAttentionAndCarriesResolutions pins the
 // opportunistic anchor's fold snapshot over the two attention shapes the
 // reviewer's probe showed it mishandling: a steering turn re-sent with
@@ -309,10 +429,11 @@ func TestFullScanSnapshotDedupesReSentAttentionAndCarriesResolutions(t *testing.
 	for _, row := range sidecar.PendingAttention {
 		rows[row.AttentionID] = row
 	}
-	if want := []string{"att_dup", "att_resolved", "att_pending"}; len(sidecar.PendingAttention) != len(want) {
+	want := []string{"att_dup", "att_resolved", "att_pending"}
+	if len(sidecar.PendingAttention) != len(want) {
 		t.Fatalf("snapshot rows: got %d (%v), want %d — a re-sent attention must not add a row", len(sidecar.PendingAttention), sidecar.PendingAttention, len(want))
 	}
-	for _, id := range []string{"att_dup", "att_resolved", "att_pending"} {
+	for _, id := range want {
 		if _, present := rows[id]; !present {
 			t.Fatalf("snapshot is missing attention %q: %+v", id, sidecar.PendingAttention)
 		}

--- a/agent/transcript/failures.go
+++ b/agent/transcript/failures.go
@@ -118,9 +118,20 @@ func NewFailureCounter(fromEntryOrdinal int) *FailureCounter {
 // A floor below zero (the sidecar's "not computed" sentinel) is refused: an
 // absent floor must fall back to the full scan, not silently count from
 // zero — the false all-clean is what the count exists to prevent.
+//
+// A divergence ordinal INSIDE the prefix is refused too: the floor is a
+// single count over [0, prefixEntryCount) computed without the fork bound, so
+// a fork child (inherited parent prefix below DivergenceTurn) cannot tell
+// how many of those failures were the parent's. Charging them to the child
+// is the attribution bug the bound exists to prevent; refusing the floor
+// sends the caller to its full-scan fallback, which re-derives the count
+// with the bound applied entry by entry.
 func NewFailureCounterSeeded(floor, prefixEntryCount, fromEntryOrdinal int) (*FailureCounter, error) {
 	if floor < 0 || prefixEntryCount < 0 {
 		return nil, fmt.Errorf("failure floor %d over %d prefix entries is invalid", floor, prefixEntryCount)
+	}
+	if fromEntryOrdinal > 0 && fromEntryOrdinal < prefixEntryCount {
+		return nil, fmt.Errorf("divergence ordinal %d inside the %d-entry prefix cannot bound a precomputed failure floor", fromEntryOrdinal, prefixEntryCount)
 	}
 	return &FailureCounter{
 		toolNames: map[string]string{},

--- a/agent/transcript/failures.go
+++ b/agent/transcript/failures.go
@@ -2,6 +2,7 @@ package transcript
 
 import (
 	"encoding/json"
+	"fmt"
 	"slices"
 
 	"primeradiant.com/evener/agent/schema"
@@ -105,6 +106,28 @@ type FailureCounter struct {
 // bound exists to prevent. Pass 0 (or 1) for a session that inherited nothing.
 func NewFailureCounter(fromEntryOrdinal int) *FailureCounter {
 	return &FailureCounter{toolNames: map[string]string{}, from: fromEntryOrdinal}
+}
+
+// NewFailureCounterSeeded returns a counter pre-set to floor failures over
+// prefix entries this process did not decode, positioned so the entries it
+// observes from here on continue the 1-based ordinal sequence from
+// prefixEntryCount. It is the windowed-resume form of NewFailureCounter: the
+// floor is what a full scan's TrackFailures seed would have counted over the
+// prefix, bounded by the same divergence rule.
+//
+// A floor below zero (the sidecar's "not computed" sentinel) is refused: an
+// absent floor must fall back to the full scan, not silently count from
+// zero — the false all-clean is what the count exists to prevent.
+func NewFailureCounterSeeded(floor, prefixEntryCount, fromEntryOrdinal int) (*FailureCounter, error) {
+	if floor < 0 || prefixEntryCount < 0 {
+		return nil, fmt.Errorf("failure floor %d over %d prefix entries is invalid", floor, prefixEntryCount)
+	}
+	return &FailureCounter{
+		toolNames: map[string]string{},
+		count:     floor,
+		ordinal:   prefixEntryCount,
+		from:      fromEntryOrdinal,
+	}, nil
 }
 
 // Observe records one transcript entry's turn: it learns the tool names the

--- a/agent/transcript/sidecar.go
+++ b/agent/transcript/sidecar.go
@@ -1,0 +1,317 @@
+package transcript
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+)
+
+// resumeSidecarVersion is the resume sidecar format version. Bump on any
+// incompatible change to the shape below.
+const resumeSidecarVersion = 1
+
+// resumeSidecarAnchorBytes mirrors turnIndexAnchorBytes: the byte window each
+// anchor stamps, sized to bind the sidecar to the transcript's identity
+// without reading the whole prefix.
+const resumeSidecarAnchorBytes = 256
+
+// sidecarLimit bounds the sidecar file read. The sidecar is metadata plus a
+// small fold snapshot; a transcript whose sidecar exceeds this limit is
+// treated as corrupt (fallback to full scan), never trusted.
+const resumeSidecarLimit = 1 << 20
+
+// sidecarSuffix is the path suffix of the resume sidecar relative to its
+// transcript: "<transcript>.resume-sidecar.json".
+const resumeSidecarSuffix = ".resume-sidecar.json"
+
+// SidecarPath returns the resume sidecar path for a transcript path.
+func SidecarPath(transcriptPath string) string {
+	return transcriptPath + resumeSidecarSuffix
+}
+
+// sidecarAnchor is a bounded byte-range stamp over the transcript, copied
+// from turnIndexAnchor: one sha256 over [Offset, Offset+Length).
+type sidecarAnchor struct {
+	Offset int64  `json:"offset"`
+	Length int    `json:"length"`
+	Stamp  string `json:"stamp"`
+}
+
+// SidecarPendingAttention snapshots one delegate attention whose lifecycle
+// spans the prefix boundary: the fold needs its content to resolve a suffix
+// resolution turn and its disposition to answer pendingIDs correctly.
+type SidecarPendingAttention struct {
+	AttentionID      string      `json:"attention_id"`
+	Message          JSONMessage `json:"message"`
+	Resolution       string      `json:"resolution,omitempty"`
+	ResumeGeneration uint64      `json:"resume_generation,omitempty"`
+}
+
+// JSONMessage preserves an llm message's JSON bytes inside the sidecar
+// without the transcript package depending on the llm message shape: the
+// fold re-decodes it on the agent side. Marshalling through RawMessage keeps
+// the sidecar a byte-level artifact of this package.
+type JSONMessage json.RawMessage
+
+// MarshalJSON implements json.Marshaler.
+func (m JSONMessage) MarshalJSON() ([]byte, error) {
+	if len(m) == 0 {
+		return []byte("null"), nil
+	}
+	return m, nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (m *JSONMessage) UnmarshalJSON(data []byte) error {
+	*m = JSONMessage(append(json.RawMessage(nil), data...))
+	return nil
+}
+
+// SidecarDeliveryCommit snapshots one committed delegate delivery.
+type SidecarDeliveryCommit struct {
+	DeliveryID string `json:"delivery_id"`
+	ToolCallID string `json:"tool_call_id"`
+}
+
+// ResumeSidecar is the durable validated-offset sidecar for transcript
+// resume. Its contract: every field describes the transcript PREFIX strictly
+// before Offset, and Offset points AT the last checkpoint entry — so the
+// suffix a validated windowed resume decodes is exactly ResumeHistory's
+// window. A transcript without a checkpoint gets no sidecar: all its entries
+// are live history, and skipping any of them would change restore behavior.
+type ResumeSidecar struct {
+	Version                 int    `json:"version"`
+	TranscriptFormatVersion int    `json:"transcript_format_version"`
+	SessionID               string `json:"session_id"`
+
+	// TranscriptSize is the file size observed when the sidecar was written.
+	// A current size smaller than this is a truncation the sidecar cannot
+	// vouch for: full scan. A larger size is append-only growth, the expected
+	// case between an anchor and the next resume.
+	TranscriptSize int64 `json:"transcript_size"`
+	// ValidBytes is TranscriptSize minus any unterminated crash tail the
+	// anchor observed. The offset is bounded by it.
+	ValidBytes int64 `json:"valid_bytes"`
+
+	// Offset is the byte offset where the suffix begins — the start of the
+	// last checkpoint entry, so the windowed suffix a resume decodes is
+	// exactly ResumeHistory's window ([last checkpoint, ...subsequent]).
+	// The entry ENDING at Offset is the last prefix entry.
+	Offset int64 `json:"offset"`
+
+	// MaxSeq is the highest entry.Seq at or before Offset.
+	MaxSeq int `json:"max_seq"`
+	// EntryCount is the number of entries at or before Offset.
+	EntryCount int `json:"entry_count"`
+	// FailureFloor is the failed-tool-call count over the prefix entries the
+	// anchor observed, bounded by the same divergence rule TrackFailures
+	// applies. -1 means "not computed by this anchor"; callers that need it
+	// fall back to a full scan.
+	FailureFloor int `json:"failure_floor"`
+
+	// FileIdentity, ModTimeUnixNS, FirstAnchor, and TailAnchor bind the
+	// sidecar to one file incarnation, mirroring turnIndexDisk's identity
+	// fields. FirstAnchor stamps the first bytes of the file; TailAnchor
+	// stamps the bytes immediately before Offset.
+	FileIdentity  string        `json:"file_identity"`
+	ModTimeUnixNS int64         `json:"mod_time_unix_ns"`
+	FirstAnchor   sidecarAnchor `json:"first_anchor"`
+	TailAnchor    sidecarAnchor `json:"tail_anchor"`
+
+	// BoundarySeq cross-checks Offset: the entry that ends exactly at Offset
+	// must carry this seq. A mismatching boundary record is corruption.
+	BoundarySeq int `json:"boundary_seq"`
+
+	// SnapshotsComplete reports whether the fold snapshots below were
+	// computed over every entry. The post-full-scan anchor always sets it
+	// (it decoded the whole file). The compaction anchor sets it only when
+	// the session's live attention state is empty — a session with live
+	// pending attentions cannot reconstruct their durable content without
+	// re-reading the transcript, so it writes SnapshotsComplete=false and a
+	// resume that NEEDS the fold falls back to the full scan rather than
+	// folding an incomplete state.
+	SnapshotsComplete bool `json:"snapshots_complete"`
+
+	// Fold snapshots (valid when SnapshotsComplete).
+	PendingAttention []SidecarPendingAttention `json:"pending_attention,omitempty"`
+	DeliveryCommits  []SidecarDeliveryCommit   `json:"delivery_commits,omitempty"`
+	// ClientMutationTurns maps mutation IDs to the stable turn IDs of their
+	// prefix turns; restore consults it to avoid re-executing a mutation
+	// whose turns predate the offset.
+	ClientMutationTurns map[string]string `json:"client_mutation_turns,omitempty"`
+
+	// IntegrityStamp is the sha256 of the sidecar JSON with this field
+	// empty; a mismatch is corruption.
+	IntegrityStamp string `json:"integrity_stamp"`
+}
+
+// sidecarIntegrityStamp computes the integrity stamp for a sidecar value.
+func sidecarIntegrityStamp(sidecar ResumeSidecar) string {
+	sidecar.IntegrityStamp = ""
+	data, err := json.Marshal(sidecar)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// ReadSidecar reads and structurally validates the resume sidecar for a
+// transcript. It returns ok=false for a missing, unreadable, oversized,
+// malformed, version-mismatched, or integrity-failing sidecar — every such
+// case is a full-scan fallback, never an error to the caller.
+func ReadSidecar(transcriptPath string) (sidecar ResumeSidecar, ok bool) {
+	data, err := os.ReadFile(SidecarPath(transcriptPath))
+	if err != nil || int64(len(data)) > resumeSidecarLimit {
+		return ResumeSidecar{}, false
+	}
+	var candidate ResumeSidecar
+	if err := json.Unmarshal(data, &candidate); err != nil {
+		return ResumeSidecar{}, false
+	}
+	if candidate.Version != resumeSidecarVersion || candidate.TranscriptFormatVersion != FormatVersion {
+		return ResumeSidecar{}, false
+	}
+	if candidate.IntegrityStamp == "" || candidate.IntegrityStamp != sidecarIntegrityStamp(candidate) {
+		return ResumeSidecar{}, false
+	}
+	return candidate, true
+}
+
+// WriteSidecar persists the sidecar atomically: temp file in the same
+// directory, fsync, rename. The transcript package's own durability model
+// (writeTranscript's forceSync path) uses the same discipline. A write
+// failure is returned to the caller; the resume fast path treats it as
+// non-fatal (the next resume simply falls back).
+func WriteSidecar(transcriptPath string, sidecar ResumeSidecar) error {
+	sidecar.IntegrityStamp = sidecarIntegrityStamp(sidecar)
+	data, err := json.Marshal(sidecar)
+	if err != nil {
+		return fmt.Errorf("marshal resume sidecar: %w", err)
+	}
+	path := SidecarPath(transcriptPath)
+	temp, err := os.CreateTemp(filepath.Dir(path), ".resume-sidecar-*")
+	if err != nil {
+		return fmt.Errorf("create resume sidecar temp: %w", err)
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath) //nolint:errcheck // best-effort cleanup after rename/failure
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("write resume sidecar: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("sync resume sidecar: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("close resume sidecar temp: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("rename resume sidecar: %w", err)
+	}
+	return nil
+}
+
+// sidecarAnchors computes the first and tail anchors for a transcript prefix
+// [0, offset). It mirrors transcriptAnchors from turn_index.go, with the tail
+// anchored at the offset rather than the file end.
+func sidecarAnchors(file sidecarReaderAt, offset int64) (first, tail sidecarAnchor) {
+	if offset <= 0 {
+		return sidecarAnchor{}, sidecarAnchor{}
+	}
+	firstLength := min(int64(resumeSidecarAnchorBytes), offset)
+	first = sidecarAnchorAt(file, 0, int(firstLength))
+	tailOffset := max(offset-int64(resumeSidecarAnchorBytes), 0)
+	tail = sidecarAnchorAt(file, tailOffset, int(offset-tailOffset))
+	return first, tail
+}
+
+// sidecarReaderAt is the read-at surface both anchor paths need: *os.File
+// directly, or an afero.File when that is all the caller holds (the Writer's
+// fs may be injected).
+type sidecarReaderAt interface {
+	ReadAt(b []byte, off int64) (int, error)
+}
+
+func sidecarAnchorAt(file sidecarReaderAt, offset int64, length int) sidecarAnchor {
+	data := make([]byte, length)
+	n, _ := file.ReadAt(data, offset)
+	sum := sha256.Sum256(data[:n])
+	return sidecarAnchor{Offset: offset, Length: n, Stamp: hex.EncodeToString(sum[:])}
+}
+
+// sidecarAnchorsMatch re-reads both anchor windows and compares stamps.
+// Mirrors anchorsMatchObserved from turn_index.go.
+func sidecarAnchorsMatch(file sidecarReaderAt, first, tail sidecarAnchor) bool {
+	for _, anchor := range []sidecarAnchor{first, tail} {
+		if anchor.Length <= 0 || anchor.Stamp == "" {
+			return false
+		}
+		data := make([]byte, anchor.Length)
+		n, err := file.ReadAt(data, anchor.Offset)
+		if err != nil && err != io.EOF {
+			return false
+		}
+		sum := sha256.Sum256(data[:n])
+		if n != anchor.Length || hex.EncodeToString(sum[:]) != anchor.Stamp {
+			return false
+		}
+	}
+	return true
+}
+
+// sidecarFileIdentity derives the file incarnation identity. It mirrors
+// fileIdentity from turn_index.go (which the transcript package cannot
+// import): the reflect-based Dev/Ino read with a Windows fallback. The
+// anchors provide the byte-level binding; this identity binds the
+// incarnation.
+func sidecarFileIdentity(info os.FileInfo) string {
+	if info == nil || info.Sys() == nil {
+		return ""
+	}
+	value := reflect.Indirect(reflect.ValueOf(info.Sys()))
+	if !value.IsValid() || value.Kind() != reflect.Struct {
+		return ""
+	}
+	field := func(name string) (uint64, bool) {
+		got := value.FieldByName(name)
+		if !got.IsValid() {
+			return 0, false
+		}
+		switch got.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return uint64(got.Int()), true
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return got.Uint(), true
+		default:
+			return 0, false
+		}
+	}
+	if device, ok := field("Dev"); ok {
+		if inode, ok := field("Ino"); ok {
+			return fmt.Sprintf("dev:%d:ino:%d", device, inode)
+		}
+	}
+	volume, volumeOK := field("VolumeSerialNumber")
+	high, highOK := field("FileIndexHigh")
+	low, lowOK := field("FileIndexLow")
+	if !volumeOK {
+		volume, volumeOK = field("vol")
+	}
+	if !highOK {
+		high, highOK = field("idxhi")
+	}
+	if !lowOK {
+		low, lowOK = field("idxlo")
+	}
+	if volumeOK && highOK && lowOK {
+		return fmt.Sprintf("volume:%d:index:%d", volume, high<<32|low)
+	}
+	return ""
+}

--- a/agent/transcript/sidecar.go
+++ b/agent/transcript/sidecar.go
@@ -189,11 +189,20 @@ func ReadSidecar(transcriptPath string) (sidecar ResumeSidecar, ok bool) {
 // (writeTranscript's forceSync path) uses the same discipline. A write
 // failure is returned to the caller; the resume fast path treats it as
 // non-fatal (the next resume simply falls back).
+//
+// A sidecar that would exceed the read limit is refused here rather than
+// written-and-forever-rejected: ReadSidecar caps the read at
+// resumeSidecarLimit, so an oversized write would cycle pointlessly —
+// every resume rewrites it, every read discards it. Refusing at the write
+// keeps the (correct) fallback to the full scan instead.
 func WriteSidecar(transcriptPath string, sidecar ResumeSidecar) error {
 	sidecar.IntegrityStamp = sidecarIntegrityStamp(sidecar)
 	data, err := json.Marshal(sidecar)
 	if err != nil {
 		return fmt.Errorf("marshal resume sidecar: %w", err)
+	}
+	if int64(len(data)) > resumeSidecarLimit {
+		return fmt.Errorf("resume sidecar is %d bytes, over the %d read limit", len(data), resumeSidecarLimit)
 	}
 	path := SidecarPath(transcriptPath)
 	temp, err := os.CreateTemp(filepath.Dir(path), ".resume-sidecar-*")

--- a/agent/transcript/sidecar.go
+++ b/agent/transcript/sidecar.go
@@ -141,12 +141,11 @@ type ResumeSidecar struct {
 
 	// SnapshotsComplete reports whether the fold snapshots below were
 	// computed over every entry. The post-full-scan anchor always sets it
-	// (it decoded the whole file). The compaction anchor sets it only when
-	// the session's live attention state is empty — a session with live
-	// pending attentions cannot reconstruct their durable content without
-	// re-reading the transcript, so it writes SnapshotsComplete=false and a
-	// resume that NEEDS the fold falls back to the full scan rather than
-	// folding an incomplete state.
+	// (it decoded the whole file). The compaction anchor never does: it
+	// cannot reconstruct the prefix's fold state without re-reading the
+	// transcript, so it writes SnapshotsComplete=false and a resume that
+	// NEEDS the fold falls back to the full scan rather than folding an
+	// incomplete state.
 	SnapshotsComplete bool `json:"snapshots_complete"`
 
 	// Fold snapshots (valid when SnapshotsComplete).

--- a/agent/transcript/sidecar.go
+++ b/agent/transcript/sidecar.go
@@ -109,6 +109,17 @@ type ResumeSidecar struct {
 	MaxSeq int `json:"max_seq"`
 	// EntryCount is the number of entries at or before Offset.
 	EntryCount int `json:"entry_count"`
+	// PrefixTurnCount is the number of turn positions a full AppWire
+	// projection of the whole file holds strictly below the suffix: the
+	// prelude turn (when the header projects one) plus one position for
+	// every prefix entry that projects at least one thread item. Only the
+	// post-full-scan anchor computes it (it decoded the prefix and knows
+	// which kinds projected); the compaction anchor writes -1, and a resume
+	// that needs windowed turn paging then falls back rather than guessing.
+	// Entries that project nothing (empty-text marker turns) are common in
+	// compacted prefixes, so the figure is genuinely not derivable from
+	// EntryCount.
+	PrefixTurnCount int `json:"prefix_turn_count"`
 	// FailureFloor is the failed-tool-call count over the prefix entries the
 	// anchor observed, bounded by the same divergence rule TrackFailures
 	// applies. -1 means "not computed by this anchor"; callers that need it

--- a/agent/transcript/sidecar.go
+++ b/agent/transcript/sidecar.go
@@ -8,7 +8,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"reflect"
+
+	"primeradiant.com/evener/internal/fileident"
 )
 
 // resumeSidecarVersion is the resume sidecar format version. Bump on any
@@ -266,52 +267,9 @@ func sidecarAnchorsMatch(file sidecarReaderAt, first, tail sidecarAnchor) bool {
 	return true
 }
 
-// sidecarFileIdentity derives the file incarnation identity. It mirrors
-// fileIdentity from turn_index.go (which the transcript package cannot
-// import): the reflect-based Dev/Ino read with a Windows fallback. The
-// anchors provide the byte-level binding; this identity binds the
-// incarnation.
+// sidecarFileIdentity derives the file incarnation identity through the
+// shared internal/fileident package (also used by internal/apptranscript's
+// turn index, which this package cannot import).
 func sidecarFileIdentity(info os.FileInfo) string {
-	if info == nil || info.Sys() == nil {
-		return ""
-	}
-	value := reflect.Indirect(reflect.ValueOf(info.Sys()))
-	if !value.IsValid() || value.Kind() != reflect.Struct {
-		return ""
-	}
-	field := func(name string) (uint64, bool) {
-		got := value.FieldByName(name)
-		if !got.IsValid() {
-			return 0, false
-		}
-		switch got.Kind() {
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			return uint64(got.Int()), true
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			return got.Uint(), true
-		default:
-			return 0, false
-		}
-	}
-	if device, ok := field("Dev"); ok {
-		if inode, ok := field("Ino"); ok {
-			return fmt.Sprintf("dev:%d:ino:%d", device, inode)
-		}
-	}
-	volume, volumeOK := field("VolumeSerialNumber")
-	high, highOK := field("FileIndexHigh")
-	low, lowOK := field("FileIndexLow")
-	if !volumeOK {
-		volume, volumeOK = field("vol")
-	}
-	if !highOK {
-		high, highOK = field("idxhi")
-	}
-	if !lowOK {
-		low, lowOK = field("idxlo")
-	}
-	if volumeOK && highOK && lowOK {
-		return fmt.Sprintf("volume:%d:index:%d", volume, high<<32|low)
-	}
-	return ""
+	return fileident.FileIdentity(info)
 }

--- a/agent/transcript/sidecar_test.go
+++ b/agent/transcript/sidecar_test.go
@@ -37,6 +37,76 @@ func seedWindowedTranscript(t *testing.T, sessionID string, n int) string {
 	return path
 }
 
+// TestWriteSidecarFromWriterWindowsAtCheckpointEntryStart pins the
+// compaction anchor's window: a sidecar written from a LIVE writer right
+// after it appended a checkpoint must anchor at the START of that entry, so
+// the windowed resume that validates it decodes [checkpoint, ...rest] — the
+// same window ResumeHistory defines. The failure this pins: an anchor written
+// at the post-checkpoint append position silently drops the compaction
+// summary from every resumed session's live history.
+func TestWriteSidecarFromWriterWindowsAtCheckpointEntryStart(t *testing.T) {
+	const sessionID = "s_anchor"
+	dir := t.TempDir()
+	path := filepath.Join(dir, sessionID+".transcript.jsonl")
+	w, err := NewWriter(path, Header{SessionID: sessionID})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if err := w.Append(schema.NewTurn(schema.TurnUserInput, llm.User("turn"))); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+	// The compaction moment: the checkpoint is the LAST entry appended.
+	if err := w.Append(schema.NewTurn(schema.TurnCheckpoint, llm.User("compaction summary"))); err != nil {
+		t.Fatalf("append checkpoint: %v", err)
+	}
+	// The compaction anchor. The writer must refuse to claim snapshots it
+	// did not compute (complete=false); the fold falls back to its full read.
+	if err := w.WriteSidecarFromWriter(path, nil, nil, nil, false); err != nil {
+		t.Fatalf("write sidecar from writer: %v", err)
+	}
+	// Turn the writer's crank once more the way the session would, so the
+	// file has a suffix entry AFTER the checkpoint too.
+	if err := w.Append(schema.NewTurn(schema.TurnUserInput, llm.User("after compaction"))); err != nil {
+		t.Fatalf("append after: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	resumed, view, err := OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("windowed resume: %v", err)
+	}
+	defer resumed.Close() //nolint:errcheck
+	if !view.SidecarUsed {
+		t.Fatalf("resume fell back to full scan — the compaction anchor did not validate")
+	}
+	if len(view.Entries) != 2 {
+		t.Fatalf("suffix entries: got %d, want 2 (the checkpoint entry + the post-compaction entry)", len(view.Entries))
+	}
+	if view.Entries[0].Turn.Kind != schema.TurnCheckpoint {
+		t.Fatalf("suffix's first entry: got kind %q, want the checkpoint entry — the compaction summary must survive resume", view.Entries[0].Turn.Kind)
+	}
+	if view.PrefixEntryCount != 3 {
+		t.Fatalf("prefix entry count: got %d, want 3", view.PrefixEntryCount)
+	}
+	// The prefix facts must match what the post-full-scan anchor would write
+	// for the same file: the boundary seq is the last PREFIX entry's seq, not
+	// the checkpoint's.
+	sidecar, ok := ReadSidecar(path)
+	if !ok {
+		t.Fatalf("sidecar missing")
+	}
+	if sidecar.BoundarySeq != sidecar.MaxSeq {
+		t.Fatalf("boundary seq %d must equal the prefix max seq %d", sidecar.BoundarySeq, sidecar.MaxSeq)
+	}
+	if sidecar.SnapshotsComplete {
+		t.Fatalf("compaction anchor must not claim complete snapshots it did not compute")
+	}
+}
+
 // resumeViaSidecar runs OpenWriterForResume twice: the first call performs
 // the full scan and writes the opportunistic sidecar; the second must use
 // it. entryCount is the seeded entry count. Returns the second call's view

--- a/agent/transcript/sidecar_test.go
+++ b/agent/transcript/sidecar_test.go
@@ -5,7 +5,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/fuzz/fault"
 	"primeradiant.com/evener/llm"
 )
 
@@ -104,6 +107,63 @@ func TestWriteSidecarFromWriterWindowsAtCheckpointEntryStart(t *testing.T) {
 	}
 	if sidecar.SnapshotsComplete {
 		t.Fatalf("compaction anchor must not claim complete snapshots it did not compute")
+	}
+}
+
+// TestRollbackAfterCheckpointInvalidatesAnchor pins the crash-consistency
+// window: a durable append that fails and rolls back must not leave the
+// writer's checkpoint anchor (or its in-memory write position) claiming
+// bytes the file no longer holds. The next plain append after a rollback
+// uses writePos to place the next checkpoint anchor; a stale value would
+// window a future resume past bytes that are back in the file.
+func TestRollbackAfterCheckpointInvalidatesAnchor(t *testing.T) {
+	const sessionID = "s_rollback"
+	dir := t.TempDir()
+	path := filepath.Join(dir, sessionID+".transcript.jsonl")
+	// A fault fs that fails the 4th sync (the durable append's sync), with
+	// every other op succeeding: the durable append writes, its sync fails,
+	// and the rollback truncates the entry back out.
+	fs := fault.FS(afero.NewMemMapFs(), fault.FromBytes(faultPlan(9)))
+	w, err := newWriterFS(fs, path, Header{SessionID: sessionID}, true)
+	if err != nil {
+		t.Fatalf("newWriterFS: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		// Plain appends: SyncInterval 0 syncs every write, so advance the
+		// fault plan past the header ops and these syncs first. faultPlan(k)
+		// trips exactly the k-th op; the writer's op order here is
+		// 0=MkdirAll 1=Create 2=header Write 3=header Sync, then each plain
+		// append is Write+Sync (ops 4,5 then 6,7) — so the durable
+		// checkpoint's Sync is op 9.
+		if err := w.Append(schema.NewTurn(schema.TurnUserInput, llm.User("turn"))); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+	// A checkpoint entry, appended durably — its sync is the faulted op, so
+	// the append rolls back.
+	err = w.AppendDurable(schema.NewTurn(schema.TurnCheckpoint, llm.User("checkpoint that rolls back")))
+	if err == nil {
+		t.Fatal("expected the faulted durable append to fail")
+	}
+	w.mu.Lock()
+	ckptStart := w.lastCheckpointStart
+	writePos := w.writePos
+	w.mu.Unlock()
+	if ckptStart != -1 {
+		t.Fatalf("checkpoint anchor survived a rollback: start=%d, want -1", ckptStart)
+	}
+	// The rollback restored the position to the pre-append offset; the
+	// next append must place itself there, not past the rolled-back bytes.
+	info, statErr := fs.Stat(path)
+	if statErr != nil {
+		t.Fatalf("stat: %v", statErr)
+	}
+	if writePos != info.Size() {
+		t.Fatalf("writePos after rollback: got %d, want the file size %d", writePos, info.Size())
+	}
+	// The anchor the writer would write now must refuse (no checkpoint).
+	if anchorErr := w.WriteSidecarFromWriter(path, nil, nil, nil, false); anchorErr == nil {
+		t.Fatal("writer accepted a sidecar anchor with no surviving checkpoint")
 	}
 }
 

--- a/agent/transcript/sidecar_test.go
+++ b/agent/transcript/sidecar_test.go
@@ -1,0 +1,322 @@
+package transcript
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/llm"
+)
+
+// seedWindowedTranscript writes a transcript with header + n user entries +
+// one CHECKPOINT entry and returns its path. The checkpoint is what the
+// opportunistic anchor keys its offset AT (ResumeHistory's window starts at
+// the last checkpoint), so every windowed-resume fixture needs one.
+func seedWindowedTranscript(t *testing.T, sessionID string, n int) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, sessionID+".transcript.jsonl")
+	w, err := NewWriter(path, Header{SessionID: sessionID})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	for i := 0; i < n; i++ {
+		turn := schema.NewTurn(schema.TurnUserInput, llm.User("turn text"))
+		if err := w.Append(turn); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+	checkpoint := schema.NewTurn(schema.TurnCheckpoint, llm.User("compaction summary"))
+	if err := w.Append(checkpoint); err != nil {
+		t.Fatalf("append checkpoint: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	return path
+}
+
+// resumeViaSidecar runs OpenWriterForResume twice: the first call performs
+// the full scan and writes the opportunistic sidecar; the second must use
+// it. entryCount is the seeded entry count. Returns the second call's view
+// and writer.
+func resumeViaSidecar(t *testing.T, path, sessionID string, entryCount int) (ResumeView, *Writer) {
+	t.Helper()
+	first, view, err := OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("first resume: %v", err)
+	}
+	if view.SidecarUsed {
+		t.Fatalf("first resume used a sidecar that does not exist yet")
+	}
+	if len(view.Entries) != entryCount {
+		t.Fatalf("first resume entries: got %d, want %d", len(view.Entries), entryCount)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first: %v", err)
+	}
+	second, view, err := OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("second resume: %v", err)
+	}
+	if !view.SidecarUsed {
+		t.Fatalf("second resume did not use the sidecar (full scan fell back)")
+	}
+	return view, second
+}
+
+// TestOpenWriterForResumeWindowedSecondResumeIsSuffixOnly: the opportunistic
+// anchor after a full scan must make the SECOND resume windowed — zero
+// decoded prefix entries, correct prefix count, correct maxSeq floor, and a
+// writer whose next append does not collide.
+func TestOpenWriterForResumeWindowedSecondResumeIsSuffixOnly(t *testing.T) {
+	const sessionID = "sidecar_window"
+	path := seedWindowedTranscript(t, sessionID, 5)
+	view, w := resumeViaSidecar(t, path, sessionID, 6)
+	defer w.Close() //nolint:errcheck // test cleanup
+
+	// The suffix is exactly ResumeHistory's window: the checkpoint entry
+	// itself plus everything after it (nothing yet), and NOT the five user
+	// entries before it.
+	if len(view.Entries) != 1 || view.Entries[0].Turn.Kind != schema.TurnCheckpoint {
+		t.Fatalf("windowed suffix: got %d entries, want 1 (the checkpoint)", len(view.Entries))
+	}
+	if view.PrefixEntryCount != 5 {
+		t.Fatalf("prefix entry count: got %d, want 5", view.PrefixEntryCount)
+	}
+	// Appending after a windowed resume must not collide with the existing
+	// seqs: the writer's seq must exceed the floor.
+	turn := schema.NewTurn(schema.TurnUserInput, llm.User("after resume"))
+	if err := w.Append(turn); err != nil {
+		t.Fatalf("append after windowed resume: %v", err)
+	}
+	// And a THIRD resume must now see exactly one suffix entry.
+	third, view3, err := OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("third resume: %v", err)
+	}
+	defer third.Close() //nolint:errcheck
+	if !view3.SidecarUsed {
+		t.Fatalf("third resume fell back to full scan")
+	}
+	if len(view3.Entries) != 2 || view3.PrefixEntryCount != 5 {
+		t.Fatalf("third resume: suffix=%d prefix=%d, want 2 (checkpoint + appended) and 5", len(view3.Entries), view3.PrefixEntryCount)
+	}
+	if view3.Entries[0].Seq <= view.Sidecar.BoundarySeq {
+		t.Fatalf("suffix seq %d not above boundary %d", view3.Entries[0].Seq, view.Sidecar.BoundarySeq)
+	}
+}
+
+// TestOpenWriterForResumeAppendsBetweenScansAdvanceTheSuffix: appends after
+// the sidecar was written are append-only growth — anchors still validate,
+// and the windowed read picks up the new entries.
+func TestOpenWriterForResumeAppendsBetweenScansAdvanceTheSuffix(t *testing.T) {
+	const sessionID = "sidecar_growth"
+	path := seedWindowedTranscript(t, sessionID, 3)
+	first, _, err := OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("first resume: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first: %v", err)
+	}
+	// Append through a plain writer AFTER the sidecar exists.
+	grow, err := OpenWriter(path)
+	if err != nil {
+		t.Fatalf("open grow writer: %v", err)
+	}
+	if err := grow.Append(schema.NewTurn(schema.TurnUserInput, llm.User("grown"))); err != nil {
+		t.Fatalf("grow append: %v", err)
+	}
+	if err := grow.Close(); err != nil {
+		t.Fatalf("close grow: %v", err)
+	}
+	second, view, err := OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("second resume: %v", err)
+	}
+	defer second.Close() //nolint:errcheck
+	if !view.SidecarUsed {
+		t.Fatalf("append-only growth fell back to full scan")
+	}
+	if len(view.Entries) != 2 || view.PrefixEntryCount != 3 {
+		t.Fatalf("windowed view: suffix=%d prefix=%d, want 2 (checkpoint + grown) and 3", len(view.Entries), view.PrefixEntryCount)
+	}
+}
+
+// TestOpenWriterFallsBackToFullScanWhenSidecarMissing: no sidecar on disk
+// means the legacy full-scan contract, byte for byte.
+func TestOpenWriterFallsBackToFullScanWhenSidecarMissing(t *testing.T) {
+	const sessionID = "sidecar_missing"
+	path := seedWindowedTranscript(t, sessionID, 4)
+	w, view, err := OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("resume without sidecar: %v", err)
+	}
+	defer w.Close() //nolint:errcheck
+	if view.SidecarUsed {
+		t.Fatalf("sidecar used with no sidecar file")
+	}
+	if len(view.Entries) != 5 || view.PrefixEntryCount != 0 {
+		t.Fatalf("full-scan view: entries=%d prefix=%d, want 5 and 0", len(view.Entries), view.PrefixEntryCount)
+	}
+}
+
+// TestOpenWriterFallsBackToFullScanWhenSidecarOffsetExceedsFileSize: a
+// truncated transcript invalidates the sidecar's bounds — full scan.
+func TestOpenWriterFallsBackToFullScanWhenSidecarOffsetExceedsFileSize(t *testing.T) {
+	const sessionID = "sidecar_truncated"
+	path := seedWindowedTranscript(t, sessionID, 6)
+	w, _, err := OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("first resume: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close first: %v", err)
+	}
+	// Truncate the file below the sidecar's recorded size.
+	if err := os.Truncate(path, 64); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	// A truncated file may no longer parse at all; both outcomes (clean
+	// fallback full-scan error, or a parse failure) must be errors, never a
+	// silently accepted windowed read.
+	second, view, err := OpenWriterForResume(path, sessionID)
+	if err == nil {
+		defer second.Close() //nolint:errcheck
+		if view.SidecarUsed {
+			t.Fatalf("windowed read accepted a truncated transcript")
+		}
+	}
+}
+
+// TestOpenWriterFallsBackToFullScanWhenSidecarFileIdentityMismatches: a
+// different file incarnation (fork child: new file, replayed content) must
+// fail the identity gate and fall back to the full scan.
+func TestOpenWriterFallsBackToFullScanWhenSidecarFileIdentityMismatches(t *testing.T) {
+	const sessionID = "sidecar_fork"
+	path := seedWindowedTranscript(t, sessionID, 5)
+	w, _, err := OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("parent first resume: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close parent first: %v", err)
+	}
+	// Fork child: copy the transcript bytes to a NEW file. Same content,
+	// different incarnation — the sidecar's identity must not validate.
+	childPath := path + ".child"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read parent: %v", err)
+	}
+	if err := os.WriteFile(childPath, data, 0o644); err != nil {
+		t.Fatalf("write child: %v", err)
+	}
+	// Copy the sidecar too — the whole point is that it must be REFUSED
+	// even though its content matches the child's bytes.
+	sidecarData, err := os.ReadFile(SidecarPath(path))
+	if err != nil {
+		t.Fatalf("read sidecar: %v", err)
+	}
+	if err := os.WriteFile(SidecarPath(childPath), sidecarData, 0o644); err != nil {
+		t.Fatalf("write child sidecar: %v", err)
+	}
+	child, view, err := OpenWriterForResume(childPath, sessionID)
+	if err != nil {
+		t.Fatalf("child resume: %v", err)
+	}
+	defer child.Close() //nolint:errcheck
+	if view.SidecarUsed {
+		t.Fatalf("fork child accepted the parent's sidecar")
+	}
+	if len(view.Entries) != 6 {
+		t.Fatalf("child full scan entries: got %d, want 6", len(view.Entries))
+	}
+}
+
+// TestSidecarSeqFloorPreventsSeqCollision: the windowed writer's next seq
+// must exceed the sidecar's floor even when the suffix is empty — resumed
+// writes never collide with entries the windowed read never saw.
+func TestSidecarSeqFloorPreventsSeqCollision(t *testing.T) {
+	const sessionID = "sidecar_seqfloor"
+	path := seedWindowedTranscript(t, sessionID, 4)
+	view, w := resumeViaSidecar(t, path, sessionID, 5)
+	defer w.Close() //nolint:errcheck
+	if view.Sidecar.MaxSeq != 3 {
+		t.Fatalf("sidecar max seq: got %d, want 3 (the last PREFIX entry; seqs are 0-based, 4 user entries = seqs 0-3, the checkpoint at seq 4 is in the suffix)", view.Sidecar.MaxSeq)
+	}
+	if w.seq != 5 {
+		t.Fatalf("writer next seq: got %d, want 5 (above the suffix's checkpoint at seq 4)", w.seq)
+	}
+	if err := w.Append(schema.NewTurn(schema.TurnUserInput, llm.User("post"))); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if w.seq != 6 {
+		t.Fatalf("seq after append: got %d, want 6", w.seq)
+	}
+}
+
+// TestSidecarRoundTripPreservesFoldSnapshotFields: WriteSidecar → ReadSidecar
+// preserves every snapshot field and rejects tampering.
+func TestSidecarRoundTripPreservesFoldSnapshotFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.transcript.jsonl")
+	if err := os.WriteFile(path, []byte("header\nentry\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	sidecar := ResumeSidecar{
+		Version:                 resumeSidecarVersion,
+		TranscriptFormatVersion: FormatVersion,
+		SessionID:               "s",
+		TranscriptSize:          13,
+		ValidBytes:              13,
+		Offset:                  13,
+		MaxSeq:                  1,
+		EntryCount:              1,
+		FailureFloor:            2,
+		FileIdentity:            "dev:1:ino:2",
+		BoundarySeq:             1,
+		SnapshotsComplete:       true,
+		PendingAttention: []SidecarPendingAttention{
+			{AttentionID: "att1", Message: JSONMessage(`{"role":"user","content":[{"type":"text","text":"hi"}]}`), Resolution: "consumed", ResumeGeneration: 3},
+		},
+		DeliveryCommits:     []SidecarDeliveryCommit{{DeliveryID: "d1", ToolCallID: "tc1"}},
+		ClientMutationTurns: map[string]string{"cm1": "turn_9"},
+	}
+	if err := WriteSidecar(path, sidecar); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+	got, ok := ReadSidecar(path)
+	if !ok {
+		t.Fatalf("read sidecar failed")
+	}
+	if got.SessionID != "s" || got.Offset != 13 || got.MaxSeq != 1 || got.EntryCount != 1 || got.FailureFloor != 2 {
+		t.Fatalf("scalar fields mismatch: %+v", got)
+	}
+	if len(got.PendingAttention) != 1 || got.PendingAttention[0].AttentionID != "att1" || got.PendingAttention[0].ResumeGeneration != 3 {
+		t.Fatalf("pending attention mismatch: %+v", got.PendingAttention)
+	}
+	if string(got.PendingAttention[0].Message) == "" {
+		t.Fatalf("pending attention message lost")
+	}
+	if len(got.DeliveryCommits) != 1 || got.DeliveryCommits[0].DeliveryID != "d1" {
+		t.Fatalf("delivery commits mismatch: %+v", got.DeliveryCommits)
+	}
+	if got.ClientMutationTurns["cm1"] != "turn_9" {
+		t.Fatalf("client mutation turns mismatch: %+v", got.ClientMutationTurns)
+	}
+	// Tampering must fail the integrity check.
+	raw, err := os.ReadFile(SidecarPath(path))
+	if err != nil {
+		t.Fatalf("read raw: %v", err)
+	}
+	tampered := []byte(string(raw[:len(raw)-3]) + "999")
+	if err := os.WriteFile(SidecarPath(path), tampered, 0o644); err != nil {
+		t.Fatalf("write tampered: %v", err)
+	}
+	if _, ok := ReadSidecar(path); ok {
+		t.Fatalf("tampered sidecar accepted")
+	}
+}

--- a/agent/transcript/transcript.go
+++ b/agent/transcript/transcript.go
@@ -750,6 +750,43 @@ func OpenWriterForSessionWithFS(fs afero.Fs, path, expectedSessionID string) (*W
 	return w, scan.entries, err
 }
 
+// RefreshSidecarFromFullScan re-derives and rewrites the resume sidecar by
+// scanning the whole transcript — the opportunistic anchor, exported for the
+// one caller that pays a full decode anyway: serve's file-form fallback for
+// a compaction-anchored sidecar (whose PrefixTurnCount is -1, so windowed
+// turn paging cannot be armed from it). That fallback re-reads the whole
+// file for the identity projection; this refresh converts the same cost
+// into the sidecar the NEXT resume windows on, instead of leaving the
+// session re-reading the file on every resume forever.
+//
+// Every refusal writeSidecarAfterFullScan applies (no checkpoint, no prefix,
+// inconsistent fold, unreadable anchors) leaves the sidecar untouched — the
+// caller's read already succeeded, and a refresh that cannot vouch for the
+// file must not replace what an earlier anchor wrote. Best-effort by
+// contract: an error is reported but never blocks the caller's operation.
+func RefreshSidecarFromFullScan(path, expectedSessionID string) error {
+	f, err := openTranscriptAppendFile(path)
+	if err != nil {
+		return fmt.Errorf("open transcript for sidecar refresh: %w", err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return fmt.Errorf("stat transcript for sidecar refresh: %w", err)
+	}
+	writer, scan, err := resumeWriter(afero.NewOsFs(), f, expectedSessionID)
+	if err != nil {
+		return fmt.Errorf("scan transcript for sidecar refresh: %w", err)
+	}
+	// The anchor write needs the file open (its second stat and its anchors
+	// read through it); the writer owns it, so close only after.
+	writeSidecarAfterFullScan(path, f, info, scan, expectedSessionID)
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("close transcript after sidecar refresh: %w", err)
+	}
+	return nil
+}
+
 func openWriter(path, expectedSessionID string) (*Writer, scanResult, error) {
 	f, err := openTranscriptAppendFile(path)
 	if err != nil {
@@ -983,22 +1020,29 @@ func projectsThreadItems(turn schema.Turn) bool {
 // vouch for: the delegate-attention fold over every entry, projected into
 // the sidecar's snapshot types. ok is false when the transcript's attention
 // records are inconsistent (a resolution for an attention that never
-// appended, or a resolution naming no attention) — the caller must not write
-// a sidecar claiming complete snapshots over such a file, because the seeded
-// fold would silently reconstruct an empty state where the full read errors.
-// The structural checks here are the ones the full entry list can judge
-// without importing the agent's fold: an unresolvable resolution, or a
-// resolution that names no attention, is inconsistent on their face.
+// appended, a resolution naming no attention, or a resolution whose shape the
+// file fold would reject) — the caller must not write a sidecar claiming
+// complete snapshots over such a file, because the seeded fold would silently
+// reconstruct an empty state where the full read errors. The structural
+// checks here are the ones the full entry list can judge without importing
+// the agent's fold: an unresolvable resolution, or a resolution that names
+// no attention, is inconsistent on their face.
+//
+// The attention pass mirrors the agent's file fold rule for rule, in file
+// order, keyed on the attention ID rather than the entry: a re-sent steering
+// turn with identical content is a legal transcript (a second sighting adds
+// nothing), so the snapshot records the attention once, with its resolution
+// when one exists. Resolutions are carried, not dropped — a seeded fold that
+// sees an attention resolved in the prefix must report it resolved, exactly
+// as the file fold would. Every shape the file fold rejects (a non-steering
+// attention turn, a conflicting re-send, an unknown disposition, a
+// conflicting re-resolution, a resume generation claimed twice) is refused
+// here too, so the anchor never writes a snapshot the seeded fold would
+// accept over a file the full read errors on.
 func foldSnapshotForSidecar(entries []Entry) (pending []SidecarPendingAttention, commits []SidecarDeliveryCommit, mutations map[string]string, ok bool) {
 	pending = nil
 	commits = nil
 	mutations = map[string]string{}
-	appended := map[string]bool{}
-	for i := range entries {
-		if id := entries[i].Turn.AttentionID; id != "" {
-			appended[id] = true
-		}
-	}
 	for i := range entries {
 		turn := entries[i].Turn
 		if turn.ClientMutationID != "" {
@@ -1008,35 +1052,91 @@ func foldSnapshotForSidecar(entries []Entry) (pending []SidecarPendingAttention,
 			commits = append(commits, SidecarDeliveryCommit{DeliveryID: commit.DeliveryID, ToolCallID: commit.ToolCallID})
 		}
 	}
-	// Resolution pass: an attention is pending only if its steering turn
-	// exists with no resolution anywhere in the file.
-	resolved := map[string]bool{}
-	for i := range entries {
-		if r := entries[i].Turn.AttentionResolution; r != nil {
-			if r.AttentionID == "" || !appended[r.AttentionID] {
-				// A resolution whose attention never appended is the fold's
-				// "resolved before it was appended" error — visible here
-				// without the fold itself.
-				return nil, nil, nil, false
-			}
-			resolved[r.AttentionID] = true
-		}
-	}
+	// Attention pass, in file order: rows is the fold state at the end of the
+	// entry list, order the attention IDs in first-sighting order (what the
+	// fold's order slice holds).
+	rows := map[string]SidecarPendingAttention{}
+	order := []string{}
+	generations := map[uint64]string{}
 	for i := range entries {
 		turn := entries[i].Turn
-		if turn.AttentionID == "" || resolved[turn.AttentionID] {
-			continue
+		if turn.AttentionID != "" {
+			// The fold admits an attention only as a steering turn carrying no
+			// resolution of its own; anything else it rejects on sight.
+			if turn.Kind != schema.TurnSteering || turn.AttentionResolution != nil {
+				return nil, nil, nil, false
+			}
+			if row, sighted := rows[turn.AttentionID]; sighted {
+				// A re-send with identical content is a no-op (the fold
+				// keeps the first sighting); different content is the fold's
+				// "conflicting content" error. Nil is the fold's
+				// "unmarshalable message" refusal — refused here too.
+				encoded := marshalFoldMessage(turn)
+				if encoded == nil || !bytes.Equal(row.Message, encoded) {
+					return nil, nil, nil, false
+				}
+				continue
+			}
+			encoded := marshalFoldMessage(turn)
+			if encoded == nil {
+				return nil, nil, nil, false
+			}
+			rows[turn.AttentionID] = SidecarPendingAttention{AttentionID: turn.AttentionID, Message: JSONMessage(encoded)}
+			order = append(order, turn.AttentionID)
 		}
-		message, err := json.Marshal(turn.Message)
-		if err != nil {
-			continue
+		if r := turn.AttentionResolution; r != nil {
+			// The fold admits a resolution only as a resolution turn whose
+			// pointer names the attention.
+			if turn.Kind != schema.TurnAttentionResolution || turn.AttentionID != "" || r.AttentionID == "" {
+				return nil, nil, nil, false
+			}
+			row, sighted := rows[r.AttentionID]
+			if !sighted {
+				// "Resolved before it was appended" — order matters to the
+				// fold, so it matters here.
+				return nil, nil, nil, false
+			}
+			if r.Disposition != "consumed" && r.Disposition != "discarded" {
+				return nil, nil, nil, false
+			}
+			if r.Disposition == "discarded" && r.ResumeGeneration != 0 {
+				return nil, nil, nil, false
+			}
+			if row.Resolution != "" {
+				// An identical re-resolution is the fold's no-op; anything
+				// else is its "conflicting resolutions" error.
+				if row.Resolution != r.Disposition || row.ResumeGeneration != r.ResumeGeneration {
+					return nil, nil, nil, false
+				}
+				continue
+			}
+			if r.ResumeGeneration != 0 {
+				if other, claimed := generations[r.ResumeGeneration]; claimed && other != r.AttentionID {
+					return nil, nil, nil, false
+				}
+				generations[r.ResumeGeneration] = r.AttentionID
+			}
+			row.Resolution = r.Disposition
+			row.ResumeGeneration = r.ResumeGeneration
+			rows[r.AttentionID] = row
 		}
-		pending = append(pending, SidecarPendingAttention{
-			AttentionID: turn.AttentionID,
-			Message:     JSONMessage(message),
-		})
+	}
+	pending = make([]SidecarPendingAttention, 0, len(order))
+	for _, id := range order {
+		pending = append(pending, rows[id])
 	}
 	return pending, commits, mutations, true
+}
+
+// marshalFoldMessage encodes a steering turn's message for the fold
+// snapshot, or nil when it cannot be encoded — a message the seeded fold
+// could not reconstruct is a state the snapshot must refuse, not carry.
+func marshalFoldMessage(turn schema.Turn) []byte {
+	message, err := json.Marshal(turn.Message)
+	if err != nil {
+		return nil
+	}
+	return message
 }
 
 // resumeWindowed validates a sidecar against the opened file and, on
@@ -1121,6 +1221,14 @@ func resumeWindowed(f *os.File, info os.FileInfo, sidecar ResumeSidecar, expecte
 	// Boundary cross-check: the suffix's first entry must follow the
 	// sidecar's boundary seq. A lower seq means the offset is not where the
 	// sidecar says the prefix ends.
+	//
+	// A stale anchor pointing at an OLDER checkpoint than the file's last
+	// (a later compaction's anchor write failed, or commits landed after it)
+	// passes every gate here by design: the suffix it decodes is a SUPERSET
+	// of ResumeHistory's window — extra pre-last-checkpoint entries the file
+	// legitimately holds, every downstream invariant intact. The failure
+	// direction of a stale anchor is a slower resume, never a wrong one,
+	// which is why nothing here detects it.
 	if len(entries) > 0 && entries[0].Seq <= sidecar.BoundarySeq {
 		_ = f.Close()
 		return ResumeView{}, nil, false

--- a/agent/transcript/transcript.go
+++ b/agent/transcript/transcript.go
@@ -623,7 +623,14 @@ func (w *Writer) append(turn schema.Turn, forceSync bool) error {
 		w.lastCheckpointStart = startOffset
 		w.checkpointPrefixSeq = w.lastAppendedSeq
 		w.checkpointPrefixCount = w.sidecarEntryCount
-		w.checkpointFailureFloor = w.failures.Count()
+		// The absent floor is -1, not 0: a nil counter has measured nothing,
+		// and "zero failures over the prefix" from a producer that never
+		// counted is the false all-clear the -1 sentinel exists to prevent
+		// (the same convention FailureFloor documents).
+		w.checkpointFailureFloor = -1
+		if w.failures != nil {
+			w.checkpointFailureFloor = w.failures.Count()
+		}
 	}
 	// The entry just written carried seq w.seq-1 (Entry.Seq is assigned
 	// before the increment above).

--- a/agent/transcript/transcript.go
+++ b/agent/transcript/transcript.go
@@ -901,14 +901,6 @@ func byteOffsetOfEntry(f *os.File, entryIndex int) (int64, error) {
 // and the resume's own full read (the fallback the seeded fold's caller
 // holds) remains the authority for anything the fold would have caught.
 func foldSnapshotForSidecar(entries []Entry) (pending []SidecarPendingAttention, commits []SidecarDeliveryCommit, mutations map[string]string) {
-	// The message content lives on the attention's steering turn; the sidecar
-	// re-marshals it from the decoded entry.
-	byAttention := map[string]Entry{}
-	for i := range entries {
-		if id := entries[i].Turn.AttentionID; id != "" {
-			byAttention[id] = entries[i]
-		}
-	}
 	pending = nil
 	commits = nil
 	mutations = map[string]string{}
@@ -920,13 +912,9 @@ func foldSnapshotForSidecar(entries []Entry) (pending []SidecarPendingAttention,
 		for _, commit := range turn.DelegateDeliveryCommits {
 			commits = append(commits, SidecarDeliveryCommit{DeliveryID: commit.DeliveryID, ToolCallID: commit.ToolCallID})
 		}
-		if turn.AttentionID == "" {
-			continue
-		}
-		// A pending attention is one whose steering turn exists with no
-		// resolution anywhere in the file.
 	}
-	// Resolution pass: an attention is pending only if unresolved.
+	// Resolution pass: an attention is pending only if its steering turn
+	// exists with no resolution anywhere in the file.
 	resolved := map[string]bool{}
 	for i := range entries {
 		if r := entries[i].Turn.AttentionResolution; r != nil {

--- a/agent/transcript/transcript.go
+++ b/agent/transcript/transcript.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -236,9 +237,45 @@ type Writer struct {
 	lastSync time.Time
 
 	// sidecarEntryCount counts entries appended so far, seeded by
-	// TrackSidecarEntryCount at resume (prefix + suffix) or zero for a fresh
-	// writer, and advanced by every append. Guarded by mu.
+	// the resume constructors (prefix + suffix for a windowed read, the
+	// whole list for a full scan, zero for a fresh writer) and advanced by
+	// every append. WriteSidecarFromWriter reports it as the sidecar's
+	// EntryCount. Guarded by mu.
 	sidecarEntryCount int
+
+	// lastCheckpointStart is the byte offset where the most recently appended
+	// CHECKPOINT/SUMMARY entry BEGINS, or -1 before one exists. It is the
+	// writer-side mirror of the resume scan's lastCheckpointOffset: the resume
+	// window starts AT the checkpoint entry (ResumeHistory returns
+	// [checkpoint, ...rest]), so a sidecar written at compaction must point
+	// at that entry's start, not at the append position after it.
+	// checkpointPrefixSeq and checkpointPrefixCount record, at the moment
+	// that entry was appended, the facts the sidecar's prefix half needs:
+	// the seq of the last entry BEFORE the checkpoint and the count of those
+	// entries — the same prefix-relative facts the post-full-scan anchor
+	// derives. Guarded by mu; -1/-0 mean "no anchor yet" (count 0 is only
+	// valid with seq -1: a checkpoint-first transcript has no prefix to skip,
+	// and the scan anchor refuses that case).
+	lastCheckpointStart   int64
+	checkpointPrefixSeq   int
+	checkpointPrefixCount int
+	// lastAppendedSeq is the seq of the most recently appended entry (-1
+	// before any): the checkpoint capture reads it to learn the LAST PREFIX
+	// entry's seq — the boundary record the sidecar cross-checks the suffix's
+	// first entry against. Guarded by mu.
+	lastAppendedSeq int
+	// checkpointFailureFloor is the writer's failure count at the moment the
+	// checkpoint was appended — the floor over the prefix entries, the same
+	// figure the post-full-scan anchor derives by counting the prefix.
+	checkpointFailureFloor int
+
+	// writePos is the writer's byte position at the end of the last line it
+	// wrote — the seek-end the append path would otherwise have to ask the
+	// file for. Seeding it from the constructors' scans avoids a Seek per
+	// append (which would also shift the fault-injection op indices the
+	// fault tests count on) and keeps lastCheckpointStart's captured entry
+	// starts exact. Guarded by mu.
+	writePos int64
 
 	// failures counts the session's failed tool calls as they are written, for
 	// the live figure a running session reports. Nil until TrackFailures
@@ -374,7 +411,14 @@ func newWriterFS(fs afero.Fs, path string, header Header, sync bool) (*Writer, e
 		}
 	}
 
-	return &Writer{fs: fs, file: f, lastSync: time.Now(), header: header}, nil
+	return &Writer{fs: fs, file: f, lastSync: time.Now(), header: header, lastCheckpointStart: -1, lastAppendedSeq: -1, writePos: int64(len(data)) + 1}, nil
+}
+
+// isCheckpointTurn reports whether a turn defines a compaction boundary —
+// the kinds ResumeHistory restarts live history from. The sidecar's offset
+// keys at the START of the entry carrying such a turn.
+func isCheckpointTurn(turn schema.Turn) bool {
+	return turn.Kind == schema.TurnCheckpoint || turn.Kind == schema.TurnSummary
 }
 
 // Header returns the transcript's validated header: the header this writer
@@ -436,13 +480,16 @@ func (w *Writer) EstablishDurability() error {
 	return nil
 }
 
-// WriteSidecarFromWriter writes the resume sidecar for this writer's file at
-// its CURRENT append position: the prefix is everything durably appended so
-// far. It is the compaction and clean-shutdown anchor. floor facts (entry
-// count, max seq, failure floor) come from the writer's own running state;
-// the caller supplies the fold snapshots it can vouch for, with complete
-// reporting whether they cover every prefix entry. Best-effort: a failure is
-// returned but must never block the calling session operation.
+// WriteSidecarFromWriter writes the resume sidecar for this writer's file,
+// anchoring at the START of the last appended CHECKPOINT/SUMMARY entry — the
+// same boundary the post-full-scan anchor uses, so both anchors define the
+// identical resume window: the suffix a windowed resume decodes is
+// [checkpoint, ...rest], exactly ResumeHistory's window. The prefix is
+// everything before that entry. It is the compaction anchor. Floor facts
+// (entry count, max seq, failure floor) come from the writer's own running
+// state; the caller supplies the fold snapshots it can vouch for, with
+// complete reporting whether they cover every prefix entry. Best-effort: a
+// failure is returned but must never block the calling session operation.
 func (w *Writer) WriteSidecarFromWriter(path string, pending []SidecarPendingAttention, commits []SidecarDeliveryCommit, mutations map[string]string, complete bool) error {
 	if w == nil || w.file == nil {
 		return errors.New("transcript writer is nil")
@@ -466,40 +513,37 @@ func (w *Writer) WriteSidecarFromWriter(path string, pending []SidecarPendingAtt
 		w.dirty = false
 		w.lastSync = time.Now()
 	}
-	offset, err := w.file.Seek(0, io.SeekEnd)
+	if w.lastCheckpointStart < 0 {
+		return errors.New("transcript has no checkpoint to anchor the sidecar at")
+	}
+	offset := w.lastCheckpointStart
+	if w.checkpointPrefixCount == 0 || w.checkpointPrefixSeq < 0 {
+		// A checkpoint-first transcript: nothing before the boundary to skip.
+		// The post-full-scan anchor refuses the same case.
+		return errors.New("transcript has no prefix before the checkpoint to anchor")
+	}
+	current, err := w.file.Stat()
 	if err != nil {
-		return fmt.Errorf("seek transcript end for sidecar: %w", err)
-	}
-	if offset <= 0 {
-		return errors.New("transcript has no prefix to anchor")
-	}
-	floor := -1
-	if w.failures != nil {
-		floor = w.failures.Count()
+		return fmt.Errorf("stat transcript after sync for sidecar: %w", err)
 	}
 	sidecar := ResumeSidecar{
 		Version:                 resumeSidecarVersion,
 		TranscriptFormatVersion: FormatVersion,
 		SessionID:               w.header.SessionID,
-		TranscriptSize:          offset,
-		ValidBytes:              offset,
+		TranscriptSize:          current.Size(),
+		ValidBytes:              current.Size(),
 		Offset:                  offset,
-		MaxSeq:                  w.seq - 1,
-		EntryCount:              w.sidecarEntryCount,
-		FailureFloor:            floor,
+		MaxSeq:                  w.checkpointPrefixSeq,
+		EntryCount:              w.checkpointPrefixCount,
+		PrefixTurnCount:         -1, // not computable without the prefix entries
+		FailureFloor:            w.checkpointFailureFloor,
 		FileIdentity:            sidecarFileIdentity(info),
 		ModTimeUnixNS:           info.ModTime().UnixNano(),
-		BoundarySeq:             w.seq - 1,
+		BoundarySeq:             w.checkpointPrefixSeq,
 		SnapshotsComplete:       complete,
 		PendingAttention:        pending,
 		DeliveryCommits:         commits,
 		ClientMutationTurns:     mutations,
-	}
-	if sidecar.EntryCount < 0 || sidecar.MaxSeq < 0 {
-		// The writer never learned its starting count (a plain OpenWriter
-		// that only counted seqs); it cannot vouch for the entry count the
-		// turn-id projection needs.
-		return errors.New("transcript writer cannot vouch for prefix entry count")
 	}
 	sidecar.FirstAnchor, sidecar.TailAnchor = sidecarAnchors(w.file, offset)
 	if sidecar.FirstAnchor.Length <= 0 || sidecar.TailAnchor.Length <= 0 {
@@ -507,12 +551,6 @@ func (w *Writer) WriteSidecarFromWriter(path string, pending []SidecarPendingAtt
 	}
 	return WriteSidecar(path, sidecar)
 }
-
-// sidecarEntryCount is the writer's count of entries appended so far: seeded
-// by the resume constructors (prefix + suffix for a windowed read, the whole
-// list for a full scan, zero for a fresh writer) and advanced by append.
-// WriteSidecarFromWriter reports it as the sidecar's EntryCount. Guarded by
-// mu.
 
 func (w *Writer) append(turn schema.Turn, forceSync bool) error {
 	if w == nil || w.closed.Load() {
@@ -546,6 +584,9 @@ func (w *Writer) append(turn schema.Turn, forceSync bool) error {
 		if err != nil {
 			return fmt.Errorf("seek transcript append start: %w", err)
 		}
+		w.writePos = startOffset
+	} else {
+		startOffset = w.writePos
 	}
 
 	previousDirty := w.dirty
@@ -573,11 +614,26 @@ func (w *Writer) append(turn schema.Turn, forceSync bool) error {
 	}
 
 	w.seq++
+	if isCheckpointTurn(turn) {
+		// The prefix facts are the state BEFORE this checkpoint entry:
+		// sidecarEntryCount and seq have not yet counted it, so capturing here
+		// (before the increment below) records exactly the entries the
+		// sidecar's prefix covers — the same facts the post-full-scan anchor
+		// derives as len(entries[:checkpointIdx]) and prefix[n-1].Seq.
+		w.lastCheckpointStart = startOffset
+		w.checkpointPrefixSeq = w.lastAppendedSeq
+		w.checkpointPrefixCount = w.sidecarEntryCount
+		w.checkpointFailureFloor = w.failures.Count()
+	}
+	// The entry just written carried seq w.seq-1 (Entry.Seq is assigned
+	// before the increment above).
+	w.lastAppendedSeq = w.seq - 1
 	w.sidecarEntryCount++
 	// Counted only once the entry is on its way to the file and no rollback can
 	// take it back: the figure is a statement about the transcript, so it moves
 	// for exactly the entries a later reader of that transcript would see.
 	w.failures.Observe(turn)
+	w.writePos = startOffset + int64(len(data)) + 1
 	return nil
 }
 
@@ -700,6 +756,12 @@ type ResumeView struct {
 	// Entries. Entry i of Entries has global 1-based position
 	// PrefixEntryCount + i + 1 — the position its turn id is minted from.
 	PrefixEntryCount int
+	// PrefixTurnCount is the sidecar's count of turn positions the full
+	// AppWire projection holds below Entries (-1 when the anchor did not
+	// compute it — the compaction anchor cannot without the prefix entries).
+	// A caller arming windowed turn paging needs it; without it the only
+	// honest fallback is the full projection.
+	PrefixTurnCount int
 	// SidecarUsed reports whether the windowed read validated a sidecar.
 	// False means the full scan ran (including the fallback paths).
 	SidecarUsed bool
@@ -791,6 +853,12 @@ func writeSidecarAfterFullScan(path string, f *os.File, info os.FileInfo, scan s
 		return
 	}
 	prefix := entries[:checkpointIdx]
+	if len(prefix) == 0 {
+		// A checkpoint-first transcript (nothing before the checkpoint)
+		// has no prefix to skip either.
+		return
+	}
+	boundarySeq := prefix[len(prefix)-1].Seq
 	sidecar := ResumeSidecar{
 		Version:                 resumeSidecarVersion,
 		TranscriptFormatVersion: FormatVersion,
@@ -798,23 +866,20 @@ func writeSidecarAfterFullScan(path string, f *os.File, info os.FileInfo, scan s
 		TranscriptSize:          current.Size(),
 		ValidBytes:              current.Size(),
 		Offset:                  offset,
-		MaxSeq:                  -1,
+		MaxSeq:                  boundarySeq,
 		EntryCount:              len(prefix),
-		FailureFloor:            -1,
+		PrefixTurnCount:         -1,
 		FileIdentity:            sidecarFileIdentity(info),
 		ModTimeUnixNS:           current.ModTime().UnixNano(),
-		BoundarySeq:             0,
+		BoundarySeq:             boundarySeq,
 		SnapshotsComplete:       true,
 	}
-	if n := len(prefix); n > 0 {
-		sidecar.MaxSeq = prefix[n-1].Seq
-		sidecar.BoundarySeq = prefix[n-1].Seq
-	}
-	if sidecar.EntryCount == 0 || sidecar.MaxSeq < 0 {
-		// A checkpoint-first transcript (nothing before the checkpoint)
-		// has no prefix to skip either.
-		return
-	}
+	// The exact prefix-turn count: the prelude rule is header-derived (a
+	// non-empty SystemPrompt projects one), and the per-kind emission rule is
+	// the same one the projection applies per entry. Counted over the prefix
+	// because a windowed turn snapshot pages in the full projection's cursor
+	// space, and only this anchor holds the prefix entries to count.
+	sidecar.PrefixTurnCount = prefixTurnCount(scan.header, prefix)
 	// The failure floor is computed exactly the way a TrackFailures seed
 	// would count the PREFIX entries — same counter, same rule — so the
 	// windowed resume that draws from it reports the figure the full scan
@@ -827,8 +892,15 @@ func writeSidecarAfterFullScan(path string, f *os.File, info os.FileInfo, scan s
 	// Fold snapshots over the WHOLE entry list (the fold is a file-wide
 	// invariant; the boundary only decides which entries the next resume
 	// re-decodes): pending attentions with content, delivery commits, and
-	// the client-mutation identity index.
-	sidecar.PendingAttention, sidecar.DeliveryCommits, sidecar.ClientMutationTurns = foldSnapshotForSidecar(entries)
+	// the client-mutation identity index. A fold inconsistency is reported,
+	// not swallowed: the anchor then writes no sidecar at all, so the resume
+	// falls back to the full scan instead of trusting an empty snapshot a
+	// broken fold produced.
+	pending, commits, mutations, foldOK := foldSnapshotForSidecar(entries)
+	if !foldOK {
+		return
+	}
+	sidecar.PendingAttention, sidecar.DeliveryCommits, sidecar.ClientMutationTurns = pending, commits, mutations
 	sidecar.FirstAnchor, sidecar.TailAnchor = sidecarAnchors(f, offset)
 	if sidecar.FirstAnchor.Length <= 0 || sidecar.TailAnchor.Length <= 0 {
 		return
@@ -837,32 +909,79 @@ func writeSidecarAfterFullScan(path string, f *os.File, info os.FileInfo, scan s
 }
 
 // lastCheckpointEntry returns the index of the first entry of the last
-// TurnCheckpoint/TUMMARY turn, or -1 when none exists. The FIRST entry of
+// TurnCheckpoint/TurnSummary turn, or -1 when none exists. The FIRST entry of
 // the checkpoint matters because the offset must point AT it: ResumeHistory
 // returns [checkpoint, ...subsequent], so the suffix must include the
 // checkpoint entry itself.
 func lastCheckpointEntry(entries []Entry) int {
 	last := -1
 	for i := range entries {
-		if kind := entries[i].Turn.Kind; kind == schema.TurnCheckpoint || kind == schema.TurnSummary {
+		if isCheckpointTurn(entries[i].Turn) {
 			last = i
 		}
 	}
 	return last
 }
 
+// prefixTurnCount counts the turn positions a full AppWire projection holds
+// over one entry list plus its header: the prelude (a non-empty
+// SystemPrompt projects one) plus one position per entry whose turn projects
+// at least one thread item. It mirrors internal/apptranscript's rules
+// (PreludeTurn, ProjectTurn) because this package cannot import that one;
+// the differential test that keeps the two honest is
+// TestWindowedSnapshotMatchesFullProjectionDifferential, which fails if the
+// count and the projection disagree over the same entries.
+func prefixTurnCount(header Header, entries []Entry) int {
+	count := 0
+	if strings.TrimSpace(header.SystemPrompt) != "" {
+		count++
+	}
+	for i := range entries {
+		if projectsThreadItems(entries[i].Turn) {
+			count++
+		}
+	}
+	return count
+}
+
+// projectsThreadItems reports whether the AppWire projector emits at least
+// one thread item for a turn — whether the entry carrying it occupies a turn
+// position. The kind rules restated from ProjectTurn: the marker kinds emit
+// nothing when they carry no text (a checkpoint with empty text renders no
+// row), while every conversation kind (user, assistant, steering, tool
+// results, failure, resolution) always projects.
+func projectsThreadItems(turn schema.Turn) bool {
+	switch turn.Kind {
+	case schema.TurnCheckpoint, schema.TurnSummary, schema.TurnModelSwitch, schema.TurnEnvironment, schema.TurnHookCompleted:
+		if strings.TrimSpace(turn.Message.Text()) != "" {
+			return true
+		}
+		return turn.Kind == schema.TurnHookCompleted && turn.Hook != nil
+	default:
+		return true
+	}
+}
+
 // foldSnapshotForSidecar computes the fold snapshots a full-scan anchor can
 // vouch for: the delegate-attention fold over every entry, projected into
-// the sidecar's snapshot types. A fold failure means the transcript's
-// attention records are inconsistent — the sidecar then reports NO pending
-// attentions and NO commits (nil), which the seeded fold treats as
-// "nothing straddling"; that under-reports only transient wake behavior,
-// and the resume's own full read (the fallback the seeded fold's caller
-// holds) remains the authority for anything the fold would have caught.
-func foldSnapshotForSidecar(entries []Entry) (pending []SidecarPendingAttention, commits []SidecarDeliveryCommit, mutations map[string]string) {
+// the sidecar's snapshot types. ok is false when the transcript's attention
+// records are inconsistent (a resolution for an attention that never
+// appended, or a resolution naming no attention) — the caller must not write
+// a sidecar claiming complete snapshots over such a file, because the seeded
+// fold would silently reconstruct an empty state where the full read errors.
+// The structural checks here are the ones the full entry list can judge
+// without importing the agent's fold: an unresolvable resolution, or a
+// resolution that names no attention, is inconsistent on their face.
+func foldSnapshotForSidecar(entries []Entry) (pending []SidecarPendingAttention, commits []SidecarDeliveryCommit, mutations map[string]string, ok bool) {
 	pending = nil
 	commits = nil
 	mutations = map[string]string{}
+	appended := map[string]bool{}
+	for i := range entries {
+		if id := entries[i].Turn.AttentionID; id != "" {
+			appended[id] = true
+		}
+	}
 	for i := range entries {
 		turn := entries[i].Turn
 		if turn.ClientMutationID != "" {
@@ -877,6 +996,12 @@ func foldSnapshotForSidecar(entries []Entry) (pending []SidecarPendingAttention,
 	resolved := map[string]bool{}
 	for i := range entries {
 		if r := entries[i].Turn.AttentionResolution; r != nil {
+			if r.AttentionID == "" || !appended[r.AttentionID] {
+				// A resolution whose attention never appended is the fold's
+				// "resolved before it was appended" error — visible here
+				// without the fold itself.
+				return nil, nil, nil, false
+			}
 			resolved[r.AttentionID] = true
 		}
 	}
@@ -894,7 +1019,7 @@ func foldSnapshotForSidecar(entries []Entry) (pending []SidecarPendingAttention,
 			Message:     JSONMessage(message),
 		})
 	}
-	return pending, commits, mutations
+	return pending, commits, mutations, true
 }
 
 // resumeWindowed validates a sidecar against the opened file and, on
@@ -997,10 +1122,11 @@ func resumeWindowed(f *os.File, info os.FileInfo, sidecar ResumeSidecar, expecte
 		_ = f.Close()
 		return ResumeView{}, nil, false
 	}
-	writer := &Writer{fs: afero.NewOsFs(), file: f, seq: nextSeq, lastSync: time.Now(), header: header, sidecarEntryCount: sidecar.EntryCount + len(entries)}
+	writer := &Writer{fs: afero.NewOsFs(), file: f, seq: nextSeq, lastSync: time.Now(), header: header, sidecarEntryCount: sidecar.EntryCount + len(entries), lastCheckpointStart: -1, lastAppendedSeq: maxSeq, writePos: sidecar.Offset + validLen}
 	view := ResumeView{
 		Entries:          entries,
 		PrefixEntryCount: sidecar.EntryCount,
+		PrefixTurnCount:  sidecar.PrefixTurnCount,
 		SidecarUsed:      true,
 		Sidecar:          sidecar,
 	}
@@ -1097,7 +1223,7 @@ func resumeWriter(fs afero.Fs, f afero.File, expectedSessionID string) (*Writer,
 		if entry.Seq > maxSeq {
 			maxSeq = entry.Seq
 		}
-		if kind := entry.Turn.Kind; kind == schema.TurnCheckpoint || kind == schema.TurnSummary {
+		if isCheckpointTurn(entry.Turn) {
 			lastCheckpointOffset = entryStartOffset
 		}
 	}
@@ -1129,13 +1255,15 @@ func resumeWriter(fs afero.Fs, f afero.File, expectedSessionID string) (*Writer,
 		return nil, scanResult{}, fmt.Errorf("seek to end of transcript: %w", err)
 	}
 
-	return &Writer{fs: fs, file: f, seq: nextSeq, lastSync: time.Now(), header: header, sidecarEntryCount: len(entries)}, scanResult{entries: entries, lastCheckpointOffset: lastCheckpointOffset}, nil
+	return &Writer{fs: fs, file: f, seq: nextSeq, lastSync: time.Now(), header: header, sidecarEntryCount: len(entries), lastCheckpointStart: lastCheckpointOffset, lastAppendedSeq: maxSeq, writePos: validLen}, scanResult{entries: entries, lastCheckpointOffset: lastCheckpointOffset, header: header}, nil
 }
 
 // scanResult is what a full resume scan learned besides the entries: the
 // byte offset of the last checkpoint entry, recorded during the scan so the
-// opportunistic sidecar write needs no second file pass.
+// opportunistic sidecar write needs no second file pass, and the validated
+// header (for the prelude rule the prefix-turn count applies).
 type scanResult struct {
 	entries              []Entry
 	lastCheckpointOffset int64
+	header               Header
 }

--- a/agent/transcript/transcript.go
+++ b/agent/transcript/transcript.go
@@ -780,10 +780,16 @@ func RefreshSidecarFromFullScan(path, expectedSessionID string) error {
 		return fmt.Errorf("scan transcript for sidecar refresh: %w", err)
 	}
 	// The anchor write needs the file open (its second stat and its anchors
-	// read through it); the writer owns it, so close only after.
-	writeSidecarAfterFullScan(path, f, info, scan, expectedSessionID)
+	// read through it); the writer owns it, so close only after. The write
+	// error is returned, not swallowed: a sidecar that cannot be written is
+	// the one failure a caller can report (the resume itself already
+	// succeeded, and the next one simply falls back to the full scan).
+	writeErr := writeSidecarAfterFullScan(path, f, info, scan, expectedSessionID)
 	if err := writer.Close(); err != nil {
 		return fmt.Errorf("close transcript after sidecar refresh: %w", err)
+	}
+	if writeErr != nil {
+		return fmt.Errorf("write sidecar after full scan: %w", writeErr)
 	}
 	return nil
 }
@@ -865,8 +871,10 @@ func OpenWriterForResume(path, expectedSessionID string) (*Writer, ResumeView, e
 	// the last checkpoint's offset), so the sidecar it writes carries
 	// complete snapshots and the NEXT resume of this session can be
 	// windowed. A write failure is non-fatal — this resume already
-	// succeeded, and the next one simply falls back to another full scan.
-	writeSidecarAfterFullScan(path, f, info, scan, expectedSessionID)
+	// succeeded, and the next one simply falls back to another full scan —
+	// so the error is deliberately discarded here (the refresh path reports
+	// its own; this one has no caller to tell).
+	_ = writeSidecarAfterFullScan(path, f, info, scan, expectedSessionID)
 	return writer, ResumeView{Entries: scan.entries, PrefixEntryCount: 0, SidecarUsed: false}, nil
 }
 
@@ -887,31 +895,31 @@ func OpenWriterForResume(path, expectedSessionID string) (*Writer, ResumeView, e
 // ordinal is 0 (the anchor is written by the transcript package, which has
 // no fork knowledge; a fork child's file never validates this sidecar
 // anyway, because its file identity differs from the parent's).
-func writeSidecarAfterFullScan(path string, f *os.File, info os.FileInfo, scan scanResult, expectedSessionID string) {
+func writeSidecarAfterFullScan(path string, f *os.File, info os.FileInfo, scan scanResult, expectedSessionID string) error {
 	entries := scan.entries
 	// The sidecar must only be written over a file whose current state this
 	// scan vouches for. A partial tail was truncated by resumeWriter; stat
 	// again so TranscriptSize reflects the post-truncation size.
 	current, err := f.Stat()
 	if err != nil {
-		return
+		return nil
 	}
 	// The scan recorded where the last checkpoint entry starts; no second
 	// file pass. No checkpoint means every entry is live history — no
 	// sidecar.
 	offset := scan.lastCheckpointOffset
 	if offset <= 0 {
-		return
+		return nil
 	}
 	checkpointIdx := lastCheckpointEntry(entries)
 	if checkpointIdx < 0 {
-		return
+		return nil
 	}
 	prefix := entries[:checkpointIdx]
 	if len(prefix) == 0 {
 		// A checkpoint-first transcript (nothing before the checkpoint)
 		// has no prefix to skip either.
-		return
+		return nil
 	}
 	boundarySeq := prefix[len(prefix)-1].Seq
 	// The exact prefix-turn count: the prelude rule is header-derived (a
@@ -953,14 +961,17 @@ func writeSidecarAfterFullScan(path string, f *os.File, info os.FileInfo, scan s
 	// broken fold produced.
 	pending, commits, mutations, foldOK := foldSnapshotForSidecar(entries)
 	if !foldOK {
-		return
+		return nil
 	}
 	sidecar.PendingAttention, sidecar.DeliveryCommits, sidecar.ClientMutationTurns = pending, commits, mutations
 	sidecar.FirstAnchor, sidecar.TailAnchor = sidecarAnchors(f, offset)
 	if sidecar.FirstAnchor.Length <= 0 || sidecar.TailAnchor.Length <= 0 {
-		return
+		return nil
 	}
-	_ = WriteSidecar(path, sidecar)
+	if err := WriteSidecar(path, sidecar); err != nil {
+		return err
+	}
+	return nil
 }
 
 // lastCheckpointEntry returns the index of the first entry of the last
@@ -1001,17 +1012,41 @@ func prefixTurnCount(header Header, entries []Entry) int {
 
 // projectsThreadItems reports whether the AppWire projector emits at least
 // one thread item for a turn — whether the entry carrying it occupies a turn
-// position. The kind rules restated from ProjectTurn: the marker kinds emit
-// nothing when they carry no text (a checkpoint with empty text renders no
-// row), while every conversation kind (user, assistant, steering, tool
-// results, failure, resolution) always projects.
+// position. The kind rules restated from ProjectTurn, exactly as it emits:
+//
+//   - TurnAttentionResolution and TurnSystem have no case in ProjectTurn's
+//     switch — both fall to its default and emit nothing, so a prefix holding
+//     either occupies no position (every delegate session writes resolution
+//     turns; counting them inflated the count and duplicated turns at the
+//     hub paging seam).
+//   - The marker kinds (checkpoint, summary, model switch, environment, hook)
+//     emit nothing without text; a hook-completed turn can also render from
+//     its Hook announcement alone.
+//   - Tool and tool-results turns emit one item per tool RESULT part except
+//     communicate results, which the projector skips — so a turn whose parts
+//     are all communicate results (or that has none) emits nothing.
+//   - Every other conversation kind (user, steering, assistant, failure)
+//     always projects at least one item.
 func projectsThreadItems(turn schema.Turn) bool {
 	switch turn.Kind {
-	case schema.TurnCheckpoint, schema.TurnSummary, schema.TurnModelSwitch, schema.TurnEnvironment, schema.TurnHookCompleted:
-		if strings.TrimSpace(turn.Message.Text()) != "" {
-			return true
+	case schema.TurnAttentionResolution, schema.TurnSystem:
+		return false
+	case schema.TurnCheckpoint, schema.TurnSummary, schema.TurnModelSwitch, schema.TurnEnvironment:
+		return strings.TrimSpace(turn.Message.Text()) != ""
+	case schema.TurnHookCompleted:
+		return strings.TrimSpace(turn.Message.Text()) != "" || turn.Hook != nil
+	case schema.TurnTool, schema.TurnToolResults:
+		for _, part := range turn.Message.Content {
+			if part.Kind != llm.ContentToolResult || part.ToolResult == nil {
+				continue
+			}
+			// A communicate result is skipped by the projector; every other
+			// tool result emits an item.
+			if part.ToolResult.Name != "communicate" {
+				return true
+			}
 		}
-		return turn.Kind == schema.TurnHookCompleted && turn.Hook != nil
+		return false
 	default:
 		return true
 	}

--- a/agent/transcript/transcript.go
+++ b/agent/transcript/transcript.go
@@ -499,6 +499,10 @@ func (w *Writer) WriteSidecarFromWriter(path string, pending []SidecarPendingAtt
 	if w.closed.Load() {
 		return errors.New("transcript writer is closed")
 	}
+	// One stat covers both facts (identity and size): fsync changes neither
+	// the size nor the mtime, so the post-sync re-stat the first draft carried
+	// was redundant — unlike writeSidecarAfterFullScan, whose second stat IS
+	// load-bearing (the scan truncated a crash tail between them).
 	info, err := w.file.Stat()
 	if err != nil {
 		return fmt.Errorf("stat transcript for sidecar: %w", err)
@@ -522,16 +526,12 @@ func (w *Writer) WriteSidecarFromWriter(path string, pending []SidecarPendingAtt
 		// The post-full-scan anchor refuses the same case.
 		return errors.New("transcript has no prefix before the checkpoint to anchor")
 	}
-	current, err := w.file.Stat()
-	if err != nil {
-		return fmt.Errorf("stat transcript after sync for sidecar: %w", err)
-	}
 	sidecar := ResumeSidecar{
 		Version:                 resumeSidecarVersion,
 		TranscriptFormatVersion: FormatVersion,
 		SessionID:               w.header.SessionID,
-		TranscriptSize:          current.Size(),
-		ValidBytes:              current.Size(),
+		TranscriptSize:          info.Size(),
+		ValidBytes:              info.Size(),
 		Offset:                  offset,
 		MaxSeq:                  w.checkpointPrefixSeq,
 		EntryCount:              w.checkpointPrefixCount,

--- a/agent/transcript/transcript.go
+++ b/agent/transcript/transcript.go
@@ -659,6 +659,16 @@ func (w *Writer) appendFailureLocked(operation string, err error, startOffset in
 }
 
 func (w *Writer) rollbackAppendLocked(startOffset int64) error {
+	// The in-memory position moves with the file: a rollback that truncates
+	// must not leave writePos (or a checkpoint anchor captured inside the
+	// rolled-back range) claiming bytes the file no longer holds.
+	if w.lastCheckpointStart >= startOffset {
+		w.lastCheckpointStart = -1
+		w.checkpointPrefixSeq = 0
+		w.checkpointPrefixCount = 0
+		w.checkpointFailureFloor = 0
+	}
+	w.writePos = startOffset
 	truncateErr := w.file.Truncate(startOffset)
 	_, seekErr := w.file.Seek(0, io.SeekEnd)
 	if truncateErr != nil && seekErr != nil {

--- a/agent/transcript/transcript.go
+++ b/agent/transcript/transcript.go
@@ -660,7 +660,8 @@ func OpenWriter(path string) (*Writer, error) {
 // OpenWriterForSession opens a transcript for resume, requiring its header to
 // belong to expectedSessionID and returning the validated semantic entries.
 func OpenWriterForSession(path, expectedSessionID string) (*Writer, []Entry, error) {
-	return openWriter(path, expectedSessionID)
+	w, scan, err := openWriter(path, expectedSessionID)
+	return w, scan.entries, err
 }
 
 // OpenWriterForSessionWithFS is the filesystem-injecting form of
@@ -672,13 +673,14 @@ func OpenWriterForSessionWithFS(fs afero.Fs, path, expectedSessionID string) (*W
 	if err != nil {
 		return nil, nil, fmt.Errorf("open transcript for resume: %w", err)
 	}
-	return resumeWriter(fs, f, expectedSessionID)
+	w, scan, err := resumeWriter(fs, f, expectedSessionID)
+	return w, scan.entries, err
 }
 
-func openWriter(path, expectedSessionID string) (*Writer, []Entry, error) {
+func openWriter(path, expectedSessionID string) (*Writer, scanResult, error) {
 	f, err := openTranscriptAppendFile(path)
 	if err != nil {
-		return nil, nil, fmt.Errorf("open transcript for resume: %w", err)
+		return nil, scanResult{}, fmt.Errorf("open transcript for resume: %w", err)
 	}
 	return resumeWriter(afero.NewOsFs(), f, expectedSessionID)
 }
@@ -738,18 +740,17 @@ func OpenWriterForResume(path, expectedSessionID string) (*Writer, ResumeView, e
 			return nil, ResumeView{}, fmt.Errorf("open transcript for resume: %w", err)
 		}
 	}
-	writer, entries, err := resumeWriter(afero.NewOsFs(), f, expectedSessionID)
+	writer, scan, err := resumeWriter(afero.NewOsFs(), f, expectedSessionID)
 	if err != nil {
 		return nil, ResumeView{}, err
 	}
-	// Opportunistic anchor (the third anchor point): the full scan decoded
-	// every entry, so the sidecar it writes carries complete snapshots and
-	// the NEXT resume of this session can be windowed. The offset choice is
-	// the whole-file boundary: the next resume decodes only turns appended
-	// after this one. A write failure is non-fatal — this resume already
+	// Opportunistic anchor: the full scan decoded every entry (and recorded
+	// the last checkpoint's offset), so the sidecar it writes carries
+	// complete snapshots and the NEXT resume of this session can be
+	// windowed. A write failure is non-fatal — this resume already
 	// succeeded, and the next one simply falls back to another full scan.
-	writeSidecarAfterFullScan(path, f, info, entries, expectedSessionID)
-	return writer, ResumeView{Entries: entries, PrefixEntryCount: 0, SidecarUsed: false}, nil
+	writeSidecarAfterFullScan(path, f, info, scan, expectedSessionID)
+	return writer, ResumeView{Entries: scan.entries, PrefixEntryCount: 0, SidecarUsed: false}, nil
 }
 
 // writeSidecarAfterFullScan writes the opportunistic resume sidecar from a
@@ -769,7 +770,8 @@ func OpenWriterForResume(path, expectedSessionID string) (*Writer, ResumeView, e
 // ordinal is 0 (the anchor is written by the transcript package, which has
 // no fork knowledge; a fork child's file never validates this sidecar
 // anyway, because its file identity differs from the parent's).
-func writeSidecarAfterFullScan(path string, f *os.File, info os.FileInfo, entries []Entry, expectedSessionID string) {
+func writeSidecarAfterFullScan(path string, f *os.File, info os.FileInfo, scan scanResult, expectedSessionID string) {
+	entries := scan.entries
 	// The sidecar must only be written over a file whose current state this
 	// scan vouches for. A partial tail was truncated by resumeWriter; stat
 	// again so TranscriptSize reflects the post-truncation size.
@@ -777,21 +779,15 @@ func writeSidecarAfterFullScan(path string, f *os.File, info os.FileInfo, entrie
 	if err != nil {
 		return
 	}
-	// Find the last checkpoint entry and the byte offset where it starts.
-	// entries holds every decoded entry in order; the byte offsets are
-	// re-derived by re-scanning line lengths (the full scan did not retain
-	// them), which is a second pass over an already-decoded list — cheap
-	// compared to the decode itself.
+	// The scan recorded where the last checkpoint entry starts; no second
+	// file pass. No checkpoint means every entry is live history — no
+	// sidecar.
+	offset := scan.lastCheckpointOffset
+	if offset <= 0 {
+		return
+	}
 	checkpointIdx := lastCheckpointEntry(entries)
 	if checkpointIdx < 0 {
-		// No checkpoint: every entry is live history. No sidecar.
-		return
-	}
-	offset, err := byteOffsetOfEntry(f, checkpointIdx)
-	if err != nil {
-		return
-	}
-	if offset <= 0 {
 		return
 	}
 	prefix := entries[:checkpointIdx]
@@ -853,43 +849,6 @@ func lastCheckpointEntry(entries []Entry) int {
 		}
 	}
 	return last
-}
-
-// byteOffsetOfEntry returns the byte offset where the entry at index starts.
-// It re-walks the file's lines counting entry records (skipping the header
-// and blank lines), matching the full scan's ordering exactly.
-func byteOffsetOfEntry(f *os.File, entryIndex int) (int64, error) {
-	if _, err := f.Seek(0, io.SeekStart); err != nil {
-		return 0, err
-	}
-	reader := bufio.NewReaderSize(f, 64*1024)
-	var offset int64
-	seen := 0
-	headerRead := false
-	for {
-		line, complete, bytesRead, err := ReadLine(reader, transcriptJSONLMaxLineBytes)
-		if err != nil || !complete {
-			return 0, fmt.Errorf("rescan transcript for sidecar offset: %v", err)
-		}
-		line = bytes.TrimSpace(line)
-		if len(line) == 0 {
-			offset += bytesRead
-			continue
-		}
-		if !headerRead {
-			headerRead = true
-			offset += bytesRead
-			continue
-		}
-		if seen == entryIndex {
-			// Seek back to the start so the writer's later SeekEnd (and any
-			// caller holding read position expectations) is unaffected.
-			_, _ = f.Seek(0, io.SeekEnd)
-			return offset, nil
-		}
-		seen++
-		offset += bytesRead
-	}
 }
 
 // foldSnapshotForSidecar computes the fold snapshots a full-scan anchor can
@@ -1077,11 +1036,15 @@ func openWriterFS(fs afero.Fs, path string) (*Writer, error) {
 	return w, err
 }
 
-func resumeWriter(fs afero.Fs, f afero.File, expectedSessionID string) (*Writer, []Entry, error) {
+func resumeWriter(fs afero.Fs, f afero.File, expectedSessionID string) (*Writer, scanResult, error) {
 	// Validate complete v2 records while finding the next sequence and the byte
 	// boundary before any crash tail. The shared framer drains an arbitrarily
 	// large unterminated tail without retaining the file in memory.
 	maxSeq := -1
+	// lastCheckpointOffset is the byte offset of the last CHECKPOINT/SUMMARY
+	// entry observed during the scan — the boundary the opportunistic sidecar
+	// anchors at, recorded here so it needs no second file pass.
+	lastCheckpointOffset := int64(-1)
 	// entries is non-nil even for a header-only transcript: the
 	// delegate-attention fold keys on nilness to decide whether it can fold
 	// in memory or must re-read the file.
@@ -1095,13 +1058,18 @@ func resumeWriter(fs afero.Fs, f afero.File, expectedSessionID string) (*Writer,
 		line, complete, bytesRead, readErr := ReadLine(reader, transcriptJSONLMaxLineBytes)
 		if readErr != nil {
 			_ = f.Close()
-			return nil, nil, fmt.Errorf("read transcript for resume: %w", readErr)
+			return nil, scanResult{}, fmt.Errorf("read transcript for resume: %w", readErr)
 		}
 		if !complete {
 			hasPartialTail = bytesRead > 0
 			break
 		}
 		validLen += bytesRead
+		// The byte offset where the entry this iteration decodes STARTS:
+		// validLen already counted the line's bytes, so subtracting this
+		// line's length gives its start. Recorded for checkpoint-kind entries
+		// so the opportunistic sidecar write needs no second file pass.
+		entryStartOffset := validLen - int64(bytesRead)
 		line = bytes.TrimSpace(line)
 		if len(line) == 0 {
 			continue
@@ -1111,11 +1079,11 @@ func resumeWriter(fs afero.Fs, f afero.File, expectedSessionID string) (*Writer,
 			header, err = DecodeHeader(line)
 			if err != nil {
 				_ = f.Close()
-				return nil, nil, fmt.Errorf("parse transcript header: %w", err)
+				return nil, scanResult{}, fmt.Errorf("parse transcript header: %w", err)
 			}
 			if expectedSessionID != "" && header.SessionID != expectedSessionID {
 				_ = f.Close()
-				return nil, nil, fmt.Errorf("transcript header session ID %q does not match requested session ID %q", header.SessionID, expectedSessionID)
+				return nil, scanResult{}, fmt.Errorf("transcript header session ID %q does not match requested session ID %q", header.SessionID, expectedSessionID)
 			}
 			headerRead = true
 			continue
@@ -1123,25 +1091,28 @@ func resumeWriter(fs afero.Fs, f afero.File, expectedSessionID string) (*Writer,
 		entry, err := DecodeEntry(line)
 		if err != nil {
 			_ = f.Close()
-			return nil, nil, fmt.Errorf("parse transcript entry: %w", err)
+			return nil, scanResult{}, fmt.Errorf("parse transcript entry: %w", err)
 		}
 		entries = append(entries, entry)
 		if entry.Seq > maxSeq {
 			maxSeq = entry.Seq
 		}
+		if kind := entry.Turn.Kind; kind == schema.TurnCheckpoint || kind == schema.TurnSummary {
+			lastCheckpointOffset = entryStartOffset
+		}
 	}
 	if !headerRead {
 		_ = f.Close()
 		if hasPartialTail && validLen == 0 {
-			return nil, nil, errors.New("transcript has no complete lines")
+			return nil, scanResult{}, errors.New("transcript has no complete lines")
 		}
-		return nil, nil, fmt.Errorf("%w: missing transcript header", ErrUnsupportedFormat)
+		return nil, scanResult{}, fmt.Errorf("%w: missing transcript header", ErrUnsupportedFormat)
 	}
 
 	if hasPartialTail {
 		if err := f.Truncate(validLen); err != nil {
 			_ = f.Close() // cleanup on error path; the truncate error is what matters
-			return nil, nil, fmt.Errorf("truncate partial line: %w", err)
+			return nil, scanResult{}, fmt.Errorf("truncate partial line: %w", err)
 		}
 	}
 
@@ -1155,8 +1126,16 @@ func resumeWriter(fs afero.Fs, f afero.File, expectedSessionID string) (*Writer,
 	// Seek to end for subsequent appends.
 	if _, err := f.Seek(0, io.SeekEnd); err != nil {
 		_ = f.Close() // cleanup on error path; the seek error is what matters
-		return nil, nil, fmt.Errorf("seek to end of transcript: %w", err)
+		return nil, scanResult{}, fmt.Errorf("seek to end of transcript: %w", err)
 	}
 
-	return &Writer{fs: fs, file: f, seq: nextSeq, lastSync: time.Now(), header: header, sidecarEntryCount: len(entries)}, entries, nil
+	return &Writer{fs: fs, file: f, seq: nextSeq, lastSync: time.Now(), header: header, sidecarEntryCount: len(entries)}, scanResult{entries: entries, lastCheckpointOffset: lastCheckpointOffset}, nil
+}
+
+// scanResult is what a full resume scan learned besides the entries: the
+// byte offset of the last checkpoint entry, recorded during the scan so the
+// opportunistic sidecar write needs no second file pass.
+type scanResult struct {
+	entries              []Entry
+	lastCheckpointOffset int64
 }

--- a/agent/transcript/transcript.go
+++ b/agent/transcript/transcript.go
@@ -235,6 +235,11 @@ type Writer struct {
 	dirty    bool
 	lastSync time.Time
 
+	// sidecarEntryCount counts entries appended so far, seeded by
+	// TrackSidecarEntryCount at resume (prefix + suffix) or zero for a fresh
+	// writer, and advanced by every append. Guarded by mu.
+	sidecarEntryCount int
+
 	// failures counts the session's failed tool calls as they are written, for
 	// the live figure a running session reports. Nil until TrackFailures
 	// installs it, and a nil counter reports ABSENT rather than zero: a writer
@@ -270,6 +275,30 @@ func (w *Writer) TrackFailures(seed []Entry, fromEntryOrdinal int) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.failures = counter
+}
+
+// TrackFailuresSeeded is TrackFailures for a windowed resume: the counter
+// starts at the sidecar's prefix floor (positioned at prefixEntryCount so
+// suffix ordinals continue the sequence) and then observes the suffix
+// entries the full seed would have counted. A floor below zero — the
+// sidecar's "not computed" sentinel — is an error the caller must answer by
+// falling back to the full scan; a silent zero would report a session-wide
+// clean the transcript cannot vouch for.
+func (w *Writer) TrackFailuresSeeded(suffix []Entry, floor, prefixEntryCount, fromEntryOrdinal int) error {
+	if w == nil {
+		return nil
+	}
+	counter, err := NewFailureCounterSeeded(floor, prefixEntryCount, fromEntryOrdinal)
+	if err != nil {
+		return err
+	}
+	for _, entry := range suffix {
+		counter.Observe(entry.Turn)
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.failures = counter
+	return nil
 }
 
 // FailedToolCalls is how many of the session's tool calls have failed so far,
@@ -407,6 +436,84 @@ func (w *Writer) EstablishDurability() error {
 	return nil
 }
 
+// WriteSidecarFromWriter writes the resume sidecar for this writer's file at
+// its CURRENT append position: the prefix is everything durably appended so
+// far. It is the compaction and clean-shutdown anchor. floor facts (entry
+// count, max seq, failure floor) come from the writer's own running state;
+// the caller supplies the fold snapshots it can vouch for, with complete
+// reporting whether they cover every prefix entry. Best-effort: a failure is
+// returned but must never block the calling session operation.
+func (w *Writer) WriteSidecarFromWriter(path string, pending []SidecarPendingAttention, commits []SidecarDeliveryCommit, mutations map[string]string, complete bool) error {
+	if w == nil || w.file == nil {
+		return errors.New("transcript writer is nil")
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed.Load() {
+		return errors.New("transcript writer is closed")
+	}
+	info, err := w.file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat transcript for sidecar: %w", err)
+	}
+	// Seek-end reports the append position; a dirty tail is not yet durable,
+	// so establish the barrier first — the sidecar must never vouch for
+	// bytes the file may still lose.
+	if w.dirty {
+		if err := w.file.Sync(); err != nil {
+			return fmt.Errorf("sync transcript for sidecar: %w", err)
+		}
+		w.dirty = false
+		w.lastSync = time.Now()
+	}
+	offset, err := w.file.Seek(0, io.SeekEnd)
+	if err != nil {
+		return fmt.Errorf("seek transcript end for sidecar: %w", err)
+	}
+	if offset <= 0 {
+		return errors.New("transcript has no prefix to anchor")
+	}
+	floor := -1
+	if w.failures != nil {
+		floor = w.failures.Count()
+	}
+	sidecar := ResumeSidecar{
+		Version:                 resumeSidecarVersion,
+		TranscriptFormatVersion: FormatVersion,
+		SessionID:               w.header.SessionID,
+		TranscriptSize:          offset,
+		ValidBytes:              offset,
+		Offset:                  offset,
+		MaxSeq:                  w.seq - 1,
+		EntryCount:              w.sidecarEntryCount,
+		FailureFloor:            floor,
+		FileIdentity:            sidecarFileIdentity(info),
+		ModTimeUnixNS:           info.ModTime().UnixNano(),
+		BoundarySeq:             w.seq - 1,
+		SnapshotsComplete:       complete,
+		PendingAttention:        pending,
+		DeliveryCommits:         commits,
+		ClientMutationTurns:     mutations,
+	}
+	if sidecar.EntryCount < 0 || sidecar.MaxSeq < 0 {
+		// The writer never learned its starting count (a plain OpenWriter
+		// that only counted seqs); it cannot vouch for the entry count the
+		// turn-id projection needs.
+		return errors.New("transcript writer cannot vouch for prefix entry count")
+	}
+	sidecar.FirstAnchor, sidecar.TailAnchor = sidecarAnchors(w.file, offset)
+	if sidecar.FirstAnchor.Length <= 0 || sidecar.TailAnchor.Length <= 0 {
+		return errors.New("transcript anchors are empty")
+	}
+	return WriteSidecar(path, sidecar)
+}
+
+// sidecarEntryCount is the writer's count of entries appended so far: seeded
+// by the resume constructors (prefix + suffix for a windowed read, the whole
+// list for a full scan, zero for a fresh writer) and advanced by append.
+// WriteSidecarFromWriter reports it as the sidecar's EntryCount. Guarded by
+// mu.
+
 func (w *Writer) append(turn schema.Turn, forceSync bool) error {
 	if w == nil || w.closed.Load() {
 		return nil
@@ -466,6 +573,7 @@ func (w *Writer) append(turn schema.Turn, forceSync bool) error {
 	}
 
 	w.seq++
+	w.sidecarEntryCount++
 	// Counted only once the entry is on its way to the file and no rollback can
 	// take it back: the figure is a statement about the transcript, so it moves
 	// for exactly the entries a later reader of that transcript would see.
@@ -575,6 +683,400 @@ func openWriter(path, expectedSessionID string) (*Writer, []Entry, error) {
 	return resumeWriter(afero.NewOsFs(), f, expectedSessionID)
 }
 
+// ResumeView is what a windowed resume learned about the transcript prefix it
+// did not decode. It is populated only by OpenWriterForResume; the full-scan
+// fallback also fills it (with PrefixEntryCount covering the whole file and
+// empty snapshots), so the restore path has one shape regardless of which
+// read actually ran.
+type ResumeView struct {
+	// Entries are the decoded entries of the suffix. When a sidecar was
+	// used this is only the entries after the validated offset; otherwise it
+	// is every entry in the file (identical to the legacy
+	// OpenWriterForSession return).
+	Entries []Entry
+	// PrefixEntryCount is the number of entries before the first entry of
+	// Entries. Entry i of Entries has global 1-based position
+	// PrefixEntryCount + i + 1 — the position its turn id is minted from.
+	PrefixEntryCount int
+	// SidecarUsed reports whether the windowed read validated a sidecar.
+	// False means the full scan ran (including the fallback paths).
+	SidecarUsed bool
+	// Sidecar carries the validated prefix snapshot. It is the zero value
+	// when SidecarUsed is false; restore consults its fold snapshots only
+	// when it needs them, and falls back to a full scan when a needed
+	// snapshot is incomplete.
+	Sidecar ResumeSidecar
+}
+
+// OpenWriterForResume opens a transcript for resume the way
+// OpenWriterForSession does, but windowed: when a validated sidecar exists,
+// only the entries after its offset are decoded. Every mismatch — missing,
+// corrupt, stale, truncated, or boundary-violating sidecar — falls back to
+// the same full scan OpenWriterForSession performs, never an error.
+//
+// expectedSessionID is validated against the transcript header on BOTH
+// paths: the windowed read still decodes the header line itself.
+func OpenWriterForResume(path, expectedSessionID string) (*Writer, ResumeView, error) {
+	f, err := openTranscriptAppendFile(path)
+	if err != nil {
+		return nil, ResumeView{}, fmt.Errorf("open transcript for resume: %w", err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, ResumeView{}, fmt.Errorf("stat transcript for resume: %w", err)
+	}
+	if sidecar, ok := ReadSidecar(path); ok {
+		if view, writer, ok := resumeWindowed(f, info, sidecar, expectedSessionID); ok {
+			return writer, view, nil
+		}
+		// Validation failed after the file was read past its header; reopen
+		// for the full scan so the shared reader starts at byte zero.
+		_ = f.Close()
+		f, err = openTranscriptAppendFile(path)
+		if err != nil {
+			return nil, ResumeView{}, fmt.Errorf("open transcript for resume: %w", err)
+		}
+	}
+	writer, entries, err := resumeWriter(afero.NewOsFs(), f, expectedSessionID)
+	if err != nil {
+		return nil, ResumeView{}, err
+	}
+	// Opportunistic anchor (the third anchor point): the full scan decoded
+	// every entry, so the sidecar it writes carries complete snapshots and
+	// the NEXT resume of this session can be windowed. The offset choice is
+	// the whole-file boundary: the next resume decodes only turns appended
+	// after this one. A write failure is non-fatal — this resume already
+	// succeeded, and the next one simply falls back to another full scan.
+	writeSidecarAfterFullScan(path, f, info, entries, expectedSessionID)
+	return writer, ResumeView{Entries: entries, PrefixEntryCount: 0, SidecarUsed: false}, nil
+}
+
+// writeSidecarAfterFullScan writes the opportunistic resume sidecar from a
+// completed full scan. It is best-effort: every failure is swallowed because
+// the sidecar is an optimization, never a correctness dependency.
+//
+// The offset is CHECKPOINT-RELATIVE: it points at the start of the last
+// checkpoint entry (TurnCheckpoint/TurnSummary), so the suffix a windowed
+// resume decodes is exactly ResumeHistory's window ([last checkpoint,
+// ...rest]) — the live history every resume consumer derives from. A
+// transcript with no checkpoint gets NO sidecar: all of its entries are live
+// history, so a windowed read would skip exactly the entries restore needs.
+//
+// The snapshots ARE complete for this anchor — the full scan decoded every
+// entry — so they are computed here: the attention fold, delivery commits,
+// client-mutation turns, and the divergence-bounded failure floor. fromEntry
+// ordinal is 0 (the anchor is written by the transcript package, which has
+// no fork knowledge; a fork child's file never validates this sidecar
+// anyway, because its file identity differs from the parent's).
+func writeSidecarAfterFullScan(path string, f *os.File, info os.FileInfo, entries []Entry, expectedSessionID string) {
+	// The sidecar must only be written over a file whose current state this
+	// scan vouches for. A partial tail was truncated by resumeWriter; stat
+	// again so TranscriptSize reflects the post-truncation size.
+	current, err := f.Stat()
+	if err != nil {
+		return
+	}
+	// Find the last checkpoint entry and the byte offset where it starts.
+	// entries holds every decoded entry in order; the byte offsets are
+	// re-derived by re-scanning line lengths (the full scan did not retain
+	// them), which is a second pass over an already-decoded list — cheap
+	// compared to the decode itself.
+	checkpointIdx := lastCheckpointEntry(entries)
+	if checkpointIdx < 0 {
+		// No checkpoint: every entry is live history. No sidecar.
+		return
+	}
+	offset, err := byteOffsetOfEntry(f, checkpointIdx)
+	if err != nil {
+		return
+	}
+	if offset <= 0 {
+		return
+	}
+	prefix := entries[:checkpointIdx]
+	sidecar := ResumeSidecar{
+		Version:                 resumeSidecarVersion,
+		TranscriptFormatVersion: FormatVersion,
+		SessionID:               expectedSessionID,
+		TranscriptSize:          current.Size(),
+		ValidBytes:              current.Size(),
+		Offset:                  offset,
+		MaxSeq:                  -1,
+		EntryCount:              len(prefix),
+		FailureFloor:            -1,
+		FileIdentity:            sidecarFileIdentity(info),
+		ModTimeUnixNS:           current.ModTime().UnixNano(),
+		BoundarySeq:             0,
+		SnapshotsComplete:       true,
+	}
+	if n := len(prefix); n > 0 {
+		sidecar.MaxSeq = prefix[n-1].Seq
+		sidecar.BoundarySeq = prefix[n-1].Seq
+	}
+	if sidecar.EntryCount == 0 || sidecar.MaxSeq < 0 {
+		// A checkpoint-first transcript (nothing before the checkpoint)
+		// has no prefix to skip either.
+		return
+	}
+	// The failure floor is computed exactly the way a TrackFailures seed
+	// would count the PREFIX entries — same counter, same rule — so the
+	// windowed resume that draws from it reports the figure the full scan
+	// would have seeded.
+	counter := NewFailureCounter(0)
+	for _, entry := range prefix {
+		counter.Observe(entry.Turn)
+	}
+	sidecar.FailureFloor = counter.Count()
+	// Fold snapshots over the WHOLE entry list (the fold is a file-wide
+	// invariant; the boundary only decides which entries the next resume
+	// re-decodes): pending attentions with content, delivery commits, and
+	// the client-mutation identity index.
+	sidecar.PendingAttention, sidecar.DeliveryCommits, sidecar.ClientMutationTurns = foldSnapshotForSidecar(entries)
+	sidecar.FirstAnchor, sidecar.TailAnchor = sidecarAnchors(f, offset)
+	if sidecar.FirstAnchor.Length <= 0 || sidecar.TailAnchor.Length <= 0 {
+		return
+	}
+	_ = WriteSidecar(path, sidecar)
+}
+
+// lastCheckpointEntry returns the index of the first entry of the last
+// TurnCheckpoint/TUMMARY turn, or -1 when none exists. The FIRST entry of
+// the checkpoint matters because the offset must point AT it: ResumeHistory
+// returns [checkpoint, ...subsequent], so the suffix must include the
+// checkpoint entry itself.
+func lastCheckpointEntry(entries []Entry) int {
+	last := -1
+	for i := range entries {
+		if kind := entries[i].Turn.Kind; kind == schema.TurnCheckpoint || kind == schema.TurnSummary {
+			last = i
+		}
+	}
+	return last
+}
+
+// byteOffsetOfEntry returns the byte offset where the entry at index starts.
+// It re-walks the file's lines counting entry records (skipping the header
+// and blank lines), matching the full scan's ordering exactly.
+func byteOffsetOfEntry(f *os.File, entryIndex int) (int64, error) {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return 0, err
+	}
+	reader := bufio.NewReaderSize(f, 64*1024)
+	var offset int64
+	seen := 0
+	headerRead := false
+	for {
+		line, complete, bytesRead, err := ReadLine(reader, transcriptJSONLMaxLineBytes)
+		if err != nil || !complete {
+			return 0, fmt.Errorf("rescan transcript for sidecar offset: %v", err)
+		}
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			offset += bytesRead
+			continue
+		}
+		if !headerRead {
+			headerRead = true
+			offset += bytesRead
+			continue
+		}
+		if seen == entryIndex {
+			// Seek back to the start so the writer's later SeekEnd (and any
+			// caller holding read position expectations) is unaffected.
+			_, _ = f.Seek(0, io.SeekEnd)
+			return offset, nil
+		}
+		seen++
+		offset += bytesRead
+	}
+}
+
+// foldSnapshotForSidecar computes the fold snapshots a full-scan anchor can
+// vouch for: the delegate-attention fold over every entry, projected into
+// the sidecar's snapshot types. A fold failure means the transcript's
+// attention records are inconsistent — the sidecar then reports NO pending
+// attentions and NO commits (nil), which the seeded fold treats as
+// "nothing straddling"; that under-reports only transient wake behavior,
+// and the resume's own full read (the fallback the seeded fold's caller
+// holds) remains the authority for anything the fold would have caught.
+func foldSnapshotForSidecar(entries []Entry) (pending []SidecarPendingAttention, commits []SidecarDeliveryCommit, mutations map[string]string) {
+	// The message content lives on the attention's steering turn; the sidecar
+	// re-marshals it from the decoded entry.
+	byAttention := map[string]Entry{}
+	for i := range entries {
+		if id := entries[i].Turn.AttentionID; id != "" {
+			byAttention[id] = entries[i]
+		}
+	}
+	pending = nil
+	commits = nil
+	mutations = map[string]string{}
+	for i := range entries {
+		turn := entries[i].Turn
+		if turn.ClientMutationID != "" {
+			mutations[turn.ClientMutationID] = turn.StableTurnID
+		}
+		for _, commit := range turn.DelegateDeliveryCommits {
+			commits = append(commits, SidecarDeliveryCommit{DeliveryID: commit.DeliveryID, ToolCallID: commit.ToolCallID})
+		}
+		if turn.AttentionID == "" {
+			continue
+		}
+		// A pending attention is one whose steering turn exists with no
+		// resolution anywhere in the file.
+	}
+	// Resolution pass: an attention is pending only if unresolved.
+	resolved := map[string]bool{}
+	for i := range entries {
+		if r := entries[i].Turn.AttentionResolution; r != nil {
+			resolved[r.AttentionID] = true
+		}
+	}
+	for i := range entries {
+		turn := entries[i].Turn
+		if turn.AttentionID == "" || resolved[turn.AttentionID] {
+			continue
+		}
+		message, err := json.Marshal(turn.Message)
+		if err != nil {
+			continue
+		}
+		pending = append(pending, SidecarPendingAttention{
+			AttentionID: turn.AttentionID,
+			Message:     JSONMessage(message),
+		})
+	}
+	return pending, commits, mutations
+}
+
+// resumeWindowed validates a sidecar against the opened file and, on
+// success, decodes the header line plus the suffix after the offset. It
+// reports ok=false (with the file closed) on any mismatch; the caller falls
+// back to the full scan.
+func resumeWindowed(f *os.File, info os.FileInfo, sidecar ResumeSidecar, expectedSessionID string) (ResumeView, *Writer, bool) {
+	// Structural bounds first: the sidecar must describe this session, a
+	// prefix inside the valid bytes of a file at least as large.
+	if sidecar.SessionID != "" && sidecar.SessionID != expectedSessionID {
+		_ = f.Close()
+		return ResumeView{}, nil, false
+	}
+	if sidecar.Offset <= 0 || sidecar.Offset > sidecar.ValidBytes || sidecar.ValidBytes > sidecar.TranscriptSize || sidecar.TranscriptSize > info.Size() {
+		_ = f.Close()
+		return ResumeView{}, nil, false
+	}
+	// Append-only identity: the same file incarnation (fork children and
+	// replaced files fail here), grown or equal. This mirrors
+	// usableTurnIndex's sameFile/appendOnly gate.
+	sameFile := sidecar.FileIdentity != "" && sidecar.FileIdentity == sidecarFileIdentity(info)
+	if !sameFile {
+		_ = f.Close()
+		return ResumeView{}, nil, false
+	}
+	// Anchors bind the prefix bytes: first window of the file, and the
+	// window ending at the offset.
+	if !sidecarAnchorsMatch(f, sidecar.FirstAnchor, sidecar.TailAnchor) {
+		_ = f.Close()
+		return ResumeView{}, nil, false
+	}
+
+	// Decode the header line: identity validation must still run on the
+	// windowed path.
+	header, err := readHeaderAt(f)
+	if err != nil {
+		_ = f.Close()
+		return ResumeView{}, nil, false
+	}
+	if expectedSessionID != "" && header.SessionID != expectedSessionID {
+		_ = f.Close()
+		return ResumeView{}, nil, false
+	}
+
+	// Read the suffix from the offset. validSuffixEnd bounds the crash tail:
+	// bytes beyond the last complete line are drained and truncated, exactly
+	// like the full scan.
+	reader := io.NewSectionReader(f, sidecar.Offset, info.Size()-sidecar.Offset)
+	buffered := bufio.NewReaderSize(reader, 64*1024)
+	entries := make([]Entry, 0)
+	maxSeq := sidecar.MaxSeq
+	var validLen int64
+	hasPartialTail := false
+	for {
+		line, complete, bytesRead, readErr := ReadLine(buffered, transcriptJSONLMaxLineBytes)
+		if readErr != nil {
+			_ = f.Close()
+			return ResumeView{}, nil, false
+		}
+		if !complete {
+			hasPartialTail = bytesRead > 0
+			break
+		}
+		validLen += bytesRead
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		entry, err := DecodeEntry(line)
+		if err != nil {
+			// A corrupt suffix entry is a transcript the full scan must
+			// judge (its wf7e posture is the full reader's decision, not the
+			// windowed reader's).
+			_ = f.Close()
+			return ResumeView{}, nil, false
+		}
+		entries = append(entries, entry)
+		if entry.Seq > maxSeq {
+			maxSeq = entry.Seq
+		}
+	}
+	// Boundary cross-check: the suffix's first entry must follow the
+	// sidecar's boundary seq. A lower seq means the offset is not where the
+	// sidecar says the prefix ends.
+	if len(entries) > 0 && entries[0].Seq <= sidecar.BoundarySeq {
+		_ = f.Close()
+		return ResumeView{}, nil, false
+	}
+	if hasPartialTail {
+		if err := f.Truncate(sidecar.Offset + validLen); err != nil {
+			_ = f.Close()
+			return ResumeView{}, nil, false
+		}
+	}
+	nextSeq := 0
+	if maxSeq >= 0 {
+		nextSeq = maxSeq + 1
+	}
+	if _, err := f.Seek(0, io.SeekEnd); err != nil {
+		_ = f.Close()
+		return ResumeView{}, nil, false
+	}
+	writer := &Writer{fs: afero.NewOsFs(), file: f, seq: nextSeq, lastSync: time.Now(), header: header, sidecarEntryCount: sidecar.EntryCount + len(entries)}
+	view := ResumeView{
+		Entries:          entries,
+		PrefixEntryCount: sidecar.EntryCount,
+		SidecarUsed:      true,
+		Sidecar:          sidecar,
+	}
+	return view, writer, true
+}
+
+// readHeaderAt decodes the first line of the file without disturbing the
+// caller's read position for the suffix (it reads through a section reader).
+func readHeaderAt(f *os.File) (Header, error) {
+	reader := bufio.NewReaderSize(io.NewSectionReader(f, 0, defaultHeaderReadBytes), 64*1024)
+	line, complete, _, err := ReadLine(reader, transcriptJSONLMaxLineBytes)
+	if err != nil || !complete {
+		return Header{}, fmt.Errorf("read transcript header: %v", err)
+	}
+	line = bytes.TrimSpace(line)
+	return DecodeHeader(line)
+}
+
+// defaultHeaderReadBytes bounds the section the header is read from. The
+// header must be a single complete line; transcripts with larger headers
+// fail the line-size contract in ReadLine anyway.
+const defaultHeaderReadBytes = 1 << 20
+
 // openWriterFS is the filesystem-injecting seam used by tests and the
 // persistence fuzzer. Production uses openWriter so it can refuse symlinks at
 // the operating-system open boundary.
@@ -668,5 +1170,5 @@ func resumeWriter(fs afero.Fs, f afero.File, expectedSessionID string) (*Writer,
 		return nil, nil, fmt.Errorf("seek to end of transcript: %w", err)
 	}
 
-	return &Writer{fs: fs, file: f, seq: nextSeq, lastSync: time.Now(), header: header}, entries, nil
+	return &Writer{fs: fs, file: f, seq: nextSeq, lastSync: time.Now(), header: header, sidecarEntryCount: len(entries)}, entries, nil
 }

--- a/agent/transcript/transcript.go
+++ b/agent/transcript/transcript.go
@@ -876,6 +876,12 @@ func writeSidecarAfterFullScan(path string, f *os.File, info os.FileInfo, scan s
 		return
 	}
 	boundarySeq := prefix[len(prefix)-1].Seq
+	// The exact prefix-turn count: the prelude rule is header-derived (a
+	// non-empty SystemPrompt projects one), and the per-kind emission rule is
+	// the same one the projection applies per entry. Counted over the prefix
+	// because a windowed turn snapshot pages in the full projection's cursor
+	// space, and only this anchor holds the prefix entries to count.
+	turnsBelow := prefixTurnCount(scan.header, prefix)
 	sidecar := ResumeSidecar{
 		Version:                 resumeSidecarVersion,
 		TranscriptFormatVersion: FormatVersion,
@@ -885,18 +891,12 @@ func writeSidecarAfterFullScan(path string, f *os.File, info os.FileInfo, scan s
 		Offset:                  offset,
 		MaxSeq:                  boundarySeq,
 		EntryCount:              len(prefix),
-		PrefixTurnCount:         -1,
+		PrefixTurnCount:         turnsBelow,
 		FileIdentity:            sidecarFileIdentity(info),
 		ModTimeUnixNS:           current.ModTime().UnixNano(),
 		BoundarySeq:             boundarySeq,
 		SnapshotsComplete:       true,
 	}
-	// The exact prefix-turn count: the prelude rule is header-derived (a
-	// non-empty SystemPrompt projects one), and the per-kind emission rule is
-	// the same one the projection applies per entry. Counted over the prefix
-	// because a windowed turn snapshot pages in the full projection's cursor
-	// space, and only this anchor holds the prefix entries to count.
-	sidecar.PrefixTurnCount = prefixTurnCount(scan.header, prefix)
 	// The failure floor is computed exactly the way a TrackFailures seed
 	// would count the PREFIX entries — same counter, same rule — so the
 	// windowed resume that draws from it reports the figure the full scan

--- a/agent/transcript/transcript.go
+++ b/agent/transcript/transcript.go
@@ -1041,6 +1041,10 @@ func foldSnapshotForSidecar(entries []Entry) (pending []SidecarPendingAttention,
 	commits = nil
 	mutations = map[string]string{}
 	commitIDs := map[string]string{}
+	// The reverse of commitIDs (tool call → delivery), so the per-commit
+	// conflict check is a lookup instead of a scan over every prior commit —
+	// the scan made the snapshot quadratic over delivery-heavy transcripts.
+	commitToolCalls := map[string]string{}
 	for i := range entries {
 		turn := entries[i].Turn
 		if turn.ClientMutationID != "" {
@@ -1074,12 +1078,11 @@ func foldSnapshotForSidecar(entries []Entry) (pending []SidecarPendingAttention,
 					}
 					continue
 				}
-				for deliveryID, toolCallID := range commitIDs {
-					if toolCallID == commit.ToolCallID && deliveryID != commit.DeliveryID {
-						return nil, nil, nil, false
-					}
+				if other, claimed := commitToolCalls[commit.ToolCallID]; claimed && other != commit.DeliveryID {
+					return nil, nil, nil, false
 				}
 				commitIDs[commit.DeliveryID] = commit.ToolCallID
+				commitToolCalls[commit.ToolCallID] = commit.DeliveryID
 				commits = append(commits, SidecarDeliveryCommit{DeliveryID: commit.DeliveryID, ToolCallID: commit.ToolCallID})
 			}
 		}

--- a/agent/transcript/transcript.go
+++ b/agent/transcript/transcript.go
@@ -22,6 +22,7 @@ import (
 
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/agent/task"
+	"primeradiant.com/evener/llm"
 )
 
 // DefaultMaxLineBytes is the maximum transcript record payload. The trailing
@@ -1018,38 +1019,69 @@ func projectsThreadItems(turn schema.Turn) bool {
 
 // foldSnapshotForSidecar computes the fold snapshots a full-scan anchor can
 // vouch for: the delegate-attention fold over every entry, projected into
-// the sidecar's snapshot types. ok is false when the transcript's attention
-// records are inconsistent (a resolution for an attention that never
-// appended, a resolution naming no attention, or a resolution whose shape the
-// file fold would reject) — the caller must not write a sidecar claiming
-// complete snapshots over such a file, because the seeded fold would silently
-// reconstruct an empty state where the full read errors. The structural
-// checks here are the ones the full entry list can judge without importing
-// the agent's fold: an unresolvable resolution, or a resolution that names
-// no attention, is inconsistent on their face.
+// the sidecar's snapshot types. The agent's file fold is the authority; this
+// restates its rules rule-for-rule, in file order, because the agent imports
+// this package and the reverse edge would be a cycle. Every entry shape the
+// file fold rejects — a non-steering attention turn, a conflicting or
+// unmarshalable re-send, a resolution turn with no resolution, a resolution
+// before its append, an unknown disposition, a conflicting re-resolution, a
+// resume generation claimed twice, a delivery commit off a tool-results turn
+// or referencing an absent or conflicting tool call — is refused here too
+// (ok=false, nothing written), so the anchor never writes a snapshot the
+// seeded fold would accept over a file the full read errors on.
 //
-// The attention pass mirrors the agent's file fold rule for rule, in file
-// order, keyed on the attention ID rather than the entry: a re-sent steering
-// turn with identical content is a legal transcript (a second sighting adds
-// nothing), so the snapshot records the attention once, with its resolution
-// when one exists. Resolutions are carried, not dropped — a seeded fold that
-// sees an attention resolved in the prefix must report it resolved, exactly
-// as the file fold would. Every shape the file fold rejects (a non-steering
-// attention turn, a conflicting re-send, an unknown disposition, a
-// conflicting re-resolution, a resume generation claimed twice) is refused
-// here too, so the anchor never writes a snapshot the seeded fold would
-// accept over a file the full read errors on.
+// The attention rows key on the attention ID, not the entry: a re-sent
+// steering turn with identical content is a legal transcript (a second
+// sighting adds nothing), so the snapshot records the attention once —
+// first sighting's content, its resolution and resume generation carried
+// when one exists — with the ids in first-sighting order, matching the
+// fold's order slice.
 func foldSnapshotForSidecar(entries []Entry) (pending []SidecarPendingAttention, commits []SidecarDeliveryCommit, mutations map[string]string, ok bool) {
 	pending = nil
 	commits = nil
 	mutations = map[string]string{}
+	commitIDs := map[string]string{}
 	for i := range entries {
 		turn := entries[i].Turn
 		if turn.ClientMutationID != "" {
 			mutations[turn.ClientMutationID] = turn.StableTurnID
 		}
-		for _, commit := range turn.DelegateDeliveryCommits {
-			commits = append(commits, SidecarDeliveryCommit{DeliveryID: commit.DeliveryID, ToolCallID: commit.ToolCallID})
+		if len(turn.DelegateDeliveryCommits) > 0 {
+			// The fold's own rules for delivery commits, mirrored: commits ride
+			// only on tool-results turns, name both identities, reference a
+			// tool result the turn's message actually carries, and never
+			// conflict with a delivery or tool call claimed earlier in the
+			// file. A commit violating any of these is a file the full fold
+			// errors on — the snapshot must refuse it, not carry it.
+			if turn.Kind != schema.TurnToolResults {
+				return nil, nil, nil, false
+			}
+			resultIDs := map[string]bool{}
+			for _, part := range turn.Message.Content {
+				if part.Kind == llm.ContentToolResult && part.ToolResult != nil && part.ToolResult.ToolCallID != "" {
+					resultIDs[part.ToolResult.ToolCallID] = true
+				}
+			}
+			for _, commit := range turn.DelegateDeliveryCommits {
+				if commit.DeliveryID == "" || commit.ToolCallID == "" || !resultIDs[commit.ToolCallID] {
+					return nil, nil, nil, false
+				}
+				if _, seen := commitIDs[commit.DeliveryID]; seen {
+					// A delivery named twice: the fold accepts it only when
+					// the repeat names the same tool call.
+					if commitIDs[commit.DeliveryID] != commit.ToolCallID {
+						return nil, nil, nil, false
+					}
+					continue
+				}
+				for deliveryID, toolCallID := range commitIDs {
+					if toolCallID == commit.ToolCallID && deliveryID != commit.DeliveryID {
+						return nil, nil, nil, false
+					}
+				}
+				commitIDs[commit.DeliveryID] = commit.ToolCallID
+				commits = append(commits, SidecarDeliveryCommit{DeliveryID: commit.DeliveryID, ToolCallID: commit.ToolCallID})
+			}
 		}
 	}
 	// Attention pass, in file order: rows is the fold state at the end of the
@@ -1066,77 +1098,73 @@ func foldSnapshotForSidecar(entries []Entry) (pending []SidecarPendingAttention,
 			if turn.Kind != schema.TurnSteering || turn.AttentionResolution != nil {
 				return nil, nil, nil, false
 			}
+			// A message the seeded fold could not reconstruct is a state the
+			// snapshot must refuse, not carry.
+			encoded, err := json.Marshal(turn.Message)
+			if err != nil {
+				return nil, nil, nil, false
+			}
 			if row, sighted := rows[turn.AttentionID]; sighted {
 				// A re-send with identical content is a no-op (the fold
 				// keeps the first sighting); different content is the fold's
-				// "conflicting content" error. Nil is the fold's
-				// "unmarshalable message" refusal — refused here too.
-				encoded := marshalFoldMessage(turn)
-				if encoded == nil || !bytes.Equal(row.Message, encoded) {
+				// "conflicting content" error.
+				if !bytes.Equal(row.Message, encoded) {
 					return nil, nil, nil, false
 				}
 				continue
-			}
-			encoded := marshalFoldMessage(turn)
-			if encoded == nil {
-				return nil, nil, nil, false
 			}
 			rows[turn.AttentionID] = SidecarPendingAttention{AttentionID: turn.AttentionID, Message: JSONMessage(encoded)}
 			order = append(order, turn.AttentionID)
 		}
-		if r := turn.AttentionResolution; r != nil {
-			// The fold admits a resolution only as a resolution turn whose
-			// pointer names the attention.
-			if turn.Kind != schema.TurnAttentionResolution || turn.AttentionID != "" || r.AttentionID == "" {
+		r := turn.AttentionResolution
+		if r == nil {
+			// A resolution-kind turn with no resolution pointer is the fold's
+			// "attention resolution turn has no resolution" error.
+			if turn.Kind == schema.TurnAttentionResolution {
 				return nil, nil, nil, false
 			}
-			row, sighted := rows[r.AttentionID]
-			if !sighted {
-				// "Resolved before it was appended" — order matters to the
-				// fold, so it matters here.
-				return nil, nil, nil, false
-			}
-			if r.Disposition != "consumed" && r.Disposition != "discarded" {
-				return nil, nil, nil, false
-			}
-			if r.Disposition == "discarded" && r.ResumeGeneration != 0 {
-				return nil, nil, nil, false
-			}
-			if row.Resolution != "" {
-				// An identical re-resolution is the fold's no-op; anything
-				// else is its "conflicting resolutions" error.
-				if row.Resolution != r.Disposition || row.ResumeGeneration != r.ResumeGeneration {
-					return nil, nil, nil, false
-				}
-				continue
-			}
-			if r.ResumeGeneration != 0 {
-				if other, claimed := generations[r.ResumeGeneration]; claimed && other != r.AttentionID {
-					return nil, nil, nil, false
-				}
-				generations[r.ResumeGeneration] = r.AttentionID
-			}
-			row.Resolution = r.Disposition
-			row.ResumeGeneration = r.ResumeGeneration
-			rows[r.AttentionID] = row
+			continue
 		}
+		// The fold admits a resolution only as a resolution turn whose
+		// pointer names the attention.
+		if turn.Kind != schema.TurnAttentionResolution || turn.AttentionID != "" || r.AttentionID == "" {
+			return nil, nil, nil, false
+		}
+		row, sighted := rows[r.AttentionID]
+		if !sighted {
+			// "Resolved before it was appended" — order matters to the
+			// fold, so it matters here.
+			return nil, nil, nil, false
+		}
+		if r.Disposition != schema.AttentionDispositionConsumed && r.Disposition != schema.AttentionDispositionDiscarded {
+			return nil, nil, nil, false
+		}
+		if r.Disposition == schema.AttentionDispositionDiscarded && r.ResumeGeneration != 0 {
+			return nil, nil, nil, false
+		}
+		if row.Resolution != "" {
+			// An identical re-resolution is the fold's no-op; anything
+			// else is its "conflicting resolutions" error.
+			if row.Resolution != r.Disposition || row.ResumeGeneration != r.ResumeGeneration {
+				return nil, nil, nil, false
+			}
+			continue
+		}
+		if r.ResumeGeneration != 0 {
+			if other, claimed := generations[r.ResumeGeneration]; claimed && other != r.AttentionID {
+				return nil, nil, nil, false
+			}
+			generations[r.ResumeGeneration] = r.AttentionID
+		}
+		row.Resolution = r.Disposition
+		row.ResumeGeneration = r.ResumeGeneration
+		rows[r.AttentionID] = row
 	}
 	pending = make([]SidecarPendingAttention, 0, len(order))
 	for _, id := range order {
 		pending = append(pending, rows[id])
 	}
 	return pending, commits, mutations, true
-}
-
-// marshalFoldMessage encodes a steering turn's message for the fold
-// snapshot, or nil when it cannot be encoded — a message the seeded fold
-// could not reconstruct is a state the snapshot must refuse, not carry.
-func marshalFoldMessage(turn schema.Turn) []byte {
-	message, err := json.Marshal(turn.Message)
-	if err != nil {
-		return nil
-	}
-	return message
 }
 
 // resumeWindowed validates a sidecar against the opened file and, on

--- a/agent/transcript/writer_failures_test.go
+++ b/agent/transcript/writer_failures_test.go
@@ -129,3 +129,33 @@ func TestWriterDoesNotCountAnEntryThatFailedToLand(t *testing.T) {
 		t.Fatalf("FailedToolCalls() = %d, want 0: the entry never reached the transcript", count)
 	}
 }
+
+// TestSeededFloorRefusesADivergenceOrdinalInsideThePrefix pins the fork-child
+// rule on the windowed path: the sidecar's floor is one count over the whole
+// prefix computed WITHOUT the fork bound, so a fork child (whose inherited
+// parent prefix sits below DivergenceTurn) cannot tell which of those failures
+// were the parent's. The seeded constructor must refuse such a floor so the
+// caller falls back to its full-scan re-derivation (which applies the bound
+// entry by entry) instead of charging the parent's failures to the child.
+func TestSeededFloorRefusesADivergenceOrdinalInsideThePrefix(t *testing.T) {
+	// A 4-entry prefix with a divergence ordinal inside it (a fork child
+	// inheriting 3 parent entries and starting its own history at ordinal 2).
+	if _, err := NewFailureCounterSeeded(3, 4, 2); err == nil {
+		t.Fatal("seeded counter accepted a floor over a prefix the divergence ordinal cuts through")
+	}
+	// The non-fork shapes stay valid: divergence 0 (nothing inherited — the
+	// floor's whole range is the session's own) and divergence at or past the
+	// prefix (the bound does not cut the range the floor covers). Ordinal 1
+	// cuts a 4-entry prefix just as much as 2 does: only 0 leaves the range
+	// whole.
+	for _, from := range []int{0, 4, 9} {
+		if _, err := NewFailureCounterSeeded(3, 4, from); err != nil {
+			t.Fatalf("seeded counter refused a valid divergence ordinal %d: %v", from, err)
+		}
+	}
+	// Ordinal 1 is inside the prefix: it excludes entry 0 from the session's
+	// own span, and the precomputed floor cannot express that.
+	if _, err := NewFailureCounterSeeded(3, 4, 1); err == nil {
+		t.Fatal("seeded counter accepted a floor over a prefix the divergence ordinal cuts through")
+	}
+}

--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -162,7 +162,7 @@ type serveDeps struct {
 	// skipped. Same injectability rationale — the windowed branch is the
 	// one this daemon actually takes on a large resumed session, so tests
 	// must be able to observe and fault it.
-	prepareAppIdentityFromEntriesWindowed func(sourceID, threadID, ref string, header transcript.Header, entries []transcript.Entry, prefixEntryCount int) (server.PreparedAppIdentity, error)
+	prepareAppIdentityFromEntriesWindowed func(sourceID, threadID, ref string, header transcript.Header, entries []transcript.Entry, prefixEntryCount, prefixTurnCount int) (server.PreparedAppIdentity, error)
 	updateSessionID                       func(*rvreg.Registration, string) error
 	observeCallbacks                      func(serveCallbackObserver)
 }
@@ -556,12 +556,19 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 		// OpenWriterForSession pass) and validated its header against the
 		// session id; projecting from those entries keeps the daemon's
 		// startup from re-reading and re-decoding the whole append-only file.
-		if windowed, prefixEntries, _ := sess.RestoredTranscriptWindowed(); windowed {
+		if windowed, prefixEntries, prefixTurns, _ := sess.RestoredTranscriptWindowed(); windowed {
 			// The windowed read decoded only a suffix: project it with the
 			// global entry positions so turn ids match the file-backed paging,
 			// and page the snapshot in the full position space (older pages
-			// fall through to the hub's transcript paging).
-			prepared, err = deps.prepareAppIdentityFromEntriesWindowed("local", sess.ID(), workspaceRef, header, entries, prefixEntries)
+			// fall through to the hub's transcript paging). The sidecar's
+			// prefix-turn count is what arms that paging; a compaction-anchored
+			// resume (whose sidecar could not compute it) falls back to the
+			// file form — one bounded re-read, not a wrong cursor space.
+			if prefixTurns >= 0 {
+				prepared, err = deps.prepareAppIdentityFromEntriesWindowed("local", sess.ID(), workspaceRef, header, entries, prefixEntries, prefixTurns)
+			} else {
+				prepared, err = deps.prepareAppIdentity("local", sess.ID(), workspaceRef, sess.TranscriptPath())
+			}
 		} else {
 			prepared, err = deps.prepareAppIdentityFromEntries("local", sess.ID(), workspaceRef, header, entries)
 		}

--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -166,8 +166,9 @@ type serveDeps struct {
 	// refreshResumeSidecar rewrites a session's resume sidecar from a full
 	// transcript scan. The compaction-anchored fallback calls it after its
 	// file-form re-read so the NEXT resume windows instead of repeating that
-	// re-read. Injectable so a test can observe (and fault) the refresh the
-	// same way the identity forms above are observed.
+	// re-read. Injectable for pattern consistency with the filesystem-touching
+	// collaborators around it (the prepareAppIdentity* deps) and as the
+	// injection point for the fallback's best-effort branch below.
 	refreshResumeSidecar func(transcriptPath, sessionID string) error
 	updateSessionID      func(*rvreg.Registration, string) error
 	observeCallbacks     func(serveCallbackObserver)

--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -156,8 +156,15 @@ type serveDeps struct {
 	// the resume branch below bypasses prepareAppIdentity, so without this
 	// seam no test can observe which form ran.
 	prepareAppIdentityFromEntries func(sourceID, threadID, ref string, header transcript.Header, entries []transcript.Entry) (server.PreparedAppIdentity, error)
-	updateSessionID               func(*rvreg.Registration, string) error
-	observeCallbacks              func(serveCallbackObserver)
+	// prepareAppIdentityFromEntriesWindowed is the windowed-resume form of
+	// prepareAppIdentityFromEntries: the entries are the suffix a validated
+	// sidecar let restore decode, and prefixEntryCount is what the read
+	// skipped. Same injectability rationale — the windowed branch is the
+	// one this daemon actually takes on a large resumed session, so tests
+	// must be able to observe and fault it.
+	prepareAppIdentityFromEntriesWindowed func(sourceID, threadID, ref string, header transcript.Header, entries []transcript.Entry, prefixEntryCount int) (server.PreparedAppIdentity, error)
+	updateSessionID                       func(*rvreg.Registration, string) error
+	observeCallbacks                      func(serveCallbackObserver)
 }
 
 type serveCallbackObserver struct {
@@ -195,13 +202,14 @@ func defaultServeDeps() serveDeps {
 		drainWaitExpiry: func() <-chan time.Time { return time.After(shutdownDrainWaitBudget) },
 		subscriberCount: func(s serveServer, id string) int { return s.(*server.Server).AppSubscriberCount(id) },
 		notifyContext:   signal.NotifyContext, startCPUProfile: cmdutil.StartCPUProfile, startTrace: cmdutil.StartTrace,
-		register:                      func(r *rvreg.Registration, dir string, entry rendezvous.Entry) error { return r.Register(dir, entry) },
-		serveHTTP:                     func(s *http.Server, l net.Listener) error { return s.Serve(l) },
-		provisionSandbox:              provisionSandbox,
-		newClearSession:               agent.NewSession,
-		prepareAppIdentity:            server.PrepareAppIdentityForRef,
-		prepareAppIdentityFromEntries: server.PrepareAppIdentityFromEntries,
-		updateSessionID:               func(r *rvreg.Registration, id string) error { return r.UpdateSessionID(id) },
+		register:                              func(r *rvreg.Registration, dir string, entry rendezvous.Entry) error { return r.Register(dir, entry) },
+		serveHTTP:                             func(s *http.Server, l net.Listener) error { return s.Serve(l) },
+		provisionSandbox:                      provisionSandbox,
+		newClearSession:                       agent.NewSession,
+		prepareAppIdentity:                    server.PrepareAppIdentityForRef,
+		prepareAppIdentityFromEntries:         server.PrepareAppIdentityFromEntries,
+		prepareAppIdentityFromEntriesWindowed: server.PrepareAppIdentityFromEntriesWindowed,
+		updateSessionID:                       func(r *rvreg.Registration, id string) error { return r.UpdateSessionID(id) },
 	}
 }
 
@@ -548,7 +556,15 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 		// OpenWriterForSession pass) and validated its header against the
 		// session id; projecting from those entries keeps the daemon's
 		// startup from re-reading and re-decoding the whole append-only file.
-		prepared, err = deps.prepareAppIdentityFromEntries("local", sess.ID(), workspaceRef, header, entries)
+		if windowed, prefixEntries, _ := sess.RestoredTranscriptWindowed(); windowed {
+			// The windowed read decoded only a suffix: project it with the
+			// global entry positions so turn ids match the file-backed paging,
+			// and page the snapshot in the full position space (older pages
+			// fall through to the hub's transcript paging).
+			prepared, err = deps.prepareAppIdentityFromEntriesWindowed("local", sess.ID(), workspaceRef, header, entries, prefixEntries)
+		} else {
+			prepared, err = deps.prepareAppIdentityFromEntries("local", sess.ID(), workspaceRef, header, entries)
+		}
 	} else {
 		prepared, err = deps.prepareAppIdentity("local", sess.ID(), workspaceRef, sess.TranscriptPath())
 	}

--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -576,15 +576,6 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 				prepared, err = deps.prepareAppIdentityFromEntriesWindowed("local", sess.ID(), workspaceRef, header, entries, prefixEntries, prefixTurns)
 			} else {
 				prepared, err = deps.prepareAppIdentity("local", sess.ID(), workspaceRef, sess.TranscriptPath())
-				// The file form re-reads the whole transcript anyway, so pay
-				// the same cost once to convert the compaction-anchored sidecar
-				// into the full-scan one — the NEXT resume then windows and
-				// arms paging instead of taking this fallback again.
-				// Best-effort: a session whose sidecar cannot be refreshed
-				// keeps the fallback, which is correct, only slower.
-				if refreshErr := deps.refreshResumeSidecar(sess.TranscriptPath(), sess.ID()); refreshErr != nil {
-					fmt.Fprintf(os.Stderr, "resume sidecar refresh after compaction-anchored fallback: %v\n", refreshErr)
-				}
 			}
 		} else {
 			prepared, err = deps.prepareAppIdentityFromEntries("local", sess.ID(), workspaceRef, header, entries)
@@ -596,6 +587,17 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 		sess.Close()
 		listener.Close() //nolint:errcheck // returning the preparation failure; the close error is not actionable
 		return fmt.Errorf("prepare app identity: %w", err)
+	}
+	// The compaction-anchored fallback above just paid a full file read for the
+	// identity projection; convert that read into the sidecar the NEXT resume
+	// windows on, so the fallback stays one-per-compaction instead of every
+	// resume. A second independent full scan, paid once. Best-effort: a session
+	// whose sidecar cannot be refreshed keeps the fallback — correct, only
+	// slower. Runs after the error gate so a failing startup pays nothing.
+	if windowed, _, prefixTurns, _ := sess.RestoredTranscriptWindowed(); windowed && prefixTurns < 0 {
+		if refreshErr := deps.refreshResumeSidecar(sess.TranscriptPath(), sess.ID()); refreshErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: resume sidecar refresh after compaction-anchored fallback: %v\n", refreshErr)
+		}
 	}
 	srv.ReplaceAppIdentity(prepared, nil)
 	rvRegistration := &rvreg.Registration{}

--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -163,8 +163,14 @@ type serveDeps struct {
 	// one this daemon actually takes on a large resumed session, so tests
 	// must be able to observe and fault it.
 	prepareAppIdentityFromEntriesWindowed func(sourceID, threadID, ref string, header transcript.Header, entries []transcript.Entry, prefixEntryCount, prefixTurnCount int) (server.PreparedAppIdentity, error)
-	updateSessionID                       func(*rvreg.Registration, string) error
-	observeCallbacks                      func(serveCallbackObserver)
+	// refreshResumeSidecar rewrites a session's resume sidecar from a full
+	// transcript scan. The compaction-anchored fallback calls it after its
+	// file-form re-read so the NEXT resume windows instead of repeating that
+	// re-read. Injectable so a test can observe (and fault) the refresh the
+	// same way the identity forms above are observed.
+	refreshResumeSidecar func(transcriptPath, sessionID string) error
+	updateSessionID      func(*rvreg.Registration, string) error
+	observeCallbacks     func(serveCallbackObserver)
 }
 
 type serveCallbackObserver struct {
@@ -209,6 +215,7 @@ func defaultServeDeps() serveDeps {
 		prepareAppIdentity:                    server.PrepareAppIdentityForRef,
 		prepareAppIdentityFromEntries:         server.PrepareAppIdentityFromEntries,
 		prepareAppIdentityFromEntriesWindowed: server.PrepareAppIdentityFromEntriesWindowed,
+		refreshResumeSidecar:                  transcript.RefreshSidecarFromFullScan,
 		updateSessionID:                       func(r *rvreg.Registration, id string) error { return r.UpdateSessionID(id) },
 	}
 }
@@ -568,6 +575,15 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 				prepared, err = deps.prepareAppIdentityFromEntriesWindowed("local", sess.ID(), workspaceRef, header, entries, prefixEntries, prefixTurns)
 			} else {
 				prepared, err = deps.prepareAppIdentity("local", sess.ID(), workspaceRef, sess.TranscriptPath())
+				// The file form re-reads the whole transcript anyway, so pay
+				// the same cost once to convert the compaction-anchored sidecar
+				// into the full-scan one — the NEXT resume then windows and
+				// arms paging instead of taking this fallback again.
+				// Best-effort: a session whose sidecar cannot be refreshed
+				// keeps the fallback, which is correct, only slower.
+				if refreshErr := deps.refreshResumeSidecar(sess.TranscriptPath(), sess.ID()); refreshErr != nil {
+					fmt.Fprintf(os.Stderr, "resume sidecar refresh after compaction-anchored fallback: %v\n", refreshErr)
+				}
 			}
 		} else {
 			prepared, err = deps.prepareAppIdentityFromEntries("local", sess.ID(), workspaceRef, header, entries)

--- a/cmd/evener/serve_resume_identity_test.go
+++ b/cmd/evener/serve_resume_identity_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"os"
@@ -332,5 +333,75 @@ func TestServeResumeCompactionFallbackRefreshesSidecar(t *testing.T) {
 	}
 	if probe.windowedPrefixTurns != 2 {
 		t.Fatalf("windowed prefix turns after refresh = %d, want 2", probe.windowedPrefixTurns)
+	}
+}
+
+// TestServeResumeCompactionFallbackSurvivesRefreshFailure pins the refresh's
+// best-effort contract: a refresh that fails must not fail the daemon — the
+// session keeps serving on the file form, correct only slower, and the next
+// compaction-anchored resume tries the refresh again.
+func TestServeResumeCompactionFallbackSurvivesRefreshFailure(t *testing.T) {
+	installServeScriptedProvider(t, &scriptedProvider{name: "openai"})
+	stateDir := t.TempDir()
+	const sessionID = "02wMz5Txv1C3Hut0M8GCeB"
+	seedWindowedResumableSession(t, stateDir, sessionID)
+	path := filepath.Join(stateDir, "sessions", sessionID+".transcript.jsonl")
+	sidecar, ok := transcript.ReadSidecar(path)
+	if !ok {
+		t.Fatalf("sidecar missing after seeded first resume")
+	}
+	sidecar.PrefixTurnCount = -1
+	sidecar.SnapshotsComplete = false
+	sidecar.PendingAttention = nil
+	sidecar.DeliveryCommits = nil
+	sidecar.ClientMutationTurns = nil
+	if err := transcript.WriteSidecar(path, sidecar); err != nil {
+		t.Fatalf("rewrite sidecar with compaction-anchor shape: %v", err)
+	}
+
+	// Fault the refresh: every call fails. The daemon must still come up and
+	// serve on the file form — the fallback is the contract, the refresh is
+	// the optimization.
+	probe := &serveResumeIdentityProbe{}
+	deps := defaultServeDeps()
+	deps.ensureConfigDirs = func() error { return nil }
+	deps.seedMarketplaces = func() error { return nil }
+	var cancel context.CancelFunc
+	deps.notifyContext = func(ctx context.Context, _ ...os.Signal) (context.Context, context.CancelFunc) {
+		next, stop := context.WithCancel(ctx)
+		cancel = stop
+		return next, stop
+	}
+	deps.refreshResumeSidecar = func(transcriptPath, sessionID string) error {
+		probe.refreshUsed = true
+		return errors.New("simulated sidecar refresh failure")
+	}
+	deps.serveHTTP = func(*http.Server, net.Listener) error {
+		cancel()
+		return http.ErrServerClosed
+	}
+	args := []string{
+		"--model", "openai/gpt-test",
+		"--addr", "127.0.0.1:0",
+		"--resume", sessionID,
+		"--dir", t.TempDir(),
+		"--state-dir", stateDir,
+		"--run-dir", t.TempDir(),
+		"--no-project-prompts",
+	}
+	if serveErr := runServeWithDeps(args, deps); serveErr != nil {
+		t.Fatalf("serve with a failing refresh must still start: %v", serveErr)
+	}
+	if !probe.refreshUsed {
+		t.Fatal("the refresh dep was not exercised on the compaction-anchored fallback")
+	}
+	// The sidecar keeps its compaction-anchored shape — a failed refresh
+	// leaves the previous state untouched rather than corrupting it.
+	surviving, ok := transcript.ReadSidecar(path)
+	if !ok {
+		t.Fatalf("sidecar missing after a failed refresh")
+	}
+	if surviving.PrefixTurnCount != -1 || surviving.SnapshotsComplete {
+		t.Fatalf("failed refresh mutated the sidecar: prefixTurns=%d complete=%v, want -1 and false", surviving.PrefixTurnCount, surviving.SnapshotsComplete)
 	}
 }

--- a/cmd/evener/serve_resume_identity_test.go
+++ b/cmd/evener/serve_resume_identity_test.go
@@ -54,13 +54,13 @@ func seedResumableSession(t *testing.T, stateDir, sessionID string, headerSessio
 // returns, and the test reads the probe only after that return. The serve
 // goroutines spawned along the way never touch the probe.
 type serveResumeIdentityProbe struct {
-	entriesFormUsed bool
-	fileFormUsed    bool
-	windowedFormUsed bool
-	windowedPrefixTurns int
+	entriesFormUsed       bool
+	fileFormUsed          bool
+	windowedFormUsed      bool
+	windowedPrefixTurns   int
 	windowedPrefixEntries int
-	gotThreadID     string
-	gotEntryCount   int
+	gotThreadID           string
+	gotEntryCount         int
 }
 
 // runServeResumeWithProbe drives one --resume through runServeWithDeps and
@@ -132,7 +132,7 @@ func seedWindowedResumableSession(t *testing.T, stateDir, sessionID string) {
 	path := filepath.Join(stateDir, "sessions", sessionID+".transcript.jsonl")
 	writer, err := transcript.NewWriter(path, transcript.Header{
 		SessionID:  sessionID,
-		ProfileID: "openai",
+		ProfileID:  "openai",
 		Model:      "gpt-test",
 		WorkingDir: stateDir,
 	})

--- a/cmd/evener/serve_resume_identity_test.go
+++ b/cmd/evener/serve_resume_identity_test.go
@@ -56,6 +56,9 @@ func seedResumableSession(t *testing.T, stateDir, sessionID string, headerSessio
 type serveResumeIdentityProbe struct {
 	entriesFormUsed bool
 	fileFormUsed    bool
+	windowedFormUsed bool
+	windowedPrefixTurns int
+	windowedPrefixEntries int
 	gotThreadID     string
 	gotEntryCount   int
 }
@@ -86,6 +89,13 @@ func runServeResumeWithProbe(t *testing.T, stateDir, sessionID string) (*serveRe
 		probe.fileFormUsed = true
 		return fileForm(sourceID, threadID, ref, transcriptPath)
 	}
+	windowedForm := deps.prepareAppIdentityFromEntriesWindowed
+	deps.prepareAppIdentityFromEntriesWindowed = func(sourceID, threadID, ref string, header transcript.Header, entries []transcript.Entry, prefixEntryCount, prefixTurnCount int) (server.PreparedAppIdentity, error) {
+		probe.windowedFormUsed = true
+		probe.windowedPrefixEntries = prefixEntryCount
+		probe.windowedPrefixTurns = prefixTurnCount
+		return windowedForm(sourceID, threadID, ref, header, entries, prefixEntryCount, prefixTurnCount)
+	}
 	deps.serveHTTP = func(*http.Server, net.Listener) error {
 		// Cancel before returning: the shutdown goroutine waits on ctx.Done()
 		// even after serveHTTP returns, so returning without canceling would
@@ -105,6 +115,87 @@ func runServeResumeWithProbe(t *testing.T, stateDir, sessionID string) (*serveRe
 	}
 	serveErr := runServeWithDeps(args, deps)
 	return probe, serveErr
+}
+
+// seedWindowedResumableSession seeds a session whose transcript carries a
+// validated resume sidecar: two prefix entries, a checkpoint entry (the
+// boundary the sidecar anchors at), then one suffix entry. The FIRST resume
+// writes the opportunistic sidecar (full scan), so the SECOND resume — the
+// one this helper's caller drives — reads the windowed form.
+func seedWindowedResumableSession(t *testing.T, stateDir, sessionID string) {
+	t.Helper()
+	if err := schema.SaveSessionMeta(stateDir, schema.SessionMeta{
+		ID: sessionID, ProfileID: "openai", Model: "gpt-test",
+	}); err != nil {
+		t.Fatalf("SaveSessionMeta: %v", err)
+	}
+	path := filepath.Join(stateDir, "sessions", sessionID+".transcript.jsonl")
+	writer, err := transcript.NewWriter(path, transcript.Header{
+		SessionID:  sessionID,
+		ProfileID: "openai",
+		Model:      "gpt-test",
+		WorkingDir: stateDir,
+	})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	for _, text := range []string{"first turn", "second turn"} {
+		if err := writer.Append(schema.NewTurn(schema.TurnUserInput, llm.User(text))); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+	if err := writer.Append(schema.NewTurn(schema.TurnCheckpoint, llm.User("compaction summary"))); err != nil {
+		t.Fatalf("Append checkpoint: %v", err)
+	}
+	if err := writer.Append(schema.NewTurn(schema.TurnUserInput, llm.User("after compaction"))); err != nil {
+		t.Fatalf("Append suffix: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+	// First resume: full scan, which writes the opportunistic sidecar with
+	// the exact prefix-turn count.
+	first, _, err := transcript.OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("first resume: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first: %v", err)
+	}
+}
+
+// TestServeResumeWindowedIdentityArmsWindowedPaging pins the serve-level
+// wiring issue #643's windowed snapshot: a --resume whose sidecar validated
+// must seed its identity through the WINDOWED form — armed with the sidecar's
+// exact prefix-turn count, not zero. The zero-count bug left every windowed
+// Latest/Page taking the non-windowed branch, so windowed paging never ran
+// in production despite its tests passing.
+func TestServeResumeWindowedIdentityArmsWindowedPaging(t *testing.T) {
+	installServeScriptedProvider(t, &scriptedProvider{name: "openai"})
+	stateDir := t.TempDir()
+	const sessionID = "02wMz5Txv1C3Hut0M8GCeB"
+	seedWindowedResumableSession(t, stateDir, sessionID)
+
+	probe, serveErr := runServeResumeWithProbe(t, stateDir, sessionID)
+	if serveErr != nil {
+		t.Fatalf("runServeWithDeps(resume): %v", serveErr)
+	}
+	if !probe.windowedFormUsed {
+		t.Fatal("resume with a valid sidecar did not use the windowed identity form")
+	}
+	if probe.entriesFormUsed || probe.fileFormUsed {
+		t.Fatal("windowed resume also used another identity form")
+	}
+	// Two prefix entries + the checkpoint entry; the sidecar's prefix spans
+	// the two user turns (the checkpoint is the suffix's first entry).
+	if probe.windowedPrefixEntries != 2 {
+		t.Fatalf("windowed prefix entries = %d, want 2", probe.windowedPrefixEntries)
+	}
+	// Both prefix entries project turns, and no system prompt means no
+	// prelude: the prefix-turn count is 2, not 0 — the arming value.
+	if probe.windowedPrefixTurns != 2 {
+		t.Fatalf("windowed prefix turns = %d, want 2 (armed, not zero)", probe.windowedPrefixTurns)
+	}
 }
 
 // TestServeResumeSeedsIdentityFromRestoredEntries pins the serve-level

--- a/cmd/evener/serve_resume_identity_test.go
+++ b/cmd/evener/serve_resume_identity_test.go
@@ -405,3 +405,79 @@ func TestServeResumeCompactionFallbackSurvivesRefreshFailure(t *testing.T) {
 		t.Fatalf("failed refresh mutated the sidecar: prefixTurns=%d complete=%v, want -1 and false", surviving.PrefixTurnCount, surviving.SnapshotsComplete)
 	}
 }
+
+// TestServeResumeFailedIdentitySkipsSidecarRefresh pins the refresh's
+// placement AFTER the identity projection's error gate: a startup whose
+// projection fails is about to abort, so it must not pay the second full
+// transcript scan the refresh performs. The ordering is otherwise
+// invisible — both orders produce identical observable state on success —
+// so the assertion records WHICH ran via order-sensitive probe fields.
+func TestServeResumeFailedIdentitySkipsSidecarRefresh(t *testing.T) {
+	installServeScriptedProvider(t, &scriptedProvider{name: "openai"})
+	stateDir := t.TempDir()
+	const sessionID = "02wMz5Txv1C3Hut0M8GCeB"
+	seedWindowedResumableSession(t, stateDir, sessionID)
+	path := filepath.Join(stateDir, "sessions", sessionID+".transcript.jsonl")
+	sidecar, ok := transcript.ReadSidecar(path)
+	if !ok {
+		t.Fatalf("sidecar missing after seeded first resume")
+	}
+	sidecar.PrefixTurnCount = -1
+	sidecar.SnapshotsComplete = false
+	sidecar.PendingAttention = nil
+	sidecar.DeliveryCommits = nil
+	sidecar.ClientMutationTurns = nil
+	if err := transcript.WriteSidecar(path, sidecar); err != nil {
+		t.Fatalf("rewrite sidecar with compaction-anchor shape: %v", err)
+	}
+
+	probe := &serveResumeIdentityProbe{}
+	deps := defaultServeDeps()
+	deps.ensureConfigDirs = func() error { return nil }
+	deps.seedMarketplaces = func() error { return nil }
+	var cancel context.CancelFunc
+	deps.notifyContext = func(ctx context.Context, _ ...os.Signal) (context.Context, context.CancelFunc) {
+		next, stop := context.WithCancel(ctx)
+		cancel = stop
+		return next, stop
+	}
+	// The projection fails: the daemon must abort startup.
+	fileForm := deps.prepareAppIdentity
+	deps.prepareAppIdentity = func(sourceID, threadID, ref, transcriptPath string) (server.PreparedAppIdentity, error) {
+		probe.fileFormUsed = true
+		// Run the real projection for its side effects, then fail: the
+		// failure is what the gate under test observes.
+		if _, err := fileForm(sourceID, threadID, ref, transcriptPath); err != nil {
+			t.Logf("underlying projection also failed: %v", err)
+		}
+		return server.PreparedAppIdentity{}, errors.New("simulated identity projection failure")
+	}
+	// The refresh, if it ran, would record it.
+	deps.refreshResumeSidecar = func(transcriptPath, sessionID string) error {
+		probe.refreshUsed = true
+		return nil
+	}
+	deps.serveHTTP = func(*http.Server, net.Listener) error {
+		cancel()
+		return http.ErrServerClosed
+	}
+	args := []string{
+		"--model", "openai/gpt-test",
+		"--addr", "127.0.0.1:0",
+		"--resume", sessionID,
+		"--dir", t.TempDir(),
+		"--state-dir", stateDir,
+		"--run-dir", t.TempDir(),
+		"--no-project-prompts",
+	}
+	serveErr := runServeWithDeps(args, deps)
+	if serveErr == nil {
+		t.Fatal("a failing identity projection must fail serve startup")
+	}
+	if !strings.Contains(serveErr.Error(), "prepare app identity") {
+		t.Fatalf("serve error = %v, want the projection failure", serveErr)
+	}
+	if probe.refreshUsed {
+		t.Fatal("the sidecar refresh ran for a startup whose projection failed — it must sit after the error gate")
+	}
+}

--- a/cmd/evener/serve_resume_identity_test.go
+++ b/cmd/evener/serve_resume_identity_test.go
@@ -254,3 +254,72 @@ func TestServeResumeForeignHeaderEntryListFailsStartup(t *testing.T) {
 		t.Fatalf("serve error = %v, want the restore-stage failure naming the mismatch", serveErr)
 	}
 }
+
+// TestServeResumeCompactionFallbackRefreshesSidecar pins the steady-state
+// repair: a --resume over a compaction-anchored sidecar (whose prefix-turn
+// count is -1) must take the file form ONCE and convert the sidecar to the
+// full-scan one — so the NEXT resume windows and arms paging instead of
+// re-reading the whole file on every daemon start forever. Without the
+// refresh, compacting sessions pay the full file re-read per resume as a
+// permanent steady state, which is exactly the cost the sidecar exists to
+// remove.
+func TestServeResumeCompactionFallbackRefreshesSidecar(t *testing.T) {
+	installServeScriptedProvider(t, &scriptedProvider{name: "openai"})
+	stateDir := t.TempDir()
+	const sessionID = "02wMz5Txv1C3Hut0M8GCeB"
+	// Seed the windowed fixture, then overwrite its sidecar with the
+	// compaction-anchored shape: same boundary, but PrefixTurnCount -1 and
+	// no fold snapshots — what the compaction anchor writes after a
+	// checkpoint that no full scan has followed.
+	seedWindowedResumableSession(t, stateDir, sessionID)
+	path := filepath.Join(stateDir, "sessions", sessionID+".transcript.jsonl")
+	sidecar, ok := transcript.ReadSidecar(path)
+	if !ok {
+		t.Fatalf("sidecar missing after seeded first resume")
+	}
+	sidecar.PrefixTurnCount = -1
+	sidecar.SnapshotsComplete = false
+	sidecar.PendingAttention = nil
+	sidecar.DeliveryCommits = nil
+	sidecar.ClientMutationTurns = nil
+	if err := transcript.WriteSidecar(path, sidecar); err != nil {
+		t.Fatalf("rewrite sidecar with compaction-anchor shape: %v", err)
+	}
+
+	// First serve run: the compaction-anchored sidecar validates (windowed
+	// read) but cannot arm paging, so the file form runs — and the refresh
+	// must follow it.
+	probe, serveErr := runServeResumeWithProbe(t, stateDir, sessionID)
+	if serveErr != nil {
+		t.Fatalf("first serve run: %v", serveErr)
+	}
+	if !probe.fileFormUsed {
+		t.Fatal("compaction-anchored resume did not take the file form")
+	}
+	if probe.windowedFormUsed || probe.entriesFormUsed {
+		t.Fatal("compaction-anchored resume used a non-file identity form")
+	}
+	refreshed, ok := transcript.ReadSidecar(path)
+	if !ok {
+		t.Fatalf("sidecar missing after the fallback run")
+	}
+	if !refreshed.SnapshotsComplete || refreshed.PrefixTurnCount != 2 {
+		t.Fatalf("sidecar was not refreshed to the full-scan shape: complete=%v prefixTurns=%d, want complete=true prefixTurns=2", refreshed.SnapshotsComplete, refreshed.PrefixTurnCount)
+	}
+
+	// Second serve run over the refreshed sidecar: it must go windowed with
+	// the armed count — the steady state is repaired, not repeated.
+	probe, serveErr = runServeResumeWithProbe(t, stateDir, sessionID)
+	if serveErr != nil {
+		t.Fatalf("second serve run: %v", serveErr)
+	}
+	if !probe.windowedFormUsed {
+		t.Fatal("resume after the refresh did not use the windowed form")
+	}
+	if probe.fileFormUsed {
+		t.Fatal("resume after the refresh repeated the file form — the steady state was not repaired")
+	}
+	if probe.windowedPrefixTurns != 2 {
+		t.Fatalf("windowed prefix turns after refresh = %d, want 2", probe.windowedPrefixTurns)
+	}
+}

--- a/cmd/evener/serve_resume_identity_test.go
+++ b/cmd/evener/serve_resume_identity_test.go
@@ -59,6 +59,8 @@ type serveResumeIdentityProbe struct {
 	windowedFormUsed      bool
 	windowedPrefixTurns   int
 	windowedPrefixEntries int
+	refreshUsed           bool
+	refreshPath           string
 	gotThreadID           string
 	gotEntryCount         int
 }
@@ -95,6 +97,12 @@ func runServeResumeWithProbe(t *testing.T, stateDir, sessionID string) (*serveRe
 		probe.windowedPrefixEntries = prefixEntryCount
 		probe.windowedPrefixTurns = prefixTurnCount
 		return windowedForm(sourceID, threadID, ref, header, entries, prefixEntryCount, prefixTurnCount)
+	}
+	refreshForm := deps.refreshResumeSidecar
+	deps.refreshResumeSidecar = func(transcriptPath, sessionID string) error {
+		probe.refreshUsed = true
+		probe.refreshPath = transcriptPath
+		return refreshForm(transcriptPath, sessionID)
 	}
 	deps.serveHTTP = func(*http.Server, net.Listener) error {
 		// Cancel before returning: the shutdown goroutine waits on ctx.Done()
@@ -298,6 +306,9 @@ func TestServeResumeCompactionFallbackRefreshesSidecar(t *testing.T) {
 	}
 	if probe.windowedFormUsed || probe.entriesFormUsed {
 		t.Fatal("compaction-anchored resume used a non-file identity form")
+	}
+	if !probe.refreshUsed || probe.refreshPath != path {
+		t.Fatalf("refresh seam: used=%v path=%q, want used=true path=%q", probe.refreshUsed, probe.refreshPath, path)
 	}
 	refreshed, ok := transcript.ReadSidecar(path)
 	if !ok {

--- a/internal/apptranscript/apptranscript.go
+++ b/internal/apptranscript/apptranscript.go
@@ -705,23 +705,33 @@ func TurnsFromEntries(header transcript.Header, entries []transcript.Entry, proj
 // when the prefix is empty — with a non-empty prefix the prelude's position
 // belongs to prefix turns this projection does not hold.
 //
-// It returns the projected turns and the count of prefix TURN POSITIONS the
-// full projection would hold below them (for a zero prefix: 1 when a prelude
-// was emitted, else 0). The caller uses that count to offset paging cursors
-// into the same space.
-func TurnsFromEntriesWindowed(header transcript.Header, entries []transcript.Entry, prefixEntryCount int, project EntryProjector) ([]appwire.Turn, int) {
+// It returns the projected turns and the count of turn POSITIONS the full
+// projection would hold below them: the prelude (when the header projects
+// one) plus prefixTurnCount, the count of prefix entries that project at
+// least one thread item — a figure ONLY the sidecar can supply exactly
+// (it decoded the prefix; the suffix alone cannot infer which kinds
+// projected). The caller uses that count to offset paging cursors into the
+// same space, so a windowed snapshot pages as the full projection would.
+// A negative prefixTurnCount means the sidecar did not compute it: the
+// caller must not arm windowed paging on this projection.
+func TurnsFromEntriesWindowed(header transcript.Header, entries []transcript.Entry, prefixEntryCount, prefixTurnCount int, project EntryProjector) ([]appwire.Turn, int) {
 	var turns []appwire.Turn
 	for i := range entries {
 		projectEntryIntoTurns(&turns, project, nil, entries[i].Turn, prefixEntryCount+i+1)
 	}
-	if prefixEntryCount > 0 {
-		return turns, 0 // prelude position belongs to the unseen prefix
+	// The prelude belongs to the prefix's position space whenever a prefix
+	// exists: the full projection emits it before every entry turn, so with
+	// a non-empty prefix its position is below the window and emitting it
+	// here would double it (the hub's file-backed pages already serve it).
+	// With no prefix it is the only position below the window — count 1.
+	if prefixEntryCount == 0 && prefixTurnCount < 0 {
+		if p := PreludeTurn(header); p != nil {
+			turns = append([]appwire.Turn{*p}, turns...)
+			return turns, 1
+		}
+		return turns, 0
 	}
-	if prelude := PreludeTurn(header); prelude != nil {
-		turns = append([]appwire.Turn{*prelude}, turns...)
-		return turns, 1
-	}
-	return turns, 0
+	return turns, prefixTurnCount
 }
 
 // projectEntryIntoTurns is the per-entry step both forms share: turn id,

--- a/internal/apptranscript/apptranscript.go
+++ b/internal/apptranscript/apptranscript.go
@@ -707,13 +707,17 @@ func TurnsFromEntries(header transcript.Header, entries []transcript.Entry, proj
 //
 // It returns the projected turns and the count of turn POSITIONS the full
 // projection would hold below them: the prelude (when the header projects
-// one) plus prefixTurnCount, the count of prefix entries that project at
-// least one thread item — a figure ONLY the sidecar can supply exactly
-// (it decoded the prefix; the suffix alone cannot infer which kinds
-// projected). The caller uses that count to offset paging cursors into the
-// same space, so a windowed snapshot pages as the full projection would.
-// A negative prefixTurnCount means the sidecar did not compute it: the
-// caller must not arm windowed paging on this projection.
+// one and the prefix is empty) plus prefixTurnCount, the count of prefix
+// entries that project at least one thread item — a figure ONLY the sidecar
+// can supply exactly (it decoded the prefix; the suffix alone cannot infer
+// which kinds projected). The caller uses that count to offset paging
+// cursors into the same space, so a windowed snapshot pages as the full
+// projection would. A negative prefixTurnCount is refused by the caller
+// (PrepareAppIdentityFromEntriesWindowed) before this runs; a zero-prefix
+// windowed resume cannot occur either (the full-scan anchor refuses a
+// checkpoint-first transcript, so every validated sidecar has a non-empty
+// prefix), but the zero-prefix prelude rule is kept for the function's own
+// contract.
 func TurnsFromEntriesWindowed(header transcript.Header, entries []transcript.Entry, prefixEntryCount, prefixTurnCount int, project EntryProjector) ([]appwire.Turn, int) {
 	var turns []appwire.Turn
 	for i := range entries {
@@ -724,7 +728,7 @@ func TurnsFromEntriesWindowed(header transcript.Header, entries []transcript.Ent
 	// a non-empty prefix its position is below the window and emitting it
 	// here would double it (the hub's file-backed pages already serve it).
 	// With no prefix it is the only position below the window — count 1.
-	if prefixEntryCount == 0 && prefixTurnCount < 0 {
+	if prefixEntryCount == 0 {
 		if p := PreludeTurn(header); p != nil {
 			turns = append([]appwire.Turn{*p}, turns...)
 			return turns, 1

--- a/internal/apptranscript/apptranscript.go
+++ b/internal/apptranscript/apptranscript.go
@@ -697,6 +697,33 @@ func TurnsFromEntries(header transcript.Header, entries []transcript.Entry, proj
 	return turns, nil
 }
 
+// TurnsFromEntriesWindowed projects a resume's SUFFIX entries into AppWire
+// turns with the global entry positions a full projection would assign:
+// suffix entry i has 1-based position prefixEntryCount + i + 1, so every
+// persisted turn id ("turn_<entryIndex>") matches the id the hub's
+// file-backed paging mints for the same entry. The prelude is emitted only
+// when the prefix is empty — with a non-empty prefix the prelude's position
+// belongs to prefix turns this projection does not hold.
+//
+// It returns the projected turns and the count of prefix TURN POSITIONS the
+// full projection would hold below them (for a zero prefix: 1 when a prelude
+// was emitted, else 0). The caller uses that count to offset paging cursors
+// into the same space.
+func TurnsFromEntriesWindowed(header transcript.Header, entries []transcript.Entry, prefixEntryCount int, project EntryProjector) ([]appwire.Turn, int) {
+	var turns []appwire.Turn
+	for i := range entries {
+		projectEntryIntoTurns(&turns, project, nil, entries[i].Turn, prefixEntryCount+i+1)
+	}
+	if prefixEntryCount > 0 {
+		return turns, 0 // prelude position belongs to the unseen prefix
+	}
+	if prelude := PreludeTurn(header); prelude != nil {
+		turns = append([]appwire.Turn{*prelude}, turns...)
+		return turns, 1
+	}
+	return turns, 0
+}
+
 // projectEntryIntoTurns is the per-entry step both forms share: turn id,
 // items, failure stamp, timestamp, and usage. TurnsFromFile's scan passes
 // each raw entry, which this helper decodes; TurnsFromEntries passes the

--- a/internal/fileident/fileident.go
+++ b/internal/fileident/fileident.go
@@ -1,0 +1,63 @@
+// Package fileident derives a stable file-incarnation identity from an
+// os.FileInfo: the device/inode pair on Unix, the volume/file-index pair on
+// Windows. Two packages need the same derivation (agent/transcript's resume
+// sidecar and internal/apptranscript's turn index) and neither can import
+// the other (apptranscript already imports transcript), so the one copy
+// lives here at the root internal level both can reach.
+package fileident
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+)
+
+// FileIdentity returns a string that names the file's incarnation, or ""
+// when the platform or the FileInfo carries nothing usable. It reflects
+// over os.FileInfo.Sys() (Stat_t on Unix, Win32FileAttributeData on
+// Windows) so it stays portable without per-platform files for what is,
+// on each platform, a handful of field reads.
+func FileIdentity(info os.FileInfo) string {
+	if info == nil || info.Sys() == nil {
+		return ""
+	}
+	value := reflect.Indirect(reflect.ValueOf(info.Sys()))
+	if !value.IsValid() || value.Kind() != reflect.Struct {
+		return ""
+	}
+	field := func(name string) (uint64, bool) {
+		got := value.FieldByName(name)
+		if !got.IsValid() {
+			return 0, false
+		}
+		switch got.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return uint64(got.Int()), true
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return got.Uint(), true
+		default:
+			return 0, false
+		}
+	}
+	if device, ok := field("Dev"); ok {
+		if inode, ok := field("Ino"); ok {
+			return fmt.Sprintf("dev:%d:ino:%d", device, inode)
+		}
+	}
+	volume, volumeOK := field("VolumeSerialNumber")
+	high, highOK := field("FileIndexHigh")
+	low, lowOK := field("FileIndexLow")
+	if !volumeOK {
+		volume, volumeOK = field("vol")
+	}
+	if !highOK {
+		high, highOK = field("idxhi")
+	}
+	if !lowOK {
+		low, lowOK = field("idxlo")
+	}
+	if volumeOK && highOK && lowOK {
+		return fmt.Sprintf("volume:%d:index:%d", volume, high<<32|low)
+	}
+	return ""
+}

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -170,7 +170,7 @@ func PrepareAppIdentityFromEntries(sourceID, threadID, ref string, header transc
 //
 // The header rules are the entries form's: the restore pass already
 // validated it against threadID.
-func PrepareAppIdentityFromEntriesWindowed(sourceID, threadID, ref string, header transcript.Header, entries []transcript.Entry, prefixEntryCount int) (PreparedAppIdentity, error) {
+func PrepareAppIdentityFromEntriesWindowed(sourceID, threadID, ref string, header transcript.Header, entries []transcript.Entry, prefixEntryCount, prefixTurnCount int) (PreparedAppIdentity, error) {
 	sourceID, parsedRef, err := parseAppIdentityRef(sourceID, threadID, ref)
 	if err != nil {
 		return PreparedAppIdentity{}, err
@@ -181,18 +181,18 @@ func PrepareAppIdentityFromEntriesWindowed(sourceID, threadID, ref string, heade
 	if prefixEntryCount < 0 {
 		return PreparedAppIdentity{}, errors.New("windowed identity prefix entry count is negative")
 	}
+	if prefixTurnCount < 0 {
+		return PreparedAppIdentity{}, errors.New("windowed identity prefix turn count is negative")
+	}
 	toolNames := map[string]string{}
-	turns, prefixTurnCount := apptranscript.TurnsFromEntriesWindowed(header, entries, prefixEntryCount, func(turn schema.Turn, turnID string, entryIndex int) []appwire.ThreadItem {
+	turns, turnPrefixCount := apptranscript.TurnsFromEntriesWindowed(header, entries, prefixEntryCount, prefixTurnCount, func(turn schema.Turn, turnID string, entryIndex int) []appwire.ThreadItem {
 		return apptranscript.ProjectTurn(turnID, entryIndex, turn, toolNames, nil, apptranscript.ToolResultOutputImages)
 	})
-	highest := prefixEntryCount
-	if n := len(entries); n > 0 {
-		highest = prefixEntryCount + n
-	}
+	highest := prefixEntryCount + len(entries)
 	return finishPreparedAppIdentity(sourceID, threadID, parsedRef, prepareAppIdentitySource{
 		turns:            turns,
 		persistedEntries: highest,
-		prefixTurnCount:  prefixTurnCount,
+		prefixTurnCount:  turnPrefixCount,
 	})
 }
 

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -92,24 +92,37 @@ func fromTranscriptFile(threadID, transcriptPath string) (prepareAppIdentitySour
 	return out, nil
 }
 
+// parseAppIdentityRef is the shared validation head of every
+// PrepareAppIdentity* form: sourceID defaulting, the thread-id requirement,
+// ref parsing, and the ref/source match. Each form then does its own
+// transcript work; the error text and ordering are identical across forms
+// because they all come through here.
+func parseAppIdentityRef(sourceID, threadID, ref string) (string, appwire.Ref, error) {
+	if sourceID == "" {
+		sourceID = "local"
+	}
+	if strings.TrimSpace(threadID) == "" {
+		return "", appwire.Ref{}, errors.New("thread id is required")
+	}
+	parsedRef, err := appwire.ParseRef(strings.TrimSpace(ref))
+	if err != nil {
+		return "", appwire.Ref{}, fmt.Errorf("invalid app identity ref: %w", err)
+	}
+	if parsedRef.SourceID != sourceID {
+		return "", appwire.Ref{}, fmt.Errorf("app identity ref belongs to source %s, not %s", parsedRef.SourceID, sourceID)
+	}
+	return sourceID, parsedRef, nil
+}
+
 // PrepareAppIdentityForRef is PrepareAppIdentity for a replacement that keeps
 // the same stable workspace ref while advancing the live session instance.
 // The projector must use that ref too: otherwise the first event after clear
 // would be published to the replacement session's derived ref and existing
 // subscribers would miss it.
 func PrepareAppIdentityForRef(sourceID, threadID, ref, transcriptPath string) (PreparedAppIdentity, error) {
-	if sourceID == "" {
-		sourceID = "local"
-	}
-	if strings.TrimSpace(threadID) == "" {
-		return PreparedAppIdentity{}, errors.New("thread id is required")
-	}
-	parsedRef, err := appwire.ParseRef(strings.TrimSpace(ref))
+	sourceID, parsedRef, err := parseAppIdentityRef(sourceID, threadID, ref)
 	if err != nil {
-		return PreparedAppIdentity{}, fmt.Errorf("invalid app identity ref: %w", err)
-	}
-	if parsedRef.SourceID != sourceID {
-		return PreparedAppIdentity{}, fmt.Errorf("app identity ref belongs to source %s, not %s", parsedRef.SourceID, sourceID)
+		return PreparedAppIdentity{}, err
 	}
 	source, err := fromTranscriptFile(threadID, transcriptPath)
 	if err != nil {
@@ -132,18 +145,9 @@ func PrepareAppIdentityForRef(sourceID, threadID, ref, transcriptPath string) (P
 // the fence of live turn ids above the seeded ones -- is identical to
 // PrepareAppIdentityForRef.
 func PrepareAppIdentityFromEntries(sourceID, threadID, ref string, header transcript.Header, entries []transcript.Entry) (PreparedAppIdentity, error) {
-	if sourceID == "" {
-		sourceID = "local"
-	}
-	if strings.TrimSpace(threadID) == "" {
-		return PreparedAppIdentity{}, errors.New("thread id is required")
-	}
-	parsedRef, err := appwire.ParseRef(strings.TrimSpace(ref))
+	sourceID, parsedRef, err := parseAppIdentityRef(sourceID, threadID, ref)
 	if err != nil {
-		return PreparedAppIdentity{}, fmt.Errorf("invalid app identity ref: %w", err)
-	}
-	if parsedRef.SourceID != sourceID {
-		return PreparedAppIdentity{}, fmt.Errorf("app identity ref belongs to source %s, not %s", parsedRef.SourceID, sourceID)
+		return PreparedAppIdentity{}, err
 	}
 	if header.SessionID != "" && header.SessionID != threadID {
 		return PreparedAppIdentity{}, fmt.Errorf("transcript header belongs to session %s, not %s", header.SessionID, threadID)
@@ -167,18 +171,9 @@ func PrepareAppIdentityFromEntries(sourceID, threadID, ref string, header transc
 // The header rules are the entries form's: the restore pass already
 // validated it against threadID.
 func PrepareAppIdentityFromEntriesWindowed(sourceID, threadID, ref string, header transcript.Header, entries []transcript.Entry, prefixEntryCount int) (PreparedAppIdentity, error) {
-	if sourceID == "" {
-		sourceID = "local"
-	}
-	if strings.TrimSpace(threadID) == "" {
-		return PreparedAppIdentity{}, errors.New("thread id is required")
-	}
-	parsedRef, err := appwire.ParseRef(strings.TrimSpace(ref))
+	sourceID, parsedRef, err := parseAppIdentityRef(sourceID, threadID, ref)
 	if err != nil {
-		return PreparedAppIdentity{}, fmt.Errorf("invalid app identity ref: %w", err)
-	}
-	if parsedRef.SourceID != sourceID {
-		return PreparedAppIdentity{}, fmt.Errorf("app identity ref belongs to source %s, not %s", parsedRef.SourceID, sourceID)
+		return PreparedAppIdentity{}, err
 	}
 	if header.SessionID != "" && header.SessionID != threadID {
 		return PreparedAppIdentity{}, fmt.Errorf("transcript header belongs to session %s, not %s", header.SessionID, threadID)

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -1227,7 +1227,11 @@ func transcriptHeaderFromReader(source io.Reader, maxLineBytes int) transcript.H
 
 // appLatestTurns windows the newest limit turns out of the installed snapshot
 // and returns the cursor for the page before them. A limit of zero or less
-// returns the whole thread with no cursor.
+// returns the whole thread with no cursor. A WINDOWED snapshot (a suffix seed)
+// holds only its window, so a zero-or-less limit returns the window with the
+// prefix-boundary cursor instead — the older turns live below that boundary,
+// where the hub's file-backed paging serves them; the daemon cannot return
+// what it never held.
 func (s *Server) appLatestTurns(threadID string, limit int) ([]appwire.Turn, string) {
 	snapshot := s.appTurnSnapshotForID(threadID)
 	if snapshot == nil {

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -16,10 +16,12 @@ import (
 
 	"primeradiant.com/evener/agent"
 	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/internal/appprojector"
 	"primeradiant.com/evener/internal/appserver"
+	"primeradiant.com/evener/internal/apptranscript"
 	"primeradiant.com/evener/llm"
 )
 
@@ -61,6 +63,11 @@ func PrepareAppIdentity(sourceID, threadID, transcriptPath string) (PreparedAppI
 type prepareAppIdentitySource struct {
 	turns            []appwire.Turn
 	persistedEntries int
+	// prefixTurnCount is the number of turn positions below turns that a
+	// windowed projection did not hold. Zero for the full projections; set
+	// by the windowed entries form so the snapshot pages in the full
+	// position space.
+	prefixTurnCount int
 }
 
 // fromTranscriptFile is the file-reading source. A missing transcript is not
@@ -148,12 +155,58 @@ func PrepareAppIdentityFromEntries(sourceID, threadID, ref string, header transc
 	return finishPreparedAppIdentity(sourceID, threadID, parsedRef, prepareAppIdentitySource{turns: turns, persistedEntries: persisted})
 }
 
+// PrepareAppIdentityFromEntriesWindowed is PrepareAppIdentityFromEntries for
+// a windowed resume: entries are the SUFFIX a validated sidecar allowed the
+// restore to decode, and prefixEntryCount is the entry count before them.
+// Turn ids are minted with GLOBAL entry positions (prefixEntryCount + i + 1)
+// so they match the hub's file-backed paging of the same transcript
+// exactly, the persisted-entry fence covers the whole file, and the
+// installed snapshot pages in the full position space — older pages below
+// the window return no turns and the hub serves them from the transcript.
+//
+// The header rules are the entries form's: the restore pass already
+// validated it against threadID.
+func PrepareAppIdentityFromEntriesWindowed(sourceID, threadID, ref string, header transcript.Header, entries []transcript.Entry, prefixEntryCount int) (PreparedAppIdentity, error) {
+	if sourceID == "" {
+		sourceID = "local"
+	}
+	if strings.TrimSpace(threadID) == "" {
+		return PreparedAppIdentity{}, errors.New("thread id is required")
+	}
+	parsedRef, err := appwire.ParseRef(strings.TrimSpace(ref))
+	if err != nil {
+		return PreparedAppIdentity{}, fmt.Errorf("invalid app identity ref: %w", err)
+	}
+	if parsedRef.SourceID != sourceID {
+		return PreparedAppIdentity{}, fmt.Errorf("app identity ref belongs to source %s, not %s", parsedRef.SourceID, sourceID)
+	}
+	if header.SessionID != "" && header.SessionID != threadID {
+		return PreparedAppIdentity{}, fmt.Errorf("transcript header belongs to session %s, not %s", header.SessionID, threadID)
+	}
+	if prefixEntryCount < 0 {
+		return PreparedAppIdentity{}, errors.New("windowed identity prefix entry count is negative")
+	}
+	toolNames := map[string]string{}
+	turns, prefixTurnCount := apptranscript.TurnsFromEntriesWindowed(header, entries, prefixEntryCount, func(turn schema.Turn, turnID string, entryIndex int) []appwire.ThreadItem {
+		return apptranscript.ProjectTurn(turnID, entryIndex, turn, toolNames, nil, apptranscript.ToolResultOutputImages)
+	})
+	highest := prefixEntryCount
+	if n := len(entries); n > 0 {
+		highest = prefixEntryCount + n
+	}
+	return finishPreparedAppIdentity(sourceID, threadID, parsedRef, prepareAppIdentitySource{
+		turns:            turns,
+		persistedEntries: highest,
+		prefixTurnCount:  prefixTurnCount,
+	})
+}
+
 // finishPreparedAppIdentity validates the identity triple and installs the
 // projected source into a PreparedAppIdentity. It is the shared tail of
 // PrepareAppIdentityForRef and PrepareAppIdentityFromEntries.
 func finishPreparedAppIdentity(sourceID, threadID string, parsedRef appwire.Ref, source prepareAppIdentitySource) (PreparedAppIdentity, error) {
 	snapshot := &appTurnSnapshot{threadID: threadID}
-	snapshot.Seed(source.turns)
+	snapshot.SeedWindowed(source.turns, source.prefixTurnCount)
 	// Fence the live turn ids above the seeded ones HERE, where the seed count
 	// is known, rather than waiting for the session's own SessionStart to carry
 	// it: nothing orders that event ahead of the first turn-starting request,

--- a/server/appwire_turns.go
+++ b/server/appwire_turns.go
@@ -443,15 +443,16 @@ func (s *appTurnSnapshot) Page(cursor string, limit int) appwire.ThreadTurnsList
 			return appwire.ThreadTurnsListResponse{Data: nil, NextCursor: cursor}
 		}
 		// Window-local bounds: the window's turns occupy global positions
-		// [prefixTurnCount, prefixTurnCount+len(turns)). The page's lower
-		// bound never reaches below the prefix boundary: the turns there
-		// belong to the hub's file-backed pages, and the next cursor hands
-		// the client off at exactly that boundary — the position the full
-		// projection would point to when its own page runs out of window
-		// turns.
+		// [prefixTurnCount, prefixTurnCount+len(turns)). The next cursor
+		// points at the page's own lower bound — prefixTurnCount + localLo —
+		// so a client paging downward walks the window's turns page by page,
+		// exactly as the full projection's paging walks the same turns. Only
+		// when the page reaches the window floor (localLo == 0) does the
+		// cursor land on the prefix boundary, handing the client off to the
+		// hub's file-backed pages.
 		localHi := hi - s.prefixTurnCount
 		localLo := max(localHi-limit, 0)
-		return appwire.ThreadTurnsListResponse{Data: cloneAppTurns(s.turns[localLo:localHi]), NextCursor: strconv.Itoa(s.prefixTurnCount)}
+		return appwire.ThreadTurnsListResponse{Data: cloneAppTurns(s.turns[localLo:localHi]), NextCursor: strconv.Itoa(s.prefixTurnCount + localLo)}
 	}
 	page := appwire.PageTurns(s.turns, cursor, limit)
 	page.Data = cloneAppTurns(page.Data)

--- a/server/appwire_turns.go
+++ b/server/appwire_turns.go
@@ -406,12 +406,13 @@ func (s *appTurnSnapshot) Latest(limit int) ([]appwire.Turn, string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.prefixTurnCount > 0 {
-		// Windowed seed: page in the full-projection position space. A
-		// window smaller than the limit extends below the window; the
-		// cursor then points at the prefix boundary and the hub serves the
-		// older turns from its file-backed paging.
+		// Windowed seed: page in the full-projection position space. A window
+		// smaller than the limit extends below the window; the cursor then
+		// points at the prefix boundary and the hub serves the older turns
+		// from its file-backed paging. A limit that reaches past the window
+		// is the same case — the window cannot serve more than it holds.
 		total := s.prefixTurnCount + len(s.turns)
-		if limit <= 0 || total <= limit {
+		if limit <= 0 || limit >= len(s.turns) || total <= limit {
 			return cloneAppTurns(s.turns), strconv.Itoa(s.prefixTurnCount)
 		}
 		lo := len(s.turns) - limit
@@ -450,13 +451,7 @@ func (s *appTurnSnapshot) Page(cursor string, limit int) appwire.ThreadTurnsList
 		// turns.
 		localHi := hi - s.prefixTurnCount
 		localLo := max(localHi-limit, 0)
-		next := ""
-		if s.prefixTurnCount > 0 {
-			next = strconv.Itoa(s.prefixTurnCount)
-		} else if localLo > 0 {
-			next = strconv.Itoa(localLo)
-		}
-		return appwire.ThreadTurnsListResponse{Data: cloneAppTurns(s.turns[localLo:localHi]), NextCursor: next}
+		return appwire.ThreadTurnsListResponse{Data: cloneAppTurns(s.turns[localLo:localHi]), NextCursor: strconv.Itoa(s.prefixTurnCount)}
 	}
 	page := appwire.PageTurns(s.turns, cursor, limit)
 	page.Data = cloneAppTurns(page.Data)

--- a/server/appwire_turns.go
+++ b/server/appwire_turns.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -77,6 +78,13 @@ type appTurnSnapshot struct {
 	threadID  string
 	turns     []appwire.Turn
 	turnIndex map[string]int
+	// prefixTurnCount is the number of turn positions a windowed seed holds
+	// BELOW s.turns (zero for a full seed). Cursors Latest and Page hand out
+	// are expressed in the FULL projection's position space — the same
+	// space the hub's file-backed paging uses — so a client can page across
+	// the seam. Pages that fall entirely below the window return no turns;
+	// the hub serves them from the transcript. Guarded by mu.
+	prefixTurnCount int
 	// activeTurnID names the turn steering ITEMS attach to. Steering is the one
 	// notification that does not carry its own turn ID, so the reducer has to
 	// remember which turn is in flight.
@@ -98,9 +106,21 @@ type appTurnSnapshot struct {
 // nested item is deep-cloned, so later mutation of the argument cannot reach
 // installed state.
 func (s *appTurnSnapshot) Seed(turns []appwire.Turn) {
+	s.SeedWindowed(turns, 0)
+}
+
+// SeedWindowed is Seed for a suffix projection: prefixTurnCount is the number
+// of turn positions the full projection holds BELOW these turns. Turn ids are
+// global either way (the caller minted them with global entry positions), so
+// only paging is affected: Latest and Page express their cursors in the
+// full-projection position space, and pages below the window return no turns
+// — the hub serves those from its own file-backed paging of the same
+// transcript.
+func (s *appTurnSnapshot) SeedWindowed(turns []appwire.Turn, prefixTurnCount int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	s.prefixTurnCount = prefixTurnCount
 	s.turns = make([]appwire.Turn, len(turns))
 	s.turnIndex = make(map[string]int, len(turns))
 	s.activeTurnID = ""
@@ -147,6 +167,15 @@ func (s *appTurnSnapshot) applyLocked(records []appserver.SequencedNotification)
 			return &s.turns[idx]
 		}
 		if id == appwire.SystemPreludeTurnID {
+			// A windowed seed's prefix is unseen turn positions served by
+			// the hub from the transcript: the prelude already lives there
+			// (its position is the oldest by definition), so inserting a
+			// fresh copy here would double it and shift the window's
+			// positions into the prefix's cursor space. Report nothing; the
+			// client reads the prelude from the prefix pages.
+			if s.prefixTurnCount > 0 {
+				return nil
+			}
 			// The prelude turn is the one turn whose id fixes its position:
 			// it holds content from before the session's first real turn by
 			// definition (apptranscript.PreludeTurn, appprojector's bundled
@@ -376,6 +405,18 @@ func (s *appTurnSnapshot) Snapshot() []appwire.Turn {
 func (s *appTurnSnapshot) Latest(limit int) ([]appwire.Turn, string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.prefixTurnCount > 0 {
+		// Windowed seed: page in the full-projection position space. A
+		// window smaller than the limit extends below the window; the
+		// cursor then points at the prefix boundary and the hub serves the
+		// older turns from its file-backed paging.
+		total := s.prefixTurnCount + len(s.turns)
+		if limit <= 0 || total <= limit {
+			return cloneAppTurns(s.turns), strconv.Itoa(s.prefixTurnCount)
+		}
+		lo := len(s.turns) - limit
+		return cloneAppTurns(s.turns[lo:]), strconv.Itoa(total - limit)
+	}
 	turns, cursor := appwire.WindowTurns(s.turns, limit)
 	return cloneAppTurns(turns), cursor
 }
@@ -383,6 +424,40 @@ func (s *appTurnSnapshot) Latest(limit int) ([]appwire.Turn, string) {
 func (s *appTurnSnapshot) Page(cursor string, limit int) appwire.ThreadTurnsListResponse {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.prefixTurnCount > 0 {
+		// Cursor is an exclusive upper bound in the full position space.
+		// Pages above the prefix boundary serve from the window; pages at or
+		// below it return empty data (NextCursor preserves the client's
+		// position) — the hub's fallback answers those from the transcript.
+		hi := s.prefixTurnCount + len(s.turns)
+		if cursor != "" {
+			if c, err := strconv.Atoi(cursor); err == nil {
+				hi = c
+			}
+		}
+		if hi > s.prefixTurnCount+len(s.turns) {
+			hi = s.prefixTurnCount + len(s.turns)
+		}
+		if hi <= s.prefixTurnCount {
+			return appwire.ThreadTurnsListResponse{Data: nil, NextCursor: cursor}
+		}
+		// Window-local bounds: the window's turns occupy global positions
+		// [prefixTurnCount, prefixTurnCount+len(turns)). The page's lower
+		// bound never reaches below the prefix boundary: the turns there
+		// belong to the hub's file-backed pages, and the next cursor hands
+		// the client off at exactly that boundary — the position the full
+		// projection would point to when its own page runs out of window
+		// turns.
+		localHi := hi - s.prefixTurnCount
+		localLo := max(localHi-limit, 0)
+		next := ""
+		if s.prefixTurnCount > 0 {
+			next = strconv.Itoa(s.prefixTurnCount)
+		} else if localLo > 0 {
+			next = strconv.Itoa(localLo)
+		}
+		return appwire.ThreadTurnsListResponse{Data: cloneAppTurns(s.turns[localLo:localHi]), NextCursor: next}
+	}
 	page := appwire.PageTurns(s.turns, cursor, limit)
 	page.Data = cloneAppTurns(page.Data)
 	return page

--- a/server/appwire_turns_windowed_test.go
+++ b/server/appwire_turns_windowed_test.go
@@ -2,11 +2,43 @@ package server
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/internal/appserver"
+	"primeradiant.com/evener/internal/apptranscript"
+	"primeradiant.com/evener/llm"
 )
+
+// agentSidecarPrefixTurnCount computes the prefix-turn count the way the
+// transcript package's full-scan anchor does. The rule is private there, so
+// this helper restates it beside the differential that compares it against
+// the real projection: a mismatch between the two is the drift the
+// differential catches.
+func agentSidecarPrefixTurnCount(t *testing.T, header transcript.Header, prefix []transcript.Entry) int {
+	t.Helper()
+	// Mirror of transcript.prefixTurnCount: prelude (non-empty system prompt)
+	// plus one position per entry whose turn projects thread items.
+	count := 0
+	if strings.TrimSpace(header.SystemPrompt) != "" {
+		count++
+	}
+	for i := range prefix {
+		turn := prefix[i].Turn
+		projects := true
+		switch turn.Kind {
+		case schema.TurnCheckpoint, schema.TurnSummary, schema.TurnModelSwitch, schema.TurnEnvironment, schema.TurnHookCompleted:
+			projects = strings.TrimSpace(turn.Message.Text()) != "" || (turn.Kind == schema.TurnHookCompleted && turn.Hook != nil)
+		}
+		if projects {
+			count++
+		}
+	}
+	return count
+}
 
 // TestWindowedSnapshotPagesInFullPositionSpace: a windowed seed's Latest and
 // Page cursors must live in the same front-anchored position space a full
@@ -59,6 +91,32 @@ func TestWindowedSnapshotPagesInFullPositionSpace(t *testing.T) {
 	}
 	if cursor != "5" {
 		t.Fatalf("Latest(10) cursor: got %q, want 5", cursor)
+	}
+}
+
+// TestWindowedSnapshotLatestLimitBetweenWindowAndTotal: a limit that reaches
+// past the window but not the full position space (window 3, prefix 5, total
+// 8, limit 4) must return the whole window with the prefix-boundary cursor —
+// the window cannot serve more turns than it holds. This pins the panic the
+// naive `lo := len(turns)-limit` produced (slice bounds [-1:]) — limit is
+// client-controlled, so the negative index was reachable from a request.
+func TestWindowedSnapshotLatestLimitBetweenWindowAndTotal(t *testing.T) {
+	snapshot := &appTurnSnapshot{threadID: "th_l"}
+	window := make([]appwire.Turn, 3)
+	for i := range window {
+		window[i] = appwire.Turn{ID: "turn_" + strconv.Itoa(6+i), Items: []appwire.ThreadItem{{ID: "i" + strconv.Itoa(i)}}, ItemsView: "full", Status: appwire.TurnStatusCompleted}
+	}
+	snapshot.SeedWindowed(window, 5)
+
+	turns, cursor := snapshot.Latest(4)
+	if len(turns) != 3 {
+		t.Fatalf("Latest(4) turns: %d, want 3 (the window cannot serve more than it holds)", len(turns))
+	}
+	if turns[0].ID != "turn_6" || turns[2].ID != "turn_8" {
+		t.Fatalf("Latest(4) turn ids: %v", turns)
+	}
+	if cursor != "5" {
+		t.Fatalf("Latest(4) cursor: got %q, want 5 (the prefix boundary — the hub serves the rest)", cursor)
 	}
 }
 
@@ -145,5 +203,64 @@ func TestWindowedSnapshotMatchesFullProjectionDifferential(t *testing.T) {
 	}
 	if fullPage.NextCursor != "4" {
 		t.Fatalf("full next cursor: got %q, want 4 (sanity)", fullPage.NextCursor)
+	}
+}
+
+// TestTurnsFromEntriesWindowedCountMatchesFullProjection is the drift guard
+// for the sidecar's PrefixTurnCount: over the same transcript, the count the
+// windowed projection returns must equal the number of turns the FULL
+// projection holds below the suffix. The count is computed by the transcript
+// package (prefixTurnCount) from the prefix entries the windowed form never
+// sees, so this differential — full projection over prefix+suffix versus
+// windowed projection seeded with the transcript package's count — is what
+// proves the restated emission rules have not drifted.
+func TestTurnsFromEntriesWindowedCountMatchesFullProjection(t *testing.T) {
+	// A prefix mix that exercises the emission rules: projecting kinds, a
+	// marker kind with empty text (projects nothing), and a prelude.
+	header := transcript.Header{SessionID: "th_c", SystemPrompt: "system prompt"}
+	prefix := []transcript.Entry{
+		{Kind: "entry", Seq: 0, Turn: schema.NewTurn(schema.TurnUserInput, llm.User("one"))},
+		{Kind: "entry", Seq: 1, Turn: schema.NewTurn(schema.TurnAssistant, llm.Assistant("two"))},
+		// Empty-text environment turn: ProjectTurn emits nothing.
+		{Kind: "entry", Seq: 2, Turn: schema.NewTurn(schema.TurnEnvironment, llm.User("   "))},
+		{Kind: "entry", Seq: 3, Turn: schema.NewTurn(schema.TurnCheckpoint, llm.User("compaction summary"))},
+	}
+	suffix := []transcript.Entry{
+		{Kind: "entry", Seq: 4, Turn: schema.NewTurn(schema.TurnUserInput, llm.User("after"))},
+		{Kind: "entry", Seq: 5, Turn: schema.NewTurn(schema.TurnAssistant, llm.Assistant("done"))},
+	}
+	project := func(turn schema.Turn, turnID string, entryIndex int) []appwire.ThreadItem {
+		return apptranscript.ProjectTurn(turnID, entryIndex, turn, map[string]string{}, nil, apptranscript.ToolResultOutputImages)
+	}
+
+	// The count the sidecar would carry: transcript's restated rule.
+	want := agentSidecarPrefixTurnCount(t, header, prefix)
+	// The full projection over prefix+suffix: prelude + one turn per
+	// projecting entry (2 prefix entries project; the empty environment
+	// turn does not), then the suffix's turns.
+	fullTurns, _ := apptranscript.TurnsFromEntries(header, append(append([]transcript.Entry{}, prefix...), suffix...), project)
+	// Turns below the suffix in the full projection: everything except the
+	// suffix's turns. The suffix holds 2 turns; count them directly.
+	suffixTurns, _ := apptranscript.TurnsFromEntries(transcript.Header{}, suffix, project)
+	below := len(fullTurns) - len(suffixTurns)
+	if want != below {
+		t.Fatalf("prefix turn count drift: sidecar rule says %d, full projection holds %d below the window", want, below)
+	}
+
+	// The windowed turns are the full projection's suffix turns — the same
+	// turns at the same global ids — nothing else (the prelude belongs to the
+	// prefix space; the hub's file-backed pages serve it).
+	windowedTurns, windowedPrefix := apptranscript.TurnsFromEntriesWindowed(header, suffix, len(prefix), want, project)
+	if windowedPrefix != want {
+		t.Fatalf("windowed prefix count: got %d, want %d", windowedPrefix, want)
+	}
+	fullSuffix := fullTurns[len(fullTurns)-len(suffixTurns):]
+	if len(windowedTurns) != len(fullSuffix) {
+		t.Fatalf("windowed turns: got %d, want %d (the full projection's suffix turns)", len(windowedTurns), len(fullSuffix))
+	}
+	for i := range windowedTurns {
+		if windowedTurns[i].ID != fullSuffix[i].ID {
+			t.Fatalf("windowed turn %d id: got %q, want %q", i, windowedTurns[i].ID, fullSuffix[i].ID)
+		}
 	}
 }

--- a/server/appwire_turns_windowed_test.go
+++ b/server/appwire_turns_windowed_test.go
@@ -1,8 +1,8 @@
 package server
 
 import (
+	"path/filepath"
 	"strconv"
-	"strings"
 	"testing"
 
 	"primeradiant.com/evener/agent/schema"
@@ -12,33 +12,6 @@ import (
 	"primeradiant.com/evener/internal/apptranscript"
 	"primeradiant.com/evener/llm"
 )
-
-// agentSidecarPrefixTurnCount computes the prefix-turn count the way the
-// transcript package's full-scan anchor does. The rule is private there, so
-// this helper restates it beside the differential that compares it against
-// the real projection: a mismatch between the two is the drift the
-// differential catches.
-func agentSidecarPrefixTurnCount(t *testing.T, header transcript.Header, prefix []transcript.Entry) int {
-	t.Helper()
-	// Mirror of transcript.prefixTurnCount: prelude (non-empty system prompt)
-	// plus one position per entry whose turn projects thread items.
-	count := 0
-	if strings.TrimSpace(header.SystemPrompt) != "" {
-		count++
-	}
-	for i := range prefix {
-		turn := prefix[i].Turn
-		projects := true
-		switch turn.Kind {
-		case schema.TurnCheckpoint, schema.TurnSummary, schema.TurnModelSwitch, schema.TurnEnvironment, schema.TurnHookCompleted:
-			projects = strings.TrimSpace(turn.Message.Text()) != "" || (turn.Kind == schema.TurnHookCompleted && turn.Hook != nil)
-		}
-		if projects {
-			count++
-		}
-	}
-	return count
-}
 
 // TestWindowedSnapshotPagesInFullPositionSpace: a windowed seed's Latest and
 // Page cursors must live in the same front-anchored position space a full
@@ -211,21 +184,26 @@ func TestWindowedSnapshotMatchesFullProjectionDifferential(t *testing.T) {
 // windowed projection returns must equal the number of turns the FULL
 // projection holds below the suffix. The count is computed by the transcript
 // package (prefixTurnCount) from the prefix entries the windowed form never
-// sees, so this differential — full projection over prefix+suffix versus
-// windowed projection seeded with the transcript package's count — is what
-// proves the restated emission rules have not drifted.
+// sees, so this differential compares the count the production anchor
+// actually wrote (read back from the sidecar) against the count the real
+// full projection holds below the suffix — a drift in either side fails.
 func TestTurnsFromEntriesWindowedCountMatchesFullProjection(t *testing.T) {
+	const sessionID = "02wMz5Txv1C3Hut0M8GCeB"
 	// A prefix mix that exercises the emission rules: projecting kinds, a
 	// marker kind with empty text (projects nothing), and a prelude.
-	header := transcript.Header{SessionID: "th_c", SystemPrompt: "system prompt"}
+	header := transcript.Header{SessionID: sessionID, SystemPrompt: "system prompt"}
+	// The fixture mirrors a real windowed resume's boundary: the sidecar
+	// anchors AT the checkpoint entry, so the checkpoint is the SUFFIX's
+	// first entry (ResumeHistory's window starts at it) and the prefix is
+	// everything before it.
 	prefix := []transcript.Entry{
 		{Kind: "entry", Seq: 0, Turn: schema.NewTurn(schema.TurnUserInput, llm.User("one"))},
 		{Kind: "entry", Seq: 1, Turn: schema.NewTurn(schema.TurnAssistant, llm.Assistant("two"))},
 		// Empty-text environment turn: ProjectTurn emits nothing.
 		{Kind: "entry", Seq: 2, Turn: schema.NewTurn(schema.TurnEnvironment, llm.User("   "))},
-		{Kind: "entry", Seq: 3, Turn: schema.NewTurn(schema.TurnCheckpoint, llm.User("compaction summary"))},
 	}
 	suffix := []transcript.Entry{
+		{Kind: "entry", Seq: 3, Turn: schema.NewTurn(schema.TurnCheckpoint, llm.User("compaction summary"))},
 		{Kind: "entry", Seq: 4, Turn: schema.NewTurn(schema.TurnUserInput, llm.User("after"))},
 		{Kind: "entry", Seq: 5, Turn: schema.NewTurn(schema.TurnAssistant, llm.Assistant("done"))},
 	}
@@ -233,18 +211,46 @@ func TestTurnsFromEntriesWindowedCountMatchesFullProjection(t *testing.T) {
 		return apptranscript.ProjectTurn(turnID, entryIndex, turn, map[string]string{}, nil, apptranscript.ToolResultOutputImages)
 	}
 
-	// The count the sidecar would carry: transcript's restated rule.
-	want := agentSidecarPrefixTurnCount(t, header, prefix)
+	// The count the sidecar actually carries: write this transcript and
+	// resume it once — the full-scan anchor computes PrefixTurnCount from
+	// the prefix entries it decoded.
+	path := filepath.Join(t.TempDir(), sessionID+".transcript.jsonl")
+	writer, err := transcript.NewWriter(path, header)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	for _, entry := range append(append([]transcript.Entry{}, prefix...), suffix...) {
+		if err := writer.Append(entry.Turn); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	first, _, err := transcript.OpenWriterForResume(path, sessionID)
+	if err != nil {
+		t.Fatalf("first resume: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first: %v", err)
+	}
+	sidecar, ok := transcript.ReadSidecar(path)
+	if !ok {
+		t.Fatalf("sidecar missing after the full-scan resume")
+	}
+	want := sidecar.PrefixTurnCount
 	// The full projection over prefix+suffix: prelude + one turn per
 	// projecting entry (2 prefix entries project; the empty environment
 	// turn does not), then the suffix's turns.
 	fullTurns, _ := apptranscript.TurnsFromEntries(header, append(append([]transcript.Entry{}, prefix...), suffix...), project)
-	// Turns below the suffix in the full projection: everything except the
-	// suffix's turns. The suffix holds 2 turns; count them directly.
+	// Turns below the WINDOW in the full projection: the window's turns are
+	// the SUFFIX entries' turns (the checkpoint entry is the suffix's first
+	// entry — ResumeHistory's window starts AT it), so below-the-window is
+	// everything the full projection holds before the first suffix turn.
 	suffixTurns, _ := apptranscript.TurnsFromEntries(transcript.Header{}, suffix, project)
 	below := len(fullTurns) - len(suffixTurns)
-	if want != below {
-		t.Fatalf("prefix turn count drift: sidecar rule says %d, full projection holds %d below the window", want, below)
+	if below != want {
+		t.Fatalf("prefix turn count drift: sidecar says %d, full projection holds %d below the window", want, below)
 	}
 
 	// The windowed turns are the full projection's suffix turns — the same

--- a/server/appwire_turns_windowed_test.go
+++ b/server/appwire_turns_windowed_test.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"strconv"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/internal/appserver"
+)
+
+// TestWindowedSnapshotPagesInFullPositionSpace: a windowed seed's Latest and
+// Page cursors must live in the same front-anchored position space a full
+// seed of the same transcript would produce, with pages below the window
+// returning empty data (the hub serves those from its file-backed paging).
+func TestWindowedSnapshotPagesInFullPositionSpace(t *testing.T) {
+	snapshot := &appTurnSnapshot{threadID: "th_w"}
+	// Simulate a windowed seed: 5 prefix turn positions, 3 window turns.
+	window := make([]appwire.Turn, 3)
+	for i := range window {
+		window[i] = appwire.Turn{ID: "turn_" + strconv.Itoa(6+i), Items: []appwire.ThreadItem{{ID: "i" + strconv.Itoa(i)}}, ItemsView: "full", Status: appwire.TurnStatusCompleted}
+	}
+	snapshot.SeedWindowed(window, 5)
+
+	// Latest(2): the newest 2 turns, cursor pointing at global position 6.
+	turns, cursor := snapshot.Latest(2)
+	if len(turns) != 2 || turns[0].ID != "turn_7" || turns[1].ID != "turn_8" {
+		t.Fatalf("Latest(2) turns: %v", turns)
+	}
+	if cursor != "6" {
+		t.Fatalf("Latest(2) cursor: got %q, want 6 (global space)", cursor)
+	}
+
+	// Page above the boundary: page from cursor 6 with limit 2 → turns 5-6
+	// (global), i.e. window-local position 0 only (turn_5 belongs to the
+	// prefix's position space; the hub serves it from disk).
+	page := snapshot.Page("6", 2)
+	if len(page.Data) != 1 || page.Data[0].ID != "turn_6" {
+		t.Fatalf("Page(6,2) data: %v", page.Data)
+	}
+	if page.NextCursor != "5" {
+		t.Fatalf("Page(6,2) next: got %q, want 5 (the prefix boundary)", page.NextCursor)
+	}
+
+	// Page at the boundary: cursor 5 (== prefixTurnCount) returns empty —
+	// the hub's file-backed paging owns everything below.
+	page = snapshot.Page("5", 2)
+	if len(page.Data) != 0 {
+		t.Fatalf("Page(5,2) data: %v, want empty below the window", page.Data)
+	}
+	if page.NextCursor != "5" {
+		t.Fatalf("Page(5,2) next: got %q, want the cursor preserved", page.NextCursor)
+	}
+
+	// A limit larger than the window: everything the window holds, cursor
+	// at the prefix boundary.
+	turns, cursor = snapshot.Latest(10)
+	if len(turns) != 3 {
+		t.Fatalf("Latest(10) turns: %d, want 3", len(turns))
+	}
+	if cursor != "5" {
+		t.Fatalf("Latest(10) cursor: got %q, want 5", cursor)
+	}
+}
+
+// TestWindowedSnapshotPreludeNotificationDoesNotShiftPositions: a live
+// prelude notification arriving on a windowed snapshot must not insert a
+// prelude turn into the window — the prelude's position belongs to the
+// prefix the hub serves from disk, and a front insertion would shift every
+// window position into the prefix's cursor space.
+func TestWindowedSnapshotPreludeNotificationDoesNotShiftPositions(t *testing.T) {
+	snapshot := &appTurnSnapshot{threadID: "th_p"}
+	window := []appwire.Turn{{ID: "turn_6", Items: []appwire.ThreadItem{{ID: "i1"}}, ItemsView: "full", Status: appwire.TurnStatusCompleted}}
+	snapshot.SeedWindowed(window, 5)
+
+	// A prelude-announcing notification (e.g. plugin loaded, bundled into
+	// the prelude turn by the projector).
+	snapshot.Apply([]appserver.SequencedNotification{{
+		Notification: appwire.Notification{
+			Method: "plugin/loaded",
+			Params: []byte(`{"name":"x"}`),
+		},
+	}})
+
+	if len(snapshot.turns) != 1 {
+		t.Fatalf("windowed snapshot grew to %d turns after a prelude notification; the prelude must not enter the window", len(snapshot.turns))
+	}
+	if snapshot.turns[0].ID != "turn_6" {
+		t.Fatalf("window turn changed: %q", snapshot.turns[0].ID)
+	}
+}
+
+// TestWindowedSnapshotMatchesFullProjectionDifferential: over the same
+// suffix, the windowed form's turn ids and cursor space must equal what the
+// full form produces over prefix+suffix. This is the differential that
+// keeps the hub's live/past paging seam invisible to clients.
+func TestWindowedSnapshotMatchesFullProjectionDifferential(t *testing.T) {
+	// Full projection: turns 1..8 (ids turn_1..turn_8).
+	full := make([]appwire.Turn, 8)
+	for i := range full {
+		full[i] = appwire.Turn{ID: "turn_" + strconv.Itoa(i+1), Items: []appwire.ThreadItem{{ID: "i" + strconv.Itoa(i)}}, ItemsView: "full", Status: appwire.TurnStatusCompleted}
+	}
+	fullSnapshot := &appTurnSnapshot{threadID: "th_d"}
+	fullSnapshot.Seed(full)
+
+	// Windowed projection: prefix 5, suffix turns 6..8 with the SAME ids.
+	window := full[5:]
+	windowedSnapshot := &appTurnSnapshot{threadID: "th_d"}
+	windowedSnapshot.SeedWindowed(window, 5)
+
+	// Latest must agree on turns and cursor.
+	fullTurns, fullCursor := fullSnapshot.Latest(2)
+	winTurns, winCursor := windowedSnapshot.Latest(2)
+	if fullCursor != winCursor {
+		t.Fatalf("Latest cursor mismatch: full=%q windowed=%q", fullCursor, winCursor)
+	}
+	if len(fullTurns) != len(winTurns) {
+		t.Fatalf("Latest turn count mismatch: full=%d windowed=%d", len(fullTurns), len(winTurns))
+	}
+	for i := range fullTurns {
+		if fullTurns[i].ID != winTurns[i].ID {
+			t.Fatalf("Latest turn %d id mismatch: full=%q windowed=%q", i, fullTurns[i].ID, winTurns[i].ID)
+		}
+	}
+
+	// Page from a cursor above the window. The full projection pages turns
+	// 5-6 (next=4); the window holds only turn_6, so its page returns what
+	// it holds and hands off AT the prefix boundary (next=5). The invariant
+	// is not cursor equality — the windowed page is a prefix-truncated view,
+	// and smaller pages near the boundary are the design — it is that the
+	// windowed page never returns MORE than the full one, never skips a
+	// position the full page covered, and its next cursor lands exactly on
+	// the boundary the hub's file-backed paging takes over from.
+	fullPage := fullSnapshot.Page("6", 2)
+	winPage := windowedSnapshot.Page("6", 2)
+	if len(winPage.Data) > len(fullPage.Data) {
+		t.Fatalf("windowed page returned more turns than the full projection")
+	}
+	for i := range winPage.Data {
+		if winPage.Data[i].ID != fullPage.Data[len(fullPage.Data)-len(winPage.Data)+i].ID {
+			t.Fatalf("windowed page is not the trailing run of the full page's turns")
+		}
+	}
+	if winPage.NextCursor != "5" {
+		t.Fatalf("windowed next cursor: got %q, want the prefix boundary 5", winPage.NextCursor)
+	}
+	if fullPage.NextCursor != "4" {
+		t.Fatalf("full next cursor: got %q, want 4 (sanity)", fullPage.NextCursor)
+	}
+}

--- a/server/appwire_turns_windowed_test.go
+++ b/server/appwire_turns_windowed_test.go
@@ -99,24 +99,40 @@ func TestWindowedSnapshotLatestLimitBetweenWindowAndTotal(t *testing.T) {
 // prefix the hub serves from disk, and a front insertion would shift every
 // window position into the prefix's cursor space.
 func TestWindowedSnapshotPreludeNotificationDoesNotShiftPositions(t *testing.T) {
-	snapshot := &appTurnSnapshot{threadID: "th_p"}
-	window := []appwire.Turn{{ID: "turn_6", Items: []appwire.ThreadItem{{ID: "i1"}}, ItemsView: "full", Status: appwire.TurnStatusCompleted}}
-	snapshot.SeedWindowed(window, 5)
-
-	// A prelude-announcing notification (e.g. plugin loaded, bundled into
-	// the prelude turn by the projector).
-	snapshot.Apply([]appserver.SequencedNotification{{
+	// The real shape that reaches ensureTurn's prelude branch: a
+	// turn/item-started notification whose turn id is the prelude's
+	// (appwire.SystemPreludeTurnID) — the projector routes prelude-eligible
+	// startup announcements there. A made-up method would be dropped by
+	// applyLocked's switch before the guard under test ever ran, and the
+	// test would pass vacuously.
+	preludeNotification := appserver.SequencedNotification{
 		Notification: appwire.Notification{
-			Method: "plugin/loaded",
-			Params: []byte(`{"name":"x"}`),
+			Method: appwire.NotifyItemStarted,
+			Params: []byte(`{"threadId":"th_p","turnId":"` + appwire.SystemPreludeTurnID + `","item":{"id":"item_system_prompt_0","type":"systemMessage","status":"inProgress"}}`),
 		},
-	}})
-
-	if len(snapshot.turns) != 1 {
-		t.Fatalf("windowed snapshot grew to %d turns after a prelude notification; the prelude must not enter the window", len(snapshot.turns))
 	}
-	if snapshot.turns[0].ID != "turn_6" {
-		t.Fatalf("window turn changed: %q", snapshot.turns[0].ID)
+
+	// Windowed: the prelude belongs to the unseen prefix the hub serves from
+	// disk — the notification must NOT insert it into the window.
+	windowed := &appTurnSnapshot{threadID: "th_p"}
+	window := []appwire.Turn{{ID: "turn_6", Items: []appwire.ThreadItem{{ID: "i1"}}, ItemsView: "full", Status: appwire.TurnStatusCompleted}}
+	windowed.SeedWindowed(window, 5)
+	windowed.Apply([]appserver.SequencedNotification{preludeNotification})
+	if len(windowed.turns) != 1 {
+		t.Fatalf("windowed snapshot grew to %d turns after a prelude notification; the prelude must not enter the window", len(windowed.turns))
+	}
+	if windowed.turns[0].ID != "turn_6" {
+		t.Fatalf("window turn changed: %q", windowed.turns[0].ID)
+	}
+
+	// Non-windowed control: the SAME notification must insert the prelude —
+	// this is what proves the windowed branch above suppressed it rather
+	// than the notification being dead on arrival.
+	plain := &appTurnSnapshot{threadID: "th_p"}
+	plain.SeedWindowed(window, 0)
+	plain.Apply([]appserver.SequencedNotification{preludeNotification})
+	if len(plain.turns) != 2 || plain.turns[0].ID != appwire.SystemPreludeTurnID {
+		t.Fatalf("non-windowed control: turns=%v, want the prelude inserted at the front — otherwise the windowed assertion above proved nothing", plain.turns)
 	}
 }
 
@@ -247,11 +263,36 @@ func TestTurnsFromEntriesWindowedCountMatchesFullProjection(t *testing.T) {
 	// anchors AT the checkpoint entry, so the checkpoint is the SUFFIX's
 	// first entry (ResumeHistory's window starts at it) and the prefix is
 	// everything before it.
+	// An attention resolution turn: ProjectTurn has NO case for it — the
+	// default emits nothing — so it occupies no turn position. Written by
+	// production for every delegate session that resolves an attention.
+	resolution := schema.NewTurn(schema.TurnAttentionResolution, llm.User(""))
+	resolution.AttentionResolution = &schema.AttentionResolutionInfo{AttentionID: "att1", Disposition: "consumed"}
+	// A tool-results turn whose only part is a communicate result: the
+	// projector skips communicate results, so it emits nothing.
+	communicateOnly := schema.NewTurn(schema.TurnToolResults, llm.User("results"))
+	communicateOnly.Message.Content = []llm.ContentPart{{
+		Kind:       llm.ContentToolResult,
+		ToolResult: &llm.ToolResultData{ToolCallID: "c1", Name: "communicate", Content: "spoken"},
+	}}
+	// A steering turn (a delegate attention's durable record) projects.
+	steering := schema.NewTurn(schema.TurnSteering, llm.User("steer"))
+	steering.AttentionID = "att1"
 	prefix := []transcript.Entry{
 		{Kind: "entry", Seq: 0, Turn: schema.NewTurn(schema.TurnUserInput, llm.User("one"))},
 		{Kind: "entry", Seq: 1, Turn: schema.NewTurn(schema.TurnAssistant, llm.Assistant("two"))},
 		// Empty-text environment turn: ProjectTurn emits nothing.
 		{Kind: "entry", Seq: 2, Turn: schema.NewTurn(schema.TurnEnvironment, llm.User("   "))},
+		// A steering turn (a delegate attention's durable record) projects.
+		{Kind: "entry", Seq: 3, Turn: steering},
+		// The attention opened above, resolved. ProjectTurn has NO case for
+		// the resolution kind — the default emits nothing — so it occupies no
+		// turn position. Written by production for every delegate session
+		// that resolves an attention.
+		{Kind: "entry", Seq: 4, Turn: resolution},
+		// A system turn: also unhandled by ProjectTurn, also no position.
+		{Kind: "entry", Seq: 5, Turn: schema.NewTurn(schema.TurnSystem, llm.System("sys"))},
+		{Kind: "entry", Seq: 6, Turn: communicateOnly},
 	}
 	suffix := []transcript.Entry{
 		{Kind: "entry", Seq: 3, Turn: schema.NewTurn(schema.TurnCheckpoint, llm.User("compaction summary"))},

--- a/server/appwire_turns_windowed_test.go
+++ b/server/appwire_turns_windowed_test.go
@@ -154,13 +154,12 @@ func TestWindowedSnapshotMatchesFullProjectionDifferential(t *testing.T) {
 	}
 
 	// Page from a cursor above the window. The full projection pages turns
-	// 5-6 (next=4); the window holds only turn_6, so its page returns what
-	// it holds and hands off AT the prefix boundary (next=5). The invariant
-	// is not cursor equality — the windowed page is a prefix-truncated view,
-	// and smaller pages near the boundary are the design — it is that the
-	// windowed page never returns MORE than the full one, never skips a
-	// position the full page covered, and its next cursor lands exactly on
-	// the boundary the hub's file-backed paging takes over from.
+	// 5-6 (next=4); the window holds only turn_6, so its page returns what it
+	// holds and its next cursor lands AT the prefix boundary (next=5) — this
+	// page's lower bound IS the window floor (localLo=0), so the handoff is
+	// correct. The invariant is that the windowed page never returns MORE
+	// than the full one, never skips a position the full page covered, and
+	// its next cursor names the position the page actually stopped at.
 	fullPage := fullSnapshot.Page("6", 2)
 	winPage := windowedSnapshot.Page("6", 2)
 	if len(winPage.Data) > len(fullPage.Data) {
@@ -172,10 +171,62 @@ func TestWindowedSnapshotMatchesFullProjectionDifferential(t *testing.T) {
 		}
 	}
 	if winPage.NextCursor != "5" {
-		t.Fatalf("windowed next cursor: got %q, want the prefix boundary 5", winPage.NextCursor)
+		t.Fatalf("windowed next cursor: got %q, want 5 (the prefix boundary — this page reached the window floor)", winPage.NextCursor)
 	}
 	if fullPage.NextCursor != "4" {
 		t.Fatalf("full next cursor: got %q, want 4 (sanity)", fullPage.NextCursor)
+	}
+}
+
+// TestWindowedPagingWalksEveryWindowTurn pins the adversarial finding that a
+// full window page (localLo > 0) handed the client a cursor at the PREFIX
+// BOUNDARY, so the next page fell below the window and the hub's file-backed
+// paging took over — silently skipping every window turn below localLo. A
+// client paging the way the web frontend does (Latest, then follow
+// NextCursor) must reach every window turn exactly once, in order, with no
+// duplicates and no gaps, and hand off to the hub only at the window floor.
+func TestWindowedPagingWalksEveryWindowTurn(t *testing.T) {
+	// A window larger than one page: 70 window turns over a 5-turn prefix,
+	// paged 30 at a time (the frontend's OLDER_TURNS_PAGE_SIZE).
+	prefixTurns := 5
+	window := make([]appwire.Turn, 70)
+	for i := range window {
+		window[i] = appwire.Turn{ID: "turn_" + strconv.Itoa(prefixTurns+i+1), Items: []appwire.ThreadItem{{ID: "i" + strconv.Itoa(i)}}, ItemsView: "full", Status: appwire.TurnStatusCompleted}
+	}
+	snapshot := &appTurnSnapshot{threadID: "th_walk"}
+	snapshot.SeedWindowed(window, prefixTurns)
+
+	seen := map[string]bool{}
+	turns, cursor := snapshot.Latest(30)
+	if len(turns) != 30 {
+		t.Fatalf("Latest(30) turns: got %d, want 30", len(turns))
+	}
+	for _, turn := range turns {
+		if seen[turn.ID] {
+			t.Fatalf("duplicate turn %q in the paging walk", turn.ID)
+		}
+		seen[turn.ID] = true
+	}
+	pages := 0
+	for cursor != "" && pages < 10 {
+		page := snapshot.Page(cursor, 30)
+		for _, turn := range page.Data {
+			if seen[turn.ID] {
+				t.Fatalf("duplicate turn %q in the paging walk", turn.ID)
+			}
+			seen[turn.ID] = true
+		}
+		cursor = page.NextCursor
+		pages++
+	}
+	// Every window turn must have been reachable.
+	if len(seen) != len(window) {
+		t.Fatalf("paging walk reached %d of %d window turns — %d unreachable", len(seen), len(window), len(window)-len(seen))
+	}
+	// The walk must hand off to the hub's file-backed paging exactly at the
+	// prefix boundary, never above it (an early handoff is what skipped turns).
+	if cursor != strconv.Itoa(prefixTurns) {
+		t.Fatalf("final cursor: got %q, want the prefix boundary %d — the walk handed off at the wrong position", cursor, prefixTurns)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #643. A resumed session's wall-clock time-to-ready was dominated by full decodes of an unbounded append-only transcript, even though compaction means only a tiny suffix is live history (measured on a real 183MB / 84k-entry transcript: the last checkpoint sits at line 84,065 of 84,146 — 0.4% of the bytes are live; resume decoded all of them, twice).

This adds a **validated-offset resume sidecar** — `<transcript>.resume-sidecar.json` — recording the byte offset of the last checkpoint entry. A windowed resume validates it (session id, bounds, file identity via dev/inode, sha256 anchors over the first and pre-boundary byte windows, boundary seq) and decodes only `[checkpoint, ...rest]`: exactly ResumeHistory's window. **Windowed resume measured 10.4ms vs a 614ms full scan on a 183MB fixture (~59x).**

## What changed

- **Two anchors write the sidecar.** Compaction (the writer records the checkpoint entry's byte-start plus prefix facts as it appends; `PrefixTurnCount=-1`, snapshots incomplete — it cannot vouch for what it never decoded) and opportunistic post-full-scan (every entry decoded; complete snapshots, exact prefix-turn count).
- **Serve's compaction-anchored fallback refreshes the sidecar** after the identity projection's error gate — the full read it already pays converts the sidecar to the full-scan one, so the next resume goes windowed instead of repeating the fallback. Measured: worst case is one doubled read per compaction, vs every resume before.
- **The daemon's turn snapshot arms windowed** via the sidecar's prefix-turn count, paging in the full projection's cursor space; older pages fall through to the hub's file-backed paging.
- **Unconditional full-scan fallback** on any mismatch — missing, corrupt, stale, truncated, or boundary-violating sidecar never errors; the legacy path runs. Fork children fail the file-identity gate by construction.
- **Fold snapshots** (pending attentions with resolutions, delivery commits, client-mutation turns) carried when complete; the transcript package restates the agent fold's rules rule-for-rule (forced by the import cycle) and refuses any file the fold would reject.

Deviation from the issue's design, deliberately: **no clean-shutdown anchor** — shutdown cannot know the checkpoint boundary without re-reading, and a wrong offset would skip live history. The opportunistic anchor covers the shutdown case on the resume that follows.

## Verification

- All 16 issue-list tests, plus the suites: `agent` 118.9s, `cmd/evener` 26.7s, `server` 8.0s, `internal/apptranscript` 7.7s, `agent/transcript` 1.4s; gofmt/vet clean; the `FuzzDelegateAttentionFold` extension ran 875+ clean engine executions.
- **Differentials, not fixtures-as-proof**: the sidecar's prefix-turn count is asserted against the real full projection over the same entries (including every non-projecting kind — resolution, system, communicate-only tool results); the snapshot's refusals are asserted against the agent fold over 17 shapes AND over fuzz-generated inputs; the windowed snapshot's turns/cursors are asserted against the full projection's.
- **Every fix in the loop is mutation-verified** — reverting each one fails the test that claims to guard it (the exact failure mode, not a vacuous pass).
- Lifecycle walked empirically by a reviewer: fresh → compaction anchor → windowed resume → refresh → windowed → second compaction → refresh, every transition validating (identity, anchors, boundary), every window matching ResumeHistory's.

## Review process

Four simplify angles (Reuse / Simplification / Efficiency / Altitude) then two adversarial rounds, all findings adjudicated against the code before applying. The loop caught and fixed: a boundary cursor that stranded window turns (medium), a failure-count attribution bug on fork children (medium), the fold snapshot's attention dedupe and dropped resolutions (medium), two parity gaps plus their missing differential (medium), an inflated prefix-turn count that duplicated turns at the hub paging seam (**high** — the projection restatement counted kinds `ProjectTurn` emits nothing for), a quadratic conflict scan (medium, measured 8.9s at 40k commits), a vacuous prelude test, and an unguarded error-gate ordering. Each round's findings shrank; round 2's verified-clean sections cover the full lifecycle, crash windows, rollback handling, and fold parity.

Follow-ups filed: #742 (the rearm fallback's per-resume full read for non-serve consumers), #743 (the fallback's doubled decode), #746 (the sidecar's 1MiB limit vs delivery-heavy transcripts).
