### PR TITLE
fix(providers): report a set-but-shadowed credential env var

### DIFF
--- a/appwire/types.go
+++ b/appwire/types.go
@@ -1944,14 +1944,19 @@ type AuthStatusResponse struct {
 	// HasStoredFile is true when a key exists in credentials.toml.
 	HasStoredFile bool `json:"hasStoredFile,omitempty"`
 	// EnvVar is the name of the env var that supplies a key, when present.
-	EnvVar       string `json:"envVar,omitempty"`
-	Email        string `json:"email,omitempty"`
-	StoredEmail  string `json:"storedEmail,omitempty"`
-	AccountID    string `json:"accountId,omitempty"`
-	WorkspaceID  string `json:"workspaceId,omitempty"`
-	NeedsRefresh bool   `json:"needsRefresh,omitempty"`
-	NeedsLogin   bool   `json:"needsLogin,omitempty"`
-	Error        string `json:"error,omitempty"`
+	EnvVar string `json:"envVar,omitempty"`
+	// ShadowedEnvVar names an environment variable that is set but loses to
+	// a higher-precedence credential (api_key, credential_headers, or
+	// store, spec §10); empty when no such variable is set, including when
+	// an env source is itself what resolves.
+	ShadowedEnvVar string `json:"shadowedEnvVar,omitempty"`
+	Email          string `json:"email,omitempty"`
+	StoredEmail    string `json:"storedEmail,omitempty"`
+	AccountID      string `json:"accountId,omitempty"`
+	WorkspaceID    string `json:"workspaceId,omitempty"`
+	NeedsRefresh   bool   `json:"needsRefresh,omitempty"`
+	NeedsLogin     bool   `json:"needsLogin,omitempty"`
+	Error          string `json:"error,omitempty"`
 }
 
 type AuthLoginStartParams struct {
@@ -2548,7 +2553,12 @@ type InstanceEntry struct {
 	HasStoredFile  bool     `json:"hasStoredFile,omitempty"`
 	HasStoredOAuth bool     `json:"hasStoredOAuth"`
 	EnvVar         string   `json:"envVar,omitempty"`
-	StoredEmail    string   `json:"storedEmail,omitempty"`
+	// ShadowedEnvVar names an environment variable that is set but loses to
+	// a higher-precedence credential (api_key, credential_headers, or
+	// store, spec §10); empty when no such variable is set, including when
+	// an env source is itself what resolves.
+	ShadowedEnvVar string `json:"shadowedEnvVar,omitempty"`
+	StoredEmail    string `json:"storedEmail,omitempty"`
 	// CredentialRequired is false when this instance has no credential to
 	// look for at all — auth = none or optional-bearer — so an absent
 	// credential is not a missing one. It is never omitted: false is the

--- a/appwire/types_test.go
+++ b/appwire/types_test.go
@@ -494,7 +494,7 @@ func TestInstanceEntryOmitsUnsetRegistryFields(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 	got := string(raw)
-	for _, absent := range []string{`"base"`, `"surface"`, `"baseUrl"`, `"vars"`, `"hidden"`, `"authModes"`, `"hasStoredFile"`, `"envVar"`, `"storedEmail"`, `"warnings"`} {
+	for _, absent := range []string{`"base"`, `"surface"`, `"baseUrl"`, `"vars"`, `"hidden"`, `"authModes"`, `"hasStoredFile"`, `"envVar"`, `"shadowedEnvVar"`, `"storedEmail"`, `"warnings"`} {
 		if strings.Contains(got, absent) {
 			t.Fatalf("marshal=%s should omit %s", got, absent)
 		}

--- a/cmd/evener-hub/app_auth.go
+++ b/cmd/evener-hub/app_auth.go
@@ -188,6 +188,7 @@ func (c *hubAuthController) Status(params appwire.AuthStatusParams) (appwire.Aut
 			Auth:             res.Transport.Auth,
 			Implicit:         true,
 			CredentialSource: res.Credential.Source,
+			ShadowedEnvVar:   res.ShadowedEnvVar,
 			Warnings:         res.Warnings,
 		}), nil
 	}

--- a/cmd/evener-hub/app_auth.go
+++ b/cmd/evener-hub/app_auth.go
@@ -626,11 +626,12 @@ func (c *hubAuthController) instanceStatus(inst registry.Instance) appwire.AuthS
 		// A credential resolved from anywhere is a sign-in; "none" is the one
 		// state that is not one, and for an auth-none instance it is also not
 		// anything missing.
-		SignedIn:      inst.CredentialSource != "none",
-		ActiveSource:  inst.CredentialSource,
-		AuthModes:     authModesFor(inst.Auth),
-		HasStoredFile: hasFile,
-		EnvVar:        envVar,
+		SignedIn:       inst.CredentialSource != "none",
+		ActiveSource:   inst.CredentialSource,
+		AuthModes:      authModesFor(inst.Auth),
+		HasStoredFile:  hasFile,
+		EnvVar:         envVar,
+		ShadowedEnvVar: inst.ShadowedEnvVar,
 	}
 }
 

--- a/cmd/evener-hub/app_auth_instance_test.go
+++ b/cmd/evener-hub/app_auth_instance_test.go
@@ -248,6 +248,58 @@ func TestAuth_InstanceStatus_ReflectsRegistryCredentialSource(t *testing.T) {
 	}
 }
 
+// TestAuth_InstanceStatus_ReportsShadowedEnvVar covers the shadow relation
+// that ActiveSource cannot express on its own: WORK_ANT_KEY set in the
+// environment while a stored key outranks it (spec §10). Before the hub
+// reported this separately, the credentials pane had no way to tell the
+// user their exported variable was doing nothing (issue #712).
+func TestAuth_InstanceStatus_ReportsShadowedEnvVar(t *testing.T) {
+	oaitest.IsolateOpenAIAuth(t)
+	dir := t.TempDir()
+	stateDir := t.TempDir()
+	tomlPath := writeProvidersToml(t, dir, bearerInstanceToml)
+	ctrl := newTestAuthController(t, dir, stateDir, tomlPath, map[string]string{"WORK_ANT_KEY": "env-key"})
+	instances := &hubInstancesController{reg: ctrl.reg, providersConfigPath: tomlPath, auth: ctrl}
+
+	// With only the environment variable set, it is what resolves - nothing
+	// shadows it.
+	inst, ok := ctrl.reg.Get().Instance("work-ant")
+	if !ok {
+		t.Fatal("an authored entry is always an instance")
+	}
+	if inst.CredentialSource != "env:WORK_ANT_KEY" || inst.ShadowedEnvVar != "" {
+		t.Fatalf("credential source = %q shadowed = %q, want env:WORK_ANT_KEY and no shadow", inst.CredentialSource, inst.ShadowedEnvVar)
+	}
+	if got := ctrl.instanceStatus(inst); got.EnvVar != "WORK_ANT_KEY" || got.ShadowedEnvVar != "" {
+		t.Fatalf("status = %+v, want EnvVar WORK_ANT_KEY and no shadow", got)
+	}
+	if row := instanceListRow(t, instances, "work-ant"); row.EnvVar != "WORK_ANT_KEY" || row.ShadowedEnvVar != "" {
+		t.Fatalf("evener/instance/list row = %+v, want EnvVar WORK_ANT_KEY and no shadow", row)
+	}
+
+	// A stored key outranks it: the store wins, and the still-set
+	// environment variable is now a real shadow every surface should carry.
+	if err := ctrl.creds.Set("work-ant", "sk-w"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := ctrl.reg.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	inst, ok = ctrl.reg.Get().Instance("work-ant")
+	if !ok {
+		t.Fatal("a stored key makes the instance resolvable")
+	}
+	if inst.CredentialSource != "store" || inst.ShadowedEnvVar != "WORK_ANT_KEY" {
+		t.Fatalf("credential source = %q shadowed = %q, want store/WORK_ANT_KEY", inst.CredentialSource, inst.ShadowedEnvVar)
+	}
+	if got := ctrl.instanceStatus(inst); got.ActiveSource != "store" || got.ShadowedEnvVar != "WORK_ANT_KEY" {
+		t.Fatalf("status = %+v, want ActiveSource store and ShadowedEnvVar WORK_ANT_KEY", got)
+	}
+	if row := instanceListRow(t, instances, "work-ant"); row.ActiveSource != "store" || row.ShadowedEnvVar != "WORK_ANT_KEY" {
+		t.Fatalf("evener/instance/list row = %+v, want ActiveSource store and ShadowedEnvVar WORK_ANT_KEY", row)
+	}
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // 5. An instance whose name is the registry id resolves the same way
 // ─────────────────────────────────────────────────────────────────────────────

--- a/cmd/evener-hub/app_auth_instance_test.go
+++ b/cmd/evener-hub/app_auth_instance_test.go
@@ -300,6 +300,38 @@ func TestAuth_InstanceStatus_ReportsShadowedEnvVar(t *testing.T) {
 	}
 }
 
+// TestAuth_StatusFallbackReportsShadowedEnvVar covers the curated-implicit-
+// provider fallback in Status (PR #758 review): a provider with no
+// resolvable base URL (openai-compatible with OPENAI_COMPATIBLE_BASE_URL
+// unset) is Hidden, so it never becomes an r.Instance() and Status falls
+// through to ResolveInstance and a hand-built registry.Instance. That
+// construction must carry ShadowedEnvVar the same as the normal path does.
+func TestAuth_StatusFallbackReportsShadowedEnvVar(t *testing.T) {
+	oaitest.IsolateOpenAIAuth(t)
+	dir := t.TempDir()
+	stateDir := t.TempDir()
+	ctrl := newTestAuthController(t, dir, stateDir, writeProvidersToml(t, dir, ""),
+		map[string]string{"OPENAI_COMPATIBLE_API_KEY": "env-key"})
+
+	if _, ok := ctrl.reg.Get().Instance("openai-compatible"); ok {
+		t.Fatal("openai-compatible with no base URL must be Hidden, not an instance")
+	}
+	if err := ctrl.creds.Set("openai-compatible", "stored-key"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := ctrl.reg.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	status, err := ctrl.Status(appwire.AuthStatusParams{Provider: "openai-compatible"})
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.ActiveSource != "store" || status.ShadowedEnvVar != "OPENAI_COMPATIBLE_API_KEY" {
+		t.Fatalf("status = %+v, want ActiveSource store and ShadowedEnvVar OPENAI_COMPATIBLE_API_KEY (the fallback construction must carry it too)", status)
+	}
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // 5. An instance whose name is the registry id resolves the same way
 // ─────────────────────────────────────────────────────────────────────────────

--- a/cmd/evener-hub/app_instances.go
+++ b/cmd/evener-hub/app_instances.go
@@ -98,6 +98,7 @@ func (c *hubInstancesController) entryFor(inst registry.Instance) appwire.Instan
 		HasStoredFile:      status.HasStoredFile,
 		HasStoredOAuth:     status.HasStoredOAuth,
 		EnvVar:             status.EnvVar,
+		ShadowedEnvVar:     status.ShadowedEnvVar,
 		StoredEmail:        status.StoredEmail,
 		CredentialRequired: inst.Auth != registry.AuthNone && inst.Auth != registry.AuthOptionalBearer,
 		Warnings:           inst.Warnings,

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/credentialLabels.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/credentialLabels.test.ts
@@ -166,6 +166,47 @@ describe("credentialLayers", () => {
     ]);
   });
 
+  // The other shadow relation spec §10 admits: an environment variable left
+  // set behind a source that outranks it. shadowedEnvVar is the hub's own
+  // answer to this for the environment layer, since activeSource only ever
+  // names the winner (issue #712).
+  test("an environment variable left set behind a higher-ranked source shows as shadowed", () => {
+    const inst = instance({
+      name: "a",
+      providerId: "anthropic",
+      activeSource: "store",
+      hasStoredFile: true,
+      shadowedEnvVar: "ANTHROPIC_API_KEY",
+    });
+    expect(credentialLayers(inst)).toEqual([
+      { source: "store", label: "Configured via stored API key", effective: true },
+      {
+        source: "env:ANTHROPIC_API_KEY",
+        label: "Configured via environment variable (ANTHROPIC_API_KEY)",
+        effective: false,
+      },
+    ]);
+  });
+
+  test("a stored key and a shadowed env var both render when providers.toml beats both", () => {
+    const inst = instance({
+      name: "a",
+      providerId: "anthropic",
+      activeSource: "api_key",
+      hasStoredFile: true,
+      shadowedEnvVar: "ANTHROPIC_API_KEY",
+    });
+    expect(credentialLayers(inst)).toEqual([
+      { source: "api_key", label: "Configured via providers.toml", effective: true },
+      { source: "store", label: "Configured via stored API key", effective: false },
+      {
+        source: "env:ANTHROPIC_API_KEY",
+        label: "Configured via environment variable (ANTHROPIC_API_KEY)",
+        effective: false,
+      },
+    ]);
+  });
+
   test("an oauth-effective instance shows only the oauth layer - oauth-openai-codex never shares an instance with store/env", () => {
     const inst = instance({
       name: "a",

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/credentialLabels.ts
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/credentialLabels.ts
@@ -47,16 +47,16 @@ export function activeSourceLabel(instance: InstanceEntry): string {
 
 // credentialLayers lists the credential line(s) the detail sheet shows: the
 // effective source first, then any credential this instance holds that the
-// resolution passed over. Spec §10 ranks four of them - api_key >
-// credential_headers > store > env - but the wire only lets the pane see one
-// of those losers: hasStoredFile is read straight from the credential store
+// resolution passed over (spec §10: api_key > credential_headers > store >
+// env). hasStoredFile is read straight from the credential store
 // (instanceStatus, cmd/evener-hub/app_auth.go), independently of what won,
-// while envVar is DERIVED from an "env:" activeSource and so is only ever
-// set on the winner. A set-but-losing environment variable is therefore
-// invisible here until the hub reports it separately. Saying the stored key
-// lost matters most anyway: it is the one the sheet offers to replace.
-// Empty when nothing has ever resolved (activeSource "none"); see
-// activeSourceLabel for that case's own message.
+// so a stored key behind providers.toml or a credential header renders as
+// shadowed. shadowedEnvVar answers the same question for the environment
+// layer: activeSource only ever names the winner, so a set-but-losing
+// variable has no other way onto the wire - the hub reports it separately
+// (issue #712). The two can coexist (an api_key can shadow both a stored
+// key and a set variable at once). Empty when nothing has ever resolved
+// (activeSource "none"); see activeSourceLabel for that case's own message.
 export function credentialLayers(instance: InstanceEntry): CredentialLayerView[] {
   if (instance.activeSource === "none") return [];
   const layers: CredentialLayerView[] = [
@@ -64,6 +64,13 @@ export function credentialLayers(instance: InstanceEntry): CredentialLayerView[]
   ];
   if (instance.hasStoredFile && instance.activeSource !== "store") {
     layers.push({ source: "store", label: STORED_KEY_LABEL, effective: false });
+  }
+  if (instance.shadowedEnvVar) {
+    layers.push({
+      source: `env:${instance.shadowedEnvVar}`,
+      label: `Configured via environment variable (${instance.shadowedEnvVar})`,
+      effective: false,
+    });
   }
   return layers;
 }

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -121,6 +121,7 @@ export interface AuthStatusResponse {
   hasStoredOAuth: boolean;
   hasStoredFile?: boolean;
   envVar?: string;
+  shadowedEnvVar?: string;
   email?: string;
   storedEmail?: string;
   accountId?: string;
@@ -535,6 +536,7 @@ export interface InstanceEntry {
   hasStoredFile?: boolean;
   hasStoredOAuth: boolean;
   envVar?: string;
+  shadowedEnvVar?: string;
   storedEmail?: string;
   credentialRequired: boolean;
   warnings?: string[];

--- a/cmd/evener/providers.go
+++ b/cmd/evener/providers.go
@@ -107,9 +107,16 @@ func runProvidersList(args []string, stdout, stderr io.Writer) error {
 		if base == "" {
 			base = inst.ProviderID
 		}
-		notes := inst.Warnings
+		notes := append([]string(nil), inst.Warnings...)
+		if inst.ShadowedEnvVar != "" {
+			// The variable is set but a higher-precedence source won (spec
+			// §10); naming it is the only way the user learns their export
+			// is doing nothing (issue #712). The source it lost to is named,
+			// never the value either side holds.
+			notes = append(notes, fmt.Sprintf("%s set but shadowed by %s", inst.ShadowedEnvVar, inst.CredentialSource))
+		}
 		if inst.Default {
-			notes = append(append([]string(nil), notes...), "default")
+			notes = append(notes, "default")
 		}
 		// The credential SOURCE is what a listing may show; the value it names
 		// never crosses this boundary (spec §11.2) — and neither does the

--- a/cmd/evener/providers_test.go
+++ b/cmd/evener/providers_test.go
@@ -138,6 +138,32 @@ func TestProvidersListShowsInstancesCredentialSourcesAndStrayEntries(t *testing.
 	}
 }
 
+// TestProvidersListReportsShadowedEnvVar covers the shadow relation
+// CredentialSource cannot express on its own: WORK_API_KEY set in the
+// environment while a stored key outranks it (spec §10). Before this note,
+// `evener providers list` gave no sign the exported variable was doing
+// nothing (issue #712).
+func TestProvidersListReportsShadowedEnvVar(t *testing.T) {
+	root := providersTestEnv(t, map[string]string{"WORK_API_KEY": "env-secret-val"})
+	writeProvidersToml(t, root, "[providers.work]\nbase = \"openai\"\nbase_url = \"https://gw.example.com/v1\"\n")
+	creds := "schema = 1\n[providers.work]\napi_key = \"store-secret-val\"\n"
+	if err := os.WriteFile(filepath.Join(root, "credentials.toml"), []byte(creds), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := runProviders([]string{"list"}, nil, &stdout, &stderr); err != nil {
+		t.Fatalf("list: %v\n%s", err, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "WORK_API_KEY set but shadowed by store") {
+		t.Fatalf("missing shadowed env var note in\n%s", out)
+	}
+	if strings.Contains(out, "env-secret-val") || strings.Contains(out, "store-secret-val") {
+		t.Fatalf("list prints credential sources, never values (spec §11.2):\n%s", out)
+	}
+}
+
 // The tri-state's third state is visible, not silent (spec §14.1).
 func TestProvidersListReportsAnEmptyProvidersConfigAsNoUserLayer(t *testing.T) {
 	providersTestEnv(t, map[string]string{"EVENER_PROVIDERS_CONFIG": ""})

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -674,6 +674,32 @@ _(no fields)_
 | `vars` | `map[string]string` | yes |  |
 
 
+### `InstanceEntry`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `name` | `string` |  |  |
+| `base` | `string` | yes |  |
+| `providerId` | `string` |  |  |
+| `protocol` | `string` |  |  |
+| `surface` | `string` | yes |  |
+| `auth` | `string` |  |  |
+| `baseUrl` | `string` | yes |  |
+| `vars` | `map[string]string` | yes |  |
+| `implicit` | `bool` |  |  |
+| `hidden` | `bool` | yes |  |
+| `isDefault` | `bool` |  |  |
+| `authModes` | `[]string` | yes |  |
+| `activeSource` | `string` |  |  |
+| `hasStoredFile` | `bool` | yes |  |
+| `hasStoredOAuth` | `bool` |  |  |
+| `envVar` | `string` | yes |  |
+| `shadowedEnvVar` | `string` | yes |  |
+| `storedEmail` | `string` | yes |  |
+| `credentialRequired` | `bool` |  |  |
+| `warnings` | `[]string` | yes |  |
+
+
 ### `InstanceListResponse`
 
 | Field | Go type | Omitempty | Embedded |

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -385,6 +385,7 @@ An embedded type contributes its own fields inline.
 | `hasStoredOAuth` | `bool` |  |  |
 | `hasStoredFile` | `bool` | yes |  |
 | `envVar` | `string` | yes |  |
+| `shadowedEnvVar` | `string` | yes |  |
 | `email` | `string` | yes |  |
 | `storedEmail` | `string` | yes |  |
 | `accountId` | `string` | yes |  |

--- a/internal/appwiredoc/main.go
+++ b/internal/appwiredoc/main.go
@@ -114,6 +114,12 @@ func build() docData {
 		register(v)
 	}
 	register(appwire.EvenerDelegateInfo{})
+	// InstanceEntry never appears as a method's own Params/Result - only
+	// nested inside InstanceListResponse.Instances - so without this it
+	// would never get a field table of its own, and a field documented on
+	// its AuthStatusResponse twin (e.g. shadowedEnvVar) would silently go
+	// undocumented here (PR #758 review).
+	register(appwire.InstanceEntry{})
 
 	for _, m := range appwire.Methods {
 		d.Methods = append(d.Methods, methodView{

--- a/internal/appwiredoc/main_test.go
+++ b/internal/appwiredoc/main_test.go
@@ -136,3 +136,29 @@ func TestBuildIncludesStableDelegateInfo(t *testing.T) {
 	}
 	t.Fatal("build() missing EvenerDelegateInfo")
 }
+
+// TestBuildIncludesInstanceEntry guards PR #758's review finding:
+// InstanceEntry only ever appears nested inside InstanceListResponse's
+// Instances field, never as a method's own Params/Result, so without an
+// explicit registration it silently gets no field table at all - and a
+// field added there (shadowedEnvVar) can be documented on its
+// AuthStatusResponse twin while missing here with nothing to catch it.
+func TestBuildIncludesInstanceEntry(t *testing.T) {
+	d := build()
+	for _, tv := range d.Types {
+		if tv.Name != "InstanceEntry" {
+			continue
+		}
+		fields := map[string]bool{}
+		for _, field := range tv.Fields {
+			fields[field.JSON] = true
+		}
+		for _, name := range []string{"name", "providerId", "activeSource", "envVar", "shadowedEnvVar", "credentialRequired"} {
+			if !fields[name] {
+				t.Fatalf("InstanceEntry missing field %q: %+v", name, tv.Fields)
+			}
+		}
+		return
+	}
+	t.Fatal("build() missing InstanceEntry")
+}

--- a/llm/registry/instances.go
+++ b/llm/registry/instances.go
@@ -33,7 +33,12 @@ type Instance struct {
 	Hidden           bool              `json:"hidden,omitempty"`
 	Default          bool              `json:"default,omitempty"`
 	CredentialSource string            `json:"credential_source"`
-	Warnings         []string          `json:"warnings,omitempty"`
+	// ShadowedEnvVar names an environment variable that is set but loses to
+	// a higher-precedence credential (api_key, credential_headers, or
+	// store, spec §10); empty when no such variable is set, including when
+	// an env source is itself what resolves.
+	ShadowedEnvVar string   `json:"shadowed_env_var,omitempty"`
+	Warnings       []string `json:"warnings,omitempty"`
 }
 
 // envVarName is the spec §6.2 rule: the id uppercased with `-` → `_`.
@@ -95,6 +100,39 @@ func (r *Registry) effectiveAPIKeyEnv(rec *record) []string {
 	return rec.ownAPIKeyEnv
 }
 
+// envCandidates lists, in the order credential resolution tries them, every
+// environment variable name that could supply rec's key: its effective
+// api_key_env, then (only for a name that is not itself a registry id, spec
+// §10) the name derived from the instance name. It never reads the
+// environment; it only says which variables would matter if they were set,
+// so both credential (which stops at the first hit) and shadowedEnvVar
+// (which wants to know about one even when something else already won) can
+// share the one list.
+func (r *Registry) envCandidates(rec *record) []string {
+	var out []string
+	out = append(out, r.effectiveAPIKeyEnv(rec)...)
+	if _, isRegistryID := r.curated[rec.name]; !isRegistryID {
+		out = append(out, InstanceKeyEnvVar(rec.name))
+	}
+	return out
+}
+
+// shadowedEnvVar names an environment variable that is set but loses to
+// cred, the credential that actually resolved (spec §10: api_key >
+// credential_headers > store > env). Empty when nothing shadows it: no
+// candidate is set, or an env source is itself what won.
+func (r *Registry) shadowedEnvVar(rec *record, cred Credential) string {
+	if strings.HasPrefix(cred.Source, "env:") {
+		return ""
+	}
+	for _, name := range r.envCandidates(rec) {
+		if v, ok := r.env(name); ok && v != "" {
+			return name
+		}
+	}
+	return ""
+}
+
 // credential resolves an instance's credential in spec §10's order and
 // returns the "no credential" warnings (none for the none/optional-bearer
 // schemes). It never performs I/O beyond a file-existence check.
@@ -138,13 +176,7 @@ func (r *Registry) credential(rec *record) (Credential, []string) {
 			return Credential{Value: v, Source: "store"}, nil
 		}
 	}
-	for _, name := range r.effectiveAPIKeyEnv(rec) {
-		if v, ok := r.env(name); ok && v != "" {
-			return Credential{Value: v, Source: "env:" + name}, nil
-		}
-	}
-	if _, isRegistryID := r.curated[rec.name]; !isRegistryID {
-		name := InstanceKeyEnvVar(rec.name)
+	for _, name := range r.envCandidates(rec) {
 		if v, ok := r.env(name); ok && v != "" {
 			return Credential{Value: v, Source: "env:" + name}, nil
 		}
@@ -288,6 +320,7 @@ func (r *Registry) Instances() []Instance {
 			Auth: h.Transport.Auth, BaseURL: baseURL, Vars: maps.Clone(inst.rec.userVars), DefaultModel: h.DefaultModel,
 			Implicit: inst.implicit, Hidden: h.Hidden, Default: inst.name == def,
 			CredentialSource: cred.Source, Warnings: warns,
+			ShadowedEnvVar: r.shadowedEnvVar(inst.rec, cred),
 		})
 	}
 	return out

--- a/llm/registry/instances.go
+++ b/llm/registry/instances.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -117,15 +118,45 @@ func (r *Registry) envCandidates(rec *record) []string {
 	return out
 }
 
+// consumedEnvVars names the environment variable(s) a winning api_key or
+// credential_headers expression itself expanded (a "$VAR" reference), so
+// shadowedEnvVar can tell "this is what resolved the credential" apart from
+// "this lost." Empty for a literal value (no "$") and for every other
+// source, which consumes no expression.
+func consumedEnvVars(rec *record, source string) []string {
+	switch source {
+	case "api_key":
+		refs, _, _ := ScanConfigValue(rec.head.APIKey)
+		return refs
+	case "credential_headers":
+		refs, _, _ := ScanConfigValue(rec.head.CredentialHeaders["Authorization"])
+		return refs
+	default:
+		return nil
+	}
+}
+
 // shadowedEnvVar names an environment variable that is set but loses to
 // cred, the credential that actually resolved (spec §10: api_key >
-// credential_headers > store > env). Empty when nothing shadows it: no
-// candidate is set, or an env source is itself what won.
+// credential_headers > store > env). Only those three sources can shadow
+// anything: oauth-openai-codex and gcp-adc are terminal branches in
+// credential that never consult api_key_env at all (whether they resolve,
+// giving "oauth"/"adc", or not, giving "none" the same as every other
+// unresolved scheme), so naming a candidate against any of them - including
+// "none" - would blame a source that was never actually in contention.
+// Empty when nothing shadows it: no remaining candidate is set, or an env
+// source is itself what won.
 func (r *Registry) shadowedEnvVar(rec *record, cred Credential) string {
-	if strings.HasPrefix(cred.Source, "env:") {
+	switch cred.Source {
+	case "api_key", "credential_headers", "store":
+	default:
 		return ""
 	}
+	consumed := consumedEnvVars(rec, cred.Source)
 	for _, name := range r.envCandidates(rec) {
+		if slices.Contains(consumed, name) {
+			continue
+		}
 		if v, ok := r.env(name); ok && v != "" {
 			return name
 		}

--- a/llm/registry/instances_test.go
+++ b/llm/registry/instances_test.go
@@ -230,6 +230,65 @@ base_url = "https://proxy/v1"
 	}
 }
 
+// TestInstances_ShadowedEnvVar covers the shadow relation TestCredential_Order
+// does not: an environment variable that is SET but loses to a
+// higher-precedence source (api_key, credential_headers, or store, spec
+// §10), which today's ActiveSource cannot express because it only ever names
+// the winner (issue #712). Instance.ShadowedEnvVar names that variable, or
+// is empty when nothing shadows it — including when an env source is itself
+// what wins, or when no candidate is set at all.
+func TestInstances_ShadowedEnvVar(t *testing.T) {
+	cfg := `
+[providers.lit]
+base = "openai"
+api_key = "literal-key"
+[providers.hdr]
+base = "openai"
+base_url = "https://gw/v1"
+api_key_env = ["HDR_KEY"]
+credential_headers = { "Authorization" = "Bearer $PORTKEY_KEY" }
+[providers.stored]
+base = "openai"
+base_url = "https://gw/v1"
+api_key_env = ["STORED_KEY"]
+[providers.envwins]
+base = "openai"
+base_url = "https://gw/v1"
+api_key_env = ["ENV_KEY"]
+[providers.nothing]
+base = "openai"
+base_url = "https://gw/v1"
+api_key_env = ["UNSET_KEY"]
+`
+	env := map[string]string{
+		"OPENAI_API_KEY": "sk-openai", "PORTKEY_KEY": "pk",
+		"HDR_KEY": "hdr-val", "STORED_KEY": "stored-shadow-val", "ENV_KEY": "env-val",
+	}
+	r := fixtureLoad(t, env, cfg, WithCredentials(fakeCreds{"stored": "from-store"}))
+	want := map[string]struct {
+		source string
+		shadow string
+	}{
+		"lit":     {"api_key", "OPENAI_API_KEY"}, // no base_url: inherits openai's APIKeyEnv, which is set but loses to the literal key
+		"hdr":     {"credential_headers", "HDR_KEY"},
+		"stored":  {"store", "STORED_KEY"},
+		"envwins": {"env:ENV_KEY", ""}, // the env source is itself the winner, not a shadow
+		"nothing": {"none", ""},        // UNSET_KEY is unset: no candidate to shadow with
+	}
+	for name, w := range want {
+		inst, ok := r.Instance(name)
+		if !ok {
+			t.Fatalf("%s: not an instance", name)
+		}
+		if inst.CredentialSource != w.source {
+			t.Fatalf("%s: credential source = %q, want %q", name, inst.CredentialSource, w.source)
+		}
+		if inst.ShadowedEnvVar != w.shadow {
+			t.Errorf("%s: ShadowedEnvVar = %q, want %q", name, inst.ShadowedEnvVar, w.shadow)
+		}
+	}
+}
+
 func TestCredential_ValueNeverSerializes(t *testing.T) {
 	raw, err := json.Marshal(Credential{Value: "x", Source: "store"})
 	if err != nil || strings.Contains(string(raw), "x") {

--- a/llm/registry/instances_test.go
+++ b/llm/registry/instances_test.go
@@ -259,10 +259,16 @@ api_key_env = ["ENV_KEY"]
 base = "openai"
 base_url = "https://gw/v1"
 api_key_env = ["UNSET_KEY"]
+[providers.apiref]
+base = "openai"
+base_url = "https://gw/v1"
+api_key = "$APIREF_KEY"
+api_key_env = ["APIREF_KEY"]
 `
 	env := map[string]string{
 		"OPENAI_API_KEY": "sk-openai", "PORTKEY_KEY": "pk",
 		"HDR_KEY": "hdr-val", "STORED_KEY": "stored-shadow-val", "ENV_KEY": "env-val",
+		"APIREF_KEY": "apiref-val",
 	}
 	r := fixtureLoad(t, env, cfg, WithCredentials(fakeCreds{"stored": "from-store"}))
 	want := map[string]struct {
@@ -274,6 +280,10 @@ api_key_env = ["UNSET_KEY"]
 		"stored":  {"store", "STORED_KEY"},
 		"envwins": {"env:ENV_KEY", ""}, // the env source is itself the winner, not a shadow
 		"nothing": {"none", ""},        // UNSET_KEY is unset: no candidate to shadow with
+		// api_key is itself a $VAR reference to APIREF_KEY, which is ALSO
+		// listed in api_key_env: that name is what resolved the credential,
+		// not a loser, even though it is also a candidate (PR #758 review).
+		"apiref": {"api_key", ""},
 	}
 	for name, w := range want {
 		inst, ok := r.Instance(name)
@@ -286,6 +296,36 @@ api_key_env = ["UNSET_KEY"]
 		if inst.ShadowedEnvVar != w.shadow {
 			t.Errorf("%s: ShadowedEnvVar = %q, want %q", name, inst.ShadowedEnvVar, w.shadow)
 		}
+	}
+}
+
+// TestInstances_ShadowedEnvVarSkipsAnUnresolvedHigherPrecedenceScheme covers
+// the other half of the PR #758 review: oauth-openai-codex and gcp-adc are
+// terminal branches in credential (spec §10) - when neither resolves,
+// credential returns "none" without ever consulting api_key_env, so a
+// candidate env var that happens to be set must not be reported as shadowed
+// by a scheme that never looked at it ("WORK_API_KEY set but shadowed by
+// none" would be a lie: none is not a competing precedence source here, it
+// is this instance's entire resolution never reaching the env candidates at
+// all). google-vertex resolves through gcp-adc; with no ADC file or
+// GOOGLE_APPLICATION_CREDENTIALS reachable, it stays unresolved.
+func TestInstances_ShadowedEnvVarSkipsAnUnresolvedHigherPrecedenceScheme(t *testing.T) {
+	cfg := `
+[providers.myvertex]
+base = "google-vertex"
+api_key_env = ["FAKE_VERTEX_KEY"]
+`
+	r := fixtureLoad(t, map[string]string{"FAKE_VERTEX_KEY": "set-but-irrelevant"}, cfg)
+	rec := r.explicit["myvertex"]
+	if rec.head.Transport.Auth != AuthGCPADC {
+		t.Fatalf("myvertex must inherit gcp-adc from google-vertex, got %q", rec.head.Transport.Auth)
+	}
+	cred, _ := r.credential(rec)
+	if cred.Source != "none" {
+		t.Fatalf("gcp-adc with no ADC reachable must resolve none, got %q", cred.Source)
+	}
+	if got := r.shadowedEnvVar(rec, cred); got != "" {
+		t.Fatalf("an unresolved gcp-adc scheme must never report a shadow, got %q", got)
 	}
 }
 

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -257,7 +257,8 @@ func (r *Registry) ResolveInstance(name string) (Resolved, error) {
 		Instance: rec.name, ProviderID: providerID, Protocol: rec.head.Protocol, Surface: rec.head.Surface,
 		Transport: transport, Caps: caps, Headers: r.buildHeaders(rec.head.Headers, nil),
 		Credential: cred, CredentialHeaders: credHeaders, Provenance: prov, Warnings: warnings,
-		DefaultModel: rec.head.DefaultModel, CheapModel: rec.head.CheapModel,
+		ShadowedEnvVar: r.shadowedEnvVar(rec, cred),
+		DefaultModel:   rec.head.DefaultModel, CheapModel: rec.head.CheapModel,
 	}, nil
 }
 

--- a/llm/registry/types.go
+++ b/llm/registry/types.go
@@ -194,8 +194,13 @@ type Resolved struct {
 	Headers           map[string]string `json:"headers,omitempty"`
 	Credential        Credential        `json:"-"`
 	CredentialHeaders map[string]string `json:"-"`
-	Provenance        map[string]string `json:"provenance,omitempty"`
-	Warnings          []string          `json:"warnings,omitempty"`
+	// ShadowedEnvVar names an environment variable that is set but loses to
+	// Credential (spec §10); empty when nothing shadows it. Hidden from
+	// JSON alongside Credential - a caller that needs it re-exposes it on
+	// its own output type, as instanceStatus does for the hub.
+	ShadowedEnvVar string            `json:"-"`
+	Provenance     map[string]string `json:"provenance,omitempty"`
+	Warnings       []string          `json:"warnings,omitempty"`
 	// DefaultModel and CheapModel are the instance's curated or configured
 	// default_model / cheap_model (spec §6.2, §7.5); the agent's profile reads
 	// them instead of a per-provider switch.


### PR DESCRIPTION
Fixes #712

## Summary

When a credential environment variable is SET but loses to a
higher-precedence source (`api_key`, `credential_headers`, or a stored
key, spec §10's order), nothing on the hub, CLI, or wire could say so:
`activeSource`/`envVar` only ever name the winner. A user who exports
`OPENAI_API_KEY` while a store entry or `providers.toml` `api_key` wins
saw only the winner, with no way to tell why their variable did nothing.
`credentialLabels.ts` documented this exact gap after #704's review.

## Fix shape

- `llm/registry`: `Instance` gains `ShadowedEnvVar`, computed by
  `shadowedEnvVar` from the same ordered candidate list `credential()`
  already tries (now shared via a new `envCandidates` helper) — checked
  independently of which source actually won. Empty when nothing shadows
  it: no candidate is set, or an env source is itself the winner.
- `appwire`: `AuthStatusResponse` and `InstanceEntry` carry the same field
  (`shadowedEnvVar`, omitempty) — names only, never a credential value.
- Hub: `instanceStatus` and `entryFor` pass it through unchanged.
- `evener providers list`: a NOTES-column note, e.g. `WORK_API_KEY set but
  shadowed by store`.
- Hub credentials pane (`credentialLabels.ts`): `credentialLayers` renders
  a new shadowed layer for it, alongside the existing shadowed-store-key
  layer (the two can coexist when `api_key` beats both).

## Testing

- `llm/registry`: new `TestInstances_ShadowedEnvVar` covers api_key,
  credential_headers, and store each shadowing a set env var, an
  env-effective instance showing no self-shadow, and no candidate set at
  all.
- `cmd/evener-hub`: new `TestAuth_InstanceStatus_ReportsShadowedEnvVar`
  drives the real `instanceStatus` and `evener/instance/list` (`List()`)
  handlers through the env-wins → store-wins transition.
- `cmd/evener`: new `TestProvidersListReportsShadowedEnvVar` asserts the
  NOTES-column text and that no credential value ever prints.
- `credentialLabels.test.ts`: new cases for the env-shadow layer alone and
  combined with a shadowed store key.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` on all touched Go files (clean)
- [x] `go test` on `llm/registry`, `appwire`, `cmd/evener-hub` (incl.
      `internal/...`), `cmd/evener` (incl. `internal/...`), `cmd/evener-tui`
      (incl. `internal/...`) — all pass
- [x] `make lint` — all gates pass (incl. `lint-generated`, confirming
      `types.gen.ts` / `docs/appwire-protocol.md` are current)
- [ ] Frontend `credentialLabels.test.ts` changes are hand-verified against
      existing conventions but not executed — `node_modules` isn't
      installed in this offline worktree, and frontend checks aren't part
      of `make lint` in this repo.