### PR TITLE
fix(appserver-test): wait for the close record before stopping the trace

### DIFF
--- a/internal/appserver/websocket_trace_test.go
+++ b/internal/appserver/websocket_trace_test.go
@@ -193,36 +193,42 @@ func TestServeWebSocketTraceSeparatesConnections(t *testing.T) {
 	if err := second.Close(websocket.StatusNormalClosure, ""); err != nil {
 		t.Fatalf("close second: %v", err)
 	}
+	// ServeWebSocket writes its close record from a defer that only runs once
+	// the handler goroutine finishes teardown. That goroutine's completion is
+	// independent of the client-side Close calls above: websocket.Accept
+	// hijacks the connection immediately, so httptest.Server's own shutdown
+	// bookkeeping stops tracking it long before the handler actually returns,
+	// and httpServer.Close below won't wait for it either. Wait for every
+	// connection's close record to land before stopping the trace, or
+	// trace.Close can race the still-running handler and silently drop it
+	// (WebSocketTrace.record discards writes once closed).
+	var records []decodedWebSocketTraceRecord
+	waitUntil(t, "both connections' open, outbound frame, and close records to land in the trace", func() bool {
+		records = readWebSocketTraceRecords(t, path)
+		byConnection, _ := groupWebSocketTraceRecordsByConnection(records)
+		if len(byConnection) != 2 {
+			return false
+		}
+		for _, conn := range byConnection {
+			if !conn.sawOpen || !conn.sawClose || !conn.sawOutbound {
+				return false
+			}
+		}
+		return true
+	})
 	httpServer.Close()
 	if err := trace.Close(); err != nil {
 		t.Fatalf("close trace: %v", err)
 	}
 
-	records := readWebSocketTraceRecords(t, path)
-	byConnection := make(map[string][]decodedWebSocketTraceRecord)
-	for _, record := range records {
-		byConnection[record.Connection] = append(byConnection[record.Connection], record)
-	}
+	records = readWebSocketTraceRecords(t, path)
+	byConnection, seenRequests := groupWebSocketTraceRecordsByConnection(records)
 	if len(byConnection) != 2 {
 		t.Fatalf("traced connections = %d, want 2: %+v", len(byConnection), records)
 	}
-	seenRequests := make(map[string]bool)
-	for connection, connectionRecords := range byConnection {
-		var sawOpen, sawClose, sawOutbound bool
-		for _, record := range connectionRecords {
-			switch {
-			case record.Event == "open":
-				sawOpen = true
-			case record.Event == "close":
-				sawClose = true
-			case record.Event == "frame" && record.Direction == "hub_to_browser":
-				sawOutbound = true
-			case record.Event == "frame" && record.Direction == "browser_to_hub" && record.Frame != nil:
-				seenRequests[*record.Frame] = true
-			}
-		}
-		if !sawOpen || !sawClose || !sawOutbound {
-			t.Errorf("connection %q records = %+v, want open, outbound frame, and close", connection, connectionRecords)
+	for connection, conn := range byConnection {
+		if !conn.sawOpen || !conn.sawClose || !conn.sawOutbound {
+			t.Errorf("connection %q records = %+v, want open, outbound frame, and close", connection, conn.records)
 		}
 	}
 	for _, request := range requests {
@@ -230,6 +236,40 @@ func TestServeWebSocketTraceSeparatesConnections(t *testing.T) {
 			t.Errorf("missing exact inbound request %q in trace", request)
 		}
 	}
+}
+
+// webSocketTraceConnection is one connection's trace records plus whether
+// its lifecycle events (open, an outbound frame, close) were all seen.
+type webSocketTraceConnection struct {
+	records                        []decodedWebSocketTraceRecord
+	sawOpen, sawClose, sawOutbound bool
+}
+
+// groupWebSocketTraceRecordsByConnection groups trace records by connection
+// and classifies each connection's lifecycle coverage, alongside the exact
+// inbound request payloads seen across all connections.
+func groupWebSocketTraceRecordsByConnection(records []decodedWebSocketTraceRecord) (byConnection map[string]*webSocketTraceConnection, seenRequests map[string]bool) {
+	byConnection = make(map[string]*webSocketTraceConnection)
+	seenRequests = make(map[string]bool)
+	for _, record := range records {
+		conn := byConnection[record.Connection]
+		if conn == nil {
+			conn = &webSocketTraceConnection{}
+			byConnection[record.Connection] = conn
+		}
+		conn.records = append(conn.records, record)
+		switch {
+		case record.Event == "open":
+			conn.sawOpen = true
+		case record.Event == "close":
+			conn.sawClose = true
+		case record.Event == "frame" && record.Direction == "hub_to_browser":
+			conn.sawOutbound = true
+		case record.Event == "frame" && record.Direction == "browser_to_hub" && record.Frame != nil:
+			seenRequests[*record.Frame] = true
+		}
+	}
+	return byConnection, seenRequests
 }
 
 func TestServerShutdownDrainsOpenTracedWebSocket(t *testing.T) {


### PR DESCRIPTION
Fixes #762

Root cause: `TestServeWebSocketTraceSeparatesConnections` closed the client-side websockets and then called `httpServer.Close()` and `trace.Close()` before reading the trace file, assuming those synchronize with `ServeWebSocket`'s handler goroutine finishing — but `websocket.Accept` hijacks the connection immediately, so `httptest.Server`'s own `ConnState`-tracked `WaitGroup` stops counting that connection at hijack time, long before the handler's deferred `WebSocketTrace.ConnectionClosed` call actually runs; when that defer lands after `trace.Close()` has already executed, `WebSocketTrace.record`'s `if t.closed { return }` guard silently drops the close record, reproducing the reported symptom (open + two frames, no close, no error) in roughly 1 of 5 runs. Production code already gets this right — `cmd/evener-hub/main.go` and the sibling test `TestServerShutdownDrainsOpenTracedWebSocket` both call `Server.Shutdown` (which drains every handler goroutine) before `WebSocketTrace.Close` — so the fix is test-only: wait, condition-based via the package's existing `waitUntil` helper, for both connections' open/outbound-frame/close records to land before stopping the trace.

## Test plan
- [x] Reproduced on unmodified `main` (3407eafb5): `go test ./internal/appserver/ -run TestServeWebSocketTraceSeparatesConnections -count=10` failed on the 5th iteration with the reported symptom (connection's records end after open + two frames, no close)
- [x] After the fix: `go test ./internal/appserver/ -run TestServeWebSocketTraceSeparatesConnections -count=50` — 50/50 pass
- [x] After the fix: `go test ./internal/appserver/ -run TestServeWebSocketTraceSeparatesConnections -count=50 -race` — 50/50 pass, no races
- [x] `go test ./internal/appserver/` — full package passes, pristine output
- [x] `make lint` — all checks PASS (lint-naming, lint-gofmt, lint-evenerfuzz, lint-eval, lint-internal, lint-golangci, lint-generated, lint-fuzz-registry, secret-scan)
- [x] No production code changed