### PR TITLE
test(appsource): wait out the relay recovery latch

### DIFF
--- a/cmd/evener-hub/internal/appsource/relay_session_test.go
+++ b/cmd/evener-hub/internal/appsource/relay_session_test.go
@@ -1506,16 +1506,13 @@ func TestRelaySessionRecoversCanonicalFeedAndEmitsResyncWithoutAnotherRead(t *te
 	}
 	live.Acknowledge()
 	sessionLease := lease.(*relaySessionLease)
+	awaitRecoveryLatchRelease(t, sessionLease.session)
 	sessionLease.session.mu.Lock()
 	listenerCount := len(sessionLease.session.listeners)
 	listenerStarts := sessionLease.session.nextListener
-	recovering := sessionLease.session.recovering
 	sessionLease.session.mu.Unlock()
 	if listenerCount != 1 || listenerStarts != 1 {
 		t.Fatalf("listeners after reconnect: live=%d started=%d, want one resumed listener", listenerCount, listenerStarts)
-	}
-	if recovering {
-		t.Fatal("relay session still marked recovering after replacement feed resumed")
 	}
 	if got := daemon.dials.Load(); got != 2 {
 		t.Fatalf("dial count = %d, want exactly one replacement connection", got)
@@ -1586,6 +1583,30 @@ func TestRelaySessionRecoveryDisconnectBeforeHandoffResolutionStartsSuccessor(t 
 		t.Fatalf("successor live delta = %q", got)
 	}
 	live.Acknowledge()
+}
+
+// awaitRecoveryLatchRelease blocks until recoverCanonicalFeed has left the
+// session, which no frame the replacement connection delivers can prove.
+// Resolving the recovery handoff is what queues that connection's first live
+// frames, and the loop clears the latch on a later, separate acquisition of
+// the session lock -- so a listener holding such a frame is ordered before the
+// clear, not after it.
+func awaitRecoveryLatchRelease(t *testing.T, session *relaySession) {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		session.mu.Lock()
+		recovering := session.recovering
+		session.mu.Unlock()
+		if !recovering {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("relay session still marked recovering after replacement feed resumed")
+		case <-time.After(time.Millisecond):
+		}
+	}
 }
 
 func decodeRelayDelta(t *testing.T, notification appwire.Notification) string {


### PR DESCRIPTION
Fixes #764

Both CI sightings (jobs 99720001053 and 99724449184, both race-root, both on 2026-09-01) failed with the same line:

```
--- FAIL: TestRelaySessionRecoversCanonicalFeedAndEmitsResyncWithoutAnotherRead (0.02s)
    relay_session_test.go:1518: relay session still marked recovering after replacement feed resumed
```

## Reproduced

`go test -race -run TestRelaySessionRecovers -count=100` (and 300, `-cpu 1,2,4`) is clean on an idle machine. Under CPU oversubscription it is not: 10 concurrent copies of the compiled `-race` test binary at `-count=400 -cpu 1,2,4`, with six busy-loop processes competing for the box, produced **101 failures in 12,000 runs (0.84%)**, every one of them the assertion above and none of them a race-detector report.

## Root cause: a test ordering assumption, not a relay race

The test treats "I received the replacement connection's first live delta" as proof that `recoverCanonicalFeed` has finished. `relay_session.go` guarantees the reverse order.

After the replacement read's response, the delta the test injects arrives while the read's `relayCapture` is still installed with `cutSeen` set, so `observe` parks it in `capture.afterCut` instead of publishing it. Those frames are released by `finishHandoff`, which runs inside `result.Handoff.Abort()`:

```go
result, err := s.read(s.ctx, params)
if err == nil {
        handoffResolved := result.Handoff.Abort()   // queues afterCut under s.mu, then unlocks
        s.mu.Lock()                                 // <-- separate, later acquisition
        live := handoffResolved && s.connection != nil && !s.connection.disconnected
        if live {
                s.recovering = false
        }
```

So the delta is enqueued *before* the latch is cleared, and three goroutine handoffs stand between the enqueue and the test's read: `publishLoop` picks the job up, `listener.forward` moves it to the listener's out channel, and the test goroutine wakes on it. If the recovery goroutine loses the CPU anywhere in that gap, the test acquires `s.mu` first and sees `recovering == true`. That is exactly what a slower, loaded CI runner buys.

Window confirmed by construction: inserting `time.Sleep(20 * time.Millisecond)` between `Handoff.Abort()` and the `s.mu.Lock()` above makes the old test fail **20/20**; three bare `runtime.Gosched()` calls in the same spot fail 3/50 on an idle box. (Probe reverted; no production code is touched by this PR.)

`recovering` staying set for that moment is correct behaviour, not a bug to fix in the relay. It is a latch meaning "a recovery loop goroutine is live", and its handoff is safe in both interleavings: a `disconnect` landing in the window skips spawning a second goroutine because `recovering` is still set, and the in-flight loop then evaluates `live` under the same lock, sees `s.connection` nil or disconnected, and loops round to re-read. Clearing the latch earlier would be the wrong change.

## Fix

The test now waits for the transition it wants to observe rather than assuming a frame implies it — `awaitRecoveryLatchRelease` polls the latch under `s.mu` against a 5s deadline and reports the original message if it never clears. The listener and dial-count assertions move behind the wait, so they read the post-recovery steady state.

## Verification

- The 20ms probe that failed the old test 20/20 now passes 20/20.
- The reproducing recipe (10 copies x 400 x `-cpu 1,2,4` under load, 12,000 runs) is clean — was 101 failures.
- `go test -race -run TestRelaySessionRecovers -count=100 -cpu 1,2,4` clean.
- Full `go test -race ./cmd/evener-hub/internal/appsource/` clean.
- `gofmt`, `go vet`, `make lint` (all 9 targets) clean.
