### PR TITLE
test(evener-hub): isolate throwaway-root leak glob from concurrent hub-suite runs

### DIFF
--- a/cmd/evener-hub/testmain_test.go
+++ b/cmd/evener-hub/testmain_test.go
@@ -213,7 +213,15 @@ func (p fakeProber) Probe(rendezvous.Entry) hubcore.ProbeResult {
 // A child that inherits EVENER_HUB_TEST_ENV_ROOT must therefore create nothing of
 // its own, and must not remove what it did not create.
 func TestReExecutedHelperLeavesNoThrowawayRoot(t *testing.T) {
-	pattern := filepath.Join(os.TempDir(), "evener-hub-test-env-*")
+	// Glob a TMPDIR owned by this test case, not the machine-wide
+	// os.TempDir(): any other process running this package's suite
+	// concurrently mints and removes its own evener-hub-test-env-* root in
+	// the shared temp dir on its own schedule, which flips a machine-wide
+	// count for reasons that have nothing to do with the helper under test.
+	// Handing the helper below this directory as its own TMPDIR means a root
+	// it (incorrectly) mints lands here too, so the glob still catches it.
+	helperTempDir := t.TempDir()
+	pattern := filepath.Join(helperTempDir, "evener-hub-test-env-*")
 	before, err := filepath.Glob(pattern)
 	if err != nil {
 		t.Fatalf("glob throwaway roots: %v", err)
@@ -229,7 +237,7 @@ func TestReExecutedHelperLeavesNoThrowawayRoot(t *testing.T) {
 	// precisely the cleanup that a killed process never reaches. Production
 	// kills these -- the fake server blocks in Serve until the parent is done.
 	cmd := exec.Command(exe, "-test.run=^TestFakeCodexAppServerHelper$")
-	cmd.Env = append(os.Environ(), testEnvRootVar+"="+testEnvRoot, "EVENER_FAKE_CODEX_APP_SERVER=serve")
+	cmd.Env = append(os.Environ(), testEnvRootVar+"="+testEnvRoot, "EVENER_FAKE_CODEX_APP_SERVER=serve", "TMPDIR="+helperTempDir)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start re-executed helper: %v", err)
 	}


### PR DESCRIPTION
Fixes #761

## Summary
- `TestReExecutedHelperLeavesNoThrowawayRoot` globbed the machine-wide `os.TempDir()` for `evener-hub-test-env-*` and compared before/after counts across spawning-then-killing a re-exec'd helper, assuming exclusive ownership of that namespace. Any other process running the `cmd/evener-hub` suite concurrently mints or removes its own top-level root during that window, flipping the count for reasons unrelated to the helper under test.
- Give the re-exec'd helper its own `TMPDIR`, scoped to a `t.TempDir()` this test case owns, and glob that directory instead of the shared one. The correct helper never touches it (it inherits the root via `EVENER_HUB_TEST_ENV_ROOT` and mints nothing), so sibling processes can no longer perturb the count.
- The test still catches the leak it exists to catch: a helper that regresses to minting its own root lands inside the scoped `TMPDIR` too, so the glob still sees it. Verified by temporarily forcing that regression (`inherited = false` in `TestMain`) and watching the test fail with the expected message, then reverting.

## Test plan
- [x] `go test ./cmd/evener-hub/ -run TestReExecutedHelperLeavesNoThrowawayRoot -count=10 -v` — 10/10 pass
- [x] Two concurrent `go test ./cmd/evener-hub/ -run TestReExecutedHelper -count=5` processes launched in parallel — both pass 5/5, proving immunity to a sibling hub-suite run
- [x] Temporarily broke `TestMain`'s inheritance check (`inherited = false`) — test correctly fails with "a re-executed helper minted 1 throwaway root(s) of its own..."; reverted and confirmed passing again
- [x] `go test ./cmd/evener-hub/...` (full package) — all subpackages `ok`, zero failures
- [x] `gofmt -l` on the changed file — clean
- [x] `make lint` — all targets PASS (lint-naming, lint-gofmt, lint-evenerfuzz, lint-eval, lint-internal, lint-golangci, lint-generated, lint-fuzz-registry, secret-scan)