### PR TITLE
test(agent): capture the stop before triggering its settlement

### DIFF
--- a/agent/delegate_resource_runtime_test.go
+++ b/agent/delegate_resource_runtime_test.go
@@ -1614,6 +1614,26 @@ func currentDelegateStop(t *testing.T, controller *delegateTreeController) *dele
 	return controller.stop
 }
 
+// awaitDelegateStopAdmission blocks until the controller durably admits a
+// subtree stop and returns that stop. A test that goes on to trigger
+// settlement (FinishGeneration, releasing the provider) MUST hold the stop it
+// captured here rather than reading controller.stop back afterwards: the
+// reconcile driver clears controller.stop the instant the stop settles, so the
+// later read races the completion it is waiting for.
+func awaitDelegateStopAdmission(t *testing.T, controller *delegateTreeController) *delegateStopState {
+	t.Helper()
+	var stop *delegateStopState
+	// TRIPWIRE: admission is a durable fsync + local drive, expected in low
+	// hundreds of ms; 5s only absorbs CI scheduling stalls.
+	waitForCondition(t, 5*time.Second, "stable stop admission", func() bool {
+		controller.mu.Lock()
+		defer controller.mu.Unlock()
+		stop = controller.stop
+		return stop != nil
+	})
+	return stop
+}
+
 func stableJobStopState(t *testing.T, invocation stableJobStopInvocation) jobStopResult {
 	t.Helper()
 	if invocation.err != nil {

--- a/agent/job_stop_live_watches_test.go
+++ b/agent/job_stop_live_watches_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	toolpkg "primeradiant.com/evener/agent/internal/tool"
 )
@@ -121,21 +120,12 @@ func TestJobStopReportsLiveWatchesSettled(t *testing.T) {
 			"max_wait_ms": 5000,
 		})
 	}()
-	// Wait for durable stop admission before finishing the generation — the
+	// Capture the stop at admission before finishing the generation — the
 	// pattern the retention tests use (delegate_resource_retention_stop_test.go).
-	// (currentDelegateStop itself is unsuitable to poll: it fails the test when
-	// the stop is not yet admitted.)
-	// TRIPWIRE: admission is a durable fsync + local drive, expected in low
-	// hundreds of ms; 5s only absorbs CI scheduling stalls.
-	waitForCondition(t, 5*time.Second, "stable stop admission", func() bool {
-		f.controller.mu.Lock()
-		defer f.controller.mu.Unlock()
-		return f.controller.stop != nil
-	})
+	stop := awaitDelegateStopAdmission(t, f.controller)
 	if _, err := f.controller.FinishGeneration(delegateLease{delegateID: "dlg_observer", generation: 1}, delegateFinish{}); err != nil {
 		t.Fatalf("finish observer generation: %v", err)
 	}
-	stop := currentDelegateStop(t, f.controller)
 	<-stop.done
 	state := stableJobStopState(t, <-result)
 	if len(state.LiveWatches) != 1 || state.LiveWatches[0].ID != watchID {
@@ -184,13 +174,7 @@ func TestJobStopLiveWatchesSettleRefresh(t *testing.T) {
 			"max_wait_ms": 5000,
 		})
 	}()
-	// TRIPWIRE: admission is a durable fsync + local drive, expected in low
-	// hundreds of ms; 5s only absorbs CI scheduling stalls.
-	waitForCondition(t, 5*time.Second, "stable stop admission", func() bool {
-		f.controller.mu.Lock()
-		defer f.controller.mu.Unlock()
-		return f.controller.stop != nil
-	})
+	stop := awaitDelegateStopAdmission(t, f.controller)
 	// Clear the watch between admission and settle: the settled result must
 	// not report it.
 	if _, err := f.rootJM.clearReceiverWatchByID(onlyWatchIDIn(t, f.rootJM), "child-dlg_observer", "dlg_observer"); err != nil {
@@ -199,7 +183,6 @@ func TestJobStopLiveWatchesSettleRefresh(t *testing.T) {
 	if _, err := f.controller.FinishGeneration(delegateLease{delegateID: "dlg_observer", generation: 1}, delegateFinish{}); err != nil {
 		t.Fatalf("finish observer generation: %v", err)
 	}
-	stop := currentDelegateStop(t, f.controller)
 	<-stop.done
 	state := stableJobStopState(t, <-result)
 	if len(state.LiveWatches) != 0 {


### PR DESCRIPTION
Fixes #763

## What failed

CI run 33456103694, job 99696266050 (`race-modules`, PR #750):

```
--- FAIL: TestJobStopLiveWatchesSettleRefresh (0.01s)
    job_stop_live_watches_test.go:202: stable stop was not durably admitted
```

Line 202 was `stop := currentDelegateStop(t, f.controller)`, which fails when
`controller.stop == nil`. The test had already waited for `controller.stop != nil`
80 lines earlier, so the stop was admitted and then disappeared. 0.01s rules out a
timeout.

## Root cause

A test-side ordering assumption, not a production race. The sequence in
`TestJobStopLiveWatchesSettleRefresh`:

1. `waitForCondition` observes `controller.stop != nil` — the stop is admitted. A
   `runStopReconcileDriver` goroutine (launched from `StopSubtree`,
   `delegate_tree_stop.go:137`) is running `drainStop`, parked in
   `waitForDelegateStopProgress` because `stop.active` still holds
   `{dlg_observer, generation 1}`.
2. `FinishGeneration(lease{dlg_observer, 1}, ...)` →
   `generationFinishedPlansLocked` (`delegate_tree_finish.go:305-310`) deletes the
   lease from `stop.active` and calls `signalStopProgressLocked()`.
3. The driver goroutine wakes, calls `Reconcile`, finds every outstanding set
   empty, and runs the completion path at `delegate_tree_restore.go:317-319`:
   `close(stop.done); c.stop = nil`.
4. The test's `currentDelegateStop` reads `controller.stop` under the mutex. If
   the driver got to step 3 first, it reads `nil` and fails.

Clearing `controller.stop` on completion is correct — it is the *pending* stop,
and production callers handle the nil (`stopForResult` returns nil for a completed
stop; `drainStop` returns immediately on a nil stop). Only the test assumed the
stop pointer would still be there after it triggered the settlement it was about
to wait for.

`TestJobStopReportsLiveWatchesSettled` had the identical window at line 138.

## Reproduction

Pre-fix, in this worktree, `agent`:

| Recipe | Failures |
| --- | --- |
| `go test -race -run TestJobStopLiveWatchesSettleRefresh -count=50 .` | 2 / 50 |
| `go test -race -run TestJobStopLiveWatchesSettleRefresh -count=200 -cpu 1,2,4 .` | 14 / 600 |
| `go test -race -run TestJobStopReportsLiveWatchesSettled -count=200 -cpu 1,2,4 .` | 1 / 600 |

Every failure carried the CI assertion text verbatim, at 0.05-0.08s.

## Fix

Add `awaitDelegateStopAdmission`, which polls for admission and captures the
`*delegateStopState` under the same mutex acquisition that observes it. Both
settle tests now hold that pointer across `FinishGeneration` and wait on its
`done` channel, so the completion they are waiting for can no longer erase the
handle they wait on. This is the pattern
`delegate_resource_retention_stop_test.go` already uses.

No assertion was weakened: both tests still wait for the real stop completion and
still assert the full settled live-watch inventory.

The other five `currentDelegateStop` call sites all capture the stop *before*
triggering settlement (before `harness.release()` / `clock.Advance` /
`FinishGeneration`) and are unaffected.

## Verification

- `go test -race -run 'TestJobStopLiveWatchesSettleRefresh|TestJobStopReportsLiveWatchesSettled' -count=300 -cpu 1,2,4 .` — clean (900 runs each)
- `go test -race -run TestJobStopLiveWatchesSettleRefresh -count=200 -cpu 1,2,4 .` — clean (600 runs)
- `go test -race -count=1 .` for `primeradiant.com/evener/agent` — ok, 167s
- `gofmt -l`, `go vet`, `make lint` — all clean
