### PR TITLE
test(agent): wait for supervision quiescence, not a stale run channel

### DIFF
--- a/agent/delegate_resource_supervision_test.go
+++ b/agent/delegate_resource_supervision_test.go
@@ -2315,6 +2315,19 @@ func restoreSupervisionRoot(t *testing.T, fixture coldStableDelegateFixture, clo
 	return root
 }
 
+// waitForStableSupervisionRun blocks until the stable child owes no more
+// supervision work: no run, drive turn, or finalization is live, and no
+// delegate attention is still waiting for a run to be dispatched.
+//
+// It cannot simply join the child's completion channel. That channel is
+// REPLACED (resetSubagentForRunLocked) at the start of every run, so the
+// channel current when this helper is entered can still be the PREVIOUS run's:
+// arming attention only notifies, and the drive that notify triggers is
+// refused while the prior run is still running or finalizing, and is deferred
+// to a retry while the controller still holds the prior generation. Joining
+// that stale channel returns while the awaited run is only starting, so a
+// caller that then reads the delegate event log sees the PRIOR generation's
+// run-finished record.
 func waitForStableSupervisionRun(t *testing.T, root *Session, childID string) {
 	t.Helper()
 	sub := root.subagents.get(childID)
@@ -2322,12 +2335,104 @@ func waitForStableSupervisionRun(t *testing.T, root *Session, childID string) {
 		t.Fatalf("stable child %q was not tracked", childID)
 	}
 	sub.mu.Lock()
-	done := sub.done
+	hasChannel := sub.done != nil
 	sub.mu.Unlock()
-	if done == nil {
+	if !hasChannel {
 		t.Fatalf("stable child %q has no completion channel", childID)
 	}
-	<-done
+	desc := fmt.Sprintf("stable child %q supervision to quiesce", childID)
+	// TRIPWIRE: every supervision run in these tests is served by a scripted
+	// in-process adapter, so quiescence is reached in milliseconds; this bound
+	// only fires on a genuine hang.
+	waitForCondition(t, 30*time.Second, desc, func() bool {
+		sub.mu.Lock()
+		sess := sub.sess
+		closed := sub.closed
+		sub.mu.Unlock()
+		// Dispatching an armed attention hands the work along a chain of
+		// states, and no single one of them covers the whole chain: an arm
+		// awaiting retry, attention pending with no reservation yet, a
+		// reservation that has consumed the pending id but not yet committed,
+		// an open generation whose run goroutine has not started, and finally
+		// the child's own run flags. Each stage is entered before its
+		// predecessor is left, so reading them in dispatch order means work
+		// that races past one read is caught by a later one.
+		if sess != nil && !closed {
+			if sess.hasPendingDelegateAttentionArmRetry() {
+				return false
+			}
+			if pending, err := sess.pendingDelegateAttentionIDs(); err != nil || len(pending) != 0 {
+				return false
+			}
+			if controller, delegateID := sess.delegateController, sess.owningDelegateID; controller != nil && delegateID != "" {
+				if controller.reservedAttentionID(sess) != "" {
+					return false
+				}
+				controller.mu.Lock()
+				aggregate := controller.durable[delegateID]
+				runOpen := aggregate != nil && aggregate.CurrentRunOpen
+				controller.mu.Unlock()
+				if runOpen {
+					return false
+				}
+			}
+		}
+		sub.mu.Lock()
+		done := sub.done
+		live := sub.running || sub.driving || sub.finalizing
+		sub.mu.Unlock()
+		if live || done == nil {
+			return false
+		}
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	})
+}
+
+// TestWaitForStableSupervisionRunOutlastsDeferredAttentionDrive pins the
+// contract of waitForStableSupervisionRun: it must not return while an armed
+// delegate attention still owes a run. Arming attention only notifies, and
+// driveStableDelegateAttention refuses the resulting drive whenever the child
+// is not drivable yet (mid-run, mid-finalization, or dispose gated) or the
+// controller is still busy with the previous generation. The dispose gate
+// stands in for those refusals here because it is the one a test can hold open
+// deterministically. Without the wait the helper joins the WARM run's already
+// closed channel and the caller reads that generation's reported delivery
+// instead of the attention generation's private no-action finish.
+func TestWaitForStableSupervisionRunOutlastsDeferredAttentionDrive(t *testing.T) {
+	fixture := newColdStableDelegateFixture(t, "")
+	fixture.adapter.steps = []func(llm.Request) llm.Response{
+		func(llm.Request) llm.Response { return finalResponse("warm result") },
+		func(llm.Request) llm.Response {
+			return llm.Response{Message: llm.Assistant("attention requires no action")}
+		},
+	}
+	root := restoreSupervisionRoot(t, fixture, nil)
+	sub := warmStableSupervisionDelegate(t, root, fixture)
+	waitForStableSupervisionRun(t, root, fixture.childID)
+
+	if !sub.trySetDisposeGate() {
+		t.Fatal("could not gate the quiescent stable child")
+	}
+	armStableSupervisionAttention(t, sub, "attention:deferred", "inspect before the drive is admitted")
+	// Release the refused drive only after the helper has had time to observe
+	// the idle child, which is the state the stale-channel join returned on.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		sub.clearDisposeGate()
+		sub.sess.notify()
+	}()
+
+	waitForStableSupervisionRun(t, root, fixture.childID)
+
+	finished := latestDelegateControllerRunFinished(t, root.delegateController, fixture.delegateID)
+	if finished.Generation != 2 || finished.Disposition != delegatestore.DispositionCompletedNoAction || finished.DeliveryID != "" {
+		t.Fatalf("deferred attention finish = %#v, want the attention generation's private no-action", finished)
+	}
 }
 
 func warmStableSupervisionDelegate(t *testing.T, root *Session, fixture coldStableDelegateFixture) *subagent {


### PR DESCRIPTION
Fixes #765

## Root cause

The CI failure was a test-harness ordering bug, not a production supervision race.

`waitForStableSupervisionRun` captured `sub.done` once and blocked on it:

```go
sub.mu.Lock()
done := sub.done
sub.mu.Unlock()
<-done
```

`sub.done` is **replaced** at the start of every run (`resetSubagentForRunLocked`, agent/subagents.go:1424), and `close(done)` at the end of a run closes the channel that run captured, not whatever `sub.done` points at by then (agent/subagents.go:1790).

Arming delegate attention is only a wake: `armDelegateAttention` -> `armDelegateAttentionOnce` -> `s.notify()` (agent/session_attention.go:481) -> `driveChildIfNotStopGated` -> `driveStableDelegateAttention`. That drive is **refused** when the child is not drivable yet:

- `blocked := sub.closed || sub.running || sub.driving || ... || sub.finalizing` (agent/delegate_runtime.go:339-346), and
- `ReserveAttention` returning `errDelegateTargetBusy`/`errTreeAtCapacity`, which only schedules `retryDelegateAttentionLater()` (agent/delegate_runtime.go:352-358).

Both are reachable straight after `warmStableSupervisionDelegate` returns: the warm delegate_send's inline waiter is satisfied inside the run's finalize tail, so the warm run goroutine is still `finalizing` (and the controller still holds generation 1, since `ReportFinalizationQuiesced` runs *after* `close(done)`) while the test appends the notification and arms attention.

So the failing interleaving is:

1. Warm delivery resolves; the warm run goroutine is still in its finalize tail.
2. The test arms attention; the drive is refused/deferred, and nothing has replaced `sub.done`.
3. `waitForStableSupervisionRun` captures the **warm** run's channel.
4. The warm tail re-arms the pending attention (agent/subagents.go:1780-1788), which launches the attention run and installs a fresh `sub.done`; only then does it `close()` the warm channel.
5. The helper returns while the attention run is only starting. `<-snapshots` then waits for `subagentBeforeSettlement`, which fires *before* settlement (agent/subagents.go:1621), so the store read at line 220 lands inside the attention run's settlement window.
6. `latestDelegateControllerRunFinished` therefore returns the newest record it can find: generation 1, `reported`, `.../delivery/1`.

That is exactly the CI text.

## Reproduction

Deterministic, in-tree, no production changes. Holding the dispose gate (`trySetDisposeGate`, a real refusal in the same drive guard) over the arm produces a byte-identical failure signature:

```
system-only attention finish = delegatestore.RunFinished{Generation:0x1, ...
  Disposition:"reported", DeliveryID:"dlg_034H3KIYaDoXr15tVUNors/delivery/1",
  Packet:(*delegatestore.TerminalPacket)(nil), ObserverCallbackDelivered:false},
  want private no-action
```

vs CI's `Generation:0x1, Disposition:"reported", DeliveryID:"dlg_034H2RvTZxo9e9lnjwyXE5/delivery/1"` — identical apart from the ULID and timestamp. 10/10 fail on the old helper; 400/400 pass on the new one.

(The unmodified flaky test passed 50/50 locally under `-race`, as reported in the issue. The window is narrow: the test side does a durable transcript append between the warm delivery and the arm, which normally outlasts the warm run's finalize tail.)

## Fix

Poll for supervision quiescence instead of joining one channel. Dispatching an armed attention walks a chain of states and no single one covers it, so the poll reads them **in dispatch order** — arm retry, pending attention, attention reservation, open generation, then the child's own run flags. Each stage is entered before its predecessor is left (`acceptDelegateAttention` clears the pending id only after `ReserveAttention` recorded the reservation; `CommitStart` releases the reservation and appends `RunStarted` under one `c.mu` hold), so work that races past one read is caught by a later one.

Reading them in the other order is not enough: an earlier draft checked the run flags first and the pending id last, and still failed ~1 in 200 with `CurrentRunOpen:true` while `sub.running` was still false — the gap between `CommitStart` and `resetSubagentForRunLocked`.

A regression test pins the helper's contract, since ~40 tests depend on it.

## Verification

- `go test -race -run TestDelegateResourceSupervision_AttentionNotificationRemainsNoAction -count=50 -cpu=1,2,4` — clean (150 runs)
- `go test -race -run TestWaitForStableSupervisionRunOutlastsDeferredAttentionDrive -count=200 -cpu=1,2` — clean (400 runs)
- `go test -race -run 'TestDelegateResource|TestWaitForStableSupervisionRun|TestDelegateAttention' -count=5` — clean
- `go test -race ./agent` (full package) — clean
- `gofmt`, `make lint` — clean

## Note

#763/#764 may share this root cause: the same helper is used after shell-attention triggers (`TestDelegateResourceSupervision_BareShellAttentionCompletesNoActionWithoutSecondReport` and friends), which arm attention through the same deferred-drive path. Worth re-checking those against this change before doing separate investigations.
