### PR TITLE
refactor: add systemNotification helper for faux-XML model notifications

### DIFF
--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -114,7 +114,7 @@ func watchLostAtRestartMessage(target string, status jobstore.Status) string {
 	)
 }
 
-const callbackWatchesCancelledAtRestartMessage = "<system-notification>All your callback watches were cancelled because the agent restarted. No further deliveries will occur. If you still want a callback, re-register it with the job_watch tool.</system-notification>"
+var callbackWatchesCancelledAtRestartMessage = systemNotification("All your callback watches were cancelled because the agent restarted. No further deliveries will occur. If you still want a callback, re-register it with the job_watch tool.")
 
 // watchLostAtRestartSessionMessage is the restart end-notice text for a
 // session-target watch (source "self" or "parent"): its target is this

--- a/agent/session_tools_aux_exact_fuzz_test.go
+++ b/agent/session_tools_aux_exact_fuzz_test.go
@@ -177,8 +177,17 @@ func auxCommunicateExact(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "SKILL.md"), []byte("---\nname: fixture\ndescription: fixture\n---\nbody\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got, err := h(context.Background(), nil, map[string]any{"skill_name": "fixture"}); err != nil || !strings.Contains(got.(string), "body") {
+	if got, err := h(context.Background(), nil, map[string]any{"skill_name": "fixture"}); err != nil {
 		t.Fatalf("skill load = %#v, %v", got, err)
+	} else {
+		s := got.(string)
+		if !strings.Contains(s, "body") {
+			t.Fatalf("skill load missing body: %q", s)
+		}
+		wantNotif := systemNotificationf("Paths referenced in this skill are relative to the skill directory: %q", root)
+		if !strings.HasPrefix(s, wantNotif) {
+			t.Fatalf("skill load prefix = %q, want %q", s, wantNotif)
+		}
 	}
 }
 

--- a/agent/session_tools_communicate.go
+++ b/agent/session_tools_communicate.go
@@ -192,7 +192,7 @@ func registerSkillTool(reg *tool.Registry, deps *toolDeps) {
 				if err != nil {
 					return nil, fmt.Errorf("loading skill %q: %w", skillName, err)
 				}
-				return fmt.Sprintf("Skill: %s\nLocation: %s\n\n---\n\n%s", skillName, meta.Dir, body), nil
+				return systemNotificationf("Paths referenced in this skill are relative to the skill directory: %q", meta.Dir) + "\n\n" + body, nil
 			},
 		})
 	}

--- a/agent/system_notification.go
+++ b/agent/system_notification.go
@@ -1,0 +1,16 @@
+package agent
+
+import "fmt"
+
+// systemNotification wraps msg in a <system-notification> faux-XML block.
+// These blocks are used for one-way notifications to the model that are not
+// steering messages (which use <SYSTEM-REMINDER>) — e.g. tool-output context
+// like a skill's directory path, or a callback-cancellation notice.
+func systemNotification(msg string) string {
+	return "<system-notification>" + msg + "</system-notification>"
+}
+
+// systemNotificationf is the format variant of systemNotification.
+func systemNotificationf(format string, args ...any) string {
+	return systemNotification(fmt.Sprintf(format, args...))
+}

--- a/agent/system_notification_test.go
+++ b/agent/system_notification_test.go
@@ -1,0 +1,21 @@
+package agent
+
+import "testing"
+
+func TestSystemNotification(t *testing.T) {
+	t.Parallel()
+	got := systemNotification("hello")
+	want := "<system-notification>hello</system-notification>"
+	if got != want {
+		t.Fatalf("systemNotification = %q, want %q", got, want)
+	}
+}
+
+func TestSystemNotificationf(t *testing.T) {
+	t.Parallel()
+	got := systemNotificationf("dir: %q", "/tmp/skill")
+	want := "<system-notification>dir: \"/tmp/skill\"</system-notification>"
+	if got != want {
+		t.Fatalf("systemNotificationf = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Add a standard `systemNotification`/`systemNotificationf` helper that wraps text in `<system-notification>` faux-XML blocks, matching the convention already used for tool-output notifications to the model.

## Changes

- **New: `agent/system_notification.go`** — `systemNotification(msg)` and `systemNotificationf(format, args...)` helpers
- **`agent/session_tools_communicate.go`** — the `use_skill` tool handler now uses `systemNotificationf` to emit a `<system-notification>` block telling the model that paths in the skill are relative to the skill directory, replacing the ad-hoc `Skill: %s\nLocation: %s` header
- **`agent/job_watch.go`** — `callbackWatchesCancelledAtRestartMessage` changed from a `const` literal to a `var` initialized through `systemNotification(...)`. The wrapped text is identical.
- **`agent/system_notification_test.go`** — unit tests for both helpers
- **`agent/session_tools_aux_exact_fuzz_test.go`** — strengthened the skill tool test to assert the exact `<system-notification>` prefix including the directory path

## Test plan

- `go build ./agent/...`
- `go vet ./agent/...`
- `go test -run TestSystemNotification -v ./agent/`
- `go test -run TestRestartCancelsNoSendReceiverWatchWithSystemNotification -v ./agent/`
- `go test -tags evenerfuzz -run FuzzSessionToolsAuxExact -fuzztime=1s ./agent/`