### PR TITLE
refactor: add helpers for faux-XML model notifications and reminders

### DIFF
--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -114,7 +114,7 @@ func watchLostAtRestartMessage(target string, status jobstore.Status) string {
 	)
 }
 
-const callbackWatchesCancelledAtRestartMessage = "<system-notification>All your callback watches were cancelled because the agent restarted. No further deliveries will occur. If you still want a callback, re-register it with the job_watch tool.</system-notification>"
+var callbackWatchesCancelledAtRestartMessage = systemNotification("All your callback watches were cancelled because the agent restarted. No further deliveries will occur. If you still want a callback, re-register it with the job_watch tool.")
 
 // watchLostAtRestartSessionMessage is the restart end-notice text for a
 // session-target watch (source "self" or "parent"): its target is this
@@ -2445,11 +2445,11 @@ func selfInfluenceNotice(self bool, gradientDepth int, truncated bool) string {
 	}
 	switch {
 	case truncated:
-		return "<system-reminder>↳ you're many exchanges deep responding to your own influence — consider disengaging.</system-reminder>"
+		return systemReminder("↳ you're many exchanges deep responding to your own influence — consider disengaging.")
 	case gradientDepth >= 2:
-		return fmt.Sprintf("<system-reminder>↳ you're ~%d exchanges deep responding to your own influence — consider disengaging.</system-reminder>", gradientDepth)
+		return systemReminderf("↳ you're ~%d exchanges deep responding to your own influence — consider disengaging.", gradientDepth)
 	default:
-		return "<system-reminder>↳ this turn responded to your last message.</system-reminder>"
+		return systemReminder("↳ this turn responded to your last message.")
 	}
 }
 

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -756,7 +756,7 @@ func (s *Session) processInputKindWithProvenance(ctx context.Context, input stri
 					// the model includes the interrupt notice in history.
 					// This is the user-visible "interrupted here" marker
 					// in the transcript that consumers (TUI / hub) render.
-					interruptMsg := "<SYSTEM-REMINDER>The user interrupted the previous turn before it completed. Any partial tool output above is incomplete. Wait for the user's next message before continuing.</SYSTEM-REMINDER>"
+					interruptMsg := systemReminderBlock("The user interrupted the previous turn before it completed. Any partial tool output above is incomplete. Wait for the user's next message before continuing.")
 					s.appendSteeringTurn(interruptMsg, events.SteeringKindInterrupted)
 				}
 				if emitEnd {

--- a/agent/session_tools_aux_exact_fuzz_test.go
+++ b/agent/session_tools_aux_exact_fuzz_test.go
@@ -177,8 +177,17 @@ func auxCommunicateExact(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "SKILL.md"), []byte("---\nname: fixture\ndescription: fixture\n---\nbody\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got, err := h(context.Background(), nil, map[string]any{"skill_name": "fixture"}); err != nil || !strings.Contains(got.(string), "body") {
+	if got, err := h(context.Background(), nil, map[string]any{"skill_name": "fixture"}); err != nil {
 		t.Fatalf("skill load = %#v, %v", got, err)
+	} else {
+		s := got.(string)
+		if !strings.Contains(s, "body") {
+			t.Fatalf("skill load missing body: %q", s)
+		}
+		wantNotif := systemNotificationf("Paths referenced in this skill are relative to the skill directory: %q", root)
+		if !strings.HasPrefix(s, wantNotif) {
+			t.Fatalf("skill load prefix = %q, want %q", s, wantNotif)
+		}
 	}
 }
 

--- a/agent/session_tools_communicate.go
+++ b/agent/session_tools_communicate.go
@@ -192,7 +192,7 @@ func registerSkillTool(reg *tool.Registry, deps *toolDeps) {
 				if err != nil {
 					return nil, fmt.Errorf("loading skill %q: %w", skillName, err)
 				}
-				return fmt.Sprintf("Skill: %s\nLocation: %s\n\n---\n\n%s", skillName, meta.Dir, body), nil
+				return systemNotificationf("Paths referenced in this skill are relative to the skill directory: %q", meta.Dir) + "\n\n" + body, nil
 			},
 		})
 	}

--- a/agent/system_notification.go
+++ b/agent/system_notification.go
@@ -1,0 +1,64 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// systemNotification wraps msg in a <system-notification> faux-XML block.
+// These blocks are used for one-way notifications to the model that are not
+// steering messages (which use <SYSTEM-REMINDER>) — e.g. tool-output context
+// like a skill's directory path, or a callback-cancellation notice.
+func systemNotification(msg string) string {
+	return "<system-notification>" + msg + "</system-notification>"
+}
+
+// systemNotificationf is the format variant of systemNotification.
+func systemNotificationf(format string, args ...any) string {
+	return systemNotification(fmt.Sprintf(format, args...))
+}
+
+// systemReminder wraps msg in a <system-reminder> faux-XML block. These
+// blocks are used for terse, single-line notices delivered as tool output —
+// e.g. the self-influence breaker's disengagement nudge. This is distinct from
+// systemReminderBlock, which wraps multi-line steering content in uppercase
+// <SYSTEM-REMINDER> tags.
+func systemReminder(msg string) string {
+	return "<system-reminder>" + msg + "</system-reminder>"
+}
+
+// systemReminderf is the format variant of systemReminder.
+func systemReminderf(format string, args ...any) string {
+	return systemReminder(fmt.Sprintf(format, args...))
+}
+
+// systemReminderBlock wraps inner content in a multi-line <SYSTEM-REMINDER>
+// faux-XML block. Used for steering messages the model treats as system
+// direction rather than conversational content — e.g. task reminders and the
+// interrupt marker. The content is written between the opening and closing
+// tags with newline separators.
+func systemReminderBlock(inner string) string {
+	var b strings.Builder
+	b.WriteString("<SYSTEM-REMINDER>\n")
+	b.WriteString(inner)
+	if !strings.HasSuffix(inner, "\n") {
+		b.WriteString("\n")
+	}
+	b.WriteString("</SYSTEM-REMINDER>")
+	return b.String()
+}
+
+// systemReminderBlockBuilder returns a strings.Builder pre-seeded with the
+// opening <SYSTEM-REMINDER> tag. The caller writes inner content and then
+// calls finishSystemReminderBlock to close the block.
+func systemReminderBlockBuilder() *strings.Builder {
+	var b strings.Builder
+	b.WriteString("<SYSTEM-REMINDER>\n")
+	return &b
+}
+
+// finishSystemReminderBlock closes a builder started by systemReminderBlockBuilder.
+func finishSystemReminderBlock(b *strings.Builder) string {
+	b.WriteString("</SYSTEM-REMINDER>")
+	return b.String()
+}

--- a/agent/system_notification_test.go
+++ b/agent/system_notification_test.go
@@ -1,0 +1,77 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSystemNotification(t *testing.T) {
+	t.Parallel()
+	got := systemNotification("hello")
+	want := "<system-notification>hello</system-notification>"
+	if got != want {
+		t.Fatalf("systemNotification = %q, want %q", got, want)
+	}
+}
+
+func TestSystemNotificationf(t *testing.T) {
+	t.Parallel()
+	got := systemNotificationf("dir: %q", "/tmp/skill")
+	want := `<system-notification>dir: "/tmp/skill"</system-notification>`
+	if got != want {
+		t.Fatalf("systemNotificationf = %q, want %q", got, want)
+	}
+}
+
+func TestSystemReminder(t *testing.T) {
+	t.Parallel()
+	got := systemReminder("nudge")
+	want := "<system-reminder>nudge</system-reminder>"
+	if got != want {
+		t.Fatalf("systemReminder = %q, want %q", got, want)
+	}
+}
+
+func TestSystemReminderf(t *testing.T) {
+	t.Parallel()
+	got := systemReminderf("depth ~%d", 3)
+	want := "<system-reminder>depth ~3</system-reminder>"
+	if got != want {
+		t.Fatalf("systemReminderf = %q, want %q", got, want)
+	}
+}
+
+func TestSystemReminderBlock(t *testing.T) {
+	t.Parallel()
+	got := systemReminderBlock("inner content")
+	if !strings.HasPrefix(got, "<SYSTEM-REMINDER>\n") {
+		t.Fatalf("missing opening tag+newline: %q", got)
+	}
+	if !strings.HasSuffix(got, "</SYSTEM-REMINDER>") {
+		t.Fatalf("missing closing tag: %q", got)
+	}
+	if !strings.Contains(got, "inner content") {
+		t.Fatalf("missing inner content: %q", got)
+	}
+}
+
+func TestSystemReminderBlock_TrailingNewline(t *testing.T) {
+	t.Parallel()
+	// Inner content that already ends with \n should not get a doubled newline.
+	got := systemReminderBlock("line1\n")
+	want := "<SYSTEM-REMINDER>\nline1\n</SYSTEM-REMINDER>"
+	if got != want {
+		t.Fatalf("systemReminderBlock = %q, want %q", got, want)
+	}
+}
+
+func TestSystemReminderBlockBuilder(t *testing.T) {
+	t.Parallel()
+	b := systemReminderBlockBuilder()
+	b.WriteString("task: do thing\n")
+	got := finishSystemReminderBlock(b)
+	want := "<SYSTEM-REMINDER>\ntask: do thing\n</SYSTEM-REMINDER>"
+	if got != want {
+		t.Fatalf("builder result = %q, want %q", got, want)
+	}
+}

--- a/agent/task_reminders.go
+++ b/agent/task_reminders.go
@@ -20,10 +20,9 @@ const (
 // canUseTaskList is the caller's answer to "does this session serve task_list";
 // false swaps the closing call instruction for wording the session can obey.
 func formatCurrentTaskSteering(task taskpkg.Task, canUseTaskList bool) string {
-	var b strings.Builder
-	b.WriteString("<SYSTEM-REMINDER>\n")
-	fmt.Fprintf(&b, "<CURRENT-TASK id=\"%d\">\n", task.ID)
-	fmt.Fprintf(&b, "<TITLE>%s</TITLE>\n", task.Description)
+	b := systemReminderBlockBuilder()
+	fmt.Fprintf(b, "<CURRENT-TASK id=\"%d\">\n", task.ID)
+	fmt.Fprintf(b, "<TITLE>%s</TITLE>\n", task.Description)
 	if task.Prompt != "" {
 		b.WriteString("<INSTRUCTIONS>\n")
 		b.WriteString(strings.TrimSpace(task.Prompt))
@@ -31,12 +30,11 @@ func formatCurrentTaskSteering(task taskpkg.Task, canUseTaskList bool) string {
 	}
 	b.WriteString("</CURRENT-TASK>\n")
 	if canUseTaskList {
-		fmt.Fprintf(&b, "Call your next tool: use task_list to mark task %d as done when this step is complete.\n", task.ID)
+		fmt.Fprintf(b, "Call your next tool: use task_list to mark task %d as done when this step is complete.\n", task.ID)
 	} else {
-		fmt.Fprintf(&b, "Work task %d now, and say so when this step is complete.\n", task.ID)
+		fmt.Fprintf(b, "Work task %d now, and say so when this step is complete.\n", task.ID)
 	}
-	b.WriteString("</SYSTEM-REMINDER>")
-	return b.String()
+	return finishSystemReminderBlock(b)
 }
 
 // taskReminderFull generates the full task list for post-compaction injection,
@@ -48,24 +46,22 @@ func taskReminderFull(store *taskpkg.TaskStore) string {
 		return ""
 	}
 
-	var b strings.Builder
-	b.WriteString("<SYSTEM-REMINDER>\n")
+	b := systemReminderBlockBuilder()
 	b.WriteString("Task list:\n")
 	for _, t := range tasks {
-		fmt.Fprintf(&b, "  [%s] #%d: %s", t.Status, t.ID, t.Description)
+		fmt.Fprintf(b, "  [%s] #%d: %s", t.Status, t.ID, t.Description)
 		if t.ReasoningEffort != "" {
-			fmt.Fprintf(&b, " [%s]", t.ReasoningEffort)
+			fmt.Fprintf(b, " [%s]", t.ReasoningEffort)
 		}
 		if len(t.DependsOn) > 0 {
-			fmt.Fprintf(&b, " (depends_on: %v)", t.DependsOn)
+			fmt.Fprintf(b, " (depends_on: %v)", t.DependsOn)
 		}
 		b.WriteString("\n")
 		for _, n := range t.Notes {
-			fmt.Fprintf(&b, "    note: %s\n", n)
+			fmt.Fprintf(b, "    note: %s\n", n)
 		}
 	}
-	b.WriteString("</SYSTEM-REMINDER>")
-	return b.String()
+	return finishSystemReminderBlock(b)
 }
 
 // taskReminderForInactivity re-emits the current task's steering message when


### PR DESCRIPTION
## Summary

Add standard helpers in `agent/system_notification.go` for the three faux-XML block types used to communicate with the model, and refactor all call sites to use them.

## Helpers

| Helper | Tag | Use case |
|--------|-----|----------|
| `systemNotification` / `systemNotificationf` | `<system-notification>` | One-way tool-output notifications (skill directory, callback cancellation) |
| `systemReminder` / `systemReminderf` | `<system-reminder>` | Terse single-line notices (self-influence breaker nudges) |
| `systemReminderBlock` / `systemReminderBlockBuilder` / `finishSystemReminderBlock` | `<SYSTEM-REMINDER>` | Multi-line steering messages (task reminders, interrupt marker) |

## Call sites refactored

- **`session_tools_communicate.go`** — `use_skill` tool now emits a `<system-notification>` block instead of the ad-hoc `Skill: %s\nLocation: %s` header
- **`job_watch.go`** — `callbackWatchesCancelledAtRestartMessage` changed from `const` literal to `var` via `systemNotification`; `selfInfluenceNotice` uses `systemReminder`/`systemReminderf`
- **`session_lifecycle.go`** — interrupt marker uses `systemReminderBlock`
- **`task_reminders.go`** — `formatCurrentTaskSteering` and `taskReminderFull` use `systemReminderBlockBuilder`/`finishSystemReminderBlock`

## Notes

- All wrapped text is unchanged; existing exact-string test assertions still pass.
- The interrupt marker gains a newline after the opening `<SYSTEM-REMINDER>` tag (multi-line format instead of single-line). This is compatible with existing substring assertions.
- `callbackWatchesCancelledAtRestartMessage` changed from `const` to `var` (Go constants can only be literals, not function calls).

## Test plan

- `go build ./agent/...`
- `go vet ./agent/...`
- `go test -run TestSystemNotification -v ./agent/`
- `go test -run TestSystemReminder -v ./agent/`
- `go test -run TestSelfInfluenceNotice -v ./agent/`
- `go test -run TestRestartCancelsNoSendReceiverWatchWithSystemNotification -v ./agent/`
- `go test -run TestTaskReminder -v ./agent/`
- `go test -run TestSettlement -v ./agent/`
- `go test -tags evenerfuzz -run FuzzSessionToolsAuxExact -fuzztime=1s ./agent/`