### PR TITLE
docs(agent): state the measured stop-admission latency in the tripwire

### DIFF
--- a/agent/delegate_resource_runtime_test.go
+++ b/agent/delegate_resource_runtime_test.go
@@ -1623,8 +1623,9 @@ func currentDelegateStop(t *testing.T, controller *delegateTreeController) *dele
 func awaitDelegateStopAdmission(t *testing.T, controller *delegateTreeController) *delegateStopState {
 	t.Helper()
 	var stop *delegateStopState
-	// TRIPWIRE: admission is a durable fsync + local drive, expected in low
-	// hundreds of ms; 5s only absorbs CI scheduling stalls.
+	// TRIPWIRE: admission is a durable fsync + local drive, measured at
+	// 5-17ms across 1200 samples with the whole module under -race on a
+	// saturated box; 5s only absorbs pathological CI stalls.
 	waitForCondition(t, 5*time.Second, "stable stop admission", func() bool {
 		controller.mu.Lock()
 		defer controller.mu.Unlock()


### PR DESCRIPTION
The `awaitDelegateStopAdmission` tripwire comment said admission was "expected in low hundreds of ms", which instrumenting the helper showed to be wrong by an order of magnitude: 5-17ms across 1200 samples (p50 5.5ms, p99 12.4ms) taken with the full agent module running `go test -race ./...` concurrently with targeted stress of both settle tests on an already-loaded box — the saturated condition the 5s bound exists to absorb.

Comment only, no behavior change; the 5s bound stays as is, with ~294x headroom over the observed max. This corrects the number a future reader would weigh against a flake in this territory.