### PR TITLE
fix(tui): bound the stream test's burst so the hub keeps the TUI subscribed

### DIFF
--- a/cmd/evener-tui/tmux_e2e_test.go
+++ b/cmd/evener-tui/tmux_e2e_test.go
@@ -1021,6 +1021,19 @@ func TestTUITmuxE2E_APIErrorsRenderInPlace(t *testing.T) {
 	app.WaitFor("Hub session start failed.", "cause appwire thread/start: spawn failed", "> spawn should fail")
 }
 
+// tuiE2EStreamBurst is how many agent deltas each round of the stream test
+// hands the hub before it starts capturing. The whole burst is queued up
+// front, so the TUI is still working through the backlog for the poll loop
+// that follows — the pane changes under all but the last of those captures,
+// which is the condition under test.
+//
+// It is sized from both ends: well under appwire.NotificationBufferCap (4096)
+// so the hub never evicts the TUI as a slow consumer mid-test, and small
+// enough that the backlog drains in a fraction of tuiE2EWaitTimeout even on a
+// starved runner — 100 deltas settle in under a second here, against a 60s
+// deadline.
+const tuiE2EStreamBurst = 100
+
 // TestTUITmuxE2E_CaptureStableDuringStream exercises CaptureStable under the
 // exact condition kata nxq6 reported the pane going blank above the composer:
 // a rapid burst of hub notifications re-rendering the pane in a tight loop,
@@ -1036,6 +1049,19 @@ func TestTUITmuxE2E_APIErrorsRenderInPlace(t *testing.T) {
 // to require completeness evidence (all anchors present, including the
 // last-written footer) before accepting stability, which is what
 // CaptureStable's anchor arguments do.
+//
+// The burst has to stay inside what the hub will actually carry. An
+// unthrottled broadcast goroutine — the shape this test used to have — pushes
+// deltas at ~120k/s, far past anything the TUI can drain, so Server.Broadcast
+// fills the connection's outbound buffer (appwire.NotificationBufferCap
+// frames) and evicts the TUI as a slow consumer within ~260ms. Everything
+// after that point is reconnect churn, not a render storm: the dropped client
+// logs its keepalive teardown straight into the pane (these E2E runs pass
+// -debug, which disables the alternate screen), scrolling the grid, and with
+// no hub left to notify it the TUI has no reason to repaint over the damage —
+// so the pane stays torn, without breadcrumb or composer, for CaptureStable's
+// whole deadline. Bounded bursts keep the subscription alive, so the storm
+// this test means to create is the one it actually gets.
 func TestTUITmuxE2E_CaptureStableDuringStream(t *testing.T) {
 	t.Parallel()
 	requireTmux(t)
@@ -1050,24 +1076,10 @@ func TestTUITmuxE2E_CaptureStableDuringStream(t *testing.T) {
 	openLiveSession(t, app)
 	app.WaitFor("evener / session / live task", "initial answer", "enter send")
 
-	stop := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		for {
-			select {
-			case <-stop:
-				return
-			default:
-			}
+	for range 5 {
+		for range tuiE2EStreamBurst {
 			hub.BroadcastAgentDelta("01LIVE", "streamed word ")
 		}
-	})
-	t.Cleanup(func() {
-		close(stop)
-		wg.Wait()
-	})
-
-	for range 5 {
 		app.CaptureStable("evener / session / live task", "enter send")
 	}
 }


### PR DESCRIPTION
Fixes #779

## What the anchors fix covered, and what it didn't

`0e45c25c2` + `19b6f32cc` made `CaptureStable` accept a frame only when every
completeness anchor is present **and** the capture is byte-identical to the one
a poll interval earlier. That closed the failure it was aimed at: run
33424655285 returned a *torn* frame to the caller, and the caller's own
assertion caught it after the fact. With anchors in the acceptance condition,
`CaptureStable` can no longer hand back a frame missing the breadcrumb or the
composer. That part holds.

What it could not close is a pane that is torn and *stays* torn. Three post-fix
CI sightings — jobs
[99697926985](https://github.com/prime-radiant-inc/evener/actions/runs/33456647919),
[99723420167](https://github.com/prime-radiant-inc/evener/actions/runs/33465153801),
[99735295912](https://github.com/prime-radiant-inc/evener/actions/runs/33468646646)
— all timed out with the post-anchors wording:

```
pane never rendered a complete, stable frame (missing ["evener / session / live task" "enter send"])
within 1m0s — either the pane is still changing every 10ms (a real, ongoing render),
or the wanted anchors never rendered
```

(That message text only exists after `19b6f32cc`, which is what proves those
runs carried the anchors fix.) Each attached a pane with no breadcrumb and no
composer, sometimes with duplicated header rows at the top and stray
`appwire: keepalive ping failed …` lines at the bottom. A frame torn for a
full minute is not a capture race — no acceptance predicate could have helped.

> Note: issue #779 cites job `99699887011` as the sighting. That job's log
> actually fails `TestServeWebSocketTraceSeparatesConnections`; `cmd/evener-tui`
> passed in 14.3s. The three jobs above are the real post-fix sightings.

## Root cause

The test's own broadcast goroutine, not the helper.

- Unthrottled, it hands the hub **~120k deltas/second** — measured 1,186,992
  broadcasts in 9.7s on this fixture.
- `Server.Broadcast` → `deliverNotifications` → `Connection.enqueue` is
  non-blocking into a buffer of `appwire.NotificationBufferCap` (4096) frames;
  a full buffer means `evictSlowConsumer`.
- A probe on this exact fixture measured the hub dropping the TUI's
  subscription after **260ms and 5,796 broadcasts**.

Everything after that point is reconnect churn, not a render storm. The dropped
`appwire` client logs its keepalive teardown with `log.Printf`, which lands
straight in the pane (these E2E runs pass `-debug`, i.e. no alternate screen).
That scrolls tmux's grid, and with no hub left to notify it the TUI has no
reason to repaint over the damage — so the pane stays torn until the 60s
deadline.

So the test passed only when its five captures beat the eviction it caused
itself, and failed when they didn't. It never exercised the sustained
re-render storm its doc comment describes.

## Fix

Each round hands the hub a bounded burst (100 deltas) and then captures while
the TUI works through the backlog. Sized from both ends: far under the 4096-frame
buffer so the hub never evicts the TUI, and small enough that the backlog drains
in a fraction of the 60s deadline even on a starved runner.

Probe evidence across 1,293 polls of the new shape: subscription never dropped,
no capture ever saw a missing anchor, and the pane was still changing under
every poll but the one that converged — which is the condition the test exists
to exercise.

`CaptureStable` itself is unchanged.

## Verification

Stress on a 16-core box, 6 concurrent copies of the test binary against 10
spinning CPU hogs, same recipe both sides:

| tree | runs | failures |
| --- | --- | --- |
| `main` | 270 | **102 (38%)** |
| this branch | 270 | 0 |
| this branch, 8 copies vs 12 hogs | 2000 | 0 |

Reproduced failures on `main` were byte-identical to the CI signature (same
message, same pane shape, same stray keepalive lines).

Also: `go test ./cmd/evener-tui/... -count=1` (1312 tests, 0 skipped, 0 failed),
`gofmt -l` clean, `make lint` all green.

## Left alone, worth a look separately

`appwire`'s keepalive teardown logs through the standard `log` package, so on a
TUI launched without the alternate screen it writes into the live pane and
corrupts the render irrecoverably (bubbletea's diff renderer has no idea the
grid moved). That is what makes the torn pane permanent rather than transient.
Out of scope here — it's a product behaviour change, not a test fix — but it is
a real wart for anyone whose hub connection drops.
