### PR TITLE
appprojector: give fill_required repairs their own phrase

### DIFF
--- a/internal/appprojector/appwire_projection.go
+++ b/internal/appprojector/appwire_projection.go
@@ -1744,6 +1744,11 @@ func repairChangePhrase(raw string) string {
 		return fmt.Sprintf("removed the unrecognized %q field", field)
 	case "unicode_repair":
 		return "fixed an invalid character in the arguments"
+	case "fill_required":
+		if key, ok := strings.CutPrefix(fieldDetail(parts), "filled "); ok && key != "" {
+			return fmt.Sprintf("filled the required %q key", key)
+		}
+		return fmt.Sprintf("filled a required key in the %q field", field)
 	default:
 		if field == "" {
 			return "adjusted the arguments"

--- a/internal/appprojector/appwire_projection_test.go
+++ b/internal/appprojector/appwire_projection_test.go
@@ -1847,6 +1847,30 @@ func TestAppEventProjectorProjectsAgentOnlyEventsAsSystemAnnouncements(t *testin
 			notContains: []string{"fill_required:output:filled message", "adjusted the"},
 		},
 		{
+			name: "tool call repaired: fill_required three keys",
+			event: events.SessionEvent{Kind: events.EventToolCallRepaired, SessionID: "th_1", Data: events.ToolCallRepairedData{
+				ToolName: "communicate",
+				CallID:   "c1",
+				Changes: []string{
+					"fill_required:output:filled message",
+					"fill_required:output:filled data",
+					"fill_required:output:filled artifacts",
+				},
+			}},
+			description: "Tool call repaired",
+			contains: []string{
+				`filled the required "message" key`,
+				`filled the required "data" key`,
+				`filled the required "artifacts" key`,
+			},
+			notContains: []string{
+				"fill_required:output:filled message",
+				"fill_required:output:filled data",
+				"fill_required:output:filled artifacts",
+				"adjusted the",
+			},
+		},
+		{
 			name: "tool call repaired: multiple changes",
 			event: events.SessionEvent{Kind: events.EventToolCallRepaired, SessionID: "th_1", Data: events.ToolCallRepairedData{
 				ToolName: "communicate",

--- a/internal/appprojector/appwire_projection_test.go
+++ b/internal/appprojector/appwire_projection_test.go
@@ -1836,6 +1836,17 @@ func TestAppEventProjectorProjectsAgentOnlyEventsAsSystemAnnouncements(t *testin
 			notContains: []string{`unicode_repair::invalid \u escape → �`},
 		},
 		{
+			name: "tool call repaired: fill_required",
+			event: events.SessionEvent{Kind: events.EventToolCallRepaired, SessionID: "th_1", Data: events.ToolCallRepairedData{
+				ToolName: "communicate",
+				CallID:   "c1",
+				Changes:  []string{"fill_required:output:filled message"},
+			}},
+			description: "Tool call repaired",
+			contains:    []string{"communicate", "filled", "message"},
+			notContains: []string{"fill_required:output:filled message", "adjusted the"},
+		},
+		{
 			name: "tool call repaired: multiple changes",
 			event: events.SessionEvent{Kind: events.EventToolCallRepaired, SessionID: "th_1", Data: events.ToolCallRepairedData{
 				ToolName: "communicate",


### PR DESCRIPTION
Fixes #689. The change-kind switch had no `fill_required` case, so filled-envelope repairs rendered as the generic "adjusted the output field" repeated per key. Adds the case (extracting the filled key from the real `filled <key>` detail shape produced by fillCommunicateEnvelope), with the issue's three-key worst case pinned as distinct non-repeated clauses.

Pipeline provenance: TDD red-checked (both rounds, production-only revert proof); two adversarial reviews SURVIVES (correctness lens verified the sole emitter and ran built code; regression lens swept consumers); their one converged Minor (multi-key case unpinned) closed in a micro round; simplify pass returned NO-OP with reasoning. Full trail in .superpowers/sdd/2026-09-01-issue-sweep/.