### PR TITLE
test: bring both writeExecutable copies up to the canonical ForkLock semantics

### DIFF
--- a/cmd/evener-tui/internal/hubstart/hub_start_test.go
+++ b/cmd/evener-tui/internal/hubstart/hub_start_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -442,6 +443,15 @@ func withLocalHubImmediateExitWindow(t *testing.T, window time.Duration) {
 
 func writeExecutable(t *testing.T, path string) {
 	t.Helper()
+
+	// Hold ForkLock across the write, matching install_test.go's
+	// writeExecutable: os.WriteFile holds path open for writing, and a
+	// sibling parallel test that forks for its own os/exec in that window
+	// leaves the child holding the write fd until it execs, so a later exec
+	// of path fails with ETXTBSY (golang/go#22315). Reading the lock across
+	// the write excludes any concurrent fork.
+	syscall.ForkLock.RLock()
+	defer syscall.ForkLock.RUnlock()
 	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/binresolve/sibling_test.go
+++ b/internal/binresolve/sibling_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -183,6 +184,15 @@ func TestSiblingDirHandlesEmptyAndMissing(t *testing.T) {
 
 func writeExecutable(t *testing.T, path string) {
 	t.Helper()
+
+	// Hold ForkLock across the write, matching install_test.go's
+	// writeExecutable: os.WriteFile holds path open for writing, and a
+	// sibling parallel test that forks for its own os/exec in that window
+	// leaves the child holding the write fd until it execs, so a later exec
+	// of path fails with ETXTBSY (golang/go#22315). Reading the lock across
+	// the write excludes any concurrent fork.
+	syscall.ForkLock.RLock()
+	defer syscall.ForkLock.RUnlock()
 	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #610. The writeExecutable helpers in cmd/evener-tui/internal/hubstart and internal/binresolve shared the root package's helper name but lacked its syscall.ForkLock guard; both now hold RLock across the write, matching install_test.go:1316 and three other in-repo precedents.

Pipeline provenance: adversarial review SURVIVES (stdlib-source-level verification that no ForkLock recursion exists on the Linux CLOEXEC path; structural identity with the canonical helper confirmed; the fix's honesty claims — no t.Parallel, binresolve never forks — independently verified). Simplify pass NO-OP. Reviewer notes for the record: the guard is prophylactic today (nothing currently execs these helpers' output), and hub_start_fuzz_test.go's fuzzStartLocalHub carries its own inline unguarded write-then-exec outside this issue's scope; six near-identical helper copies across packages would need a shared test package to consolidate — deliberate non-goals here.