### PR TITLE
fix(hub): close two relay-family delivery windows (#773, #780)

### DIFF
--- a/cmd/evener-hub/app_relay.go
+++ b/cmd/evener-hub/app_relay.go
@@ -492,6 +492,20 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 				routing    relayNotificationRouting
 			}
 			pendingDeliveries := make([]pendingRelayDelivery, 0, hubRelayPendingDeliveryLimit)
+			// routeChangeWait is the wake-up a parked frame waits on.
+			// signalRouteChangeLocked closes handle.routeChanged and installs a
+			// fresh one, so this must be taken before the routes are read that
+			// decide to park: a capture taken afterwards can be the replacement
+			// channel, and the frame then sleeps through the very publication it
+			// is waiting for until unrelated traffic on the same key wakes it.
+			// A capture that is already closed by the time the loop selects on
+			// it just costs one extra resolution pass.
+			var routeChangeWait <-chan struct{}
+			captureRouteChange := func() {
+				relayMu.Lock()
+				routeChangeWait = handle.routeChanged
+				relayMu.Unlock()
+			}
 			acknowledge := func(delivery appsource.RelayDelivery) {
 				if delivery.Acknowledge != nil {
 					delivery.Acknowledge()
@@ -605,6 +619,7 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 				acknowledge(delivery)
 			}
 			processPending := func() {
+				captureRouteChange()
 				kept := pendingDeliveries[:0]
 				for _, pending := range pendingDeliveries {
 					targets, wait := lookupTargets(pending.routingKey, pending.routing)
@@ -625,6 +640,7 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 				return false
 			}
 			acceptDelivery := func(delivery appsource.RelayDelivery) {
+				captureRouteChange()
 				routingKey, routing := relayNotificationRoutingKey(delivery.Notification, handle.canonical.SourceID)
 				if routing == relayNotificationTargeted && hasPendingTarget(routingKey) {
 					pendingDeliveries = append(pendingDeliveries, pendingRelayDelivery{delivery: delivery, routingKey: routingKey, routing: routing})
@@ -725,9 +741,7 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 				}
 				var routeChanged <-chan struct{}
 				if len(pendingDeliveries) != 0 {
-					relayMu.Lock()
-					routeChanged = handle.routeChanged
-					relayMu.Unlock()
+					routeChanged = routeChangeWait
 				}
 				select {
 				case <-handle.ctx.Done():

--- a/cmd/evener-hub/app_relay_alias_test.go
+++ b/cmd/evener-hub/app_relay_alias_test.go
@@ -65,6 +65,7 @@ func TestHubRelaySharedSessionAliasesDeliverEachNotificationOnce(t *testing.T) {
 	if _, err := fresh.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: rootRef, Subscribe: true}); err != nil {
 		t.Fatalf("subscribe fresh client: %v", err)
 	}
+	awaitLiveHubSubscriptions(t, appServer, 3)
 
 	params, err := json.Marshal(appwire.ReasoningSummaryDeltaParams{
 		ThreadID:     "root-thread",
@@ -78,8 +79,9 @@ func TestHubRelaySharedSessionAliasesDeliverEachNotificationOnce(t *testing.T) {
 		t.Fatal(err)
 	}
 	pool.emit(t, appwire.Notification{Method: appwire.NotifyReasoningSummaryDelta, Params: params})
-	// Every alias fanout has acknowledged and enqueued the delta before emit
-	// returns. This connection-wide marker is therefore an ordered drain barrier.
+	// Every subscription is live, so each alias fanout has acknowledged and
+	// enqueued the delta on its connection before emit returns. This
+	// connection-wide marker is therefore an ordered drain barrier.
 	appServer.BroadcastAll("test/alias-barrier", map[string]any{})
 
 	if got := aliasDeltaCountUntilBarrier(t, longLived, "one logical delta"); got != 1 {

--- a/cmd/evener-hub/app_relay_alias_test.go
+++ b/cmd/evener-hub/app_relay_alias_test.go
@@ -212,6 +212,7 @@ func TestHubRelaySharedSessionAliasesEnrichUntargetedOutputImages(t *testing.T) 
 			t.Fatalf("subscribe client to %s: %v", ref, err)
 		}
 	}
+	awaitLiveHubSubscriptions(t, appServer, 2)
 
 	started := appwire.NotificationMessage(appwire.NotifyItemStarted, map[string]any{
 		"turnId": "turn-image",

--- a/cmd/evener-hub/app_relay_alias_test.go
+++ b/cmd/evener-hub/app_relay_alias_test.go
@@ -335,6 +335,7 @@ func TestHubRelayThreadIDReadUsesAuthoritativeResponseRef(t *testing.T) {
 	if _, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{ThreadID: "lookup-thread", Subscribe: true}); err != nil {
 		t.Fatalf("subscribe by thread id: %v", err)
 	}
+	awaitLiveHubSubscriptions(t, appServer, 1)
 	params, err := json.Marshal(appwire.ReasoningSummaryDeltaParams{
 		ThreadID:     "lookup-thread",
 		Ref:          "local:workspace-thread",
@@ -534,6 +535,41 @@ func (p *aliasRelayPool) emit(t *testing.T, notification appwire.Notification) {
 		case <-time.After(2 * time.Second):
 			t.Fatal("relay listener did not acknowledge notification")
 		}
+	}
+}
+
+// awaitLiveHubSubscriptions blocks until the hub holds at least want live
+// thread subscriptions and none is still buffering.
+//
+// A thread/read response enters the connection's send queue before appserver
+// commits the hydration capture that response opened -- enqueueResponse hands
+// the message to the writer goroutine and only then calls the finalizer. So a
+// client's ThreadRead can return while its own subscription is still
+// buffering, and Subscriptions.Route parks a relay broadcast in that buffer
+// instead of delivering it. A BroadcastAll barrier enqueued next goes straight
+// to the connection, ahead of the buffered frame, and a test counting frames
+// up to the barrier sees none.
+func awaitLiveHubSubscriptions(t *testing.T, server *appserver.Server, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var live, buffering int
+		for _, row := range server.DebugSubscriptions().Subscriptions {
+			switch {
+			case row.Withdrawn:
+			case row.Buffering:
+				buffering++
+			default:
+				live++
+			}
+		}
+		if buffering == 0 && live >= want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("hub subscriptions never settled: %d live, %d buffering, want %d live", live, buffering, want)
+		}
+		time.Sleep(time.Millisecond)
 	}
 }
 

--- a/cmd/evener-hub/app_relay_closed_capabilities_test.go
+++ b/cmd/evener-hub/app_relay_closed_capabilities_test.go
@@ -221,6 +221,7 @@ func TestHubRelayRelayKeyImageMetadata(t *testing.T) {
 			t.Fatalf("subscribe client to %s: %v", ref, err)
 		}
 	}
+	awaitLiveHubSubscriptions(t, appServer, 3)
 
 	tests := []struct {
 		name       string

--- a/cmd/evener-hub/app_relay_test.go
+++ b/cmd/evener-hub/app_relay_test.go
@@ -2685,3 +2685,128 @@ func (h *recordingRelayHandoff) Abort() bool {
 	})
 	return won
 }
+
+// TestHubRelayPendingFrameWakesOnARoutePublishItRaced pins the wake-up a
+// parked relay frame waits on. signalRouteChangeLocked closes the handle's
+// route-change channel and installs a fresh one, so a listener that captures
+// the channel after deciding to park -- rather than before reading the routes
+// that decision rests on -- captures the replacement and sleeps through the
+// publication it is waiting for. The park hook here holds the listener in
+// exactly that gap while the replacement read publishes its routes.
+func TestHubRelayPendingFrameWakesOnARoutePublishItRaced(t *testing.T) {
+	const (
+		downstreamRef       = "local:wake-downstream"
+		oldAuthoritativeRef = "local:wake-authoritative-old"
+		newAuthoritativeRef = "local:wake-authoritative-new"
+	)
+	canonicalOld := appwire.Ref{SourceID: "local", ThreadID: "wake-old"}
+	canonicalNew := appwire.Ref{SourceID: "local", ThreadID: "wake-new"}
+	newLease := func(authoritativeRef string) *scriptedRelaySessionLease {
+		return &scriptedRelaySessionLease{
+			readResult: appsource.RelayReadResult{
+				Response: appwire.ThreadReadResponse{Thread: appwire.Thread{
+					ID: "wake-downstream", Source: "local",
+					Evener: appwire.EvenerThread{Ref: authoritativeRef},
+				}},
+				Handoff: &guardedRelayHandoff{prepareAllowed: true, commitAllowed: true},
+			},
+			deliveries: make(chan appsource.RelayDelivery),
+		}
+	}
+	oldLease := newLease(oldAuthoritativeRef)
+	replacementLease := newLease(newAuthoritativeRef)
+	replacementReadEntered := make(chan struct{})
+	releaseReplacementRead := make(chan struct{})
+	replacementLease.readHook = func() {
+		close(replacementReadEntered)
+		<-releaseReplacementRead
+	}
+	var resolveMu sync.Mutex
+	resolved := canonicalOld
+	source := &relaySessionTestSource{
+		resolveRelay: func(appwire.ThreadReadParams) (appwire.Ref, error) {
+			resolveMu.Lock()
+			defer resolveMu.Unlock()
+			return resolved, nil
+		},
+		acquireRelay: func(ref appwire.Ref) (appsource.RelaySessionRoutePublicationLease, error) {
+			if ref == canonicalOld {
+				return routeAwareTestLease(oldLease), nil
+			}
+			return routeAwareTestLease(replacementLease), nil
+		},
+	}
+	sources := appsource.NewRegistry()
+	sources.Add(source)
+	appServer := newHubAppServer(hubcore.WebConfig{HubStateRoot: t.TempDir(), Past: hubcore.NewPastIndex("")}, sources)
+	hub := httptest.NewServer(http.HandlerFunc(appServer.ServeWebSocket))
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if _, err := client.ThreadRead(context.Background(), appwire.ThreadReadParams{Ref: downstreamRef, Subscribe: true}); err != nil {
+		t.Fatalf("initial ThreadRead: %v", err)
+	}
+	resolveMu.Lock()
+	resolved = canonicalNew
+	resolveMu.Unlock()
+
+	// Hold the listener between parking the frame and waiting for its wake-up,
+	// so the replacement read's route publication lands inside that gap.
+	parked := make(chan struct{})
+	resumeListener := make(chan struct{})
+	var parkOnce sync.Once
+	previousObserveWait := observeHubRelayWait
+	observeHubRelayWait = func() {
+		parkOnce.Do(func() {
+			close(parked)
+			<-resumeListener
+		})
+	}
+	t.Cleanup(func() { observeHubRelayWait = previousObserveWait })
+
+	replacementResult := make(chan error, 1)
+	go func() {
+		_, err := client.ThreadRead(context.Background(), appwire.ThreadReadParams{
+			Ref: downstreamRef, Subscribe: true, ReplaceSubscription: true,
+		})
+		replacementResult <- err
+	}()
+	<-replacementReadEntered
+	acknowledged := make(chan struct{})
+	go func() {
+		replacementLease.deliveries <- appsource.RelayDelivery{
+			Notification: appwire.Notification{
+				Method: appwire.NotifyAgentMessageDelta,
+				Params: testRawJSON(t, appwire.AgentMessageDeltaParams{
+					Ref: newAuthoritativeRef, ThreadID: "wake-authoritative-new",
+					TurnID: "turn-wake", ItemID: "item-wake", Delta: "raced publish",
+				}),
+			},
+			Acknowledge: func() { close(acknowledged) },
+		}
+	}()
+	select {
+	case <-parked:
+	case <-time.After(5 * time.Second):
+		close(releaseReplacementRead)
+		t.Fatal("changed-target notification was never parked for the pending replacement generation")
+	}
+	close(releaseReplacementRead)
+	if err := <-replacementResult; err != nil {
+		close(resumeListener)
+		t.Fatalf("replacement ThreadRead: %v", err)
+	}
+	close(resumeListener)
+	select {
+	case got := <-client.Notifications():
+		if got.Method != appwire.NotifyAgentMessageDelta {
+			t.Fatalf("notification after raced publish method = %q, want %q", got.Method, appwire.NotifyAgentMessageDelta)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("parked notification slept through the route publication it raced")
+	}
+	<-acknowledged
+}


### PR DESCRIPTION
Fixes #773. Fixes #780.

Two distinct windows in the 2026-08-31 relay-demultiplexing family. Both reproduced under CPU oversubscription with the byte-identical CI signature, then pinned by construction. One is a test-side ordering assumption; the other is a production lost wake-up.

## Reproduced

Recipe: N concurrent copies of the compiled `-race` test binary at `-count=C -cpu 1,2,4`, with six busy-loop processes competing for the box.

| test | failures | runs | assertion |
| --- | --- | --- | --- |
| `TestHubRelayThreadIDReadUsesAuthoritativeResponseRef` (#773) | 92 | 12,000 | `app_relay_alias_test.go:352: thread-id subscriber received authoritative-ref delta 0 times, want once` |
| `TestHubRelaySharedSessionAliasesDeliverEachNotificationOnce` | 106 | 7,200 | lines 89/106, same shape |
| `TestHubRelaySharedSessionAliasesEnrichUntargetedOutputImages` | 97 | 7,200 | line 242, same shape |
| `TestHubRelayRemapRetainsAuthoritativeRouteDuringReplacementRead` (#780) | 30 | 9,000 | `app_relay_test.go:1944: changed-target notification was lost after replacement routes published`, every one at `(1.01s)` |

Every failure matched its CI text exactly. No race-detector report in any of them.

## Window 1 (#773 and its siblings): a capture that is still buffering

`Connection.enqueueResponse` puts the response into the send queue and only *then* commits the hydration capture that response opened:

```go
case c.send <- msg:
        finalizer := c.takeHydration(responseID)
        c.sendMu.RUnlock()
        if finalizer != nil {
                if responseSucceeded || finalizer.releaseOnErrorResponse {
                        finalizer.commit()   // <- releaseHydration, well after the response is queued
```

A writer goroutine drains `c.send`, so a client's `ThreadRead` can return before `commit()` runs. Until it does, `Subscriptions.Route` parks a broadcast for that key in `sub.buffer` and does not return the connection as live. `Server.BroadcastAll` takes neither path — it calls `conn.enqueue` directly — so the test's barrier overtakes the still-buffered delta, and the count-until-barrier loop returns 0.

These tests all treated "the last ThreadRead returned" as "every subscription is live". `TestHubRelaySharedSessionAliasesDeliverEachNotificationOnce` even stated the invariant in a comment ("Every alias fanout has acknowledged and enqueued the delta before emit returns"); it holds only once the captures have released.

Window confirmed by construction: a `time.Sleep(20 * time.Millisecond)` between `c.send <- msg` and `finalizer.commit()` fails the old tests **20/20**. Running the whole `cmd/evener-hub` package under that probe found exactly four affected tests — the three above plus `TestHubRelayRelayKeyImageMetadata`, which never flaked naturally in 7,200 runs but shares the window. (Probe reverted; no production code in this window is touched.)

**Fix** (test-side): `awaitLiveHubSubscriptions` polls `Server.DebugSubscriptions()` until no subscription row is still buffering and at least the expected number are live, before the test emits. The capture row exists before its response is queued, so an already-returned `ThreadRead` can never add one later — the predicate cannot pass early.

## Window 2 (#780): a parked relay frame sleeps through its own wake-up

This one is production, not test ordering.

A targeted frame whose route is not published yet parks in the canonical listener's pending queue and waits on `handle.routeChanged`. `signalRouteChangeLocked` closes that channel and installs a fresh one:

```go
signalRouteChangeLocked := func(handle *hubRelayHandle) {
        close(handle.routeChanged)
        handle.routeChanged = make(chan struct{})
}
```

The listener captured the channel at the top of its *next* select loop — after `lookupTargets` had already released `relayMu` and decided to park:

```go
targets, pending := lookupTargets(routingKey, routing)   // decides to park, releases relayMu
if pending { pendingDeliveries = append(...); return }
// ... next loop iteration:
relayMu.Lock()
routeChanged = handle.routeChanged                       // may be the replacement channel
relayMu.Unlock()
```

A route publication landing in that gap closes the channel the frame should have been waiting on and installs a new one, so the listener parks on the replacement. Nothing recovers it: `retireIdle` on the idle ticker does not drain pending frames, so the frame stalls until unrelated traffic arrives on the same key. In the remap test nothing else arrives, which is why every CI and local failure sits at exactly `(1.01s)` — the assertion's own timeout.

Window confirmed by construction: a `time.Sleep(20 * time.Millisecond)` at the end of `acceptDelivery`'s pending branch — inside that gap — fails the test **20/20**. (Probe reverted.)

**Fix**: capture the wake-up before reading the routes that decide to park, at the top of `acceptDelivery` and `processPending`. A capture taken before the read is either closed by a later publication (the listener wakes and re-resolves) or reflects routes the read already saw. A capture that is already closed when the loop selects on it costs one extra resolution pass and nothing else, so there is no hot spin.

`TestHubRelayPendingFrameWakesOnARoutePublishItRaced` pins it deterministically: the existing `observeHubRelayWait` hook holds the listener in exactly that gap while the replacement read publishes its routes. It fails **10/10** without the production change and passes **20/20** with it.

## Sweep

The coordinator widened this to the relay test files. Evidence gathered:

- `app_relay_alias_test.go` / `app_relay_closed_capabilities_test.go` — four tests in window 1, all fixed.
- `app_relay_test.go` — the remap test is window 2, fixed in production. Full `TestHubRelay|TestRelay` surface stressed under load afterwards.
- `relay_session_test.go` (`internal/appsource`) — `TestRelaySession*` clean over 3,600 runs under the same load recipe; #768's fix holds and nothing new surfaced.
- `handle.publicationDone` uses the same swap-channel idiom but captures under the lock that reads `publications`, so it is correct as written. `routeChanged` was the only broken instance.

## Verification

- Reproducing recipe against the fixed tree: all five tests, 7,200 runs each — clean. Was 92 / 106 / 97 / 30.
- Both 20ms probes that failed 20/20 now pass 20/20.
- `TestHubRelayPendingFrameWakesOnARoutePublishItRaced`: 10/10 fail on the old listener, 20/20 pass `-race` on the new one.
- `go test -race ./cmd/evener-hub/` (full package) and `./cmd/evener-hub/internal/appsource/` — clean.
- `gofmt`, `go vet`, `make lint` — clean.
