### PR TITLE
hub: classify Edit's caller-blame refusals as wire errors

### DIFF
--- a/cmd/evener-hub/app_instances.go
+++ b/cmd/evener-hub/app_instances.go
@@ -267,12 +267,11 @@ func (c *hubInstancesController) Create(params appwire.InstanceCreateParams) err
 // merely displayed, which would stop the instance inheriting its provider's
 // key (spec §10, §11.3).
 //
-// Every refusal that blames the fields the caller sent — an unknown name, an
-// invalid vars key, an edit that would leave the instance unable to load —
-// comes back as appwire.InvalidParams, the same convention Create uses
-// (#717/#748). A refusal about the hub's own state (the registry not loaded,
-// a read, write, or restore failure) stays a plain error: that is not the
-// caller's to fix.
+// Refusals follow Create's convention (#717/#748): the ones that blame the
+// fields the caller sent — an unknown name, an invalid vars key, an edit
+// that would leave the instance unable to load — come back as
+// appwire.InvalidParams; the hub's own faults (the registry not loaded, a
+// read, write, or restore failure) stay plain errors.
 func (c *hubInstancesController) Edit(params appwire.InstanceEditParams) error {
 	if err := c.refuseWhenBroken(); err != nil {
 		return err

--- a/cmd/evener-hub/app_instances.go
+++ b/cmd/evener-hub/app_instances.go
@@ -266,6 +266,13 @@ func (c *hubInstancesController) Create(params appwire.InstanceCreateParams) err
 // shadowing entry carrying those fields alone — never a base_url the form
 // merely displayed, which would stop the instance inheriting its provider's
 // key (spec §10, §11.3).
+//
+// Every refusal that blames the fields the caller sent — an unknown name, an
+// invalid vars key, an edit that would leave the instance unable to load —
+// comes back as appwire.InvalidParams, the same convention Create uses
+// (#717/#748). A refusal about the hub's own state (the registry not loaded,
+// a read, write, or restore failure) stays a plain error: that is not the
+// caller's to fix.
 func (c *hubInstancesController) Edit(params appwire.InstanceEditParams) error {
 	if err := c.refuseWhenBroken(); err != nil {
 		return err
@@ -291,7 +298,7 @@ func (c *hubInstancesController) Edit(params appwire.InstanceEditParams) error {
 	p, authored := l.Providers[name]
 	if !authored {
 		if _, ok := c.reg.Get().Instance(name); !ok {
-			return fmt.Errorf("instance %q not found", name)
+			return appwire.InvalidParams(fmt.Sprintf("instance %q not found", name))
 		}
 		p = registry.Provider{ID: name}
 	}

--- a/cmd/evener-hub/app_instances.go
+++ b/cmd/evener-hub/app_instances.go
@@ -272,7 +272,7 @@ func (c *hubInstancesController) Edit(params appwire.InstanceEditParams) error {
 	}
 	name := strings.TrimSpace(params.Name)
 	if err := validVarNames(params.Vars); err != nil {
-		return err
+		return appwire.InvalidParams(err.Error())
 	}
 
 	c.mu.Lock()

--- a/cmd/evener-hub/app_instances_test.go
+++ b/cmd/evener-hub/app_instances_test.go
@@ -495,6 +495,13 @@ func TestInstances_EditRejectsUnknownInstance(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "nowhere") {
 		t.Fatalf("Edit = %v, want an unknown-instance error", err)
 	}
+	// A name that resolves to nothing is the caller's to fix, the same shape
+	// as Create's unknown-base-provider check (#717/#748) — InvalidParams,
+	// not an internal fault.
+	var wire appwire.WireError
+	if !errors.As(err, &wire) || wire.Code != appwire.CodeInvalidParams {
+		t.Fatalf("Edit = %v, want an InvalidParams wire error", err)
+	}
 }
 
 // TestInstances_RemoveRefusesImplicitInstance: an instance that exists from

--- a/cmd/evener-hub/app_instances_test.go
+++ b/cmd/evener-hub/app_instances_test.go
@@ -812,6 +812,13 @@ func TestInstances_RefusesAVarsKeyThePlaceholderGrammarCannotName(t *testing.T) 
 			if !strings.Contains(err.Error(), "invalid variable name") {
 				t.Fatalf("Edit = %v, want the refusal to name the offending key", err)
 			}
+			// validVarNames is the same helper Create uses, and Create's
+			// refusal is InvalidParams (#717/#748); Edit must classify it the
+			// same way so a client can tell its own bad input from a hub fault.
+			var wire appwire.WireError
+			if !errors.As(err, &wire) || wire.Code != appwire.CodeInvalidParams {
+				t.Fatalf("Edit = %v, want an InvalidParams wire error", err)
+			}
 			if got := readConfigProviders(t, f.tomlPath)["ok"].Transport.Vars; len(got) != 0 {
 				t.Fatalf("the refused edit wrote vars %v", got)
 			}


### PR DESCRIPTION
Fixes #749. Edit's shared validVarNames refusal and its unknown-instance refusal both returned raw errors while Create's siblings were already classified (#748); both are now appwire.InvalidParams, with wire-class assertions extended in the existing table tests (red-first, both rounds).

Pipeline provenance: adversarial review REFUTED round 1 (the unknown-instance exit at :294 was still raw — the exact defect class, one exit below the first fix); round 2 closed it and swept every remaining Edit exit, finding the rest are genuine hub-state faults correctly left plain. Simplify pass folded the duplicated wire-classification doc paragraph into a pointer at Create's. Remove and SetDefault carry the identical raw not-found shape — split out as #788 rather than expanded here (the reviewers' own scope ruling).