### PR TITLE
appwire: route connection-lifecycle logging through an injectable sink

### DIFF
--- a/appwire/client.go
+++ b/appwire/client.go
@@ -33,9 +33,7 @@ type Client struct {
 	pendingCoord  PendingCoordinator
 	featuresMu    sync.RWMutex
 	features      FeatureSet
-	// logf receives connection-lifecycle events a peer cannot observe from
-	// its own side of the socket (today: keepalive teardown, see
-	// runClientKeepalive). Nil until SetLogf installs one.
+	// logf sinks connection-lifecycle events; nil discards them. See SetLogf.
 	logf func(format string, args ...any)
 	// closed latches the read loop's exit. failPending only fails the entries
 	// registered at that instant; a request that registers afterwards would
@@ -143,14 +141,14 @@ func (c *Client) SetOrderedFrameHandler(handler func(Message, error)) {
 
 // SetLogf installs a sink for connection-lifecycle events a peer cannot
 // observe from its own side of the socket (today: keepalive teardown, see
-// runClientKeepalive). Nil — the state before SetLogf is called — discards
-// them: this client runs inside interactive TUI sessions where the standard
-// log package's default stderr destination would scroll into bubbletea's
-// live grid in -debug mode (no alternate screen) and corrupt the render
-// permanently (issue #783), so silence is the only default safe everywhere.
-// Callers that want these events (hub, TUI) provide their own sink. Set it
-// before Start: startWithKeepalive reads it once, to hand to the keepalive
-// goroutine.
+// runClientKeepalive). Until it is called the sink is nil and those events
+// are discarded: this client runs inside interactive TUI sessions where the
+// standard log package's default stderr destination would scroll into
+// bubbletea's live grid in -debug mode (no alternate screen) and corrupt the
+// render permanently (issue #783), so silence is the only default safe
+// everywhere. Callers that want these events (hub, TUI) provide their own
+// sink. Set it before Start, which reads the sink once to hand to the
+// keepalive goroutine.
 func (c *Client) SetLogf(logf func(format string, args ...any)) {
 	c.logf = logf
 }

--- a/appwire/client.go
+++ b/appwire/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -34,6 +33,10 @@ type Client struct {
 	pendingCoord  PendingCoordinator
 	featuresMu    sync.RWMutex
 	features      FeatureSet
+	// logf receives connection-lifecycle events a peer cannot observe from
+	// its own side of the socket (today: keepalive teardown, see
+	// runClientKeepalive). Nil until SetLogf installs one.
+	logf func(format string, args ...any)
 	// closed latches the read loop's exit. failPending only fails the entries
 	// registered at that instant; a request that registers afterwards would
 	// otherwise wait forever for a response no goroutine can deliver (a first
@@ -83,7 +86,7 @@ func (c *Client) Start(ctx context.Context) {
 
 func (c *Client) startWithKeepalive(ctx context.Context, pingInterval, pongTimeout time.Duration) {
 	if pinger, ok := c.transport.(Pinger); ok {
-		go runClientKeepalive(ctx, pinger, c.transport.Close, pingInterval, pongTimeout)
+		go runClientKeepalive(ctx, pinger, c.transport.Close, pingInterval, pongTimeout, c.logf)
 	}
 	go func() {
 		for {
@@ -138,6 +141,20 @@ func (c *Client) SetOrderedFrameHandler(handler func(Message, error)) {
 	c.orderedFrames = handler
 }
 
+// SetLogf installs a sink for connection-lifecycle events a peer cannot
+// observe from its own side of the socket (today: keepalive teardown, see
+// runClientKeepalive). Nil — the state before SetLogf is called — discards
+// them: this client runs inside interactive TUI sessions where the standard
+// log package's default stderr destination would scroll into bubbletea's
+// live grid in -debug mode (no alternate screen) and corrupt the render
+// permanently (issue #783), so silence is the only default safe everywhere.
+// Callers that want these events (hub, TUI) provide their own sink. Set it
+// before Start: startWithKeepalive reads it once, to hand to the keepalive
+// goroutine.
+func (c *Client) SetLogf(logf func(format string, args ...any)) {
+	c.logf = logf
+}
+
 type requestIDObserverKey struct{}
 
 // WithRequestIDObserver returns a context that reports the id appwire mints for
@@ -165,8 +182,10 @@ func requestIDObserverFrom(ctx context.Context) func(ID) {
 // with an ordinary transport error, so without the log a pong-timeout
 // teardown under load — e.g. the hub subprocess starved past
 // interval+timeout by concurrent CI gates (#154) — is indistinguishable
-// from a dead hub.
-func runClientKeepalive(ctx context.Context, pinger Pinger, closeFn func() error, interval, timeout time.Duration) {
+// from a dead hub. The line goes through logf (installed via SetLogf, nil
+// discards it) rather than the standard log package, so it can never land on
+// a live TUI session's terminal (issue #783).
+func runClientKeepalive(ctx context.Context, pinger Pinger, closeFn func() error, interval, timeout time.Duration, logf func(format string, args ...any)) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
@@ -178,7 +197,9 @@ func runClientKeepalive(ctx context.Context, pinger Pinger, closeFn func() error
 			err := pinger.Ping(pingCtx)
 			cancel()
 			if err != nil {
-				log.Printf("appwire: keepalive ping failed (ping interval %s, pong timeout %s): %v; closing connection", interval, timeout, err)
+				if logf != nil {
+					logf("appwire: keepalive ping failed (ping interval %s, pong timeout %s): %v; closing connection", interval, timeout, err)
+				}
 				_ = closeFn()
 				return
 			}

--- a/appwire/client_keepalive_log_test.go
+++ b/appwire/client_keepalive_log_test.go
@@ -23,6 +23,35 @@ func (s *silentPingerTransport) Ping(ctx context.Context) error {
 	return ctx.Err()
 }
 
+// runKeepaliveTearDown starts a client whose every ping is guaranteed to miss
+// its pong deadline, waits for the keepalive to tear the connection down, and
+// returns whatever that teardown wrote to the standard log package. A nil
+// logf leaves SetLogf uncalled, so a caller passing nil exercises the
+// untouched default rather than an explicitly installed nil sink.
+func runKeepaliveTearDown(t *testing.T, logf func(format string, args ...any)) *bytes.Buffer {
+	t.Helper()
+	var globalLog bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&globalLog)
+	t.Cleanup(func() { log.SetOutput(prev) })
+
+	client := NewClient(&silentPingerTransport{newPingingTransport()})
+	if logf != nil {
+		client.SetLogf(logf)
+	}
+	client.startWithKeepalive(t.Context(), time.Millisecond, 5*time.Millisecond)
+
+	select {
+	case _, ok := <-client.Notifications():
+		if ok {
+			t.Fatal("expected notifications channel to close, got a value")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("keepalive did not tear down the client")
+	}
+	return &globalLog
+}
+
 // TestClientKeepaliveLogsTearDown pins the #154 diagnostic: when the client
 // keepalive closes the connection it must emit one self-describing log line
 // naming the keepalive and the ping error, delivered through the sink
@@ -36,35 +65,16 @@ func (s *silentPingerTransport) Ping(ctx context.Context) error {
 // alternate screen) renders stderr straight into bubbletea's live grid,
 // corrupting the render permanently — proven in the #779/#782 investigation.
 func TestClientKeepaliveLogsTearDown(t *testing.T) {
-	var globalLog bytes.Buffer
-	prev := log.Writer()
-	log.SetOutput(&globalLog)
-	t.Cleanup(func() { log.SetOutput(prev) })
-
 	var sink bytes.Buffer
-	base := newPingingTransport()
-	transport := &silentPingerTransport{base}
-	client := NewClient(transport)
-	client.SetLogf(func(format string, args ...any) {
+	globalLog := runKeepaliveTearDown(t, func(format string, args ...any) {
 		fmt.Fprintf(&sink, format, args...)
 	})
 
-	ctx := t.Context()
-	client.startWithKeepalive(ctx, time.Millisecond, 5*time.Millisecond)
-
-	select {
-	case _, ok := <-client.Notifications():
-		if ok {
-			t.Fatal("expected notifications channel to close, got a value")
-		}
-	case <-time.After(time.Second):
-		t.Fatal("keepalive did not tear down the client")
-	}
-
-	// The log line is written before closeFn runs, and the teardown observed
-	// above is what closeFn caused, so the line is already in the buffer.
-	if !strings.Contains(sink.String(), "keepalive") || !strings.Contains(sink.String(), "ping") {
-		t.Fatalf("keepalive teardown logged no self-describing line to the injected sink; got:\n%s", sink.String())
+	// The log line is written before closeFn runs, and the teardown the helper
+	// waited for is what closeFn caused, so the line is already in the buffer.
+	logged := sink.String()
+	if !strings.Contains(logged, "keepalive") || !strings.Contains(logged, "ping") {
+		t.Fatalf("keepalive teardown logged no self-describing line to the injected sink; got:\n%s", logged)
 	}
 	if globalLog.Len() != 0 {
 		t.Fatalf("keepalive teardown wrote to the standard log package's writer (would corrupt a live TUI render, issue #783); got:\n%s", globalLog.String())
@@ -77,27 +87,7 @@ func TestClientKeepaliveLogsTearDown(t *testing.T) {
 // default stderr destination is unsafe (issue #783), so silence has to be
 // what a caller gets for free without wiring a sink — see SetLogf.
 func TestClientKeepaliveDefaultLogfDiscards(t *testing.T) {
-	var globalLog bytes.Buffer
-	prev := log.Writer()
-	log.SetOutput(&globalLog)
-	t.Cleanup(func() { log.SetOutput(prev) })
-
-	base := newPingingTransport()
-	transport := &silentPingerTransport{base}
-	client := NewClient(transport)
-
-	ctx := t.Context()
-	client.startWithKeepalive(ctx, time.Millisecond, 5*time.Millisecond)
-
-	select {
-	case _, ok := <-client.Notifications():
-		if ok {
-			t.Fatal("expected notifications channel to close, got a value")
-		}
-	case <-time.After(time.Second):
-		t.Fatal("keepalive did not tear down the client")
-	}
-
+	globalLog := runKeepaliveTearDown(t, nil)
 	if globalLog.Len() != 0 {
 		t.Fatalf("keepalive teardown wrote to the standard log package's writer with no sink configured; got:\n%s", globalLog.String())
 	}

--- a/appwire/client_keepalive_log_test.go
+++ b/appwire/client_keepalive_log_test.go
@@ -3,7 +3,9 @@ package appwire
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log"
+	"strings"
 	"testing"
 	"time"
 )
@@ -23,14 +25,61 @@ func (s *silentPingerTransport) Ping(ctx context.Context) error {
 
 // TestClientKeepaliveLogsTearDown pins the #154 diagnostic: when the client
 // keepalive closes the connection it must emit one self-describing log line
-// naming the keepalive and the ping error. The socket then presents a
-// normal-looking failure ("use of closed network connection" on every later
-// write), so this line is the only artifact that separates a pong-timeout
-// teardown under load from a genuinely dead hub.
+// naming the keepalive and the ping error, delivered through the sink
+// installed by SetLogf. The socket then presents a normal-looking failure
+// ("use of closed network connection" on every later write), so this line is
+// the only artifact that separates a pong-timeout teardown under load from a
+// genuinely dead hub.
+//
+// It also pins #783: the line must never reach the standard log package's
+// writer. That writer defaults to stderr, and a -debug TUI session (no
+// alternate screen) renders stderr straight into bubbletea's live grid,
+// corrupting the render permanently — proven in the #779/#782 investigation.
 func TestClientKeepaliveLogsTearDown(t *testing.T) {
-	var buf bytes.Buffer
+	var globalLog bytes.Buffer
 	prev := log.Writer()
-	log.SetOutput(&buf)
+	log.SetOutput(&globalLog)
+	t.Cleanup(func() { log.SetOutput(prev) })
+
+	var sink bytes.Buffer
+	base := newPingingTransport()
+	transport := &silentPingerTransport{base}
+	client := NewClient(transport)
+	client.SetLogf(func(format string, args ...any) {
+		fmt.Fprintf(&sink, format, args...)
+	})
+
+	ctx := t.Context()
+	client.startWithKeepalive(ctx, time.Millisecond, 5*time.Millisecond)
+
+	select {
+	case _, ok := <-client.Notifications():
+		if ok {
+			t.Fatal("expected notifications channel to close, got a value")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("keepalive did not tear down the client")
+	}
+
+	// The log line is written before closeFn runs, and the teardown observed
+	// above is what closeFn caused, so the line is already in the buffer.
+	if !strings.Contains(sink.String(), "keepalive") || !strings.Contains(sink.String(), "ping") {
+		t.Fatalf("keepalive teardown logged no self-describing line to the injected sink; got:\n%s", sink.String())
+	}
+	if globalLog.Len() != 0 {
+		t.Fatalf("keepalive teardown wrote to the standard log package's writer (would corrupt a live TUI render, issue #783); got:\n%s", globalLog.String())
+	}
+}
+
+// TestClientKeepaliveDefaultLogfDiscards proves a Client with no SetLogf call
+// neither panics nor writes anywhere on keepalive teardown. appwire.Client
+// runs inside interactive TUI sessions where the standard log package's
+// default stderr destination is unsafe (issue #783), so silence has to be
+// what a caller gets for free without wiring a sink — see SetLogf.
+func TestClientKeepaliveDefaultLogfDiscards(t *testing.T) {
+	var globalLog bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&globalLog)
 	t.Cleanup(func() { log.SetOutput(prev) })
 
 	base := newPingingTransport()
@@ -49,9 +98,7 @@ func TestClientKeepaliveLogsTearDown(t *testing.T) {
 		t.Fatal("keepalive did not tear down the client")
 	}
 
-	// The log line is written before closeFn runs, and the teardown observed
-	// above is what closeFn caused, so the line is already in the buffer.
-	if !bytes.Contains(buf.Bytes(), []byte("keepalive")) || !bytes.Contains(buf.Bytes(), []byte("ping")) {
-		t.Fatalf("keepalive teardown logged no self-describing line; got:\n%s", buf.String())
+	if globalLog.Len() != 0 {
+		t.Fatalf("keepalive teardown wrote to the standard log package's writer with no sink configured; got:\n%s", globalLog.String())
 	}
 }

--- a/appwire/registered_coverage_evenerfuzz_test.go
+++ b/appwire/registered_coverage_evenerfuzz_test.go
@@ -127,7 +127,7 @@ func coverFailureBranches(t *testing.T) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	runClientKeepalive(ctx, nil, func() error { return nil }, time.Hour, time.Hour)
+	runClientKeepalive(ctx, nil, func() error { return nil }, time.Hour, time.Hour, nil)
 
 	failedTransport := &sendErrTransport{memoryTransport: newMemoryTransport(), err: errors.New("send")}
 	c := NewClient(failedTransport)

--- a/cmd/evener-hub/internal/appsource/codex_source.go
+++ b/cmd/evener-hub/internal/appsource/codex_source.go
@@ -45,6 +45,16 @@ func defaultAppwireDial(ctx context.Context, endpoint string, client *http.Clien
 	return appwire.DialWebSocketWithHeaders(ctx, endpoint, client, header)
 }
 
+// appsourceConnectionLogf is the appwire.Client connection-lifecycle sink
+// (see appwire.Client.SetLogf) for every source's dialed connections
+// (codex, local daemon). The hub is a plain daemon, never a TUI rendering
+// over an interactive terminal, so its own stderr — labelled like every
+// other hub diagnostic — is a safe destination, unlike the TUI's stderr
+// (issue #783).
+func appsourceConnectionLogf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "[hub] "+format+"\n", args...)
+}
+
 func NewCodexSource(cfg CodexSourceConfig, client *http.Client) *CodexSource {
 	sourceID := cfg.ID
 	if sourceID == "" {
@@ -699,6 +709,7 @@ func (s *CodexSource) connect(ctx context.Context) (*appwire.Client, func() erro
 		return nil, nil, codexSourceDialError(err)
 	}
 	client := appwire.NewClient(transport)
+	client.SetLogf(appsourceConnectionLogf)
 	client.Start(context.WithoutCancel(ctx))
 	var initialized appwire.InitializeResponse
 	if err := client.Request(ctx, appwire.MethodInitialize, struct {

--- a/cmd/evener-hub/internal/appsource/codex_source.go
+++ b/cmd/evener-hub/internal/appsource/codex_source.go
@@ -45,13 +45,12 @@ func defaultAppwireDial(ctx context.Context, endpoint string, client *http.Clien
 	return appwire.DialWebSocketWithHeaders(ctx, endpoint, client, header)
 }
 
-// appsourceConnectionLogf is the appwire.Client connection-lifecycle sink
-// (see appwire.Client.SetLogf) for every source's dialed connections
-// (codex, local daemon). The hub is a plain daemon, never a TUI rendering
-// over an interactive terminal, so its own stderr — labelled like every
-// other hub diagnostic — is a safe destination, unlike the TUI's stderr
-// (issue #783).
-func appsourceConnectionLogf(format string, args ...any) {
+// hubConnectionLogf is the appwire.Client connection-lifecycle sink (see
+// appwire.Client.SetLogf) for every source's dialed connections (codex,
+// local daemon). The hub is a plain daemon, never a TUI rendering over an
+// interactive terminal, so its own stderr — labelled like every other hub
+// diagnostic — is a safe destination, unlike the TUI's stderr (issue #783).
+func hubConnectionLogf(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, "[hub] "+format+"\n", args...)
 }
 
@@ -709,7 +708,7 @@ func (s *CodexSource) connect(ctx context.Context) (*appwire.Client, func() erro
 		return nil, nil, codexSourceDialError(err)
 	}
 	client := appwire.NewClient(transport)
-	client.SetLogf(appsourceConnectionLogf)
+	client.SetLogf(hubConnectionLogf)
 	client.Start(context.WithoutCancel(ctx))
 	var initialized appwire.InitializeResponse
 	if err := client.Request(ctx, appwire.MethodInitialize, struct {

--- a/cmd/evener-hub/internal/appsource/local_daemon.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon.go
@@ -147,6 +147,7 @@ func (s *LocalDaemonSource) AcquireRelaySession(ref appwire.Ref) (RelaySessionRo
 					return nil, nil, localDaemonDialError(dialErr)
 				}
 				client := appwire.NewClient(transport)
+				client.SetLogf(appsourceConnectionLogf)
 				client.SetOrderedFrameHandler(func(message appwire.Message, err error) {
 					observe(epoch, message, err)
 				})
@@ -621,6 +622,7 @@ func (s *LocalDaemonSource) withClientCallMapper(
 	}
 	defer transport.Close() //nolint:errcheck // transport cleanup; error is not actionable
 	client := appwire.NewClient(transport)
+	client.SetLogf(appsourceConnectionLogf)
 	client.Start(ctx)
 	if _, err := client.Initialize(ctx, appwire.InitializeParams{ClientInfo: appwire.ClientInfo{Name: "evener-hub"}}); err != nil {
 		if cerr := ctx.Err(); cerr != nil {

--- a/cmd/evener-hub/internal/appsource/local_daemon.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon.go
@@ -147,7 +147,7 @@ func (s *LocalDaemonSource) AcquireRelaySession(ref appwire.Ref) (RelaySessionRo
 					return nil, nil, localDaemonDialError(dialErr)
 				}
 				client := appwire.NewClient(transport)
-				client.SetLogf(appsourceConnectionLogf)
+				client.SetLogf(hubConnectionLogf)
 				client.SetOrderedFrameHandler(func(message appwire.Message, err error) {
 					observe(epoch, message, err)
 				})
@@ -622,7 +622,7 @@ func (s *LocalDaemonSource) withClientCallMapper(
 	}
 	defer transport.Close() //nolint:errcheck // transport cleanup; error is not actionable
 	client := appwire.NewClient(transport)
-	client.SetLogf(appsourceConnectionLogf)
+	client.SetLogf(hubConnectionLogf)
 	client.Start(ctx)
 	if _, err := client.Initialize(ctx, appwire.InitializeParams{ClientInfo: appwire.ClientInfo{Name: "evener-hub"}}); err != nil {
 		if cerr := ctx.Err(); cerr != nil {

--- a/cmd/evener-hub/internal/hubcore/prober.go
+++ b/cmd/evener-hub/internal/hubcore/prober.go
@@ -2,7 +2,9 @@ package hubcore
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -16,6 +18,15 @@ import (
 type StatusProber struct {
 	Timeout time.Duration
 	client  *http.Client
+}
+
+// hubConnectionLogf is the appwire.Client connection-lifecycle sink (see
+// appwire.Client.SetLogf) for probe connections: the hub is a plain daemon,
+// never a TUI rendering over an interactive terminal, so its own stderr —
+// labelled like every other hub diagnostic (past.go, roster.go) — is a safe
+// destination, unlike the TUI's stderr (issue #783).
+func hubConnectionLogf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "[hub] "+format+"\n", args...)
 }
 
 // Probe implements Prober.
@@ -38,6 +49,7 @@ func (p *StatusProber) Probe(entry rendezvous.Entry) ProbeResult {
 	}
 	defer transport.Close() //nolint:errcheck // probe cleanup; error is not actionable
 	appClient := appwire.NewClient(transport)
+	appClient.SetLogf(hubConnectionLogf)
 	appClient.Start(ctx)
 	if _, err := appClient.Initialize(ctx, appwire.InitializeParams{ClientInfo: appwire.ClientInfo{Name: "evener-hub"}}); err != nil {
 		return ProbeResult{}

--- a/cmd/evener-tui/internal/hubstart/hub_start.go
+++ b/cmd/evener-tui/internal/hubstart/hub_start.go
@@ -305,7 +305,7 @@ func StartHubClient(ctx context.Context, cfg HubStartConfig) (HubRuntime, error)
 	}
 	if cfg.DialHub == nil {
 		cfg.DialHub = func(ctx context.Context, addr HubAddress, httpClient *http.Client) (*appwire.Client, error) {
-			return dialHubRPC(ctx, addr, httpClient, cfg.ObserveFrames)
+			return dialHubRPC(ctx, addr, httpClient, cfg.ObserveFrames, connectionLogf(cfg.LogFile))
 		}
 	}
 	if cfg.CheckHubEnvironment == nil {
@@ -400,12 +400,13 @@ func waitForHubHealth(ctx context.Context, addr HubAddress, httpClient *http.Cli
 	}
 }
 
-func dialHubRPC(ctx context.Context, addr HubAddress, httpClient *http.Client, observeFrames func(appwire.Message, error)) (*appwire.Client, error) {
+func dialHubRPC(ctx context.Context, addr HubAddress, httpClient *http.Client, observeFrames func(appwire.Message, error), logf func(format string, args ...any)) (*appwire.Client, error) {
 	transport, err := appwire.DialWebSocket(ctx, hubRPCURL(addr), httpClient)
 	if err != nil {
 		return nil, err
 	}
 	client := appwire.NewClient(transport)
+	client.SetLogf(logf)
 	if observeFrames != nil {
 		client.SetOrderedFrameHandler(observeFrames)
 	}
@@ -586,8 +587,37 @@ func StartupErrorScreen(err error) string {
 }
 
 func WriteStartupDiagnostic(logFile string, err error) {
+	if err == nil {
+		return
+	}
+	kind := StartupErrorKind("unknown")
+	if startupErr, ok := errors.AsType[StartupError](err); ok {
+		kind = startupErr.Kind
+	}
+	appendDiagnosticLine(logFile, fmt.Sprintf("evener-tui startup failed kind=%s error=%s", kind, err))
+}
+
+// connectionLogf returns an appwire.Client connection-lifecycle sink (see
+// appwire.Client.SetLogf) that appends to the same file WriteStartupDiagnostic
+// uses, instead of the process's own stderr. A -debug TUI session runs
+// without bubbletea's alternate screen, so a line on stderr scrolls the live
+// render and corrupts it permanently (issue #783); an empty logFile (no
+// --log-file/EVENER_TUI_LOG_FILE configured) discards silently, same as
+// WriteStartupDiagnostic.
+func connectionLogf(logFile string) func(format string, args ...any) {
+	return func(format string, args ...any) {
+		appendDiagnosticLine(logFile, fmt.Sprintf(format, args...))
+	}
+}
+
+// appendDiagnosticLine appends one line (a trailing newline is added) to
+// logFile, creating its parent directory and the file itself as needed.
+// Best-effort: an empty logFile or any failure to create the directory or
+// open/write the file is silently swallowed — every caller uses this for
+// optional diagnostics with no actionable response to a write failure.
+func appendDiagnosticLine(logFile, line string) {
 	logFile = strings.TrimSpace(logFile)
-	if logFile == "" || err == nil {
+	if logFile == "" {
 		return
 	}
 	if mkErr := os.MkdirAll(filepath.Dir(logFile), 0o755); mkErr != nil {
@@ -598,10 +628,5 @@ func WriteStartupDiagnostic(logFile string, err error) {
 		return
 	}
 	defer func() { _ = f.Close() }()
-	kind := StartupErrorKind("unknown")
-	if startupErr, ok := errors.AsType[StartupError](err); ok {
-		kind = startupErr.Kind
-	}
-	// Best-effort diagnostic; a write failure here is unactionable.
-	_, _ = fmt.Fprintf(f, "evener-tui startup failed kind=%s error=%s\n", kind, err)
+	_, _ = fmt.Fprintln(f, line)
 }

--- a/cmd/evener-tui/internal/hubstart/hub_start_covtest_test.go
+++ b/cmd/evener-tui/internal/hubstart/hub_start_covtest_test.go
@@ -43,7 +43,7 @@ func TestCovDialHubRPCWithFrameHandler(t *testing.T) {
 		observed <- observedFrame{msg: msg, err: err}
 	}
 
-	client, err := dialHubRPC(context.Background(), addr, srv.Client(), handler)
+	client, err := dialHubRPC(context.Background(), addr, srv.Client(), handler, nil)
 	if err != nil {
 		t.Fatalf("dialHubRPC: %v", err)
 	}

--- a/cmd/evener-tui/internal/hubstart/hub_start_fuzz_test.go
+++ b/cmd/evener-tui/internal/hubstart/hub_start_fuzz_test.go
@@ -206,7 +206,7 @@ func fuzzStartHubEdges(t *testing.T) {
 
 func fuzzTransportEdges(t *testing.T) {
 	t.Helper()
-	_, _ = dialHubRPC(context.Background(), HubAddress{BaseURL: "http://127.0.0.1:0"}, &http.Client{}, nil)
+	_, _ = dialHubRPC(context.Background(), HubAddress{BaseURL: "http://127.0.0.1:0"}, &http.Client{}, nil, nil)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := websocket.Accept(w, r, nil)
 		if err != nil {
@@ -215,7 +215,7 @@ func fuzzTransportEdges(t *testing.T) {
 		_, _, _ = conn.Read(r.Context())
 		_ = conn.Close(websocket.StatusInternalError, "stop")
 	}))
-	_, _ = dialHubRPC(context.Background(), HubAddress{BaseURL: srv.URL}, srv.Client(), nil)
+	_, _ = dialHubRPC(context.Background(), HubAddress{BaseURL: srv.URL}, srv.Client(), nil, nil)
 	srv.Close()
 
 	canceled, cancel := context.WithCancel(context.Background())
@@ -266,7 +266,7 @@ func fuzzDialHubRPC(t *testing.T, protocol string) {
 	srv := fakeHubServer(t, protocol)
 	defer srv.Close()
 	addr := HubAddress{BaseURL: srv.URL}
-	client, err := dialHubRPC(context.Background(), addr, srv.Client(), nil)
+	client, err := dialHubRPC(context.Background(), addr, srv.Client(), nil, nil)
 	// v2 requires an exact protocol match (appwire.Client.Initialize), so every
 	// other value — including an absent one, which is what an old hub sends —
 	// must be refused rather than treated as "unknown, probably fine".

--- a/cmd/evener-tui/internal/hubstart/hub_start_test.go
+++ b/cmd/evener-tui/internal/hubstart/hub_start_test.go
@@ -434,9 +434,10 @@ func TestConnectionLogfAppendsToLogFile(t *testing.T) {
 }
 
 // TestConnectionLogfDiscardsWithoutLogFile proves the sink is a safe no-op
-// when no --log-file/EVENER_TUI_LOG_FILE was configured, matching
-// WriteStartupDiagnostic's own behavior — nothing is created on disk and
-// nothing panics.
+// when no --log-file/EVENER_TUI_LOG_FILE was configured: with no path to
+// append to there is nothing to create, and the call must return without
+// panicking rather than falling back to stderr, matching
+// WriteStartupDiagnostic's own behavior.
 func TestConnectionLogfDiscardsWithoutLogFile(t *testing.T) {
 	logf := connectionLogf("")
 	logf("appwire: keepalive ping failed: %v", errors.New("boom"))

--- a/cmd/evener-tui/internal/hubstart/hub_start_test.go
+++ b/cmd/evener-tui/internal/hubstart/hub_start_test.go
@@ -347,7 +347,7 @@ func TestDialHubRPCReportsIncompatibleAPIForMismatchedProtocol(t *testing.T) {
 	defer srv.Close()
 	addr := HubAddress{BaseURL: srv.URL}
 
-	_, err := dialHubRPC(context.Background(), addr, srv.Client(), nil)
+	_, err := dialHubRPC(context.Background(), addr, srv.Client(), nil, nil)
 	if err == nil {
 		t.Fatal("dialHubRPC accepted a mismatched protocol version")
 	}
@@ -412,6 +412,34 @@ func TestStartHubClientWritesStartupDiagnosticsToLogFile(t *testing.T) {
 	if got := string(data); !strings.Contains(got, "startup failed") || !strings.Contains(got, "remote-no-autostart") {
 		t.Fatalf("log=%q, want startup diagnostic", got)
 	}
+}
+
+// TestConnectionLogfAppendsToLogFile pins the appwire.Client connection-
+// lifecycle sink (issue #783): dialHubRPC wires it to connectionLogf, which
+// must land formatted lines in the TUI's own diagnostics file rather than
+// the process's stderr — a -debug TUI session has no alternate screen to
+// protect a live bubbletea render from a stray stderr write.
+func TestConnectionLogfAppendsToLogFile(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "conn.log")
+	logf := connectionLogf(logFile)
+	logf("appwire: keepalive ping failed (%s): %v; closing connection", "5s", errors.New("boom"))
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if got := string(data); !strings.Contains(got, "keepalive ping failed (5s): boom; closing connection") {
+		t.Fatalf("log=%q, want formatted keepalive line", got)
+	}
+}
+
+// TestConnectionLogfDiscardsWithoutLogFile proves the sink is a safe no-op
+// when no --log-file/EVENER_TUI_LOG_FILE was configured, matching
+// WriteStartupDiagnostic's own behavior — nothing is created on disk and
+// nothing panics.
+func TestConnectionLogfDiscardsWithoutLogFile(t *testing.T) {
+	logf := connectionLogf("")
+	logf("appwire: keepalive ping failed: %v", errors.New("boom"))
 }
 
 func TestStartLocalHubReportsImmediateExitOutput(t *testing.T) {


### PR DESCRIPTION
Fixes #783. appwire's keepalive/teardown logging went through the std log package to stderr, which in a -debug TUI session (no alternate screen) scrolls the live tmux grid and permanently corrupts bubbletea's diff render — the mechanism that made #779's transient eviction into a 60s torn pane. Client.SetLogf now follows appserver.ServerConfig.Logf's convention (nil = silent); the hub wires its [hub]-prefixed stderr closures, the TUI wires its --log-file/EVENER_TUI_LOG_FILE diagnostics sink.

**Deliberate trade-off for the merge decision** (named by the adversarial regression review): TUI keepalive diagnostics are now silent by default unless --log-file/EVENER_TUI_LOG_FILE is set — exactly what #783 asked for, at a real forensic-signal cost in plain sessions.

Pipeline provenance: TDD (stderr-capture red first); adversarial pair SURVIVES ×2 (full sweep of appwire + spawn stderr routing + every TUI construction site; race audit clean); simplify pass deduplicated the branch's test scaffolding (mutation-tested to prove the nil-sink guarantee held), renamed the stuttering helper, and declined cross-package consolidation with import-graph reasoning (the [hub]-stderr one-liner is an established 35-site inline convention). SetLogf-before-Start remains convention-enforced, documented like its SetOrderedFrameHandler sibling.