### PR TITLE
test: guard every runtime-pair fixture write against ETXTBSY

### DIFF
--- a/runtime_pair_build_test.go
+++ b/runtime_pair_build_test.go
@@ -1090,9 +1090,11 @@ func mutateWebWaitDeferral(t *testing.T, fixture runtimeBuildFixture) {
 		t.Fatal("test-web wait mutation target changed; update the mechanism RED test")
 	}
 	data = bytes.Replace(data, []byte(old), []byte(deferredWaitBlock), 1)
-	if err := os.WriteFile(path, data, 0o755); err != nil {
-		t.Fatalf("write test-web mutation: %v", err)
-	}
+	// writeExecutable (install_test.go) holds syscall.ForkLock across the
+	// write so a sibling parallel test's fork can't inherit this open write
+	// fd and fail its exec with ETXTBSY (golang/go#22315) — this script is
+	// what make test-web execs next. Same hazard class as #270.
+	writeExecutable(t, path, string(data))
 }
 
 func TestMakeTestWebInterruptDuringExitCleanupPreservesStatus(t *testing.T) {

--- a/runtime_pair_build_test.go
+++ b/runtime_pair_build_test.go
@@ -1091,9 +1091,15 @@ func mutateWebWaitDeferral(t *testing.T, fixture runtimeBuildFixture) {
 	}
 	data = bytes.Replace(data, []byte(old), []byte(deferredWaitBlock), 1)
 	// writeExecutable (install_test.go) holds syscall.ForkLock across the
-	// write so a sibling parallel test's fork can't inherit this open write
-	// fd and fail its exec with ETXTBSY (golang/go#22315) — this script is
-	// what make test-web execs next. Same hazard class as #270.
+	// write so a concurrent fork can't inherit this open write fd and fail
+	// its exec with ETXTBSY (golang/go#22315) — this script is what make
+	// test-web execs next, same hazard class as #270. None of this
+	// function's callers (runWebWaitHandoff's TestMakeTestWeb* invocations)
+	// call t.Parallel, and Go never runs a non-parallel test's body
+	// concurrently with anything else in the package, so no sibling test
+	// actually races this write today. The guard is defensive consistency
+	// with the canonical helper, not evidence of a live race at this
+	// specific call site.
 	writeExecutable(t, path, string(data))
 }
 
@@ -1717,6 +1723,20 @@ func writeTestFile(t *testing.T, path string, data []byte, mode os.FileMode) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
 	}
+	// This is the file's one write chokepoint: copyRepositoryFile and every
+	// other caller route through it, including the scripts/*.sh fixture
+	// copies and the go/npm/node/git toolchain shims that make test-web and
+	// make build genuinely exec by relative path (issue #609). A raw write
+	// leaves an open write fd a concurrent fork could inherit, failing its
+	// exec with ETXTBSY (golang/go#22315). No test in this file currently
+	// calls t.Parallel on anything that reaches this helper, so nothing
+	// races these writes today, but the guard costs nothing and forecloses
+	// the hazard by construction rather than by today's test ordering —
+	// every write here takes it, rather than special-casing by mode.
+	// Mirrors writeExecutable's discipline (install_test.go) for its own
+	// callers.
+	syscall.ForkLock.RLock()
+	defer syscall.ForkLock.RUnlock()
 	if err := os.WriteFile(path, data, mode); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}

--- a/runtime_pair_build_test.go
+++ b/runtime_pair_build_test.go
@@ -1090,17 +1090,7 @@ func mutateWebWaitDeferral(t *testing.T, fixture runtimeBuildFixture) {
 		t.Fatal("test-web wait mutation target changed; update the mechanism RED test")
 	}
 	data = bytes.Replace(data, []byte(old), []byte(deferredWaitBlock), 1)
-	// writeExecutable (install_test.go) holds syscall.ForkLock across the
-	// write so a concurrent fork can't inherit this open write fd and fail
-	// its exec with ETXTBSY (golang/go#22315) — this script is what make
-	// test-web execs next, same hazard class as #270. None of this
-	// function's callers (runWebWaitHandoff's TestMakeTestWeb* invocations)
-	// call t.Parallel, and Go never runs a non-parallel test's body
-	// concurrently with anything else in the package, so no sibling test
-	// actually races this write today. The guard is defensive consistency
-	// with the canonical helper, not evidence of a live race at this
-	// specific call site.
-	writeExecutable(t, path, string(data))
+	writeTestFile(t, path, data, 0o755)
 }
 
 func TestMakeTestWebInterruptDuringExitCleanupPreservesStatus(t *testing.T) {
@@ -1723,18 +1713,15 @@ func writeTestFile(t *testing.T, path string, data []byte, mode os.FileMode) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
 	}
-	// This is the file's one write chokepoint: copyRepositoryFile and every
-	// other caller route through it, including the scripts/*.sh fixture
-	// copies and the go/npm/node/git toolchain shims that make test-web and
-	// make build genuinely exec by relative path (issue #609). A raw write
-	// leaves an open write fd a concurrent fork could inherit, failing its
-	// exec with ETXTBSY (golang/go#22315). No test in this file currently
-	// calls t.Parallel on anything that reaches this helper, so nothing
-	// races these writes today, but the guard costs nothing and forecloses
-	// the hazard by construction rather than by today's test ordering —
-	// every write here takes it, rather than special-casing by mode.
-	// Mirrors writeExecutable's discipline (install_test.go) for its own
-	// callers.
+	// Every fixture write lands here, including the scripts/*.sh copies and
+	// the go/npm/node/git toolchain shims that make test-web and make build
+	// exec by relative path (issue #609). os.WriteFile leaves an open write
+	// fd that a concurrent fork inherits until it execs, failing that exec
+	// with ETXTBSY (golang/go#22315); holding ForkLock for reading across
+	// the write excludes such a fork, as writeExecutable (install_test.go)
+	// does for its own callers. Nothing reaching this helper runs parallel
+	// today, so taking the lock on every write forecloses the hazard by
+	// construction instead of leaning on test ordering.
 	syscall.ForkLock.RLock()
 	defer syscall.ForkLock.RUnlock()
 	if err := os.WriteFile(path, data, mode); err != nil {


### PR DESCRIPTION
Fixes #609. The ForkLock guard now lives in writeTestFile — the chokepoint every fixture write in runtime_pair_build_test.go routes through (script copies, the go/npm/node/git toolchain shims that make test-web and make build exec, and the mutation write the issue named).

Pipeline provenance: adversarial review REFUTED round 1 (guarding one call site left 8 identically-hazardous siblings, including the same file's first write; and the rationale comment named an unreachable mechanism); round 2 moved the guard to the chokepoint and — rather than softening the comment — traced every goroutine and the test scheduler's guarantees to establish no in-process concurrent forker exists today, so the comments now state the guard is defensive consistency by construction, not evidence of a live race. Simplify pass rerouted the original call site through the file's own guarded helper (deleting a cross-file exception and its justification comment) and corrected the chokepoint comment's overclaim (two non-executable marker writes still bypass it, deliberately). No red test: a dynamic ETXTBSY repro is timing-infeasible; the in-repo static-audit convention (open PR #606) is the right future home.