### PR TITLE
gate: guard vitest report parsing in test-timing-budget

### DIFF
--- a/scripts/gate/test-timing-budget.sh
+++ b/scripts/gate/test-timing-budget.sh
@@ -214,7 +214,10 @@ else
 				:
 			fi
 			if [ -f "$report" ]; then
-				vitest_json_to_tsv "$report" >>"$measured"
+				if ! vitest_json_to_tsv "$report" >>"$measured"; then
+					echo "test-timing-budget: failed to parse vitest report at $report" >&2
+					go_measure_failed=1
+				fi
 			else
 				echo "test-timing-budget: no vitest report at $report (see $work/vitest.log)" >&2
 				go_measure_failed=1

--- a/scripts/gate/test-timing-budget.sh
+++ b/scripts/gate/test-timing-budget.sh
@@ -214,7 +214,19 @@ else
 				:
 			fi
 			if [ -f "$report" ]; then
-				if ! vitest_json_to_tsv "$report" >>"$measured"; then
+				# Parse into a scratch-private file first and merge only on
+				# success: appending vitest_json_to_tsv straight to $measured
+				# would let a mid-loop crash (issue #598 F3 -- valid top-level
+				# JSON, then a malformed entry after at least one TEST row was
+				# already printed) leave orphaned TEST rows with no SUM row in
+				# the retained-on-failure scratch (below, once go_measure_failed
+				# is nonzero), which would look like a clean, silently-incomplete
+				# "web" measurement to a later --measured replay instead of the
+				# incomplete run it is.
+				web_rows="$work/vitest-rows.tsv"
+				if vitest_json_to_tsv "$report" >"$web_rows"; then
+					cat "$web_rows" >>"$measured"
+				else
 					echo "test-timing-budget: failed to parse vitest report at $report" >&2
 					go_measure_failed=1
 				fi


### PR DESCRIPTION
Fixes #598. test-timing-budget's vitest_json_to_tsv pipeline could swallow a mid-parse vitest crash: the TSV conversion's exit status went unchecked, and partially-written rows could leak into the retained $measured scratch as if they were real measurements. Two script-only fixes: (1) guard the vitest_json_to_tsv call and fail the gate loudly on parse failure; (2) buffer vitest rows to a scratch-private file merged into $measured only on success, so a crash can't leave half-parsed rows behind.

Per Jesse's directive, this PR contains ONLY the production-script fixes — the stub-vitest selftest an earlier revision added is gone (and the selftest infrastructure generally is being removed in a separate PR). scripts/gate/test-timing-budget-selftest.sh, make/testing.mk, and docs/developing-evener/testing.md are byte-identical to main on this branch.