### PR TITLE
repair: render enum values type-faithfully in constraint messages

### DIFF
--- a/agent/internal/tool/repair/explain.go
+++ b/agent/internal/tool/repair/explain.go
@@ -979,6 +979,15 @@ func examplePlaceholder(typ string) string {
 	}
 }
 
+// asStringSlice renders v — a schema's "required" list or "enum" list, in
+// either the []string a hand-built schema may carry or the []any a
+// JSON-decoded one unmarshals to — as a []string. Non-string elements are
+// formatted with fmt.Sprint (the value-rendering convention constraintMessage
+// already uses for a wrong-type instance value) rather than dropped: a
+// required list's entries are always already strings (JSON-Schema property
+// names), so this only changes output for an enum's non-string values — an
+// integer or boolean enum's allowed values must still render into the
+// constraint message instead of silently disappearing (issue #625).
 func asStringSlice(v any) []string {
 	switch s := v.(type) {
 	case []string:
@@ -986,9 +995,7 @@ func asStringSlice(v any) []string {
 	case []any:
 		out := make([]string, 0, len(s))
 		for _, e := range s {
-			if str, ok := e.(string); ok {
-				out = append(out, str)
-			}
+			out = append(out, fmt.Sprint(e))
 		}
 		return out
 	}

--- a/agent/internal/tool/repair/explain.go
+++ b/agent/internal/tool/repair/explain.go
@@ -496,7 +496,7 @@ func constraintMessage(toolName string, containerSchema map[string]any, displayP
 		arr, _ := value.([]any)
 		return fmt.Sprintf("%s: argument %q is below minItems (%d). Value has %d items.", toolName, displayPath, limit, len(arr))
 	case "enum":
-		allowed := asStringSlice(fieldSchema["enum"])
+		allowed := formatEnumValues(fieldSchema["enum"])
 		if len(allowed) == 0 {
 			return ""
 		}
@@ -794,8 +794,8 @@ func branchRequirement(branch any) string {
 	props := schemaProps(schema)
 	for _, name := range req {
 		prop := schemaMap(props, name)
-		if allowed := asStringSlice(prop["enum"]); len(allowed) > 0 {
-			parts = append(parts, fmt.Sprintf("%q must be one of %s", name, joinQuoted(allowed)))
+		if allowed := formatEnumValues(prop["enum"]); len(allowed) > 0 {
+			parts = append(parts, fmt.Sprintf("%q must be one of %s", name, strings.Join(allowed, ", ")))
 		}
 	}
 	return strings.Join(parts, ", ")
@@ -979,15 +979,18 @@ func examplePlaceholder(typ string) string {
 	}
 }
 
-// asStringSlice renders v — a schema's "required" list or "enum" list, in
-// either the []string a hand-built schema may carry or the []any a
-// JSON-decoded one unmarshals to — as a []string. Non-string elements are
-// formatted with fmt.Sprint (the value-rendering convention constraintMessage
-// already uses for a wrong-type instance value) rather than dropped: a
-// required list's entries are always already strings (JSON-Schema property
-// names), so this only changes output for an enum's non-string values — an
-// integer or boolean enum's allowed values must still render into the
-// constraint message instead of silently disappearing (issue #625).
+// asStringSlice renders v — a schema's "required" list — as a []string,
+// dropping any non-string element. Handles both the []string a hand-built
+// schema may carry and the []any a JSON-decoded one unmarshals to. Callers
+// render an "enum" list instead through formatEnumValues, never this: a
+// required list's entries are always already strings (JSON-Schema requires
+// it, and a schema violating that fails compilation before
+// ExplainSchemaError can ever run — issue #625's adversarial review, F4),
+// so dropping a non-string here is unreachable in practice, not a lossy
+// shortcut. Silently underreporting an impossible entry is preferable to
+// rendering it: this list's callers use its entries as bare property names,
+// and a formatted non-string among them (e.g. a stray "3") would read as a
+// property name that doesn't exist.
 func asStringSlice(v any) []string {
 	switch s := v.(type) {
 	case []string:
@@ -995,9 +998,67 @@ func asStringSlice(v any) []string {
 	case []any:
 		out := make([]string, 0, len(s))
 		for _, e := range s {
-			out = append(out, fmt.Sprint(e))
+			if str, ok := e.(string); ok {
+				out = append(out, str)
+			}
 		}
 		return out
 	}
 	return nil
+}
+
+// formatEnumValues renders a schema's "enum" list as JSON literals, one
+// string per value, ready to join with ", " into a message a model will
+// read as JSON syntax: a string value quoted ("open"), any other JSON type
+// (number, boolean, null, or a nested array/object) rendered as its own
+// JSON literal (1, true, null, [1,2]) — never Go's %v syntax. Handles both
+// the []string a hand-built schema may carry and the []any a JSON-decoded
+// one unmarshals to; unlike asStringSlice, every element here is
+// individually re-encoded, because a bare Go string isn't yet the
+// JSON-quoted form the message needs.
+//
+// This is the shared renderer for both of the enum-message call sites
+// (constraintMessage and branchRequirement) — issue #625's adversarial
+// review, F1: the two sites previously disagreed (one quoted every value,
+// the other quoted none), and quoting a non-string value either way
+// visually asserts the wrong JSON type, coaching the model to retry with a
+// value that fails validation again the same way. Routing both sites
+// through one function is what keeps them from re-diverging.
+func formatEnumValues(v any) []string {
+	switch s := v.(type) {
+	case []string:
+		out := make([]string, len(s))
+		for i, e := range s {
+			out[i] = formatEnumValue(e)
+		}
+		return out
+	case []any:
+		out := make([]string, len(s))
+		for i, e := range s {
+			out[i] = formatEnumValue(e)
+		}
+		return out
+	}
+	return nil
+}
+
+// formatEnumValue renders one enum value as its own JSON literal via
+// json.Marshal — the single source of truth for "what does this value look
+// like in JSON," rather than hand-rolled quoting rules. Every value reaching
+// here came from a compiled JSON-Schema's enum list (json.Unmarshal output,
+// or an equivalent Go literal built by this codebase's own schema
+// constructors), all of which are directly JSON-marshalable, so Marshal
+// cannot fail in practice; the fmt.Sprint fallback only guards that.
+//
+// A number outside roughly the 1e-6..1e21 magnitude range still renders in
+// scientific notation (json.Marshal's own choice, e.g. 1e21 -> "1e+21") —
+// valid JSON, so left as-is rather than special-cased: matching
+// json.Marshal's formatting is the JSON-faithful contract this function
+// exists to keep, not a promise of decimal notation at every magnitude.
+func formatEnumValue(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprint(v)
+	}
+	return string(b)
 }

--- a/agent/internal/tool/repair/explain.go
+++ b/agent/internal/tool/repair/explain.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"slices"
 	"sort"
 	"strconv"
@@ -1008,25 +1009,22 @@ func asStringSlice(v any) []string {
 // (1, true, null, [1,2]). Quoting a non-string would visually assert the
 // wrong JSON type and coach a retry that fails validation the same way, so
 // both enum call sites (constraintMessage and branchRequirement) render
-// through here rather than quoting on their own. Handles both the []string
-// a hand-built schema may carry and the []any a JSON-decoded one
-// unmarshals to.
+// through here rather than quoting on their own. v can carry the list as
+// any slice or array type — []any (a JSON-decoded schema), []string (many
+// hand-built ones), or a genuinely typed slice like []int or []bool, which
+// schema compilation accepts and preserves through cloning just the same —
+// so this walks by reflection rather than naming each shape. A non-slice,
+// non-array v, including nil, returns nil.
 func formatEnumValues(v any) []string {
-	switch s := v.(type) {
-	case []string:
-		out := make([]string, len(s))
-		for i, e := range s {
-			out[i] = formatEnumValue(e)
-		}
-		return out
-	case []any:
-		out := make([]string, len(s))
-		for i, e := range s {
-			out[i] = formatEnumValue(e)
-		}
-		return out
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
+		return nil
 	}
-	return nil
+	out := make([]string, rv.Len())
+	for i := range out {
+		out[i] = formatEnumValue(rv.Index(i).Interface())
+	}
+	return out
 }
 
 // formatEnumValue renders one enum value as its own JSON literal, making

--- a/agent/internal/tool/repair/explain.go
+++ b/agent/internal/tool/repair/explain.go
@@ -979,18 +979,13 @@ func examplePlaceholder(typ string) string {
 	}
 }
 
-// asStringSlice renders v — a schema's "required" list — as a []string,
-// dropping any non-string element. Handles both the []string a hand-built
-// schema may carry and the []any a JSON-decoded one unmarshals to. Callers
-// render an "enum" list instead through formatEnumValues, never this: a
-// required list's entries are always already strings (JSON-Schema requires
-// it, and a schema violating that fails compilation before
-// ExplainSchemaError can ever run — issue #625's adversarial review, F4),
-// so dropping a non-string here is unreachable in practice, not a lossy
-// shortcut. Silently underreporting an impossible entry is preferable to
-// rendering it: this list's callers use its entries as bare property names,
-// and a formatted non-string among them (e.g. a stray "3") would read as a
-// property name that doesn't exist.
+// asStringSlice renders a schema's "required" list as a []string, handling
+// both the []string a hand-built schema may carry and the []any a
+// JSON-decoded one unmarshals to. Non-string elements are dropped: a
+// required list's entries are property names, always strings, and a schema
+// violating that fails compilation before ExplainSchemaError can run. An
+// "enum" list renders through formatEnumValues instead, which must keep
+// values of every JSON type.
 func asStringSlice(v any) []string {
 	switch s := v.(type) {
 	case []string:
@@ -1008,22 +1003,14 @@ func asStringSlice(v any) []string {
 }
 
 // formatEnumValues renders a schema's "enum" list as JSON literals, one
-// string per value, ready to join with ", " into a message a model will
-// read as JSON syntax: a string value quoted ("open"), any other JSON type
-// (number, boolean, null, or a nested array/object) rendered as its own
-// JSON literal (1, true, null, [1,2]) — never Go's %v syntax. Handles both
-// the []string a hand-built schema may carry and the []any a JSON-decoded
-// one unmarshals to; unlike asStringSlice, every element here is
-// individually re-encoded, because a bare Go string isn't yet the
-// JSON-quoted form the message needs.
-//
-// This is the shared renderer for both of the enum-message call sites
-// (constraintMessage and branchRequirement) — issue #625's adversarial
-// review, F1: the two sites previously disagreed (one quoted every value,
-// the other quoted none), and quoting a non-string value either way
-// visually asserts the wrong JSON type, coaching the model to retry with a
-// value that fails validation again the same way. Routing both sites
-// through one function is what keeps them from re-diverging.
+// string per value, ready to join with ", " into a message a model reads as
+// JSON syntax: a string quoted ("open"), any other type as its own literal
+// (1, true, null, [1,2]). Quoting a non-string would visually assert the
+// wrong JSON type and coach a retry that fails validation the same way, so
+// both enum call sites (constraintMessage and branchRequirement) render
+// through here rather than quoting on their own. Handles both the []string
+// a hand-built schema may carry and the []any a JSON-decoded one
+// unmarshals to.
 func formatEnumValues(v any) []string {
 	switch s := v.(type) {
 	case []string:
@@ -1042,19 +1029,13 @@ func formatEnumValues(v any) []string {
 	return nil
 }
 
-// formatEnumValue renders one enum value as its own JSON literal via
-// json.Marshal — the single source of truth for "what does this value look
-// like in JSON," rather than hand-rolled quoting rules. Every value reaching
-// here came from a compiled JSON-Schema's enum list (json.Unmarshal output,
-// or an equivalent Go literal built by this codebase's own schema
-// constructors), all of which are directly JSON-marshalable, so Marshal
-// cannot fail in practice; the fmt.Sprint fallback only guards that.
-//
-// A number outside roughly the 1e-6..1e21 magnitude range still renders in
-// scientific notation (json.Marshal's own choice, e.g. 1e21 -> "1e+21") —
-// valid JSON, so left as-is rather than special-cased: matching
-// json.Marshal's formatting is the JSON-faithful contract this function
-// exists to keep, not a promise of decimal notation at every magnitude.
+// formatEnumValue renders one enum value as its own JSON literal, making
+// json.Marshal the single rule for what a value looks like in JSON —
+// including its number formatting, which turns to scientific notation
+// outside roughly the 1e-6..1e21 magnitude range (1e21 -> "1e+21"). Every
+// value here comes from a compiled schema's enum list and is JSON
+// marshalable, so the fmt.Sprint fallback only guards an error that cannot
+// happen in practice.
 func formatEnumValue(v any) string {
 	b, err := json.Marshal(v)
 	if err != nil {

--- a/agent/internal/tool/repair/explain_action_branch_test.go
+++ b/agent/internal/tool/repair/explain_action_branch_test.go
@@ -169,7 +169,7 @@ func TestExplainSchemaError_ConstraintKeywordInWrongBranchGolden(t *testing.T) {
 		}},
 	}
 	got := ExplainSchemaError("task_list", taskListParams(), args, "tasks/0/type", "enum")
-	want := "task_list: argument \"tasks[0].type\" is not one of the allowed values: research, implement, verify, fix. Value is \"bogus\". " +
+	want := "task_list: argument \"tasks[0].type\" is not one of the allowed values: \"research\", \"implement\", \"verify\", \"fix\". Value is \"bogus\". " +
 		"(this failure is in the array for action \"append\"; your action \"update\" takes \"updates\", not tasks)"
 	if got != want {
 		t.Fatalf("got:\n%s\nwant:\n%s", got, want)

--- a/agent/internal/tool/repair/explain_covtest_test.go
+++ b/agent/internal/tool/repair/explain_covtest_test.go
@@ -581,6 +581,12 @@ func TestExplainSchemaError_PresentFieldUnhandledKeyword(t *testing.T) {
 }
 
 // TestAsStringSlice covers asStringSlice with various input types.
+// asStringSlice's only remaining callers render a schema's "required" list
+// (issue #625's adversarial review, F4: a non-string required-list entry
+// fails schema compilation before ExplainSchemaError can ever be called, so
+// it drops non-strings rather than rendering them — that shape is provably
+// unreachable, and a dropped entry under-reports rather than corrupting a
+// property-name list with a stray formatted garbage value).
 func TestAsStringSlice(t *testing.T) {
 	tests := []struct {
 		name string
@@ -589,12 +595,7 @@ func TestAsStringSlice(t *testing.T) {
 	}{
 		{"[]string", []string{"a", "b"}, []string{"a", "b"}},
 		{"[]any", []any{"a", "b"}, []string{"a", "b"}},
-		// Issue #625: non-string elements render via fmt.Sprint rather than
-		// being dropped, so a non-string enum's allowed values still show up
-		// in the constraint message instead of silently disappearing.
-		{"[]any with non-strings", []any{"a", 1, "b"}, []string{"a", "1", "b"}},
-		{"[]any integer enum", []any{float64(1), float64(2), float64(3)}, []string{"1", "2", "3"}},
-		{"[]any boolean enum", []any{true, false}, []string{"true", "false"}},
+		{"[]any with non-strings", []any{"a", 1, "b"}, []string{"a", "b"}},
 		{"nil", nil, nil},
 		{"string", "hello", nil},
 		{"int", 42, nil},
@@ -608,6 +609,58 @@ func TestAsStringSlice(t *testing.T) {
 			for i := range got {
 				if got[i] != tc.want[i] {
 					t.Fatalf("asStringSlice(%v)[%d] = %q, want %q", tc.v, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestFormatEnumValues covers formatEnumValues, the shared renderer for
+// constraintMessage's and branchRequirement's enum clauses (issue #625's
+// adversarial review, F1: the two sites must render a non-string enum's
+// allowed values identically and type-faithfully, not one quoted and one
+// bare). Each case's want is JSON-Marshal's actual output for that value —
+// a string quoted, everything else its own JSON literal — never Go's %v
+// syntax (F2: composite values must read as JSON, not e.g. "map[a:1]").
+func TestFormatEnumValues(t *testing.T) {
+	tests := []struct {
+		name string
+		v    any
+		want []string
+	}{
+		{"[]string", []string{"open", "closed"}, []string{`"open"`, `"closed"`}},
+		{"[]any strings", []any{"open", "closed"}, []string{`"open"`, `"closed"`}},
+		{"[]any integers (float64, MCP-decoded shape)", []any{float64(1), float64(2), float64(3)}, []string{"1", "2", "3"}},
+		{"[]any booleans", []any{true, false}, []string{"true", "false"}},
+		{"[]any null", []any{nil}, []string{"null"}},
+		{"[]any mixed types", []any{"open", float64(1), true, nil}, []string{`"open"`, "1", "true", "null"}},
+		// F2: a nested array/object enum member renders as its own JSON
+		// value, not Go's %v syntax (which would print "[1 2]"/"map[a:1]").
+		{"[]any nested array", []any{[]any{float64(1), float64(2)}}, []string{"[1,2]"}},
+		{"[]any nested object", []any{map[string]any{"a": float64(1)}}, []string{`{"a":1}`}},
+		// F3, decided: fmt.Sprint's %g switches to scientific notation far
+		// more aggressively than JSON encoding does (JSON only above ~1e21
+		// or below ~1e-6 magnitude); a realistic whole-number enum value
+		// like 1e20 now renders as a plain decimal instead of "1e+20".
+		// Outside that range JSON encoding still uses scientific notation
+		// (e.g. 1e21 -> "1e+21") — valid JSON, so left as-is: matching
+		// json.Marshal's own number formatting is the JSON-faithful
+		// contract, not a promise of decimal notation at every magnitude.
+		{"[]any large float stays decimal", []any{1e20}, []string{"100000000000000000000"}},
+		{"[]any float past json.Marshal's decimal range", []any{1e21}, []string{"1e+21"}},
+		{"nil", nil, nil},
+		{"string", "hello", nil},
+		{"int", 42, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatEnumValues(tc.v)
+			if len(got) != len(tc.want) {
+				t.Fatalf("formatEnumValues(%v) = %v, want %v", tc.v, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("formatEnumValues(%v)[%d] = %q, want %q", tc.v, i, got[i], tc.want[i])
 				}
 			}
 		})

--- a/agent/internal/tool/repair/explain_covtest_test.go
+++ b/agent/internal/tool/repair/explain_covtest_test.go
@@ -581,12 +581,6 @@ func TestExplainSchemaError_PresentFieldUnhandledKeyword(t *testing.T) {
 }
 
 // TestAsStringSlice covers asStringSlice with various input types.
-// asStringSlice's only remaining callers render a schema's "required" list
-// (issue #625's adversarial review, F4: a non-string required-list entry
-// fails schema compilation before ExplainSchemaError can ever be called, so
-// it drops non-strings rather than rendering them — that shape is provably
-// unreachable, and a dropped entry under-reports rather than corrupting a
-// property-name list with a stray formatted garbage value).
 func TestAsStringSlice(t *testing.T) {
 	tests := []struct {
 		name string
@@ -616,12 +610,9 @@ func TestAsStringSlice(t *testing.T) {
 }
 
 // TestFormatEnumValues covers formatEnumValues, the shared renderer for
-// constraintMessage's and branchRequirement's enum clauses (issue #625's
-// adversarial review, F1: the two sites must render a non-string enum's
-// allowed values identically and type-faithfully, not one quoted and one
-// bare). Each case's want is JSON-Marshal's actual output for that value —
-// a string quoted, everything else its own JSON literal — never Go's %v
-// syntax (F2: composite values must read as JSON, not e.g. "map[a:1]").
+// constraintMessage's and branchRequirement's enum clauses. Each case's
+// want is json.Marshal's own output for that value: a string quoted,
+// everything else its own JSON literal, never Go's %v syntax.
 func TestFormatEnumValues(t *testing.T) {
 	tests := []struct {
 		name string
@@ -634,18 +625,15 @@ func TestFormatEnumValues(t *testing.T) {
 		{"[]any booleans", []any{true, false}, []string{"true", "false"}},
 		{"[]any null", []any{nil}, []string{"null"}},
 		{"[]any mixed types", []any{"open", float64(1), true, nil}, []string{`"open"`, "1", "true", "null"}},
-		// F2: a nested array/object enum member renders as its own JSON
-		// value, not Go's %v syntax (which would print "[1 2]"/"map[a:1]").
+		// A composite enum member renders as its own JSON value, not Go's %v
+		// syntax (which would print "[1 2]"/"map[a:1]").
 		{"[]any nested array", []any{[]any{float64(1), float64(2)}}, []string{"[1,2]"}},
 		{"[]any nested object", []any{map[string]any{"a": float64(1)}}, []string{`{"a":1}`}},
-		// F3, decided: fmt.Sprint's %g switches to scientific notation far
-		// more aggressively than JSON encoding does (JSON only above ~1e21
-		// or below ~1e-6 magnitude); a realistic whole-number enum value
-		// like 1e20 now renders as a plain decimal instead of "1e+20".
-		// Outside that range JSON encoding still uses scientific notation
-		// (e.g. 1e21 -> "1e+21") — valid JSON, so left as-is: matching
-		// json.Marshal's own number formatting is the JSON-faithful
-		// contract, not a promise of decimal notation at every magnitude.
+		// JSON number encoding only turns to scientific notation above
+		// ~1e21 or below ~1e-6 magnitude, so a whole-number enum value like
+		// 1e20 renders as a plain decimal. Past that range it renders as
+		// "1e+21" — still valid JSON, and matching json.Marshal is the
+		// contract, not decimal notation at every magnitude.
 		{"[]any large float stays decimal", []any{1e20}, []string{"100000000000000000000"}},
 		{"[]any float past json.Marshal's decimal range", []any{1e21}, []string{"1e+21"}},
 		{"nil", nil, nil},

--- a/agent/internal/tool/repair/explain_covtest_test.go
+++ b/agent/internal/tool/repair/explain_covtest_test.go
@@ -589,7 +589,12 @@ func TestAsStringSlice(t *testing.T) {
 	}{
 		{"[]string", []string{"a", "b"}, []string{"a", "b"}},
 		{"[]any", []any{"a", "b"}, []string{"a", "b"}},
-		{"[]any with non-strings", []any{"a", 1, "b"}, []string{"a", "b"}},
+		// Issue #625: non-string elements render via fmt.Sprint rather than
+		// being dropped, so a non-string enum's allowed values still show up
+		// in the constraint message instead of silently disappearing.
+		{"[]any with non-strings", []any{"a", 1, "b"}, []string{"a", "1", "b"}},
+		{"[]any integer enum", []any{float64(1), float64(2), float64(3)}, []string{"1", "2", "3"}},
+		{"[]any boolean enum", []any{true, false}, []string{"true", "false"}},
 		{"nil", nil, nil},
 		{"string", "hello", nil},
 		{"int", 42, nil},

--- a/agent/internal/tool/repair/explain_covtest_test.go
+++ b/agent/internal/tool/repair/explain_covtest_test.go
@@ -636,6 +636,13 @@ func TestFormatEnumValues(t *testing.T) {
 		// contract, not decimal notation at every magnitude.
 		{"[]any large float stays decimal", []any{1e20}, []string{"100000000000000000000"}},
 		{"[]any float past json.Marshal's decimal range", []any{1e21}, []string{"1e+21"}},
+		// A genuinely typed slice or array (not []any) renders the same as
+		// its []any equivalent — reflection walks any slice/array kind
+		// uniformly, so these need no dedicated case in formatEnumValues.
+		{"[]int", []int{1, 2, 3}, []string{"1", "2", "3"}},
+		{"[]bool", []bool{true, false}, []string{"true", "false"}},
+		{"[]float64", []float64{1.5, 2.5}, []string{"1.5", "2.5"}},
+		{"[3]int array (not slice)", [3]int{1, 2, 3}, []string{"1", "2", "3"}},
 		{"nil", nil, nil},
 		{"string", "hello", nil},
 		{"int", 42, nil},

--- a/agent/internal/tool/repair/explain_oneof_test.go
+++ b/agent/internal/tool/repair/explain_oneof_test.go
@@ -98,10 +98,61 @@ func delegateOneOfIntEnumArgs() map[string]any {
 // branch's enum-constrained properties, which silently dropped non-string
 // enum values. An integer-enum branch requirement rendered as `send all of
 // "n"` with no allowed-values clause at all. The branch requirement must
-// name the allowed values regardless of their JSON type.
+// name the allowed values regardless of their JSON type — bare (unquoted),
+// per the adversarial review's F1: quoting a number here would visually
+// assert a JSON string and coach a retry with {"n": "1"}, which fails
+// validation again the same way.
 func TestExplainSchemaError_OneOfBranchNamesIntegerEnumValues(t *testing.T) {
 	msg := ExplainSchemaError("delegate", delegateOneOfIntEnumParams(), delegateOneOfIntEnumArgs(), "", "not")
-	if !strings.Contains(msg, `"n" must be one of "1", "2", "3"`) {
-		t.Fatalf("message must render branch 1's integer enum allowed values: %q", msg)
+	if !strings.Contains(msg, `"n" must be one of 1, 2, 3`) {
+		t.Fatalf("message must render branch 1's integer enum allowed values bare (not quoted): %q", msg)
+	}
+}
+
+// delegateOneOfBoolEnumParams mirrors delegateOneOfIntEnumParams but with a
+// boolean-enum property ("flag") — the exact shape the adversarial review's
+// F1 finding traced through the real joinQuoted/branchRequirement bodies to
+// demonstrate the quoting defect (a boolean rendered as "true", "false"
+// reads as a JSON string enum, not a JSON boolean one).
+func delegateOneOfBoolEnumParams() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"task": map[string]any{"type": "string"},
+			"flag": map[string]any{"type": "boolean", "enum": []any{true, false}},
+		},
+		"required": []any{"task"},
+		"oneOf": []any{
+			map[string]any{"not": map[string]any{"required": []string{"flag"}}},
+			map[string]any{
+				"required": []string{"flag"},
+				"properties": map[string]any{
+					"flag": map[string]any{"enum": []any{true, false}},
+				},
+			},
+		},
+	}
+}
+
+func delegateOneOfBoolEnumArgs() map[string]any {
+	return map[string]any{
+		"task": "ping",
+		"flag": "true",
+	}
+}
+
+// Adversarial review of issue #625, F1: branchRequirement quoted every enum
+// value regardless of JSON type, so a boolean-enum branch requirement
+// rendered `"flag" must be one of "true", "false"` — indistinguishable from
+// how the same code renders a string enum, even though the schema requires
+// a bare JSON boolean. The branch requirement must render bare true/false.
+func TestExplainSchemaError_OneOfBranchNamesBooleanEnumValues(t *testing.T) {
+	msg := ExplainSchemaError("delegate", delegateOneOfBoolEnumParams(), delegateOneOfBoolEnumArgs(), "", "not")
+	if !strings.Contains(msg, `"flag" must be one of true, false`) {
+		t.Fatalf("message must render branch 1's boolean enum allowed values bare (not quoted): %q", msg)
+	}
+	if strings.Contains(msg, `"true", "false"`) {
+		t.Fatalf("message quoted the boolean enum values, visually asserting the wrong JSON type: %q", msg)
 	}
 }

--- a/agent/internal/tool/repair/explain_oneof_test.go
+++ b/agent/internal/tool/repair/explain_oneof_test.go
@@ -64,10 +64,12 @@ func TestExplainSchemaError_OneOfConstraintDoesNotReportMissingArgument(t *testi
 
 // delegateOneOfEnumParams mirrors delegateOneOfParams with a single
 // non-string-enum property in place of the string-enum "sandbox": the
-// second oneOf branch requires prop and constrains it to enum. Integer enum
-// values are float64, as they are when a tool schema is JSON-decoded into
-// map[string]any.
-func delegateOneOfEnumParams(prop, typ string, enum []any) map[string]any {
+// second oneOf branch requires prop and constrains it to enum. enum takes
+// any slice or array type: []any (integer enum values are float64, as they
+// are when a tool schema is JSON-decoded into map[string]any) or a
+// genuinely typed slice like []int or []bool, which schema compilation
+// accepts and preserves through cloning just the same.
+func delegateOneOfEnumParams(prop, typ string, enum any) map[string]any {
 	return map[string]any{
 		"type":                 "object",
 		"additionalProperties": false,
@@ -113,5 +115,27 @@ func TestExplainSchemaError_OneOfBranchNamesBooleanEnumValues(t *testing.T) {
 	}
 	if strings.Contains(msg, `"true", "false"`) {
 		t.Fatalf("message quoted the boolean enum values, visually asserting the wrong JSON type: %q", msg)
+	}
+}
+
+// A genuinely typed Go slice (not []any) must name its branch's allowed
+// values the same as its []any equivalent above: schema compilation accepts
+// this shape and preserves it through cloning, so it reaches branchRequirement
+// still typed.
+func TestExplainSchemaError_OneOfBranchNamesTypedIntSliceEnumValues(t *testing.T) {
+	params := delegateOneOfEnumParams("n", "integer", []int{1, 2, 3})
+	args := map[string]any{"task": "ping", "n": 5}
+	msg := ExplainSchemaError("delegate", params, args, "", "not")
+	if !strings.Contains(msg, `"n" must be one of 1, 2, 3`) {
+		t.Fatalf("message must render branch 1's typed []int enum allowed values bare: %q", msg)
+	}
+}
+
+func TestExplainSchemaError_OneOfBranchNamesTypedBoolSliceEnumValues(t *testing.T) {
+	params := delegateOneOfEnumParams("flag", "boolean", []bool{true, false})
+	args := map[string]any{"task": "ping", "flag": "true"}
+	msg := ExplainSchemaError("delegate", params, args, "", "not")
+	if !strings.Contains(msg, `"flag" must be one of true, false`) {
+		t.Fatalf("message must render branch 1's typed []bool enum allowed values bare: %q", msg)
 	}
 }

--- a/agent/internal/tool/repair/explain_oneof_test.go
+++ b/agent/internal/tool/repair/explain_oneof_test.go
@@ -62,93 +62,52 @@ func TestExplainSchemaError_OneOfConstraintDoesNotReportMissingArgument(t *testi
 	}
 }
 
-// delegateOneOfIntEnumParams mirrors delegateOneOfParams but the second
-// branch requires an integer-enum property ("n") instead of a string-enum
-// one. Enum values are float64, as they are when a tool schema is
-// JSON-decoded into map[string]any.
-func delegateOneOfIntEnumParams() map[string]any {
+// delegateOneOfEnumParams mirrors delegateOneOfParams with a single
+// non-string-enum property in place of the string-enum "sandbox": the
+// second oneOf branch requires prop and constrains it to enum. Integer enum
+// values are float64, as they are when a tool schema is JSON-decoded into
+// map[string]any.
+func delegateOneOfEnumParams(prop, typ string, enum []any) map[string]any {
 	return map[string]any{
 		"type":                 "object",
 		"additionalProperties": false,
 		"properties": map[string]any{
 			"task": map[string]any{"type": "string"},
-			"n":    map[string]any{"type": "integer", "enum": []any{float64(1), float64(2), float64(3)}},
+			prop:   map[string]any{"type": typ, "enum": enum},
 		},
 		"required": []any{"task"},
 		"oneOf": []any{
-			map[string]any{"not": map[string]any{"required": []string{"n"}}},
+			map[string]any{"not": map[string]any{"required": []string{prop}}},
 			map[string]any{
-				"required": []string{"n"},
+				"required": []string{prop},
 				"properties": map[string]any{
-					"n": map[string]any{"enum": []any{float64(1), float64(2), float64(3)}},
+					prop: map[string]any{"enum": enum},
 				},
 			},
 		},
 	}
 }
 
-func delegateOneOfIntEnumArgs() map[string]any {
-	return map[string]any{
-		"task": "ping",
-		"n":    float64(5),
-	}
-}
-
-// Issue #625 case 2: branchRequirement used asStringSlice to render a
-// branch's enum-constrained properties, which silently dropped non-string
-// enum values. An integer-enum branch requirement rendered as `send all of
-// "n"` with no allowed-values clause at all. The branch requirement must
-// name the allowed values regardless of their JSON type — bare (unquoted),
-// per the adversarial review's F1: quoting a number here would visually
-// assert a JSON string and coach a retry with {"n": "1"}, which fails
-// validation again the same way.
+// Issue #625 case 2: a branch requirement must name its enum's allowed
+// values whatever their JSON type, and render them as that type. Bare, for
+// a number: quoting one would assert a JSON string and coach a retry with
+// {"n": "1"}, which fails validation again the same way.
 func TestExplainSchemaError_OneOfBranchNamesIntegerEnumValues(t *testing.T) {
-	msg := ExplainSchemaError("delegate", delegateOneOfIntEnumParams(), delegateOneOfIntEnumArgs(), "", "not")
+	params := delegateOneOfEnumParams("n", "integer", []any{float64(1), float64(2), float64(3)})
+	args := map[string]any{"task": "ping", "n": float64(5)}
+	msg := ExplainSchemaError("delegate", params, args, "", "not")
 	if !strings.Contains(msg, `"n" must be one of 1, 2, 3`) {
 		t.Fatalf("message must render branch 1's integer enum allowed values bare (not quoted): %q", msg)
 	}
 }
 
-// delegateOneOfBoolEnumParams mirrors delegateOneOfIntEnumParams but with a
-// boolean-enum property ("flag") — the exact shape the adversarial review's
-// F1 finding traced through the real joinQuoted/branchRequirement bodies to
-// demonstrate the quoting defect (a boolean rendered as "true", "false"
-// reads as a JSON string enum, not a JSON boolean one).
-func delegateOneOfBoolEnumParams() map[string]any {
-	return map[string]any{
-		"type":                 "object",
-		"additionalProperties": false,
-		"properties": map[string]any{
-			"task": map[string]any{"type": "string"},
-			"flag": map[string]any{"type": "boolean", "enum": []any{true, false}},
-		},
-		"required": []any{"task"},
-		"oneOf": []any{
-			map[string]any{"not": map[string]any{"required": []string{"flag"}}},
-			map[string]any{
-				"required": []string{"flag"},
-				"properties": map[string]any{
-					"flag": map[string]any{"enum": []any{true, false}},
-				},
-			},
-		},
-	}
-}
-
-func delegateOneOfBoolEnumArgs() map[string]any {
-	return map[string]any{
-		"task": "ping",
-		"flag": "true",
-	}
-}
-
-// Adversarial review of issue #625, F1: branchRequirement quoted every enum
-// value regardless of JSON type, so a boolean-enum branch requirement
-// rendered `"flag" must be one of "true", "false"` — indistinguishable from
-// how the same code renders a string enum, even though the schema requires
-// a bare JSON boolean. The branch requirement must render bare true/false.
+// A boolean enum renders bare too. Quoted, `"flag" must be one of "true",
+// "false"` is indistinguishable from how the same code renders a string
+// enum, though the schema requires a JSON boolean.
 func TestExplainSchemaError_OneOfBranchNamesBooleanEnumValues(t *testing.T) {
-	msg := ExplainSchemaError("delegate", delegateOneOfBoolEnumParams(), delegateOneOfBoolEnumArgs(), "", "not")
+	params := delegateOneOfEnumParams("flag", "boolean", []any{true, false})
+	args := map[string]any{"task": "ping", "flag": "true"}
+	msg := ExplainSchemaError("delegate", params, args, "", "not")
 	if !strings.Contains(msg, `"flag" must be one of true, false`) {
 		t.Fatalf("message must render branch 1's boolean enum allowed values bare (not quoted): %q", msg)
 	}

--- a/agent/internal/tool/repair/explain_oneof_test.go
+++ b/agent/internal/tool/repair/explain_oneof_test.go
@@ -61,3 +61,47 @@ func TestExplainSchemaError_OneOfConstraintDoesNotReportMissingArgument(t *testi
 		t.Fatalf("message must name the constrained field sandbox_net: %q", msg)
 	}
 }
+
+// delegateOneOfIntEnumParams mirrors delegateOneOfParams but the second
+// branch requires an integer-enum property ("n") instead of a string-enum
+// one. Enum values are float64, as they are when a tool schema is
+// JSON-decoded into map[string]any.
+func delegateOneOfIntEnumParams() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"task": map[string]any{"type": "string"},
+			"n":    map[string]any{"type": "integer", "enum": []any{float64(1), float64(2), float64(3)}},
+		},
+		"required": []any{"task"},
+		"oneOf": []any{
+			map[string]any{"not": map[string]any{"required": []string{"n"}}},
+			map[string]any{
+				"required": []string{"n"},
+				"properties": map[string]any{
+					"n": map[string]any{"enum": []any{float64(1), float64(2), float64(3)}},
+				},
+			},
+		},
+	}
+}
+
+func delegateOneOfIntEnumArgs() map[string]any {
+	return map[string]any{
+		"task": "ping",
+		"n":    float64(5),
+	}
+}
+
+// Issue #625 case 2: branchRequirement used asStringSlice to render a
+// branch's enum-constrained properties, which silently dropped non-string
+// enum values. An integer-enum branch requirement rendered as `send all of
+// "n"` with no allowed-values clause at all. The branch requirement must
+// name the allowed values regardless of their JSON type.
+func TestExplainSchemaError_OneOfBranchNamesIntegerEnumValues(t *testing.T) {
+	msg := ExplainSchemaError("delegate", delegateOneOfIntEnumParams(), delegateOneOfIntEnumArgs(), "", "not")
+	if !strings.Contains(msg, `"n" must be one of "1", "2", "3"`) {
+		t.Fatalf("message must render branch 1's integer enum allowed values: %q", msg)
+	}
+}

--- a/agent/internal/tool/repair/explain_test.go
+++ b/agent/internal/tool/repair/explain_test.go
@@ -290,11 +290,6 @@ func TestExplainSchemaError_ConstraintClasses(t *testing.T) {
 			want:             `ask_user: argument "questions" exceeds maxItems (4). Value has 5 items.`,
 		},
 		{
-			// Allowed values render JSON-faithfully: a string enum's members
-			// are JSON-quoted (adversarial review of issue #625, F1 — an
-			// unquoted string list here while branchRequirement quoted
-			// everything was itself an inconsistency between the two enum
-			// call sites the fix touches).
 			name:             "enum",
 			toolName:         "task_list",
 			params:           taskListParamsForExplain(),
@@ -316,13 +311,11 @@ func TestExplainSchemaError_ConstraintClasses(t *testing.T) {
 			want:             `task_list: argument "updates[0].status" is not one of the allowed values: "open", "in_progress", "done", "cancelled". Value is "bogus".`,
 		},
 		{
-			// Issue #625: asStringSlice dropped non-string enum values, so an
-			// integer enum's allowed list came out empty and constraintMessage
-			// fell back to the generic "wrong type or value" message. Enum
-			// values arrive as float64 here (as they do when a tool schema is
-			// JSON-decoded into map[string]any). Numbers render bare (no
-			// quotes) — JSON-faithful, so the model can copy a value straight
-			// back into the argument.
+			// Issue #625: a non-string enum's allowed values used to be dropped,
+			// leaving an empty list that fell back to the generic "wrong type or
+			// value" message. Enum values arrive as float64 here, as they do
+			// when a tool schema is JSON-decoded into map[string]any, and render
+			// bare so the model can copy one straight back into the argument.
 			name:     "integer enum",
 			toolName: "my_tool",
 			params: map[string]any{
@@ -338,10 +331,9 @@ func TestExplainSchemaError_ConstraintClasses(t *testing.T) {
 			want:             `my_tool: argument "n" is not one of the allowed values: 1, 2, 3. Value is "5".`,
 		},
 		{
-			// Adversarial review of issue #625, F1: a boolean enum's allowed
-			// values must also render bare. Quoting them ("true", "false")
-			// would visually assert a JSON string, coaching a retry with
-			// {"flag": "true"} that fails validation again the same way.
+			// A boolean enum's allowed values render bare too. Quoting them
+			// ("true", "false") would assert a JSON string, coaching a retry
+			// with {"flag": "true"} that fails validation the same way.
 			name:     "boolean enum",
 			toolName: "my_tool",
 			params: map[string]any{

--- a/agent/internal/tool/repair/explain_test.go
+++ b/agent/internal/tool/repair/explain_test.go
@@ -290,13 +290,18 @@ func TestExplainSchemaError_ConstraintClasses(t *testing.T) {
 			want:             `ask_user: argument "questions" exceeds maxItems (4). Value has 5 items.`,
 		},
 		{
+			// Allowed values render JSON-faithfully: a string enum's members
+			// are JSON-quoted (adversarial review of issue #625, F1 — an
+			// unquoted string list here while branchRequirement quoted
+			// everything was itself an inconsistency between the two enum
+			// call sites the fix touches).
 			name:             "enum",
 			toolName:         "task_list",
 			params:           taskListParamsForExplain(),
 			args:             map[string]any{"action": "bogus"},
 			instanceLocation: "action",
 			keyword:          "enum",
-			want:             `task_list: argument "action" is not one of the allowed values: view, append, update. Value is "bogus".`,
+			want:             `task_list: argument "action" is not one of the allowed values: "view", "append", "update". Value is "bogus".`,
 		},
 		{
 			name:     "nested enum",
@@ -308,14 +313,16 @@ func TestExplainSchemaError_ConstraintClasses(t *testing.T) {
 			},
 			instanceLocation: "updates/0/status",
 			keyword:          "enum",
-			want:             `task_list: argument "updates[0].status" is not one of the allowed values: open, in_progress, done, cancelled. Value is "bogus".`,
+			want:             `task_list: argument "updates[0].status" is not one of the allowed values: "open", "in_progress", "done", "cancelled". Value is "bogus".`,
 		},
 		{
 			// Issue #625: asStringSlice dropped non-string enum values, so an
 			// integer enum's allowed list came out empty and constraintMessage
 			// fell back to the generic "wrong type or value" message. Enum
 			// values arrive as float64 here (as they do when a tool schema is
-			// JSON-decoded into map[string]any).
+			// JSON-decoded into map[string]any). Numbers render bare (no
+			// quotes) — JSON-faithful, so the model can copy a value straight
+			// back into the argument.
 			name:     "integer enum",
 			toolName: "my_tool",
 			params: map[string]any{
@@ -329,6 +336,25 @@ func TestExplainSchemaError_ConstraintClasses(t *testing.T) {
 			instanceLocation: "n",
 			keyword:          "enum",
 			want:             `my_tool: argument "n" is not one of the allowed values: 1, 2, 3. Value is "5".`,
+		},
+		{
+			// Adversarial review of issue #625, F1: a boolean enum's allowed
+			// values must also render bare. Quoting them ("true", "false")
+			// would visually assert a JSON string, coaching a retry with
+			// {"flag": "true"} that fails validation again the same way.
+			name:     "boolean enum",
+			toolName: "my_tool",
+			params: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"flag": map[string]any{"type": "boolean", "enum": []any{true, false}},
+				},
+				"required": []string{"flag"},
+			},
+			args:             map[string]any{"flag": "yes"},
+			instanceLocation: "flag",
+			keyword:          "enum",
+			want:             `my_tool: argument "flag" is not one of the allowed values: true, false. Value is "yes".`,
 		},
 	}
 	for _, tc := range tests {

--- a/agent/internal/tool/repair/explain_test.go
+++ b/agent/internal/tool/repair/explain_test.go
@@ -310,6 +310,26 @@ func TestExplainSchemaError_ConstraintClasses(t *testing.T) {
 			keyword:          "enum",
 			want:             `task_list: argument "updates[0].status" is not one of the allowed values: open, in_progress, done, cancelled. Value is "bogus".`,
 		},
+		{
+			// Issue #625: asStringSlice dropped non-string enum values, so an
+			// integer enum's allowed list came out empty and constraintMessage
+			// fell back to the generic "wrong type or value" message. Enum
+			// values arrive as float64 here (as they do when a tool schema is
+			// JSON-decoded into map[string]any).
+			name:     "integer enum",
+			toolName: "my_tool",
+			params: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"n": map[string]any{"type": "integer", "enum": []any{float64(1), float64(2), float64(3)}},
+				},
+				"required": []string{"n"},
+			},
+			args:             map[string]any{"n": float64(5)},
+			instanceLocation: "n",
+			keyword:          "enum",
+			want:             `my_tool: argument "n" is not one of the allowed values: 1, 2, 3. Value is "5".`,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/agent/internal/tool/repair/explain_test.go
+++ b/agent/internal/tool/repair/explain_test.go
@@ -348,6 +348,39 @@ func TestExplainSchemaError_ConstraintClasses(t *testing.T) {
 			keyword:          "enum",
 			want:             `my_tool: argument "flag" is not one of the allowed values: true, false. Value is "yes".`,
 		},
+		{
+			// A genuinely typed Go slice (not []any) renders the same as its
+			// []any equivalent: schema compilation accepts this shape and
+			// preserves it through cloning, so formatEnumValues must too.
+			name:     "typed []int slice enum",
+			toolName: "my_tool",
+			params: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"n": map[string]any{"type": "integer", "enum": []int{1, 2, 3}},
+				},
+				"required": []string{"n"},
+			},
+			args:             map[string]any{"n": 5},
+			instanceLocation: "n",
+			keyword:          "enum",
+			want:             `my_tool: argument "n" is not one of the allowed values: 1, 2, 3. Value is "5".`,
+		},
+		{
+			name:     "typed []bool slice enum",
+			toolName: "my_tool",
+			params: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"flag": map[string]any{"type": "boolean", "enum": []bool{true, false}},
+				},
+				"required": []string{"flag"},
+			},
+			args:             map[string]any{"flag": "yes"},
+			instanceLocation: "flag",
+			keyword:          "enum",
+			want:             `my_tool: argument "flag" is not one of the allowed values: true, false. Value is "yes".`,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/agent/session_tool_repair_test.go
+++ b/agent/session_tool_repair_test.go
@@ -229,7 +229,7 @@ func TestPrepareToolCall_NestedSchemaErrors_NameRealFieldAndContainer(t *testing
 		call := llm.ToolCallData{ID: "c4", Name: "task_list",
 			Arguments: json.RawMessage(`{"update":[{"id":1,"status":"bogus"}]}`)}
 		res := prepareToolCall(call, reg.Get("task_list"), []string{"task_list"}, "task_list", "communicate", "")
-		want := "task_list: argument \"update[0].status\" is not one of the allowed values: open, in_progress, done, cancelled. Value is \"bogus\"."
+		want := "task_list: argument \"update[0].status\" is not one of the allowed values: \"open\", \"in_progress\", \"done\", \"cancelled\". Value is \"bogus\"."
 		if res.PrevalErr != want {
 			t.Fatalf("PrevalErr =\n%s\nwant:\n%s", res.PrevalErr, want)
 		}


### PR DESCRIPTION
Fixes #625. asStringSlice dropped non-string enum members, so an integer/boolean enum produced an empty allowed-values list and the constraint message degraded to the generic 'wrong type or value'. Enum rendering now goes through one json.Marshal-faithful renderer at both call sites (constraintMessage and branchRequirement): strings quoted, numbers/booleans/null bare, composites as real JSON — i.e. exactly what the value looks like in the JSON the model must send back.

Pipeline provenance: adversarial review REFUTED round 1 (the oneOf path QUOTED integer enums, visually asserting string type and inviting a stringified retry that fails again; and it diverged from the unquoted constraintMessage rendering); round 2 rebuilt it type-faithfully, reverting the round-1 asStringSlice change entirely (required-lists provably never see non-strings), with the string-enum quoting change's goldens swept repo-wide (two beyond the review's named files). Simplify pass trimmed review-history narration and shared a duplicated test fixture. Scientific-notation boundary for extreme floats documented and tested; json.Marshal HTML-escaping of <>& in string enums flagged (no built-in schema hits it).