### PR TITLE
DO NOT MERGE agent: name live stable delegates in the end_turn running-work warning

### DIFF
--- a/agent/delegate_tree_controller_test.go
+++ b/agent/delegate_tree_controller_test.go
@@ -489,6 +489,7 @@ var delegateControllerDormancyExpectedInventory = map[delegateControllerDormancy
 	{filename: "session_attention.go", function: "(*Session).finishRootDelegateAttentionTurn", kind: "session attention method", symbol: "resolveAttentionDurably"}:                    1,
 	{filename: "session_events.go", function: "(*Session).SetDescendantEventFunc", kind: "lifecycle method", symbol: "Snapshot"}:                                                       1,
 	{filename: "session_tools_jobs.go", function: "stableDelegateRowsForSession", kind: "lifecycle method", symbol: "Snapshot"}:                                                        1,
+	{filename: "session_tools_jobs.go", function: "(*Session).runningStableDelegateIDs", kind: "lifecycle method", symbol: "Snapshot"}:                                                 1,
 	{filename: "status.go", function: "(*Session).DetailedStatus", kind: "lifecycle method", symbol: "Snapshot"}:                                                                       1,
 	{filename: "delegate_tree_stop.go", function: "(*delegateTreeController).drainStop", kind: "lifecycle method", symbol: "ReconcileRequirements"}:                                    1,
 	{filename: "delegate_tree_stop.go", function: "(*delegateTreeController).drainStop", kind: "lifecycle method", symbol: "Reconcile"}:                                                1,

--- a/agent/session_communicate_endturn_oneshot_test.go
+++ b/agent/session_communicate_endturn_oneshot_test.go
@@ -317,3 +317,154 @@ func TestCommunicate_EndTurnDoesNotWarnForExitedDetachedProcess(t *testing.T) {
 		t.Fatalf("communicate response = %v, want no warning for an exited detached process", response)
 	}
 }
+
+// TestCommunicate_EndTurnWarnsForLiveGrandchildDelegate drives a real depth-2
+// delegate tree: root creates A with a delegation_allowance, then A itself
+// (not root) creates B and ends ITS OWN turn while B is still live. Adversarial
+// review of #585 found the shipped fix used
+// row.descriptor.OwnerSessionID == s.ID(), but OwnerSessionID is the TREE'S
+// ROOT session id on every row (delegate_tree_start.go), never the immediate
+// parent — so that filter only ever matches when s IS the root, and every
+// non-root delegate (the default at MaxSubagentDepth 2: "a delegate itself
+// delegate one level") silently got nil for its own live children. This drives
+// A's REAL communicate handler (via A.reg.ExecuteCall, not a hand-built
+// message) to prove A's own end_turn warning names A's own child, not just
+// root's.
+//
+// It also pins the direct-vs-transitive design choice the review flagged as
+// needing a decision: while B is live, ROOT's own end_turn warning (checked
+// first, before A ends its turn and goes idle) must name A — root's own
+// direct child — but must NOT name B, A's child and root's grandchild. Each
+// session warns about what it itself is holding open, matching the scope
+// sessionRunningJobIDs already gives shell jobs (a session's own job manager
+// only ever lists jobs it launched itself, never a child's).
+func TestCommunicate_EndTurnWarnsForLiveGrandchildDelegate(t *testing.T) {
+	gate := make(chan struct{})
+	childAdapter := &fakeAdapter{
+		name: "openai",
+		steps: []func(llm.Request) llm.Response{
+			func(llm.Request) llm.Response {
+				<-gate
+				return toolCallResponse(communicateCall("grandchild-done", "grandchild done"))
+			},
+		},
+	}
+	childClient := llm.NewClient()
+	childClient.Register(childAdapter)
+	registerTestSessionNamer(childClient)
+
+	root := newSession(t, withConfig(SessionConfig{
+		StateDir:         t.TempDir(),
+		MaxSubagentDepth: 2,
+		NoProjectPrompts: true,
+		TurnEndsProcess:  true,
+		testOnly: testConfig{
+			skipGitSnapshot:     true,
+			minimalSystemPrompt: true,
+			noSyncJobStore:      true,
+			childClientFactory:  func() *llm.Client { return childClient },
+		},
+	}))
+	// Registered after newSession (whose t.Cleanup(sess.Close) ran first): LIFO
+	// releases the grandchild's blocked turn before Close waits on it.
+	t.Cleanup(func() { close(gate) })
+
+	parentRes := root.reg.ExecuteCall(context.Background(), root.env, llm.ToolCallData{
+		ID:        "delegate-parent",
+		Name:      "delegate",
+		Arguments: json.RawMessage(`{"task":"supervise a child delegate","delegation_allowance":1}`),
+	})
+	if parentRes.IsError {
+		t.Fatalf("root delegate returned error: %s", parentRes.Output)
+	}
+	var parentOut struct {
+		DelegateID     string `json:"delegate_id"`
+		ChildSessionID string `json:"child_session_id"`
+	}
+	if err := json.Unmarshal(toolResultJSON(parentRes), &parentOut); err != nil {
+		t.Fatalf("unmarshal root delegate output: %v (output: %s)", err, parentRes.Output)
+	}
+	a := root.subagents.get(parentOut.ChildSessionID)
+	if a == nil || a.sess == nil {
+		t.Fatalf("A's child session %q is not tracked", parentOut.ChildSessionID)
+	}
+
+	// A's own tool calls need A's current lease in context, exactly as its real
+	// run loop would supply it (delegate_runtime.go sets this on runCtx before
+	// sub.run): driving A.reg.ExecuteCall directly (as this file's other tests
+	// already do for root) skips that plumbing, so it is reconstructed here the
+	// same way TestDelegateResourceCreate_RegisteredNestedCreateUsesCurrentLease
+	// (delegate_resource_create_test.go) does for the identical situation.
+	root.delegateController.mu.Lock()
+	aLive := root.delegateController.live[parentOut.DelegateID]
+	if aLive == nil || aLive.binding == nil {
+		root.delegateController.mu.Unlock()
+		t.Fatalf("A (%q) has no live generation binding", parentOut.DelegateID)
+	}
+	aLease := aLive.binding.lease
+	root.delegateController.mu.Unlock()
+	aCtx := context.WithValue(context.Background(), delegateRunLeaseContextKey{}, aLease)
+
+	grandchildRes := a.sess.reg.ExecuteCall(aCtx, a.sess.env, llm.ToolCallData{
+		ID:        "delegate-grandchild",
+		Name:      "delegate",
+		Arguments: json.RawMessage(`{"task":"do something slowly"}`),
+	})
+	if grandchildRes.IsError {
+		t.Fatalf("A's own delegate call returned error: %s", grandchildRes.Output)
+	}
+	var grandchildOut struct {
+		DelegateID string `json:"delegate_id"`
+		Status     string `json:"status"`
+	}
+	if err := json.Unmarshal(toolResultJSON(grandchildRes), &grandchildOut); err != nil {
+		t.Fatalf("unmarshal A's delegate output: %v (output: %s)", err, grandchildRes.Output)
+	}
+	if grandchildOut.DelegateID == "" || grandchildOut.Status != "running" {
+		t.Fatalf("A's delegate output = %+v, want a running delegate", grandchildOut)
+	}
+
+	// Root's own end_turn, checked first (A is still running, hasn't gone idle
+	// yet): root's warning must name its own direct child A, but not reach past
+	// A into A's own child B.
+	rootRes := root.reg.ExecuteCall(context.Background(), root.env, communicateCallArgs("root-end-turn", map[string]any{
+		"message":  "pausing, my own child is still working",
+		"end_turn": true,
+	}))
+	if rootRes.IsError {
+		t.Fatalf("root's communicate error: %s", rootRes.Output)
+	}
+	var rootResp map[string]any
+	if err := json.Unmarshal(toolResultJSON(rootRes), &rootResp); err != nil {
+		t.Fatalf("unmarshal root's communicate output: %v", err)
+	}
+	rootWarning, ok := rootResp["warning"].(string)
+	if !ok || rootWarning == "" {
+		t.Fatalf("expected root's end_turn to warn about root's own live child delegate, got: %v", rootResp)
+	}
+	if !strings.Contains(rootWarning, parentOut.DelegateID) {
+		t.Fatalf("root warning = %q, want it to name root's own live delegate id %q", rootWarning, parentOut.DelegateID)
+	}
+	if strings.Contains(rootWarning, grandchildOut.DelegateID) {
+		t.Fatalf("root warning = %q, want it to NOT name grandchild delegate id %q (not root's direct child)", rootWarning, grandchildOut.DelegateID)
+	}
+
+	res := a.sess.reg.ExecuteCall(aCtx, a.sess.env, communicateCallArgs("a-end-turn", map[string]any{
+		"message":  "pausing, my child is still working",
+		"end_turn": true,
+	}))
+	if res.IsError {
+		t.Fatalf("A's communicate error: %s", res.Output)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(toolResultJSON(res), &resp); err != nil {
+		t.Fatalf("unmarshal A's communicate output: %v", err)
+	}
+	warning, ok := resp["warning"].(string)
+	if !ok || warning == "" {
+		t.Fatalf("expected A's end_turn to warn about A's own live child delegate, got: %v", resp)
+	}
+	if !strings.Contains(warning, grandchildOut.DelegateID) {
+		t.Fatalf("warning = %q, want it to name A's own live delegate id %q", warning, grandchildOut.DelegateID)
+	}
+}

--- a/agent/session_communicate_endturn_oneshot_test.go
+++ b/agent/session_communicate_endturn_oneshot_test.go
@@ -66,6 +66,45 @@ func endTurnWarningWithRunningJob(t *testing.T, s *Session) (warning, jobID stri
 	return got, shellOut.JobID
 }
 
+// newSessionWithRunningDelegates builds a session whose delegates park on a
+// gate: a child's single turn blocks until cleanup releases it, so a delegate
+// started through the real delegate tool — by the session itself or by one of
+// its own delegates — stays lifecycle-running for the whole test.
+func newSessionWithRunningDelegates(t *testing.T, maxSubagentDepth int) *Session {
+	t.Helper()
+
+	gate := make(chan struct{})
+	childAdapter := &fakeAdapter{
+		name: "openai",
+		steps: []func(llm.Request) llm.Response{
+			func(llm.Request) llm.Response {
+				<-gate
+				return toolCallResponse(communicateCall("delegate-done", "delegate done"))
+			},
+		},
+	}
+	childClient := llm.NewClient()
+	childClient.Register(childAdapter)
+	registerTestSessionNamer(childClient)
+
+	s := newSession(t, withConfig(SessionConfig{
+		StateDir:         t.TempDir(),
+		MaxSubagentDepth: maxSubagentDepth,
+		NoProjectPrompts: true,
+		TurnEndsProcess:  true,
+		testOnly: testConfig{
+			skipGitSnapshot:     true,
+			minimalSystemPrompt: true,
+			noSyncJobStore:      true,
+			childClientFactory:  func() *llm.Client { return childClient },
+		},
+	}))
+	// Registered after newSession (whose t.Cleanup(sess.Close) ran first): LIFO
+	// releases the parked turns before Close waits on them.
+	t.Cleanup(func() { close(gate) })
+	return s
+}
+
 // TestCommunicate_EndTurnWarningIsHonestInOneShot pins the correction to the
 // warn-first text for a session whose process exits with the turn. The old
 // wording promised "each job remains notification-armed and will report
@@ -179,58 +218,7 @@ func TestCommunicate_EndTurnWarnsForLiveDetachedProcess(t *testing.T) {
 // #585): a live delegate is session-owned work exactly like a background job,
 // so the warning must name both by id, not just the shell job.
 func TestCommunicate_EndTurnWarnsForLiveDelegate(t *testing.T) {
-	gate := make(chan struct{})
-	childAdapter := &fakeAdapter{
-		name: "openai",
-		steps: []func(llm.Request) llm.Response{
-			func(llm.Request) llm.Response {
-				<-gate
-				return toolCallResponse(communicateCall("child-done", "child done"))
-			},
-		},
-	}
-	childClient := llm.NewClient()
-	childClient.Register(childAdapter)
-	registerTestSessionNamer(childClient)
-
-	s := newSession(t, withConfig(SessionConfig{
-		StateDir:         t.TempDir(),
-		MaxSubagentDepth: 1,
-		NoProjectPrompts: true,
-		TurnEndsProcess:  true,
-		testOnly: testConfig{
-			skipGitSnapshot:     true,
-			minimalSystemPrompt: true,
-			noSyncJobStore:      true,
-			childClientFactory:  func() *llm.Client { return childClient },
-		},
-	}))
-	// Registered after newSession (whose t.Cleanup(sess.Close) ran first): LIFO
-	// releases the child's blocked turn before Close waits on it.
-	t.Cleanup(func() { close(gate) })
-
-	shellRes := s.reg.ExecuteCall(context.Background(), s.env, llm.ToolCallData{
-		ID:        "shell",
-		Name:      "shell",
-		Arguments: json.RawMessage(`{"command":"sleep 30","mode":"background"}`),
-	})
-	if shellRes.IsError {
-		t.Fatalf("shell returned error: %s", shellRes.Output)
-	}
-	var shellOut struct {
-		JobID  string `json:"job_id"`
-		Status string `json:"status"`
-	}
-	if err := json.Unmarshal(toolResultJSON(shellRes), &shellOut); err != nil {
-		t.Fatalf("unmarshal shell output: %v (output: %s)", err, shellRes.Output)
-	}
-	if shellOut.JobID == "" || shellOut.Status != "running" {
-		t.Fatalf("shell output = %+v, want a running job", shellOut)
-	}
-	t.Cleanup(func() {
-		_, _ = s.jobManager.stop(shellOut.JobID)
-		waitForShellDone(t, s.jobManager, shellOut.JobID)
-	})
+	s := newSessionWithRunningDelegates(t, 1)
 
 	delegateRes := s.reg.ExecuteCall(context.Background(), s.env, llm.ToolCallData{
 		ID:        "delegate",
@@ -251,24 +239,9 @@ func TestCommunicate_EndTurnWarnsForLiveDelegate(t *testing.T) {
 		t.Fatalf("delegate output = %+v, want a running delegate", delegateOut)
 	}
 
-	res := s.reg.ExecuteCall(context.Background(), s.env, communicateCallArgs("end-turn-warning", map[string]any{
-		"message":  "done for now",
-		"end_turn": true,
-	}))
-	if res.IsError {
-		t.Fatalf("communicate error: %s", res.Output)
-	}
-	var resp map[string]any
-	if err := json.Unmarshal(toolResultJSON(res), &resp); err != nil {
-		t.Fatalf("unmarshal communicate output: %v", err)
-	}
-	warning, ok := resp["warning"].(string)
-	if !ok || warning == "" {
-		t.Fatalf("expected a non-empty warning naming the running shell job and delegate, got: %v", resp)
-	}
-	if !strings.Contains(warning, shellOut.JobID) {
-		t.Fatalf("warning = %q, want it to name shell job id %q", warning, shellOut.JobID)
-	}
+	// Starts the background shell job and asserts the warning names it; the live
+	// delegate must be named alongside it.
+	warning, _ := endTurnWarningWithRunningJob(t, s)
 	if !strings.Contains(warning, delegateOut.DelegateID) {
 		t.Fatalf("warning = %q, want it to name live delegate id %q", warning, delegateOut.DelegateID)
 	}
@@ -339,35 +312,7 @@ func TestCommunicate_EndTurnDoesNotWarnForExitedDetachedProcess(t *testing.T) {
 // sessionRunningJobIDs already gives shell jobs (a session's own job manager
 // only ever lists jobs it launched itself, never a child's).
 func TestCommunicate_EndTurnWarnsForLiveGrandchildDelegate(t *testing.T) {
-	gate := make(chan struct{})
-	childAdapter := &fakeAdapter{
-		name: "openai",
-		steps: []func(llm.Request) llm.Response{
-			func(llm.Request) llm.Response {
-				<-gate
-				return toolCallResponse(communicateCall("grandchild-done", "grandchild done"))
-			},
-		},
-	}
-	childClient := llm.NewClient()
-	childClient.Register(childAdapter)
-	registerTestSessionNamer(childClient)
-
-	root := newSession(t, withConfig(SessionConfig{
-		StateDir:         t.TempDir(),
-		MaxSubagentDepth: 2,
-		NoProjectPrompts: true,
-		TurnEndsProcess:  true,
-		testOnly: testConfig{
-			skipGitSnapshot:     true,
-			minimalSystemPrompt: true,
-			noSyncJobStore:      true,
-			childClientFactory:  func() *llm.Client { return childClient },
-		},
-	}))
-	// Registered after newSession (whose t.Cleanup(sess.Close) ran first): LIFO
-	// releases the grandchild's blocked turn before Close waits on it.
-	t.Cleanup(func() { close(gate) })
+	root := newSessionWithRunningDelegates(t, 2)
 
 	parentRes := root.reg.ExecuteCall(context.Background(), root.env, llm.ToolCallData{
 		ID:        "delegate-parent",

--- a/agent/session_communicate_endturn_oneshot_test.go
+++ b/agent/session_communicate_endturn_oneshot_test.go
@@ -172,6 +172,108 @@ func TestCommunicate_EndTurnWarnsForLiveDetachedProcess(t *testing.T) {
 	}
 }
 
+// TestCommunicate_EndTurnWarnsForLiveDelegate drives a real stable delegate
+// through the delegate tool, holds its single child turn open on a gate, and
+// ends the turn through the real communicate handler while a background shell
+// job is ALSO still running. runningJobIDs only ever named shell jobs (issue
+// #585): a live delegate is session-owned work exactly like a background job,
+// so the warning must name both by id, not just the shell job.
+func TestCommunicate_EndTurnWarnsForLiveDelegate(t *testing.T) {
+	gate := make(chan struct{})
+	childAdapter := &fakeAdapter{
+		name: "openai",
+		steps: []func(llm.Request) llm.Response{
+			func(llm.Request) llm.Response {
+				<-gate
+				return toolCallResponse(communicateCall("child-done", "child done"))
+			},
+		},
+	}
+	childClient := llm.NewClient()
+	childClient.Register(childAdapter)
+	registerTestSessionNamer(childClient)
+
+	s := newSession(t, withConfig(SessionConfig{
+		StateDir:         t.TempDir(),
+		MaxSubagentDepth: 1,
+		NoProjectPrompts: true,
+		TurnEndsProcess:  true,
+		testOnly: testConfig{
+			skipGitSnapshot:     true,
+			minimalSystemPrompt: true,
+			noSyncJobStore:      true,
+			childClientFactory:  func() *llm.Client { return childClient },
+		},
+	}))
+	// Registered after newSession (whose t.Cleanup(sess.Close) ran first): LIFO
+	// releases the child's blocked turn before Close waits on it.
+	t.Cleanup(func() { close(gate) })
+
+	shellRes := s.reg.ExecuteCall(context.Background(), s.env, llm.ToolCallData{
+		ID:        "shell",
+		Name:      "shell",
+		Arguments: json.RawMessage(`{"command":"sleep 30","mode":"background"}`),
+	})
+	if shellRes.IsError {
+		t.Fatalf("shell returned error: %s", shellRes.Output)
+	}
+	var shellOut struct {
+		JobID  string `json:"job_id"`
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(toolResultJSON(shellRes), &shellOut); err != nil {
+		t.Fatalf("unmarshal shell output: %v (output: %s)", err, shellRes.Output)
+	}
+	if shellOut.JobID == "" || shellOut.Status != "running" {
+		t.Fatalf("shell output = %+v, want a running job", shellOut)
+	}
+	t.Cleanup(func() {
+		_, _ = s.jobManager.stop(shellOut.JobID)
+		waitForShellDone(t, s.jobManager, shellOut.JobID)
+	})
+
+	delegateRes := s.reg.ExecuteCall(context.Background(), s.env, llm.ToolCallData{
+		ID:        "delegate",
+		Name:      "delegate",
+		Arguments: json.RawMessage(`{"task":"do something slowly"}`),
+	})
+	if delegateRes.IsError {
+		t.Fatalf("delegate returned error: %s", delegateRes.Output)
+	}
+	var delegateOut struct {
+		DelegateID string `json:"delegate_id"`
+		Status     string `json:"status"`
+	}
+	if err := json.Unmarshal(toolResultJSON(delegateRes), &delegateOut); err != nil {
+		t.Fatalf("unmarshal delegate output: %v (output: %s)", err, delegateRes.Output)
+	}
+	if delegateOut.DelegateID == "" || delegateOut.Status != "running" {
+		t.Fatalf("delegate output = %+v, want a running delegate", delegateOut)
+	}
+
+	res := s.reg.ExecuteCall(context.Background(), s.env, communicateCallArgs("end-turn-warning", map[string]any{
+		"message":  "done for now",
+		"end_turn": true,
+	}))
+	if res.IsError {
+		t.Fatalf("communicate error: %s", res.Output)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(toolResultJSON(res), &resp); err != nil {
+		t.Fatalf("unmarshal communicate output: %v", err)
+	}
+	warning, ok := resp["warning"].(string)
+	if !ok || warning == "" {
+		t.Fatalf("expected a non-empty warning naming the running shell job and delegate, got: %v", resp)
+	}
+	if !strings.Contains(warning, shellOut.JobID) {
+		t.Fatalf("warning = %q, want it to name shell job id %q", warning, shellOut.JobID)
+	}
+	if !strings.Contains(warning, delegateOut.DelegateID) {
+		t.Fatalf("warning = %q, want it to name live delegate id %q", warning, delegateOut.DelegateID)
+	}
+}
+
 func TestCommunicate_EndTurnDoesNotWarnForExitedDetachedProcess(t *testing.T) {
 	s := newSession(t, withConfig(SessionConfig{
 		MaxSubagentDepth: 1,

--- a/agent/session_tools_communicate.go
+++ b/agent/session_tools_communicate.go
@@ -137,8 +137,9 @@ func registerCommunicateTool(reg *tool.Registry, deps *toolDeps) {
 }
 
 // runningJobsEndTurnWarning builds the end_turn=true warning naming this
-// session's still-running managed jobs or detached processes. Warn-first (2026-08-06 ruling): the
-// communicate call still succeeds, there is no refusal path.
+// session's still-running managed jobs, detached processes, or live stable
+// delegates. Warn-first (2026-08-06 ruling): the communicate call still
+// succeeds, there is no refusal path.
 //
 // The promise the warning can make depends on whether the session outlives the
 // turn. Where it does, the warning complements docs/job-control.md's
@@ -152,16 +153,23 @@ func registerCommunicateTool(reg *tool.Registry, deps *toolDeps) {
 // reprieve — so this warning must not imply the job is safe.
 func runningJobsEndTurnWarning(jobIDs []string, turnEndsProcess bool) string {
 	detached := false
+	delegate := false
 	for _, id := range jobIDs {
 		if strings.HasPrefix(id, "detached process ") {
 			detached = true
-			break
+		}
+		if strings.HasPrefix(id, "delegate ") {
+			delegate = true
 		}
 	}
-	noun := "job(s)"
+	nouns := []string{"job(s)"}
 	if detached {
-		noun = "job(s) or detached process(es)"
+		nouns = append(nouns, "detached process(es)")
 	}
+	if delegate {
+		nouns = append(nouns, "delegate(s)")
+	}
+	noun := strings.Join(nouns, " or ")
 	outcome := "each job remains notification-armed and will report separately on completion."
 	if turnEndsProcess {
 		outcome = "a job that finishes is reported in a further turn, but this run's process exits once that work is drained, so a job that keeps running is killed at exit rather than reported on later."

--- a/agent/session_tools_jobs.go
+++ b/agent/session_tools_jobs.go
@@ -1837,18 +1837,34 @@ func sessionRunningWorkIDs(s *Session) []string {
 }
 
 // runningStableDelegateIDs returns the running stable delegates this session
-// owns, named "delegate <id>" to match delegateActor.describe's convention for
-// naming a delegate in user-facing text. This is an owner-authoritative read
-// straight off the delegate controller's snapshot (the same source status.go
-// and jobs_activity.go use to list a session's own delegates), not the job
-// manager: delegates never mint job store rows.
+// directly spawned, named "delegate <id>" to match delegateActor.describe's
+// convention for naming a delegate in user-facing text. This is an
+// owner-authoritative read straight off the delegate controller's snapshot,
+// not the job manager: delegates never mint job store rows.
+//
+// Descriptor.OwnerSessionID is the TREE'S ROOT session id on every row in the
+// tree, not the immediate parent (delegate_tree_start.go's ReserveCreate sets
+// it once to c.rootSessionID regardless of which session or delegate created
+// the row) — so it only scopes "same tree", not "my child". The direct-parent
+// link is Descriptor.ParentDelegateID, which blockingDelegateIDs already uses
+// the same way to find "this session's direct child delegates"; s.owningDelegateID
+// is empty for the root session (root's own rows have ParentDelegateID ""), so
+// this one filter naturally covers both the root and every descendant with no
+// special-casing. Each session is scoped to its own DIRECT children only, not
+// the whole subtree: end_turn is about what this session itself is holding
+// open, not what any of its descendants are separately responsible for
+// reporting on when they end their own turns — the same direct-only scope
+// sessionRunningJobIDs already gives shell jobs (each session's own job
+// manager only ever lists jobs it launched itself).
 func (s *Session) runningStableDelegateIDs() []string {
 	if s == nil || s.delegateController == nil {
 		return nil
 	}
 	var ids []string
 	for _, row := range s.delegateController.Snapshot().rows {
-		if row.descriptor.OwnerSessionID == s.ID() && row.lifecycle == delegateLifecycleRunning {
+		if row.descriptor.OwnerSessionID == s.delegateRootSessionID &&
+			row.descriptor.ParentDelegateID == s.owningDelegateID &&
+			row.lifecycle == delegateLifecycleRunning {
 			ids = append(ids, "delegate "+row.id)
 		}
 	}

--- a/agent/session_tools_jobs.go
+++ b/agent/session_tools_jobs.go
@@ -1826,13 +1826,33 @@ func sessionRunningJobIDs(s *Session) []string {
 	return ids
 }
 
-// sessionRunningWorkIDs combines managed jobs with detached processes owned by
-// this session. Detached processes deliberately stay out of the job manager and
-// drain accounting, but an end_turn warning must still name one while its own
-// completion receipt is open.
+// sessionRunningWorkIDs combines managed jobs with detached processes and live
+// stable delegates owned by this session. Detached processes and delegates
+// deliberately stay out of the job manager and drain accounting, but an
+// end_turn warning must still name one while it is still live.
 func sessionRunningWorkIDs(s *Session) []string {
 	ids := sessionRunningJobIDs(s)
-	return append(ids, s.runningDetachedProcessIDs()...)
+	ids = append(ids, s.runningDetachedProcessIDs()...)
+	return append(ids, s.runningStableDelegateIDs()...)
+}
+
+// runningStableDelegateIDs returns the running stable delegates this session
+// owns, named "delegate <id>" to match delegateActor.describe's convention for
+// naming a delegate in user-facing text. This is an owner-authoritative read
+// straight off the delegate controller's snapshot (the same source status.go
+// and jobs_activity.go use to list a session's own delegates), not the job
+// manager: delegates never mint job store rows.
+func (s *Session) runningStableDelegateIDs() []string {
+	if s == nil || s.delegateController == nil {
+		return nil
+	}
+	var ids []string
+	for _, row := range s.delegateController.Snapshot().rows {
+		if row.descriptor.OwnerSessionID == s.ID() && row.lifecycle == delegateLifecycleRunning {
+			ids = append(ids, "delegate "+row.id)
+		}
+	}
+	return ids
 }
 
 func (s *Session) recordDetachedProcess(process execenv.DetachedProcess) {


### PR DESCRIPTION
Fixes #585. communicate(end_turn=true)'s running-work warning enumerated shell jobs and detached processes but never a session's live child delegates, so a turn ended while a delegate was still working with no warning. runningStableDelegateIDs now names each session's direct running delegates, folded into the same warning.

Pipeline provenance: adversarial review REFUTED round 1 (the first filter, OwnerSessionID == s.ID(), only ever matched the tree root — OwnerSessionID is set once to the root for every delegate — so every non-root session ending its turn silently warned about nothing, and the depth-1 test couldn't see it); round 2 re-derived the filter on ParentDelegateID == s.owningDelegateID (the same link blockingDelegateIDs uses; empty-for-root covers all sessions uniformly) and chose direct-children-only to match the shell-job half's established scope, with a depth-2 test proven red both directions (missing warning AND transitive overreach). Simplify shared the test scaffolding. A flagged empty-rootSessionID edge was verified unreachable (the controller-nil guard precedes it). Direct-vs-transitive is a deliberate, documented call for your review.