### PR TITLE
agent: attribute model-switch live listing to the live session id

### DIFF
--- a/agent/apilog_session_attribution_test.go
+++ b/agent/apilog_session_attribution_test.go
@@ -499,14 +499,19 @@ func newModelSwitchAttributionSession(t *testing.T, client *llm.Client, stateDir
 }
 
 // TestModelSwitchLiveListingAttribution pins issue #754: resolveModelSwitchTarget
-// (agent/session_set_model.go), used by SetModel and by subagent
-// explicit-model-override selection (selectSubagentModel), lists the switch
-// target's instance with a bare context.Background() even though every call
-// site runs on an already-existing session with a real s.id in scope — the
-// same unattributed-API-log defect TestPreSessionLiveModelListingAttribution
-// pins for pre-session listings (issue #745 / PR #752), but here session
-// attribution is trivially available rather than sometimes structurally
-// absent.
+// (agent/session_set_model.go), used by SetModel and by both
+// resolveModelSwitchTarget call sites inside selectSubagentModel — the plain
+// explicit-override path (subagent_model_selection.go:117) and the
+// plugin-agent-resolution-failed fallback path (subagent_model_selection.go:74)
+// — lists the switch target's instance with a bare context.Background() even
+// though every call site runs on an already-existing session with a real
+// s.id in scope. Same unattributed-API-log defect
+// TestPreSessionLiveModelListingAttribution pins for pre-session listings
+// (issue #745 / PR #752), but here session attribution is trivially
+// available rather than sometimes structurally absent. All three call sites
+// get the identical one-line fix, so all three are pinned here rather than
+// just the shared helper: a fix applied to two of the three call sites would
+// still leave the third silently unattributed.
 func TestModelSwitchLiveListingAttribution(t *testing.T) {
 	t.Run("SetModel", func(t *testing.T) {
 		stateDir := t.TempDir()
@@ -529,7 +534,7 @@ func TestModelSwitchLiveListingAttribution(t *testing.T) {
 		assertSessionAPILogAttributed(t, stateDir, sess.ID())
 	})
 
-	t.Run("subagent explicit model override", func(t *testing.T) {
+	t.Run("subagent explicit model override (no plugin agent, :117)", func(t *testing.T) {
 		stateDir := t.TempDir()
 		client := llm.NewClient()
 		client.Register(&fakeAdapter{name: "openai", liveModels: attemptRecordingLiveModels("openai")})
@@ -542,6 +547,52 @@ func TestModelSwitchLiveListingAttribution(t *testing.T) {
 		sess := newModelSwitchAttributionSession(t, client, stateDir)
 		if _, err := sess.selectSubagentModel(context.Background(), "gpt-5.2", ""); err != nil {
 			t.Fatalf("selectSubagentModel: %v", err)
+		}
+
+		if err := logger.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		assertSessionAPILogAttributed(t, stateDir, sess.ID())
+	})
+
+	// This subtest drives selectSubagentModel's OTHER resolveModelSwitchTarget
+	// call site: the plugin-fallback branch at subagent_model_selection.go:74,
+	// reached only when a plugin agent is named, its own Model resolution
+	// fails (resolvePluginAgentModel returns a non-empty reason), and an
+	// explicit override model is also supplied. The plugin's requested model
+	// ("gpt-9.9-plugin-unavailable") names nothing any instance serves, so
+	// resolvePluginAgentRef rejects it before any listing (reason
+	// "unavailable", mirroring TestSelectSubagentModel_PluginAvailabilityPrecedence's
+	// "unservable plugin model is refused without listing" case) — the only
+	// live listing this subtest drives is the explicit override's, at :74.
+	t.Run("subagent plugin-fallback model override (:74)", func(t *testing.T) {
+		stateDir := t.TempDir()
+		client := llm.NewClient()
+		client.Register(&fakeAdapter{name: "openai", liveModels: attemptRecordingLiveModels("openai")})
+		logger, err := llm.NewSessionAPILogger(stateDir)
+		if err != nil {
+			t.Fatalf("NewSessionAPILogger: %v", err)
+		}
+		client.Use(logger)
+
+		sess := newModelSwitchAttributionSession(t, client, stateDir)
+		sess.pluginAgents = map[string]plugin.Agent{
+			"reviewer": {
+				Name:       "reviewer",
+				Model:      "gpt-9.9-plugin-unavailable",
+				PluginName: "test-plugin",
+			},
+		}
+
+		selected, err := sess.selectSubagentModel(context.Background(), "gpt-5.2", "reviewer")
+		if err != nil {
+			t.Fatalf("selectSubagentModel: %v", err)
+		}
+		if selected.warning == nil {
+			t.Fatal("expected a plugin-fallback warning (proves the :74 branch ran), got nil")
+		}
+		if selected.profile.Model() != "gpt-5.2" {
+			t.Fatalf("selected model = %q, want the explicit fallback %q", selected.profile.Model(), "gpt-5.2")
 		}
 
 		if err := logger.Close(); err != nil {

--- a/agent/apilog_session_attribution_test.go
+++ b/agent/apilog_session_attribution_test.go
@@ -474,6 +474,83 @@ func TestNewSessionAttributesOtherProviderStartupListingToSessionAPILog(t *testi
 	}
 }
 
+// newModelSwitchAttributionSession builds a session whose id is pre-reserved
+// (the same cfg.spawn.sessionID contract TestPreSessionLiveModelListingAttribution's
+// delegate subtest uses), so NewSession's own construction-time listing lands
+// in the session's own log rather than the unattributed bucket. That keeps
+// the unattributed bucket untouched by anything but the switch-path listing a
+// TestModelSwitchLiveListingAttribution subtest drives afterward, letting it
+// reuse assertSessionAPILogAttributed unmodified.
+func newModelSwitchAttributionSession(t *testing.T, client *llm.Client, stateDir string) *Session {
+	t.Helper()
+	cfg := SessionConfig{
+		MaxSubagentDepth: 1,
+		NoProjectPrompts: true,
+		StateDir:         stateDir,
+		testOnly:         testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true},
+	}
+	cfg.spawn.sessionID = identifier.MustNewSessionID()
+	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), cfg)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	t.Cleanup(func() { sess.Close() })
+	return sess
+}
+
+// TestModelSwitchLiveListingAttribution pins issue #754: resolveModelSwitchTarget
+// (agent/session_set_model.go), used by SetModel and by subagent
+// explicit-model-override selection (selectSubagentModel), lists the switch
+// target's instance with a bare context.Background() even though every call
+// site runs on an already-existing session with a real s.id in scope — the
+// same unattributed-API-log defect TestPreSessionLiveModelListingAttribution
+// pins for pre-session listings (issue #745 / PR #752), but here session
+// attribution is trivially available rather than sometimes structurally
+// absent.
+func TestModelSwitchLiveListingAttribution(t *testing.T) {
+	t.Run("SetModel", func(t *testing.T) {
+		stateDir := t.TempDir()
+		client := llm.NewClient()
+		client.Register(&fakeAdapter{name: "openai", liveModels: attemptRecordingLiveModels("openai")})
+		logger, err := llm.NewSessionAPILogger(stateDir)
+		if err != nil {
+			t.Fatalf("NewSessionAPILogger: %v", err)
+		}
+		client.Use(logger)
+
+		sess := newModelSwitchAttributionSession(t, client, stateDir)
+		if err := sess.SetModel("gpt-5.2"); err != nil {
+			t.Fatalf("SetModel: %v", err)
+		}
+
+		if err := logger.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		assertSessionAPILogAttributed(t, stateDir, sess.ID())
+	})
+
+	t.Run("subagent explicit model override", func(t *testing.T) {
+		stateDir := t.TempDir()
+		client := llm.NewClient()
+		client.Register(&fakeAdapter{name: "openai", liveModels: attemptRecordingLiveModels("openai")})
+		logger, err := llm.NewSessionAPILogger(stateDir)
+		if err != nil {
+			t.Fatalf("NewSessionAPILogger: %v", err)
+		}
+		client.Use(logger)
+
+		sess := newModelSwitchAttributionSession(t, client, stateDir)
+		if _, err := sess.selectSubagentModel(context.Background(), "gpt-5.2", ""); err != nil {
+			t.Fatalf("selectSubagentModel: %v", err)
+		}
+
+		if err := logger.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		assertSessionAPILogAttributed(t, stateDir, sess.ID())
+	})
+}
+
 func TestSessionSettlesProviderResolutionFailureBeforeTransport(t *testing.T) {
 	stateDir := t.TempDir()
 	client := llm.NewClient()

--- a/agent/session.go
+++ b/agent/session.go
@@ -1190,7 +1190,7 @@ func (s *Session) SetModel(model string) error {
 	// the membership preflight below (see resolveModelSwitchTarget) — this
 	// rejects before any state changes when the target instance can
 	// enumerate its models and the requested model isn't among them.
-	nextProfile, err = resolveModelSwitchTarget(client, nextProfile)
+	nextProfile, err = resolveModelSwitchTarget(client, nextProfile, s.id)
 	if err != nil {
 		return err
 	}

--- a/agent/session_set_model.go
+++ b/agent/session_set_model.go
@@ -80,9 +80,17 @@ const modelSwitchEnumerationTimeout = 8 * time.Second
 // the network latency/timeout budget per switch and open a TOCTOU window where
 // the provider's model list could change between the metadata-fill call and
 // the membership-check call, letting the two disagree about availability.
-func resolveModelSwitchTarget(client *llm.Client, profile *provider.Profile) (*provider.Profile, error) {
+// sessionID attributes the canonical API-log attempt this listing produces
+// (llm.WithAPILogContext), matching resolveLiveModelProfileWithEnumerationTimeout's
+// pre-session counterpart — every caller here (SetModel, subagent model
+// selection) runs on an already-existing session, so sessionID is always that
+// session's own id.
+func resolveModelSwitchTarget(client *llm.Client, profile *provider.Profile, sessionID string) (*provider.Profile, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), modelSwitchEnumerationTimeout)
 	defer cancel()
+	if sessionID != "" {
+		ctx = llm.WithAPILogContext(ctx, sessionID)
+	}
 	filled, enumeration := fillLiveModelMetadata(ctx, client, profile)
 	if enumeration.err != nil {
 		// Fail open unconditionally: an instance that cannot be listed at all

--- a/agent/subagent_model_selection.go
+++ b/agent/subagent_model_selection.go
@@ -71,7 +71,7 @@ func (s *Session) selectSubagentModel(
 			if crossProvider {
 				resolved = resolved.WithCommunicateOverridesFrom(base)
 			}
-			resolved, err = resolveModelSwitchTarget(s.client, resolved)
+			resolved, err = resolveModelSwitchTarget(s.client, resolved, s.id)
 			if err != nil {
 				return subagentModelSelection{}, fmt.Errorf("model override %q: %w", explicitModel, err)
 			}
@@ -114,7 +114,7 @@ func (s *Session) selectSubagentModel(
 	if crossProvider {
 		resolved = resolved.WithCommunicateOverridesFrom(base)
 	}
-	resolved, err = resolveModelSwitchTarget(s.client, resolved)
+	resolved, err = resolveModelSwitchTarget(s.client, resolved, s.id)
 	if err != nil {
 		return subagentModelSelection{}, fmt.Errorf("model override %q: %w", explicitModel, err)
 	}


### PR DESCRIPTION
Fixes #754. resolveModelSwitchTarget issued its live model listing with a bare context.Background() on an already-live session, so the canonical API-log attempt landed in unattributed.api.jsonl even though s.id was in scope — the same defect PR #752 fixed for pre-session listings. Threads sessionID through, wrapping with llm.WithAPILogContext, at all three call sites (SetModel + both selectSubagentModel branches).

Pipeline provenance: adversarial review SURVIVES (proven, not asserted — the s.id-non-empty invariant traced from NewSession's construction order, the ctx forwarding verified against context.WithValue semantics, fidelity to #752 confirmed byte-for-byte). One actionable Minor (the subagent subtest covered 2 of 3 call sites) closed in a micro round with an isolating sed red-check; all 3 sites now individually pinned. Simplify pass NO-OP (the sessionID guard is load-bearing, the shared test setup is the file's dominant convention). A pre-existing sibling (resolvePluginAgentModel's :148 listing, correctly attributed via turn-ctx but untested) filed as #799.