### PR TITLE
fuzz-harvest: never harvest a credential carried in a URL path (/auth)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -33,6 +33,7 @@ regexes = [
   '''sk-LIVETEST[0-9a-f]*''',       # fake illustrative key in subagent fixtures + design docs
   '''a\.eyJlbWFpbCI6ImpAZXhhbXBsZS5jb20ifQ\.sig''', # fake JWT ({"email":"j@example.com"}) in auth/openai fuzz seeds
   '''att_02wMz5TxuyedWwYBSOAa[0-9a-z]*''', # deterministic attempt-id fixtures in cmd/evener-doctor/main_test.go, not keys
+  '''synTHETIC_9mK3vL8pR2nW5tY0cF6hJ4bD1gA7eSqZx''', # fake hub-token-shaped fixture proving #795's /auth guard, cmd/evener-fuzz-harvest/coverage_test.go
 ]
 
 # The seed corpora are deliberately NOT path-allowlisted: that would make

--- a/cmd/evener-fuzz-harvest/coverage_test.go
+++ b/cmd/evener-fuzz-harvest/coverage_test.go
@@ -231,21 +231,15 @@ func scenarioReverseHTTPNoMatchAndBadQuery(t *testing.T) {
 	}
 }
 
-// A hub bearer token riding in the URL path (as /auth/<token> authenticates,
-// cmd/evener-hub/internal/hubedge.HandleAuth) has no entry in
-// fuzzReadOnlyRoutes, so without a guard it falls through reverseMapHTTP's
-// longest-prefix match to the "/" catch-all and its suffix — the token itself
-// — is gated by gateString with entropyCheck hard-disabled, which only the
-// known-secret regexes (harvest.go/sanitize.go) can catch, and none matches a
-// bare high-entropy token. Regression for issue #795: the token must never
-// survive into a committed corpus seed. Uses a synthetic token, never a real
-// one.
-func scenarioReverseHTTPAuthPathTokenNeverHarvested(t *testing.T) {
-	const syntheticToken = "synTHETIC_9mK3vL8pR2nW5tY0cF6hJ4bD1gA7eSqZx" // fake; base64url-shaped, ~43 chars like a real hub token
-
+// assertAuthPathTokenNotHarvested harvests a single recorded GET to authPath
+// (which must embed token) and fails if token appears anywhere in the
+// written corpus tree. Shared by the canonical-case and re-cased-path leak
+// regressions below.
+func assertAuthPathTokenNotHarvested(t *testing.T, authPath, token string) {
+	t.Helper()
 	d := t.TempDir()
 	log := filepath.Join(d, "http")
-	mustHarvestWrite(t, log, marshalLine(t, recordedHTTPRequest{Method: "GET", Path: "/auth/" + syntheticToken})+"\n")
+	mustHarvestWrite(t, log, marshalLine(t, recordedHTTPRequest{Method: "GET", Path: authPath})+"\n")
 
 	out := t.TempDir()
 	r := newRunner(out, NewEmitter(false, defaultMaxSeedBytes), nil)
@@ -259,11 +253,39 @@ func scenarioReverseHTTPAuthPathTokenNeverHarvested(t *testing.T) {
 		if rerr != nil {
 			return nil //nolint:nilerr
 		}
-		if bytes.Contains(raw, []byte(syntheticToken)) {
-			t.Fatalf("synthetic auth token leaked into committed seed %s:\n%s", path, raw)
+		if bytes.Contains(raw, []byte(token)) {
+			t.Fatalf("token leaked into committed seed %s:\n%s", path, raw)
 		}
 		return nil
 	})
+}
+
+// A hub bearer token riding in the URL path (as /auth/<token> authenticates,
+// cmd/evener-hub/internal/hubedge.HandleAuth) has no entry in
+// fuzzReadOnlyRoutes, so without a guard it falls through reverseMapHTTP's
+// longest-prefix match to the "/" catch-all and its suffix — the token itself
+// — is gated by gateString with entropyCheck hard-disabled, which only the
+// known-secret regexes (harvest.go/sanitize.go) can catch, and none matches a
+// bare high-entropy token. Regression for issue #795: the token must never
+// survive into a committed corpus seed. Uses a synthetic token, never a real
+// one.
+func scenarioReverseHTTPAuthPathTokenNeverHarvested(t *testing.T) {
+	const syntheticToken = "synTHETIC_9mK3vL8pR2nW5tY0cF6hJ4bD1gA7eSqZx" // fake; base64url-shaped, ~43 chars like a real hub token
+	assertAuthPathTokenNotHarvested(t, "/auth/"+syntheticToken, syntheticToken)
+}
+
+// isAuthBootstrapPath's match is case-insensitive (strings.ToLower before
+// comparing), so a manually re-cased /Auth/<token> is excluded from harvest
+// exactly like the canonical-case form. Neither hubedge's real mux nor
+// AuthGuard is case-insensitive (a re-cased request 401s and never actually
+// authenticates — net/http.ServeMux pattern matching is byte-exact), so this
+// doesn't widen what a "real" leak looks like; it keeps redaction
+// conservative for a shape that could still carry a genuine, copied token if
+// something upstream (a note app's autocapitalize, a manual edit) re-cased
+// the URL before it was requested. adv-795-completeness.md Finding 2.
+func scenarioReverseHTTPAuthPathTokenCaseInsensitive(t *testing.T) {
+	const syntheticToken = "sYNtheTIC_caseVariant7hJ4bD1gA9eSqZxK3vL8pR" // fake; distinct from the canonical-case test's token
+	assertAuthPathTokenNotHarvested(t, "/Auth/"+syntheticToken, syntheticToken)
 }
 
 // A legitimate high-entropy path component on an ordinary (non-/auth) route —
@@ -285,6 +307,43 @@ func scenarioReverseHTTPLegitimateSessionSuffixNotRedacted(t *testing.T) {
 
 	if st := r.stat("http"); st.seeds != 1 || st.leaks != 0 {
 		t.Fatalf("legitimate session-shaped suffix was over-redacted: seeds=%d leaks=%d skipped=%d", st.seeds, st.leaks, st.skipped)
+	}
+}
+
+// isAuthBootstrapPath hand-duplicates hubedge's /auth recognition with no
+// shared source of truth: cmd/evener-fuzz-harvest cannot import
+// cmd/evener-hub/internal/hubedge to check against the real thing, because
+// Go's internal/ visibility rule restricts that package to importers rooted
+// at cmd/evener-hub/, and this package lives outside that subtree (there is
+// no exported constant elsewhere either side could share — confirmed by
+// adv-795-completeness.md Finding 1). Absent a compiler-enforced link, this
+// table pins isAuthBootstrapPath's exact accept/reject contract instead, so
+// a future edit that narrows or widens what counts as the auth bootstrap
+// path breaks this test rather than silently reopening issue #795's leak.
+func scenarioIsAuthBootstrapPathShapes(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/auth", true},                      // bare, exact (today's main form)
+		{"/auth/tok123", true},               // path-token form (PR #431)
+		{"/auth/tok123/extra", true},         // prefix match; trailing garbage ignored
+		{"/auth/tok123/", true},              // trailing slash
+		{"/Auth/tok123", true},               // re-cased path form
+		{"/AUTH", true},                      // re-cased bare form
+		{"/aUtH/tok123", true},               // mixed case
+		{"", false},                          // empty
+		{"/", false},                         // root
+		{"/authorize", false},                // "auth"-prefixed but a different segment
+		{"/Authorize", false},                // same, re-cased
+		{"/authx", false},                    // same, no separator at all
+		{"/s/034H8eMmMT7fAzLo5EkvY3", false}, // ordinary route
+		{"/api/health", false},               // another exempt-but-unrelated route
+	}
+	for _, c := range cases {
+		if got := isAuthBootstrapPath(c.path); got != c.want {
+			t.Errorf("isAuthBootstrapPath(%q) = %v, want %v", c.path, got, c.want)
+		}
 	}
 }
 

--- a/cmd/evener-fuzz-harvest/coverage_test.go
+++ b/cmd/evener-fuzz-harvest/coverage_test.go
@@ -231,6 +231,63 @@ func scenarioReverseHTTPNoMatchAndBadQuery(t *testing.T) {
 	}
 }
 
+// A hub bearer token riding in the URL path (as /auth/<token> authenticates,
+// cmd/evener-hub/internal/hubedge.HandleAuth) has no entry in
+// fuzzReadOnlyRoutes, so without a guard it falls through reverseMapHTTP's
+// longest-prefix match to the "/" catch-all and its suffix — the token itself
+// — is gated by gateString with entropyCheck hard-disabled, which only the
+// known-secret regexes (harvest.go/sanitize.go) can catch, and none matches a
+// bare high-entropy token. Regression for issue #795: the token must never
+// survive into a committed corpus seed. Uses a synthetic token, never a real
+// one.
+func scenarioReverseHTTPAuthPathTokenNeverHarvested(t *testing.T) {
+	const syntheticToken = "synTHETIC_9mK3vL8pR2nW5tY0cF6hJ4bD1gA7eSqZx" // fake; base64url-shaped, ~43 chars like a real hub token
+
+	d := t.TempDir()
+	log := filepath.Join(d, "http")
+	mustHarvestWrite(t, log, marshalLine(t, recordedHTTPRequest{Method: "GET", Path: "/auth/" + syntheticToken})+"\n")
+
+	out := t.TempDir()
+	r := newRunner(out, NewEmitter(false, defaultMaxSeedBytes), nil)
+	harvestHTTP(r, []string{log})
+
+	_ = filepath.WalkDir(out, func(path string, ent fs.DirEntry, err error) error { //nolint:errcheck
+		if err != nil || ent.IsDir() {
+			return nil //nolint:nilerr // skip unreadable/dir entries during the scan
+		}
+		raw, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil //nolint:nilerr
+		}
+		if bytes.Contains(raw, []byte(syntheticToken)) {
+			t.Fatalf("synthetic auth token leaked into committed seed %s:\n%s", path, raw)
+		}
+		return nil
+	})
+}
+
+// A legitimate high-entropy path component on an ordinary (non-/auth) route —
+// e.g. a session ID in /s/<id>, the same 22-char base62 shape
+// identifier.NewSessionID produces — must still be harvested normally. This
+// guards against "fixing" #795 by broadly enabling entropyCheck for the http
+// surface instead of excluding /auth: session IDs routinely exceed the
+// entropy threshold, so that approach would drop most legitimate
+// session-ID-bearing seeds across every route, not just /auth.
+func scenarioReverseHTTPLegitimateSessionSuffixNotRedacted(t *testing.T) {
+	const sessionLikeSuffix = "034H8eMmMT7fAzLo5EkvY3" // synthetic; 22-char base62 shape (see identifier.NewSessionID)
+
+	d := t.TempDir()
+	log := filepath.Join(d, "http")
+	mustHarvestWrite(t, log, marshalLine(t, recordedHTTPRequest{Method: "GET", Path: "/s/" + sessionLikeSuffix})+"\n")
+
+	r := newRunner(t.TempDir(), NewEmitter(false, defaultMaxSeedBytes), nil)
+	harvestHTTP(r, []string{log})
+
+	if st := r.stat("http"); st.seeds != 1 || st.leaks != 0 {
+		t.Fatalf("legitimate session-shaped suffix was over-redacted: seeds=%d leaks=%d skipped=%d", st.seeds, st.leaks, st.skipped)
+	}
+}
+
 func scenarioForEachJSONLineOpenAndEmpty(t *testing.T) {
 	if err := forEachJSONLine(filepath.Join(t.TempDir(), "missing"), func([]byte) {}); err == nil {
 		t.Fatal("open")

--- a/cmd/evener-fuzz-harvest/http.go
+++ b/cmd/evener-fuzz-harvest/http.go
@@ -61,16 +61,15 @@ func reverseMapHTTP(method, reqPath, rawQuery string) (uint8, string, bool) {
 		return 0, "", false
 	}
 	if isAuthBootstrapPath(reqPath) {
-		// /auth and /auth/<token> authenticate the request (see
-		// cmd/evener-hub/internal/hubedge.HandleAuth); the token itself rides
-		// in the path. /auth has no entry in fuzzReadOnlyRoutes, so without
-		// this guard it falls through the longest-prefix match below to the
-		// "/" catch-all and the token becomes the harvested suffix — gated
+		// /auth has no entry in fuzzReadOnlyRoutes, so without this guard it
+		// falls through the longest-prefix match below to the "/" catch-all
+		// and a path-carried credential becomes the harvested suffix — gated
 		// only by known-secret regexes (entropy-checking is off for this
 		// surface; see gateString), none of which matches a bare high-entropy
 		// token. Drop it instead: /auth was never a fuzzed route anyway
 		// (AuthGuard intercepts it ahead of the SPA shell), so this costs no
-		// coverage. Issue #795.
+		// coverage. See isAuthBootstrapPath's doc comment for what this
+		// matches and why. Issue #795.
 		return 0, "", false
 	}
 	best := -1
@@ -98,11 +97,30 @@ func reverseMapHTTP(method, reqPath, rawQuery string) (uint8, string, bool) {
 }
 
 // isAuthBootstrapPath reports whether reqPath is the hub's auth bootstrap
-// endpoint: bare /auth or /auth/<token>. Mirrors how AuthGuard recognizes it
-// (cmd/evener-hub/internal/hubedge/auth_token.go's isAuthExempt checks the
-// bare form; HandleAuth's mux registration and its
-// strings.TrimPrefix(r.URL.Path, "/auth/") define the path-token form). Not
-// importable directly: hubedge is internal to cmd/evener-hub.
+// endpoint: bare /auth or /auth/<token>, matched case-insensitively so a
+// manually re-cased path (e.g. /Auth/<token>) is excluded too — see
+// scenarioReverseHTTPAuthPathTokenCaseInsensitive. hubedge's real router
+// isn't case-insensitive (net/http.ServeMux is byte-exact, so a re-cased
+// request just 401s), but redaction stays conservative regardless of whether
+// the shape could authenticate today.
+//
+// hubedge's own recognition of this path is split across two states.
+// Today, on main, isAuthExempt (cmd/evener-hub/internal/hubedge/auth_token.go)
+// matches only the bare "/auth" case, and HandleAuth reads the token from
+// the query string. The not-yet-merged PR #431 adds the /auth/<token> path
+// form (HandleAuth's strings.TrimPrefix(r.URL.Path, "/auth/")) and a
+// matching "/auth/" mux registration. isAuthBootstrapPath covers both so
+// this guard already holds once 431 lands (issue #795's own gating note:
+// "#431 must not merge until this lands").
+//
+// This can't import hubedge to check itself against the original: hubedge
+// is internal to cmd/evener-hub, and this package lives outside that
+// subtree (Go's internal/ visibility rule), so there is no shared constant
+// or function either side can reference — this is a second, hand-maintained
+// encoding of the same fact. scenarioIsAuthBootstrapPathShapes pins its
+// exact accept/reject contract so a future /auth shape change here fails a
+// test instead of silently reopening this issue's leak.
 func isAuthBootstrapPath(reqPath string) bool {
-	return reqPath == "/auth" || strings.HasPrefix(reqPath, "/auth/")
+	lower := strings.ToLower(reqPath)
+	return lower == "/auth" || strings.HasPrefix(lower, "/auth/")
 }

--- a/cmd/evener-fuzz-harvest/http.go
+++ b/cmd/evener-fuzz-harvest/http.go
@@ -60,6 +60,19 @@ func reverseMapHTTP(method, reqPath, rawQuery string) (uint8, string, bool) {
 	if method != http.MethodGet {
 		return 0, "", false
 	}
+	if isAuthBootstrapPath(reqPath) {
+		// /auth and /auth/<token> authenticate the request (see
+		// cmd/evener-hub/internal/hubedge.HandleAuth); the token itself rides
+		// in the path. /auth has no entry in fuzzReadOnlyRoutes, so without
+		// this guard it falls through the longest-prefix match below to the
+		// "/" catch-all and the token becomes the harvested suffix — gated
+		// only by known-secret regexes (entropy-checking is off for this
+		// surface; see gateString), none of which matches a bare high-entropy
+		// token. Drop it instead: /auth was never a fuzzed route anyway
+		// (AuthGuard intercepts it ahead of the SPA shell), so this costs no
+		// coverage. Issue #795.
+		return 0, "", false
+	}
 	best := -1
 	for i, base := range fuzzReadOnlyRoutes {
 		if strings.HasPrefix(reqPath, base) && (best < 0 || len(base) > len(fuzzReadOnlyRoutes[best])) {
@@ -82,4 +95,14 @@ func reverseMapHTTP(method, reqPath, rawQuery string) (uint8, string, bool) {
 		rem = dec
 	}
 	return uint8(best), rem, true
+}
+
+// isAuthBootstrapPath reports whether reqPath is the hub's auth bootstrap
+// endpoint: bare /auth or /auth/<token>. Mirrors how AuthGuard recognizes it
+// (cmd/evener-hub/internal/hubedge/auth_token.go's isAuthExempt checks the
+// bare form; HandleAuth's mux registration and its
+// strings.TrimPrefix(r.URL.Path, "/auth/") define the path-token form). Not
+// importable directly: hubedge is internal to cmd/evener-hub.
+func isAuthBootstrapPath(reqPath string) bool {
+	return reqPath == "/auth" || strings.HasPrefix(reqPath, "/auth/")
 }

--- a/cmd/evener-fuzz-harvest/program_fuzz_test.go
+++ b/cmd/evener-fuzz-harvest/program_fuzz_test.go
@@ -10,6 +10,7 @@ func FuzzHarvestProgram(f *testing.F) {
 		scenarioGitleaksScanOutcomes, scenarioHarvestLeakExitAndSmallHelpers, scenarioEmitterWriteFileFailure,
 		scenarioHarvesterInjectedSanitizeAndEmitFailures, scenarioReverseHTTPNoMatchAndBadQuery,
 		scenarioReverseHTTPAuthPathTokenNeverHarvested, scenarioReverseHTTPLegitimateSessionSuffixNotRedacted,
+		scenarioReverseHTTPAuthPathTokenCaseInsensitive, scenarioIsAuthBootstrapPathShapes,
 		scenarioForEachJSONLineOpenAndEmpty, scenarioRemainingFilesystemAndGateBranches,
 		scenarioRunLogAndPersonalKeepNote, scenarioToolArgsSecondDecodeAndSanitizeFailure,
 		scenarioHarvestRunInjectedOutcomes, scenarioRunnerFailureAccountingAndHelpers,

--- a/cmd/evener-fuzz-harvest/program_fuzz_test.go
+++ b/cmd/evener-fuzz-harvest/program_fuzz_test.go
@@ -9,6 +9,7 @@ func FuzzHarvestProgram(f *testing.F) {
 		scenarioHarvestRunFailuresAndMain, scenarioMixedSurfaceFixtures, scenarioSanitizerRemainingPrimitiveBranches,
 		scenarioGitleaksScanOutcomes, scenarioHarvestLeakExitAndSmallHelpers, scenarioEmitterWriteFileFailure,
 		scenarioHarvesterInjectedSanitizeAndEmitFailures, scenarioReverseHTTPNoMatchAndBadQuery,
+		scenarioReverseHTTPAuthPathTokenNeverHarvested, scenarioReverseHTTPLegitimateSessionSuffixNotRedacted,
 		scenarioForEachJSONLineOpenAndEmpty, scenarioRemainingFilesystemAndGateBranches,
 		scenarioRunLogAndPersonalKeepNote, scenarioToolArgsSecondDecodeAndSanitizeFailure,
 		scenarioHarvestRunInjectedOutcomes, scenarioRunnerFailureAccountingAndHelpers,


### PR DESCRIPTION
Fixes #795. **Security:** the fuzz-corpus harvester's http-suffix secret gate does not catch a bearer token that appears as a URL path suffix (entropy-checking is disabled there and no sanitizer regex matches a bare token), so a credential in the request PATH reverse-maps onto the catch-all route and lands unredacted in a testdata/fuzz seed the documented EVENER_RECORD_HTTP workflow commits to git. This becomes reachable once the pairing token moves to /auth/<token> (PR #431).

**Fix (option B):** drop /auth requests in reverseMapHTTP before the seed gate — /auth was never an intentionally-fuzzed route (AuthGuard intercepts it), so zero fuzz-coverage cost. Chosen over entropy-gating (option A), which was empirically shown to false-flag ~74% of legitimate session IDs and fail every harvest run. Match is case-insensitive (a re-cased /Auth/<token> must not leak even though it never authenticates), and a table test pins the accept/reject shape contract as a drift guard (Go internal/ visibility prevents sharing hubedge's matcher; the test documents why).

Pipeline provenance: strict-TDD red-leak proof (synthetic token, RED on unfixed code → GREEN); over-redaction regression (legit session-ID suffix still harvested); adversarial pair — completeness lens SURVIVES (verified /auth is the only path-carried-credential route; entropy false-positive rate independently reproduced at 73.9%), regression lens SURVIVES (reverseMapHTTP byte-identical for non-/auth). Their two findings (case-sensitivity, drift guard) closed in a round, red-checked. secret-scan clean.

Gates PR #431.