### PR TITLE
agent: key the worktree-dispose watch gate on receiver identity

### DIFF
--- a/agent/delegate_resource_worktree_test.go
+++ b/agent/delegate_resource_worktree_test.go
@@ -45,6 +45,47 @@ func TestStableDelegateWorktree_RootCloseCleansEligibleScratch(t *testing.T) {
 	}
 }
 
+// TestStableDelegateWorktree_DisposeGateCatchesReceiverRoutedWatch covers
+// issue #695: a stable-receiver watch (the observer-sidecar class, #655)
+// synthesizes send.To as the stableWatchReceiverTarget sentinel, never the
+// delegate ID, so the dispose gate's plain send.To/ResolvedSendTo comparison
+// against id misses it. The gate must also catch a watch whose receiver
+// identity (receiverSessionID/receiverDelegateID) names the delegate being
+// disposed.
+func TestStableDelegateWorktree_DisposeGateCatchesReceiverRoutedWatch(t *testing.T) {
+	r := newWorktreeRepo(t)
+	id, _, _ := r.seedStableIsolationLane(t)
+
+	childSessionID := "child-" + id
+	key := watchKey{
+		VisibleSessionID:   r.s.id,
+		Target:             "job_source",
+		SendTo:             stableWatchReceiverTarget,
+		ReceiverSessionID:  childSessionID,
+		ReceiverDelegateID: id,
+	}
+	cfg := &watchConfig{
+		id:                 "w1",
+		watchID:            "watch-1",
+		target:             "job_source",
+		send:               &watchSendArgs{To: stableWatchReceiverTarget},
+		receiverSessionID:  childSessionID,
+		receiverDelegateID: id,
+		stableReceiver:     true,
+	}
+	r.s.jobManager.mu.Lock()
+	r.s.jobManager.watches[key] = cfg
+	r.s.jobManager.mu.Unlock()
+
+	_, err := r.s.worktreeDispose(context.Background(), id, false, false)
+	if err == nil {
+		t.Fatal("expected dispose to be refused while a receiver-routed watch targets the delegate, got success")
+	}
+	if !strings.Contains(err.Error(), "is the target of an armed or pending watch send") {
+		t.Fatalf("dispose error = %v, want the watch-gate refusal", err)
+	}
+}
+
 func TestStableDelegateWorktree_ExplicitDisposalPreservesDirtyAndD0Checks(t *testing.T) {
 	t.Run("dirty", func(t *testing.T) {
 		r := newWorktreeRepo(t)

--- a/agent/job_watch_end_notice_test.go
+++ b/agent/job_watch_end_notice_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/internal/jobstore"
 )
 
@@ -96,6 +97,72 @@ func TestWatchEndNoticeRoutesToCrossSessionReceiver(t *testing.T) {
 	if len(ownerQueue) == 0 {
 		t.Error("owner queue is empty; it should still carry the target's own job-stopped notification")
 	}
+}
+
+// TestDescendantReceiverWatchSurvivesJobManagerClose investigates issue #695's
+// adversarial-review Finding 1: does a configureDescendantReceiverWatch-shaped
+// watch (ReceiverSessionID set, ReceiverDelegateID empty) still deliver to its
+// receiverNotify closure after its OWN job manager has gone through the close
+// teardown Session.close() runs on every subagent in a dispose cascade
+// (jobManager.closeRuntimeState)? If it does, a delegate that installed this
+// watch on a descendant, then got disposed, remains a live receiver after
+// dispose. If closeRuntimeState already tears the watch down, the hazard
+// cannot reproduce this way.
+//
+// "armed" is the control: the identical watch, fired with no close in
+// between, must reach the receiver -- proving the installed shape and the
+// synthetic event actually exercise onSessionEvent's notify branch, so an
+// empty queue in "after_close" is attributable to the close, not a setup
+// mistake. Target is the session pseudo-target ("caller"), not a real shell
+// job, so closeRuntimeState's running-job wait has nothing to wait for.
+func TestDescendantReceiverWatchSurvivesJobManagerClose(t *testing.T) {
+	t.Parallel()
+	install := func(t *testing.T, jm *jobManager, receiverQueue *[]jobNotification) {
+		t.Helper()
+		if _, err := jm.configureWatch(watchArgs{
+			Target:            runtimeMessageAliasCaller,
+			Events:            []string{"communicate"},
+			ReceiverSessionID: "S-observer",
+			ReceiverNotify:    func(n jobNotification) { *receiverQueue = append(*receiverQueue, n) },
+		}); err != nil {
+			t.Fatalf("install: %v", err)
+		}
+	}
+
+	t.Run("armed", func(t *testing.T) {
+		t.Parallel()
+		jm := newTestJM(t)
+		var receiverQueue []jobNotification
+		install(t, jm, &receiverQueue)
+
+		jm.onSessionEvent(events.SessionEvent{Kind: events.EventCommunicate})
+
+		if len(receiverQueue) == 0 {
+			t.Fatal("receiver got no notification for a live watch -- setup does not exercise the notify branch, so the after_close case proves nothing")
+		}
+	})
+
+	t.Run("after_close", func(t *testing.T) {
+		t.Parallel()
+		jm := newTestJM(t)
+		var receiverQueue []jobNotification
+		install(t, jm, &receiverQueue)
+
+		// Simulate the watch's own job manager closing as part of a dispose
+		// cascade: Session.close() calls jobManager.closeRuntimeState() on
+		// every subagent it drains, including a descendant whose job manager
+		// holds a watch keyed to some other (possibly disposed) session as
+		// receiver.
+		if err := jm.closeRuntimeState(); err != nil {
+			t.Fatalf("closeRuntimeState: %v", err)
+		}
+
+		jm.onSessionEvent(events.SessionEvent{Kind: events.EventCommunicate})
+
+		if len(receiverQueue) != 0 {
+			t.Fatalf("receiver got %d notification(s) after its watch's job manager closed: %+v -- the watch survived teardown and can still deliver to a torn-down receiver", len(receiverQueue), receiverQueue)
+		}
+	})
 }
 
 // The end notice is for watches that ended unheard. A watch that already

--- a/agent/session_tools_worktree_dispose.go
+++ b/agent/session_tools_worktree_dispose.go
@@ -417,17 +417,32 @@ func (s *Session) subtreeWatchesTargeting(id, receiverSessionID string) bool {
 }
 
 // watchesTargeting reports whether any armed watch config sends to id, any
-// pending/terminal-flush watch-send frame resolves send_to id, or any watch's
-// receiver identity names id, in this job manager. Read under jm.mu.
+// pending/terminal-flush watch-send frame resolves send_to id, or a
+// stable-receiver watch's receiver identity names id, in this job manager.
+// Read under jm.mu.
 //
-// A stable-receiver watch (the observer-sidecar class, #655) synthesizes
-// send.To as the stableWatchReceiverTarget sentinel, never the delegate ID
+// A stable-receiver watch (the observer-sidecar class, #655,
+// configureStableWatchOnSource) synthesizes send.To as the
+// stableWatchReceiverTarget sentinel, never the delegate ID
 // (applyStableReceiverWatchSend), so the plain send.To/ResolvedSendTo checks
 // above never match id for that class of watch. watchConfigMatchesReceiver —
 // the same receiver-keyed matching liveWatchSummariesForReceiver and the
 // #655 job_stop live-watch inventory use — catches it by receiver identity
 // instead: id plus receiverSessionID (id's own child session ID, resolved by
 // the caller).
+//
+// This does NOT catch the structurally distinct descendant-receiver watch
+// class configureDescendantReceiverWatch installs (job_watch source="job_…"
+// against a descendant's concrete job): that class always stamps an empty
+// ReceiverDelegateID (session.ID() only, never owningDelegateID), so
+// watchConfigMatchesReceiver — which requires both fields — can never match
+// it here. That gap is real but verified benign (#695 adversarial review,
+// round 2): the watch lives in the OWNER descendant's own job manager, which
+// Session.close's subagent cascade also tears down (jobManager.
+// closeRuntimeState deletes it from jm.watches, and routeWatchNotifications
+// separately refuses on jm.closing) synchronously, within the same dispose
+// call, before a disposed receiver could ever see a delivery — see
+// TestDescendantReceiverWatchSurvivesJobManagerClose.
 func (jm *jobManager) watchesTargeting(id, receiverSessionID string) bool {
 	jm.mu.Lock()
 	defer jm.mu.Unlock()

--- a/agent/session_tools_worktree_dispose.go
+++ b/agent/session_tools_worktree_dispose.go
@@ -127,7 +127,7 @@ func (s *Session) disposeStableDelegateLane(ctx context.Context, id string, forc
 	if state.active || state.currentRunOpen || state.pendingStopSeq != 0 {
 		return WorktreeDisposeResult{}, fmt.Errorf("manage_worktree dispose: %s still has running or unfinished work; wait for it to finish", id)
 	}
-	if s.subtreeWatchesTargeting(id) {
+	if s.subtreeWatchesTargeting(id, state.descriptor.ChildSessionID) {
 		return WorktreeDisposeResult{}, fmt.Errorf("manage_worktree dispose: %s is the target of an armed or pending watch send; clear the watch before disposing", id)
 	}
 
@@ -400,22 +400,35 @@ func laneAheadCount(run worktree.GitRunner, lanePath, baseSHA string) (n int, ok
 	return n, true
 }
 
-func (s *Session) subtreeWatchesTargeting(id string) bool {
-	if s.jobManager != nil && s.jobManager.watchesTargeting(id) {
+// subtreeWatchesTargeting reports whether any watch anywhere in s's subtree
+// targets id, the delegate being disposed. receiverSessionID is id's own
+// child session ID (the receiver identity a stable-receiver watch on id
+// carries; #695), threaded unchanged through the recursion.
+func (s *Session) subtreeWatchesTargeting(id, receiverSessionID string) bool {
+	if s.jobManager != nil && s.jobManager.watchesTargeting(id, receiverSessionID) {
 		return true
 	}
 	for _, sub := range s.subagents.directSubagents() {
-		if sub.sess != nil && sub.sess.subtreeWatchesTargeting(id) {
+		if sub.sess != nil && sub.sess.subtreeWatchesTargeting(id, receiverSessionID) {
 			return true
 		}
 	}
 	return false
 }
 
-// watchesTargeting reports whether any armed watch config sends to id, or any
-// pending/terminal-flush watch-send frame resolves send_to id, in this job
-// manager. Read under jm.mu.
-func (jm *jobManager) watchesTargeting(id string) bool {
+// watchesTargeting reports whether any armed watch config sends to id, any
+// pending/terminal-flush watch-send frame resolves send_to id, or any watch's
+// receiver identity names id, in this job manager. Read under jm.mu.
+//
+// A stable-receiver watch (the observer-sidecar class, #655) synthesizes
+// send.To as the stableWatchReceiverTarget sentinel, never the delegate ID
+// (applyStableReceiverWatchSend), so the plain send.To/ResolvedSendTo checks
+// above never match id for that class of watch. watchConfigMatchesReceiver —
+// the same receiver-keyed matching liveWatchSummariesForReceiver and the
+// #655 job_stop live-watch inventory use — catches it by receiver identity
+// instead: id plus receiverSessionID (id's own child session ID, resolved by
+// the caller).
+func (jm *jobManager) watchesTargeting(id, receiverSessionID string) bool {
 	jm.mu.Lock()
 	defer jm.mu.Unlock()
 	for _, cfg := range jm.watches {
@@ -427,12 +440,18 @@ func (jm *jobManager) watchesTargeting(id string) bool {
 				return true
 			}
 		}
+		if watchConfigMatchesReceiver(cfg, receiverSessionID, id) {
+			return true
+		}
 	}
 	for cfg := range jm.terminalFlush {
 		for key := range cfg.pending {
 			if key.ResolvedSendTo == id {
 				return true
 			}
+		}
+		if watchConfigMatchesReceiver(cfg, receiverSessionID, id) {
+			return true
 		}
 	}
 	return false

--- a/agent/session_tools_worktree_dispose_branches_test.go
+++ b/agent/session_tools_worktree_dispose_branches_test.go
@@ -208,7 +208,7 @@ func TestSubtreeWatchesTargetingNoJobManager(t *testing.T) {
 		},
 	}
 	// jobManager is nil, subagents is initialized but empty
-	if s.subtreeWatchesTargeting("dlg_test") {
+	if s.subtreeWatchesTargeting("dlg_test", "") {
 		t.Fatalf("expected false with no jobManager or subagents")
 	}
 }
@@ -223,7 +223,7 @@ func TestWatchesTargetingEmpty(t *testing.T) {
 		terminalFlush: map[*watchConfig]bool{},
 	}
 	// Call watchesTargeting — it will lock jm.mu and iterate empty maps
-	if jm.watchesTargeting("dlg_test") {
+	if jm.watchesTargeting("dlg_test", "") {
 		t.Fatalf("expected false with empty watches")
 	}
 }

--- a/agent/session_tools_worktree_dispose_covtest2_test.go
+++ b/agent/session_tools_worktree_dispose_covtest2_test.go
@@ -16,7 +16,7 @@ func TestWatchesTargeting_SendMatch(t *testing.T) {
 		},
 		terminalFlush: map[*watchConfig]bool{},
 	}
-	if !jm.watchesTargeting("dlg_target") {
+	if !jm.watchesTargeting("dlg_target", "") {
 		t.Fatal("expected true for send.To match")
 	}
 }
@@ -33,7 +33,7 @@ func TestWatchesTargeting_PendingMatch(t *testing.T) {
 		},
 		terminalFlush: map[*watchConfig]bool{},
 	}
-	if !jm.watchesTargeting("dlg_target") {
+	if !jm.watchesTargeting("dlg_target", "") {
 		t.Fatal("expected true for pending match")
 	}
 }
@@ -49,7 +49,7 @@ func TestWatchesTargeting_TerminalFlushMatch(t *testing.T) {
 		watches:       map[watchKey]*watchConfig{},
 		terminalFlush: map[*watchConfig]bool{cfg: true},
 	}
-	if !jm.watchesTargeting("dlg_target") {
+	if !jm.watchesTargeting("dlg_target", "") {
 		t.Fatal("expected true for terminalFlush match")
 	}
 }
@@ -67,7 +67,7 @@ func TestWatchesTargeting_NoMatch(t *testing.T) {
 		},
 		terminalFlush: map[*watchConfig]bool{},
 	}
-	if jm.watchesTargeting("dlg_target") {
+	if jm.watchesTargeting("dlg_target", "") {
 		t.Fatal("expected false for no match")
 	}
 }
@@ -83,7 +83,7 @@ func TestWatchesTargeting_SendNil(t *testing.T) {
 		},
 		terminalFlush: map[*watchConfig]bool{},
 	}
-	if jm.watchesTargeting("dlg_target") {
+	if jm.watchesTargeting("dlg_target", "") {
 		t.Fatal("expected false for nil send and empty pending")
 	}
 }
@@ -96,7 +96,7 @@ func TestSubtreeWatchesTargeting_NilJobManagerWithSubagents(t *testing.T) {
 			subs: map[string]*subagent{},
 		},
 	}
-	if s.subtreeWatchesTargeting("dlg_test") {
+	if s.subtreeWatchesTargeting("dlg_test", "") {
 		t.Fatal("expected false with nil jobManager and empty subagents")
 	}
 }
@@ -106,7 +106,7 @@ func TestSubtreeWatchesTargeting_NilSubagents(t *testing.T) {
 	s := &Session{
 		subagents: &subagentManager{subs: map[string]*subagent{}},
 	}
-	if s.subtreeWatchesTargeting("dlg_test") {
+	if s.subtreeWatchesTargeting("dlg_test", "") {
 		t.Fatal("expected false with empty subagents")
 	}
 }
@@ -125,7 +125,93 @@ func TestSubtreeWatchesTargeting_JobManagerMatch(t *testing.T) {
 		jobManager: jm,
 		subagents:  &subagentManager{subs: map[string]*subagent{}},
 	}
-	if !s.subtreeWatchesTargeting("dlg_target") {
+	if !s.subtreeWatchesTargeting("dlg_target", "") {
 		t.Fatal("expected true for jobManager match")
+	}
+}
+
+// TestWatchesTargeting_ReceiverMatch covers the watchConfigMatchesReceiver
+// branch (#695): a stable-receiver watch's send.To is the
+// stableWatchReceiverTarget sentinel, never the delegate id, so only
+// receiver-identity matching catches it.
+func TestWatchesTargeting_ReceiverMatch(t *testing.T) {
+	jm := &jobManager{
+		watches: map[watchKey]*watchConfig{
+			{Target: "job_1"}: {
+				send:               &watchSendArgs{To: stableWatchReceiverTarget},
+				receiverSessionID:  "child-session",
+				receiverDelegateID: "dlg_target",
+			},
+		},
+		terminalFlush: map[*watchConfig]bool{},
+	}
+	if !jm.watchesTargeting("dlg_target", "child-session") {
+		t.Fatal("expected true for receiver-identity match despite sentinel send.To")
+	}
+}
+
+// TestWatchesTargeting_ReceiverSessionMismatch covers watchConfigMatchesReceiver
+// requiring BOTH receiverSessionID and receiverDelegateID: a delegate-id match
+// alone, with the wrong session, must not count as targeting.
+func TestWatchesTargeting_ReceiverSessionMismatch(t *testing.T) {
+	jm := &jobManager{
+		watches: map[watchKey]*watchConfig{
+			{Target: "job_1"}: {
+				send:               &watchSendArgs{To: stableWatchReceiverTarget},
+				receiverSessionID:  "other-session",
+				receiverDelegateID: "dlg_target",
+			},
+		},
+		terminalFlush: map[*watchConfig]bool{},
+	}
+	if jm.watchesTargeting("dlg_target", "child-session") {
+		t.Fatal("expected false: receiverDelegateID matches but receiverSessionID does not")
+	}
+}
+
+// TestWatchesTargeting_TerminalFlushReceiverMatch covers the receiver-identity
+// check in the terminalFlush loop.
+func TestWatchesTargeting_TerminalFlushReceiverMatch(t *testing.T) {
+	cfg := &watchConfig{
+		receiverSessionID:  "child-session",
+		receiverDelegateID: "dlg_target",
+	}
+	jm := &jobManager{
+		watches:       map[watchKey]*watchConfig{},
+		terminalFlush: map[*watchConfig]bool{cfg: true},
+	}
+	if !jm.watchesTargeting("dlg_target", "child-session") {
+		t.Fatal("expected true for terminalFlush receiver-identity match")
+	}
+}
+
+// TestSubtreeWatchesTargeting_ReceiverMatchInSubagent covers receiverSessionID
+// propagating unchanged through the subagent recursion (#695): a
+// receiver-routed watch armed in a subagent's own job manager must still be
+// found from the ancestor's subtree scan.
+func TestSubtreeWatchesTargeting_ReceiverMatchInSubagent(t *testing.T) {
+	childJM := &jobManager{
+		watches: map[watchKey]*watchConfig{
+			{Target: "job_1"}: {
+				send:               &watchSendArgs{To: stableWatchReceiverTarget},
+				receiverSessionID:  "child-session",
+				receiverDelegateID: "dlg_target",
+			},
+		},
+		terminalFlush: map[*watchConfig]bool{},
+	}
+	child := &Session{
+		jobManager: childJM,
+		subagents:  &subagentManager{subs: map[string]*subagent{}},
+	}
+	s := &Session{
+		subagents: &subagentManager{
+			subs: map[string]*subagent{
+				"child-session": {sess: child},
+			},
+		},
+	}
+	if !s.subtreeWatchesTargeting("dlg_target", "child-session") {
+		t.Fatal("expected true for a receiver-routed watch armed in a subagent's job manager")
 	}
 }

--- a/agent/session_tools_worktree_dispose_covtest2_test.go
+++ b/agent/session_tools_worktree_dispose_covtest2_test.go
@@ -215,3 +215,31 @@ func TestSubtreeWatchesTargeting_ReceiverMatchInSubagent(t *testing.T) {
 		t.Fatal("expected true for a receiver-routed watch armed in a subagent's job manager")
 	}
 }
+
+// TestWatchesTargeting_DescendantReceiverClassDoesNotMatch pins a KNOWN,
+// verified-benign gap surfaced by the #695 adversarial review (round 2):
+// configureDescendantReceiverWatch (session_tools_jobs.go) always stamps an
+// empty receiverDelegateID (session.ID() only, never owningDelegateID), so
+// watchConfigMatchesReceiver -- which requires both fields -- can never match
+// this class here, regardless of receiverSessionID. This is intentionally
+// left uncaught: the watch lives in the owner descendant's own job manager,
+// which Session.close's subagent cascade tears down synchronously within the
+// same dispose call (see TestDescendantReceiverWatchSurvivesJobManagerClose
+// for the proof that its delivery closure cannot fire afterward). If this
+// test starts failing because receiverDelegateID stops being empty for this
+// class, the doc comment on watchesTargeting needs re-reviewing, not just
+// this assertion.
+func TestWatchesTargeting_DescendantReceiverClassDoesNotMatch(t *testing.T) {
+	jm := &jobManager{
+		watches: map[watchKey]*watchConfig{
+			{Target: "job_1"}: {
+				receiverSessionID:  "child-session",
+				receiverDelegateID: "", // configureDescendantReceiverWatch's actual shape
+			},
+		},
+		terminalFlush: map[*watchConfig]bool{},
+	}
+	if jm.watchesTargeting("dlg_target", "child-session") {
+		t.Fatal("expected false: the descendant-receiver class always carries an empty receiverDelegateID and cannot match here today")
+	}
+}


### PR DESCRIPTION
Fixes #695. The dispose gate's watchesTargeting only compared cfg.send.To/ResolvedSendTo against the delegate ID, so a stable-receiver watch (whose send.To is the stable_watch_receiver sentinel, never the delegate ID) escaped the gate — a disposed delegate could remain the live receiver of an armed watch. watchesTargeting/subtreeWatchesTargeting now also match receiver identity via watchConfigMatchesReceiver (the same matcher the #655/job_stop inventory uses), keyed on the disposed delegate's ChildSessionID.

Pipeline provenance: red-first dispose test (receiver-routed watch escapes pre-fix); adversarial pair — regression lens SURVIVES (the receiver match is structurally incapable of over-matching: compound-AND on unique, non-model-settable identity; caller sweep exhaustive; delegate-ID path empirically unchanged under -race). The correctness lens raised a Critical (a second empty-ReceiverDelegateID descendant-watch class escapes the gate) — investigated per the Iron Law and the delivery-hazard half proved a FALSE POSITIVE: disposeStableExecute calls close() synchronously, cascading to every descendant, and closeRuntimeState sets jm.closing=true (routeWatchNotifications refuses on it) + deletes the watch before dispose returns, so no post-dispose delivery is possible (pinned by TestDescendantReceiverWatchSurvivesJobManagerClose: after_close → zero notifications). The escape's doc overclaim was corrected and the verified-safe non-match pinned against future drift. #727 boundary (job_stop inventory + clear) untouched. Simplify NO-OP.