### PR TITLE
registry: enable web_search only on a vendor's first-party endpoint

### DIFF
--- a/agent/session_model_test.go
+++ b/agent/session_model_test.go
@@ -918,6 +918,62 @@ func TestSession_WebSearch_FlagSetOnRequest(t *testing.T) {
 	}
 }
 
+// TestSession_WebSearch_FlagNotSetWhenBaseURLDiverges covers issue #738: an
+// instance with its own base_url no longer inherits the vendor's
+// provider-level web_search (llm/registry's endpoint gate), so the request
+// this session builds must not carry the flag - a gateway that does not
+// implement the hosted tool rejects it and, before this fix, ended the
+// session on turn one. "gw" is the fixture's base=openai instance pointed at
+// a different base_url (profile_testhelpers_test.go); it never sets
+// web_search itself.
+func TestSession_WebSearch_FlagNotSetWhenBaseURLDiverges(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	c := llm.NewClient()
+	f := &fakeAdapter{
+		name: "gw",
+		steps: []func(req llm.Request) llm.Response{
+			func(req llm.Request) llm.Response {
+				return wrapCommunicateResponse(llm.Response{
+					Message: llm.Message{
+						Role:    llm.RoleAssistant,
+						Content: []llm.ContentPart{{Kind: llm.ContentText, Text: "done"}},
+					},
+					Finish: llm.FinishReason{Reason: "stop"},
+					Usage:  llm.Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+				})
+			},
+		},
+	}
+	c.Register(f)
+
+	profile := resolveTestProfile("gw", nil, "gpt-5.2")
+	if profile.SupportsWebSearch() {
+		t.Fatal("pre-condition: gw must not resolve web_search (its base_url diverges from openai's default)")
+	}
+
+	sess, err := NewSession(c, withTestSessionNamer(c, profile), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	defer cancel()
+	_, err = sess.ProcessInput(ctx, "hello", nil)
+	if err != nil {
+		t.Fatalf("ProcessInput: %v", err)
+	}
+
+	reqs := f.Requests()
+	if len(reqs) == 0 {
+		t.Fatalf("no requests captured")
+	}
+	if reqs[0].WebSearch {
+		t.Fatalf("WebSearch flag set on request for a base_url-diverged instance")
+	}
+}
+
 func TestSession_PauseTurn_ContinuesLoop(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/agent/session_model_test.go
+++ b/agent/session_model_test.go
@@ -918,7 +918,7 @@ func TestSession_WebSearch_FlagSetOnRequest(t *testing.T) {
 	}
 }
 
-// TestSession_WebSearch_FlagNotSetWhenBaseURLDiverges covers issue #738: an
+// TestSession_WebSearch_FlagNotSetWhenBaseURLDiverges pins that an
 // instance with its own base_url no longer inherits the vendor's
 // provider-level web_search (llm/registry's endpoint gate), so the request
 // this session builds must not carry the flag - a gateway that does not

--- a/agent/session_model_test.go
+++ b/agent/session_model_test.go
@@ -922,10 +922,25 @@ func TestSession_WebSearch_FlagSetOnRequest(t *testing.T) {
 // instance with its own base_url no longer inherits the vendor's
 // provider-level web_search (llm/registry's endpoint gate), so the request
 // this session builds must not carry the flag - a gateway that does not
-// implement the hosted tool rejects it and, before this fix, ended the
-// session on turn one. "gw" is the fixture's base=openai instance pointed at
-// a different base_url (profile_testhelpers_test.go); it never sets
-// web_search itself.
+// implement the hosted tool rejects it, ending the session on turn one.
+// "gw" is the fixture's base=openai instance pointed at a different
+// base_url (profile_testhelpers_test.go); it never sets web_search itself.
+//
+// This test only proves the session's own derivation (providerWebSearchEnabled
+// -> profile.SupportsWebSearch -> registry.BoolValue) reads a gated profile
+// correctly - BoolValue collapses nil and false alike, so it would pass
+// unchanged whether the registry stripped WebSearch to nil or to false. It
+// cannot, on its own, see a fail-open gap at the wire-building layer, where
+// a caller that sets Request.WebSearch directly (bypassing
+// providerWebSearchEnabled entirely - cmd/llmcall's --web-search flag, for
+// one) would hit a protocol adapter's own gate (caps.WebSearch == nil ||
+// *caps.WebSearch), which treats nil as permissive. The wire-layer leak is
+// pinned separately and directly in llm/providers/responses
+// (TestBuildBody_WebSearchNilCapsIsFailOpen); this test closes the gap at
+// its own layer instead by also asserting the resolved Caps.WebSearch
+// pointer itself is explicit false, not nil, so a registry regression back
+// to nil'ing the cap fails here even though req.WebSearch would still read
+// false.
 func TestSession_WebSearch_FlagNotSetWhenBaseURLDiverges(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -950,6 +965,9 @@ func TestSession_WebSearch_FlagNotSetWhenBaseURLDiverges(t *testing.T) {
 	profile := resolveTestProfile("gw", nil, "gpt-5.2")
 	if profile.SupportsWebSearch() {
 		t.Fatal("pre-condition: gw must not resolve web_search (its base_url diverges from openai's default)")
+	}
+	if ws := profile.Resolved().Caps.WebSearch; ws == nil || *ws {
+		t.Fatalf("pre-condition: gw's resolved Caps.WebSearch must be an explicit false, not nil (nil is fail-open at the adapter layer): %v", ws)
 	}
 
 	sess, err := NewSession(c, withTestSessionNamer(c, profile), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{})

--- a/llm/client_registry_test.go
+++ b/llm/client_registry_test.go
@@ -413,3 +413,39 @@ func TestClientCanServe(t *testing.T) {
 		t.Fatal("unknown instances and Codex ids off the allowlist are not (spec §7.3)")
 	}
 }
+
+// TestClientWebSearchGatedInstanceSendsNoHostedTool traces the registry's
+// web_search endpoint gate end to end, through the one seam it cannot test
+// alone: the protocol builders treat Caps.WebSearch == nil as permissive
+// (each protocol's *_WebSearchNilCapsIsFailOpen test), so the registry must
+// resolve a non-first-party endpoint to an explicit false even when no
+// layer ever granted web_search (azure grants it nowhere). With that false
+// in the resolved record, a caller setting req.WebSearch = true directly -
+// never consulting registry.Caps - still produces a wire request with no
+// hosted tool, closing issue #738's crash path.
+func TestClientWebSearchGatedInstanceSendsNoHostedTool(t *testing.T) {
+	srv, seen := responsesServer(t)
+	r := fixtureRegistry(t, srv.URL, map[string]registry.Provider{
+		"azuregw": {Base: "azure", APIKey: "k", Transport: registry.Transport{BaseURL: srv.URL}},
+	})
+	res, err := r.Resolve("azuregw/gpt-5.5")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Caps.WebSearch == nil || *res.Caps.WebSearch {
+		t.Fatalf("the gate must resolve a nil-capped non-first-party instance to an explicit false, got %v", res.Caps.WebSearch)
+	}
+	c := llm.NewClient(llm.WithRegistry(r))
+	req := userRequest("azuregw", "gpt-5.5")
+	req.WebSearch = true
+	if _, err := c.Complete(context.Background(), req); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	reqs := seen()
+	if len(reqs) != 1 || reqs[0].Path != "/responses" {
+		t.Fatalf("wire: %+v", reqs)
+	}
+	if tools, has := reqs[0].Body["tools"]; has {
+		t.Fatalf("the hosted web_search tool must not reach a gated endpoint: %v", tools)
+	}
+}

--- a/llm/providers/anthropic/protocol_test.go
+++ b/llm/providers/anthropic/protocol_test.go
@@ -48,6 +48,37 @@ func TestProtocolPrunablePathsMatchRegistry(t *testing.T) {
 	}
 }
 
+// TestProtocolBuildBody_WebSearchNilCapsIsFailOpen pins the mechanism
+// behind issue #738's endpoint gate on this protocol too (the Responses
+// twin is TestBuildBody_WebSearchNilCapsIsFailOpen): the gate here,
+// req.WebSearch && (caps.WebSearch == nil || *caps.WebSearch)
+// (protocol_request.go), treats an unset capability as permissive. That is
+// the right default for a model this adapter has no catalog opinion about -
+// trust the caller's own req.WebSearch - but it means the registry's
+// endpoint gate (llm/registry/resolve.go, gateWebSearch) can never
+// represent "denied because this endpoint is not the vendor's first-party
+// API" as a bare nil: a caller that sets req.WebSearch = true without
+// consulting registry.Caps would still get the hosted tool sent to an
+// endpoint that rejects it. The registry closes this by carrying an
+// explicit false, never nil; this test pins why that is necessary at this
+// layer - nil is let through right here, by design - and that the
+// explicit false actually holds the tool back.
+func TestProtocolBuildBody_WebSearchNilCapsIsFailOpen(t *testing.T) {
+	req := protoReq("")
+	req.WebSearch = true
+	res := protoRes(nil) // Caps.WebSearch left nil, the state a gated instance must never carry
+	if res.Caps.WebSearch != nil {
+		t.Fatal("test setup: protoRes(nil) must leave WebSearch nil")
+	}
+	tools, _ := protoBuild(t, req, res)["tools"].([]map[string]any)
+	if len(tools) != 1 || tools[0]["type"] != "web_search_20250305" {
+		t.Fatalf("nil Caps.WebSearch is fail-open at this layer: a caller setting req.WebSearch still gets the tool: %v", tools)
+	}
+	if _, has := protoBuild(t, req, protoRes(func(c *registry.Caps) { c.WebSearch = new(false) }))["tools"]; has {
+		t.Fatal("an explicit false must hold the web search tool back")
+	}
+}
+
 func TestProtocolBuildBody_ThinkingShapes(t *testing.T) {
 	cases := []struct {
 		name         string

--- a/llm/providers/google/protocol_test.go
+++ b/llm/providers/google/protocol_test.go
@@ -86,6 +86,35 @@ func TestProtocolBuildBody(t *testing.T) {
 	}
 }
 
+// TestProtocolBuildBody_WebSearchNilCapsIsFailOpen pins the mechanism
+// behind issue #738's endpoint gate on this protocol too (the Responses
+// and Anthropic twins share the name): the gate here,
+// req.WebSearch && (caps.WebSearch == nil || *caps.WebSearch)
+// (protocol.go), treats an unset capability as permissive - trust the
+// caller's own req.WebSearch - so the registry's endpoint gate
+// (llm/registry/resolve.go, gateWebSearch) can never represent "denied
+// because this endpoint is not the vendor's first-party API" as a bare
+// nil: a caller setting req.WebSearch = true without consulting
+// registry.Caps would still get google_search sent to an endpoint that
+// rejects it. The registry closes this by carrying an explicit false,
+// never nil; this test pins why that is necessary at this layer and that
+// the explicit false actually holds the tool back.
+func TestProtocolBuildBody_WebSearchNilCapsIsFailOpen(t *testing.T) {
+	req := protoReq("")
+	req.WebSearch = true
+	res := protoRes(nil) // Caps.WebSearch left nil, the state a gated instance must never carry
+	if res.Caps.WebSearch != nil {
+		t.Fatal("test setup: protoRes(nil) must leave WebSearch nil")
+	}
+	tools, _ := protoBuild(t, req, res)["tools"].([]map[string]any)
+	if len(tools) != 1 || tools[0]["google_search"] == nil {
+		t.Fatalf("nil Caps.WebSearch is fail-open at this layer: a caller setting req.WebSearch still gets google_search: %v", tools)
+	}
+	if _, has := protoBuild(t, req, protoRes(func(c *registry.Caps) { c.WebSearch = new(false) }))["tools"]; has {
+		t.Fatal("an explicit false must hold google_search back")
+	}
+}
+
 func TestProtocolBuildBody_MultimodalToolResultsCap(t *testing.T) {
 	req := llm.Request{Model: "gemini-x", Messages: []llm.Message{
 		{Role: llm.RoleAssistant, Content: []llm.ContentPart{{Kind: llm.ContentToolCall, ToolCall: &llm.ToolCallData{ID: "c1", Name: "shot", Arguments: []byte(`{}`)}}}},

--- a/llm/providers/responses/request_test.go
+++ b/llm/providers/responses/request_test.go
@@ -141,6 +141,36 @@ func TestBuildBody_OpenAIRow(t *testing.T) {
 	}
 }
 
+// TestBuildBody_WebSearchNilCapsIsFailOpen pins the mechanism behind issue
+// #738's endpoint gate: this layer's own gate, caps.WebSearch == nil ||
+// *caps.WebSearch, treats an unset capability as permissive. That is the
+// right default for a model this adapter simply has no catalog opinion
+// about - trust the caller's own req.WebSearch - but it means the
+// registry's endpoint gate (llm/registry/resolve.go, gateWebSearch) can
+// never represent "denied because this endpoint is not the vendor's
+// first-party API" as a bare nil: any caller that independently sets
+// req.WebSearch = true without first consulting registry.Caps -
+// cmd/llmcall's --web-search flag builds its request this way, never
+// touching the registry's decision at all - would still get the hosted
+// tool sent to an endpoint that rejects it, reproducing #738's crash. The
+// registry closes this by stripping to an explicit false rather than nil
+// (llm/registry's TestResolve_WebSearchEndpointGate and
+// TestResolveInstanceCarriesWebSearchDisabledWarning pin that half); this
+// test pins the reason that fix is necessary, not optional: nil is let
+// through right here, unconditionally, by design.
+func TestBuildBody_WebSearchNilCapsIsFailOpen(t *testing.T) {
+	req := userReq("hi")
+	req.WebSearch = true
+	res := resolved(nil) // Caps.WebSearch left nil, the state a gated instance must never carry
+	if res.Caps.WebSearch != nil {
+		t.Fatal("test setup: resolved(nil) must leave WebSearch nil")
+	}
+	tools, _ := build(t, req, res)["tools"].([]map[string]any)
+	if len(tools) != 1 || tools[0]["type"] != "web_search" {
+		t.Fatalf("nil Caps.WebSearch is fail-open at this layer: a caller setting req.WebSearch still gets the tool: %v", tools)
+	}
+}
+
 func TestBuildBody_CodexLite(t *testing.T) {
 	req := userReq("hi")
 	req.Tools = []llm.ToolDefinition{{Name: "f", Parameters: map[string]any{"type": "object"}}}

--- a/llm/registry/hostrules.go
+++ b/llm/registry/hostrules.go
@@ -123,8 +123,32 @@ func validateOllamaURL(raw string, normalizePath bool) (string, error) {
 	return u.String(), nil
 }
 
+// validVertexLocation reports whether a Vertex location is shaped like the
+// region token vertexHost may compose into a hostname: a single RFC-1123
+// label - letters, digits, and interior hyphens, at most 63 bytes. A
+// location is us-central1 or global, never a host: a dot, slash, colon, or
+// any other byte would let the derivation build an authority outside
+// *.googleapis.com (or smuggle a path into it), so the vertex-location
+// rule refuses to derive from anything else (resolveBaseURLVia, load.go)
+// and the canonical first-party comparison refuses to admit it
+// (hostRuleInputAdmissible, instances.go).
+func validVertexLocation(loc string) bool {
+	if len(loc) == 0 || len(loc) > 63 || loc[0] == '-' || loc[len(loc)-1] == '-' {
+		return false
+	}
+	for i := 0; i < len(loc); i++ {
+		c := loc[i]
+		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
 // vertexHost is the vertex-location rule (spec §9.4): the Vertex API host
-// for a location.
+// for a location. Callers validate the location first (validVertexLocation);
+// this function only composes.
 func vertexHost(location string) string {
 	switch location {
 	case "global":

--- a/llm/registry/instance_resolve_test.go
+++ b/llm/registry/instance_resolve_test.go
@@ -244,6 +244,9 @@ func TestResolveInstanceCarriesWebSearchDisabledWarning(t *testing.T) {
 	if strings.Contains(strings.Join(instOK.Warnings, "\n"), "web_search disabled") {
 		t.Fatalf("ResolveInstance: an explicit web_search = true must suppress the warning: %v", instOK.Warnings)
 	}
+	if instOK.Caps.WebSearch == nil || !*instOK.Caps.WebSearch {
+		t.Fatalf("ResolveInstance: the explicit opt-in must survive as a non-nil true, not merely avoid the warning: %v", bp(instOK.Caps.WebSearch))
+	}
 	modelOK, err := r.Resolve("optedin/gpt-5.5")
 	if err != nil {
 		t.Fatalf("Resolve(optedin/gpt-5.5): %v", err)

--- a/llm/registry/instance_resolve_test.go
+++ b/llm/registry/instance_resolve_test.go
@@ -198,7 +198,7 @@ func TestResolveInstanceCarriesConverterNotes(t *testing.T) {
 }
 
 // TestResolveInstanceCarriesWebSearchDisabledWarning pins parity with
-// resolveOn (issue #738): a record that is not reaching its provider's
+// resolveOn: a record that is not reaching its provider's
 // first-party endpoint must explain a stripped web_search through
 // ResolveInstance the same way a model-based Resolve already does
 // (gateWebSearch, resolve.go, is the one function both call), and an

--- a/llm/registry/instance_resolve_test.go
+++ b/llm/registry/instance_resolve_test.go
@@ -196,3 +196,48 @@ func TestResolveInstanceCarriesConverterNotes(t *testing.T) {
 		t.Fatalf("converter notes must ride through to Warnings: %v", res.Warnings)
 	}
 }
+
+// TestResolveInstanceCarriesWebSearchDisabledWarning pins parity with
+// resolveOn (issue #738): a record that is not reaching its provider's
+// first-party endpoint must explain a stripped web_search through
+// ResolveInstance the same way a model-based Resolve already does
+// (gateWebSearch, resolve.go, is the one function both call), and an
+// explicit web_search on the instance's own entry must suppress the
+// warning identically on both paths.
+func TestResolveInstanceCarriesWebSearchDisabledWarning(t *testing.T) {
+	r := cutoverRegistry(t, map[string]string{"OPENAI_API_KEY": "k"}, map[string]Provider{
+		"gw":      {Base: "openai", Transport: Transport{BaseURL: "https://gw.example.com/v1"}},
+		"optedin": {Base: "openai", Transport: Transport{BaseURL: "https://gw.example.com/v1"}, Caps: Caps{WebSearch: new(true)}},
+	})
+	want := "web_search disabled: this endpoint is not openai's first-party API (set web_search = true on the instance to opt back in)"
+
+	instRes, err := r.ResolveInstance("gw")
+	if err != nil {
+		t.Fatalf("ResolveInstance(gw): %v", err)
+	}
+	if !strings.Contains(strings.Join(instRes.Warnings, "\n"), want) {
+		t.Fatalf("ResolveInstance must explain a stripped web_search: %v", instRes.Warnings)
+	}
+	modelRes, err := r.Resolve("gw/gpt-5.5")
+	if err != nil {
+		t.Fatalf("Resolve(gw/gpt-5.5): %v", err)
+	}
+	if !strings.Contains(strings.Join(modelRes.Warnings, "\n"), want) {
+		t.Fatalf("resolveOn must carry the identical warning ResolveInstance does: %v", modelRes.Warnings)
+	}
+
+	instOK, err := r.ResolveInstance("optedin")
+	if err != nil {
+		t.Fatalf("ResolveInstance(optedin): %v", err)
+	}
+	if strings.Contains(strings.Join(instOK.Warnings, "\n"), "web_search disabled") {
+		t.Fatalf("ResolveInstance: an explicit web_search = true must suppress the warning: %v", instOK.Warnings)
+	}
+	modelOK, err := r.Resolve("optedin/gpt-5.5")
+	if err != nil {
+		t.Fatalf("Resolve(optedin/gpt-5.5): %v", err)
+	}
+	if strings.Contains(strings.Join(modelOK.Warnings, "\n"), "web_search disabled") {
+		t.Fatalf("resolveOn: an explicit web_search = true must suppress the warning too: %v", modelOK.Warnings)
+	}
+}

--- a/llm/registry/instance_resolve_test.go
+++ b/llm/registry/instance_resolve_test.go
@@ -203,7 +203,12 @@ func TestResolveInstanceCarriesConverterNotes(t *testing.T) {
 // ResolveInstance the same way a model-based Resolve already does
 // (gateWebSearch, resolve.go, is the one function both call), and an
 // explicit web_search on the instance's own entry must suppress the
-// warning identically on both paths.
+// warning identically on both paths. It also pins that the strip lands as
+// an explicit false at this call site too, not nil: every protocol
+// adapter's own gate treats caps.WebSearch == nil as permissive, so a
+// caller reading Resolved straight from ResolveInstance (not through
+// profile.SupportsWebSearch's BoolValue, which happens to collapse nil and
+// false alike) must still see an unambiguous deny.
 func TestResolveInstanceCarriesWebSearchDisabledWarning(t *testing.T) {
 	r := cutoverRegistry(t, map[string]string{"OPENAI_API_KEY": "k"}, map[string]Provider{
 		"gw":      {Base: "openai", Transport: Transport{BaseURL: "https://gw.example.com/v1"}},
@@ -218,12 +223,18 @@ func TestResolveInstanceCarriesWebSearchDisabledWarning(t *testing.T) {
 	if !strings.Contains(strings.Join(instRes.Warnings, "\n"), want) {
 		t.Fatalf("ResolveInstance must explain a stripped web_search: %v", instRes.Warnings)
 	}
+	if instRes.Caps.WebSearch == nil || *instRes.Caps.WebSearch {
+		t.Fatalf("ResolveInstance must strip to an explicit false, not nil (nil is fail-open at the adapter layer): %v", bp(instRes.Caps.WebSearch))
+	}
 	modelRes, err := r.Resolve("gw/gpt-5.5")
 	if err != nil {
 		t.Fatalf("Resolve(gw/gpt-5.5): %v", err)
 	}
 	if !strings.Contains(strings.Join(modelRes.Warnings, "\n"), want) {
 		t.Fatalf("resolveOn must carry the identical warning ResolveInstance does: %v", modelRes.Warnings)
+	}
+	if modelRes.Caps.WebSearch == nil || *modelRes.Caps.WebSearch {
+		t.Fatalf("resolveOn must strip to an explicit false too, identically: %v", bp(modelRes.Caps.WebSearch))
 	}
 
 	instOK, err := r.ResolveInstance("optedin")

--- a/llm/registry/instances.go
+++ b/llm/registry/instances.go
@@ -102,9 +102,9 @@ func (r *Registry) effectiveAPIKeyEnv(rec *record) []string {
 }
 
 // firstPartyEndpoint reports whether the endpoint a specific resolution
-// actually reaches - resolvedBaseURL, the fully resolved transport
-// buildTransport produced, row-level overrides and all, not just the
-// instance's own rec.head.Transport - is its provider's
+// actually reaches - transport, the fully resolved Transport buildTransport
+// produced (row-level overrides and all, not just the instance's own
+// rec.head.Transport), resolved for proto - is its provider's
 // (r.curated[rec.providerID], which is rec itself for a curated record) own
 // canonical endpoint. WebSearch's gate uses this (spec §10's endpoint-stop
 // above is the analog; gateWebSearch in resolve.go applies it) - Jesse's
@@ -128,7 +128,12 @@ func (r *Registry) effectiveAPIKeyEnv(rec *record) []string {
 //
 // Two shapes, both compared against defaults, the provider's own template
 // resolved with only its curated vars - no user vars, no environment (spec
-// §10's "after substituting the curated defaults"):
+// §10's "after substituting the curated defaults"), and both with the
+// trailing-slash normalization protocolhttp.URL itself applies
+// (strings.TrimRight(BaseURL, "/") before joining the endpoint path) so a
+// *_BASE_URL that merely repeats or drops a trailing slash is not read as
+// a different endpoint - not a broader canonicalization, just mirroring
+// the one the request builder already does:
 //
 //   - !ownOverride (including every curated record, which can never set
 //     rec.ownBaseURL and whose curated rows carry no per-row override
@@ -152,16 +157,39 @@ func (r *Registry) effectiveAPIKeyEnv(rec *record) []string {
 //     a missing curated default must not be read as "nothing to compare",
 //     or every google-vertex-anthropic and google-vertex-based record
 //     would be first-party by default, override or not.
-func (r *Registry) firstPartyEndpoint(rec *record, resolvedBaseURL string, ownOverride bool) bool {
+//
+// The base_url check alone is not the complete picture: a canonical
+// base_url with its own endpoint, stream_endpoint, or count_tokens_endpoint
+// sends the same web-search-bearing request body somewhere else entirely
+// (buildTransport merges a row's own endpoint overrides too, the same
+// class of gap ownOverride already closes for base_url). For an instance,
+// all three are compared against what buildTransport would produce for the
+// provider's own record with no row and no instance overrides, for the
+// same proto - which already applies the cross-protocol rule (spec §4.2),
+// so a legitimately cross-protocol instance is compared against its own
+// protocol's defaults, not its base's. A curated record skips this
+// comparison entirely (rec.curated below): its own rows can carry their
+// own curated endpoints from the models.dev conversion's npm-to-preset
+// mapping (google-vertex's claude-opus-5 row genuinely uses the
+// vertex-anthropic preset's endpoints, baked in at conversion time, not a
+// redirect), and there is no row-less baseline to compare a curated
+// record's own row against that would not misread the vendor's own
+// cross-protocol mapping as one. ModelsEndpoint is not part of this class:
+// every protocol's ListModels sends a bodyless GET, so it can never carry a
+// WebSearch tool definition regardless of where it points.
+func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto string, ownOverride bool) bool {
 	base, ok := r.curated[rec.providerID]
 	if !ok {
 		return true
 	}
-	if resolvedBaseURL == "" {
+	own := strings.TrimRight(transport.BaseURL, "/")
+	if own == "" {
 		return true
 	}
 	defaults, missing, _ := r.resolveBaseURLWith(base, base.head.Transport, r.defaultVarLookup(base))
-	if len(missing) > 0 {
+	defaults = strings.TrimRight(defaults, "/")
+	switch {
+	case len(missing) > 0:
 		// rec.curated is an explicit belt-and-suspenders guard, not load-
 		// bearing against today's data: a curated record never folds a
 		// LayerConfig layer, so ownOverride and vertexHostOverridden (both
@@ -172,9 +200,29 @@ func (r *Registry) firstPartyEndpoint(rec *record, resolvedBaseURL string, ownOv
 		// trusted the same way the vendor's provider-level template
 		// already is, rather than accidentally gated by a mechanism built
 		// to catch user-config redirection.
-		return rec.curated || (!ownOverride && !r.vertexHostOverridden(rec))
+		if !rec.curated && (ownOverride || r.vertexHostOverridden(rec)) {
+			return false
+		}
+	case own != defaults:
+		return false
 	}
-	return resolvedBaseURL == defaults
+	if rec.curated {
+		// The base_url checks above already establish this resolution
+		// reaches the vendor: trust the rest of a curated record's own
+		// data too, endpoints included. A curated row can legitimately
+		// carry its own Endpoint/StreamEndpoint/CountTokensEndpoint from
+		// the models.dev conversion's npm-to-preset mapping
+		// (google-vertex's claude-opus-5 row: protocol anthropic, the
+		// vertex-anthropic preset's endpoints, both baked in at
+		// conversion time, spec §4.2 - not user config); comparing that
+		// against a same-provider, row-less baseline would misread the
+		// vendor's own cross-protocol mapping as a redirect.
+		return true
+	}
+	canonical, _ := r.buildTransport(base, Model{}, proto)
+	return transport.Endpoint == canonical.Endpoint &&
+		transport.StreamEndpoint == canonical.StreamEndpoint &&
+		transport.CountTokensEndpoint == canonical.CountTokensEndpoint
 }
 
 // vertexHostOverridden reports whether rec's own vars (never the curated

--- a/llm/registry/instances.go
+++ b/llm/registry/instances.go
@@ -101,31 +101,60 @@ func (r *Registry) effectiveAPIKeyEnv(rec *record) []string {
 	return rec.ownAPIKeyEnv
 }
 
-// baseURLDiverged reports whether rec's actually-resolved base URL differs
-// from what its provider (r.curated[rec.providerID], which is rec itself
-// for a curated record) resolves to using only the curated defaults - no
-// vars, no environment. It is WebSearch's analog of the endpoint stop
-// above (spec §10; gateWebSearch in resolve.go applies it), but broader: an
-// unused api_key_env is merely wasted, so the stop above fires only for a
-// literal base_url override, letting a *_BASE_URL environment override
-// (Bedrock's and Vertex's vars, or a same-shaped proxy) inherit the vendor
-// key normally. A hosted-tool definition the gateway does not implement
-// instead fails the whole request (issue #738), so this check also catches
-// that narrower environment-only case. When the provider's own template
-// cannot fully resolve without vars only a real deployment supplies
-// (Vertex's project, Bedrock's region), there is no baseline to compare
-// against, so nothing is reported as diverged.
-func (r *Registry) baseURLDiverged(rec *record) bool {
+// firstPartyEndpoint reports whether rec reaches its provider
+// (r.curated[rec.providerID], which is rec itself for a curated record) at
+// that vendor's own canonical endpoint. WebSearch's gate uses this (spec
+// §10's endpoint-stop is the analog; gateWebSearch in resolve.go applies
+// it) - Jesse's framing (2026-09-01, issue #738): "web_search should only
+// be available from openai as openai." A vendor's hosted search runs on the
+// vendor's own infrastructure, so any redirection away from it forfeits
+// the capability, however the redirection is expressed - unlike the
+// endpoint stop below, which only fires for a literal base_url override
+// and lets a *_BASE_URL environment override inherit the key normally
+// (an unused credential is merely wasted; a hosted-tool definition the
+// gateway does not implement fails the whole request).
+//
+// Two shapes, both compared against defaults, the provider's own template
+// resolved with only its curated vars - no user vars, no environment (spec
+// §10's "after substituting the curated defaults"):
+//
+//   - rec.ownBaseURL == "" (including every curated record, which never
+//     sets it): rec's own config never replaced the provider's base_url
+//     template, so the template itself proves nothing - first-party turns
+//     on whether the *values* plugged into it (rec's own vars, then
+//     environment, then the curated default, spec §9.1's order) land on
+//     the curated default when the provider defines one (openai's
+//     BASE_URL; a *_BASE_URL environment override is exactly the case this
+//     line exists to catch). A provider whose template takes only
+//     deployment-specific variables with no curated default (Vertex's
+//     project, Bedrock's region - every deployment supplies its own) has
+//     no default to diverge from, so the template alone being intact is
+//     first-party.
+//   - rec.ownBaseURL != "": rec's own config set a literal base_url,
+//     replacing the template outright. First-party only if that literal
+//     reproduces the curated default byte for byte (copying the default
+//     verbatim is not "different", spec §10). A provider with no curated
+//     default has nothing a literal override could legitimately reproduce,
+//     so this is never first-party - the fix for the gap a prior version of
+//     this check left open: a missing curated default used to make every
+//     google-vertex-anthropic/google-vertex-based record "first-party" by
+//     default, literal override or not, because the check never
+//     distinguished "the template has no default" from "rec kept the
+//     template".
+func (r *Registry) firstPartyEndpoint(rec *record) bool {
 	base, ok := r.curated[rec.providerID]
 	if !ok {
-		return false
+		return true
 	}
 	own, _, _ := r.resolveBaseURL(rec, rec.head.Transport)
-	defaults, missing, _ := r.resolveBaseURLWith(base, base.head.Transport, r.defaultVarLookup(base))
-	if own == "" || len(missing) > 0 {
-		return false
+	if own == "" {
+		return true
 	}
-	return own != defaults
+	defaults, missing, _ := r.resolveBaseURLWith(base, base.head.Transport, r.defaultVarLookup(base))
+	if len(missing) > 0 {
+		return rec.curated || rec.ownBaseURL == ""
+	}
+	return own == defaults
 }
 
 // envCandidates lists, in the order credential resolution tries them, every

--- a/llm/registry/instances.go
+++ b/llm/registry/instances.go
@@ -101,58 +101,115 @@ func (r *Registry) effectiveAPIKeyEnv(rec *record) []string {
 	return rec.ownAPIKeyEnv
 }
 
-// firstPartyEndpoint reports whether rec reaches its provider
-// (r.curated[rec.providerID], which is rec itself for a curated record) at
-// that vendor's own canonical endpoint. WebSearch's gate uses this (spec
-// §10's endpoint-stop is the analog; gateWebSearch in resolve.go applies
-// it) - Jesse's framing (2026-09-01, issue #738): "web_search should only
-// be available from openai as openai." A vendor's hosted search runs on the
-// vendor's own infrastructure, so any redirection away from it forfeits
-// the capability, however the redirection is expressed - unlike the
-// endpoint stop above, which only fires for a literal base_url override
-// and lets a *_BASE_URL environment override inherit the key normally
-// (an unused credential is merely wasted; a hosted-tool definition the
-// gateway does not implement fails the whole request).
+// firstPartyEndpoint reports whether the endpoint a specific resolution
+// actually reaches - resolvedBaseURL, the fully resolved transport
+// buildTransport produced, row-level overrides and all, not just the
+// instance's own rec.head.Transport - is its provider's
+// (r.curated[rec.providerID], which is rec itself for a curated record) own
+// canonical endpoint. WebSearch's gate uses this (spec §10's endpoint-stop
+// above is the analog; gateWebSearch in resolve.go applies it) - Jesse's
+// framing (2026-09-01, issue #738): "web_search should only be available
+// from openai as openai." A vendor's hosted search runs on the vendor's own
+// infrastructure, so any redirection away from it forfeits the capability,
+// however the redirection is expressed - unlike the endpoint stop above,
+// which only fires for a literal base_url override and lets a *_BASE_URL
+// environment override inherit the key normally (an unused credential is
+// merely wasted; a hosted-tool definition the gateway does not implement
+// fails the whole request).
+//
+// ownOverride is true when anything rec's own config controls replaced the
+// provider's base_url template outright, rather than merely supplying
+// values for it: a literal base_url= on the instance itself
+// (rec.ownBaseURL != ""), or on the specific model row being resolved
+// (row.Transport's own BaseURL, spec §10's `[providers.X.models."id"]`
+// transport keys) - a row-level override must gate the same as an
+// instance-level one, since buildTransport merges it into the same
+// endpoint the request actually reaches.
 //
 // Two shapes, both compared against defaults, the provider's own template
 // resolved with only its curated vars - no user vars, no environment (spec
 // §10's "after substituting the curated defaults"):
 //
-//   - rec.ownBaseURL == "" (including every curated record, which never
-//     sets it): rec's own config never replaced the provider's base_url
-//     template, so the template itself proves nothing - first-party turns
-//     on whether the *values* plugged into it (rec's own vars, then
-//     environment, then the curated default, spec §9.1's order) land on
-//     the curated default when the provider defines one (openai's
-//     BASE_URL; a *_BASE_URL environment override is exactly the case this
-//     line exists to catch). A provider whose template takes only
-//     deployment-specific variables with no curated default (Vertex's
-//     project, Bedrock's region - every deployment supplies its own) has
-//     no default to diverge from, so the template alone being intact is
-//     first-party.
-//   - rec.ownBaseURL != "": rec's own config set a literal base_url,
-//     replacing the template outright. First-party only if that literal
-//     reproduces the curated default byte for byte (copying the default
-//     verbatim is not "different", spec §10). A provider with no curated
-//     default has nothing a literal override could legitimately reproduce,
-//     so this is never first-party: a missing curated default must not be
-//     read as "nothing to compare", or every google-vertex-anthropic and
-//     google-vertex-based record would be first-party by default, literal
-//     override or not.
-func (r *Registry) firstPartyEndpoint(rec *record) bool {
+//   - !ownOverride (including every curated record, which can never set
+//     rec.ownBaseURL and whose curated rows carry no per-row override
+//     today): nothing replaced the provider's base_url template, so the
+//     template itself proves nothing - first-party turns on whether the
+//     *values* plugged into it (rec's own vars, then environment, then the
+//     curated default, spec §9.1's order) land on the curated default when
+//     the provider defines one (openai's BASE_URL; a *_BASE_URL environment
+//     override is exactly the case this line exists to catch). A provider
+//     whose template takes only deployment-specific variables with no
+//     curated default (Vertex's project, Bedrock's region - every
+//     deployment supplies its own) has no default to diverge from, so the
+//     template alone being intact is first-party - unless the record
+//     redirects the one variable that is not deployment-specific: see
+//     vertexHostOverridden.
+//   - ownOverride: something replaced the template outright. First-party
+//     only if the fully resolved URL reproduces the curated default byte
+//     for byte (copying the default verbatim is not "different", spec
+//     §10). A provider with no curated default has nothing a literal
+//     override could legitimately reproduce, so this is never first-party:
+//     a missing curated default must not be read as "nothing to compare",
+//     or every google-vertex-anthropic and google-vertex-based record
+//     would be first-party by default, override or not.
+func (r *Registry) firstPartyEndpoint(rec *record, resolvedBaseURL string, ownOverride bool) bool {
 	base, ok := r.curated[rec.providerID]
 	if !ok {
 		return true
 	}
-	own, _, _ := r.resolveBaseURL(rec, rec.head.Transport)
-	if own == "" {
+	if resolvedBaseURL == "" {
 		return true
 	}
 	defaults, missing, _ := r.resolveBaseURLWith(base, base.head.Transport, r.defaultVarLookup(base))
 	if len(missing) > 0 {
-		return rec.curated || rec.ownBaseURL == ""
+		// rec.curated is an explicit belt-and-suspenders guard, not load-
+		// bearing against today's data: a curated record never folds a
+		// LayerConfig layer, so ownOverride and vertexHostOverridden (both
+		// sourced from rec.userVars / a LayerConfig row) are already
+		// structurally false for one. It stays explicit so a future curated
+		// overlay row that sets its own base_url or GOOGLE_VERTEX_HOST -
+		// the vendor's own documented shape, not a user redirect - is
+		// trusted the same way the vendor's provider-level template
+		// already is, rather than accidentally gated by a mechanism built
+		// to catch user-config redirection.
+		return rec.curated || (!ownOverride && !r.vertexHostOverridden(rec))
 	}
-	return own == defaults
+	return resolvedBaseURL == defaults
+}
+
+// vertexHostOverridden reports whether rec's own vars (never the curated
+// default, since google-vertex-anthropic/google-vertex define none) supply
+// a literal GOOGLE_VERTEX_HOST directly, bypassing vertexHost(LOCATION) -
+// the derivation the vertex-location host rule exists to perform
+// (resolveBaseURLWith's HostRuleVertexLocation case, load.go). The
+// vars-only carve-out above trusts a record that keeps the template, but a
+// direct GOOGLE_VERTEX_HOST leaves rec.ownBaseURL empty (the template is
+// technically untouched - it is still
+// "{GOOGLE_VERTEX_HOST}/v1/projects/.../locations/...") while still routing
+// every request to an arbitrary gateway, because GOOGLE_VERTEX_HOST is not
+// deployment-specific the way GOOGLE_VERTEX_PROJECT/LOCATION are: there is
+// exactly one correct value for a given location, computed by the rule,
+// and a record that supplies its own is substituting a choice, not
+// deployment data. A supplied value that happens to equal what the
+// derivation would have produced anyway is not an override (copying the
+// default verbatim is not "different", spec §10).
+//
+// Only vertex-location needs this today: Ollama's host rule
+// (resolveOllamaHost) derives from OLLAMA_HOST/OLLAMA_BASE_URL through a
+// different shape entirely (no single "the" derived value to compare
+// against), and no Ollama-family provider sets web_search, so there is
+// nothing for the same class of bypass to reach yet.
+func (r *Registry) vertexHostOverridden(rec *record) bool {
+	if rec.head.Transport.HostRule != HostRuleVertexLocation {
+		return false
+	}
+	raw := r.varLookupWith(rec, func(string) {})
+	given, ok := raw("GOOGLE_VERTEX_HOST")
+	if !ok {
+		return false
+	}
+	loc, ok := raw("GOOGLE_VERTEX_LOCATION")
+	return !ok || given != vertexHost(loc)
 }
 
 // envCandidates lists, in the order credential resolution tries them, every

--- a/llm/registry/instances.go
+++ b/llm/registry/instances.go
@@ -103,81 +103,55 @@ func (r *Registry) effectiveAPIKeyEnv(rec *record) []string {
 
 // firstPartyEndpoint reports whether the endpoint a specific resolution
 // actually reaches - transport, the fully resolved Transport buildTransport
-// produced (row-level overrides and all, not just the instance's own
-// rec.head.Transport), resolved for proto - is its provider's
-// (r.curated[rec.providerID], which is rec itself for a curated record) own
-// canonical endpoint. WebSearch's gate uses this (spec §10's endpoint-stop
-// above is the analog; gateWebSearch in resolve.go applies it) - Jesse's
-// framing (2026-09-01, issue #738): "web_search should only be available
-// from openai as openai." A vendor's hosted search runs on the vendor's own
-// infrastructure, so any redirection away from it forfeits the capability,
-// however the redirection is expressed - unlike the endpoint stop above,
-// which only fires for a literal base_url override and lets a *_BASE_URL
-// environment override inherit the key normally (an unused credential is
-// merely wasted; a hosted-tool definition the gateway does not implement
-// fails the whole request).
+// produced (row-level overrides included, not just the instance's own
+// rec.head.Transport), resolved for proto against row rowID - is its
+// provider's (r.curated[rec.providerID], which is rec itself for a curated
+// record) own first-party endpoint: a vendor's hosted tools run on the
+// vendor's own infrastructure, so a resolution reaching anywhere else does
+// not get to carry them (WebSearch's gate, resolve.go's gateWebSearch,
+// applies this; spec §10's credential endpoint stop is the analogous rule
+// for the API key). TestResolve_WebSearchEndpointGate pins the case
+// catalog this has to get right; the invariants below are the ones a
+// reader would not derive from the code alone.
 //
-// ownOverride is true when anything rec's own config controls replaced the
-// provider's base_url template outright, rather than merely supplying
-// values for it: a literal base_url= on the instance itself
-// (rec.ownBaseURL != ""), or on the specific model row being resolved
-// (row.Transport's own BaseURL, spec §10's `[providers.X.models."id"]`
-// transport keys) - a row-level override must gate the same as an
-// instance-level one, since buildTransport merges it into the same
-// endpoint the request actually reaches.
+// ownOverride is true when anything rec's own config replaced the
+// provider's base_url template outright - literally (rec.ownBaseURL) or on
+// the resolved row (row.Transport's own BaseURL) - rather than merely
+// supplying values for it. base_url is compared against the provider's own
+// template resolved with only its curated vars (spec §10's "after
+// substituting the curated defaults"); trailing slashes are trimmed on
+// both sides first, mirroring protocolhttp.URL's own
+// strings.TrimRight(BaseURL, "/") rather than inventing a broader
+// canonicalization. A provider whose template needs only
+// deployment-specific variables with no curated default (Vertex, Bedrock)
+// has no default to diverge from - the template alone being intact is
+// first-party there, unless the record redirects the one variable that is
+// not deployment-specific (vertexHostOverridden).
 //
-// Two shapes, both compared against defaults, the provider's own template
-// resolved with only its curated vars - no user vars, no environment (spec
-// §10's "after substituting the curated defaults"), and both with the
-// trailing-slash normalization protocolhttp.URL itself applies
-// (strings.TrimRight(BaseURL, "/") before joining the endpoint path) so a
-// *_BASE_URL that merely repeats or drops a trailing slash is not read as
-// a different endpoint - not a broader canonicalization, just mirroring
-// the one the request builder already does:
+// A resolved base_url is not the whole story: its own endpoint,
+// stream_endpoint, or count_tokens_endpoint can send the same
+// web-search-bearing request body elsewhere while base_url stays
+// canonical. All three are judged the same way base_url is: against what
+// buildTransport produces for the provider's own record with no instance
+// overrides, for proto (which already applies the cross-protocol rule,
+// spec §4.2, so a legitimately cross-protocol instance is judged against
+// its own protocol's defaults) and the matching curated row
+// (base.head.Models[rowID]) rather than no row at all - a non-curated
+// instance that inherits a curated row with its own transport (a custom
+// instance with base = "google-vertex" resolving a Claude model, whose row
+// genuinely carries the vertex-anthropic preset from the models.dev
+// npm-to-preset conversion) is judged against that row, not a row-less
+// baseline that could never reproduce it; rowID == "" (ResolveInstance's
+// model-less path) falls back to the row-less comparison a provider-level
+// resolution needs anyway. ModelsEndpoint is excluded from this class:
+// ListModels is always a bodyless GET, so it can never carry WebSearch.
 //
-//   - !ownOverride (including every curated record, which can never set
-//     rec.ownBaseURL and whose curated rows carry no per-row override
-//     today): nothing replaced the provider's base_url template, so the
-//     template itself proves nothing - first-party turns on whether the
-//     *values* plugged into it (rec's own vars, then environment, then the
-//     curated default, spec §9.1's order) land on the curated default when
-//     the provider defines one (openai's BASE_URL; a *_BASE_URL environment
-//     override is exactly the case this line exists to catch). A provider
-//     whose template takes only deployment-specific variables with no
-//     curated default (Vertex's project, Bedrock's region - every
-//     deployment supplies its own) has no default to diverge from, so the
-//     template alone being intact is first-party - unless the record
-//     redirects the one variable that is not deployment-specific: see
-//     vertexHostOverridden.
-//   - ownOverride: something replaced the template outright. First-party
-//     only if the fully resolved URL reproduces the curated default byte
-//     for byte (copying the default verbatim is not "different", spec
-//     §10). A provider with no curated default has nothing a literal
-//     override could legitimately reproduce, so this is never first-party:
-//     a missing curated default must not be read as "nothing to compare",
-//     or every google-vertex-anthropic and google-vertex-based record
-//     would be first-party by default, override or not.
-//
-// The base_url check alone is not the complete picture: a canonical
-// base_url with its own endpoint, stream_endpoint, or count_tokens_endpoint
-// sends the same web-search-bearing request body somewhere else entirely
-// (buildTransport merges a row's own endpoint overrides too, the same
-// class of gap ownOverride already closes for base_url). For an instance,
-// all three are compared against what buildTransport would produce for the
-// provider's own record with no row and no instance overrides, for the
-// same proto - which already applies the cross-protocol rule (spec §4.2),
-// so a legitimately cross-protocol instance is compared against its own
-// protocol's defaults, not its base's. A curated record skips this
-// comparison entirely (rec.curated below): its own rows can carry their
-// own curated endpoints from the models.dev conversion's npm-to-preset
-// mapping (google-vertex's claude-opus-5 row genuinely uses the
-// vertex-anthropic preset's endpoints, baked in at conversion time, not a
-// redirect), and there is no row-less baseline to compare a curated
-// record's own row against that would not misread the vendor's own
-// cross-protocol mapping as one. ModelsEndpoint is not part of this class:
-// every protocol's ListModels sends a bodyless GET, so it can never carry a
-// WebSearch tool definition regardless of where it points.
-func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto string, ownOverride bool) bool {
+// A curated record (rec.curated) is trusted outright once base_url checks
+// out, endpoint comparison included: it is compared against itself
+// (base == rec), so the comparison would be trivially true anyway, but
+// skipping it also skips the row lookup, which matters when rowID names a
+// row the curated record's own config (not a user's) supplies.
+func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto, rowID string, ownOverride bool) bool {
 	base, ok := r.curated[rec.providerID]
 	if !ok {
 		return true
@@ -190,16 +164,12 @@ func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto st
 	defaults = strings.TrimRight(defaults, "/")
 	switch {
 	case len(missing) > 0:
-		// rec.curated is an explicit belt-and-suspenders guard, not load-
-		// bearing against today's data: a curated record never folds a
-		// LayerConfig layer, so ownOverride and vertexHostOverridden (both
-		// sourced from rec.userVars / a LayerConfig row) are already
-		// structurally false for one. It stays explicit so a future curated
-		// overlay row that sets its own base_url or GOOGLE_VERTEX_HOST -
-		// the vendor's own documented shape, not a user redirect - is
-		// trusted the same way the vendor's provider-level template
-		// already is, rather than accidentally gated by a mechanism built
-		// to catch user-config redirection.
+		// rec.curated is a belt-and-suspenders guard, not load-bearing
+		// against today's data (a curated record never folds a
+		// LayerConfig layer, so ownOverride/vertexHostOverridden are
+		// already false for one) - kept explicit so a future curated row
+		// with its own base_url or GOOGLE_VERTEX_HOST is trusted the same
+		// way the vendor's provider-level template already is.
 		if !rec.curated && (ownOverride || r.vertexHostOverridden(rec)) {
 			return false
 		}
@@ -207,19 +177,13 @@ func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto st
 		return false
 	}
 	if rec.curated {
-		// The base_url checks above already establish this resolution
-		// reaches the vendor: trust the rest of a curated record's own
-		// data too, endpoints included. A curated row can legitimately
-		// carry its own Endpoint/StreamEndpoint/CountTokensEndpoint from
-		// the models.dev conversion's npm-to-preset mapping
-		// (google-vertex's claude-opus-5 row: protocol anthropic, the
-		// vertex-anthropic preset's endpoints, both baked in at
-		// conversion time, spec §4.2 - not user config); comparing that
-		// against a same-provider, row-less baseline would misread the
-		// vendor's own cross-protocol mapping as a redirect.
 		return true
 	}
-	canonical, _ := r.buildTransport(base, Model{}, proto)
+	var row Model
+	if rowID != "" {
+		row = base.head.Models[rowID]
+	}
+	canonical, _ := r.buildTransport(base, row, proto)
 	return transport.Endpoint == canonical.Endpoint &&
 		transport.StreamEndpoint == canonical.StreamEndpoint &&
 		transport.CountTokensEndpoint == canonical.CountTokensEndpoint
@@ -229,24 +193,21 @@ func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto st
 // default, since google-vertex-anthropic/google-vertex define none) supply
 // a literal GOOGLE_VERTEX_HOST directly, bypassing vertexHost(LOCATION) -
 // the derivation the vertex-location host rule exists to perform
-// (resolveBaseURLWith's HostRuleVertexLocation case, load.go). The
-// vars-only carve-out above trusts a record that keeps the template, but a
-// direct GOOGLE_VERTEX_HOST leaves rec.ownBaseURL empty (the template is
-// technically untouched - it is still
-// "{GOOGLE_VERTEX_HOST}/v1/projects/.../locations/...") while still routing
-// every request to an arbitrary gateway, because GOOGLE_VERTEX_HOST is not
-// deployment-specific the way GOOGLE_VERTEX_PROJECT/LOCATION are: there is
-// exactly one correct value for a given location, computed by the rule,
-// and a record that supplies its own is substituting a choice, not
-// deployment data. A supplied value that happens to equal what the
-// derivation would have produced anyway is not an override (copying the
-// default verbatim is not "different", spec §10).
+// (resolveBaseURLWith's HostRuleVertexLocation case, load.go). Unlike
+// GOOGLE_VERTEX_PROJECT/LOCATION, which are genuinely deployment-specific,
+// GOOGLE_VERTEX_HOST has exactly one correct value for a given location;
+// supplying a different one is a redirect the vars-only carve-out above
+// would otherwise miss, since it leaves rec.ownBaseURL empty (the template
+// is technically untouched). A supplied value that happens to equal the
+// derivation's own answer is not an override (copying the default
+// verbatim is not "different", spec §10).
 //
-// Only vertex-location needs this today: Ollama's host rule
-// (resolveOllamaHost) derives from OLLAMA_HOST/OLLAMA_BASE_URL through a
-// different shape entirely (no single "the" derived value to compare
-// against), and no Ollama-family provider sets web_search, so there is
-// nothing for the same class of bypass to reach yet.
+// This check is Vertex-specific by necessity, not by choice: it is the
+// only host rule with both a missing curated base_url default and a
+// provider that sets web_search today. A future provider sharing that
+// shape - no curated default, host routed through its own env var, kept
+// template - would need an equivalent check of its own; nothing here
+// generalizes to it automatically.
 func (r *Registry) vertexHostOverridden(rec *record) bool {
 	if rec.head.Transport.HostRule != HostRuleVertexLocation {
 		return false

--- a/llm/registry/instances.go
+++ b/llm/registry/instances.go
@@ -160,6 +160,11 @@ func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto, r
 	if own == "" {
 		return true
 	}
+	// missing (not just defaults) decides which switch case applies, and
+	// both come from this one resolveBaseURLWith call - a second call
+	// keyed on missing == 0 would just repeat this same work, not skip it -
+	// so defaults sits unused in the len(missing) > 0 case rather than
+	// being computed twice.
 	defaults, missing, _ := r.resolveBaseURLWith(base, base.head.Transport, r.defaultVarLookup(base))
 	defaults = strings.TrimRight(defaults, "/")
 	switch {
@@ -170,7 +175,7 @@ func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto, r
 		// already false for one) - kept explicit so a future curated row
 		// with its own base_url or GOOGLE_VERTEX_HOST is trusted the same
 		// way the vendor's provider-level template already is.
-		if !rec.curated && (ownOverride || r.vertexHostOverridden(rec)) {
+		if !rec.curated && (ownOverride || r.vertexHostOverridden(rec, base, own)) {
 			return false
 		}
 	case own != defaults:
@@ -189,18 +194,25 @@ func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto, r
 		transport.CountTokensEndpoint == canonical.CountTokensEndpoint
 }
 
-// vertexHostOverridden reports whether rec's own vars (never the curated
-// default, since google-vertex-anthropic/google-vertex define none) supply
-// a literal GOOGLE_VERTEX_HOST directly, bypassing vertexHost(LOCATION) -
-// the derivation the vertex-location host rule exists to perform
-// (resolveBaseURLWith's HostRuleVertexLocation case, load.go). Unlike
-// GOOGLE_VERTEX_PROJECT/LOCATION, which are genuinely deployment-specific,
-// GOOGLE_VERTEX_HOST has exactly one correct value for a given location;
-// supplying a different one is a redirect the vars-only carve-out above
-// would otherwise miss, since it leaves rec.ownBaseURL empty (the template
-// is technically untouched). A supplied value that happens to equal the
-// derivation's own answer is not an override (copying the default
-// verbatim is not "different", spec §10).
+// vertexHostOverridden reports whether rec's resolved host diverges from
+// Vertex's real, location-derived infrastructure - the derivation the
+// vertex-location host rule exists to perform (resolveBaseURLWith's
+// HostRuleVertexLocation case, load.go) - by either of two means:
+//
+//   - rec's own host_rule differs from base's: swapping to a different
+//     rule (the only other one today, ollama-host) does not intercept
+//     GOOGLE_VERTEX_HOST at all, so a literal value supplied alongside it
+//     flows straight through unresolved-by-derivation. Because that swap
+//     also disables the direct-override check below (a record inspecting
+//     its own, now-different rule would never even look), the swap itself
+//     counts as divergence rather than being trusted to self-report.
+//   - own's actual resolved host does not match vertexHost(LOCATION),
+//     checked directly against the fully resolved URL rather than by
+//     asking rec's own (unswapped) rule whether GOOGLE_VERTEX_HOST was
+//     overridden - so a value that happens to equal the derivation's own
+//     answer is not an override (copying the default verbatim is not
+//     "different", spec §10), and no other means of steering the same
+//     outcome slips through.
 //
 // This check is Vertex-specific by necessity, not by choice: it is the
 // only host rule with both a missing curated base_url default and a
@@ -208,17 +220,15 @@ func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto, r
 // shape - no curated default, host routed through its own env var, kept
 // template - would need an equivalent check of its own; nothing here
 // generalizes to it automatically.
-func (r *Registry) vertexHostOverridden(rec *record) bool {
-	if rec.head.Transport.HostRule != HostRuleVertexLocation {
-		return false
+func (r *Registry) vertexHostOverridden(rec, base *record, own string) bool {
+	if rec.head.Transport.HostRule != base.head.Transport.HostRule {
+		return true
 	}
-	raw := r.varLookupWith(rec, func(string) {})
-	given, ok := raw("GOOGLE_VERTEX_HOST")
+	loc, ok := r.varLookupWith(rec, func(string) {})("GOOGLE_VERTEX_LOCATION")
 	if !ok {
 		return false
 	}
-	loc, ok := raw("GOOGLE_VERTEX_LOCATION")
-	return !ok || given != vertexHost(loc)
+	return !strings.HasPrefix(own, strings.TrimRight(vertexHost(loc), "/")+"/")
 }
 
 // envCandidates lists, in the order credential resolution tries them, every

--- a/llm/registry/instances.go
+++ b/llm/registry/instances.go
@@ -138,9 +138,12 @@ func (r *Registry) effectiveAPIKeyEnv(rec *record) []string {
 // The canonical resolution admits values from the actual resolution's own
 // variable lookup only where they cannot move the request off the vendor's
 // infrastructure (canonicalVarLookup): path-position vars pass through
-// verbatim, authority-position vars resolve only from curated defaults or
-// a host rule's own derivation and otherwise stay unexpanded, failing the
-// comparison against any actually-resolved URL - fail closed.
+// verbatim; authority-affecting vars - template-authority placeholders and
+// the inputs the host rule derives the authority from - resolve only from
+// curated defaults, the rule's own derivation, or a rule input whose
+// validated shape proves it harmless (a label-shaped Vertex location), and
+// otherwise stay unexpanded, failing the comparison against any
+// actually-resolved URL - fail closed.
 //
 // ref and altID feed the canonical glob replay (canonicalRow) so curated
 // glob rows match the same ids they matched in the actual resolution;
@@ -159,7 +162,7 @@ func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto, r
 		row = r.canonicalRow(base, ref, altID, rowID, proto)
 	}
 	canonical := r.transportShape(base, row, proto)
-	lookup := r.canonicalVarLookup(rec, base, canonical.BaseURL)
+	lookup := r.canonicalVarLookup(rec, base, canonical)
 	noEnv := func(string) (string, bool) { return "", false }
 	baseURL, _, _ := r.resolveBaseURLVia(canonical, lookup, noEnv)
 	canonical.BaseURL = baseURL
@@ -210,27 +213,65 @@ func (r *Registry) canonicalRow(base *record, ref, altID, rowID, proto string) M
 }
 
 // canonicalVarLookup supplies variable values for the canonical resolution
-// of the base_url template tpl. Path-position vars take the actual
-// resolution's own value (rec's full lookup: user vars, environment,
+// of the transport shape's base_url template. Path-position vars take the
+// actual resolution's own value (rec's full lookup: user vars, environment,
 // curated defaults) - both sides then expand identically, and a path value
 // can never rewrite the authority the template terminated before the var
-// began. Authority-position vars (authorityVars) take only the provider's
-// curated default, never a user- or environment-supplied value; a host
-// rule may still derive one (resolveBaseURLVia's vertex-location case
-// derives vertexHost(GOOGLE_VERTEX_LOCATION) - a path-position lookup -
-// when this lookup declines GOOGLE_VERTEX_HOST), and a var with neither
-// default nor derivation stays unexpanded, so the canonical URL cannot
-// equal any actually-resolved one: fail closed.
-func (r *Registry) canonicalVarLookup(rec, base *record, tpl string) func(string) (string, bool) {
-	authority := authorityVars(tpl)
+// began. Authority-affecting vars - a placeholder inside the template's
+// authority region (authorityVars), or any input the shape's host RULE
+// consumes to derive the authority (hostRuleAuthorityVars; template
+// position cannot see those, and a poisoned derivation input rewrites the
+// host on both sides identically, comparing equal) - never take a raw user
+// or environment value. They resolve from the provider's curated default,
+// or from the actual value only when the rule's own input validation
+// proves it cannot move the derivation off the vendor's domain
+// (hostRuleInputAdmissible: a label-shaped Vertex location). Anything else
+// stays unexpanded, so the canonical URL cannot equal any actually-resolved
+// one: fail closed.
+func (r *Registry) canonicalVarLookup(rec, base *record, shape Transport) func(string) (string, bool) {
+	authority := authorityVars(shape.BaseURL)
+	for _, name := range hostRuleAuthorityVars(shape.HostRule) {
+		authority[name] = true
+	}
 	actual := r.varLookup(rec)
 	defaults := r.defaultVarLookup(base)
 	return func(name string) (string, bool) {
 		if authority[name] {
+			if v, ok := actual(name); ok && hostRuleInputAdmissible(shape.HostRule, name, v) {
+				return v, true
+			}
 			return defaults(name)
 		}
 		return actual(name)
 	}
+}
+
+// hostRuleAuthorityVars names the variables a host rule consumes to
+// produce the authority. The rule's derivation runs on these values, so
+// they are authority-affecting wherever they appear: GOOGLE_VERTEX_LOCATION
+// sits in path position in the Vertex template, yet vertexHost builds the
+// host from it. OLLAMA_BASE_URL is deliberately absent - the ollama-host
+// rule reads it from the environment, which the canonical resolution
+// already severs (resolveBaseURLVia's env parameter).
+func hostRuleAuthorityVars(rule string) []string {
+	switch rule {
+	case HostRuleVertexLocation:
+		return []string{"GOOGLE_VERTEX_HOST", "GOOGLE_VERTEX_LOCATION"}
+	case HostRuleOllamaHost:
+		return []string{"OLLAMA_HOST"}
+	}
+	return nil
+}
+
+// hostRuleInputAdmissible reports whether a host rule's derivation input
+// may take the user's own value on the canonical side: only when its
+// shape proves the derivation cannot leave the vendor's domain. A Vertex
+// location that is a single hostname label (validVertexLocation) composes
+// into *.googleapis.com and nothing else. No other rule input qualifies -
+// GOOGLE_VERTEX_HOST and OLLAMA_HOST are the authority itself, and only a
+// curated default or the derivation may supply those.
+func hostRuleInputAdmissible(rule, name, value string) bool {
+	return rule == HostRuleVertexLocation && name == "GOOGLE_VERTEX_LOCATION" && validVertexLocation(value)
 }
 
 // authorityVars names the {VAR} placeholders in tpl's authority region -

--- a/llm/registry/instances.go
+++ b/llm/registry/instances.go
@@ -104,150 +104,185 @@ func (r *Registry) effectiveAPIKeyEnv(rec *record) []string {
 
 // firstPartyEndpoint reports whether the endpoint a specific resolution
 // actually reaches - transport, the fully resolved Transport buildTransport
-// produced (row-level overrides included, not just the instance's own
-// rec.head.Transport), resolved for proto against row rowID - is its
-// provider's (r.curated[rec.providerID], which is rec itself for a curated
-// record) own first-party endpoint: a vendor's hosted tools run on the
-// vendor's own infrastructure, so a resolution reaching anywhere else does
-// not get to carry them (WebSearch's gate, resolve.go's gateWebSearch,
-// applies this; spec §10's credential endpoint stop is the analogous rule
-// for the API key). TestResolve_WebSearchEndpointGate pins the case
-// catalog this has to get right; the invariants below are the ones a
-// reader would not derive from the code alone.
+// produced, with config layers, glob rows, environment overrides, host
+// rules, and alias imports all folded in - is its provider's own
+// first-party endpoint: a vendor's hosted tools run on the vendor's own
+// infrastructure, so a resolution reaching anywhere else does not get to
+// carry them (WebSearch's gate, resolve.go's gateWebSearch, applies this;
+// spec §10's credential endpoint stop is the analogous rule for the API
+// key).
 //
-// ownOverride is true when anything rec's own config replaced the
-// provider's base_url template outright - literally (rec.ownBaseURL) or on
-// the resolved row (row.Transport's own BaseURL) - rather than merely
-// supplying values for it. base_url is compared against the provider's own
-// template resolved with only its curated vars (spec §10's "after
-// substituting the curated defaults"); trailing slashes are trimmed on
-// both sides first, mirroring protocolhttp.URL's own
-// strings.TrimRight(BaseURL, "/") rather than inventing a broader
-// canonicalization. A provider whose template needs only
-// deployment-specific variables with no curated default (Vertex, Bedrock)
-// has no default to diverge from - the template alone being intact is
-// first-party there, unless the record redirects the one variable that is
-// not deployment-specific (vertexHostOverridden).
+// The judgment is first-party by construction, not by override-detection:
+// config is compositional, so the channels that can redirect a request are
+// combinatorial and enumerating them cannot converge. Instead the
+// provider's curated layers alone (r.curated[rec.providerID]: the
+// snapshot/cache and overlay data, never the user's config or environment)
+// are resolved through the same transport machinery into the canonical
+// transport for (proto, rowID), and the actual transport must equal it:
+// base_url componentwise (sameEndpointURL) and each request-carrying
+// endpoint path exactly (Endpoint, StreamEndpoint, CountTokensEndpoint;
+// ModelsEndpoint is excluded because ListModels is a bodyless GET that can
+// never carry WebSearch). Any difference means the request lands somewhere
+// the vendor's own data does not describe. An override that reproduces the
+// canonical endpoint verbatim compares equal, so spec §10's "copying the
+// default is not different" needs no special case; neither does trusting a
+// curated record, whose actual resolution is the canonical one unless the
+// environment redirects it - which must strip, and does, by comparing
+// unequal. A record with no curated provider at all (a from-scratch
+// [providers.X] with its own base_url) has no vendor endpoint to diverge
+// from and is trivially first-party; only its own explicit web_search can
+// grant the capability anyway.
 //
-// A resolved base_url is not the whole story: its own endpoint,
-// stream_endpoint, or count_tokens_endpoint can send the same
-// web-search-bearing request body elsewhere while base_url stays
-// canonical. All three are judged the same way base_url is: against what
-// buildTransport produces for the provider's own record with no instance
-// overrides, for proto (which already applies the cross-protocol rule,
-// spec §4.2, so a legitimately cross-protocol instance is judged against
-// its own protocol's defaults) and the matching curated row
-// (base.head.Models[rowID]) rather than no row at all - a non-curated
-// instance that inherits a curated row with its own transport (a custom
-// instance with base = "google-vertex" resolving a Claude model, whose row
-// genuinely carries the vertex-anthropic preset from the models.dev
-// npm-to-preset conversion) is judged against that row, not a row-less
-// baseline that could never reproduce it; rowID == "" (ResolveInstance's
-// model-less path) falls back to the row-less comparison a provider-level
-// resolution needs anyway. ModelsEndpoint is excluded from this class:
-// ListModels is always a bodyless GET, so it can never carry WebSearch.
+// The canonical resolution admits values from the actual resolution's own
+// variable lookup only where they cannot move the request off the vendor's
+// infrastructure (canonicalVarLookup): path-position vars pass through
+// verbatim, authority-position vars resolve only from curated defaults or
+// a host rule's own derivation and otherwise stay unexpanded, failing the
+// comparison against any actually-resolved URL - fail closed.
 //
-// A curated record (rec.curated) is trusted outright once base_url checks
-// out, endpoint comparison included: it is compared against itself
-// (base == rec), so the comparison would be trivially true anyway, but
-// skipping it also skips the row lookup, which matters when rowID names a
-// row the curated record's own config (not a user's) supplies.
-func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto, rowID string, ownOverride bool) bool {
+// ref and altID feed the canonical glob replay (canonicalRow) so curated
+// glob rows match the same ids they matched in the actual resolution;
+// rowID names the resolved row - the alias target's row when an alias
+// imported its transport (resolveOn's canonicalRowID). All three empty is
+// ResolveInstance's model-less path, judged row-less on both sides.
+// TestResolve_WebSearchEndpointGate and TestResolve_WebSearchCanonicalGate
+// pin the case catalog this has to get right.
+func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto, rowID, ref, altID string) bool {
 	base, ok := r.curated[rec.providerID]
 	if !ok {
 		return true
 	}
-	own := strings.TrimRight(transport.BaseURL, "/")
-	if own == "" {
-		return true
-	}
-	// missing (not just defaults) decides which switch case applies, and
-	// both come from this one resolveBaseURLWith call - a second call
-	// keyed on missing == 0 would just repeat this same work, not skip it -
-	// so defaults sits unused in the len(missing) > 0 case rather than
-	// being computed twice.
-	defaults, missing, _ := r.resolveBaseURLWith(base, base.head.Transport, r.defaultVarLookup(base))
-	defaults = strings.TrimRight(defaults, "/")
-	switch {
-	case len(missing) > 0:
-		// rec.curated is a belt-and-suspenders guard, not load-bearing
-		// against today's data (a curated record never folds a
-		// LayerConfig layer, so ownOverride/vertexHostOverridden are
-		// already false for one) - kept explicit so a future curated row
-		// with its own base_url or GOOGLE_VERTEX_HOST is trusted the same
-		// way the vendor's provider-level template already is.
-		if !rec.curated && (ownOverride || r.vertexHostOverridden(rec, base)) {
-			return false
-		}
-	case own != defaults:
-		return false
-	}
-	if rec.curated {
-		return true
-	}
 	var row Model
-	if rowID != "" {
-		row = base.head.Models[rowID]
+	if rowID != "" || ref != "" {
+		row = r.canonicalRow(base, ref, altID, rowID, proto)
 	}
-	canonical, _ := r.buildTransport(base, row, proto)
-	return transport.Endpoint == canonical.Endpoint &&
+	canonical := r.transportShape(base, row, proto)
+	lookup := r.canonicalVarLookup(rec, base, canonical.BaseURL)
+	noEnv := func(string) (string, bool) { return "", false }
+	baseURL, _, _ := r.resolveBaseURLVia(canonical, lookup, noEnv)
+	canonical.BaseURL = baseURL
+	for _, field := range []*string{&canonical.Endpoint, &canonical.StreamEndpoint, &canonical.CountTokensEndpoint} {
+		expanded, _ := expandTemplate(*field, lookup)
+		*field = expanded
+	}
+	return sameEndpointURL(transport.BaseURL, canonical.BaseURL) &&
+		transport.Endpoint == canonical.Endpoint &&
 		transport.StreamEndpoint == canonical.StreamEndpoint &&
 		transport.CountTokensEndpoint == canonical.CountTokensEndpoint
 }
 
-// vertexHostOverridden reports whether rec's own GOOGLE_VERTEX_HOST
-// diverges from Vertex's real, location-derived infrastructure - the
-// derivation the vertex-location host rule exists to perform
-// (resolveBaseURLWith's HostRuleVertexLocation case, load.go) - by either
-// of two means:
-//
-//   - rec's own host_rule differs from base's: swapping to a different
-//     rule (the only other one today, ollama-host) does not intercept
-//     GOOGLE_VERTEX_HOST at all, so a literal value supplied alongside it
-//     flows straight through unresolved-by-derivation. Because that swap
-//     also disables the direct-override check below (a record inspecting
-//     its own, now-different rule would never even look), the swap itself
-//     counts as divergence rather than being trusted to self-report.
-//   - a supplied GOOGLE_VERTEX_HOST does not parse as exactly
-//     vertexHost(LOCATION)'s scheme and authority, with nothing else: no
-//     path, query, fragment, or userinfo. The canonical form vertexHost
-//     itself produces is authority-only (e.g. "https://aiplatform.googleapis.com",
-//     never a trailing slash or anything after it), so that is the whole
-//     comparison - not a prefix of the assembled base_url, which a value
-//     like "https://aiplatform.googleapis.com/proxy" would pass (the
-//     template's own "/v1/projects/..." continuation makes an injected
-//     path segment indistinguishable from the real one once the two are
-//     concatenated and read back as one string). Comparing the
-//     un-concatenated GOOGLE_VERTEX_HOST value on its own, component by
-//     component, closes that: a path, a different port, or userinfo all
-//     fail the check on their own terms, and a value that happens to
-//     equal the derivation's own answer is not an override (copying the
-//     default verbatim is not "different", spec §10).
-//
-// This check is Vertex-specific by necessity, not by choice: it is the
-// only host rule with both a missing curated base_url default and a
-// provider that sets web_search today. A future provider sharing that
-// shape - no curated default, host routed through its own env var, kept
-// template - would need an equivalent check of its own; nothing here
-// generalizes to it automatically.
-func (r *Registry) vertexHostOverridden(rec, base *record) bool {
-	if rec.head.Transport.HostRule != base.head.Transport.HostRule {
+// canonicalRow replays the provider's curated layers alone into the row the
+// canonical resolution resolves: the merged curated exact row, plus every
+// curated glob row applied in the order resolveOn applies them (top-level
+// globs once per layer tag, the layer's own globs, then the exact row),
+// matching against the same reference and alias-target ids the actual
+// resolution matched. base's layers are curated by construction, so no
+// LayerConfig contribution - the channel the gate exists to judge - can
+// reach the result.
+func (r *Registry) canonicalRow(base *record, ref, altID, rowID, proto string) Model {
+	var row Model
+	if rowID != "" {
+		if m, ok := base.head.Models[rowID]; ok {
+			row = cloneModel(m)
+		}
+	}
+	// The caps and provenance sinks are discarded: only the transport
+	// fields applyGlobs and applyRowScalars merge matter here.
+	caps := Caps{}
+	prov := map[string]string{}
+	crossProto := proto != base.head.Protocol
+	seenTag := map[string]bool{}
+	for _, layer := range base.layers {
+		if !seenTag[layer.tag] {
+			seenTag[layer.tag] = true
+			r.applyGlobs(&caps, &row, r.topGlobs[layer.tag], layer.tag, ref, altID, proto, crossProto, prov)
+		}
+		r.applyGlobs(&caps, &row, layer.rows, layer.tag, ref, altID, proto, crossProto, prov)
+		if rowID != "" {
+			if lr, ok := layer.rows[rowID]; ok {
+				applyRowScalars(&row, lr, layer.tag, prov)
+			}
+		}
+	}
+	return row
+}
+
+// canonicalVarLookup supplies variable values for the canonical resolution
+// of the base_url template tpl. Path-position vars take the actual
+// resolution's own value (rec's full lookup: user vars, environment,
+// curated defaults) - both sides then expand identically, and a path value
+// can never rewrite the authority the template terminated before the var
+// began. Authority-position vars (authorityVars) take only the provider's
+// curated default, never a user- or environment-supplied value; a host
+// rule may still derive one (resolveBaseURLVia's vertex-location case
+// derives vertexHost(GOOGLE_VERTEX_LOCATION) - a path-position lookup -
+// when this lookup declines GOOGLE_VERTEX_HOST), and a var with neither
+// default nor derivation stays unexpanded, so the canonical URL cannot
+// equal any actually-resolved one: fail closed.
+func (r *Registry) canonicalVarLookup(rec, base *record, tpl string) func(string) (string, bool) {
+	authority := authorityVars(tpl)
+	actual := r.varLookup(rec)
+	defaults := r.defaultVarLookup(base)
+	return func(name string) (string, bool) {
+		if authority[name] {
+			return defaults(name)
+		}
+		return actual(name)
+	}
+}
+
+// authorityVars names the {VAR} placeholders in tpl's authority region -
+// at or before the end of scheme://host[:port], where an expanded value
+// could supply or alter the scheme, host, or port. A template that does
+// not begin with a literal scheme starts with a placeholder that expands
+// to one ({BASE_URL}, {GOOGLE_VERTEX_HOST}, {OLLAMA_HOST}), so its
+// authority begins at position 0. A placeholder at or past the first
+// path, query, or fragment delimiter cannot escape into the authority -
+// the template already terminated it - and is not listed.
+func authorityVars(tpl string) map[string]bool {
+	out := map[string]bool{}
+	start := 0
+	if i := strings.Index(tpl, "://"); i >= 0 {
+		start = i + 3
+	}
+	end := len(tpl)
+	for _, d := range "/?#" {
+		if i := strings.IndexRune(tpl[start:], d); i >= 0 && start+i < end {
+			end = start + i
+		}
+	}
+	for _, m := range placeholderRe.FindAllStringSubmatchIndex(tpl, -1) {
+		if m[0] < end {
+			out[tpl[m[2]:m[3]]] = true
+		}
+	}
+	return out
+}
+
+// sameEndpointURL reports whether two resolved base URLs name the same
+// endpoint. Trailing slashes are trimmed first, mirroring the HTTP
+// builder's own strings.TrimRight(BaseURL, "/") (protocolhttp.URL) rather
+// than inventing a broader canonicalization. Equal strings are the same
+// endpoint - an unresolved template equals only the identically unresolved
+// template - and anything else must parse on both sides and match on every
+// URL component, where a bare trailing "?" or "#" differs from their
+// absence (ForceQuery, Fragment) even with nothing after them, and the
+// escaped path preserves percent-encoding rather than comparing decoded
+// forms.
+func sameEndpointURL(a, b string) bool {
+	a, b = strings.TrimRight(a, "/"), strings.TrimRight(b, "/")
+	if a == b {
 		return true
 	}
-	raw := r.varLookupWith(rec, func(string) {})
-	given, ok := raw("GOOGLE_VERTEX_HOST")
-	if !ok {
+	ua, errA := url.Parse(a)
+	ub, errB := url.Parse(b)
+	if errA != nil || errB != nil {
 		return false
 	}
-	loc, ok := raw("GOOGLE_VERTEX_LOCATION")
-	if !ok {
-		return false
-	}
-	u, err := url.Parse(given)
-	if err != nil || u.User != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
-		return true
-	}
-	return u.Scheme+"://"+u.Host != vertexHost(loc)
+	return ua.Scheme == ub.Scheme && ua.Opaque == ub.Opaque &&
+		ua.User.String() == ub.User.String() && ua.Host == ub.Host &&
+		ua.EscapedPath() == ub.EscapedPath() && ua.ForceQuery == ub.ForceQuery &&
+		ua.RawQuery == ub.RawQuery && ua.Fragment == ub.Fragment
 }
 
 // envCandidates lists, in the order credential resolution tries them, every

--- a/llm/registry/instances.go
+++ b/llm/registry/instances.go
@@ -101,6 +101,33 @@ func (r *Registry) effectiveAPIKeyEnv(rec *record) []string {
 	return rec.ownAPIKeyEnv
 }
 
+// baseURLDiverged reports whether rec's actually-resolved base URL differs
+// from what its provider (r.curated[rec.providerID], which is rec itself
+// for a curated record) resolves to using only the curated defaults - no
+// vars, no environment. It is WebSearch's analog of the endpoint stop
+// above (spec §10; gateWebSearch in resolve.go applies it), but broader: an
+// unused api_key_env is merely wasted, so the stop above fires only for a
+// literal base_url override, letting a *_BASE_URL environment override
+// (Bedrock's and Vertex's vars, or a same-shaped proxy) inherit the vendor
+// key normally. A hosted-tool definition the gateway does not implement
+// instead fails the whole request (issue #738), so this check also catches
+// that narrower environment-only case. When the provider's own template
+// cannot fully resolve without vars only a real deployment supplies
+// (Vertex's project, Bedrock's region), there is no baseline to compare
+// against, so nothing is reported as diverged.
+func (r *Registry) baseURLDiverged(rec *record) bool {
+	base, ok := r.curated[rec.providerID]
+	if !ok {
+		return false
+	}
+	own, _, _ := r.resolveBaseURL(rec, rec.head.Transport)
+	defaults, missing, _ := r.resolveBaseURLWith(base, base.head.Transport, r.defaultVarLookup(base))
+	if own == "" || len(missing) > 0 {
+		return false
+	}
+	return own != defaults
+}
+
 // envCandidates lists, in the order credential resolution tries them, every
 // environment variable name that could supply rec's key: its effective
 // api_key_env, then (only for a name that is not itself a registry id, spec

--- a/llm/registry/instances.go
+++ b/llm/registry/instances.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
@@ -175,7 +176,7 @@ func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto, r
 		// already false for one) - kept explicit so a future curated row
 		// with its own base_url or GOOGLE_VERTEX_HOST is trusted the same
 		// way the vendor's provider-level template already is.
-		if !rec.curated && (ownOverride || r.vertexHostOverridden(rec, base, own)) {
+		if !rec.curated && (ownOverride || r.vertexHostOverridden(rec, base)) {
 			return false
 		}
 	case own != defaults:
@@ -194,10 +195,11 @@ func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto, r
 		transport.CountTokensEndpoint == canonical.CountTokensEndpoint
 }
 
-// vertexHostOverridden reports whether rec's resolved host diverges from
-// Vertex's real, location-derived infrastructure - the derivation the
-// vertex-location host rule exists to perform (resolveBaseURLWith's
-// HostRuleVertexLocation case, load.go) - by either of two means:
+// vertexHostOverridden reports whether rec's own GOOGLE_VERTEX_HOST
+// diverges from Vertex's real, location-derived infrastructure - the
+// derivation the vertex-location host rule exists to perform
+// (resolveBaseURLWith's HostRuleVertexLocation case, load.go) - by either
+// of two means:
 //
 //   - rec's own host_rule differs from base's: swapping to a different
 //     rule (the only other one today, ollama-host) does not intercept
@@ -206,13 +208,21 @@ func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto, r
 //     also disables the direct-override check below (a record inspecting
 //     its own, now-different rule would never even look), the swap itself
 //     counts as divergence rather than being trusted to self-report.
-//   - own's actual resolved host does not match vertexHost(LOCATION),
-//     checked directly against the fully resolved URL rather than by
-//     asking rec's own (unswapped) rule whether GOOGLE_VERTEX_HOST was
-//     overridden - so a value that happens to equal the derivation's own
-//     answer is not an override (copying the default verbatim is not
-//     "different", spec §10), and no other means of steering the same
-//     outcome slips through.
+//   - a supplied GOOGLE_VERTEX_HOST does not parse as exactly
+//     vertexHost(LOCATION)'s scheme and authority, with nothing else: no
+//     path, query, fragment, or userinfo. The canonical form vertexHost
+//     itself produces is authority-only (e.g. "https://aiplatform.googleapis.com",
+//     never a trailing slash or anything after it), so that is the whole
+//     comparison - not a prefix of the assembled base_url, which a value
+//     like "https://aiplatform.googleapis.com/proxy" would pass (the
+//     template's own "/v1/projects/..." continuation makes an injected
+//     path segment indistinguishable from the real one once the two are
+//     concatenated and read back as one string). Comparing the
+//     un-concatenated GOOGLE_VERTEX_HOST value on its own, component by
+//     component, closes that: a path, a different port, or userinfo all
+//     fail the check on their own terms, and a value that happens to
+//     equal the derivation's own answer is not an override (copying the
+//     default verbatim is not "different", spec §10).
 //
 // This check is Vertex-specific by necessity, not by choice: it is the
 // only host rule with both a missing curated base_url default and a
@@ -220,15 +230,24 @@ func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto, r
 // shape - no curated default, host routed through its own env var, kept
 // template - would need an equivalent check of its own; nothing here
 // generalizes to it automatically.
-func (r *Registry) vertexHostOverridden(rec, base *record, own string) bool {
+func (r *Registry) vertexHostOverridden(rec, base *record) bool {
 	if rec.head.Transport.HostRule != base.head.Transport.HostRule {
 		return true
 	}
-	loc, ok := r.varLookupWith(rec, func(string) {})("GOOGLE_VERTEX_LOCATION")
+	raw := r.varLookupWith(rec, func(string) {})
+	given, ok := raw("GOOGLE_VERTEX_HOST")
 	if !ok {
 		return false
 	}
-	return !strings.HasPrefix(own, strings.TrimRight(vertexHost(loc), "/")+"/")
+	loc, ok := raw("GOOGLE_VERTEX_LOCATION")
+	if !ok {
+		return false
+	}
+	u, err := url.Parse(given)
+	if err != nil || u.User != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+		return true
+	}
+	return u.Scheme+"://"+u.Host != vertexHost(loc)
 }
 
 // envCandidates lists, in the order credential resolution tries them, every

--- a/llm/registry/instances.go
+++ b/llm/registry/instances.go
@@ -129,9 +129,11 @@ func (r *Registry) effectiveAPIKeyEnv(rec *record) []string {
 // curated record, whose actual resolution is the canonical one unless the
 // environment redirects it - which must strip, and does, by comparing
 // unequal. A record with no curated provider at all (a from-scratch
-// [providers.X] with its own base_url) has no vendor endpoint to diverge
-// from and is trivially first-party; only its own explicit web_search can
-// grant the capability anyway.
+// [providers.X] with its own base_url) has no vendor data to prove
+// anything against, so it is gated the same way rather than trusted:
+// nothing non-explicit survives - gateWebSearch normalizes its nil to a
+// silent false and strips a glob-granted true - and the instance's own
+// explicit web_search remains the grant.
 //
 // The canonical resolution admits values from the actual resolution's own
 // variable lookup only where they cannot move the request off the vendor's
@@ -150,7 +152,7 @@ func (r *Registry) effectiveAPIKeyEnv(rec *record) []string {
 func (r *Registry) firstPartyEndpoint(rec *record, transport Transport, proto, rowID, ref, altID string) bool {
 	base, ok := r.curated[rec.providerID]
 	if !ok {
-		return true
+		return false
 	}
 	var row Model
 	if rowID != "" || ref != "" {
@@ -262,15 +264,28 @@ func authorityVars(tpl string) map[string]bool {
 // sameEndpointURL reports whether two resolved base URLs name the same
 // endpoint. Trailing slashes are trimmed first, mirroring the HTTP
 // builder's own strings.TrimRight(BaseURL, "/") (protocolhttp.URL) rather
-// than inventing a broader canonicalization. Equal strings are the same
-// endpoint - an unresolved template equals only the identically unresolved
-// template - and anything else must parse on both sides and match on every
-// URL component, where a bare trailing "?" or "#" differs from their
-// absence (ForceQuery, Fragment) even with nothing after them, and the
-// escaped path preserves percent-encoding rather than comparing decoded
-// forms.
+// than inventing a broader canonicalization.
+//
+// Any "?" or "#" anywhere in either RAW string rejects outright, before
+// any equality: the builder concatenates the endpoint path onto the raw
+// base, so either delimiter sends the endpoint into the query or fragment
+// instead of the path - and the parsed forms cannot be trusted to see
+// that (url.URL has no ForceFragment: "https://h" and "https://h#" parse
+// identically while building different requests). No curated base
+// resolves to a URL containing either delimiter
+// (TestCuratedBaseURLsCarryNoQueryOrFragment pins that, embedded catalog
+// and fixture both), so the reject can never misjudge vendor data.
+//
+// Past that, equal strings are the same endpoint - an unresolved template
+// equals only the identically unresolved template - and anything else
+// must parse on both sides and match on scheme, userinfo, host, and the
+// escaped path, which preserves percent-encoding rather than comparing
+// decoded forms.
 func sameEndpointURL(a, b string) bool {
 	a, b = strings.TrimRight(a, "/"), strings.TrimRight(b, "/")
+	if strings.ContainsAny(a, "?#") || strings.ContainsAny(b, "?#") {
+		return false
+	}
 	if a == b {
 		return true
 	}
@@ -281,8 +296,7 @@ func sameEndpointURL(a, b string) bool {
 	}
 	return ua.Scheme == ub.Scheme && ua.Opaque == ub.Opaque &&
 		ua.User.String() == ub.User.String() && ua.Host == ub.Host &&
-		ua.EscapedPath() == ub.EscapedPath() && ua.ForceQuery == ub.ForceQuery &&
-		ua.RawQuery == ub.RawQuery && ua.Fragment == ub.Fragment
+		ua.EscapedPath() == ub.EscapedPath()
 }
 
 // envCandidates lists, in the order credential resolution tries them, every

--- a/llm/registry/instances.go
+++ b/llm/registry/instances.go
@@ -109,7 +109,7 @@ func (r *Registry) effectiveAPIKeyEnv(rec *record) []string {
 // be available from openai as openai." A vendor's hosted search runs on the
 // vendor's own infrastructure, so any redirection away from it forfeits
 // the capability, however the redirection is expressed - unlike the
-// endpoint stop below, which only fires for a literal base_url override
+// endpoint stop above, which only fires for a literal base_url override
 // and lets a *_BASE_URL environment override inherit the key normally
 // (an unused credential is merely wasted; a hosted-tool definition the
 // gateway does not implement fails the whole request).
@@ -135,12 +135,10 @@ func (r *Registry) effectiveAPIKeyEnv(rec *record) []string {
 //     reproduces the curated default byte for byte (copying the default
 //     verbatim is not "different", spec §10). A provider with no curated
 //     default has nothing a literal override could legitimately reproduce,
-//     so this is never first-party - the fix for the gap a prior version of
-//     this check left open: a missing curated default used to make every
-//     google-vertex-anthropic/google-vertex-based record "first-party" by
-//     default, literal override or not, because the check never
-//     distinguished "the template has no default" from "rec kept the
-//     template".
+//     so this is never first-party: a missing curated default must not be
+//     read as "nothing to compare", or every google-vertex-anthropic and
+//     google-vertex-based record would be first-party by default, literal
+//     override or not.
 func (r *Registry) firstPartyEndpoint(rec *record) bool {
 	base, ok := r.curated[rec.providerID]
 	if !ok {

--- a/llm/registry/load.go
+++ b/llm/registry/load.go
@@ -821,28 +821,6 @@ func (rec *record) aliasFromConfig(id string) bool {
 	return false
 }
 
-// rowOwnBaseURL reports whether the user's own config layer - not an
-// inherited curated layer - set a literal base_url for row id, the same
-// origin/provenance discipline ownBaseURL applies at the record level,
-// applied here row by row (mirroring aliasFromConfig's exact-row check for
-// AliasOf). A curated row can carry its own Transport.BaseURL too (Google
-// Vertex MaaS rows, whose API endpoint models.dev's own upstream data
-// supplies per model, modelsdev.go's convertModelOverride), and that is
-// vendor data, not a user redirect - firstPartyEndpoint's canonical-row
-// transport comparison already judges those correctly on their own, so
-// only a user-authored override needs to gate here.
-func (rec *record) rowOwnBaseURL(id string) bool {
-	for _, l := range rec.layers {
-		if l.tag != LayerConfig {
-			continue
-		}
-		if m, ok := l.rows[id]; ok {
-			return m.Transport != nil && m.Transport.BaseURL != ""
-		}
-	}
-	return false
-}
-
 // aliasTarget resolves an alias_of reference: an exact row of the same
 // record first, else "provider-id/id" against the curated registry. A glob
 // pattern never names a target, on either side of the slash.
@@ -920,6 +898,15 @@ func (r *Registry) varLookup(rec *record) func(string) (string, bool) {
 // the transport's host rule (spec §9.1). missing lists unresolved
 // variables; warnings carry host-rule failures.
 func (r *Registry) resolveBaseURLWith(rec *record, t Transport, lookup func(string) (string, bool)) (string, []string, []string) {
+	return r.resolveBaseURLVia(t, lookup, r.env)
+}
+
+// resolveBaseURLVia is resolveBaseURLWith with the environment injectable:
+// the ollama-host rule reads OLLAMA_BASE_URL from the environment directly
+// rather than through the variable lookup, so the canonical first-party
+// resolution (firstPartyEndpoint, instances.go) passes an empty env to keep
+// a live override out of the canonical URL.
+func (r *Registry) resolveBaseURLVia(t Transport, lookup, env func(string) (string, bool)) (string, []string, []string) {
 	var warnings []string
 	switch t.HostRule {
 	case HostRuleOllamaHost:
@@ -928,7 +915,7 @@ func (r *Registry) resolveBaseURLWith(rec *record, t Transport, lookup func(stri
 			if name != "OLLAMA_HOST" {
 				return inner(name)
 			}
-			baseURL, _ := r.env("OLLAMA_BASE_URL")
+			baseURL, _ := env("OLLAMA_BASE_URL")
 			host, _ := inner("OLLAMA_HOST")
 			u, err := resolveOllamaHost(baseURL, host)
 			if err != nil {

--- a/llm/registry/load.go
+++ b/llm/registry/load.go
@@ -937,6 +937,10 @@ func (r *Registry) resolveBaseURLVia(t Transport, lookup, env func(string) (stri
 			if !ok {
 				return "", false
 			}
+			if !validVertexLocation(loc) {
+				warnings = append(warnings, fmt.Sprintf("invalid GOOGLE_VERTEX_LOCATION %q: a Vertex location is a single hostname label (letters, digits, and interior hyphens, like us-central1)", loc))
+				return "", false
+			}
 			return vertexHost(loc), true
 		}
 	}

--- a/llm/registry/load.go
+++ b/llm/registry/load.go
@@ -821,6 +821,28 @@ func (rec *record) aliasFromConfig(id string) bool {
 	return false
 }
 
+// rowOwnBaseURL reports whether the user's own config layer - not an
+// inherited curated layer - set a literal base_url for row id, the same
+// origin/provenance discipline ownBaseURL applies at the record level,
+// applied here row by row (mirroring aliasFromConfig's exact-row check for
+// AliasOf). A curated row can carry its own Transport.BaseURL too (Google
+// Vertex MaaS rows, whose API endpoint models.dev's own upstream data
+// supplies per model, modelsdev.go's convertModelOverride), and that is
+// vendor data, not a user redirect - firstPartyEndpoint's canonical-row
+// transport comparison already judges those correctly on their own, so
+// only a user-authored override needs to gate here.
+func (rec *record) rowOwnBaseURL(id string) bool {
+	for _, l := range rec.layers {
+		if l.tag != LayerConfig {
+			continue
+		}
+		if m, ok := l.rows[id]; ok {
+			return m.Transport != nil && m.Transport.BaseURL != ""
+		}
+	}
+	return false
+}
+
 // aliasTarget resolves an alias_of reference: an exact row of the same
 // record first, else "provider-id/id" against the curated registry. A glob
 // pattern never names a target, on either side of the slash.

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -235,9 +235,12 @@ func (r *Registry) ResolveInstance(name string) (Resolved, error) {
 		}
 		mergeCaps(&caps, layer.provider, layer.tag+"/provider", prov)
 	}
-	r.gateWebSearch(&caps, prov, rec)
+	webSearchWarning := r.gateWebSearch(&caps, prov, rec)
 	seedFields(&caps, rec.head.Protocol)
 	transport, warnings := r.buildTransport(rec, Model{}, rec.head.Protocol)
+	if webSearchWarning != "" {
+		warnings = append(warnings, webSearchWarning)
+	}
 	cred, cw := r.credential(rec)
 	warnings = append(warnings, cw...)
 	credHeaders := map[string]string{}
@@ -270,19 +273,23 @@ func webSearchExplicit(prov map[string]string) bool {
 	return strings.HasPrefix(prov["WebSearch"], LayerConfig+"/")
 }
 
-// gateWebSearch applies issue #738's endpoint gate: WebSearch is a
+// gateWebSearch applies issue #738's first-party gate: WebSearch is a
 // platform-side capability, not a wire-protocol fact (spec §4.2 says
 // explicitly it is not one of the facts an alias imports), so it does not
-// survive on a record whose resolved base_url diverges from its provider's
-// own default (baseURLDiverged, instances.go) - unless the record's own
+// survive on a record that is not reaching its provider's first-party
+// endpoint (firstPartyEndpoint, instances.go) - unless the record's own
 // providers.toml entry set WebSearch itself, in which case an explicit true
-// or false always wins.
-func (r *Registry) gateWebSearch(caps *Caps, prov map[string]string, rec *record) {
-	if caps.WebSearch == nil || webSearchExplicit(prov) || !r.baseURLDiverged(rec) {
-		return
+// or false always wins. Returns the warning naming why WebSearch was
+// stripped, so an operator fronting a real first-party vendor with a mirror
+// or audit gateway sees why web_search went quiet instead of finding out
+// only when the model tries to use it and cannot; empty when nothing fired.
+func (r *Registry) gateWebSearch(caps *Caps, prov map[string]string, rec *record) string {
+	if caps.WebSearch == nil || webSearchExplicit(prov) || r.firstPartyEndpoint(rec) {
+		return ""
 	}
 	caps.WebSearch = nil
 	delete(prov, "WebSearch")
+	return fmt.Sprintf("web_search disabled: this endpoint is not %s's first-party API (set web_search = true on the instance to opt back in)", rec.providerID)
 }
 
 func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved, error) {
@@ -366,7 +373,9 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 	if !liveApplied {
 		r.applyLive(&caps, rec, ref.Model, hit, prov)
 	}
-	r.gateWebSearch(&caps, prov, rec)
+	if w := r.gateWebSearch(&caps, prov, rec); w != "" {
+		warnings = append(warnings, w)
+	}
 	seedFields(&caps, rowProto)
 
 	transport, tw := r.buildTransport(rec, row, rowProto)

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -328,7 +328,13 @@ func (r *Registry) gateWebSearch(caps *Caps, prov map[string]string, rec *record
 	}
 	caps.WebSearch = new(false)
 	prov["WebSearch"] = "gate/first-party"
-	return fmt.Sprintf("web_search disabled: this endpoint is not %s's first-party API (set web_search = true on the instance to opt back in)", rec.providerID)
+	// A from-scratch record has no curated provider id; the warning names
+	// the instance itself there.
+	name := rec.providerID
+	if name == "" {
+		name = rec.name
+	}
+	return fmt.Sprintf("web_search disabled: this endpoint is not %s's first-party API (set web_search = true on the instance to opt back in)", name)
 }
 
 func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved, error) {

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -235,6 +235,7 @@ func (r *Registry) ResolveInstance(name string) (Resolved, error) {
 		}
 		mergeCaps(&caps, layer.provider, layer.tag+"/provider", prov)
 	}
+	r.gateWebSearch(&caps, prov, rec)
 	seedFields(&caps, rec.head.Protocol)
 	transport, warnings := r.buildTransport(rec, Model{}, rec.head.Protocol)
 	cred, cw := r.credential(rec)
@@ -260,6 +261,28 @@ func (r *Registry) ResolveInstance(name string) (Resolved, error) {
 		ShadowedEnvVar: r.shadowedEnvVar(rec, cred),
 		DefaultModel:   rec.head.DefaultModel, CheapModel: rec.head.CheapModel,
 	}, nil
+}
+
+// webSearchExplicit reports whether prov attributes Caps.WebSearch to a
+// layer the record's own providers.toml entry contributed (tag "config"),
+// as opposed to a base-chain layer, a row glob, or nothing at all.
+func webSearchExplicit(prov map[string]string) bool {
+	return strings.HasPrefix(prov["WebSearch"], LayerConfig+"/")
+}
+
+// gateWebSearch applies issue #738's endpoint gate: WebSearch is a
+// platform-side capability, not a wire-protocol fact (spec §4.2 says
+// explicitly it is not one of the facts an alias imports), so it does not
+// survive on a record whose resolved base_url diverges from its provider's
+// own default (baseURLDiverged, instances.go) - unless the record's own
+// providers.toml entry set WebSearch itself, in which case an explicit true
+// or false always wins.
+func (r *Registry) gateWebSearch(caps *Caps, prov map[string]string, rec *record) {
+	if caps.WebSearch == nil || webSearchExplicit(prov) || !r.baseURLDiverged(rec) {
+		return
+	}
+	caps.WebSearch = nil
+	delete(prov, "WebSearch")
 }
 
 func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved, error) {
@@ -343,6 +366,7 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 	if !liveApplied {
 		r.applyLive(&caps, rec, ref.Model, hit, prov)
 	}
+	r.gateWebSearch(&caps, prov, rec)
 	seedFields(&caps, rowProto)
 
 	transport, tw := r.buildTransport(rec, row, rowProto)

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -299,6 +299,11 @@ func webSearchExplicit(prov map[string]string) bool {
 // nil'ing a capability this gate means to deny is fail-open for any caller
 // that does not separately re-derive it through BoolValue.
 //
+// The same fail-open reasoning covers a WebSearch no layer ever set: off
+// the first-party endpoint a nil is normalized to an explicit false too,
+// silently - no layer's value was overturned, so the warning and the
+// provenance repoint stay reserved for a stripped true.
+//
 // The rewrite - prov's entry repointed at the gate, a warning returned -
 // happens only when the gate is the reason the value is false: caps.WebSearch
 // was true before it ran. When an earlier, non-config layer already set
@@ -308,9 +313,14 @@ func webSearchExplicit(prov map[string]string) bool {
 // reason and returns no warning.
 //
 // Returns the warning naming why WebSearch was stripped; empty when
-// nothing fired, including when the value was already false.
+// nothing fired, including when the value was already false or only ever
+// nil (the normalization is silent).
 func (r *Registry) gateWebSearch(caps *Caps, prov map[string]string, rec *record, transport Transport, proto, rowID, ref, altID string) string {
-	if caps.WebSearch == nil || webSearchExplicit(prov) || r.firstPartyEndpoint(rec, transport, proto, rowID, ref, altID) {
+	if webSearchExplicit(prov) || r.firstPartyEndpoint(rec, transport, proto, rowID, ref, altID) {
+		return ""
+	}
+	if caps.WebSearch == nil {
+		caps.WebSearch = new(false)
 		return ""
 	}
 	if !*caps.WebSearch {

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -235,11 +235,10 @@ func (r *Registry) ResolveInstance(name string) (Resolved, error) {
 		}
 		mergeCaps(&caps, layer.provider, layer.tag+"/provider", prov)
 	}
-	webSearchWarning := r.gateWebSearch(&caps, prov, rec)
 	seedFields(&caps, rec.head.Protocol)
 	transport, warnings := r.buildTransport(rec, Model{}, rec.head.Protocol)
-	if webSearchWarning != "" {
-		warnings = append(warnings, webSearchWarning)
+	if w := r.gateWebSearch(&caps, prov, rec, transport.BaseURL, rec.ownBaseURL != ""); w != "" {
+		warnings = append(warnings, w)
 	}
 	cred, cw := r.credential(rec)
 	warnings = append(warnings, cw...)
@@ -277,18 +276,33 @@ func webSearchExplicit(prov map[string]string) bool {
 // platform-side capability, not a wire-protocol fact (spec §4.2 says
 // explicitly it is not one of the facts an alias imports), so it does not
 // survive on a record that is not reaching its provider's first-party
-// endpoint (firstPartyEndpoint, instances.go) - unless the record's own
-// providers.toml entry set WebSearch itself, in which case an explicit true
-// or false always wins. Returns the warning naming why WebSearch was
-// stripped, so an operator fronting a real first-party vendor with a mirror
-// or audit gateway sees why web_search went quiet instead of finding out
-// only when the model tries to use it and cannot; empty when nothing fired.
-func (r *Registry) gateWebSearch(caps *Caps, prov map[string]string, rec *record) string {
-	if caps.WebSearch == nil || webSearchExplicit(prov) || r.firstPartyEndpoint(rec) {
+// endpoint (firstPartyEndpoint, instances.go, judged against
+// resolvedBaseURL - the fully resolved transport, row-level overrides
+// included, not just the instance's own - and ownOverride, true when
+// anything rec's own config controls replaced the base_url template
+// outright) - unless the record's own providers.toml entry set WebSearch
+// itself, in which case an explicit true or false always wins.
+//
+// A rejected WebSearch becomes an explicit false, never nil: every protocol
+// adapter's own gate treats caps.WebSearch == nil as permissive ("no
+// catalog opinion either way, trust the caller's own request flag"), so
+// nil'ing a capability this gate means to deny is fail-open for any caller
+// that does not separately re-derive it through BoolValue - a bare
+// Request.WebSearch = true, set without consulting the registry at all,
+// would still reach the wire. false is unambiguous at every layer that
+// reads it. prov's entry is repointed at the gate rather than deleted, so
+// Provenance still explains the value instead of looking unset.
+//
+// Returns the warning naming why WebSearch was stripped, so an operator
+// fronting a real first-party vendor with a mirror or audit gateway sees
+// why web_search went quiet instead of finding out only when the model
+// tries to use it and cannot; empty when nothing fired.
+func (r *Registry) gateWebSearch(caps *Caps, prov map[string]string, rec *record, resolvedBaseURL string, ownOverride bool) string {
+	if caps.WebSearch == nil || webSearchExplicit(prov) || r.firstPartyEndpoint(rec, resolvedBaseURL, ownOverride) {
 		return ""
 	}
-	caps.WebSearch = nil
-	delete(prov, "WebSearch")
+	caps.WebSearch = new(false)
+	prov["WebSearch"] = "gate/first-party"
 	return fmt.Sprintf("web_search disabled: this endpoint is not %s's first-party API (set web_search = true on the instance to opt back in)", rec.providerID)
 }
 
@@ -373,13 +387,14 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 	if !liveApplied {
 		r.applyLive(&caps, rec, ref.Model, hit, prov)
 	}
-	if w := r.gateWebSearch(&caps, prov, rec); w != "" {
-		warnings = append(warnings, w)
-	}
 	seedFields(&caps, rowProto)
 
 	transport, tw := r.buildTransport(rec, row, rowProto)
 	warnings = append(warnings, tw...)
+	rowOwnBaseURL := row.Transport != nil && row.Transport.BaseURL != ""
+	if w := r.gateWebSearch(&caps, prov, rec, transport.BaseURL, rec.ownBaseURL != "" || rowOwnBaseURL); w != "" {
+		warnings = append(warnings, w)
+	}
 	headers := r.buildHeaders(rec.head.Headers, row.Headers)
 	cred, cw := r.credential(rec)
 	warnings = append(warnings, cw...)

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -415,8 +415,7 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 
 	transport, tw := r.buildTransport(rec, row, rowProto)
 	warnings = append(warnings, tw...)
-	rowOwnBaseURL := row.Transport != nil && row.Transport.BaseURL != ""
-	if w := r.gateWebSearch(&caps, prov, rec, transport, rowProto, canonicalRowID, rec.ownBaseURL != "" || rowOwnBaseURL); w != "" {
+	if w := r.gateWebSearch(&caps, prov, rec, transport, rowProto, canonicalRowID, rec.ownBaseURL != "" || rec.rowOwnBaseURL(hit.rowID)); w != "" {
 		warnings = append(warnings, w)
 	}
 	headers := r.buildHeaders(rec.head.Headers, row.Headers)

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -237,13 +237,13 @@ func (r *Registry) ResolveInstance(name string) (Resolved, error) {
 	}
 	seedFields(&caps, rec.head.Protocol)
 	transport, warnings := r.buildTransport(rec, Model{}, rec.head.Protocol)
-	// rowID "" falls firstPartyEndpoint's endpoint comparison back to
-	// protocol defaults on both sides (no row to diverge on), so it is
-	// effectively a no-op here - correctly so: ListModels and credential
-	// probes, this path's only callers, never build a body, so there is no
-	// WebSearch tool for a row-level endpoint override to redirect. The
-	// base_url check above it still applies in full.
-	if w := r.gateWebSearch(&caps, prov, rec, transport, rec.head.Protocol, "", rec.ownBaseURL != ""); w != "" {
+	// rowID/ref "" keep firstPartyEndpoint's canonical resolution row-less
+	// and glob-less, mirroring the row-less buildTransport call above -
+	// correctly so: ListModels and credential probes, this path's only
+	// callers, never build a body, so there is no WebSearch tool for a
+	// row-level override to redirect. The base_url and endpoint-path
+	// comparison still applies in full.
+	if w := r.gateWebSearch(&caps, prov, rec, transport, rec.head.Protocol, "", "", ""); w != "" {
 		warnings = append(warnings, w)
 	}
 	cred, cw := r.credential(rec)
@@ -309,8 +309,8 @@ func webSearchExplicit(prov map[string]string) bool {
 //
 // Returns the warning naming why WebSearch was stripped; empty when
 // nothing fired, including when the value was already false.
-func (r *Registry) gateWebSearch(caps *Caps, prov map[string]string, rec *record, transport Transport, proto, rowID string, ownOverride bool) string {
-	if caps.WebSearch == nil || webSearchExplicit(prov) || r.firstPartyEndpoint(rec, transport, proto, rowID, ownOverride) {
+func (r *Registry) gateWebSearch(caps *Caps, prov map[string]string, rec *record, transport Transport, proto, rowID, ref, altID string) string {
+	if caps.WebSearch == nil || webSearchExplicit(prov) || r.firstPartyEndpoint(rec, transport, proto, rowID, ref, altID) {
 		return ""
 	}
 	if !*caps.WebSearch {
@@ -415,7 +415,7 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 
 	transport, tw := r.buildTransport(rec, row, rowProto)
 	warnings = append(warnings, tw...)
-	if w := r.gateWebSearch(&caps, prov, rec, transport, rowProto, canonicalRowID, rec.ownBaseURL != "" || rec.rowOwnBaseURL(hit.rowID)); w != "" {
+	if w := r.gateWebSearch(&caps, prov, rec, transport, rowProto, canonicalRowID, ref.Model, altID); w != "" {
 		warnings = append(warnings, w)
 	}
 	headers := r.buildHeaders(rec.head.Headers, row.Headers)
@@ -591,9 +591,13 @@ func (r *Registry) applyLive(c *Caps, rec *record, model string, hit lookupHit, 
 	mergeCaps(c, lr.Caps, LayerLive, prov)
 }
 
-// buildTransport applies the cross-protocol rule, the row transport, the
-// protocol defaults, and variable substitution (spec §9.1).
-func (r *Registry) buildTransport(rec *record, row Model, proto string) (Transport, []string) {
+// transportShape assembles the unexpanded transport for rec resolving row on
+// proto: the record's head transport under the cross-protocol rule, the row
+// transport merged on top, and the protocol's default endpoints filled in.
+// It is the shared front half of buildTransport and of the canonical
+// first-party resolution (firstPartyEndpoint, instances.go), which expand
+// it with different variable lookups.
+func (r *Registry) transportShape(rec *record, row Model, proto string) Transport {
 	t := cloneTransport(rec.head.Transport)
 	if proto != rec.head.Protocol {
 		clearProtocolTransport(&t)
@@ -611,6 +615,13 @@ func (r *Registry) buildTransport(rec *record, row Model, proto string) (Transpo
 	setIfEmpty(&t.StreamEndpoint, d.StreamEndpoint)
 	setIfEmpty(&t.ModelsEndpoint, d.ModelsEndpoint)
 	setIfEmpty(&t.CountTokensEndpoint, d.CountTokensEndpoint)
+	return t
+}
+
+// buildTransport applies the cross-protocol rule, the row transport, the
+// protocol defaults, and variable substitution (spec §9.1).
+func (r *Registry) buildTransport(rec *record, row Model, proto string) (Transport, []string) {
+	t := r.transportShape(rec, row, proto)
 	// The templates, captured before substitution, are the authoritative list
 	// of variables Resolved may expose (URL parts such as a region, resource,
 	// or project). Resolved is serialized by `evener models inspect`, so no

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -237,6 +237,12 @@ func (r *Registry) ResolveInstance(name string) (Resolved, error) {
 	}
 	seedFields(&caps, rec.head.Protocol)
 	transport, warnings := r.buildTransport(rec, Model{}, rec.head.Protocol)
+	// rowID "" falls firstPartyEndpoint's endpoint comparison back to
+	// protocol defaults on both sides (no row to diverge on), so it is
+	// effectively a no-op here - correctly so: ListModels and credential
+	// probes, this path's only callers, never build a body, so there is no
+	// WebSearch tool for a row-level endpoint override to redirect. The
+	// base_url check above it still applies in full.
 	if w := r.gateWebSearch(&caps, prov, rec, transport, rec.head.Protocol, "", rec.ownBaseURL != ""); w != "" {
 		warnings = append(warnings, w)
 	}
@@ -338,6 +344,14 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 	if hit.rowID != "" && hit.rowID != ref.Model {
 		altID = hit.rowID
 	}
+	// canonicalRowID names the row the endpoint gate (gateWebSearch,
+	// firstPartyEndpoint) compares transport against. It starts as the
+	// resolved row's own id, but a same-provider alias that imports its
+	// target's transport below is judged against the target's row instead
+	// (base.head.Models has no entry under the alias's own id - a
+	// user-chosen name, not a curated one - so looking it up there would
+	// find nothing and fall back to a row-less, and wrong, baseline).
+	canonicalRowID := hit.rowID
 	// Layer 0: alias seeding (spec §4.2).
 	if row.AliasOf != "" {
 		target, same, err := r.resolveAliasTarget(rec, row.AliasOf)
@@ -346,6 +360,7 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 		} else {
 			seedFromAlias(&caps, &row, target, prov)
 			if same && rec.head.Models[hit.rowID].Protocol == "" && rec.head.Models[hit.rowID].Transport == nil {
+				canonicalRowID = target.Model.ID
 				row.Protocol = target.Model.Protocol
 				if target.Model.Transport != nil {
 					t := cloneTransport(*target.Model.Transport)
@@ -401,7 +416,7 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 	transport, tw := r.buildTransport(rec, row, rowProto)
 	warnings = append(warnings, tw...)
 	rowOwnBaseURL := row.Transport != nil && row.Transport.BaseURL != ""
-	if w := r.gateWebSearch(&caps, prov, rec, transport, rowProto, hit.rowID, rec.ownBaseURL != "" || rowOwnBaseURL); w != "" {
+	if w := r.gateWebSearch(&caps, prov, rec, transport, rowProto, canonicalRowID, rec.ownBaseURL != "" || rowOwnBaseURL); w != "" {
 		warnings = append(warnings, w)
 	}
 	headers := r.buildHeaders(rec.head.Headers, row.Headers)

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -237,7 +237,7 @@ func (r *Registry) ResolveInstance(name string) (Resolved, error) {
 	}
 	seedFields(&caps, rec.head.Protocol)
 	transport, warnings := r.buildTransport(rec, Model{}, rec.head.Protocol)
-	if w := r.gateWebSearch(&caps, prov, rec, transport.BaseURL, rec.ownBaseURL != ""); w != "" {
+	if w := r.gateWebSearch(&caps, prov, rec, transport, rec.head.Protocol, rec.ownBaseURL != ""); w != "" {
 		warnings = append(warnings, w)
 	}
 	cred, cw := r.credential(rec)
@@ -307,8 +307,8 @@ func webSearchExplicit(prov map[string]string) bool {
 // why web_search went quiet instead of finding out only when the model
 // tries to use it and cannot; empty when nothing fired, including when the
 // value was already false.
-func (r *Registry) gateWebSearch(caps *Caps, prov map[string]string, rec *record, resolvedBaseURL string, ownOverride bool) string {
-	if caps.WebSearch == nil || webSearchExplicit(prov) || r.firstPartyEndpoint(rec, resolvedBaseURL, ownOverride) {
+func (r *Registry) gateWebSearch(caps *Caps, prov map[string]string, rec *record, transport Transport, proto string, ownOverride bool) string {
+	if caps.WebSearch == nil || webSearchExplicit(prov) || r.firstPartyEndpoint(rec, transport, proto, ownOverride) {
 		return ""
 	}
 	if !*caps.WebSearch {
@@ -405,7 +405,7 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 	transport, tw := r.buildTransport(rec, row, rowProto)
 	warnings = append(warnings, tw...)
 	rowOwnBaseURL := row.Transport != nil && row.Transport.BaseURL != ""
-	if w := r.gateWebSearch(&caps, prov, rec, transport.BaseURL, rec.ownBaseURL != "" || rowOwnBaseURL); w != "" {
+	if w := r.gateWebSearch(&caps, prov, rec, transport, rowProto, rec.ownBaseURL != "" || rowOwnBaseURL); w != "" {
 		warnings = append(warnings, w)
 	}
 	headers := r.buildHeaders(rec.head.Headers, row.Headers)

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -290,15 +290,28 @@ func webSearchExplicit(prov map[string]string) bool {
 // that does not separately re-derive it through BoolValue - a bare
 // Request.WebSearch = true, set without consulting the registry at all,
 // would still reach the wire. false is unambiguous at every layer that
-// reads it. prov's entry is repointed at the gate rather than deleted, so
-// Provenance still explains the value instead of looking unset.
+// reads it.
+//
+// The rewrite - prov's entry repointed at the gate, a warning returned -
+// happens only when the gate is the reason the value is false: caps.WebSearch
+// was true before it ran. When some earlier, non-config layer already set
+// false for its own reason (amazon-bedrock's *anthropic.* row glob: the
+// Messages endpoint simply lacks the capability, nothing to do with
+// whether this endpoint is first-party), the gate agrees with the outcome
+// but is not why it holds, so it leaves Provenance naming the real reason
+// and returns no warning - nothing changed here for an operator to be told
+// about.
 //
 // Returns the warning naming why WebSearch was stripped, so an operator
 // fronting a real first-party vendor with a mirror or audit gateway sees
 // why web_search went quiet instead of finding out only when the model
-// tries to use it and cannot; empty when nothing fired.
+// tries to use it and cannot; empty when nothing fired, including when the
+// value was already false.
 func (r *Registry) gateWebSearch(caps *Caps, prov map[string]string, rec *record, resolvedBaseURL string, ownOverride bool) string {
 	if caps.WebSearch == nil || webSearchExplicit(prov) || r.firstPartyEndpoint(rec, resolvedBaseURL, ownOverride) {
+		return ""
+	}
+	if !*caps.WebSearch {
 		return ""
 	}
 	caps.WebSearch = new(false)

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -237,7 +237,7 @@ func (r *Registry) ResolveInstance(name string) (Resolved, error) {
 	}
 	seedFields(&caps, rec.head.Protocol)
 	transport, warnings := r.buildTransport(rec, Model{}, rec.head.Protocol)
-	if w := r.gateWebSearch(&caps, prov, rec, transport, rec.head.Protocol, rec.ownBaseURL != ""); w != "" {
+	if w := r.gateWebSearch(&caps, prov, rec, transport, rec.head.Protocol, "", rec.ownBaseURL != ""); w != "" {
 		warnings = append(warnings, w)
 	}
 	cred, cw := r.credential(rec)
@@ -266,49 +266,45 @@ func (r *Registry) ResolveInstance(name string) (Resolved, error) {
 }
 
 // webSearchExplicit reports whether prov attributes Caps.WebSearch to a
-// layer the record's own providers.toml entry contributed (tag "config"),
-// as opposed to a base-chain layer, a row glob, or nothing at all.
+// deliberate, individually considered choice in the record's own
+// providers.toml entry: an instance-wide setting (tag "config/provider")
+// or an exact single-model override (`[providers.X.models."id"]`, tag
+// "config/row"). A glob-matched value (tag "config/glob:<pattern>",
+// whether from a top-level `[models."<glob>"]` or a provider-scoped
+// `[providers.X.models."<glob>"]` - the tag does not distinguish them) does
+// not count, even though it also originates in the user's own config: a
+// pattern match was never considered against this specific instance or
+// model, so trusting it would let a broad rule silently re-enable a
+// stripped capability on an endpoint its author never looked at.
 func webSearchExplicit(prov map[string]string) bool {
-	return strings.HasPrefix(prov["WebSearch"], LayerConfig+"/")
+	tag := prov["WebSearch"]
+	return tag == LayerConfig+"/provider" || tag == LayerConfig+"/row"
 }
 
-// gateWebSearch applies issue #738's first-party gate: WebSearch is a
-// platform-side capability, not a wire-protocol fact (spec §4.2 says
-// explicitly it is not one of the facts an alias imports), so it does not
-// survive on a record that is not reaching its provider's first-party
-// endpoint (firstPartyEndpoint, instances.go, judged against
-// resolvedBaseURL - the fully resolved transport, row-level overrides
-// included, not just the instance's own - and ownOverride, true when
-// anything rec's own config controls replaced the base_url template
-// outright) - unless the record's own providers.toml entry set WebSearch
-// itself, in which case an explicit true or false always wins.
+// gateWebSearch enforces that WebSearch - a platform-side capability, not a
+// wire-protocol fact (spec §4.2) - survives only on a record reaching its
+// provider's first-party endpoint (firstPartyEndpoint), unless the
+// record's own config set it explicitly (webSearchExplicit), in which case
+// that value always wins.
 //
 // A rejected WebSearch becomes an explicit false, never nil: every protocol
 // adapter's own gate treats caps.WebSearch == nil as permissive ("no
 // catalog opinion either way, trust the caller's own request flag"), so
 // nil'ing a capability this gate means to deny is fail-open for any caller
-// that does not separately re-derive it through BoolValue - a bare
-// Request.WebSearch = true, set without consulting the registry at all,
-// would still reach the wire. false is unambiguous at every layer that
-// reads it.
+// that does not separately re-derive it through BoolValue.
 //
 // The rewrite - prov's entry repointed at the gate, a warning returned -
 // happens only when the gate is the reason the value is false: caps.WebSearch
-// was true before it ran. When some earlier, non-config layer already set
+// was true before it ran. When an earlier, non-config layer already set
 // false for its own reason (amazon-bedrock's *anthropic.* row glob: the
-// Messages endpoint simply lacks the capability, nothing to do with
-// whether this endpoint is first-party), the gate agrees with the outcome
-// but is not why it holds, so it leaves Provenance naming the real reason
-// and returns no warning - nothing changed here for an operator to be told
-// about.
+// Messages endpoint simply lacks the capability), the gate agrees with the
+// outcome but is not why it holds, so it leaves Provenance naming the real
+// reason and returns no warning.
 //
-// Returns the warning naming why WebSearch was stripped, so an operator
-// fronting a real first-party vendor with a mirror or audit gateway sees
-// why web_search went quiet instead of finding out only when the model
-// tries to use it and cannot; empty when nothing fired, including when the
-// value was already false.
-func (r *Registry) gateWebSearch(caps *Caps, prov map[string]string, rec *record, transport Transport, proto string, ownOverride bool) string {
-	if caps.WebSearch == nil || webSearchExplicit(prov) || r.firstPartyEndpoint(rec, transport, proto, ownOverride) {
+// Returns the warning naming why WebSearch was stripped; empty when
+// nothing fired, including when the value was already false.
+func (r *Registry) gateWebSearch(caps *Caps, prov map[string]string, rec *record, transport Transport, proto, rowID string, ownOverride bool) string {
+	if caps.WebSearch == nil || webSearchExplicit(prov) || r.firstPartyEndpoint(rec, transport, proto, rowID, ownOverride) {
 		return ""
 	}
 	if !*caps.WebSearch {
@@ -405,7 +401,7 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 	transport, tw := r.buildTransport(rec, row, rowProto)
 	warnings = append(warnings, tw...)
 	rowOwnBaseURL := row.Transport != nil && row.Transport.BaseURL != ""
-	if w := r.gateWebSearch(&caps, prov, rec, transport, rowProto, rec.ownBaseURL != "" || rowOwnBaseURL); w != "" {
+	if w := r.gateWebSearch(&caps, prov, rec, transport, rowProto, hit.rowID, rec.ownBaseURL != "" || rowOwnBaseURL); w != "" {
 		warnings = append(warnings, w)
 	}
 	headers := r.buildHeaders(rec.head.Headers, row.Headers)

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -331,12 +331,10 @@ surface = "anthropic"
 // hosted-tool definition the gateway does not implement fails the whole
 // request, so a *_BASE_URL environment override that keeps the template is
 // just as untrustworthy here even though credentials keep flowing through
-// it. vertexgw is the regression case for a prior version of this gate,
-// which exempted every google-vertex-anthropic/google-vertex-based record
-// unconditionally (missing a curated default for GOOGLE_VERTEX_PROJECT/
-// LOCATION was read as "nothing to compare", regardless of whether the
-// record's own base_url ever touched the template) - the exact #738 failure
-// shape, one vendor over.
+// it. vertexgw guards the vars-only carve-out: a provider with no curated
+// default for its base_url vars (GOOGLE_VERTEX_PROJECT/LOCATION) must stay
+// gated when its own base_url replaced the template - the exact #738
+// failure shape, one vendor over.
 func TestResolve_WebSearchEndpointGate(t *testing.T) {
 	cfg := `
 [providers.bedrock]

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -678,6 +678,140 @@ base_url = "https://gw.example/v1"
 	}
 }
 
+// TestResolve_WebSearchRawDelimiterReject pins sameEndpointURL's raw-string
+// delimiter reject: the HTTP builder concatenates the endpoint path onto
+// the RAW base string, so a base URL carrying "?" or "#" sends the endpoint
+// into the query or fragment instead of the path - and a bare trailing "#"
+// is invisible to a parsed comparison (url.URL has no ForceFragment;
+// Fragment is "" for "https://h" and "https://h#" alike), so parsing alone
+// would call it first-party while the request goes somewhere else. No
+// curated base resolves to a URL containing either delimiter
+// (TestCuratedBaseURLsCarryNoQueryOrFragment), so any appearance at all is
+// noncanonical and strips.
+func TestResolve_WebSearchRawDelimiterReject(t *testing.T) {
+	cfg := `
+[providers.fragbare]
+base = "openai"
+base_url = "https://api.openai.com/v1#"
+
+[providers.fragtext]
+base = "openai"
+base_url = "https://api.openai.com/v1#x"
+
+[providers.fragmid]
+base = "openai"
+base_url = "https://api.openai.com/#/v1"
+
+[providers.querybare]
+base = "openai"
+base_url = "https://api.openai.com/v1?"
+
+[providers.querytext]
+base = "openai"
+base_url = "https://api.openai.com/v1?tenant=1"
+`
+	r := fixtureLoad(t, nil, cfg)
+	for _, c := range []struct{ ref, desc string }{
+		{"fragbare/gpt-5.5", "a bare trailing # parses identically to no fragment but redirects the concatenated endpoint into the fragment"},
+		{"fragtext/gpt-5.5", "a fragment with content is off the canonical shape"},
+		{"fragmid/gpt-5.5", "a mid-string # truncates the path the endpoint was meant to extend"},
+		{"querybare/gpt-5.5", "a bare trailing ? redirects the concatenated endpoint into the query"},
+		{"querytext/gpt-5.5", "a query string is off the canonical shape"},
+	} {
+		res := mustResolve(t, r, c.ref)
+		if bp(res.Caps.WebSearch) != "false" {
+			t.Errorf("%s: web_search = %s, want false (%s)", c.ref, bp(res.Caps.WebSearch), c.desc)
+		}
+		if !hasWarning(res, "web_search disabled") {
+			t.Errorf("%s: expected the web_search-disabled warning (%s): %v", c.ref, c.desc, res.Warnings)
+		}
+	}
+}
+
+// TestCuratedBaseURLsCarryNoQueryOrFragment pins the precondition the raw
+// delimiter reject stands on: no curated provider template, curated var
+// default, or curated row base_url carries "?" or "#", in the embedded
+// catalog or the test fixture, so rejecting the delimiters outright can
+// never misjudge vendor data. A curated entry that ever needs one must
+// revisit sameEndpointURL first.
+func TestCuratedBaseURLsCarryNoQueryOrFragment(t *testing.T) {
+	for name, r := range map[string]*Registry{"embedded": embeddedLoad(t), "fixture": fixtureLoad(t, nil, "")} {
+		for _, id := range r.ProviderIDs() {
+			p, _ := r.Provider(id)
+			if strings.ContainsAny(p.Transport.BaseURL, "?#") {
+				t.Errorf("%s: %s: provider base_url %q carries a query or fragment delimiter", name, id, p.Transport.BaseURL)
+			}
+			for varName, v := range p.Transport.Vars {
+				if strings.ContainsAny(v, "?#") {
+					t.Errorf("%s: %s: var default %s = %q carries a query or fragment delimiter", name, id, varName, v)
+				}
+			}
+			for rowID, m := range p.Models {
+				if m.Transport != nil && strings.ContainsAny(m.Transport.BaseURL, "?#") {
+					t.Errorf("%s: %s.models.%q: row base_url %q carries a query or fragment delimiter", name, id, rowID, m.Transport.BaseURL)
+				}
+			}
+		}
+	}
+}
+
+// TestResolve_WebSearchFromScratchProviderFailsClosed pins the gate on a
+// provider with no curated identity at all (a from-scratch [providers.X]
+// with its own protocol and base_url): with no vendor record there is no
+// canonical endpoint to prove anything against, so the resolution is gated
+// exactly like a diverged one - a nil WebSearch normalizes to a silent
+// explicit false (the adapters' nil-is-permissive gates would otherwise
+// fail open for a direct req.WebSearch = true), a non-explicit true (a
+// user glob) is stripped with the warning, and the instance's own explicit
+// web_search = true remains the escape hatch.
+func TestResolve_WebSearchFromScratchProviderFailsClosed(t *testing.T) {
+	cfg := `
+[providers.custom]
+protocol = "openai-responses"
+base_url = "https://custom.example/v1"
+
+[providers.customoptin]
+protocol = "openai-responses"
+base_url = "https://custom.example/v1"
+web_search = true
+
+[providers.customglob]
+protocol = "openai-responses"
+base_url = "https://custom.example/v1"
+[providers.customglob.models."m*"]
+web_search = true
+`
+	r := fixtureLoad(t, nil, cfg)
+	res := mustResolve(t, r, "custom/m1")
+	if bp(res.Caps.WebSearch) != "false" || hasWarning(res, "web_search disabled") {
+		t.Errorf("custom/m1: web_search = %s warnings = %v, want a silent explicit false (nil is fail-open at the adapter layer)", bp(res.Caps.WebSearch), res.Warnings)
+	}
+	if tag, ok := res.Provenance["WebSearch"]; ok {
+		t.Errorf("custom/m1: the silent nil normalization must leave no provenance entry: %q", tag)
+	}
+	inst, err := r.ResolveInstance("custom")
+	if err != nil {
+		t.Fatalf("ResolveInstance: %v", err)
+	}
+	if bp(inst.Caps.WebSearch) != "false" || hasWarning(inst, "web_search disabled") {
+		t.Errorf("ResolveInstance(custom): web_search = %s warnings = %v, want a silent explicit false", bp(inst.Caps.WebSearch), inst.Warnings)
+	}
+	optin := mustResolve(t, r, "customoptin/m1")
+	if bp(optin.Caps.WebSearch) != "true" || hasWarning(optin, "web_search disabled") {
+		t.Errorf("customoptin/m1: web_search = %s warnings = %v, want the explicit opt-in honored silently", bp(optin.Caps.WebSearch), optin.Warnings)
+	}
+	glob := mustResolve(t, r, "customglob/m1")
+	if bp(glob.Caps.WebSearch) != "false" || !hasWarning(glob, "web_search disabled") {
+		t.Errorf("customglob/m1: web_search = %s warnings = %v, want the non-explicit glob true stripped with the warning", bp(glob.Caps.WebSearch), glob.Warnings)
+	}
+	if got := glob.Provenance["WebSearch"]; got != "gate/first-party" {
+		t.Errorf("customglob/m1: a stripped true repoints provenance at the gate, got %q", got)
+	}
+	if !hasWarning(glob, "not customglob's first-party API") {
+		t.Errorf("customglob/m1: the warning must name the instance when there is no curated provider id: %v", glob.Warnings)
+	}
+}
+
 // TestResolve_WebSearchInheritedCuratedRowBaseURL guards against treating
 // an inherited curated row's own base_url as a user override: Google
 // Vertex MaaS rows carry a row-level base_url straight from models.dev's

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -557,6 +557,85 @@ base = "google-vertex-anthropic"
 	}
 }
 
+// TestResolve_WebSearchCanonicalGate pins the redirection channels the
+// canonical-comparison design must catch: instead of enumerating each
+// config channel that can move a request (an open-ended set), the gate
+// resolves the provider's curated layers alone into a canonical transport
+// and demands the actual resolution's transport equal it componentwise.
+// Each case here is a channel a prior enumeration round missed.
+func TestResolve_WebSearchCanonicalGate(t *testing.T) {
+	cfg := `
+[providers.vertexhostnoloc]
+base = "google-vertex-anthropic"
+[providers.vertexhostnoloc.vars]
+"GOOGLE_VERTEX_HOST" = "https://no-loc-gateway.example"
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+
+[providers.vertexrowrule]
+base = "google-vertex-anthropic"
+[providers.vertexrowrule.vars]
+"GOOGLE_VERTEX_HOST" = "https://row-rule-gateway.example"
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+[providers.vertexrowrule.models."claude-opus-5"]
+host_rule = "ollama-host"
+
+[providers.vertexglobgw]
+base = "google-vertex-anthropic"
+[providers.vertexglobgw.vars]
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "global"
+[providers.vertexglobgw.models."claude-*"]
+base_url = "https://glob-gateway.example/v1"
+
+[providers.vertexaliastarget]
+base = "google-vertex"
+[providers.vertexaliastarget.vars]
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "global"
+[providers.vertexaliastarget.models."my-claude-alias"]
+alias_of = "claude-opus-5"
+[providers.vertexaliastarget.models."claude-opus-5"]
+base_url = "https://alias-target-gateway.example/v1"
+
+[providers.vertexhostquery]
+base = "google-vertex-anthropic"
+[providers.vertexhostquery.vars]
+"GOOGLE_VERTEX_HOST" = "https://aiplatform.googleapis.com?"
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "global"
+
+[providers.vertexhostfragment]
+base = "google-vertex-anthropic"
+[providers.vertexhostfragment.vars]
+"GOOGLE_VERTEX_HOST" = "https://aiplatform.googleapis.com#"
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "global"
+`
+	r := fixtureLoad(t, nil, cfg)
+	cases := []struct {
+		ref      string
+		want     string
+		wantWarn bool
+		desc     string
+	}{
+		{"vertexhostnoloc/claude-opus-5", "false", true, "a GOOGLE_VERTEX_HOST with no GOOGLE_VERTEX_LOCATION has no canonical derivation to check against, so the gate must fail closed, not open"},
+		{"vertexrowrule/claude-opus-5", "false", true, "a model row swapping host_rule redirects the resolved URL; divergence is judged on the final transport, not the provider-level rule"},
+		{"vertexglobgw/claude-opus-5", "false", true, "a user glob row's base_url redirects a vars-only provider even though no exact config row exists"},
+		{"vertexaliastarget/my-claude-alias", "false", true, "a base_url override on the alias TARGET's row rides the alias import; the target's override provenance must gate the alias too"},
+		{"vertexhostquery/claude-opus-5", "false", true, "a GOOGLE_VERTEX_HOST with a bare trailing ? changes the assembled request URL and must not read as the canonical host"},
+		{"vertexhostfragment/claude-opus-5", "false", true, "a GOOGLE_VERTEX_HOST with a bare trailing # changes the assembled request URL and must not read as the canonical host"},
+	}
+	for _, c := range cases {
+		res := mustResolve(t, r, c.ref)
+		if got := bp(res.Caps.WebSearch); got != c.want {
+			t.Errorf("%s: web_search = %s, want %s (%s)", c.ref, got, c.want, c.desc)
+		}
+		if got := hasWarning(res, "web_search disabled"); got != c.wantWarn {
+			t.Errorf("%s: web_search-disabled warning present = %v, want %v (%s): %v", c.ref, got, c.wantWarn, c.desc, res.Warnings)
+		}
+	}
+}
+
 // TestResolve_WebSearchInheritedCuratedRowBaseURL guards against treating
 // an inherited curated row's own base_url as a user override: Google
 // Vertex MaaS rows carry a row-level base_url straight from models.dev's

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -414,6 +414,10 @@ base = "google-vertex-anthropic"
 "GOOGLE_VERTEX_HOST" = "https://aiplatform.googleapis.com"
 "GOOGLE_VERTEX_PROJECT" = "my-project"
 "GOOGLE_VERTEX_LOCATION" = "global"
+
+[providers.bedrockgw]
+base = "amazon-bedrock"
+base_url = "https://bedrock-gateway.example/v1"
 `
 	r := fixtureLoad(t, map[string]string{"OPENAI_API_KEY": "k", "ANTHROPIC_API_KEY": "a"}, cfg)
 	cases := []struct {
@@ -443,6 +447,25 @@ base = "google-vertex-anthropic"
 		if got := hasWarning(res, "web_search disabled"); got != c.wantWarn {
 			t.Errorf("%s: web_search-disabled warning present = %v, want %v (%s): %v", c.ref, got, c.wantWarn, c.desc, res.Warnings)
 		}
+	}
+
+	// bedrockgw is diverged (a literal base_url, so not first-party) but
+	// resolves an *anthropic.* row: amazon-bedrock's own curated glob
+	// already sets web_search = false there for an unrelated reason (the
+	// Messages endpoint lacks the capability, providers_overlay.toml), not
+	// because of divergence. The gate must not restate a value that was
+	// already correct: no warning (nothing changed), and Provenance must
+	// keep naming the glob, not the gate, so a reader still finds the real
+	// reason.
+	bgw := mustResolve(t, r, "bedrockgw/anthropic.claude-sonnet-5")
+	if bp(bgw.Caps.WebSearch) != "false" {
+		t.Errorf("bedrockgw: web_search = %s, want false (unchanged - already false before the gate ran)", bp(bgw.Caps.WebSearch))
+	}
+	if got := bgw.Provenance["WebSearch"]; got != "overlay/glob:*anthropic.*" {
+		t.Errorf("bedrockgw: Provenance[WebSearch] = %q, want the original glob's tag preserved, not overwritten by the gate", got)
+	}
+	if hasWarning(bgw, "web_search disabled") {
+		t.Errorf("bedrockgw: unexpected web_search-disabled warning for a value the gate did not change: %v", bgw.Warnings)
 	}
 
 	proxy := fixtureLoad(t, map[string]string{"OPENAI_API_KEY": "k", "OPENAI_BASE_URL": "https://proxy.example/v1"}, "")

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -322,14 +322,21 @@ surface = "anthropic"
 
 // TestResolve_WebSearchEndpointGate covers issue #738: WebSearch is a
 // platform-side capability, not a wire-protocol fact (spec §4.2 says
-// explicitly it is not one of the facts an alias imports), so an instance
-// whose resolved base_url diverges from its provider's own default must not
-// inherit it - the same family as spec §10's credential endpoint stop, but
-// not limited to a literal base_url override: sending an unused credential
-// to the wrong endpoint is merely wasted, while sending a hosted-tool
-// definition the gateway does not implement fails the whole request, so a
-// *_BASE_URL environment override that keeps the template is just as
-// untrustworthy here even though credentials keep flowing through it.
+// explicitly it is not one of the facts an alias imports), so it survives
+// only on a record reaching its provider's first-party endpoint (Jesse's
+// framing, 2026-09-01: "web_search should only be available from openai as
+// openai"). This is the same family as spec §10's credential endpoint stop,
+// but not limited to a literal base_url override: sending an unused
+// credential to the wrong endpoint is merely wasted, while sending a
+// hosted-tool definition the gateway does not implement fails the whole
+// request, so a *_BASE_URL environment override that keeps the template is
+// just as untrustworthy here even though credentials keep flowing through
+// it. vertexgw is the regression case for a prior version of this gate,
+// which exempted every google-vertex-anthropic/google-vertex-based record
+// unconditionally (missing a curated default for GOOGLE_VERTEX_PROJECT/
+// LOCATION was read as "nothing to compare", regardless of whether the
+// record's own base_url ever touched the template) - the exact #738 failure
+// shape, one vendor over.
 func TestResolve_WebSearchEndpointGate(t *testing.T) {
 	cfg := `
 [providers.bedrock]
@@ -348,6 +355,7 @@ web_search = true
 
 [providers.optedout]
 base = "anthropic"
+base_url = "https://gw.example/v1"
 web_search = false
 
 [providers.vertex]
@@ -355,30 +363,43 @@ base = "google-vertex-anthropic"
 [providers.vertex.vars]
 "GOOGLE_VERTEX_PROJECT" = "my-project"
 "GOOGLE_VERTEX_LOCATION" = "global"
+
+[providers.vertexgw]
+base = "google-vertex-anthropic"
+base_url = "https://vertex-gateway.example/v1"
 `
 	r := fixtureLoad(t, map[string]string{"OPENAI_API_KEY": "k", "ANTHROPIC_API_KEY": "a"}, cfg)
 	cases := []struct {
-		ref  string
-		want string
-		desc string
+		ref      string
+		want     string
+		wantWarn bool
+		desc     string
 	}{
-		{"bedrock/us.openai.gpt-5.6-luna", "nil", "a literal base_url naming a different endpoint must not inherit web_search"},
-		{"openai/gpt-5.5", "true", "openai itself, unmodified, must keep web_search"},
-		{"same/gpt-5.5", "true", "copying the default base_url verbatim is not different (spec §10)"},
-		{"optedin/gpt-5.5", "true", "an explicit web_search = true must still opt a proxy in"},
-		{"optedout/claude-opus-5", "false", "an explicit web_search = false must still be the escape hatch"},
-		{"vertex/claude-opus-5", "true", "vertex keeps the template and supplies vars, so it inherits normally"},
+		{"bedrock/us.openai.gpt-5.6-luna", "nil", true, "a literal base_url naming a different endpoint must not inherit web_search"},
+		{"openai/gpt-5.5", "true", false, "openai itself, unmodified, must keep web_search"},
+		{"same/gpt-5.5", "true", false, "copying the default base_url verbatim is not different (spec §10)"},
+		{"optedin/gpt-5.5", "true", false, "an explicit web_search = true must still opt a proxy in, silently"},
+		{"optedout/claude-opus-5", "false", false, "an explicit web_search = false at a genuinely diverged base_url is still the escape hatch, silently"},
+		{"vertex/claude-opus-5", "true", false, "vertex keeps the template and supplies vars, so it inherits normally"},
+		{"vertexgw/claude-opus-5", "nil", true, "a literal base_url on a Vertex-based instance must not inherit web_search either - the vars-only carve-out must not swallow this"},
 	}
 	for _, c := range cases {
 		res := mustResolve(t, r, c.ref)
 		if got := bp(res.Caps.WebSearch); got != c.want {
 			t.Errorf("%s: web_search = %s, want %s (%s)", c.ref, got, c.want, c.desc)
 		}
+		if got := hasWarning(res, "web_search disabled"); got != c.wantWarn {
+			t.Errorf("%s: web_search-disabled warning present = %v, want %v (%s): %v", c.ref, got, c.wantWarn, c.desc, res.Warnings)
+		}
 	}
 
 	proxy := fixtureLoad(t, map[string]string{"OPENAI_API_KEY": "k", "OPENAI_BASE_URL": "https://proxy.example/v1"}, "")
-	if res := mustResolve(t, proxy, "openai/gpt-5.5"); bp(res.Caps.WebSearch) != "nil" {
+	res := mustResolve(t, proxy, "openai/gpt-5.5")
+	if bp(res.Caps.WebSearch) != "nil" {
 		t.Errorf("openai/gpt-5.5 via OPENAI_BASE_URL: web_search = %s, want nil (a gateway that merely speaks the protocol cannot honor it)", bp(res.Caps.WebSearch))
+	}
+	if !hasWarning(res, "web_search disabled") {
+		t.Errorf("openai/gpt-5.5 via OPENAI_BASE_URL: expected a web_search-disabled warning, got %v", res.Warnings)
 	}
 }
 

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -636,6 +636,48 @@ base = "google-vertex-anthropic"
 	}
 }
 
+// TestResolve_WebSearchNilCapFailsClosed pins the gate's nil
+// normalization: an instance resolving off its provider's first-party
+// endpoint whose provider never granted web_search anywhere
+// (Caps.WebSearch nil across every layer) must still land as an explicit
+// false - the protocol adapters' own gates treat nil as permissive (trust
+// the caller's req.WebSearch, see each protocol's
+// *_WebSearchNilCapsIsFailOpen test), so a bare nil on a gated endpoint
+// would let a caller's request flag send the hosted tool anyway. The
+// normalization is silent hardening, not a user-visible strip: no warning
+// and no provenance repoint, both of which name the gate only when it
+// overturns a true some layer actually set. On the first-party endpoint
+// nil stays nil - no catalog opinion, none invented.
+func TestResolve_WebSearchNilCapFailsClosed(t *testing.T) {
+	cfg := `
+[providers.groqgw]
+base = "groq"
+base_url = "https://gw.example/v1"
+`
+	r := fixtureLoad(t, map[string]string{"GROQ_API_KEY": "k"}, cfg)
+	res := mustResolve(t, r, "groqgw/llama-3.3-70b-versatile")
+	if bp(res.Caps.WebSearch) != "false" {
+		t.Errorf("diverged nil-capped instance: web_search = %s, want explicit false (nil is fail-open at the adapter layer)", bp(res.Caps.WebSearch))
+	}
+	if hasWarning(res, "web_search disabled") {
+		t.Errorf("the nil normalization must be silent - no layer's true was overturned: %v", res.Warnings)
+	}
+	if tag, ok := res.Provenance["WebSearch"]; ok {
+		t.Errorf("no layer set web_search and the gate changed no true, so no provenance entry belongs: %q", tag)
+	}
+	inst, err := r.ResolveInstance("groqgw")
+	if err != nil {
+		t.Fatalf("ResolveInstance: %v", err)
+	}
+	if bp(inst.Caps.WebSearch) != "false" || hasWarning(inst, "web_search disabled") {
+		t.Errorf("ResolveInstance parity: web_search = %s warnings = %v, want a silent explicit false", bp(inst.Caps.WebSearch), inst.Warnings)
+	}
+	fp := mustResolve(t, r, "groq/llama-3.3-70b-versatile")
+	if fp.Caps.WebSearch != nil {
+		t.Errorf("first-party groq never granted web_search: nil must stay nil, got %s", bp(fp.Caps.WebSearch))
+	}
+}
+
 // TestResolve_WebSearchInheritedCuratedRowBaseURL guards against treating
 // an inherited curated row's own base_url as a user override: Google
 // Vertex MaaS rows carry a row-level base_url straight from models.dev's

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -426,6 +426,28 @@ base = "openai"
 base_url = "https://gw.example/v1"
 [providers.rowoptedin.models."gpt-5.5"]
 web_search = true
+
+[providers.vertexhostrule]
+base = "google-vertex-anthropic"
+host_rule = "ollama-host"
+[providers.vertexhostrule.vars]
+"GOOGLE_VERTEX_HOST" = "https://ollama-swap-gateway.example"
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "global"
+
+[providers.vertexalias]
+base = "google-vertex"
+[providers.vertexalias.vars]
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "global"
+[providers.vertexalias.models."my-claude-alias"]
+alias_of = "claude-opus-5"
+
+[providers.vertexaliasgw]
+base = "google-vertex"
+base_url = "https://alias-gateway.example/v1"
+[providers.vertexaliasgw.models."my-claude-alias"]
+alias_of = "claude-opus-5"
 `
 	r := fixtureLoad(t, map[string]string{"OPENAI_API_KEY": "k", "ANTHROPIC_API_KEY": "a"}, cfg)
 	cases := []struct {
@@ -453,6 +475,9 @@ web_search = true
 		{"vertexclaude/claude-opus-5", "true", false, "a custom instance inheriting google-vertex resolves Claude through the curated vertex-anthropic row transport, which is first-party even though a row-less comparison would disagree"},
 		{"globgw/gpt-5.5", "false", true, "a provider-scoped glob's web_search = true is not a deliberate per-instance/per-model opt-in and must not bypass the gate on a diverged instance"},
 		{"rowoptedin/gpt-5.5", "true", false, "an exact-model web_search = true is a deliberate opt-in and must still win, even at a diverged base_url"},
+		{"vertexhostrule/claude-opus-5", "false", true, "swapping host_rule away from vertex-location cannot silence the host-override check just by making it inspect the wrong rule"},
+		{"vertexalias/my-claude-alias", "true", false, "a same-provider alias to a transport-bearing curated row is first-party, judged against the target's own canonical transport, not a row-less baseline"},
+		{"vertexaliasgw/my-claude-alias", "false", true, "the same alias on a diverged instance still strips, regardless of the alias mechanism"},
 	}
 	for _, c := range cases {
 		res := mustResolve(t, r, c.ref)

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -418,6 +418,22 @@ base = "google-vertex-anthropic"
 [providers.bedrockgw]
 base = "amazon-bedrock"
 base_url = "https://bedrock-gateway.example/v1"
+
+[providers.endpointgw]
+base = "openai"
+endpoint = "/custom-endpoint"
+
+[providers.streamendpointgw]
+base = "openai"
+stream_endpoint = "/custom-stream-endpoint"
+
+[providers.counttokensendpointgw]
+base = "openai"
+count_tokens_endpoint = "/custom-count-endpoint"
+
+[providers.endpointsame]
+base = "openai"
+endpoint = "/responses"
 `
 	r := fixtureLoad(t, map[string]string{"OPENAI_API_KEY": "k", "ANTHROPIC_API_KEY": "a"}, cfg)
 	cases := []struct {
@@ -438,6 +454,10 @@ base_url = "https://bedrock-gateway.example/v1"
 		{"vertexrow/claude-opus-5", "false", true, "a model row's own divergent base_url strips web_search on the vars-only-carve-out family too"},
 		{"vertexhostgw/claude-opus-5", "false", true, "overriding GOOGLE_VERTEX_HOST directly bypasses the location-derived host and must not be first-party"},
 		{"vertexhostsame/claude-opus-5", "true", false, "a GOOGLE_VERTEX_HOST override that reproduces the location-derived host verbatim is not different"},
+		{"endpointgw/gpt-5.5", "false", true, "a canonical base_url with a custom endpoint must strip web_search - the endpoint decides where the request lands too"},
+		{"streamendpointgw/gpt-5.5", "false", true, "a canonical base_url with a custom stream_endpoint must strip web_search - streaming carries the same web_search tool"},
+		{"counttokensendpointgw/gpt-5.5", "false", true, "a canonical base_url with a custom count_tokens_endpoint must strip web_search - count-tokens requests carry the same tools, unpruned"},
+		{"endpointsame/gpt-5.5", "true", false, "an endpoint override that reproduces the protocol default verbatim is not different"},
 	}
 	for _, c := range cases {
 		res := mustResolve(t, r, c.ref)
@@ -475,6 +495,21 @@ base_url = "https://bedrock-gateway.example/v1"
 	}
 	if !hasWarning(res, "web_search disabled") {
 		t.Errorf("openai/gpt-5.5 via OPENAI_BASE_URL: expected a web_search-disabled warning, got %v", res.Warnings)
+	}
+
+	// A trailing slash on OPENAI_BASE_URL must not read as divergence: the
+	// HTTP builder (protocolhttp.URL) does strings.TrimRight(BaseURL, "/")
+	// before joining the endpoint path, so
+	// "https://api.openai.com/v1/" and "https://api.openai.com/v1" hit the
+	// identical physical endpoint. The genuinely-different case (proxy,
+	// above) still strips.
+	trailingSlash := fixtureLoad(t, map[string]string{"OPENAI_API_KEY": "k", "OPENAI_BASE_URL": "https://api.openai.com/v1/"}, "")
+	ts := mustResolve(t, trailingSlash, "openai/gpt-5.5")
+	if bp(ts.Caps.WebSearch) != "true" {
+		t.Errorf("openai/gpt-5.5 via OPENAI_BASE_URL with a trailing slash: web_search = %s, want true (same endpoint once the builder trims the slash)", bp(ts.Caps.WebSearch))
+	}
+	if hasWarning(ts, "web_search disabled") {
+		t.Errorf("openai/gpt-5.5 via OPENAI_BASE_URL with a trailing slash: unexpected web_search-disabled warning: %v", ts.Warnings)
 	}
 }
 

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -335,6 +335,28 @@ surface = "anthropic"
 // default for its base_url vars (GOOGLE_VERTEX_PROJECT/LOCATION) must stay
 // gated when its own base_url replaced the template - the exact #738
 // failure shape, one vendor over.
+//
+// The case list also pins three properties the gate must hold beyond that:
+//   - the strip lands as an explicit false, never nil: every protocol
+//     adapter's own gate (caps.WebSearch == nil || *caps.WebSearch) treats
+//     nil as permissive, so nil'ing the cap only denies a caller that also
+//     rederives WebSearch from Caps (profile.SupportsWebSearch does; a
+//     caller that sets Request.WebSearch directly - cmd/llmcall's
+//     --web-search flag, for one - does not, and would still get the
+//     tool). Every "stripped" case below asserts "false", not "nil" (bp on
+//     a *bool distinguishes all three states).
+//   - a model row's own divergent base_url (rowdiverge, vertexrow) gates
+//     the same as an instance-level one: buildTransport merges a row's own
+//     base_url into the same endpoint the request actually reaches, so the
+//     gate has to judge that fully resolved endpoint, not just the
+//     instance's.
+//   - overriding a host-rule-computed variable directly (vertexhostgw)
+//     bypasses vertex-location's derivation (vertexHost(LOCATION)) the same
+//     way a literal base_url does, while leaving ownBaseURL empty - the
+//     vars-only carve-out trusts vars, but not the one var whose whole job
+//     is picking the host. vertexhostsame is the verbatim-match carve-out's
+//     Vertex analog: supplying the host rule's own answer by hand is not
+//     "different".
 func TestResolve_WebSearchEndpointGate(t *testing.T) {
 	cfg := `
 [providers.bedrock]
@@ -365,6 +387,33 @@ base = "google-vertex-anthropic"
 [providers.vertexgw]
 base = "google-vertex-anthropic"
 base_url = "https://vertex-gateway.example/v1"
+
+[providers.rowdiverge]
+base = "openai"
+[providers.rowdiverge.models."gpt-5.5"]
+base_url = "https://row-gateway.example/v1"
+
+[providers.vertexrow]
+base = "google-vertex-anthropic"
+[providers.vertexrow.vars]
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "global"
+[providers.vertexrow.models."claude-opus-5"]
+base_url = "https://row-gateway.example/v1"
+
+[providers.vertexhostgw]
+base = "google-vertex-anthropic"
+[providers.vertexhostgw.vars]
+"GOOGLE_VERTEX_HOST" = "https://vertex-gateway.example"
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "global"
+
+[providers.vertexhostsame]
+base = "google-vertex-anthropic"
+[providers.vertexhostsame.vars]
+"GOOGLE_VERTEX_HOST" = "https://aiplatform.googleapis.com"
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "global"
 `
 	r := fixtureLoad(t, map[string]string{"OPENAI_API_KEY": "k", "ANTHROPIC_API_KEY": "a"}, cfg)
 	cases := []struct {
@@ -373,13 +422,18 @@ base_url = "https://vertex-gateway.example/v1"
 		wantWarn bool
 		desc     string
 	}{
-		{"bedrock/us.openai.gpt-5.6-luna", "nil", true, "a literal base_url naming a different endpoint must not inherit web_search"},
+		{"bedrock/us.openai.gpt-5.6-luna", "false", true, "a literal base_url naming a different endpoint must not inherit web_search, and must land as an explicit false, not nil"},
 		{"openai/gpt-5.5", "true", false, "openai itself, unmodified, must keep web_search"},
 		{"same/gpt-5.5", "true", false, "copying the default base_url verbatim is not different (spec §10)"},
 		{"optedin/gpt-5.5", "true", false, "an explicit web_search = true must still opt a proxy in, silently"},
 		{"optedout/claude-opus-5", "false", false, "an explicit web_search = false at a genuinely diverged base_url is still the escape hatch, silently"},
 		{"vertex/claude-opus-5", "true", false, "vertex keeps the template and supplies vars, so it inherits normally"},
-		{"vertexgw/claude-opus-5", "nil", true, "a literal base_url on a Vertex-based instance must not inherit web_search either - the vars-only carve-out must not swallow this"},
+		{"vertexgw/claude-opus-5", "false", true, "a literal base_url on a Vertex-based instance must not inherit web_search either - the vars-only carve-out must not swallow this"},
+		{"rowdiverge/gpt-5.5", "false", true, "a model row's own divergent base_url must strip web_search even though the instance itself is first-party"},
+		{"rowdiverge/gpt-5.6", "true", false, "a different model under the same first-party instance, with no row override, keeps web_search"},
+		{"vertexrow/claude-opus-5", "false", true, "a model row's own divergent base_url strips web_search on the vars-only-carve-out family too"},
+		{"vertexhostgw/claude-opus-5", "false", true, "overriding GOOGLE_VERTEX_HOST directly bypasses the location-derived host and must not be first-party"},
+		{"vertexhostsame/claude-opus-5", "true", false, "a GOOGLE_VERTEX_HOST override that reproduces the location-derived host verbatim is not different"},
 	}
 	for _, c := range cases {
 		res := mustResolve(t, r, c.ref)
@@ -393,8 +447,8 @@ base_url = "https://vertex-gateway.example/v1"
 
 	proxy := fixtureLoad(t, map[string]string{"OPENAI_API_KEY": "k", "OPENAI_BASE_URL": "https://proxy.example/v1"}, "")
 	res := mustResolve(t, proxy, "openai/gpt-5.5")
-	if bp(res.Caps.WebSearch) != "nil" {
-		t.Errorf("openai/gpt-5.5 via OPENAI_BASE_URL: web_search = %s, want nil (a gateway that merely speaks the protocol cannot honor it)", bp(res.Caps.WebSearch))
+	if bp(res.Caps.WebSearch) != "false" {
+		t.Errorf("openai/gpt-5.5 via OPENAI_BASE_URL: web_search = %s, want false, not nil (a gateway that merely speaks the protocol cannot honor it, and nil is fail-open at the adapter layer)", bp(res.Caps.WebSearch))
 	}
 	if !hasWarning(res, "web_search disabled") {
 		t.Errorf("openai/gpt-5.5 via OPENAI_BASE_URL: expected a web_search-disabled warning, got %v", res.Warnings)

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -448,6 +448,27 @@ base = "google-vertex"
 base_url = "https://alias-gateway.example/v1"
 [providers.vertexaliasgw.models."my-claude-alias"]
 alias_of = "claude-opus-5"
+
+[providers.vertexhostpath]
+base = "google-vertex-anthropic"
+[providers.vertexhostpath.vars]
+"GOOGLE_VERTEX_HOST" = "https://aiplatform.googleapis.com/proxy"
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "global"
+
+[providers.vertexhostport]
+base = "google-vertex-anthropic"
+[providers.vertexhostport.vars]
+"GOOGLE_VERTEX_HOST" = "https://aiplatform.googleapis.com:8443"
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "global"
+
+[providers.vertexhostuserinfo]
+base = "google-vertex-anthropic"
+[providers.vertexhostuserinfo.vars]
+"GOOGLE_VERTEX_HOST" = "https://attacker@aiplatform.googleapis.com"
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "global"
 `
 	r := fixtureLoad(t, map[string]string{"OPENAI_API_KEY": "k", "ANTHROPIC_API_KEY": "a"}, cfg)
 	cases := []struct {
@@ -478,6 +499,9 @@ alias_of = "claude-opus-5"
 		{"vertexhostrule/claude-opus-5", "false", true, "swapping host_rule away from vertex-location cannot silence the host-override check just by making it inspect the wrong rule"},
 		{"vertexalias/my-claude-alias", "true", false, "a same-provider alias to a transport-bearing curated row is first-party, judged against the target's own canonical transport, not a row-less baseline"},
 		{"vertexaliasgw/my-claude-alias", "false", true, "the same alias on a diverged instance still strips, regardless of the alias mechanism"},
+		{"vertexhostpath/claude-opus-5", "false", true, "a GOOGLE_VERTEX_HOST carrying a path (a real segment injected before the template's own /v1/projects/... path) must not pass a prefix check that only looks at the start of the assembled URL"},
+		{"vertexhostport/claude-opus-5", "false", true, "a GOOGLE_VERTEX_HOST carrying a port must not match the canonical host"},
+		{"vertexhostuserinfo/claude-opus-5", "false", true, "a GOOGLE_VERTEX_HOST carrying userinfo must not match the canonical host"},
 	}
 	for _, c := range cases {
 		res := mustResolve(t, r, c.ref)
@@ -530,6 +554,65 @@ alias_of = "claude-opus-5"
 	}
 	if hasWarning(ts, "web_search disabled") {
 		t.Errorf("openai/gpt-5.5 via OPENAI_BASE_URL with a trailing slash: unexpected web_search-disabled warning: %v", ts.Warnings)
+	}
+}
+
+// TestResolve_WebSearchInheritedCuratedRowBaseURL guards against treating
+// an inherited curated row's own base_url as a user override: Google
+// Vertex MaaS rows carry a row-level base_url straight from models.dev's
+// own upstream data (modelsdev.go's
+// convertModelOverride, triggered by a provider api field), not from any
+// user's config. vertexmaas below reproduces that shape - a curated,
+// vars-only provider template (so the provider-level base_url alone can
+// never resolve, exercising firstPartyEndpoint's missing-vars branch) whose
+// one row carries its own literal base_url. A custom instance that merely
+// inherits that row, with no base_url of its own anywhere, must keep
+// web_search; only a genuine user-config override of that same row may
+// strip it.
+func TestResolve_WebSearchInheritedCuratedRowBaseURL(t *testing.T) {
+	overlay := `
+[providers.vertexmaas]
+implicit = true
+protocol = "openai-chat"
+base_url = "{GOOGLE_VERTEX_HOST}/v1/projects/{GOOGLE_VERTEX_PROJECT}/locations/{GOOGLE_VERTEX_LOCATION}"
+host_rule = "vertex-location"
+web_search = true
+[providers.vertexmaas.models."maas-model"]
+base_url = "https://maas-curated-endpoint.example/v1"
+`
+	cfg := `
+[providers.vertexmaasinstance]
+base = "vertexmaas"
+[providers.vertexmaasinstance.vars]
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "global"
+
+[providers.vertexmaasuser]
+base = "vertexmaas"
+[providers.vertexmaasuser.vars]
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "global"
+[providers.vertexmaasuser.models."maas-model"]
+base_url = "https://user-override-gateway.example/v1"
+`
+	r := fixtureLoad(t, nil, cfg, WithOverlay(overlayWith(overlay)))
+	cases := []struct {
+		ref      string
+		want     string
+		wantWarn bool
+		desc     string
+	}{
+		{"vertexmaasinstance/maas-model", "true", false, "inheriting a curated row's own base_url (Vertex MaaS shape) is not a user override and must keep web_search"},
+		{"vertexmaasuser/maas-model", "false", true, "a genuine user-config override of that same row's base_url must still strip web_search"},
+	}
+	for _, c := range cases {
+		res := mustResolve(t, r, c.ref)
+		if got := bp(res.Caps.WebSearch); got != c.want {
+			t.Errorf("%s: web_search = %s, want %s (%s)", c.ref, got, c.want, c.desc)
+		}
+		if got := hasWarning(res, "web_search disabled"); got != c.wantWarn {
+			t.Errorf("%s: web_search-disabled warning present = %v, want %v (%s): %v", c.ref, got, c.wantWarn, c.desc, res.Warnings)
+		}
 	}
 }
 

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -320,43 +320,17 @@ surface = "anthropic"
 	}
 }
 
-// TestResolve_WebSearchEndpointGate covers issue #738: WebSearch is a
-// platform-side capability, not a wire-protocol fact (spec §4.2 says
-// explicitly it is not one of the facts an alias imports), so it survives
-// only on a record reaching its provider's first-party endpoint (Jesse's
-// framing, 2026-09-01: "web_search should only be available from openai as
-// openai"). This is the same family as spec §10's credential endpoint stop,
-// but not limited to a literal base_url override: sending an unused
-// credential to the wrong endpoint is merely wasted, while sending a
-// hosted-tool definition the gateway does not implement fails the whole
-// request, so a *_BASE_URL environment override that keeps the template is
-// just as untrustworthy here even though credentials keep flowing through
-// it. vertexgw guards the vars-only carve-out: a provider with no curated
-// default for its base_url vars (GOOGLE_VERTEX_PROJECT/LOCATION) must stay
-// gated when its own base_url replaced the template - the exact #738
-// failure shape, one vendor over.
-//
-// The case list also pins three properties the gate must hold beyond that:
-//   - the strip lands as an explicit false, never nil: every protocol
-//     adapter's own gate (caps.WebSearch == nil || *caps.WebSearch) treats
-//     nil as permissive, so nil'ing the cap only denies a caller that also
-//     rederives WebSearch from Caps (profile.SupportsWebSearch does; a
-//     caller that sets Request.WebSearch directly - cmd/llmcall's
-//     --web-search flag, for one - does not, and would still get the
-//     tool). Every "stripped" case below asserts "false", not "nil" (bp on
-//     a *bool distinguishes all three states).
-//   - a model row's own divergent base_url (rowdiverge, vertexrow) gates
-//     the same as an instance-level one: buildTransport merges a row's own
-//     base_url into the same endpoint the request actually reaches, so the
-//     gate has to judge that fully resolved endpoint, not just the
-//     instance's.
-//   - overriding a host-rule-computed variable directly (vertexhostgw)
-//     bypasses vertex-location's derivation (vertexHost(LOCATION)) the same
-//     way a literal base_url does, while leaving ownBaseURL empty - the
-//     vars-only carve-out trusts vars, but not the one var whose whole job
-//     is picking the host. vertexhostsame is the verbatim-match carve-out's
-//     Vertex analog: supplying the host rule's own answer by hand is not
-//     "different".
+// TestResolve_WebSearchEndpointGate pins WebSearch's first-party-endpoint
+// gate: a platform-side capability, not a wire-protocol fact (spec §4.2
+// says explicitly it is not one of the facts an alias imports), so it
+// survives only on a record reaching its provider's own endpoint. This is
+// the same family as spec §10's credential endpoint stop, but broader: an
+// unused credential is merely wasted, while a hosted-tool definition the
+// gateway does not implement fails the whole request, so this gate also
+// catches a *_BASE_URL environment override that keeps the template
+// (which credentials tolerate) and judges the resolved endpoint path
+// (Endpoint/StreamEndpoint/CountTokensEndpoint), not just base_url. Each
+// case's desc states the specific rule it pins.
 func TestResolve_WebSearchEndpointGate(t *testing.T) {
 	cfg := `
 [providers.bedrock]
@@ -434,6 +408,24 @@ count_tokens_endpoint = "/custom-count-endpoint"
 [providers.endpointsame]
 base = "openai"
 endpoint = "/responses"
+
+[providers.vertexclaude]
+base = "google-vertex"
+[providers.vertexclaude.vars]
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "global"
+
+[providers.globgw]
+base = "openai"
+base_url = "https://glob-gateway.example/v1"
+[providers.globgw.models."gpt-5*"]
+web_search = true
+
+[providers.rowoptedin]
+base = "openai"
+base_url = "https://gw.example/v1"
+[providers.rowoptedin.models."gpt-5.5"]
+web_search = true
 `
 	r := fixtureLoad(t, map[string]string{"OPENAI_API_KEY": "k", "ANTHROPIC_API_KEY": "a"}, cfg)
 	cases := []struct {
@@ -458,6 +450,9 @@ endpoint = "/responses"
 		{"streamendpointgw/gpt-5.5", "false", true, "a canonical base_url with a custom stream_endpoint must strip web_search - streaming carries the same web_search tool"},
 		{"counttokensendpointgw/gpt-5.5", "false", true, "a canonical base_url with a custom count_tokens_endpoint must strip web_search - count-tokens requests carry the same tools, unpruned"},
 		{"endpointsame/gpt-5.5", "true", false, "an endpoint override that reproduces the protocol default verbatim is not different"},
+		{"vertexclaude/claude-opus-5", "true", false, "a custom instance inheriting google-vertex resolves Claude through the curated vertex-anthropic row transport, which is first-party even though a row-less comparison would disagree"},
+		{"globgw/gpt-5.5", "false", true, "a provider-scoped glob's web_search = true is not a deliberate per-instance/per-model opt-in and must not bypass the gate on a diverged instance"},
+		{"rowoptedin/gpt-5.5", "true", false, "an exact-model web_search = true is a deliberate opt-in and must still win, even at a diverged base_url"},
 	}
 	for _, c := range cases {
 		res := mustResolve(t, r, c.ref)

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -320,6 +320,68 @@ surface = "anthropic"
 	}
 }
 
+// TestResolve_WebSearchEndpointGate covers issue #738: WebSearch is a
+// platform-side capability, not a wire-protocol fact (spec §4.2 says
+// explicitly it is not one of the facts an alias imports), so an instance
+// whose resolved base_url diverges from its provider's own default must not
+// inherit it - the same family as spec §10's credential endpoint stop, but
+// not limited to a literal base_url override: sending an unused credential
+// to the wrong endpoint is merely wasted, while sending a hosted-tool
+// definition the gateway does not implement fails the whole request, so a
+// *_BASE_URL environment override that keeps the template is just as
+// untrustworthy here even though credentials keep flowing through it.
+func TestResolve_WebSearchEndpointGate(t *testing.T) {
+	cfg := `
+[providers.bedrock]
+base = "openai"
+base_url = "https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1"
+api_key_env = ["OPENAI_API_KEY"]
+
+[providers.same]
+base = "openai"
+base_url = "https://api.openai.com/v1"
+
+[providers.optedin]
+base = "openai"
+base_url = "https://gw.example/v1"
+web_search = true
+
+[providers.optedout]
+base = "anthropic"
+web_search = false
+
+[providers.vertex]
+base = "google-vertex-anthropic"
+[providers.vertex.vars]
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "global"
+`
+	r := fixtureLoad(t, map[string]string{"OPENAI_API_KEY": "k", "ANTHROPIC_API_KEY": "a"}, cfg)
+	cases := []struct {
+		ref  string
+		want string
+		desc string
+	}{
+		{"bedrock/us.openai.gpt-5.6-luna", "nil", "a literal base_url naming a different endpoint must not inherit web_search"},
+		{"openai/gpt-5.5", "true", "openai itself, unmodified, must keep web_search"},
+		{"same/gpt-5.5", "true", "copying the default base_url verbatim is not different (spec §10)"},
+		{"optedin/gpt-5.5", "true", "an explicit web_search = true must still opt a proxy in"},
+		{"optedout/claude-opus-5", "false", "an explicit web_search = false must still be the escape hatch"},
+		{"vertex/claude-opus-5", "true", "vertex keeps the template and supplies vars, so it inherits normally"},
+	}
+	for _, c := range cases {
+		res := mustResolve(t, r, c.ref)
+		if got := bp(res.Caps.WebSearch); got != c.want {
+			t.Errorf("%s: web_search = %s, want %s (%s)", c.ref, got, c.want, c.desc)
+		}
+	}
+
+	proxy := fixtureLoad(t, map[string]string{"OPENAI_API_KEY": "k", "OPENAI_BASE_URL": "https://proxy.example/v1"}, "")
+	if res := mustResolve(t, proxy, "openai/gpt-5.5"); bp(res.Caps.WebSearch) != "nil" {
+		t.Errorf("openai/gpt-5.5 via OPENAI_BASE_URL: web_search = %s, want nil (a gateway that merely speaks the protocol cannot honor it)", bp(res.Caps.WebSearch))
+	}
+}
+
 func TestFindModel(t *testing.T) {
 	state := t.TempDir()
 	_ = os.MkdirAll(filepath.Join(state, "auth"), 0o700)

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -812,6 +812,71 @@ web_search = true
 	}
 }
 
+// TestResolve_WebSearchVertexLocationValidation pins the host-rule-input
+// blind spot: GOOGLE_VERTEX_LOCATION sits in path position in the base_url
+// template, but the vertex-location host rule derives the AUTHORITY from
+// that very value (vertexHost), so a hostile location poisons the actual
+// and canonical resolutions identically and template-position
+// classification alone would compare the two poisoned URLs equal. A
+// location is a region token (a single RFC-1123 hostname label: letters,
+// digits, interior hyphens - us-central1), never a host: anything else
+// fails closed on both layers - the rule refuses to derive a host from it
+// (the "invalid GOOGLE_VERTEX_LOCATION" warning), and the canonical
+// lookup refuses to admit it, so the comparison diverges and web_search
+// strips. Label-shaped locations resolve exactly as before.
+func TestResolve_WebSearchVertexLocationValidation(t *testing.T) {
+	cfg := `
+[providers.vertexlocslash]
+base = "google-vertex-anthropic"
+[providers.vertexlocslash.vars]
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "evil.com/"
+
+[providers.vertexlocdots]
+base = "google-vertex-anthropic"
+[providers.vertexlocdots.vars]
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "evil.com"
+
+[providers.vertexlocport]
+base = "google-vertex-anthropic"
+[providers.vertexlocport.vars]
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "us-central1:8443"
+
+[providers.vertexlocok]
+base = "google-vertex-anthropic"
+[providers.vertexlocok.vars]
+"GOOGLE_VERTEX_PROJECT" = "my-project"
+"GOOGLE_VERTEX_LOCATION" = "us-central1"
+`
+	r := fixtureLoad(t, nil, cfg)
+	cases := []struct {
+		ref         string
+		want        string
+		wantWarn    bool
+		wantInvalid bool
+		desc        string
+	}{
+		{"vertexlocslash/claude-opus-5", "false", true, true, "a location with a slash rewrites the derived authority's host and path"},
+		{"vertexlocdots/claude-opus-5", "false", true, true, "a location with dots is a host, not a region label"},
+		{"vertexlocport/claude-opus-5", "false", true, true, "a location with a port is not a region label"},
+		{"vertexlocok/claude-opus-5", "true", false, false, "a label-shaped region derives the canonical host on both sides"},
+	}
+	for _, c := range cases {
+		res := mustResolve(t, r, c.ref)
+		if got := bp(res.Caps.WebSearch); got != c.want {
+			t.Errorf("%s: web_search = %s, want %s (%s)", c.ref, got, c.want, c.desc)
+		}
+		if got := hasWarning(res, "web_search disabled"); got != c.wantWarn {
+			t.Errorf("%s: web_search-disabled warning present = %v, want %v (%s): %v", c.ref, got, c.wantWarn, c.desc, res.Warnings)
+		}
+		if got := hasWarning(res, "invalid GOOGLE_VERTEX_LOCATION"); got != c.wantInvalid {
+			t.Errorf("%s: invalid-location warning present = %v, want %v (%s): %v", c.ref, got, c.wantInvalid, c.desc, res.Warnings)
+		}
+	}
+}
+
 // TestResolve_WebSearchInheritedCuratedRowBaseURL guards against treating
 // an inherited curated row's own base_url as a user override: Google
 // Vertex MaaS rows carry a row-level base_url straight from models.dev's

--- a/llm/registry/testdata/golden/azure-claude-opus-4-5.json
+++ b/llm/registry/testdata/golden/azure-claude-opus-4-5.json
@@ -70,7 +70,8 @@
       "temperature": true,
       "top_p": true
     },
-    "thinking_shape": "budget+effort"
+    "thinking_shape": "budget+effort",
+    "web_search": false
   },
   "provenance": {
     "ContextWindow": "snapshot/row",

--- a/llm/registry/testdata/golden/azure-claude-prod.json
+++ b/llm/registry/testdata/golden/azure-claude-prod.json
@@ -71,7 +71,8 @@
       "temperature": true,
       "top_p": true
     },
-    "thinking_shape": "budget+effort"
+    "thinking_shape": "budget+effort",
+    "web_search": false
   },
   "provenance": {
     "ContextWindow": "alias",

--- a/llm/registry/testdata/golden/azure-gpt55-prod.json
+++ b/llm/registry/testdata/golden/azure-gpt55-prod.json
@@ -83,7 +83,8 @@
       "text.verbosity": false,
       "top_p": true,
       "truncation": false
-    }
+    },
+    "web_search": false
   },
   "provenance": {
     "ContextWindow": "alias",

--- a/llm/registry/testdata/golden/azure-llama.json
+++ b/llm/registry/testdata/golden/azure-llama.json
@@ -59,7 +59,8 @@
       "text.verbosity": false,
       "top_p": true,
       "truncation": false
-    }
+    },
+    "web_search": false
   },
   "provenance": {
     "ContextWindow": "snapshot/row",

--- a/llm/registry/testdata/golden/bedrock-gpt-5.5.json
+++ b/llm/registry/testdata/golden/bedrock-gpt-5.5.json
@@ -86,7 +86,8 @@
       "text.verbosity": false,
       "top_p": true,
       "truncation": false
-    }
+    },
+    "web_search": false
   },
   "provenance": {
     "ContextWindow": "snapshot/row",

--- a/llm/registry/testdata/golden/local-whatever-claude.json
+++ b/llm/registry/testdata/golden/local-whatever-claude.json
@@ -46,7 +46,8 @@
       "temperature": true,
       "top_p": true,
       "user": false
-    }
+    },
+    "web_search": false
   },
   "provenance": {
     "ContextWindow": "overlay/provider",

--- a/llm/registry/testdata/golden/local-whatever.json
+++ b/llm/registry/testdata/golden/local-whatever.json
@@ -46,7 +46,8 @@
       "temperature": true,
       "top_p": true,
       "user": false
-    }
+    },
+    "web_search": false
   },
   "provenance": {
     "ContextWindow": "overlay/provider",

--- a/llm/registry/testdata/golden/ollama-llama3-base-url.json
+++ b/llm/registry/testdata/golden/ollama-llama3-base-url.json
@@ -50,7 +50,8 @@
       "temperature": true,
       "top_p": true,
       "user": false
-    }
+    },
+    "web_search": false
   },
   "provenance": {
     "ContextWindow": "live",

--- a/llm/registry/testdata/golden/ollama-llama3-ipv6.json
+++ b/llm/registry/testdata/golden/ollama-llama3-ipv6.json
@@ -50,7 +50,8 @@
       "temperature": true,
       "top_p": true,
       "user": false
-    }
+    },
+    "web_search": false
   },
   "provenance": {
     "ContextWindow": "live",

--- a/llm/registry/testdata/golden/openai-gpt-5.5-proxy.json
+++ b/llm/registry/testdata/golden/openai-gpt-5.5-proxy.json
@@ -85,7 +85,8 @@
     "max_tokens_field": "max_completion_tokens",
     "reasoning_summary": "detailed",
     "strict_tools": true,
-    "image_detail": "original"
+    "image_detail": "original",
+    "web_search": false
   },
   "headers": {
     "OpenAI-Organization": "org-golden"
@@ -120,6 +121,7 @@
     "StructuredOutput": "snapshot/row",
     "Surface": "snapshot/row",
     "Tools": "snapshot/row",
+    "WebSearch": "gate/first-party",
     "model": "row:gpt-5.5"
   },
   "warnings": [

--- a/llm/registry/testdata/golden/openai-gpt-5.5-proxy.json
+++ b/llm/registry/testdata/golden/openai-gpt-5.5-proxy.json
@@ -122,6 +122,9 @@
     "Tools": "snapshot/row",
     "model": "row:gpt-5.5"
   },
+  "warnings": [
+    "web_search disabled: this endpoint is not openai's first-party API (set web_search = true on the instance to opt back in)"
+  ],
   "default_model": "gpt-5.6",
   "cheap_model": "gpt-4.1-nano",
   "credential_source": "env:OPENAI_API_KEY",

--- a/llm/registry/testdata/golden/openai-gpt-5.5-proxy.json
+++ b/llm/registry/testdata/golden/openai-gpt-5.5-proxy.json
@@ -85,8 +85,7 @@
     "max_tokens_field": "max_completion_tokens",
     "reasoning_summary": "detailed",
     "strict_tools": true,
-    "image_detail": "original",
-    "web_search": true
+    "image_detail": "original"
   },
   "headers": {
     "OpenAI-Organization": "org-golden"
@@ -121,7 +120,6 @@
     "StructuredOutput": "snapshot/row",
     "Surface": "snapshot/row",
     "Tools": "snapshot/row",
-    "WebSearch": "overlay/provider",
     "model": "row:gpt-5.5"
   },
   "default_model": "gpt-5.6",

--- a/llm/registry/testdata/golden/work-glm.json
+++ b/llm/registry/testdata/golden/work-glm.json
@@ -55,7 +55,8 @@
     "max_tokens_field": "max_completion_tokens",
     "thinking_format": "zai",
     "reasoning_summary": "auto",
-    "strict_tools": true
+    "strict_tools": true,
+    "web_search": false
   },
   "headers": {
     "OpenAI-Organization": "org-golden",
@@ -72,6 +73,7 @@
     "StrictTools": "overlay/provider",
     "Surface": "derived",
     "ThinkingFormat": "config/row",
+    "WebSearch": "gate/first-party",
     "model": "row:glm-5.2-nvfp4"
   },
   "warnings": [

--- a/llm/registry/testdata/golden/work-glm.json
+++ b/llm/registry/testdata/golden/work-glm.json
@@ -74,6 +74,9 @@
     "ThinkingFormat": "config/row",
     "model": "row:glm-5.2-nvfp4"
   },
+  "warnings": [
+    "web_search disabled: this endpoint is not openai's first-party API (set web_search = true on the instance to opt back in)"
+  ],
   "default_model": "gpt-5.6",
   "cheap_model": "gpt-4.1-nano",
   "credential_source": "credential_headers",

--- a/llm/registry/testdata/golden/work-glm.json
+++ b/llm/registry/testdata/golden/work-glm.json
@@ -55,8 +55,7 @@
     "max_tokens_field": "max_completion_tokens",
     "thinking_format": "zai",
     "reasoning_summary": "auto",
-    "strict_tools": true,
-    "web_search": true
+    "strict_tools": true
   },
   "headers": {
     "OpenAI-Organization": "org-golden",
@@ -73,7 +72,6 @@
     "StrictTools": "overlay/provider",
     "Surface": "derived",
     "ThinkingFormat": "config/row",
-    "WebSearch": "overlay/provider",
     "model": "row:glm-5.2-nvfp4"
   },
   "default_model": "gpt-5.6",


### PR DESCRIPTION
Fixes #738. An instance with its own base_url (e.g. base = "openai" pointed at a proxy) inherited the vendor's provider-level web_search = true and died on turn 1 when the endpoint rejected the hosted tool. Per Jesse's ruling, web_search is a FIRST-PARTY-ENDPOINT capability: firstPartyEndpoint(rec) keeps it only when the instance uses the vendor's own canonical endpoint — a literal base_url= override strips it, and so does a *_BASE_URL env override (deliberately stricter than spec §10's credential endpoint-stop, which lets env overrides inherit: a wasted key is harmless, an unimplemented hosted tool kills the request). A vars-only Vertex/Bedrock instance (template intact, deployment vars supplied) IS first-party and keeps it. Explicit web_search = true/false on the instance always wins, and a resolve-time warning explains the strip.

Pipeline provenance: both adversarial lenses REFUTED round 1 with a Critical — the divergence heuristic exempted the whole google-vertex family (unresolved template vars read as 'no baseline → not diverged'), leaving the issue's exact bug open for Vertex; Jesse's first-party ruling reframed the gate, fixing that and a latent Bedrock hole. Scoped re-review ALL ADDRESSED (vertexgw red-checked both directions; vars-only Vertex goldens byte-identical; env-override strips while plain openai keeps). A parity test pins the warning on both resolve paths per the file's convention. Simplify: comment corrections only. Other-caps enumeration (twice-verified): web_search is the only provider-level vendor-hosted cap; everything else is wire-protocol shape or model facts.

Notes: spec §10 is deliberately NOT amended — the stricter web_search rule awaits Jesse's own inline-annotation convention. A hypothetical future preset-defined base_url would misread as user-typed (unreachable today — no curated preset defines one). The larger first-party-vs-openai-compatible config-model idea is tracked as #803.