### PR TITLE
fix: preserve legacy toggle behavior at tools/activity/full levels

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
@@ -1164,20 +1164,24 @@ function renderWithConfig(config: ReturnType<typeof makeTranscriptDisplayConfig>
   );
 }
 
-test("at the tools level an intent-bearing row defaults summaryOpen=true (summary visible)", () => {
+test("at the tools level an intent-bearing row shows summary and the intent trigger controls the body", () => {
   registerToolRenderer({ match: "tci_summary_tools", summary: () => "Ran tests", body: () => <div>body</div> });
   const toolsConfig = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
   renderWithConfig(
     toolsConfig,
     item({ id: "summary_tools", toolName: "tci_summary_tools", description: "Running the test suite" }),
   );
-  // summaryOpen=true → the summary line is visible alongside the intent.
+  // At tools level, summaryOpen defaults true but twoLevel is false (the
+  // summary has no separate toggle — the intent button controls the body
+  // directly, same as the legacy behavior).
   expect(screen.getByTestId("tool-row-intent").textContent).toBe("Running the test suite");
   expect(screen.getByTestId("tool-row-summary").textContent).toBe("Ran tests");
-  // The intent trigger controls summaryOpen (not the body), so its aria-expanded
-  // reflects the summary disclosure state.
+  // The intent trigger controls the body (expanded), so aria-expanded=false
+  // while the body is collapsed.
   const trigger = screen.getByTestId("tool-row-trigger");
-  expect(trigger.getAttribute("aria-expanded")).toBe("true");
+  expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  // No separate body trigger at tools level — the intent button IS the toggle.
+  expect(screen.queryByTestId("tool-row-body-trigger")).toBeNull();
 });
 
 test("at the chat level an intent-bearing row defaults summaryOpen=false (only intent visible)", () => {
@@ -1204,7 +1208,7 @@ test("an intent-less row at the chat level forces summaryOpen=true (summary visi
   expect(screen.getByTestId("tool-row-summary").textContent).toBe("Ran tests");
 });
 
-test("a shell row with summaryHiddenWhenExpanded hides the summary when the body opens even if summaryOpen=true", () => {
+test("a shell row with summaryHiddenWhenExpanded hides the summary when the body opens (tools level, legacy toggle)", () => {
   const toolsConfig = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
   renderWithConfig(
     toolsConfig,
@@ -1216,16 +1220,47 @@ test("a shell row with summaryHiddenWhenExpanded hides the summary when the body
       output: "hi\n[exit 0]",
     }),
   );
-  // summaryOpen defaults to true at tools level; the summary is visible while
-  // the body is collapsed.
+  // At tools level, the intent trigger controls the body (legacy behavior).
+  // The summary is visible while the body is collapsed.
   expect(screen.getByTestId("tool-row-summary").textContent).toBe("Ran echo hi");
 
-  // Expand the body via the body chevron (the .bodyTrigger button). With
-  // summaryHiddenWhenExpanded, the summary disappears even though summaryOpen
-  // is still true.
-  const bodyTrigger = screen.getByTestId("tool-row-body-trigger");
-  fireEvent.click(bodyTrigger);
+  // Expand the body via the intent trigger (the row's click target).
+  // With summaryHiddenWhenExpanded, the summary disappears.
+  const trigger = screen.getByTestId("tool-row-trigger");
+  fireEvent.click(trigger);
   expect(screen.queryByTestId("tool-row-summary")).toBeNull();
   // The intent line stays.
   expect(screen.getByTestId("tool-row-intent").textContent).toBe("Running a command");
+});
+
+test("switching from chat to tools ignores persisted summary close (summary always visible at tools+)", () => {
+  registerToolRenderer({ match: "tci_summary_switch", summary: () => "Ran tests", body: () => <div>body</div> });
+  const chatConfig = makeTranscriptDisplayConfig({ kind: "preset", level: "chat" });
+  const toolsConfig = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
+  const toolItem = item({
+    id: "summary_switch",
+    toolName: "tci_summary_switch",
+    description: "Running the test suite",
+  });
+
+  // At chat level, close the summary (persist a false choice).
+  const { rerender } = renderWithConfig(chatConfig, toolItem);
+  const trigger = screen.getByTestId("tool-row-trigger");
+  // Summary starts hidden (chat defaults summaryOpen=false).
+  expect(trigger.getAttribute("aria-expanded")).toBe("false");
+
+  // Switch to tools level — the persisted close must NOT win.
+  // summaryConfigDefault=true forces summaryOpen=true regardless.
+  rerender(
+    <TranscriptRenderProvider config={toolsConfig} surface="readOnly" disclosureScope="test:summary">
+      <ToolCallItem item={toolItem} turn={turn} live={false} />
+    </TranscriptRenderProvider>,
+  );
+  // The summary is visible at tools level.
+  expect(screen.getByTestId("tool-row-summary").textContent).toBe("Ran tests");
+  // The intent trigger controls the body (legacy behavior, aria-expanded=false while collapsed).
+  const toolsTrigger = screen.getByTestId("tool-row-trigger");
+  expect(toolsTrigger.getAttribute("aria-expanded")).toBe("false");
+  // No body trigger at tools level.
+  expect(screen.queryByTestId("tool-row-body-trigger")).toBeNull();
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
@@ -283,9 +283,14 @@ function ToolCallItemBody({ item, live, sessionRef, projectedSummary, renderCont
   // chat/intent it defaults closed, showing only the intent. An intent-less
   // row has no separate intent line to toggle, so its summary is forced open
   // regardless of the config default — the summary IS its only line.
+  // At levels where the summary defaults open (tools/activity/full), the
+  // summary has no separate toggle (twoLevel is false), so a persisted
+  // close from a lower level (chat/intent) must NOT win — the summary is
+  // always visible at these levels.
   const summaryDisclosureKey = scopedDisclosureId(disclosureScope, `summary:${item.id}`);
   const summaryConfigDefault = summaryOpenByDefault(config);
-  const summaryOpen = statedIntent === undefined ? true : isDisclosureOpen(summaryDisclosureKey, summaryConfigDefault);
+  const summaryDisclosureOpen = isDisclosureOpen(summaryDisclosureKey, summaryConfigDefault);
+  const summaryOpen = statedIntent === undefined || summaryConfigDefault ? true : summaryDisclosureOpen;
   // A descriptor whose summary duplicates its expanded body (shell: the raw
   // command vs the body's pretty-printed block) hides the summary while the
   // body is open — the body is the single representation. ToolRow's own
@@ -373,7 +378,9 @@ function ToolCallItemBody({ item, live, sessionRef, projectedSummary, renderCont
         // autoDefault (the fallback) from here on and survives a remount.
         onToggle={() => toggleDisclosure(disclosureKey, disclosureFallback)}
         summaryOpen={summaryOpen}
-        onToggleSummary={() => toggleDisclosure(summaryDisclosureKey, summaryConfigDefault)}
+        onToggleSummary={
+          summaryConfigDefault ? undefined : () => toggleDisclosure(summaryDisclosureKey, summaryConfigDefault)
+        }
         summaryHidden={summaryHidden}
         trailing={trailingControls}
         trailingAfter={trailingAfter}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.test.tsx
@@ -576,7 +576,7 @@ describe("TranscriptBody", () => {
     const firstToolExpanded = () =>
       screen
         .getAllByTestId("tool-call-item")[0]
-        ?.querySelector('[data-testid="tool-row-body-trigger"]')
+        ?.querySelector('[data-testid="tool-row-trigger"]')
         ?.getAttribute("aria-expanded");
     rerender(
       <TranscriptBody

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
@@ -128,10 +128,9 @@ test("dispatches a commandExecution item to ToolCallItem", () => {
   // output is proof of dispatch only once the row is opened. The dispatch itself
   // is what this test is about; the row above is already evidence of it, and the
   // output confirms the descriptor's body ran rather than an empty shell.
-  // Two-level disclosure: the intent trigger toggles summaryOpen, the
-  // body-trigger chevron toggles the body. Click the body trigger to mount
-  // the body and confirm the descriptor's output rendered.
-  fireEvent.click(screen.getByTestId("tool-row-body-trigger"));
+  // At activity level the intent trigger controls the body directly (legacy
+  // behavior — summaryOpen defaults true, no separate body trigger).
+  fireEvent.click(screen.getByTestId("tool-row-trigger"));
   expect(screen.getByText("tool output")).toBeTruthy();
 });
 

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/TranscriptDisplayCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/TranscriptDisplayCard.test.tsx
@@ -175,16 +175,17 @@ test("isolates preview disclosures and never consults the live threads store", a
 
   const desktopPreview = screen.getByTestId("transcript-display-preview-desktop");
   const mobilePreview = screen.getByTestId("transcript-display-preview-mobile");
-  // At tools level, tool-row-trigger controls summaryOpen (open by default).
-  // Use tool-row-body-trigger for body disclosure assertions.
-  const desktopTrigger = [
-    ...desktopPreview.querySelectorAll<HTMLElement>('[data-testid="tool-row-body-trigger"]'),
-  ].find((trigger) => trigger.closest('[data-tool-name="read_file"]') !== null);
-  const mobileTrigger = [...mobilePreview.querySelectorAll<HTMLElement>('[data-testid="tool-row-body-trigger"]')].find(
+  // At tools level, the intent trigger (tool-row-trigger) controls the body
+  // directly (legacy behavior — summaryOpen defaults true, no separate
+  // body trigger). Use tool-row-trigger for body disclosure assertions.
+  const desktopTrigger = [...desktopPreview.querySelectorAll<HTMLElement>('[data-testid="tool-row-trigger"]')].find(
+    (trigger) => trigger.closest('[data-tool-name="read_file"]') !== null,
+  );
+  const mobileTrigger = [...mobilePreview.querySelectorAll<HTMLElement>('[data-testid="tool-row-trigger"]')].find(
     (trigger) => trigger.closest('[data-tool-name="read_file"]') !== null,
   );
   if (!(desktopTrigger instanceof HTMLElement) || !(mobileTrigger instanceof HTMLElement)) {
-    throw new Error("preview read_file body trigger was not rendered");
+    throw new Error("preview read_file trigger was not rendered");
   }
   expect(desktopTrigger.getAttribute("aria-expanded")).toBe("false");
   expect(mobileTrigger.getAttribute("aria-expanded")).toBe("false");


### PR DESCRIPTION
## Summary

Fixes a serious regression from PR #781 (merged): the two-level disclosure (`summaryOpen` + body) was incorrectly enabled at ALL verbosity levels, breaking the existing row-click-to-toggle-body behavior at tools/activity/full. Tool results no longer toggled open and closed, and tool row icons appeared dropped.

## Root cause

`ToolCallItem` always passed `onToggleSummary` to `ToolRow`, making `twoLevel = true` at every verbosity level. At tools/activity/full, this made the intent button toggle `summaryOpen` instead of the body — breaking the existing toggle behavior.

## Fix

Only pass `onToggleSummary` when `summaryConfigDefault` is `false` (chat/intent levels). At tools+, `onToggleSummary` is `undefined` so `twoLevel = false` — the intent button controls the body directly (legacy behavior), the summary stays visible, and no `.bodyTrigger` chevron renders.

## Test plan

- `make test-web`: PASS (typecheck + test + lint)
- `make test-web-browser`: PASS (layout + overflow + shell + spawn guards)