### PR TITLE
fix(agent): keep working descendants active

### DIFF
--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -1837,9 +1837,7 @@ func (s *Session) acceptNotificationInput(ctx context.Context, turnID string) (p
 	//
 	// The announce precedes every content event of the turn. A boundary that
 	// came after would leave that content attributed to the turn before it.
-	if s.servedByDaemon() {
-		s.emit(events.EventTurnStarted, events.TurnStartedData{TurnID: turnID})
-	}
+	s.emit(events.EventTurnStarted, events.TurnStartedData{TurnID: turnID})
 	if reminder != "" {
 		s.emit(events.EventSteeringInjected, events.SteeringInjectedData{Text: reminder, Kind: events.SteeringKindNotification})
 	}

--- a/agent/session_provenance_test.go
+++ b/agent/session_provenance_test.go
@@ -204,9 +204,16 @@ func TestAcceptNotificationInputAdoptsNotificationProvenance(t *testing.T) {
 	if !provenance.ContainsWatch(s.activeCausalProvenance(), "watch_A", "wg_1") {
 		t.Fatalf("active provenance = %+v, want notification provenance", s.activeCausalProvenance())
 	}
+	boundary := <-s.events
+	if boundary.Kind != events.EventTurnStarted {
+		t.Fatalf("first event = %s, want TURN_STARTED", boundary.Kind)
+	}
+	if !provenance.ContainsWatch(boundary.Provenance, "watch_A", "wg_1") {
+		t.Fatalf("boundary event provenance = %+v, want watch_A/wg_1", boundary.Provenance)
+	}
 	ev := <-s.events
 	if ev.Kind != events.EventSteeringInjected {
-		t.Fatalf("first event = %s, want STEERING_INJECTED", ev.Kind)
+		t.Fatalf("second event = %s, want STEERING_INJECTED", ev.Kind)
 	}
 	if !provenance.ContainsWatch(ev.Provenance, "watch_A", "wg_1") {
 		t.Fatalf("steering event provenance = %+v, want watch_A/wg_1", ev.Provenance)
@@ -226,9 +233,16 @@ func TestAcceptNotificationInputAdoptsCallerWatchSendStateProvenance(t *testing.
 	if !provenance.ContainsWatch(s.activeCausalProvenance(), cfg.watchID, cfg.generation) {
 		t.Fatalf("active provenance = %+v, want caller watch-send state provenance", s.activeCausalProvenance())
 	}
+	boundary := <-s.events
+	if boundary.Kind != events.EventTurnStarted {
+		t.Fatalf("first event = %s, want TURN_STARTED", boundary.Kind)
+	}
+	if !provenance.ContainsWatch(boundary.Provenance, cfg.watchID, cfg.generation) {
+		t.Fatalf("boundary event provenance = %+v, want %s/%s", boundary.Provenance, cfg.watchID, cfg.generation)
+	}
 	ev := <-s.events
 	if ev.Kind != events.EventSteeringInjected {
-		t.Fatalf("first event = %s, want STEERING_INJECTED", ev.Kind)
+		t.Fatalf("second event = %s, want STEERING_INJECTED", ev.Kind)
 	}
 	if !provenance.ContainsWatch(ev.Provenance, cfg.watchID, cfg.generation) {
 		t.Fatalf("steering event provenance = %+v, want %s/%s", ev.Provenance, cfg.watchID, cfg.generation)
@@ -283,9 +297,16 @@ func TestAcceptNotificationInputAdoptsRestoredCallerWatchSendProvenance(t *testi
 	if !provenance.ContainsWatch(s.activeCausalProvenance(), "watch_restore", "wg_restore") {
 		t.Fatalf("active provenance = %+v, want restored watch-send state provenance", s.activeCausalProvenance())
 	}
+	boundary := <-s.events
+	if boundary.Kind != events.EventTurnStarted {
+		t.Fatalf("first event = %s, want TURN_STARTED", boundary.Kind)
+	}
+	if !provenance.ContainsWatch(boundary.Provenance, "watch_restore", "wg_restore") {
+		t.Fatalf("boundary event provenance = %+v, want restored watch provenance", boundary.Provenance)
+	}
 	ev := <-s.events
 	if ev.Kind != events.EventSteeringInjected {
-		t.Fatalf("first event = %s, want STEERING_INJECTED", ev.Kind)
+		t.Fatalf("second event = %s, want STEERING_INJECTED", ev.Kind)
 	}
 	if !provenance.ContainsWatch(ev.Provenance, "watch_restore", "wg_restore") {
 		t.Fatalf("steering event provenance = %+v, want restored watch provenance", ev.Provenance)

--- a/agent/session_turn_boundary_test.go
+++ b/agent/session_turn_boundary_test.go
@@ -10,6 +10,7 @@ import (
 	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/internal/agenttest"
 	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/internal/appprojector"
 )
 
 // boundaryRecorder collects the events a served session emits. Registering a
@@ -561,14 +562,12 @@ func TestWakeResumesOnceTheUserTurnReleasesTheName(t *testing.T) {
 	}
 }
 
-// TestUnservedSessionNamesNoTurn keeps in-process subagents off both halves of
-// this machinery. They run EntryNotification per delegate wake and share the
-// parent's StateDir (subagents.go), so naming their turns would cost a durable
-// write per wake and publish turn frames on a thread no client can address.
-//
-// It asserts the gate (servedByDaemon) and its consequence (no name) together,
-// because the second is only correct while the first holds; split apart, either
-// half would keep passing after the other stopped being true.
+// TestUnservedSessionNamesNoTurn keeps in-process subagents from taking durable
+// mutation turn names. They run EntryNotification per delegate wake and share
+// the parent's StateDir (subagents.go), so naming their turns would cost a
+// durable write per wake. Their descendant projection still gets a turn
+// boundary with an empty name; AppEventProjector mints its read-side ID and
+// publishes the thread active.
 //
 // NOTE: `docs/superpowers/plans/2026-08-16-controllable-subagents.md` proposes
 // reversing this deliberately — delegates would take durable names so they can
@@ -588,39 +587,60 @@ func TestUnservedSessionNamesNoTurn(t *testing.T) {
 	}
 }
 
-// TestUnservedSessionAnnouncesNoBoundary pins the guard that keeps descendant
-// projections untouched — and it cannot be pinned through the events channel,
-// because an unserved session's events go nowhere a test can drain. It rides
-// the descendant hook instead, which is exactly the path that matters:
-// sendEvent forwards to descendantEvent regardless of authoritativeConsumer
-// (session_events.go), so an unguarded emit would push a boundary into every
-// in-process subagent's projection and close and reopen turns on a delegate
-// thread no client can address.
-func TestUnservedSessionAnnouncesNoBoundary(t *testing.T) {
-	s := newTestSessionForEnvctx(t) // no drain registered
+// TestUnservedSessionAnnouncesBoundary pins the boundary that makes an
+// in-process descendant's projected thread active while it works. It cannot be
+// observed through the events channel because an unserved session has no
+// authoritative consumer, so the test rides the descendant hook — the same
+// path a real child's events take into its root daemon's AppWire projection.
+func TestUnservedSessionAnnouncesBoundary(t *testing.T) {
+	parent := newTestSessionForEnvctx(t)
 
 	var mu sync.Mutex
-	var forwarded []events.EventKind
-	// descendantEvent is what a real child inherits from its parent
-	// (cfg.spawn.descendantEvent, installed at spawn); setting it here reaches
-	// the same sendEvent branch without standing a subagent up.
-	s.descendantEvent = func(ev events.SessionEvent) {
+	var forwarded []events.SessionEvent
+	parent.SetDescendantEventFunc(func(ev events.SessionEvent) {
 		mu.Lock()
 		defer mu.Unlock()
-		forwarded = append(forwarded, ev.Kind)
+		forwarded = append(forwarded, ev)
+	})
+	prepared, err := parent.prepareSubagentRun(context.Background(), "inspect", "", "", 0, "", "", nil, nil)
+	if err != nil {
+		t.Fatalf("prepareSubagentRun: %v", err)
 	}
+	defer releasePreparedTreeSlot(prepared)
+	s := prepared.sub.sess
+	defer s.Close()
+
 	s.SteerKind("look at this", events.SteeringKindNotification)
 
-	if _, err := s.ProcessInputKind(context.Background(), "", nil, EntryNotification); err != nil {
+	if _, err = s.ProcessInputKind(context.Background(), "", nil, EntryNotification); err != nil {
 		t.Fatalf("ProcessInputKind(EntryNotification): %v", err)
 	}
 
 	mu.Lock()
 	defer mu.Unlock()
-	if i := indexOf(forwarded, events.EventTurnStarted); i >= 0 {
-		t.Fatalf("an unserved session forwarded a turn boundary to its descendants at %d: %v", i, forwarded)
+	kinds := make([]events.EventKind, 0, len(forwarded))
+	for _, event := range forwarded {
+		kinds = append(kinds, event.Kind)
 	}
-	if indexOf(forwarded, events.EventSteeringInjected) < 0 {
-		t.Fatalf("the descendant hook saw no events at all (%v); the test would pass for the wrong reason", forwarded)
+	boundary := indexOf(kinds, events.EventTurnStarted)
+	if boundary < 0 {
+		t.Fatalf("the descendant hook saw no turn boundary: %v", kinds)
 	}
+	steering := indexOf(kinds, events.EventSteeringInjected)
+	if steering < 0 {
+		t.Fatalf("the descendant hook saw no events at all (%v); the test would pass for the wrong reason", kinds)
+	}
+	if boundary > steering {
+		t.Fatalf("turn boundary arrived after turn content: %v", kinds)
+	}
+
+	projector := appprojector.NewAppEventProjector(s.ID(), "local:"+s.ID())
+	for _, event := range forwarded {
+		for _, notification := range projector.Project(event) {
+			if params, ok := notification.Params.(appwire.ThreadStatusChangedParams); ok && params.Status.Type == appwire.ThreadStatusActive {
+				return
+			}
+		}
+	}
+	t.Fatalf("the descendant event stream never projected status %q: %v", appwire.ThreadStatusActive, kinds)
 }


### PR DESCRIPTION
## Summary

- emit `EventTurnStarted` for notification-driven in-process descendants even when they have no durable mutation turn name
- let the root AppWire descendant projection publish `active` instead of retaining a stale `idle` status beside an active turn
- update notification provenance assertions for the required boundary-before-content order

## Root cause

`acceptNotificationInput` suppressed `EventTurnStarted` when `servedByDaemon()` was false. In-process descendants are unserved, so later assistant events opened an implicit projected turn without emitting `ThreadStatusActive`. The sidebar therefore received an active turn ID with an idle thread status and classified the working descendant as inactive.

## Regression coverage

`TestUnservedSessionAnnouncesBoundary` now creates a real prepared child, drives a notification turn through `ProcessInputKind`, verifies the inherited descendant callback receives the boundary before content, and confirms the forwarded stream projects `ThreadStatusActive`.

The test fails when the old `servedByDaemon()` guard is restored and passes with this fix.

## Verification

- `make lint`
- `make vet`
- `make test`
- independent review: no Critical, Important, or Minor findings
