### PR TITLE
fix: add speaker-gutter padding to intentGroupItems for icon alignment

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/session.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/session.module.css
@@ -56,6 +56,18 @@
   gap: 0;
 }
 
+/* Above the breakpoint, the intent group items need the same
+ * --speaker-gutter padding that .runContent provides for regular
+ * tool-call rows. Without it, the .rowIcon's negative margin
+ * (margin-left: calc(-1 * var(--speaker-gutter))) pulls the icon
+ * out of the container — making icons invisible and rows appear
+ * outdented. This matches the .runContent indent at turnblock.module.css:42-46. */
+@media (min-width: 700px) {
+  .intentGroupItems {
+    padding-left: var(--speaker-gutter);
+  }
+}
+
 .coldStart {
   width: 100%;
   max-width: 76rem;

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolcallitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolcallitem.module.css
@@ -7,7 +7,6 @@
   display: flex;
   flex-direction: column;
   padding: var(--space-2) 0;
-  overflow: hidden;
 }
 
 /* The shared row (ToolRow.tsx) - see that file for the row grammar it


### PR DESCRIPTION
## Summary

Fixes two remaining issues from the verbosity redesign:
1. **Icons missing in intent mode**: tool icons (read_file, shell, etc.) were invisible because `.rowIcon`'s negative margin pulled them out of the container
2. **Intents outdented in intent mode**: rows appeared misaligned vs tools mode

## Root cause

In intent mode, `ToolCallItem` renders inside `.intentGroupItems` which lacked the `--speaker-gutter` padding that `.runContent` provides at tools level. Without this padding, the `.rowIcon`'s `margin-left: calc(-1 * var(--speaker-gutter))` pulled icons out of the visible area.

## Fix

Add the same `@media (min-width: 700px) { padding-left: var(--speaker-gutter) }` rule to `.intentGroupItems` that `.runContent` has in `turnblock.module.css:42-46`.

## Test plan

- `make test-web`: PASS (typecheck + test + lint)
- `make test-web-browser`: PASS (layout + overflow + shell + spawn guards)