### PR TITLE
fix: always enable twoLevel disclosure (progressive unfold at all levels)

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
@@ -1164,24 +1164,26 @@ function renderWithConfig(config: ReturnType<typeof makeTranscriptDisplayConfig>
   );
 }
 
-test("at the tools level an intent-bearing row shows summary and the intent trigger controls the body", () => {
+test("at the tools level an intent-bearing row defaults to L1 (summary visible)", () => {
   registerToolRenderer({ match: "tci_summary_tools", summary: () => "Ran tests", body: () => <div>body</div> });
   const toolsConfig = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
   renderWithConfig(
     toolsConfig,
     item({ id: "summary_tools", toolName: "tci_summary_tools", description: "Running the test suite" }),
   );
-  // At tools level, summaryOpen defaults true but twoLevel is false (the
-  // summary has no separate toggle — the intent button controls the body
-  // directly, same as the legacy behavior).
+  // At tools level, summaryOpen defaults true (L1): intent + summary visible.
   expect(screen.getByTestId("tool-row-intent").textContent).toBe("Running the test suite");
   expect(screen.getByTestId("tool-row-summary").textContent).toBe("Ran tests");
-  // The intent trigger controls the body (expanded), so aria-expanded=false
-  // while the body is collapsed.
+  // The intent trigger controls the summary: aria-expanded=true (open).
   const trigger = screen.getByTestId("tool-row-trigger");
-  expect(trigger.getAttribute("aria-expanded")).toBe("false");
-  // No separate body trigger at tools level — the intent button IS the toggle.
-  expect(screen.queryByTestId("tool-row-body-trigger")).toBeNull();
+  expect(trigger.getAttribute("aria-expanded")).toBe("true");
+  // A separate body trigger controls the body (expanded), collapsed by default.
+  const bodyTrigger = screen.getByTestId("tool-row-body-trigger");
+  expect(bodyTrigger.getAttribute("aria-expanded")).toBe("false");
+  // Clicking the body trigger opens the body (L2).
+  fireEvent.click(bodyTrigger);
+  expect(bodyTrigger.getAttribute("aria-expanded")).toBe("true");
+  expect(screen.getByTestId("tool-call-body")).toBeTruthy();
 });
 
 test("at the chat level an intent-bearing row defaults summaryOpen=false (only intent visible)", () => {
@@ -1208,7 +1210,7 @@ test("an intent-less row at the chat level forces summaryOpen=true (summary visi
   expect(screen.getByTestId("tool-row-summary").textContent).toBe("Ran tests");
 });
 
-test("a shell row with summaryHiddenWhenExpanded hides the summary when the body opens (tools level, legacy toggle)", () => {
+test("a shell row with summaryHiddenWhenExpanded hides the summary when the body opens (tools level)", () => {
   const toolsConfig = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
   renderWithConfig(
     toolsConfig,
@@ -1220,20 +1222,19 @@ test("a shell row with summaryHiddenWhenExpanded hides the summary when the body
       output: "hi\n[exit 0]",
     }),
   );
-  // At tools level, the intent trigger controls the body (legacy behavior).
-  // The summary is visible while the body is collapsed.
+  // At tools level, summaryOpen defaults true (L1): the summary is visible.
   expect(screen.getByTestId("tool-row-summary").textContent).toBe("Ran echo hi");
 
-  // Expand the body via the intent trigger (the row's click target).
+  // Expand the body via the body trigger (the .bodyTrigger chevron).
   // With summaryHiddenWhenExpanded, the summary disappears.
-  const trigger = screen.getByTestId("tool-row-trigger");
-  fireEvent.click(trigger);
+  const bodyTrigger = screen.getByTestId("tool-row-body-trigger");
+  fireEvent.click(bodyTrigger);
   expect(screen.queryByTestId("tool-row-summary")).toBeNull();
   // The intent line stays.
   expect(screen.getByTestId("tool-row-intent").textContent).toBe("Running a command");
 });
 
-test("switching from chat to tools ignores persisted summary close (summary always visible at tools+)", () => {
+test("defaults apply at each level; an explicit summary choice persists across level changes", () => {
   registerToolRenderer({ match: "tci_summary_switch", summary: () => "Ran tests", body: () => <div>body</div> });
   const chatConfig = makeTranscriptDisplayConfig({ kind: "preset", level: "chat" });
   const toolsConfig = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
@@ -1243,24 +1244,35 @@ test("switching from chat to tools ignores persisted summary close (summary alwa
     description: "Running the test suite",
   });
 
-  // At chat level, close the summary (persist a false choice).
+  // At chat level, summary defaults closed (L0): only intent visible.
   const { rerender } = renderWithConfig(chatConfig, toolItem);
   const trigger = screen.getByTestId("tool-row-trigger");
-  // Summary starts hidden (chat defaults summaryOpen=false).
   expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  expect(screen.queryByTestId("tool-row-summary")).toBeNull();
 
-  // Switch to tools level — the persisted close must NOT win.
-  // summaryConfigDefault=true forces summaryOpen=true regardless.
+  // Switch to tools level — no explicit choice yet, so the default applies:
+  // summaryOpen defaults true (L1).
   rerender(
     <TranscriptRenderProvider config={toolsConfig} surface="readOnly" disclosureScope="test:summary">
       <ToolCallItem item={toolItem} turn={turn} live={false} />
     </TranscriptRenderProvider>,
   );
-  // The summary is visible at tools level.
   expect(screen.getByTestId("tool-row-summary").textContent).toBe("Ran tests");
-  // The intent trigger controls the body (legacy behavior, aria-expanded=false while collapsed).
   const toolsTrigger = screen.getByTestId("tool-row-trigger");
+  expect(toolsTrigger.getAttribute("aria-expanded")).toBe("true");
+  // A body trigger now exists (twoLevel is always enabled).
+  expect(screen.queryByTestId("tool-row-body-trigger")).not.toBeNull();
+
+  // Explicitly close the summary at tools level (persist a false choice).
+  fireEvent.click(toolsTrigger);
   expect(toolsTrigger.getAttribute("aria-expanded")).toBe("false");
-  // No body trigger at tools level.
-  expect(screen.queryByTestId("tool-row-body-trigger")).toBeNull();
+  expect(screen.queryByTestId("tool-row-summary")).toBeNull();
+
+  // Switch back to chat — the explicit close persists; summary stays closed.
+  rerender(
+    <TranscriptRenderProvider config={chatConfig} surface="readOnly" disclosureScope="test:summary">
+      <ToolCallItem item={toolItem} turn={turn} live={false} />
+    </TranscriptRenderProvider>,
+  );
+  expect(screen.queryByTestId("tool-row-summary")).toBeNull();
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
@@ -277,20 +277,18 @@ function ToolCallItemBody({ item, live, sessionRef, projectedSummary, renderCont
   const disclosureFallback = configDefault || (autoDefault && !superseded);
   const expanded = isDisclosureOpen(disclosureKey, disclosureFallback);
 
-  // Two-level disclosure (Task 5): the summary line has its own open/closed
-  // state, independent of the body disclosure. At verbosity levels where
-  // toolCalls is true (tools/activity/full) the summary defaults open; at
-  // chat/intent it defaults closed, showing only the intent. An intent-less
-  // row has no separate intent line to toggle, so its summary is forced open
-  // regardless of the config default — the summary IS its only line.
-  // At levels where the summary defaults open (tools/activity/full), the
-  // summary has no separate toggle (twoLevel is false), so a persisted
-  // close from a lower level (chat/intent) must NOT win — the summary is
-  // always visible at these levels.
+  // Two-level disclosure: the summary line has its own open/closed state,
+  // independent of the body disclosure. At verbosity levels where toolCalls is
+  // true (tools/activity/full) the summary defaults open; at chat/intent it
+  // defaults closed, showing only the intent. An intent-less row has no
+  // separate intent line to toggle, so its summary is forced open regardless
+  // of the config default. An explicit user choice (open or close) persists
+  // across verbosity level changes — the default only applies when there is
+  // no explicit choice.
   const summaryDisclosureKey = scopedDisclosureId(disclosureScope, `summary:${item.id}`);
   const summaryConfigDefault = summaryOpenByDefault(config);
   const summaryDisclosureOpen = isDisclosureOpen(summaryDisclosureKey, summaryConfigDefault);
-  const summaryOpen = statedIntent === undefined || summaryConfigDefault ? true : summaryDisclosureOpen;
+  const summaryOpen = statedIntent === undefined ? true : summaryDisclosureOpen;
   // A descriptor whose summary duplicates its expanded body (shell: the raw
   // command vs the body's pretty-printed block) hides the summary while the
   // body is open — the body is the single representation. ToolRow's own
@@ -378,9 +376,7 @@ function ToolCallItemBody({ item, live, sessionRef, projectedSummary, renderCont
         // autoDefault (the fallback) from here on and survives a remount.
         onToggle={() => toggleDisclosure(disclosureKey, disclosureFallback)}
         summaryOpen={summaryOpen}
-        onToggleSummary={
-          summaryConfigDefault ? undefined : () => toggleDisclosure(summaryDisclosureKey, summaryConfigDefault)
-        }
+        onToggleSummary={() => toggleDisclosure(summaryDisclosureKey, summaryConfigDefault)}
         summaryHidden={summaryHidden}
         trailing={trailingControls}
         trailingAfter={trailingAfter}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolRow.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolRow.tsx
@@ -568,7 +568,7 @@ export function ToolRow({
         </button>
       )}
       {hasIntent && twoLevel && bodyTriggerOnSummaryLine && (
-        <div id={summaryRegionId} className={CLASS.summaryLine}>
+        <div id={summaryRegionId} className={CLASS.summaryLine} data-body-trigger="true">
           {summaryContent}
           {bodyTriggerButton}
         </div>

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.test.tsx
@@ -576,7 +576,7 @@ describe("TranscriptBody", () => {
     const firstToolExpanded = () =>
       screen
         .getAllByTestId("tool-call-item")[0]
-        ?.querySelector('[data-testid="tool-row-trigger"]')
+        ?.querySelector('[data-testid="tool-row-body-trigger"]')
         ?.getAttribute("aria-expanded");
     rerender(
       <TranscriptBody

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
@@ -128,9 +128,10 @@ test("dispatches a commandExecution item to ToolCallItem", () => {
   // output is proof of dispatch only once the row is opened. The dispatch itself
   // is what this test is about; the row above is already evidence of it, and the
   // output confirms the descriptor's body ran rather than an empty shell.
-  // At activity level the intent trigger controls the body directly (legacy
-  // behavior — summaryOpen defaults true, no separate body trigger).
-  fireEvent.click(screen.getByTestId("tool-row-trigger"));
+  // At activity level the item has intent (auto-added by the item() helper),
+  // so twoLevel is enabled: the intent button toggles the summary (already open
+  // at activity level) and the .bodyTrigger chevron toggles the body.
+  fireEvent.click(screen.getByTestId("tool-row-body-trigger"));
   expect(screen.getByText("tool output")).toBeTruthy();
 });
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolcallitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolcallitem.module.css
@@ -271,6 +271,17 @@
   line-height: var(--line-height-title);
 }
 
+/* When a .bodyTrigger chevron shares the summary line (two-level disclosure at
+   tools/activity/full), the demoted summary must leave room for it instead of
+   demanding 100% — otherwise the chevron's intrinsic width overflows the
+   container. flex-shrink:1 and flex-basis:auto let the summary shrink to fit
+   alongside the flex:none body trigger; min-width:0 + the .clamped
+   overflow:hidden clip the nowrap text to the shrunken width. */
+.summaryLine[data-body-trigger="true"] .demoted {
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
 /* The COLLAPSED second line's truncation (ToolRow.tsx's grammar): a
  * middle-truncate, not an end-truncate. The line becomes a two-span flex row
  * - the head ellipsis-clamps under pressure, the tail never shrinks, so the

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/TranscriptDisplayCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/TranscriptDisplayCard.test.tsx
@@ -175,13 +175,14 @@ test("isolates preview disclosures and never consults the live threads store", a
 
   const desktopPreview = screen.getByTestId("transcript-display-preview-desktop");
   const mobilePreview = screen.getByTestId("transcript-display-preview-mobile");
-  // At tools level, the intent trigger (tool-row-trigger) controls the body
-  // directly (legacy behavior — summaryOpen defaults true, no separate
-  // body trigger). Use tool-row-trigger for body disclosure assertions.
-  const desktopTrigger = [...desktopPreview.querySelectorAll<HTMLElement>('[data-testid="tool-row-trigger"]')].find(
-    (trigger) => trigger.closest('[data-tool-name="read_file"]') !== null,
-  );
-  const mobileTrigger = [...mobilePreview.querySelectorAll<HTMLElement>('[data-testid="tool-row-trigger"]')].find(
+  // At tools level, twoLevel is always enabled for intent-bearing rows: the
+  // intent trigger (tool-row-trigger) controls the summary, the .bodyTrigger
+  // chevron (tool-row-body-trigger) controls the body. Use the body trigger
+  // for body disclosure assertions.
+  const desktopTrigger = [
+    ...desktopPreview.querySelectorAll<HTMLElement>('[data-testid="tool-row-body-trigger"]'),
+  ].find((trigger) => trigger.closest('[data-tool-name="read_file"]') !== null);
+  const mobileTrigger = [...mobilePreview.querySelectorAll<HTMLElement>('[data-testid="tool-row-body-trigger"]')].find(
     (trigger) => trigger.closest('[data-tool-name="read_file"]') !== null,
   );
   if (!(desktopTrigger instanceof HTMLElement) || !(mobileTrigger instanceof HTMLElement)) {


### PR DESCRIPTION
## Summary

Makes `twoLevel` always enabled for intent-bearing rows, so the intent button always toggles the summary (L0↔L1) and the `.bodyTrigger` chevron always toggles the body (L1↔L2) at every verbosity level. The only difference between verbosity levels is the default disclosure state.

### Changes

- **`ToolCallItem.tsx`**: Removes the `summaryConfigDefault ? undefined` conditional on `onToggleSummary` and the `summaryConfigDefault ? true` override on `summaryOpen`. An explicit user choice (open or close) now persists across verbosity level changes — the default only applies when there is no explicit choice.
- **`ToolRow.tsx`**: Adds `data-body-trigger` attribute on the summary line when the body trigger chevron shares it.
- **`toolcallitem.module.css`**: CSS override for `.summaryLine[data-body-trigger="true"] .demoted` — lets the demoted summary shrink (`flex: 0 1 auto; min-width: 0`) instead of demanding `flex: 0 0 100%`, preventing horizontal overflow when the body trigger chevron shares the line at narrow widths.
- **Tests**: Updated 5 test files to use `tool-row-body-trigger` (which controls the body) instead of `tool-row-trigger` (which now controls the summary) for body disclosure assertions.

### Disclosure levels (same components, different defaults)

| Level | summaryOpen default | expanded default | Starts at |
|-------|---------------------|------------------|-----------|
| chat | false | false | L0 |
| intent | false | false | L0 |
| tools | true | false | L1 |
| activity | true | false | L1 |
| full | true | true | L2 |

### Gates

- `make test-web` (typecheck + test + lint): PASS
- `make test-web-browser` (layout + overflow + shell + spawn guards): PASS