### PR TITLE
fix(agent): reset communicate previews across retries

### DIFF
--- a/agent/communicate_preview_cleanup_test.go
+++ b/agent/communicate_preview_cleanup_test.go
@@ -7,54 +7,155 @@ import (
 	"slices"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/llm"
 )
 
-func TestCallModelUnionsPreviewIDsAcrossRetryAttempts(t *testing.T) {
-	tests := []struct {
-		name   string
-		second string
-		want   []string
-	}{
-		{name: "success without preview", want: []string{"call-a"}},
-		{name: "success with distinct preview", second: "call-b", want: []string{"call-a", "call-b"}},
+func TestProcessInputRetryDiscardsFailedPreviewAndCommitsFinalOnce(t *testing.T) {
+	var attempts atomic.Int32
+	client := llm.NewClient()
+	client.Register(&streamingAdapter{name: "openai", streamScript: func(st *llm.ChanStream) {
+		if attempts.Add(1) == 1 {
+			call := communicateCall("failed-call", "failed preview")
+			sendCommunicatePreview(st, call)
+			st.Send(llm.StreamEvent{Type: llm.StreamEventError, Err: llm.NewStreamError("openai", "retry", nil)})
+			return
+		}
+		call := communicateCall("final-call", "final answer")
+		sendCommunicatePreview(st, call)
+		st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallEnd, ToolCall: &call})
+		finish := llm.FinishReason{Reason: llm.FinishReasonToolCalls}
+		st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &finish})
+	}})
+	policy := llm.RetryPolicy{MaxRetries: 1}
+	sess, err := NewSession(client, withTestSessionNamer(client, NewOpenAIProfile("gpt-test")), execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{
+		LLMRetryPolicy: &policy,
+		LLMSleep:       func(context.Context, time.Duration) error { return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			var attempts atomic.Int32
-			client := llm.NewClient()
-			client.Register(&streamingAdapter{name: "openai", streamScript: func(st *llm.ChanStream) {
-				if attempts.Add(1) == 1 {
-					call := communicateCall("call-a", "first")
-					st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallStart, ToolCall: &llm.ToolCallData{ID: call.ID, Name: call.Name}})
-					st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallDelta, ToolCall: &llm.ToolCallData{ID: call.ID, Arguments: call.Arguments}})
-					st.Send(llm.StreamEvent{Type: llm.StreamEventError, Err: llm.NewStreamError("openai", "retry", nil)})
-					return
-				}
-				if tc.second != "" {
-					call := communicateCall(tc.second, "second")
-					st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallStart, ToolCall: &llm.ToolCallData{ID: call.ID, Name: call.Name}})
-					st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallDelta, ToolCall: &llm.ToolCallData{ID: call.ID, Arguments: call.Arguments}})
-				}
-				finish := llm.FinishReason{Reason: llm.FinishReasonToolCalls}
-				st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &finish})
-			}})
-			sess, err := NewSession(client, NewOpenAIProfile("gpt-test"), execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{})
-			if err != nil {
-				t.Fatal(err)
-			}
-			policy := llm.RetryPolicy{MaxRetries: 1}
-			resp, err := sess.callModel(context.Background(), policy, NewOpenAIProfile("gpt-test"), llm.Request{Provider: "openai", Model: "gpt-test", Messages: []llm.Message{llm.User("run")}}, &groupRecord{})
-			if err != nil {
-				t.Fatalf("callModel: %v", err)
-			}
-			if !slices.Equal(resp.CommunicatePreviewCallIDs, tc.want) {
-				t.Fatalf("preview IDs=%v want=%v", resp.CommunicatePreviewCallIDs, tc.want)
-			}
-		})
+	recorder := startPreviewEventRecorder(sess)
+	out, callErr := sess.ProcessInput(context.Background(), "run", nil)
+	evs := recorder.stop(sess)
+	if callErr != nil {
+		t.Fatalf("ProcessInput: %v", callErr)
+	}
+	if out != "final answer" {
+		t.Fatalf("ProcessInput output=%q want=%q", out, "final answer")
+	}
+
+	lifecycle := inspectPreviewLifecycle(evs)
+	if lifecycle.maxActive != 1 {
+		t.Fatalf("maximum active previews=%d want=1; events=%v", lifecycle.maxActive, evs)
+	}
+	if !maps.Equal(lifecycle.resets, map[string]int{"failed-call": 1, "final-call": 1}) {
+		t.Fatalf("preview reset counts=%v; events=%v", lifecycle.resets, evs)
+	}
+	if len(lifecycle.active) != 0 {
+		t.Fatalf("active previews after completion=%v; events=%v", lifecycle.active, evs)
+	}
+	var completed []events.CommunicateData
+	for _, ev := range evs {
+		if ev.Kind == events.EventCommunicate {
+			completed = append(completed, ev.Data.(events.CommunicateData))
+		}
+	}
+	if len(completed) != 1 || completed[0].CallID != "final-call" || completed[0].Message != "final answer" {
+		t.Fatalf("final communicate events=%v want one matching final-call; events=%v", completed, evs)
+	}
+}
+
+func TestCallModelRetryResetsReusedPreviewCallIDGeneration(t *testing.T) {
+	var attempts atomic.Int32
+	client := llm.NewClient()
+	client.Register(&streamingAdapter{name: "openai", streamScript: func(st *llm.ChanStream) {
+		attempt := attempts.Add(1)
+		call := communicateCall("reused-call", "first generation")
+		if attempt == 2 {
+			call = communicateCall("reused-call", "second generation")
+		}
+		sendCommunicatePreview(st, call)
+		if attempt == 1 {
+			st.Send(llm.StreamEvent{Type: llm.StreamEventError, Err: llm.NewStreamError("openai", "retry", nil)})
+			return
+		}
+		st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallEnd, ToolCall: &call})
+		finish := llm.FinishReason{Reason: llm.FinishReasonToolCalls}
+		st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &finish})
+	}})
+	sess, err := NewSession(client, NewOpenAIProfile("gpt-test"), execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := startPreviewEventRecorder(sess)
+	resp, callErr := sess.callModel(context.Background(), llm.RetryPolicy{MaxRetries: 1}, NewOpenAIProfile("gpt-test"), llm.Request{
+		Provider: "openai",
+		Model:    "gpt-test",
+		Messages: []llm.Message{llm.User("run")},
+	}, &groupRecord{})
+	evs := recorder.stop(sess)
+	if callErr != nil {
+		t.Fatalf("callModel: %v", callErr)
+	}
+	if !slices.Equal(resp.CommunicatePreviewCallIDs, []string{"reused-call"}) {
+		t.Fatalf("active preview IDs=%v want=[reused-call]", resp.CommunicatePreviewCallIDs)
+	}
+	lifecycle := inspectPreviewLifecycle(evs)
+	if len(lifecycle.startsWhileActive) != 0 || !maps.Equal(lifecycle.active, map[string]struct{}{"reused-call": {}}) {
+		t.Fatalf("overlapping starts=%v active=%v; events=%v", lifecycle.startsWhileActive, lifecycle.active, evs)
+	}
+	if !maps.Equal(lifecycle.resets, map[string]int{"reused-call": 1}) {
+		t.Fatalf("preview reset counts=%v; events=%v", lifecycle.resets, evs)
+	}
+}
+
+func TestContinuationRecoveryDiscardsFailedCommunicatePreview(t *testing.T) {
+	var attempts atomic.Int32
+	continuationErr := llm.ErrorFromHTTPStatus("openai", 404, "Previous response not found", map[string]any{
+		"error": map[string]any{"code": "previous_response_not_found", "message": "Previous response not found"},
+	}, nil)
+	client := llm.NewClient()
+	client.Register(&streamingAdapter{name: "openai", streamScript: func(st *llm.ChanStream) {
+		callID := "recovery-call"
+		message := "recovered"
+		if attempts.Add(1) == 1 {
+			callID = "expired-call"
+			message = "expired preview"
+		}
+		call := communicateCall(callID, message)
+		sendCommunicatePreview(st, call)
+		if call.ID == "expired-call" {
+			st.Send(llm.StreamEvent{Type: llm.StreamEventError, Err: continuationErr})
+			return
+		}
+		st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallEnd, ToolCall: &call})
+		finish := llm.FinishReason{Reason: llm.FinishReasonToolCalls}
+		st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &finish})
+	}})
+	policy := llm.RetryPolicy{MaxRetries: 0}
+	sess, err := NewSession(client, NewOpenAIProfile("primary"), execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{LLMRetryPolicy: &policy})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := startPreviewEventRecorder(sess)
+	resp, _, _, callErr := sess.callModelWithFallback(context.Background(), NewOpenAIProfile("primary"), phase8DeltaRequest(), phase8FullHistory(), "", 1)
+	evs := recorder.stop(sess)
+	if callErr != nil {
+		t.Fatalf("callModelWithFallback: %v", callErr)
+	}
+	if !slices.Equal(resp.CommunicatePreviewCallIDs, []string{"recovery-call"}) {
+		t.Fatalf("active preview IDs=%v want=[recovery-call]", resp.CommunicatePreviewCallIDs)
+	}
+	lifecycle := inspectPreviewLifecycle(evs)
+	if lifecycle.maxActive != 1 || !maps.Equal(lifecycle.active, map[string]struct{}{"recovery-call": {}}) {
+		t.Fatalf("preview lifecycle max=%d active=%v; events=%v", lifecycle.maxActive, lifecycle.active, evs)
+	}
+	if !maps.Equal(lifecycle.resets, map[string]int{"expired-call": 1}) {
+		t.Fatalf("preview reset counts=%v; events=%v", lifecycle.resets, evs)
 	}
 }
 
@@ -65,8 +166,7 @@ func TestCallModelPanicAfterConsumeResetsTransferredPreview(t *testing.T) {
 	client := llm.NewClient()
 	client.Register(&streamingAdapter{name: "openai", streamScript: func(st *llm.ChanStream) {
 		call := communicateCall("panic-call", "preview")
-		st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallStart, ToolCall: &llm.ToolCallData{ID: call.ID, Name: call.Name}})
-		st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallDelta, ToolCall: &llm.ToolCallData{ID: call.ID, Arguments: call.Arguments}})
+		sendCommunicatePreview(st, call)
 		finish := llm.FinishReason{Reason: llm.FinishReasonToolCalls}
 		st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &finish})
 	}})
@@ -103,14 +203,14 @@ func TestCallModelPanicAfterConsumeResetsTransferredPreview(t *testing.T) {
 	}
 }
 
-func TestCallModelWithFallbackUnionsPrimaryAndFallbackPreviewIDs(t *testing.T) {
+func TestCallModelWithFallbackRetainsOnlyActivePreviewIDs(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		fallbackID string
 		want       []string
 	}{
-		{name: "fallback without preview", want: []string{"primary-call"}},
-		{name: "distinct fallback preview", fallbackID: "fallback-call", want: []string{"fallback-call", "primary-call"}},
+		{name: "fallback without preview"},
+		{name: "distinct fallback preview", fallbackID: "fallback-call", want: []string{"fallback-call"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var streams atomic.Int32
@@ -118,15 +218,13 @@ func TestCallModelWithFallbackUnionsPrimaryAndFallbackPreviewIDs(t *testing.T) {
 			client.Register(&streamingAdapter{name: "openai", streamScript: func(st *llm.ChanStream) {
 				if streams.Add(1) == 1 {
 					call := communicateCall("primary-call", "primary")
-					st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallStart, ToolCall: &llm.ToolCallData{ID: call.ID, Name: call.Name}})
-					st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallDelta, ToolCall: &llm.ToolCallData{ID: call.ID, Arguments: call.Arguments}})
+					sendCommunicatePreview(st, call)
 					st.Send(llm.StreamEvent{Type: llm.StreamEventError, Err: llm.ErrorFromHTTPStatus("openai", 403, "fallback", nil, nil)})
 					return
 				}
 				if tc.fallbackID != "" {
 					call := communicateCall(tc.fallbackID, "fallback")
-					st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallStart, ToolCall: &llm.ToolCallData{ID: call.ID, Name: call.Name}})
-					st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallDelta, ToolCall: &llm.ToolCallData{ID: call.ID, Arguments: call.Arguments}})
+					sendCommunicatePreview(st, call)
 				}
 				finish := llm.FinishReason{Reason: llm.FinishReasonToolCalls}
 				st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &finish})
@@ -135,12 +233,21 @@ func TestCallModelWithFallbackUnionsPrimaryAndFallbackPreviewIDs(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			resp, _, _, err := sess.callModelWithFallback(context.Background(), NewOpenAIProfile("gpt-primary"), llm.Request{Provider: "openai", Model: "gpt-primary", Messages: []llm.Message{llm.User("run")}}, nil, "", 0)
-			if err != nil {
-				t.Fatalf("fallback call: %v", err)
+			recorder := startPreviewEventRecorder(sess)
+			resp, _, _, callErr := sess.callModelWithFallback(context.Background(), NewOpenAIProfile("gpt-primary"), llm.Request{Provider: "openai", Model: "gpt-primary", Messages: []llm.Message{llm.User("run")}}, nil, "", 0)
+			evs := recorder.stop(sess)
+			if callErr != nil {
+				t.Fatalf("fallback call: %v", callErr)
 			}
 			if !slices.Equal(resp.CommunicatePreviewCallIDs, tc.want) {
 				t.Fatalf("preview IDs=%v want=%v", resp.CommunicatePreviewCallIDs, tc.want)
+			}
+			lifecycle := inspectPreviewLifecycle(evs)
+			if lifecycle.maxActive != 1 {
+				t.Fatalf("maximum active previews=%d want=1; events=%v", lifecycle.maxActive, evs)
+			}
+			if !slices.Equal(sortedPreviewCallIDs(lifecycle.active), tc.want) || !maps.Equal(lifecycle.resets, map[string]int{"primary-call": 1}) {
+				t.Fatalf("preview lifecycle active=%v resets=%v; events=%v", lifecycle.active, lifecycle.resets, evs)
 			}
 		})
 	}
@@ -152,14 +259,12 @@ func TestCallModelWithFallbackPanicResetsTransferredPrimaryExactlyOnce(t *testin
 	client.Register(&streamingAdapter{name: "openai", streamScript: func(st *llm.ChanStream) {
 		if streams.Add(1) == 1 {
 			call := communicateCall("primary-call", "primary")
-			st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallStart, ToolCall: &llm.ToolCallData{ID: call.ID, Name: call.Name}})
-			st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallDelta, ToolCall: &llm.ToolCallData{ID: call.ID, Arguments: call.Arguments}})
+			sendCommunicatePreview(st, call)
 			st.Send(llm.StreamEvent{Type: llm.StreamEventError, Err: llm.ErrorFromHTTPStatus("openai", 403, "fallback", nil, nil)})
 			return
 		}
 		call := communicateCall("fallback-call", "fallback")
-		st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallStart, ToolCall: &llm.ToolCallData{ID: call.ID, Name: call.Name}})
-		st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallDelta, ToolCall: &llm.ToolCallData{ID: call.ID, Arguments: call.Arguments}})
+		sendCommunicatePreview(st, call)
 		finish := llm.FinishReason{Reason: llm.FinishReasonToolCalls}
 		st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &finish})
 	}})
@@ -210,8 +315,7 @@ func TestCommunicatePreviewResetsWhenCallerAbortsAfterStream(t *testing.T) {
 	client.Register(&streamingAdapter{
 		name: "openai",
 		streamScript: func(st *llm.ChanStream) {
-			st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallStart, ToolCall: &llm.ToolCallData{ID: call.ID, Name: call.Name}})
-			st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallDelta, ToolCall: &llm.ToolCallData{ID: call.ID, Arguments: call.Arguments}})
+			sendCommunicatePreview(st, call)
 			st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallEnd, ToolCall: &call})
 			finish := llm.FinishReason{Reason: llm.FinishReasonToolCalls}
 			st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &finish})
@@ -254,4 +358,55 @@ func TestCommunicatePreviewResetsWhenCallerAbortsAfterStream(t *testing.T) {
 	if start != 1 || delta != 1 || reset != 1 || completed != 0 {
 		t.Fatalf("preview lifecycle start=%d delta=%d reset=%d communicate=%d events=%v", start, delta, reset, completed, got)
 	}
+}
+
+type previewEventRecorder struct {
+	collect func() []events.SessionEvent
+}
+
+func startPreviewEventRecorder(sess *Session) *previewEventRecorder {
+	return &previewEventRecorder{collect: drainEvents(sess)}
+}
+
+func (r *previewEventRecorder) stop(sess *Session) []events.SessionEvent {
+	sess.Close()
+	return r.collect()
+}
+
+func sendCommunicatePreview(st *llm.ChanStream, call llm.ToolCallData) {
+	st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallStart, ToolCall: &llm.ToolCallData{ID: call.ID, Name: call.Name}})
+	st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallDelta, ToolCall: &llm.ToolCallData{ID: call.ID, Arguments: call.Arguments}})
+}
+
+type previewLifecycle struct {
+	active            map[string]struct{}
+	resets            map[string]int
+	startsWhileActive map[string]int
+	maxActive         int
+}
+
+func inspectPreviewLifecycle(evs []events.SessionEvent) previewLifecycle {
+	result := previewLifecycle{
+		active:            map[string]struct{}{},
+		resets:            map[string]int{},
+		startsWhileActive: map[string]int{},
+	}
+	for _, ev := range evs {
+		switch ev.Kind {
+		case events.EventCommunicatePreviewStart:
+			callID := ev.Data.(events.CommunicatePreviewStartData).CallID
+			if _, active := result.active[callID]; active {
+				result.startsWhileActive[callID]++
+			}
+			result.active[callID] = struct{}{}
+			result.maxActive = max(result.maxActive, len(result.active))
+		case events.EventCommunicatePreviewReset:
+			callID := ev.Data.(events.CommunicatePreviewResetData).CallID
+			result.resets[callID]++
+			delete(result.active, callID)
+		case events.EventCommunicate:
+			delete(result.active, ev.Data.(events.CommunicateData).CallID)
+		}
+	}
+	return result
 }

--- a/agent/communicate_preview_cleanup_test.go
+++ b/agent/communicate_preview_cleanup_test.go
@@ -113,6 +113,64 @@ func TestCallModelRetryResetsReusedPreviewCallIDGeneration(t *testing.T) {
 	}
 }
 
+func TestContentFilterRecoveryResetsReusedPreviewCallIDGeneration(t *testing.T) {
+	contentFilterErr := llm.ErrorFromHTTPStatus(
+		"openai", 400, "content filter triggered",
+		map[string]any{"error": map[string]any{"code": "invalid_prompt"}},
+		nil,
+	)
+	if llm.Kind(contentFilterErr) != llm.KindContentFilter {
+		t.Fatalf("fixture kind=%v want=%v", llm.Kind(contentFilterErr), llm.KindContentFilter)
+	}
+
+	var attempts atomic.Int32
+	client := llm.NewClient()
+	client.Register(&streamingAdapter{name: "openai", streamScript: func(st *llm.ChanStream) {
+		attempt := attempts.Add(1)
+		call := communicateCall("reused-call", "blocked generation")
+		if attempt == 2 {
+			call = communicateCall("reused-call", "recovered generation")
+		}
+		sendCommunicatePreview(st, call)
+		if attempt == 1 {
+			st.Send(llm.StreamEvent{Type: llm.StreamEventError, Err: contentFilterErr})
+			return
+		}
+		st.Send(llm.StreamEvent{Type: llm.StreamEventToolCallEnd, ToolCall: &call})
+		finish := llm.FinishReason{Reason: llm.FinishReasonToolCalls}
+		st.Send(llm.StreamEvent{Type: llm.StreamEventFinish, FinishReason: &finish})
+	}})
+	policy := llm.RetryPolicy{MaxRetries: 0}
+	sess, err := NewSession(client, withTestSessionNamer(client, NewOpenAIProfile("gpt-test")), execenv.NewLocalExecutionEnvironment(t.TempDir()), SessionConfig{
+		LLMRetryPolicy: &policy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := startPreviewEventRecorder(sess)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter and compaction; only fires on a genuine hang.
+	defer cancel()
+	out, callErr := sess.ProcessInput(ctx, "run", nil)
+	evs := recorder.stop(sess)
+	if callErr != nil {
+		t.Fatalf("ProcessInput: %v", callErr)
+	}
+	if out != "recovered generation" {
+		t.Fatalf("ProcessInput output=%q want=%q", out, "recovered generation")
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("stream attempts=%d want=2", attempts.Load())
+	}
+
+	lifecycle := inspectPreviewLifecycle(evs)
+	if lifecycle.maxActive != 1 || len(lifecycle.startsWhileActive) != 0 || len(lifecycle.active) != 0 {
+		t.Fatalf("preview lifecycle max=%d overlapping=%v active=%v; events=%v", lifecycle.maxActive, lifecycle.startsWhileActive, lifecycle.active, evs)
+	}
+	if !maps.Equal(lifecycle.resets, map[string]int{"reused-call": 2}) {
+		t.Fatalf("preview reset counts=%v; events=%v", lifecycle.resets, evs)
+	}
+}
+
 func TestContinuationRecoveryDiscardsFailedCommunicatePreview(t *testing.T) {
 	var attempts atomic.Int32
 	continuationErr := llm.ErrorFromHTTPStatus("openai", 404, "Previous response not found", map[string]any{

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -1348,6 +1348,7 @@ func (s *Session) processOneInput(ctx context.Context, input string, images []Im
 		if err != nil {
 			retry, ferr := s.handleModelError(ctx, err, req, &contentFilterRetried)
 			if retry {
+				s.resetCommunicatePreviews(communicatePreviewCalls)
 				continue
 			}
 			return "", progressed, ferr

--- a/agent/session_model_call.go
+++ b/agent/session_model_call.go
@@ -866,9 +866,7 @@ func (s *Session) callModelWithFallback(ctx context.Context, profile *provider.P
 	previewCalls := map[string]struct{}{}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			for callID := range previewCalls {
-				s.emit(events.EventCommunicatePreviewReset, events.CommunicatePreviewResetData{CallID: callID})
-			}
+			s.resetCommunicatePreviews(previewCalls)
 			panic(recovered)
 		}
 	}()
@@ -913,6 +911,7 @@ func (s *Session) callModelWithFallback(ctx context.Context, profile *provider.P
 		if _, from := recorder.BestSalvage(); from != nil {
 			s.emit(events.EventAssistantTextReset, events.AssistantTextResetData{})
 		}
+		s.resetCommunicatePreviews(previewCalls)
 		var recoveryRecord groupRecord
 		modelResp, err = s.callModel(callCtx, policy, profile, retryReq, &recoveryRecord)
 		rememberPreviews(modelResp)
@@ -978,6 +977,7 @@ func (s *Session) callModelWithFallback(ctx context.Context, profile *provider.P
 			if _, from := recorder.BestSalvage(); from != nil {
 				s.emit(events.EventAssistantTextReset, events.AssistantTextResetData{})
 			}
+			s.resetCommunicatePreviews(previewCalls)
 			var fallbackRecord groupRecord
 			modelResp, err = s.callModel(callCtx, policy, fbProfile, fbReq, &fallbackRecord)
 			rememberPreviews(modelResp)

--- a/agent/session_model_call.go
+++ b/agent/session_model_call.go
@@ -968,7 +968,7 @@ func (s *Session) callModelWithFallback(ctx context.Context, profile *provider.P
 			fbReq.ProviderOptions = fbProfile.ProviderOptions()
 			s.applyModelRequestMetadata(&fbReq)
 			// Group-transition reset (spec: "Group-transition reset"): OnReset
-			// only clears the screen between attempts WITHIN one callModel
+			// only discards partial output between attempts WITHIN one callModel
 			// invocation, so a chain walk away from a group that already
 			// delivered partial output leaves that partial rendered above this
 			// fallback's output. Recomputed from the recorder rather than a

--- a/agent/session_stream.go
+++ b/agent/session_stream.go
@@ -43,6 +43,13 @@ func sortedPreviewCallIDs(calls map[string]struct{}) []string {
 	return ids
 }
 
+func (s *Session) resetCommunicatePreviews(calls map[string]struct{}) {
+	for callID := range calls {
+		s.emit(events.EventCommunicatePreviewReset, events.CommunicatePreviewResetData{CallID: callID})
+		delete(calls, callID)
+	}
+}
+
 // attemptObservation carries one consumeModelStream attempt's phase/stats back
 // to callModel's retry closure, feeding llm.RetryStream's early-stop rules.
 // Populated on every return path, including errors, so a mid-stream failure
@@ -144,9 +151,7 @@ func (s *Session) callModel(ctx context.Context, policy llm.RetryPolicy, profile
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			for id := range previewCalls {
-				s.emit(events.EventCommunicatePreviewReset, events.CommunicatePreviewResetData{CallID: id})
-			}
+			s.resetCommunicatePreviews(previewCalls)
 			panic(recovered)
 		}
 	}()
@@ -174,6 +179,7 @@ func (s *Session) callModel(ctx context.Context, policy llm.RetryPolicy, profile
 			// discard it so the retry's output replaces rather than appends.
 			OnReset: func() {
 				s.emit(events.EventAssistantTextReset, events.AssistantTextResetData{})
+				s.resetCommunicatePreviews(previewCalls)
 			},
 			// FailFastAfter enables both llm.RetryStream early-stop rules: the
 			// streak rule (modelRetryFailFastAfter consecutive consume-phase


### PR DESCRIPTION
## Summary
- reset active `communicate` previews before in-model retries, Responses continuation recovery, and model fallbacks
- remove reset call IDs from active ownership so panic/final cleanup remains exact-once and reused IDs start a new generation
- add regressions for retry, continuation, fallback, reused IDs, and single final communication behavior

## Testing
- `go test -race ./agent -run 'Test(ProcessInputRetryDiscardsFailedPreviewAndCommitsFinalOnce|CallModelRetryResetsReusedPreviewCallIDGeneration|ContinuationRecoveryDiscardsFailedCommunicatePreview|CallModelPanicAfterConsumeResetsTransferredPreview|CallModelWithFallbackRetainsOnlyActivePreviewIDs|CallModelWithFallbackPanicResetsTransferredPrimaryExactlyOnce|CommunicatePreviewResetsWhenCallerAbortsAfterStream)$' -count=1`
- `make lint`
- `make vet`
- `make test`