### PR TITLE
feat: flip activity/full content vectors and make summary line clickable

### DIFF
--- a/cmd/evener-hub/frontend/src/dev/overflowharness-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/overflowharness-entry.tsx
@@ -273,10 +273,13 @@ navigationStore.setState({
 });
 initTranscriptDisplay();
 // The browser guard must not inherit a developer's local transcript settings.
-// Activity plus both diagnostic families keeps the real system-prompt and raw
-// notification disclosure fixtures mounted in both layout classes.
+// Tools plus both diagnostic families keeps the real system-prompt and raw
+// notification disclosure fixtures mounted in both layout classes. Tools
+// (not activity) because activity now has expandByDefault=true, which would
+// auto-open the notification card and the harness's click-to-expand step
+// would then close it.
 const guardTranscriptConfig = makeTranscriptDisplayConfig(
-  { kind: "preset", level: "activity" },
+  { kind: "preset", level: "tools" },
   {
     systemEvents: true,
     promptEvents: true,

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import type { ReactElement } from "react";
 import { afterEach, expect, test, vi } from "vitest";
 import { makeTranscriptDisplayConfig } from "../../../transcriptDisplay/config";
 import {
@@ -76,6 +77,20 @@ function expandRow(): void {
   fireEvent.click(screen.getByTestId("tool-row-trigger"));
 }
 
+// At activity level (the default config when no provider is used),
+// expandByDefault is now true — bodies auto-expand. Tests that need a
+// collapsed-by-default row (e.g. to test the collapsed→expanded transition)
+// use a tools-level config where expandByDefault is false.
+const toolsConfig = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
+
+function renderTools(node: ReactElement) {
+  return render(
+    <TranscriptRenderProvider config={toolsConfig} surface="readOnly" disclosureScope="test:tools">
+      {node}
+    </TranscriptRenderProvider>,
+  );
+}
+
 // The disclosure trigger is a real button[aria-expanded] (see ToolRow.tsx),
 // not a native <details>/<summary> - the open/closed state is
 // read off aria-expanded on the tool-row, and toggled by clicking it. These
@@ -99,7 +114,7 @@ test("falls back to the default descriptor (raw output body) for an unregistered
     />,
   );
   expect(screen.getByText("tci_unregistered")).toBeTruthy(); // default summary = tool name
-  expandRow();
+  // At activity level the body auto-expands (expandByDefault=true).
   const body = screen.getByTestId("tool-call-body");
   const blocks = body.querySelectorAll("pre > code");
   expect(blocks).toHaveLength(2);
@@ -116,7 +131,7 @@ test("the default descriptor keeps both arguments and output visible for a settl
       live={false}
     />,
   );
-  expandRow();
+  // At activity level the body auto-expands (expandByDefault=true).
 
   const body = screen.getByTestId("tool-call-body");
   const argsBlock = within(body).getByRole("region", { name: "Tool call arguments" });
@@ -157,7 +172,7 @@ test("passes live through to the descriptor's body component", () => {
   }
   registerToolRenderer({ match: "tci_live_echo", summary: () => "s", body: LiveEcho });
   render(<ToolCallItem item={item({ toolName: "tci_live_echo" })} turn={turn} live={true} />);
-  expandRow();
+  // At activity level the body auto-expands (expandByDefault=true).
   expect(screen.getByTestId("live-echo").textContent).toBe("true");
 });
 
@@ -174,7 +189,7 @@ test("dedicated renderers do not get MCP argument blocks", () => {
       live={false}
     />,
   );
-  expandRow();
+  // At activity level the body auto-expands (expandByDefault=true).
   const body = screen.getByTestId("tool-call-body");
   expect(within(body).queryByRole("region", { name: "Tool call arguments" })).toBeNull();
   expect(screen.getByTestId("dedicated-body").textContent).toBe("body output");
@@ -198,7 +213,7 @@ test("passes sessionRef through to the descriptor's body component", () => {
       sessionRef="ref_parent_1"
     />,
   );
-  expandRow();
+  // At activity level the body auto-expands (expandByDefault=true).
   expect(screen.getByTestId("session-ref-echo").textContent).toBe("ref_parent_1");
 });
 
@@ -208,7 +223,7 @@ test("sessionRef is undefined at the descriptor's body when ToolCallItem itself 
   }
   registerToolRenderer({ match: "tci_session_ref_echo_2", summary: () => "s", body: SessionRefEcho });
   render(<ToolCallItem item={item({ toolName: "tci_session_ref_echo_2" })} turn={turn} live={false} />);
-  expandRow();
+  // At activity level the body auto-expands (expandByDefault=true).
   expect(screen.getByTestId("session-ref-echo-2").textContent).toBe("(none)");
 });
 
@@ -249,14 +264,18 @@ test("suppress returning false renders the row normally", () => {
 
 test("a row with a body starts collapsed", () => {
   registerToolRenderer({ match: "tci_collapsed", summary: () => "s", body: () => <div>body text</div> });
-  render(<ToolCallItem item={item({ toolName: "tci_collapsed" })} turn={turn} live={false} />);
+  // At activity level the body auto-expands; use tools level (expandByDefault=false)
+  // to verify the collapsed default.
+  renderTools(<ToolCallItem item={item({ toolName: "tci_collapsed" })} turn={turn} live={false} />);
   const details = screen.getByTestId("tool-call-item");
   expect(rowIsOpen(details)).toBe(false);
 });
 
 test("the disclosure trigger controls the mounted body by its stable ID", () => {
   registerToolRenderer({ match: "tci_controls_body", summary: () => "s", body: () => <div>body</div> });
-  render(<ToolCallItem item={item({ toolName: "tci_controls_body" })} turn={turn} live={false} />);
+  // At activity level the body auto-expands; use tools level to test the
+  // collapsed→expanded transition.
+  renderTools(<ToolCallItem item={item({ toolName: "tci_controls_body" })} turn={turn} live={false} />);
   const trigger = screen.getByTestId("tool-row-trigger");
   expect(trigger.getAttribute("aria-controls")).toBeTruthy();
   expect(document.getElementById(trigger.getAttribute("aria-controls")!)).toBe(null);
@@ -269,11 +288,13 @@ test("the disclosure trigger controls the mounted body by its stable ID", () => 
 
 test("Full establishes one open baseline, preserves a later manual close, and opens new eligible rows", () => {
   registerToolRenderer({ match: "tci_baseline", summary: () => "s", body: () => <div>body text</div> });
-  const activity = makeTranscriptDisplayConfig({ kind: "preset", level: "activity" });
+  // At activity level expandByDefault is now true, so use tools level
+  // (expandByDefault=false) to verify the collapsed baseline.
+  const tools = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
   const full = makeTranscriptDisplayConfig({ kind: "preset", level: "full" });
   const first = item({ id: "baseline_first", toolName: "tci_baseline" });
   const second = item({ id: "baseline_second", toolName: "tci_baseline" });
-  const renderBody = (config: typeof activity, items: ItemModel[]) => (
+  const renderBody = (config: typeof tools, items: ItemModel[]) => (
     <TranscriptRenderProvider
       config={config}
       surface="readOnly"
@@ -286,7 +307,7 @@ test("Full establishes one open baseline, preserves a later manual close, and op
     </TranscriptRenderProvider>
   );
 
-  const { rerender } = render(renderBody(activity, [first]));
+  const { rerender } = render(renderBody(tools, [first]));
   expect(rowIsOpen()).toBe(false);
   toggleRow();
   toggleRow();
@@ -320,7 +341,9 @@ test("omitted disclosure scopes remain isolated by live, readOnly, and preview s
 
 test("clicking the summary manually expands a collapsed row", () => {
   registerToolRenderer({ match: "tci_manual_open", summary: () => "s", body: () => <div>body text</div> });
-  render(<ToolCallItem item={item({ toolName: "tci_manual_open" })} turn={turn} live={false} />);
+  // At activity level the body auto-expands; use tools level to test the
+  // collapsed→expanded transition.
+  renderTools(<ToolCallItem item={item({ toolName: "tci_manual_open" })} turn={turn} live={false} />);
   const details = screen.getByTestId("tool-call-item");
   expect(rowIsOpen(details)).toBe(false);
   toggleRow(details);
@@ -333,12 +356,14 @@ test("clicking the summary manually expands a collapsed row", () => {
 test("an expanded tool row stays expanded across an unmount+remount with the same item id (store-backed)", () => {
   registerToolRenderer({ match: "tci_remount", summary: () => "s", body: () => <div>body text</div> });
   const toolItem = item({ id: "item_remount_1", toolName: "tci_remount" });
-  const { unmount } = render(<ToolCallItem item={toolItem} turn={turn} live={false} />);
+  // At activity level the body auto-expands; use tools level to test the
+  // store-backed expanded state.
+  const { unmount } = renderTools(<ToolCallItem item={toolItem} turn={turn} live={false} />);
   toggleRow(screen.getByTestId("tool-call-item"));
   expect(rowIsOpen(screen.getByTestId("tool-call-item"))).toBe(true);
 
   unmount();
-  render(<ToolCallItem item={toolItem} turn={turn} live={false} />);
+  renderTools(<ToolCallItem item={toolItem} turn={turn} live={false} />);
   // Still open after the remount - the state came from the store, not useState.
   expect(rowIsOpen(screen.getByTestId("tool-call-item"))).toBe(true);
 });
@@ -346,11 +371,15 @@ test("an expanded tool row stays expanded across an unmount+remount with the sam
 test("the same tool item id has independent disclosure state in different sessions", () => {
   registerToolRenderer({ match: "tci_session_isolation", summary: () => "s", body: () => <div>body text</div> });
   const shared = item({ id: "same_item", toolName: "tci_session_isolation" });
+  // At activity level the body auto-expands; use tools level (expandByDefault=false)
+  // to test independent disclosure state (both start collapsed). Do NOT set a
+  // custom disclosureScope so disclosureScopeForSession creates per-session scopes.
+  const toolsConfigScoped = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
   render(
-    <>
+    <TranscriptRenderProvider config={toolsConfigScoped} surface="readOnly">
       <ToolCallItem item={shared} turn={turn} live={false} sessionRef="session_a" />
       <ToolCallItem item={shared} turn={turn} live={false} sessionRef="session_b" />
-    </>,
+    </TranscriptRenderProvider>,
   );
 
   const rows = screen.getAllByTestId("tool-call-item");
@@ -378,7 +407,9 @@ test("shell: a failing exit code auto-expands the row once it settles (the real 
 
 test("shell: a clean exit does not auto-expand", () => {
   const output = "stdout\n[exit 0]";
-  render(
+  // At activity level the body auto-expands; use tools level (expandByDefault=false)
+  // to verify a clean exit does not auto-expand.
+  renderTools(
     <ToolCallItem
       item={item({ toolName: "shell", argumentsJSON: JSON.stringify({ command: "true" }), output })}
       turn={turn}
@@ -411,7 +442,7 @@ test("a tool call's outputImages render as gallery thumbnails", () => {
       live={false}
     />,
   );
-  expandRow();
+  // At activity level the body auto-expands (expandByDefault=true).
   expect(screen.getAllByTestId("image-gallery-thumb")).toHaveLength(2);
 });
 
@@ -443,7 +474,7 @@ test("other tools' outputImages keep the default 96px thumbnail size", () => {
       live={false}
     />,
   );
-  expandRow();
+  // At activity level the body auto-expands (expandByDefault=true).
   const thumb = screen.getByTestId("image-gallery-thumb");
   expect(thumb.className.split(/\s+/)).not.toContain(galleryStyles.thumbLarge);
 });
@@ -463,7 +494,7 @@ test("outputImages render even for a body-less descriptor (the row still becomes
       live={false}
     />,
   );
-  expandRow();
+  // At activity level the body auto-expands (expandByDefault=true).
   expect(screen.getAllByTestId("image-gallery-thumb")).toHaveLength(1);
 });
 
@@ -502,7 +533,9 @@ test("an errored tool row earns a failure marker in its summary", () => {
 
 test("a clean tool call earns NO failure marker and stays collapsed (success recedes)", () => {
   registerToolRenderer({ match: "tci_ok_glyph", summary: () => "did a thing", body: () => <div>b</div> });
-  render(<ToolCallItem item={item({ toolName: "tci_ok_glyph" })} turn={turn} live={false} />);
+  // At activity level the body auto-expands; use tools level to verify a
+  // clean call stays collapsed.
+  renderTools(<ToolCallItem item={item({ toolName: "tci_ok_glyph" })} turn={turn} live={false} />);
   expect(screen.getByTestId("tool-call-item").getAttribute("data-failed")).toBe(null);
   expect(screen.queryByTestId("failure-glyph")).toBe(null);
   expect(rowIsOpen(screen.getByTestId("tool-call-item"))).toBe(false);
@@ -558,7 +591,9 @@ test("an expanded shell row drops the one-line summary - the body's pretty-print
 });
 
 test("a collapsed shell row keeps the one-line summary; opening the row drops it", () => {
-  render(
+  // At activity level the body auto-expands; use tools level to test the
+  // collapsed→expanded transition.
+  renderTools(
     <ToolCallItem
       item={item({
         toolName: "shell",
@@ -609,7 +644,9 @@ test('old-daemon reload: error present but status still "completed" is treated a
 
 test("an empty-string error is not a failure (the wire only stamps failed when error is non-empty)", () => {
   registerToolRenderer({ match: "tci_empty_err", summary: () => "s", body: () => <div>b</div> });
-  render(<ToolCallItem item={item({ toolName: "tci_empty_err", error: "" })} turn={turn} live={false} />);
+  // At activity level the body auto-expands; use tools level to verify a
+  // non-failed row stays collapsed.
+  renderTools(<ToolCallItem item={item({ toolName: "tci_empty_err", error: "" })} turn={turn} live={false} />);
   expect(screen.getByTestId("tool-call-item").getAttribute("data-failed")).toBe(null);
   expect(rowIsOpen(screen.getByTestId("tool-call-item"))).toBe(false);
 });
@@ -640,7 +677,9 @@ test("a preval-only failure superseded by a later same-tool success starts colla
   };
   threadsStore.setState({ threads: new Map([["ref_a", threadWith([failedItem, okItem])]]) });
 
-  render(<ToolCallItem item={failedItem} turn={turn} live={false} sessionRef="ref_a" />);
+  // At activity level the body auto-expands; use tools level to verify the
+  // superseded failure starts collapsed.
+  renderTools(<ToolCallItem item={failedItem} turn={turn} live={false} sessionRef="ref_a" />);
 
   const details = screen.getByTestId("tool-call-item");
   // Still attributable: the failure marker never goes away.
@@ -720,7 +759,9 @@ test("supersession is reactive: a row already settled and rendered collapses onc
   });
   threadsStore.setState({ threads: new Map([["ref_a", threadWith([failedItem])]]) });
 
-  render(<ToolCallItem item={failedItem} turn={turn} live={false} sessionRef="ref_a" />);
+  // At activity level the body auto-expands; use tools level so the only
+  // thing keeping the row open is the preval failure's autoExpand.
+  renderTools(<ToolCallItem item={failedItem} turn={turn} live={false} sessionRef="ref_a" />);
   expect(rowIsOpen(screen.getByTestId("tool-call-item"))).toBe(true);
 
   const okItem: ItemModel = {
@@ -754,7 +795,9 @@ test("a reader who manually reopened a superseded row keeps it open (explicit to
   };
   threadsStore.setState({ threads: new Map([["ref_a", threadWith([failedItem, okItem])]]) });
 
-  render(<ToolCallItem item={failedItem} turn={turn} live={false} sessionRef="ref_a" />);
+  // At activity level the body auto-expands; use tools level so the
+  // superseded failure starts collapsed (autoDefault is false).
+  renderTools(<ToolCallItem item={failedItem} turn={turn} live={false} sessionRef="ref_a" />);
   const details = screen.getByTestId("tool-call-item");
   expect(rowIsOpen(details)).toBe(false);
 
@@ -875,7 +918,9 @@ test("clicking Open beside does not toggle the row open (the summary's own toggl
   resetThreadsStoreForTests();
   seedThreadCwd("ref_a", "/home/proj");
   vi.spyOn(paneActions, "openBeside").mockImplementation(() => {});
-  render(
+  // At activity level the body auto-expands; use tools level to verify the
+  // row starts collapsed and Open beside does not toggle it.
+  renderTools(
     <ToolCallItem
       item={item({
         toolName: "read_file",
@@ -920,7 +965,9 @@ test("a read_file card on an image file opens beside as an image (DECISION C: ki
 test("a read_file card's Open beside control rides inline between the file name and the line range", () => {
   resetThreadsStoreForTests();
   seedThreadCwd("ref_a", "/home/proj");
-  render(
+  // At activity level the body auto-expands (no head/tail split); use tools
+  // level to test the collapsed summary's trailingAfter placement.
+  renderTools(
     <ToolCallItem
       item={item({
         toolName: "read_file",

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolRow.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolRow.tsx
@@ -488,8 +488,11 @@ export function ToolRow({
     .join(" ");
   // The .bodyTrigger chevron button: a separate disclosure for the body that
   // coexists with the intent button's summary disclosure in two-level mode.
-  // It carries its own chevron (without the tool-row-chevron testid, so the
-  // intent button's inline chevron stays the unique match for that testid).
+  // On the summary line it is an OVERLAY (absolute, full width/height) so the
+  // entire summary line is clickable to toggle the body — same pattern as the
+  // intent-less overlay trigger. The chevron rides at the end as a visual
+  // indicator. On the intent line (summary hidden, body expanded) it is a
+  // normal flex item beside the intent button.
   const bodyTriggerButton = twoLevel ? (
     <button
       type="button"
@@ -569,8 +572,8 @@ export function ToolRow({
       )}
       {hasIntent && twoLevel && bodyTriggerOnSummaryLine && (
         <div id={summaryRegionId} className={CLASS.summaryLine} data-body-trigger="true">
-          {summaryContent}
           {bodyTriggerButton}
+          {summaryContent}
         </div>
       )}
       {hasIntent && !twoLevel && !showIntentTrailing && <div className={CLASS.summaryLine}>{summaryContent}</div>}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
@@ -124,14 +124,9 @@ test("dispatches a commandExecution item to ToolCallItem", () => {
   const items = [item({ id: "a", type: "commandExecution", toolName: "tb-tool-x", output: "tool output" })];
   render(<TurnBlock turn={turn(items)} />);
   expect(screen.getByTestId("tool-call-item")).toBeTruthy();
-  // A tool row starts collapsed and now mounts its body only while open, so the
-  // output is proof of dispatch only once the row is opened. The dispatch itself
-  // is what this test is about; the row above is already evidence of it, and the
-  // output confirms the descriptor's body ran rather than an empty shell.
-  // At activity level the item has intent (auto-added by the item() helper),
-  // so twoLevel is enabled: the intent button toggles the summary (already open
-  // at activity level) and the .bodyTrigger chevron toggles the body.
-  fireEvent.click(screen.getByTestId("tool-row-body-trigger"));
+  // A tool row mounts its body only while open. At activity level
+  // (expandByDefault=true) the body auto-expands, so the output is already
+  // visible — confirming the descriptor's body ran rather than an empty shell.
   expect(screen.getByText("tool output")).toBeTruthy();
 });
 
@@ -601,11 +596,14 @@ test("steering, systemMessage, and warning are run rows: they render INSIDE a ru
 });
 
 test("agentMessage and reasoning render inside a run-content wrapper", () => {
+  // At activity level reasoning=false hides reasoning items; use full level
+  // (reasoning=true) so the think-block renders.
+  const fullConfig = makeTranscriptDisplayConfig({ kind: "preset", level: "full" });
   const items = [
     item({ id: "a", type: "agentMessage", text: "reply" }),
     item({ id: "r", type: "reasoning", reasoningSummaries: [["hmm"]], status: "completed" }),
   ];
-  render(<TurnBlock turn={turn(items)} />);
+  render(<TurnBlock turn={turn(items, {}, fullConfig)} />);
   expectInsideRunContent(screen.getByTestId("agent-message-item"));
   expectInsideRunContent(screen.getByTestId("think-block"));
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
@@ -3,8 +3,11 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
 import { afterEach, beforeAll, expect, test } from "vitest";
 import { resetWorkspaceStoreForTests, workspaceStore } from "../../../../shell/workspace";
+import { makeTranscriptDisplayConfig } from "../../../../transcriptDisplay/config";
+import { TranscriptRenderProvider } from "../../../../transcriptDisplay/renderContext";
 import { resetDisclosureStoreForTests } from "../../../../widgets/disclosure/disclosureStore";
 import { NotificationCard } from "./NotificationCard";
 import type { ParsedNotification } from "./steeringClassify";
@@ -32,6 +35,20 @@ function notif(overrides: Partial<ParsedNotification> = {}): ParsedNotification 
   };
 }
 
+// At activity level (the default config when no provider is used),
+// expandByDefault is now true — the card auto-expands. Tests that need a
+// collapsed-by-default card use a tools-level config where expandByDefault
+// is false.
+const toolsConfig = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
+
+function renderTools(node: ReactElement) {
+  return render(
+    <TranscriptRenderProvider config={toolsConfig} surface="readOnly" disclosureScope="nc:tools">
+      {node}
+    </TranscriptRenderProvider>,
+  );
+}
+
 test("renders the title and tags the tone", () => {
   render(<NotificationCard notification={notif()} />);
   expect(screen.getByText("Job completed")).toBeTruthy();
@@ -39,7 +56,7 @@ test("renders the title and tags the tone", () => {
 });
 
 test("renders stable delegate identity as Delegate while shell identity remains Job", async () => {
-  const user = userEvent.setup();
+  const _user = userEvent.setup();
   const { rerender } = render(
     <NotificationCard
       notification={notif({
@@ -54,7 +71,8 @@ test("renders stable delegate identity as Delegate while shell identity remains 
     />,
   );
   expect(screen.getByTestId("notification-card").textContent).toContain("Delegate completed");
-  await user.click(screen.getByTestId("notification-card"));
+  // At activity level the card auto-expands (expandByDefault=true), so the
+  // fields are already visible without clicking.
   expect(screen.getByText(/delegate id/i).parentElement?.textContent).toContain("dlg_42");
   expect(screen.queryByText(/job id/i)).toBeNull();
 
@@ -73,7 +91,9 @@ test("renders stable delegate identity as Delegate while shell identity remains 
 });
 
 test("collapses to a single row by default; card chrome appears on expand", () => {
-  render(<NotificationCard notification={notif({ tone: "neutral", title: "explorer finished" })} />);
+  // At activity level the card auto-expands; use tools level to test the
+  // collapsed→expanded→collapsed transition.
+  renderTools(<NotificationCard notification={notif({ tone: "neutral", title: "explorer finished" })} />);
   const row = screen.getByTestId("notification-card");
   expect(row.textContent).toContain("explorer finished");
   expect(screen.queryByTestId("notification-card-root")).toBeNull();
@@ -86,12 +106,14 @@ test("collapses to a single row by default; card chrome appears on expand", () =
 
 test("an expanded notification card stays open across a remount through the scoped store", () => {
   const notification = notif({ title: "remount me" });
-  const { unmount } = render(<NotificationCard notification={notification} sessionRef="session_a" />);
+  // At activity level the card auto-expands; use tools level to test that a
+  // manually expanded card stays open across a remount.
+  const { unmount } = renderTools(<NotificationCard notification={notification} sessionRef="session_a" />);
   fireEvent.click(screen.getByTestId("notification-card"));
   expect((screen.getByTestId("notification-card").closest("details") as HTMLDetailsElement).open).toBe(true);
 
   unmount();
-  render(<NotificationCard notification={notification} sessionRef="session_a" />);
+  renderTools(<NotificationCard notification={notification} sessionRef="session_a" />);
   expect((screen.getByTestId("notification-card").closest("details") as HTMLDetailsElement).open).toBe(true);
 });
 
@@ -123,7 +145,7 @@ test("the collapsed row prefers a job description to its generic job type", () =
 });
 
 test("renders parsed job fields and excerpt as ordinary readable text", async () => {
-  const user = userEvent.setup();
+  const _user = userEvent.setup();
   render(
     <NotificationCard
       notification={notif({
@@ -137,7 +159,7 @@ test("renders parsed job fields and excerpt as ordinary readable text", async ()
       })}
     />,
   );
-  await user.click(screen.getByTestId("notification-card"));
+  // At activity level the card auto-expands (expandByDefault=true).
   expect(screen.getByTestId("notification-field-status").textContent).toContain("completed");
   expect(screen.getByTestId("notification-field-job-type").textContent).toContain("delegate");
   expect(screen.getByTestId("notification-field-output").textContent).toContain("4");
@@ -212,20 +234,20 @@ test("missing and malformed refs have no dead open-subagent action", () => {
 });
 
 test("the raw block is always kept inspectable", async () => {
-  const user = userEvent.setup();
+  const _user = userEvent.setup();
   render(
     <NotificationCard
       notification={notif({ rawText: '<job-notification job_id="abc">the raw text</job-notification>' })}
     />,
   );
-  await user.click(screen.getByTestId("notification-card"));
+  // At activity level the card auto-expands (expandByDefault=true).
   expect(screen.getByTestId("notification-raw").textContent).toContain("the raw text");
 });
 
 test("an excerpt is shown, entity-decoded, as escaped text (never live HTML)", async () => {
-  const user = userEvent.setup();
+  const _user = userEvent.setup();
   render(<NotificationCard notification={notif({ excerpt: "&lt;script&gt;alert(1)&lt;/script&gt;" })} />);
-  await user.click(screen.getByTestId("notification-card"));
+  // At activity level the card auto-expands (expandByDefault=true).
   // Decoded to <script>… but rendered as text, so it appears verbatim and no
   // script element is ever created.
   expect(screen.getByText("<script>alert(1)</script>")).toBeTruthy();
@@ -238,29 +260,29 @@ test("an excerpt is shown, entity-decoded, as escaped text (never live HTML)", a
 // including a literal ampersand and text that already looks like an entity
 // (decoding &amp; last is what keeps "&lt;" text from over-decoding to "<").
 test("kata 77sf: a delimiter-bearing excerpt decodes to the exact original text", async () => {
-  const user = userEvent.setup();
+  const _user = userEvent.setup();
   const original = 'before & after </job-notification> <script>&lt;already-escaped&gt;</script> "quoted"';
   const escapeLikeProducer = (s: string) =>
     s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
   render(<NotificationCard notification={notif({ excerpt: escapeLikeProducer(original) })} />);
-  await user.click(screen.getByTestId("notification-card"));
+  // At activity level the card auto-expands (expandByDefault=true).
   expect(screen.getByTestId("notification-field-excerpt").textContent).toBe(original);
   expect(document.querySelector("script")).toBe(null);
 });
 
 test("a very long excerpt remains a bounded normal-text preview without adding a nested disclosure", async () => {
-  const user = userEvent.setup();
+  const _user = userEvent.setup();
   const long = "x".repeat(900);
   render(<NotificationCard notification={notif({ excerpt: long })} />);
-  await user.click(screen.getByTestId("notification-card"));
+  // At activity level the card auto-expands (expandByDefault=true).
   expect(screen.getByText(/x{500}…/)).toBeTruthy();
   expect(screen.getByTestId("notification-card-root").querySelectorAll("details")).toHaveLength(1);
 });
 
 test("keeps raw notification as the one direct full-width disclosure row", async () => {
-  const user = userEvent.setup();
+  const _user = userEvent.setup();
   render(<NotificationCard notification={notif({ excerpt: "useful output" })} />);
-  await user.click(screen.getByTestId("notification-card"));
+  // At activity level the card auto-expands (expandByDefault=true).
   const root = screen.getByTestId("notification-card-root");
   const raw = screen.getByTestId("notification-raw-disclosure");
   expect(root.querySelectorAll("details")).toHaveLength(1);
@@ -270,9 +292,9 @@ test("keeps raw notification as the one direct full-width disclosure row", async
 });
 
 test("keeps the raw disclosure native and preserves its visible marker row", async () => {
-  const user = userEvent.setup();
+  const _user = userEvent.setup();
   render(<NotificationCard notification={notif()} />);
-  await user.click(screen.getByTestId("notification-card"));
+  // At activity level the card auto-expands (expandByDefault=true).
   const raw = screen.getByTestId("notification-raw-disclosure") as HTMLDetailsElement;
   const summary = raw.querySelector("summary");
   expect(summary?.tagName).toBe("SUMMARY");
@@ -288,15 +310,15 @@ test("keeps the raw disclosure native and preserves its visible marker row", asy
 });
 
 test("a communicate message renders through markdown", async () => {
-  const user = userEvent.setup();
+  const _user = userEvent.setup();
   render(<NotificationCard notification={notif({ message: "**bold** result" })} />);
-  await user.click(screen.getByTestId("notification-card"));
+  // At activity level the card auto-expands (expandByDefault=true).
   expect(screen.getByTestId("notification-card-root").querySelector("strong")?.textContent).toBe("bold");
 });
 
 test("concerns surface as a quiet note", async () => {
-  const user = userEvent.setup();
+  const _user = userEvent.setup();
   render(<NotificationCard notification={notif({ concerns: ["edge case A", "edge case B"] })} />);
-  await user.click(screen.getByTestId("notification-card"));
+  // At activity level the card auto-expands (expandByDefault=true).
   expect(screen.getByTestId("notification-card-root").textContent).toContain("edge case A; edge case B");
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/SteeringItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/SteeringItem.test.tsx
@@ -280,7 +280,7 @@ test("a job-notification steer renders a notification card (not a steering divid
 
 test("a job-notification steer expands the notification before asserting card body content", () => {
   render(<SteeringItem item={item({ text: JOB_NOTIFICATION_STEERING })} turn={turn} live={false} />);
-  fireEvent.click(screen.getByTestId("notification-card"));
+  // At activity level the card auto-expands (expandByDefault=true).
   expect(screen.getByTestId("notification-card-root")).toBeTruthy();
   expect(screen.getByText("Job completed")).toBeTruthy();
 });
@@ -293,7 +293,7 @@ excerpt:
 </job-notification>`;
   render(<SteeringItem item={item({ text })} turn={turn} live={false} />);
 
-  fireEvent.click(screen.getByTestId("notification-card"));
+  // At activity level the card auto-expands (expandByDefault=true).
 
   const excerpt = screen.getByTestId("notification-field-excerpt");
   expect(excerpt.textContent).toBe(" Test Files  1 failed | 283 passed");
@@ -327,7 +327,7 @@ excerpt:
 ${decoded}
 </job-notification>`;
   render(<SteeringItem item={item({ text })} turn={turn} live={false} />);
-  fireEvent.click(screen.getByTestId("notification-card"));
+  // At activity level the card auto-expands (expandByDefault=true).
 
   const excerpt = screen.getByTestId("notification-field-excerpt");
   // Explicit truncation affordance, final content visible, older content
@@ -350,7 +350,7 @@ excerpt:
 {"message":"**literal shell output**","data":{"status":"ok","concerns":["from stdout"]}}
 </job-notification>`;
   render(<SteeringItem item={item({ text })} turn={turn} live={false} />);
-  fireEvent.click(screen.getByTestId("notification-card"));
+  // At activity level the card auto-expands (expandByDefault=true).
 
   const root = screen.getByTestId("notification-card-root");
   // The raw JSON text is reader-visible verbatim (not consumed as an envelope).
@@ -375,7 +375,7 @@ excerpt:
 {not json} [31mFAIL[39m
 </job-notification>`;
   render(<SteeringItem item={item({ text })} turn={turn} live={false} />);
-  fireEvent.click(screen.getByTestId("notification-card"));
+  // At activity level the card auto-expands (expandByDefault=true).
 
   expect(screen.getByText("FAIL").closest('[data-ansi-fg="red"]')).toBeTruthy();
 });
@@ -405,7 +405,7 @@ test("a notification restores its owning session to main before opening the chil
 
 test("a notification card always keeps the verbatim block inspectable in a raw disclosure", () => {
   render(<SteeringItem item={item({ text: JOB_NOTIFICATION_STEERING })} turn={turn} live={false} />);
-  fireEvent.click(screen.getByTestId("notification-card"));
+  // At activity level the card auto-expands (expandByDefault=true).
   expect(screen.getByTestId("notification-raw").textContent).toContain("job_7");
 });
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/SystemNoticeItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/SystemNoticeItem.test.tsx
@@ -5,6 +5,8 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeAll, beforeEach, expect, test } from "vitest";
 import type { ItemModel, TurnModel } from "../../../../protocol/model";
 import { prefsStore, resetPrefsStoreForTests } from "../../../../stores/prefs";
+import { makeTranscriptDisplayConfig } from "../../../../transcriptDisplay/config";
+import { TranscriptRenderProvider } from "../../../../transcriptDisplay/renderContext";
 import { resetDisclosureStoreForTests } from "../../../../widgets/disclosure/disclosureStore";
 import { TurnBlock } from "../TurnBlock";
 import { SYSTEM_PROMPT_ITEM_ID } from "../transcriptVisibility";
@@ -62,6 +64,20 @@ function turnWith(items: ItemModel[]): TurnModel {
   return { id: "turn_1", status: "completed", items };
 }
 
+// At activity level (the default config when no provider is used),
+// expandByDefault is now true — scaffold disclosures and system-event groups
+// auto-expand. Tests that need a collapsed-by-default disclosure use a
+// tools-level config where expandByDefault is false.
+const toolsConfig = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
+
+function renderTurnTools(turn: TurnModel, sessionRef?: string) {
+  return render(
+    <TranscriptRenderProvider config={toolsConfig} surface="readOnly" disclosureScope="sni:tools">
+      <TurnBlock turn={turn} sessionRef={sessionRef} />
+    </TranscriptRenderProvider>,
+  );
+}
+
 test('self-registers under the wire\'s system-message item type ("systemMessage")', () => {
   expect(itemRendererFor("systemMessage")).toBe(SystemNoticeItem);
 });
@@ -91,7 +107,9 @@ test("two consecutive systemMessage items (run of 2) both render standalone, not
 
 test("three consecutive systemMessage items group into one collapsed disclosure", () => {
   const items = [item("a"), item("b"), item("c")];
-  render(<TurnBlock turn={turnWith(items)} />);
+  // At activity level the group auto-expands; use tools level to test the
+  // collapsed default.
+  renderTurnTools(turnWith(items));
   const group = screen.getByTestId("system-notice-group") as HTMLDetailsElement;
   expect(group.tagName).toBe("DETAILS");
   expect(group.open).toBe(false);
@@ -103,11 +121,15 @@ test("three consecutive systemMessage items group into one collapsed disclosure"
 test("the same scaffold item id has independent disclosure state in different sessions", () => {
   showSystemPrompt();
   const shared = item("same_item", { eventKind: "system_prompt", text: "You are a helpful assistant." });
+  // At activity level the scaffold auto-expands; use tools level to test
+  // independent collapsed state. Use separate disclosureScopes per session
+  // so disclosureScopeForSession creates per-session scopes.
+  const toolsConfigScoped = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
   render(
-    <>
+    <TranscriptRenderProvider config={toolsConfigScoped} surface="readOnly">
       <TurnBlock turn={turnWith([shared])} sessionRef="session_a" />
       <TurnBlock turn={turnWith([shared])} sessionRef="session_b" />
-    </>,
+    </TranscriptRenderProvider>,
   );
 
   const scaffolds = screen.getAllByTestId("system-notice-scaffold") as HTMLDetailsElement[];
@@ -132,14 +154,16 @@ test("the group's summary names the count and the first event", () => {
 // survives the remount that would reset a native uncontrolled <details>.
 test("an expanded system-events group stays open across an unmount+remount (store-backed by the run's first item id)", () => {
   const items = [item("a"), item("b"), item("c")];
-  const { unmount } = render(<TurnBlock turn={turnWith(items)} />);
+  // At activity level the group auto-expands; use tools level to test the
+  // collapsed→expanded→remount-persisted transition.
+  const { unmount } = renderTurnTools(turnWith(items));
   const group = screen.getByTestId("system-notice-group") as HTMLDetailsElement;
   expect(group.open).toBe(false);
   fireEvent.click(group.querySelector("summary")!);
   expect((screen.getByTestId("system-notice-group") as HTMLDetailsElement).open).toBe(true);
 
   unmount();
-  render(<TurnBlock turn={turnWith(items)} />);
+  renderTurnTools(turnWith(items));
   expect((screen.getByTestId("system-notice-group") as HTMLDetailsElement).open).toBe(true);
 });
 
@@ -187,7 +211,9 @@ test("a systemMessage item with blank text falls back to a sentence-case categor
 
 test("a system_prompt eventKind item renders as a collapsed scaffold disclosure, even when its text is short", () => {
   showSystemPrompt();
-  render(<TurnBlock turn={turnWith([item("a", { text: "short", eventKind: "system_prompt" })])} />);
+  // At activity level the scaffold auto-expands; use tools level to test the
+  // collapsed default.
+  renderTurnTools(turnWith([item("a", { text: "short", eventKind: "system_prompt" })]));
   const scaffold = screen.getByTestId("system-notice-scaffold") as HTMLDetailsElement;
   expect(scaffold.tagName).toBe("DETAILS");
   expect(scaffold.open).toBe(false);
@@ -197,7 +223,9 @@ test("a system_prompt eventKind item renders as a collapsed scaffold disclosure,
 test("an expanded system prompt keeps its summary and Markdown body in full-width rows", () => {
   showSystemPrompt();
   const text = `## Identity\n\n${"You are a careful assistant. ".repeat(1000)}`;
-  render(<TurnBlock turn={turnWith([item("prompt", { text, eventKind: "system_prompt" })])} />);
+  // At activity level the scaffold auto-expands; use tools level to test the
+  // collapsed default and structure.
+  renderTurnTools(turnWith([item("prompt", { text, eventKind: "system_prompt" })]));
   const scaffold = screen.getByTestId("system-notice-scaffold") as HTMLDetailsElement;
   const summary = scaffold.querySelector("summary");
   const body = scaffold.querySelector('[data-testid="system-notice-scaffold-body"]');

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.test.tsx
@@ -2,8 +2,11 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
 import { afterEach, expect, test } from "vitest";
 import type { ItemModel, TurnModel } from "../../../../protocol/model";
+import { makeTranscriptDisplayConfig } from "../../../../transcriptDisplay/config";
+import { TranscriptRenderProvider } from "../../../../transcriptDisplay/renderContext";
 import { resetDisclosureStoreForTests } from "../../../../widgets/disclosure/disclosureStore";
 import { requireClass } from "../../../../widgets/internal/requireClass";
 import rawStreamingStyles from "../streamingtext.module.css";
@@ -28,6 +31,28 @@ const turn: TurnModel = { id: "turn_1", status: "inProgress", items: [] };
 
 function item(overrides: Partial<ItemModel> = {}): ItemModel {
   return { id: "item_1", turnId: "turn_1", type: "reasoning", text: "", ...overrides };
+}
+
+// At activity level (the default config when no provider is used),
+// expandByDefault is now true — the settled disclosure auto-expands. Tests
+// that need a collapsed-by-default disclosure use a tools-level config where
+// expandByDefault is false.
+const toolsConfig = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
+
+function renderTools(node: ReactElement) {
+  return render(
+    <TranscriptRenderProvider config={toolsConfig} surface="readOnly" disclosureScope="tb:tools">
+      {node}
+    </TranscriptRenderProvider>,
+  );
+}
+
+function renderTurnTools(node: ReactElement) {
+  return render(
+    <TranscriptRenderProvider config={toolsConfig} surface="readOnly" disclosureScope="tb:turn">
+      {node}
+    </TranscriptRenderProvider>,
+  );
 }
 
 test('self-registers under the wire\'s reasoning item type ("reasoning")', () => {
@@ -223,7 +248,7 @@ test("an inProgress reasoning item that is no longer the turn's tail renders the
     text: "answering",
     status: "inProgress",
   };
-  render(<ThinkBlock item={think} turn={{ ...turn, items: [think, later] }} live={true} />);
+  renderTools(<ThinkBlock item={think} turn={{ ...turn, items: [think, later] }} live={true} />);
   const summary = document.querySelector("summary");
   expect(summary?.textContent).toBe("Thought · final line");
   expect(summary?.textContent).not.toMatch(/\d/);
@@ -239,7 +264,7 @@ test("an inProgress reasoning item that IS the turn's tail stays live", () => {
 
 test("through TurnBlock: a later item landing in the turn collapses the live thought to its disclosure", () => {
   const think = item({ id: "think_flow", status: "inProgress", reasoningSummaries: [["deep thought line"]] });
-  const { rerender } = render(<TurnBlock turn={{ ...turn, items: [think] }} />);
+  const { rerender } = renderTurnTools(<TurnBlock turn={{ ...turn, items: [think] }} />);
   expect(screen.getByText("Thinking…")).toBeTruthy();
 
   const later: ItemModel = {
@@ -249,7 +274,11 @@ test("through TurnBlock: a later item landing in the turn collapses the live tho
     text: "now answering",
     status: "inProgress",
   };
-  rerender(<TurnBlock turn={{ ...turn, items: [think, later] }} />);
+  rerender(
+    <TranscriptRenderProvider config={toolsConfig} surface="readOnly" disclosureScope="tb:turn">
+      <TurnBlock turn={{ ...turn, items: [think, later] }} />
+    </TranscriptRenderProvider>,
+  );
   expect(screen.queryByText("Thinking…")).toBeNull();
   expect(document.querySelector('[data-testid="think-block"] summary')?.textContent).toBe(
     "Thought · deep thought line",
@@ -332,7 +361,7 @@ test("no fade and no clip flag over the live draft - nothing is cut off to mark"
 // --- settled: duration + final context --------------------------------------
 
 test("settled collapses to a closed details with duration and the final nonblank context line", () => {
-  render(
+  renderTools(
     <ThinkBlock
       item={item({ reasoningSummaries: [["The answer is 42.\nmore reasoning"]] })}
       turn={turn}
@@ -351,7 +380,7 @@ test("opening the disclosure drops the preview from the summary", () => {
     id: "think_open_preview",
     reasoningSummaries: [["First line of reasoning\n\nsecond paragraph"]],
   });
-  render(<ThinkBlock item={think} turn={turn} live={false} />);
+  renderTools(<ThinkBlock item={think} turn={turn} live={false} />);
   const summary = screen.getByText(/Thought/);
   const preview = summary.textContent?.split("·")[1]?.trim() ?? "";
   expect(preview).toBeTruthy();
@@ -360,7 +389,7 @@ test("opening the disclosure drops the preview from the summary", () => {
 });
 
 test("the open disclosure keeps the dot-joined duration label - never the old 'for' phrasing", () => {
-  render(
+  renderTools(
     <ThinkBlock
       item={item({
         id: "think_open_duration",
@@ -384,7 +413,7 @@ test("the open disclosure keeps the dot-joined duration label - never the old 'f
 // summary and turning 90° when open (ToolRow's data-open idiom).
 
 test("the settled summary trails with a chevron that tracks the open state", () => {
-  render(
+  renderTools(
     <ThinkBlock
       item={item({ id: "think_chevron", reasoningSummaries: [["deep thought"]] })}
       turn={turn}
@@ -418,7 +447,7 @@ test("the summary text ellipsizes in its own span so the trailing chevron is nev
 });
 
 test("the collapsed summary keeps the final context even though the expanded body remains complete", () => {
-  const { container } = render(
+  const { container } = renderTools(
     <ThinkBlock
       item={item({ reasoningSummaries: [["Delegating simple directory inspection task\n\nmore detail"]] })}
       turn={turn}
@@ -431,7 +460,7 @@ test("the collapsed summary keeps the final context even though the expanded bod
 });
 
 test("the plain context removes common Markdown decoration while the expanded body still parses Markdown", () => {
-  const { container } = render(
+  const { container } = renderTools(
     <ThinkBlock
       item={item({ reasoningSummaries: [["**Delegating simple directory inspection task**"]] })}
       turn={turn}
@@ -446,7 +475,7 @@ test("the plain context removes common Markdown decoration while the expanded bo
 
 test("a long final context line is honestly truncated in the collapsed summary", () => {
   const longLine = `final context ${"x".repeat(180)}`;
-  render(<ThinkBlock item={item({ reasoningSummaries: [[longLine]] })} turn={turn} live={false} />);
+  renderTools(<ThinkBlock item={item({ reasoningSummaries: [[longLine]] })} turn={turn} live={false} />);
   const summary = document.querySelector("summary")?.textContent ?? "";
   expect(summary.endsWith("…")).toBe(true);
   expect(summary).not.toContain(longLine);
@@ -564,24 +593,28 @@ test("markdown in a thought is parsed identically while live and once settled (s
 // would reset a native uncontrolled <details>.
 test("an expanded settled think block stays open across an unmount+remount with the same item id (store-backed)", () => {
   const think = item({ id: "item_think_remount", reasoningSummaries: [["deep thoughts here"]] });
-  const { unmount } = render(<ThinkBlock item={think} turn={turn} live={false} />);
+  const { unmount } = renderTools(<ThinkBlock item={think} turn={turn} live={false} />);
   const details = screen.getByRole("group") as HTMLDetailsElement;
   expect(details.open).toBe(false);
   fireEvent.click(details.querySelector("summary")!);
   expect((screen.getByRole("group") as HTMLDetailsElement).open).toBe(true);
 
   unmount();
-  render(<ThinkBlock item={think} turn={turn} live={false} />);
+  renderTools(<ThinkBlock item={think} turn={turn} live={false} />);
   expect((screen.getByRole("group") as HTMLDetailsElement).open).toBe(true);
 });
 
 test("the same settled think item id has independent disclosure state in different sessions", () => {
   const shared = item({ id: "same_item", reasoningSummaries: [["deep thoughts here"]] });
+  // At activity level the disclosure auto-expands; use tools level to test
+  // independent collapsed state. Do NOT set a custom disclosureScope so
+  // disclosureScopeForSession creates per-session scopes.
+  const toolsConfigScoped = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
   render(
-    <>
+    <TranscriptRenderProvider config={toolsConfigScoped} surface="readOnly">
       <ThinkBlock item={shared} turn={turn} live={false} sessionRef="session_a" />
       <ThinkBlock item={shared} turn={turn} live={false} sessionRef="session_b" />
-    </>,
+    </TranscriptRenderProvider>,
   );
 
   const blocks = screen.getAllByRole("group") as HTMLDetailsElement[];
@@ -595,14 +628,14 @@ test("the same settled think item id has independent disclosure state in differe
 });
 
 test("no fabricated duration: without real item.startedAt/completedAt, the label omits a number entirely (never invents one)", () => {
-  render(<ThinkBlock item={item({ reasoningSummaries: [["content"]] })} turn={turn} live={false} />);
+  renderTools(<ThinkBlock item={item({ reasoningSummaries: [["content"]] })} turn={turn} live={false} />);
   const summary = document.querySelector("summary");
   expect(summary?.textContent).toBe("Thought · content");
   expect(summary?.textContent).not.toMatch(/\d/);
 });
 
 test("a replay item's real startedAt/completedAt pair produces a duration label", () => {
-  render(
+  renderTools(
     <ThinkBlock
       item={item({
         reasoningSummaries: [["content"]],
@@ -617,7 +650,7 @@ test("a replay item's real startedAt/completedAt pair produces a duration label"
 });
 
 test("a live-observed timing pair (no wire pair) produces a real duration label once settled", () => {
-  render(
+  renderTools(
     <ThinkBlock
       item={item({
         reasoningSummaries: [["content"]],
@@ -632,7 +665,7 @@ test("a live-observed timing pair (no wire pair) produces a real duration label 
 });
 
 test("the wire pair wins over the observed pair when both are present", () => {
-  render(
+  renderTools(
     <ThinkBlock
       item={item({
         reasoningSummaries: [["content"]],
@@ -649,7 +682,7 @@ test("the wire pair wins over the observed pair when both are present", () => {
 });
 
 test("a completed sub-second thought reports milliseconds, not a rounded second", () => {
-  render(
+  renderTools(
     <ThinkBlock
       item={item({
         reasoningSummaries: [["content"]],
@@ -707,11 +740,15 @@ test("settled with only whitespace-only summary chunks renders nothing", () => {
 
 test("live streaming settles cleanly into the collapsed disclosure, no leftover live body", () => {
   const liveItem = item({ reasoningSummaries: [["thinking..."]] });
-  const { rerender } = render(<ThinkBlock item={liveItem} turn={turn} live={true} />);
+  const { rerender } = renderTools(<ThinkBlock item={liveItem} turn={turn} live={true} />);
   expect(screen.getByTestId("think-block-live-body").textContent?.trim()).toBe("thinking...");
 
   const settledItem = { ...liveItem, status: "completed" };
-  rerender(<ThinkBlock item={settledItem} turn={{ ...turn, status: "completed" }} live={false} />);
+  rerender(
+    <TranscriptRenderProvider config={toolsConfig} surface="readOnly" disclosureScope="tb:tools">
+      <ThinkBlock item={settledItem} turn={{ ...turn, status: "completed" }} live={false} />
+    </TranscriptRenderProvider>,
+  );
 
   expect(screen.queryByTestId("think-block-live-body")).toBeNull();
   expect(screen.queryByText("Thinking…")).toBeNull();

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolRowGrammar.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolRowGrammar.test.tsx
@@ -7,9 +7,12 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
 import { afterEach, expect, test, vi } from "vitest";
 import type { ItemModel, TurnModel } from "../../../protocol/model";
 import { resetWorkspaceStoreForTests, workspaceStore } from "../../../shell/workspace";
+import { makeTranscriptDisplayConfig } from "../../../transcriptDisplay/config";
+import { TranscriptRenderProvider } from "../../../transcriptDisplay/renderContext";
 import { resetDisclosureStoreForTests } from "../../../widgets/disclosure/disclosureStore";
 import { ToolCallItem } from "./ToolCallItem";
 import { statedIntentOf, ToolRow } from "./ToolRow";
@@ -38,6 +41,20 @@ function rowCss(): string {
 
 function item(overrides: Partial<ItemModel> = {}): ItemModel {
   return { id: "item_1", turnId: "turn_1", type: "commandExecution", text: "", ...overrides };
+}
+
+// At activity level (the default config when no provider is used),
+// expandByDefault is now true — bodies auto-expand. Tests that need a
+// collapsed-by-default row use a tools-level config where expandByDefault
+// is false.
+const toolsConfig = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
+
+function renderTools(node: ReactElement) {
+  return render(
+    <TranscriptRenderProvider config={toolsConfig} surface="readOnly" disclosureScope="trg:tools">
+      {node}
+    </TranscriptRenderProvider>,
+  );
 }
 
 // --- A1: one row grammar, composed not copied -----------------------------
@@ -574,7 +591,9 @@ test("a descriptor's monoSummary flag puts its summary in fixed-width - shell's 
 
 test("an expandable row exposes aria-expanded reflecting its state", () => {
   registerToolRenderer({ match: "trg_aria", summary: () => "s", body: () => <div>b</div> });
-  render(<ToolCallItem item={item({ toolName: "trg_aria" })} turn={turn} live={false} />);
+  // At activity level the body auto-expands; use tools level to test the
+  // collapsed→expanded transition.
+  renderTools(<ToolCallItem item={item({ toolName: "trg_aria" })} turn={turn} live={false} />);
   const trigger = screen.getByTestId("tool-row-trigger");
   expect(trigger.getAttribute("aria-expanded")).toBe("false");
   fireEvent.click(trigger);
@@ -599,7 +618,9 @@ test("an expandable row shows a disclosure chevron; a non-expandable row shows n
 
 test("the chevron reports its open state for the stylesheet's rotation, and is hidden from AT", () => {
   registerToolRenderer({ match: "trg_chev_state", summary: () => "s", body: () => <div>b</div> });
-  render(<ToolCallItem item={item({ toolName: "trg_chev_state" })} turn={turn} live={false} />);
+  // At activity level the body auto-expands; use tools level to test the
+  // collapsed→expanded chevron state transition.
+  renderTools(<ToolCallItem item={item({ toolName: "trg_chev_state" })} turn={turn} live={false} />);
   const chevron = screen.getByTestId("tool-row-chevron");
   expect(chevron.getAttribute("aria-hidden")).toBe("true");
   expect(chevron.getAttribute("data-open")).toBe("false");

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolcallitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolcallitem.module.css
@@ -277,6 +277,31 @@
    container. flex-shrink:1 and flex-basis:auto let the summary shrink to fit
    alongside the flex:none body trigger; min-width:0 + the .clamped
    overflow:hidden clip the nowrap text to the shrunken width. */
+.summaryLine[data-body-trigger="true"] {
+  position: relative;
+}
+
+.summaryLine[data-body-trigger="true"] .bodyTrigger {
+  position: absolute;
+  inset: 0;
+  justify-content: flex-end;
+  overflow: hidden;
+}
+
+.summaryLine[data-body-trigger="true"] .summary {
+  position: relative;
+  z-index: var(--z-raised);
+  pointer-events: none;
+}
+
+.summaryLine[data-body-trigger="true"] .summary a,
+.summaryLine[data-body-trigger="true"] .summary button,
+.summaryLine[data-body-trigger="true"] .summary input,
+.summaryLine[data-body-trigger="true"] .summary select,
+.summaryLine[data-body-trigger="true"] .summary textarea {
+  pointer-events: auto;
+}
+
 .summaryLine[data-body-trigger="true"] .demoted {
   flex: 0 1 auto;
   min-width: 0;

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/config.test.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/config.test.ts
@@ -55,8 +55,8 @@ describe("transcript display config", () => {
     expect(presetContent("activity")).toEqual({
       toolIntent: true,
       toolCalls: true,
-      reasoning: true,
-      expandByDefault: false,
+      reasoning: false,
+      expandByDefault: true,
     });
     expect(presetContent("full")).toEqual({
       toolIntent: true,

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/config.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/config.ts
@@ -53,7 +53,7 @@ const CONTENT_VECTORS: Readonly<Record<ContentLevel, ContentVector>> = {
   chat: { toolIntent: true, toolCalls: false, reasoning: false, expandByDefault: false },
   intent: { toolIntent: true, toolCalls: false, reasoning: false, expandByDefault: false },
   tools: { toolIntent: true, toolCalls: true, reasoning: false, expandByDefault: false },
-  activity: { toolIntent: true, toolCalls: true, reasoning: true, expandByDefault: false },
+  activity: { toolIntent: true, toolCalls: true, reasoning: false, expandByDefault: true },
   full: { toolIntent: true, toolCalls: true, reasoning: true, expandByDefault: true },
 };
 

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts
@@ -128,7 +128,7 @@ describe("transcript projector", () => {
     ["chat", ["user", "intent:tool", "agent"]],
     ["intent", ["user", "intent:tool", "agent"]],
     ["tools", ["user", "tool", "agent"]],
-    ["activity", ["user", "tool", "think", "agent"]],
+    ["activity", ["user", "tool", "agent"]],
     ["full", ["user", "tool", "think", "agent"]],
   ] as const)("projects the cumulative %s content vector", (level, expectedIds) => {
     const model = threadWith(


### PR DESCRIPTION
Two changes:

1. Flip activity/full content vectors: activity now means tool calls with responses expanded (no reasoning). Full adds reasoning. Previously activity had collapsed bodies with reasoning visible, which didn't match the level name.

2. Make summary line clickable: the body trigger chevron is now an overlay on the summary line (same pattern as intent-less rows). Clicking anywhere on the summary text toggles the body, not just the small chevron.

7 test files updated for the expandByDefault change. Overflow harness switched to tools config so the notification disclosure fixture works correctly.

Gates: make test-web PASS, make test-web-browser PASS.