### PR TITLE
fix(web): present confirmed cancellation as neutral

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
@@ -143,7 +143,7 @@ test("confirmed cancellation recedes while expanded diagnostics retain physical 
   expect(screen.queryByText("warning")).toBeNull();
 
   await user.click(row);
-  expect(screen.getByTestId("notification-field-status").textContent).toContain("cancelled");
+  expect((await screen.findByTestId("notification-field-status")).textContent).toContain("cancelled");
   expect(screen.getByTestId("notification-field-reason").textContent).toContain("stopped_by_parent");
   expect(screen.getByTestId("notification-field-exit").textContent).toContain("-1");
   expect(screen.getByTestId("notification-raw").textContent).toContain('exit_code="-1"');

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
@@ -5,6 +5,8 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, expect, test } from "vitest";
 import { resetWorkspaceStoreForTests, workspaceStore } from "../../../../shell/workspace";
+import { makeTranscriptDisplayConfig } from "../../../../transcriptDisplay/config";
+import { TranscriptRenderProvider } from "../../../../transcriptDisplay/renderContext";
 import { resetDisclosureStoreForTests } from "../../../../widgets/disclosure/disclosureStore";
 import { NotificationCard } from "./NotificationCard";
 import type { ParsedNotification } from "./steeringClassify";
@@ -116,21 +118,22 @@ test("the secondary line surfaces the demoted metadata", () => {
   expect(screen.getByText("shell · exit 2 · boom")).toBeTruthy();
 });
 
-test("confirmed cancellation recedes while expanded diagnostics retain physical exit", async () => {
-  const user = userEvent.setup();
+test("confirmed cancellation recedes while expanded diagnostics retain physical exit", () => {
   render(
-    <NotificationCard
-      notification={notif({
-        title: "Job cancelled",
-        tone: "neutral",
-        secondary: "Run repository lint, vet, and test gates",
-        status: "cancelled",
-        reason: "stopped_by_parent",
-        exitCode: -1,
-        rawText:
-          '<job-notification status="cancelled" reason="stopped_by_parent" exit_code="-1">cancelled</job-notification>',
-      })}
-    />,
+    <TranscriptRenderProvider config={makeTranscriptDisplayConfig({ kind: "preset", level: "full" })}>
+      <NotificationCard
+        notification={notif({
+          title: "Job cancelled",
+          tone: "neutral",
+          secondary: "Run repository lint, vet, and test gates",
+          status: "cancelled",
+          reason: "stopped_by_parent",
+          exitCode: -1,
+          rawText:
+            '<job-notification status="cancelled" reason="stopped_by_parent" exit_code="-1">cancelled</job-notification>',
+        })}
+      />
+    </TranscriptRenderProvider>,
   );
 
   const row = screen.getByTestId("notification-card");
@@ -142,8 +145,7 @@ test("confirmed cancellation recedes while expanded diagnostics retain physical 
   expect(screen.queryByText("error")).toBeNull();
   expect(screen.queryByText("warning")).toBeNull();
 
-  await user.click(row);
-  expect((await screen.findByTestId("notification-field-status")).textContent).toContain("cancelled");
+  expect(screen.getByTestId("notification-field-status").textContent).toContain("cancelled");
   expect(screen.getByTestId("notification-field-reason").textContent).toContain("stopped_by_parent");
   expect(screen.getByTestId("notification-field-exit").textContent).toContain("-1");
   expect(screen.getByTestId("notification-raw").textContent).toContain('exit_code="-1"');

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
@@ -116,7 +116,8 @@ test("the secondary line surfaces the demoted metadata", () => {
   expect(screen.getByText("shell · exit 2 · boom")).toBeTruthy();
 });
 
-test("confirmed cancellation recedes while expanded diagnostics retain physical exit", () => {
+test("confirmed cancellation recedes while expanded diagnostics retain physical exit", async () => {
+  const user = userEvent.setup();
   render(
     <NotificationCard
       notification={notif({
@@ -141,7 +142,7 @@ test("confirmed cancellation recedes while expanded diagnostics retain physical 
   expect(screen.queryByText("error")).toBeNull();
   expect(screen.queryByText("warning")).toBeNull();
 
-  fireEvent.click(row);
+  await user.click(row);
   expect(screen.getByTestId("notification-field-status").textContent).toContain("cancelled");
   expect(screen.getByTestId("notification-field-reason").textContent).toContain("stopped_by_parent");
   expect(screen.getByTestId("notification-field-exit").textContent).toContain("-1");

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
@@ -116,6 +116,37 @@ test("the secondary line surfaces the demoted metadata", () => {
   expect(screen.getByText("shell · exit 2 · boom")).toBeTruthy();
 });
 
+test("confirmed cancellation recedes while expanded diagnostics retain physical exit", () => {
+  render(
+    <NotificationCard
+      notification={notif({
+        title: "Job cancelled",
+        tone: "neutral",
+        secondary: "Run repository lint, vet, and test gates",
+        status: "cancelled",
+        reason: "stopped_by_parent",
+        exitCode: -1,
+        rawText: '<job-notification status="cancelled" reason="stopped_by_parent" exit_code="-1">cancelled</job-notification>',
+      })}
+    />,
+  );
+
+  const row = screen.getByTestId("notification-card");
+  expect(row.getAttribute("data-tone")).toBe("neutral");
+  expect(row.textContent).toContain("Job cancelled");
+  expect(row.textContent).toContain("Run repository lint, vet, and test gates");
+  expect(row.textContent).not.toContain("exit -1");
+  expect(row.textContent).not.toContain("stopped_by_parent");
+  expect(screen.queryByText("error")).toBeNull();
+  expect(screen.queryByText("warning")).toBeNull();
+
+  fireEvent.click(row);
+  expect(screen.getByTestId("notification-field-status").textContent).toContain("cancelled");
+  expect(screen.getByTestId("notification-field-reason").textContent).toContain("stopped_by_parent");
+  expect(screen.getByTestId("notification-field-exit").textContent).toContain("-1");
+  expect(screen.getByTestId("notification-raw").textContent).toContain('exit_code="-1"');
+});
+
 test("the collapsed row prefers a job description to its generic job type", () => {
   render(<NotificationCard notification={notif({ secondary: "Inspect the workspace" })} />);
   expect(screen.getByTestId("notification-card").textContent).toContain("Inspect the workspace");

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
@@ -126,7 +126,8 @@ test("confirmed cancellation recedes while expanded diagnostics retain physical 
         status: "cancelled",
         reason: "stopped_by_parent",
         exitCode: -1,
-        rawText: '<job-notification status="cancelled" reason="stopped_by_parent" exit_code="-1">cancelled</job-notification>',
+        rawText:
+          '<job-notification status="cancelled" reason="stopped_by_parent" exit_code="-1">cancelled</job-notification>',
       })}
     />,
   );

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
@@ -220,7 +220,7 @@ Watch event triggered: file changed.
 test("an Observer callback parses as a notification", () => {
   const notifications = notificationsOf(
     parseSteeringNotifications(
-      "Observer callback:\nmessage: something happened\noutput: {\"message\":\"done\",\"data\":{\"status\":\"done\"}}",
+      'Observer callback:\nmessage: something happened\noutput: {"message":"done","data":{"status":"done"}}',
     ),
   );
   const n = notif(notifications, 0);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
@@ -151,6 +151,63 @@ Job j completed.
   expect(notif(notificationsOf(parseSteeringNotifications(block)), 0).tone).toBe("error");
 });
 
+test("confirmed parent cancellation is neutral and keeps signed diagnostics", () => {
+  const block = `<job-notification job_id="job_1" job_type="shell" status="cancelled" reason="stopped_by_parent" exit_code="-1" description="Run repository lint, vet, and test gates">
+Job job_1 cancelled.
+</job-notification>`;
+  expect(notif(notificationsOf(parseSteeringNotifications(block)), 0)).toMatchObject({
+    title: "Job cancelled",
+    tone: "neutral",
+    secondary: "Run repository lint, vet, and test gates",
+    status: "cancelled",
+    reason: "stopped_by_parent",
+    exitCode: -1,
+  });
+});
+
+test.each([
+  ["stopped", "stopped_by_parent", "-1", "warning", "shell · stopped_by_parent"],
+  ["stopped", "cancelled", "-1", "warning", "shell · cancelled"],
+  ["stopped", "run_timeout", "-1", "warning", "shell · run_timeout"],
+  ["failed", "killed_by_signal: terminated", "-1", "error", "shell · exit -1 · killed_by_signal: terminated"],
+  ["completed", "exit_zero", "7", "error", "shell · exit 7 · exit_zero"],
+  ["mystery", "", "7", "error", "shell · exit 7"],
+] as const)("maps %s/%s/exit %s to %s", (status, reason, exit, tone, secondary) => {
+  const block = `<job-notification job_id="job_matrix" job_type="shell" status="${status}" reason="${reason}" exit_code="${exit}">
+Job job_matrix ${status}.
+</job-notification>`;
+  expect(notif(notificationsOf(parseSteeringNotifications(block)), 0)).toMatchObject({ tone, secondary });
+});
+
+test("explicit failure keeps a neutral secondary without compacting malformed exit text", () => {
+  const block = `<job-notification job_id="job_bad_exit" job_type="shell" status="failed" reason="wait_failed" exit_code="7x">
+Job job_bad_exit failed.
+</job-notification>`;
+  expect(notif(notificationsOf(parseSteeringNotifications(block)), 0)).toMatchObject({
+    tone: "error",
+    secondary: "shell · wait_failed",
+    exitCode: undefined,
+  });
+});
+
+test("unknown malformed exit stays neutral", () => {
+  const block = `<job-notification job_id="job_unknown_exit" job_type="shell" status="mystery" exit_code="7x">
+Job job_unknown_exit mystery.
+</job-notification>`;
+  expect(notif(notificationsOf(parseSteeringNotifications(block)), 0)).toMatchObject({
+    tone: "neutral",
+    secondary: "shell",
+    exitCode: undefined,
+  });
+});
+
+test("blank status does not mask a failed event", () => {
+  const block = `<job-notification job_id="job_blank_status" job_type="shell" status="   " event="failed" exit_code="0">
+Job job_blank_status failed.
+</job-notification>`;
+  expect(notif(notificationsOf(parseSteeringNotifications(block)), 0).tone).toBe("error");
+});
+
 test("a job-less watch event classifies as a watch notification", () => {
   const block = `<job-notification job_id="" event="watch" job_type="" status="watch" reason="file changed" output_bytes="0">
 Watch event triggered: file changed.
@@ -162,9 +219,49 @@ Watch event triggered: file changed.
 
 test("an Observer callback parses as a notification", () => {
   const notifications = notificationsOf(
-    parseSteeringNotifications("Observer callback:\nmessage: something happened\noutput: details here"),
+    parseSteeringNotifications(
+      "Observer callback:\nmessage: something happened\noutput: {\"message\":\"done\",\"data\":{\"status\":\"done\"}}",
+    ),
   );
-  expect(notif(notifications, 0).title).toBe("Observer callback");
+  const n = notif(notifications, 0);
+  expect(n.title).toBe("Observer callback");
+  expect(n.tone).toBe("warning");
+});
+
+test("absent outer status/event with communicate cancelled and exit -1 stays neutral without compacting exit", () => {
+  const block = `<job-notification job_id="job_delegate_cancelled" job_type="delegate" exit_code="-1">
+Job job_delegate_cancelled reported.
+excerpt:
+{"message":"done","data":{"status":"cancelled"}}
+</job-notification>`;
+  expect(notif(notificationsOf(parseSteeringNotifications(block)), 0)).toMatchObject({
+    tone: "neutral",
+    secondary: "delegate",
+  });
+});
+
+test("absent outer status/event with communicate stopped and exit -1 warns without compacting exit", () => {
+  const block = `<job-notification job_id="job_delegate_stopped" job_type="delegate" exit_code="-1">
+Job job_delegate_stopped reported.
+excerpt:
+{"message":"done","data":{"status":"stopped"}}
+</job-notification>`;
+  expect(notif(notificationsOf(parseSteeringNotifications(block)), 0)).toMatchObject({
+    tone: "warning",
+    secondary: "delegate",
+  });
+});
+
+test("explicit outer cancelled plus communicate done stays neutral", () => {
+  const block = `<job-notification job_id="job_delegate_outer_cancelled" job_type="delegate" status="cancelled">
+Job job_delegate_outer_cancelled reported.
+excerpt:
+{"message":"done","data":{"status":"done"}}
+</job-notification>`;
+  expect(notif(notificationsOf(parseSteeringNotifications(block)), 0)).toMatchObject({
+    tone: "neutral",
+    secondary: "delegate",
+  });
 });
 
 test("an Observer callback with no output surfaces its message prose (not just the raw disclosure)", () => {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
@@ -215,6 +215,7 @@ Watch event triggered: file changed.
   const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
   expect(n.type).toBe("watch");
   expect(n.title).toBe("Watch triggered");
+  expect(n.tone).toBe("warning");
 });
 
 test("an Observer callback parses as a notification", () => {
@@ -358,6 +359,7 @@ excerpt:
   const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
   expect(n.message).toBe("**done** with the work");
   expect(n.concerns).toEqual(["watch the edge case"]);
+  expect(n.tone).toBe("warning");
 });
 
 // A delegate's communicate envelope rides the excerpt as body content, so

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts
@@ -75,6 +75,46 @@ function optionalNonNegativeInteger(attrs: Record<string, string>, key: string):
   return Number.isSafeInteger(value) && value >= 0 ? value : undefined;
 }
 
+type JobDisposition = "success" | "failure" | "cancelled" | "stopped" | "unknown";
+
+interface JobNotificationAnalysis {
+  disposition: JobDisposition;
+  exitCode?: number;
+}
+
+function optionalSignedInteger(raw: string | undefined): number | undefined {
+  const text = (raw ?? "").trim();
+  if (!/^-?\d+$/.test(text)) return undefined;
+  const value = Number(text);
+  return Number.isSafeInteger(value) ? value : undefined;
+}
+
+function analyzeJobNotification(
+  attrs: Record<string, string>,
+  communicate: CommunicateEnvelope | null,
+): JobNotificationAnalysis {
+  const outerStatus = (attrs.status ?? "").trim().toLowerCase();
+  const outerEvent = (attrs.event ?? "").trim().toLowerCase();
+  const communicateStatus = (communicate?.status ?? "").trim().toLowerCase();
+  const status = outerStatus || outerEvent || communicateStatus;
+  const exitCode = optionalSignedInteger(attrs.exit_code);
+
+  let disposition: JobDisposition = "unknown";
+  if (status === "failed" || status === "error" || status === "exhausted" || status.includes("fail")) {
+    disposition = "failure";
+  } else if (status === "cancelled") {
+    disposition = "cancelled";
+  } else if (status === "stopped") {
+    disposition = "stopped";
+  } else if (status === "completed" || status === "done") {
+    disposition = exitCode !== undefined && exitCode !== 0 ? "failure" : "success";
+  } else if (exitCode !== undefined && exitCode !== 0) {
+    disposition = "failure";
+  }
+
+  return exitCode === undefined ? { disposition } : { disposition, exitCode };
+}
+
 // A notification-text fragment in source order: either a raw
 // <job|delegate-notification> block (still unparsed - the caller classifies
 // it) or a trimmed span of text between/around blocks. Splitting into
@@ -228,6 +268,25 @@ function notificationTone(attrs: Record<string, string>, communicate: Communicat
   return "neutral";
 }
 
+function jobNotificationTone(
+  attrs: Record<string, string>,
+  communicate: CommunicateEnvelope | null,
+  analysis: JobNotificationAnalysis,
+): NotificationTone {
+  if (analysis.disposition === "failure") return "error";
+  const event = (attrs.event ?? "").trim().toLowerCase();
+  if (
+    (communicate?.concerns.length ?? 0) > 0 ||
+    analysis.disposition === "stopped" ||
+    event === "watch_send" ||
+    event === "watch"
+  ) {
+    return "warning";
+  }
+  if (analysis.disposition === "success") return "success";
+  return "neutral";
+}
+
 function titleForJobNotification(attrs: Record<string, string>, type: string): string {
   if (type === "watch-send") return "Watch delivered";
   if (type === "watch") return "Watch triggered";
@@ -236,13 +295,19 @@ function titleForJobNotification(attrs: Record<string, string>, type: string): s
   return `Job ${status}`;
 }
 
-function notificationSecondary(attrs: Record<string, string>, tone: NotificationTone, description: string): string {
+function notificationSecondary(
+  attrs: Record<string, string>,
+  tone: NotificationTone,
+  description: string,
+  analysis: JobNotificationAnalysis,
+): string {
   const bits: string[] = [];
   const type = (attrs.job_type ?? "").trim();
   if (description) bits.push(description);
   else if (type && type !== "job") bits.push(type);
-  const exit = (attrs.exit_code ?? "").trim();
-  if (exit && exit !== "0") bits.push(`exit ${exit}`);
+  if (analysis.disposition === "failure" && analysis.exitCode !== undefined && analysis.exitCode !== 0) {
+    bits.push(`exit ${analysis.exitCode}`);
+  }
   const reason = (attrs.reason ?? "").trim();
   if (reason && (tone === "error" || tone === "warning")) bits.push(reason);
   return bits.join(" · ");
@@ -268,21 +333,22 @@ function parseJobNotification(block: string): ParsedNotification | null {
   let type = "job";
   if ((attrs.event === "watch" || attrs.status === "watch") && !attrs.job_id) type = "watch";
   if (attrs.event === "watch_send") type = "watch-send";
-  const tone = notificationTone(attrs, communicate);
   const transcriptRef = isValidTranscriptRef(attrs.transcript_ref) ? attrs.transcript_ref : undefined;
   const description = decodeNotificationEntities(attrs.description ?? "").trim();
+  const analysis = analyzeJobNotification(attrs, communicate);
+  const tone = jobNotificationTone(attrs, communicate, analysis);
   return {
     type,
     title: titleForJobNotification(attrs, type),
     tone,
-    secondary: notificationSecondary(attrs, tone, description),
+    secondary: notificationSecondary(attrs, tone, description, analysis),
     jobId: attrs.job_id?.trim() || undefined,
     jobType: attrs.job_type?.trim() || undefined,
     description: description || undefined,
     status: attrs.status?.trim() || undefined,
     reason: attrs.reason?.trim() || undefined,
     outputBytes: optionalNonNegativeInteger(attrs, "output_bytes"),
-    exitCode: optionalNonNegativeInteger(attrs, "exit_code"),
+    exitCode: analysis.exitCode,
     transcriptRef,
     excerpt,
     message: communicate?.message || undefined,

--- a/docs/superpowers/plans/2026-09-01-job-cancellation-presentation-plan.md
+++ b/docs/superpowers/plans/2026-09-01-job-cancellation-presentation-plan.md
@@ -1,0 +1,393 @@
+# Job Cancellation Presentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render confirmed parent cancellation as neutral while preserving stopped attention, genuine failures, and complete diagnostics.
+
+**Architecture:** Keep the backend contract unchanged. Add one private job-notification analysis in `steeringClassify.ts`; parse authority and signed exit once, then reuse that result for job tone, summary, and typed metadata. Leave shared delegate/observer tone logic and live activity formatting unchanged.
+
+**Tech Stack:** TypeScript 6, React 19, Vitest 4, Testing Library, Biome.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-job-cancellation-presentation-design.md`
+
+## Global constraints
+
+- Change only the two documentation files and these frontend files:
+  - `cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts`
+  - `cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts`
+  - `cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx`
+- Do not change backend, protocol, generated, activity, CSS, or shared component files.
+- Explicit `cancelled` is neutral; every explicit `stopped` is warning; failure remains error.
+- Delegate, watch, concern, and historical observer-callback behavior must remain unchanged.
+- Tests are deterministic and use existing Chai-compatible assertions.
+- Never run `npm ci` in a shared worktree setup.
+
+---
+
+### Task 1: Bootstrap the isolated frontend worktree
+
+**Files:**
+- No tracked files.
+
+**Interfaces:**
+- Produces a valid shared `node_modules` symlink and verified frontend toolchain before any direct `npx` command.
+
+- [ ] **Step 1: Confirm worktree identity and cleanliness**
+
+```bash
+git branch --show-current
+git status --short
+git rev-parse --show-toplevel
+git rev-parse --path-format=absolute --git-common-dir
+```
+
+Expected: the implementation branch is active and the worktree contains only the two intended untracked documentation files copied from the reviewed draft.
+
+- [ ] **Step 2: Link the repository's one real frontend install**
+
+```bash
+main_checkout="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
+shared_modules="$main_checkout/cmd/evener-hub/frontend/node_modules"
+test -d "$shared_modules"
+ln -sfn "$shared_modules" cmd/evener-hub/frontend/node_modules
+```
+
+Expected: `test -d` and `ln -sfn` exit zero. Do not stage the ignored symlink.
+
+- [ ] **Step 3: Read target help and run preflight**
+
+```bash
+make help
+make web-preflight
+```
+
+Expected: both commands exit zero. Stop if dependency versions or generated frontend prerequisites do not match.
+
+---
+
+### Task 2: Specify job-notification analysis behavior
+
+**Files:**
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts`
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx`
+
+**Interfaces:**
+- Pins the private analyzer's externally visible result through `parseSteeringNotifications`.
+- Preserves existing `ParsedNotification` and `NotificationCard` public interfaces.
+
+- [ ] **Step 1: Add the exact cancellation and terminal matrix parser tests**
+
+Use the existing `notificationsOf` and `notif` helpers in `steeringClassify.test.ts`. Add:
+
+```ts
+test("confirmed parent cancellation is neutral and keeps signed diagnostics", () => {
+  const block = `<job-notification job_id="job_1" job_type="shell" status="cancelled" reason="stopped_by_parent" exit_code="-1" description="Run repository lint, vet, and test gates">
+Job job_1 cancelled.
+</job-notification>`;
+  expect(notif(notificationsOf(parseSteeringNotifications(block)), 0)).toMatchObject({
+    title: "Job cancelled",
+    tone: "neutral",
+    secondary: "Run repository lint, vet, and test gates",
+    status: "cancelled",
+    reason: "stopped_by_parent",
+    exitCode: -1,
+  });
+});
+
+test.each([
+  ["stopped", "stopped_by_parent", "-1", "warning", "shell · stopped_by_parent"],
+  ["stopped", "cancelled", "-1", "warning", "shell · cancelled"],
+  ["stopped", "run_timeout", "-1", "warning", "shell · run_timeout"],
+  ["failed", "killed_by_signal: terminated", "-1", "error", "shell · exit -1 · killed_by_signal: terminated"],
+  ["completed", "exit_zero", "7", "error", "shell · exit 7 · exit_zero"],
+  ["mystery", "", "7", "error", "shell · exit 7"],
+] as const)("maps %s/%s/exit %s to %s", (status, reason, exit, tone, secondary) => {
+  const block = `<job-notification job_id="job_matrix" job_type="shell" status="${status}" reason="${reason}" exit_code="${exit}">
+Job job_matrix ${status}.
+</job-notification>`;
+  expect(notif(notificationsOf(parseSteeringNotifications(block)), 0)).toMatchObject({ tone, secondary });
+});
+```
+
+Add focused cases for:
+
+```ts
+// Explicit failure remains error, but malformed exit is absent everywhere.
+status="failed" reason="wait_failed" exit_code="7x"
+// Unknown malformed exit is neutral.
+status="mystery" exit_code="7x"
+// Blank status must not mask a failed event.
+status="   " event="failed" exit_code="0"
+```
+
+For the first case assert `{ tone: "error", secondary: "shell · wait_failed", exitCode: undefined }`. For the second assert `{ tone: "neutral", secondary: "shell", exitCode: undefined }`. For the third assert `tone: "error"`.
+
+- [ ] **Step 2: Add authority and historical-reader regressions**
+
+Add job-notification cases proving:
+
+- absent outer status/event plus communicate `cancelled` and exit `-1` → neutral with no compact exit;
+- absent outer status/event plus communicate `stopped` and exit `-1` → warning with no compact exit;
+- explicit outer `cancelled` plus communicate `done` → neutral.
+
+Use `job_type="delegate"` so the existing parser reads the communicate envelope. Assert the complete tone and secondary values.
+
+Extend the existing observer-callback test with `tone: "warning"` for communicate `done`. Keep existing watch and concern warning assertions; add tone assertions only where absent.
+
+- [ ] **Step 3: Add the component presentation regression with supported matchers**
+
+In `NotificationCard.test.tsx`, use the existing `notif` factory:
+
+```ts
+test("confirmed cancellation recedes while expanded diagnostics retain physical exit", () => {
+  render(
+    <NotificationCard
+      notification={notif({
+        title: "Job cancelled",
+        tone: "neutral",
+        secondary: "Run repository lint, vet, and test gates",
+        status: "cancelled",
+        reason: "stopped_by_parent",
+        exitCode: -1,
+        rawText:
+          '<job-notification status="cancelled" reason="stopped_by_parent" exit_code="-1">cancelled</job-notification>',
+      })}
+    />,
+  );
+
+  const row = screen.getByTestId("notification-card");
+  expect(row.getAttribute("data-tone")).toBe("neutral");
+  expect(row.textContent).toContain("Job cancelled");
+  expect(row.textContent).toContain("Run repository lint, vet, and test gates");
+  expect(row.textContent).not.toContain("exit -1");
+  expect(row.textContent).not.toContain("stopped_by_parent");
+  expect(screen.queryByText("error")).toBeNull();
+  expect(screen.queryByText("warning")).toBeNull();
+
+  fireEvent.click(row);
+  expect(screen.getByTestId("notification-field-status").textContent).toContain("cancelled");
+  expect(screen.getByTestId("notification-field-reason").textContent).toContain("stopped_by_parent");
+  expect(screen.getByTestId("notification-field-exit").textContent).toContain("-1");
+  expect(screen.getByTestId("notification-raw").textContent).toContain('exit_code="-1"');
+});
+```
+
+- [ ] **Step 4: Run the focused tests and verify the behavioral red state**
+
+```bash
+cd cmd/evener-hub/frontend
+npx vitest run \
+  src/panes/session/transcript/messages/steeringClassify.test.ts \
+  src/panes/session/transcript/messages/NotificationCard.test.tsx \
+  --maxWorkers=1
+```
+
+Expected: parser cancellation/signed-exit assertions fail against current production behavior. The component regression may already pass because `NotificationCard` correctly renders the parsed model it receives; that is not the production failing boundary.
+
+- [ ] **Step 5: Commit tests and reviewed documentation**
+
+```bash
+git add \
+  docs/superpowers/specs/2026-09-01-job-cancellation-presentation-design.md \
+  docs/superpowers/plans/2026-09-01-job-cancellation-presentation-plan.md \
+  cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts \
+  cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
+git commit -m "test(web): specify job cancellation presentation"
+```
+
+---
+
+### Task 3: Analyze each job notification once
+
+**Files:**
+- Modify: `cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts`
+
+**Interfaces:**
+- Produces private `JobDisposition`, `JobNotificationAnalysis`, and `analyzeJobNotification` symbols.
+- Preserves exported types and functions.
+- Leaves the existing `notificationTone` implementation and all non-job callers unchanged.
+
+- [ ] **Step 1: Add exact signed-exit parsing and private analysis**
+
+Add near the existing integer parser:
+
+```ts
+type JobDisposition = "success" | "failure" | "cancelled" | "stopped" | "unknown";
+
+interface JobNotificationAnalysis {
+  disposition: JobDisposition;
+  exitCode?: number;
+}
+
+function optionalSignedInteger(raw: string | undefined): number | undefined {
+  const text = (raw ?? "").trim();
+  if (!/^-?\d+$/.test(text)) return undefined;
+  const value = Number(text);
+  return Number.isSafeInteger(value) ? value : undefined;
+}
+
+function analyzeJobNotification(
+  attrs: Record<string, string>,
+  communicate: CommunicateEnvelope | null,
+): JobNotificationAnalysis {
+  const outerStatus = (attrs.status ?? "").trim().toLowerCase();
+  const outerEvent = (attrs.event ?? "").trim().toLowerCase();
+  const communicateStatus = (communicate?.status ?? "").trim().toLowerCase();
+  const status = outerStatus || outerEvent || communicateStatus;
+  const exitCode = optionalSignedInteger(attrs.exit_code);
+
+  let disposition: JobDisposition = "unknown";
+  if (status === "failed" || status === "error" || status === "exhausted" || status.includes("fail")) {
+    disposition = "failure";
+  } else if (status === "cancelled") {
+    disposition = "cancelled";
+  } else if (status === "stopped") {
+    disposition = "stopped";
+  } else if (status === "completed" || status === "done") {
+    disposition = exitCode !== undefined && exitCode !== 0 ? "failure" : "success";
+  } else if (exitCode !== undefined && exitCode !== 0) {
+    disposition = "failure";
+  }
+
+  return exitCode === undefined ? { disposition } : { disposition, exitCode };
+}
+```
+
+Do not add `reason` to the analysis input or disposition rules.
+
+- [ ] **Step 2: Add job-only tone mapping**
+
+Add a private helper used only by `parseJobNotification`:
+
+```ts
+function jobNotificationTone(
+  attrs: Record<string, string>,
+  communicate: CommunicateEnvelope | null,
+  analysis: JobNotificationAnalysis,
+): NotificationTone {
+  if (analysis.disposition === "failure") return "error";
+  const event = (attrs.event ?? "").trim().toLowerCase();
+  if (
+    (communicate?.concerns.length ?? 0) > 0 ||
+    analysis.disposition === "stopped" ||
+    event === "watch_send" ||
+    event === "watch"
+  ) {
+    return "warning";
+  }
+  if (analysis.disposition === "success") return "success";
+  return "neutral";
+}
+```
+
+Do not change shared `notificationTone`; delegate notifications and observer callbacks continue to use it.
+
+- [ ] **Step 3: Make the compact summary consume the same analysis**
+
+Change `notificationSecondary` to receive `analysis: JobNotificationAnalysis`. Append exit only from the parsed result:
+
+```ts
+if (analysis.disposition === "failure" && analysis.exitCode !== undefined && analysis.exitCode !== 0) {
+  bits.push(`exit ${analysis.exitCode}`);
+}
+```
+
+Keep the existing reason rule: reason appears only for error or warning tones.
+
+- [ ] **Step 4: Wire one analysis through `parseJobNotification`**
+
+After parsing communicate/description, compute once:
+
+```ts
+const analysis = analyzeJobNotification(attrs, communicate);
+const tone = jobNotificationTone(attrs, communicate, analysis);
+```
+
+Use that same object for:
+
+```ts
+secondary: notificationSecondary(attrs, tone, description, analysis),
+exitCode: analysis.exitCode,
+```
+
+Remove the old call to shared `notificationTone` from this parser only. Keep `optionalNonNegativeInteger(attrs, "output_bytes")` unchanged.
+
+- [ ] **Step 5: Format all touched frontend files before final focused verification**
+
+```bash
+cd cmd/evener-hub/frontend
+npx biome check --write \
+  src/panes/session/transcript/messages/steeringClassify.ts \
+  src/panes/session/transcript/messages/steeringClassify.test.ts \
+  src/panes/session/transcript/messages/NotificationCard.test.tsx
+```
+
+Expected: exit zero. Inspect every rewrite.
+
+- [ ] **Step 6: Run the focused green tests**
+
+```bash
+cd cmd/evener-hub/frontend
+npx vitest run \
+  src/panes/session/transcript/messages/steeringClassify.test.ts \
+  src/panes/session/transcript/messages/NotificationCard.test.tsx \
+  --maxWorkers=1
+```
+
+Expected: both files pass with zero failures.
+
+- [ ] **Step 7: Commit the implementation**
+
+```bash
+git add \
+  cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts \
+  cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts \
+  cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
+git commit -m "fix(web): present confirmed cancellation as neutral"
+```
+
+---
+
+### Task 4: Run canonical gates and audit scope
+
+**Files:**
+- Verify only the five tracked paths named in Global constraints.
+
+**Interfaces:**
+- Produces final evidence that focused behavior and repository gates pass without scope expansion.
+
+- [ ] **Step 1: Run the canonical frontend gate**
+
+```bash
+make test-web
+```
+
+Expected: frontend unit tests, TypeScript, and Biome exit zero.
+
+- [ ] **Step 2: Run repository gates**
+
+```bash
+make lint
+make vet
+make test
+```
+
+Expected: every command exits zero. Diagnose any failure; do not suppress or weaken a check.
+
+- [ ] **Step 3: Audit the exact branch diff**
+
+Capture the worktree's base commit before implementation as `BASE`. Then run:
+
+```bash
+git diff --check "$BASE"..HEAD
+git diff --name-only "$BASE"..HEAD
+git status --short
+git diff "$BASE"..HEAD -- \
+  docs/superpowers/specs/2026-09-01-job-cancellation-presentation-design.md \
+  docs/superpowers/plans/2026-09-01-job-cancellation-presentation-plan.md \
+  cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts \
+  cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts \
+  cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
+```
+
+Expected: no whitespace errors; only the five named paths changed; worktree clean; exact cancellation neutral; every stopped warning; failures error; signed exit preserved in expanded/raw diagnostics; observer/delegate/watch behavior unchanged.

--- a/docs/superpowers/specs/2026-09-01-job-cancellation-presentation-design.md
+++ b/docs/superpowers/specs/2026-09-01-job-cancellation-presentation-design.md
@@ -1,0 +1,175 @@
+# Job Cancellation Presentation
+
+## Status
+
+Approved after competitive adversarial review and simplify-code review. This is a frontend transcript-reader change. Backend lifecycle and persistence semantics remain unchanged.
+
+## Problem
+
+A confirmed parent-driven shell stop is serialized as:
+
+```text
+status="cancelled" reason="stopped_by_parent" exit_code="-1"
+```
+
+`status` is the logical lifecycle result. `exit_code` is the physical process wait result after termination. `steeringClassify.ts` currently checks every nonzero raw exit before it checks status, so this coherent cancellation renders as a red error:
+
+```text
+error  Job cancelled  Run repository lint, vet, and test gates · exit -1 · stopped_by_parent
+```
+
+The reader also treats `-1` inconsistently: the compact summary displays it from the raw attribute, while `optionalNonNegativeInteger` rejects it from expanded typed metadata.
+
+## Existing contracts
+
+- `agent/internal/jobstore/record.go` defines `completed`, `failed`, `cancelled`, `stopped`, and `exhausted` as distinct terminal statuses.
+- `agent/job_shell.go` gives an accepted stop precedence over timeout, wait error, signal death, and exit code while retaining the physical wait result.
+- `docs/job-control.md` makes status the primary branch field. `cancelled` means an intentional, confirmed stop. `stopped` means work did not complete and Evener could not attribute it to normal failure or confirmed cancellation.
+- Activity and task surfaces already avoid treating cancellation as failure. They have separate live/backend authority and are outside this change.
+- `NotificationCard` reserves amber for attention and red for failure; success and neutral notifications recede without a chip.
+
+## Goals
+
+1. Interpret job-notification lifecycle status before physical exit code.
+2. Render explicit `cancelled` as neutral settled non-success.
+3. Keep every explicit `stopped` outcome as warning/attention.
+4. Keep explicit and compatibility-derived failures red.
+5. Parse status authority and signed exit once per job notification, then reuse that analysis for tone, summary, and metadata.
+6. Preserve signed exit, reason, and raw text in expanded diagnostics.
+7. Preserve historical delegate, watch, concern, and observer-callback behavior.
+
+## Non-goals
+
+- Do not change backend statuses, reasons, signaling, persistence, notification markup, AppWire, generated files, or activity projection.
+- Do not add a backend tone or other UI-specific field.
+- Do not treat cancellation as success.
+- Do not change activity, task, subagent, rail, CSS, or generic steering behavior.
+- Do not remove raw evidence.
+
+## Ownership and implementation boundary
+
+Backend status, reason, and exit code remain authoritative facts. Historical transcript compatibility belongs to the transcript parser, not to live activity formatting.
+
+Add a private, React-free analysis inside `steeringClassify.ts`, adjacent to `parseJobNotification`:
+
+```ts
+type JobDisposition = "success" | "failure" | "cancelled" | "stopped" | "unknown";
+
+interface JobNotificationAnalysis {
+  disposition: JobDisposition;
+  exitCode?: number;
+}
+
+function analyzeJobNotification(
+  attrs: Record<string, string>,
+  communicate: CommunicateEnvelope | null,
+): JobNotificationAnalysis;
+```
+
+The analyzer:
+
+1. trims and lowercases each candidate before selection;
+2. selects the first nonempty value from outer `status`, outer `event`, then communicate status;
+3. parses `exit_code` once as an exact signed base-10 safe integer;
+4. classifies from normalized status plus parsed exit.
+
+`reason` is preserved as metadata and summary copy but does not determine disposition. This follows the status-first contract and keeps every explicit `stopped` outcome distinct from confirmed `cancelled`.
+
+The existing shared `notificationTone` remains unchanged for delegate notifications and durable observer-callback replay. Job-specific authority and disposition mapping stay inside `parseJobNotification`, preventing observer events from masking communicate status.
+
+## Classification contract
+
+| Authoritative status | Parsed exit | Disposition | Tone |
+|---|---:|---|---|
+| `failed`, `error`, `exhausted`, or historical status containing `fail` | any | `failure` | error |
+| `cancelled` | any | `cancelled` | neutral |
+| `stopped` | any | `stopped` | warning |
+| `completed` or `done` | absent or `0` | `success` | success |
+| `completed` or `done` | nonzero | `failure` | error |
+| absent or unknown | nonzero | `failure` | error |
+| absent or unknown | absent or `0` | `unknown` | neutral |
+
+Explicit `cancelled` and `stopped` always outrank exit code. `cancelled + stopped_by_parent + -1` is neutral cancellation. `stopped + stopped_by_parent + -1` remains warning because status says cancellation was not confirmed.
+
+A malformed exit is absent. It never appears in typed metadata or compact summary. An explicit failure status still produces error tone when its exit attribute is malformed.
+
+## Job-notification presentation
+
+`parseJobNotification` computes one `JobNotificationAnalysis` and uses it for all job-specific consumers.
+
+### Tone
+
+- failure → `error`;
+- stopped, watch/watch-send, or communicate concerns → `warning`;
+- success → `success`;
+- cancelled or unknown → `neutral`.
+
+Watch and concern rules remain unchanged.
+
+### Compact summary
+
+1. Keep decoded description, falling back to a non-generic job type.
+2. Show `exit N` only when disposition is failure and the one parsed exit is defined and nonzero.
+3. Show reason only for error or warning tones.
+4. Confirmed cancellation therefore shows only the description; it omits `exit -1` and `stopped_by_parent`.
+5. A stopped timeout shows `run_timeout` but not its termination sentinel.
+6. A genuine signal/nonzero failure may show its parsed exit and reason.
+
+The title remains `Job cancelled`.
+
+### Expanded and raw diagnostics
+
+Keep `optionalNonNegativeInteger` for nonnegative counters such as `output_bytes`. Assign `ParsedNotification.exitCode` from the analyzer's signed value. `NotificationMetadata` already accepts negative numbers, so expanded details show `Exit code -1`. Raw notification text remains unchanged.
+
+## Compatibility
+
+- Missing or unknown status retains nonzero-exit failure fallback.
+- Historical `completed + nonzero` remains error.
+- Blank outer status does not mask a meaningful event or communicate status.
+- For job notifications, explicit outer status/event outranks communicate status.
+- Delegate notifications retain current shared tone behavior.
+- Historical observer callbacks retain communicate-first success detection and success-to-warning coercion.
+- Watch, watch-send, concerns, malformed blocks, and success behavior remain unchanged.
+- No wire negotiation or migration is required.
+
+## Deterministic tests
+
+Extend `steeringClassify.test.ts` with:
+
+- exact `cancelled/stopped_by_parent/-1` → neutral, description-only summary, typed exit `-1`;
+- every explicit `stopped`, including `stopped_by_parent`, `cancelled`, and `run_timeout` → warning without compact sentinel;
+- signal/nonzero/wait-style failure → error with parsed exit and reason;
+- completed/nonzero and missing-status/nonzero compatibility → error;
+- explicit failed + malformed exit → error, no compact exit, no typed exit;
+- unknown + malformed exit → neutral;
+- whitespace-only status + failed event → error;
+- absent outer status + communicate cancelled/stopped → consistent tone and summary;
+- explicit outer cancelled + communicate done → outer status wins;
+- historical observer callback with communicate done → warning;
+- existing watch and concern tones remain warning.
+
+Extend `NotificationCard.test.tsx` using existing Chai-compatible idioms (`getAttribute`, `textContent`, truthiness, and null checks). Assert that a neutral cancelled card:
+
+- has `data-tone="neutral"` and no chip;
+- keeps title and description in the collapsed row;
+- omits cancellation sentinel and routine reason while collapsed;
+- shows Status, Reason, and signed Exit code after expansion;
+- preserves the raw block.
+
+## Acceptance criteria
+
+1. The observed confirmed parent cancellation renders neutral with no colored chip.
+2. Its collapsed row contains `Job cancelled` and its description, not `exit -1` or `stopped_by_parent`.
+3. Expanded metadata and raw disclosure retain status, reason, and signed exit.
+4. Every explicit stopped outcome renders warning.
+5. Explicit failures, exhaustion, signal failures, fallback nonzero exits, and contradictory completed/nonzero payloads render error.
+6. Tone, summary, and metadata consume one normalized analysis and one parsed exit.
+7. Delegate, watch, concern, success, observer-callback, and malformed-notification behavior does not regress.
+8. Touched frontend files pass Biome, focused tests pass, and `make test-web`, `make lint`, `make vet`, and `make test` exit zero.
+9. No backend, protocol, generated, activity, or CSS files change.
+
+## Review resolution
+
+Accepted review corrections: keep `stopped` distinct from `cancelled`; scope outer-first authority to job notifications; normalize candidates before selection; parse and classify once; reject malformed compact exits; use supported test matchers; bootstrap worktree dependencies before `npx`; format before final focused tests and commits.
+
+The proposal to reconcile or change backend activity outcome handling was rejected as outside this defect. The stronger altitude correction was applied instead: activity remains untouched, and historical compatibility analysis is private to the transcript reader.


### PR DESCRIPTION
## Summary
- classify job notifications from authoritative lifecycle status before physical exit code
- render confirmed cancellation as neutral while keeping stopped outcomes warning and failures error
- preserve signed exit/reason/raw diagnostics and historical delegate, watch, concern, and observer behavior
- document the reviewed design and implementation plan

## Testing
- focused Vitest: 57/57 passed
- `make test-web`
- `make lint`
- `make vet`
- `make test`