### PR TITLE
feat(agent): seed delegate task lists; the brief parameter is prompt

### DIFF
--- a/agent/builtin_agents_test.go
+++ b/agent/builtin_agents_test.go
@@ -574,7 +574,7 @@ func TestSpawnAgent_DefaultSubagentGetsComposedPrompt(t *testing.T) {
 	if !strings.Contains(subagentSystemPrompt, "Delegated task limits") {
 		t.Error("default subagent prompt should contain shared delegated-task guidance")
 	}
-	if !strings.Contains(subagentSystemPrompt, "focused subagent") {
+	if !strings.Contains(subagentSystemPrompt, "one delegated unit of work") {
 		t.Error("default subagent prompt should contain subagent persona instructions")
 	}
 }

--- a/agent/delegate_legacy_dormancy_test.go
+++ b/agent/delegate_legacy_dormancy_test.go
@@ -41,7 +41,7 @@ func TestDelegateLegacyDormancy_NoDelegateJobRecordCanBeCreated(t *testing.T) {
 	call := root.reg.ExecuteCall(context.Background(), root.currentEnv(), llm.ToolCallData{
 		ID:        "legacy-dormancy-create",
 		Name:      "delegate",
-		Arguments: json.RawMessage(`{"task":"prove stable-only creation"}`),
+		Arguments: json.RawMessage(`{"prompt":"prove stable-only creation"}`),
 	})
 	if call.IsError {
 		t.Fatalf("registered delegate returned transport error: %s", call.Output)

--- a/agent/delegate_resource_create_test.go
+++ b/agent/delegate_resource_create_test.go
@@ -212,7 +212,7 @@ func TestDelegateResourceCreate_RegisteredPostCommitFailureRetainsStableIdentity
 		}
 		return nil
 	}
-	raw, err := json.Marshal(map[string]any{"task": "retain stable identity after oversized construction failure"})
+	raw, err := json.Marshal(map[string]any{"prompt": "retain stable identity after oversized construction failure"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,7 +291,7 @@ func TestDelegateResourceCreate_RegisteredResultPreservesWorktreeAndModelFallbac
 		ID:   "registered-create-metadata",
 		Name: "delegate",
 		Arguments: json.RawMessage(`{
-			"task":"preserve creation metadata",
+			"prompt":"preserve creation metadata",
 			"agent_type":"reviewer",
 			"isolation":"worktree"
 		}`),
@@ -1543,7 +1543,7 @@ func TestDelegateResourceCreate_RegisteredRejectsCreationMaxWait(t *testing.T) {
 		t.Fatal(err)
 	}
 	raw, err := json.Marshal(map[string]any{
-		"task":        "reject creation wait",
+		"prompt":      "reject creation wait",
 		"max_wait_ms": 1,
 	})
 	if err != nil {
@@ -1657,7 +1657,7 @@ func TestDelegateResourceCreate_RegisteredNestedCreateUsesCurrentLease(t *testin
 
 func executeTask6RegisteredDelegate(ctx context.Context, t *testing.T, session *Session, task string, allowance int) map[string]any {
 	t.Helper()
-	arguments := map[string]any{"task": task}
+	arguments := map[string]any{"prompt": task}
 	if allowance != 0 {
 		arguments["delegation_allowance"] = allowance
 	}

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -1138,6 +1138,11 @@ func (runtime delegateRuntime) create(ctx context.Context, args delegateArgs) de
 	if isolationName != "" && isolationName != "worktree" {
 		return delegateStartFailed(fmt.Errorf("invalid_request: isolation %q is not supported (expected \"worktree\")", isolationName))
 	}
+	if len(args.TaskList) > 0 && s.cfg.ShareTasksWithChildren {
+		// A shared store already has the parent's tasks and is never
+		// re-seeded, so the items would vanish; say so instead.
+		return delegateStartFailed(errors.New("invalid_request: task_list cannot seed a delegate that shares your task store; add the steps to your own task_list instead"))
+	}
 	if strings.TrimSpace(s.stateDir) == "" {
 		return delegateStartFailed(errors.New("delegate creation requires a durable state directory"))
 	}

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -1286,7 +1286,7 @@ func (s *Session) stableDelegateEffectiveToolNameCeiling(selection subagentModel
 	return stableDelegateToolNameCeiling(s.reg, s.resultToolName(), allTools, allowedTools, deniedTools, args.DelegationAllowance > 0, args.WatchParent, isolationName)
 }
 
-func (runtime delegateRuntime) describe(ctx context.Context, args delegateArgs, task, isolationName string, requestedSandbox *sandbox.SandboxPolicy, selection subagentModelSelection, toolNameCeiling []string) (delegatestore.Descriptor, identifier.Project, error) {
+func (runtime delegateRuntime) describe(ctx context.Context, args delegateArgs, brief, isolationName string, requestedSandbox *sandbox.SandboxPolicy, selection subagentModelSelection, toolNameCeiling []string) (delegatestore.Descriptor, identifier.Project, error) {
 	s := runtime.owner
 	s.mu.Lock()
 	childConfig := s.cfg.toSnapshot().Clone()
@@ -1348,8 +1348,8 @@ func (runtime delegateRuntime) describe(ctx context.Context, args delegateArgs, 
 	}
 	descriptor := delegatestore.Descriptor{
 		VisibleSessionID:              s.id,
-		Task:                          task,
-		Description:                   task,
+		Task:                          brief,
+		Description:                   brief,
 		AgentType:                     agentType,
 		RequestedModel:                selection.requestedModel,
 		ResolvedProfileID:             selection.profile.ID(),
@@ -1370,9 +1370,11 @@ func (runtime delegateRuntime) describe(ctx context.Context, args delegateArgs, 
 		Provenance:                    s.activeCausalProvenance(),
 		Resumable:                     true,
 	}
+	var roleTasks []task.TaskTemplate
 	if selection.agent != nil {
-		descriptor.TaskTemplates = append(descriptor.TaskTemplates, selection.agent.Tasks...)
+		roleTasks = selection.agent.Tasks
 	}
+	descriptor.TaskTemplates = task.ExpandParentTasks(roleTasks, args.TaskList)
 	if callID, ok := ctx.Value(ctxToolCallID).(string); ok {
 		descriptor.OriginToolCallID = callID
 	}

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -1132,7 +1132,7 @@ func (runtime delegateRuntime) create(ctx context.Context, args delegateArgs) de
 	}
 	task := strings.TrimSpace(args.Task)
 	if task == "" {
-		return delegateStartFailed(errors.New("invalid_request: task is required"))
+		return delegateStartFailed(errors.New("invalid_request: prompt is required"))
 	}
 	isolationName := strings.TrimSpace(args.Isolation)
 	if isolationName != "" && isolationName != "worktree" {

--- a/agent/delegate_schema_test.go
+++ b/agent/delegate_schema_test.go
@@ -28,8 +28,8 @@ func TestDelegateAllowanceParamElidedWhenNoOp(t *testing.T) {
 			if !ok {
 				continue
 			}
-			// Identify delegate by its signature params, independent of wire rename.
-			if _, hasTask := props["task"]; hasTask {
+			// Identify delegate by its signature params.
+			if _, hasPrompt := props["prompt"]; hasPrompt {
 				if _, hasAgentType := props["agent_type"]; hasAgentType {
 					return props
 				}

--- a/agent/delegate_shared_workspace_test.go
+++ b/agent/delegate_shared_workspace_test.go
@@ -168,7 +168,7 @@ func TestCreateDelegateSharedWorkspaceAdvisory(t *testing.T) {
 	adapter.awaitRun(t)
 
 	// The tool projection must surface the advisory to the model, once.
-	raw, err := stableDelegateCreateTool(context.Background(), root, map[string]any{"task": "third in the shared workspace"}, 8192)
+	raw, err := stableDelegateCreateTool(context.Background(), root, map[string]any{"prompt": "third in the shared workspace"}, 8192)
 	if err != nil {
 		t.Fatalf("delegate tool: %v", err)
 	}

--- a/agent/delegate_task_list_test.go
+++ b/agent/delegate_task_list_test.go
@@ -154,3 +154,18 @@ func TestCreateDelegate_SubagentDelegatesOnlyWhenGranted(t *testing.T) {
 		})
 	}
 }
+
+// A delegate that shares its parent's task store cannot be seeded with its
+// own task_list: PopulateFromTemplates is a no-op on a non-empty store, so the
+// items would vanish silently. Refuse at creation instead.
+func TestCreateDelegate_TaskListRejectedWhenSharingTaskStore(t *testing.T) {
+	root, _, _ := newDelegateResourceBootstrapSession(t)
+	root.cfg.ShareTasksWithChildren = true
+	result := root.createDelegate(context.Background(), delegateArgs{Task: "brief", TaskList: []taskpkg.TaskTemplate{{Title: "inspect", Prompt: "read the spec"}}})
+	if result.Err == nil || !strings.Contains(result.Err.Error(), "invalid_request") || !strings.Contains(result.Err.Error(), "task_list") {
+		t.Fatalf("createDelegate with task_list on a shared store: err = %v, want invalid_request naming task_list", result.Err)
+	}
+	if plain := root.createDelegate(context.Background(), delegateArgs{Task: "brief"}); plain.Err != nil {
+		t.Fatalf("createDelegate without task_list on a shared store: %v", plain.Err)
+	}
+}

--- a/agent/delegate_task_list_test.go
+++ b/agent/delegate_task_list_test.go
@@ -119,7 +119,7 @@ func TestBuiltinAgents_SubagentCarriesDelegationTools(t *testing.T) {
 	for _, tool := range agents["subagent"].Tools {
 		have[tool] = true
 	}
-	for _, want := range []string{"delegate", "delegate_send", "job_status", "job_watch", "job_stop", "job_list", "read_transcript"} {
+	for _, want := range []string{"delegate", "delegate_send", "job_status", "job_stop", "job_list", "read_transcript"} {
 		if !have[want] {
 			t.Errorf("subagent role missing tool %q", want)
 		}
@@ -148,8 +148,8 @@ func TestCreateDelegate_SubagentDelegatesOnlyWhenGranted(t *testing.T) {
 			if names["delegate"] != tc.want {
 				t.Errorf("child has delegate tool = %v, want %v (allowance %d)", names["delegate"], tc.want, tc.allowance)
 			}
-			if tc.want && !names["job_watch"] {
-				t.Error("granted subagent should also have job_watch to supervise its own delegates")
+			if names["job_watch"] != tc.want {
+				t.Errorf("child has job_watch = %v, want %v: a granted subagent supervises its delegates with it, a leaf does not get it", names["job_watch"], tc.want)
 			}
 		})
 	}

--- a/agent/delegate_task_list_test.go
+++ b/agent/delegate_task_list_test.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	taskpkg "primeradiant.com/evener/agent/task"
+)
+
+// The delegate brief parameter is `prompt`; `task_list` seeds the delegate's
+// task list. Both decode from the raw tool args.
+func TestDecodeDelegateArgs_PromptAndTaskList(t *testing.T) {
+	a, err := decodeDelegateArgs(map[string]any{
+		"prompt": "do work",
+		"task_list": []any{
+			map[string]any{"title": "inspect", "prompt": "read the spec"},
+			map[string]any{"title": "verify", "prompt": "run the check", "reasoning_effort": "low", "type": "verify"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if a.Task != "do work" {
+		t.Fatalf("prompt decoded as %q", a.Task)
+	}
+	want := []taskpkg.TaskTemplate{
+		{Title: "inspect", Prompt: "read the spec"},
+		{Title: "verify", Prompt: "run the check", ReasoningEffort: "low", Type: "verify"},
+	}
+	if len(a.TaskList) != len(want) {
+		t.Fatalf("task_list = %+v, want %+v", a.TaskList, want)
+	}
+	for i := range want {
+		if a.TaskList[i] != want[i] {
+			t.Errorf("task_list[%d] = %+v, want %+v", i, a.TaskList[i], want[i])
+		}
+	}
+}
+
+func TestDecodeDelegateArgs_TaskListRejectsMalformed(t *testing.T) {
+	cases := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"not an array", map[string]any{"prompt": "p", "task_list": "step one"}, "task_list must be an array"},
+		{"item not an object", map[string]any{"prompt": "p", "task_list": []any{"step one"}}, "task_list[0] must be an object"},
+		{"missing prompt", map[string]any{"prompt": "p", "task_list": []any{map[string]any{"title": "inspect"}}}, "task_list[0].prompt is required"},
+		{"missing title", map[string]any{"prompt": "p", "task_list": []any{map[string]any{"prompt": "read"}}}, "task_list[0].title is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := decodeDelegateArgs(tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// The parent's task_list is frozen into the delegate descriptor at creation,
+// so launch and every later resume seed the child's task list from it.
+func TestCreateDelegate_TaskListFreezesIntoDescriptor(t *testing.T) {
+	root, _, _ := newDelegateResourceBootstrapSession(t)
+	parent := []taskpkg.TaskTemplate{
+		{Title: "inspect", Prompt: "read the spec"},
+		{Title: "verify", Prompt: "run the check", Type: "verify"},
+	}
+	result := root.createDelegate(context.Background(), delegateArgs{Task: "brief", TaskList: parent})
+	if result.Err != nil {
+		t.Fatalf("createDelegate: %v", result.Err)
+	}
+	root.delegateController.mu.Lock()
+	aggregate := root.delegateController.durable[result.DelegateID]
+	live := root.delegateController.live[result.DelegateID]
+	root.delegateController.mu.Unlock()
+	if aggregate == nil {
+		t.Fatal("no durable aggregate for the created delegate")
+	}
+	got := aggregate.Descriptor.TaskTemplates
+	if len(got) != 2 || got[0].Title != "inspect" || got[1].Title != "verify" || got[1].Type != "verify" {
+		t.Fatalf("descriptor task templates = %+v, want the parent's two tasks", got)
+	}
+	if live == nil || live.binding == nil || live.binding.runtime == nil {
+		t.Fatal("no live child session for the created delegate")
+	}
+	tasks := live.binding.runtime.getOrCreateTaskStore().View()
+	if len(tasks) != 2 || tasks[0].Description != "inspect" || tasks[1].Description != "verify" {
+		t.Fatalf("child task list = %+v, want the parent's two tasks", tasks)
+	}
+	if tasks[0].Status != taskpkg.TaskInProgress || tasks[1].Status != taskpkg.TaskOpen {
+		t.Errorf("child task statuses = %q,%q, want in_progress then open", tasks[0].Status, tasks[1].Status)
+	}
+}
+
+// An empty brief is an error at decode time: a delegate started without input
+// sits idle, which hangs whoever waits on it.
+func TestDecodeDelegateArgs_RejectsEmptyPrompt(t *testing.T) {
+	for _, args := range []map[string]any{{}, {"prompt": "   "}, {"task": "old key"}} {
+		_, err := decodeDelegateArgs(args)
+		if err == nil || !strings.Contains(err.Error(), "invalid_request: prompt is required") {
+			t.Errorf("decode(%v) err = %v, want prompt-required invalid_request", args, err)
+		}
+	}
+}

--- a/agent/delegate_task_list_test.go
+++ b/agent/delegate_task_list_test.go
@@ -106,3 +106,51 @@ func TestDecodeDelegateArgs_RejectsEmptyPrompt(t *testing.T) {
 		}
 	}
 }
+
+// The subagent role carries the delegate and job-control tools so that the
+// parent's delegation_allowance decides whether it may delegate: granted, the
+// child registers delegate; not granted, it stays a leaf.
+func TestBuiltinAgents_SubagentCarriesDelegationTools(t *testing.T) {
+	agents, err := builtinAgents()
+	if err != nil {
+		t.Fatalf("builtinAgents: %v", err)
+	}
+	have := map[string]bool{}
+	for _, tool := range agents["subagent"].Tools {
+		have[tool] = true
+	}
+	for _, want := range []string{"delegate", "delegate_send", "job_status", "job_watch", "job_stop", "job_list", "read_transcript"} {
+		if !have[want] {
+			t.Errorf("subagent role missing tool %q", want)
+		}
+	}
+}
+
+func TestCreateDelegate_SubagentDelegatesOnlyWhenGranted(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		allowance int
+		want      bool
+	}{{"granted", 1, true}, {"leaf", 0, false}} {
+		t.Run(tc.name, func(t *testing.T) {
+			root, _, _ := newDelegateResourceBootstrapSession(t)
+			result := root.createDelegate(context.Background(), delegateArgs{Task: "brief", AgentType: "subagent", DelegationAllowance: tc.allowance})
+			if result.Err != nil {
+				t.Fatalf("createDelegate: %v", result.Err)
+			}
+			root.delegateController.mu.Lock()
+			live := root.delegateController.live[result.DelegateID]
+			root.delegateController.mu.Unlock()
+			if live == nil || live.binding == nil || live.binding.runtime == nil {
+				t.Fatal("no live child session")
+			}
+			names := live.binding.runtime.reg.RegisteredNames()
+			if names["delegate"] != tc.want {
+				t.Errorf("child has delegate tool = %v, want %v (allowance %d)", names["delegate"], tc.want, tc.allowance)
+			}
+			if tc.want && !names["job_watch"] {
+				t.Error("granted subagent should also have job_watch to supervise its own delegates")
+			}
+		})
+	}
+}

--- a/agent/delegate_task_list_test.go
+++ b/agent/delegate_task_list_test.go
@@ -48,6 +48,8 @@ func TestDecodeDelegateArgs_TaskListRejectsMalformed(t *testing.T) {
 		{"item not an object", map[string]any{"prompt": "p", "task_list": []any{"step one"}}, "task_list[0] must be an object"},
 		{"missing prompt", map[string]any{"prompt": "p", "task_list": []any{map[string]any{"title": "inspect"}}}, "task_list[0].prompt is required"},
 		{"missing title", map[string]any{"prompt": "p", "task_list": []any{map[string]any{"prompt": "read"}}}, "task_list[0].title is required"},
+		{"bad reasoning_effort", map[string]any{"prompt": "p", "task_list": []any{map[string]any{"title": "t", "prompt": "read", "reasoning_effort": "xhigh"}}}, "task_list[0].reasoning_effort must be one of low, medium, high"},
+		{"bad type", map[string]any{"prompt": "p", "task_list": []any{map[string]any{"title": "t", "prompt": "read", "type": "bogus"}}}, "task_list[0].type must be one of research, implement, verify, fix"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/agent/events_queue_covtest_test.go
+++ b/agent/events_queue_covtest_test.go
@@ -310,20 +310,20 @@ func TestCovSessionRunningJobIDs_NilSession(t *testing.T) {
 // (session_tools_jobs.go line 345).
 func TestCovDecodeDelegateArgs(t *testing.T) {
 	// sandbox_net non-bool.
-	_, err := decodeDelegateArgs(map[string]any{"sandbox_net": "yes"})
+	_, err := decodeDelegateArgs(map[string]any{"prompt": "p", "sandbox_net": "yes"})
 	if err == nil || !strings.Contains(err.Error(), "sandbox_net must be a JSON boolean") {
 		t.Fatalf("expected sandbox_net error, got %v", err)
 	}
 
 	// Negative delegation_allowance.
-	_, err = decodeDelegateArgs(map[string]any{"delegation_allowance": -1})
+	_, err = decodeDelegateArgs(map[string]any{"prompt": "p", "delegation_allowance": -1})
 	if err == nil || !strings.Contains(err.Error(), "delegation_allowance must be non-negative") {
 		t.Fatalf("expected delegation_allowance error, got %v", err)
 	}
 
 	// Valid args.
 	args, err := decodeDelegateArgs(map[string]any{
-		"task":                 "do stuff",
+		"prompt":               "do stuff",
 		"agent_type":           "coder",
 		"model":                "gpt-5",
 		"reasoning_effort":     "high",
@@ -345,19 +345,19 @@ func TestCovDecodeDelegateArgs(t *testing.T) {
 	}
 
 	// sandbox_net = false explicitly.
-	args, err = decodeDelegateArgs(map[string]any{"sandbox_net": false})
+	args, err = decodeDelegateArgs(map[string]any{"prompt": "p", "sandbox_net": false})
 	if err != nil || args.SandboxNet == nil || *args.SandboxNet {
 		t.Fatalf("sandbox_net=false: args=%+v, err=%v", args, err)
 	}
 
 	// sandbox_net omitted → nil (inherit).
-	args, err = decodeDelegateArgs(map[string]any{})
+	args, err = decodeDelegateArgs(map[string]any{"prompt": "p"})
 	if err != nil || args.SandboxNet != nil {
 		t.Fatalf("sandbox_net omitted: args=%+v, err=%v", args, err)
 	}
 
 	// delegation_allowance = 0 → unset.
-	args, err = decodeDelegateArgs(map[string]any{"delegation_allowance": 0})
+	args, err = decodeDelegateArgs(map[string]any{"prompt": "p", "delegation_allowance": 0})
 	if err != nil || args.DelegationAllowance != 0 {
 		t.Fatalf("delegation_allowance=0: args=%+v, err=%v", args, err)
 	}

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -177,7 +177,7 @@ func DefDelegateWithSandbox(agentTypes []string, sandboxSchema DelegateSandboxSc
 			"properties": map[string]any{
 				"prompt": map[string]any{
 					"type":        "string",
-					"description": "The brief. It is the only input the delegate receives: none of your conversation, the user's message, or what you have learned reaches it. State the user's request for this unit (quote it), the facts it needs that you already know (environment, tools present or missing, paths, formats), exactly which files or paths it owns and must not touch, the acceptance check (the exact command(s) and the expected result), and the evidence to report back (paths, diffs, the check's output). For a unit with more than one step, put the steps in task_list rather than here.",
+					"description": "The brief: the delegate's only top-level input (task_list adds the ordered step prompts). None of your conversation, the user's message, or what you have learned reaches it. State the user's request for this unit (quote it), the facts it needs that you already know (environment, tools present or missing, paths, formats), exactly which files or paths it owns and must not touch, the acceptance check (the exact command(s) and the expected result), and the evidence to report back (paths, diffs, the check's output). For a unit with more than one step, put the steps in task_list rather than here.",
 				},
 				"task_list": map[string]any{
 					"type":        "array",

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -175,7 +175,25 @@ func DefDelegateWithSandbox(agentTypes []string, sandboxSchema DelegateSandboxSc
 			"type":                 "object",
 			"additionalProperties": false,
 			"properties": map[string]any{
-				"task":                 map[string]any{"type": "string"},
+				"prompt": map[string]any{
+					"type":        "string",
+					"description": "The brief. It is the only input the delegate receives: none of your conversation, the user's message, or what you have learned reaches it. State the user's request for this unit (quote it), the facts it needs that you already know (environment, tools present or missing, paths, formats), exactly which files or paths it owns and must not touch, the acceptance check (the exact command(s) and the expected result), and the evidence to report back (paths, diffs, the check's output). For a unit with more than one step, put the steps in task_list rather than here.",
+				},
+				"task_list": map[string]any{
+					"type":        "array",
+					"description": "Seed the delegate's task list, one item per step, in order. Items fill the role's parent_tasks slot when its default task list has one and follow the role's default tasks otherwise. The first task auto-starts and its prompt is injected into the delegate; the delegate works the list in order and marks each task done. Each item's prompt must stand alone: the delegate sees no other context.",
+					"items": map[string]any{
+						"type":                 "object",
+						"additionalProperties": false,
+						"properties": map[string]any{
+							"title":            map[string]any{"type": "string", "description": "Short task title, under 10 words."},
+							"prompt":           map[string]any{"type": "string", "description": "Full, self-contained instruction for this step."},
+							"reasoning_effort": map[string]any{"type": "string", "enum": []string{"low", "medium", "high"}, "description": "Reasoning effort while this task is in progress."},
+							"type":             map[string]any{"type": "string", "enum": []string{"research", "implement", "verify", "fix"}, "description": "Kind of work; defaults to implement."},
+						},
+						"required": []string{"title", "prompt"},
+					},
+				},
 				"agent_type":           agentTypeSchema,
 				"model":                map[string]any{"type": "string", "description": delegateModelOverrideDescription},
 				"reasoning_effort":     map[string]any{"type": "string", "description": "Reasoning effort for this delegate (low, medium, or high). Default inherits from parent.", "enum": []string{"low", "medium", "high"}},
@@ -197,7 +215,7 @@ func DefDelegateWithSandbox(agentTypes []string, sandboxSchema DelegateSandboxSc
 					"additionalProperties": true,
 				},
 			},
-			"required": []string{"task"},
+			"required": []string{"prompt"},
 		},
 	}
 	props := def.Parameters["properties"].(map[string]any)

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -197,7 +197,7 @@ func DefDelegateWithSandbox(agentTypes []string, sandboxSchema DelegateSandboxSc
 				"agent_type":           agentTypeSchema,
 				"model":                map[string]any{"type": "string", "description": delegateModelOverrideDescription},
 				"reasoning_effort":     map[string]any{"type": "string", "description": "Reasoning effort for this delegate (low, medium, or high). Default inherits from parent.", "enum": []string{"low", "medium", "high"}},
-				"delegation_allowance": map[string]any{"type": "integer", "description": "0 (default): a leaf delegate that cannot itself delegate. >0: the delegate may delegate, granting onward allowances strictly smaller than this; must be strictly less than your own allowance. The allowance only takes effect if the chosen agent_type actually has the `delegate` tool: the built-in `subagent` role is a non-delegating leaf, so a >0 allowance on it is a silent no-op. For a multi-level tree, omit agent_type (the default role can delegate)."},
+				"delegation_allowance": map[string]any{"type": "integer", "description": "0 (default): a leaf delegate that cannot itself delegate. >0: the delegate may delegate, granting onward allowances strictly smaller than this; must be strictly less than your own allowance. The allowance only takes effect if the chosen agent_type carries the `delegate` tool (the built-in `default` and `subagent` roles do; `explorer` does not)."},
 				"watch_parent":         map[string]any{"type": "boolean", "description": "Grant this child permission to observe your session with job_watch(source=\"parent\"). This does not grant delegation or any transitive watch permission."},
 				"isolation": map[string]any{
 					"type":        "string",

--- a/agent/internal/tool/definitions_test.go
+++ b/agent/internal/tool/definitions_test.go
@@ -170,10 +170,13 @@ func TestDefDelegateParamsAndEnum(t *testing.T) {
 		t.Fatalf("Strict = %v, want false", def.Strict)
 	}
 	props := def.Parameters["properties"].(map[string]any)
-	for _, p := range []string{"task", "agent_type", "model", "reasoning_effort", "result_schema"} {
+	for _, p := range []string{"prompt", "task_list", "agent_type", "model", "reasoning_effort", "result_schema"} {
 		if _, ok := props[p]; !ok {
 			t.Errorf("DefDelegate missing param %q", p)
 		}
+	}
+	if _, ok := props["task"]; ok {
+		t.Errorf("DefDelegate must not have the renamed task param")
 	}
 	if _, ok := props["background"]; ok {
 		t.Errorf("DefDelegate must not have the removed background param")
@@ -185,8 +188,8 @@ func TestDefDelegateParamsAndEnum(t *testing.T) {
 		t.Errorf("DefDelegate must not expose creation max_wait_ms")
 	}
 	req := def.Parameters["required"].([]string)
-	if len(req) != 1 || req[0] != "task" {
-		t.Errorf("required = %v, want [task]", req)
+	if len(req) != 1 || req[0] != "prompt" {
+		t.Errorf("required = %v, want [prompt]", req)
 	}
 	at := props["agent_type"].(map[string]any)
 	enum := at["enum"].([]string)
@@ -885,5 +888,47 @@ func TestDefTaskList_PresenceBased(t *testing.T) {
 	}
 	if top, has := params["required"]; has {
 		t.Fatalf("schema must not force-require add/update at top level: %v", top)
+	}
+}
+
+// TestDefDelegatePromptAndTaskListSchema pins the delegate brief contract: the
+// brief parameter is `prompt`, it carries a description (the delegate sees
+// nothing but this string and its role prompt), and `task_list` seeds the
+// delegate's task list with title+prompt items.
+func TestDefDelegatePromptAndTaskListSchema(t *testing.T) {
+	props := DefDelegate(nil).Parameters["properties"].(map[string]any)
+	prompt := props["prompt"].(map[string]any)
+	if prompt["type"] != "string" {
+		t.Errorf("prompt type = %v, want string", prompt["type"])
+	}
+	if desc, _ := prompt["description"].(string); desc == "" {
+		t.Error("prompt must carry a description; it is the only input the delegate sees")
+	}
+	tl, ok := props["task_list"].(map[string]any)
+	if !ok {
+		t.Fatal("DefDelegate has no task_list param")
+	}
+	if tl["type"] != "array" {
+		t.Errorf("task_list type = %v, want array", tl["type"])
+	}
+	if desc, _ := tl["description"].(string); desc == "" {
+		t.Error("task_list must carry a description")
+	}
+	items := tl["items"].(map[string]any)
+	if items["type"] != "object" {
+		t.Errorf("task_list items type = %v, want object", items["type"])
+	}
+	itemProps := items["properties"].(map[string]any)
+	for _, p := range []string{"title", "prompt", "reasoning_effort", "type"} {
+		if _, ok := itemProps[p]; !ok {
+			t.Errorf("task_list item missing property %q", p)
+		}
+	}
+	req := items["required"].([]string)
+	if len(req) != 2 || req[0] != "title" || req[1] != "prompt" {
+		t.Errorf("task_list item required = %v, want [title prompt]", req)
+	}
+	if items["additionalProperties"] != false {
+		t.Errorf("task_list items additionalProperties = %v, want false", items["additionalProperties"])
 	}
 }

--- a/agent/job_delegate.go
+++ b/agent/job_delegate.go
@@ -14,6 +14,7 @@ import (
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/sandbox"
 	"primeradiant.com/evener/agent/schema"
+	taskpkg "primeradiant.com/evener/agent/task"
 )
 
 const (
@@ -35,6 +36,7 @@ type delegateArgs struct {
 	Sandbox             string
 	SandboxNet          *bool
 	ResultSchema        map[string]any
+	TaskList            []taskpkg.TaskTemplate
 }
 
 type delegateWorktreeReport struct {

--- a/agent/jobs_seed100_fuzz_test.go
+++ b/agent/jobs_seed100_fuzz_test.go
@@ -246,7 +246,7 @@ func seed100JobTools(t *testing.T, text string) {
 	_, _, _ = (&Session{}).clearDescendantReceiverWatchByID("x")
 	_ = (&Session{}).liveDescendantSessions()
 
-	for _, args := range []map[string]any{{}, {"task": "x", "tasks": []any{"y"}}, {"tasks": "bad"}, {"tasks": []any{1}}} {
+	for _, args := range []map[string]any{{}, {"prompt": "x", "tasks": []any{"y"}}, {"tasks": "bad"}, {"tasks": []any{1}}} {
 		_, _ = decodeDelegateArgs(args)
 	}
 

--- a/agent/lifecycle_seqfuzz_test.go
+++ b/agent/lifecycle_seqfuzz_test.go
@@ -215,7 +215,7 @@ func buildResponse(kind responseKind, callSeq int) llm.Response {
 	case kindShellBackground:
 		return lifecycleToolCall(id, "shell", map[string]any{"command": "echo bg " + strconv.Itoa(callSeq), "mode": "background"})
 	case kindDelegate:
-		return lifecycleToolCall(id, "delegate", map[string]any{"task": "child task " + strconv.Itoa(callSeq), "delegation_allowance": 0})
+		return lifecycleToolCall(id, "delegate", map[string]any{"prompt": "child task " + strconv.Itoa(callSeq), "delegation_allowance": 0})
 	case kindBoom:
 		return lifecycleToolCall(id, lifecycleBoomTool, map[string]any{})
 	default:

--- a/agent/prompts/sections/delegation.md
+++ b/agent/prompts/sections/delegation.md
@@ -5,9 +5,11 @@ cannot delegate further. Pass `delegation_allowance` to `delegate` to let a
 delegate delegate in turn — each grant must be strictly smaller than your own
 allowance, so the chain always shortens and allowance 0 is a leaf.
 
-Use `delegate` to assign scoped work. `delegate` returns one durable `delegate_id` (`dlg_...`)
-plus stable conversation metadata; it never returns an
-activation `job_id` and does not accept `max_wait_ms`. Use `delegate_send` with
+Use `delegate` to assign scoped work: `prompt` is the brief and `task_list`
+the ordered steps, when the unit has more than one.
+`delegate` returns one durable `delegate_id` (`dlg_...`) plus stable
+conversation metadata; it never returns an activation `job_id` and does not
+accept `max_wait_ms`. Use `delegate_send` with
 the `delegate_id` to continue delegate work. Use
 `job_status(target=<dlg_...>)` for metadata-only orientation,
 `job_stop(target=<dlg_...>)` to stop that delegate and its subtree, and the
@@ -41,10 +43,26 @@ Prefer a single well-scoped subagent with a checklist over many tiny subagents
 for one coherent investigation. Prefer several subagents in parallel when the
 questions are genuinely independent.
 
-When delegating, give the subagent enough context to succeed without pulling the
-entire problem back into the parent context: the user request, scope boundaries,
-relevant files or allowed paths, acceptance criteria, commands to run when known,
-and the exact evidence you expect in its final report.
+A delegate sees only your brief and its role prompt: none of your
+conversation, not the user's message, not what you have learned. Every brief
+therefore carries, in this order:
+
+1. The user's request for this unit, quoted, plus the facts it needs that
+   you already know: environment, tools present or missing, paths, formats.
+2. What it owns: the exact files or paths it may create or modify, and what
+   it must not touch.
+3. The acceptance check: the exact command(s) that prove the unit done and
+   the result you expect from them.
+4. The report: the evidence to send back, meaning paths, diffs, and the
+   check's output.
+
+A brief missing any of these is not ready to send. Do not delegate an
+underspecified unit; specify it first.
+
+When the unit has more than one step, pass the steps as `task_list`, one item
+per step with a self-contained prompt: the delegate works them in order, marks
+each done, and is steered to the next. The brief still states the unit's
+purpose, what the delegate owns, the acceptance check, and the report.
 
 For research-and-report delegations, require sources, dates when currentness
 matters, assumptions, uncertainty, and a concise recommendation or conclusion.

--- a/agent/sandbox_delegate_contract_test.go
+++ b/agent/sandbox_delegate_contract_test.go
@@ -127,7 +127,7 @@ func TestExecTool_UnsupportedHostRejectsExplicitSandboxControlsBeforeRepair(t *t
 		t.Run(tc.name, func(t *testing.T) {
 			home := t.TempDir()
 			s := sbxDelegateSession(t, sandbox.HostFacts{OS: "linux", Home: home})
-			args := map[string]any{"task": "do work"}
+			args := map[string]any{"prompt": "do work"}
 			maps.Copy(args, tc.args)
 
 			result := execDelegateForContract(t, s, args)
@@ -141,7 +141,7 @@ func TestExecTool_UnsupportedHostPreservesBenignRepairWithSandboxControlsOmitted
 	home := t.TempDir()
 	s := sbxDelegateSession(t, sandbox.HostFacts{OS: "linux", Home: home})
 	result := execDelegateForContract(t, s, map[string]any{
-		"task":                "do work",
+		"prompt":              "do work",
 		"unrelated_extra_arg": true,
 	})
 	if result.IsError {
@@ -204,7 +204,7 @@ func TestExecTool_SupportedHostPreservesExplicitSandboxControls(t *testing.T) {
 					t.Fatalf("refresh delegate tool schema: %v", err)
 				}
 			}
-			args := map[string]any{"task": "do work"}
+			args := map[string]any{"prompt": "do work"}
 			maps.Copy(args, tc.args)
 
 			result := execDelegateForContract(t, s, args)
@@ -230,7 +230,7 @@ func TestStableDelegateCreateTool_UnsupportedSandboxReportsInvalidParameters(t *
 	s := sbxDelegateSession(t, sandbox.HostFacts{OS: "linux", Home: home})
 
 	_, err := stableDelegateCreateTool(context.Background(), s, map[string]any{
-		"task":        "do work",
+		"prompt":      "do work",
 		"sandbox":     "read-only",
 		"sandbox_net": true,
 	}, 8192)
@@ -330,9 +330,9 @@ func TestDelegateSchemaOmitsUnsupportedSandboxControls(t *testing.T) {
 		t.Errorf("unsupported-host schema exposes %q", "sandbox")
 	}
 	compiled := compileDelegateParameters(t, params)
-	requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work"}, true)
-	requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox": "off"}, false)
-	requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox_net": false}, false)
+	requireDelegateSchemaValidation(t, compiled, map[string]any{"prompt": "do work"}, true)
+	requireDelegateSchemaValidation(t, compiled, map[string]any{"prompt": "do work", "sandbox": "off"}, false)
+	requireDelegateSchemaValidation(t, compiled, map[string]any{"prompt": "do work", "sandbox_net": false}, false)
 }
 
 func TestDelegateSchemaHonorsParentConfinementAndNetwork(t *testing.T) {
@@ -364,8 +364,8 @@ func TestDelegateSchemaHonorsParentConfinementAndNetwork(t *testing.T) {
 					t.Fatalf("sandbox property exposed for parent with no accepted explicit modes: %#v", props["sandbox"])
 				}
 				compiled := compileDelegateParameters(t, params)
-				requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox": "restricted"}, false)
-				requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox_net": false}, false)
+				requireDelegateSchemaValidation(t, compiled, map[string]any{"prompt": "do work", "sandbox": "restricted"}, false)
+				requireDelegateSchemaValidation(t, compiled, map[string]any{"prompt": "do work", "sandbox_net": false}, false)
 				return
 			}
 			if _, ok := props["sandbox_net"]; ok {
@@ -384,10 +384,10 @@ func TestDelegateSchemaHonorsParentConfinementAndNetwork(t *testing.T) {
 			// (which the combined enum never lists) is schema-invalid, and a legacy
 			// sandbox_net property is rejected by additionalProperties:false.
 			for _, value := range tc.wantSandboxEnum {
-				requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox": value}, true)
+				requireDelegateSchemaValidation(t, compiled, map[string]any{"prompt": "do work", "sandbox": value}, true)
 			}
-			requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox": "off+nonet"}, false)
-			requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox_net": false}, false)
+			requireDelegateSchemaValidation(t, compiled, map[string]any{"prompt": "do work", "sandbox": "off+nonet"}, false)
+			requireDelegateSchemaValidation(t, compiled, map[string]any{"prompt": "do work", "sandbox_net": false}, false)
 		})
 	}
 }
@@ -431,19 +431,19 @@ func TestExecTool_WriteBlockedParentSchemaAndRuntimeContract(t *testing.T) {
 		t.Fatal("provider wire schema exposes a sandbox_net property; the combined enum replaced it")
 	}
 	compiled := compileDelegateParameters(t, params)
-	requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox": "restricted"}, false)
-	requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox_net": false}, false)
-	requireDelegateSchemaValidation(t, compiled, map[string]any{"task": "do work", "sandbox": "nonet"}, true)
+	requireDelegateSchemaValidation(t, compiled, map[string]any{"prompt": "do work", "sandbox": "restricted"}, false)
+	requireDelegateSchemaValidation(t, compiled, map[string]any{"prompt": "do work", "sandbox_net": false}, false)
+	requireDelegateSchemaValidation(t, compiled, map[string]any{"prompt": "do work", "sandbox": "nonet"}, true)
 
 	// "restricted" is not in the advertised enum, so schema prevalidation rejects
 	// it before the handler ever sees it: a PrevalOnly error with no delegate launch.
-	restricted := execDelegateForContract(t, s, map[string]any{"task": "do work", "sandbox": "restricted"})
+	restricted := execDelegateForContract(t, s, map[string]any{"prompt": "do work", "sandbox": "restricted"})
 	if !restricted.IsError || !restricted.PrevalOnly {
 		t.Fatalf("restricted exec result = %#v, want a prevalidation rejection (IsError=true, PrevalOnly=true)", restricted)
 	}
 	requireNoDelegatePreRepairState(t, s)
 
-	netOnly := execDelegateForContract(t, s, map[string]any{"task": "do work", "sandbox": "nonet"})
+	netOnly := execDelegateForContract(t, s, map[string]any{"prompt": "do work", "sandbox": "nonet"})
 	if netOnly.IsError {
 		t.Fatalf("write-blocked parent net-only tightening failed: %#v", netOnly)
 	}
@@ -520,7 +520,7 @@ func TestStableDelegateCreateTool_RejectsAffectedSandboxCombinations(t *testing.
 			lane, home := sbxLane(t)
 			s := sbxDelegateSession(t, sbxBwrapFacts(home))
 			setParentSandboxForContract(t, s, sbxBwrapFacts(home), lane, tc.parentMode, tc.parentNet)
-			args := map[string]any{"task": "do work"}
+			args := map[string]any{"prompt": "do work"}
 			maps.Copy(args, tc.args)
 			_, err := stableDelegateCreateTool(context.Background(), s, args, 8192)
 			requireDelegateSandboxRequestError(t, err, tc.invalidParameters)
@@ -533,7 +533,7 @@ func TestStableDelegateCreateTool_UnsupportedHostRejectsNetworkOnly(t *testing.T
 	_, home := sbxLane(t)
 	s := sbxDelegateSession(t, sandbox.HostFacts{OS: "linux", Home: home})
 	_, err := stableDelegateCreateTool(context.Background(), s, map[string]any{
-		"task":    "do work",
+		"prompt":  "do work",
 		"sandbox": "nonet",
 	}, 8192)
 	requireDelegateSandboxRequestError(t, err, []string{"sandbox"})

--- a/agent/session_communicate_test.go
+++ b/agent/session_communicate_test.go
@@ -398,7 +398,7 @@ func TestCommunicate_StatusBatchedWithDelegateDoesNotEndTurn(t *testing.T) {
 	c := llm.NewClient()
 
 	delegateArgs, _ := json.Marshal(map[string]any{
-		"task": "Return CHILD_DONE.",
+		"prompt": "Return CHILD_DONE.",
 	})
 	delegate := llm.ToolCallData{
 		ID:        "delegate_1",

--- a/agent/session_tool_repair_oneof_test.go
+++ b/agent/session_tool_repair_oneof_test.go
@@ -39,7 +39,7 @@ func TestPrepareToolCall_DelegateLegacySandboxNetDropped(t *testing.T) {
 	call := llm.ToolCallData{
 		ID:   "legacy-net",
 		Name: "delegate",
-		Arguments: json.RawMessage(`{"task":"ping","agent_type":"subagent","isolation":"worktree",` +
+		Arguments: json.RawMessage(`{"prompt":"ping","agent_type":"subagent","isolation":"worktree",` +
 			`"sandbox":"off","sandbox_net":true,"reasoning_effort":"low","delegation_allowance":0}`),
 	}
 	res := prepareToolCall(call, rt, []string{"delegate"}, "delegate", "communicate", "")
@@ -96,7 +96,7 @@ func TestExecTool_DelegateOffPlusNonetRejectedByHandler(t *testing.T) {
 	res := s.execTool(context.Background(), llm.ToolCallData{
 		ID:        "off-nonet",
 		Name:      "delegate",
-		Arguments: json.RawMessage(`{"task":"ping","sandbox":"off+nonet"}`),
+		Arguments: json.RawMessage(`{"prompt":"ping","sandbox":"off+nonet"}`),
 	}, "")
 	if !res.IsError {
 		t.Fatalf("expected error for off+nonet (off has no network confinement), got: %s", res.FullOutput)

--- a/agent/session_tool_repair_test.go
+++ b/agent/session_tool_repair_test.go
@@ -38,10 +38,10 @@ func TestExecTool_DelegateRejectsUnsupportedWaitWithoutStarting(t *testing.T) {
 		name string
 		args string
 	}{
-		{name: "max_wait_ms", args: `{"task":"must not start","max_wait_ms":1000}`},
-		{name: "block", args: `{"task":"must not start","block":true}`},
-		{name: "block_timeout_ms", args: `{"task":"must not start","block_timeout_ms":1000}`},
-		{name: "background", args: `{"task":"must not start","background":true}`},
+		{name: "max_wait_ms", args: `{"prompt":"must not start","max_wait_ms":1000}`},
+		{name: "block", args: `{"prompt":"must not start","block":true}`},
+		{name: "block_timeout_ms", args: `{"prompt":"must not start","block_timeout_ms":1000}`},
+		{name: "background", args: `{"prompt":"must not start","background":true}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			before := len(s.delegateController.Snapshot().rows)

--- a/agent/session_tools_jobs.go
+++ b/agent/session_tools_jobs.go
@@ -15,6 +15,7 @@ import (
 	"primeradiant.com/evener/agent/internal/jobstore"
 	"primeradiant.com/evener/agent/internal/tool"
 	"primeradiant.com/evener/agent/schema"
+	taskpkg "primeradiant.com/evener/agent/task"
 )
 
 const (
@@ -455,8 +456,11 @@ func watchInspectFound(inspect jobWatchInspectToolResult) bool {
 // tri-state sandbox_net (nil = inherit, never a silent false) — is unit-testable
 // without minting a delegate.
 func decodeDelegateArgs(args map[string]any) (delegateArgs, error) {
+	if strings.TrimSpace(stringArg(args, "prompt")) == "" {
+		return delegateArgs{}, errors.New("invalid_request: prompt is required")
+	}
 	a := delegateArgs{
-		Task:            stringArg(args, "task"),
+		Task:            stringArg(args, "prompt"),
 		AgentType:       stringArg(args, "agent_type"),
 		Model:           stringArg(args, "model"),
 		ReasoningEffort: stringArg(args, "reasoning_effort"),
@@ -505,7 +509,48 @@ func decodeDelegateArgs(args map[string]any) (delegateArgs, error) {
 	if resultSchema, ok := args["result_schema"].(map[string]any); ok {
 		a.ResultSchema = resultSchema
 	}
+	taskList, err := delegateTaskListArg(args)
+	if err != nil {
+		return delegateArgs{}, err
+	}
+	a.TaskList = taskList
 	return a, nil
+}
+
+// delegateTaskListArg decodes the delegate tool's task_list items into task
+// templates. Every item needs a title and a prompt; the delegate sees nothing
+// but these strings, so an empty prompt is an error rather than a blank task.
+func delegateTaskListArg(args map[string]any) ([]taskpkg.TaskTemplate, error) {
+	raw, ok := args["task_list"]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, errors.New("invalid_request: task_list must be an array")
+	}
+	out := make([]taskpkg.TaskTemplate, 0, len(items))
+	for i, item := range items {
+		fields, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("invalid_request: task_list[%d] must be an object", i)
+		}
+		title := strings.TrimSpace(stringArg(fields, "title"))
+		if title == "" {
+			return nil, fmt.Errorf("invalid_request: task_list[%d].title is required", i)
+		}
+		prompt := strings.TrimSpace(stringArg(fields, "prompt"))
+		if prompt == "" {
+			return nil, fmt.Errorf("invalid_request: task_list[%d].prompt is required", i)
+		}
+		out = append(out, taskpkg.TaskTemplate{
+			Title:           title,
+			Prompt:          prompt,
+			ReasoningEffort: strings.TrimSpace(stringArg(fields, "reasoning_effort")),
+			Type:            strings.TrimSpace(stringArg(fields, "type")),
+		})
+	}
+	return out, nil
 }
 
 func jobStatusTool(s *Session, args map[string]any, maxChars int) (any, error) {

--- a/agent/session_tools_jobs.go
+++ b/agent/session_tools_jobs.go
@@ -543,11 +543,21 @@ func delegateTaskListArg(args map[string]any) ([]taskpkg.TaskTemplate, error) {
 		if prompt == "" {
 			return nil, fmt.Errorf("invalid_request: task_list[%d].prompt is required", i)
 		}
+		effort := strings.TrimSpace(stringArg(fields, "reasoning_effort"))
+		if effort != "" && effort != "low" && effort != "medium" && effort != "high" {
+			return nil, fmt.Errorf("invalid_request: task_list[%d].reasoning_effort must be one of low, medium, high", i)
+		}
+		kind := strings.TrimSpace(stringArg(fields, "type"))
+		switch taskpkg.TaskType(kind) {
+		case "", taskpkg.TaskTypeResearch, taskpkg.TaskTypeImplement, taskpkg.TaskTypeVerify, taskpkg.TaskTypeFix:
+		default:
+			return nil, fmt.Errorf("invalid_request: task_list[%d].type must be one of research, implement, verify, fix", i)
+		}
 		out = append(out, taskpkg.TaskTemplate{
 			Title:           title,
 			Prompt:          prompt,
-			ReasoningEffort: strings.TrimSpace(stringArg(fields, "reasoning_effort")),
-			Type:            strings.TrimSpace(stringArg(fields, "type")),
+			ReasoningEffort: effort,
+			Type:            kind,
 		})
 	}
 	return out, nil

--- a/agent/session_tools_jobs_covtest2_test.go
+++ b/agent/session_tools_jobs_covtest2_test.go
@@ -1139,7 +1139,7 @@ func TestCovDelegateSandboxToolResultFrom(t *testing.T) {
 // (session_tools_jobs.go lines 345-382): validation branches.
 func TestCovDecodeDelegateArgs2(t *testing.T) {
 	// Valid minimal.
-	a, err := decodeDelegateArgs(map[string]any{"task": "do work"})
+	a, err := decodeDelegateArgs(map[string]any{"prompt": "do work"})
 	if err != nil {
 		t.Fatalf("minimal: %v", err)
 	}
@@ -1148,13 +1148,13 @@ func TestCovDecodeDelegateArgs2(t *testing.T) {
 	}
 
 	// sandbox_net as non-boolean — error.
-	_, err = decodeDelegateArgs(map[string]any{"sandbox_net": "false"})
+	_, err = decodeDelegateArgs(map[string]any{"prompt": "p", "sandbox_net": "false"})
 	if err == nil || !strings.Contains(err.Error(), "sandbox_net must be a JSON boolean") {
 		t.Fatalf("non-bool sandbox_net: %v", err)
 	}
 
 	// sandbox_net as true.
-	a, err = decodeDelegateArgs(map[string]any{"sandbox_net": true})
+	a, err = decodeDelegateArgs(map[string]any{"prompt": "p", "sandbox_net": true})
 	if err != nil {
 		t.Fatalf("sandbox_net true: %v", err)
 	}
@@ -1163,7 +1163,7 @@ func TestCovDecodeDelegateArgs2(t *testing.T) {
 	}
 
 	// sandbox_net as false.
-	a, err = decodeDelegateArgs(map[string]any{"sandbox_net": false})
+	a, err = decodeDelegateArgs(map[string]any{"prompt": "p", "sandbox_net": false})
 	if err != nil {
 		t.Fatalf("sandbox_net false: %v", err)
 	}
@@ -1172,7 +1172,7 @@ func TestCovDecodeDelegateArgs2(t *testing.T) {
 	}
 
 	// sandbox_net absent — nil (inherit).
-	a, err = decodeDelegateArgs(map[string]any{})
+	a, err = decodeDelegateArgs(map[string]any{"prompt": "p"})
 	if err != nil {
 		t.Fatalf("absent sandbox_net: %v", err)
 	}
@@ -1181,13 +1181,13 @@ func TestCovDecodeDelegateArgs2(t *testing.T) {
 	}
 
 	// delegation_allowance negative — error.
-	_, err = decodeDelegateArgs(map[string]any{"delegation_allowance": -1})
+	_, err = decodeDelegateArgs(map[string]any{"prompt": "p", "delegation_allowance": -1})
 	if err == nil || !strings.Contains(err.Error(), "must be non-negative") {
 		t.Fatalf("negative allowance: %v", err)
 	}
 
 	// delegation_allowance positive — OK.
-	a, err = decodeDelegateArgs(map[string]any{"delegation_allowance": 3})
+	a, err = decodeDelegateArgs(map[string]any{"prompt": "p", "delegation_allowance": 3})
 	if err != nil {
 		t.Fatalf("positive allowance: %v", err)
 	}
@@ -1196,7 +1196,7 @@ func TestCovDecodeDelegateArgs2(t *testing.T) {
 	}
 
 	// delegation_allowance zero — unset (strict-zero).
-	a, err = decodeDelegateArgs(map[string]any{"delegation_allowance": 0})
+	a, err = decodeDelegateArgs(map[string]any{"prompt": "p", "delegation_allowance": 0})
 	if err != nil {
 		t.Fatalf("zero allowance: %v", err)
 	}
@@ -1205,7 +1205,7 @@ func TestCovDecodeDelegateArgs2(t *testing.T) {
 	}
 
 	// result_schema present.
-	a, err = decodeDelegateArgs(map[string]any{"result_schema": map[string]any{"type": "object"}})
+	a, err = decodeDelegateArgs(map[string]any{"prompt": "p", "result_schema": map[string]any{"type": "object"}})
 	if err != nil {
 		t.Fatalf("result_schema: %v", err)
 	}
@@ -1215,7 +1215,7 @@ func TestCovDecodeDelegateArgs2(t *testing.T) {
 
 	// Full args.
 	a, err = decodeDelegateArgs(map[string]any{
-		"task":                 "work",
+		"prompt":               "work",
 		"agent_type":           "researcher",
 		"model":                "gpt-5",
 		"reasoning_effort":     "high",

--- a/agent/session_tools_jobs_seed100_range_a_test.go
+++ b/agent/session_tools_jobs_seed100_range_a_test.go
@@ -29,7 +29,7 @@ func seed100ToolsRangeA(t *testing.T) {
 	bare := newSession(t)
 	_, _ = stableDelegateSendTool(context.Background(), bare, map[string]any{"to": "caller"}, 100)
 	_, _ = stableDelegateCreateTool(context.Background(), bare, map[string]any{"sandbox_net": "bad"}, 100)
-	_, _ = stableDelegateCreateTool(context.Background(), &Session{}, map[string]any{"task": "x"}, 100)
+	_, _ = stableDelegateCreateTool(context.Background(), &Session{}, map[string]any{"prompt": "x"}, 100)
 	_, _ = jobWatchTool(bare, map[string]any{"operation": "create", "source": "bad-source"}, 100)
 	ended := frozenTestTime
 

--- a/agent/session_tools_test.go
+++ b/agent/session_tools_test.go
@@ -249,7 +249,7 @@ func TestDelegateCallResponseReportsSelectedAgentCapabilities(t *testing.T) {
 		ID:   "delegate-capability-response",
 		Name: "delegate",
 		Arguments: json.RawMessage(`{
-			"task":"TASK_SENTINEL",
+			"prompt":"TASK_SENTINEL",
 			"agent_type":"explorer"
 		}`),
 	})

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -261,6 +261,17 @@ func baseSubagentToolPolicy(agent *plugin.Agent, canDelegate bool) (allTools boo
 		// automatic compaction to run unsteered. The untyped surface already
 		// keeps it (deny-list path), so listing tools: must not take it away.
 		allowed = appendUniqueStrings(allowed, "compact_context")
+		// Root-only job and delegation tools in a typed role's list are
+		// allowance-gated: granted, the role keeps them and gains job_watch
+		// to supervise its delegates; a leaf loses them, on every spawn
+		// path, exactly as the untyped surface does.
+		if canDelegate {
+			if hasString(allowed, "delegate") {
+				allowed = appendUniqueStrings(allowed, "job_watch")
+			}
+		} else {
+			allowed = removeRootOnlySubagentTools(allowed)
+		}
 		return false, allowed, nil
 	default:
 		if canDelegate {
@@ -657,7 +668,6 @@ func (s *Session) prepareSubagentRunFromSelection(
 ) (*preparedSubagentRun, error) {
 	s.mu.Lock()
 	depth := s.depth
-	allowance := s.delegationAllowance
 	parentCfg := s.cfg
 	subscriberCount := s.subscriberCountFn
 	s.mu.Unlock()
@@ -820,7 +830,10 @@ func (s *Session) prepareSubagentRunFromSelection(
 		allowedTools = append([]string(nil), frozen.ToolNameCeiling...)
 		subCfg.spawn.toolNameCeiling = append([]string(nil), allowedTools...)
 	} else {
-		allTools, allowedTools, deniedTools = baseSubagentToolPolicy(agent, allowance > 0)
+		// The policy follows the CHILD's granted allowance, not this session's:
+		// a leaf spawned by a coordinator must not inherit the coordinator's
+		// job-supervision tools.
+		allTools, allowedTools, deniedTools = baseSubagentToolPolicy(agent, childCanDelegate)
 		if subCfg.spawn.parentWatchGranted && !allTools {
 			if len(allowedTools) > 0 {
 				allowedTools = appendUniqueStrings(allowedTools, "job_watch")

--- a/agent/task/task_store.go
+++ b/agent/task/task_store.go
@@ -512,8 +512,33 @@ func (s *TaskStore) currentInProgressLocked() (Task, bool) {
 	return Task{}, false
 }
 
+// ExpandParentTasks merges a parent's task list into a role's task templates:
+// the items replace the role's parent_tasks placeholder when it has one and
+// follow the role's own tasks otherwise. With no parent tasks the templates
+// come back unchanged, so a placeholder that carries its own prompt stays a
+// task.
+func ExpandParentTasks(templates, parentTasks []TaskTemplate) []TaskTemplate {
+	if len(parentTasks) == 0 {
+		return append([]TaskTemplate(nil), templates...)
+	}
+	var out []TaskTemplate
+	replaced := false
+	for _, tt := range templates {
+		if tt.Insert == "parent_tasks" {
+			out = append(out, parentTasks...)
+			replaced = true
+		} else {
+			out = append(out, tt)
+		}
+	}
+	if !replaced {
+		out = append(out, parentTasks...)
+	}
+	return out
+}
+
 // PopulateFromTemplates initializes the task store from agent definition templates.
-// If parentTasks is non-nil and non-empty, they replace the template with Insert=="parent_tasks".
+// Parent tasks are merged in by ExpandParentTasks.
 // The first task is auto-started (set to in_progress).
 // No-op if the store already has tasks.
 func (s *TaskStore) PopulateFromTemplates(templates []TaskTemplate, parentTasks []TaskTemplate) error {
@@ -524,15 +549,7 @@ func (s *TaskStore) PopulateFromTemplates(templates []TaskTemplate, parentTasks 
 		return nil // already populated
 	}
 
-	// Build the effective template list by expanding the insert placeholder.
-	var effective []TaskTemplate
-	for _, tt := range templates {
-		if tt.Insert == "parent_tasks" && len(parentTasks) > 0 {
-			effective = append(effective, parentTasks...)
-		} else {
-			effective = append(effective, tt)
-		}
-	}
+	effective := ExpandParentTasks(templates, parentTasks)
 
 	// Convert templates to tasks.
 	for _, tt := range effective {

--- a/agent/task/task_store_test.go
+++ b/agent/task/task_store_test.go
@@ -593,3 +593,57 @@ func TestTaskUpdate_EmptyStatusStillValidates(t *testing.T) {
 		t.Fatal("bogus status must still be rejected")
 	}
 }
+
+func TestExpandParentTasks_ReplacesPlaceholder(t *testing.T) {
+	got := ExpandParentTasks(
+		[]TaskTemplate{{Title: "lead", Prompt: "p"}, {Insert: "parent_tasks", Title: "placeholder"}, {Title: "tail"}},
+		[]TaskTemplate{{Title: "from-parent-1", Prompt: "a"}, {Title: "from-parent-2", Prompt: "b"}},
+	)
+	want := []string{"lead", "from-parent-1", "from-parent-2", "tail"}
+	if len(got) != len(want) {
+		t.Fatalf("templates = %d, want %d", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i].Title != w {
+			t.Errorf("template[%d] = %q, want %q", i, got[i].Title, w)
+		}
+	}
+}
+
+func TestExpandParentTasks_AppendsWithoutPlaceholder(t *testing.T) {
+	got := ExpandParentTasks(
+		[]TaskTemplate{{Title: "role-default", Prompt: "p"}},
+		[]TaskTemplate{{Title: "from-parent", Prompt: "a"}},
+	)
+	if len(got) != 2 || got[0].Title != "role-default" || got[1].Title != "from-parent" {
+		t.Fatalf("templates = %+v, want role default followed by the parent task", got)
+	}
+	if only := ExpandParentTasks(nil, []TaskTemplate{{Title: "from-parent", Prompt: "a"}}); len(only) != 1 || only[0].Title != "from-parent" {
+		t.Fatalf("templates with no role defaults = %+v, want just the parent task", only)
+	}
+}
+
+func TestExpandParentTasks_KeepsPlaceholderTaskWithoutParentTasks(t *testing.T) {
+	got := ExpandParentTasks([]TaskTemplate{{Insert: "parent_tasks", Title: "Scan workspace", Prompt: "p"}}, nil)
+	if len(got) != 1 || got[0].Title != "Scan workspace" {
+		t.Fatalf("templates = %+v, want the placeholder kept as a task", got)
+	}
+}
+
+func TestPopulateFromTemplates_ParentTasksAppendWithoutPlaceholder(t *testing.T) {
+	s := newTestStore(t)
+	err := s.PopulateFromTemplates(
+		[]TaskTemplate{{Title: "role-default", Prompt: "p"}},
+		[]TaskTemplate{{Title: "from-parent", Prompt: "a", Type: "verify"}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := s.View()
+	if len(got) != 2 {
+		t.Fatalf("tasks = %d, want 2 (role default + parent)", len(got))
+	}
+	if got[1].Description != "from-parent" || got[1].Type != TaskTypeVerify {
+		t.Errorf("parent task not appended: %+v", got[1])
+	}
+}

--- a/agent/transcript_render.go
+++ b/agent/transcript_render.go
@@ -1548,7 +1548,7 @@ func toolInputSummary(name string, args json.RawMessage) string {
 		return quoteIfSet(get("query"))
 
 	case "delegate":
-		parts := []string{truncRunes(get("task"), 80)}
+		parts := []string{truncRunes(get("prompt"), 80)}
 		if at := get("agent_type"); at != "" {
 			parts = append(parts, "type="+at)
 		}

--- a/agent/transcript_render.go
+++ b/agent/transcript_render.go
@@ -1548,7 +1548,13 @@ func toolInputSummary(name string, args json.RawMessage) string {
 		return quoteIfSet(get("query"))
 
 	case "delegate":
-		parts := []string{truncRunes(get("prompt"), 80)}
+		// Older transcripts carry the brief under the retired task key;
+		// display only, invocation validation stays prompt-only.
+		brief := get("prompt")
+		if brief == "" {
+			brief = get("task")
+		}
+		parts := []string{truncRunes(brief, 80)}
 		if at := get("agent_type"); at != "" {
 			parts = append(parts, "type="+at)
 		}

--- a/agent/transcript_render_fuzz_test.go
+++ b/agent/transcript_render_fuzz_test.go
@@ -410,7 +410,7 @@ func FuzzToolInputSummary(f *testing.F) {
 		{"glob", `{"pattern":"**/*.go","path":"/src"}`},
 		{"web_fetch", `{"url":"https://example.com/x?y=1","question":"why"}`},
 		{"web_search", `{"query":"how to fuzz"}`},
-		{"delegate", `{"task":"do the thing","agent_type":"coder","max_wait_ms":5000}`},
+		{"delegate", `{"prompt":"do the thing","agent_type":"coder","max_wait_ms":5000}`},
 		{"job_send_message", `{"target":"job7","message":"ping"}`},
 		{"delegate_send", `{"to":"child","message":"go on"}`},
 		{"use_skill", `{"skill_name":"par"}`},
@@ -770,7 +770,7 @@ func trender_program(program []byte, payload string) (transcript.Header, []trans
 			panic(err)
 		}
 		entries := []transcript.Entry{
-			entry(schema.TurnAssistant, call("job", "delegate", `{"task":"child"}`)),
+			entry(schema.TurnAssistant, call("job", "delegate", `{"prompt":"child"}`)),
 			entry(schema.TurnToolResults, result("job", "delegate", string(bodyBytes), false)),
 		}
 		return header, entries, "last:2", opt

--- a/agent/transcript_render_lookup_exact_fuzz_test.go
+++ b/agent/transcript_render_lookup_exact_fuzz_test.go
@@ -92,7 +92,7 @@ func rleRenderEdges(t *testing.T, payload string) {
 		{"glob", `{"pattern":"*.go","path":"/tmp"}`, "`*.go` in /tmp"},
 		{"web_fetch", `{"url":"https://example.com/x","question":"q"}`, "example.com `q`"},
 		{"web_search", `{"query":"q"}`, "`q`"},
-		{"delegate", `{"task":"t","agent_type":"coder","max_wait_ms":3}`, "t type=coder max_wait_ms=3"},
+		{"delegate", `{"prompt":"t","agent_type":"coder","max_wait_ms":3}`, "t type=coder max_wait_ms=3"},
 		{"job_send_message", `{"target":"j","message":"m"}`, "j `m`"},
 		{"delegate_send", `{"to":"j","message":"m"}`, "j `m`"},
 		{"use_skill", `{"skill_name":"s"}`, "s"},

--- a/agent/transcript_render_test.go
+++ b/agent/transcript_render_test.go
@@ -1073,6 +1073,7 @@ func TestToolInputSummary(t *testing.T) {
 		{"web_fetch shows host not full url", "web_fetch", `{"url":"https://example.com/a/b?c=d","question":"what"}`, "example.com", ""},
 		{"web_search shows query", "web_search", `{"query":"golang testing"}`, "golang testing", ""},
 		{"delegate shows task/type/max_wait_ms", "delegate", `{"prompt":"do thing","agent_type":"explorer","max_wait_ms":5000}`, "max_wait_ms=5000", "background"},
+		{"delegate shows a legacy task brief", "delegate", `{"task":"legacy brief","agent_type":"explorer"}`, "legacy brief", "background"},
 		{"delegate omits max_wait_ms when zero", "delegate", `{"prompt":"do thing","agent_type":"explorer","max_wait_ms":0}`, "explorer", "max_wait_ms"},
 		{"job_send_message shows id/message", "job_send_message", `{"target":"job_01J","message":"continue"}`, "job_01J", ""},
 		{"delegate_send shows delegate/message", "delegate_send", `{"to":"dlg_01J","message":"continue"}`, "dlg_01J", ""},

--- a/agent/transcript_render_test.go
+++ b/agent/transcript_render_test.go
@@ -1072,8 +1072,8 @@ func TestToolInputSummary(t *testing.T) {
 		{"glob shows pattern", "glob", `{"pattern":"**/*.go"}`, "**/*.go", ""},
 		{"web_fetch shows host not full url", "web_fetch", `{"url":"https://example.com/a/b?c=d","question":"what"}`, "example.com", ""},
 		{"web_search shows query", "web_search", `{"query":"golang testing"}`, "golang testing", ""},
-		{"delegate shows task/type/max_wait_ms", "delegate", `{"task":"do thing","agent_type":"explorer","max_wait_ms":5000}`, "max_wait_ms=5000", "background"},
-		{"delegate omits max_wait_ms when zero", "delegate", `{"task":"do thing","agent_type":"explorer","max_wait_ms":0}`, "explorer", "max_wait_ms"},
+		{"delegate shows task/type/max_wait_ms", "delegate", `{"prompt":"do thing","agent_type":"explorer","max_wait_ms":5000}`, "max_wait_ms=5000", "background"},
+		{"delegate omits max_wait_ms when zero", "delegate", `{"prompt":"do thing","agent_type":"explorer","max_wait_ms":0}`, "explorer", "max_wait_ms"},
 		{"job_send_message shows id/message", "job_send_message", `{"target":"job_01J","message":"continue"}`, "job_01J", ""},
 		{"delegate_send shows delegate/message", "delegate_send", `{"to":"dlg_01J","message":"continue"}`, "dlg_01J", ""},
 		{"use_skill shows skill", "use_skill", `{"skill_name":"brainstorming"}`, "brainstorming", ""},
@@ -1981,7 +1981,7 @@ func TestRenderMarkdown_DelegateToolCallAppears(t *testing.T) {
 	})
 	entries := []transcript.Entry{
 		// seq 0: assistant turn issuing a delegate call.
-		toolCallEntry(call("call_delegate", "delegate", `{"task":"investigate the render path","agent_type":"explorer"}`)),
+		toolCallEntry(call("call_delegate", "delegate", `{"prompt":"investigate the render path","agent_type":"explorer"}`)),
 		// seq 1: the paired delegate result.
 		toolResultEntry(result("call_delegate", "delegate", body, false)),
 	}
@@ -2038,7 +2038,7 @@ func TestRenderMarkdown_BatchedDelegateToolCallsAppear(t *testing.T) {
 	calls := make([]*llm.ToolCallData, len(specs))
 	results := make([]*llm.ToolResultData, len(specs))
 	for i, sp := range specs {
-		calls[i] = call(sp.callID, "delegate", fmt.Sprintf(`{"task":"batched research task %d"}`, i))
+		calls[i] = call(sp.callID, "delegate", fmt.Sprintf(`{"prompt":"batched research task %d"}`, i))
 		body := delegateCreateBody(t, stableDelegateCreateResult{
 			DelegateID:    sp.delegateID,
 			Type:          "delegate",
@@ -2086,7 +2086,7 @@ func TestRenderOutline_DelegateToolCallAppears(t *testing.T) {
 		TranscriptRef: childRef,
 	})
 	entries := []transcript.Entry{
-		toolCallEntry(call("call_del", "delegate", `{"task":"map the render path"}`)),
+		toolCallEntry(call("call_del", "delegate", `{"prompt":"map the render path"}`)),
 		toolResultEntry(result("call_del", "delegate", body, false)),
 	}
 	out, _, _ := renderOutline(entries, 0, len(entries)-1)
@@ -2123,7 +2123,7 @@ func TestRenderOutline_BatchedDelegateToolCallsAppear(t *testing.T) {
 	calls := make([]*llm.ToolCallData, len(specs))
 	results := make([]*llm.ToolResultData, len(specs))
 	for i, sp := range specs {
-		calls[i] = call(sp.callID, "delegate", fmt.Sprintf(`{"task":"outline batch task %d"}`, i))
+		calls[i] = call(sp.callID, "delegate", fmt.Sprintf(`{"prompt":"outline batch task %d"}`, i))
 		body := delegateCreateBody(t, stableDelegateCreateResult{
 			DelegateID:    sp.delegateID,
 			Type:          "delegate",

--- a/cmd/evener-hub/frontend/src/dev/overflowharness-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/overflowharness-entry.tsx
@@ -153,7 +153,7 @@ const snapshot: ThreadReadResponse = {
             callId: "call_1",
             status: "completed",
             durationMs: 1500,
-            argumentsJson: JSON.stringify({ task: TASK, mode: "foreground_timeout", delegateId: "dlg_1" }),
+            argumentsJson: JSON.stringify({ prompt: TASK, mode: "foreground_timeout", delegateId: "dlg_1" }),
             output: JSON.stringify({ delegate_id: "dlg_1", status: "running", reason: CARD_LONG_TOKEN }),
           },
           {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
@@ -1032,7 +1032,7 @@ test("delegate tool rows keep the human description as intent and suppress the t
       item={item({
         toolName: "delegate",
         description: "Testing delegation",
-        argumentsJSON: JSON.stringify({ task: "Run the linter" }),
+        argumentsJSON: JSON.stringify({ prompt: "Run the linter" }),
       })}
       turn={turn}
       live={false}
@@ -1051,7 +1051,7 @@ test("task-only delegate intent previews preserve an emoji at the Unicode clippi
         item={item({
           id: "unicode_delegate",
           toolName: "delegate",
-          argumentsJSON: JSON.stringify({ task: emojiTask }),
+          argumentsJSON: JSON.stringify({ prompt: emojiTask }),
           output: JSON.stringify({ status: "completed" }),
         })}
         turn={turn}
@@ -1061,7 +1061,7 @@ test("task-only delegate intent previews preserve an emoji at the Unicode clippi
         item={item({
           id: "ascii_boundary_delegate",
           toolName: "delegate",
-          argumentsJSON: JSON.stringify({ task: exactAsciiTask }),
+          argumentsJSON: JSON.stringify({ prompt: exactAsciiTask }),
           output: JSON.stringify({ status: "completed" }),
         })}
         turn={turn}
@@ -1083,7 +1083,7 @@ test("delegate controls require stable delegate_id and reject activation-only jo
           id: "stable_delegate",
           callId: "call_stable_delegate",
           toolName: "delegate",
-          argumentsJSON: JSON.stringify({ task: "stable" }),
+          argumentsJSON: JSON.stringify({ prompt: "stable" }),
           output: JSON.stringify({
             delegate_id: "dlg_stable",
             status: "running",
@@ -1098,7 +1098,7 @@ test("delegate controls require stable delegate_id and reject activation-only jo
           id: "activation_only_delegate",
           callId: "call_activation_only_delegate",
           toolName: "delegate",
-          argumentsJSON: JSON.stringify({ task: "legacy activation" }),
+          argumentsJSON: JSON.stringify({ prompt: "legacy activation" }),
           output: JSON.stringify({ job_id: "job_legacy", status: "running", transcript_ref: "job:job_legacy" }),
         })}
         turn={turn}
@@ -1140,13 +1140,13 @@ test("blank and non-string delegate tasks keep status without inventing an inten
   const blank = item({
     id: "blank_delegate",
     toolName: "delegate",
-    argumentsJSON: JSON.stringify({ task: " \n\t " }),
+    argumentsJSON: JSON.stringify({ prompt: " \n\t " }),
     output: JSON.stringify({ status: "completed" }),
   });
   const nonString = item({
     id: "non_string_delegate",
     toolName: "delegate",
-    argumentsJSON: JSON.stringify({ task: ["not", "text"] }),
+    argumentsJSON: JSON.stringify({ prompt: ["not", "text"] }),
     output: JSON.stringify({ status: "completed" }),
   });
   render(
@@ -1167,7 +1167,7 @@ test("delegate tool rows use a single top-level disclosure trigger owned by Tool
       item={item({
         toolName: "delegate",
         description: "Testing disclosure boundaries",
-        argumentsJSON: JSON.stringify({ task: "Run tests" }),
+        argumentsJSON: JSON.stringify({ prompt: "Run tests" }),
       })}
       turn={turn}
       live={false}
@@ -1185,7 +1185,7 @@ test("a live, unsettled delegate call renders a running/working status dot (neve
       item={item({
         toolName: "delegate",
         description: "Delegated task is still live",
-        argumentsJSON: JSON.stringify({ task: "Keep going" }),
+        argumentsJSON: JSON.stringify({ prompt: "Keep going" }),
       })}
       turn={turn}
       live={true}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
@@ -1323,3 +1323,18 @@ test("defaults apply at each level; an explicit summary choice persists across l
   );
   expect(screen.queryByTestId("tool-row-summary")).toBeNull();
 });
+
+test("delegate rows from transcripts recorded before the prompt rename still show the brief", () => {
+  render(
+    <ToolCallItem
+      item={item({
+        id: "legacy_delegate",
+        toolName: "delegate",
+        argumentsJSON: JSON.stringify({ task: "Legacy brief from an older transcript" }),
+      })}
+      turn={turn}
+      live={false}
+    />,
+  );
+  expect(screen.getByTestId("tool-row-intent").textContent).toContain("Legacy brief");
+});

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
@@ -72,8 +72,8 @@ function delegateIntentOf(item: ItemModel): string | undefined {
   const statedIntent = statedIntentOf(item);
   if (statedIntent !== undefined) return statedIntent;
 
-  const task = str(parseArgs(item.argumentsJSON), "task")?.replace(/\s+/g, " ").trim();
-  return task === undefined || task === "" ? undefined : clipDelegateIntent(task, DELEGATE_INTENT_PREVIEW_MAX);
+  const brief = str(parseArgs(item.argumentsJSON), "prompt")?.replace(/\s+/g, " ").trim();
+  return brief === undefined || brief === "" ? undefined : clipDelegateIntent(brief, DELEGATE_INTENT_PREVIEW_MAX);
 }
 
 // Both status readers take the delegate call's ALREADY-PARSED output envelope

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
@@ -72,7 +72,9 @@ function delegateIntentOf(item: ItemModel): string | undefined {
   const statedIntent = statedIntentOf(item);
   if (statedIntent !== undefined) return statedIntent;
 
-  const brief = str(parseArgs(item.argumentsJSON), "prompt")?.replace(/\s+/g, " ").trim();
+  const args = parseArgs(item.argumentsJSON);
+  // Transcripts recorded before the rename carry the brief under `task`.
+  const brief = (str(args, "prompt") ?? str(args, "task"))?.replace(/\s+/g, " ").trim();
   return brief === undefined || brief === "" ? undefined : clipDelegateIntent(brief, DELEGATE_INTENT_PREVIEW_MAX);
 }
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.test.tsx
@@ -510,7 +510,7 @@ describe("TranscriptBody", () => {
       text: "",
       toolName: "delegate",
       description: "Inspect a child session",
-      argumentsJSON: '{"task":"inspect"}',
+      argumentsJSON: '{"prompt":"inspect"}',
       output: JSON.stringify({ delegate_id: "dlg_ordinary", status: "running", transcript_ref: "local:child" }),
       status: "completed",
     };

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentModule.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentModule.test.tsx
@@ -100,7 +100,7 @@ test("rowFromDelegateItem uses stable delegate_id and rejects activation-only jo
   const stable = rowFromDelegateItem(
     delegateItem({
       callId: "call_stable",
-      argumentsJSON: JSON.stringify({ task: "inspect" }),
+      argumentsJSON: JSON.stringify({ prompt: "inspect" }),
       output: JSON.stringify({
         delegate_id: "dlg_stable",
         status: "running",
@@ -118,7 +118,7 @@ test("rowFromDelegateItem uses stable delegate_id and rejects activation-only jo
     rowFromDelegateItem(
       delegateItem({
         callId: "call_legacy",
-        argumentsJSON: JSON.stringify({ task: "legacy" }),
+        argumentsJSON: JSON.stringify({ prompt: "legacy" }),
         output: JSON.stringify({ job_id: "job_legacy", status: "running" }),
       }),
     ),
@@ -129,7 +129,7 @@ test("rowFromDelegateItem uses stable delegate_id and rejects activation-only jo
 
 test("delegate: summary is the human description", () => {
   const d = toolRendererFor("delegate");
-  const args = JSON.stringify({ task: "Run the full test suite and report back" });
+  const args = JSON.stringify({ prompt: "Run the full test suite and report back" });
   expect(d.summary(delegateItem({ description: "Testing delegation", argumentsJSON: args }))).toBe(
     "Testing delegation",
   );
@@ -138,7 +138,7 @@ test("delegate: summary is the human description", () => {
 test("delegate: delegated task text is not used for the row summary", () => {
   const d = toolRendererFor("delegate");
   const longTask = "x".repeat(100);
-  const args = JSON.stringify({ task: longTask });
+  const args = JSON.stringify({ prompt: longTask });
   expect(d.summary(delegateItem({ description: "Testing delegation", argumentsJSON: args }))).toBe(
     "Testing delegation",
   );
@@ -151,7 +151,7 @@ test("two delegate ToolCallItems each retain their own card and open action", ()
     turnId: turn.id,
     callId: "call_d1",
     description: "first delegate",
-    argumentsJSON: JSON.stringify({ task: "first child" }),
+    argumentsJSON: JSON.stringify({ prompt: "first child" }),
     output: JSON.stringify({ delegate_id: "dlg_1", status: "running", transcript_ref: "ref_child_1" }),
   });
   const second = delegateItem({
@@ -159,7 +159,7 @@ test("two delegate ToolCallItems each retain their own card and open action", ()
     turnId: turn.id,
     callId: "call_d2",
     description: "second delegate",
-    argumentsJSON: JSON.stringify({ task: "second child" }),
+    argumentsJSON: JSON.stringify({ prompt: "second child" }),
     output: JSON.stringify({ delegate_id: "dlg_2", status: "running", transcript_ref: "ref_child_2" }),
   });
   render(
@@ -193,7 +193,7 @@ test("a settled delegate row renders an honest ms-scale duration", () => {
   const settled = delegateItem({
     id: "d_done",
     callId: "call_done",
-    argumentsJSON: JSON.stringify({ task: "did the thing" }),
+    argumentsJSON: JSON.stringify({ prompt: "did the thing" }),
     output: JSON.stringify({ delegate_id: "job_d", status: "completed", transcript_ref: "ref_d" }),
     startedAt: new Date(startedMs).toISOString(),
     completedAt: new Date(startedMs + 12_000).toISOString(),
@@ -209,7 +209,7 @@ test("a failed card carries the danger rail itself - there is no module chrome t
   const failed = delegateItem({
     id: "d_fail",
     callId: "call_fail",
-    argumentsJSON: JSON.stringify({ task: "will fail" }),
+    argumentsJSON: JSON.stringify({ prompt: "will fail" }),
     output: JSON.stringify({ delegate_id: "job_f", status: "failed", transcript_ref: "ref_f", reason: "build error" }),
   });
   render(<Body item={failed} live={false} />);
@@ -231,7 +231,7 @@ test("3zf8: a cancelled child gets its own distinct stopped kind", () => {
   const stopped = delegateItem({
     id: "d_stopped",
     callId: "call_stopped",
-    argumentsJSON: JSON.stringify({ task: "misbehaving, killed" }),
+    argumentsJSON: JSON.stringify({ prompt: "misbehaving, killed" }),
     output: JSON.stringify({ delegate_id: "job_stopped", status: "cancelled", transcript_ref: "ref_stopped" }),
   });
   render(<Body item={stopped} live={false} />);
@@ -248,7 +248,7 @@ function delegateWithTranscriptRef(ref: string): ItemModel {
   return delegateItem({
     id: "d_ref",
     callId: "call_ref",
-    argumentsJSON: JSON.stringify({ task: "has a transcript" }),
+    argumentsJSON: JSON.stringify({ prompt: "has a transcript" }),
     output: JSON.stringify({ delegate_id: "job_ref", status: "running", transcript_ref: ref }),
   });
 }
@@ -338,7 +338,7 @@ test("no open-transcript button when the row has no transcriptRef yet", () => {
   const noRef = delegateItem({
     id: "d_noref",
     callId: "call_noref",
-    argumentsJSON: JSON.stringify({ task: "no ref yet" }),
+    argumentsJSON: JSON.stringify({ prompt: "no ref yet" }),
     output: "",
   });
   const turn: TurnModel = { id: "turn_noref", status: "completed", items: [] };
@@ -353,7 +353,7 @@ test("a still-running row (with a transcriptRef) offers Open transcript, not gat
   const running = delegateItem({
     id: "d_run_link",
     callId: "call_run_link",
-    argumentsJSON: JSON.stringify({ task: "still running" }),
+    argumentsJSON: JSON.stringify({ prompt: "still running" }),
     output: JSON.stringify({ delegate_id: "job_rl", status: "running", transcript_ref: "ref_run_link" }),
   });
   const turn: TurnModel = { id: "turn_run_link", status: "inProgress", items: [] };
@@ -444,7 +444,7 @@ test("a folded card quotes the child's newest own words from the full event stre
   const running = delegateItem({
     id: "d_quote",
     callId: "call_quote",
-    argumentsJSON: JSON.stringify({ task: "audit the reducer" }),
+    argumentsJSON: JSON.stringify({ prompt: "audit the reducer" }),
     output: JSON.stringify({ delegate_id: "job_q", status: "running", transcript_ref: "ref_quote_child" }),
   });
   render(<Body item={running} live={false} />);
@@ -476,7 +476,7 @@ test("expanding a card lists recent quotes - intents plain, messages italic - ea
   const running = delegateItem({
     id: "d_quotes",
     callId: "call_quotes",
-    argumentsJSON: JSON.stringify({ task: "audit the reducer" }),
+    argumentsJSON: JSON.stringify({ prompt: "audit the reducer" }),
     output: JSON.stringify({ delegate_id: "job_qs", status: "running", transcript_ref: "ref_quotes_child" }),
   });
   const user = userEvent.setup();
@@ -512,7 +512,7 @@ test("an expanded card with no child activity yet says so instead of rendering a
   const running = delegateItem({
     id: "d_empty_quotes",
     callId: "call_empty_quotes",
-    argumentsJSON: JSON.stringify({ task: "just spawned" }),
+    argumentsJSON: JSON.stringify({ prompt: "just spawned" }),
     output: JSON.stringify({ delegate_id: "job_eq", status: "running" }),
   });
   const user = userEvent.setup();
@@ -572,7 +572,7 @@ test("mhcf: the Activity feed caps to the 5 most recent steps, not the first 5",
   const running = delegateItem({
     id: "d_cap",
     callId: "call_cap",
-    argumentsJSON: JSON.stringify({ task: "long running audit" }),
+    argumentsJSON: JSON.stringify({ prompt: "long running audit" }),
     output: JSON.stringify({ delegate_id: "job_cap", status: "running", transcript_ref: "ref_cap_child" }),
   });
   const user = userEvent.setup();
@@ -635,7 +635,7 @@ test("the Activity feed elides round_timings items and ordinals count only real 
   const running = delegateItem({
     id: "d_rt",
     callId: "call_rt",
-    argumentsJSON: JSON.stringify({ task: "timing audit" }),
+    argumentsJSON: JSON.stringify({ prompt: "timing audit" }),
     output: JSON.stringify({ delegate_id: "job_rt", status: "running", transcript_ref: "ref_rt_child" }),
   });
   const user = userEvent.setup();
@@ -659,7 +659,7 @@ test("dr7e: no Job detail section renders when neither resumable nor exhaustion 
   const settled = delegateItem({
     id: "d_noexhaust",
     callId: "call_noexhaust",
-    argumentsJSON: JSON.stringify({ task: "quick task" }),
+    argumentsJSON: JSON.stringify({ prompt: "quick task" }),
     output: JSON.stringify({ delegate_id: "job_noex", status: "completed" }),
   });
   const user = userEvent.setup();
@@ -694,7 +694,7 @@ test("the stats line counts the child's turns and tool calls from the full-turns
   const running = delegateItem({
     id: "d_counts",
     callId: "call_counts",
-    argumentsJSON: JSON.stringify({ task: "count my work" }),
+    argumentsJSON: JSON.stringify({ prompt: "count my work" }),
     output: JSON.stringify({ delegate_id: "job_counts", status: "running", transcript_ref: "ref_counts_child" }),
   });
   render(<Body item={running} live={false} />);
@@ -741,7 +741,7 @@ test("the stats line singularizes a single turn and a single call", async () => 
   const running = delegateItem({
     id: "d_single_counts",
     callId: "call_single_counts",
-    argumentsJSON: JSON.stringify({ task: "count one thing" }),
+    argumentsJSON: JSON.stringify({ prompt: "count one thing" }),
     output: JSON.stringify({
       delegate_id: "job_single_counts",
       status: "running",
@@ -765,7 +765,7 @@ test("a running card's stats line closes with a live elapsed clock from its star
   const running = delegateItem({
     id: "d_clock",
     callId: "call_clock",
-    argumentsJSON: JSON.stringify({ task: "timing me" }),
+    argumentsJSON: JSON.stringify({ prompt: "timing me" }),
     output: JSON.stringify({ delegate_id: "job_clock", status: "running" }),
     startedAt: new Date(now - 221_000).toISOString(),
   });
@@ -801,7 +801,7 @@ test("stable delegate attention and lifecycle own the card while child content s
     id: "d_await",
     turnId: turn.id,
     callId: "call_await",
-    argumentsJSON: JSON.stringify({ task: "needs an answer" }),
+    argumentsJSON: JSON.stringify({ prompt: "needs an answer" }),
     output: JSON.stringify({
       delegate_id: stable.delegateId,
       status: "running",
@@ -874,7 +874,7 @@ test("the card is headless: no tag, no open button inside it", () => {
   const running = delegateItem({
     id: "d_headless",
     callId: "call_headless",
-    argumentsJSON: JSON.stringify({ task: "identity is above me" }),
+    argumentsJSON: JSON.stringify({ prompt: "identity is above me" }),
     output: JSON.stringify({ delegate_id: "job_headless", status: "running", transcript_ref: "ref_headless" }),
   });
   render(<Body item={running} live={false} />);
@@ -891,7 +891,7 @@ test("a headless card exposes hidden identity and status, a visible status shape
       item={delegateItem({
         id: "d_accessible",
         callId: "call_accessible",
-        argumentsJSON: JSON.stringify({ task: "accessible child" }),
+        argumentsJSON: JSON.stringify({ prompt: "accessible child" }),
         output: JSON.stringify({ delegate_id: "dlg_accessible", status: "completed" }),
       })}
       live={false}
@@ -924,7 +924,7 @@ test("multiple cards schedule no intervals of their own", () => {
         item={delegateItem({
           id: "d_clock_a",
           callId: "call_clock_a",
-          argumentsJSON: JSON.stringify({ task: "clock a" }),
+          argumentsJSON: JSON.stringify({ prompt: "clock a" }),
           output: JSON.stringify({ delegate_id: "dlg_clock_a", status: "running" }),
         })}
         live={false}
@@ -933,7 +933,7 @@ test("multiple cards schedule no intervals of their own", () => {
         item={delegateItem({
           id: "d_clock_b",
           callId: "call_clock_b",
-          argumentsJSON: JSON.stringify({ task: "clock b" }),
+          argumentsJSON: JSON.stringify({ prompt: "clock b" }),
           output: JSON.stringify({ delegate_id: "dlg_clock_b", status: "running" }),
         })}
         live={false}
@@ -957,7 +957,7 @@ test("the stats line joins its present segments - never a dangling separator", a
   const running = delegateItem({
     id: "d_seps",
     callId: "call_seps",
-    argumentsJSON: JSON.stringify({ task: "counts only, no tokens, no clock" }),
+    argumentsJSON: JSON.stringify({ prompt: "counts only, no tokens, no clock" }),
     output: JSON.stringify({ delegate_id: "job_seps", status: "running", transcript_ref: "ref_seps_child" }),
   });
   render(<Body item={running} live={false} />);
@@ -1042,7 +1042,7 @@ test("a historical session read hydrates a card's kind, tokens, and clock from t
         id: "d_hist",
         turnId: turn.id,
         callId: "call_hist",
-        argumentsJSON: JSON.stringify({ task: "historical child" }),
+        argumentsJSON: JSON.stringify({ prompt: "historical child" }),
         output: JSON.stringify({ delegate_id: "dlg_hist", status: "running", transcript_ref: "ref_hist_child" }),
       })}
       turn={turn}
@@ -1088,7 +1088,7 @@ test("the folded quote of a markdown final report lands on its first substantive
   const done = delegateItem({
     id: "d_md_quote",
     callId: "call_md_quote",
-    argumentsJSON: JSON.stringify({ task: "fix the findings" }),
+    argumentsJSON: JSON.stringify({ prompt: "fix the findings" }),
     output: JSON.stringify({ delegate_id: "job_md", status: "completed", transcript_ref: "ref_md_child" }),
   });
   render(<Body item={done} live={false} />);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentModuleStore.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentModuleStore.test.ts
@@ -46,7 +46,7 @@ test("delegate cards with the same ids read stable status only from their own se
     callId: "call_a",
     text: "",
     description: "Shared delegate",
-    argumentsJSON: JSON.stringify({ task: "shared task" }),
+    argumentsJSON: JSON.stringify({ prompt: "shared task" }),
     output: JSON.stringify({ delegate_id: "dlg_shared", status: "running" }),
   };
   render(

--- a/cmd/evener-hub/frontend/src/panes/transcript/Transcript.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/transcript/Transcript.test.tsx
@@ -180,7 +180,7 @@ test("renders the thread's turns through the shared VirtualList/TurnBlock engine
               toolName: "delegate",
               callId: "call_delegate",
               description: "Observed delegate",
-              argumentsJson: JSON.stringify({ task: "inspect the observed thread" }),
+              argumentsJson: JSON.stringify({ prompt: "inspect the observed thread" }),
               output: JSON.stringify({ delegate_id: "dlg_observed", status: "running" }),
               status: "completed",
             },

--- a/cmd/evener-tui/internal/msgrender/tool_bodies.go
+++ b/cmd/evener-tui/internal/msgrender/tool_bodies.go
@@ -244,8 +244,8 @@ func delegateBody(args ToolArgs, output string, width int) string {
 
 	th := tuitheme.ActiveTheme()
 	summaryLabel := "delegate"
-	if task := strings.TrimSpace(args.Str("task")); task != "" {
-		summaryLabel = task
+	if brief := strings.TrimSpace(args.Str("prompt")); brief != "" {
+		summaryLabel = brief
 	}
 	identity := identifier.AbbreviateJobID(jobID, 26)
 	if identity != "" {

--- a/cmd/evener-tui/internal/msgrender/tool_bodies.go
+++ b/cmd/evener-tui/internal/msgrender/tool_bodies.go
@@ -244,7 +244,11 @@ func delegateBody(args ToolArgs, output string, width int) string {
 
 	th := tuitheme.ActiveTheme()
 	summaryLabel := "delegate"
-	if brief := strings.TrimSpace(args.Str("prompt")); brief != "" {
+	brief := strings.TrimSpace(args.Str("prompt"))
+	if brief == "" {
+		brief = strings.TrimSpace(args.Str("task")) // brief key in transcripts recorded before the rename
+	}
+	if brief != "" {
 		summaryLabel = brief
 	}
 	identity := identifier.AbbreviateJobID(jobID, 26)

--- a/cmd/evener-tui/internal/msgrender/tool_renderers.go
+++ b/cmd/evener-tui/internal/msgrender/tool_renderers.go
@@ -449,7 +449,7 @@ func init() {
 	toolRenderers["delegate"] = ToolRenderer{
 		Verb: func(_ ToolArgs) string { return "delegate" },
 		Target: func(args ToolArgs) string {
-			task := args.Str("task")
+			task := args.Str("prompt")
 			if len(task) > 80 {
 				task = task[:80] + "…"
 			}

--- a/cmd/evener-tui/internal/msgrender/tool_renderers.go
+++ b/cmd/evener-tui/internal/msgrender/tool_renderers.go
@@ -450,6 +450,9 @@ func init() {
 		Verb: func(_ ToolArgs) string { return "delegate" },
 		Target: func(args ToolArgs) string {
 			task := args.Str("prompt")
+			if task == "" {
+				task = args.Str("task") // brief key in transcripts recorded before the rename
+			}
 			if len(task) > 80 {
 				task = task[:80] + "…"
 			}

--- a/cmd/evener-tui/internal/msgrender/tool_renderers_fuzz_test.go
+++ b/cmd/evener-tui/internal/msgrender/tool_renderers_fuzz_test.go
@@ -36,7 +36,7 @@ func FuzzRenderToolCall(f *testing.F) {
 		{"glob", `{"pattern":"**/*"}`, "", "boom"},
 		{"prov__operation", `{"q":"hi","n":3}`, `{"data":1}`, ""},
 		{"weird-unknown", `not-json`, "", ""},
-		{"delegate", `{"task":"do\nthing"}`, "", ""},
+		{"delegate", `{"prompt":"do\nthing"}`, "", ""},
 		{"", "", "", ""},
 		{"write_file", `{"file_path":"/x","content":"a\nb"}`, "", ""},
 	}
@@ -138,7 +138,7 @@ func replayRenderSurface() {
 		{Name: "read_file", RawArgs: `{"file_path":"x.go","intent":"inspect"}`, Output: "a\nb\nc\nd\ne\nf\n", Done: true, Expanded: true, Duration: 250 * time.Millisecond},
 		{Name: "read_file", RawArgs: `{"file_path":"x.go"}`, Detail: "detail", Output: "output", Error: "boom", Expanded: true},
 		{Name: "read_file", RawArgs: `{"file_path":"x.go"}`, Detail: "detail", Error: "boom", Expanded: true},
-		{Name: "delegate", RawArgs: `{"task":"inspect"}`, Error: "boom", Expanded: true, Subagent: &transcript.SubagentRunInfo{Task: "inspect", Status: "done"}},
+		{Name: "delegate", RawArgs: `{"prompt":"inspect"}`, Error: "boom", Expanded: true, Subagent: &transcript.SubagentRunInfo{Task: "inspect", Status: "done"}},
 		{Name: "delegate_send", RawArgs: `{}`, Done: true, Expanded: true, Subagent: &transcript.SubagentRunInfo{}},
 		{Name: "unknown", RawArgs: `{}`, Done: false, Expanded: false},
 		{Name: "unknown", RawArgs: `{}`, Output: `{"ok":true}`, Error: "boom", Expanded: true},
@@ -176,7 +176,7 @@ func replayRenderSurface() {
 	_ = toolRenderers["shell"].Target(ToolArgs{"command": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"})
 	_ = toolRenderers["grep"].Result(nil, "", "", 0)
 	_ = toolRenderers["list_dir"].Result(nil, `[{"name":"x"}]`, "", 0)
-	_ = toolRenderers["delegate"].Target(ToolArgs{"task": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"})
+	_ = toolRenderers["delegate"].Target(ToolArgs{"prompt": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"})
 	_ = toolRenderers["use_skill"].Target(ToolArgs{"skill_name": "named"})
 	_ = formatLineCount(1)
 	mcp, _ := lookupToolRenderer("provider__operation")
@@ -193,7 +193,7 @@ func replayRenderSurface() {
 	_ = taskListBody(nil, "", 80)
 	_ = taskListBody(nil, "bad", 80)
 	_ = taskListBody(nil, `[{"description":"done","status":"done"},{"name":"work","status":"in_progress"},{"name":"wait","status":"pending"}]`, 80)
-	_ = delegateBody(ToolArgs{"task": " task ", "job_id": "123456789", "status": ""}, "", 10)
+	_ = delegateBody(ToolArgs{"prompt": " task ", "job_id": "123456789", "status": ""}, "", 10)
 	_ = delegateBody(nil, `{"job_id":"abcdefghi","status":"completed"}`, 80)
 	_ = delegateBody(ToolArgs{"job_id": "fallback", "status": "queued"}, "bad", 80)
 	_ = SubagentRunBody(transcript.SubagentRunInfo{}, 10)

--- a/cmd/evener-tui/internal/msgrender/tool_renderers_test.go
+++ b/cmd/evener-tui/internal/msgrender/tool_renderers_test.go
@@ -268,7 +268,7 @@ func TestWebSearchRenderer(t *testing.T) {
 
 func TestDelegateRenderer(t *testing.T) {
 	r, _ := lookupToolRenderer("delegate")
-	args := toolArgsFromJSON(`{"task":"do something useful"}`)
+	args := toolArgsFromJSON(`{"prompt":"do something useful"}`)
 	if r.Verb(args) != "delegate" {
 		t.Errorf("delegate verb = %q", r.Verb(args))
 	}

--- a/cmd/evener-tui/internal/msgrender/tool_renderers_test.go
+++ b/cmd/evener-tui/internal/msgrender/tool_renderers_test.go
@@ -275,6 +275,13 @@ func TestDelegateRenderer(t *testing.T) {
 	if !strings.Contains(r.Target(args), "do something") {
 		t.Errorf("delegate target should include task: %q", r.Target(args))
 	}
+	legacy := toolArgsFromJSON(`{"task":"legacy brief"}`)
+	if !strings.Contains(r.Target(legacy), "legacy brief") {
+		t.Errorf("delegate target should fall back to a legacy task key: %q", r.Target(legacy))
+	}
+	if body := delegateBody(legacy, "", 80); !strings.Contains(body, "legacy brief") {
+		t.Errorf("delegate body should fall back to a legacy task key: %q", body)
+	}
 }
 
 func TestJobSendMessageRenderer(t *testing.T) {

--- a/cmd/evener-tui/internal/toolsummary/fuzz_coverage_test.go
+++ b/cmd/evener-tui/internal/toolsummary/fuzz_coverage_test.go
@@ -21,7 +21,7 @@ func TestFuzzCoverageUnion(t *testing.T) {
 		{"glob", `{"pattern":"*"}`},
 		{"grep", `{"pattern":"x"}`},
 		{"web_fetch", `{"url":"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"}`},
-		{"delegate", `{"task":"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"}`},
+		{"delegate", `{"prompt":"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"}`},
 		{"job_send_message", `{"target":"worker"}`},
 		{"delegate_send", `{"to":"worker"}`},
 		{"job_read_output", `{"job_id":"one"}`},

--- a/cmd/evener-tui/internal/toolsummary/tool_summary.go
+++ b/cmd/evener-tui/internal/toolsummary/tool_summary.go
@@ -175,6 +175,9 @@ func SummarizeToolInDir(toolName, argsJSON, cwd string) (desc, detail string) {
 
 	case "delegate":
 		task := str("prompt")
+		if task == "" {
+			task = str("task") // brief key in transcripts recorded before the rename
+		}
 		firstLine := task
 		if before, _, ok := strings.Cut(task, "\n"); ok {
 			firstLine = before

--- a/cmd/evener-tui/internal/toolsummary/tool_summary.go
+++ b/cmd/evener-tui/internal/toolsummary/tool_summary.go
@@ -174,7 +174,7 @@ func SummarizeToolInDir(toolName, argsJSON, cwd string) (desc, detail string) {
 		return desc, detail
 
 	case "delegate":
-		task := str("task")
+		task := str("prompt")
 		firstLine := task
 		if before, _, ok := strings.Cut(task, "\n"); ok {
 			firstLine = before

--- a/cmd/evener-tui/internal/toolsummary/tool_summary_fuzz_test.go
+++ b/cmd/evener-tui/internal/toolsummary/tool_summary_fuzz_test.go
@@ -24,7 +24,7 @@ func FuzzSummarizeTool(f *testing.F) {
 		{"task_list", `{"action":"append","tasks":[{"description":"d","prompt":"p\nq"}]}`},
 		{"task_list", `{"action":"update","updates":[{"id":1,"status":"done"}]}`},
 		{"web_search", `{"query":"go fuzzing"}`},
-		{"delegate", `{"task":"do a thing\nover two lines"}`},
+		{"delegate", `{"prompt":"do a thing\nover two lines"}`},
 		{"communicate", `{"message":"hi"}`},
 		{"communicate", `{"output":{"message":"nested"}}`},
 		{"some_mcp__op", `{"a":"b","n":3,"flag":true}`},

--- a/cmd/evener-tui/internal/toolsummary/tool_summary_test.go
+++ b/cmd/evener-tui/internal/toolsummary/tool_summary_test.go
@@ -175,7 +175,7 @@ func TestSummarizeTool_WebSearch(t *testing.T) {
 }
 
 func TestSummarizeTool_Delegate(t *testing.T) {
-	desc, _ := SummarizeTool("delegate", `{"task":"Explore the codebase and find all usages of the Foo interface"}`)
+	desc, _ := SummarizeTool("delegate", `{"prompt":"Explore the codebase and find all usages of the Foo interface"}`)
 	if !strings.Contains(desc, "Explore") {
 		t.Errorf("got %q", desc)
 	}

--- a/cmd/evener-tui/internal/toolsummary/tool_summary_test.go
+++ b/cmd/evener-tui/internal/toolsummary/tool_summary_test.go
@@ -175,6 +175,9 @@ func TestSummarizeTool_WebSearch(t *testing.T) {
 }
 
 func TestSummarizeTool_Delegate(t *testing.T) {
+	if legacy, _ := SummarizeTool("delegate", `{"task":"Legacy brief from an older transcript"}`); !strings.Contains(legacy, "Legacy brief") {
+		t.Errorf("legacy task key not rendered: %q", legacy)
+	}
 	desc, _ := SummarizeTool("delegate", `{"prompt":"Explore the codebase and find all usages of the Foo interface"}`)
 	if !strings.Contains(desc, "Explore") {
 		t.Errorf("got %q", desc)

--- a/cmd/evener-tui/internal/transcript/fuzz_coverage_union_test.go
+++ b/cmd/evener-tui/internal/transcript/fuzz_coverage_union_test.go
@@ -24,7 +24,7 @@ func replayTranscriptCoverage(t *testing.T) {
 		{ID: "user", TurnID: "turn_1", Type: "userMessage", Text: "hello"},
 		{ID: "reason", TurnID: "turn_1", Type: "reasoning"},
 		{ID: "agent", TurnID: "turn_1", Type: "agentMessage", Text: "answer"},
-		{ID: "tool", CallID: "call", TurnID: "turn_1", Type: "commandExecution", ToolName: "delegate", ArgumentsJSON: `{"task":"cover"}`, Raw: []byte(`{"started_job_id":"job","type":"delegate","status":"running","task":"cover","transcript_ref":"ref","origin_turn_id":"turn_1","origin_tool_call_id":"call","origin_item_id":"tool","total_bytes":3}`), StartedAt: ms(10)},
+		{ID: "tool", CallID: "call", TurnID: "turn_1", Type: "commandExecution", ToolName: "delegate", ArgumentsJSON: `{"prompt":"cover"}`, Raw: []byte(`{"started_job_id":"job","type":"delegate","status":"running","task":"cover","transcript_ref":"ref","origin_turn_id":"turn_1","origin_tool_call_id":"call","origin_item_id":"tool","total_bytes":3}`), StartedAt: ms(10)},
 		{ID: "tool", CallID: "call", TurnID: "turn_1", Type: "commandExecution", ToolName: "delegate_send", ArgumentsJSON: `{}`, Output: `{"delegate_id":"delegate","latest_job_id":"job","status":"completed","output_bytes":5}`, StartedAt: ms(10), CompletedAt: ms(20)},
 		{ID: "communicate", Type: "commandExecution", ToolName: "communicate", Output: "ok"},
 	}

--- a/cmd/evener-tui/internal/transcript/reducer_fuzz_test.go
+++ b/cmd/evener-tui/internal/transcript/reducer_fuzz_test.go
@@ -25,7 +25,7 @@ func FuzzApplyThreadItem(f *testing.F) {
 		{"reasoning", "", "", "", ""},
 		{"userMessage", "", "", "", ""},
 		{"systemMessage", "", "", "", ""},
-		{"commandExecution", `{"job_id":"j1","type":"delegate","status":"running"}`, "", "delegate", `{"task":"x"}`},
+		{"commandExecution", `{"job_id":"j1","type":"delegate","status":"running"}`, "", "delegate", `{"prompt":"x"}`},
 		{"commandExecution", `{"delegate_id":"d1","status":"completed","task":"t"}`, "", "delegate", ""},
 		{"commandExecution", "", `{"job_id":"j2","type":"shell"}`, "shell", `{"command":"ls"}`},
 		{"commandExecution", `{"current_job_id":"c","total_bytes":42}`, "", "delegate_send", `{"to":"d"}`},

--- a/cmd/evener/run_drain_nested_test.go
+++ b/cmd/evener/run_drain_nested_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func scriptedDelegateCallWithAllowance(id, task string, allowance int) llm.Response {
-	args, _ := json.Marshal(map[string]any{"task": task, "delegation_allowance": allowance})
+	args, _ := json.Marshal(map[string]any{"prompt": task, "delegation_allowance": allowance})
 	return scriptedToolCalls(llm.ToolCallData{ID: id, Name: "delegate", Arguments: args, Type: "function"})
 }
 

--- a/cmd/evener/run_drain_test.go
+++ b/cmd/evener/run_drain_test.go
@@ -75,7 +75,7 @@ func messagesText(messages []llm.Message) string {
 }
 
 func scriptedDelegateCall(id, task string) llm.Response {
-	args, _ := json.Marshal(map[string]any{"task": task})
+	args, _ := json.Marshal(map[string]any{"prompt": task})
 	return scriptedToolCalls(llm.ToolCallData{ID: id, Name: "delegate", Arguments: args, Type: "function"})
 }
 

--- a/docs/job-control.md
+++ b/docs/job-control.md
@@ -362,7 +362,7 @@ Canonical background shape:
 
 ```json
 {
-  "task": "Investigate the failing parser test and report findings.",
+  "prompt": "Investigate the failing parser test and report findings.",
   "agent_type": "explorer",
   "model": "openai/gpt-5.5",
   "reasoning_effort": "high"
@@ -373,7 +373,11 @@ Full target shape (no `max_wait_ms`):
 
 ```json
 {
-  "task": "Investigate the failing parser test and report findings.",
+  "prompt": "Investigate the failing parser test and report findings.",
+  "task_list": [
+    {"title": "Reproduce", "prompt": "Run the parser test suite and capture the failing case verbatim."},
+    {"title": "Report", "prompt": "Report the failing input, the stack, and the smallest change that would fix it.", "type": "research"}
+  ],
   "agent_type": "explorer",
   "model": "openai/gpt-5.5",
   "reasoning_effort": "high",

--- a/docs/job-control.md
+++ b/docs/job-control.md
@@ -49,7 +49,9 @@ This reference contract is not itself the runtime system prompt, but the followi
 - Shell commands run in `mode="foreground"` by default and return inline output for quick commands. Set `mode="background"` to launch-and-return as a session-owned job; foreground commands that exceed the session-default wait are promoted to durable background jobs and return a `job_id`. Set `mode="detached"` only to immediately disown a process that does not need Evener job visibility, output, notification, or stop control; it returns only a PID.
 - Delegate creation returns after one stable `delegate_id` and its initial input
   are durable. It does not accept `max_wait_ms` and does not expose a run handle.
-- Use `delegate` to start a new delegate conversation. It returns `dlg_...`,
+- Use `delegate` to start a new delegate conversation: `prompt` is the brief
+  (the only input the delegate receives) and `task_list` seeds its task list,
+  one item per step. It returns `dlg_...`,
   child/session transcript metadata, status, and resumability—never `job_...`.
 - Use `delegate_send` for follow-up: a running delegate is steered; an idle,
   resumable delegate starts its next private run through the same call.

--- a/docs/subagent-management/11-delegate-resource-model.md
+++ b/docs/subagent-management/11-delegate-resource-model.md
@@ -594,9 +594,12 @@ durable fold rejects any disagreement between them.
 TaskTemplates stores a copy of every template in the selected named agent's
 ordered workflow, including each title, prompt, reasoning effort, type, and
 insertion directive. Stable construction populates the child task store from
-that complete committed slice. Registered delegate creation supplies no parent
-task templates, preserving the existing child-workflow behavior without
-consulting the live agent registry after commit.
+that complete committed slice. A parent-supplied `task_list` is expanded into
+that slice at describe time (replacing the role's `parent_tasks` placeholder,
+or following the role's defaults when it has none), so launch and every
+resume seed the child from the same frozen list without consulting the live
+agent registry after commit. A delegate that shares its parent's task store
+refuses `task_list` at creation, since a shared store is never re-seeded.
 
 ToolNameCeiling stores the sorted, unique, pre-commit ceiling derived from the
 effective parent registry, named-agent policy, watch and delegation grants,

--- a/internal/bundled/agents/subagent.md
+++ b/internal/bundled/agents/subagent.md
@@ -1,20 +1,26 @@
 ---
 name: subagent
-description: "Focused subagent for a single scoped task. A non-delegating leaf: it has no `delegate` tool and cannot spawn further agents regardless of any delegation_allowance granted to it. It can send results or observer callbacks to its caller. For a multi-level tree, delegate with the default role instead of this one."
+description: "Implementer for one bounded unit of work: owns the paths its brief names, makes the change, runs the check that proves it, and reports the evidence. Also handles a scoped investigation or review when that is what the brief asks for. A non-delegating leaf: it has no `delegate` tool and cannot spawn further agents regardless of any delegation_allowance granted to it. For a multi-level tree, delegate with the default role instead of this one."
 model: inherit
 color: blue
 tools: [glob, grep, read_file, write_file, apply_patch, shell, task_list, web_fetch, delegate_send]
 ---
 
-You are a focused subagent executing a specific delegated task. Your default mode is
-scoped execution: do what was asked, stay within scope, and report back clearly.
-Do not assume the task requires code changes, tests, or broad workspace inspection
-unless the task actually calls for them. You MUST try your hardest to successfully
-complete every task — never refuse, never claim it is impossible. Find a way.
-Complete the work and report your findings.
+You are a subagent executing one delegated unit of work. Your brief is the
+whole specification: what you own, what done means, and how you will know you
+have succeeded. You MUST try your hardest to complete it — never refuse, never
+claim it is impossible. Find a way.
 
 If your task list is populated, it defines your workflow: work the tasks in
 order, mark each done as you finish it, and report at the end.
+
+## Scope
+
+- Do exactly the unit the brief describes. Own the files and paths it names
+  and do not touch others. Do not broaden the unit on your own.
+- A brief that asks for a change is asking you to make it, not to describe
+  it. A brief that asks for a report, a review, or a check is asking for
+  exactly that and no edits.
 
 ## Reporting
 
@@ -38,33 +44,23 @@ contain the actual answer, findings, or blocking details.
 ## Workflow
 
 - Always attempt the task. Never refuse, decline, or ask for clarification.
-- Start with the narrowest action that can complete the task. Do not broaden the
-  task on your own.
-- Do not assume the task needs implementation work. Many delegated tasks are read-only,
-  observational, or operational.
-- Verify facts that matter to the requested result, but do not add extra checking
-  just because it is available.
-- Fix errors yourself rather than reporting them and stopping.
+- Fix errors inside your unit yourself rather than reporting them and stopping.
 - Read the complete error message before attempting fixes. Stack traces often contain the
   exact answer.
 - When you have multiple independent actions (reading files, running commands), issue them
   as parallel tool calls in a single response. Five reads in one call are far cheaper than
   five sequential calls.
-- Keep changes minimal and focused on the task.
-- If the task does not require file changes, do not modify files.
-- If the task asks for a single command, check, or answer, do that and stop.
+- Keep changes minimal and focused on the unit.
 - Do not add error handling or validation for scenarios that cannot occur.
 
-## Verification
+## Done means checked
 
-Verify only to the level the task requires:
-
-1. If you changed files, ran commands, or checked a condition, report the evidence.
-2. If the task explicitly asks for tests or validation, run them and include the results.
-3. Do not go hunting for unrelated tests or perform extra workspace checks unless they
-   are necessary to answer the delegated task.
-4. If you took an extra step beyond the literal request because it was necessary, say so
-   explicitly in your final report.
+Before you report, run the success check your brief names and include its
+output. If it fails, fix within your unit and run it again. If the brief names
+no check, run the most direct check the work admits and say that it was your
+choice. Do not go hunting for unrelated tests or perform workspace checks
+beyond what proves your unit done. If you took a step beyond the brief because
+it was necessary, say so explicitly in your final report.
 
 ## Non-interactive
 

--- a/internal/bundled/agents/subagent.md
+++ b/internal/bundled/agents/subagent.md
@@ -13,6 +13,9 @@ unless the task actually calls for them. You MUST try your hardest to successful
 complete every task — never refuse, never claim it is impossible. Find a way.
 Complete the work and report your findings.
 
+If your task list is populated, it defines your workflow: work the tasks in
+order, mark each done as you finish it, and report at the end.
+
 ## Reporting
 
 The parent agent only sees the result you send back, not your intermediate tool

--- a/internal/bundled/agents/subagent.md
+++ b/internal/bundled/agents/subagent.md
@@ -3,7 +3,7 @@ name: subagent
 description: "Implementer for one bounded unit of work: owns the paths its brief names, makes the change, runs the check that proves it, and reports the evidence. Also handles a scoped investigation or review when that is what the brief asks for. Delegates in turn only when its parent grants a `delegation_allowance`; with the default allowance of 0 it is a leaf."
 model: inherit
 color: blue
-tools: [glob, grep, read_file, write_file, apply_patch, shell, task_list, web_fetch, delegate, delegate_send, job_status, job_list, job_stop, job_watch, read_transcript]
+tools: [glob, grep, read_file, write_file, apply_patch, shell, task_list, web_fetch, delegate, delegate_send, job_status, job_list, job_stop, read_transcript]
 ---
 
 You are a subagent executing one delegated unit of work. Your brief is the

--- a/internal/bundled/agents/subagent.md
+++ b/internal/bundled/agents/subagent.md
@@ -1,9 +1,9 @@
 ---
 name: subagent
-description: "Implementer for one bounded unit of work: owns the paths its brief names, makes the change, runs the check that proves it, and reports the evidence. Also handles a scoped investigation or review when that is what the brief asks for. A non-delegating leaf: it has no `delegate` tool and cannot spawn further agents regardless of any delegation_allowance granted to it. For a multi-level tree, delegate with the default role instead of this one."
+description: "Implementer for one bounded unit of work: owns the paths its brief names, makes the change, runs the check that proves it, and reports the evidence. Also handles a scoped investigation or review when that is what the brief asks for. Delegates in turn only when its parent grants a `delegation_allowance`; with the default allowance of 0 it is a leaf."
 model: inherit
 color: blue
-tools: [glob, grep, read_file, write_file, apply_patch, shell, task_list, web_fetch, delegate_send]
+tools: [glob, grep, read_file, write_file, apply_patch, shell, task_list, web_fetch, delegate, delegate_send, job_status, job_list, job_stop, job_watch, read_transcript]
 ---
 
 You are a subagent executing one delegated unit of work. Your brief is the

--- a/internal/bundled/plugins/coordinator-workflow/agents/coordinator.md
+++ b/internal/bundled/plugins/coordinator-workflow/agents/coordinator.md
@@ -27,18 +27,19 @@ tasks:
       that package's API, not a lower-level alternative. Plan how you
       will verify the result — what acceptance criteria matter, what
       shortcuts to watch for. Create the task list you will pass
-      to the implementer inside the delegate task prompt.
+      to the implementer inside the delegate prompt.
       DO NOT read source files, run code, or test solutions during
       planning. Your job is to write the delegation prompt, not to
       do the implementer's work.
     reasoning_effort: high
   - title: Delegate
     prompt: >
-      Start ONE implementer with delegate using your delegation prompt and task list
-      from your plan. Use agent_type="implementer", reasoning_effort=low. Low
-      reasoning effort gives the implementer more rounds in its time
-      budget; it auto-escalates when the agent gets stuck. Include the
-      task list directly in the task prompt. The delegate task must contain
+      Start ONE implementer with delegate: your delegation prompt goes in
+      `prompt` and the task list from your plan in `task_list`, one
+      self-contained item per step. Use agent_type="implementer",
+      reasoning_effort=low. Low reasoning effort gives the implementer more
+      rounds in its time budget; it auto-escalates when the agent gets
+      stuck. The delegate prompt must contain
       ALL critical constraints from the spec — the implementer reads this first
       and may start work immediately. Do not summarize — include constraints
       verbatim. Keep the returned delegate_id and transcript_ref for follow-up,
@@ -49,7 +50,7 @@ tasks:
     prompt: >
       Start a verifier with delegate to check the implementer's work. Use
       agent_type="verifier", reasoning_effort=low. The
-      verifier's task parameter must include:
+      verifier's prompt must include:
       (1) the COMPLETE task spec verbatim, (2) the acceptance
       criteria, (3) what the implementer reported doing, and
       (4) the implementer's transcript_ref (from the delegate


### PR DESCRIPTION
## What

`delegate` gets a `task_list` parameter that seeds the delegate's task list, and its brief parameter is renamed from `task` to `prompt` and given a description.

- `task_list`: array of `{title, prompt, reasoning_effort?, type?}`. Items replace the role's `parent_tasks` placeholder when its default task list has one (explorer) and follow the role's defaults otherwise (subagent, default). The list is frozen into the delegate descriptor at creation, so launch and every resume seed the child from it. The first task auto-starts and its prompt is injected, same as a root session.
- `prompt`: required, non-empty. The description states what a brief has to carry, because the delegate receives nothing else: the request quoted, known facts, owned paths, the acceptance check, the report. An empty or missing brief is now `invalid_request: prompt is required` instead of a delegate that starts with no input and sits idle.
- No alias for `task`. Internal field names (descriptor `task`, status projections) are unchanged.

## Why

The legacy `spawn_agent` tool carried `task_list` (pre-populate through the `parent_tasks` slot) until the tool surface was replaced on 2026-06-09 (`a240649ef`); `delegate` never got it and the slot has been empty since. Terminal-Bench trials show why it matters: across 259 delegations in five prompt variants, every brief was a one-paragraph string, 96-99% read-only, and the `task` parameter had no description at all. A micro-experiment series found that a prescriptive brief contract raises briefs that name an acceptance check from 6% to 61-85%.

## Prompting

- `delegation.md`: the "give the subagent enough context" advice becomes the four-part brief contract, plus one paragraph on `task_list` for multi-step units.
- `subagent` role: "if your task list is populated, it defines your workflow."
- `docs/job-control.md`: parameter mention.

## Tests

- `agent/task`: `ExpandParentTasks` (placeholder replaced, appended when absent, placeholder task kept when there are no parent tasks) and `PopulateFromTemplates` append behaviour.
- `agent/internal/tool`: schema pins `prompt` (required, described) and the `task_list` item schema; no `task`.
- `agent`: `decodeDelegateArgs` decodes `prompt` and `task_list`, rejects malformed lists and empty prompts; `createDelegate` freezes the list into the descriptor and the child's task store shows the tasks with the first in progress.
- TUI renderers and every scripted delegate call in the suites moved to `prompt`.

## Follow-ups (not in this PR)

- `delegate_send.task_list` append (the legacy `resume_agent` had it).
- Whether the `reasoning_effort` enum for delegates should include the parent's `max`.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT
