### PR TITLE
fix(agent): orient session namer prompts on the overarching session goal

### DIFF
--- a/agent/cov_w2tail_namer_test.go
+++ b/agent/cov_w2tail_namer_test.go
@@ -29,10 +29,10 @@ func (a *erroringAdapter) Stream(ctx context.Context, req llm.Request) (llm.Stre
 func TestW2Tail_nameSession_Guards(t *testing.T) {
 	profile := NewOpenAIProfile("gpt-5.2")
 
-	if _, err := nameSession(context.Background(), nil, profile, sessionNameSourcePrompt, "text", noNamerSleep); err == nil {
+	if _, err := nameSession(context.Background(), nil, profile, sessionNameSourcePrompt, "text", "", noNamerSleep); err == nil {
 		t.Errorf("nil client should error")
 	}
-	if _, err := nameSession(context.Background(), llm.NewClient(), nil, sessionNameSourcePrompt, "text", noNamerSleep); err == nil {
+	if _, err := nameSession(context.Background(), llm.NewClient(), nil, sessionNameSourcePrompt, "text", "", noNamerSleep); err == nil {
 		t.Errorf("nil profile should error")
 	}
 }
@@ -40,7 +40,7 @@ func TestW2Tail_nameSession_Guards(t *testing.T) {
 func TestW2Tail_nameSession_LLMErrorWrapped(t *testing.T) {
 	client := llm.NewClient()
 	client.Register(&erroringAdapter{name: "openai"})
-	_, err := nameSession(context.Background(), client, NewOpenAIProfile("gpt-5.2"), sessionNameSourcePrompt, "do a thing", noNamerSleep)
+	_, err := nameSession(context.Background(), client, NewOpenAIProfile("gpt-5.2"), sessionNameSourcePrompt, "do a thing", "", noNamerSleep)
 	if err == nil {
 		t.Fatalf("expected wrapped LLM error")
 	}
@@ -59,7 +59,7 @@ func TestW2Tail_nameSession_EmptyNameAfterSanitize(t *testing.T) {
 			},
 		},
 	})
-	_, err := nameSession(context.Background(), client, NewOpenAIProfile("gpt-5.2"), sessionNameSourceCompaction, "summary text", noNamerSleep)
+	_, err := nameSession(context.Background(), client, NewOpenAIProfile("gpt-5.2"), sessionNameSourceCompaction, "summary text", "", noNamerSleep)
 	if err == nil {
 		t.Fatalf("expected empty-name error after sanitize")
 	}

--- a/agent/session_misc_fuzz_test.go
+++ b/agent/session_misc_fuzz_test.go
@@ -144,7 +144,7 @@ func FuzzSessionMetadataHelpers(f *testing.F) {
 		if *new(text) != text || sessionNameSourceLabel(string(mode)) != normalizeSessionNameSource(string(mode)) {
 			t.Fatal("session-name source helpers disagree")
 		}
-		if _, err := nameSession(context.Background(), nil, nil, string(mode), text, nil); err == nil {
+		if _, err := nameSession(context.Background(), nil, nil, string(mode), text, "", nil); err == nil {
 			t.Fatal("session namer accepted a nil client")
 		}
 

--- a/agent/session_misc_fuzz_test.go
+++ b/agent/session_misc_fuzz_test.go
@@ -135,7 +135,7 @@ func FuzzSessionMetadataHelpers(f *testing.F) {
 		} else if utf8.ValidString(text) && !utf8.ValidString(trimmed) {
 			t.Fatal("session-namer trimming corrupted valid UTF-8")
 		}
-		if !strings.Contains(sessionNamerUserPrompt(string(mode), text), trimForSessionNamer(text)) {
+		if !strings.Contains(sessionNamerUserPrompt(string(mode), text, ""), trimForSessionNamer(text)) {
 			t.Fatal("namer prompt omitted the bounded source text")
 		}
 		if schema := sessionNameSchema(); schema["type"] != "object" {

--- a/agent/session_namer.go
+++ b/agent/session_namer.go
@@ -152,7 +152,7 @@ func sessionNamerUserPrompt(source, text string) string {
 	var label string
 	switch normalizeSessionNameSource(source) {
 	case sessionNameSourceCompaction:
-		label = "Use this compaction summary to refresh the session title. The title must still name the session's overarching goal, not the momentary activity: the summary's Current State and Pending Work sections describe what was happening at one instant, so do not title the session after them. Look for the goal in the user's original request and the conversation timeline."
+		label = "Use this compaction summary/checkpoint to refresh the session title. The title must still name the session's overarching goal, not the momentary activity. Find the goal in the user's original request and the conversation timeline."
 	default:
 		label = "Use this initial user prompt to name the session"
 	}

--- a/agent/session_namer.go
+++ b/agent/session_namer.go
@@ -41,7 +41,9 @@ type sessionNameResult struct {
 // production passes s.cfg.LLMSleep (nil, so GenerateObject uses the real
 // DefaultSleep), while tests inject a no-op so a retryable provider error
 // doesn't burn the full 1+2+4+8s backoff as real wall time.
-func nameSession(ctx context.Context, client *llm.Client, profile *provider.Profile, source, text string, sleep llm.SleepFunc) (sessionNameResult, error) {
+// currentTitle is the session's existing title when refreshing from a
+// compaction turn, or "" when naming from the initial prompt (no title yet).
+func nameSession(ctx context.Context, client *llm.Client, profile *provider.Profile, source, text, currentTitle string, sleep llm.SleepFunc) (sessionNameResult, error) {
 	if client == nil {
 		return sessionNameResult{}, errors.New("session namer: llm client is nil")
 	}
@@ -72,7 +74,7 @@ func nameSession(ctx context.Context, client *llm.Client, profile *provider.Prof
 		Provider:    profile.CheapProvider(),
 		Model:       model,
 		System:      new(sessionNamerSystemPrompt),
-		Prompt:      new(sessionNamerUserPrompt(source, text)),
+		Prompt:      new(sessionNamerUserPrompt(source, text, currentTitle)),
 		Temperature: &temp,
 		MaxTokens:   &maxTokens,
 		Sleep:       sleep,
@@ -148,15 +150,19 @@ Rules:
   session after the current activity, the file being edited, or the test being
   debugged.`
 
-func sessionNamerUserPrompt(source, text string) string {
+func sessionNamerUserPrompt(source, text, currentTitle string) string {
 	var label string
 	switch normalizeSessionNameSource(source) {
 	case sessionNameSourceCompaction:
-		label = "Use this compaction summary/checkpoint to refresh the session title. The title must still name the session's overarching goal, not the momentary activity. Find the goal in the user's original request and the conversation timeline."
+		label = "Use this compaction summary/checkpoint to refresh the session title. The title must still name the session's overarching goal, not the momentary activity. Keep the current title unless it no longer names the goal. Find the goal in the user's original request and the conversation timeline."
 	default:
 		label = "Use this initial user prompt to name the session"
 	}
-	return label + ":\n\n" + trimForSessionNamer(text)
+	prompt := label + ":\n\n"
+	if title := strings.TrimSpace(currentTitle); title != "" {
+		prompt += "Current title: " + title + "\n\n"
+	}
+	return prompt + trimForSessionNamer(text)
 }
 
 func sessionNameSchema() map[string]any {
@@ -377,6 +383,16 @@ func (s *Session) shouldNameFromCompaction() bool {
 	return source == sessionNameSourcePrompt || source == sessionNameSourceCompaction
 }
 
+// currentSessionName returns the session's existing title, or "" when none is
+// set. The compaction namer passes it into the naming prompt so a refresh can
+// preserve a goal-level title instead of re-deriving one from text that may
+// have lost the original goal to compaction truncation or shedding.
+func (s *Session) currentSessionName() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.naming.value
+}
+
 func (s *Session) nameSessionFromText(ctx context.Context, source, text string) error {
 	source = normalizeSessionNameSource(source)
 	if !s.shouldApplySessionName(source) {
@@ -391,7 +407,7 @@ func (s *Session) nameSessionFromText(ctx context.Context, source, text string) 
 	if s.cfg.testOnly.namerClient != nil {
 		namerClient = s.cfg.testOnly.namerClient
 	}
-	result, err := nameSession(ctx, namerClient, s.currentProfile(), source, text, s.cfg.LLMSleep)
+	result, err := nameSession(ctx, namerClient, s.currentProfile(), source, text, s.currentSessionName(), s.cfg.LLMSleep)
 	if err != nil {
 		// Record the suppression before writing the advisory: the advisory is
 		// the only externally observable marker that this attempt finished, so

--- a/agent/session_namer.go
+++ b/agent/session_namer.go
@@ -134,6 +134,9 @@ func configuredSessionNamerModel(profile *provider.Profile) string {
 }
 
 const sessionNamerSystemPrompt = `You generate concise session titles for a developer assistant.
+The title is a durable label a human uses to find this session in a list, so it
+must name the session's overarching goal: the problem the user wants solved
+across the whole session.
 Return only JSON matching the requested schema.
 Rules:
 - 2 to 6 words.
@@ -141,13 +144,15 @@ Rules:
 - Use Title Case.
 - No ending punctuation.
 - No quotes or markdown.
-- Prefer the concrete task or outcome over generic wording.`
+- Name the overall goal, not what was happening at one moment. Do not title the
+  session after the current activity, the file being edited, or the test being
+  debugged.`
 
 func sessionNamerUserPrompt(source, text string) string {
 	var label string
 	switch normalizeSessionNameSource(source) {
 	case sessionNameSourceCompaction:
-		label = "Use this compaction summary/checkpoint to refresh the session title"
+		label = "Use this compaction summary to refresh the session title. The title must still name the session's overarching goal, not the momentary activity: the summary's Current State and Pending Work sections describe what was happening at one instant, so do not title the session after them. Look for the goal in the user's original request and the conversation timeline."
 	default:
 		label = "Use this initial user prompt to name the session"
 	}

--- a/agent/session_namer_covtest_test.go
+++ b/agent/session_namer_covtest_test.go
@@ -116,7 +116,7 @@ func TestSessionNameSchema(t *testing.T) {
 // TestSessionNamerUserPrompt covers the prompt builder (lines 142-150).
 func TestSessionNamerUserPrompt(t *testing.T) {
 	// Prompt source.
-	got := sessionNamerUserPrompt(sessionNameSourcePrompt, "test input")
+	got := sessionNamerUserPrompt(sessionNameSourcePrompt, "test input", "")
 	if !strings.Contains(got, "initial user prompt") {
 		t.Fatalf("missing prompt label: %q", got)
 	}
@@ -125,9 +125,17 @@ func TestSessionNamerUserPrompt(t *testing.T) {
 	}
 
 	// Compaction source.
-	got = sessionNamerUserPrompt(sessionNameSourceCompaction, "summary text")
+	got = sessionNamerUserPrompt(sessionNameSourceCompaction, "summary text", "Existing Title")
 	if !strings.Contains(got, "compaction summary") {
 		t.Fatalf("missing compaction label: %q", got)
+	}
+	if !strings.Contains(got, "Current title: Existing Title") {
+		t.Fatalf("compaction prompt missing current title: %q", got)
+	}
+	// Empty current title (initial naming) must not render a title prefix.
+	got = sessionNamerUserPrompt(sessionNameSourceCompaction, "summary text", "")
+	if strings.Contains(got, "Current title:") {
+		t.Fatalf("empty current title should not render prefix: %q", got)
 	}
 }
 

--- a/agent/session_namer_hook_test.go
+++ b/agent/session_namer_hook_test.go
@@ -287,6 +287,49 @@ func TestSessionNameFromCompactionTurn_RefreshesPromptName(t *testing.T) {
 	}
 }
 
+// TestSessionNameFromCompactionTurn_SendsCurrentTitleToLLM proves the session's
+// existing title crosses into the naming request on the compaction refresh
+// path: the model can then keep a goal-level title instead of re-deriving one
+// from checkpoint text that may have lost the original goal (roborev #826).
+func TestSessionNameFromCompactionTurn_SendsCurrentTitleToLLM(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	adapter := &fakeAdapter{
+		name: "openai",
+		steps: []func(req llm.Request) llm.Response{
+			func(req llm.Request) llm.Response {
+				joined := messagesText(req.Messages)
+				if !strings.Contains(joined, "Current title: Fix Parser Crashes") {
+					t.Errorf("naming request missing current title: %q", joined)
+				}
+				return llm.Response{Message: llm.Assistant(`{"name":"Fix Parser Crashes"}`)}
+			},
+		},
+	}
+	client := llm.NewClient()
+	client.Register(adapter)
+	profile := WithCheapModel(NewOpenAIProfile("gpt-5.2"), "gpt-4.1-nano")
+	sess, err := NewSession(client, profile, execenv.NewLocalExecutionEnvironment(dir), SessionConfig{StateDir: dir})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+
+	sess.mu.Lock()
+	sess.naming.value = "Fix Parser Crashes"
+	sess.naming.source = sessionNameSourcePrompt
+	sess.naming.updated = time.Now().UTC()
+	sess.mu.Unlock()
+
+	turn := schema.NewTurn(schema.TurnCheckpoint, llm.User("[CONTEXT CHECKPOINT]\nWorking Notes: debugging test failures"))
+	if err := sess.nameSessionFromCompactionTurn(context.Background(), turn); err != nil {
+		t.Fatalf("nameSessionFromCompactionTurn: %v", err)
+	}
+	if got := sess.Meta().Name; got != "Fix Parser Crashes" {
+		t.Fatalf("Name = %q, want preserved title", got)
+	}
+}
+
 func TestSessionNameFromCompactionTurn_SkipsNonCompactionAndManualName(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/agent/session_namer_program_fuzz_test.go
+++ b/agent/session_namer_program_fuzz_test.go
@@ -58,8 +58,8 @@ func FuzzSessionNamerProgram(f *testing.F) {
 		if mode&1 != 0 {
 			source = sessionNameSourceCompaction
 		}
-		prompt := sessionNamerUserPrompt(source, text)
-		if again := sessionNamerUserPrompt(source, text); prompt != again {
+		prompt := sessionNamerUserPrompt(source, text, "")
+		if again := sessionNamerUserPrompt(source, text, ""); prompt != again {
 			t.Fatalf("session namer prompt was not deterministic")
 		}
 		clean := sanitizeSessionName(candidate)

--- a/agent/session_namer_program_fuzz_test.go
+++ b/agent/session_namer_program_fuzz_test.go
@@ -97,23 +97,23 @@ func FuzzSessionNamerProgram(f *testing.F) {
 		}
 
 		// Exercise public input guards before constructing a valid scripted call.
-		if _, err := nameSession(context.Background(), nil, profile, source, text, noNamerSleep); err == nil {
+		if _, err := nameSession(context.Background(), nil, profile, source, text, "", noNamerSleep); err == nil {
 			t.Fatal("nil client was accepted")
 		}
-		if _, err := nameSession(context.Background(), llm.NewClient(), nil, source, text, noNamerSleep); err == nil {
+		if _, err := nameSession(context.Background(), llm.NewClient(), nil, source, text, "", noNamerSleep); err == nil {
 			t.Fatal("nil profile was accepted")
 		}
-		if _, err := nameSession(context.Background(), llm.NewClient(), profile, source, " ", noNamerSleep); err == nil {
+		if _, err := nameSession(context.Background(), llm.NewClient(), profile, source, " ", "", noNamerSleep); err == nil {
 			t.Fatal("empty source text was accepted")
 		}
 		// A record with no model id: the degenerate profile the namer must refuse.
 		emptyModel := provider.FromResolved(registry.Resolved{Instance: "openai"}, nil)
-		if _, err := nameSession(context.Background(), llm.NewClient(), emptyModel, source, text, noNamerSleep); err == nil {
+		if _, err := nameSession(context.Background(), llm.NewClient(), emptyModel, source, text, "", noNamerSleep); err == nil {
 			t.Fatal("empty model was accepted")
 		}
 		failureClient := llm.NewClient()
 		failureClient.Register(namerFuzzErrorAdapter{})
-		if _, err := nameSession(context.Background(), failureClient, profile, source, text, noNamerSleep); err == nil || !strings.Contains(err.Error(), "scripted failure") {
+		if _, err := nameSession(context.Background(), failureClient, profile, source, text, "", noNamerSleep); err == nil || !strings.Contains(err.Error(), "scripted failure") {
 			t.Fatalf("scripted provider error = %v", err)
 		}
 
@@ -136,7 +136,7 @@ func FuzzSessionNamerProgram(f *testing.F) {
 		}}
 		client := llm.NewClient()
 		client.Register(adapter)
-		result, err := nameSession(context.Background(), client, profile, source, text, noNamerSleep)
+		result, err := nameSession(context.Background(), client, profile, source, text, "", noNamerSleep)
 		if wantNameError {
 			if err == nil || !strings.Contains(err.Error(), "generated name is empty") {
 				t.Fatalf("empty scripted name error = %v", err)

--- a/agent/session_namer_test.go
+++ b/agent/session_namer_test.go
@@ -44,7 +44,7 @@ func TestNameSession_UsesCheapModelAndStructuredOutput(t *testing.T) {
 	client := llm.NewClient()
 	client.Register(adapter)
 
-	got, err := nameSession(context.Background(), client, profile, sessionNameSourcePrompt, "fix the flaky test in agent/session_test.go", noNamerSleep)
+	got, err := nameSession(context.Background(), client, profile, sessionNameSourcePrompt, "fix the flaky test in agent/session_test.go", "", noNamerSleep)
 	if err != nil {
 		t.Fatalf("nameSession: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestNameSession_RoutesToCheapProvider(t *testing.T) {
 	client.Register(mainAdapter)
 	client.Register(cheapAdapter)
 
-	got, err := nameSession(context.Background(), client, profile, sessionNameSourcePrompt, "name this session", noNamerSleep)
+	got, err := nameSession(context.Background(), client, profile, sessionNameSourcePrompt, "name this session", "", noNamerSleep)
 	if err != nil {
 		t.Fatalf("nameSession: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestNameSession_FallsBackToActiveModel(t *testing.T) {
 	client := llm.NewClient()
 	client.Register(adapter)
 
-	got, err := nameSession(context.Background(), client, NewOpenAIProfile("gpt-5.2"), sessionNameSourcePrompt, "review the system prompt", noNamerSleep)
+	got, err := nameSession(context.Background(), client, NewOpenAIProfile("gpt-5.2"), sessionNameSourcePrompt, "review the system prompt", "", noNamerSleep)
 	if err != nil {
 		t.Fatalf("nameSession: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestNameSession_SanitizesGeneratedName(t *testing.T) {
 	client := llm.NewClient()
 	client.Register(adapter)
 
-	got, err := nameSession(context.Background(), client, NewOpenAIProfile("gpt-5.2"), sessionNameSourceCompaction, "[CONTEXT SUMMARY] parser failures", noNamerSleep)
+	got, err := nameSession(context.Background(), client, NewOpenAIProfile("gpt-5.2"), sessionNameSourceCompaction, "[CONTEXT SUMMARY] parser failures", "", noNamerSleep)
 	if err != nil {
 		t.Fatalf("nameSession: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestNameSession_RejectsEmptySourceText(t *testing.T) {
 	t.Parallel()
 	client := llm.NewClient()
 	client.Register(&fakeAdapter{name: "openai"})
-	_, err := nameSession(context.Background(), client, NewOpenAIProfile("gpt-5.2"), sessionNameSourcePrompt, "   ", noNamerSleep)
+	_, err := nameSession(context.Background(), client, NewOpenAIProfile("gpt-5.2"), sessionNameSourcePrompt, "   ", "", noNamerSleep)
 	if err == nil || !strings.Contains(err.Error(), "source text is empty") {
 		t.Fatalf("err = %v, want source text error", err)
 	}


### PR DESCRIPTION
## Summary

The session auto-namer titled sessions after momentary activity ("what are you doing right this second") instead of the session's overarching goal. Root cause is prompt orientation, not plumbing:

- The compaction refresh path (which overwrites the name after every compaction CHECKPOINT/SUMMARY turn) feeds the namer handoff summaries whose mandated Current State / Pending Work sections describe one instant — `defaultSummaryPrefix` literally asks "what file was being edited, what problem was being debugged."
- The namer's own system prompt said "prefer the concrete task or outcome over generic wording," which steers a temp-0 cheap call toward the most concrete, most recent thing in its input.

The name field is human-visibility only (confirmed by tracing all `naming.value` reads: it flows to `SessionMeta.Name` → `EventSessionNameChanged` → webui sidebar via `SessionDisplayName`, and never back into agent context), so it should be a durable label of the session's overall goal.

## Changes

Copy-only, in `agent/session_namer.go` (+7/−2):

- `sessionNamerSystemPrompt`: defines the title as a durable label a human uses to find the session in a list; must name the overarching goal — the problem the user wants solved across the whole session — and must not title after current activity, the file being edited, or the test being debugged.
- `sessionNamerUserPrompt` (compaction label): warns that the summary's Current State and Pending Work sections are momentary snapshots to ignore for naming, and points at the user's original request and the conversation timeline.

Routing, sanitization, source precedence (manual > compaction > prompt), triggers, and quota suppression are untouched.

## Testing

- gofmt clean, `go vet ./agent/` clean
- `go test ./agent/ -run 'SessionName|SessionNamer|Rename|NameSession' -count=1` — ok
- Full `go test ./agent/ -count=1` — ok (287.415s, exit 0)

No prose-pinning tests were added: `docs/developing-evener/testing.md` ("Prompt Prose Is Not a Test Oracle") bans asserting on prompt copy; the existing behavioral suite covers the plumbing this change leaves unchanged.

Follow-up for surfacing the name as the terminal title: #825.
