### PR TITLE
fix(agent): gate session namer temperature on the resolved cheap-model row

### DIFF
--- a/agent/session_namer.go
+++ b/agent/session_namer.go
@@ -15,6 +15,7 @@ import (
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
+	"primeradiant.com/evener/llm/registry"
 )
 
 const (
@@ -143,21 +144,20 @@ func sessionNamerModel(profile *provider.Profile) string {
 
 // sessionNamerTemperature returns the naming call's temperature setting: a
 // pointer to 0.0 when the resolved cheap-model row vouches for the parameter,
-// nil when it does not or cannot vouch. The unknown cases — a synthesized row
-// (no catalog row, no live listing) or an instance that fails to resolve —
-// carry no facts, and an unknown capability must read as "do not send" rather
-// than "send": a wrong send is a provider 400 (issue #834), while a wrong omit
-// only loses a determinism hint the naming prompt's low-stakes output barely
-// uses.
+// nil when it does not or cannot vouch. Unknown capability must read as "do
+// not send" rather than "send": a wrong send is a provider 400 (issue #834),
+// while a wrong omit only loses a determinism hint the naming prompt's
+// low-stakes output barely uses. The voucher is registry.TemperatureSupported,
+// which requires a catalog row (a live-only or synthesized row inherits the
+// protocol's send-by-default baseline without any catalog fact) and reads the
+// protocol-keyed temperature path, so Google rows are judged on
+// generationConfig.temperature.
 func sessionNamerTemperature(client *llm.Client, profile *provider.Profile, model string) *float64 {
 	if client == nil || profile == nil || model == "" {
 		return nil
 	}
 	res, err := client.Resolve(profile.CheapProvider() + "/" + model)
-	if err != nil || res.Synthesized {
-		return nil
-	}
-	if !res.Caps.Fields["temperature"] {
+	if err != nil || !registry.TemperatureSupported(res) {
 		return nil
 	}
 	temp := 0.0
@@ -165,10 +165,17 @@ func sessionNamerTemperature(client *llm.Client, profile *provider.Profile, mode
 }
 
 // isTemperatureUnsupported reports whether err is a rejected-request error
-// whose message names the temperature parameter (e.g. Bedrock's "Unsupported
-// parameter: 'temperature' is not supported with this model").
+// rejecting the temperature parameter specifically (e.g. Bedrock's "Unsupported
+// parameter: 'temperature' is not supported with this model"). Matching a bare
+// "temperature" substring would over-retry on unrelated invalid-request
+// messages that merely mention the word, so this matches the
+// unsupported-parameter phrasing with the parameter in quotes.
 func isTemperatureUnsupported(err error) bool {
-	return llm.Kind(err) == llm.KindInvalidRequest && strings.Contains(err.Error(), "temperature")
+	if llm.Kind(err) != llm.KindInvalidRequest {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unsupported parameter") && strings.Contains(msg, "'temperature'")
 }
 
 func configuredSessionNamerModel(profile *provider.Profile) string {

--- a/agent/session_namer.go
+++ b/agent/session_namer.go
@@ -165,17 +165,23 @@ func sessionNamerTemperature(client *llm.Client, profile *provider.Profile, mode
 }
 
 // isTemperatureUnsupported reports whether err is a rejected-request error
-// rejecting the temperature parameter specifically (e.g. Bedrock's "Unsupported
-// parameter: 'temperature' is not supported with this model"). Matching a bare
-// "temperature" substring would over-retry on unrelated invalid-request
-// messages that merely mention the word, so this matches the
-// unsupported-parameter phrasing with the parameter in quotes.
+// rejecting the temperature parameter specifically. Providers word this
+// differently — Bedrock's "Unsupported parameter: 'temperature' is not
+// supported with this model", OpenAI's "Unknown parameter: 'temperature'",
+// "unknown_parameter: temperature" — so this accepts the two rejection
+// phrasings (with or without the underscore) plus the parameter name, quoted
+// or not. Matching the parameter name alone would over-retry on unrelated
+// invalid-request messages that merely mention the word, so the rejection
+// phrase is required too.
 func isTemperatureUnsupported(err error) bool {
 	if llm.Kind(err) != llm.KindInvalidRequest {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "unsupported parameter") && strings.Contains(msg, "'temperature'")
+	rejection := strings.Contains(msg, "unsupported parameter") ||
+		strings.Contains(msg, "unknown parameter") ||
+		strings.Contains(msg, "unknown_parameter")
+	return rejection && strings.Contains(msg, "temperature")
 }
 
 func configuredSessionNamerModel(profile *provider.Profile) string {

--- a/agent/session_namer.go
+++ b/agent/session_namer.go
@@ -63,24 +63,37 @@ func nameSession(ctx context.Context, client *llm.Client, profile *provider.Prof
 		return sessionNameResult{}, errors.New("session namer: model is empty")
 	}
 	maxTokens := 80
-	temp := 0.0
+	// #834: gate temperature on the resolved cheap-model row. A Bedrock-style
+	// wire id with no catalog row resolves synthesized; the protocol baseline
+	// marks temperature send-by-default, so nothing prunes it and the provider
+	// 400s — one dead request per session. Naming is deterministic decoration,
+	// so omitting the parameter on doubt costs nothing.
+	temp := sessionNamerTemperature(client, profile, model)
 	// Naming is best-effort decoration with its own short deadline. It opts out
 	// of the turn retry wall budget so a naming storm does not add load while a
 	// real turn waits on the same provider bucket.
 	namerPolicy := llm.DefaultRetryPolicy()
 	namerPolicy.RateLimitWallBudget = 0
-	res, err := llm.GenerateObject(callCtx, llm.GenerateObjectOptions{
+	opts := llm.GenerateObjectOptions{
 		Client:      client,
 		Provider:    profile.CheapProvider(),
 		Model:       model,
 		System:      new(sessionNamerSystemPrompt),
 		Prompt:      new(sessionNamerUserPrompt(source, text, currentTitle)),
-		Temperature: &temp,
+		Temperature: temp,
 		MaxTokens:   &maxTokens,
 		Sleep:       sleep,
 		RetryPolicy: &namerPolicy,
 		Schema:      sessionNameSchema(),
-	})
+	}
+	res, err := llm.GenerateObject(callCtx, opts)
+	if err != nil && temp != nil && isTemperatureUnsupported(err) {
+		// Defense in depth: a row that vouches for temperature can still be
+		// wrong (an id the catalog mis-knows). Retry exactly once with the
+		// parameter dropped rather than failing the whole naming attempt.
+		opts.Temperature = nil
+		res, err = llm.GenerateObject(callCtx, opts)
+	}
 	if err != nil {
 		return sessionNameResult{}, fmt.Errorf("session namer: %w", err)
 	}
@@ -126,6 +139,36 @@ func sessionNamerModel(profile *provider.Profile) string {
 		return model
 	}
 	return strings.TrimSpace(profile.Model())
+}
+
+// sessionNamerTemperature returns the naming call's temperature setting: a
+// pointer to 0.0 when the resolved cheap-model row vouches for the parameter,
+// nil when it does not or cannot vouch. The unknown cases — a synthesized row
+// (no catalog row, no live listing) or an instance that fails to resolve —
+// carry no facts, and an unknown capability must read as "do not send" rather
+// than "send": a wrong send is a provider 400 (issue #834), while a wrong omit
+// only loses a determinism hint the naming prompt's low-stakes output barely
+// uses.
+func sessionNamerTemperature(client *llm.Client, profile *provider.Profile, model string) *float64 {
+	if client == nil || profile == nil || model == "" {
+		return nil
+	}
+	res, err := client.Resolve(profile.CheapProvider() + "/" + model)
+	if err != nil || res.Synthesized {
+		return nil
+	}
+	if !res.Caps.Fields["temperature"] {
+		return nil
+	}
+	temp := 0.0
+	return &temp
+}
+
+// isTemperatureUnsupported reports whether err is a rejected-request error
+// whose message names the temperature parameter (e.g. Bedrock's "Unsupported
+// parameter: 'temperature' is not supported with this model").
+func isTemperatureUnsupported(err error) bool {
+	return llm.Kind(err) == llm.KindInvalidRequest && strings.Contains(err.Error(), "temperature")
 }
 
 func configuredSessionNamerModel(profile *provider.Profile) string {

--- a/agent/session_namer.go
+++ b/agent/session_namer.go
@@ -165,23 +165,16 @@ func sessionNamerTemperature(client *llm.Client, profile *provider.Profile, mode
 }
 
 // isTemperatureUnsupported reports whether err is a rejected-request error
-// rejecting the temperature parameter specifically. Providers word this
-// differently — Bedrock's "Unsupported parameter: 'temperature' is not
-// supported with this model", OpenAI's "Unknown parameter: 'temperature'",
-// "unknown_parameter: temperature" — so this accepts the two rejection
-// phrasings (with or without the underscore) plus the parameter name, quoted
-// or not. Matching the parameter name alone would over-retry on unrelated
-// invalid-request messages that merely mention the word, so the rejection
-// phrase is required too.
+// naming the temperature parameter as the rejected one. It delegates to
+// llm.RejectedParameter, which reads the structured error.param and the
+// message shapes the classifier already recognizes — every provider phrasing
+// (Bedrock's "Unsupported parameter: 'temperature'", OpenAI's "Unrecognized
+// request argument supplied: temperature", the "unknown field temperature"
+// form, structured unknown_parameter/unsupported_parameter codes) — instead of
+// re-matching provider prose here.
 func isTemperatureUnsupported(err error) bool {
-	if llm.Kind(err) != llm.KindInvalidRequest {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	rejection := strings.Contains(msg, "unsupported parameter") ||
-		strings.Contains(msg, "unknown parameter") ||
-		strings.Contains(msg, "unknown_parameter")
-	return rejection && strings.Contains(msg, "temperature")
+	return llm.Kind(err) == llm.KindInvalidRequest &&
+		llm.RejectedParameter(err) == "temperature"
 }
 
 func configuredSessionNamerModel(profile *provider.Profile) string {

--- a/agent/session_namer.go
+++ b/agent/session_namer.go
@@ -171,10 +171,26 @@ func sessionNamerTemperature(client *llm.Client, profile *provider.Profile, mode
 // (Bedrock's "Unsupported parameter: 'temperature'", OpenAI's "Unrecognized
 // request argument supplied: temperature", the "unknown field temperature"
 // form, structured unknown_parameter/unsupported_parameter codes) — instead of
-// re-matching provider prose here.
+// re-matching provider prose here. The comparison is against the rejected
+// protocol's own temperature path: a Google-protocol rejection names the
+// nested spelling ("generationConfig.temperature"), everything else the plain
+// one, and an error with no protocol attribution is compared against both.
 func isTemperatureUnsupported(err error) bool {
-	return llm.Kind(err) == llm.KindInvalidRequest &&
-		llm.RejectedParameter(err) == "temperature"
+	if llm.Kind(err) != llm.KindInvalidRequest {
+		return false
+	}
+	param := llm.RejectedParameter(err)
+	if param == "" {
+		return false
+	}
+	switch llm.ErrorProtocol(err) {
+	case registry.ProtocolGoogle:
+		return param == "generationConfig.temperature"
+	case "":
+		return param == "temperature" || param == "generationConfig.temperature"
+	default:
+		return param == "temperature"
+	}
 }
 
 func configuredSessionNamerModel(profile *provider.Profile) string {

--- a/agent/session_namer_temperature_test.go
+++ b/agent/session_namer_temperature_test.go
@@ -92,6 +92,69 @@ func TestNameSession_OmitsTemperatureForSynthesizedRows(t *testing.T) {
 	}
 }
 
+// TestNameSession_OmitsTemperatureForLiveOnlyRows: a live-listed model with no
+// catalog row resolves non-synthesized, but its temperature flag is the
+// protocol baseline — not a catalog fact. The gate must still omit the
+// parameter (roborev on #835: live-only rows bypassed the synthesized check).
+func TestNameSession_OmitsTemperatureForLiveOnlyRows(t *testing.T) {
+	t.Parallel()
+	reg := bedrockishRegistry(t)
+	// A live listing on the openai instance advertising a model the catalog
+	// does not know: resolves via the "live" step, non-synthesized.
+	reg.ApplyLive("bedrock", []registry.Model{{ID: "us.openai.gpt-live-only-9"}})
+	adapter := &temperatureSpyAdapter{
+		name: "bedrock",
+		respondWith: func(req llm.Request, call int) (llm.Response, error) {
+			if req.Temperature != nil {
+				t.Errorf("call %d: namer sent temperature to a live-only model", call)
+			}
+			return llm.Response{Message: llm.Assistant(`{"name":"Fix Parser Bug"}`)}, nil
+		},
+	}
+	client := llm.NewClient(llm.WithRegistry(reg))
+	client.Register(adapter)
+
+	profile := WithCheapModel(NewOpenAIProfile("gpt-5.2"), "bedrock/us.openai.gpt-live-only-9")
+	got, err := nameSession(context.Background(), client, profile, sessionNameSourcePrompt, "fix the parser", "", noNamerSleep)
+	if err != nil {
+		t.Fatalf("nameSession: %v", err)
+	}
+	if got.Name != "Fix Parser Bug" {
+		t.Fatalf("Name = %q, want Fix Parser Bug", got.Name)
+	}
+	if len(adapter.calls) != 1 {
+		t.Fatalf("calls = %d, want 1", len(adapter.calls))
+	}
+}
+
+// TestNameSession_SendsTemperatureForGoogleRows: Google rows key their
+// temperature capability on generationConfig.temperature, not temperature;
+// a supported Google model must still receive the parameter (roborev on
+// #835: the fixed key read as missing and dropped it for all Google models).
+func TestNameSession_SendsTemperatureForGoogleRows(t *testing.T) {
+	t.Parallel()
+	adapter := &temperatureSpyAdapter{
+		name: "google",
+		respondWith: func(req llm.Request, call int) (llm.Response, error) {
+			if req.Temperature == nil {
+				t.Errorf("call %d: namer omitted temperature on a supported Google model", call)
+			}
+			return llm.Response{Message: llm.Assistant(`{"name":"Fix Parser Bug"}`)}, nil
+		},
+	}
+	client := llm.NewClient()
+	client.Register(adapter)
+
+	profile := WithCheapModel(NewOpenAIProfile("gpt-5.2"), "google/gemini-2.5-pro")
+	got, err := nameSession(context.Background(), client, profile, sessionNameSourcePrompt, "fix the parser", "", noNamerSleep)
+	if err != nil {
+		t.Fatalf("nameSession: %v", err)
+	}
+	if got.Name != "Fix Parser Bug" {
+		t.Fatalf("Name = %q, want Fix Parser Bug", got.Name)
+	}
+}
+
 // TestNameSession_OmitsTemperatureForFalseCapability: moonshotai's catalog rows
 // carry fields.temperature=false; the namer must omit the parameter.
 func TestNameSession_OmitsTemperatureForFalseCapability(t *testing.T) {

--- a/agent/session_namer_temperature_test.go
+++ b/agent/session_namer_temperature_test.go
@@ -1,0 +1,204 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"primeradiant.com/evener/llm"
+	"primeradiant.com/evener/llm/registry"
+)
+
+// Temperature gate (issue #834): the namer must not send temperature to models
+// whose resolved row cannot vouch for it. A Bedrock-style wire id with no
+// catalog row resolves to a synthesized row whose temperature baseline is
+// "send" — nothing prunes it — and the provider 400s, costing one dead request
+// per session.
+
+// temperatureSpyAdapter records each request's temperature so tests can
+// assert presence/absence across calls.
+type temperatureSpyAdapter struct {
+	name        string
+	respondWith func(req llm.Request, call int) (llm.Response, error)
+	calls       []llm.Request
+}
+
+func (a *temperatureSpyAdapter) Name() string { return a.name }
+func (a *temperatureSpyAdapter) Complete(ctx context.Context, req llm.Request) (llm.Response, error) {
+	_ = ctx
+	a.calls = append(a.calls, req)
+	return a.respondWith(req, len(a.calls))
+}
+func (a *temperatureSpyAdapter) Stream(ctx context.Context, req llm.Request) (llm.Stream, error) {
+	_ = ctx
+	_ = req
+	return nil, llm.ErrStreamUnsupported
+}
+
+// bedrockishRegistry builds a hermetic registry whose "bedrock" instance
+// speaks the OpenAI responses protocol over a custom base URL — the shape from
+// the issue: models resolve (so requests dispatch) but no catalog row exists,
+// so every model on it resolves synthesized.
+func bedrockishRegistry(t *testing.T) *registry.Registry {
+	t.Helper()
+	r, err := registry.Load(
+		registry.WithOffline(true), registry.WithoutCache(), registry.WithNoUserLayer(),
+		registry.WithStateRoot(t.TempDir()),
+		registry.WithEnv(func(string) (string, bool) { return "", false }),
+		registry.WithInstances(map[string]registry.Provider{
+			"bedrock": {
+				Base: "openai", Protocol: registry.ProtocolOpenAIResponses, Surface: registry.SurfaceGeneric,
+				APIKey: "test", Transport: registry.Transport{BaseURL: "https://bedrock.example.com/v1"},
+			},
+			// moonshotai carries provider-level fields with temperature=false
+			// (providers_overlay.toml), so its models resolve with the
+			// capability explicitly disabled.
+			"moonshotai": {APIKey: "test"},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	return r
+}
+
+// TestNameSession_OmitsTemperatureForSynthesizedRows: an unknown wire id
+// (no catalog row, no live listing) resolves synthesized; its temperature
+// capability is unknown, so the namer must omit the parameter entirely.
+func TestNameSession_OmitsTemperatureForSynthesizedRows(t *testing.T) {
+	t.Parallel()
+	adapter := &temperatureSpyAdapter{
+		name: "bedrock",
+		respondWith: func(req llm.Request, call int) (llm.Response, error) {
+			if req.Temperature != nil {
+				t.Errorf("call %d: namer sent temperature %v to a synthesized-row model", call, *req.Temperature)
+			}
+			return llm.Response{Message: llm.Assistant(`{"name":"Fix Parser Bug"}`)}, nil
+		},
+	}
+	client := llm.NewClient(llm.WithRegistry(bedrockishRegistry(t)))
+	client.Register(adapter)
+
+	profile := WithCheapModel(NewOpenAIProfile("gpt-5.2"), "bedrock/us.openai.gpt-5.6-luna")
+	got, err := nameSession(context.Background(), client, profile, sessionNameSourcePrompt, "fix the parser", "", noNamerSleep)
+	if err != nil {
+		t.Fatalf("nameSession: %v", err)
+	}
+	if got.Name != "Fix Parser Bug" {
+		t.Fatalf("Name = %q, want Fix Parser Bug", got.Name)
+	}
+	if len(adapter.calls) != 1 {
+		t.Fatalf("calls = %d, want 1 (no retry needed when temperature is gated)", len(adapter.calls))
+	}
+}
+
+// TestNameSession_OmitsTemperatureForFalseCapability: moonshotai's catalog rows
+// carry fields.temperature=false; the namer must omit the parameter.
+func TestNameSession_OmitsTemperatureForFalseCapability(t *testing.T) {
+	t.Parallel()
+	adapter := &temperatureSpyAdapter{
+		name: "moonshotai",
+		respondWith: func(req llm.Request, call int) (llm.Response, error) {
+			if req.Temperature != nil {
+				t.Errorf("call %d: namer sent temperature %v to a temperature=false model", call, *req.Temperature)
+			}
+			return llm.Response{Message: llm.Assistant(`{"name":"Fix Parser Bug"}`)}, nil
+		},
+	}
+	client := llm.NewClient(llm.WithRegistry(bedrockishRegistry(t)))
+	client.Register(adapter)
+
+	profile := WithCheapModel(NewOpenAIProfile("gpt-5.2"), "moonshotai/kimi-k3")
+	got, err := nameSession(context.Background(), client, profile, sessionNameSourcePrompt, "fix the parser", "", noNamerSleep)
+	if err != nil {
+		t.Fatalf("nameSession: %v", err)
+	}
+	if got.Name != "Fix Parser Bug" {
+		t.Fatalf("Name = %q, want Fix Parser Bug", got.Name)
+	}
+}
+
+// TestNameSession_SendsTemperatureForKnownCapability: the openai catalog row
+// vouches for temperature; the namer still sends it (determinism for naming
+// stays on models that support it).
+func TestNameSession_SendsTemperatureForKnownCapability(t *testing.T) {
+	t.Parallel()
+	adapter := &temperatureSpyAdapter{
+		name: "openai",
+		respondWith: func(req llm.Request, call int) (llm.Response, error) {
+			if req.Temperature == nil {
+				t.Errorf("call %d: namer omitted temperature on a model whose row supports it", call)
+			}
+			return llm.Response{Message: llm.Assistant(`{"name":"Fix Flaky Test"}`)}, nil
+		},
+	}
+	client := llm.NewClient()
+	client.Register(adapter)
+
+	got, err := nameSession(context.Background(), client, WithCheapModel(NewOpenAIProfile("gpt-5.2"), "gpt-4.1-nano"), sessionNameSourcePrompt, "fix the flaky test", "", noNamerSleep)
+	if err != nil {
+		t.Fatalf("nameSession: %v", err)
+	}
+	if got.Name != "Fix Flaky Test" {
+		t.Fatalf("Name = %q, want Fix Flaky Test", got.Name)
+	}
+}
+
+// TestNameSession_RetriesOnceWithoutTemperature: a row that claims temperature
+// support but the provider rejects it (Bedrock 400 "Unsupported parameter:
+// 'temperature'") must be retried exactly once with the parameter dropped,
+// and the naming must succeed on the retry.
+func TestNameSession_RetriesOnceWithoutTemperature(t *testing.T) {
+	t.Parallel()
+	adapter := &temperatureSpyAdapter{
+		name: "openai",
+		respondWith: func(req llm.Request, call int) (llm.Response, error) {
+			if call == 1 {
+				return llm.Response{}, llm.ErrorFromHTTPStatus(req.Provider, 400,
+					"responses.create failed: Unsupported parameter: 'temperature' is not supported with this model.", nil, nil)
+			}
+			if req.Temperature != nil {
+				t.Errorf("call %d: retry still carried temperature", call)
+			}
+			return llm.Response{Message: llm.Assistant(`{"name":"Fix Flaky Test"}`)}, nil
+		},
+	}
+	client := llm.NewClient()
+	client.Register(adapter)
+
+	got, err := nameSession(context.Background(), client, WithCheapModel(NewOpenAIProfile("gpt-5.2"), "gpt-4.1-nano"), sessionNameSourcePrompt, "fix the flaky test", "", noNamerSleep)
+	if err != nil {
+		t.Fatalf("nameSession: %v", err)
+	}
+	if got.Name != "Fix Flaky Test" {
+		t.Fatalf("Name = %q, want Fix Flaky Test", got.Name)
+	}
+	if len(adapter.calls) != 2 {
+		t.Fatalf("calls = %d, want exactly 2 (original + one temperature-free retry)", len(adapter.calls))
+	}
+}
+
+// TestNameSession_NoRetryWithoutTemperatureInMessage: an invalid-request
+// error that does not name temperature must not trigger the retry.
+func TestNameSession_NoRetryWithoutTemperatureInMessage(t *testing.T) {
+	t.Parallel()
+	adapter := &temperatureSpyAdapter{
+		name: "openai",
+		respondWith: func(req llm.Request, call int) (llm.Response, error) {
+			return llm.Response{}, llm.ErrorFromHTTPStatus(req.Provider, 400, "model not found", nil, nil)
+		},
+	}
+	client := llm.NewClient()
+	client.Register(adapter)
+
+	_, err := nameSession(context.Background(), client, WithCheapModel(NewOpenAIProfile("gpt-5.2"), "gpt-4.1-nano"), sessionNameSourcePrompt, "fix the flaky test", "", noNamerSleep)
+	if err == nil {
+		t.Fatal("expected error to surface")
+	}
+	if len(adapter.calls) != 1 {
+		t.Fatalf("calls = %d, want 1 (no retry for unrelated invalid request)", len(adapter.calls))
+	}
+	if !strings.Contains(err.Error(), "session namer:") {
+		t.Fatalf("error = %v, want wrapped namer error", err)
+	}
+}

--- a/agent/session_namer_temperature_test.go
+++ b/agent/session_namer_temperature_test.go
@@ -327,8 +327,9 @@ func TestIsTemperatureUnsupported(t *testing.T) {
 	}
 
 	// A structured error.param in the raw body reaches the predicate through
-	// ErrorFromHTTPStatus too, not only ClassifyHTTPError.
-	raw := map[string]any{"error": map[string]any{"message": "Unsupported", "type": "invalid_request_error", "param": "temperature"}}
+	// ErrorFromHTTPStatus too, not only ClassifyHTTPError. The code vouches
+	// that this is a rejection (round-7: a param alone is not one).
+	raw := map[string]any{"error": map[string]any{"message": "Unsupported", "type": "invalid_request_error", "param": "temperature", "code": "unknown_parameter"}}
 	statusErr := llm.ErrorFromHTTPStatus("openai", 400, "Unsupported", raw, nil)
 	if !isTemperatureUnsupported(statusErr) {
 		t.Error("ErrorFromHTTPStatus with structured param temperature must trigger the retry")
@@ -338,10 +339,17 @@ func TestIsTemperatureUnsupported(t *testing.T) {
 	// error selects it, and an unattributed error accepts either spelling.
 	googleRes := registry.Resolved{Instance: "google", Protocol: registry.ProtocolGoogle}
 	googleErr := llm.ClassifyHTTPError("generateContent", 400, nil,
-		[]byte(`{"error":{"message":"Unsupported","code":400,"status":"INVALID_ARGUMENT","param":"generationConfig.temperature"}}`),
+		[]byte(`{"error":{"message":"Unsupported","code":"unsupported_parameter","status":"INVALID_ARGUMENT","param":"generationConfig.temperature"}}`),
 		googleRes)
 	if !isTemperatureUnsupported(googleErr) {
 		t.Error("Google-protocol rejection naming generationConfig.temperature must trigger the retry")
+	}
+	// An invalid-value error pointing at temperature must not trigger it.
+	googleValueErr := llm.ClassifyHTTPError("generateContent", 400, nil,
+		[]byte(`{"error":{"message":"Invalid value for 'generationConfig.temperature': must be between 0 and 2.","code":"invalid_value","status":"INVALID_ARGUMENT","param":"generationConfig.temperature"}}`),
+		googleRes)
+	if isTemperatureUnsupported(googleValueErr) {
+		t.Error("Google invalid-value error naming generationConfig.temperature must not trigger the retry")
 	}
 	plainGoogleErr := llm.ErrorFromHTTPStatus("anyone", 400, "Unsupported parameter: 'generationConfig.temperature'", nil, nil)
 	if !isTemperatureUnsupported(plainGoogleErr) {

--- a/agent/session_namer_temperature_test.go
+++ b/agent/session_namer_temperature_test.go
@@ -155,8 +155,10 @@ func TestNameSession_SendsTemperatureForGoogleRows(t *testing.T) {
 	}
 }
 
-// TestNameSession_OmitsTemperatureForFalseCapability: moonshotai's catalog rows
-// carry fields.temperature=false; the namer must omit the parameter.
+// TestNameSession_OmitsTemperatureForFalseCapability: models.dev marks
+// moonshotai/kimi-k3 temperature=false; the registry's derivation maps that
+// to Caps.Sampling=false (modelsdev.go), and TemperatureSupported gates on it.
+// The namer must omit the parameter.
 func TestNameSession_OmitsTemperatureForFalseCapability(t *testing.T) {
 	t.Parallel()
 	adapter := &temperatureSpyAdapter{

--- a/agent/session_namer_temperature_test.go
+++ b/agent/session_namer_temperature_test.go
@@ -265,3 +265,28 @@ func TestNameSession_NoRetryWithoutTemperatureInMessage(t *testing.T) {
 		t.Fatalf("error = %v, want wrapped namer error", err)
 	}
 }
+
+// TestIsTemperatureUnsupported pins the retry predicate's phrasings: each
+// provider's rejection form triggers it, and a message naming temperature
+// without a rejection phrase (or an unrelated parameter) does not.
+func TestIsTemperatureUnsupported(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{"bedrock quoted", `openai error (status=400): responses.create failed: Unsupported parameter: 'temperature' is not supported with this model.`, true},
+		{"openai unknown parameter", `openai error (status=400): Unknown parameter: 'temperature'.`, true},
+		{"underscore form", `openai error (status=400): unknown_parameter: temperature`, true},
+		{"unquoted", `bedrock error (status=400): Unsupported parameter: temperature is not supported with this model.`, true},
+		{"other parameter rejected", `openai error (status=400): Unsupported parameter: 'top_p' is not supported with this model.`, false},
+		{"mentions temperature without rejection", `openai error (status=400): temperature value out of range`, false},
+		{"unrelated", `openai error (status=400): model not found`, false},
+	}
+	for _, tc := range cases {
+		err := llm.ErrorFromHTTPStatus("openai", 400, tc.msg, nil, nil)
+		if got := isTemperatureUnsupported(err); got != tc.want {
+			t.Errorf("%s: isTemperatureUnsupported(%q) = %v, want %v", tc.name, tc.msg, got, tc.want)
+		}
+	}
+}

--- a/agent/session_namer_temperature_test.go
+++ b/agent/session_namer_temperature_test.go
@@ -217,6 +217,12 @@ func TestNameSession_RetriesOnceWithoutTemperature(t *testing.T) {
 		name: "openai",
 		respondWith: func(req llm.Request, call int) (llm.Response, error) {
 			if call == 1 {
+				// The capability gate said the row vouches for temperature, so
+				// the first request must carry it — otherwise this test would
+				// pass without exercising the retry path at all.
+				if req.Temperature == nil {
+					t.Error("first request omitted temperature: capability gate broken, retry not exercised")
+				}
 				return llm.Response{}, llm.ErrorFromHTTPStatus(req.Provider, 400,
 					"responses.create failed: Unsupported parameter: 'temperature' is not supported with this model.", nil, nil)
 			}
@@ -316,5 +322,33 @@ func TestIsTemperatureUnsupported(t *testing.T) {
 	quota := llm.ErrorFromHTTPStatus("openai", 429, `Unsupported parameter: 'temperature'`, nil, nil)
 	if isTemperatureUnsupported(quota) {
 		t.Error("non-400 status naming temperature must not trigger the retry")
+	}
+
+	// A structured error.param in the raw body reaches the predicate through
+	// ErrorFromHTTPStatus too, not only ClassifyHTTPError.
+	raw := map[string]any{"error": map[string]any{"message": "Unsupported", "type": "invalid_request_error", "param": "temperature"}}
+	statusErr := llm.ErrorFromHTTPStatus("openai", 400, "Unsupported", raw, nil)
+	if !isTemperatureUnsupported(statusErr) {
+		t.Error("ErrorFromHTTPStatus with structured param temperature must trigger the retry")
+	}
+
+	// Google rejections use the nested spelling; the protocol stamped on the
+	// error selects it, and an unattributed error accepts either spelling.
+	googleRes := registry.Resolved{Instance: "google", Protocol: registry.ProtocolGoogle}
+	googleErr := llm.ClassifyHTTPError("generateContent", 400, nil,
+		[]byte(`{"error":{"message":"Unsupported","code":400,"status":"INVALID_ARGUMENT","param":"generationConfig.temperature"}}`),
+		googleRes)
+	if !isTemperatureUnsupported(googleErr) {
+		t.Error("Google-protocol rejection naming generationConfig.temperature must trigger the retry")
+	}
+	plainGoogleErr := llm.ErrorFromHTTPStatus("anyone", 400, "Unsupported parameter: 'generationConfig.temperature'", nil, nil)
+	if !isTemperatureUnsupported(plainGoogleErr) {
+		t.Error("unattributed rejection naming generationConfig.temperature must trigger the retry")
+	}
+	googlePlainTemp := llm.ClassifyHTTPError("generateContent", 400, nil,
+		[]byte(`{"error":{"message":"Unsupported parameter: 'temperature'","code":400,"status":"INVALID_ARGUMENT"}}`),
+		googleRes)
+	if isTemperatureUnsupported(googlePlainTemp) {
+		t.Error("Google-protocol rejection naming plain temperature must not trigger the retry")
 	}
 }

--- a/agent/session_namer_temperature_test.go
+++ b/agent/session_namer_temperature_test.go
@@ -266,27 +266,55 @@ func TestNameSession_NoRetryWithoutTemperatureInMessage(t *testing.T) {
 	}
 }
 
-// TestIsTemperatureUnsupported pins the retry predicate's phrasings: each
-// provider's rejection form triggers it, and a message naming temperature
-// without a rejection phrase (or an unrelated parameter) does not.
+// TestIsTemperatureUnsupported pins the retry predicate: every rejection
+// shape the classifier recognizes (spec §12 message patterns and structured
+// error.param codes) triggers it for temperature, other parameters and
+// non-rejection messages do not, and non-invalid-request kinds never do.
 func TestIsTemperatureUnsupported(t *testing.T) {
-	cases := []struct {
+	// Message shapes the classifier's parameterMessagePatterns match; these
+	// flow through ErrorFromHTTPStatus → parameterNameFromMessage.
+	msgCases := []struct {
 		name string
 		msg  string
 		want bool
 	}{
-		{"bedrock quoted", `openai error (status=400): responses.create failed: Unsupported parameter: 'temperature' is not supported with this model.`, true},
-		{"openai unknown parameter", `openai error (status=400): Unknown parameter: 'temperature'.`, true},
-		{"underscore form", `openai error (status=400): unknown_parameter: temperature`, true},
-		{"unquoted", `bedrock error (status=400): Unsupported parameter: temperature is not supported with this model.`, true},
-		{"other parameter rejected", `openai error (status=400): Unsupported parameter: 'top_p' is not supported with this model.`, false},
-		{"mentions temperature without rejection", `openai error (status=400): temperature value out of range`, false},
-		{"unrelated", `openai error (status=400): model not found`, false},
+		{"bedrock quoted", `responses.create failed: Unsupported parameter: 'temperature' is not supported with this model.`, true},
+		{"openai unknown parameter", `Unknown parameter: 'temperature'.`, true},
+		{"unrecognized argument", `Unrecognized request argument supplied: temperature`, true},
+		{"unknown field", `Invalid value for 'temperature': unknown field temperature`, true},
+		{"other parameter rejected", `Unsupported parameter: 'top_p' is not supported with this model.`, false},
+		{"mentions temperature without rejection", `temperature value out of range`, false},
+		{"unrelated", `model not found`, false},
 	}
-	for _, tc := range cases {
+	for _, tc := range msgCases {
 		err := llm.ErrorFromHTTPStatus("openai", 400, tc.msg, nil, nil)
 		if got := isTemperatureUnsupported(err); got != tc.want {
 			t.Errorf("%s: isTemperatureUnsupported(%q) = %v, want %v", tc.name, tc.msg, got, tc.want)
 		}
+	}
+
+	// Structured rejections: code unknown_parameter/unsupported_parameter
+	// with error.param naming the parameter. These classify through
+	// ClassifyHTTPError, whose paramFromError reads error.param.
+	structured := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"structured param temperature", `{"error":{"message":"Unsupported parameter","type":"invalid_request_error","param":"temperature","code":"unknown_parameter"}}`, true},
+		{"structured param other", `{"error":{"message":"Unsupported parameter","type":"invalid_request_error","param":"top_p","code":"unknown_parameter"}}`, false},
+	}
+	res := registry.Resolved{Instance: "openai", Protocol: registry.ProtocolOpenAIResponses}
+	for _, tc := range structured {
+		err := llm.ClassifyHTTPError("responses.create", 400, nil, []byte(tc.body), res)
+		if got := isTemperatureUnsupported(err); got != tc.want {
+			t.Errorf("%s: isTemperatureUnsupported(body %q) = %v, want %v", tc.name, tc.body, got, tc.want)
+		}
+	}
+
+	// Non-invalid-request kinds never trigger, even naming temperature.
+	quota := llm.ErrorFromHTTPStatus("openai", 429, `Unsupported parameter: 'temperature'`, nil, nil)
+	if isTemperatureUnsupported(quota) {
+		t.Error("non-400 status naming temperature must not trigger the retry")
 	}
 }

--- a/llm/classify_http.go
+++ b/llm/classify_http.go
@@ -40,7 +40,7 @@ func ClassifyHTTPError(operation string, status int, headers http.Header, body [
 		return &contextLengthError{base}
 	case code == "unknown_parameter", code == "unsupported_parameter":
 		base.retryable = false
-		base.rejectedParam = paramFromError(raw)
+		base.rejectedParam = rejectedParameter(raw, base.message)
 		base.hint = fieldHint(base.rejectedParam, res)
 		return &invalidRequestError{base}
 	}
@@ -60,7 +60,7 @@ func ClassifyHTTPError(operation string, status int, headers http.Header, body [
 	if err := classifyByMessage(base); err != nil {
 		return err
 	}
-	base.rejectedParam = parameterNameFromMessage(base.message)
+	base.rejectedParam = rejectedParameter(raw, base.message)
 	base.hint = fieldHint(base.rejectedParam, res)
 	return &invalidRequestError{base}
 }
@@ -85,16 +85,20 @@ func ErrorProtocol(err error) string {
 	return ""
 }
 
-// paramFromError reads error.param from a decoded provider body, or "" when
-// the body has no error object or the param is absent or non-string
-// (including JSON null, which OpenAI sends when no parameter is implicated).
-func paramFromError(raw map[string]any) string {
-	errObj, ok := raw["error"].(map[string]any)
-	if !ok {
-		return ""
+// rejectedParameter extracts the parameter a provider rejection named: the
+// structured error.param takes precedence, with the spec §12 message patterns
+// as fallback. raw is the decoded provider body (any shape; non-maps yield
+// ""), message the failure message. One extraction shared by every error
+// construction path, so a rejection identified either way carries the name.
+func rejectedParameter(raw any, message string) string {
+	if m, ok := raw.(map[string]any); ok {
+		if errObj, ok := m["error"].(map[string]any); ok {
+			if param, _ := errObj["param"].(string); param != "" {
+				return param
+			}
+		}
 	}
-	param, _ := errObj["param"].(string)
-	return param
+	return parameterNameFromMessage(message)
 }
 
 // retryDelayFromHeaders honors Retry-After first, then the

--- a/llm/classify_http.go
+++ b/llm/classify_http.go
@@ -26,15 +26,15 @@ func ClassifyHTTPError(operation string, status int, headers http.Header, body [
 	now := time.Now()
 	message := ProviderFailureMessage(operation, body)
 	base := httpBaseError{
-		provider:      res.Instance,
-		protocol:      res.Protocol,
-		statusCode:    status,
-		message:       message,
-		rejectedParam: rejectedParameter(raw, message),
-		errorCode:     extractErrorCode(raw),
-		retryAfter:    retryDelayFromHeaders(headers, now),
-		rawResponse:   raw,
+		provider:    res.Instance,
+		protocol:    res.Protocol,
+		statusCode:  status,
+		message:     message,
+		errorCode:   extractErrorCode(raw),
+		retryAfter:  retryDelayFromHeaders(headers, now),
+		rawResponse: raw,
 	}
+	base.rejectedParam = rejectedParameter(raw, message, base.errorCode)
 	code := base.errorCode
 	switch {
 	case status == 413, code == "context_length_exceeded", code == "request_too_large":
@@ -85,15 +85,24 @@ func ErrorProtocol(err error) string {
 	return ""
 }
 
-// rejectedParameter extracts the parameter a provider rejection named: the
-// structured error.param takes precedence, with the spec §12 message patterns
-// as fallback. raw is the decoded provider body (any shape; non-maps yield
-// ""), message the failure message. One extraction shared by every error
-// construction path, so a rejection identified either way carries the name.
-func rejectedParameter(raw any, message string) string {
+// rejectedParameter extracts the parameter a provider *rejection* named: the
+// structured error.param, honored only when the error is actually a
+// parameter-rejection — its code is unknown_parameter/unsupported_parameter or
+// its message matches a spec §12 rejection pattern — with the message patterns
+// as fallback and confirmation. raw is the decoded provider body (any shape;
+// non-maps yield ""), message the failure message, errorCode the code the
+// classifier extracted. error.param alone must not read as rejection: it is a
+// general field, and providers also use it to point at the offending
+// parameter in invalid-value errors ("Invalid value for 'temperature': must
+// be between 0 and 2"), where dropping the parameter would be wrong. One
+// extraction shared by every error construction path, so a rejection
+// identified either way carries the name.
+func rejectedParameter(raw any, message, errorCode string) string {
 	if m, ok := raw.(map[string]any); ok {
 		if errObj, ok := m["error"].(map[string]any); ok {
-			if param, _ := errObj["param"].(string); param != "" {
+			param, _ := errObj["param"].(string)
+			if param != "" && (errorCode == "unknown_parameter" || errorCode == "unsupported_parameter" ||
+				parameterNameFromMessage(message) != "") {
 				return param
 			}
 		}

--- a/llm/classify_http.go
+++ b/llm/classify_http.go
@@ -40,7 +40,8 @@ func ClassifyHTTPError(operation string, status int, headers http.Header, body [
 		return &contextLengthError{base}
 	case code == "unknown_parameter", code == "unsupported_parameter":
 		base.retryable = false
-		base.hint = fieldHint(paramFromError(raw), res)
+		base.rejectedParam = paramFromError(raw)
+		base.hint = fieldHint(base.rejectedParam, res)
 		return &invalidRequestError{base}
 	}
 	if usageLimitCodes[code] {
@@ -59,7 +60,8 @@ func ClassifyHTTPError(operation string, status int, headers http.Header, body [
 	if err := classifyByMessage(base); err != nil {
 		return err
 	}
-	base.hint = fieldHint(parameterNameFromMessage(base.message), res)
+	base.rejectedParam = parameterNameFromMessage(base.message)
+	base.hint = fieldHint(base.rejectedParam, res)
 	return &invalidRequestError{base}
 }
 

--- a/llm/classify_http.go
+++ b/llm/classify_http.go
@@ -24,14 +24,16 @@ func ClassifyHTTPError(operation string, status int, headers http.Header, body [
 	var raw map[string]any
 	_ = json.Unmarshal(body, &raw) // a non-JSON body classifies by status alone
 	now := time.Now()
+	message := ProviderFailureMessage(operation, body)
 	base := httpBaseError{
-		provider:    res.Instance,
-		protocol:    res.Protocol,
-		statusCode:  status,
-		message:     ProviderFailureMessage(operation, body),
-		errorCode:   extractErrorCode(raw),
-		retryAfter:  retryDelayFromHeaders(headers, now),
-		rawResponse: raw,
+		provider:      res.Instance,
+		protocol:      res.Protocol,
+		statusCode:    status,
+		message:       message,
+		rejectedParam: rejectedParameter(raw, message),
+		errorCode:     extractErrorCode(raw),
+		retryAfter:    retryDelayFromHeaders(headers, now),
+		rawResponse:   raw,
 	}
 	code := base.errorCode
 	switch {
@@ -40,7 +42,6 @@ func ClassifyHTTPError(operation string, status int, headers http.Header, body [
 		return &contextLengthError{base}
 	case code == "unknown_parameter", code == "unsupported_parameter":
 		base.retryable = false
-		base.rejectedParam = rejectedParameter(raw, base.message)
 		base.hint = fieldHint(base.rejectedParam, res)
 		return &invalidRequestError{base}
 	}
@@ -60,7 +61,6 @@ func ClassifyHTTPError(operation string, status int, headers http.Header, body [
 	if err := classifyByMessage(base); err != nil {
 		return err
 	}
-	base.rejectedParam = rejectedParameter(raw, base.message)
 	base.hint = fieldHint(base.rejectedParam, res)
 	return &invalidRequestError{base}
 }

--- a/llm/classify_http_test.go
+++ b/llm/classify_http_test.go
@@ -207,3 +207,45 @@ func TestClassifyHTTPErrorKeepsProviderMessageVerbatim(t *testing.T) {
 		t.Fatal("plain errors carry no protocol or hint")
 	}
 }
+
+// TestRejectedParameter pins the exported accessor callers use instead of
+// re-matching provider prose: the structured error.param code path, every
+// message pattern the classifier recognizes, and the no-parameter cases.
+func TestRejectedParameter(t *testing.T) {
+	structured := ClassifyHTTPError("responses.create", 400, nil,
+		[]byte(`{"error":{"message":"Unsupported parameter","type":"invalid_request_error","param":"temperature","code":"unknown_parameter"}}`),
+		responsesRes)
+	if got := RejectedParameter(structured); got != "temperature" {
+		t.Errorf("structured param: RejectedParameter = %q, want temperature", got)
+	}
+
+	msgs := []struct {
+		msg  string
+		want string
+	}{
+		{"Unrecognized request argument supplied: temperature", "temperature"},
+		{"Unknown parameter: 'temperature'", "temperature"},
+		{"Unsupported parameter: 'temperature' is not supported with this model.", "temperature"},
+		{"Invalid value: unknown field temperature", "temperature"},
+		{"Unsupported parameter: 'top_p' is not supported with this model.", "top_p"},
+		{"temperature value out of range", ""},
+		{"model not found", ""},
+	}
+	for _, tc := range msgs {
+		err := ErrorFromHTTPStatus("openai", 400, tc.msg, nil, nil)
+		if got := RejectedParameter(err); got != tc.want {
+			t.Errorf("RejectedParameter(%q) = %q, want %q", tc.msg, got, tc.want)
+		}
+	}
+
+	// Non-provider errors carry no parameter.
+	if got := RejectedParameter(errors.New("plain")); got != "" {
+		t.Errorf("plain error: RejectedParameter = %q, want \"\"", got)
+	}
+	// A rejection-shaped message on a non-400 status still names its
+	// parameter — the accessor reports the fact; callers gate on Kind.
+	quota := ErrorFromHTTPStatus("openai", 429, "Unsupported parameter: 'temperature'", nil, nil)
+	if got := RejectedParameter(quota); got != "temperature" {
+		t.Errorf("non-400 status: RejectedParameter = %q, want temperature (callers gate on Kind)", got)
+	}
+}

--- a/llm/classify_http_test.go
+++ b/llm/classify_http_test.go
@@ -268,4 +268,13 @@ func TestRejectedParameter(t *testing.T) {
 	if got := RejectedParameter(classified); got != "temperature" {
 		t.Errorf("classifier structured path with null param must fall back to the message: got %q", got)
 	}
+
+	// Non-400/422 statuses classify early but keep the parameter: the accessor
+	// covers every construction path (round-6 Low on #835).
+	quotaClassified := ClassifyHTTPError("responses.create", 429, nil,
+		[]byte(`{"error":{"message":"Unsupported parameter: 'temperature' is not supported with this model.","type":"invalid_request_error","param":null,"code":"rate_limit_exceeded"}}`),
+		responsesRes)
+	if got := RejectedParameter(quotaClassified); got != "temperature" {
+		t.Errorf("429 through ClassifyHTTPError must keep the rejected parameter: got %q", got)
+	}
 }

--- a/llm/classify_http_test.go
+++ b/llm/classify_http_test.go
@@ -250,15 +250,30 @@ func TestRejectedParameter(t *testing.T) {
 	}
 
 	// ErrorFromHTTPStatus reads a structured error.param from raw, not only
-	// message patterns (the raw shape mirrors a decoded provider body).
-	rawStructured := map[string]any{"error": map[string]any{"message": "Unsupported", "type": "invalid_request_error", "param": "temperature"}}
+	// message patterns — but only when the error is actually a rejection: here
+	// the code vouches (round-7: a param alone is not a rejection).
+	rawStructured := map[string]any{"error": map[string]any{"message": "Unsupported", "type": "invalid_request_error", "param": "temperature", "code": "unknown_parameter"}}
 	if err := ErrorFromHTTPStatus("openai", 400, "Unsupported", rawStructured, nil); RejectedParameter(err) != "temperature" {
-		t.Error("ErrorFromHTTPStatus must extract structured error.param from raw")
+		t.Error("ErrorFromHTTPStatus must extract structured error.param from raw for a rejection code")
 	}
-	// Structured param takes precedence over a message naming another one.
-	rawBoth := map[string]any{"error": map[string]any{"message": "Unsupported parameter: 'top_p'", "param": "temperature"}}
-	if err := ErrorFromHTTPStatus("openai", 400, "Unsupported parameter: 'top_p'", rawBoth, nil); RejectedParameter(err) != "temperature" {
-		t.Error("structured error.param must take precedence over the message pattern")
+	// A rejection-shaped message vouches for the structured param too.
+	rawMsgShaped := map[string]any{"error": map[string]any{"message": "Unsupported parameter: 'top_p'", "param": "temperature"}}
+	if err := ErrorFromHTTPStatus("openai", 400, "Unsupported parameter: 'top_p'", rawMsgShaped, nil); RejectedParameter(err) != "temperature" {
+		t.Error("structured error.param must take precedence over the message pattern when the message is a rejection")
+	}
+	// A param on a non-rejection error is a pointer at the offending value,
+	// not a rejection: "Invalid value for 'temperature': must be between 0
+	// and 2" with param=temperature must NOT read as rejected (round-7).
+	rawValue := map[string]any{"error": map[string]any{"message": "Invalid value for 'temperature': must be between 0 and 2.", "type": "invalid_request_error", "param": "temperature", "code": "invalid_value"}}
+	if err := ErrorFromHTTPStatus("openai", 400, "Invalid value for 'temperature': must be between 0 and 2.", rawValue, nil); RejectedParameter(err) != "" {
+		t.Error("an invalid-value error's error.param must not read as a rejection")
+	}
+	// The same shape through the classifier.
+	valueClassified := ClassifyHTTPError("responses.create", 400, nil,
+		[]byte(`{"error":{"message":"Invalid value for 'temperature': must be between 0 and 2.","type":"invalid_request_error","param":"temperature","code":"invalid_value"}}`),
+		responsesRes)
+	if got := RejectedParameter(valueClassified); got != "" {
+		t.Errorf("classifier: an invalid-value error must not carry a rejected parameter: got %q", got)
 	}
 	// The classifier's structured code path falls back to the message when
 	// error.param is absent (JSON null, as OpenAI sends).

--- a/llm/classify_http_test.go
+++ b/llm/classify_http_test.go
@@ -248,4 +248,24 @@ func TestRejectedParameter(t *testing.T) {
 	if got := RejectedParameter(quota); got != "temperature" {
 		t.Errorf("non-400 status: RejectedParameter = %q, want temperature (callers gate on Kind)", got)
 	}
+
+	// ErrorFromHTTPStatus reads a structured error.param from raw, not only
+	// message patterns (the raw shape mirrors a decoded provider body).
+	rawStructured := map[string]any{"error": map[string]any{"message": "Unsupported", "type": "invalid_request_error", "param": "temperature"}}
+	if err := ErrorFromHTTPStatus("openai", 400, "Unsupported", rawStructured, nil); RejectedParameter(err) != "temperature" {
+		t.Error("ErrorFromHTTPStatus must extract structured error.param from raw")
+	}
+	// Structured param takes precedence over a message naming another one.
+	rawBoth := map[string]any{"error": map[string]any{"message": "Unsupported parameter: 'top_p'", "param": "temperature"}}
+	if err := ErrorFromHTTPStatus("openai", 400, "Unsupported parameter: 'top_p'", rawBoth, nil); RejectedParameter(err) != "temperature" {
+		t.Error("structured error.param must take precedence over the message pattern")
+	}
+	// The classifier's structured code path falls back to the message when
+	// error.param is absent (JSON null, as OpenAI sends).
+	classified := ClassifyHTTPError("responses.create", 400, nil,
+		[]byte(`{"error":{"message":"Unsupported parameter: 'temperature' is not supported with this model.","type":"invalid_request_error","param":null,"code":"unsupported_parameter"}}`),
+		responsesRes)
+	if got := RejectedParameter(classified); got != "temperature" {
+		t.Errorf("classifier structured path with null param must fall back to the message: got %q", got)
+	}
 }

--- a/llm/errors.go
+++ b/llm/errors.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -105,16 +106,20 @@ func (e *ConfigurationError) Raw() any { return nil }
 func (e *ConfigurationError) Unwrap() error { return e.Cause }
 
 type httpBaseError struct {
-	provider    string
-	protocol    string
-	hint        string
-	statusCode  int
-	message     string
-	errorCode   string
-	retryable   bool
-	retryAfter  *time.Duration
-	rawResponse any
-	cause       error
+	provider string
+	protocol string
+	hint     string
+	// rejectedParam is the request parameter a provider rejection named, from
+	// the structured error.param or a spec §12 message pattern: "temperature"
+	// for a rejected temperature, "" when the rejection named nothing.
+	rejectedParam string
+	statusCode    int
+	message       string
+	errorCode     string
+	retryable     bool
+	retryAfter    *time.Duration
+	rawResponse   any
+	cause         error
 }
 
 // Error returns the error message in the form "<provider> error (status=<code>): <message>",
@@ -158,6 +163,28 @@ func (e *httpBaseError) StatusCode() int { return e.statusCode }
 // ErrorCode returns the provider-specific error code extracted from the response
 // body, or the empty string if none was found.
 func (e *httpBaseError) ErrorCode() string { return e.errorCode }
+
+// RejectedParameter returns the request parameter a rejected-request error
+// named, in the provider's own spelling ("temperature",
+// "max_completion_tokens", …), or "" when the error named no parameter or is
+// not a typed provider rejection. It reads the structured error.param and the
+// message shapes ClassifyHTTPError recognizes, so callers never re-match
+// provider prose.
+func (e *httpBaseError) RejectedParameter() string { return e.rejectedParam }
+
+// RejectedParameter returns the request parameter a rejected-request error
+// named, in the provider's own spelling, or "" when the error named no
+// parameter or is not a typed provider rejection. It reads the structured
+// error.param and the message shapes ClassifyHTTPError and
+// ErrorFromHTTPStatus recognize, so callers never re-match provider prose
+// (the namer's temperature retry is the motivating caller).
+func RejectedParameter(err error) string {
+	var p interface{ RejectedParameter() string }
+	if errors.As(err, &p) {
+		return p.RejectedParameter()
+	}
+	return ""
+}
 
 // Retryable reports whether retrying the request might succeed.
 func (e *httpBaseError) Retryable() bool { return e.retryable }
@@ -359,12 +386,13 @@ func RewriteErrorProvider(err error, provider string) error {
 // status codes yield a retryable UnknownHTTPError.
 func ErrorFromHTTPStatus(provider string, statusCode int, message string, raw any, retryAfter *time.Duration) error {
 	base := httpBaseError{
-		provider:    strings.TrimSpace(provider),
-		statusCode:  statusCode,
-		message:     message,
-		errorCode:   extractErrorCode(raw),
-		retryAfter:  retryAfter,
-		rawResponse: raw,
+		provider:      strings.TrimSpace(provider),
+		statusCode:    statusCode,
+		message:       message,
+		rejectedParam: parameterNameFromMessage(message),
+		errorCode:     extractErrorCode(raw),
+		retryAfter:    retryAfter,
+		rawResponse:   raw,
 	}
 	return errorFromHTTPStatus(base)
 }

--- a/llm/errors.go
+++ b/llm/errors.go
@@ -385,12 +385,13 @@ func RewriteErrorProvider(err error, provider string) error {
 // responses are further refined by message via classifyByMessage. Unrecognized
 // status codes yield a retryable UnknownHTTPError.
 func ErrorFromHTTPStatus(provider string, statusCode int, message string, raw any, retryAfter *time.Duration) error {
+	code := extractErrorCode(raw)
 	base := httpBaseError{
 		provider:      strings.TrimSpace(provider),
 		statusCode:    statusCode,
 		message:       message,
-		rejectedParam: rejectedParameter(raw, message),
-		errorCode:     extractErrorCode(raw),
+		rejectedParam: rejectedParameter(raw, message, code),
+		errorCode:     code,
 		retryAfter:    retryAfter,
 		rawResponse:   raw,
 	}

--- a/llm/errors.go
+++ b/llm/errors.go
@@ -389,7 +389,7 @@ func ErrorFromHTTPStatus(provider string, statusCode int, message string, raw an
 		provider:      strings.TrimSpace(provider),
 		statusCode:    statusCode,
 		message:       message,
-		rejectedParam: parameterNameFromMessage(message),
+		rejectedParam: rejectedParameter(raw, message),
 		errorCode:     extractErrorCode(raw),
 		retryAfter:    retryAfter,
 		rawResponse:   raw,

--- a/llm/registry/prune.go
+++ b/llm/registry/prune.go
@@ -108,14 +108,21 @@ func TemperatureSupported(res Resolved) bool {
 	return res.Caps.Fields[path]
 }
 
-// catalogBacked reports whether any resolved fact is attributed to a curated
-// layer (the models.dev snapshot or the curated overlay), distinguishing a
-// catalog row from a user-configured custom one whose every fact — if any —
-// is config-attributed.
+// catalogBacked reports whether any resolved fact is attributed to a
+// model-specific catalog row: a curated snapshot, overlay, or cache layer
+// setting a row's facts ("<layer>/row"). Provider- and glob-level curated facts
+// ("<layer>/provider", "<layer>/…<glob>") do not count — a user-defined model
+// on a curated base inherits a dozen overlay/provider facts (StrictTools,
+// MaxTokensField, most Fields.*), and those inherited facts must not mistake
+// the custom row for a catalog one (the round-5 probe on a work/my-model
+// row showed exactly this).
 func catalogBacked(provenance map[string]string) bool {
 	for _, source := range provenance {
-		if strings.HasPrefix(source, LayerSnapshot+"/") || strings.HasPrefix(source, LayerOverlay+"/") {
-			return true
+		if strings.HasSuffix(source, "/row") {
+			switch layer := strings.TrimSuffix(source, "/row"); layer {
+			case LayerSnapshot, LayerOverlay, LayerCache:
+				return true
+			}
 		}
 	}
 	return false

--- a/llm/registry/prune.go
+++ b/llm/registry/prune.go
@@ -118,8 +118,8 @@ func TemperatureSupported(res Resolved) bool {
 // row showed exactly this).
 func catalogBacked(provenance map[string]string) bool {
 	for _, source := range provenance {
-		if strings.HasSuffix(source, "/row") {
-			switch layer := strings.TrimSuffix(source, "/row"); layer {
+		if layer, ok := strings.CutSuffix(source, "/row"); ok {
+			switch layer {
 			case LayerSnapshot, LayerOverlay, LayerCache:
 				return true
 			}

--- a/llm/registry/prune.go
+++ b/llm/registry/prune.go
@@ -58,6 +58,43 @@ func PrunablePaths(protocol string) []string {
 	return paths
 }
 
+// TemperaturePath returns the prunable path that controls the temperature
+// parameter for a protocol (e.g. "temperature" for the OpenAI and Anthropic
+// protocols, "generationConfig.temperature" for Google), or "" when the
+// protocol is unknown.
+func TemperaturePath(protocol string) string {
+	switch protocol {
+	case ProtocolGoogle:
+		return "generationConfig.temperature"
+	default:
+		if table, ok := prunable[protocol]; ok {
+			if _, has := table["temperature"]; has {
+				return "temperature"
+			}
+		}
+		return ""
+	}
+}
+
+// TemperatureSupported reports whether a resolved row vouches that its model
+// accepts the temperature parameter. The answer is tri-state in spirit: false
+// for a false or absent Fields flag, but the row's provenance must also show a
+// catalog row (model = "row:…", including the region/dated spellings) — a
+// live-only or synthesized row inherits the protocol's send-by-default
+// baseline without any catalog fact, and that default must not read as
+// support (issue #834: such rows 400 on the parameter).
+func TemperatureSupported(res Resolved) bool {
+	path := TemperaturePath(res.Protocol)
+	if path == "" {
+		return false
+	}
+	step, _, isRow := strings.Cut(res.Provenance["model"], ":")
+	if !isRow || step != "row" && step != "region" && step != "dated" {
+		return false
+	}
+	return res.Caps.Fields[path]
+}
+
 // Baseline returns a copy of the protocol's path → send-by-default table.
 func Baseline(protocol string) map[string]bool {
 	table, ok := prunable[protocol]

--- a/llm/registry/prune.go
+++ b/llm/registry/prune.go
@@ -77,19 +77,26 @@ func TemperaturePath(protocol string) string {
 }
 
 // TemperatureSupported reports whether a resolved row vouches that its model
-// accepts the temperature parameter. The answer is tri-state in spirit: false
-// for a false or absent Fields flag, but the row's provenance must also show a
-// catalog row (model = "row:…", including the region/dated spellings) — a
-// live-only or synthesized row inherits the protocol's send-by-default
-// baseline without any catalog fact, and that default must not read as
-// support (issue #834: such rows 400 on the parameter).
+// accepts the temperature parameter. Two catalog facts must agree: the row's
+// Sampling cap must not be explicitly false (models.dev rows with
+// temperature=false map to Sampling=false while their Fields flag stays at the
+// send-by-default baseline — ShapeRequest drops the parameter for exactly
+// these rows), and the protocol-keyed Fields flag must be true. The row's
+// provenance must also show a catalog row (model = "row:…", including the
+// region/dated spellings) — a live-only or synthesized row inherits the
+// protocol's send-by-default baseline without any catalog fact, and that
+// default must not read as support (issue #834: such rows 400 on the
+// parameter).
 func TemperatureSupported(res Resolved) bool {
 	path := TemperaturePath(res.Protocol)
 	if path == "" {
 		return false
 	}
+	if res.Caps.Sampling != nil && !*res.Caps.Sampling {
+		return false
+	}
 	step, _, isRow := strings.Cut(res.Provenance["model"], ":")
-	if !isRow || step != "row" && step != "region" && step != "dated" {
+	if !isRow || (step != "row" && step != "region" && step != "dated") {
 		return false
 	}
 	return res.Caps.Fields[path]

--- a/llm/registry/prune.go
+++ b/llm/registry/prune.go
@@ -77,16 +77,19 @@ func TemperaturePath(protocol string) string {
 }
 
 // TemperatureSupported reports whether a resolved row vouches that its model
-// accepts the temperature parameter. Two catalog facts must agree: the row's
-// Sampling cap must not be explicitly false (models.dev rows with
-// temperature=false map to Sampling=false while their Fields flag stays at the
-// send-by-default baseline — ShapeRequest drops the parameter for exactly
-// these rows), and the protocol-keyed Fields flag must be true. The row's
-// provenance must also show a catalog row (model = "row:…", including the
-// region/dated spellings) — a live-only or synthesized row inherits the
-// protocol's send-by-default baseline without any catalog fact, and that
-// default must not read as support (issue #834: such rows 400 on the
-// parameter).
+// accepts the temperature parameter. The voucher must be a fact, not the
+// send-by-default baseline: (1) the row's Sampling cap must not be explicitly
+// false (models.dev rows with temperature=false map to Sampling=false while
+// their Fields flag stays at baseline — ShapeRequest drops the parameter for
+// exactly these rows); (2) the lookup must have found a row (model =
+// "row:…", including the region/dated spellings) — a live-only or synthesized
+// row inherits the baseline without any fact; (3) the row must be
+// catalog-backed — some fact attributed to the curated snapshot or overlay —
+// or the temperature Fields flag must be explicitly set by any layer
+// ("Fields.<path>" provenance): a user-configured custom model carries no
+// catalog facts, so its baseline true is silence, not support (issue #834:
+// such rows 400 on the parameter), while an explicit
+// fields.temperature = true is a deliberate choice and vouches.
 func TemperatureSupported(res Resolved) bool {
 	path := TemperaturePath(res.Protocol)
 	if path == "" {
@@ -99,7 +102,23 @@ func TemperatureSupported(res Resolved) bool {
 	if !isRow || (step != "row" && step != "region" && step != "dated") {
 		return false
 	}
+	if _, explicit := res.Provenance["Fields."+path]; !explicit && !catalogBacked(res.Provenance) {
+		return false
+	}
 	return res.Caps.Fields[path]
+}
+
+// catalogBacked reports whether any resolved fact is attributed to a curated
+// layer (the models.dev snapshot or the curated overlay), distinguishing a
+// catalog row from a user-configured custom one whose every fact — if any —
+// is config-attributed.
+func catalogBacked(provenance map[string]string) bool {
+	for _, source := range provenance {
+		if strings.HasPrefix(source, LayerSnapshot+"/") || strings.HasPrefix(source, LayerOverlay+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 // Baseline returns a copy of the protocol's path → send-by-default table.

--- a/llm/registry/prune_test.go
+++ b/llm/registry/prune_test.go
@@ -148,3 +148,108 @@ func TestPrune_DeveloperRoleIsPseudoAndAbsentPathsAreNotReported(t *testing.T) {
 		t.Fatal("developer_role must not touch the body")
 	}
 }
+
+func TestTemperaturePath(t *testing.T) {
+	cases := []struct {
+		protocol string
+		want     string
+	}{
+		{ProtocolOpenAIChat, "temperature"},
+		{ProtocolOpenAIResponses, "temperature"},
+		{ProtocolAnthropic, "temperature"},
+		{ProtocolGoogle, "generationConfig.temperature"},
+		{"unknown-protocol", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := TemperaturePath(tc.protocol); got != tc.want {
+			t.Errorf("TemperaturePath(%q) = %q, want %q", tc.protocol, got, tc.want)
+		}
+	}
+}
+
+func TestTemperatureSupported(t *testing.T) {
+	boolPtr := func(v bool) *bool { return &v }
+	row := func(step, model string) map[string]string {
+		if model == "" {
+			return map[string]string{"model": step}
+		}
+		return map[string]string{"model": step + ":" + model}
+	}
+	cases := []struct {
+		name string
+		res  Resolved
+		want bool
+	}{
+		{
+			name: "catalog row with fields true",
+			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: row("row", "gpt-x"),
+				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
+			want: true,
+		},
+		{
+			name: "region-prefixed catalog row",
+			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: row("region", "gpt-x"),
+				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
+			want: true,
+		},
+		{
+			name: "dated-suffix catalog row",
+			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: row("dated", "gpt-x"),
+				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
+			want: true,
+		},
+		{
+			name: "catalog row with fields false",
+			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: row("row", "gpt-x"),
+				Caps: Caps{Fields: map[string]bool{"temperature": false}}},
+		},
+		{
+			name: "live-only row inherits send-by-default baseline",
+			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: row("live", ""),
+				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
+		},
+		{
+			name: "synthesized row",
+			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: row("synthesized", ""),
+				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
+		},
+		{
+			name: "absent model provenance",
+			res: Resolved{Protocol: ProtocolOpenAIResponses,
+				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
+		},
+		{
+			name: "sampling false overrides fields true",
+			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: row("row", "o-x"),
+				Caps: Caps{Sampling: boolPtr(false), Fields: map[string]bool{"temperature": true}}},
+		},
+		{
+			name: "sampling true keeps fields verdict",
+			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: row("row", "gpt-x"),
+				Caps: Caps{Sampling: boolPtr(true), Fields: map[string]bool{"temperature": true}}},
+			want: true,
+		},
+		{
+			name: "google row keys generationConfig.temperature",
+			res: Resolved{Protocol: ProtocolGoogle, Provenance: row("row", "gemini-x"),
+				Caps: Caps{Fields: map[string]bool{"generationConfig.temperature": true}}},
+			want: true,
+		},
+		{
+			name: "google row with plain temperature key only reads as absent",
+			res: Resolved{Protocol: ProtocolGoogle, Provenance: row("row", "gemini-x"),
+				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
+		},
+		{
+			name: "unknown protocol",
+			res: Resolved{Protocol: "unknown", Provenance: row("row", "x"),
+				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
+		},
+	}
+	for _, tc := range cases {
+		if got := TemperatureSupported(tc.res); got != tc.want {
+			t.Errorf("%s: TemperatureSupported = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/llm/registry/prune_test.go
+++ b/llm/registry/prune_test.go
@@ -176,6 +176,13 @@ func TestTemperatureSupported(t *testing.T) {
 		}
 		return map[string]string{"model": step + ":" + model}
 	}
+	// catalogRow is a row lookup that also carries a snapshot-attributed fact,
+	// as every real catalog row does (context window, family, …).
+	catalogRow := func(step, model string) map[string]string {
+		prov := row(step, model)
+		prov["ContextWindow"] = LayerSnapshot + "/row"
+		return prov
+	}
 	cases := []struct {
 		name string
 		res  Resolved
@@ -183,25 +190,25 @@ func TestTemperatureSupported(t *testing.T) {
 	}{
 		{
 			name: "catalog row with fields true",
-			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: row("row", "gpt-x"),
+			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: catalogRow("row", "gpt-x"),
 				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
 			want: true,
 		},
 		{
 			name: "region-prefixed catalog row",
-			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: row("region", "gpt-x"),
+			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: catalogRow("region", "gpt-x"),
 				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
 			want: true,
 		},
 		{
 			name: "dated-suffix catalog row",
-			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: row("dated", "gpt-x"),
+			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: catalogRow("dated", "gpt-x"),
 				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
 			want: true,
 		},
 		{
 			name: "catalog row with fields false",
-			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: row("row", "gpt-x"),
+			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: catalogRow("row", "gpt-x"),
 				Caps: Caps{Fields: map[string]bool{"temperature": false}}},
 		},
 		{
@@ -226,25 +233,57 @@ func TestTemperatureSupported(t *testing.T) {
 		},
 		{
 			name: "sampling true keeps fields verdict",
-			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: row("row", "gpt-x"),
+			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: catalogRow("row", "gpt-x"),
 				Caps: Caps{Sampling: boolPtr(true), Fields: map[string]bool{"temperature": true}}},
 			want: true,
 		},
 		{
 			name: "google row keys generationConfig.temperature",
-			res: Resolved{Protocol: ProtocolGoogle, Provenance: row("row", "gemini-x"),
+			res: Resolved{Protocol: ProtocolGoogle, Provenance: catalogRow("row", "gemini-x"),
 				Caps: Caps{Fields: map[string]bool{"generationConfig.temperature": true}}},
 			want: true,
 		},
 		{
 			name: "google row with plain temperature key only reads as absent",
-			res: Resolved{Protocol: ProtocolGoogle, Provenance: row("row", "gemini-x"),
+			res: Resolved{Protocol: ProtocolGoogle, Provenance: catalogRow("row", "gemini-x"),
 				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
 		},
 		{
 			name: "unknown protocol",
 			res: Resolved{Protocol: "unknown", Provenance: row("row", "x"),
 				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
+		},
+		{
+			// A user-configured custom row with no catalog facts and no explicit
+			// temperature field: baseline true is silence, not support.
+			name: "user-configured row with no facts",
+			res: Resolved{Protocol: ProtocolOpenAIResponses, Provenance: row("row", "my-model"),
+				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
+		},
+		{
+			// A user-configured row with facts but none catalog-attributed and no
+			// explicit temperature field: still silence.
+			name: "user-configured row with config-attributed facts only",
+			res: Resolved{Protocol: ProtocolOpenAIResponses,
+				Provenance: func() map[string]string {
+					prov := row("row", "my-model")
+					prov["ContextWindow"] = LayerConfig + "/row"
+					return prov
+				}(),
+				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
+		},
+		{
+			// An explicit fields.temperature = true from any layer is a deliberate
+			// choice and vouches without catalog backing.
+			name: "user-configured row with explicit fields temperature true",
+			res: Resolved{Protocol: ProtocolOpenAIResponses,
+				Provenance: func() map[string]string {
+					prov := row("row", "my-model")
+					prov["Fields.temperature"] = LayerConfig + "/row"
+					return prov
+				}(),
+				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
+			want: true,
 		},
 	}
 	for _, tc := range cases {

--- a/llm/registry/prune_test.go
+++ b/llm/registry/prune_test.go
@@ -285,6 +285,34 @@ func TestTemperatureSupported(t *testing.T) {
 				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
 			want: true,
 		},
+		{
+			// A user-defined model on a curated base inherits provider-level
+			// overlay facts (StrictTools, MaxTokensField, most Fields.*) — those
+			// inherited facts must not mistake the custom row for a catalog one
+			// (round-5 probe on a work/my-model row showed exactly this).
+			name: "user-configured row inheriting overlay provider facts",
+			res: Resolved{Protocol: ProtocolOpenAIResponses,
+				Provenance: func() map[string]string {
+					prov := row("row", "my-model")
+					prov["StrictTools"] = LayerOverlay + "/provider"
+					prov["MaxTokensField"] = LayerOverlay + "/provider"
+					prov["Fields.store"] = LayerOverlay + "/provider"
+					return prov
+				}(),
+				Caps: Caps{Fields: map[string]bool{"temperature": true, "store": false}}},
+		},
+		{
+			// A cached catalog row fact vouches the same way a snapshot one does.
+			name: "cache-backed catalog row",
+			res: Resolved{Protocol: ProtocolOpenAIResponses,
+				Provenance: func() map[string]string {
+					prov := catalogRow("row", "gpt-x")
+					prov["ContextWindow"] = LayerCache + "/row"
+					return prov
+				}(),
+				Caps: Caps{Fields: map[string]bool{"temperature": true}}},
+			want: true,
+		},
 	}
 	for _, tc := range cases {
 		if got := TemperatureSupported(tc.res); got != tc.want {


### PR DESCRIPTION
## Summary

Fixes #834 (the namer-side half — proposed fix 1). **Stacks on #826** (branch `namer-temperature-gate` is based on `session-auto-namer` HEAD; merge #826 first).

## Problem

The session namer set `Temperature` unconditionally. On a Bedrock-hosted model whose wire id has no catalog row (`bedrock/us.openai.gpt-5.6-luna`), the row resolves **synthesized**; the protocol baseline marks temperature send-by-default, nothing prunes it, and the provider 400s — one dead request and a warning per session (135 of 135 Terminal-Bench trials per run).

## Fix

Two layers, both in `agent/session_namer.go`:

1. **Caps gate**: `sessionNamerTemperature` resolves the cheap ref (`CheapProvider() + "/" + model`) through the client's registry and returns a temperature **only** when a real catalog row vouches for it (`Fields["temperature"] == true`, `Synthesized == false`). Synthesized rows, failed resolutions, and false-capability rows all omit the parameter. Unknown capability reads as *do-not-send*: a wrong send is a provider 400, a wrong omit only loses a determinism hint on a low-stakes decoration call.
2. **Single retry (defense in depth)**: when a row vouches for temperature but the provider rejects it anyway (`KindInvalidRequest` naming temperature), retry exactly once with the parameter dropped instead of failing the naming attempt.

## What's out of scope (per the issue)

- Fix 2 (Bedrock `us.openai.*` / `us.anthropic.*` wire-id resolution to catalog rows) — the already-scoped "Bedrock ID alias in LookupModelInfo" registry item; that fixes the empty model snapshot too.
- Fix 3 (unrelated startup noise: `models.list` 404 on Bedrock, the default ollama probe).

## Testing

Behavioral, per repo policy (scripted provider adapter, hermetic registry; no prompt-prose assertions). New `agent/session_namer_temperature_test.go`, TDD red→green (2 of 5 failed before the fix):

- synthesized-row model (hermetic bedrock-shaped instance, exactly the #834 shape) → no temperature in the request, exactly 1 call
- catalog row with `fields.temperature=false` (moonshotai) → no temperature
- catalog row with `temperature=true` (openai) → temperature sent
- temperature-naming 400 from a vouching row → exactly one retry, without the parameter
- unrelated 400 → no retry, error surfaces wrapped

Gates: gofmt clean, `go vet ./agent/` clean, namer suite ok, `make lint-evenerfuzz` PASS (65s), full `go test ./agent/` ok (234s), `make fuzz` exit 0.

The workaround from the issue (`alias_of` / `fields.temperature = false` config) remains valid and now composes with the gate.
