### PR TITLE
make: run lint-gofmt with the active toolchain's gofmt

### DIFF
--- a/make/linting.mk
+++ b/make/linting.mk
@@ -134,8 +134,12 @@ lint-cache-clean:
 ## trigger: Required CI (via make lint); local pre-merge.
 ## requires: None beyond the Go toolchain.
 ## fails-when: Any tracked .go file is not gofmt-clean.
+# Runs the active toolchain's own gofmt rather than whatever gofmt is on PATH:
+# go.mod's `go` directive (with GOTOOLCHAIN=auto) makes `go` switch to a newer
+# toolchain, but a distro gofmt binary never switches, so PATH's gofmt can lag
+# the compiler and disagree with it about formatting.
 lint-gofmt:
-	$(call run_quiet_lint,files="$$(git ls-files -z -- '*.go' | xargs -0 gofmt -l)"; status=$$?; if [ "$$status" -ne 0 ]; then if [ -n "$$files" ]; then printf '%s\n' "$$files"; fi; exit "$$status"; fi; if [ -n "$$files" ]; then printf '%s\n' "$$files"; exit 1; fi)
+	$(call run_quiet_lint,files="$$(git ls-files -z -- '*.go' | xargs -0 "$$(go env GOROOT)/bin/gofmt" -l)"; status=$$?; if [ "$$status" -ne 0 ]; then if [ -n "$$files" ]; then printf '%s\n' "$$files"; fi; exit "$$status"; fi; if [ -n "$$files" ]; then printf '%s\n' "$$files"; exit 1; fi)
 
 # lint-generated fails if any committed generated output is stale: the appwire
 # catalog or a make/*.mk annotation changed without the outputs being

--- a/makefiletargets_audit_test.go
+++ b/makefiletargets_audit_test.go
@@ -784,7 +784,7 @@ func TestEveryGeneratedRegionIsInTheStalenessDiff(t *testing.T) {
 // is which of them is wrong, not which is easier to edit.
 var lintGateCommands = map[string]string{
 	"lint-naming":        "go run ./cmd/evener-dev/bin tomlcheck",
-	"lint-gofmt":         "gofmt -l",
+	"lint-gofmt":         "/bin/gofmt\" -l",
 	"lint-evenerfuzz":    "-tags evenerfuzz",
 	"lint-eval":          "-tags eval ",
 	"lint-internal":      "go run ./cmd/evener-dev/bin internalcheck",


### PR DESCRIPTION
`lint-gofmt` called bare `gofmt`, assuming PATH's formatter matches the compiler. It doesn't have to: go.mod's toolchain line makes `go` auto-switch to 1.27.0, but the standalone `gofmt` binary on PATH is whatever the distro installed (go1.22 on Ubuntu 24.04, which ships nothing newer than 1.24). The stale formatter flagged three clean files, so `make lint` failed on a clean `main`.

This resolves gofmt through `go env GOROOT`, so the target always runs the formatter that matches the compiler, locally and in CI. One recipe line plus a comment explaining why.

Verification on the affected machine:
- `make lint-gofmt` on clean `origin/main`: FAIL (three files) before, PASS after.
- A deliberately unformatted tracked file still fails the target.
- `make lint-generated` clean (annotation lines untouched).