### PR TITLE
fix(agent): harden task-list schema and progress

### DIFF
--- a/agent/cov_intg_hooks_test.go
+++ b/agent/cov_intg_hooks_test.go
@@ -112,6 +112,43 @@ func TestIntg_ExecTool_PreToolUseRewritesInput(t *testing.T) {
 	collect()
 }
 
+func TestIntg_ExecTool_PreToolUseRewriteRevalidatesTaskList(t *testing.T) {
+	t.Parallel()
+	sess, _ := intg_hookSession(t, `{
+		"hooks": {
+			"PreToolUse": [
+				{"matcher": "task_list", "hooks": [{"type": "command", "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\",\"updatedInput\":{\"add\":[{\"type\":\"implement\",\"brief\":\"rewritten brief\",\"prompt\":\"do it\"}]}}}'"}]}
+			]
+		}
+	}`)
+	defer sess.Close()
+
+	// The original call is valid. The hook replaces its add entry with the
+	// known-bad brief shape, so the post-hook dispatch must run task_list's
+	// targeted PreValidate rather than only generic JSON-schema validation.
+	res := sess.execTool(context.Background(), llm.ToolCallData{
+		ID:        "hook-rewritten-task",
+		Name:      "task_list",
+		Arguments: json.RawMessage(`{"add":[{"type":"implement","description":"original","prompt":"do it"}]}`),
+	}, "")
+	if !res.IsError {
+		t.Fatalf("hook-rewritten invalid task_list = %+v, want targeted prevalidation error", res)
+	}
+	want := `add entry 0 has invalid field "brief"; use the required field named "description" instead`
+	if !strings.Contains(res.Output, want) {
+		t.Fatalf("hook-rewritten task_list diagnostic = %q, want %q", res.Output, want)
+	}
+	if strings.Contains(res.Output, "tool args schema validation failed") {
+		t.Fatalf("hook-rewritten task_list should not fall through to generic schema validation: %q", res.Output)
+	}
+	sess.mu.Lock()
+	executed := sess.taskToolEverUsed
+	sess.mu.Unlock()
+	if executed {
+		t.Fatal("hook-rewritten invalid task_list reached the task handler")
+	}
+}
+
 func TestIntg_ExecTool_PreToolUseInvalidUpdatedInputErrors(t *testing.T) {
 	t.Parallel()
 	sess, ran := intg_hookSession(t, `{

--- a/agent/cov_task_updated_test.go
+++ b/agent/cov_task_updated_test.go
@@ -1,8 +1,11 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"reflect"
+	"strings"
 	"testing"
 
 	"primeradiant.com/evener/agent/events"
@@ -143,6 +146,79 @@ func TestTaskTool_UpdateToInProgressEmitsTaskUpdated(t *testing.T) {
 		return
 	}
 	t.Fatalf("TASK_UPDATED = %#v", emitted)
+}
+
+func TestTaskTool_MixedAddFailingUpdateIsAtomic(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store := taskpkg.NewTaskStore(dir, "mixed-atomic")
+	if _, err := store.Append([]taskpkg.TaskInput{
+		{Type: taskpkg.TaskTypeImplement, Description: "current", Prompt: "p"},
+		{Type: taskpkg.TaskTypeImplement, Description: "open", Prompt: "p"},
+	}); err != nil {
+		t.Fatalf("seed tasks: %v", err)
+	}
+	if err := store.Update([]taskpkg.TaskUpdate{{ID: 1, Status: taskpkg.TaskInProgress}}); err != nil {
+		t.Fatalf("seed current task: %v", err)
+	}
+	before := store.View()
+	wantPersisted, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("marshal pre-call tasks: %v", err)
+	}
+
+	var emitted []events.EventData
+	deps := &toolDeps{
+		emit:           func(_ events.EventKind, data events.EventData) { emitted = append(emitted, data) },
+		steer:          func(string, string) {},
+		resultToolName: func() string { return "communicate" },
+		taskGuard: taskGuard{
+			getOrCreateTaskStore: func() *taskpkg.TaskStore { return store },
+			markUsed:             func() {},
+		},
+	}
+	reg := tool.NewRegistry()
+	registerTaskTools(reg, deps)
+
+	// The add is valid, but the update would introduce a second current task.
+	// It must fail as one transaction: no task, save, event, or next-ID advance
+	// from the add may escape before the conflict is detected.
+	args := json.RawMessage(`{"add":[{"type":"implement","description":"must not leak","prompt":"p"}],"update":[{"id":2,"status":"in_progress"}]}`)
+	for _, callID := range []string{"failed", "retry-failed"} {
+		res := reg.ExecuteCall(context.Background(), nil, llm.ToolCallData{ID: callID, Name: "task_list", Arguments: args})
+		if !res.IsError || !strings.Contains(res.Output, "only one task may be in_progress") {
+			t.Fatalf("mixed call %s = %+v, want in_progress conflict", callID, res)
+		}
+		if got := store.View(); !reflect.DeepEqual(got, before) {
+			t.Fatalf("in-memory tasks after %s = %#v, want %#v", callID, got, before)
+		}
+		reloaded := taskpkg.NewTaskStore(dir, "mixed-atomic")
+		if err := reloaded.Load(); err != nil {
+			t.Fatalf("reload after %s: %v", callID, err)
+		}
+		persisted, err := json.Marshal(reloaded.View())
+		if err != nil {
+			t.Fatalf("marshal persisted tasks after %s: %v", callID, err)
+		}
+		if !bytes.Equal(persisted, wantPersisted) {
+			t.Fatalf("persisted tasks after %s = %s, want %s", callID, persisted, wantPersisted)
+		}
+	}
+	if len(emitted) != 0 {
+		t.Fatalf("failed mixed calls emitted task updates: %#v", emitted)
+	}
+
+	// A corrected retry gets the original next ID, proving neither failed call
+	// persisted a partial add or consumed an ID.
+	corrected := json.RawMessage(`{"add":[{"type":"implement","description":"must not leak","prompt":"p"}],"update":[{"id":1,"status":"done"}]}`)
+	res := reg.ExecuteCall(context.Background(), nil, llm.ToolCallData{ID: "corrected", Name: "task_list", Arguments: corrected})
+	if res.IsError {
+		t.Fatalf("corrected mixed retry: %s", res.Output)
+	}
+	after := store.View()
+	if len(after) != 3 || after[2].ID != 3 || after[2].Description != "must not leak" {
+		t.Fatalf("corrected retry tasks = %#v, want exactly one new task with ID 3", after)
+	}
 }
 
 func TestTaskUpdatedDataUsesFirstInProgressTask(t *testing.T) {

--- a/agent/events/eventdata_program_fuzz_test.go
+++ b/agent/events/eventdata_program_fuzz_test.go
@@ -76,7 +76,7 @@ type eventDataProgramCase struct {
 func eventDataProgramCases(text string, n int, flag bool) []eventDataProgramCase {
 	exitCode := n
 	return []eventDataProgramCase{
-		{SessionStartData{Profile: text, Model: text, Restored: flag, Turns: n, CurrentWork: &CurrentWorkSeedData{Tasks: &TaskStateData{Total: n, Done: n}, Goal: &GoalStateData{Objective: text, Status: text, Iterations: n}}, TaskStoreOwnerSessionID: text}, EventSessionStart},
+		{SessionStartData{Profile: text, Model: text, Restored: flag, Turns: n, CurrentWork: &CurrentWorkSeedData{Tasks: &TaskStateData{Total: n, Done: n, Cancelled: n, Remaining: n}, Goal: &GoalStateData{Objective: text, Status: text, Iterations: n}}, TaskStoreOwnerSessionID: text}, EventSessionStart},
 		{SessionEndData{Reason: text, State: text, Turns: n, Interrupted: flag}, EventSessionEnd},
 		{UserInputData{Text: text, Turn: n}, EventUserInput},
 		{AssistantTextStartData{Model: text}, EventAssistantTextStart},
@@ -94,7 +94,7 @@ func eventDataProgramCases(text string, n int, flag bool) []eventDataProgramCase
 		{ToolCallRepairedData{ToolName: text, CallID: text, Changes: []string{text}}, EventToolCallRepaired},
 		{SteeringInjectedData{Text: text}, EventSteeringInjected},
 		{QueueChangedData{Depth: n, Preview: []string{text}}, EventQueueChanged},
-		{TaskUpdatedData{Total: n, Done: n, Current: &TaskSummaryData{ID: n, Description: text}, TaskStoreOwnerSessionID: text}, EventTaskUpdated},
+		{TaskUpdatedData{Total: n, Done: n, Cancelled: n, Remaining: n, Current: &TaskSummaryData{ID: n, Description: text}, TaskStoreOwnerSessionID: text}, EventTaskUpdated},
 		{SessionNameChangedData{Name: text, Source: text}, EventSessionNameChanged},
 		{ModelChangedData{OldProvider: text, OldModel: text, NewProvider: text, NewModel: text, ReasoningEffortLevels: []string{text}, SupportsReasoning: flag}, EventModelChanged},
 		{ReasoningEffortChangedData{ReasoningEffort: text}, EventReasoningEffortChanged},

--- a/agent/events/payloads.go
+++ b/agent/events/payloads.go
@@ -454,9 +454,11 @@ type TaskSummaryData struct {
 
 // TaskStateData is an authoritative task-list progress snapshot.
 type TaskStateData struct {
-	Total   int              `json:"total"`
-	Done    int              `json:"done"`
-	Current *TaskSummaryData `json:"current,omitempty"`
+	Total     int              `json:"total"`
+	Done      int              `json:"done"`
+	Cancelled int              `json:"cancelled"`
+	Remaining int              `json:"remaining"`
+	Current   *TaskSummaryData `json:"current,omitempty"`
 }
 
 // TaskUpdatedData is the payload for an EventTaskUpdated event: the current
@@ -465,6 +467,8 @@ type TaskStateData struct {
 type TaskUpdatedData struct {
 	Total                   int              `json:"total"`
 	Done                    int              `json:"done"`
+	Cancelled               int              `json:"cancelled"`
+	Remaining               int              `json:"remaining"`
 	Current                 *TaskSummaryData `json:"current,omitempty"`
 	TaskStoreOwnerSessionID string           `json:"task_store_owner_session_id,omitempty"`
 	// TaskPublicationEpoch and TaskPublicationRevision are internal ordering

--- a/agent/events/payloads_test.go
+++ b/agent/events/payloads_test.go
@@ -13,6 +13,8 @@ func TestTaskUpdatedData_CurrentJSON(t *testing.T) {
 	}
 	withCurrentData.Total = 3
 	withCurrentData.Done = 1
+	withCurrentData.Cancelled = 1
+	withCurrentData.Remaining = 1
 	withCurrentData.Current = &TaskSummaryData{ID: 2, Description: "live current task"}
 	withCurrent, err := json.Marshal(withCurrentData)
 	if err != nil {
@@ -21,6 +23,11 @@ func TestTaskUpdatedData_CurrentJSON(t *testing.T) {
 	if !strings.Contains(string(withCurrent), `"current":{"id":2,"description":"live current task"}`) {
 		t.Fatalf("TaskUpdatedData JSON = %s", withCurrent)
 	}
+	for _, want := range []string{`"cancelled":1`, `"remaining":1`} {
+		if !strings.Contains(string(withCurrent), want) {
+			t.Fatalf("TaskUpdatedData JSON = %s, missing %s", withCurrent, want)
+		}
+	}
 	if strings.Contains(string(withCurrent), "revision") || strings.Contains(string(withCurrent), "epoch") {
 		t.Fatalf("TaskUpdatedData JSON leaked internal publication identity: %s", withCurrent)
 	}
@@ -28,12 +35,19 @@ func TestTaskUpdatedData_CurrentJSON(t *testing.T) {
 	withoutCurrentData := TaskUpdatedData{}
 	withoutCurrentData.Total = 3
 	withoutCurrentData.Done = 1
+	withoutCurrentData.Cancelled = 1
+	withoutCurrentData.Remaining = 1
 	withoutCurrent, err := json.Marshal(withoutCurrentData)
 	if err != nil {
 		t.Fatalf("marshal TaskUpdatedData without current: %v", err)
 	}
 	if strings.Contains(string(withoutCurrent), `"current"`) {
 		t.Fatalf("TaskUpdatedData without current = %s", withoutCurrent)
+	}
+	for _, want := range []string{`"cancelled":1`, `"remaining":1`} {
+		if !strings.Contains(string(withoutCurrent), want) {
+			t.Fatalf("TaskUpdatedData without current = %s, missing %s", withoutCurrent, want)
+		}
 	}
 }
 
@@ -114,7 +128,7 @@ func TestSessionStartCurrentWorkSeedCarriesAuthoritativeEmptyTasks(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := string(encoded), `{"profile":"","model":"","current_work":{"tasks":{"total":0,"done":0},"goal":null}}`; got != want {
+	if got, want := string(encoded), `{"profile":"","model":"","current_work":{"tasks":{"total":0,"done":0,"cancelled":0,"remaining":0},"goal":null}}`; got != want {
 		t.Fatalf("SessionStartData JSON = %s, want %s", got, want)
 	}
 	var roundTrip SessionStartData

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -622,7 +622,7 @@ func DefTaskList(effortLevels []string) llm.ToolDefinition {
 	strictFalse := false
 	return llm.ToolDefinition{
 		Name:        "task_list",
-		Description: "Manage your task list. A bare call (or empty add/update) returns the current list. Use add to append new tasks (type, brief description <10 words, detailed prompt, optional depends_on/reasoning_effort) and update to change existing tasks (id plus optional status, notes, depends_on, reasoning_effort) — both in the same call when useful. When you mark a task done, the next eligible task auto-starts and its prompt is injected. Use depends_on to express ordering and notes to record what happened. Only one task may be in_progress at a time; to start a new one, complete or defer the current one in the same update array.",
+		Description: "Manage your task list. A bare call (or empty add/update) returns the current list. Use add to append new tasks (type, the field named description <10 words, detailed prompt, optional depends_on/reasoning_effort) and update to change existing tasks (id plus optional status, notes, depends_on, reasoning_effort) — both in the same call when useful. When you mark a task done, the next eligible task auto-starts and its prompt is injected. Use depends_on to express ordering and notes to record what happened. Only one task may be in_progress at a time; to start a new one, complete or defer the current one in the same update array.",
 		// Strict is explicitly false: the OpenAI Responses adapter defaults
 		// strict=true when unset and force-requires every nested property,
 		// which would force strict-mode models to emit "status": "" (enum
@@ -635,9 +635,10 @@ func DefTaskList(effortLevels []string) llm.ToolDefinition {
 			"properties": map[string]any{
 				"add": map[string]any{
 					"type":        "array",
-					"description": "Tasks to add. Omit or [] for none. Each: type, brief description (<10 words), a detailed prompt, optional depends_on (IDs of existing tasks, or of earlier tasks in this same add array which get sequential IDs), and optional reasoning_effort.",
+					"description": "Tasks to add. Omit or [] for none. Each: type, the field named description (<10 words), a detailed prompt, optional depends_on (IDs of existing tasks, or of earlier tasks in this same add array which get sequential IDs), and optional reasoning_effort.",
 					"items": map[string]any{
-						"type": "object",
+						"type":                 "object",
+						"additionalProperties": false,
 						"properties": map[string]any{
 							"type": map[string]any{
 								"type":        "string",
@@ -660,7 +661,8 @@ func DefTaskList(effortLevels []string) llm.ToolDefinition {
 					"type":        "array",
 					"description": "Changes to existing tasks. Omit or [] for none. Each: id plus optional status, notes, depends_on, or reasoning_effort. Omit status to leave it unchanged.",
 					"items": map[string]any{
-						"type": "object",
+						"type":                 "object",
+						"additionalProperties": false,
 						"properties": map[string]any{
 							"id":     map[string]any{"type": "integer"},
 							"status": map[string]any{"type": "string", "enum": []string{"open", "in_progress", "done", "cancelled"}},

--- a/agent/internal/tool/definitions_test.go
+++ b/agent/internal/tool/definitions_test.go
@@ -874,6 +874,12 @@ func TestDefTaskList_PresenceBased(t *testing.T) {
 	if !ok || len(addReq) != 3 || addReq[0] != "type" || addReq[1] != "description" || addReq[2] != "prompt" {
 		t.Fatalf("add item required = %v, want [type description prompt]", addItems["required"])
 	}
+	if addItems["additionalProperties"] != false {
+		t.Fatalf("add item additionalProperties = %v, want false", addItems["additionalProperties"])
+	}
+	if _, has := addItems["properties"].(map[string]any)["brief"]; has {
+		t.Fatal("add item schema must not accept a brief alias")
+	}
 	update, has := props["update"]
 	if !has {
 		t.Fatal("schema must have an update property")
@@ -882,6 +888,12 @@ func TestDefTaskList_PresenceBased(t *testing.T) {
 	updateReq, ok := updateItems["required"].([]string)
 	if !ok || len(updateReq) != 1 || updateReq[0] != "id" {
 		t.Fatalf("update item required = %v, want [id]", updateItems["required"])
+	}
+	if updateItems["additionalProperties"] != false {
+		t.Fatalf("update item additionalProperties = %v, want false", updateItems["additionalProperties"])
+	}
+	if _, has := updateItems["properties"].(map[string]any)["brief"]; has {
+		t.Fatal("update item schema must not accept a brief alias")
 	}
 	if top, has := params["required"]; has {
 		t.Fatalf("schema must not force-require add/update at top level: %v", top)

--- a/agent/internal/tool/registry.go
+++ b/agent/internal/tool/registry.go
@@ -359,6 +359,9 @@ type RegisteredTool struct {
 	Schema     *jsonschema.Schema
 	Limit      schema.ToolOutputLimit
 	OmitIntent bool
+	// PreValidate optionally rejects a tool-specific argument shape before the
+	// generic JSON schema validator renders its diagnostic.
+	PreValidate func(args map[string]any) error
 	// Agent-layer executor with environment context.
 	Exec func(ctx context.Context, env execenv.ExecutionEnvironment, args map[string]any) (any, error)
 }
@@ -674,6 +677,12 @@ func (r *Registry) ExecuteCall(ctx context.Context, env execenv.ExecutionEnviron
 			return truncateResult(name, callID, err.Error(), true, t.Limit)
 		}
 		args = normalized
+	}
+
+	if t.PreValidate != nil {
+		if err := t.PreValidate(args); err != nil {
+			return truncateResult(name, callID, err.Error(), true, t.Limit)
+		}
 	}
 
 	if err := t.Schema.Validate(args); err != nil {

--- a/agent/internal/tool/registry.go
+++ b/agent/internal/tool/registry.go
@@ -616,6 +616,17 @@ func (r *Registry) Names() []string {
 // each returned as an error result. ImageResult and StateResult values are
 // unpacked into the result's image and state fields.
 func (r *Registry) ExecuteCall(ctx context.Context, env execenv.ExecutionEnvironment, call llm.ToolCallData) ExecResult {
+	return r.executeCall(ctx, env, call, false)
+}
+
+// ExecutePreparedCall runs a session-prepared call. Preparation has already
+// normalized and prevalidated arguments, so it preserves ExecuteCall's generic
+// execution behavior without applying a RegisteredTool.PreValidate twice.
+func (r *Registry) ExecutePreparedCall(ctx context.Context, env execenv.ExecutionEnvironment, call llm.ToolCallData) ExecResult {
+	return r.executeCall(ctx, env, call, true)
+}
+
+func (r *Registry) executeCall(ctx context.Context, env execenv.ExecutionEnvironment, call llm.ToolCallData, prevalidated bool) ExecResult {
 	name := call.Name
 	callID := call.ID
 	if strings.TrimSpace(callID) == "" {
@@ -679,7 +690,7 @@ func (r *Registry) ExecuteCall(ctx context.Context, env execenv.ExecutionEnviron
 		args = normalized
 	}
 
-	if t.PreValidate != nil {
+	if !prevalidated && t.PreValidate != nil {
 		if err := t.PreValidate(args); err != nil {
 			return truncateResult(name, callID, err.Error(), true, t.Limit)
 		}

--- a/agent/session_tool_repair.go
+++ b/agent/session_tool_repair.go
@@ -104,6 +104,12 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 		fillChanges = fillCommunicateEnvelope(envelope, filled)
 		args = filled
 	}
+	if t.PreValidate != nil {
+		if err := t.PreValidate(args); err != nil {
+			res.PrevalErr = err.Error()
+			return res
+		}
+	}
 
 	if err := t.Schema.Validate(args); err != nil {
 		// A length stop that cut the stream before any argument byte leaves

--- a/agent/session_tool_repair_task_branch_test.go
+++ b/agent/session_tool_repair_task_branch_test.go
@@ -69,9 +69,9 @@ func TestPrepareToolCall_UpdateEntryInAddArrayExplains(t *testing.T) {
 	}
 }
 
-// The same misfiled-entry call through execTool must surface the
-// schema-explained error to the model.
-func TestExecTool_TaskListMisfiledEntrySurfacesSchemaError(t *testing.T) {
+// The same misfiled-entry call through execTool must surface the targeted
+// task-list diagnostic before generic schema repair can discard its fields.
+func TestExecTool_TaskListMisfiledEntrySurfacesTargetedPrevalidation(t *testing.T) {
 	s := newSession(t, withoutGitSnapshot())
 	s.stateDir = t.TempDir()
 	registerTaskTools(s.reg, &toolDeps{
@@ -93,7 +93,34 @@ func TestExecTool_TaskListMisfiledEntrySurfacesSchemaError(t *testing.T) {
 	if !res.IsError {
 		t.Fatalf("expected error for update-shaped entry in add, got: %s", res.FullOutput)
 	}
-	if !strings.Contains(res.FullOutput, "add[0]") || !strings.Contains(res.FullOutput, "description") {
-		t.Fatalf("model-visible error must name the add item requirements: %s", res.FullOutput)
+	if !strings.Contains(res.FullOutput, "add entry 0") || !strings.Contains(res.FullOutput, "id") || !strings.Contains(res.FullOutput, "status") {
+		t.Fatalf("model-visible error must name the misfiled add fields: %s", res.FullOutput)
+	}
+}
+
+func TestExecTool_TaskListBriefSurfacesTargetedPrevalidation(t *testing.T) {
+	s := newSession(t, withoutGitSnapshot())
+	s.stateDir = t.TempDir()
+	registerTaskTools(s.reg, &toolDeps{
+		emit:           func(events.EventKind, events.EventData) {},
+		steer:          func(string, string) {},
+		resultToolName: func() string { return "communicate" },
+		taskGuard: taskGuard{
+			getOrCreateTaskStore: func() *taskpkg.TaskStore {
+				return taskpkg.NewTaskStore(t.TempDir(), "brief-prevalidation")
+			},
+			markUsed: func() {},
+		},
+	})
+	res := s.execTool(context.Background(), llm.ToolCallData{
+		ID:        "brief-exec",
+		Name:      "task_list",
+		Arguments: json.RawMessage(`{"add":[{"type":"implement","description":"write test","prompt":"write test","brief":"wrong field"}]}`),
+	}, "")
+	if !res.IsError {
+		t.Fatalf("expected targeted brief validation error, got: %s", res.FullOutput)
+	}
+	if !strings.Contains(res.FullOutput, "brief") || !strings.Contains(res.FullOutput, "required field named") || !strings.Contains(res.FullOutput, "description") {
+		t.Fatalf("model-visible error = %q, want targeted brief guidance", res.FullOutput)
 	}
 }

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -787,7 +787,7 @@ func (s *Session) execTool(ctx context.Context, call llm.ToolCallData, finishRea
 			Err:        prep.Err,
 		}
 	} else {
-		res = s.reg.ExecuteCall(ctx, s.currentEnv(), call)
+		res = s.reg.ExecutePreparedCall(ctx, s.currentEnv(), call)
 	}
 	res.DurationMS = time.Since(toolStart).Milliseconds()
 	// M7: on a sandbox denial in an interactive root session, raise a human approval

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -666,6 +666,7 @@ func (s *Session) execTool(ctx context.Context, call llm.ToolCallData, finishRea
 	requestedVisible := providerToolName(call.Name, nameMap)
 	prep := prepareToolCall(call, s.reg.Get(call.Name), visibleNames, requestedVisible, s.resultToolName(), finishReason)
 	call = prep.Call
+	prevalidated := true
 	if len(prep.Changes) > 0 {
 		s.emit(events.EventToolCallRepaired, events.ToolCallRepairedData{
 			ToolName: call.Name,
@@ -714,6 +715,11 @@ func (s *Session) execTool(ctx context.Context, call llm.ToolCallData, finishRea
 					IsError:    true,
 				}
 			}
+			// Preparation validated the original arguments. A hook may replace
+			// any semantic task field, so dispatch this changed call through the
+			// normal PreValidate path while unchanged prepared calls still avoid
+			// running that hook twice.
+			prevalidated = false
 		}
 	}
 	s.execToolCheckpoint("after_pre_hook")
@@ -787,7 +793,11 @@ func (s *Session) execTool(ctx context.Context, call llm.ToolCallData, finishRea
 			Err:        prep.Err,
 		}
 	} else {
-		res = s.reg.ExecutePreparedCall(ctx, s.currentEnv(), call)
+		if prevalidated {
+			res = s.reg.ExecutePreparedCall(ctx, s.currentEnv(), call)
+		} else {
+			res = s.reg.ExecuteCall(ctx, s.currentEnv(), call)
+		}
 	}
 	res.DurationMS = time.Since(toolStart).Milliseconds()
 	// M7: on a sandbox denial in an interactive root session, raise a human approval

--- a/agent/session_tools_aux_exact_fuzz_test.go
+++ b/agent/session_tools_aux_exact_fuzz_test.go
@@ -215,7 +215,7 @@ func auxGoalTaskExact(t *testing.T) {
 	}
 	_ = formatTaskList([]taskpkg.Task{{ID: 1, Type: taskpkg.TaskTypeImplement, Description: "x", Status: taskpkg.TaskDone, DependsOn: []int{2}, ReasoningEffort: "high", Notes: []string{"n"}}})
 	_ = goalStateView(goal.Snapshot{})
-	if taskListAllDone([]taskpkg.Task{{Status: taskpkg.TaskOpen}}) || !taskListAllDone([]taskpkg.Task{{Status: taskpkg.TaskDone}}) {
+	if taskpkg.Summarize([]taskpkg.Task{{Status: taskpkg.TaskOpen}}).NoActionableTasks() || !taskpkg.Summarize([]taskpkg.Task{{Status: taskpkg.TaskDone}}).NoActionableTasks() {
 		t.Fatal("task completion classifier mismatch")
 	}
 }

--- a/agent/session_tools_task.go
+++ b/agent/session_tools_task.go
@@ -94,20 +94,21 @@ func formatMutationAck(added int, updates []taskpkg.TaskUpdate) string {
 }
 
 // taskToolState is the task-list mutation snapshot carried to human clients.
-// Started is present only for explicit updates whose final status is
-// in_progress, so the frontend can distinguish a real transition from a
-// status reassertion without changing the model-facing tool schema or the
-// persisted Task shape.
+// Started is present for every in_progress task in a mutation snapshot. It is
+// true only when this call transitioned that task into progress (explicitly or
+// by auto-advance), letting the frontend distinguish that from an existing
+// current task or a status reassertion without changing the model-facing tool
+// schema or the persisted Task shape.
 type taskToolState struct {
 	taskpkg.Task
 	Started *bool `json:"started,omitempty"`
 }
 
-func taskToolStateSnapshot(tasks []taskpkg.Task, inProgressUpdates map[int]struct{}, started map[int]bool) []taskToolState {
+func taskToolStateSnapshot(tasks []taskpkg.Task, started map[int]bool) []taskToolState {
 	snapshot := make([]taskToolState, len(tasks))
 	for i, task := range tasks {
 		snapshot[i].Task = task
-		if _, ok := inProgressUpdates[task.ID]; !ok {
+		if task.Status != taskpkg.TaskInProgress {
 			continue
 		}
 		transitioned := started[task.ID]
@@ -431,7 +432,6 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 				for _, t := range mutation.After {
 					afterByID[t.ID] = t
 				}
-				inProgressUpdates := make(map[int]struct{}, len(updates))
 				started := make(map[int]bool)
 				var completedAny bool
 				var manuallyStartedID int
@@ -446,7 +446,6 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 						completedAny = true
 					}
 					if status == taskpkg.TaskInProgress {
-						inProgressUpdates[u.ID] = struct{}{}
 						if previous[u.ID] != taskpkg.TaskInProgress {
 							started[u.ID] = true
 							manuallyStartedID = u.ID
@@ -467,7 +466,7 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 					deps.emit(events.EventTaskUpdated, taskUpdatedData(taskpkg.Summarize(mutation.After), "", epoch, revision))
 					return tool.StateResult{
 						Output: formatMutationAck(len(added), updates),
-						State:  taskToolStateSnapshot(mutation.After, inProgressUpdates, started),
+						State:  taskToolStateSnapshot(mutation.After, started),
 					}, nil
 				}
 
@@ -484,6 +483,7 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 							next := eligible[0]
 							if auto, err := store.UpdateWithSnapshot([]taskpkg.TaskUpdate{{ID: next.ID, Status: taskpkg.TaskInProgress}}); err == nil {
 								finalTasks = auto.After
+								started[next.ID] = true
 								deps.steer(formatCurrentTaskSteering(next, true), events.SteeringKindCurrentTask)
 							}
 						} else {
@@ -520,7 +520,7 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 				taskUpdate := taskUpdatedData(summary, "", epoch, revision)
 				deps.emit(events.EventTaskUpdated, taskUpdate)
 				fmt.Fprintf(&msg, "Progress: %s.", summary.ProgressText())
-				return tool.StateResult{Output: msg.String(), State: taskToolStateSnapshot(finalTasks, inProgressUpdates, started)}, nil
+				return tool.StateResult{Output: msg.String(), State: taskToolStateSnapshot(finalTasks, started)}, nil
 			})
 		},
 	})

--- a/agent/session_tools_task.go
+++ b/agent/session_tools_task.go
@@ -139,6 +139,12 @@ func mutateAndPublishTaskStore(store *taskpkg.TaskStore, mutation func(epoch, re
 // prepareToolCall's guard: a direct handler caller (tests, internal callers)
 // bypasses prevalidation, and silently treating an action-shaped call as a
 // view would let the caller believe its mutations applied.
+//
+// Item-field validation deliberately runs again here as a standalone handler
+// safety invariant for direct/internal callers that bypass registry
+// PreValidate. The preparation and decode paths both call the single
+// validateTaskListItemFields validator, so their allowlists and targeted
+// diagnostics remain one shared contract rather than duplicated behavior.
 func decodeTaskArgs(args map[string]any) (adds []taskpkg.TaskInput, updates []taskpkg.TaskUpdate, err error) {
 	for _, retired := range []string{"action", "tasks", "updates"} {
 		if _, supplied := args[retired]; supplied {

--- a/agent/session_tools_task.go
+++ b/agent/session_tools_task.go
@@ -60,7 +60,7 @@ func formatTaskList(tasks []taskpkg.Task) string {
 		}
 	}
 	summary := taskpkg.Summarize(tasks)
-	fmt.Fprintf(&b, "\nProgress: %d/%d tasks complete.", summary.Done, summary.Total)
+	fmt.Fprintf(&b, "\nProgress: %s.", summary.ProgressText())
 	return b.String()
 }
 
@@ -150,13 +150,16 @@ func decodeTaskArgs(args map[string]any) (adds []taskpkg.TaskInput, updates []ta
 		if !ok {
 			return nil, nil, fmt.Errorf("add entry %d must be an object with type, description, and prompt", i)
 		}
+		if err := validateTaskListItemFields("add", i, m); err != nil {
+			return nil, nil, err
+		}
 		var input taskpkg.TaskInput
 		if t, ok := m["type"].(string); ok {
 			input.Type = taskpkg.TaskType(t)
 		}
 		description, ok := m["description"].(string)
 		if !ok {
-			return nil, nil, fmt.Errorf("add entry %d requires a string description", i)
+			return nil, nil, fmt.Errorf("add entry %d requires the field named description as a string; valid add shape: {type, description, prompt}", i)
 		}
 		input.Description = description
 		prompt, ok := m["prompt"].(string)
@@ -189,6 +192,9 @@ func decodeTaskArgs(args map[string]any) (adds []taskpkg.TaskInput, updates []ta
 		m, ok := r.(map[string]any)
 		if !ok {
 			return nil, nil, fmt.Errorf("update entry %d must be an object with id", i)
+		}
+		if err := validateTaskListItemFields("update", i, m); err != nil {
+			return nil, nil, err
 		}
 		idFloat, ok := m["id"].(float64)
 		if !ok {
@@ -224,6 +230,58 @@ func decodeTaskArgs(args map[string]any) (adds []taskpkg.TaskInput, updates []ta
 		updates = append(updates, u)
 	}
 	return adds, updates, nil
+}
+
+func validateTaskListItemFields(kind string, index int, item map[string]any) error {
+	allowed := map[string]bool{}
+	switch kind {
+	case "add":
+		for _, field := range []string{"type", "description", "prompt", "depends_on", "reasoning_effort"} {
+			allowed[field] = true
+		}
+	case "update":
+		for _, field := range []string{"id", "status", "notes", "depends_on", "reasoning_effort"} {
+			allowed[field] = true
+		}
+	}
+	for field := range item {
+		if allowed[field] {
+			continue
+		}
+		if field == "brief" {
+			return fmt.Errorf("%s entry %d has invalid field brief; use the required field named description instead; valid add shape: {type, description, prompt}", kind, index)
+		}
+		return fmt.Errorf("%s entry %d has unknown field %q", kind, index, field)
+	}
+	return nil
+}
+
+func validateTaskListArgs(args map[string]any) error {
+	for _, kind := range []string{"add", "update"} {
+		raw, supplied := args[kind]
+		if !supplied {
+			continue
+		}
+		items, ok := raw.([]any)
+		if !ok {
+			continue // The JSON schema reports an array type mismatch.
+		}
+		for i, rawItem := range items {
+			item, ok := rawItem.(map[string]any)
+			if !ok {
+				continue // The JSON schema reports an object type mismatch.
+			}
+			if err := validateTaskListItemFields(kind, i, item); err != nil {
+				return err
+			}
+			if kind == "add" {
+				if _, ok := item["description"]; !ok {
+					return fmt.Errorf("add entry %d requires the field named description; valid add shape: {type, description, prompt}", i)
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // decodeIDList converts a JSON array of numbers into []int.
@@ -287,7 +345,8 @@ func validateUpdateIDs(store *taskpkg.TaskStore, updates []taskpkg.TaskUpdate) e
 func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 	// Task management.
 	_ = reg.Register(tool.RegisteredTool{
-		Definition: tool.DefTaskList(deps.reasoningEffortLevels),
+		Definition:  tool.DefTaskList(deps.reasoningEffortLevels),
+		PreValidate: validateTaskListArgs,
 		Exec: func(ctx context.Context, env execenv.ExecutionEnvironment, args map[string]any) (any, error) {
 			_ = ctx
 			deps.taskGuard.MarkUsed()
@@ -330,7 +389,7 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 					taskUpdate := taskUpdatedData(taskpkg.Summarize(tasks), "", epoch, revision)
 					deps.emit(events.EventTaskUpdated, taskUpdate)
 					return tool.StateResult{
-						Output: fmt.Sprintf("Added %d task(s). Progress: %d/%d tasks complete.", len(added), taskUpdate.Done, taskUpdate.Total),
+						Output: fmt.Sprintf("Added %d task(s). Progress: %s.", len(added), taskpkg.Summarize(tasks).ProgressText()),
 						State:  tasks,
 					}, nil
 				}
@@ -417,17 +476,25 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 						} else {
 							// No eligible task. If nothing remains open or in_progress,
 							// signal the agent that the list is exhausted.
-							allDone := taskListAllDone(finalTasks)
-							if allDone && len(finalTasks) > 0 {
+							summary := taskpkg.Summarize(finalTasks)
+							if summary.NoActionableTasks() && summary.Total > 0 {
 								var blockingDelegateIDs []string
 								if deps.blockingDelegateIDs != nil {
 									blockingDelegateIDs = deps.blockingDelegateIDs()
 								}
-								deps.sendTaskCompletionSteering(taskReminderAllDoneWhileDelegatesRun(deps.resultToolName(), blockingDelegateIDs), blockingDelegateIDs)
+								deps.sendTaskCompletionSteering(taskReminderTerminalWhileDelegatesRun(deps.resultToolName(), blockingDelegateIDs, summary.AllDone()), blockingDelegateIDs)
 								if len(blockingDelegateIDs) == 0 {
-									msg.WriteString("All tasks complete. ")
+									if summary.AllDone() {
+										msg.WriteString("All tasks complete. ")
+									} else {
+										msg.WriteString("No actionable tasks remain. ")
+									}
 								} else {
-									msg.WriteString("All tasks complete; waiting for delegate(s) ")
+									if summary.AllDone() {
+										msg.WriteString("All tasks complete; waiting for delegate(s) ")
+									} else {
+										msg.WriteString("No actionable tasks remain; waiting for delegate(s) ")
+									}
 									msg.WriteString(strings.Join(blockingDelegateIDs, ", "))
 									msg.WriteString(". ")
 								}
@@ -436,9 +503,10 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 					}
 				}
 
-				taskUpdate := taskUpdatedData(taskpkg.Summarize(finalTasks), "", epoch, revision)
+				summary := taskpkg.Summarize(finalTasks)
+				taskUpdate := taskUpdatedData(summary, "", epoch, revision)
 				deps.emit(events.EventTaskUpdated, taskUpdate)
-				fmt.Fprintf(&msg, "Progress: %d/%d tasks complete.", taskUpdate.Done, taskUpdate.Total)
+				fmt.Fprintf(&msg, "Progress: %s.", summary.ProgressText())
 				return tool.StateResult{Output: msg.String(), State: taskToolStateSnapshot(finalTasks, inProgressUpdates, started)}, nil
 			})
 		},
@@ -468,13 +536,4 @@ func taskUpdatedData(summary taskpkg.ListSummary, taskStoreOwnerSessionID string
 		TaskPublicationEpoch:    publicationEpoch,
 		TaskPublicationRevision: publicationRevision,
 	}
-}
-
-func taskListAllDone(tasks []taskpkg.Task) bool {
-	for _, task := range tasks {
-		if task.Status == taskpkg.TaskOpen || task.Status == taskpkg.TaskInProgress {
-			return false
-		}
-	}
-	return true
 }

--- a/agent/session_tools_task.go
+++ b/agent/session_tools_task.go
@@ -310,51 +310,6 @@ func decodeIDList(raw []any) ([]int, error) {
 	return ids, nil
 }
 
-// validateUpdateIDs rejects update entries whose target — or any task their
-// depends_on names — does not exist in the pre-add store state. The model
-// composed the call before any new IDs existed, so an update can neither
-// target nor depend on this call's adds; the same error covers "never
-// existed" and "not yet created" (the model cannot distinguish them and
-// shouldn't need to). Without the depends_on check the store would validate
-// post-add and accept a guessed new ID — exactly the ID-guessing the
-// pre-add target rule exists to prevent.
-//
-// This is handler-side policy over a store API that cannot express the
-// pre-add transaction: the semantic rule (the model cannot know new IDs)
-// belongs here, not in the store. If a second mutation caller appears, hoist
-// the whole combined batch into a store-level ApplyBatch(adds, updates) that
-// validates updates against the pre-add state under one lock and returns one
-// snapshot — until then the double validation (updateLocked re-rejects the
-// same unknown IDs) is the price of exactly one caller.
-//
-// Only load-bearing when the call also adds: updateLocked enforces the same
-// rejections (identical errors, nothing applied) when there are no adds, so
-// callers gate on len(adds) > 0 and skip the duplicated pass.
-func validateUpdateIDs(store *taskpkg.TaskStore, updates []taskpkg.TaskUpdate) error {
-	if len(updates) == 0 {
-		return nil
-	}
-	tasks := store.View()
-	known := make(map[int]struct{}, len(tasks))
-	for _, t := range tasks {
-		known[t.ID] = struct{}{}
-	}
-	for _, u := range updates {
-		if _, ok := known[u.ID]; !ok {
-			return fmt.Errorf("unknown task ID %d", u.ID)
-		}
-		if u.DependsOn == nil {
-			continue
-		}
-		for _, dep := range *u.DependsOn {
-			if _, ok := known[dep]; !ok {
-				return fmt.Errorf("task %d depends on unknown task %d", u.ID, dep)
-			}
-		}
-	}
-	return nil
-}
-
 func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 	// Task management.
 	_ = reg.Register(tool.RegisteredTool{
@@ -376,24 +331,11 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 			}
 
 			return mutateAndPublishTaskStore(store, func(epoch, revision uint64) (any, error) {
-				// Validate update IDs against the PRE-ADD state when this
-				// call also adds: the model composed the call before any new
-				// IDs existed, so an update can never legitimately target or
-				// depend on this call's adds. (Without adds, updateLocked
-				// enforces the same rejections itself.)
-				if len(adds) > 0 {
-					if err := validateUpdateIDs(store, updates); err != nil {
-						return nil, err
-					}
-				}
-				var added []taskpkg.Task
-				if len(adds) > 0 {
-					added, err = store.Append(adds)
+				if len(updates) == 0 {
+					added, err := store.Append(adds)
 					if err != nil {
 						return nil, err
 					}
-				}
-				if len(updates) == 0 {
 					// Adds only: terse acknowledgement. The current task is
 					// announced via a separate SYSTEM-REMINDER steering message
 					// when the agent actually transitions one to in_progress,
@@ -407,7 +349,15 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 						State:  tasks,
 					}, nil
 				}
-				mutation, err := store.UpdateWithSnapshot(updates)
+				var mutation taskpkg.TaskUpdateSnapshot
+				if len(adds) == 0 {
+					// Keep update-only validation order and snapshot behavior exactly
+					// as before; ApplyBatch is needed only where additions and
+					// updates must commit together.
+					mutation, err = store.UpdateWithSnapshot(updates)
+				} else {
+					mutation, err = store.ApplyBatch(adds, updates)
+				}
 				if err != nil {
 					return nil, err
 				}
@@ -415,10 +365,9 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 				// Classify each ID from the final status the store applied, so
 				// duplicate entries cannot steer a task that ended completed or
 				// suppress auto-advance after the final state is known. Note:
-				// mutation.Before is the POST-ADD pre-update state, but every
-				// update target pre-existed the call (validateUpdateIDs), so its
-				// Before status equals its pre-call status — adds never touch
-				// existing tasks' statuses.
+				// mutation.Before is the pre-combined-batch state. ApplyBatch
+				// enforces that every update target pre-existed the call, so its
+				// status is the caller's true pre-call status.
 				previous := make(map[int]taskpkg.TaskStatus, len(mutation.Before))
 				for _, task := range mutation.Before {
 					previous[task.ID] = task.Status
@@ -465,13 +414,13 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 				if !completedAny && manuallyStartedID == 0 {
 					deps.emit(events.EventTaskUpdated, taskUpdatedData(taskpkg.Summarize(mutation.After), "", epoch, revision))
 					return tool.StateResult{
-						Output: formatMutationAck(len(added), updates),
+						Output: formatMutationAck(len(adds), updates),
 						State:  taskToolStateSnapshot(mutation.After, started),
 					}, nil
 				}
 
 				var msg strings.Builder
-				msg.WriteString(formatMutationAck(len(added), updates))
+				msg.WriteString(formatMutationAck(len(adds), updates))
 				msg.WriteString(" ")
 				finalTasks := mutation.After
 

--- a/agent/session_tools_task.go
+++ b/agent/session_tools_task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -244,14 +245,25 @@ func validateTaskListItemFields(kind string, index int, item map[string]any) err
 			allowed[field] = true
 		}
 	}
+	if _, hasBrief := item["brief"]; hasBrief {
+		if kind == "add" {
+			return fmt.Errorf("add entry %d has invalid field %q; use the required field named %q instead; valid add shape: {type, description, prompt}", index, "brief", "description")
+		}
+		return fmt.Errorf("update entry %d has invalid field %q; valid update shape: {id, status, notes, depends_on, reasoning_effort}", index, "brief")
+	}
+	unknown := make([]string, 0, len(item))
 	for field := range item {
-		if allowed[field] {
-			continue
+		if !allowed[field] {
+			unknown = append(unknown, field)
 		}
-		if field == "brief" {
-			return fmt.Errorf("%s entry %d has invalid field brief; use the required field named description instead; valid add shape: {type, description, prompt}", kind, index)
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		quoted := make([]string, len(unknown))
+		for i, field := range unknown {
+			quoted[i] = strconv.Quote(field)
 		}
-		return fmt.Errorf("%s entry %d has unknown field %q", kind, index, field)
+		return fmt.Errorf("%s entry %d has unknown fields %s", kind, index, strings.Join(quoted, ", "))
 	}
 	return nil
 }
@@ -516,7 +528,12 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 // taskStateData is the single conversion from transport-neutral task semantics
 // to event task state, shared by start seeds and mutation carriers.
 func taskStateData(summary taskpkg.ListSummary) events.TaskStateData {
-	data := events.TaskStateData{Total: summary.Total, Done: summary.Done}
+	data := events.TaskStateData{
+		Total:     summary.Total,
+		Done:      summary.Done,
+		Cancelled: summary.Cancelled,
+		Remaining: summary.Remaining,
+	}
 	if summary.Current != nil {
 		data.Current = &events.TaskSummaryData{
 			ID:          summary.Current.ID,
@@ -531,6 +548,8 @@ func taskUpdatedData(summary taskpkg.ListSummary, taskStoreOwnerSessionID string
 	return events.TaskUpdatedData{
 		Total:                   state.Total,
 		Done:                    state.Done,
+		Cancelled:               state.Cancelled,
+		Remaining:               state.Remaining,
 		Current:                 state.Current,
 		TaskStoreOwnerSessionID: taskStoreOwnerSessionID,
 		TaskPublicationEpoch:    publicationEpoch,

--- a/agent/session_tools_task.go
+++ b/agent/session_tools_task.go
@@ -398,10 +398,11 @@ func registerTaskTools(reg *tool.Registry, deps *toolDeps) {
 					// when the agent actually transitions one to in_progress,
 					// either manually or via auto-advance.
 					tasks := store.View()
-					taskUpdate := taskUpdatedData(taskpkg.Summarize(tasks), "", epoch, revision)
+					summary := taskpkg.Summarize(tasks)
+					taskUpdate := taskUpdatedData(summary, "", epoch, revision)
 					deps.emit(events.EventTaskUpdated, taskUpdate)
 					return tool.StateResult{
-						Output: fmt.Sprintf("Added %d task(s). Progress: %s.", len(added), taskpkg.Summarize(tasks).ProgressText()),
+						Output: fmt.Sprintf("Added %d task(s). Progress: %s.", len(added), summary.ProgressText()),
 						State:  tasks,
 					}, nil
 				}

--- a/agent/session_tools_task_test.go
+++ b/agent/session_tools_task_test.go
@@ -425,6 +425,82 @@ func TestTaskTool_NotesOnlyUpdateWorks(t *testing.T) {
 	}
 }
 
+func TestTaskTool_RejectsUnknownNestedFieldsAtomically(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+		want []string
+	}{
+		{
+			name: "add brief instead of description",
+			args: map[string]any{"add": []any{map[string]any{
+				"type": "implement", "brief": "wrong field", "prompt": "do it",
+			}}},
+			want: []string{"brief", "description", "type", "prompt"},
+		},
+		{
+			name: "add missing description",
+			args: map[string]any{"add": []any{map[string]any{
+				"type": "implement", "prompt": "do it",
+			}}},
+			want: []string{"description", "type", "prompt"},
+		},
+		{
+			name: "add unknown field alongside valid mutation",
+			args: map[string]any{"add": []any{
+				map[string]any{"type": "implement", "description": "valid", "prompt": "do it"},
+				map[string]any{"type": "verify", "description": "invalid", "prompt": "check it", "unknown": true},
+			}},
+			want: []string{"unknown"},
+		},
+		{
+			name: "malformed update alongside valid mutation",
+			args: map[string]any{"update": []any{
+				map[string]any{"id": 1, "status": "done"},
+				map[string]any{"id": 1, "brief": "invalid"},
+			}},
+			want: []string{"brief", "description"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "existing", Prompt: "keep me"}})
+			res := h.call(t, tc.args)
+			if !res.IsError {
+				t.Fatalf("nested unknown field must be rejected: %s", res.FullOutput)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(res.FullOutput, want) {
+					t.Errorf("diagnostic = %q, want %q", res.FullOutput, want)
+				}
+			}
+			view := h.store.View()
+			if len(view) != 1 || view[0].Status != taskpkg.TaskOpen || view[0].Description != "existing" {
+				t.Fatalf("invalid batch mutated tasks: %+v", view)
+			}
+		})
+	}
+}
+
+func TestTaskTool_CancelledTerminalListUsesOutcomeSummary(t *testing.T) {
+	h := newTaskToolHarness(t, []taskpkg.TaskInput{{Description: "stop", Prompt: "stop"}})
+	res := h.update(t, map[string]any{"id": 1, "status": "cancelled"})
+	if res.IsError {
+		t.Fatalf("cancel task: %s", res.FullOutput)
+	}
+	for _, want := range []string{
+		"No actionable tasks remain.",
+		"0 done, 1 cancelled, 0 remaining (1 total)",
+	} {
+		if !strings.Contains(res.FullOutput, want) {
+			t.Errorf("terminal response = %q, want %q", res.FullOutput, want)
+		}
+	}
+	if strings.Contains(res.FullOutput, "All tasks complete") {
+		t.Fatalf("cancelled terminal response must not say all tasks complete: %q", res.FullOutput)
+	}
+}
+
 // TestTaskTool_UpdateDependsOnSameCallAddRejected: an update's depends_on
 // may not reference an ID this call's add would assign — the model cannot
 // know it, and allowing it invites ID-guessing (the same reason update

--- a/agent/session_tools_task_test.go
+++ b/agent/session_tools_task_test.go
@@ -459,7 +459,14 @@ func TestTaskTool_RejectsUnknownNestedFieldsAtomically(t *testing.T) {
 				map[string]any{"id": 1, "status": "done"},
 				map[string]any{"id": 1, "brief": "invalid"},
 			}},
-			want: []string{"brief", "description"},
+			want: []string{"brief", "id", "status", "notes"},
+		},
+		{
+			name: "unknown fields report in sorted order",
+			args: map[string]any{"update": []any{
+				map[string]any{"id": 1, "zeta": true, "alpha": true},
+			}},
+			want: []string{`unknown fields "alpha", "zeta"`},
 		},
 	}
 	for _, tc := range tests {
@@ -479,6 +486,22 @@ func TestTaskTool_RejectsUnknownNestedFieldsAtomically(t *testing.T) {
 				t.Fatalf("invalid batch mutated tasks: %+v", view)
 			}
 		})
+	}
+}
+
+func TestTaskStateDataCarriesDistinctOutcomes(t *testing.T) {
+	summary := taskpkg.Summarize([]taskpkg.Task{
+		{Status: taskpkg.TaskDone},
+		{Status: taskpkg.TaskCancelled},
+		{Status: taskpkg.TaskOpen},
+	})
+	state := taskStateData(summary)
+	if state.Total != 3 || state.Done != 1 || state.Cancelled != 1 || state.Remaining != 1 {
+		t.Fatalf("taskStateData() = %+v, want total=3 done=1 cancelled=1 remaining=1", state)
+	}
+	updated := taskUpdatedData(summary, "owner", 7, 9)
+	if updated.Total != 3 || updated.Done != 1 || updated.Cancelled != 1 || updated.Remaining != 1 {
+		t.Fatalf("taskUpdatedData() = %+v, want total=3 done=1 cancelled=1 remaining=1", updated)
 	}
 }
 

--- a/agent/task/store_crud_fuzz_test.go
+++ b/agent/task/store_crud_fuzz_test.go
@@ -207,6 +207,7 @@ func checkTaskInvariants(t *testing.T, s *TaskStore) {
 	status := make(map[int]TaskStatus, len(view))
 	inProgress := 0
 	doneCount := 0
+	cancelledCount := 0
 	for _, tk := range view {
 		if ids[tk.ID] {
 			t.Fatalf("duplicate task ID %d", tk.ID)
@@ -221,6 +222,8 @@ func checkTaskInvariants(t *testing.T, s *TaskStore) {
 			inProgress++
 		case TaskDone:
 			doneCount++
+		case TaskCancelled:
+			cancelledCount++
 		}
 	}
 	if inProgress > 1 {
@@ -241,13 +244,19 @@ func checkTaskInvariants(t *testing.T, s *TaskStore) {
 		t.Fatalf("committed dependency graph contains a cycle")
 	}
 
-	// Progress mirrors the view.
-	total, done := s.Progress()
+	// Progress mirrors the view's distinct outcomes.
+	total, done, cancelled, remaining := s.Progress()
 	if total != len(view) {
 		t.Fatalf("Progress total=%d, want %d", total, len(view))
 	}
 	if done != doneCount {
 		t.Fatalf("Progress done=%d, want %d", done, doneCount)
+	}
+	if cancelled != cancelledCount {
+		t.Fatalf("Progress cancelled=%d, want %d", cancelled, cancelledCount)
+	}
+	if remaining != len(view)-doneCount-cancelledCount {
+		t.Fatalf("Progress remaining=%d, want %d", remaining, len(view)-doneCount-cancelledCount)
 	}
 
 	// NextEligible: open tasks with satisfied deps, strictly ID-sorted.

--- a/agent/task/store_crud_fuzz_test.go
+++ b/agent/task/store_crud_fuzz_test.go
@@ -244,19 +244,20 @@ func checkTaskInvariants(t *testing.T, s *TaskStore) {
 		t.Fatalf("committed dependency graph contains a cycle")
 	}
 
-	// Progress mirrors the view's distinct outcomes.
-	total, done, cancelled, remaining := s.Progress()
+	// Progress preserves its legacy fields; Summary mirrors all outcomes.
+	total, done := s.Progress()
 	if total != len(view) {
 		t.Fatalf("Progress total=%d, want %d", total, len(view))
 	}
 	if done != doneCount {
 		t.Fatalf("Progress done=%d, want %d", done, doneCount)
 	}
-	if cancelled != cancelledCount {
-		t.Fatalf("Progress cancelled=%d, want %d", cancelled, cancelledCount)
+	summary := s.Summary()
+	if summary.Cancelled != cancelledCount {
+		t.Fatalf("Summary cancelled=%d, want %d", summary.Cancelled, cancelledCount)
 	}
-	if remaining != len(view)-doneCount-cancelledCount {
-		t.Fatalf("Progress remaining=%d, want %d", remaining, len(view)-doneCount-cancelledCount)
+	if summary.Remaining != len(view)-doneCount-cancelledCount {
+		t.Fatalf("Summary remaining=%d, want %d", summary.Remaining, len(view)-doneCount-cancelledCount)
 	}
 
 	// NextEligible: open tasks with satisfied deps, strictly ID-sorted.

--- a/agent/task/store_fault_program_fuzz_test.go
+++ b/agent/task/store_fault_program_fuzz_test.go
@@ -121,8 +121,8 @@ func taskFaultLifecycleMatrix(t *testing.T, input TaskInput) {
 	if err := s.Update([]TaskUpdate{{ID: added[1].ID, Status: TaskCancelled}}); err != nil {
 		t.Fatalf("Update cancelled task: %v", err)
 	}
-	if total, done := s.Progress(); total != 4 || done != 1 {
-		t.Fatalf("Progress = (%d, %d), want (4, 1)", total, done)
+	if total, done, cancelled, remaining := s.Progress(); total != 4 || done != 1 || cancelled != 1 || remaining != 2 {
+		t.Fatalf("Progress = (%d, %d, %d, %d), want (4, 1, 1, 2)", total, done, cancelled, remaining)
 	}
 	eligible := s.NextEligible()
 	if len(eligible) != 2 || eligible[0].ID != added[2].ID || eligible[1].ID != dependent[0].ID {

--- a/agent/task/store_fault_program_fuzz_test.go
+++ b/agent/task/store_fault_program_fuzz_test.go
@@ -121,8 +121,11 @@ func taskFaultLifecycleMatrix(t *testing.T, input TaskInput) {
 	if err := s.Update([]TaskUpdate{{ID: added[1].ID, Status: TaskCancelled}}); err != nil {
 		t.Fatalf("Update cancelled task: %v", err)
 	}
-	if total, done, cancelled, remaining := s.Progress(); total != 4 || done != 1 || cancelled != 1 || remaining != 2 {
-		t.Fatalf("Progress = (%d, %d, %d, %d), want (4, 1, 1, 2)", total, done, cancelled, remaining)
+	if total, done := s.Progress(); total != 4 || done != 1 {
+		t.Fatalf("Progress = (%d, %d), want (4, 1)", total, done)
+	}
+	if summary := s.Summary(); summary.Cancelled != 1 || summary.Remaining != 2 {
+		t.Fatalf("Summary = %+v, want cancelled=1 remaining=2", summary)
 	}
 	eligible := s.NextEligible()
 	if len(eligible) != 2 || eligible[0].ID != added[2].ID || eligible[1].ID != dependent[0].ID {

--- a/agent/task/task_store.go
+++ b/agent/task/task_store.go
@@ -115,27 +115,50 @@ type TaskUpdateSnapshot struct {
 	After  []Task
 }
 
-// ListSummary is the transport-neutral progress and current-work view of a task
-// list. Current is an owned copy and may be mutated independently of the input.
+// ListSummary is the transport-neutral outcome and current-work view of a task
+// list. Done and Cancelled are distinct terminal outcomes; Remaining includes
+// open and in-progress tasks. Current is an owned copy and may be mutated
+// independently of the input.
 type ListSummary struct {
-	Total   int
-	Done    int
-	Current *Task
+	Total     int
+	Done      int
+	Cancelled int
+	Remaining int
+	Current   *Task
 }
 
-// Summarize derives progress and the first in-progress task from one list
-// snapshot. Only done tasks count as complete.
+// ProgressText is the shared human-readable outcome contract for task clients.
+func (s ListSummary) ProgressText() string {
+	return fmt.Sprintf("%d done, %d cancelled, %d remaining (%d total)", s.Done, s.Cancelled, s.Remaining, s.Total)
+}
+
+// AllDone reports whether every non-empty task list member finished normally.
+func (s ListSummary) AllDone() bool {
+	return s.Total > 0 && s.Done == s.Total
+}
+
+// NoActionableTasks reports whether every task has a terminal outcome.
+func (s ListSummary) NoActionableTasks() bool {
+	return s.Remaining == 0
+}
+
+// Summarize derives distinct task outcomes and the first in-progress task from
+// one list snapshot.
 func Summarize(tasks []Task) ListSummary {
 	summary := ListSummary{Total: len(tasks)}
 	for i := range tasks {
-		if tasks[i].Status == TaskDone {
+		switch tasks[i].Status {
+		case TaskDone:
 			summary.Done++
+		case TaskCancelled:
+			summary.Cancelled++
 		}
 		if summary.Current == nil && tasks[i].Status == TaskInProgress {
 			current := cloneTasks(tasks[i : i+1])[0]
 			summary.Current = &current
 		}
 	}
+	summary.Remaining = summary.Total - summary.Done - summary.Cancelled
 	return summary
 }
 
@@ -453,14 +476,14 @@ func (s *TaskStore) Append(items []TaskInput) ([]Task, error) {
 	return added, nil
 }
 
-// Progress returns (total tasks, completed tasks). Only tasks with
-// status "done" count as completed. Cancelled tasks are not complete.
-func (s *TaskStore) Progress() (total, done int) {
+// Progress returns total, done, cancelled, and remaining task counts from one
+// locked snapshot. Done and cancelled remain distinct terminal outcomes.
+func (s *TaskStore) Progress() (total, done, cancelled, remaining int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	summary := Summarize(s.tasks)
-	return summary.Total, summary.Done
+	return summary.Total, summary.Done, summary.Cancelled, summary.Remaining
 }
 
 // NextEligible returns open tasks whose dependencies are all satisfied

--- a/agent/task/task_store.go
+++ b/agent/task/task_store.go
@@ -312,12 +312,19 @@ func (s *TaskStore) Load() error {
 
 // save writes the task list to disk atomically.
 func (s *TaskStore) save() error {
+	return s.saveTasks(s.tasks)
+}
+
+// saveTasks writes a supplied task snapshot atomically without changing the
+// in-memory store. It lets a combined mutation persist its fully validated
+// staged state before committing that state under the data lock.
+func (s *TaskStore) saveTasks(tasks []Task) error {
 	dir := filepath.Dir(s.path)
 	if err := s.fs.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create tasks dir: %w", err)
 	}
 
-	data, err := json.MarshalIndent(s.tasks, "", "  ")
+	data, err := json.MarshalIndent(tasks, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal tasks: %w", err)
 	}
@@ -423,7 +430,18 @@ func hasCycle(adj map[int][]int) bool {
 func (s *TaskStore) Append(items []TaskInput) ([]Task, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	added, err := s.appendLocked(items)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.save(); err != nil {
+		return added, fmt.Errorf("save: %w", err)
+	}
+	return added, nil
+}
 
+// appendLocked adds tasks to s.tasks but does not save. Callers must hold s.mu.
+func (s *TaskStore) appendLocked(items []TaskInput) ([]Task, error) {
 	savedNextID := s.nextID
 
 	// Build all tasks first without committing to s.tasks.
@@ -469,10 +487,6 @@ func (s *TaskStore) Append(items []TaskInput) ([]Task, error) {
 	}
 
 	s.tasks = append(s.tasks, added...)
-
-	if err := s.save(); err != nil {
-		return added, fmt.Errorf("save: %w", err)
-	}
 	return added, nil
 }
 
@@ -613,6 +627,9 @@ func (s *TaskStore) UpdateWithSnapshot(updates []TaskUpdate) (TaskUpdateSnapshot
 	if err := s.updateLocked(updates); err != nil {
 		return TaskUpdateSnapshot{}, err
 	}
+	if err := s.save(); err != nil {
+		return TaskUpdateSnapshot{}, fmt.Errorf("save: %w", err)
+	}
 	return TaskUpdateSnapshot{
 		Before: before,
 		After:  cloneTasks(s.tasks),
@@ -744,5 +761,63 @@ func (s *TaskStore) updateLocked(updates []TaskUpdate) error {
 		}
 	}
 
-	return s.save()
+	return nil
+}
+
+// ApplyBatch atomically applies additions and updates as one task-list
+// mutation. Updates are validated against the pre-add task set, so callers
+// cannot target or depend on a same-call addition they could not have known.
+// All validation and timestamped work happens on a staged store; exactly one
+// durable save succeeds before the staged state replaces the in-memory state.
+func (s *TaskStore) ApplyBatch(adds []TaskInput, updates []TaskUpdate) (TaskUpdateSnapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.validateUpdateIDsLocked(updates); err != nil {
+		return TaskUpdateSnapshot{}, err
+	}
+	before := cloneTasks(s.tasks)
+	staged := TaskStore{
+		tasks:  cloneTasks(s.tasks),
+		nextID: s.nextID,
+		now:    s.now,
+		fs:     s.fs,
+		path:   s.path,
+	}
+	if _, err := staged.appendLocked(adds); err != nil {
+		return TaskUpdateSnapshot{}, err
+	}
+	if err := staged.updateLocked(updates); err != nil {
+		return TaskUpdateSnapshot{}, err
+	}
+	if err := s.saveTasks(staged.tasks); err != nil {
+		return TaskUpdateSnapshot{}, fmt.Errorf("save: %w", err)
+	}
+	s.tasks = staged.tasks
+	s.nextID = staged.nextID
+	return TaskUpdateSnapshot{Before: before, After: cloneTasks(s.tasks)}, nil
+}
+
+// validateUpdateIDsLocked enforces the task_list contract that updates in a
+// combined add+update call may only refer to tasks present before the call.
+// Callers must hold s.mu.
+func (s *TaskStore) validateUpdateIDsLocked(updates []TaskUpdate) error {
+	known := make(map[int]struct{}, len(s.tasks))
+	for _, task := range s.tasks {
+		known[task.ID] = struct{}{}
+	}
+	for _, update := range updates {
+		if _, ok := known[update.ID]; !ok {
+			return fmt.Errorf("unknown task ID %d", update.ID)
+		}
+		if update.DependsOn == nil {
+			continue
+		}
+		for _, depID := range *update.DependsOn {
+			if _, ok := known[depID]; !ok {
+				return fmt.Errorf("task %d depends on unknown task %d", update.ID, depID)
+			}
+		}
+	}
+	return nil
 }

--- a/agent/task/task_store.go
+++ b/agent/task/task_store.go
@@ -476,14 +476,21 @@ func (s *TaskStore) Append(items []TaskInput) ([]Task, error) {
 	return added, nil
 }
 
-// Progress returns total, done, cancelled, and remaining task counts from one
-// locked snapshot. Done and cancelled remain distinct terminal outcomes.
-func (s *TaskStore) Progress() (total, done, cancelled, remaining int) {
+// Summary returns a rich outcome snapshot from one locked task-store view.
+func (s *TaskStore) Summary() ListSummary {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return Summarize(s.tasks)
+}
 
+// Progress returns (total tasks, completed tasks) for compatibility with its
+// original public contract. Call Summary for distinct cancelled and remaining
+// counts.
+func (s *TaskStore) Progress() (total, done int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	summary := Summarize(s.tasks)
-	return summary.Total, summary.Done, summary.Cancelled, summary.Remaining
+	return summary.Total, summary.Done
 }
 
 // NextEligible returns open tasks whose dependencies are all satisfied

--- a/agent/task/task_store_test.go
+++ b/agent/task/task_store_test.go
@@ -448,18 +448,18 @@ func TestSummarizeReturnsOwnedCurrentTask(t *testing.T) {
 	}
 }
 
-func TestTaskStore_ProgressReturnsDistinctOutcomeCounts(t *testing.T) {
+func TestTaskStore_ProgressPreservesLegacyCountsAndSummaryAddsOutcomes(t *testing.T) {
 	s := newTestStore(t)
 	added, _ := s.Append([]TaskInput{{Description: "a"}, {Description: "b"}, {Description: "c"}})
 	_ = s.Update([]TaskUpdate{{ID: added[0].ID, Status: TaskDone}})
 	_ = s.Update([]TaskUpdate{{ID: added[1].ID, Status: TaskCancelled}})
-	total, done, cancelled, remaining := s.Progress()
-	if total != 3 || done != 1 || cancelled != 1 || remaining != 1 {
-		t.Errorf("Progress = (%d,%d,%d,%d), want (3,1,1,1)", total, done, cancelled, remaining)
+	total, done := s.Progress()
+	if total != 3 || done != 1 {
+		t.Errorf("Progress = (%d,%d), want (3,1)", total, done)
 	}
-	summary := Summarize(s.View())
-	if total != summary.Total || done != summary.Done || cancelled != summary.Cancelled || remaining != summary.Remaining {
-		t.Errorf("Progress = (%d,%d,%d,%d), Summarize = (%d,%d,%d,%d)", total, done, cancelled, remaining, summary.Total, summary.Done, summary.Cancelled, summary.Remaining)
+	summary := s.Summary()
+	if total != summary.Total || done != summary.Done || summary.Cancelled != 1 || summary.Remaining != 1 {
+		t.Errorf("Progress = (%d,%d), Summary = (%d,%d,%d,%d)", total, done, summary.Total, summary.Done, summary.Cancelled, summary.Remaining)
 	}
 }
 

--- a/agent/task/task_store_test.go
+++ b/agent/task/task_store_test.go
@@ -382,7 +382,7 @@ func TestUpdate_DoubleInProgress_DoesNotBlameATaskTheBatchResolves(t *testing.T)
 	}
 }
 
-func TestSummarizeCountsDoneAndSelectsFirstInProgress(t *testing.T) {
+func TestSummarizeCountsOutcomesAndSelectsFirstInProgress(t *testing.T) {
 	tasks := []Task{
 		{ID: 1, Status: TaskDone, Description: "done"},
 		{ID: 2, Status: TaskInProgress, Description: "first current"},
@@ -392,11 +392,33 @@ func TestSummarizeCountsDoneAndSelectsFirstInProgress(t *testing.T) {
 	}
 
 	summary := Summarize(tasks)
-	if summary.Total != 5 || summary.Done != 1 {
-		t.Fatalf("Summarize = %+v, want Total=5 Done=1", summary)
+	if summary.Total != 5 || summary.Done != 1 || summary.Cancelled != 1 || summary.Remaining != 3 {
+		t.Fatalf("Summarize = %+v, want Total=5 Done=1 Cancelled=1 Remaining=3", summary)
 	}
 	if summary.Current == nil || summary.Current.ID != 2 || summary.Current.Description != "first current" {
 		t.Fatalf("Summarize Current = %+v, want task 2 first current", summary.Current)
+	}
+}
+
+func TestListSummaryProgressText(t *testing.T) {
+	tests := []struct {
+		name  string
+		tasks []Task
+		want  string
+	}{
+		{name: "empty", want: "0 done, 0 cancelled, 0 remaining (0 total)"},
+		{name: "open", tasks: []Task{{Status: TaskOpen}}, want: "0 done, 0 cancelled, 1 remaining (1 total)"},
+		{name: "in progress", tasks: []Task{{Status: TaskInProgress}}, want: "0 done, 0 cancelled, 1 remaining (1 total)"},
+		{name: "done", tasks: []Task{{Status: TaskDone}}, want: "1 done, 0 cancelled, 0 remaining (1 total)"},
+		{name: "cancelled", tasks: []Task{{Status: TaskCancelled}}, want: "0 done, 1 cancelled, 0 remaining (1 total)"},
+		{name: "mixed", tasks: []Task{{Status: TaskDone}, {Status: TaskCancelled}, {Status: TaskOpen}, {Status: TaskInProgress}}, want: "1 done, 1 cancelled, 2 remaining (4 total)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Summarize(tc.tasks).ProgressText(); got != tc.want {
+				t.Fatalf("ProgressText() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -426,18 +448,18 @@ func TestSummarizeReturnsOwnedCurrentTask(t *testing.T) {
 	}
 }
 
-func TestTaskStore_ProgressCountsOnlyDone(t *testing.T) {
+func TestTaskStore_ProgressReturnsDistinctOutcomeCounts(t *testing.T) {
 	s := newTestStore(t)
 	added, _ := s.Append([]TaskInput{{Description: "a"}, {Description: "b"}, {Description: "c"}})
 	_ = s.Update([]TaskUpdate{{ID: added[0].ID, Status: TaskDone}})
 	_ = s.Update([]TaskUpdate{{ID: added[1].ID, Status: TaskCancelled}})
-	total, done := s.Progress()
-	if total != 3 || done != 1 {
-		t.Errorf("Progress = (%d,%d), want (3,1) — cancelled is not done", total, done)
+	total, done, cancelled, remaining := s.Progress()
+	if total != 3 || done != 1 || cancelled != 1 || remaining != 1 {
+		t.Errorf("Progress = (%d,%d,%d,%d), want (3,1,1,1)", total, done, cancelled, remaining)
 	}
 	summary := Summarize(s.View())
-	if total != summary.Total || done != summary.Done {
-		t.Errorf("Progress = (%d,%d), Summarize = (%d,%d)", total, done, summary.Total, summary.Done)
+	if total != summary.Total || done != summary.Done || cancelled != summary.Cancelled || remaining != summary.Remaining {
+		t.Errorf("Progress = (%d,%d,%d,%d), Summarize = (%d,%d,%d,%d)", total, done, cancelled, remaining, summary.Total, summary.Done, summary.Cancelled, summary.Remaining)
 	}
 }
 

--- a/agent/task_reminders.go
+++ b/agent/task_reminders.go
@@ -107,6 +107,31 @@ func taskReminderAllDoneWhileDelegatesRun(resultTool string, delegateIDs []strin
 	return reminder + "\n" + formatTaskCompletionMachineBlock(taskCompletionSteeringData(delegateIDs))
 }
 
+// taskReminderTerminalWhileDelegatesRun preserves the completed-all-tasks
+// reminder for a fully done list, while accurately describing a list whose
+// terminal state includes cancelled tasks.
+func taskReminderTerminalWhileDelegatesRun(resultTool string, delegateIDs []string, allDone bool) string {
+	if allDone {
+		return taskReminderAllDoneWhileDelegatesRun(resultTool, delegateIDs)
+	}
+	var reminder string
+	if len(delegateIDs) == 0 {
+		reminder = "<SYSTEM-REMINDER>\n" +
+			"No actionable tasks remain on your task list. " +
+			"If you have other work to do, add it to the task list now. " +
+			"Otherwise, deliver your final output with the " + resultTool + " tool.\n" +
+			"</SYSTEM-REMINDER>"
+	} else {
+		reminder = "<SYSTEM-REMINDER>\n" +
+			"No actionable tasks remain on your task list, but delegate(s) " + strings.Join(delegateIDs, ", ") +
+			" are still running. Wait for their result before deciding whether to finish. " +
+			"If you have other work to do, add it to the task list after the delegate result arrives. " +
+			"Otherwise, deliver your final output with the " + resultTool + " tool after that result.\n" +
+			"</SYSTEM-REMINDER>"
+	}
+	return reminder + "\n" + formatTaskCompletionMachineBlock(taskCompletionSteeringData(delegateIDs))
+}
+
 func taskCompletionSteeringData(delegateIDs []string) events.TaskCompletionSteeringData {
 	state := events.TaskCompletionReadyForFinalOutput
 	if len(delegateIDs) != 0 {

--- a/agent/task_store_test.go
+++ b/agent/task_store_test.go
@@ -1332,9 +1332,9 @@ func TestTaskStore_Progress(t *testing.T) {
 	}
 
 	// No tasks done yet.
-	total, done := s.Progress()
-	if total != 3 || done != 0 {
-		t.Fatalf("initial: expected total=3 done=0, got total=%d done=%d", total, done)
+	total, done, cancelled, remaining := s.Progress()
+	if total != 3 || done != 0 || cancelled != 0 || remaining != 3 {
+		t.Fatalf("initial: expected total=3 done=0 cancelled=0 remaining=3, got total=%d done=%d cancelled=%d remaining=%d", total, done, cancelled, remaining)
 	}
 
 	// Mark one done, one cancelled.
@@ -1345,9 +1345,9 @@ func TestTaskStore_Progress(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	total, done = s.Progress()
-	if total != 3 || done != 1 {
-		t.Fatalf("after updates: expected total=3 done=1, got total=%d done=%d", total, done)
+	total, done, cancelled, remaining = s.Progress()
+	if total != 3 || done != 1 || cancelled != 1 || remaining != 1 {
+		t.Fatalf("after updates: expected total=3 done=1 cancelled=1 remaining=1, got total=%d done=%d cancelled=%d remaining=%d", total, done, cancelled, remaining)
 	}
 }
 

--- a/agent/task_store_test.go
+++ b/agent/task_store_test.go
@@ -936,7 +936,7 @@ func TestTaskListTool_AppendViewUpdate(t *testing.T) {
 	if !strings.Contains(appendRes.Output, "Added 2 task(s)") {
 		t.Fatalf("append output missing acknowledgment: %s", appendRes.Output)
 	}
-	if !strings.Contains(appendRes.Output, "Progress: 0/2") {
+	if !strings.Contains(appendRes.Output, "Progress: 0 done, 0 cancelled, 2 remaining (2 total)") {
 		t.Fatalf("append output missing progress: %s", appendRes.Output)
 	}
 
@@ -1332,9 +1332,9 @@ func TestTaskStore_Progress(t *testing.T) {
 	}
 
 	// No tasks done yet.
-	total, done, cancelled, remaining := s.Progress()
-	if total != 3 || done != 0 || cancelled != 0 || remaining != 3 {
-		t.Fatalf("initial: expected total=3 done=0 cancelled=0 remaining=3, got total=%d done=%d cancelled=%d remaining=%d", total, done, cancelled, remaining)
+	total, done := s.Progress()
+	if total != 3 || done != 0 {
+		t.Fatalf("initial: expected total=3 done=0, got total=%d done=%d", total, done)
 	}
 
 	// Mark one done, one cancelled.
@@ -1345,9 +1345,13 @@ func TestTaskStore_Progress(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	total, done, cancelled, remaining = s.Progress()
-	if total != 3 || done != 1 || cancelled != 1 || remaining != 1 {
-		t.Fatalf("after updates: expected total=3 done=1 cancelled=1 remaining=1, got total=%d done=%d cancelled=%d remaining=%d", total, done, cancelled, remaining)
+	total, done = s.Progress()
+	if total != 3 || done != 1 {
+		t.Fatalf("after updates: expected total=3 done=1, got total=%d done=%d", total, done)
+	}
+	summary := s.Summary()
+	if summary.Cancelled != 1 || summary.Remaining != 1 {
+		t.Fatalf("after updates: Summary=%+v, want cancelled=1 remaining=1", summary)
 	}
 }
 

--- a/agent/task_store_test.go
+++ b/agent/task_store_test.go
@@ -1493,6 +1493,18 @@ func TestTaskListTool_UpdateAutoAdvanceFiresSteeringNotOutput(t *testing.T) {
 	if !strings.Contains(updateRes.Output, "Progress") {
 		t.Fatalf("tool response should include Progress: %s", updateRes.Output)
 	}
+	var updateState []taskToolState
+	if err := json.Unmarshal(updateRes.ToolState, &updateState); err != nil {
+		t.Fatalf("decode update ToolState: %v; raw=%s", err, updateRes.ToolState)
+	}
+	for _, state := range updateState {
+		if state.ID == 2 {
+			if state.Started == nil || !*state.Started {
+				t.Fatalf("auto-advanced task ToolState marker = %v, want true", state.Started)
+			}
+			break
+		}
+	}
 
 	// Steering queue should carry the current-task SYSTEM-REMINDER for task 2.
 	sess.mu.Lock()
@@ -1513,6 +1525,58 @@ func TestTaskListTool_UpdateAutoAdvanceFiresSteeringNotOutput(t *testing.T) {
 	if !strings.Contains(queue[0], "Task B") {
 		t.Fatalf("auto-advance steering should include task B title: %s", queue[0])
 	}
+}
+
+func TestTaskListTool_UpdateNonCurrentLeavesExistingCurrentMarkerFalse(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	c := llm.NewClient()
+	c.Register(&fakeAdapter{name: "openai"})
+	sess, err := NewSession(c, NewOpenAIProfile("test"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+
+	ctx := context.Background()
+	env := sess.env
+	sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
+		ID:   "add",
+		Name: "task_list",
+		Arguments: json.RawMessage(`{"add":[
+			{"type":"implement","description":"first","prompt":"first"},
+			{"type":"implement","description":"current","prompt":"current"},
+			{"type":"implement","description":"non-current","prompt":"non-current"}
+		]}`),
+	})
+	// Completing task 1 auto-advances task 2, making it the existing current
+	// task before this call completes the unrelated task 3.
+	sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
+		ID:        "advance",
+		Name:      "task_list",
+		Arguments: json.RawMessage(`{"update":[{"id":1,"status":"done"}]}`),
+	})
+	res := sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
+		ID:        "complete-non-current",
+		Name:      "task_list",
+		Arguments: json.RawMessage(`{"update":[{"id":3,"status":"done"}]}`),
+	})
+	if res.IsError {
+		t.Fatalf("complete non-current: %s", res.Output)
+	}
+	var state []taskToolState
+	if err := json.Unmarshal(res.ToolState, &state); err != nil {
+		t.Fatalf("decode ToolState: %v; raw=%s", err, res.ToolState)
+	}
+	for _, task := range state {
+		if task.ID == 2 {
+			if task.Started == nil || *task.Started {
+				t.Fatalf("existing current ToolState marker = %v, want false", task.Started)
+			}
+			return
+		}
+	}
+	t.Fatal("ToolState missing existing current task")
 }
 
 func TestTaskListTool_ManualInProgressFiresSteering(t *testing.T) {
@@ -1554,6 +1618,23 @@ func TestTaskListTool_ManualInProgressFiresSteering(t *testing.T) {
 	if updateRes.IsError {
 		t.Fatalf("update error: %s", updateRes.Output)
 	}
+	assertStartedMarker := func(toolState []byte, want bool) {
+		t.Helper()
+		var state []taskToolState
+		if err := json.Unmarshal(toolState, &state); err != nil {
+			t.Fatalf("decode ToolState: %v; raw=%s", err, toolState)
+		}
+		for _, task := range state {
+			if task.ID == 2 {
+				if task.Started == nil || *task.Started != want {
+					t.Fatalf("task 2 ToolState marker = %v, want %t", task.Started, want)
+				}
+				return
+			}
+		}
+		t.Fatal("ToolState missing task 2")
+	}
+	assertStartedMarker(updateRes.ToolState, true)
 
 	// Tool response stays minimal.
 	if strings.Contains(updateRes.Output, "Task B") {
@@ -1576,6 +1657,17 @@ func TestTaskListTool_ManualInProgressFiresSteering(t *testing.T) {
 	if !strings.Contains(queue[0], `<CURRENT-TASK id="2">`) {
 		t.Fatalf("manual in_progress steering should target task 2: %s", queue[0])
 	}
+
+	// Reasserting the current status is not another transition.
+	reassertRes := sess.reg.ExecuteCall(ctx, env, llm.ToolCallData{
+		ID:        "c3",
+		Name:      "task_list",
+		Arguments: json.RawMessage(`{"update":[{"id": 2, "status": "in_progress", "notes": "still working"}]}`),
+	})
+	if reassertRes.IsError {
+		t.Fatalf("reassert error: %s", reassertRes.Output)
+	}
+	assertStartedMarker(reassertRes.ToolState, false)
 }
 
 func TestTaskListTool_UpdateRejectsMultipleInProgress(t *testing.T) {

--- a/agent/task_workflow_test.go
+++ b/agent/task_workflow_test.go
@@ -22,7 +22,7 @@ func TestFormatTaskList(t *testing.T) {
 	if strings.Contains(out, "{") || strings.Contains(out, `"id"`) || strings.Contains(out, `"status"`) {
 		t.Fatalf("task list must be plain text, not JSON:\n%s", out)
 	}
-	for _, want := range []string{"1.", "Set up parser", "done", "in_progress", "Wire the lexer", "depends on: 1", "effort: high", "deferred until parser lands", "1/3"} {
+	for _, want := range []string{"1.", "Set up parser", "done", "in_progress", "Wire the lexer", "depends on: 1", "effort: high", "deferred until parser lands", "1 done, 0 cancelled, 2 remaining (3 total)"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("task list missing %q:\n%s", want, out)
 		}

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -284,7 +284,7 @@ var Notifications = []NotificationSpec{
 	{NotifyEvenerMarketplaceUpdated, EmptyParams{}, "Broadcast after a marketplace mutation (add/remove/refresh); no payload. Clients refresh the marketplace list."},
 	{NotifyEvenerPluginUpdated, EmptyParams{}, "Broadcast after a plugin mutation (install/upgrade/remove/enable/disable/setAutoUpgrade); no payload. Clients refresh the plugin list."},
 	{NotifyEvenerThreadResync, ThreadResyncParams{}, "Hub-originated hint asking clients to re-read one thread after relay recovery."},
-	{NotifyEvenerTaskUpdated, TaskUpdatedParams{}, "The session's task-list progress (total/done) changed."},
+	{NotifyEvenerTaskUpdated, TaskUpdatedParams{}, "The session's task-list outcome counts (total/done/cancelled/remaining) changed."},
 	{NotifyEvenerGoalUpdated, GoalUpdatedParams{}, "The session's complete structured goal state changed; null clears it."},
 	{NotifyEvenerSandboxEscalationRequested, SandboxEscalationRequested{}, "A harness-raised, human-gated sandbox-exemption approval card (M7); the tool-exec goroutine blocks until answered via evener/sandbox/escalation/resolve."},
 	{NotifyEvenerSandboxEscalationResolved, SandboxEscalationResolved{}, "A previously-raised sandbox escalation left the pending set — resolved, turn-interrupted, or cleared by session close (M7); every OTHER subscribed client clears its now-stale copy of the card."},

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -524,8 +524,8 @@ type TaskSummary struct {
 type TaskAggregate struct {
 	Total     int          `json:"total"`
 	Done      int          `json:"done"`
-	Cancelled int          `json:"cancelled"`
-	Remaining int          `json:"remaining"`
+	Cancelled int          `json:"cancelled,omitempty"`
+	Remaining int          `json:"remaining,omitempty"`
 	Current   *TaskSummary `json:"current,omitempty"`
 }
 
@@ -703,8 +703,8 @@ type TaskUpdatedParams struct {
 	Ref       string       `json:"ref"`
 	Total     int          `json:"total"`
 	Done      int          `json:"done"`
-	Cancelled int          `json:"cancelled"`
-	Remaining int          `json:"remaining"`
+	Cancelled int          `json:"cancelled,omitempty"`
+	Remaining int          `json:"remaining,omitempty"`
 	Current   *TaskSummary `json:"current,omitempty"`
 }
 

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -522,9 +522,11 @@ type TaskSummary struct {
 // snapshot. A nil *TaskAggregate on EvenerThread means the source cannot know
 // the session's task state; a present zero is an authoritative empty list.
 type TaskAggregate struct {
-	Total   int          `json:"total"`
-	Done    int          `json:"done"`
-	Current *TaskSummary `json:"current,omitempty"`
+	Total     int          `json:"total"`
+	Done      int          `json:"done"`
+	Cancelled int          `json:"cancelled"`
+	Remaining int          `json:"remaining"`
+	Current   *TaskSummary `json:"current,omitempty"`
 }
 
 type EvenerThread struct {
@@ -697,11 +699,13 @@ type ThreadQueueChangedParams struct {
 // task-list progress after a change, so a client refreshes the status row
 // event-driven instead of polling evener/tasks/list.
 type TaskUpdatedParams struct {
-	ThreadID string       `json:"threadId"`
-	Ref      string       `json:"ref"`
-	Total    int          `json:"total"`
-	Done     int          `json:"done"`
-	Current  *TaskSummary `json:"current,omitempty"`
+	ThreadID  string       `json:"threadId"`
+	Ref       string       `json:"ref"`
+	Total     int          `json:"total"`
+	Done      int          `json:"done"`
+	Cancelled int          `json:"cancelled"`
+	Remaining int          `json:"remaining"`
+	Current   *TaskSummary `json:"current,omitempty"`
 }
 
 // GoalUpdatedParams is the complete session goal state after a mutation. Goal

--- a/cmd/evener-hub/app_threadread.go
+++ b/cmd/evener-hub/app_threadread.go
@@ -534,7 +534,12 @@ func persistedTaskAggregate(stateDir, sessionID string) *appwire.TaskAggregate {
 		return nil
 	}
 	summary := taskpkg.Summarize(tasks.View())
-	aggregate := &appwire.TaskAggregate{Total: summary.Total, Done: summary.Done}
+	aggregate := &appwire.TaskAggregate{
+		Total:     summary.Total,
+		Done:      summary.Done,
+		Cancelled: summary.Cancelled,
+		Remaining: summary.Remaining,
+	}
 	if summary.Current != nil {
 		aggregate.Current = &appwire.TaskSummary{ID: summary.Current.ID, Description: summary.Current.Description}
 	}

--- a/cmd/evener-hub/app_threadread_tasks_test.go
+++ b/cmd/evener-hub/app_threadread_tasks_test.go
@@ -47,7 +47,7 @@ func TestPastThreadReadProjectsPersistedTaskAggregate(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("pastThreadForRead: thread=%+v found=%v err=%v", thread, ok, err)
 	}
-	want := &appwire.TaskAggregate{Total: 2, Done: 1}
+	want := &appwire.TaskAggregate{Total: 2, Done: 1, Remaining: 1}
 	if thread.Evener.Tasks == nil || *thread.Evener.Tasks != *want {
 		t.Fatalf("persisted task aggregate=%+v, want %+v", thread.Evener.Tasks, want)
 	}

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.test.tsx
@@ -298,6 +298,26 @@ test("status row has no inline Details/Tasks/Activity buttons; they live in the 
   expect(screen.getByRole("menuitem", { name: /Activity/ })).toBeTruthy();
 });
 
+test("SessionChrome shows task outcome aggregates in its actions menu", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  fake.on("thread/read", () =>
+    readResponse("ref_outcomes", {
+      evener: {
+        ref: "ref_outcomes",
+        capabilities: CAPABILITIES,
+        queue: { revision: 0 },
+        tasks: { total: 7, done: 1, cancelled: 5, remaining: 1 },
+      },
+    }),
+  );
+  await threadsStore.getState().ensureThread("ref_outcomes");
+
+  render(<SessionChrome ref="ref_outcomes" />);
+  await user.click(screen.getByRole("button", { name: /session actions/i }));
+  expect(screen.getByRole("menuitem", { name: "Tasks 1 done, 5 cancelled, 1 remaining (7 total)" })).toBeTruthy();
+});
+
 test("desktop Session actions opens the full Verbosity Dialog, persists selection, and restores trigger focus", async () => {
   const user = userEvent.setup();
   const fake = connectFakeClient();

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.test.tsx
@@ -318,6 +318,26 @@ test("SessionChrome shows task outcome aggregates in its actions menu", async ()
   expect(screen.getByRole("menuitem", { name: "Tasks 1 done, 5 cancelled, 1 remaining (7 total)" })).toBeTruthy();
 });
 
+test("SessionChrome infers a missing zero outcome in its task label", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  fake.on("thread/read", () =>
+    readResponse("ref_remaining", {
+      evener: {
+        ref: "ref_remaining",
+        capabilities: CAPABILITIES,
+        queue: { revision: 0 },
+        tasks: { total: 7, done: 1, remaining: 5 },
+      },
+    }),
+  );
+  await threadsStore.getState().ensureThread("ref_remaining");
+
+  render(<SessionChrome ref="ref_remaining" />);
+  await user.click(screen.getByRole("button", { name: /session actions/i }));
+  expect(screen.getByRole("menuitem", { name: "Tasks 1 done, 0 cancelled, 5 remaining (7 total)" })).toBeTruthy();
+});
+
 test("desktop Session actions opens the full Verbosity Dialog, persists selection, and restores trigger focus", async () => {
   const user = userEvent.setup();
   const fake = connectFakeClient();

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.tsx
@@ -47,7 +47,7 @@ import { DetailsPanel, type DetailsPanelHandle } from "./DetailsPanel";
 import { GoalControl } from "./GoalControl";
 import { StatusRow } from "./StatusRow";
 import styles from "./sessionchrome.module.css";
-import { TasksPanel, type TasksPanelHandle } from "./TasksPanel";
+import { TasksPanel, type TasksPanelHandle, taskAggregateLabel } from "./TasksPanel";
 import "../../sessionPanels";
 
 export type SessionChromePlacement = "footer" | "composer";
@@ -190,7 +190,7 @@ export function SessionChrome({ ref: sessionRef, placement = "footer", onOpenTas
             canShutdown={model.capabilities.shutdown}
             session={menuSession}
             panesOpen={{ details: detailsOpen, tasks: tasksOpen, activity: activityOpen }}
-            taskLabel={model.tasks ? `Tasks ${model.tasks.done}/${model.tasks.total}` : undefined}
+            taskLabel={model.tasks ? `Tasks ${taskAggregateLabel(model.tasks)}` : undefined}
             activityLabel={activityLabel}
             onOpenVerbosity={() => setVerbosityOpen(true)}
             actions={{

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/TasksPanel.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/TasksPanel.test.tsx
@@ -178,6 +178,28 @@ test("outcome aggregates show terminal progress instead of done/total", async ()
   ).toBe("6");
 });
 
+test("outcome aggregates infer an omitted zero outcome for labels and terminal meters", async () => {
+  const fake = connectFakeClient();
+  fake.on("evener/tasks/list", () => ({ data: [] }));
+  const cancelledOnly = testModel({ tasks: { total: 7, done: 1, cancelled: 5 } });
+  const { unmount } = render(<TasksPanelBody sessionRef="ref_cancelled" model={cancelledOnly} />);
+
+  await waitFor(() => expect(screen.getByTestId("tasks-body-head")).toBeTruthy());
+  const cancelledMeter = screen.getByRole("meter", {
+    name: "Task progress: 1 done, 5 cancelled, 0 remaining (7 total)",
+  });
+  expect(cancelledMeter.getAttribute("aria-valuenow")).toBe("6");
+  unmount();
+
+  const remainingOnly = testModel({ tasks: { total: 7, done: 1, remaining: 5 } });
+  render(<TasksPanelBody sessionRef="ref_remaining" model={remainingOnly} />);
+  await waitFor(() => expect(screen.getByTestId("tasks-body-head")).toBeTruthy());
+  const remainingMeter = screen.getByRole("meter", {
+    name: "Task progress: 1 done, 0 cancelled, 5 remaining (7 total)",
+  });
+  expect(remainingMeter.getAttribute("aria-valuenow")).toBe("1");
+});
+
 // --- STATUS_TONE: pinning test (review finding) --------------------------
 // The mapping shipped entirely untested, which is how `cancelled: "danger"`
 // slipped through: the legacy comment cited for that choice

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/TasksPanel.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/TasksPanel.test.tsx
@@ -156,6 +156,28 @@ test("the trigger shows the done/total counts once the aggregate has arrived", (
   expect(screen.getByRole("button", { name: "Tasks 3/7" })).toBeTruthy();
 });
 
+test("outcome aggregates show terminal progress instead of done/total", async () => {
+  const fake = connectFakeClient();
+  fake.on("evener/tasks/list", () => ({ data: [] }));
+  const model = testModel({ tasks: { total: 7, done: 1, cancelled: 5, remaining: 1 } });
+
+  render(
+    <>
+      <TasksPanel sessionRef="ref_a" model={model} />
+      <TasksPanelBody sessionRef="ref_a" model={model} />
+    </>,
+  );
+
+  expect(screen.getByRole("button", { name: "Tasks 1 done, 5 cancelled, 1 remaining (7 total)" })).toBeTruthy();
+  await waitFor(() => expect(screen.getByTestId("tasks-body-head")).toBeTruthy());
+  expect(screen.getByTestId("tasks-body-head").textContent).toContain("1 done, 5 cancelled, 1 remaining (7 total)");
+  expect(
+    screen
+      .getByRole("meter", { name: "Task progress: 1 done, 5 cancelled, 1 remaining (7 total)" })
+      .getAttribute("aria-valuenow"),
+  ).toBe("6");
+});
+
 // --- STATUS_TONE: pinning test (review finding) --------------------------
 // The mapping shipped entirely untested, which is how `cancelled: "danger"`
 // slipped through: the legacy comment cited for that choice

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/TasksPanel.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/TasksPanel.tsx
@@ -176,8 +176,23 @@ export const STATUS_TONE: Record<TaskStatus, ChipTone> = {
   cancelled: "neutral",
 };
 
+function hasTaskOutcomes(tasks: NonNullable<ThreadModel["tasks"]>): boolean {
+  return tasks.cancelled !== undefined && tasks.remaining !== undefined;
+}
+
+function taskMeterValue(tasks: NonNullable<ThreadModel["tasks"]>): number {
+  return tasks.cancelled !== undefined && tasks.remaining !== undefined ? tasks.done + tasks.cancelled : tasks.done;
+}
+
+export function taskAggregateLabel(tasks: NonNullable<ThreadModel["tasks"]>): string {
+  if (hasTaskOutcomes(tasks)) {
+    return `${tasks.done} done, ${tasks.cancelled} cancelled, ${tasks.remaining} remaining (${tasks.total} total)`;
+  }
+  return `${tasks.done}/${tasks.total}`;
+}
+
 function triggerLabel(tasks: ThreadModel["tasks"]): string {
-  return tasks ? `Tasks ${tasks.done}/${tasks.total}` : "Tasks";
+  return tasks ? `Tasks ${taskAggregateLabel(tasks)}` : "Tasks";
 }
 
 // The one name this panel's failure goes by. Both reports of it - the toast
@@ -570,13 +585,19 @@ export function TasksPanelBody({ sessionRef, model }: TasksPanelBodyProps) {
         {model.tasks && (
           <div className={CLASS.bodyHead} data-testid="tasks-body-head">
             <Meter
-              label={`Task progress: ${model.tasks.done} of ${model.tasks.total} complete`}
-              value={model.tasks.done}
+              label={
+                hasTaskOutcomes(model.tasks)
+                  ? `Task progress: ${taskAggregateLabel(model.tasks)}`
+                  : `Task progress: ${model.tasks.done} of ${model.tasks.total} complete`
+              }
+              value={taskMeterValue(model.tasks)}
               max={model.tasks.total}
               tone="neutral"
             />
             <span className={CLASS.count}>
-              {model.tasks.done}/{model.tasks.total} done
+              {hasTaskOutcomes(model.tasks)
+                ? taskAggregateLabel(model.tasks)
+                : `${model.tasks.done}/${model.tasks.total} done`}
             </span>
           </div>
         )}

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/TasksPanel.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/TasksPanel.tsx
@@ -177,16 +177,16 @@ export const STATUS_TONE: Record<TaskStatus, ChipTone> = {
 };
 
 function hasTaskOutcomes(tasks: NonNullable<ThreadModel["tasks"]>): boolean {
-  return tasks.cancelled !== undefined && tasks.remaining !== undefined;
+  return tasks.cancelled !== undefined || tasks.remaining !== undefined;
 }
 
 function taskMeterValue(tasks: NonNullable<ThreadModel["tasks"]>): number {
-  return tasks.cancelled !== undefined && tasks.remaining !== undefined ? tasks.done + tasks.cancelled : tasks.done;
+  return hasTaskOutcomes(tasks) ? tasks.done + (tasks.cancelled ?? 0) : tasks.done;
 }
 
 export function taskAggregateLabel(tasks: NonNullable<ThreadModel["tasks"]>): string {
   if (hasTaskOutcomes(tasks)) {
-    return `${tasks.done} done, ${tasks.cancelled} cancelled, ${tasks.remaining} remaining (${tasks.total} total)`;
+    return `${tasks.done} done, ${tasks.cancelled ?? 0} cancelled, ${tasks.remaining ?? 0} remaining (${tasks.total} total)`;
   }
   return `${tasks.done}/${tasks.total}`;
 }

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.test.tsx
@@ -181,6 +181,45 @@ test("a notes-only in_progress reassertion does not render a started row", () =>
   expect(screen.queryByTestId("task-card-row")).toBeNull();
 });
 
+test("completing a non-current task does not mistake the existing current task for an auto-start", () => {
+  renderItem(
+    taskItem({ update: [{ id: 3, status: "done" }] }, "Updated 3→done. Progress: 2/3 tasks complete.", {
+      raw: [
+        { id: 1, type: "implement", description: "first", prompt: "", status: "done" },
+        { id: 2, type: "implement", description: "current", prompt: "", status: "in_progress", started: false },
+        { id: 3, type: "implement", description: "non-current", prompt: "", status: "done" },
+      ],
+    }),
+  );
+  const rows = screen.getAllByTestId("task-card-row");
+  expect(rows).toHaveLength(1);
+  expect(rows[0]?.textContent).toContain("non-current");
+});
+
+test("a reasserted current task is touched before its started row is suppressed", () => {
+  renderItem(
+    taskItem(
+      {
+        update: [
+          { id: 3, status: "done" },
+          { id: 2, status: "in_progress", notes: "still working" },
+        ],
+      },
+      "Updated 3→done, 2→in_progress. Progress: 2/3 tasks complete.",
+      {
+        raw: [
+          { id: 1, type: "implement", description: "first", prompt: "", status: "done" },
+          { id: 2, type: "implement", description: "current", prompt: "", status: "in_progress", started: false },
+          { id: 3, type: "implement", description: "non-current", prompt: "", status: "done" },
+        ],
+      },
+    ),
+  );
+  const rows = screen.getAllByTestId("task-card-row");
+  expect(rows).toHaveLength(1);
+  expect(rows[0]?.getAttribute("data-touch")).toBe("done");
+});
+
 test("a real in_progress transition renders a started row from its authoritative marker", () => {
   renderItem(
     taskItem({ action: "update", updates: [{ id: 1, status: "in_progress" }] }, "Updated 1→in_progress.", {
@@ -302,7 +341,7 @@ test("completing a task shows the auto-started row the daemon advanced to (autho
     taskItem(
       { action: "update", updates: [{ id: 4, status: "done" }] },
       "Updated 4→done. Progress: 4/7 tasks complete.",
-      { raw: sevenTaskState() },
+      { raw: sevenTaskState({ 5: { started: true } }) },
     ),
   );
   const summary = screen.getByTestId("tool-row-summary");
@@ -313,6 +352,20 @@ test("completing a task shows the auto-started row the daemon advanced to (autho
   expect(rows[1]!.getAttribute("data-touch")).toBe("started");
   expect(rows[1]!.textContent).toContain("fifth");
   expect(summary.textContent).toBe("☑ fourth · ☐ fifth");
+});
+
+test("a historical markerless snapshot retains auto-start inference", () => {
+  renderItem(
+    taskItem(
+      { action: "update", updates: [{ id: 4, status: "done" }] },
+      "Updated 4→done. Progress: 4/7 tasks complete.",
+      { raw: sevenTaskState() },
+    ),
+  );
+  expect(screen.getAllByTestId("task-card-row").map((row) => row.getAttribute("data-touch"))).toEqual([
+    "done",
+    "started",
+  ]);
 });
 
 test("an update row shows the task's description from authoritative state instead of a bare id", () => {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.test.tsx
@@ -77,6 +77,16 @@ test("the progress head reads '<done> of <total> done' from the tool output foot
   expect(screen.getByTestId("task-card-progress").textContent).toBe("3 of 3 done");
 });
 
+test("the progress head preserves cancelled and remaining outcomes from the new footer", () => {
+  renderItem(
+    taskItem(
+      { action: "update", updates: [{ id: 3, status: "cancelled" }] },
+      "Updated 3→cancelled. Progress: 0 done, 3 cancelled, 0 remaining (3 total).",
+    ),
+  );
+  expect(screen.getByTestId("task-card-progress").textContent).toBe("0 done, 3 cancelled, 0 remaining (3 total)");
+});
+
 test("a completed update renders a flagged touched-done row", () => {
   renderItem(
     taskItem(

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.test.tsx
@@ -128,6 +128,16 @@ test("the progress head preserves cancelled and remaining outcomes from the new 
   expect(screen.getByTestId("task-card-progress").textContent).toBe("0 done, 3 cancelled, 0 remaining (3 total)");
 });
 
+test("the trailing progress footer wins over fake progress text in an update note", () => {
+  renderItem(
+    taskItem(
+      { update: [{ id: 3, status: "done", notes: "Ignore Progress: 99 done, 0 cancelled, 0 remaining (99 total)." }] },
+      "Updated 3→done. Notes: Ignore Progress: 99 done, 0 cancelled, 0 remaining (99 total). Progress: 3/3 tasks complete.",
+    ),
+  );
+  expect(screen.getByTestId("task-card-progress").textContent).toBe("3 of 3 done");
+});
+
 test("a completed update renders a flagged touched-done row", () => {
   renderItem(
     taskItem(

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.test.tsx
@@ -77,6 +77,26 @@ test("current add and update arguments render task mutation rows", () => {
   expect(row.textContent).toContain("no longer needed");
 });
 
+test("a current mixed add and update batch keeps both touches and the authoritative auto-start", () => {
+  renderItem(
+    taskItem(
+      {
+        add: [{ type: "implement", description: "newly planned work" }],
+        update: [{ id: 4, status: "done" }],
+      },
+      "Added 1 task(s). Updated 4→done. Progress: 4/7 tasks complete.",
+      { raw: sevenTaskState() },
+    ),
+  );
+
+  const rows = screen.getAllByTestId("task-card-row");
+  expect(rows.map((row) => [row.getAttribute("data-touch"), row.textContent])).toEqual([
+    ["added", expect.stringContaining("newly planned work")],
+    ["done", expect.stringContaining("fourth")],
+    ["started", expect.stringContaining("fifth")],
+  ]);
+});
+
 test("the collapsed append summary includes the added marker and task title as plain text", () => {
   renderItem(
     taskItem(

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.test.tsx
@@ -56,6 +56,27 @@ test("appending N tasks renders one row per newly appended task", () => {
   expect(screen.getByText("check the thing")).toBeTruthy();
 });
 
+test("current add and update arguments render task mutation rows", () => {
+  const { unmount } = renderItem(
+    taskItem(
+      { add: [{ type: "implement", description: "build the current thing" }] },
+      "Added 1 task(s). Progress: 0/1 tasks complete.",
+    ),
+  );
+  expect(screen.getByTestId("task-card-row").textContent).toContain("build the current thing");
+
+  unmount();
+  renderItem(
+    taskItem(
+      { update: [{ id: 3, status: "cancelled", notes: "no longer needed" }] },
+      "Updated 3→cancelled. Progress: 0 done, 1 cancelled, 0 remaining (1 total).",
+    ),
+  );
+  const row = screen.getByTestId("task-card-row");
+  expect(row.getAttribute("data-touch")).toBe("cancelled");
+  expect(row.textContent).toContain("no longer needed");
+});
+
 test("the collapsed append summary includes the added marker and task title as plain text", () => {
   renderItem(
     taskItem(

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.tsx
@@ -172,13 +172,19 @@ const TOUCH_BY_STATUS: Record<string, TaskTouch> = {
   in_progress: "started",
 };
 
-const PROGRESS_RE = /Progress:\s*(\d+)\s*\/\s*(\d+)\s*tasks complete/;
-const OUTCOME_PROGRESS_RE = /Progress:\s*(\d+)\s+done,\s*(\d+)\s+cancelled,\s*(\d+)\s+remaining\s*\((\d+)\s+total\)/;
+const PROGRESS_RE = /Progress:\s*(\d+)\s*\/\s*(\d+)\s*tasks complete/g;
+const OUTCOME_PROGRESS_RE = /Progress:\s*(\d+)\s+done,\s*(\d+)\s+cancelled,\s*(\d+)\s+remaining\s*\((\d+)\s+total\)/g;
+
+function lastProgressMatch(output: string, pattern: RegExp): RegExpMatchArray | undefined {
+  const matches = [...output.matchAll(pattern)];
+  return matches[matches.length - 1];
+}
 
 function parseProgress(output: string | undefined): Progress | undefined {
   if (!output) return undefined;
-  const outcome = OUTCOME_PROGRESS_RE.exec(output);
-  if (outcome) {
+  const outcome = lastProgressMatch(output, OUTCOME_PROGRESS_RE);
+  const legacy = lastProgressMatch(output, PROGRESS_RE);
+  if (outcome && (!legacy || (outcome.index ?? -1) > (legacy.index ?? -1))) {
     return {
       done: Number(outcome[1]),
       cancelled: Number(outcome[2]),
@@ -186,9 +192,8 @@ function parseProgress(output: string | undefined): Progress | undefined {
       total: Number(outcome[4]),
     };
   }
-  const m = PROGRESS_RE.exec(output);
-  if (!m) return undefined;
-  return { done: Number(m[1]), total: Number(m[2]) };
+  if (!legacy) return undefined;
+  return { done: Number(legacy[1]), total: Number(legacy[2]) };
 }
 
 // isTaskMutation is the non-suppression predicate: a valid append/update with

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.tsx
@@ -99,55 +99,67 @@ function finalUpdates(updates: Record<string, unknown>[]): Record<string, unknow
 function mutationRows(item: ItemModel): TouchedRow[] | undefined {
   const args = parseArgs(item.argumentsJSON);
   const action = str(args, "action") ?? "";
-  if (action === "append" || (action === "" && asObjectArray(args.add).length > 0)) {
-    const tasks = action === "append" ? asObjectArray(args.tasks) : asObjectArray(args.add);
+  if (action === "append") {
+    const tasks = asObjectArray(args.tasks);
     if (tasks.length === 0) return undefined;
-    return tasks.map((task, i) => ({
-      key: `append_${i}`,
-      touch: "added",
-      label: str(task, "description") ?? (action === "append" ? str(task, "prompt") : undefined) ?? "(untitled task)",
-    }));
+    return appendRows(tasks, true);
   }
-  if (action === "update" || action === "") {
-    const updates = finalUpdates(action === "update" ? asObjectArray(args.updates) : asObjectArray(args.update));
-    if (updates.length === 0) return undefined;
-    // Only a real status change earns a row - matching the legacy card, which
-    // flags exactly done/cancelled/in_progress updates (renderer.js:5010) and
-    // renders a note-only or reopened update as no per-row change at all.
-    const state = parseTaskState(item.raw);
-    const rows: TouchedRow[] = [];
-    const touchedIds = new Set<number>();
-    let completedAny = false;
-    for (const [i, update] of updates.entries()) {
-      const status = str(update, "status");
-      const touch = TOUCH_BY_STATUS[status ?? ""];
-      if (!touch) continue;
-      const id = typeof update.id === "number" ? update.id : undefined;
-      const stateTask = id === undefined ? undefined : state?.find((task) => task.id === id);
-      // The Go task tool marks explicit in_progress updates from its pre-state.
-      // A false marker is a status reassertion carrying notes, not a fresh
-      // start. Unmarked historical state keeps the existing argument-only
-      // rendering for transcripts written before this marker existed.
-      if (touch === "started" && stateTask?.started === false) continue;
-      if (id !== undefined) touchedIds.add(id);
-      if (touch === "done" || touch === "cancelled") completedAny = true;
-      rows.push({
-        key: `update_${i}`,
-        touch,
-        label: taskLabel(state, id),
-        note: str(update, "notes") || undefined,
-      });
-    }
-    // The daemon may advance a DIFFERENT task to in_progress as a side
-    // effect of this same call (session_tools_task.go's auto-advance); that
-    // task never appears in the caller's own `updates` above.
-    const started = autoStartedTask(state, touchedIds, completedAny);
-    if (started) {
-      rows.push({ key: `auto_started_${started.id}`, touch: "started", label: taskLabel(state, started.id) });
-    }
-    return rows;
+  if (action === "update") {
+    const updates = finalUpdates(asObjectArray(args.updates));
+    return updates.length > 0 ? updateRows(item, updates) : undefined;
   }
-  return undefined;
+  if (action !== "") return undefined;
+
+  const adds = asObjectArray(args.add);
+  const updates = finalUpdates(asObjectArray(args.update));
+  if (adds.length === 0 && updates.length === 0) return undefined;
+  return [...appendRows(adds, false), ...updateRows(item, updates)];
+}
+
+function appendRows(tasks: Record<string, unknown>[], legacy: boolean): TouchedRow[] {
+  return tasks.map((task, i) => ({
+    key: `append_${i}`,
+    touch: "added",
+    label: str(task, "description") ?? (legacy ? str(task, "prompt") : undefined) ?? "(untitled task)",
+  }));
+}
+
+function updateRows(item: ItemModel, updates: Record<string, unknown>[]): TouchedRow[] {
+  // Only a real status change earns a row - matching the legacy card, which
+  // flags exactly done/cancelled/in_progress updates (renderer.js:5010) and
+  // renders a note-only or reopened update as no per-row change at all.
+  const state = parseTaskState(item.raw);
+  const rows: TouchedRow[] = [];
+  const touchedIds = new Set<number>();
+  let completedAny = false;
+  for (const [i, update] of updates.entries()) {
+    const status = str(update, "status");
+    const touch = TOUCH_BY_STATUS[status ?? ""];
+    if (!touch) continue;
+    const id = typeof update.id === "number" ? update.id : undefined;
+    const stateTask = id === undefined ? undefined : state?.find((task) => task.id === id);
+    // The Go task tool marks explicit in_progress updates from its pre-state.
+    // A false marker is a status reassertion carrying notes, not a fresh
+    // start. Unmarked historical state keeps the existing argument-only
+    // rendering for transcripts written before this marker existed.
+    if (touch === "started" && stateTask?.started === false) continue;
+    if (id !== undefined) touchedIds.add(id);
+    if (touch === "done" || touch === "cancelled") completedAny = true;
+    rows.push({
+      key: `update_${i}`,
+      touch,
+      label: taskLabel(state, id),
+      note: str(update, "notes") || undefined,
+    });
+  }
+  // The daemon may advance a DIFFERENT task to in_progress as a side effect
+  // of this same call (session_tools_task.go's auto-advance); that task never
+  // appears in the caller's own `updates` above.
+  const started = autoStartedTask(state, touchedIds, completedAny);
+  if (started) {
+    rows.push({ key: `auto_started_${started.id}`, touch: "started", label: taskLabel(state, started.id) });
+  }
+  return rows;
 }
 
 // touchKind's status-to-flag mapping for the three statuses the card renders as

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.tsx
@@ -138,12 +138,14 @@ function updateRows(item: ItemModel, updates: Record<string, unknown>[]): Touche
     if (!touch) continue;
     const id = typeof update.id === "number" ? update.id : undefined;
     const stateTask = id === undefined ? undefined : state?.find((task) => task.id === id);
-    // The Go task tool marks explicit in_progress updates from its pre-state.
+    // A suppressed status reassertion still belongs to this call. Record it
+    // before filtering so it cannot be rediscovered as an auto-start below.
+    if (id !== undefined) touchedIds.add(id);
+    // The Go task tool marks every current task from this call's pre-state.
     // A false marker is a status reassertion carrying notes, not a fresh
     // start. Unmarked historical state keeps the existing argument-only
     // rendering for transcripts written before this marker existed.
     if (touch === "started" && stateTask?.started === false) continue;
-    if (id !== undefined) touchedIds.add(id);
     if (touch === "done" || touch === "cancelled") completedAny = true;
     rows.push({
       key: `update_${i}`,

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.tsx
@@ -93,24 +93,23 @@ function finalUpdates(updates: Record<string, unknown>[]): Record<string, unknow
   return [...latestByID.values(), ...unmarked].sort((a, b) => a.index - b.index).map(({ update }) => update);
 }
 
-// A valid mutation is exactly what the legacy validAppend/validUpdate gates
-// accepted (renderer.js:4786-4788): append with a non-empty tasks array, or
-// update with a non-empty updates array. Anything else (view, or a malformed
+// A valid mutation is a current add/update batch or its historical
+// action:append/action:update equivalent. Anything else (view, or a malformed
 // call) is not a card.
 function mutationRows(item: ItemModel): TouchedRow[] | undefined {
   const args = parseArgs(item.argumentsJSON);
   const action = str(args, "action") ?? "";
-  if (action === "append") {
-    const tasks = asObjectArray(args.tasks);
+  if (action === "append" || (action === "" && asObjectArray(args.add).length > 0)) {
+    const tasks = action === "append" ? asObjectArray(args.tasks) : asObjectArray(args.add);
     if (tasks.length === 0) return undefined;
     return tasks.map((task, i) => ({
       key: `append_${i}`,
       touch: "added",
-      label: str(task, "description") ?? str(task, "prompt") ?? "(untitled task)",
+      label: str(task, "description") ?? (action === "append" ? str(task, "prompt") : undefined) ?? "(untitled task)",
     }));
   }
-  if (action === "update") {
-    const updates = finalUpdates(asObjectArray(args.updates));
+  if (action === "update" || action === "") {
+    const updates = finalUpdates(action === "update" ? asObjectArray(args.updates) : asObjectArray(args.update));
     if (updates.length === 0) return undefined;
     // Only a real status change earns a row - matching the legacy card, which
     // flags exactly done/cancelled/in_progress updates (renderer.js:5010) and

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.tsx
@@ -67,6 +67,8 @@ interface TouchedRow {
 interface Progress {
   done: number;
   total: number;
+  cancelled?: number;
+  remaining?: number;
 }
 
 function asObjectArray(value: unknown): Record<string, unknown>[] {
@@ -158,9 +160,19 @@ const TOUCH_BY_STATUS: Record<string, TaskTouch> = {
 };
 
 const PROGRESS_RE = /Progress:\s*(\d+)\s*\/\s*(\d+)\s*tasks complete/;
+const OUTCOME_PROGRESS_RE = /Progress:\s*(\d+)\s+done,\s*(\d+)\s+cancelled,\s*(\d+)\s+remaining\s*\((\d+)\s+total\)/;
 
 function parseProgress(output: string | undefined): Progress | undefined {
   if (!output) return undefined;
+  const outcome = OUTCOME_PROGRESS_RE.exec(output);
+  if (outcome) {
+    return {
+      done: Number(outcome[1]),
+      cancelled: Number(outcome[2]),
+      remaining: Number(outcome[3]),
+      total: Number(outcome[4]),
+    };
+  }
   const m = PROGRESS_RE.exec(output);
   if (!m) return undefined;
   return { done: Number(m[1]), total: Number(m[2]) };
@@ -220,11 +232,17 @@ function TaskCardBody({ item }: ToolRenderProps) {
       {progress && (
         <div className={CLASS.head}>
           <span className={CLASS.progress} data-testid="task-card-progress">
-            {progress.done} of {progress.total} done
+            {progress.cancelled === undefined || progress.remaining === undefined
+              ? `${progress.done} of ${progress.total} done`
+              : `${progress.done} done, ${progress.cancelled} cancelled, ${progress.remaining} remaining (${progress.total} total)`}
           </span>
           <Meter
-            label={`Task progress: ${progress.done} of ${progress.total} complete`}
-            value={progress.done}
+            label={
+              progress.cancelled === undefined || progress.remaining === undefined
+                ? `Task progress: ${progress.done} of ${progress.total} complete`
+                : `Task progress: ${progress.done} done, ${progress.cancelled} cancelled, ${progress.remaining} remaining (${progress.total} total)`
+            }
+            value={progress.done + (progress.cancelled ?? 0)}
             max={progress.total}
             tone="neutral"
           />

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.tsx
@@ -176,7 +176,10 @@ const PROGRESS_RE = /Progress:\s*(\d+)\s*\/\s*(\d+)\s*tasks complete/g;
 const OUTCOME_PROGRESS_RE = /Progress:\s*(\d+)\s+done,\s*(\d+)\s+cancelled,\s*(\d+)\s+remaining\s*\((\d+)\s+total\)/g;
 
 function lastProgressMatch(output: string, pattern: RegExp): RegExpMatchArray | undefined {
-  const matches = [...output.matchAll(pattern)];
+  // matchAll's iterator starts at its pattern's lastIndex. Clone the global
+  // pattern for every parse so a later consumer cannot carry mutable state
+  // into this helper.
+  const matches = [...output.matchAll(new RegExp(pattern.source, pattern.flags))];
   return matches[matches.length - 1];
 }
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskData.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskData.ts
@@ -42,17 +42,21 @@ export function taskLabel(tasks: TaskRow[] | null, id: number | undefined): stri
 // done or cancelled row - completedAny, matching that Go gate's own name)
 // and did not ALSO explicitly start a task itself; either way that decision
 // already happened server-side and rides in the SAME State this call
-// returns, so it's found rather than re-derived here: the one in_progress
-// task the caller's own rows didn't already name. touchedIds is every id
-// the caller's own updates already earned a row for (including an explicit
-// in_progress one), so an explicit start is never double-counted -
-// task_store.go's Update enforces a single in_progress task store-wide, so
-// at most one candidate can ever match.
+// returns, so it's found rather than re-derived here. Current daemon snapshots
+// mark every in-progress row: only a true marker is an auto-start candidate.
+// Historical markerless snapshots retain the legacy fallback of finding the
+// untouched in-progress task. touchedIds is every id the caller's own updates
+// already earned a row for (including an explicit in_progress one), so an
+// explicit start is never double-counted.
 export function autoStartedTask(
   tasks: TaskRow[] | null,
   touchedIds: ReadonlySet<number>,
   completedAny: boolean,
 ): TaskRow | undefined {
   if (!tasks || !completedAny) return undefined;
+  const current = tasks.filter((t) => t.status === "in_progress");
+  if (current.some((t) => t.started !== undefined)) {
+    return current.find((t) => t.started === true && !touchedIds.has(t.id));
+  }
   return tasks.find((t) => t.status === "in_progress" && !touchedIds.has(t.id));
 }

--- a/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
@@ -3052,7 +3052,11 @@ test("hydrateThread preserves task aggregate through notification mutation and r
     },
     2000,
   );
-  expect(model.tasks).toEqual({ total: 7, done: 7, current: { id: 7, description: "replacement task" } });
+  expect(model.tasks).toEqual({
+    total: 7,
+    done: 7,
+    current: { id: 7, description: "replacement task" },
+  });
 
   model = applyNotification(
     model,
@@ -3060,6 +3064,23 @@ test("hydrateThread preserves task aggregate through notification mutation and r
     3000,
   );
   expect(model.tasks).toEqual({ total: 7, done: 7 });
+
+  model = applyNotification(
+    model,
+    {
+      method: "evener/task/updated",
+      params: { threadId: "thr_t", ref: "ref_t", total: 7, done: 1, cancelled: 5, remaining: 1 },
+    },
+    4000,
+  );
+  expect(model.tasks).toEqual({ total: 7, done: 1, cancelled: 5, remaining: 1 });
+
+  model = applyNotification(
+    model,
+    { method: "evener/task/updated", params: { threadId: "thr_t", ref: "ref_t", total: 3, done: 0, cancelled: 3 } },
+    5000,
+  );
+  expect(model.tasks).toEqual({ total: 3, done: 0, cancelled: 3, remaining: 0 });
 
   const rehydrated = testHydrate({
     evener: {

--- a/cmd/evener-hub/frontend/src/protocol/reducer.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.ts
@@ -1127,6 +1127,12 @@ function applyNotificationToThread(model: ThreadModel, n: AnyNotification, now: 
         tasks: {
           total: n.params.total,
           done: n.params.done,
+          ...(n.params.cancelled === undefined ? {} : { cancelled: n.params.cancelled }),
+          ...(n.params.remaining === undefined
+            ? n.params.cancelled === undefined
+              ? {}
+              : { remaining: Math.max(0, n.params.total - n.params.done - n.params.cancelled) }
+            : { remaining: n.params.remaining }),
           ...(n.params.current ? { current: n.params.current } : {}),
         },
         lastFrameAt: now,

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -1478,6 +1478,8 @@ export interface Source {
 export interface TaskAggregate {
   total: number;
   done: number;
+  cancelled: number;
+  remaining: number;
   current?: TaskSummary;
 }
 
@@ -1499,6 +1501,8 @@ export interface TaskUpdatedParams {
   ref: string;
   total: number;
   done: number;
+  cancelled: number;
+  remaining: number;
   current?: TaskSummary;
 }
 

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -1478,8 +1478,8 @@ export interface Source {
 export interface TaskAggregate {
   total: number;
   done: number;
-  cancelled: number;
-  remaining: number;
+  cancelled?: number;
+  remaining?: number;
   current?: TaskSummary;
 }
 
@@ -1501,8 +1501,8 @@ export interface TaskUpdatedParams {
   ref: string;
   total: number;
   done: number;
-  cancelled: number;
-  remaining: number;
+  cancelled?: number;
+  remaining?: number;
   current?: TaskSummary;
 }
 

--- a/cmd/evener-tui/hub_model_test.go
+++ b/cmd/evener-tui/hub_model_test.go
@@ -2728,7 +2728,7 @@ func TestHubModelStatusUsesHubThreadTasksAndAuth(t *testing.T) {
 		"Dir: /tmp/details",
 		"Turns: 2",
 		"Context: 42% used",
-		"Tasks: 1/2 done, 1 active",
+		"Tasks: 1 done, 0 cancelled, 1 remaining (2 total)",
 		"Auth: openai OAuth jesse@example.test",
 		"Recent errors:",
 		"turn_2: provider quota exceeded",

--- a/cmd/evener-tui/hub_status.go
+++ b/cmd/evener-tui/hub_status.go
@@ -273,24 +273,7 @@ func writeWrappedStatusList(b *strings.Builder, label string, items []string, wi
 }
 
 func taskSummary(tasks []taskpkg.Task) string {
-	if len(tasks) == 0 {
-		return "0/0 done"
-	}
-	done := 0
-	active := 0
-	for _, task := range tasks {
-		switch task.Status {
-		case taskpkg.TaskDone, taskpkg.TaskCancelled:
-			done++
-		case taskpkg.TaskInProgress:
-			active++
-		}
-	}
-	summary := fmt.Sprintf("%d/%d done", done, len(tasks))
-	if active > 0 {
-		summary += fmt.Sprintf(", %d active", active)
-	}
-	return summary
+	return taskpkg.Summarize(tasks).ProgressText()
 }
 
 // authSummary is the session-status pane's one-line credential field. It

--- a/cmd/evener-tui/hub_status_test.go
+++ b/cmd/evener-tui/hub_status_test.go
@@ -6,9 +6,23 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+	taskpkg "primeradiant.com/evener/agent/task"
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener-tui/internal/tuitheme"
 )
+
+func TestTaskSummaryUsesSharedOutcomeCounts(t *testing.T) {
+	tasks := []taskpkg.Task{
+		{Status: taskpkg.TaskDone},
+		{Status: taskpkg.TaskCancelled},
+		{Status: taskpkg.TaskOpen},
+		{Status: taskpkg.TaskInProgress},
+	}
+	const want = "1 done, 1 cancelled, 2 remaining (4 total)"
+	if got := taskSummary(tasks); got != want {
+		t.Fatalf("taskSummary() = %q, want %q", got, want)
+	}
+}
 
 // TestRenderHubSessionStatusWithoutDiagnosticsMatchesThinSummary guards the
 // existing contract: when EvenerDiagnostics is nil, the rendered status is

--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -1535,7 +1535,12 @@ func (l liveThreadEnvelopeSource) TaskAggregate() *appwire.TaskAggregate {
 		return nil
 	}
 	summary := taskpkg.Summarize(tasks)
-	aggregate := &appwire.TaskAggregate{Total: summary.Total, Done: summary.Done}
+	aggregate := &appwire.TaskAggregate{
+		Total:     summary.Total,
+		Done:      summary.Done,
+		Cancelled: summary.Cancelled,
+		Remaining: summary.Remaining,
+	}
 	if summary.Current != nil {
 		aggregate.Current = &appwire.TaskSummary{ID: summary.Current.ID, Description: summary.Current.Description}
 	}

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -211,7 +211,7 @@ Pushed to subscribed connections; no `id`. The web client maps these in
 | `evener/marketplace/updated` | `EmptyParams` | Broadcast after a marketplace mutation (add/remove/refresh); no payload. Clients refresh the marketplace list. |
 | `evener/plugin/updated` | `EmptyParams` | Broadcast after a plugin mutation (install/upgrade/remove/enable/disable/setAutoUpgrade); no payload. Clients refresh the plugin list. |
 | `evener/thread/resync` | `ThreadResyncParams` | Hub-originated hint asking clients to re-read one thread after relay recovery. |
-| `evener/task/updated` | `TaskUpdatedParams` | The session's task-list progress (total/done) changed. |
+| `evener/task/updated` | `TaskUpdatedParams` | The session's task-list outcome counts (total/done/cancelled/remaining) changed. |
 | `evener/goal/updated` | `GoalUpdatedParams` | The session's complete structured goal state changed; null clears it. |
 | `evener/sandbox/escalation/requested` | `SandboxEscalationRequested` | A harness-raised, human-gated sandbox-exemption approval card (M7); the tool-exec goroutine blocks until answered via evener/sandbox/escalation/resolve. |
 | `evener/sandbox/escalation/resolved` | `SandboxEscalationResolved` | A previously-raised sandbox escalation left the pending set — resolved, turn-interrupted, or cleared by session close (M7); every OTHER subscribed client clears its now-stale copy of the card. |
@@ -1421,6 +1421,8 @@ _(no fields)_
 | `ref` | `string` |  |  |
 | `total` | `int` |  |  |
 | `done` | `int` |  |  |
+| `cancelled` | `int` |  |  |
+| `remaining` | `int` |  |  |
 | `current` | `*appwire.TaskSummary` | yes |  |
 
 

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -1421,8 +1421,8 @@ _(no fields)_
 | `ref` | `string` |  |  |
 | `total` | `int` |  |  |
 | `done` | `int` |  |  |
-| `cancelled` | `int` |  |  |
-| `remaining` | `int` |  |  |
+| `cancelled` | `int` | yes |  |
+| `remaining` | `int` | yes |  |
 | `current` | `*appwire.TaskSummary` | yes |  |
 
 

--- a/internal/appprojector/appwire_projection.go
+++ b/internal/appprojector/appwire_projection.go
@@ -1025,11 +1025,13 @@ func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification
 		}
 		p.observeTaskPublication(data.TaskPublicationEpoch, data.TaskPublicationRevision)
 		notification := p.notification(appwire.NotifyEvenerTaskUpdated, appwire.TaskUpdatedParams{
-			ThreadID: p.threadID,
-			Ref:      p.ref,
-			Total:    data.Total,
-			Done:     data.Done,
-			Current:  taskSummary(data.Current),
+			ThreadID:  p.threadID,
+			Ref:       p.ref,
+			Total:     data.Total,
+			Done:      data.Done,
+			Cancelled: data.Cancelled,
+			Remaining: data.Remaining,
+			Current:   taskSummary(data.Current),
 		})
 		notification.TaskStoreOwnerSessionID = data.TaskStoreOwnerSessionID
 		notification.TaskPublicationEpoch = data.TaskPublicationEpoch
@@ -1268,7 +1270,13 @@ func taskAggregate(data *events.TaskStateData) *appwire.TaskAggregate {
 	if data == nil {
 		return nil
 	}
-	return &appwire.TaskAggregate{Total: data.Total, Done: data.Done, Current: taskSummary(data.Current)}
+	return &appwire.TaskAggregate{
+		Total:     data.Total,
+		Done:      data.Done,
+		Cancelled: data.Cancelled,
+		Remaining: data.Remaining,
+		Current:   taskSummary(data.Current),
+	}
 }
 
 func goalState(data *events.GoalStateData) *appwire.GoalState {

--- a/internal/appprojector/appwire_projection_test.go
+++ b/internal/appprojector/appwire_projection_test.go
@@ -205,6 +205,21 @@ func TestProject_TaskUpdated(t *testing.T) {
 	}
 }
 
+func TestProject_TaskUpdatedPreservesFullyCancelledState(t *testing.T) {
+	p := NewAppEventProjector("th1", "local:th1")
+	out := p.Project(events.SessionEvent{
+		Kind: events.EventTaskUpdated,
+		Data: events.TaskUpdatedData{Total: 3, Cancelled: 3, Remaining: 0},
+	})
+	if len(out) != 1 {
+		t.Fatalf("notifications = %+v, want one task update", out)
+	}
+	params, ok := out[0].Params.(appwire.TaskUpdatedParams)
+	if !ok || params.Total != 3 || params.Done != 0 || params.Cancelled != 3 || params.Remaining != 0 || params.Current != nil {
+		t.Fatalf("params = %+v, want fully cancelled task state", out[0].Params)
+	}
+}
+
 func TestProject_SessionStartCarriesCurrentWorkSeed(t *testing.T) {
 	p := NewAppEventProjector("th1", "local:th1")
 	out := p.Project(events.SessionEvent{Kind: events.EventSessionStart, Data: events.SessionStartData{
@@ -212,13 +227,13 @@ func TestProject_SessionStartCarriesCurrentWorkSeed(t *testing.T) {
 		TaskPublicationEpoch:    7,
 		TaskPublicationRevision: 41,
 		CurrentWork: &events.CurrentWorkSeedData{
-			Tasks: &events.TaskStateData{Total: 3, Done: 1, Current: &events.TaskSummaryData{ID: 2, Description: "seeded task"}},
+			Tasks: &events.TaskStateData{Total: 3, Done: 1, Cancelled: 1, Remaining: 1, Current: &events.TaskSummaryData{ID: 2, Description: "seeded task"}},
 			Goal:  &events.GoalStateData{Objective: "seeded objective", Status: "active", Iterations: 2},
 		},
 	}})
 
 	thread := notificationThread(t, out, appwire.NotifyThreadStarted)
-	if thread.Evener.Tasks == nil || thread.Evener.Tasks.Total != 3 || thread.Evener.Tasks.Done != 1 ||
+	if thread.Evener.Tasks == nil || thread.Evener.Tasks.Total != 3 || thread.Evener.Tasks.Done != 1 || thread.Evener.Tasks.Cancelled != 1 || thread.Evener.Tasks.Remaining != 1 ||
 		thread.Evener.Tasks.Current == nil || thread.Evener.Tasks.Current.Description != "seeded task" {
 		t.Fatalf("started tasks = %+v, want complete current-work seed", thread.Evener.Tasks)
 	}

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -696,7 +696,13 @@ func currentWorkSeedWithoutTasks(seed *events.CurrentWorkSeedData) *events.Curre
 }
 
 func taskPatch(params appwire.TaskUpdatedParams) *appwire.TaskAggregate {
-	return cloneTaskAggregate(&appwire.TaskAggregate{Total: params.Total, Done: params.Done, Current: params.Current})
+	return cloneTaskAggregate(&appwire.TaskAggregate{
+		Total:     params.Total,
+		Done:      params.Done,
+		Cancelled: params.Cancelled,
+		Remaining: params.Remaining,
+		Current:   params.Current,
+	})
 }
 
 func goalPatch(params appwire.GoalUpdatedParams) *appwire.GoalState {

--- a/server/appwire_runtime_test.go
+++ b/server/appwire_runtime_test.go
@@ -14,6 +14,13 @@ import (
 	"primeradiant.com/evener/internal/appserver"
 )
 
+func TestTaskPatchPreservesFullyCancelledOutcome(t *testing.T) {
+	got := taskPatch(appwire.TaskUpdatedParams{Total: 3, Cancelled: 3, Remaining: 0})
+	if got == nil || got.Total != 3 || got.Done != 0 || got.Cancelled != 3 || got.Remaining != 0 || got.Current != nil {
+		t.Fatalf("taskPatch() = %+v, want fully cancelled task state", got)
+	}
+}
+
 func TestAppCapabilities_SteerGatedOnActiveTurn(t *testing.T) {
 	t.Parallel()
 	cases := []struct {


### PR DESCRIPTION
## Summary
- close nested task-list add/update schemas and reject `brief` without aliasing it
- return targeted add-shape diagnostics and preserve atomic rejection for malformed batches
- share done/cancelled/remaining/total outcome text between agent task responses and the TUI

## Restrictions retained
- Atomic batches, required update IDs, valid statuses, single in-progress, dependency/cycle checks, unknown-ID/no-op rejection, and retired shapes remain unchanged.
- `brief` remains invalid in every nested add/update entry and is never copied to `description`.

## Tests
- `go test ./agent/task -count=1`
- `go test ./agent/internal/tool -run 'TestDefTaskList' -count=1`
- `go test ./agent -run 'Test(TaskTool_|TaskStore_Progress)' -count=1`
- `go test ./cmd/evener-tui -run 'TestTaskSummaryUsesSharedOutcomeCounts' -count=1`

Closes #830
