### PR TITLE
fix(agent): normalize job_watch operation arguments

### DIFF
--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -326,10 +326,10 @@ func DefJobWatch(eventKinds []string) llm.ToolDefinition {
 				"operation":            map[string]any{"type": "string", "description": "create, list, inspect, or clear.", "enum": []string{"create", "list", "inspect", "clear"}},
 				"watch_id":             map[string]any{"type": "string", "description": "watch_id returned by job_watch create/list; required for inspect and clear."},
 				"source":               map[string]any{"type": "string", "description": "`self`, `parent` when granted by delegate(watch_parent=true), a stable delegate ID (`dlg_...`), or a concrete shell job_id visible to this session."},
-				"output_match":         map[string]any{"type": "string", "description": "RE2 regex over the job's raw output bytes, scanned through a rolling 4096-byte window (not line by line), so output with no newlines still matches. A single match may be at most 4096 bytes, and each occurrence fires once. Case-sensitive unless (?i). ^ and $ are multiline by default and also anchor at the window edge, so $ matches at the end of the output produced so far. Prefer a narrow pattern (READY) over an open-ended one (.*READY.*). Invalid regex errors at creation."},
+				"output_match":         map[string]any{"type": []string{"string", "null"}, "description": "RE2 regex over the job's raw output bytes, scanned through a rolling 4096-byte window (not line by line), so output with no newlines still matches. A single match may be at most 4096 bytes, and each occurrence fires once. Case-sensitive unless (?i). ^ and $ are multiline by default and also anchor at the window edge, so $ matches at the end of the output produced so far. Prefer a narrow pattern (READY) over an open-ended one (.*READY.*). Invalid regex errors at creation."},
 				"progress_interval_ms": map[string]any{"type": []string{"integer", "null"}, "description": "Periodic progress trigger interval in ms (min 1000, max 3600000; handler clamps later). Use events/event_filter for session event frames."},
 				"events": map[string]any{
-					"type":        "array",
+					"type":        []string{"array", "null"},
 					"items":       map[string]any{"type": "string"},
 					"description": "Event kinds to watch; [\"*\"] = all visible. Available: " + kinds + ". Watch communicate for result/status messages.",
 				},
@@ -338,7 +338,7 @@ func DefJobWatch(eventKinds []string) llm.ToolDefinition {
 					"description": "Fire on each Nth occurrence of the single watched event kind. 1 is the default (fire on every occurrence); values above 1 require `events` to contain exactly one kind.",
 				},
 				"event_filter": map[string]any{
-					"type":                 "object",
+					"type":                 []string{"object", "null"},
 					"additionalProperties": false,
 					"description":          "Structured predicate for assistant.tool watches. With events [\"assistant.tool\"], match the emitted tool call by tool_name and/or status. Communicate content is delivered in event.message for the observer task to evaluate.",
 					"properties": map[string]any{

--- a/agent/internal/tool/definitions_test.go
+++ b/agent/internal/tool/definitions_test.go
@@ -456,6 +456,21 @@ func TestDefJobWatchParamsAndKinds(t *testing.T) {
 	}
 }
 
+func TestDefJobWatchOptionalTriggerFieldsAreNullable(t *testing.T) {
+	props := DefJobWatch([]string{"communicate"}).Parameters["properties"].(map[string]any)
+	for _, name := range []string{"output_match", "events", "event_filter"} {
+		t.Run(name, func(t *testing.T) {
+			typeValues, ok := props[name].(map[string]any)["type"].([]string)
+			if !ok {
+				t.Fatalf("%s type = %#v, want nullable type array", name, props[name].(map[string]any)["type"])
+			}
+			if !slices.Contains(typeValues, "null") {
+				t.Fatalf("%s type = %#v, want null", name, typeValues)
+			}
+		})
+	}
+}
+
 func TestDefJobWatchUsesSourceAndOmitsSend(t *testing.T) {
 	def := DefJobWatch([]string{"assistant.tool", "communicate", "job.notification"})
 	props := def.Parameters["properties"].(map[string]any)

--- a/agent/job_notify_coalesce_test.go
+++ b/agent/job_notify_coalesce_test.go
@@ -128,12 +128,11 @@ func TestWatchBudgetClearCoalescesWithMatchedEvent(t *testing.T) {
 		waitForShellDone(t, s.jobManager, jobID)
 	})
 
-	if _, err := jobWatchTool(s, map[string]any{
-		"operation": "create",
-		"source":    jobID,
-		"events":    []any{"job.notification"},
-	}, jobToolResultDefaultMaxChar); err != nil {
-		t.Fatalf("job_watch create: %v", err)
+	// Public job_watch rejects a concrete job.notification watch because a
+	// completion notification is already automatic. This test exercises the
+	// retained internal coalescing mechanism directly.
+	if _, err := s.jobManager.configureWatch(watchArgs{Target: jobID, Events: []string{"job.notification"}}); err != nil {
+		t.Fatalf("configure watch: %v", err)
 	}
 	s.jobManager.mu.Lock()
 	var watched *watchConfig

--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -802,6 +802,29 @@ func validateWatchTriggerShape(a watchArgs) error {
 	if a.ProgressIntervalMS > 0 && len(a.Events) > 0 && isWatchSessionTarget(a.Target) {
 		return errors.New("invalid_request: session event watches use events/event_filter/every; progress_interval_ms is for periodic progress watches")
 	}
+	// Internal watch machinery retains concrete-job event predicates for
+	// coalescing and delivery bookkeeping. The public job_watch create surface is
+	// narrower: a shell process cannot originate assistant/communicate events, and
+	// its terminal notification is delivered automatically.
+	if a.Operation == "create" && strings.HasPrefix(a.Target, "job_") {
+		var reasons []string
+		var impossible []string
+		for _, name := range a.Events {
+			switch name {
+			case "assistant.tool", "communicate":
+				impossible = append(impossible, name)
+			}
+		}
+		if len(impossible) > 0 {
+			reasons = append(reasons, fmt.Sprintf("concrete shell job %q cannot emit session events %s; use output_match for its output or progress_interval_ms for periodic progress", a.Target, strings.Join(impossible, ", ")))
+		}
+		if slices.Contains(a.Events, "job.notification") {
+			reasons = append(reasons, fmt.Sprintf("concrete shell job %q terminal notification is automatic; do not create a job.notification watch — end its turn and await the completion notification", a.Target))
+		}
+		if len(reasons) > 0 {
+			return fmt.Errorf("invalid_request: %s", strings.Join(reasons, "; "))
+		}
+	}
 	return nil
 }
 

--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -807,22 +807,8 @@ func validateWatchTriggerShape(a watchArgs) error {
 	// narrower: a shell process cannot originate assistant/communicate events, and
 	// its terminal notification is delivered automatically.
 	if a.Operation == "create" && strings.HasPrefix(a.Target, "job_") {
-		var reasons []string
-		var impossible []string
-		for _, name := range a.Events {
-			switch name {
-			case "assistant.tool", "communicate":
-				impossible = append(impossible, name)
-			}
-		}
-		if len(impossible) > 0 {
-			reasons = append(reasons, fmt.Sprintf("concrete shell job %q cannot emit session events %s; use output_match for its output or progress_interval_ms for periodic progress", a.Target, strings.Join(impossible, ", ")))
-		}
-		if slices.Contains(a.Events, "job.notification") {
-			reasons = append(reasons, fmt.Sprintf("concrete shell job %q terminal notification is automatic; do not create a job.notification watch — end its turn and await the completion notification", a.Target))
-		}
-		if len(reasons) > 0 {
-			return fmt.Errorf("invalid_request: %s", strings.Join(reasons, "; "))
+		if len(a.Events) > 0 {
+			return fmt.Errorf("invalid_request: concrete shell job %q cannot use events %s; its terminal notification is automatic, so end its turn and await completion, or use output_match for its output or progress_interval_ms for periodic progress", a.Target, strings.Join(a.Events, ", "))
 		}
 	}
 	return nil

--- a/agent/job_watch_config_test.go
+++ b/agent/job_watch_config_test.go
@@ -182,6 +182,39 @@ func TestConfigureWatchRejectsAssistantMessageEvent(t *testing.T) {
 	}
 }
 
+func TestConfigureWatchRejectsImpossibleConcreteJobEventWatches(t *testing.T) {
+	jm := newTestJM(t)
+	rec, err := jm.createShell(createShellOpts{Command: "watched"})
+	if err != nil {
+		t.Fatalf("create shell: %v", err)
+	}
+	t.Cleanup(func() { finishRunningTestJob(t, jm, rec.JobID) })
+
+	for _, tc := range []struct {
+		name   string
+		events []string
+		filter *watchEventFilter
+		wants  []string
+	}{
+		{"assistant tool", []string{"assistant.tool"}, nil, []string{"assistant.tool", "concrete shell job"}},
+		{"communicate", []string{"communicate"}, nil, []string{"communicate", "concrete shell job"}},
+		{"assistant tool filter", []string{"assistant.tool"}, &watchEventFilter{ToolName: "read_file"}, []string{"assistant.tool", "concrete shell job"}},
+		{"terminal notification", []string{"job.notification"}, nil, []string{"automatic", "end its turn"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := jm.configureWatch(watchArgs{Operation: "create", Source: rec.JobID, Target: rec.JobID, Events: tc.events, EventFilter: tc.filter})
+			if err == nil {
+				t.Fatal("configureWatch succeeded, want impossible concrete-job event rejection")
+			}
+			for _, want := range tc.wants {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error = %q, want %q", err, want)
+				}
+			}
+		})
+	}
+}
+
 func TestJobWatchAliasTargetWithoutContextFailsTargetNotFound(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {

--- a/agent/job_watch_config_test.go
+++ b/agent/job_watch_config_test.go
@@ -200,6 +200,7 @@ func TestConfigureWatchRejectsImpossibleConcreteJobEventWatches(t *testing.T) {
 		{"communicate", []string{"communicate"}, nil, []string{"communicate", "concrete shell job"}},
 		{"assistant tool filter", []string{"assistant.tool"}, &watchEventFilter{ToolName: "read_file"}, []string{"assistant.tool", "concrete shell job"}},
 		{"terminal notification", []string{"job.notification"}, nil, []string{"automatic", "end its turn"}},
+		{"wildcard", []string{"*"}, nil, []string{"*", "automatic", "output_match"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := jm.configureWatch(watchArgs{Operation: "create", Source: rec.JobID, Target: rec.JobID, Events: tc.events, EventFilter: tc.filter})

--- a/agent/session_jobtree_drain_undisposed_test.go
+++ b/agent/session_jobtree_drain_undisposed_test.go
@@ -455,7 +455,7 @@ func TestClearedWatchStartsAFreshAnnouncementEpisode(t *testing.T) {
 		func(llm.Request) llm.Response {
 			return toolCallResponse(llm.ToolCallData{
 				ID: "watch-it", Name: "job_watch", Type: "function",
-				Arguments: json.RawMessage(`{"operation":"create","source":"` + jobID + `","events":["job.notification"]}`),
+				Arguments: json.RawMessage(`{"operation":"create","source":"` + jobID + `","output_match":"READY"}`),
 			})
 		},
 		func(llm.Request) llm.Response {
@@ -522,11 +522,9 @@ func TestClearedWatchStartsAFreshAnnouncementEpisode(t *testing.T) {
 	watched.deliveries = watchDeliveryBudget - 1
 	sess.jobManager.mu.Unlock()
 
-	// This is a real matching session event, and the next delivery crosses the
-	// actual budget auto-clear path rather than merely deleting jm.watches.
-	onSessionEventKD(sess.jobManager, events.EventJobFinished, events.JobFinishedData{
-		JobID: jobID, JobType: "shell", Status: "completed",
-	})
+	// This real output match crosses the actual budget auto-clear path rather
+	// than merely deleting jm.watches.
+	feedJob(sess.jobManager, jobID, []byte("READY\n"))
 	sess.jobManager.mu.Lock()
 	stillLive := false
 	for _, cfg := range sess.jobManager.watches {

--- a/agent/session_tools_jobs.go
+++ b/agent/session_tools_jobs.go
@@ -1977,6 +1977,7 @@ func watchArgsFromToolArgs(args map[string]any) (watchArgs, error) {
 		return watchArgs{}, err
 	}
 	a.EventFilter = eventFilter
+	normalizeWatchArgsForOperation(&a)
 	switch a.Operation {
 	case "create":
 		if a.Source == "" {
@@ -1988,7 +1989,7 @@ func watchArgsFromToolArgs(args map[string]any) (watchArgs, error) {
 		}
 	case "inspect", "clear":
 		if a.WatchID == "" {
-			return watchArgs{}, errors.New("invalid_request: watch_id is required")
+			return watchArgs{}, fmt.Errorf("invalid_request: watch_id is required for operation=%q; use %s", a.Operation, watchOperationRepairShape(a))
 		}
 	default:
 		return watchArgs{}, fmt.Errorf("invalid_request: unsupported operation %q", a.Operation)
@@ -2002,6 +2003,21 @@ func watchArgsFromToolArgs(args map[string]any) (watchArgs, error) {
 	return a, nil
 }
 
+// normalizeWatchArgsForOperation erases only the exact neutral trigger values
+// providers commonly materialize on inspection operations. The raw values stay
+// in the tool call record for diagnostics; meaningful values are rejected below.
+func normalizeWatchArgsForOperation(a *watchArgs) {
+	if a.Operation == "create" {
+		return
+	}
+	if len(a.Events) == 0 {
+		a.Events = nil
+	}
+	if a.Every == 0 || a.Every == 1 {
+		a.Every = 0
+	}
+}
+
 // watchTriggerFieldNames lists the arguments that select what a created watch
 // fires on, in the DefJobWatch property order. They are meaningful only for
 // operation="create"; list/inspect/clear take only watch_id, so a trigger field
@@ -2012,10 +2028,10 @@ var watchTriggerFieldNames = []string{"output_match", "progress_interval_ms", "e
 // trigger field the call actually supplied alongside a non-create operation.
 // Omitting all of them stays valid: create on a granted cross-session source
 // (parent) watches all bounded public events, and list/inspect/clear need none.
-// Nullable trigger fields (progress_interval_ms, every — schema type
-// ["integer","null"]) with a null value count as omitted, matching how
-// shellIntArg decodes them everywhere else: a client serializing optional
-// fields as null is not arming a trigger.
+// Null, empty, and default values count as omitted. This is deliberately
+// operation-aware: create keeps its full trigger vocabulary, while list,
+// inspect, and clear tolerate provider-materialized optional fields without
+// accepting a real trigger outside create.
 func rejectWatchTriggerFieldsOnNonCreate(args map[string]any, a watchArgs) error {
 	if a.Operation == "create" {
 		return nil
@@ -2023,23 +2039,78 @@ func rejectWatchTriggerFieldsOnNonCreate(args map[string]any, a watchArgs) error
 	var supplied []string
 	for _, name := range watchTriggerFieldNames {
 		value, ok := args[name]
-		if !ok || value == nil {
+		if !ok || watchTriggerArgumentIsNeutral(name, value, a) {
 			continue
 		}
-		supplied = append(supplied, name)
+		supplied = append(supplied, formatWatchTriggerArgument(name, value))
 	}
 	if len(supplied) == 0 {
 		return nil
 	}
 	return fmt.Errorf(
-		"invalid_request: trigger fields apply only to operation=\"create\"; %s supplied with operation=%q — set operation=\"create\" to arm a watch, or drop %s to %s",
-		strings.Join(supplied, ", "), a.Operation, strings.Join(supplied, ", "), a.Operation,
+		"invalid_request: trigger fields apply only to operation=\"create\"; received %s with operation=%q — set operation=\"create\" to arm a watch, or remove those fields and use %s",
+		strings.Join(supplied, ", "), a.Operation, watchOperationRepairShape(a),
 	)
+}
+
+func watchTriggerArgumentIsNeutral(name string, value any, a watchArgs) bool {
+	if value == nil {
+		return true
+	}
+	switch name {
+	case "output_match":
+		_, ok := value.(string)
+		return ok && a.OutputMatch == ""
+	case "events":
+		return len(a.Events) == 0
+	case "event_filter":
+		return a.EventFilter == nil
+	case "progress_interval_ms":
+		return a.ProgressIntervalMS == 0 && watchIntegerValue(value) == 0
+	case "every":
+		return (a.Every == 0 || a.Every == 1) && (watchIntegerValue(value) == 0 || watchIntegerValue(value) == 1)
+	default:
+		return false
+	}
+}
+
+func watchIntegerValue(value any) int {
+	switch v := value.(type) {
+	case int:
+		return v
+	case float64:
+		return int(v)
+	default:
+		return -1
+	}
+}
+
+func formatWatchTriggerArgument(name string, value any) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprintf("%s=%#v", name, value)
+	}
+	return fmt.Sprintf("%s=%s", name, encoded)
+}
+
+func watchOperationRepairShape(a watchArgs) string {
+	switch a.Operation {
+	case "list":
+		return `{"operation":"list"}`
+	case "inspect", "clear":
+		watchID := a.WatchID
+		if watchID == "" {
+			watchID = "watch_..."
+		}
+		return fmt.Sprintf(`{"operation":%q,"watch_id":%q}`, a.Operation, watchID)
+	default:
+		return fmt.Sprintf(`{"operation":%q}`, a.Operation)
+	}
 }
 
 func watchEventFilterArg(args map[string]any) (*watchEventFilter, error) {
 	raw, ok := args["event_filter"]
-	if !ok {
+	if !ok || raw == nil {
 		return nil, nil
 	}
 	values, ok := raw.(map[string]any)
@@ -2069,7 +2140,7 @@ func watchEventFilterArg(args map[string]any) (*watchEventFilter, error) {
 
 func stringArrayArg(args map[string]any, key string) ([]string, error) {
 	raw, ok := args[key]
-	if !ok {
+	if !ok || raw == nil {
 		return nil, nil
 	}
 	values, ok := raw.([]any)

--- a/agent/session_tools_jobs.go
+++ b/agent/session_tools_jobs.go
@@ -1978,6 +1978,7 @@ func watchArgsFromToolArgs(args map[string]any) (watchArgs, error) {
 	}
 	a.EventFilter = eventFilter
 	normalizeWatchArgsForOperation(&a)
+	missingWatchID := false
 	switch a.Operation {
 	case "create":
 		if a.Source == "" {
@@ -1989,13 +1990,16 @@ func watchArgsFromToolArgs(args map[string]any) (watchArgs, error) {
 		}
 	case "inspect", "clear":
 		if a.WatchID == "" {
-			return watchArgs{}, fmt.Errorf("invalid_request: watch_id is required for operation=%q; use %s", a.Operation, watchOperationRepairShape(a))
+			missingWatchID = true
 		}
 	default:
 		return watchArgs{}, fmt.Errorf("invalid_request: unsupported operation %q", a.Operation)
 	}
 	if err := rejectWatchTriggerFieldsOnNonCreate(args, a); err != nil {
 		return watchArgs{}, err
+	}
+	if missingWatchID {
+		return watchArgs{}, fmt.Errorf("invalid_request: watch_id is required for operation=%q; use %s", a.Operation, watchOperationRepairShape(a))
 	}
 	if a.Source == "*" {
 		return watchArgs{}, errors.New("invalid_request: wildcard watch target is not supported in v1")
@@ -2047,9 +2051,14 @@ func rejectWatchTriggerFieldsOnNonCreate(args map[string]any, a watchArgs) error
 	if len(supplied) == 0 {
 		return nil
 	}
+	missingWatchID := (a.Operation == "inspect" || a.Operation == "clear") && a.WatchID == ""
+	missing := ""
+	if missingWatchID {
+		missing = fmt.Sprintf("watch_id is required for operation=%q; ", a.Operation)
+	}
 	return fmt.Errorf(
-		"invalid_request: trigger fields apply only to operation=\"create\"; received %s with operation=%q — set operation=\"create\" to arm a watch, or remove those fields and use %s",
-		strings.Join(supplied, ", "), a.Operation, watchOperationRepairShape(a),
+		"invalid_request: %strigger fields apply only to operation=\"create\"; received %s with operation=%q — set operation=\"create\" to arm a watch, or remove those fields and use %s",
+		missing, strings.Join(supplied, ", "), a.Operation, watchOperationRepairShape(a),
 	)
 }
 

--- a/agent/session_tools_jobs_watch_test.go
+++ b/agent/session_tools_jobs_watch_test.go
@@ -465,6 +465,43 @@ func TestWatchArgsFromToolArgsRequiresWatchIDWithActionableShape(t *testing.T) {
 	}
 }
 
+func TestWatchArgsFromToolArgsCombinesMissingWatchIDAndMeaningfulTriggerDiagnostics(t *testing.T) {
+	t.Parallel()
+	for _, operation := range []string{"inspect", "clear"} {
+		t.Run(operation, func(t *testing.T) {
+			t.Parallel()
+			_, err := watchArgsFromToolArgs(map[string]any{
+				"operation":            operation,
+				"output_match":         "ready",
+				"progress_interval_ms": 5000,
+				"events":               []any{"communicate"},
+				"every":                2,
+				"event_filter":         map[string]any{"tool_name": "read_file"},
+			})
+			if err == nil {
+				t.Fatal("watchArgsFromToolArgs succeeded, want invalid_request")
+			}
+			repair := fmt.Sprintf(`{"operation":%q,"watch_id":"watch_..."}`, operation)
+			for _, want := range []string{
+				"watch_id is required",
+				`output_match="ready"`,
+				"progress_interval_ms=5000",
+				`events=["communicate"]`,
+				"every=2",
+				`event_filter={"tool_name":"read_file"}`,
+				repair,
+			} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error = %q, want %q", err, want)
+				}
+			}
+			if !strings.HasSuffix(err.Error(), repair) {
+				t.Fatalf("error = %q, want it to end with repair %q", err, repair)
+			}
+		})
+	}
+}
+
 // TestWatchArgsFromToolArgsAcceptsTriggerFieldsOnCreate pins the flip side of the
 // rejection above: every trigger field stays valid on create, so the new guard
 // cannot start rejecting legitimate installs.

--- a/agent/session_tools_jobs_watch_test.go
+++ b/agent/session_tools_jobs_watch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 	"testing"
 
@@ -319,6 +320,146 @@ func TestWatchArgsFromToolArgsTreatsNullTriggerFieldsAsOmitted(t *testing.T) {
 			}
 			if a.ProgressIntervalMS != 0 || a.Every != 0 {
 				t.Fatalf("null trigger field decoded nonzero: %+v", a)
+			}
+		})
+	}
+}
+
+// TestWatchArgsFromToolArgsNormalizesNeutralTriggerShapes covers provider calls
+// that materialize optional create-only fields on every operation. Neutral
+// values do not arm a trigger and so must parse like absent fields; non-create
+// operations still reject a meaningful trigger below.
+func TestWatchArgsFromToolArgsNormalizesNeutralTriggerShapes(t *testing.T) {
+	t.Parallel()
+	operations := []struct {
+		name string
+		args map[string]any
+	}{
+		{"create", map[string]any{"operation": "create", "source": "parent"}},
+		{"list", map[string]any{"operation": "list"}},
+		{"inspect", map[string]any{"operation": "inspect", "watch_id": "watch_x"}},
+		{"clear", map[string]any{"operation": "clear", "watch_id": "watch_x"}},
+	}
+	neutralValues := []struct {
+		name  string
+		field string
+		value any
+	}{
+		{"null output_match", "output_match", nil},
+		{"empty output_match", "output_match", ""},
+		{"null events", "events", nil},
+		{"empty events", "events", []any{}},
+		{"null event_filter", "event_filter", nil},
+		{"empty event_filter", "event_filter", map[string]any{}},
+		{"null progress_interval_ms", "progress_interval_ms", nil},
+		{"zero progress_interval_ms", "progress_interval_ms", 0},
+		{"null every", "every", nil},
+		{"zero every", "every", 0},
+		{"default every", "every", 1},
+	}
+	for _, operation := range operations {
+		for _, neutral := range neutralValues {
+			t.Run(operation.name+"/"+neutral.name, func(t *testing.T) {
+				t.Parallel()
+				args := maps.Clone(operation.args)
+				args[neutral.field] = neutral.value
+				if _, err := watchArgsFromToolArgs(args); err != nil {
+					t.Fatalf("watchArgsFromToolArgs(%#v): %v", args, err)
+				}
+			})
+		}
+	}
+}
+
+func TestJobWatchToolAcceptsMaterializedNeutralTriggerFields(t *testing.T) {
+	t.Parallel()
+	s := newTestSession(t)
+	exec := func(id, arguments string) tooldefs.ExecResult {
+		t.Helper()
+		return s.reg.ExecuteCall(context.Background(), s.env, llm.ToolCallData{
+			ID:        id,
+			Name:      "job_watch",
+			Arguments: json.RawMessage(arguments),
+		})
+	}
+
+	created := exec("create", `{"operation":"create","source":"self","events":["assistant.tool"],"output_match":null,"event_filter":null,"progress_interval_ms":0,"every":1}`)
+	if created.IsError {
+		t.Fatalf("job_watch create with null optional trigger fields: %s", created.Output)
+	}
+	var createOut struct {
+		WatchID string `json:"watch_id"`
+	}
+	if err := json.Unmarshal(toolResultJSON(created), &createOut); err != nil {
+		t.Fatalf("unmarshal create result: %v (output: %s)", err, created.Output)
+	}
+	if createOut.WatchID == "" {
+		t.Fatalf("create result = %s, want watch_id", created.Output)
+	}
+
+	for _, tc := range []struct {
+		name string
+		args string
+	}{
+		{"list", `{"operation":"list","output_match":"","events":[],"event_filter":{},"progress_interval_ms":0,"every":1}`},
+		{"inspect", fmt.Sprintf(`{"operation":"inspect","watch_id":%q,"output_match":null,"events":null,"event_filter":null,"progress_interval_ms":0,"every":1}`, createOut.WatchID)},
+		{"clear", fmt.Sprintf(`{"operation":"clear","watch_id":%q,"output_match":"","events":[],"event_filter":{},"progress_interval_ms":0,"every":1}`, createOut.WatchID)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if res := exec(tc.name, tc.args); res.IsError {
+				t.Fatalf("job_watch %s with neutral trigger fields: %s", tc.name, res.Output)
+			}
+		})
+	}
+}
+
+func TestWatchArgsFromToolArgsRejectsMeaningfulNonCreateFieldsWithRepairShape(t *testing.T) {
+	t.Parallel()
+	for _, operation := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"list", map[string]any{"operation": "list"}, `{"operation":"list"}`},
+		{"inspect", map[string]any{"operation": "inspect", "watch_id": "watch_x"}, `{"operation":"inspect","watch_id":"watch_x"}`},
+		{"clear", map[string]any{"operation": "clear", "watch_id": "watch_x"}, `{"operation":"clear","watch_id":"watch_x"}`},
+	} {
+		t.Run(operation.name, func(t *testing.T) {
+			t.Parallel()
+			args := maps.Clone(operation.args)
+			args["output_match"] = "ready"
+			args["progress_interval_ms"] = 5000
+			args["events"] = []any{"communicate"}
+			args["every"] = 2
+			args["event_filter"] = map[string]any{"tool_name": "read_file"}
+			_, err := watchArgsFromToolArgs(args)
+			if err == nil {
+				t.Fatal("watchArgsFromToolArgs succeeded, want invalid_request")
+			}
+			for _, want := range []string{
+				`output_match="ready"`,
+				"progress_interval_ms=5000",
+				`events=["communicate"]`,
+				"every=2",
+				`event_filter={"tool_name":"read_file"}`,
+				operation.want,
+			} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error = %q, want %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+func TestWatchArgsFromToolArgsRequiresWatchIDWithActionableShape(t *testing.T) {
+	t.Parallel()
+	for _, operation := range []string{"inspect", "clear"} {
+		t.Run(operation, func(t *testing.T) {
+			t.Parallel()
+			_, err := watchArgsFromToolArgs(map[string]any{"operation": operation})
+			if err == nil || !strings.Contains(err.Error(), `"watch_id"`) {
+				t.Fatalf("error = %v, want a repair shape that includes watch_id", err)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #828

## Summary
- make optional job_watch trigger schema fields nullable and normalize neutral materialized values for list, inspect, and clear
- report every meaningful non-create trigger argument with its received value and an operation-specific repair shape
- reject public concrete-job session-event predicates that cannot originate from a shell job, and explain automatic terminal notifications

## Retained restrictions
- inspect and clear still require watch_id
- meaningful triggers remain create-only
- event_filter remains assistant.tool-only; regex and cadence validation are unchanged
- source authorization/topology and legacy public-field rejection remain unchanged
- internal event-watch coalescing remains available to the runtime

## Tests
- go test ./agent ./agent/internal/tool -count=1
- focused job_watch regression and affected-event tests