### PR TITLE
fix(hub): capture os.Stderr once to eliminate keepalive/stderr race

### DIFF
--- a/cmd/evener-hub/internal/appsource/codex_source.go
+++ b/cmd/evener-hub/internal/appsource/codex_source.go
@@ -45,13 +45,19 @@ func defaultAppwireDial(ctx context.Context, endpoint string, client *http.Clien
 	return appwire.DialWebSocketWithHeaders(ctx, endpoint, client, header)
 }
 
+// hubStderr is captured once because runClientKeepalive outlives the test
+// that started it (connect uses context.WithoutCancel), so reading the
+// mutable os.Stderr global from that goroutine races any test that swaps
+// and restores os.Stderr (issue #837).
+var hubStderr = os.Stderr
+
 // hubConnectionLogf is the appwire.Client connection-lifecycle sink (see
 // appwire.Client.SetLogf) for every source's dialed connections (codex,
 // local daemon). The hub is a plain daemon, never a TUI rendering over an
 // interactive terminal, so its own stderr — labelled like every other hub
 // diagnostic — is a safe destination, unlike the TUI's stderr (issue #783).
 func hubConnectionLogf(format string, args ...any) {
-	fmt.Fprintf(os.Stderr, "[hub] "+format+"\n", args...)
+	_, _ = fmt.Fprintf(hubStderr, "[hub] "+format+"\n", args...)
 }
 
 func NewCodexSource(cfg CodexSourceConfig, client *http.Client) *CodexSource {


### PR DESCRIPTION
## What

`race-root` CI caught a data race (issue #837): a keepalive goroutine in `appwire.Client` read the process-global `os.Stderr` (via `hubConnectionLogf` in `codex_source.go`) at call time, racing `TestRunMainAddrZeroReportsAndBindsTheRealPort`'s `os.Stderr = origStderr` restore.

## Root cause

- `hubConnectionLogf` (`codex_source.go:54`) reads `os.Stderr` at call time: `fmt.Fprintf(os.Stderr, ...)`
- The keepalive goroutine (`runClientKeepalive` in `appwire/client.go:199`) calls this sink
- `connect` (`codex_source.go:712`) starts the keepalive with `context.WithoutCancel(ctx)`, so it outlives the test that started it
- `TestRunMainAddrZeroReportsAndBindsTheRealPort` writes `os.Stderr = origStderr` (`main_ephemeral_port_test.go:119`)
- Result: concurrent unsynchronized read + write of the `os.Stderr` global → data race

## Fix

Capture `os.Stderr` once into a package-level `var hubStderr = os.Stderr` so the sink holds a stable `*os.File` reference that is never reassigned. The keepalive goroutine writes to the stable reference, not the mutable global.

- In production `os.Stderr` is never reassigned, so behavior is unchanged.
- In tests, keepalive diagnostics go to the real process stderr (fd 2) instead of a test's transient pipe — correct, since no test asserts on keepalive teardown lines.
- `_, _ =` discards the `fmt.Fprintf` return to satisfy errcheck (the built-in `os.Stderr` errcheck exemption does not apply to a plain `*os.File` variable).

One file changed: `cmd/evener-hub/internal/appsource/codex_source.go`.

## Verification

- ✅ Targeted race stress test (`-count=20 -parallel=8 -race` on the two affected tests): exit 0
- ✅ Full `cmd/evener-hub` race suite (`-race -count=1`): exit 0 (158s)
- ✅ `go vet`, `gofmt`, `golangci-lint`: clean

Fixes #837